### PR TITLE
Update last_id between client retries

### DIFF
--- a/src/drone.rs
+++ b/src/drone.rs
@@ -116,7 +116,7 @@ impl Drone {
         );
         let last_id = client.get_last_id();
 
-        let tx = match req {
+        let mut tx = match req {
             DroneRequest::GetAirdrop {
                 airdrop_request_amount,
                 client_pubkey,
@@ -147,7 +147,7 @@ impl Drone {
                         influxdb::Value::Integer(self.request_current as i64),
                     ).to_owned(),
             );
-            client.retry_transfer_signed(&tx, 10)
+            client.retry_transfer(&self.mint_keypair, &mut tx, 10)
         } else {
             Err(Error::new(ErrorKind::Other, "token limit reached"))
         }

--- a/src/thin_client.rs
+++ b/src/thin_client.rs
@@ -75,13 +75,15 @@ impl ThinClient {
     }
 
     /// Retry a sending a signed Transaction to the server for processing.
-    pub fn retry_transfer_signed(
+    pub fn retry_transfer(
         &mut self,
-        tx: &Transaction,
+        keypair: &Keypair,
+        tx: &mut Transaction,
         tries: usize,
     ) -> io::Result<Signature> {
-        let data = serialize(&tx).expect("serialize Transaction in pub fn transfer_signed");
         for x in 0..tries {
+            tx.sign(&keypair, self.get_last_id());
+            let data = serialize(&tx).expect("serialize Transaction in pub fn transfer_signed");
             self.transactions_socket
                 .send_to(&data, &self.transactions_addr)?;
             if self.poll_for_signature(&tx.signature).is_ok() {
@@ -91,7 +93,7 @@ impl ThinClient {
         }
         Err(io::Error::new(
             io::ErrorKind::Other,
-            "retry_transfer_signed failed",
+            "retry_transfer failed",
         ))
     }
 

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -95,12 +95,12 @@ impl Transaction {
         let mut tx = Transaction {
             signature: Signature::default(),
             account_keys,
-            last_id,
+            last_id: Hash::default(),
             fee,
             program_ids,
             instructions,
         };
-        tx.sign(from_keypair);
+        tx.sign(from_keypair, last_id);
         tx
     }
     pub fn userdata(&self, instruction_index: usize) -> &[u8] {
@@ -146,7 +146,8 @@ impl Transaction {
     }
 
     /// Sign this transaction.
-    pub fn sign(&mut self, keypair: &Keypair) {
+    pub fn sign(&mut self, keypair: &Keypair, last_id: Hash) {
+        self.last_id = last_id;
         let sign_data = self.get_sign_data();
         self.signature = Signature::new(keypair.sign(&sign_data).as_ref());
     }

--- a/tests/multinode.rs
+++ b/tests/multinode.rs
@@ -1490,9 +1490,9 @@ fn send_tx_and_retry_get_balance(
     let mut client = mk_client(leader);
     trace!("getting leader last_id");
     let last_id = client.get_last_id();
-    let tx = Transaction::system_new(&alice.keypair(), *bob_pubkey, transfer_amount, last_id);
+    let mut tx = Transaction::system_new(&alice.keypair(), *bob_pubkey, transfer_amount, last_id);
     info!("executing leader transfer");
-    let _res = client.retry_transfer_signed(&tx, 30);
+    let _res = client.retry_transfer(&alice.keypair(), &mut tx, 30);
     retry_get_balance(&mut client, bob_pubkey, expected)
 }
 


### PR DESCRIPTION
#### Problem

Transactions from Rust clients may be getting rejected when it requires multiple retries. The transaction's last_id is never updated, so one it's too old, all retries will be rejected:

#### Summary of Changes

Extended `Transaction::sign()` with `last_id: Hash`, and updated usages to query for the latest last_id  before signing.

Fixes #1694

