### PR TITLE
multinode-demo: Automatically add rsync:// prefix to URLs that need it

### DIFF
--- a/multinode-demo/client.sh
+++ b/multinode-demo/client.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# usage: $0 <network path to solana repo on leader machine> <number of nodes in the network>"
+# usage: $0 <rsync network path to solana repo on leader machine> <number of nodes in the network>"
 #
 
 here=$(dirname "$0")
@@ -11,10 +11,12 @@ SOLANA_CONFIG_DIR=config-client-demo
 leader=${1:-${here}/..}  # Default to local solana repo
 count=${2:-1}
 
+rsync_leader_url=$(rsync_url "$leader")
+
 set -ex
 mkdir -p $SOLANA_CONFIG_DIR
-rsync -vz "$leader"/config/leader.json $SOLANA_CONFIG_DIR/
-rsync -vz "$leader"/config/mint-demo.json $SOLANA_CONFIG_DIR/
+rsync -vPz "$rsync_leader_url"/config/leader.json $SOLANA_CONFIG_DIR/
+rsync -vPz "$rsync_leader_url"/config/mint-demo.json $SOLANA_CONFIG_DIR/
 
 # shellcheck disable=SC2086 # $solana_client_demo should not be quoted
 exec $solana_client_demo \

--- a/multinode-demo/common.sh
+++ b/multinode-demo/common.sh
@@ -47,3 +47,22 @@ export RUST_BACKTRACE=1
 [[ $(uname) = Linux ]] && (set -x; sudo sysctl -w net.core.rmem_max=26214400 1>/dev/null 2>/dev/null)
 
 SOLANA_CONFIG_DIR=${SNAP_DATA:-$PWD}/config
+
+rsync_url() { # adds the 'rsync://` prefix to URLs that need it
+  local url="$1"
+
+  if [[ "$url" =~ ^.*:.*$ ]]; then
+    # assume remote-shell transport when colon is present, use $url unmodified
+    echo "$url"
+    return
+  fi
+
+  if [[ -d "$url" ]]; then
+    # assume local directory if $url is a valid directory, use $url unmodified
+    echo "$url"
+    return
+  fi
+
+  # Default to rsync:// URL
+  echo "rsync://$url"
+}

--- a/multinode-demo/drone.sh
+++ b/multinode-demo/drone.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# usage: $0 <network path to solana repo on leader machine>
+# usage: $0 <rsync network path to solana repo on leader machine>
 #
 
 here=$(dirname "$0")
@@ -19,15 +19,16 @@ if [[ -d "$SNAP" ]]; then
     # Assume drone is running on the same node as the leader by default
     leader_address="localhost"
   fi
-  leader=rsync://"$leader_address"
+  leader="$leader_address"
 else
   leader=${1:-${here}/..}  # Default to local solana repo
 fi
 
+rsync_leader_url=$(rsync_url "$leader")
 set -ex
 mkdir -p $SOLANA_CONFIG_DIR
-rsync -vz "$leader"/config/leader.json $SOLANA_CONFIG_DIR/
-rsync -vz "$leader"/config/mint-demo.json $SOLANA_CONFIG_DIR/
+rsync -vPz "$rsync_leader_url"/config/leader.json $SOLANA_CONFIG_DIR/
+rsync -vPz "$rsync_leader_url"/config/mint-demo.json $SOLANA_CONFIG_DIR/
 
 # shellcheck disable=SC2086 # $solana_drone should not be quoted
 exec $solana_drone \


### PR DESCRIPTION
Thinks like this now work, which is much more ergonomic:
```
$ ./multinode-demo/validator.sh testnet.solana.com
$ ./multinode-demo/client-demo.sh testnet.solana.com
```