### PR TITLE
Update README with proposed way to download the gpu lib

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-*.a filter=lfs diff=lfs merge=lfs -text

--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ $ cargo +nightly bench --features="unstable"
 To run the benchmarks on Linux with GPU optimizations enabled:
 
 ```bash
+$ wget https://solana.com/gpu/latest/libcuda_verify_ed25519.a
 $ cargo +nightly bench --features="unstable,cuda"
 ```
 


### PR DESCRIPTION
If you checked here yesterday, this was a top-level file in git-lfs,
but that made the developer workflow more painful so we boot that
file and are making it available via an http endpoint.