### PR TITLE
Return output receivers from each stage

### DIFF
--- a/src/banking_stage.rs
+++ b/src/banking_stage.rs
@@ -23,9 +23,6 @@ use transaction::Transaction;
 pub struct BankingStage {
     /// Handle to the stage's thread.
     pub thread_hdl: JoinHandle<()>,
-
-    /// Output receiver for the following stage.
-    pub signal_receiver: Receiver<Signal>,
 }
 
 impl BankingStage {
@@ -38,7 +35,7 @@ impl BankingStage {
         exit: Arc<AtomicBool>,
         verified_receiver: Receiver<Vec<(SharedPackets, Vec<u8>)>>,
         packet_recycler: PacketRecycler,
-    ) -> Self {
+    ) -> (Self, Receiver<Signal>) {
         let (signal_sender, signal_receiver) = channel();
         let thread_hdl = Builder::new()
             .name("solana-banking-stage".to_string())
@@ -56,10 +53,7 @@ impl BankingStage {
                 }
             })
             .unwrap();
-        BankingStage {
-            thread_hdl,
-            signal_receiver,
-        }
+        (BankingStage { thread_hdl }, signal_receiver)
     }
 
     /// Convert the transactions from a blob of binary data to a vector of transactions and

--- a/src/blob_fetch_stage.rs
+++ b/src/blob_fetch_stage.rs
@@ -9,19 +9,22 @@ use std::thread::JoinHandle;
 use streamer::{self, BlobReceiver};
 
 pub struct BlobFetchStage {
-    pub blob_receiver: BlobReceiver,
     pub thread_hdls: Vec<JoinHandle<()>>,
 }
 
 impl BlobFetchStage {
-    pub fn new(socket: UdpSocket, exit: Arc<AtomicBool>, blob_recycler: BlobRecycler) -> Self {
+    pub fn new(
+        socket: UdpSocket,
+        exit: Arc<AtomicBool>,
+        blob_recycler: BlobRecycler,
+    ) -> (Self, BlobReceiver) {
         Self::new_multi_socket(vec![socket], exit, blob_recycler)
     }
     pub fn new_multi_socket(
         sockets: Vec<UdpSocket>,
         exit: Arc<AtomicBool>,
         blob_recycler: BlobRecycler,
-    ) -> Self {
+    ) -> (Self, BlobReceiver) {
         let (blob_sender, blob_receiver) = channel();
         let thread_hdls: Vec<_> = sockets
             .into_iter()
@@ -35,9 +38,6 @@ impl BlobFetchStage {
             })
             .collect();
 
-        BlobFetchStage {
-            blob_receiver,
-            thread_hdls,
-        }
+        (BlobFetchStage { thread_hdls }, blob_receiver)
     }
 }

--- a/src/fetch_stage.rs
+++ b/src/fetch_stage.rs
@@ -9,19 +9,22 @@ use std::thread::JoinHandle;
 use streamer::{self, PacketReceiver};
 
 pub struct FetchStage {
-    pub packet_receiver: PacketReceiver,
     pub thread_hdls: Vec<JoinHandle<()>>,
 }
 
 impl FetchStage {
-    pub fn new(socket: UdpSocket, exit: Arc<AtomicBool>, packet_recycler: PacketRecycler) -> Self {
+    pub fn new(
+        socket: UdpSocket,
+        exit: Arc<AtomicBool>,
+        packet_recycler: PacketRecycler,
+    ) -> (Self, PacketReceiver) {
         Self::new_multi_socket(vec![socket], exit, packet_recycler)
     }
     pub fn new_multi_socket(
         sockets: Vec<UdpSocket>,
         exit: Arc<AtomicBool>,
         packet_recycler: PacketRecycler,
-    ) -> Self {
+    ) -> (Self, PacketReceiver) {
         let (packet_sender, packet_receiver) = channel();
         let thread_hdls: Vec<_> = sockets
             .into_iter()
@@ -35,9 +38,6 @@ impl FetchStage {
             })
             .collect();
 
-        FetchStage {
-            packet_receiver,
-            thread_hdls,
-        }
+        (FetchStage { thread_hdls }, packet_receiver)
     }
 }

--- a/src/request_stage.rs
+++ b/src/request_stage.rs
@@ -17,7 +17,6 @@ use timing;
 
 pub struct RequestStage {
     pub thread_hdl: JoinHandle<()>,
-    pub blob_receiver: BlobReceiver,
     pub request_processor: Arc<RequestProcessor>,
 }
 
@@ -85,7 +84,7 @@ impl RequestStage {
         packet_receiver: Receiver<SharedPackets>,
         packet_recycler: PacketRecycler,
         blob_recycler: BlobRecycler,
-    ) -> Self {
+    ) -> (Self, BlobReceiver) {
         let request_processor = Arc::new(request_processor);
         let request_processor_ = request_processor.clone();
         let (blob_sender, blob_receiver) = channel();
@@ -106,10 +105,12 @@ impl RequestStage {
                 }
             })
             .unwrap();
-        RequestStage {
-            thread_hdl,
+        (
+            RequestStage {
+                thread_hdl,
+                request_processor,
+            },
             blob_receiver,
-            request_processor,
-        }
+        )
     }
 }

--- a/src/rpu.rs
+++ b/src/rpu.rs
@@ -56,7 +56,7 @@ impl Rpu {
 
         let blob_recycler = BlobRecycler::default();
         let request_processor = RequestProcessor::new(bank.clone());
-        let request_stage = RequestStage::new(
+        let (request_stage, blob_receiver) = RequestStage::new(
             request_processor,
             exit.clone(),
             packet_receiver,
@@ -68,7 +68,7 @@ impl Rpu {
             respond_socket,
             exit.clone(),
             blob_recycler.clone(),
-            request_stage.blob_receiver,
+            blob_receiver,
         );
 
         let thread_hdls = vec![t_receiver, t_responder, request_stage.thread_hdl];

--- a/src/server.rs
+++ b/src/server.rs
@@ -63,7 +63,7 @@ impl Server {
         thread_hdls.extend(rpu.thread_hdls);
 
         let blob_recycler = BlobRecycler::default();
-        let tpu = Tpu::new(
+        let (tpu, blob_receiver) = Tpu::new(
             bank.clone(),
             tick_duration,
             transactions_socket,
@@ -92,7 +92,7 @@ impl Server {
             window,
             entry_height,
             blob_recycler.clone(),
-            tpu.blob_receiver,
+            blob_receiver,
         );
         thread_hdls.extend(vec![t_broadcast]);
 

--- a/src/sigverify_stage.rs
+++ b/src/sigverify_stage.rs
@@ -18,18 +18,17 @@ use streamer::{self, PacketReceiver};
 use timing;
 
 pub struct SigVerifyStage {
-    pub verified_receiver: Receiver<Vec<(SharedPackets, Vec<u8>)>>,
     pub thread_hdls: Vec<JoinHandle<()>>,
 }
 
 impl SigVerifyStage {
-    pub fn new(exit: Arc<AtomicBool>, packet_receiver: Receiver<SharedPackets>) -> Self {
+    pub fn new(
+        exit: Arc<AtomicBool>,
+        packet_receiver: Receiver<SharedPackets>,
+    ) -> (Self, Receiver<Vec<(SharedPackets, Vec<u8>)>>) {
         let (verified_sender, verified_receiver) = channel();
         let thread_hdls = Self::verifier_services(exit, packet_receiver, verified_sender);
-        SigVerifyStage {
-            thread_hdls,
-            verified_receiver,
-        }
+        (SigVerifyStage { thread_hdls }, verified_receiver)
     }
 
     fn verify_batch(batch: Vec<SharedPackets>) -> Vec<(SharedPackets, Vec<u8>)> {

--- a/src/window_stage.rs
+++ b/src/window_stage.rs
@@ -10,7 +10,6 @@ use std::thread::JoinHandle;
 use streamer::{self, BlobReceiver, Window};
 
 pub struct WindowStage {
-    pub blob_receiver: BlobReceiver,
     pub thread_hdls: Vec<JoinHandle<()>>,
 }
 
@@ -23,7 +22,7 @@ impl WindowStage {
         exit: Arc<AtomicBool>,
         blob_recycler: BlobRecycler,
         fetch_stage_receiver: BlobReceiver,
-    ) -> Self {
+    ) -> (Self, BlobReceiver) {
         let (retransmit_sender, retransmit_receiver) = channel();
 
         let t_retransmit = streamer::retransmitter(
@@ -46,9 +45,6 @@ impl WindowStage {
         );
         let thread_hdls = vec![t_retransmit, t_window];
 
-        WindowStage {
-            blob_receiver,
-            thread_hdls,
-        }
+        (WindowStage { thread_hdls }, blob_receiver)
     }
 }

--- a/src/write_stage.rs
+++ b/src/write_stage.rs
@@ -19,7 +19,6 @@ use streamer::{BlobReceiver, BlobSender};
 
 pub struct WriteStage {
     pub thread_hdl: JoinHandle<()>,
-    pub blob_receiver: BlobReceiver,
 }
 
 impl WriteStage {
@@ -50,7 +49,7 @@ impl WriteStage {
         blob_recycler: BlobRecycler,
         writer: W,
         entry_receiver: Receiver<Vec<Entry>>,
-    ) -> Self {
+    ) -> (Self, BlobReceiver) {
         let (blob_sender, blob_receiver) = channel();
         let thread_hdl = Builder::new()
             .name("solana-writer".to_string())
@@ -71,9 +70,6 @@ impl WriteStage {
             })
             .unwrap();
 
-        WriteStage {
-            thread_hdl,
-            blob_receiver,
-        }
+        (WriteStage { thread_hdl }, blob_receiver)
     }
 }


### PR DESCRIPTION
Reaching into the stages' structs for their receivers is, in hindsight,
more awkward than returning multiple values from constructors. By
returning the receiver, the caller can name the receiver whatever it
wants (as you would with any return value), and doesn't need to
reach into the struct for the field (which is super awkward in
combination with move semantics).