### PR TITLE
Build but don't run benchmarks

### DIFF
--- a/ci/buildkite.yml
+++ b/ci/buildkite.yml
@@ -4,11 +4,11 @@ steps:
     env:
       CARGO_TARGET_CACHE_NAME: "stable"
     timeout_in_minutes: 30
-    #  - command: "ci/docker-run.sh solanalabs/rust-nightly ci/test-bench.sh"
-    #    name: "bench [public]"
-    #    env:
-    #      CARGO_TARGET_CACHE_NAME: "nightly"
-    #    timeout_in_minutes: 30
+  - command: "ci/docker-run.sh solanalabs/rust-nightly ci/test-bench.sh"
+    name: "bench [public]"
+    env:
+      CARGO_TARGET_CACHE_NAME: "nightly"
+    timeout_in_minutes: 30
   - command: "ci/shellcheck.sh"
     name: "shellcheck [public]"
     timeout_in_minutes: 20

--- a/ci/test-bench.sh
+++ b/ci/test-bench.sh
@@ -10,4 +10,4 @@ _() {
   "$@"
 }
 
-_ cargo bench --features=unstable --verbose
+_ cargo bench --features=unstable --verbose --no-run


### PR DESCRIPTION
My previous PR assumed `cargo +nightly build --features=unstable` would build the benchmarks. Instead, run `cargo bench` with the `--no-run` flag.