### PR TITLE
ci: Speed up snap build

### DIFF
--- a/ci/buildkite-snap.yml
+++ b/ci/buildkite-snap.yml
@@ -1,4 +1,4 @@
 steps:
   - command: "ci/snap.sh"
-    timeout_in_minutes: 30
+    timeout_in_minutes: 20
     name: "snap [public]"

--- a/ci/buildkite.yml
+++ b/ci/buildkite.yml
@@ -24,7 +24,7 @@ steps:
     agents:
       - "queue=cuda"
   - command: "ci/pr-snap.sh"
-    timeout_in_minutes: 30
+    timeout_in_minutes: 20
     name: "snap [public]"
   - wait
   - command: "ci/publish-crate.sh"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -59,41 +59,32 @@ apps:
     command: drone.sh
 
 parts:
-  solana-rsync:
+  solana:
     plugin: nil
-    override-build: |
-      # TODO: build rsync from source instead of sneaking it in from the host
-      # system...
-      set -x
-      mkdir -p $SNAPCRAFT_PART_INSTALL/bin
-      cp -av /usr/bin/rsync $SNAPCRAFT_PART_INSTALL/bin/
-
-  solana-scripts:
-    plugin: nil
-    override-build: |
-      set -x
-      mkdir -p $SNAPCRAFT_PART_INSTALL/bin
-      cp -av multinode-demo/* $SNAPCRAFT_PART_INSTALL/bin/
-
-  solana-cuda:
-    plugin: rust
-    rust-channel: stable
-    rust-features:
-      - erasure
-      - cuda
     prime:
-      - bin/solana-fullnode-cuda
+      - bin
       - usr/lib/libgf_complete.so.1
       - usr/lib/libJerasure.so.2
     override-build: |
+      # Build/install solana-fullnode-cuda
       ./fetch-perf-libs.sh
-      snapcraftctl build
+      cargo install --features=cuda,erasure --root $SNAPCRAFT_PART_INSTALL --bin solana-fullnode
       mv $SNAPCRAFT_PART_INSTALL/bin/solana-fullnode $SNAPCRAFT_PART_INSTALL
       rm -rf $SNAPCRAFT_PART_INSTALL/bin/*
       mv $SNAPCRAFT_PART_INSTALL/solana-fullnode $SNAPCRAFT_PART_INSTALL/bin/solana-fullnode-cuda
       mkdir -p $SNAPCRAFT_PART_INSTALL/usr/lib/
       cp -f libJerasure.so $SNAPCRAFT_PART_INSTALL/usr/lib/libJerasure.so.2
       cp -f libgf_complete.so $SNAPCRAFT_PART_INSTALL/usr/lib/libgf_complete.so.1
-  solana:
-    plugin: rust
-    rust-channel: stable
+
+      # Build/install all other programs
+      cargo install --root $SNAPCRAFT_PART_INSTALL --bins
+
+      # Install multinode scripts
+      mkdir -p $SNAPCRAFT_PART_INSTALL/bin
+      cp -av multinode-demo/* $SNAPCRAFT_PART_INSTALL/bin/
+
+      # TODO: build rsync from source instead of sneaking it in from the host
+      # system...
+      set -x
+      mkdir -p $SNAPCRAFT_PART_INSTALL/bin
+      cp -av /usr/bin/rsync $SNAPCRAFT_PART_INSTALL/bin/


### PR DESCRIPTION
1. Use pre-installed host rust toolchain
2. Build reference/performance fullnode in same part to avoid rebuilding libraries
3. Merge scripts into same part