### PR TITLE
Use Vec instead of VecDeque for SharedBlobs

### DIFF
--- a/benches/ledger.rs
+++ b/benches/ledger.rs
@@ -7,7 +7,6 @@ use solana::ledger::{next_entries, reconstruct_entries_from_blobs, Block};
 use solana::packet::BlobRecycler;
 use solana::signature::{Keypair, KeypairUtil};
 use solana::transaction::Transaction;
-use std::collections::VecDeque;
 use test::Bencher;
 
 #[bench]
@@ -21,8 +20,7 @@ fn bench_block_to_blobs_to_block(bencher: &mut Bencher) {
 
     let blob_recycler = BlobRecycler::default();
     bencher.iter(|| {
-        let mut blob_q = VecDeque::new();
-        entries.to_blobs(&blob_recycler, &mut blob_q);
-        assert_eq!(reconstruct_entries_from_blobs(blob_q).unwrap(), entries);
+        let blobs = entries.to_blobs(&blob_recycler);
+        assert_eq!(reconstruct_entries_from_blobs(blobs).unwrap(), entries);
     });
 }

--- a/src/replicate_stage.rs
+++ b/src/replicate_stage.rs
@@ -43,7 +43,7 @@ impl ReplicateStage {
 
         let res = bank.process_entries(entries.clone());
 
-        while let Some(blob) = blobs.pop_front() {
+        for blob in blobs {
             blob_recycler.recycle(blob);
         }
 

--- a/src/retransmit_stage.rs
+++ b/src/retransmit_stage.rs
@@ -32,7 +32,7 @@ fn retransmit(
             Crdt::retransmit(&crdt, b, sock)?;
         }
     }
-    while let Some(b) = dq.pop_front() {
+    for b in dq {
         recycler.recycle(b);
     }
     Ok(())

--- a/src/streamer.rs
+++ b/src/streamer.rs
@@ -64,8 +64,8 @@ pub fn receiver(
 
 fn recv_send(sock: &UdpSocket, recycler: &BlobRecycler, r: &BlobReceiver) -> Result<()> {
     let timer = Duration::new(1, 0);
-    let mut msgs = r.recv_timeout(timer)?;
-    Blob::send_to(recycler, sock, &mut msgs)?;
+    let msgs = r.recv_timeout(timer)?;
+    Blob::send_to(recycler, sock, msgs)?;
     Ok(())
 }
 
@@ -144,7 +144,6 @@ pub fn blob_receiver(
 #[cfg(test)]
 mod test {
     use packet::{Blob, BlobRecycler, Packet, PacketRecycler, Packets, PACKET_DATA_SIZE};
-    use std::collections::VecDeque;
     use std::io;
     use std::io::Write;
     use std::net::UdpSocket;
@@ -198,7 +197,7 @@ mod test {
                 resp_recycler.clone(),
                 r_responder,
             );
-            let mut msgs = VecDeque::new();
+            let mut msgs = Vec::new();
             for i in 0..10 {
                 let b = resp_recycler.allocate();
                 {
@@ -207,7 +206,7 @@ mod test {
                     w.meta.size = PACKET_DATA_SIZE;
                     w.meta.set_addr(&addr);
                 }
-                msgs.push_back(b);
+                msgs.push(b);
             }
             s_responder.send(msgs).expect("send");
             t_responder

--- a/src/tvu.rs
+++ b/src/tvu.rs
@@ -154,7 +154,6 @@ pub mod tests {
     use packet::BlobRecycler;
     use service::Service;
     use signature::{Keypair, KeypairUtil};
-    use std::collections::VecDeque;
     use std::net::UdpSocket;
     use std::sync::atomic::AtomicBool;
     use std::sync::mpsc::channel;
@@ -248,7 +247,7 @@ pub mod tests {
         );
 
         let mut alice_ref_balance = starting_balance;
-        let mut msgs = VecDeque::new();
+        let mut msgs = Vec::new();
         let mut cur_hash = Hash::default();
         let mut blob_id = 0;
         let num_transfers = 10;
@@ -287,7 +286,7 @@ pub mod tests {
                     w.set_size(serialized_entry.len());
                     w.meta.set_addr(&replicate_addr);
                 }
-                msgs.push_back(b);
+                msgs.push(b);
             }
         }
 

--- a/src/vote_stage.rs
+++ b/src/vote_stage.rs
@@ -12,7 +12,6 @@ use packet::{BlobRecycler, SharedBlob};
 use result::Result;
 use service::Service;
 use signature::Keypair;
-use std::collections::VecDeque;
 use std::result;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, RwLock};
@@ -136,7 +135,7 @@ pub fn send_leader_vote(
             if let Ok(shared_blob) =
                 create_new_signed_vote_blob(&last_id, keypair, crdt, blob_recycler)
             {
-                vote_blob_sender.send(VecDeque::from(vec![shared_blob]))?;
+                vote_blob_sender.send(vec![shared_blob])?;
                 let finality_ms = now - super_majority_timestamp;
 
                 *last_valid_validator_timestamp = super_majority_timestamp;
@@ -170,7 +169,7 @@ fn send_validator_vote(
     if let Ok(shared_blob) = create_new_signed_vote_blob(&last_id, keypair, crdt, blob_recycler) {
         inc_new_counter_info!("replicate-vote_sent", 1);
 
-        vote_blob_sender.send(VecDeque::from(vec![shared_blob]))?;
+        vote_blob_sender.send(vec![shared_blob])?;
     }
     Ok(())
 }
@@ -388,7 +387,7 @@ pub mod tests {
         assert!(vote_blob.is_ok());
 
         // vote should be valid
-        let blob = vote_blob.unwrap().pop_front().unwrap();
+        let blob = &vote_blob.unwrap()[0];
         let tx = deserialize(&(blob.read().unwrap().data)).unwrap();
         assert!(bank.process_transaction(&tx).is_ok());
     }

--- a/src/window.rs
+++ b/src/window.rs
@@ -613,11 +613,7 @@ pub fn new_window_from_entries(
     blob_recycler: &BlobRecycler,
 ) -> SharedWindow {
     // convert to blobs
-    let mut blobs = Vec::new();
-    ledger_tail.to_blobs(&blob_recycler, &mut blobs);
-
-    // flatten deque to vec
-    let blobs: Vec<_> = blobs.into_iter().collect();
+    let blobs = ledger_tail.to_blobs(&blob_recycler);
     initialized_window(&node_info, blobs, entry_height)
 }
 

--- a/src/write_stage.rs
+++ b/src/write_stage.rs
@@ -12,7 +12,6 @@ use packet::BlobRecycler;
 use result::{Error, Result};
 use service::Service;
 use signature::Keypair;
-use std::collections::VecDeque;
 use std::net::UdpSocket;
 use std::sync::atomic::AtomicUsize;
 use std::sync::mpsc::{channel, Receiver, RecvTimeoutError};
@@ -55,7 +54,7 @@ impl WriteStage {
         //on a valid last id
 
         trace!("New blobs? {}", entries.len());
-        let mut blobs = VecDeque::new();
+        let mut blobs = Vec::new();
         entries.to_blobs(blob_recycler, &mut blobs);
 
         if !blobs.is_empty() {

--- a/src/write_stage.rs
+++ b/src/write_stage.rs
@@ -54,8 +54,7 @@ impl WriteStage {
         //on a valid last id
 
         trace!("New blobs? {}", entries.len());
-        let mut blobs = Vec::new();
-        entries.to_blobs(blob_recycler, &mut blobs);
+        let blobs = entries.to_blobs(blob_recycler);
 
         if !blobs.is_empty() {
             inc_new_counter_info!("write_stage-recv_vote", votes.len());


### PR DESCRIPTION
Vec has a simpler implementation and is generally simpler to use than VecDeque. Use VecDeque when you need efficient insert and remove from the front, otherwise Vec. In this PR, we see that all uses of `pop_front()` could be comfortably replaced with a simple loop over the vector, and that therefore moving to Vec makes the codebase simpler across the board.

Fixes #572