### PR TITLE
bench-tps will now generate an ephemeral identity if not provided with one

### DIFF
--- a/multinode-demo/client.sh
+++ b/multinode-demo/client.sh
@@ -20,10 +20,7 @@ usage() {
 }
 
 if [[ -z $1 ]]; then # default behavior
-  mkdir -p config-client/
-  $solana_keygen -o config-client/client-id.json
   $solana_bench_tps \
-    --identity config-client/client-id.json \
     --network 127.0.0.1:8001 \
     --drone 127.0.0.1:9900 \
     --duration 90 \

--- a/multinode-demo/common.sh
+++ b/multinode-demo/common.sh
@@ -133,5 +133,4 @@ tune_networking() {
 SOLANA_CONFIG_DIR=${SNAP_DATA:-$PWD}/config
 SOLANA_CONFIG_PRIVATE_DIR=${SNAP_DATA:-$PWD}/config-private
 SOLANA_CONFIG_VALIDATOR_DIR=${SNAP_DATA:-$PWD}/config-validator
-SOLANA_CONFIG_CLIENT_DIR=${SNAP_USER_DATA:-$PWD}/config-client
 

--- a/net/remote/remote-client.sh
+++ b/net/remote/remote-client.sh
@@ -32,7 +32,6 @@ snap)
   sudo snap install solana.snap --devmode --dangerous
 
   solana_bench_tps=/snap/bin/solana.bench-tps
-  solana_keygen=/snap/bin/solana.keygen
   ;;
 local|tar)
   PATH="$HOME"/.cargo/bin:"$PATH"
@@ -44,7 +43,6 @@ local|tar)
 
   net/scripts/rsync-retry.sh -vPrc "$entrypointIp:~/.cargo/bin/solana*" ~/.cargo/bin/
   solana_bench_tps=solana-bench-tps
-  solana_keygen=solana-keygen
   ;;
 *)
   echo "Unknown deployment method: $deployMethod"
@@ -60,19 +58,12 @@ clientCommand="\
   $solana_bench_tps \
     --network $entrypointIp:8001 \
     --drone $entrypointIp:9900 \
-    --identity client.json \
     --duration 7500 \
     --sustained \
     --threads $threadCount \
 "
 
-keygenCommand="$solana_keygen -o client.json"
 tmux new -s solana-bench-tps -d "
-  [[ -r client.json ]] || {
-    echo '$ $keygenCommand'  | tee -a client.log
-    $keygenCommand >> client.log 2>&1
-  }
-
   while true; do
     echo === Client start: \$(date) | tee -a client.log
     $metricsWriteDatapoint 'testnet-deploy client-begin=1'

--- a/src/bin/bench-tps.rs
+++ b/src/bin/bench-tps.rs
@@ -539,7 +539,6 @@ fn main() {
                 .long("identity")
                 .value_name("PATH")
                 .takes_value(true)
-                .required(true)
                 .help("File containing a client identity (keypair)"),
         )
         .arg(
@@ -609,8 +608,11 @@ fn main() {
         addr
     };
 
-    let id =
-        read_keypair(matches.value_of("identity").unwrap()).expect("can't read client identity");
+    let id = if matches.is_present("identity") {
+        read_keypair(matches.value_of("identity").unwrap()).expect("can't read client identity")
+    } else {
+        Keypair::new()
+    };
 
     let threads = if let Some(t) = matches.value_of("threads") {
         t.to_string().parse().expect("can't parse threads")


### PR DESCRIPTION
Also simplify scripts as a result