### PR TITLE
Optimize some CI stuff

### DIFF
--- a/ci/buildkite.yml
+++ b/ci/buildkite.yml
@@ -1,4 +1,11 @@
 steps:
+  - command: "ci/test-stable-perf.sh"
+    name: "stable-perf [public]"
+    env:
+      CARGO_TARGET_CACHE_NAME: "stable-perf"
+    timeout_in_minutes: 20
+    agents:
+      - "queue=cuda"
   - command: "ci/docker-run.sh solanalabs/rust:1.30.1 ci/test-stable.sh"
     name: "stable [public]"
     env:
@@ -17,13 +24,6 @@ steps:
     env:
       CARGO_TARGET_CACHE_NAME: "nightly"
     timeout_in_minutes: 30
-  - command: "ci/test-stable-perf.sh"
-    name: "stable-perf [public]"
-    env:
-      CARGO_TARGET_CACHE_NAME: "stable-perf"
-    timeout_in_minutes: 20
-    agents:
-      - "queue=cuda"
   # TODO: Fix and re-enable test-large-network.sh
   # - command: "ci/test-large-network.sh || true"
   #   name: "large-network [public] [ignored]"

--- a/ci/buildkite.yml
+++ b/ci/buildkite.yml
@@ -4,7 +4,7 @@ steps:
     env:
       CARGO_TARGET_CACHE_NAME: "stable"
     timeout_in_minutes: 30
-  - command: "ci/docker-run.sh solanalabs/rust-nightly:2018-11-12 ci/test-bench.sh"
+  - command: "ci/test-bench.sh"
     name: "bench [public]"
     env:
       CARGO_TARGET_CACHE_NAME: "nightly"

--- a/ci/buildkite.yml
+++ b/ci/buildkite.yml
@@ -6,15 +6,20 @@ steps:
     timeout_in_minutes: 20
     agents:
       - "queue=cuda"
+  - command: "ci/test-bench.sh"
+    name: "bench [public]"
+    env:
+      CARGO_TARGET_CACHE_NAME: "nightly"
+    timeout_in_minutes: 30
   - command: "ci/docker-run.sh solanalabs/rust:1.30.1 ci/test-stable.sh"
     name: "stable [public]"
     env:
       CARGO_TARGET_CACHE_NAME: "stable"
     timeout_in_minutes: 30
-  - command: "ci/test-bench.sh"
-    name: "bench [public]"
+  - command: "ci/docker-run.sh solanalabs/rust:1.30.1 ci/test-checks.sh"
+    name: "checks [public]"
     env:
-      CARGO_TARGET_CACHE_NAME: "nightly"
+      CARGO_TARGET_CACHE_NAME: "checks"
     timeout_in_minutes: 30
   - command: "ci/shellcheck.sh"
     name: "shellcheck [public]"

--- a/ci/test-bench.sh
+++ b/ci/test-bench.sh
@@ -8,7 +8,6 @@ source ci/upload_ci_artifact.sh
 
 eval "$(ci/channel-info.sh)"
 
-curl https://sh.rustup.rs -sSf | sh
 rustup install nightly
 rustup default nightly
 rustc --version

--- a/ci/test-bench.sh
+++ b/ci/test-bench.sh
@@ -8,6 +8,12 @@ source ci/upload_ci_artifact.sh
 
 eval "$(ci/channel-info.sh)"
 
+curl https://sh.rustup.rs -sSf | sh
+rustup install nightly
+rustup default nightly
+rustc --version
+cargo --version
+
 ci/version-check.sh nightly
 export RUST_BACKTRACE=1
 

--- a/ci/test-bench.sh
+++ b/ci/test-bench.sh
@@ -8,13 +8,6 @@ source ci/upload_ci_artifact.sh
 
 eval "$(ci/channel-info.sh)"
 
-_() {
-  echo "--- $*"
-  "$@"
-}
-
-set -o pipefail
-
 ci/version-check.sh nightly
 if ! ci/version-check.sh nightly; then
   # This job doesn't run within a container, try once to upgrade tooling on a
@@ -23,6 +16,13 @@ if ! ci/version-check.sh nightly; then
   rustup default nightly
   ci/version-check.sh nightly
 fi
+
+_() {
+  echo "--- $*"
+  "$@"
+}
+
+set -o pipefail
 export RUST_BACKTRACE=1
 
 UPLOAD_METRICS=""

--- a/ci/test-bench.sh
+++ b/ci/test-bench.sh
@@ -15,12 +15,14 @@ _() {
 
 set -o pipefail
 
-_ rustup install nightly
-_ rustup default nightly
-_ rustc --version
-_ cargo --version
-
 ci/version-check.sh nightly
+if ! ci/version-check.sh nightly; then
+  # This job doesn't run within a container, try once to upgrade tooling on a
+  # version check failure
+  rustup install nightly
+  rustup default nightly
+  ci/version-check.sh nightly
+fi
 export RUST_BACKTRACE=1
 
 UPLOAD_METRICS=""

--- a/ci/test-bench.sh
+++ b/ci/test-bench.sh
@@ -8,18 +8,20 @@ source ci/upload_ci_artifact.sh
 
 eval "$(ci/channel-info.sh)"
 
-rustup install nightly
-rustup default nightly
-rustc --version
-cargo --version
-
-ci/version-check.sh nightly
-export RUST_BACKTRACE=1
-
 _() {
   echo "--- $*"
   "$@"
 }
+
+
+_ rustup install nightly
+_ rustup default nightly
+_ rustc --version
+_ cargo --version
+
+ci/version-check.sh nightly
+export RUST_BACKTRACE=1
+
 
 set -o pipefail
 
@@ -33,14 +35,14 @@ fi
 
 BENCH_FILE=bench_output.log
 BENCH_ARTIFACT=current_bench_results.log
-_ cargo bench --features=unstable --verbose -- -Z unstable-options --format=json | tee "$BENCH_FILE"
+_ cargo bench --features=unstable -- -Z unstable-options --format=json | tee "$BENCH_FILE"
 
 # Run bpf_loader bench with bpf_c feature enabled
 (
   set -x
   cd "programs/native/bpf_loader"
   echo --- program/native/bpf_loader bench --features=bpf_c
-  cargo bench --verbose --features="bpf_c" -- -Z unstable-options --format=json --nocapture | tee -a ../../../"$BENCH_FILE"
+  cargo bench --features="bpf_c" -- -Z unstable-options --format=json --nocapture | tee -a ../../../"$BENCH_FILE"
 )
 
 _ cargo run --release --bin solana-upload-perf -- "$BENCH_FILE" "$TARGET_BRANCH" "$UPLOAD_METRICS" > "$BENCH_ARTIFACT"

--- a/ci/test-bench.sh
+++ b/ci/test-bench.sh
@@ -29,6 +29,15 @@ fi
 BENCH_FILE=bench_output.log
 BENCH_ARTIFACT=current_bench_results.log
 _ cargo bench --features=unstable --verbose -- -Z unstable-options --format=json | tee "$BENCH_FILE"
-_ cargo run --release --bin solana-upload-perf -- "$BENCH_FILE" "$TARGET_BRANCH" "$UPLOAD_METRICS" >"$BENCH_ARTIFACT"
+
+# Run bpf_loader bench with bpf_c feature enabled
+(
+  set -x
+  cd "programs/native/bpf_loader"
+  echo --- program/native/bpf_loader bench --features=bpf_c
+  cargo bench --verbose --features="bpf_c" -- -Z unstable-options --format=json --nocapture | tee -a ../../../"$BENCH_FILE"
+)
+
+_ cargo run --release --bin solana-upload-perf -- "$BENCH_FILE" "$TARGET_BRANCH" "$UPLOAD_METRICS" > "$BENCH_ARTIFACT"
 
 upload_ci_artifact "$BENCH_ARTIFACT"

--- a/ci/test-bench.sh
+++ b/ci/test-bench.sh
@@ -13,6 +13,7 @@ _() {
   "$@"
 }
 
+set -o pipefail
 
 _ rustup install nightly
 _ rustup default nightly
@@ -21,9 +22,6 @@ _ cargo --version
 
 ci/version-check.sh nightly
 export RUST_BACKTRACE=1
-
-
-set -o pipefail
 
 UPLOAD_METRICS=""
 TARGET_BRANCH=$BUILDKITE_BRANCH
@@ -35,14 +33,14 @@ fi
 
 BENCH_FILE=bench_output.log
 BENCH_ARTIFACT=current_bench_results.log
-_ cargo bench --features=unstable -- -Z unstable-options --format=json | tee "$BENCH_FILE"
+_ cargo bench --features=unstable --verbose -- -Z unstable-options --format=json | tee "$BENCH_FILE"
 
 # Run bpf_loader bench with bpf_c feature enabled
 (
   set -x
   cd "programs/native/bpf_loader"
   echo --- program/native/bpf_loader bench --features=bpf_c
-  cargo bench --features="bpf_c" -- -Z unstable-options --format=json --nocapture | tee -a ../../../"$BENCH_FILE"
+  cargo bench --verbose --features="bpf_c" -- -Z unstable-options --format=json --nocapture | tee -a ../../../"$BENCH_FILE"
 )
 
 _ cargo run --release --bin solana-upload-perf -- "$BENCH_FILE" "$TARGET_BRANCH" "$UPLOAD_METRICS" > "$BENCH_ARTIFACT"

--- a/ci/test-checks.sh
+++ b/ci/test-checks.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -e
+
+cd "$(dirname "$0")/.."
+
+ci/version-check.sh stable
+export RUST_BACKTRACE=1
+export RUSTFLAGS="-D warnings"
+
+_() {
+  echo "--- $*"
+  "$@"
+}
+
+_ cargo fmt -- --check
+_ cargo clippy -- --version
+_ cargo clippy -- --deny=warnings
+
+_ ci/audit.sh

--- a/ci/test-nightly.sh
+++ b/ci/test-nightly.sh
@@ -27,14 +27,6 @@ maybe_cargo_install() {
   done
 }
 
-# Run program/native/bpf_loader's bench with bpf_c feature
-(
-  set -x
-  cd "programs/native/bpf_loader"
-  echo --- program/native/bpf_loader bench --features=bpf_c
-  cargo bench --verbose --features="bpf_c" -- --nocapture
-)
-
 maybe_cargo_install cov
 
 # Generate coverage data and report via unit-test suite.

--- a/ci/test-stable-perf.sh
+++ b/ci/test-stable-perf.sh
@@ -24,7 +24,7 @@ _() {
   "$@"
 }
 
-FEATURES=cuda,erasure,chacha
+FEATURES=bpf_c,cuda,erasure,chacha
 _ cargo build --all --verbose --features="$FEATURES"
 _ cargo test --verbose --features="$FEATURES" --lib
 
@@ -32,8 +32,16 @@ _ cargo test --verbose --features="$FEATURES" --lib
 for test in tests/*.rs; do
   test=${test##*/} # basename x
   test=${test%.rs} # basename x .rs
-  _ cargo test --verbose --jobs=1 --features="$FEATURES" --test="$test"
+  _ cargo test --verbose --features="$FEATURES" --test="$test" -- --test-threads=1
 done
+
+# Run bpf_loader test with bpf_c features enabled
+(
+  set -x
+  cd "programs/native/bpf_loader"
+  echo --- program/native/bpf_loader test --features=bpf_c
+  cargo test --verbose --features="bpf_c"
+)
 
 echo --- ci/localnet-sanity.sh
 (

--- a/ci/test-stable-perf.sh
+++ b/ci/test-stable-perf.sh
@@ -10,6 +10,7 @@ if ! ci/version-check.sh stable; then
   # This job doesn't run within a container, try once to upgrade tooling on a
   # version check failure
   rustup install stable
+  rustup default stable
   ci/version-check.sh stable
 fi
 export RUST_BACKTRACE=1

--- a/ci/test-stable-perf.sh
+++ b/ci/test-stable-perf.sh
@@ -13,17 +13,18 @@ if ! ci/version-check.sh stable; then
   rustup default stable
   ci/version-check.sh stable
 fi
+
 export RUST_BACKTRACE=1
 export RUSTFLAGS="-D warnings"
-
-./fetch-perf-libs.sh
-# shellcheck source=/dev/null
-source ./target/perf-libs/env.sh
 
 _() {
   echo "--- $*"
   "$@"
 }
+
+./fetch-perf-libs.sh
+# shellcheck source=/dev/null
+source ./target/perf-libs/env.sh
 
 FEATURES=bpf_c,cuda,erasure,chacha
 _ cargo build --all --verbose --features="$FEATURES"

--- a/ci/test-stable.sh
+++ b/ci/test-stable.sh
@@ -27,14 +27,14 @@ maybe_install() {
 _ cargo fmt -- --check
 _ cargo clippy -- --version
 _ cargo clippy -- --deny=warnings
-_ cargo build --all --verbose
-_ cargo test --verbose --lib
+_ cargo build --all
+_ cargo test --lib
 
 # Run integration tests serially
 for test in tests/*.rs; do
   test=${test##*/} # basename x
   test=${test%.rs} # basename x .rs
-  _ cargo test --verbose --test="$test" -- --test-threads=1
+  _ cargo test --test="$test" -- --test-threads=1
 done
 
 # Run native program tests
@@ -43,7 +43,7 @@ for program in programs/native/*; do
   (
     set -x
     cd "$program"
-    cargo test --verbose
+    cargo test
   )
 done
 

--- a/ci/test-stable.sh
+++ b/ci/test-stable.sh
@@ -25,8 +25,8 @@ maybe_install() {
 }
 
 _ rustup install beta
-_ rustc beta --version
-_ cargo beta --version
+_ rustc +beta --version
+_ cargo +beta --version
 
 _ cargo fmt -- --check
 _ cargo clippy -- --version

--- a/ci/test-stable.sh
+++ b/ci/test-stable.sh
@@ -25,23 +25,22 @@ maybe_install() {
 }
 
 _ rustup install beta
-_ rustup default beta
 _ rustup component add rustfmt-preview --toolchain beta
 _ rustup component add clippy-preview --toolchain beta
-_ rustc --version
-_ cargo --version
+_ rustc +beta --version
+_ cargo +beta --version
 
 _ cargo fmt -- --check
 _ cargo clippy -- --version
 _ cargo clippy -- --deny=warnings
-_ cargo build --all --verbose
-_ cargo test --verbose --lib
+_ cargo +beta build --all --verbose
+_ cargo +beta test --verbose --lib
 
 # Run integration tests serially
 for test in tests/*.rs; do
   test=${test##*/} # basename x
   test=${test%.rs} # basename x .rs
-  _ cargo test --verbose --test="$test" -- --test-threads=1
+  _ cargo +beta test --verbose --test="$test" -- --test-threads=1
 done
 
 # Run native program tests
@@ -50,7 +49,7 @@ for program in programs/native/*; do
   (
     set -x
     cd "$program"
-    cargo test --verbose
+    cargo +beta test --verbose
   )
 done
 

--- a/ci/test-stable.sh
+++ b/ci/test-stable.sh
@@ -34,10 +34,10 @@ _ cargo test --verbose --lib
 for test in tests/*.rs; do
   test=${test##*/} # basename x
   test=${test%.rs} # basename x .rs
-  _ cargo test --verbose --jobs=1 --test="$test" --features="bpf_c"
+  _ cargo test --verbose --test="$test" -- --test-threads=1
 done
 
-# Run native program's tests
+# Run native program tests
 for program in programs/native/*; do
   echo --- "$program"
   (
@@ -46,14 +46,6 @@ for program in programs/native/*; do
     cargo test --verbose
   )
 done
-
-# Run program/native/bpf_loader's test with bpf_c feature
-(
-  set -x
-  cd "programs/native/bpf_loader"
-  echo --- program/native/bpf_loader test --features=bpf_c
-  cargo test --verbose --features="bpf_c"
-)
 
 # Build the HTML
 export PATH=$CARGO_HOME/bin:$PATH

--- a/ci/test-stable.sh
+++ b/ci/test-stable.sh
@@ -24,9 +24,6 @@ maybe_install() {
   done
 }
 
-_ cargo fmt -- --check
-_ cargo clippy -- --version
-_ cargo clippy -- --deny=warnings
 _ cargo build --all --verbose
 _ cargo test --verbose --lib
 
@@ -60,5 +57,3 @@ echo --- ci/localnet-sanity.sh
   export PATH=$PWD/target/debug:$PATH
   USE_INSTALL=1 ci/localnet-sanity.sh
 )
-
-_ ci/audit.sh

--- a/ci/test-stable.sh
+++ b/ci/test-stable.sh
@@ -27,14 +27,14 @@ maybe_install() {
 _ cargo fmt -- --check
 _ cargo clippy -- --version
 _ cargo clippy -- --deny=warnings
-_ cargo build --all
-_ cargo test --lib
+_ cargo build --all --verbose
+_ cargo test --verbose --lib
 
 # Run integration tests serially
 for test in tests/*.rs; do
   test=${test##*/} # basename x
   test=${test%.rs} # basename x .rs
-  _ cargo test --test="$test" -- --test-threads=1
+  _ cargo test --verbose --test="$test" -- --test-threads=1
 done
 
 # Run native program tests
@@ -43,7 +43,7 @@ for program in programs/native/*; do
   (
     set -x
     cd "$program"
-    cargo test
+    cargo test --verbose
   )
 done
 

--- a/ci/test-stable.sh
+++ b/ci/test-stable.sh
@@ -24,21 +24,17 @@ maybe_install() {
   done
 }
 
-_ rustup install beta
-_ rustc +beta --version
-_ cargo +beta --version
-
 _ cargo fmt -- --check
 _ cargo clippy -- --version
 _ cargo clippy -- --deny=warnings
-_ cargo +beta build --all --verbose
-_ cargo +beta test --verbose --lib
+_ cargo build --all --verbose
+_ cargo test --verbose --lib
 
 # Run integration tests serially
 for test in tests/*.rs; do
   test=${test##*/} # basename x
   test=${test%.rs} # basename x .rs
-  _ cargo +beta test --verbose --test="$test" -- --test-threads=1
+  _ cargo test --verbose --test="$test" -- --test-threads=1
 done
 
 # Run native program tests
@@ -47,7 +43,7 @@ for program in programs/native/*; do
   (
     set -x
     cd "$program"
-    cargo +beta test --verbose
+    cargo test --verbose
   )
 done
 

--- a/ci/test-stable.sh
+++ b/ci/test-stable.sh
@@ -24,17 +24,21 @@ maybe_install() {
   done
 }
 
+_ rustup install beta
+_ rustc beta --version
+_ cargo beta --version
+
 _ cargo fmt -- --check
 _ cargo clippy -- --version
 _ cargo clippy -- --deny=warnings
-_ cargo build --all --verbose
-_ cargo test --verbose --lib
+_ cargo +beta build --all --verbose
+_ cargo +beta test --verbose --lib
 
 # Run integration tests serially
 for test in tests/*.rs; do
   test=${test##*/} # basename x
   test=${test%.rs} # basename x .rs
-  _ cargo test --verbose --test="$test" -- --test-threads=1
+  _ cargo +beta test --verbose --test="$test" -- --test-threads=1
 done
 
 # Run native program tests
@@ -43,7 +47,7 @@ for program in programs/native/*; do
   (
     set -x
     cd "$program"
-    cargo test --verbose
+    cargo +beta test --verbose
   )
 done
 

--- a/ci/test-stable.sh
+++ b/ci/test-stable.sh
@@ -24,6 +24,13 @@ maybe_install() {
   done
 }
 
+_ rustup install beta
+_ rustup default beta
+_ rustup component add rustfmt-previewm --toolchain beta
+_ rustup component add clippy-preview --toolchain beta
+_ rustc --version
+_ cargo --version
+
 _ cargo fmt -- --check
 _ cargo clippy -- --version
 _ cargo clippy -- --deny=warnings

--- a/ci/test-stable.sh
+++ b/ci/test-stable.sh
@@ -26,7 +26,7 @@ maybe_install() {
 
 _ rustup install beta
 _ rustup default beta
-_ rustup component add rustfmt-previewm --toolchain beta
+_ rustup component add rustfmt-preview --toolchain beta
 _ rustup component add clippy-preview --toolchain beta
 _ rustc --version
 _ cargo --version

--- a/ci/test-stable.sh
+++ b/ci/test-stable.sh
@@ -24,23 +24,17 @@ maybe_install() {
   done
 }
 
-_ rustup install beta
-_ rustup component add rustfmt-preview --toolchain beta
-_ rustup component add clippy-preview --toolchain beta
-_ rustc +beta --version
-_ cargo +beta --version
-
 _ cargo fmt -- --check
 _ cargo clippy -- --version
 _ cargo clippy -- --deny=warnings
-_ cargo +beta build --all --verbose
-_ cargo +beta test --verbose --lib
+_ cargo build --all --verbose
+_ cargo test --verbose --lib
 
 # Run integration tests serially
 for test in tests/*.rs; do
   test=${test##*/} # basename x
   test=${test%.rs} # basename x .rs
-  _ cargo +beta test --verbose --test="$test" -- --test-threads=1
+  _ cargo test --verbose --test="$test" -- --test-threads=1
 done
 
 # Run native program tests
@@ -49,7 +43,7 @@ for program in programs/native/*; do
   (
     set -x
     cd "$program"
-    cargo +beta test --verbose
+    cargo test --verbose
   )
 done
 

--- a/programs/native/bpf_loader/benches/bpf_loader.rs
+++ b/programs/native/bpf_loader/benches/bpf_loader.rs
@@ -94,6 +94,7 @@ fn bench_program_alu(bencher: &mut Bencher) {
     assert!(0f64 != summary.median);
     let mips = (instructions * (ns_per_s / summary.median as u64)) / one_million;
     println!("  {:?} MIPS", mips);
+    println!("{{ \"type\": \"bench\", \"name\": \"bench_program_alu_interpreted_mips\", \"median\": {:?}, \"deviation\": 0 }}", mips);
 
     println!("JIT to native:");
     vm.jit_compile().unwrap();
@@ -112,4 +113,6 @@ fn bench_program_alu(bencher: &mut Bencher) {
     assert!(0f64 != summary.median);
     let mips = (instructions * (ns_per_s / summary.median as u64)) / one_million;
     println!("  {:?} MIPS", mips);
+      println!("{{ \"type\": \"bench\", \"name\": \"bench_program_alu_jit_to_native_mips\", \"median\": {:?}, \"deviation\": 0 }}", mips);
+
 }

--- a/programs/native/bpf_loader/benches/bpf_loader.rs
+++ b/programs/native/bpf_loader/benches/bpf_loader.rs
@@ -113,6 +113,5 @@ fn bench_program_alu(bencher: &mut Bencher) {
     assert!(0f64 != summary.median);
     let mips = (instructions * (ns_per_s / summary.median as u64)) / one_million;
     println!("  {:?} MIPS", mips);
-      println!("{{ \"type\": \"bench\", \"name\": \"bench_program_alu_jit_to_native_mips\", \"median\": {:?}, \"deviation\": 0 }}", mips);
-
+    println!("{{ \"type\": \"bench\", \"name\": \"bench_program_alu_jit_to_native_mips\", \"median\": {:?}, \"deviation\": 0 }}", mips);
 }

--- a/src/bin/upload-perf.rs
+++ b/src/bin/upload-perf.rs
@@ -100,8 +100,12 @@ fn main() {
         println!("bench_name, median, last_median, deviation, last_deviation");
         for (entry, values) in results {
             println!(
-                "{}, {}, {}, {}, {}",
-                entry, values.0, values.2, values.1, values.3
+                "{:#10?}, {:#10?}, {:#10?}, {:#10?}, {}",
+                values.0,
+                values.2.parse::<i32>().unwrap(),
+                values.1,
+                values.3.parse::<i32>().unwrap(),
+                entry,
             );
         }
     } else {
@@ -109,7 +113,7 @@ fn main() {
         println!("hash: {}", trimmed_hash);
         println!("bench_name, median, deviation");
         for (entry, values) in results {
-            println!("{}, {}, {}", entry, values.0, values.1);
+            println!("{:10?}, {:10?}, {}", values.0, values.1, entry);
         }
     }
     solana_metrics::flush();


### PR DESCRIPTION
#### Problem

- Rebuilds
- Not running integrations tests sequentially
- Slow overall
- Tasks uses cuda when they don't need it

#### Summary of Changes

- Re-ordered and re-grouped builds so that like builds built together (features together, etc...)
- Fixed how we run integration tests sequentially.  `-jobs` was being used but that only affects how many threads are used to build the tests.  We want many threads building but only one thread running a test at a time.  Changed from `-jobs` to `--test-threads`.  This means we build fast but run each test sequentially in a single thread.
- Not using beta 1.31 yet, it does cut down on the rebuilds but it also takes a lot longer to compile.  Reported an issue to cargo: https://github.com/rust-lang/cargo/issues/6337
- Buildkite runs multiple tasks in parallel so the total time to run is the time it takes to run the longest task.  Bench was taking ~30 mins in Docker.  Not running in docker brought it down to ~15 mins which are about the same as the next longest task so overall CI times are down from ~30 mins to ~15 mins.  Also, the single `cargo bench` command is taking pretty much the entire ~15 mins.  Could split that out into multiple Buildkite tasks and do them in parallel.
- Schedule stable-perf first so cuda not grabbed and hogged by another build task that does not need it.  Should result in more predictable CI times.
- Break out clippy into its own task to run in parallel since it takes 10 mins alone.

More details in the comments below...

Fixes #