### PR TITLE
Support -V/--version on all CLI apps

### DIFF
--- a/src/bin/bench-tps.rs
+++ b/src/bin/bench-tps.rs
@@ -1,4 +1,5 @@
 extern crate bincode;
+#[macro_use]
 extern crate clap;
 extern crate influx_db_client;
 extern crate rayon;
@@ -377,6 +378,7 @@ fn main() {
     let mut tx_count = 500_000;
 
     let matches = App::new("solana-bench-tps")
+        .version(crate_version!())
         .arg(
             Arg::with_name("leader")
                 .short("l")

--- a/src/bin/drone.rs
+++ b/src/bin/drone.rs
@@ -1,4 +1,5 @@
 extern crate bincode;
+#[macro_use]
 extern crate clap;
 extern crate serde_json;
 extern crate solana;
@@ -26,6 +27,7 @@ fn main() {
     logger::setup();
     set_panic_hook("drone");
     let matches = App::new("drone")
+        .version(crate_version!())
         .arg(
             Arg::with_name("leader")
                 .short("l")

--- a/src/bin/fullnode-config.rs
+++ b/src/bin/fullnode-config.rs
@@ -1,3 +1,4 @@
+#[macro_use]
 extern crate clap;
 extern crate dirs;
 extern crate serde_json;
@@ -13,6 +14,7 @@ use std::net::SocketAddr;
 
 fn main() {
     let matches = App::new("fullnode-config")
+        .version(crate_version!())
         .arg(
             Arg::with_name("local")
                 .short("l")

--- a/src/bin/fullnode.rs
+++ b/src/bin/fullnode.rs
@@ -1,3 +1,4 @@
+#[macro_use]
 extern crate clap;
 extern crate getopts;
 extern crate log;
@@ -23,6 +24,7 @@ fn main() -> () {
     logger::setup();
     set_panic_hook("fullnode");
     let matches = App::new("fullnode")
+        .version(crate_version!())
         .arg(
             Arg::with_name("identity")
                 .short("i")

--- a/src/bin/genesis.rs
+++ b/src/bin/genesis.rs
@@ -16,6 +16,7 @@ use std::process::exit;
 
 fn main() -> Result<(), Box<error::Error>> {
     let matches = App::new("solana-genesis")
+        .version(crate_version!())
         .arg(
             Arg::with_name("tokens")
                 .short("t")

--- a/src/bin/keygen.rs
+++ b/src/bin/keygen.rs
@@ -1,3 +1,4 @@
+#[macro_use]
 extern crate clap;
 extern crate dirs;
 extern crate ring;
@@ -13,6 +14,7 @@ use std::path::Path;
 
 fn main() -> Result<(), Box<error::Error>> {
     let matches = App::new("solana-keygen")
+        .version(crate_version!())
         .arg(
             Arg::with_name("outfile")
                 .short("o")

--- a/src/bin/ledger-tool.rs
+++ b/src/bin/ledger-tool.rs
@@ -1,3 +1,4 @@
+#[macro_use]
 extern crate clap;
 extern crate serde_json;
 extern crate solana;
@@ -12,6 +13,7 @@ use std::process::exit;
 fn main() {
     logger::setup();
     let matches = App::new("ledger-tool")
+        .version(crate_version!())
         .arg(
             Arg::with_name("ledger")
                 .short("l")

--- a/src/bin/wallet.rs
+++ b/src/bin/wallet.rs
@@ -1,6 +1,7 @@
 extern crate atty;
 extern crate bincode;
 extern crate bs58;
+#[macro_use]
 extern crate clap;
 extern crate dirs;
 extern crate serde_json;
@@ -74,6 +75,7 @@ impl Default for WalletConfig {
 
 fn parse_args() -> Result<WalletConfig, Box<error::Error>> {
     let matches = App::new("solana-wallet")
+        .version(crate_version!())
         .arg(
             Arg::with_name("leader")
                 .short("l")


### PR DESCRIPTION
All CLI apps that use clap (in other words, except for bench-streamer)
can use crate_version! to take the version from Cargo.toml.

This change addresses #700.