### PR TITLE
Multinode fast exit

### DIFF
--- a/src/fullnode.rs
+++ b/src/fullnode.rs
@@ -347,6 +347,7 @@ mod tests {
     use crdt::TestNode;
     use fullnode::FullNode;
     use mint::Mint;
+    use service::Service;
     use signature::{KeyPair, KeyPairUtil};
     use std::sync::atomic::AtomicBool;
     use std::sync::Arc;
@@ -360,7 +361,7 @@ mod tests {
         let entry = tn.data.clone();
         let v = FullNode::new_validator(kp, bank, 0, None, tn, &entry, exit);
         v.exit();
-        v.close().unwrap();
+        v.join().unwrap();
     }
     #[test]
     fn validator_parallel_exit() {
@@ -375,10 +376,10 @@ mod tests {
                 FullNode::new_validator(kp, bank, 0, None, tn, &entry, exit)
             })
             .collect();
-        //each validator can exit in parallel to speed many sequential calls to `close`
+        //each validator can exit in parallel to speed many sequential calls to `join`
         vals.iter().for_each(|v| v.exit());
-        //while close is called sequentially, the above exit call notified all the
+        //while join is called sequentially, the above exit call notified all the
         //validators to exit from all their threads
-        vals.into_iter().for_each(|v| v.close().unwrap());
+        vals.into_iter().for_each(|v| v.join().unwrap());
     }
 }

--- a/src/fullnode.rs
+++ b/src/fullnode.rs
@@ -319,7 +319,7 @@ impl FullNode {
     }
 
     //used for notifying many nodes in parallel to exit
-    pub fn notify_exit(self) {
+    pub fn notify_exit(&self) {
         self.exit.store(true, Ordering::Relaxed);
     }
     pub fn close(self) -> Result<()> {

--- a/src/fullnode.rs
+++ b/src/fullnode.rs
@@ -318,6 +318,10 @@ impl FullNode {
         FullNode { exit, thread_hdls }
     }
 
+    //used for notifying many nodes in parallel to exit
+    pub fn notify_exit(self) {
+        self.exit.store(true, Ordering::Relaxed);
+    }
     pub fn close(self) -> Result<()> {
         self.exit.store(true, Ordering::Relaxed);
         self.join()
@@ -355,6 +359,7 @@ mod tests {
         let exit = Arc::new(AtomicBool::new(false));
         let entry = tn.data.clone();
         let v = FullNode::new_validator(kp, bank, 0, None, tn, &entry, exit);
+        v.notify_exit();
         v.close().unwrap();
     }
 }

--- a/tests/multinode.rs
+++ b/tests/multinode.rs
@@ -465,6 +465,9 @@ fn test_multi_node_dynamic_network() {
     }
     assert_eq!(consecutive_success, 10);
     for (_, node) in validators {
+        node.notify_exit();
+    }
+    for (_, node) in validators {
         node.close().unwrap();
     }
     server.close().unwrap();

--- a/tests/multinode.rs
+++ b/tests/multinode.rs
@@ -465,9 +465,9 @@ fn test_multi_node_dynamic_network() {
     }
     assert_eq!(consecutive_success, 10);
     for (_, node) in &validators {
-        node.notify_exit();
+        node.exit();
     }
-    server.notify_exit();
+    server.exit();
     for (_, node) in validators {
         node.close().unwrap();
     }

--- a/tests/multinode.rs
+++ b/tests/multinode.rs
@@ -11,6 +11,7 @@ use solana::fullnode::{FullNode, LedgerFile};
 use solana::logger;
 use solana::mint::Mint;
 use solana::ncp::Ncp;
+use solana::service::Service;
 use solana::signature::{KeyPair, KeyPairUtil, PublicKey};
 use solana::streamer::default_window;
 use solana::thin_client::ThinClient;
@@ -469,9 +470,9 @@ fn test_multi_node_dynamic_network() {
     }
     server.exit();
     for (_, node) in validators {
-        node.close().unwrap();
+        node.join().unwrap();
     }
-    server.close().unwrap();
+    server.join().unwrap();
 
     std::fs::remove_file(ledger_path).unwrap();
 }

--- a/tests/multinode.rs
+++ b/tests/multinode.rs
@@ -467,6 +467,7 @@ fn test_multi_node_dynamic_network() {
     for (_, node) in validators {
         node.notify_exit();
     }
+    server.notify_exit();
     for (_, node) in validators {
         node.close().unwrap();
     }

--- a/tests/multinode.rs
+++ b/tests/multinode.rs
@@ -464,7 +464,7 @@ fn test_multi_node_dynamic_network() {
         }
     }
     assert_eq!(consecutive_success, 10);
-    for (_, node) in validators {
+    for (_, node) in &validators {
         node.notify_exit();
     }
     server.notify_exit();


### PR DESCRIPTION
Multinode dynamic test was sequentially exiting validators which took over a minute, this allows it to notify all of them to exit before join.  Exit is no longer noticeable.  