### PR TITLE
Pass Bank::process_transactions() a reference instead of moving

### DIFF
--- a/src/bank.rs
+++ b/src/bank.rs
@@ -503,7 +503,7 @@ impl Bank {
         res
     }
 
-    pub fn process_entry(&self, entry: Entry) -> Result<()> {
+    pub fn process_entry(&self, entry: &Entry) -> Result<()> {
         if !entry.transactions.is_empty() {
             for result in self.process_transactions(&entry.transactions) {
                 result?;
@@ -532,16 +532,16 @@ impl Bank {
             *tail_idx = (*tail_idx + 1) % WINDOW_SIZE as usize;
 
             entry_count += 1;
-            self.process_entry(entry)?;
+            self.process_entry(&entry)?;
         }
 
         Ok(entry_count)
     }
 
     /// Process an ordered list of entries.
-    pub fn process_entries(&self, entries: Vec<Entry>) -> Result<()> {
+    pub fn process_entries(&self, entries: &[Entry]) -> Result<()> {
         for entry in entries {
-            self.process_entry(entry)?;
+            self.process_entry(&entry)?;
         }
         Ok(())
     }
@@ -915,7 +915,7 @@ mod tests {
         );
 
         // Now ensure the TX is accepted despite pointing to the ID of an empty entry.
-        bank.process_entries(vec![entry]).unwrap();
+        bank.process_entries(&[entry]).unwrap();
         assert!(bank.process_transaction(&tx).is_ok());
     }
 

--- a/src/bin/ledger-tool.rs
+++ b/src/bin/ledger-tool.rs
@@ -122,7 +122,7 @@ fn main() {
                 if i >= head {
                     break;
                 }
-                if let Err(e) = bank.process_entry(entry) {
+                if let Err(e) = bank.process_entry(&entry) {
                     eprintln!("verify failed at entry[{}], err: {:?}", i + 2, e);
                     exit(1);
                 }

--- a/src/broadcast_stage.rs
+++ b/src/broadcast_stage.rs
@@ -80,7 +80,7 @@ fn broadcast(
         {
             let mut win = window.write().unwrap();
             assert!(blobs.len() <= win.len());
-            for b in blobs.iter() {
+            for b in &blobs {
                 let ix = b.read().get_index().expect("blob index");
                 let pos = (ix % WINDOW_SIZE) as usize;
                 if let Some(x) = win[pos].data.take() {
@@ -92,7 +92,7 @@ fn broadcast(
 
                 trace!("{} null {}", id, pos);
             }
-            for b in blobs.iter() {
+            for b in &blobs {
                 let ix = b.read().get_index().expect("blob index");
                 let pos = (ix % WINDOW_SIZE) as usize;
                 trace!("{} caching {} at {}", id, ix, pos);

--- a/src/crdt.rs
+++ b/src/crdt.rs
@@ -326,7 +326,7 @@ impl Crdt {
     // TODO: Dummy leader scheduler, need to implement actual leader scheduling.
     pub fn get_scheduled_leader(&self, entry_height: u64) -> Option<Pubkey> {
         match self.scheduled_leaders.get(&entry_height) {
-            Some(x) => Some(x.clone()),
+            Some(x) => Some(*x),
             None => Some(self.my_data().leader_id),
         }
     }

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -107,8 +107,8 @@ impl Entry {
             <= BLOB_DATA_SIZE as u64
     }
 
-    pub fn num_will_fit(transactions: Vec<Transaction>) -> usize {
-        if transactions.len() == 0 {
+    pub fn num_will_fit(transactions: &[Transaction]) -> usize {
+        if transactions.is_empty() {
             return 0;
         }
         let mut num = transactions.len();
@@ -196,7 +196,7 @@ impl Entry {
 /// the signature.  If num_hashes is zero and there's no transaction data,
 ///  start_hash is returned.
 fn next_hash(start_hash: &Hash, num_hashes: u64, transactions: &[Transaction]) -> Hash {
-    if num_hashes == 0 && transactions.len() == 0 {
+    if num_hashes == 0 && transactions.is_empty() {
         return *start_hash;
     }
 

--- a/src/fullnode.rs
+++ b/src/fullnode.rs
@@ -386,7 +386,7 @@ impl Fullnode {
 
         // Make a new RPU to serve requests out of the new bank we've created
         // instead of the old one
-        if !self.rpu.is_none() {
+        if self.rpu.is_some() {
             let old_rpu = self.rpu.take().unwrap();
             old_rpu.close()?;
             self.rpu = Some(Rpu::new(

--- a/src/replicate_stage.rs
+++ b/src/replicate_stage.rs
@@ -40,7 +40,7 @@ impl ReplicateStage {
             entries.append(&mut more);
         }
 
-        let res = bank.process_entries(entries.clone());
+        let res = bank.process_entries(&entries);
 
         {
             let mut wcrdt = crdt.write().unwrap();

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -211,7 +211,7 @@ impl JsonRpcRequestProcessor {
     fn get_account_info(&self, pubkey: Pubkey) -> Result<Account> {
         self.bank
             .get_account(&pubkey)
-            .ok_or(Error::invalid_request())
+            .ok_or_else(Error::invalid_request)
     }
     fn get_balance(&self, pubkey: Pubkey) -> Result<i64> {
         let val = self.bank.get_balance(&pubkey);


### PR DESCRIPTION
When we move the transaction from input to `Result<Transaction>`, we lose the ability to reference the original transaction in the error case. Our choices are to populate the error structures with more data (specifically, the Signature) or change these functions to borrow the transaction. This PR chooses the latter. Not certain that's the right choice. Thoughts?

This PR is a WIP because it breaks the integration tests. Need to debug...