### PR TITLE
Ensure the full workspace is built for coverage and restore recently ignored tests

### DIFF
--- a/ci/test-nightly.sh
+++ b/ci/test-nightly.sh
@@ -27,6 +27,7 @@ cargo_install_unless cargo-cov cargo cov --help
 
 # Generate coverage data and report via unit-test suite.
 _ cargo cov clean
+_ cargo cov build --all
 _ cargo cov test --lib
 _ cargo cov report
 

--- a/src/compute_leader_finality_service.rs
+++ b/src/compute_leader_finality_service.rs
@@ -163,7 +163,6 @@ pub mod tests {
     use std::time::Duration;
 
     #[test]
-    #[ignore]
     fn test_compute_finality() {
         solana_logger::setup();
 

--- a/src/fullnode.rs
+++ b/src/fullnode.rs
@@ -811,7 +811,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
     fn test_wrong_role_transition() {
         // Create the leader node information
         let bootstrap_leader_keypair = Arc::new(Keypair::new());
@@ -931,7 +930,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
     fn test_validator_to_leader_transition() {
         // Make a leader identity
         let leader_keypair = Keypair::new();

--- a/src/leader_scheduler.rs
+++ b/src/leader_scheduler.rs
@@ -683,7 +683,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
     fn test_active_set() {
         let leader_id = Keypair::new().pubkey();
         let active_window_length = 1000;
@@ -904,7 +903,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
     fn test_scheduler() {
         // Test when the number of validators equals
         // seed_rotation_interval / leader_rotation_interval, so each validator
@@ -963,7 +961,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
     fn test_scheduler_active_window() {
         let num_validators = 10;
         let num_vote_account_tokens = 1;
@@ -1047,7 +1044,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
     fn test_multiple_vote() {
         let leader_keypair = Keypair::new();
         let leader_id = leader_keypair.pubkey();
@@ -1275,7 +1271,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
     fn test_avoid_consecutive_leaders() {
         // Test when there is both a leader + validator in the active set
         run_consecutive_leader_test(1, true);
@@ -1289,7 +1284,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
     fn test_max_height_for_leader() {
         let bootstrap_leader_keypair = Keypair::new();
         let bootstrap_leader_id = bootstrap_leader_keypair.pubkey();

--- a/src/replay_stage.rs
+++ b/src/replay_stage.rs
@@ -270,7 +270,6 @@ mod test {
     use std::sync::{Arc, RwLock};
 
     #[test]
-    #[ignore]
     pub fn test_replay_stage_leader_rotation_exit() {
         solana_logger::setup();
 
@@ -468,7 +467,6 @@ mod test {
     }
 
     #[test]
-    #[ignore]
     fn test_vote_error_replay_stage_leader_rotation() {
         // Set up dummy node to host a ReplayStage
         let my_keypair = Keypair::new();

--- a/src/thin_client.rs
+++ b/src/thin_client.rs
@@ -596,7 +596,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
     fn test_register_vote_account() {
         solana_logger::setup();
         let leader_keypair = Arc::new(Keypair::new());


### PR DESCRIPTION
Fixes the "failures on nightly:" section of #2193