### PR TITLE
Compute finality computation in new ComputeLeaderFinalityService

### DIFF
--- a/src/bank.rs
+++ b/src/bank.rs
@@ -346,7 +346,6 @@ impl Bank {
                 return Some(entry.1);
             }
         }
-
         None
     }
 
@@ -388,7 +387,6 @@ impl Bank {
                 }
             }
         }
-
         None
     }
 
@@ -1125,7 +1123,8 @@ impl Bank {
             .unwrap_or(0)
     }
 
-    /// TODO: fix once there's real staking
+    /// TODO: Need to implement a real staking contract to hold node stake.
+    /// Right now this just gets the account balances. See github issue #1655.
     pub fn get_stake(&self, pubkey: &Pubkey) -> i64 {
         self.get_balance(pubkey)
     }

--- a/src/bank.rs
+++ b/src/bank.rs
@@ -383,7 +383,7 @@ impl Bank {
             if ((nth - tick_height) as usize) < MAX_ENTRY_IDS {
                 total += stake;
                 if total > supermajority_stake {
-                    return Self::tick_height_to_timestamp(&*last_ids, *tick_height);
+                    return Self::tick_height_to_timestamp(&last_ids, *tick_height);
                 }
             }
         }

--- a/src/bank.rs
+++ b/src/bank.rs
@@ -123,22 +123,22 @@ pub struct LastIds {
     /// values are so old that the `last_id` has been pulled out of the queue.
 
     /// updated whenever an id is registered
-    nth: u64,
+    tick_height: u64,
 
     /// last id to be registered
     last: Option<Hash>,
 
-    /// Mapping of hashes to signature sets along with timestamp and what nth
+    /// Mapping of hashes to signature sets along with timestamp and what tick_height
     /// was when the id was added. The bank uses this data to
     /// reject transactions with signatures it's seen before and to reject
-    /// transactions that are too old (nth is too small)
+    /// transactions that are too old (tick_height is too small)
     sigs: HashMap<Hash, (SignatureStatusMap, u64, u64)>,
 }
 
 impl Default for LastIds {
     fn default() -> Self {
         LastIds {
-            nth: 0,
+            tick_height: 0,
             last: None,
             sigs: HashMap::new(),
         }
@@ -172,9 +172,6 @@ pub struct Bank {
     /// Tracks and updates the leader schedule based on the votes and account stakes
     /// processed by the bank
     pub leader_scheduler: Arc<RwLock<LeaderScheduler>>,
-
-    // The number of ticks that have elapsed since genesis
-    tick_height: Mutex<u64>,
 }
 
 impl Default for Bank {
@@ -188,7 +185,6 @@ impl Default for Bank {
             account_subscriptions: RwLock::new(HashMap::new()),
             signature_subscriptions: RwLock::new(HashMap::new()),
             leader_scheduler: Arc::new(RwLock::new(LeaderScheduler::default())),
-            tick_height: Mutex::new(0),
         }
     }
 }
@@ -270,7 +266,7 @@ impl Bank {
         let entry = last_ids.sigs.get(&entry_id);
 
         match entry {
-            Some(entry) => ((last_ids.nth - entry.2) as usize) < max_age,
+            Some(entry) => ((last_ids.tick_height - entry.2) as usize) < max_age,
             _ => false,
         }
     }
@@ -281,7 +277,7 @@ impl Bank {
         sig: &Signature,
     ) -> Result<()> {
         if let Some(entry) = last_ids.sigs.get_mut(last_id) {
-            if ((last_ids.nth - entry.2) as usize) < MAX_ENTRY_IDS {
+            if ((last_ids.tick_height - entry.2) as usize) < MAX_ENTRY_IDS {
                 return Self::reserve_signature(&mut entry.0, sig);
             }
         }
@@ -359,7 +355,7 @@ impl Bank {
         let mut ret = Vec::new();
         for (i, id) in ids.iter().enumerate() {
             if let Some(entry) = last_ids.sigs.get(id) {
-                if ((last_ids.nth - entry.2) as usize) < MAX_ENTRY_IDS {
+                if ((last_ids.tick_height - entry.2) as usize) < MAX_ENTRY_IDS {
                     ret.push((i, entry.1));
                 }
             }
@@ -377,10 +373,10 @@ impl Bank {
         // Sort by tick height
         ticks_and_stakes.sort_by(|a, b| a.0.cmp(&b.0));
         let last_ids = self.last_ids.read().unwrap();
-        let nth = last_ids.nth;
+        let current_tick_height = last_ids.tick_height;
         let mut total = 0;
         for (tick_height, stake) in ticks_and_stakes.iter() {
-            if ((nth - tick_height) as usize) < MAX_ENTRY_IDS {
+            if ((current_tick_height - tick_height) as usize) < MAX_ENTRY_IDS {
                 total += stake;
                 if total > supermajority_stake {
                     return Self::tick_height_to_timestamp(&last_ids, *tick_height);
@@ -390,6 +386,19 @@ impl Bank {
         None
     }
 
+    /// Tell the bank about the genesis Entry IDs.
+    pub fn register_genesis_entry(&self, last_id: &Hash) {
+        let mut last_ids = self.last_ids.write().unwrap();
+
+        last_ids
+            .sigs
+            .insert(*last_id, (HashMap::new(), timestamp(), 0));
+
+        last_ids.last = Some(*last_id);
+
+        inc_new_counter_info!("bank-register_genesis_entry_id-registered", 1);
+    }
+
     /// Tell the bank which Entry IDs exist on the ledger. This function
     /// assumes subsequent calls correspond to later entries, and will boot
     /// the oldest ones once its internal cache is full. Once boot, the
@@ -397,22 +406,21 @@ impl Bank {
     pub fn register_entry_id(&self, last_id: &Hash) {
         let mut last_ids = self.last_ids.write().unwrap();
 
-        // Increment "nth" so that the index of this tick in the LastIds structure
-        // matches the "tick height" when the validator votes for this tick
-        last_ids.nth += 1;
-        let last_ids_nth = last_ids.nth;
+        last_ids.tick_height += 1;
+        let last_ids_tick_height = last_ids.tick_height;
 
         // this clean up can be deferred until sigs gets larger
-        //  because we verify entry.nth every place we check for validity
+        // because we verify entry.tick_height every place we check for validity
         if last_ids.sigs.len() >= MAX_ENTRY_IDS {
-            last_ids
-                .sigs
-                .retain(|_, (_, _, nth)| ((last_ids_nth - *nth) as usize) < MAX_ENTRY_IDS);
+            last_ids.sigs.retain(|_, (_, _, tick_height)| {
+                ((last_ids_tick_height - *tick_height) as usize) < MAX_ENTRY_IDS
+            });
         }
 
-        last_ids
-            .sigs
-            .insert(*last_id, (HashMap::new(), timestamp(), last_ids_nth));
+        last_ids.sigs.insert(
+            *last_id,
+            (HashMap::new(), timestamp(), last_ids_tick_height),
+        );
 
         last_ids.last = Some(*last_id);
 
@@ -925,17 +933,12 @@ impl Bank {
                 result?;
             }
         } else {
-            let tick_height = {
-                let mut tick_height_lock = self.tick_height.lock().unwrap();
-                *tick_height_lock += 1;
-                *tick_height_lock
-            };
-
+            self.register_entry_id(&entry.id);
+            let tick_height = self.last_ids.read().unwrap().tick_height;
             self.leader_scheduler
                 .write()
                 .unwrap()
                 .update_height(tick_height, self);
-            self.register_entry_id(&entry.id);
         }
 
         Ok(())
@@ -980,7 +983,6 @@ impl Bank {
                 // if its a tick, execute the group and register the tick
                 self.par_execute_entries(&mt_group)?;
                 self.register_entry_id(&entry.id);
-                *self.tick_height.lock().unwrap() += 1;
                 mt_group = vec![];
                 continue;
             }
@@ -1086,8 +1088,8 @@ impl Bank {
                 trace!("applied genesis payment {:?} => {:?}", deposit, account);
             }
         }
-        self.register_entry_id(&entry0.id);
-        self.register_entry_id(&entry1.id);
+        self.register_genesis_entry(&entry0.id);
+        self.register_genesis_entry(&entry1.id);
 
         Ok(self.process_ledger_blocks(entry1.id, 2, entries)?)
     }
@@ -1214,12 +1216,12 @@ impl Bank {
 
     pub fn get_current_leader(&self) -> Option<Pubkey> {
         let ls_lock = self.leader_scheduler.read().unwrap();
-        let tick_height = self.tick_height.lock().unwrap();
-        ls_lock.get_scheduled_leader(*tick_height)
+        let tick_height = self.last_ids.read().unwrap().tick_height;
+        ls_lock.get_scheduled_leader(tick_height)
     }
 
     pub fn get_tick_height(&self) -> u64 {
-        *self.tick_height.lock().unwrap()
+        self.last_ids.read().unwrap().tick_height
     }
 
     fn check_account_subscriptions(&self, pubkey: &Pubkey, account: &Account) {

--- a/src/cluster_info.rs
+++ b/src/cluster_info.rs
@@ -108,8 +108,6 @@ pub struct NodeInfo {
     pub contact_info: ContactInfo,
     /// current leader identity
     pub leader_id: Pubkey,
-    /// information about the state of the ledger
-    pub ledger_state: LedgerState,
 }
 
 impl NodeInfo {
@@ -133,9 +131,6 @@ impl NodeInfo {
                 version: 0,
             },
             leader_id: Pubkey::default(),
-            ledger_state: LedgerState {
-                last_id: Hash::default(),
-            },
         }
     }
 
@@ -706,17 +701,6 @@ impl ClusterInfo {
 
         trace!("get updates since response {} {}", v, updated_data.len());
         (id, max_updated_node, updated_data)
-    }
-
-    pub fn valid_last_ids(&self) -> Vec<Hash> {
-        self.table
-            .values()
-            .filter(|r| {
-                r.id != Pubkey::default()
-                    && (Self::is_valid_address(&r.contact_info.tpu)
-                        || Self::is_valid_address(&r.contact_info.tvu))
-            }).map(|x| x.ledger_state.last_id)
-            .collect()
     }
 
     pub fn window_index_request(&self, ix: u64) -> Result<(SocketAddr, Vec<u8>)> {
@@ -1775,36 +1759,6 @@ mod tests {
             };
             assert_eq!(blob.get_id().unwrap(), id);
         }
-    }
-
-    #[test]
-    fn test_valid_last_ids() {
-        logger::setup();
-        let mut leader0 = NodeInfo::new_with_socketaddr(&socketaddr!("127.0.0.2:1234"));
-        leader0.ledger_state.last_id = hash(b"0");
-        let mut leader1 = NodeInfo::new_multicast();
-        leader1.ledger_state.last_id = hash(b"1");
-        let mut leader2 =
-            NodeInfo::new_with_pubkey_socketaddr(Pubkey::default(), &socketaddr!("127.0.0.2:1234"));
-        leader2.ledger_state.last_id = hash(b"2");
-        // test that only valid tvu or tpu are retured as nodes
-        let mut leader3 = NodeInfo::new(
-            Keypair::new().pubkey(),
-            socketaddr!("127.0.0.1:1234"),
-            socketaddr_any!(),
-            socketaddr!("127.0.0.1:1236"),
-            socketaddr_any!(),
-            socketaddr_any!(),
-        );
-        leader3.ledger_state.last_id = hash(b"3");
-        let mut cluster_info = ClusterInfo::new(leader0.clone()).expect("ClusterInfo::new");
-        cluster_info.insert(&leader1);
-        cluster_info.insert(&leader2);
-        cluster_info.insert(&leader3);
-        assert_eq!(
-            cluster_info.valid_last_ids(),
-            vec![leader0.ledger_state.last_id]
-        );
     }
 
     /// Validates the node that sent Protocol::ReceiveUpdates gets its

--- a/src/compute_leader_finality_service.rs
+++ b/src/compute_leader_finality_service.rs
@@ -43,10 +43,14 @@ impl ComputeLeaderFinalityService {
             bank_accounts
                 .values()
                 .filter_map(|account| {
+                    // Filter out any accounts that don't belong to the VoteProgram
+                    // by returning None
                     if VoteProgram::check_id(&account.program_id) {
                         if let Ok(vote_state) = VoteProgram::deserialize(&account.userdata) {
                             let validator_stake = bank.get_stake(&vote_state.node_id);
                             total_stake += validator_stake;
+                            // Filter out any validators that don't have at least one vote
+                            // by returning None
                             return vote_state
                                 .votes
                                 .back()

--- a/src/leader_finality_stage.rs
+++ b/src/leader_finality_stage.rs
@@ -19,7 +19,7 @@ pub enum FinalityError {
     NoValidSupermajority,
 }
 
-pub const COMPTUTE_FINALITY_MS: u64 = 1000;
+pub const COMPUTE_FINALITY_MS: u64 = 1000;
 
 pub struct LeaderFinalityStage {
     compute_finality_thread: JoinHandle<()>,
@@ -38,6 +38,7 @@ impl LeaderFinalityStage {
             // TODO: Doesn't account for duplicates since a single validator could potentially register
             // multiple vote accounts. Once that is no longer possible (see the TODO in vote_program.rs,
             // process_transaction(), case VoteInstruction::RegisterAccount), this will be more accurate.
+            // See github issue 1654.
             bank_accounts
                 .values()
                 .filter_map(|account| {
@@ -106,7 +107,7 @@ impl LeaderFinalityStage {
                         break;
                     }
                     Self::compute_finality(&bank, &mut last_valid_validator_timestamp);
-                    sleep(Duration::from_millis(COMPTUTE_FINALITY_MS));
+                    sleep(Duration::from_millis(COMPUTE_FINALITY_MS));
                 }
             }).unwrap();
 

--- a/src/leader_finality_stage.rs
+++ b/src/leader_finality_stage.rs
@@ -1,0 +1,198 @@
+//! The `leader_finality_stage` module implements the stage which regularly
+//! calculates the last finality times observed by the leader
+
+use bank::Bank;
+use influx_db_client as influxdb;
+use metrics;
+use service::Service;
+use std::result;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::thread::sleep;
+use std::thread::{self, Builder, JoinHandle};
+use std::time::Duration;
+use timing;
+use vote_program::VoteProgram;
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum FinalityError {
+    NoValidSupermajority,
+}
+
+pub const COMPTUTE_FINALITY_MS: u64 = 1000;
+
+pub struct LeaderFinalityStage {
+    compute_finality_thread: JoinHandle<()>,
+}
+
+impl LeaderFinalityStage {
+    fn get_last_supermajority_timestamp(
+        bank: &Arc<Bank>,
+        now: u64,
+        last_valid_validator_timestamp: u64,
+    ) -> result::Result<u64, FinalityError> {
+        let mut total_stake = 0;
+
+        let mut ticks_and_stakes: Vec<(u64, i64)> = {
+            let bank_accounts = bank.accounts.read().unwrap();
+            // TODO: Doesn't account for duplicates since a single validator could potentially register
+            // multiple vote accounts. Once that is no longer possible (see the TODO in vote_program.rs,
+            // process_transaction(), case VoteInstruction::RegisterAccount), this will be more accurate.
+            bank_accounts
+                .values()
+                .filter_map(|account| {
+                    if VoteProgram::check_id(&account.program_id) {
+                        if let Ok(vote_state) = VoteProgram::deserialize(&account.userdata) {
+                            let validator_stake = bank.get_stake(&vote_state.node_id);
+                            total_stake += validator_stake;
+                            return vote_state
+                                .votes
+                                .back()
+                                .map(|vote| (vote.tick_height, validator_stake));
+                        }
+                    }
+
+                    None
+                }).collect()
+        };
+
+        let super_majority_stake = (2 * total_stake) / 3;
+
+        if let Some(last_valid_validator_timestamp) =
+            bank.get_finality_timestamp(&mut ticks_and_stakes, super_majority_stake)
+        {
+            return Ok(last_valid_validator_timestamp);
+        }
+
+        if last_valid_validator_timestamp != 0 {
+            metrics::submit(
+                influxdb::Point::new(&"leader-finality")
+                    .add_field(
+                        "duration_ms",
+                        influxdb::Value::Integer((now - last_valid_validator_timestamp) as i64),
+                    ).to_owned(),
+            );
+        }
+
+        Err(FinalityError::NoValidSupermajority)
+    }
+
+    pub fn compute_finality(bank: &Arc<Bank>, last_valid_validator_timestamp: &mut u64) {
+        let now = timing::timestamp();
+        if let Ok(super_majority_timestamp) =
+            Self::get_last_supermajority_timestamp(bank, now, *last_valid_validator_timestamp)
+        {
+            let finality_ms = now - super_majority_timestamp;
+
+            *last_valid_validator_timestamp = super_majority_timestamp;
+            bank.set_finality((now - *last_valid_validator_timestamp) as usize);
+
+            metrics::submit(
+                influxdb::Point::new(&"leader-finality")
+                    .add_field("duration_ms", influxdb::Value::Integer(finality_ms as i64))
+                    .to_owned(),
+            );
+        }
+    }
+
+    /// Create a new LeaderFinalityStage for computing finality.
+    pub fn new(bank: Arc<Bank>, exit: Arc<AtomicBool>) -> Self {
+        let compute_finality_thread = Builder::new()
+            .name("solana-leader-finality-stage".to_string())
+            .spawn(move || {
+                let mut last_valid_validator_timestamp = 0;
+                loop {
+                    if exit.load(Ordering::Relaxed) {
+                        break;
+                    }
+                    Self::compute_finality(&bank, &mut last_valid_validator_timestamp);
+                    sleep(Duration::from_millis(COMPTUTE_FINALITY_MS));
+                }
+            }).unwrap();
+
+        (LeaderFinalityStage {
+            compute_finality_thread,
+        })
+    }
+}
+
+impl Service for LeaderFinalityStage {
+    type JoinReturnType = ();
+
+    fn join(self) -> thread::Result<()> {
+        self.compute_finality_thread.join()
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use bank::Bank;
+    use bincode::serialize;
+    use hash::hash;
+    use leader_finality_stage::LeaderFinalityStage;
+    use logger;
+    use mint::Mint;
+    use signature::{Keypair, KeypairUtil};
+    use std::sync::Arc;
+    use std::thread::sleep;
+    use std::time::Duration;
+    use transaction::Transaction;
+    use vote_program::Vote;
+    use vote_transaction::{create_vote_account, VoteTransaction};
+
+    #[test]
+    fn test_compute_finality() {
+        logger::setup();
+
+        let mint = Mint::new(1234);
+        let bank = Arc::new(Bank::new(&mint));
+        // generate 10 validators, but only vote for the first 6 validators
+        let ids: Vec<_> = (0..10)
+            .map(|i| {
+                let last_id = hash(&serialize(&i).unwrap()); // Unique hash
+                bank.register_entry_id(&last_id);
+                // sleep to get a different timestamp in the bank
+                sleep(Duration::from_millis(1));
+                last_id
+            }).collect();
+
+        // Create a total of 10 vote accounts, each will have a balance of 1 (after giving 1 to
+        // their vote account), for a total staking pool of 10 tokens.
+        let vote_accounts: Vec<_> = (0..10)
+            .map(|i| {
+                // Create new validator to vote
+                let validator_keypair = Keypair::new();
+                let last_id = ids[i];
+
+                // Give the validator some tokens
+                bank.transfer(2, &mint.keypair(), validator_keypair.pubkey(), last_id)
+                    .unwrap();
+                let vote_account = create_vote_account(&validator_keypair, &bank, 1, last_id)
+                    .expect("Expected successful creation of account");
+
+                if i < 6 {
+                    let vote = Vote {
+                        tick_height: (i + 1) as u64,
+                    };
+                    let vote_tx = Transaction::vote_new(&vote_account, vote, last_id, 0);
+                    bank.process_transaction(&vote_tx).unwrap();
+                }
+                vote_account
+            }).collect();
+
+        // There isn't 2/3 consensus, so the bank's finality value should be the default
+        let mut last_finality_time = 0;
+        LeaderFinalityStage::compute_finality(&bank, &mut last_finality_time);
+        assert_eq!(bank.finality(), std::usize::MAX);
+
+        // Get another validator to vote, so we now have 2/3 consensus
+        let vote_account = &vote_accounts[7];
+        let vote = Vote { tick_height: 7 };
+        let vote_tx = Transaction::vote_new(&vote_account, vote, ids[6], 0);
+        bank.process_transaction(&vote_tx).unwrap();
+
+        LeaderFinalityStage::compute_finality(&bank, &mut last_finality_time);
+        assert!(bank.finality() != std::usize::MAX);
+        assert!(last_finality_time > 0);
+    }
+}

--- a/src/leader_scheduler.rs
+++ b/src/leader_scheduler.rs
@@ -290,7 +290,7 @@ impl LeaderScheduler {
         let lower_bound = height.saturating_sub(self.active_window_length);
 
         {
-            let bank_accounts = &*bank.accounts.read().unwrap();
+            let bank_accounts = &bank.accounts.read().unwrap();
 
             bank_accounts
                 .values()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,7 @@ pub mod erasure;
 pub mod fetch_stage;
 pub mod fullnode;
 pub mod hash;
+pub mod leader_finality_stage;
 pub mod leader_scheduler;
 pub mod ledger;
 pub mod ledger_write_stage;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,7 @@ pub mod client;
 #[macro_use]
 pub mod cluster_info;
 pub mod budget_program;
+pub mod compute_leader_finality_service;
 pub mod drone;
 pub mod entry;
 pub mod entry_writer;
@@ -34,7 +35,6 @@ pub mod erasure;
 pub mod fetch_stage;
 pub mod fullnode;
 pub mod hash;
-pub mod leader_finality_stage;
 pub mod leader_scheduler;
 pub mod ledger;
 pub mod ledger_write_stage;

--- a/src/poh_recorder.rs
+++ b/src/poh_recorder.rs
@@ -34,7 +34,7 @@ impl PohRecorder {
         // TODO: amortize the cost of this lock by doing the loop in here for
         // some min amount of hashes
         let mut poh = self.poh.lock().unwrap();
-        if self.is_max_tick_height_reached(&*poh) {
+        if self.is_max_tick_height_reached(&poh) {
             Err(Error::PohRecorderError(PohRecorderError::MaxHeightReached))
         } else {
             poh.hash();
@@ -47,7 +47,7 @@ impl PohRecorder {
         // hasn't been reached.
         // This guarantees PoH order and Entry production and banks LastId queue is the same
         let mut poh = self.poh.lock().unwrap();
-        if self.is_max_tick_height_reached(&*poh) {
+        if self.is_max_tick_height_reached(&poh) {
             Err(Error::PohRecorderError(PohRecorderError::MaxHeightReached))
         } else if self.is_virtual {
             self.generate_and_store_tick(&mut *poh);
@@ -67,7 +67,7 @@ impl PohRecorder {
         // Register and send the entry out while holding the lock.
         // This guarantees PoH order and Entry production and banks LastId queue is the same.
         let mut poh = self.poh.lock().unwrap();
-        if self.is_max_tick_height_reached(&*poh) {
+        if self.is_max_tick_height_reached(&poh) {
             Err(Error::PohRecorderError(PohRecorderError::MaxHeightReached))
         } else {
             self.record_and_send_txs(&mut *poh, mixin, txs)?;

--- a/src/tpu.rs
+++ b/src/tpu.rs
@@ -30,7 +30,6 @@ use banking_stage::{BankingStage, BankingStageReturnType};
 use entry::Entry;
 use fetch_stage::FetchStage;
 use hash::Hash;
-use leader_finality_stage::LeaderFinalityStage;
 use ledger_write_stage::LedgerWriteStage;
 use poh_service::Config;
 use service::Service;
@@ -51,7 +50,6 @@ pub struct Tpu {
     sigverify_stage: SigVerifyStage,
     banking_stage: BankingStage,
     ledger_write_stage: LedgerWriteStage,
-    leader_finality_stage: LeaderFinalityStage,
     exit: Arc<AtomicBool>,
 }
 
@@ -85,16 +83,14 @@ impl Tpu {
         let ledger_write_stage =
             LedgerWriteStage::new(Some(ledger_path), entry_receiver, Some(ledger_entry_sender));
 
-        let leader_finality_stage = LeaderFinalityStage::new(bank.clone(), exit.clone());
-
         let tpu = Tpu {
             fetch_stage,
             sigverify_stage,
             banking_stage,
             ledger_write_stage,
-            leader_finality_stage,
             exit: exit.clone(),
         };
+
         (tpu, entry_forwarder, exit)
     }
 
@@ -119,7 +115,6 @@ impl Service for Tpu {
         self.fetch_stage.join()?;
         self.sigverify_stage.join()?;
         self.ledger_write_stage.join()?;
-        self.leader_finality_stage.join()?;
         match self.banking_stage.join()? {
             Some(BankingStageReturnType::LeaderRotation) => Ok(Some(TpuReturnType::LeaderRotation)),
             _ => Ok(None),

--- a/src/vote_program.rs
+++ b/src/vote_program.rs
@@ -106,7 +106,7 @@ impl VoteProgram {
         match deserialize(tx.userdata(instruction_index)) {
             Ok(VoteInstruction::RegisterAccount) => {
                 // TODO: a single validator could register multiple "vote accounts"
-                // which would clutter the "accounts" structure.
+                // which would clutter the "accounts" structure. See github issue 1654.
                 accounts[1].program_id = Self::id();
 
                 let mut vote_state = VoteProgram {

--- a/src/vote_stage.rs
+++ b/src/vote_stage.rs
@@ -17,11 +17,9 @@ use transaction::Transaction;
 use vote_program::Vote;
 use vote_transaction::VoteTransaction;
 
-pub const VOTE_TIMEOUT_MS: u64 = 1000;
-
 #[derive(Debug, PartialEq, Eq)]
 pub enum VoteError {
-    NoValidLastIdsToVoteOn,
+    NoValidSupermajority,
     NoLeader,
     LeaderInfoNotFound,
 }

--- a/src/vote_transaction.rs
+++ b/src/vote_transaction.rs
@@ -1,8 +1,14 @@
 //! The `vote_transaction` module provides functionality for creating vote transactions.
 
+#[cfg(test)]
+use bank::Bank;
 use bincode::{deserialize, serialize};
 use hash::Hash;
+#[cfg(test)]
+use result::Result;
 use signature::Keypair;
+#[cfg(test)]
+use signature::KeypairUtil;
 use solana_sdk::pubkey::Pubkey;
 use system_transaction::SystemTransaction;
 use transaction::Transaction;
@@ -79,6 +85,28 @@ impl VoteTransaction for Transaction {
         }
         votes
     }
+}
+
+#[cfg(test)]
+pub fn create_vote_account(
+    node_keypair: &Keypair,
+    bank: &Bank,
+    num_tokens: i64,
+    last_id: Hash,
+) -> Result<Keypair> {
+    let new_vote_account = Keypair::new();
+
+    // Create the new vote account
+    let tx =
+        Transaction::vote_account_new(node_keypair, new_vote_account.pubkey(), last_id, num_tokens);
+    bank.process_transaction(&tx)?;
+
+    // Register the vote account to the validator
+    let tx =
+        Transaction::vote_account_register(node_keypair, new_vote_account.pubkey(), last_id, 0);
+    bank.process_transaction(&tx)?;
+
+    Ok(new_vote_account)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
#### Problem

In the vote contract PR, the leader voting stage was removed because leader voting was unnecessary and leaders couldn't pin bank state to tick height. Inserting votes into the ClusterInfo was also removed b/c votes are not processed by the VoteContract in the bank. This means the old computation of finality based on votes in the ClusterInfo needs to be reworked.

#### Summary of Changes

Compute finality in a LeaderFinalityStage, which periodically reads the bank for "stake" (currently implemented as account balances) and valid ticks (checks the LastIds structure) to compute the last timestamp at which 2/3 of the stake has reached finality. Based on the legacy computation of finality time here: https://github.com/solana-labs/solana/blob/160cff4a30fa77abe56d7c7f0d0888c5f4a12461/src/vote_stage.rs#L54

Fixes #
