### PR TITLE
Remove clones in native programs

### DIFF
--- a/programs/native/lua_loader/src/lib.rs
+++ b/programs/native/lua_loader/src/lib.rs
@@ -63,9 +63,10 @@ fn entrypoint(
     solana_logger::setup();
 
     if keyed_accounts[0].account.executable {
-        let code = keyed_accounts[0].account.userdata.clone();
-        let code = str::from_utf8(&code).unwrap();
-        match run_lua(&mut keyed_accounts[1..], &code, tx_data) {
+        let (codes, params) = keyed_accounts.split_at_mut(1);
+        let code = &codes[0].account.userdata;
+        let code = str::from_utf8(code).unwrap();
+        match run_lua(params, &code, tx_data) {
             Ok(()) => {
                 trace!("Lua success");
             }

--- a/programs/native/native_loader/src/lib.rs
+++ b/programs/native/native_loader/src/lib.rs
@@ -60,8 +60,9 @@ pub fn entrypoint(
 ) -> Result<(), ProgramError> {
     if keyed_accounts[0].account.executable {
         // dispatch it
-        let name = keyed_accounts[0].account.userdata.clone();
-        let name = match str::from_utf8(&name) {
+        let (names, params) = keyed_accounts.split_at_mut(1);
+        let name = &names[0].account.userdata;
+        let name = match str::from_utf8(name) {
             Ok(v) => v,
             Err(e) => {
                 warn!("Invalid UTF-8 sequence: {}", e);
@@ -85,12 +86,7 @@ pub fn entrypoint(
                             return Err(ProgramError::GenericError);
                         }
                     };
-                return entrypoint(
-                    program_id,
-                    &mut keyed_accounts[1..],
-                    ix_userdata,
-                    tick_height,
-                );
+                return entrypoint(program_id, params, ix_userdata, tick_height);
             },
             Err(e) => {
                 warn!("Unable to load: {:?}", e);


### PR DESCRIPTION
#### Problem

Rust's borrow-checker won't let you pass around mutable borrows from multiple places of a slice.

#### Summary of Changes

The `split_at` methods nicely tuck away the safe unsafe calls that appease the borrow-checker. This PR uses `split_at_mut` to remove 3 places where we clone the program to workaround the borrow-checker.

Alternatively, we could pass the executable accounts in as a separate [immutable] slice, but that'll require changing every program's `entrypoint()` and it's not obvious that'll work out. If it does, the change in this PR will at least make it a hair easier to migrate.
