### PR TITLE
Use retry_transfer to test multiple times for replicator tokens

### DIFF
--- a/src/replicator.rs
+++ b/src/replicator.rs
@@ -12,6 +12,7 @@ use crate::rpc_request::{RpcClient, RpcRequest};
 use crate::service::Service;
 use crate::store_ledger_stage::StoreLedgerStage;
 use crate::streamer::BlobReceiver;
+use crate::thin_client::retry_get_balance;
 use crate::window;
 use crate::window_service::window_service;
 use rand::thread_rng;
@@ -194,7 +195,7 @@ impl Replicator {
 
         let mut client = mk_client(&leader);
 
-        if client.get_balance(&keypair.pubkey()).is_err() {
+        if retry_get_balance(&mut client, &keypair.pubkey(), None).is_none() {
             let mut drone_addr = leader_info.tpu;
             drone_addr.set_port(DRONE_PORT);
 

--- a/tests/replicator.rs
+++ b/tests/replicator.rs
@@ -10,6 +10,8 @@ use solana::ledger::{create_tmp_genesis, get_tmp_ledger_path, read_ledger};
 use solana::logger;
 use solana::replicator::Replicator;
 use solana_sdk::signature::{Keypair, KeypairUtil};
+use solana_sdk::system_transaction::SystemTransaction;
+use solana_sdk::transaction::Transaction;
 use std::fs::remove_dir_all;
 use std::sync::Arc;
 use std::thread::sleep;
@@ -53,8 +55,15 @@ fn test_replicator_startup() {
 
         let replicator_keypair = Keypair::new();
 
+        let amount = 1;
+        let mut tx = Transaction::system_new(
+            &mint.keypair(),
+            replicator_keypair.pubkey(),
+            amount,
+            last_id,
+        );
         leader_client
-            .transfer(1, &mint.keypair(), replicator_keypair.pubkey(), &last_id)
+            .retry_transfer(&mint.keypair(), &mut tx, 5)
             .unwrap();
 
         info!("starting replicator node");


### PR DESCRIPTION
#### Problem

replicator_startup test failing in CI sometimes.

#### Summary of Changes

Add some retries to transfer/get_balance operations.

Fixes #2073 
