### PR TITLE
Update versions in install-libssl-compatibility.sh

### DIFF
--- a/net/scripts/install-libssl-compatability.sh
+++ b/net/scripts/install-libssl-compatability.sh
@@ -13,7 +13,6 @@ apt-get --assume-yes install libssl-dev
 #
 # cc: https://github.com/solana-labs/solana/issues/1090
 # cc: https://packages.ubuntu.com/bionic/amd64/libssl1.1/download
-wget http://security.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.0g-2ubuntu4.1_amd64.deb
-dpkg -i libssl1.1_1.1.0g-2ubuntu4.1_amd64.deb
-rm libssl1.1_1.1.0g-2ubuntu4.1_amd64.deb
-
+wget http://security.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.0g-2ubuntu4.3_amd64.deb
+dpkg -i libssl1.1_1.1.0g-2ubuntu4.3_amd64.deb
+rm libssl1.1_1.1.0g-2ubuntu4.3_amd64.deb


### PR DESCRIPTION
#### Problem
Bootstrap node was failing to install libssl on startup due to dependency errors

#### Summary of Changes
Bump versions of needed dependencies

Fixes #
