### PR TITLE
Correctly describe repair and retransmit peers

### DIFF
--- a/src/cluster_info.rs
+++ b/src/cluster_info.rs
@@ -288,18 +288,11 @@ impl ClusterInfo {
             .collect()
     }
 
-    /// all peers with valid tvus and gossip ports
+    /// all tvu peers with valid gossip addrs
     pub fn repair_peers(&self) -> Vec<NodeInfo> {
-        let me = self.my_data().id;
-        self.gossip
-            .crds
-            .table
-            .values()
-            .filter_map(|x| x.value.contact_info())
-            .filter(|x| x.id != me)
-            .filter(|x| ContactInfo::is_valid_address(&x.tvu))
+        ClusterInfo::tvu_peers(self)
+            .into_iter()
             .filter(|x| ContactInfo::is_valid_address(&x.gossip))
-            .cloned()
             .collect()
     }
 

--- a/src/db_window.rs
+++ b/src/db_window.rs
@@ -74,7 +74,7 @@ pub fn repair(
         }
     }
 
-    let num_peers = rcluster_info.tvu_peers().len() as u64;
+    let num_peers = rcluster_info.repair_peers().len() as u64;
 
     // Check if there's a max_entry_height limitation
     let max_repair_entry_height = if max_entry_height == 0 {

--- a/src/window.rs
+++ b/src/window.rs
@@ -176,7 +176,7 @@ impl WindowUtil for Window {
             }
         }
 
-        let num_peers = rcluster_info.tvu_peers().len() as u64;
+        let num_peers = rcluster_info.repair_peers().len() as u64;
         let max_repair = if max_entry_height == 0 {
             calculate_max_repair(
                 num_peers,


### PR DESCRIPTION
#### Problem
Modules were using tvu peers to figure out repair and retransmit peers. But tvu peers is an impure function that filters out the leader because retransmit was also using the same method to figure out retransmit peers. This can lead to the leader not being considered for repair and mismatched peer sizes (tvu_peers vs gossip_peers when the run_window_index method is actually called).
#### Summary of Changes
Added functions to be more explicit about which peers are being selected for retransmit and repair. 

Fixes #
