### PR TITLE
ci/channel-info.sh: Add script to fetch latest channel info

### DIFF
--- a/ci/channel-info.sh
+++ b/ci/channel-info.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+#
+# Computes the current branch names of the edge, beta and stable
+# channels, as well as the latest tagged release for beta and stable.
+#
+# stdout of this script may be eval-ed
+#
+
+here="$(dirname "$0")"
+
+# shellcheck source=ci/semver_bash/semver.sh
+source "$here"/semver_bash/semver.sh
+
+remote=https://github.com/solana-labs/solana.git
+
+# Fetch all vX.Y.Z tags
+#
+# NOTE: pre-release tags are explicitly ignored
+#
+# shellcheck disable=SC2207
+tags=( \
+  $(git ls-remote --tags $remote \
+    | cut -c52- \
+    | grep '^v[[:digit:]][[:digit:]]*\.[[:digit:]][[:digit:]]*.[[:digit:]][[:digit:]]*$' \
+    | cut -c2- \
+  ) \
+)
+
+# Fetch all the vX.Y branches
+#
+# shellcheck disable=SC2207
+heads=( \
+  $(git ls-remote --heads $remote \
+    | cut -c53- \
+    | grep '^v[[:digit:]][[:digit:]]*\.[[:digit:]][[:digit:]]*$' \
+    | cut -c2- \
+  ) \
+)
+
+# Figure the beta channel by looking for the largest vX.Y branch
+beta=
+for head in "${heads[@]}"; do
+  if [[ -n $beta ]]; then
+    if semverLT "$head.0" "$beta.0"; then
+      continue
+    fi
+  fi
+  beta=$head
+done
+
+# Figure the stable channel by looking for the second largest vX.Y branch
+stable=
+for head in "${heads[@]}"; do
+  if [[ $head = "$beta" ]]; then
+    continue
+  fi
+  if [[ -n $stable ]]; then
+    if semverLT "$head.0" "$stable.0"; then
+      continue
+    fi
+  fi
+  stable=$head
+done
+
+for tag in "${tags[@]}"; do
+  if [[ -n $beta && $tag = $beta* ]]; then
+    if [[ -n $beta_tag ]]; then
+      if semverLT "$tag" "$beta_tag"; then
+        continue
+      fi
+    fi
+    beta_tag=$tag
+  fi
+
+  if [[ -n $stable && $tag = $stable* ]]; then
+    if [[ -n $stable_tag ]]; then
+      if semverLT "$tag" "$stable_tag"; then
+        continue
+      fi
+    fi
+    stable_tag=$tag
+  fi
+done
+
+echo EDGE_CHANNEL=master
+echo BETA_CHANNEL="${beta:+v$beta}"
+echo STABLE_CHANNEL="${stable:+v$stable}"
+echo BETA_CHANNEL_LATEST_TAG="${beta_tag:+v$beta_tag}"
+echo STABLE_CHANNEL_LATEST_TAG="${stable_tag:+v$stable_tag}"
+
+exit 0

--- a/ci/semver_bash/LICENSE
+++ b/ci/semver_bash/LICENSE
@@ -1,0 +1,26 @@
+Copyright (c) 2013, Ray Bejjani
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met: 
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer. 
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution. 
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+The views and conclusions contained in the software and documentation are those
+of the authors and should not be interpreted as representing official policies, 
+either expressed or implied, of the FreeBSD Project.

--- a/ci/semver_bash/README.md
+++ b/ci/semver_bash/README.md
@@ -1,0 +1,31 @@
+semver_bash is a bash parser for semantic versioning
+====================================================
+
+[Semantic Versioning](http://semver.org/) is a set of guidelines that help keep
+version and version management sane. This is a bash based parser to help manage
+a project's versions. Use it from a Makefile or any scripts you use in your
+project.
+
+Usage
+-----
+semver_bash can be used from the command line as:  
+
+    $ ./semver.sh "3.2.1" "3.2.1-alpha"  
+    3.2.1 -> M: 3 m:2 p:1 s:  
+    3.2.1-alpha -> M: 3 m:2 p:1 s:-alpha  
+    3.2.1 == 3.2.1-alpha -> 1.  
+    3.2.1 < 3.2.1-alpha -> 1.  
+    3.2.1 > 3.2.1-alpha -> 0.
+
+
+Alternatively, you can source it from within a script:
+
+    . ./semver.sh  
+    
+    local MAJOR=0  
+    local MINOR=0  
+    local PATCH=0  
+    local SPECIAL=""
+    
+    semverParseInto "1.2.3" MAJOR MINOR PATCH SPECIAL  
+    semverParseInto "3.2.1" MAJOR MINOR PATCH SPECIAL  

--- a/ci/semver_bash/semver.sh
+++ b/ci/semver_bash/semver.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env sh
+
+function semverParseInto() {
+    local RE='[^0-9]*\([0-9]*\)[.]\([0-9]*\)[.]\([0-9]*\)\([0-9A-Za-z-]*\)'
+    #MAJOR
+    eval $2=`echo $1 | sed -e "s#$RE#\1#"`
+    #MINOR
+    eval $3=`echo $1 | sed -e "s#$RE#\2#"`
+    #MINOR
+    eval $4=`echo $1 | sed -e "s#$RE#\3#"`
+    #SPECIAL
+    eval $5=`echo $1 | sed -e "s#$RE#\4#"`
+}
+
+function semverEQ() {
+    local MAJOR_A=0
+    local MINOR_A=0
+    local PATCH_A=0
+    local SPECIAL_A=0
+
+    local MAJOR_B=0
+    local MINOR_B=0
+    local PATCH_B=0
+    local SPECIAL_B=0
+
+    semverParseInto $1 MAJOR_A MINOR_A PATCH_A SPECIAL_A
+    semverParseInto $2 MAJOR_B MINOR_B PATCH_B SPECIAL_B
+
+    if [ $MAJOR_A -ne $MAJOR_B ]; then
+        return 1
+    fi
+
+    if [ $MINOR_A -ne $MINOR_B ]; then
+        return 1
+    fi
+
+    if [ $PATCH_A -ne $PATCH_B ]; then
+        return 1
+    fi
+
+    if [[ "_$SPECIAL_A" != "_$SPECIAL_B" ]]; then
+        return 1
+    fi
+
+
+    return 0
+
+}
+
+function semverLT() {
+    local MAJOR_A=0
+    local MINOR_A=0
+    local PATCH_A=0
+    local SPECIAL_A=0
+
+    local MAJOR_B=0
+    local MINOR_B=0
+    local PATCH_B=0
+    local SPECIAL_B=0
+
+    semverParseInto $1 MAJOR_A MINOR_A PATCH_A SPECIAL_A
+    semverParseInto $2 MAJOR_B MINOR_B PATCH_B SPECIAL_B
+
+    if [ $MAJOR_A -lt $MAJOR_B ]; then
+        return 0
+    fi
+
+    if [[ $MAJOR_A -le $MAJOR_B  && $MINOR_A -lt $MINOR_B ]]; then
+        return 0
+    fi
+    
+    if [[ $MAJOR_A -le $MAJOR_B  && $MINOR_A -le $MINOR_B && $PATCH_A -lt $PATCH_B ]]; then
+        return 0
+    fi
+
+    if [[ "_$SPECIAL_A"  == "_" ]] && [[ "_$SPECIAL_B"  == "_" ]] ; then
+        return 1
+    fi
+    if [[ "_$SPECIAL_A"  == "_" ]] && [[ "_$SPECIAL_B"  != "_" ]] ; then
+        return 1
+    fi
+    if [[ "_$SPECIAL_A"  != "_" ]] && [[ "_$SPECIAL_B"  == "_" ]] ; then
+        return 0
+    fi
+
+    if [[ "_$SPECIAL_A" < "_$SPECIAL_B" ]]; then
+        return 0
+    fi
+
+    return 1
+
+}
+
+function semverGT() {
+    semverEQ $1 $2
+    local EQ=$?
+
+    semverLT $1 $2
+    local LT=$?
+
+    if [ $EQ -ne 0 ] && [ $LT -ne 0 ]; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+if [ "___semver.sh" == "___`basename $0`" ]; then
+
+MAJOR=0
+MINOR=0
+PATCH=0
+SPECIAL=""
+
+semverParseInto $1 MAJOR MINOR PATCH SPECIAL
+echo "$1 -> M: $MAJOR m:$MINOR p:$PATCH s:$SPECIAL"
+
+semverParseInto $2 MAJOR MINOR PATCH SPECIAL
+echo "$2 -> M: $MAJOR m:$MINOR p:$PATCH s:$SPECIAL"
+
+semverEQ $1 $2
+echo "$1 == $2 -> $?."
+
+semverLT $1 $2
+echo "$1 < $2 -> $?."
+
+semverGT $1 $2
+echo "$1 > $2 -> $?."
+
+fi

--- a/ci/semver_bash/semver_test.sh
+++ b/ci/semver_bash/semver_test.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+
+. ./semver.sh
+
+semverTest() {
+local A=R1.3.2
+local B=R2.3.2
+local C=R1.4.2
+local D=R1.3.3
+local E=R1.3.2a
+local F=R1.3.2b
+local G=R1.2.3
+
+local MAJOR=0
+local MINOR=0
+local PATCH=0
+local SPECIAL=""
+
+semverParseInto $A MAJOR MINOR PATCH SPECIAL
+echo "$A -> M:$MAJOR m:$MINOR p:$PATCH s:$SPECIAL. Expect M:1 m:3 p:2 s:"
+semverParseInto $E MAJOR MINOR PATCH SPECIAL
+echo "$E -> M:$MAJOR m:$MINOR p:$PATCH s:$SPECIAL. Expect M:1 m:3 p:2 s:a"
+
+echo "Equality comparisions"
+semverEQ $A $A
+echo "$A == $A -> $?. Expect 0."
+
+semverLT $A $A
+echo "$A < $A -> $?. Expect 1."
+
+semverGT $A $A
+echo "$A > $A -> $?. Expect 1."
+
+
+echo "Major number comparisions"
+semverEQ $A $B
+echo "$A == $B -> $?. Expect 1."
+
+semverLT $A $B
+echo "$A < $B -> $?. Expect 0."
+
+semverGT $A $B
+echo "$A > $B -> $?. Expect 1."
+
+semverEQ $B $A
+echo "$B == $A -> $?. Expect 1."
+
+semverLT $B $A
+echo "$B < $A -> $?. Expect 1."
+
+semverGT $B $A
+echo "$B > $A -> $?. Expect 0."
+
+
+echo "Minor number comparisions"
+semverEQ $A $C
+echo "$A == $C -> $?. Expect 1."
+
+semverLT $A $C
+echo "$A < $C -> $?. Expect 0."
+
+semverGT $A $C
+echo "$A > $C -> $?. Expect 1."
+
+semverEQ $C $A
+echo "$C == $A -> $?. Expect 1."
+
+semverLT $C $A
+echo "$C < $A -> $?. Expect 1."
+
+semverGT $C $A
+echo "$C > $A -> $?. Expect 0."
+
+echo "patch number comparisions"
+semverEQ $A $D
+echo "$A == $D -> $?. Expect 1."
+
+semverLT $A $D
+echo "$A < $D -> $?. Expect 0."
+
+semverGT $A $D
+echo "$A > $D -> $?. Expect 1."
+
+semverEQ $D $A
+echo "$D == $A -> $?. Expect 1."
+
+semverLT $D $A
+echo "$D < $A -> $?. Expect 1."
+
+semverGT $D $A
+echo "$D > $A -> $?. Expect 0."
+
+echo "special section vs no special comparisions"
+semverEQ $A $E
+echo "$A == $E -> $?. Expect 1."
+
+semverLT $A $E
+echo "$A < $E -> $?. Expect 1."
+
+semverGT $A $E
+echo "$A > $E -> $?. Expect 0."
+
+semverEQ $E $A
+echo "$E == $A -> $?. Expect 1."
+
+semverLT $E $A
+echo "$E < $A -> $?. Expect 0."
+
+semverGT $E $A
+echo "$E > $A -> $?. Expect 1."
+
+echo "special section vs special comparisions"
+semverEQ $E $F
+echo "$E == $F -> $?. Expect 1."
+
+semverLT $E $F
+echo "$E < $F -> $?. Expect 0."
+
+semverGT $E $F
+echo "$E > $F -> $?. Expect 1."
+
+semverEQ $F $E
+echo "$F == $E -> $?. Expect 1."
+
+semverLT $F $E
+echo "$F < $E -> $?. Expect 1."
+
+semverGT $F $E
+echo "$F > $E -> $?. Expect 0."
+
+echo "Minor and patch number comparisons"
+semverEQ $A $G
+echo "$A == $G -> $?. Expect 1."
+
+semverLT $A $G
+echo "$A < $G -> $?. Expect 1."
+
+semverGT $A $G
+echo "$A > $G -> $?. Expect 0."
+
+semverEQ $G $A
+echo "$G == $A -> $?. Expect 1."
+
+semverLT $G $A
+echo "$G < $A -> $?. Expect 0."
+
+semverGT $G $A
+echo "$G > $A -> $?. Expect 1."
+}
+
+semverTest

--- a/ci/shellcheck.sh
+++ b/ci/shellcheck.sh
@@ -6,6 +6,7 @@ cd "$(dirname "$0")/.."
 
 set -x
 find . -name "*.sh" \
+    -not -regex ".*/ci/semver_bash/.*" \
     -not -regex ".*/.cargo/.*" \
     -not -regex ".*/node_modules/.*" \
     -not -regex ".*/target/.*" \

--- a/ci/snap.sh
+++ b/ci/snap.sh
@@ -7,16 +7,19 @@ if [[ -z $BUILDKITE_BRANCH ]] || ./ci/is-pr.sh; then
   DRYRUN="echo"
 fi
 
-# BUILDKITE_TAG is the normal environment variable set by Buildkite.  However
-# when this script is run from a triggered pipeline, TRIGGERED_BUILDKITE_TAG is
-# used instead of BUILDKITE_TAG (due to Buildkite limitations that prevents
-# BUILDKITE_TAG from propagating through to triggered pipelines)
-if [[ -n "$BUILDKITE_TAG" || -n "$TRIGGERED_BUILDKITE_TAG" ]]; then
+eval "$(ci/channel-info.sh)"
+
+if [[ $BUILDKITE_BRANCH = "$STABLE_CHANNEL" ]]; then
   SNAP_CHANNEL=stable
-elif [[ $BUILDKITE_BRANCH = master ]]; then
+elif [[ $BUILDKITE_BRANCH = "$EDGE_CHANNEL" ]]; then
   SNAP_CHANNEL=edge
-else
+elif [[ $BUILDKITE_BRANCH = "$BETA_CHANNEL" ]]; then
   SNAP_CHANNEL=beta
+fi
+
+if [[ -z $SNAP_CHANNEL ]]; then
+  echo Unable to determine channel to publish into, exiting.
+  exit 0
 fi
 
 if [[ -z $DRYRUN ]]; then


### PR DESCRIPTION
With a repo that actually conforms to what's documented at #995:
```
$ ci/channel-info.sh
EDGE_CHANNEL=master
BETA_CHANNEL=v0.8
STABLE_CHANNEL=v0.7
BETA_CHANNEL_LATEST_TAG=v0.8.0
STABLE_CHANNEL_LATEST_TAG=v0.7.1
```
Depends-on: #995