### PR TITLE
Workaround linux hang

### DIFF
--- a/src/historian.rs
+++ b/src/historian.rs
@@ -16,8 +16,8 @@ pub struct Historian {
 
 impl Historian {
     pub fn new(start_hash: &Hash, ms_per_tick: Option<u64>) -> Self {
-        let (sender, event_receiver) = sync_channel(1000);
-        let (entry_sender, receiver) = sync_channel(1000);
+        let (sender, event_receiver) = sync_channel(10_000);
+        let (entry_sender, receiver) = sync_channel(10_000);
         let thread_hdl =
             Historian::create_recorder(*start_hash, ms_per_tick, event_receiver, entry_sender);
         Historian {


### PR DESCRIPTION
Without this patch, Linux systems would hang when running the demo.

The root cause (why Linux is acting differently than macOS) was
not determined, but we know the problem is caused by a known
issue in the transaction pipeline - that entries are not pulled
off the historian channel until after the full transaction batch
is processed. This patch makes the sync_channel large enough that
it should never block on a gigabit network.