### PR TITLE
bench-tps/net sanity: add ability to check for unexpected extra nodes

### DIFF
--- a/ci/localnet-sanity.sh
+++ b/ci/localnet-sanity.sh
@@ -73,7 +73,7 @@ echo "--- Node count"
   set -x
   client_id=/tmp/client-id.json-$$
   $solana_keygen -o $client_id
-  $solana_bench_tps --identity $client_id --num-nodes 3 --converge-only
+  $solana_bench_tps --identity $client_id --num-nodes 3 --reject-extra-nodes --converge-only
   rm -rf $client_id
 ) || flag_error
 

--- a/ci/testnet-deploy.sh
+++ b/ci/testnet-deploy.sh
@@ -108,6 +108,11 @@ time net/gce.sh create "${gce_create_args[@]}"
 net/init-metrics.sh -e
 
 echo --- net.sh start
-time net/net.sh start -s "$snapChannel"
+maybeRejectExtraNodes=
+if ! $publicNetwork; then
+  maybeRejectExtraNodes="-o rejectExtraNodes"
+fi
+# shellcheck disable=SC2086 # Don't want to double quote maybeRejectExtraNodes
+time net/net.sh start -s "$snapChannel" $maybeRejectExtraNodes
 
 exit 0

--- a/ci/testnet-sanity.sh
+++ b/ci/testnet-sanity.sh
@@ -32,5 +32,6 @@ echo --- net.sh sanity
 net/net.sh sanity \
   ${NO_LEDGER_VERIFY:+-o noLedgerVerify} \
   ${NO_VALIDATOR_SANITY:+-o noValidatorSanity} \
+  ${REJECT_EXTRA_NODES:+-o rejectExtraNodes} \
 
 exit 0

--- a/net/net.sh
+++ b/net/net.sh
@@ -34,6 +34,7 @@ Operate a configured testnet
  sanity/start-specific options:
    -o noLedgerVerify    - Skip ledger verification
    -o noValidatorSanity - Skip validator sanity
+   -o rejectExtraNodes  - Require the exact number of nodes
 
  stop-specific options:
    none
@@ -78,7 +79,7 @@ while getopts "h?S:s:o:f:" opt; do
     ;;
   o)
     case $OPTARG in
-    noLedgerVerify|noValidatorSanity)
+    noLedgerVerify|noValidatorSanity|rejectExtraNodes)
       sanityExtraArgs="$sanityExtraArgs -o $OPTARG"
       ;;
     *)

--- a/net/remote/remote-sanity.sh
+++ b/net/remote/remote-sanity.sh
@@ -27,6 +27,7 @@ missing() {
 
 ledgerVerify=true
 validatorSanity=true
+rejectExtraNodes=false
 while [[ $1 = -o ]]; do
   opt="$2"
   shift 2
@@ -36,6 +37,9 @@ while [[ $1 = -o ]]; do
     ;;
   noValidatorSanity)
     validatorSanity=false
+    ;;
+  rejectExtraNodes)
+    rejectExtraNodes=true
     ;;
   *)
     echo "Error: unknown option: $opt"
@@ -89,7 +93,18 @@ echo "+++ $entrypointIp: node count ($numNodes expected)"
 (
   set -x
   $solana_keygen -o "$client_id"
-  $solana_bench_tps --network "$entrypointIp:8001" --identity "$client_id" --num-nodes "$numNodes" --converge-only
+
+  maybeRejectExtraNodes=
+  if $rejectExtraNodes; then
+    maybeRejectExtraNodes="--reject-extra-nodes"
+  fi
+
+  $solana_bench_tps \
+    --network "$entrypointIp:8001" \
+    --identity "$client_id" \
+    --num-nodes "$numNodes" \
+    $maybeRejectExtraNodes \
+    --converge-only
 )
 
 echo "--- $entrypointIp: verify ledger"

--- a/src/bin/bench-tps.rs
+++ b/src/bin/bench-tps.rs
@@ -432,6 +432,11 @@ fn main() {
                 .help("wait for NUM nodes to converge"),
         )
         .arg(
+            Arg::with_name("reject-extra-nodes")
+                .long("reject-extra-nodes")
+                .help("require exactly num-nodes on convergence.  Appropriate only for internal networks"),
+        )
+        .arg(
             Arg::with_name("threads")
                 .short("t")
                 .long("threads")
@@ -517,6 +522,16 @@ fn main() {
         );
         exit(1);
     }
+    if matches.is_present("reject-extra-nodes") {
+        if nodes.len() > num_nodes {
+            println!(
+                "Error: Extra nodes discovered.  Expecting exactly {}",
+                num_nodes
+            );
+            exit(1);
+        }
+    }
+
     if leader.is_none() {
         println!("no leader");
         exit(1);


### PR DESCRIPTION
Fixes #712

Or rather, if this doesn't fix #712 then it'll turn the testnet red and we'll know.  