### PR TITLE
Only send sigverify to GPU if batch size is >64

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,3 +116,7 @@ harness = false
 [[bench]]
 name = "signature"
 harness = false
+
+[[bench]]
+name = "sigverify"
+harness = false

--- a/benches/sigverify.rs
+++ b/benches/sigverify.rs
@@ -1,0 +1,36 @@
+#[macro_use]
+extern crate criterion;
+extern crate bincode;
+extern crate rayon;
+extern crate solana;
+
+use criterion::{Bencher, Criterion};
+use solana::packet::{to_packets, PacketRecycler};
+use solana::sigverify;
+use solana::transaction::test_tx;
+
+fn bench_sig_verify(bencher: &mut Bencher) {
+    let tx = test_tx();
+
+    // generate packet vector
+    let packet_recycler = PacketRecycler::default();
+    let batches = to_packets(&packet_recycler, &vec![tx; 128]);
+
+    // verify packets
+    bencher.iter(|| {
+        let _ans = sigverify::ed25519_verify(&batches);
+    })
+}
+
+fn bench(criterion: &mut Criterion) {
+    criterion.bench_function("bench_sig_verify", |bencher| {
+        bench_sig_verify(bencher);
+    });
+}
+
+criterion_group!(
+    name = benches;
+    config = Criterion::default().sample_size(2);
+    targets = bench
+);
+criterion_main!(benches);

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -207,7 +207,6 @@ impl Transaction {
     }
 }
 
-#[cfg(test)]
 pub fn test_tx() -> Transaction {
     let keypair1 = KeyPair::new();
     let pubkey1 = keypair1.pubkey();


### PR DESCRIPTION
Seems to be a decent crossover point for Xeon E5-2620 v4 8c,16t vs. nvidia 1080ti