### PR TITLE
Move BloomHashIndex into its own module

### DIFF
--- a/src/bloom.rs
+++ b/src/bloom.rs
@@ -1,14 +1,9 @@
 //! Simple Bloom Filter
+use crate::bloom_hash_index::BloomHashIndex;
 use bv::BitVec;
 use rand::{self, Rng};
 use std::cmp;
 use std::marker::PhantomData;
-
-/// Generate a stable hash of `self` for each `hash_index`
-/// Best effort can be made for uniqueness of each hash.
-pub trait BloomHashIndex {
-    fn hash(&self, hash_index: u64) -> u64;
-}
 
 #[derive(Serialize, Deserialize, Default, Clone, Debug, PartialEq)]
 pub struct Bloom<T: BloomHashIndex> {

--- a/src/bloom_hash_index.rs
+++ b/src/bloom_hash_index.rs
@@ -1,4 +1,3 @@
-use crate::bloom::BloomHashIndex;
 use solana_sdk::hash::Hash;
 use solana_sdk::pubkey::Pubkey;
 
@@ -11,6 +10,12 @@ fn slice_hash(slice: &[u8], hash_index: u64) -> u64 {
         rv |= u64::from(slice[pos as usize % len]) << i;
     }
     rv
+}
+
+/// Generate a stable hash of `self` for each `hash_index`
+/// Best effort can be made for uniqueness of each hash.
+pub trait BloomHashIndex {
+    fn hash(&self, hash_index: u64) -> u64;
 }
 
 impl BloomHashIndex for Pubkey {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ pub mod bank;
 pub mod banking_stage;
 pub mod blob_fetch_stage;
 pub mod bloom;
+pub mod bloom_hash_index;
 pub mod broadcast_service;
 #[cfg(feature = "chacha")]
 pub mod chacha;
@@ -26,7 +27,6 @@ pub mod crds_gossip;
 pub mod crds_gossip_error;
 pub mod crds_gossip_pull;
 pub mod crds_gossip_push;
-pub mod crds_traits_impls;
 pub mod crds_value;
 #[macro_use]
 pub mod contact_info;


### PR DESCRIPTION
#### Problem

Awkward name `cdrs_traits_impl.rs`

#### Summary of Changes

Rename the module and yoink the trait definition.

Slightly better would be to put it in the SDK so that the trait
implementations could go into hash and pubkey, but if we don't
want compatibility constraints, this is the next best thing.

