### PR TITLE
Update testnet scripts to use release tar ball (#1660)

### DIFF
--- a/ci/publish-solana-tar.sh
+++ b/ci/publish-solana-tar.sh
@@ -33,6 +33,7 @@ if [[ -z $DRYRUN ]]; then
     git rev-parse HEAD
   ) > solana-release/version.txt
 
+  ./fetch-perf-libs.sh
   cargo install --features=cuda --root solana-release
   ./scripts/install-native-programs.sh solana-release
 

--- a/ci/testnet-deploy.sh
+++ b/ci/testnet-deploy.sh
@@ -9,8 +9,10 @@ clientNodeCount=0
 validatorNodeCount=10
 publicNetwork=false
 snapChannel=edge
+releaseChannel=edge
 delete=false
 enableGpu=false
+useReleaseChannel=false
 
 usage() {
   exitcode=0
@@ -29,6 +31,8 @@ Deploys a CD testnet
   options:
    -s edge|beta|stable  - Deploy the specified Snap release channel
                           (default: $snapChannel)
+   -t edge|beta|stable  - Deploy the specified prebuilt tar from channel
+                          (default: $releaseChannel)
    -n [number]          - Number of validator nodes (default: $validatorNodeCount)
    -c [number]          - Number of client nodes (default: $clientNodeCount)
    -P                   - Use public network IP addresses (default: $publicNetwork)
@@ -49,7 +53,7 @@ zone=$2
 [[ -n $zone ]] || usage "Zone not specified"
 shift 2
 
-while getopts "h?p:Pn:c:s:gG:a:d" opt; do
+while getopts "h?p:Pn:c:s:t:gG:a:d" opt; do
   case $opt in
   h | \?)
     usage
@@ -70,6 +74,17 @@ while getopts "h?p:Pn:c:s:gG:a:d" opt; do
       ;;
     *)
       usage "Invalid snap channel: $OPTARG"
+      ;;
+    esac
+    ;;
+  t)
+    case $OPTARG in
+    edge|beta|stable)
+      releaseChannel=$OPTARG
+      useReleaseChannel=true
+      ;;
+    *)
+      usage "Invalid release channel: $OPTARG"
       ;;
     esac
     ;;
@@ -131,6 +146,9 @@ if ! $publicNetwork; then
   maybeRejectExtraNodes="-o rejectExtraNodes"
 fi
 # shellcheck disable=SC2086 # Don't want to double quote maybeRejectExtraNodes
-time net/net.sh start -s "$snapChannel" $maybeRejectExtraNodes
-
+if ! $useReleaseChannel; then
+  time net/net.sh start -s "$snapChannel" $maybeRejectExtraNodes
+else
+  time net/net.sh start -t "$releaseChannel" $maybeRejectExtraNodes
+fi
 exit 0

--- a/net/net.sh
+++ b/net/net.sh
@@ -25,6 +25,7 @@ Operate a configured testnet
  start-specific options:
    -S [snapFilename]    - Deploy the specified Snap file
    -s edge|beta|stable  - Deploy the latest Snap on the specified Snap release channel
+   -t edge|beta|stable  - Deploy the latest tarball release for the specified channel
    -f [cargoFeatures]   - List of |cargo --feaures=| to activate
                           (ignored if -s or -S is specified)
 
@@ -44,6 +45,7 @@ EOF
 }
 
 snapChannel=
+releaseChannel=
 snapFilename=
 deployMethod=local
 sanityExtraArgs=
@@ -53,7 +55,7 @@ command=$1
 [[ -n $command ]] || usage
 shift
 
-while getopts "h?S:s:o:f:" opt; do
+while getopts "h?S:s:t:o:f:" opt; do
   case $opt in
   h | \?)
     usage
@@ -71,6 +73,17 @@ while getopts "h?S:s:o:f:" opt; do
       ;;
     *)
       usage "Invalid snap channel: $OPTARG"
+      ;;
+    esac
+    ;;
+  t)
+    case $OPTARG in
+    edge|beta|stable)
+      releaseChannel=$OPTARG
+      deployMethod=tar
+      ;;
+    *)
+      usage "Invalid release channel: $OPTARG"
       ;;
     esac
     ;;
@@ -138,6 +151,9 @@ startLeader() {
     case $deployMethod in
     snap)
       rsync -vPrc -e "ssh ${sshOptions[*]}" "$snapFilename" "$ipAddress:~/solana/solana.snap"
+      ;;
+    tar)
+      rsync -vPrc -e "ssh ${sshOptions[*]}" "$SOLANA_ROOT"/solana-release/bin/* "$ipAddress:~/.cargo/bin/"
       ;;
     local)
       rsync -vPrc -e "ssh ${sshOptions[*]}" "$SOLANA_ROOT"/farf/bin/* "$ipAddress:~/.cargo/bin/"
@@ -234,6 +250,16 @@ start() {
         echo "Error: Snap not readable: $snapFilename"
         exit 1
       }
+    fi
+    ;;
+  tar)
+    if [[ -n $releaseChannel ]]; then
+      rm -f "$SOLANA_ROOT"/solana-release.tar.bz2
+      cd "$SOLANA_ROOT"
+
+      set -x
+      curl -o solana-release.tar.bz2 http://solana-release.s3.amazonaws.com/"$releaseChannel"/solana-release.tar.bz2
+      tar jxvf solana-release.tar.bz2
     fi
     ;;
   local)

--- a/net/remote/remote-client.sh
+++ b/net/remote/remote-client.sh
@@ -35,7 +35,7 @@ snap)
   solana_bench_tps=/snap/bin/solana.bench-tps
   solana_keygen=/snap/bin/solana.keygen
   ;;
-local)
+local|tar)
   PATH="$HOME"/.cargo/bin:"$PATH"
   export USE_INSTALL=1
   export SOLANA_DEFAULT_METRICS_RATE=1

--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -77,7 +77,7 @@ snap)
 
   echo "Succeeded in ${SECONDS} seconds"
   ;;
-local)
+local|tar)
   PATH="$HOME"/.cargo/bin:"$PATH"
   export USE_INSTALL=1
   export RUST_LOG

--- a/net/remote/remote-sanity.sh
+++ b/net/remote/remote-sanity.sh
@@ -65,7 +65,7 @@ snap)
   client_id=~/snap/solana/current/config/client-id.json
 
   ;;
-local)
+local|tar)
   PATH="$HOME"/.cargo/bin:"$PATH"
   export USE_INSTALL=1
   entrypointRsyncUrl="$entrypointIp:~/solana"


### PR DESCRIPTION
* Update testnet scripts to use release tar ball

* use curl instead of s3cmd

#### Problem
Snap builds were showing inconsistent behavior in testnet.

#### Summary of Changes
Adds mechanism to deploy prebuilt images via tar package to testnet.

