### PR TITLE
Add requestAirdrop and sendTransaction endpoints to json-rpc api

### DIFF
--- a/src/fullnode.rs
+++ b/src/fullnode.rs
@@ -3,6 +3,7 @@
 use bank::Bank;
 use broadcast_stage::BroadcastStage;
 use crdt::{Crdt, NodeInfo, TestNode};
+use drone::DRONE_PORT;
 use entry::Entry;
 use ledger::read_ledger;
 use ncp::Ncp;
@@ -202,10 +203,13 @@ impl Fullnode {
         );
         thread_hdls.extend(rpu.thread_hdls());
 
+        let mut drone_addr = node.data.contact_info.tpu;
+        drone_addr.set_port(DRONE_PORT);
         let rpc_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), RPC_PORT);
         let rpc_service = JsonRpcService::new(
             bank.clone(),
             node.data.contact_info.tpu,
+            drone_addr,
             rpc_addr,
             exit.clone(),
         );
@@ -302,10 +306,13 @@ impl Fullnode {
         );
         thread_hdls.extend(rpu.thread_hdls());
 
+        let mut drone_addr = entry_point.contact_info.ncp;
+        drone_addr.set_port(DRONE_PORT);
         let rpc_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), RPC_PORT);
         let rpc_service = JsonRpcService::new(
             bank.clone(),
             node.data.contact_info.tpu,
+            drone_addr,
             rpc_addr,
             exit.clone(),
         );

--- a/src/fullnode.rs
+++ b/src/fullnode.rs
@@ -207,7 +207,7 @@ impl Fullnode {
         drone_addr.set_port(DRONE_PORT);
         let rpc_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), RPC_PORT);
         let rpc_service = JsonRpcService::new(
-            bank.clone(),
+            &bank,
             node.data.contact_info.tpu,
             drone_addr,
             rpc_addr,
@@ -310,7 +310,7 @@ impl Fullnode {
         drone_addr.set_port(DRONE_PORT);
         let rpc_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), RPC_PORT);
         let rpc_service = JsonRpcService::new(
-            bank.clone(),
+            &bank,
             node.data.contact_info.tpu,
             drone_addr,
             rpc_addr,

--- a/src/fullnode.rs
+++ b/src/fullnode.rs
@@ -203,7 +203,12 @@ impl Fullnode {
         thread_hdls.extend(rpu.thread_hdls());
 
         let rpc_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), RPC_PORT);
-        let rpc_service = JsonRpcService::new(bank.clone(), rpc_addr, exit.clone());
+        let rpc_service = JsonRpcService::new(
+            bank.clone(),
+            node.data.contact_info.tpu,
+            rpc_addr,
+            exit.clone(),
+        );
         thread_hdls.extend(rpc_service.thread_hdls());
 
         let blob_recycler = BlobRecycler::default();
@@ -298,7 +303,12 @@ impl Fullnode {
         thread_hdls.extend(rpu.thread_hdls());
 
         let rpc_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), RPC_PORT);
-        let rpc_service = JsonRpcService::new(bank.clone(), rpc_addr, exit.clone());
+        let rpc_service = JsonRpcService::new(
+            bank.clone(),
+            node.data.contact_info.tpu,
+            rpc_addr,
+            exit.clone(),
+        );
         thread_hdls.extend(rpc_service.thread_hdls());
 
         let blob_recycler = BlobRecycler::default();

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -25,13 +25,13 @@ pub struct JsonRpcService {
 
 impl JsonRpcService {
     pub fn new(
-        bank: Arc<Bank>,
+        bank: &Arc<Bank>,
         transactions_addr: SocketAddr,
         drone_addr: SocketAddr,
         rpc_addr: SocketAddr,
         exit: Arc<AtomicBool>,
     ) -> Self {
-        let request_processor = JsonRpcRequestProcessor::new(bank);
+        let request_processor = JsonRpcRequestProcessor::new(bank.clone());
         let thread_hdl = Builder::new()
             .name("solana-jsonrpc".to_string())
             .spawn(move || {


### PR DESCRIPTION
Closes #702 
This pr completes implementing the basic Wallet functionality in the json-rpc API.