### PR TITLE
Stop validator first to stop voting before the leader stops

### DIFF
--- a/tests/multinode.rs
+++ b/tests/multinode.rs
@@ -274,8 +274,8 @@ fn test_boot_validator_from_file() {
     let getbal = retry_get_balance(&mut client, &bob_pubkey, Some(leader_balance));
     assert!(getbal == Some(leader_balance));
 
-    leader_fullnode.close().unwrap();
     val_fullnode.close().unwrap();
+    leader_fullnode.close().unwrap();
     std::fs::remove_file(ledger_path).unwrap();
 }
 


### PR DESCRIPTION
Follow-up from 7672506b45c4e5f0a880a593a7d57887c51a3c48 to address https://buildkite.com/solana-labs/solana/builds/1792#00e13505-1134-450a-bb6a-04639f35148a.  Not sure why CI didn't catch this before merging, I guess it's just a race without this patch...