### PR TITLE
increase startup timeout for localnet sanity

### DIFF
--- a/ci/localnet-sanity.sh
+++ b/ci/localnet-sanity.sh
@@ -127,7 +127,7 @@ waitForAllNodesToInit() {
   SECONDS=
   for initCompleteFile in "${initCompleteFiles[@]}"; do
     while [[ ! -r $initCompleteFile ]]; do
-      if [[ $SECONDS -ge 30 ]]; then
+      if [[ $SECONDS -ge 240 ]]; then
         echo "^^^ +++"
         echo "Error: $initCompleteFile not found in $SECONDS seconds"
         exit 1


### PR DESCRIPTION
#### Problem
 builds on non-CI machines can easily take longer than 30 seconds, and localnet-sanity triggers rebuilds by running via "cargo run"

 #### Summary of Changes
 increase startup timeout