### PR TITLE
Speed up client demo

### DIFF
--- a/src/bank.rs
+++ b/src/bank.rs
@@ -96,6 +96,12 @@ impl Bank {
         last_item.0
     }
 
+    /// Return all recent entry IDs. The last item is the most recent.
+    pub fn last_ids(&self) -> Vec<Hash> {
+        let last_ids = self.last_ids.read().expect("'last_ids' read lock");
+        last_ids.iter().map(|x| x.0).collect()
+    }
+
     fn reserve_signature(signatures: &RwLock<HashSet<Signature>>, sig: &Signature) -> Result<()> {
         if signatures
             .read()

--- a/src/request.rs
+++ b/src/request.rs
@@ -8,6 +8,7 @@ use signature::PublicKey;
 pub enum Request {
     GetBalance { key: PublicKey },
     GetLastId,
+    GetLastIds,
     GetTransactionCount,
 }
 
@@ -22,5 +23,6 @@ impl Request {
 pub enum Response {
     Balance { key: PublicKey, val: Option<i64> },
     LastId { id: Hash },
+    LastIds { ids: Vec<Hash> },
     TransactionCount { transaction_count: u64 },
 }

--- a/src/request_processor.rs
+++ b/src/request_processor.rs
@@ -34,6 +34,12 @@ impl RequestProcessor {
                 info!("Response::LastId {:?}", rsp);
                 Some(rsp)
             }
+            Request::GetLastIds => {
+                let ids = self.bank.last_ids();
+                let rsp = (Response::LastIds { ids }, rsp_addr);
+                info!("Response::LastIds {:?}", rsp);
+                Some(rsp)
+            }
             Request::GetTransactionCount => {
                 let transaction_count = self.bank.transaction_count() as u64;
                 let rsp = (Response::TransactionCount { transaction_count }, rsp_addr);


### PR DESCRIPTION
Model 1,000's of separate thin clients, each randomly observing
an arbitrary last_id in the past hour. Doing so allows the bank
to check for duplicate signatures of many transactions in parallel.