### PR TITLE
wallet:  Provide entire elf to bpf_loader

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -616,14 +616,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "getopts"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "glob"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1731,7 +1723,6 @@ dependencies = [
 name = "solana"
 version = "0.11.0"
 dependencies = [
- "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "bincode 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bs58 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bv 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1740,10 +1731,8 @@ dependencies = [
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "dirs 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "elf 0.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "generic-array 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "getopts 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex-literal 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipnetwork 0.12.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1783,7 +1772,6 @@ dependencies = [
  "solana-system-program 0.11.0",
  "solana-vote-program 0.11.0",
  "solana-vote-signer 0.0.1",
- "sys-info 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "untrusted 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2680,7 +2668,6 @@ dependencies = [
 "checksum futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "ab90cde24b3319636588d0c35fe03b1333857621051837ed769faefb4c2162e4"
 "checksum generic-array 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3c0f28c2f5bfb5960175af447a2da7c18900693738343dc896ffbcabd9839592"
 "checksum generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ef25c5683767570c2bbd7deba372926a55eaae9982d7726ee2a1050239d45b9d"
-"checksum getopts 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "0a7292d30132fb5424b354f5dc02512a86e4c516fe544bb7a25e7f266951b797"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
 "checksum globset 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4743617a7464bbda3c8aec8558ff2f9429047e025771037df561d383337ff865"
 "checksum h2 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "7dd33bafe2e6370e6c8eb0cf1b8c5f93390b90acde7e9b03723f166b28b648ed"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,6 @@ test = []
 unstable = []
 
 [dependencies]
-atty = "0.2"
 bincode = "1.0.0"
 bs58 = "0.2.0"
 bv = { version = "0.10.0", features = ["serde"] }
@@ -73,10 +72,8 @@ bytes = "0.4"
 chrono = { version = "0.4.0", features = ["serde"] }
 clap = "2.31"
 dirs = "1.0.2"
-elf = "0.0.10"
 env_logger = "0.6.0"
 generic-array = { version = "0.12.0", default-features = false, features = ["serde"] }
-getopts = "0.2"
 hex-literal = "0.1.1"
 indexmap = "1.0"
 ipnetwork = "0.12.7"
@@ -116,7 +113,6 @@ solana-storage-program = { path = "programs/native/storage", version = "0.11.0" 
 solana-system-program = { path = "programs/native/system", version = "0.11.0" }
 solana-vote-program = { path = "programs/native/vote", version = "0.11.0" }
 solana-vote-signer = { path = "vote-signer", version = "0.0.1" }
-sys-info = "0.5.6"
 tokio = "0.1"
 tokio-codec = "0.1"
 untrusted = "0.6.2"


### PR DESCRIPTION
wallet was not updated to send the entire elf to bpf_loader, it was still only sending the .text section.  
Also remove a couple unused `/Cargo.toml` dependencies for good measure.