### PR TITLE
Pass any serializable to Transaction constructor

### DIFF
--- a/src/budget_program.rs
+++ b/src/budget_program.rs
@@ -292,12 +292,12 @@ mod test {
         ];
         let from = Keypair::new();
         let contract = Keypair::new();
-        let userdata = vec![1, 2, 3];
+        let userdata = (1u8, 2u8, 3u8);
         let tx = Transaction::new(
             &from,
             &[contract.pubkey()],
             BudgetState::id(),
-            userdata,
+            &userdata,
             Hash::default(),
             0,
         );

--- a/src/loader_transaction.rs
+++ b/src/loader_transaction.rs
@@ -1,6 +1,5 @@
 //! The `dynamic_transaction` module provides functionality for loading and calling a program
 
-use bincode::serialize;
 use hash::Hash;
 use signature::{Keypair, KeypairUtil};
 use solana_sdk::loader_instruction::LoaderInstruction;
@@ -36,8 +35,7 @@ impl LoaderTransaction for Transaction {
             bytes.len()
         );
         let instruction = LoaderInstruction::Write { offset, bytes };
-        let userdata = serialize(&instruction).unwrap();
-        Transaction::new(from_keypair, &[], loader, userdata, last_id, fee)
+        Transaction::new(from_keypair, &[], loader, &instruction, last_id, fee)
     }
 
     fn finalize(from_keypair: &Keypair, loader: Pubkey, last_id: Hash, fee: u64) -> Self {
@@ -46,7 +44,6 @@ impl LoaderTransaction for Transaction {
             from_keypair.pubkey(),
         );
         let instruction = LoaderInstruction::Finalize;
-        let userdata = serialize(&instruction).unwrap();
-        Transaction::new(from_keypair, &[], loader, userdata, last_id, fee)
+        Transaction::new(from_keypair, &[], loader, &instruction, last_id, fee)
     }
 }

--- a/src/storage_program.rs
+++ b/src/storage_program.rs
@@ -66,7 +66,7 @@ mod test {
             &keypair,
             &[],
             StorageProgram::id(),
-            vec![],
+            &(),
             Default::default(),
             0,
         );

--- a/src/storage_transaction.rs
+++ b/src/storage_transaction.rs
@@ -1,4 +1,3 @@
-use bincode::serialize;
 use hash::Hash;
 use signature::{Keypair, KeypairUtil};
 use storage_program::StorageProgram;
@@ -11,12 +10,11 @@ pub trait StorageTransaction {
 impl StorageTransaction for Transaction {
     fn storage_new_mining_proof(from_keypair: &Keypair, sha_state: Hash, last_id: Hash) -> Self {
         let program = StorageProgram::SubmitMiningProof { sha_state };
-        let userdata = serialize(&program).unwrap();
         Transaction::new(
             from_keypair,
             &[from_keypair.pubkey()],
             StorageProgram::id(),
-            userdata,
+            &program,
             last_id,
             0,
         )

--- a/src/system_transaction.rs
+++ b/src/system_transaction.rs
@@ -1,6 +1,5 @@
 //! The `system_transaction` module provides functionality for creating system transactions.
 
-use bincode::serialize;
 use hash::Hash;
 use signature::{Keypair, KeypairUtil};
 use solana_sdk::pubkey::Pubkey;
@@ -56,12 +55,11 @@ impl SystemTransaction for Transaction {
             space,
             program_id,
         };
-        let userdata = serialize(&create).unwrap();
         Transaction::new(
             from_keypair,
             &[to],
             SystemProgram::id(),
-            userdata,
+            &create,
             last_id,
             fee,
         )
@@ -69,12 +67,11 @@ impl SystemTransaction for Transaction {
     /// Create and sign new SystemProgram::Assign transaction
     fn system_assign(from_keypair: &Keypair, last_id: Hash, program_id: Pubkey, fee: u64) -> Self {
         let assign = SystemProgram::Assign { program_id };
-        let userdata = serialize(&assign).unwrap();
         Transaction::new(
             from_keypair,
             &[],
             SystemProgram::id(),
-            userdata,
+            &assign,
             last_id,
             fee,
         )
@@ -92,12 +89,11 @@ impl SystemTransaction for Transaction {
         fee: u64,
     ) -> Self {
         let move_tokens = SystemProgram::Move { tokens };
-        let userdata = serialize(&move_tokens).unwrap();
         Transaction::new(
             from_keypair,
             &[to],
             SystemProgram::id(),
-            userdata,
+            &move_tokens,
             last_id,
             fee,
         )
@@ -109,11 +105,7 @@ impl SystemTransaction for Transaction {
             .enumerate()
             .map(|(i, (_, amount))| {
                 let spend = SystemProgram::Move { tokens: *amount };
-                Instruction {
-                    program_ids_index: 0,
-                    userdata: serialize(&spend).unwrap(),
-                    accounts: vec![0, i as u8 + 1],
-                }
+                Instruction::new(0, &spend, vec![0, i as u8 + 1])
             }).collect();
         let to_keys: Vec<_> = moves.iter().map(|(to_key, _)| *to_key).collect();
 
@@ -129,15 +121,7 @@ impl SystemTransaction for Transaction {
     /// Create and sign new SystemProgram::Spawn transaction
     fn system_spawn(from_keypair: &Keypair, last_id: Hash, fee: u64) -> Self {
         let spawn = SystemProgram::Spawn;
-        let userdata = serialize(&spawn).unwrap();
-        Transaction::new(
-            from_keypair,
-            &[],
-            SystemProgram::id(),
-            userdata,
-            last_id,
-            fee,
-        )
+        Transaction::new(from_keypair, &[], SystemProgram::id(), &spawn, last_id, fee)
     }
 }
 

--- a/src/vote_transaction.rs
+++ b/src/vote_transaction.rs
@@ -2,7 +2,7 @@
 
 #[cfg(test)]
 use bank::Bank;
-use bincode::{deserialize, serialize};
+use bincode::deserialize;
 use hash::Hash;
 #[cfg(test)]
 use result::Result;
@@ -34,8 +34,14 @@ pub trait VoteTransaction {
 impl VoteTransaction for Transaction {
     fn vote_new(vote_account: &Keypair, vote: Vote, last_id: Hash, fee: u64) -> Self {
         let instruction = VoteInstruction::NewVote(vote);
-        let userdata = serialize(&instruction).expect("serialize instruction");
-        Transaction::new(vote_account, &[], VoteProgram::id(), userdata, last_id, fee)
+        Transaction::new(
+            vote_account,
+            &[],
+            VoteProgram::id(),
+            &instruction,
+            last_id,
+            fee,
+        )
     }
 
     fn vote_account_new(
@@ -62,12 +68,11 @@ impl VoteTransaction for Transaction {
         fee: u64,
     ) -> Self {
         let register_tx = VoteInstruction::RegisterAccount;
-        let userdata = serialize(&register_tx).unwrap();
         Transaction::new(
             validator_id,
             &[vote_account_id],
             VoteProgram::id(),
-            userdata,
+            &register_tx,
             last_id,
             fee,
         )

--- a/tests/programs.rs
+++ b/tests/programs.rs
@@ -4,7 +4,6 @@ extern crate serde_derive;
 extern crate solana;
 extern crate solana_sdk;
 
-use bincode::serialize;
 use solana::bank::Bank;
 #[cfg(feature = "bpf_c")]
 use solana::bpf_loader;
@@ -189,7 +188,7 @@ fn test_program_native_noop() {
         &loader.mint.keypair(),
         &[],
         program.program.pubkey(),
-        vec![1u8],
+        &1u8,
         loader.mint.last_id(),
         0,
     );
@@ -248,12 +247,11 @@ fn test_program_lua_move_funds() {
         loader.bank.process_transactions(&vec![tx.clone()]),
     );
 
-    let data = serialize(&10).unwrap();
     let tx = Transaction::new(
         &from,
         &[to],
         program.program.pubkey(),
-        data,
+        &10,
         loader.mint.last_id(),
         0,
     );


### PR DESCRIPTION
#### Problem

The test suite is hard to read to because of all the `let userdata = serialize(&instruction).unwrap();` statements. They could all be `&instruction` expressions and inlined into the Transaction constructors.

#### Summary of Changes

* Add an `Instruction` constructor that accepts anything that implements `Serialize`
* Change `Transaction` constructor to accept a `Serialize` instead of a `Vec<u8>`
* Delete lots of calls to `bincode::serialize`
