### PR TITLE
improve localnet-sanity's robustness

### DIFF
--- a/ci/localnet-sanity.sh
+++ b/ci/localnet-sanity.sh
@@ -69,8 +69,8 @@ echo "--- Wallet sanity"
 
 echo "--- Node count"
 (
-  set -x
   source multinode-demo/common.sh
+  set -x
   client_id=/tmp/client-id.json-$$
   $solana_keygen -o $client_id
   $solana_bench_tps --identity $client_id --num-nodes 3 --converge-only
@@ -81,8 +81,8 @@ killBackgroundCommands
 
 echo "--- Ledger verification"
 (
-  set -x
   source multinode-demo/common.sh
+  set -x
   cp -R "$SOLANA_CONFIG_DIR"/ledger /tmp/ledger-$$
   $solana_ledger_tool --ledger /tmp/ledger-$$ verify
   rm -rf /tmp/ledger-$$

--- a/src/bin/bench-streamer.rs
+++ b/src/bin/bench-streamer.rs
@@ -2,7 +2,7 @@ extern crate clap;
 extern crate solana;
 
 use clap::{App, Arg};
-use solana::nat::bind_to;
+use solana::netutil::bind_to;
 use solana::packet::{Packet, PacketRecycler, BLOB_SIZE, PACKET_DATA_SIZE};
 use solana::result::Result;
 use solana::streamer::{receiver, PacketReceiver};
@@ -84,7 +84,7 @@ fn main() -> Result<()> {
     let mut read_channels = Vec::new();
     let mut read_threads = Vec::new();
     for _ in 0..num_sockets {
-        let read = bind_to(port);
+        let read = bind_to(port, false).unwrap();
         read.set_read_timeout(Some(Duration::new(1, 0))).unwrap();
 
         addr = read.local_addr().unwrap();

--- a/src/bin/bench-tps.rs
+++ b/src/bin/bench-tps.rs
@@ -18,7 +18,7 @@ use solana::logger;
 use solana::metrics;
 use solana::ncp::Ncp;
 use solana::service::Service;
-use solana::signature::{read_keypair, GenKeys, Keypair, KeypairUtil};
+use solana::signature::{read_keypair, GenKeys, Keypair, KeypairUtil, Pubkey};
 use solana::thin_client::{poll_gossip_for_leader, ThinClient};
 use solana::timing::{duration_as_ms, duration_as_s};
 use solana::transaction::Transaction;
@@ -506,16 +506,34 @@ fn main() {
 
     let exit_signal = Arc::new(AtomicBool::new(false));
     let mut c_threads = vec![];
-    let (validators, leader) = converge(&leader, &exit_signal, num_nodes, &mut c_threads);
+    let (nodes, leader) = converge(&leader, &exit_signal, num_nodes, &mut c_threads);
 
-    println!(" Node address         | Node identifier");
-    println!("----------------------+------------------");
-    for node in &validators {
-        println!(" {:20} | {}", node.contact_info.tpu.to_string(), node.id);
+    let leader_id = if let Some(leader) = &leader {
+        leader.id
+    } else {
+        Default::default()
+    };
+
+    fn print_gossip_info(nodes: &Vec<NodeInfo>, leader_id: &Pubkey) -> () {
+        println!(" Node gossip address | Node identifier");
+        println!("---------------------+------------------");
+        for node in nodes {
+            println!(
+                " {:20} | {}{}",
+                node.contact_info.ncp.to_string(),
+                node.id,
+                if node.id == *leader_id {
+                    " <==== leader"
+                } else {
+                    ""
+                }
+            );
+        }
+        println!("Nodes: {}", nodes.len());
     }
-    println!("Nodes: {}", validators.len());
+    print_gossip_info(&nodes, &leader_id);
 
-    if validators.len() < num_nodes {
+    if nodes.len() < num_nodes {
         println!(
             "Error: Insufficient nodes discovered.  Expecting {} or more",
             num_nodes
@@ -574,7 +592,7 @@ fn main() {
     let maxes = Arc::new(RwLock::new(Vec::new()));
     let sample_period = 1; // in seconds
     println!("Sampling TPS every {} second...", sample_period);
-    let v_threads: Vec<_> = validators
+    let v_threads: Vec<_> = nodes
         .into_iter()
         .map(|v| {
             let exit_signal = exit_signal.clone();
@@ -724,6 +742,7 @@ fn converge(
     //wait for the network to converge, 30 seconds should be plenty
     for _ in 0..30 {
         if spy_ref.read().unwrap().leader_data().is_none() {
+            sleep(Duration::new(1, 0));
             continue;
         }
 

--- a/src/bin/fullnode-config.rs
+++ b/src/bin/fullnode-config.rs
@@ -7,7 +7,7 @@ extern crate solana;
 use clap::{App, Arg};
 use solana::crdt::FULLNODE_PORT_RANGE;
 use solana::fullnode::Config;
-use solana::nat::{get_ip_addr, get_public_ip_addr, parse_port_or_addr};
+use solana::netutil::{get_ip_addr, get_public_ip_addr, parse_port_or_addr};
 use solana::signature::read_pkcs8;
 use std::io;
 use std::net::SocketAddr;

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,11 +1,11 @@
 use crdt::{NodeInfo, FULLNODE_PORT_RANGE};
-use nat::bind_in_range;
+use netutil::bind_in_range;
 use std::time::Duration;
 use thin_client::ThinClient;
 
 pub fn mk_client(r: &NodeInfo) -> ThinClient {
-    let requests_socket = bind_in_range(FULLNODE_PORT_RANGE).unwrap();
-    let transactions_socket = bind_in_range(FULLNODE_PORT_RANGE).unwrap();
+    let (_, requests_socket) = bind_in_range(FULLNODE_PORT_RANGE).unwrap();
+    let (_, transactions_socket) = bind_in_range(FULLNODE_PORT_RANGE).unwrap();
 
     requests_socket
         .set_read_timeout(Some(Duration::new(1, 0)))

--- a/src/drone.rs
+++ b/src/drone.rs
@@ -162,7 +162,7 @@ mod tests {
     use fullnode::Fullnode;
     use logger;
     use mint::Mint;
-    use nat::get_ip_addr;
+    use netutil::get_ip_addr;
     use service::Service;
     use signature::{Keypair, KeypairUtil};
     use std::fs::remove_dir_all;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,8 +30,8 @@ pub mod ledger;
 pub mod logger;
 pub mod metrics;
 pub mod mint;
-pub mod nat;
 pub mod ncp;
+pub mod netutil;
 pub mod packet;
 pub mod payment_plan;
 pub mod record_stage;
@@ -72,6 +72,7 @@ extern crate jsonrpc_http_server;
 extern crate log;
 extern crate nix;
 extern crate rayon;
+extern crate reqwest;
 extern crate ring;
 extern crate serde;
 #[macro_use]

--- a/src/thin_client.rs
+++ b/src/thin_client.rs
@@ -7,10 +7,12 @@ use bank::Account;
 use bincode::{deserialize, serialize};
 use crdt::{Crdt, CrdtError, NodeInfo};
 use hash::Hash;
+use log::Level;
 use ncp::Ncp;
 use request::{Request, Response};
 use result::{Error, Result};
 use signature::{Keypair, Pubkey, Signature};
+use std;
 use std::collections::HashMap;
 use std::io;
 use std::net::{SocketAddr, UdpSocket};
@@ -64,9 +66,17 @@ impl ThinClient {
     pub fn recv_response(&self) -> io::Result<Response> {
         let mut buf = vec![0u8; 1024];
         trace!("start recv_from");
-        let (len, from) = self.requests_socket.recv_from(&mut buf)?;
-        trace!("end recv_from got {} {}", len, from);
-        deserialize(&buf).or_else(|_| Err(io::Error::new(io::ErrorKind::Other, "deserialize")))
+        match self.requests_socket.recv_from(&mut buf) {
+            Ok((len, from)) => {
+                trace!("end recv_from got {} {}", len, from);
+                deserialize(&buf)
+                    .or_else(|_| Err(io::Error::new(io::ErrorKind::Other, "deserialize")))
+            }
+            Err(e) => {
+                trace!("end recv_from got {:?}", e);
+                Err(e)
+            }
+        }
     }
 
     pub fn process_response(&mut self, resp: &Response) {
@@ -358,29 +368,97 @@ impl Drop for ThinClient {
     }
 }
 
+fn trace_node_info(nodes: &Vec<NodeInfo>, leader_id: &Pubkey) -> () {
+    trace!(" NodeInfo.contact_info     | Node identifier");
+    trace!("---------------------------+------------------");
+    for node in nodes {
+        trace!(
+            " ncp: {:20} | {}{}",
+            node.contact_info.ncp.to_string(),
+            node.id,
+            if node.id == *leader_id {
+                " <==== leader"
+            } else {
+                ""
+            }
+        );
+        trace!(" rpu: {:20} | ", node.contact_info.rpu.to_string(),);
+        trace!(" tpu: {:20} | ", node.contact_info.tpu.to_string(),);
+    }
+    trace!("Nodes: {}", nodes.len());
+}
+
 pub fn poll_gossip_for_leader(leader_ncp: SocketAddr, timeout: Option<u64>) -> Result<NodeInfo> {
     let exit = Arc::new(AtomicBool::new(false));
-    trace!("polling {:?} for leader", leader_ncp);
     let (node, gossip_socket) = Crdt::spy_node();
+    let my_addr = gossip_socket.local_addr().unwrap();
     let crdt = Arc::new(RwLock::new(Crdt::new(node).expect("Crdt::new")));
     let window = Arc::new(RwLock::new(vec![]));
     let ncp = Ncp::new(&crdt.clone(), window, None, gossip_socket, exit.clone());
+
     let leader_entry_point = NodeInfo::new_entry_point(&leader_ncp);
     crdt.write().unwrap().insert(&leader_entry_point);
 
     sleep(Duration::from_millis(100));
 
+    let deadline = match timeout {
+        Some(timeout) => Duration::new(timeout, 0),
+        None => Duration::new(std::u64::MAX, 0),
+    };
     let now = Instant::now();
     // Block until leader's correct contact info is received
-    while crdt.read().unwrap().leader_data().is_none() {
-        if timeout.is_some() && now.elapsed() > Duration::new(timeout.unwrap(), 0) {
+    let leader;
+
+    loop {
+        trace!("polling {:?} for leader from {:?}", leader_ncp, my_addr);
+
+        if let Some(l) = crdt.read().unwrap().leader_data() {
+            leader = Some(l.clone());
+            break;
+        }
+
+        if log_enabled!(Level::Trace) {
+            // print validators/fullnodes
+            let nodes: Vec<NodeInfo> = crdt
+                .read()
+                .unwrap()
+                .table
+                .values()
+                .filter(|x| Crdt::is_valid_address(&x.contact_info.rpu))
+                .cloned()
+                .collect();
+            trace_node_info(&nodes, &Default::default());
+        }
+
+        if now.elapsed() > deadline {
             return Err(Error::CrdtError(CrdtError::NoLeader));
         }
+
+        sleep(Duration::from_millis(100));
     }
 
     ncp.close()?;
-    let leader = crdt.read().unwrap().leader_data().unwrap().clone();
-    Ok(leader)
+
+    if log_enabled!(Level::Trace) {
+        let leader_id = if let Some(leader) = &leader {
+            leader.id
+        } else {
+            Default::default()
+        };
+
+        // print validators/fullnodes
+        let nodes: Vec<NodeInfo> = crdt
+            .read()
+            .unwrap()
+            .table
+            .values()
+            .filter(|x| Crdt::is_valid_address(&x.contact_info.rpu))
+            .cloned()
+            .collect();
+        trace_node_info(&nodes, &leader_id);
+    }
+
+    Ok(leader.unwrap().clone())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
* fix poll_gossip_for_leader() loop to actually wait
         for 30 seconds
    * reduce reuseaddr use to only when necessary,
         try to avoid already bound sockets
    * move nat.rs to netutil.rs
    * add gossip tracing to thin_client and bench-tps