### PR TITLE
Entry height for fast dup detection

### DIFF
--- a/src/bank.rs
+++ b/src/bank.rs
@@ -259,6 +259,8 @@ impl Bank {
                 } else {
                     bal.tokens -= contract.tokens;
                 }
+                // next transaction has to be on a greater height
+                bal.version = tx.last_id.height;
             };
         }
 

--- a/src/bench_versioned.rs
+++ b/src/bench_versioned.rs
@@ -1,0 +1,182 @@
+use crdt::NodeInfo;
+use influx_db_client as influxdb;
+use metrics;
+use signature::{GenKeys, KeyPair, KeyPairUtil, PublicKey};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::Instant;
+use thin_client::ThinClient;
+use timing::{duration_as_ms, duration_as_s};
+use transaction::Transaction;
+
+const UPDATE_MILLIS: u64 = 500;
+
+/// execute transfers between keys
+/// 1. `tx_count` keys are generated
+/// 2. each key is given the `amount` of tokens
+/// 3. first half of keys sends 1 token to second half of keys
+/// 4. and vice versa
+/// 5. since some of the transactions may get dropped, the `amount` of tokens should cover the
+///    unbalanced drops between the halfs
+pub fn exececute(
+    leader: &NodeInfo,
+    client: &mut ThinClient,
+    source: &KeyPair,
+    tx_count: usize,
+    amount: i64,
+    exit_signal: Arc<AtomicBool>,
+) {
+    info!("Creating {} keypairs...", tx_count);
+    let mut seed = [0u8; 32];
+    seed.copy_from_slice(&source.public_key_bytes()[..32]);
+    let mut rnd = GenKeys::new(seed);
+    let keys = rnd.gen_n_keypairs(tx_count as i64);
+    //each key will have a RESVER_AMOUNT of tokens
+    distribute(client, source, &keys, amount);
+
+    while !exit_signal.load(Ordering::Relaxed) {
+        let transfer_start = Instant::now();
+        info!(
+            "Transferring 1 unit {} times... to {}",
+            tx_count, leader.contact_info.tpu
+        );
+
+        let half = tx_count / 2;
+        //each key will have a RESERVE_AMOUNT of tokens
+        //and can swap 1 token, allow for up to RESERVE_AMOUNT of unbalanced drops
+        swap(client, &keys[..half], &keys[half..]);
+        swap(client, &keys[half..], &keys[..half]);
+
+        info!(
+            "Tx send done. {} ms {} tps",
+            duration_as_ms(&transfer_start.elapsed()),
+            tx_count as f32 / duration_as_s(&transfer_start.elapsed()),
+        );
+        metrics::submit(
+            influxdb::Point::new("bench-tps")
+                .add_tag("op", influxdb::Value::String("do_tx_transfers".to_string()))
+                .add_field(
+                    "duration",
+                    influxdb::Value::Integer(duration_as_ms(&transfer_start.elapsed()) as i64),
+                )
+                .add_field("count", influxdb::Value::Integer(tx_count as i64))
+                .to_owned(),
+        );
+    }
+    reclaim(client, &keys, &source.pubkey());
+}
+
+pub fn distribute(client: &mut ThinClient, source: &KeyPair, keypairs: &[KeyPair], amount: i64) {
+    // distribute initial seed to the group
+    let desired = amount * (keypairs.len() as i64);
+    loop {
+        let last_id = client.get_last_id();
+        let tx = Transaction::new(source, keypairs[0].pubkey(), desired, last_id);
+        client.transfer_signed(&tx).unwrap();
+        let _ = client
+            .poll_update(30 * UPDATE_MILLIS, &keypairs[0].pubkey())
+            .expect("initial seed transfer");
+        let bal = client.get_balance(&keypairs[0].pubkey()).unwrap_or(0);
+        assert!(bal == 0 || bal == desired);
+        if bal == desired {
+            break;
+        }
+    }
+
+    let mut distributed = 0usize;
+    // distribute within the group
+    while distributed < keypairs.len() {
+        distributed = 0;
+        let last_id = client.get_last_id();
+        let sources: Vec<&KeyPair> = keypairs
+            .iter()
+            .filter_map(|key| {
+                let balance = client.get_balance(&key.pubkey()).unwrap_or(0);
+                if balance > amount {
+                    Some(key)
+                } else {
+                    None
+                }
+            })
+            .collect();
+        let destinations: Vec<&KeyPair> = keypairs
+            .iter()
+            .filter_map(|key| {
+                let balance = client.get_balance(&key.pubkey()).unwrap_or(0);
+                if balance > 0 {
+                    None
+                } else {
+                    Some(key)
+                }
+            })
+            .collect();
+        sources.iter().zip(destinations.iter()).for_each(|(s, d)| {
+            let balance = client.get_balance(&s.pubkey()).unwrap();
+            let spend = ((balance / amount) / 2) * amount;
+            let tx = Transaction::new(s, d.pubkey(), spend, last_id.clone());
+            client.transfer_signed(&tx).unwrap();
+        });
+        let count: usize = sources
+            .iter()
+            .map(|s| {
+                let _ = client.poll_update(UPDATE_MILLIS, &s.pubkey());
+                let bal = client.get_balance(&s.pubkey()).unwrap_or(0);
+                (bal > 0) as usize
+            })
+            .sum();
+        distributed += count;
+        let count: usize = destinations
+            .iter()
+            .map(|s| {
+                let _ = client.poll_update(UPDATE_MILLIS, &s.pubkey());
+                let bal = client.get_balance(&s.pubkey()).unwrap_or(0);
+                (bal > 0) as usize
+            })
+            .sum();
+        distributed += count;
+    }
+}
+
+pub fn swap(client: &mut ThinClient, sources: &[KeyPair], destinations: &[KeyPair]) {
+    let last_id = client.get_last_id();
+    sources.iter().zip(destinations.iter()).for_each(|(s, d)| {
+        let tx = Transaction::new(s, d.pubkey(), 1, last_id.clone());
+        client.transfer_signed(&tx).unwrap();
+    });
+}
+
+pub fn reclaim(client: &mut ThinClient, keypairs: &[KeyPair], sink: &PublicKey) {
+    let mut unreclaimed = keypairs.len();
+    while unreclaimed != 0 {
+        let last_id = client.get_last_id();
+        let sources: Vec<&KeyPair> = keypairs
+            .iter()
+            .filter_map(|key| {
+                let balance = client.get_balance(&key.pubkey()).unwrap_or(0);
+                if balance > 0 {
+                    Some(key)
+                } else {
+                    None
+                }
+            })
+            .collect();
+        sources.iter().for_each(|s| {
+            let spend = client.get_balance(&s.pubkey()).unwrap();
+            let tx = Transaction::new(s, *sink, spend, last_id.clone());
+            client.transfer_signed(&tx).unwrap();
+        });
+        unreclaimed = sources
+            .iter()
+            .map(|s| {
+                let spend = client.get_balance(&s.pubkey()).unwrap();
+                if spend == 0 {
+                    0
+                } else {
+                    let _ = client.poll_update(UPDATE_MILLIS, &s.pubkey());
+                    let bal = client.get_balance(&s.pubkey()).unwrap_or(0);
+                    (bal > 0) as usize
+                }
+            })
+            .sum();
+    }
+}

--- a/src/bench_versioned.rs
+++ b/src/bench_versioned.rs
@@ -18,7 +18,7 @@ const UPDATE_MILLIS: u64 = 500;
 /// 4. and vice versa
 /// 5. since some of the transactions may get dropped, the `amount` of tokens should cover the
 ///    unbalanced drops between the halfs
-pub fn exececute(
+pub fn execute(
     leader: &NodeInfo,
     client: &mut ThinClient,
     source: &KeyPair,

--- a/src/bin/bench-tps.rs
+++ b/src/bin/bench-tps.rs
@@ -323,7 +323,6 @@ fn main() {
     }
 
     let mut client = mk_client(&leader);
-    let mut barrier_client = mk_client(&leader);
 
     let mut seed = [0u8; 32];
     seed.copy_from_slice(&id.public_key_bytes()[..32]);
@@ -333,7 +332,7 @@ fn main() {
     airdrop_tokens(&mut client, &leader, &id, RESERVE_AMOUNT * tx_count);
 
     println!("Get last ID...");
-    let mut last_id = client.get_last_id();
+    let last_id = client.get_last_id();
     println!("Got last ID {:?}", last_id);
 
     let first_tx_count = client.transaction_count();
@@ -362,6 +361,8 @@ fn main() {
         .map(|_| {
             let exit_signal = exit_signal.clone();
             let leader = leader.clone();
+            let keypair =
+                read_keypair(matches.value_of("keypair").unwrap()).expect("client keypair");
             Builder::new()
                 .name("solana-client-sender".to_string())
                 .spawn(move || {
@@ -370,7 +371,7 @@ fn main() {
                     bench_versioned::execute(
                         &leader,
                         &mut client,
-                        &id,
+                        &keypair,
                         my_tx_count as usize,
                         RESERVE_AMOUNT,
                         exit_signal,

--- a/src/bin/bench-tps.rs
+++ b/src/bin/bench-tps.rs
@@ -122,7 +122,7 @@ fn send_barrier_transaction(barrier_client: &mut ThinClient, last_id: &mut LastI
 
         *last_id = barrier_client.get_last_id();
         let sig = barrier_client
-            .transfer(0, &id, id.pubkey(), *last_id)
+            .transfer(0, &id, id.pubkey(), last_id)
             .expect("Unable to send barrier transaction");
 
         let confirmatiom = barrier_client.poll_for_signature(&sig);
@@ -142,10 +142,7 @@ fn send_barrier_transaction(barrier_client: &mut ThinClient, last_id: &mut LastI
             );
 
             // Sanity check that the client balance is still 1
-            let balance = barrier_client
-                .poll_get_balance(&id.pubkey())
-                .map(|x| x.tokens)
-                .unwrap_or(-1);
+            let balance = barrier_client.poll_get_balance(&id.pubkey()).unwrap_or(-1);
             if balance != 1 {
                 panic!("Expected an account balance of 1 (balance: {}", balance);
             }
@@ -172,70 +169,6 @@ fn send_barrier_transaction(barrier_client: &mut ThinClient, last_id: &mut LastI
     }
 }
 
-fn distribute(
-    client: &mut ThinClient,
-    keypairs: &mut [KeyPair],
-) { 
-    let mut distributed = 0;
-    while distributed < keypairs.len() {
-        distributed = 0;
-        let last_id = client.get_last_id();
-        let sources = keypairs.iter().filter_map(|key| {
-                let balance = client.get_balance(i.pubkey());
-                if balance > 1 {
-                    Some(key)
-                } else {
-                    None
-                }
-            });
-        let destinations = keypairs.iter().filter_map(|key| {
-                let balance = client.get_balance(i.pubkey());
-                if balance > 0 {
-                    None
-                } else {
-                    Some(key)
-                }
-        });
-        sources.zip(destinations).foreach(|s,d| {
-            let balance = client.get_balance(s.pubkey());
-            let spend = balance/2;
-            let tx = Transaction::new(s, d.pubkey(), spend, last_id);
-            client.transfer_signed(&tx).unwrap();
-        });
-        distributed += sources.map(|s| {
-            let update = client.poll_update(1000, s);
-            (update.is_ok() && client.get_balance() > 0) as u64
-        }).sum();
-        distributed += destinations.map(|s| {
-            let update = client.poll_update(1000, s);
-            (update.is_ok() && client.get_balance() > 0) as u64
-        }).sum();
-}
-
-fn flood(
-    client: &mut ThinClient,
-    keypairs: &mut [KeyPair],
-) { 
-    let mut source = 1;
-    let mut filled = 2;
-    while filled <= keypairs.len() {
-        let last_id = client.get_last_id();
-        for i in 0..source {
-            for j in source .. filled {
-                let balance = client.get_balance(keypairs[i].0);
-                let spend = balance/(filled - source + 1);
-                let tx = Transaction::new(&keypairs[i] keypairs[j].pubkey(), spend, *last_id);
-                client.transfer_signed(&tx).unwrap();
-            }
-        }
-        source = filled;
-        filled = cmp::min(filled + source, keypairs.len());
-        for k in &keypairs[0..source] {
-            client.poll_update(10000, key)
-        }
-    }
-}
- 
 fn generate_txs(
     shared_txs: &Arc<RwLock<VecDeque<Vec<Transaction>>>>,
     id: &KeyPair,

--- a/src/bin/fullnode.rs
+++ b/src/bin/fullnode.rs
@@ -90,8 +90,8 @@ fn main() -> () {
     };
 
     let mut client = mk_client(&repl_clone);
-    let previous_balance = client.poll_get_balance(&leader_pubkey).unwrap();
-    eprintln!("balance is {}", previous_balance);
+    let previous_balance = client.get_versioned_account(&leader_pubkey).unwrap();
+    eprintln!("balance is {:?}", previous_balance);
 
     if previous_balance == 0 {
         eprintln!("requesting airdrop from {}", drone_addr);
@@ -105,11 +105,9 @@ fn main() -> () {
         // Try multiple times to confirm a non-zero balance.  |poll_get_balance| currently times
         // out after 1 second, and sometimes this is not enough time while the network is
         // booting
-        let balance_ok = (0..30).any(|i| {
-            let balance = client.poll_get_balance(&leader_pubkey).unwrap();
-            eprintln!("new balance is {} (attempt #{})", balance, i);
-            balance > 0
-        });
+        let balance_ok = client
+            .poll_update(previous_balance.verison, 10000, &leader_pubkey)
+            .is_ok();
         assert!(balance_ok, "0 balance, airdrop failed?");
     }
 

--- a/src/bin/fullnode.rs
+++ b/src/bin/fullnode.rs
@@ -93,7 +93,7 @@ fn main() -> () {
     let previous_balance = client.get_versioned_account(&leader_pubkey).unwrap();
     eprintln!("balance is {:?}", previous_balance);
 
-    if previous_balance == 0 {
+    if previous_balance.tokens == 0 {
         eprintln!("requesting airdrop from {}", drone_addr);
         request_airdrop(&drone_addr, &leader_pubkey, 50).unwrap_or_else(|_| {
             panic!(
@@ -105,9 +105,7 @@ fn main() -> () {
         // Try multiple times to confirm a non-zero balance.  |poll_get_balance| currently times
         // out after 1 second, and sometimes this is not enough time while the network is
         // booting
-        let balance_ok = client
-            .poll_update(previous_balance.verison, 10000, &leader_pubkey)
-            .is_ok();
+        let balance_ok = client.poll_update(10000, &leader_pubkey).is_ok();
         assert!(balance_ok, "0 balance, airdrop failed?");
     }
 

--- a/src/bin/wallet.rs
+++ b/src/bin/wallet.rs
@@ -19,7 +19,6 @@ use std::error;
 use std::fmt;
 use std::fs::File;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
-use std::time::Duration;
 
 enum WalletCommand {
     Address,

--- a/src/entry_writer.rs
+++ b/src/entry_writer.rs
@@ -45,7 +45,7 @@ impl<'a, W: Write> EntryWriter<'a, W> {
     fn write_and_register_entry(&mut self, entry: &Entry) -> io::Result<()> {
         trace!("write_and_register_entry entry");
         if !entry.has_more {
-            self.bank.register_entry_id(&entry.id);
+            self.bank.register_entry_hash(&entry.id);
         }
         Self::write_entry(&mut self.writer, entry)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@
 pub mod counter;
 pub mod bank;
 pub mod banking_stage;
+pub mod bench_versioned;
 pub mod blob_fetch_stage;
 pub mod budget;
 pub mod choose_gossip_peer_strategy;

--- a/src/mint.rs
+++ b/src/mint.rs
@@ -4,7 +4,7 @@ use entry::Entry;
 use hash::{hash, Hash};
 use ring::rand::SystemRandom;
 use signature::{KeyPair, KeyPairUtil, PublicKey};
-use transaction::Transaction;
+use transaction::{LastId, Transaction};
 use untrusted::Input;
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -38,8 +38,11 @@ impl Mint {
         hash(&self.pkcs8)
     }
 
-    pub fn last_id(&self) -> Hash {
-        self.create_entries()[1].id
+    pub fn last_id(&self) -> LastId {
+        LastId {
+            height: 2,
+            hash: self.create_entries()[1].id,
+        }
     }
 
     pub fn keypair(&self) -> KeyPair {
@@ -52,7 +55,11 @@ impl Mint {
 
     pub fn create_transactions(&self) -> Vec<Transaction> {
         let keypair = self.keypair();
-        let tx = Transaction::new(&keypair, self.pubkey(), self.tokens, self.seed());
+        let id = LastId {
+            hash: self.seed(),
+            height: 1,
+        };
+        let tx = Transaction::new(&keypair, self.pubkey(), self.tokens, id);
         vec![tx]
     }
 

--- a/src/request.rs
+++ b/src/request.rs
@@ -1,7 +1,7 @@
 //! The `request` module defines the messages for the thin client.
 
-use hash::Hash;
-use signature::{PublicKey, Signature};
+use signature::PublicKey;
+use transaction::{Height, LastId};
 
 #[cfg_attr(feature = "cargo-clippy", allow(large_enum_variant))]
 #[derive(Serialize, Deserialize, Debug, Clone, Copy)]
@@ -9,7 +9,6 @@ pub enum Request {
     GetBalance { key: PublicKey },
     GetLastId,
     GetTransactionCount,
-    GetSignature { signature: Signature },
 }
 
 impl Request {
@@ -21,8 +20,15 @@ impl Request {
 
 #[derive(Serialize, Deserialize, Debug)]
 pub enum Response {
-    Balance { key: PublicKey, val: i64 },
-    LastId { id: Hash },
-    TransactionCount { transaction_count: u64 },
-    SignatureStatus { signature_status: bool },
+    Balance {
+        key: PublicKey,
+        val: i64,
+        height: Height,
+    },
+    LastId {
+        id: LastId,
+    },
+    TransactionCount {
+        transaction_count: u64,
+    },
 }

--- a/src/request_processor.rs
+++ b/src/request_processor.rs
@@ -23,8 +23,15 @@ impl RequestProcessor {
     ) -> Option<(Response, SocketAddr)> {
         match msg {
             Request::GetBalance { key } => {
-                let val = self.bank.get_balance(&key);
-                let rsp = (Response::Balance { key, val }, rsp_addr);
+                let val = self.bank.get_versioned_account(&key);
+                let rsp = (
+                    Response::Balance {
+                        key: key,
+                        val: val.tokens,
+                        height: val.version,
+                    },
+                    rsp_addr,
+                );
                 info!("Response::Balance {:?}", rsp);
                 Some(rsp)
             }
@@ -38,12 +45,6 @@ impl RequestProcessor {
                 let transaction_count = self.bank.transaction_count() as u64;
                 let rsp = (Response::TransactionCount { transaction_count }, rsp_addr);
                 info!("Response::TransactionCount {:?}", rsp);
-                Some(rsp)
-            }
-            Request::GetSignature { signature } => {
-                let signature_status = self.bank.has_signature(&signature);
-                let rsp = (Response::SignatureStatus { signature_status }, rsp_addr);
-                info!("Response::Signature {:?}", rsp);
                 Some(rsp)
             }
         }

--- a/src/thin_client.rs
+++ b/src/thin_client.rs
@@ -193,7 +193,7 @@ impl ThinClient {
         self.last_id.clone().expect("some last_id")
     }
 
-    /// poll until the account version is equal or greater than the version for millies
+    /// poll until the account version is greater than the current version for millies
     pub fn poll_update(
         &mut self,
         millies: u64,
@@ -204,7 +204,7 @@ impl ThinClient {
         let version = self.balances.get(pubkey).map(|v| v.version).unwrap_or(1);
         loop {
             if let Ok(bal) = self.get_versioned_account(pubkey) {
-                if bal.version >= version {
+                if bal.version > version {
                     return Ok(bal);
                 }
             }

--- a/src/tpu.rs
+++ b/src/tpu.rs
@@ -75,9 +75,9 @@ impl Tpu {
 
         let (record_stage, entry_receiver) = match tick_duration {
             Some(tick_duration) => {
-                RecordStage::new_with_clock(signal_receiver, &bank.last_id(), tick_duration)
+                RecordStage::new_with_clock(signal_receiver, &bank.last_id().hash, tick_duration)
             }
-            None => RecordStage::new(signal_receiver, &bank.last_id()),
+            None => RecordStage::new(signal_receiver, &bank.last_id().hash),
         };
 
         let (write_stage, blob_receiver) = WriteStage::new(

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -75,6 +75,13 @@ pub enum Instruction {
     NewVote(Vote),
 }
 
+pub type Height = u64;
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Default)]
+pub struct LastId {
+    pub height: Height,
+    pub hash: Hash,
+}
+
 /// An instruction signed by a client with `PublicKey`.
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub struct Transaction {
@@ -88,7 +95,7 @@ pub struct Transaction {
     pub instruction: Instruction,
 
     /// The ID of a recent ledger entry.
-    pub last_id: Hash,
+    pub last_id: LastId,
 
     /// The number of tokens paid for processing and storage of this transaction.
     pub fee: i64,
@@ -99,7 +106,7 @@ impl Transaction {
     fn new_from_instruction(
         from_keypair: &KeyPair,
         instruction: Instruction,
-        last_id: Hash,
+        last_id: LastId,
         fee: i64,
     ) -> Self {
         let from = from_keypair.pubkey();
@@ -120,7 +127,7 @@ impl Transaction {
         to: PublicKey,
         tokens: i64,
         fee: i64,
-        last_id: Hash,
+        last_id: LastId,
     ) -> Self {
         let payment = Payment {
             tokens: tokens - fee,
@@ -133,23 +140,23 @@ impl Transaction {
     }
 
     /// Create and sign a new Transaction. Used for unit-testing.
-    pub fn new(from_keypair: &KeyPair, to: PublicKey, tokens: i64, last_id: Hash) -> Self {
+    pub fn new(from_keypair: &KeyPair, to: PublicKey, tokens: i64, last_id: LastId) -> Self {
         Self::new_taxed(from_keypair, to, tokens, 0, last_id)
     }
 
     /// Create and sign a new Witness Timestamp. Used for unit-testing.
-    pub fn new_timestamp(from_keypair: &KeyPair, dt: DateTime<Utc>, last_id: Hash) -> Self {
+    pub fn new_timestamp(from_keypair: &KeyPair, dt: DateTime<Utc>, last_id: LastId) -> Self {
         let instruction = Instruction::ApplyTimestamp(dt);
         Self::new_from_instruction(from_keypair, instruction, last_id, 0)
     }
 
     /// Create and sign a new Witness Signature. Used for unit-testing.
-    pub fn new_signature(from_keypair: &KeyPair, tx_sig: Signature, last_id: Hash) -> Self {
+    pub fn new_signature(from_keypair: &KeyPair, tx_sig: Signature, last_id: LastId) -> Self {
         let instruction = Instruction::ApplySignature(tx_sig);
         Self::new_from_instruction(from_keypair, instruction, last_id, 0)
     }
 
-    pub fn new_vote(from_keypair: &KeyPair, vote: Vote, last_id: Hash, fee: i64) -> Self {
+    pub fn new_vote(from_keypair: &KeyPair, vote: Vote, last_id: LastId, fee: i64) -> Self {
         Transaction::new_from_instruction(&from_keypair, Instruction::NewVote(vote), last_id, fee)
     }
 
@@ -159,7 +166,7 @@ impl Transaction {
         to: PublicKey,
         dt: DateTime<Utc>,
         tokens: i64,
-        last_id: Hash,
+        last_id: LastId,
     ) -> Self {
         let from = from_keypair.pubkey();
         let budget = Budget::Or(
@@ -210,7 +217,7 @@ impl Transaction {
 pub fn test_tx() -> Transaction {
     let keypair1 = KeyPair::new();
     let pubkey1 = keypair1.pubkey();
-    let zero = Hash::default();
+    let zero = LastId::default();
     Transaction::new(&keypair1, pubkey1, 42, zero)
 }
 

--- a/src/voting.rs
+++ b/src/voting.rs
@@ -1,18 +1,17 @@
 use entry::Entry;
-use hash::Hash;
 use signature::PublicKey;
-use transaction::{Instruction, Transaction, Vote};
+use transaction::{Instruction, LastId, Transaction, Vote};
 
-pub fn entries_to_votes(entries: &[Entry]) -> Vec<(PublicKey, Vote, Hash)> {
+pub fn entries_to_votes(entries: &[Entry]) -> Vec<(PublicKey, Vote, LastId)> {
     entries
         .iter()
         .flat_map(|entry| entry.transactions.iter().filter_map(transaction_to_vote))
         .collect()
 }
 
-pub fn transaction_to_vote(tx: &Transaction) -> Option<(PublicKey, Vote, Hash)> {
+pub fn transaction_to_vote(tx: &Transaction) -> Option<(PublicKey, Vote, LastId)> {
     match tx.instruction {
-        Instruction::NewVote(ref vote) => Some((tx.from, vote.clone(), tx.last_id)),
+        Instruction::NewVote(ref vote) => Some((tx.from, vote.clone(), tx.last_id.clone())),
         _ => None,
     }
 }

--- a/src/write_stage.rs
+++ b/src/write_stage.rs
@@ -45,7 +45,7 @@ impl WriteStage {
         for entry in entries.clone() {
             ledger_writer.write_entry(&entry)?;
             if !entry.has_more {
-                bank.register_entry_id(&entry.id);
+                bank.register_entry_hash(&entry.id);
             }
         }
 

--- a/tests/multinode.rs
+++ b/tests/multinode.rs
@@ -658,7 +658,8 @@ fn retry_get_balance(
 ) -> Option<i64> {
     const LAST: usize = 20;
     for run in 0..(LAST + 1) {
-        let out = client.poll_get_balance(bob_pubkey);
+        let _ = client.poll_update(1000, bob_pubkey);
+        let out = client.get_balance(bob_pubkey);
         if expected.is_none() || run == LAST {
             return out.ok().clone();
         }


### PR DESCRIPTION
A bunch of changes.  I would love a pass from everyone since it touched a bunch of files

* `LastId` structure that has a Hash + Entry Height
* `VersionedAccount` structure.  Spends are valid only if they are for a height that is greater then `VersionedAccount.version`, the spend updates the version to `Transaction.last_id.height`
* a bunch of changes to wallet and bench to make it all work.  The bencher allocates 1000 tokens to a bunch of keys.  Those keys swap the tokens to each other without veirfication.  So we can drop at most 1k requests in 1 direction.  it should be fairly unlikely.  This allows the bencher to transmit without verification.