### PR TITLE
remove IPADDR, which was making Rob feel ill

### DIFF
--- a/multinode-demo/client.sh
+++ b/multinode-demo/client.sh
@@ -1,15 +1,14 @@
 #!/bin/bash
 
 if [[ -z $1 ]]; then
-  printf 'usage: %s [network path to solana repo on leader machine] [number of nodes in the network if greater then 1]' "$0"
-  exit 1
+    echo "usage: $0 [network path to solana repo on leader machine] <number of nodes in the network>"
+    exit 1
 fi
 
 LEADER=$1
 COUNT=${2:-1}
 
-set -x
-rsync -v "$LEADER"/{leader.json,mint-demo.json} . || exit $?
+rsync -vz "$LEADER"/{leader.json,mint-demo.json} . || exit $?
 
 # if RUST_LOG is unset, default to info
 export RUST_LOG=${RUST_LOG:-solana=info}

--- a/multinode-demo/leader.sh
+++ b/multinode-demo/leader.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
-here=$(dirname $0)
+here=$(dirname "$0")
+
+# shellcheck source=/dev/null
 . "${here}"/myip.sh
 
 myip=$(myip) || exit $?

--- a/multinode-demo/leader.sh
+++ b/multinode-demo/leader.sh
@@ -1,14 +1,26 @@
 #!/bin/bash
+here=$(dirname $0)
+. "${here}"/myip.sh
+
+myip=$(myip) || exit $?
+
+[[ -f leader-"${myip}".json ]] || {
+  echo "I can't find a matching leader config file for \"${myip}\"...
+Please run ${here}/setup.sh first.
+"
+  exit 1
+}
 
 # if RUST_LOG is unset, default to info
 export RUST_LOG=${RUST_LOG:-solana=info}
 
-set -x
-[[ $(uname) = Linux ]] && sudo sysctl -w net.core.rmem_max=26214400
+[[ $(uname) = Linux ]] && sudo sysctl -w net.core.rmem_max=26214400 1>/dev/null 2>/dev/null
 
-IPADDR="$(ifconfig | awk '/inet (addr)?/ {print $2}' | cut -d: -f2 | grep -v '127.0.0.1')"
-
-cp leader-"$IPADDR".json leader.json
+# this makes a leader.json file available alongside genesis, etc. for
+#  validators and clients
+cp leader-"${myip}".json leader.json
 
 cargo run --release --bin solana-fullnode -- \
-      -l leader.json < genesis.log tx-*.log > tx-"$(date -u +%Y%m%d%k%M%S%N)".log
+      -l leader-"${myip}".json \
+      < genesis.log tx-*.log \
+      > tx-"$(date -u +%Y%m%d%H%M%S%N)".log

--- a/multinode-demo/myip.sh
+++ b/multinode-demo/myip.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+function myip()
+{
+  declare ipaddrs=(
+    $(curl -s ifconfig.co)                             # query interwebs
+    $(ifconfig | awk '/inet(6)? (addr:)?/ {print $2}') # machine interfaces
+  )
+
+  if (( ! ${#ipaddrs[*]} ))
+  then
+      echo "
+myip: error: I'm having trouble determining what our IP address is...
+  Are we connected to a network?
+
+"
+      return 1
+  fi
+
+
+  declare prompt="
+Please choose the IP address you want to advertise to the network:
+
+   0) ${ipaddrs[0]} <====== this one was returned by the interwebs...
+"
+
+  for ((i=1; i < ${#ipaddrs[*]}; i++))
+  do
+    prompt+="   $i) ${ipaddrs[i]}
+"
+  done
+
+  while read -p "${prompt}
+please enter a number [0 for default]: " which
+  do
+    [[ -z ${which} ]] && break;
+    [[ ${which} =~ [0-9]+ ]] && (( which < ${#ipaddrs[*]} )) && break;
+    echo "Ug. invalid entry \"${which}\"...
+"
+    sleep 1
+  done
+
+  which=${which:-0}
+
+  echo "${ipaddrs[which]}"
+
+}
+
+if [[ ${0} == ${BASH_SOURCE[0]} ]]
+then
+    myip "$@"
+fi

--- a/multinode-demo/myip.sh
+++ b/multinode-demo/myip.sh
@@ -30,7 +30,7 @@ Please choose the IP address you want to advertise to the network:
 "
   done
 
-  while read -p "${prompt}
+  while read -r -p "${prompt}
 please enter a number [0 for default]: " which
   do
     [[ -z ${which} ]] && break;
@@ -46,7 +46,7 @@ please enter a number [0 for default]: " which
 
 }
 
-if [[ ${0} == ${BASH_SOURCE[0]} ]]
+if [[ ${0} == "${BASH_SOURCE[0]}" ]]
 then
     myip "$@"
 fi

--- a/multinode-demo/myip.sh
+++ b/multinode-demo/myip.sh
@@ -2,10 +2,16 @@
 
 function myip()
 {
-  declare ipaddrs=(
-    $(curl -s ifconfig.co)                             # query interwebs
-    $(ifconfig | awk '/inet(6)? (addr:)?/ {print $2}') # machine interfaces
-  )
+  declare ipaddrs=( )
+
+  # query interwebs
+  mapfile -t ipaddrs < <(curl -s ifconfig.co)
+
+  # machine's interfaces
+  mapfile -t -O "${#ipaddrs[*]}" ipaddrs < \
+          <(ifconfig | awk '/inet(6)? (addr:)?/ {print $2}')
+
+  ipaddrs=( "${extips[@]}" "${ipaddrs[@]}" )
 
   if (( ! ${#ipaddrs[*]} ))
   then

--- a/multinode-demo/setup.sh
+++ b/multinode-demo/setup.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
-here=$(dirname $0)
+here=$(dirname "$0")
+
+# shellcheck source=/dev/null
 . "${here}"/myip.sh
 
 myip=$(myip) || exit $?

--- a/multinode-demo/setup.sh
+++ b/multinode-demo/setup.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
+here=$(dirname $0)
+. "${here}"/myip.sh
 
-TOKENS=${1:-1000000000}
+myip=$(myip) || exit $?
 
-cargo run --release --bin solana-mint-demo <<<"${TOKENS}" > mint-demo.json
+num_tokens=${1:-1000000000}
+
+cargo run --release --bin solana-mint-demo <<<"${num_tokens}" > mint-demo.json
 cargo run --release --bin solana-genesis-demo < mint-demo.json > genesis.log
 
-IPADDR="$(ifconfig | awk '/inet (addr)?/ {print $2}' | cut -d: -f2 | grep -v '127.0.0.1')"
-
-cargo run --release --bin solana-fullnode-config -- -d > leader-"$IPADDR".json
-cargo run --release --bin solana-fullnode-config -- -b 9000 -d > validator-"$IPADDR".json
+cargo run --release --bin solana-fullnode-config -- -d > leader-"${myip}".json
+cargo run --release --bin solana-fullnode-config -- -b 9000 -d > validator-"${myip}".json

--- a/multinode-demo/validator.sh
+++ b/multinode-demo/validator.sh
@@ -1,22 +1,30 @@
 #!/bin/bash
+here=$(dirname $0)
+. "${here}"/myip.sh
 
-if [[ -z $1 ]]; then
-  printf 'usage: %s [network path to solana repo on leader machine]\n' "$0"
+leader=$1
+
+[[ -z ${leader} ]] && {
+  echo "usage: $0 [network path to solana repo on leader machine]"
   exit 1
-fi
+}
 
-LEADER=$1
+myip=$(myip) || exit $?
 
-set -x
+[[ -f validator-"$myip".json ]] || {
+  echo "I can't find a matching validator config file for \"${myip}\"...
+Please run ${here}/setup.sh first.
+"
+  exit 1
+}
 
-rsync -v "$LEADER"/{mint-demo.json,leader.json,genesis.log,tx-*.log} . || exit $?
+rsync -vz "${leader}"/{mint-demo.json,leader.json,genesis.log,tx-*.log} . || exit $?
 
-[[ $(uname) = Linux ]] && sudo sysctl -w net.core.rmem_max=26214400
+[[ $(uname) = Linux ]] && sudo sysctl -w net.core.rmem_max=26214400 1>/dev/null 2>/dev/null
 
 # if RUST_LOG is unset, default to info
 export RUST_LOG=${RUST_LOG:-solana=info}
 
-IPADDR="$(ifconfig | awk '/inet (addr)?/ {print $2}' | cut -d: -f2 | grep -v '127.0.0.1')"
-
 cargo run --release --bin solana-fullnode -- \
-    -l validator-"$IPADDR".json -v leader.json < genesis.log tx-*.log
+      -l validator-"${myip}".json -v leader.json \
+      < genesis.log tx-*.log

--- a/multinode-demo/validator.sh
+++ b/multinode-demo/validator.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
-here=$(dirname $0)
+here=$(dirname "$0")
+
+# shellcheck source=/dev/null
 . "${here}"/myip.sh
 
 leader=$1


### PR DESCRIPTION
  IPADDR is simple, which is nice, but not exactly what we need for testnet, where NAT'd
  folks need to join in, need to advertize themselves as on the interweb.

  myip() helps, but there's some TODOs: fullnode-config probably needs to
  be told where it lives in the real world (machine interfaces tell us dick),
  or incorporate something like the "ifconfig.co" code in myip.sh