### PR TITLE
s/contract/program

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@ pub mod client;
 pub mod instruction;
 #[macro_use]
 pub mod crdt;
-pub mod budget_contract;
+pub mod budget_program;
 pub mod drone;
 pub mod entry;
 pub mod entry_writer;
@@ -53,7 +53,7 @@ pub mod signature;
 pub mod sigverify;
 pub mod sigverify_stage;
 pub mod streamer;
-pub mod system_contract;
+pub mod system_program;
 pub mod thin_client;
 pub mod timing;
 pub mod tpu;

--- a/src/mint.rs
+++ b/src/mint.rs
@@ -68,15 +68,15 @@ mod tests {
     use super::*;
     use bincode::deserialize;
     use ledger::Block;
-    use system_contract::SystemContract;
+    use system_program::SystemProgram;
 
     #[test]
     fn test_create_transactions() {
         let mut transactions = Mint::new(100).create_transactions().into_iter();
         let tx = transactions.next().unwrap();
-        assert!(SystemContract::check_id(&tx.contract_id));
-        let instruction: SystemContract = deserialize(&tx.userdata).unwrap();
-        if let SystemContract::Move { tokens } = instruction {
+        assert!(SystemProgram::check_id(&tx.program_id));
+        let instruction: SystemProgram = deserialize(&tx.userdata).unwrap();
+        if let SystemProgram::Move { tokens } = instruction {
             assert_eq!(tokens, 100);
         }
         assert_eq!(transactions.next(), None);

--- a/src/thin_client.rs
+++ b/src/thin_client.rs
@@ -428,7 +428,7 @@ mod tests {
     use mint::Mint;
     use signature::{Keypair, KeypairUtil};
     use std::fs::remove_dir_all;
-    use system_contract::SystemContract;
+    use system_program::SystemProgram;
 
     fn tmp_ledger(name: &str, mint: &Mint) -> String {
         use std::env;
@@ -536,7 +536,7 @@ mod tests {
 
         let mut tr2 = Transaction::new(&alice.keypair(), bob_pubkey, 501, last_id);
         let mut instruction2 = deserialize(&tr2.userdata).unwrap();
-        if let SystemContract::Move { ref mut tokens } = instruction2 {
+        if let SystemProgram::Move { ref mut tokens } = instruction2 {
             *tokens = 502;
         }
         tr2.userdata = serialize(&instruction2).unwrap();

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -2,14 +2,14 @@
 
 use bincode::{deserialize, serialize};
 use budget::{Budget, Condition};
-use budget_contract::BudgetContract;
+use budget_program::BudgetProgram;
 use chrono::prelude::*;
 use hash::Hash;
 use instruction::{Contract, Instruction, Plan, Vote};
 use payment_plan::{Payment, PaymentPlan};
 use signature::{Keypair, KeypairUtil, Pubkey, Signature};
 use std::mem::size_of;
-use system_contract::SystemContract;
+use system_program::SystemProgram;
 
 pub const SIGNED_DATA_OFFSET: usize = size_of::<Signature>();
 pub const SIG_OFFSET: usize = 0;
@@ -18,18 +18,18 @@ pub const PUB_KEY_OFFSET: usize = size_of::<Signature>() + size_of::<u64>();
 /// An instruction signed by a client with `Pubkey`.
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub struct Transaction {
-    /// A digital signature of `keys`, `contract_id`, `last_id`, `fee` and `userdata`, signed by `Pubkey`.
+    /// A digital signature of `keys`, `program_id`, `last_id`, `fee` and `userdata`, signed by `Pubkey`.
     pub signature: Signature,
 
     /// The `Pubkeys` that are executing this transaction userdata.  The meaning of each key is
-    /// contract-specific.
+    /// program-specific.
     /// * keys[0] - Typically this is the `caller` public key.  `signature` is verified with keys[0].
     /// In the future which key pays the fee and which keys have signatures would be configurable.
-    /// * keys[1] - Typically this is the contract context or the recipient of the tokens
+    /// * keys[1] - Typically this is the program context or the recipient of the tokens
     pub keys: Vec<Pubkey>,
 
-    /// the contract id to execute
-    pub contract_id: Pubkey,
+    /// The program code that executes this transaction is identified by the program_id.
+    pub program_id: Pubkey,
 
     /// The ID of a recent ledger entry.
     pub last_id: Hash,
@@ -44,15 +44,15 @@ pub struct Transaction {
 impl Transaction {
     /// Create a signed transaction from the given `Instruction`.
     /// * `from_keypair` - The key used to sign the transaction.  This key is stored as keys[0]
-    /// * `transaction_keys` - The keys for the transaction.  These are the contract state
+    /// * `transaction_keys` - The keys for the transaction.  These are the program state
     ///    instances or token recipient keys.
-    /// * `userdata` - The input data that the contract will execute with
+    /// * `userdata` - The input data that the program will execute with
     /// * `last_id` - The PoH hash.
     /// * `fee` - The transaction fee.
     fn new_with_userdata(
         from_keypair: &Keypair,
         transaction_keys: &[Pubkey],
-        contract_id: Pubkey,
+        program_id: Pubkey,
         userdata: Vec<u8>,
         last_id: Hash,
         fee: i64,
@@ -63,7 +63,7 @@ impl Transaction {
         let mut tx = Transaction {
             signature: Signature::default(),
             keys,
-            contract_id,
+            program_id,
             last_id,
             fee,
             userdata,
@@ -74,14 +74,14 @@ impl Transaction {
     /// Create and sign a new Transaction. Used for unit-testing.
     pub fn budget_new_taxed(
         from_keypair: &Keypair,
-        contract: Pubkey,
+        to: Pubkey,
         tokens: i64,
         fee: i64,
         last_id: Hash,
     ) -> Self {
         let payment = Payment {
             tokens: tokens - fee,
-            to: contract,
+            to: to,
         };
         let budget = Budget::Pay(payment);
         let plan = Plan::Budget(budget);
@@ -89,8 +89,8 @@ impl Transaction {
         let userdata = serialize(&instruction).unwrap();
         Self::new_with_userdata(
             from_keypair,
-            &[contract],
-            BudgetContract::id(),
+            &[to],
+            BudgetProgram::id(),
             userdata,
             last_id,
             fee,
@@ -115,7 +115,7 @@ impl Transaction {
         Self::new_with_userdata(
             from_keypair,
             &[contract, to],
-            BudgetContract::id(),
+            BudgetProgram::id(),
             userdata,
             last_id,
             0,
@@ -134,7 +134,7 @@ impl Transaction {
         Self::new_with_userdata(
             from_keypair,
             &[contract, to],
-            BudgetContract::id(),
+            BudgetProgram::id(),
             userdata,
             last_id,
             0,
@@ -147,7 +147,7 @@ impl Transaction {
         Self::new_with_userdata(
             from_keypair,
             &[],
-            BudgetContract::id(),
+            BudgetProgram::id(),
             userdata,
             last_id,
             fee,
@@ -174,58 +174,58 @@ impl Transaction {
         Self::new_with_userdata(
             from_keypair,
             &[contract],
-            BudgetContract::id(),
+            BudgetProgram::id(),
             userdata,
             last_id,
             0,
         )
     }
-    /// Create and sign new SystemContract::CreateAccount transaction
+    /// Create and sign new SystemProgram::CreateAccount transaction
     pub fn system_create(
         from_keypair: &Keypair,
         to: Pubkey,
         last_id: Hash,
         tokens: i64,
         space: u64,
-        contract_id: Option<Pubkey>,
+        program_id: Option<Pubkey>,
         fee: i64,
     ) -> Self {
-        let create = SystemContract::CreateAccount {
+        let create = SystemProgram::CreateAccount {
             tokens, //TODO, the tokens to allocate might need to be higher then 0 in the future
             space,
-            contract_id,
+            program_id,
         };
         Transaction::new_with_userdata(
             from_keypair,
             &[to],
-            SystemContract::id(),
+            SystemProgram::id(),
             serialize(&create).unwrap(),
             last_id,
             fee,
         )
     }
-    /// Create and sign new SystemContract::CreateAccount transaction
+    /// Create and sign new SystemProgram::CreateAccount transaction
     pub fn system_assign(
         from_keypair: &Keypair,
         last_id: Hash,
-        contract_id: Pubkey,
+        program_id: Pubkey,
         fee: i64,
     ) -> Self {
-        let create = SystemContract::Assign { contract_id };
+        let create = SystemProgram::Assign { program_id };
         Transaction::new_with_userdata(
             from_keypair,
             &[],
-            SystemContract::id(),
+            SystemProgram::id(),
             serialize(&create).unwrap(),
             last_id,
             fee,
         )
     }
-    /// Create and sign new SystemContract::CreateAccount transaction with some defaults
+    /// Create and sign new SystemProgram::CreateAccount transaction with some defaults
     pub fn system_new(from_keypair: &Keypair, to: Pubkey, tokens: i64, last_id: Hash) -> Self {
         Transaction::system_create(from_keypair, to, last_id, tokens, 0, None, 0)
     }
-    /// Create and sign new SystemContract::Move transaction
+    /// Create and sign new SystemProgram::Move transaction
     pub fn system_move(
         from_keypair: &Keypair,
         to: Pubkey,
@@ -233,17 +233,17 @@ impl Transaction {
         last_id: Hash,
         fee: i64,
     ) -> Self {
-        let create = SystemContract::Move { tokens };
+        let create = SystemProgram::Move { tokens };
         Transaction::new_with_userdata(
             from_keypair,
             &[to],
-            SystemContract::id(),
+            SystemProgram::id(),
             serialize(&create).unwrap(),
             last_id,
             fee,
         )
     }
-    /// Create and sign new SystemContract::Move transaction
+    /// Create and sign new SystemProgram::Move transaction
     pub fn new(from_keypair: &Keypair, to: Pubkey, tokens: i64, last_id: Hash) -> Self {
         Transaction::system_move(from_keypair, to, tokens, last_id, 0)
     }
@@ -251,8 +251,8 @@ impl Transaction {
     fn get_sign_data(&self) -> Vec<u8> {
         let mut data = serialize(&(&self.keys)).expect("serialize keys");
 
-        let contract_id = serialize(&(&self.contract_id)).expect("serialize contract_id");
-        data.extend_from_slice(&contract_id);
+        let program_id = serialize(&(&self.program_id)).expect("serialize program_id");
+        data.extend_from_slice(&program_id);
 
         let last_id_data = serialize(&(&self.last_id)).expect("serialize last_id");
         data.extend_from_slice(&last_id_data);
@@ -370,7 +370,7 @@ mod tests {
             keys: vec![],
             last_id: Default::default(),
             signature: Default::default(),
-            contract_id: Default::default(),
+            program_id: Default::default(),
             fee: 0,
             userdata,
         };
@@ -489,7 +489,7 @@ mod tests {
             1, 1, 1,
         ]);
 
-        let contract = Pubkey::new(&[
+        let program_id = Pubkey::new(&[
             2, 2, 2, 4, 5, 6, 7, 8, 9, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 9, 8, 7, 6, 5, 4,
             2, 2, 2,
         ]);
@@ -497,7 +497,7 @@ mod tests {
         let tx = Transaction::new_with_userdata(
             keypair,
             &[keypair.pubkey(), to],
-            contract,
+            program_id,
             vec![1, 2, 3],
             Hash::default(),
             99,


### PR DESCRIPTION
Rename contract to program and update documentation in code.  The reason for this change is because our system distinguishes code from instances of state that the code operates on.

A computer program is a passive collection of instructions; a process is the actual execution of those instructions. Several processes may be associated with the same program; for example, opening up several instances of the same program often means more than one process is being executed.

Program seems like a fitting definition.