### PR TITLE
Add tick_height to Entry to be able to repair by period, chain forks of Entries, etc.

### DIFF
--- a/src/bank.rs
+++ b/src/bank.rs
@@ -1821,7 +1821,7 @@ mod tests {
             let mut e = ledger::next_entries(&hash, 0, txs);
             entries.append(&mut e);
             hash = entries.last().unwrap().id;
-            let tick = Entry::new(&hash, num_hashes, vec![]);
+            let tick = Entry::new(&hash, 0, num_hashes, vec![]);
             hash = tick.id;
             last_id = hash;
             entries.push(tick);
@@ -1842,11 +1842,11 @@ mod tests {
         for i in 0..length {
             let keypair = Keypair::new();
             let tx = Transaction::system_new(&mint.keypair(), keypair.pubkey(), 1, last_id);
-            let entry = Entry::new(&hash, num_hashes, vec![tx]);
+            let entry = Entry::new(&hash, 0, num_hashes, vec![tx]);
             hash = entry.id;
             entries.push(entry);
             if (i + 1) % ticks == 0 {
-                let tick = Entry::new(&hash, num_hashes, vec![]);
+                let tick = Entry::new(&hash, 0, num_hashes, vec![]);
                 hash = tick.id;
                 last_id = hash;
                 entries.push(tick);
@@ -2154,16 +2154,16 @@ mod tests {
         // ensure bank can process 2 entries that do not have a common account and tick is registered
         let tx = Transaction::system_new(&keypair2, keypair3.pubkey(), 1, bank.last_id());
         let entry_1 = next_entry(&last_id, 1, vec![tx]);
-        let new_tick = next_entry(&entry_1.id, 1, vec![]);
-        let tx = Transaction::system_new(&keypair1, keypair4.pubkey(), 1, new_tick.id);
-        let entry_2 = next_entry(&new_tick.id, 1, vec![tx]);
+        let tick = next_entry(&entry_1.id, 1, vec![]);
+        let tx = Transaction::system_new(&keypair1, keypair4.pubkey(), 1, tick.id);
+        let entry_2 = next_entry(&tick.id, 1, vec![tx]);
         assert_eq!(
-            bank.par_process_entries(&[entry_1.clone(), new_tick.clone(), entry_2]),
+            bank.par_process_entries(&[entry_1.clone(), tick.clone(), entry_2]),
             Ok(())
         );
         assert_eq!(bank.get_balance(&keypair3.pubkey()), 1);
         assert_eq!(bank.get_balance(&keypair4.pubkey()), 1);
-        assert_eq!(bank.last_id(), new_tick.id);
+        assert_eq!(bank.last_id(), tick.id);
         // ensure that errors are returned
         assert_eq!(
             bank.par_process_entries(&[entry_1]),

--- a/src/cluster_info.rs
+++ b/src/cluster_info.rs
@@ -1292,8 +1292,8 @@ mod tests {
             writer
                 .write_entries(
                     &vec![
-                        Entry::new_tick(&zero, 0, &zero),
-                        Entry::new_tick(&one, 0, &one),
+                        Entry::new_tick(&zero, 0, 0, &zero),
+                        Entry::new_tick(&one, 1, 0, &one),
                     ]
                     .to_vec(),
                 )

--- a/src/leader_scheduler.rs
+++ b/src/leader_scheduler.rs
@@ -483,20 +483,20 @@ pub fn make_active_set_entries(
     // 1) Create transfer token entry
     let transfer_tx =
         Transaction::system_new(&token_source, active_keypair.pubkey(), 3, *last_tick_id);
-    let transfer_entry = Entry::new(last_entry_id, 1, vec![transfer_tx]);
+    let transfer_entry = Entry::new(last_entry_id, 0, 1, vec![transfer_tx]);
     let mut last_entry_id = transfer_entry.id;
 
     // 2) Create and register the vote account
     let vote_account = Keypair::new();
     let new_vote_account_tx =
         Transaction::vote_account_new(active_keypair, vote_account.pubkey(), *last_tick_id, 1, 1);
-    let new_vote_account_entry = Entry::new(&last_entry_id, 1, vec![new_vote_account_tx]);
+    let new_vote_account_entry = Entry::new(&last_entry_id, 0, 1, vec![new_vote_account_tx]);
     last_entry_id = new_vote_account_entry.id;
 
     // 3) Create vote entry
     let vote = Vote { tick_height: 1 };
     let vote_tx = Transaction::vote_new(&vote_account, vote, *last_tick_id, 0);
-    let vote_entry = Entry::new(&last_entry_id, 1, vec![vote_tx]);
+    let vote_entry = Entry::new(&last_entry_id, 0, 1, vec![vote_tx]);
     last_entry_id = vote_entry.id;
 
     // 4) Create the ending empty ticks

--- a/src/mint.rs
+++ b/src/mint.rs
@@ -96,9 +96,9 @@ impl Mint {
     }
 
     pub fn create_entries(&self) -> Vec<Entry> {
-        let e0 = Entry::new(&self.seed(), 0, vec![]);
-        let e1 = Entry::new(&e0.id, 1, self.create_transaction());
-        let e2 = Entry::new(&e1.id, 1, vec![]); // include a tick
+        let e0 = Entry::new(&self.seed(), 0, 0, vec![]);
+        let e1 = Entry::new(&e0.id, 0, 1, self.create_transaction());
+        let e2 = Entry::new(&e1.id, 0, 1, vec![]); // include a tick
         vec![e0, e1, e2]
     }
 }

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -462,7 +462,7 @@ pub fn make_consecutive_blobs(
     let num_hashes = 1;
     let mut all_entries = Vec::with_capacity(num_blobs_to_make as usize);
     for _ in 0..num_blobs_to_make {
-        let entry = Entry::new(&last_hash, num_hashes, vec![]);
+        let entry = Entry::new(&last_hash, 0, num_hashes, vec![]);
         last_hash = entry.id;
         all_entries.push(entry);
     }

--- a/src/poh.rs
+++ b/src/poh.rs
@@ -12,6 +12,7 @@ pub struct Poh {
 #[derive(Debug)]
 pub struct PohEntry {
     pub prev_id: Hash,
+    pub tick_height: u64,
     pub num_hashes: u64,
     pub id: Hash,
     pub mixin: Option<Hash>,
@@ -43,6 +44,7 @@ impl Poh {
 
         PohEntry {
             prev_id,
+            tick_height: self.tick_height,
             num_hashes,
             id: self.id,
             mixin: Some(mixin),
@@ -60,10 +62,12 @@ impl Poh {
         let prev_id = self.prev_id;
         self.prev_id = self.id;
 
+        let tick_height = self.tick_height;
         self.tick_height += 1;
 
         PohEntry {
             prev_id,
+            tick_height,
             num_hashes,
             id: self.id,
             mixin: None,
@@ -106,6 +110,7 @@ mod tests {
             Hash::default(),
             &[PohEntry {
                 prev_id: Hash::default(),
+                tick_height: 0,
                 num_hashes: 0,
                 id: Hash::default(),
                 mixin: None,

--- a/src/replay_stage.rs
+++ b/src/replay_stage.rs
@@ -348,7 +348,7 @@ mod test {
         let mut entries_to_send = vec![];
 
         while entries_to_send.len() < total_entries_to_send {
-            let entry = Entry::new(&mut last_id, num_hashes, vec![]);
+            let entry = Entry::new(&mut last_id, 0, num_hashes, vec![]);
             last_id = entry.id;
             entries_to_send.push(entry);
         }
@@ -567,7 +567,7 @@ mod test {
         let leader_rotation_index = (bootstrap_height - initial_tick_height - 1) as usize;
         let mut expected_last_id = Hash::default();
         for i in 0..total_entries_to_send {
-            let entry = Entry::new(&mut last_id, num_hashes, vec![]);
+            let entry = Entry::new(&mut last_id, 0, num_hashes, vec![]);
             last_id = entry.id;
             entry_sender
                 .send(vec![entry.clone()])
@@ -626,7 +626,7 @@ mod test {
         let mut last_id = Hash::default();
         let mut entries = Vec::new();
         for _ in 0..5 {
-            let entry = Entry::new(&mut last_id, 1, vec![]); //just ticks
+            let entry = Entry::new(&mut last_id, 0, 1, vec![]); //just ticks
             last_id = entry.id;
             entries.push(entry);
         }
@@ -653,7 +653,7 @@ mod test {
 
         entries.clear();
         for _ in 0..5 {
-            let entry = Entry::new(&mut Hash::default(), 0, vec![]); //just broken entries
+            let entry = Entry::new(&mut Hash::default(), 0, 0, vec![]); //just broken entries
             entries.push(entry);
         }
         entry_sender

--- a/src/storage_stage.rs
+++ b/src/storage_stage.rs
@@ -419,7 +419,7 @@ mod tests {
         let keypair = Keypair::new();
         let vote_tx = VoteTransaction::vote_new(&keypair, vote, Hash::default(), 1);
         vote_txs.push(vote_tx);
-        let vote_entries = vec![Entry::new(&Hash::default(), 1, vote_txs)];
+        let vote_entries = vec![Entry::new(&Hash::default(), 0, 1, vote_txs)];
         storage_entry_sender.send(vote_entries).unwrap();
 
         for _ in 0..5 {

--- a/src/tvu.rs
+++ b/src/tvu.rs
@@ -290,10 +290,10 @@ pub mod tests {
         let transfer_amount = 501;
         let bob_keypair = Keypair::new();
         for i in 0..num_transfers {
-            let entry0 = Entry::new(&cur_hash, i, vec![]);
+            let entry0 = Entry::new(&cur_hash, 0, i, vec![]);
             cur_hash = entry0.id;
             bank.register_tick(&cur_hash);
-            let entry_tick0 = Entry::new(&cur_hash, i + 1, vec![]);
+            let entry_tick0 = Entry::new(&cur_hash, 0, i + 1, vec![]);
             cur_hash = entry_tick0.id;
 
             let tx0 = Transaction::system_new(
@@ -303,11 +303,11 @@ pub mod tests {
                 cur_hash,
             );
             bank.register_tick(&cur_hash);
-            let entry_tick1 = Entry::new(&cur_hash, i + 1, vec![]);
+            let entry_tick1 = Entry::new(&cur_hash, 0, i + 1, vec![]);
             cur_hash = entry_tick1.id;
-            let entry1 = Entry::new(&cur_hash, i + num_transfers, vec![tx0]);
+            let entry1 = Entry::new(&cur_hash, 0, i + num_transfers, vec![tx0]);
             bank.register_tick(&entry1.id);
-            let entry_tick2 = Entry::new(&entry1.id, i + 1, vec![]);
+            let entry_tick2 = Entry::new(&entry1.id, 0, i + 1, vec![]);
             cur_hash = entry_tick2.id;
 
             alice_ref_balance -= transfer_amount;


### PR DESCRIPTION
#### Problem
 repair with slot+index isn't working well enough in leader rotation,
  especially in the case where the last blobs have been lost

 indexing blobs absolutely means that we have to have some way to
  determine whether a leader period has ended based on blob indexes
  alone (not really possible), or by counting ticks already received
  in that slot (slow)

 indexing blobs in absolute terms gets around this problem, but doing so
  means we can't be sure which leader period to look into to formulate
  the repair response

 #### Summary of Changes
 add tick_height to Entries

Fixes #