### PR TITLE
Load nvidia drivers on node startup

### DIFF
--- a/net/gce.sh
+++ b/net/gce.sh
@@ -430,6 +430,10 @@ $(
     network-config.sh \
     remove-docker-interface.sh \
 
+    if "$enableGpu"; then
+      cat enable-nvidia-persistence-mode.sh
+    fi
+
 )
 
 cat > /etc/motd <<EOM

--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -144,13 +144,16 @@ local|tar)
     maybeNoLeaderRotation="--no-leader-rotation"
   fi
 
-
-  case $nodeType in
-  bootstrap-leader)
-    if [[ -e /dev/nvidia0 && -x ~/.cargo/bin/solana-fullnode-cuda ]]; then
+  if [[ -x ~/.cargo/bin/solana-fullnode-cuda ]]; then
+    nvidia-smi
+    if [[ -e /dev/nvidia0 ]]; then
       echo Selecting solana-fullnode-cuda
       export SOLANA_CUDA=1
     fi
+  fi
+
+  case $nodeType in
+  bootstrap-leader)
     if [[ $skipSetup != true ]]; then
       ./multinode-demo/setup.sh -t bootstrap-leader $setupArgs
     fi
@@ -160,11 +163,6 @@ local|tar)
     ;;
   fullnode)
     net/scripts/rsync-retry.sh -vPrc "$entrypointIp":~/.cargo/bin/ ~/.cargo/bin/
-
-    if [[ -e /dev/nvidia0 && -x ~/.cargo/bin/solana-fullnode-cuda ]]; then
-      echo Selecting solana-fullnode-cuda
-      export SOLANA_CUDA=1
-    fi
 
     if [[ $skipSetup != true ]]; then
       ./multinode-demo/setup.sh -t fullnode $setupArgs

--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -144,16 +144,13 @@ local|tar)
     maybeNoLeaderRotation="--no-leader-rotation"
   fi
 
-  if [[ -x ~/.cargo/bin/solana-fullnode-cuda ]]; then
-    nvidia-smi
-    if [[ -e /dev/nvidia0 ]]; then
-      echo Selecting solana-fullnode-cuda
-      export SOLANA_CUDA=1
-    fi
-  fi
 
   case $nodeType in
   bootstrap-leader)
+    if [[ -e /dev/nvidia0 && -x ~/.cargo/bin/solana-fullnode-cuda ]]; then
+      echo Selecting solana-fullnode-cuda
+      export SOLANA_CUDA=1
+    fi
     if [[ $skipSetup != true ]]; then
       ./multinode-demo/setup.sh -t bootstrap-leader $setupArgs
     fi
@@ -163,6 +160,11 @@ local|tar)
     ;;
   fullnode)
     net/scripts/rsync-retry.sh -vPrc "$entrypointIp":~/.cargo/bin/ ~/.cargo/bin/
+
+    if [[ -e /dev/nvidia0 && -x ~/.cargo/bin/solana-fullnode-cuda ]]; then
+      echo Selecting solana-fullnode-cuda
+      export SOLANA_CUDA=1
+    fi
 
     if [[ $skipSetup != true ]]; then
       ./multinode-demo/setup.sh -t fullnode $setupArgs

--- a/net/scripts/enable-nvidia-persistence-mode.sh
+++ b/net/scripts/enable-nvidia-persistence-mode.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -ex
+
+nvidia-smi -pm ENABLED || true

--- a/net/scripts/enable-nvidia-persistence-mode.sh
+++ b/net/scripts/enable-nvidia-persistence-mode.sh
@@ -1,4 +1,2 @@
 #!/usr/bin/env bash
-set -ex
-
-nvidia-smi -pm ENABLED || true
+nvidia-smi -pm ENABLED


### PR DESCRIPTION
#### Problem
Testnet is not running cuda enabled code even though hardware has the required GPUs and software
 
#### Summary of Changes
There was a race condition between running Solana binaries and loading of Nvidia drivers. Scripts were not detecting the cuda device sometimes, and were starting non cuda daemons.

This change loads the drivers before detecting cuda device.