### PR TITLE
Use RPC endpoint of the provided network entrypoint rather than searching for the leader

### DIFF
--- a/wallet/src/main.rs
+++ b/wallet/src/main.rs
@@ -52,6 +52,7 @@ pub fn parse_args(matches: &ArgMatches<'_>) -> Result<WalletConfig, Box<dyn erro
         proxy,
         drone_port: None,
         rpc_client: None,
+        rpc_port: None,
     })
 }
 

--- a/wallet/tests/pay.rs
+++ b/wallet/tests/pay.rs
@@ -74,10 +74,12 @@ fn test_wallet_timestamp_tx() {
     let mut config_payer = WalletConfig::default();
     config_payer.network = leader_data.gossip;
     config_payer.drone_port = Some(drone_addr.port());
+    config_payer.rpc_port = Some(leader_data.rpc.port());
 
     let mut config_witness = WalletConfig::default();
     config_witness.network = leader_data.gossip;
     config_witness.drone_port = Some(drone_addr.port());
+    config_witness.rpc_port = Some(leader_data.rpc.port());
 
     assert_ne!(config_payer.id.pubkey(), config_witness.id.pubkey());
 
@@ -173,10 +175,12 @@ fn test_wallet_witness_tx() {
     let mut config_payer = WalletConfig::default();
     config_payer.network = leader_data.gossip;
     config_payer.drone_port = Some(drone_addr.port());
+    config_payer.rpc_port = Some(leader_data.rpc.port());
 
     let mut config_witness = WalletConfig::default();
     config_witness.network = leader_data.gossip;
     config_witness.drone_port = Some(drone_addr.port());
+    config_witness.rpc_port = Some(leader_data.rpc.port());
 
     assert_ne!(config_payer.id.pubkey(), config_witness.id.pubkey());
 
@@ -268,6 +272,7 @@ fn test_wallet_cancel_tx() {
     let mut config_payer = WalletConfig::default();
     config_payer.network = leader_data.gossip;
     config_payer.drone_port = Some(drone_addr.port());
+    config_payer.rpc_port = Some(leader_data.rpc.port());
 
     let mut config_witness = WalletConfig::default();
     config_witness.network = leader_data.gossip;

--- a/wallet/tests/request_airdrop.rs
+++ b/wallet/tests/request_airdrop.rs
@@ -58,6 +58,7 @@ fn test_wallet_request_airdrop() {
     let mut bob_config = WalletConfig::default();
     bob_config.network = leader_data.gossip;
     bob_config.drone_port = Some(drone_addr.port());
+    bob_config.rpc_port = Some(leader_data.rpc.port());
     bob_config.command = WalletCommand::Airdrop(50);
 
     let sig_response = process_command(&bob_config);


### PR DESCRIPTION
1. The current leader may not even have a running RPC endpoint
2. The RPC API forwards transactions to the leader anyway, so there's no need for the wallet to chase after the leader
3. Removes the wallet thin_client dependency finally