### PR TITLE
poll_get_balance no longer fails intermittently for zero balance accounts

### DIFF
--- a/src/bin/wallet.rs
+++ b/src/bin/wallet.rs
@@ -243,6 +243,7 @@ fn process_command(
                 }
                 Err(error) => {
                     println!("An error occurred: {:?}", error);
+                    Err(error)?;
                 }
             }
         }


### PR DESCRIPTION
While polling for a non-zero balance, it's not uncommon for one of the get_balance requests to fail with EWOULDBLOCK.  Previously when a get_balance request failure occurred on the last iteration of the polling loop, poll_get_balance returned an error even though the N-1 iterations may have successfully retrieved a balance of 0.