### PR TITLE
snap: Add daemon plugs

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -59,18 +59,24 @@ apps:
     plugs:
       - network
       - home
-
   daemon-validator:
     daemon: simple
     command: validator.sh
-
+    plugs:
+      - network
+      - network-bind
   daemon-leader:
     daemon: simple
     command: leader.sh
-
+    plugs:
+      - network
+      - network-bind
   daemon-drone:
     daemon: simple
     command: drone.sh
+    plugs:
+      - network
+      - network-bind
 
 parts:
   solana:


### PR DESCRIPTION
Helps reduce log spew, and will be needed when we drop `--devmode`