### PR TITLE
multinode-demo: Drop -t hint

### DIFF
--- a/multinode-demo/leader.sh
+++ b/multinode-demo/leader.sh
@@ -13,7 +13,7 @@ fi
 [[ -f "$SOLANA_CONFIG_DIR"/leader.json ]] || {
   echo "$SOLANA_CONFIG_DIR/leader.json not found, create it by running:"
   echo
-  echo "  ${here}/setup.sh -t leader"
+  echo "  ${here}/setup.sh"
   exit 1
 }
 

--- a/multinode-demo/validator.sh
+++ b/multinode-demo/validator.sh
@@ -59,7 +59,7 @@ fi
 [[ -f "$SOLANA_CONFIG_DIR"/validator.json ]] || {
   echo "$SOLANA_CONFIG_DIR/validator.json not found, create it by running:"
   echo
-  echo "  ${here}/setup.sh -t validator"
+  echo "  ${here}/setup.sh"
   exit 1
 }
 


### PR DESCRIPTION
Fixes #793. `./multinode-demo/validator.sh` told @aeyakovenko to run `./multinode-demo/setup.sh -t validator`, which is the wrong thing to do when trying to run everything from the same workspace.  Instead a normal ``./multinode-demo/setup.sh` is needed 