### PR TITLE
fix compile error

### DIFF
--- a/src/accountant.rs
+++ b/src/accountant.rs
@@ -443,8 +443,8 @@ mod bench {
             .collect();
         bencher.iter(|| {
             // Since benchmarker runs this multiple times, we need to clear the signatures.
-            for (_, sigs) in acc.last_ids.read().unwrap().iter() {
-                sigs.write().unwrap().clear();
+            for sigs in acc.last_ids.read().unwrap().iter() {
+                sigs.1.write().unwrap().clear();
             }
 
             assert!(


### PR DESCRIPTION
```
$ cargo +nightly bench --features="unstable" -- --nocapture

error[E0658]: non-reference pattern used to match a reference (see issue #42640)
   --> src/accountant.rs:446:17
    |
446 |             for (_, sigs) in acc.last_ids.read().unwrap().iter() {
    |                 ^^^^^^^^^ help: consider using a reference: `&(_, sigs)`
    |
    = help: add #![feature(match_default_bindings)] to the crate attributes to enable
```
