### PR TITLE
Revert TCP sync of ledger

### DIFF
--- a/src/accountant_skel.rs
+++ b/src/accountant_skel.rs
@@ -7,7 +7,7 @@ use serde_json;
 use signature::PublicKey;
 use std::default::Default;
 use std::io::{ErrorKind, Write};
-use std::net::{TcpListener, TcpStream, UdpSocket};
+use std::net::{TcpStream, UdpSocket};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::channel;
 use std::sync::{Arc, Mutex};
@@ -162,16 +162,6 @@ impl<W: Write + Send + 'static> AccountantSkel<W> {
             }
         });
 
-        let listener = TcpListener::bind(addr)?;
-        let t_listener = spawn(move || {
-            for stream in listener.incoming() {
-                match stream {
-                    Ok(stream) => obj.lock().unwrap().subscribers.push(stream),
-                    Err(_) => break,
-                }
-            }
-        });
-
-        Ok(vec![t_receiver, t_responder, t_server, t_listener])
+        Ok(vec![t_receiver, t_responder, t_server])
     }
 }

--- a/src/bin/client-demo.rs
+++ b/src/bin/client-demo.rs
@@ -7,7 +7,7 @@ use solana::mint::Mint;
 use solana::signature::{KeyPair, KeyPairUtil};
 use solana::transaction::Transaction;
 use std::io::stdin;
-use std::net::{TcpStream, UdpSocket};
+use std::net::UdpSocket;
 use std::time::Instant;
 use rayon::prelude::*;
 
@@ -20,10 +20,7 @@ fn main() {
     let mint_pubkey = mint.pubkey();
 
     let socket = UdpSocket::bind(send_addr).unwrap();
-    let stream = TcpStream::connect(addr).unwrap();
-    stream.set_nonblocking(true).expect("nonblocking");
-
-    let acc = AccountantStub::new(addr, socket, stream);
+    let acc = AccountantStub::new(addr, socket);
     let last_id = acc.get_last_id().unwrap();
 
     let mint_balance = acc.get_balance(&mint_pubkey).unwrap().unwrap();
@@ -74,9 +71,6 @@ fn main() {
     while val > mint_balance - txs {
         val = acc.get_balance(&mint_pubkey).unwrap().unwrap();
     }
-    //if txs > 0 {
-    //    acc.wait_on_signature(&sig, &last_id).unwrap();
-    //}
 
     let duration = now.elapsed();
     let ns = duration.as_secs() * 1_000_000_000 + u64::from(duration.subsec_nanos());


### PR DESCRIPTION
The feature was too rushed. We technically don't need it until we
implement consensus. It'll come back another day (with many more tests!)