### PR TITLE
Solana Drone

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ path = "src/bin/mint-demo.rs"
 
 [[bin]]
 name = "solana-drone"
-path = "src/bin/drone-demo.rs"
+path = "src/bin/drone.rs"
 
 [badges]
 codecov = { repository = "solana-labs/solana", branch = "master", service = "github" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,10 @@ path = "src/bin/mint.rs"
 name = "solana-mint-demo"
 path = "src/bin/mint-demo.rs"
 
+[[bin]]
+name = "solana-drone"
+path = "src/bin/drone-demo.rs"
+
 [badges]
 codecov = { repository = "solana-labs/solana", branch = "master", service = "github" }
 
@@ -70,3 +74,6 @@ getopts = "0.2"
 atty = "0.2"
 rand = "0.5.1"
 pnet = "0.21.0"
+tokio = "0.1"
+tokio-codec = "0.1"
+tokio-io = "0.1"

--- a/src/bin/drone-demo.rs
+++ b/src/bin/drone-demo.rs
@@ -1,0 +1,131 @@
+extern crate atty;
+extern crate bincode;
+extern crate env_logger;
+extern crate getopts;
+extern crate serde_json;
+extern crate solana;
+extern crate tokio;
+extern crate tokio_codec;
+extern crate tokio_io;
+
+use atty::{is, Stream as atty_stream};
+use bincode::deserialize;
+use getopts::Options;
+use solana::crdt::get_ip_addr;
+use solana::drone::{Drone, DroneRequest};
+use solana::mint::MintDemo;
+use solana::signature::GenKeys;
+use std::io::{stdin, Read};
+use std::net::SocketAddr;
+use std::env;
+use std::process::exit;
+use std::sync::{Arc, Mutex};
+use tokio_codec::{Decoder, BytesCodec};
+use tokio::net::TcpListener;
+use tokio::prelude::*;
+
+fn print_usage(program: &str, opts: Options) {
+    // TODO: Write this help information
+    let mut brief = format!("Usage: cat <transaction.log> | {} [options]\n\n", program);
+    brief += "  This is dummy content and still needs updating\n";
+
+    print!("{}", opts.usage(&brief));
+}
+
+fn main() {
+    env_logger::init();
+    let mut opts = Options::new();
+    opts.optopt("t", "", "time", "time slice over which to limit token requests to drone");
+    opts.optopt("c", "", "cap", "request limit for time slice");
+    opts.optflag("h", "help", "print help");
+    let args: Vec<String> = env::args().collect();
+    let matches = match opts.parse(&args[1..]) {
+        Ok(m) => m,
+        Err(e) => {
+            eprintln!("{}", e);
+            exit(1);
+        }
+    };
+    if matches.opt_present("h") {
+        let program = args[0].clone();
+        print_usage(&program, opts);
+        return;
+    }
+    let time_slice: Option<u64>;
+    if matches.opt_present("t") {
+        time_slice = matches.opt_str("t").expect("unexpected string from input").parse().ok();
+    }
+    else {
+        time_slice = None;
+    }
+    let request_cap: Option<u64>;
+    if matches.opt_present("c") {
+        request_cap = matches.opt_str("c").expect("unexpected string from input").parse().ok();
+    }
+    else {
+        request_cap = None;
+    }
+
+    if is(atty_stream::Stdin) {
+        eprintln!("nothing found on stdin, expected a json file");
+        exit(1);
+    }
+
+    let mut buffer = String::new();
+    let num_bytes = stdin().read_to_string(&mut buffer).unwrap();
+    if num_bytes == 0 {
+        eprintln!("empty file on stdin, expected a json file");
+        exit(1);
+    }
+
+    let demo: MintDemo = serde_json::from_str(&buffer).unwrap_or_else(|e| {
+        eprintln!("failed to parse json: {}", e);
+        exit(1);
+    });
+
+    let mint_keypair = demo.mint.keypair();
+
+    let mut drone_addr: SocketAddr = "0.0.0.0:9900".parse().unwrap();
+    drone_addr.set_ip(get_ip_addr().unwrap());
+    let mut transactions_addr = drone_addr.clone();
+    transactions_addr.set_port(8000);
+    let mut requests_addr = drone_addr.clone();
+    requests_addr.set_port(8003);
+    let drone = Arc::new(Mutex::new(Drone::new(mint_keypair, drone_addr, transactions_addr, requests_addr, time_slice, request_cap)));
+    let socket = TcpListener::bind(&drone_addr).unwrap();
+    println!("Listening on: {}", drone_addr);
+    let done = socket
+        .incoming()
+        .map_err(|e| println!("failed to accept socket; error = {:?}", e))
+        .for_each(move |socket| {
+            let drone1 = drone.clone();
+            let client_ip = socket.peer_addr().expect("drone peer_addr").ip();
+            let framed = BytesCodec::new().framed(socket);
+            let (_writer, reader) = framed.split();
+
+            let processor = reader
+                .for_each(move |bytes| {
+                    let req: DroneRequest = deserialize(&bytes).expect("deserialize packet in drone");
+                    println!("req: {:?}", req);
+                    let result = drone1.lock().unwrap().check_rate_limit(client_ip);
+                    println!("ip check: {:?}", result);
+                    let result1 = drone1.lock().unwrap().send_airdrop(req);
+                    println!("data: {:?}", result1);
+                    Ok(())
+                })
+                .and_then(|()| {
+                    println!("Socket received FIN packet and closed connection");
+                    Ok(())
+                })
+                .or_else(|err| {
+                    println!("Socket closed with error: {:?}", err);
+                    Err(err)
+                })
+                .then(|result| {
+                    println!("Socket closed with result: {:?}", result);
+                    Ok(())
+                });
+            tokio::spawn(processor)
+        });
+    tokio::run(done);
+}

--- a/src/bin/drone.rs
+++ b/src/bin/drone.rs
@@ -27,7 +27,7 @@ use tokio::prelude::*;
 use tokio_codec::{BytesCodec, Decoder};
 
 fn print_usage(program: &str, opts: Options) {
-    let mut brief = format!("Usage: cat <transaction.log> | {} [options]\n\n", program);
+    let mut brief = format!("Usage: cat <mint-demo.json> | {} [options]\n\n", program);
     brief += "  Run a Solana Drone to act as the custodian of the mint's remaining tokens\n";
 
     print!("{}", opts.usage(&brief));

--- a/src/bin/drone.rs
+++ b/src/bin/drone.rs
@@ -99,15 +99,12 @@ fn main() {
 
     let mut drone_addr: SocketAddr = "0.0.0.0:9900".parse().unwrap();
     drone_addr.set_ip(get_ip_addr().unwrap());
-    let mut transactions_addr = drone_addr.clone();
-    transactions_addr.set_port(8000);
-    let mut requests_addr = drone_addr.clone();
-    requests_addr.set_port(8003);
+    let mut server_addr = drone_addr.clone();
+    server_addr.set_port(8000);
     let drone = Arc::new(Mutex::new(Drone::new(
         mint_keypair,
         drone_addr,
-        transactions_addr,
-        requests_addr,
+        server_addr,
         time_slice,
         request_cap,
     )));

--- a/src/bin/genesis-demo.rs
+++ b/src/bin/genesis-demo.rs
@@ -36,7 +36,7 @@ fn main() {
     seed.copy_from_slice(&demo.mint.keypair().public_key_bytes()[..32]);
     let rnd = GenKeys::new(seed);
     let num_accounts = demo.num_accounts;
-    let tokens_per_user = 1_000;
+    let tokens_per_user = 500;
 
     let keypairs = rnd.gen_n_keypairs(num_accounts);
 

--- a/src/crdt.rs
+++ b/src/crdt.rs
@@ -784,14 +784,21 @@ pub struct TestNode {
 
 impl TestNode {
     pub fn new() -> TestNode {
-        let gossip = UdpSocket::bind("0.0.0.0:0").unwrap();
-        let gossip_send = UdpSocket::bind("0.0.0.0:0").unwrap();
-        let requests = UdpSocket::bind("0.0.0.0:0").unwrap();
         let transaction = UdpSocket::bind("0.0.0.0:0").unwrap();
-        let replicate = UdpSocket::bind("0.0.0.0:0").unwrap();
+        let mut addr = transaction.local_addr().unwrap();
+        let port = addr.port();
+        addr.set_port(port + 1);
+        let gossip = UdpSocket::bind(addr.clone()).unwrap();
+        addr.set_port(port + 2);
+        let replicate = UdpSocket::bind(addr.clone()).unwrap();
+        addr.set_port(port + 3);
+        let requests = UdpSocket::bind(addr.clone()).unwrap();
+        addr.set_port(port + 4);
+        let repair = UdpSocket::bind(addr.clone()).unwrap();
+
+        let gossip_send = UdpSocket::bind("0.0.0.0:0").unwrap();
         let respond = UdpSocket::bind("0.0.0.0:0").unwrap();
         let broadcast = UdpSocket::bind("0.0.0.0:0").unwrap();
-        let repair = UdpSocket::bind("0.0.0.0:0").unwrap();
         let retransmit = UdpSocket::bind("0.0.0.0:0").unwrap();
         let pubkey = KeyPair::new().pubkey();
         let data = ReplicatedData::new(

--- a/src/drone.rs
+++ b/src/drone.rs
@@ -35,8 +35,7 @@ pub struct Drone {
     mint_keypair: KeyPair,
     ip_cache: Vec<IpAddr>,
     _airdrop_addr: SocketAddr,
-    transactions_addr: SocketAddr,
-    requests_addr: SocketAddr,
+    server_addr: SocketAddr,
     pub time_slice: Duration,
     request_cap: u64,
     pub request_current: u64,
@@ -46,8 +45,7 @@ impl Drone {
     pub fn new(
         mint_keypair: KeyPair,
         _airdrop_addr: SocketAddr,
-        transactions_addr: SocketAddr,
-        requests_addr: SocketAddr,
+        server_addr: SocketAddr,
         time_input: Option<u64>,
         request_cap_input: Option<u64>,
     ) -> Drone {
@@ -63,20 +61,21 @@ impl Drone {
             mint_keypair,
             ip_cache: Vec::new(),
             _airdrop_addr,
-            transactions_addr,
-            requests_addr,
+            server_addr,
             time_slice,
             request_cap,
             request_current: 0,
         }
     }
 
+    pub fn new_from_server_addr(&mut self, addr_type: ServerAddr) -> SocketAddr {
+        let mut new_addr = self.server_addr.clone();
+        new_addr.set_port(self.server_addr.port() + addr_type as u16);
+        new_addr
+    }
+
     pub fn check_request_count(&mut self) -> bool {
-        if self.request_current <= self.request_cap {
-            true
-        } else {
-            false
-        }
+        self.request_current <= self.request_cap
     }
 
     pub fn clear_request_count(&mut self) {
@@ -112,9 +111,9 @@ impl Drone {
             let transactions_socket = UdpSocket::bind("0.0.0.0:0").unwrap();
 
             let mut client = ThinClient::new(
-                self.requests_addr,
+                self.new_from_server_addr(ServerAddr::RequestsAddr),
                 requests_socket,
-                self.transactions_addr,
+                self.new_from_server_addr(ServerAddr::TransactionsAddr),
                 transactions_socket,
             );
             let last_id = client.get_last_id();
@@ -149,6 +148,14 @@ impl Drone {
     }
 }
 
+pub enum ServerAddr {
+    TransactionsAddr,
+    GossipAddr,
+    ReplicateAddr,
+    RequestsAddr,
+    RepaidAddr,
+}
+
 #[cfg(test)]
 mod tests {
     use bank::Bank;
@@ -172,18 +179,8 @@ mod tests {
         let keypair = KeyPair::new();
         let mut addr: SocketAddr = "0.0.0.0:9900".parse().unwrap();
         addr.set_ip(get_ip_addr().unwrap());
-        let mut transactions_addr = addr.clone();
-        transactions_addr.set_port(8000);
-        let mut requests_addr = addr.clone();
-        requests_addr.set_port(8003);
-        let mut drone = Drone::new(
-            keypair,
-            addr,
-            transactions_addr,
-            requests_addr,
-            None,
-            Some(3),
-        );
+        let server_addr = addr.clone();
+        let mut drone = Drone::new(keypair, addr, server_addr, None, Some(3));
         assert!(drone.check_request_count());
         drone.request_current = 4;
         assert!(!drone.check_request_count());
@@ -194,15 +191,12 @@ mod tests {
         let keypair = KeyPair::new();
         let mut addr: SocketAddr = "0.0.0.0:9900".parse().unwrap();
         addr.set_ip(get_ip_addr().unwrap());
-        let mut transactions_addr = addr.clone();
-        transactions_addr.set_port(8000);
-        let mut requests_addr = addr.clone();
-        requests_addr.set_port(8003);
-        let mut drone = Drone::new(keypair, addr, transactions_addr, requests_addr, None, None);
+        let server_addr = addr.clone();
+        let mut drone = Drone::new(keypair, addr, server_addr, None, None);
         drone.request_current = drone.request_current + 256;
-        assert!(drone.request_current == 256);
+        assert_eq!(drone.request_current, 256);
         drone.clear_request_count();
-        assert!(drone.request_current == 0);
+        assert_eq!(drone.request_current, 0);
     }
 
     #[test]
@@ -210,11 +204,8 @@ mod tests {
         let keypair = KeyPair::new();
         let mut addr: SocketAddr = "0.0.0.0:9900".parse().unwrap();
         addr.set_ip(get_ip_addr().unwrap());
-        let mut transactions_addr = addr.clone();
-        transactions_addr.set_port(8000);
-        let mut requests_addr = addr.clone();
-        requests_addr.set_port(8003);
-        let mut drone = Drone::new(keypair, addr, transactions_addr, requests_addr, None, None);
+        let server_addr = addr.clone();
+        let mut drone = Drone::new(keypair, addr, server_addr, None, None);
         let ip = "127.0.0.1".parse().expect("create IpAddr from string");
         assert_eq!(drone.ip_cache.len(), 0);
         drone.add_ip_to_cache(ip);
@@ -227,11 +218,8 @@ mod tests {
         let keypair = KeyPair::new();
         let mut addr: SocketAddr = "0.0.0.0:9900".parse().unwrap();
         addr.set_ip(get_ip_addr().unwrap());
-        let mut transactions_addr = addr.clone();
-        transactions_addr.set_port(8000);
-        let mut requests_addr = addr.clone();
-        requests_addr.set_port(8003);
-        let mut drone = Drone::new(keypair, addr, transactions_addr, requests_addr, None, None);
+        let server_addr = addr.clone();
+        let mut drone = Drone::new(keypair, addr, server_addr, None, None);
         let ip = "127.0.0.1".parse().expect("create IpAddr from string");
         assert_eq!(drone.ip_cache.len(), 0);
         drone.add_ip_to_cache(ip);
@@ -246,17 +234,13 @@ mod tests {
         let keypair = KeyPair::new();
         let mut addr: SocketAddr = "0.0.0.0:9900".parse().unwrap();
         addr.set_ip(get_ip_addr().unwrap());
-        let mut transactions_addr = addr.clone();
-        transactions_addr.set_port(8000);
-        let mut requests_addr = addr.clone();
-        requests_addr.set_port(8003);
+        let server_addr = addr.clone();
         let time_slice: Option<u64> = None;
         let request_cap: Option<u64> = None;
         let drone = Drone::new(
             keypair,
             addr,
-            transactions_addr,
-            requests_addr,
+            server_addr,
             time_slice,
             request_cap,
         );
@@ -295,7 +279,6 @@ mod tests {
             alice.keypair(),
             addr,
             leader.data.transactions_addr,
-            leader.data.requests_addr,
             None,
             None,
         );

--- a/src/drone.rs
+++ b/src/drone.rs
@@ -252,14 +252,14 @@ mod tests {
         );
         sleep(Duration::from_millis(900));
 
-        let mut addr: SocketAddr = "0.0.0.0:9900".parse().unwrap();
-        addr.set_ip(get_ip_addr().unwrap());
+        let mut addr: SocketAddr = "0.0.0.0:9900".parse().expect("bind to drone socket");
+        addr.set_ip(get_ip_addr().expect("drone get_ip_addr"));
         let mut drone = Drone::new(
             alice.keypair(),
             addr,
             leader.data.transactions_addr,
             None,
-            None,
+            Some(5_000_050),
         );
 
         let bob_req = DroneRequest::GetAirdrop {
@@ -276,8 +276,8 @@ mod tests {
         let carlos_result = drone.send_airdrop(carlos_req).expect("send airdrop test");
         assert!(carlos_result > 0);
 
-        let requests_socket = UdpSocket::bind("0.0.0.0:0").unwrap();
-        let transactions_socket = UdpSocket::bind("0.0.0.0:0").unwrap();
+        let requests_socket = UdpSocket::bind("0.0.0.0:0").expect("drone bind to requests socket");
+        let transactions_socket = UdpSocket::bind("0.0.0.0:0").expect("drone bind to transactions socket");
 
         let mut client = ThinClient::new(
             leader.data.requests_addr,

--- a/src/drone.rs
+++ b/src/drone.rs
@@ -1,18 +1,28 @@
+//! The `drone` module provides an object for launching a Solana Drone,
+//! which is the custodian of any remaining tokens in a mint.
+//! The Solana Drone builds and send airdrop transactions,
+//! checking requests against a request cap for a given time time_slice
+//! and (to come) an IP rate limit.
+
 use signature::{KeyPair, PublicKey};
 use std::io;
+use std::io::{Error, ErrorKind};
 use std::net::{IpAddr, SocketAddr, UdpSocket};
 use std::time::Duration;
 use thin_client::ThinClient;
 use transaction::Transaction;
 
-pub const TIME_SLICE: u64 = 1;
+pub const TIME_SLICE: u64 = 60;
 pub const REQUEST_CAP: u64 = 500;
 pub const SMALL_BATCH: i64 = 50;
 pub const TPS_BATCH: i64 = 5_000_000;
 
 #[derive(Serialize, Deserialize, Debug)]
 pub enum DroneRequest {
-    GetAirdrop { request_type: DroneRequestType, client_public_key: PublicKey },
+    GetAirdrop {
+        request_type: DroneRequestType,
+        client_public_key: PublicKey,
+    },
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -24,18 +34,18 @@ pub enum DroneRequestType {
 pub struct Drone {
     mint_keypair: KeyPair,
     ip_cache: Vec<IpAddr>,
-    airdrop_addr: SocketAddr,
+    _airdrop_addr: SocketAddr,
     transactions_addr: SocketAddr,
     requests_addr: SocketAddr,
-    time_slice: Duration,
+    pub time_slice: Duration,
     request_cap: u64,
-    request_current: u64,
+    pub request_current: u64,
 }
 
 impl Drone {
     pub fn new(
         mint_keypair: KeyPair,
-        airdrop_addr: SocketAddr,
+        _airdrop_addr: SocketAddr,
         transactions_addr: SocketAddr,
         requests_addr: SocketAddr,
         time_input: Option<u64>,
@@ -43,22 +53,34 @@ impl Drone {
     ) -> Drone {
         let time_slice = match time_input {
             Some(time) => Duration::new(time, 0),
-            None => Duration::new(TIME_SLICE, 0)
+            None => Duration::new(TIME_SLICE, 0),
         };
         let request_cap = match request_cap_input {
             Some(cap) => cap,
-            None => REQUEST_CAP
+            None => REQUEST_CAP,
         };
         Drone {
             mint_keypair,
             ip_cache: Vec::new(),
-            airdrop_addr,
+            _airdrop_addr,
             transactions_addr,
             requests_addr,
             time_slice,
             request_cap,
             request_current: 0,
         }
+    }
+
+    pub fn check_request_count(&mut self) -> bool {
+        if self.request_current <= self.request_cap {
+            true
+        } else {
+            false
+        }
+    }
+
+    pub fn clear_request_count(&mut self) {
+        self.request_current = 0;
     }
 
     pub fn add_ip_to_cache(&mut self, ip: IpAddr) {
@@ -75,42 +97,55 @@ impl Drone {
         if self.ip_cache.contains(&ip) {
             // Add proper error handling here
             Err(ip)
-        }
-        else {
+        } else {
             self.add_ip_to_cache(ip);
             Ok(ip)
         }
-        // Test for quota limit met
     }
 
     pub fn send_airdrop(&mut self, req: DroneRequest) -> Result<usize, io::Error> {
-        let tx: Transaction;
+        self.request_current += 1;
 
-        let requests_socket = UdpSocket::bind("0.0.0.0:0").unwrap();
-        let transactions_socket = UdpSocket::bind("0.0.0.0:0").unwrap();
+        if self.check_request_count() {
+            let tx: Transaction;
+            let requests_socket = UdpSocket::bind("0.0.0.0:0").unwrap();
+            let transactions_socket = UdpSocket::bind("0.0.0.0:0").unwrap();
 
-        let mut client = ThinClient::new(
-            self.requests_addr,
-            requests_socket,
-            self.transactions_addr,
-            transactions_socket,
-        );
-        let last_id = client.get_last_id();
+            let mut client = ThinClient::new(
+                self.requests_addr,
+                requests_socket,
+                self.transactions_addr,
+                transactions_socket,
+            );
+            let last_id = client.get_last_id();
 
-        match req {
-            DroneRequest::GetAirdrop { request_type, client_public_key } => {
-                match request_type {
+            match req {
+                DroneRequest::GetAirdrop {
+                    request_type,
+                    client_public_key,
+                } => match request_type {
                     DroneRequestType::SmallBatch => {
-                        tx = Transaction::new(&self.mint_keypair, client_public_key, SMALL_BATCH, last_id);
+                        tx = Transaction::new(
+                            &self.mint_keypair,
+                            client_public_key,
+                            SMALL_BATCH,
+                            last_id,
+                        );
                     }
                     DroneRequestType::TPSBatch => {
-                        tx = Transaction::new(&self.mint_keypair, client_public_key, TPS_BATCH, last_id);
+                        tx = Transaction::new(
+                            &self.mint_keypair,
+                            client_public_key,
+                            TPS_BATCH,
+                            last_id,
+                        );
                     }
-                }
+                },
             }
+            client.transfer_signed(tx)
+        } else {
+            Err(Error::new(ErrorKind::Other, "request limit reached"))
         }
-
-        client.transfer_signed(tx)
     }
 }
 
@@ -118,18 +153,57 @@ impl Drone {
 mod tests {
     use bank::Bank;
     use crdt::{get_ip_addr, TestNode};
-    use drone::{Drone, DroneRequest, DroneRequestType, TIME_SLICE, REQUEST_CAP, SMALL_BATCH, TPS_BATCH};
+    use drone::{Drone, DroneRequest, DroneRequestType, REQUEST_CAP, SMALL_BATCH, TIME_SLICE,
+                TPS_BATCH};
     use logger;
     use mint::Mint;
     use server::Server;
     use signature::{KeyPair, KeyPairUtil};
     use std::io::sink;
     use std::net::{SocketAddr, UdpSocket};
-    use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
     use std::thread::sleep;
     use std::time::Duration;
     use thin_client::ThinClient;
+
+    #[test]
+    fn test_check_request_count() {
+        let keypair = KeyPair::new();
+        let mut addr: SocketAddr = "0.0.0.0:9900".parse().unwrap();
+        addr.set_ip(get_ip_addr().unwrap());
+        let mut transactions_addr = addr.clone();
+        transactions_addr.set_port(8000);
+        let mut requests_addr = addr.clone();
+        requests_addr.set_port(8003);
+        let mut drone = Drone::new(
+            keypair,
+            addr,
+            transactions_addr,
+            requests_addr,
+            None,
+            Some(3),
+        );
+        assert!(drone.check_request_count());
+        drone.request_current = 4;
+        assert!(!drone.check_request_count());
+    }
+
+    #[test]
+    fn test_clear_request_count() {
+        let keypair = KeyPair::new();
+        let mut addr: SocketAddr = "0.0.0.0:9900".parse().unwrap();
+        addr.set_ip(get_ip_addr().unwrap());
+        let mut transactions_addr = addr.clone();
+        transactions_addr.set_port(8000);
+        let mut requests_addr = addr.clone();
+        requests_addr.set_port(8003);
+        let mut drone = Drone::new(keypair, addr, transactions_addr, requests_addr, None, None);
+        drone.request_current = drone.request_current + 256;
+        assert!(drone.request_current == 256);
+        drone.clear_request_count();
+        assert!(drone.request_current == 0);
+    }
 
     #[test]
     fn test_add_ip_to_cache() {
@@ -178,7 +252,14 @@ mod tests {
         requests_addr.set_port(8003);
         let time_slice: Option<u64> = None;
         let request_cap: Option<u64> = None;
-        let drone = Drone::new(keypair, addr, transactions_addr, requests_addr, time_slice, request_cap);
+        let drone = Drone::new(
+            keypair,
+            addr,
+            transactions_addr,
+            requests_addr,
+            time_slice,
+            request_cap,
+        );
         assert_eq!(drone.time_slice, Duration::new(TIME_SLICE, 0));
         assert_eq!(drone.request_cap, REQUEST_CAP);
     }
@@ -210,13 +291,26 @@ mod tests {
 
         let mut addr: SocketAddr = "0.0.0.0:9900".parse().unwrap();
         addr.set_ip(get_ip_addr().unwrap());
-        let mut drone = Drone::new(alice.keypair(), addr, leader.data.transactions_addr, leader.data.requests_addr, None, None);
+        let mut drone = Drone::new(
+            alice.keypair(),
+            addr,
+            leader.data.transactions_addr,
+            leader.data.requests_addr,
+            None,
+            None,
+        );
 
-        let bob_req = DroneRequest::GetAirdrop{ request_type: DroneRequestType::SmallBatch, client_public_key: bob_pubkey };
+        let bob_req = DroneRequest::GetAirdrop {
+            request_type: DroneRequestType::SmallBatch,
+            client_public_key: bob_pubkey,
+        };
         let bob_result = drone.send_airdrop(bob_req).expect("send airdrop test");
         assert!(bob_result > 0);
 
-        let carlos_req = DroneRequest::GetAirdrop{ request_type: DroneRequestType::TPSBatch, client_public_key: carlos_pubkey };
+        let carlos_req = DroneRequest::GetAirdrop {
+            request_type: DroneRequestType::TPSBatch,
+            client_public_key: carlos_pubkey,
+        };
         let carlos_result = drone.send_airdrop(carlos_req).expect("send airdrop test");
         assert!(carlos_result > 0);
 

--- a/src/drone.rs
+++ b/src/drone.rs
@@ -13,7 +13,7 @@ use thin_client::ThinClient;
 use transaction::Transaction;
 
 pub const TIME_SLICE: u64 = 60;
-pub const REQUEST_CAP: u64 = 10_000_000;
+pub const REQUEST_CAP: u64 = 150_000;
 
 #[derive(Serialize, Deserialize, Debug)]
 pub enum DroneRequest {

--- a/src/drone.rs
+++ b/src/drone.rs
@@ -1,0 +1,246 @@
+use signature::{KeyPair, PublicKey};
+use std::io;
+use std::net::{IpAddr, SocketAddr, UdpSocket};
+use std::time::Duration;
+use thin_client::ThinClient;
+use transaction::Transaction;
+
+pub const TIME_SLICE: u64 = 1;
+pub const REQUEST_CAP: u64 = 500;
+pub const SMALL_BATCH: i64 = 50;
+pub const TPS_BATCH: i64 = 5_000_000;
+
+#[derive(Serialize, Deserialize, Debug)]
+pub enum DroneRequest {
+    GetAirdrop { request_type: DroneRequestType, client_public_key: PublicKey },
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub enum DroneRequestType {
+    SmallBatch,
+    TPSBatch,
+}
+
+pub struct Drone {
+    mint_keypair: KeyPair,
+    ip_cache: Vec<IpAddr>,
+    airdrop_addr: SocketAddr,
+    transactions_addr: SocketAddr,
+    requests_addr: SocketAddr,
+    time_slice: Duration,
+    request_cap: u64,
+    request_current: u64,
+}
+
+impl Drone {
+    pub fn new(
+        mint_keypair: KeyPair,
+        airdrop_addr: SocketAddr,
+        transactions_addr: SocketAddr,
+        requests_addr: SocketAddr,
+        time_input: Option<u64>,
+        request_cap_input: Option<u64>,
+    ) -> Drone {
+        let time_slice = match time_input {
+            Some(time) => Duration::new(time, 0),
+            None => Duration::new(TIME_SLICE, 0)
+        };
+        let request_cap = match request_cap_input {
+            Some(cap) => cap,
+            None => REQUEST_CAP
+        };
+        Drone {
+            mint_keypair,
+            ip_cache: Vec::new(),
+            airdrop_addr,
+            transactions_addr,
+            requests_addr,
+            time_slice,
+            request_cap,
+            request_current: 0,
+        }
+    }
+
+    pub fn add_ip_to_cache(&mut self, ip: IpAddr) {
+        self.ip_cache.push(ip);
+    }
+
+    pub fn clear_ip_cache(&mut self) {
+        self.ip_cache.clear();
+    }
+
+    pub fn check_rate_limit(&mut self, ip: IpAddr) -> Result<IpAddr, IpAddr> {
+        // [WIP] This is placeholder code for a proper rate limiter.
+        // Right now it will only allow one total drone request per IP
+        if self.ip_cache.contains(&ip) {
+            // Add proper error handling here
+            Err(ip)
+        }
+        else {
+            self.add_ip_to_cache(ip);
+            Ok(ip)
+        }
+        // Test for quota limit met
+    }
+
+    pub fn send_airdrop(&mut self, req: DroneRequest) -> Result<usize, io::Error> {
+        let tx: Transaction;
+
+        let requests_socket = UdpSocket::bind("0.0.0.0:0").unwrap();
+        let transactions_socket = UdpSocket::bind("0.0.0.0:0").unwrap();
+
+        let mut client = ThinClient::new(
+            self.requests_addr,
+            requests_socket,
+            self.transactions_addr,
+            transactions_socket,
+        );
+        let last_id = client.get_last_id();
+
+        match req {
+            DroneRequest::GetAirdrop { request_type, client_public_key } => {
+                match request_type {
+                    DroneRequestType::SmallBatch => {
+                        tx = Transaction::new(&self.mint_keypair, client_public_key, SMALL_BATCH, last_id);
+                    }
+                    DroneRequestType::TPSBatch => {
+                        tx = Transaction::new(&self.mint_keypair, client_public_key, TPS_BATCH, last_id);
+                    }
+                }
+            }
+        }
+
+        client.transfer_signed(tx)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bank::Bank;
+    use crdt::{get_ip_addr, TestNode};
+    use drone::{Drone, DroneRequest, DroneRequestType, TIME_SLICE, REQUEST_CAP, SMALL_BATCH, TPS_BATCH};
+    use logger;
+    use mint::Mint;
+    use server::Server;
+    use signature::{KeyPair, KeyPairUtil};
+    use std::io::sink;
+    use std::net::{SocketAddr, UdpSocket};
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
+    use std::thread::sleep;
+    use std::time::Duration;
+    use thin_client::ThinClient;
+
+    #[test]
+    fn test_add_ip_to_cache() {
+        let keypair = KeyPair::new();
+        let mut addr: SocketAddr = "0.0.0.0:9900".parse().unwrap();
+        addr.set_ip(get_ip_addr().unwrap());
+        let mut transactions_addr = addr.clone();
+        transactions_addr.set_port(8000);
+        let mut requests_addr = addr.clone();
+        requests_addr.set_port(8003);
+        let mut drone = Drone::new(keypair, addr, transactions_addr, requests_addr, None, None);
+        let ip = "127.0.0.1".parse().expect("create IpAddr from string");
+        assert_eq!(drone.ip_cache.len(), 0);
+        drone.add_ip_to_cache(ip);
+        assert_eq!(drone.ip_cache.len(), 1);
+        assert!(drone.ip_cache.contains(&ip));
+    }
+
+    #[test]
+    fn test_clear_ip_cache() {
+        let keypair = KeyPair::new();
+        let mut addr: SocketAddr = "0.0.0.0:9900".parse().unwrap();
+        addr.set_ip(get_ip_addr().unwrap());
+        let mut transactions_addr = addr.clone();
+        transactions_addr.set_port(8000);
+        let mut requests_addr = addr.clone();
+        requests_addr.set_port(8003);
+        let mut drone = Drone::new(keypair, addr, transactions_addr, requests_addr, None, None);
+        let ip = "127.0.0.1".parse().expect("create IpAddr from string");
+        assert_eq!(drone.ip_cache.len(), 0);
+        drone.add_ip_to_cache(ip);
+        assert_eq!(drone.ip_cache.len(), 1);
+        drone.clear_ip_cache();
+        assert_eq!(drone.ip_cache.len(), 0);
+        assert!(drone.ip_cache.is_empty());
+    }
+
+    #[test]
+    fn test_drone_default_init() {
+        let keypair = KeyPair::new();
+        let mut addr: SocketAddr = "0.0.0.0:9900".parse().unwrap();
+        addr.set_ip(get_ip_addr().unwrap());
+        let mut transactions_addr = addr.clone();
+        transactions_addr.set_port(8000);
+        let mut requests_addr = addr.clone();
+        requests_addr.set_port(8003);
+        let time_slice: Option<u64> = None;
+        let request_cap: Option<u64> = None;
+        let drone = Drone::new(keypair, addr, transactions_addr, requests_addr, time_slice, request_cap);
+        assert_eq!(drone.time_slice, Duration::new(TIME_SLICE, 0));
+        assert_eq!(drone.request_cap, REQUEST_CAP);
+    }
+
+    #[test]
+    fn test_send_airdrop() {
+        logger::setup();
+        let leader = TestNode::new();
+
+        let alice = Mint::new(10_000_000);
+        let bank = Bank::new(&alice);
+        let bob_pubkey = KeyPair::new().pubkey();
+        let carlos_pubkey = KeyPair::new().pubkey();
+        let exit = Arc::new(AtomicBool::new(false));
+
+        let server = Server::new_leader(
+            bank,
+            Some(Duration::from_millis(30)),
+            leader.data.clone(),
+            leader.sockets.requests,
+            leader.sockets.transaction,
+            leader.sockets.broadcast,
+            leader.sockets.respond,
+            leader.sockets.gossip,
+            exit.clone(),
+            sink(),
+        );
+        sleep(Duration::from_millis(900));
+
+        let mut addr: SocketAddr = "0.0.0.0:9900".parse().unwrap();
+        addr.set_ip(get_ip_addr().unwrap());
+        let mut drone = Drone::new(alice.keypair(), addr, leader.data.transactions_addr, leader.data.requests_addr, None, None);
+
+        let bob_req = DroneRequest::GetAirdrop{ request_type: DroneRequestType::SmallBatch, client_public_key: bob_pubkey };
+        let bob_result = drone.send_airdrop(bob_req).expect("send airdrop test");
+        assert!(bob_result > 0);
+
+        let carlos_req = DroneRequest::GetAirdrop{ request_type: DroneRequestType::TPSBatch, client_public_key: carlos_pubkey };
+        let carlos_result = drone.send_airdrop(carlos_req).expect("send airdrop test");
+        assert!(carlos_result > 0);
+
+        let requests_socket = UdpSocket::bind("0.0.0.0:0").unwrap();
+        let transactions_socket = UdpSocket::bind("0.0.0.0:0").unwrap();
+
+        let mut client = ThinClient::new(
+            leader.data.requests_addr,
+            requests_socket,
+            leader.data.transactions_addr,
+            transactions_socket,
+        );
+
+        let bob_balance = client.poll_get_balance(&bob_pubkey);
+        info!("Small batch balance: {:?}", bob_balance);
+        assert_eq!(bob_balance.unwrap(), SMALL_BATCH);
+
+        let carlos_balance = client.poll_get_balance(&carlos_pubkey);
+        info!("TPS batch balance: {:?}", carlos_balance);
+        assert_eq!(carlos_balance.unwrap(), TPS_BATCH);
+
+        exit.store(true, Ordering::Relaxed);
+        for t in server.thread_hdls {
+            t.join().unwrap();
+        }
+    }
+}

--- a/src/drone.rs
+++ b/src/drone.rs
@@ -277,7 +277,8 @@ mod tests {
         assert!(carlos_result > 0);
 
         let requests_socket = UdpSocket::bind("0.0.0.0:0").expect("drone bind to requests socket");
-        let transactions_socket = UdpSocket::bind("0.0.0.0:0").expect("drone bind to transactions socket");
+        let transactions_socket =
+            UdpSocket::bind("0.0.0.0:0").expect("drone bind to transactions socket");
 
         let mut client = ThinClient::new(
             leader.data.requests_addr,

--- a/src/drone.rs
+++ b/src/drone.rs
@@ -168,8 +168,8 @@ mod tests {
     use signature::{KeyPair, KeyPairUtil};
     use std::io::sink;
     use std::net::{SocketAddr, UdpSocket};
-    use std::sync::Arc;
     use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
     use std::thread::sleep;
     use std::time::Duration;
     use thin_client::ThinClient;
@@ -237,13 +237,7 @@ mod tests {
         let server_addr = addr.clone();
         let time_slice: Option<u64> = None;
         let request_cap: Option<u64> = None;
-        let drone = Drone::new(
-            keypair,
-            addr,
-            server_addr,
-            time_slice,
-            request_cap,
-        );
+        let drone = Drone::new(keypair, addr, server_addr, time_slice, request_cap);
         assert_eq!(drone.time_slice, Duration::new(TIME_SLICE, 0));
         assert_eq!(drone.request_cap, REQUEST_CAP);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ pub mod banking_stage;
 pub mod blob_fetch_stage;
 pub mod budget;
 pub mod crdt;
+pub mod drone;
 pub mod entry;
 pub mod entry_writer;
 #[cfg(feature = "erasure")]


### PR DESCRIPTION
For now, this maintains the previous singlenode setup as-is, and leaves the previous client-demo intact. I put in a little structure toward a TPS demo through the drone as well, but no functionality yet.
There is also no rate limiting by IP, as yet. (There is some rudimentary structure in that direction, but probably not the best way to do it.)
It does impose request cap for a given time time slice; I put in some defaults, for when no options are specified. Would love to discuss what seems reasonable!

Fixes #342