### PR TITLE
Wildcard early OOM deb package revision

### DIFF
--- a/net/scripts/install-earlyoom.sh
+++ b/net/scripts/install-earlyoom.sh
@@ -13,8 +13,8 @@ sysctl -w kernel.sysrq=$(( $(cat /proc/sys/kernel/sysrq) | 64 ))
 if command -v earlyoom; then
   systemctl status earlyoom
 else
-  wget http://ftp.us.debian.org/debian/pool/main/e/earlyoom/earlyoom_1.1-2_amd64.deb
-  apt install --quiet --yes ./earlyoom_1.1-2_amd64.deb
+  wget  -r -l1 -np http://ftp.us.debian.org/debian/pool/main/e/earlyoom/ -A 'earlyoom_1.1-*_amd64.deb' -e robots=off -nd
+  apt install --quiet --yes ./earlyoom_1.1-*_amd64.deb
 
   cat > earlyoom <<OOM
   # use the kernel OOM killer, trigger at 20% available RAM,


### PR DESCRIPTION
http://ftp.us.debian.org/debian/pool/main/e/earlyoom/ has dropped the 1.1-2 revision. So network deployment scripts were failing.