### PR TITLE
Bump drone read timeout to 10s

### DIFF
--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -543,7 +543,7 @@ pub fn request_airdrop(
 ) -> Result<Signature, Error> {
     // TODO: make this async tokio client
     let mut stream = TcpStream::connect(drone_addr)?;
-    stream.set_read_timeout(Some(Duration::new(3, 0)))?;
+    stream.set_read_timeout(Some(Duration::new(10, 0)))?;
     let req = DroneRequest::GetAirdrop {
         airdrop_request_amount: tokens,
         client_pubkey: *id,


### PR DESCRIPTION
The previous timeout of 3s was not generous enough occasionally.

cc: https://github.com/solana-labs/solana/issues/1536