### PR TITLE
Optimize Transaction/Instruction serialization with custom routine

### DIFF
--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -12,6 +12,7 @@ pub mod native_program;
 pub mod packet;
 pub mod payment_plan;
 pub mod pubkey;
+pub mod shortvec;
 pub mod signature;
 pub mod storage_program;
 pub mod system_instruction;

--- a/sdk/src/shortvec.rs
+++ b/sdk/src/shortvec.rs
@@ -1,0 +1,358 @@
+use bincode::{deserialize_from, serialize_into, Error};
+use serde::Serialize;
+use std::io::{Cursor, Read, Write};
+use std::mem::size_of;
+
+pub fn encode_len<W: Write>(writer: &mut W, len: usize) -> Result<(), Error> {
+    let mut rem_len = len;
+    loop {
+        let mut elem = (rem_len & 0x7f) as u8;
+        rem_len >>= 7;
+        if rem_len == 0 {
+            writer.write_all(&[elem])?;
+            break;
+        } else {
+            elem |= 0x80;
+            writer.write_all(&[elem])?;
+        }
+    }
+    Ok(())
+}
+
+pub fn decode_len<R: Read>(reader: &mut R) -> Result<usize, Error> {
+    let mut len: usize = 0;
+    let mut size: usize = 0;
+    loop {
+        let mut elem = [0u8; 1];
+        reader.read_exact(&mut elem)?;
+        len |= (elem[0] as usize & 0x7f) << (size * 7);
+        size += 1;
+        if elem[0] as usize & 0x80 == 0 {
+            break;
+        }
+        assert!(size <= size_of::<usize>() + 1);
+    }
+    Ok(len)
+}
+
+pub fn serialize_vec_with<T>(
+    mut writer: &mut Cursor<&mut [u8]>,
+    input: &[T],
+    ser_fn: fn(&mut Cursor<&mut [u8]>, &T) -> Result<(), Error>,
+) -> Result<(), Error> {
+    encode_len(&mut writer, input.len())?;
+    input.iter().for_each(|e| ser_fn(&mut writer, &e).unwrap());
+    Ok(())
+}
+
+pub fn serialize_vec<W: Write, T>(mut writer: W, input: &[T]) -> Result<(), Error>
+where
+    T: Serialize,
+{
+    encode_len(&mut writer, input.len())?;
+    input
+        .iter()
+        .for_each(|e| serialize_into(&mut writer, &e).unwrap());
+    Ok(())
+}
+
+pub fn deserialize_vec<R: Read, T>(mut reader: &mut R) -> Result<Vec<T>, Error>
+where
+    T: serde::de::DeserializeOwned,
+{
+    let vec_len = decode_len(&mut reader)?;
+    let mut vec: Vec<T> = Vec::with_capacity(vec_len);
+    for _ in 0..vec_len {
+        let t: T = deserialize_from(&mut reader)?;
+        vec.push(t);
+    }
+    Ok(vec)
+}
+
+pub fn deserialize_vec_with<T>(
+    mut reader: &mut Cursor<&[u8]>,
+    deser_fn: fn(&mut Cursor<&[u8]>) -> Result<T, Error>,
+) -> Result<Vec<T>, Error> {
+    let vec_len = decode_len(&mut reader)?;
+    let mut vec: Vec<T> = Vec::with_capacity(vec_len);
+    for _ in 0..vec_len {
+        let t: T = deser_fn(&mut reader)?;
+        vec.push(t);
+    }
+    Ok(vec)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bincode::{deserialize, serialize, serialized_size};
+    use serde::ser::Serializer;
+    use serde::Deserialize;
+    use std::fmt;
+    use std::io::Cursor;
+
+    #[test]
+    fn test_shortvec_encode_len() {
+        let mut buf = vec![0u8; size_of::<u64>() + 1];
+        let mut wr = Cursor::new(&mut buf[..]);
+        encode_len(&mut wr, 0x0).unwrap();
+        let vec = wr.get_ref()[..wr.position() as usize].to_vec();
+        assert_eq!(vec, vec![0u8]);
+        wr.set_position(0);
+        encode_len(&mut wr, 0x5).unwrap();
+        let vec = wr.get_ref()[..wr.position() as usize].to_vec();
+        assert_eq!(vec, vec![0x5u8]);
+        wr.set_position(0);
+        encode_len(&mut wr, 0x7f).unwrap();
+        let vec = wr.get_ref()[..wr.position() as usize].to_vec();
+        assert_eq!(vec, vec![0x7fu8]);
+        wr.set_position(0);
+        encode_len(&mut wr, 0x80).unwrap();
+        let vec = wr.get_ref()[..wr.position() as usize].to_vec();
+        assert_eq!(vec, vec![0x80u8, 0x01u8]);
+        wr.set_position(0);
+        encode_len(&mut wr, 0xff).unwrap();
+        let vec = wr.get_ref()[..wr.position() as usize].to_vec();
+        assert_eq!(vec, vec![0xffu8, 0x01u8]);
+        wr.set_position(0);
+        encode_len(&mut wr, 0x100).unwrap();
+        let vec = wr.get_ref()[..wr.position() as usize].to_vec();
+        assert_eq!(vec, vec![0x80u8, 0x02u8]);
+        wr.set_position(0);
+        encode_len(&mut wr, 0x7fff).unwrap();
+        let vec = wr.get_ref()[..wr.position() as usize].to_vec();
+        assert_eq!(vec, vec![0xffu8, 0xffu8, 0x01u8]);
+        wr.set_position(0);
+        encode_len(&mut wr, 0x200000).unwrap();
+        let vec = wr.get_ref()[..wr.position() as usize].to_vec();
+        assert_eq!(vec, vec![0x80u8, 0x80u8, 0x80u8, 0x01u8]);
+        wr.set_position(0);
+        encode_len(&mut wr, 0x7ffffffff).unwrap();
+        let vec = wr.get_ref()[..wr.position() as usize].to_vec();
+        assert_eq!(vec, vec![0xffu8, 0xffu8, 0xffu8, 0xffu8, 0x7fu8]);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_shortvec_decode_zero_len() {
+        let mut buf = vec![];
+        let mut rd = Cursor::new(&mut buf[..]);
+        assert_eq!(decode_len(&mut rd).unwrap(), 0);
+        assert_eq!(rd.position(), 0);
+    }
+
+    #[test]
+    fn test_shortvec_decode_len() {
+        let mut buf = vec![0u8];
+        let mut rd = Cursor::new(&mut buf[..]);
+        assert_eq!(decode_len(&mut rd).unwrap(), 0);
+        assert_eq!(rd.position(), 1);
+        let mut buf = vec![5u8];
+        let mut rd = Cursor::new(&mut buf[..]);
+        assert_eq!(decode_len(&mut rd).unwrap(), 5);
+        assert_eq!(rd.position(), 1);
+        let mut buf = vec![0x7fu8];
+        let mut rd = Cursor::new(&mut buf[..]);
+        assert_eq!(decode_len(&mut rd).unwrap(), 0x7f);
+        assert_eq!(rd.position(), 1);
+        let mut buf = vec![0x80u8, 0x01u8];
+        let mut rd = Cursor::new(&mut buf[..]);
+        assert_eq!(decode_len(&mut rd).unwrap(), 0x80);
+        assert_eq!(rd.position(), 2);
+        let mut buf = vec![0xffu8, 0x01u8];
+        let mut rd = Cursor::new(&mut buf[..]);
+        assert_eq!(decode_len(&mut rd).unwrap(), 0xff);
+        assert_eq!(rd.position(), 2);
+        let mut buf = vec![0x80u8, 0x02u8];
+        let mut rd = Cursor::new(&mut buf[..]);
+        assert_eq!(decode_len(&mut rd).unwrap(), 0x100);
+        assert_eq!(rd.position(), 2);
+        let mut buf = vec![0xffu8, 0xffu8, 0x01u8];
+        let mut rd = Cursor::new(&mut buf[..]);
+        assert_eq!(decode_len(&mut rd).unwrap(), 0x7fff);
+        assert_eq!(rd.position(), 3);
+        let mut buf = vec![0x80u8, 0x80u8, 0x80u8, 0x01u8];
+        let mut rd = Cursor::new(&mut buf[..]);
+        assert_eq!(decode_len(&mut rd).unwrap(), 0x200000);
+        assert_eq!(rd.position(), 4);
+        let mut buf = vec![0xffu8, 0xffu8, 0xffu8, 0xffu8, 0x7fu8];
+        let mut rd = Cursor::new(&mut buf[..]);
+        assert_eq!(decode_len(&mut rd).unwrap(), 0x7ffffffff);
+        assert_eq!(rd.position(), 5);
+    }
+
+    #[test]
+    fn test_shortvec_u8() {
+        let vec: Vec<u8> = vec![4; 32];
+        let mut buf = vec![0u8; serialized_size(&vec).unwrap() as usize + 1];
+        let mut wr = Cursor::new(&mut buf[..]);
+        serialize_vec(&mut wr, &vec).unwrap();
+        let size = wr.position() as usize;
+        let ser = &wr.into_inner()[..size];
+        assert_eq!(ser.len(), vec.len() + 1);
+        let mut rd = Cursor::new(&ser[..]);
+        let deser: Vec<u8> = deserialize_vec(&mut rd).unwrap();
+        assert_eq!(vec, deser);
+    }
+
+    #[derive(Debug, Eq, PartialEq)]
+    struct TestVec {
+        vec_u8: Vec<u8>,
+        id: u8,
+        vec_u32: Vec<u32>,
+    }
+
+    impl TestVec {
+        pub fn serialize_with(
+            mut writer: &mut Cursor<&mut [u8]>,
+            tv: &TestVec,
+        ) -> Result<(), Error> {
+            serialize_vec(&mut writer, &tv.vec_u8).unwrap();
+            serialize_into(&mut writer, &tv.id).unwrap();
+            serialize_vec(&mut writer, &tv.vec_u32).unwrap();
+            Ok(())
+        }
+        pub fn from_bytes(mut reader: &mut Cursor<&[u8]>) -> Result<Self, Error> {
+            let vec_u8: Vec<u8> = deserialize_vec(&mut reader).unwrap();
+            let id: u8 = deserialize_from(&mut reader).unwrap();
+            let vec_u32: Vec<u32> = deserialize_vec(&mut reader).unwrap();
+            Ok(TestVec {
+                vec_u8,
+                id,
+                vec_u32,
+            })
+        }
+        pub fn serialized_size(&self) -> u64 {
+            let mut buf = vec![0u8; size_of::<u64>() + 1];
+            let mut size = size_of::<u64>();
+            let mut wr = Cursor::new(&mut buf[..]);
+            encode_len(&mut wr, self.vec_u8.len()).unwrap();
+            size += wr.position() as usize + self.vec_u8.len() * size_of::<u8>();
+            size += size_of::<u8>();
+            wr.set_position(0);
+            encode_len(&mut wr, self.vec_u32.len()).unwrap();
+            size += wr.position() as usize + self.vec_u32.len() * size_of::<u32>();
+            size as u64
+        }
+    }
+
+    impl Serialize for TestVec {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+        {
+            use serde::ser::Error;
+            let mut buf = vec![0u8; self.serialized_size() as usize];
+            let mut wr = Cursor::new(&mut buf[..]);
+            serialize_vec(&mut wr, &self.vec_u8).map_err(Error::custom)?;
+            serialize_into(&mut wr, &self.id).map_err(Error::custom)?;
+            serialize_vec(&mut wr, &self.vec_u32).map_err(Error::custom)?;
+            let len = wr.position() as usize;
+            serializer.serialize_bytes(&wr.into_inner()[..len])
+        }
+    }
+
+    struct TestVecVisitor;
+    impl<'a> serde::de::Visitor<'a> for TestVecVisitor {
+        type Value = TestVec;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            formatter.write_str("Expecting TestVec")
+        }
+        fn visit_bytes<E>(self, data: &[u8]) -> Result<TestVec, E>
+        where
+            E: serde::de::Error,
+        {
+            use serde::de::Error;
+            let mut rd = Cursor::new(&data[..]);
+            let v1: Vec<u8> = deserialize_vec(&mut rd).map_err(Error::custom)?;
+            let id: u8 = deserialize_from(&mut rd).map_err(Error::custom)?;
+            let v2: Vec<u32> = deserialize_vec(&mut rd).map_err(Error::custom)?;
+            Ok(TestVec {
+                vec_u8: v1,
+                id,
+                vec_u32: v2,
+            })
+        }
+    }
+    impl<'de> Deserialize<'de> for TestVec {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: ::serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_bytes(TestVecVisitor)
+        }
+    }
+
+    #[test]
+    fn test_shortvec_testvec() {
+        let tvec: TestVec = TestVec {
+            vec_u8: vec![4; 32],
+            id: 5,
+            vec_u32: vec![6; 32],
+        };
+        let size = tvec.serialized_size() as usize;
+        assert_eq!(
+            size,
+            tvec.vec_u8.len() + 1 + 1 + (tvec.vec_u32.len() * 4) + 1 + 8
+        );
+        let ser = serialize(&tvec).unwrap();
+        assert_eq!(
+            ser.len(),
+            tvec.vec_u8.len() + 1 + 1 + (tvec.vec_u32.len() * 4) + 1 + 8
+        );
+        let deser = deserialize(&ser).unwrap();
+        assert_eq!(tvec, deser);
+    }
+
+    #[derive(Serialize, Deserialize, Debug, Eq, PartialEq)]
+    struct TestVecArr {
+        data: Vec<TestVec>,
+    }
+    impl TestVecArr {
+        fn new() -> Self {
+            TestVecArr { data: vec![] }
+        }
+        fn serialized_size(tvec: &TestVecArr) -> u64 {
+            let mut buf = vec![0u8; size_of::<u64>() + 1];
+            let mut wr = Cursor::new(&mut buf[..]);
+            encode_len(&mut wr, tvec.data.len()).unwrap();
+            let size: u64 = tvec
+                .data
+                .iter()
+                .map(|tv| TestVec::serialized_size(&tv))
+                .sum();
+            size_of::<u64>() as u64 + size + wr.position()
+        }
+    }
+    #[test]
+    fn test_shortvec_testvec_with() {
+        let tvec1 = TestVec {
+            vec_u8: vec![4; 32],
+            id: 5,
+            vec_u32: vec![6; 32],
+        };
+        let tvec2 = TestVec {
+            vec_u8: vec![7; 32],
+            id: 8,
+            vec_u32: vec![9; 32],
+        };
+        let tvec3 = TestVec {
+            vec_u8: vec![],
+            id: 10,
+            vec_u32: vec![11; 32],
+        };
+        let mut tvecarr: TestVecArr = TestVecArr::new();
+        tvecarr.data.push(tvec1);
+        tvecarr.data.push(tvec2);
+        tvecarr.data.push(tvec3);
+        let mut buf = vec![0u8; TestVecArr::serialized_size(&tvecarr) as usize];
+        let mut wr = Cursor::new(&mut buf[..]);
+        serialize_vec_with(&mut wr, &tvecarr.data, TestVec::serialize_with).unwrap();
+        let size = wr.position() as usize;
+        let ser = &wr.into_inner()[..size];
+        let mut rd = Cursor::new(&ser[..]);
+        let deser = deserialize_vec_with(&mut rd, TestVec::from_bytes).unwrap();
+        assert_eq!(tvecarr.data, deser);
+    }
+}

--- a/src/chacha.rs
+++ b/src/chacha.rs
@@ -166,7 +166,7 @@ mod tests {
         assert_eq!(
             hasher.result(),
             Hash::new(&hex!(
-                "1ef70b5491a5f2b05ebeb0f92a03c131a7a78622f3643064d6d3c52a0c083175"
+                "16b1159b112b11d7a2fb7b0471797ab079bce7e0e86b8a879474616abb61e5aa"
             )),
         );
         remove_file(out_path).unwrap();

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -125,11 +125,13 @@ impl Entry {
 
     /// Estimate serialized_size of Entry without creating an Entry.
     pub fn serialized_size(transactions: &[Transaction]) -> u64 {
-        let txs_size = serialized_size(transactions).unwrap();
-
+        let txs_size: u64 = transactions
+            .iter()
+            .map(|tx| Transaction::serialized_size(&tx))
+            .sum();
         // tick_height+num_hashes   +    id  +              txs
 
-        (2 * size_of::<u64>() + size_of::<Hash>()) as u64 + txs_size
+        (3 * size_of::<u64>() + size_of::<Hash>()) as u64 + txs_size
     }
 
     pub fn num_will_fit(transactions: &[Transaction]) -> usize {
@@ -432,7 +434,7 @@ pub fn make_large_test_entries(num_entries: usize) -> Vec<Entry> {
         one,
     );
 
-    let serialized_size = serialized_size(&vec![&tx]).unwrap();
+    let serialized_size = serialized_size(&[&tx]).unwrap();
     let num_txs = BLOB_DATA_SIZE / serialized_size as usize;
     let txs = vec![tx; num_txs];
     let entry = next_entries(&one, 1, txs)[0].clone();
@@ -672,8 +674,8 @@ mod tests {
         };
         let tx_large = Transaction::budget_new(&keypair, keypair.pubkey(), 1, next_id);
 
-        let tx_small_size = serialized_size(&tx_small).unwrap() as usize;
-        let tx_large_size = serialized_size(&tx_large).unwrap() as usize;
+        let tx_small_size = serialized_size(&[&tx_small]).unwrap() as usize;
+        let tx_large_size = serialized_size(&[&tx_large]).unwrap() as usize;
         let entry_size = serialized_size(&Entry {
             tick_height: 0,
             num_hashes: 0,

--- a/src/sigverify.rs
+++ b/src/sigverify.rs
@@ -7,13 +7,13 @@
 use crate::counter::Counter;
 use crate::packet::{Packet, SharedPackets};
 use crate::result::Result;
-use byteorder::{LittleEndian, ReadBytesExt};
 use log::Level;
 use solana_sdk::pubkey::Pubkey;
+use solana_sdk::shortvec::decode_len;
 use solana_sdk::signature::Signature;
 #[cfg(test)]
 use solana_sdk::transaction::Transaction;
-use std::io;
+use std::io::Cursor;
 use std::mem::size_of;
 use std::sync::atomic::AtomicUsize;
 
@@ -126,17 +126,25 @@ pub fn ed25519_verify(batches: &[SharedPackets]) -> Vec<Vec<u8>> {
 }
 
 pub fn get_packet_offsets(packet: &Packet, current_offset: u32) -> (u32, u32, u32, u32) {
-    // Read in u64 as the size of signatures array
-    let mut rdr = io::Cursor::new(&packet.data[TX_OFFSET..size_of::<u64>()]);
-    let sig_len = rdr.read_u64::<LittleEndian>().unwrap() as u32;
+    // Read in the size of signatures array
+    let start_offset = TX_OFFSET + size_of::<u64>();
+    let mut rd = Cursor::new(&packet.data[start_offset..]);
+    let sig_len = decode_len(&mut rd).unwrap();
+    let sig_size = rd.position() as usize;
+    let msg_start_offset = start_offset + sig_size + sig_len * size_of::<Signature>();
+    let mut rd = Cursor::new(&packet.data[msg_start_offset..]);
+    let _ = decode_len(&mut rd).unwrap();
+    let pubkey_size = rd.position() as usize;
+    let pubkey_offset = current_offset as usize + msg_start_offset + pubkey_size;
 
-    let msg_start_offset =
-        current_offset + size_of::<u64>() as u32 + sig_len * size_of::<Signature>() as u32;
-    let pubkey_offset = msg_start_offset + size_of::<u64>() as u32;
+    let sig_start = start_offset + current_offset as usize + sig_size;
 
-    let sig_start = TX_OFFSET as u32 + size_of::<u64>() as u32;
-
-    (sig_len, sig_start, msg_start_offset, pubkey_offset)
+    (
+        sig_len as u32,
+        sig_start as u32,
+        current_offset + msg_start_offset as u32,
+        pubkey_offset as u32,
+    )
 }
 
 pub fn generate_offsets(batches: &[SharedPackets]) -> Result<TxOffsets> {
@@ -151,14 +159,14 @@ pub fn generate_offsets(batches: &[SharedPackets]) -> Result<TxOffsets> {
         p.read().unwrap().packets.iter().for_each(|packet| {
             let current_offset = current_packet as u32 * size_of::<Packet>() as u32;
 
-            let (sig_len, _sig_start, msg_start_offset, pubkey_offset) =
+            let (sig_len, sig_start, msg_start_offset, pubkey_offset) =
                 get_packet_offsets(packet, current_offset);
             let mut pubkey_offset = pubkey_offset;
 
             sig_lens.push(sig_len);
 
             trace!("pubkey_offset: {}", pubkey_offset);
-            let mut sig_offset = current_offset + size_of::<u64>() as u32;
+            let mut sig_offset = sig_start;
             for _ in 0..sig_len {
                 signature_offsets.push(sig_offset);
                 sig_offset += size_of::<Signature>() as u32;
@@ -334,7 +342,9 @@ mod tests {
     use solana_sdk::signature::{Keypair, KeypairUtil};
     use solana_sdk::system_instruction::SystemInstruction;
     use solana_sdk::system_program;
-    use solana_sdk::transaction::{Instruction, Transaction, SIG_OFFSET};
+    use solana_sdk::transaction::{Instruction, Transaction};
+
+    const SIG_OFFSET: usize = std::mem::size_of::<u64>() + 1;
 
     pub fn memfind<A: Eq>(a: &[A], b: &[A]) -> Option<usize> {
         assert!(a.len() >= b.len());
@@ -414,9 +424,9 @@ mod tests {
         let (sig_len, sig_start, msg_start_offset, pubkey_offset) =
             sigverify::get_packet_offsets(&packet, 0);
         assert_eq!(sig_len, 1);
-        assert_eq!(sig_start, 8);
-        assert_eq!(msg_start_offset, 72);
-        assert_eq!(pubkey_offset, 80);
+        assert_eq!(sig_start, 9);
+        assert_eq!(msg_start_offset, 73);
+        assert_eq!(pubkey_offset, 74);
     }
 
     fn generate_packet_vec(


### PR DESCRIPTION
#### Problem
The usage of vectors in Transaction/Instruction results in 8 bytes to be used for each of the vector to store the size. This could add up to the over all size of the packet sent over the network.

#### Summary of Changes
In most cases, the size for each of these vectors could be fit in either 1 or 2 bytes there by reducing the size of the serialized data. Each vector is serialized to a series of bytes with the first few bytes holding the vector length and then the elements themselves.

The vector length is encoded using a variable length of bytes using the following sequence. The first 7 bits of each byte should map to the next 7 lowest bits of the u64, and the top bit should indicate if the next byte needs to be read (0 means you're done). So that's the bottom 56 bits that can be serialized in 8 bytes. The 9th byte then holds all remaining 8 bits. That is, the top bit in the 9th byte does not indicate there's a 10th byte.

Fixes #
