### PR TITLE
Use ed25519_init() for faster failures

### DIFF
--- a/src/sigverify_stage.rs
+++ b/src/sigverify_stage.rs
@@ -25,6 +25,7 @@ pub struct SigVerifyStage {
 
 impl SigVerifyStage {
     pub fn new(packet_receiver: Receiver<SharedPackets>) -> (Self, Receiver<VerifiedPackets>) {
+        sigverify::init();
         let (verified_sender, verified_receiver) = channel();
         let thread_hdls = Self::verifier_services(packet_receiver, verified_sender);
         (SigVerifyStage { thread_hdls }, verified_receiver)


### PR DESCRIPTION
Currently when we fail to initialize CUDA the resulting errors are very subtle (eg, airdrops evaporate without a peep).  Instead we ought to be complaining loudly and that's what this PR does.