### PR TITLE
Add solana_ prefix to native_loader program

### DIFF
--- a/programs/native/native_loader/Cargo.toml
+++ b/programs/native/native_loader/Cargo.toml
@@ -14,5 +14,5 @@ log = "0.4.2"
 solana-sdk = { path = "../../../sdk", version = "0.11.0" }
 
 [lib]
-name = "native_loader"
+name = "solana_native_loader"
 crate-type = ["lib"]

--- a/src/bank.rs
+++ b/src/bank.rs
@@ -13,12 +13,12 @@ use leader_scheduler::LeaderScheduler;
 use ledger::Block;
 use log::Level;
 use mint::Mint;
-use native_loader;
 use poh_recorder::PohRecorder;
 use poh_service::NUM_TICKS_PER_SECOND;
 use rayon::prelude::*;
 use rpc::RpcSignatureStatus;
 use runtime::{self, RuntimeError};
+use solana_native_loader;
 use solana_sdk::account::Account;
 use solana_sdk::bpf_loader;
 use solana_sdk::budget_program;
@@ -412,7 +412,7 @@ impl Bank {
             owner: system_program::id(),
             userdata: b"solana_system_program".to_vec(),
             executable: true,
-            loader: native_loader::id(),
+            loader: solana_native_loader::id(),
         };
         accounts.store(&system_program::id(), &system_program_account);
     }
@@ -427,7 +427,7 @@ impl Bank {
             owner: vote_program::id(),
             userdata: b"solana_vote_program".to_vec(),
             executable: true,
-            loader: native_loader::id(),
+            loader: solana_native_loader::id(),
         };
         accounts.store(&vote_program::id(), &vote_program_account);
 
@@ -437,7 +437,7 @@ impl Bank {
             owner: storage_program::id(),
             userdata: b"solana_storage_program".to_vec(),
             executable: true,
-            loader: native_loader::id(),
+            loader: solana_native_loader::id(),
         };
         accounts.store(&storage_program::id(), &storage_program_account);
 
@@ -447,7 +447,7 @@ impl Bank {
             owner: bpf_loader::id(),
             userdata: b"solana_bpf_loader".to_vec(),
             executable: true,
-            loader: native_loader::id(),
+            loader: solana_native_loader::id(),
         };
 
         accounts.store(&bpf_loader::id(), &bpf_loader_account);
@@ -458,7 +458,7 @@ impl Bank {
             owner: budget_program::id(),
             userdata: b"solana_budget_program".to_vec(),
             executable: true,
-            loader: native_loader::id(),
+            loader: solana_native_loader::id(),
         };
         accounts.store(&budget_program::id(), &budget_program_account);
 
@@ -468,7 +468,7 @@ impl Bank {
             owner: token_program::id(),
             userdata: b"solana_erc20".to_vec(),
             executable: true,
-            loader: native_loader::id(),
+            loader: solana_native_loader::id(),
         };
 
         accounts.store(&token_program::id(), &erc20_account);
@@ -783,7 +783,7 @@ impl Bank {
         let mut accounts = Vec::new();
         let mut depth = 0;
         loop {
-            if native_loader::check_id(&program_id) {
+            if solana_native_loader::check_id(&program_id) {
                 // at the root of the chain, ready to dispatch
                 break;
             }
@@ -2203,7 +2203,7 @@ mod tests {
         ]);
 
         assert_eq!(system_program::id(), system);
-        assert_eq!(native_loader::id(), native);
+        assert_eq!(solana_native_loader::id(), native);
         assert_eq!(bpf_loader::id(), bpf);
         assert_eq!(budget_program::id(), budget);
         assert_eq!(storage_program::id(), storage);
@@ -2216,7 +2216,7 @@ mod tests {
         let mut unique = HashSet::new();
         let ids = vec![
             system_program::id(),
-            native_loader::id(),
+            solana_native_loader::id(),
             bpf_loader::id(),
             budget_program::id(),
             storage_program::id(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,7 +105,6 @@ extern crate serde;
 extern crate serde_derive;
 #[macro_use]
 extern crate serde_json;
-extern crate native_loader;
 extern crate serde_cbor;
 extern crate sha2;
 extern crate socket2;
@@ -118,6 +117,7 @@ extern crate solana_jsonrpc_macros as jsonrpc_macros;
 extern crate solana_jsonrpc_pubsub as jsonrpc_pubsub;
 extern crate solana_jsonrpc_ws_server as jsonrpc_ws_server;
 extern crate solana_metrics;
+extern crate solana_native_loader;
 extern crate solana_sdk;
 extern crate sys_info;
 extern crate tokio;

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1,4 +1,4 @@
-use native_loader;
+use solana_native_loader;
 use solana_sdk::account::{create_keyed_accounts, Account, KeyedAccount};
 use solana_sdk::native_program::ProgramError;
 use solana_sdk::pubkey::Pubkey;
@@ -46,7 +46,7 @@ fn process_instruction(
             tick_height,
         )
     } else {
-        native_loader::entrypoint(
+        solana_native_loader::entrypoint(
             &program_id,
             &mut keyed_accounts,
             &tx.instructions[instruction_index].userdata,

--- a/tests/programs.rs
+++ b/tests/programs.rs
@@ -1,8 +1,8 @@
 extern crate bincode;
 extern crate elf;
-extern crate native_loader;
 extern crate serde_derive;
 extern crate solana;
+extern crate solana_native_loader;
 extern crate solana_sdk;
 
 use solana::bank::Bank;
@@ -69,7 +69,7 @@ impl Loader {
             mint.last_id(),
             1,
             56, // TODO
-            native_loader::id(),
+            solana_native_loader::id(),
             0,
         );
         check_tx_results(&bank, &tx, bank.process_transactions(&vec![tx.clone()]));
@@ -77,7 +77,7 @@ impl Loader {
         let name = String::from(loader_name);
         let tx = Transaction::loader_write(
             &loader,
-            native_loader::id(),
+            solana_native_loader::id(),
             0,
             name.as_bytes().to_vec(),
             mint.last_id(),
@@ -85,7 +85,8 @@ impl Loader {
         );
         check_tx_results(&bank, &tx, bank.process_transactions(&vec![tx.clone()]));
 
-        let tx = Transaction::loader_finalize(&loader, native_loader::id(), mint.last_id(), 0);
+        let tx =
+            Transaction::loader_finalize(&loader, solana_native_loader::id(), mint.last_id(), 0);
         check_tx_results(&bank, &tx, bank.process_transactions(&vec![tx.clone()]));
 
         let tx = Transaction::system_spawn(&loader, mint.last_id(), 0);
@@ -101,7 +102,7 @@ impl Loader {
     pub fn new_native() -> Self {
         let mint = Mint::new(50);
         let bank = Bank::new(&mint);
-        let loader = native_loader::id();
+        let loader = solana_native_loader::id();
 
         Loader { mint, bank, loader }
     }


### PR DESCRIPTION
This allows its logging to show up in the default RUST_LOG=solana=info
log setting

Addresses the first point of #2065:
> Change this line: https://github.com/solana-labs/solana/blob/master/programs/native/native_loader/src/lib.rs#L97 from warn! to println!
warn! is not logging to the log for some reason.