### PR TITLE
net/: Leader rotation flag plumbing

### DIFF
--- a/ci/testnet-deploy.sh
+++ b/ci/testnet-deploy.sh
@@ -13,6 +13,7 @@ snapChannel=edge
 tarChannelOrTag=edge
 delete=false
 enableGpu=false
+leaderRotation=true
 useTarReleaseChannel=false
 
 usage() {
@@ -42,6 +43,7 @@ Deploys a CD testnet
    -P                   - Use public network IP addresses (default: $publicNetwork)
    -G                   - Enable GPU, and set count/type of GPUs to use (e.g n1-standard-16 --accelerator count=4,type=nvidia-tesla-k80)
    -g                   - Enable GPU (default: $enableGpu)
+   -b                   - Disable leader rotation
    -a [address]         - Set the bootstrap fullnode's external IP address to this GCE address
    -d                   - Delete the network
 
@@ -59,7 +61,7 @@ zone=$3
 [[ -n $zone ]] || usage "Zone not specified"
 shift 3
 
-while getopts "h?p:Pn:c:s:t:gG:a:d" opt; do
+while getopts "h?p:Pn:c:s:t:gG:a:db" opt; do
   case $opt in
   h | \?)
     usage
@@ -93,6 +95,9 @@ while getopts "h?p:Pn:c:s:t:gG:a:d" opt; do
       usage "Invalid release channel: $OPTARG"
       ;;
     esac
+    ;;
+  b)
+    leaderRotation=false
     ;;
   g)
     enableGpu=true
@@ -128,6 +133,10 @@ if $enableGpu; then
   else
     create_args+=(-G "$bootstrapFullNodeMachineType")
   fi
+fi
+
+if ! $leaderRotation; then
+  create_args+=(-b)
 fi
 
 if $publicNetwork; then

--- a/ci/testnet-manager.sh
+++ b/ci/testnet-manager.sh
@@ -203,6 +203,7 @@ start() {
       export NO_VALIDATOR_SANITY=1
       ci/testnet-deploy.sh edge-testnet-solana-com ec2 us-west-1a \
         -s "$CHANNEL_OR_TAG" -n 3 -c 0 -P -a eipalloc-0ccd4f2239886fa94 \
+        -b \
         ${maybeDelete:+-d}
     )
     ;;
@@ -215,6 +216,7 @@ start() {
       export NO_VALIDATOR_SANITY=1
       ci/testnet-deploy.sh edge-perf-testnet-solana-com ec2 us-west-2b \
         -g -t "$CHANNEL_OR_TAG" -c 2 \
+        -b \
         ${maybeDelete:+-d}
     )
     ;;
@@ -227,6 +229,7 @@ start() {
       export NO_VALIDATOR_SANITY=1
       ci/testnet-deploy.sh beta-testnet-solana-com ec2 us-west-1a \
         -t "$CHANNEL_OR_TAG" -n 3 -c 0 -P -a eipalloc-0f286cf8a0771ce35 \
+        -b \
         ${maybeDelete:+-d}
     )
     ;;
@@ -239,6 +242,7 @@ start() {
       export NO_VALIDATOR_SANITY=1
       ci/testnet-deploy.sh beta-perf-testnet-solana-com ec2 us-west-2b \
         -g -t "$CHANNEL_OR_TAG" -c 2 \
+        -b \
         ${maybeDelete:+-d}
     )
     ;;
@@ -254,6 +258,7 @@ start() {
       #  ${maybeDelete:+-d}
       ci/testnet-deploy.sh testnet-solana-com ec2 us-west-1a \
         -t "$CHANNEL_OR_TAG" -n 3 -c 0 -P -a eipalloc-0fa502bf95f6f18b2 \
+        -b \
         ${maybeDelete:+-d}
     )
     ;;
@@ -267,6 +272,7 @@ start() {
       ci/testnet-deploy.sh perf-testnet-solana-com gce us-west1-b \
         -G "n1-standard-16 --accelerator count=2,type=nvidia-tesla-v100" \
         -t "$CHANNEL_OR_TAG" -c 2 \
+        -b \
         ${maybeDelete:+-d}
       #ci/testnet-deploy.sh perf-testnet-solana-com ec2 us-east-1a \
       #  -g \

--- a/multinode-demo/bootstrap-leader.sh
+++ b/multinode-demo/bootstrap-leader.sh
@@ -29,11 +29,28 @@ else
   program="$solana_fullnode"
 fi
 
+maybe_no_leader_rotation=
+if [[ $1 = --no-leader-rotation ]]; then
+  maybe_no_leader_rotation="--no-leader-rotation"
+  shift
+fi
+
+if [[ -n $1 ]]; then
+  echo "Unknown argument: $1"
+  exit 1
+fi
+
+if [[ -d $SNAP ]]; then
+  if [[ $(snapctl get leader-rotation) = false ]]; then
+    maybe_no_leader_rotation="--no-leader-rotation"
+  fi
+fi
+
 tune_networking
 
 trap 'kill "$pid" && wait "$pid"' INT TERM
 $program \
-  --no-leader-rotation \
+  $maybe_no_leader_rotation \
   --identity "$SOLANA_CONFIG_DIR"/bootstrap-leader.json \
   --ledger "$SOLANA_CONFIG_DIR"/bootstrap-leader-ledger \
   --rpc 8899 \

--- a/net/common.sh
+++ b/net/common.sh
@@ -29,6 +29,7 @@ fullnodeIpList=()
 fullnodeIpListPrivate=()
 clientIpList=()
 clientIpListPrivate=()
+leaderRotation=
 
 buildSshOptions() {
   sshOptions=(
@@ -50,6 +51,7 @@ loadConfigFile() {
   [[ -n "$publicNetwork" ]] || usage "Config file invalid, publicNetwork unspecified: $configFile"
   [[ -n "$netBasename" ]] || usage "Config file invalid, netBasename unspecified: $configFile"
   [[ -n $sshPrivateKey ]] || usage "Config file invalid, sshPrivateKey unspecified: $configFile"
+  [[ -n $leaderRotation ]] || usage "Config file invalid, leaderRotation unspecified: $configFile"
   [[ ${#fullnodeIpList[@]} -gt 0 ]] || usage "Config file invalid, fullnodeIpList unspecified: $configFile"
   [[ ${#fullnodeIpListPrivate[@]} -gt 0 ]] || usage "Config file invalid, fullnodeIpListPrivate unspecified: $configFile"
 

--- a/net/net.sh
+++ b/net/net.sh
@@ -197,6 +197,7 @@ startBootstrapLeader() {
          ${#fullnodeIpList[@]} \
          \"$RUST_LOG\" \
          $skipSetup \
+         $leaderRotation \
       "
   ) >> "$logFile" 2>&1 || {
     cat "$logFile"
@@ -223,6 +224,7 @@ startNode() {
          ${#fullnodeIpList[@]} \
          \"$RUST_LOG\" \
          $skipSetup \
+         $leaderRotation \
       "
   ) >> "$logFile" 2>&1 &
   declare pid=$!

--- a/net/remote/remote-sanity.sh
+++ b/net/remote/remote-sanity.sh
@@ -22,9 +22,10 @@ missing() {
   exit 1
 }
 
-[[ -n $deployMethod ]] || missing deployMethod
-[[ -n $entrypointIp ]] || missing entrypointIp
-[[ -n $numNodes ]]     || missing numNodes
+[[ -n $deployMethod ]]   || missing deployMethod
+[[ -n $entrypointIp ]]   || missing entrypointIp
+[[ -n $numNodes ]]       || missing numNodes
+[[ -n $leaderRotation ]] || missing leaderRotation
 
 ledgerVerify=true
 validatorSanity=true


### PR DESCRIPTION
Leader rotation is now enabled by default for locally created networks, either via the `multinode-demo/` scripts directly or `net/`.

To disable leader rotation locally:
```
$ ./net/gce.sh create -b ...
```
or
```
$ ./multinode-demo/leader.sh --no-leader-rotation
$ ./multinode-demo/validator.sh --no-leader-rotation
```

Automated testnets have leader rotation explicitly disabled for now until it's ready.

cc: #2016