### PR TITLE
Add metric for fullnode/drone panics

### DIFF
--- a/src/bin/drone.rs
+++ b/src/bin/drone.rs
@@ -24,8 +24,8 @@ use tokio_codec::{BytesCodec, Decoder};
 
 fn main() {
     env_logger::init();
-    set_panic_hook();
-    let matches = App::new("solana-client-demo")
+    set_panic_hook("drone");
+    let matches = App::new("drone")
         .arg(
             Arg::with_name("leader")
                 .short("l")

--- a/src/bin/drone.rs
+++ b/src/bin/drone.rs
@@ -12,6 +12,7 @@ use clap::{App, Arg};
 use solana::crdt::NodeInfo;
 use solana::drone::{Drone, DroneRequest};
 use solana::fullnode::Config;
+use solana::metrics::set_panic_hook;
 use solana::signature::read_keypair;
 use std::fs::File;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
@@ -23,6 +24,7 @@ use tokio_codec::{BytesCodec, Decoder};
 
 fn main() {
     env_logger::init();
+    set_panic_hook();
     let matches = App::new("solana-client-demo")
         .arg(
             Arg::with_name("leader")

--- a/src/bin/fullnode.rs
+++ b/src/bin/fullnode.rs
@@ -18,7 +18,7 @@ use std::process::exit;
 
 fn main() -> () {
     env_logger::init();
-    set_panic_hook();
+    set_panic_hook("fullnode");
     let matches = App::new("fullnode")
         .arg(
             Arg::with_name("identity")

--- a/src/bin/fullnode.rs
+++ b/src/bin/fullnode.rs
@@ -8,6 +8,7 @@ extern crate solana;
 use clap::{App, Arg};
 use solana::crdt::{NodeInfo, TestNode};
 use solana::fullnode::{Config, FullNode, LedgerFile};
+use solana::metrics::set_panic_hook;
 use solana::service::Service;
 use solana::signature::{KeyPair, KeyPairUtil};
 use std::fs::File;
@@ -17,6 +18,7 @@ use std::process::exit;
 
 fn main() -> () {
     env_logger::init();
+    set_panic_hook();
     let matches = App::new("fullnode")
         .arg(
             Arg::with_name("identity")

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -185,7 +185,7 @@ pub fn flush() {
 }
 
 /// Hook the panic handler to generate a data point on each panic
-pub fn set_panic_hook() {
+pub fn set_panic_hook(program: &'static str) {
     use std::panic;
     use std::sync::{Once, ONCE_INIT};
     static SET_HOOK: Once = ONCE_INIT;
@@ -195,12 +195,16 @@ pub fn set_panic_hook() {
             default_hook(ono);
             submit(
                 influxdb::Point::new("panic")
-                    .add_field(
+                    .add_tag("program", influxdb::Value::String(program.to_string()))
+                    .add_tag(
                         "thread",
                         influxdb::Value::String(
                             thread::current().name().unwrap_or("?").to_string(),
                         ),
                     )
+                    // The 'one' field exists to give Kapacitor Alerts a numerical value
+                    // to filter on
+                    .add_field("one", influxdb::Value::Integer(1))
                     .add_field(
                         "message",
                         influxdb::Value::String(


### PR DESCRIPTION
Fixes #651 

Eg:
```bash
$ influx -host metrics.solana.com -ssl -database scratch -execute 'SELECT * FROM "scratch"."autogen"."panic" WHERE time > now() - 10m'
name: panic
time                location                  message                                                                                                                                                 thread
----                --------                  -------                                                                                                                                                 ------
1531849375818000000 src/bin/fullnode.rs:24:22 panicked at 'oops, test panic', src/bin/fullnode.rs:24:22                                                                                                           ?
1531849585120000000 libcore/result.rs:945:5   panicked at 'called `Result::unwrap()` on an `Err` value: Os { code: 48, kind: AddrInUse, message: "Address already in use" }', libcore/result.rs:945:5 main
```