### PR TITLE
Apply clippy feedback and add it to CI

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,0 +1,1 @@
+too-many-arguments-threshold = 9

--- a/benches/banking_stage.rs
+++ b/benches/banking_stage.rs
@@ -134,7 +134,7 @@ fn bench_banking_stage_multi_accounts(bencher: &mut Bencher) {
         let bank = Arc::new(Bank::new(&mint));
 
         let verified_setup: Vec<_> =
-            to_packets_chunked(&packet_recycler, setup_transactions.clone(), tx)
+            to_packets_chunked(&packet_recycler, &setup_transactions.clone(), tx)
                 .into_iter()
                 .map(|x| {
                     let len = (*x).read().unwrap().packets.len();
@@ -153,7 +153,7 @@ fn bench_banking_stage_multi_accounts(bencher: &mut Bencher) {
 
         check_txs(verified_setup_len, &signal_receiver, num_src_accounts);
 
-        let verified: Vec<_> = to_packets_chunked(&packet_recycler, transactions.clone(), 192)
+        let verified: Vec<_> = to_packets_chunked(&packet_recycler, &transactions.clone(), 192)
             .into_iter()
             .map(|x| {
                 let len = (*x).read().unwrap().packets.len();
@@ -201,7 +201,7 @@ fn bench_banking_stage_single_from(bencher: &mut Bencher) {
 
     bencher.iter(move || {
         let bank = Arc::new(Bank::new(&mint));
-        let verified: Vec<_> = to_packets_chunked(&packet_recycler, transactions.clone(), tx)
+        let verified: Vec<_> = to_packets_chunked(&packet_recycler, &transactions.clone(), tx)
             .into_iter()
             .map(|x| {
                 let len = (*x).read().unwrap().packets.len();

--- a/benches/banking_stage.rs
+++ b/benches/banking_stage.rs
@@ -144,12 +144,8 @@ fn bench_banking_stage_multi_accounts(bencher: &mut Bencher) {
 
         let verified_setup_len = verified_setup.len();
         verified_sender.send(verified_setup).unwrap();
-        BankingStage::process_packets(
-            bank.clone(),
-            &verified_receiver,
-            &signal_sender,
-            &packet_recycler,
-        ).unwrap();
+        BankingStage::process_packets(&bank, &verified_receiver, &signal_sender, &packet_recycler)
+            .unwrap();
 
         check_txs(verified_setup_len, &signal_receiver, num_src_accounts);
 
@@ -163,12 +159,8 @@ fn bench_banking_stage_multi_accounts(bencher: &mut Bencher) {
 
         let verified_len = verified.len();
         verified_sender.send(verified).unwrap();
-        BankingStage::process_packets(
-            bank.clone(),
-            &verified_receiver,
-            &signal_sender,
-            &packet_recycler,
-        ).unwrap();
+        BankingStage::process_packets(&bank, &verified_receiver, &signal_sender, &packet_recycler)
+            .unwrap();
 
         check_txs(verified_len, &signal_receiver, tx);
     });
@@ -210,12 +202,8 @@ fn bench_banking_stage_single_from(bencher: &mut Bencher) {
             .collect();
         let verified_len = verified.len();
         verified_sender.send(verified).unwrap();
-        BankingStage::process_packets(
-            bank.clone(),
-            &verified_receiver,
-            &signal_sender,
-            &packet_recycler,
-        ).unwrap();
+        BankingStage::process_packets(&bank, &verified_receiver, &signal_sender, &packet_recycler)
+            .unwrap();
 
         check_txs(verified_len, &signal_receiver, tx);
     });

--- a/ci/test-nightly.sh
+++ b/ci/test-nightly.sh
@@ -14,6 +14,8 @@ _() {
 _ cargo build --verbose --features unstable
 _ cargo test --verbose --features unstable
 
+_ cargo install --force clippy
+_ cargo clippy -- --deny=warnings
 
 exit 0
 

--- a/ci/test-nightly.sh
+++ b/ci/test-nightly.sh
@@ -13,8 +13,6 @@ _() {
 
 _ cargo build --verbose --features unstable
 _ cargo test --verbose --features unstable
-
-_ cargo install --force clippy
 _ cargo clippy -- --deny=warnings
 
 exit 0

--- a/src/bank.rs
+++ b/src/bank.rs
@@ -120,11 +120,7 @@ impl Bank {
 
     /// Commit funds to the `payment.to` party.
     fn apply_payment(&self, payment: &Payment, balances: &mut HashMap<PublicKey, i64>) {
-        if balances.contains_key(&payment.to) {
-            *balances.get_mut(&payment.to).unwrap() += payment.tokens;
-        } else {
-            balances.insert(payment.to, payment.tokens);
-        }
+        *balances.entry(payment.to).or_insert(0) += payment.tokens;
     }
 
     /// Return the last entry ID registered.
@@ -511,7 +507,7 @@ impl Bank {
         let bals = self.balances
             .read()
             .expect("'balances' read lock in get_balance");
-        bals.get(pubkey).map(|x| *x).unwrap_or(0)
+        bals.get(pubkey).cloned().unwrap_or(0)
     }
 
     pub fn transaction_count(&self) -> usize {

--- a/src/banking_stage.rs
+++ b/src/banking_stage.rs
@@ -40,7 +40,7 @@ impl BankingStage {
             .name("solana-banking-stage".to_string())
             .spawn(move || loop {
                 if let Err(e) = Self::process_packets(
-                    bank.clone(),
+                    &bank.clone(),
                     &verified_receiver,
                     &signal_sender,
                     &packet_recycler,
@@ -72,7 +72,7 @@ impl BankingStage {
     /// Process the incoming packets and send output `Signal` messages to `signal_sender`.
     /// Discard packets via `packet_recycler`.
     pub fn process_packets(
-        bank: Arc<Bank>,
+        bank: &Arc<Bank>,
         verified_receiver: &Receiver<Vec<(SharedPackets, Vec<u8>)>>,
         signal_sender: &Sender<Signal>,
         packet_recycler: &PacketRecycler,

--- a/src/bin/client-demo.rs
+++ b/src/bin/client-demo.rs
@@ -399,7 +399,7 @@ fn converge(
     let window = default_window();
     let gossip_send_socket = udp_random_bind(8000, 10000, 5).unwrap();
     let ncp = Ncp::new(
-        spy_ref.clone(),
+        &spy_ref.clone(),
         window.clone(),
         spy_gossip,
         gossip_send_socket,

--- a/src/bin/client-demo.rs
+++ b/src/bin/client-demo.rs
@@ -129,7 +129,7 @@ fn generate_and_send_txs(
                 leader.contact_info.tpu
             );
             for tx in txs {
-                client.transfer_signed(tx.clone()).unwrap();
+                client.transfer_signed(tx).unwrap();
             }
         });
     println!(

--- a/src/bin/drone.rs
+++ b/src/bin/drone.rs
@@ -62,7 +62,7 @@ fn main() {
 
     let leader: NodeInfo;
     if let Some(l) = matches.value_of("leader") {
-        leader = read_leader(l.to_string()).node_info;
+        leader = read_leader(l).node_info;
     } else {
         let server_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 8000);
         leader = NodeInfo::new_leader(&server_addr);
@@ -70,7 +70,7 @@ fn main() {
 
     let mint: Mint;
     if let Some(m) = matches.value_of("mint") {
-        mint = read_mint(m.to_string()).expect("client mint");
+        mint = read_mint(m).expect("client mint");
     } else {
         eprintln!("No mint found!");
         exit(1);
@@ -148,13 +148,13 @@ fn main() {
         });
     tokio::run(done);
 }
-fn read_leader(path: String) -> Config {
-    let file = File::open(path.clone()).expect(&format!("file not found: {}", path));
-    serde_json::from_reader(file).expect(&format!("failed to parse {}", path))
+fn read_leader(path: &str) -> Config {
+    let file = File::open(path).unwrap_or_else(|_| panic!("file not found: {}", path));
+    serde_json::from_reader(file).unwrap_or_else(|_| panic!("failed to parse {}", path))
 }
 
-fn read_mint(path: String) -> Result<Mint, Box<error::Error>> {
-    let file = File::open(path.clone())?;
+fn read_mint(path: &str) -> Result<Mint, Box<error::Error>> {
+    let file = File::open(path.to_string())?;
     let mint = serde_json::from_reader(file)?;
     Ok(mint)
 }

--- a/src/bin/fullnode.rs
+++ b/src/bin/fullnode.rs
@@ -82,7 +82,7 @@ fn main() -> () {
             None,
         )
     } else {
-        node.data.leader_id = node.data.id.clone();
+        node.data.leader_id = node.data.id;
 
         let outfile = if let Some(o) = matches.value_of("output") {
             OutFile::Path(o.to_string())

--- a/src/blob_fetch_stage.rs
+++ b/src/blob_fetch_stage.rs
@@ -18,14 +18,14 @@ impl BlobFetchStage {
     pub fn new(
         socket: UdpSocket,
         exit: Arc<AtomicBool>,
-        blob_recycler: BlobRecycler,
+        blob_recycler: &BlobRecycler,
     ) -> (Self, BlobReceiver) {
         Self::new_multi_socket(vec![socket], exit, blob_recycler)
     }
     pub fn new_multi_socket(
         sockets: Vec<UdpSocket>,
         exit: Arc<AtomicBool>,
-        blob_recycler: BlobRecycler,
+        blob_recycler: &BlobRecycler,
     ) -> (Self, BlobReceiver) {
         let (blob_sender, blob_receiver) = channel();
         let thread_hdls: Vec<_> = sockets

--- a/src/choose_gossip_peer_strategy.rs
+++ b/src/choose_gossip_peer_strategy.rs
@@ -159,7 +159,7 @@ impl<'a> ChooseWeightedPeerStrategy<'a> {
 
         // Return u32 b/c the weighted sampling API from rand::distributions
         // only takes u32 for weights
-        if weighted_vote >= std::u32::MAX as f64 {
+        if weighted_vote >= f64::from(std::u32::MAX) {
             return std::u32::MAX;
         }
 
@@ -173,7 +173,7 @@ impl<'a> ChooseWeightedPeerStrategy<'a> {
 
 impl<'a> ChooseGossipPeerStrategy for ChooseWeightedPeerStrategy<'a> {
     fn choose_peer<'b>(&self, options: Vec<&'b NodeInfo>) -> Result<&'b NodeInfo> {
-        if options.len() < 1 {
+        if options.is_empty() {
             Err(CrdtError::TooSmall)?;
         }
 

--- a/src/drone.rs
+++ b/src/drone.rs
@@ -17,7 +17,7 @@ use transaction::Transaction;
 pub const TIME_SLICE: u64 = 60;
 pub const REQUEST_CAP: u64 = 1_000_000;
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone, Copy)]
 pub enum DroneRequest {
     GetAirdrop {
         airdrop_request_amount: u64,

--- a/src/drone.rs
+++ b/src/drone.rs
@@ -112,7 +112,7 @@ impl Drone {
                 airdrop_request_amount,
                 client_public_key,
             } => {
-                request_amount = airdrop_request_amount.clone();
+                request_amount = airdrop_request_amount;
                 tx = Transaction::new(
                     &self.mint_keypair,
                     client_public_key,
@@ -136,7 +136,7 @@ impl Drone {
                     )
                     .to_owned(),
             );
-            client.transfer_signed(tx)
+            client.transfer_signed(&tx)
         } else {
             Err(Error::new(ErrorKind::Other, "token limit reached"))
         }

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -144,7 +144,7 @@ fn next_hash(start_hash: &Hash, num_hashes: u64, transactions: &[Transaction]) -
 
 /// Creates the next Tick or Transaction Entry `num_hashes` after `start_hash`.
 pub fn next_entry(start_hash: &Hash, num_hashes: u64, transactions: Vec<Transaction>) -> Entry {
-    assert!(num_hashes > 0 || transactions.len() == 0);
+    assert!(num_hashes > 0 || transactions.is_empty());
     Entry {
         num_hashes,
         id: next_hash(start_hash, num_hashes, &transactions),

--- a/src/fetch_stage.rs
+++ b/src/fetch_stage.rs
@@ -18,14 +18,14 @@ impl FetchStage {
     pub fn new(
         socket: UdpSocket,
         exit: Arc<AtomicBool>,
-        packet_recycler: PacketRecycler,
+        packet_recycler: &PacketRecycler,
     ) -> (Self, PacketReceiver) {
         Self::new_multi_socket(vec![socket], exit, packet_recycler)
     }
     pub fn new_multi_socket(
         sockets: Vec<UdpSocket>,
         exit: Arc<AtomicBool>,
-        packet_recycler: PacketRecycler,
+        packet_recycler: &PacketRecycler,
     ) -> (Self, PacketReceiver) {
         let (packet_sender, packet_receiver) = channel();
         let thread_hdls: Vec<_> = sockets

--- a/src/fullnode.rs
+++ b/src/fullnode.rs
@@ -112,7 +112,7 @@ impl FullNode {
                 entry_height,
                 Some(ledger_tail),
                 node,
-                network_entry_point,
+                &network_entry_point,
                 exit.clone(),
             );
             info!(
@@ -208,7 +208,7 @@ impl FullNode {
         let bank = Arc::new(bank);
         let mut thread_hdls = vec![];
         let rpu = Rpu::new(
-            bank.clone(),
+            &bank.clone(),
             node.sockets.requests,
             node.sockets.respond,
             exit.clone(),
@@ -229,7 +229,7 @@ impl FullNode {
         thread_hdls.extend(tpu.thread_hdls());
         let window = FullNode::new_window(ledger_tail, entry_height, &crdt, &blob_recycler);
         let ncp = Ncp::new(
-            crdt.clone(),
+            &crdt.clone(),
             window.clone(),
             node.sockets.gossip,
             node.sockets.gossip_send,
@@ -285,13 +285,13 @@ impl FullNode {
         entry_height: u64,
         ledger_tail: Option<Vec<Entry>>,
         node: TestNode,
-        entry_point: NodeInfo,
+        entry_point: &NodeInfo,
         exit: Arc<AtomicBool>,
     ) -> Self {
         let bank = Arc::new(bank);
         let mut thread_hdls = vec![];
         let rpu = Rpu::new(
-            bank.clone(),
+            &bank.clone(),
             node.sockets.requests,
             node.sockets.respond,
             exit.clone(),
@@ -308,7 +308,7 @@ impl FullNode {
         let window = FullNode::new_window(ledger_tail, entry_height, &crdt, &blob_recycler);
 
         let ncp = Ncp::new(
-            crdt.clone(),
+            &crdt.clone(),
             window.clone(),
             node.sockets.gossip,
             node.sockets.gossip_send,
@@ -367,7 +367,7 @@ mod tests {
         let bank = Bank::new(&alice);
         let exit = Arc::new(AtomicBool::new(false));
         let entry = tn.data.clone();
-        let v = FullNode::new_validator(kp, bank, 0, None, tn, entry, exit);
+        let v = FullNode::new_validator(kp, bank, 0, None, tn, &entry, exit);
         v.close().unwrap();
     }
 }

--- a/src/fullnode.rs
+++ b/src/fullnode.rs
@@ -99,7 +99,7 @@ impl FullNode {
             "starting... local gossip address: {} (advertising {})",
             local_gossip_addr, node.data.contact_info.ncp
         );
-        let requests_addr = node.data.contact_info.rpu.clone();
+        let requests_addr = node.data.contact_info.rpu;
         let exit = Arc::new(AtomicBool::new(false));
         if !leader {
             let testnet_addr = network_entry_for_validator.expect("validator requires entry");
@@ -121,7 +121,7 @@ impl FullNode {
             );
             server
         } else {
-            node.data.leader_id = node.data.id.clone();
+            node.data.leader_id = node.data.id;
             let outfile_for_leader: Box<Write + Send> = match outfile_for_leader {
                 Some(OutFile::Path(file)) => Box::new(
                     OpenOptions::new()
@@ -218,11 +218,11 @@ impl FullNode {
         let blob_recycler = BlobRecycler::default();
         let crdt = Arc::new(RwLock::new(Crdt::new(node.data)));
         let (tpu, blob_receiver) = Tpu::new(
-            bank.clone(),
-            crdt.clone(),
+            &bank.clone(),
+            &crdt.clone(),
             tick_duration,
             node.sockets.transaction,
-            blob_recycler.clone(),
+            &blob_recycler.clone(),
             exit.clone(),
             writer,
         );

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -9,6 +9,6 @@ static INIT: Once = ONCE_INIT;
 /// Setup function that is only run once, even if called multiple times.
 pub fn setup() {
     INIT.call_once(|| {
-        let _ = env_logger::init();
+        env_logger::init();
     });
 }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -81,13 +81,13 @@ impl Default for MetricsAgent {
 impl MetricsAgent {
     fn new(writer: Arc<MetricsWriter + Send + Sync>, write_frequency: Duration) -> Self {
         let (sender, receiver) = channel::<MetricsCommand>();
-        thread::spawn(move || Self::run(receiver, writer, write_frequency));
+        thread::spawn(move || Self::run(&receiver, &writer, write_frequency));
         MetricsAgent { sender }
     }
 
     fn run(
-        receiver: Receiver<MetricsCommand>,
-        writer: Arc<MetricsWriter>,
+        receiver: &Receiver<MetricsCommand>,
+        writer: &Arc<MetricsWriter + Send + Sync>,
         write_frequency: Duration,
     ) {
         trace!("run: enter");

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -36,10 +36,11 @@ impl InfluxDbMetricsWriter {
     }
 
     fn build_client() -> Option<influxdb::Client> {
-        let host = env::var("INFLUX_HOST").unwrap_or("https://metrics.solana.com:8086".to_string());
-        let db = env::var("INFLUX_DATABASE").unwrap_or("scratch".to_string());
-        let username = env::var("INFLUX_USERNAME").unwrap_or("scratch_writer".to_string());
-        let password = env::var("INFLUX_PASSWORD").unwrap_or("topsecret".to_string());
+        let host = env::var("INFLUX_HOST")
+            .unwrap_or_else(|_| "https://metrics.solana.com:8086".to_string());
+        let db = env::var("INFLUX_DATABASE").unwrap_or_else(|_| "scratch".to_string());
+        let username = env::var("INFLUX_USERNAME").unwrap_or_else(|_| "scratch_writer".to_string());
+        let password = env::var("INFLUX_PASSWORD").unwrap_or_else(|_| "topsecret".to_string());
 
         debug!("InfluxDB host={} db={} username={}", host, db, username);
         let mut client = influxdb::Client::new_with_option(host, db, None)
@@ -120,13 +121,11 @@ impl MetricsAgent {
             }
 
             let now = Instant::now();
-            if now.duration_since(last_write_time) >= write_frequency {
-                if !points.is_empty() {
-                    debug!("run: writing {} points", points.len());
-                    writer.write(points);
-                    points = Vec::new();
-                    last_write_time = now;
-                }
+            if now.duration_since(last_write_time) >= write_frequency && !points.is_empty() {
+                debug!("run: writing {} points", points.len());
+                writer.write(points);
+                points = Vec::new();
+                last_write_time = now;
             }
         }
         trace!("run: exit");

--- a/src/nat.rs
+++ b/src/nat.rs
@@ -92,7 +92,7 @@ pub fn udp_public_bind(label: &str, startport: u16, endport: u16) -> UdpSocketPa
                 //
                 // TODO: Remove the |sender| socket and deal with the downstream changes to
                 //       the UDP signalling
-                let mut local_addr_sender = local_addr.clone();
+                let mut local_addr_sender = local_addr;
                 local_addr_sender.set_port(public_addr.port());
                 UdpSocket::bind(local_addr_sender).unwrap()
             };

--- a/src/ncp.rs
+++ b/src/ncp.rs
@@ -18,7 +18,7 @@ pub struct Ncp {
 
 impl Ncp {
     pub fn new(
-        crdt: Arc<RwLock<Crdt>>,
+        crdt: &Arc<RwLock<Crdt>>,
         window: Arc<RwLock<Vec<Option<SharedBlob>>>>,
         gossip_listen_socket: UdpSocket,
         gossip_send_socket: UdpSocket,
@@ -93,7 +93,7 @@ mod tests {
         let c = Arc::new(RwLock::new(crdt));
         let w = Arc::new(RwLock::new(vec![]));
         let d = Ncp::new(
-            c.clone(),
+            &c.clone(),
             w,
             tn.sockets.gossip,
             tn.sockets.gossip_send,

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -240,7 +240,7 @@ impl Packets {
 
 pub fn to_packets_chunked<T: Serialize>(
     r: &PacketRecycler,
-    xs: Vec<T>,
+    xs: &[T],
     chunks: usize,
 ) -> Vec<SharedPackets> {
     let mut out = vec![];
@@ -258,10 +258,10 @@ pub fn to_packets_chunked<T: Serialize>(
         }
         out.push(p);
     }
-    return out;
+    out
 }
 
-pub fn to_packets<T: Serialize>(r: &PacketRecycler, xs: Vec<T>) -> Vec<SharedPackets> {
+pub fn to_packets<T: Serialize>(r: &PacketRecycler, xs: &[T]) -> Vec<SharedPackets> {
     to_packets_chunked(r, xs, NUM_PACKETS)
 }
 
@@ -347,7 +347,7 @@ impl Blob {
     }
 
     pub fn is_coding(&self) -> bool {
-        return (self.get_flags().unwrap() & BLOB_FLAG_IS_CODING) != 0;
+        (self.get_flags().unwrap() & BLOB_FLAG_IS_CODING) != 0
     }
 
     pub fn set_coding(&mut self) -> Result<()> {
@@ -524,15 +524,15 @@ mod tests {
     fn test_to_packets() {
         let tx = Request::GetTransactionCount;
         let re = PacketRecycler::default();
-        let rv = to_packets(&re, vec![tx.clone(); 1]);
+        let rv = to_packets(&re, &vec![tx.clone(); 1]);
         assert_eq!(rv.len(), 1);
         assert_eq!(rv[0].read().unwrap().packets.len(), 1);
 
-        let rv = to_packets(&re, vec![tx.clone(); NUM_PACKETS]);
+        let rv = to_packets(&re, &vec![tx.clone(); NUM_PACKETS]);
         assert_eq!(rv.len(), 1);
         assert_eq!(rv[0].read().unwrap().packets.len(), NUM_PACKETS);
 
-        let rv = to_packets(&re, vec![tx.clone(); NUM_PACKETS + 1]);
+        let rv = to_packets(&re, &vec![tx.clone(); NUM_PACKETS + 1]);
         assert_eq!(rv.len(), 2);
         assert_eq!(rv[0].read().unwrap().packets.len(), NUM_PACKETS);
         assert_eq!(rv[1].read().unwrap().packets.len(), 1);

--- a/src/record_stage.rs
+++ b/src/record_stage.rs
@@ -32,7 +32,7 @@ impl RecordStage {
         start_hash: &Hash,
     ) -> (Self, Receiver<Vec<Entry>>) {
         let (entry_sender, entry_receiver) = channel();
-        let start_hash = start_hash.clone();
+        let start_hash = *start_hash;
 
         let thread_hdl = Builder::new()
             .name("solana-record-stage".to_string())
@@ -52,7 +52,7 @@ impl RecordStage {
         tick_duration: Duration,
     ) -> (Self, Receiver<Vec<Entry>>) {
         let (entry_sender, entry_receiver) = channel();
-        let start_hash = start_hash.clone();
+        let start_hash = *start_hash;
 
         let thread_hdl = Builder::new()
             .name("solana-record-stage".to_string())
@@ -60,13 +60,14 @@ impl RecordStage {
                 let mut recorder = Recorder::new(start_hash);
                 let start_time = Instant::now();
                 loop {
-                    if let Err(_) = Self::try_process_signals(
+                    if Self::try_process_signals(
                         &mut recorder,
                         start_time,
                         tick_duration,
                         &signal_receiver,
                         &entry_sender,
-                    ) {
+                    ).is_err()
+                    {
                         return;
                     }
                     recorder.hash();

--- a/src/replicate_stage.rs
+++ b/src/replicate_stage.rs
@@ -66,7 +66,7 @@ impl ReplicateStage {
             let shared_blob = blob_recycler.allocate();
             let (vote, addr) = {
                 let mut wcrdt = crdt.write().unwrap();
-                wcrdt.insert_votes(votes);
+                wcrdt.insert_votes(&votes);
                 //TODO: doesn't seem like there is a synchronous call to get height and id
                 info!("replicate_stage {} {:?}", height, &last_id[..8]);
                 wcrdt.new_vote(height, last_id)

--- a/src/request.rs
+++ b/src/request.rs
@@ -4,7 +4,7 @@ use hash::Hash;
 use signature::{PublicKey, Signature};
 
 #[cfg_attr(feature = "cargo-clippy", allow(large_enum_variant))]
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, Copy)]
 pub enum Request {
     GetBalance { key: PublicKey },
     GetLastId,

--- a/src/rpu.rs
+++ b/src/rpu.rs
@@ -41,7 +41,7 @@ pub struct Rpu {
 
 impl Rpu {
     pub fn new(
-        bank: Arc<Bank>,
+        bank: &Arc<Bank>,
         requests_socket: UdpSocket,
         respond_socket: UdpSocket,
         exit: Arc<AtomicBool>,

--- a/src/sigverify.rs
+++ b/src/sigverify.rs
@@ -66,6 +66,7 @@ fn batch_size(batches: &[SharedPackets]) -> usize {
         .sum()
 }
 
+#[cfg_attr(feature = "cargo-clippy", allow(ptr_arg))]
 #[cfg(not(feature = "cuda"))]
 pub fn ed25519_verify(batches: &Vec<SharedPackets>) -> Vec<Vec<u8>> {
     use rayon::prelude::*;

--- a/src/sigverify.rs
+++ b/src/sigverify.rs
@@ -59,7 +59,7 @@ fn verify_packet(packet: &Packet) -> u8 {
     ).is_ok() as u8
 }
 
-fn batch_size(batches: &Vec<SharedPackets>) -> usize {
+fn batch_size(batches: &[SharedPackets]) -> usize {
     batches
         .iter()
         .map(|p| p.read().unwrap().packets.len())

--- a/src/timing.rs
+++ b/src/timing.rs
@@ -3,20 +3,20 @@ use std::time::Duration;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 pub fn duration_as_us(d: &Duration) -> u64 {
-    return (d.as_secs() * 1000 * 1000) + (d.subsec_nanos() as u64 / 1_000);
+    (d.as_secs() * 1000 * 1000) + (u64::from(d.subsec_nanos()) / 1_000)
 }
 
 pub fn duration_as_ms(d: &Duration) -> u64 {
-    return (d.as_secs() * 1000) + (d.subsec_nanos() as u64 / 1_000_000);
+    (d.as_secs() * 1000) + (u64::from(d.subsec_nanos()) / 1_000_000)
 }
 
 pub fn duration_as_s(d: &Duration) -> f32 {
-    return d.as_secs() as f32 + (d.subsec_nanos() as f32 / 1_000_000_000.0);
+    d.as_secs() as f32 + (d.subsec_nanos() as f32 / 1_000_000_000.0)
 }
 
 pub fn timestamp() -> u64 {
     let now = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .expect("create timestamp in timing");
-    return duration_as_ms(&now);
+    duration_as_ms(&now)
 }

--- a/src/tpu.rs
+++ b/src/tpu.rs
@@ -52,11 +52,11 @@ pub struct Tpu {
 
 impl Tpu {
     pub fn new<W: Write + Send + 'static>(
-        bank: Arc<Bank>,
-        crdt: Arc<RwLock<Crdt>>,
+        bank: &Arc<Bank>,
+        crdt: &Arc<RwLock<Crdt>>,
         tick_duration: Option<Duration>,
         transactions_socket: UdpSocket,
-        blob_recycler: BlobRecycler,
+        blob_recycler: &BlobRecycler,
         exit: Arc<AtomicBool>,
         writer: W,
     ) -> (Self, BlobReceiver) {

--- a/src/tpu.rs
+++ b/src/tpu.rs
@@ -63,7 +63,7 @@ impl Tpu {
         let packet_recycler = PacketRecycler::default();
 
         let (fetch_stage, packet_receiver) =
-            FetchStage::new(transactions_socket, exit, packet_recycler.clone());
+            FetchStage::new(transactions_socket, exit, &packet_recycler.clone());
 
         let (sigverify_stage, verified_receiver) = SigVerifyStage::new(packet_receiver);
 

--- a/src/tvu.rs
+++ b/src/tvu.rs
@@ -83,7 +83,7 @@ impl Tvu {
         let (fetch_stage, blob_fetch_receiver) = BlobFetchStage::new_multi_socket(
             vec![replicate_socket, repair_socket],
             exit,
-            blob_recycler.clone(),
+            &blob_recycler.clone(),
         );
         //TODO
         //the packets coming out of blob_receiver need to be sent to the GPU and verified
@@ -161,7 +161,7 @@ pub mod tests {
     ) -> Result<(Ncp, Window)> {
         let window = streamer::default_window();
         let send_sock = UdpSocket::bind("0.0.0.0:0").expect("bind 0");
-        let ncp = Ncp::new(crdt, window.clone(), listen, send_sock, exit)?;
+        let ncp = Ncp::new(&crdt, window.clone(), listen, send_sock, exit)?;
         Ok((ncp, window))
     }
     /// Test that message sent from leader to target1 and replicated to target2

--- a/src/tvu.rs
+++ b/src/tvu.rs
@@ -89,11 +89,11 @@ impl Tvu {
         //the packets coming out of blob_receiver need to be sent to the GPU and verified
         //then sent to the window, which does the erasure coding reconstruction
         let (window_stage, blob_window_receiver) = WindowStage::new(
-            crdt.clone(),
+            &crdt.clone(),
             window,
             entry_height,
             retransmit_socket,
-            blob_recycler.clone(),
+            &blob_recycler.clone(),
             blob_fetch_receiver,
         );
 

--- a/src/voting.rs
+++ b/src/voting.rs
@@ -3,17 +3,15 @@ use hash::Hash;
 use signature::PublicKey;
 use transaction::{Instruction, Vote};
 
-pub fn entries_to_votes(entries: &Vec<Entry>) -> Vec<(PublicKey, Vote, Hash)> {
+pub fn entries_to_votes(entries: &[Entry]) -> Vec<(PublicKey, Vote, Hash)> {
     entries
         .iter()
         .flat_map(|entry| {
             let vs: Vec<(PublicKey, Vote, Hash)> = entry
                 .transactions
                 .iter()
-                .filter_map(|tx| match &tx.instruction {
-                    &Instruction::NewVote(ref vote) => {
-                        Some((tx.from.clone(), vote.clone(), tx.last_id.clone()))
-                    }
+                .filter_map(|tx| match tx.instruction {
+                    Instruction::NewVote(ref vote) => Some((tx.from, vote.clone(), tx.last_id)),
                     _ => None,
                 })
                 .collect();

--- a/src/window_stage.rs
+++ b/src/window_stage.rs
@@ -15,11 +15,11 @@ pub struct WindowStage {
 
 impl WindowStage {
     pub fn new(
-        crdt: Arc<RwLock<Crdt>>,
+        crdt: &Arc<RwLock<Crdt>>,
         window: Window,
         entry_height: u64,
         retransmit_socket: UdpSocket,
-        blob_recycler: BlobRecycler,
+        blob_recycler: &BlobRecycler,
         fetch_stage_receiver: BlobReceiver,
     ) -> (Self, BlobReceiver) {
         let (retransmit_sender, retransmit_receiver) = channel();

--- a/src/write_stage.rs
+++ b/src/write_stage.rs
@@ -35,7 +35,7 @@ impl WriteStage {
     ) -> Result<()> {
         let entries = entry_receiver.recv_timeout(Duration::new(1, 0))?;
         let votes = entries_to_votes(&entries);
-        crdt.write().unwrap().insert_votes(votes);
+        crdt.write().unwrap().insert_votes(&votes);
         entry_writer.write_and_register_entries(&entries)?;
         trace!("New blobs? {}", entries.len());
         let mut blobs = VecDeque::new();

--- a/tests/data_replicator.rs
+++ b/tests/data_replicator.rs
@@ -21,7 +21,7 @@ fn test_node(exit: Arc<AtomicBool>) -> (Arc<RwLock<Crdt>>, Ncp, UdpSocket) {
     let c = Arc::new(RwLock::new(crdt));
     let w = Arc::new(RwLock::new(vec![]));
     let d = Ncp::new(
-        c.clone(),
+        &c.clone(),
         w,
         tn.sockets.gossip,
         tn.sockets.gossip_send,

--- a/tests/multinode.rs
+++ b/tests/multinode.rs
@@ -35,7 +35,7 @@ fn converge(leader: &NodeInfo, num_nodes: usize) -> Vec<NodeInfo> {
     let spy_ref = Arc::new(RwLock::new(spy_crdt));
     let spy_window = default_window();
     let ncp = Ncp::new(
-        spy_ref.clone(),
+        &spy_ref.clone(),
         spy_window,
         spy.sockets.gossip,
         spy.sockets.gossip_send,


### PR DESCRIPTION
Clippy is a great linter. Those just learning Rust should find its feedback on idioms and borrowing should find it especially helpful. This PR accepts nearly all Clippy advice, silencing just one because I don't want to clean up the sigverify bindings (@sakridge), and then adds Clippy to CI so that future PRs will be blocked if you don't acknowledge Clippy. 