### PR TITLE
Permit fullnodes to advertise a different address than what they bind to

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ Runtime configuration files for the daemon can be found in
 
 #### Leader daemon
 ```bash
-$ sudo snap set solana mode=leader
+$ sudo snap set solana mode=leader public-ip=$(curl -s http://ifconfig.co)
 ```
 
 If CUDA is available:
@@ -189,19 +189,21 @@ read only = true
 ```
 3. Run `sudo systemctl enable rsync; sudo systemctl start rsync`
 4. Test by running `rsync -Pzravv rsync://<ip-address-of-leader>/config
-solana-config` from another machine.  If the leader is running on a cloud
+solana-config` from another machine.  **If the leader is running on a cloud
 provider it may be necessary to configure the Firewall rules to permit ingress
-to port tcp:873, tcp:9900 and the port range udp:8000-udp:10000
+to port tcp:873, tcp:9900 and the port range udp:8000-udp:10000**
 
 
 To run both the Leader and Drone:
 ```bash
-$ sudo snap set solana mode=leader+drone
+$ sudo snap set solana mode=leader+drone public-ip=$(curl -s http://ifconfig.co)
+
 ```
 
 #### Validator daemon
 ```bash
-$ sudo snap set solana mode=validator
+$ sudo snap set solana mode=validator public-ip=$(curl -s http://ifconfig.co)
+
 ```
 If CUDA is available:
 ```bash

--- a/multinode-demo/setup.sh
+++ b/multinode-demo/setup.sh
@@ -1,10 +1,53 @@
 #!/bin/bash
 
-num_tokens=${1:-1000000000}
+num_tokens=1000000000
+public_ip=
 
 here=$(dirname "$0")
 # shellcheck source=multinode-demo/common.sh
 source "$here"/common.sh
+
+usage () {
+  cat <<EOF
+usage: $0 [-n num_tokens] [-P] [-p public_ip_address]
+
+Creates a fullnode configuration
+
+ -n num_tokens         - Number of tokens to create
+ -p public_ip_address  - Public IP address to advertise
+                         (default uses the system IP address, which may be
+                          on a private network)
+ -P                    - Autodetect the public IP address of the machine
+EOF
+}
+
+while getopts "h?n:p:P" opt; do
+  case $opt in
+  h|\?)
+    usage
+    exit 0
+    ;;
+  p)
+    public_ip="$OPTARG"
+    ;;
+  n)
+    num_tokens="$OPTARG"
+    ;;
+  P)
+    public_ip="$(curl -s ifconfig.co)"
+    echo "Public IP autodetected as $public_ip"
+    ;;
+  esac
+done
+
+
+if [[ -n "$public_ip" ]]; then
+  leader_address_args=(-b "$public_ip":8000)
+  validator_address_args=(-b "$public_ip":9000)
+else
+  leader_address_args=(-d)
+  validator_address_args=(-d -b 9000)
+fi
 
 set -e
 
@@ -19,9 +62,9 @@ echo "Creating $SOLANA_CONFIG_DIR/genesis.log"
 $solana_genesis < "$SOLANA_CONFIG_DIR"/mint.json > "$SOLANA_CONFIG_DIR"/genesis.log
 
 echo "Creating $SOLANA_CONFIG_DIR/leader.json"
-$solana_fullnode_config -d > "$SOLANA_CONFIG_DIR"/leader.json
+$solana_fullnode_config "${leader_address_args[@]}" > "$SOLANA_CONFIG_DIR"/leader.json
 
 echo "Creating $SOLANA_CONFIG_DIR/validator.json"
-$solana_fullnode_config -d -b 9000 > "$SOLANA_CONFIG_DIR"/validator.json
+$solana_fullnode_config "${validator_address_args[@]}" > "$SOLANA_CONFIG_DIR"/validator.json
 
 ls -lh "$SOLANA_CONFIG_DIR/"

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -10,7 +10,8 @@ if [[ -z "$mode" ]]; then
   exit 0
 fi
 
-$SNAP/bin/setup.sh "$(snapctl get num-tokens)"
+public_ip="$(snapctl get public-ip)"
+$SNAP/bin/setup.sh -n "$(snapctl get num-tokens)" -p ${public_ip:+-p $public_ip}
 
 case $mode in
 leader+drone)

--- a/src/thin_client.rs
+++ b/src/thin_client.rs
@@ -150,11 +150,16 @@ impl ThinClient {
                 .send_to(&data, &self.requests_addr)
                 .expect("buffer error in pub fn get_last_id");
 
-            if let Ok(resp) = self.recv_response() {
-                if let &Response::LastId { .. } = &resp {
-                    done = true;
+            match self.recv_response() {
+                Ok(resp) => {
+                    if let &Response::LastId { .. } = &resp {
+                        done = true;
+                    }
+                    self.process_response(resp);
                 }
-                self.process_response(resp);
+                Err(e) => {
+                    debug!("thin_client get_last_id error: {}", e);
+                }
             }
         }
         self.last_id.expect("some last_id")


### PR DESCRIPTION
This permits GCP-based nodes to talk to each other over public IP addresses (provided firewall ingress rules are setup correctly for the nodes).

The leader/validator need to advertise their public IP so they can be found, but cannot bind to their public IP as they only see their private IP.

The issue of NAT traversal for client nodes is not addressed here.