### PR TITLE
Attempt to stabilize the test suite

### DIFF
--- a/ci/test-stable-perf.sh
+++ b/ci/test-stable-perf.sh
@@ -20,7 +20,12 @@ _() {
   "$@"
 }
 
-_ cargo test --features=cuda,erasure,chacha
+FEATURES=cuda,erasure,chacha
+_ cargo test --verbose --features=$FEATURES --lib
+
+# Run integration tests serially
+# shellcheck disable=SC2016
+_ find tests -type file -exec sh -c 'echo --test=$(basename ${0%.*})' {} \; | xargs cargo test --verbose --jobs=1 --features=$FEATURES
 
 echo --- ci/localnet-sanity.sh
 (

--- a/ci/test-stable.sh
+++ b/ci/test-stable.sh
@@ -13,8 +13,12 @@ _() {
 
 _ cargo fmt -- --check
 _ cargo build --verbose
-_ cargo test --verbose
+_ cargo test --verbose --lib
 _ cargo clippy -- --deny=warnings
+
+# Run integration tests serially
+# shellcheck disable=SC2016
+_ find tests -type file -exec sh -c 'echo --test=$(basename ${0%.*})' {} \; | xargs cargo test --verbose --jobs=1
 
 echo --- ci/localnet-sanity.sh
 (


### PR DESCRIPTION
The integration tests are allowed to open sockets, so running them
in parallel may cause "Too many open files" errors. This patch
runs the unit tests in parallel and the integration test serially.