### PR TITLE
Fetch v0.10.4 which has v100 binary compiled in

### DIFF
--- a/fetch-perf-libs.sh
+++ b/fetch-perf-libs.sh
@@ -15,7 +15,7 @@ mkdir -p target/perf-libs
   cd target/perf-libs
   (
     set -x
-    curl https://solana-perf.s3.amazonaws.com/v0.10.3/x86_64-unknown-linux-gnu/solana-perf.tgz | tar zxvf -
+    curl https://solana-perf.s3.amazonaws.com/v0.10.4/x86_64-unknown-linux-gnu/solana-perf.tgz | tar zxvf -
   )
 
   if [[ -r /usr/local/cuda/version.txt && -r cuda-version.txt ]]; then


### PR DESCRIPTION
This may or may not fix high latencies seen on the snap build on v100.
GPU driver will not have to JIT the device code for V100 though which
is an improvement.

#### Problem

#### Summary of Changes

Fixes #
