### PR TITLE
Increase PACKET_DATA_SIZE to 1k

### DIFF
--- a/sdk/src/packet.rs
+++ b/sdk/src/packet.rs
@@ -1,2 +1,2 @@
 /// Maximum over-the-wire size of a Transaction
-pub const PACKET_DATA_SIZE: usize = 512;
+pub const PACKET_DATA_SIZE: usize = 1024;


### PR DESCRIPTION
512 bytes is not enough for a two Instruction Transaction with 3 signatures.  1k seems nice, but I don't have much reason to pick it over other numbers larger than 512

Fixes #1598
