### PR TITLE
Dynamic N layer 'avalanche' broadcast and retransmit

### DIFF
--- a/src/broadcast_service.rs
+++ b/src/broadcast_service.rs
@@ -1,6 +1,7 @@
 //! The `broadcast_service` broadcasts data from a leader node to validators
 //!
-use crate::cluster_info::{ClusterInfo, ClusterInfoError, NodeInfo};
+use crate::bank::Bank;
+use crate::cluster_info::{ClusterInfo, ClusterInfoError, NodeInfo, DATA_PLANE_FANOUT};
 use crate::counter::Counter;
 use crate::db_ledger::DbLedger;
 use crate::entry::Entry;
@@ -241,6 +242,7 @@ pub struct BroadcastService {
 impl BroadcastService {
     fn run(
         db_ledger: &Arc<DbLedger>,
+        bank: &Arc<Bank>,
         sock: &UdpSocket,
         cluster_info: &Arc<RwLock<ClusterInfo>>,
         window: &SharedWindow,
@@ -260,7 +262,9 @@ impl BroadcastService {
             if exit_signal.load(Ordering::Relaxed) {
                 return BroadcastServiceReturnType::ExitSignal;
             }
-            let broadcast_table = cluster_info.read().unwrap().tvu_peers();
+            let mut broadcast_table = cluster_info.read().unwrap().sorted_tvu_peers(&bank);
+            // Layer 1 nodes are limited to the fanout size.
+            broadcast_table.truncate(DATA_PLANE_FANOUT);
             inc_new_counter_info!("broadcast_service-num_peers", broadcast_table.len() + 1);
             let leader_id = cluster_info.read().unwrap().leader_id();
             if let Err(e) = broadcast(
@@ -309,6 +313,7 @@ impl BroadcastService {
     #[allow(clippy::too_many_arguments, clippy::new_ret_no_self)]
     pub fn new(
         db_ledger: Arc<DbLedger>,
+        bank: Arc<Bank>,
         sock: UdpSocket,
         cluster_info: Arc<RwLock<ClusterInfo>>,
         window: SharedWindow,
@@ -326,6 +331,7 @@ impl BroadcastService {
                 let _exit = Finalizer::new(exit_sender);
                 Self::run(
                     &db_ledger,
+                    &bank,
                     &sock,
                     &cluster_info,
                     &window,
@@ -401,10 +407,12 @@ mod test {
         let shared_window = Arc::new(RwLock::new(window));
         let (entry_sender, entry_receiver) = channel();
         let exit_sender = Arc::new(AtomicBool::new(false));
+        let bank = Arc::new(Bank::default());
 
         // Start up the broadcast stage
         let (broadcast_service, exit_signal) = BroadcastService::new(
             db_ledger.clone(),
+            bank.clone(),
             leader_info.sockets.broadcast,
             cluster_info,
             shared_window,

--- a/src/broadcast_service.rs
+++ b/src/broadcast_service.rs
@@ -240,6 +240,7 @@ pub struct BroadcastService {
 }
 
 impl BroadcastService {
+    #[allow(clippy::too_many_arguments)]
     fn run(
         db_ledger: &Arc<DbLedger>,
         bank: &Arc<Bank>,

--- a/src/cluster_info.rs
+++ b/src/cluster_info.rs
@@ -332,7 +332,7 @@ impl ClusterInfo {
 
     pub fn sorted_tvu_peers(&self, bank: &Arc<Bank>) -> Vec<NodeInfo> {
         let peers = self.tvu_peers();
-        let mut peers_with_stakes: Vec<(&NodeInfo, u64)> =
+        let mut peers_with_stakes: Vec<_> =
             peers.iter().map(|c| (c, bank.get_stake(&c.id))).collect();
         peers_with_stakes.sort_unstable_by(|l, r| {
             let cmp = r.1.cmp(&l.1);

--- a/src/cluster_info.rs
+++ b/src/cluster_info.rs
@@ -319,7 +319,7 @@ impl ClusterInfo {
             .collect()
     }
 
-    fn sort_by_stake(peers: Vec<NodeInfo>, bank: &Arc<Bank>) -> Vec<(u64, NodeInfo)> {
+    fn sort_by_stake(peers: &[NodeInfo], bank: &Arc<Bank>) -> Vec<(u64, NodeInfo)> {
         let mut peers_with_stakes: Vec<_> = peers
             .iter()
             .map(|c| (bank.get_stake(&c.id), c.clone()))
@@ -330,7 +330,7 @@ impl ClusterInfo {
 
     pub fn sorted_retransmit_peers(&self, bank: &Arc<Bank>) -> Vec<NodeInfo> {
         let peers = self.retransmit_peers();
-        let peers_with_stakes: Vec<_> = ClusterInfo::sort_by_stake(peers, bank);
+        let peers_with_stakes: Vec<_> = ClusterInfo::sort_by_stake(&peers, bank);
         peers_with_stakes
             .iter()
             .map(|(_, peer)| (*peer).clone())
@@ -339,7 +339,7 @@ impl ClusterInfo {
 
     pub fn sorted_tvu_peers(&self, bank: &Arc<Bank>) -> Vec<NodeInfo> {
         let peers = self.tvu_peers();
-        let peers_with_stakes: Vec<_> = ClusterInfo::sort_by_stake(peers, bank);
+        let peers_with_stakes: Vec<_> = ClusterInfo::sort_by_stake(&peers, bank);
         peers_with_stakes
             .iter()
             .map(|(_, peer)| (*peer).clone())

--- a/src/cluster_info.rs
+++ b/src/cluster_info.rs
@@ -1690,5 +1690,8 @@ mod tests {
         for i in 0..25_000 {
             assert!(broadcast_set.contains(&(i as usize)));
         }
+        assert!(broadcast_set.contains(&(layer_indices.last().unwrap() - 1)));
+        //sanity check for past total capacity.
+        assert!(!broadcast_set.contains(&(layer_indices.last().unwrap())));
     }
 }

--- a/src/cluster_info.rs
+++ b/src/cluster_info.rs
@@ -1302,12 +1302,10 @@ mod tests {
     use crate::crds_value::CrdsValueLabel;
     use crate::db_ledger::DbLedger;
     use crate::ledger::get_tmp_ledger_path;
-
     use crate::packet::BLOB_HEADER_SIZE;
     use crate::result::Error;
     use solana_sdk::signature::{Keypair, KeypairUtil};
     use std::collections::HashSet;
-    use std::fs::remove_dir_all;
     use std::net::{IpAddr, Ipv4Addr, SocketAddr};
     use std::sync::{Arc, RwLock};
 

--- a/src/cluster_info.rs
+++ b/src/cluster_info.rs
@@ -380,7 +380,7 @@ impl ClusterInfo {
                     // Needs more layers.
                     num_layers += 1;
                     remaining_nodes -= layer_capacity;
-                    let end = layer_indices.last().unwrap().clone();
+                    let end = *layer_indices.last().unwrap();
                     layer_indices.push(layer_capacity + end);
 
                     if grow {
@@ -390,7 +390,7 @@ impl ClusterInfo {
                     }
                 } else {
                     //everything will now fit in the layers we have
-                    let end = layer_indices.last().unwrap().clone();
+                    let end = *layer_indices.last().unwrap();
                     layer_indices.push(layer_capacity + end);
                     break;
                 }

--- a/src/cluster_info.rs
+++ b/src/cluster_info.rs
@@ -364,10 +364,10 @@ impl ClusterInfo {
     ) -> (usize, Vec<usize>) {
         let mut layer_indices: Vec<usize> = vec![0];
         if nodes == 0 {
-            return (0, vec![]);
+            (0, vec![])
         } else if nodes <= fanout {
             // single layer data plane
-            return (1, layer_indices);
+            (1, layer_indices)
         } else {
             //layer 1 is going to be the first num fanout nodes, so exclude those
             let mut remaining_nodes = nodes - fanout;

--- a/src/contact_info.rs
+++ b/src/contact_info.rs
@@ -3,10 +3,11 @@ use bincode::serialize;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::{Keypair, KeypairUtil, Signable, Signature};
 use solana_sdk::timing::timestamp;
+use std::cmp::{Ordering, Ord, PartialEq, PartialOrd};
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
 /// Structure representing a node on the network
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct ContactInfo {
     pub id: Pubkey,
     /// signature of this ContactInfo
@@ -26,6 +27,26 @@ pub struct ContactInfo {
     /// latest wallclock picked
     pub wallclock: u64,
 }
+
+impl Ord for ContactInfo {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.id.cmp(&other.id)
+    }
+}
+
+impl PartialOrd for ContactInfo {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl PartialEq for ContactInfo {
+    fn eq(&self, other: &Self) -> bool {
+        self.id == other.id
+    }
+}
+
+impl Eq for ContactInfo { }
 
 #[macro_export]
 macro_rules! socketaddr {

--- a/src/contact_info.rs
+++ b/src/contact_info.rs
@@ -3,7 +3,7 @@ use bincode::serialize;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::{Keypair, KeypairUtil, Signable, Signature};
 use solana_sdk::timing::timestamp;
-use std::cmp::{Ordering, Ord, PartialEq, PartialOrd};
+use std::cmp::{Ord, Ordering, PartialEq, PartialOrd};
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
 /// Structure representing a node on the network
@@ -46,7 +46,7 @@ impl PartialEq for ContactInfo {
     }
 }
 
-impl Eq for ContactInfo { }
+impl Eq for ContactInfo {}
 
 #[macro_export]
 macro_rules! socketaddr {

--- a/src/fullnode.rs
+++ b/src/fullnode.rs
@@ -303,6 +303,7 @@ impl Fullnode {
 
             let (broadcast_service, _) = BroadcastService::new(
                 db_ledger.clone(),
+                bank.clone(),
                 node.sockets
                     .broadcast
                     .try_clone()
@@ -476,6 +477,7 @@ impl Fullnode {
 
         let (broadcast_service, _) = BroadcastService::new(
             self.db_ledger.clone(),
+            self.bank.clone(),
             self.broadcast_socket
                 .try_clone()
                 .expect("Failed to clone broadcast socket"),

--- a/src/retransmit_stage.rs
+++ b/src/retransmit_stage.rs
@@ -37,7 +37,7 @@ fn retransmit(
             .add_field("count", influxdb::Value::Integer(dq.len() as i64))
             .to_owned(),
     );
-    
+
     // TODO layer 2 logic here
     // 1 - find out if I am in layer 1 first
     // 1.1 - If yes, then broadcast to all layer 1 nodes

--- a/src/retransmit_stage.rs
+++ b/src/retransmit_stage.rs
@@ -37,7 +37,7 @@ fn retransmit(
             .add_field("count", influxdb::Value::Integer(dq.len() as i64))
             .to_owned(),
     );
-
+    
     // TODO layer 2 logic here
     // 1 - find out if I am in layer 1 first
     // 1.1 - If yes, then broadcast to all layer 1 nodes

--- a/src/retransmit_stage.rs
+++ b/src/retransmit_stage.rs
@@ -64,8 +64,11 @@ fn retransmit(
             .iter()
             .position(|ci| bank.get_stake(&ci.id) <= bank.get_stake(&my_id));
         //find my layer
-        let locality =
-            ClusterInfo::localize(&layer_indices, NEIGHBORHOOD_SIZE, my_index.unwrap_or(0));
+        let locality = ClusterInfo::localize(
+            &layer_indices,
+            NEIGHBORHOOD_SIZE,
+            my_index.unwrap_or(peers.len() - 1),
+        );
         let mut retransmit_peers =
             peers[locality.neighbor_bounds.0..locality.neighbor_bounds.1].to_vec();
         locality.child_layer_peers.iter().cloned().for_each(|ix| {

--- a/src/retransmit_stage.rs
+++ b/src/retransmit_stage.rs
@@ -71,14 +71,14 @@ fn retransmit(
         );
         let mut retransmit_peers =
             peers[locality.neighbor_bounds.0..locality.neighbor_bounds.1].to_vec();
-        locality.child_layer_peers.iter().cloned().for_each(|ix| {
+        locality.child_layer_peers.iter().for_each(|&ix| {
             if let Some(peer) = peers.get(ix) {
                 retransmit_peers.push(peer.clone());
             }
         });
 
         for b in &mut dq {
-            ClusterInfo::retransmit_to(&cluster_info, retransmit_peers.to_vec(), b, sock)?;
+            ClusterInfo::retransmit_to(&cluster_info, &retransmit_peers, b, sock)?;
         }
     }
     Ok(())

--- a/src/tvu.rs
+++ b/src/tvu.rs
@@ -96,6 +96,7 @@ impl Tvu {
         //the packets coming out of blob_receiver need to be sent to the GPU and verified
         //then sent to the window, which does the erasure coding reconstruction
         let (retransmit_stage, blob_window_receiver) = RetransmitStage::new(
+            bank,
             db_ledger,
             &cluster_info,
             bank.tick_height(),


### PR DESCRIPTION
#### Problem
In a large network that tasks the leader with broadcasting to all validators, the leader's bandwidth can get saturated. To counter this we implemented a single layer avalanche where the leader doesn't have to replay all messages to each validator, instead validators can share the leader's messages with each other. But even this single layer avalanche can be crippled when network sizes get larger than a few hundred. We need more layers.

#### Summary of Changes
Implemented an N layer avalanche mechanism to distribute leader messages across the entire network. 
There are a couple of knobs to tweak here to figure out if the layers should be increasing, or constant in capacity and how many nodes are allowed in each "neighborhood". 
The general idea behind these changes is described in #2008 but that RFC still needs updating.

Fixes #
