### PR TITLE
Boot exit variables from FullNode constructors

### DIFF
--- a/src/bin/fullnode.rs
+++ b/src/bin/fullnode.rs
@@ -14,8 +14,6 @@ use solana::service::Service;
 use std::fs::File;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::process::exit;
-use std::sync::atomic::AtomicBool;
-use std::sync::Arc;
 //use std::time::Duration;
 
 fn main() -> () {
@@ -68,11 +66,10 @@ fn main() -> () {
         }
     }
     let mut node = TestNode::new_with_bind_addr(repl_data, bind_addr);
-    let exit = Arc::new(AtomicBool::new(false));
     let fullnode = if let Some(t) = matches.value_of("testnet") {
         let testnet_address_string = t.to_string();
         let testnet_addr = testnet_address_string.parse().unwrap();
-        FullNode::new(node, false, InFile::StdIn, Some(testnet_addr), None, exit)
+        FullNode::new(node, false, InFile::StdIn, Some(testnet_addr), None)
     } else {
         node.data.current_leader_id = node.data.id.clone();
 
@@ -81,7 +78,7 @@ fn main() -> () {
         } else {
             OutFile::StdOut
         };
-        FullNode::new(node, true, InFile::StdIn, None, Some(outfile), exit)
+        FullNode::new(node, true, InFile::StdIn, None, Some(outfile))
     };
     fullnode.join().expect("join");
 }

--- a/src/blob_fetch_stage.rs
+++ b/src/blob_fetch_stage.rs
@@ -3,13 +3,14 @@
 use packet::BlobRecycler;
 use service::Service;
 use std::net::UdpSocket;
-use std::sync::atomic::AtomicBool;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::channel;
 use std::sync::Arc;
 use std::thread::{self, JoinHandle};
 use streamer::{self, BlobReceiver};
 
 pub struct BlobFetchStage {
+    exit: Arc<AtomicBool>,
     thread_hdls: Vec<JoinHandle<()>>,
 }
 
@@ -39,7 +40,11 @@ impl BlobFetchStage {
             })
             .collect();
 
-        (BlobFetchStage { thread_hdls }, blob_receiver)
+        (BlobFetchStage { exit, thread_hdls }, blob_receiver)
+    }
+
+    pub fn close(&self) {
+        self.exit.store(true, Ordering::Relaxed);
     }
 }
 

--- a/src/fetch_stage.rs
+++ b/src/fetch_stage.rs
@@ -3,13 +3,14 @@
 use packet::PacketRecycler;
 use service::Service;
 use std::net::UdpSocket;
-use std::sync::atomic::AtomicBool;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::channel;
 use std::sync::Arc;
 use std::thread::{self, JoinHandle};
 use streamer::{self, PacketReceiver};
 
 pub struct FetchStage {
+    exit: Arc<AtomicBool>,
     thread_hdls: Vec<JoinHandle<()>>,
 }
 
@@ -39,7 +40,11 @@ impl FetchStage {
             })
             .collect();
 
-        (FetchStage { thread_hdls }, packet_receiver)
+        (FetchStage { exit, thread_hdls }, packet_receiver)
+    }
+
+    pub fn close(&self) {
+        self.exit.store(true, Ordering::Relaxed);
     }
 }
 

--- a/src/tpu.rs
+++ b/src/tpu.rs
@@ -87,6 +87,11 @@ impl Tpu {
         };
         (tpu, blob_receiver)
     }
+
+    pub fn close(self) -> thread::Result<()> {
+        self.fetch_stage.close();
+        self.join()
+    }
 }
 
 impl Service for Tpu {

--- a/src/tvu.rs
+++ b/src/tvu.rs
@@ -101,6 +101,11 @@ impl Tvu {
             window_stage,
         }
     }
+
+    pub fn close(self) -> thread::Result<()> {
+        self.fetch_stage.close();
+        self.join()
+    }
 }
 
 impl Service for Tvu {
@@ -136,7 +141,7 @@ pub mod tests {
     use signature::{KeyPair, KeyPairUtil};
     use std::collections::VecDeque;
     use std::net::UdpSocket;
-    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::atomic::AtomicBool;
     use std::sync::mpsc::channel;
     use std::sync::{Arc, RwLock};
     use std::time::Duration;
@@ -279,8 +284,7 @@ pub mod tests {
         let bob_balance = bank.get_balance(&bob_keypair.pubkey());
         assert_eq!(bob_balance, starting_balance - alice_ref_balance);
 
-        exit.store(true, Ordering::Relaxed);
-        tvu.join().expect("join");
+        tvu.close().expect("close");
         dr_l.0.join().expect("join");
         dr_2.0.join().expect("join");
         dr_1.0.join().expect("join");


### PR DESCRIPTION
Before this change, the multinode tests would pass the same exit variable to all full nodes and when set, they'd all shut down at once. With this patch, the system is shut down more predictably. One calls the new `close()` function on `FullNode` and then sets its private exit variable that is only watched by the NCP and TPU's FetchStage (or TVU's BlobFetchStage).

Fixes #232