### PR TITLE
snap: Copy over versioned libgf_complete.so

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -11,5 +11,6 @@ fn main() {
     }
     if !env::var("CARGO_FEATURE_ERASURE").is_err() {
         println!("cargo:rustc-link-lib=dylib=Jerasure");
+        println!("cargo:rustc-link-lib=dylib=gf_complete");
     }
 }

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -45,12 +45,6 @@ apps:
     command: solana-client-demo
 
 parts:
-  solana-perf-package:
-    plugin: dump
-    build-attributes: [no-system-libraries]
-    source: https://solana-perf.s3.amazonaws.com/master/x86_64-unknown-linux-gnu/solana-perf.tgz
-    prime:
-      - solana-perf-HEAD.txt
   solana-cuda:
     plugin: rust
     rust-channel: stable
@@ -62,9 +56,7 @@ parts:
       - usr/lib/libgf_complete.so.1
       - usr/lib/libJerasure.so.2
     override-build: |
-      cp -f $SNAPCRAFT_STAGE/libcuda_verify_ed25519.a .
-      cp -f $SNAPCRAFT_STAGE/libJerasure.so .
-      cp -f $SNAPCRAFT_STAGE/libgf_complete.so .
+      ./fetch-perf-libs.sh
       snapcraftctl build
       mv $SNAPCRAFT_PART_INSTALL/bin/solana-fullnode $SNAPCRAFT_PART_INSTALL
       rm -rf $SNAPCRAFT_PART_INSTALL/bin/*
@@ -72,8 +64,6 @@ parts:
       mkdir -p $SNAPCRAFT_PART_INSTALL/usr/lib/
       cp -f libJerasure.so $SNAPCRAFT_PART_INSTALL/usr/lib/libJerasure.so.2
       cp -f libgf_complete.so $SNAPCRAFT_PART_INSTALL/usr/lib/libgf_complete.so.1
-    after:
-      - solana-perf-package
   solana:
     plugin: rust
     rust-channel: stable


### PR DESCRIPTION
Resolves `ci/publish-snap.sh` build failure on cloud CI machines (ie, machines that don't have libgf_complete.so installed globally)