### PR TITLE
remote-sanity.sh: Properly check for failure (can't rely on `set -e` here)

### DIFF
--- a/net/remote/remote-sanity.sh
+++ b/net/remote/remote-sanity.sh
@@ -137,8 +137,8 @@ fi
 echo "--- $entrypointIp: validator sanity"
 if $validatorSanity; then
   (
-    set -ex -o pipefail
-    ./multinode-demo/setup.sh -t validator
+    set -x -o pipefail
+    ./multinode-demo/setup.sh -t validator || exit $?
     timeout 10s ./multinode-demo/validator.sh "$entrypointRsyncUrl" "$entrypointIp:8001" 2>&1 | tee validator.log
   ) || {
     exitcode=$?


### PR DESCRIPTION
cc: #2013

The rest of our `set -e` usage in the tree appears clean.  Probably should try to avoid `set -e` in the future though, the list of caveats is too long for most mere morals to manage.