### PR TITLE
Run BPF tests in CI

### DIFF
--- a/ci/docker-rust/Dockerfile
+++ b/ci/docker-rust/Dockerfile
@@ -20,7 +20,6 @@ RUN set -x && \
       rsync \
       sudo \
       && \
-    rustup toolchain install nightly && \
     rustup component add rustfmt-preview && \
     rustup component add clippy-preview && \
     rm -rf /var/lib/apt/lists/* && \

--- a/ci/docker-rust/Dockerfile
+++ b/ci/docker-rust/Dockerfile
@@ -20,6 +20,7 @@ RUN set -x && \
       rsync \
       sudo \
       && \
+    rustup toolchain install nightly && \
     rustup component add rustfmt-preview && \
     rustup component add clippy-preview && \
     rm -rf /var/lib/apt/lists/* && \

--- a/ci/test-nightly.sh
+++ b/ci/test-nightly.sh
@@ -32,7 +32,7 @@ maybe_cargo_install() {
   set -x
   cd "programs/native/bpf_loader"
   echo --- program/native/bpf_loader bench --features=bpf_c
-  cargo +nightly bench --verbose --features="bpf_c" -- --nocapture
+  cargo bench --verbose --features="bpf_c" -- --nocapture
 )
 
 maybe_cargo_install cov

--- a/ci/test-nightly.sh
+++ b/ci/test-nightly.sh
@@ -27,6 +27,14 @@ maybe_cargo_install() {
   done
 }
 
+# Run program/native/bpf_loader's bench with bpf_c feature
+(
+  set -x
+  cd "programs/native/bpf_loader"
+  echo --- program/native/bpf_loader bench --features=bpf_c
+  cargo +nightly bench --verbose --features="bpf_c" -- --nocapture
+)
+
 maybe_cargo_install cov
 
 # Generate coverage data and report via unit-test suite.

--- a/ci/test-stable.sh
+++ b/ci/test-stable.sh
@@ -33,7 +33,7 @@ _ cargo clippy -- --deny=warnings
 for test in tests/*.rs; do
   test=${test##*/} # basename x
   test=${test%.rs} # basename x .rs
-  _ cargo test --verbose --jobs=1 --test="$test"
+  _ cargo test --verbose --jobs=1 --test="$test" --features="bpf_c"
 done
 
 # Run native program's tests
@@ -45,6 +45,16 @@ for program in programs/native/*; do
     cargo test --verbose
   )
 done
+
+# Run program/native/bpf_loader's test and bench with bpf_c feature
+(
+  set -x
+  cd "programs/native/bpf_loader"
+  echo --- program/native/bpf_loader test --features=bpf_c
+  cargo test --verbose --features="bpf_c"
+  echo --- program/native/bpf_loader bench --features=bpf_c
+  cargo +nightly bench --verbose --features="bpf_c" -- --nocapture
+)
 
 # Build the HTML
 export PATH=$CARGO_HOME/bin:$PATH

--- a/ci/test-stable.sh
+++ b/ci/test-stable.sh
@@ -46,14 +46,12 @@ for program in programs/native/*; do
   )
 done
 
-# Run program/native/bpf_loader's test and bench with bpf_c feature
+# Run program/native/bpf_loader's test with bpf_c feature
 (
   set -x
   cd "programs/native/bpf_loader"
   echo --- program/native/bpf_loader test --features=bpf_c
   cargo test --verbose --features="bpf_c"
-  echo --- program/native/bpf_loader bench --features=bpf_c
-  cargo +nightly bench --verbose --features="bpf_c" -- --nocapture
 )
 
 # Build the HTML


### PR DESCRIPTION
#### Problem

Tests that actually run BPF programs are featurized with `bpf_c` are not run by CI

#### Summary of Changes

Modified CI to run all lib tests with `bpf_c` feature turned on as well as run the bpf_loader tests and bench with `bpf_c` feature turned on.  This also required the installation of the rust nightly toolchain in the docker-rust image.

Fixes #
