### PR TITLE
Set drone address to always be the initial network entry point

### DIFF
--- a/multinode-demo/client.sh
+++ b/multinode-demo/client.sh
@@ -20,7 +20,7 @@ usage() {
 }
 
 if [[ -z $1 ]]; then # default behavior
-  $solana_bench_tps --identity config-private/client-id.json --network 127.0.0.1:8001 --duration 90
+  $solana_bench_tps --identity config-private/client-id.json --network 127.0.0.1:8001 --drone 127.0.0.1:8001 --duration 90
 else
   $solana_bench_tps "$@"
 fi

--- a/multinode-demo/client.sh
+++ b/multinode-demo/client.sh
@@ -20,7 +20,7 @@ usage() {
 }
 
 if [[ -z $1 ]]; then # default behavior
-  $solana_bench_tps --identity config-private/client-id.json --network 127.0.0.1:8001 --drone 127.0.0.1:8001 --duration 90
+  $solana_bench_tps --identity config-private/client-id.json --network 127.0.0.1:8001 --drone 127.0.0.1:9900 --duration 90
 else
   $solana_bench_tps "$@"
 fi

--- a/net/remote/remote-client.sh
+++ b/net/remote/remote-client.sh
@@ -59,6 +59,7 @@ scripts/net-stats.sh  > net-stats.log 2>&1 &
 clientCommand="\
   $solana_bench_tps \
     --network $entrypointIp:8001 \
+    --drone $entrypointIp:9900 \
     --identity client.json \
     --duration 7500 \
     --sustained \

--- a/net/remote/remote-sanity.sh
+++ b/net/remote/remote-sanity.sh
@@ -107,6 +107,7 @@ echo "+++ $entrypointIp: node count ($numNodes expected)"
 
   $solana_bench_tps \
     --network "$entrypointIp:8001" \
+    --drone "$entrypointIp:9900" \
     --identity "$client_id" \
     --num-nodes "$numNodes" \
     $maybeRejectExtraNodes \

--- a/src/bin/bench-tps.rs
+++ b/src/bin/bench-tps.rs
@@ -508,6 +508,14 @@ fn main() {
                 .help("Rendezvous with the network at this gossip entry point; defaults to 127.0.0.1:8001"),
         )
         .arg(
+            Arg::with_name("drone")
+                .short("d")
+                .long("drone")
+                .value_name("HOST:PORT")
+                .takes_value(true)
+                .help("Location of the drone; defaults to network:DRONE_PORT"),
+        )
+        .arg(
             Arg::with_name("identity")
                 .short("i")
                 .long("identity")
@@ -572,7 +580,15 @@ fn main() {
         socketaddr!("127.0.0.1:8001")
     };
 
-    let mut drone_addr = network.clone();
+    let mut drone_addr = if let Some(addr) = matches.value_of("drone") {
+        addr.parse().unwrap_or_else(|e| {
+            eprintln!("failed to parse drone address: {}", e);
+            exit(1)
+        })
+    } else {
+        network.clone()
+    };
+
     drone_addr.set_port(DRONE_PORT);
 
     let id =

--- a/src/bin/bench-tps.rs
+++ b/src/bin/bench-tps.rs
@@ -586,10 +586,9 @@ fn main() {
             exit(1)
         })
     } else {
-        network.clone()
+        let mut addr = network.clone();
+        addr.set_port(DRONE_PORT);
     };
-
-    drone_addr.set_port(DRONE_PORT);
 
     let id =
         read_keypair(matches.value_of("identity").unwrap()).expect("can't read client identity");

--- a/src/bin/bench-tps.rs
+++ b/src/bin/bench-tps.rs
@@ -580,7 +580,7 @@ fn main() {
         socketaddr!("127.0.0.1:8001")
     };
 
-    let mut drone_addr = if let Some(addr) = matches.value_of("drone") {
+    let drone_addr = if let Some(addr) = matches.value_of("drone") {
         addr.parse().unwrap_or_else(|e| {
             eprintln!("failed to parse drone address: {}", e);
             exit(1)
@@ -588,6 +588,7 @@ fn main() {
     } else {
         let mut addr = network.clone();
         addr.set_port(DRONE_PORT);
+        addr
     };
 
     let id =


### PR DESCRIPTION
#### Problem
When leader rotation occurs, clients may try to contact the drone at the new leader which does not host the drone.

#### Summary of Changes
Set drone address to always be the initial network entry point, so that even when leaders rotate the client can still find the drone

Fixes #
