### PR TITLE
MT safe bank and atomic multiple program execution

### DIFF
--- a/benches/bank.rs
+++ b/benches/bank.rs
@@ -42,7 +42,7 @@ fn bench_process_transaction(bencher: &mut Bencher) {
     bencher.iter(|| {
         // Since benchmarker runs this multiple times, we need to clear the signatures.
         bank.clear_signatures();
-        let results = bank.process_transactions(transactions.clone());
+        let results = bank.process_transactions(&transactions);
         assert!(results.iter().all(Result::is_ok));
     })
 }

--- a/benches/banking_stage.rs
+++ b/benches/banking_stage.rs
@@ -1,85 +1,24 @@
 #![feature(test)]
 extern crate bincode;
+extern crate rand;
 extern crate rayon;
 extern crate solana;
 extern crate test;
 
+use rand::{thread_rng, Rng};
 use rayon::prelude::*;
 use solana::bank::Bank;
-use solana::banking_stage::BankingStage;
+use solana::banking_stage::{BankingStage, NUM_THREADS};
 use solana::entry::Entry;
 use solana::mint::Mint;
 use solana::packet::{to_packets_chunked, PacketRecycler};
-use solana::poh_service::PohService;
-use solana::signature::{Keypair, KeypairUtil};
+use solana::signature::{KeypairUtil, Pubkey, Signature};
 use solana::transaction::Transaction;
 use std::iter;
 use std::sync::mpsc::{channel, Receiver};
 use std::sync::Arc;
 use std::time::Duration;
 use test::Bencher;
-
-// use self::test::Bencher;
-// use bank::{Bank, MAX_ENTRY_IDS};
-// use bincode::serialize;
-// use hash::hash;
-// use mint::Mint;
-// use rayon::prelude::*;
-// use signature::{Keypair, KeypairUtil};
-// use std::collections::HashSet;
-// use std::time::Instant;
-// use transaction::Transaction;
-//
-// fn bench_process_transactions(_bencher: &mut Bencher) {
-//     let mint = Mint::new(100_000_000);
-//     let bank = Bank::new(&mint);
-//     // Create transactions between unrelated parties.
-//     let txs = 100_000;
-//     let last_ids: Mutex<HashSet<Hash>> = Mutex::new(HashSet::new());
-//     let transactions: Vec<_> = (0..txs)
-//         .into_par_iter()
-//         .map(|i| {
-//             // Seed the 'to' account and a cell for its signature.
-//             let dummy_id = i % (MAX_ENTRY_IDS as i32);
-//             let last_id = hash(&serialize(&dummy_id).unwrap()); // Semi-unique hash
-//             {
-//                 let mut last_ids = last_ids.lock().unwrap();
-//                 if !last_ids.contains(&last_id) {
-//                     last_ids.insert(last_id);
-//                     bank.register_entry_id(&last_id);
-//                 }
-//             }
-//
-//             // Seed the 'from' account.
-//             let rando0 = Keypair::new();
-//             let tx = Transaction::new(&mint.keypair(), rando0.pubkey(), 1_000, last_id);
-//             bank.process_transaction(&tx).unwrap();
-//
-//             let rando1 = Keypair::new();
-//             let tx = Transaction::new(&rando0, rando1.pubkey(), 2, last_id);
-//             bank.process_transaction(&tx).unwrap();
-//
-//             // Finally, return a transaction that's unique
-//             Transaction::new(&rando0, rando1.pubkey(), 1, last_id)
-//         })
-//         .collect();
-//
-//     let banking_stage = EventProcessor::new(bank, &mint.last_id(), None);
-//
-//     let now = Instant::now();
-//     assert!(banking_stage.process_transactions(transactions).is_ok());
-//     let duration = now.elapsed();
-//     let sec = duration.as_secs() as f64 + duration.subsec_nanos() as f64 / 1_000_000_000.0;
-//     let tps = txs as f64 / sec;
-//
-//     // Ensure that all transactions were successfully logged.
-//     drop(banking_stage.historian_input);
-//     let entries: Vec<Entry> = banking_stage.output.lock().unwrap().iter().collect();
-//     assert_eq!(entries.len(), 1);
-//     assert_eq!(entries[0].transactions.len(), txs as usize);
-//
-//     println!("{} tps", tps);
-// }
 
 fn check_txs(receiver: &Receiver<Vec<Entry>>, ref_tx_count: usize) {
     let mut total = 0;
@@ -101,132 +40,137 @@ fn check_txs(receiver: &Receiver<Vec<Entry>>, ref_tx_count: usize) {
 
 #[bench]
 fn bench_banking_stage_multi_accounts(bencher: &mut Bencher) {
-    let tx = 10_000_usize;
+    let txes = 1000 * NUM_THREADS;
     let mint_total = 1_000_000_000_000;
     let mint = Mint::new(mint_total);
-    let num_dst_accounts = 8 * 1024;
-    let num_src_accounts = 8 * 1024;
-
-    let srckeys: Vec<_> = (0..num_src_accounts).map(|_| Keypair::new()).collect();
-    let dstkeys: Vec<_> = (0..num_dst_accounts)
-        .map(|_| Keypair::new().pubkey())
-        .collect();
-
-    let transactions: Vec<_> = (0..tx)
-        .map(|i| {
-            Transaction::new(
-                &srckeys[i % num_src_accounts],
-                dstkeys[i % num_dst_accounts],
-                i as i64,
-                mint.last_id(),
-            )
-        }).collect();
 
     let (verified_sender, verified_receiver) = channel();
-    let (entry_sender, entry_receiver) = channel();
     let packet_recycler = PacketRecycler::default();
-
-    let setup_transactions: Vec<_> = (0..num_src_accounts)
-        .map(|i| {
-            Transaction::new(
-                &mint.keypair(),
-                srckeys[i].pubkey(),
-                mint_total / num_src_accounts as i64,
-                mint.last_id(),
-            )
+    let bank = Arc::new(Bank::new(&mint));
+    let dummy = Transaction::new(&mint.keypair(), mint.keypair().pubkey(), 1, mint.last_id());
+    let transactions: Vec<_> = (0..txes)
+        .into_par_iter()
+        .map(|_| {
+            let mut new = dummy.clone();
+            let from: Vec<u8> = (0..64).map(|_| thread_rng().gen()).collect();
+            let to: Vec<u8> = (0..64).map(|_| thread_rng().gen()).collect();
+            let sig: Vec<u8> = (0..64).map(|_| thread_rng().gen()).collect();
+            new.keys[0] = Pubkey::new(&from[0..32]);
+            new.keys[1] = Pubkey::new(&to[0..32]);
+            new.signature = Signature::new(&sig[0..64]);
+            new
         }).collect();
-
+    transactions.iter().for_each(|tx| {
+        let fund = Transaction::new(
+            &mint.keypair(),
+            tx.keys[0],
+            mint_total / txes as i64,
+            mint.last_id(),
+        );
+        assert!(bank.process_transaction(&fund).is_ok());
+    });
+    //sanity check, make sure all the transactions can execute sequentially
+    transactions.iter().for_each(|tx| {
+        let res = bank.process_transaction(&tx);
+        assert!(res.is_ok(), "sanity test transactions");
+    });
+    bank.clear_signatures();
+    //sanity check, make sure all the transactions can execute in parallel
+    let res = bank.process_transactions(&transactions);
+    for r in res {
+        assert!(r.is_ok(), "sanity parallel execution");
+    }
+    bank.clear_signatures();
+    let verified: Vec<_> = to_packets_chunked(&packet_recycler, &transactions.clone(), 192)
+        .into_iter()
+        .map(|x| {
+            let len = x.read().packets.len();
+            (x, iter::repeat(1).take(len).collect())
+        }).collect();
+    let (_stage, signal_receiver) = BankingStage::new(bank.clone(), verified_receiver, None);
     bencher.iter(move || {
-        let bank = Arc::new(Bank::new(&mint));
-
-        let (hash_sender, hash_receiver) = channel();
-        let (_poh_service, poh_receiver) = PohService::new(bank.last_id(), hash_receiver, None);
-
-        let verified_setup: Vec<_> =
-            to_packets_chunked(&packet_recycler, &setup_transactions.clone(), tx)
-                .into_iter()
-                .map(|x| {
-                    let len = (x).read().packets.len();
-                    (x, iter::repeat(1).take(len).collect())
-                }).collect();
-
-        verified_sender.send(verified_setup).unwrap();
-        BankingStage::process_packets(
-            &bank,
-            &hash_sender,
-            &poh_receiver,
-            &verified_receiver,
-            &entry_sender,
-        ).unwrap();
-
-        check_txs(&entry_receiver, num_src_accounts);
-
-        let verified: Vec<_> = to_packets_chunked(&packet_recycler, &transactions.clone(), 192)
-            .into_iter()
-            .map(|x| {
-                let len = (x).read().packets.len();
-                (x, iter::repeat(1).take(len).collect())
-            }).collect();
-
-        verified_sender.send(verified).unwrap();
-        BankingStage::process_packets(
-            &bank,
-            &hash_sender,
-            &poh_receiver,
-            &verified_receiver,
-            &entry_sender,
-        ).unwrap();
-
-        check_txs(&entry_receiver, tx);
+        for v in verified.chunks(verified.len() / NUM_THREADS) {
+            verified_sender.send(v.to_vec()).unwrap();
+        }
+        check_txs(&signal_receiver, txes);
+        bank.clear_signatures();
+        bank.register_entry_id(&mint.last_id());
     });
 }
 
 #[bench]
-fn bench_banking_stage_single_from(bencher: &mut Bencher) {
-    let tx = 10_000_usize;
-    let mint = Mint::new(1_000_000_000_000);
-    let mut pubkeys = Vec::new();
-    let num_keys = 8;
-    for _ in 0..num_keys {
-        pubkeys.push(Keypair::new().pubkey());
-    }
-
-    let transactions: Vec<_> = (0..tx)
-        .into_par_iter()
-        .map(|i| {
-            Transaction::new(
-                &mint.keypair(),
-                pubkeys[i % num_keys],
-                i as i64,
-                mint.last_id(),
-            )
-        }).collect();
+fn bench_banking_stage_multi_programs(bencher: &mut Bencher) {
+    //use solana::logger;
+    //logger::setup();
+    let progs = 5;
+    let txes = 1000 * NUM_THREADS;
+    let mint_total = 1_000_000_000_000;
+    let mint = Mint::new(mint_total);
 
     let (verified_sender, verified_receiver) = channel();
-    let (entry_sender, entry_receiver) = channel();
     let packet_recycler = PacketRecycler::default();
-
+    let bank = Arc::new(Bank::new(&mint));
+    let dummy = Transaction::new(&mint.keypair(), mint.keypair().pubkey(), 1, mint.last_id());
+    let transactions: Vec<_> = (0..txes)
+        .into_par_iter()
+        .map(|_| {
+            let mut new = dummy.clone();
+            let from: Vec<u8> = (0..32).map(|_| thread_rng().gen()).collect();
+            let sig: Vec<u8> = (0..64).map(|_| thread_rng().gen()).collect();
+            let to: Vec<u8> = (0..32).map(|_| thread_rng().gen()).collect();
+            new.keys[0] = Pubkey::new(&from[0..32]);
+            new.keys[1] = Pubkey::new(&to[0..32]);
+            let prog = new.programs[0].clone();
+            for i in 1..progs {
+                //generate programs that spend to random keys
+                let to: Vec<u8> = (0..32).map(|_| thread_rng().gen()).collect();
+                let to_key = Pubkey::new(&to[0..32]);
+                new.keys.push(to_key);
+                assert_eq!(new.keys.len(), i + 2);
+                new.programs.push(prog.clone());
+                assert_eq!(new.programs.len(), i + 1);
+                new.programs[i].accounts[1] = 1 + i as u8;
+                assert_eq!(new.keys[new.programs[i].accounts[1] as usize], to_key);
+            }
+            assert_eq!(new.programs.len(), progs);
+            new.signature = Signature::new(&sig[0..64]);
+            new
+        }).collect();
+    transactions.iter().for_each(|tx| {
+        let fund = Transaction::new(
+            &mint.keypair(),
+            tx.keys[0],
+            mint_total / txes as i64,
+            mint.last_id(),
+        );
+        assert!(bank.process_transaction(&fund).is_ok());
+    });
+    //sanity check, make sure all the transactions can execute sequentially
+    transactions.iter().for_each(|tx| {
+        let res = bank.process_transaction(&tx);
+        assert!(res.is_ok(), "sanity test transactions");
+    });
+    bank.clear_signatures();
+    //sanity check, make sure all the transactions can execute in parallel
+    let res = bank.process_transactions(&transactions);
+    for r in res {
+        assert!(r.is_ok(), "sanity parallel execution");
+    }
+    bank.clear_signatures();
+    let verified: Vec<_> = to_packets_chunked(&packet_recycler, &transactions.clone(), 96)
+        .into_iter()
+        .map(|x| {
+            let len = x.read().packets.len();
+            (x, iter::repeat(1).take(len).collect())
+        }).collect();
+    let (_stage, signal_receiver) = BankingStage::new(bank.clone(), verified_receiver, None);
     bencher.iter(move || {
-        let bank = Arc::new(Bank::new(&mint));
-
-        let (hash_sender, hash_receiver) = channel();
-        let (_poh_service, poh_receiver) = PohService::new(bank.last_id(), hash_receiver, None);
-
-        let verified: Vec<_> = to_packets_chunked(&packet_recycler, &transactions.clone(), tx)
-            .into_iter()
-            .map(|x| {
-                let len = (x).read().packets.len();
-                (x, iter::repeat(1).take(len).collect())
-            }).collect();
-        verified_sender.send(verified).unwrap();
-        BankingStage::process_packets(
-            &bank,
-            &hash_sender,
-            &poh_receiver,
-            &verified_receiver,
-            &entry_sender,
-        ).unwrap();
-
-        check_txs(&entry_receiver, tx);
+        for v in verified.chunks(verified.len() / NUM_THREADS) {
+            verified_sender.send(v.to_vec()).unwrap();
+        }
+        check_txs(&signal_receiver, txes);
+        bank.clear_signatures();
+        // make sure the transactions are still valid
+        bank.register_entry_id(&mint.last_id());
     });
 }

--- a/src/banking_stage.rs
+++ b/src/banking_stage.rs
@@ -15,20 +15,36 @@ use result::{Error, Result};
 use service::Service;
 use std::net::SocketAddr;
 use std::sync::atomic::AtomicUsize;
-use std::sync::mpsc::{channel, Receiver, RecvTimeoutError, Sender};
-use std::sync::Arc;
+use std::thread::sleep;
+use std::sync::mpsc::{channel, Receiver, RecvTimeoutError};
+use std::sync::{Arc, Mutex};
 use std::thread::{self, Builder, JoinHandle};
 use std::time::Duration;
 use std::time::Instant;
 use timing;
 use transaction::Transaction;
 
+pub const NUM_THREADS: usize = 10;
 /// Stores the stage's thread handle and output receiver.
 pub struct BankingStage {
     /// Handle to the stage's thread.
-    thread_hdl: JoinHandle<()>,
+    thread_hdls: Vec<JoinHandle<()>>,
+}
+ 
+pub enum Config {
+    /// * `Tick` - Run full PoH thread.  Tick is a rough estimate of how many hashes to roll before transmitting a new entry.
+    Tick(usize),
+    /// * `Sleep`- Low power mode.  Sleep is a rough estimate of how long to sleep before rolling 1 poh once and producing 1
+    /// tick.
+    Sleep(Duration),
 }
 
+impl Default for Config {
+    fn default() -> Config {
+        // TODO: Change this to Tick to enable PoH
+        Config::Sleep(Duration::from_millis(500))
+    }
+}
 impl BankingStage {
     /// Create the stage using `bank`. Exit when `verified_receiver` is dropped.
     /// Discard input packets using `packet_recycler` to minimize memory
@@ -36,49 +52,60 @@ impl BankingStage {
     pub fn new(
         bank: Arc<Bank>,
         verified_receiver: Receiver<Vec<(SharedPackets, Vec<u8>)>>,
-        tick_duration: Option<Duration>,
+        config: Config,
     ) -> (Self, Receiver<Vec<Entry>>) {
         let (entry_sender, entry_receiver) = channel();
-        let thread_hdl = Builder::new()
-            .name("solana-banking-stage".to_string())
-            .spawn(move || {
-                let poh_service = PohService::new(bank.last_id(), tick_duration.is_some());
+        let shared_verified_receiver = Arc::new(Mutex::new(verified_receiver));
+        let poh = PohService::new(bank.clone(), entry_sender);
+        let tick_poh = poh.clone();
 
-                let mut last_tick = Instant::now();
-
-                loop {
-                    let timeout =
-                        tick_duration.map(|duration| duration - (Instant::now() - last_tick));
-
-                    if let Err(e) = Self::process_packets(
-                        timeout,
-                        &bank,
-                        &poh_service,
-                        &verified_receiver,
-                        &entry_sender,
-                    ) {
-                        match e {
-                            Error::RecvTimeoutError(RecvTimeoutError::Disconnected) => break,
-                            Error::RecvTimeoutError(RecvTimeoutError::Timeout) => (),
-                            Error::RecvError(_) => break,
-                            Error::SendError => break,
-                            _ => {
-                                error!("process_packets() {:?}", e);
-                                break;
-                            }
-                        }
-                    }
-                    if tick_duration.is_some() && last_tick.elapsed() > tick_duration.unwrap() {
-                        if let Err(e) = Self::tick(&poh_service, &entry_sender) {
-                            error!("tick() {:?}", e);
-                        }
-                        last_tick = Instant::now();
+        // Single thread to generate entries from many banks.
+        // This thread talks to poh_service and broadcasts the entries once they have been recorded.
+        // Once an entry has been recorded, its last_id is registered with the bank.
+        let tick_producer = Builder::new()
+            .name("solana-banking-stage-tick_producer".to_string())
+            .spawn(move || 
+                if let Err(e) = Self::tick_producer(
+                   tick_poh,
+                   config,
+                ) {
+                    match e {
+                        Error::RecvError(_) => (),
+                        Error::SendError => (),
+                        _ => error!("solana-banking-stage-tick_producer unexpected error {:?}", e),
                     }
                 }
-                poh_service.join().unwrap();
-            }).unwrap();
-        (BankingStage { thread_hdl }, entry_receiver)
+            ).unwrap();
+
+        // Many banks that process transactions in parallel.
+        let mut thread_hdls: Vec<JoinHandle<()>> = (0..NUM_THREADS)
+            .into_iter()
+            .map(|_| {
+                let thread_bank = bank.clone();
+                let thread_verified_receiver = shared_verified_receiver.clone();
+                let thread_poh = poh.clone();
+                Builder::new()
+                    .name("solana-banking-stage-tx".to_string())
+                    .spawn(move || loop {
+                        if let Err(e) = Self::process_packets(
+                            &thread_bank,
+                            &thread_verified_receiver,
+                            &thread_poh,
+                        ) {
+                            match e {
+                                Error::RecvTimeoutError(RecvTimeoutError::Disconnected) => break,
+                                Error::RecvTimeoutError(RecvTimeoutError::Timeout) => (),
+                                Error::RecvError(_) => break,
+                                Error::SendError => break,
+                                _ => error!("solana-banking-stage-tx {:?}", e),
+                            }
+                        }
+                    }).unwrap()
+            }).collect();
+        thread_hdls.push(tick_producer);
+        (BankingStage { thread_hdls }, entry_receiver)
     }
+
 
     /// Convert the transactions from a blob of binary data to a vector of transactions and
     /// an unused `SocketAddr` that could be used to send a response.
@@ -92,26 +119,31 @@ impl BankingStage {
             }).collect()
     }
 
-    fn tick(poh_service: &PohService, entry_sender: &Sender<Vec<Entry>>) -> Result<()> {
-        let poh = poh_service.tick();
-        let entry = Entry {
-            num_hashes: poh.num_hashes,
-            id: poh.id,
-            transactions: vec![],
-        };
-        entry_sender.send(vec![entry])?;
-        Ok(())
+    fn tick_producer(
+        poh: PohService,
+        config: Config,
+    ) -> Result<()> {
+         loop {
+            match config {
+                Config::Tick(num) => {
+                    for _ in 0..num {
+                        poh.hash();
+                    }
+                }
+                Config::Sleep(duration) => {
+                    sleep(duration);
+                }
+            }
+            poh.tick()?;
+        } 
     }
 
     fn process_transactions(
         bank: &Arc<Bank>,
-        transactions: &[Transaction],
-        poh_service: &PohService,
-    ) -> Result<Vec<Entry>> {
-        let mut entries = Vec::new();
-
-        debug!("processing: {}", transactions.len());
-
+        transactions: Vec<Transaction>,
+        poh: &PohService,
+    ) -> Result<()> {
+        debug!("transactions: {}", transactions.len());
         let mut chunk_start = 0;
         while chunk_start != transactions.len() {
             let chunk_end = chunk_start + Entry::num_will_fit(&transactions[chunk_start..]);
@@ -133,46 +165,26 @@ impl BankingStage {
                     }
                 }).collect();
 
-            debug!("processed: {}", processed_transactions.len());
-
-            chunk_start = chunk_end;
-
-            let hash = hasher.result();
-
             if !processed_transactions.is_empty() {
-                let poh = poh_service.record(hash);
-
-                bank.register_entry_id(&poh.id);
-                entries.push(Entry {
-                    num_hashes: poh.num_hashes,
-                    id: poh.id,
-                    transactions: processed_transactions,
-                });
+                let hash = hasher.result();
+                debug!("processed ok: {} {}", processed_transactions.len(), hash);
+                poh.record(hash, processed_transactions)?;
             }
+            chunk_start = chunk_end;
         }
-
-        debug!("done process_transactions, {} entries", entries.len());
-
-        Ok(entries)
+        debug!("done process_transactions");
+        Ok(())
     }
 
     /// Process the incoming packets and send output `Signal` messages to `signal_sender`.
     /// Discard packets via `packet_recycler`.
     pub fn process_packets(
-        timeout: Option<Duration>,
         bank: &Arc<Bank>,
-        poh_service: &PohService,
-        verified_receiver: &Receiver<Vec<(SharedPackets, Vec<u8>)>>,
-        entry_sender: &Sender<Vec<Entry>>,
+        verified_receiver: &Arc<Mutex<Receiver<Vec<(SharedPackets, Vec<u8>)>>>>,
+        poh: &PohService,
     ) -> Result<()> {
         let recv_start = Instant::now();
-        // TODO pass deadline to recv_deadline() when/if it becomes available?
-        let mms = if let Some(timeout) = timeout {
-            verified_receiver.recv_timeout(timeout)?
-        } else {
-            verified_receiver.recv()?
-        };
-        let now = Instant::now();
+        let mms = verified_receiver.lock().unwrap().recv()?;
         let mut reqs_len = 0;
         let mms_len = mms.len();
         info!(
@@ -203,14 +215,12 @@ impl BankingStage {
                     },
                 }).collect();
             debug!("verified transactions {}", transactions.len());
-
-            let entries = Self::process_transactions(bank, &transactions, poh_service)?;
-            entry_sender.send(entries)?;
+            Self::process_transactions(bank, transactions, poh)?;
         }
 
         inc_new_counter_info!(
             "banking_stage-time_ms",
-            timing::duration_as_ms(&now.elapsed()) as usize
+            timing::duration_as_ms(&proc_start.elapsed()) as usize
         );
         let total_time_s = timing::duration_as_s(&proc_start.elapsed());
         let total_time_ms = timing::duration_as_ms(&proc_start.elapsed());
@@ -235,7 +245,10 @@ impl Service for BankingStage {
     type JoinReturnType = ();
 
     fn join(self) -> thread::Result<()> {
-        self.thread_hdl.join()
+        for thread_hdl in self.thread_hdls {
+            thread_hdl.join()?;
+        }
+        Ok(())
     }
 }
 
@@ -387,5 +400,4 @@ mod tests {
         }
         assert_eq!(bank.get_balance(&alice.pubkey()), 1);
     }
-
 }

--- a/src/fullnode.rs
+++ b/src/fullnode.rs
@@ -316,14 +316,11 @@ impl Fullnode {
             }
             None => {
                 // Start in leader mode.
-                let tick_duration = None;
-                // TODO: To light up PoH, uncomment the following line:
-                //let tick_duration = Some(Duration::from_millis(1000));
                 let (tpu, entry_receiver, tpu_exit) = Tpu::new(
                     keypair.clone(),
                     &bank,
                     &crdt,
-                    tick_duration,
+                    Default::default(),
                     node.sockets
                         .transaction
                         .iter()
@@ -430,14 +427,11 @@ impl Fullnode {
 
     fn validator_to_leader(&mut self, entry_height: u64) {
         self.crdt.write().unwrap().set_leader(self.keypair.pubkey());
-        let tick_duration = None;
-        // TODO: To light up PoH, uncomment the following line:
-        //let tick_duration = Some(Duration::from_millis(1000));
         let (tpu, blob_receiver, tpu_exit) = Tpu::new(
             self.keypair.clone(),
             &self.bank,
             &self.crdt,
-            tick_duration,
+            Default::default(),
             self.transaction_sockets
                 .iter()
                 .map(|s| s.try_clone().expect("Failed to clone transaction sockets"))

--- a/src/mint.rs
+++ b/src/mint.rs
@@ -74,8 +74,8 @@ mod tests {
     fn test_create_transactions() {
         let mut transactions = Mint::new(100).create_transactions().into_iter();
         let tx = transactions.next().unwrap();
-        assert!(SystemProgram::check_id(&tx.program_id));
-        let instruction: SystemProgram = deserialize(&tx.userdata).unwrap();
+        assert!(SystemProgram::check_id(tx.program_id(0)));
+        let instruction: SystemProgram = deserialize(&tx.programs[0].userdata).unwrap();
         if let SystemProgram::Move { tokens } = instruction {
             assert_eq!(tokens, 100);
         }

--- a/src/poh_service.rs
+++ b/src/poh_service.rs
@@ -9,16 +9,19 @@
 //! The resulting stream of Hashes represents ordered events in time.
 //!
 use hash::Hash;
-use poh::{Poh, PohEntry};
-use service::Service;
-use std::sync::atomic::{AtomicBool, Ordering};
+use poh::{Poh};
+use entry::Entry;
+use transaction::Transaction;
+use bank::Bank;
+use result::Result;
+use std::sync::mpsc::{Sender};
 use std::sync::{Arc, Mutex};
-use std::thread::{self, Builder, JoinHandle};
 
+#[derive(Clone)]
 pub struct PohService {
     poh: Arc<Mutex<Poh>>,
-    thread_hdl: JoinHandle<()>,
-    run_poh: Arc<AtomicBool>,
+    bank: Arc<Bank>,
+    sender: Sender<Vec<Entry>>,
 }
 
 impl PohService {
@@ -26,84 +29,50 @@ impl PohService {
     /// sending back Entry messages until either the receiver or sender channel is closed.
     /// if tick_duration is some, service will automatically produce entries every
     ///  `tick_duration`.
-    pub fn new(start_hash: Hash, run_poh: bool) -> Self {
-        let poh = Arc::new(Mutex::new(Poh::new(start_hash)));
-        let run_poh = Arc::new(AtomicBool::new(run_poh));
-
-        let thread_poh = poh.clone();
-        let thread_run_poh = run_poh.clone();
-        let thread_hdl = Builder::new()
-            .name("solana-record-service".to_string())
-            .spawn(move || {
-                while thread_run_poh.load(Ordering::Relaxed) {
-                    thread_poh.lock().unwrap().hash();
-                }
-            }).unwrap();
-
+    pub fn new(bank: Arc<Bank>, sender: Sender<Vec<Entry>>) -> Self {
+        let poh = Arc::new(Mutex::new(Poh::new(bank.last_id())));
         PohService {
             poh,
-            run_poh,
-            thread_hdl,
+            bank,
+            sender,
         }
     }
 
-    pub fn tick(&self) -> PohEntry {
+    pub fn hash(&self) {
+        // TODO: amortize the cost of this lock by doing the loop in here for
+        // some min amount of hashes
         let mut poh = self.poh.lock().unwrap();
-        poh.tick()
+        poh.hash()
+    }
+ 
+    pub fn tick(&self) -> Result<()> {
+        // Register and send the entry out while holding the lock.
+        // This guarantees PoH order and Entry production and banks LastId queue is the same
+        let mut poh = self.poh.lock().unwrap();
+        let tick = poh.tick();
+        self.bank.register_entry_id(&tick.id);
+        let entry = Entry {
+            num_hashes: tick.num_hashes,
+            id: tick.id,
+            transactions: vec![],
+        };   
+        self.sender.send(vec![entry])?; 
+        Ok(())
     }
 
-    pub fn record(&self, mixin: Hash) -> PohEntry {
+    pub fn record(&self, mixin: Hash, txs: Vec<Transaction>) -> Result<()> {
+        // Register and send the entry out while holding the lock.
+        // This guarantees PoH order and Entry production and banks LastId queue is the same.
         let mut poh = self.poh.lock().unwrap();
-        poh.record(mixin)
-    }
-
-    //    fn process_hash(
-    //        mixin: Option<Hash>,
-    //        poh: &mut Poh,
-    //        sender: &Sender<PohEntry>,
-    //    ) -> Result<(), ()> {
-    //        let resp = match mixin {
-    //            Some(mixin) => poh.record(mixin),
-    //            None => poh.tick(),
-    //        };
-    //        sender.send(resp).or(Err(()))?;
-    //        Ok(())
-    //    }
-    //
-    //    fn process_hashes(
-    //        poh: &mut Poh,
-    //        receiver: &Receiver<Option<Hash>>,
-    //        sender: &Sender<PohEntry>,
-    //    ) -> Result<(), ()> {
-    //        loop {
-    //            match receiver.recv() {
-    //                Ok(hash) => Self::process_hash(hash, poh, sender)?,
-    //                Err(RecvError) => return Err(()),
-    //            }
-    //        }
-    //    }
-    //
-    //    fn try_process_hashes(
-    //        poh: &mut Poh,
-    //        receiver: &Receiver<Option<Hash>>,
-    //        sender: &Sender<PohEntry>,
-    //    ) -> Result<(), ()> {
-    //        loop {
-    //            match receiver.try_recv() {
-    //                Ok(hash) => Self::process_hash(hash, poh, sender)?,
-    //                Err(TryRecvError::Empty) => return Ok(()),
-    //                Err(TryRecvError::Disconnected) => return Err(()),
-    //            };
-    //        }
-    //    }
-}
-
-impl Service for PohService {
-    type JoinReturnType = ();
-
-    fn join(self) -> thread::Result<()> {
-        self.run_poh.store(false, Ordering::Relaxed);
-        self.thread_hdl.join()
+        let tick = poh.record(mixin);
+        self.bank.register_entry_id(&tick.id);
+        let entry = Entry {
+            num_hashes: tick.num_hashes,
+            id: tick.id,
+            transactions: txs,
+        };   
+        self.sender.send(vec![entry])?; 
+        Ok(())
     }
 }
 

--- a/src/poh_service.rs
+++ b/src/poh_service.rs
@@ -8,14 +8,14 @@
 //!
 //! The resulting stream of Hashes represents ordered events in time.
 //!
-use hash::Hash;
-use poh::{Poh};
-use entry::Entry;
-use transaction::Transaction;
 use bank::Bank;
+use entry::Entry;
+use hash::Hash;
+use poh::Poh;
 use result::Result;
-use std::sync::mpsc::{Sender};
+use std::sync::mpsc::Sender;
 use std::sync::{Arc, Mutex};
+use transaction::Transaction;
 
 #[derive(Clone)]
 pub struct PohService {
@@ -31,11 +31,7 @@ impl PohService {
     ///  `tick_duration`.
     pub fn new(bank: Arc<Bank>, sender: Sender<Vec<Entry>>) -> Self {
         let poh = Arc::new(Mutex::new(Poh::new(bank.last_id())));
-        PohService {
-            poh,
-            bank,
-            sender,
-        }
+        PohService { poh, bank, sender }
     }
 
     pub fn hash(&self) {
@@ -44,7 +40,7 @@ impl PohService {
         let mut poh = self.poh.lock().unwrap();
         poh.hash()
     }
- 
+
     pub fn tick(&self) -> Result<()> {
         // Register and send the entry out while holding the lock.
         // This guarantees PoH order and Entry production and banks LastId queue is the same
@@ -55,8 +51,8 @@ impl PohService {
             num_hashes: tick.num_hashes,
             id: tick.id,
             transactions: vec![],
-        };   
-        self.sender.send(vec![entry])?; 
+        };
+        self.sender.send(vec![entry])?;
         Ok(())
     }
 
@@ -70,8 +66,8 @@ impl PohService {
             num_hashes: tick.num_hashes,
             id: tick.id,
             transactions: txs,
-        };   
-        self.sender.send(vec![entry])?; 
+        };
+        self.sender.send(vec![entry])?;
         Ok(())
     }
 }

--- a/src/storage_program.rs
+++ b/src/storage_program.rs
@@ -5,7 +5,6 @@
 use bank::Account;
 use bincode::deserialize;
 use signature::Pubkey;
-use transaction::Transaction;
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum StorageProgram {
@@ -27,12 +26,16 @@ impl StorageProgram {
         account.tokens
     }
 
-    pub fn process_transaction(tx: &Transaction, _accounts: &mut [Account]) {
-        let syscall: StorageProgram = deserialize(&tx.userdata).unwrap();
+    pub fn process_transaction(
+        _keys: &[&Pubkey],
+        _accounts: &mut [&mut Account],
+        userdata: &[u8],
+    ) -> Result<(), ()> {
+        let syscall: StorageProgram = deserialize(&userdata).unwrap();
         match syscall {
             StorageProgram::SubmitMiningProof { sha_state } => {
                 info!("Mining proof submitted with state {}", sha_state[0]);
-                return;
+                return Ok(());
             }
         }
     }

--- a/src/system_program.rs
+++ b/src/system_program.rs
@@ -2,11 +2,7 @@
 
 use bank::Account;
 use bincode::deserialize;
-use dynamic_program::DynamicProgram;
 use signature::Pubkey;
-use std::collections::HashMap;
-use std::sync::RwLock;
-use transaction::Transaction;
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum SystemProgram {
@@ -28,10 +24,11 @@ pub enum SystemProgram {
     /// * Transaction::keys[0] - source
     /// * Transaction::keys[1] - destination
     Move { tokens: i64 },
-    /// Load a program
-    /// program_id - id to associate this program
-    /// nanme - file path of the program to load
-    Load { program_id: Pubkey, name: String },
+    // TODO move this to the loader contract
+    // /// Load a program
+    // /// program_id - id to associate this program
+    // /// nanme - file path of the program to load
+    // Load { program_id: Pubkey, name: String },
 }
 
 pub const SYSTEM_PROGRAM_ID: [u8; 32] = [0u8; 32];
@@ -48,11 +45,11 @@ impl SystemProgram {
         account.tokens
     }
     pub fn process_transaction(
-        tx: &Transaction,
-        accounts: &mut [Account],
-        loaded_programs: &RwLock<HashMap<Pubkey, DynamicProgram>>,
-    ) {
-        if let Ok(syscall) = deserialize(&tx.userdata) {
+        _keys: &[&Pubkey],
+        accounts: &mut [&mut Account],
+        userdata: &[u8],
+    ) -> Result<(), ()> {
+        if let Ok(syscall) = deserialize(&userdata) {
             trace!("process_transaction: {:?}", syscall);
             match syscall {
                 SystemProgram::CreateAccount {
@@ -61,13 +58,15 @@ impl SystemProgram {
                     program_id,
                 } => {
                     if !Self::check_id(&accounts[0].program_id) {
-                        return;
+                        //TODO:  add system error codes
+                        return Ok(());
                     }
                     if space > 0
                         && (!accounts[1].userdata.is_empty()
                             || !Self::check_id(&accounts[1].program_id))
                     {
-                        return;
+                        //TODO:  add system error codes
+                        return Ok(());
                     }
                     accounts[0].tokens -= tokens;
                     accounts[1].tokens += tokens;
@@ -76,46 +75,65 @@ impl SystemProgram {
                 }
                 SystemProgram::Assign { program_id } => {
                     if !Self::check_id(&accounts[0].program_id) {
-                        return;
+                        //TODO:  add system error codes
+                        return Ok(());
                     }
                     accounts[0].program_id = program_id;
                 }
                 SystemProgram::Move { tokens } => {
-                    //bank should be verifying correctness
+                    // TODO: when signature sets are added, we need to check that keys[0] is the signer
+                    // bank should be verifying correctness
                     accounts[0].tokens -= tokens;
                     accounts[1].tokens += tokens;
-                }
-                SystemProgram::Load { program_id, name } => {
-                    let mut hashmap = loaded_programs.write().unwrap();
-                    hashmap.insert(program_id, DynamicProgram::new(name));
-                }
+                } // TODO:
+                  //1. move load into its own contract
+                  //2. It should operate with the default contract signature
+                  //3. client creates an account with system, and assigns it to the loader contract
+                  //4. client uploads the bytes
+                  //5. calls "Loader::mark_executable"
+                  //6. Dynamic transactions put the public key of the account used to laod the program into `Transaction::program_keys`
+                  // 7.  execute_transactions asks the loader to interpret the account userdata and call
+                  //SystemProgram::Load { program_id, name } => {
+                  //    let mut hashmap = loaded_programs.write().unwrap();
+                  //    hashmap.insert(program_id, DynamicProgram::new(name));
+                  //}
             }
         } else {
-            info!("Invalid transaction userdata: {:?}", tx.userdata);
+            info!("Invalid transaction userdata: {:?}", userdata);
         }
+        //TODO:  add system error codes
+        Ok(())
     }
 }
 #[cfg(test)]
 mod test {
     use bank::Account;
-    use bincode::serialize;
-    use dynamic_program::KeyedAccount;
     use hash::Hash;
     use signature::{Keypair, KeypairUtil, Pubkey};
-    use std::collections::HashMap;
-    use std::sync::RwLock;
-    use std::thread;
     use system_program::SystemProgram;
     use transaction::Transaction;
-
+    fn to_refs<'a, T>(keys: &'a [T]) -> Vec<&'a T> {
+        keys.iter().collect()
+    }
+    fn to_mut_refs<'a, T>(accounts: &'a mut [T]) -> Vec<&'a mut T> {
+        accounts.iter_mut().collect()
+    }
+    fn process_transaction(tx: &Transaction, accounts: &mut [Account]) {
+        assert!(
+            SystemProgram::process_transaction(
+                &to_refs(&tx.keys),
+                &mut to_mut_refs(accounts),
+                &tx.programs[0].userdata,
+            ).is_ok()
+        );
+    }
     #[test]
     fn test_create_noop() {
         let from = Keypair::new();
         let to = Keypair::new();
         let mut accounts = vec![Account::default(), Account::default()];
         let tx = Transaction::system_new(&from, to.pubkey(), 0, Hash::default());
-        let hash = RwLock::new(HashMap::new());
-        SystemProgram::process_transaction(&tx, &mut accounts, &hash);
+        process_transaction(&tx, &mut accounts);
         assert_eq!(accounts[0].tokens, 0);
         assert_eq!(accounts[1].tokens, 0);
     }
@@ -126,8 +144,7 @@ mod test {
         let mut accounts = vec![Account::default(), Account::default()];
         accounts[0].tokens = 1;
         let tx = Transaction::system_new(&from, to.pubkey(), 1, Hash::default());
-        let hash = RwLock::new(HashMap::new());
-        SystemProgram::process_transaction(&tx, &mut accounts, &hash);
+        process_transaction(&tx, &mut accounts);
         assert_eq!(accounts[0].tokens, 0);
         assert_eq!(accounts[1].tokens, 1);
     }
@@ -139,8 +156,7 @@ mod test {
         accounts[0].tokens = 1;
         accounts[0].program_id = from.pubkey();
         let tx = Transaction::system_new(&from, to.pubkey(), 1, Hash::default());
-        let hash = RwLock::new(HashMap::new());
-        SystemProgram::process_transaction(&tx, &mut accounts, &hash);
+        process_transaction(&tx, &mut accounts);
         assert_eq!(accounts[0].tokens, 1);
         assert_eq!(accounts[1].tokens, 0);
     }
@@ -151,8 +167,7 @@ mod test {
         let mut accounts = vec![Account::default(), Account::default()];
         let tx =
             Transaction::system_create(&from, to.pubkey(), Hash::default(), 0, 1, to.pubkey(), 0);
-        let hash = RwLock::new(HashMap::new());
-        SystemProgram::process_transaction(&tx, &mut accounts, &hash);
+        process_transaction(&tx, &mut accounts);
         assert!(accounts[0].userdata.is_empty());
         assert_eq!(accounts[1].userdata.len(), 1);
         assert_eq!(accounts[1].program_id, to.pubkey());
@@ -172,8 +187,7 @@ mod test {
             Pubkey::default(),
             0,
         );
-        let hash = RwLock::new(HashMap::new());
-        SystemProgram::process_transaction(&tx, &mut accounts, &hash);
+        process_transaction(&tx, &mut accounts);
         assert!(accounts[1].userdata.is_empty());
     }
     #[test]
@@ -191,8 +205,7 @@ mod test {
             Pubkey::default(),
             0,
         );
-        let hash = RwLock::new(HashMap::new());
-        SystemProgram::process_transaction(&tx, &mut accounts, &hash);
+        process_transaction(&tx, &mut accounts);
         assert!(accounts[1].userdata.is_empty());
     }
     #[test]
@@ -210,124 +223,123 @@ mod test {
             Pubkey::default(),
             0,
         );
-        let hash = RwLock::new(HashMap::new());
-        SystemProgram::process_transaction(&tx, &mut accounts, &hash);
+        process_transaction(&tx, &mut accounts);
         assert_eq!(accounts[1].userdata.len(), 3);
     }
-    #[test]
-    fn test_load_call() {
-        // first load the program
-        let loaded_programs = RwLock::new(HashMap::new());
-        {
-            let from = Keypair::new();
-            let mut accounts = vec![Account::default(), Account::default()];
-            let program_id = Pubkey::default(); // same program id for both
-            let tx = Transaction::system_load(
-                &from,
-                Hash::default(),
-                0,
-                program_id,
-                "move_funds".to_string(),
-            );
+    // TODO: move this to the laoder contract
+    //#[test]
+    //fn test_load_call() {
+    //    // first load the program
+    //    let loaded_programs = RwLock::new(HashMap::new());
+    //    {
+    //        let from = Keypair::new();
+    //        let mut accounts = vec![Account::default(), Account::default()];
+    //        let program_id = Pubkey::default(); // same program id for both
+    //        let tx = Transaction::system_load(
+    //            &from,
+    //            Hash::default(),
+    //            0,
+    //            program_id,
+    //            "move_funds".to_string(),
+    //        );
 
-            SystemProgram::process_transaction(&tx, &mut accounts, &loaded_programs);
-        }
-        // then call the program
-        {
-            let program_id = Pubkey::default(); // same program id for both
-            let keys = vec![Pubkey::default(), Pubkey::default()];
-            let mut accounts = vec![Account::default(), Account::default()];
-            accounts[0].tokens = 100;
-            accounts[1].tokens = 1;
-            let tokens: i64 = 100;
-            let data: Vec<u8> = serialize(&tokens).unwrap();
-            {
-                let hash = loaded_programs.write().unwrap();
-                match hash.get(&program_id) {
-                    Some(dp) => {
-                        let mut infos: Vec<_> = (&keys)
-                            .into_iter()
-                            .zip(&mut accounts)
-                            .map(|(key, account)| KeyedAccount { key, account })
-                            .collect();
+    //        SystemProgram::process_transaction(&tx, &mut accounts, &loaded_programs);
+    //    }
+    //    // then call the program
+    //    {
+    //        let program_id = Pubkey::default(); // same program id for both
+    //        let keys = vec![Pubkey::default(), Pubkey::default()];
+    //        let mut accounts = vec![Account::default(), Account::default()];
+    //        accounts[0].tokens = 100;
+    //        accounts[1].tokens = 1;
+    //        let tokens: i64 = 100;
+    //        let data: Vec<u8> = serialize(&tokens).unwrap();
+    //        {
+    //            let hash = loaded_programs.write().unwrap();
+    //            match hash.get(&program_id) {
+    //                Some(dp) => {
+    //                    let mut infos: Vec<_> = (&keys)
+    //                        .into_iter()
+    //                        .zip(&mut accounts)
+    //                        .map(|(key, account)| KeyedAccount { key, account })
+    //                        .collect();
 
-                        dp.call(&mut infos, &data);
-                    }
-                    None => panic!("failed to find program in hash"),
-                }
-            }
-            assert_eq!(0, accounts[0].tokens);
-            assert_eq!(101, accounts[1].tokens);
-        }
-    }
-    #[test]
-    fn test_load_call_many_threads() {
-        let num_threads = 42;
-        let num_iters = 100;
-        let mut threads = Vec::new();
-        for _t in 0..num_threads {
-            threads.push(thread::spawn(move || {
-                let _tid = thread::current().id();
-                for _i in 0..num_iters {
-                    // first load the program
-                    let loaded_programs = RwLock::new(HashMap::new());
-                    {
-                        let from = Keypair::new();
-                        let mut accounts = vec![Account::default(), Account::default()];
-                        let program_id = Pubkey::default(); // same program id for both
-                        let tx = Transaction::system_load(
-                            &from,
-                            Hash::default(),
-                            0,
-                            program_id,
-                            "move_funds".to_string(),
-                        );
+    //                    dp.call(&mut infos, &data);
+    //                }
+    //                None => panic!("failed to find program in hash"),
+    //            }
+    //        }
+    //        assert_eq!(0, accounts[0].tokens);
+    //        assert_eq!(101, accounts[1].tokens);
+    //    }
+    //}
+    //#[test]
+    //fn test_load_call_many_threads() {
+    //    let num_threads = 42;
+    //    let num_iters = 100;
+    //    let mut threads = Vec::new();
+    //    for _t in 0..num_threads {
+    //        threads.push(thread::spawn(move || {
+    //            let _tid = thread::current().id();
+    //            for _i in 0..num_iters {
+    //                // first load the program
+    //                let loaded_programs = RwLock::new(HashMap::new());
+    //                {
+    //                    let from = Keypair::new();
+    //                    let mut accounts = vec![Account::default(), Account::default()];
+    //                    let program_id = Pubkey::default(); // same program id for both
+    //                    let tx = Transaction::system_load(
+    //                        &from,
+    //                        Hash::default(),
+    //                        0,
+    //                        program_id,
+    //                        "move_funds".to_string(),
+    //                    );
 
-                        SystemProgram::process_transaction(&tx, &mut accounts, &loaded_programs);
-                    }
-                    // then call the program
-                    {
-                        let program_id = Pubkey::default(); // same program id for both
-                        let keys = vec![Pubkey::default(), Pubkey::default()];
-                        let mut accounts = vec![Account::default(), Account::default()];
-                        accounts[0].tokens = 100;
-                        accounts[1].tokens = 1;
-                        let tokens: i64 = 100;
-                        let data: Vec<u8> = serialize(&tokens).unwrap();
-                        {
-                            let hash = loaded_programs.write().unwrap();
-                            match hash.get(&program_id) {
-                                Some(dp) => {
-                                    let mut infos: Vec<_> = (&keys)
-                                        .into_iter()
-                                        .zip(&mut accounts)
-                                        .map(|(key, account)| KeyedAccount { key, account })
-                                        .collect();
+    //                    SystemProgram::process_transaction(&tx, &mut accounts, &loaded_programs);
+    //                }
+    //                // then call the program
+    //                {
+    //                    let program_id = Pubkey::default(); // same program id for both
+    //                    let keys = vec![Pubkey::default(), Pubkey::default()];
+    //                    let mut accounts = vec![Account::default(), Account::default()];
+    //                    accounts[0].tokens = 100;
+    //                    accounts[1].tokens = 1;
+    //                    let tokens: i64 = 100;
+    //                    let data: Vec<u8> = serialize(&tokens).unwrap();
+    //                    {
+    //                        let hash = loaded_programs.write().unwrap();
+    //                        match hash.get(&program_id) {
+    //                            Some(dp) => {
+    //                                let mut infos: Vec<_> = (&keys)
+    //                                    .into_iter()
+    //                                    .zip(&mut accounts)
+    //                                    .map(|(key, account)| KeyedAccount { key, account })
+    //                                    .collect();
 
-                                    dp.call(&mut infos, &data);
-                                }
-                                None => panic!("failed to find program in hash"),
-                            }
-                        }
-                        assert_eq!(0, accounts[0].tokens);
-                        assert_eq!(101, accounts[1].tokens);
-                    }
-                }
-            }));
-        }
+    //                                dp.call(&mut infos, &data);
+    //                            }
+    //                            None => panic!("failed to find program in hash"),
+    //                        }
+    //                    }
+    //                    assert_eq!(0, accounts[0].tokens);
+    //                    assert_eq!(101, accounts[1].tokens);
+    //                }
+    //            }
+    //        }));
+    //    }
 
-        for thread in threads {
-            thread.join().unwrap();
-        }
-    }
+    //    for thread in threads {
+    //        thread.join().unwrap();
+    //    }
+    //}
     #[test]
     fn test_create_assign() {
         let from = Keypair::new();
         let program = Keypair::new();
         let mut accounts = vec![Account::default()];
         let tx = Transaction::system_assign(&from, Hash::default(), program.pubkey(), 0);
-        let hash = RwLock::new(HashMap::new());
-        SystemProgram::process_transaction(&tx, &mut accounts, &hash);
+        process_transaction(&tx, &mut accounts);
         assert_eq!(accounts[0].program_id, program.pubkey());
     }
     #[test]
@@ -337,12 +349,12 @@ mod test {
         let mut accounts = vec![Account::default(), Account::default()];
         accounts[0].tokens = 1;
         let tx = Transaction::new(&from, to.pubkey(), 1, Hash::default());
-        let hash = RwLock::new(HashMap::new());
-        SystemProgram::process_transaction(&tx, &mut accounts, &hash);
+        process_transaction(&tx, &mut accounts);
         assert_eq!(accounts[0].tokens, 0);
         assert_eq!(accounts[1].tokens, 1);
     }
-    /// Detect binary changes in the serialized program userdata, which could have a downstream
+
+    /// Detect binary changes in the serialized program programs[0].userdata, which could have a downstream
     /// affect on SDKs and DApps
     #[test]
     fn test_sdk_serialize() {
@@ -361,7 +373,7 @@ mod test {
         );
 
         assert_eq!(
-            tx.userdata,
+            tx.programs[0].userdata,
             vec![
                 0, 0, 0, 0, 111, 0, 0, 0, 0, 0, 0, 0, 222, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0,
                 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
@@ -380,7 +392,7 @@ mod test {
         );
 
         assert_eq!(
-            tx.userdata,
+            tx.programs[0].userdata,
             vec![
                 0, 0, 0, 0, 111, 0, 0, 0, 0, 0, 0, 0, 222, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
@@ -395,7 +407,7 @@ mod test {
             0,
         );
         assert_eq!(
-            tx.userdata,
+            tx.programs[0].userdata,
             vec![
                 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                 0, 0, 0, 0, 0, 0, 0, 0
@@ -404,6 +416,9 @@ mod test {
 
         // Move
         let tx = Transaction::system_move(&keypair, keypair.pubkey(), 123, Hash::default(), 0);
-        assert_eq!(tx.userdata, vec![2, 0, 0, 0, 123, 0, 0, 0, 0, 0, 0, 0]);
+        assert_eq!(
+            tx.programs[0].userdata,
+            vec![2, 0, 0, 0, 123, 0, 0, 0, 0, 0, 0, 0]
+        );
     }
 }

--- a/src/thin_client.rs
+++ b/src/thin_client.rs
@@ -537,11 +537,11 @@ mod tests {
         let last_id = client.get_last_id();
 
         let mut tr2 = Transaction::new(&alice.keypair(), bob_pubkey, 501, last_id);
-        let mut instruction2 = deserialize(&tr2.userdata).unwrap();
+        let mut instruction2 = deserialize(&tr2.programs[0].userdata).unwrap();
         if let SystemProgram::Move { ref mut tokens } = instruction2 {
             *tokens = 502;
         }
-        tr2.userdata = serialize(&instruction2).unwrap();
+        tr2.programs[0].userdata = serialize(&instruction2).unwrap();
         let signature = client.transfer_signed(&tr2).unwrap();
         client.poll_for_signature(&signature).unwrap();
 

--- a/src/tpu.rs
+++ b/src/tpu.rs
@@ -26,7 +26,7 @@
 //! ```
 
 use bank::Bank;
-use banking_stage::BankingStage;
+use banking_stage::{self, BankingStage};
 use crdt::Crdt;
 use entry::Entry;
 use fetch_stage::FetchStage;
@@ -38,7 +38,6 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::Receiver;
 use std::sync::{Arc, RwLock};
 use std::thread;
-use std::time::Duration;
 use write_stage::{WriteStage, WriteStageReturnType};
 
 pub enum TpuReturnType {
@@ -58,7 +57,7 @@ impl Tpu {
         keypair: Arc<Keypair>,
         bank: &Arc<Bank>,
         crdt: &Arc<RwLock<Crdt>>,
-        tick_duration: Option<Duration>,
+        tick_duration: banking_stage::Config,
         transactions_sockets: Vec<UdpSocket>,
         ledger_path: &str,
         sigverify_disabled: bool,

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -15,6 +15,17 @@ pub const SIGNED_DATA_OFFSET: usize = size_of::<Signature>();
 pub const SIG_OFFSET: usize = 0;
 pub const PUB_KEY_OFFSET: usize = size_of::<Signature>() + size_of::<u64>();
 
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
+pub struct Program {
+    /// The program code that executes this transaction is identified by the program_id.
+    /// this is an offset into the Transaction::keys field
+    pub program_id: u8,
+    /// Indecies into the keys array of which accounts to load
+    pub accounts: Vec<u8>,
+    /// Userdata to be stored in the account
+    pub userdata: Vec<u8>,
+}
+
 /// An instruction signed by a client with `Pubkey`.
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub struct Transaction {
@@ -28,20 +39,47 @@ pub struct Transaction {
     /// * keys[1] - Typically this is the program context or the recipient of the tokens
     pub keys: Vec<Pubkey>,
 
-    /// The program code that executes this transaction is identified by the program_id.
-    pub program_id: Pubkey,
-
     /// The ID of a recent ledger entry.
     pub last_id: Hash,
 
     /// The number of tokens paid for processing and storage of this transaction.
     pub fee: i64,
 
-    /// Userdata to be stored in the account
-    pub userdata: Vec<u8>,
+    /// program
+    pub program_keys: Vec<Pubkey>,
+    pub programs: Vec<Program>,
 }
 
 impl Transaction {
+    /// Create a signed transaction from the given `Program` vector.
+    /// * `from_keypair` - The key used to sign the transaction.  This key is stored as keys[0]
+    /// * `transaction_keys` - The keys for the transaction.  These are the program state
+    ///    instances or token recipient keys.
+    /// * `last_id` - The PoH hash.
+    /// * `fee` - The transaction fee.
+    /// * `programs` - The programs and their arguments that the transaction will execute atomically
+    pub fn new_with_programs(
+        from_keypair: &Keypair,
+        transaction_keys: &[Pubkey],
+        last_id: Hash,
+        fee: i64,
+        program_keys: &[Pubkey],
+        programs: Vec<Program>,
+    ) -> Self {
+        let from = from_keypair.pubkey();
+        let mut keys = vec![from];
+        keys.extend_from_slice(transaction_keys);
+        let mut tx = Transaction {
+            signature: Signature::default(),
+            keys,
+            last_id,
+            fee,
+            program_keys: program_keys.to_vec(),
+            programs,
+        };
+        tx.sign(from_keypair);
+        tx
+    }
     /// Create a signed transaction from the given `Instruction`.
     /// * `from_keypair` - The key used to sign the transaction.  This key is stored as keys[0]
     /// * `transaction_keys` - The keys for the transaction.  These are the program state
@@ -57,19 +95,21 @@ impl Transaction {
         last_id: Hash,
         fee: i64,
     ) -> Self {
-        let from = from_keypair.pubkey();
-        let mut keys = vec![from];
-        keys.extend_from_slice(transaction_keys);
-        let mut tx = Transaction {
-            signature: Signature::default(),
-            keys,
-            program_id,
+        let len = transaction_keys.len() + 1; //+1 for from
+        let program_keys = [program_id];
+        let programs = vec![Program {
+            program_id: 0 as u8,
+            userdata,
+            accounts: (0..len).into_iter().map(|x| x as u8).collect(),
+        }];
+        Self::new_with_programs(
+            from_keypair,
+            transaction_keys,
             last_id,
             fee,
-            userdata,
-        };
-        tx.sign(from_keypair);
-        tx
+            &program_keys,
+            programs,
+        )
     }
     /// Create and sign a new Transaction. Used for unit-testing.
     pub fn budget_new_taxed(
@@ -99,6 +139,10 @@ impl Transaction {
     /// Create and sign a new Transaction. Used for unit-testing.
     pub fn budget_new(from_keypair: &Keypair, to: Pubkey, tokens: i64, last_id: Hash) -> Self {
         Self::budget_new_taxed(from_keypair, to, tokens, 0, last_id)
+    }
+
+    pub fn program_id(&self, program_ix: usize) -> &Pubkey {
+        &self.program_keys[self.programs[program_ix].program_id as usize]
     }
 
     /// Create and sign a new Witness Timestamp. Used for unit-testing.
@@ -268,24 +312,25 @@ impl Transaction {
             fee,
         )
     }
-    /// Create and sign new SystemProgram::Load transaction
-    pub fn system_load(
-        from_keypair: &Keypair,
-        last_id: Hash,
-        fee: i64,
-        program_id: Pubkey,
-        name: String,
-    ) -> Self {
-        let load = SystemProgram::Load { program_id, name };
-        Transaction::new_with_userdata(
-            from_keypair,
-            &[],
-            SystemProgram::id(),
-            serialize(&load).unwrap(),
-            last_id,
-            fee,
-        )
-    }
+    // TODO: see system_program notes for Load
+    // /// Create and sign new SystemProgram::Load transaction
+    // pub fn system_load(
+    //     from_keypair: &Keypair,
+    //     last_id: Hash,
+    //     fee: i64,
+    //     program_id: Pubkey,
+    //     name: String,
+    // ) -> Self {
+    //     let load = SystemProgram::Load { program_id, name };
+    //     Transaction::new_with_userdata(
+    //         from_keypair,
+    //         &[],
+    //         SystemProgram::id(),
+    //         serialize(&load).unwrap(),
+    //         last_id,
+    //         fee,
+    //     )
+    // }
     /// Create and sign new SystemProgram::Move transaction
     pub fn new(from_keypair: &Keypair, to: Pubkey, tokens: i64, last_id: Hash) -> Self {
         Transaction::system_move(from_keypair, to, tokens, last_id, 0)
@@ -294,17 +339,17 @@ impl Transaction {
     fn get_sign_data(&self) -> Vec<u8> {
         let mut data = serialize(&(&self.keys)).expect("serialize keys");
 
-        let program_id = serialize(&(&self.program_id)).expect("serialize program_id");
-        data.extend_from_slice(&program_id);
-
         let last_id_data = serialize(&(&self.last_id)).expect("serialize last_id");
         data.extend_from_slice(&last_id_data);
 
         let fee_data = serialize(&(&self.fee)).expect("serialize last_id");
         data.extend_from_slice(&fee_data);
 
-        let userdata = serialize(&(&self.userdata)).expect("serialize userdata");
-        data.extend_from_slice(&userdata);
+        let program_keys = serialize(&(&self.program_keys)).expect("serialize program_keys");
+        data.extend_from_slice(&program_keys);
+
+        let programs = serialize(&(&self.programs)).expect("serialize programs");
+        data.extend_from_slice(&programs);
         data
     }
 
@@ -332,7 +377,9 @@ impl Transaction {
         &self.keys[0]
     }
     pub fn instruction(&self) -> Option<Instruction> {
-        deserialize(&self.userdata).ok()
+        self.programs
+            .get(0)
+            .and_then(|p| deserialize(&p.userdata).ok())
     }
     /// Verify only the payment plan.
     pub fn verify_plan(&self) -> bool {
@@ -416,13 +463,18 @@ mod tests {
         });
         let instruction = Instruction::NewContract(Contract { budget, tokens: 0 });
         let userdata = serialize(&instruction).unwrap();
+        let programs = vec![Program {
+            program_id: 0,
+            userdata,
+            accounts: vec![],
+        }];
         let claim0 = Transaction {
             keys: vec![],
             last_id: Default::default(),
             signature: Default::default(),
-            program_id: Default::default(),
+            program_keys: vec![],
+            programs,
             fee: 0,
-            userdata,
         };
         let buf = serialize(&claim0).unwrap();
         let claim1: Transaction = deserialize(&buf).unwrap();
@@ -442,7 +494,7 @@ mod tests {
                 payment.tokens = contract.tokens; // <-- attack, part 2!
             }
         }
-        tx.userdata = serialize(&instruction).unwrap();
+        tx.programs[0].userdata = serialize(&instruction).unwrap();
         assert!(tx.verify_plan());
         assert!(!tx.verify_signature());
     }
@@ -461,9 +513,14 @@ mod tests {
                 payment.to = thief_keypair.pubkey(); // <-- attack!
             }
         }
-        tx.userdata = serialize(&instruction).unwrap();
+        tx.programs[0].userdata = serialize(&instruction).unwrap();
         assert!(tx.verify_plan());
         assert!(!tx.verify_signature());
+    }
+    #[test]
+    fn test_program_id() {
+        let tx = test_tx();
+        assert_eq!(*tx.program_id(0), SystemProgram::id());
     }
     #[test]
     fn test_layout() {
@@ -481,7 +538,7 @@ mod tests {
     #[test]
     fn test_userdata_layout() {
         let mut tx0 = test_tx();
-        tx0.userdata = vec![1, 2, 3];
+        tx0.programs[0].userdata = vec![1, 2, 3];
         let sign_data0a = tx0.get_sign_data();
         let tx_bytes = serialize(&tx0).unwrap();
         assert!(tx_bytes.len() < PACKET_DATA_SIZE);
@@ -496,9 +553,9 @@ mod tests {
         );
         let tx1 = deserialize(&tx_bytes).unwrap();
         assert_eq!(tx0, tx1);
-        assert_eq!(tx1.userdata, vec![1, 2, 3]);
+        assert_eq!(tx1.programs[0].userdata, vec![1, 2, 3]);
 
-        tx0.userdata = vec![1, 2, 4];
+        tx0.programs[0].userdata = vec![1, 2, 4];
         let sign_data0b = tx0.get_sign_data();
         assert_ne!(sign_data0a, sign_data0b);
     }
@@ -515,7 +572,7 @@ mod tests {
                 payment.tokens = 2; // <-- attack!
             }
         }
-        tx.userdata = serialize(&instruction).unwrap();
+        tx.programs[0].userdata = serialize(&instruction).unwrap();
         assert!(!tx.verify_plan());
 
         // Also, ensure all branchs of the plan spend all tokens
@@ -525,7 +582,7 @@ mod tests {
                 payment.tokens = 0; // <-- whoops!
             }
         }
-        tx.userdata = serialize(&instruction).unwrap();
+        tx.programs[0].userdata = serialize(&instruction).unwrap();
         assert!(!tx.verify_plan());
     }
 
@@ -555,18 +612,19 @@ mod tests {
         assert_eq!(
             serialize(&tx).unwrap(),
             vec![
-                88, 1, 212, 176, 31, 197, 35, 156, 135, 24, 30, 57, 204, 253, 224, 28, 89, 189, 53,
-                64, 27, 148, 42, 199, 43, 236, 85, 182, 150, 64, 96, 53, 255, 235, 90, 197, 228, 6,
-                105, 22, 140, 209, 206, 221, 85, 117, 125, 126, 11, 1, 176, 130, 57, 236, 7, 155,
-                127, 58, 130, 92, 230, 219, 254, 0, 3, 0, 0, 0, 0, 0, 0, 0, 32, 253, 186, 201, 177,
-                11, 117, 135, 187, 167, 181, 188, 22, 59, 206, 105, 231, 150, 215, 30, 78, 212, 76,
-                16, 252, 180, 72, 134, 137, 247, 161, 68, 32, 253, 186, 201, 177, 11, 117, 135,
-                187, 167, 181, 188, 22, 59, 206, 105, 231, 150, 215, 30, 78, 212, 76, 16, 252, 180,
-                72, 134, 137, 247, 161, 68, 1, 1, 1, 4, 5, 6, 7, 8, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9,
-                9, 9, 9, 9, 9, 9, 8, 7, 6, 5, 4, 1, 1, 1, 2, 2, 2, 4, 5, 6, 7, 8, 9, 1, 1, 1, 1, 1,
-                1, 1, 1, 1, 1, 1, 1, 1, 1, 9, 8, 7, 6, 5, 4, 2, 2, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 99, 0, 0, 0, 0,
-                0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3
+                234, 139, 34, 5, 120, 28, 107, 203, 69, 25, 236, 200, 164, 1, 12, 47, 147, 53, 41,
+                143, 23, 116, 230, 203, 59, 228, 153, 14, 22, 241, 103, 226, 186, 169, 181, 65, 49,
+                215, 44, 2, 61, 214, 113, 216, 184, 206, 147, 104, 140, 225, 138, 21, 172, 135,
+                211, 80, 103, 80, 216, 106, 249, 86, 194, 1, 3, 0, 0, 0, 0, 0, 0, 0, 32, 253, 186,
+                201, 177, 11, 117, 135, 187, 167, 181, 188, 22, 59, 206, 105, 231, 150, 215, 30,
+                78, 212, 76, 16, 252, 180, 72, 134, 137, 247, 161, 68, 32, 253, 186, 201, 177, 11,
+                117, 135, 187, 167, 181, 188, 22, 59, 206, 105, 231, 150, 215, 30, 78, 212, 76, 16,
+                252, 180, 72, 134, 137, 247, 161, 68, 1, 1, 1, 4, 5, 6, 7, 8, 9, 9, 9, 9, 9, 9, 9,
+                9, 9, 9, 9, 9, 9, 9, 9, 9, 8, 7, 6, 5, 4, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 99, 0, 0, 0, 0, 0,
+                0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 2, 2, 2, 4, 5, 6, 7, 8, 9, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+                1, 1, 1, 1, 1, 9, 8, 7, 6, 5, 4, 2, 2, 2, 1, 0, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0,
+                0, 0, 0, 0, 1, 2, 3, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3
             ],
         );
     }


### PR DESCRIPTION
* Make bank transaction processing MT safe.  This also fixed a bug where a multiple spend within a batch was generating extra tokens :)
* Allow for transactions to send multiple programs that will execute as one atomic operation
* The above required a change to the transaction encoding and the ABI between the bank and the programs.  (@garious there is an unsafe call to create a subset of mutable references that I couldn't find a way around https://github.com/solana-labs/solana/pull/1309/files#diff-7145777648f8c12caeb15b4e1755215cR438)
* Store error codes for signatures

@garious @mvines before i rebase, let me know if this covers all the things we talked about last week.  i know its a lot of changes but it all came together really well.  Take a look at the new bank tests (https://github.com/solana-labs/solana/pull/1309/files#diff-7145777648f8c12caeb15b4e1755215cR872), that should showcase the improvements.  Also, how do i update the sdk golden image tests?  A big TODO is to pass multiple signatures in the TX, ill need some help from @sakridge with changing the cuda to support that

So main reason why it all came together in one change was that to fix the bug and still allow for context free contract execution the accounts need to be "locked" while they are being changed in the bank's pipeline.  which means that spending from 1 to many would be bottlenecked by a single transaction thats in the pipeline.

The batching implementation is most of #1293, the main differences are
1. keep the signed data in the transaction data
2. use a program_keys vector in the Transaction
3. use old names to reduce churn in other parts of the codebase

1 and 3 can be addressed later.  For 2, this allows us to pack more things into one transaction.  The reason why they are not stored as "keys" is because the engine doesn't distinguish RO from RW accounts in the transaction.

Bench results (mac)
* bench_banking_stage_multi_programs ... bench:  28,720,294 ns/iter (+/- 9,772,506)
* bench_banking_stage_multi_accounts ... bench:  13,838,541 ns/iter (+/- 8,367,130)

Multi programs process about `8*1024*5` programs per iteration (5 per tx that are spent atomically).  700ns per program.
Multi accounts processes `8*1024` transactions.  1.6us per atomic transaction

@rob-solana
Poh service is the entry generator and also what drives last_id registration into the bank.
https://github.com/solana-labs/solana/pull/1309/files#diff-a731213f65ed3e3b9e6129eb03dc9efeR121
There is a race between the entry output, and last_id's in the bank.  The last_id queue has to move in lockstep with whats in the "ledger", which is the Entry output.  With multiple threads driving the bank the output and updates to LastId queue need to be linearized.