### PR TITLE
Map counters to metrics

### DIFF
--- a/src/counter.rs
+++ b/src/counter.rs
@@ -1,3 +1,5 @@
+use influx_db_client as influxdb;
+use metrics;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 use timing;
@@ -45,6 +47,15 @@ impl Counter {
                 timing::timestamp(),
             );
         }
+        metrics::submit(
+            influxdb::Point::new(&format!("counter_{}", self.name))
+                .add_field("count", influxdb::Value::Integer(events as i64))
+                .add_field(
+                    "duration_ms",
+                    influxdb::Value::Integer(timing::duration_as_ms(&dur) as i64),
+                )
+                .to_owned(),
+        );
     }
 }
 #[cfg(test)]

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -56,6 +56,7 @@ impl InfluxDbMetricsWriter {
 impl MetricsWriter for InfluxDbMetricsWriter {
     fn write(&self, points: Vec<influxdb::Point>) {
         if let Some(ref client) = self.client {
+            info!("submitting {} points", points.len());
             if let Err(err) = client.write_points(
                 influxdb::Points { point: points },
                 Some(influxdb::Precision::Milliseconds),


### PR DESCRIPTION
Simple mapping of counter measurements to influx data points

Note that by default these counters get dumped into the `scratch` database, which is global amongst all users.  If you want isolation there's currently two easy options:
1) Continue to use the `scratch` database but rename the counter to something like `$(whoami)-counter`
2) `export INFLUX_DATABASE=$(whoami)_database` in your shell before running, where `$(whoami)_database` is something that you've already setup in influx.  Might need to set `INFLUX_USERNAME` and `INFLUX_PASSWORD` appropriately as well.