### PR TITLE
Transactions with atomic sequences of Programs

### DIFF
--- a/benches/banking_stage.rs
+++ b/benches/banking_stage.rs
@@ -63,8 +63,8 @@ fn bench_banking_stage_multi_accounts(bencher: &mut Bencher) {
             let from: Vec<u8> = (0..64).map(|_| thread_rng().gen()).collect();
             let to: Vec<u8> = (0..64).map(|_| thread_rng().gen()).collect();
             let sig: Vec<u8> = (0..64).map(|_| thread_rng().gen()).collect();
-            new.keys[0] = Pubkey::new(&from[0..32]);
-            new.keys[1] = Pubkey::new(&to[0..32]);
+            new.account_keys[0] = Pubkey::new(&from[0..32]);
+            new.account_keys[1] = Pubkey::new(&to[0..32]);
             new.signature = Signature::new(&sig[0..64]);
             new
         }).collect();
@@ -72,7 +72,7 @@ fn bench_banking_stage_multi_accounts(bencher: &mut Bencher) {
     transactions.iter().for_each(|tx| {
         let fund = Transaction::system_move(
             &mint.keypair(),
-            tx.keys[0],
+            tx.account_keys[0],
             mint_total / txes as i64,
             mint.last_id(),
             0,
@@ -105,6 +105,93 @@ fn bench_banking_stage_multi_accounts(bencher: &mut Bencher) {
         check_txs(&signal_receiver, txes);
         bank.clear_signatures();
         // make sure the tx last id is still registered
+        bank.register_entry_id(&mint.last_id());
+    });
+}
+
+#[bench]
+fn bench_banking_stage_multi_programs(bencher: &mut Bencher) {
+    //use solana::logger;
+    //logger::setup();
+    let progs = 5;
+    let txes = 1000 * NUM_THREADS;
+    let mint_total = 1_000_000_000_000;
+    let mint = Mint::new(mint_total);
+
+    let (verified_sender, verified_receiver) = channel();
+    let bank = Arc::new(Bank::new(&mint));
+    let dummy = Transaction::system_move(
+        &mint.keypair(),
+        mint.keypair().pubkey(),
+        1,
+        mint.last_id(),
+        0,
+    );
+    let transactions: Vec<_> = (0..txes)
+        .into_par_iter()
+        .map(|_| {
+            let mut new = dummy.clone();
+            let from: Vec<u8> = (0..32).map(|_| thread_rng().gen()).collect();
+            let sig: Vec<u8> = (0..64).map(|_| thread_rng().gen()).collect();
+            let to: Vec<u8> = (0..32).map(|_| thread_rng().gen()).collect();
+            new.account_keys[0] = Pubkey::new(&from[0..32]);
+            new.account_keys[1] = Pubkey::new(&to[0..32]);
+            let prog = new.instructions[0].clone();
+            for i in 1..progs {
+                //generate programs that spend to random keys
+                let to: Vec<u8> = (0..32).map(|_| thread_rng().gen()).collect();
+                let to_key = Pubkey::new(&to[0..32]);
+                new.account_keys.push(to_key);
+                assert_eq!(new.account_keys.len(), i + 2);
+                new.instructions.push(prog.clone());
+                assert_eq!(new.instructions.len(), i + 1);
+                new.instructions[i].accounts[1] = 1 + i as u8;
+                assert_eq!(new.key(i, 1), Some(&to_key));
+                assert_eq!(
+                    new.account_keys[new.instructions[i].accounts[1] as usize],
+                    to_key
+                );
+            }
+            assert_eq!(new.instructions.len(), progs);
+            new.signature = Signature::new(&sig[0..64]);
+            new
+        }).collect();
+    transactions.iter().for_each(|tx| {
+        let fund = Transaction::system_move(
+            &mint.keypair(),
+            tx.account_keys[0],
+            mint_total / txes as i64,
+            mint.last_id(),
+            0,
+        );
+        assert!(bank.process_transaction(&fund).is_ok());
+    });
+    //sanity check, make sure all the transactions can execute sequentially
+    transactions.iter().for_each(|tx| {
+        let res = bank.process_transaction(&tx);
+        assert!(res.is_ok(), "sanity test transactions");
+    });
+    bank.clear_signatures();
+    //sanity check, make sure all the transactions can execute in parallel
+    let res = bank.process_transactions(&transactions);
+    for r in res {
+        assert!(r.is_ok(), "sanity parallel execution");
+    }
+    bank.clear_signatures();
+    let verified: Vec<_> = to_packets_chunked(&transactions.clone(), 96)
+        .into_iter()
+        .map(|x| {
+            let len = x.read().unwrap().packets.len();
+            (x, iter::repeat(1).take(len).collect())
+        }).collect();
+    let (_stage, signal_receiver) = BankingStage::new(&bank, verified_receiver, Default::default());
+    bencher.iter(move || {
+        for v in verified.chunks(verified.len() / NUM_THREADS) {
+            verified_sender.send(v.to_vec()).unwrap();
+        }
+        check_txs(&signal_receiver, txes);
+        bank.clear_signatures();
+        // make sure the transactions are still valid
         bank.register_entry_id(&mint.last_id());
     });
 }

--- a/src/banking_stage.rs
+++ b/src/banking_stage.rs
@@ -224,7 +224,7 @@ impl BankingStage {
                 .zip(vers)
                 .filter_map(|(tx, ver)| match tx {
                     None => None,
-                    Some((tx, _addr)) => if tx.verify_plan() && ver != 0 {
+                    Some((tx, _addr)) => if tx.verify_refs() && tx.verify_plan() && ver != 0 {
                         Some(tx)
                     } else {
                         None

--- a/src/mint.rs
+++ b/src/mint.rs
@@ -76,8 +76,9 @@ mod tests {
     fn test_create_transactions() {
         let mut transactions = Mint::new(100).create_transactions().into_iter();
         let tx = transactions.next().unwrap();
-        assert!(SystemProgram::check_id(&tx.program_id));
-        let instruction: SystemProgram = deserialize(&tx.userdata).unwrap();
+        assert_eq!(tx.instructions.len(), 1);
+        assert!(SystemProgram::check_id(tx.program_id(0)));
+        let instruction: SystemProgram = deserialize(tx.userdata(0)).unwrap();
         if let SystemProgram::Move { tokens } = instruction {
             assert_eq!(tokens, 100);
         }

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -173,7 +173,7 @@ impl RpcSol for RpcSolImpl {
         Ok(
             match meta.request_processor.get_signature_status(signature) {
                 Ok(_) => RpcSignatureStatus::Confirmed,
-                Err(BankError::ProgramRuntimeError) => RpcSignatureStatus::ProgramRuntimeError,
+                Err(BankError::ProgramRuntimeError(_)) => RpcSignatureStatus::ProgramRuntimeError,
                 Err(BankError::SignatureNotFound) => RpcSignatureStatus::SignatureNotFound,
                 Err(err) => {
                     trace!("mapping {:?} to GenericFailure", err);

--- a/src/storage_program.rs
+++ b/src/storage_program.rs
@@ -33,9 +33,10 @@ impl StorageProgram {
 
     pub fn process_transaction(
         tx: &Transaction,
-        _accounts: &mut [Account],
+        pix: usize,
+        _accounts: &mut [&mut Account],
     ) -> Result<(), StorageError> {
-        if let Ok(syscall) = deserialize(&tx.userdata) {
+        if let Ok(syscall) = deserialize(tx.userdata(pix)) {
             match syscall {
                 StorageProgram::SubmitMiningProof { sha_state } => {
                     info!("Mining proof submitted with state {}", sha_state[0]);
@@ -49,4 +50,22 @@ impl StorageProgram {
 }
 
 #[cfg(test)]
-mod test {}
+mod test {
+    use super::*;
+    use signature::Keypair;
+    use signature::KeypairUtil;
+
+    #[test]
+    fn test_storage_tx() {
+        let keypair = Keypair::new();
+        let tx = Transaction::new(
+            &keypair,
+            &[],
+            StorageProgram::id(),
+            vec![],
+            Default::default(),
+            0,
+        );
+        assert!(StorageProgram::process_transaction(&tx, 0, &mut []).is_err());
+    }
+}

--- a/src/thin_client.rs
+++ b/src/thin_client.rs
@@ -540,11 +540,11 @@ mod tests {
         let last_id = client.get_last_id();
 
         let mut tr2 = Transaction::system_new(&alice.keypair(), bob_pubkey, 501, last_id);
-        let mut instruction2 = deserialize(&tr2.userdata).unwrap();
+        let mut instruction2 = deserialize(tr2.userdata(0)).unwrap();
         if let SystemProgram::Move { ref mut tokens } = instruction2 {
             *tokens = 502;
         }
-        tr2.userdata = serialize(&instruction2).unwrap();
+        tr2.instructions[0].userdata = serialize(&instruction2).unwrap();
         let signature = client.transfer_signed(&tr2).unwrap();
         client.poll_for_signature(&signature).unwrap();
 

--- a/tests/programs.rs
+++ b/tests/programs.rs
@@ -141,6 +141,14 @@ fn test_native_move_funds_succes_many_threads() {
         thread.join().unwrap();
     }
 }
+fn process_transaction(
+    tx: &Transaction,
+    accounts: &mut [Account],
+    loaded_programs: &RwLock<HashMap<Pubkey, DynamicProgram>>,
+) {
+    let mut refs: Vec<&mut Account> = accounts.iter_mut().collect();
+    SystemProgram::process_transaction(&tx, 0, &mut refs[..], loaded_programs)
+}
 
 #[test]
 fn test_system_program_load_call() {
@@ -158,7 +166,7 @@ fn test_system_program_load_call() {
             "move_funds".to_string(),
         );
 
-        SystemProgram::process_transaction(&tx, &mut accounts, &loaded_programs);
+        process_transaction(&tx, &mut accounts, &loaded_programs);
     }
     // then call the program
     {
@@ -211,7 +219,7 @@ fn test_system_program_load_call_many_threads() {
                         "move_funds".to_string(),
                     );
 
-                    SystemProgram::process_transaction(&tx, &mut accounts, &loaded_programs);
+                    process_transaction(&tx, &mut accounts, &loaded_programs);
                 }
                 // then call the program
                 {


### PR DESCRIPTION
Transactions contain a vector of instructions that are executed atomically.
Bench shows a 2.3x speed up when using 5 instructions per tx.
More ips for the same tps.
with pr
```
test bench_banking_stage_multi_accounts ... bench:   2,932,757 ns/iter (+/- 233,628)
test bench_banking_stage_multi_programs ... bench:   5,605,320 ns/iter (+/- 580,425)
```
master
```
test bench_banking_stage_multi_accounts ... bench:   2,583,595 ns/iter (+/- 398,312)
```
2.5/(5.6/5) = 2.23x more ips o a mac.  We could pack more than 5 instructions into a larger transaction size.  5 fit into 512 bytes.