### PR TITLE
improve the error messages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,4 +62,4 @@ matches = "^0.1.6"
 byteorder = "^1.2.1"
 libc = "^0.2.1"
 getopts = "^0.2"
-
+isatty = "0.1"

--- a/src/bin/genesis-demo.rs
+++ b/src/bin/genesis-demo.rs
@@ -1,13 +1,15 @@
+extern crate isatty;
 extern crate serde_json;
 extern crate solana;
 
+use isatty::stdin_isatty;
 use solana::entry::create_entry;
 use solana::event::Event;
 use solana::hash::Hash;
 use solana::mint::Mint;
 use solana::signature::{KeyPair, KeyPairUtil, PublicKey};
 use solana::transaction::Transaction;
-use std::io::stdin;
+use std::io::{stdin, Read};
 use std::process::exit;
 
 fn transfer(from: &KeyPair, (to, tokens): (PublicKey, i64), last_id: Hash) -> Event {
@@ -15,7 +17,19 @@ fn transfer(from: &KeyPair, (to, tokens): (PublicKey, i64), last_id: Hash) -> Ev
 }
 
 fn main() {
-    let mint: Mint = serde_json::from_reader(stdin()).unwrap_or_else(|e| {
+    if stdin_isatty() {
+        eprintln!("nothing found on stdin, expected a json file");
+        exit(1);
+    }
+
+    let mut buffer = String::new();
+    let num_bytes = stdin().read_to_string(&mut buffer).unwrap();
+    if num_bytes == 0 {
+        eprintln!("empty file on stdin, expected a json file");
+        exit(1);
+    }
+
+    let mint: Mint = serde_json::from_str(&buffer).unwrap_or_else(|e| {
         eprintln!("failed to parse json: {}", e);
         exit(1);
     });

--- a/src/bin/genesis.rs
+++ b/src/bin/genesis.rs
@@ -1,14 +1,28 @@
 //! A command-line executable for generating the chain's genesis block.
 
+extern crate isatty;
 extern crate serde_json;
 extern crate solana;
 
+use isatty::stdin_isatty;
 use solana::mint::Mint;
-use std::io::stdin;
+use std::io::{stdin, Read};
 use std::process::exit;
 
 fn main() {
-    let mint: Mint = serde_json::from_reader(stdin()).unwrap_or_else(|e| {
+    if stdin_isatty() {
+        eprintln!("nothing found on stdin, expected a json file");
+        exit(1);
+    }
+
+    let mut buffer = String::new();
+    let num_bytes = stdin().read_to_string(&mut buffer).unwrap();
+    if num_bytes == 0 {
+        eprintln!("empty file on stdin, expected a json file");
+        exit(1);
+    }
+
+    let mint: Mint = serde_json::from_str(&buffer).unwrap_or_else(|e| {
         eprintln!("failed to parse json: {}", e);
         exit(1);
     });

--- a/src/bin/mint.rs
+++ b/src/bin/mint.rs
@@ -1,16 +1,25 @@
+extern crate isatty;
 extern crate serde_json;
 extern crate solana;
 
+use isatty::stdin_isatty;
 use solana::mint::Mint;
 use std::io;
 use std::process::exit;
 
 fn main() {
     let mut input_text = String::new();
+    if stdin_isatty() {
+        eprintln!("nothing found on stdin, expected a token number");
+        exit(1);
+    }
+
     io::stdin().read_line(&mut input_text).unwrap();
     let trimmed = input_text.trim();
-    let tokens = trimmed.parse::<i64>().unwrap();
-
+    let tokens = trimmed.parse::<i64>().unwrap_or_else(|e| {
+        eprintln!("{}", e);
+        exit(1);
+    });
     let mint = Mint::new(tokens);
     let serialized = serde_json::to_string(&mint).unwrap_or_else(|e| {
         eprintln!("failed to serialize: {}", e);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,8 @@ pub mod accountant_skel;
 pub mod accountant_stub;
 pub mod ecdsa;
 pub mod entry;
+#[cfg(feature = "erasure")]
+pub mod erasure;
 pub mod event;
 pub mod hash;
 pub mod historian;
@@ -17,8 +19,6 @@ pub mod signature;
 pub mod streamer;
 pub mod subscribers;
 pub mod transaction;
-#[cfg(feature = "erasure")]
-pub mod erasure;
 extern crate bincode;
 extern crate byteorder;
 extern crate chrono;


### PR DESCRIPTION
This PR uses `stdin_isatty()` to raise an error when someone does not pipe a file into stdin or the file does not exist. 