### PR TITLE
Buffer tokens when switching directions to prevent errors

### DIFF
--- a/src/drone.rs
+++ b/src/drone.rs
@@ -16,7 +16,7 @@ use thin_client::ThinClient;
 use transaction::Transaction;
 
 pub const TIME_SLICE: u64 = 60;
-pub const REQUEST_CAP: u64 = 10_000_000;
+pub const REQUEST_CAP: u64 = 500_000_000;
 pub const DRONE_PORT: u16 = 9900;
 
 #[derive(Serialize, Deserialize, Debug, Clone, Copy)]


### PR DESCRIPTION
Even if transactions are dropped, accounts will have buffer
of tokens. Should reduce or eliminate AccountNotFound errors seen in the leader while bench-tps is running.