### PR TITLE
RPC API now assumes a drone running on the bootstrap leader

### DIFF
--- a/ci/testnet-manager.sh
+++ b/ci/testnet-manager.sh
@@ -64,6 +64,7 @@ fi
 
 export SOLANA_METRICS_CONFIG="db=$TESTNET,$SOLANA_METRICS_PARTIAL_CONFIG"
 echo "SOLANA_METRICS_CONFIG: $SOLANA_METRICS_CONFIG"
+source scripts/configure-metrics.sh
 
 ci/channel-info.sh
 eval "$(ci/channel-info.sh)"
@@ -277,6 +278,7 @@ sanity-or-restart)
     echo Pass
   else
     echo "+++ Sanity failed, restarting the network"
+    $metricsWriteDatapoint "testnet-manager sanity-failure=1"
     start
   fi
   ;;

--- a/drone/src/drone.rs
+++ b/drone/src/drone.rs
@@ -175,6 +175,10 @@ pub fn request_airdrop_transaction(
     tokens: u64,
     last_id: Hash,
 ) -> Result<Transaction, Error> {
+    info!(
+        "request_airdrop_transaction: drone_addr={} id={} tokens={} last_id={}",
+        drone_addr, id, tokens, last_id
+    );
     // TODO: make this async tokio client
     let mut stream = TcpStream::connect_timeout(drone_addr, Duration::new(3, 0))?;
     stream.set_read_timeout(Some(Duration::new(10, 0)))?;


### PR DESCRIPTION
With leader rotation enabled it's no longer valid to assume the drone is running on the current leader node.  Instead assume the drone runs on the bootstrap leader.

Part of #2278