### PR TITLE
Fix bench tps txs

### DIFF
--- a/src/bin/bench-tps.rs
+++ b/src/bin/bench-tps.rs
@@ -290,7 +290,7 @@ fn do_tx_transfers(
     }
 }
 
-const MAX_SPENDS_PER_TX: usize = 5;
+const MAX_SPENDS_PER_TX: usize = 4;
 fn verify_transfer(client: &mut ThinClient, tx: &Transaction) -> bool {
     if client.poll_for_signature(&tx.signatures[0]).is_err() {
         println!("no signature");

--- a/src/thin_client.rs
+++ b/src/thin_client.rs
@@ -10,6 +10,7 @@ use cluster_info::{ClusterInfo, ClusterInfoError, NodeInfo};
 use hash::Hash;
 use log::Level;
 use ncp::Ncp;
+use packet::PACKET_DATA_SIZE;
 use result::{Error, Result};
 use rpc_request::RpcRequest;
 use serde_json;
@@ -69,6 +70,7 @@ impl ThinClient {
     /// does not wait for a response.
     pub fn transfer_signed(&self, tx: &Transaction) -> io::Result<Signature> {
         let data = serialize(&tx).expect("serialize Transaction in pub fn transfer_signed");
+        assert!(data.len() < PACKET_DATA_SIZE);
         self.transactions_socket
             .send_to(&data, &self.transactions_addr)?;
         Ok(tx.signatures[0])


### PR DESCRIPTION
#### Problem

Transactions are too big with the multi-sig change to have 5 funding targets.

#### Summary of Changes

Lower the target number to 4 so transactions fit.

Fixes #1840 
