### PR TITLE
Change leader rotation time to a multiple of ticks per block

### DIFF
--- a/src/leader_scheduler.rs
+++ b/src/leader_scheduler.rs
@@ -19,11 +19,11 @@ use solana_vote_signer::rpc::LocalVoteSigner;
 use std::io::Cursor;
 use std::sync::Arc;
 
-pub const BLOCK_TICK_COUNT: u64 = 4;
-pub const DEFAULT_BOOTSTRAP_HEIGHT: u64 = BLOCK_TICK_COUNT * 256;
-pub const DEFAULT_LEADER_ROTATION_INTERVAL: u64 = BLOCK_TICK_COUNT * 32;
-pub const DEFAULT_SEED_ROTATION_INTERVAL: u64 = BLOCK_TICK_COUNT * 256;
-pub const DEFAULT_ACTIVE_WINDOW_LENGTH: u64 = BLOCK_TICK_COUNT * 256;
+pub const TICKS_PER_BLOCK: u64 = 4;
+pub const DEFAULT_BOOTSTRAP_HEIGHT: u64 = TICKS_PER_BLOCK * 256;
+pub const DEFAULT_LEADER_ROTATION_INTERVAL: u64 = TICKS_PER_BLOCK * 32;
+pub const DEFAULT_SEED_ROTATION_INTERVAL: u64 = TICKS_PER_BLOCK * 256;
+pub const DEFAULT_ACTIVE_WINDOW_LENGTH: u64 = TICKS_PER_BLOCK * 256;
 
 pub struct LeaderSchedulerConfig {
     // The interval at which to rotate the leader, should be much less than

--- a/src/leader_scheduler.rs
+++ b/src/leader_scheduler.rs
@@ -4,7 +4,6 @@
 use crate::bank::Bank;
 
 use crate::entry::{create_ticks, Entry};
-use crate::replay_stage;
 use crate::vote_signer_proxy::VoteSignerProxy;
 use bincode::serialize;
 use byteorder::{LittleEndian, ReadBytesExt};
@@ -20,10 +19,11 @@ use solana_vote_signer::rpc::LocalVoteSigner;
 use std::io::Cursor;
 use std::sync::Arc;
 
-pub const DEFAULT_BOOTSTRAP_HEIGHT: u64 = replay_stage::BLOCK_TICK_COUNT * 256;
-pub const DEFAULT_LEADER_ROTATION_INTERVAL: u64 = replay_stage::BLOCK_TICK_COUNT * 32;
-pub const DEFAULT_SEED_ROTATION_INTERVAL: u64 = replay_stage::BLOCK_TICK_COUNT * 256;
-pub const DEFAULT_ACTIVE_WINDOW_LENGTH: u64 = replay_stage::BLOCK_TICK_COUNT * 256;
+pub const BLOCK_TICK_COUNT: u64 = 4;
+pub const DEFAULT_BOOTSTRAP_HEIGHT: u64 = BLOCK_TICK_COUNT * 256;
+pub const DEFAULT_LEADER_ROTATION_INTERVAL: u64 = BLOCK_TICK_COUNT * 32;
+pub const DEFAULT_SEED_ROTATION_INTERVAL: u64 = BLOCK_TICK_COUNT * 256;
+pub const DEFAULT_ACTIVE_WINDOW_LENGTH: u64 = BLOCK_TICK_COUNT * 256;
 
 pub struct LeaderSchedulerConfig {
     // The interval at which to rotate the leader, should be much less than

--- a/src/leader_scheduler.rs
+++ b/src/leader_scheduler.rs
@@ -4,6 +4,7 @@
 use crate::bank::Bank;
 
 use crate::entry::{create_ticks, Entry};
+use crate::replay_stage;
 use crate::vote_signer_proxy::VoteSignerProxy;
 use bincode::serialize;
 use byteorder::{LittleEndian, ReadBytesExt};
@@ -19,10 +20,10 @@ use solana_vote_signer::rpc::LocalVoteSigner;
 use std::io::Cursor;
 use std::sync::Arc;
 
-pub const DEFAULT_BOOTSTRAP_HEIGHT: u64 = 1000;
-pub const DEFAULT_LEADER_ROTATION_INTERVAL: u64 = 100;
-pub const DEFAULT_SEED_ROTATION_INTERVAL: u64 = 1000;
-pub const DEFAULT_ACTIVE_WINDOW_LENGTH: u64 = 1000;
+pub const DEFAULT_BOOTSTRAP_HEIGHT: u64 = replay_stage::BLOCK_TICK_COUNT * 256;
+pub const DEFAULT_LEADER_ROTATION_INTERVAL: u64 = replay_stage::BLOCK_TICK_COUNT * 32;
+pub const DEFAULT_SEED_ROTATION_INTERVAL: u64 = replay_stage::BLOCK_TICK_COUNT * 256;
+pub const DEFAULT_ACTIVE_WINDOW_LENGTH: u64 = replay_stage::BLOCK_TICK_COUNT * 256;
 
 pub struct LeaderSchedulerConfig {
     // The interval at which to rotate the leader, should be much less than

--- a/src/replay_stage.rs
+++ b/src/replay_stage.rs
@@ -7,6 +7,7 @@ use crate::entry::{EntryReceiver, EntrySender};
 use solana_sdk::hash::Hash;
 
 use crate::entry::EntrySlice;
+use crate::leader_scheduler::BLOCK_TICK_COUNT;
 use crate::packet::BlobError;
 use crate::result::{Error, Result};
 use crate::service::Service;
@@ -25,7 +26,6 @@ use std::thread::{self, Builder, JoinHandle};
 use std::time::Duration;
 use std::time::Instant;
 
-pub const BLOCK_TICK_COUNT: u64 = 4;
 pub const MAX_ENTRY_RECV_PER_ITER: usize = 512;
 
 #[derive(Debug, PartialEq, Eq, Clone)]

--- a/src/replay_stage.rs
+++ b/src/replay_stage.rs
@@ -7,7 +7,7 @@ use crate::entry::{EntryReceiver, EntrySender};
 use solana_sdk::hash::Hash;
 
 use crate::entry::EntrySlice;
-use crate::leader_scheduler::BLOCK_TICK_COUNT;
+use crate::leader_scheduler::TICKS_PER_BLOCK;
 use crate::packet::BlobError;
 use crate::result::{Error, Result};
 use crate::service::Service;
@@ -104,7 +104,7 @@ impl ReplayStage {
         let my_id = keypair.pubkey();
 
         // Next vote tick is ceiling of (current tick/ticks per block)
-        let mut num_ticks_to_next_vote = BLOCK_TICK_COUNT - (bank.tick_height() % BLOCK_TICK_COUNT);
+        let mut num_ticks_to_next_vote = TICKS_PER_BLOCK - (bank.tick_height() % TICKS_PER_BLOCK);
         let mut start_entry_index = 0;
         for (i, entry) in entries.iter().enumerate() {
             inc_new_counter_info!("replicate-stage_bank-tick", bank.tick_height() as usize);
@@ -157,7 +157,7 @@ impl ReplayStage {
                     break;
                 }
                 start_entry_index = i + 1;
-                num_ticks_to_next_vote = BLOCK_TICK_COUNT;
+                num_ticks_to_next_vote = TICKS_PER_BLOCK;
             }
         }
 


### PR DESCRIPTION
### Problem
The leader rotation time is not aligned with voting

### Solution
The leader rotation time will be calculated as a multiple of ticks per block. The votes are casted every block period. This will align the rotation time with voting.