### PR TITLE
Reject old transactions so that we can boot old signatures

### DIFF
--- a/src/accountant_skel.rs
+++ b/src/accountant_skel.rs
@@ -77,6 +77,7 @@ impl<W: Write + Send + 'static> AccountantSkel<W> {
     pub fn sync(&mut self) -> Hash {
         while let Ok(entry) = self.historian.receiver.try_recv() {
             self.last_id = entry.id;
+            self.acc.register_entry_id(&self.last_id);
             writeln!(self.writer, "{}", serde_json::to_string(&entry).unwrap()).unwrap();
         }
         self.last_id


### PR DESCRIPTION
Reject old transactions so that we can calculate an upper bound for memory usage, and therefore ensure the server won't slow down over time to crash due to memory exhaustion.

This is also a handy feature for the clients. A client can't tell if their transaction was dropped or if it were bumped into a mempool for later execution. The feature lets the client know for sure that if their transaction doesn't show up on the ledger after a known number of entries, those funds can safely be spent elsewhere.