### PR TITLE
comment on bad blob usage

### DIFF
--- a/src/packet.rs
+++ b/src/packet.rs
@@ -246,7 +246,10 @@ pub fn to_blob<T: Serialize>(
         let mut b = blob.write().unwrap();
         let v = serialize(&resp)?;
         let len = v.len();
-        //TODO: we are not using .data_mut() method here because the raw bytes are being serialized and sent, this isn't the right interface, and we should create a separate path for sending request responses in the RPU
+        // TODO: we are not using .data_mut() method here because
+        // the raw bytes are being serialized and sent, this isn't the
+        // right interface, and we should create a separate path for
+        // sending request responses in the RPU
         b.data[..len].copy_from_slice(&v);
         b.meta.size = len;
         b.meta.set_addr(&rsp_addr);

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -246,6 +246,7 @@ pub fn to_blob<T: Serialize>(
         let mut b = blob.write().unwrap();
         let v = serialize(&resp)?;
         let len = v.len();
+        //TODO: we are not using .data_mut() method here because the raw bytes are being serialized and sent, this isn't the right interface, and we should create a separate path for sending request responses in the RPU
         b.data[..len].copy_from_slice(&v);
         b.meta.size = len;
         b.meta.set_addr(&rsp_addr);


### PR DESCRIPTION
we are using blobs as a response in the RPU, but the responses ignore the 'header' we have in blobs for broadcast/retransmition.  its just overloading that interface.

I think we should actually pull that header (index and sender) out of the blobs and wrap the events structure, since they are specific to the PoH stream.