### PR TITLE
Fix RPC address clashes on local multi-node testnet

### DIFF
--- a/src/bin/fullnode.rs
+++ b/src/bin/fullnode.rs
@@ -9,7 +9,7 @@ extern crate solana;
 
 use clap::{App, Arg};
 use solana::client::mk_client;
-use solana::cluster_info::Node;
+use solana::cluster_info::{Node, FULLNODE_PORT_RANGE};
 use solana::drone::DRONE_PORT;
 use solana::fullnode::{Config, Fullnode, FullnodeReturnType};
 use solana::leader_scheduler::LeaderScheduler;
@@ -110,7 +110,7 @@ fn main() {
         }
         Some(port_number)
     } else {
-        match find_available_port_in_range((8899, 8999)) {
+        match find_available_port_in_range(FULLNODE_PORT_RANGE) {
             Ok(port) => Some(port),
             Err(_) => None,
         }


### PR DESCRIPTION
#### Problem
Fullnodes created in a local testnet figure out what RPC address to use from the json config file which has a static address for RPC. This results in a panic when running two or more nodes in a local testnet since the client's RPC requests can be served by the wrong node.

#### Summary of Changes
Make fullnodes search for available rpc ports instead of using the one from the json config. Clients already find nodes via gossip anyway. 

Fixes #
