### PR TITLE
Avoid accounts_db deadlock

### DIFF
--- a/ci/buildkite-stability.yml
+++ b/ci/buildkite-stability.yml
@@ -1,0 +1,4 @@
+steps:
+  - command: "ci/iterations-localnet.sh"
+    name: "iterations-localnet"
+    timeout_in_minutes: 40

--- a/ci/iterations-localnet.sh
+++ b/ci/iterations-localnet.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -e
+
+FEATURES="$1"
+
+cd "$(dirname "$0")/.."
+
+# Clear cached json keypair files
+rm -rf "$HOME/.config/solana"
+
+source ci/_
+ci/version-check-with-upgrade.sh stable
+export RUST_BACKTRACE=1
+export RUSTFLAGS="-D warnings"
+
+_ scripts/ulimit-n.sh
+_ cargo build --all --features="$FEATURES"
+
+export PATH=$PWD/target/debug:$PATH
+export USE_INSTALL=1
+
+_ ci/localnet-sanity.sh -b -i 256
+# TODO: Enable next line once leader rotation stability is fixed
+#_ ci/localnet-sanity.sh -i 256

--- a/ci/localnet-sanity.sh
+++ b/ci/localnet-sanity.sh
@@ -1,23 +1,80 @@
 #!/usr/bin/env bash
 set -e
-#
-# Perform a quick sanity test on a leader, drone, validator and client running
-# locally on the same machine
-#
+
+iterations=1
+maybeNoLeaderRotation=
+extraNodes=0
+
+usage() {
+  exitcode=0
+  if [[ -n "$1" ]]; then
+    exitcode=1
+    echo "Error: $*"
+  fi
+  cat <<EOF
+usage: $0 [options...]
+
+Start a local cluster and run sanity on it
+
+  options:
+   -i [number] - Number of times to run sanity (default: $iterations)
+   -b          - Disable leader rotation
+   -x          - Add an extra fullnode (may be supplied multiple times)
+
+EOF
+  exit $exitcode
+}
 
 cd "$(dirname "$0")"/..
+
+while getopts "h?i:bx" opt; do
+  case $opt in
+  h | \?)
+    usage
+    ;;
+  i)
+    iterations=$OPTARG
+    ;;
+  b)
+    maybeNoLeaderRotation="--no-leader-rotation"
+    ;;
+  x)
+    extraNodes=$((extraNodes + 1))
+    ;;
+  *)
+    usage "Error: unhandled option: $opt"
+    ;;
+  esac
+done
+
 source ci/upload-ci-artifact.sh
 source scripts/configure-metrics.sh
 
 multinode-demo/setup.sh
 
-backgroundCommands="drone bootstrap-leader fullnode fullnode-x"
-pids=()
+backgroundCommands=(
+  "multinode-demo/drone.sh"
+  "multinode-demo/bootstrap-leader.sh $maybeNoLeaderRotation"
+  "multinode-demo/fullnode.sh $maybeNoLeaderRotation"
+)
 
-for cmd in $backgroundCommands; do
+for _ in $(seq 1 $extraNodes); do
+  backgroundCommands+=(
+    "multinode-demo/fullnode-x.sh $maybeNoLeaderRotation"
+  )
+done
+numNodes=$((2 + extraNodes))
+
+pids=()
+logs=()
+
+for cmd in "${backgroundCommands[@]}"; do
   echo "--- Start $cmd"
-  rm -f log-"$cmd".txt
-  multinode-demo/"$cmd".sh > log-"$cmd".txt 2>&1 &
+  baseCmd=$(basename "${cmd// */}" .sh)
+  declare log=log-$baseCmd.txt
+  rm -f "$log"
+  $cmd > "$log" 2>&1 &
+  logs+=("$log")
   declare pid=$!
   pids+=("$pid")
   echo "pid: $pid"
@@ -43,10 +100,9 @@ shutdown() {
   set +e
 
   echo "--- Upload artifacts"
-  for cmd in $backgroundCommands; do
-    declare logfile=log-$cmd.txt
-    upload-ci-artifact "$logfile"
-    tail "$logfile"
+  for log in "${logs[@]}"; do
+    upload-ci-artifact "$log"
+    tail "$log"
   done
 
   exit $exitcode
@@ -56,40 +112,46 @@ trap shutdown EXIT INT
 
 set -e
 
+declare iteration=1
+
 flag_error() {
-  echo Failed
+  echo "Failed (iteration: $iteration/$iterations)"
   echo "^^^ +++"
   exit 1
 }
 
-echo "--- Node count"
-(
-  source multinode-demo/common.sh
-  set -x
-  client_id=/tmp/client-id.json-$$
-  $solana_keygen -o $client_id || exit $?
-  $solana_bench_tps \
-    --identity $client_id \
-    --num-nodes 3 \
-    --reject-extra-nodes \
-    --converge-only || exit $?
-  rm -rf $client_id
-) || flag_error
+while [[ $iteration -le $iterations ]]; do
+  echo "--- Node count ($iteration)"
+  (
+    source multinode-demo/common.sh
+    set -x
+    client_id=/tmp/client-id.json-$$
+    $solana_keygen -o $client_id || exit $?
+    $solana_bench_tps \
+      --identity $client_id \
+      --num-nodes $numNodes \
+      --reject-extra-nodes \
+      --converge-only || exit $?
+    rm -rf $client_id
+  ) || flag_error
 
-echo "--- RPC API: getTransactionCount"
-(
-  set -x
-  curl --retry 5 --retry-delay 2 --retry-connrefused \
-    -X POST -H 'Content-Type: application/json' \
-    -d '{"jsonrpc":"2.0","id":1, "method":"getTransactionCount"}' \
-    http://localhost:8899
-) || flag_error
+  echo "--- RPC API: getTransactionCount ($iteration)"
+  (
+    set -x
+    curl --retry 5 --retry-delay 2 --retry-connrefused \
+      -X POST -H 'Content-Type: application/json' \
+      -d '{"jsonrpc":"2.0","id":1, "method":"getTransactionCount"}' \
+      http://localhost:8899
+  ) || flag_error
 
-echo "--- Wallet sanity"
-(
-  set -x
-  timeout 60s scripts/wallet-sanity.sh
-) || flag_error
+  echo "--- Wallet sanity ($iteration)"
+  (
+    set -x
+    timeout 60s scripts/wallet-sanity.sh
+  ) || flag_error
+
+  iteration=$((iteration + 1))
+done
 
 killBackgroundCommands
 
@@ -103,5 +165,6 @@ echo "--- Ledger verification"
 ) || flag_error
 
 echo +++
-echo Ok
+echo "Ok ($iterations iterations)"
+
 exit 0

--- a/ci/test-stable.sh
+++ b/ci/test-stable.sh
@@ -39,5 +39,5 @@ echo --- ci/localnet-sanity.sh
   set -x
   # Assume |cargo build| has populated target/debug/ successfully.
   export PATH=$PWD/target/debug:$PATH
-  USE_INSTALL=1 ci/localnet-sanity.sh
+  USE_INSTALL=1 ci/localnet-sanity.sh -x
 )


### PR DESCRIPTION
get_last_supermajority_timestamp() was holding an accounts_db lock while calling into the bank, which was causing a deadlock.   Refactored that function to avoid the issue. 

Also created a new iterations test script (which will run as a nightly buildkite job) that consistently reproduced the deadlock in ~5 min without the fix, but successfully runs for hours without a deadlock with the fix applied.

NB: currently iterations are run with leader rotation disabled, as stability bugs still linger with leader rotation enabled.

cc: #2314