### PR TITLE
Faster startup

### DIFF
--- a/src/bank.rs
+++ b/src/bank.rs
@@ -260,7 +260,10 @@ impl Bank {
             .collect()
     }
 
-    pub fn process_entries(&self, entries: Vec<Entry>) -> Result<()> {
+    pub fn process_entries<I>(&self, entries: I) -> Result<()>
+    where
+        I: IntoIterator<Item = Entry>,
+    {
         for entry in entries {
             self.register_entry_id(&entry.id);
             for result in self.process_transactions(entry.transactions) {

--- a/src/bank.rs
+++ b/src/bank.rs
@@ -265,10 +265,10 @@ impl Bank {
         I: IntoIterator<Item = Entry>,
     {
         for entry in entries {
-            self.register_entry_id(&entry.id);
             for result in self.process_transactions(entry.transactions) {
                 result?;
             }
+            self.register_entry_id(&entry.id);
         }
         Ok(())
     }

--- a/src/bin/fullnode.rs
+++ b/src/bin/fullnode.rs
@@ -115,9 +115,7 @@ fn main() {
 
     eprintln!("processing entries...");
 
-    let mut last_id = entry1.id;
     for entry in entries {
-        last_id = entry.id;
         let results = bank.process_transactions(entry.transactions);
         for result in results {
             if let Err(e) = result {
@@ -125,7 +123,7 @@ fn main() {
                 exit(1);
             }
         }
-        bank.register_entry_id(&last_id);
+        bank.register_entry_id(&entry.id);
     }
 
     eprintln!("creating networking stack...");
@@ -166,7 +164,6 @@ fn main() {
         let file = File::create("leader.log").expect("leader.log create");
         let server = Server::new_leader(
             bank,
-            last_id,
             //Some(Duration::from_millis(1000)),
             None,
             repl_data.clone(),

--- a/src/bin/fullnode.rs
+++ b/src/bin/fullnode.rs
@@ -114,17 +114,7 @@ fn main() {
     bank.register_entry_id(&entry1.id);
 
     eprintln!("processing entries...");
-
-    for entry in entries {
-        let results = bank.process_transactions(entry.transactions);
-        for result in results {
-            if let Err(e) = result {
-                eprintln!("failed to process transaction {:?}", e);
-                exit(1);
-            }
-        }
-        bank.register_entry_id(&entry.id);
-    }
+    bank.process_entries(entries).expect("process_entries");
 
     eprintln!("creating networking stack...");
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -3,7 +3,6 @@
 use bank::Bank;
 use crdt::{Crdt, ReplicatedData};
 use data_replicator::DataReplicator;
-use hash::Hash;
 use packet;
 use rpu::Rpu;
 use std::io::Write;
@@ -23,7 +22,6 @@ pub struct Server {
 impl Server {
     pub fn new_leader<W: Write + Send + 'static>(
         bank: Bank,
-        start_hash: Hash,
         tick_duration: Option<Duration>,
         me: ReplicatedData,
         requests_socket: UdpSocket,
@@ -42,7 +40,6 @@ impl Server {
         let blob_recycler = packet::BlobRecycler::default();
         let tpu = Tpu::new(
             bank.clone(),
-            start_hash,
             tick_duration,
             transactions_socket,
             blob_recycler.clone(),

--- a/src/thin_client.rs
+++ b/src/thin_client.rs
@@ -202,7 +202,6 @@ mod tests {
 
         let server = Server::new_leader(
             bank,
-            alice.last_id(),
             Some(Duration::from_millis(30)),
             leader.data.clone(),
             leader.sockets.requests,
@@ -247,7 +246,6 @@ mod tests {
 
         let server = Server::new_leader(
             bank,
-            alice.last_id(),
             Some(Duration::from_millis(30)),
             leader.data.clone(),
             leader.sockets.requests,

--- a/src/tpu.rs
+++ b/src/tpu.rs
@@ -4,7 +4,6 @@
 use bank::Bank;
 use banking_stage::BankingStage;
 use fetch_stage::FetchStage;
-use hash::Hash;
 use packet::{BlobRecycler, PacketRecycler};
 use record_stage::RecordStage;
 use sigverify_stage::SigVerifyStage;
@@ -25,7 +24,6 @@ pub struct Tpu {
 impl Tpu {
     pub fn new<W: Write + Send + 'static>(
         bank: Arc<Bank>,
-        start_hash: Hash,
         tick_duration: Option<Duration>,
         transactions_socket: UdpSocket,
         blob_recycler: BlobRecycler,
@@ -49,10 +47,10 @@ impl Tpu {
         let record_stage = match tick_duration {
             Some(tick_duration) => RecordStage::new_with_clock(
                 banking_stage.signal_receiver,
-                &start_hash,
+                &bank.last_id(),
                 tick_duration,
             ),
-            None => RecordStage::new(banking_stage.signal_receiver, &start_hash),
+            None => RecordStage::new(banking_stage.signal_receiver, &bank.last_id()),
         };
 
         let write_stage = WriteStage::new(

--- a/tests/multinode.rs
+++ b/tests/multinode.rs
@@ -106,7 +106,6 @@ fn test_multi_node() {
     let leader_bank = Bank::new(&alice);
     let server = Server::new_leader(
         leader_bank,
-        alice.last_id(),
         None,
         leader.data.clone(),
         leader.sockets.requests,


### PR DESCRIPTION
Speed comes from minimizing thread contention between the bank's data structures. The most important one is the `last_ids` queue, which is used to check for duplicate transactions. To maximize throughput, you want to choose as many different `last_id`s as possible in your transactions.