### PR TITLE
to_blobs() cleanup

### DIFF
--- a/benches/db_ledger.rs
+++ b/benches/db_ledger.rs
@@ -44,7 +44,7 @@ fn setup_read_bench(
     entries.extend(make_tiny_test_entries(num_small_blobs as usize));
 
     // Convert the entries to blobs, write the blobs to the ledger
-    let shared_blobs = entries.to_blobs();
+    let shared_blobs = entries.to_shared_blobs();
     for b in shared_blobs.iter() {
         b.write().unwrap().set_slot(slot).unwrap();
     }
@@ -60,7 +60,7 @@ fn bench_write_small(bench: &mut Bencher) {
     let ledger_path = get_tmp_ledger_path("bench_write_small");
     let num_entries = 32 * 1024;
     let entries = make_tiny_test_entries(num_entries);
-    let shared_blobs = entries.to_blobs();
+    let shared_blobs = entries.to_shared_blobs();
     let mut blob_locks: Vec<_> = shared_blobs.iter().map(|b| b.write().unwrap()).collect();
     let mut blobs: Vec<&mut Blob> = blob_locks.iter_mut().map(|b| &mut **b).collect();
     bench_write_blobs(bench, &mut blobs, &ledger_path);
@@ -73,7 +73,7 @@ fn bench_write_big(bench: &mut Bencher) {
     let ledger_path = get_tmp_ledger_path("bench_write_big");
     let num_entries = 32 * 1024;
     let entries = make_tiny_test_entries(num_entries);
-    let shared_blobs = entries.to_blobs();
+    let shared_blobs = entries.to_shared_blobs();
     let mut blob_locks: Vec<_> = shared_blobs.iter().map(|b| b.write().unwrap()).collect();
     let mut blobs: Vec<&mut Blob> = blob_locks.iter_mut().map(|b| &mut **b).collect();
     bench_write_blobs(bench, &mut blobs, &ledger_path);
@@ -147,7 +147,7 @@ fn bench_insert_data_blob_small(bench: &mut Bencher) {
         DbLedger::open(&ledger_path).expect("Expected to be able to open database ledger");
     let num_entries = 32 * 1024;
     let entries = make_tiny_test_entries(num_entries);
-    let mut shared_blobs = entries.to_blobs();
+    let mut shared_blobs = entries.to_shared_blobs();
     shared_blobs.shuffle(&mut thread_rng());
 
     bench.iter(move || {
@@ -172,7 +172,7 @@ fn bench_insert_data_blob_big(bench: &mut Bencher) {
         DbLedger::open(&ledger_path).expect("Expected to be able to open database ledger");
     let num_entries = 32 * 1024;
     let entries = make_large_test_entries(num_entries);
-    let mut shared_blobs = entries.to_blobs();
+    let mut shared_blobs = entries.to_shared_blobs();
     shared_blobs.shuffle(&mut thread_rng());
 
     bench.iter(move || {

--- a/src/broadcast_service.rs
+++ b/src/broadcast_service.rs
@@ -72,7 +72,7 @@ fn broadcast(
 
     let blobs: Vec<_> = ventries
         .into_par_iter()
-        .flat_map(|p| p.to_blobs())
+        .flat_map(|p| p.to_shared_blobs())
         .collect();
 
     let blobs_slot_heights: Vec<(SharedBlob, u64)> = blobs.into_iter().zip(slot_heights).collect();

--- a/src/erasure.rs
+++ b/src/erasure.rs
@@ -770,7 +770,7 @@ pub mod test {
             WINDOW_SIZE
         ];
         let entries = make_tiny_test_entries(num_blobs);
-        let blobs = entries.to_blobs();
+        let blobs = entries.to_shared_blobs();
 
         {
             // Make some dummy slots

--- a/tests/multinode.rs
+++ b/tests/multinode.rs
@@ -1609,9 +1609,10 @@ fn test_broadcast_last_tick() {
                 break;
             }
         }
-        let actual_last_tick = &reconstruct_entries_from_blobs(vec![last_tick_blob])
-            .expect("Expected to be able to reconstruct entries from blob")
-            .0[0];
+        let actual_last_tick =
+            &reconstruct_entries_from_blobs(vec![&*last_tick_blob.read().unwrap()])
+                .expect("Expected to be able to reconstruct entries from blob")
+                .0[0];
         assert_eq!(actual_last_tick, &expected_last_tick);
     }
 


### PR DESCRIPTION
#### Problem
1) to_blobs created shared blobs, no way to convert entries to regular blobs
2) reconstruct_entries_from_blobs didn't work with Blobs, only Shared blobs
#### Summary of Changes
1) Make distinction between to_blobs and to_shared_blob
2) Make reconstruct_entries_from_blobs accept Blob iterators

Fixes #
