### PR TITLE
Fix bank coalescing

### DIFF
--- a/benches/banking_stage.rs
+++ b/benches/banking_stage.rs
@@ -79,7 +79,7 @@ use std::sync::Arc;
 //     println!("{} tps", tps);
 // }
 
-fn check_txs(_batches: usize, receiver: &Receiver<Signal>, ref_tx_count: usize) {
+fn check_txs(receiver: &Receiver<Signal>, ref_tx_count: usize) {
     let mut total = 0;
     loop {
         let signal = receiver.recv().unwrap();
@@ -150,7 +150,7 @@ fn bench_banking_stage_multi_accounts(bencher: &mut Bencher) {
         BankingStage::process_packets(&bank, &verified_receiver, &signal_sender, &packet_recycler)
             .unwrap();
 
-        check_txs(verified_setup_len, &signal_receiver, num_src_accounts);
+        check_txs(&signal_receiver, num_src_accounts);
 
         let verified: Vec<_> = to_packets_chunked(&packet_recycler, &transactions.clone(), 192)
             .into_iter()
@@ -165,7 +165,7 @@ fn bench_banking_stage_multi_accounts(bencher: &mut Bencher) {
         BankingStage::process_packets(&bank, &verified_receiver, &signal_sender, &packet_recycler)
             .unwrap();
 
-        check_txs(verified_len, &signal_receiver, tx);
+        check_txs(&signal_receiver, tx);
     });
 }
 
@@ -208,7 +208,7 @@ fn bench_banking_stage_single_from(bencher: &mut Bencher) {
         BankingStage::process_packets(&bank, &verified_receiver, &signal_sender, &packet_recycler)
             .unwrap();
 
-        check_txs(verified_len, &signal_receiver, tx);
+        check_txs(&signal_receiver, tx);
     });
 }
 

--- a/benches/banking_stage.rs
+++ b/benches/banking_stage.rs
@@ -79,9 +79,9 @@ use std::sync::Arc;
 //     println!("{} tps", tps);
 // }
 
-fn check_txs(batches: usize, receiver: &Receiver<Signal>, ref_tx_count: usize) {
+fn check_txs(_batches: usize, receiver: &Receiver<Signal>, ref_tx_count: usize) {
     let mut total = 0;
-    for _ in 0..batches {
+    loop {
         let signal = receiver.recv().unwrap();
         if let Signal::Transactions(transactions) = signal {
             total += transactions.len();

--- a/src/banking_stage.rs
+++ b/src/banking_stage.rs
@@ -116,6 +116,7 @@ impl BankingStage {
                         if 0 == vers[i] {
                             None
                         } else {
+                            //seems like we should only deserialize verified data
                             deserialize(&x.data[0..x.meta.size]).ok()
                         }
                     })
@@ -126,8 +127,10 @@ impl BankingStage {
         for txs in txs.chunks(MAX_COALESCED_TXS) {
             debug!("process_transactions");
             let transactions: Vec<_> = txs.to_vec(); //TODO: so many allocs
+
             let results = bank.process_transactions(transactions);
             debug!("done process_transactions");
+            //once processed, results cannot be merged, output must be sent even if its smaller than a blob
             let output = results.into_iter().filter_map(|x| x.ok()).collect(); //TODO: so many allocs
             signal_sender.send(Signal::Transactions(output))?;
         }

--- a/tests/multinode.rs
+++ b/tests/multinode.rs
@@ -524,7 +524,7 @@ fn test_multi_node_dynamic_network() {
         Ok(val) => val
             .parse()
             .expect(&format!("env var {} is not parse-able as usize", key)),
-        Err(_) => 120,
+        Err(_) => 100,
     };
 
     let purge_key = "SOLANA_DYNAMIC_NODES_PURGE_LAG";

--- a/tests/multinode.rs
+++ b/tests/multinode.rs
@@ -524,7 +524,7 @@ fn test_multi_node_dynamic_network() {
         Ok(val) => val
             .parse()
             .expect(&format!("env var {} is not parse-able as usize", key)),
-        Err(_) => 230,
+        Err(_) => 120,
     };
 
     let purge_key = "SOLANA_DYNAMIC_NODES_PURGE_LAG";


### PR DESCRIPTION
once transactions are processed, they can't be coalesced since that will break assumptions that every transaction in an entry can be spent independently. 

* coalescing the batch right before process creates a 2x performance hit (banking_stage bench)
* right thing to do is #950 i think
* @garious @pgarg66 i backed out the change to coalesce transactions.  but this brings us down to 120 nodes :(