### PR TITLE
Move long benches

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,10 @@ name = "solana-bench-tps"
 path = "src/bin/bench-tps.rs"
 
 [[bin]]
+name = "solana-bench-streamer"
+path = "src/bin/bench-streamer.rs"
+
+[[bin]]
 name = "solana-wallet"
 path = "src/bin/wallet.rs"
 
@@ -104,8 +108,4 @@ harness = false
 
 [[bench]]
 name = "signature"
-harness = false
-
-[[bench]]
-name = "streamer"
 harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,8 @@ authors = [
 license = "Apache-2.0"
 
 [[bin]]
-name = "solana-client-demo"
-path = "src/bin/client-demo.rs"
+name = "solana-bench-tps"
+path = "src/bin/bench-tps.rs"
 
 [[bin]]
 name = "solana-wallet"

--- a/ci/testnet-sanity.sh
+++ b/ci/testnet-sanity.sh
@@ -30,7 +30,7 @@ else
   if [[ -n "$USE_SNAP" ]]; then
     # TODO: Merge client.sh functionality into solana-client-demo proper and
     #       remove this USE_SNAP case
-    cmd=$solana_client_demo
+    cmd=$solana_bench_tps
   else
     cmd=multinode-demo/client.sh
   fi

--- a/multinode-demo/client.sh
+++ b/multinode-demo/client.sh
@@ -46,7 +46,7 @@ while true; do
     client_json="$SOLANA_CONFIG_CLIENT_DIR"/client.json
     [[ -r $client_json ]] || $solana_keygen -o "$client_json"
 
-    $solana_client_demo \
+    $solana_bench_tps \
       -n "$count" \
       -l "$SOLANA_CONFIG_CLIENT_DIR"/leader.json \
       -k "$SOLANA_CONFIG_CLIENT_DIR"/client.json \

--- a/multinode-demo/common.sh
+++ b/multinode-demo/common.sh
@@ -24,7 +24,7 @@ fi
 if [[ -d $SNAP ]]; then # Running inside a Linux Snap?
   solana_program() {
     declare program="$1"
-    if [[ "$program" = wallet || "$program" = client-demo ]]; then
+    if [[ "$program" = wallet || "$program" = bench-tps ]]; then
       # TODO: Merge wallet.sh/client.sh functionality into
       #       solana-wallet/solana-demo-client proper and remove this special case
       printf "%s/bin/solana-%s" "$SNAP" "$program"
@@ -84,7 +84,7 @@ else
   fi
 fi
 
-solana_client_demo=$(solana_program client-demo)
+solana_bench_tps=$(solana_program bench-tps)
 solana_wallet=$(solana_program wallet)
 solana_drone=$(solana_program drone)
 solana_fullnode=$(solana_program fullnode)

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -44,10 +44,10 @@ apps:
     command: solana-keygen
     plugs:
       - home
-  client-demo:
-    # TODO: Merge client.sh functionality into solana-client-demo proper
+  bench-tps:
+    # TODO: Merge client.sh functionality into solana-bench-tps proper
     command: client.sh
-    #command: solana-client-demo
+    #command: solana-bench-tps
     plugs:
       - network
       - network-bind

--- a/src/bin/bench-streamer.rs
+++ b/src/bin/bench-streamer.rs
@@ -1,10 +1,5 @@
-#[macro_use]
-extern crate log;
 extern crate solana;
-#[macro_use]
-extern crate criterion;
 
-use criterion::{Bencher, Criterion};
 use solana::packet::{Packet, PacketRecycler, BLOB_SIZE, PACKET_DATA_SIZE};
 use solana::result::Result;
 use solana::streamer::{receiver, PacketReceiver};
@@ -62,7 +57,7 @@ fn sink(
     })
 }
 
-fn bench_streamer_with_result() -> Result<()> {
+fn main() -> Result<()> {
     let read = UdpSocket::bind("127.0.0.1:0")?;
     read.set_read_timeout(Some(Duration::new(1, 0)))?;
 
@@ -87,7 +82,7 @@ fn bench_streamer_with_result() -> Result<()> {
     let time = elapsed.as_secs() * 10000000000 + elapsed.subsec_nanos() as u64;
     let ftime = (time as f64) / 10000000000f64;
     let fcount = (end_val - start_val) as f64;
-    trace!("performance: {:?}", fcount / ftime);
+    println!("performance: {:?}", fcount / ftime);
     exit.store(true, Ordering::Relaxed);
     t_reader.join()?;
     t_producer1.join()?;
@@ -96,22 +91,3 @@ fn bench_streamer_with_result() -> Result<()> {
     t_sink.join()?;
     Ok(())
 }
-
-fn bench_streamer(bencher: &mut Bencher) {
-    bencher.iter(|| {
-        bench_streamer_with_result().unwrap();
-    });
-}
-
-fn bench(criterion: &mut Criterion) {
-    criterion.bench_function("bench_streamer", |bencher| {
-        bench_streamer(bencher);
-    });
-}
-
-criterion_group!(
-    name = benches;
-    config = Criterion::default().sample_size(2);
-    targets = bench
-);
-criterion_main!(benches);

--- a/src/bin/bench-tps.rs
+++ b/src/bin/bench-tps.rs
@@ -162,7 +162,7 @@ fn main() {
     let mut num_nodes = 1usize;
     let mut time_sec = 90;
 
-    let matches = App::new("solana-client-demo")
+    let matches = App::new("solana-bench-tps")
         .arg(
             Arg::with_name("leader")
                 .short("l")


### PR DESCRIPTION
The long-running benchmarks don't need libtest or criterion and could make use of debug symbols for debugging. Neither the integration tests or the benchmarks is the right place for them. This PR moves them to `src/bin/bench-*`.

Fixes #710