### PR TITLE
Update test-bench.sh for rust nightly 1.33

### DIFF
--- a/ci/version-check-with-upgrade.sh
+++ b/ci/version-check-with-upgrade.sh
@@ -6,6 +6,5 @@ cd "$(dirname "$0")"
 channel=${1:-stable}
 if ! ./version-check.sh "$channel"; then
   rustup install "$channel"
-  rustup default "$channel"
   ./version-check.sh "$channel"
 fi

--- a/ci/version-check.sh
+++ b/ci/version-check.sh
@@ -4,8 +4,9 @@ set -e
 require() {
   declare expectedProgram="$1"
   declare expectedVersion="$2"
+  shift 2
 
-  read -r program version _ < <($expectedProgram -V)
+  read -r program version _ < <($expectedProgram "$@" -V)
 
   declare ok=true
   [[ $program = "$expectedProgram" ]] || ok=false
@@ -20,8 +21,8 @@ require() {
 
 case ${1:-stable} in
 nightly)
-  require rustc 1.32.[0-9]+-nightly
-  require cargo 1.32.[0-9]+-nightly
+  require rustc 1.32.[0-9]+-nightly +nightly
+  require cargo 1.32.[0-9]+-nightly +nightly
   ;;
 stable)
   require rustc 1.31.[0-9]+

--- a/ci/version-check.sh
+++ b/ci/version-check.sh
@@ -21,8 +21,8 @@ require() {
 
 case ${1:-stable} in
 nightly)
-  require rustc 1.32.[0-9]+-nightly +nightly
-  require cargo 1.32.[0-9]+-nightly +nightly
+  require rustc 1.33.[0-9]+-nightly +nightly
+  require cargo 1.33.[0-9]+-nightly +nightly
   ;;
 stable)
   require rustc 1.31.[0-9]+


### PR DESCRIPTION
test-bench.sh is failing because upstream rust nightly just version bumped.  We run things in containers to prevent exactly this kind of random churn, but benching in docker is 3x slower than on the metal.  So just ++ the nightly version
