### PR TITLE
Add debug fn for program ids

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1845,6 +1845,7 @@ dependencies = [
  "hex-literal 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.46 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ chrono = { version = "0.4.0", features = ["serde"] }
 hashbrown = "0.1.7"
 indexmap = "1.0"
 itertools = "0.8.0"
+lazy_static = "1.2.0"
 libc = "0.2.46"
 log = "0.4.2"
 nix = "0.12.0"

--- a/src/bank.rs
+++ b/src/bank.rs
@@ -412,6 +412,23 @@ impl Bank {
         Ok(())
     }
 
+    fn program_id_to_string(id: &Pubkey) -> String {
+        lazy_static! {
+            static ref PROGRAMS: HashMap<Pubkey, &'static str> = {
+                let mut map = HashMap::new();
+                map.insert(system_program::id(), "system_program");
+                map.insert(solana_native_loader::id(), "solana_native_loader");
+                map.insert(bpf_loader::id(), "bpf_loader");
+                map.insert(budget_program::id(), "budget_program");
+                map.insert(storage_program::id(), "storage_program");
+                map.insert(token_program::id(), "token_program");
+                map.insert(vote_program::id(), "vote_program");
+                map
+            };
+        }
+        PROGRAMS.get(id).unwrap_or(&"unknown program").to_string()
+    }
+
     fn load_accounts(
         &self,
         txs: &[Transaction],
@@ -482,6 +499,11 @@ impl Bank {
             } else {
                 if err_count == 0 {
                     info!("tx error: {:?} {:?}", r, tx);
+                    if log_enabled!(Level::Trace) {
+                        for (i, id) in tx.program_ids.iter().enumerate() {
+                            trace!("program[{}]: {}", i, Self::program_id_to_string(id));
+                        }
+                    }
                 }
                 err_count += 1;
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,6 +78,9 @@ pub mod window_service;
 extern crate hex_literal;
 
 #[macro_use]
+extern crate lazy_static;
+
+#[macro_use]
 extern crate log;
 
 #[macro_use]


### PR DESCRIPTION
#### Problem

Nice to see when there is an error what program it is from.

#### Summary of Changes

Add function to map ids to a string name, print that when there is an error.

Fixes #
