### PR TITLE
accept other socket errors, ignore unless out of tries

### DIFF
--- a/src/netutil.rs
+++ b/src/netutil.rs
@@ -126,7 +126,7 @@ pub fn bind_in_range(range: (u16, u16)) -> io::Result<(u16, UdpSocket)> {
                 break Result::Ok((sock.local_addr().unwrap().port(), sock));
             }
             Err(err) => {
-                if err.kind() != io::ErrorKind::AddrInUse || tries_left == 0 {
+                if tries_left == 0 {
                     return Err(err);
                 }
             }
@@ -170,6 +170,8 @@ pub fn find_available_port_in_range(range: (u16, u16)) -> io::Result<u16> {
     let mut tries_left = end - start;
     let mut rand_port = thread_rng().gen_range(start, end);
     loop {
+        eprintln!("trying port {}", rand_port);
+
         match TcpListener::bind(SocketAddr::new(
             IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)),
             rand_port,
@@ -178,7 +180,7 @@ pub fn find_available_port_in_range(range: (u16, u16)) -> io::Result<u16> {
                 break Ok(rand_port);
             }
             Err(err) => {
-                if err.kind() != io::ErrorKind::AddrInUse || tries_left == 0 {
+                if tries_left == 0 {
                     return Err(err);
                 }
             }


### PR DESCRIPTION
#### Problem
 bind_in_range() and find_available_port_in_range() may miss a port
 for any number of reasons, but only pay attention to AddrInUse, resulting
 in unnecessary aborts/panics when we still have ports in the range we
 can try

 #### Summary of Changes
 allow for other errors to occur, e.g. PermissionDenied (as seen on WSL)

Fixes #