### PR TITLE
Remove |cargo package| sanity step

### DIFF
--- a/ci/publish-crate.sh
+++ b/ci/publish-crate.sh
@@ -27,20 +27,18 @@ CRATES=(
 )
 
 
-cargoCommand="cargo package"
-
 # Only package/publish if this is a tagged release
-if [[ -n $TRIGGERED_BUILDKITE_TAG ]]; then
+[[ -n $TRIGGERED_BUILDKITE_TAG ]] || {
+  echo TRIGGERED_BUILDKITE_TAG unset, skipped
+  exit 0
+}
 
-  # Only publish if there's no human around
-  if [[ -n $CI ]]; then
-    cargoCommand="cargo publish --token $CRATES_IO_TOKEN"
-    if [[ -z "$CRATES_IO_TOKEN" ]]; then
-      echo CRATES_IO_TOKEN undefined
-      exit 1
-    fi
-  fi
-fi
+[[ -n "$CRATES_IO_TOKEN" ]] || {
+  echo CRATES_IO_TOKEN undefined
+  exit 1
+}
+
+cargoCommand="cargo publish --token $CRATES_IO_TOKEN"
 
 for crate in "${CRATES[@]}"; do
   if [[ ! -r $crate/Cargo.toml ]]; then
@@ -48,7 +46,8 @@ for crate in "${CRATES[@]}"; do
     exit 1
   fi
   echo "-- $crate"
-  # TODO: Ensure the published version matches the contents of BUILDKITE_TAG
+  # TODO: Ensure the published version matches the contents of
+  # TRIGGERED_BUILDKITE_TAG
   (
     set -x
     # TODO: the rocksdb package does not build with the stock rust docker image,


### PR DESCRIPTION
Unfortunately due to our multi-crate repo, as soon as
|./scripts/increment-cargo-version.sh| is run after a release, |cargo
package| will fail for crates that depend on other in-tree crates, as
the new crate version has not yet been published to crates.io.
For now this means that we need to continue flying blind and be prepared
to deal with minor publishing issues on each new release.

#### Problem

#### Summary of Changes

Fixes #
