### PR TITLE
Stop installing rustfmt-preview, it's already present

### DIFF
--- a/ci/test-stable.sh
+++ b/ci/test-stable.sh
@@ -11,7 +11,6 @@ _() {
   "$@"
 }
 
-_ rustup component add rustfmt-preview
 _ cargo fmt -- --check
 _ cargo build --verbose
 _ cargo test --verbose


### PR DESCRIPTION
Part 2 of #848 

This works now too:
```bash
$ ci/docker-run.sh solanalabs/rust cargo fmt
```