### PR TITLE
Remove purging of leader id from cluster info

### DIFF
--- a/src/cluster_info.rs
+++ b/src/cluster_info.rs
@@ -455,7 +455,6 @@ impl ClusterInfo {
             if *id == leader_id {
                 info!("{}: PURGE LEADER {}", self.id, id,);
                 inc_new_counter_info!("cluster_info-purge-purged_leader", 1, 1);
-                self.set_leader(Pubkey::default());
             }
         }
     }
@@ -1782,7 +1781,7 @@ mod tests {
         let len = cluster_info.table.len() as u64;
         cluster_info.purge(now + GOSSIP_PURGE_MILLIS + 1);
         assert_eq!(len as usize - 1, cluster_info.table.len());
-        assert_eq!(cluster_info.my_data().leader_id, Pubkey::default());
+        assert_eq!(cluster_info.my_data().leader_id, nxt.id);
         assert!(cluster_info.leader_data().is_none());
     }
 


### PR DESCRIPTION
#### Problem

Currently, when leader is purged, the leader id is set to default, and then this leader id in the ClusterInfo is never set back even if the leader is added back into the live table through gossip later. This irreparably breaks retransmit and causes validators to fall far behind. Cherry-picking same change as: https://github.com/solana-labs/solana/pull/1642

#### Summary of Changes

Prevent the leader from being purged. Stabilizes leader and validator windows in test net.

Fixes #
