### PR TITLE
Up log rotate size and reduce count

### DIFF
--- a/multinode-demo/common.sh
+++ b/multinode-demo/common.sh
@@ -33,7 +33,7 @@ if [[ -d $SNAP ]]; then # Running inside a Linux Snap?
     fi
   }
   rsync="$SNAP"/bin/rsync
-  multilog="$SNAP/bin/multilog t s16777215 n200"
+  multilog="$SNAP/bin/multilog t s67108860 n50"
   leader_logger="$multilog $SNAP_DATA/leader"
   validator_logger="$multilog t $SNAP_DATA/validator"
   drone_logger="$multilog $SNAP_DATA/drone"


### PR DESCRIPTION
64mb log is easier to deal with and if compressed is not very large.