### PR TITLE
Move vote into ReplicateStage after process_entries

### DIFF
--- a/src/tvu.rs
+++ b/src/tvu.rs
@@ -108,7 +108,6 @@ impl Tvu {
             blob_recycler,
             blob_window_receiver,
             ledger_path,
-            exit,
         );
 
         Tvu {

--- a/src/vote_stage.rs
+++ b/src/vote_stage.rs
@@ -155,7 +155,7 @@ pub fn send_leader_vote(
     Ok(())
 }
 
-fn send_validator_vote(
+pub fn send_validator_vote(
     bank: &Arc<Bank>,
     keypair: &Arc<Keypair>,
     crdt: &Arc<RwLock<Crdt>>,


### PR DESCRIPTION
This does not implement the 1sec sleep on validator votes from `VoteStage::run`
I played around with a couple different methods, but didn't want to delay this PR any more.

Fixes #1129