### PR TITLE
Add hostname information to db entries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,6 +109,7 @@ sys-info = "0.5.6"
 tokio = "0.1"
 tokio-codec = "0.1"
 untrusted = "0.6.2"
+lazy_static = "1.2.0"
 solana-bpfloader = { path = "programs/native/bpf_loader", version = "0.11.0" }
 solana-erc20 = { path = "programs/native/erc20", version = "0.11.0" }
 solana-lualoader = { path = "programs/native/lua_loader", version = "0.11.0" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,6 +123,8 @@ extern crate sys_info;
 extern crate tokio;
 extern crate tokio_codec;
 extern crate untrusted;
+#[macro_use]
+extern crate lazy_static;
 
 #[cfg(test)]
 #[macro_use]


### PR DESCRIPTION
Add new field to each db entry identifying the host that it originated from.

#### Problem
The metrics that are submitted currently do not have the node information that makes it difficult to get per node statistics and the dashboard hence just displays the accumulated statistics for all the validator nodes.

#### Summary of Changes
Add the node information to each db entry that gets submitted that allows for filtering based on node information and display per node statistics in the dashboard.

Fixes #
