### PR TITLE
Change testnet automation to use TAR instead of snap

### DIFF
--- a/ci/publish-solana-tar.sh
+++ b/ci/publish-solana-tar.sh
@@ -55,21 +55,27 @@ echo --- Creating tarball
   tar jvcf solana-release.tar.bz2 solana-release/
 )
 
-echo --- AWS S3 Store
-if [[ -z $DRYRUN ]]; then
-  (
-    set -x
-    if [[ ! -r s3cmd-2.0.1/s3cmd ]]; then
-      rm -rf s3cmd-2.0.1.tar.gz s3cmd-2.0.1
-      $DRYRUN wget https://github.com/s3tools/s3cmd/releases/download/v2.0.1/s3cmd-2.0.1.tar.gz
-      $DRYRUN tar zxf s3cmd-2.0.1.tar.gz
-    fi
+echo --- Saving build artifacts
+source ci/upload_ci_artifact.sh
+upload_ci_artifact solana-release.tar.bz2
 
-    $DRYRUN python ./s3cmd-2.0.1/s3cmd --acl-public put solana-release.tar.bz2 \
-      s3://solana-release/"$CHANNEL_OR_TAG"/solana-release.tar.bz2
-  )
-else
-  echo Skipped due to DRYRUN
+if [[ -z $DO_NOT_PUBLISH_TAR ]]; then
+  echo --- AWS S3 Store
+  if [[ -z $DRYRUN ]]; then
+    (
+      set -x
+      if [[ ! -r s3cmd-2.0.1/s3cmd ]]; then
+        rm -rf s3cmd-2.0.1.tar.gz s3cmd-2.0.1
+        $DRYRUN wget https://github.com/s3tools/s3cmd/releases/download/v2.0.1/s3cmd-2.0.1.tar.gz
+        $DRYRUN tar zxf s3cmd-2.0.1.tar.gz
+      fi
+
+      $DRYRUN python ./s3cmd-2.0.1/s3cmd --acl-public put solana-release.tar.bz2 \
+        s3://solana-release/"$CHANNEL_OR_TAG"/solana-release.tar.bz2
+    )
+  else
+    echo Skipped due to DRYRUN
+  fi
 fi
 exit 0
 

--- a/ci/solana-testnet.yml
+++ b/ci/solana-testnet.yml
@@ -1,9 +1,4 @@
 steps:
-  - command: "test -n $USE_PREBUILT_CHANNEL_TARBALL || ci/snap.sh"
-    label: "create snap"
-
-  - wait
-
   - command: "ci/testnet-automation.sh"
     label: "run testnet"
     agents:

--- a/ci/testnet-automation.sh
+++ b/ci/testnet-automation.sh
@@ -4,8 +4,8 @@ set -e
 cd "$(dirname "$0")/.."
 
 if [[ -z $USE_PREBUILT_CHANNEL_TARBALL ]]; then
-  echo --- downloading snap from build artifacts
-  buildkite-agent artifact download "solana_*.snap" .
+  echo --- downloading tar from build artifacts
+  buildkite-agent artifact download "solana*.tar.bz2" .
 fi
 
 # shellcheck disable=SC1091
@@ -35,7 +35,7 @@ launchTestnet() {
   if [[ -n $USE_PREBUILT_CHANNEL_TARBALL ]]; then
     net/net.sh start -o noValidatorSanity -t "$CHANNEL"
   else
-    net/net.sh start -o noValidatorSanity -S solana_*.snap
+    net/net.sh start -o noValidatorSanity -T solana*.tar.bz2
   fi
 
   echo --- wait "$ITERATION_WAIT" seconds to complete test


### PR DESCRIPTION
#### Problem
SNAP builds may not include CUDA support. So testnet automation will report TPS numbers without CUDA support

#### Summary of Changes
Use TAR builds in testnet automation.
