### PR TITLE
Disallow localhost in deployment

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ unstable = []
 ipv6 = []
 cuda = []
 erasure = []
+test = []
 
 [dependencies]
 atty = "0.2"

--- a/ci/test-large-network.sh
+++ b/ci/test-large-network.sh
@@ -42,4 +42,4 @@ if [[ $(sysctl -n net.core.wmem_max) -lt 1610612736 ]]; then
 fi
 
 set -x
-exec cargo test --release --features=erasure test_multi_node_dynamic_network -- --ignored
+exec cargo test --release --features=erasure,test test_multi_node_dynamic_network -- --ignored

--- a/ci/test-nightly.sh
+++ b/ci/test-nightly.sh
@@ -11,7 +11,7 @@ _() {
 }
 
 _ cargo build --verbose --features unstable
-_ cargo test --verbose --features unstable
+_ cargo test --verbose --features=unstable,test
 _ cargo clippy -- --deny=warnings
 
 exit 0

--- a/ci/test-stable-perf.sh
+++ b/ci/test-stable-perf.sh
@@ -19,7 +19,7 @@ _() {
   "$@"
 }
 
-_ cargo test --features=cuda,erasure
+_ cargo test --features=cuda,erasure,test
 
 echo --- ci/localnet-sanity.sh
 (

--- a/ci/test-stable.sh
+++ b/ci/test-stable.sh
@@ -12,7 +12,7 @@ _() {
 
 _ cargo fmt -- --check
 _ cargo build --verbose
-_ cargo test --verbose
+_ cargo test --features=test --verbose
 
 echo --- ci/localnet-sanity.sh
 (

--- a/src/crdt.rs
+++ b/src/crdt.rs
@@ -1239,7 +1239,10 @@ impl Crdt {
             .unwrap()
     }
     fn is_valid_address_internal(addr: SocketAddr, cfg_test: bool) -> bool {
-        (addr.port() != 0) && !(addr.ip().is_unspecified() || addr.ip().is_multicast() || (addr.ip().is_loopback() && !cfg_test))
+        (addr.port() != 0)
+            && !(addr.ip().is_unspecified()
+                || addr.ip().is_multicast()
+                || (addr.ip().is_loopback() && !cfg_test))
     }
     /// port must not be 0
     /// ip must be specified and not mulitcast

--- a/src/crdt.rs
+++ b/src/crdt.rs
@@ -1248,7 +1248,7 @@ impl Crdt {
     /// ip must be specified and not mulitcast
     /// loopback ip is only allowed in tests
     pub fn is_valid_address(addr: SocketAddr) -> bool {
-        Self::is_valid_address_internal(addr, cfg!(test) || cfg!(feature="test"))
+        Self::is_valid_address_internal(addr, cfg!(test) || cfg!(feature = "test"))
     }
 }
 

--- a/src/crdt.rs
+++ b/src/crdt.rs
@@ -1238,9 +1238,8 @@ impl Crdt {
             })
             .unwrap()
     }
-
     pub fn is_valid_address(addr: SocketAddr) -> bool {
-        (addr.port() != 0) && !(addr.ip().is_unspecified() || addr.ip().is_multicast())
+        (addr.port() != 0) && !(addr.ip().is_unspecified() || addr.ip().is_multicast()) && !(addr.ip().is_localhost() || !cfg!("test"))
     }
 }
 

--- a/src/crdt.rs
+++ b/src/crdt.rs
@@ -1248,7 +1248,7 @@ impl Crdt {
     /// ip must be specified and not mulitcast
     /// loopback ip is only allowed in tests
     pub fn is_valid_address(addr: SocketAddr) -> bool {
-        Self::is_valid_address_internal(addr, cfg!(test))
+        Self::is_valid_address_internal(addr, cfg!(test) || cfg!(feature="test"))
     }
 }
 

--- a/tests/data_replicator.rs
+++ b/tests/data_replicator.rs
@@ -193,6 +193,7 @@ pub fn crdt_retransmit() -> result::Result<()> {
 #[ignore]
 fn test_external_liveness_table() {
     logger::setup();
+    assert!(cfg!(feature="test"));
     let c1_c4_exit = Arc::new(AtomicBool::new(false));
     let c2_c3_exit = Arc::new(AtomicBool::new(false));
 

--- a/tests/data_replicator.rs
+++ b/tests/data_replicator.rs
@@ -193,7 +193,7 @@ pub fn crdt_retransmit() -> result::Result<()> {
 #[ignore]
 fn test_external_liveness_table() {
     logger::setup();
-    assert!(cfg!(feature="test"));
+    assert!(cfg!(feature = "test"));
     let c1_c4_exit = Arc::new(AtomicBool::new(false));
     let c2_c3_exit = Arc::new(AtomicBool::new(false));
 

--- a/tests/multinode.rs
+++ b/tests/multinode.rs
@@ -120,6 +120,7 @@ fn make_tiny_test_entries(start_hash: Hash, num: usize) -> Vec<Entry> {
 
 #[test]
 fn test_multi_node_ledger_window() -> result::Result<()> {
+    assert!(cfg!(feature="test"));
     logger::setup();
 
     let leader_keypair = Keypair::new();
@@ -518,6 +519,7 @@ fn test_leader_restart_validator_start_from_old_ledger() -> result::Result<()> {
 #[ignore]
 fn test_multi_node_dynamic_network() {
     logger::setup();
+    assert!(cfg!(feature="test"));
     let key = "SOLANA_DYNAMIC_NODES";
     let num_nodes: usize = match env::var(key) {
         Ok(val) => val

--- a/tests/multinode.rs
+++ b/tests/multinode.rs
@@ -120,7 +120,7 @@ fn make_tiny_test_entries(start_hash: Hash, num: usize) -> Vec<Entry> {
 
 #[test]
 fn test_multi_node_ledger_window() -> result::Result<()> {
-    assert!(cfg!(feature="test"));
+    assert!(cfg!(feature = "test"));
     logger::setup();
 
     let leader_keypair = Keypair::new();
@@ -519,7 +519,7 @@ fn test_leader_restart_validator_start_from_old_ledger() -> result::Result<()> {
 #[ignore]
 fn test_multi_node_dynamic_network() {
     logger::setup();
-    assert!(cfg!(feature="test"));
+    assert!(cfg!(feature = "test"));
     let key = "SOLANA_DYNAMIC_NODES";
     let num_nodes: usize = match env::var(key) {
         Ok(val) => val


### PR DESCRIPTION
loopback addresses shouldn't be valid outside of the test environment.  unfortunately integration tests in `tests` do not have `cfg!(test)` attribute set, so we need a feature flag for it.

```
let testnode = TestNode::new_localhost();
```
thats in poll_gossip_for_leader
So it's poisoning the network with localhosts.  This should prevent bugs like this in the future