### PR TITLE
Add names to trait parameters

### DIFF
--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -129,31 +129,31 @@ build_rpc_trait! {
         type Metadata;
 
         #[rpc(meta, name = "confirmTransaction")]
-        fn confirm_transaction(&self, Self::Metadata, String) -> Result<bool>;
+        fn confirm_transaction(&self, meta: Self::Metadata, id: String) -> Result<bool>;
 
         #[rpc(meta, name = "getAccountInfo")]
-        fn get_account_info(&self, Self::Metadata, String) -> Result<Account>;
+        fn get_account_info(&self, meta: Self::Metadata, id: String) -> Result<Account>;
 
         #[rpc(meta, name = "getBalance")]
-        fn get_balance(&self, Self::Metadata, String) -> Result<i64>;
+        fn get_balance(&self, meta: Self::Metadata, id: String) -> Result<i64>;
 
         #[rpc(meta, name = "getFinality")]
-        fn get_finality(&self, Self::Metadata) -> Result<usize>;
+        fn get_finality(&self, meta: Self::Metadata) -> Result<usize>;
 
         #[rpc(meta, name = "getLastId")]
-        fn get_last_id(&self, Self::Metadata) -> Result<String>;
+        fn get_last_id(&self, meta: Self::Metadata) -> Result<String>;
 
         #[rpc(meta, name = "getSignatureStatus")]
-        fn get_signature_status(&self, Self::Metadata, String) -> Result<RpcSignatureStatus>;
+        fn get_signature_status(&self, meta: Self::Metadata, id: String) -> Result<RpcSignatureStatus>;
 
         #[rpc(meta, name = "getTransactionCount")]
-        fn get_transaction_count(&self, Self::Metadata) -> Result<u64>;
+        fn get_transaction_count(&self, meta: Self::Metadata) -> Result<u64>;
 
         #[rpc(meta, name= "requestAirdrop")]
-        fn request_airdrop(&self, Self::Metadata, String, u64) -> Result<String>;
+        fn request_airdrop(&self, meta: Self::Metadata, id: String, tokens: u64) -> Result<String>;
 
         #[rpc(meta, name = "sendTransaction")]
-        fn send_transaction(&self, Self::Metadata, Vec<u8>) -> Result<String>;
+        fn send_transaction(&self, meta: Self::Metadata, data: Vec<u8>) -> Result<String>;
     }
 }
 

--- a/src/rpc_pubsub.rs
+++ b/src/rpc_pubsub.rs
@@ -91,21 +91,21 @@ build_rpc_trait! {
             // Get notification every time account userdata is changed
             // Accepts pubkey parameter as base-58 encoded string
             #[rpc(name = "accountSubscribe")]
-            fn account_subscribe(&self, Self::Metadata, pubsub::Subscriber<Account>, String);
+            fn account_subscribe(&self, meta: Self::Metadata, subscriber: pubsub::Subscriber<Account>, pubkey_str: String);
 
             // Unsubscribe from account notification subscription.
             #[rpc(name = "accountUnsubscribe")]
-            fn account_unsubscribe(&self, SubscriptionId) -> Result<bool>;
+            fn account_unsubscribe(&self, id: SubscriptionId) -> Result<bool>;
         }
         #[pubsub(name = "signatureNotification")] {
             // Get notification when signature is verified
             // Accepts signature parameter as base-58 encoded string
             #[rpc(name = "signatureSubscribe")]
-            fn signature_subscribe(&self, Self::Metadata, pubsub::Subscriber<RpcSignatureStatus>, String);
+            fn signature_subscribe(&self, meta: Self::Metadata, subscriber: pubsub::Subscriber<RpcSignatureStatus>, pubkey_str: String);
 
             // Unsubscribe from signature notification subscription.
             #[rpc(name = "signatureUnsubscribe")]
-            fn signature_unsubscribe(&self, SubscriptionId) -> Result<bool>;
+            fn signature_unsubscribe(&self, id: SubscriptionId) -> Result<bool>;
         }
     }
 }


### PR DESCRIPTION
#### Problem

Rust 2018 (next month's stable) breaks `cargo fix` because a jsonrpc macro generates traits with anonymous functions. To reproduce:

```bash
$ rustup update beta
$ echo 'edition = "2018"' >> Cargo.toml
$ cargo +beta fix
```

#### Summary of Changes

Add parameter names, but this exposes a known issue in the jsonrpc macro:

https://github.com/paritytech/jsonrpc/issues/328

Use this PR to track the status of that issue.


cc #1406