### PR TITLE
budget_contract: Remove Signature from ApplySignature

### DIFF
--- a/src/entry.rs
+++ b/src/entry.rs
@@ -256,13 +256,8 @@ mod tests {
             Utc::now(),
             zero,
         );
-        let tx1 = Transaction::budget_new_signature(
-            &keypair,
-            keypair.pubkey(),
-            keypair.pubkey(),
-            Default::default(),
-            zero,
-        );
+        let tx1 =
+            Transaction::budget_new_signature(&keypair, keypair.pubkey(), keypair.pubkey(), zero);
         let mut e0 = Entry::new(&zero, 0, vec![tx0.clone(), tx1.clone()], false);
         assert!(e0.verify(&zero));
 

--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -2,7 +2,6 @@ use budget::Budget;
 use chrono::prelude::{DateTime, Utc};
 use payment_plan::{Payment, PaymentPlan, Witness};
 use signature::Pubkey;
-use signature::Signature;
 
 /// The type of payment plan. Each item must implement the PaymentPlan trait.
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
@@ -61,7 +60,7 @@ pub enum Instruction {
 
     /// Tell the payment plan that the `NewContract` with `Signature` has been
     /// signed by the containing transaction's `Pubkey`.
-    ApplySignature(Signature),
+    ApplySignature,
 
     /// Vote for a PoH that is equal to the lastid of this transaction
     NewVote(Vote),

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -127,10 +127,9 @@ impl Transaction {
         from_keypair: &Keypair,
         contract: Pubkey,
         to: Pubkey,
-        signature: Signature,
         last_id: Hash,
     ) -> Self {
-        let instruction = Instruction::ApplySignature(signature);
+        let instruction = Instruction::ApplySignature;
         let userdata = serialize(&instruction).unwrap();
         Self::new_with_userdata(
             from_keypair,


### PR DESCRIPTION
It's vestigial now that each budget contract has its own distinct state