### PR TITLE
testnet-manager.sh plumbing to support cluster software updates while preserving the ledger

### DIFF
--- a/ci/shellcheck.sh
+++ b/ci/shellcheck.sh
@@ -4,15 +4,15 @@
 set -e
 
 cd "$(dirname "$0")/.."
-
-set -x
-find . -name "*.sh" \
-    -not -regex ".*/ci/semver_bash/.*" \
-    -not -regex ".*/.cargo/.*" \
-    -not -regex ".*/node_modules/.*" \
-    -not -regex ".*/target/.*" \
-    -print0 \
-  | xargs -0 \
-      ci/docker-run.sh koalaman/shellcheck --color=always --external-sources --shell=bash
-
+(
+  set -x
+  find . -name "*.sh" \
+      -not -regex ".*/ci/semver_bash/.*" \
+      -not -regex ".*/.cargo/.*" \
+      -not -regex ".*/node_modules/.*" \
+      -not -regex ".*/target/.*" \
+      -print0 \
+    | xargs -0 \
+        ci/docker-run.sh koalaman/shellcheck --color=always --external-sources --shell=bash
+)
 echo --- ok

--- a/ci/testnet-manager.sh
+++ b/ci/testnet-manager.sh
@@ -50,6 +50,8 @@ steps:
             value: "sanity-or-restart"
           - label: "Start (or restart) the network"
             value: "start"
+          - label: "Update the network software.  Restart network on failure"
+            value: "update-or-restart"
           - label: "Stop the network"
             value: "stop"
           - label: "Sanity check only"
@@ -176,6 +178,7 @@ start() {
   else
     echo "--- stop $TESTNET"
   fi
+  declare maybeReuseLedger=$2
 
   case $TESTNET in
   testnet-edge)
@@ -186,6 +189,7 @@ start() {
       RUST_LOG=solana=info \
         ci/testnet-deploy.sh edge-testnet-solana-com ec2 us-west-1a \
           -t "$CHANNEL_OR_TAG" -n 3 -c 0 -P -a eipalloc-0ccd4f2239886fa94 \
+          ${maybeReuseLedger:+-r} \
           ${maybeDelete:+-d}
     )
     ;;
@@ -197,6 +201,7 @@ start() {
         ci/testnet-deploy.sh edge-perf-testnet-solana-com ec2 us-west-2b \
           -g -t "$CHANNEL_OR_TAG" -c 2 \
           -b \
+          ${maybeReuseLedger:+-r} \
           ${maybeDelete:+-d}
     )
     ;;
@@ -209,6 +214,7 @@ start() {
         ci/testnet-deploy.sh beta-testnet-solana-com ec2 us-west-1a \
           -t "$CHANNEL_OR_TAG" -n 3 -c 0 -P -a eipalloc-0f286cf8a0771ce35 \
           -b \
+          ${maybeReuseLedger:+-r} \
           ${maybeDelete:+-d}
     )
     ;;
@@ -220,6 +226,7 @@ start() {
         ci/testnet-deploy.sh beta-perf-testnet-solana-com ec2 us-west-2b \
           -g -t "$CHANNEL_OR_TAG" -c 2 \
           -b \
+          ${maybeReuseLedger:+-r} \
           ${maybeDelete:+-d}
     )
     ;;
@@ -232,9 +239,11 @@ start() {
         ci/testnet-deploy.sh testnet-solana-com ec2 us-west-1a \
           -t "$CHANNEL_OR_TAG" -n 3 -c 0 -P -a eipalloc-0fa502bf95f6f18b2 \
           -b \
+          ${maybeReuseLedger:+-r} \
           ${maybeDelete:+-d}
         #ci/testnet-deploy.sh testnet-solana-com gce us-east1-c \
         #  -s "$CHANNEL_OR_TAG" -n 3 -c 0 -P -a testnet-solana-com  \
+        #  ${maybeReuseLedger:+-r} \
         #  ${maybeDelete:+-d}
     )
     ;;
@@ -248,10 +257,12 @@ start() {
           -t "$CHANNEL_OR_TAG" -c 2 \
           -b \
           -d pd-ssd \
+          ${maybeReuseLedger:+-r} \
           ${maybeDelete:+-d}
         #ci/testnet-deploy.sh perf-testnet-solana-com ec2 us-east-1a \
         #  -g \
         #  -t "$CHANNEL_OR_TAG" -c 2 \
+        #  ${maybeReuseLedger:+-r} \
         #  ${maybeDelete:+-d}
     )
     ;;
@@ -276,13 +287,28 @@ start)
 stop)
   stop
   ;;
+update-or-restart)
+  if start "" update; then
+    echo Update successful
+  else
+    echo "+++ Update failed, restarting the network"
+    $metricsWriteDatapoint "testnet-manager update-failure=1"
+    start
+  fi
+  ;;
 sanity-or-restart)
   if sanity; then
     echo Pass
   else
-    echo "+++ Sanity failed, restarting the network"
+    echo "+++ Sanity failed, updating the network"
     $metricsWriteDatapoint "testnet-manager sanity-failure=1"
-    start
+    if start "" update; then
+      echo Update successful
+    else
+      echo "+++ Update failed, restarting the network"
+      $metricsWriteDatapoint "testnet-manager update-failure=1"
+      start
+    fi
   fi
   ;;
 esac

--- a/net/gce.sh
+++ b/net/gce.sh
@@ -63,12 +63,12 @@ Manage testnet instances
  common options:
    -p [prefix]      - Optional common prefix for instance names to avoid
                       collisions (default: $prefix)
+   -z [zone]        - Zone for the nodes (default: $zone)
 
  create-specific options:
    -n [number]      - Number of additional fullnodes (default: $additionalFullNodeCount)
    -c [number]      - Number of client nodes (default: $clientNodeCount)
    -P               - Use public network IP addresses (default: $publicNetwork)
-   -z [zone]        - Zone for the nodes (default: $zone)
    -g               - Enable GPU (default: $enableGpu)
    -G               - Enable GPU, and set count/type of GPUs to use (e.g $cpuBootstrapLeaderMachineType --accelerator count=4,type=nvidia-tesla-k80)
    -a [address]     - Set the bootstreap fullnode's external IP address to this value.

--- a/net/net.sh
+++ b/net/net.sh
@@ -371,15 +371,15 @@ start() {
   $metricsWriteDatapoint "testnet-deploy net-fullnodes-started=1"
   additionalNodeDeployTime=$SECONDS
 
-  if ! $updateNodes; then
-    sanity
+  if $updateNodes; then
+    for ipAddress in "${clientIpList[@]}"; do
+      stopNode "$ipAddress"
+    done
   fi
+  sanity
 
   SECONDS=0
   for ipAddress in "${clientIpList[@]}"; do
-    if $updateNodes; then
-      stopNode "$ipAddress"
-    fi
     startClient "$ipAddress" "$netLogDir/client-$ipAddress.log"
   done
   clientDeployTime=$SECONDS


### PR DESCRIPTION
Rolling updates are disabled for now, but should be a two liner to enable once we're ready.  For now an update stops each node, rsyncs over new code, and starts them back up.  If this process fails, the nodes are recreated from scratch.  A metric datapoint is emitted when this occurs, for notification purposes.