### PR TITLE
Boot spending plan

### DIFF
--- a/src/budget.rs
+++ b/src/budget.rs
@@ -4,7 +4,7 @@
 //! `Payment`, the payment is executed.
 
 use chrono::prelude::*;
-use payment_plan::{Payment, PaymentPlan, Witness};
+use payment_plan::{Payment, Witness};
 use signature::Pubkey;
 use std::mem;
 
@@ -75,11 +75,9 @@ impl Budget {
             (Condition::Signature(from), Payment { tokens, to: from }),
         )
     }
-}
 
-impl PaymentPlan for Budget {
     /// Return Payment if the budget requires no additional Witnesses.
-    fn final_payment(&self) -> Option<Payment> {
+    pub fn final_payment(&self) -> Option<Payment> {
         match self {
             Budget::Pay(payment) => Some(payment.clone()),
             _ => None,
@@ -87,7 +85,7 @@ impl PaymentPlan for Budget {
     }
 
     /// Return true if the budget spends exactly `spendable_tokens`.
-    fn verify(&self, spendable_tokens: i64) -> bool {
+    pub fn verify(&self, spendable_tokens: i64) -> bool {
         match self {
             Budget::Pay(payment) | Budget::After(_, payment) => payment.tokens == spendable_tokens,
             Budget::Or(a, b) => a.1.tokens == spendable_tokens && b.1.tokens == spendable_tokens,
@@ -96,7 +94,7 @@ impl PaymentPlan for Budget {
 
     /// Apply a witness to the budget to see if the budget can be reduced.
     /// If so, modify the budget in-place.
-    fn apply_witness(&mut self, witness: &Witness, from: &Pubkey) {
+    pub fn apply_witness(&mut self, witness: &Witness, from: &Pubkey) {
         let new_payment = match self {
             Budget::After(cond, payment) if cond.is_satisfied(witness, from) => Some(payment),
             Budget::Or((cond, payment), _) if cond.is_satisfied(witness, from) => Some(payment),

--- a/src/budget_contract.rs
+++ b/src/budget_contract.rs
@@ -4,7 +4,7 @@ use bincode::{self, deserialize, serialize_into, serialized_size};
 use budget::Budget;
 use chrono::prelude::{DateTime, Utc};
 use instruction::Instruction;
-use payment_plan::{PaymentPlan, Witness};
+use payment_plan::Witness;
 use signature::Pubkey;
 use std::io;
 use transaction::Transaction;

--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -1,42 +1,12 @@
 use budget::Budget;
 use chrono::prelude::{DateTime, Utc};
-use payment_plan::{Payment, PaymentPlan, Witness};
-use signature::Pubkey;
-
-/// The type of payment plan. Each item must implement the PaymentPlan trait.
-#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
-pub enum Plan {
-    /// The builtin contract language Budget.
-    Budget(Budget),
-}
-
-// A proxy for the underlying DSL.
-impl PaymentPlan for Plan {
-    fn final_payment(&self) -> Option<Payment> {
-        match self {
-            Plan::Budget(budget) => budget.final_payment(),
-        }
-    }
-
-    fn verify(&self, spendable_tokens: i64) -> bool {
-        match self {
-            Plan::Budget(budget) => budget.verify(spendable_tokens),
-        }
-    }
-
-    fn apply_witness(&mut self, witness: &Witness, from: &Pubkey) {
-        match self {
-            Plan::Budget(budget) => budget.apply_witness(witness, from),
-        }
-    }
-}
 
 /// A smart contract.
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub struct Contract {
-    /// The number of tokens allocated to the `Plan` and any transaction fees.
+    /// The number of tokens allocated to the `Budget` and any transaction fees.
     pub tokens: i64,
-    pub plan: Plan,
+    pub budget: Budget,
 }
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub struct Vote {

--- a/src/payment_plan.rs
+++ b/src/payment_plan.rs
@@ -25,16 +25,3 @@ pub struct Payment {
     /// The `Pubkey` that `tokens` should be paid to.
     pub to: Pubkey,
 }
-
-/// Interface to smart contracts.
-pub trait PaymentPlan {
-    /// Return Payment if the payment plan requires no additional Witnesses.
-    fn final_payment(&self) -> Option<Payment>;
-
-    /// Return true if the plan spends exactly `spendable_tokens`.
-    fn verify(&self, spendable_tokens: i64) -> bool;
-
-    /// Apply a witness to the payment plan to see if the plan can be reduced.
-    /// If so, modify the plan in-place.
-    fn apply_witness(&mut self, witness: &Witness, from: &Pubkey);
-}

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -6,7 +6,7 @@ use budget_contract::BudgetContract;
 use chrono::prelude::*;
 use hash::Hash;
 use instruction::{Contract, Instruction, Vote};
-use payment_plan::{Payment, PaymentPlan};
+use payment_plan::Payment;
 use signature::{Keypair, KeypairUtil, Pubkey, Signature};
 use std::mem::size_of;
 use system_contract::SystemContract;


### PR DESCRIPTION
I had intended SpendingPlan to be an interface to the contract engine, but we went another direction. Boot it.

This also removes the useless `Plan` wrapper in the userdata, so changes the transaction format.