### PR TITLE
Pull channel functionality into record_stage

### DIFF
--- a/src/banking_stage.rs
+++ b/src/banking_stage.rs
@@ -6,7 +6,7 @@ use event::Event;
 use packet;
 use packet::SharedPackets;
 use rayon::prelude::*;
-use recorder::Signal;
+use record_stage::Signal;
 use result::Result;
 use std::net::SocketAddr;
 use std::sync::Arc;
@@ -123,7 +123,7 @@ impl BankingStage {
 //use event::Event;
 //use hash::Hash;
 //use record_stage::RecordStage;
-//use recorder::Signal;
+//use record_stage::Signal;
 //use result::Result;
 //use std::sync::mpsc::{channel, Sender};
 //use std::sync::{Arc, Mutex};
@@ -261,7 +261,7 @@ mod bench {
     use event::Event;
     use mint::Mint;
     use packet::{to_packets, PacketRecycler};
-    use recorder::Signal;
+    use record_stage::Signal;
     use signature::{KeyPair, KeyPairUtil};
     use std::iter;
     use std::sync::Arc;

--- a/src/recorder.rs
+++ b/src/recorder.rs
@@ -1,41 +1,20 @@
 //! The `recorder` module provides an object for generating a Proof of History.
-//! It records Event items on behalf of its users. It continuously generates
-//! new hashes, only stopping to check if it has been sent an Event item. It
-//! tags each Event with an Entry, and sends it back. The Entry includes the
-//! Event, the latest hash, and the number of hashes since the last event.
-//! The resulting stream of entries represents ordered events in time.
+//! It records Event items on behalf of its users.
 
 use entry::Entry;
 use event::Event;
 use hash::{hash, Hash};
-use std::sync::mpsc::{Receiver, Sender, TryRecvError};
 use std::time::{Duration, Instant};
 
-#[cfg_attr(feature = "cargo-clippy", allow(large_enum_variant))]
-pub enum Signal {
-    Tick,
-    Events(Vec<Event>),
-}
-
-#[derive(Debug, PartialEq, Eq)]
-pub enum ExitReason {
-    RecvDisconnected,
-    SendDisconnected,
-}
-
 pub struct Recorder {
-    sender: Sender<Entry>,
-    receiver: Receiver<Signal>,
     last_hash: Hash,
     num_hashes: u64,
     num_ticks: u32,
 }
 
 impl Recorder {
-    pub fn new(receiver: Receiver<Signal>, sender: Sender<Entry>, last_hash: Hash) -> Self {
+    pub fn new(last_hash: Hash) -> Self {
         Recorder {
-            receiver,
-            sender,
             last_hash,
             num_hashes: 0,
             num_ticks: 0,
@@ -47,66 +26,17 @@ impl Recorder {
         self.num_hashes += 1;
     }
 
-    pub fn record_entry(&mut self, events: Vec<Event>) -> Result<(), ExitReason> {
-        let entry = Entry::new_mut(&mut self.last_hash, &mut self.num_hashes, events);
-        self.sender
-            .send(entry)
-            .or(Err(ExitReason::SendDisconnected))?;
-        Ok(())
+    pub fn record(&mut self, events: Vec<Event>) -> Entry {
+        Entry::new_mut(&mut self.last_hash, &mut self.num_hashes, events)
     }
 
-    pub fn process_events(
-        &mut self,
-        duration_data: Option<(Instant, Duration)>,
-    ) -> Result<(), ExitReason> {
-        loop {
-            if let Some((start_time, tick_duration)) = duration_data {
-                if start_time.elapsed() > tick_duration * (self.num_ticks + 1) {
-                    self.record_entry(vec![])?;
-                    // TODO: don't let this overflow u32
-                    self.num_ticks += 1;
-                }
-            }
-
-            match self.receiver.try_recv() {
-                Ok(signal) => match signal {
-                    Signal::Tick => {
-                        self.record_entry(vec![])?;
-                    }
-                    Signal::Events(events) => {
-                        self.record_entry(events)?;
-                    }
-                },
-                Err(TryRecvError::Empty) => return Ok(()),
-                Err(TryRecvError::Disconnected) => return Err(ExitReason::RecvDisconnected),
-            };
+    pub fn tick(&mut self, start_time: Instant, tick_duration: Duration) -> Option<Entry> {
+        if start_time.elapsed() > tick_duration * (self.num_ticks + 1) {
+            // TODO: don't let this overflow u32
+            self.num_ticks += 1;
+            Some(self.record(vec![]))
+        } else {
+            None
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use signature::{KeyPair, KeyPairUtil};
-    use std::sync::mpsc::channel;
-
-    #[test]
-    fn test_events() {
-        let (signal_sender, signal_receiver) = channel();
-        let (entry_sender, entry_receiver) = channel();
-        let zero = Hash::default();
-        let mut recorder = Recorder::new(signal_receiver, entry_sender, zero);
-        let alice_keypair = KeyPair::new();
-        let bob_pubkey = KeyPair::new().pubkey();
-        let event0 = Event::new_transaction(&alice_keypair, bob_pubkey, 1, zero);
-        let event1 = Event::new_transaction(&alice_keypair, bob_pubkey, 2, zero);
-        signal_sender
-            .send(Signal::Events(vec![event0, event1]))
-            .unwrap();
-        recorder.process_events(None).unwrap();
-
-        drop(recorder.sender);
-        let entries: Vec<_> = entry_receiver.iter().collect();
-        assert_eq!(entries.len(), 1);
     }
 }


### PR DESCRIPTION
This makes record_stage consistent with the other stages. The stage
manages the channels. Anything else is in a standalone object.