### PR TITLE
Install native program shared objects in the right location

### DIFF
--- a/net/net.sh
+++ b/net/net.sh
@@ -141,7 +141,7 @@ build() {
       export NDEBUG=1
       cargo install --path drone --features=$cargoFeatures --root farf
       cargo install --path . --features=$cargoFeatures --root farf
-      ./scripts/install-native-programs.sh farf/ release
+      ./scripts/install-native-programs.sh farf/bin/ release
     "
   )
   echo "Build took $SECONDS seconds"


### PR DESCRIPTION
#2066 helped point out that all native program shared objects where missing from a locally-deployed testnet.  Added 4 characters to fix this :-/

Fixes #2065
