### PR TITLE
move fork-able, checkpoint-able state into BankState

### DIFF
--- a/src/entry.rs
+++ b/src/entry.rs
@@ -33,6 +33,9 @@ pub type EntryReceiver = Receiver<Vec<Entry>>;
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub struct Entry {
+    /// The SHA-256 hash we started from, i.e. the previous Entry ID.
+    pub start_hash: Hash,
+
     /// The number of hashes since the previous Entry ID.
     pub num_hashes: u64,
 


### PR DESCRIPTION
#### Problem

a slice of Entries arriving from the window stage can start at an arbitrary
  Entry, current single-linked list of state checkpoints Bank can't deal
  with that

  #### Summary of Changes

introduce an inner "BankState", to allow Bank to have multiple "heads" along with a HashMap of read-only checkpoints that are parents of those heads


Fixes #