### PR TITLE
Increase the number of files a node may have open at a time

### DIFF
--- a/ci/test-large-network.sh
+++ b/ci/test-large-network.sh
@@ -15,10 +15,7 @@ export LD_LIBRARY_PATH=$PWD/target/perf-libs:$LD_LIBRARY_PATH
 
 export RUST_LOG=multinode=info
 
-if [[ $(ulimit -n) -lt 65000 ]]; then
-  echo 'Error: nofiles too small, run "ulimit -n 65000" to continue'
-  exit 1
-fi
+scripts/ulimit-n.sh
 
 if [[ $(sysctl -n net.core.rmem_default) -lt 1610612736 ]]; then
   echo 'Error: rmem_default too small, run "sudo sysctl -w net.core.rmem_default=1610612736" to continue'

--- a/ci/test-stable.sh
+++ b/ci/test-stable.sh
@@ -12,16 +12,7 @@ _() {
   "$@"
 }
 
-maxOpenFds=65000
-if [[ $(uname) = Darwin ]]; then
-  maxOpenFds=24576 # Appears to be the max permitted on macOS...
-fi
-if [[ $(ulimit -n) -lt $maxOpenFds ]]; then
-  ulimit -n $maxOpenFds|| {
-    echo 'Error: nofiles too small, run "ulimit -n 65000" to continue';
-    exit 1
-  }
-fi
+_ scripts/ulimit-n.sh
 
 _ cargo build --all --verbose
 _ cargo test --all --verbose --lib -- --nocapture --test-threads=1

--- a/multinode-demo/bootstrap-leader.sh
+++ b/multinode-demo/bootstrap-leader.sh
@@ -46,7 +46,7 @@ if [[ -d $SNAP ]]; then
   fi
 fi
 
-tune_networking
+tune_system
 
 trap 'kill "$pid" && wait "$pid"' INT TERM
 $program \

--- a/multinode-demo/common.sh
+++ b/multinode-demo/common.sh
@@ -95,9 +95,12 @@ export RUST_BACKTRACE=1
 # shellcheck source=scripts/configure-metrics.sh
 source "$(dirname "${BASH_SOURCE[0]}")"/../scripts/configure-metrics.sh
 
-tune_networking() {
+tune_system() {
   # Skip in CI
   [[ -z $CI ]] || return 0
+
+  # shellcheck source=scripts/ulimit-n.sh
+  source "$(dirname "${BASH_SOURCE[0]}")"/../scripts/ulimit-n.sh
 
   # Reference: https://medium.com/@CameronSparr/increase-os-udp-buffers-to-improve-performance-51d167bb1360
   if [[ $(uname) = Linux ]]; then

--- a/multinode-demo/fullnode.sh
+++ b/multinode-demo/fullnode.sh
@@ -167,7 +167,7 @@ rsync_url() { # adds the 'rsync://` prefix to URLs that need it
 
 rsync_leader_url=$(rsync_url "$leader")
 
-tune_networking
+tune_system
 
 set -ex
 $rsync -vPr "$rsync_leader_url"/config/ "$ledger_config_dir"

--- a/scripts/ulimit-n.sh
+++ b/scripts/ulimit-n.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+#
+# Adjust the maximum number of files that may be opened to as large as possible.
+#
+
+maxOpenFds=65000
+if [[ $(uname) = Darwin ]]; then
+  maxOpenFds=24576 # Appears to be the max permitted on macOS...
+fi
+
+if [[ $(ulimit -n) -lt $maxOpenFds ]]; then
+  ulimit -n $maxOpenFds || {
+    echo "Error: nofiles too small: $(ulimit -n). Run \"ulimit -n $maxOpenFds\" to continue";
+    exit 1
+  }
+fi
+


### PR DESCRIPTION
RocksDb uses up a lot of file descriptors, the current setup runs out after about 30 mins on testnet.
