### PR TITLE
Add webwallet

### DIFF
--- a/book/art/tpu.bob
+++ b/book/art/tpu.bob
@@ -6,7 +6,7 @@
              |                              |    v                  |
              |  .-------.  .-----------.  .-+-------.   .--------.  |  .------------.
  .---------. |  | Fetch |  | SigVerify |  | Banking |   | Ledger |  |  | Broadcast  |
- | Clients |--->| Stage |->| Stage     |->| Stage   |-->| Write  +---->| Stage      |
+ | Clients |--->| Stage |->| Stage     |->| Stage   |-->| Write  +---->| Service    |
  `---------` |  |       |  |           |  |         |   | Stage  |  |  |            |
              |  `-------`  `-----------`  `----+----`   `---+----`  |  `------------`
              |                                 |            |       |

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -5,6 +5,7 @@
 - [Terminology](terminology.md)
 
 - [Getting Started](getting-started.md)
+  - [Example: Web Wallet](webwallet.md)
 
 - [Programming Model](programs.md)
   - [Example: Tic-Tac-Toe](tictactoe.md)

--- a/book/src/webwallet.md
+++ b/book/src/webwallet.md
@@ -1,0 +1,13 @@
+# Example app: Web Wallet
+
+## Build and run a web wallet locally
+
+First fetch the example code:
+
+```sh
+$ git clone https://github.com/solana-labs/example-webwallet.git
+$ cd example-webwallet
+```
+
+Next, follow the steps in the git repository's
+[README](https://github.com/solana-labs/example-webwallet/blob/master/README.md).


### PR DESCRIPTION
#### Problem

The only link to the Web Wallet example is buried at the bottom of the web3 docs: https://solana-labs.github.io/solana-web3.js/

#### Summary of Changes

Reference the webwallet example in the Getting Started section of the book, since an external developer could create a web wallet without needing to write their own on-chain program. An ERC20-like example would be great to toss here as well.
