### PR TITLE
Install EarlyOOM on testnet nodes

### DIFF
--- a/ci/install-earlyoom.sh
+++ b/ci/install-earlyoom.sh
@@ -1,0 +1,32 @@
+#!/bin/bash -x
+#
+# Install EarlyOOM
+#
+
+[[ $(uname) = Linux ]] || exit 1
+
+# 64 - enable signalling of processes (term, kill, oom-kill)
+# TODO: This setting will not persist across reboots
+sysrq=$(( $(cat /proc/sys/kernel/sysrq) | 64 ))
+sudo sysctl -w kernel.sysrq=$sysrq
+
+if command -v earlyoom; then
+  sudo systemctl status earlyoom
+  exit 0
+fi
+
+wget http://ftp.us.debian.org/debian/pool/main/e/earlyoom/earlyoom_1.1-2_amd64.deb
+sudo apt install --quiet --yes ./earlyoom_1.1-2_amd64.deb
+
+cat > earlyoom <<OOM
+# use the kernel OOM killer, trigger at 20% available RAM,
+EARLYOOM_ARGS="-k -m 20"
+OOM
+sudo cp earlyoom /etc/default/
+rm earlyoom
+
+sudo systemctl stop earlyoom
+sudo systemctl enable earlyoom
+sudo systemctl start earlyoom
+
+exit 0

--- a/ci/testnet-deploy.sh
+++ b/ci/testnet-deploy.sh
@@ -52,6 +52,12 @@ if [[ -n $LOCAL_SNAP ]]; then
 fi
 SNAP_INSTALL_CMD="sudo snap remove solana; $SNAP_INSTALL_CMD"
 
+EARLYOOM_INSTALL_CMD="\
+  wget -O install-earlyoom.sh https://raw.githubusercontent.com/solana-labs/solana/master/ci/install-earlyoom.sh; \
+  bash install-earlyoom.sh \
+"
+SNAP_INSTALL_CMD="$EARLYOOM_INSTALL_CMD; $SNAP_INSTALL_CMD"
+
 # `export SKIP_INSTALL=1` to reset the network without reinstalling the snap
 if [[ -n $SKIP_INSTALL ]]; then
   SNAP_INSTALL_CMD="echo Install skipped"


### PR DESCRIPTION
By triggering the Linux OOM killer when RAM usage is at 20% we avoid thrashing memory as the system grinds its way down to 0 free pages and often becomes unresponsive. 

Ref: https://github.com/rfjakob/earlyoom