### PR TITLE
Execute Budget Contracts via Wallet CLI

### DIFF
--- a/rfcs/rfc-006-budget-contract-language.md
+++ b/rfcs/rfc-006-budget-contract-language.md
@@ -12,7 +12,8 @@ $ solana-wallet [common-options] [command] [command-specific options]
 `command` variants:
 * `pay`
 * `cancel`
-* `apply`
+* `send-signature`
+* `send-timestamp`
 
 #### Unconditional Immediate Transfer
 ```sh
@@ -27,7 +28,7 @@ $ solana-wallet pay <PUBKEY> 123
 ```sh
 // Command
 $ solana-wallet pay <PUBKEY> 123 \
-    --after 2018-12-24T23:59 --require-timestamp-from <PUBKEY>
+    --after 2018-12-24T23:59:00 --require-timestamp-from <PUBKEY>
 
 // Return
 {signature: <TX_SIGNATURE>, processId: <PROCESS_ID>}
@@ -90,7 +91,7 @@ $ solana-wallet cancel <PROCESS_ID>
 #### Send Signature
 ```sh
 // Command
-$ solana-wallet send-signature <PROCESS_ID>
+$ solana-wallet send-signature <PUBKEY> <PROCESS_ID>
 
 // Return
 <TX_SIGNATURE>
@@ -101,7 +102,7 @@ $ solana-wallet send-signature <PROCESS_ID>
 Use the current system time:
 ```sh
 // Command
-$ solana-wallet send-timestamp <PROCESS_ID>
+$ solana-wallet send-timestamp <PUBKEY> <PROCESS_ID>
 
 // Return
 <TX_SIGNATURE>
@@ -110,7 +111,7 @@ $ solana-wallet send-timestamp <PROCESS_ID>
 Or specify some other arbitrary timestamp:
 ```sh
 // Command
-$ solana-wallet send-timestamp <PROCESS_ID> --date 2018-12-24T23:59
+$ solana-wallet send-timestamp <PUBKEY> <PROCESS_ID> --date 2018-12-24T23:59:00
 
 // Return
 <TX_SIGNATURE>

--- a/scripts/wallet-sanity.sh
+++ b/scripts/wallet-sanity.sh
@@ -35,11 +35,11 @@ pay_and_confirm() {
 
 $solana_wallet "${entrypoint[@]}" address
 check_balance_output "No account found" "Your balance is: 0"
-$solana_wallet "${entrypoint[@]}" airdrop --tokens 60
+$solana_wallet "${entrypoint[@]}" airdrop 60
 check_balance_output "Your balance is: 60"
-$solana_wallet "${entrypoint[@]}" airdrop --tokens 40
+$solana_wallet "${entrypoint[@]}" airdrop 40
 check_balance_output "Your balance is: 100"
-pay_and_confirm --to $garbage_address --tokens 99
+pay_and_confirm $garbage_address 99
 check_balance_output "Your balance is: 1"
 
 echo PASS

--- a/src/bin/wallet.rs
+++ b/src/bin/wallet.rs
@@ -208,8 +208,15 @@ fn main() -> Result<(), Box<error::Error>> {
             SubCommand::with_name("send-timestamp")
                 .about("Send a timestamp to unlock a transfer")
                 .arg(
-                    Arg::with_name("process-id")
+                    Arg::with_name("to")
                         .index(1)
+                        .value_name("PUBKEY")
+                        .takes_value(true)
+                        .required(true)
+                        .help("The pubkey of recipient"),
+                ).arg(
+                    Arg::with_name("process-id")
+                        .index(2)
                         .value_name("PROCESS_ID")
                         .takes_value(true)
                         .required(true)

--- a/src/bin/wallet.rs
+++ b/src/bin/wallet.rs
@@ -189,10 +189,9 @@ fn main() -> Result<(), Box<error::Error>> {
                         .use_delimiter(true)
                         .help("Any third party signatures required to unlock the tokens"),
                 ).arg(
-                    Arg::with_name("cancellable")
-                        .long("cancellable")
-                        .takes_value(false)
-                        .requires("witness"),
+                    Arg::with_name("cancelable")
+                        .long("cancelable")
+                        .takes_value(false),
                 ),
         ).subcommand(
             SubCommand::with_name("send-signature")

--- a/src/bin/wallet.rs
+++ b/src/bin/wallet.rs
@@ -197,8 +197,15 @@ fn main() -> Result<(), Box<error::Error>> {
             SubCommand::with_name("send-signature")
                 .about("Send a signature to authorize a transfer")
                 .arg(
-                    Arg::with_name("process-id")
+                    Arg::with_name("to")
                         .index(1)
+                        .value_name("PUBKEY")
+                        .takes_value(true)
+                        .required(true)
+                        .help("The pubkey of recipient"),
+                ).arg(
+                    Arg::with_name("process-id")
+                        .index(2)
                         .value_name("PROCESS_ID")
                         .takes_value(true)
                         .required(true)

--- a/src/bin/wallet.rs
+++ b/src/bin/wallet.rs
@@ -115,47 +115,114 @@ fn main() -> Result<(), Box<error::Error>> {
                 .value_name("URL")
                 .help("Address of TLS proxy")
                 .conflicts_with("rpc-port")
-        ).subcommand(
+        ).subcommand(SubCommand::with_name("address").about("Get your public key"))
+        .subcommand(
             SubCommand::with_name("airdrop")
                 .about("Request a batch of tokens")
                 .arg(
                     Arg::with_name("tokens")
-                        .long("tokens")
+                        .index(1)
                         .value_name("NUM")
                         .takes_value(true)
                         .required(true)
                         .help("The number of tokens to request"),
                 ),
+        ).subcommand(SubCommand::with_name("balance").about("Get your balance"))
+        .subcommand(
+            SubCommand::with_name("cancel")
+                .about("Cancel a transfer")
+                .arg(
+                    Arg::with_name("process-id")
+                        .index(1)
+                        .value_name("PROCESS_ID")
+                        .takes_value(true)
+                        .required(true)
+                        .help("The process id of the transfer to cancel"),
+                ),
+        ).subcommand(
+            SubCommand::with_name("confirm")
+                .about("Confirm transaction by signature")
+                .arg(
+                    Arg::with_name("signature")
+                        .index(1)
+                        .value_name("SIGNATURE")
+                        .takes_value(true)
+                        .required(true)
+                        .help("The transaction signature to confirm"),
+                ),
         ).subcommand(
             SubCommand::with_name("pay")
                 .about("Send a payment")
                 .arg(
+                    Arg::with_name("to")
+                        .index(1)
+                        .value_name("PUBKEY")
+                        .takes_value(true)
+                        .required(true)
+                        .help("The pubkey of recipient"),
+                ).arg(
                     Arg::with_name("tokens")
-                        .long("tokens")
+                        .index(2)
                         .value_name("NUM")
                         .takes_value(true)
                         .required(true)
                         .help("The number of tokens to send"),
                 ).arg(
-                    Arg::with_name("to")
-                        .long("to")
+                    Arg::with_name("timestamp")
+                        .long("after")
+                        .value_name("DATETIME")
+                        .takes_value(true)
+                        .help("A timestamp after which transaction will execute"),
+                ).arg(
+                    Arg::with_name("timestamp-pubkey")
+                        .long("require-timestamp-from")
                         .value_name("PUBKEY")
                         .takes_value(true)
-                        .help("The pubkey of recipient"),
+                        .requires("timestamp")
+                        .help("Require timestamp from this third party"),
+                ).arg(
+                    Arg::with_name("witness")
+                        .long("require-signature-from")
+                        .value_name("PUBKEY")
+                        .takes_value(true)
+                        .multiple(true)
+                        .use_delimiter(true)
+                        .help("Any third party signatures required to unlock the tokens"),
+                ).arg(
+                    Arg::with_name("cancellable")
+                        .long("cancellable")
+                        .takes_value(false)
+                        .requires("witness"),
                 ),
         ).subcommand(
-            SubCommand::with_name("confirm")
-                .about("Confirm your payment by signature")
+            SubCommand::with_name("send-signature")
+                .about("Send a signature to authorize a transfer")
                 .arg(
-                    Arg::with_name("signature")
+                    Arg::with_name("process-id")
                         .index(1)
-                        .value_name("SIGNATURE")
+                        .value_name("PROCESS_ID")
+                        .takes_value(true)
                         .required(true)
-                        .help("The transaction signature to confirm"),
-                ),
-        ).subcommand(SubCommand::with_name("balance").about("Get your balance"))
-        .subcommand(SubCommand::with_name("address").about("Get your public key"))
-        .get_matches();
+                        .help("The process id of the transfer to authorize")
+                )
+        ).subcommand(
+            SubCommand::with_name("send-timestamp")
+                .about("Send a timestamp to unlock a transfer")
+                .arg(
+                    Arg::with_name("process-id")
+                        .index(1)
+                        .value_name("PROCESS_ID")
+                        .takes_value(true)
+                        .required(true)
+                        .help("The process id of the transfer to unlock")
+                ).arg(
+                    Arg::with_name("datetime")
+                        .long("date")
+                        .value_name("DATETIME")
+                        .takes_value(true)
+                        .help("Optional arbitrary timestamp to apply")
+                )
+        ).get_matches();
 
     let config = parse_args(&matches)?;
     let result = process_command(&config)?;

--- a/src/budget_program.rs
+++ b/src/budget_program.rs
@@ -333,6 +333,7 @@ mod test {
             contract.pubkey(),
             dt,
             from.pubkey(),
+            true,
             1,
             Hash::default(),
         );
@@ -407,6 +408,7 @@ mod test {
             contract.pubkey(),
             dt,
             from.pubkey(),
+            true,
             1,
             Hash::default(),
         );
@@ -471,6 +473,8 @@ mod test {
             to.pubkey(),
             contract.pubkey(),
             Utc::now(),
+            from.pubkey(),
+            true,
             1,
             Hash::default(),
         );
@@ -524,6 +528,7 @@ mod test {
             contract,
             date,
             keypair.pubkey(),
+            true,
             192,
             Hash::default(),
         );

--- a/src/budget_program.rs
+++ b/src/budget_program.rs
@@ -332,6 +332,7 @@ mod test {
             to.pubkey(),
             contract.pubkey(),
             dt,
+            from.pubkey(),
             1,
             Hash::default(),
         );
@@ -405,6 +406,7 @@ mod test {
             to.pubkey(),
             contract.pubkey(),
             dt,
+            from.pubkey(),
             1,
             Hash::default(),
         );
@@ -516,8 +518,15 @@ mod test {
             ]
         );
 
-        let tx =
-            Transaction::budget_new_on_date(&keypair, to, contract, date, 192, Hash::default());
+        let tx = Transaction::budget_new_on_date(
+            &keypair,
+            to,
+            contract,
+            date,
+            keypair.pubkey(),
+            192,
+            Hash::default(),
+        );
         assert_eq!(
             tx.userdata,
             vec![

--- a/src/budget_program.rs
+++ b/src/budget_program.rs
@@ -333,7 +333,7 @@ mod test {
             contract.pubkey(),
             dt,
             from.pubkey(),
-            true,
+            None,
             1,
             Hash::default(),
         );
@@ -408,7 +408,7 @@ mod test {
             contract.pubkey(),
             dt,
             from.pubkey(),
-            true,
+            Some(from.pubkey()),
             1,
             Hash::default(),
         );
@@ -474,7 +474,7 @@ mod test {
             contract.pubkey(),
             Utc::now(),
             from.pubkey(),
-            true,
+            None,
             1,
             Hash::default(),
         );
@@ -528,7 +528,7 @@ mod test {
             contract,
             date,
             keypair.pubkey(),
-            true,
+            Some(keypair.pubkey()),
             192,
             Hash::default(),
         );

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -194,7 +194,21 @@ impl RpcSol for RpcSolImpl {
                 debug!("send_transaction: send_to error: {:?}", err);
                 Error::internal_error()
             })?;
-        Ok(bs58::encode(tx.signature).into_string())
+        let now = Instant::now();
+        let mut signature_status;
+        loop {
+            signature_status = meta
+                .request_processor
+                .get_signature_status(tx.signature)
+                .map_err(|_| Error::internal_error())?;
+
+            if signature_status {
+                return Ok(bs58::encode(tx.signature).into_string());
+            } else if now.elapsed().as_secs() > 5 {
+                return Err(Error::internal_error());
+            }
+            sleep(Duration::from_millis(100));
+        }
     }
 }
 #[derive(Clone)]

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -152,12 +152,13 @@ impl Transaction {
         to: Pubkey,
         contract: Pubkey,
         dt: DateTime<Utc>,
+        dt_pubkey: Pubkey,
         tokens: i64,
         last_id: Hash,
     ) -> Self {
         let from = from_keypair.pubkey();
         let budget = Budget::Or(
-            (Condition::Timestamp(dt, from), Payment { tokens, to }),
+            (Condition::Timestamp(dt, dt_pubkey), Payment { tokens, to }),
             (Condition::Signature(from), Payment { tokens, to: from }),
         );
         let instruction = Instruction::NewContract(Contract { budget, tokens });

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -153,12 +153,11 @@ impl Transaction {
         contract: Pubkey,
         dt: DateTime<Utc>,
         dt_pubkey: Pubkey,
-        cancelable: bool,
+        cancelable: Option<Pubkey>,
         tokens: i64,
         last_id: Hash,
     ) -> Self {
-        let from = from_keypair.pubkey();
-        let budget = if cancelable {
+        let budget = if let Some(from) = cancelable {
             Budget::Or(
                 (Condition::Timestamp(dt, dt_pubkey), Payment { tokens, to }),
                 (Condition::Signature(from), Payment { tokens, to: from }),

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -478,7 +478,7 @@ pub fn process_command(config: &WalletConfig) -> Result<String, Box<error::Error
                     "processId": format!("{}", contract_state.pubkey()),
                 }).to_string())
             } else {
-                Ok("Combo Txs not yet handled".to_string())
+                Ok("Combo transactions not yet handled".to_string())
             }
         }
         // Apply time elapsed to contract

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -143,7 +143,7 @@ pub fn parse_command(
             };
             let timestamp = if pay_matches.is_present("timestamp") {
                 // Parse input for serde_json
-                let date_string = if !pay_matches.value_of("timestamp").unwrap().contains("Z") {
+                let date_string = if !pay_matches.value_of("timestamp").unwrap().contains('Z') {
                     format!("\"{}Z\"", pay_matches.value_of("timestamp").unwrap())
                 } else {
                     format!("\"{}\"", pay_matches.value_of("timestamp").unwrap())
@@ -229,7 +229,7 @@ pub fn parse_command(
                 let date_string = if !timestamp_matches
                     .value_of("datetime")
                     .unwrap()
-                    .contains("Z")
+                    .contains('Z')
                 {
                     format!("\"{}Z\"", timestamp_matches.value_of("datetime").unwrap())
                 } else {
@@ -340,7 +340,7 @@ pub fn process_command(config: &WalletConfig) -> Result<String, Box<error::Error
             }
             let signature_str = signature.as_str().unwrap();
 
-            Ok(format!("{}", signature_str))
+            Ok(signature_str.to_string())
         }
         // Confirm the last client transaction by signature
         WalletCommand::Confirm(signature) => {
@@ -392,7 +392,7 @@ pub fn process_command(config: &WalletConfig) -> Result<String, Box<error::Error
                 }
                 let signature_str = signature.as_str().unwrap();
 
-                Ok(format!("{}", signature_str))
+                Ok(signature_str.to_string())
             } else if *witnesses == None {
                 let dt = timestamp.unwrap();
                 let dt_pubkey = match timestamp_pubkey {
@@ -430,7 +430,7 @@ pub fn process_command(config: &WalletConfig) -> Result<String, Box<error::Error
             } else if timestamp == None {
                 Ok("Witness Txs not yet handled".to_string())
             } else {
-                Ok("Witness Txs not yet handled".to_string())
+                Ok("Combo Txs not yet handled".to_string())
             }
         }
         // Apply time elapsed to contract
@@ -500,7 +500,7 @@ pub fn process_command(config: &WalletConfig) -> Result<String, Box<error::Error
             }
             let signature_str = signature.as_str().unwrap();
 
-            Ok(format!("{}", signature_str))
+            Ok(signature_str.to_string())
         }
     }
 }

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -374,6 +374,7 @@ pub fn process_command(config: &WalletConfig) -> Result<String, Box<error::Error
                 .into_vec()
                 .map_err(|_| WalletError::RpcRequestError("Received bad last_id".to_string()))?;
             let last_id = Hash::new(&last_id_vec);
+            let cancelable_bool = cancelable.is_some();
 
             if timestamp == None && *witnesses == None {
                 let tx = Transaction::new(&config.id, to, tokens, last_id);
@@ -400,7 +401,14 @@ pub fn process_command(config: &WalletConfig) -> Result<String, Box<error::Error
                 };
                 let process_id = Keypair::new().pubkey();
                 let tx = Transaction::budget_new_on_date(
-                    &config.id, to, process_id, dt, dt_pubkey, tokens, last_id,
+                    &config.id,
+                    to,
+                    process_id,
+                    dt,
+                    dt_pubkey,
+                    cancelable_bool,
+                    tokens,
+                    last_id,
                 );
                 let serialized = serialize(&tx).unwrap();
                 let params = json!(serialized);


### PR DESCRIPTION
Remaining issues:

(1) `send-signature` and `send-timestamp` currently require as an input the `to` pubkey from the original transaction (to use `Transaction::budget_new_signature`/`Transaction::budget_new_timestamp`). The appropriate way to handle this is probably to use the process_id to determine the `to` pubkey, but due to possible implications in the Transaction module, I thought this would be best handled in a separate PR.

(2) The CLI cannot handle: payments requiring multiple witnesses or those requiring a timestamp and a witness. This requires at the least an "And" case added for `Budget`, which I'd like to handle separately. At present, a payment made with multiple `require-signature-from` arguments will only store the first pubkey provided. A payment made with both `require-signature-from` and `after` arguments will return a "Combo Txs not yet handled" message.

(3) Currently, accounts cannot successfully submit a signature or timestamp without having a positive balance. I have addressed this in the Timestamp and Witness wallet commands by checking balance, and airdropping 1 if empty. But I'm not sure if this is the right approach. Perhaps we do want to require accounts to have a previous balance of tokens in order to sign transactions?