### PR TITLE
Use a Drop trait to keep track of lifetimes for recycled objects.

### DIFF
--- a/src/bin/bench-streamer.rs
+++ b/src/bin/bench-streamer.rs
@@ -20,8 +20,8 @@ fn producer(addr: &SocketAddr, recycler: &PacketRecycler, exit: Arc<AtomicBool>)
     let send = UdpSocket::bind("0.0.0.0:0").unwrap();
     let msgs = recycler.allocate();
     let msgs_ = msgs.clone();
-    msgs.write().unwrap().packets.resize(10, Packet::default());
-    for w in &mut msgs.write().unwrap().packets {
+    msgs.write().packets.resize(10, Packet::default());
+    for w in &mut msgs.write().packets {
         w.meta.size = PACKET_DATA_SIZE;
         w.meta.set_addr(&addr);
     }
@@ -30,7 +30,7 @@ fn producer(addr: &SocketAddr, recycler: &PacketRecycler, exit: Arc<AtomicBool>)
             return;
         }
         let mut num = 0;
-        for p in &msgs_.read().unwrap().packets {
+        for p in &msgs_.read().packets {
             let a = p.meta.addr();
             assert!(p.meta.size < BLOB_SIZE);
             send.send_to(&p.data[..p.meta.size], &a).unwrap();
@@ -52,7 +52,7 @@ fn sink(
         }
         let timer = Duration::new(1, 0);
         if let Ok(msgs) = r.recv_timeout(timer) {
-            rvs.fetch_add(msgs.read().unwrap().packets.len(), Ordering::Relaxed);
+            rvs.fetch_add(msgs.read().packets.len(), Ordering::Relaxed);
             recycler.recycle(msgs, "sink");
         }
     })
@@ -91,12 +91,7 @@ fn main() -> Result<()> {
 
         let (s_reader, r_reader) = channel();
         read_channels.push(r_reader);
-        read_threads.push(receiver(
-            Arc::new(read),
-            exit.clone(),
-            pack_recycler.clone(),
-            s_reader,
-        ));
+        read_threads.push(receiver(Arc::new(read), exit.clone(), s_reader));
     }
 
     let t_producer1 = producer(&addr, &pack_recycler, exit.clone());

--- a/src/bin/bench-tps.rs
+++ b/src/bin/bench-tps.rs
@@ -17,7 +17,6 @@ use solana::hash::Hash;
 use solana::logger;
 use solana::metrics;
 use solana::ncp::Ncp;
-use solana::packet::BlobRecycler;
 use solana::service::Service;
 use solana::signature::{read_keypair, GenKeys, Keypair, KeypairUtil};
 use solana::thin_client::{poll_gossip_for_leader, ThinClient};
@@ -695,14 +694,7 @@ fn converge(
     spy_crdt.set_leader(leader.id);
     let spy_ref = Arc::new(RwLock::new(spy_crdt));
     let window = Arc::new(RwLock::new(default_window()));
-    let ncp = Ncp::new(
-        &spy_ref,
-        window,
-        BlobRecycler::default(),
-        None,
-        gossip_socket,
-        exit_signal.clone(),
-    );
+    let ncp = Ncp::new(&spy_ref, window, None, gossip_socket, exit_signal.clone());
     let mut v: Vec<NodeInfo> = vec![];
     // wait for the network to converge, 30 seconds should be plenty
     for _ in 0..30 {

--- a/src/budget_contract.rs
+++ b/src/budget_contract.rs
@@ -439,7 +439,7 @@ mod test {
         ]);
         let date =
             DateTime::<Utc>::from_utc(NaiveDate::from_ymd(2016, 7, 8).and_hms(9, 10, 11), Utc);
-        let dateIso8601 = "2016-07-08T09:10:11Z";
+        let date_is_08601 = "2016-07-08T09:10:11Z";
 
         let tx = Transaction::budget_new(&keypair, to, 192, Hash::default());
         assert_eq!(
@@ -477,9 +477,9 @@ mod test {
             date,
             Hash::default(),
         );
-        let mut expectedUserdata = vec![1, 0, 0, 0, 20, 0, 0, 0, 0, 0, 0, 0];
-        expectedUserdata.extend(dateIso8601.as_bytes());
-        assert_eq!(tx.userdata, expectedUserdata,);
+        let mut expected_userdata = vec![1, 0, 0, 0, 20, 0, 0, 0, 0, 0, 0, 0];
+        expected_userdata.extend(date_is_08601.as_bytes());
+        assert_eq!(tx.userdata, expected_userdata,);
 
         // ApplySignature
         let tx = Transaction::budget_new_signature(&keypair, keypair.pubkey(), to, Hash::default());

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -84,7 +84,7 @@ impl Entry {
     ) -> SharedBlob {
         let blob = blob_recycler.allocate();
         {
-            let mut blob_w = blob.write().unwrap();
+            let mut blob_w = blob.write();
             let pos = {
                 let mut out = Cursor::new(blob_w.data_mut());
                 serialize_into(&mut out, &self).expect("failed to serialize output");

--- a/src/ledger.rs
+++ b/src/ledger.rs
@@ -456,7 +456,7 @@ pub fn reconstruct_entries_from_blobs(blobs: Vec<SharedBlob>) -> Result<Vec<Entr
 
     for blob in blobs {
         let entry = {
-            let msg = blob.read().unwrap();
+            let msg = blob.read();
             let msg_size = msg.get_size()?;
             deserialize(&msg.data()[..msg_size])
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,7 @@ pub mod payment_plan;
 pub mod record_stage;
 pub mod recorder;
 pub mod recvmmsg;
+pub mod recycler;
 pub mod replicate_stage;
 pub mod request;
 pub mod request_processor;

--- a/src/recycler.rs
+++ b/src/recycler.rs
@@ -1,0 +1,173 @@
+use std::fmt;
+use std::sync::{Arc, Mutex, RwLock, RwLockReadGuard, RwLockWriteGuard};
+
+/// A function that leaves the given type in the same state as Default,
+/// but starts with an existing type instead of allocating a new one.
+pub trait Reset {
+    fn reset(&mut self);
+}
+
+/// An value that's returned to its heap once dropped.
+pub struct Recyclable<T: Default + Reset> {
+    val: Arc<RwLock<T>>,
+    landfill: Arc<Mutex<Vec<Arc<RwLock<T>>>>>,
+}
+
+impl<T: Default + Reset> Recyclable<T> {
+    pub fn read(&self) -> RwLockReadGuard<T> {
+        self.val.read().unwrap()
+    }
+    pub fn write(&self) -> RwLockWriteGuard<T> {
+        self.val.write().unwrap()
+    }
+}
+
+impl<T: Default + Reset> Drop for Recyclable<T> {
+    fn drop(&mut self) {
+        if Arc::strong_count(&self.val) == 1 {
+            // this isn't thread safe, it will allow some concurrent drops to leak and not recycle
+            // if that happens the allocator will end up allocating from the heap
+            self.landfill.lock().unwrap().push(self.val.clone());
+        }
+    }
+}
+
+impl<T: Default + Reset> Clone for Recyclable<T> {
+    fn clone(&self) -> Self {
+        Recyclable {
+            val: self.val.clone(),
+            landfill: self.landfill.clone(),
+        }
+    }
+}
+
+impl<T: fmt::Debug + Default + Reset> fmt::Debug for Recyclable<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Recyclable {:?}", &self.read())
+    }
+}
+
+/// An object to minimize memory allocations. Use `allocate()`
+/// to get recyclable values of type `T`. When those recyclables
+/// are dropped, they're returned to the recycler. The next time
+/// `allocate()` is called, the value will be pulled from the
+/// recycler instead being allocated from memory.
+
+pub struct Recycler<T: Default + Reset> {
+    landfill: Arc<Mutex<Vec<Arc<RwLock<T>>>>>,
+}
+impl<T: Default + Reset> Clone for Recycler<T> {
+    fn clone(&self) -> Self {
+        Recycler {
+            landfill: self.landfill.clone(),
+        }
+    }
+}
+
+impl<T: Default + Reset> Default for Recycler<T> {
+    fn default() -> Self {
+        Recycler {
+            landfill: Arc::new(Mutex::new(vec![])),
+        }
+    }
+}
+
+impl<T: Default + Reset> Recycler<T> {
+    pub fn allocate(&self) -> Recyclable<T> {
+        let val = self
+            .landfill
+            .lock()
+            .unwrap()
+            .pop()
+            .map(|val| {
+                val.write().unwrap().reset();
+                val
+            }).unwrap_or_else(|| Arc::new(RwLock::new(Default::default())));
+        Recyclable {
+            val,
+            landfill: self.landfill.clone(),
+        }
+    }
+    pub fn recycle(&self, r: Recyclable<T>, _name: &str) {
+        drop(r)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::mem;
+    use std::sync::mpsc::channel;
+
+    #[derive(Default)]
+    struct Foo {
+        x: u8,
+    }
+
+    impl Reset for Foo {
+        fn reset(&mut self) {
+            self.x = 0;
+        }
+    }
+
+    #[test]
+    fn test_allocate() {
+        let recycler: Recycler<Foo> = Recycler::default();
+        let r = recycler.allocate();
+        assert_eq!(r.read().x, 0);
+    }
+
+    #[test]
+    fn test_recycle() {
+        let recycler: Recycler<Foo> = Recycler::default();
+
+        {
+            let foo = recycler.allocate();
+            foo.write().x = 1;
+        }
+        assert_eq!(recycler.landfill.lock().unwrap().len(), 1);
+
+        let foo = recycler.allocate();
+        assert_eq!(foo.read().x, 0);
+        assert_eq!(recycler.landfill.lock().unwrap().len(), 0);
+    }
+    #[test]
+    fn test_channel() {
+        let recycler: Recycler<Foo> = Recycler::default();
+        let (sender, receiver) = channel();
+        {
+            let foo = recycler.allocate();
+            foo.write().x = 1;
+            sender.send(foo).unwrap();
+            assert_eq!(recycler.landfill.lock().unwrap().len(), 0);
+        }
+        {
+            let foo = receiver.recv().unwrap();
+            assert_eq!(foo.read().x, 1);
+            assert_eq!(recycler.landfill.lock().unwrap().len(), 0);
+        }
+        assert_eq!(recycler.landfill.lock().unwrap().len(), 1);
+    }
+    #[test]
+    fn test_window() {
+        let recycler: Recycler<Foo> = Recycler::default();
+        let mut window = vec![None];
+        let (sender, receiver) = channel();
+        {
+            // item is in the window while its in the pipeline
+            // which is used to serve requests from other threads
+            let item = recycler.allocate();
+            item.write().x = 1;
+            window[0] = Some(item);
+            sender.send(window[0].clone().unwrap()).unwrap();
+        }
+        {
+            let foo = receiver.recv().unwrap();
+            assert_eq!(foo.read().x, 1);
+            let old = mem::replace(&mut window[0], None).unwrap();
+            assert_eq!(old.read().x, 1);
+        }
+        // only one thing should be in the landfill at the end
+        assert_eq!(recycler.landfill.lock().unwrap().len(), 1);
+    }
+}

--- a/src/request_stage.rs
+++ b/src/request_stage.rs
@@ -49,7 +49,7 @@ impl RequestStage {
         let mut reqs_len = 0;
         let proc_start = Instant::now();
         for msgs in batch {
-            let reqs: Vec<_> = Self::deserialize_requests(&msgs.read().unwrap())
+            let reqs: Vec<_> = Self::deserialize_requests(&msgs.read())
                 .into_iter()
                 .filter_map(|x| x)
                 .collect();
@@ -80,11 +80,11 @@ impl RequestStage {
     pub fn new(
         request_processor: RequestProcessor,
         packet_receiver: Receiver<SharedPackets>,
-        packet_recycler: PacketRecycler,
-        blob_recycler: BlobRecycler,
     ) -> (Self, BlobReceiver) {
+        let packet_recycler = PacketRecycler::default();
         let request_processor = Arc::new(request_processor);
         let request_processor_ = request_processor.clone();
+        let blob_recycler = BlobRecycler::default();
         let (blob_sender, blob_receiver) = channel();
         let thread_hdl = Builder::new()
             .name("solana-request-stage".to_string())

--- a/src/retransmit_stage.rs
+++ b/src/retransmit_stage.rs
@@ -3,7 +3,6 @@
 use counter::Counter;
 use crdt::Crdt;
 use log::Level;
-use packet::BlobRecycler;
 use result::{Error, Result};
 use service::Service;
 use std::net::UdpSocket;
@@ -17,24 +16,14 @@ use streamer::BlobReceiver;
 use window::SharedWindow;
 use window_service::window_service;
 
-fn retransmit(
-    crdt: &Arc<RwLock<Crdt>>,
-    recycler: &BlobRecycler,
-    r: &BlobReceiver,
-    sock: &UdpSocket,
-) -> Result<()> {
+fn retransmit(crdt: &Arc<RwLock<Crdt>>, r: &BlobReceiver, sock: &UdpSocket) -> Result<()> {
     let timer = Duration::new(1, 0);
     let mut dq = r.recv_timeout(timer)?;
     while let Ok(mut nq) = r.try_recv() {
         dq.append(&mut nq);
     }
-    {
-        for b in &dq {
-            Crdt::retransmit(&crdt, b, sock)?;
-        }
-    }
-    for b in dq {
-        recycler.recycle(b, "retransmit");
+    for b in &mut dq {
+        Crdt::retransmit(&crdt, b, sock)?;
     }
     Ok(())
 }
@@ -47,18 +36,13 @@ fn retransmit(
 /// * `crdt` - This structure needs to be updated and populated by the bank and via gossip.
 /// * `recycler` - Blob recycler.
 /// * `r` - Receive channel for blobs to be retransmitted to all the layer 1 nodes.
-fn retransmitter(
-    sock: Arc<UdpSocket>,
-    crdt: Arc<RwLock<Crdt>>,
-    recycler: BlobRecycler,
-    r: BlobReceiver,
-) -> JoinHandle<()> {
+fn retransmitter(sock: Arc<UdpSocket>, crdt: Arc<RwLock<Crdt>>, r: BlobReceiver) -> JoinHandle<()> {
     Builder::new()
         .name("solana-retransmitter".to_string())
         .spawn(move || {
             trace!("retransmitter started");
             loop {
-                if let Err(e) = retransmit(&crdt, &recycler, &r, &sock) {
+                if let Err(e) = retransmit(&crdt, &r, &sock) {
                     match e {
                         Error::RecvTimeoutError(RecvTimeoutError::Disconnected) => break,
                         Error::RecvTimeoutError(RecvTimeoutError::Timeout) => (),
@@ -83,23 +67,16 @@ impl RetransmitStage {
         entry_height: u64,
         retransmit_socket: Arc<UdpSocket>,
         repair_socket: Arc<UdpSocket>,
-        blob_recycler: &BlobRecycler,
         fetch_stage_receiver: BlobReceiver,
     ) -> (Self, BlobReceiver) {
         let (retransmit_sender, retransmit_receiver) = channel();
 
-        let t_retransmit = retransmitter(
-            retransmit_socket,
-            crdt.clone(),
-            blob_recycler.clone(),
-            retransmit_receiver,
-        );
+        let t_retransmit = retransmitter(retransmit_socket, crdt.clone(), retransmit_receiver);
         let (blob_sender, blob_receiver) = channel();
         let t_window = window_service(
             crdt.clone(),
             window,
             entry_height,
-            blob_recycler.clone(),
             fetch_stage_receiver,
             blob_sender,
             retransmit_sender,

--- a/src/thin_client.rs
+++ b/src/thin_client.rs
@@ -9,7 +9,6 @@ use crdt::{Crdt, CrdtError, NodeInfo};
 use hash::Hash;
 use log::Level;
 use ncp::Ncp;
-use packet::BlobRecycler;
 use request::{Request, Response};
 use result::{Error, Result};
 use signature::{Keypair, Pubkey, Signature};
@@ -375,14 +374,7 @@ pub fn poll_gossip_for_leader(leader_ncp: SocketAddr, timeout: Option<u64>) -> R
     let my_addr = gossip_socket.local_addr().unwrap();
     let crdt = Arc::new(RwLock::new(Crdt::new(node).expect("Crdt::new")));
     let window = Arc::new(RwLock::new(vec![]));
-    let ncp = Ncp::new(
-        &crdt.clone(),
-        window,
-        BlobRecycler::default(),
-        None,
-        gossip_socket,
-        exit.clone(),
-    );
+    let ncp = Ncp::new(&crdt.clone(), window, None, gossip_socket, exit.clone());
 
     let leader_entry_point = NodeInfo::new_entry_point(&leader_ncp);
     crdt.write().unwrap().insert(&leader_entry_point);

--- a/src/window.rs
+++ b/src/window.rs
@@ -18,7 +18,7 @@ use std::sync::{Arc, RwLock};
 
 pub const WINDOW_SIZE: u64 = 2 * 1024;
 
-#[derive(Clone, Default)]
+#[derive(Default, Clone)]
 pub struct WindowSlot {
     pub data: Option<SharedBlob>,
     pub coding: Option<SharedBlob>,
@@ -28,7 +28,7 @@ pub struct WindowSlot {
 impl WindowSlot {
     fn blob_index(&self) -> Option<u64> {
         match self.data {
-            Some(ref blob) => blob.read().unwrap().get_index().ok(),
+            Some(ref blob) => blob.read().get_index().ok(),
             None => None,
         }
     }
@@ -194,12 +194,7 @@ impl WindowUtil for Window {
     ) {
         let w = (pix % WINDOW_SIZE) as usize;
 
-        let is_coding = {
-            let blob_r = blob
-                .read()
-                .expect("blob read lock for flogs streamer::window");
-            blob_r.is_coding()
-        };
+        let is_coding = blob.read().is_coding();
 
         // insert a newly received blob into a window slot, clearing out and recycling any previous
         //  blob unless the incoming blob is a duplicate (based on idx)
@@ -213,7 +208,7 @@ impl WindowUtil for Window {
             c_or_d: &str,
         ) -> bool {
             if let Some(old) = mem::replace(window_slot, Some(blob)) {
-                let is_dup = old.read().unwrap().get_index().unwrap() == pix;
+                let is_dup = old.read().get_index().unwrap() == pix;
                 recycler.recycle(old, "insert_blob_is_dup");
                 trace!(
                     "{}: occupied {} window slot {:}, is_dup: {}",
@@ -263,7 +258,7 @@ impl WindowUtil for Window {
             trace!("{}: k: {} consumed: {}", id, k, *consumed,);
 
             if let Some(blob) = &self[k].data {
-                if blob.read().unwrap().get_index().unwrap() < *consumed {
+                if blob.read().get_index().unwrap() < *consumed {
                     // window wrap-around, end of received
                     break;
                 }
@@ -271,7 +266,10 @@ impl WindowUtil for Window {
                 // self[k].data is None, end of received
                 break;
             }
-            consume_queue.push(self[k].data.clone().expect("clone in fn recv_window"));
+            let slot = self[k].clone();
+            if let Some(r) = slot.data {
+                consume_queue.push(r)
+            }
             *consumed += 1;
         }
     }
@@ -324,7 +322,7 @@ pub fn blob_idx_in_window(id: &Pubkey, pix: u64, consumed: u64, received: &mut u
 }
 
 pub fn default_window() -> Window {
-    vec![WindowSlot::default(); WINDOW_SIZE as usize]
+    (0..WINDOW_SIZE).map(|_| WindowSlot::default()).collect()
 }
 
 pub fn index_blobs(
@@ -336,7 +334,7 @@ pub fn index_blobs(
     trace!("{}: INDEX_BLOBS {}", node_info.id, blobs.len());
     for (i, b) in blobs.iter().enumerate() {
         // only leader should be broadcasting
-        let mut blob = b.write().expect("'blob' write lock in crdt::index_blobs");
+        let mut blob = b.write();
         blob.set_id(node_info.id)
             .expect("set_id in pub fn broadcast");
         blob.set_index(*receive_index + i as u64)
@@ -373,7 +371,7 @@ pub fn initialized_window(
     // populate the window, offset by implied index
     let diff = cmp::max(blobs.len() as isize - window.len() as isize, 0) as usize;
     for b in blobs.into_iter().skip(diff) {
-        let ix = b.read().unwrap().get_index().expect("blob index");
+        let ix = b.read().get_index().expect("blob index");
         let pos = (ix % WINDOW_SIZE) as usize;
         trace!("{} caching {} at {}", id, ix, pos);
         assert!(window[pos].data.is_none());
@@ -387,16 +385,16 @@ pub fn new_window_from_entries(
     ledger_tail: &[Entry],
     entry_height: u64,
     node_info: &NodeInfo,
-    blob_recycler: &BlobRecycler,
 ) -> Window {
     // convert to blobs
+    let blob_recycler = BlobRecycler::default();
     let blobs = ledger_tail.to_blobs(&blob_recycler);
     initialized_window(&node_info, blobs, entry_height)
 }
 
 #[cfg(test)]
 mod test {
-    use packet::{Blob, BlobRecycler, Packet, PacketRecycler, Packets, PACKET_DATA_SIZE};
+    use packet::{Blob, BlobRecycler, Packet, Packets, PACKET_DATA_SIZE};
     use signature::Pubkey;
     use std::io;
     use std::io::Write;
@@ -412,7 +410,7 @@ mod test {
         for _t in 0..5 {
             let timer = Duration::new(1, 0);
             match r.recv_timeout(timer) {
-                Ok(m) => *num += m.read().unwrap().packets.len(),
+                Ok(m) => *num += m.read().packets.len(),
                 e => info!("error {:?}", e),
             }
             if *num == 10 {
@@ -434,28 +432,17 @@ mod test {
         let addr = read.local_addr().unwrap();
         let send = UdpSocket::bind("127.0.0.1:0").expect("bind");
         let exit = Arc::new(AtomicBool::new(false));
-        let pack_recycler = PacketRecycler::default();
         let resp_recycler = BlobRecycler::default();
         let (s_reader, r_reader) = channel();
-        let t_receiver = receiver(
-            Arc::new(read),
-            exit.clone(),
-            pack_recycler.clone(),
-            s_reader,
-        );
+        let t_receiver = receiver(Arc::new(read), exit.clone(), s_reader);
         let t_responder = {
             let (s_responder, r_responder) = channel();
-            let t_responder = responder(
-                "streamer_send_test",
-                Arc::new(send),
-                resp_recycler.clone(),
-                r_responder,
-            );
+            let t_responder = responder("streamer_send_test", Arc::new(send), r_responder);
             let mut msgs = Vec::new();
             for i in 0..10 {
-                let b = resp_recycler.allocate();
+                let mut b = resp_recycler.allocate();
                 {
-                    let mut w = b.write().unwrap();
+                    let mut w = b.write();
                     w.data[0] = i as u8;
                     w.meta.size = PACKET_DATA_SIZE;
                     w.meta.set_addr(&addr);

--- a/tests/multinode.rs
+++ b/tests/multinode.rs
@@ -13,7 +13,6 @@ use solana::ledger::LedgerWriter;
 use solana::logger;
 use solana::mint::Mint;
 use solana::ncp::Ncp;
-use solana::packet::BlobRecycler;
 use solana::result;
 use solana::service::Service;
 use solana::signature::{Keypair, KeypairUtil, Pubkey};
@@ -41,11 +40,9 @@ fn make_spy_node(leader: &NodeInfo) -> (Ncp, Arc<RwLock<Crdt>>, Pubkey) {
     spy_crdt.set_leader(leader.id);
     let spy_crdt_ref = Arc::new(RwLock::new(spy_crdt));
     let spy_window = Arc::new(RwLock::new(default_window()));
-    let recycler = BlobRecycler::default();
     let ncp = Ncp::new(
         &spy_crdt_ref,
         spy_window,
-        recycler,
         None,
         spy.sockets.gossip,
         exit.clone(),


### PR DESCRIPTION
* Move recycler instances to the point of allocation
* sinks no longer need to call `recycle`
* Remove the recycler arguments from all the apis that no longer need them
update for #1250 