### PR TITLE
Use known keys in the unit test to avoid random false positives.

### DIFF
--- a/src/bloom.rs
+++ b/src/bloom.rs
@@ -81,6 +81,8 @@ mod test {
     #[test]
     fn test_add_contains() {
         let mut bloom: Bloom<Hash> = Bloom::random(100, 0.1, 100);
+        //known keys to avoid false positives in the test
+        bloom.keys = vec![0, 1, 2, 3];
 
         let key = hash(b"hello");
         assert!(!bloom.contains(&key));


### PR DESCRIPTION
#### Problem

Random keys cause unit tests to randomly fail due to a false positive.

#### Summary of Changes

Use known keys in the unit test.

Fixes #
