### PR TITLE
Vec<Entry> between Record and Write stages

### DIFF
--- a/src/bin/genesis.rs
+++ b/src/bin/genesis.rs
@@ -10,7 +10,6 @@ use solana::mint::Mint;
 use std::error;
 use std::io::{stdin, stdout, Read};
 use std::process::exit;
-use std::sync::Mutex;
 
 fn main() -> Result<(), Box<error::Error>> {
     if is(Stream::Stdin) {
@@ -26,7 +25,7 @@ fn main() -> Result<(), Box<error::Error>> {
     }
 
     let mint: Mint = serde_json::from_str(&buffer)?;
-    let writer = Mutex::new(stdout());
-    EntryWriter::write_entries(&writer, &mint.create_entries())?;
+    let mut writer = stdout();
+    EntryWriter::write_entries(&mut writer, &mint.create_entries())?;
     Ok(())
 }

--- a/src/tpu.rs
+++ b/src/tpu.rs
@@ -34,7 +34,7 @@ use sigverify_stage::SigVerifyStage;
 use std::io::Write;
 use std::net::UdpSocket;
 use std::sync::atomic::AtomicBool;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use std::thread::JoinHandle;
 use std::time::Duration;
 use streamer::BlobReceiver;
@@ -81,7 +81,7 @@ impl Tpu {
             bank.clone(),
             exit.clone(),
             blob_recycler.clone(),
-            Mutex::new(writer),
+            writer,
             record_stage.entry_receiver,
         );
         let mut thread_hdls = vec![

--- a/src/write_stage.rs
+++ b/src/write_stage.rs
@@ -25,7 +25,7 @@ impl WriteStage {
         exit: Arc<AtomicBool>,
         blob_recycler: BlobRecycler,
         writer: Mutex<W>,
-        entry_receiver: Receiver<Entry>,
+        entry_receiver: Receiver<Vec<Entry>>,
     ) -> Self {
         let (blob_sender, blob_receiver) = channel();
         let thread_hdl = Builder::new()
@@ -54,7 +54,7 @@ impl WriteStage {
     pub fn new_drain(
         bank: Arc<Bank>,
         exit: Arc<AtomicBool>,
-        entry_receiver: Receiver<Entry>,
+        entry_receiver: Receiver<Vec<Entry>>,
     ) -> Self {
         let (_blob_sender, blob_receiver) = channel();
         let thread_hdl = Builder::new()

--- a/src/write_stage.rs
+++ b/src/write_stage.rs
@@ -26,14 +26,13 @@ impl WriteStage {
     /// Process any Entry items that have been published by the Historian.
     /// continuosly broadcast blobs of entries out
     pub fn write_and_send_entries<W: Write>(
-        entry_writer: &EntryWriter,
+        entry_writer: &EntryWriter<W>,
         blob_sender: &BlobSender,
         blob_recycler: &BlobRecycler,
-        writer: &Mutex<W>,
         entry_receiver: &Receiver<Vec<Entry>>,
     ) -> Result<()> {
         let entries = entry_receiver.recv_timeout(Duration::new(1, 0))?;
-        entry_writer.write_and_register_entries(writer, &entries)?;
+        entry_writer.write_and_register_entries(&entries)?;
         trace!("New blobs? {}", entries.len());
         let mut blobs = VecDeque::new();
         entries.to_blobs(blob_recycler, &mut blobs);
@@ -56,14 +55,12 @@ impl WriteStage {
         let thread_hdl = Builder::new()
             .name("solana-writer".to_string())
             .spawn(move || {
-                let entry_writer = EntryWriter::new(&bank);
-                let writer = Mutex::new(writer);
+                let entry_writer = EntryWriter::new(&bank, Mutex::new(writer));
                 loop {
                     let _ = Self::write_and_send_entries(
                         &entry_writer,
                         &blob_sender,
                         &blob_recycler,
-                        &writer,
                         &entry_receiver,
                     );
                     if exit.load(Ordering::Relaxed) {

--- a/src/write_stage.rs
+++ b/src/write_stage.rs
@@ -12,7 +12,7 @@ use std::collections::VecDeque;
 use std::io::Write;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::{channel, Receiver};
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use std::thread::{Builder, JoinHandle};
 use std::time::Duration;
 use streamer::{BlobReceiver, BlobSender};
@@ -26,7 +26,7 @@ impl WriteStage {
     /// Process any Entry items that have been published by the Historian.
     /// continuosly broadcast blobs of entries out
     pub fn write_and_send_entries<W: Write>(
-        entry_writer: &EntryWriter<W>,
+        entry_writer: &mut EntryWriter<W>,
         blob_sender: &BlobSender,
         blob_recycler: &BlobRecycler,
         entry_receiver: &Receiver<Vec<Entry>>,
@@ -55,10 +55,10 @@ impl WriteStage {
         let thread_hdl = Builder::new()
             .name("solana-writer".to_string())
             .spawn(move || {
-                let entry_writer = EntryWriter::new(&bank, Mutex::new(writer));
+                let mut entry_writer = EntryWriter::new(&bank, writer);
                 loop {
                     let _ = Self::write_and_send_entries(
-                        &entry_writer,
+                        &mut entry_writer,
                         &blob_sender,
                         &blob_recycler,
                         &entry_receiver,


### PR DESCRIPTION
Now that recording an entry creates a `Vec<Entry>`, this PR updates the channel to `Vec<Entry>` as well. Before this PR, we'd pass each entry individually just to read them right back into a new `Vec<Entry>` on the other side.

This PR also moves channel-related code from EntryWriter to WriteStage - long overdue cleanup.