### PR TITLE
Add configurable RUST_LOG for ./net.sh sanity

### DIFF
--- a/net/net.sh
+++ b/net/net.sh
@@ -37,9 +37,6 @@ Operate a configured testnet
    -r                          - Reuse existing node/ledger configuration from a
                                  previous |start| (ie, don't run ./mulitnode-demo/setup.sh).
 
-   Note: if RUST_LOG is set in the environment it will be propogated into the
-         network nodes.
-
  sanity/start/update-specific options:
    -o noLedgerVerify    - Skip ledger verification
    -o noValidatorSanity - Skip fullnode sanity
@@ -51,6 +48,8 @@ Operate a configured testnet
  logs-specific options:
    none
 
+Note: if RUST_LOG is set in the environment it will be propogated into the
+      network nodes.
 EOF
   exit $exitcode
 }
@@ -278,7 +277,7 @@ sanity() {
     set -x
     # shellcheck disable=SC2029 # remote-client.sh args are expanded on client side intentionally
     ssh "${sshOptions[@]}" "$host" \
-      "./solana/net/remote/remote-sanity.sh $sanityExtraArgs"
+      "./solana/net/remote/remote-sanity.sh $sanityExtraArgs \"$RUST_LOG\""
   ) || ok=false
 
   $metricsWriteDatapoint "testnet-deploy net-sanity-complete=1"

--- a/net/remote/remote-sanity.sh
+++ b/net/remote/remote-sanity.sh
@@ -50,6 +50,9 @@ while [[ $1 = -o ]]; do
   esac
 done
 
+RUST_LOG="$1"
+export RUST_LOG=${RUST_LOG:-solana=info} # if RUST_LOG is unset, default to info
+
 source net/common.sh
 loadConfigFile
 


### PR DESCRIPTION
Usage:
```bash
$ RUST_LOG=solana=trace ./net.sh sanity
```

#### Problem

#### Summary of Changes

Fixes #
