### PR TITLE
Moved deserialization of blobs to entries from replicate_stage to window_service

### DIFF
--- a/src/entry.rs
+++ b/src/entry.rs
@@ -9,7 +9,11 @@ use rayon::prelude::*;
 use signature::Pubkey;
 use std::io::Cursor;
 use std::net::SocketAddr;
+use std::sync::mpsc::{Receiver, Sender};
 use transaction::Transaction;
+
+pub type EntrySender = Sender<Vec<Entry>>;
+pub type EntryReceiver = Receiver<Vec<Entry>>;
 
 /// Each Entry contains three pieces of data. The `num_hashes` field is the number
 /// of hashes performed since the previous entry.  The `id` field is the result


### PR DESCRIPTION
Moving the deserialization of blobs to entries to the window_service so that we don't increment the "consumed" count in the window unless the blob is valid. This prevents cases where the window sends the replicate_stage bogus blobs that it can't deserialize into entries, in which case the blob for that height never get detected/ repaired b/c the window has moved on.