### PR TITLE
minor testnet ci fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1752,6 +1752,7 @@ dependencies = [
  "solana-netutil 0.12.0",
  "solana-sdk 0.12.0",
  "solana-system-program 0.12.0",
+ "sys-info 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "untrusted 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/ci/localnet-sanity.sh
+++ b/ci/localnet-sanity.sh
@@ -82,6 +82,15 @@ echo "--- Node count"
   rm -rf $client_id
 ) || flag_error
 
+echo "--- RPC API: getTransactionCount"
+(
+  set -x
+  curl -X POST \
+    -H 'Content-Type: application/json' \
+    -d '{"jsonrpc":"2.0","id":1, "method":"getTransactionCount"}' \
+    http://localhost:8899
+) || flag_error
+
 killBackgroundCommands
 
 echo "--- Ledger verification"

--- a/ci/testnet-manager.sh
+++ b/ci/testnet-manager.sh
@@ -116,9 +116,7 @@ sanity() {
   testnet-edge)
     (
       set -x
-      NO_LEDGER_VERIFY=1 \
-      NO_VALIDATOR_SANITY=1 \
-        ci/testnet-sanity.sh edge-testnet-solana-com ec2 us-west-1a
+      ci/testnet-sanity.sh edge-testnet-solana-com ec2 us-west-1a
     )
     ;;
   testnet-edge-perf)
@@ -133,9 +131,7 @@ sanity() {
   testnet-beta)
     (
       set -x
-      NO_LEDGER_VERIFY=1 \
-      NO_VALIDATOR_SANITY=1 \
-        ci/testnet-sanity.sh beta-testnet-solana-com ec2 us-west-1a
+      ci/testnet-sanity.sh beta-testnet-solana-com ec2 us-west-1a
     )
     ;;
   testnet-beta-perf)
@@ -150,9 +146,7 @@ sanity() {
   testnet)
     (
       set -x
-      NO_LEDGER_VERIFY=1 \
-      NO_VALIDATOR_SANITY=1 \
-        ci/testnet-sanity.sh testnet-solana-com ec2 us-west-1a
+      ci/testnet-sanity.sh testnet-solana-com ec2 us-west-1a
       #ci/testnet-sanity.sh testnet-solana-com gce us-east1-c
     )
     ;;

--- a/net/remote/remote-client.sh
+++ b/net/remote/remote-client.sh
@@ -49,7 +49,9 @@ local|tar)
   exit 1
 esac
 
-scripts/oom-monitor.sh > oom-monitor.log 2>&1 &
+(
+  sudo scripts/oom-monitor.sh
+) > oom-monitor.log 2>&1 &
 scripts/net-stats.sh  > net-stats.log 2>&1 &
 
 ! tmux list-sessions || tmux kill-session

--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -136,7 +136,9 @@ local|tar)
   # shellcheck source=/dev/null
   source ./target/perf-libs/env.sh
 
-  scripts/oom-monitor.sh  > oom-monitor.log 2>&1 &
+  (
+    sudo scripts/oom-monitor.sh
+  ) > oom-monitor.log 2>&1 &
   scripts/net-stats.sh  > net-stats.log 2>&1 &
 
   maybeNoLeaderRotation=

--- a/net/remote/remote-sanity.sh
+++ b/net/remote/remote-sanity.sh
@@ -90,10 +90,19 @@ local|tar)
 esac
 
 
+echo "--- RPC API: getTransactionCount"
+(
+  set -x
+  curl -X POST \
+    -H 'Content-Type: application/json' \
+    -d '{"jsonrpc":"2.0","id":1, "method":"getTransactionCount"}' \
+    http://"$entrypointIp":8899
+)
+
 echo "--- $entrypointIp: wallet sanity"
 (
   set -x
-  scripts/wallet-sanity.sh "$entrypointIp:8001"
+  scripts/wallet-sanity.sh "$entrypointIp":8001
 )
 
 echo "+++ $entrypointIp: node count ($numNodes expected)"


### PR DESCRIPTION
* Enable ledger/validator sanity for non-perf testnets
* Run oom-monitor as root