### PR TITLE
Add bench_streamer feature to inhibit building solana-bench-streamer by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ name = "solana-upload-perf"
 path = "src/bin/upload-perf.rs"
 
 [[bin]]
+required-features = ["bench_streamer"]
 name = "solana-bench-streamer"
 path = "src/bin/bench-streamer.rs"
 
@@ -62,6 +63,7 @@ erasure = []
 ipv6 = []
 test = []
 unstable = []
+bench_streamer = []
 
 [dependencies]
 atty = "0.2"

--- a/ci/test-checks.sh
+++ b/ci/test-checks.sh
@@ -12,8 +12,12 @@ _() {
   "$@"
 }
 
+# bench_streamer is disabled by default to speed up dev builds, enable it
+# explicitly here to ensure it still passes clippy
+FEATURES=bench_streamer
+
 _ cargo fmt -- --check
 _ cargo clippy -- --version
-_ cargo clippy -- --deny=warnings
+_ cargo clippy --features="$FEATURES" -- --deny=warnings
 
 _ ci/audit.sh

--- a/ci/test-stable.sh
+++ b/ci/test-stable.sh
@@ -23,7 +23,11 @@ if [[ $(ulimit -n) -lt $maxOpenFds ]]; then
   }
 fi
 
-_ cargo build --all --verbose
+# bench_streamer is enabled by default to speed up dev builds, enable it
+# explicitly here to ensure it still compiles
+FEATURES=bench_streamer
+
+_ cargo build --all --verbose --features="$FEATURES"
 _ cargo test --verbose --lib -- --nocapture --test-threads=1
 
 # Run integration tests serially


### PR DESCRIPTION
This program is not currently used in any automation and is fairly slow
to build.  Disabling it by default will speed incremental builds.