### PR TITLE
Reorg the markdown book to cater to app devs

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -4,10 +4,8 @@
 
 - [Terminology](terminology.md)
 
-- [Synchronization](synchronization.md)
-  - [Introduction to VDFs](vdf.md)
-  - [Proof of History](poh.md)
-  - [Leader Rotation](leader-scheduler.md)
+- [On-chain programs](programs.md)
+  - [The Runtime](runtime.md)
 
 - [Fullnode](fullnode.md)
   - [Tpu](tpu.md)
@@ -15,12 +13,13 @@
   - [Ncp](ncp.md)
   - [JsonRpcService](jsonrpc-service.md)
 
-- [Avalanche replication](avalanche.md)
-  - [Storage](storage.md)
-
-- [On-chain programs](programs.md)
-  - [The Runtime](runtime.md)
-  - [Ledger format](ledger.md)
+- [A Solana Cluster](cluster.md)
+  - [Synchronization](synchronization.md)
+    - [Introduction to VDFs](vdf.md)
+    - [Proof of History](poh.md)
+  - [Ledger Broadcasting](avalanche.md)
+  - [Ledger Replication](storage.md)
+  - [Leader Rotation](leader-scheduler.md)
 
 ## Appendix
 

--- a/src/avalanche.md
+++ b/src/avalanche.md
@@ -1,4 +1,4 @@
-# Avalanche replication
+# Ledger Broadcasting
 
 The [Avalance explainer video](https://www.youtube.com/watch?v=qt_gDRXHrHQ) is
 a conceptual overview of how a Solana leader can continuously process a gigabit

--- a/src/cluster.md
+++ b/src/cluster.md
@@ -1,0 +1,10 @@
+# A Solana Cluster
+
+A Solana cluster is a set of fullnodes working together to serve client
+transactions and maintain the integrity of the ledger. Many clusters may
+coexist.  When two clusters share a common genesis block, they attempt to
+converge. Otherwise, they simply ignore the existence of the other.
+Transactions sent to the wrong one are quietly rejected. In this chapter,
+we'll discuss how a cluster is created, how nodes join the cluster, how
+they share the ledger, how they ensure the ledger is replicated, and how
+the cope with buggy and malicious nodes.

--- a/src/ledger.md
+++ b/src/ledger.md
@@ -1,1 +1,0 @@
-# Ledger format

--- a/src/storage.md
+++ b/src/storage.md
@@ -1,4 +1,4 @@
-# Storage
+# Ledger Replication
 
 ## Background
 


### PR DESCRIPTION
#### Problem

The markdown book is awkwardly ordered. It goes into detail about synchronization first because that was Solana's key innovation. But a high-level introduction is sufficient for that. The details should be discussed way later, closer to where the algorithms that depend on them are.

#### Summary of Changes

New structure:

First, talk about how a client interacts with Solana to do useful things. Then describe how the fullnode works and why it's so very fast.  Last, why fullnodes generally do what clients ask them to, and what happens when they don't.

