### PR TITLE
Debug broadcast

### DIFF
--- a/benches/db_ledger.rs
+++ b/benches/db_ledger.rs
@@ -158,13 +158,10 @@ fn bench_insert_data_blob_small(bench: &mut Bencher) {
     let mut blob_locks: Vec<_> = shared_blobs.iter().map(|b| b.write().unwrap()).collect();
     let mut blobs: Vec<&mut Blob> = blob_locks.iter_mut().map(|b| &mut **b).collect();
     blobs.shuffle(&mut thread_rng());
-    let slot = 0;
 
     bench.iter(move || {
         for blob in blobs.iter_mut() {
-            let index = blob.index().unwrap();
-            let key = DataCf::key(slot, index);
-            db_ledger.insert_data_blob(&key, blob).unwrap();
+            db_ledger.insert_data_blobs(vec![blob]).unwrap();
             blob.set_index(index + num_entries as u64).unwrap();
         }
     });
@@ -185,13 +182,10 @@ fn bench_insert_data_blob_big(bench: &mut Bencher) {
     let mut blob_locks: Vec<_> = shared_blobs.iter().map(|b| b.write().unwrap()).collect();
     let mut blobs: Vec<&mut Blob> = blob_locks.iter_mut().map(|b| &mut **b).collect();
     blobs.shuffle(&mut thread_rng());
-    let slot = 0;
 
     bench.iter(move || {
         for blob in blobs.iter_mut() {
-            let index = blob.index().unwrap();
-            let key = DataCf::key(slot, index);
-            db_ledger.insert_data_blob(&key, blob).unwrap();
+            db_ledger.insert_data_blobs(vec![blob]).unwrap();
             blob.set_index(index + num_entries as u64).unwrap();
         }
     });

--- a/fullnode/src/main.rs
+++ b/fullnode/src/main.rs
@@ -119,7 +119,7 @@ fn main() {
     let mut leader_scheduler = LeaderScheduler::default();
 
     // Remove this line to enable leader rotation
-    leader_scheduler.use_only_bootstrap_leader = true;
+    leader_scheduler.use_only_bootstrap_leader = use_only_bootstrap_leader;
 
     let rpc_port = if let Some(port) = matches.value_of("rpc") {
         let port_number = port.to_string().parse().expect("integer");

--- a/fullnode/src/main.rs
+++ b/fullnode/src/main.rs
@@ -119,7 +119,7 @@ fn main() {
     let mut leader_scheduler = LeaderScheduler::default();
 
     // Remove this line to enable leader rotation
-    leader_scheduler.use_only_bootstrap_leader = use_only_bootstrap_leader;
+    leader_scheduler.use_only_bootstrap_leader = true;
 
     let rpc_port = if let Some(port) = matches.value_of("rpc") {
         let port_number = port.to_string().parse().expect("integer");

--- a/src/broadcast_service.rs
+++ b/src/broadcast_service.rs
@@ -125,6 +125,7 @@ fn broadcast(
             }
             for b in &blobs {
                 {
+                    println!("blob size: {}", b.read().unwrap().data_size()?);
                     let ix = b.read().unwrap().index().expect("blob index");
                     let pos = (ix % window_size) as usize;
                     trace!("{} caching {} at {}", id, ix, pos);
@@ -133,9 +134,14 @@ fn broadcast(
                 }
             }
 
-            db_ledger
-                .write_shared_blobs(&blobs)
-                .expect("Unrecoverable failure to write to database");
+            let write_start = Instant::now();
+            db_ledger.write_shared_blobs(&blobs).expect("Unrecoverable failure to write to database");
+            let duration = duration_as_ms(&write_start.elapsed()) as usize;
+            println!(
+                "Writing {} blobs in broadcast, elapsed: {}",
+                blobs.len(),
+                duration
+            );
         }
 
         // Fill in the coding blob data from the window data blobs

--- a/src/broadcast_service.rs
+++ b/src/broadcast_service.rs
@@ -135,7 +135,9 @@ fn broadcast(
             }
 
             let write_start = Instant::now();
-            db_ledger.write_shared_blobs(&blobs).expect("Unrecoverable failure to write to database");
+            db_ledger
+                .write_shared_blobs(&blobs)
+                .expect("Unrecoverable failure to write to database");
             let duration = duration_as_ms(&write_start.elapsed()) as usize;
             println!(
                 "Writing {} blobs in broadcast, elapsed: {}",

--- a/src/broadcast_service.rs
+++ b/src/broadcast_service.rs
@@ -125,7 +125,6 @@ fn broadcast(
             }
             for b in &blobs {
                 {
-                    println!("blob size: {}", b.read().unwrap().data_size()?);
                     let ix = b.read().unwrap().index().expect("blob index");
                     let pos = (ix % window_size) as usize;
                     trace!("{} caching {} at {}", id, ix, pos);
@@ -134,16 +133,9 @@ fn broadcast(
                 }
             }
 
-            let write_start = Instant::now();
             db_ledger
                 .write_consecutive_blobs(&blobs)
                 .expect("Unrecoverable failure to write to database");
-            let duration = duration_as_ms(&write_start.elapsed()) as usize;
-            println!(
-                "Writing {} blobs in broadcast, elapsed: {}",
-                blobs.len(),
-                duration
-            );
         }
 
         // Fill in the coding blob data from the window data blobs

--- a/src/broadcast_service.rs
+++ b/src/broadcast_service.rs
@@ -100,7 +100,8 @@ fn broadcast(
         {
             let mut win = window.write().unwrap();
             assert!(blobs.len() <= win.len());
-            for (b, _) in &blobs {
+            let blobs: Vec<_> = blobs.into_iter().map(|(b, _)| b).collect();
+            for b in &blobs {
                 let ix = b.read().unwrap().index().expect("blob index");
                 let pos = (ix % window_size) as usize;
                 if let Some(x) = win[pos].data.take() {
@@ -122,7 +123,7 @@ fn broadcast(
 
                 trace!("{} null {}", id, pos);
             }
-            for (b, _) in &blobs {
+            for b in &blobs {
                 {
                     let ix = b.read().unwrap().index().expect("blob index");
                     let pos = (ix % window_size) as usize;
@@ -130,8 +131,11 @@ fn broadcast(
                     assert!(win[pos].data.is_none());
                     win[pos].data = Some(b.clone());
                 }
-                db_ledger.write_shared_blobs(vec![b])?;
             }
+
+            db_ledger
+                .write_shared_blobs(&blobs)
+                .expect("Unrecoverable failure to write to database");
         }
 
         // Fill in the coding blob data from the window data blobs

--- a/src/broadcast_service.rs
+++ b/src/broadcast_service.rs
@@ -136,7 +136,7 @@ fn broadcast(
 
             let write_start = Instant::now();
             db_ledger
-                .write_shared_blobs(&blobs)
+                .write_consecutive_blobs(&blobs)
                 .expect("Unrecoverable failure to write to database");
             let duration = duration_as_ms(&write_start.elapsed()) as usize;
             println!(

--- a/src/db_ledger.rs
+++ b/src/db_ledger.rs
@@ -931,17 +931,25 @@ mod tests {
             }
 
             assert_eq!(
-                db_ledger.write_shared_blobs(shared_blobs.iter().skip(1).step_by(2)).unwrap(),
+                db_ledger
+                    .write_shared_blobs(shared_blobs.iter().skip(1).step_by(2))
+                    .unwrap(),
                 vec![]
             );
 
             assert_eq!(
-                db_ledger.write_shared_blobs(shared_blobs.iter().step_by(2)).unwrap(),
+                db_ledger
+                    .write_shared_blobs(shared_blobs.iter().step_by(2))
+                    .unwrap(),
                 original_entries
             );
 
             let meta_key = MetaCf::key(DEFAULT_SLOT_HEIGHT);
-            let meta = db_ledger.meta_cf.get(&db_ledger.db, &meta_key).unwrap().unwrap();
+            let meta = db_ledger
+                .meta_cf
+                .get(&db_ledger.db, &meta_key)
+                .unwrap()
+                .unwrap();
             assert_eq!(meta.consumed, num_entries);
             assert_eq!(meta.received, num_entries);
             assert_eq!(meta.consumed_slot, num_entries - 1);

--- a/src/db_ledger.rs
+++ b/src/db_ledger.rs
@@ -7,7 +7,9 @@ use crate::packet::{Blob, SharedBlob, BLOB_HEADER_SIZE};
 use crate::result::{Error, Result};
 use bincode::{deserialize, serialize};
 use byteorder::{BigEndian, ByteOrder, ReadBytesExt};
-use rocksdb::{ColumnFamily, ColumnFamilyDescriptor, DBRawIterator, Options, WriteBatch, DB};
+use rocksdb::{
+    ColumnFamily, ColumnFamilyDescriptor, DBCompactionStyle, DBRawIterator, Options, WriteBatch, DB,
+};
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 use solana_sdk::signature::{Keypair, KeypairUtil};
@@ -539,6 +541,7 @@ impl DbLedger {
         let mut options = Options::default();
         options.set_max_write_buffer_number(32);
         options.set_write_buffer_size(512 * 1024 * 1024);
+        options.set_compaction_style(DBCompactionStyle::Universal);
         options
     }
 
@@ -547,10 +550,11 @@ impl DbLedger {
         options.create_if_missing(true);
         options.create_missing_column_families(true);
         options.increase_parallelism(TOTAL_THREADS);
-        options.set_max_background_flushes(16);
-        options.set_max_background_compactions(8);
+        options.set_max_background_flushes(4);
+        options.set_max_background_compactions(4);
         options.set_max_write_buffer_number(32);
         options.set_write_buffer_size(512 * 1024 * 1024);
+        options.set_compaction_style(DBCompactionStyle::Universal);
         options
     }
 }

--- a/src/db_ledger.rs
+++ b/src/db_ledger.rs
@@ -11,12 +11,10 @@ use rocksdb::{ColumnFamily, ColumnFamilyDescriptor, DBRawIterator, Options, Writ
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 use solana_sdk::signature::{Keypair, KeypairUtil};
-use solana_sdk::timing::duration_as_ms;
 use std::borrow::Borrow;
 use std::cmp::max;
 use std::io;
 use std::path::Path;
-use std::time::Instant;
 
 pub const DB_LEDGER_DIRECTORY: &str = "rocksdb";
 // A good value for this is the number of cores on the machine
@@ -317,7 +315,7 @@ impl DbLedger {
     where
         I: IntoIterator<Item = &'a &'a Blob>,
     {
-        let blobs = blobs.into_iter().map(|b| *b);
+        let blobs = blobs.into_iter().cloned();
         let new_entries = self.insert_data_blobs(blobs)?;
         Ok(new_entries)
     }
@@ -347,25 +345,16 @@ impl DbLedger {
     {
         let mut new_blobs: Vec<_> = new_blobs.into_iter().collect();
 
-        if new_blobs.len() == 0 {
+        if new_blobs.is_empty() {
             return Ok(vec![]);
         }
 
-        let new_blobs_len = new_blobs.len();
-        let sort_start = Instant::now();
         new_blobs.sort_unstable_by(|b1, b2| {
             b1.borrow()
                 .index()
                 .unwrap()
                 .cmp(&b2.borrow().index().unwrap())
         });
-        let duration = duration_as_ms(&sort_start.elapsed()) as usize;
-        if new_blobs_len > 100 {
-            println!(
-                "Sort {} blobs in db_ledger, elapsed: {}",
-                new_blobs_len, duration
-            );
-        }
 
         let meta_key = MetaCf::key(DEFAULT_SLOT_HEIGHT);
 
@@ -400,7 +389,6 @@ impl DbLedger {
 
         let mut consumed_queue = vec![];
 
-        let loop_start = Instant::now();
         if meta.consumed == lowest_index {
             // Find the next consecutive block of blobs.
             // TODO: account for consecutive blocks that
@@ -459,20 +447,10 @@ impl DbLedger {
             }
         }
 
-        let duration = duration_as_ms(&loop_start.elapsed()) as usize;
-        if new_blobs_len > 100 {
-            println!("Loop blobs in db_ledger, elapsed: {}", duration);
-        }
-        let put_cf = Instant::now();
         // Commit Step: Atomic write both the metadata and the data
         let mut batch = WriteBatch::default();
         if should_write_meta {
             batch.put_cf(self.meta_cf.handle(&self.db), &meta_key, &serialize(&meta)?)?;
-        }
-
-        let duration = duration_as_ms(&put_cf.elapsed()) as usize;
-        if new_blobs_len > 100 {
-            println!("Put_Cf blobs in db_ledger, elapsed: {}", duration);
         }
 
         for blob in new_blobs {
@@ -482,21 +460,13 @@ impl DbLedger {
             batch.put_cf(self.data_cf.handle(&self.db), &key, serialized_blob_datas)?;
         }
 
-        let db_start = Instant::now();
         self.db.write(batch)?;
-        let duration = duration_as_ms(&db_start.elapsed()) as usize;
-        if new_blobs_len > 100 {
-            println!(
-                "Writing {} blobs in db_ledger, elapsed: {}",
-                new_blobs_len, duration
-            );
-        }
         Ok(consumed_queue)
     }
 
     // Writes a list of sorted, consecutive broadcast blobs to the db_ledger
     pub fn write_consecutive_blobs(&self, blobs: &[SharedBlob]) -> Result<()> {
-        assert!(blobs.len() > 0);
+        assert!(!blobs.is_empty());
 
         let meta_key = MetaCf::key(DEFAULT_SLOT_HEIGHT);
 

--- a/src/db_ledger.rs
+++ b/src/db_ledger.rs
@@ -484,7 +484,10 @@ impl DbLedger {
         }
 
         let db_start = Instant::now();
-        self.db.write(batch)?;
+        let mut write_options = WriteOptions::default();
+        write_options.set_sync(false);
+        write_options.disable_wal(true);
+        self.db.write_opt(batch, &write_options)?;
         let duration = duration_as_ms(&db_start.elapsed()) as usize;
         println!("Writing {} blobs in db_ledger, elapsed: {}", len, duration);
         Ok(consumed_queue)

--- a/src/db_ledger.rs
+++ b/src/db_ledger.rs
@@ -18,7 +18,7 @@ use std::path::Path;
 
 pub const DB_LEDGER_DIRECTORY: &str = "rocksdb";
 // A good value for this is the number of cores on the machine
-pub const TOTAL_THREADS: i32 = 4;
+pub const TOTAL_THREADS: i32 = 8;
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum DbLedgerError {
@@ -583,8 +583,8 @@ impl DbLedger {
         options.create_if_missing(true);
         options.create_missing_column_families(true);
         options.increase_parallelism(TOTAL_THREADS);
-        options.set_max_background_flushes(2);
-        options.set_max_background_compactions(2);
+        options.set_max_background_flushes(4);
+        options.set_max_background_compactions(4);
         options.set_max_write_buffer_number(32);
         options.set_write_buffer_size(512 * 1024 * 1024);
         options

--- a/src/db_window.rs
+++ b/src/db_window.rs
@@ -310,8 +310,8 @@ pub fn process_blob(
         )?;
         vec![]
     } else {
-        let data_key = DataCf::key(slot, pix);
-        db_ledger.insert_data_blob(&data_key, &blob.read().unwrap())?
+        db_ledger
+            .insert_data_blobs(vec![&*blob.read().unwrap()])?
     };
 
     #[cfg(feature = "erasure")]

--- a/src/db_window.rs
+++ b/src/db_window.rs
@@ -310,8 +310,7 @@ pub fn process_blob(
         )?;
         vec![]
     } else {
-        db_ledger
-            .insert_data_blobs(vec![&*blob.read().unwrap()])?
+        db_ledger.insert_data_blobs(vec![&*blob.read().unwrap()])?
     };
 
     #[cfg(feature = "erasure")]

--- a/src/thin_client.rs
+++ b/src/thin_client.rs
@@ -450,6 +450,7 @@ mod tests {
         let mut bank = Bank::new(&alice);
         let bob_pubkey = Keypair::new().pubkey();
         let ledger_path = create_tmp_ledger_with_mint("thin_client", &alice);
+        let entry_height = alice.create_entries().len() as u64;
 
         let leader_scheduler = Arc::new(RwLock::new(LeaderScheduler::from_bootstrap_leader(
             leader_data.id,
@@ -461,7 +462,7 @@ mod tests {
             leader_keypair,
             vote_account_keypair,
             bank,
-            0,
+            entry_height,
             &last_id,
             leader,
             None,


### PR DESCRIPTION
#### Problem
Broadcast stage could not process blobs fast enough during heavy load, causing leader crash due to buildup of blobs in channel.

#### Summary of Changes
1) Tune RocksDb to handle this load.
2) Bulk insert blobs to db_ledger in broadcast stage instead of one at a time.


Fixes #
