### PR TITLE
Add net/scp.sh for easier file transfer to/from network nodes

### DIFF
--- a/net/scp.sh
+++ b/net/scp.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+here=$(dirname "$0")
+# shellcheck source=net/common.sh
+source "$here"/common.sh
+
+usage() {
+  exitcode=0
+  if [[ -n "$1" ]]; then
+    exitcode=1
+    echo "Error: $*"
+  fi
+  cat <<EOF
+usage: $0 source ... target
+
+node scp - behaves like regular scp with the necessary options to
+access network nodes added automatically
+
+EOF
+  exit $exitcode
+}
+
+while getopts "h?" opt; do
+  case $opt in
+  h | \?)
+    usage
+    ;;
+  *)
+    usage "Error: unhandled option: $opt"
+    ;;
+  esac
+done
+
+loadConfigFile
+
+if [[ -n "$1" ]]; then
+  set -x
+  exec scp "${sshOptions[@]}" "$@"
+fi
+
+exec "$here"/ssh.sh
+
+exit 0

--- a/net/ssh.sh
+++ b/net/ssh.sh
@@ -65,5 +65,8 @@ else
     printNode client "$ipAddress"
   done
 fi
+echo
+echo "Use |scp.sh| to transfer files to and from nodes"
+echo
 
 exit 0


### PR DESCRIPTION
@carllin, at your request!

You still need to know the IP address to the desired node, like normal scp.  Run `./scp.sh` without any arguments to view that.  Otherwise it's just `./scp.sh foo 1.2.3.4:` or `./scp.sh 1.2.3.4:bar .`