### PR TITLE
storage program: Correct crate-type to match other native programs

### DIFF
--- a/programs/native/storage/Cargo.toml
+++ b/programs/native/storage/Cargo.toml
@@ -18,5 +18,5 @@ solana-sdk = { path = "../../../sdk", version = "0.11.0" }
 
 [lib]
 name = "solana_storage_program"
-crate-type = ["dylib"]
+crate-type = ["cdylib"]
 


### PR DESCRIPTION
These commands produced no "hihi" output from the storage program:
```
$ ( cd programs/native/storage/; cargo build )
$ RUST_LOG=solana=info cargo test test_replicator_startup --features="chacha"
```
with the following patch applied:
```diff
diff --git a/programs/native/storage/src/lib.rs b/programs/native/storage/src/lib.rs
index a449a2d..aaa8429 100644
--- a/programs/native/storage/src/lib.rs
+++ b/programs/native/storage/src/lib.rs
@@ -17,6 +17,7 @@ fn entrypoint(
     _tick_height: u64,
 ) -> Result<(), ProgramError> {
     solana_logger::setup();
+    info!("hihi");
 
     // accounts_keys[0] must be signed
     if keyed_accounts[0].signer_key().is_none() {
```
because the storage program was erroneously a "dylib" create instead of "cdylib" like all other native programs.