### PR TITLE
add --no-capture to get some logs from flaky tests

### DIFF
--- a/ci/test-stable.sh
+++ b/ci/test-stable.sh
@@ -13,13 +13,13 @@ _() {
 }
 
 _ cargo build --all --verbose
-_ cargo test --verbose --lib
+_ cargo test --verbose --lib -- --nocapture
 
 # Run integration tests serially
 for test in tests/*.rs; do
   test=${test##*/} # basename x
   test=${test%.rs} # basename x .rs
-  _ cargo test --verbose --test="$test" -- --test-threads=1
+  _ cargo test --verbose --test="$test" -- --test-threads=1 --nocapture
 done
 
 # Run native program tests
@@ -28,7 +28,7 @@ for program in programs/native/*; do
   (
     set -x
     cd "$program"
-    cargo test --verbose
+    cargo test --verbose -- --nocapture
   )
 done
 


### PR DESCRIPTION
#### Problem
 flaky tests may emit specific failures that are lost without --nocapture

 #### Summary of Changes
 add --nocapture to test runs in ci/test-stable.sh, the main test runner

Fixes #