### PR TITLE
solana-keygen: Mark --outfile parameter as required

### DIFF
--- a/src/bin/keygen.rs
+++ b/src/bin/keygen.rs
@@ -21,6 +21,7 @@ fn main() -> Result<(), Box<error::Error>> {
                 .long("outfile")
                 .value_name("PATH")
                 .takes_value(true)
+                .required(true)
                 .help("path to generated file"),
         ).get_matches();
 


### PR DESCRIPTION
As a result, 
```bash
$ solana-keygen
```
now produces a helpful message instead of silently doing nothing