### PR TITLE
Rename finality to confirmation

### DIFF
--- a/ci/testnet-automation.sh
+++ b/ci/testnet-automation.sh
@@ -56,24 +56,24 @@ launchTestnet() {
         WHERE time > now() - 300s GROUP BY time(1s)
     )'
 
-  declare q_mean_finality='
-    SELECT round(mean("duration_ms")) as "mean_finality"
-      FROM "testnet-automation"."autogen"."leader-finality"
+  declare q_mean_confirmation='
+    SELECT round(mean("duration_ms")) as "mean_confirmation"
+      FROM "testnet-automation"."autogen"."leader-confirmation"
       WHERE time > now() - 300s'
 
-  declare q_max_finality='
-    SELECT round(max("duration_ms")) as "max_finality"
-      FROM "testnet-automation"."autogen"."leader-finality"
+  declare q_max_confirmation='
+    SELECT round(max("duration_ms")) as "max_confirmation"
+      FROM "testnet-automation"."autogen"."leader-confirmation"
       WHERE time > now() - 300s'
 
-  declare q_99th_finality='
-    SELECT round(percentile("duration_ms", 99)) as "99th_finality"
-      FROM "testnet-automation"."autogen"."leader-finality"
+  declare q_99th_confirmation='
+    SELECT round(percentile("duration_ms", 99)) as "99th_confirmation"
+      FROM "testnet-automation"."autogen"."leader-confirmation"
       WHERE time > now() - 300s'
 
   curl -G "https://metrics.solana.com:8086/query?u=${INFLUX_USERNAME}&p=${INFLUX_PASSWORD}" \
     --data-urlencode "db=$INFLUX_DATABASE" \
-    --data-urlencode "q=$q_mean_tps;$q_max_tps;$q_mean_finality;$q_max_finality;$q_99th_finality" |
+    --data-urlencode "q=$q_mean_tps;$q_max_tps;$q_mean_confirmation;$q_max_confirmation;$q_99th_confirmation" |
     python ci/testnet-automation-json-parser.py >>TPS"$nodeCount".log
 
   upload-ci-artifact TPS"$nodeCount".log

--- a/metrics/testnet-monitor.json
+++ b/metrics/testnet-monitor.json
@@ -722,7 +722,7 @@
           ],
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "SELECT mean(\"duration_ms\") FROM \"$testnet\".\"autogen\".\"leader-finality\" WHERE $timeFilter \n\n\n",
+          "query": "SELECT mean(\"duration_ms\") FROM \"$testnet\".\"autogen\".\"leader-confirmation\" WHERE $timeFilter \n\n\n",
           "rawQuery": true,
           "refId": "A",
           "resultFormat": "time_series",
@@ -744,7 +744,7 @@
         }
       ],
       "thresholds": "",
-      "title": "Mean Finality",
+      "title": "Mean Confirmation",
       "type": "singlestat",
       "valueFontSize": "70%",
       "valueMaps": [
@@ -833,7 +833,7 @@
           ],
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "SELECT median(\"duration_ms\") FROM \"$testnet\".\"autogen\".\"leader-finality\" WHERE $timeFilter \n\n\n",
+          "query": "SELECT median(\"duration_ms\") FROM \"$testnet\".\"autogen\".\"leader-confirmation\" WHERE $timeFilter \n\n\n",
           "rawQuery": true,
           "refId": "A",
           "resultFormat": "time_series",
@@ -855,7 +855,7 @@
         }
       ],
       "thresholds": "",
-      "title": "Median Finality",
+      "title": "Median Confirmation",
       "type": "singlestat",
       "valueFontSize": "70%",
       "valueMaps": [
@@ -944,7 +944,7 @@
           ],
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "SELECT min(\"duration_ms\") FROM \"$testnet\".\"autogen\".\"leader-finality\" WHERE $timeFilter \n\n\n",
+          "query": "SELECT min(\"duration_ms\") FROM \"$testnet\".\"autogen\".\"leader-confirmation\" WHERE $timeFilter \n\n\n",
           "rawQuery": true,
           "refId": "A",
           "resultFormat": "time_series",
@@ -966,7 +966,7 @@
         }
       ],
       "thresholds": "",
-      "title": "Min Finality",
+      "title": "Min Confirmation",
       "type": "singlestat",
       "valueFontSize": "70%",
       "valueMaps": [
@@ -1055,7 +1055,7 @@
           ],
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "SELECT max(\"duration_ms\") FROM \"$testnet\".\"autogen\".\"leader-finality\" WHERE $timeFilter \n\n\n",
+          "query": "SELECT max(\"duration_ms\") FROM \"$testnet\".\"autogen\".\"leader-confirmation\" WHERE $timeFilter \n\n\n",
           "rawQuery": true,
           "refId": "A",
           "resultFormat": "time_series",
@@ -1077,7 +1077,7 @@
         }
       ],
       "thresholds": "",
-      "title": "Max Finality",
+      "title": "Max Confirmation",
       "type": "singlestat",
       "valueFontSize": "70%",
       "valueMaps": [
@@ -1166,7 +1166,7 @@
           ],
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "SELECT percentile(\"duration_ms\", 99) FROM \"$testnet\".\"autogen\".\"leader-finality\" WHERE $timeFilter \n\n\n",
+          "query": "SELECT percentile(\"duration_ms\", 99) FROM \"$testnet\".\"autogen\".\"leader-confirmation\" WHERE $timeFilter \n\n\n",
           "rawQuery": true,
           "refId": "A",
           "resultFormat": "time_series",
@@ -1188,7 +1188,7 @@
         }
       ],
       "thresholds": "",
-      "title": "Finality (99th percentile)",
+      "title": "Confirmation (99th percentile)",
       "type": "singlestat",
       "valueFontSize": "70%",
       "valueMaps": [
@@ -1651,7 +1651,7 @@
           "measurement": "counter-cluster_info-vote-count",
           "orderByTime": "ASC",
           "policy": "autogen",
-          "query": "SELECT mean(\"duration_ms\") FROM \"$testnet\".\"autogen\".\"leader-finality\" WHERE $timeFilter GROUP BY time(1s) FILL(0)\n",
+          "query": "SELECT mean(\"duration_ms\") FROM \"$testnet\".\"autogen\".\"leader-confirmation\" WHERE $timeFilter GROUP BY time(1s) FILL(0)\n",
           "rawQuery": true,
           "refId": "A",
           "resultFormat": "time_series",
@@ -1675,7 +1675,7 @@
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Finality",
+      "title": "Time since last Confirmation",
       "tooltip": {
         "shared": true,
         "sort": 0,

--- a/src/bank.rs
+++ b/src/bank.rs
@@ -876,7 +876,8 @@ impl Bank {
     }
 
     pub fn set_confirmation(&self, confirmation: usize) {
-        self.confirmation_time.store(confirmation, Ordering::Relaxed);
+        self.confirmation_time
+            .store(confirmation, Ordering::Relaxed);
     }
 
     fn send_account_notifications(

--- a/src/compute_leader_confirmation_service.rs
+++ b/src/compute_leader_confirmation_service.rs
@@ -1,5 +1,5 @@
-//! The `compute_leader_finality_service` module implements the tools necessary
-//! to generate a thread which regularly calculates the last finality times
+//! The `compute_leader_confirmation_service` module implements the tools necessary
+//! to generate a thread which regularly calculates the last confirmation times
 //! observed by the leader
 
 use crate::bank::Bank;
@@ -17,23 +17,23 @@ use std::thread::{self, Builder, JoinHandle};
 use std::time::Duration;
 
 #[derive(Debug, PartialEq, Eq)]
-pub enum FinalityError {
+pub enum ConfirmationError {
     NoValidSupermajority,
 }
 
-pub const COMPUTE_FINALITY_MS: u64 = 100;
+pub const COMPUTE_CONFIRMATION_MS: u64 = 100;
 
-pub struct ComputeLeaderFinalityService {
-    compute_finality_thread: JoinHandle<()>,
+pub struct ComputeLeaderConfirmationService {
+    compute_confirmation_thread: JoinHandle<()>,
 }
 
-impl ComputeLeaderFinalityService {
+impl ComputeLeaderConfirmationService {
     fn get_last_supermajority_timestamp(
         bank: &Arc<Bank>,
         leader_id: Pubkey,
         now: u64,
         last_valid_validator_timestamp: u64,
-    ) -> result::Result<u64, FinalityError> {
+    ) -> result::Result<u64, ConfirmationError> {
         let mut total_stake = 0;
 
         let mut ticks_and_stakes: Vec<(u64, u64)> = {
@@ -72,14 +72,14 @@ impl ComputeLeaderFinalityService {
         let super_majority_stake = (2 * total_stake) / 3;
 
         if let Some(last_valid_validator_timestamp) =
-            bank.get_finality_timestamp(&mut ticks_and_stakes, super_majority_stake)
+            bank.get_confirmation_timestamp(&mut ticks_and_stakes, super_majority_stake)
         {
             return Ok(last_valid_validator_timestamp);
         }
 
         if last_valid_validator_timestamp != 0 {
             submit(
-                influxdb::Point::new(&"leader-finality")
+                influxdb::Point::new(&"leader-confirmation")
                     .add_field(
                         "duration_ms",
                         influxdb::Value::Integer((now - last_valid_validator_timestamp) as i64),
@@ -88,10 +88,10 @@ impl ComputeLeaderFinalityService {
             );
         }
 
-        Err(FinalityError::NoValidSupermajority)
+        Err(ConfirmationError::NoValidSupermajority)
     }
 
-    pub fn compute_finality(
+    pub fn compute_confirmation(
         bank: &Arc<Bank>,
         leader_id: Pubkey,
         last_valid_validator_timestamp: &mut u64,
@@ -103,53 +103,53 @@ impl ComputeLeaderFinalityService {
             now,
             *last_valid_validator_timestamp,
         ) {
-            let finality_ms = now - super_majority_timestamp;
+            let confirmation_ms = now - super_majority_timestamp;
 
             *last_valid_validator_timestamp = super_majority_timestamp;
-            bank.set_finality((now - *last_valid_validator_timestamp) as usize);
+            bank.set_confirmation((now - *last_valid_validator_timestamp) as usize);
 
             submit(
-                influxdb::Point::new(&"leader-finality")
-                    .add_field("duration_ms", influxdb::Value::Integer(finality_ms as i64))
+                influxdb::Point::new(&"leader-confirmation")
+                    .add_field("duration_ms", influxdb::Value::Integer(confirmation_ms as i64))
                     .to_owned(),
             );
         }
     }
 
-    /// Create a new ComputeLeaderFinalityService for computing finality.
+    /// Create a new ComputeLeaderConfirmationService for computing confirmation.
     pub fn new(bank: Arc<Bank>, leader_id: Pubkey, exit: Arc<AtomicBool>) -> Self {
-        let compute_finality_thread = Builder::new()
-            .name("solana-leader-finality-stage".to_string())
+        let compute_confirmation_thread = Builder::new()
+            .name("solana-leader-confirmation-stage".to_string())
             .spawn(move || {
                 let mut last_valid_validator_timestamp = 0;
                 loop {
                     if exit.load(Ordering::Relaxed) {
                         break;
                     }
-                    Self::compute_finality(&bank, leader_id, &mut last_valid_validator_timestamp);
-                    sleep(Duration::from_millis(COMPUTE_FINALITY_MS));
+                    Self::compute_confirmation(&bank, leader_id, &mut last_valid_validator_timestamp);
+                    sleep(Duration::from_millis(COMPUTE_CONFIRMATION_MS));
                 }
             })
             .unwrap();
 
-        (ComputeLeaderFinalityService {
-            compute_finality_thread,
+        (ComputeLeaderConfirmationService {
+            compute_confirmation_thread,
         })
     }
 }
 
-impl Service for ComputeLeaderFinalityService {
+impl Service for ComputeLeaderConfirmationService {
     type JoinReturnType = ();
 
     fn join(self) -> thread::Result<()> {
-        self.compute_finality_thread.join()
+        self.compute_confirmation_thread.join()
     }
 }
 
 #[cfg(test)]
 pub mod tests {
     use crate::bank::Bank;
-    use crate::compute_leader_finality_service::ComputeLeaderFinalityService;
+    use crate::compute_leader_confirmation_service::ComputeLeaderConfirmationService;
     use crate::create_vote_account::*;
 
     use crate::mint::Mint;
@@ -164,7 +164,7 @@ pub mod tests {
     use std::time::Duration;
 
     #[test]
-    fn test_compute_finality() {
+    fn test_compute_confirmation() {
         solana_logger::setup();
 
         let mint = Mint::new(1234);
@@ -206,14 +206,14 @@ pub mod tests {
             })
             .collect();
 
-        // There isn't 2/3 consensus, so the bank's finality value should be the default
-        let mut last_finality_time = 0;
-        ComputeLeaderFinalityService::compute_finality(
+        // There isn't 2/3 consensus, so the bank's confirmation value should be the default
+        let mut last_confirmation_time = 0;
+        ComputeLeaderConfirmationService::compute_confirmation(
             &bank,
             dummy_leader_id,
-            &mut last_finality_time,
+            &mut last_confirmation_time,
         );
-        assert_eq!(bank.finality(), std::usize::MAX);
+        assert_eq!(bank.confirmation(), std::usize::MAX);
 
         // Get another validator to vote, so we now have 2/3 consensus
         let vote_account = &vote_accounts[7];
@@ -221,12 +221,12 @@ pub mod tests {
         let vote_tx = Transaction::vote_new(&vote_account, vote, ids[6], 0);
         bank.process_transaction(&vote_tx).unwrap();
 
-        ComputeLeaderFinalityService::compute_finality(
+        ComputeLeaderConfirmationService::compute_confirmation(
             &bank,
             dummy_leader_id,
-            &mut last_finality_time,
+            &mut last_confirmation_time,
         );
-        assert!(bank.finality() != std::usize::MAX);
-        assert!(last_finality_time > 0);
+        assert!(bank.confirmation() != std::usize::MAX);
+        assert!(last_confirmation_time > 0);
     }
 }

--- a/src/compute_leader_confirmation_service.rs
+++ b/src/compute_leader_confirmation_service.rs
@@ -110,7 +110,10 @@ impl ComputeLeaderConfirmationService {
 
             submit(
                 influxdb::Point::new(&"leader-confirmation")
-                    .add_field("duration_ms", influxdb::Value::Integer(confirmation_ms as i64))
+                    .add_field(
+                        "duration_ms",
+                        influxdb::Value::Integer(confirmation_ms as i64),
+                    )
                     .to_owned(),
             );
         }
@@ -126,7 +129,11 @@ impl ComputeLeaderConfirmationService {
                     if exit.load(Ordering::Relaxed) {
                         break;
                     }
-                    Self::compute_confirmation(&bank, leader_id, &mut last_valid_validator_timestamp);
+                    Self::compute_confirmation(
+                        &bank,
+                        leader_id,
+                        &mut last_valid_validator_timestamp,
+                    );
                     sleep(Duration::from_millis(COMPUTE_CONFIRMATION_MS));
                 }
             })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@ pub mod create_vote_account;
 #[macro_use]
 pub mod contact_info;
 pub mod cluster_info;
-pub mod compute_leader_finality_service;
+pub mod compute_leader_confirmation_service;
 pub mod db_ledger;
 pub mod db_window;
 pub mod entry;

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -135,8 +135,8 @@ build_rpc_trait! {
         #[rpc(meta, name = "getBalance")]
         fn get_balance(&self, Self::Metadata, String) -> Result<u64>;
 
-        #[rpc(meta, name = "getFinality")]
-        fn get_finality(&self, Self::Metadata) -> Result<usize>;
+        #[rpc(meta, name = "getConfirmation")]
+        fn get_confirmation(&self, Self::Metadata) -> Result<usize>;
 
         #[rpc(meta, name = "getLastId")]
         fn get_last_id(&self, Self::Metadata) -> Result<String>;
@@ -184,9 +184,9 @@ impl RpcSol for RpcSolImpl {
         let pubkey = verify_pubkey(id)?;
         meta.request_processor.get_balance(pubkey)
     }
-    fn get_finality(&self, meta: Self::Metadata) -> Result<usize> {
-        info!("get_finality rpc request received");
-        meta.request_processor.get_finality()
+    fn get_confirmation(&self, meta: Self::Metadata) -> Result<usize> {
+        info!("get_confirmation rpc request received");
+        meta.request_processor.get_confirmation()
     }
     fn get_last_id(&self, meta: Self::Metadata) -> Result<String> {
         info!("get_last_id rpc request received");
@@ -329,8 +329,8 @@ impl JsonRpcRequestProcessor {
         let val = self.bank.get_balance(&pubkey);
         Ok(val)
     }
-    fn get_finality(&self) -> Result<usize> {
-        Ok(self.bank.finality())
+    fn get_confirmation(&self) -> Result<usize> {
+        Ok(self.bank.confirmation())
     }
     fn get_last_id(&self) -> Result<String> {
         let id = self.bank.last_id();
@@ -612,11 +612,11 @@ mod tests {
     }
 
     #[test]
-    fn test_rpc_get_finality() {
+    fn test_rpc_get_confirmation() {
         let bob_pubkey = Keypair::new().pubkey();
         let (io, meta, _last_id, _alice_keypair) = start_rpc_handler_with_tx(bob_pubkey);
 
-        let req = format!(r#"{{"jsonrpc":"2.0","id":1,"method":"getFinality"}}"#);
+        let req = format!(r#"{{"jsonrpc":"2.0","id":1,"method":"getConfirmation"}}"#);
         let res = io.handle_request_sync(&req, meta);
         let expected = format!(r#"{{"jsonrpc":"2.0","result":18446744073709551615,"id":1}}"#);
         let expected: Response =

--- a/src/rpc_request.rs
+++ b/src/rpc_request.rs
@@ -44,7 +44,7 @@ pub enum RpcRequest {
     ConfirmTransaction,
     GetAccountInfo,
     GetBalance,
-    GetFinality,
+    GetConfirmation,
     GetLastId,
     GetSignatureStatus,
     GetTransactionCount,
@@ -89,7 +89,7 @@ impl RpcRequest {
             RpcRequest::ConfirmTransaction => "confirmTransaction",
             RpcRequest::GetAccountInfo => "getAccountInfo",
             RpcRequest::GetBalance => "getBalance",
-            RpcRequest::GetFinality => "getFinality",
+            RpcRequest::GetConfirmation => "getConfirmation",
             RpcRequest::GetLastId => "getLastId",
             RpcRequest::GetSignatureStatus => "getSignatureStatus",
             RpcRequest::GetTransactionCount => "getTransactionCount",
@@ -166,9 +166,9 @@ mod tests {
         );
         assert_eq!(request["method"], "getBalance");
 
-        let test_request = RpcRequest::GetFinality;
+        let test_request = RpcRequest::GetConfirmation;
         let request = test_request.build_request_json(1, None);
-        assert_eq!(request["method"], "getFinality");
+        assert_eq!(request["method"], "getConfirmation");
         assert_eq!(request["params"], json!(null));
 
         let test_request = RpcRequest::GetLastId;

--- a/src/status_deque.rs
+++ b/src/status_deque.rs
@@ -44,7 +44,7 @@ struct StatusEntry<T> {
     /// when the id was registered, according to network time
     tick_height: u64,
 
-    /// timestamp when this id was registered, used for stats/finality
+    /// timestamp when this id was registered, used for stats/confirmation
     timestamp: u64,
 
     /// a map of signature status, used for duplicate detection
@@ -183,8 +183,8 @@ impl<T: Clone> StatusDeque<T> {
     }
 
     /// Looks through a list of tick heights and stakes, and finds the latest
-    /// tick that has achieved finality
-    pub fn get_finality_timestamp(
+    /// tick that has achieved confirmation
+    pub fn get_confirmation_timestamp(
         &self,
         ticks_and_stakes: &mut [(u64, u64)],
         supermajority_stake: u64,

--- a/tests/multinode.rs
+++ b/tests/multinode.rs
@@ -714,8 +714,8 @@ fn test_multi_node_dynamic_network() {
     let mut validators: Vec<_> = t2.into_iter().map(|t| t.join().unwrap()).collect();
 
     let mut client = mk_client(&leader_data);
-    let mut last_finality = client.get_finality();
-    info!("Last finality {}", last_finality);
+    let mut last_confirmation = client.get_confirmation();
+    info!("Last confirmation {}", last_confirmation);
     let start = Instant::now();
     let mut consecutive_success = 0;
     let mut expected_balance = leader_balance;
@@ -738,28 +738,28 @@ fn test_multi_node_dynamic_network() {
         assert!(e.is_ok(), "err: {:?}", e);
 
         let now = Instant::now();
-        let mut finality = client.get_finality();
+        let mut confirmation = client.get_confirmation();
 
-        // Need this to make sure the finality is updated
+        // Need this to make sure the confirmation is updated
         // (i.e. the node is not returning stale value)
-        while last_finality == finality {
-            finality = client.get_finality();
+        while last_confirmation == confirmation {
+            confirmation = client.get_confirmation();
         }
 
-        while duration_as_ms(&now.elapsed()) < finality as u64 {
+        while duration_as_ms(&now.elapsed()) < confirmation as u64 {
             sleep(Duration::from_millis(100));
-            finality = client.get_finality()
+            confirmation = client.get_confirmation()
         }
 
-        last_finality = finality;
+        last_confirmation = confirmation;
 
         let balance = retry_get_balance(&mut client, &bob_pubkey, Some(expected_balance));
         assert_eq!(balance, Some(expected_balance));
         consecutive_success += 1;
 
         info!(
-            "SUCCESS[{}] balance: {}, finality: {} ms",
-            i, expected_balance, last_finality,
+            "SUCCESS[{}] balance: {}, confirmation: {} ms",
+            i, expected_balance, last_confirmation,
         );
 
         if consecutive_success == 10 {


### PR DESCRIPTION
#### Problem
The finality term is overloaded. The keyword should be replace with confirmation.

#### Summary of Changes
Changed finality to confirmation.

Fixes #2243
