### PR TITLE
Use SSD for testnet automation

### DIFF
--- a/ci/testnet-automation.sh
+++ b/ci/testnet-automation.sh
@@ -25,6 +25,7 @@ launchTestnet() {
   echo --- setup "$nodeCount" node test
   net/gce.sh create \
     -b \
+    -d pd-ssd \
     -n "$nodeCount" -c "$CLIENT_COUNT" \
     -G "$LEADER_CPU_MACHINE_TYPE" \
     -p "$TESTNET_TAG" -z "$TESTNET_ZONE"


### PR DESCRIPTION
#### Problem
Testnet automation does not achieve peak performance due to hard disk performance.

#### Summary of Changes
Use SSD in testnet cluster nodes.