### PR TITLE
Use relocatable BPF ELFs

### DIFF
--- a/programs/bpf/c/sdk/inc/solana_sdk.h
+++ b/programs/bpf/c/sdk/inc/solana_sdk.h
@@ -34,36 +34,15 @@ typedef unsigned long int uint64_t;
 typedef enum { false = 0, true } bool;
 
 /**
- * Built-in helper functions
- * @{
- * The BPF VM makes a limited number of helper functions available to BPF
- * programs.  They are resolved at run-time and identified by a function index.
- * Calling any of these functions results in `Call` instruction out of the
- * user's BPF program.
- *
- * The helper functions all follow the same signature:
- *
- * int helper(uint64_t, uint64_t, uint64_t, uint64_t, uint64_t)
- *
- * The meaning of each argument and return value is dependent on the particular
- * helper function being called.
+ * Helper function that prints a string to stdout
  */
+extern void sol_log(const char*);
 
 /**
- * Helper function that prints to stdout
- *
- * Prints the hexadecimal representation of each parameter
+ * Helper function that prints a 64 bit values represented in hexadecimal
+ * to stdout
  */
-#define BPF_TRACE_PRINTK_IDX 6
-static int (*sol_print)(
-  uint64_t,
-  uint64_t,
-  uint64_t,
-  uint64_t,
-  uint64_t
-) = (void *)BPF_TRACE_PRINTK_IDX;
-
-/**@}*/
+extern void sol_log_64(uint64_t, uint64_t, uint64_t, uint64_t, uint64_t);
 
 /**
  * Prefix for all BPF functions
@@ -147,7 +126,7 @@ SOL_FN_PREFIX int sol_memcmp(const void *s1, const void *s2, int n) {
  */
 #define sol_panic() _sol_panic(__LINE__)
 SOL_FN_PREFIX void _sol_panic(uint64_t line) {
-  sol_print(0xFF, 0xFF, 0xFF, 0xFF, line);
+  sol_log_64(0xFF, 0xFF, 0xFF, 0xFF, line);
   uint8_t *pv = (uint8_t *)1;
   *pv = 1;
 }
@@ -241,9 +220,9 @@ SOL_FN_PREFIX bool sol_deserialize(
  *
  * @param key The public key to print
  */
-SOL_FN_PREFIX void sol_print_key(const SolPubkey *key) {
+SOL_FN_PREFIX void sol_log_key(const SolPubkey *key) {
   for (int j = 0; j < sizeof(*key); j++) {
-    sol_print(0, 0, 0, j, key->x[j]);
+    sol_log_64(0, 0, 0, j, key->x[j]);
   }
 }
 
@@ -252,9 +231,9 @@ SOL_FN_PREFIX void sol_print_key(const SolPubkey *key) {
  *
  * @param array The array to print
  */
-SOL_FN_PREFIX void sol_print_array(const uint8_t *array, int len) {
+SOL_FN_PREFIX void sol_log_array(const uint8_t *array, int len) {
   for (int j = 0; j < len; j++) {
-    sol_print(0, 0, 0, j, array[j]);
+    sol_log_64(0, 0, 0, j, array[j]);
   }
 }
 
@@ -266,20 +245,20 @@ SOL_FN_PREFIX void sol_print_array(const uint8_t *array, int len) {
  * @param data A pointer to the instruction data to print
  * @param data_len The length in bytes of the instruction data
  */
-SOL_FN_PREFIX void sol_print_params(
+SOL_FN_PREFIX void sol_log_params(
   uint64_t num_ka,
   const SolKeyedAccounts *ka,
   const uint8_t *data,
   uint64_t data_len
 ) {
-  sol_print(0, 0, 0, 0, num_ka);
+  sol_log_64(0, 0, 0, 0, num_ka);
   for (int i = 0; i < num_ka; i++) {
-    sol_print_key(ka[i].key);
-    sol_print(0, 0, 0, 0, *ka[i].tokens);
-    sol_print_array(ka[i].userdata, ka[i].userdata_len);
-    sol_print_key(ka[i].program_id);
+    sol_log_key(ka[i].key);
+    sol_log_64(0, 0, 0, 0, *ka[i].tokens);
+    sol_log_array(ka[i].userdata, ka[i].userdata_len);
+    sol_log_key(ka[i].program_id);
   }
-  sol_print_array(data, data_len);
+  sol_log_array(data, data_len);
 }
 
 /**@}*/
@@ -299,7 +278,7 @@ SOL_FN_PREFIX void sol_print_params(
  *   if (!sol_deserialize(buf, ka, SOL_ARRAY_SIZE(ka), NULL, &data, &data_len)) {
  *     return false;
  *   }
- *   print_params(1, ka, data, data_len);
+ *   log_params(1, ka, data, data_len);
  *   return true;
  * }
  */

--- a/programs/bpf/c/src/move_funds.c
+++ b/programs/bpf/c/src/move_funds.c
@@ -24,9 +24,9 @@ extern bool entrypoint(const uint8_t *input) {
   if (*ka[0].tokens >= tokens) {
     *ka[0].tokens -= tokens;
     *ka[2].tokens += tokens;
-    // sol_print(0, 0, *ka[0].tokens, *ka[2].tokens, tokens);
+    // sol_log_64(0, 0, *ka[0].tokens, *ka[2].tokens, tokens);
   } else {
-    // sol_print(0, 0, 0xFF, *ka[0].tokens, tokens);
+    // sol_log_64(0, 0, 0xFF, *ka[0].tokens, tokens);
   }
   return true;
 }

--- a/programs/bpf/c/src/noop.c
+++ b/programs/bpf/c/src/noop.c
@@ -15,11 +15,13 @@ extern bool entrypoint(const uint8_t *input) {
   SolKeyedAccounts ka[NUM_KA];
   const uint8_t *data;
   uint64_t data_len;
+  
+  sol_log("noop");
 
   if (!sol_deserialize(input, ka, NUM_KA, NULL, &data, &data_len)) {
     return false;
   }
-  sol_print_params(NUM_KA, ka, data, data_len);
+  sol_log_params(NUM_KA, ka, data, data_len);
 
   sol_assert(sizeof(int8_t) == 1);
   sol_assert(sizeof(uint8_t) == 1);

--- a/programs/native/bpf_loader/Cargo.toml
+++ b/programs/native/bpf_loader/Cargo.toml
@@ -13,7 +13,7 @@ elf = "0.0.10"
 env_logger = "0.5.12"
 libc = "0.2.43"
 log = "0.4.2"
-solana_rbpf = "0.1.2"
+solana_rbpf = { path = "../../../../rbpf" }
 serde = "1.0.27"
 serde_derive = "1.0.27"
 solana-sdk = { path = "../../../sdk", version = "0.11.0" }


### PR DESCRIPTION
#### Problem

BPF VM did not allow relocations and therefore programs could not access things like static strings and had to use hard-coded indexes to call external functions.

#### Summary of Changes

rodata relocations and extern symbol relocations are now supported.  The vm has also changed to allows the registration of a helper function and it's verifier function which allows helpers to treat their arguments as pointers.

Fixes #
