### PR TITLE
Refine docker image tagging to avoid breaking stabilization branches on updates

### DIFF
--- a/ci/buildkite.yml
+++ b/ci/buildkite.yml
@@ -1,5 +1,5 @@
 steps:
-  - command: "ci/docker-run.sh solanalabs/rust ci/test-stable.sh"
+  - command: "ci/docker-run.sh solanalabs/rust:1.28.0 ci/test-stable.sh"
     name: "stable [public]"
     env:
       CARGO_TARGET_CACHE_NAME: "stable"
@@ -12,7 +12,7 @@ steps:
   - command: "ci/shellcheck.sh"
     name: "shellcheck [public]"
     timeout_in_minutes: 20
-  - command: "ci/docker-run.sh solanalabs/rust-nightly ci/test-nightly.sh || true"
+  - command: "ci/docker-run.sh solanalabs/rust-nightly:2018-09-03 ci/test-nightly.sh || true"
     name: "nightly [public]"
     env:
       CARGO_TARGET_CACHE_NAME: "nightly"

--- a/ci/docker-rust-nightly/Dockerfile
+++ b/ci/docker-rust-nightly/Dockerfile
@@ -1,10 +1,10 @@
 FROM solanalabs/rust
-ARG nightly=nightly-2018-09-03
+ARG date
 
 RUN set -x && \
-    rustup install $nightly && \
-    rustup default $nightly && \
-    rustup component add clippy-preview --toolchain=$nightly && \
+    rustup install nightly-$date && \
+    rustup default nightly-$date && \
+    rustup component add clippy-preview --toolchain=nightly-$date && \
     rustc --version && \
     cargo --version && \
-    cargo +$nightly install cargo-cov
+    cargo +nightly-$date install cargo-cov

--- a/ci/docker-rust-nightly/README.md
+++ b/ci/docker-rust-nightly/README.md
@@ -12,15 +12,15 @@ to avoid the build breaking at unexpected times, as occasionally nightly will
 introduce breaking changes.
 
 To update the pinned version:
-1. Locally update the `ARG nightly=xyz` line in `ci/docker-rust-nightly/Dockerfile`
-1. Run `ci/docker-rust-nightly/build.sh` to rebuild the nightly image locally
-1. Run `SOLANA_DOCKER_RUN_NOSETUID=1 ci/docker-run.sh --nopull solanalabs/rust-nightly ci/test-nightly.sh` to
-   confirm the new nightly image builds.  Fix any issues as needed
+1. Run `ci/docker-rust-nightly/build.sh` to rebuild the nightly image locally,
+   or potentially `ci/docker-rust-nightly/build.sh YYYY-MM-DD` if there's a
+   specific YYYY-MM-DD that is desired (default is today's build).
+1. Run `SOLANA_DOCKER_RUN_NOSETUID=1 ci/docker-run.sh --nopull solanalabs/rust-nightly:YYYY-MM-DD ci/test-nightly.sh`
+   to confirm the new nightly image builds.  Fix any issues as needed
 1. Run `docker login` to enable pushing images to Docker Hub, if you're authorized.
-1. Run `CI=true ci/docker-rust-nightly/build.sh` to push the new nightly image to dockerhub.com.
-   **Note that all CI may be broken now until the next step is completed.**
-1. Merge the update to `ARG nightly=xyz` and any codebase adjustments needed.
-
+1. Run `CI=true ci/docker-rust-nightly/build.sh YYYY-MM-DD` to push the new nightly image to dockerhub.com.
+1. Modify the `solanalabs/rust-nightly:YYYY-MM-DD` reference in `ci/buildkite.yml` from the previous to
+   new *YYYY-MM-DD* value, send a PR with this change and any codebase adjustments needed.
 
 ## Troubleshooting
 

--- a/ci/docker-rust-nightly/build.sh
+++ b/ci/docker-rust-nightly/build.sh
@@ -2,11 +2,12 @@
 
 cd "$(dirname "$0")"
 
-docker build -t solanalabs/rust-nightly .
+nightlyDate=${1:-$(date +%Y-%m-%d)}
+docker build -t solanalabs/rust-nightly:"$nightlyDate" --build-arg date="$nightlyDate" .
 
 maybeEcho=
 if [[ -z $CI ]]; then
   echo "Not CI, skipping |docker push|"
   maybeEcho="echo"
 fi
-$maybeEcho docker push solanalabs/rust-nightly
+$maybeEcho docker push solanalabs/rust-nightly:"$nightlyDate"

--- a/ci/docker-rust/Dockerfile
+++ b/ci/docker-rust/Dockerfile
@@ -1,3 +1,5 @@
+# Note: when the rust version (1.28) is changed also modify
+# ci/buildkite.yml to pick up the new image tag
 FROM rust:1.28
 
 RUN set -x && \

--- a/ci/docker-rust/build.sh
+++ b/ci/docker-rust/build.sh
@@ -3,4 +3,9 @@
 cd "$(dirname "$0")"
 
 docker build -t solanalabs/rust .
+
+read -r rustc version _ < <(docker run solanalabs/rust rustc --version)
+[[ $rustc = rustc ]]
+docker tag solanalabs/rust:latest solanalabs/rust:"$version"
+
 docker push solanalabs/rust


### PR DESCRIPTION
Fixes #1136