### PR TITLE
Fix link to book in Local Testnet section

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ $ ./ci/run-local.sh
 Local Testnet
 ---
 
-Start your own testnet locally, instructions are in the book [Solana: Blockchain Rebuild for Scale: Getting Started](https://solana-labs.github.io/solana/getting-started.html).
+Start your own testnet locally, instructions are in the book [Solana: Blockchain Rebuild for Scale: Getting Started](https://solana-labs.github.io/book/getting-started.html).
 
 Remote Testnets
 ---


### PR DESCRIPTION
#### Problem
The Getting Started link in Local Testnet section is broken.

#### Summary of Changes
Fixed the link