### PR TITLE
Allow BPF structure passing and returning

### DIFF
--- a/programs/bpf/c/src/struct_pass.c
+++ b/programs/bpf/c/src/struct_pass.c
@@ -1,0 +1,17 @@
+#include <solana_sdk.h>
+
+struct foo {const uint8_t *input;};
+void foo(const uint8_t *input, struct foo foo) ;
+
+extern bool entrypoint(const uint8_t *input) {
+  struct foo f;
+  f.input = input;
+  foo(input, f);
+  return true;
+}
+
+void foo(const uint8_t *input, struct foo foo) {
+  sol_log_64(0, 0, 0, (uint64_t)input, (uint64_t)foo.input);
+  sol_assert(input == foo.input);
+}
+

--- a/programs/bpf/c/src/struct_ret.c
+++ b/programs/bpf/c/src/struct_ret.c
@@ -1,0 +1,18 @@
+#include <solana_sdk.h>
+
+struct foo {const uint8_t *input;};
+struct foo bar(const uint8_t *input);
+
+extern bool entrypoint(const uint8_t *input) {
+  struct foo foo = bar(input);
+  sol_log_64(0, 0, 0, (uint64_t)input, (uint64_t)foo.input);
+  sol_assert(input == foo.input);
+  return true;
+}
+
+struct foo bar(const uint8_t *input) {
+  struct foo foo;
+  foo.input = input;
+  return foo;
+}
+

--- a/programs/native/bpf_loader/build.rs
+++ b/programs/native/bpf_loader/build.rs
@@ -18,6 +18,9 @@ fn main() {
         println!("cargo:rerun-if-changed=../../bpf/c/src/bench_alu.c");
         println!("cargo:rerun-if-changed=../../bpf/c/src/move_funds.c");
         println!("cargo:rerun-if-changed=../../bpf/c/src/noop.c");
+        println!("cargo:rerun-if-changed=../../bpf/c/src/noop++.c");
+        println!("cargo:rerun-if-changed=../../bpf/c/src/struct_pass.c");
+        println!("cargo:rerun-if-changed=../../bpf/c/src/struct_ret.c");
         println!("cargo:warning=(not a warning) Compiling C-based BPF programs");
         let status = Command::new("make")
             .current_dir("../../bpf/c")

--- a/sdk/bpf/scripts/install.sh
+++ b/sdk/bpf/scripts/install.sh
@@ -32,7 +32,7 @@ if [[ ! -r criterion-$machine-$version.md ]]; then
 fi
 
 # Install LLVM
-version=v0.0.5
+version=v0.0.6
 if [[ ! -f llvm-native-$machine-$version.md ]]; then
   (
     filename=solana-llvm-$machine.tar.bz2


### PR DESCRIPTION
#### Problem

LLVM did not allow passing or returning structs when building BPF

#### Summary of Changes

Removed LLVM restrictions.  This PR adds tests and updates the llvm package.  The actual LLVM changes can be found here: https://github.com/solana-labs/llvm

Fixes #
https://github.com/solana-labs/solana/issues/1803
https://github.com/solana-labs/solana/issues/1802