### PR TITLE
Parallelize accountant

### DIFF
--- a/src/bin/testnode.rs
+++ b/src/bin/testnode.rs
@@ -32,7 +32,7 @@ fn main() {
         None
     };
 
-    let mut acc = Accountant::new_from_deposit(&deposit.unwrap());
+    let acc = Accountant::new_from_deposit(&deposit.unwrap());
 
     let mut last_id = entry1.id;
     for entry in entries {


### PR DESCRIPTION
This is not yet integrated into AccountantSkel, so don't expect the top-level demo benchmark to change, but includes a microbenchmark that demonstrates that performance doubles compared to the single-threaded version.

Also, before adding to AccountantSkel, we need to ensure all transactions commute.