### PR TITLE
Return errors to client via jsonrpc

### DIFF
--- a/src/bank.rs
+++ b/src/bank.rs
@@ -796,7 +796,7 @@ mod tests {
         assert_eq!(bank.transaction_count(), 0);
     }
 
-    // TODO: This test verifies potentially undesirable behavior
+    // TODO: This test demonstrates that fees are not paid when a program fails.
     // See github issue 1157 (https://github.com/solana-labs/solana/issues/1157)
     #[test]
     fn test_detect_failed_duplicate_transactions_issue_1157() {
@@ -805,17 +805,32 @@ mod tests {
         let dest = Keypair::new();
 
         // source with 0 contract context
-        let tx = Transaction::system_new(&mint.keypair(), dest.pubkey(), 2, mint.last_id());
+        let tx = Transaction::system_create(
+            &mint.keypair(),
+            dest.pubkey(),
+            mint.last_id(),
+            2,
+            0,
+            Pubkey::default(),
+            1,
+        );
         let signature = tx.signature;
         assert!(!bank.has_signature(&signature));
         let res = bank.process_transaction(&tx);
-        // This is the potentially wrong behavior
-        // result failed, but signature is registered
+
+        // Result failed, but signature is registered
         assert!(!res.is_ok());
         assert!(bank.has_signature(&signature));
-        // sanity check that tokens didn't move
+        assert_matches!(
+            bank.get_signature_status(&signature),
+            Err(BankError::ResultWithNegativeTokens(_))
+        );
+
+        // The tokens didn't move, but the from address paid the transaction fee.
         assert_eq!(bank.get_balance(&dest.pubkey()), 0);
-        assert_eq!(bank.get_balance(&mint.pubkey()), 1);
+
+        // BUG: This should be the original balance minus the transaction fee.
+        //assert_eq!(bank.get_balance(&mint.pubkey()), 0);
     }
 
     #[test]
@@ -887,6 +902,16 @@ mod tests {
             bank.reserve_signature_with_last_id(&signature, &mint.last_id())
                 .is_ok()
         );
+    }
+
+    #[test]
+    fn test_get_signature_status() {
+        let mint = Mint::new(1);
+        let bank = Bank::new(&mint);
+        let signature = Signature::default();
+        bank.reserve_signature_with_last_id(&signature, &mint.last_id())
+            .expect("reserve signature");
+        assert!(bank.get_signature_status(&signature).is_ok());
     }
 
     #[test]

--- a/src/bank.rs
+++ b/src/bank.rs
@@ -89,6 +89,10 @@ pub enum BankError {
     /// the `last_id` has been discarded.
     LastIdNotFound(Hash),
 
+    /// The bank has not seen a transaction with the given `Signature` or the transaction is
+    /// too old and has been discarded.
+    SignatureNotFound,
+
     /// Proof of History verification failed.
     LedgerVerificationFailed,
     /// Contract's transaction token balance does not equal the balance after the transaction
@@ -709,17 +713,18 @@ impl Bank {
         self.transaction_count.load(Ordering::Relaxed)
     }
 
-    pub fn has_signature(&self, signature: &Signature) -> bool {
-        let last_ids_sigs = self
-            .last_ids_sigs
-            .read()
-            .expect("'last_ids_sigs' read lock");
-        for (_hash, signatures) in last_ids_sigs.iter() {
-            if signatures.0.contains_key(signature) {
-                return true;
+    pub fn get_signature_status(&self, signature: &Signature) -> Result<()> {
+        let last_ids_sigs = self.last_ids_sigs.read().unwrap();
+        for (_hash, (signatures, _)) in last_ids_sigs.iter() {
+            if let Some(res) = signatures.get(signature) {
+                return res.clone();
             }
         }
-        false
+        Err(BankError::SignatureNotFound)
+    }
+
+    pub fn has_signature(&self, signature: &Signature) -> bool {
+        self.get_signature_status(signature) != Err(BankError::SignatureNotFound)
     }
 
     /// Hash the `accounts` HashMap. This represents a validator's interpretation


### PR DESCRIPTION
Before this patch, the client could not tell the difference between a transaction that's been seen by the network, and one that failed because of a bug in its program. With this patch, the client can detect if the transaction was not seen, whether it succeed, or how the the transaction failed. Missing bits of information that still exist:

* Can't tell the difference between a transaction that hasn't been seen and one whose signature has been purged because it's too old.
* Can't tell what the specific program error was, just that the error was detected in the program versus in the bank.

Also updated the test about potentially desirable behavior (cc #1157). The only part that's undesirable now is that the bank isn't taking the fee when it knows the transaction's program failed. It should.

One thing I don't like about this PR is that it shares too much information with the client. jsonrpc should probably define a separate error structure similar to BankError and maintain backward compatibility.

Fixes #1298