### PR TITLE
Add timeout to TcpStream connect, and rename test

### DIFF
--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -582,7 +582,7 @@ mod tests {
     }
 
     #[test]
-    fn test_rpc_request_airdrop() {
+    fn test_rpc_fail_request_airdrop() {
         let bob_pubkey = Keypair::new().pubkey();
         let (io, meta, _last_id, _alice_keypair) = start_rpc_handler_with_tx(bob_pubkey);
 

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -643,7 +643,7 @@ pub fn request_airdrop(
     tokens: u64,
 ) -> Result<Signature, Error> {
     // TODO: make this async tokio client
-    let mut stream = TcpStream::connect(drone_addr)?;
+    let mut stream = TcpStream::connect_timeout(drone_addr, Duration::new(3, 0))?;
     stream.set_read_timeout(Some(Duration::new(10, 0)))?;
     let req = DroneRequest::GetAirdrop {
         airdrop_request_amount: tokens,


### PR DESCRIPTION
#### Problem
`test_rpc_request_airdrop` hangs for some users. TcpStream::connect can hang if your machine's firewall is configured to hang on connection.
Also the name of that test doesn't indicate that the airdrop is supposed to fail.

#### Summary of Changes
Added timeout to TcpStream
Renamed test

Fixes #
