### PR TITLE
Fetch perf-libs with configurable packet size

### DIFF
--- a/fetch-perf-libs.sh
+++ b/fetch-perf-libs.sh
@@ -15,7 +15,7 @@ mkdir -p target/perf-libs
   cd target/perf-libs
   (
     set -x
-    curl https://solana-perf.s3.amazonaws.com/v0.10.1/x86_64-unknown-linux-gnu/solana-perf.tgz | tar zxvf -
+    curl https://solana-perf.s3.amazonaws.com/v0.10.2/x86_64-unknown-linux-gnu/solana-perf.tgz | tar zxvf -
   )
 
   if [[ -r /usr/local/cuda/version.txt && -r cuda-version.txt ]]; then


### PR DESCRIPTION
sig verify library uses passed in size directly
to get packet size, so rust side can be modified
without changing cuda library.