### PR TITLE
Move wallet airdrop retries into fullnode start script

### DIFF
--- a/ci/localnet-sanity.sh
+++ b/ci/localnet-sanity.sh
@@ -18,12 +18,6 @@ for cmd in $backgroundCommands; do
   echo "--- Start $cmd"
   rm -f log-"$cmd".txt
   multinode-demo/"$cmd".sh > log-"$cmd".txt 2>&1 &
-  if [[ $cmd = drone ]]; then
-    # Give the drone time to startup before the fullnodes attempt to airdrop
-    # from it (TODO: alternatively adjust `solana-wallet airdrop` to retry on
-    # "Connection refused" errors)
-    sleep 2
-  fi
   declare pid=$!
   pids+=("$pid")
   echo "pid: $pid"


### PR DESCRIPTION
The new CUDA bootstrap leader in Azure CI is starting a little slower than the previous GCP instance, which appears to be triggering an airdrop timeout.  eg:
* https://buildkite.com/solana-labs/solana/builds/161#b466cdf2-be63-469a-a6a0-15130b79e207
* https://buildkite.com/solana-labs/solana/builds/157#de2cd52f-3222-4e32-8955-d52acdb0143e

Adjust the scripts to be more tolerant.