### PR TITLE
Treat rustc warnings as errors in CI

### DIFF
--- a/ci/test-stable-perf.sh
+++ b/ci/test-stable-perf.sh
@@ -9,6 +9,7 @@ if ! ci/version-check.sh stable; then
   ci/version-check.sh stable
 fi
 export RUST_BACKTRACE=1
+export RUSTFLAGS="-D warnings"
 
 ./fetch-perf-libs.sh
 export LD_LIBRARY_PATH=$PWD/target/perf-libs:/usr/local/cuda/lib64:$LD_LIBRARY_PATH

--- a/ci/test-stable.sh
+++ b/ci/test-stable.sh
@@ -4,6 +4,7 @@ cd "$(dirname "$0")/.."
 
 ci/version-check.sh stable
 export RUST_BACKTRACE=1
+export RUSTFLAGS="-D warnings"
 
 _() {
   echo "--- $*"

--- a/src/system_program.rs
+++ b/src/system_program.rs
@@ -41,7 +41,7 @@ impl SystemProgram {
         account.tokens
     }
     pub fn process_transaction(tx: &Transaction, accounts: &mut [Account]) {
-        if let Ok(syscall) = deserialize(&tx.userdata){
+        if let Ok(syscall) = deserialize(&tx.userdata) {
             trace!("process_transaction: {:?}", syscall);
             match syscall {
                 SystemProgram::CreateAccount {

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -143,14 +143,7 @@ impl Transaction {
     pub fn budget_new_vote(from_keypair: &Keypair, vote: Vote, last_id: Hash, fee: i64) -> Self {
         let instruction = Instruction::NewVote(vote);
         let userdata = serialize(&instruction).expect("serialize instruction");
-        Self::new_with_userdata(
-            from_keypair,
-            &[],
-            BudgetState::id(),
-            userdata,
-            last_id,
-            fee,
-        )
+        Self::new_with_userdata(from_keypair, &[], BudgetState::id(), userdata, last_id, fee)
     }
 
     /// Create and sign a postdated Transaction. Used for unit-testing.

--- a/src/window.rs
+++ b/src/window.rs
@@ -230,6 +230,11 @@ impl WindowUtil for Window {
         self[w].leader_unknown = leader_unknown;
         *pending_retransmits = true;
 
+        #[cfg(not(feature = "erasure"))]
+        {
+            // suppress warning: unused variable: `recycler`
+            let _ = recycler;
+        }
         #[cfg(feature = "erasure")]
         {
             if erasure::recover(


### PR DESCRIPTION
Warnings are not forced to errors in local builds however, as this can be tedious when rapidly iterating