### PR TITLE
Make accounts field of solana::bank::Accounts private again

### DIFF
--- a/src/bank.rs
+++ b/src/bank.rs
@@ -197,7 +197,7 @@ pub struct Accounts {
     // TODO: implement values() or something? take this back to private
     //  from the voting/leader/finality code
     //  issue #1701
-    pub accounts: HashMap<Pubkey, Account>,
+    accounts: HashMap<Pubkey, Account>,
 
     /// The number of transactions the bank has processed without error since the
     /// start of the ledger.
@@ -208,6 +208,11 @@ pub struct Accounts {
 }
 
 impl Accounts {
+    /// Returns a read-only iterator over all known accounts
+    pub fn account_values(&self) -> std::collections::hash_map::Values<Pubkey, Account> {
+        self.accounts.values()
+    }
+
     fn load(&self, pubkey: &Pubkey) -> Option<&Account> {
         if let Some(account) = self.accounts.get(pubkey) {
             return Some(account);

--- a/src/compute_leader_finality_service.rs
+++ b/src/compute_leader_finality_service.rs
@@ -43,8 +43,7 @@ impl ComputeLeaderFinalityService {
             // process_transaction(), case VoteInstruction::RegisterAccount), this will be more accurate.
             // See github issue 1654.
             bank_accounts
-                .accounts
-                .values()
+                .account_values()
                 .filter_map(|account| {
                     // Filter out any accounts that don't belong to the VoteProgram
                     // by returning None

--- a/src/leader_scheduler.rs
+++ b/src/leader_scheduler.rs
@@ -317,8 +317,7 @@ impl LeaderScheduler {
 
             // TODO: iterate through checkpoints, too
             accounts
-                .accounts
-                .values()
+                .account_values()
                 .filter_map(|account| {
                     if vote_program::check_id(&account.owner) {
                         if let Ok(vote_state) = VoteProgram::deserialize(&account.userdata) {


### PR DESCRIPTION
#### Problem
`Accounts::accounts` should not be publicly exposed

#### Summary of Changes

Make the field private and expose an account_values() method that
returns the values iterator from the internal hashmap

Fixes #1701 
