### PR TITLE
ignore multinode demo logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,8 +12,6 @@ Cargo.lock
 /config-client/
 /multinode-demo/test/config-client/
 
-# test temp files, ledgers, etc.
-/farf/
-
 # log files
 *.log
+log-*.txt


### PR DESCRIPTION
git status always shows log files as untracked

add log-*.txt (multinode demo logs) to .gitignore

Fixes #