### PR TITLE
ci: Add wallet sanity timeout

### DIFF
--- a/ci/localnet-sanity.sh
+++ b/ci/localnet-sanity.sh
@@ -71,7 +71,7 @@ flag_error() {
 echo "--- Wallet sanity"
 (
   set -x
-  scripts/wallet-sanity.sh
+  timeout 60s scripts/wallet-sanity.sh
 ) || flag_error
 
 echo "--- Node count"


### PR DESCRIPTION
wallet-sanity.sh got stuck recently in CI [1] and clogged up a buildkite agent for 20min before the system-level timeout kicked in.  Instead enforce a 60 second timeout for wallet-sanity.sh itself. 

This doesn't fix the underlying issue but (a) helps keep CI unclogged, (b) should result in log artifacts from getting uploaded the next time this timeout occurs so actual debug can occur

[1] https://buildkite.com/solana-labs/solana/builds/36#3455eb98-23e5-4643-a4ea-700799358205