### PR TITLE
Remove vestigial vote account configuration from fullnode-config

### DIFF
--- a/fullnode-config/src/lib.rs
+++ b/fullnode-config/src/lib.rs
@@ -17,9 +17,6 @@ pub struct Config {
 
     /// Fullnode identity
     pub identity_pkcs8: Vec<u8>,
-
-    /// Fullnode vote account
-    pub vote_account_pkcs8: Vec<u8>,
 }
 
 impl Config {
@@ -40,9 +37,5 @@ impl Config {
     pub fn keypair(&self) -> Keypair {
         Keypair::from_pkcs8(Input::from(&self.identity_pkcs8))
             .expect("from_pkcs8 in fullnode::Config keypair")
-    }
-    pub fn vote_account_keypair(&self) -> Keypair {
-        Keypair::from_pkcs8(Input::from(&self.vote_account_pkcs8))
-            .expect("from_pkcs8 in fullnode::Config vote_account_keypair")
     }
 }

--- a/fullnode-config/src/main.rs
+++ b/fullnode-config/src/main.rs
@@ -1,4 +1,4 @@
-use solana_sdk::signature::{gen_pkcs8, read_pkcs8};
+use solana_sdk::signature::read_pkcs8;
 use std::io;
 
 fn main() {
@@ -49,7 +49,6 @@ fn main() {
         use_local_address: matches.is_present("local"),
         use_public_address: matches.is_present("public"),
         identity_pkcs8: read_pkcs8(id_path).expect("invalid keypair"),
-        vote_account_pkcs8: gen_pkcs8().unwrap(),
     };
 
     let stdout = io::stdout();

--- a/fullnode/src/main.rs
+++ b/fullnode/src/main.rs
@@ -85,7 +85,7 @@ fn main() {
     let nosigverify = matches.is_present("nosigverify");
     let use_only_bootstrap_leader = matches.is_present("no-leader-rotation");
 
-    let (keypair, _vote_account_keypair, gossip) = if let Some(i) = matches.value_of("identity") {
+    let (keypair, gossip) = if let Some(i) = matches.value_of("identity") {
         let path = i.to_string();
         if let Ok(file) = File::open(path.clone()) {
             let parse: serde_json::Result<solana_fullnode_config::Config> =
@@ -98,11 +98,7 @@ fn main() {
                     &config_data.bind_addr(FULLNODE_PORT_RANGE.0),
                 );
 
-                (
-                    keypair,
-                    config_data.vote_account_keypair(),
-                    node_info.gossip,
-                )
+                (keypair, node_info.gossip)
             } else {
                 eprintln!("failed to parse {}", path);
                 exit(1);
@@ -112,7 +108,7 @@ fn main() {
             exit(1);
         }
     } else {
-        (Keypair::new(), Keypair::new(), socketaddr!(0, 8000))
+        (Keypair::new(), socketaddr!(0, 8000))
     };
 
     let ledger_path = matches.value_of("ledger").unwrap();
@@ -150,7 +146,7 @@ fn main() {
         .expect("Failed to register node");
     let vote_account_id: Pubkey =
         serde_json::from_value(resp).expect("Invalid register node response");
-    info!("New vote account ID is {:?}", vote_account_id);
+    info!("Vote account ID is {:?}", vote_account_id);
     let keypair = Arc::new(keypair);
     let pubkey = keypair.pubkey();
 


### PR DESCRIPTION
This code became unused with the introduction of the vote signer service