### PR TITLE
ci/test-*: Permit build on Cargo.{lock,toml} changes

### DIFF
--- a/ci/test-bench.sh
+++ b/ci/test-bench.sh
@@ -10,6 +10,8 @@ annotate() {
 
 ci/affects-files.sh \
   .rs$ \
+  Cargo.lock$ \
+  Cargo.toml$ \
   ci/test-bench.sh \
 || {
   annotate --style info --context test-bench \

--- a/ci/test-coverage.sh
+++ b/ci/test-coverage.sh
@@ -10,6 +10,8 @@ annotate() {
 
 ci/affects-files.sh \
   .rs$ \
+  Cargo.lock$ \
+  Cargo.toml$ \
   ci/test-coverage.sh \
   scripts/coverage.sh \
 || {

--- a/ci/test-stable-perf.sh
+++ b/ci/test-stable-perf.sh
@@ -10,6 +10,8 @@ annotate() {
 
 ci/affects-files.sh \
   .rs$ \
+  Cargo.lock$ \
+  Cargo.toml$ \
   ci/test-stable-perf.sh \
   ci/test-stable.sh \
 || {


### PR DESCRIPTION
Dependabot PRs only affect Cargo.* files and should trigger the full PR build suite instead of skipping bench/perf/coverage