### PR TITLE
Add sleep to prevent spinning thread in JsonRpcService

### DIFF
--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -58,6 +58,7 @@ impl JsonRpcService {
                         server.unwrap().close();
                         break;
                     }
+                    sleep(Duration::from_millis(100));
                 }
                 ()
             })


### PR DESCRIPTION
Fixes #1172 