### PR TITLE
TPU-friendly Historian

### DIFF
--- a/src/bin/historian-demo.rs
+++ b/src/bin/historian-demo.rs
@@ -8,25 +8,26 @@ use solana::ledger::Block;
 use solana::recorder::Signal;
 use solana::signature::{KeyPair, KeyPairUtil};
 use solana::transaction::Transaction;
-use std::sync::mpsc::SendError;
+use std::sync::mpsc::{sync_channel, SendError, SyncSender};
 use std::thread::sleep;
 use std::time::Duration;
 
-fn create_ledger(hist: &Historian, seed: &Hash) -> Result<(), SendError<Signal>> {
+fn create_ledger(input: &SyncSender<Signal>, seed: &Hash) -> Result<(), SendError<Signal>> {
     sleep(Duration::from_millis(15));
     let keypair = KeyPair::new();
     let tr = Transaction::new(&keypair, keypair.pubkey(), 42, *seed);
     let signal0 = Signal::Event(Event::Transaction(tr));
-    hist.input.send(signal0)?;
+    input.send(signal0)?;
     sleep(Duration::from_millis(10));
     Ok(())
 }
 
 fn main() {
+    let (input, event_receiver) = sync_channel(10);
     let seed = Hash::default();
-    let hist = Historian::new(&seed, Some(10));
-    create_ledger(&hist, &seed).expect("send error");
-    drop(hist.input);
+    let hist = Historian::new(event_receiver, &seed, Some(10));
+    create_ledger(&input, &seed).expect("send error");
+    drop(input);
     let entries: Vec<Entry> = hist.output.iter().collect();
     for entry in &entries {
         println!("{:?}", entry);

--- a/src/bin/historian-demo.rs
+++ b/src/bin/historian-demo.rs
@@ -17,7 +17,7 @@ fn create_ledger(hist: &Historian, seed: &Hash) -> Result<(), SendError<Signal>>
     let keypair = KeyPair::new();
     let tr = Transaction::new(&keypair, keypair.pubkey(), 42, *seed);
     let signal0 = Signal::Event(Event::Transaction(tr));
-    hist.sender.send(signal0)?;
+    hist.input.send(signal0)?;
     sleep(Duration::from_millis(10));
     Ok(())
 }
@@ -26,8 +26,8 @@ fn main() {
     let seed = Hash::default();
     let hist = Historian::new(&seed, Some(10));
     create_ledger(&hist, &seed).expect("send error");
-    drop(hist.sender);
-    let entries: Vec<Entry> = hist.receiver.iter().collect();
+    drop(hist.input);
+    let entries: Vec<Entry> = hist.output.iter().collect();
     for entry in &entries {
         println!("{:?}", entry);
     }

--- a/src/historian.rs
+++ b/src/historian.rs
@@ -9,20 +9,20 @@ use std::thread::{spawn, JoinHandle};
 use std::time::Instant;
 
 pub struct Historian {
-    pub sender: SyncSender<Signal>,
-    pub receiver: Receiver<Entry>,
+    pub input: SyncSender<Signal>,
+    pub output: Receiver<Entry>,
     pub thread_hdl: JoinHandle<ExitReason>,
 }
 
 impl Historian {
     pub fn new(start_hash: &Hash, ms_per_tick: Option<u64>) -> Self {
-        let (sender, event_receiver) = sync_channel(10_000);
-        let (entry_sender, receiver) = sync_channel(10_000);
+        let (input, event_receiver) = sync_channel(10_000);
+        let (entry_sender, output) = sync_channel(10_000);
         let thread_hdl =
             Historian::create_recorder(*start_hash, ms_per_tick, event_receiver, entry_sender);
         Historian {
-            sender,
-            receiver,
+            input,
+            output,
             thread_hdl,
         }
     }
@@ -62,21 +62,21 @@ mod tests {
         let zero = Hash::default();
         let hist = Historian::new(&zero, None);
 
-        hist.sender.send(Signal::Tick).unwrap();
+        hist.input.send(Signal::Tick).unwrap();
         sleep(Duration::new(0, 1_000_000));
-        hist.sender.send(Signal::Tick).unwrap();
+        hist.input.send(Signal::Tick).unwrap();
         sleep(Duration::new(0, 1_000_000));
-        hist.sender.send(Signal::Tick).unwrap();
+        hist.input.send(Signal::Tick).unwrap();
 
-        let entry0 = hist.receiver.recv().unwrap();
-        let entry1 = hist.receiver.recv().unwrap();
-        let entry2 = hist.receiver.recv().unwrap();
+        let entry0 = hist.output.recv().unwrap();
+        let entry1 = hist.output.recv().unwrap();
+        let entry2 = hist.output.recv().unwrap();
 
         assert_eq!(entry0.num_hashes, 0);
         assert_eq!(entry1.num_hashes, 0);
         assert_eq!(entry2.num_hashes, 0);
 
-        drop(hist.sender);
+        drop(hist.input);
         assert_eq!(
             hist.thread_hdl.join().unwrap(),
             ExitReason::RecvDisconnected
@@ -89,8 +89,8 @@ mod tests {
     fn test_historian_closed_sender() {
         let zero = Hash::default();
         let hist = Historian::new(&zero, None);
-        drop(hist.receiver);
-        hist.sender.send(Signal::Tick).unwrap();
+        drop(hist.output);
+        hist.input.send(Signal::Tick).unwrap();
         assert_eq!(
             hist.thread_hdl.join().unwrap(),
             ExitReason::SendDisconnected
@@ -102,9 +102,9 @@ mod tests {
         let zero = Hash::default();
         let hist = Historian::new(&zero, Some(20));
         sleep(Duration::from_millis(300));
-        hist.sender.send(Signal::Tick).unwrap();
-        drop(hist.sender);
-        let entries: Vec<Entry> = hist.receiver.iter().collect();
+        hist.input.send(Signal::Tick).unwrap();
+        drop(hist.input);
+        let entries: Vec<Entry> = hist.output.iter().collect();
         assert!(entries.len() > 1);
 
         // Ensure the ID is not the seed.


### PR DESCRIPTION
Before these patches, the Historian owned both its input and output channels. If other stages in the TPU pipeline followed suit, there'd be no way to stitch them together. With these patches, we look to set a more composable precedent. We have 3 choices of which channel to hoist: the input, the output, or both. With a bit of experimentation, it seems hoisting just the input channel results in both the most natural code and the most flexible. One might guess that hoisting both would be more flexible, but because `Sync` leaks into the sender's type signature, the only advantage to hoisting the output channel is to set the size of it (so might as well just pass in an integer!)

A pipeline can now be written as:

```rust
let (input, output) = channel();
let a = Stage0::new(output);
let b = Stage1::new(a.output);
let c = Stage2::new(b.output);
input.send(42);
drop(input);
assert_eq(c.output.iter().collect().len(), 1)
```