### PR TITLE
Tell verifiers when not to parallelize accounting

### DIFF
--- a/src/accountant_skel.rs
+++ b/src/accountant_skel.rs
@@ -511,7 +511,6 @@ mod bench {
         let tps = txs as f64 / sec;
 
         // Ensure that all transactions were successfully logged.
-        skel.historian.sender.send(Signal::Tick).unwrap();
         drop(skel.historian.sender);
         let entries: Vec<Entry> = skel.historian.receiver.iter().collect();
         assert_eq!(entries.len(), 1);

--- a/src/bin/testnode.rs
+++ b/src/bin/testnode.rs
@@ -53,9 +53,7 @@ fn main() {
     let mut last_id = entry1.id;
     for entry in entries {
         last_id = entry.id;
-        for event in entry.events {
-            acc.process_verified_event(&event).unwrap();
-        }
+        acc.process_verified_events(entry.events).unwrap();
     }
 
     let historian = Historian::new(&last_id, Some(1000));


### PR DESCRIPTION
Without this patch, many batches of transactions could be tossed
into a single entry, but the parallelized accountant can only
guarentee the transactions in the batch can be processed in
parallel.

This patch signals the historian to generate a new Entry after
each batch. Validators must maintain sequential consistency
across Entries.