### PR TITLE
Rewrote service trait join() method to allow custom join values

### DIFF
--- a/src/banking_stage.rs
+++ b/src/banking_stage.rs
@@ -136,9 +136,7 @@ impl BankingStage {
 }
 
 impl Service for BankingStage {
-    fn thread_hdls(self) -> Vec<JoinHandle<()>> {
-        vec![self.thread_hdl]
-    }
+    type JoinReturnType = ();
 
     fn join(self) -> thread::Result<()> {
         self.thread_hdl.join()

--- a/src/blob_fetch_stage.rs
+++ b/src/blob_fetch_stage.rs
@@ -44,12 +44,10 @@ impl BlobFetchStage {
 }
 
 impl Service for BlobFetchStage {
-    fn thread_hdls(self) -> Vec<JoinHandle<()>> {
-        self.thread_hdls
-    }
+    type JoinReturnType = ();
 
     fn join(self) -> thread::Result<()> {
-        for thread_hdl in self.thread_hdls() {
+        for thread_hdl in self.thread_hdls {
             thread_hdl.join()?;
         }
         Ok(())

--- a/src/broadcast_stage.rs
+++ b/src/broadcast_stage.rs
@@ -191,9 +191,7 @@ impl BroadcastStage {
 }
 
 impl Service for BroadcastStage {
-    fn thread_hdls(self) -> Vec<JoinHandle<()>> {
-        vec![self.thread_hdl]
-    }
+    type JoinReturnType = ();
 
     fn join(self) -> thread::Result<()> {
         self.thread_hdl.join()

--- a/src/fetch_stage.rs
+++ b/src/fetch_stage.rs
@@ -45,12 +45,10 @@ impl FetchStage {
 }
 
 impl Service for FetchStage {
-    fn thread_hdls(self) -> Vec<JoinHandle<()>> {
-        self.thread_hdls
-    }
+    type JoinReturnType = ();
 
     fn join(self) -> thread::Result<()> {
-        for thread_hdl in self.thread_hdls() {
+        for thread_hdl in self.thread_hdls {
             thread_hdl.join()?;
         }
         Ok(())

--- a/src/ncp.rs
+++ b/src/ncp.rs
@@ -66,12 +66,10 @@ impl Ncp {
 }
 
 impl Service for Ncp {
-    fn thread_hdls(self) -> Vec<JoinHandle<()>> {
-        self.thread_hdls
-    }
+    type JoinReturnType = ();
 
     fn join(self) -> thread::Result<()> {
-        for thread_hdl in self.thread_hdls() {
+        for thread_hdl in self.thread_hdls {
             thread_hdl.join()?;
         }
         Ok(())

--- a/src/record_stage.rs
+++ b/src/record_stage.rs
@@ -127,9 +127,7 @@ impl RecordStage {
 }
 
 impl Service for RecordStage {
-    fn thread_hdls(self) -> Vec<JoinHandle<()>> {
-        vec![self.thread_hdl]
-    }
+    type JoinReturnType = ();
 
     fn join(self) -> thread::Result<()> {
         self.thread_hdl.join()

--- a/src/request_stage.rs
+++ b/src/request_stage.rs
@@ -116,9 +116,7 @@ impl RequestStage {
 }
 
 impl Service for RequestStage {
-    fn thread_hdls(self) -> Vec<JoinHandle<()>> {
-        vec![self.thread_hdl]
-    }
+    type JoinReturnType = ();
 
     fn join(self) -> thread::Result<()> {
         self.thread_hdl.join()

--- a/src/retransmit_stage.rs
+++ b/src/retransmit_stage.rs
@@ -113,12 +113,10 @@ impl RetransmitStage {
 }
 
 impl Service for RetransmitStage {
-    fn thread_hdls(self) -> Vec<JoinHandle<()>> {
-        self.thread_hdls
-    }
+    type JoinReturnType = ();
 
     fn join(self) -> thread::Result<()> {
-        for thread_hdl in self.thread_hdls() {
+        for thread_hdl in self.thread_hdls {
             thread_hdl.join()?;
         }
         Ok(())

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -68,9 +68,7 @@ impl JsonRpcService {
 }
 
 impl Service for JsonRpcService {
-    fn thread_hdls(self) -> Vec<JoinHandle<()>> {
-        vec![self.thread_hdl]
-    }
+    type JoinReturnType = ();
 
     fn join(self) -> thread::Result<()> {
         self.thread_hdl.join()

--- a/src/service.rs
+++ b/src/service.rs
@@ -1,6 +1,7 @@
-use std::thread::{JoinHandle, Result};
+use std::thread::Result;
 
 pub trait Service {
-    fn thread_hdls(self) -> Vec<JoinHandle<()>>;
-    fn join(self) -> Result<()>;
+    type JoinReturnType;
+
+    fn join(self) -> Result<Self::JoinReturnType>;
 }

--- a/src/sigverify_stage.rs
+++ b/src/sigverify_stage.rs
@@ -126,12 +126,10 @@ impl SigVerifyStage {
 }
 
 impl Service for SigVerifyStage {
-    fn thread_hdls(self) -> Vec<JoinHandle<()>> {
-        self.thread_hdls
-    }
+    type JoinReturnType = ();
 
     fn join(self) -> thread::Result<()> {
-        for thread_hdl in self.thread_hdls() {
+        for thread_hdl in self.thread_hdls {
             thread_hdl.join()?;
         }
         Ok(())

--- a/src/tpu.rs
+++ b/src/tpu.rs
@@ -37,7 +37,7 @@ use sigverify_stage::SigVerifyStage;
 use std::net::UdpSocket;
 use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, RwLock};
-use std::thread::{self, JoinHandle};
+use std::thread;
 use std::time::Duration;
 use streamer::BlobReceiver;
 use write_stage::WriteStage;
@@ -106,20 +106,15 @@ impl Tpu {
 }
 
 impl Service for Tpu {
-    fn thread_hdls(self) -> Vec<JoinHandle<()>> {
-        let mut thread_hdls = vec![];
-        thread_hdls.extend(self.fetch_stage.thread_hdls().into_iter());
-        thread_hdls.extend(self.sigverify_stage.thread_hdls().into_iter());
-        thread_hdls.extend(self.banking_stage.thread_hdls().into_iter());
-        thread_hdls.extend(self.record_stage.thread_hdls().into_iter());
-        thread_hdls.extend(self.write_stage.thread_hdls().into_iter());
-        thread_hdls
-    }
+    type JoinReturnType = ();
 
     fn join(self) -> thread::Result<()> {
-        for thread_hdl in self.thread_hdls() {
-            thread_hdl.join()?;
-        }
+        self.fetch_stage.join()?;
+        self.sigverify_stage.join()?;
+        self.banking_stage.join()?;
+        self.record_stage.join()?;
+        self.write_stage.join()?;
+
         Ok(())
     }
 }

--- a/src/tvu.rs
+++ b/src/tvu.rs
@@ -47,7 +47,7 @@ use signature::Keypair;
 use std::net::UdpSocket;
 use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, RwLock};
-use std::thread::{self, JoinHandle};
+use std::thread;
 use window::SharedWindow;
 
 pub struct Tvu {
@@ -125,18 +125,13 @@ impl Tvu {
 }
 
 impl Service for Tvu {
-    fn thread_hdls(self) -> Vec<JoinHandle<()>> {
-        let mut thread_hdls = vec![];
-        thread_hdls.extend(self.replicate_stage.thread_hdls().into_iter());
-        thread_hdls.extend(self.fetch_stage.thread_hdls().into_iter());
-        thread_hdls.extend(self.retransmit_stage.thread_hdls().into_iter());
-        thread_hdls
-    }
+    type JoinReturnType = ();
 
     fn join(self) -> thread::Result<()> {
-        for thread_hdl in self.thread_hdls() {
-            thread_hdl.join()?;
-        }
+        self.replicate_stage.join()?;
+        self.fetch_stage.join()?;
+        self.retransmit_stage.join()?;
+
         Ok(())
     }
 }

--- a/src/vote_stage.rs
+++ b/src/vote_stage.rs
@@ -213,9 +213,7 @@ impl VoteStage {
 }
 
 impl Service for VoteStage {
-    fn thread_hdls(self) -> Vec<JoinHandle<()>> {
-        vec![self.thread_hdl]
-    }
+    type JoinReturnType = ();
 
     fn join(self) -> thread::Result<()> {
         self.thread_hdl.join()?;

--- a/src/write_stage.rs
+++ b/src/write_stage.rs
@@ -135,11 +135,10 @@ impl WriteStage {
 }
 
 impl Service for WriteStage {
-    fn thread_hdls(self) -> Vec<JoinHandle<()>> {
-        self.thread_hdls
-    }
+    type JoinReturnType = ();
+
     fn join(self) -> thread::Result<()> {
-        for thread_hdl in self.thread_hdls() {
+        for thread_hdl in self.thread_hdls {
             thread_hdl.join()?;
         }
         Ok(())


### PR DESCRIPTION
Right now the Service trait enforces through its JoinHandles method that all threads must return unit. This makes it hard to propagate messages from individual services, for instance, communicating from the writestage or broadcast stage that they closed down due leader rotation. 