### PR TITLE
Upgrade grcov

### DIFF
--- a/ci/test-nightly.sh
+++ b/ci/test-nightly.sh
@@ -38,7 +38,7 @@ if [[ ! -f ./grcov ]]; then
   fi
   uname_m=$(uname -m | tr '[:upper:]' '[:lower:]')
   name=grcov-${uname}-${uname_m}.tar.bz2
-  _ wget "https://github.com/mozilla/grcov/releases/download/v0.2.3/${name}"
+  _ wget "https://github.com/mozilla/grcov/releases/download/v0.3.2/${name}"
   _ tar -xjf "${name}"
 fi
 _ ./grcov . -t lcov > lcov.info


### PR DESCRIPTION
#### Problem

grcov v0.2.3 can't parse the files generated by cargo-cov

#### Summary of Changes

Test-drive latest grcov

cc #433

