### PR TITLE
Demote 'sorted leader' log from info to debug

### DIFF
--- a/src/crdt.rs
+++ b/src/crdt.rs
@@ -600,7 +600,7 @@ impl Crdt {
         }
         let mut sorted: Vec<(&PublicKey, usize)> = table.into_iter().collect();
         if sorted.len() > 0 {
-            info!("sorted leaders {:?}", sorted);
+            debug!("sorted leaders {:?}", sorted);
         }
         sorted.sort_by_key(|a| a.1);
         sorted.last().map(|a| *a.0)


### PR DESCRIPTION
This single line practically DOSes the default logging from leader/validator