### PR TITLE
Avoid -d arg conflict

### DIFF
--- a/ci/testnet-deploy.sh
+++ b/ci/testnet-deploy.sh
@@ -15,6 +15,7 @@ snapChannel=edge
 tarChannelOrTag=edge
 delete=false
 enableGpu=false
+bootDiskType=""
 leaderRotation=true
 useTarReleaseChannel=false
 
@@ -47,10 +48,10 @@ Deploys a CD testnet
    -g                   - Enable GPU (default: $enableGpu)
    -b                   - Disable leader rotation
    -a [address]         - Set the bootstrap fullnode's external IP address to this GCE address
-   -d                   - Delete the network
+   -d [disk-type]       - Specify a boot disk type (default None) Use pd-ssd to get ssd on GCE.
+   -D                   - Delete the network
    -r                   - Reuse existing node/ledger configuration from a
                           previous |start| (ie, don't run ./mulitnode-demo/setup.sh).
-
 
    Note: the SOLANA_METRICS_CONFIG environment variable is used to configure
          metrics
@@ -66,7 +67,7 @@ zone=$3
 [[ -n $zone ]] || usage "Zone not specified"
 shift 3
 
-while getopts "h?p:Pn:c:s:t:gG:a:dbr" opt; do
+while getopts "h?p:Pn:c:s:t:gG:a:Dbd:r" opt; do
   case $opt in
   h | \?)
     usage
@@ -115,6 +116,9 @@ while getopts "h?p:Pn:c:s:t:gG:a:dbr" opt; do
     bootstrapFullNodeAddress=$OPTARG
     ;;
   d)
+    bootDiskType=$OPTARG
+    ;;
+  D)
     delete=true
     ;;
   r)
@@ -161,6 +165,11 @@ if ! $skipSetup; then
     -c "$clientNodeCount"
     -n "$additionalFullNodeCount"
   )
+
+  if [[ -n $bootDiskType ]]; then
+    create_args+=(-d "$bootDiskType")
+  fi
+
   if $enableGpu; then
     if [[ -z $bootstrapFullNodeMachineType ]]; then
       create_args+=(-g)

--- a/ci/testnet-manager.sh
+++ b/ci/testnet-manager.sh
@@ -190,7 +190,7 @@ start() {
         ci/testnet-deploy.sh edge-testnet-solana-com ec2 us-west-1a \
           -t "$CHANNEL_OR_TAG" -n 3 -c 0 -P -a eipalloc-0ccd4f2239886fa94 \
           ${maybeReuseLedger:+-r} \
-          ${maybeDelete:+-d}
+          ${maybeDelete:+-D}
     )
     ;;
   testnet-edge-perf)
@@ -202,7 +202,7 @@ start() {
           -g -t "$CHANNEL_OR_TAG" -c 2 \
           -b \
           ${maybeReuseLedger:+-r} \
-          ${maybeDelete:+-d}
+          ${maybeDelete:+-D}
     )
     ;;
   testnet-beta)
@@ -215,7 +215,7 @@ start() {
           -t "$CHANNEL_OR_TAG" -n 3 -c 0 -P -a eipalloc-0f286cf8a0771ce35 \
           -b \
           ${maybeReuseLedger:+-r} \
-          ${maybeDelete:+-d}
+          ${maybeDelete:+-D}
     )
     ;;
   testnet-beta-perf)
@@ -227,7 +227,7 @@ start() {
           -g -t "$CHANNEL_OR_TAG" -c 2 \
           -b \
           ${maybeReuseLedger:+-r} \
-          ${maybeDelete:+-d}
+          ${maybeDelete:+-D}
     )
     ;;
   testnet)
@@ -240,11 +240,11 @@ start() {
           -t "$CHANNEL_OR_TAG" -n 3 -c 0 -P -a eipalloc-0fa502bf95f6f18b2 \
           -b \
           ${maybeReuseLedger:+-r} \
-          ${maybeDelete:+-d}
+          ${maybeDelete:+-D}
         #ci/testnet-deploy.sh testnet-solana-com gce us-east1-c \
         #  -s "$CHANNEL_OR_TAG" -n 3 -c 0 -P -a testnet-solana-com  \
         #  ${maybeReuseLedger:+-r} \
-        #  ${maybeDelete:+-d}
+        #  ${maybeDelete:+-D}
     )
     ;;
   testnet-perf)
@@ -258,12 +258,12 @@ start() {
           -b \
           -d pd-ssd \
           ${maybeReuseLedger:+-r} \
-          ${maybeDelete:+-d}
+          ${maybeDelete:+-D}
         #ci/testnet-deploy.sh perf-testnet-solana-com ec2 us-east-1a \
         #  -g \
         #  -t "$CHANNEL_OR_TAG" -c 2 \
         #  ${maybeReuseLedger:+-r} \
-        #  ${maybeDelete:+-d}
+        #  ${maybeDelete:+-D}
     )
     ;;
   *)


### PR DESCRIPTION
-D is now "delete"
-d is now "disk type"

Only affected `testnet-perf`