### PR TITLE
WIP: Migrate BankingStage to a scoped thread

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,7 @@ byteorder = "1.2.1"
 bytes = "0.4"
 chrono = { version = "0.4.0", features = ["serde"] }
 clap = "2.31"
+crossbeam-utils = "0.5"
 dirs = "1.0.2"
 env_logger = "0.5.12"
 generic-array = { version = "0.12.0", default-features = false, features = ["serde"] }

--- a/src/fullnode.rs
+++ b/src/fullnode.rs
@@ -22,18 +22,18 @@ use tvu::Tvu;
 use untrusted::Input;
 use window;
 
-pub enum NodeRole {
-    Leader(LeaderServices),
+pub enum NodeRole<'a> {
+    Leader(LeaderServices<'a>),
     Validator(ValidatorServices),
 }
 
-pub struct LeaderServices {
-    tpu: Tpu,
+pub struct LeaderServices<'a> {
+    tpu: Tpu<'a>,
     broadcast_stage: BroadcastStage,
 }
 
-impl LeaderServices {
-    fn new(tpu: Tpu, broadcast_stage: BroadcastStage) -> Self {
+impl<'a> LeaderServices<'a> {
+    fn new(tpu: Tpu<'a>, broadcast_stage: BroadcastStage) -> Self {
         LeaderServices {
             tpu,
             broadcast_stage,
@@ -72,8 +72,8 @@ pub enum FullnodeReturnType {
     LeaderRotation,
 }
 
-pub struct Fullnode {
-    pub node_role: Option<NodeRole>,
+pub struct Fullnode<'a> {
+    pub node_role: Option<NodeRole<'a>>,
     keypair: Arc<Keypair>,
     exit: Arc<AtomicBool>,
     rpu: Option<Rpu>,
@@ -116,7 +116,7 @@ impl Config {
     }
 }
 
-impl Fullnode {
+impl<'a> Fullnode<'a> {
     pub fn new(
         node: Node,
         ledger_path: &str,
@@ -493,7 +493,7 @@ impl Fullnode {
     }
 }
 
-impl Service for Fullnode {
+impl<'a> Service for Fullnode<'a> {
     type JoinReturnType = Option<FullnodeReturnType>;
 
     fn join(self) -> Result<Option<FullnodeReturnType>> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,6 +69,7 @@ extern crate byteorder;
 extern crate bytes;
 extern crate chrono;
 extern crate clap;
+extern crate crossbeam_utils;
 extern crate dirs;
 extern crate generic_array;
 extern crate itertools;

--- a/src/tpu.rs
+++ b/src/tpu.rs
@@ -47,16 +47,16 @@ pub enum TpuReturnType {
     LeaderRotation,
 }
 
-pub struct Tpu {
+pub struct Tpu<'a> {
     fetch_stage: FetchStage,
     sigverify_stage: SigVerifyStage,
-    banking_stage: BankingStage,
+    banking_stage: BankingStage<'a>,
     record_stage: RecordStage,
     write_stage: WriteStage,
     exit: Arc<AtomicBool>,
 }
 
-impl Tpu {
+impl<'a> Tpu<'a> {
     pub fn new(
         keypair: Arc<Keypair>,
         bank: &Arc<Bank>,
@@ -119,7 +119,7 @@ impl Tpu {
     }
 }
 
-impl Service for Tpu {
+impl<'a> Service for Tpu<'a> {
     type JoinReturnType = Option<TpuReturnType>;
 
     fn join(self) -> thread::Result<(Option<TpuReturnType>)> {


### PR DESCRIPTION
Showing how scoped threads are almost a drop-in replacement for
std::thread. They unfortunately have a viral effect of requiring
an explicit lifetime routed through every struct that contains
the scoped thread.

The benefit of using the explicit lifetime is that it'll allow
Rust to track all recyclables through a lifetime-aware recycler.
As long as the owner of the recyclable falls out of scope before
the struct that owns the recycler, the program will compile.
No need for runtime reference counting.