### PR TITLE
solanalabs/rust docker image: Include rustfmt-preview

### DIFF
--- a/ci/docker-rust/Dockerfile
+++ b/ci/docker-rust/Dockerfile
@@ -11,4 +11,5 @@ RUN apt update && \
       sudo \
       cmake \
       && \
+    rustup component add rustfmt-preview && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Step 1 in preventing all PR builds from installing rustfmt-preview on every run