### PR TITLE
Add loader_ prefix to LoaderTransaction methods

### DIFF
--- a/src/loader_transaction.rs
+++ b/src/loader_transaction.rs
@@ -7,7 +7,7 @@ use solana_sdk::pubkey::Pubkey;
 use transaction::Transaction;
 
 pub trait LoaderTransaction {
-    fn write(
+    fn loader_write(
         from_keypair: &Keypair,
         loader: Pubkey,
         offset: u32,
@@ -16,11 +16,11 @@ pub trait LoaderTransaction {
         fee: u64,
     ) -> Self;
 
-    fn finalize(from_keypair: &Keypair, loader: Pubkey, last_id: Hash, fee: u64) -> Self;
+    fn loader_finalize(from_keypair: &Keypair, loader: Pubkey, last_id: Hash, fee: u64) -> Self;
 }
 
 impl LoaderTransaction for Transaction {
-    fn write(
+    fn loader_write(
         from_keypair: &Keypair,
         loader: Pubkey,
         offset: u32,
@@ -38,7 +38,7 @@ impl LoaderTransaction for Transaction {
         Transaction::new(from_keypair, &[], loader, &instruction, last_id, fee)
     }
 
-    fn finalize(from_keypair: &Keypair, loader: Pubkey, last_id: Hash, fee: u64) -> Self {
+    fn loader_finalize(from_keypair: &Keypair, loader: Pubkey, last_id: Hash, fee: u64) -> Self {
         trace!(
             "LoaderTransaction::Finalize() program {:?}",
             from_keypair.pubkey(),

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -422,7 +422,7 @@ pub fn process_command(config: &WalletConfig) -> Result<String, Box<error::Error
 
             let mut offset = 0;
             for chunk in program_userdata.chunks(USERDATA_CHUNK_SIZE) {
-                let tx = Transaction::write(
+                let tx = Transaction::loader_write(
                     &program,
                     bpf_loader::id(),
                     offset,
@@ -440,7 +440,7 @@ pub fn process_command(config: &WalletConfig) -> Result<String, Box<error::Error
             }
 
             let last_id = get_last_id(&config)?;
-            let tx = Transaction::finalize(&program, bpf_loader::id(), last_id, 0);
+            let tx = Transaction::loader_finalize(&program, bpf_loader::id(), last_id, 0);
             send_and_confirm_tx(&config, &tx).map_err(|_| {
                 WalletError::DynamicProgramError("Program finalize transaction failed".to_string())
             })?;

--- a/tests/programs.rs
+++ b/tests/programs.rs
@@ -71,7 +71,7 @@ impl Loader {
         check_tx_results(&bank, &tx, bank.process_transactions(&vec![tx.clone()]));
 
         let name = String::from(loader_name);
-        let tx = Transaction::write(
+        let tx = Transaction::loader_write(
             &loader,
             native_loader::id(),
             0,
@@ -81,7 +81,7 @@ impl Loader {
         );
         check_tx_results(&bank, &tx, bank.process_transactions(&vec![tx.clone()]));
 
-        let tx = Transaction::finalize(&loader, native_loader::id(), mint.last_id(), 0);
+        let tx = Transaction::loader_finalize(&loader, native_loader::id(), mint.last_id(), 0);
         check_tx_results(&bank, &tx, bank.process_transactions(&vec![tx.clone()]));
 
         let tx = Transaction::system_spawn(&loader, mint.last_id(), 0);
@@ -140,7 +140,7 @@ impl Program {
         let chunk_size = 256; // Size of chunk just needs to fit into tx
         let mut offset = 0;
         for chunk in userdata.chunks(chunk_size) {
-            let tx = Transaction::write(
+            let tx = Transaction::loader_write(
                 &program,
                 loader.loader,
                 offset,
@@ -156,7 +156,7 @@ impl Program {
             offset += chunk_size as u32;
         }
 
-        let tx = Transaction::finalize(&program, loader.loader, loader.mint.last_id(), 0);
+        let tx = Transaction::loader_finalize(&program, loader.loader, loader.mint.last_id(), 0);
         check_tx_results(
             &loader.bank,
             &tx,


### PR DESCRIPTION
#### Problem

We're awkwardly using traits to add constructors to transactions, and naming those methods 3 different ways.

* `<combinator_name>`
* `<namespace>_<combinator_name>`
* `<namespace>_new_<noun>`

#### Summary of Changes

Drops to 2 different naming conventions:

* `<namespace>_<combinator_name>`
* `<namespace>_new_<noun>`

