### PR TITLE
Rename Crdt to ClusterInfo

### DIFF
--- a/src/bin/fullnode-config.rs
+++ b/src/bin/fullnode-config.rs
@@ -5,7 +5,7 @@ extern crate serde_json;
 extern crate solana;
 
 use clap::{App, Arg};
-use solana::crdt::FULLNODE_PORT_RANGE;
+use solana::cluster_info::FULLNODE_PORT_RANGE;
 use solana::fullnode::Config;
 use solana::logger;
 use solana::netutil::{get_ip_addr, get_public_ip_addr, parse_port_or_addr};

--- a/src/bin/fullnode.rs
+++ b/src/bin/fullnode.rs
@@ -9,7 +9,7 @@ extern crate solana;
 
 use clap::{App, Arg};
 use solana::client::mk_client;
-use solana::crdt::Node;
+use solana::cluster_info::Node;
 use solana::drone::DRONE_PORT;
 use solana::fullnode::{Config, Fullnode, FullnodeReturnType};
 use solana::logger;

--- a/src/bin/replicator.rs
+++ b/src/bin/replicator.rs
@@ -7,7 +7,7 @@ extern crate solana;
 
 use clap::{App, Arg};
 use solana::chacha::chacha_cbc_encrypt_files;
-use solana::crdt::Node;
+use solana::cluster_info::Node;
 use solana::fullnode::Config;
 use solana::ledger::LEDGER_DATA_FILE;
 use solana::logger;

--- a/src/budget_instruction.rs
+++ b/src/budget_instruction.rs
@@ -12,9 +12,9 @@ pub struct Contract {
 pub struct Vote {
     /// We send some gossip specific membership information through the vote to shortcut
     /// liveness voting
-    /// The version of the CRDT struct that the last_id of this network voted with
+    /// The version of the ClusterInfo struct that the last_id of this network voted with
     pub version: u64,
-    /// The version of the CRDT struct that has the same network configuration as this one
+    /// The version of the ClusterInfo struct that has the same network configuration as this one
     pub contact_info_version: u64,
     // TODO: add signature of the state here as well
 }

--- a/src/choose_gossip_peer_strategy.rs
+++ b/src/choose_gossip_peer_strategy.rs
@@ -1,4 +1,4 @@
-use crdt::{CrdtError, NodeInfo};
+use cluster_info::{ClusterInfoError, NodeInfo};
 use rand::distributions::{Distribution, Weighted, WeightedChoice};
 use rand::thread_rng;
 use result::Result;
@@ -29,7 +29,7 @@ impl<'a, 'b> ChooseRandomPeerStrategy<'a> {
 impl<'a> ChooseGossipPeerStrategy for ChooseRandomPeerStrategy<'a> {
     fn choose_peer<'b>(&self, options: Vec<&'b NodeInfo>) -> Result<&'b NodeInfo> {
         if options.is_empty() {
-            Err(CrdtError::NoPeers)?;
+            Err(ClusterInfoError::NoPeers)?;
         }
 
         let n = ((self.random)() as usize) % options.len();
@@ -87,8 +87,8 @@ impl<'a> ChooseWeightedPeerStrategy<'a> {
     fn calculate_weighted_remote_index(&self, peer_id: Pubkey) -> u32 {
         let mut last_seen_index = 0;
         // If the peer is not in our remote table, then we leave last_seen_index as zero.
-        // Only happens when a peer appears in our crdt.table but not in our crdt.remote,
-        // which means a validator was directly injected into our crdt.table
+        // Only happens when a peer appears in our cluster_info.table but not in our cluster_info.remote,
+        // which means a validator was directly injected into our cluster_info.table
         if let Some(index) = self.remote.get(&peer_id) {
             last_seen_index = *index;
         }
@@ -174,7 +174,7 @@ impl<'a> ChooseWeightedPeerStrategy<'a> {
 impl<'a> ChooseGossipPeerStrategy for ChooseWeightedPeerStrategy<'a> {
     fn choose_peer<'b>(&self, options: Vec<&'b NodeInfo>) -> Result<&'b NodeInfo> {
         if options.is_empty() {
-            Err(CrdtError::NoPeers)?;
+            Err(ClusterInfoError::NoPeers)?;
         }
 
         let mut weighted_peers = vec![];

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,4 +1,4 @@
-use crdt::{NodeInfo, FULLNODE_PORT_RANGE};
+use cluster_info::{NodeInfo, FULLNODE_PORT_RANGE};
 use netutil::bind_in_range;
 use std::time::Duration;
 use thin_client::ThinClient;

--- a/src/drone.rs
+++ b/src/drone.rs
@@ -224,7 +224,7 @@ pub fn run_local_drone(mint_keypair: Keypair, network: SocketAddr, sender: Sende
 #[cfg(test)]
 mod tests {
     use bank::Bank;
-    use crdt::Node;
+    use cluster_info::Node;
     use drone::{Drone, DroneRequest, REQUEST_CAP, TIME_SLICE};
     use fullnode::Fullnode;
     use logger;

--- a/src/erasure.rs
+++ b/src/erasure.rs
@@ -591,7 +591,7 @@ pub fn recover(id: &Pubkey, window: &mut [WindowSlot], start_idx: u64, start: us
 
 #[cfg(test)]
 mod test {
-    use crdt;
+    use cluster_info;
     use erasure;
     use logger;
     use packet::{SharedBlob, BLOB_DATA_SIZE, BLOB_HEADER_SIZE, BLOB_SIZE};
@@ -726,7 +726,7 @@ mod test {
             blobs.push(b_);
         }
 
-        let d = crdt::NodeInfo::new_localhost(Keypair::new().pubkey());
+        let d = cluster_info::NodeInfo::new_localhost(Keypair::new().pubkey());
         assert!(index_blobs(&d, &blobs, &mut (offset as u64)).is_ok());
         for b in blobs {
             let idx = b.read().unwrap().get_index().unwrap() as usize % WINDOW_SIZE;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@ pub mod chacha;
 pub mod choose_gossip_peer_strategy;
 pub mod client;
 #[macro_use]
-pub mod crdt;
+pub mod cluster_info;
 pub mod bpf_verifier;
 pub mod budget_program;
 pub mod drone;

--- a/src/result.rs
+++ b/src/result.rs
@@ -2,7 +2,7 @@
 
 use bank;
 use bincode;
-use crdt;
+use cluster_info;
 #[cfg(feature = "erasure")]
 use erasure;
 use packet;
@@ -20,7 +20,7 @@ pub enum Error {
     RecvTimeoutError(std::sync::mpsc::RecvTimeoutError),
     Serialize(std::boxed::Box<bincode::ErrorKind>),
     BankError(bank::BankError),
-    CrdtError(crdt::CrdtError),
+    ClusterInfoError(cluster_info::ClusterInfoError),
     BlobError(packet::BlobError),
     #[cfg(feature = "erasure")]
     ErasureError(erasure::ErasureError),
@@ -52,9 +52,9 @@ impl std::convert::From<bank::BankError> for Error {
         Error::BankError(e)
     }
 }
-impl std::convert::From<crdt::CrdtError> for Error {
-    fn from(e: crdt::CrdtError) -> Error {
-        Error::CrdtError(e)
+impl std::convert::From<cluster_info::ClusterInfoError> for Error {
+    fn from(e: cluster_info::ClusterInfoError) -> Error {
+        Error::ClusterInfoError(e)
     }
 }
 #[cfg(feature = "erasure")]

--- a/src/retransmit_stage.rs
+++ b/src/retransmit_stage.rs
@@ -1,7 +1,7 @@
 //! The `retransmit_stage` retransmits blobs between validators
 
+use cluster_info::ClusterInfo;
 use counter::Counter;
-use crdt::Crdt;
 use entry::Entry;
 use log::Level;
 use result::{Error, Result};
@@ -22,33 +22,41 @@ pub enum RetransmitStageReturnType {
     LeaderRotation(u64),
 }
 
-fn retransmit(crdt: &Arc<RwLock<Crdt>>, r: &BlobReceiver, sock: &UdpSocket) -> Result<()> {
+fn retransmit(
+    cluster_info: &Arc<RwLock<ClusterInfo>>,
+    r: &BlobReceiver,
+    sock: &UdpSocket,
+) -> Result<()> {
     let timer = Duration::new(1, 0);
     let mut dq = r.recv_timeout(timer)?;
     while let Ok(mut nq) = r.try_recv() {
         dq.append(&mut nq);
     }
     for b in &mut dq {
-        Crdt::retransmit(&crdt, b, sock)?;
+        ClusterInfo::retransmit(&cluster_info, b, sock)?;
     }
     Ok(())
 }
 
 /// Service to retransmit messages from the leader to layer 1 nodes.
-/// See `crdt` for network layer definitions.
+/// See `cluster_info` for network layer definitions.
 /// # Arguments
 /// * `sock` - Socket to read from.  Read timeout is set to 1.
 /// * `exit` - Boolean to signal system exit.
-/// * `crdt` - This structure needs to be updated and populated by the bank and via gossip.
+/// * `cluster_info` - This structure needs to be updated and populated by the bank and via gossip.
 /// * `recycler` - Blob recycler.
 /// * `r` - Receive channel for blobs to be retransmitted to all the layer 1 nodes.
-fn retransmitter(sock: Arc<UdpSocket>, crdt: Arc<RwLock<Crdt>>, r: BlobReceiver) -> JoinHandle<()> {
+fn retransmitter(
+    sock: Arc<UdpSocket>,
+    cluster_info: Arc<RwLock<ClusterInfo>>,
+    r: BlobReceiver,
+) -> JoinHandle<()> {
     Builder::new()
         .name("solana-retransmitter".to_string())
         .spawn(move || {
             trace!("retransmitter started");
             loop {
-                if let Err(e) = retransmit(&crdt, &r, &sock) {
+                if let Err(e) = retransmit(&cluster_info, &r, &sock) {
                     match e {
                         Error::RecvTimeoutError(RecvTimeoutError::Disconnected) => break,
                         Error::RecvTimeoutError(RecvTimeoutError::Timeout) => (),
@@ -69,7 +77,7 @@ pub struct RetransmitStage {
 
 impl RetransmitStage {
     pub fn new(
-        crdt: &Arc<RwLock<Crdt>>,
+        cluster_info: &Arc<RwLock<ClusterInfo>>,
         window: SharedWindow,
         entry_height: u64,
         retransmit_socket: Arc<UdpSocket>,
@@ -78,11 +86,12 @@ impl RetransmitStage {
     ) -> (Self, Receiver<Vec<Entry>>) {
         let (retransmit_sender, retransmit_receiver) = channel();
 
-        let t_retransmit = retransmitter(retransmit_socket, crdt.clone(), retransmit_receiver);
+        let t_retransmit =
+            retransmitter(retransmit_socket, cluster_info.clone(), retransmit_receiver);
         let (entry_sender, entry_receiver) = channel();
         let done = Arc::new(AtomicBool::new(false));
         let t_window = window_service(
-            crdt.clone(),
+            cluster_info.clone(),
             window,
             entry_height,
             0,

--- a/src/tpu.rs
+++ b/src/tpu.rs
@@ -27,7 +27,7 @@
 
 use bank::Bank;
 use banking_stage::{BankingStage, Config};
-use crdt::Crdt;
+use cluster_info::ClusterInfo;
 use entry::Entry;
 use fetch_stage::FetchStage;
 use service::Service;
@@ -56,7 +56,7 @@ impl Tpu {
     pub fn new(
         keypair: Arc<Keypair>,
         bank: &Arc<Bank>,
-        crdt: &Arc<RwLock<Crdt>>,
+        cluster_info: &Arc<RwLock<ClusterInfo>>,
         tick_duration: Config,
         transactions_sockets: Vec<UdpSocket>,
         ledger_path: &str,
@@ -76,7 +76,7 @@ impl Tpu {
         let (write_stage, entry_forwarder) = WriteStage::new(
             keypair,
             bank.clone(),
-            crdt.clone(),
+            cluster_info.clone(),
             ledger_path,
             entry_receiver,
             entry_height,

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -4,7 +4,7 @@ use budget_program::BudgetState;
 use budget_transaction::BudgetTransaction;
 use chrono::prelude::*;
 use clap::ArgMatches;
-use crdt::NodeInfo;
+use cluster_info::NodeInfo;
 use drone::DroneRequest;
 use fullnode::Config;
 use hash::Hash;
@@ -613,7 +613,7 @@ mod tests {
     use super::*;
     use bank::Bank;
     use clap::{App, Arg, SubCommand};
-    use crdt::Node;
+    use cluster_info::Node;
     use drone::run_local_drone;
     use fullnode::Fullnode;
     use ledger::LedgerWriter;


### PR DESCRIPTION
> In distributed computing, a conflict-free replicated data type (CRDT) is a data structure which can be replicated across multiple computers in a network, where the replicas can be updated independently and concurrently without coordination between the replicas, and where it is always mathematically possible to resolve inconsistencies which might result.

https://en.wikipedia.org/wiki/Conflict-free_replicated_data_type

Like a Vec, a CRDT is a data structure. To structure data is to make it available to desirable algorithms, but to name a type after its structure is to say almost nothing at all about it. We don't need to even tag a type name with a structure name - that's an implementation detail. Instead, this PR attempts to give the struct a name that best describes its contents.

> A computer cluster is a set of loosely or tightly connected computers that work together so that, in many respects, they can be viewed as a single system.

https://en.wikipedia.org/wiki/Computer_cluster

Towards #1409