### PR TITLE
use public ip for network discovery

### DIFF
--- a/src/crdt.rs
+++ b/src/crdt.rs
@@ -20,6 +20,7 @@ use counter::Counter;
 use hash::Hash;
 use ledger::LedgerWindow;
 use log::Level;
+use nat::get_public_ip_addr;
 use nat::udp_random_bind;
 use packet::{to_blob, Blob, BlobRecycler, SharedBlob, BLOB_SIZE};
 use pnet_datalink as datalink;
@@ -199,6 +200,21 @@ impl NodeInfo {
             addr.clone(),
             addr.clone(),
         )
+    }
+    pub fn new_ncp_only() -> (Self, UdpSocket, UdpSocket) {
+        let keypair = Keypair::new();
+        let ip_addr = get_public_ip_addr().expect("autodetect ip address");
+        let addr = SocketAddr::new(ip_addr, 0);
+        let gossip = UdpSocket::bind(addr).unwrap();
+        let daddr: SocketAddr = "0.0.0.0:0".parse().unwrap();
+        let gossip_send = UdpSocket::bind(daddr).unwrap();
+        let gossip_addr = gossip.local_addr().unwrap();
+        assert!(
+            Crdt::is_valid_address(gossip_addr),
+            "NodeInfo::new_ncp_only ip autodetect failed"
+        );
+        let node = NodeInfo::new(keypair.pubkey(), gossip_addr, daddr, daddr, daddr, daddr);
+        (node, gossip, gossip_send)
     }
 
     pub fn debug_id(&self) -> u64 {

--- a/tests/data_replicator.rs
+++ b/tests/data_replicator.rs
@@ -173,7 +173,7 @@ pub fn crdt_retransmit() -> result::Result<()> {
         .into_par_iter()
         .map(|s| {
             let mut b = Blob::default();
-            s.set_read_timeout(Some(Duration::new(1, 0))).unwrap();
+            s.set_read_timeout(Some(Duration::new(2, 0))).unwrap();
             let res = s.recv_from(&mut b.data);
             res.is_err() //true if failed to receive the retransmit packet
         })


### PR DESCRIPTION
oll_gossip_for_leader needs to use a valid gossip address, and not advertise a fullnode. Real fix for this is staking.

Another approach is #1066  . Only one or the other should be merged