### PR TITLE
Initialize windows with last up-to-WINDOW_SIZE blobs

### DIFF
--- a/src/drone.rs
+++ b/src/drone.rs
@@ -273,6 +273,7 @@ mod tests {
         let server = FullNode::new_leader(
             bank,
             0,
+            None,
             Some(Duration::from_millis(30)),
             leader,
             exit.clone(),

--- a/src/thin_client.rs
+++ b/src/thin_client.rs
@@ -290,6 +290,7 @@ mod tests {
         let server = FullNode::new_leader(
             bank,
             0,
+            None,
             Some(Duration::from_millis(30)),
             leader,
             exit.clone(),
@@ -329,6 +330,7 @@ mod tests {
         let server = FullNode::new_leader(
             bank,
             0,
+            None,
             Some(Duration::from_millis(30)),
             leader,
             exit.clone(),
@@ -380,6 +382,7 @@ mod tests {
         let server = FullNode::new_leader(
             bank,
             0,
+            None,
             Some(Duration::from_millis(30)),
             leader,
             exit.clone(),

--- a/tests/multinode.rs
+++ b/tests/multinode.rs
@@ -314,6 +314,9 @@ fn restart_leader(
 
 #[test]
 fn test_leader_restart_validator_start_from_old_ledger() {
+    // this test verifies that a freshly started leader makes his ledger available
+    //    in the repair window to validators that are started with an older
+    //    ledger (currently up to WINDOW_SIZE entries)
     logger::setup();
 
     let (alice, ledger_path) = genesis(100_000);
@@ -330,7 +333,7 @@ fn test_leader_restart_validator_start_from_old_ledger() {
     let mut stale_ledger_path = ledger_path.clone();
     stale_ledger_path.insert_str(ledger_path.rfind("/").unwrap() + 1, "stale_");
 
-    std::fs::copy(ledger_path.clone(), stale_ledger_path.clone())
+    std::fs::copy(&ledger_path, &stale_ledger_path)
         .expect(format!("copy {} to {}", &ledger_path, &stale_ledger_path,).as_str());
 
     // restart the leader
@@ -366,7 +369,7 @@ fn test_leader_restart_validator_start_from_old_ledger() {
 
     let mut client = mk_client(&validator_data);
     let getbal = retry_get_balance(&mut client, &bob_pubkey, Some(leader_balance));
-    assert!(getbal == Some(leader_balance));
+    assert_eq!(getbal, Some(leader_balance));
 
     exit.store(true, Ordering::Relaxed);
     leader_fullnode.join().unwrap();

--- a/tests/multinode.rs
+++ b/tests/multinode.rs
@@ -306,6 +306,7 @@ fn test_multi_node_dynamic_network() {
         Some(OutFile::Path(ledger_path.clone())),
         exit.clone(),
     );
+    info!("{:x} LEADER", leader_data.debug_id());
     let threads = server.thread_hdls();
     let leader_balance =
         send_tx_and_retry_get_balance(&leader_data, &alice, &bob_pubkey, Some(500)).unwrap();
@@ -328,6 +329,7 @@ fn test_multi_node_dynamic_network() {
                 Some(OutFile::Path(ledger_path.clone())),
                 exit.clone(),
             );
+            info!("{:x} VALIDATOR", rd.debug_id());
             (rd, exit, val)
         })
         .collect();


### PR DESCRIPTION
the goal of this PR is to have full windows on all nodes at all times, which should reduce "failed RequestWindowIndex" in replication during test_multi_node_dynamic_network().