### PR TITLE
bpf/c/sdk tweaks

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -24,6 +24,8 @@ fn main() {
             + &env::var("PROFILE").unwrap()
             + &"/bpf".to_string();
 
+        println!("cargo:rerun-if-changed=programs/bpf/c/sdk/bpf.mk");
+        println!("cargo:rerun-if-changed=programs/bpf/c/sdk/inc/sol_bpf.h");
         println!("cargo:rerun-if-changed=programs/bpf/c/makefile");
         println!("cargo:rerun-if-changed=programs/bpf/c/src/move_funds.c");
         println!("cargo:rerun-if-changed=programs/bpf/c/src/noop.c");

--- a/programs/bpf/c/sdk/README.md
+++ b/programs/bpf/c/sdk/README.md
@@ -8,11 +8,12 @@ The following link describes how to install llvm:
 
 ### macOS
 
-Ensure the latest llvm is installed:
+The following depends on Homebrew, instructions on how to install Homebrew are at https://brew.sh
+
+Once Homebrew is installed, ensure the latest llvm is installed:
 ```
 $ brew update        # <- ensure your brew is up to date
-$ brew list llvm     # <- should see "llvm: stable 7.0.0 (bottled), HEAD [keg-only]"
-$ brew install llvm
-$ brew --prefix llvm # <- should output "/usr/local/opt/llvm"
+$ brew install llvm  # <- should output “Warning: llvm 7.0.0 is already installed and up-to-date”
+$ brew --prefix llvm # <- should output “/usr/local/opt/llvm”
 ```
 

--- a/programs/bpf/c/sdk/bpf.mk
+++ b/programs/bpf/c/sdk/bpf.mk
@@ -7,7 +7,7 @@ _@ :=@
 endif
 
 INC_DIRS :=
-SYSTEM_INC_DIRS := -isystem $(dir $(lastword $(MAKEFILE_LIST)))/inc
+SYSTEM_INC_DIRS := -isystem $(dir $(lastword $(MAKEFILE_LIST)))inc
 SRC_DIR := ./src
 OUT_DIR := ./out
 
@@ -18,25 +18,25 @@ else
 LLVM_DIR := /usr/local/opt/llvm
 endif
 
-CC = $(LLVM_DIR)/bin/clang
-CC_FLAGS = \
-	-Werror \
-	-target \
-	bpf -O2 \
-	-emit-llvm \
-	-fno-builtin
+CC := $(LLVM_DIR)/bin/clang
+CC_FLAGS := \
+  -Werror \
+  -target bpf \
+  -O2 \
+  -emit-llvm \
+  -fno-builtin \
 
-LD = $(LLVM_DIR)/bin/llc
-LD_FLAGS = \
-	-march=bpf \
-	-filetype=obj \
-	-function-sections
+LD := $(LLVM_DIR)/bin/llc
+LD_FLAGS := \
+  -march=bpf \
+  -filetype=obj \
+  -function-sections \
 
-OBJ_DUMP = $(LLVM_DIR)/bin/llvm-objdump
-OBJ_DUMP_FLAGS = \
-	-color \
-	-source \
-	-disassemble
+OBJ_DUMP := $(LLVM_DIR)/bin/llvm-objdump
+OBJ_DUMP_FLAGS := \
+  -color \
+  -source \
+  -disassemble \
 
 help:
 	@echo 'BPF Program makefile'
@@ -81,7 +81,7 @@ help:
 $(OUT_DIR)/%.bc: $(SRC_DIR)/%.c
 	@echo "[cc] $@ ($<)"
 	$(_@)mkdir -p $(OUT_DIR)
-	$(_@)$(CC) $(CC_FLAGS) $(SYSTEM_INC_DIRS) $(INC_DIRS) -o $@ -c $<  -MMD -MF $(@:.bc=.d)
+	$(_@)$(CC) $(CC_FLAGS) $(SYSTEM_INC_DIRS) $(INC_DIRS) -o $@ -c $< -MD -MF $(@:.bc=.d)
 
 .PRECIOUS: $(OUT_DIR)/%.o
 $(OUT_DIR)/%.o: $(OUT_DIR)/%.bc

--- a/programs/bpf/c/sdk/bpf.mk
+++ b/programs/bpf/c/sdk/bpf.mk
@@ -26,8 +26,8 @@ CC_FLAGS := \
   -emit-llvm \
   -fno-builtin \
 
-LD := $(LLVM_DIR)/bin/llc
-LD_FLAGS := \
+LLC := $(LLVM_DIR)/bin/llc
+LLC_FLAGS := \
   -march=bpf \
   -filetype=obj \
   -function-sections \
@@ -85,8 +85,8 @@ $(OUT_DIR)/%.bc: $(SRC_DIR)/%.c
 
 .PRECIOUS: $(OUT_DIR)/%.o
 $(OUT_DIR)/%.o: $(OUT_DIR)/%.bc
-	@echo "[ld] $@ ($<)"
-	$(_@)$(LD) $(LD_FLAGS) -o $@ $<
+	@echo "[llc] $@ ($<)"
+	$(_@)$(LLC) $(LLC_FLAGS) -o $@ $<
 
 -include $(wildcard $(OUT_DIR)/*.d)
 

--- a/programs/bpf/c/sdk/inc/sol_bpf.h
+++ b/programs/bpf/c/sdk/inc/sol_bpf.h
@@ -1,11 +1,10 @@
-#ifndef SOL_BPF_H
-#define SOL_BPF_H
+#pragma once
 /**
  * @brief Solana C-based BPF program utility functions and types
  */
 
 /**
- * Numberic types
+ * Numeric types
  */
 typedef signed char int8_t;
 typedef unsigned char uint8_t;
@@ -57,7 +56,7 @@ static int (*sol_print)(
  * Prefix for all BPF functions
  *
  * This prefix should be used for functions in order to facilitate
- * interopability with BPF representation
+ * interoperability with BPF representation
  */
 #define SOL_FN_PREFIX __attribute__((always_inline)) static
 
@@ -78,7 +77,7 @@ typedef struct {
  *
  * @param one First public key
  * @param two Second public key
- * @return True if the same
+ * @return true if the same
  */
 SOL_FN_PREFIX bool SolPubkey_same(const SolPubkey *one, const SolPubkey *two) {
   for (int i = 0; i < SIZE_PUBKEY; i++) {
@@ -145,7 +144,7 @@ SOL_FN_PREFIX void _sol_panic(uint64_t line) {
  * @param ka Pointer to an array of SolKeyedAccounts to deserialize into
  * @param data On return, a pointer to the instruction data
  * @param data_len On return, the length in bytes of the instruction data
- * @return Boolan True if successful
+ * @return Boolean true if successful
  */
 SOL_FN_PREFIX bool sol_deserialize(
   const uint8_t *input,
@@ -243,7 +242,7 @@ SOL_FN_PREFIX void sol_print_params(
  * Program entrypoint
  * @{
  *
- * The following is An example of a simple program that prints the input
+ * The following is an example of a simple program that prints the input
  * parameters it received:
  *
  * #define NUM_KA 1
@@ -265,10 +264,8 @@ SOL_FN_PREFIX void sol_print_params(
  * Program entrypoint signature
  *
  * @param input An array containing serialized input parameters
- * @return True if successful
+ * @return true if successful
  */
 extern bool entrypoint(const uint8_t *input);
 
 /**@}*/
-
-#endif  // SOL_BPF_C

--- a/programs/bpf/c/sdk/inc/sol_bpf.h
+++ b/programs/bpf/c/sdk/inc/sol_bpf.h
@@ -3,6 +3,10 @@
  * @brief Solana C-based BPF program utility functions and types
  */
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * Numeric types
  */
@@ -267,5 +271,9 @@ SOL_FN_PREFIX void sol_print_params(
  * @return true if successful
  */
 extern bool entrypoint(const uint8_t *input);
+
+#ifdef __cplusplus
+}
+#endif
 
 /**@}*/

--- a/programs/bpf/c/sdk/inc/sol_bpf.h
+++ b/programs/bpf/c/sdk/inc/sol_bpf.h
@@ -1,5 +1,5 @@
-#ifndef SOL_BPF_C_H
-#define SOL_BPF_C_H
+#ifndef SOL_BPF_H
+#define SOL_BPF_H
 /**
  * @brief Solana C-based BPF program utility functions and types
  */
@@ -271,4 +271,4 @@ extern bool entrypoint(const uint8_t *input);
 
 /**@}*/
 
-#endif  // SOL_BPF_C_H
+#endif  // SOL_BPF_C

--- a/programs/bpf/c/sdk/inc/sol_bpf_c.h
+++ b/programs/bpf/c/sdk/inc/sol_bpf_c.h
@@ -43,8 +43,13 @@ typedef enum { false = 0, true } bool;
  * Prints the hexadecimal representation of each parameter
  */
 #define BPF_TRACE_PRINTK_IDX 6
-static int (*sol_print)(uint64_t, uint64_t, uint64_t, uint64_t,
-                        uint64_t) = (void *)BPF_TRACE_PRINTK_IDX;
+static int (*sol_print)(
+  uint64_t,
+  uint64_t,
+  uint64_t,
+  uint64_t,
+  uint64_t
+) = (void *)BPF_TRACE_PRINTK_IDX;
 
 /**@}*/
 
@@ -142,9 +147,13 @@ SOL_FN_PREFIX void _sol_panic(uint64_t line) {
  * @param data_len On return, the length in bytes of the instruction data
  * @return Boolan True if successful
  */
-SOL_FN_PREFIX bool sol_deserialize(const uint8_t *input, uint64_t num_ka,
-                                   SolKeyedAccounts *ka, uint8_t **data,
-                                   uint64_t *data_len) {
+SOL_FN_PREFIX bool sol_deserialize(
+  const uint8_t *input,
+  uint64_t num_ka,
+  SolKeyedAccounts *ka,
+  uint8_t **data,
+  uint64_t *data_len
+) {
   if (num_ka != *(uint64_t *)input) {
     return false;
   }
@@ -212,8 +221,12 @@ SOL_FN_PREFIX void sol_print_array(const uint8_t *array, int len) {
  * @param data A pointer to the instruction data to print
  * @param data_len The length in bytes of the instruction data
  */
-SOL_FN_PREFIX void sol_print_params(uint64_t num_ka, const SolKeyedAccounts *ka,
-                                    const uint8_t *data, uint64_t data_len) {
+SOL_FN_PREFIX void sol_print_params(
+  uint64_t num_ka,
+  const SolKeyedAccounts *ka,
+  const uint8_t *data,
+  uint64_t data_len
+) {
   sol_print(0, 0, 0, 0, num_ka);
   for (int i = 0; i < num_ka; i++) {
     sol_print_key(ka[i].key);

--- a/programs/bpf/c/sdk/inc/sol_bpf_c.h
+++ b/programs/bpf/c/sdk/inc/sol_bpf_c.h
@@ -75,7 +75,7 @@ typedef struct {
  * @param two Second public key
  * @return True if the same
  */
-SOL_FN_PREFIX bool SolPubkey_same(SolPubkey *one, SolPubkey *two) {
+SOL_FN_PREFIX bool SolPubkey_same(const SolPubkey *one, const SolPubkey *two) {
   for (int i = 0; i < SIZE_PUBKEY; i++) {
     if (one->x[i] != two->x[i]) {
       return false;
@@ -98,9 +98,9 @@ typedef struct {
 /**
  * Copies memory
  */
-SOL_FN_PREFIX void sol_memcpy(void *dst, void *src, int len) {
+SOL_FN_PREFIX void sol_memcpy(void *dst, const void *src, int len) {
   for (int i = 0; i < len; i++) {
-    *((uint8_t *)dst + i) = *((uint8_t *)src + i);
+    *((uint8_t *)dst + i) = *((const uint8_t *)src + i);
   }
 }
 
@@ -142,7 +142,7 @@ SOL_FN_PREFIX void _sol_panic(uint64_t line) {
  * @param data_len On return, the length in bytes of the instruction data
  * @return Boolan True if successful
  */
-SOL_FN_PREFIX bool sol_deserialize(uint8_t *input, uint64_t num_ka,
+SOL_FN_PREFIX bool sol_deserialize(const uint8_t *input, uint64_t num_ka,
                                    SolKeyedAccounts *ka, uint8_t **data,
                                    uint64_t *data_len) {
   if (num_ka != *(uint64_t *)input) {
@@ -187,7 +187,7 @@ SOL_FN_PREFIX bool sol_deserialize(uint8_t *input, uint64_t num_ka,
  *
  * @param key The public key to print
  */
-SOL_FN_PREFIX void sol_print_key(SolPubkey *key) {
+SOL_FN_PREFIX void sol_print_key(const SolPubkey *key) {
   for (int j = 0; j < SIZE_PUBKEY; j++) {
     sol_print(0, 0, 0, j, key->x[j]);
   }
@@ -198,7 +198,7 @@ SOL_FN_PREFIX void sol_print_key(SolPubkey *key) {
  *
  * @param array The array to print
  */
-SOL_FN_PREFIX void sol_print_array(uint8_t *array, int len) {
+SOL_FN_PREFIX void sol_print_array(const uint8_t *array, int len) {
   for (int j = 0; j < len; j++) {
     sol_print(0, 0, 0, j, array[j]);
   }
@@ -212,8 +212,8 @@ SOL_FN_PREFIX void sol_print_array(uint8_t *array, int len) {
  * @param data A pointer to the instruction data to print
  * @param data_len The length in bytes of the instruction data
  */
-SOL_FN_PREFIX void sol_print_params(uint64_t num_ka, SolKeyedAccounts *ka,
-                                    uint8_t *data, uint64_t data_len) {
+SOL_FN_PREFIX void sol_print_params(uint64_t num_ka, const SolKeyedAccounts *ka,
+                                    const uint8_t *data, uint64_t data_len) {
   sol_print(0, 0, 0, 0, num_ka);
   for (int i = 0; i < num_ka; i++) {
     sol_print_key(ka[i].key);
@@ -235,12 +235,12 @@ SOL_FN_PREFIX void sol_print_params(uint64_t num_ka, SolKeyedAccounts *ka,
  *
  * #define NUM_KA 1
  *
- * bool entrypoint(uint8_t *input) {
+ * bool entrypoint(const uint8_t *input) {
  *   SolKeyedAccounts ka[NUM_KA];
  *   uint8_t *data;
  *   uint64_t data_len;
  *
- *   if (1 != sol_deserialize((uint8_t *)buf, NUM_KA, ka, &data, &data_len)) {
+ *   if (1 != sol_deserialize(buf, NUM_KA, ka, &data, &data_len)) {
  *     return false;
  *   }
  *   print_params(1, ka, data, data_len);
@@ -254,7 +254,7 @@ SOL_FN_PREFIX void sol_print_params(uint64_t num_ka, SolKeyedAccounts *ka,
  * @param input An array containing serialized input parameters
  * @return True if successful
  */
-extern bool entrypoint(uint8_t *input);
+extern bool entrypoint(const uint8_t *input);
 
 /**@}*/
 

--- a/programs/bpf/c/src/move_funds.c
+++ b/programs/bpf/c/src/move_funds.c
@@ -3,7 +3,7 @@
  * another
  */
 
-#include <sol_bpf_c.h>
+#include <sol_bpf.h>
 
 /**
  * Number of SolKeyedAccounts expected. The program should bail if an

--- a/programs/bpf/c/src/move_funds.c
+++ b/programs/bpf/c/src/move_funds.c
@@ -6,17 +6,17 @@
 #include <sol_bpf_c.h>
 
 /**
- * Numer of SolKeyedAccounts expected. The program should bail if an
+ * Number of SolKeyedAccounts expected. The program should bail if an
  * unexpected number of accounts are passed to the program's entrypoint
  */
 #define NUM_KA 3
 
-extern bool entrypoint(uint8_t *input) {
+extern bool entrypoint(const uint8_t *input) {
   SolKeyedAccounts ka[NUM_KA];
   uint8_t *data;
   uint64_t data_len;
 
-  if (!sol_deserialize((uint8_t *)input, NUM_KA, ka, &data, &data_len)) {
+  if (!sol_deserialize(input, NUM_KA, ka, &data, &data_len)) {
     return false;
   }
 

--- a/programs/bpf/c/src/noop.c
+++ b/programs/bpf/c/src/noop.c
@@ -3,7 +3,7 @@
  * passed to it
  */
 
-#include <sol_bpf_c.h>
+#include <sol_bpf.h>
 
 /**
  * Number of SolKeyedAccounts expected. The program should bail if an

--- a/programs/bpf/c/src/noop.c
+++ b/programs/bpf/c/src/noop.c
@@ -6,17 +6,17 @@
 #include <sol_bpf_c.h>
 
 /**
- * Numer of SolKeyedAccounts expected. The program should bail if an
+ * Number of SolKeyedAccounts expected. The program should bail if an
  * unexpected number of accounts are passed to the program's entrypoint
  */
 #define NUM_KA 1
 
-extern bool entrypoint(uint8_t *input) {
+extern bool entrypoint(const uint8_t *input) {
   SolKeyedAccounts ka[NUM_KA];
   uint8_t *data;
   uint64_t data_len;
 
-  if (!sol_deserialize((uint8_t *)input, NUM_KA, ka, &data, &data_len)) {
+  if (!sol_deserialize(input, NUM_KA, ka, &data, &data_len)) {
     return false;
   }
   sol_print_params(1, ka, data, data_len);

--- a/programs/bpf/c/src/noop.c
+++ b/programs/bpf/c/src/noop.c
@@ -19,6 +19,6 @@ extern bool entrypoint(const uint8_t *input) {
   if (!sol_deserialize(input, NUM_KA, ka, &data, &data_len)) {
     return false;
   }
-  sol_print_params(1, ka, data, data_len);
+  sol_print_params(NUM_KA, ka, data, data_len);
   return true;
 }

--- a/programs/bpf/c/src/tictactoe.c
+++ b/programs/bpf/c/src/tictactoe.c
@@ -2,7 +2,7 @@
  * @brief TicTacToe Dashboard C-based BPF program
  */
 
-#include <sol_bpf_c.h>
+#include <sol_bpf.h>
 #include "tictactoe.h"
 
 typedef enum {

--- a/programs/bpf/c/src/tictactoe.c
+++ b/programs/bpf/c/src/tictactoe.c
@@ -173,7 +173,7 @@ SOL_FN_PREFIX Result game_keep_alive(Game *self, SolPubkey *player,
 }
 
 /**
- * Numer of SolKeyedAccounts expected. The program should bail if an
+ * Number of SolKeyedAccounts expected. The program should bail if an
  * unexpected number of accounts are passed to the program's entrypoint
  *
  * accounts[0] On Init must be player X, after that doesn't matter,
@@ -183,13 +183,13 @@ SOL_FN_PREFIX Result game_keep_alive(Game *self, SolPubkey *player,
  */
 #define NUM_KA 3
 
-extern bool entrypoint(uint8_t *input) {
+extern bool entrypoint(const uint8_t *input) {
   SolKeyedAccounts ka[NUM_KA];
   uint8_t *data;
   uint64_t data_len;
   int err = 0;
 
-  if (!sol_deserialize((uint8_t *)input, NUM_KA, ka, &data, &data_len)) {
+  if (!sol_deserialize(input, NUM_KA, ka, &data, &data_len)) {
     return false;
   }
 

--- a/programs/bpf/c/src/tictactoe_dashboard.c
+++ b/programs/bpf/c/src/tictactoe_dashboard.c
@@ -54,7 +54,7 @@ SOL_FN_PREFIX bool update(Dashboard *self, Game *game, SolPubkey *game_pubkey) {
 }
 
 /**
- * Numer of SolKeyedAccounts expected. The program should bail if an
+ * Number of SolKeyedAccounts expected. The program should bail if an
  * unexpected number of accounts are passed to the program's entrypoint
  *
  * accounts[0] doesn't matter, anybody can cause a dashboard update
@@ -63,13 +63,13 @@ SOL_FN_PREFIX bool update(Dashboard *self, Game *game, SolPubkey *game_pubkey) {
  */
 #define NUM_KA 3
 
-extern bool entrypoint(uint8_t *input) {
+extern bool entrypoint(const uint8_t *input) {
   SolKeyedAccounts ka[NUM_KA];
   uint8_t *data;
   uint64_t data_len;
   int err = 0;
 
-  if (!sol_deserialize((uint8_t *)input, NUM_KA, ka, &data, &data_len)) {
+  if (!sol_deserialize(input, NUM_KA, ka, &data, &data_len)) {
     return false;
   }
 

--- a/programs/bpf/c/src/tictactoe_dashboard.c
+++ b/programs/bpf/c/src/tictactoe_dashboard.c
@@ -2,7 +2,7 @@
  * @brief TicTacToe C-based BPF program
  */
 
-#include <sol_bpf_c.h>
+#include <sol_bpf.h>
 #include "tictactoe.h"
 
 #define MAX_GAMES_TRACKED 5


### PR DESCRIPTION
* use const more
* include system deps
* reformat sol_bpf_c.h a little, and rename it to sol_bpf.h ("c" is implicit cause it's a .h file)
* use `#pragma once`
* add `extern "C"` block to prep for C++