### PR TITLE
Move book dev instructions out of top-level readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,34 +61,6 @@ $ git clone https://github.com/solana-labs/solana.git
 $ cd solana
 ```
 
-Building the Solana book
----
-
-Install mdbook:
-
-```bash
-cargo install mdbook
-```
-
-Run any Rust tests in the markdown:
-
-```bash
-make -C book test
-```
-
-Render markdown as HTML:
-
-```bash
-make -C book build
-```
-
-Render and view the book:
-
-```bash
-make -C book open
-```
-
-
 Testing
 ---
 

--- a/book/README.md
+++ b/book/README.md
@@ -1,0 +1,26 @@
+Building the Solana book
+---
+
+Install mdbook:
+
+```bash
+cargo install mdbook
+```
+
+Run any Rust tests in the markdown:
+
+```bash
+make test
+```
+
+Render markdown as HTML:
+
+```bash
+make build
+```
+
+Render and view the book:
+
+```bash
+make open
+```


### PR DESCRIPTION
Treat book as though it is developed in isolation. When changes are made to that directory, it'd be fine if CI only ran `book/build.sh` (and only published it to gh-pages if merged).