### PR TITLE
Wallet sanity improvement

### DIFF
--- a/scripts/wallet-sanity.sh
+++ b/scripts/wallet-sanity.sh
@@ -20,11 +20,20 @@ garbage_address=vS3ngn1TfQmpsW1Z4NkLuqNAQFF3dYQw8UZ6TCx9bmq
 check_balance_output() {
   declare expected_output="$1"
   exec 42>&1
-  output=$($solana_wallet "${entrypoint[@]}" balance | tee >(cat - >&42))
-  if [[ ! "$output" =~ $expected_output ]]; then
-    echo "Balance is incorrect.  Expected: $expected_output"
-    exit 1
-  fi
+  attempts=3
+  while [[ $attempts -gt 0 ]]; do
+    output=$($solana_wallet "${entrypoint[@]}" balance | tee >(cat - >&42))
+    if [[ "$output" =~ $expected_output ]]; then
+      break
+    else
+      sleep 1
+      (( attempts=attempts-1 ))
+      if [[ $attempts -eq 0 ]]; then
+        echo "Balance is incorrect.  Expected: $expected_output"
+        exit 1
+      fi
+    fi
+  done
 }
 
 pay_and_confirm() {

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -328,12 +328,12 @@ pub fn process_command(config: &WalletConfig) -> Result<String, Box<error::Error
                     .as_i64()
                     .unwrap_or(previous_balance);
 
-                if previous_balance != current_balance {
+                if previous_balance < current_balance {
                     break;
                 }
                 println!(".");
             }
-            if current_balance - previous_balance != tokens {
+            if current_balance - previous_balance < tokens {
                 Err("Airdrop failed!")?;
             }
             Ok(format!("Your balance is: {:?}", current_balance))


### PR DESCRIPTION
#### Problem
Wallet-sanity fails with `Error: StringError("Airdrop failed!")` when it shouldn't.

Logging from #1678 demonstrated that in the failure cases, the previous- and current-balance checks in the 2nd `solana-wallet airdrop` request went to different nodes (leader and validator-x).
The balance-check loop exited immediately suggesting a balance change. This could happen if: (a) previous balance was actually greater than current balance (ie. current balance came from a validator had not yet registered the airdrop); or (b) the balance changed by more than the airdrop amount (ie. previous balance came from a validator that had not yet registered the 1st airdrop).

Similarly, wallet-sanity can fail if the `solana-wallet balance` request reaches a validator that is behind in replication; would result in a `Balance is incorrect.` failure. First CI run of this PR exemplifies this issue, and logs demonstrate that the failing balance check is to validator-x (which still sees account at balance 0).

#### Summary of Changes
Improves balance-check logic in `solana-wallet airdrop` to only exit loop if balance increases, and to assume that the airdrop succeeded even if the balance increases by more than the expected amount.

Adds retries to check_balance_output to give validator time to catch up.

Fixes #1673 
