### PR TITLE
Use hostname or hash to display in dashboard

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2010,9 +2010,9 @@ dependencies = [
  "influx_db_client 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.9.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-sdk 0.11.0",
+ "sys-info 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/metrics/Cargo.toml
+++ b/metrics/Cargo.toml
@@ -9,9 +9,9 @@ license = "Apache-2.0"
 [dependencies]
 influx_db_client = "0.3.6"
 log = "0.4.2"
-rand = "0.6.1"
 reqwest = "0.9.0"
 lazy_static = "1.2.0"
+sys-info = "0.5.6"
 solana-sdk = { path = "../sdk", version = "0.11.0" }
 
 [lib]

--- a/metrics/src/lib.rs
+++ b/metrics/src/lib.rs
@@ -1,11 +1,11 @@
 pub extern crate influx_db_client;
 #[macro_use]
 extern crate lazy_static;
-extern crate rand;
 extern crate reqwest;
 #[macro_use]
 extern crate log;
 extern crate solana_sdk;
+extern crate sys_info;
 
 mod metrics;
 pub use metrics::flush;

--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -124,6 +124,7 @@ local|tar)
   PATH="$HOME"/.cargo/bin:"$PATH"
   export USE_INSTALL=1
   export RUST_LOG
+  export SOLANA_METRICS_DISPLAY_HOSTNAME=1
 
   # Setup `/var/snap/solana/current` symlink so rsyncing the genesis
   # ledger works (reference: `net/scripts/install-rsync.sh`)


### PR DESCRIPTION
#### Problem
The host_id information associated with a node uses a random value which makes it difficult to map it to a particular node.

#### Summary of Changes
Display hostname information associated with the node when environment is set (set for testnet by default), otherwise display the hash of the hostname.

Fixes #
