### PR TITLE
Escape RUST_LOG configuration in remote-node.sh

### DIFF
--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -69,7 +69,7 @@ snap)
   logger "$logmarker"
 
   # shellcheck disable=SC2086 # Don't want to double quote "$nodeConfig"
-  sudo snap set solana $nodeConfig
+  sudo snap set solana "$nodeConfig"
   snap info solana
   sudo snap get solana
   echo Slight delay to get more syslog output

--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -44,11 +44,11 @@ snap)
   sudo snap install solana.snap --devmode --dangerous
 
   commonNodeConfig="\
-    leader-ip=$entrypointIp \
+    leader-ip=\"$entrypointIp\" \
     default-metrics-rate=1 \
-    metrics-config=$SOLANA_METRICS_CONFIG \
+    metrics-config=\"$SOLANA_METRICS_CONFIG\" \
     rust-log=\"$RUST_LOG\" \
-    setup-args=$setupArgs \
+    setup-args=\"$setupArgs\" \
   "
 
   if [[ -e /dev/nvidia0 ]]; then

--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -43,6 +43,7 @@ snap)
     net/scripts/rsync-retry.sh -vPrc "$entrypointIp:~/solana/solana.snap" .
   sudo snap install solana.snap --devmode --dangerous
 
+  # shellcheck disable=SC2089
   commonNodeConfig="\
     leader-ip=\"$entrypointIp\" \
     default-metrics-rate=1 \

--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -47,7 +47,7 @@ snap)
     leader-ip=$entrypointIp \
     default-metrics-rate=1 \
     metrics-config=$SOLANA_METRICS_CONFIG \
-    rust-log=$RUST_LOG \
+    rust-log=\"$RUST_LOG\" \
     setup-args=$setupArgs \
   "
 


### PR DESCRIPTION
- If it was set to #, it was causing other parameters to be commented out