### PR TITLE
Supply --rpc explicitly

### DIFF
--- a/ci/docker-solana/entrypoint.sh
+++ b/ci/docker-solana/entrypoint.sh
@@ -12,7 +12,7 @@ solana-genesis --num_tokens 1000000000 --mint /config/drone-keypair.json --boots
 
 solana-drone --keypair /config/drone-keypair.json --network 127.0.0.1:8001 &
 drone=$!
-solana-fullnode --identity /config/leader-config.json --ledger /ledger/ &
+solana-fullnode --identity /config/leader-config.json --ledger /ledger/ --rpc 8899 &
 fullnode=$!
 
 abort() {

--- a/multinode-demo/leader.sh
+++ b/multinode-demo/leader.sh
@@ -35,6 +35,7 @@ trap 'kill "$pid" && wait "$pid"' INT TERM
 $program \
   --identity "$SOLANA_CONFIG_DIR"/leader.json \
   --ledger "$SOLANA_CONFIG_DIR"/ledger \
+  --rpc 8899 \
   > >($leader_logger) 2>&1 &
 pid=$!
 oom_score_adj "$pid" 1000


### PR DESCRIPTION
As of c81a3f6ced1125030bf895bf213e7978b4abeb4e the RPC port is randomly assigned by default, which is helpful for tests but unhelpful for real users.