### PR TITLE
Extract runtime

### DIFF
--- a/src/bank.rs
+++ b/src/bank.rs
@@ -1,5 +1,5 @@
-//! The `bank` module tracks client accounts and the progress of smart
-//! contracts. It offers a high-level API that signs transactions
+//! The `bank` module tracks client accounts and the progress of on-chain
+//! programs. It offers a high-level API that signs transactions
 //! on behalf of the caller, and a low-level API for when they have
 //! already been signed and verified.
 
@@ -85,9 +85,6 @@ pub enum BankError {
 
     /// The program returned an error
     ProgramError(u8, ProgramError),
-
-    /// Contract id is unknown
-    UnknownContractId(u8),
 
     /// Recoding into PoH failed
     RecordFailure,
@@ -274,7 +271,7 @@ impl Checkpoint for Accounts {
     }
 }
 
-/// Manager for the state of all accounts and contracts after processing its entries.
+/// Manager for the state of all accounts and programs after processing its entries.
 pub struct Bank {
     /// A map of account public keys to the balance in that account.
     pub accounts: RwLock<Accounts>,
@@ -642,8 +639,8 @@ impl Bank {
                 return Err(BankError::LastIdNotFound);
             }
 
-            // There is no way to predict what contract will execute without an error
-            // If a fee can pay for execution then the contract will be scheduled
+            // There is no way to predict what program will execute without an error
+            // If a fee can pay for execution then the program will be scheduled
             let err =
                 Self::reserve_signature_with_last_id(last_ids, &tx.last_id, &tx.signatures[0]);
             if let Err(BankError::LastIdNotFound) = err {
@@ -1209,15 +1206,15 @@ impl Bank {
             account.tokens
         }
     }
-    /// Each contract would need to be able to introspect its own state
-    /// this is hard coded to the budget contract language
+    /// Each program would need to be able to introspect its own state
+    /// this is hard-coded to the Budget language
     pub fn get_balance(&self, pubkey: &Pubkey) -> u64 {
         self.get_account(pubkey)
             .map(|x| Self::read_balance(&x))
             .unwrap_or(0)
     }
 
-    /// TODO: Need to implement a real staking contract to hold node stake.
+    /// TODO: Need to implement a real staking program to hold node stake.
     /// Right now this just gets the account balances. See github issue #1655.
     pub fn get_stake(&self, pubkey: &Pubkey) -> u64 {
         self.get_balance(pubkey)
@@ -1547,7 +1544,7 @@ mod tests {
         let bank = Bank::new(&mint);
         let dest = Keypair::new();
 
-        // source with 0 contract context
+        // source with 0 program context
         let tx = Transaction::system_create(
             &mint.keypair(),
             dest.pubkey(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,6 +65,7 @@ pub mod retransmit_stage;
 pub mod rpc;
 pub mod rpc_pubsub;
 pub mod rpc_request;
+pub mod runtime;
 pub mod service;
 pub mod signature;
 pub mod sigverify;

--- a/src/program.rs
+++ b/src/program.rs
@@ -8,4 +8,13 @@ pub enum ProgramError {
 
     /// The program returned an error
     RuntimeError,
+
+    /// Program's instruction token balance does not equal the balance after the instruction
+    UnbalancedInstruction,
+
+    /// Program modified an account's program id
+    ModifiedProgramId,
+
+    /// Program spent the tokens of an account that doesn't belong to it
+    ExternalAccountTokenSpend,
 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1,0 +1,124 @@
+use budget_program;
+use native_loader;
+use program::ProgramError;
+use solana_sdk::account::{create_keyed_accounts, Account, KeyedAccount};
+use solana_sdk::pubkey::Pubkey;
+use storage_program;
+use system_program;
+use transaction::Transaction;
+use vote_program;
+
+pub fn is_legacy_program(program_id: &Pubkey) -> bool {
+    system_program::check_id(program_id)
+        || budget_program::check_id(program_id)
+        || storage_program::check_id(program_id)
+        || vote_program::check_id(program_id)
+}
+
+/// Process an instruction
+/// This method calls the instruction's program entry pont method
+fn process_instruction(
+    tx: &Transaction,
+    instruction_index: usize,
+    executable_accounts: &mut [(Pubkey, Account)],
+    program_accounts: &mut [&mut Account],
+    tick_height: u64,
+) -> Result<(), ProgramError> {
+    let program_id = tx.program_id(instruction_index);
+
+    // Call the contract method
+    // It's up to the contract to implement its own rules on moving funds
+    if is_legacy_program(&program_id) {
+        if system_program::check_id(&program_id) {
+            system_program::process(&tx, instruction_index, program_accounts)?;
+        } else if budget_program::check_id(&program_id) {
+            budget_program::process(&tx, instruction_index, program_accounts)?;
+        } else if storage_program::check_id(&program_id) {
+            storage_program::process(&tx, instruction_index, program_accounts)?;
+        } else if vote_program::check_id(&program_id) {
+            vote_program::process(&tx, instruction_index, program_accounts)?;
+        } else {
+            unreachable!();
+        };
+    } else {
+        let mut keyed_accounts = create_keyed_accounts(executable_accounts);
+        let mut keyed_accounts2: Vec<_> = tx.instructions[instruction_index]
+            .accounts
+            .iter()
+            .map(|&index| &tx.account_keys[index as usize])
+            .zip(program_accounts.iter_mut())
+            .map(|(key, account)| KeyedAccount { key, account })
+            .collect();
+        keyed_accounts.append(&mut keyed_accounts2);
+
+        if !native_loader::process_instruction(
+            &program_id,
+            &mut keyed_accounts,
+            &tx.instructions[instruction_index].userdata,
+            tick_height,
+        ) {
+            return Err(ProgramError::RuntimeError);
+        }
+    }
+    Ok(())
+}
+
+fn verify_instruction(
+    program_id: &Pubkey,
+    pre_program_id: &Pubkey,
+    pre_tokens: u64,
+    account: &Account,
+) -> Result<(), ProgramError> {
+    // Verify the transaction
+
+    // Make sure that program_id is still the same or this was just assigned by the system call contract
+    if *pre_program_id != account.owner && !system_program::check_id(&program_id) {
+        return Err(ProgramError::ModifiedProgramId);
+    }
+    // For accounts unassigned to the contract, the individual balance of each accounts cannot decrease.
+    if *program_id != account.owner && pre_tokens > account.tokens {
+        return Err(ProgramError::ExternalAccountTokenSpend);
+    }
+    Ok(())
+}
+
+/// Execute an instruction
+/// This method calls the instruction's program entry pont method and verifies that the result of
+/// the call does not violate the bank's accounting rules.
+/// The accounts are committed back to the bank only if this function returns Ok(_).
+pub fn execute_instruction(
+    tx: &Transaction,
+    instruction_index: usize,
+    executable_accounts: &mut [(Pubkey, Account)],
+    program_accounts: &mut [&mut Account],
+    tick_height: u64,
+) -> Result<(), ProgramError> {
+    let program_id = tx.program_id(instruction_index);
+    // TODO: the runtime should be checking read/write access to memory
+    // we are trusting the hard coded contracts not to clobber or allocate
+    let pre_total: u64 = program_accounts.iter().map(|a| a.tokens).sum();
+    let pre_data: Vec<_> = program_accounts
+        .iter_mut()
+        .map(|a| (a.owner, a.tokens))
+        .collect();
+
+    process_instruction(
+        tx,
+        instruction_index,
+        executable_accounts,
+        program_accounts,
+        tick_height,
+    )?;
+
+    // Verify the instruction
+    for ((pre_program_id, pre_tokens), post_account) in pre_data.iter().zip(program_accounts.iter())
+    {
+        verify_instruction(&program_id, pre_program_id, *pre_tokens, post_account)?;
+    }
+    // The total sum of all the tokens in all the accounts cannot change.
+    let post_total: u64 = program_accounts.iter().map(|a| a.tokens).sum();
+    if pre_total != post_total {
+        return Err(ProgramError::UnbalancedInstruction);
+    }
+    Ok(())
+}

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -26,8 +26,8 @@ fn process_instruction(
 ) -> Result<(), ProgramError> {
     let program_id = tx.program_id(instruction_index);
 
-    // Call the contract method
-    // It's up to the contract to implement its own rules on moving funds
+    // Call the program method
+    // It's up to the program to implement its own rules on moving funds
     if is_legacy_program(&program_id) {
         if system_program::check_id(&program_id) {
             system_program::process(&tx, instruction_index, program_accounts)?;
@@ -71,11 +71,11 @@ fn verify_instruction(
 ) -> Result<(), ProgramError> {
     // Verify the transaction
 
-    // Make sure that program_id is still the same or this was just assigned by the system call contract
+    // Make sure that program_id is still the same or this was just assigned by the system program
     if *pre_program_id != account.owner && !system_program::check_id(&program_id) {
         return Err(ProgramError::ModifiedProgramId);
     }
-    // For accounts unassigned to the contract, the individual balance of each accounts cannot decrease.
+    // For accounts unassigned to the program, the individual balance of each accounts cannot decrease.
     if *program_id != account.owner && pre_tokens > account.tokens {
         return Err(ProgramError::ExternalAccountTokenSpend);
     }
@@ -95,7 +95,7 @@ pub fn execute_instruction(
 ) -> Result<(), ProgramError> {
     let program_id = tx.program_id(instruction_index);
     // TODO: the runtime should be checking read/write access to memory
-    // we are trusting the hard coded contracts not to clobber or allocate
+    // we are trusting the hard-coded programs not to clobber or allocate
     let pre_total: u64 = program_accounts.iter().map(|a| a.tokens).sum();
     let pre_data: Vec<_> = program_accounts
         .iter_mut()

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -16,7 +16,7 @@ pub fn is_legacy_program(program_id: &Pubkey) -> bool {
 }
 
 /// Process an instruction
-/// This method calls the instruction's program entry pont method
+/// This method calls the instruction's program entrypoint method
 fn process_instruction(
     tx: &Transaction,
     instruction_index: usize,
@@ -83,7 +83,7 @@ fn verify_instruction(
 }
 
 /// Execute an instruction
-/// This method calls the instruction's program entry pont method and verifies that the result of
+/// This method calls the instruction's program entrypoint method and verifies that the result of
 /// the call does not violate the bank's accounting rules.
 /// The accounts are committed back to the bank only if this function returns Ok(_).
 pub fn execute_instruction(


### PR DESCRIPTION
#### Problem

We talk about the "runtime" in the contracts engine RFC, but it's not in a module or a struct of its own. It's some set of Bank methods acting on a subset of Bank state. Without that separation, it'll be difficult to ask others to scrutinize that mission-critical code.

#### Summary of Changes

Move execute_instruction() into a new runtime.rs module.

TODO:

- [x] Merge #1897
- [ ] Attempt to move execute_transaction() too

Fixes #1528 
