### PR TITLE
re-enable test_tpu_forwarder

### DIFF
--- a/ci/test-stable.sh
+++ b/ci/test-stable.sh
@@ -13,8 +13,7 @@ _() {
 }
 
 if [[ $(ulimit -n) -lt 65000 ]]; then
-  echo 'Error: nofiles too small, run "ulimit -n 65000" to continue'
-  exit 1
+  ulimit -n 65000 || echo 'Error: nofiles too small, run "ulimit -n 65000" to continue' && exit 1
 fi
 
 _ cargo build --all --verbose

--- a/src/tpu_forwarder.rs
+++ b/src/tpu_forwarder.rs
@@ -114,7 +114,6 @@ mod tests {
     use std::time::Duration;
 
     #[test]
-    #[ignore]
     pub fn test_tpu_forwarder() {
         let nodes: Vec<_> = (0..3)
             .map(|_| {


### PR DESCRIPTION
#### Problem
 test_tpu_forwarder is ignored, but is a key part of leader rotation

 #### Summary of Changes
 un-ignore it

Fixes #