### PR TITLE
Shrink ledger buffers

### DIFF
--- a/src/ledger.rs
+++ b/src/ledger.rs
@@ -77,10 +77,6 @@ pub struct LedgerWindow {
 pub const LEDGER_DATA_FILE: &str = "data";
 const LEDGER_INDEX_FILE: &str = "index";
 
-const LEDGER_BUF_COUNT: usize = 32 * 1024;
-const LEDGER_DATA_BUF_SIZE: usize = LEDGER_BUF_COUNT * BLOB_DATA_SIZE;
-const LEDGER_INDEX_BUF_SIZE: usize = LEDGER_BUF_COUNT * SIZEOF_U64 as usize;
-
 // use a CONST because there's a cast, and we don't want "sizeof::<u64> as u64"...
 const SIZEOF_U64: u64 = size_of::<u64>() as u64;
 
@@ -116,9 +112,9 @@ impl LedgerWindow {
         let ledger_path = Path::new(&ledger_path);
 
         let index = File::open(ledger_path.join(LEDGER_INDEX_FILE))?;
-        let index = BufReader::with_capacity(LEDGER_INDEX_BUF_SIZE, index);
+        let index = BufReader::new(index);
         let data = File::open(ledger_path.join(LEDGER_DATA_FILE))?;
-        let data = BufReader::with_capacity(LEDGER_DATA_BUF_SIZE, data);
+        let data = BufReader::with_capacity(BLOB_DATA_SIZE, data);
 
         Ok(LedgerWindow { index, data })
     }
@@ -188,10 +184,10 @@ pub fn verify_ledger(ledger_path: &str) -> io::Result<()> {
             format!("index is not a multiple of {} bytes long", SIZEOF_U64),
         ))?;
     }
-    let mut index = BufReader::with_capacity(LEDGER_INDEX_BUF_SIZE, index);
+    let mut index = BufReader::new(index);
 
     let data = File::open(ledger_path.join(LEDGER_DATA_FILE))?;
-    let mut data = BufReader::with_capacity(LEDGER_DATA_BUF_SIZE, data);
+    let mut data = BufReader::with_capacity(BLOB_DATA_SIZE, data);
 
     let mut last_data_offset = 0;
     let mut index_offset = 0;


### PR DESCRIPTION
#### Problem

large BufReader BufWriter buffers cosume a bunch of CPU for initialization, and a lot of RAM while running, especially in test runs, 1000x slower than necessary, 1000x bigger than necessary

#### Summary of Changes
use default buffer size for index, use BLOB_DATA_SIZE for data buffer

Fixes #