### PR TITLE
Ignore error while enabling nvidia persistence mode (#2265)

### DIFF
--- a/net/scripts/enable-nvidia-persistence-mode.sh
+++ b/net/scripts/enable-nvidia-persistence-mode.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-nvidia-smi -pm ENABLED
+nvidia-smi -pm ENABLED || true


### PR DESCRIPTION
#### Problem
Validators are not configured with GPUs in testnet. The current script is failing, as it tries to configure nvidia persistence mode

#### Summary of Changes
Ignore error from nvidia command, as the GPU may not be present