### PR TITLE
Spawn threads based on cpu count

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ solana-native-loader = { path = "programs/native/native_loader", version = "0.12
 solana-netutil = { path = "netutil", version = "0.12.0" }
 solana-sdk = { path = "sdk", version = "0.12.0" }
 solana-system-program = { path = "programs/native/system", version = "0.12.0" }
+sys-info = "0.5.6"
 tokio = "0.1"
 tokio-codec = "0.1"
 untrusted = "0.6.2"

--- a/benches/banking_stage.rs
+++ b/benches/banking_stage.rs
@@ -5,7 +5,7 @@ extern crate test;
 use rand::{thread_rng, Rng};
 use rayon::prelude::*;
 use solana::bank::Bank;
-use solana::banking_stage::{BankingStage, NUM_THREADS};
+use solana::banking_stage::BankingStage;
 use solana::entry::Entry;
 use solana::mint::Mint;
 use solana::packet::to_packets_chunked;
@@ -41,7 +41,8 @@ fn check_txs(receiver: &Receiver<Vec<Entry>>, ref_tx_count: usize) {
 
 #[bench]
 fn bench_banking_stage_multi_accounts(bencher: &mut Bencher) {
-    let txes = 1000 * NUM_THREADS;
+    let num_threads = BankingStage::num_threads() as usize;
+    let txes = 1000 * num_threads;
     let mint_total = 1_000_000_000_000;
     let mint = Mint::new(mint_total);
 
@@ -119,7 +120,7 @@ fn bench_banking_stage_multi_accounts(bencher: &mut Bencher) {
         if bank.count_valid_ids(&[mint.last_id()]).len() == 0 {
             bank.register_tick(&mint.last_id());
         }
-        for v in verified.chunks(verified.len() / NUM_THREADS) {
+        for v in verified.chunks(verified.len() / num_threads) {
             verified_sender.send(v.to_vec()).unwrap();
         }
         check_txs(&signal_receiver, txes);
@@ -130,7 +131,8 @@ fn bench_banking_stage_multi_accounts(bencher: &mut Bencher) {
 #[bench]
 fn bench_banking_stage_multi_programs(bencher: &mut Bencher) {
     let progs = 4;
-    let txes = 1000 * NUM_THREADS;
+    let num_threads = BankingStage::num_threads() as usize;
+    let txes = 1000 * num_threads;
     let mint_total = 1_000_000_000_000;
     let mint = Mint::new(mint_total);
 
@@ -223,7 +225,7 @@ fn bench_banking_stage_multi_programs(bencher: &mut Bencher) {
         if bank.count_valid_ids(&[mint.last_id()]).len() == 0 {
             bank.register_tick(&mint.last_id());
         }
-        for v in verified.chunks(verified.len() / NUM_THREADS) {
+        for v in verified.chunks(verified.len() / num_threads) {
             verified_sender.send(v.to_vec()).unwrap();
         }
         check_txs(&signal_receiver, txes);


### PR DESCRIPTION
#### Problem
The number of threads spawned in banking stage is currently hard coded to 10 which could affect the performance if the CPU count is much higher in the node.

#### Summary of Changes
Spawn threads based on the available CPU count in the node to utilize the usage at the fullest and is seen to help increase the mean TPS by around 15% on a node with CPU count as 16.

Fixes #
