### PR TITLE
Bypass lock_accounts when validating

### DIFF
--- a/src/bank.rs
+++ b/src/bank.rs
@@ -876,7 +876,13 @@ impl Bank {
 
     pub fn process_entry(&self, entry: &Entry) -> Result<()> {
         if !entry.transactions.is_empty() {
-            for result in self.process_transactions(&entry.transactions) {
+            // The leader guarentees all unique accounts within a single entry.
+            let lock_results = entry.transactions.iter().map(|_| Ok(())).collect();
+            for result in self.execute_and_commit_transactions(
+                &entry.transactions,
+                lock_results,
+                MAX_ENTRY_IDS,
+            ) {
                 result?;
             }
         } else {


### PR DESCRIPTION
Proposed alternative to #1499. The problem being solved here (@aeyakovenko, create a ticket?) is to ensure the validator is at least as fast as the leader, even though the validator may have fewer and slower CPUs.

The leader rejects any transactions that attempts to write to the same
account as any other. The validator, therefore, can skip the check
so long as it processes entries sequentially.

Please don't merge this. Cherry-pick and benchmark.