### PR TITLE
Add missing error counters and load_account test cases

### DIFF
--- a/sdk/src/account.rs
+++ b/sdk/src/account.rs
@@ -2,7 +2,7 @@ use crate::pubkey::Pubkey;
 
 /// An Account with userdata that is stored on chain
 #[repr(C)]
-#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+#[derive(Serialize, Deserialize, Debug, Clone, Default, Eq, PartialEq)]
 pub struct Account {
     /// tokens in the account
     pub tokens: u64,


### PR DESCRIPTION
#### Problem

- Loading loaders did not update error counters, added new error counters
- Cases where invalid indices could cause a panic, changed to return an error
- Added tests covering `load_accounts`

#### Summary of Changes

Fixes #
