### PR TITLE
Fix testnet bootup issue

### DIFF
--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -172,17 +172,17 @@ local|tar)
     fi
 
     set -x
-    set +e
     if [[ $skipSetup != true ]]; then
       ./multinode-demo/setup.sh -t fullnode $setupArgs
     fi
-    ./multinode-demo/fullnode.sh $maybeNoLeaderRotation "$entrypointIp":~/solana "$entrypointIp:8001" > fullnode.log 2>&1 & disown
+    ./multinode-demo/fullnode.sh $maybeNoLeaderRotation "$entrypointIp":~/solana "$entrypointIp:8001" > fullnode.log 2>&1 &
     ;;
   *)
     echo "Error: unknown node type: $nodeType"
     exit 1
     ;;
   esac
+  disown
   ;;
 *)
   echo "Unknown deployment method: $deployMethod"

--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -172,10 +172,11 @@ local|tar)
     fi
 
     set -x
+    set +e
     if [[ $skipSetup != true ]]; then
       ./multinode-demo/setup.sh -t fullnode $setupArgs
     fi
-    ./multinode-demo/fullnode.sh $maybeNoLeaderRotation "$entrypointIp":~/solana "$entrypointIp:8001" > fullnode.log 2>&1 &
+    ./multinode-demo/fullnode.sh $maybeNoLeaderRotation "$entrypointIp":~/solana "$entrypointIp:8001" > fullnode.log 2>&1 & disown
     ;;
   *)
     echo "Error: unknown node type: $nodeType"


### PR DESCRIPTION
#### Problem
Testnet for edge-perf was not successfully booting up. It was failing in detecting all the nodes.

#### Summary of Changes
The remote-node script is run on remote virtual machine instance via ssh shell. The last command in the script launches fullnode.sh in the background. While it's running, the ssh connection is terminated. The systemd was sending SIGRTMIN+24 to the processes of the shell, and sometimes killing fullnode.sh before it got a chance to finish. 

This change disowns the background process that's spawned when running fullnode.sh. This will prevent systemd from killing the process.