### PR TITLE
Drone clean-up

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1954,6 +1954,7 @@ dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.84 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.84 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-logger 0.12.0",
  "solana-metrics 0.12.0",
  "solana-sdk 0.12.0",
  "tokio 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/ci/test-stable.sh
+++ b/ci/test-stable.sh
@@ -28,7 +28,7 @@ for program in programs/native/*; do
 done
 
 # Run integration tests serially
-for test in tests/*.rs wallet/tests/*.rs; do
+for test in tests/*.rs wallet/tests/*.rs drone/tests/*.rs; do
   test=${test##*/} # basename x
   test=${test%.rs} # basename x .rs
   _ cargo test --all --verbose --features="$FEATURES" --test="$test" -- --test-threads=1 --nocapture

--- a/drone/Cargo.toml
+++ b/drone/Cargo.toml
@@ -19,6 +19,7 @@ clap = "2.31"
 log = "0.4.2"
 serde = "1.0.84"
 serde_derive = "1.0.84"
+solana-logger = { path = "../logger", version = "0.12.0" }
 solana-sdk = { path = "../sdk", version = "0.12.0" }
 solana-metrics = { path = "../metrics", version = "0.12.0" }
 tokio = "0.1"
@@ -31,4 +32,3 @@ crate-type = ["lib"]
 [[bin]]
 name = "solana-drone"
 path = "src/bin/drone.rs"
-

--- a/drone/src/bin/drone.rs
+++ b/drone/src/bin/drone.rs
@@ -1,7 +1,6 @@
-use byteorder::{ByteOrder, LittleEndian};
-use bytes::Bytes;
 use clap::{crate_version, App, Arg};
-use solana_drone::drone::{Drone, DroneRequest, DRONE_PORT};
+use log::*;
+use solana_drone::drone::{Drone, DRONE_PORT};
 use solana_drone::socketaddr;
 use solana_sdk::signature::read_keypair;
 use std::error;
@@ -14,6 +13,7 @@ use tokio::prelude::*;
 use tokio_codec::{BytesCodec, Decoder};
 
 fn main() -> Result<(), Box<error::Error>> {
+    solana_logger::setup();
     solana_metrics::set_panic_hook("drone");
     let matches = App::new("drone")
         .version(crate_version!())
@@ -74,7 +74,7 @@ fn main() -> Result<(), Box<error::Error>> {
     });
 
     let socket = TcpListener::bind(&drone_addr).unwrap();
-    println!("Drone started. Listening on: {}", drone_addr);
+    info!("Drone started. Listening on: {}", drone_addr);
     let done = socket
         .incoming()
         .map_err(|e| println!("failed to accept socket; error = {:?}", e))
@@ -84,40 +84,12 @@ fn main() -> Result<(), Box<error::Error>> {
             let (writer, reader) = framed.split();
 
             let processor = reader.and_then(move |bytes| {
-                let req: DroneRequest = bincode::deserialize(&bytes).or_else(|err| {
-                    Err(io::Error::new(
-                        io::ErrorKind::Other,
-                        format!("deserialize packet in drone: {:?}", err),
-                    ))
-                })?;
-
-                println!("Airdrop transaction requested...{:?}", req);
-                let res = drone2.lock().unwrap().build_airdrop_transaction(req);
-                match res {
-                    Ok(tx) => {
-                        let response_vec = bincode::serialize(&tx).or_else(|err| {
-                            Err(io::Error::new(
-                                io::ErrorKind::Other,
-                                format!("deserialize packet in drone: {:?}", err),
-                            ))
-                        })?;
-
-                        let mut response_vec_with_length = vec![0; 2];
-                        LittleEndian::write_u16(
-                            &mut response_vec_with_length,
-                            response_vec.len() as u16,
-                        );
-                        response_vec_with_length.extend_from_slice(&response_vec);
-
-                        let response_bytes = Bytes::from(response_vec_with_length);
-                        println!("Airdrop transaction granted");
-                        Ok(response_bytes)
-                    }
-                    Err(err) => {
-                        println!("Airdrop transaction failed: {:?}", err);
-                        Err(err)
-                    }
-                }
+                let response_bytes = drone2
+                    .lock()
+                    .unwrap()
+                    .process_drone_request(&bytes)
+                    .unwrap();
+                Ok(response_bytes)
             });
             let server = writer
                 .send_all(processor.or_else(|err| {

--- a/drone/tests/local-drone.rs
+++ b/drone/tests/local-drone.rs
@@ -1,0 +1,36 @@
+use solana_drone::drone::{request_airdrop_transaction, run_local_drone};
+use solana_sdk::hash::Hash;
+use solana_sdk::signature::{Keypair, KeypairUtil};
+use solana_sdk::system_instruction::SystemInstruction;
+use solana_sdk::system_program;
+use solana_sdk::transaction::Transaction;
+use std::sync::mpsc::channel;
+
+#[test]
+fn test_local_drone() {
+    let keypair = Keypair::new();
+    let to = Keypair::new().pubkey();
+    let tokens = 50;
+    let last_id = Hash::new(&to.as_ref());
+    let expected_instruction = SystemInstruction::CreateAccount {
+        tokens,
+        space: 0,
+        program_id: system_program::id(),
+    };
+    let mut expected_tx = Transaction::new(
+        &keypair,
+        &[to],
+        system_program::id(),
+        &expected_instruction,
+        last_id,
+        0,
+    );
+    expected_tx.sign(&[&keypair], last_id);
+
+    let (sender, receiver) = channel();
+    run_local_drone(keypair, sender);
+    let drone_addr = receiver.recv().unwrap();
+
+    let result = request_airdrop_transaction(&drone_addr, &to, tokens, last_id);
+    assert_eq!(expected_tx, result.unwrap());
+}


### PR DESCRIPTION
#### Problem
Drone service and local-drone test fixture were both large and hard to test.
Also, it was annoying that the drone printed so many messages, instead of using the slick logger like everything else.

#### Summary of Changes
Break out drone request deserialization, processing, and response building into separate method, `process_drone_request`, and add unit tests.
Add integration test for `run_local_drone`
Implement solana::logger for drone, and convert `println!` statements to `info!` (and one `warn!`)

Fixes #1220 
