### PR TITLE
CI builds no longer turn red if a metrics write fails

### DIFF
--- a/.buildkite/hooks/post-command
+++ b/.buildkite/hooks/post-command
@@ -41,5 +41,5 @@ else
 
   point="job_stats,$point_tags $point_fields"
 
-  ci/metrics_write_datapoint.sh "$point"
+  ci/metrics_write_datapoint.sh "$point" || true
 fi


### PR DESCRIPTION
Fixes the issue observed at https://buildkite.com/solana-labs/solana-snap/builds/238#a1b43aeb-b2db-4c0d-b6e4-3f8a7ec0c136/411-415