### PR TITLE
obsolete : stream tap for realtime UI development/prototyping

### DIFF
--- a/ledger-bridge/.gitignore
+++ b/ledger-bridge/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/ledger-bridge/index.js
+++ b/ledger-bridge/index.js
@@ -1,0 +1,51 @@
+import PubNub from 'pubnub';
+import readline from 'readline';
+
+var pubKey = process.env.PN_PUB_KEY;
+var subKey = process.env.PN_SUB_KEY;
+var nodeInfo = JSON.parse(process.env.NODE_INFO);
+var nodeId = 'node@' + nodeInfo.ip;
+
+console.log("starting: " + nodeId);
+
+var pubnub = new PubNub({
+    publishKey: pubKey,
+    subscribeKey: subKey,
+    uuid: nodeId,
+    ssl: true
+});
+
+pubnub.subscribe({channels:['testbridge']});
+pubnub.setState({channels:['testbridge'],state:nodeInfo});
+
+var dgram = require('dgram');
+
+var HOST = '127.0.0.1';
+var PORT = 7654;
+
+var server = dgram.createSocket('udp4');
+
+server.on('listening', function () {
+    var address = server.address();
+    console.log('UDP Server listening on ' + address.address + ":" + address.port);
+});
+
+server.on('message', function (data, remote) {
+  var message = JSON.parse(data);
+  message.ts = new Date().toISOString();
+  message.nodeId = nodeId;
+
+  pubnub.publish({
+    channel: 'testbridge',
+    message: message
+  }, (status, response) => {
+    if (status.error) {
+      console.log("ERR:\t" + JSON.stringify(status) + "\t" + JSON.stringify(message));
+    } else {
+      console.log("OK\t" + JSON.stringify(message));
+    }
+  });
+});
+
+server.bind(PORT, HOST);
+

--- a/ledger-bridge/package.json
+++ b/ledger-bridge/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "ledger_bridge",
+  "version": "1.0.0",
+  "main": "index.js",
+  "license": "MIT",
+  "dependencies": {
+    "babel-cli": "^6.26.0",
+    "babel-preset-env": "^1.7.0",
+    "pubnub": "^4.21.6"
+  },
+  "scripts": {
+    "start": "./run.sh"
+  }
+}

--- a/ledger-bridge/run.sh
+++ b/ledger-bridge/run.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# these keys don't work - get demo keys at https://pubnub.com
+PN_PUB_KEY=pub-c-00000000-0000-0000-0000-000000000000
+PN_SUB_KEY=sub-c-00000000-0000-0000-0000-000000000000
+NODE_INFO=$(curl -q -s ifconfig.co/json)
+
+export PN_PUB_KEY
+export PN_SUB_KEY
+export NODE_INFO
+
+yarn run babel-node --presets env index.js


### PR DESCRIPTION
#### Problem

* to create UIs based on streaming data, we need a convenient way to see the ledger data stream
* to avoid massive changes to the websocket API while we're still working out what we need, it could be useful to bridge to a data stream service like PubNub
* sidestep/avoid the ledger/db_ledger code paths temporarily while that code transition completes

#### Summary of Changes

* modify broadcast_service.rs to sink JSON to a UDP socket
* admittedly quick & dirty implementation to bridge data quickly & have minimal code footprint
* create a small nodejs app "ledger-bridge" that can bridge the UDP json to the data stream API

* TODO: address json & UDP packet size, more reliable transport
* TODO: sync up with folks to see where this type of functionality should *actually* live
* TODO: address replaying history once ledger/db_ledger have a chance to fully bake

Previous Technique from #2296 was:

* extend ledger-tool to have a json-tail subcommand that produces continuous flat file json output

Fixes #

N/A
