### PR TITLE
stabilize testing with --test-threads=1

### DIFF
--- a/ci/test-nightly.sh
+++ b/ci/test-nightly.sh
@@ -13,7 +13,7 @@ _() {
 }
 
 # Uncomment this to run nightly test suit
-# _ cargo test --verbose --features=unstable
+# _ cargo test --verbose --features=unstable -- --test-threads=1
 
 maybe_cargo_install() {
   for cmd in "$@"; do

--- a/ci/test-stable-perf.sh
+++ b/ci/test-stable-perf.sh
@@ -24,7 +24,7 @@ source ./target/perf-libs/env.sh
 
 FEATURES=bpf_c,cuda,erasure,chacha
 _ cargo build --all --verbose --features="$FEATURES"
-_ cargo test --verbose --features="$FEATURES" --lib
+_ cargo test --verbose --features="$FEATURES" --lib -- --nocapture --test-threads=1
 
 # Run integration tests serially
 for test in tests/*.rs; do

--- a/ci/test-stable.sh
+++ b/ci/test-stable.sh
@@ -13,7 +13,7 @@ _() {
 }
 
 _ cargo build --all --verbose
-_ cargo test --verbose --lib -- --nocapture
+_ cargo test --verbose --lib -- --nocapture --test-threads=1
 
 # Run integration tests serially
 for test in tests/*.rs; do


### PR DESCRIPTION
#### Problem
 many of our tests start servers that do no co-exist gracefully, until these tessts are moved or the code that creates the co-existence issues is fixed, run CI in single-threaded mode

 #### Summary of Changes
 ci/test-stable.sh to test main lib of solana in single-threaded mode

Fixes #