### PR TITLE
Last ids Q

### DIFF
--- a/benches/bank.rs
+++ b/benches/bank.rs
@@ -4,9 +4,7 @@ extern crate rayon;
 extern crate solana;
 extern crate test;
 
-use bincode::serialize;
 use solana::bank::*;
-use solana::hash::hash;
 use solana::mint::Mint;
 use solana::signature::{Keypair, KeypairUtil};
 use solana::system_transaction::SystemTransaction;
@@ -21,7 +19,7 @@ fn bench_process_transaction(bencher: &mut Bencher) {
     // Create transactions between unrelated parties.
     let transactions: Vec<_> = (0..4096)
         .into_iter()
-        .map(|i| {
+        .map(|_| {
             // Seed the 'from' account.
             let rando0 = Keypair::new();
             let tx = Transaction::system_move(


### PR DESCRIPTION
Use a single data structure thats locked atomically for queue ops.  There are a couple of spots where we take a read and or write lock of both of these.  If the order is ever reversed it will cause a hard to debug deadlock.  Using one structure is less efficient, but prevents those deadlocks.

It would be nice to move all the LastId specific ops into their own module as functions of this structure, but thats a big change.