### PR TITLE
Initial vote signing service implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1909,7 +1909,6 @@ dependencies = [
 name = "solana-vote-signer"
 version = "0.0.1"
 dependencies = [
- "bs58 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-jsonrpc-core 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1909,8 +1909,10 @@ dependencies = [
 name = "solana-vote-signer"
 version = "0.0.1"
 dependencies = [
+ "bs58 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-jsonrpc-core 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-jsonrpc-http-server 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-jsonrpc-macros 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/vote-signer/Cargo.toml
+++ b/vote-signer/Cargo.toml
@@ -7,7 +7,6 @@ repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 
 [dependencies]
-bs58 = "0.2.0"
 clap = "2.31"
 log = "0.4.2"
 solana-sdk = { path = "../sdk", version = "0.11.0" }

--- a/vote-signer/Cargo.toml
+++ b/vote-signer/Cargo.toml
@@ -7,8 +7,10 @@ repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 
 [dependencies]
+bs58 = "0.2.0"
 clap = "2.31"
 log = "0.4.2"
+serde_json = "1.0.10"
 solana-sdk = { path = "../sdk", version = "0.11.0" }
 solana-metrics = { path = "../metrics", version = "0.11.0" }
 solana-jsonrpc-core = "0.3.0"

--- a/vote-signer/src/lib.rs
+++ b/vote-signer/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod rpc;
 
+extern crate bs58;
 #[macro_use]
 extern crate log;
 extern crate solana_jsonrpc_core as jsonrpc_core;
@@ -7,3 +8,6 @@ extern crate solana_jsonrpc_http_server as jsonrpc_http_server;
 extern crate solana_sdk;
 #[macro_use]
 extern crate solana_jsonrpc_macros as jsonrpc_macros;
+#[cfg(test)]
+#[macro_use]
+extern crate serde_json;

--- a/vote-signer/src/lib.rs
+++ b/vote-signer/src/lib.rs
@@ -1,6 +1,5 @@
 pub mod rpc;
 
-extern crate bs58;
 #[macro_use]
 extern crate log;
 extern crate solana_jsonrpc_core as jsonrpc_core;

--- a/vote-signer/src/rpc.rs
+++ b/vote-signer/src/rpc.rs
@@ -232,7 +232,6 @@ mod tests {
 
         if let Response::Single(out) = result {
             if let Output::Success(succ) = out {
-                println!("success: {:?}", succ);
                 assert_eq!(succ.jsonrpc.unwrap(), Version::V2);
                 assert_eq!(succ.id, Id::Num(1));
                 assert!(succ.result.is_array());
@@ -240,6 +239,38 @@ mod tests {
                     succ.result.as_array().unwrap().len(),
                     mem::size_of::<Pubkey>()
                 );
+            } else {
+                assert!(false);
+            }
+        } else {
+            assert!(false);
+        }
+    }
+
+    #[test]
+    fn test_rpc_register_node_invalid_sig() {
+        let (io, meta) = start_rpc_handler();
+
+        let node_keypair = Keypair::new();
+        let node_pubkey = node_keypair.pubkey();
+        let msg = "This is a test";
+        let msg1 = "This is a Test1";
+        let sig = Signature::new(&node_keypair.sign(msg.as_bytes()).as_ref());
+        let req = json!({
+           "jsonrpc": "2.0",
+           "id": 1,
+           "method": "registerNode",
+           "params": [node_pubkey.to_string(), sig, msg1.as_bytes()],
+        });
+        let res = io.handle_request_sync(&req.to_string(), meta);
+
+        let result: Response = serde_json::from_str(&res.expect("actual response"))
+            .expect("actual response deserialization");
+
+        if let Response::Single(out) = result {
+            if let Output::Failure(succ) = out {
+                assert_eq!(succ.jsonrpc.unwrap(), Version::V2);
+                assert_eq!(succ.id, Id::Num(1));
             } else {
                 assert!(false);
             }
@@ -269,7 +300,38 @@ mod tests {
 
         if let Response::Single(out) = result {
             if let Output::Success(succ) = out {
-                println!("success: {:?}", succ);
+                assert_eq!(succ.jsonrpc.unwrap(), Version::V2);
+                assert_eq!(succ.id, Id::Num(1));
+            } else {
+                assert!(false);
+            }
+        } else {
+            assert!(false);
+        }
+    }
+
+    #[test]
+    fn test_rpc_deregister_node_invalid_sig() {
+        let (io, meta) = start_rpc_handler();
+
+        let node_keypair = Keypair::new();
+        let node_pubkey = node_keypair.pubkey();
+        let msg = "This is a test";
+        let msg1 = "This is a Test1";
+        let sig = Signature::new(&node_keypair.sign(msg.as_bytes()).as_ref());
+        let req = json!({
+           "jsonrpc": "2.0",
+           "id": 1,
+           "method": "deregisterNode",
+           "params": [node_pubkey.to_string(), sig, msg1.as_bytes()],
+        });
+        let res = io.handle_request_sync(&req.to_string(), meta);
+
+        let result: Response = serde_json::from_str(&res.expect("actual response"))
+            .expect("actual response deserialization");
+
+        if let Response::Single(out) = result {
+            if let Output::Failure(succ) = out {
                 assert_eq!(succ.jsonrpc.unwrap(), Version::V2);
                 assert_eq!(succ.id, Id::Num(1));
             } else {

--- a/vote-signer/src/rpc.rs
+++ b/vote-signer/src/rpc.rs
@@ -97,9 +97,10 @@ impl VoteSignerRpc for VoteSignerRpcImpl {
         signed_msg: Vec<u8>,
     ) -> Result<Pubkey> {
         info!("register rpc request received: {:?}", id);
-        match sig.verify(id.as_ref(), signed_msg.as_ref()) {
-            true => meta.request_processor.register(id),
-            false => Err(Error::invalid_request()),
+        if sig.verify(id.as_ref(), signed_msg.as_ref()) {
+            meta.request_processor.register(id)
+        } else {
+            Err(Error::invalid_request())
         }
     }
 
@@ -111,9 +112,10 @@ impl VoteSignerRpc for VoteSignerRpcImpl {
         signed_msg: Vec<u8>,
     ) -> Result<Signature> {
         info!("sign rpc request received: {:?}", id);
-        match sig.verify(id.as_ref(), signed_msg.as_ref()) {
-            true => meta.request_processor.sign(id, signed_msg),
-            false => Err(Error::invalid_request()),
+        if sig.verify(id.as_ref(), signed_msg.as_ref()) {
+            meta.request_processor.sign(id, &signed_msg)
+        } else {
+            Err(Error::invalid_request())
         }
     }
 
@@ -125,9 +127,10 @@ impl VoteSignerRpc for VoteSignerRpcImpl {
         signed_msg: Vec<u8>,
     ) -> Result<()> {
         info!("deregister rpc request received: {:?}", id);
-        match sig.verify(id.as_ref(), signed_msg.as_ref()) {
-            true => meta.request_processor.deregister(id),
-            false => Err(Error::invalid_request()),
+        if sig.verify(id.as_ref(), signed_msg.as_ref()) {
+            meta.request_processor.deregister(id)
+        } else {
+            Err(Error::invalid_request())
         }
     }
 }
@@ -149,7 +152,7 @@ impl VoteSignRequestProcessor {
             }
         }
     }
-    pub fn sign(&self, pubkey: Pubkey, msg: Vec<u8>) -> Result<Signature> {
+    pub fn sign(&self, pubkey: Pubkey, msg: &[u8]) -> Result<Signature> {
         match self.nodes.read().unwrap().get(&pubkey) {
             Some(voting_keypair) => {
                 let sig = Signature::new(&voting_keypair.sign(&msg).as_ref());


### PR DESCRIPTION
#### Problem
Extract vote signing functionality to a separate daemon

#### Summary of Changes
Validator nodes can register/deregister with vote signing service. The nodes can use the service to sign their votes.

Reference: https://github.com/solana-labs/solana/blob/master/rfcs/0009-enclave.md

Fixes #1975 #1950 
