### PR TITLE
Cap repair requests timeout

### DIFF
--- a/src/window.rs
+++ b/src/window.rs
@@ -108,6 +108,14 @@ fn repair_window(
     }
     *last = consumed;
     *times += 1;
+
+    // Experiment with capping repair request duration.
+    // Once nodes are too far behind they can spend many
+    // seconds without asking for repair
+    if *times > 128 {
+        *times = 65;
+    }
+
     //if times flips from all 1s 7 -> 8, 15 -> 16, we retry otherwise return Ok
     if *times & (*times - 1) != 0 {
         trace!("repair_window counter {} {} {}", *times, consumed, received);


### PR DESCRIPTION
When nodes get too far behind they can spend 3-4 seconds just sending 1 or 2 repair requests. These can get dropped or go to nodes which don't have the blob yet, so send repair requests at ~64 blobs received which may give them a better chance to catch up.