### PR TITLE
ClusterInfo returns Result<Self> instead of Self, which is unwrap()ped or expect()ed everywhere, resulting in a bunch of extra code

### DIFF
--- a/src/bin/bench-tps.rs
+++ b/src/bin/bench-tps.rs
@@ -819,7 +819,7 @@ fn converge(
 ) -> (Vec<NodeInfo>, Option<NodeInfo>, Ncp) {
     //lets spy on the network
     let (node, gossip_socket) = ClusterInfo::spy_node();
-    let mut spy_cluster_info = ClusterInfo::new(node).expect("ClusterInfo::new");
+    let mut spy_cluster_info = ClusterInfo::new(node);
     spy_cluster_info.insert_info(leader.clone());
     spy_cluster_info.set_leader(leader.id);
     let spy_ref = Arc::new(RwLock::new(spy_cluster_info));

--- a/src/cluster_info.rs
+++ b/src/cluster_info.rs
@@ -78,7 +78,7 @@ enum Protocol {
 }
 
 impl ClusterInfo {
-    pub fn new(node_info: NodeInfo) -> Result<ClusterInfo> {
+    pub fn new(node_info: NodeInfo) -> Self {
         let mut me = ClusterInfo {
             gossip: CrdsGossip::default(),
         };
@@ -86,7 +86,7 @@ impl ClusterInfo {
         me.gossip.set_self(id);
         me.insert_info(node_info);
         me.push_self();
-        Ok(me)
+        me
     }
     pub fn push_self(&mut self) {
         let mut my_data = self.my_data();
@@ -1050,9 +1050,7 @@ mod tests {
         //check that gossip doesn't try to push to invalid addresses
         let node = Node::new_localhost();
         let (spy, _) = ClusterInfo::spy_node();
-        let cluster_info = Arc::new(RwLock::new(
-            ClusterInfo::new(node.info).expect("ClusterInfo::new"),
-        ));
+        let cluster_info = Arc::new(RwLock::new(ClusterInfo::new(node.info)));
         cluster_info.write().unwrap().insert_info(spy);
         cluster_info
             .write()
@@ -1071,14 +1069,14 @@ mod tests {
     #[test]
     fn test_cluster_info_new() {
         let d = NodeInfo::new_localhost(Keypair::new().pubkey(), timestamp());
-        let cluster_info = ClusterInfo::new(d.clone()).expect("ClusterInfo::new");
+        let cluster_info = ClusterInfo::new(d.clone());
         assert_eq!(d.id, cluster_info.my_data().id);
     }
 
     #[test]
     fn insert_info_test() {
         let d = NodeInfo::new_localhost(Keypair::new().pubkey(), timestamp());
-        let mut cluster_info = ClusterInfo::new(d).expect("ClusterInfo::new");
+        let mut cluster_info = ClusterInfo::new(d);
         let d = NodeInfo::new_localhost(Keypair::new().pubkey(), timestamp());
         let label = CrdsValueLabel::ContactInfo(d.id);
         cluster_info.insert_info(d);
@@ -1087,7 +1085,7 @@ mod tests {
     #[test]
     fn window_index_request() {
         let me = NodeInfo::new_localhost(Keypair::new().pubkey(), timestamp());
-        let mut cluster_info = ClusterInfo::new(me).expect("ClusterInfo::new");
+        let mut cluster_info = ClusterInfo::new(me);
         let rv = cluster_info.window_index_request(0);
         assert_matches!(rv, Err(Error::ClusterInfoError(ClusterInfoError::NoPeers)));
 
@@ -1275,7 +1273,7 @@ mod tests {
     fn test_default_leader() {
         logger::setup();
         let node_info = NodeInfo::new_localhost(Keypair::new().pubkey(), 0);
-        let mut cluster_info = ClusterInfo::new(node_info).unwrap();
+        let mut cluster_info = ClusterInfo::new(node_info);
         let network_entry_point = NodeInfo::new_entry_point(&socketaddr!("127.0.0.1:1239"));
         cluster_info.insert_info(network_entry_point);
         assert!(cluster_info.leader_data().is_none());

--- a/src/fullnode.rs
+++ b/src/fullnode.rs
@@ -226,9 +226,7 @@ impl Fullnode {
         let window = new_window(32 * 1024);
         let shared_window = Arc::new(RwLock::new(window));
         node.info.wallclock = timestamp();
-        let cluster_info = Arc::new(RwLock::new(
-            ClusterInfo::new(node.info).expect("ClusterInfo::new"),
-        ));
+        let cluster_info = Arc::new(RwLock::new(ClusterInfo::new(node.info)));
 
         let (rpc_service, rpc_pubsub_service) =
             Self::startup_rpc_services(rpc_addr, rpc_pubsub_addr, &bank, &cluster_info);

--- a/src/ncp.rs
+++ b/src/ncp.rs
@@ -77,7 +77,7 @@ mod tests {
     fn test_exit() {
         let exit = Arc::new(AtomicBool::new(false));
         let tn = Node::new_localhost();
-        let cluster_info = ClusterInfo::new(tn.info.clone()).expect("ClusterInfo::new");
+        let cluster_info = ClusterInfo::new(tn.info.clone());
         let c = Arc::new(RwLock::new(cluster_info));
         let w = Arc::new(RwLock::new(vec![]));
         let d = Ncp::new(&c, w, None, tn.sockets.gossip, exit.clone());

--- a/src/replicate_stage.rs
+++ b/src/replicate_stage.rs
@@ -269,7 +269,7 @@ mod test {
         let my_keypair = Keypair::new();
         let my_id = my_keypair.pubkey();
         let my_node = Node::new_localhost_with_pubkey(my_id);
-        let cluster_info_me = ClusterInfo::new(my_node.info.clone()).expect("ClusterInfo::new");
+        let cluster_info_me = ClusterInfo::new(my_node.info.clone());
 
         // Create keypair for the old leader
         let old_leader_id = Keypair::new().pubkey();
@@ -411,9 +411,7 @@ mod test {
             Fullnode::new_bank_from_ledger(&my_ledger_path, leader_scheduler);
 
         // Set up the cluster info
-        let cluster_info_me = Arc::new(RwLock::new(
-            ClusterInfo::new(my_node.info.clone()).expect("ClusterInfo::new"),
-        ));
+        let cluster_info_me = Arc::new(RwLock::new(ClusterInfo::new(my_node.info.clone())));
 
         // Set up the replicate stage
         let vote_account_keypair = Arc::new(Keypair::new());
@@ -525,9 +523,7 @@ mod test {
             Fullnode::new_bank_from_ledger(&my_ledger_path, leader_scheduler);
 
         // Set up the cluster info
-        let cluster_info_me = Arc::new(RwLock::new(
-            ClusterInfo::new(my_node.info.clone()).expect("ClusterInfo::new"),
-        ));
+        let cluster_info_me = Arc::new(RwLock::new(ClusterInfo::new(my_node.info.clone())));
 
         // Set up the replicate stage
         let vote_account_keypair = Arc::new(vote_account_keypair);
@@ -607,9 +603,7 @@ mod test {
         let vote_keypair = Keypair::new();
         let my_node = Node::new_localhost_with_pubkey(my_id);
         // Set up the cluster info
-        let cluster_info_me = Arc::new(RwLock::new(
-            ClusterInfo::new(my_node.info.clone()).expect("ClusterInfo::new"),
-        ));
+        let cluster_info_me = Arc::new(RwLock::new(ClusterInfo::new(my_node.info.clone())));
         let (entry_sender, entry_receiver) = channel();
         let (ledger_entry_sender, _ledger_entry_receiver) = channel();
         let mut last_entry_id = Hash::default();

--- a/src/replicator.rs
+++ b/src/replicator.rs
@@ -83,9 +83,7 @@ impl Replicator {
         let window = window::new_window(REPLICATOR_WINDOW_SIZE);
         let shared_window = Arc::new(RwLock::new(window));
 
-        let cluster_info = Arc::new(RwLock::new(
-            ClusterInfo::new(node.info).expect("ClusterInfo::new"),
-        ));
+        let cluster_info = Arc::new(RwLock::new(ClusterInfo::new(node.info)));
 
         let leader_info = network_addr.map(|i| NodeInfo::new_entry_point(&i));
         let leader_pubkey;

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -388,7 +388,7 @@ mod tests {
         bank.process_transaction(&tx).expect("process transaction");
 
         let request_processor = JsonRpcRequestProcessor::new(Arc::new(bank));
-        let cluster_info = Arc::new(RwLock::new(ClusterInfo::new(NodeInfo::default()).unwrap()));
+        let cluster_info = Arc::new(RwLock::new(ClusterInfo::new(NodeInfo::default())));
         let leader = NodeInfo::new_with_socketaddr(&socketaddr!("127.0.0.1:1234"));
         cluster_info.write().unwrap().insert_info(leader.clone());
         cluster_info.write().unwrap().set_leader(leader.id);
@@ -412,7 +412,7 @@ mod tests {
     fn test_rpc_new() {
         let alice = Mint::new(10_000);
         let bank = Bank::new(&alice);
-        let cluster_info = Arc::new(RwLock::new(ClusterInfo::new(NodeInfo::default()).unwrap()));
+        let cluster_info = Arc::new(RwLock::new(ClusterInfo::new(NodeInfo::default())));
         let rpc_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 24680);
         let rpc_service = JsonRpcService::new(&Arc::new(bank), &cluster_info, rpc_addr);
         let thread = rpc_service.thread_hdl.thread();
@@ -706,7 +706,7 @@ mod tests {
         io.extend_with(rpc.to_delegate());
         let meta = Meta {
             request_processor: JsonRpcRequestProcessor::new(Arc::new(bank)),
-            cluster_info: Arc::new(RwLock::new(ClusterInfo::new(NodeInfo::default()).unwrap())),
+            cluster_info: Arc::new(RwLock::new(ClusterInfo::new(NodeInfo::default()))),
             rpc_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 0),
             exit: Arc::new(AtomicBool::new(false)),
         };
@@ -725,7 +725,7 @@ mod tests {
 
     #[test]
     fn test_rpc_get_leader_addr() {
-        let cluster_info = Arc::new(RwLock::new(ClusterInfo::new(NodeInfo::default()).unwrap()));
+        let cluster_info = Arc::new(RwLock::new(ClusterInfo::new(NodeInfo::default())));
         assert_eq!(
             get_leader_addr(&cluster_info),
             Err(Error {

--- a/src/thin_client.rs
+++ b/src/thin_client.rs
@@ -323,9 +323,7 @@ pub fn poll_gossip_for_leader(leader_ncp: SocketAddr, timeout: Option<u64>) -> R
     let exit = Arc::new(AtomicBool::new(false));
     let (node, gossip_socket) = ClusterInfo::spy_node();
     let my_addr = gossip_socket.local_addr().unwrap();
-    let cluster_info = Arc::new(RwLock::new(
-        ClusterInfo::new(node).expect("ClusterInfo::new"),
-    ));
+    let cluster_info = Arc::new(RwLock::new(ClusterInfo::new(node)));
     let window = Arc::new(RwLock::new(vec![]));
     let ncp = Ncp::new(
         &cluster_info.clone(),

--- a/src/tvu.rs
+++ b/src/tvu.rs
@@ -208,14 +208,14 @@ pub mod tests {
         let exit = Arc::new(AtomicBool::new(false));
 
         //start cluster_info_l
-        let mut cluster_info_l = ClusterInfo::new(leader.info.clone()).expect("ClusterInfo::new");
+        let mut cluster_info_l = ClusterInfo::new(leader.info.clone());
         cluster_info_l.set_leader(leader.info.id);
 
         let cref_l = Arc::new(RwLock::new(cluster_info_l));
         let dr_l = new_ncp(cref_l, leader.sockets.gossip, exit.clone());
 
         //start cluster_info2
-        let mut cluster_info2 = ClusterInfo::new(target2.info.clone()).expect("ClusterInfo::new");
+        let mut cluster_info2 = ClusterInfo::new(target2.info.clone());
         cluster_info2.insert_info(leader.info.clone());
         cluster_info2.set_leader(leader.info.id);
         let leader_id = leader.info.id;
@@ -254,7 +254,7 @@ pub mod tests {
         let bank = Arc::new(bank);
 
         //start cluster_info1
-        let mut cluster_info1 = ClusterInfo::new(target1.info.clone()).expect("ClusterInfo::new");
+        let mut cluster_info1 = ClusterInfo::new(target1.info.clone());
         cluster_info1.insert_info(leader.info.clone());
         cluster_info1.set_leader(leader.info.id);
         let cref1 = Arc::new(RwLock::new(cluster_info1));

--- a/src/window_service.rs
+++ b/src/window_service.rs
@@ -387,7 +387,7 @@ mod test {
         logger::setup();
         let tn = Node::new_localhost();
         let exit = Arc::new(AtomicBool::new(false));
-        let mut cluster_info_me = ClusterInfo::new(tn.info.clone()).expect("ClusterInfo::new");
+        let mut cluster_info_me = ClusterInfo::new(tn.info.clone());
         let me_id = cluster_info_me.my_data().id;
         cluster_info_me.set_leader(me_id);
         let subs = Arc::new(RwLock::new(cluster_info_me));
@@ -451,7 +451,7 @@ mod test {
         logger::setup();
         let tn = Node::new_localhost();
         let exit = Arc::new(AtomicBool::new(false));
-        let cluster_info_me = ClusterInfo::new(tn.info.clone()).expect("ClusterInfo::new");
+        let cluster_info_me = ClusterInfo::new(tn.info.clone());
         let me_id = cluster_info_me.my_data().id;
         let subs = Arc::new(RwLock::new(cluster_info_me));
 
@@ -515,7 +515,7 @@ mod test {
         logger::setup();
         let tn = Node::new_localhost();
         let exit = Arc::new(AtomicBool::new(false));
-        let cluster_info_me = ClusterInfo::new(tn.info.clone()).expect("ClusterInfo::new");
+        let cluster_info_me = ClusterInfo::new(tn.info.clone());
         let me_id = cluster_info_me.my_data().id;
         let subs = Arc::new(RwLock::new(cluster_info_me));
 

--- a/tests/data_replicator.rs
+++ b/tests/data_replicator.rs
@@ -20,7 +20,7 @@ use std::time::Duration;
 
 fn test_node(exit: Arc<AtomicBool>) -> (Arc<RwLock<ClusterInfo>>, Ncp, UdpSocket) {
     let mut tn = Node::new_localhost();
-    let cluster_info = ClusterInfo::new(tn.info.clone()).expect("ClusterInfo::new");
+    let cluster_info = ClusterInfo::new(tn.info.clone());
     let c = Arc::new(RwLock::new(cluster_info));
     let w = Arc::new(RwLock::new(vec![]));
     let d = Ncp::new(&c.clone(), w, None, tn.sockets.gossip, exit);

--- a/tests/multinode.rs
+++ b/tests/multinode.rs
@@ -47,7 +47,7 @@ fn make_spy_node(leader: &NodeInfo) -> (Ncp, Arc<RwLock<ClusterInfo>>, Pubkey) {
     let me = spy.info.id.clone();
     let daddr = "0.0.0.0:0".parse().unwrap();
     spy.info.tvu = daddr;
-    let mut spy_cluster_info = ClusterInfo::new(spy.info).expect("ClusterInfo::new");
+    let mut spy_cluster_info = ClusterInfo::new(spy.info);
     spy_cluster_info.insert_info(leader.clone());
     spy_cluster_info.set_leader(leader.id);
     let spy_cluster_info_ref = Arc::new(RwLock::new(spy_cluster_info));
@@ -68,7 +68,7 @@ fn make_listening_node(leader: &NodeInfo) -> (Ncp, Arc<RwLock<ClusterInfo>>, Nod
     let new_node = Node::new_localhost();
     let new_node_info = new_node.info.clone();
     let me = new_node.info.id.clone();
-    let mut new_node_cluster_info = ClusterInfo::new(new_node_info).expect("ClusterInfo::new");
+    let mut new_node_cluster_info = ClusterInfo::new(new_node_info);
     new_node_cluster_info.insert_info(leader.clone());
     new_node_cluster_info.set_leader(leader.id);
     let new_node_cluster_info_ref = Arc::new(RwLock::new(new_node_cluster_info));


### PR DESCRIPTION
#### Summary of Changes
 remove Result<> return from ClusterInfo::new()

Fixes #