### PR TITLE
Relocate native programs to deps/ subdirectory of the current executable

### DIFF
--- a/ci/publish-solana-tar.sh
+++ b/ci/publish-solana-tar.sh
@@ -45,7 +45,7 @@ echo --- Creating tarball
 
   cargo install --path drone --root solana-release
   cargo install --path . --root solana-release
-  ./scripts/install-native-programs.sh solana-release/bin release
+  ./scripts/install-native-programs.sh solana-release/bin/deps/ release
 
   ./fetch-perf-libs.sh
   # shellcheck source=/dev/null

--- a/ci/test-stable.sh
+++ b/ci/test-stable.sh
@@ -50,7 +50,5 @@ echo --- ci/localnet-sanity.sh
   set -x
   # Assume |cargo build| has populated target/debug/ successfully.
   export PATH=$PWD/target/debug:$PATH
-  # Move programs into the executable location so native_loader can find them
-  scripts/install-native-programs.sh "$PWD"/target/debug debug
   USE_INSTALL=1 ci/localnet-sanity.sh
 )

--- a/net/net.sh
+++ b/net/net.sh
@@ -141,7 +141,7 @@ build() {
       export NDEBUG=1
       cargo install --path drone --features=$cargoFeatures --root farf
       cargo install --path . --features=$cargoFeatures --root farf
-      ./scripts/install-native-programs.sh farf/ release
+      ./scripts/install-native-programs.sh farf/bin/deps/ release
     "
   )
   echo "Build took $SECONDS seconds"

--- a/programs/native/native_loader/src/lib.rs
+++ b/programs/native/native_loader/src/lib.rs
@@ -38,15 +38,20 @@ const PLATFORM_FILE_EXTENSION_NATIVE: &str = "so";
 const PLATFORM_FILE_EXTENSION_NATIVE: &str = "dll";
 
 fn create_path(name: &str) -> PathBuf {
-    let pathbuf = {
-        let current_exe = env::current_exe().unwrap();
-        PathBuf::from(current_exe.parent().unwrap())
-    };
+    let current_exe = env::current_exe().unwrap();
+    let current_exe_directory = PathBuf::from(current_exe.parent().unwrap());
+    let library_file_name = PathBuf::from(PLATFORM_FILE_PREFIX_NATIVE.to_string() + name)
+        .with_extension(PLATFORM_FILE_EXTENSION_NATIVE);
 
-    pathbuf.join(
-        PathBuf::from(PLATFORM_FILE_PREFIX_NATIVE.to_string() + name)
-            .with_extension(PLATFORM_FILE_EXTENSION_NATIVE),
-    )
+    // Check the current_exe directory for the library as `cargo tests` are run
+    // from the deps/ subdirectory
+    let file_path = current_exe_directory.join(&library_file_name);
+    if file_path.exists() {
+        file_path
+    } else {
+        // `cargo build` places dependent libraries in the deps/ subdirectory
+        current_exe_directory.join("deps").join(library_file_name)
+    }
 }
 
 pub fn check_id(program_id: &Pubkey) -> bool {

--- a/sdk/docker-solana/build.sh
+++ b/sdk/docker-solana/build.sh
@@ -24,7 +24,7 @@ rm -rf usr/
   cargo install --path . --root sdk/docker-solana/usr
 "
 cp -f entrypoint.sh usr/bin/solana-entrypoint.sh
-../../scripts/install-native-programs.sh usr/bin/ release
+../../scripts/install-native-programs.sh usr/bin/deps/ release
 
 docker build -t solanalabs/solana:$CHANNEL .
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -95,7 +95,8 @@ parts:
       cargo install --path . --root $SNAPCRAFT_PART_INSTALL --bins
 
       # Install native programs
-      ./scripts/install-native-programs.sh $SNAPCRAFT_PART_INSTALL/bin/ release
+      mkdir -p $SNAPCRAFT_PART_INSTALL/bin/deps/
+      ./scripts/install-native-programs.sh $SNAPCRAFT_PART_INSTALL/bin/deps/ release
 
       # Install multinode-demo/
       mkdir -p $SNAPCRAFT_PART_INSTALL/multinode-demo/


### PR DESCRIPTION
This layout is `cargo build` compatible, no post-build file moves
required.

Fixes #2065, in a better way than the attempt at #2067
Also fixes #2068.