### PR TITLE
dash for namespaces

### DIFF
--- a/src/counter.rs
+++ b/src/counter.rs
@@ -50,7 +50,7 @@ impl Counter {
         }
         if times % INFLUX_RATE == 0 && times > 0 {
             metrics::submit(
-                influxdb::Point::new(&format!("counter_{}", self.name))
+                influxdb::Point::new(&format!("counter-{}", self.name))
                     .add_field(
                         "count",
                         influxdb::Value::Integer(counts as i64 - lastlog as i64),


### PR DESCRIPTION
Use `-` to separate namespaces for counters. This may require a reboot of the influx the databases.