### PR TITLE
Increase ulimits in node startup

### DIFF
--- a/multinode-demo/bootstrap-leader.sh
+++ b/multinode-demo/bootstrap-leader.sh
@@ -46,6 +46,7 @@ if [[ -d $SNAP ]]; then
   fi
 fi
 
+tune_filesystem
 tune_networking
 
 trap 'kill "$pid" && wait "$pid"' INT TERM

--- a/multinode-demo/common.sh
+++ b/multinode-demo/common.sh
@@ -131,6 +131,10 @@ tune_networking() {
   fi
 }
 
+tune_filesystem() {
+  ulimit -n 65535
+}
+
 # The directory on the bootstrap leader that is rsynced by other full nodes as
 # they boot (TODO: Eventually this should go away)
 SOLANA_RSYNC_CONFIG_DIR=${SNAP_DATA:-$PWD}/config

--- a/multinode-demo/fullnode.sh
+++ b/multinode-demo/fullnode.sh
@@ -167,6 +167,7 @@ rsync_url() { # adds the 'rsync://` prefix to URLs that need it
 
 rsync_leader_url=$(rsync_url "$leader")
 
+tune_filesystem
 tune_networking
 
 set -ex


### PR DESCRIPTION
#### Problem
RocksDb uses up a lot of file descriptors, the current setup runs out after about 30 mins on testnet.

#### Summary of Changes
Increase file descriptor limit

Fixes #
