### PR TITLE
Assert recycler is given last reference to data

### DIFF
--- a/src/ledger.rs
+++ b/src/ledger.rs
@@ -8,8 +8,8 @@ use packet::{self, SharedBlob, BLOB_DATA_SIZE, BLOB_SIZE};
 use rayon::prelude::*;
 use std::collections::VecDeque;
 use std::io::Cursor;
-use transaction::Transaction;
 use std::sync::Arc;
+use transaction::Transaction;
 
 // a Block is a slice of Entries
 

--- a/src/ncp.rs
+++ b/src/ncp.rs
@@ -64,10 +64,7 @@ mod tests {
     use std::sync::{Arc, RwLock};
 
     #[test]
-    #[ignore]
     // test that stage will exit when flag is set
-    // TODO: Troubleshoot Docker-based coverage build and re-enabled
-    // this test. It is probably failing due to too many threads.
     fn test_exit() {
         let exit = Arc::new(AtomicBool::new(false));
         let tn = TestNode::new();

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -166,6 +166,7 @@ impl<T: Default> Recycler<T> {
             .unwrap_or_else(|| Arc::new(RwLock::new(Default::default())))
     }
     pub fn recycle(&self, msgs: Arc<RwLock<T>>) {
+        assert_eq!(Arc::strong_count(&msgs), 1); // Ensure this function holds that last reference.
         let mut gc = self.gc.lock().expect("recycler lock in pub fn recycle");
         gc.push(msgs);
     }

--- a/src/streamer.rs
+++ b/src/streamer.rs
@@ -660,9 +660,8 @@ mod bench {
             let timer = Duration::new(1, 0);
             match r.recv_timeout(timer) {
                 Ok(msgs) => {
-                    let msgs_ = msgs.clone();
                     *rvs.lock().unwrap() += msgs.read().unwrap().packets.len();
-                    recycler.recycle(msgs_);
+                    recycler.recycle(msgs);
                 }
                 _ => (),
             }

--- a/src/streamer.rs
+++ b/src/streamer.rs
@@ -331,7 +331,12 @@ fn recv_window(
                         let block_start = *consumed - (*consumed % erasure::NUM_CODED);
                         let coding_end = block_start + erasure::NUM_CODED;
                         // We've received all this block's data blobs, go and null out the window now
-                        for j in block_start..coding_end {
+                        for j in block_start..*consumed {
+                            if let Some(b) = mem::replace(&mut window[j % WINDOW_SIZE], None) {
+                                recycler.recycle(b);
+                            }
+                        }
+                        for j in *consumed..coding_end {
                             window[j % WINDOW_SIZE] = None;
                         }
 

--- a/src/tvu.rs
+++ b/src/tvu.rs
@@ -230,19 +230,19 @@ pub mod tests {
 
             for entry in vec![entry0, entry1] {
                 let b = resp_recycler.allocate();
-                let b_ = b.clone();
-                let mut w = b.write().unwrap();
-                w.set_index(blob_id).unwrap();
-                blob_id += 1;
-                w.set_id(leader_id).unwrap();
+                {
+                    let mut w = b.write().unwrap();
+                    w.set_index(blob_id).unwrap();
+                    blob_id += 1;
+                    w.set_id(leader_id).unwrap();
 
-                let serialized_entry = serialize(&entry).unwrap();
+                    let serialized_entry = serialize(&entry).unwrap();
 
-                w.data_mut()[..serialized_entry.len()].copy_from_slice(&serialized_entry);
-                w.set_size(serialized_entry.len());
-                w.meta.set_addr(&replicate_addr);
-                drop(w);
-                msgs.push_back(b_);
+                    w.data_mut()[..serialized_entry.len()].copy_from_slice(&serialized_entry);
+                    w.set_size(serialized_entry.len());
+                    w.meta.set_addr(&replicate_addr);
+                }
+                msgs.push_back(b);
             }
         }
 


### PR DESCRIPTION
This patch likely fixes the sporadic failures in the following tests:

```
test server::tests::validator_exit ... FAILED
test streamer::test::streamer_send_test ... FAILED
test thin_client::tests::test_bad_sig ... FAILED
test drone::tests::test_send_airdrop ... FAILED
test thin_client::tests::test_thin_client ... FAILED
```