### PR TITLE
Fix bug introduced during RUST_LOG escaping

### DIFF
--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -68,7 +68,7 @@ snap)
   logmarker="solana deploy $(date)/$RANDOM"
   logger "$logmarker"
 
-  # shellcheck disable=SC2086 # Don't want to double quote "$nodeConfig"
+  # shellcheck disable=SC2086,SC2090 # Don't want to double quote "$nodeConfig"
   sudo snap set solana $nodeConfig
   snap info solana
   sudo snap get solana

--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -69,7 +69,7 @@ snap)
   logger "$logmarker"
 
   # shellcheck disable=SC2086 # Don't want to double quote "$nodeConfig"
-  sudo snap set solana "$nodeConfig"
+  sudo snap set solana $nodeConfig
   snap info solana
   sudo snap get solana
   echo Slight delay to get more syslog output


### PR DESCRIPTION
- remote node configuration should not be quoted