### PR TITLE
Reuse entry_writer from solana-genesis

### DIFF
--- a/src/bin/genesis.rs
+++ b/src/bin/genesis.rs
@@ -6,31 +6,27 @@ extern crate solana;
 
 use atty::{is, Stream};
 use solana::mint::Mint;
-use std::io::{stdin, Read};
+use std::error;
+use std::io::{stdin, stdout, Read, Write};
 use std::process::exit;
 
-fn main() {
+fn main() -> Result<(), Box<error::Error>> {
     if is(Stream::Stdin) {
         eprintln!("nothing found on stdin, expected a json file");
         exit(1);
     }
 
     let mut buffer = String::new();
-    let num_bytes = stdin().read_to_string(&mut buffer).unwrap();
+    let num_bytes = stdin().read_to_string(&mut buffer)?;
     if num_bytes == 0 {
         eprintln!("empty file on stdin, expected a json file");
         exit(1);
     }
 
-    let mint: Mint = serde_json::from_str(&buffer).unwrap_or_else(|e| {
-        eprintln!("failed to parse json: {}", e);
-        exit(1);
-    });
+    let mint: Mint = serde_json::from_str(&buffer)?;
+    let mut writer = stdout();
     for x in mint.create_entries() {
-        let serialized = serde_json::to_string(&x).unwrap_or_else(|e| {
-            eprintln!("failed to serialize: {}", e);
-            exit(1);
-        });
-        println!("{}", serialized);
+        writeln!(writer, "{}", serde_json::to_string(&x)?)?;
     }
+    Ok(())
 }

--- a/src/bin/genesis.rs
+++ b/src/bin/genesis.rs
@@ -5,10 +5,12 @@ extern crate serde_json;
 extern crate solana;
 
 use atty::{is, Stream};
+use solana::entry_writer::EntryWriter;
 use solana::mint::Mint;
 use std::error;
-use std::io::{stdin, stdout, Read, Write};
+use std::io::{stdin, stdout, Read};
 use std::process::exit;
+use std::sync::Mutex;
 
 fn main() -> Result<(), Box<error::Error>> {
     if is(Stream::Stdin) {
@@ -24,9 +26,7 @@ fn main() -> Result<(), Box<error::Error>> {
     }
 
     let mint: Mint = serde_json::from_str(&buffer)?;
-    let mut writer = stdout();
-    for x in mint.create_entries() {
-        writeln!(writer, "{}", serde_json::to_string(&x)?)?;
-    }
+    let writer = Mutex::new(stdout());
+    EntryWriter::write_entries(&writer, &mint.create_entries())?;
     Ok(())
 }

--- a/src/entry_writer.rs
+++ b/src/entry_writer.rs
@@ -25,15 +25,22 @@ impl<'a> EntryWriter<'a> {
         EntryWriter { bank }
     }
 
-    fn write_entry<W: Write>(&self, writer: &Mutex<W>, entry: &Entry) -> io::Result<()> {
-        trace!("write_entry entry");
+    fn write_and_register_entry<W: Write>(
+        &self,
+        writer: &Mutex<W>,
+        entry: &Entry,
+    ) -> io::Result<()> {
+        trace!("write_and_register_entry entry");
         if !entry.has_more {
             self.bank.register_entry_id(&entry.id);
         }
         writeln!(
-            writer.lock().expect("'writer' lock in fn fn write_entry"),
+            writer
+                .lock()
+                .expect("'writer' lock in fn fn write_and_register_entry"),
             "{}",
-            serde_json::to_string(&entry).expect("'entry' to_strong in fn write_entry")
+            serde_json::to_string(&entry)
+                .expect("'entry' to_strong in fn write_and_register_entry")
         )
     }
 
@@ -45,10 +52,10 @@ impl<'a> EntryWriter<'a> {
         //TODO implement a serialize for channel that does this without allocations
         let mut l = vec![];
         let entry = entry_receiver.recv_timeout(Duration::new(1, 0))?;
-        self.write_entry(writer, &entry)?;
+        self.write_and_register_entry(writer, &entry)?;
         l.push(entry);
         while let Ok(entry) = entry_receiver.try_recv() {
-            self.write_entry(writer, &entry)?;
+            self.write_and_register_entry(writer, &entry)?;
             l.push(entry);
         }
         Ok(l)
@@ -110,14 +117,18 @@ mod tests {
         assert!(entries[0].has_more);
         assert!(!entries[1].has_more);
 
-        // Verify that write_entry doesn't register the first entries after a split.
+        // Verify that write_and_register_entry doesn't register the first entries after a split.
         assert_eq!(bank.last_id(), mint.last_id());
         let writer = Mutex::new(sink());
-        entry_writer.write_entry(&writer, &entries[0]).unwrap();
+        entry_writer
+            .write_and_register_entry(&writer, &entries[0])
+            .unwrap();
         assert_eq!(bank.last_id(), mint.last_id());
 
-        // Verify that write_entry registers the final entry after a split.
-        entry_writer.write_entry(&writer, &entries[1]).unwrap();
+        // Verify that write_and_register_entry registers the final entry after a split.
+        entry_writer
+            .write_and_register_entry(&writer, &entries[1])
+            .unwrap();
         assert_eq!(bank.last_id(), entries[1].id);
     }
 }

--- a/src/entry_writer.rs
+++ b/src/entry_writer.rs
@@ -11,7 +11,7 @@ use serde_json;
 use std::collections::VecDeque;
 use std::io::{self, sink, Write};
 use std::sync::mpsc::Receiver;
-use std::sync::{Arc, Mutex};
+use std::sync::Mutex;
 use std::time::Duration;
 use streamer::BlobSender;
 
@@ -94,7 +94,7 @@ impl<'a> EntryWriter<'a> {
     /// continuosly broadcast blobs of entries out
     pub fn drain_entries(&self, entry_receiver: &Receiver<Entry>) -> Result<()> {
         let entries = Self::recv_entries(entry_receiver)?;
-        self.write_and_register_entries(&Arc::new(Mutex::new(sink())), &entries)?;
+        self.write_and_register_entries(&Mutex::new(sink()), &entries)?;
         Ok(())
     }
 }

--- a/src/entry_writer.rs
+++ b/src/entry_writer.rs
@@ -50,15 +50,14 @@ impl<'a> EntryWriter<'a> {
         entry_receiver: &Receiver<Entry>,
     ) -> Result<Vec<Entry>> {
         //TODO implement a serialize for channel that does this without allocations
-        let mut l = vec![];
         let entry = entry_receiver.recv_timeout(Duration::new(1, 0))?;
         self.write_and_register_entry(writer, &entry)?;
-        l.push(entry);
+        let mut entries = vec![entry];
         while let Ok(entry) = entry_receiver.try_recv() {
             self.write_and_register_entry(writer, &entry)?;
-            l.push(entry);
+            entries.push(entry);
         }
-        Ok(l)
+        Ok(entries)
     }
 
     /// Process any Entry items that have been published by the Historian.


### PR DESCRIPTION
Dumb down solana-genesis so that its functionality can be used in the multinode tests.