### PR TITLE
Migrate to solana-labs fork of jsonrpc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,9 +84,9 @@ env_logger = "0.5.12"
 generic-array = { version = "0.12.0", default-features = false, features = ["serde"] }
 getopts = "0.2"
 influx_db_client = "0.3.4"
-jsonrpc-core = { git = "https://github.com/paritytech/jsonrpc", rev = "4b6060b" }
-jsonrpc-http-server = { git = "https://github.com/paritytech/jsonrpc", rev = "4b6060b" }
-jsonrpc-macros = { git = "https://github.com/paritytech/jsonrpc", rev = "4b6060b" }
+jsonrpc-core = { git = "https://github.com/solana-labs/jsonrpc", rev = "4b6060b" }
+jsonrpc-http-server = { git = "https://github.com/solana-labs/jsonrpc", rev = "4b6060b" }
+jsonrpc-macros = { git = "https://github.com/solana-labs/jsonrpc", rev = "4b6060b" }
 ipnetwork = "0.12.7"
 itertools = "0.7.8"
 libc = "0.2.43"


### PR DESCRIPTION
Towards #1333

This changes aims to be a no-op. Future changes to rev should be
along the new solana-0.1 branch. Once those crates are published to crates.io, point to the published ones.