### PR TITLE
use USER instead of whoami

### DIFF
--- a/net/gce.sh
+++ b/net/gce.sh
@@ -6,7 +6,7 @@ source "$here"/../scripts/gcloud.sh
 # shellcheck source=net/common.sh
 source "$here"/common.sh
 
-prefix=testnet-dev-$(whoami | sed -e s/[^a-z0-9].*//)
+prefix=testnet-dev-${USER//[^A-Za-z0-9]/}
 validatorNodeCount=5
 clientNodeCount=1
 leaderMachineType=n1-standard-16
@@ -36,8 +36,8 @@ Configure a GCE-based testnet
  delete - delete the testnet
 
  common options:
-   -p prefix        - Optional common prefix for instance names to avoid collisions
-                      (default: $prefix)
+   -p prefix        - Optional common prefix for instance names to avoid
+                        collisions (default: $prefix)
 
  create-specific options:
    -n number        - Number of validator nodes (default: $validatorNodeCount)
@@ -69,6 +69,7 @@ while getopts "h?p:Pi:n:c:z:g" opt; do
     usage
     ;;
   p)
+    [[ ${OPTARG//[^A-Za-z0-9]/} == "$OPTARG" ]] || usage "Invalid prefix: \"$OPTARG\", alphanumeric only"
     prefix=$OPTARG
     ;;
   P)

--- a/scripts/gcloud.sh
+++ b/scripts/gcloud.sh
@@ -181,23 +181,26 @@ gcloud_FigureRemoteUsername() {
 
   echo "Detecting remote username using $zone in $zone:"
 
-
   # Figure the gcp ssh username
   (
     set -x
 
     # Try to ping the machine first.  There can be a delay between when the
     # instance is reported as RUNNING and when it's reachable over the network
-    timeout 30s bash -c "set -o pipefail; until ping -c 3 $publicIp | tr - _; do echo .; done"
+    timeout 30s bash -c "set -o pipefail; until ping -c 3 $publicIp | tr - _; do echo .; sleep 1; done"
 
-    gcloud compute ssh "$name" --zone "$zone" -- "echo whoami \$(whoami)" | tee whoami
+    gcloud compute ssh "$name" --zone "$zone" -- "echo whoami:\$USER:iamwho" | tr -d $'\r '| tee /tmp/whoami-$$
   )
+  while IFS=: read -r whoami gcloud_username iamwho ; do
+    [[ $whoami == "whoami" && $iamwho == "iamwho" ]] && break;
+  done < /tmp/whoami-$$
+  rm -f /tmp/whoami-$$
 
-  [[ "$(tr -dc '[:print:]' < whoami; rm -f whoami)" =~ ^whoami\ (.*)$ ]] || {
-    echo Unable to figure remote user name;
-    exit 1
-  }
-  gcloud_username="${BASH_REMATCH[1]}"
+  if [[ -z $gcloud_username ]]; then
+      echo Unable to figure remote user name
+      exit 1
+  fi
+
   echo "Remote username: $gcloud_username"
 }
 
@@ -288,4 +291,3 @@ gcloud_PrepInstancesForSsh() {
     fi
   done
 }
-

--- a/scripts/gcloud.sh
+++ b/scripts/gcloud.sh
@@ -202,7 +202,7 @@ gcloud_FigureRemoteUsername() {
 
     # Try to ping the machine first.  There can be a delay between when the
     # instance is reported as RUNNING and when it's reachable over the network
-    timeout 30s bash -c "set -o pipefail; until ping -c 3 $publicIp | tr - _; do echo .; sleep 1; done"
+    timeout 30s bash -c "set -o pipefail; until ping -c 3 $publicIp | tr - _; do echo .; done"
 
     gcloud compute ssh "$name" --zone "$zone" -- "echo whoami:\$USER:iamwho" | tr -d $'\r '| tee /tmp/whoami-$$
   )


### PR DESCRIPTION
make gcloud_FigureRemoteUsername robust against unsolicited output
   (that I get on login ;) )

validate --prefix argument