### PR TITLE
Don't clone before borrowing

### DIFF
--- a/benches/bank.rs
+++ b/benches/bank.rs
@@ -32,7 +32,7 @@ fn bench_process_transaction(bencher: &mut Bencher) {
 
             let rando1 = KeyPair::new();
             let tx = Transaction::new(&rando0, rando1.pubkey(), 1, last_id);
-            assert!(bank.process_transaction(&tx.clone()).is_ok());
+            assert!(bank.process_transaction(&tx).is_ok());
 
             // Finally, return the transaction to the benchmark.
             tx

--- a/src/banking_stage.rs
+++ b/src/banking_stage.rs
@@ -40,7 +40,7 @@ impl BankingStage {
             .name("solana-banking-stage".to_string())
             .spawn(move || loop {
                 if let Err(e) = Self::process_packets(
-                    &bank.clone(),
+                    &bank,
                     &verified_receiver,
                     &signal_sender,
                     &packet_recycler,

--- a/src/bin/client-demo.rs
+++ b/src/bin/client-demo.rs
@@ -224,7 +224,7 @@ fn main() {
 
     let signal = Arc::new(AtomicBool::new(false));
     let mut c_threads = vec![];
-    let validators = converge(&leader, &signal.clone(), num_nodes, &mut c_threads);
+    let validators = converge(&leader, &signal, num_nodes, &mut c_threads);
     assert_eq!(validators.len(), num_nodes);
 
     let mut client = mk_client(&leader);
@@ -393,7 +393,7 @@ fn converge(
     let window = default_window();
     let gossip_send_socket = udp_random_bind(8000, 10000, 5).unwrap();
     let ncp = Ncp::new(
-        &spy_ref.clone(),
+        &spy_ref,
         window.clone(),
         spy_gossip,
         gossip_send_socket,

--- a/src/fullnode.rs
+++ b/src/fullnode.rs
@@ -195,7 +195,7 @@ impl FullNode {
         let bank = Arc::new(bank);
         let mut thread_hdls = vec![];
         let rpu = Rpu::new(
-            &bank.clone(),
+            &bank,
             node.sockets.requests,
             node.sockets.respond,
             exit.clone(),
@@ -205,18 +205,18 @@ impl FullNode {
         let blob_recycler = BlobRecycler::default();
         let crdt = Arc::new(RwLock::new(Crdt::new(node.data)));
         let (tpu, blob_receiver) = Tpu::new(
-            &bank.clone(),
-            &crdt.clone(),
+            &bank,
+            &crdt,
             tick_duration,
             node.sockets.transaction,
-            &blob_recycler.clone(),
+            &blob_recycler,
             exit.clone(),
             writer,
         );
         thread_hdls.extend(tpu.thread_hdls());
         let window = FullNode::new_window(ledger_tail, entry_height, &crdt, &blob_recycler);
         let ncp = Ncp::new(
-            &crdt.clone(),
+            &crdt,
             window.clone(),
             node.sockets.gossip,
             node.sockets.gossip_send,
@@ -278,7 +278,7 @@ impl FullNode {
         let bank = Arc::new(bank);
         let mut thread_hdls = vec![];
         let rpu = Rpu::new(
-            &bank.clone(),
+            &bank,
             node.sockets.requests,
             node.sockets.respond,
             exit.clone(),
@@ -295,7 +295,7 @@ impl FullNode {
         let window = FullNode::new_window(ledger_tail, entry_height, &crdt, &blob_recycler);
 
         let ncp = Ncp::new(
-            &crdt.clone(),
+            &crdt,
             window.clone(),
             node.sockets.gossip,
             node.sockets.gossip_send,
@@ -304,7 +304,7 @@ impl FullNode {
 
         let tvu = Tvu::new(
             keypair,
-            bank.clone(),
+            &bank,
             entry_height,
             crdt.clone(),
             window.clone(),

--- a/src/ncp.rs
+++ b/src/ncp.rs
@@ -93,7 +93,7 @@ mod tests {
         let c = Arc::new(RwLock::new(crdt));
         let w = Arc::new(RwLock::new(vec![]));
         let d = Ncp::new(
-            &c.clone(),
+            &c,
             w,
             tn.sockets.gossip,
             tn.sockets.gossip_send,

--- a/src/sigverify_stage.rs
+++ b/src/sigverify_stage.rs
@@ -77,7 +77,7 @@ impl SigVerifyStage {
         verified_sender: Arc<Mutex<Sender<VerifiedPackets>>>,
     ) -> JoinHandle<()> {
         spawn(move || loop {
-            if let Err(e) = Self::verifier(&packet_receiver.clone(), &verified_sender.clone()) {
+            if let Err(e) = Self::verifier(&packet_receiver, &verified_sender) {
                 match e {
                     Error::RecvTimeoutError(RecvTimeoutError::Disconnected) => break,
                     Error::RecvTimeoutError(RecvTimeoutError::Timeout) => (),

--- a/src/tpu.rs
+++ b/src/tpu.rs
@@ -63,7 +63,7 @@ impl Tpu {
         let packet_recycler = PacketRecycler::default();
 
         let (fetch_stage, packet_receiver) =
-            FetchStage::new(transactions_socket, exit, &packet_recycler.clone());
+            FetchStage::new(transactions_socket, exit, &packet_recycler);
 
         let (sigverify_stage, verified_receiver) = SigVerifyStage::new(packet_receiver);
 

--- a/tests/multinode.rs
+++ b/tests/multinode.rs
@@ -35,7 +35,7 @@ fn converge(leader: &NodeInfo, num_nodes: usize) -> Vec<NodeInfo> {
     let spy_ref = Arc::new(RwLock::new(spy_crdt));
     let spy_window = default_window();
     let ncp = Ncp::new(
-        &spy_ref.clone(),
+        &spy_ref,
         spy_window,
         spy.sockets.gossip,
         spy.sockets.gossip_send,


### PR DESCRIPTION
Clippy told us to change function parameters to references, but
wasn't able to then tell us that the clone() before borrowing
was superfluous. This patch removes those by hand.

No expectation of a performance improvement here, since we were
just cloning reference counts. Just removes a bunch of noise.