### PR TITLE
Add metrics for prune messages

### DIFF
--- a/src/cluster_info.rs
+++ b/src/cluster_info.rs
@@ -899,14 +899,13 @@ impl ClusterInfo {
                 if data.verify() {
                     inc_new_counter_info!("cluster_info-prune_message", 1);
                     inc_new_counter_info!("cluster_info-prune_message-size", data.prunes.len());
-                    let prune_res = me.write().unwrap().gossip.process_prune_msg(
+                    match prune_res = me.write().unwrap().gossip.process_prune_msg(
                         from,
                         data.destination,
                         &data.prunes,
                         data.wallclock,
                         timestamp(),
-                    );
-                    match prune_res {
+                    ) {
                         Err(CrdsGossipError::PruneMessageTimeout) => {
                             inc_new_counter_info!("cluster_info-prune_message_timeout", 1)
                         }

--- a/src/cluster_info.rs
+++ b/src/cluster_info.rs
@@ -899,7 +899,7 @@ impl ClusterInfo {
                 if data.verify() {
                     inc_new_counter_info!("cluster_info-prune_message", 1);
                     inc_new_counter_info!("cluster_info-prune_message-size", data.prunes.len());
-                    match prune_res = me.write().unwrap().gossip.process_prune_msg(
+                    match me.write().unwrap().gossip.process_prune_msg(
                         from,
                         data.destination,
                         &data.prunes,
@@ -912,6 +912,7 @@ impl ClusterInfo {
                         Err(CrdsGossipError::BadPruneDestination) => {
                             inc_new_counter_info!("cluster_info-bad_prune_destination", 1)
                         }
+                        Err(_) => (),
                         Ok(_) => (),
                     }
                 }


### PR DESCRIPTION
#### Problem
We need metrics to understand how to tune constants in live testnets.
#### Summary of Changes
Added counters for prune message errors

Fixes #
