### PR TITLE
Up network buffers to 64MB max

### DIFF
--- a/multinode-demo/common.sh
+++ b/multinode-demo/common.sh
@@ -154,7 +154,7 @@ tune_networking() {
       # test the existence of the sysctls before trying to set them
       # go ahead and return true and don't exit if these calls fail
       sysctl net.core.rmem_max 2>/dev/null 1>/dev/null &&
-          sudo sysctl -w net.core.rmem_max=26214400 1>/dev/null 2>/dev/null
+          sudo sysctl -w net.core.rmem_max=67108864 1>/dev/null 2>/dev/null
 
       sysctl net.core.rmem_default 2>/dev/null 1>/dev/null &&
           sudo sysctl -w net.core.rmem_default=26214400 1>/dev/null 2>/dev/null


### PR DESCRIPTION
500ms of data at 1Gbps = 125GB/2 = 64MB
Seems to help tx rate in GCP network tests.