### PR TITLE
Increase window size

### DIFF
--- a/src/window.rs
+++ b/src/window.rs
@@ -17,7 +17,7 @@ use std::net::SocketAddr;
 use std::sync::atomic::AtomicUsize;
 use std::sync::{Arc, RwLock};
 
-pub const WINDOW_SIZE: u64 = 2 * 1024;
+pub const WINDOW_SIZE: u64 = 32 * 1024;
 
 #[derive(Default, Clone)]
 pub struct WindowSlot {


### PR DESCRIPTION
Addresses the following problem
- Validators are not able to keep up with the leader
- The future blobs (outside of window) get dropped
- The validators won't process repair requests for these future blobs