### PR TITLE
Large network test to not poll validator for sigs

### DIFF
--- a/tests/multinode.rs
+++ b/tests/multinode.rs
@@ -677,11 +677,9 @@ fn test_multi_node_dynamic_network() {
             let mut num_nodes_behind = 0i64;
             validators.retain(|server| {
                 let mut client = mk_client(&server.0);
-                trace!("{:x} polling for signature", server.0.debug_id());
-                num_nodes_behind += match client.poll_for_signature(&sig) {
-                    Ok(_) => 0,
-                    Err(_) => 1,
-                };
+                trace!("{:x} checking signature", server.0.debug_id());
+                num_nodes_behind += if client.check_signature(&sig) { 0 } else { 1 };
+                server.1.exit();
                 true
             });
 


### PR DESCRIPTION
- The finality is already reached. The test will check the signature
  in validators once, instead of polling. This will help speed up the test.