### PR TITLE
Relax debit authorization

### DIFF
--- a/src/bank.rs
+++ b/src/bank.rs
@@ -484,12 +484,24 @@ impl Bank {
             }).collect()
     }
 
+    // Return true if the given account is being used by its program or if owned by pubkey that signed this transaction.
+    // Note: does not authorize if owned by a different program, even if signed.
+    fn is_debit_authorized(
+        account_index: usize,
+        instruction_program_id: &Pubkey,
+        account_program_id: &Pubkey,
+    ) -> bool {
+        instruction_program_id == account_program_id
+            || SystemProgram::check_id(&account_program_id) && account_index == 0
+    }
+
     pub fn verify_transaction(
         instruction_index: usize,
         tx_program_id: &Pubkey,
         pre_program_id: &Pubkey,
         pre_tokens: i64,
         account: &Account,
+        account_index: usize,
     ) -> Result<()> {
         // Verify the transaction
         // make sure that program_id is still the same or this was just assigned by the system call contract
@@ -501,7 +513,9 @@ impl Bank {
             return Err(BankError::ModifiedContractId(instruction_index as u8));
         }
         // For accounts unassigned to the contract, the individual balance of each accounts cannot decrease.
-        if *tx_program_id != account.program_id && pre_tokens > account.tokens {
+        if !Self::is_debit_authorized(account_index, tx_program_id, pre_program_id)
+            && pre_tokens > account.tokens
+        {
             return Err(BankError::ExternalAccountTokenSpend(
                 instruction_index as u8,
             ));
@@ -629,15 +643,14 @@ impl Bank {
             return Err(BankError::UnknownContractId(instruction_index as u8));
         }
         // Verify the transaction
-        for ((pre_program_id, pre_tokens), post_account) in
-            pre_data.iter().zip(program_accounts.iter())
-        {
+        for (i, (pre_program_id, pre_tokens)) in pre_data.iter().enumerate() {
             Self::verify_transaction(
                 instruction_index,
                 &tx_program_id,
                 pre_program_id,
                 *pre_tokens,
-                post_account,
+                &program_accounts[i],
+                i,
             )?;
         }
         // Send notifications


### PR DESCRIPTION
No need to assign an account to a program just to spend its tokens.
If the client signed the transaction for the program to spend tokens
that it owns, then let the program do it.

TODO:
- [ ] Add tests
- [ ] Find out if this means SystemProgram::Assign can be removed
