### PR TITLE
validator.sh: Guard against rsyncing TBs of ledger

### DIFF
--- a/multinode-demo/validator.sh
+++ b/multinode-demo/validator.sh
@@ -72,14 +72,6 @@ rm -rf "$SOLANA_LEADER_CONFIG_DIR"
 set -ex
 $rsync -vPrz "$rsync_leader_url"/config/ "$SOLANA_LEADER_CONFIG_DIR"
 
-# migrate from old ledger format?  why not...
-if [[ ! -f "$SOLANA_LEADER_CONFIG_DIR"/ledger.log &&
-          -f "$SOLANA_LEADER_CONFIG_DIR"/genesis.log ]]; then
-  (shopt -s nullglob &&
-     cat "$SOLANA_LEADER_CONFIG_DIR"/genesis.log \
-         "$SOLANA_LEADER_CONFIG_DIR"/tx-*.log) > "$SOLANA_LEADER_CONFIG_DIR"/ledger.log
-fi
-
 # Ensure the validator has at least 1 token before connecting to the network
 # TODO: Remove this workaround
 while ! $solana_wallet \

--- a/multinode-demo/validator.sh
+++ b/multinode-demo/validator.sh
@@ -70,7 +70,11 @@ tune_networking
 SOLANA_LEADER_CONFIG_DIR="$SOLANA_CONFIG_DIR"/leader-config
 rm -rf "$SOLANA_LEADER_CONFIG_DIR"
 set -ex
-$rsync -vPrz "$rsync_leader_url"/config/ "$SOLANA_LEADER_CONFIG_DIR"
+$rsync -vPrz --max-size=100M "$rsync_leader_url"/config/ "$SOLANA_LEADER_CONFIG_DIR"
+[[ -r "$SOLANA_LEADER_CONFIG_DIR"/ledger.log ]] || {
+  echo "Unable to retrieve ledger.log from $rsync_leader_url"
+  exit 1
+}
 
 # Ensure the validator has at least 1 token before connecting to the network
 # TODO: Remove this workaround


### PR DESCRIPTION
1. A validator on the testnet OOMs (cc: #782)
2. The validator restarts and tries to `rsync` a couple TB from the leader

Sure so much has already gone wrong, but let's not exacerbate the situation with a never-ending `rsync`.