### PR TITLE
Confine `use rocksdb` to src/db_ledger.rs 

### DIFF
--- a/benches/db_ledger.rs
+++ b/benches/db_ledger.rs
@@ -5,7 +5,6 @@ extern crate test;
 
 use rand::seq::SliceRandom;
 use rand::{thread_rng, Rng};
-use rocksdb::{Options, DB};
 use solana::db_ledger::{DataCf, DbLedger, LedgerColumnFamilyRaw};
 use solana::ledger::{get_tmp_ledger_path, make_large_test_entries, make_tiny_test_entries, Block};
 use solana::packet::{Blob, BLOB_HEADER_SIZE};
@@ -30,8 +29,7 @@ fn bench_write_blobs(bench: &mut Bencher, blobs: &mut [&mut Blob], ledger_path: 
         }
     });
 
-    DB::destroy(&Options::default(), &ledger_path)
-        .expect("Expected successful database destruction");
+    DbLedger::destroy(&ledger_path).expect("Expected successful database destruction");
 }
 
 // Insert some blobs into the ledger in preparation for read benchmarks
@@ -108,8 +106,7 @@ fn bench_read_sequential(bench: &mut Bencher) {
         }
     });
 
-    DB::destroy(&Options::default(), &ledger_path)
-        .expect("Expected successful database destruction");
+    DbLedger::destroy(&ledger_path).expect("Expected successful database destruction");
 }
 
 #[bench]
@@ -142,8 +139,7 @@ fn bench_read_random(bench: &mut Bencher) {
         }
     });
 
-    DB::destroy(&Options::default(), &ledger_path)
-        .expect("Expected successful database destruction");
+    DbLedger::destroy(&ledger_path).expect("Expected successful database destruction");
 }
 
 #[bench]
@@ -168,8 +164,7 @@ fn bench_insert_data_blob_small(bench: &mut Bencher) {
         }
     });
 
-    DB::destroy(&Options::default(), &ledger_path)
-        .expect("Expected successful database destruction");
+    DbLedger::destroy(&ledger_path).expect("Expected successful database destruction");
 }
 
 #[bench]
@@ -194,6 +189,5 @@ fn bench_insert_data_blob_big(bench: &mut Bencher) {
         }
     });
 
-    DB::destroy(&Options::default(), &ledger_path)
-        .expect("Expected successful database destruction");
+    DbLedger::destroy(&ledger_path).expect("Expected successful database destruction");
 }

--- a/src/db_ledger.rs
+++ b/src/db_ledger.rs
@@ -20,10 +20,17 @@ pub const DB_LEDGER_DIRECTORY: &str = "rocksdb";
 // A good value for this is the number of cores on the machine
 pub const TOTAL_THREADS: i32 = 8;
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug)]
 pub enum DbLedgerError {
     BlobForIndexExists,
     InvalidBlobData,
+    RocksDb(rocksdb::Error),
+}
+
+impl std::convert::From<rocksdb::Error> for Error {
+    fn from(e: rocksdb::Error) -> Error {
+        Error::DbLedgerError(DbLedgerError::RocksDb(e))
+    }
 }
 
 pub trait LedgerColumnFamily {

--- a/src/db_ledger.rs
+++ b/src/db_ledger.rs
@@ -7,7 +7,7 @@ use crate::packet::{Blob, SharedBlob, BLOB_HEADER_SIZE};
 use crate::result::{Error, Result};
 use bincode::{deserialize, serialize};
 use byteorder::{BigEndian, ByteOrder, ReadBytesExt};
-use rocksdb::{ColumnFamily, ColumnFamilyDescriptor, DBRawIterator, Options, WriteBatch, DB};
+use rocksdb::{ColumnFamily, ColumnFamilyDescriptor, Options, WriteBatch, DB};
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 use solana_sdk::signature::{Keypair, KeypairUtil};
@@ -15,6 +15,9 @@ use std::borrow::Borrow;
 use std::cmp::max;
 use std::io;
 use std::path::Path;
+
+// Re-export rocksdb::DBRawIterator until it can be encapsulated
+pub use rocksdb::DBRawIterator;
 
 pub const DB_LEDGER_DIRECTORY: &str = "rocksdb";
 // A good value for this is the number of cores on the machine

--- a/src/db_window.rs
+++ b/src/db_window.rs
@@ -10,7 +10,6 @@ use crate::packet::{SharedBlob, BLOB_HEADER_SIZE};
 use crate::result::Result;
 use crate::streamer::BlobSender;
 use log::Level;
-use rocksdb::DBRawIterator;
 use solana_metrics::{influxdb, submit};
 use solana_sdk::pubkey::Pubkey;
 use std::cmp;

--- a/src/db_window.rs
+++ b/src/db_window.rs
@@ -416,7 +416,6 @@ mod test {
     use crate::ledger::{get_tmp_ledger_path, make_tiny_test_entries, Block};
     use crate::packet::{index_blobs, Blob, Packet, Packets, SharedBlob, PACKET_DATA_SIZE};
     use crate::streamer::{receiver, responder, PacketReceiver};
-    use rocksdb::{Options, DB};
     use solana_sdk::signature::{Keypair, KeypairUtil};
     use std::io;
     use std::io::Write;
@@ -538,7 +537,6 @@ mod test {
     pub fn test_find_missing_data_indexes_sanity() {
         let slot = DEFAULT_SLOT_HEIGHT;
 
-        // Create RocksDb ledger
         let db_ledger_path = get_tmp_ledger_path("test_find_missing_data_indexes_sanity");
         let db_ledger = DbLedger::open(&db_ledger_path).unwrap();
 
@@ -579,14 +577,12 @@ mod test {
         }
 
         drop(db_ledger);
-        DB::destroy(&Options::default(), &db_ledger_path)
-            .expect("Expected successful database destruction");
+        DbLedger::destroy(&db_ledger_path).expect("Expected successful database destruction");
     }
 
     #[test]
     pub fn test_find_missing_data_indexes() {
         let slot = DEFAULT_SLOT_HEIGHT;
-        // Create RocksDb ledger
         let db_ledger_path = get_tmp_ledger_path("test_find_missing_data_indexes");
         let db_ledger = DbLedger::open(&db_ledger_path).unwrap();
 
@@ -669,14 +665,12 @@ mod test {
         }
 
         drop(db_ledger);
-        DB::destroy(&Options::default(), &db_ledger_path)
-            .expect("Expected successful database destruction");
+        DbLedger::destroy(&db_ledger_path).expect("Expected successful database destruction");
     }
 
     #[test]
     pub fn test_no_missing_blob_indexes() {
         let slot = DEFAULT_SLOT_HEIGHT;
-        // Create RocksDb ledger
         let db_ledger_path = get_tmp_ledger_path("test_find_missing_data_indexes");
         let db_ledger = DbLedger::open(&db_ledger_path).unwrap();
 
@@ -705,8 +699,7 @@ mod test {
         }
 
         drop(db_ledger);
-        DB::destroy(&Options::default(), &db_ledger_path)
-            .expect("Expected successful database destruction");
+        DbLedger::destroy(&db_ledger_path).expect("Expected successful database destruction");
     }
 
     #[cfg(all(feature = "erasure", test))]
@@ -762,7 +755,6 @@ mod test {
         let leader_keypair = Keypair::new();
         let mut leader_scheduler = LeaderScheduler::from_bootstrap_leader(leader_keypair.pubkey());
 
-        // Create RocksDb ledger
         let db_ledger_path = get_tmp_ledger_path("test_process_blob");
         let db_ledger = Arc::new(DbLedger::open(&db_ledger_path).unwrap());
 
@@ -803,7 +795,6 @@ mod test {
         assert_eq!(consume_queue, original_entries);
 
         drop(db_ledger);
-        DB::destroy(&Options::default(), &db_ledger_path)
-            .expect("Expected successful database destruction");
+        DbLedger::destroy(&db_ledger_path).expect("Expected successful database destruction");
     }
 }

--- a/src/erasure.rs
+++ b/src/erasure.rs
@@ -620,7 +620,7 @@ pub mod test {
 
     // TODO: Temprorary function used in tests to generate a database ledger
     // from the window (which is used to generate the erasure coding)
-    // until we also transition generate_coding() and BroadcastStage to use RocksDb.
+    // until we also transition generate_coding() and BroadcastStage to use DbLedger
     // Github issue: https://github.com/solana-labs/solana/issues/1899.
     pub fn generate_db_ledger_from_window(
         ledger_path: &str,

--- a/src/fullnode.rs
+++ b/src/fullnode.rs
@@ -184,7 +184,7 @@ impl Fullnode {
         sigverify_disabled: bool,
         rpc_port: Option<u16>,
     ) -> Self {
-        // Create the RocksDb ledger
+        // Create the Dbledger
         let db_ledger = Self::make_db_ledger(ledger_path);
 
         let mut rpc_addr = node.info.rpc;
@@ -588,7 +588,7 @@ impl Fullnode {
     }
 
     fn make_db_ledger(ledger_path: &str) -> Arc<DbLedger> {
-        // Destroy any existing instances of the RocksDb ledger
+        // Destroy any existing instances of the Dbledger
         DbLedger::destroy(&ledger_path).expect("Expected successful database destruction");
         let ledger_entries = read_ledger(ledger_path, true)
             .expect("opening ledger")

--- a/src/replicator.rs
+++ b/src/replicator.rs
@@ -108,9 +108,9 @@ impl Replicator {
         let (entry_window_sender, entry_window_receiver) = channel();
         let store_ledger_stage = StoreLedgerStage::new(entry_window_receiver, ledger_path);
 
-        // Create the RocksDb ledger, eventually will simply repurpose the input
-        // ledger path as the RocksDb ledger path once we replace the ledger with
-        // RocksDb. Note for now, this ledger will not contain any of the existing entries
+        // Create DbLedger, eventually will simply repurpose the input
+        // ledger path as the DbLedger path once we replace the ledger with
+        // DbLedger. Note for now, this ledger will not contain any of the existing entries
         // in the ledger located at ledger_path, and will only append on newly received
         // entries after being passed to window_service
         let db_ledger = Arc::new(

--- a/src/result.rs
+++ b/src/result.rs
@@ -9,7 +9,6 @@ use crate::packet;
 use crate::poh_recorder;
 use crate::vote_stage;
 use bincode;
-use rocksdb;
 use serde_json;
 use std;
 use std::any::Any;
@@ -31,7 +30,6 @@ pub enum Error {
     SendError,
     PohRecorderError(poh_recorder::PohRecorderError),
     VoteError(vote_stage::VoteError),
-    RocksDb(rocksdb::Error),
     DbLedgerError(db_ledger::DbLedgerError),
 }
 
@@ -109,11 +107,6 @@ impl std::convert::From<poh_recorder::PohRecorderError> for Error {
 impl std::convert::From<vote_stage::VoteError> for Error {
     fn from(e: vote_stage::VoteError) -> Error {
         Error::VoteError(e)
-    }
-}
-impl std::convert::From<rocksdb::Error> for Error {
-    fn from(e: rocksdb::Error) -> Error {
-        Error::RocksDb(e)
     }
 }
 impl std::convert::From<db_ledger::DbLedgerError> for Error {

--- a/src/tvu.rs
+++ b/src/tvu.rs
@@ -193,7 +193,6 @@ pub mod tests {
     use crate::tvu::{Sockets, Tvu};
     use crate::window::{self, SharedWindow};
     use bincode::serialize;
-    use rocksdb::{Options, DB};
     use solana_sdk::hash::Hash;
     use solana_sdk::signature::{Keypair, KeypairUtil};
     use solana_sdk::system_transaction::SystemTransaction;
@@ -367,8 +366,7 @@ pub mod tests {
         dr_1.0.join().expect("join");
         t_receiver.join().expect("join");
         t_responder.join().expect("join");
-        DB::destroy(&Options::default(), &db_ledger_path)
-            .expect("Expected successful database destuction");
+        DbLedger::destroy(&db_ledger_path).expect("Expected successful database destruction");
         let _ignored = remove_dir_all(&db_ledger_path);
     }
 }

--- a/src/window_service.rs
+++ b/src/window_service.rs
@@ -232,7 +232,6 @@ mod test {
     use crate::packet::{SharedBlob, PACKET_DATA_SIZE};
     use crate::streamer::{blob_receiver, responder};
     use crate::window_service::{repair_backoff, window_service};
-    use rocksdb::{Options, DB};
     use solana_sdk::hash::Hash;
     use std::fs::remove_dir_all;
     use std::net::UdpSocket;
@@ -322,8 +321,7 @@ mod test {
         t_receiver.join().expect("join");
         t_responder.join().expect("join");
         t_window.join().expect("join");
-        DB::destroy(&Options::default(), &db_ledger_path)
-            .expect("Expected successful database destuction");
+        DbLedger::destroy(&db_ledger_path).expect("Expected successful database destruction");
         let _ignored = remove_dir_all(&db_ledger_path);
     }
 
@@ -406,8 +404,7 @@ mod test {
         t_receiver.join().expect("join");
         t_responder.join().expect("join");
         t_window.join().expect("join");
-        DB::destroy(&Options::default(), &db_ledger_path)
-            .expect("Expected successful database destuction");
+        DbLedger::destroy(&db_ledger_path).expect("Expected successful database destruction");
         let _ignored = remove_dir_all(&db_ledger_path);
     }
 

--- a/tests/replicator.rs
+++ b/tests/replicator.rs
@@ -160,8 +160,8 @@ fn test_replicator_startup() {
         leader.close().expect("Expected successful node closure");
     }
 
-    DbLedger::destroy(&leader_ledger_path).expect("Expected successful database destuction");
-    DbLedger::destroy(&replicator_ledger_path).expect("Expected successful database destuction");
+    DbLedger::destroy(&leader_ledger_path).expect("Expected successful database destruction");
+    DbLedger::destroy(&replicator_ledger_path).expect("Expected successful database destruction");
     let _ignored = remove_dir_all(&leader_ledger_path);
     let _ignored = remove_dir_all(&replicator_ledger_path);
 }


### PR DESCRIPTION
Part 1 of encapsulating rocksdb.  `db_ledger.rs` still leaks rocksdb types to the rest of the tree, but at least those types now only come from a single source.