### PR TITLE
Remove sleeps on fullnode spin-up in integration tests

### DIFF
--- a/tests/rpc.rs
+++ b/tests/rpc.rs
@@ -58,7 +58,6 @@ fn test_rpc_send_tx() {
         None,
         STORAGE_ROTATE_TEST_COUNT,
     );
-    sleep(Duration::from_millis(900));
 
     let client = reqwest::Client::new();
     let request = json!({

--- a/wallet/tests/pay.rs
+++ b/wallet/tests/pay.rs
@@ -19,8 +19,6 @@ use solana_wallet::wallet::{
 use std::fs::remove_dir_all;
 use std::sync::mpsc::channel;
 use std::sync::{Arc, RwLock};
-use std::thread::sleep;
-use std::time::Duration;
 
 fn check_balance(expected_balance: u64, client: &RpcClient, params: Value) {
     let balance = client
@@ -65,7 +63,6 @@ fn test_wallet_timestamp_tx() {
         None,
         STORAGE_ROTATE_TEST_COUNT,
     );
-    sleep(Duration::from_millis(900));
 
     let (sender, receiver) = channel();
     run_local_drone(alice.keypair(), sender);
@@ -163,7 +160,6 @@ fn test_wallet_witness_tx() {
         None,
         STORAGE_ROTATE_TEST_COUNT,
     );
-    sleep(Duration::from_millis(900));
 
     let (sender, receiver) = channel();
     run_local_drone(alice.keypair(), sender);
@@ -257,7 +253,6 @@ fn test_wallet_cancel_tx() {
         None,
         STORAGE_ROTATE_TEST_COUNT,
     );
-    sleep(Duration::from_millis(900));
 
     let (sender, receiver) = channel();
     run_local_drone(alice.keypair(), sender);

--- a/wallet/tests/request_airdrop.rs
+++ b/wallet/tests/request_airdrop.rs
@@ -15,8 +15,6 @@ use solana_wallet::wallet::{process_command, WalletCommand, WalletConfig};
 use std::fs::remove_dir_all;
 use std::sync::mpsc::channel;
 use std::sync::{Arc, RwLock};
-use std::thread::sleep;
-use std::time::Duration;
 
 #[test]
 fn test_wallet_request_airdrop() {
@@ -51,7 +49,6 @@ fn test_wallet_request_airdrop() {
         None,
         STORAGE_ROTATE_TEST_COUNT,
     );
-    sleep(Duration::from_millis(900));
 
     let (sender, receiver) = channel();
     run_local_drone(alice.keypair(), sender);


### PR DESCRIPTION
#### Problem
Sleeps in Wallet integration tests should not be necessary.

#### Summary of Changes
Removes sleeps

Fixes #2406 
