### PR TITLE
localnet-sanity.sh: Ensure subshell failures are reported

### DIFF
--- a/ci/localnet-sanity.sh
+++ b/ci/localnet-sanity.sh
@@ -73,8 +73,12 @@ echo "--- Node count"
   source multinode-demo/common.sh
   set -x
   client_id=/tmp/client-id.json-$$
-  $solana_keygen -o $client_id
-  $solana_bench_tps --identity $client_id --num-nodes 3 --reject-extra-nodes --converge-only
+  $solana_keygen -o $client_id || exit $?
+  $solana_bench_tps \
+    --identity $client_id \
+    --num-nodes 3 \
+    --reject-extra-nodes \
+    --converge-only || exit $?
   rm -rf $client_id
 ) || flag_error
 
@@ -85,7 +89,7 @@ echo "--- Ledger verification"
   source multinode-demo/common.sh
   set -x
   cp -R "$SOLANA_CONFIG_DIR"/ledger /tmp/ledger-$$
-  $solana_ledger_tool --ledger /tmp/ledger-$$ verify
+  $solana_ledger_tool --ledger /tmp/ledger-$$ verify || exit $?
   rm -rf /tmp/ledger-$$
 ) || flag_error
 


### PR DESCRIPTION
This bash construct results in `this_should_never_run` getting run for some reason (hey bash gurus, why?!)
```bash
#!/usr/bin/env bash                                                                                                                                                                     
(
  set -e
  invalid_command && \
  this_should_never_run  #<- why does `|| echo subshell failed` below affect `set -e` above?                                                                                            
) || echo subshell fail: $?
```

`localnet-sanity.sh` was using this construct, which could cause sanity failures to go unreported.  The workaround is to add more bash to manually exit the subshell
