### PR TITLE
Ignore attempts to delete the ledger in some tests

### DIFF
--- a/src/cluster_info.rs
+++ b/src/cluster_info.rs
@@ -1207,7 +1207,7 @@ mod tests {
         );
         assert!(!rv.is_empty());
 
-        remove_dir_all(ledger_path).unwrap();
+        let _ignored = remove_dir_all(ledger_path);
     }
 
     /// test window requests respond with the right blob, and do not overrun

--- a/src/fullnode.rs
+++ b/src/fullnode.rs
@@ -1007,6 +1007,6 @@ mod tests {
         // Shut down
         t_responder.join().expect("responder thread join");
         validator.close().unwrap();
-        remove_dir_all(&validator_ledger_path).unwrap();
+        let _ignored = remove_dir_all(&validator_ledger_path);
     }
 }

--- a/src/ledger.rs
+++ b/src/ledger.rs
@@ -827,7 +827,7 @@ mod tests {
         assert!(LedgerWindow::open(&ledger_path).is_err());
         assert!(read_ledger(&ledger_path, false).is_err());
 
-        std::fs::remove_dir_all(ledger_path).unwrap();
+        let _ignored = std::fs::remove_dir_all(ledger_path);
     }
 
     fn truncated_last_entry(ledger_path: &str, entries: Vec<Entry>) {


### PR DESCRIPTION
#### Problem

Some tests fail because they were unable to delete the ledger dir (another test running in parallel?). I only seem to be able to repro this locally.

#### Summary of Changes
Can't really help it if the delete fails so instead of failing the test, just ignore the result.

Fixes #
