### PR TITLE
Hoist last_id

### DIFF
--- a/src/bank.rs
+++ b/src/bank.rs
@@ -170,7 +170,7 @@ impl Bank {
             return Err(BankError::AccountNotFound);
         }
 
-        if !self.reserve_signature_with_last_id(&tr.sig, &tr.data.last_id) {
+        if !self.reserve_signature_with_last_id(&tr.sig, &tr.last_id) {
             return Err(BankError::InvalidTransferSignature);
         }
 
@@ -179,7 +179,7 @@ impl Bank {
             let current = bal.load(Ordering::Relaxed) as i64;
 
             if current < tr.data.tokens {
-                self.forget_signature_with_last_id(&tr.sig, &tr.data.last_id);
+                self.forget_signature_with_last_id(&tr.sig, &tr.last_id);
                 return Err(BankError::InsufficientFunds);
             }
 

--- a/src/bank.rs
+++ b/src/bank.rs
@@ -160,7 +160,7 @@ impl Bank {
     /// Deduct tokens from the 'from' address the account has sufficient
     /// funds and isn't a duplicate.
     pub fn process_verified_transaction_debits(&self, tr: &Transaction) -> Result<()> {
-        info!("Transaction {}", tr.data.tokens);
+        info!("Transaction {}", tr.contract.tokens);
         let bals = self.balances
             .read()
             .expect("'balances' read lock in process_verified_transaction_debits");
@@ -178,14 +178,14 @@ impl Bank {
             let bal = option.expect("assignment of option to bal");
             let current = bal.load(Ordering::Relaxed) as i64;
 
-            if current < tr.data.tokens {
+            if current < tr.contract.tokens {
                 self.forget_signature_with_last_id(&tr.sig, &tr.last_id);
                 return Err(BankError::InsufficientFunds);
             }
 
             let result = bal.compare_exchange(
                 current as isize,
-                (current - tr.data.tokens) as isize,
+                (current - tr.contract.tokens) as isize,
                 Ordering::Relaxed,
                 Ordering::Relaxed,
             );
@@ -201,7 +201,7 @@ impl Bank {
     }
 
     pub fn process_verified_transaction_credits(&self, tr: &Transaction) {
-        let mut plan = tr.data.plan.clone();
+        let mut plan = tr.contract.plan.clone();
         plan.apply_witness(&Witness::Timestamp(*self.last_time
             .read()
             .expect("timestamp creation in process_verified_transaction_credits")));

--- a/src/bin/testnode.rs
+++ b/src/bin/testnode.rs
@@ -88,7 +88,7 @@ fn main() {
     // transfer to oneself.
     let entry1: Entry = entries.next().unwrap();
     let deposit = if let Event::Transaction(ref tr) = entry1.events[0] {
-        tr.data.plan.final_payment()
+        tr.contract.plan.final_payment()
     } else {
         None
     };

--- a/src/mint.rs
+++ b/src/mint.rs
@@ -76,7 +76,7 @@ mod tests {
     fn test_create_events() {
         let mut events = Mint::new(100).create_events().into_iter();
         if let Event::Transaction(tr) = events.next().unwrap() {
-            if let Plan::Pay(payment) = tr.data.plan {
+            if let Plan::Pay(payment) = tr.contract.plan {
                 assert_eq!(tr.from, payment.to);
             }
         }

--- a/src/thin_client.rs
+++ b/src/thin_client.rs
@@ -301,8 +301,8 @@ mod tests {
         let last_id = client.get_last_id().wait().unwrap();
 
         let mut tr2 = Transaction::new(&alice.keypair(), bob_pubkey, 501, last_id);
-        tr2.data.tokens = 502;
-        tr2.data.plan = Plan::new_payment(502, bob_pubkey);
+        tr2.contract.tokens = 502;
+        tr2.contract.plan = Plan::new_payment(502, bob_pubkey);
         let _sig = client.transfer_signed(tr2).unwrap();
 
         let balance = poll_get_balance(&mut client, &bob_pubkey);


### PR DESCRIPTION
@sakridge, how badly does this break GPU signature verification? The "signed data" is in the same location and technically has the same length, but is rearranged.