### PR TITLE
Utilize parallelized accountant in demo

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,10 @@ path = "src/bin/genesis-demo.rs"
 name = "solana-mint"
 path = "src/bin/mint.rs"
 
+[[bin]]
+name = "solana-mint-demo"
+path = "src/bin/mint-demo.rs"
+
 [badges]
 codecov = { repository = "solana-labs/solana", branch = "master", service = "github" }
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ Now you can start the server:
     $ cat genesis.log | cargo run --release --bin solana-testnode > transactions0.log
 ```
 
+Wait a few seconds for the server to initialize. It will print "Ready." when it's safe
+to start sending it transactions.
+
 Then, in a separate shell, let's execute some transactions. Note we pass in
 the JSON configuration file here, not the genesis ledger.
 

--- a/README.md
+++ b/README.md
@@ -39,25 +39,25 @@ $ cd solana
 The testnode server is initialized with a ledger from stdin and
 generates new ledger entries on stdout. To create the input ledger, we'll need
 to create *the mint* and use it to generate a *genesis ledger*. It's done in
-two steps because the mint.json file contains a private key that will be
+two steps because the mint-demo.json file contains private keys that will be
 used later in this demo.
 
 ```bash
-    $ echo 1000000000 | cargo run --release --bin solana-mint | tee mint.json
-    $ cat mint.json | cargo run --release --bin solana-genesis | tee genesis.log
+    $ echo 1000000000 | cargo run --release --bin solana-mint-demo > mint-demo.json
+    $ cat mint-demo.json | cargo run --release --bin solana-genesis-demo > genesis.log
 ```
 
 Now you can start the server:
 
 ```bash
-    $ cat genesis.log | cargo run --release --bin solana-testnode | tee transactions0.log
+    $ cat genesis.log | cargo run --release --bin solana-testnode > transactions0.log
 ```
 
 Then, in a separate shell, let's execute some transactions. Note we pass in
 the JSON configuration file here, not the genesis ledger.
 
 ```bash
-    $ cat mint.json | cargo run --release --bin solana-client-demo
+    $ cat mint-demo.json | cargo run --release --bin solana-client-demo
 ```
 
 Now kill the server with Ctrl-C, and take a look at the ledger. You should
@@ -73,14 +73,14 @@ Now restart the server from where we left off. Pass it both the genesis ledger, 
 the transaction ledger.
 
 ```bash
-    $ cat genesis.log transactions0.log | cargo run --release --bin solana-testnode | tee transactions1.log
+    $ cat genesis.log transactions0.log | cargo run --release --bin solana-testnode > transactions1.log
 ```
 
 Lastly, run the client demo again, and verify that all funds were spent in the
 previous round, and so no additional transactions are added.
 
 ```bash
-    $ cat mint.json | cargo run --release --bin solana-client-demo
+    $ cat mint-demo.json | cargo run --release --bin solana-client-demo
 ```
 
 Stop the server again, and verify there are only Tick entries, and no Transaction entries.

--- a/src/accountant_skel.rs
+++ b/src/accountant_skel.rs
@@ -52,9 +52,9 @@ pub enum Subscription {
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct EntryInfo {
-    id: Hash,
-    num_hashes: u64,
-    num_events: u64,
+    pub id: Hash,
+    pub num_hashes: u64,
+    pub num_events: u64,
 }
 
 impl Request {
@@ -70,7 +70,7 @@ impl Request {
 #[derive(Serialize, Deserialize, Debug)]
 pub enum Response {
     Balance { key: PublicKey, val: Option<i64> },
-    Entries { entries: Vec<Entry> },
+    EntryInfo(EntryInfo),
     LastId { id: Hash },
 }
 
@@ -96,7 +96,7 @@ impl<W: Write + Send + 'static> AccountantSkel<W> {
                 num_hashes: entry.num_hashes,
                 num_events: entry.events.len() as u64,
             };
-            let data = serialize(&entry_info).expect("serialize EntryInfo");
+            let data = serialize(&Response::EntryInfo(entry_info)).expect("serialize EntryInfo");
             let _res = socket.send_to(&data, addr);
         }
     }

--- a/src/accountant_skel.rs
+++ b/src/accountant_skel.rs
@@ -468,7 +468,7 @@ mod tests {
         let socket = UdpSocket::bind(send_addr).unwrap();
         socket.set_read_timeout(Some(Duration::new(5, 0))).unwrap();
 
-        let acc = AccountantStub::new(&addr, socket);
+        let mut acc = AccountantStub::new(&addr, socket);
         let last_id = acc.get_last_id().wait().unwrap();
 
         let tr = Transaction::new(&alice.keypair(), bob_pubkey, 500, last_id);

--- a/src/accountant_stub.rs
+++ b/src/accountant_stub.rs
@@ -131,6 +131,17 @@ impl AccountantStub {
     /// Return the number of transactions the server processed since creating
     /// this stub instance.
     pub fn transaction_count(&mut self) -> u64 {
+        // Wait for at least one EntryInfo.
+        let mut done = false;
+        while !done {
+            let resp = self.recv_response().expect("recv response");
+            if let &Response::EntryInfo(_) = &resp {
+                done = true;
+            }
+            self.process_response(resp);
+        }
+
+        // Then take the rest.
         self.socket.set_nonblocking(true).expect("set nonblocking");
         loop {
             match self.recv_response() {

--- a/src/bin/client-demo.rs
+++ b/src/bin/client-demo.rs
@@ -77,6 +77,7 @@ fn main() {
         exit(1);
     }
 
+    println!("Parsing stdin...");
     let demo: MintDemo = serde_json::from_reader(stdin()).unwrap_or_else(|e| {
         eprintln!("failed to parse json: {}", e);
         exit(1);
@@ -84,9 +85,11 @@ fn main() {
 
     let socket = UdpSocket::bind(&send_addr).unwrap();
     let mut acc = AccountantStub::new(&addr, socket);
-    println!("Get last id");
+
+    println!("Get last ID...");
     let last_id = acc.get_last_id().wait().unwrap();
 
+    println!("Creating keypairs...");
     let txs = demo.users.len() / 2;
     let keypairs: Vec<_> = demo.users
         .into_par_iter()
@@ -127,7 +130,6 @@ fn main() {
     });
 
     let mut tx_count = acc.transaction_count();
-    println!("tx count {}", tx_count);
     let mut prev_tx_count = tx_count + 1;
 
     println!("Waiting for the server to go idle...",);
@@ -142,5 +144,5 @@ fn main() {
     let duration = now.elapsed();
     let ns = duration.as_secs() * 1_000_000_000 + u64::from(duration.subsec_nanos());
     let tps = (txs * 1_000_000_000) as f64 / ns as f64;
-    println!("Done. If no packets dropped, {} tps", tps);
+    println!("Done. {} tps", tps);
 }

--- a/src/bin/client-demo.rs
+++ b/src/bin/client-demo.rs
@@ -83,7 +83,7 @@ fn main() {
     });
 
     let socket = UdpSocket::bind(&send_addr).unwrap();
-    let acc = AccountantStub::new(&addr, socket);
+    let mut acc = AccountantStub::new(&addr, socket);
     println!("Get last id");
     let last_id = acc.get_last_id().wait().unwrap();
 

--- a/src/bin/client-demo.rs
+++ b/src/bin/client-demo.rs
@@ -18,8 +18,7 @@ use std::env;
 use std::io::{stdin, Read};
 use std::net::UdpSocket;
 use std::process::exit;
-use std::thread::sleep;
-use std::time::{Duration, Instant};
+use std::time::Instant;
 use untrusted::Input;
 
 fn print_usage(program: &str, opts: Options) {
@@ -129,17 +128,13 @@ fn main() {
         }
     });
 
+    println!("Waiting for half the transactions to complete...",);
     let mut tx_count = acc.transaction_count();
-    let mut prev_tx_count = tx_count + 1;
-
-    println!("Waiting for the server to go idle...",);
-    while tx_count != prev_tx_count {
-        sleep(Duration::from_millis(20));
-        prev_tx_count = tx_count;
+    while tx_count < transactions.len() as u64 / 2 {
         tx_count = acc.transaction_count();
     }
     let txs = tx_count - initial_tx_count;
-    println!("Sent transactions {}", txs);
+    println!("Transactions processed {}", txs);
 
     let duration = now.elapsed();
     let ns = duration.as_secs() * 1_000_000_000 + u64::from(duration.subsec_nanos());

--- a/src/bin/client-demo.rs
+++ b/src/bin/client-demo.rs
@@ -4,21 +4,23 @@ extern crate isatty;
 extern crate rayon;
 extern crate serde_json;
 extern crate solana;
+extern crate untrusted;
 
 use futures::Future;
 use getopts::Options;
 use isatty::stdin_isatty;
 use rayon::prelude::*;
 use solana::accountant_stub::AccountantStub;
-use solana::mint::Mint;
+use solana::mint::MintDemo;
 use solana::signature::{KeyPair, KeyPairUtil};
 use solana::transaction::Transaction;
 use std::env;
 use std::io::{stdin, Read};
 use std::net::UdpSocket;
 use std::process::exit;
-use std::thread::sleep;
-use std::time::{Duration, Instant};
+use std::time::Instant;
+use untrusted::Input;
+//use std::sync::mpsc::sync_channel;
 
 fn print_usage(program: &str, opts: Options) {
     let mut brief = format!("Usage: cat <mint.json> | {} [options]\n\n", program);
@@ -75,37 +77,33 @@ fn main() {
         exit(1);
     }
 
-    let mint: Mint = serde_json::from_str(&buffer).unwrap_or_else(|e| {
+    let demo: MintDemo = serde_json::from_reader(stdin()).unwrap_or_else(|e| {
         eprintln!("failed to parse json: {}", e);
         exit(1);
     });
-    let mint_keypair = mint.keypair();
-    let mint_pubkey = mint.pubkey();
 
     let socket = UdpSocket::bind(&send_addr).unwrap();
-    println!("Stub new");
     let acc = AccountantStub::new(&addr, socket);
     println!("Get last id");
     let last_id = acc.get_last_id().wait().unwrap();
 
-    println!("Get Balance");
-    let mint_balance = acc.get_balance(&mint_pubkey).wait().unwrap();
-    println!("Mint's Initial Balance {}", mint_balance);
+    let txs = demo.users.len() / 2;
+    let keypairs: Vec<_> = demo.users
+        .into_par_iter()
+        .map(|(pkcs8, _)| KeyPair::from_pkcs8(Input::from(&pkcs8)).unwrap())
+        .collect();
+    let keypair_pairs: Vec<_> = keypairs.chunks(2).collect();
 
     println!("Signing transactions...");
-    let txs = 1_000_000;
     let now = Instant::now();
-    let transactions: Vec<_> = (0..txs)
+    let transactions: Vec<_> = keypair_pairs
         .into_par_iter()
-        .map(|_| {
-            let rando_pubkey = KeyPair::new().pubkey();
-            Transaction::new(&mint_keypair, rando_pubkey, 1, last_id)
-        })
+        .map(|chunk| Transaction::new(&chunk[0], chunk[1].pubkey(), 1, last_id))
         .collect();
     let duration = now.elapsed();
-    let ns = duration.as_secs() * 2_000_000_000 + u64::from(duration.subsec_nanos());
-    let bsps = f64::from(txs) / ns as f64;
-    let nsps = ns as f64 / f64::from(txs);
+    let ns = duration.as_secs() * 1_000_000_000 + u64::from(duration.subsec_nanos());
+    let bsps = txs as f64 / ns as f64;
+    let nsps = ns as f64 / txs as f64;
     println!(
         "Done. {} thousand signatures per second, {}us per signature",
         bsps * 1_000_000_f64,
@@ -116,33 +114,25 @@ fn main() {
     let now = Instant::now();
     let sz = transactions.len() / threads;
     let chunks: Vec<_> = transactions.chunks(sz).collect();
-    let _: Vec<_> = chunks
-        .into_par_iter()
-        .map(|trs| {
-            println!("Transferring 1 unit {} times...", trs.len());
-            let send_addr = "0.0.0.0:0";
-            let socket = UdpSocket::bind(send_addr).unwrap();
-            let acc = AccountantStub::new(&addr, socket);
-            for tr in trs {
-                acc.transfer_signed(tr.clone()).unwrap();
-            }
-            ()
-        })
-        .collect();
-    println!("Waiting for last transaction to be confirmed...",);
-    let mut val = mint_balance;
-    let mut prev = 0;
-    while val != prev {
-        sleep(Duration::from_millis(20));
-        prev = val;
-        val = acc.get_balance(&mint_pubkey).wait().unwrap();
-    }
-    println!("Mint's Final Balance {}", val);
-    let txs = mint_balance - val;
-    println!("Successful transactions {}", txs);
+    chunks.into_par_iter().for_each(|trs| {
+        println!("Transferring 1 unit {} times...", trs.len());
+        let send_addr = "0.0.0.0:0";
+        let socket = UdpSocket::bind(send_addr).unwrap();
+        //let (entry_info_sender, receiver) = sync_channel(1000);
+        //let acc = AccountantStub::new_thin_client(&addr, socket, entry_info_sender);
+        let acc = AccountantStub::new(&addr, socket);
+        for tr in trs {
+            acc.transfer_signed(tr.clone()).unwrap();
+        }
+
+        println!("Waiting for the server to go idle...",);
+        //while receiver.recv().unwrap().num_events > 0 {}
+    });
+
+    println!("Sent transactions {}", txs);
 
     let duration = now.elapsed();
     let ns = duration.as_secs() * 1_000_000_000 + u64::from(duration.subsec_nanos());
     let tps = (txs * 1_000_000_000) as f64 / ns as f64;
-    println!("Done. {} tps!", tps);
+    println!("Done. If no packets dropped, {} tps", tps);
 }

--- a/src/bin/client-demo.rs
+++ b/src/bin/client-demo.rs
@@ -18,9 +18,9 @@ use std::env;
 use std::io::{stdin, Read};
 use std::net::UdpSocket;
 use std::process::exit;
-use std::time::Instant;
+use std::thread::sleep;
+use std::time::{Duration, Instant};
 use untrusted::Input;
-//use std::sync::mpsc::sync_channel;
 
 fn print_usage(program: &str, opts: Options) {
     let mut brief = format!("Usage: cat <mint.json> | {} [options]\n\n", program);
@@ -110,6 +110,8 @@ fn main() {
         nsps / 1_000_f64
     );
 
+    let initial_tx_count = acc.transaction_count();
+
     println!("Transfering {} transactions in {} batches", txs, threads);
     let now = Instant::now();
     let sz = transactions.len() / threads;
@@ -118,17 +120,23 @@ fn main() {
         println!("Transferring 1 unit {} times...", trs.len());
         let send_addr = "0.0.0.0:0";
         let socket = UdpSocket::bind(send_addr).unwrap();
-        //let (entry_info_sender, receiver) = sync_channel(1000);
-        //let acc = AccountantStub::new_thin_client(&addr, socket, entry_info_sender);
         let acc = AccountantStub::new(&addr, socket);
         for tr in trs {
             acc.transfer_signed(tr.clone()).unwrap();
         }
-
-        println!("Waiting for the server to go idle...",);
-        //while receiver.recv().unwrap().num_events > 0 {}
     });
 
+    let mut tx_count = acc.transaction_count();
+    println!("tx count {}", tx_count);
+    let mut prev_tx_count = tx_count + 1;
+
+    println!("Waiting for the server to go idle...",);
+    while tx_count != prev_tx_count {
+        sleep(Duration::from_millis(20));
+        prev_tx_count = tx_count;
+        tx_count = acc.transaction_count();
+    }
+    let txs = tx_count - initial_tx_count;
     println!("Sent transactions {}", txs);
 
     let duration = now.elapsed();

--- a/src/bin/client-demo.rs
+++ b/src/bin/client-demo.rs
@@ -78,7 +78,7 @@ fn main() {
     }
 
     println!("Parsing stdin...");
-    let demo: MintDemo = serde_json::from_reader(stdin()).unwrap_or_else(|e| {
+    let demo: MintDemo = serde_json::from_str(&buffer).unwrap_or_else(|e| {
         eprintln!("failed to parse json: {}", e);
         exit(1);
     });

--- a/src/bin/genesis-demo.rs
+++ b/src/bin/genesis-demo.rs
@@ -6,15 +6,15 @@ extern crate solana;
 extern crate untrusted;
 
 use isatty::stdin_isatty;
+use rayon::prelude::*;
+use solana::accountant::MAX_ENTRY_IDS;
 use solana::entry::{create_entry, next_tick};
 use solana::event::Event;
-use solana::accountant::MAX_ENTRY_IDS;
 use solana::mint::MintDemo;
 use solana::signature::{KeyPair, KeyPairUtil};
 use solana::transaction::Transaction;
 use std::io::{stdin, Read};
 use std::process::exit;
-use rayon::prelude::*;
 use untrusted::Input;
 
 // Generate a ledger with lots and lots of accounts.

--- a/src/bin/genesis-demo.rs
+++ b/src/bin/genesis-demo.rs
@@ -31,7 +31,7 @@ fn main() {
         exit(1);
     }
 
-    let demo: MintDemo = serde_json::from_reader(stdin()).unwrap_or_else(|e| {
+    let demo: MintDemo = serde_json::from_str(&buffer).unwrap_or_else(|e| {
         eprintln!("failed to parse json: {}", e);
         exit(1);
     });

--- a/src/bin/genesis-demo.rs
+++ b/src/bin/genesis-demo.rs
@@ -1,21 +1,23 @@
 extern crate isatty;
+extern crate rayon;
+extern crate ring;
 extern crate serde_json;
 extern crate solana;
+extern crate untrusted;
 
 use isatty::stdin_isatty;
-use solana::entry::create_entry;
+use solana::entry::{create_entry, next_tick};
 use solana::event::Event;
-use solana::hash::Hash;
-use solana::mint::Mint;
-use solana::signature::{KeyPair, KeyPairUtil, PublicKey};
+use solana::accountant::MAX_ENTRY_IDS;
+use solana::mint::MintDemo;
+use solana::signature::{KeyPair, KeyPairUtil};
 use solana::transaction::Transaction;
 use std::io::{stdin, Read};
 use std::process::exit;
+use rayon::prelude::*;
+use untrusted::Input;
 
-fn transfer(from: &KeyPair, (to, tokens): (PublicKey, i64), last_id: Hash) -> Event {
-    Event::Transaction(Transaction::new(from, to, tokens, last_id))
-}
-
+// Generate a ledger with lots and lots of accounts.
 fn main() {
     if stdin_isatty() {
         eprintln!("nothing found on stdin, expected a json file");
@@ -29,20 +31,39 @@ fn main() {
         exit(1);
     }
 
-    let mint: Mint = serde_json::from_str(&buffer).unwrap_or_else(|e| {
+    let demo: MintDemo = serde_json::from_reader(stdin()).unwrap_or_else(|e| {
         eprintln!("failed to parse json: {}", e);
         exit(1);
     });
-    let mut entries = mint.create_entries();
 
-    let from = mint.keypair();
-    let seed = mint.seed();
-    let alice = (KeyPair::new().pubkey(), 200);
-    let bob = (KeyPair::new().pubkey(), 100);
-    let events = vec![transfer(&from, alice, seed), transfer(&from, bob, seed)];
-    entries.push(create_entry(&seed, 0, events));
+    let num_accounts = demo.users.len();
+    let last_id = demo.mint.last_id();
+    let mint_keypair = demo.mint.keypair();
 
-    for entry in entries {
+    eprintln!("Signing {} transactions...", num_accounts);
+    let events: Vec<_> = demo.users
+        .into_par_iter()
+        .map(|(pkcs8, tokens)| {
+            let rando = KeyPair::from_pkcs8(Input::from(&pkcs8)).unwrap();
+            let tr = Transaction::new(&mint_keypair, rando.pubkey(), tokens, last_id);
+            Event::Transaction(tr)
+        })
+        .collect();
+
+    for entry in demo.mint.create_entries() {
+        println!("{}", serde_json::to_string(&entry).unwrap());
+    }
+
+    eprintln!("Logging the creation of {} accounts...", num_accounts);
+    let entry = create_entry(&last_id, 0, events);
+    println!("{}", serde_json::to_string(&entry).unwrap());
+
+    eprintln!("Creating {} empty entries...", MAX_ENTRY_IDS);
+    // Offer client lots of entry IDs to use for each transaction's last_id.
+    let mut last_id = last_id;
+    for _ in 0..MAX_ENTRY_IDS {
+        let entry = next_tick(&last_id, 1);
+        last_id = entry.id;
         let serialized = serde_json::to_string(&entry).unwrap_or_else(|e| {
             eprintln!("failed to serialize: {}", e);
             exit(1);

--- a/src/bin/mint-demo.rs
+++ b/src/bin/mint-demo.rs
@@ -1,0 +1,33 @@
+extern crate rayon;
+extern crate ring;
+extern crate serde_json;
+extern crate solana;
+
+use solana::mint::{Mint, MintDemo};
+use solana::signature::KeyPair;
+use std::io;
+use rayon::prelude::*;
+use ring::rand::SystemRandom;
+
+fn main() {
+    let mut input_text = String::new();
+    io::stdin().read_line(&mut input_text).unwrap();
+    let trimmed = input_text.trim();
+    let tokens = trimmed.parse::<i64>().unwrap();
+
+    let mint = Mint::new(tokens);
+    let tokens_per_user = 1_000;
+    let num_accounts = tokens / tokens_per_user;
+    let rnd = SystemRandom::new();
+
+    let users: Vec<_> = (0..num_accounts)
+        .into_par_iter()
+        .map(|_| {
+            let pkcs8 = KeyPair::generate_pkcs8(&rnd).unwrap().to_vec();
+            (pkcs8, tokens_per_user)
+        })
+        .collect();
+
+    let demo = MintDemo { mint, users };
+    println!("{}", serde_json::to_string(&demo).unwrap());
+}

--- a/src/bin/mint-demo.rs
+++ b/src/bin/mint-demo.rs
@@ -3,11 +3,11 @@ extern crate ring;
 extern crate serde_json;
 extern crate solana;
 
+use rayon::prelude::*;
+use ring::rand::SystemRandom;
 use solana::mint::{Mint, MintDemo};
 use solana::signature::KeyPair;
 use std::io;
-use rayon::prelude::*;
-use ring::rand::SystemRandom;
 
 fn main() {
     let mut input_text = String::new();

--- a/src/bin/testnode.rs
+++ b/src/bin/testnode.rs
@@ -72,7 +72,7 @@ fn main() {
 
     // The first item in the ledger is required to be an entry with zero num_hashes,
     // which implies its id can be used as the ledger's seed.
-    entries.next().unwrap();
+    let entry0 = entries.next().unwrap();
 
     // The second item in the ledger is a special transaction where the to and from
     // fields are the same. That entry should be treated as a deposit, not a
@@ -85,11 +85,14 @@ fn main() {
     };
 
     let acc = Accountant::new_from_deposit(&deposit.unwrap());
+    acc.register_entry_id(&entry0.id);
+    acc.register_entry_id(&entry1.id);
 
     let mut last_id = entry1.id;
     for entry in entries {
         last_id = entry.id;
         acc.process_verified_events(entry.events).unwrap();
+        acc.register_entry_id(&last_id);
     }
 
     let historian = Historian::new(&last_id, Some(1000));

--- a/src/bin/testnode.rs
+++ b/src/bin/testnode.rs
@@ -64,7 +64,7 @@ fn main() {
 
     eprintln!("Initializing...");
     let mut entries = buffer.lines().map(|line| {
-        serde_json::from_str(&line.unwrap()).unwrap_or_else(|e| {
+        serde_json::from_str(&line).unwrap_or_else(|e| {
             eprintln!("failed to parse json: {}", e);
             exit(1);
         })

--- a/src/bin/testnode.rs
+++ b/src/bin/testnode.rs
@@ -62,8 +62,9 @@ fn main() {
         exit(1);
     }
 
+    eprintln!("Initializing...");
     let mut entries = buffer.lines().map(|line| {
-        serde_json::from_str(&line).unwrap_or_else(|e| {
+        serde_json::from_str(&line.unwrap()).unwrap_or_else(|e| {
             eprintln!("failed to parse json: {}", e);
             exit(1);
         })
@@ -99,8 +100,8 @@ fn main() {
         stdout(),
         historian,
     )));
-    eprintln!("Listening on {}", addr);
     let threads = AccountantSkel::serve(&skel, &addr, exit.clone()).unwrap();
+    eprintln!("Ready. Listening on {}", addr);
     for t in threads {
         t.join().expect("join");
     }

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -61,7 +61,7 @@ fn add_event_data(hash_data: &mut Vec<u8>, event: &Event) {
 }
 
 /// Creates the hash `num_hashes` after `start_hash`. If the event contains
-/// signature, the final hash will be a hash of both the previous ID and
+/// a signature, the final hash will be a hash of both the previous ID and
 /// the signature.
 pub fn next_hash(start_hash: &Hash, num_hashes: u64, events: &[Event]) -> Hash {
     let mut id = *start_hash;
@@ -76,10 +76,12 @@ pub fn next_hash(start_hash: &Hash, num_hashes: u64, events: &[Event]) -> Hash {
     }
 
     if !hash_data.is_empty() {
-        return extend_and_hash(&id, &hash_data);
+        extend_and_hash(&id, &hash_data)
+    } else if num_hashes != 0 {
+        hash(&id)
+    } else {
+        id
     }
-
-    id
 }
 
 /// Creates the next Entry `num_hashes` after `start_hash`.
@@ -167,6 +169,8 @@ mod tests {
     #[test]
     fn test_next_tick() {
         let zero = Hash::default();
-        assert_eq!(next_tick(&zero, 1).num_hashes, 1)
+        let tick = next_tick(&zero, 1);
+        assert_eq!(tick.num_hashes, 1);
+        assert_ne!(tick.id, zero);
     }
 }

--- a/src/mint.rs
+++ b/src/mint.rs
@@ -58,6 +58,12 @@ impl Mint {
     }
 }
 
+#[derive(Serialize, Deserialize, Debug)]
+pub struct MintDemo {
+    pub mint: Mint,
+    pub users: Vec<(Vec<u8>, i64)>,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
The goal of this PR is to create a demo that benchmarks the server using a more real world scenario, where transactions are generally independent of another. To do it, we seed one million accounts with 1000 tokens, and then create a half million transactions between them. Furthermore, instead of waiting until we're sure the server has processed everything, we improve our precision by stopping the benchmark while the system is at full throttle - after 250,000 transactions are recorded. Furthermore, unlike previous versions of the benchmark, we don't postpone writing the ledger. Instead, the benchmark includes serialization of those 250,000 transactions.

For this demo to work, the server somehow needs to seed 1,000,000 accounts and the client needs to know the private key of each of those accounts in order to send it to someone else. To share that information, I added a `solana-mint-demo` app that generates a `mint-demo.json` file, which contains those 1,000,000 keys along with the `mint.json` information we've seen before. Likewise, a new `solana-genesis-demo` was added to seed the accounts on the server side. We unfortunately couldn't do that from the client side, because we need to be sure every one of those accounts exist, and those checks and retries would take a very long time to execute from the client.

I don't recommend looking at the accountant_stub too closely, as it will mostly be deleted once we move to tokio. Apologies for the drop in code coverage, but I don't want to spend time testing code I want to delete.