### PR TITLE
Randomize repair requests

### DIFF
--- a/src/window.rs
+++ b/src/window.rs
@@ -8,7 +8,7 @@ use erasure;
 use ledger::Block;
 use log::Level;
 use packet::{BlobRecycler, SharedBlob, SharedBlobs, BLOB_SIZE};
-use rand::{thread_rng, RngCore};
+use rand::{thread_rng, Rng};
 use result::{Error, Result};
 use signature::Pubkey;
 use std::cmp;
@@ -111,7 +111,7 @@ fn repair_backoff(last: &mut u64, times: &mut usize, consumed: u64) -> bool {
     }
 
     //if we get lucky, make the request, which should exponentially get less likely
-    thread_rng().next_u64() % (*times as u64) == 0
+    thread_rng().gen_range(0, *times as u64) == 0
 }
 
 fn repair_window(

--- a/src/window.rs
+++ b/src/window.rs
@@ -126,7 +126,7 @@ fn repair_window(
 ) -> Result<()> {
     //exponential backoff
     if !repair_backoff(last, times, consumed) {
-        return Ok(())
+        return Ok(());
     }
 
     let highest_lost = calculate_highest_lost_blob_index(
@@ -166,7 +166,8 @@ fn add_block_to_retransmit_queue(
     recycler: &BlobRecycler,
     retransmit_queue: &mut VecDeque<SharedBlob>,
 ) {
-    let p = b.read()
+    let p = b
+        .read()
         .expect("'b' read lock in fn add_block_to_retransmit_queue");
     //TODO this check isn't safe against adverserial packets
     //we need to maintain a sequence window
@@ -191,7 +192,8 @@ fn add_block_to_retransmit_queue(
         //is dropped via a weakref to the recycler
         let nv = recycler.allocate();
         {
-            let mut mnv = nv.write()
+            let mut mnv = nv
+                .write()
                 .expect("recycler write lock in fn add_block_to_retransmit_queue");
             let sz = p.meta.size;
             mnv.meta.size = sz;
@@ -285,7 +287,8 @@ fn process_blob(
     let w = (pix % WINDOW_SIZE) as usize;
 
     let is_coding = {
-        let blob_r = blob.read()
+        let blob_r = blob
+            .read()
             .expect("blob read lock for flogs streamer::window");
         blob_r.is_coding()
     };
@@ -420,7 +423,8 @@ fn recv_window(
 ) -> Result<()> {
     let timer = Duration::from_millis(200);
     let mut dq = r.recv_timeout(timer)?;
-    let maybe_leader: Option<NodeInfo> = crdt.read()
+    let maybe_leader: Option<NodeInfo> = crdt
+        .read()
         .expect("'crdt' read lock in fn recv_window")
         .leader_data()
         .cloned();


### PR DESCRIPTION
Do exponential backoff, but randomize when the request fires.  This should spread out some of the thundering heard issues we are seeing on the network.