### PR TITLE
Use a smaller test value for window_size

### DIFF
--- a/src/bank.rs
+++ b/src/bank.rs
@@ -1706,7 +1706,7 @@ mod tests {
         //            let (_, _) = bank.process_ledger(ledger).unwrap();
         //        }
 
-        let window_size = WINDOW_SIZE as usize;
+        let window_size = 128;
         for entry_count in window_size - 3..window_size + 2 {
             let (ledger, pubkey) = create_sample_ledger(entry_count);
             let bank = Bank::default();
@@ -1714,7 +1714,7 @@ mod tests {
             assert_eq!(bank.get_balance(&pubkey), 1);
             assert_eq!(ledger_height, entry_count as u64 + 3);
             assert_eq!(tick_height, 2);
-            assert!(tail.len() <= window_size);
+            assert!(tail.len() <= WINDOW_SIZE as usize);
             let last_entry = &tail[tail.len() - 1];
             assert_eq!(bank.last_id(), last_entry.id);
         }


### PR DESCRIPTION
Otherwise this test takes forever to run.

#### Problem

The run time of test_process_ledger_around_window_size is dependent on WINDOW_SIZE constant, but when that increases so does the test. It also takes over 3 minutes to run.

#### Summary of Changes

Lower the window size.

Fixes #
