### PR TITLE
Refactoring for upcoming thin client port

### DIFF
--- a/src/bin/testnode.rs
+++ b/src/bin/testnode.rs
@@ -103,7 +103,13 @@ fn main() {
     let mut last_id = entry1.id;
     for entry in entries {
         last_id = entry.id;
-        acc.process_verified_events(entry.events).unwrap();
+        let results = acc.process_verified_events(entry.events);
+        for result in results {
+            if let Err(e) = result {
+                eprintln!("failed to process event {:?}", e);
+                exit(1);
+            }
+        }
         acc.register_entry_id(&last_id);
     }
 


### PR DESCRIPTION
No new functionality here. Working towards sending thin client Request messages to one port and Events to another. Note that the current port will accept `Event`, not `Request::Transaction`. If you expect that to break the GPU code, now's the time to yell loudly.