### PR TITLE
Tick entry ids

### DIFF
--- a/src/banking_stage.rs
+++ b/src/banking_stage.rs
@@ -2,7 +2,7 @@
 //! to contruct a software pipeline. The stage uses all available CPU cores and
 //! can do its processing in parallel with signature verification on the GPU.
 
-use bank::Bank;
+use bank::{Bank, NUM_TICKS_PER_SECOND};
 use bincode::deserialize;
 use budget_transaction::BudgetTransaction;
 use counter::Counter;
@@ -45,7 +45,7 @@ pub enum Config {
 impl Default for Config {
     fn default() -> Config {
         // TODO: Change this to Tick to enable PoH
-        Config::Sleep(Duration::from_millis(500))
+        Config::Sleep(Duration::from_millis(1000 / NUM_TICKS_PER_SECOND as u64))
     }
 }
 impl BankingStage {

--- a/src/poh_recorder.rs
+++ b/src/poh_recorder.rs
@@ -53,7 +53,7 @@ impl PohRecorder {
         // This guarantees PoH order and Entry production and banks LastId queue is the same.
         let mut poh = self.poh.lock().unwrap();
         let tick = poh.record(mixin);
-        self.bank.register_entry_id(&tick.id);
+        // don't register an entry
         let entry = Entry {
             num_hashes: tick.num_hashes,
             id: tick.id,


### PR DESCRIPTION
Only register tick entry last_ids, and generate test ledgers with ticks.  The other side of this fix is that entries entering the pipeline cannot block time, so when they enter the bank threads need enough time to reliably finish before that last_id is expired. 