### PR TITLE
split load+execute from commit in bank, insert record between them in TPU code

### DIFF
--- a/src/bank.rs
+++ b/src/bank.rs
@@ -2067,6 +2067,7 @@ mod tests {
         assert_eq!(bank.get_pubkeys_for_entry_height(0), vec![]);
     }
 
+    #[test]
     fn test_bank_process_and_record_transactions() {
         let mint = Mint::new(10_000);
         let bank = Arc::new(Bank::new(&mint));

--- a/src/bank.rs
+++ b/src/bank.rs
@@ -473,6 +473,7 @@ impl Bank {
             .load_accounts(txs, &mut last_ids, lock_results, max_age, error_counters)
     }
 
+    #[allow(clippy::type_complexity)]
     fn load_and_execute_transactions(
         &self,
         txs: &[Transaction],


### PR DESCRIPTION
#### Problem
 the TPU bank is hard to checkpoint because transaction commits are unsynchronized with the corresponding Entry generation and record

 #### Summary of Changes
 split load+execute+commit into load+execute and commit, and stick record between them

Fixes #2486