### PR TITLE
Use drone in TPS client demo

### DIFF
--- a/multinode-demo/client.sh
+++ b/multinode-demo/client.sh
@@ -14,10 +14,19 @@ rsync_leader_url=$(rsync_url "$leader")
 
 set -ex
 mkdir -p "$SOLANA_CONFIG_CLIENT_DIR"
-$rsync -vPz "$rsync_leader_url"/config/leader.json "$SOLANA_CONFIG_CLIENT_DIR"/
-$rsync -vPz "$rsync_leader_url"/config-private/mint.json "$SOLANA_CONFIG_CLIENT_DIR"/
+if [[ ! -r "$SOLANA_CONFIG_CLIENT_DIR"/leader.json ]]; then
+  (
+    set -x
+    $rsync -vPz "$rsync_leader_url"/config/leader.json "$SOLANA_CONFIG_CLIENT_DIR"/
+  )
+fi
+
+client_json="$SOLANA_CONFIG_CLIENT_DIR"/client.json
+if [[ ! -r $client_json ]]; then
+  $solana_mint <<<0 > "$client_json"
+fi
 
 # shellcheck disable=SC2086 # $solana_client_demo should not be quoted
 exec $solana_client_demo \
   -n "$count" -l "$SOLANA_CONFIG_CLIENT_DIR"/leader.json \
-  < "$SOLANA_CONFIG_CLIENT_DIR"/mint.json
+  < "$SOLANA_CONFIG_CLIENT_DIR"/client.json

--- a/multinode-demo/client.sh
+++ b/multinode-demo/client.sh
@@ -28,5 +28,4 @@ fi
 
 # shellcheck disable=SC2086 # $solana_client_demo should not be quoted
 exec $solana_client_demo \
-  -n "$count" -l "$SOLANA_CONFIG_CLIENT_DIR"/leader.json \
-  < "$SOLANA_CONFIG_CLIENT_DIR"/client.json
+  -n "$count" -l "$SOLANA_CONFIG_CLIENT_DIR"/leader.json -m "$SOLANA_CONFIG_CLIENT_DIR"/client.json

--- a/src/bin/client-demo.rs
+++ b/src/bin/client-demo.rs
@@ -415,7 +415,6 @@ fn request_airdrop(
     let req = DroneRequest::GetAirdrop {
         airdrop_request_amount: tokens,
         client_public_key: id.pubkey(),
-        tps_demo: true,
     };
     let tx = serialize(&req).expect("serialize drone request");
     stream.write_all(&tx).unwrap();

--- a/src/bin/client-demo.rs
+++ b/src/bin/client-demo.rs
@@ -220,23 +220,6 @@ fn main() {
     let validators = converge(&leader, signal.clone(), num_nodes, &mut c_threads);
     assert_eq!(validators.len(), num_nodes);
 
-    // if is(Stream::Stdin) {
-    //     eprintln!("nothing found on stdin, expected a json file");
-    //     exit(1);
-    // }
-    //
-    // let mut buffer = String::new();
-    // let num_bytes = stdin().read_to_string(&mut buffer).unwrap();
-    // if num_bytes == 0 {
-    //     eprintln!("empty file on stdin, expected a json file");
-    //     exit(1);
-    // }
-    //
-    // println!("Parsing stdin...");
-    // let id: Mint = serde_json::from_str(&buffer).unwrap_or_else(|e| {
-    //     eprintln!("failed to parse json: {}", e);
-    //     exit(1);
-    // });
     let mut client = mk_client(&leader);
 
     let starting_balance = client.poll_get_balance(&id.pubkey()).unwrap();

--- a/src/bin/wallet.rs
+++ b/src/bin/wallet.rs
@@ -321,7 +321,6 @@ fn request_airdrop(
     let req = DroneRequest::GetAirdrop {
         airdrop_request_amount: tokens,
         client_public_key: id.pubkey(),
-        tps_demo: false,
     };
     let tx = serialize(&req).expect("serialize drone request");
     stream.write_all(&tx).unwrap();

--- a/src/bin/wallet.rs
+++ b/src/bin/wallet.rs
@@ -321,6 +321,7 @@ fn request_airdrop(
     let req = DroneRequest::GetAirdrop {
         airdrop_request_amount: tokens,
         client_public_key: id.pubkey(),
+        tps_demo: false,
     };
     let tx = serialize(&req).expect("serialize drone request");
     stream.write_all(&tx).unwrap();

--- a/src/drone.rs
+++ b/src/drone.rs
@@ -278,12 +278,13 @@ mod tests {
             leader_data.transactions_addr,
             leader_data.requests_addr,
             None,
-            Some(5_000_050),
+            Some(150_000),
         );
 
         let bob_req = DroneRequest::GetAirdrop {
             airdrop_request_amount: 50,
             client_public_key: bob_pubkey,
+            tps_demo: false,
         };
         let bob_result = drone.send_airdrop(bob_req).expect("send airdrop test");
         assert!(bob_result > 0);
@@ -291,6 +292,7 @@ mod tests {
         let carlos_req = DroneRequest::GetAirdrop {
             airdrop_request_amount: 5_000_000,
             client_public_key: carlos_pubkey,
+            tps_demo: true,
         };
         let carlos_result = drone.send_airdrop(carlos_req).expect("send airdrop test");
         assert!(carlos_result > 0);


### PR DESCRIPTION
Toward #504 
This needs a WIP tag, but I don't seem to have that power. 

This initial pass doesn't change anything in the way the (TPS) solana-client-demo composes or times transactions; it just uses the drone to airdrop a bunch of tokens to the client account, and seeds a set of recipient keypairs from the client id.

This presents a couple possible issues for the public testnet:
(1) Currently, the spent tokens go to a set of random accounts in the ether.
(2) Because of packet loss, not all tokens are actually spent, leaving a fairly large balance in the client's account.

It would be nice to return at least the unspent tokens to the mint. Solana-drone could be extended to allow clients to request the testnet mint's public key. Is this worthwhile?
As for the TPS transactions, paying to the mint is also appealing, but might require some finagling. It looks like rapid-fire tx between the same 2 accounts for the same amount of tokens cause Duplicate Signature errors.