### PR TITLE
Replicator timeout

### DIFF
--- a/replicator/src/main.rs
+++ b/replicator/src/main.rs
@@ -82,7 +82,7 @@ fn main() {
 
     let leader_info = NodeInfo::new_entry_point(&network_addr);
 
-    let replicator = Replicator::new(ledger_path, node, &leader_info, &keypair).unwrap();
+    let replicator = Replicator::new(ledger_path, node, &leader_info, &keypair, None).unwrap();
 
     replicator.join();
 }

--- a/src/replicator.rs
+++ b/src/replicator.rs
@@ -102,8 +102,9 @@ impl Replicator {
     /// Returns a Result that contains a replicator on success
     ///
     /// # Arguments
-    /// * `ledger_path` - Not actually optional path to where the the ledger will be stored
-    /// * `node` -
+    /// * `ledger_path` - (Not actually optional) path to where the the ledger will be stored.
+    /// Causes panic if none
+    /// * `node` - The replicator node
     /// * `leader_info` - NodeInfo representing the leader
     /// * `keypair` - Keypair for this replicator
     /// * `timeout` - (optional) timeout for polling for leader/downloading the ledger. Defaults to

--- a/src/window_service.rs
+++ b/src/window_service.rs
@@ -110,7 +110,8 @@ fn recv_window(
     if !consume_queue.is_empty() {
         inc_new_counter_info!("streamer-recv_window-consume", consume_queue.len());
         if let Some(entry_sender) = entry_sender {
-            entry_sender.send(consume_queue)?;
+            // Purposefully ignoring failed sends in case receiver is dropped
+            let _ignored = entry_sender.send(consume_queue);
         }
     }
     Ok(())

--- a/src/window_service.rs
+++ b/src/window_service.rs
@@ -110,8 +110,7 @@ fn recv_window(
     if !consume_queue.is_empty() {
         inc_new_counter_info!("streamer-recv_window-consume", consume_queue.len());
         if let Some(entry_sender) = entry_sender {
-            // Purposefully ignoring failed sends in case receiver is dropped
-            let _ignored = entry_sender.send(consume_queue);
+            entry_sender.send(consume_queue)?;
         }
     }
     Ok(())

--- a/tests/replicator.rs
+++ b/tests/replicator.rs
@@ -257,6 +257,7 @@ fn test_replicator_startup_leader_hang() {
 }
 
 #[test]
+#[should_panic]
 fn test_replicator_startup_ledger_hang() {
     use std::net::UdpSocket;
 

--- a/tests/replicator.rs
+++ b/tests/replicator.rs
@@ -221,7 +221,7 @@ fn test_replicator_startup() {
 
 #[test]
 #[should_panic]
-fn test_replicator_startup_hang() {
+fn test_replicator_startup_leader_hang() {
     use std::net::{IpAddr, Ipv4Addr, SocketAddr};
     use std::time::Duration;
 
@@ -245,6 +245,83 @@ fn test_replicator_startup_hang() {
             replicator_node,
             &leader_info,
             &replicator_keypair,
+            Some(Duration::from_secs(3)),
+        )
+        .unwrap();
+    }
+
+    DbLedger::destroy(&leader_ledger_path).expect("Expected successful database destruction");
+    DbLedger::destroy(&replicator_ledger_path).expect("Expected successful database destruction");
+    let _ignored = remove_dir_all(&leader_ledger_path);
+    let _ignored = remove_dir_all(&replicator_ledger_path);
+}
+
+#[test]
+fn test_replicator_startup_ledger_hang() {
+    use std::net::UdpSocket;
+
+    solana_logger::setup();
+    info!("starting replicator test");
+    let replicator_ledger_path = &get_tmp_ledger_path("replicator_test_replicator_ledger");
+
+    info!("starting leader node");
+    let leader_keypair = Arc::new(Keypair::new());
+    let leader_node = Node::new_localhost_with_pubkey(leader_keypair.pubkey());
+    let leader_info = leader_node.info.clone();
+
+    let leader_ledger_path = "replicator_test_leader_ledger";
+    let (_, leader_ledger_path) = create_tmp_genesis(leader_ledger_path, 100, leader_info.id, 1);
+
+    let validator_ledger_path =
+        tmp_copy_ledger(&leader_ledger_path, "replicator_test_validator_ledger");
+
+    {
+        let signer_proxy =
+            VoteSignerProxy::new(&leader_keypair, Box::new(LocalVoteSigner::default()));
+
+        let _ = Fullnode::new(
+            leader_node,
+            &leader_ledger_path,
+            leader_keypair,
+            Arc::new(signer_proxy),
+            None,
+            false,
+            LeaderScheduler::from_bootstrap_leader(leader_info.id.clone()),
+            None,
+        );
+
+        let validator_keypair = Arc::new(Keypair::new());
+        let signer_proxy =
+            VoteSignerProxy::new(&validator_keypair, Box::new(LocalVoteSigner::default()));
+        let validator_node = Node::new_localhost_with_pubkey(validator_keypair.pubkey());
+        #[cfg(feature = "chacha")]
+        let validator_node_info = validator_node.info.clone();
+
+        let _ = Fullnode::new(
+            validator_node,
+            &validator_ledger_path,
+            validator_keypair,
+            Arc::new(signer_proxy),
+            Some(leader_info.gossip),
+            false,
+            LeaderScheduler::from_bootstrap_leader(leader_info.id),
+            None,
+        );
+
+        info!("starting replicator node");
+        let bad_keys = Keypair::new();
+        let mut replicator_node = Node::new_localhost_with_pubkey(bad_keys.pubkey());
+
+        // Pass bad TVU sockets to prevent successful ledger download
+        replicator_node.sockets.tvu = vec![UdpSocket::bind("0.0.0.0:0").unwrap()];
+
+        let leader_info = NodeInfo::new_entry_point(&leader_info.gossip);
+
+        let _ = Replicator::new(
+            Some(replicator_ledger_path),
+            replicator_node,
+            &leader_info,
+            &bad_keys,
             Some(Duration::from_secs(3)),
         )
         .unwrap();

--- a/tests/replicator.rs
+++ b/tests/replicator.rs
@@ -294,8 +294,6 @@ fn test_replicator_startup_ledger_hang() {
         let signer_proxy =
             VoteSignerProxy::new(&validator_keypair, Box::new(LocalVoteSigner::default()));
         let validator_node = Node::new_localhost_with_pubkey(validator_keypair.pubkey());
-        #[cfg(feature = "chacha")]
-        let validator_node_info = validator_node.info.clone();
 
         let _ = Fullnode::new(
             validator_node,

--- a/tests/replicator.rs
+++ b/tests/replicator.rs
@@ -220,7 +220,6 @@ fn test_replicator_startup() {
 }
 
 #[test]
-#[should_panic]
 fn test_replicator_startup_leader_hang() {
     use std::net::{IpAddr, Ipv4Addr, SocketAddr};
     use std::time::Duration;
@@ -240,24 +239,24 @@ fn test_replicator_startup_leader_hang() {
         let fake_gossip = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 0);
         let leader_info = NodeInfo::new_entry_point(&fake_gossip);
 
-        let _ = Replicator::new(
+        let replicator_res = Replicator::new(
             Some(replicator_ledger_path),
             replicator_node,
             &leader_info,
             &replicator_keypair,
             Some(Duration::from_secs(3)),
-        )
-        .unwrap();
+        );
+
+        assert!(replicator_res.is_err());
     }
 
-    DbLedger::destroy(&leader_ledger_path).expect("Expected successful database destruction");
-    DbLedger::destroy(&replicator_ledger_path).expect("Expected successful database destruction");
+    let _ignored = DbLedger::destroy(&leader_ledger_path);
+    let _ignored = DbLedger::destroy(&replicator_ledger_path);
     let _ignored = remove_dir_all(&leader_ledger_path);
     let _ignored = remove_dir_all(&replicator_ledger_path);
 }
 
 #[test]
-#[should_panic]
 fn test_replicator_startup_ledger_hang() {
     use std::net::UdpSocket;
 
@@ -318,18 +317,19 @@ fn test_replicator_startup_ledger_hang() {
 
         let leader_info = NodeInfo::new_entry_point(&leader_info.gossip);
 
-        let _ = Replicator::new(
+        let replicator_res = Replicator::new(
             Some(replicator_ledger_path),
             replicator_node,
             &leader_info,
             &bad_keys,
             Some(Duration::from_secs(3)),
-        )
-        .unwrap();
+        );
+
+        assert!(replicator_res.is_err());
     }
 
-    DbLedger::destroy(&leader_ledger_path).expect("Expected successful database destruction");
-    DbLedger::destroy(&replicator_ledger_path).expect("Expected successful database destruction");
+    let _ignored = DbLedger::destroy(&leader_ledger_path);
+    let _ignored = DbLedger::destroy(&replicator_ledger_path);
     let _ignored = remove_dir_all(&leader_ledger_path);
     let _ignored = remove_dir_all(&replicator_ledger_path);
 }


### PR DESCRIPTION
#### Problem

Replicator hangs if polling for leader fails or if unable to download ledger

#### Summary of Changes

Add an optional `timeout: Option<Duration>` to `Replicator::new`. Defaults to 10 seconds

Is currently only used when polling for the leader or downloading the ledger.

Ledger download times out if **0** entries are received within 10 seconds of initiation

Fixes #2379 