### PR TITLE
Distinguish indices to signed keys from unsigned ones

### DIFF
--- a/src/bank.rs
+++ b/src/bank.rs
@@ -538,13 +538,13 @@ impl Bank {
     /// Execute a function with a subset of accounts as writable references.
     /// Since the subset can point to the same references, in any order there is no way
     /// for the borrow checker to track them with regards to the original set.
-    fn with_subset<F, A>(accounts: &mut [Account], ixes: &[u8], func: F) -> A
+    fn with_subset<F, A>(accounts: &mut [Account], ixes: &[(u8, bool)], func: F) -> A
     where
         F: Fn(&mut [&mut Account]) -> A,
     {
         let mut subset: Vec<&mut Account> = ixes
             .iter()
-            .map(|ix| {
+            .map(|(ix, _)| {
                 let ptr = &mut accounts[*ix as usize] as *mut Account;
                 // lifetime of this unsafe is only within the scope of the closure
                 // there is no way to reorder them without breaking borrow checker rules
@@ -1270,12 +1270,12 @@ mod tests {
             Instruction {
                 program_ids_index: 0,
                 userdata: serialize(&spend).unwrap(),
-                accounts: vec![0, 1],
+                accounts: vec![(0, false), (1, false)],
             },
             Instruction {
                 program_ids_index: 0,
                 userdata: serialize(&spend).unwrap(),
-                accounts: vec![0, 2],
+                accounts: vec![(0, false), (2, false)],
             },
         ];
 

--- a/src/system_transaction.rs
+++ b/src/system_transaction.rs
@@ -135,7 +135,7 @@ impl SystemTransaction for Transaction {
                 Instruction {
                     program_ids_index: 0,
                     userdata: serialize(&spend).unwrap(),
-                    accounts: vec![0, i as u8 + 1],
+                    accounts: vec![(0, false), (i as u8 + 1, false)],
                 }
             }).collect();
         let to_keys: Vec<_> = moves.iter().map(|(to_key, _)| *to_key).collect();
@@ -227,7 +227,7 @@ mod tests {
         assert_eq!(tx.account_keys[1], t1.pubkey());
         assert_eq!(tx.account_keys[2], t2.pubkey());
         assert_eq!(tx.instructions.len(), 2);
-        assert_eq!(tx.instructions[0].accounts, vec![0, 1]);
-        assert_eq!(tx.instructions[1].accounts, vec![0, 2]);
+        assert_eq!(tx.instructions[0].accounts, vec![(0, true), (1, false)]);
+        assert_eq!(tx.instructions[1].accounts, vec![(0, true), (2, false)]);
     }
 }

--- a/src/system_transaction.rs
+++ b/src/system_transaction.rs
@@ -230,4 +230,21 @@ mod tests {
         assert_eq!(tx.instructions[0].accounts, vec![(0, true), (1, false)]);
         assert_eq!(tx.instructions[1].accounts, vec![(0, true), (2, false)]);
     }
+
+    #[test]
+    fn test_move_attack() {
+        let from = Keypair::new();
+        let to = Keypair::new().pubkey();
+        let mut tx = Transaction::system_move(&from, to, 1, Default::default(), 0);
+        assert!(tx.verify_refs());
+
+        tx.instructions[0].accounts[0].0 = 1; // <-- attack! Attempt to spend `to` tokens instead of `from` tokens.
+        tx.sign(&from);
+        assert!(tx.verify_signature());
+        assert!(!tx.verify_refs());
+
+        // Note: here's how to sneak by verify_refs(). The engine itself needs to reject debits from unsigned accounts.
+        tx.instructions[0].accounts[0].1 = false;
+        assert!(tx.verify_refs());
+    }
 }


### PR DESCRIPTION
This will allow the contract engine to reject debits from accounts with
unsigned keys.