### PR TITLE
Don't mark a build as failed if line coverage drops

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,2 +1,5 @@
 ignore:
   - "src/bin" 
+coverage:
+  status:
+    patch: off


### PR DESCRIPTION
It's not always a problem if line coverage drops. For example,
coverage will drop if you make well-tested code more succinct.
It just means the uncovered code is just a larger percentage of
the codebase.