### PR TITLE
Overhaul wallet rpc/drone command-line arguments

### DIFF
--- a/book/src/wallet.md
+++ b/book/src/wallet.md
@@ -168,21 +168,23 @@ $ solana-wallet send-timestamp <PUBKEY> <PROCESS_ID> --date 2018-12-24T23:59:00
 ### Usage
 
 ```manpage
-solana-wallet 0.11.0
+solana-wallet 0.12.0
 
 USAGE:
-    solana-wallet [OPTIONS] [SUBCOMMAND]
+    solana-wallet [FLAGS] [OPTIONS] [SUBCOMMAND]
 
 FLAGS:
     -h, --help       Prints help information
+        --rpc-tls    Enable TLS for the RPC endpoint
     -V, --version    Prints version information
 
 OPTIONS:
-    -k, --keypair <PATH>         /path/to/id.json
-    -n, --network <HOST:PORT>    Rendezvous with the network at this gossip entry point; defaults to 127.0.0.1:8001
-        --proxy <URL>            Address of TLS proxy
-        --port <NUM>             Optional rpc-port configuration to connect to non-default nodes
-        --timeout <SECS>         Max seconds to wait to get necessary gossip from the network
+        --drone-host <IP ADDRESS>    Drone host to use [default: same as --host]
+        --drone-port <PORT>          Drone port to use [default: 9900]
+    -n, --host <IP ADDRESS>          Host to use for both RPC and drone [default: 127.0.0.1]
+    -k, --keypair <PATH>             /path/to/id.json
+        --rpc-host <IP ADDRESS>      RPC host to use [default: same as --host]
+        --rpc-port <PORT>            RPC port to use [default: 8899]
 
 SUBCOMMANDS:
     address                  Get your public key
@@ -199,7 +201,7 @@ SUBCOMMANDS:
 ```
 
 ```manpage
-solana-wallet-address 
+solana-wallet-address
 Get your public key
 
 USAGE:
@@ -211,7 +213,7 @@ FLAGS:
 ```
 
 ```manpage
-solana-wallet-airdrop 
+solana-wallet-airdrop
 Request a batch of tokens
 
 USAGE:
@@ -226,7 +228,7 @@ ARGS:
 ```
 
 ```manpage
-solana-wallet-balance 
+solana-wallet-balance
 Get your balance
 
 USAGE:
@@ -238,7 +240,7 @@ FLAGS:
 ```
 
 ```manpage
-solana-wallet-cancel 
+solana-wallet-cancel
 Cancel a transfer
 
 USAGE:
@@ -253,7 +255,7 @@ ARGS:
 ```
 
 ```manpage
-solana-wallet-confirm 
+solana-wallet-confirm
 Confirm transaction by signature
 
 USAGE:
@@ -268,7 +270,7 @@ ARGS:
 ```
 
 ```manpage
-solana-wallet-deploy 
+solana-wallet-deploy
 Deploy a program
 
 USAGE:
@@ -283,7 +285,7 @@ ARGS:
 ```
 
 ```manpage
-solana-wallet-get-transaction-count 
+solana-wallet-get-transaction-count
 Get current transaction count
 
 USAGE:
@@ -295,14 +297,14 @@ FLAGS:
 ```
 
 ```manpage
-solana-wallet-pay 
+solana-wallet-pay
 Send a payment
 
 USAGE:
     solana-wallet pay [FLAGS] [OPTIONS] <PUBKEY> <NUM>
 
 FLAGS:
-        --cancelable    
+        --cancelable
     -h, --help          Prints help information
     -V, --version       Prints version information
 
@@ -317,7 +319,7 @@ ARGS:
 ```
 
 ```manpage
-solana-wallet-send-signature 
+solana-wallet-send-signature
 Send a signature to authorize a transfer
 
 USAGE:
@@ -333,7 +335,7 @@ ARGS:
 ```
 
 ```manpage
-solana-wallet-send-timestamp 
+solana-wallet-send-timestamp
 Send a timestamp to unlock a transfer
 
 USAGE:

--- a/multinode-demo/fullnode.sh
+++ b/multinode-demo/fullnode.sh
@@ -194,7 +194,7 @@ $solana_wallet --keypair "$fullnode_id_path" address
 # - one token to keep the node identity public key valid.
 retries=5
 while true; do
-  if $solana_wallet --keypair "$fullnode_id_path" --network "$leader_address" airdrop 3; then
+  if $solana_wallet --keypair "$fullnode_id_path" --host "${leader_address%:*}" airdrop 3; then
     break
   fi
 

--- a/net/remote/remote-sanity.sh
+++ b/net/remote/remote-sanity.sh
@@ -123,7 +123,7 @@ echo "--- RPC API: getTransactionCount"
 echo "--- $entrypointIp: wallet sanity"
 (
   set -x
-  scripts/wallet-sanity.sh "$entrypointIp":8001
+  scripts/wallet-sanity.sh --host "$entrypointIp"
 )
 
 echo "--- $entrypointIp: verify ledger"

--- a/scripts/wallet-sanity.sh
+++ b/scripts/wallet-sanity.sh
@@ -12,7 +12,7 @@ source multinode-demo/common.sh
 if [[ -z $1 ]]; then # no network argument, use default
   entrypoint=()
 else
-  entrypoint=(-n "$1")
+  entrypoint=("$@")
 fi
 
 # Tokens transferred to this address are lost forever...

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -507,7 +507,7 @@ mod tests {
         let thread = rpc_service.thread_hdl.thread();
         assert_eq!(thread.name().unwrap(), "solana-jsonrpc");
 
-        let rpc_string = get_rpc_request_str(rpc_addr);
+        let rpc_string = get_rpc_request_str(rpc_addr, false);
         let client = reqwest::Client::new();
         let request = json!({
            "jsonrpc": "2.0",
@@ -755,7 +755,7 @@ mod tests {
            "params": json!([serial_tx])
         });
         let rpc_addr = leader_data.rpc;
-        let rpc_string = get_rpc_request_str(rpc_addr);
+        let rpc_string = get_rpc_request_str(rpc_addr, false);
         let mut response = client
             .post(&rpc_string)
             .header(CONTENT_TYPE, "application/json")

--- a/src/rpc_request.rs
+++ b/src/rpc_request.rs
@@ -21,7 +21,7 @@ impl RpcClient {
     }
 
     pub fn new_with_timeout(addr: SocketAddr, timeout: Duration) -> Self {
-        let addr = get_rpc_request_str(addr);
+        let addr = get_rpc_request_str(addr, false);
         let client = reqwest::Client::builder()
             .timeout(timeout)
             .build()
@@ -30,7 +30,7 @@ impl RpcClient {
     }
 
     pub fn new_from_socket(addr: SocketAddr) -> Self {
-        Self::new(get_rpc_request_str(addr))
+        Self::new(get_rpc_request_str(addr, false))
     }
 
     pub fn retry_make_rpc_request(
@@ -77,8 +77,12 @@ impl RpcClient {
     }
 }
 
-pub fn get_rpc_request_str(rpc_addr: SocketAddr) -> String {
-    format!("http://{}", rpc_addr)
+pub fn get_rpc_request_str(rpc_addr: SocketAddr, tls: bool) -> String {
+    if tls {
+        format!("https://{}", rpc_addr)
+    } else {
+        format!("http://{}", rpc_addr)
+    }
 }
 
 pub trait RpcRequestHandler {

--- a/wallet/src/main.rs
+++ b/wallet/src/main.rs
@@ -1,22 +1,46 @@
 use clap::{crate_version, App, Arg, ArgMatches, SubCommand};
-use solana::socketaddr;
 use solana_sdk::signature::{gen_keypair_file, read_keypair, KeypairUtil};
 use solana_wallet::wallet::{parse_command, process_command, WalletConfig, WalletError};
 use std::error;
-use std::net::SocketAddr;
 
 pub fn parse_args(matches: &ArgMatches<'_>) -> Result<WalletConfig, Box<dyn error::Error>> {
-    let network = if let Some(addr) = matches.value_of("network") {
-        addr.parse().or_else(|_| {
-            Err(WalletError::BadParameter(
-                "Invalid network location".to_string(),
-            ))
-        })?
+    let host = matches
+        .value_of("host")
+        .unwrap()
+        .parse()
+        .or_else(|_| Err(WalletError::BadParameter("Invalid host".to_string())))?;
+
+    let drone_host = if let Some(drone_host) = matches.value_of("drone_host") {
+        Some(
+            drone_host
+                .parse()
+                .or_else(|_| Err(WalletError::BadParameter("Invalid drone host".to_string())))?,
+        )
     } else {
-        socketaddr!("127.0.0.1:8001")
+        None
     };
 
-    let proxy = matches.value_of("proxy").map(|proxy| proxy.to_string());
+    let rpc_host = if let Some(rpc_host) = matches.value_of("rpc_host") {
+        Some(
+            rpc_host
+                .parse()
+                .or_else(|_| Err(WalletError::BadParameter("Invalid rpc host".to_string())))?,
+        )
+    } else {
+        None
+    };
+
+    let drone_port = matches
+        .value_of("drone_port")
+        .unwrap()
+        .parse()
+        .or_else(|_| Err(WalletError::BadParameter("Invalid drone port".to_string())))?;
+
+    let rpc_port = matches
+        .value_of("rpc_port")
+        .unwrap()
+        .parse()
+        .or_else(|_| Err(WalletError::BadParameter("Invalid rpc port".to_string())))?;
 
     let mut path = dirs::home_dir().expect("home directory");
     let id_path = if matches.is_present("keypair") {
@@ -42,40 +66,83 @@ pub fn parse_args(matches: &ArgMatches<'_>) -> Result<WalletConfig, Box<dyn erro
     Ok(WalletConfig {
         id,
         command,
-        network,
-        proxy,
-        drone_port: None,
+        drone_host,
+        drone_port,
+        host,
         rpc_client: None,
-        rpc_port: None,
+        rpc_host,
+        rpc_port,
+        rpc_tls: matches.is_present("rpc_tls"),
     })
 }
 
 fn main() -> Result<(), Box<dyn error::Error>> {
     solana_logger::setup();
+
+    let (default_host, default_rpc_port, default_drone_port) = {
+        let defaults = WalletConfig::default();
+        (
+            defaults.host.to_string(),
+            defaults.rpc_port.to_string(),
+            defaults.drone_port.to_string(),
+        )
+    };
+
     let matches = App::new("solana-wallet")
         .version(crate_version!())
         .arg(
-            Arg::with_name("network")
+            Arg::with_name("host")
                 .short("n")
-                .long("network")
-                .value_name("HOST:PORT")
+                .long("host")
+                .value_name("IP ADDRESS")
                 .takes_value(true)
-                .help("Rendezvous with the network at this gossip entry point; defaults to 127.0.0.1:8001"),
-        ).arg(
+                .default_value(&default_host)
+                .help("Host to use for both RPC and drone"),
+        )
+        .arg(
+            Arg::with_name("rpc_host")
+                .long("rpc-host")
+                .value_name("IP ADDRESS")
+                .takes_value(true)
+                .help("RPC host to use [default: same as --host]"),
+        )
+        .arg(
+            Arg::with_name("rpc_port")
+                .long("rpc-port")
+                .value_name("PORT")
+                .takes_value(true)
+                .default_value(&default_rpc_port)
+                .help("RPC port to use"),
+        )
+        .arg(
+            Arg::with_name("rpc_tps")
+                .long("rpc-tls")
+                .help("Enable TLS for the RPC endpoint"),
+        )
+        .arg(
+            Arg::with_name("drone_host")
+                .long("drone-host")
+                .value_name("IP ADDRESS")
+                .takes_value(true)
+                .help("Drone host to use [default: same as --host]"),
+        )
+        .arg(
+            Arg::with_name("drone_port")
+                .long("drone-port")
+                .value_name("PORT")
+                .takes_value(true)
+                .default_value(&default_drone_port)
+                .help("Drone port to use"),
+        )
+        .arg(
             Arg::with_name("keypair")
                 .short("k")
                 .long("keypair")
                 .value_name("PATH")
                 .takes_value(true)
                 .help("/path/to/id.json"),
-        ).arg(
-            Arg::with_name("proxy")
-                .long("proxy")
-                .takes_value(true)
-                .value_name("URL")
-                .help("Address of TLS proxy")
-                .conflicts_with("rpc-port")
-        ).subcommand(SubCommand::with_name("address").about("Get your public key"))
+        )
+        .subcommand(SubCommand::with_name("address").about("Get your public key"))
         .subcommand(
             SubCommand::with_name("airdrop")
                 .about("Request a batch of tokens")
@@ -87,7 +154,8 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                         .required(true)
                         .help("The number of tokens to request"),
                 ),
-        ).subcommand(SubCommand::with_name("balance").about("Get your balance"))
+        )
+        .subcommand(SubCommand::with_name("balance").about("Get your balance"))
         .subcommand(
             SubCommand::with_name("cancel")
                 .about("Cancel a transfer")
@@ -99,7 +167,8 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                         .required(true)
                         .help("The process id of the transfer to cancel"),
                 ),
-        ).subcommand(
+        )
+        .subcommand(
             SubCommand::with_name("confirm")
                 .about("Confirm transaction by signature")
                 .arg(
@@ -110,7 +179,8 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                         .required(true)
                         .help("The transaction signature to confirm"),
                 ),
-        ).subcommand(
+        )
+        .subcommand(
             SubCommand::with_name("deploy")
                 .about("Deploy a program")
                 .arg(
@@ -120,12 +190,12 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                         .takes_value(true)
                         .required(true)
                         .help("/path/to/program.o"),
-                )
-                // TODO: Add "loader" argument; current default is bpf_loader
-        ).subcommand(
-            SubCommand::with_name("get-transaction-count")
-                .about("Get current transaction count")
-        ).subcommand(
+                ), // TODO: Add "loader" argument; current default is bpf_loader
+        )
+        .subcommand(
+            SubCommand::with_name("get-transaction-count").about("Get current transaction count"),
+        )
+        .subcommand(
             SubCommand::with_name("pay")
                 .about("Send a payment")
                 .arg(
@@ -135,27 +205,31 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                         .takes_value(true)
                         .required(true)
                         .help("The pubkey of recipient"),
-                ).arg(
+                )
+                .arg(
                     Arg::with_name("tokens")
                         .index(2)
                         .value_name("NUM")
                         .takes_value(true)
                         .required(true)
                         .help("The number of tokens to send"),
-                ).arg(
+                )
+                .arg(
                     Arg::with_name("timestamp")
                         .long("after")
                         .value_name("DATETIME")
                         .takes_value(true)
                         .help("A timestamp after which transaction will execute"),
-                ).arg(
+                )
+                .arg(
                     Arg::with_name("timestamp-pubkey")
                         .long("require-timestamp-from")
                         .value_name("PUBKEY")
                         .takes_value(true)
                         .requires("timestamp")
                         .help("Require timestamp from this third party"),
-                ).arg(
+                )
+                .arg(
                     Arg::with_name("witness")
                         .long("require-signature-from")
                         .value_name("PUBKEY")
@@ -163,12 +237,14 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                         .multiple(true)
                         .use_delimiter(true)
                         .help("Any third party signatures required to unlock the tokens"),
-                ).arg(
+                )
+                .arg(
                     Arg::with_name("cancelable")
                         .long("cancelable")
                         .takes_value(false),
                 ),
-        ).subcommand(
+        )
+        .subcommand(
             SubCommand::with_name("send-signature")
                 .about("Send a signature to authorize a transfer")
                 .arg(
@@ -178,15 +254,17 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                         .takes_value(true)
                         .required(true)
                         .help("The pubkey of recipient"),
-                ).arg(
+                )
+                .arg(
                     Arg::with_name("process-id")
                         .index(2)
                         .value_name("PROCESS_ID")
                         .takes_value(true)
                         .required(true)
-                        .help("The process id of the transfer to authorize")
-                )
-        ).subcommand(
+                        .help("The process id of the transfer to authorize"),
+                ),
+        )
+        .subcommand(
             SubCommand::with_name("send-timestamp")
                 .about("Send a timestamp to unlock a transfer")
                 .arg(
@@ -196,21 +274,24 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                         .takes_value(true)
                         .required(true)
                         .help("The pubkey of recipient"),
-                ).arg(
+                )
+                .arg(
                     Arg::with_name("process-id")
                         .index(2)
                         .value_name("PROCESS_ID")
                         .takes_value(true)
                         .required(true)
-                        .help("The process id of the transfer to unlock")
-                ).arg(
+                        .help("The process id of the transfer to unlock"),
+                )
+                .arg(
                     Arg::with_name("datetime")
                         .long("date")
                         .value_name("DATETIME")
                         .takes_value(true)
-                        .help("Optional arbitrary timestamp to apply")
-                )
-        ).get_matches();
+                        .help("Optional arbitrary timestamp to apply"),
+                ),
+        )
+        .get_matches();
 
     let config = parse_args(&matches)?;
     let result = process_command(&config)?;

--- a/wallet/tests/pay.rs
+++ b/wallet/tests/pay.rs
@@ -72,14 +72,12 @@ fn test_wallet_timestamp_tx() {
     let rpc_client = RpcClient::new_from_socket(leader_data.rpc);
 
     let mut config_payer = WalletConfig::default();
-    config_payer.network = leader_data.gossip;
-    config_payer.drone_port = Some(drone_addr.port());
-    config_payer.rpc_port = Some(leader_data.rpc.port());
+    config_payer.drone_port = drone_addr.port();
+    config_payer.rpc_port = leader_data.rpc.port();
 
     let mut config_witness = WalletConfig::default();
-    config_witness.network = leader_data.gossip;
-    config_witness.drone_port = Some(drone_addr.port());
-    config_witness.rpc_port = Some(leader_data.rpc.port());
+    config_witness.drone_port = drone_addr.port();
+    config_witness.rpc_port = leader_data.rpc.port();
 
     assert_ne!(config_payer.id.pubkey(), config_witness.id.pubkey());
 
@@ -173,14 +171,12 @@ fn test_wallet_witness_tx() {
     let rpc_client = RpcClient::new_from_socket(leader_data.rpc);
 
     let mut config_payer = WalletConfig::default();
-    config_payer.network = leader_data.gossip;
-    config_payer.drone_port = Some(drone_addr.port());
-    config_payer.rpc_port = Some(leader_data.rpc.port());
+    config_payer.drone_port = drone_addr.port();
+    config_payer.rpc_port = leader_data.rpc.port();
 
     let mut config_witness = WalletConfig::default();
-    config_witness.network = leader_data.gossip;
-    config_witness.drone_port = Some(drone_addr.port());
-    config_witness.rpc_port = Some(leader_data.rpc.port());
+    config_witness.drone_port = drone_addr.port();
+    config_witness.rpc_port = leader_data.rpc.port();
 
     assert_ne!(config_payer.id.pubkey(), config_witness.id.pubkey());
 
@@ -270,14 +266,12 @@ fn test_wallet_cancel_tx() {
     let rpc_client = RpcClient::new_from_socket(leader_data.rpc);
 
     let mut config_payer = WalletConfig::default();
-    config_payer.network = leader_data.gossip;
-    config_payer.drone_port = Some(drone_addr.port());
-    config_payer.rpc_port = Some(leader_data.rpc.port());
+    config_payer.drone_port = drone_addr.port();
+    config_payer.rpc_port = leader_data.rpc.port();
 
     let mut config_witness = WalletConfig::default();
-    config_witness.network = leader_data.gossip;
-    config_witness.drone_port = Some(drone_addr.port());
-    config_witness.rpc_port = Some(leader_data.rpc.port());
+    config_witness.drone_port = drone_addr.port();
+    config_witness.rpc_port = leader_data.rpc.port();
 
     assert_ne!(config_payer.id.pubkey(), config_witness.id.pubkey());
 

--- a/wallet/tests/request_airdrop.rs
+++ b/wallet/tests/request_airdrop.rs
@@ -56,9 +56,8 @@ fn test_wallet_request_airdrop() {
     let drone_addr = receiver.recv().unwrap();
 
     let mut bob_config = WalletConfig::default();
-    bob_config.network = leader_data.gossip;
-    bob_config.drone_port = Some(drone_addr.port());
-    bob_config.rpc_port = Some(leader_data.rpc.port());
+    bob_config.drone_port = drone_addr.port();
+    bob_config.rpc_port = leader_data.rpc.port();
     bob_config.command = WalletCommand::Airdrop(50);
 
     let sig_response = process_command(&bob_config);


### PR DESCRIPTION
The wallet cli interface has grown a little long in the tooth and is due for a little cleanup.  Out with:
* `--network` as wallet doesn't use the thin client anymore at all
* `--proxy` as this really means "enable TLS"
* uncomfortable assumptions that the RPC API and Drone live on the same host

Replace with:
```
        --rpc-tls                    Enable TLS for the RPC endpoint
        --drone-host <IP ADDRESS>    Drone host to use [default: same as --host]
        --drone-port <PORT>          Drone port to use [default: 9900]
    -n, --host <IP ADDRESS>          Host to use for both RPC and drone [default: 127.0.0.1]
        --rpc-host <IP ADDRESS>      RPC host to use [default: same as --host]
        --rpc-port <PORT>            RPC port to use [default: 8899]
```
