### PR TITLE
fullnode: Include port number when gossip bind_to fails

### DIFF
--- a/multinode-demo/fullnode.sh
+++ b/multinode-demo/fullnode.sh
@@ -133,8 +133,16 @@ else
   mkdir -p "$SOLANA_CONFIG_DIR"
   fullnode_json_path=$SOLANA_CONFIG_DIR/fullnode-x$$.json
 
-  port=9000
-  (((port += ($$ % 1000)) && (port == 9000) && port++))
+  # Find an available port in the range 9100-9899
+  (( port = 9100 + ($$ % 800) ))
+  while true; do
+    (( port = port >= 9900 ? 9100 : ++port ))
+    if ! nc -z 127.0.0.1 $port; then
+      echo "Selected port $port"
+      break;
+    fi
+    echo "Port $port is in use"
+  done
 
   $solana_fullnode_config --keypair="$fullnode_id_path" -l -b "$port" > "$fullnode_json_path"
 

--- a/src/cluster_info.rs
+++ b/src/cluster_info.rs
@@ -1053,7 +1053,9 @@ impl Node {
         let (gossip_port, gossip) = if gossip_addr.port() != 0 {
             (
                 gossip_addr.port(),
-                bind_to(gossip_addr.port(), false).expect("gossip_addr bind"),
+                bind_to(gossip_addr.port(), false).unwrap_or_else(|e| {
+                    panic!("gossip_addr bind_to port {}: {}", gossip_addr.port(), e)
+                }),
             )
         } else {
             bind()


### PR DESCRIPTION
Hoping this extra debug will help debug info this CI failure when it next occurs:
> thread 'main' panicked at 'gossip_addr bind: Os { code: 98, kind: AddrInUse, message: "Address already in use" }'

cc: https://buildkite.com/solana-labs/solana/builds/28#6d6efffa-bc30-420f-8415-b694efed78c8