### PR TITLE
Fix Gossip Pushes going to invalid addresses

### DIFF
--- a/src/crds_gossip_push.rs
+++ b/src/crds_gossip_push.rs
@@ -10,6 +10,7 @@
 
 use bincode::serialized_size;
 use bloom::Bloom;
+use cluster_info::ClusterInfo;
 use crds::{Crds, VersionedCrdsValue};
 use crds_gossip_error::CrdsGossipError;
 use crds_value::{CrdsValue, CrdsValueLabel};
@@ -176,6 +177,11 @@ impl CrdsGossipPush {
             }
             if new_items.get(&val.0.pubkey()).is_some() {
                 continue;
+            }
+            if let Some(contact) = val.1.value.contact_info() {
+                if !ClusterInfo::is_valid_address(&contact.ncp) {
+                    continue;
+                }
             }
             let bloom = Bloom::random(network_size, 0.1, 1024 * 8 * 4);
             new_items.insert(val.0.pubkey(), bloom);

--- a/src/crds_gossip_push.rs
+++ b/src/crds_gossip_push.rs
@@ -10,7 +10,7 @@
 
 use bincode::serialized_size;
 use bloom::Bloom;
-use cluster_info::ClusterInfo;
+use contact_info::ContactInfo;
 use crds::{Crds, VersionedCrdsValue};
 use crds_gossip_error::CrdsGossipError;
 use crds_value::{CrdsValue, CrdsValueLabel};
@@ -179,7 +179,7 @@ impl CrdsGossipPush {
                 continue;
             }
             if let Some(contact) = val.1.value.contact_info() {
-                if !ClusterInfo::is_valid_address(&contact.ncp) {
+                if !ContactInfo::is_valid_address(&contact.ncp) {
                     continue;
                 }
             }

--- a/tests/multinode.rs
+++ b/tests/multinode.rs
@@ -8,6 +8,7 @@ extern crate solana_sdk;
 
 use solana::blob_fetch_stage::BlobFetchStage;
 use solana::cluster_info::{ClusterInfo, Node, NodeInfo};
+use solana::contact_info::ContactInfo;
 use solana::entry::{reconstruct_entries_from_blobs, Entry};
 use solana::fullnode::{Fullnode, FullnodeReturnType};
 use solana::hash::Hash;
@@ -1621,7 +1622,7 @@ fn test_broadcast_last_tick() {
 
 fn mk_client(leader: &NodeInfo) -> ThinClient {
     let transactions_socket = UdpSocket::bind("0.0.0.0:0").unwrap();
-    assert!(ClusterInfo::is_valid_address(&leader.tpu));
+    assert!(ContactInfo::is_valid_address(&leader.tpu));
     ThinClient::new(leader.rpc, leader.tpu, transactions_socket)
 }
 


### PR DESCRIPTION
#### Problem
While creating new push requests, gossip pulls peer ids out of the active set but the active set has spy nodes (invalid gossip nodes). This results in the network trying to communicate with the spy nodes and sending data to their invalid ncp addresses. 

#### Summary of Changes
Disallow entries with invalid ncp from ever being part of the active set.

Fixes #1838 
