### PR TITLE
Load nvidia drivers on node startup (#2263)

### DIFF
--- a/net/gce.sh
+++ b/net/gce.sh
@@ -430,6 +430,10 @@ $(
     network-config.sh \
     remove-docker-interface.sh \
 
+    if "$enableGpu"; then
+      cat enable-nvidia-persistence-mode.sh
+    fi
+
 )
 
 cat > /etc/motd <<EOM

--- a/net/scripts/enable-nvidia-persistence-mode.sh
+++ b/net/scripts/enable-nvidia-persistence-mode.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+nvidia-smi -pm ENABLED


### PR DESCRIPTION
* Load nvidia drivers on node startup

* added new script to enable nvidia driver persistent mode

* remove set -ex

#### Problem
Testnet is not running cuda enabled code even though hardware has the required GPUs and software

#### Summary of Changes
There was a race condition between running Solana binaries and loading of Nvidia drivers. Scripts were not detecting the cuda device sometimes, and were starting non cuda daemons.

This change loads the drivers before detecting cuda device.