### PR TITLE
CI overhaul follow-ups

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Solana crate](https://img.shields.io/crates/v/solana.svg)](https://crates.io/crates/solana)
 [![Solana documentation](https://docs.rs/solana/badge.svg)](https://docs.rs/solana)
-[![Build Status](https://travis-ci.org/solana-labs/solana.svg?branch=master)](https://travis-ci.org/solana-labs/solana)
+[![Build status](https://badge.buildkite.com/d4c4d7da9154e3a8fb7199325f430ccdb05be5fc1e92777e51.svg)](https://buildkite.com/solana-labs/solana)
 [![codecov](https://codecov.io/gh/solana-labs/solana/branch/master/graph/badge.svg)](https://codecov.io/gh/solana-labs/solana)
 
 Disclaimer

--- a/ci/buildkite.yml
+++ b/ci/buildkite.yml
@@ -1,10 +1,26 @@
 steps:
   - command: "ci/coverage.sh"
-    label: "coverage [public]"
+    label: "coverage"
+    # TODO: Run coverage in a docker image rather than assuming kcov/cargo-kcov
+    #       is installed on the build agent...
+    #plugins:
+    #  docker#v1.1.1:
+    #    image: "rust"
+    #    user: "998:997" # buildkite-agent:buildkite-agent
+    #    environment:
+    #      - CODECOV_TOKEN=$CODECOV_TOKEN
   - command: "ci/test-stable.sh"
     label: "stable [public]"
+    plugins:
+      docker#v1.1.1:
+        image: "rust"
+        user: "998:997" # buildkite-agent:buildkite-agent
   - command: "ci/test-nightly.sh || true"
     label: "nightly - FAILURES IGNORED [public]"
+    plugins:
+      docker#v1.1.1:
+        image: "rustlang/rust:nightly"
+        user: "998:997" # buildkite-agent:buildkite-agent
   - command: "ci/test-ignored.sh || true"
     label: "ignored - FAILURES IGNORED [public]"
   - command: "ci/test-cuda.sh"
@@ -12,3 +28,10 @@ steps:
   - wait
   - command: "ci/publish.sh"
     label: "publish release artifacts"
+    plugins:
+      docker#v1.1.1:
+        image: "rust"
+        user: "998:997" # buildkite-agent:buildkite-agent
+        environment:
+          - BUILDKITE_TAG=$BUILDKITE_TAG
+          - CRATES_IO_TOKEN=$CRATES_IO_TOKEN

--- a/ci/coverage.sh
+++ b/ci/coverage.sh
@@ -2,8 +2,16 @@
 
 cd $(dirname $0)/..
 
-source $HOME/.cargo/env
-rustup update
+if [[ -r ~/.cargo/env ]]; then
+  # Pick up local install of kcov/cargo-kcov
+  source ~/.cargo/env
+fi
+
+rustc --version
+cargo --version
+kcov --version
+cargo-kcov --version
+
 export RUST_BACKTRACE=1
 cargo build
 cargo kcov

--- a/ci/test-ignored.sh
+++ b/ci/test-ignored.sh
@@ -2,7 +2,8 @@
 
 cd $(dirname $0)/..
 
-source $HOME/.cargo/env
-rustup update
+rustc --version
+cargo --version
+
 export RUST_BACKTRACE=1
 cargo test -- --ignored

--- a/ci/test-nightly.sh
+++ b/ci/test-nightly.sh
@@ -2,7 +2,9 @@
 
 cd $(dirname $0)/..
 
-source $HOME/.cargo/env
+rustc --version
+cargo --version
+
 rustup component add rustfmt-preview
 cargo fmt -- --write-mode=diff
 cargo build --verbose --features unstable

--- a/ci/test-stable.sh
+++ b/ci/test-stable.sh
@@ -2,7 +2,9 @@
 
 cd $(dirname $0)/..
 
-source $HOME/.cargo/env
+rustc --version
+cargo --version
+
 rustup component add rustfmt-preview
 cargo fmt -- --write-mode=diff
 cargo build --verbose


### PR DESCRIPTION
* Run `ci/test-*.sh` in docker to remove assumptions about what's currently installed on the buildkite agents (except `test-cuda.sh` for now...)
* Update link to CI badge in the README

Fixes #235 