### PR TITLE
Fix rpc port argument name

### DIFF
--- a/sdk/docker-solana/entrypoint.sh
+++ b/sdk/docker-solana/entrypoint.sh
@@ -21,7 +21,7 @@ drone=$!
 solana-fullnode \
   --identity /config/leader-config.json \
   --ledger /ledger/ \
-  --rpc 8899 &
+  --rpc-port 8899 &
 fullnode=$!
 
 abort() {


### PR DESCRIPTION
#### Problem
Launching solana localnet via the sdk failing due to this error: 
```
error: Found argument '--rpc' which wasn't expected, or isn't valid in this context
	Did you mean --rpc-port?
```

#### Summary of Changes
Update argument name to match recent changes

Fixes #
