### PR TITLE
Various minor testnet demo script tweaks

### DIFF
--- a/ci/buildkite.yml
+++ b/ci/buildkite.yml
@@ -1,9 +1,10 @@
 steps:
-  - command: "ci/coverage.sh"
-    name: "coverage [public]"
-    timeout_in_minutes: 20
   - command: "ci/docker-run.sh rust ci/test-stable.sh"
     name: "stable [public]"
+    timeout_in_minutes: 20
+  - wait
+  - command: "ci/coverage.sh"
+    name: "coverage [public]"
     timeout_in_minutes: 20
   - command: "ci/docker-run.sh rustlang/rust:nightly ci/test-nightly.sh || true"
     name: "nightly - FAILURES IGNORED [public]"

--- a/multinode-demo/leader.sh
+++ b/multinode-demo/leader.sh
@@ -3,5 +3,6 @@
 # if RUST_LOG is unset, default to info
 export RUST_LOG=${RUST_LOG:-solana=info}
 
-sudo sysctl -w net.core.rmem_max=26214400
+set -x
+[[ $(uname) = Linux ]] && sudo sysctl -w net.core.rmem_max=26214400
 cargo run --release --bin solana-fullnode -- -l leader.json < genesis.log

--- a/multinode-demo/validator.sh
+++ b/multinode-demo/validator.sh
@@ -11,7 +11,7 @@ set -x
 
 rsync -v -e ssh "$LEADER"/{mint-demo.json,leader.json,genesis.log} . || exit $?
 
-sudo sysctl -w net.core.rmem_max=26214400
+[[ $(uname) = Linux ]] && sudo sysctl -w net.core.rmem_max=26214400
 
 # if RUST_LOG is unset, default to info
 export RUST_LOG=${RUST_LOG:-solana=info}

--- a/src/bin/client-demo.rs
+++ b/src/bin/client-demo.rs
@@ -395,6 +395,6 @@ fn converge(
 }
 
 fn read_leader(path: String) -> ReplicatedData {
-    let file = File::open(path).expect("file");
-    serde_json::from_reader(file).expect("parse")
+    let file = File::open(path.clone()).expect(&format!("file not found: {}", path));
+    serde_json::from_reader(file).expect(&format!("failed to parse {}", path))
 }

--- a/src/bin/fullnode.rs
+++ b/src/bin/fullnode.rs
@@ -115,14 +115,20 @@ fn main() {
             if let Ok(data) = serde_json::from_reader(file) {
                 repl_data = data;
             } else {
-                warn!("failed to parse leader {}, generating new identity", path);
+                warn!("failed to parse {}, generating new identity", path);
             }
+        } else {
+            warn!("failed to read {}, generating new identity", path);
         }
     }
+
     let threads = if matches.opt_present("v") {
-        eprintln!("starting validator... {}", repl_data.requests_addr);
         let path = matches.opt_str("v").unwrap();
-        let file = File::open(path).expect("file");
+        eprintln!(
+            "starting validator... {} using {}",
+            repl_data.requests_addr, path
+        );
+        let file = File::open(path.clone()).expect(&format!("file not found: {}", path));
         let leader = serde_json::from_reader(file).expect("parse");
         let s = Server::new_validator(
             bank,


### PR DESCRIPTION
1. Permit the testnet to run all on the same machine/workspace (leader, validator, client) for quick tests
1. Only `sudo` on Linux
1. Tiny error reporting improvements, as an excuse to do something in Rust. 