### PR TITLE
Cleanup builtin program naming and bank

### DIFF
--- a/src/bank.rs
+++ b/src/bank.rs
@@ -803,37 +803,17 @@ impl Bank {
         // Call the contract method
         // It's up to the contract to implement its own rules on moving funds
         if system_program::check_id(&program_id) {
-            if let Err(err) =
-                system_program::process_instruction(&tx, instruction_index, program_accounts)
-            {
-                let err = match err {
-                    system_program::Error::ResultWithNegativeTokens => {
-                        ProgramError::ResultWithNegativeTokens
-                    }
-                    _ => ProgramError::RuntimeError,
-                };
-                return Err(BankError::ProgramError(instruction_index as u8, err));
-            }
+            system_program::process(&tx, instruction_index, program_accounts)
+                .map_err(|err| BankError::ProgramError(instruction_index as u8, err))?;
         } else if budget_program::check_id(&program_id) {
-            if budget_program::process_instruction(&tx, instruction_index, program_accounts)
-                .is_err()
-            {
-                let err = ProgramError::RuntimeError;
-                return Err(BankError::ProgramError(instruction_index as u8, err));
-            }
+            budget_program::process(&tx, instruction_index, program_accounts)
+                .map_err(|err| BankError::ProgramError(instruction_index as u8, err))?;
         } else if storage_program::check_id(&program_id) {
-            if storage_program::process_instruction(&tx, instruction_index, program_accounts)
-                .is_err()
-            {
-                let err = ProgramError::RuntimeError;
-                return Err(BankError::ProgramError(instruction_index as u8, err));
-            }
+            storage_program::process(&tx, instruction_index, program_accounts)
+                .map_err(|err| BankError::ProgramError(instruction_index as u8, err))?;
         } else if vote_program::check_id(&program_id) {
-            if vote_program::process_instruction(&tx, instruction_index, program_accounts).is_err()
-            {
-                let err = ProgramError::RuntimeError;
-                return Err(BankError::ProgramError(instruction_index as u8, err));
-            }
+            vote_program::process(&tx, instruction_index, program_accounts)
+                .map_err(|err| BankError::ProgramError(instruction_index as u8, err))?;
         } else {
             let mut accounts = self.load_executable_accounts(tx.program_ids[instruction_index])?;
             let mut keyed_accounts = create_keyed_accounts(&mut accounts);

--- a/src/bank.rs
+++ b/src/bank.rs
@@ -819,7 +819,7 @@ impl Bank {
         // It's up to the contract to implement its own rules on moving funds
         if system_program::check_id(&program_id) {
             if let Err(err) =
-                system_program::process_transaction(&tx, instruction_index, program_accounts)
+                system_program::process_instruction(&tx, instruction_index, program_accounts)
             {
                 let err = match err {
                     system_program::Error::ResultWithNegativeTokens(i) => {
@@ -830,19 +830,19 @@ impl Bank {
                 return Err(err);
             }
         } else if budget_program::check_id(&program_id) {
-            if budget_program::process_transaction(&tx, instruction_index, program_accounts)
+            if budget_program::process_instruction(&tx, instruction_index, program_accounts)
                 .is_err()
             {
                 return Err(BankError::ProgramRuntimeError(instruction_index as u8));
             }
         } else if storage_program::check_id(&program_id) {
-            if storage_program::process_transaction(&tx, instruction_index, program_accounts)
+            if storage_program::process_instruction(&tx, instruction_index, program_accounts)
                 .is_err()
             {
                 return Err(BankError::ProgramRuntimeError(instruction_index as u8));
             }
         } else if vote_program::check_id(&program_id) {
-            if vote_program::process_transaction(&tx, instruction_index, program_accounts).is_err()
+            if vote_program::process_instruction(&tx, instruction_index, program_accounts).is_err()
             {
                 return Err(BankError::ProgramRuntimeError(instruction_index as u8));
             }

--- a/src/bank.rs
+++ b/src/bank.rs
@@ -822,8 +822,8 @@ impl Bank {
                 system_program::process_instruction(&tx, instruction_index, program_accounts)
             {
                 let err = match err {
-                    system_program::Error::ResultWithNegativeTokens(i) => {
-                        BankError::ResultWithNegativeTokens(i)
+                    system_program::Error::ResultWithNegativeTokens => {
+                        BankError::ResultWithNegativeTokens(instruction_index as u8)
                     }
                     _ => BankError::ProgramRuntimeError(instruction_index as u8),
                 };

--- a/src/budget_program.rs
+++ b/src/budget_program.rs
@@ -4,6 +4,7 @@ use budget_expr::BudgetExpr;
 use budget_instruction::Instruction;
 use chrono::prelude::{DateTime, Utc};
 use payment_plan::Witness;
+use program::ProgramError;
 use solana_sdk::account::Account;
 use solana_sdk::pubkey::Pubkey;
 use std::io;
@@ -131,6 +132,14 @@ pub fn process_instruction(
         );
         Err(BudgetError::UserdataDeserializeFailure)
     }
+}
+
+pub fn process(
+    tx: &Transaction,
+    instruction_index: usize,
+    accounts: &mut [&mut Account],
+) -> std::result::Result<(), ProgramError> {
+    process_instruction(&tx, instruction_index, accounts).map_err(|_| ProgramError::RuntimeError)
 }
 
 //TODO the contract needs to provide a "get_balance" introspection call of the userdata

--- a/src/budget_program.rs
+++ b/src/budget_program.rs
@@ -116,13 +116,13 @@ fn apply_debits(
 /// * accounts[0] - The source of the tokens
 /// * accounts[1] - The contract context.  Once the contract has been completed, the tokens can
 /// be spent from this account .
-pub fn process_transaction(
+pub fn process_instruction(
     tx: &Transaction,
     instruction_index: usize,
     accounts: &mut [&mut Account],
 ) -> Result<(), BudgetError> {
     if let Ok(instruction) = deserialize(tx.userdata(instruction_index)) {
-        trace!("process_transaction: {:?}", instruction);
+        trace!("process_instruction: {:?}", instruction);
         apply_debits(tx, instruction_index, accounts, &instruction)
     } else {
         info!(
@@ -264,7 +264,7 @@ mod test {
 
     fn process_transaction(tx: &Transaction, accounts: &mut [Account]) -> Result<(), BudgetError> {
         let mut refs: Vec<&mut Account> = accounts.iter_mut().collect();
-        super::process_transaction(&tx, 0, &mut refs[..])
+        super::process_instruction(&tx, 0, &mut refs[..])
     }
     #[test]
     fn test_serializer() {

--- a/src/budget_transaction.rs
+++ b/src/budget_transaction.rs
@@ -3,7 +3,7 @@
 use bincode::deserialize;
 use budget_expr::{BudgetExpr, Condition};
 use budget_instruction::Instruction;
-use budget_program::BudgetProgram;
+use budget_program;
 use chrono::prelude::*;
 use payment_plan::Payment;
 use signature::{Keypair, KeypairUtil};
@@ -85,7 +85,7 @@ impl BudgetTransaction for Transaction {
         };
         let budget_instruction = Instruction::NewBudget(BudgetExpr::Pay(payment));
 
-        let program_ids = vec![Pubkey::new(&SYSTEM_PROGRAM_ID), BudgetProgram::id()];
+        let program_ids = vec![Pubkey::new(&SYSTEM_PROGRAM_ID), budget_program::id()];
 
         let instructions = vec![
             transaction::Instruction::new(0, &system_instruction, vec![0, 1]),
@@ -119,7 +119,7 @@ impl BudgetTransaction for Transaction {
         Self::new(
             from_keypair,
             &[contract, to],
-            BudgetProgram::id(),
+            budget_program::id(),
             &instruction,
             last_id,
             0,
@@ -137,7 +137,7 @@ impl BudgetTransaction for Transaction {
         Self::new(
             from_keypair,
             &[contract, to],
-            BudgetProgram::id(),
+            budget_program::id(),
             &instruction,
             last_id,
             0,
@@ -167,7 +167,7 @@ impl BudgetTransaction for Transaction {
         Self::new(
             from_keypair,
             &[contract],
-            BudgetProgram::id(),
+            budget_program::id(),
             &instruction,
             last_id,
             0,
@@ -195,7 +195,7 @@ impl BudgetTransaction for Transaction {
         Self::new(
             from_keypair,
             &[contract],
-            BudgetProgram::id(),
+            budget_program::id(),
             &instruction,
             last_id,
             0,

--- a/src/compute_leader_finality_service.rs
+++ b/src/compute_leader_finality_service.rs
@@ -13,7 +13,7 @@ use std::sync::Arc;
 use std::thread::sleep;
 use std::thread::{self, Builder, JoinHandle};
 use std::time::Duration;
-use vote_program::VoteProgram;
+use vote_program::{self, VoteProgram};
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum FinalityError {
@@ -46,7 +46,7 @@ impl ComputeLeaderFinalityService {
                 .filter_map(|account| {
                     // Filter out any accounts that don't belong to the VoteProgram
                     // by returning None
-                    if VoteProgram::check_id(&account.owner) {
+                    if vote_program::check_id(&account.owner) {
                         if let Ok(vote_state) = VoteProgram::deserialize(&account.userdata) {
                             let validator_stake = bank.get_stake(&vote_state.node_id);
                             total_stake += validator_stake;

--- a/src/leader_scheduler.rs
+++ b/src/leader_scheduler.rs
@@ -14,7 +14,7 @@ use std::collections::HashSet;
 use std::io::Cursor;
 use system_transaction::SystemTransaction;
 use transaction::Transaction;
-use vote_program::{Vote, VoteProgram};
+use vote_program::{self, Vote, VoteProgram};
 use vote_transaction::VoteTransaction;
 
 pub const DEFAULT_BOOTSTRAP_HEIGHT: u64 = 1000;
@@ -309,7 +309,7 @@ impl LeaderScheduler {
                 .accounts
                 .values()
                 .filter_map(|account| {
-                    if VoteProgram::check_id(&account.owner) {
+                    if vote_program::check_id(&account.owner) {
                         if let Ok(vote_state) = VoteProgram::deserialize(&account.userdata) {
                             return vote_state
                                 .votes

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,6 +56,7 @@ pub mod payment_plan;
 pub mod poh;
 pub mod poh_recorder;
 pub mod poh_service;
+pub mod program;
 pub mod recvmmsg;
 pub mod replicate_stage;
 pub mod replicator;

--- a/src/mint.rs
+++ b/src/mint.rs
@@ -109,14 +109,14 @@ mod tests {
     use bincode::deserialize;
     use ledger::Block;
     use solana_sdk::system_instruction::SystemInstruction;
-    use system_program::SystemProgram;
+    use system_program;
 
     #[test]
     fn test_create_transactions() {
         let mut transactions = Mint::new(100).create_transaction().into_iter();
         let tx = transactions.next().unwrap();
         assert_eq!(tx.instructions.len(), 1);
-        assert!(SystemProgram::check_id(tx.program_id(0)));
+        assert!(system_program::check_id(tx.program_id(0)));
         let instruction: SystemInstruction = deserialize(tx.userdata(0)).unwrap();
         if let SystemInstruction::Move { tokens } = instruction {
             assert_eq!(tokens, 100);
@@ -133,8 +133,8 @@ mod tests {
             .into_iter();
         let tx = transactions.next().unwrap();
         assert_eq!(tx.instructions.len(), 2);
-        assert!(SystemProgram::check_id(tx.program_id(0)));
-        assert!(SystemProgram::check_id(tx.program_id(1)));
+        assert!(system_program::check_id(tx.program_id(0)));
+        assert!(system_program::check_id(tx.program_id(1)));
         let instruction: SystemInstruction = deserialize(tx.userdata(0)).unwrap();
         if let SystemInstruction::Move { tokens } = instruction {
             assert_eq!(tokens, 100);

--- a/src/program.rs
+++ b/src/program.rs
@@ -1,0 +1,11 @@
+/// Reasons a program might have rejected an instruction.
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum ProgramError {
+    /// Contract's transactions resulted in an account with a negative balance
+    /// The difference from InsufficientFundsForFee is that the transaction was executed by the
+    /// contract
+    ResultWithNegativeTokens,
+
+    /// The program returned an error
+    RuntimeError,
+}

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -191,7 +191,7 @@ impl RpcSol for RpcSolImpl {
             match meta.request_processor.get_signature_status(signature) {
                 Ok(_) => RpcSignatureStatus::Confirmed,
                 Err(BankError::AccountInUse) => RpcSignatureStatus::AccountInUse,
-                Err(BankError::ProgramRuntimeError(_)) => RpcSignatureStatus::ProgramRuntimeError,
+                Err(BankError::ProgramError(_, _)) => RpcSignatureStatus::ProgramRuntimeError,
                 // Report SignatureReserved as SignatureNotFound as SignatureReserved is
                 // transitory while the bank processes the associated transaction.
                 Err(BankError::SignatureReserved) => RpcSignatureStatus::SignatureNotFound,

--- a/src/rpc_pubsub.rs
+++ b/src/rpc_pubsub.rs
@@ -246,7 +246,7 @@ impl RpcSolPubSub for RpcSolPubSubImpl {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use budget_program::BudgetProgram;
+    use budget_program;
     use budget_transaction::BudgetTransaction;
     use jsonrpc_core::futures::sync::mpsc;
     use mint::Mint;
@@ -400,7 +400,7 @@ mod tests {
         let witness = Keypair::new();
         let contract_funds = Keypair::new();
         let contract_state = Keypair::new();
-        let budget_program_id = BudgetProgram::id();
+        let budget_program_id = budget_program::id();
         let loader = Pubkey::default(); // TODO
         let executable = false; // TODO
         let bank = Bank::new(&alice);

--- a/src/sigverify.rs
+++ b/src/sigverify.rs
@@ -323,13 +323,13 @@ pub fn make_packet_from_transaction(tx: Transaction) -> Packet {
 #[cfg(test)]
 mod tests {
     use bincode::serialize;
-    use budget_program::BudgetProgram;
+    use budget_program;
     use packet::{Packet, SharedPackets};
     use signature::{Keypair, KeypairUtil};
     use sigverify;
     use solana_sdk::hash::Hash;
     use solana_sdk::system_instruction::SystemInstruction;
-    use system_program::SystemProgram;
+    use system_program;
     use system_transaction::{memfind, test_tx};
     use transaction;
     use transaction::Transaction;
@@ -429,7 +429,7 @@ mod tests {
 
         let system_instruction = SystemInstruction::Move { tokens };
 
-        let program_ids = vec![SystemProgram::id(), BudgetProgram::id()];
+        let program_ids = vec![system_program::id(), budget_program::id()];
 
         let instructions = vec![transaction::Instruction::new(
             0,

--- a/src/storage_program.rs
+++ b/src/storage_program.rs
@@ -22,34 +22,32 @@ const STORAGE_PROGRAM_ID: [u8; 32] = [
     0,
 ];
 
-impl StorageProgram {
-    pub fn check_id(program_id: &Pubkey) -> bool {
-        program_id.as_ref() == STORAGE_PROGRAM_ID
-    }
+pub fn check_id(program_id: &Pubkey) -> bool {
+    program_id.as_ref() == STORAGE_PROGRAM_ID
+}
 
-    pub fn id() -> Pubkey {
-        Pubkey::new(&STORAGE_PROGRAM_ID)
-    }
+pub fn id() -> Pubkey {
+    Pubkey::new(&STORAGE_PROGRAM_ID)
+}
 
-    pub fn get_balance(account: &Account) -> u64 {
-        account.tokens
-    }
+pub fn get_balance(account: &Account) -> u64 {
+    account.tokens
+}
 
-    pub fn process_transaction(
-        tx: &Transaction,
-        pix: usize,
-        _accounts: &mut [&mut Account],
-    ) -> Result<(), StorageError> {
-        if let Ok(syscall) = deserialize(tx.userdata(pix)) {
-            match syscall {
-                StorageProgram::SubmitMiningProof { sha_state } => {
-                    info!("Mining proof submitted with state {:?}", sha_state);
-                    return Ok(());
-                }
+pub fn process_transaction(
+    tx: &Transaction,
+    pix: usize,
+    _accounts: &mut [&mut Account],
+) -> Result<(), StorageError> {
+    if let Ok(syscall) = deserialize(tx.userdata(pix)) {
+        match syscall {
+            StorageProgram::SubmitMiningProof { sha_state } => {
+                info!("Mining proof submitted with state {:?}", sha_state);
+                return Ok(());
             }
-        } else {
-            return Err(StorageError::InvalidUserData);
         }
+    } else {
+        return Err(StorageError::InvalidUserData);
     }
 }
 
@@ -62,14 +60,7 @@ mod test {
     #[test]
     fn test_storage_tx() {
         let keypair = Keypair::new();
-        let tx = Transaction::new(
-            &keypair,
-            &[],
-            StorageProgram::id(),
-            &(),
-            Default::default(),
-            0,
-        );
-        assert!(StorageProgram::process_transaction(&tx, 0, &mut []).is_err());
+        let tx = Transaction::new(&keypair, &[], id(), &(), Default::default(), 0);
+        assert!(process_transaction(&tx, 0, &mut []).is_err());
     }
 }

--- a/src/storage_program.rs
+++ b/src/storage_program.rs
@@ -3,6 +3,7 @@
 //!  and give reward for good proofs.
 
 use bincode::deserialize;
+use program::ProgramError;
 use solana_sdk::account::Account;
 use solana_sdk::hash::Hash;
 use solana_sdk::pubkey::Pubkey;
@@ -49,6 +50,14 @@ pub fn process_instruction(
     } else {
         return Err(StorageError::InvalidUserData);
     }
+}
+
+pub fn process(
+    tx: &Transaction,
+    instruction_index: usize,
+    accounts: &mut [&mut Account],
+) -> std::result::Result<(), ProgramError> {
+    process_instruction(&tx, instruction_index, accounts).map_err(|_| ProgramError::RuntimeError)
 }
 
 #[cfg(test)]

--- a/src/storage_program.rs
+++ b/src/storage_program.rs
@@ -34,7 +34,7 @@ pub fn get_balance(account: &Account) -> u64 {
     account.tokens
 }
 
-pub fn process_transaction(
+pub fn process_instruction(
     tx: &Transaction,
     pix: usize,
     _accounts: &mut [&mut Account],
@@ -61,6 +61,6 @@ mod test {
     fn test_storage_tx() {
         let keypair = Keypair::new();
         let tx = Transaction::new(&keypair, &[], id(), &(), Default::default(), 0);
-        assert!(process_transaction(&tx, 0, &mut []).is_err());
+        assert!(process_instruction(&tx, 0, &mut []).is_err());
     }
 }

--- a/src/storage_stage.rs
+++ b/src/storage_stage.rs
@@ -18,7 +18,7 @@ use std::sync::mpsc::RecvTimeoutError;
 use std::sync::{Arc, RwLock};
 use std::thread::{self, Builder, JoinHandle};
 use std::time::Duration;
-use vote_program::VoteProgram;
+use vote_program;
 
 // Block of hash answers to validate against
 // Vec of [ledger blocks] x [keys]
@@ -215,7 +215,7 @@ impl StorageStage {
             // the storage_keys with their signatures.
             for tx in entry.transactions {
                 for program_id in tx.program_ids {
-                    if VoteProgram::check_id(&program_id) {
+                    if vote_program::check_id(&program_id) {
                         debug!(
                             "generating storage_keys from votes current_key_idx: {}",
                             *current_key_idx

--- a/src/storage_transaction.rs
+++ b/src/storage_transaction.rs
@@ -1,6 +1,6 @@
 use signature::{Keypair, KeypairUtil};
 use solana_sdk::hash::Hash;
-use storage_program::StorageProgram;
+use storage_program::{self, StorageProgram};
 use transaction::Transaction;
 
 pub trait StorageTransaction {
@@ -13,7 +13,7 @@ impl StorageTransaction for Transaction {
         Transaction::new(
             from_keypair,
             &[from_keypair.pubkey()],
-            StorageProgram::id(),
+            storage_program::id(),
             &program,
             last_id,
             0,

--- a/src/system_program.rs
+++ b/src/system_program.rs
@@ -1,6 +1,7 @@
 //! system program
 
 use bincode::deserialize;
+use program::ProgramError;
 use solana_sdk::account::Account;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::system_instruction::SystemInstruction;
@@ -97,6 +98,17 @@ pub fn process_instruction(
         info!("Invalid transaction userdata: {:?}", tx.userdata(pix));
         Err(Error::InvalidArgument)
     }
+}
+
+pub fn process(
+    tx: &Transaction,
+    instruction_index: usize,
+    accounts: &mut [&mut Account],
+) -> std::result::Result<(), ProgramError> {
+    process_instruction(&tx, instruction_index, accounts).map_err(|err| match err {
+        Error::ResultWithNegativeTokens => ProgramError::ResultWithNegativeTokens,
+        _ => ProgramError::RuntimeError,
+    })
 }
 
 #[cfg(test)]

--- a/src/system_program.rs
+++ b/src/system_program.rs
@@ -12,7 +12,7 @@ pub enum Error {
     InvalidArgument,
     AssignOfUnownedAccount,
     AccountNotFinalized,
-    ResultWithNegativeTokens(u8),
+    ResultWithNegativeTokens,
 }
 impl std::fmt::Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
@@ -60,7 +60,7 @@ pub fn process_instruction(
                 }
                 if tokens > accounts[0].tokens {
                     info!("Insufficient tokens in account[0]");
-                    Err(Error::ResultWithNegativeTokens(pix as u8))?;
+                    Err(Error::ResultWithNegativeTokens)?;
                 }
                 accounts[0].tokens -= tokens;
                 accounts[1].tokens += tokens;
@@ -79,7 +79,7 @@ pub fn process_instruction(
                 //bank should be verifying correctness
                 if tokens > accounts[0].tokens {
                     info!("Insufficient tokens in account[0]");
-                    Err(Error::ResultWithNegativeTokens(pix as u8))?;
+                    Err(Error::ResultWithNegativeTokens)?;
                 }
                 accounts[0].tokens -= tokens;
                 accounts[1].tokens += tokens;

--- a/src/system_program.rs
+++ b/src/system_program.rs
@@ -35,13 +35,13 @@ pub fn id() -> Pubkey {
 pub fn get_balance(account: &Account) -> u64 {
     account.tokens
 }
-pub fn process_transaction(
+pub fn process_instruction(
     tx: &Transaction,
     pix: usize,
     accounts: &mut [&mut Account],
 ) -> Result<()> {
     if let Ok(syscall) = deserialize(tx.userdata(pix)) {
-        trace!("process_transaction: {:?}", syscall);
+        trace!("process_instruction: {:?}", syscall);
         match syscall {
             SystemInstruction::CreateAccount {
                 tokens,
@@ -111,7 +111,7 @@ mod test {
 
     fn process_transaction(tx: &Transaction, accounts: &mut [Account]) -> Result<()> {
         let mut refs: Vec<&mut Account> = accounts.iter_mut().collect();
-        super::process_transaction(&tx, 0, &mut refs[..])
+        super::process_instruction(&tx, 0, &mut refs[..])
     }
 
     #[test]

--- a/src/system_transaction.rs
+++ b/src/system_transaction.rs
@@ -4,7 +4,7 @@ use signature::{Keypair, KeypairUtil};
 use solana_sdk::hash::Hash;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::system_instruction::SystemInstruction;
-use system_program::SystemProgram;
+use system_program;
 
 use transaction::{Instruction, Transaction};
 
@@ -60,7 +60,7 @@ impl SystemTransaction for Transaction {
         Transaction::new(
             from_keypair,
             &[to],
-            SystemProgram::id(),
+            system_program::id(),
             &create,
             last_id,
             fee,
@@ -72,7 +72,7 @@ impl SystemTransaction for Transaction {
         Transaction::new(
             from_keypair,
             &[],
-            SystemProgram::id(),
+            system_program::id(),
             &assign,
             last_id,
             fee,
@@ -94,7 +94,7 @@ impl SystemTransaction for Transaction {
         Transaction::new(
             from_keypair,
             &[to],
-            SystemProgram::id(),
+            system_program::id(),
             &move_tokens,
             last_id,
             fee,
@@ -116,14 +116,21 @@ impl SystemTransaction for Transaction {
             &to_keys,
             last_id,
             fee,
-            vec![SystemProgram::id()],
+            vec![system_program::id()],
             instructions,
         )
     }
     /// Create and sign new SystemInstruction::Spawn transaction
     fn system_spawn(from_keypair: &Keypair, last_id: Hash, fee: u64) -> Self {
         let spawn = SystemInstruction::Spawn;
-        Transaction::new(from_keypair, &[], SystemProgram::id(), &spawn, last_id, fee)
+        Transaction::new(
+            from_keypair,
+            &[],
+            system_program::id(),
+            &spawn,
+            last_id,
+            fee,
+        )
     }
 }
 

--- a/src/vote_program.rs
+++ b/src/vote_program.rs
@@ -3,6 +3,7 @@
 
 use bincode::{deserialize, serialize};
 use byteorder::{ByteOrder, LittleEndian};
+use program::ProgramError;
 use solana_sdk::account::Account;
 use solana_sdk::pubkey::Pubkey;
 use std;
@@ -114,6 +115,14 @@ pub fn process_instruction(
             Err(Error::UserdataDeserializeFailure)
         }
     }
+}
+
+pub fn process(
+    tx: &Transaction,
+    instruction_index: usize,
+    accounts: &mut [&mut Account],
+) -> std::result::Result<(), ProgramError> {
+    process_instruction(&tx, instruction_index, accounts).map_err(|_| ProgramError::RuntimeError)
 }
 
 pub fn get_max_size() -> usize {

--- a/src/vote_program.rs
+++ b/src/vote_program.rs
@@ -64,7 +64,7 @@ pub fn id() -> Pubkey {
     Pubkey::new(&VOTE_PROGRAM_ID)
 }
 
-pub fn process_transaction(
+pub fn process_instruction(
     tx: &Transaction,
     instruction_index: usize,
     accounts: &mut [&mut Account],

--- a/src/vote_transaction.rs
+++ b/src/vote_transaction.rs
@@ -12,7 +12,7 @@ use solana_sdk::hash::Hash;
 use solana_sdk::pubkey::Pubkey;
 use system_transaction::SystemTransaction;
 use transaction::Transaction;
-use vote_program::{Vote, VoteInstruction, VoteProgram};
+use vote_program::{self, Vote, VoteInstruction};
 
 pub trait VoteTransaction {
     fn vote_new(vote_account: &Keypair, vote: Vote, last_id: Hash, fee: u64) -> Self;
@@ -37,7 +37,7 @@ impl VoteTransaction for Transaction {
         Transaction::new(
             vote_account,
             &[],
-            VoteProgram::id(),
+            vote_program::id(),
             &instruction,
             last_id,
             fee,
@@ -55,8 +55,8 @@ impl VoteTransaction for Transaction {
             new_vote_account_id,
             last_id,
             num_tokens,
-            VoteProgram::get_max_size() as u64,
-            VoteProgram::id(),
+            vote_program::get_max_size() as u64,
+            vote_program::id(),
             0,
         )
     }
@@ -71,7 +71,7 @@ impl VoteTransaction for Transaction {
         Transaction::new(
             validator_id,
             &[vote_account_id],
-            VoteProgram::id(),
+            vote_program::id(),
             &register_tx,
             last_id,
             fee,
@@ -82,7 +82,7 @@ impl VoteTransaction for Transaction {
         let mut votes = vec![];
         for i in 0..self.instructions.len() {
             let tx_program_id = self.program_id(i);
-            if VoteProgram::check_id(&tx_program_id) {
+            if vote_program::check_id(&tx_program_id) {
                 if let Ok(Some(VoteInstruction::NewVote(vote))) = deserialize(&self.userdata(i)) {
                     votes.push((self.account_keys[0], vote, self.last_id))
                 }

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -1,7 +1,7 @@
 use bincode::serialize;
 use bpf_loader;
 use bs58;
-use budget_program::BudgetProgram;
+use budget_program;
 use budget_transaction::BudgetTransaction;
 use chrono::prelude::*;
 use clap::ArgMatches;
@@ -497,7 +497,7 @@ pub fn process_command(config: &WalletConfig) -> Result<String, Box<error::Error
 
                 let contract_funds = Keypair::new();
                 let contract_state = Keypair::new();
-                let budget_program_id = BudgetProgram::id();
+                let budget_program_id = budget_program::id();
 
                 // Create account for contract funds
                 let tx = Transaction::system_create(
@@ -553,7 +553,7 @@ pub fn process_command(config: &WalletConfig) -> Result<String, Box<error::Error
 
                 let contract_funds = Keypair::new();
                 let contract_state = Keypair::new();
-                let budget_program_id = BudgetProgram::id();
+                let budget_program_id = budget_program::id();
 
                 // Create account for contract funds
                 let tx = Transaction::system_create(


### PR DESCRIPTION
* Rename process_transaction() functions to process_instruction()
* Move id(), check_id(), and process_instruction() to top-level functions
* Extract ProgramError from BankError
* Work towards extracting process_transaction() from the bank