### PR TITLE
BPF programs can support up to 5 arguments

### DIFF
--- a/programs/bpf/c/src/move_funds/move_funds.c
+++ b/programs/bpf/c/src/move_funds/move_funds.c
@@ -13,22 +13,21 @@
 
 extern bool entrypoint(const uint8_t *input) {
   SolKeyedAccount ka[NUM_KA];
-  const uint8_t *data;
-  uint64_t data_len;
+  SolParameters params = (SolParameters) { .ka = ka };
 
-  if (!sol_deserialize(input, ka, NUM_KA, NULL, &data, &data_len, NULL)) {
+  if (!sol_deserialize(input, &params, SOL_ARRAY_SIZE(ka))) {
     return false;
   }
 
-  if (!ka[0].is_signer) {
+  if (!params.ka[0].is_signer) {
     sol_log("Transaction not signed by key 0");
     return false;
   }
 
-  int64_t tokens = *(int64_t *)data;
-  if (*ka[0].tokens >= tokens) {
-    *ka[0].tokens -= tokens;
-    *ka[2].tokens += tokens;
+  int64_t tokens = *(int64_t *)params.data;
+  if (*params.ka[0].tokens >= tokens) {
+    *params.ka[0].tokens -= tokens;
+    *params.ka[2].tokens += tokens;
     // sol_log_64(0, 0, *ka[0].tokens, *ka[2].tokens, tokens);
   } else {
     // sol_log_64(0, 0, 0xFF, *ka[0].tokens, tokens);

--- a/programs/bpf/c/src/noop++/noop++.cc
+++ b/programs/bpf/c/src/noop++/noop++.cc
@@ -6,26 +6,17 @@
 
 extern bool entrypoint(const uint8_t *input) {
   SolKeyedAccount ka[1];
-  uint64_t ka_len;
-  const uint8_t *data;
-  uint64_t data_len;
-  SolClusterInfo info;
+  SolParameters params = (SolParameters) { .ka = ka };
 
   sol_log(__FILE__);
-   
-  if (!sol_deserialize(input, ka, SOL_ARRAY_SIZE(ka), &ka_len, &data, &data_len, &info)) {
+
+  if (!sol_deserialize(input, &params, SOL_ARRAY_SIZE(ka))) {
     return false;
   }
 
-  sol_log("Tick height:");
-  sol_log_64(info.tick_height, 0, 0, 0, 0);
-  sol_log("Program identifier:");
-  sol_log_key(info.program_id);
-
-  // Log the provided account keys and instruction input data.  In the case of
-  // the no-op program, no account keys or input data are expected but real
+  // Log the provided input parameters.  In the case of  the no-op
+  // program, no account keys or input data are expected but real
   // programs will have specific requirements so they can do their work.
-  sol_log("Account keys and instruction input data:");
-  sol_log_params(ka, ka_len, data, data_len);
+  sol_log_params(&params);
   return true;
 }

--- a/programs/bpf/c/src/noop/noop.c
+++ b/programs/bpf/c/src/noop/noop.c
@@ -14,9 +14,9 @@ extern bool entrypoint(const uint8_t *input) {
     return false;
   }
 
-  // // Log the provided input parameters.  In the case of  the no-op
-  // // program, no account keys or input data are expected but real
-  // // programs will have specific requirements so they can do their work.
+  // Log the provided input parameters.  In the case of  the no-op
+  // program, no account keys or input data are expected but real
+  // programs will have specific requirements so they can do their work.
   sol_log_params(&params);
   return true;
 }

--- a/programs/bpf/c/src/noop/noop.c
+++ b/programs/bpf/c/src/noop/noop.c
@@ -6,26 +6,18 @@
 
 extern bool entrypoint(const uint8_t *input) {
   SolKeyedAccount ka[1];
-  uint64_t ka_len;
-  const uint8_t *data;
-  uint64_t data_len;
-  SolClusterInfo info;
+  SolParameters params = (SolParameters) { .ka = ka };
 
   sol_log(__FILE__);
 
-  if (!sol_deserialize(input, ka, SOL_ARRAY_SIZE(ka), &ka_len, &data, &data_len, &info)) {
+  if (!sol_deserialize(input, &params, SOL_ARRAY_SIZE(ka))) {
     return false;
   }
-  sol_log("Tick height:");
-  sol_log_64(info.tick_height, 0, 0, 0, 0);
-  sol_log("Program identifier:");
-  sol_log_key(info.program_id);
 
-  // Log the provided account keys and instruction input data.  In the case of
-  // the no-op program, no account keys or input data are expected but real
-  // programs will have specific requirements so they can do their work.
-  sol_log("Account keys and instruction input data:");
-  sol_log_params(ka, ka_len, data, data_len);
+  // // Log the provided input parameters.  In the case of  the no-op
+  // // program, no account keys or input data are expected but real
+  // // programs will have specific requirements so they can do their work.
+  sol_log_params(&params);
   return true;
 }
 

--- a/sdk/bpf/inc/solana_sdk.h
+++ b/sdk/bpf/inc/solana_sdk.h
@@ -176,19 +176,19 @@ SOL_FN_PREFIX size_t sol_strlen(const char *s) {
  * the BPF VM to immediately halt execution. No accounts' userdata are updated
  */
 #define sol_panic() _sol_panic(__LINE__)
-  SOL_FN_PREFIX void _sol_panic(uint64_t line) {
-    sol_log_64(0xFF, 0xFF, 0xFF, 0xFF, line);
-    uint8_t *pv = (uint8_t *)1;
-    *pv = 1;
-  }
+SOL_FN_PREFIX void _sol_panic(uint64_t line) {
+  sol_log_64(0xFF, 0xFF, 0xFF, 0xFF, line);
+  uint8_t *pv = (uint8_t *)1;
+  *pv = 1;
+}
 
 /**
  * Asserts
  */
 #define sol_assert(expr)  \
-  if (!(expr)) {          \
-    _sol_panic(__LINE__); \
-  }
+if (!(expr)) {          \
+  _sol_panic(__LINE__); \
+}
 
 /**
  * Structure that the program's entrypoint input data is deserialized into.


### PR DESCRIPTION
#### Problem

BPF can support up to 5 function arguments.  We may be able to get around this by making modifications to the compiler to pass additional arguments via the stack.  That will take time and this function should be cleaned up anyway.

#### Summary of Changes

Refactor and cleanup sol_deserialize() to reduce the number of arguments.

Fixes #2420