### PR TITLE
change EC2 machine type used for leader

### DIFF
--- a/net/gce.sh
+++ b/net/gce.sh
@@ -23,7 +23,7 @@ ec2)
   source "$here"/scripts/ec2-provider.sh
 
   cpuBootstrapLeaderMachineType=m4.4xlarge
-  gpuBootstrapLeaderMachineType=p2.xlarge
+  gpuBootstrapLeaderMachineType=p3.8xlarge
   bootstrapLeaderMachineType=$cpuBootstrapLeaderMachineType
   fullNodeMachineType=m4.2xlarge
   clientMachineType=m4.2xlarge

--- a/net/gce.sh
+++ b/net/gce.sh
@@ -25,7 +25,7 @@ ec2)
   cpuBootstrapLeaderMachineType=m4.4xlarge
   gpuBootstrapLeaderMachineType=p3.8xlarge
   bootstrapLeaderMachineType=$cpuBootstrapLeaderMachineType
-  fullNodeMachineType=m4.2xlarge
+  fullNodeMachineType=m4.4xlarge
   clientMachineType=m4.2xlarge
   ;;
 *)


### PR DESCRIPTION
#### Problem
Testnet perf is not performing at par on EC2 when compared to GCP.

#### Summary of Changes
The leader machine type on EC2 was not at par with GCP configuration. It was causing performance degradation for perf testnet
