### PR TITLE
tx confirmed/sec ---> tx processed/sec

### DIFF
--- a/src/bin/client-demo.rs
+++ b/src/bin/client-demo.rs
@@ -1,3 +1,4 @@
+extern crate rayon;
 extern crate serde_json;
 extern crate solana;
 
@@ -8,6 +9,7 @@ use solana::transaction::Transaction;
 use std::io::stdin;
 use std::net::{TcpStream, UdpSocket};
 use std::time::Instant;
+use rayon::prelude::*;
 
 fn main() {
     let addr = "127.0.0.1:8000";
@@ -21,16 +23,17 @@ fn main() {
     let stream = TcpStream::connect(addr).unwrap();
     stream.set_nonblocking(true).expect("nonblocking");
 
-    let mut acc = AccountantStub::new(addr, socket, stream);
+    let acc = AccountantStub::new(addr, socket, stream);
     let last_id = acc.get_last_id().unwrap();
 
     let mint_balance = acc.get_balance(&mint_pubkey).unwrap().unwrap();
     println!("Mint's Initial Balance {}", mint_balance);
 
     println!("Signing transactions...");
-    let txs = mint_balance;
+    let txs = 10_000;
     let now = Instant::now();
     let transactions: Vec<_> = (0..txs)
+        .into_par_iter()
         .map(|_| {
             let rando_pubkey = KeyPair::new().pubkey();
             Transaction::new(&mint_keypair, rando_pubkey, 1, last_id)
@@ -48,9 +51,7 @@ fn main() {
 
     println!("Verify signatures...");
     let now = Instant::now();
-    for tr in &transactions {
-        assert!(tr.verify());
-    }
+    transactions.par_iter().for_each(|tr| assert!(tr.verify()));
     let duration = now.elapsed();
     let ns = duration.as_secs() * 1_000_000_000 + u64::from(duration.subsec_nanos());
     let bsvps = txs as f64 / ns as f64;
@@ -63,21 +64,27 @@ fn main() {
 
     println!("Transferring 1 unit {} times...", txs);
     let now = Instant::now();
-    let mut sig = Default::default();
+    let mut _sig = Default::default();
     for tr in transactions {
-        sig = tr.sig;
+        _sig = tr.sig;
         acc.transfer_signed(tr).unwrap();
     }
     println!("Waiting for last transaction to be confirmed...",);
-    if txs > 0 {
-        acc.wait_on_signature(&sig, &last_id).unwrap();
+    let mut val = mint_balance;
+    while val > mint_balance - txs {
+        val = acc.get_balance(&mint_pubkey).unwrap().unwrap();
     }
+    //if txs > 0 {
+    //    acc.wait_on_signature(&sig, &last_id).unwrap();
+    //}
 
     let duration = now.elapsed();
     let ns = duration.as_secs() * 1_000_000_000 + u64::from(duration.subsec_nanos());
     let tps = (txs * 1_000_000_000) as f64 / ns as f64;
     println!("Done. {} tps!", tps);
-    let val = acc.get_balance(&mint_pubkey).unwrap().unwrap();
     println!("Mint's Final Balance {}", val);
     assert_eq!(val, mint_balance - txs);
+
+    // Force the ledger to print on the server.
+    acc.get_last_id().unwrap();
 }


### PR DESCRIPTION
Before this patch, we were waiting until the full log was
sent back across the wire, parsed, and interpreted. That was giving
us a metric of "transactions confirmed per second" instead of
"transactions processed per second". Instead, we'll just send one
tiny packet back with the balance. As soon as the balance is what
we expect it to be, we end the benchmark.

Also, parallelize the creation of transactions and signature verification so that we don't have to wait very long to get to the good stuff.