### PR TITLE
BPF SDK additions needed to get capnproto C bindings working

### DIFF
--- a/programs/bpf/c/sdk/bpf.mk
+++ b/programs/bpf/c/sdk/bpf.mk
@@ -95,12 +95,12 @@ help:
 $(OUT_DIR)/%.bc: $(SRC_DIR)/%.c
 	@echo "[cc] $@ ($<)"
 	$(_@)mkdir -p $(OUT_DIR)
-	$(_@)$(CC) $(CC_FLAGS) $(SYSTEM_INC_DIRS) $(INC_DIRS) -o $@ -c $< -MD -MF $(@:.bc=.d)
+	$(_@)$(CC) $(CC_FLAGS) $(SYSTEM_INC_DIRS) $(addprefix -I,$(INC_DIRS)) -o $@ -c $< -MD -MF $(@:.bc=.d)
 
 $(OUT_DIR)/%.bc: $(SRC_DIR)/%.cc
 	@echo "[cc] $@ ($<)"
 	$(_@)mkdir -p $(OUT_DIR)
-	$(_@)$(CXX) $(CXX_FLAGS) $(SYSTEM_INC_DIRS) $(INC_DIRS) -o $@ -c $< -MD -MF $(@:.bc=.d)
+	$(_@)$(CXX) $(CXX_FLAGS) $(SYSTEM_INC_DIRS) $(addprefix -I,$(INC_DIRS)) -o $@ -c $< -MD -MF $(@:.bc=.d)
 
 .PRECIOUS: $(OUT_DIR)/%.o
 $(OUT_DIR)/%.o: $(OUT_DIR)/%.bc

--- a/programs/bpf/c/sdk/inc/solana_sdk.h
+++ b/programs/bpf/c/sdk/inc/solana_sdk.h
@@ -32,6 +32,8 @@ typedef signed int int32_t;
 typedef unsigned int uint32_t;
 typedef signed long int int64_t;
 typedef unsigned long int uint64_t;
+typedef int64_t ssize_t;
+typedef uint64_t size_t;
 
 #if defined (__cplusplus) || defined(static_assert)
 static_assert(sizeof(int8_t) == 1);
@@ -134,6 +136,30 @@ SOL_FN_PREFIX int sol_memcmp(const void *s1, const void *s2, int n) {
     }
   }
   return 0;
+}
+
+/**
+ * Fill a byte string with a byte value
+ */
+SOL_FN_PREFIX void *sol_memset(void *b, int c, size_t len) {
+  uint8_t *a = (uint8_t *) b;
+  while (len > 0) {
+    *a = c;
+    a++;
+    len--;
+  }
+}
+
+/**
+ * Find length of string
+ */
+SOL_FN_PREFIX size_t sol_strlen(const char *s) {
+  size_t len = 0;
+  while (*s) {
+    len++;
+    s++;
+  }
+  return len;
 }
 
 /**

--- a/programs/bpf/c/sdk/inc/stdio.h
+++ b/programs/bpf/c/sdk/inc/stdio.h
@@ -1,0 +1,2 @@
+#pragma once
+typedef void *FILE;

--- a/programs/bpf/c/sdk/inc/stdlib.h
+++ b/programs/bpf/c/sdk/inc/stdlib.h
@@ -1,0 +1,2 @@
+#pragma once
+#include <solana_sdk.h>

--- a/programs/bpf/c/sdk/inc/string.h
+++ b/programs/bpf/c/sdk/inc/string.h
@@ -1,0 +1,7 @@
+#pragma once
+#include <solana_sdk.h>
+
+#define memcpy sol_memcpy
+#define memset sol_memset
+#define strlen sol_strlen
+

--- a/programs/bpf/c/sdk/inc/sys/param.h
+++ b/programs/bpf/c/sdk/inc/sys/param.h
@@ -1,0 +1,1 @@
+#pragma once


### PR DESCRIPTION
This PR contains the `solana_sdk.h`, etc changes needed by #1346 to get far enough to be blocked by the current crop of LLVM+BPF limitations.

Once we have #1806 some of this PR gets backed out