### PR TITLE
Tweak GCE scripts for higher node count

### DIFF
--- a/net/net.sh
+++ b/net/net.sh
@@ -254,8 +254,10 @@ start() {
 
   SECONDS=0
   pids=()
+  loopCount=0
   for ipAddress in "${validatorIpList[@]}"; do
     startValidator "$ipAddress"
+    ((loopCount++ % 2 == 0)) && sleep 2
   done
 
   for pid in "${pids[@]}"; do

--- a/net/net.sh
+++ b/net/net.sh
@@ -257,6 +257,10 @@ start() {
   loopCount=0
   for ipAddress in "${validatorIpList[@]}"; do
     startValidator "$ipAddress"
+
+    # Staggering validator startup time. If too many validators
+    # bootup simultaneously, leader node gets more rsync requests
+    # from the validators than it can handle.
     ((loopCount++ % 2 == 0)) && sleep 2
   done
 


### PR DESCRIPTION
- Some validators were unable to rsync config from leader when
  the node count was high (e.g. 25). Looks like the leader node was
  getting more rsync requests in parallel than it count handle.
- This change staggers the validators bootup, and rsync time