### PR TITLE
Voting leader [wip] something is busted

### DIFF
--- a/src/bank.rs
+++ b/src/bank.rs
@@ -176,6 +176,14 @@ impl Bank {
         }
         Err(BankError::LastIdNotFound(*last_id))
     }
+    /// Look through the last_ids and find all the valid ids
+    /// This is batched to avoid holding the lock for a significant amount of time
+    pub fn count_valid_ids(&self, ids: &[Hash]) -> usize {
+        let last_ids = self.last_ids_sigs.read().unwrap();
+        ids.iter()
+            .map(|id| last_ids.get(id).is_some() as usize)
+            .sum()
+    }
 
     /// Tell the bank which Entry IDs exist on the ledger. This function
     /// assumes subsequent calls correspond to later entries, and will boot
@@ -742,7 +750,22 @@ mod tests {
             Err(BankError::LastIdNotFound(mint.last_id()))
         );
     }
-
+    #[test]
+    fn test_cound_valid_ids() {
+        let mint = Mint::new(1);
+        let bank = Bank::new(&mint);
+        let sig = Signature::default();
+        let ids: Vec<_> = (0..MAX_ENTRY_IDS)
+            .map(|i| {
+                let last_id = hash(&serialize(&i).unwrap()); // Unique hash
+                bank.register_entry_id(&last_id);
+                last_id
+            })
+            .collect();
+        assert_eq!(bank.count_valid_ids(&[]), 0);
+        assert_eq!(bank.count_valid_ids(&[mint.last_id()]), 0);
+        assert_eq!(bank.count_valid_ids(&ids), ids.len());
+    }
     #[test]
     fn test_debits_before_credits() {
         let mint = Mint::new(2);

--- a/src/bank.rs
+++ b/src/bank.rs
@@ -754,7 +754,6 @@ mod tests {
     fn test_cound_valid_ids() {
         let mint = Mint::new(1);
         let bank = Bank::new(&mint);
-        let sig = Signature::default();
         let ids: Vec<_> = (0..MAX_ENTRY_IDS)
             .map(|i| {
                 let last_id = hash(&serialize(&i).unwrap()); // Unique hash

--- a/src/bin/fullnode.rs
+++ b/src/bin/fullnode.rs
@@ -76,11 +76,11 @@ fn main() -> () {
         let testnet_address_string = t.to_string();
         let testnet_addr = testnet_address_string.parse().unwrap();
 
-        FullNode::new(node, false, ledger, Some(keypair), Some(testnet_addr))
+        FullNode::new(node, false, ledger, keypair, Some(testnet_addr))
     } else {
         node.data.leader_id = node.data.id;
 
-        FullNode::new(node, true, ledger, None, None)
+        FullNode::new(node, true, ledger, keypair, None)
     };
     fullnode.join().expect("join");
 }

--- a/src/crdt.rs
+++ b/src/crdt.rs
@@ -132,7 +132,7 @@ pub struct NodeInfo {
     /// current leader identity
     pub leader_id: PublicKey,
     /// information about the state of the ledger
-    ledger_state: LedgerState,
+    pub ledger_state: LedgerState,
 }
 
 fn make_debug_id(buf: &[u8]) -> u64 {

--- a/src/crdt.rs
+++ b/src/crdt.rs
@@ -353,7 +353,7 @@ impl Crdt {
             warn!(
                 "{:x}: VOTE for unknown id: {:x}",
                 self.debug_id(),
-                make_debug_id(&pubkey)
+                make_debug_id(pubkey)
             );
             return;
         }
@@ -367,6 +367,15 @@ impl Crdt {
             );
             return;
         }
+        if *pubkey == self.my_data().leader_id {
+            info!(
+                "{:x}: LEADER_VOTED! {:x}",
+                self.debug_id(),
+                make_debug_id(&pubkey)
+            );
+            inc_new_counter!("crdt-insert_vote-leader_voted", 1);
+        }
+
         if v.version <= self.table[pubkey].version {
             debug!(
                 "{:x}: VOTE for old version: {:x}",
@@ -379,11 +388,13 @@ impl Crdt {
             let mut data = self.table[pubkey].clone();
             data.version = v.version;
             data.ledger_state.last_id = last_id;
+
             debug!(
                 "{:x}: INSERTING VOTE! for {:x}",
                 self.debug_id(),
                 data.debug_id()
             );
+            self.update_liveness(data.id);
             self.insert(&data);
         }
     }
@@ -1124,7 +1135,7 @@ impl Crdt {
                     return;
                 }
                 if e.is_err() {
-                    info!(
+                    debug!(
                         "{:x}: run_listen timeout, table size: {}",
                         debug_id,
                         obj.read().unwrap().table.len()

--- a/src/crdt.rs
+++ b/src/crdt.rs
@@ -367,7 +367,6 @@ impl Crdt {
             );
             return;
         }
-        self.update_leader_liveness();
         if v.version <= self.table[pubkey].version {
             debug!(
                 "{:x}: VOTE for old version: {:x}",
@@ -386,15 +385,6 @@ impl Crdt {
                 data.debug_id()
             );
             self.insert(&data);
-        }
-    }
-    fn update_leader_liveness(&mut self) {
-        //TODO: (leaders should vote)
-        //until then we pet their liveness every time we see some votes from anyone
-        let ld = self.leader_data().map(|x| x.id);
-        trace!("leader_id {:?}", ld);
-        if let Some(leader_id) = ld {
-            self.update_liveness(leader_id);
         }
     }
     pub fn insert_votes(&mut self, votes: &[(PublicKey, Vote, Hash)]) {
@@ -1466,34 +1456,6 @@ mod tests {
         //should be accepted, since the update is for the same address field as the one we know
         assert_eq!(crdt.table[&d.id].version, 1);
     }
-
-    #[test]
-    fn test_insert_vote_leader_liveness() {
-        logger::setup();
-        // TODO: remove this test once leaders vote
-        let d = NodeInfo::new_leader(&"127.0.0.1:1234".parse().unwrap());
-        assert_eq!(d.version, 0);
-        let mut crdt = Crdt::new(d.clone()).unwrap();
-        let leader = NodeInfo::new_leader(&"127.0.0.2:1235".parse().unwrap());
-        assert_ne!(d.id, leader.id);
-        crdt.insert(&leader);
-        crdt.set_leader(leader.id);
-        let live: u64 = crdt.alive[&leader.id];
-        trace!("{:x} live {}", leader.debug_id(), live);
-        let vote_new_version_old_addrs = Vote {
-            version: d.version + 1,
-            contact_info_version: 0,
-        };
-        sleep(Duration::from_millis(100));
-        let votes = vec![(d.id.clone(), vote_new_version_old_addrs, Hash::default())];
-        crdt.insert_votes(&votes);
-        let updated = crdt.alive[&leader.id];
-        //should be accepted, since the update is for the same address field as the one we know
-        assert_eq!(crdt.table[&d.id].version, 1);
-        trace!("{:x} {} {}", leader.debug_id(), updated, live);
-        assert!(updated > live);
-    }
-
     fn sorted(ls: &Vec<NodeInfo>) -> Vec<NodeInfo> {
         let mut copy: Vec<_> = ls.iter().cloned().collect();
         copy.sort_by(|x, y| x.id.cmp(&y.id));

--- a/src/drone.rs
+++ b/src/drone.rs
@@ -266,7 +266,8 @@ mod tests {
         const TPS_BATCH: i64 = 5_000_000;
 
         logger::setup();
-        let leader = TestNode::new_localhost();
+        let leader_kp = KeyPair::new();
+        let leader = TestNode::new_localhost_with_pubkey(leader_kp.pubkey());
 
         let alice = Mint::new(10_000_000);
         let bank = Bank::new(&alice);
@@ -276,6 +277,7 @@ mod tests {
         let leader_data = leader.data.clone();
 
         let server = FullNode::new_leader(
+            leader_kp,
             bank,
             0,
             None,

--- a/src/fullnode.rs
+++ b/src/fullnode.rs
@@ -103,7 +103,6 @@ impl FullNode {
             let testnet_addr = network_entry_for_validator.expect("validator requires entry");
 
             let network_entry_point = NodeInfo::new_entry_point(testnet_addr);
-            let keypair = keypair_for_validator.expect("validator requires keypair");
             let server = FullNode::new_validator(
                 keypair,
                 bank,

--- a/src/fullnode.rs
+++ b/src/fullnode.rs
@@ -62,7 +62,7 @@ impl FullNode {
         mut node: TestNode,
         leader: bool,
         ledger: LedgerFile,
-        keypair_for_validator: Option<KeyPair>,
+        keypair: KeyPair,
         network_entry_for_validator: Option<SocketAddr>,
     ) -> FullNode {
         info!("creating bank...");
@@ -122,6 +122,7 @@ impl FullNode {
             node.data.leader_id = node.data.id;
 
             let server = FullNode::new_leader(
+                keypair,
                 bank,
                 entry_height,
                 Some(ledger_tail),
@@ -184,6 +185,7 @@ impl FullNode {
     ///              `---------------------`
     /// ```
     pub fn new_leader<W: Write + Send + 'static>(
+        keypair: KeyPair,
         bank: Bank,
         entry_height: u64,
         ledger_tail: Option<Vec<Entry>>,
@@ -205,6 +207,7 @@ impl FullNode {
         let blob_recycler = BlobRecycler::default();
         let crdt = Arc::new(RwLock::new(Crdt::new(node.data).expect("Crdt::new")));
         let (tpu, blob_receiver) = Tpu::new(
+            keypair,
             &bank,
             &crdt,
             tick_duration,

--- a/src/thin_client.rs
+++ b/src/thin_client.rs
@@ -274,7 +274,8 @@ mod tests {
     #[test]
     fn test_thin_client() {
         logger::setup();
-        let leader = TestNode::new_localhost();
+        let leader_kp = KeyPair::new();
+        let leader = TestNode::new_localhost_with_pubkey(leader_kp.pubkey());
         let leader_data = leader.data.clone();
 
         let alice = Mint::new(10_000);
@@ -283,6 +284,7 @@ mod tests {
         let exit = Arc::new(AtomicBool::new(false));
 
         let server = FullNode::new_leader(
+            leader_kp,
             bank,
             0,
             None,
@@ -317,7 +319,8 @@ mod tests {
     #[ignore]
     fn test_bad_sig() {
         logger::setup();
-        let leader = TestNode::new_localhost();
+        let leader_kp = KeyPair::new();
+        let leader = TestNode::new_localhost_with_pubkey(leader_kp.pubkey());
         let alice = Mint::new(10_000);
         let bank = Bank::new(&alice);
         let bob_pubkey = KeyPair::new().pubkey();
@@ -325,6 +328,7 @@ mod tests {
         let leader_data = leader.data.clone();
 
         let server = FullNode::new_leader(
+            leader_kp,
             bank,
             0,
             None,
@@ -371,13 +375,15 @@ mod tests {
     #[test]
     fn test_client_check_signature() {
         logger::setup();
-        let leader = TestNode::new_localhost();
+        let leader_kp = KeyPair::new();
+        let leader = TestNode::new_localhost_with_pubkey(leader_kp.pubkey());
         let alice = Mint::new(10_000);
         let bank = Bank::new(&alice);
         let bob_pubkey = KeyPair::new().pubkey();
         let exit = Arc::new(AtomicBool::new(false));
         let leader_data = leader.data.clone();
         let server = FullNode::new_leader(
+            leader_kp,
             bank,
             0,
             None,

--- a/src/tpu.rs
+++ b/src/tpu.rs
@@ -52,6 +52,7 @@ pub struct Tpu {
 
 impl Tpu {
     pub fn new<W: Write + Send + 'static>(
+        keypair: KeyPair,
         bank: &Arc<Bank>,
         crdt: &Arc<RwLock<Crdt>>,
         tick_duration: Option<Duration>,
@@ -78,6 +79,7 @@ impl Tpu {
         };
 
         let (write_stage, blob_receiver) = WriteStage::new(
+            keypair,
             bank.clone(),
             crdt.clone(),
             blob_recycler.clone(),

--- a/src/tpu.rs
+++ b/src/tpu.rs
@@ -32,6 +32,7 @@ use fetch_stage::FetchStage;
 use packet::{BlobRecycler, PacketRecycler};
 use record_stage::RecordStage;
 use service::Service;
+use signature::KeyPair;
 use sigverify_stage::SigVerifyStage;
 use std::io::Write;
 use std::net::UdpSocket;

--- a/src/voting.rs
+++ b/src/voting.rs
@@ -1,21 +1,18 @@
 use entry::Entry;
 use hash::Hash;
 use signature::PublicKey;
-use transaction::{Instruction, Vote};
+use transaction::{Instruction, Transaction, Vote};
 
 pub fn entries_to_votes(entries: &[Entry]) -> Vec<(PublicKey, Vote, Hash)> {
     entries
         .iter()
-        .flat_map(|entry| {
-            let vs: Vec<(PublicKey, Vote, Hash)> = entry
-                .transactions
-                .iter()
-                .filter_map(|tx| match tx.instruction {
-                    Instruction::NewVote(ref vote) => Some((tx.from, vote.clone(), tx.last_id)),
-                    _ => None,
-                })
-                .collect();
-            vs
-        })
+        .flat_map(|entry| entry.transactions.iter().filter_map(transaction_to_vote))
         .collect()
+}
+
+pub fn transaction_to_vote(tx: &Transaction) -> Option<(PublicKey, Vote, Hash)> {
+    match tx.instruction {
+        Instruction::NewVote(ref vote) => Some((tx.from, vote.clone(), tx.last_id)),
+        _ => None,
+    }
 }

--- a/src/write_stage.rs
+++ b/src/write_stage.rs
@@ -66,7 +66,8 @@ impl WriteStage {
                 .map(|x| x.ledger_state.last_id)
                 .collect();
             let total = bank.count_valid_ids(&ids);
-            if total > 2 * ids.len() / 3 {
+            //TODO(anatoly): this isn't stake based voting
+            if total > (2 * ids.len()) / 3 {
                 *last_vote = now;
                 let last_id = bank.last_id();
                 let shared_blob = blob_recycler.allocate();

--- a/src/write_stage.rs
+++ b/src/write_stage.rs
@@ -3,6 +3,7 @@
 //! stdout, and then sends the Entry to its output channel.
 
 use bank::Bank;
+use bincode::serialize;
 use counter::Counter;
 use crdt::Crdt;
 use entry::Entry;
@@ -11,6 +12,7 @@ use ledger::Block;
 use packet::BlobRecycler;
 use result::{Error, Result};
 use service::Service;
+use signature::KeyPair;
 use std::collections::VecDeque;
 use std::io::Write;
 use std::sync::atomic::AtomicUsize;
@@ -19,29 +21,67 @@ use std::sync::{Arc, RwLock};
 use std::thread::{self, Builder, JoinHandle};
 use std::time::Duration;
 use streamer::{BlobReceiver, BlobSender};
+use timing;
+use transaction::Transaction;
 use voting::entries_to_votes;
 
 pub struct WriteStage {
     thread_hdl: JoinHandle<()>,
 }
 
+const VOTE_TIMEOUT_MS: u64 = 1000;
+
 impl WriteStage {
     /// Process any Entry items that have been published by the RecordStage.
     /// continuosly broadcast blobs of entries out
     pub fn write_and_send_entries<W: Write>(
+        keypair: &KeyPair,
+        bank: &Arc<Bank>,
         crdt: &Arc<RwLock<Crdt>>,
         entry_writer: &mut EntryWriter<W>,
         blob_sender: &BlobSender,
         blob_recycler: &BlobRecycler,
         entry_receiver: &Receiver<Vec<Entry>>,
+        last_vote: &mut u64,
     ) -> Result<()> {
         let entries = entry_receiver.recv_timeout(Duration::new(1, 0))?;
         let votes = entries_to_votes(&entries);
         crdt.write().unwrap().insert_votes(&votes);
+
+        //TODO(anatoly): real stake based voting needs to change this
+        //leader simply votes if the current set of validators have voted
+        //on a valid last id
         entry_writer.write_and_register_entries(&entries)?;
         trace!("New blobs? {}", entries.len());
         let mut blobs = VecDeque::new();
         entries.to_blobs(blob_recycler, &mut blobs);
+
+        let now = timing::timestamp();
+        if now - *last_vote > VOTE_TIMEOUT_MS {
+            //TODO(anatoly): vote if the last id set is mostly valid
+            let ids: Vec<_> = crdt.read()
+                .unwrap()
+                .table
+                .values()
+                .map(|x| x.ledger_state.last_id)
+                .collect();
+            let total = bank.count_valid_ids(&ids);
+            if total > 2 * ids.len() / 3 {
+                *last_vote = now;
+                let last_id = bank.last_id();
+                let shared_blob = blob_recycler.allocate();
+                let (vote, addr) = crdt.write().unwrap().new_vote(last_id)?;
+                let tx = Transaction::new_vote(&keypair, vote, last_id, 0);
+                let bytes = serialize(&tx)?;
+                let len = bytes.len();
+                {
+                    let mut blob = shared_blob.write().unwrap();
+                    blob.data[..len].copy_from_slice(&bytes);
+                    blob.meta.set_addr(&addr);
+                    blob.meta.size = len;
+                }
+            }
+        }
         if !blobs.is_empty() {
             inc_new_counter!("write_stage-broadcast_vote-count", votes.len());
             inc_new_counter!("write_stage-broadcast_blobs-count", blobs.len());
@@ -53,6 +93,7 @@ impl WriteStage {
 
     /// Create a new WriteStage for writing and broadcasting entries.
     pub fn new<W: Write + Send + 'static>(
+        keypair: KeyPair,
         bank: Arc<Bank>,
         crdt: Arc<RwLock<Crdt>>,
         blob_recycler: BlobRecycler,
@@ -64,13 +105,17 @@ impl WriteStage {
             .name("solana-writer".to_string())
             .spawn(move || {
                 let mut entry_writer = EntryWriter::new(&bank, writer);
+                let mut last_vote = 0;
                 loop {
                     if let Err(e) = Self::write_and_send_entries(
+                        &keypair,
+                        &bank,
                         &crdt,
                         &mut entry_writer,
                         &blob_sender,
                         &blob_recycler,
                         &entry_receiver,
+                        &mut last_vote,
                     ) {
                         match e {
                             Error::RecvTimeoutError(RecvTimeoutError::Disconnected) => break,

--- a/src/write_stage.rs
+++ b/src/write_stage.rs
@@ -81,11 +81,13 @@ impl WriteStage {
                     blob.meta.set_addr(&addr);
                     blob.meta.size = len;
                 }
+                blobs.append(shared_blob);
+                inc_new_counter!("write_stage-broadcast_sent_vote", 1);
             }
         }
         if !blobs.is_empty() {
-            inc_new_counter!("write_stage-broadcast_vote-count", votes.len());
-            inc_new_counter!("write_stage-broadcast_blobs-count", blobs.len());
+            inc_new_counter!("write_stage-broadcast_recv_vote", votes.len());
+            inc_new_counter!("write_stage-broadcast_blobs", blobs.len());
             trace!("broadcasting {}", blobs.len());
             blob_sender.send(blobs)?;
         }

--- a/tests/multinode.rs
+++ b/tests/multinode.rs
@@ -87,7 +87,8 @@ fn test_multi_node_validator_catchup_from_zero() {
     logger::setup();
     const N: usize = 5;
     trace!("test_multi_node_validator_catchup_from_zero");
-    let leader = TestNode::new_localhost();
+    let leader_kp = KeyPair::new();
+    let leader = TestNode::new_localhost_with_pubkey(leader_kp.pubkey());
     let leader_data = leader.data.clone();
     let bob_pubkey = KeyPair::new().pubkey();
 
@@ -96,7 +97,7 @@ fn test_multi_node_validator_catchup_from_zero() {
         leader,
         true,
         LedgerFile::Path(ledger_path.clone()),
-        None,
+        leader_kp,
         None,
     );
     let mut nodes = vec![server];
@@ -107,7 +108,7 @@ fn test_multi_node_validator_catchup_from_zero() {
             validator,
             false,
             LedgerFile::Path(ledger_path.clone()),
-            Some(keypair),
+            keypair,
             Some(leader_data.contact_info.ncp),
         );
         nodes.push(val);
@@ -141,7 +142,7 @@ fn test_multi_node_validator_catchup_from_zero() {
         validator,
         false,
         LedgerFile::Path(ledger_path.clone()),
-        Some(keypair),
+        keypair,
         Some(leader_data.contact_info.ncp),
     );
     nodes.push(val);
@@ -187,7 +188,8 @@ fn test_multi_node_basic() {
     logger::setup();
     const N: usize = 5;
     trace!("test_multi_node_basic");
-    let leader = TestNode::new_localhost();
+    let leader_kp = KeyPair::new();
+    let leader = TestNode::new_localhost_with_pubkey(leader_kp.pubkey());
     let leader_data = leader.data.clone();
     let bob_pubkey = KeyPair::new().pubkey();
     let (alice, ledger_path) = genesis(10_000);
@@ -195,7 +197,7 @@ fn test_multi_node_basic() {
         leader,
         true,
         LedgerFile::Path(ledger_path.clone()),
-        None,
+        leader_kp,
         None,
     );
     let mut nodes = vec![server];
@@ -206,7 +208,7 @@ fn test_multi_node_basic() {
             validator,
             false,
             LedgerFile::Path(ledger_path.clone()),
-            Some(keypair),
+            keypair,
             Some(leader_data.contact_info.ncp),
         );
         nodes.push(val);
@@ -240,7 +242,8 @@ fn test_multi_node_basic() {
 #[test]
 fn test_boot_validator_from_file() {
     logger::setup();
-    let leader = TestNode::new_localhost();
+    let leader_kp = KeyPair::new();
+    let leader = TestNode::new_localhost_with_pubkey(leader_kp.pubkey());
     let bob_pubkey = KeyPair::new().pubkey();
     let (alice, ledger_path) = genesis(100_000);
     let leader_data = leader.data.clone();
@@ -248,7 +251,7 @@ fn test_boot_validator_from_file() {
         leader,
         true,
         LedgerFile::Path(ledger_path.clone()),
-        None,
+        leader_kp,
         None,
     );
     let leader_balance =
@@ -265,7 +268,7 @@ fn test_boot_validator_from_file() {
         validator,
         false,
         LedgerFile::Path(ledger_path.clone()),
-        Some(keypair),
+        keypair,
         Some(leader_data.contact_info.ncp),
     );
     let mut client = mk_client(&validator_data);
@@ -278,13 +281,14 @@ fn test_boot_validator_from_file() {
 }
 
 fn create_leader(ledger_path: &str) -> (NodeInfo, FullNode) {
-    let leader = TestNode::new_localhost();
+    let leader_kp = KeyPair::new();
+    let leader = TestNode::new_localhost_with_pubkey(leader_kp.pubkey());
     let leader_data = leader.data.clone();
     let leader_fullnode = FullNode::new(
         leader,
         true,
         LedgerFile::Path(ledger_path.to_string()),
-        None,
+        leader_kp,
         None,
     );
     (leader_data, leader_fullnode)
@@ -335,7 +339,7 @@ fn test_leader_restart_validator_start_from_old_ledger() {
         validator,
         false,
         LedgerFile::Path(stale_ledger_path.clone()),
-        Some(keypair),
+        keypair,
         Some(leader_data.contact_info.ncp),
     );
 
@@ -370,7 +374,8 @@ fn test_leader_restart_validator_start_from_old_ledger() {
 fn test_multi_node_dynamic_network() {
     logger::setup();
     const N: usize = 60;
-    let leader = TestNode::new_localhost();
+    let leader_kp = KeyPair::new();
+    let leader = TestNode::new_localhost_with_pubkey(leader_kp.pubkey());
     let bob_pubkey = KeyPair::new().pubkey();
     let (alice, ledger_path) = genesis(100_000);
     let leader_data = leader.data.clone();
@@ -378,7 +383,7 @@ fn test_multi_node_dynamic_network() {
         leader,
         true,
         LedgerFile::Path(ledger_path.clone()),
-        None,
+        leader_kp,
         None,
     );
     info!("{:x} LEADER", leader_data.debug_id());
@@ -403,7 +408,7 @@ fn test_multi_node_dynamic_network() {
                 validator,
                 false,
                 LedgerFile::Path(ledger_path.clone()),
-                Some(keypair),
+                keypair,
                 Some(leader_data.contact_info.ncp),
             );
             info!("started[{}/{}] {:x}", n, N, rd.debug_id());

--- a/tests/multinode.rs
+++ b/tests/multinode.rs
@@ -373,7 +373,7 @@ fn test_leader_restart_validator_start_from_old_ledger() {
 #[ignore]
 fn test_multi_node_dynamic_network() {
     logger::setup();
-    const N: usize = 60;
+    const N: usize = 25;
     let leader_kp = KeyPair::new();
     let leader = TestNode::new_localhost_with_pubkey(leader_kp.pubkey());
     let bob_pubkey = KeyPair::new().pubkey();


### PR DESCRIPTION
Leaders will continue voting if the members of the network are all on valid last ids.  This removes a hack in the current voting code which updates the leader whenever any vote is registered.

This isn't correct for consensus, since for consensus the leader needs to keep track of what height each validator has voted on, and vote when 2/3rds of them have moved forward and vote for the new height.