### PR TITLE
Fix shared object relcations with multiple static arrays

### DIFF
--- a/programs/bpf/c/src/multiple_static.c
+++ b/programs/bpf/c/src/multiple_static.c
@@ -1,0 +1,10 @@
+#include <solana_sdk.h>
+
+static const char msg[] = "This is a message";
+static const char msg2[] = "This is a different message";
+
+extern bool entrypoint(const uint8_t *input) {
+  sol_log((char*)msg);
+  sol_log((char*)msg2);
+  return true;
+}

--- a/sdk/bpf/scripts/install.sh
+++ b/sdk/bpf/scripts/install.sh
@@ -32,7 +32,7 @@ if [[ ! -r criterion-$machine-$version.md ]]; then
 fi
 
 # Install LLVM
-version=v0.0.6
+version=v0.0.7
 if [[ ! -f llvm-native-$machine-$version.md ]]; then
   (
     filename=solana-llvm-$machine.tar.bz2

--- a/tests/programs.rs
+++ b/tests/programs.rs
@@ -299,7 +299,13 @@ fn test_program_builtin_bpf_noop() {
 fn test_program_bpf_c() {
     logger::setup();
 
-    let programs = ["noop", "struct_pass", "struct_ret", "noop++"];
+    let programs = [
+        "noop",
+        "noop++",
+        "struct_pass",
+        "struct_ret",
+        "multiple_static",
+    ];
     for program in programs.iter() {
         println!("Test program: {:?}", program);
         let mut file = File::open(create_bpf_path(program)).expect("file open failed");


### PR DESCRIPTION
#### Problem

Multiple static arrays produce section relocations that LLVM's BPF cannot handle.

#### Summary of Changes

Instead, force relocations to be symbol based like all other rodata

Fixes #1804
