### PR TITLE
Test-drive Criterion.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,3 +81,10 @@ futures = "0.1.21"
 clap = "2.31"
 reqwest = "0.8.6"
 influx_db_client = "0.3.4"
+
+[dev-dependencies]
+criterion = "0.2"
+
+[[bench]]
+name = "bank"
+harness = false

--- a/benches/bank.rs
+++ b/benches/bank.rs
@@ -39,13 +39,17 @@ fn bench_process_transaction(bencher: &mut Bencher) {
         })
         .collect();
 
-    bencher.iter(|| {
-        // Since benchmarker runs this multiple times, we need to clear the signatures.
-        bank.clear_signatures();
-
-        let results = bank.process_transactions(transactions.clone());
-        assert!(results.iter().all(Result::is_ok));
-    })
+    bencher.iter_with_setup(
+        || {
+            // Since benchmarker runs this multiple times, we need to clear the signatures.
+            bank.clear_signatures();
+            transactions.clone()
+        },
+        |transactions| {
+            let results = bank.process_transactions(transactions);
+            assert!(results.iter().all(Result::is_ok));
+        },
+    )
 }
 
 fn bench(criterion: &mut Criterion) {

--- a/benches/bank.rs
+++ b/benches/bank.rs
@@ -1,0 +1,51 @@
+#![feature(test)]
+
+extern crate bincode;
+extern crate rayon;
+extern crate solana;
+extern crate test;
+
+use bincode::serialize;
+use rayon::prelude::*;
+use solana::bank::*;
+use solana::hash::hash;
+use solana::mint::Mint;
+use solana::signature::{KeyPair, KeyPairUtil};
+use solana::transaction::Transaction;
+use test::Bencher;
+
+#[bench]
+fn bench_process_transaction(bencher: &mut Bencher) {
+    let mint = Mint::new(100_000_000);
+    let bank = Bank::new(&mint);
+
+    // Create transactions between unrelated parties.
+    let transactions: Vec<_> = (0..4096)
+        .into_par_iter()
+        .map(|i| {
+            // Seed the 'from' account.
+            let rando0 = KeyPair::new();
+            let tx = Transaction::new(&mint.keypair(), rando0.pubkey(), 10_000, mint.last_id());
+            assert!(bank.process_transaction(&tx).is_ok());
+
+            // Seed the 'to' account and a cell for its signature.
+            let last_id = hash(&serialize(&i).unwrap()); // Unique hash
+            bank.register_entry_id(&last_id);
+
+            let rando1 = KeyPair::new();
+            let tx = Transaction::new(&rando0, rando1.pubkey(), 1, last_id);
+            assert!(bank.process_transaction(&tx.clone()).is_ok());
+
+            // Finally, return a the transaction to benchmark.
+            tx
+        })
+        .collect();
+
+    bencher.iter(|| {
+        // Since benchmarker runs this multiple times, we need to clear the signatures.
+        bank.clear_signatures();
+
+        let results = bank.process_transactions(transactions.clone());
+        assert!(results.iter().all(Result::is_ok));
+    });
+}

--- a/benches/bank.rs
+++ b/benches/bank.rs
@@ -34,7 +34,7 @@ fn bench_process_transaction(bencher: &mut Bencher) {
             let tx = Transaction::new(&rando0, rando1.pubkey(), 1, last_id);
             assert!(bank.process_transaction(&tx.clone()).is_ok());
 
-            // Finally, return a the transaction to benchmark.
+            // Finally, return the transaction to the benchmark.
             tx
         })
         .collect();

--- a/benches/bank.rs
+++ b/benches/bank.rs
@@ -1,20 +1,18 @@
-#![feature(test)]
-
+#[macro_use]
+extern crate criterion;
 extern crate bincode;
 extern crate rayon;
 extern crate solana;
-extern crate test;
 
 use bincode::serialize;
+use criterion::{Bencher, Criterion};
 use rayon::prelude::*;
 use solana::bank::*;
 use solana::hash::hash;
 use solana::mint::Mint;
 use solana::signature::{KeyPair, KeyPairUtil};
 use solana::transaction::Transaction;
-use test::Bencher;
 
-#[bench]
 fn bench_process_transaction(bencher: &mut Bencher) {
     let mint = Mint::new(100_000_000);
     let bank = Bank::new(&mint);
@@ -47,5 +45,14 @@ fn bench_process_transaction(bencher: &mut Bencher) {
 
         let results = bank.process_transactions(transactions.clone());
         assert!(results.iter().all(Result::is_ok));
+    })
+}
+
+fn bench(criterion: &mut Criterion) {
+    criterion.bench_function("bench_process_transaction", |bencher| {
+        bench_process_transaction(bencher);
     });
 }
+
+criterion_group!(benches, bench);
+criterion_main!(benches);


### PR DESCRIPTION
See: https://japaric.github.io/criterion.rs/book/criterion_rs.html

We gain:
* The ability to do benchmarking from Rust stable
* More meaningful metrics. Maybe reliable enough to block PRs introducing regressions via CI
* gnuplot visualizations

We lose:
* The ability to benchmark private functions
* The use of `#[bench]`
* The community's more popular workflow.

Sample command-line output:

```
bench_process_transaction
                        time:   [2.4687 ms 2.4882 ms 2.5087 ms]
                        change: [-24.796% -22.249% -19.699%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  1 (1.00%) high mild
  5 (5.00%) high severe
```

Sample output from the HTML report:

```
	Lower bound	Estimate	Upper bound
Slope	2.5577 ms	2.6233 ms	2.7048 ms
R²	0.2362935	0.2435784	0.2324819
Mean	2.8168 ms	2.9047 ms	2.9977 ms
Std. Dev.	376.91 us	461.51 us	553.39 us
Median	2.6520 ms	2.8219 ms	3.0084 ms
MAD	339.46 us	489.37 us	594.31 us
```


[bench_process_transaction.pdf](https://github.com/solana-labs/solana/files/2182387/bench_process_transaction.pdf)

cc: #283

