### PR TITLE
Permit more than the requested amount of nodes

### DIFF
--- a/src/bin/client-demo.rs
+++ b/src/bin/client-demo.rs
@@ -225,7 +225,8 @@ fn main() {
     let signal = Arc::new(AtomicBool::new(false));
     let mut c_threads = vec![];
     let validators = converge(&leader, &signal, num_nodes, &mut c_threads);
-    assert_eq!(validators.len(), num_nodes);
+    println!("Network has {} node(s)", validators.len());
+    assert!(validators.len() >= num_nodes);
 
     let mut client = mk_client(&leader);
 
@@ -417,6 +418,12 @@ fn converge(
             println!("CONVERGED!");
             rv.extend(v.into_iter());
             break;
+        } else {
+            println!(
+                "{} node(s) discovered (looking for {} or more)",
+                v.len(),
+                num_nodes
+            );
         }
         sleep(Duration::new(1, 0));
     }


### PR DESCRIPTION
This certainly avoids the assert at #678 but I'd like to still understand why it's occurring before landing anything like this patch 