### PR TITLE
env variable for default metrics rate that gets set for counters

### DIFF
--- a/src/counter.rs
+++ b/src/counter.rs
@@ -1,9 +1,10 @@
 use influx_db_client as influxdb;
 use metrics;
+use std::env;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use timing;
 
-const INFLUX_RATE: usize = 100;
+const DEFAULT_METRICS_RATE: usize = 10;
 
 pub struct Counter {
     pub name: &'static str,
@@ -12,7 +13,7 @@ pub struct Counter {
     pub times: AtomicUsize,
     /// last accumulated value logged
     pub lastlog: AtomicUsize,
-    pub lograte: usize,
+    pub lograte: AtomicUsize,
 }
 
 macro_rules! create_counter {
@@ -22,7 +23,7 @@ macro_rules! create_counter {
             counts: AtomicUsize::new(0),
             times: AtomicUsize::new(0),
             lastlog: AtomicUsize::new(0),
-            lograte: $lograte,
+            lograte: AtomicUsize::new($lograte),
         }
     };
 }
@@ -35,7 +36,7 @@ macro_rules! inc_counter {
 
 macro_rules! inc_new_counter {
     ($name:expr, $count:expr) => {{
-        static mut INC_NEW_COUNTER: Counter = create_counter!($name, 10);
+        static mut INC_NEW_COUNTER: Counter = create_counter!($name, 0);
         inc_counter!(INC_NEW_COUNTER, $count);
     }};
     ($name:expr, $count:expr, $lograte:expr) => {{
@@ -45,11 +46,21 @@ macro_rules! inc_new_counter {
 }
 
 impl Counter {
+    fn default_log_rate() -> usize {
+        env::var("SOLANA_DEFAULT_METRICS_RATE")
+            .map(|x| x.parse().unwrap_or(DEFAULT_METRICS_RATE))
+            .unwrap_or(DEFAULT_METRICS_RATE)
+    }
     pub fn inc(&mut self, events: usize) {
         let counts = self.counts.fetch_add(events, Ordering::Relaxed);
         let times = self.times.fetch_add(1, Ordering::Relaxed);
-        let lastlog = self.lastlog.load(Ordering::Relaxed);
-        if times % self.lograte == 0 && times > 0 {
+        let mut lograte = self.lograte.load(Ordering::Relaxed);
+        if lograte == 0 {
+            lograte = Counter::default_log_rate();
+            self.lograte.store(lograte, Ordering::Relaxed);
+        }
+        if times % lograte == 0 && times > 0 {
+            let lastlog = self.lastlog.load(Ordering::Relaxed);
             info!(
                 "COUNTER:{{\"name\": \"{}\", \"counts\": {}, \"samples\": {},  \"now\": {}}}",
                 self.name,
@@ -57,8 +68,6 @@ impl Counter {
                 times,
                 timing::timestamp(),
             );
-        }
-        if times % INFLUX_RATE == 0 && times > 0 {
             metrics::submit(
                 influxdb::Point::new(&format!("counter-{}", self.name))
                     .add_field(
@@ -75,6 +84,7 @@ impl Counter {
 #[cfg(test)]
 mod tests {
     use counter::Counter;
+    use std::env;
     use std::sync::atomic::{AtomicUsize, Ordering};
     #[test]
     fn test_counter() {
@@ -84,7 +94,7 @@ mod tests {
         unsafe {
             assert_eq!(COUNTER.counts.load(Ordering::Relaxed), 1);
             assert_eq!(COUNTER.times.load(Ordering::Relaxed), 1);
-            assert_eq!(COUNTER.lograte, 100);
+            assert_eq!(COUNTER.lograte.load(Ordering::Relaxed), 100);
             assert_eq!(COUNTER.lastlog.load(Ordering::Relaxed), 0);
             assert_eq!(COUNTER.name, "test");
         }
@@ -105,5 +115,22 @@ mod tests {
         //the variable is internal to the macro scope so there is no way to introspect it
         inc_new_counter!("counter-1", 1);
         inc_new_counter!("counter-2", 1, 2);
+    }
+    #[test]
+    fn test_lograte() {
+        static mut COUNTER: Counter = create_counter!("test_lograte", 0);
+        inc_counter!(COUNTER, 2);
+        unsafe {
+            assert_eq!(COUNTER.lograte.load(Ordering::Relaxed), 10);
+        }
+    }
+    #[test]
+    fn test_lograte_env() {
+        static mut COUNTER: Counter = create_counter!("test_lograte_env", 0);
+        env::set_var("SOLANA_DEFAULT_METRICS_RATE", "50");
+        inc_counter!(COUNTER, 2);
+        unsafe {
+            assert_eq!(COUNTER.lograte.load(Ordering::Relaxed), 50);
+        }
     }
 }

--- a/tests/multinode.rs
+++ b/tests/multinode.rs
@@ -15,6 +15,7 @@ use solana::service::Service;
 use solana::signature::{KeyPair, KeyPairUtil, PublicKey};
 use solana::streamer::default_window;
 use solana::thin_client::ThinClient;
+use std::env;
 use std::fs::File;
 use std::net::UdpSocket;
 use std::sync::atomic::AtomicBool;
@@ -368,6 +369,7 @@ fn test_leader_restart_validator_start_from_old_ledger() {
 #[test]
 #[ignore]
 fn test_multi_node_dynamic_network() {
+    env::set_var("SOLANA_DEFAULT_METRICS_RATE", "100");
     logger::setup();
     const N: usize = 60;
     let leader = TestNode::new_localhost();


### PR DESCRIPTION
Dynamically set the metrics rate based on the env var.  Verified that there is no performance hit to the multinode dynamic test.

@pgarg66 the scripts that boot the network can set this variable to some value