### PR TITLE
 Extract execute_transaction() from the bank

### DIFF
--- a/src/bank.rs
+++ b/src/bank.rs
@@ -712,7 +712,7 @@ impl Bank {
     /// for the borrow checker to track them with regards to the original set.
     fn with_subset<F, A>(accounts: &mut [Account], ixes: &[u8], func: F) -> A
     where
-        F: Fn(&mut [&mut Account]) -> A,
+        F: FnOnce(&mut [&mut Account]) -> A,
     {
         let mut subset: Vec<&mut Account> = ixes
             .iter()
@@ -770,8 +770,8 @@ impl Bank {
     ) -> Result<()> {
         for (instruction_index, instruction) in tx.instructions.iter().enumerate() {
             let program_id = tx.program_id(instruction_index);
+            let mut executable_accounts = self.load_executable_accounts(*program_id)?;
             Self::with_subset(tx_accounts, &instruction.accounts, |program_accounts| {
-                let mut executable_accounts = self.load_executable_accounts(*program_id)?;
                 runtime::execute_instruction(
                     tx,
                     instruction_index,

--- a/src/budget_program.rs
+++ b/src/budget_program.rs
@@ -139,7 +139,7 @@ pub fn process(
     instruction_index: usize,
     accounts: &mut [&mut Account],
 ) -> std::result::Result<(), ProgramError> {
-    process_instruction(&tx, instruction_index, accounts).map_err(|_| ProgramError::RuntimeError)
+    process_instruction(&tx, instruction_index, accounts).map_err(|_| ProgramError::GenericError)
 }
 
 //TODO the contract needs to provide a "get_balance" introspection call of the userdata

--- a/src/program.rs
+++ b/src/program.rs
@@ -7,7 +7,7 @@ pub enum ProgramError {
     ResultWithNegativeTokens,
 
     /// The program returned an error
-    RuntimeError,
+    GenericError,
 
     /// Program's instruction token balance does not equal the balance after the instruction
     UnbalancedInstruction,

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -8,6 +8,13 @@ use system_program;
 use transaction::Transaction;
 use vote_program;
 
+/// Reasons the runtime might have rejected a transaction.
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum RuntimeError {
+    /// Executing the instruction at the given index produced an error.
+    ProgramError(u8, ProgramError),
+}
+
 pub fn is_legacy_program(program_id: &Pubkey) -> bool {
     system_program::check_id(program_id)
         || budget_program::check_id(program_id)
@@ -57,7 +64,7 @@ fn process_instruction(
             &tx.instructions[instruction_index].userdata,
             tick_height,
         ) {
-            return Err(ProgramError::RuntimeError);
+            return Err(ProgramError::GenericError);
         }
     }
     Ok(())
@@ -86,7 +93,7 @@ fn verify_instruction(
 /// This method calls the instruction's program entrypoint method and verifies that the result of
 /// the call does not violate the bank's accounting rules.
 /// The accounts are committed back to the bank only if this function returns Ok(_).
-pub fn execute_instruction(
+fn execute_instruction(
     tx: &Transaction,
     instruction_index: usize,
     executable_accounts: &mut [(Pubkey, Account)],
@@ -119,6 +126,49 @@ pub fn execute_instruction(
     let post_total: u64 = program_accounts.iter().map(|a| a.tokens).sum();
     if pre_total != post_total {
         return Err(ProgramError::UnbalancedInstruction);
+    }
+    Ok(())
+}
+
+/// Execute a function with a subset of accounts as writable references.
+/// Since the subset can point to the same references, in any order there is no way
+/// for the borrow checker to track them with regards to the original set.
+fn with_subset<F, A>(accounts: &mut [Account], ixes: &[u8], func: F) -> A
+where
+    F: FnOnce(&mut [&mut Account]) -> A,
+{
+    let mut subset: Vec<&mut Account> = ixes
+        .iter()
+        .map(|ix| {
+            let ptr = &mut accounts[*ix as usize] as *mut Account;
+            // lifetime of this unsafe is only within the scope of the closure
+            // there is no way to reorder them without breaking borrow checker rules
+            unsafe { &mut *ptr }
+        }).collect();
+    func(&mut subset)
+}
+
+/// Execute a transaction.
+/// This method calls each instruction in the transaction over the set of loaded Accounts
+/// The accounts are committed back to the bank only if every instruction succeeds
+pub fn execute_transaction(
+    tx: &Transaction,
+    loaders: &mut [Vec<(Pubkey, Account)>],
+    tx_accounts: &mut [Account],
+    tick_height: u64,
+) -> Result<(), RuntimeError> {
+    for (instruction_index, instruction) in tx.instructions.iter().enumerate() {
+        let executable_accounts = &mut (&mut loaders[instruction.program_ids_index as usize]);
+        with_subset(tx_accounts, &instruction.accounts, |program_accounts| {
+            execute_instruction(
+                tx,
+                instruction_index,
+                executable_accounts,
+                program_accounts,
+                tick_height,
+            ).map_err(|err| RuntimeError::ProgramError(instruction_index as u8, err))?;
+            Ok(())
+        })?;
     }
     Ok(())
 }

--- a/src/storage_program.rs
+++ b/src/storage_program.rs
@@ -57,7 +57,7 @@ pub fn process(
     instruction_index: usize,
     accounts: &mut [&mut Account],
 ) -> std::result::Result<(), ProgramError> {
-    process_instruction(&tx, instruction_index, accounts).map_err(|_| ProgramError::RuntimeError)
+    process_instruction(&tx, instruction_index, accounts).map_err(|_| ProgramError::GenericError)
 }
 
 #[cfg(test)]

--- a/src/system_program.rs
+++ b/src/system_program.rs
@@ -107,7 +107,7 @@ pub fn process(
 ) -> std::result::Result<(), ProgramError> {
     process_instruction(&tx, instruction_index, accounts).map_err(|err| match err {
         Error::ResultWithNegativeTokens => ProgramError::ResultWithNegativeTokens,
-        _ => ProgramError::RuntimeError,
+        _ => ProgramError::GenericError,
     })
 }
 

--- a/src/vote_program.rs
+++ b/src/vote_program.rs
@@ -122,7 +122,7 @@ pub fn process(
     instruction_index: usize,
     accounts: &mut [&mut Account],
 ) -> std::result::Result<(), ProgramError> {
-    process_instruction(&tx, instruction_index, accounts).map_err(|_| ProgramError::RuntimeError)
+    process_instruction(&tx, instruction_index, accounts).map_err(|_| ProgramError::GenericError)
 }
 
 pub fn get_max_size() -> usize {


### PR DESCRIPTION
#### Problem

Even if runtime.rs was moved into the SDK, a developer still couldn't write unit tests for their transactions.

#### Summary of Changes

* Move execute_transaction() from bank to runtime
* Fix with_subset() to allow mutable references to be passed to its closure. cc: @aeyakovenko
* No longer load the same loader accounts multiple times for one transaction
* Rename ProgramError::RuntimeError to ProgramError::GenericError
* Add RuntimeError to runtime.rs

Fixes #1528
