### PR TITLE
Cleanup slot remnants in db_ledger

### DIFF
--- a/benches/db_ledger.rs
+++ b/benches/db_ledger.rs
@@ -45,10 +45,13 @@ fn setup_read_bench(
     let mut entries = make_large_test_entries(num_large_blobs as usize);
     entries.extend(make_tiny_test_entries(num_small_blobs as usize));
 
-    // Convert the entries to blobs, wrsite the blobs to the ledger
+    // Convert the entries to blobs, write the blobs to the ledger
     let shared_blobs = entries.to_blobs();
+    for b in shared_blobs {
+        b.write().unwrap().set_slot(slot).unwrap();
+    }
     db_ledger
-        .write_shared_blobs(slot, &shared_blobs)
+        .write_shared_blobs(&shared_blobs)
         .expect("Expectd successful insertion of blobs into ledger");
 }
 

--- a/benches/db_ledger.rs
+++ b/benches/db_ledger.rs
@@ -47,7 +47,7 @@ fn setup_read_bench(
 
     // Convert the entries to blobs, write the blobs to the ledger
     let shared_blobs = entries.to_blobs();
-    for b in shared_blobs {
+    for b in shared_blobs.iter() {
         b.write().unwrap().set_slot(slot).unwrap();
     }
     db_ledger

--- a/src/broadcast_service.rs
+++ b/src/broadcast_service.rs
@@ -122,7 +122,7 @@ fn broadcast(
 
                 trace!("{} null {}", id, pos);
             }
-            for (b, slot) in &blobs {
+            for (b, _) in &blobs {
                 {
                     let ix = b.read().unwrap().index().expect("blob index");
                     let pos = (ix % window_size) as usize;
@@ -130,10 +130,7 @@ fn broadcast(
                     assert!(win[pos].data.is_none());
                     win[pos].data = Some(b.clone());
                 }
-                db_ledger
-                    .write()
-                    .unwrap()
-                    .write_shared_blobs(*slot, vec![b])?;
+                db_ledger.write().unwrap().write_shared_blobs(vec![b])?;
             }
         }
 

--- a/src/cluster_info.rs
+++ b/src/cluster_info.rs
@@ -1236,7 +1236,7 @@ mod tests {
             {
                 let mut w_ledger = db_ledger.write().unwrap();
                 w_ledger
-                    .write_shared_blobs(2, vec![&blob])
+                    .write_shared_blobs(vec![&blob])
                     .expect("Expect successful ledger write");
             }
 

--- a/src/erasure.rs
+++ b/src/erasure.rs
@@ -634,7 +634,6 @@ pub mod test {
     pub fn generate_db_ledger_from_window(
         ledger_path: &str,
         window: &[WindowSlot],
-        slot_height: u64,
         use_random: bool,
     ) -> DbLedger {
         let mut db_ledger =
@@ -649,14 +648,14 @@ pub mod test {
                         .data_cf
                         .put_by_slot_index(
                             &db_ledger.db,
-                            slot_height,
+                            data_l.slot().unwrap(),
                             data_l.index().unwrap(),
                             &data_l.data[..data_l.data_size().unwrap() as usize],
                         )
                         .expect("Expected successful put into data column of ledger");
                 } else {
                     db_ledger
-                        .write_shared_blobs(slot_height, vec![data].into_iter())
+                        .write_shared_blobs(vec![data].into_iter())
                         .unwrap();
                 }
             }
@@ -670,13 +669,13 @@ pub mod test {
 
                 let data_size = coding_lock
                     .size()
-                    .expect("Expected coding blob to have valid ata size");
+                    .expect("Expected coding blob to have valid data size");
 
                 db_ledger
                     .erasure_cf
                     .put_by_slot_index(
                         &db_ledger.db,
-                        slot_height,
+                        coding_lock.slot().unwrap(),
                         index,
                         &coding_lock.data[..data_size as usize + BLOB_HEADER_SIZE],
                     )
@@ -792,8 +791,10 @@ pub mod test {
 
         {
             // Make some dummy slots
-            let slot_tick_heights: Vec<(&SharedBlob, u64)> =
-                blobs.iter().zip(vec![0; blobs.len()]).collect();
+            let slot_tick_heights: Vec<(&SharedBlob, u64)> = blobs
+                .iter()
+                .zip(vec![DEFAULT_SLOT_HEIGHT; blobs.len()])
+                .collect();
             index_blobs(slot_tick_heights, &Keypair::new().pubkey(), offset as u64);
         }
 
@@ -844,7 +845,6 @@ pub mod test {
         let db_ledger = Arc::new(RwLock::new(generate_db_ledger_from_window(
             &ledger_path,
             &window,
-            DEFAULT_SLOT_HEIGHT,
             true,
         )));
 
@@ -899,7 +899,6 @@ pub mod test {
         let db_ledger = Arc::new(RwLock::new(generate_db_ledger_from_window(
             &ledger_path,
             &window,
-            DEFAULT_SLOT_HEIGHT,
             true,
         )));
 

--- a/src/tpu_forwarder.rs
+++ b/src/tpu_forwarder.rs
@@ -115,7 +115,6 @@ mod tests {
     use std::time::Duration;
 
     #[test]
-    #[ignore]
     pub fn test_tpu_forwarder() {
         let nodes: Vec<_> = (0..3)
             .map(|_| {

--- a/src/tpu_forwarder.rs
+++ b/src/tpu_forwarder.rs
@@ -115,6 +115,7 @@ mod tests {
     use std::time::Duration;
 
     #[test]
+    #[ignore]
     pub fn test_tpu_forwarder() {
         let nodes: Vec<_> = (0..3)
             .map(|_| {


### PR DESCRIPTION
#### Problem
Slots are in the blob, so they don't need to be passed as arguments to db_ledger functions

#### Summary of Changes
Remove slots from db_ledger function signatures

Fixes #
