### PR TITLE
ci: Add cleanup script to manage build agent disk space

### DIFF
--- a/ci/buildkite.yml
+++ b/ci/buildkite.yml
@@ -32,3 +32,7 @@ steps:
   - command: "ci/publish-crate.sh"
     timeout_in_minutes: 20
     name: "publish crate"
+  - command: "ci/hoover.sh"
+    timeout_in_minutes: 20
+    name: "clean agent"
+

--- a/ci/hoover.sh
+++ b/ci/hoover.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+#
+# Regular maintenance performed on a buildkite agent to control disk usage
+#
+
+echo --- Delete all exited containers first
+(
+  set -x
+  exited=$(docker ps -aq --no-trunc --filter "status=exited")
+  if [[ -n "$exited" ]]; then
+    docker rm "$exited"
+  fi
+)
+
+echo --- Delete untagged images
+(
+  set -x
+  untagged=$(docker images | grep '<none>'| awk '{ print $3 }')
+  if [[ -n "$untagged" ]]; then
+    docker rmi "$untagged"
+  fi
+)
+
+echo --- Delete all dangling images
+(
+  set -x
+  dangling=$(docker images --filter 'dangling=true' -q --no-trunc | sort | uniq)
+  if [[ -n "$dangling" ]]; then
+    docker rmi "$dangling"
+  fi
+)
+
+echo --- Remove unused docker networks
+(
+  set -x
+  docker network prune -f
+)
+
+echo "--- Delete /tmp files older than 1 day owned by $(whoami)"
+(
+  set -x
+  find /tmp -maxdepth 1 -user "$(whoami)" -mtime +1 -print0 | xargs -0 rm -rf
+)
+
+echo --- System Status
+(
+  set -x
+  docker images
+  docker ps
+  docker network ls
+  df -h
+)
+
+exit 0


### PR DESCRIPTION
Docker containers/images in particular need to be actively pruned to avoid running out of disk