### PR TITLE
flush writer, makes partial deserialization a bit less likely

### DIFF
--- a/src/entry_writer.rs
+++ b/src/entry_writer.rs
@@ -20,7 +20,8 @@ impl<'a, W: Write> EntryWriter<'a, W> {
 
     fn write_entry(writer: &mut W, entry: &Entry) -> io::Result<()> {
         let serialized = serde_json::to_string(entry).unwrap();
-        writeln!(writer, "{}", serialized)
+        writeln!(writer, "{}", serialized)?;
+        writer.flush()
     }
 
     pub fn write_entries<I>(writer: &mut W, entries: I) -> io::Result<()>


### PR DESCRIPTION
Validators may barf on partially serialized output of an entry to the leader's persistent ledger

This change makes that a bit less likely, but isn't a complete solution, which is a re-write of the persistent ledger, a part of which is covered by issue #698.
