### PR TITLE
ci/localnet-sanity.sh: verify the RPC port on a non-bootstrap-leader node is working

### DIFF
--- a/fullnode/src/main.rs
+++ b/fullnode/src/main.rs
@@ -179,11 +179,11 @@ fn main() {
                 .help("Use DIR as persistent ledger location"),
         )
         .arg(
-            Arg::with_name("rpc")
-                .long("rpc")
+            Arg::with_name("rpc_port")
+                .long("rpc-port")
                 .value_name("PORT")
                 .takes_value(true)
-                .help("Custom RPC port for this node"),
+                .help("RPC port to use for this node"),
         )
         .get_matches();
 
@@ -207,7 +207,7 @@ fn main() {
     let mut leader_scheduler = LeaderScheduler::default();
     leader_scheduler.use_only_bootstrap_leader = use_only_bootstrap_leader;
 
-    let rpc_port = if let Some(port) = matches.value_of("rpc") {
+    let rpc_port = if let Some(port) = matches.value_of("rpc_port") {
         let port_number = port.to_string().parse().expect("integer");
         if port_number == 0 {
             eprintln!("Invalid RPC port requested: {:?}", port);

--- a/multinode-demo/bootstrap-leader.sh
+++ b/multinode-demo/bootstrap-leader.sh
@@ -53,7 +53,7 @@ $program \
   $maybe_no_leader_rotation \
   --identity "$SOLANA_CONFIG_DIR"/bootstrap-leader.json \
   --ledger "$SOLANA_CONFIG_DIR"/bootstrap-leader-ledger \
-  --rpc 8899 \
+  --rpc-port 8899 \
   > >($bootstrap_leader_logger) 2>&1 &
 pid=$!
 oom_score_adj "$pid" 1000

--- a/multinode-demo/fullnode.sh
+++ b/multinode-demo/fullnode.sh
@@ -20,12 +20,13 @@ usage() {
     echo "$*"
     echo
   fi
-  echo "usage: $0 [-x] [--no-leader-rotation] [rsync network path to bootstrap leader configuration] [network entry point]"
+  echo "usage: $0 [-x] [--no-leader-rotation] [--rpc-port port] [rsync network path to bootstrap leader configuration] [network entry point]"
   echo
   echo " Start a full node on the specified network"
   echo
   echo "   -x: runs a new, dynamically-configured full node"
   echo "   --no-leader-rotation: disable leader rotation"
+  echo "   --rpc-port port: custom RPC port for this node"
   echo
   exit 1
 }
@@ -45,6 +46,12 @@ maybe_no_leader_rotation=
 if [[ $1 = --no-leader-rotation ]]; then
   maybe_no_leader_rotation="--no-leader-rotation"
   shift
+fi
+
+maybe_rpc_port=
+if [[ $1 = --rpc-port ]]; then
+  maybe_rpc_port="--rpc $2"
+  shift 2
 fi
 
 if [[ -d $SNAP ]]; then
@@ -211,6 +218,7 @@ done
 trap 'kill "$pid" && wait "$pid"' INT TERM
 $program \
   $maybe_no_leader_rotation \
+  $maybe_rpc_port \
   --identity "$fullnode_json_path" \
   --network "$leader_address" \
   --ledger "$ledger_config_dir"/ledger \

--- a/multinode-demo/fullnode.sh
+++ b/multinode-demo/fullnode.sh
@@ -216,6 +216,7 @@ while true; do
 done
 
 trap 'kill "$pid" && wait "$pid"' INT TERM
+# shellcheck disable=SC2086 # Don't want to double quote # maybe_rpc_port
 $program \
   $maybe_no_leader_rotation \
   $maybe_rpc_port \

--- a/multinode-demo/fullnode.sh
+++ b/multinode-demo/fullnode.sh
@@ -50,7 +50,7 @@ fi
 
 maybe_rpc_port=
 if [[ $1 = --rpc-port ]]; then
-  maybe_rpc_port="--rpc $2"
+  maybe_rpc_port="$1 $2"
   shift 2
 fi
 

--- a/scripts/wallet-sanity.sh
+++ b/scripts/wallet-sanity.sh
@@ -45,21 +45,21 @@ pay_and_confirm() {
 
 $solana_keygen
 
-leader_readiness=false
+node_readiness=false
 timeout=60
 while [[ $timeout -gt 0 ]]; do
   expected_output="Leader ready"
   exec 42>&1
   output=$($solana_wallet "${entrypoint[@]}" get-transaction-count | tee >(cat - >&42))
   if [[ $output -gt 0 ]]; then
-    leader_readiness=true
+    node_readiness=true
     break
   fi
   sleep 2
   (( timeout=timeout-2 ))
 done
-if ! "$leader_readiness"; then
-  echo "Timed out waiting for leader"
+if ! "$node_readiness"; then
+  echo "Timed out waiting for cluster to start"
   exit 1
 fi
 


### PR DESCRIPTION
Also added a convenient cli switch to tell the wallet to use the RPC port on the non-bootstrap-leader.