### PR TITLE
disable sig verify, retry the tx transfer as well as get balance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ unstable = []
 ipv6 = []
 cuda = []
 erasure = []
+sigverify_cpu_disable = []
 
 [dependencies]
 rayon = "1.0.0"

--- a/src/sigverify.rs
+++ b/src/sigverify.rs
@@ -42,6 +42,7 @@ pub fn init() {
 }
 
 #[cfg(not(feature = "cuda"))]
+#[cfg(not(feature = "sigverify_cpu_disable"))]
 fn verify_packet(packet: &Packet) -> u8 {
     use ring::signature;
     use signature::{PublicKey, Signature};
@@ -65,6 +66,13 @@ fn verify_packet(packet: &Packet) -> u8 {
         untrusted::Input::from(&packet.data[sig_start..sig_end]),
     ).is_ok() as u8
 }
+
+#[cfg(feature = "sigverify_cpu_disable")]
+fn verify_packet(_packet: &Packet) -> u8 {
+    warn!("signature verification is disabled");
+    return 1;
+}
+
 
 fn batch_size(batches: &[SharedPackets]) -> usize {
     batches

--- a/tests/multinode.rs
+++ b/tests/multinode.rs
@@ -380,7 +380,7 @@ fn test_multi_node_dynamic_network() {
 
     let leader = TestNode::new_localhost();
     let bob_pubkey = KeyPair::new().pubkey();
-    let (alice, ledger_path) = genesis(100_000);
+    let (alice, ledger_path) = genesis(10_000_000);
     let alice_arc = Arc::new(RwLock::new(alice));
     let leader_data = leader.data.clone();
     let server = FullNode::new(
@@ -391,14 +391,14 @@ fn test_multi_node_dynamic_network() {
         None,
     );
     info!("{:x} LEADER", leader_data.debug_id());
-    let leader_balance = send_tx_and_retry_get_balance(
+    let leader_balance = retry_send_tx_and_retry_get_balance(
         &leader_data,
         &alice_arc.read().unwrap(),
         &bob_pubkey,
         Some(500),
     ).unwrap();
     assert_eq!(leader_balance, 500);
-    let leader_balance = send_tx_and_retry_get_balance(
+    let leader_balance = retry_send_tx_and_retry_get_balance(
         &leader_data,
         &alice_arc.read().unwrap(),
         &bob_pubkey,
@@ -417,7 +417,7 @@ fn test_multi_node_dynamic_network() {
                     info!("Spawned thread {}", n);
                     let keypair = KeyPair::new();
                     //send some tokens to the new validator
-                    let bal = send_tx_and_retry_get_balance(
+                    let bal = retry_send_tx_and_retry_get_balance(
                         &leader_data,
                         &alice_clone.read().unwrap(),
                         &keypair.pubkey(),
@@ -470,7 +470,7 @@ fn test_multi_node_dynamic_network() {
     for i in 0..num_nodes {
         //verify leader can do transfer
         let expected = ((i + 3) * 500) as i64;
-        let leader_balance = send_tx_and_retry_get_balance(
+        let leader_balance = retry_send_tx_and_retry_get_balance(
             &leader_data,
             &alice_arc.read().unwrap(),
             &bob_pubkey,
@@ -586,4 +586,33 @@ fn send_tx_and_retry_get_balance(
         .transfer(500, &alice.keypair(), *bob_pubkey, &last_id)
         .unwrap();
     retry_get_balance(&mut client, bob_pubkey, expected)
+}
+
+fn retry_send_tx_and_retry_get_balance(
+    leader: &NodeInfo,
+    alice: &Mint,
+    bob_pubkey: &PublicKey,
+    expected: Option<i64>,
+) -> Option<i64> {
+    let mut client = mk_client(leader);
+    trace!("getting leader last_id");
+    let last_id = client.get_last_id();
+    info!("executing leader transfer");
+    const LAST: usize = 30;
+    for run in 0..(LAST + 1) {
+    	let _sig = client
+    	    .transfer(500, &alice.keypair(), *bob_pubkey, &last_id)
+    	    .unwrap();
+        let out = client.poll_get_balance(bob_pubkey);
+        if expected.is_none() || run == LAST {
+            return out.ok().clone();
+        }
+        trace!("retry_get_balance[{}] {:?} {:?}", run, out, expected);
+        if let (Some(e), Ok(o)) = (expected, out) {
+            if o == e {
+                return Some(o);
+            }
+        }
+    }
+    None
 }


### PR DESCRIPTION
```
cargo test --release --features=sigverify_cpu_disable -- --ignored dynamic
```
CPU utilization is low, and everything boots up pretty quickly, but i see 
```
 INFO 2018-07-26T04:59:35Z: multinode: executing leader transfer
thread 'solana-listen' panicked at 'assertion failed: len < BLOB_SIZE', src/packet.rs:283:9
note: Run with `RUST_BACKTRACE=1` for a backtrace.
 INFO 2018-07-26T04:59:42Z: multinode: SUCCESS[0] 1 out of 400 distance: 399
 INFO 2018-07-26T04:59:42Z: multinode: executing leader transfer
 INFO 2018-07-26T04:59:48Z: multinode: SUCCESS[1] 0 out of 400 distance: 799
```
which is in this crdt.rs:1061 i think
```
} else if let Ok(r) = to_blob(rsp, addr, &blob_recycler) {
```

thats because 400 updates doesn't fit into 64kb, so we should only send the first 64kb worth of updates.  maybe boot external liveness for now, and bring it back later when we see membership failures.