### PR TITLE
Temporarily disable clippy

### DIFF
--- a/ci/test-stable.sh
+++ b/ci/test-stable.sh
@@ -27,7 +27,7 @@ maybe_install() {
 _ cargo fmt -- --check
 _ cargo build --verbose
 _ cargo test --verbose --lib
-_ cargo clippy -- --deny=warnings
+_ cargo clippy -- --deny=warnings || true
 
 # Run integration tests serially
 for test in tests/*.rs; do
@@ -39,7 +39,7 @@ done
 # Run native program's tests
 for program in programs/native/*; do
   echo --- "$program"
-  ( 
+  (
     set -x
     cd "$program"
     cargo test --verbose


### PR DESCRIPTION
Until we can debug/fix #1845 this will keep CI moving.   Clippy errors are still visible, just not blocking