### PR TITLE
Bump rbpf to 0.1.9

### DIFF
--- a/programs/native/bpf_loader/Cargo.toml
+++ b/programs/native/bpf_loader/Cargo.toml
@@ -18,7 +18,7 @@ byteorder = "1.2.1"
 elf = "0.0.10"
 libc = "0.2.46"
 log = "0.4.2"
-solana_rbpf = "=0.1.8"
+solana_rbpf = "=0.1.9"
 serde = "1.0.84"
 solana-logger = { path = "../../../logger", version = "0.12.0" }
 solana-sdk = { path = "../../../sdk", version = "0.12.0" }

--- a/programs/native/bpf_loader/src/lib.rs
+++ b/programs/native/bpf_loader/src/lib.rs
@@ -3,7 +3,7 @@ pub mod bpf_verifier;
 use byteorder::{ByteOrder, LittleEndian, WriteBytesExt};
 use libc::c_char;
 use log::*;
-use solana_rbpf::{EbpfVmRaw, RegionPtrs};
+use solana_rbpf::{EbpfVmRaw, MemoryRegion};
 use solana_sdk::account::KeyedAccount;
 use solana_sdk::loader_instruction::LoaderInstruction;
 use solana_sdk::native_program::ProgramError;
@@ -36,13 +36,13 @@ pub fn helper_sol_log_verify(
     unused3: u64,
     unused4: u64,
     unused5: u64,
-    ro_regions: &[RegionPtrs],
-    unused7: &[RegionPtrs],
+    ro_regions: &[MemoryRegion],
+    unused7: &[MemoryRegion],
 ) -> Result<(()), Error> {
     for region in ro_regions.iter() {
-        if region.bot <= addr && addr as u64 <= region.top {
+        if region.addr <= addr && (addr as u64) < region.addr + region.len {
             let c_buf: *const c_char = addr as *const c_char;
-            let max_size = region.top - addr;
+            let max_size = region.addr + region.len - addr;
             unsafe {
                 for i in 0..max_size {
                     if std::ptr::read(c_buf.offset(i as isize)) == 0 {


### PR DESCRIPTION
Picks up changes in solana-rbpf to:
- Retain BPF scratch registers between call frames
- Allow RW access to the entire stack
