### PR TITLE
Migrate solana-drone to clap crate for CLI arguments

### DIFF
--- a/multinode-demo/drone.sh
+++ b/multinode-demo/drone.sh
@@ -38,4 +38,4 @@ $rsync -vPz "$rsync_leader_url"/config/leader.json "$SOLANA_CONFIG_DIR"/
 
 # shellcheck disable=SC2086 # $solana_drone should not be quoted
 exec $solana_drone \
-  -l "$SOLANA_CONFIG_DIR"/leader.json < "$SOLANA_CONFIG_PRIVATE_DIR"/mint.json
+  -l "$SOLANA_CONFIG_DIR"/leader.json -m "$SOLANA_CONFIG_PRIVATE_DIR"/mint.json

--- a/src/bin/wallet.rs
+++ b/src/bin/wallet.rs
@@ -3,7 +3,6 @@ extern crate bincode;
 extern crate bs58;
 extern crate clap;
 extern crate env_logger;
-extern crate getopts;
 extern crate serde_json;
 extern crate solana;
 


### PR DESCRIPTION
Toward #543 
Remaining: client-demo (handled in PR #540), fullnode, and fullnode-config