### PR TITLE
Upgrade Rust stable to 1.30.1

### DIFF
--- a/ci/buildkite.yml
+++ b/ci/buildkite.yml
@@ -1,5 +1,5 @@
 steps:
-  - command: "ci/docker-run.sh solanalabs/rust:1.30.0 ci/test-stable.sh"
+  - command: "ci/docker-run.sh solanalabs/rust:1.30.1 ci/test-stable.sh"
     name: "stable [public]"
     env:
       CARGO_TARGET_CACHE_NAME: "stable"

--- a/ci/docker-rust/Dockerfile
+++ b/ci/docker-rust/Dockerfile
@@ -1,6 +1,6 @@
 # Note: when the rust version is changed also modify
 # ci/buildkite.yml to pick up the new image tag
-FROM rust:1.30.0
+FROM rust:1.30.1
 
 RUN set -x && \
     apt update && \


### PR DESCRIPTION
#### Problem

`cargo doc` broke in the upgrade from 1.29.1 to 1.30.0

#### Summary of Changes

Upgrade to 1.30.1

Fixes #1700
