### PR TITLE
replace 'daddr' checks with 'is_valid_address()'

### DIFF
--- a/src/bin/client-demo.rs
+++ b/src/bin/client-demo.rs
@@ -396,7 +396,6 @@ fn converge(
     threads: &mut Vec<JoinHandle<()>>,
 ) -> Vec<NodeInfo> {
     //lets spy on the network
-    let daddr = "0.0.0.0:0".parse().unwrap();
     let (spy, spy_gossip) = spy_node();
     let mut spy_crdt = Crdt::new(spy).expect("Crdt::new");
     spy_crdt.insert(&leader);
@@ -420,7 +419,7 @@ fn converge(
             .table
             .values()
             .into_iter()
-            .filter(|x| x.contact_info.rpu != daddr)
+            .filter(|x| Crdt::is_valid_address(x.contact_info.rpu))
             .cloned()
             .collect();
         if v.len() >= num_nodes {

--- a/src/crdt.rs
+++ b/src/crdt.rs
@@ -1376,12 +1376,6 @@ mod tests {
             "0.0.0.0:0".parse().unwrap(),
         );
         assert_eq!(Crdt::new(d8).is_ok(), true);
-        let bad_address_port = "127.0.0.1:0".parse().unwrap();
-        let bad_address_unspecified = "0.0.0.0:1234".parse().unwrap();
-        let bad_address_multicast = "224.254.0.0:1234".parse().unwrap();
-        assert!(!Crdt::is_valid_address(bad_address_port));
-        assert!(!Crdt::is_valid_address(bad_address_unspecified));
-        assert!(!Crdt::is_valid_address(bad_address_multicast));
     }
 
     #[test]
@@ -1924,5 +1918,15 @@ mod tests {
         assert!(!me.alive.contains_key(&node.id));
         assert!(!me.alive.contains_key(&node_with_same_addr.id));
         assert!(me.alive[&node_with_diff_addr.id] > 0);
+    }
+    
+    #[test]
+    fn test_is_valid_address() {
+        let bad_address_port = "127.0.0.1:0".parse().unwrap();
+        assert!(!Crdt::is_valid_address(bad_address_port));
+        let bad_address_unspecified = "0.0.0.0:1234".parse().unwrap();
+        assert!(!Crdt::is_valid_address(bad_address_unspecified));
+        let bad_address_multicast = "224.254.0.0:1234".parse().unwrap();
+        assert!(!Crdt::is_valid_address(bad_address_multicast));
     }
 }

--- a/src/crdt.rs
+++ b/src/crdt.rs
@@ -1142,7 +1142,7 @@ impl Crdt {
     }
 
     pub fn is_valid_address(addr: SocketAddr) -> bool {
-        (addr.port() != 0) && !(addr.ip().is_unspecified() || addr.ip().is_multicast()) 
+        (addr.port() != 0) && !(addr.ip().is_unspecified() || addr.ip().is_multicast())
     }
 }
 
@@ -1376,6 +1376,12 @@ mod tests {
             "0.0.0.0:0".parse().unwrap(),
         );
         assert_eq!(Crdt::new(d8).is_ok(), true);
+        let bad_address_port = "127.0.0.1:0".parse().unwrap();
+        let bad_address_unspecified = "0.0.0.0:1234".parse().unwrap();
+        let bad_address_multicast = "224.254.0.0:1234".parse().unwrap();
+        assert!(!Crdt::is_valid_address(bad_address_port));
+        assert!(!Crdt::is_valid_address(bad_address_unspecified));
+        assert!(!Crdt::is_valid_address(bad_address_multicast));
     }
 
     #[test]

--- a/tests/multinode.rs
+++ b/tests/multinode.rs
@@ -54,7 +54,7 @@ fn converge(leader: &NodeInfo, num_nodes: usize) -> Vec<NodeInfo> {
             .values()
             .into_iter()
             .filter(|x| x.id != me)
-            .filter(|x| x.contact_info.rpu != daddr)
+            .filter(|x| Crdt::is_valid_address(x.contact_info.rpu))
             .cloned()
             .collect();
         if num >= num_nodes as u64 && v.len() >= num_nodes {
@@ -483,9 +483,8 @@ fn mk_client(leader: &NodeInfo) -> ThinClient {
         .set_read_timeout(Some(Duration::new(1, 0)))
         .unwrap();
     let transactions_socket = UdpSocket::bind("0.0.0.0:0").unwrap();
-    let daddr = "0.0.0.0:0".parse().unwrap();
-    assert!(leader.contact_info.rpu != daddr);
-    assert!(leader.contact_info.tpu != daddr);
+    assert!(Crdt::is_valid_address(leader.contact_info.rpu));
+    assert!(Crdt::is_valid_address(leader.contact_info.tpu));
     ThinClient::new(
         leader.contact_info.rpu,
         requests_socket,


### PR DESCRIPTION
defined a new function `is_valid_address` as suggested in #656 to use Rust's `ip().is_unspecified()` and `ip().is_multicast()` functions instead of comparing against `0.0.0.0:0`