### PR TITLE
Install llvm-cov on nightly to revive coverage

### DIFF
--- a/ci/docker-rust-nightly/Dockerfile
+++ b/ci/docker-rust-nightly/Dockerfile
@@ -1,3 +1,6 @@
 FROM rustlang/rust:nightly
 
-RUN cargo install --force clippy cargo-cov
+RUN cargo install --force clippy cargo-cov && \
+    echo deb http://ftp.debian.org/debian stretch-backports main >> /etc/apt/sources.list && \
+    apt update && \
+    apt install -y llvm-6.0

--- a/ci/test-nightly.sh
+++ b/ci/test-nightly.sh
@@ -15,9 +15,6 @@ _ cargo build --verbose --features unstable
 _ cargo test --verbose --features unstable
 _ cargo clippy -- --deny=warnings
 
-exit 0
-
-# Coverage disabled (see issue #433)
 _ cargo cov test
 _ cargo cov report
 
@@ -27,6 +24,6 @@ ls -l target/cov/report/index.html
 if [[ -z "$CODECOV_TOKEN" ]]; then
   echo CODECOV_TOKEN undefined
 else
-  bash <(curl -s https://codecov.io/bash) -x 'llvm-cov gcov'
+  bash <(curl -s https://codecov.io/bash) -x 'llvm-cov-6.0 gcov'
 fi
 


### PR DESCRIPTION
Not sure if this works. `docker run` failing for unrelated reasons locally. These are the commands it took to get llvm-cov 6.0 installed, which is the version the `cargo cov` README recommends installing on Ubuntu/Debian.

Towards #433 