### PR TITLE
not quite banishing build.rs, but better

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,15 +1,22 @@
 use std::env;
 
 fn main() {
-    println!("cargo:rustc-link-search=native=.");
-    if !env::var("CARGO_FEATURE_CUDA").is_err() {
+    println!("cargo:rerun-if-changed=target/perf-libs");
+
+    let cuda = !env::var("CARGO_FEATURE_CUDA").is_err();
+    let erasure = !env::var("CARGO_FEATURE_ERASURE").is_err();
+
+    if cuda || erasure {
+        println!("cargo:rustc-link-search=native=target/perf-libs");
+    }
+    if cuda {
         println!("cargo:rustc-link-lib=static=cuda_verify_ed25519");
         println!("cargo:rustc-link-search=native=/usr/local/cuda/lib64");
         println!("cargo:rustc-link-lib=dylib=cudart");
         println!("cargo:rustc-link-lib=dylib=cuda");
         println!("cargo:rustc-link-lib=dylib=cudadevrt");
     }
-    if !env::var("CARGO_FEATURE_ERASURE").is_err() {
+    if erasure {
         println!("cargo:rustc-link-lib=dylib=Jerasure");
         println!("cargo:rustc-link-lib=dylib=gf_complete");
     }

--- a/ci/test-large-network.sh
+++ b/ci/test-large-network.sh
@@ -12,7 +12,7 @@ fi
 export RUST_BACKTRACE=1
 
 ./fetch-perf-libs.sh
-export LD_LIBRARY_PATH+=:$PWD
+export LD_LIBRARY_PATH=$PWD/target/perf-libs:$LD_LIBRARY_PATH
 
 export RUST_LOG=multinode=info
 

--- a/ci/test-stable-perf.sh
+++ b/ci/test-stable-perf.sh
@@ -11,7 +11,7 @@ fi
 export RUST_BACKTRACE=1
 
 ./fetch-perf-libs.sh
-export LD_LIBRARY_PATH=$PWD:/usr/local/cuda/lib64
+export LD_LIBRARY_PATH=$PWD/target/perf-libs:/usr/local/cuda/lib64:$LD_LIBRARY_PATH
 export PATH=$PATH:/usr/local/cuda/bin
 
 _() {

--- a/fetch-perf-libs.sh
+++ b/fetch-perf-libs.sh
@@ -10,28 +10,30 @@ if [[ $(uname -m) != x86_64 ]]; then
   exit 1
 fi
 
+mkdir -p target/perf-libs
 (
-  set -x
-  curl -o solana-perf.tgz \
-    https://solana-perf.s3.amazonaws.com/master/x86_64-unknown-linux-gnu/solana-perf.tgz
-  tar zxvf solana-perf.tgz
-)
+  cd target/perf-libs
+  (
+    set -x
+    curl https://solana-perf.s3.amazonaws.com/master/x86_64-unknown-linux-gnu/solana-perf.tgz | tar zxvf -
+  )
 
-if [[ -r /usr/local/cuda/version.txt && -r cuda-version.txt ]]; then
-  if ! diff /usr/local/cuda/version.txt cuda-version.txt > /dev/null; then
+  if [[ -r /usr/local/cuda/version.txt && -r cuda-version.txt ]]; then
+    if ! diff /usr/local/cuda/version.txt cuda-version.txt > /dev/null; then
+        echo ==============================================
+        echo Warning: possible CUDA version mismatch
+        echo
+        echo "Expected version: $(cat cuda-version.txt)"
+        echo "Detected version: $(cat /usr/local/cuda/version.txt)"
+        echo ==============================================
+    fi
+  else
     echo ==============================================
-    echo Warning: possible CUDA version mismatch
-    echo
-    echo "Expected version: $(cat cuda-version.txt)"
-    echo "Detected version: $(cat /usr/local/cuda/version.txt)"
+    echo Warning: unable to validate CUDA version
     echo ==============================================
   fi
-else
-  echo ==============================================
-  echo Warning: unable to validate CUDA version
-  echo ==============================================
-fi
 
-echo "Downloaded solana-perf version: $(cat solana-perf-HEAD.txt)"
+  echo "Downloaded solana-perf version: $(cat solana-perf-HEAD.txt)"
+)
 
 exit 0

--- a/multinode-demo/common.sh
+++ b/multinode-demo/common.sh
@@ -80,7 +80,7 @@ else
     fi
 
     # Locate perf libs downloaded by |./fetch-perf-libs.sh|
-    LD_LIBRARY_PATH=$(cd "$here" && dirname "$PWD"):$LD_LIBRARY_PATH
+    LD_LIBRARY_PATH=$(cd "$here" && dirname "$PWD"/target/perf-libs):$LD_LIBRARY_PATH
     export LD_LIBRARY_PATH
   fi
 fi

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -108,8 +108,8 @@ parts:
       rm -rf $SNAPCRAFT_PART_INSTALL/bin/*
       mv $SNAPCRAFT_PART_INSTALL/solana-fullnode $SNAPCRAFT_PART_INSTALL/bin/solana-fullnode-cuda
       mkdir -p $SNAPCRAFT_PART_INSTALL/usr/lib/
-      cp -f libJerasure.so $SNAPCRAFT_PART_INSTALL/usr/lib/libJerasure.so.2
-      cp -f libgf_complete.so $SNAPCRAFT_PART_INSTALL/usr/lib/libgf_complete.so.1
+      cp -f target/perf-libs/libJerasure.so $SNAPCRAFT_PART_INSTALL/usr/lib/libJerasure.so.2
+      cp -f target/perf-libs/libgf_complete.so $SNAPCRAFT_PART_INSTALL/usr/lib/libgf_complete.so.1
 
       # Build/install all other programs
       cargo install --root $SNAPCRAFT_PART_INSTALL --bins


### PR DESCRIPTION
this change advises cargo what things build.rs cares about, instead of everything under the tree root

https://doc.rust-lang.org/cargo/reference/build-scripts.html

find in page: "rerun-if-changed=PATH"