### PR TITLE
Install kcov to CI environment

### DIFF
--- a/ci/docker-rust/Dockerfile
+++ b/ci/docker-rust/Dockerfile
@@ -19,6 +19,15 @@ RUN set -x && \
       && \
     rustup component add rustfmt-preview && \
     rustup component add clippy-preview && \
+    apt install -y \
+      binutils-dev \
+      libcurl4-openssl-dev \
+      zlib1g-dev \
+      libdw-dev \
+      libiberty-dev \
+      && \
+    cargo install cargo-kcov && \
+    cargo kcov --print-install-kcov-sh | VERBOSE=1 bash && \
     rm -rf /var/lib/apt/lists/* && \
     rustc --version && \
     cargo --version


### PR DESCRIPTION
This PR just gets the CI environment in a place where we can run `cargo-kcov` in addition to `cargo-cov`.  The same person wrote both tools. It looked like `cargo-cov` was the way to go, but I'm not having a lot of success with it, and the author is still using kcov for his own work.

The trouble with kcov is that there's no Windows port, it's slow on macOS, and requires a bunch of system dependencies and a source build of kcov (requires cmake, pkg-config, full Xcode install).  ...but if the usual developer workflow is to just look at the CI-generated HTML report posted to PRs, then none of that is all that problematic. If the developer workflow is to work towards 100% coverage locally, before submitting the PR, then this solution is pretty clunky.