### PR TITLE
Add signature verification to gossip

### DIFF
--- a/sdk/src/signature.rs
+++ b/sdk/src/signature.rs
@@ -32,16 +32,16 @@ impl Signature {
 
 pub trait Signable {
     fn sign(&mut self, keypair: &Keypair) {
-        let data = self.get_sign_data();
+        let data = self.signable_data();
         self.set_signature(Signature::new(&keypair.sign(&data).as_ref()));
     }
     fn verify(&self) -> bool {
         self.get_signature()
-            .verify(&self.pubkey().as_ref(), &self.get_sign_data())
+            .verify(&self.pubkey().as_ref(), &self.signable_data())
     }
 
     fn pubkey(&self) -> Pubkey;
-    fn get_sign_data(&self) -> Vec<u8>;
+    fn signable_data(&self) -> Vec<u8>;
     fn get_signature(&self) -> Signature;
     fn set_signature(&mut self, signature: Signature);
 }

--- a/sdk/src/signature.rs
+++ b/sdk/src/signature.rs
@@ -33,9 +33,7 @@ impl Signature {
 pub trait Signable {
     fn sign(&mut self, keypair: &Keypair) {
         let data = self.get_sign_data();
-        self.set_signature(Signature::new(
-            &keypair.sign(&data).as_ref(),
-        ));
+        self.set_signature(Signature::new(&keypair.sign(&data).as_ref()));
     }
     fn verify(&self) -> bool {
         self.get_signature()

--- a/sdk/src/signature.rs
+++ b/sdk/src/signature.rs
@@ -30,6 +30,24 @@ impl Signature {
     }
 }
 
+pub trait Signable {
+    fn sign(&mut self, keypair: &Keypair) {
+        let data = self.get_sign_data();
+        self.set_signature(Signature::new(
+            &keypair.sign(&data).as_ref(),
+        ));
+    }
+    fn verify(&self) -> bool {
+        self.get_signature()
+            .verify(&self.pubkey().as_ref(), &self.get_sign_data())
+    }
+
+    fn pubkey(&self) -> Pubkey;
+    fn get_sign_data(&self) -> Vec<u8>;
+    fn get_signature(&self) -> Signature;
+    fn set_signature(&mut self, signature: Signature);
+}
+
 impl AsRef<[u8]> for Signature {
     fn as_ref(&self) -> &[u8] {
         &self.0[..]

--- a/src/cluster_info.rs
+++ b/src/cluster_info.rs
@@ -1426,10 +1426,6 @@ mod tests {
         let leader = NodeInfo::new_localhost(leader_keypair.pubkey(), 0);
         let peer = NodeInfo::new_localhost(peer_keypair.pubkey(), 0);
         let mut cluster_info = ClusterInfo::new_with_keypair(node_info.clone(), Arc::new(keypair));
-        let peer_cluster_info = &Arc::new(RwLock::new(ClusterInfo::new_with_keypair(
-            peer.clone(),
-            Arc::new(peer_keypair),
-        )));
         cluster_info.set_leader(leader.id);
         cluster_info.insert_info(peer.clone());
         //check that all types of gossip messages are signed correctly

--- a/src/cluster_info.rs
+++ b/src/cluster_info.rs
@@ -83,7 +83,7 @@ impl Signable for PruneData {
         self.pubkey
     }
 
-    fn get_sign_data(&self) -> Vec<u8> {
+    fn signable_data(&self) -> Vec<u8> {
         #[derive(Serialize)]
         struct SignData {
             pubkey: Pubkey,
@@ -805,7 +805,7 @@ impl ClusterInfo {
                         prunes,
                         signature: Signature::default(),
                         destination: from,
-                        source: ci.ncp.clone(),
+                        source: ci.ncp,
                     };
                     prune_msg.sign(&me.read().unwrap().keypair);
                     let rsp = Protocol::PruneMessage(self_id, prune_msg);

--- a/src/cluster_info.rs
+++ b/src/cluster_info.rs
@@ -66,7 +66,7 @@ pub struct ClusterInfo {
 #[derive(Serialize, Deserialize, Debug)]
 #[cfg_attr(feature = "cargo-clippy", allow(large_enum_variant))]
 enum Protocol {
-    /// Gosisp protocol messages
+    /// Gossip protocol messages
     PullRequest(Bloom<Hash>, CrdsValue),
     PullResponse(Pubkey, Vec<CrdsValue>),
     PushMessage(Pubkey, Vec<CrdsValue>),
@@ -165,11 +165,7 @@ impl ClusterInfo {
         let prev = self.leader_id();
         let self_id = self.gossip.id;
         let now = timestamp();
-        let leader = LeaderId {
-            id: self_id,
-            leader_id: key,
-            wallclock: now,
-        };
+        let leader = LeaderId::new(self_id, key, now);
         let entry = CrdsValue::LeaderId(leader);
         warn!("{}: LEADER_UPDATE TO {} from {}", self_id, key, prev);
         self.gossip.process_push_message(&[entry], now);
@@ -821,7 +817,7 @@ impl ClusterInfo {
         ledger_window: &mut Option<&mut LedgerWindow>,
     ) -> Vec<SharedBlob> {
         match request {
-            // TODO sigverify these
+            // TODO(sagar) sigverify these
             Protocol::PullRequest(filter, caller) => {
                 Self::handle_pull_request(me, filter, caller, from_addr)
             }

--- a/src/cluster_info.rs
+++ b/src/cluster_info.rs
@@ -883,11 +883,8 @@ impl ClusterInfo {
         match request {
             // TODO verify messages faster
             Protocol::PullRequest(filter, caller) => {
-                if caller.verify() {
-                    Self::handle_pull_request(me, filter, caller, from_addr)
-                } else {
-                    vec![]
-                }
+                //Pulls don't need to be verified
+                Self::handle_pull_request(me, filter, caller, from_addr)
             }
             Protocol::PullResponse(from, mut data) => {
                 data.retain(|v| v.verify());
@@ -899,9 +896,9 @@ impl ClusterInfo {
                 Self::handle_push_message(me, from, &data)
             }
             Protocol::PruneMessage(from, data) => {
-                if data.destination == me.read().unwrap().id() && data.source == *from_addr && data
-                    .signature
-                    .verify(from.as_ref(), data.get_sign_data().as_ref())
+                if data.destination == me.read().unwrap().id()
+                    && data.source == *from_addr
+                    && data.verify()
                 {
                     inc_new_counter_info!("cluster_info-prune_message", 1);
                     inc_new_counter_info!("cluster_info-prune_message-size", data.prunes.len());

--- a/src/contact_info.rs
+++ b/src/contact_info.rs
@@ -171,7 +171,7 @@ impl Signable for ContactInfo {
         self.id
     }
 
-    fn get_sign_data(&self) -> Vec<u8> {
+    fn signable_data(&self) -> Vec<u8> {
         #[derive(Serialize)]
         struct SignData {
             id: Pubkey,

--- a/src/crds.rs
+++ b/src/crds.rs
@@ -288,7 +288,7 @@ mod test {
         );
         let v2 = VersionedCrdsValue::new(
             1,
-            CrdsValue::LeaderId(LeaderId::new(key.pubkey(),Pubkey::default(),0)),
+            CrdsValue::LeaderId(LeaderId::new(key.pubkey(), Pubkey::default(), 0)),
         );
         assert!(v1 > v2);
         assert!(!(v1 < v2));
@@ -303,7 +303,7 @@ mod test {
         );
         let v2 = VersionedCrdsValue::new(
             1,
-            CrdsValue::LeaderId(LeaderId::new(Keypair::new().pubkey(), Pubkey::default(),0)),
+            CrdsValue::LeaderId(LeaderId::new(Keypair::new().pubkey(), Pubkey::default(), 0)),
         );
         assert!(v1 != v2);
         assert!(!(v1 == v2));

--- a/src/crds.rs
+++ b/src/crds.rs
@@ -41,7 +41,7 @@ pub enum CrdsError {
     InsertFailed,
 }
 
-/// This structure stores some local metadata assosciated with the CrdsValue
+/// This structure stores some local metadata associated with the CrdsValue
 /// The implementation of PartialOrd ensures that the "highest" version is always picked to be
 /// stored in the Crds
 #[derive(PartialEq, Debug)]
@@ -188,11 +188,7 @@ mod test {
         let mut crds = Crds::default();
         let original = CrdsValue::LeaderId(LeaderId::default());
         assert_matches!(crds.insert(original.clone(), 0), Ok(_));
-        let val = CrdsValue::LeaderId(LeaderId {
-            id: Pubkey::default(),
-            leader_id: Pubkey::default(),
-            wallclock: 1,
-        });
+        let val = CrdsValue::LeaderId(LeaderId::new(Pubkey::default(), Pubkey::default(), 1));
         assert_eq!(
             crds.insert(val.clone(), 1).unwrap().unwrap().value,
             original
@@ -255,19 +251,11 @@ mod test {
         let key = Keypair::new();
         let v1 = VersionedCrdsValue::new(
             1,
-            CrdsValue::LeaderId(LeaderId {
-                id: key.pubkey(),
-                leader_id: Pubkey::default(),
-                wallclock: 0,
-            }),
+            CrdsValue::LeaderId(LeaderId::new(key.pubkey(), Pubkey::default(), 0)),
         );
         let v2 = VersionedCrdsValue::new(
             1,
-            CrdsValue::LeaderId(LeaderId {
-                id: key.pubkey(),
-                leader_id: Pubkey::default(),
-                wallclock: 0,
-            }),
+            CrdsValue::LeaderId(LeaderId::new(key.pubkey(), Pubkey::default(), 0)),
         );
         assert!(!(v1 != v2));
         assert!(v1 == v2);
@@ -277,19 +265,11 @@ mod test {
         let key = Keypair::new();
         let v1 = VersionedCrdsValue::new(
             1,
-            CrdsValue::LeaderId(LeaderId {
-                id: key.pubkey(),
-                leader_id: Pubkey::default(),
-                wallclock: 0,
-            }),
+            CrdsValue::LeaderId(LeaderId::new(key.pubkey(), Pubkey::default(), 0)),
         );
         let v2 = VersionedCrdsValue::new(
             1,
-            CrdsValue::LeaderId(LeaderId {
-                id: key.pubkey(),
-                leader_id: key.pubkey(),
-                wallclock: 0,
-            }),
+            CrdsValue::LeaderId(LeaderId::new(key.pubkey(), key.pubkey(), 0)),
         );
         assert!(v1 != v2);
         assert!(!(v1 == v2));
@@ -304,19 +284,11 @@ mod test {
         let key = Keypair::new();
         let v1 = VersionedCrdsValue::new(
             1,
-            CrdsValue::LeaderId(LeaderId {
-                id: key.pubkey(),
-                leader_id: Pubkey::default(),
-                wallclock: 1,
-            }),
+            CrdsValue::LeaderId(LeaderId::new(key.pubkey(), Pubkey::default(), 1)),
         );
         let v2 = VersionedCrdsValue::new(
             1,
-            CrdsValue::LeaderId(LeaderId {
-                id: key.pubkey(),
-                leader_id: Pubkey::default(),
-                wallclock: 0,
-            }),
+            CrdsValue::LeaderId(LeaderId::new(key.pubkey(),Pubkey::default(),0)),
         );
         assert!(v1 > v2);
         assert!(!(v1 < v2));
@@ -327,19 +299,11 @@ mod test {
     fn test_label_order() {
         let v1 = VersionedCrdsValue::new(
             1,
-            CrdsValue::LeaderId(LeaderId {
-                id: Keypair::new().pubkey(),
-                leader_id: Pubkey::default(),
-                wallclock: 0,
-            }),
+            CrdsValue::LeaderId(LeaderId::new(Keypair::new().pubkey(), Pubkey::default(), 0)),
         );
         let v2 = VersionedCrdsValue::new(
             1,
-            CrdsValue::LeaderId(LeaderId {
-                id: Keypair::new().pubkey(),
-                leader_id: Pubkey::default(),
-                wallclock: 0,
-            }),
+            CrdsValue::LeaderId(LeaderId::new(Keypair::new().pubkey(), Pubkey::default(),0)),
         );
         assert!(v1 != v2);
         assert!(!(v1 == v2));

--- a/src/crds_gossip.rs
+++ b/src/crds_gossip.rs
@@ -529,15 +529,15 @@ mod test {
             Pubkey::new(hash(&[1; 32]).as_ref()),
             &[prune_pubkey],
             now,
-            now
+            now,
         );
         assert_eq!(res.err(), Some(CrdsGossipError::BadPruneDestination));
         //correct dest
-        res = crds_gossip.process_prune_msg(ci.id, id, &[prune_pubkey], now ,now);
+        res = crds_gossip.process_prune_msg(ci.id, id, &[prune_pubkey], now, now);
         assert!(res.is_ok());
         //test timeout
-        let timeout = now + crds_gossip.push.prune_timeout*2;
-        res = crds_gossip.process_prune_msg(ci.id, id, &[prune_pubkey], now , timeout);
+        let timeout = now + crds_gossip.push.prune_timeout * 2;
+        res = crds_gossip.process_prune_msg(ci.id, id, &[prune_pubkey], now, timeout);
         assert_eq!(res.err(), Some(CrdsGossipError::PruneMessageTimeout));
     }
 }

--- a/src/crds_gossip_error.rs
+++ b/src/crds_gossip_error.rs
@@ -5,4 +5,5 @@ pub enum CrdsGossipError {
     PushMessagePrune,
     PushMessageOldVersion,
     BadPruneDestination,
+    PruneMessageTimeout,
 }

--- a/src/crds_gossip_error.rs
+++ b/src/crds_gossip_error.rs
@@ -4,4 +4,5 @@ pub enum CrdsGossipError {
     PushMessageTimeout,
     PushMessagePrune,
     PushMessageOldVersion,
+    BadPruneDestination,
 }

--- a/src/crds_gossip_pull.rs
+++ b/src/crds_gossip_pull.rs
@@ -292,11 +292,7 @@ mod test {
 
         // node contains a key from the dest node, but at an older local timestamp
         let dest_id = new.label().pubkey();
-        let same_key = CrdsValue::LeaderId(LeaderId {
-            id: dest_id,
-            leader_id: dest_id,
-            wallclock: 1,
-        });
+        let same_key = CrdsValue::LeaderId(LeaderId::new(dest_id, dest_id, 1));
         node_crds.insert(same_key.clone(), 0).unwrap();
         assert_eq!(
             node_crds

--- a/src/crds_gossip_pull.rs
+++ b/src/crds_gossip_pull.rs
@@ -12,6 +12,7 @@
 use bincode::serialized_size;
 use bloom::Bloom;
 use crds::Crds;
+use crds_gossip::CRDS_GOSSIP_BLOOM_SIZE;
 use crds_gossip_error::CrdsGossipError;
 use crds_value::{CrdsValue, CrdsValueLabel};
 use packet::BLOB_DATA_SIZE;
@@ -135,7 +136,10 @@ impl CrdsGossipPull {
     }
     /// build a filter of the current crds table
     fn build_crds_filter(&self, crds: &Crds) -> Bloom<Hash> {
-        let num = crds.table.values().count() + self.purged_values.len();
+        let num = cmp::max(
+            CRDS_GOSSIP_BLOOM_SIZE,
+            crds.table.values().count() + self.purged_values.len(),
+        );
         let mut bloom = Bloom::random(num, 0.1, 4 * 1024 * 8 - 1);
         for v in crds.table.values() {
             bloom.add(&v.value_hash);

--- a/src/crds_gossip_push.rs
+++ b/src/crds_gossip_push.rs
@@ -26,6 +26,7 @@ use std::collections::HashMap;
 pub const CRDS_GOSSIP_NUM_ACTIVE: usize = 30;
 pub const CRDS_GOSSIP_PUSH_FANOUT: usize = 6;
 pub const CRDS_GOSSIP_PUSH_MSG_TIMEOUT_MS: u64 = 5000;
+pub const CRDS_GOSSIP_PRUNE_MSG_TIMEOUT_MS: u64 = 500;
 
 pub struct CrdsGossipPush {
     /// max bytes per message
@@ -38,6 +39,7 @@ pub struct CrdsGossipPush {
     pub num_active: usize,
     pub push_fanout: usize,
     pub msg_timeout: u64,
+    pub prune_timeout: u64,
 }
 
 impl Default for CrdsGossipPush {
@@ -50,6 +52,8 @@ impl Default for CrdsGossipPush {
             num_active: CRDS_GOSSIP_NUM_ACTIVE,
             push_fanout: CRDS_GOSSIP_PUSH_FANOUT,
             msg_timeout: CRDS_GOSSIP_PUSH_MSG_TIMEOUT_MS,
+            prune_timeout: CRDS_GOSSIP_PRUNE_MSG_TIMEOUT_MS,
+
         }
     }
 }

--- a/src/crds_gossip_push.rs
+++ b/src/crds_gossip_push.rs
@@ -53,7 +53,6 @@ impl Default for CrdsGossipPush {
             push_fanout: CRDS_GOSSIP_PUSH_FANOUT,
             msg_timeout: CRDS_GOSSIP_PUSH_MSG_TIMEOUT_MS,
             prune_timeout: CRDS_GOSSIP_PRUNE_MSG_TIMEOUT_MS,
-
         }
     }
 }

--- a/src/crds_gossip_push.rs
+++ b/src/crds_gossip_push.rs
@@ -12,6 +12,7 @@ use bincode::serialized_size;
 use bloom::Bloom;
 use contact_info::ContactInfo;
 use crds::{Crds, VersionedCrdsValue};
+use crds_gossip::CRDS_GOSSIP_BLOOM_SIZE;
 use crds_gossip_error::CrdsGossipError;
 use crds_value::{CrdsValue, CrdsValueLabel};
 use indexmap::map::IndexMap;
@@ -183,7 +184,8 @@ impl CrdsGossipPush {
                     continue;
                 }
             }
-            let bloom = Bloom::random(network_size, 0.1, 1024 * 8 * 4);
+            let size = cmp::max(CRDS_GOSSIP_BLOOM_SIZE, network_size);
+            let mut bloom = Bloom::random(size, 0.1, 1024 * 8 * 4);
             new_items.insert(val.0.pubkey(), bloom);
             if new_items.len() == need {
                 break;

--- a/src/crds_value.rs
+++ b/src/crds_value.rs
@@ -145,10 +145,7 @@ impl CrdsValue {
             CrdsValue::Vote(vote) => vote.signature,
             CrdsValue::LeaderId(leader_id) => leader_id.signature,
         };
-        sig.verify(
-            &self.label().pubkey().as_ref(),
-            &self.get_sign_data(),
-        )
+        sig.verify(&self.label().pubkey().as_ref(), &self.get_sign_data())
     }
 
     /// get all the data relevant to signing contained in this value (excludes signature fields)

--- a/src/crds_value.rs
+++ b/src/crds_value.rs
@@ -38,7 +38,7 @@ impl Signable for LeaderId {
         self.id
     }
 
-    fn get_sign_data(&self) -> Vec<u8> {
+    fn signable_data(&self) -> Vec<u8> {
         #[derive(Serialize)]
         struct SignData {
             id: Pubkey,
@@ -67,7 +67,7 @@ impl Signable for Vote {
         self.transaction.account_keys[0]
     }
 
-    fn get_sign_data(&self) -> Vec<u8> {
+    fn signable_data(&self) -> Vec<u8> {
         #[derive(Serialize)]
         struct SignData {
             transaction: Transaction,
@@ -214,7 +214,7 @@ impl Signable for CrdsValue {
         }
     }
 
-    fn get_sign_data(&self) -> Vec<u8> {
+    fn signable_data(&self) -> Vec<u8> {
         unimplemented!()
     }
 

--- a/src/fullnode.rs
+++ b/src/fullnode.rs
@@ -234,7 +234,7 @@ impl Fullnode {
         node.info.wallclock = timestamp();
         let cluster_info = Arc::new(RwLock::new(ClusterInfo::new_with_keypair(
             node.info,
-            Some(keypair.clone()),
+            keypair.clone(),
         )));
 
         let (rpc_service, rpc_pubsub_service) =

--- a/src/fullnode.rs
+++ b/src/fullnode.rs
@@ -232,7 +232,10 @@ impl Fullnode {
         let window = new_window(32 * 1024);
         let shared_window = Arc::new(RwLock::new(window));
         node.info.wallclock = timestamp();
-        let cluster_info = Arc::new(RwLock::new(ClusterInfo::new(node.info)));
+        let cluster_info = Arc::new(RwLock::new(ClusterInfo::new_with_keypair(
+            node.info,
+            Some(keypair.clone()),
+        )));
 
         let (rpc_service, rpc_pubsub_service) =
             Self::startup_rpc_services(rpc_addr, rpc_pubsub_addr, &bank, &cluster_info);

--- a/tests/data_replicator.rs
+++ b/tests/data_replicator.rs
@@ -11,6 +11,7 @@ use solana::ncp::Ncp;
 use solana::packet::{Blob, SharedBlob};
 use solana::result;
 use solana::service::Service;
+use solana::signature::{Keypair, KeypairUtil};
 use solana_sdk::timing::timestamp;
 use std::net::UdpSocket;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -19,8 +20,9 @@ use std::thread::sleep;
 use std::time::Duration;
 
 fn test_node(exit: Arc<AtomicBool>) -> (Arc<RwLock<ClusterInfo>>, Ncp, UdpSocket) {
-    let mut tn = Node::new_localhost();
-    let cluster_info = ClusterInfo::new(tn.info.clone());
+    let keypair = Keypair::new();
+    let mut tn = Node::new_localhost_with_pubkey(keypair.pubkey());
+    let cluster_info = ClusterInfo::new_with_keypair(tn.info.clone(), Arc::new(keypair));
     let c = Arc::new(RwLock::new(cluster_info));
     let w = Arc::new(RwLock::new(vec![]));
     let d = Ncp::new(&c.clone(), w, None, tn.sockets.gossip, exit);

--- a/tests/multinode.rs
+++ b/tests/multinode.rs
@@ -42,12 +42,13 @@ use std::thread::{sleep, Builder, JoinHandle};
 use std::time::{Duration, Instant};
 
 fn make_spy_node(leader: &NodeInfo) -> (Ncp, Arc<RwLock<ClusterInfo>>, Pubkey) {
+    let keypair = Keypair::new();
     let exit = Arc::new(AtomicBool::new(false));
-    let mut spy = Node::new_localhost();
+    let mut spy = Node::new_localhost_with_pubkey(keypair.pubkey());
     let me = spy.info.id.clone();
     let daddr = "0.0.0.0:0".parse().unwrap();
     spy.info.tvu = daddr;
-    let mut spy_cluster_info = ClusterInfo::new(spy.info);
+    let mut spy_cluster_info = ClusterInfo::new_with_keypair(spy.info, Arc::new(keypair));
     spy_cluster_info.insert_info(leader.clone());
     spy_cluster_info.set_leader(leader.id);
     let spy_cluster_info_ref = Arc::new(RwLock::new(spy_cluster_info));
@@ -64,11 +65,12 @@ fn make_spy_node(leader: &NodeInfo) -> (Ncp, Arc<RwLock<ClusterInfo>>, Pubkey) {
 }
 
 fn make_listening_node(leader: &NodeInfo) -> (Ncp, Arc<RwLock<ClusterInfo>>, Node, Pubkey) {
+    let keypair = Keypair::new();
     let exit = Arc::new(AtomicBool::new(false));
-    let new_node = Node::new_localhost();
+    let new_node = Node::new_localhost_with_pubkey(keypair.pubkey());
     let new_node_info = new_node.info.clone();
     let me = new_node.info.id.clone();
-    let mut new_node_cluster_info = ClusterInfo::new(new_node_info);
+    let mut new_node_cluster_info = ClusterInfo::new_with_keypair(new_node_info, Arc::new(keypair));
     new_node_cluster_info.insert_info(leader.clone());
     new_node_cluster_info.set_leader(leader.id);
     let new_node_cluster_info_ref = Arc::new(RwLock::new(new_node_cluster_info));


### PR DESCRIPTION
#### Problem
Gossip lacks signature verification for messages, which means data can be spoofed.

#### Summary of Changes
Added Signatures to replicated gossip values and added verification of values are they get replicated across the network

Fixes #1855 and #1952
