### PR TITLE
Upgrade to influx_db_client@0.3.6 and restore client.get_version() usage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,7 @@ env_logger = "0.5.12"
 generic-array = { version = "0.12.0", default-features = false, features = ["serde"] }
 getopts = "0.2"
 hex-literal = "0.1.1"
-influx_db_client = "0.3.4"
+influx_db_client = "0.3.6"
 solana-jsonrpc-core = "0.3.0"
 solana-jsonrpc-http-server = "0.3.0"
 solana-jsonrpc-macros = "0.3.0"

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -48,9 +48,7 @@ impl InfluxDbMetricsWriter {
         client.set_read_timeout(1 /*second*/);
         client.set_write_timeout(1 /*second*/);
 
-        // TODO: Restore the next line once https://github.com/driftluo/InfluxDBClient-rs/pull/31
-        //       is merged and published in the influxdb crate
-        //debug!("InfluxDB version: {:?}", client.get_version());
+        debug!("InfluxDB version: {:?}", client.get_version());
         Some(client)
     }
 }


### PR DESCRIPTION
client.get_version() no longer panics as of https://github.com/driftluo/InfluxDBClient-rs/pull/31