### PR TITLE
Replace with_subset()

### DIFF
--- a/benches/runtime.rs
+++ b/benches/runtime.rs
@@ -1,0 +1,14 @@
+#![feature(test)]
+
+extern crate test;
+
+use solana::runtime::*;
+use test::Bencher;
+
+#[bench]
+fn bench_has_duplicates(bencher: &mut Bencher) {
+    bencher.iter(|| {
+        let data = test::black_box([1, 2, 3]);
+        assert!(!has_duplicates(&data));
+    })
+}


### PR DESCRIPTION
with_subset() keeps getting in my way and its lack of tests makes it difficult to understand why that closure is required. As it turns out, it's not. Worse, the closure didn't make the function safe as the code comment described. One could have passed in duplicate indexes and convinced the compiler to let it stomp on a second mut reference pointing to the same element.

#### Summary of Changes

This PR replaces `with_subset()` with a simpler, safer, and better documented use of unsafe code.

Only concern here is that the HashSet is both redundant and slow for short lists of primitive types. Perhaps it can be removed or replaced by `xs.clone().sort()` followed by a check for adjacent duplicates.

