### PR TITLE
Fix bpf-sdk docker build

### DIFF
--- a/sdk/bpf/bpf.mk
+++ b/sdk/bpf/bpf.mk
@@ -29,7 +29,7 @@ endif
 
 SYSTEM_INC_DIRS := \
   $(LOCAL_PATH)inc \
-  $(LLVM_DIR)lib/clang/8.0.0/include \
+  $(LOCAL_PATH)llvm-native/lib/clang/8.0.0/include \
 
 C_FLAGS := \
   -Werror \

--- a/sdk/bpf/bpf.mk
+++ b/sdk/bpf/bpf.mk
@@ -12,7 +12,7 @@ INC_DIRS ?=
 SRC_DIR ?= ./src
 TEST_DIR ?= ./test
 OUT_DIR ?= ./out
-OS := $(uname)
+OS := $(shell uname)
 
 ifeq ($(DOCKER),1)
 LLVM_DIR = $(LOCAL_PATH)llvm-docker/

--- a/sdk/bpf/llvm-docker/bin/clang
+++ b/sdk/bpf/llvm-docker/bin/clang
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 set -e
-WORKDIR=$( pwd )
-SDKPATH="$( cd "$(dirname "$0")" ; pwd -P )"/../../inc
-docker run --workdir /workdir --volume $WORKDIR:/workdir --volume $SDKPATH:/usr/local/include --rm solanalabs/llvm `basename "$0"` "$@"
+PROGRAM=$(basename "$0")
+SDKROOT="$(cd "$(dirname "$0")"/../..; pwd -P)"
+[[ -z $V ]] || set -x
+exec docker run \
+  --workdir "$PWD" \
+  --volume "$PWD:$PWD" \
+  --volume "$SDKROOT:$SDKROOT" \
+  --rm solanalabs/llvm \
+  "$PROGRAM" "$@"

--- a/sdk/bpf/llvm-docker/bin/clang++
+++ b/sdk/bpf/llvm-docker/bin/clang++
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 set -e
-WORKDIR=$( pwd )
-SDKPATH="$( cd "$(dirname "$0")" ; pwd -P )"/../../inc
-docker run --workdir /workdir --volume $WORKDIR:/workdir --volume $SDKPATH:/usr/local/include --rm solanalabs/llvm `basename "$0"` "$@"
+PROGRAM=$(basename "$0")
+SDKROOT="$(cd "$(dirname "$0")"/../..; pwd -P)"
+[[ -z $V ]] || set -x
+exec docker run \
+  --workdir "$PWD" \
+  --volume "$PWD:$PWD" \
+  --volume "$SDKROOT:$SDKROOT" \
+  --rm solanalabs/llvm \
+  "$PROGRAM" "$@"

--- a/sdk/bpf/llvm-docker/bin/llc
+++ b/sdk/bpf/llvm-docker/bin/llc
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 set -e
-WORKDIR=$( pwd )
-SDKPATH="$( cd "$(dirname "$0")" ; pwd -P )"/../../inc
-docker run --workdir /workdir --volume $WORKDIR:/workdir --volume $SDKPATH:/usr/local/include --rm solanalabs/llvm `basename "$0"` "$@"
+PROGRAM=$(basename "$0")
+SDKROOT="$(cd "$(dirname "$0")"/../..; pwd -P)"
+[[ -z $V ]] || set -x
+exec docker run \
+  --workdir "$PWD" \
+  --volume "$PWD:$PWD" \
+  --volume "$SDKROOT:$SDKROOT" \
+  --rm solanalabs/llvm \
+  "$PROGRAM" "$@"

--- a/sdk/bpf/llvm-docker/bin/llvm-objdump
+++ b/sdk/bpf/llvm-docker/bin/llvm-objdump
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 set -e
-WORKDIR=$( pwd )
-SDKPATH="$( cd "$(dirname "$0")" ; pwd -P )"/../../inc
-docker run --workdir /workdir --volume $WORKDIR:/workdir --volume $SDKPATH:/usr/local/include --rm solanalabs/llvm `basename "$0"` "$@"
+PROGRAM=$(basename "$0")
+SDKROOT="$(cd "$(dirname "$0")"/../..; pwd -P)"
+[[ -z $V ]] || set -x
+exec docker run \
+  --workdir "$PWD" \
+  --volume "$PWD:$PWD" \
+  --volume "$SDKROOT:$SDKROOT" \
+  --rm solanalabs/llvm \
+  "$PROGRAM" "$@"

--- a/sdk/bpf/llvm-docker/generate.sh
+++ b/sdk/bpf/llvm-docker/generate.sh
@@ -3,12 +3,17 @@
 read -r -d '' SCRIPT << 'EOM'
 #!/usr/bin/env bash
 set -e
-WORKDIR=$( pwd )
-SDKPATH="$( cd "$(dirname "$0")" ; pwd -P )"/../../inc
-docker run --workdir /workdir --volume $WORKDIR:/workdir --volume $SDKPATH:/usr/local/include --rm solanalabs/llvm `basename "$0"` "$@"
+PROGRAM=$(basename "$0")
+SDKROOT="$(cd "$(dirname "$0")"/../..; pwd -P)"
+[[ -z $V ]] || set -x
+exec docker run \
+  --workdir "$PWD" \
+  --volume "$PWD:$PWD" \
+  --volume "$SDKROOT:$SDKROOT" \
+  --rm solanalabs/llvm \
+  "$PROGRAM" "$@"
 EOM
 
-echo "$SCRIPT" > bin/clang
-echo "$SCRIPT" > bin/clang++
-echo "$SCRIPT" > bin/llc
-echo "$SCRIPT" > bin/llvm-objdump
+for program in clang clang++ llc llvm-objdump; do
+  echo "$SCRIPT" > bin/$program
+done


### PR DESCRIPTION
The main change here is to map the bpf-sdk and source files to the same location within the llvm docker container, so that paths that were constructed outside of the docker container remain valid within the container.

Fixes #1985
Also requires https://github.com/solana-labs/llvm-builder/pull/2

