### PR TITLE
Add leader-readiness test to wallet-sanity

### DIFF
--- a/scripts/wallet-sanity.sh
+++ b/scripts/wallet-sanity.sh
@@ -35,19 +35,18 @@ pay_and_confirm() {
 
 leader_readiness=false
 timeout=60
-while [ $timeout -gt 0 ]
-do
+while [[ $timeout -gt 0 ]]; do
   expected_output="Leader ready"
   exec 42>&1
-  output=$($solana_wallet "${entrypoint[@]}" leader-ready | tee >(cat - >&42))
-  if [[ "$output" =~ $expected_output ]]; then
+  output=$($solana_wallet "${entrypoint[@]}" get-transaction-count | tee >(cat - >&42))
+  if [[ $output -gt 0 ]]; then
     leader_readiness=true
     break
   fi
   sleep 2
   (( timeout=timeout-2 ))
 done
-if [ "$leader_readiness" = false ]; then
+if ! "$leader_readiness"; then
   echo "Timed out waiting for leader"
   exit 1
 fi

--- a/src/bin/wallet.rs
+++ b/src/bin/wallet.rs
@@ -163,8 +163,8 @@ fn main() -> Result<(), Box<error::Error>> {
                 )
                 // TODO: Add "loader" argument; current default is bpf_loader
         ).subcommand(
-            SubCommand::with_name("leader-ready")
-                .about("Determine leader readiness")
+            SubCommand::with_name("get-transaction-count")
+                .about("Get current transaction count")
         ).subcommand(
             SubCommand::with_name("pay")
                 .about("Send a payment")

--- a/src/bin/wallet.rs
+++ b/src/bin/wallet.rs
@@ -163,6 +163,9 @@ fn main() -> Result<(), Box<error::Error>> {
                 )
                 // TODO: Add "loader" argument; current default is bpf_loader
         ).subcommand(
+            SubCommand::with_name("leader-ready")
+                .about("Determine leader readiness")
+        ).subcommand(
             SubCommand::with_name("pay")
                 .about("Send a payment")
                 .arg(

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -42,7 +42,7 @@ pub enum WalletCommand {
     Cancel(Pubkey),
     Confirm(Signature),
     Deploy(String),
-    GetLeaderReadiness,
+    GetTransactionCount,
     // Pay(tokens, to, timestamp, timestamp_pubkey, witness(es), cancelable)
     Pay(
         i64,
@@ -146,7 +146,7 @@ pub fn parse_command(
                 .unwrap()
                 .to_string(),
         )),
-        ("leader-ready", Some(_matches)) => Ok(WalletCommand::GetLeaderReadiness),
+        ("get-transaction-count", Some(_matches)) => Ok(WalletCommand::GetTransactionCount),
         ("pay", Some(pay_matches)) => {
             let tokens = pay_matches.value_of("tokens").unwrap().parse()?;
             let to = if pay_matches.is_present("to") {
@@ -454,15 +454,12 @@ pub fn process_command(config: &WalletConfig) -> Result<String, Box<error::Error
                 "programId": format!("{}", program.pubkey()),
             }).to_string())
         }
-        WalletCommand::GetLeaderReadiness => {
-            // TODO: This logic is currently only correct for initial network boot;
-            // needs updating for leader rotation
+        WalletCommand::GetTransactionCount => {
             let transaction_count = RpcRequest::GetTransactionCount
                 .make_rpc_request(&config.rpc_addr, 1, None)?
                 .as_u64();
             match transaction_count {
-                Some(0) => Ok("Leader not ready".to_string()),
-                Some(_) => Ok("Leader ready".to_string()),
+                Some(count) => Ok(count.to_string()),
                 None => Err(WalletError::RpcRequestError(
                     "Received result of an unexpected type".to_string(),
                 ))?,


### PR DESCRIPTION
Discovered that on initial testnet boot, `wallet-sanity.sh` was firing off airdrop requests before the leader TPU was up and running, leading to "Airdrop failed" errors. (This race condition is likely happening on some CI builds as well.)

This PR provides a leader-ready subcommand in solana-wallet, and implements a check in `wallet-sanity.sh` for leader readiness before attempting to airdrop, etc.

Fixes #1559 