### PR TITLE
Remove get_stake placeholder

### DIFF
--- a/src/bank.rs
+++ b/src/bank.rs
@@ -885,12 +885,6 @@ impl Bank {
             .unwrap_or(0)
     }
 
-    /// TODO: Need to implement a real staking program to hold node stake.
-    /// Right now this just gets the account balances. See github issue #1655.
-    pub fn get_stake(&self, pubkey: &Pubkey) -> u64 {
-        self.get_balance(pubkey)
-    }
-
     pub fn get_account(&self, pubkey: &Pubkey) -> Option<Account> {
         self.accounts.load_slow(pubkey)
     }

--- a/src/cluster_info.rs
+++ b/src/cluster_info.rs
@@ -321,7 +321,7 @@ impl ClusterInfo {
     fn sort_by_stake(peers: &[NodeInfo], bank: &Arc<Bank>) -> Vec<(u64, NodeInfo)> {
         let mut peers_with_stakes: Vec<_> = peers
             .iter()
-            .map(|c| (bank.get_stake(&c.id), c.clone()))
+            .map(|c| (bank.get_balance(&c.id), c.clone()))
             .collect();
         peers_with_stakes.sort_unstable();
         peers_with_stakes

--- a/src/compute_leader_confirmation_service.rs
+++ b/src/compute_leader_confirmation_service.rs
@@ -60,7 +60,7 @@ impl ComputeLeaderConfirmationService {
         let mut ticks_and_stakes: Vec<(u64, u64)> = vote_states
             .iter()
             .filter_map(|vote_state| {
-                let validator_stake = bank.get_stake(&vote_state.node_id);
+                let validator_stake = bank.get_balance(&vote_state.node_id);
                 total_stake += validator_stake;
                 // Filter out any validators that don't have at least one vote
                 // by returning None

--- a/src/leader_scheduler.rs
+++ b/src/leader_scheduler.rs
@@ -419,7 +419,7 @@ impl LeaderScheduler {
     {
         let mut active_accounts: Vec<(&'a Pubkey, u64)> = active
             .filter_map(|pk| {
-                let stake = bank.get_stake(pk);
+                let stake = bank.get_balance(pk);
                 if stake > 0 {
                     Some((pk, stake as u64))
                 } else {

--- a/src/retransmit_stage.rs
+++ b/src/retransmit_stage.rs
@@ -62,7 +62,7 @@ fn retransmit(
         //find my index (my ix is the same as the first node with smaller stake)
         let my_index = peers
             .iter()
-            .position(|ci| bank.get_stake(&ci.id) <= bank.get_stake(&my_id));
+            .position(|ci| bank.get_balance(&ci.id) <= bank.get_balance(&my_id));
         //find my layer
         let locality = ClusterInfo::localize(
             &layer_indices,


### PR DESCRIPTION
#### Problem

Bank has a method `get_stake` with a TODO referencing #1655, but said staking accounts can exist in current code as VoteProgram accounts.

#### Summary of Changes

Delete `get_stake()` and use `get_balance()` on staking accounts instead.

cc #1655
