### PR TITLE
bank: Add an explicit state of a reserved signature

### DIFF
--- a/sdk/src/transaction.rs
+++ b/sdk/src/transaction.rs
@@ -282,7 +282,7 @@ mod tests {
         assert!(!tx.verify_refs());
     }
 
-    /// Detect binary changes in the serialized contract userdata, which could have a downstream
+    /// Detect binary changes in the serialized transaction userdata, which could have a downstream
     /// affect on SDKs and DApps
     #[test]
     fn test_sdk_serialize() {

--- a/src/bank.rs
+++ b/src/bank.rs
@@ -77,6 +77,9 @@ pub enum BankError {
     /// too old and has been discarded.
     SignatureNotFound,
 
+    /// A transaction with this signature has been received but not yet executed
+    SignatureReserved,
+
     /// Proof of History verification failed.
     LedgerVerificationFailed,
 
@@ -431,7 +434,7 @@ impl Bank {
         if let Some(_result) = signatures.get(signature) {
             return Err(BankError::DuplicateSignature);
         }
-        signatures.insert(*signature, Ok(()));
+        signatures.insert(*signature, Err(BankError::SignatureReserved));
         Ok(())
     }
 
@@ -1747,7 +1750,10 @@ mod tests {
         let signature = Signature::default();
         bank.reserve_signature_with_last_id_test(&signature, &mint.last_id())
             .expect("reserve signature");
-        assert_eq!(bank.get_signature_status(&signature), Ok(()));
+        assert_eq!(
+            bank.get_signature_status(&signature),
+            Err(BankError::SignatureReserved)
+        );
     }
 
     #[test]

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -192,6 +192,9 @@ impl RpcSol for RpcSolImpl {
                 Ok(_) => RpcSignatureStatus::Confirmed,
                 Err(BankError::AccountInUse) => RpcSignatureStatus::AccountInUse,
                 Err(BankError::ProgramRuntimeError(_)) => RpcSignatureStatus::ProgramRuntimeError,
+                // Report SignatureReserved as SignatureNotFound as SignatureReserved is
+                // transitory while the bank processes the associated transaction.
+                Err(BankError::SignatureReserved) => RpcSignatureStatus::SignatureNotFound,
                 Err(BankError::SignatureNotFound) => RpcSignatureStatus::SignatureNotFound,
                 Err(err) => {
                     trace!("mapping {:?} to GenericFailure", err);


### PR DESCRIPTION
An RPC client that fetches the signature status before the bank finishes
executing the corresponding Transaction should receive SignatureNotFound
instead of Confirmed

Background: This issue was reproducing 100% by running the solana-web3.js tests.  Tests such as https://github.com/solana-labs/solana-web3.js/blob/master/test/token-program.test.js#L861-L863 where not failing as expected prior to this patch (such tests would also pass if `sleep()` was applied between the time the transaction was sent and the RPC signature status was checked).