### PR TITLE
ci/localnet-sanity.sh: Add sleep to work around drone startup delay

### DIFF
--- a/ci/localnet-sanity.sh
+++ b/ci/localnet-sanity.sh
@@ -18,6 +18,12 @@ for cmd in $backgroundCommands; do
   echo "--- Start $cmd"
   rm -f log-"$cmd".txt
   multinode-demo/"$cmd".sh > log-"$cmd".txt 2>&1 &
+  if [[ $cmd = drone ]]; then
+    # Give the drone time to startup before the fullnodes attempt to airdrop
+    # from it (TODO: alternatively adjust `solana-wallet airdrop` to retry on
+    # "Connection refused" errors)
+    sleep 2
+  fi
   declare pid=$!
   pids+=("$pid")
   echo "pid: $pid"


### PR DESCRIPTION
When `./multinode-demo/fullnode.sh` runs too quickly after `./multinode-demo/drone.sh, we'll see:
```
+ [[ -d /solana/config-local/fullnode-ledger/ledger ]]
+ solana-wallet --keypair /solana/config-local/fullnode-id.json address
8CSJzWe1Qmgz5SNR6qgVNVn9mi9H6NpFGkAiirpCBBVP
+ solana-wallet --keypair /solana/config-local/fullnode-id.json --network 127.0.0.1:8001 airdrop 3
[2018-12-10T20:52:15.378308463Z INFO  solana::cluster_info] ReceiveUpdates took: 13 ms  len: 2
Requesting airdrop of 3 tokens from 172.17.0.2:9900
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Os { code: 111, kind: ConnectionRefused, message: "Connection refused" }', libcore/result.rs:1009:5
```

eg: https://buildkite.com/solana-labs/solana/builds/5927#ffc2a7fd-08df-4004-bca4-02ccf94cf07c

Sheepishly attempt to avoid this with a `sleep` for now.  