### PR TITLE
Add comment about rustc version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ $ source $HOME/.cargo/env
 $ rustup component add rustfmt-preview
 ```
 
-If your rustc version is lower than 1.25.0, please update and install rustfmt:
+If your rustc version is lower than 1.25.0, please update it:
 
 ```bash
 $ rustup update

--- a/README.md
+++ b/README.md
@@ -106,6 +106,13 @@ $ source $HOME/.cargo/env
 $ rustup component add rustfmt-preview
 ```
 
+If your rustc version is lower than 1.25.0, please update and install rustfmt:
+
+```bash
+$ rustup update
+$ rustup component add rustfmt-preview
+```
+
 Download the source code:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -110,7 +110,6 @@ If your rustc version is lower than 1.25.0, please update and install rustfmt:
 
 ```bash
 $ rustup update
-$ rustup component add rustfmt-preview
 ```
 
 Download the source code:


### PR DESCRIPTION
Hello,
There were lot of updates while I'm on vacation, so merged it and run test, but it showed some new errors...
```
...
error: Could not compile `solana`.
warning: build failed, waiting for other jobs to finish...
error: `std::mem::size_of` is not yet stable as a const fn
   --> src/packet.rs:214:32
    |
214 | const BLOB_INDEX_SIZE: usize = size_of::<u64>();
    |                                ^^^^^^^^^^^^^^^^
    |
    = help: in Nightly builds, add `#![feature(const_size_of)]` to the crate attributes to enable

error: aborting due to previous error
...
```

It seems it is related with rustfmt, but I couldn't add `rustfmt-preview` because of rustc version.
```
$ rustup component add rustfmt-preview
error: toolchain 'stable-x86_64-apple-darwin' does not contain component 'rustfmt-preview' for target 'x86_64-apple-darwin'
```

My rustc version was 1.22.0, and it worked find after I updated to newest one.
How about add comment about version in README?

Thanks.