### PR TITLE
Test cleanup

### DIFF
--- a/ci/test-stable.sh
+++ b/ci/test-stable.sh
@@ -12,6 +12,11 @@ _() {
   "$@"
 }
 
+if [[ $(ulimit -n) -lt 65000 ]]; then
+  echo 'Error: nofiles too small, run "ulimit -n 65000" to continue'
+  exit 1
+fi
+
 _ cargo build --all --verbose
 _ cargo test --verbose --lib -- --nocapture
 

--- a/src/replicator.rs
+++ b/src/replicator.rs
@@ -175,118 +175,15 @@ impl Replicator {
 
 #[cfg(test)]
 mod tests {
-    use client::mk_client;
-    use cluster_info::Node;
-    use db_ledger::DbLedger;
-    use fullnode::Fullnode;
-    use leader_scheduler::LeaderScheduler;
-    use ledger::{create_tmp_genesis, get_tmp_ledger_path, read_ledger};
     use logger;
     use replicator::sample_file;
-    use replicator::Replicator;
     use signature::{Keypair, KeypairUtil};
     use solana_sdk::hash::Hash;
     use std::fs::File;
-    use std::fs::{create_dir_all, remove_dir_all, remove_file};
+    use std::fs::{create_dir_all, remove_file};
     use std::io::Write;
     use std::mem::size_of;
     use std::path::PathBuf;
-    use std::sync::atomic::{AtomicBool, Ordering};
-    use std::sync::Arc;
-    use std::thread::sleep;
-    use std::time::Duration;
-
-    #[test]
-    fn test_replicator_startup() {
-        logger::setup();
-        info!("starting replicator test");
-        let entry_height = 0;
-        let replicator_ledger_path = &get_tmp_ledger_path("replicator_test_replicator_ledger");
-
-        let exit = Arc::new(AtomicBool::new(false));
-        let done = Arc::new(AtomicBool::new(false));
-
-        info!("starting leader node");
-        let leader_keypair = Arc::new(Keypair::new());
-        let leader_node = Node::new_localhost_with_pubkey(leader_keypair.pubkey());
-        let network_addr = leader_node.sockets.gossip.local_addr().unwrap();
-        let leader_info = leader_node.info.clone();
-        let vote_account_keypair = Arc::new(Keypair::new());
-
-        let leader_ledger_path = "replicator_test_leader_ledger";
-        let (mint, leader_ledger_path) =
-            create_tmp_genesis(leader_ledger_path, 100, leader_info.id, 1);
-
-        {
-            let leader = Fullnode::new(
-                leader_node,
-                &leader_ledger_path,
-                leader_keypair,
-                vote_account_keypair,
-                None,
-                false,
-                LeaderScheduler::from_bootstrap_leader(leader_info.id),
-                None,
-            );
-
-            let mut leader_client = mk_client(&leader_info);
-
-            let bob = Keypair::new();
-
-            let last_id = leader_client.get_last_id();
-            leader_client
-                .transfer(1, &mint.keypair(), bob.pubkey(), &last_id)
-                .unwrap();
-
-            let replicator_keypair = Keypair::new();
-
-            info!("starting replicator node");
-            let replicator_node = Node::new_localhost_with_pubkey(replicator_keypair.pubkey());
-            let (replicator, _leader_info) = Replicator::new(
-                entry_height,
-                1,
-                &exit,
-                Some(replicator_ledger_path),
-                replicator_node,
-                Some(network_addr),
-                done.clone(),
-            );
-
-            let mut num_entries = 0;
-            for _ in 0..60 {
-                match read_ledger(replicator_ledger_path, true) {
-                    Ok(entries) => {
-                        for _ in entries {
-                            num_entries += 1;
-                        }
-                        info!("{} entries", num_entries);
-                        if num_entries > 0 {
-                            break;
-                        }
-                    }
-                    Err(e) => {
-                        info!("error reading ledger: {:?}", e);
-                    }
-                }
-                sleep(Duration::from_millis(300));
-                let last_id = leader_client.get_last_id();
-                leader_client
-                    .transfer(1, &mint.keypair(), bob.pubkey(), &last_id)
-                    .unwrap();
-            }
-            assert_eq!(done.load(Ordering::Relaxed), true);
-            assert!(num_entries > 0);
-            exit.store(true, Ordering::Relaxed);
-            replicator.join();
-            leader.exit();
-        }
-
-        DbLedger::destroy(&leader_ledger_path).expect("Expected successful database destuction");
-        DbLedger::destroy(&replicator_ledger_path)
-            .expect("Expected successful database destuction");
-        let _ignored = remove_dir_all(&leader_ledger_path);
-        let _ignored = remove_dir_all(&replicator_ledger_path);
-    }
 
     fn tmp_file_path(name: &str) -> PathBuf {
         use std::env;

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -59,8 +59,8 @@ impl JsonRpcService {
                             AccessControlAllowOrigin::Any,
                         ]))
                         .start_http(&rpc_addr);
-                if server.is_err() {
-                    warn!("JSON RPC service unavailable: unable to bind to RPC port {}. \nMake sure this port is not already in use by another application", rpc_addr.port());
+                if let Err(e) = server {
+                    warn!("JSON RPC service unavailable error: {:?}. \nAlso, check that port {} is not already in use by another application", e, rpc_addr.port());
                     return;
                 }
                 while !exit_.load(Ordering::Relaxed) {

--- a/src/rpc_pubsub.rs
+++ b/src/rpc_pubsub.rs
@@ -59,8 +59,8 @@ impl PubSubService {
                 })
                 .start(&pubsub_addr);
 
-                if server.is_err() {
-                    warn!("Pubsub service unavailable: unable to bind to port {}. \nMake sure this port is not already in use by another application", pubsub_addr.port());
+                if let Err(e) = server {
+                    warn!("Pubsub service unavailable error: {:?}. \nAlso, check that port {} is not already in use by another application", e, pubsub_addr.port());
                     return;
                 }
                 while !exit_.load(Ordering::Relaxed) {

--- a/tests/replicator.rs
+++ b/tests/replicator.rs
@@ -1,0 +1,108 @@
+#[macro_use]
+extern crate log;
+extern crate solana;
+
+use solana::client::mk_client;
+use solana::cluster_info::Node;
+use solana::db_ledger::DbLedger;
+use solana::fullnode::Fullnode;
+use solana::leader_scheduler::LeaderScheduler;
+use solana::ledger::{create_tmp_genesis, get_tmp_ledger_path, read_ledger};
+use solana::logger;
+use solana::replicator::Replicator;
+use solana::signature::{Keypair, KeypairUtil};
+use std::fs::remove_dir_all;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::thread::sleep;
+use std::time::Duration;
+
+#[test]
+fn test_replicator_startup() {
+    logger::setup();
+    info!("starting replicator test");
+    let entry_height = 0;
+    let replicator_ledger_path = &get_tmp_ledger_path("replicator_test_replicator_ledger");
+
+    let exit = Arc::new(AtomicBool::new(false));
+    let done = Arc::new(AtomicBool::new(false));
+
+    info!("starting leader node");
+    let leader_keypair = Arc::new(Keypair::new());
+    let leader_node = Node::new_localhost_with_pubkey(leader_keypair.pubkey());
+    let network_addr = leader_node.sockets.gossip.local_addr().unwrap();
+    let leader_info = leader_node.info.clone();
+    let vote_account_keypair = Arc::new(Keypair::new());
+
+    let leader_ledger_path = "replicator_test_leader_ledger";
+    let (mint, leader_ledger_path) = create_tmp_genesis(leader_ledger_path, 100, leader_info.id, 1);
+
+    {
+        let leader = Fullnode::new(
+            leader_node,
+            &leader_ledger_path,
+            leader_keypair,
+            vote_account_keypair,
+            None,
+            false,
+            LeaderScheduler::from_bootstrap_leader(leader_info.id),
+            None,
+        );
+
+        let mut leader_client = mk_client(&leader_info);
+
+        let bob = Keypair::new();
+
+        let last_id = leader_client.get_last_id();
+        leader_client
+            .transfer(1, &mint.keypair(), bob.pubkey(), &last_id)
+            .unwrap();
+
+        let replicator_keypair = Keypair::new();
+
+        info!("starting replicator node");
+        let replicator_node = Node::new_localhost_with_pubkey(replicator_keypair.pubkey());
+        let (replicator, _leader_info) = Replicator::new(
+            entry_height,
+            1,
+            &exit,
+            Some(replicator_ledger_path),
+            replicator_node,
+            Some(network_addr),
+            done.clone(),
+        );
+
+        let mut num_entries = 0;
+        for _ in 0..60 {
+            match read_ledger(replicator_ledger_path, true) {
+                Ok(entries) => {
+                    for _ in entries {
+                        num_entries += 1;
+                    }
+                    info!("{} entries", num_entries);
+                    if num_entries > 0 {
+                        break;
+                    }
+                }
+                Err(e) => {
+                    info!("error reading ledger: {:?}", e);
+                }
+            }
+            sleep(Duration::from_millis(300));
+            let last_id = leader_client.get_last_id();
+            leader_client
+                .transfer(1, &mint.keypair(), bob.pubkey(), &last_id)
+                .unwrap();
+        }
+        assert_eq!(done.load(Ordering::Relaxed), true);
+        assert!(num_entries > 0);
+        exit.store(true, Ordering::Relaxed);
+        replicator.join();
+        leader.exit();
+    }
+
+    DbLedger::destroy(&leader_ledger_path).expect("Expected successful database destuction");
+    DbLedger::destroy(&replicator_ledger_path).expect("Expected successful database destuction");
+    let _ignored = remove_dir_all(&leader_ledger_path);
+    let _ignored = remove_dir_all(&replicator_ledger_path);
+}


### PR DESCRIPTION
#### Problem

* `test_replicator_startup` can fail when run with multiple other tests.
* The json RPC startup failure messages are not clear and fixed to just something about ports.
* The regular `cargo test` requires a higher ulimit than is default on ubuntu.

#### Summary of Changes

`test_replicator_startup` moved to integration test which is run single threaded. RPC messages are improved, and ulimit is checked in `ci/test-stable.sh`.

Fixes #
