### PR TITLE
accounts should never be negative

### DIFF
--- a/src/thin_client.rs
+++ b/src/thin_client.rs
@@ -284,18 +284,18 @@ impl ThinClient {
         let now = Instant::now();
         loop {
             let balance = match self.get_balance(&pubkey) {
-                Ok(bal) => bal,
+                Ok(bal) => Some(bal),
                 Err(e) => {
                     sleep(*polling_frequency);
                     if now.elapsed() > *timeout {
                         ThinClient::submit_poll_balance_metrics(&now.elapsed());
                         return Err(e);
                     }
-                    -1
+                    None
                 }
             };
 
-            if balance >= 0 {
+            if let Some(balance) = balance {
                 ThinClient::submit_poll_balance_metrics(&now.elapsed());
                 return Ok(balance);
             }

--- a/src/thin_client.rs
+++ b/src/thin_client.rs
@@ -295,7 +295,7 @@ impl ThinClient {
                 }
             };
 
-            if let balance != 0 {
+            if balance != 0 {
                 ThinClient::submit_poll_balance_metrics(&now.elapsed());
                 return Ok(balance);
             }

--- a/src/thin_client.rs
+++ b/src/thin_client.rs
@@ -284,18 +284,18 @@ impl ThinClient {
         let now = Instant::now();
         loop {
             let balance = match self.get_balance(&pubkey) {
-                Ok(bal) => Some(bal),
+                Ok(bal) => bal,
                 Err(e) => {
                     sleep(*polling_frequency);
                     if now.elapsed() > *timeout {
                         ThinClient::submit_poll_balance_metrics(&now.elapsed());
                         return Err(e);
                     }
-                    None
+                    0
                 }
             };
 
-            if let Some(balance) = balance {
+            if let balance != 0 {
                 ThinClient::submit_poll_balance_metrics(&now.elapsed());
                 return Ok(balance);
             }


### PR DESCRIPTION
Minor nit fix.  Overloading -1 for balances will make things hard to debug, because it should indicate an accounting math error, not a local failure.


I was actually looking at the failure on 0.7, which was on the same line as bench-tps master.
0.7 bench-tps.rs:
```
  let balance = barrier_client.poll_get_balance(&id.pubkey()).unwrap_or(-1)
```
from 0.7 dashboard:
```
panicked at 'Expected an account balance of 1 (balance: -1', src/bin/bench-tps.rs:148:17
```
which is scary!