### PR TITLE
Fix too many args in Tvu::new

### DIFF
--- a/src/cluster_info.rs
+++ b/src/cluster_info.rs
@@ -62,7 +62,7 @@ pub struct ClusterInfo {
     /// The network
     pub gossip: CrdsGossip,
     /// set the keypair that will be used to sign crds values generated. It is unset only in tests.
-    keypair: Arc<Keypair>,
+    pub(crate) keypair: Arc<Keypair>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/src/fullnode.rs
+++ b/src/fullnode.rs
@@ -452,7 +452,6 @@ impl Fullnode {
             };
 
             let tvu = Tvu::new(
-                // self.keypair.clone(),
                 self.vote_account_keypair.clone(),
                 &self.bank,
                 entry_height,

--- a/src/fullnode.rs
+++ b/src/fullnode.rs
@@ -12,7 +12,7 @@ use crate::rpc_pubsub::PubSubService;
 use crate::service::Service;
 use crate::tpu::{Tpu, TpuReturnType};
 use crate::tpu_forwarder::TpuForwarder;
-use crate::tvu::{Tvu, TvuReturnType};
+use crate::tvu::{Sockets, Tvu, TvuReturnType};
 use crate::window::{new_window, SharedWindow};
 use solana_sdk::hash::Hash;
 use solana_sdk::signature::{Keypair, KeypairUtil};
@@ -269,26 +269,33 @@ impl Fullnode {
 
         let node_role = if scheduled_leader != keypair.pubkey() {
             // Start in validator mode.
+            let sockets = Sockets {
+                repair: node
+                    .sockets
+                    .repair
+                    .try_clone()
+                    .expect("Failed to clone repair socket"),
+                retransmit: node
+                    .sockets
+                    .retransmit
+                    .try_clone()
+                    .expect("Failed to clone retransmit socket"),
+                fetch: node
+                    .sockets
+                    .tvu
+                    .iter()
+                    .map(|s| s.try_clone().expect("Failed to clone TVU Sockets"))
+                    .collect(),
+            };
+
             let tvu = Tvu::new(
-                keypair.clone(),
+                // keypair.clone(),
                 vote_account_keypair.clone(),
                 &bank,
                 entry_height,
                 *last_entry_id,
                 cluster_info.clone(),
-                node.sockets
-                    .tvu
-                    .iter()
-                    .map(|s| s.try_clone().expect("Failed to clone TVU sockets"))
-                    .collect(),
-                node.sockets
-                    .repair
-                    .try_clone()
-                    .expect("Failed to clone repair socket"),
-                node.sockets
-                    .retransmit
-                    .try_clone()
-                    .expect("Failed to clone retransmit socket"),
+                sockets,
                 Some(ledger_path),
                 db_ledger.clone(),
             );
@@ -428,23 +435,30 @@ impl Fullnode {
             self.validator_to_leader(tick_height, entry_height, last_entry_id);
             Ok(())
         } else {
+            let sockets = Sockets {
+                repair: self
+                    .repair_socket
+                    .try_clone()
+                    .expect("Failed to clone repair socket"),
+                retransmit: self
+                    .retransmit_socket
+                    .try_clone()
+                    .expect("Failed to clone retransmit socket"),
+                fetch: self
+                    .tvu_sockets
+                    .iter()
+                    .map(|s| s.try_clone().expect("Failed to clone TVU Sockets"))
+                    .collect(),
+            };
+
             let tvu = Tvu::new(
-                self.keypair.clone(),
+                // self.keypair.clone(),
                 self.vote_account_keypair.clone(),
                 &self.bank,
                 entry_height,
                 last_entry_id,
                 self.cluster_info.clone(),
-                self.tvu_sockets
-                    .iter()
-                    .map(|s| s.try_clone().expect("Failed to clone TVU sockets"))
-                    .collect(),
-                self.repair_socket
-                    .try_clone()
-                    .expect("Failed to clone repair socket"),
-                self.retransmit_socket
-                    .try_clone()
-                    .expect("Failed to clone retransmit socket"),
+                sockets,
                 Some(&self.ledger_path),
                 self.db_ledger.clone(),
             );


### PR DESCRIPTION
#### Problem
`Tvu::new`  takes too many arguments and is part of the public crate API

#### Summary of Changes
Now pass in sockets through the `solana::tvu::Sockets` struct

Move `ClusterInfo::keypair` to `pub(crate)` privacy  in order to remove redundant
signing keypair parameter

Fixes #836
