### PR TITLE
DbLedger doesn't need to be mut, doesn't need an RwLock

### DIFF
--- a/src/db_ledger.rs
+++ b/src/db_ledger.rs
@@ -285,7 +285,7 @@ impl DbLedger {
         Ok(())
     }
 
-    pub fn write_shared_blobs<I>(&mut self, shared_blobs: I) -> Result<Vec<Entry>>
+    pub fn write_shared_blobs<I>(&self, shared_blobs: I) -> Result<Vec<Entry>>
     where
         I: IntoIterator,
         I::Item: Borrow<SharedBlob>,
@@ -302,7 +302,7 @@ impl DbLedger {
         Ok(entries)
     }
 
-    pub fn write_blobs<'a, I>(&mut self, blobs: I) -> Result<Vec<Entry>>
+    pub fn write_blobs<'a, I>(&self, blobs: I) -> Result<Vec<Entry>>
     where
         I: IntoIterator<Item = &'a &'a Blob>,
     {
@@ -316,7 +316,7 @@ impl DbLedger {
         Ok(entries)
     }
 
-    pub fn write_entries<I>(&mut self, slot: u64, entries: I) -> Result<Vec<Entry>>
+    pub fn write_entries<I>(&self, slot: u64, entries: I) -> Result<Vec<Entry>>
     where
         I: IntoIterator,
         I::Item: Borrow<Entry>,
@@ -427,7 +427,7 @@ impl DbLedger {
     //
     // Return tuple of (number of blob read, total size of blobs read)
     pub fn get_blob_bytes(
-        &mut self,
+        &self,
         start_index: u64,
         num_blobs: u64,
         buf: &mut [u8],
@@ -533,7 +533,7 @@ where
 {
     let mut entries = entries.into_iter();
     for ledger_path in ledger_paths {
-        let mut db_ledger =
+        let db_ledger =
             DbLedger::open(ledger_path).expect("Expected to be able to open database ledger");
         db_ledger
             .write_entries(slot_height, entries.by_ref())
@@ -545,7 +545,7 @@ pub fn genesis<'a, I>(ledger_path: &str, keypair: &Keypair, entries: I) -> Resul
 where
     I: IntoIterator<Item = &'a Entry>,
 {
-    let mut db_ledger = DbLedger::open(ledger_path)?;
+    let db_ledger = DbLedger::open(ledger_path)?;
 
     // TODO sign these blobs with keypair
     let blobs = entries.into_iter().enumerate().map(|(idx, entry)| {
@@ -631,7 +631,7 @@ mod tests {
         let blobs: Vec<&Blob> = blob_locks.iter().map(|b| &**b).collect();
 
         let ledger_path = get_tmp_ledger_path("test_get_blobs_bytes");
-        let mut ledger = DbLedger::open(&ledger_path).unwrap();
+        let ledger = DbLedger::open(&ledger_path).unwrap();
         ledger.write_blobs(&blobs).unwrap();
 
         let mut buf = [0; 1024];
@@ -814,7 +814,7 @@ mod tests {
         // Create RocksDb ledger
         let db_ledger_path = get_tmp_ledger_path("test_iteration_order");
         {
-            let mut db_ledger = DbLedger::open(&db_ledger_path).unwrap();
+            let db_ledger = DbLedger::open(&db_ledger_path).unwrap();
 
             // Write entries
             let num_entries = 8;

--- a/src/erasure.rs
+++ b/src/erasure.rs
@@ -351,7 +351,7 @@ pub fn generate_coding(
 // Recover the missing data and coding blobs from the input ledger. Returns a vector
 // of the recovered missing data blobs and a vector of the recovered coding blobs
 pub fn recover(
-    db_ledger: &Arc<RwLock<DbLedger>>,
+    db_ledger: &Arc<DbLedger>,
     slot: u64,
     start_idx: u64,
 ) -> Result<(Vec<SharedBlob>, Vec<SharedBlob>)> {

--- a/src/erasure.rs
+++ b/src/erasure.rs
@@ -367,17 +367,11 @@ pub fn recover(
         block_end_idx
     );
 
-    let data_missing = find_missing_data_indexes(
-        slot,
-        &db_ledger.read().unwrap(),
-        block_start_idx,
-        block_end_idx,
-        NUM_DATA,
-    )
-    .len();
+    let data_missing =
+        find_missing_data_indexes(slot, &db_ledger, block_start_idx, block_end_idx, NUM_DATA).len();
     let coding_missing = find_missing_coding_indexes(
         slot,
-        &db_ledger.read().unwrap(),
+        &db_ledger,
         coding_start_idx,
         block_end_idx,
         NUM_CODING,
@@ -416,10 +410,9 @@ pub fn recover(
 
     // Add the data blobs we have into the recovery vector, mark the missing ones
     for i in block_start_idx..block_end_idx {
-        let result = {
-            let r_db = db_ledger.read().unwrap();
-            r_db.data_cf.get_by_slot_index(&r_db.db, slot, i)?
-        };
+        let result = db_ledger
+            .data_cf
+            .get_by_slot_index(&db_ledger.db, slot, i)?;
 
         categorize_blob(
             &result,
@@ -432,10 +425,9 @@ pub fn recover(
 
     // Add the coding blobs we have into the recovery vector, mark the missing ones
     for i in coding_start_idx..block_end_idx {
-        let result = {
-            let r_db = db_ledger.read().unwrap();
-            r_db.erasure_cf.get_by_slot_index(&r_db.db, slot, i)?
-        };
+        let result = db_ledger
+            .erasure_cf
+            .get_by_slot_index(&db_ledger.db, slot, i)?;
 
         categorize_blob(
             &result,
@@ -528,10 +520,9 @@ pub fn recover(
         // Remove the corrupted coding blobs so there's no effort wasted in trying to reconstruct
         // the blobs again
         for i in coding_start_idx..block_end_idx {
-            {
-                let r_db = db_ledger.read().unwrap();
-                r_db.erasure_cf.delete_by_slot_index(&r_db.db, slot, i)?;
-            }
+            db_ledger
+                .erasure_cf
+                .delete_by_slot_index(&db_ledger.db, slot, i)?;
         }
         return Ok((vec![], vec![]));
     }
@@ -576,7 +567,7 @@ pub mod test {
     use rand::{thread_rng, Rng};
     use solana_sdk::pubkey::Pubkey;
     use solana_sdk::signature::{Keypair, KeypairUtil};
-    use std::sync::{Arc, RwLock};
+    use std::sync::Arc;
 
     #[test]
     pub fn test_coding() {
@@ -636,7 +627,7 @@ pub mod test {
         window: &[WindowSlot],
         use_random: bool,
     ) -> DbLedger {
-        let mut db_ledger =
+        let db_ledger =
             DbLedger::open(ledger_path).expect("Expected to be able to open database ledger");
         for slot in window {
             if let Some(ref data) = slot.data {
@@ -842,11 +833,7 @@ pub mod test {
 
         // Generate the db_ledger from the window
         let ledger_path = get_tmp_ledger_path("test_window_recover_basic");
-        let db_ledger = Arc::new(RwLock::new(generate_db_ledger_from_window(
-            &ledger_path,
-            &window,
-            true,
-        )));
+        let db_ledger = Arc::new(generate_db_ledger_from_window(&ledger_path, &window, true));
 
         // Recover it from coding
         let (recovered_data, recovered_coding) = recover(&db_ledger, 0, offset as u64)
@@ -896,11 +883,7 @@ pub mod test {
         window[erase_offset].data = None;
         window[erase_offset].coding = None;
         let ledger_path = get_tmp_ledger_path("test_window_recover_basic2");
-        let db_ledger = Arc::new(RwLock::new(generate_db_ledger_from_window(
-            &ledger_path,
-            &window,
-            true,
-        )));
+        let db_ledger = Arc::new(generate_db_ledger_from_window(&ledger_path, &window, true));
 
         // Recover it from coding
         let (recovered_data, recovered_coding) = recover(&db_ledger, 0, offset as u64)

--- a/src/fullnode.rs
+++ b/src/fullnode.rs
@@ -108,7 +108,7 @@ pub struct Fullnode {
     broadcast_socket: UdpSocket,
     rpc_addr: SocketAddr,
     rpc_pubsub_addr: SocketAddr,
-    db_ledger: Arc<RwLock<DbLedger>>,
+    db_ledger: Arc<DbLedger>,
 }
 
 impl Fullnode {
@@ -587,7 +587,7 @@ impl Fullnode {
         )
     }
 
-    fn make_db_ledger(ledger_path: &str) -> Arc<RwLock<DbLedger>> {
+    fn make_db_ledger(ledger_path: &str) -> Arc<DbLedger> {
         // Destroy any existing instances of the RocksDb ledger
         DbLedger::destroy(&ledger_path).expect("Expected successful database destruction");
         let ledger_entries = read_ledger(ledger_path, true)
@@ -597,7 +597,7 @@ impl Fullnode {
         write_entries_to_ledger(&[ledger_path], ledger_entries, DEFAULT_SLOT_HEIGHT);
         let db =
             DbLedger::open(ledger_path).expect("Expected to successfully open database ledger");
-        Arc::new(RwLock::new(db))
+        Arc::new(db)
     }
 }
 

--- a/src/gossip_service.rs
+++ b/src/gossip_service.rs
@@ -18,7 +18,7 @@ pub struct GossipService {
 impl GossipService {
     pub fn new(
         cluster_info: &Arc<RwLock<ClusterInfo>>,
-        db_ledger: Option<Arc<RwLock<DbLedger>>>,
+        db_ledger: Option<Arc<DbLedger>>,
         gossip_socket: UdpSocket,
         exit: Arc<AtomicBool>,
     ) -> Self {

--- a/src/replicator.rs
+++ b/src/replicator.rs
@@ -113,10 +113,10 @@ impl Replicator {
         // RocksDb. Note for now, this ledger will not contain any of the existing entries
         // in the ledger located at ledger_path, and will only append on newly received
         // entries after being passed to window_service
-        let db_ledger = Arc::new(RwLock::new(
+        let db_ledger = Arc::new(
             DbLedger::open(&ledger_path.unwrap())
                 .expect("Expected to be able to open database ledger"),
-        ));
+        );
 
         let gossip_service = GossipService::new(
             &cluster_info,

--- a/src/retransmit_stage.rs
+++ b/src/retransmit_stage.rs
@@ -83,7 +83,7 @@ pub struct RetransmitStage {
 impl RetransmitStage {
     #[allow(clippy::new_ret_no_self)]
     pub fn new(
-        db_ledger: Arc<RwLock<DbLedger>>,
+        db_ledger: Arc<DbLedger>,
         cluster_info: &Arc<RwLock<ClusterInfo>>,
         tick_height: u64,
         entry_height: u64,

--- a/src/tvu.rs
+++ b/src/tvu.rs
@@ -70,7 +70,7 @@ impl Tvu {
         cluster_info: &Arc<RwLock<ClusterInfo>>,
         sockets: Sockets,
         ledger_path: Option<&str>,
-        db_ledger: Arc<RwLock<DbLedger>>,
+        db_ledger: Arc<DbLedger>,
     ) -> Self {
         let exit = Arc::new(AtomicBool::new(false));
         let keypair: Arc<Keypair> = cluster_info
@@ -294,7 +294,7 @@ pub mod tests {
                 }
             },
             None,
-            Arc::new(RwLock::new(db_ledger)),
+            Arc::new(db_ledger),
         );
 
         let mut alice_ref_balance = starting_balance;


### PR DESCRIPTION
#### Problem
 RwLocks introduce contention points to DbLedger, which is stateless except for a Sync
 member (db)

 #### Summary of Changes
 remove RwLock wrappers for DbLedger

Fixes #