### PR TITLE
Fix broken leader transition tests

### DIFF
--- a/benches/banking_stage.rs
+++ b/benches/banking_stage.rs
@@ -97,7 +97,12 @@ fn bench_banking_stage_multi_accounts(bencher: &mut Bencher) {
             let len = x.read().unwrap().packets.len();
             (x, iter::repeat(1).take(len).collect())
         }).collect();
-    let (_stage, signal_receiver) = BankingStage::new(&bank, verified_receiver, Default::default());
+    let (_stage, signal_receiver) = BankingStage::new(
+        &bank,
+        verified_receiver,
+        Default::default(),
+        &mint.last_id(),
+    );
     bencher.iter(move || {
         for v in verified.chunks(verified.len() / NUM_THREADS) {
             verified_sender.send(v.to_vec()).unwrap();
@@ -182,7 +187,12 @@ fn bench_banking_stage_multi_programs(bencher: &mut Bencher) {
             let len = x.read().unwrap().packets.len();
             (x, iter::repeat(1).take(len).collect())
         }).collect();
-    let (_stage, signal_receiver) = BankingStage::new(&bank, verified_receiver, Default::default());
+    let (_stage, signal_receiver) = BankingStage::new(
+        &bank,
+        verified_receiver,
+        Default::default(),
+        &mint.last_id(),
+    );
     bencher.iter(move || {
         for v in verified.chunks(verified.len() / NUM_THREADS) {
             verified_sender.send(v.to_vec()).unwrap();

--- a/src/leader_scheduler.rs
+++ b/src/leader_scheduler.rs
@@ -430,20 +430,22 @@ pub fn set_new_leader(bank: &Bank, leader_scheduler: &mut LeaderScheduler, vote_
 pub fn make_active_set_entries(
     active_keypair: &Keypair,
     token_source: &Keypair,
-    last_id: &Hash,
+    last_entry_id: &Hash,
+    last_tick_id: &Hash,
 ) -> Vec<Entry> {
     // 1) Create transfer token entry
-    let transfer_tx = Transaction::system_new(&token_source, active_keypair.pubkey(), 1, *last_id);
-    let transfer_entry = Entry::new(last_id, 0, vec![transfer_tx]);
-    let last_id = transfer_entry.id;
+    let transfer_tx =
+        Transaction::system_new(&token_source, active_keypair.pubkey(), 1, *last_tick_id);
+    let transfer_entry = Entry::new(last_entry_id, 0, vec![transfer_tx]);
+    let last_entry_id = transfer_entry.id;
 
     // 2) Create vote entry
     let vote = Vote {
         version: 0,
         contact_info_version: 0,
     };
-    let vote_tx = Transaction::budget_new_vote(&active_keypair, vote, last_id, 0);
-    let vote_entry = Entry::new(&last_id, 0, vec![vote_tx]);
+    let vote_tx = Transaction::budget_new_vote(&active_keypair, vote, *last_tick_id, 0);
+    let vote_entry = Entry::new(&last_entry_id, 0, vec![vote_tx]);
 
     vec![transfer_entry, vote_entry]
 }

--- a/src/poh_recorder.rs
+++ b/src/poh_recorder.rs
@@ -21,8 +21,8 @@ impl PohRecorder {
     /// A recorder to synchronize PoH with the following data structures
     /// * bank - the LastId's queue is updated on `tick` and `record` events
     /// * sender - the Entry channel that outputs to the ledger
-    pub fn new(bank: Arc<Bank>, sender: Sender<Vec<Entry>>) -> Self {
-        let poh = Arc::new(Mutex::new(Poh::new(bank.last_id())));
+    pub fn new(bank: Arc<Bank>, sender: Sender<Vec<Entry>>, last_entry_id: Hash) -> Self {
+        let poh = Arc::new(Mutex::new(Poh::new(last_entry_id)));
         PohRecorder { poh, bank, sender }
     }
 
@@ -77,8 +77,9 @@ mod tests {
     fn test_poh() {
         let mint = Mint::new(1);
         let bank = Arc::new(Bank::new(&mint));
+        let last_id = bank.last_id();
         let (entry_sender, entry_receiver) = channel();
-        let poh_recorder = PohRecorder::new(bank, entry_sender);
+        let poh_recorder = PohRecorder::new(bank, entry_sender, last_id);
 
         //send some data
         let h1 = hash(b"hello world!");

--- a/src/thin_client.rs
+++ b/src/thin_client.rs
@@ -575,11 +575,13 @@ mod tests {
         let leader_data = leader.info.clone();
         let ledger_path = tmp_ledger("client_check_signature", &alice);
 
+        let genesis_entries = &alice.create_entries();
+        let entry_height = genesis_entries.len() as u64;
         let server = Fullnode::new_with_bank(
             leader_keypair,
             bank,
-            0,
-            &[],
+            entry_height,
+            &genesis_entries,
             leader,
             None,
             &ledger_path,
@@ -636,11 +638,13 @@ mod tests {
         let leader_data = leader.info.clone();
         let ledger_path = tmp_ledger("zero_balance_check", &alice);
 
+        let genesis_entries = &alice.create_entries();
+        let entry_height = genesis_entries.len() as u64;
         let server = Fullnode::new_with_bank(
             leader_keypair,
             bank,
-            0,
-            &[],
+            entry_height,
+            &genesis_entries,
             leader,
             None,
             &ledger_path,

--- a/src/tpu.rs
+++ b/src/tpu.rs
@@ -30,6 +30,7 @@ use banking_stage::{BankingStage, Config};
 use cluster_info::ClusterInfo;
 use entry::Entry;
 use fetch_stage::FetchStage;
+use hash::Hash;
 use leader_scheduler::LeaderScheduler;
 use service::Service;
 use signature::Keypair;
@@ -54,6 +55,7 @@ pub struct Tpu {
 }
 
 impl Tpu {
+    #[cfg_attr(feature = "cargo-clippy", allow(too_many_arguments))]
     pub fn new(
         keypair: Arc<Keypair>,
         bank: &Arc<Bank>,
@@ -63,6 +65,7 @@ impl Tpu {
         ledger_path: &str,
         sigverify_disabled: bool,
         entry_height: u64,
+        last_entry_id: &Hash,
         leader_scheduler: Arc<RwLock<LeaderScheduler>>,
     ) -> (Self, Receiver<Vec<Entry>>, Arc<AtomicBool>) {
         let exit = Arc::new(AtomicBool::new(false));
@@ -73,7 +76,7 @@ impl Tpu {
             SigVerifyStage::new(packet_receiver, sigverify_disabled);
 
         let (banking_stage, entry_receiver) =
-            BankingStage::new(&bank, verified_receiver, tick_duration);
+            BankingStage::new(&bank, verified_receiver, tick_duration, last_entry_id);
 
         let (write_stage, entry_forwarder) = WriteStage::new(
             keypair,

--- a/src/tvu.rs
+++ b/src/tvu.rs
@@ -39,6 +39,7 @@
 use bank::Bank;
 use blob_fetch_stage::BlobFetchStage;
 use cluster_info::ClusterInfo;
+use hash::Hash;
 use leader_scheduler::LeaderScheduler;
 use replicate_stage::{ReplicateStage, ReplicateStageReturnType};
 use retransmit_stage::RetransmitStage;
@@ -52,7 +53,7 @@ use window::SharedWindow;
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum TvuReturnType {
-    LeaderRotation(u64),
+    LeaderRotation(u64, Hash),
 }
 
 pub struct Tvu {
@@ -148,9 +149,9 @@ impl Service for Tvu {
         self.retransmit_stage.join()?;
         self.fetch_stage.join()?;
         match self.replicate_stage.join()? {
-            Some(ReplicateStageReturnType::LeaderRotation(entry_height)) => {
-                Ok(Some(TvuReturnType::LeaderRotation(entry_height)))
-            }
+            Some(ReplicateStageReturnType::LeaderRotation(entry_height, last_entry_id)) => Ok(
+                Some(TvuReturnType::LeaderRotation(entry_height, last_entry_id)),
+            ),
             _ => Ok(None),
         }
     }

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -1017,11 +1017,13 @@ mod tests {
 
         let rpc_port = 11111; // Needs to be distinct known number to not conflict with other tests
 
+        let genesis_entries = &alice.create_entries();
+        let entry_height = genesis_entries.len() as u64;
         let server = Fullnode::new_with_bank(
             leader_keypair,
             bank,
-            0,
-            &[],
+            entry_height,
+            &genesis_entries,
             leader,
             None,
             &ledger_path,


### PR DESCRIPTION
1) Switch broken tests to generate a tick in their ledgers to use as valid last_id, as only ticks are valid last_id's accepted.

2) Fix bug where PoH generator in BankingStage did not referenced the last tick instead of the last entry on startup, causing ledger verification to fail on the new tick added by the PoH generator

3) Return last entry id from Replicate stage and pass last entry id to Banking Stage as the bank now only tracks the last tick id, not the last entry id.