### PR TITLE
Don't ignore VoteProgram errors

### DIFF
--- a/src/bank.rs
+++ b/src/bank.rs
@@ -797,7 +797,9 @@ impl Bank {
                 return Err(BankError::ProgramRuntimeError(instruction_index as u8));
             }
         } else if VoteProgram::check_id(&program_id) {
-            VoteProgram::process_transaction(&tx, instruction_index, program_accounts).is_err();
+            if VoteProgram::process_transaction(&tx, instruction_index, program_accounts).is_err() {
+                return Err(BankError::ProgramRuntimeError(instruction_index as u8));
+            }
         } else {
             let mut depth = 0;
             let mut keys = Vec::new();


### PR DESCRIPTION
#### Problem

VoteProgram errors might be unintentionally ignored

#### Summary of Changes

Handle errors the same way the rest of the programs do

