### PR TITLE
 Purge BudgetTransaction from banking_stage/entry

### DIFF
--- a/src/banking_stage.rs
+++ b/src/banking_stage.rs
@@ -4,7 +4,6 @@
 
 use bank::Bank;
 use bincode::deserialize;
-use budget_transaction::BudgetTransaction;
 use counter::Counter;
 use entry::Entry;
 use log::Level;
@@ -208,7 +207,7 @@ impl BankingStage {
                 .zip(vers)
                 .filter_map(|(tx, ver)| match tx {
                     None => None,
-                    Some((tx, _addr)) => if tx.verify_refs() && tx.verify_plan() && ver != 0 {
+                    Some((tx, _addr)) => if tx.verify_refs() && ver != 0 {
                         Some(tx)
                     } else {
                         None


### PR DESCRIPTION
These are vestigial checks from back when `Transaction` was less generic