### PR TITLE
write a "unit" test for WindowLedger (it was working ;)

### DIFF
--- a/src/crdt.rs
+++ b/src/crdt.rs
@@ -1005,9 +1005,10 @@ impl Crdt {
                 return Some(out);
             } else {
                 inc_new_counter_info!("crdt-window-request-outside", 1);
-                info!(
+                trace!(
                     "requested ix {} != blob_ix {}, outside window!",
-                    ix, blob_ix
+                    ix,
+                    blob_ix
                 );
                 // falls through to checking window_ledger
             }
@@ -1029,7 +1030,7 @@ impl Crdt {
         }
 
         inc_new_counter_info!("crdt-window-request-fail", 1);
-        info!(
+        trace!(
             "{:x}: failed RequestWindowIndex {:x} {} {}",
             me.debug_id(),
             from.debug_id(),

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -105,6 +105,7 @@ impl Entry {
             if let Some(addr) = addr {
                 blob_w.meta.set_addr(addr);
             }
+            blob_w.set_flags(0).unwrap();
         }
         blob
     }


### PR DESCRIPTION
clear flags on fresh blobs, lest they sometimes impersonate coding blobs...

fix bug: advance *received whether the blob_index is in the window or not,
  failure to do so results in a stalled repair request pipeline