### PR TITLE
Remove airdrop from fullnode

### DIFF
--- a/multinode-demo/validator.sh
+++ b/multinode-demo/validator.sh
@@ -60,6 +60,7 @@ if ((!self_setup)); then
     echo "  ${here}/setup.sh"
     exit 1
   }
+  validator_id_path=$SOLANA_CONFIG_PRIVATE_DIR/validator-id.json
   validator_json_path=$SOLANA_CONFIG_VALIDATOR_DIR/validator.json
   SOLANA_LEADER_CONFIG_DIR=$SOLANA_CONFIG_VALIDATOR_DIR/leader-config
 else
@@ -77,6 +78,22 @@ else
 
   SOLANA_LEADER_CONFIG_DIR=$SOLANA_CONFIG_VALIDATOR_DIR/leader-config-x$$
 fi
+
+[[ -r $validator_id_path ]] || {
+  echo "$validator_id_path does not exist"
+  exit 1
+}
+
+# A fullnode requires 2 tokens to function:
+# - one token to create an instance of the vote_program with
+# - one second token to keep the node identity public key valid.
+(
+  set -x
+  $solana_wallet \
+    --keypair "$validator_id_path" \
+    --network "$leader_address" \
+    airdrop 2
+)
 
 rsync_leader_url=$(rsync_url "$leader")
 

--- a/src/bin/genesis.rs
+++ b/src/bin/genesis.rs
@@ -16,6 +16,13 @@ use std::error;
 use std::fs::File;
 use std::path::Path;
 
+/**
+ * Bootstrap leader gets two tokens:
+ * - one token to create an instance of the vote_program with
+ * - one second token to keep the node identity public key valid
+ */
+pub const BOOTSTRAP_LEADER_TOKENS: u64 = 2;
+
 fn main() -> Result<(), Box<error::Error>> {
     let matches = App::new("solana-genesis")
         .version(crate_version!())
@@ -62,7 +69,12 @@ fn main() -> Result<(), Box<error::Error>> {
     let num_tokens = value_t_or_exit!(matches, "num_tokens", u64);
     let file = File::open(Path::new(&matches.value_of("mint").unwrap())).unwrap();
     let pkcs8: Vec<u8> = serde_json::from_reader(&file)?;
-    let mint = Mint::new_with_pkcs8(num_tokens, pkcs8, leader_keypair.pubkey(), 1);
+    let mint = Mint::new_with_pkcs8(
+        num_tokens,
+        pkcs8,
+        leader_keypair.pubkey(),
+        BOOTSTRAP_LEADER_TOKENS,
+    );
 
     // Write the ledger entries
     let ledger_path = matches.value_of("ledger").unwrap();

--- a/src/fullnode.rs
+++ b/src/fullnode.rs
@@ -110,19 +110,28 @@ pub struct Fullnode {
 pub struct Config {
     pub node_info: NodeInfo,
     pkcs8: Vec<u8>,
+    vote_account_pkcs8: Vec<u8>,
 }
 
 impl Config {
-    pub fn new(bind_addr: &SocketAddr, pkcs8: Vec<u8>) -> Self {
+    pub fn new(bind_addr: &SocketAddr, pkcs8: Vec<u8>, vote_account_pkcs8: Vec<u8>) -> Self {
         let keypair =
             Keypair::from_pkcs8(Input::from(&pkcs8)).expect("from_pkcs8 in fullnode::Config new");
         let pubkey = keypair.pubkey();
         let node_info = NodeInfo::new_with_pubkey_socketaddr(pubkey, bind_addr);
-        Config { node_info, pkcs8 }
+        Config {
+            node_info,
+            pkcs8,
+            vote_account_pkcs8,
+        }
     }
     pub fn keypair(&self) -> Keypair {
         Keypair::from_pkcs8(Input::from(&self.pkcs8))
             .expect("from_pkcs8 in fullnode::Config keypair")
+    }
+    pub fn vote_account_keypair(&self) -> Keypair {
+        Keypair::from_pkcs8(Input::from(&self.vote_account_pkcs8))
+            .expect("from_pkcs8 in fullnode::Config vote_account_keypair")
     }
 }
 


### PR DESCRIPTION
Fullnodes on mainnet won't be able to airdrop themselves tokens at startup so let's stop pretending they can.  The bootstrap leader already has tokens via the genesis block, and all other nodes can use the wallet cli to airdrop themselves some tokens *before* starting up the fullnode program.

Fixes #1832
