### PR TITLE
Fix flaky test

### DIFF
--- a/src/sigverify.rs
+++ b/src/sigverify.rs
@@ -186,7 +186,7 @@ mod tests {
 
         // jumble some data to test failure
         if modify_data {
-            packet.data[20] = 10;
+            packet.data[20] = packet.data[20].wrapping_add(10);
         }
 
         // generate packet vector


### PR DESCRIPTION
The test would fail any time the original value was coincidently
the same as the new bogus value.