### PR TITLE
Fix test_replicator_startup failures

### DIFF
--- a/src/fullnode.rs
+++ b/src/fullnode.rs
@@ -522,7 +522,7 @@ mod tests {
     fn validator_exit() {
         let keypair = Keypair::new();
         let tn = Node::new_localhost_with_pubkey(keypair.pubkey());
-        let (alice, validator_ledger_path) = genesis("validator_exit", 10_000);
+        let (alice, validator_ledger_path, _) = genesis("validator_exit", 10_000);
         let bank = Bank::new(&alice);
         let entry = tn.info.clone();
         let v = Fullnode::new_with_bank(
@@ -547,7 +547,7 @@ mod tests {
             .map(|i| {
                 let keypair = Keypair::new();
                 let tn = Node::new_localhost_with_pubkey(keypair.pubkey());
-                let (alice, validator_ledger_path) =
+                let (alice, validator_ledger_path, _) =
                     genesis(&format!("validator_parallel_exit_{}", i), 10_000);
                 ledger_paths.push(validator_ledger_path.clone());
                 let bank = Bank::new(&alice);

--- a/src/write_stage.rs
+++ b/src/write_stage.rs
@@ -342,7 +342,7 @@ mod tests {
         let bank = Arc::new(bank);
 
         // Make a ledger
-        let (_, leader_ledger_path) = genesis("test_leader_rotation_exit", 10_000);
+        let (_, leader_ledger_path, _) = genesis("test_leader_rotation_exit", 10_000);
 
         let (entry_height, ledger_tail) = process_ledger(&leader_ledger_path, &bank);
 


### PR DESCRIPTION
The entry height was set to zero, so the replicator had to wait for repairs to get the first 2 genesis entries before the window could progress and write anything to the ledger. Occasionally, the test would check for its win condition before this repair could happen (if the test was unlucky with the repair_backoff()) . We now start with the genesis entries already in place in the replicator ledger to prevent the need for repairs, which allows the replicator to write the first new entry to the ledger immediately upon receiving it.

In reference to: https://github.com/solana-labs/solana/issues/1315