### PR TITLE
Why can I comment out this code and no tests fail?

### DIFF
--- a/src/broadcast_service.rs
+++ b/src/broadcast_service.rs
@@ -153,17 +153,18 @@ fn broadcast(
 
         *receive_index += blobs_len as u64;
 
-        // Send blobs out from the window
-        ClusterInfo::broadcast(
-            contains_last_tick,
-            leader_id,
-            &node_info,
-            &broadcast_table,
-            &window,
-            &sock,
-            transmit_index,
-            *receive_index,
-        )?;
+        //TODO: Why can I comment this out and no tests fail?
+        //// Send blobs out from the window
+        //ClusterInfo::broadcast(
+        //    contains_last_tick,
+        //    leader_id,
+        //    &node_info,
+        //    &broadcast_table,
+        //    &window,
+        //    &sock,
+        //    transmit_index,
+        //    *receive_index,
+        //)?;
     }
     let broadcast_elapsed = duration_as_ms(&broadcast_start.elapsed());
 


### PR DESCRIPTION
#### Problem

`ClusterInfo::broadcast` depends on `Window`. Rumor has it that `Window` is no longer used. Is it safe to remove this function call?

#### Summary of Changes

Comment out undocumented, untested (directly or indirectly) function `ClusterInfo::broadcast()`

