### PR TITLE
Add more counters

### DIFF
--- a/src/banking_stage.rs
+++ b/src/banking_stage.rs
@@ -125,7 +125,7 @@ impl BankingStage {
             reqs_len,
             (reqs_len as f32) / (total_time_s)
         );
-        inc_counter!(COUNTER, count, proc_start);
+        inc_counter!(COUNTER, count);
         Ok(())
     }
 }

--- a/src/counter.rs
+++ b/src/counter.rs
@@ -1,14 +1,14 @@
 use influx_db_client as influxdb;
 use metrics;
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::time::Duration;
 use timing;
+
+const INFLUX_RATE: usize = 100;
 
 pub struct Counter {
     pub name: &'static str,
     /// total accumulated value
     pub counts: AtomicUsize,
-    pub nanos: AtomicUsize,
     pub times: AtomicUsize,
     /// last accumulated value logged
     pub lastlog: AtomicUsize,
@@ -20,7 +20,6 @@ macro_rules! create_counter {
         Counter {
             name: $name,
             counts: AtomicUsize::new(0),
-            nanos: AtomicUsize::new(0),
             times: AtomicUsize::new(0),
             lastlog: AtomicUsize::new(0),
             lograte: $lograte,
@@ -29,37 +28,31 @@ macro_rules! create_counter {
 }
 
 macro_rules! inc_counter {
-    ($name:expr, $count:expr, $start:expr) => {
-        unsafe { $name.inc($count, $start.elapsed()) };
+    ($name:expr, $count:expr) => {
+        unsafe { $name.inc($count) };
     };
 }
 
 impl Counter {
-    pub fn inc(&mut self, events: usize, dur: Duration) {
-        let total = dur.as_secs() * 1_000_000_000 + dur.subsec_nanos() as u64;
+    pub fn inc(&mut self, events: usize) {
         let counts = self.counts.fetch_add(events, Ordering::Relaxed);
-        let nanos = self.nanos.fetch_add(total as usize, Ordering::Relaxed);
         let times = self.times.fetch_add(1, Ordering::Relaxed);
         let lastlog = self.lastlog.load(Ordering::Relaxed);
         if times % self.lograte == 0 && times > 0 {
             info!(
-                "COUNTER:{{\"name\": \"{}\", \"counts\": {}, \"nanos\": {}, \"samples\": {}, \"rate\": {}, \"now\": {}}}",
+                "COUNTER:{{\"name\": \"{}\", \"counts\": {}, \"samples\": {},  \"now\": {}}}",
                 self.name,
                 counts,
-                nanos,
                 times,
-                counts as f64 * 1e9 / nanos as f64,
                 timing::timestamp(),
             );
+        }
+        if times % INFLUX_RATE == 0 && times > 0 {
             metrics::submit(
                 influxdb::Point::new(&format!("counter_{}", self.name))
                     .add_field(
                         "count",
                         influxdb::Value::Integer(counts as i64 - lastlog as i64),
-                    )
-                    .add_field(
-                        "duration_ms",
-                        influxdb::Value::Integer(timing::duration_as_ms(&dur) as i64),
                     )
                     .to_owned(),
             );
@@ -72,28 +65,25 @@ impl Counter {
 mod tests {
     use counter::Counter;
     use std::sync::atomic::{AtomicUsize, Ordering};
-    use std::time::Instant;
     #[test]
     fn test_counter() {
         static mut COUNTER: Counter = create_counter!("test", 100);
-        let start = Instant::now();
         let count = 1;
-        inc_counter!(COUNTER, count, start);
+        inc_counter!(COUNTER, count);
         unsafe {
             assert_eq!(COUNTER.counts.load(Ordering::Relaxed), 1);
-            assert_ne!(COUNTER.nanos.load(Ordering::Relaxed), 0);
             assert_eq!(COUNTER.times.load(Ordering::Relaxed), 1);
             assert_eq!(COUNTER.lograte, 100);
             assert_eq!(COUNTER.lastlog.load(Ordering::Relaxed), 0);
             assert_eq!(COUNTER.name, "test");
         }
         for _ in 0..199 {
-            inc_counter!(COUNTER, 2, start);
+            inc_counter!(COUNTER, 2);
         }
         unsafe {
             assert_eq!(COUNTER.lastlog.load(Ordering::Relaxed), 199);
         }
-        inc_counter!(COUNTER, 2, start);
+        inc_counter!(COUNTER, 2);
         unsafe {
             assert_eq!(COUNTER.lastlog.load(Ordering::Relaxed), 399);
         }

--- a/src/sigverify.rs
+++ b/src/sigverify.rs
@@ -8,7 +8,6 @@ use counter::Counter;
 use packet::{Packet, SharedPackets};
 use std::mem::size_of;
 use std::sync::atomic::AtomicUsize;
-use std::time::Instant;
 use transaction::{PUB_KEY_OFFSET, SIGNED_DATA_OFFSET, SIG_OFFSET};
 
 pub const TX_OFFSET: usize = 0;
@@ -71,7 +70,6 @@ fn batch_size(batches: &Vec<SharedPackets>) -> usize {
 pub fn ed25519_verify(batches: &Vec<SharedPackets>) -> Vec<Vec<u8>> {
     use rayon::prelude::*;
     static mut COUNTER: Counter = create_counter!("ed25519_verify", 1);
-    let start = Instant::now();
     let count = batch_size(batches);
     info!("CPU ECDSA for {}", batch_size(batches));
     let rv = batches
@@ -85,7 +83,7 @@ pub fn ed25519_verify(batches: &Vec<SharedPackets>) -> Vec<Vec<u8>> {
                 .collect()
         })
         .collect();
-    inc_counter!(COUNTER, count, start);
+    inc_counter!(COUNTER, count);
     rv
 }
 
@@ -93,7 +91,6 @@ pub fn ed25519_verify(batches: &Vec<SharedPackets>) -> Vec<Vec<u8>> {
 pub fn ed25519_verify(batches: &Vec<SharedPackets>) -> Vec<Vec<u8>> {
     use packet::PACKET_DATA_SIZE;
     static mut COUNTER: Counter = create_counter!("ed25519_verify_cuda", 1);
-    let start = Instant::now();
     let count = batch_size(batches);
     info!("CUDA ECDSA for {}", batch_size(batches));
     let mut out = Vec::new();
@@ -153,7 +150,7 @@ pub fn ed25519_verify(batches: &Vec<SharedPackets>) -> Vec<Vec<u8>> {
             num += 1;
         }
     }
-    inc_counter!(COUNTER, count, start);
+    inc_counter!(COUNTER, count);
     rvs
 }
 


### PR DESCRIPTION
Tons of counters to monitor the network, set the influx logging to 100.  It would be nice to make this dynamic somehow since single host nodes can hit influx much more often then my all in one test.