### PR TITLE
deserialize using get_data_size(), which refers to blob.data()'s length,   instead of using msg.meta.size, which refers to the entire blob's length

### DIFF
--- a/src/erasure.rs
+++ b/src/erasure.rs
@@ -575,7 +575,7 @@ pub fn recover(
             data_size,
             locks[n].data()[0]
         );
-        if data_size > BLOB_SIZE as u64 {
+        if data_size > BLOB_DATA_SIZE as u64 {
             corrupt = true;
         }
     }

--- a/src/erasure.rs
+++ b/src/erasure.rs
@@ -1,5 +1,5 @@
 // Support erasure coding
-use packet::{BlobRecycler, SharedBlob, BLOB_HEADER_SIZE, BLOB_SIZE};
+use packet::{BlobRecycler, SharedBlob, BLOB_DATA_SIZE, BLOB_HEADER_SIZE};
 use std::cmp;
 use std::mem;
 use std::result;

--- a/src/ledger.rs
+++ b/src/ledger.rs
@@ -57,7 +57,7 @@ pub fn reconstruct_entries_from_blobs(blobs: VecDeque<SharedBlob>) -> bincode::R
     for blob in blobs {
         let entry = {
             let msg = blob.read().unwrap();
-            let msg_size = msg.get_size().unwrap();
+            let msg_size = msg.get_size();
             deserialize(&msg.data()[..msg_size])
         };
 
@@ -200,7 +200,6 @@ mod tests {
         let mut transactions = vec![tx0; 362];
         transactions.extend(vec![tx1; 100]);
         let entries = next_entries(&zero, 0, transactions);
-        eprintln!("entries.len() {}", entries.len());
         let blob_recycler = BlobRecycler::default();
         let mut blob_q = VecDeque::new();
         entries.to_blobs(&blob_recycler, &mut blob_q);

--- a/src/ledger.rs
+++ b/src/ledger.rs
@@ -57,7 +57,7 @@ pub fn reconstruct_entries_from_blobs(blobs: VecDeque<SharedBlob>) -> bincode::R
     for blob in blobs {
         let entry = {
             let msg = blob.read().unwrap();
-            deserialize(&msg.data()[..msg.meta.size])
+            deserialize(&msg.data()[..msg.get_data_size().unwrap() as usize])
         };
 
         match entry {

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -373,11 +373,18 @@ impl Blob {
     pub fn data_mut(&mut self) -> &mut [u8] {
         &mut self.data[BLOB_HEADER_SIZE..]
     }
+    pub fn get_size(&self) -> Result<usize> {
+        let size = self.get_data_size()? as usize;
+        assert_eq!(self.meta.size, size);
+        // TODO: return an error instead of panicking
+        Ok(size)
+    }
     pub fn set_size(&mut self, size: usize) {
         let new_size = size + BLOB_HEADER_SIZE;
         self.meta.size = new_size;
         self.set_data_size(new_size as u64).unwrap();
     }
+
     pub fn recv_from(re: &BlobRecycler, socket: &UdpSocket) -> Result<SharedBlobs> {
         let mut v = VecDeque::new();
         //DOCUMENTED SIDE-EFFECT


### PR DESCRIPTION
fixes #752