### PR TITLE
Update airdrop tokens to 3 for fullnode

### DIFF
--- a/benches/banking_stage.rs
+++ b/benches/banking_stage.rs
@@ -15,7 +15,7 @@ use solana::mint::Mint;
 use solana::packet::to_packets_chunked;
 use solana_sdk::hash::hash;
 use solana_sdk::pubkey::Pubkey;
-use solana_sdk::signature::{KeypairUtil, Signature};
+use solana_sdk::signature::{Keypair, KeypairUtil, Signature};
 use solana_sdk::system_transaction::SystemTransaction;
 use solana_sdk::transaction::Transaction;
 use std::iter;
@@ -50,6 +50,7 @@ fn bench_banking_stage_multi_accounts(bencher: &mut Bencher) {
 
     let (verified_sender, verified_receiver) = channel();
     let bank = Arc::new(Bank::new(&mint));
+    let dummy_leader_id = Keypair::new().pubkey();
     let dummy = Transaction::system_move(
         &mint.keypair(),
         mint.keypair().pubkey(),
@@ -107,6 +108,7 @@ fn bench_banking_stage_multi_accounts(bencher: &mut Bencher) {
         Default::default(),
         &mint.last_id(),
         None,
+        dummy_leader_id,
     );
 
     let mut id = mint.last_id();
@@ -137,6 +139,7 @@ fn bench_banking_stage_multi_programs(bencher: &mut Bencher) {
 
     let (verified_sender, verified_receiver) = channel();
     let bank = Arc::new(Bank::new(&mint));
+    let dummy_leader_id = Keypair::new().pubkey();
     let dummy = Transaction::system_move(
         &mint.keypair(),
         mint.keypair().pubkey(),
@@ -209,6 +212,7 @@ fn bench_banking_stage_multi_programs(bencher: &mut Bencher) {
         Default::default(),
         &mint.last_id(),
         None,
+        dummy_leader_id,
     );
 
     let mut id = mint.last_id();

--- a/multinode-demo/fullnode.sh
+++ b/multinode-demo/fullnode.sh
@@ -163,13 +163,14 @@ $rsync -vPr "$rsync_leader_url"/config/ "$ledger_config_dir"
   exit 1
 }
 
-# A fullnode requires 2 tokens to function:
+# A fullnode requires 3 tokens to function:
 # - one token to create an instance of the vote_program with
-# - one second token to keep the node identity public key valid.
+# - one token for the transaction fee
+# - one token to keep the node identity public key valid.
 $solana_wallet \
   --keypair "$fullnode_id_path" \
   --network "$leader_address" \
-  airdrop 2
+  airdrop 3
 
 trap 'kill "$pid" && wait "$pid"' INT TERM
 $program \

--- a/src/fullnode.rs
+++ b/src/fullnode.rs
@@ -322,6 +322,7 @@ impl Fullnode {
                 sigverify_disabled,
                 max_tick_height,
                 last_entry_id,
+                scheduled_leader,
             );
 
             let broadcast_service = BroadcastService::new(
@@ -486,6 +487,7 @@ impl Fullnode {
             // the window didn't overwrite the slot at for the last entry that the replicate stage
             // processed. We also want to avoid reading processing the ledger for the last id.
             &last_id,
+            self.keypair.pubkey(),
         );
 
         let broadcast_service = BroadcastService::new(

--- a/src/tpu.rs
+++ b/src/tpu.rs
@@ -10,6 +10,7 @@ use poh_service::Config;
 use service::Service;
 use sigverify_stage::SigVerifyStage;
 use solana_sdk::hash::Hash;
+use solana_sdk::pubkey::Pubkey;
 use std::net::UdpSocket;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::Receiver;
@@ -38,6 +39,7 @@ impl Tpu {
         sigverify_disabled: bool,
         max_tick_height: Option<u64>,
         last_entry_id: &Hash,
+        leader_id: Pubkey,
     ) -> (Self, Receiver<Vec<Entry>>, Arc<AtomicBool>) {
         let exit = Arc::new(AtomicBool::new(false));
 
@@ -52,6 +54,7 @@ impl Tpu {
             tick_duration,
             last_entry_id,
             max_tick_height,
+            leader_id,
         );
 
         let (ledger_write_stage, entry_forwarder) =


### PR DESCRIPTION
#### Problem
The finality timestamp could not get computed even though the validators were submitting their votes.

#### Summary of Changes
Compute the super majority stake only from validators by filtering out the current leader.

Update the airdrop tokens to 3 for fullnode to account for both fee and account creation

Fixes #
