### PR TITLE
Add coding guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,52 @@
+Solana Coding Guidelines
+===
+
+The goal of these guidelines is to improve developer productivity by allowing developers to
+jump any file in the codebase and not need to adapt to inconsistencies in how the code is
+written. The codebase should appear as if it had been authored by a single developer. If you
+don't agree with a convention, submit a PR patching this document and let's discuss! Once
+the PR is accepted, *all* code should be updated as soon as possible to reflect the new
+conventions.
+
+Rust coding conventions
+---
+
+* All Rust code is formatted using the latest version of `rustfmt`. Once installed, it will be
+  updated automatically when you update the compiler with `rustup`.
+
+* All Rust code is linted with Clippy. If you'd prefer to ignore its advice, do so explicitly:
+
+  ```rust
+  #[cfg_attr(feature = "cargo-clippy", allow(too_many_arguments))]
+  ```
+
+  Note: Clippy defaults can be overridden in the top-level file `.clippy.toml`.
+
+* For variable names, when in doubt, spell it out. The mapping from type names to variable names
+  is to lowercase the type name, putting an underscore before each capital letter. Variable names
+  should *not* be abbreviated unless being used as closure arguments and the brevity improves
+  readability. When a function has multiple instances of the same type, qualify each with a
+  prefix and underscore (i.e. alice_keypair) or a numeric suffix (i.e. tx0).
+
+* For function and method names, use `<verb>_<subject>`. For unit tests, that verb should
+  always be `test` and for benchmarks the verb should always be `bench`. Avoid namespacing
+  function names with some arbitrary word. Avoid abreviating words in function names.
+
+* As they say, "When in Rome, do as the Romans do." A good patch should acknowledge the coding
+  conventions of the code that surrounds it, even in the case where that code has not yet been
+  updated to meet the conventions described here.
+
+
+Terminology
+---
+
+Inventing new terms is allowed, but should only be done when the term is widely used and
+understood. Avoid introducing new 3-letter terms, which can be confused with 3-letter acronyms.
+
+Some terms we currently use regularly in the codebase:
+
+* hash: n. A SHA-256 Hash
+* keypair: n. A Ed25519 key-pair, containing a public and private key.
+* pubkey: n. The public key of a Ed25519 key-pair.
+* sigverify: v. To verify a Ed25519 digital signature.
+

--- a/benches/bank.rs
+++ b/benches/bank.rs
@@ -10,7 +10,7 @@ use rayon::prelude::*;
 use solana::bank::*;
 use solana::hash::hash;
 use solana::mint::Mint;
-use solana::signature::{KeyPair, KeyPairUtil};
+use solana::signature::{Keypair, KeypairUtil};
 use solana::transaction::Transaction;
 
 fn bench_process_transaction(bencher: &mut Bencher) {
@@ -22,7 +22,7 @@ fn bench_process_transaction(bencher: &mut Bencher) {
         .into_par_iter()
         .map(|i| {
             // Seed the 'from' account.
-            let rando0 = KeyPair::new();
+            let rando0 = Keypair::new();
             let tx = Transaction::new(&mint.keypair(), rando0.pubkey(), 10_000, mint.last_id());
             assert!(bank.process_transaction(&tx).is_ok());
 
@@ -30,7 +30,7 @@ fn bench_process_transaction(bencher: &mut Bencher) {
             let last_id = hash(&serialize(&i).unwrap()); // Unique hash
             bank.register_entry_id(&last_id);
 
-            let rando1 = KeyPair::new();
+            let rando1 = Keypair::new();
             let tx = Transaction::new(&rando0, rando1.pubkey(), 1, last_id);
             assert!(bank.process_transaction(&tx).is_ok());
 

--- a/benches/banking_stage.rs
+++ b/benches/banking_stage.rs
@@ -11,7 +11,7 @@ use solana::banking_stage::BankingStage;
 use solana::mint::Mint;
 use solana::packet::{to_packets_chunked, PacketRecycler};
 use solana::record_stage::Signal;
-use solana::signature::{KeyPair, KeyPairUtil};
+use solana::signature::{Keypair, KeypairUtil};
 use solana::transaction::Transaction;
 use std::iter;
 use std::sync::mpsc::{channel, Receiver};
@@ -23,7 +23,7 @@ use std::sync::Arc;
 // use hash::hash;
 // use mint::Mint;
 // use rayon::prelude::*;
-// use signature::{KeyPair, KeyPairUtil};
+// use signature::{Keypair, KeypairUtil};
 // use std::collections::HashSet;
 // use std::time::Instant;
 // use transaction::Transaction;
@@ -49,11 +49,11 @@ use std::sync::Arc;
 //             }
 //
 //             // Seed the 'from' account.
-//             let rando0 = KeyPair::new();
+//             let rando0 = Keypair::new();
 //             let tx = Transaction::new(&mint.keypair(), rando0.pubkey(), 1_000, last_id);
 //             bank.process_transaction(&tx).unwrap();
 //
-//             let rando1 = KeyPair::new();
+//             let rando1 = Keypair::new();
 //             let tx = Transaction::new(&rando0, rando1.pubkey(), 2, last_id);
 //             bank.process_transaction(&tx).unwrap();
 //
@@ -102,9 +102,9 @@ fn bench_banking_stage_multi_accounts(bencher: &mut Bencher) {
     let num_dst_accounts = 8 * 1024;
     let num_src_accounts = 8 * 1024;
 
-    let srckeys: Vec<_> = (0..num_src_accounts).map(|_| KeyPair::new()).collect();
+    let srckeys: Vec<_> = (0..num_src_accounts).map(|_| Keypair::new()).collect();
     let dstkeys: Vec<_> = (0..num_dst_accounts)
-        .map(|_| KeyPair::new().pubkey())
+        .map(|_| Keypair::new().pubkey())
         .collect();
 
     let transactions: Vec<_> = (0..tx)
@@ -175,7 +175,7 @@ fn bench_banking_stage_single_from(bencher: &mut Bencher) {
     let mut pubkeys = Vec::new();
     let num_keys = 8;
     for _ in 0..num_keys {
-        pubkeys.push(KeyPair::new().pubkey());
+        pubkeys.push(Keypair::new().pubkey());
     }
 
     let transactions: Vec<_> = (0..tx)

--- a/benches/ledger.rs
+++ b/benches/ledger.rs
@@ -6,14 +6,14 @@ use criterion::{Bencher, Criterion};
 use solana::hash::{hash, Hash};
 use solana::ledger::{next_entries, reconstruct_entries_from_blobs, Block};
 use solana::packet::BlobRecycler;
-use solana::signature::{KeyPair, KeyPairUtil};
+use solana::signature::{Keypair, KeypairUtil};
 use solana::transaction::Transaction;
 use std::collections::VecDeque;
 
 fn bench_block_to_blobs_to_block(bencher: &mut Bencher) {
     let zero = Hash::default();
     let one = hash(&zero.as_ref());
-    let keypair = KeyPair::new();
+    let keypair = Keypair::new();
     let tx0 = Transaction::new(&keypair, keypair.pubkey(), 1, one);
     let transactions = vec![tx0; 10];
     let entries = next_entries(&zero, 1, transactions);

--- a/benches/sigverify.rs
+++ b/benches/sigverify.rs
@@ -9,7 +9,7 @@ use solana::packet::{to_packets, PacketRecycler};
 use solana::sigverify;
 use solana::transaction::test_tx;
 
-fn bench_sig_verify(bencher: &mut Bencher) {
+fn bench_sigverify(bencher: &mut Bencher) {
     let tx = test_tx();
 
     // generate packet vector
@@ -23,8 +23,8 @@ fn bench_sig_verify(bencher: &mut Bencher) {
 }
 
 fn bench(criterion: &mut Criterion) {
-    criterion.bench_function("bench_sig_verify", |bencher| {
-        bench_sig_verify(bencher);
+    criterion.bench_function("bench_sigverify", |bencher| {
+        bench_sigverify(bencher);
     });
 }
 

--- a/src/bank.rs
+++ b/src/bank.rs
@@ -14,7 +14,7 @@ use ledger::Block;
 use log::Level;
 use mint::Mint;
 use payment_plan::{Payment, PaymentPlan, Witness};
-use signature::{KeyPair, PublicKey, Signature};
+use signature::{Keypair, PublicKey, Signature};
 use std::collections::hash_map::Entry::Occupied;
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::result;
@@ -519,7 +519,7 @@ impl Bank {
     pub fn transfer(
         &self,
         n: i64,
-        keypair: &KeyPair,
+        keypair: &Keypair,
         to: PublicKey,
         last_id: Hash,
     ) -> Result<Signature> {
@@ -534,7 +534,7 @@ impl Bank {
     pub fn transfer_on_date(
         &self,
         n: i64,
-        keypair: &KeyPair,
+        keypair: &Keypair,
         to: PublicKey,
         dt: DateTime<Utc>,
         last_id: Hash,
@@ -580,14 +580,14 @@ mod tests {
     use hash::hash;
     use ledger;
     use packet::BLOB_DATA_SIZE;
-    use signature::KeyPairUtil;
+    use signature::KeypairUtil;
     use std::io::{BufReader, Cursor, Seek, SeekFrom};
     use std::mem::size_of;
 
     #[test]
     fn test_two_payments_to_one_party() {
         let mint = Mint::new(10_000);
-        let pubkey = KeyPair::new().pubkey();
+        let pubkey = Keypair::new().pubkey();
         let bank = Bank::new(&mint);
         assert_eq!(bank.last_id(), mint.last_id());
 
@@ -604,7 +604,7 @@ mod tests {
     #[test]
     fn test_negative_tokens() {
         let mint = Mint::new(1);
-        let pubkey = KeyPair::new().pubkey();
+        let pubkey = Keypair::new().pubkey();
         let bank = Bank::new(&mint);
         assert_eq!(
             bank.transfer(-1, &mint.keypair(), pubkey, mint.last_id()),
@@ -617,7 +617,7 @@ mod tests {
     fn test_account_not_found() {
         let mint = Mint::new(1);
         let bank = Bank::new(&mint);
-        let keypair = KeyPair::new();
+        let keypair = Keypair::new();
         assert_eq!(
             bank.transfer(1, &keypair, mint.pubkey(), mint.last_id()),
             Err(BankError::AccountNotFound(keypair.pubkey()))
@@ -629,7 +629,7 @@ mod tests {
     fn test_insufficient_funds() {
         let mint = Mint::new(11_000);
         let bank = Bank::new(&mint);
-        let pubkey = KeyPair::new().pubkey();
+        let pubkey = Keypair::new().pubkey();
         bank.transfer(1_000, &mint.keypair(), pubkey, mint.last_id())
             .unwrap();
         assert_eq!(bank.transaction_count(), 1);
@@ -648,7 +648,7 @@ mod tests {
     fn test_transfer_to_newb() {
         let mint = Mint::new(10_000);
         let bank = Bank::new(&mint);
-        let pubkey = KeyPair::new().pubkey();
+        let pubkey = Keypair::new().pubkey();
         bank.transfer(500, &mint.keypair(), pubkey, mint.last_id())
             .unwrap();
         assert_eq!(bank.get_balance(&pubkey), 500);
@@ -658,7 +658,7 @@ mod tests {
     fn test_transfer_on_date() {
         let mint = Mint::new(1);
         let bank = Bank::new(&mint);
-        let pubkey = KeyPair::new().pubkey();
+        let pubkey = Keypair::new().pubkey();
         let dt = Utc::now();
         bank.transfer_on_date(1, &mint.keypair(), pubkey, dt, mint.last_id())
             .unwrap();
@@ -690,7 +690,7 @@ mod tests {
     fn test_cancel_transfer() {
         let mint = Mint::new(1);
         let bank = Bank::new(&mint);
-        let pubkey = KeyPair::new().pubkey();
+        let pubkey = Keypair::new().pubkey();
         let dt = Utc::now();
         let sig = bank
             .transfer_on_date(1, &mint.keypair(), pubkey, dt, mint.last_id())
@@ -795,7 +795,7 @@ mod tests {
     fn test_debits_before_credits() {
         let mint = Mint::new(2);
         let bank = Bank::new(&mint);
-        let keypair = KeyPair::new();
+        let keypair = Keypair::new();
         let tx0 = Transaction::new(&mint.keypair(), keypair.pubkey(), 2, mint.last_id());
         let tx1 = Transaction::new(&keypair, mint.pubkey(), 1, mint.last_id());
         let txs = vec![tx0, tx1];
@@ -810,7 +810,7 @@ mod tests {
     fn test_process_empty_entry_is_registered() {
         let mint = Mint::new(1);
         let bank = Bank::new(&mint);
-        let keypair = KeyPair::new();
+        let keypair = Keypair::new();
         let entry = next_entry(&mint.last_id(), 1, vec![]);
         let tx = Transaction::new(&mint.keypair(), keypair.pubkey(), 1, entry.id);
 
@@ -838,7 +838,7 @@ mod tests {
         mint: &Mint,
         length: usize,
     ) -> impl Iterator<Item = Entry> {
-        let keypair = KeyPair::new();
+        let keypair = Keypair::new();
         let hash = mint.last_id();
         let mut txs = Vec::with_capacity(length);
         for i in 0..length {
@@ -858,7 +858,7 @@ mod tests {
         let mut hash = mint.last_id();
         let mut num_hashes = 0;
         for _ in 0..length {
-            let keypair = KeyPair::new();
+            let keypair = Keypair::new();
             let tx = Transaction::new(&mint.keypair(), keypair.pubkey(), 1, hash);
             let entry = Entry::new_mut(&mut hash, &mut num_hashes, vec![tx], false);
             entries.push(entry);

--- a/src/banking_stage.rs
+++ b/src/banking_stage.rs
@@ -238,7 +238,7 @@ mod test {
 //mod tests {
 //    use bank::Bank;
 //    use mint::Mint;
-//    use signature::{KeyPair, KeyPairUtil};
+//    use signature::{Keypair, KeypairUtil};
 //    use transaction::Transaction;
 //
 //    #[test]
@@ -253,7 +253,7 @@ mod test {
 //        let banking_stage = EventProcessor::new(bank, &mint.last_id(), None);
 //
 //        // Process a batch that includes a transaction that receives two tokens.
-//        let alice = KeyPair::new();
+//        let alice = Keypair::new();
 //        let tx = Transaction::new(&mint.keypair(), alice.pubkey(), 2, mint.last_id());
 //        let transactions = vec![tx];
 //        let entry0 = banking_stage.process_transactions(transactions).unwrap();

--- a/src/bin/bench-tps.rs
+++ b/src/bin/bench-tps.rs
@@ -122,11 +122,11 @@ fn send_barrier_transaction(barrier_client: &mut ThinClient, last_id: &mut Hash,
         }
 
         *last_id = barrier_client.get_last_id();
-        let sig = barrier_client
+        let signature = barrier_client
             .transfer(0, &id, id.pubkey(), last_id)
             .expect("Unable to send barrier transaction");
 
-        let confirmatiom = barrier_client.poll_for_signature(&sig);
+        let confirmatiom = barrier_client.poll_for_signature(&signature);
         let duration_ms = duration_as_ms(&transfer_start.elapsed());
         if confirmatiom.is_ok() {
             println!("barrier transaction confirmed in {}ms", duration_ms);

--- a/src/bin/bench-tps.rs
+++ b/src/bin/bench-tps.rs
@@ -19,7 +19,7 @@ use solana::metrics;
 use solana::nat::{udp_public_bind, udp_random_bind, UdpSocketPair};
 use solana::ncp::Ncp;
 use solana::service::Service;
-use solana::signature::{read_keypair, GenKeys, KeyPair, KeyPairUtil};
+use solana::signature::{read_keypair, GenKeys, Keypair, KeypairUtil};
 use solana::streamer::default_window;
 use solana::thin_client::ThinClient;
 use solana::timing::{duration_as_ms, duration_as_s};
@@ -109,7 +109,7 @@ fn sample_tx_count(
 }
 
 /// Send loopback payment of 0 tokens and confirm the network processed it
-fn send_barrier_transaction(barrier_client: &mut ThinClient, last_id: &mut Hash, id: &KeyPair) {
+fn send_barrier_transaction(barrier_client: &mut ThinClient, last_id: &mut Hash, id: &Keypair) {
     let transfer_start = Instant::now();
 
     let mut poll_count = 0;
@@ -172,8 +172,8 @@ fn send_barrier_transaction(barrier_client: &mut ThinClient, last_id: &mut Hash,
 
 fn generate_txs(
     shared_txs: &Arc<RwLock<VecDeque<Vec<Transaction>>>>,
-    id: &KeyPair,
-    keypairs: &[KeyPair],
+    id: &Keypair,
+    keypairs: &[Keypair],
     last_id: &Hash,
     threads: usize,
     reclaim: bool,
@@ -271,7 +271,7 @@ fn do_tx_transfers(
     }
 }
 
-fn airdrop_tokens(client: &mut ThinClient, leader: &NodeInfo, id: &KeyPair, tx_count: i64) {
+fn airdrop_tokens(client: &mut ThinClient, leader: &NodeInfo, id: &Keypair, tx_count: i64) {
     let mut drone_addr = leader.contact_info.tpu;
     drone_addr.set_port(DRONE_PORT);
 
@@ -655,7 +655,7 @@ fn spy_node(addr: Option<String>) -> (NodeInfo, UdpSocket) {
         gossip_socket_pair = udp_public_bind("gossip", 8000, 10000);
     }
 
-    let pubkey = KeyPair::new().pubkey();
+    let pubkey = Keypair::new().pubkey();
     let daddr = "0.0.0.0:0".parse().unwrap();
     assert!(!gossip_socket_pair.addr.ip().is_unspecified());
     assert!(!gossip_socket_pair.addr.ip().is_multicast());

--- a/src/bin/fullnode.rs
+++ b/src/bin/fullnode.rs
@@ -13,7 +13,7 @@ use solana::fullnode::{Config, FullNode};
 use solana::logger;
 use solana::metrics::set_panic_hook;
 use solana::service::Service;
-use solana::signature::{KeyPair, KeyPairUtil};
+use solana::signature::{Keypair, KeypairUtil};
 use solana::wallet::request_airdrop;
 use std::fs::File;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
@@ -53,7 +53,7 @@ fn main() -> () {
         .get_matches();
 
     let bind_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 8000);
-    let mut keypair = KeyPair::new();
+    let mut keypair = Keypair::new();
     let mut repl_data = NodeInfo::new_leader_with_pubkey(keypair.pubkey(), &bind_addr);
     if let Some(i) = matches.value_of("identity") {
         let path = i.to_string();

--- a/src/bin/wallet.rs
+++ b/src/bin/wallet.rs
@@ -191,13 +191,13 @@ fn parse_args() -> Result<WalletConfig, Box<error::Error>> {
             Ok(WalletCommand::Pay(tokens, to))
         }
         ("confirm", Some(confirm_matches)) => {
-            let sig_vec = bs58::decode(confirm_matches.value_of("signature").unwrap())
+            let signatures = bs58::decode(confirm_matches.value_of("signature").unwrap())
                 .into_vec()
                 .expect("base58-encoded signature");
 
-            if sig_vec.len() == std::mem::size_of::<Signature>() {
-                let sig = Signature::new(&sig_vec);
-                Ok(WalletCommand::Confirm(sig))
+            if signatures.len() == std::mem::size_of::<Signature>() {
+                let signature = Signature::new(&signatures);
+                Ok(WalletCommand::Confirm(signature))
             } else {
                 eprintln!("{}", confirm_matches.usage());
                 Err(WalletError::BadParameter("Invalid signature".to_string()))
@@ -276,12 +276,12 @@ fn process_command(
         // If client has positive balance, spend tokens in {balance} number of transactions
         WalletCommand::Pay(tokens, to) => {
             let last_id = client.get_last_id();
-            let sig = client.transfer(tokens, &config.id, to, &last_id)?;
-            println!("{}", sig);
+            let signature = client.transfer(tokens, &config.id, to, &last_id)?;
+            println!("{}", signature);
         }
         // Confirm the last client transaction by signature
-        WalletCommand::Confirm(sig) => {
-            if client.check_signature(&sig) {
+        WalletCommand::Confirm(signature) => {
+            if client.check_signature(&signature) {
                 println!("Confirmed");
             } else {
                 println!("Not found");

--- a/src/bin/wallet.rs
+++ b/src/bin/wallet.rs
@@ -13,7 +13,7 @@ use solana::crdt::NodeInfo;
 use solana::drone::DRONE_PORT;
 use solana::fullnode::Config;
 use solana::logger;
-use solana::signature::{read_keypair, KeyPair, KeyPairUtil, PublicKey, Signature};
+use solana::signature::{read_keypair, Keypair, KeypairUtil, PublicKey, Signature};
 use solana::thin_client::ThinClient;
 use solana::wallet::request_airdrop;
 use std::error;
@@ -56,7 +56,7 @@ impl error::Error for WalletError {
 
 struct WalletConfig {
     leader: NodeInfo,
-    id: KeyPair,
+    id: Keypair,
     drone_addr: SocketAddr,
     command: WalletCommand,
 }
@@ -66,7 +66,7 @@ impl Default for WalletConfig {
         let default_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 8000);
         WalletConfig {
             leader: NodeInfo::new_leader(&default_addr),
-            id: KeyPair::new(),
+            id: Keypair::new(),
             drone_addr: default_addr,
             command: WalletCommand::Balance,
         }

--- a/src/bin/wallet.rs
+++ b/src/bin/wallet.rs
@@ -13,7 +13,7 @@ use solana::crdt::NodeInfo;
 use solana::drone::DRONE_PORT;
 use solana::fullnode::Config;
 use solana::logger;
-use solana::signature::{read_keypair, Keypair, KeypairUtil, PublicKey, Signature};
+use solana::signature::{read_keypair, Keypair, KeypairUtil, Pubkey, Signature};
 use solana::thin_client::ThinClient;
 use solana::wallet::request_airdrop;
 use std::error;
@@ -27,7 +27,7 @@ enum WalletCommand {
     Address,
     Balance,
     AirDrop(i64),
-    Pay(i64, PublicKey),
+    Pay(i64, Pubkey),
     Confirm(Signature),
 }
 
@@ -177,11 +177,11 @@ fn parse_args() -> Result<WalletConfig, Box<error::Error>> {
                     .into_vec()
                     .expect("base58-encoded public key");
 
-                if pubkey_vec.len() != std::mem::size_of::<PublicKey>() {
+                if pubkey_vec.len() != std::mem::size_of::<Pubkey>() {
                     eprintln!("{}", pay_matches.usage());
                     Err(WalletError::BadParameter("Invalid public key".to_string()))?;
                 }
-                PublicKey::new(&pubkey_vec)
+                Pubkey::new(&pubkey_vec)
             } else {
                 id.pubkey()
             };

--- a/src/budget.rs
+++ b/src/budget.rs
@@ -58,12 +58,7 @@ impl Budget {
     }
 
     /// Create a budget that pays `tokens` to `to` after the given DateTime.
-    pub fn new_future_payment(
-        dt: DateTime<Utc>,
-        from: Pubkey,
-        tokens: i64,
-        to: Pubkey,
-    ) -> Self {
+    pub fn new_future_payment(dt: DateTime<Utc>, from: Pubkey, tokens: i64, to: Pubkey) -> Self {
         Budget::After(Condition::Timestamp(dt, from), Payment { tokens, to })
     }
 

--- a/src/budget.rs
+++ b/src/budget.rs
@@ -118,7 +118,7 @@ impl PaymentPlan for Budget {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use signature::{KeyPair, KeyPairUtil};
+    use signature::{Keypair, KeypairUtil};
 
     #[test]
     fn test_signature_satisfied() {
@@ -160,8 +160,8 @@ mod tests {
     #[test]
     fn test_future_payment() {
         let dt = Utc.ymd(2014, 11, 14).and_hms(8, 9, 10);
-        let from = KeyPair::new().pubkey();
-        let to = KeyPair::new().pubkey();
+        let from = Keypair::new().pubkey();
+        let to = Keypair::new().pubkey();
 
         let mut budget = Budget::new_future_payment(dt, from, 42, to);
         budget.apply_witness(&Witness::Timestamp(dt), &from);
@@ -173,8 +173,8 @@ mod tests {
         // Ensure timestamp will only be acknowledged if it came from the
         // whitelisted public key.
         let dt = Utc.ymd(2014, 11, 14).and_hms(8, 9, 10);
-        let from = KeyPair::new().pubkey();
-        let to = KeyPair::new().pubkey();
+        let from = Keypair::new().pubkey();
+        let to = Keypair::new().pubkey();
 
         let mut budget = Budget::new_future_payment(dt, from, 42, to);
         let orig_budget = budget.clone();

--- a/src/choose_gossip_peer_strategy.rs
+++ b/src/choose_gossip_peer_strategy.rs
@@ -285,8 +285,8 @@ mod tests {
         remote.insert(key1, 0);
 
         for i in 0..num_peers {
-            let pk = Keypair::new().pubkey();
-            rumors.insert(pk, i);
+            let pubkey = Keypair::new().pubkey();
+            rumors.insert(pubkey, i);
         }
 
         external_liveness.insert(key1, rumors);
@@ -316,8 +316,8 @@ mod tests {
         remote.insert(key1, old_index);
 
         for _i in 0..num_peers {
-            let pk = Keypair::new().pubkey();
-            rumors.insert(pk, old_index);
+            let pubkey = Keypair::new().pubkey();
+            rumors.insert(pubkey, old_index);
         }
 
         external_liveness.insert(key1, rumors);

--- a/src/choose_gossip_peer_strategy.rs
+++ b/src/choose_gossip_peer_strategy.rs
@@ -192,7 +192,7 @@ impl<'a> ChooseGossipPeerStrategy for ChooseWeightedPeerStrategy<'a> {
 mod tests {
     use choose_gossip_peer_strategy::{ChooseWeightedPeerStrategy, DEFAULT_WEIGHT};
     use logger;
-    use signature::{KeyPair, KeyPairUtil, PublicKey};
+    use signature::{Keypair, KeypairUtil, PublicKey};
     use std;
     use std::collections::HashMap;
 
@@ -205,7 +205,7 @@ mod tests {
         logger::setup();
 
         // Initialize the filler keys
-        let key1 = KeyPair::new().pubkey();
+        let key1 = Keypair::new().pubkey();
 
         let remote: HashMap<PublicKey, u64> = HashMap::new();
         let external_liveness: HashMap<PublicKey, HashMap<PublicKey, u64>> = HashMap::new();
@@ -224,8 +224,8 @@ mod tests {
         logger::setup();
 
         // Initialize the filler keys
-        let key1 = KeyPair::new().pubkey();
-        let key2 = KeyPair::new().pubkey();
+        let key1 = Keypair::new().pubkey();
+        let key2 = Keypair::new().pubkey();
 
         let remote: HashMap<PublicKey, u64> = HashMap::new();
         let mut external_liveness: HashMap<PublicKey, HashMap<PublicKey, u64>> = HashMap::new();
@@ -249,8 +249,8 @@ mod tests {
         logger::setup();
 
         // Initialize the filler keys
-        let key1 = KeyPair::new().pubkey();
-        let key2 = KeyPair::new().pubkey();
+        let key1 = Keypair::new().pubkey();
+        let key2 = Keypair::new().pubkey();
 
         let remote: HashMap<PublicKey, u64> = HashMap::new();
         let mut external_liveness: HashMap<PublicKey, HashMap<PublicKey, u64>> = HashMap::new();
@@ -273,7 +273,7 @@ mod tests {
         logger::setup();
 
         // Initialize the filler keys
-        let key1 = KeyPair::new().pubkey();
+        let key1 = Keypair::new().pubkey();
 
         let mut remote: HashMap<PublicKey, u64> = HashMap::new();
         let mut external_liveness: HashMap<PublicKey, HashMap<PublicKey, u64>> = HashMap::new();
@@ -285,7 +285,7 @@ mod tests {
         remote.insert(key1, 0);
 
         for i in 0..num_peers {
-            let pk = KeyPair::new().pubkey();
+            let pk = Keypair::new().pubkey();
             rumors.insert(pk, i);
         }
 
@@ -303,7 +303,7 @@ mod tests {
         logger::setup();
 
         // Initialize the filler keys
-        let key1 = KeyPair::new().pubkey();
+        let key1 = Keypair::new().pubkey();
 
         let mut remote: HashMap<PublicKey, u64> = HashMap::new();
         let mut external_liveness: HashMap<PublicKey, HashMap<PublicKey, u64>> = HashMap::new();
@@ -316,7 +316,7 @@ mod tests {
         remote.insert(key1, old_index);
 
         for _i in 0..num_peers {
-            let pk = KeyPair::new().pubkey();
+            let pk = Keypair::new().pubkey();
             rumors.insert(pk, old_index);
         }
 

--- a/src/crdt.rs
+++ b/src/crdt.rs
@@ -25,7 +25,7 @@ use pnet_datalink as datalink;
 use rand::{thread_rng, RngCore};
 use rayon::prelude::*;
 use result::{Error, Result};
-use signature::{KeyPair, KeyPairUtil, PublicKey};
+use signature::{Keypair, KeypairUtil, PublicKey};
 use std;
 use std::collections::HashMap;
 use std::collections::VecDeque;
@@ -176,7 +176,7 @@ impl NodeInfo {
         let addr: SocketAddr = "0.0.0.0:0".parse().unwrap();
         assert!(addr.ip().is_unspecified());
         Self::new(
-            KeyPair::new().pubkey(),
+            Keypair::new().pubkey(),
             addr.clone(),
             addr.clone(),
             addr.clone(),
@@ -190,7 +190,7 @@ impl NodeInfo {
         let addr: SocketAddr = "224.0.1.255:1000".parse().unwrap();
         assert!(addr.ip().is_multicast());
         Self::new(
-            KeyPair::new().pubkey(),
+            Keypair::new().pubkey(),
             addr.clone(),
             addr.clone(),
             addr.clone(),
@@ -223,7 +223,7 @@ impl NodeInfo {
         )
     }
     pub fn new_leader(bind_addr: &SocketAddr) -> Self {
-        let keypair = KeyPair::new();
+        let keypair = Keypair::new();
         Self::new_leader_with_pubkey(keypair.pubkey(), bind_addr)
     }
     pub fn new_entry_point(gossip_addr: SocketAddr) -> Self {
@@ -1269,7 +1269,7 @@ pub struct TestNode {
 
 impl TestNode {
     pub fn new_localhost() -> Self {
-        let pubkey = KeyPair::new().pubkey();
+        let pubkey = Keypair::new().pubkey();
         Self::new_localhost_with_pubkey(pubkey)
     }
     pub fn new_localhost_with_pubkey(pubkey: PublicKey) -> Self {
@@ -1381,7 +1381,7 @@ mod tests {
     use logger;
     use packet::BlobRecycler;
     use result::Error;
-    use signature::{KeyPair, KeyPairUtil, PublicKey};
+    use signature::{Keypair, KeypairUtil, PublicKey};
     use std::fs::remove_dir_all;
     use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::mpsc::channel;
@@ -1403,7 +1403,7 @@ mod tests {
     #[test]
     fn test_bad_address() {
         let d1 = NodeInfo::new(
-            KeyPair::new().pubkey(),
+            Keypair::new().pubkey(),
             "0.0.0.0:1234".parse().unwrap(),
             "0.0.0.0:1235".parse().unwrap(),
             "0.0.0.0:1236".parse().unwrap(),
@@ -1415,7 +1415,7 @@ mod tests {
             Some(Error::CrdtError(CrdtError::BadGossipAddress))
         );
         let d1_1 = NodeInfo::new(
-            KeyPair::new().pubkey(),
+            Keypair::new().pubkey(),
             "0.0.0.1:1234".parse().unwrap(),
             "0.0.0.0:1235".parse().unwrap(),
             "0.0.0.0:1236".parse().unwrap(),
@@ -1427,7 +1427,7 @@ mod tests {
             Some(Error::CrdtError(CrdtError::BadContactInfo))
         );
         let d2 = NodeInfo::new(
-            KeyPair::new().pubkey(),
+            Keypair::new().pubkey(),
             "0.0.0.1:0".parse().unwrap(),
             "0.0.0.1:0".parse().unwrap(),
             "0.0.0.1:0".parse().unwrap(),
@@ -1439,7 +1439,7 @@ mod tests {
             Some(Error::CrdtError(CrdtError::BadGossipAddress))
         );
         let d2_1 = NodeInfo::new(
-            KeyPair::new().pubkey(),
+            Keypair::new().pubkey(),
             "0.0.0.1:1234".parse().unwrap(),
             "0.0.0.1:0".parse().unwrap(),
             "0.0.0.1:0".parse().unwrap(),
@@ -1467,7 +1467,7 @@ mod tests {
             Some(Error::CrdtError(CrdtError::BadNodeInfo))
         );
         let d6 = NodeInfo::new(
-            KeyPair::new().pubkey(),
+            Keypair::new().pubkey(),
             "0.0.0.0:1234".parse().unwrap(),
             "0.0.0.0:0".parse().unwrap(),
             "0.0.0.0:0".parse().unwrap(),
@@ -1479,7 +1479,7 @@ mod tests {
             Some(Error::CrdtError(CrdtError::BadGossipAddress))
         );
         let d7 = NodeInfo::new(
-            KeyPair::new().pubkey(),
+            Keypair::new().pubkey(),
             "0.0.0.1:0".parse().unwrap(),
             "0.0.0.0:0".parse().unwrap(),
             "0.0.0.0:0".parse().unwrap(),
@@ -1491,7 +1491,7 @@ mod tests {
             Some(Error::CrdtError(CrdtError::BadGossipAddress))
         );
         let d8 = NodeInfo::new(
-            KeyPair::new().pubkey(),
+            Keypair::new().pubkey(),
             "0.0.0.1:1234".parse().unwrap(),
             "0.0.0.0:0".parse().unwrap(),
             "0.0.0.0:0".parse().unwrap(),
@@ -1504,7 +1504,7 @@ mod tests {
     #[test]
     fn insert_test() {
         let mut d = NodeInfo::new(
-            KeyPair::new().pubkey(),
+            Keypair::new().pubkey(),
             "127.0.0.1:1234".parse().unwrap(),
             "127.0.0.1:1235".parse().unwrap(),
             "127.0.0.1:1236".parse().unwrap(),
@@ -1597,7 +1597,7 @@ mod tests {
     }
     #[test]
     fn replicated_data_new_leader_with_pubkey() {
-        let kp = KeyPair::new();
+        let kp = Keypair::new();
         let d1 = NodeInfo::new_leader_with_pubkey(
             kp.pubkey().clone(),
             &"127.0.0.1:1234".parse().unwrap(),
@@ -1615,7 +1615,7 @@ mod tests {
     #[test]
     fn update_test() {
         let d1 = NodeInfo::new(
-            KeyPair::new().pubkey(),
+            Keypair::new().pubkey(),
             "127.0.0.1:1234".parse().unwrap(),
             "127.0.0.1:1235".parse().unwrap(),
             "127.0.0.1:1236".parse().unwrap(),
@@ -1623,7 +1623,7 @@ mod tests {
             "127.0.0.1:1238".parse().unwrap(),
         );
         let d2 = NodeInfo::new(
-            KeyPair::new().pubkey(),
+            Keypair::new().pubkey(),
             "127.0.0.1:1234".parse().unwrap(),
             "127.0.0.1:1235".parse().unwrap(),
             "127.0.0.1:1236".parse().unwrap(),
@@ -1631,7 +1631,7 @@ mod tests {
             "127.0.0.1:1238".parse().unwrap(),
         );
         let d3 = NodeInfo::new(
-            KeyPair::new().pubkey(),
+            Keypair::new().pubkey(),
             "127.0.0.1:1234".parse().unwrap(),
             "127.0.0.1:1235".parse().unwrap(),
             "127.0.0.1:1236".parse().unwrap(),
@@ -1674,7 +1674,7 @@ mod tests {
     #[test]
     fn window_index_request() {
         let me = NodeInfo::new(
-            KeyPair::new().pubkey(),
+            Keypair::new().pubkey(),
             "127.0.0.1:1234".parse().unwrap(),
             "127.0.0.1:1235".parse().unwrap(),
             "127.0.0.1:1236".parse().unwrap(),
@@ -1685,7 +1685,7 @@ mod tests {
         let rv = crdt.window_index_request(0);
         assert_matches!(rv, Err(Error::CrdtError(CrdtError::NoPeers)));
         let nxt = NodeInfo::new(
-            KeyPair::new().pubkey(),
+            Keypair::new().pubkey(),
             "127.0.0.1:1234".parse().unwrap(),
             "127.0.0.1:1235".parse().unwrap(),
             "127.0.0.1:1236".parse().unwrap(),
@@ -1696,7 +1696,7 @@ mod tests {
         let rv = crdt.window_index_request(0);
         assert_matches!(rv, Err(Error::CrdtError(CrdtError::NoPeers)));
         let nxt = NodeInfo::new(
-            KeyPair::new().pubkey(),
+            Keypair::new().pubkey(),
             "127.0.0.2:1234".parse().unwrap(),
             "127.0.0.1:1235".parse().unwrap(),
             "127.0.0.1:1236".parse().unwrap(),
@@ -1709,7 +1709,7 @@ mod tests {
         assert_eq!(rv.0, "127.0.0.2:1234".parse().unwrap());
 
         let nxt = NodeInfo::new(
-            KeyPair::new().pubkey(),
+            Keypair::new().pubkey(),
             "127.0.0.3:1234".parse().unwrap(),
             "127.0.0.1:1235".parse().unwrap(),
             "127.0.0.1:1236".parse().unwrap(),
@@ -1735,7 +1735,7 @@ mod tests {
     #[test]
     fn gossip_request_bad_addr() {
         let me = NodeInfo::new(
-            KeyPair::new().pubkey(),
+            Keypair::new().pubkey(),
             "127.0.0.1:127".parse().unwrap(),
             "127.0.0.1:127".parse().unwrap(),
             "127.0.0.1:127".parse().unwrap(),
@@ -1760,7 +1760,7 @@ mod tests {
     #[test]
     fn gossip_request() {
         let me = NodeInfo::new(
-            KeyPair::new().pubkey(),
+            Keypair::new().pubkey(),
             "127.0.0.1:1234".parse().unwrap(),
             "127.0.0.1:1235".parse().unwrap(),
             "127.0.0.1:1236".parse().unwrap(),
@@ -1771,7 +1771,7 @@ mod tests {
         let rv = crdt.gossip_request();
         assert_matches!(rv, Err(Error::CrdtError(CrdtError::NoPeers)));
         let nxt1 = NodeInfo::new(
-            KeyPair::new().pubkey(),
+            Keypair::new().pubkey(),
             "127.0.0.2:1234".parse().unwrap(),
             "127.0.0.1:1235".parse().unwrap(),
             "127.0.0.1:1236".parse().unwrap(),
@@ -1894,7 +1894,7 @@ mod tests {
         logger::setup();
         let window = default_window();
         let me = NodeInfo::new(
-            KeyPair::new().pubkey(),
+            Keypair::new().pubkey(),
             "127.0.0.1:1234".parse().unwrap(),
             "127.0.0.1:1235".parse().unwrap(),
             "127.0.0.1:1236".parse().unwrap(),
@@ -1917,7 +1917,7 @@ mod tests {
         assert!(rv.is_none());
 
         fn tmp_ledger(name: &str) -> String {
-            let keypair = KeyPair::new();
+            let keypair = Keypair::new();
 
             let path = format!("/tmp/farf/{}-{}", name, keypair.pubkey());
 
@@ -1998,7 +1998,7 @@ mod tests {
         //add a bunch of nodes with a new leader
         for _ in 0..10 {
             let mut dum = NodeInfo::new_entry_point("127.0.0.1:1234".parse().unwrap());
-            dum.id = KeyPair::new().pubkey();
+            dum.id = Keypair::new().pubkey();
             dum.leader_id = leader1.id;
             crdt.insert(&dum);
         }
@@ -2061,7 +2061,7 @@ mod tests {
     fn test_default_leader() {
         logger::setup();
         let node_info = NodeInfo::new(
-            KeyPair::new().pubkey(),
+            Keypair::new().pubkey(),
             "127.0.0.1:1234".parse().unwrap(),
             "127.0.0.1:1235".parse().unwrap(),
             "127.0.0.1:1236".parse().unwrap(),

--- a/src/crdt.rs
+++ b/src/crdt.rs
@@ -902,7 +902,7 @@ impl Crdt {
     ) {
         trace!("got updates {}", data.len());
         // TODO we need to punish/spam resist here
-        // sig verify the whole update and slash anyone who sends a bad update
+        // sigverify the whole update and slash anyone who sends a bad update
         let mut insert_total = 0;
         for v in data {
             insert_total += self.insert(&v);

--- a/src/crdt.rs
+++ b/src/crdt.rs
@@ -909,8 +909,8 @@ impl Crdt {
         }
         inc_new_counter_info!("crdt-update-count", insert_total);
 
-        for (pk, external_remote_index) in external_liveness {
-            let remote_entry = if let Some(v) = self.remote.get(pk) {
+        for (pubkey, external_remote_index) in external_liveness {
+            let remote_entry = if let Some(v) = self.remote.get(pubkey) {
                 *v
             } else {
                 0
@@ -922,7 +922,7 @@ impl Crdt {
 
             let liveness_entry = self
                 .external_liveness
-                .entry(*pk)
+                .entry(*pubkey)
                 .or_insert_with(HashMap::new);
             let peer_index = *liveness_entry.entry(from).or_insert(*external_remote_index);
             if *external_remote_index > peer_index {

--- a/src/crdt.rs
+++ b/src/crdt.rs
@@ -228,14 +228,7 @@ impl NodeInfo {
     }
     pub fn new_entry_point(gossip_addr: SocketAddr) -> Self {
         let daddr: SocketAddr = "0.0.0.0:0".parse().unwrap();
-        NodeInfo::new(
-            Pubkey::default(),
-            gossip_addr,
-            daddr,
-            daddr,
-            daddr,
-            daddr,
-        )
+        NodeInfo::new(Pubkey::default(), gossip_addr, daddr, daddr, daddr, daddr)
     }
 }
 

--- a/src/crdt.rs
+++ b/src/crdt.rs
@@ -1597,12 +1597,12 @@ mod tests {
     }
     #[test]
     fn replicated_data_new_leader_with_pubkey() {
-        let kp = Keypair::new();
+        let keypair = Keypair::new();
         let d1 = NodeInfo::new_leader_with_pubkey(
-            kp.pubkey().clone(),
+            keypair.pubkey().clone(),
             &"127.0.0.1:1234".parse().unwrap(),
         );
-        assert_eq!(d1.id, kp.pubkey());
+        assert_eq!(d1.id, keypair.pubkey());
         assert_eq!(d1.contact_info.ncp, "127.0.0.1:1235".parse().unwrap());
         assert_eq!(d1.contact_info.tvu, "127.0.0.1:1236".parse().unwrap());
         assert_eq!(d1.contact_info.rpu, "127.0.0.1:1237".parse().unwrap());

--- a/src/drone.rs
+++ b/src/drone.rs
@@ -23,7 +23,7 @@ pub const DRONE_PORT: u16 = 9900;
 pub enum DroneRequest {
     GetAirdrop {
         airdrop_request_amount: u64,
-        client_public_key: PublicKey,
+        client_pubkey: PublicKey,
     },
 }
 
@@ -111,16 +111,16 @@ impl Drone {
         let tx = match req {
             DroneRequest::GetAirdrop {
                 airdrop_request_amount,
-                client_public_key,
+                client_pubkey,
             } => {
                 info!(
                     "Requesting airdrop of {} to {:?}",
-                    airdrop_request_amount, client_public_key
+                    airdrop_request_amount, client_pubkey
                 );
                 request_amount = airdrop_request_amount;
                 Transaction::new(
                     &self.mint_keypair,
-                    client_public_key,
+                    client_pubkey,
                     airdrop_request_amount as i64,
                     last_id,
                 )
@@ -321,14 +321,14 @@ mod tests {
 
         let bob_req = DroneRequest::GetAirdrop {
             airdrop_request_amount: 50,
-            client_public_key: bob_pubkey,
+            client_pubkey: bob_pubkey,
         };
         let bob_sig = drone.send_airdrop(bob_req).unwrap();
         assert!(client.poll_for_signature(&bob_sig).is_ok());
 
         let carlos_req = DroneRequest::GetAirdrop {
             airdrop_request_amount: 5_000_000,
-            client_public_key: carlos_pubkey,
+            client_pubkey: carlos_pubkey,
         };
         let carlos_sig = drone.send_airdrop(carlos_req).unwrap();
         assert!(client.poll_for_signature(&carlos_sig).is_ok());

--- a/src/drone.rs
+++ b/src/drone.rs
@@ -7,7 +7,7 @@
 use influx_db_client as influxdb;
 use metrics;
 use signature::Signature;
-use signature::{KeyPair, PublicKey};
+use signature::{Keypair, PublicKey};
 use std::io;
 use std::io::{Error, ErrorKind};
 use std::net::{IpAddr, SocketAddr, UdpSocket};
@@ -28,7 +28,7 @@ pub enum DroneRequest {
 }
 
 pub struct Drone {
-    mint_keypair: KeyPair,
+    mint_keypair: Keypair,
     ip_cache: Vec<IpAddr>,
     _airdrop_addr: SocketAddr,
     transactions_addr: SocketAddr,
@@ -40,7 +40,7 @@ pub struct Drone {
 
 impl Drone {
     pub fn new(
-        mint_keypair: KeyPair,
+        mint_keypair: Keypair,
         _airdrop_addr: SocketAddr,
         transactions_addr: SocketAddr,
         requests_addr: SocketAddr,
@@ -163,7 +163,7 @@ mod tests {
     use logger;
     use mint::Mint;
     use service::Service;
-    use signature::{KeyPair, KeyPairUtil};
+    use signature::{Keypair, KeypairUtil};
     use std::fs::remove_dir_all;
     use std::net::{SocketAddr, UdpSocket};
     use std::sync::atomic::{AtomicBool, Ordering};
@@ -174,7 +174,7 @@ mod tests {
 
     #[test]
     fn test_check_request_limit() {
-        let keypair = KeyPair::new();
+        let keypair = Keypair::new();
         let mut addr: SocketAddr = "0.0.0.0:9900".parse().unwrap();
         addr.set_ip(get_ip_addr().unwrap());
         let transactions_addr = "0.0.0.0:0".parse().unwrap();
@@ -194,7 +194,7 @@ mod tests {
 
     #[test]
     fn test_clear_request_count() {
-        let keypair = KeyPair::new();
+        let keypair = Keypair::new();
         let mut addr: SocketAddr = "0.0.0.0:9900".parse().unwrap();
         addr.set_ip(get_ip_addr().unwrap());
         let transactions_addr = "0.0.0.0:0".parse().unwrap();
@@ -208,7 +208,7 @@ mod tests {
 
     #[test]
     fn test_add_ip_to_cache() {
-        let keypair = KeyPair::new();
+        let keypair = Keypair::new();
         let mut addr: SocketAddr = "0.0.0.0:9900".parse().unwrap();
         addr.set_ip(get_ip_addr().unwrap());
         let transactions_addr = "0.0.0.0:0".parse().unwrap();
@@ -223,7 +223,7 @@ mod tests {
 
     #[test]
     fn test_clear_ip_cache() {
-        let keypair = KeyPair::new();
+        let keypair = Keypair::new();
         let mut addr: SocketAddr = "0.0.0.0:9900".parse().unwrap();
         addr.set_ip(get_ip_addr().unwrap());
         let transactions_addr = "0.0.0.0:0".parse().unwrap();
@@ -240,7 +240,7 @@ mod tests {
 
     #[test]
     fn test_drone_default_init() {
-        let keypair = KeyPair::new();
+        let keypair = Keypair::new();
         let mut addr: SocketAddr = "0.0.0.0:9900".parse().unwrap();
         addr.set_ip(get_ip_addr().unwrap());
         let transactions_addr = "0.0.0.0:0".parse().unwrap();
@@ -260,7 +260,7 @@ mod tests {
     }
 
     fn tmp_ledger_path(name: &str) -> String {
-        let keypair = KeyPair::new();
+        let keypair = Keypair::new();
 
         format!("/tmp/tmp-ledger-{}-{}", name, keypair.pubkey())
     }
@@ -272,13 +272,13 @@ mod tests {
         const TPS_BATCH: i64 = 5_000_000;
 
         logger::setup();
-        let leader_keypair = KeyPair::new();
+        let leader_keypair = Keypair::new();
         let leader = TestNode::new_localhost_with_pubkey(leader_keypair.pubkey());
 
         let alice = Mint::new(10_000_000);
         let bank = Bank::new(&alice);
-        let bob_pubkey = KeyPair::new().pubkey();
-        let carlos_pubkey = KeyPair::new().pubkey();
+        let bob_pubkey = Keypair::new().pubkey();
+        let carlos_pubkey = Keypair::new().pubkey();
         let exit = Arc::new(AtomicBool::new(false));
         let leader_data = leader.data.clone();
         let ledger_path = tmp_ledger_path("send_airdrop");

--- a/src/drone.rs
+++ b/src/drone.rs
@@ -7,7 +7,7 @@
 use influx_db_client as influxdb;
 use metrics;
 use signature::Signature;
-use signature::{Keypair, PublicKey};
+use signature::{Keypair, Pubkey};
 use std::io;
 use std::io::{Error, ErrorKind};
 use std::net::{IpAddr, SocketAddr, UdpSocket};
@@ -23,7 +23,7 @@ pub const DRONE_PORT: u16 = 9900;
 pub enum DroneRequest {
     GetAirdrop {
         airdrop_request_amount: u64,
-        client_pubkey: PublicKey,
+        client_pubkey: Pubkey,
     },
 }
 

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -219,7 +219,7 @@ mod tests {
     use chrono::prelude::*;
     use entry::Entry;
     use hash::hash;
-    use signature::{KeyPair, KeyPairUtil};
+    use signature::{Keypair, KeypairUtil};
     use transaction::Transaction;
 
     #[test]
@@ -237,7 +237,7 @@ mod tests {
         let zero = Hash::default();
 
         // First, verify entries
-        let keypair = KeyPair::new();
+        let keypair = Keypair::new();
         let tx0 = Transaction::new(&keypair, keypair.pubkey(), 0, zero);
         let tx1 = Transaction::new(&keypair, keypair.pubkey(), 1, zero);
         let mut e0 = Entry::new(&zero, 0, vec![tx0.clone(), tx1.clone()], false);
@@ -254,7 +254,7 @@ mod tests {
         let zero = Hash::default();
 
         // First, verify entries
-        let keypair = KeyPair::new();
+        let keypair = Keypair::new();
         let tx0 = Transaction::new_timestamp(&keypair, Utc::now(), zero);
         let tx1 = Transaction::new_signature(&keypair, Default::default(), zero);
         let mut e0 = Entry::new(&zero, 0, vec![tx0.clone(), tx1.clone()], false);
@@ -277,7 +277,7 @@ mod tests {
         assert_eq!(tick.num_hashes, 0);
         assert_eq!(tick.id, zero);
 
-        let keypair = KeyPair::new();
+        let keypair = Keypair::new();
         let tx0 = Transaction::new_timestamp(&keypair, Utc::now(), zero);
         let entry0 = next_entry(&zero, 1, vec![tx0.clone()]);
         assert_eq!(entry0.num_hashes, 1);
@@ -288,7 +288,7 @@ mod tests {
     #[should_panic]
     fn test_next_entry_panic() {
         let zero = Hash::default();
-        let keypair = KeyPair::new();
+        let keypair = Keypair::new();
         let tx = Transaction::new(&keypair, keypair.pubkey(), 0, zero);
         next_entry(&zero, 0, vec![tx]);
     }

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -6,7 +6,7 @@ use bincode::{serialize_into, serialized_size};
 use hash::{extend_and_hash, hash, Hash};
 use packet::{BlobRecycler, SharedBlob, BLOB_DATA_SIZE};
 use rayon::prelude::*;
-use signature::PublicKey;
+use signature::Pubkey;
 use std::io::Cursor;
 use std::net::SocketAddr;
 use transaction::Transaction;
@@ -83,7 +83,7 @@ impl Entry {
         &self,
         blob_recycler: &BlobRecycler,
         idx: Option<u64>,
-        id: Option<PublicKey>,
+        id: Option<Pubkey>,
         addr: Option<&SocketAddr>,
     ) -> SharedBlob {
         let blob = blob_recycler.allocate();

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -173,7 +173,7 @@ impl Entry {
 
 fn add_transaction_data(hash_data: &mut Vec<u8>, tx: &Transaction) {
     hash_data.push(0u8);
-    hash_data.extend_from_slice(&tx.sig.as_ref());
+    hash_data.extend_from_slice(&tx.signature.as_ref());
 }
 
 /// Creates the hash `num_hashes` after `start_hash`. If the transaction contains

--- a/src/entry_writer.rs
+++ b/src/entry_writer.rs
@@ -104,7 +104,7 @@ mod tests {
     use ledger;
     use mint::Mint;
     use packet::BLOB_DATA_SIZE;
-    use signature::{KeyPair, KeyPairUtil};
+    use signature::{Keypair, KeypairUtil};
     use std::io::Cursor;
     use transaction::Transaction;
 
@@ -115,7 +115,7 @@ mod tests {
 
         let writer = io::sink();
         let mut entry_writer = EntryWriter::new(&bank, writer);
-        let keypair = KeyPair::new();
+        let keypair = Keypair::new();
         let tx = Transaction::new(&mint.keypair(), keypair.pubkey(), 1, mint.last_id());
 
         // NOTE: if Entry grows to larger than a transaction, the code below falls over

--- a/src/erasure.rs
+++ b/src/erasure.rs
@@ -599,8 +599,8 @@ mod test {
     use logger;
     use packet::{BlobRecycler, BLOB_HEADER_SIZE, BLOB_SIZE};
     use rand::{thread_rng, Rng};
-    use signature::KeyPair;
-    use signature::KeyPairUtil;
+    use signature::Keypair;
+    use signature::KeypairUtil;
     //    use std::sync::{Arc, RwLock};
     use streamer::{index_blobs, WindowSlot};
 
@@ -728,7 +728,7 @@ mod test {
         }
 
         let d = crdt::NodeInfo::new(
-            KeyPair::new().pubkey(),
+            Keypair::new().pubkey(),
             "127.0.0.1:1234".parse().unwrap(),
             "127.0.0.1:1235".parse().unwrap(),
             "127.0.0.1:1236".parse().unwrap(),

--- a/src/fullnode.rs
+++ b/src/fullnode.rs
@@ -382,13 +382,13 @@ mod tests {
 
     #[test]
     fn validator_exit() {
-        let kp = Keypair::new();
-        let tn = TestNode::new_localhost_with_pubkey(kp.pubkey());
+        let keypair = Keypair::new();
+        let tn = TestNode::new_localhost_with_pubkey(keypair.pubkey());
         let alice = Mint::new(10_000);
         let bank = Bank::new(&alice);
         let exit = Arc::new(AtomicBool::new(false));
         let entry = tn.data.clone();
-        let v = FullNode::new_validator(kp, bank, 0, None, tn, &entry, exit, None, false);
+        let v = FullNode::new_validator(keypair, bank, 0, None, tn, &entry, exit, None, false);
         v.exit();
         v.join().unwrap();
     }
@@ -396,13 +396,13 @@ mod tests {
     fn validator_parallel_exit() {
         let vals: Vec<FullNode> = (0..2)
             .map(|_| {
-                let kp = Keypair::new();
-                let tn = TestNode::new_localhost_with_pubkey(kp.pubkey());
+                let keypair = Keypair::new();
+                let tn = TestNode::new_localhost_with_pubkey(keypair.pubkey());
                 let alice = Mint::new(10_000);
                 let bank = Bank::new(&alice);
                 let exit = Arc::new(AtomicBool::new(false));
                 let entry = tn.data.clone();
-                FullNode::new_validator(kp, bank, 0, None, tn, &entry, exit, None, false)
+                FullNode::new_validator(keypair, bank, 0, None, tn, &entry, exit, None, false)
             })
             .collect();
         //each validator can exit in parallel to speed many sequential calls to `join`

--- a/src/fullnode.rs
+++ b/src/fullnode.rs
@@ -8,7 +8,7 @@ use ncp::Ncp;
 use packet::BlobRecycler;
 use rpu::Rpu;
 use service::Service;
-use signature::{KeyPair, KeyPairUtil};
+use signature::{Keypair, KeypairUtil};
 use std::collections::VecDeque;
 use std::net::SocketAddr;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -37,13 +37,13 @@ pub struct Config {
 impl Config {
     pub fn new(bind_addr: &SocketAddr, pkcs8: Vec<u8>) -> Self {
         let keypair =
-            KeyPair::from_pkcs8(Input::from(&pkcs8)).expect("from_pkcs8 in fullnode::Config new");
+            Keypair::from_pkcs8(Input::from(&pkcs8)).expect("from_pkcs8 in fullnode::Config new");
         let pubkey = keypair.pubkey();
         let node_info = NodeInfo::new_leader_with_pubkey(pubkey, bind_addr);
         Config { node_info, pkcs8 }
     }
-    pub fn keypair(&self) -> KeyPair {
-        KeyPair::from_pkcs8(Input::from(&self.pkcs8))
+    pub fn keypair(&self) -> Keypair {
+        Keypair::from_pkcs8(Input::from(&self.pkcs8))
             .expect("from_pkcs8 in fullnode::Config keypair")
     }
 }
@@ -53,7 +53,7 @@ impl FullNode {
         mut node: TestNode,
         leader: bool,
         ledger_path: &str,
-        keypair: KeyPair,
+        keypair: Keypair,
         network_entry_for_validator: Option<SocketAddr>,
         sigverify_disabled: bool,
     ) -> FullNode {
@@ -127,7 +127,7 @@ impl FullNode {
         node: TestNode,
         leader: bool,
         ledger: &str,
-        keypair: KeyPair,
+        keypair: Keypair,
         network_entry_for_validator: Option<SocketAddr>,
     ) -> FullNode {
         FullNode::new_internal(
@@ -144,7 +144,7 @@ impl FullNode {
         node: TestNode,
         leader: bool,
         ledger_path: &str,
-        keypair: KeyPair,
+        keypair: Keypair,
         network_entry_for_validator: Option<SocketAddr>,
     ) -> FullNode {
         FullNode::new_internal(
@@ -202,7 +202,7 @@ impl FullNode {
     ///              `---------------------`
     /// ```
     pub fn new_leader(
-        keypair: KeyPair,
+        keypair: Keypair,
         bank: Bank,
         entry_height: u64,
         ledger_tail: Option<Vec<Entry>>,
@@ -292,7 +292,7 @@ impl FullNode {
     ///               `-------------------------------`
     /// ```
     pub fn new_validator(
-        keypair: KeyPair,
+        keypair: Keypair,
         bank: Bank,
         entry_height: u64,
         ledger_tail: Option<Vec<Entry>>,
@@ -376,13 +376,13 @@ mod tests {
     use fullnode::FullNode;
     use mint::Mint;
     use service::Service;
-    use signature::{KeyPair, KeyPairUtil};
+    use signature::{Keypair, KeypairUtil};
     use std::sync::atomic::AtomicBool;
     use std::sync::Arc;
 
     #[test]
     fn validator_exit() {
-        let kp = KeyPair::new();
+        let kp = Keypair::new();
         let tn = TestNode::new_localhost_with_pubkey(kp.pubkey());
         let alice = Mint::new(10_000);
         let bank = Bank::new(&alice);
@@ -396,7 +396,7 @@ mod tests {
     fn validator_parallel_exit() {
         let vals: Vec<FullNode> = (0..2)
             .map(|_| {
-                let kp = KeyPair::new();
+                let kp = Keypair::new();
                 let tn = TestNode::new_localhost_with_pubkey(kp.pubkey());
                 let alice = Mint::new(10_000);
                 let bank = Bank::new(&alice);

--- a/src/ledger.rs
+++ b/src/ledger.rs
@@ -508,13 +508,13 @@ mod tests {
     use entry::{next_entry, Entry};
     use hash::hash;
     use packet::{BlobRecycler, BLOB_DATA_SIZE, PACKET_DATA_SIZE};
-    use signature::{KeyPair, KeyPairUtil};
+    use signature::{Keypair, KeypairUtil};
     use std;
     use std::net::{IpAddr, Ipv4Addr, SocketAddr};
     use transaction::{Transaction, Vote};
 
     fn tmp_ledger_path(name: &str) -> String {
-        let keypair = KeyPair::new();
+        let keypair = Keypair::new();
 
         format!("/tmp/tmp-ledger-{}-{}", name, keypair.pubkey())
     }
@@ -538,7 +538,7 @@ mod tests {
     fn make_tiny_test_entries(num: usize) -> Vec<Entry> {
         let zero = Hash::default();
         let one = hash(&zero.as_ref());
-        let keypair = KeyPair::new();
+        let keypair = Keypair::new();
 
         let mut id = one;
         let mut num_hashes = 0;
@@ -557,7 +557,7 @@ mod tests {
     fn make_test_entries() -> Vec<Entry> {
         let zero = Hash::default();
         let one = hash(&zero.as_ref());
-        let keypair = KeyPair::new();
+        let keypair = Keypair::new();
         let tx0 = Transaction::new_vote(
             &keypair,
             Vote {
@@ -612,7 +612,7 @@ mod tests {
         logger::setup();
         let id = Hash::default();
         let next_id = hash(&id.as_ref());
-        let keypair = KeyPair::new();
+        let keypair = Keypair::new();
         let tx_small = Transaction::new_vote(
             &keypair,
             Vote {

--- a/src/mint.rs
+++ b/src/mint.rs
@@ -3,7 +3,7 @@
 use entry::Entry;
 use hash::{hash, Hash};
 use ring::rand::SystemRandom;
-use signature::{KeyPair, KeyPairUtil, PublicKey};
+use signature::{Keypair, KeypairUtil, PublicKey};
 use transaction::Transaction;
 use untrusted::Input;
 
@@ -17,7 +17,7 @@ pub struct Mint {
 impl Mint {
     pub fn new_with_pkcs8(tokens: i64, pkcs8: Vec<u8>) -> Self {
         let keypair =
-            KeyPair::from_pkcs8(Input::from(&pkcs8)).expect("from_pkcs8 in mint pub fn new");
+            Keypair::from_pkcs8(Input::from(&pkcs8)).expect("from_pkcs8 in mint pub fn new");
         let pubkey = keypair.pubkey();
         Mint {
             pkcs8,
@@ -28,7 +28,7 @@ impl Mint {
 
     pub fn new(tokens: i64) -> Self {
         let rnd = SystemRandom::new();
-        let pkcs8 = KeyPair::generate_pkcs8(&rnd)
+        let pkcs8 = Keypair::generate_pkcs8(&rnd)
             .expect("generate_pkcs8 in mint pub fn new")
             .to_vec();
         Self::new_with_pkcs8(tokens, pkcs8)
@@ -42,8 +42,8 @@ impl Mint {
         self.create_entries()[1].id
     }
 
-    pub fn keypair(&self) -> KeyPair {
-        KeyPair::from_pkcs8(Input::from(&self.pkcs8)).expect("from_pkcs8 in mint pub fn keypair")
+    pub fn keypair(&self) -> Keypair {
+        Keypair::from_pkcs8(Input::from(&self.pkcs8)).expect("from_pkcs8 in mint pub fn keypair")
     }
 
     pub fn pubkey(&self) -> PublicKey {

--- a/src/mint.rs
+++ b/src/mint.rs
@@ -3,14 +3,14 @@
 use entry::Entry;
 use hash::{hash, Hash};
 use ring::rand::SystemRandom;
-use signature::{Keypair, KeypairUtil, PublicKey};
+use signature::{Keypair, KeypairUtil, Pubkey};
 use transaction::Transaction;
 use untrusted::Input;
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Mint {
     pub pkcs8: Vec<u8>,
-    pubkey: PublicKey,
+    pubkey: Pubkey,
     pub tokens: i64,
 }
 
@@ -46,7 +46,7 @@ impl Mint {
         Keypair::from_pkcs8(Input::from(&self.pkcs8)).expect("from_pkcs8 in mint pub fn keypair")
     }
 
-    pub fn pubkey(&self) -> PublicKey {
+    pub fn pubkey(&self) -> Pubkey {
         self.pubkey
     }
 

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -5,7 +5,7 @@ use counter::Counter;
 use log::Level;
 use result::{Error, Result};
 use serde::Serialize;
-use signature::PublicKey;
+use signature::Pubkey;
 use std::collections::VecDeque;
 use std::fmt;
 use std::io;
@@ -302,7 +302,7 @@ pub fn to_blobs<T: Serialize>(
 }
 
 const BLOB_INDEX_END: usize = size_of::<u64>();
-const BLOB_ID_END: usize = BLOB_INDEX_END + size_of::<usize>() + size_of::<PublicKey>();
+const BLOB_ID_END: usize = BLOB_INDEX_END + size_of::<usize>() + size_of::<Pubkey>();
 const BLOB_FLAGS_END: usize = BLOB_ID_END + size_of::<u32>();
 const BLOB_SIZE_END: usize = BLOB_FLAGS_END + size_of::<u64>();
 
@@ -329,12 +329,12 @@ impl Blob {
     }
     /// sender id, we use this for identifying if its a blob from the leader that we should
     /// retransmit.  eventually blobs should have a signature that we can use ffor spam filtering
-    pub fn get_id(&self) -> Result<PublicKey> {
+    pub fn get_id(&self) -> Result<Pubkey> {
         let e = deserialize(&self.data[BLOB_INDEX_END..BLOB_ID_END])?;
         Ok(e)
     }
 
-    pub fn set_id(&mut self, id: PublicKey) -> Result<()> {
+    pub fn set_id(&mut self, id: Pubkey) -> Result<()> {
         let wtr = serialize(&id)?;
         self.data[BLOB_INDEX_END..BLOB_ID_END].clone_from_slice(&wtr);
         Ok(())

--- a/src/payment_plan.rs
+++ b/src/payment_plan.rs
@@ -4,7 +4,7 @@
 //! `Payment`, the payment is executed.
 
 use chrono::prelude::*;
-use signature::PublicKey;
+use signature::Pubkey;
 
 /// The types of events a payment plan can process.
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
@@ -12,18 +12,18 @@ pub enum Witness {
     /// The current time.
     Timestamp(DateTime<Utc>),
 
-    /// A siganture from PublicKey.
+    /// A siganture from Pubkey.
     Signature,
 }
 
-/// Some amount of tokens that should be sent to the `to` `PublicKey`.
+/// Some amount of tokens that should be sent to the `to` `Pubkey`.
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub struct Payment {
     /// Amount to be paid.
     pub tokens: i64,
 
-    /// The `PublicKey` that `tokens` should be paid to.
-    pub to: PublicKey,
+    /// The `Pubkey` that `tokens` should be paid to.
+    pub to: Pubkey,
 }
 
 /// Interface to smart contracts.
@@ -36,5 +36,5 @@ pub trait PaymentPlan {
 
     /// Apply a witness to the payment plan to see if the plan can be reduced.
     /// If so, modify the plan in-place.
-    fn apply_witness(&mut self, witness: &Witness, from: &PublicKey);
+    fn apply_witness(&mut self, witness: &Witness, from: &Pubkey);
 }

--- a/src/record_stage.rs
+++ b/src/record_stage.rs
@@ -140,7 +140,7 @@ impl Service for RecordStage {
 mod tests {
     use super::*;
     use ledger::Block;
-    use signature::{KeyPair, KeyPairUtil};
+    use signature::{Keypair, KeypairUtil};
     use std::sync::mpsc::channel;
     use std::thread::sleep;
 
@@ -185,8 +185,8 @@ mod tests {
         let (tx_sender, signal_receiver) = channel();
         let zero = Hash::default();
         let (_record_stage, entry_receiver) = RecordStage::new(signal_receiver, &zero);
-        let alice_keypair = KeyPair::new();
-        let bob_pubkey = KeyPair::new().pubkey();
+        let alice_keypair = Keypair::new();
+        let bob_pubkey = Keypair::new().pubkey();
         let tx0 = Transaction::new(&alice_keypair, bob_pubkey, 1, zero);
         let tx1 = Transaction::new(&alice_keypair, bob_pubkey, 2, zero);
         tx_sender

--- a/src/replicate_stage.rs
+++ b/src/replicate_stage.rs
@@ -8,7 +8,7 @@ use log::Level;
 use packet::BlobRecycler;
 use result::{Error, Result};
 use service::Service;
-use signature::KeyPair;
+use signature::Keypair;
 use std::net::UdpSocket;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::AtomicUsize;
@@ -72,7 +72,7 @@ impl ReplicateStage {
         Ok(())
     }
     pub fn new(
-        keypair: KeyPair,
+        keypair: Keypair,
         bank: Arc<Bank>,
         crdt: Arc<RwLock<Crdt>>,
         blob_recycler: BlobRecycler,

--- a/src/request.rs
+++ b/src/request.rs
@@ -1,12 +1,12 @@
 //! The `request` module defines the messages for the thin client.
 
 use hash::Hash;
-use signature::{PublicKey, Signature};
+use signature::{Pubkey, Signature};
 
 #[cfg_attr(feature = "cargo-clippy", allow(large_enum_variant))]
 #[derive(Serialize, Deserialize, Debug, Clone, Copy)]
 pub enum Request {
-    GetBalance { key: PublicKey },
+    GetBalance { key: Pubkey },
     GetLastId,
     GetTransactionCount,
     GetSignature { signature: Signature },
@@ -21,7 +21,7 @@ impl Request {
 
 #[derive(Serialize, Deserialize, Debug)]
 pub enum Response {
-    Balance { key: PublicKey, val: i64 },
+    Balance { key: Pubkey, val: i64 },
     LastId { id: Hash },
     TransactionCount { transaction_count: u64 },
     SignatureStatus { signature_status: bool },

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -13,7 +13,7 @@ use std::fmt;
 use std::fs::File;
 use untrusted::Input;
 
-pub type KeyPair = Ed25519KeyPair;
+pub type Keypair = Ed25519KeyPair;
 #[derive(Serialize, Deserialize, Clone, Copy, Default, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct PublicKey(GenericArray<u8, U32>);
 
@@ -74,12 +74,12 @@ impl fmt::Display for Signature {
     }
 }
 
-pub trait KeyPairUtil {
+pub trait KeypairUtil {
     fn new() -> Self;
     fn pubkey(&self) -> PublicKey;
 }
 
-impl KeyPairUtil for Ed25519KeyPair {
+impl KeypairUtil for Ed25519KeyPair {
     /// Return a new ED25519 keypair
     fn new() -> Self {
         let rng = rand::SystemRandom::new();
@@ -113,10 +113,10 @@ impl GenKeys {
         (0..n).map(|_| self.gen_seed()).collect()
     }
 
-    pub fn gen_n_keypairs(&mut self, n: i64) -> Vec<KeyPair> {
+    pub fn gen_n_keypairs(&mut self, n: i64) -> Vec<Keypair> {
         self.gen_n_seeds(n)
             .into_par_iter()
-            .map(|seed| KeyPair::from_seed_unchecked(Input::from(&seed)).unwrap())
+            .map(|seed| Keypair::from_seed_unchecked(Input::from(&seed)).unwrap())
             .collect()
     }
 }
@@ -127,7 +127,7 @@ pub fn read_pkcs8(path: &str) -> Result<Vec<u8>, Box<error::Error>> {
     Ok(pkcs8)
 }
 
-pub fn read_keypair(path: &str) -> Result<KeyPair, Box<error::Error>> {
+pub fn read_keypair(path: &str) -> Result<Keypair, Box<error::Error>> {
     let pkcs8 = read_pkcs8(path)?;
     let keypair = Ed25519KeyPair::from_pkcs8(Input::from(&pkcs8))?;
     Ok(keypair)

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -15,27 +15,27 @@ use untrusted::Input;
 
 pub type Keypair = Ed25519KeyPair;
 #[derive(Serialize, Deserialize, Clone, Copy, Default, Eq, PartialEq, Ord, PartialOrd, Hash)]
-pub struct PublicKey(GenericArray<u8, U32>);
+pub struct Pubkey(GenericArray<u8, U32>);
 
-impl PublicKey {
+impl Pubkey {
     pub fn new(pubkey_vec: &[u8]) -> Self {
-        PublicKey(GenericArray::clone_from_slice(&pubkey_vec))
+        Pubkey(GenericArray::clone_from_slice(&pubkey_vec))
     }
 }
 
-impl AsRef<[u8]> for PublicKey {
+impl AsRef<[u8]> for Pubkey {
     fn as_ref(&self) -> &[u8] {
         &self.0[..]
     }
 }
 
-impl fmt::Debug for PublicKey {
+impl fmt::Debug for Pubkey {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", bs58::encode(self.0).into_string())
     }
 }
 
-impl fmt::Display for PublicKey {
+impl fmt::Display for Pubkey {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", bs58::encode(self.0).into_string())
     }
@@ -76,7 +76,7 @@ impl fmt::Display for Signature {
 
 pub trait KeypairUtil {
     fn new() -> Self;
-    fn pubkey(&self) -> PublicKey;
+    fn pubkey(&self) -> Pubkey;
 }
 
 impl KeypairUtil for Ed25519KeyPair {
@@ -88,8 +88,8 @@ impl KeypairUtil for Ed25519KeyPair {
     }
 
     /// Return the public key for the given keypair
-    fn pubkey(&self) -> PublicKey {
-        PublicKey(GenericArray::clone_from_slice(self.public_key_bytes()))
+    fn pubkey(&self) -> Pubkey {
+        Pubkey(GenericArray::clone_from_slice(self.public_key_bytes()))
     }
 }
 
@@ -149,7 +149,7 @@ mod tests {
         }
     }
 
-    fn gen_n_pubkeys(seed: [u8; 32], n: i64) -> HashSet<PublicKey> {
+    fn gen_n_pubkeys(seed: [u8; 32], n: i64) -> HashSet<Pubkey> {
         GenKeys::new(seed)
             .gen_n_keypairs(n)
             .into_iter()

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -48,11 +48,11 @@ impl Signature {
     pub fn new(signature_slice: &[u8]) -> Self {
         Signature(GenericArray::clone_from_slice(&signature_slice))
     }
-    pub fn verify(&self, pubkey_bytes: &[u8], msg_bytes: &[u8]) -> bool {
+    pub fn verify(&self, pubkey_bytes: &[u8], message_bytes: &[u8]) -> bool {
         let pubkey = Input::from(pubkey_bytes);
-        let msg = Input::from(msg_bytes);
-        let sig = Input::from(self.0.as_slice());
-        signature::verify(&signature::ED25519, pubkey, msg, sig).is_ok()
+        let message = Input::from(message_bytes);
+        let signature = Input::from(self.0.as_slice());
+        signature::verify(&signature::ED25519, pubkey, message, signature).is_ok()
     }
 }
 

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -48,11 +48,11 @@ impl Signature {
     pub fn new(signature_slice: &[u8]) -> Self {
         Signature(GenericArray::clone_from_slice(&signature_slice))
     }
-    pub fn verify(&self, peer_public_key_bytes: &[u8], msg_bytes: &[u8]) -> bool {
-        let peer_public_key = Input::from(peer_public_key_bytes);
+    pub fn verify(&self, pubkey_bytes: &[u8], msg_bytes: &[u8]) -> bool {
+        let pubkey = Input::from(pubkey_bytes);
         let msg = Input::from(msg_bytes);
         let sig = Input::from(self.0.as_slice());
-        signature::verify(&signature::ED25519, peer_public_key, msg, sig).is_ok()
+        signature::verify(&signature::ED25519, pubkey, msg, sig).is_ok()
     }
 }
 

--- a/src/sigverify.rs
+++ b/src/sigverify.rs
@@ -138,7 +138,7 @@ pub fn ed25519_verify(batches: &[SharedPackets]) -> Vec<Vec<u8>> {
     let count = batch_size(batches);
 
     // micro-benchmarks show GPU time for smallest batch around 15-20ms
-    // and CPU speed for 64-128 sig verifies around 10-20ms. 64 is a nice
+    // and CPU speed for 64-128 sigverifies around 10-20ms. 64 is a nice
     // power-of-two number around that accounting for the fact that the CPU
     // may be busy doing other things while being a real fullnode
     // TODO: dynamically adjust this crossover
@@ -174,8 +174,8 @@ pub fn ed25519_verify(batches: &[SharedPackets]) -> Vec<Vec<u8>> {
     trace!("Starting verify num packets: {}", num);
     trace!("elem len: {}", elems.len() as u32);
     trace!("packet sizeof: {}", size_of::<Packet>() as u32);
-    trace!("pub key: {}", (TX_OFFSET + PUB_KEY_OFFSET) as u32);
-    trace!("sig offset: {}", (TX_OFFSET + SIG_OFFSET) as u32);
+    trace!("pubkey: {}", (TX_OFFSET + PUB_KEY_OFFSET) as u32);
+    trace!("signature offset: {}", (TX_OFFSET + SIG_OFFSET) as u32);
     trace!("sign data: {}", (TX_OFFSET + SIGNED_DATA_OFFSET) as u32);
     trace!("len offset: {}", PACKET_DATA_SIZE as u32);
     unsafe {

--- a/src/sigverify.rs
+++ b/src/sigverify.rs
@@ -44,14 +44,14 @@ pub fn init() {
 
 fn verify_packet(packet: &Packet) -> u8 {
     use ring::signature;
-    use signature::{PublicKey, Signature};
+    use signature::{Pubkey, Signature};
     use untrusted;
 
     let msg_start = TX_OFFSET + SIGNED_DATA_OFFSET;
     let sig_start = TX_OFFSET + SIG_OFFSET;
     let sig_end = sig_start + size_of::<Signature>();
     let pubkey_start = TX_OFFSET + PUB_KEY_OFFSET;
-    let pubkey_end = pubkey_start + size_of::<PublicKey>();
+    let pubkey_end = pubkey_start + size_of::<Pubkey>();
 
     if packet.meta.size <= msg_start {
         return 0;

--- a/src/sigverify.rs
+++ b/src/sigverify.rs
@@ -29,7 +29,7 @@ extern "C" {
         vecs: *const Elems,
         num: u32,          //number of vecs
         message_size: u32, //size of each element inside the elems field of the vec
-        public_key_offset: u32,
+        pubkey_offset: u32,
         signature_offset: u32,
         signed_message_offset: u32,
         signed_message_len_offset: u32,
@@ -50,8 +50,8 @@ fn verify_packet(packet: &Packet) -> u8 {
     let msg_start = TX_OFFSET + SIGNED_DATA_OFFSET;
     let sig_start = TX_OFFSET + SIG_OFFSET;
     let sig_end = sig_start + size_of::<Signature>();
-    let pub_key_start = TX_OFFSET + PUB_KEY_OFFSET;
-    let pub_key_end = pub_key_start + size_of::<PublicKey>();
+    let pubkey_start = TX_OFFSET + PUB_KEY_OFFSET;
+    let pubkey_end = pubkey_start + size_of::<PublicKey>();
 
     if packet.meta.size <= msg_start {
         return 0;
@@ -60,7 +60,7 @@ fn verify_packet(packet: &Packet) -> u8 {
     let msg_end = packet.meta.size;
     signature::verify(
         &signature::ED25519,
-        untrusted::Input::from(&packet.data[pub_key_start..pub_key_end]),
+        untrusted::Input::from(&packet.data[pubkey_start..pubkey_end]),
         untrusted::Input::from(&packet.data[msg_start..msg_end]),
         untrusted::Input::from(&packet.data[sig_start..sig_end]),
     ).is_ok() as u8

--- a/src/thin_client.rs
+++ b/src/thin_client.rs
@@ -6,7 +6,7 @@
 use bincode::{deserialize, serialize};
 use hash::Hash;
 use request::{Request, Response};
-use signature::{KeyPair, PublicKey, Signature};
+use signature::{Keypair, PublicKey, Signature};
 use std::collections::HashMap;
 use std::io;
 use std::net::{SocketAddr, UdpSocket};
@@ -99,7 +99,7 @@ impl ThinClient {
     pub fn transfer(
         &self,
         n: i64,
-        keypair: &KeyPair,
+        keypair: &Keypair,
         to: PublicKey,
         last_id: &Hash,
     ) -> io::Result<Signature> {
@@ -289,14 +289,14 @@ mod tests {
     use logger;
     use mint::Mint;
     use service::Service;
-    use signature::{KeyPair, KeyPairUtil};
+    use signature::{Keypair, KeypairUtil};
     use std::fs::remove_dir_all;
     use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::Arc;
     use transaction::{Instruction, Plan};
 
     fn tmp_ledger(name: &str, mint: &Mint) -> String {
-        let keypair = KeyPair::new();
+        let keypair = Keypair::new();
 
         let path = format!("/tmp/tmp-ledger-{}-{}", name, keypair.pubkey());
 
@@ -309,13 +309,13 @@ mod tests {
     #[test]
     fn test_thin_client() {
         logger::setup();
-        let leader_keypair = KeyPair::new();
+        let leader_keypair = Keypair::new();
         let leader = TestNode::new_localhost_with_pubkey(leader_keypair.pubkey());
         let leader_data = leader.data.clone();
 
         let alice = Mint::new(10_000);
         let bank = Bank::new(&alice);
-        let bob_pubkey = KeyPair::new().pubkey();
+        let bob_pubkey = Keypair::new().pubkey();
         let exit = Arc::new(AtomicBool::new(false));
         let ledger_path = tmp_ledger("thin_client", &alice);
 
@@ -358,11 +358,11 @@ mod tests {
     #[ignore]
     fn test_bad_sig() {
         logger::setup();
-        let leader_keypair = KeyPair::new();
+        let leader_keypair = Keypair::new();
         let leader = TestNode::new_localhost_with_pubkey(leader_keypair.pubkey());
         let alice = Mint::new(10_000);
         let bank = Bank::new(&alice);
-        let bob_pubkey = KeyPair::new().pubkey();
+        let bob_pubkey = Keypair::new().pubkey();
         let exit = Arc::new(AtomicBool::new(false));
         let leader_data = leader.data.clone();
         let ledger_path = tmp_ledger("bad_sig", &alice);
@@ -418,11 +418,11 @@ mod tests {
     #[test]
     fn test_client_check_signature() {
         logger::setup();
-        let leader_keypair = KeyPair::new();
+        let leader_keypair = Keypair::new();
         let leader = TestNode::new_localhost_with_pubkey(leader_keypair.pubkey());
         let alice = Mint::new(10_000);
         let bank = Bank::new(&alice);
-        let bob_pubkey = KeyPair::new().pubkey();
+        let bob_pubkey = Keypair::new().pubkey();
         let exit = Arc::new(AtomicBool::new(false));
         let leader_data = leader.data.clone();
         let ledger_path = tmp_ledger("client_check_signature", &alice);

--- a/src/thin_client.rs
+++ b/src/thin_client.rs
@@ -6,7 +6,7 @@
 use bincode::{deserialize, serialize};
 use hash::Hash;
 use request::{Request, Response};
-use signature::{Keypair, PublicKey, Signature};
+use signature::{Keypair, Pubkey, Signature};
 use std::collections::HashMap;
 use std::io;
 use std::net::{SocketAddr, UdpSocket};
@@ -27,7 +27,7 @@ pub struct ThinClient {
     transactions_socket: UdpSocket,
     last_id: Option<Hash>,
     transaction_count: u64,
-    balances: HashMap<PublicKey, i64>,
+    balances: HashMap<Pubkey, i64>,
     signature_status: bool,
 }
 
@@ -100,7 +100,7 @@ impl ThinClient {
         &self,
         n: i64,
         keypair: &Keypair,
-        to: PublicKey,
+        to: Pubkey,
         last_id: &Hash,
     ) -> io::Result<Signature> {
         let now = Instant::now();
@@ -121,7 +121,7 @@ impl ThinClient {
     /// Request the balance of the user holding `pubkey`. This method blocks
     /// until the server sends a response. If the response packet is dropped
     /// by the network, this method will hang indefinitely.
-    pub fn get_balance(&mut self, pubkey: &PublicKey) -> io::Result<i64> {
+    pub fn get_balance(&mut self, pubkey: &Pubkey) -> io::Result<i64> {
         trace!("get_balance");
         let req = Request::GetBalance { key: *pubkey };
         let data = serialize(&req).expect("serialize GetBalance in pub fn get_balance");
@@ -195,7 +195,7 @@ impl ThinClient {
         self.last_id.expect("some last_id")
     }
 
-    pub fn poll_get_balance(&mut self, pubkey: &PublicKey) -> io::Result<i64> {
+    pub fn poll_get_balance(&mut self, pubkey: &Pubkey) -> io::Result<i64> {
         let mut balance_result;
         let mut balance_value = -1;
         let now = Instant::now();

--- a/src/thin_client.rs
+++ b/src/thin_client.rs
@@ -243,7 +243,9 @@ impl ThinClient {
     /// until the server sends a response.
     pub fn check_signature(&mut self, signature: &Signature) -> bool {
         trace!("check_signature");
-        let req = Request::GetSignature { signature: *signature };
+        let req = Request::GetSignature {
+            signature: *signature,
+        };
         let data = serialize(&req).expect("serialize GetSignature in pub fn check_signature");
         let now = Instant::now();
         let mut done = false;

--- a/src/tpu.rs
+++ b/src/tpu.rs
@@ -32,7 +32,7 @@ use fetch_stage::FetchStage;
 use packet::{BlobRecycler, PacketRecycler};
 use record_stage::RecordStage;
 use service::Service;
-use signature::KeyPair;
+use signature::Keypair;
 use sigverify_stage::SigVerifyStage;
 use std::net::UdpSocket;
 use std::sync::atomic::AtomicBool;
@@ -52,7 +52,7 @@ pub struct Tpu {
 
 impl Tpu {
     pub fn new(
-        keypair: KeyPair,
+        keypair: Keypair,
         bank: &Arc<Bank>,
         crdt: &Arc<RwLock<Crdt>>,
         tick_duration: Option<Duration>,

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -79,7 +79,7 @@ pub enum Instruction {
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub struct Transaction {
     /// A digital signature of `instruction`, `last_id` and `fee`, signed by `Pubkey`.
-    pub sig: Signature,
+    pub signature: Signature,
 
     /// The `Pubkey` of the entity that signed the transaction data.
     pub from: Pubkey,
@@ -104,7 +104,7 @@ impl Transaction {
     ) -> Self {
         let from = from_keypair.pubkey();
         let mut tx = Transaction {
-            sig: Signature::default(),
+            signature: Signature::default(),
             instruction,
             last_id,
             from,
@@ -144,8 +144,8 @@ impl Transaction {
     }
 
     /// Create and sign a new Witness Signature. Used for unit-testing.
-    pub fn new_signature(from_keypair: &Keypair, tx_sig: Signature, last_id: Hash) -> Self {
-        let instruction = Instruction::ApplySignature(tx_sig);
+    pub fn new_signature(from_keypair: &Keypair, signature: Signature, last_id: Hash) -> Self {
+        let instruction = Instruction::ApplySignature(signature);
         Self::new_from_instruction(from_keypair, instruction, last_id, 0)
     }
 
@@ -186,13 +186,13 @@ impl Transaction {
     /// Sign this transaction.
     pub fn sign(&mut self, keypair: &Keypair) {
         let sign_data = self.get_sign_data();
-        self.sig = Signature::new(keypair.sign(&sign_data).as_ref());
+        self.signature = Signature::new(keypair.sign(&sign_data).as_ref());
     }
 
     /// Verify only the transaction signature.
-    pub fn verify_sig(&self) -> bool {
+    pub fn verify_signature(&self) -> bool {
         warn!("transaction signature verification called");
-        self.sig.verify(&self.from.as_ref(), &self.get_sign_data())
+        self.signature.verify(&self.from.as_ref(), &self.get_sign_data())
     }
 
     /// Verify only the payment plan.
@@ -271,7 +271,7 @@ mod tests {
             instruction,
             from: Default::default(),
             last_id: Default::default(),
-            sig: Default::default(),
+            signature: Default::default(),
             fee: 0,
         };
         let buf = serialize(&claim0).unwrap();
@@ -292,7 +292,7 @@ mod tests {
             }
         }
         assert!(tx.verify_plan());
-        assert!(!tx.verify_sig());
+        assert!(!tx.verify_signature());
     }
 
     #[test]
@@ -309,7 +309,7 @@ mod tests {
             }
         }
         assert!(tx.verify_plan());
-        assert!(!tx.verify_sig());
+        assert!(!tx.verify_signature());
     }
     #[test]
     fn test_layout() {
@@ -317,7 +317,7 @@ mod tests {
         let sign_data = tx.get_sign_data();
         let tx_bytes = serialize(&tx).unwrap();
         assert_matches!(memfind(&tx_bytes, &sign_data), Some(SIGNED_DATA_OFFSET));
-        assert_matches!(memfind(&tx_bytes, &tx.sig.as_ref()), Some(SIG_OFFSET));
+        assert_matches!(memfind(&tx_bytes, &tx.signature.as_ref()), Some(SIG_OFFSET));
         assert_matches!(memfind(&tx_bytes, &tx.from.as_ref()), Some(PUB_KEY_OFFSET));
     }
 

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -192,7 +192,8 @@ impl Transaction {
     /// Verify only the transaction signature.
     pub fn verify_signature(&self) -> bool {
         warn!("transaction signature verification called");
-        self.signature.verify(&self.from.as_ref(), &self.get_sign_data())
+        self.signature
+            .verify(&self.from.as_ref(), &self.get_sign_data())
     }
 
     /// Verify only the payment plan.

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -5,7 +5,7 @@ use budget::{Budget, Condition};
 use chrono::prelude::*;
 use hash::Hash;
 use payment_plan::{Payment, PaymentPlan, Witness};
-use signature::{Keypair, KeypairUtil, PublicKey, Signature};
+use signature::{Keypair, KeypairUtil, Pubkey, Signature};
 
 pub const SIGNED_DATA_OFFSET: usize = 112;
 pub const SIG_OFFSET: usize = 8;
@@ -32,7 +32,7 @@ impl PaymentPlan for Plan {
         }
     }
 
-    fn apply_witness(&mut self, witness: &Witness, from: &PublicKey) {
+    fn apply_witness(&mut self, witness: &Witness, from: &Pubkey) {
         match self {
             Plan::Budget(budget) => budget.apply_witness(witness, from),
         }
@@ -68,21 +68,21 @@ pub enum Instruction {
     ApplyTimestamp(DateTime<Utc>),
 
     /// Tell the payment plan that the `NewContract` with `Signature` has been
-    /// signed by the containing transaction's `PublicKey`.
+    /// signed by the containing transaction's `Pubkey`.
     ApplySignature(Signature),
 
     /// Vote for a PoH that is equal to the lastid of this transaction
     NewVote(Vote),
 }
 
-/// An instruction signed by a client with `PublicKey`.
+/// An instruction signed by a client with `Pubkey`.
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub struct Transaction {
-    /// A digital signature of `instruction`, `last_id` and `fee`, signed by `PublicKey`.
+    /// A digital signature of `instruction`, `last_id` and `fee`, signed by `Pubkey`.
     pub sig: Signature,
 
-    /// The `PublicKey` of the entity that signed the transaction data.
-    pub from: PublicKey,
+    /// The `Pubkey` of the entity that signed the transaction data.
+    pub from: Pubkey,
 
     /// The action the server should take.
     pub instruction: Instruction,
@@ -117,7 +117,7 @@ impl Transaction {
     /// Create and sign a new Transaction. Used for unit-testing.
     pub fn new_taxed(
         from_keypair: &Keypair,
-        to: PublicKey,
+        to: Pubkey,
         tokens: i64,
         fee: i64,
         last_id: Hash,
@@ -133,7 +133,7 @@ impl Transaction {
     }
 
     /// Create and sign a new Transaction. Used for unit-testing.
-    pub fn new(from_keypair: &Keypair, to: PublicKey, tokens: i64, last_id: Hash) -> Self {
+    pub fn new(from_keypair: &Keypair, to: Pubkey, tokens: i64, last_id: Hash) -> Self {
         Self::new_taxed(from_keypair, to, tokens, 0, last_id)
     }
 
@@ -156,7 +156,7 @@ impl Transaction {
     /// Create and sign a postdated Transaction. Used for unit-testing.
     pub fn new_on_date(
         from_keypair: &Keypair,
-        to: PublicKey,
+        to: Pubkey,
         dt: DateTime<Utc>,
         tokens: i64,
         last_id: Hash,

--- a/src/tvu.rs
+++ b/src/tvu.rs
@@ -42,7 +42,7 @@ use crdt::Crdt;
 use packet::BlobRecycler;
 use replicate_stage::ReplicateStage;
 use service::Service;
-use signature::KeyPair;
+use signature::Keypair;
 use std::net::UdpSocket;
 use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, RwLock};
@@ -70,7 +70,7 @@ impl Tvu {
     /// * `exit` - The exit signal.
     #[cfg_attr(feature = "cargo-clippy", allow(too_many_arguments))]
     pub fn new(
-        keypair: KeyPair,
+        keypair: Keypair,
         bank: &Arc<Bank>,
         entry_height: u64,
         crdt: Arc<RwLock<Crdt>>,
@@ -152,7 +152,7 @@ pub mod tests {
     use packet::BlobRecycler;
     use result::Result;
     use service::Service;
-    use signature::{KeyPair, KeyPairUtil};
+    use signature::{Keypair, KeypairUtil};
     use std::collections::VecDeque;
     use std::net::UdpSocket;
     use std::sync::atomic::AtomicBool;
@@ -179,7 +179,7 @@ pub mod tests {
     fn test_replicate() {
         logger::setup();
         let leader = TestNode::new_localhost();
-        let target1_keypair = KeyPair::new();
+        let target1_keypair = Keypair::new();
         let target1 = TestNode::new_localhost_with_pubkey(target1_keypair.pubkey());
         let target2 = TestNode::new_localhost();
         let exit = Arc::new(AtomicBool::new(false));
@@ -252,7 +252,7 @@ pub mod tests {
         let mut blob_id = 0;
         let num_transfers = 10;
         let transfer_amount = 501;
-        let bob_keypair = KeyPair::new();
+        let bob_keypair = Keypair::new();
         for i in 0..num_transfers {
             let entry0 = Entry::new(&cur_hash, i, vec![], false);
             bank.register_entry_id(&cur_hash);

--- a/src/vote_stage.rs
+++ b/src/vote_stage.rs
@@ -11,7 +11,7 @@ use metrics;
 use packet::{BlobRecycler, SharedBlob};
 use result::Result;
 use service::Service;
-use signature::KeyPair;
+use signature::Keypair;
 use std::collections::VecDeque;
 use std::result;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
@@ -35,7 +35,7 @@ enum VoteError {
 
 pub fn create_vote_tx_and_blob(
     last_id: &Hash,
-    keypair: &KeyPair,
+    keypair: &Keypair,
     crdt: &Arc<RwLock<Crdt>>,
     blob_recycler: &BlobRecycler,
 ) -> Result<(Transaction, SharedBlob)> {
@@ -114,7 +114,7 @@ fn get_last_id_to_vote_on(
 
 pub fn send_leader_vote(
     debug_id: u64,
-    keypair: &KeyPair,
+    keypair: &Keypair,
     bank: &Arc<Bank>,
     crdt: &Arc<RwLock<Crdt>>,
     blob_recycler: &BlobRecycler,
@@ -166,7 +166,7 @@ pub fn send_leader_vote(
 
 fn send_validator_vote(
     bank: &Arc<Bank>,
-    keypair: &Arc<KeyPair>,
+    keypair: &Arc<Keypair>,
     crdt: &Arc<RwLock<Crdt>>,
     blob_recycler: &BlobRecycler,
     vote_blob_sender: &BlobSender,
@@ -182,7 +182,7 @@ fn send_validator_vote(
 
 impl VoteStage {
     pub fn new(
-        keypair: Arc<KeyPair>,
+        keypair: Arc<Keypair>,
         bank: Arc<Bank>,
         crdt: Arc<RwLock<Crdt>>,
         blob_recycler: BlobRecycler,
@@ -203,7 +203,7 @@ impl VoteStage {
     }
 
     fn run(
-        keypair: &Arc<KeyPair>,
+        keypair: &Arc<Keypair>,
         bank: &Arc<Bank>,
         crdt: &Arc<RwLock<Crdt>>,
         blob_recycler: &BlobRecycler,
@@ -243,7 +243,7 @@ pub mod tests {
     use mint::Mint;
     use packet::BlobRecycler;
     use service::Service;
-    use signature::{KeyPair, KeyPairUtil};
+    use signature::{Keypair, KeypairUtil};
     use std::sync::atomic::AtomicBool;
     use std::sync::mpsc::channel;
     use std::sync::{Arc, RwLock};
@@ -252,7 +252,7 @@ pub mod tests {
     /// Ensure the VoteStage issues votes at the expected cadence
     #[test]
     fn test_vote_cadence() {
-        let keypair = KeyPair::new();
+        let keypair = Keypair::new();
 
         let mint = Mint::new(1234);
         let bank = Arc::new(Bank::new(&mint));

--- a/src/voting.rs
+++ b/src/voting.rs
@@ -1,16 +1,16 @@
 use entry::Entry;
 use hash::Hash;
-use signature::PublicKey;
+use signature::Pubkey;
 use transaction::{Instruction, Transaction, Vote};
 
-pub fn entries_to_votes(entries: &[Entry]) -> Vec<(PublicKey, Vote, Hash)> {
+pub fn entries_to_votes(entries: &[Entry]) -> Vec<(Pubkey, Vote, Hash)> {
     entries
         .iter()
         .flat_map(|entry| entry.transactions.iter().filter_map(transaction_to_vote))
         .collect()
 }
 
-pub fn transaction_to_vote(tx: &Transaction) -> Option<(PublicKey, Vote, Hash)> {
+pub fn transaction_to_vote(tx: &Transaction) -> Option<(Pubkey, Vote, Hash)> {
     match tx.instruction {
         Instruction::NewVote(ref vote) => Some((tx.from, vote.clone(), tx.last_id)),
         _ => None,

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -13,7 +13,7 @@ pub fn request_airdrop(
     let mut stream = TcpStream::connect(drone_addr)?;
     let req = DroneRequest::GetAirdrop {
         airdrop_request_amount: tokens,
-        client_public_key: *id,
+        client_pubkey: *id,
     };
     let tx = serialize(&req).expect("serialize drone request");
     stream.write_all(&tx).unwrap();

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -1,13 +1,13 @@
 use bincode::serialize;
 use drone::DroneRequest;
-use signature::PublicKey;
+use signature::Pubkey;
 use std::error;
 use std::io::Write;
 use std::net::{SocketAddr, TcpStream};
 
 pub fn request_airdrop(
     drone_addr: &SocketAddr,
-    id: &PublicKey,
+    id: &Pubkey,
     tokens: u64,
 ) -> Result<(), Box<error::Error>> {
     let mut stream = TcpStream::connect(drone_addr)?;

--- a/src/write_stage.rs
+++ b/src/write_stage.rs
@@ -11,7 +11,7 @@ use log::Level;
 use packet::BlobRecycler;
 use result::{Error, Result};
 use service::Service;
-use signature::KeyPair;
+use signature::Keypair;
 use std::collections::VecDeque;
 use std::net::UdpSocket;
 use std::sync::atomic::AtomicUsize;
@@ -69,7 +69,7 @@ impl WriteStage {
 
     /// Create a new WriteStage for writing and broadcasting entries.
     pub fn new(
-        keypair: KeyPair,
+        keypair: Keypair,
         bank: Arc<Bank>,
         crdt: Arc<RwLock<Crdt>>,
         blob_recycler: BlobRecycler,

--- a/tests/multinode.rs
+++ b/tests/multinode.rs
@@ -15,7 +15,7 @@ use solana::mint::Mint;
 use solana::ncp::Ncp;
 use solana::result;
 use solana::service::Service;
-use solana::signature::{KeyPair, KeyPairUtil, PublicKey};
+use solana::signature::{Keypair, KeypairUtil, PublicKey};
 use solana::streamer::{default_window, WINDOW_SIZE};
 use solana::thin_client::ThinClient;
 use solana::timing::duration_as_s;
@@ -79,7 +79,7 @@ fn converge(leader: &NodeInfo, num_nodes: usize) -> Vec<NodeInfo> {
 }
 
 fn tmp_ledger_path(name: &str) -> String {
-    let keypair = KeyPair::new();
+    let keypair = Keypair::new();
 
     format!("/tmp/tmp-ledger-{}-{}", name, keypair.pubkey())
 }
@@ -123,11 +123,11 @@ fn make_tiny_test_entries(start_hash: Hash, num: usize) -> Vec<Entry> {
 fn test_multi_node_ledger_window() -> result::Result<()> {
     logger::setup();
 
-    let leader_keypair = KeyPair::new();
+    let leader_keypair = Keypair::new();
     let leader_pubkey = leader_keypair.pubkey().clone();
     let leader = TestNode::new_localhost_with_pubkey(leader_keypair.pubkey());
     let leader_data = leader.data.clone();
-    let bob_pubkey = KeyPair::new().pubkey();
+    let bob_pubkey = Keypair::new().pubkey();
     let mut ledger_paths = Vec::new();
 
     let (alice, leader_ledger_path) = genesis("multi_node_ledger_window", 10_000);
@@ -155,7 +155,7 @@ fn test_multi_node_ledger_window() -> result::Result<()> {
 
     // start up another validator from zero, converge and then check
     // balances
-    let keypair = KeyPair::new();
+    let keypair = Keypair::new();
     let validator = TestNode::new_localhost_with_pubkey(keypair.pubkey());
     let validator_data = validator.data.clone();
     let validator = FullNode::new(
@@ -203,11 +203,11 @@ fn test_multi_node_validator_catchup_from_zero() -> result::Result<()> {
     logger::setup();
     const N: usize = 5;
     trace!("test_multi_node_validator_catchup_from_zero");
-    let leader_keypair = KeyPair::new();
+    let leader_keypair = Keypair::new();
     let leader_pubkey = leader_keypair.pubkey().clone();
     let leader = TestNode::new_localhost_with_pubkey(leader_keypair.pubkey());
     let leader_data = leader.data.clone();
-    let bob_pubkey = KeyPair::new().pubkey();
+    let bob_pubkey = Keypair::new().pubkey();
     let mut ledger_paths = Vec::new();
 
     let (alice, leader_ledger_path) = genesis("multi_node_validator_catchup_from_zero", 10_000);
@@ -228,7 +228,7 @@ fn test_multi_node_validator_catchup_from_zero() -> result::Result<()> {
 
     let mut nodes = vec![server];
     for _ in 0..N {
-        let keypair = KeyPair::new();
+        let keypair = Keypair::new();
         let validator = TestNode::new_localhost_with_pubkey(keypair.pubkey());
         let ledger_path = tmp_copy_ledger(
             &leader_ledger_path,
@@ -269,7 +269,7 @@ fn test_multi_node_validator_catchup_from_zero() -> result::Result<()> {
     success = 0;
     // start up another validator from zero, converge and then check everyone's
     // balances
-    let keypair = KeyPair::new();
+    let keypair = Keypair::new();
     let validator = TestNode::new_localhost_with_pubkey(keypair.pubkey());
     let val = FullNode::new(
         validator,
@@ -327,11 +327,11 @@ fn test_multi_node_basic() {
     logger::setup();
     const N: usize = 5;
     trace!("test_multi_node_basic");
-    let leader_keypair = KeyPair::new();
+    let leader_keypair = Keypair::new();
     let leader_pubkey = leader_keypair.pubkey().clone();
     let leader = TestNode::new_localhost_with_pubkey(leader_keypair.pubkey());
     let leader_data = leader.data.clone();
-    let bob_pubkey = KeyPair::new().pubkey();
+    let bob_pubkey = Keypair::new().pubkey();
     let mut ledger_paths = Vec::new();
 
     let (alice, leader_ledger_path) = genesis("multi_node_basic", 10_000);
@@ -345,7 +345,7 @@ fn test_multi_node_basic() {
 
     let mut nodes = vec![server];
     for _ in 0..N {
-        let keypair = KeyPair::new();
+        let keypair = Keypair::new();
         let validator = TestNode::new_localhost_with_pubkey(keypair.pubkey());
         let ledger_path = tmp_copy_ledger(&leader_ledger_path, "multi_node_basic");
         ledger_paths.push(ledger_path.clone());
@@ -389,9 +389,9 @@ fn test_multi_node_basic() {
 #[test]
 fn test_boot_validator_from_file() -> result::Result<()> {
     logger::setup();
-    let leader_keypair = KeyPair::new();
+    let leader_keypair = Keypair::new();
     let leader = TestNode::new_localhost_with_pubkey(leader_keypair.pubkey());
-    let bob_pubkey = KeyPair::new().pubkey();
+    let bob_pubkey = Keypair::new().pubkey();
     let (alice, leader_ledger_path) = genesis("boot_validator_from_file", 100_000);
     let mut ledger_paths = Vec::new();
     ledger_paths.push(leader_ledger_path.clone());
@@ -405,7 +405,7 @@ fn test_boot_validator_from_file() -> result::Result<()> {
         send_tx_and_retry_get_balance(&leader_data, &alice, &bob_pubkey, Some(1000)).unwrap();
     assert_eq!(leader_balance, 1000);
 
-    let keypair = KeyPair::new();
+    let keypair = Keypair::new();
     let validator = TestNode::new_localhost_with_pubkey(keypair.pubkey());
     let validator_data = validator.data.clone();
     let ledger_path = tmp_copy_ledger(&leader_ledger_path, "boot_validator_from_file");
@@ -431,7 +431,7 @@ fn test_boot_validator_from_file() -> result::Result<()> {
 }
 
 fn create_leader(ledger_path: &str) -> (NodeInfo, FullNode) {
-    let leader_keypair = KeyPair::new();
+    let leader_keypair = Keypair::new();
     let leader = TestNode::new_localhost_with_pubkey(leader_keypair.pubkey());
     let leader_data = leader.data.clone();
     let leader_fullnode = FullNode::new(leader, true, &ledger_path, leader_keypair, None);
@@ -446,7 +446,7 @@ fn test_leader_restart_validator_start_from_old_ledger() -> result::Result<()> {
     logger::setup();
 
     let (alice, ledger_path) = genesis("leader_restart_validator_start_from_old_ledger", 100_000);
-    let bob_pubkey = KeyPair::new().pubkey();
+    let bob_pubkey = Keypair::new().pubkey();
 
     let (leader_data, leader_fullnode) = create_leader(&ledger_path);
 
@@ -475,7 +475,7 @@ fn test_leader_restart_validator_start_from_old_ledger() -> result::Result<()> {
     let (leader_data, leader_fullnode) = create_leader(&ledger_path);
 
     // start validator from old ledger
-    let keypair = KeyPair::new();
+    let keypair = Keypair::new();
     let validator = TestNode::new_localhost_with_pubkey(keypair.pubkey());
     let validator_data = validator.data.clone();
 
@@ -535,10 +535,10 @@ fn test_multi_node_dynamic_network() {
         Err(_) => std::usize::MAX,
     };
 
-    let leader_keypair = KeyPair::new();
+    let leader_keypair = Keypair::new();
     let leader_pubkey = leader_keypair.pubkey().clone();
     let leader = TestNode::new_localhost_with_pubkey(leader_keypair.pubkey());
-    let bob_pubkey = KeyPair::new().pubkey();
+    let bob_pubkey = Keypair::new().pubkey();
     let (alice, leader_ledger_path) = genesis("multi_node_dynamic_network", 10_000_000);
 
     let mut ledger_paths = Vec::new();
@@ -584,7 +584,7 @@ fn test_multi_node_dynamic_network() {
                 .name("keypair-thread".to_string())
                 .spawn(move || {
                     info!("Spawned thread {}", n);
-                    let keypair = KeyPair::new();
+                    let keypair = Keypair::new();
                     //send some tokens to the new validator
                     let bal = retry_send_tx_and_retry_get_balance(
                         &leader_data,

--- a/tests/multinode.rs
+++ b/tests/multinode.rs
@@ -15,7 +15,7 @@ use solana::mint::Mint;
 use solana::ncp::Ncp;
 use solana::result;
 use solana::service::Service;
-use solana::signature::{Keypair, KeypairUtil, PublicKey};
+use solana::signature::{Keypair, KeypairUtil, Pubkey};
 use solana::streamer::{default_window, WINDOW_SIZE};
 use solana::thin_client::ThinClient;
 use solana::timing::duration_as_s;
@@ -751,7 +751,7 @@ fn mk_client(leader: &NodeInfo) -> ThinClient {
 
 fn retry_get_balance(
     client: &mut ThinClient,
-    bob_pubkey: &PublicKey,
+    bob_pubkey: &Pubkey,
     expected: Option<i64>,
 ) -> Option<i64> {
     const LAST: usize = 30;
@@ -773,7 +773,7 @@ fn retry_get_balance(
 fn send_tx_and_retry_get_balance(
     leader: &NodeInfo,
     alice: &Mint,
-    bob_pubkey: &PublicKey,
+    bob_pubkey: &Pubkey,
     expected: Option<i64>,
 ) -> Option<i64> {
     let mut client = mk_client(leader);
@@ -789,7 +789,7 @@ fn send_tx_and_retry_get_balance(
 fn retry_send_tx_and_retry_get_balance(
     leader: &NodeInfo,
     alice: &Mint,
-    bob_pubkey: &PublicKey,
+    bob_pubkey: &Pubkey,
     expected: Option<i64>,
 ) -> Option<i64> {
     let mut client = mk_client(leader);


### PR DESCRIPTION
Add Rust coding guidelines and update the codebase to reflect those guidelines.

I've asked all active contributors to review these guidelines. If you don't agree, please speak up! This only works when everyone's on board!

Noteworthy changes:

* Acknowledge `keypair` and `pubkey` as words.
* Do not acknowledge `sig` as a word.
* Boot the "first letter of each word" variable naming convention, which is not widely used and does not appear to improve readability anywhere except arguably one-liner closures.

Fixes #803