### PR TITLE
net: Remove node check from client start-up

### DIFF
--- a/net/net.sh
+++ b/net/net.sh
@@ -198,7 +198,7 @@ startClient() {
     set -x
     startCommon "$ipAddress"
     ssh "${sshOptions[@]}" -f "$ipAddress" \
-      "./solana/net/remote/remote-client.sh $deployMethod $entrypointIp $expectedNodeCount \"$RUST_LOG\""
+      "./solana/net/remote/remote-client.sh $deployMethod $entrypointIp \"$RUST_LOG\""
   ) >> "$logFile" 2>&1 || {
     cat "$logFile"
     echo "^^^ +++"

--- a/net/remote/remote-client.sh
+++ b/net/remote/remote-client.sh
@@ -6,8 +6,7 @@ echo "$(date) | $0 $*" > client.log
 
 deployMethod="$1"
 entrypointIp="$2"
-numNodes="$3"
-RUST_LOG="$4"
+RUST_LOG="$3"
 export RUST_LOG=${RUST_LOG:-solana=info} # if RUST_LOG is unset, default to info
 
 missing() {
@@ -17,7 +16,6 @@ missing() {
 
 [[ -n $deployMethod ]] || missing deployMethod
 [[ -n $entrypointIp ]] || missing entrypointIp
-[[ -n $numNodes ]]     || missing numNodes
 
 source net/common.sh
 loadConfigFile
@@ -58,7 +56,6 @@ clientCommand="\
   $solana_bench_tps \
     --network $entrypointIp:8001 \
     --identity client.json \
-    --num-nodes $numNodes \
     --duration 7500 \
     --sustained \
     --threads $threadCount \


### PR DESCRIPTION
If the network loses a validator or two, it's the job of the sanity
check to detect this not the bench clients

#### Problem

#### Summary of Changes

Fixes #
