### PR TITLE
Wallet CLI: add handling to separately compile and transfer raw userdata

### DIFF
--- a/src/bin/wallet.rs
+++ b/src/bin/wallet.rs
@@ -116,7 +116,7 @@ fn main() -> Result<(), Box<error::Error>> {
                         .help("The pubkey of recipient"),
                 )
                 .arg(
-                    Arg::with_name("build_only")
+                    Arg::with_name("build-only")
                         .long("build")
                         .takes_value(false)
                         .group("build")
@@ -147,21 +147,21 @@ fn main() -> Result<(), Box<error::Error>> {
             SubCommand::with_name("transfer")
                 .about("Transfer raw transaction from file or stdin")
                 .arg(
-                    Arg::with_name("userdata_path")
+                    Arg::with_name("userdata-path")
                         .short("f")
                         .long("file")
                         .value_name("PATH")
                         .help("/path/to/userdata.bin"),
                 )
                 .arg(
-                    Arg::with_name("serial_userdata")
+                    Arg::with_name("serial-userdata")
                         .index(1)
                         .value_name("ARRAY of [BYTES]"),
                 )
                 .group(
                     ArgGroup::with_name("userdata")
                         .required(true)
-                        .args(&["userdata_path", "serial_userdata"]),
+                        .args(&["userdata-path", "serial-userdata"]),
                 ),
         )
         .subcommand(SubCommand::with_name("balance").about("Get your balance"))

--- a/src/bin/wallet.rs
+++ b/src/bin/wallet.rs
@@ -114,6 +114,22 @@ fn main() -> Result<(), Box<error::Error>> {
                         .value_name("PUBKEY")
                         .takes_value(true)
                         .help("The pubkey of recipient"),
+                )
+                .arg(
+                    Arg::with_name("build_only")
+                        .long("build")
+                        .takes_value(false)
+                        .group("build")
+                        .help("Build transaction userdata without submitting it"),
+                )
+                .arg(
+                    Arg::with_name("outfile")
+                        .short("o")
+                        .long("outfile")
+                        .value_name("PATH")
+                        .takes_value(true)
+                        .help("path to generated file")
+                        .requires("build"),
                 ),
         )
         .subcommand(

--- a/src/bin/wallet.rs
+++ b/src/bin/wallet.rs
@@ -3,7 +3,7 @@ extern crate clap;
 extern crate dirs;
 extern crate solana;
 
-use clap::{App, Arg, ArgMatches, SubCommand};
+use clap::{App, Arg, ArgGroup, ArgMatches, SubCommand};
 use solana::client::mk_client;
 use solana::crdt::NodeInfo;
 use solana::drone::DRONE_PORT;
@@ -125,6 +125,27 @@ fn main() -> Result<(), Box<error::Error>> {
                         .value_name("SIGNATURE")
                         .required(true)
                         .help("The transaction signature to confirm"),
+                ),
+        )
+        .subcommand(
+            SubCommand::with_name("transfer")
+                .about("Transfer raw transaction from file or stdin")
+                .arg(
+                    Arg::with_name("userdata_path")
+                        .short("f")
+                        .long("file")
+                        .value_name("PATH")
+                        .help("/path/to/userdata.bin"),
+                )
+                .arg(
+                    Arg::with_name("serial_userdata")
+                        .index(1)
+                        .value_name("ARRAY of [BYTES]"),
+                )
+                .group(
+                    ArgGroup::with_name("userdata")
+                        .required(true)
+                        .args(&["userdata_path", "serial_userdata"]),
                 ),
         )
         .subcommand(SubCommand::with_name("balance").about("Get your balance"))

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -107,7 +107,7 @@ impl Transaction {
     /// * `userdata` - The input data that the contract will execute with
     /// * `last_id` - The PoH hash.
     /// * `fee` - The transaction fee.
-    fn new_with_userdata(
+    pub fn new_with_userdata(
         from_keypair: &Keypair,
         transaction_keys: &[Pubkey],
         userdata: Vec<u8>,

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -97,7 +97,7 @@ pub fn parse_command(
 
             let tokens = pay_matches.value_of("tokens").unwrap().parse()?;
 
-            if pay_matches.is_present("build_only") {
+            if pay_matches.is_present("build-only") {
                 let outfile = if pay_matches.is_present("outfile") {
                     Some(pay_matches.value_of("outfile").unwrap().to_string())
                 } else {
@@ -125,17 +125,8 @@ pub fn parse_command(
         ("balance", Some(_balance_matches)) => Ok(WalletCommand::Balance),
         ("address", Some(_address_matches)) => Ok(WalletCommand::Address),
         ("transfer", Some(userdata_matches)) => {
-            let userdata: Vec<u8> = if userdata_matches.is_present("serial_userdata") {
-                serde_json::from_str(userdata_matches.value_of("serial_userdata").unwrap())
-                    .or_else(|err| {
-                        Err(WalletError::BadParameter(format!(
-                            "{}: Unable to read userdata serialization: {}",
-                            err,
-                            userdata_matches.value_of("serial_userdata").unwrap()
-                        )))
-                    })?
-            } else {
-                let userdata_path = userdata_matches.value_of("userdata_path").unwrap();
+            let userdata: Vec<u8> = if userdata_matches.is_present("userdata-path") {
+                let userdata_path = userdata_matches.value_of("userdata-path").unwrap();
                 let mut file = File::open(userdata_path).or_else(|err| {
                     Err(WalletError::BadParameter(format!(
                         "{}: Unable to open userdata file: {}",
@@ -145,6 +136,15 @@ pub fn parse_command(
                 let mut buf = vec![0u8; 60];
                 file.read(&mut buf)?;
                 buf
+            } else {
+                serde_json::from_str(userdata_matches.value_of("serial-userdata").unwrap())
+                    .or_else(|err| {
+                        Err(WalletError::BadParameter(format!(
+                            "{}: Unable to read userdata serialization: {}",
+                            err,
+                            userdata_matches.value_of("serial-userdata").unwrap()
+                        )))
+                    })?
             };
             Ok(WalletCommand::TransferRaw(userdata))
         }

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -133,9 +133,10 @@ pub fn parse_command(
                         err, userdata_path
                     )))
                 })?;
-                let mut buf = vec![0u8; 60];
-                file.read(&mut buf)?;
-                buf
+                // let mut buf = vec![0u8; 60];
+                // file.read(&mut buf)?;
+                // buf
+                serde_json::from_reader(file)?
             } else {
                 serde_json::from_str(userdata_matches.value_of("serial-userdata").unwrap())
                     .or_else(|err| {
@@ -224,7 +225,7 @@ pub fn process_command(
                         fs::create_dir_all(outdir)?;
                     }
                     let mut f = File::create(path)?;
-                    f.write_all(&transaction.userdata)?;
+                    serde_json::to_writer(f, &transaction.userdata)?;
                 }
                 None => println!("{:?}", transaction.userdata),
             }


### PR DESCRIPTION
This is a starting point for a Budget compiler.
At present, compile is implemented as a "build" argument on the `pay` subcommand, which either outputs a binary file or prints to terminal. It should be generalized and implemented for other Budget-driven subcommands as they are added.
Transfer is a new subcommand that takes either a binary file or a command-line string as input to sign and send a transaction.

Both of these functionalities will require updating as the Budget DSL and Contract engine develop. See: #1189 , #1193 

Closes #1184 