### PR TITLE
Lower errors to warnings so they don't print during tests

### DIFF
--- a/src/bank.rs
+++ b/src/bank.rs
@@ -176,6 +176,7 @@ impl Bank {
         }
         Err(BankError::LastIdNotFound(*last_id))
     }
+
     /// Look through the last_ids and find all the valid ids
     /// This is batched to avoid holding the lock for a significant amount of time
     pub fn count_valid_ids(&self, ids: &[Hash]) -> usize {
@@ -397,7 +398,7 @@ impl Bank {
         for block in &entries.into_iter().chunks(VERIFY_BLOCK_SIZE) {
             let block: Vec<_> = block.collect();
             if !block.verify(&self.last_id()) {
-                error!("Ledger proof of history failed at entry: {}", entry_count);
+                warn!("Ledger proof of history failed at entry: {}", entry_count);
                 return Err(BankError::LedgerVerificationFailed);
             }
             entry_count += self.process_entries_tail(block, tail, tail_idx)?;
@@ -745,6 +746,7 @@ mod tests {
             Err(BankError::LastIdNotFound(mint.last_id()))
         );
     }
+
     #[test]
     fn test_count_valid_ids() {
         let mint = Mint::new(1);
@@ -760,6 +762,7 @@ mod tests {
         assert_eq!(bank.count_valid_ids(&[mint.last_id()]), 0);
         assert_eq!(bank.count_valid_ids(&ids), ids.len());
     }
+
     #[test]
     fn test_debits_before_credits() {
         let mint = Mint::new(2);

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -118,7 +118,7 @@ impl Entry {
         let tx_plans_verified = self.transactions.par_iter().all(|tx| {
             let r = tx.verify_plan();
             if !r {
-                error!("tx plan invalid: {:?}", tx);
+                warn!("tx plan invalid: {:?}", tx);
             }
             r
         });
@@ -127,7 +127,7 @@ impl Entry {
         }
         let ref_hash = next_hash(start_hash, self.num_hashes, &self.transactions);
         if self.id != ref_hash {
-            error!(
+            warn!(
                 "next_hash is invalid expected: {:?} actual: {:?}",
                 self.id, ref_hash
             );

--- a/src/ledger.rs
+++ b/src/ledger.rs
@@ -26,7 +26,7 @@ impl Block for [Entry] {
         entry_pairs.all(|(x0, x1)| {
             let r = x1.verify(&x0.id);
             if !r {
-                error!(
+                warn!(
                     "entry invalid!: {:?} num txs: {}",
                     x1.id,
                     x1.transactions.len()


### PR DESCRIPTION
Negative tests should trigger the warnings, but errors look like
something is wrong.