### PR TITLE
Rename Budget to BudgetExpr

### DIFF
--- a/src/budget_expr.rs
+++ b/src/budget_expr.rs
@@ -99,10 +99,12 @@ impl BudgetExpr {
     /// Return true if the budget spends exactly `spendable_tokens`.
     pub fn verify(&self, spendable_tokens: i64) -> bool {
         match self {
-            BudgetExpr::Pay(payment) | BudgetExpr::After(_, payment) | BudgetExpr::And(_, _, payment) => {
-                payment.tokens == spendable_tokens
+            BudgetExpr::Pay(payment)
+            | BudgetExpr::After(_, payment)
+            | BudgetExpr::And(_, _, payment) => payment.tokens == spendable_tokens,
+            BudgetExpr::Or(a, b) => {
+                a.1.tokens == spendable_tokens && b.1.tokens == spendable_tokens
             }
-            BudgetExpr::Or(a, b) => a.1.tokens == spendable_tokens && b.1.tokens == spendable_tokens,
         }
     }
 

--- a/src/budget_instruction.rs
+++ b/src/budget_instruction.rs
@@ -1,19 +1,19 @@
-use budget::Budget;
+use budget_expr::BudgetExpr;
 use chrono::prelude::{DateTime, Utc};
 
 /// A smart contract.
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub struct Contract {
-    /// The number of tokens allocated to the `Budget` and any transaction fees.
+    /// The number of tokens allocated to the `BudgetExpr` and any transaction fees.
     pub tokens: i64,
-    pub budget: Budget,
+    pub budget_expr: BudgetExpr,
 }
 
 /// An instruction to progress the smart contract.
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub enum Instruction {
-    /// Declare and instantiate `Budget`.
-    NewBudget(Budget),
+    /// Declare and instantiate `BudgetExpr`.
+    NewBudget(BudgetExpr),
 
     /// Tell a payment plan acknowledge the given `DateTime` has past.
     ApplyTimestamp(DateTime<Utc>),

--- a/src/cluster_info.rs
+++ b/src/cluster_info.rs
@@ -1324,7 +1324,6 @@ mod tests {
     use packet::SharedBlob;
     use result::Error;
     use signature::{Keypair, KeypairUtil};
-    use solana_sdk::pubkey::Pubkey;
     use std::fs::remove_dir_all;
     use std::net::{IpAddr, Ipv4Addr, SocketAddr};
     use std::sync::atomic::{AtomicBool, Ordering};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@ pub mod banking_stage;
 pub mod blob_fetch_stage;
 pub mod bpf_loader;
 pub mod broadcast_stage;
-pub mod budget;
+pub mod budget_expr;
 pub mod budget_instruction;
 pub mod budget_transaction;
 #[cfg(feature = "chacha")]

--- a/src/payment_plan.rs
+++ b/src/payment_plan.rs
@@ -1,4 +1,4 @@
-//! The `plan` module provides a domain-specific language for payment plans. Users create Budget objects that
+//! The `plan` module provides a domain-specific language for payment plans. Users create BudgetExpr objects that
 //! are given to an interpreter. The interpreter listens for `Witness` transactions,
 //! which it uses to reduce the payment plan. When the plan is reduced to a
 //! `Payment`, the payment is executed.


### PR DESCRIPTION
#### Problem

When the transaction engine was added, the term Budget became a namespace instead of ...a budget.

#### Summary of Changes

Rename Budget to BudgetExpr.  The name `Expr` is commonly used for an expressions in EDSLs.
