### PR TITLE
Update Drone to return tx signature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,7 @@ atty = "0.2"
 bincode = "1.0.0"
 bs58 = "0.2.0"
 byteorder = "1.2.1"
+bytes = "0.4"
 chrono = { version = "0.4.0", features = ["serde"] }
 clap = "2.31"
 dirs = "1.0.2"

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -1,15 +1,18 @@
-use bincode::serialize;
+use bincode::{deserialize, serialize};
 use drone::DroneRequest;
-use signature::Pubkey;
+use signature::{Pubkey, Signature};
 use std::error;
-use std::io::Write;
+use std::io::prelude::*;
+use std::io::{Error, ErrorKind, Write};
+use std::mem::size_of;
 use std::net::{SocketAddr, TcpStream};
 
 pub fn request_airdrop(
     drone_addr: &SocketAddr,
     id: &Pubkey,
     tokens: u64,
-) -> Result<(), Box<error::Error>> {
+) -> Result<Signature, Box<error::Error>> {
+    // TODO: make this async tokio client
     let mut stream = TcpStream::connect(drone_addr)?;
     let req = DroneRequest::GetAirdrop {
         airdrop_request_amount: tokens,
@@ -17,6 +20,16 @@ pub fn request_airdrop(
     };
     let tx = serialize(&req).expect("serialize drone request");
     stream.write_all(&tx).unwrap();
+    let mut buffer = [0; size_of::<Signature>()];
+    stream
+        .read_exact(&mut buffer)
+        .or_else(|_| Err(Error::new(ErrorKind::Other, "Airdrop failed")))?;
+    let signature: Signature = deserialize(&buffer).or_else(|err| {
+        Err(Error::new(
+            ErrorKind::Other,
+            format!("deserialize signature in request_airdrop: {:?}", err),
+        ))
+    })?;
     // TODO: add timeout to this function, in case of unresponsive drone
-    Ok(())
+    Ok(signature)
 }


### PR DESCRIPTION
With the recent changes by @aeyakovenko, this fixes #616 . Drone polls for confirmed tx signature, and returns it to the client that called request_airdrop.

Backwards compatible, but provides options in wallet CLI and bench-tps to utilize signature confirmation (and remove poll_get_balance loops).

This PR also updates the RPC module to return tx signature on requestAirdrop calls, as discussed in #1041 (fyi, @mvines )