### PR TITLE
Move LastIds-related errors into a separate enum

### DIFF
--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -1,6 +1,6 @@
 //! The `rpc` module implements the Solana RPC interface.
 
-use crate::bank::{Bank, BankError};
+use crate::bank::{Bank, BankError, LastIdsError};
 use crate::cluster_info::ClusterInfo;
 use crate::jsonrpc_core::*;
 use crate::jsonrpc_http_server::*;
@@ -202,8 +202,12 @@ impl RpcSol for RpcSolImpl {
                 Err(BankError::ProgramError(_, _)) => RpcSignatureStatus::ProgramRuntimeError,
                 // Report SignatureReserved as SignatureNotFound as SignatureReserved is
                 // transitory while the bank processes the associated transaction.
-                Err(BankError::SignatureReserved) => RpcSignatureStatus::SignatureNotFound,
-                Err(BankError::SignatureNotFound) => RpcSignatureStatus::SignatureNotFound,
+                Err(BankError::LastIdsError(LastIdsError::SignatureReserved)) => {
+                    RpcSignatureStatus::SignatureNotFound
+                }
+                Err(BankError::LastIdsError(LastIdsError::SignatureNotFound)) => {
+                    RpcSignatureStatus::SignatureNotFound
+                }
                 Err(err) => {
                     trace!("mapping {:?} to GenericFailure", err);
                     RpcSignatureStatus::GenericFailure


### PR DESCRIPTION
#### Problem

LastIds struct cannot be extracted from bank.rs without having to move BankError into a separate module.

#### Summary of Changes

Create a separate enum for the LastIds-related errors.
