### PR TITLE
Avoid restarting services on leader -> validator transition

### DIFF
--- a/src/bank.rs
+++ b/src/bank.rs
@@ -410,9 +410,11 @@ impl Bank {
     fn unlock_account(tx: &Transaction, result: &Result<()>, account_locks: &mut HashSet<Pubkey>) {
         match result {
             Err(BankError::AccountInUse) => (),
-            _ => for k in &tx.account_keys {
-                account_locks.remove(k);
-            },
+            _ => {
+                for k in &tx.account_keys {
+                    account_locks.remove(k);
+                }
+            }
         }
     }
 

--- a/src/leader_vote_stage.rs
+++ b/src/leader_vote_stage.rs
@@ -81,7 +81,7 @@ impl LeaderVoteStage {
     /// Create a new LeaderVoteStage for voting and broadcasting entries.
     pub fn new(
         keypair: Arc<Keypair>,
-        bank: Arc<Bank>,
+        bank: Arc<RwLock<Bank>>,
         cluster_info: Arc<RwLock<ClusterInfo>>,
         entry_receiver: Receiver<Vec<Entry>>,
     ) -> (Self, Receiver<Vec<Entry>>) {

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -241,9 +241,7 @@ pub fn set_panic_hook(program: &'static str) {
                     )
                     .add_field(
                         "host",
-                        influxdb::Value::String(
-                            hostname().unwrap_or_else(|_| "?".to_string())
-                        ),
+                        influxdb::Value::String(hostname().unwrap_or_else(|_| "?".to_string())),
                     )
                     .to_owned(),
             );

--- a/src/netutil.rs
+++ b/src/netutil.rs
@@ -125,9 +125,11 @@ pub fn bind_in_range(range: (u16, u16)) -> io::Result<(u16, UdpSocket)> {
                 let sock = sock.into_udp_socket();
                 break Result::Ok((sock.local_addr().unwrap().port(), sock));
             }
-            Err(err) => if err.kind() != io::ErrorKind::AddrInUse || tries_left == 0 {
-                return Err(err);
-            },
+            Err(err) => {
+                if err.kind() != io::ErrorKind::AddrInUse || tries_left == 0 {
+                    return Err(err);
+                }
+            }
         }
         tries_left -= 1;
     }
@@ -171,9 +173,11 @@ pub fn find_available_port_in_range(range: (u16, u16)) -> io::Result<u16> {
             Ok(_) => {
                 break Ok(rand_port);
             }
-            Err(err) => if err.kind() != io::ErrorKind::AddrInUse || tries_left == 0 {
-                return Err(err);
-            },
+            Err(err) => {
+                if err.kind() != io::ErrorKind::AddrInUse || tries_left == 0 {
+                    return Err(err);
+                }
+            }
         }
         tries_left -= 1;
     }

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -378,9 +378,11 @@ impl Blob {
                     }
                     return Err(Error::IO(e));
                 }
-                Ok(()) => if i == 0 {
-                    socket.set_nonblocking(true)?;
-                },
+                Ok(()) => {
+                    if i == 0 {
+                        socket.set_nonblocking(true)?;
+                    }
+                }
             }
             v.push(r);
         }

--- a/src/poh_recorder.rs
+++ b/src/poh_recorder.rs
@@ -7,7 +7,7 @@ use hash::Hash;
 use poh::Poh;
 use result::{Error, Result};
 use std::sync::mpsc::Sender;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, RwLock};
 use transaction::Transaction;
 
 #[derive(Debug, PartialEq, Eq, Clone)]
@@ -18,7 +18,7 @@ pub enum PohRecorderError {
 #[derive(Clone)]
 pub struct PohRecorder {
     poh: Arc<Mutex<Poh>>,
-    bank: Arc<Bank>,
+    bank: Arc<RwLock<Bank>>,
     sender: Sender<Vec<Entry>>,
     // TODO: whe extracting PoH generator into a separate standalone service,
     // use this field for checking timeouts when running as a validator, and as
@@ -31,7 +31,7 @@ impl PohRecorder {
     /// * bank - the LastId's queue is updated on `tick` and `record` events
     /// * sender - the Entry channel that outputs to the ledger
     pub fn new(
-        bank: Arc<Bank>,
+        bank: Arc<RwLock<Bank>>,
         sender: Sender<Vec<Entry>>,
         last_entry_id: Hash,
         tick_height: u64,
@@ -105,7 +105,7 @@ impl PohRecorder {
 
     fn register_and_send_tick(&self, poh: &mut Poh) -> Result<()> {
         let tick = poh.tick();
-        self.bank.register_entry_id(&tick.id);
+        self.bank.read().unwrap().register_entry_id(&tick.id);
         let entry = Entry {
             num_hashes: tick.num_hashes,
             id: tick.id,
@@ -128,8 +128,8 @@ mod tests {
     #[test]
     fn test_poh() {
         let mint = Mint::new(1);
-        let bank = Arc::new(Bank::new(&mint));
-        let last_id = bank.last_id();
+        let bank = Arc::new(RwLock::new(Bank::new(&mint)));
+        let last_id = bank.read().unwrap().last_id();
         let (entry_sender, entry_receiver) = channel();
         let mut poh_recorder = PohRecorder::new(bank, entry_sender, last_id, 0, None);
 

--- a/src/request_processor.rs
+++ b/src/request_processor.rs
@@ -3,15 +3,15 @@
 use bank::Bank;
 use request::{Request, Response};
 use std::net::SocketAddr;
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 
 pub struct RequestProcessor {
-    bank: Arc<Bank>,
+    bank: Arc<RwLock<Bank>>,
 }
 
 impl RequestProcessor {
     /// Create a new Tpu that wraps the given Bank.
-    pub fn new(bank: Arc<Bank>) -> Self {
+    pub fn new(bank: Arc<RwLock<Bank>>) -> Self {
         RequestProcessor { bank }
     }
 
@@ -23,31 +23,31 @@ impl RequestProcessor {
     ) -> Option<(Response, SocketAddr)> {
         match msg {
             Request::GetAccount { key } => {
-                let account = self.bank.get_account(&key);
+                let account = self.bank.read().unwrap().get_account(&key);
                 let rsp = (Response::Account { key, account }, rsp_addr);
                 info!("Response::Account {:?}", rsp);
                 Some(rsp)
             }
             Request::GetLastId => {
-                let id = self.bank.last_id();
+                let id = self.bank.read().unwrap().last_id();
                 let rsp = (Response::LastId { id }, rsp_addr);
                 info!("Response::LastId {:?}", rsp);
                 Some(rsp)
             }
             Request::GetTransactionCount => {
-                let transaction_count = self.bank.transaction_count() as u64;
+                let transaction_count = self.bank.read().unwrap().transaction_count() as u64;
                 let rsp = (Response::TransactionCount { transaction_count }, rsp_addr);
                 info!("Response::TransactionCount {:?}", rsp);
                 Some(rsp)
             }
             Request::GetSignature { signature } => {
-                let signature_status = self.bank.has_signature(&signature);
+                let signature_status = self.bank.read().unwrap().has_signature(&signature);
                 let rsp = (Response::SignatureStatus { signature_status }, rsp_addr);
                 info!("Response::Signature {:?}", rsp);
                 Some(rsp)
             }
             Request::GetFinality => {
-                let time = self.bank.finality();
+                let time = self.bank.read().unwrap().finality();
                 let rsp = (Response::Finality { time }, rsp_addr);
                 info!("Response::Finality {:?}", rsp);
                 Some(rsp)

--- a/src/rpu.rs
+++ b/src/rpu.rs
@@ -30,7 +30,7 @@ use service::Service;
 use std::net::UdpSocket;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::channel;
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 use std::thread::{self, JoinHandle};
 use streamer;
 
@@ -41,7 +41,11 @@ pub struct Rpu {
 }
 
 impl Rpu {
-    pub fn new(bank: &Arc<Bank>, requests_socket: UdpSocket, respond_socket: UdpSocket) -> Self {
+    pub fn new(
+        bank: &Arc<RwLock<Bank>>,
+        requests_socket: UdpSocket,
+        respond_socket: UdpSocket,
+    ) -> Self {
         let exit = Arc::new(AtomicBool::new(false));
         let (packet_sender, packet_receiver) = channel();
         let t_receiver = streamer::receiver(

--- a/src/tpu.rs
+++ b/src/tpu.rs
@@ -60,7 +60,7 @@ impl Tpu {
     #[cfg_attr(feature = "cargo-clippy", allow(too_many_arguments))]
     pub fn new(
         keypair: Arc<Keypair>,
-        bank: &Arc<Bank>,
+        bank: &Arc<RwLock<Bank>>,
         cluster_info: &Arc<RwLock<ClusterInfo>>,
         tick_duration: Config,
         transactions_sockets: Vec<UdpSocket>,

--- a/tests/multinode.rs
+++ b/tests/multinode.rs
@@ -1338,13 +1338,12 @@ fn test_full_leader_validator_network() {
         num_reached_target_height = 0;
         for n in nodes.iter() {
             let node_lock = n.read().unwrap();
-            let ls_lock = &node_lock.leader_scheduler;
-            if let Some(sh) = ls_lock.read().unwrap().last_seed_height {
+            let seed_height = node_lock.get_last_seed_height();
+            if let Some(sh) = seed_height {
                 if sh >= target_height {
                     num_reached_target_height += 1;
                 }
             }
-            drop(ls_lock);
         }
 
         sleep(Duration::new(1, 0));


### PR DESCRIPTION
Instead of restarting services with the new bank, simply replace the old bank instead. Currently, restarting of services can cause contention for resources.