### PR TITLE
Do not use cuda for multinode-demo validator component by default

### DIFF
--- a/multinode-demo/validator.sh
+++ b/multinode-demo/validator.sh
@@ -17,5 +17,5 @@ export RUST_LOG=solana=info
 
 sudo sysctl -w net.core.rmem_max=26214400
 
-cargo run --release --features=cuda --bin solana-fullnode -- \
+cargo run --release --bin solana-fullnode -- \
     -l validator.json -v leader.json < genesis.log


### PR DESCRIPTION
Hi, I found, that on your validator.sh run script cuda is on by default.