### PR TITLE
bench-tps: Send/confirm a loopback payment after each batch of transactions

### DIFF
--- a/src/bin/bench-tps.rs
+++ b/src/bin/bench-tps.rs
@@ -173,16 +173,12 @@ fn generate_txs(
     shared_txs: &Arc<RwLock<VecDeque<Vec<Transaction>>>>,
     id: &KeyPair,
     keypairs: &[KeyPair],
-    tx_count: i64,
     last_id: &Hash,
     threads: usize,
     reclaim: bool,
 ) {
-    println!(
-        "Signing transactions... {} (reclaim={})",
-        tx_count / 2,
-        reclaim
-    );
+    let tx_count = keypairs.len();
+    println!("Signing transactions... {} (reclaim={})", tx_count, reclaim);
     let signing_start = Instant::now();
 
     let transactions: Vec<_> = keypairs
@@ -198,8 +194,8 @@ fn generate_txs(
 
     let duration = signing_start.elapsed();
     let ns = duration.as_secs() * 1_000_000_000 + u64::from(duration.subsec_nanos());
-    let bsps = (tx_count / 2) as f64 / ns as f64;
-    let nsps = ns as f64 / (tx_count / 2) as f64;
+    let bsps = (tx_count) as f64 / ns as f64;
+    let nsps = ns as f64 / (tx_count) as f64;
     println!(
         "Done. {:.2} thousand signatures per second, {:.2} us per signature, {} ms total time",
         bsps * 1_000_000_f64,
@@ -591,7 +587,6 @@ fn main() {
             &shared_txs,
             &id,
             &keypairs,
-            tx_count,
             &last_id,
             threads,
             reclaim_tokens_back_to_source_account,

--- a/src/bin/bench-tps.rs
+++ b/src/bin/bench-tps.rs
@@ -78,19 +78,21 @@ fn sample_tx_count(
         now = Instant::now();
         let sample = tx_count - initial_tx_count;
         initial_tx_count = tx_count;
-        println!("{} Transactions processed {}", log_prefix, sample);
+
         let ns = duration.as_secs() * 1_000_000_000 + u64::from(duration.subsec_nanos());
         let tps = (sample * 1_000_000_000) as f64 / ns as f64;
         if tps > max_tps {
             max_tps = tps;
         }
-        println!("{} {:.2} TPS", log_prefix, tps);
         if tx_count > first_tx_count {
             total = tx_count - first_tx_count;
         } else {
             total = 0;
         }
-        println!("{} Total transactions processed {}", log_prefix, total);
+        println!(
+            "{} {:9.2} TPS, Transactions: {:6}, Total transactions: {}",
+            log_prefix, tps, sample, total
+        );
         sleep(Duration::new(sample_period, 0));
 
         if exit_signal.load(Ordering::Relaxed) {


### PR DESCRIPTION
Fixes #764

Rather than just waiting for `last_id` to advance, `bench-tps` now sends/confirms a single transaction and is quite patent waiting for it to complete (necessary when using CPU verification)