### PR TITLE
Avoid nested par_iter()s in ed25519_verify_cpu

### DIFF
--- a/src/sigverify.rs
+++ b/src/sigverify.rs
@@ -89,7 +89,7 @@ pub fn ed25519_verify_cpu(batches: &Vec<SharedPackets>) -> Vec<Vec<u8>> {
     let count = batch_size(batches);
     info!("CPU ECDSA for {}", batch_size(batches));
     let rv = batches
-        .into_par_iter()
+        .into_iter()
         .map(|p| {
             p.read()
                 .expect("'p' read lock in ed25519_verify")


### PR DESCRIPTION
Empirically removing the nested par_iter()s in this file avoids a
deadlock within rayon when another par_iter() is running in parallel.

Fixes #764