### PR TITLE
Upgrade ring and untrusted, and enable cargo audit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,8 +65,8 @@ generic-array = { version = "0.11.1", default-features = false, features = ["ser
 serde = "1.0.27"
 serde_derive = "1.0.27"
 serde_json = "1.0.10"
-ring = "0.12.1"
-untrusted = "0.5.1"
+ring = "0.13.2"
+untrusted = "0.6.2"
 bincode = "1.0.0"
 chrono = { version = "0.4.0", features = ["serde"] }
 log = "0.4.2"

--- a/benches/signature.rs
+++ b/benches/signature.rs
@@ -6,7 +6,7 @@ use criterion::{Bencher, Criterion};
 use solana::signature::GenKeys;
 
 fn bench_gen_keys(b: &mut Bencher) {
-    let rnd = GenKeys::new([0u8; 32]);
+    let mut rnd = GenKeys::new([0u8; 32]);
     b.iter(|| rnd.gen_n_keypairs(1000));
 }
 

--- a/ci/test-stable.sh
+++ b/ci/test-stable.sh
@@ -24,3 +24,5 @@ echo --- ci/localnet-sanity.sh
   export PATH=$PWD/target/debug:$PATH
   USE_INSTALL=1 ci/localnet-sanity.sh
 )
+
+_ ci/audit.sh

--- a/src/bin/bench-tps.rs
+++ b/src/bin/bench-tps.rs
@@ -475,7 +475,7 @@ fn main() {
 
     let mut seed = [0u8; 32];
     seed.copy_from_slice(&id.public_key_bytes()[..32]);
-    let rnd = GenKeys::new(seed);
+    let mut rnd = GenKeys::new(seed);
 
     println!("Creating {} keypairs...", tx_count / 2);
     let keypairs = rnd.gen_n_keypairs(tx_count / 2);

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -64,16 +64,16 @@ impl GenKeys {
         }
     }
 
-    fn gen_keypair(&self) -> [u8; 85] {
+    fn gen_keypair(&mut self) -> [u8; 85] {
         KeyPair::generate_pkcs8(self).unwrap()
     }
 
-    fn gen_n_seeds(&self, n: i64) -> Vec<[u8; 32]> {
+    fn gen_n_seeds(&mut self, n: i64) -> Vec<[u8; 32]> {
         let mut rng = self.generator.borrow_mut();
         (0..n).map(|_| rng.gen()).collect()
     }
 
-    pub fn gen_n_keypairs(&self, n: i64) -> Vec<KeyPair> {
+    pub fn gen_n_keypairs(&mut self, n: i64) -> Vec<KeyPair> {
         self.gen_n_seeds(n)
             .into_par_iter()
             .map(|seed| {
@@ -112,11 +112,11 @@ mod tests {
     #[test]
     fn test_new_key_is_deterministic() {
         let seed = [0u8; 32];
-        let rng0 = GenKeys::new(seed);
-        let rng1 = GenKeys::new(seed);
+        let mut gen0 = GenKeys::new(seed);
+        let mut gen1 = GenKeys::new(seed);
 
         for _ in 0..100 {
-            assert_eq!(rng0.gen_keypair().to_vec(), rng1.gen_keypair().to_vec());
+            assert_eq!(gen0.gen_keypair().to_vec(), gen1.gen_keypair().to_vec());
         }
     }
 

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -64,7 +64,7 @@ impl GenKeys {
         }
     }
 
-    fn new_key(&self) -> [u8; 85] {
+    fn gen_keypair(&self) -> [u8; 85] {
         KeyPair::generate_pkcs8(self).unwrap()
     }
 
@@ -77,7 +77,7 @@ impl GenKeys {
         self.gen_n_seeds(n)
             .into_par_iter()
             .map(|seed| {
-                let pkcs8 = GenKeys::new(seed).new_key();
+                let pkcs8 = GenKeys::new(seed).gen_keypair();
                 KeyPair::from_pkcs8(Input::from(&pkcs8)).unwrap()
             })
             .collect()
@@ -116,7 +116,7 @@ mod tests {
         let rng1 = GenKeys::new(seed);
 
         for _ in 0..100 {
-            assert_eq!(rng0.new_key().to_vec(), rng1.new_key().to_vec());
+            assert_eq!(rng0.gen_keypair().to_vec(), rng1.gen_keypair().to_vec());
         }
     }
 

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -64,8 +64,8 @@ impl GenKeys {
         }
     }
 
-    pub fn new_key(&self) -> Vec<u8> {
-        KeyPair::generate_pkcs8(self).unwrap().to_vec()
+    pub fn new_key(&self) -> [u8; 85] {
+        KeyPair::generate_pkcs8(self).unwrap()
     }
 
     pub fn gen_n_seeds(&self, n: i64) -> Vec<[u8; 32]> {
@@ -116,7 +116,7 @@ mod tests {
         let rng1 = GenKeys::new(seed);
 
         for _ in 0..100 {
-            assert_eq!(rng0.new_key(), rng1.new_key());
+            assert_eq!(rng0.new_key().to_vec(), rng1.new_key().to_vec());
         }
     }
 

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -4,12 +4,9 @@ use generic_array::typenum::{U32, U64};
 use generic_array::GenericArray;
 use rand::{ChaChaRng, Rng, SeedableRng};
 use rayon::prelude::*;
-use ring::error::Unspecified;
-use ring::rand::SecureRandom;
 use ring::signature::Ed25519KeyPair;
 use ring::{rand, signature};
 use serde_json;
-use std::cell::RefCell;
 use std::error;
 use std::fs::File;
 use untrusted::Input;
@@ -51,44 +48,30 @@ impl SignatureUtil for GenericArray<u8, U64> {
 }
 
 pub struct GenKeys {
-    // This is necessary because the rng needs to mutate its state to remain
-    // deterministic, and the fill trait requires an immuatble reference to self
-    generator: RefCell<ChaChaRng>,
+    generator: ChaChaRng,
 }
 
 impl GenKeys {
     pub fn new(seed: [u8; 32]) -> GenKeys {
-        let rng = ChaChaRng::from_seed(seed);
-        GenKeys {
-            generator: RefCell::new(rng),
-        }
+        let generator = ChaChaRng::from_seed(seed);
+        GenKeys { generator }
     }
 
-    fn gen_keypair(&mut self) -> [u8; 85] {
-        KeyPair::generate_pkcs8(self).unwrap()
+    fn gen_seed(&mut self) -> [u8; 32] {
+        let mut seed = [0u8; 32];
+        self.generator.fill(&mut seed);
+        seed
     }
 
     fn gen_n_seeds(&mut self, n: i64) -> Vec<[u8; 32]> {
-        let mut rng = self.generator.borrow_mut();
-        (0..n).map(|_| rng.gen()).collect()
+        (0..n).map(|_| self.gen_seed()).collect()
     }
 
     pub fn gen_n_keypairs(&mut self, n: i64) -> Vec<KeyPair> {
         self.gen_n_seeds(n)
             .into_par_iter()
-            .map(|seed| {
-                let pkcs8 = GenKeys::new(seed).gen_keypair();
-                KeyPair::from_pkcs8(Input::from(&pkcs8)).unwrap()
-            })
+            .map(|seed| KeyPair::from_seed_unchecked(Input::from(&seed)).unwrap())
             .collect()
-    }
-}
-
-impl SecureRandom for GenKeys {
-    fn fill(&self, dest: &mut [u8]) -> Result<(), Unspecified> {
-        let mut rng = self.generator.borrow_mut();
-        rng.fill(dest);
-        Ok(())
     }
 }
 
@@ -116,7 +99,7 @@ mod tests {
         let mut gen1 = GenKeys::new(seed);
 
         for _ in 0..100 {
-            assert_eq!(gen0.gen_keypair().to_vec(), gen1.gen_keypair().to_vec());
+            assert_eq!(gen0.gen_seed().to_vec(), gen1.gen_seed().to_vec());
         }
     }
 

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -64,11 +64,11 @@ impl GenKeys {
         }
     }
 
-    pub fn new_key(&self) -> [u8; 85] {
+    fn new_key(&self) -> [u8; 85] {
         KeyPair::generate_pkcs8(self).unwrap()
     }
 
-    pub fn gen_n_seeds(&self, n: i64) -> Vec<[u8; 32]> {
+    fn gen_n_seeds(&self, n: i64) -> Vec<[u8; 32]> {
         let mut rng = self.generator.borrow_mut();
         (0..n).map(|_| rng.gen()).collect()
     }


### PR DESCRIPTION
Running `cargo audit` tells us that `untrusted 0.5.1` has a security vulnerability and recommends upgrading to `untrusted 0.6.2`. To get there, we needed to change `GenKeys` to not implement `SecureRandom` which derives from `private::Sealed` in the latest version of `ring`.