### PR TITLE
Fix confirmation time calculation

### DIFF
--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -22,6 +22,7 @@ pub mod token_program;
 pub mod transaction;
 pub mod vote_program;
 pub mod vote_transaction;
+pub mod weighted_election;
 
 #[macro_use]
 extern crate serde_derive;

--- a/sdk/src/vote_program.rs
+++ b/sdk/src/vote_program.rs
@@ -1,10 +1,11 @@
 //! Vote program
 //! Receive and processes votes from validators
 
+use crate::hash::Hash;
 use crate::native_program::ProgramError;
 use crate::pubkey::Pubkey;
 use bincode::{deserialize, serialize_into, serialized_size, ErrorKind};
-use std::collections::VecDeque;
+use std::collections::{HashMap, VecDeque};
 
 pub const VOTE_PROGRAM_ID: [u8; 32] = [
     132, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -29,6 +30,30 @@ pub struct Vote {
     pub tick_height: u64,
 }
 
+#[derive(Serialize, Default, Deserialize, Debug, PartialEq, Eq, Clone)]
+pub struct BlockDescription {
+    pub tick_height: u64,              // The height of this block
+    pub entry_id: Hash,                // ID of the latest entry in the ledger
+    pub state_hash: Hash, // A hash representing all state after interpreting the ledger
+    pub weights: HashMap<Pubkey, u64>, // A map of voter IDs to their respective weights
+}
+
+impl BlockDescription {
+    pub fn new(
+        tick_height: u64,
+        entry_id: Hash,
+        state_hash: Hash,
+        weights: HashMap<Pubkey, u64>,
+    ) -> Self {
+        Self {
+            tick_height,
+            entry_id,
+            state_hash,
+            weights,
+        }
+    }
+}
+
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub enum VoteInstruction {
     /// Register a new "vote account" to represent a particular validator in the Vote Contract,
@@ -38,6 +63,16 @@ pub enum VoteInstruction {
     /// identified by keys[0] for voting
     RegisterAccount,
     NewVote(Vote),
+
+    /// Propose a new block to be voted on.
+    /// * Transaction::keys[0] - the leader's signed pubkey
+    /// * Transaction::keys[1] - a key to a new account holding a WeightedElection instance
+    ProposeBlock(BlockDescription),
+
+    /// Vote on a block.
+    /// * Transaction::keys[0] - the validators's signed pubkey
+    /// * Transaction::keys[1] - a key to an account holding the WeightedElection instance
+    Vote,
 }
 
 #[derive(Debug, Default, Serialize, Deserialize, PartialEq, Eq)]

--- a/sdk/src/weighted_election.rs
+++ b/sdk/src/weighted_election.rs
@@ -1,9 +1,10 @@
 //! An election object where the weight of each vote is determined upfront.
 
 use crate::pubkey::Pubkey;
+use bincode::serialized_size;
 use std::collections::HashMap;
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct Voter {
     voted: bool,
     weight: u64,
@@ -21,7 +22,7 @@ pub enum WeightedElectionError {
     VoterIdNotFound, // The voter was not registered at the time the election began.
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct WeightedElection {
     voters: HashMap<Pubkey, Voter>,
 }
@@ -57,6 +58,11 @@ impl WeightedElection {
                 Ok(())
             }
         }
+    }
+
+    pub fn serialized_size(num_voters: usize) -> usize {
+        let weights: HashMap<_, _> = (0..num_voters).map(|_| (Pubkey::default(), 1)).collect();
+        serialized_size(&Self::new(weights)).unwrap() as usize
     }
 }
 

--- a/sdk/src/weighted_election.rs
+++ b/sdk/src/weighted_election.rs
@@ -1,0 +1,105 @@
+//! An election object where the weight of each vote is determined upfront.
+
+use crate::pubkey::Pubkey;
+use std::collections::HashMap;
+
+#[derive(Serialize, Deserialize)]
+pub struct Voter {
+    voted: bool,
+    weight: u64,
+}
+
+impl Voter {
+    fn new(weight: u64) -> Self {
+        let voted = false;
+        Self { voted, weight }
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub enum WeightedElectionError {
+    VoterIdNotFound, // The voter was not registered at the time the election began.
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct WeightedElection {
+    voters: HashMap<Pubkey, Voter>,
+}
+
+impl WeightedElection {
+    pub fn new(weights: HashMap<Pubkey, u64>) -> Self {
+        let voters: HashMap<_, _> = weights
+            .into_iter()
+            .map(|(k, v)| (k, Voter::new(v)))
+            .collect();
+        Self { voters }
+    }
+
+    /// Return the combined weight of all potential voters.
+    pub fn total_weight(&self) -> u64 {
+        self.voters.iter().map(|(_, voter)| voter.weight).sum()
+    }
+
+    /// Return the combined weight of all voters that voted.
+    pub fn voted_weight(&self) -> u64 {
+        self.voters
+            .iter()
+            .map(|(_, voter)| if voter.voted { voter.weight } else { 0 })
+            .sum()
+    }
+
+    /// Process a vote from `voter_id`.
+    pub fn vote(&mut self, voter_id: &Pubkey) -> Result<(), WeightedElectionError> {
+        match self.voters.get_mut(voter_id) {
+            None => Err(WeightedElectionError::VoterIdNotFound),
+            Some(ref mut voter) => {
+                voter.voted = true;
+                Ok(())
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::signature::{Keypair, KeypairUtil};
+
+    #[test]
+    fn test_total_weight() {
+        let weights = HashMap::new();
+        assert_eq!(WeightedElection::new(weights).total_weight(), 0);
+
+        let mut weights = HashMap::new();
+        weights.insert(Keypair::new().pubkey(), 1);
+        assert_eq!(WeightedElection::new(weights).total_weight(), 1);
+
+        let mut weights = HashMap::new();
+        weights.insert(Keypair::new().pubkey(), 1);
+        weights.insert(Keypair::new().pubkey(), 2);
+        assert_eq!(WeightedElection::new(weights).total_weight(), 3);
+    }
+
+    #[test]
+    fn test_voted_weight() {
+        let alice = Keypair::new().pubkey();
+        let mut weights = HashMap::new();
+        weights.insert(alice, 1);
+
+        let mut election = WeightedElection::new(weights);
+        assert_eq!(election.voted_weight(), 0);
+
+        election.vote(&alice).unwrap();
+        assert_eq!(election.voted_weight(), 1);
+
+        // Ensure duplicate votes don't change voted weight.
+        election.vote(&alice).unwrap();
+        assert_eq!(election.voted_weight(), 1);
+
+        // Ensure unrecognized pubkeys return an error.
+        assert_eq!(
+            election.vote(&Keypair::new().pubkey()),
+            Err(WeightedElectionError::VoterIdNotFound)
+        );
+    }
+}

--- a/src/bank.rs
+++ b/src/bank.rs
@@ -17,7 +17,7 @@ use crate::runtime::{self, RuntimeError};
 use crate::status_deque::{Status, StatusDeque, MAX_ENTRY_IDS};
 use crate::storage_stage::StorageState;
 use bincode::deserialize;
-use hashbrown::HashMap;
+use hashbrown::{HashMap, HashSet};
 use itertools::Itertools;
 use log::Level;
 use rayon::prelude::*;
@@ -784,6 +784,13 @@ impl Bank {
     /// Right now this just gets the account balances. See github issue #1655.
     pub fn get_stake(&self, pubkey: &Pubkey) -> u64 {
         self.get_balance(pubkey)
+    }
+
+    pub fn get_stakes(&self, pubkeys: &HashSet<Pubkey>) -> std::collections::HashMap<Pubkey, u64> {
+        pubkeys
+            .iter()
+            .map(|pubkey| (*pubkey, self.get_stake(pubkey)))
+            .collect()
     }
 
     pub fn get_account(&self, pubkey: &Pubkey) -> Option<Account> {

--- a/src/fullnode.rs
+++ b/src/fullnode.rs
@@ -302,7 +302,7 @@ impl Fullnode {
             };
 
             // Start in leader mode.
-            let (tpu, entry_receiver, tpu_exit) = Tpu::new(
+            let (tpu, entry_receiver, tpu_exit, feedback_sender) = Tpu::new(
                 &bank,
                 Default::default(),
                 node.sockets
@@ -329,6 +329,7 @@ impl Fullnode {
                 entry_receiver,
                 max_tick_height,
                 tpu_exit,
+                feedback_sender,
             );
             let leader_state = LeaderServices::new(tpu, broadcast_service);
             Some(NodeRole::Leader(leader_state))
@@ -471,7 +472,7 @@ impl Fullnode {
             ls_lock.max_height_for_leader(tick_height + 1)
         };
 
-        let (tpu, blob_receiver, tpu_exit) = Tpu::new(
+        let (tpu, blob_receiver, tpu_exit, feedback_sender) = Tpu::new(
             &self.bank,
             Default::default(),
             self.tpu_sockets
@@ -499,6 +500,7 @@ impl Fullnode {
             blob_receiver,
             max_tick_height,
             tpu_exit,
+            feedback_sender,
         );
         let leader_state = LeaderServices::new(tpu, broadcast_service);
         self.node_role = Some(NodeRole::Leader(leader_state));

--- a/src/fullnode.rs
+++ b/src/fullnode.rs
@@ -329,6 +329,7 @@ impl Fullnode {
                 entry_receiver,
                 max_tick_height,
                 tpu_exit,
+                keypair.clone(),
                 feedback_sender,
             );
             let leader_state = LeaderServices::new(tpu, broadcast_service);
@@ -500,6 +501,7 @@ impl Fullnode {
             blob_receiver,
             max_tick_height,
             tpu_exit,
+            self.keypair.clone(),
             feedback_sender,
         );
         let leader_state = LeaderServices::new(tpu, broadcast_service);


### PR DESCRIPTION
#### Problem

Confirmation time is not calculated correctly. We currently post something closer to the time since the last confirmation.

#### Summary of Changes

Instead of registering voting accounts or sending tick heights to it the leader creates an account for each block. Validators send their votes to that account. By creating an account per block, a fullnode can recognize a block as confirmed as soon as its stake-weighted vote reaches a supermajority.

TODO:

- [ ] Send the new transactions from the leader and validator
- [ ] Detect new votes in ReplayStage and post confirmation time to influx
- [ ] Rip out all the old voting code and confirmation service

Fixes #2248
