### PR TITLE
Reuse request UDP port for responses in fullnode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,4 @@ Cargo.lock
 /config-private/
 /config-drone/
 /config-validator/
-/config-client-demo/
+/config-client/

--- a/multinode-demo/client.sh
+++ b/multinode-demo/client.sh
@@ -6,7 +6,7 @@
 here=$(dirname "$0")
 # shellcheck source=multinode-demo/common.sh
 source "$here"/common.sh
-SOLANA_CONFIG_DIR=config-client-demo
+SOLANA_CONFIG_DIR=config-client
 
 leader=${1:-${here}/..}  # Default to local solana repo
 count=${2:-1}

--- a/multinode-demo/test/wallet-sanity.sh
+++ b/multinode-demo/test/wallet-sanity.sh
@@ -1,0 +1,35 @@
+#!/bin/bash -e
+#
+# Wallet sanity test
+#
+
+here=$(dirname "$0")
+cd "$here"
+
+wallet="../wallet.sh $1"
+
+# Tokens transferred to this address are lost forever...
+garbage_address=vS3ngn1TfQmpsW1Z4NkLuqNAQFF3dYQw8UZ6TCx9bmq
+
+check_balance_output() {
+  declare expected_output="$1"
+  exec 42>&1
+  output=$($wallet balance | tee >(cat - >&42))
+  if [[ ! "$output" =~ $expected_output ]]; then
+    echo "Balance is incorrect.  Expected: $expected_output"
+    exit 1
+  fi
+}
+
+# Ensure a fresh client configuration every time
+rm -rf config-client
+
+$wallet address
+check_balance_output "No account found! Request an airdrop to get started"
+$wallet airdrop --tokens 100
+check_balance_output "Your balance is: 100"
+$wallet pay --to $garbage_address --tokens 100
+check_balance_output "Your balance is: 0"
+
+echo PASS
+exit 0

--- a/multinode-demo/wallet.sh
+++ b/multinode-demo/wallet.sh
@@ -6,7 +6,7 @@
 here=$(dirname "$0")
 # shellcheck source=multinode-demo/common.sh
 source "$here"/common.sh
-SOLANA_CONFIG_DIR=config-client-demo
+SOLANA_CONFIG_DIR=config-client
 
 leader=${1:-${here}/..}  # Default to local solana repo
 shift

--- a/src/bin/client-demo.rs
+++ b/src/bin/client-demo.rs
@@ -301,20 +301,18 @@ fn main() {
 }
 
 fn mk_client(r: &ReplicatedData) -> ThinClient {
-    let transactions_socket_pair = udp_public_bind("transactions");
-    let requests_socket_pair = udp_public_bind("requests");
+    let requests_socket = UdpSocket::bind("0.0.0.0:0").unwrap();
+    let transactions_socket = UdpSocket::bind("0.0.0.0:0").unwrap();
 
-    requests_socket_pair
-        .receiver
+    requests_socket
         .set_read_timeout(Some(Duration::new(1, 0)))
         .unwrap();
 
     ThinClient::new(
         r.requests_addr,
-        requests_socket_pair.sender,
-        requests_socket_pair.receiver,
+        requests_socket,
         r.transactions_addr,
-        transactions_socket_pair.sender,
+        transactions_socket,
     )
 }
 

--- a/src/bin/drone.rs
+++ b/src/bin/drone.rs
@@ -11,7 +11,7 @@ extern crate tokio_io;
 use atty::{is, Stream as atty_stream};
 use bincode::deserialize;
 use getopts::Options;
-use solana::crdt::{get_ip_addr, ReplicatedData};
+use solana::crdt::ReplicatedData;
 use solana::drone::{Drone, DroneRequest};
 use solana::mint::Mint;
 use std::env;
@@ -103,8 +103,7 @@ fn main() {
 
     let mint_keypair = mint.keypair();
 
-    let mut drone_addr: SocketAddr = "0.0.0.0:9900".parse().unwrap();
-    drone_addr.set_ip(get_ip_addr().unwrap());
+    let drone_addr: SocketAddr = "0.0.0.0:9900".parse().unwrap();
 
     let drone = Arc::new(Mutex::new(Drone::new(
         mint_keypair,

--- a/src/bin/fullnode.rs
+++ b/src/bin/fullnode.rs
@@ -156,16 +156,22 @@ fn main() {
             Box::new(stdout())
         };
 
+        let requests_socket = UdpSocket::bind(local_requests_addr).unwrap();
+        // Responses are sent from the same Udp port as requests are received
+        // from, in hopes that a NAT sitting in the middle will route the
+        // response Udp packet correctly back to the requester.
+        let respond_socket = requests_socket.try_clone().unwrap();
+
         let server = Server::new_leader(
             bank,
             entry_height,
             //Some(Duration::from_millis(1000)),
             None,
             repl_data.clone(),
-            UdpSocket::bind(local_requests_addr).unwrap(),
+            requests_socket,
             UdpSocket::bind(local_transactions_addr).unwrap(),
             UdpSocket::bind("0.0.0.0:0").unwrap(),
-            UdpSocket::bind("0.0.0.0:0").unwrap(),
+            respond_socket,
             UdpSocket::bind(local_gossip_addr).unwrap(),
             exit.clone(),
             outfile,

--- a/src/drone.rs
+++ b/src/drone.rs
@@ -99,7 +99,6 @@ impl Drone {
 
         let mut client = ThinClient::new(
             self.requests_addr,
-            requests_socket.try_clone().unwrap(),
             requests_socket,
             self.transactions_addr,
             transactions_socket,
@@ -293,7 +292,6 @@ mod tests {
 
         let mut client = ThinClient::new(
             leader.data.requests_addr,
-            requests_socket.try_clone().unwrap(),
             requests_socket,
             leader.data.transactions_addr,
             transactions_socket,

--- a/tests/multinode.rs
+++ b/tests/multinode.rs
@@ -246,7 +246,6 @@ fn mk_client(leader: &ReplicatedData) -> ThinClient {
 
     ThinClient::new(
         leader.requests_addr,
-        requests_socket.try_clone().unwrap(),
         requests_socket,
         leader.transactions_addr,
         transactions_socket,


### PR DESCRIPTION
This allows the UPnP port binding stuff to be mostly backed out.  Wallet now works from behind my local NAT to a public leader without `BROKEN_NAT=1`