### PR TITLE
Allow chained BudgetExpr via indirection

### DIFF
--- a/sdk/src/budget_transaction.rs
+++ b/sdk/src/budget_transaction.rs
@@ -158,11 +158,11 @@ impl BudgetTransaction for Transaction {
     ) -> Self {
         let expr = if let Some(from) = cancelable {
             BudgetExpr::Or(
-                (Condition::Timestamp(dt, dt_pubkey), Payment { tokens, to }),
-                (Condition::Signature(from), Payment { tokens, to: from }),
+                (Condition::Timestamp(dt, dt_pubkey), Box::new(BudgetExpr::new_payment(tokens, to))),
+                (Condition::Signature(from), Box::new(BudgetExpr::new_payment(tokens, from))),
             )
         } else {
-            BudgetExpr::After(Condition::Timestamp(dt, dt_pubkey), Payment { tokens, to })
+            BudgetExpr::After(Condition::Timestamp(dt, dt_pubkey), Box::new(BudgetExpr::new_payment(tokens, to)))
         };
         let instruction = Instruction::NewBudget(expr);
         Self::new(
@@ -186,11 +186,11 @@ impl BudgetTransaction for Transaction {
     ) -> Self {
         let expr = if let Some(from) = cancelable {
             BudgetExpr::Or(
-                (Condition::Signature(witness), Payment { tokens, to }),
-                (Condition::Signature(from), Payment { tokens, to: from }),
+                (Condition::Signature(witness), Box::new(BudgetExpr::new_payment(tokens, to))),
+                (Condition::Signature(from), Box::new(BudgetExpr::new_payment(tokens, from))),
             )
         } else {
-            BudgetExpr::After(Condition::Signature(witness), Payment { tokens, to })
+            BudgetExpr::After(Condition::Signature(witness), Box::new(BudgetExpr::new_payment(tokens, to)))
         };
         let instruction = Instruction::NewBudget(expr);
         Self::new(

--- a/sdk/src/budget_transaction.rs
+++ b/sdk/src/budget_transaction.rs
@@ -158,11 +158,20 @@ impl BudgetTransaction for Transaction {
     ) -> Self {
         let expr = if let Some(from) = cancelable {
             BudgetExpr::Or(
-                (Condition::Timestamp(dt, dt_pubkey), Box::new(BudgetExpr::new_payment(tokens, to))),
-                (Condition::Signature(from), Box::new(BudgetExpr::new_payment(tokens, from))),
+                (
+                    Condition::Timestamp(dt, dt_pubkey),
+                    Box::new(BudgetExpr::new_payment(tokens, to)),
+                ),
+                (
+                    Condition::Signature(from),
+                    Box::new(BudgetExpr::new_payment(tokens, from)),
+                ),
             )
         } else {
-            BudgetExpr::After(Condition::Timestamp(dt, dt_pubkey), Box::new(BudgetExpr::new_payment(tokens, to)))
+            BudgetExpr::After(
+                Condition::Timestamp(dt, dt_pubkey),
+                Box::new(BudgetExpr::new_payment(tokens, to)),
+            )
         };
         let instruction = Instruction::NewBudget(expr);
         Self::new(
@@ -186,11 +195,20 @@ impl BudgetTransaction for Transaction {
     ) -> Self {
         let expr = if let Some(from) = cancelable {
             BudgetExpr::Or(
-                (Condition::Signature(witness), Box::new(BudgetExpr::new_payment(tokens, to))),
-                (Condition::Signature(from), Box::new(BudgetExpr::new_payment(tokens, from))),
+                (
+                    Condition::Signature(witness),
+                    Box::new(BudgetExpr::new_payment(tokens, to)),
+                ),
+                (
+                    Condition::Signature(from),
+                    Box::new(BudgetExpr::new_payment(tokens, from)),
+                ),
             )
         } else {
-            BudgetExpr::After(Condition::Signature(witness), Box::new(BudgetExpr::new_payment(tokens, to)))
+            BudgetExpr::After(
+                Condition::Signature(witness),
+                Box::new(BudgetExpr::new_payment(tokens, to)),
+            )
         };
         let instruction = Instruction::NewBudget(expr);
         Self::new(


### PR DESCRIPTION
Change `And`, `Or`, and `After` expressions to contain
`Box<BudgetExpr>`s instead of directly holding payments

#### Problem

Unable to combine Budget Expressions because they go directly to payments

#### Summary of Changes

Change expressions like `And` and `After` to contain sub expressions

Add 2 tests for multisig after a different signature and multisig after a given timestamp

Fixes #1345 
