### PR TITLE
Compute leader's home directory using username, for validator setup

### DIFF
--- a/net/remote/remote-sanity.sh
+++ b/net/remote/remote-sanity.sh
@@ -68,7 +68,7 @@ snap)
 local|tar)
   PATH="$HOME"/.cargo/bin:"$PATH"
   export USE_INSTALL=1
-  entrypointRsyncUrl="$entrypointIp:~/solana"
+  entrypointRsyncUrl="$entrypointIp:~solana/solana"
 
   solana_bench_tps=solana-bench-tps
   solana_ledger_tool=solana-ledger-tool


### PR DESCRIPTION
- This is used for rsync command. If username is not provided, the current
  user on local machine is used to compute the remote home directory. This
  will fail if the local user is not same as the remote user

#### Problem
Buildkite testnet-sanity pipeline is failing in validator sanity test. It fails when validator tries to rsync configuration from the leader node.

#### Summary of Changes
Explicitly specify the remote username in the rsync command
