### PR TITLE
Switch to perf-libs v0.10.6

### DIFF
--- a/fetch-perf-libs.sh
+++ b/fetch-perf-libs.sh
@@ -16,7 +16,7 @@ mkdir -p target/perf-libs
   cd target/perf-libs
   (
     set -x
-    curl https://solana-perf.s3.amazonaws.com/v0.10.5/x86_64-unknown-linux-gnu/solana-perf.tgz | tar zxvf -
+    curl https://solana-perf.s3.amazonaws.com/v0.10.6/x86_64-unknown-linux-gnu/solana-perf.tgz | tar zxvf -
   )
 
   if [[ -z "$CUDA_HOME" ]]; then

--- a/fetch-perf-libs.sh
+++ b/fetch-perf-libs.sh
@@ -19,14 +19,13 @@ mkdir -p target/perf-libs
     curl https://solana-perf.s3.amazonaws.com/v0.10.6/x86_64-unknown-linux-gnu/solana-perf.tgz | tar zxvf -
   )
 
-  if [[ -z "$CUDA_HOME" ]]; then
-    if [[ -r "$CUDA_HOME"/solana-perf-CUDA_HOME.txt ]]; then
-      CUDA_HOME=$(cat "$CUDA_HOME"/solana-perf-CUDA_HOME.txt)
-    else
-      CUDA_HOME=/usr/local/cuda
-    fi
+  if [[ -r solana-perf-CUDA_HOME.txt ]]; then
+    CUDA_HOME=$(cat solana-perf-CUDA_HOME.txt)
+  else
+    CUDA_HOME=/usr/local/cuda
   fi
 
+  echo CUDA_HOME="$CUDA_HOME"
   if [[ -r "$CUDA_HOME"/version.txt && -r cuda-version.txt ]]; then
     if ! diff "$CUDA_HOME"/version.txt cuda-version.txt > /dev/null; then
         echo ==============================================
@@ -46,8 +45,6 @@ mkdir -p target/perf-libs
 export CUDA_HOME=$CUDA_HOME
 export LD_LIBRARY_PATH="$PWD:$CUDA_HOME/lib64:$LD_LIBRARY_PATH"
 export PATH="$PATH:$CUDA_HOME/bin"
-echo CUDA_HOME="$CUDA_HOME"
-echo LD_LIBRARY_PATH="$LD_LIBRARY_PATH"
 EOF
 
   echo "Downloaded solana-perf version: $(cat solana-perf-HEAD.txt)"


### PR DESCRIPTION
No functional changes, just proving that perf-libs can drive CUDA_HOME before taking the leap to CUDA 10