### PR TITLE
Fetch v0.10.5 perf libs

### DIFF
--- a/fetch-perf-libs.sh
+++ b/fetch-perf-libs.sh
@@ -15,7 +15,7 @@ mkdir -p target/perf-libs
   cd target/perf-libs
   (
     set -x
-    curl https://solana-perf.s3.amazonaws.com/v0.10.4/x86_64-unknown-linux-gnu/solana-perf.tgz | tar zxvf -
+    curl https://solana-perf.s3.amazonaws.com/v0.10.5/x86_64-unknown-linux-gnu/solana-perf.tgz | tar zxvf -
   )
 
   if [[ -r /usr/local/cuda/version.txt && -r cuda-version.txt ]]; then


### PR DESCRIPTION
- includes SGX enclave for signing

#### Problem
New feature - Sign data using private key stored in a SGX enclave

#### Summary of Changes
SGX enclave code is stored and built in solana-perf-libs git repository. This change pulls in the latest perf lib release, that includes SGX enclave code.
