### PR TITLE
Create/publish bpf-sdk tarball

### DIFF
--- a/ci/buildkite-snap.yml
+++ b/ci/buildkite-snap.yml
@@ -8,3 +8,6 @@ steps:
   - command: "ci/publish-crate.sh"
     timeout_in_minutes: 20
     name: "publish crate [public]"
+  - command: "ci/publish-bpf-sdk.sh"
+    timeout_in_minutes: 5
+    name: "publish bpf sdk"

--- a/ci/crate-version.sh
+++ b/ci/crate-version.sh
@@ -1,0 +1,16 @@
+#!/bin/bash -e
+#
+# Outputs the current crate version
+#
+
+cd "$(dirname "$0")"/..
+
+while read -r name equals value _; do
+  if [[ $name = version && $equals = = ]]; then
+    echo "${value//\"/}"
+    exit 0
+  fi
+done < <(cat Cargo.toml)
+
+echo Unable to locate version in Cargo.toml 1>&2
+exit 1

--- a/ci/publish-bpf-sdk.sh
+++ b/ci/publish-bpf-sdk.sh
@@ -1,0 +1,40 @@
+#!/bin/bash -e
+
+cd "$(dirname "$0")/.."
+
+version=$(./ci/crate-version.sh)
+
+echo --- Creating tarball
+(
+  set -x
+  rm -rf bpf-sdk/
+  mkdir bpf-sdk/
+  (
+    echo "$version"
+    git rev-parse HEAD
+  ) > bpf-sdk/version.txt
+
+  cp -ra programs/bpf/c/* bpf-sdk/
+
+  tar jvcf bpf-sdk.tar.bz2 bpf-sdk/
+)
+
+
+echo --- AWS S3 Store
+
+set -x
+if [[ -z "$BRANCH" || $BRANCH =~ pull/* ]]; then
+  exit 0
+fi
+
+if [[ ! -r s3cmd-2.0.1/s3cmd ]]; then
+  rm -rf s3cmd-2.0.1.tar.gz s3cmd-2.0.1
+  wget https://github.com/s3tools/s3cmd/releases/download/v2.0.1/s3cmd-2.0.1.tar.gz
+  tar zxf s3cmd-2.0.1.tar.gz
+fi
+
+python ./s3cmd-2.0.1/s3cmd --acl-public put bpf-sdk.tar.bz2 \
+  s3://solana-sdk/"$version"/bpf-sdk.tar.bz2
+
+exit 0
+


### PR DESCRIPTION
🎉 http://solana-sdk.s3.amazonaws.com/0.11.0/bpf-sdk.tar.bz2

A new tarball will be published on every commit to a branch using the crate version number.  This has the potential to confuse slightly as `0.11.0` will continue to be updated until `0.11` branches off master.  A `version.txt` is supplied in the tarball containing the exact git sha1 though