### PR TITLE
enhance ledger-tool

### DIFF
--- a/src/bank.rs
+++ b/src/bank.rs
@@ -363,7 +363,7 @@ impl Bank {
         res
     }
 
-    fn process_entry(&self, entry: Entry) -> Result<()> {
+    pub fn process_entry(&self, entry: Entry) -> Result<()> {
         if !entry.transactions.is_empty() {
             for result in self.process_transactions(entry.transactions) {
                 result?;

--- a/src/bin/ledger-tool.rs
+++ b/src/bin/ledger-tool.rs
@@ -56,24 +56,20 @@ fn main() {
 
     match matches.subcommand() {
         ("print", _) => {
-            let mut i = 0;
-            for entry in entries {
+            for (i, entry) in entries.enumerate() {
                 if i >= head {
                     break;
                 }
-                i += 1;
                 let entry = entry.unwrap();
                 println!("{:?}", entry);
             }
         }
         ("json", _) => {
-            let mut i = 0;
             stdout().write_all(b"{\"ledger\":[\n").expect("open array");
-            for entry in entries {
+            for (i, entry) in entries.enumerate() {
                 if i >= head {
                     break;
                 }
-                i += 1;
                 let entry = entry.unwrap();
                 serde_json::to_writer(stdout(), &entry).expect("serialize");
                 stdout().write_all(b",\n").expect("newline");
@@ -84,10 +80,10 @@ fn main() {
             let bank = Bank::default();
             if head != <usize>::max_value() {
                 let entries = entries.map(|entry| entry.unwrap()).take(head);
-                bank.process_ledger(entries).expect("process_ledger").0;
+                bank.process_ledger(entries).expect("process_ledger");
             } else {
                 let entries = entries.map(|entry| entry.unwrap());
-                bank.process_ledger(entries).expect("process_ledger").0;
+                bank.process_ledger(entries).expect("process_ledger");
             }
         }
         ("verify-internal", _) => {

--- a/src/ledger.rs
+++ b/src/ledger.rs
@@ -469,13 +469,13 @@ pub fn next_entries_mut(
     if transactions.is_empty() || transactions.len() == 1 {
         vec![Entry::new_mut(start_hash, num_hashes, transactions, false)]
     } else {
-        let mut start = 0;
+        let mut chunk_start = 0;
         let mut entries = Vec::new();
 
-        while start < transactions.len() {
+        while chunk_start < transactions.len() {
             let mut chunk_end = transactions.len();
             let mut upper = chunk_end;
-            let mut lower = start;
+            let mut lower = chunk_start;
             let mut next = chunk_end; // be optimistic that all will fit
 
             // binary search for how many transactions will fit in an Entry (i.e. a BLOB)
@@ -488,7 +488,7 @@ pub fn next_entries_mut(
                     next,
                     transactions.len()
                 );
-                if Entry::will_fit(transactions[start..chunk_end].to_vec()) {
+                if Entry::will_fit(transactions[chunk_start..chunk_end].to_vec()) {
                     next = (upper + chunk_end) / 2;
                     lower = chunk_end;
                     debug!(
@@ -510,10 +510,10 @@ pub fn next_entries_mut(
             entries.push(Entry::new_mut(
                 start_hash,
                 num_hashes,
-                transactions[start..chunk_end].to_vec(),
+                transactions[chunk_start..chunk_end].to_vec(),
                 transactions.len() - chunk_end > 0,
             ));
-            start = chunk_end;
+            chunk_start = chunk_end;
         }
 
         entries


### PR DESCRIPTION
* add json, which does the thing with json, move print to Rust's {:?}
  * add --head NUM, to limit how much work gets done for print, json, verify
  * add verify-internal, which very carefully checks ledger format without
      trying first to "recover" it
  * exit with errors on mis-usage

helps with #910