### PR TITLE
No longer allow unauthorized keys to witness transactions

### DIFF
--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -106,11 +106,22 @@ impl Transaction {
     pub fn userdata(&self, instruction_index: usize) -> &[u8] {
         &self.instructions[instruction_index].userdata
     }
-    pub fn key(&self, instruction_index: usize, accounts_index: usize) -> Option<&Pubkey> {
+    fn key_index(&self, instruction_index: usize, accounts_index: usize) -> Option<usize> {
         self.instructions
             .get(instruction_index)
             .and_then(|instruction| instruction.accounts.get(accounts_index))
-            .and_then(|ai| self.account_keys.get(*ai as usize))
+            .map(|&account_keys_index| account_keys_index as usize)
+    }
+    pub fn key(&self, instruction_index: usize, accounts_index: usize) -> Option<&Pubkey> {
+        self.key_index(instruction_index, accounts_index)
+            .and_then(|account_keys_index| self.account_keys.get(account_keys_index))
+    }
+    pub fn signed_key(&self, instruction_index: usize, accounts_index: usize) -> Option<&Pubkey> {
+        match self.key_index(instruction_index, accounts_index) {
+            None => None,
+            Some(0) => self.account_keys.get(0),
+            Some(_) => None,
+        }
     }
     pub fn program_id(&self, instruction_index: usize) -> &Pubkey {
         let program_ids_index = self.instructions[instruction_index].program_ids_index;
@@ -210,12 +221,25 @@ mod tests {
             instructions,
         );
         assert!(tx.verify_refs());
+
         assert_eq!(tx.key(0, 0), Some(&key.pubkey()));
+        assert_eq!(tx.signed_key(0, 0), Some(&key.pubkey()));
+
         assert_eq!(tx.key(1, 0), Some(&key.pubkey()));
+        assert_eq!(tx.signed_key(1, 0), Some(&key.pubkey()));
+
         assert_eq!(tx.key(0, 1), Some(&key1));
+        assert_eq!(tx.signed_key(0, 1), None);
+
         assert_eq!(tx.key(1, 1), Some(&key2));
+        assert_eq!(tx.signed_key(1, 1), None);
+
         assert_eq!(tx.key(2, 0), None);
+        assert_eq!(tx.signed_key(2, 0), None);
+
         assert_eq!(tx.key(0, 2), None);
+        assert_eq!(tx.signed_key(0, 2), None);
+
         assert_eq!(*tx.program_id(0), prog1);
         assert_eq!(*tx.program_id(1), prog2);
     }


### PR DESCRIPTION
Before this patch, an attacker could point Budget instructions to unsigned keys, and authorize a transaction from an unauthorized party. This patch adds a new `signed_key` method to `Transaction` that allows programs to lookup only signed keys. Currently, that implies key zero, but once `signature: Signature` becomes `Vec<Signature>`, the method will allow a program to safely use any key in that vector.