### PR TITLE
Strip cp -r arg from ledger copy

### DIFF
--- a/multinode-demo/setup.sh
+++ b/multinode-demo/setup.sh
@@ -100,7 +100,7 @@ if $bootstrap_leader; then
       --keypair="$SOLANA_CONFIG_DIR"/bootstrap-leader-id.json \
       "$ip_address_arg" > "$SOLANA_CONFIG_DIR"/bootstrap-leader.json
 
-    cp -ra "$SOLANA_RSYNC_CONFIG_DIR"/ledger "$SOLANA_CONFIG_DIR"/bootstrap-leader-ledger
+    cp -a "$SOLANA_RSYNC_CONFIG_DIR"/ledger "$SOLANA_CONFIG_DIR"/bootstrap-leader-ledger
   )
 fi
 


### PR DESCRIPTION
#### Problem
Running `./multinode-demo/setup.sh` produces an error:
`cp: the -R and -r options may not be specified together.` (This prevents the ledger copy, which in turn prevents a bootstrap-leader boot using the default script.)
According to the cp man page, the "a" arg is "the same as -dR --preserve=all", so the "r" arg should not be needed.

#### Summary of Changes
Remove "r" arg

Fixes #
