### PR TITLE
Expose signed keys to the SDK

### DIFF
--- a/programs/bpf/c/sdk/inc/solana_sdk.h
+++ b/programs/bpf/c/sdk/inc/solana_sdk.h
@@ -110,11 +110,12 @@ SOL_FN_PREFIX bool SolPubkey_same(const SolPubkey *one, const SolPubkey *two) {
  * Keyed Account
  */
 typedef struct {
-  SolPubkey *key;        /** Public Key of the account */
-  uint64_t *tokens;      /** Numer of tokens owned by this account */
-  uint64_t userdata_len; /** Length of userdata in bytes */
-  uint8_t *userdata;     /** On-chain data owned by this account */
-  SolPubkey *owner; /** Program that owns this account */
+  SolPubkey *key;        /** Public key of the account */
+  bool is_signer;        /** Transaction was signed by this account's key */
+  uint64_t *tokens;      /** Number of tokens owned by this account */
+  uint64_t userdata_len; /** Length of data in bytes */
+  uint8_t *userdata;     /** On-chain data within this account */
+  SolPubkey *owner;      /** Program that owns this account */
 } SolKeyedAccount;
 
 /**
@@ -243,6 +244,8 @@ SOL_FN_PREFIX bool sol_deserialize(
   input += sizeof(uint64_t);
   for (int i = 0; i < ka_len; i++) {
     // key
+    ka[i].is_signer = *(uint64_t *) input != 0;
+    input += sizeof(uint64_t);
     ka[i].key = (SolPubkey *) input;
     input += sizeof(SolPubkey);
 
@@ -319,6 +322,7 @@ SOL_FN_PREFIX void sol_log_params(
 ) {
   sol_log_64(0, 0, 0, 0, ka_len);
   for (int i = 0; i < ka_len; i++) {
+    sol_log_64(0, 0, 0, 0, ka[i].is_signer);
     sol_log_key(ka[i].key);
     sol_log_64(0, 0, 0, 0, *ka[i].tokens);
     sol_log_array(ka[i].userdata, ka[i].userdata_len);

--- a/programs/bpf/c/src/move_funds.c
+++ b/programs/bpf/c/src/move_funds.c
@@ -20,6 +20,11 @@ extern bool entrypoint(const uint8_t *input) {
     return false;
   }
 
+  if (!ka[0].is_signer) {
+    sol_log("Transaction not signed by key 0");
+    return false;
+  }
+
   int64_t tokens = *(int64_t *)data;
   if (*ka[0].tokens >= tokens) {
     *ka[0].tokens -= tokens;

--- a/sdk/src/account.rs
+++ b/sdk/src/account.rs
@@ -33,19 +33,50 @@ impl Account {
 #[repr(C)]
 #[derive(Debug)]
 pub struct KeyedAccount<'a> {
-    pub key: &'a Pubkey,
+    is_signer: bool, // Transaction was signed by this account's key
+    key: &'a Pubkey,
     pub account: &'a mut Account,
+}
+
+impl<'a> KeyedAccount<'a> {
+    pub fn signer_key(&self) -> Option<&Pubkey> {
+        if self.is_signer {
+            Some(self.key)
+        } else {
+            None
+        }
+    }
+
+    pub fn unsigned_key(&self) -> &Pubkey {
+        self.key
+    }
+
+    pub fn new(key: &'a Pubkey, is_signer: bool, account: &'a mut Account) -> KeyedAccount<'a> {
+        KeyedAccount {
+            key,
+            is_signer,
+            account,
+        }
+    }
 }
 
 impl<'a> From<(&'a Pubkey, &'a mut Account)> for KeyedAccount<'a> {
     fn from((key, account): (&'a Pubkey, &'a mut Account)) -> Self {
-        KeyedAccount { key, account }
+        KeyedAccount {
+            is_signer: false,
+            key,
+            account,
+        }
     }
 }
 
 impl<'a> From<&'a mut (Pubkey, Account)> for KeyedAccount<'a> {
     fn from((key, account): &'a mut (Pubkey, Account)) -> Self {
-        KeyedAccount { key, account }
+        KeyedAccount {
+            is_signer: false,
+            key,
+            account,
+        }
     }
 }
 

--- a/sdk/src/transaction.rs
+++ b/sdk/src/transaction.rs
@@ -126,7 +126,7 @@ impl Transaction {
         self.key_index(instruction_index, accounts_index)
             .and_then(|account_keys_index| self.account_keys.get(account_keys_index))
     }
-    pub fn signed_key(&self, instruction_index: usize, accounts_index: usize) -> Option<&Pubkey> {
+    pub fn signer_key(&self, instruction_index: usize, accounts_index: usize) -> Option<&Pubkey> {
         match self.key_index(instruction_index, accounts_index) {
             None => None,
             Some(signature_index) => {
@@ -232,22 +232,22 @@ mod tests {
         assert!(tx.verify_refs());
 
         assert_eq!(tx.key(0, 0), Some(&key.pubkey()));
-        assert_eq!(tx.signed_key(0, 0), Some(&key.pubkey()));
+        assert_eq!(tx.signer_key(0, 0), Some(&key.pubkey()));
 
         assert_eq!(tx.key(1, 0), Some(&key.pubkey()));
-        assert_eq!(tx.signed_key(1, 0), Some(&key.pubkey()));
+        assert_eq!(tx.signer_key(1, 0), Some(&key.pubkey()));
 
         assert_eq!(tx.key(0, 1), Some(&key1));
-        assert_eq!(tx.signed_key(0, 1), None);
+        assert_eq!(tx.signer_key(0, 1), None);
 
         assert_eq!(tx.key(1, 1), Some(&key2));
-        assert_eq!(tx.signed_key(1, 1), None);
+        assert_eq!(tx.signer_key(1, 1), None);
 
         assert_eq!(tx.key(2, 0), None);
-        assert_eq!(tx.signed_key(2, 0), None);
+        assert_eq!(tx.signer_key(2, 0), None);
 
         assert_eq!(tx.key(0, 2), None);
-        assert_eq!(tx.signed_key(0, 2), None);
+        assert_eq!(tx.signer_key(0, 2), None);
 
         assert_eq!(*tx.program_id(0), prog1);
         assert_eq!(*tx.program_id(1), prog2);

--- a/src/budget_program.rs
+++ b/src/budget_program.rs
@@ -170,7 +170,7 @@ impl BudgetProgram {
     ) -> Result<(), BudgetError> {
         let mut final_payment = None;
         if let Some(ref mut expr) = self.pending_budget {
-            let key = match tx.signed_key(instruction_index, 0) {
+            let key = match tx.signer_key(instruction_index, 0) {
                 None => return Err(BudgetError::UnsignedKey),
                 Some(key) => key,
             };
@@ -203,7 +203,7 @@ impl BudgetProgram {
         let mut final_payment = None;
 
         if let Some(ref mut expr) = self.pending_budget {
-            let key = match tx.signed_key(instruction_index, 0) {
+            let key = match tx.signer_key(instruction_index, 0) {
                 None => return Err(BudgetError::UnsignedKey),
                 Some(key) => key,
             };

--- a/src/native_loader.rs
+++ b/src/native_loader.rs
@@ -99,6 +99,10 @@ pub fn process_instruction(
             }
         }
     } else if let Ok(instruction) = deserialize(ix_userdata) {
+        if keyed_accounts[0].signer_key().is_none() {
+            warn!("key[0] did not sign the transaction");
+            return false;
+        }
         match instruction {
             LoaderInstruction::Write { offset, bytes } => {
                 trace!("NativeLoader::Write offset {} bytes {:?}", offset, bytes);
@@ -117,7 +121,10 @@ pub fn process_instruction(
 
             LoaderInstruction::Finalize => {
                 keyed_accounts[0].account.executable = true;
-                trace!("NativeLoader::Finalize prog: {:?}", keyed_accounts[0].key);
+                trace!(
+                    "NativeLoader::Finalize prog: {:?}",
+                    keyed_accounts[0].signer_key().unwrap()
+                );
             }
         }
     } else {

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -52,9 +52,12 @@ fn process_instruction(
         let mut keyed_accounts2: Vec<_> = tx.instructions[instruction_index]
             .accounts
             .iter()
-            .map(|&index| &tx.account_keys[index as usize])
-            .zip(program_accounts.iter_mut())
-            .map(|(key, account)| KeyedAccount { key, account })
+            .map(|&index| {
+                let index = index as usize;
+                let key = &tx.account_keys[index];
+                (key, index < tx.signatures.len())
+            }).zip(program_accounts.iter_mut())
+            .map(|((key, is_signer), account)| KeyedAccount::new(key, is_signer, account))
             .collect();
         keyed_accounts.append(&mut keyed_accounts2);
 

--- a/src/storage_program.rs
+++ b/src/storage_program.rs
@@ -42,7 +42,7 @@ pub fn process_instruction(
     _accounts: &mut [&mut Account],
 ) -> Result<(), StorageError> {
     // accounts_keys[0] must be signed
-    if tx.signed_key(pix, 0).is_none() {
+    if tx.signer_key(pix, 0).is_none() {
         Err(StorageError::InvalidArgument)?;
     }
 

--- a/src/system_program.rs
+++ b/src/system_program.rs
@@ -43,7 +43,7 @@ fn process_instruction(tx: &Transaction, pix: usize, accounts: &mut [&mut Accoun
         let from = 0;
 
         // all system instructions require that accounts_keys[0] be a signer
-        if tx.signed_key(pix, from).is_none() {
+        if tx.signer_key(pix, from).is_none() {
             Err(Error::InvalidArgument)?;
         }
 

--- a/src/vote_program.rs
+++ b/src/vote_program.rs
@@ -71,7 +71,7 @@ pub fn process_instruction(
     accounts: &mut [&mut Account],
 ) -> Result<()> {
     // all vote instructions require that accounts_keys[0] be a signer
-    if tx.signed_key(instruction_index, 0).is_none() {
+    if tx.signer_key(instruction_index, 0).is_none() {
         Err(Error::InvalidArguments)?;
     }
 


### PR DESCRIPTION
`sdk/`-based programs need a mechanism to determine the keys that signed the Transaction that they are executing instructions from.  

Rather then adding a `is_signed` boolean to `KeyedAccount`, the `Pubkey` itself is wrapped in an enum thus forcing the program to consider on every key access whether it's a signed or unsigned key.

Addresses most of #1827