### PR TITLE
Convert chacha_encrypt_file to work with db_ledger blobs directly

### DIFF
--- a/src/chacha.rs
+++ b/src/chacha.rs
@@ -41,8 +41,8 @@ pub fn chacha_cbc_encrypt_ledger(
 ) -> io::Result<()> {
     let mut out_file =
         BufWriter::new(File::create(out_path).expect("Can't open ledger encrypted data file"));
-    let mut buffer = [0; 4 * 1024];
-    let mut encrypted_buffer = [0; 4 * 1024];
+    let mut buffer = [0; 8 * 1024];
+    let mut encrypted_buffer = [0; 8 * 1024];
     let key = [0; CHACHA_KEY_SIZE];
     let mut total_entries = 0;
     let mut entry = slice;
@@ -55,6 +55,10 @@ pub fn chacha_cbc_encrypt_ledger(
             DEFAULT_SLOT_HEIGHT,
         ) {
             Ok((num_entries, entry_len)) => {
+                debug!(
+                    "chacha: encrypting slice: {} num_entries: {} entry_len: {}",
+                    slice, num_entries, entry_len
+                );
                 debug!("read {} bytes", entry_len);
                 let size = entry_len as usize;
                 if size == 0 {
@@ -152,7 +156,7 @@ mod tests {
         assert_eq!(
             hasher.result(),
             Hash::new(&hex!(
-                "58433c941060af56b72bfeaca161f19ed6df531efb28961dc6b83f53fbf66ffe"
+                "1ef70b5491a5f2b05ebeb0f92a03c131a7a78622f3643064d6d3c52a0c083175"
             )),
         );
         remove_file(out_path).unwrap();

--- a/src/chacha.rs
+++ b/src/chacha.rs
@@ -1,9 +1,11 @@
+use crate::db_ledger::{DbLedger, DEFAULT_SLOT_HEIGHT};
 use std::fs::File;
 use std::io;
-use std::io::Read;
-use std::io::Write;
-use std::io::{BufReader, BufWriter};
+use std::io::{BufWriter, Write};
 use std::path::Path;
+use std::sync::Arc;
+
+use crate::storage_stage::ENTRIES_PER_SEGMENT;
 
 pub const CHACHA_BLOCK_SIZE: usize = 64;
 pub const CHACHA_KEY_SIZE: usize = 32;
@@ -31,27 +33,46 @@ pub fn chacha_cbc_encrypt(input: &[u8], output: &mut [u8], key: &[u8], ivec: &mu
     }
 }
 
-pub fn chacha_cbc_encrypt_file(
-    in_path: &Path,
+pub fn chacha_cbc_encrypt_ledger(
+    db_ledger: &Arc<DbLedger>,
+    slice: u64,
     out_path: &Path,
     ivec: &mut [u8; CHACHA_BLOCK_SIZE],
 ) -> io::Result<()> {
-    let mut in_file = BufReader::new(File::open(in_path).expect("Can't open ledger data file"));
     let mut out_file =
         BufWriter::new(File::create(out_path).expect("Can't open ledger encrypted data file"));
     let mut buffer = [0; 4 * 1024];
     let mut encrypted_buffer = [0; 4 * 1024];
     let key = [0; CHACHA_KEY_SIZE];
+    let mut total_entries = 0;
+    let mut entry = slice;
 
-    while let Ok(size) = in_file.read(&mut buffer) {
-        debug!("read {} bytes", size);
-        if size == 0 {
-            break;
-        }
-        chacha_cbc_encrypt(&buffer[..size], &mut encrypted_buffer[..size], &key, ivec);
-        if let Err(res) = out_file.write(&encrypted_buffer[..size]) {
-            println!("Error writing file! {:?}", res);
-            return Err(res);
+    loop {
+        match db_ledger.get_blob_bytes(
+            entry,
+            ENTRIES_PER_SEGMENT - total_entries,
+            &mut buffer,
+            DEFAULT_SLOT_HEIGHT,
+        ) {
+            Ok((num_entries, entry_len)) => {
+                debug!("read {} bytes", entry_len);
+                let size = entry_len as usize;
+                if size == 0 {
+                    break;
+                }
+                chacha_cbc_encrypt(&buffer[..size], &mut encrypted_buffer[..size], &key, ivec);
+                if let Err(res) = out_file.write(&encrypted_buffer[..size]) {
+                    println!("Error writing file! {:?}", res);
+                    return Err(res);
+                }
+
+                total_entries += num_entries;
+                entry += num_entries;
+            }
+            Err(e) => {
+                info!("Error encrypting file: {:?}", e);
+                break;
+            }
         }
     }
     Ok(())
@@ -59,34 +80,81 @@ pub fn chacha_cbc_encrypt_file(
 
 #[cfg(test)]
 mod tests {
-    use crate::chacha::chacha_cbc_encrypt_file;
+    use crate::chacha::chacha_cbc_encrypt_ledger;
+    use crate::db_ledger::{DbLedger, DEFAULT_SLOT_HEIGHT};
+    use crate::entry::Entry;
+    use crate::ledger::get_tmp_ledger_path;
+    use ring::signature::Ed25519KeyPair;
+    use solana_sdk::budget_transaction::BudgetTransaction;
+    use solana_sdk::hash::{hash, Hash, Hasher};
+    use solana_sdk::signature::KeypairUtil;
+    use solana_sdk::transaction::Transaction;
     use std::fs::remove_file;
     use std::fs::File;
     use std::io::Read;
-    use std::io::Write;
     use std::path::Path;
+    use std::sync::Arc;
+    use untrusted::Input;
+
+    fn make_tiny_deterministic_test_entries(num: usize) -> Vec<Entry> {
+        let zero = Hash::default();
+        let one = hash(&zero.as_ref());
+        let pkcs = [
+            48, 83, 2, 1, 1, 48, 5, 6, 3, 43, 101, 112, 4, 34, 4, 32, 109, 148, 235, 20, 97, 127,
+            43, 194, 109, 43, 121, 76, 54, 38, 234, 14, 108, 68, 209, 227, 137, 191, 167, 144, 177,
+            174, 57, 182, 79, 198, 196, 93, 161, 35, 3, 33, 0, 116, 121, 255, 78, 31, 95, 179, 172,
+            30, 125, 206, 87, 88, 78, 46, 145, 25, 154, 161, 252, 3, 58, 235, 116, 39, 148, 193,
+            150, 111, 61, 20, 226,
+        ];
+        let keypair = Ed25519KeyPair::from_pkcs8(Input::from(&pkcs)).unwrap();
+
+        let mut id = one;
+        let mut num_hashes = 0;
+        (0..num)
+            .map(|_| {
+                Entry::new_mut(
+                    &mut id,
+                    &mut num_hashes,
+                    vec![Transaction::budget_new_signature(
+                        &keypair,
+                        keypair.pubkey(),
+                        keypair.pubkey(),
+                        one,
+                    )],
+                )
+            })
+            .collect()
+    }
 
     #[test]
-    fn test_encrypt_file() {
-        let in_path = Path::new("test_chacha_encrypt_file_input.txt");
+    fn test_encrypt_ledger() {
+        solana_logger::setup();
+        let ledger_dir = "chacha_test_encrypt_file";
+        let ledger_path = get_tmp_ledger_path(ledger_dir);
+        let db_ledger = Arc::new(DbLedger::open(&ledger_path).unwrap());
         let out_path = Path::new("test_chacha_encrypt_file_output.txt.enc");
-        {
-            let mut in_file = File::create(in_path).unwrap();
-            in_file.write("123456foobar".as_bytes()).unwrap();
-        }
+
+        let entries = make_tiny_deterministic_test_entries(32);
+        db_ledger
+            .write_entries(DEFAULT_SLOT_HEIGHT, 0, &entries)
+            .unwrap();
+
         let mut key = hex!(
             "abcd1234abcd1234abcd1234abcd1234 abcd1234abcd1234abcd1234abcd1234
                             abcd1234abcd1234abcd1234abcd1234 abcd1234abcd1234abcd1234abcd1234"
         );
-        assert!(chacha_cbc_encrypt_file(in_path, out_path, &mut key).is_ok());
+        assert!(chacha_cbc_encrypt_ledger(&db_ledger, 0, out_path, &mut key).is_ok());
         let mut out_file = File::open(out_path).unwrap();
         let mut buf = vec![];
         let size = out_file.read_to_end(&mut buf).unwrap();
+        let mut hasher = Hasher::default();
+        hasher.hash(&buf[..size]);
         assert_eq!(
-            buf[..size],
-            [66, 54, 56, 212, 142, 110, 105, 158, 116, 82, 120, 53]
+            hasher.result(),
+            Hash::new(&hex!(
+                "58433c941060af56b72bfeaca161f19ed6df531efb28961dc6b83f53fbf66ffe"
+            )),
         );
-        remove_file(in_path).unwrap();
         remove_file(out_path).unwrap();
     }
 }

--- a/src/chacha.rs
+++ b/src/chacha.rs
@@ -48,7 +48,7 @@ pub fn chacha_cbc_encrypt_ledger(
     let mut entry = slice;
 
     loop {
-        match db_ledger.get_blob_bytes(
+        match db_ledger.read_blobs_bytes(
             entry,
             ENTRIES_PER_SEGMENT - total_entries,
             &mut buffer,

--- a/src/chacha_cuda.rs
+++ b/src/chacha_cuda.rs
@@ -51,8 +51,8 @@ pub fn chacha_cbc_encrypt_file_many_keys(
             DEFAULT_SLOT_HEIGHT,
         ) {
             Ok((num_entries, entry_len)) => {
-                info!(
-                    "encrypting slice: {} num_entries: {} entry_len: {}",
+                debug!(
+                    "chacha_cuda: encrypting slice: {} num_entries: {} entry_len: {}",
                     slice, num_entries, entry_len
                 );
                 let entry_len_usz = entry_len as usize;
@@ -155,7 +155,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
     fn test_encrypt_file_many_keys_multiple_keys() {
         solana_logger::setup();
 
@@ -203,14 +202,13 @@ mod tests {
         let _ignored = remove_file(out_path);
     }
 
-    /*
     #[test]
     fn test_encrypt_file_many_keys_bad_key_length() {
         let mut keys = hex!("abc123");
         let ledger_dir = "test_encrypt_file_many_keys_bad_key_length";
         let ledger_path = get_tmp_ledger_path(ledger_dir);
         let samples = [0];
-        assert!(chacha_cbc_encrypt_file_many_keys(&ledger_path, 0, &mut keys, &samples,).is_err());
+        let db_ledger = Arc::new(DbLedger::open(&ledger_path).unwrap());
+        assert!(chacha_cbc_encrypt_file_many_keys(&db_ledger, 0, &mut keys, &samples,).is_err());
     }
-    */
 }

--- a/src/chacha_cuda.rs
+++ b/src/chacha_cuda.rs
@@ -44,7 +44,7 @@ pub fn chacha_cbc_encrypt_file_many_keys(
         chacha_init_sha_state(int_sha_states.as_mut_ptr(), num_keys as u32);
     }
     loop {
-        match db_ledger.get_blob_bytes(
+        match db_ledger.read_blobs_bytes(
             entry,
             ENTRIES_PER_SEGMENT - total_entries,
             &mut buffer,

--- a/src/db_ledger.rs
+++ b/src/db_ledger.rs
@@ -563,7 +563,7 @@ impl DbLedger {
     // whole blobs that fit into buf.len()
     //
     // Return tuple of (number of blob read, total size of blobs read)
-    pub fn get_blob_bytes(
+    pub fn read_blobs_bytes(
         &self,
         start_index: u64,
         num_blobs: u64,
@@ -771,7 +771,7 @@ mod tests {
     }
 
     #[test]
-    fn test_get_blobs_bytes() {
+    fn test_read_blobs_bytes() {
         let shared_blobs = make_tiny_test_entries(10).to_shared_blobs();
         let slot = DEFAULT_SLOT_HEIGHT;
         index_blobs(
@@ -783,12 +783,12 @@ mod tests {
         let blob_locks: Vec<_> = shared_blobs.iter().map(|b| b.read().unwrap()).collect();
         let blobs: Vec<&Blob> = blob_locks.iter().map(|b| &**b).collect();
 
-        let ledger_path = get_tmp_ledger_path("test_get_blobs_bytes");
+        let ledger_path = get_tmp_ledger_path("test_read_blobs_bytes");
         let ledger = DbLedger::open(&ledger_path).unwrap();
         ledger.write_blobs(&blobs).unwrap();
 
         let mut buf = [0; 1024];
-        let (num_blobs, bytes) = ledger.get_blob_bytes(0, 1, &mut buf, slot).unwrap();
+        let (num_blobs, bytes) = ledger.read_blobs_bytes(0, 1, &mut buf, slot).unwrap();
         let bytes = bytes as usize;
         assert_eq!(num_blobs, 1);
         {
@@ -796,7 +796,7 @@ mod tests {
             assert_eq!(blob_data, &blobs[0].data[..bytes]);
         }
 
-        let (num_blobs, bytes2) = ledger.get_blob_bytes(0, 2, &mut buf, slot).unwrap();
+        let (num_blobs, bytes2) = ledger.read_blobs_bytes(0, 2, &mut buf, slot).unwrap();
         let bytes2 = bytes2 as usize;
         assert_eq!(num_blobs, 2);
         assert!(bytes2 > bytes);
@@ -810,19 +810,19 @@ mod tests {
 
         // buf size part-way into blob[1], should just return blob[0]
         let mut buf = vec![0; bytes + 1];
-        let (num_blobs, bytes3) = ledger.get_blob_bytes(0, 2, &mut buf, slot).unwrap();
+        let (num_blobs, bytes3) = ledger.read_blobs_bytes(0, 2, &mut buf, slot).unwrap();
         assert_eq!(num_blobs, 1);
         let bytes3 = bytes3 as usize;
         assert_eq!(bytes3, bytes);
 
         let mut buf = vec![0; bytes2 - 1];
-        let (num_blobs, bytes4) = ledger.get_blob_bytes(0, 2, &mut buf, slot).unwrap();
+        let (num_blobs, bytes4) = ledger.read_blobs_bytes(0, 2, &mut buf, slot).unwrap();
         assert_eq!(num_blobs, 1);
         let bytes4 = bytes4 as usize;
         assert_eq!(bytes4, bytes);
 
         let mut buf = vec![0; bytes * 2];
-        let (num_blobs, bytes6) = ledger.get_blob_bytes(9, 1, &mut buf, slot).unwrap();
+        let (num_blobs, bytes6) = ledger.read_blobs_bytes(9, 1, &mut buf, slot).unwrap();
         assert_eq!(num_blobs, 1);
         let bytes6 = bytes6 as usize;
 
@@ -832,7 +832,7 @@ mod tests {
         }
 
         // Read out of range
-        assert!(ledger.get_blob_bytes(20, 2, &mut buf, slot).is_err());
+        assert!(ledger.read_blobs_bytes(20, 2, &mut buf, slot).is_err());
 
         // Destroying database without closing it first is undefined behavior
         drop(ledger);

--- a/src/ledger.rs
+++ b/src/ledger.rs
@@ -69,7 +69,7 @@ struct LedgerWindow {
     data: BufReader<File>,
 }
 
-pub const LEDGER_DATA_FILE: &str = "data";
+const LEDGER_DATA_FILE: &str = "data";
 const LEDGER_INDEX_FILE: &str = "index";
 
 // use a CONST because there's a cast, and we don't want "sizeof::<u64> as u64"...


### PR DESCRIPTION
#### Problem

With db_ledger, storage cannot encrypt the ledger file directly it needs to grab the entries from db_ledger interfaces.

#### Summary of Changes

Use db_ledger interfaces for chacha_encrypt_ledger.

Fixes #2308 
