### PR TITLE
Boot criterion

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,25 +94,17 @@ tokio = "0.1"
 tokio-codec = "0.1"
 untrusted = "0.6.2"
 
-[dev-dependencies]
-criterion = "0.2"
-
 [[bench]]
 name = "bank"
-harness = false
 
 [[bench]]
 name = "banking_stage"
-harness = false
 
 [[bench]]
 name = "ledger"
-harness = false
 
 [[bench]]
 name = "signature"
-harness = false
 
 [[bench]]
 name = "sigverify"
-harness = false

--- a/benches/banking_stage.rs
+++ b/benches/banking_stage.rs
@@ -96,7 +96,6 @@ fn check_txs(receiver: &Receiver<Signal>, ref_tx_count: usize) {
 }
 
 #[bench]
-#[ignore]
 fn bench_banking_stage_multi_accounts(bencher: &mut Bencher) {
     let tx = 10_000_usize;
     let mint_total = 1_000_000_000_000;
@@ -170,7 +169,6 @@ fn bench_banking_stage_multi_accounts(bencher: &mut Bencher) {
 }
 
 #[bench]
-#[ignore]
 fn bench_banking_stage_single_from(bencher: &mut Bencher) {
     let tx = 10_000_usize;
     let mint = Mint::new(1_000_000_000_000);

--- a/benches/banking_stage.rs
+++ b/benches/banking_stage.rs
@@ -96,6 +96,7 @@ fn check_txs(receiver: &Receiver<Signal>, ref_tx_count: usize) {
 }
 
 #[bench]
+#[ignore]
 fn bench_banking_stage_multi_accounts(bencher: &mut Bencher) {
     let tx = 10_000_usize;
     let mint_total = 1_000_000_000_000;
@@ -169,6 +170,7 @@ fn bench_banking_stage_multi_accounts(bencher: &mut Bencher) {
 }
 
 #[bench]
+#[ignore]
 fn bench_banking_stage_single_from(bencher: &mut Bencher) {
     let tx = 10_000_usize;
     let mint = Mint::new(1_000_000_000_000);

--- a/benches/ledger.rs
+++ b/benches/ledger.rs
@@ -1,15 +1,16 @@
-#[macro_use]
-extern crate criterion;
+#![feature(test)]
 extern crate solana;
+extern crate test;
 
-use criterion::{Bencher, Criterion};
 use solana::hash::{hash, Hash};
 use solana::ledger::{next_entries, reconstruct_entries_from_blobs, Block};
 use solana::packet::BlobRecycler;
 use solana::signature::{Keypair, KeypairUtil};
 use solana::transaction::Transaction;
 use std::collections::VecDeque;
+use test::Bencher;
 
+#[bench]
 fn bench_block_to_blobs_to_block(bencher: &mut Bencher) {
     let zero = Hash::default();
     let one = hash(&zero.as_ref());
@@ -25,16 +26,3 @@ fn bench_block_to_blobs_to_block(bencher: &mut Bencher) {
         assert_eq!(reconstruct_entries_from_blobs(blob_q).unwrap(), entries);
     });
 }
-
-fn bench(criterion: &mut Criterion) {
-    criterion.bench_function("bench_block_to_blobs_to_block", |bencher| {
-        bench_block_to_blobs_to_block(bencher);
-    });
-}
-
-criterion_group!(
-    name = benches;
-    config = Criterion::default().sample_size(2);
-    targets = bench
-);
-criterion_main!(benches);

--- a/benches/signature.rs
+++ b/benches/signature.rs
@@ -1,24 +1,12 @@
-#[macro_use]
-extern crate criterion;
+#![feature(test)]
 extern crate solana;
+extern crate test;
 
-use criterion::{Bencher, Criterion};
 use solana::signature::GenKeys;
+use test::Bencher;
 
+#[bench]
 fn bench_gen_keys(b: &mut Bencher) {
     let mut rnd = GenKeys::new([0u8; 32]);
     b.iter(|| rnd.gen_n_keypairs(1000));
 }
-
-fn bench(criterion: &mut Criterion) {
-    criterion.bench_function("bench_gen_keys", |bencher| {
-        bench_gen_keys(bencher);
-    });
-}
-
-criterion_group!(
-    name = benches;
-    config = Criterion::default().sample_size(2);
-    targets = bench
-);
-criterion_main!(benches);

--- a/benches/sigverify.rs
+++ b/benches/sigverify.rs
@@ -1,14 +1,15 @@
-#[macro_use]
-extern crate criterion;
+#![feature(test)]
 extern crate bincode;
 extern crate rayon;
 extern crate solana;
+extern crate test;
 
-use criterion::{Bencher, Criterion};
 use solana::packet::{to_packets, PacketRecycler};
 use solana::sigverify;
 use solana::transaction::test_tx;
+use test::Bencher;
 
+#[bench]
 fn bench_sigverify(bencher: &mut Bencher) {
     let tx = test_tx();
 
@@ -21,16 +22,3 @@ fn bench_sigverify(bencher: &mut Bencher) {
         let _ans = sigverify::ed25519_verify(&batches);
     })
 }
-
-fn bench(criterion: &mut Criterion) {
-    criterion.bench_function("bench_sigverify", |bencher| {
-        bench_sigverify(bencher);
-    });
-}
-
-criterion_group!(
-    name = benches;
-    config = Criterion::default().sample_size(2);
-    targets = bench
-);
-criterion_main!(benches);

--- a/ci/buildkite.yml
+++ b/ci/buildkite.yml
@@ -4,11 +4,11 @@ steps:
     env:
       CARGO_TARGET_CACHE_NAME: "stable"
     timeout_in_minutes: 30
-  - command: "ci/docker-run.sh solanalabs/rust-nightly ci/test-bench.sh"
-    name: "bench [public]"
-    env:
-      CARGO_TARGET_CACHE_NAME: "nightly"
-    timeout_in_minutes: 30
+    #  - command: "ci/docker-run.sh solanalabs/rust-nightly ci/test-bench.sh"
+    #    name: "bench [public]"
+    #    env:
+    #      CARGO_TARGET_CACHE_NAME: "nightly"
+    #    timeout_in_minutes: 30
   - command: "ci/shellcheck.sh"
     name: "shellcheck [public]"
     timeout_in_minutes: 20

--- a/ci/buildkite.yml
+++ b/ci/buildkite.yml
@@ -4,10 +4,10 @@ steps:
     env:
       CARGO_TARGET_CACHE_NAME: "stable"
     timeout_in_minutes: 30
-  - command: "ci/docker-run.sh solanalabs/rust ci/test-bench.sh"
+  - command: "ci/docker-run.sh solanalabs/rust-nightly ci/test-bench.sh"
     name: "bench [public]"
     env:
-      CARGO_TARGET_CACHE_NAME: "stable"
+      CARGO_TARGET_CACHE_NAME: "nightly"
     timeout_in_minutes: 30
   - command: "ci/shellcheck.sh"
     name: "shellcheck [public]"

--- a/ci/test-bench.sh
+++ b/ci/test-bench.sh
@@ -2,7 +2,7 @@
 
 cd "$(dirname "$0")/.."
 
-ci/version-check.sh stable
+ci/version-check.sh nightly
 export RUST_BACKTRACE=1
 
 _() {
@@ -10,4 +10,4 @@ _() {
   "$@"
 }
 
-_ cargo bench --verbose
+_ cargo bench --features=unstable --verbose


### PR DESCRIPTION
Criterion has too many dependencies, it's execution as slower, and
we didn't see the kind of precision we had hoped for to use it to
block CI builds.