### PR TITLE
Add custom formatting to display base58-encoded public keys, …

### DIFF
--- a/src/drone.rs
+++ b/src/drone.rs
@@ -4,6 +4,7 @@
 //! checking requests against a request cap for a given time time_slice
 //! and (to come) an IP rate limit.
 
+use bs58;
 use influx_db_client as influxdb;
 use metrics;
 use signature::Signature;
@@ -114,8 +115,9 @@ impl Drone {
                 client_public_key,
             } => {
                 info!(
-                    "Requesting airdrop of {} to {:?}",
-                    airdrop_request_amount, client_public_key
+                    "Requesting airdrop of {} to {}",
+                    airdrop_request_amount,
+                    bs58::encode(client_public_key).into_string()
                 );
                 request_amount = airdrop_request_amount;
                 Transaction::new(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,7 @@ pub mod voting;
 pub mod window_stage;
 pub mod write_stage;
 extern crate bincode;
+extern crate bs58;
 extern crate byteorder;
 extern crate chrono;
 extern crate generic_array;

--- a/src/request.rs
+++ b/src/request.rs
@@ -1,7 +1,9 @@
 //! The `request` module defines the messages for the thin client.
 
+use bs58;
 use hash::Hash;
 use signature::{PublicKey, Signature};
+use std::fmt;
 
 #[cfg_attr(feature = "cargo-clippy", allow(large_enum_variant))]
 #[derive(Serialize, Deserialize, Debug, Clone, Copy)]
@@ -19,10 +21,37 @@ impl Request {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize)]
 pub enum Response {
     Balance { key: PublicKey, val: i64 },
     LastId { id: Hash },
     TransactionCount { transaction_count: u64 },
     SignatureStatus { signature_status: bool },
+}
+
+// Custom formatter to display base58 public keys and hashes
+impl fmt::Debug for Response {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Response::Balance { key, val } => write!(
+                f,
+                "Balance {{ key: {}, val: {} }}",
+                bs58::encode(key).into_string(),
+                val
+            ),
+            Response::LastId { id } => {
+                write!(f, "LastId {{ id: {} }}", bs58::encode(id).into_string())
+            }
+            Response::TransactionCount { transaction_count } => write!(
+                f,
+                "TransactionCount {{ transaction_count: {} }}",
+                transaction_count
+            ),
+            Response::SignatureStatus { signature_status } => write!(
+                f,
+                "SignatureStatus {{ signature_status: {} }}",
+                signature_status
+            ),
+        }
+    }
 }


### PR DESCRIPTION
…signatures, and hashes in debug messages. #794  

This works for most of our current use cases, but it seems like a better (more universal) way to do this would be a custom formatter for the PublicKey, Signature, and Hash types themselves. Since they are type aliases (of GenericArray), that doesn't seem to be possible. @garious , got any fancy Rust tricks I could use to do that?