### PR TITLE
Handle event signatures consistently

### DIFF
--- a/src/bank.rs
+++ b/src/bank.rs
@@ -259,15 +259,13 @@ impl Bank {
     }
 
     fn partition_events(events: Vec<Event>) -> (Vec<Transaction>, Vec<Event>) {
-        let mut trs = vec![];
-        let mut rest = vec![];
-        for event in events {
-            match event {
-                Event::Transaction(tr) => trs.push(tr),
-                _ => rest.push(event),
-            }
-        }
-        (trs, rest)
+        (
+            events
+                .into_iter()
+                .map(|Event::Transaction(tr)| tr)
+                .collect(),
+            vec![],
+        )
     }
 
     pub fn process_verified_events(&self, events: Vec<Event>) -> Vec<Result<Event>> {
@@ -367,8 +365,6 @@ impl Bank {
     pub fn process_verified_event(&self, event: Event) -> Result<Event> {
         match event {
             Event::Transaction(ref tr) => self.process_verified_transaction(tr),
-            Event::Signature { from, tx_sig, .. } => self.process_verified_sig(from, tx_sig),
-            Event::Timestamp { from, dt, .. } => self.process_verified_timestamp(from, dt),
         }?;
         Ok(event)
     }

--- a/src/bin/testnode.rs
+++ b/src/bin/testnode.rs
@@ -97,12 +97,9 @@ fn main() {
     // fields are the same. That entry should be treated as a deposit, not a
     // transfer to oneself.
     let entry1: Entry = entries.next().unwrap();
-    let deposit = if let Event::Transaction(ref tr) = entry1.events[0] {
-        if let Instruction::NewContract(contract) = &tr.instruction {
-            contract.plan.final_payment()
-        } else {
-            None
-        }
+    let Event::Transaction(ref tr) = entry1.events[0];
+    let deposit = if let Instruction::NewContract(contract) = &tr.instruction {
+        contract.plan.final_payment()
     } else {
         None
     };

--- a/src/bin/testnode.rs
+++ b/src/bin/testnode.rs
@@ -14,6 +14,7 @@ use solana::entry::Entry;
 use solana::event::Event;
 use solana::server::Server;
 use solana::signature::{KeyPair, KeyPairUtil};
+use solana::transaction::Instruction;
 use std::env;
 use std::fs::File;
 use std::io::{stdin, stdout, Read};
@@ -97,7 +98,11 @@ fn main() {
     // transfer to oneself.
     let entry1: Entry = entries.next().unwrap();
     let deposit = if let Event::Transaction(ref tr) = entry1.events[0] {
-        tr.contract.plan.final_payment()
+        if let Instruction::NewContract(contract) = &tr.instruction {
+            contract.plan.final_payment()
+        } else {
+            None
+        }
     } else {
         None
     };

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -68,14 +68,6 @@ fn add_event_data(hash_data: &mut Vec<u8>, event: &Event) {
             hash_data.push(0u8);
             hash_data.extend_from_slice(&tr.sig);
         }
-        Event::Signature { ref sig, .. } => {
-            hash_data.push(1u8);
-            hash_data.extend_from_slice(sig);
-        }
-        Event::Timestamp { ref sig, .. } => {
-            hash_data.push(2u8);
-            hash_data.extend_from_slice(sig);
-        }
     }
 }
 
@@ -120,6 +112,7 @@ mod tests {
     use event::Event;
     use hash::hash;
     use signature::{KeyPair, KeyPairUtil};
+    use transaction::Transaction;
 
     #[test]
     fn test_entry_verify() {
@@ -154,8 +147,12 @@ mod tests {
 
         // First, verify entries
         let keypair = KeyPair::new();
-        let tr0 = Event::new_timestamp(&keypair, Utc::now(), zero);
-        let tr1 = Event::new_signature(&keypair, Default::default(), zero);
+        let tr0 = Event::Transaction(Transaction::new_timestamp(&keypair, Utc::now(), zero));
+        let tr1 = Event::Transaction(Transaction::new_signature(
+            &keypair,
+            Default::default(),
+            zero,
+        ));
         let mut e0 = Entry::new(&zero, 0, vec![tr0.clone(), tr1.clone()]);
         assert!(e0.verify(&zero));
 

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -154,8 +154,8 @@ mod tests {
 
         // First, verify entries
         let keypair = KeyPair::new();
-        let tr0 = Event::new_timestamp(&keypair, Utc::now());
-        let tr1 = Event::new_signature(&keypair, Default::default());
+        let tr0 = Event::new_timestamp(&keypair, Utc::now(), zero);
+        let tr1 = Event::new_signature(&keypair, Default::default(), zero);
         let mut e0 = Entry::new(&zero, 0, vec![tr0.clone(), tr1.clone()]);
         assert!(e0.verify(&zero));
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -34,7 +34,7 @@ impl Event {
     }
 
     /// Create and sign a new Witness Timestamp. Used for unit-testing.
-    pub fn new_timestamp(from: &KeyPair, dt: DateTime<Utc>) -> Self {
+    pub fn new_timestamp(from: &KeyPair, dt: DateTime<Utc>, _last_id: Hash) -> Self {
         let sign_data = serialize(&dt).expect("serialize 'dt' in pub fn new_timestamp");
         let sig = Signature::clone_from_slice(from.sign(&sign_data).as_ref());
         Event::Timestamp {
@@ -45,7 +45,7 @@ impl Event {
     }
 
     /// Create and sign a new Witness Signature. Used for unit-testing.
-    pub fn new_signature(from: &KeyPair, tx_sig: Signature) -> Self {
+    pub fn new_signature(from: &KeyPair, tx_sig: Signature, _last_id: Hash) -> Self {
         let sig = Signature::clone_from_slice(from.sign(&tx_sig).as_ref());
         Event::Signature {
             from: from.pubkey(),
@@ -75,7 +75,8 @@ mod tests {
 
     #[test]
     fn test_event_verify() {
-        assert!(Event::new_timestamp(&KeyPair::new(), Utc::now()).verify());
-        assert!(Event::new_signature(&KeyPair::new(), Signature::default()).verify());
+        let zero = Hash::default();
+        assert!(Event::new_timestamp(&KeyPair::new(), Utc::now(), zero).verify());
+        assert!(Event::new_signature(&KeyPair::new(), Signature::default(), zero).verify());
     }
 }

--- a/src/event.rs
+++ b/src/event.rs
@@ -1,25 +1,13 @@
 //! The `event` module handles events, which may be a `Transaction`, or a `Witness` used to process a pending
 //! Transaction.
 
-use bincode::serialize;
-use chrono::prelude::*;
 use hash::Hash;
-use signature::{KeyPair, PublicKey, Signature, SignatureUtil};
+use signature::{KeyPair, PublicKey};
 use transaction::Transaction;
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub enum Event {
     Transaction(Transaction),
-    Signature {
-        from: PublicKey,
-        tx_sig: Signature,
-        sig: Signature,
-    },
-    Timestamp {
-        from: PublicKey,
-        dt: DateTime<Utc>,
-        sig: Signature,
-    },
 }
 
 impl Event {
@@ -33,41 +21,11 @@ impl Event {
         Event::Transaction(tr)
     }
 
-    /// Create and sign a new Witness Timestamp. Used for unit-testing.
-    pub fn new_timestamp(from: &KeyPair, dt: DateTime<Utc>, last_id: Hash) -> Self {
-        let tr = Transaction::new_timestamp(from, dt, last_id);
-        Event::Transaction(tr)
-    }
-
-    /// Create and sign a new Witness Signature. Used for unit-testing.
-    pub fn new_signature(from: &KeyPair, tx_sig: Signature, last_id: Hash) -> Self {
-        let tr = Transaction::new_signature(from, tx_sig, last_id);
-        Event::Transaction(tr)
-    }
-
     /// Verify the Event's signature's are valid and if a transaction, that its
     /// spending plan is valid.
     pub fn verify(&self) -> bool {
         match *self {
             Event::Transaction(ref tr) => tr.verify_sig(),
-            Event::Signature { from, tx_sig, sig } => sig.verify(&from, &tx_sig),
-            Event::Timestamp { from, dt, sig } => sig.verify(
-                &from,
-                &serialize(&dt).expect("serialize 'dt' in pub fn verify"),
-            ),
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use signature::{KeyPair, KeyPairUtil};
-
-    #[test]
-    fn test_event_verify() {
-        let zero = Hash::default();
-        assert!(Event::new_timestamp(&KeyPair::new(), Utc::now(), zero).verify());
-        assert!(Event::new_signature(&KeyPair::new(), Signature::default(), zero).verify());
     }
 }

--- a/src/event.rs
+++ b/src/event.rs
@@ -4,7 +4,7 @@
 use bincode::serialize;
 use chrono::prelude::*;
 use hash::Hash;
-use signature::{KeyPair, KeyPairUtil, PublicKey, Signature, SignatureUtil};
+use signature::{KeyPair, PublicKey, Signature, SignatureUtil};
 use transaction::Transaction;
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
@@ -34,24 +34,15 @@ impl Event {
     }
 
     /// Create and sign a new Witness Timestamp. Used for unit-testing.
-    pub fn new_timestamp(from: &KeyPair, dt: DateTime<Utc>, _last_id: Hash) -> Self {
-        let sign_data = serialize(&dt).expect("serialize 'dt' in pub fn new_timestamp");
-        let sig = Signature::clone_from_slice(from.sign(&sign_data).as_ref());
-        Event::Timestamp {
-            from: from.pubkey(),
-            dt,
-            sig,
-        }
+    pub fn new_timestamp(from: &KeyPair, dt: DateTime<Utc>, last_id: Hash) -> Self {
+        let tr = Transaction::new_timestamp(from, dt, last_id);
+        Event::Transaction(tr)
     }
 
     /// Create and sign a new Witness Signature. Used for unit-testing.
-    pub fn new_signature(from: &KeyPair, tx_sig: Signature, _last_id: Hash) -> Self {
-        let sig = Signature::clone_from_slice(from.sign(&tx_sig).as_ref());
-        Event::Signature {
-            from: from.pubkey(),
-            tx_sig,
-            sig,
-        }
+    pub fn new_signature(from: &KeyPair, tx_sig: Signature, last_id: Hash) -> Self {
+        let tr = Transaction::new_signature(from, tx_sig, last_id);
+        Event::Transaction(tr)
     }
 
     /// Verify the Event's signature's are valid and if a transaction, that its

--- a/src/mint.rs
+++ b/src/mint.rs
@@ -76,11 +76,10 @@ mod tests {
     #[test]
     fn test_create_events() {
         let mut events = Mint::new(100).create_events().into_iter();
-        if let Event::Transaction(tr) = events.next().unwrap() {
-            if let Instruction::NewContract(contract) = tr.instruction {
-                if let Plan::Pay(payment) = contract.plan {
-                    assert_eq!(tr.from, payment.to);
-                }
+        let Event::Transaction(tr) = events.next().unwrap();
+        if let Instruction::NewContract(contract) = tr.instruction {
+            if let Plan::Pay(payment) = contract.plan {
+                assert_eq!(tr.from, payment.to);
             }
         }
         assert_eq!(events.next(), None);

--- a/src/mint.rs
+++ b/src/mint.rs
@@ -71,13 +71,16 @@ mod tests {
     use super::*;
     use ledger::Block;
     use plan::Plan;
+    use transaction::Instruction;
 
     #[test]
     fn test_create_events() {
         let mut events = Mint::new(100).create_events().into_iter();
         if let Event::Transaction(tr) = events.next().unwrap() {
-            if let Plan::Pay(payment) = tr.contract.plan {
-                assert_eq!(tr.from, payment.to);
+            if let Instruction::NewContract(contract) = tr.instruction {
+                if let Plan::Pay(payment) = contract.plan {
+                    assert_eq!(tr.from, payment.to);
+                }
             }
         }
         assert_eq!(events.next(), None);

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -7,6 +7,7 @@ use chrono::prelude::*;
 use signature::PublicKey;
 use std::mem;
 
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub enum Witness {
     Timestamp(DateTime<Utc>),
     Signature(PublicKey),

--- a/src/thin_client.rs
+++ b/src/thin_client.rs
@@ -192,6 +192,7 @@ mod tests {
     use std::thread::sleep;
     use std::time::Duration;
     use streamer::default_window;
+    use transaction::Instruction;
     use tvu::tests::TestNode;
 
     #[test]
@@ -284,8 +285,10 @@ mod tests {
         let last_id = client.get_last_id().wait().unwrap();
 
         let mut tr2 = Transaction::new(&alice.keypair(), bob_pubkey, 501, last_id);
-        tr2.contract.tokens = 502;
-        tr2.contract.plan = Plan::new_payment(502, bob_pubkey);
+        if let Instruction::NewContract(contract) = &mut tr2.instruction {
+            contract.tokens = 502;
+            contract.plan = Plan::new_payment(502, bob_pubkey);
+        }
         let _sig = client.transfer_signed(tr2).unwrap();
 
         let balance = poll_get_balance(&mut client, &bob_pubkey);

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -33,11 +33,12 @@ pub struct Transaction {
 }
 
 impl Transaction {
-    /// Create and sign a new Transaction. Used for unit-testing.
-    pub fn new(from_keypair: &KeyPair, to: PublicKey, tokens: i64, last_id: Hash) -> Self {
+    fn new_from_instruction(
+        from_keypair: &KeyPair,
+        instruction: Instruction,
+        last_id: Hash,
+    ) -> Self {
         let from = from_keypair.pubkey();
-        let plan = Plan::Pay(Payment { tokens, to });
-        let instruction = Instruction::NewContract(Contract { plan, tokens });
         let mut tr = Transaction {
             sig: Signature::default(),
             instruction,
@@ -46,6 +47,25 @@ impl Transaction {
         };
         tr.sign(from_keypair);
         tr
+    }
+
+    /// Create and sign a new Transaction. Used for unit-testing.
+    pub fn new(from_keypair: &KeyPair, to: PublicKey, tokens: i64, last_id: Hash) -> Self {
+        let plan = Plan::Pay(Payment { tokens, to });
+        let instruction = Instruction::NewContract(Contract { plan, tokens });
+        Self::new_from_instruction(from_keypair, instruction, last_id)
+    }
+
+    /// Create and sign a new Witness Timestamp. Used for unit-testing.
+    pub fn new_timestamp(from_keypair: &KeyPair, dt: DateTime<Utc>, last_id: Hash) -> Self {
+        let instruction = Instruction::ApplyTimestamp(dt);
+        Self::new_from_instruction(from_keypair, instruction, last_id)
+    }
+
+    /// Create and sign a new Witness Signature. Used for unit-testing.
+    pub fn new_signature(from_keypair: &KeyPair, tx_sig: Signature, last_id: Hash) -> Self {
+        let instruction = Instruction::ApplySignature(tx_sig);
+        Self::new_from_instruction(from_keypair, instruction, last_id)
     }
 
     /// Create and sign a postdated Transaction. Used for unit-testing.

--- a/src/tvu.rs
+++ b/src/tvu.rs
@@ -249,7 +249,7 @@ pub mod tests {
             w.set_index(i).unwrap();
             w.set_id(leader_id).unwrap();
 
-            let tr0 = Event::new_timestamp(&bob_keypair, Utc::now());
+            let tr0 = Event::new_timestamp(&bob_keypair, Utc::now(), cur_hash);
             let entry0 = Entry::new(&cur_hash, i, vec![tr0]);
             bank.register_entry_id(&cur_hash);
             cur_hash = hash(&cur_hash);

--- a/src/tvu.rs
+++ b/src/tvu.rs
@@ -154,7 +154,6 @@ pub fn test_node() -> (ReplicatedData, UdpSocket, UdpSocket, UdpSocket, UdpSocke
 pub mod tests {
     use bank::Bank;
     use bincode::serialize;
-    use chrono::prelude::*;
     use crdt::Crdt;
     use crdt::ReplicatedData;
     use entry::Entry;
@@ -249,8 +248,7 @@ pub mod tests {
             w.set_index(i).unwrap();
             w.set_id(leader_id).unwrap();
 
-            let tr0 = Event::new_timestamp(&bob_keypair, Utc::now(), cur_hash);
-            let entry0 = Entry::new(&cur_hash, i, vec![tr0]);
+            let entry0 = Entry::new(&cur_hash, i, vec![]);
             bank.register_entry_id(&cur_hash);
             cur_hash = hash(&cur_hash);
 


### PR DESCRIPTION
Currently we have an Event enum type that is either a Transaction or a Witness that a previously submitted smart contract is waiting on. In each field (Transaction, Timestamp, Signature), we see duplicate information, a `from` PublicKey and a `sig` Signature, but those signatures are not handled consistently by the SigVerifyStage or the BankingStage. Rather than handling those individually, as well as each new Event type that we add, we need the top-level data type to be a `struct` containing the PublicKey, Signature, and the signed data. This PR gets most of the way there by reducing Event to an enum with a single field, Transaction, and then replacing Transaction's `contract` field with a new `instruction` field containing a new `Instruction` enum with fields for spinning up a smart contract or applying a witness. It means that Transaction now has a clear definition, "an atomic client-defined set of instructions," and one that is consistent with both Distributed Systems and Bitcoin terminology.

The next step is to remove the Event enum, which after this patchset, only exists as a shim to minimize churn. Once removed, we'll see Entries containing a list of Transactions, not a list of Events. To extend the contract language, you'll add a field to the Instruction enum, and handle it in the Bank's `process_verified_transactions()` method. Duplicates will automatically be discarded and you can be certain the `from` PublicKey was from the entity that sent the message.

Fixes #236