### PR TITLE
Increase rmem and wmem for remote nodes in testnet (#1635)

### DIFF
--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -35,6 +35,8 @@ else
   setupArgs="-l"
 fi
 
+sudo sysctl -w net.core.rmem_default=1610612736
+sudo sysctl -w net.core.wmem_default=1610612736
 
 case $deployMethod in
 snap)


### PR DESCRIPTION
#### Problem
Testnet nodes are dropping IP packets in kernel due to rcvbuf_errors. This causes packet loss and more repair requests.

#### Summary of Changes
Increase rmem and wmem for the remote nodes.

Fixes #
Cherry-pick from master