### PR TITLE
Pass arbitrary data between instructions with native interpreters

### DIFF
--- a/programs/native/budget/src/lib.rs
+++ b/programs/native/budget/src/lib.rs
@@ -21,16 +21,18 @@ solana_entrypoint!(entrypoint);
 fn entrypoint(
     _program_id: &Pubkey,
     keyed_accounts: &mut [KeyedAccount],
-    data: &[u8],
+    argdata: &[u8],
+    _input: &[u8],
     _tick_height: u64,
-) -> Result<(), ProgramError> {
+) -> Result<Vec<u8>, ProgramError> {
     static INIT: Once = ONCE_INIT;
     INIT.call_once(|| {
         // env_logger can only be initialized once
         env_logger::init();
     });
 
-    trace!("process_instruction: {:?}", data);
+    trace!("process_instruction: {:?}", argdata);
     trace!("keyed_accounts: {:?}", keyed_accounts);
-    process_instruction(keyed_accounts, data).map_err(|_| ProgramError::GenericError)
+    process_instruction(keyed_accounts, argdata).map_err(|_| ProgramError::GenericError)?;
+    Ok(vec![])
 }

--- a/programs/native/erc20/src/lib.rs
+++ b/programs/native/erc20/src/lib.rs
@@ -21,15 +21,17 @@ solana_entrypoint!(entrypoint);
 fn entrypoint(
     program_id: &Pubkey,
     info: &mut [KeyedAccount],
-    input: &[u8],
+    argdata: &[u8],
+    _input: &[u8],
     _tick_height: u64,
-) -> Result<(), ProgramError> {
+) -> Result<Vec<u8>, ProgramError> {
     // env_logger can only be initialized once
     static INIT: Once = ONCE_INIT;
     INIT.call_once(env_logger::init);
 
-    token_program::TokenProgram::process(program_id, info, input).map_err(|err| {
+    token_program::TokenProgram::process(program_id, info, argdata).map_err(|err| {
         error!("error: {:?}", err);
         ProgramError::GenericError
-    })
+    })?;
+    Ok(vec![])
 }

--- a/programs/native/native_loader/src/lib.rs
+++ b/programs/native/native_loader/src/lib.rs
@@ -56,9 +56,10 @@ pub fn check_id(program_id: &Pubkey) -> bool {
 pub fn entrypoint(
     program_id: &Pubkey,
     keyed_accounts: &mut [KeyedAccount],
-    ix_userdata: &[u8],
+    argdata: &[u8],
+    input: &[u8],
     tick_height: u64,
-) -> Result<(), ProgramError> {
+) -> Result<Vec<u8>, ProgramError> {
     if keyed_accounts[0].account.executable {
         // dispatch it
         let name = keyed_accounts[0].account.userdata.clone();
@@ -89,7 +90,8 @@ pub fn entrypoint(
                 return entrypoint(
                     program_id,
                     &mut keyed_accounts[1..],
-                    ix_userdata,
+                    argdata,
+                    input,
                     tick_height,
                 );
             },
@@ -98,7 +100,7 @@ pub fn entrypoint(
                 return Err(ProgramError::GenericError);
             }
         }
-    } else if let Ok(instruction) = deserialize(ix_userdata) {
+    } else if let Ok(instruction) = deserialize(argdata) {
         if keyed_accounts[0].signer_key().is_none() {
             warn!("key[0] did not sign the transaction");
             return Err(ProgramError::GenericError);
@@ -128,8 +130,8 @@ pub fn entrypoint(
             }
         }
     } else {
-        warn!("Invalid userdata in instruction: {:?}", ix_userdata);
-        return Err(ProgramError::GenericError);
+        warn!("Invalid instruction argdata: {:?}", argdata);
+        return Err(ProgramError::InvalidArgumentsData);
     }
-    Ok(())
+    Ok(vec![])
 }

--- a/programs/native/noop/src/lib.rs
+++ b/programs/native/noop/src/lib.rs
@@ -9,12 +9,14 @@ solana_entrypoint!(entrypoint);
 fn entrypoint(
     program_id: &Pubkey,
     keyed_accounts: &mut [KeyedAccount],
-    data: &[u8],
+    argdata: &[u8],
+    input: &[u8],
     tick_height: u64,
-) -> Result<(), ProgramError> {
+) -> Result<Vec<u8>, ProgramError> {
     println!("noop: program_id: {:?}", program_id);
     println!("noop: keyed_accounts: {:#?}", keyed_accounts);
-    println!("noop: data: {:?}", data);
+    println!("noop: argdata: {:?}", argdata);
+    println!("noop: input: {:?}", input);
     println!("noop: tick_height: {:?}", tick_height);
-    Ok(())
+    Ok(vec![])
 }

--- a/programs/native/storage/src/lib.rs
+++ b/programs/native/storage/src/lib.rs
@@ -20,9 +20,10 @@ solana_entrypoint!(entrypoint);
 fn entrypoint(
     _program_id: &Pubkey,
     keyed_accounts: &mut [KeyedAccount],
-    data: &[u8],
+    argdata: &[u8],
+    _input: &[u8],
     _tick_height: u64,
-) -> Result<(), ProgramError> {
+) -> Result<Vec<u8>, ProgramError> {
     static INIT: Once = ONCE_INIT;
     INIT.call_once(|| {
         // env_logger can only be initialized once
@@ -35,16 +36,16 @@ fn entrypoint(
         Err(ProgramError::InvalidArgument)?;
     }
 
-    if let Ok(syscall) = deserialize(data) {
+    if let Ok(syscall) = deserialize(argdata) {
         match syscall {
             StorageProgram::SubmitMiningProof { sha_state } => {
                 info!("Mining proof submitted with state {:?}", sha_state);
             }
         }
-        Ok(())
+        Ok(vec![])
     } else {
-        info!("Invalid instruction userdata: {:?}", data);
-        Err(ProgramError::InvalidUserdata)
+        info!("Invalid instruction argdata: {:?}", argdata);
+        Err(ProgramError::InvalidArgumentsData)
     }
 }
 

--- a/programs/native/system/src/lib.rs
+++ b/programs/native/system/src/lib.rs
@@ -15,10 +15,11 @@ solana_entrypoint!(entrypoint);
 pub fn entrypoint(
     _program_id: &Pubkey,
     keyed_accounts: &mut [KeyedAccount],
-    data: &[u8],
+    argdata: &[u8],
+    _input: &[u8],
     _tick_height: u64,
-) -> Result<(), ProgramError> {
-    if let Ok(syscall) = deserialize(data) {
+) -> Result<Vec<u8>, ProgramError> {
+    if let Ok(syscall) = deserialize(argdata) {
         trace!("process_instruction: {:?}", syscall);
         trace!("keyed_accounts: {:?}", keyed_accounts);
         let from = 0;
@@ -96,9 +97,9 @@ pub fn entrypoint(
                 keyed_accounts[from].account.owner = *keyed_accounts[from].signer_key().unwrap();
             }
         }
-        Ok(())
+        Ok(vec![])
     } else {
-        info!("Invalid transaction instruction userdata: {:?}", data);
-        Err(ProgramError::InvalidArgument)
+        info!("Invalid instruction argdata: {:?}", argdata);
+        Err(ProgramError::InvalidArgumentsData)
     }
 }

--- a/sdk/src/native_program.rs
+++ b/sdk/src/native_program.rs
@@ -11,6 +11,9 @@ pub enum ProgramError {
     /// The arguments provided to a program instruction where invalid
     InvalidArgument,
 
+    /// The arguments data provided to a program instruction was invalid
+    InvalidArgumentsData,
+
     /// An instruction resulted in an account with a negative balance
     /// The difference from InsufficientFundsForFee is that the transaction was executed by the
     /// contract
@@ -53,9 +56,10 @@ pub const ENTRYPOINT: &str = "process";
 pub type Entrypoint = unsafe extern "C" fn(
     program_id: &Pubkey,
     keyed_accounts: &mut [KeyedAccount],
-    data: &[u8],
+    argdata: &[u8],
+    input: &[u8],
     tick_height: u64,
-) -> Result<(), ProgramError>;
+) -> Result<Vec<u8>, ProgramError>;
 
 // Convenience macro to define the native program entrypoint.  Supply a fn to this macro that
 // conforms to the `Entrypoint` type signature.
@@ -66,10 +70,11 @@ macro_rules! solana_entrypoint(
         pub extern "C" fn process(
             program_id: &Pubkey,
             keyed_accounts: &mut [KeyedAccount],
-            data: &[u8],
+            argdata: &[u8],
+            input: &[u8],
             tick_height: u64
-        ) -> Result<(), ProgramError> {
-            $entrypoint(program_id, keyed_accounts, data, tick_height)
+        ) -> Result<Vec<u8>, ProgramError> {
+            $entrypoint(program_id, keyed_accounts, argdata, input, tick_height)
         }
     )
 );

--- a/sdk/src/transaction.rs
+++ b/sdk/src/transaction.rs
@@ -13,6 +13,9 @@ pub const SIG_OFFSET: usize = size_of::<u64>();
 /// specified accounts and userdata
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub struct Instruction {
+    /// True if the runtime should pass the output of the previous instruction to this one.
+    pub accept_input: bool,
+
     /// The program code that executes this transaction is identified by the program_id.
     /// this is an offset into the Transaction::program_ids field
     pub program_ids_index: u8,
@@ -26,6 +29,7 @@ impl Instruction {
     pub fn new<T: Serialize>(program_ids_index: u8, userdata: &T, accounts: Vec<u8>) -> Self {
         let userdata = serialize(userdata).unwrap();
         Instruction {
+            accept_input: false,
             program_ids_index,
             userdata,
             accounts,

--- a/src/bank.rs
+++ b/src/bank.rs
@@ -1507,11 +1507,13 @@ mod tests {
         let spend = SystemInstruction::Move { tokens: 1 };
         let instructions = vec![
             Instruction {
+                accept_input: false,
                 program_ids_index: 0,
                 userdata: serialize(&spend).unwrap(),
                 accounts: vec![0, 1],
             },
             Instruction {
+                accept_input: false,
                 program_ids_index: 0,
                 userdata: serialize(&spend).unwrap(),
                 accounts: vec![0, 2],

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -45,6 +45,12 @@ fn process_instruction(
         native_loader::entrypoint
     };
 
+    let input = if tx.instructions[instruction_index].accept_input {
+        input
+    } else {
+        &[]
+    };
+
     entrypoint(
         &program_id,
         &mut keyed_accounts,


### PR DESCRIPTION
#### Problem

Using accounts to pass data between instructions is clunky and requires tokens

#### Summary of Changes

A peek at what it would look like if instructions could return data and that data was passed into the following instruction by default.

Connecting outputs to inputs by default is looking like a pretty bad idea.  Imagine in bash if every time you used `&&`, it worked like a pipe. The stdout of the previous program might be complete nonsense to the next program, which optionally accepts stdin.

Likewise, it breaks the property that two transactions each with one instruction is equivalent to 1 transaction with both instructions.

For this to work, I think we'd need a `SystemInstruction::Bind` that replaces two instructions with one that executes the first and pipes its input to the next.

Fixes #2005
