### PR TITLE
multinode-demo: Enable debug builds by default for better backtraces

### DIFF
--- a/multinode-demo/common.sh
+++ b/multinode-demo/common.sh
@@ -60,7 +60,7 @@ else
     if [[ "$program" = drone ]]; then
       maybe_package="--package solana-drone"
     fi
-    if [[ -z $DEBUG ]]; then
+    if [[ -n $NDEBUG ]]; then
       maybe_release=--release
     fi
     printf "cargo run $maybe_release $maybe_package --bin solana-%s %s -- " "$program" "$features"

--- a/net/net.sh
+++ b/net/net.sh
@@ -138,6 +138,7 @@ build() {
     fi
     $MAYBE_DOCKER bash -c "
       set -ex
+      export NDEBUG=1
       cargo install --path drone --features=$cargoFeatures --root farf
       cargo install --path . --features=$cargoFeatures --root farf
     "


### PR DESCRIPTION
It's what you want by default.  `export NDEBUG=1` for release (which is automatic when launching a testnet)