### PR TITLE
Add unit-test-friendly VoteSignerProxy constructor

### DIFF
--- a/src/compute_leader_confirmation_service.rs
+++ b/src/compute_leader_confirmation_service.rs
@@ -165,7 +165,6 @@ pub mod tests {
     use bincode::serialize;
     use solana_sdk::hash::hash;
     use solana_sdk::signature::{Keypair, KeypairUtil};
-    use solana_vote_signer::rpc::LocalVoteSigner;
     use std::sync::Arc;
     use std::thread::sleep;
     use std::time::Duration;
@@ -195,8 +194,7 @@ pub mod tests {
                 // Create new validator to vote
                 let validator_keypair = Arc::new(Keypair::new());
                 let last_id = ids[i];
-                let vote_signer =
-                    VoteSignerProxy::new(&validator_keypair, Box::new(LocalVoteSigner::default()));
+                let vote_signer = VoteSignerProxy::new_local(&validator_keypair);
 
                 // Give the validator some tokens
                 bank.transfer(2, &mint_keypair, validator_keypair.pubkey(), last_id)

--- a/src/fullnode.rs
+++ b/src/fullnode.rs
@@ -535,7 +535,6 @@ mod tests {
     use crate::tvu::TvuReturnType;
     use crate::vote_signer_proxy::VoteSignerProxy;
     use solana_sdk::signature::{Keypair, KeypairUtil};
-    use solana_vote_signer::rpc::LocalVoteSigner;
     use std::cmp;
     use std::fs::remove_dir_all;
     use std::net::UdpSocket;
@@ -559,7 +558,7 @@ mod tests {
 
         let last_id = bank.last_id();
         let keypair = Arc::new(keypair);
-        let signer = VoteSignerProxy::new(&keypair, Box::new(LocalVoteSigner::default()));
+        let signer = VoteSignerProxy::new_local(&keypair);
         let v = Fullnode::new_with_bank(
             keypair,
             Some(Arc::new(signer)),
@@ -602,7 +601,7 @@ mod tests {
                 let entry_height = 0;
                 let last_id = bank.last_id();
                 let keypair = Arc::new(keypair);
-                let signer = VoteSignerProxy::new(&keypair, Box::new(LocalVoteSigner::default()));
+                let signer = VoteSignerProxy::new_local(&keypair);
                 Fullnode::new_with_bank(
                     keypair,
                     Some(Arc::new(signer)),
@@ -675,10 +674,7 @@ mod tests {
         );
 
         let bootstrap_leader_keypair = Arc::new(bootstrap_leader_keypair);
-        let signer = VoteSignerProxy::new(
-            &bootstrap_leader_keypair,
-            Box::new(LocalVoteSigner::default()),
-        );
+        let signer = VoteSignerProxy::new_local(&bootstrap_leader_keypair);
         // Start up the leader
         let mut bootstrap_leader = Fullnode::new(
             bootstrap_leader_node,
@@ -783,10 +779,7 @@ mod tests {
 
         {
             // Test that a node knows to transition to a validator based on parsing the ledger
-            let vote_signer = VoteSignerProxy::new(
-                &bootstrap_leader_keypair,
-                Box::new(LocalVoteSigner::default()),
-            );
+            let vote_signer = VoteSignerProxy::new_local(&bootstrap_leader_keypair);
             let bootstrap_leader = Fullnode::new(
                 bootstrap_leader_node,
                 &bootstrap_leader_ledger_path,
@@ -895,8 +888,7 @@ mod tests {
             Some(bootstrap_height),
         );
 
-        let vote_signer =
-            VoteSignerProxy::new(&validator_keypair, Box::new(LocalVoteSigner::default()));
+        let vote_signer = VoteSignerProxy::new_local(&validator_keypair);
         // Start the validator
         let validator = Fullnode::new(
             validator_node,

--- a/src/leader_scheduler.rs
+++ b/src/leader_scheduler.rs
@@ -15,7 +15,6 @@ use solana_sdk::system_transaction::SystemTransaction;
 use solana_sdk::transaction::Transaction;
 use solana_sdk::vote_program::{self, Vote, VoteProgram};
 use solana_sdk::vote_transaction::VoteTransaction;
-use solana_vote_signer::rpc::LocalVoteSigner;
 use std::io::Cursor;
 use std::sync::Arc;
 
@@ -495,7 +494,7 @@ pub fn make_active_set_entries(
     let mut last_entry_id = transfer_entry.id;
 
     // 2) Create and register the vote account
-    let vote_signer = VoteSignerProxy::new(active_keypair, Box::new(LocalVoteSigner::default()));
+    let vote_signer = VoteSignerProxy::new_local(active_keypair);
     let vote_account_id: Pubkey = vote_signer.vote_account;
 
     let new_vote_account_tx =
@@ -539,7 +538,6 @@ mod tests {
     use solana_sdk::hash::Hash;
     use solana_sdk::pubkey::Pubkey;
     use solana_sdk::signature::{Keypair, KeypairUtil};
-    use solana_vote_signer::rpc::LocalVoteSigner;
     use std::hash::Hash as StdHash;
     use std::iter::FromIterator;
     use std::sync::Arc;
@@ -590,10 +588,7 @@ mod tests {
         for i in 0..num_validators {
             let new_validator = Keypair::new();
             let new_pubkey = new_validator.pubkey();
-            let vote_signer = VoteSignerProxy::new(
-                &Arc::new(new_validator),
-                Box::new(LocalVoteSigner::default()),
-            );
+            let vote_signer = VoteSignerProxy::new_local(&Arc::new(new_validator));
             validators.push(new_pubkey);
             // Give the validator some tokens
             bank.transfer(
@@ -720,8 +715,7 @@ mod tests {
                 .unwrap();
 
             // Create a vote account
-            let vote_signer =
-                VoteSignerProxy::new(&Arc::new(new_keypair), Box::new(LocalVoteSigner::default()));
+            let vote_signer = VoteSignerProxy::new_local(&Arc::new(new_keypair));
             vote_signer
                 .new_vote_account(&bank, 1 as u64, genesis_block.last_id())
                 .unwrap();
@@ -742,8 +736,7 @@ mod tests {
                 .unwrap();
 
             // Create a vote account
-            let vote_signer =
-                VoteSignerProxy::new(&Arc::new(new_keypair), Box::new(LocalVoteSigner::default()));
+            let vote_signer = VoteSignerProxy::new_local(&Arc::new(new_keypair));
             vote_signer
                 .new_vote_account(&bank, 1 as u64, genesis_block.last_id())
                 .unwrap();
@@ -1005,10 +998,7 @@ mod tests {
         for i in 0..num_validators {
             let new_validator = Keypair::new();
             let new_pubkey = new_validator.pubkey();
-            let vote_signer = VoteSignerProxy::new(
-                &Arc::new(new_validator),
-                Box::new(LocalVoteSigner::default()),
-            );
+            let vote_signer = VoteSignerProxy::new_local(&Arc::new(new_validator));
             validators.push(new_pubkey);
             // Give the validator some tokens
             bank.transfer(
@@ -1071,10 +1061,7 @@ mod tests {
         // window
         let initial_vote_height = 1;
 
-        let vote_signer = VoteSignerProxy::new(
-            &Arc::new(leader_keypair),
-            Box::new(LocalVoteSigner::default()),
-        );
+        let vote_signer = VoteSignerProxy::new_local(&Arc::new(leader_keypair));
         // Create a vote account
         vote_signer
             .new_vote_account(&bank, 1 as u64, genesis_block.last_id())
@@ -1221,10 +1208,7 @@ mod tests {
             bank.transfer(5, &mint_keypair, validator_id, last_id)
                 .unwrap();
             // Create a vote account
-            let vote_signer = VoteSignerProxy::new(
-                &Arc::new(validator_keypair),
-                Box::new(LocalVoteSigner::default()),
-            );
+            let vote_signer = VoteSignerProxy::new_local(&Arc::new(validator_keypair));
             vote_signer
                 .new_vote_account(&bank, 1 as u64, genesis_block.last_id())
                 .unwrap();
@@ -1261,10 +1245,7 @@ mod tests {
         .unwrap();
 
         // Create a vote account
-        let vote_signer = VoteSignerProxy::new(
-            &Arc::new(bootstrap_leader_keypair),
-            Box::new(LocalVoteSigner::default()),
-        );
+        let vote_signer = VoteSignerProxy::new_local(&Arc::new(bootstrap_leader_keypair));
         vote_signer
             .new_vote_account(&bank, vote_account_tokens as u64, genesis_block.last_id())
             .unwrap();
@@ -1387,10 +1368,7 @@ mod tests {
         // Create a vote account for the validator
         bank.transfer(5, &mint_keypair, validator_id, last_id)
             .unwrap();
-        let vote_signer = VoteSignerProxy::new(
-            &Arc::new(validator_keypair),
-            Box::new(LocalVoteSigner::default()),
-        );
+        let vote_signer = VoteSignerProxy::new_local(&Arc::new(validator_keypair));
         vote_signer
             .new_vote_account(&bank, 1 as u64, genesis_block.last_id())
             .unwrap();
@@ -1404,10 +1382,7 @@ mod tests {
         // Create a vote account for the leader
         bank.transfer(5, &mint_keypair, bootstrap_leader_id, last_id)
             .unwrap();
-        let vote_signer = VoteSignerProxy::new(
-            &Arc::new(bootstrap_leader_keypair),
-            Box::new(LocalVoteSigner::default()),
-        );
+        let vote_signer = VoteSignerProxy::new_local(&Arc::new(bootstrap_leader_keypair));
         vote_signer
             .new_vote_account(&bank, 1 as u64, genesis_block.last_id())
             .unwrap();

--- a/src/replay_stage.rs
+++ b/src/replay_stage.rs
@@ -293,7 +293,6 @@ mod test {
     use crate::vote_signer_proxy::VoteSignerProxy;
     use solana_sdk::hash::Hash;
     use solana_sdk::signature::{Keypair, KeypairUtil};
-    use solana_vote_signer::rpc::LocalVoteSigner;
     use std::fs::remove_dir_all;
     use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::mpsc::channel;
@@ -474,10 +473,7 @@ mod test {
         let (entry_sender, entry_receiver) = channel();
         let exit = Arc::new(AtomicBool::new(false));
         let my_keypair = Arc::new(my_keypair);
-        let vote_signer = Arc::new(VoteSignerProxy::new(
-            &my_keypair,
-            Box::new(LocalVoteSigner::default()),
-        ));
+        let vote_signer = Arc::new(VoteSignerProxy::new_local(&my_keypair));
         let (to_leader_sender, _) = channel();
         let (replay_stage, ledger_writer_recv) = ReplayStage::new(
             my_keypair.clone(),
@@ -692,10 +688,7 @@ mod test {
             .expect("Expected to err out");
 
         let my_keypair = Arc::new(my_keypair);
-        let vote_signer = Arc::new(VoteSignerProxy::new(
-            &my_keypair,
-            Box::new(LocalVoteSigner::default()),
-        ));
+        let vote_signer = Arc::new(VoteSignerProxy::new_local(&my_keypair));
         let res = ReplayStage::process_entries(
             &Arc::new(Bank::default()),
             &cluster_info_me,

--- a/src/thin_client.rs
+++ b/src/thin_client.rs
@@ -452,7 +452,6 @@ mod tests {
     use solana_sdk::system_instruction::SystemInstruction;
     use solana_sdk::vote_program::VoteProgram;
     use solana_sdk::vote_transaction::VoteTransaction;
-    use solana_vote_signer::rpc::LocalVoteSigner;
     use std::fs::remove_dir_all;
 
     #[test]
@@ -473,8 +472,7 @@ mod tests {
         )));
         bank.leader_scheduler = leader_scheduler;
         let vote_account_keypair = Arc::new(Keypair::new());
-        let vote_signer =
-            VoteSignerProxy::new(&vote_account_keypair, Box::new(LocalVoteSigner::default()));
+        let vote_signer = VoteSignerProxy::new_local(&vote_account_keypair);
         let last_id = bank.last_id();
         let server = Fullnode::new_with_bank(
             leader_keypair,
@@ -527,8 +525,7 @@ mod tests {
         )));
         bank.leader_scheduler = leader_scheduler;
         let vote_account_keypair = Arc::new(Keypair::new());
-        let vote_signer =
-            VoteSignerProxy::new(&vote_account_keypair, Box::new(LocalVoteSigner::default()));
+        let vote_signer = VoteSignerProxy::new_local(&vote_account_keypair);
         let last_id = bank.last_id();
         let server = Fullnode::new_with_bank(
             leader_keypair,
@@ -587,8 +584,7 @@ mod tests {
         )));
         bank.leader_scheduler = leader_scheduler;
         let vote_account_keypair = Arc::new(Keypair::new());
-        let vote_signer =
-            VoteSignerProxy::new(&vote_account_keypair, Box::new(LocalVoteSigner::default()));
+        let vote_signer = VoteSignerProxy::new_local(&vote_account_keypair);
         let entry_height = 0;
         let last_id = bank.last_id();
         let server = Fullnode::new_with_bank(
@@ -633,10 +629,7 @@ mod tests {
         )));
         bank.leader_scheduler = leader_scheduler;
         let leader_vote_account_keypair = Arc::new(Keypair::new());
-        let vote_signer = VoteSignerProxy::new(
-            &leader_vote_account_keypair,
-            Box::new(LocalVoteSigner::default()),
-        );
+        let vote_signer = VoteSignerProxy::new_local(&leader_vote_account_keypair);
         let server = Fullnode::new_with_bank(
             leader_keypair,
             Some(Arc::new(vote_signer)),
@@ -729,8 +722,7 @@ mod tests {
         )));
         bank.leader_scheduler = leader_scheduler;
         let vote_account_keypair = Arc::new(Keypair::new());
-        let vote_signer =
-            VoteSignerProxy::new(&vote_account_keypair, Box::new(LocalVoteSigner::default()));
+        let vote_signer = VoteSignerProxy::new_local(&vote_account_keypair);
         let last_id = bank.last_id();
         let entry_height = 0;
         let server = Fullnode::new_with_bank(

--- a/src/tvu.rs
+++ b/src/tvu.rs
@@ -199,7 +199,6 @@ pub mod tests {
     use solana_sdk::signature::{Keypair, KeypairUtil};
     use solana_sdk::system_transaction::SystemTransaction;
     use solana_sdk::transaction::Transaction;
-    use solana_vote_signer::rpc::LocalVoteSigner;
     use std::fs::remove_dir_all;
     use std::net::UdpSocket;
     use std::sync::atomic::{AtomicBool, Ordering};
@@ -280,8 +279,7 @@ pub mod tests {
         let db_ledger =
             DbLedger::open(&db_ledger_path).expect("Expected to successfully open ledger");
         let vote_account_keypair = Arc::new(Keypair::new());
-        let vote_signer =
-            VoteSignerProxy::new(&vote_account_keypair, Box::new(LocalVoteSigner::default()));
+        let vote_signer = VoteSignerProxy::new_local(&vote_account_keypair);
         let (sender, _) = channel();
         let tvu = Tvu::new(
             Some(Arc::new(vote_signer)),

--- a/src/vote_signer_proxy.rs
+++ b/src/vote_signer_proxy.rs
@@ -16,6 +16,7 @@ use solana_sdk::signature::{Keypair, KeypairUtil, Signature};
 use solana_sdk::transaction::Transaction;
 use solana_sdk::vote_program::Vote;
 use solana_sdk::vote_transaction::VoteTransaction;
+use solana_vote_signer::rpc::LocalVoteSigner;
 use solana_vote_signer::rpc::VoteSigner;
 use std::net::SocketAddr;
 use std::sync::atomic::AtomicUsize;
@@ -96,6 +97,10 @@ impl VoteSignerProxy {
             last_leader: RwLock::new(vote_account),
             unsent_votes: RwLock::new(vec![]),
         }
+    }
+
+    pub fn new_local(keypair: &Arc<Keypair>) -> Self {
+        Self::new(keypair, Box::new(LocalVoteSigner::default()))
     }
 
     pub fn new_vote_account(&self, bank: &Bank, num_tokens: u64, last_id: Hash) -> Result<()> {
@@ -209,7 +214,6 @@ mod test {
     use crate::genesis_block::GenesisBlock;
     use crate::vote_signer_proxy::VoteSignerProxy;
     use solana_sdk::signature::{Keypair, KeypairUtil};
-    use solana_vote_signer::rpc::LocalVoteSigner;
     use std::sync::mpsc::channel;
     use std::sync::{Arc, RwLock};
     use std::time::Duration;
@@ -218,10 +222,7 @@ mod test {
     pub fn test_pending_votes() {
         solana_logger::setup();
 
-        let signer = VoteSignerProxy::new(
-            &Arc::new(Keypair::new()),
-            Box::new(LocalVoteSigner::default()),
-        );
+        let signer = VoteSignerProxy::new_local(&Arc::new(Keypair::new()));
 
         // Set up dummy node to host a ReplayStage
         let my_keypair = Keypair::new();

--- a/tests/multinode.rs
+++ b/tests/multinode.rs
@@ -24,7 +24,6 @@ use solana_sdk::signature::{Keypair, KeypairUtil};
 use solana_sdk::system_transaction::SystemTransaction;
 use solana_sdk::timing::duration_as_s;
 use solana_sdk::transaction::Transaction;
-use solana_vote_signer::rpc::LocalVoteSigner;
 use std::collections::{HashSet, VecDeque};
 use std::env;
 use std::fs::remove_dir_all;
@@ -154,7 +153,7 @@ fn test_multi_node_ledger_window() -> result::Result<()> {
             .unwrap();
     }
 
-    let signer_proxy = VoteSignerProxy::new(&leader_keypair, Box::new(LocalVoteSigner::default()));
+    let signer_proxy = VoteSignerProxy::new_local(&leader_keypair);
     let leader = Fullnode::new(
         leader,
         &leader_ledger_path,
@@ -174,7 +173,7 @@ fn test_multi_node_ledger_window() -> result::Result<()> {
     let validator_pubkey = keypair.pubkey().clone();
     let validator = Node::new_localhost_with_pubkey(keypair.pubkey());
     let validator_data = validator.info.clone();
-    let signer_proxy = VoteSignerProxy::new(&keypair, Box::new(LocalVoteSigner::default()));
+    let signer_proxy = VoteSignerProxy::new_local(&keypair);
     let validator = Fullnode::new(
         validator,
         &zero_ledger_path,
@@ -258,7 +257,7 @@ fn test_multi_node_validator_catchup_from_zero() -> result::Result<()> {
         "multi_node_validator_catchup_from_zero",
     );
     ledger_paths.push(leader_ledger_path.clone());
-    let signer_proxy = VoteSignerProxy::new(&leader_keypair, Box::new(LocalVoteSigner::default()));
+    let signer_proxy = VoteSignerProxy::new_local(&leader_keypair);
     let server = Fullnode::new(
         leader,
         &leader_ledger_path,
@@ -292,7 +291,7 @@ fn test_multi_node_validator_catchup_from_zero() -> result::Result<()> {
             validator_pubkey, validator_balance
         );
 
-        let signer_proxy = VoteSignerProxy::new(&keypair, Box::new(LocalVoteSigner::default()));
+        let signer_proxy = VoteSignerProxy::new_local(&keypair);
         let val = Fullnode::new(
             validator,
             &ledger_path,
@@ -353,7 +352,7 @@ fn test_multi_node_validator_catchup_from_zero() -> result::Result<()> {
     let keypair = Arc::new(Keypair::new());
     let validator_pubkey = keypair.pubkey().clone();
     let validator = Node::new_localhost_with_pubkey(keypair.pubkey());
-    let signer_proxy = VoteSignerProxy::new(&keypair, Box::new(LocalVoteSigner::default()));
+    let signer_proxy = VoteSignerProxy::new_local(&keypair);
     info!("created start from zero validator {:?}", validator_pubkey);
 
     let val = Fullnode::new(
@@ -445,7 +444,7 @@ fn test_multi_node_basic() {
     let leader_ledger_path = tmp_copy_ledger(&genesis_ledger_path, "multi_node_basic");
     ledger_paths.push(leader_ledger_path.clone());
 
-    let signer_proxy = VoteSignerProxy::new(&leader_keypair, Box::new(LocalVoteSigner::default()));
+    let signer_proxy = VoteSignerProxy::new_local(&leader_keypair);
     let server = Fullnode::new(
         leader,
         &leader_ledger_path,
@@ -475,7 +474,7 @@ fn test_multi_node_basic() {
             "validator {}, balance {}",
             validator_pubkey, validator_balance
         );
-        let signer_proxy = VoteSignerProxy::new(&keypair, Box::new(LocalVoteSigner::default()));
+        let signer_proxy = VoteSignerProxy::new_local(&keypair);
         let val = Fullnode::new(
             validator,
             &ledger_path,
@@ -555,7 +554,7 @@ fn test_boot_validator_from_file() -> result::Result<()> {
     ledger_paths.push(leader_ledger_path.clone());
 
     let leader_data = leader.info.clone();
-    let signer_proxy = VoteSignerProxy::new(&leader_keypair, Box::new(LocalVoteSigner::default()));
+    let signer_proxy = VoteSignerProxy::new_local(&leader_keypair);
     let leader_fullnode = Fullnode::new(
         leader,
         &leader_ledger_path,
@@ -580,7 +579,7 @@ fn test_boot_validator_from_file() -> result::Result<()> {
     let validator_data = validator.info.clone();
     let ledger_path = tmp_copy_ledger(&genesis_ledger_path, "boot_validator_from_file");
     ledger_paths.push(ledger_path.clone());
-    let signer_proxy = VoteSignerProxy::new(&keypair, Box::new(LocalVoteSigner::default()));
+    let signer_proxy = VoteSignerProxy::new_local(&keypair);
     let val_fullnode = Fullnode::new(
         validator,
         &ledger_path,
@@ -646,10 +645,7 @@ fn test_leader_restart_validator_start_from_old_ledger() -> result::Result<()> {
     );
     let bob_pubkey = Keypair::new().pubkey();
 
-    let signer_proxy = Arc::new(VoteSignerProxy::new(
-        &leader_keypair,
-        Box::new(LocalVoteSigner::default()),
-    ));
+    let signer_proxy = Arc::new(VoteSignerProxy::new_local(&leader_keypair));
 
     {
         let (leader_data, leader_fullnode) =
@@ -693,7 +689,7 @@ fn test_leader_restart_validator_start_from_old_ledger() -> result::Result<()> {
     let validator = Node::new_localhost_with_pubkey(keypair.pubkey());
     let validator_data = validator.info.clone();
 
-    let signer_proxy = VoteSignerProxy::new(&keypair, Box::new(LocalVoteSigner::default()));
+    let signer_proxy = VoteSignerProxy::new_local(&keypair);
     let val_fullnode = Fullnode::new(
         validator,
         &stale_ledger_path,
@@ -762,7 +758,7 @@ fn test_multi_node_dynamic_network() {
 
     let leader_ledger_path = tmp_copy_ledger(&genesis_ledger_path, "multi_node_dynamic_network");
     ledger_paths.push(leader_ledger_path.clone());
-    let signer_proxy = VoteSignerProxy::new(&leader_keypair, Box::new(LocalVoteSigner::default()));
+    let signer_proxy = VoteSignerProxy::new_local(&leader_keypair);
     let server = Fullnode::new(
         leader,
         &leader_ledger_path,
@@ -834,8 +830,7 @@ fn test_multi_node_dynamic_network() {
                     let rd = validator.info.clone();
                     info!("starting {} {}", keypair.pubkey(), rd.id);
                     let keypair = Arc::new(keypair);
-                    let signer_proxy =
-                        VoteSignerProxy::new(&keypair, Box::new(LocalVoteSigner::default()));
+                    let signer_proxy = VoteSignerProxy::new_local(&keypair);
                     let val = Fullnode::new(
                         validator,
                         &ledger_path,
@@ -1018,7 +1013,7 @@ fn test_leader_to_validator_transition() {
         Some(bootstrap_height),
     );
 
-    let signer_proxy = VoteSignerProxy::new(&leader_keypair, Box::new(LocalVoteSigner::default()));
+    let signer_proxy = VoteSignerProxy::new_local(&leader_keypair);
     let mut leader = Fullnode::new(
         leader_node,
         &leader_ledger_path,
@@ -1173,8 +1168,7 @@ fn test_leader_validator_basic() {
     );
 
     // Start the validator node
-    let signer_proxy =
-        VoteSignerProxy::new(&validator_keypair, Box::new(LocalVoteSigner::default()));
+    let signer_proxy = VoteSignerProxy::new_local(&validator_keypair);
     let mut validator = Fullnode::new(
         validator_node,
         &validator_ledger_path,
@@ -1187,7 +1181,7 @@ fn test_leader_validator_basic() {
     );
 
     // Start the leader fullnode
-    let signer_proxy = VoteSignerProxy::new(&leader_keypair, Box::new(LocalVoteSigner::default()));
+    let signer_proxy = VoteSignerProxy::new_local(&leader_keypair);
     let mut leader = Fullnode::new(
         leader_node,
         &leader_ledger_path,
@@ -1378,10 +1372,7 @@ fn test_dropped_handoff_recovery() {
     info!("bootstrap_leader: {}", bootstrap_leader_keypair.pubkey());
     info!("'next leader': {}", next_leader_keypair.pubkey());
 
-    let signer_proxy = VoteSignerProxy::new(
-        &bootstrap_leader_keypair,
-        Box::new(LocalVoteSigner::default()),
-    );
+    let signer_proxy = VoteSignerProxy::new_local(&bootstrap_leader_keypair);
     // Start up the bootstrap leader fullnode
     let bootstrap_leader_ledger_path =
         tmp_copy_ledger(&genesis_ledger_path, "test_dropped_handoff_recovery");
@@ -1408,7 +1399,7 @@ fn test_dropped_handoff_recovery() {
         let validator_id = kp.pubkey();
         info!("validator {}: {}", i, validator_id);
         let validator_node = Node::new_localhost_with_pubkey(validator_id);
-        let signer_proxy = VoteSignerProxy::new(&kp, Box::new(LocalVoteSigner::default()));
+        let signer_proxy = VoteSignerProxy::new_local(&kp);
         let validator = Fullnode::new(
             validator_node,
             &validator_ledger_path,
@@ -1435,8 +1426,7 @@ fn test_dropped_handoff_recovery() {
 
     info!("Starting the 'next leader' node");
     let next_leader_node = Node::new_localhost_with_pubkey(next_leader_keypair.pubkey());
-    let signer_proxy =
-        VoteSignerProxy::new(&next_leader_keypair, Box::new(LocalVoteSigner::default()));
+    let signer_proxy = VoteSignerProxy::new_local(&next_leader_keypair);
     let next_leader = Fullnode::new(
         next_leader_node,
         &next_leader_ledger_path,
@@ -1584,7 +1574,7 @@ fn test_full_leader_validator_network() {
 
         let validator_id = kp.pubkey();
         let validator_node = Node::new_localhost_with_pubkey(validator_id);
-        let signer_proxy = VoteSignerProxy::new(&kp, Box::new(LocalVoteSigner::default()));
+        let signer_proxy = VoteSignerProxy::new_local(&kp);
         let leader_scheduler =
             Arc::new(RwLock::new(LeaderScheduler::new(&leader_scheduler_config)));
         let validator = Fullnode::new(
@@ -1603,7 +1593,7 @@ fn test_full_leader_validator_network() {
     }
 
     info!("Start up the bootstrap leader");
-    let signer_proxy = VoteSignerProxy::new(&leader_keypair, Box::new(LocalVoteSigner::default()));
+    let signer_proxy = VoteSignerProxy::new_local(&leader_keypair);
     let leader_scheduler = Arc::new(RwLock::new(LeaderScheduler::new(&leader_scheduler_config)));
     let bootstrap_leader = Fullnode::new(
         bootstrap_leader_node,
@@ -1782,10 +1772,7 @@ fn test_broadcast_last_tick() {
 
     // Start up the bootstrap leader fullnode
     let bootstrap_leader_keypair = Arc::new(bootstrap_leader_keypair);
-    let signer_proxy = VoteSignerProxy::new(
-        &bootstrap_leader_keypair,
-        Box::new(LocalVoteSigner::default()),
-    );
+    let signer_proxy = VoteSignerProxy::new_local(&bootstrap_leader_keypair);
     let mut bootstrap_leader = Fullnode::new(
         bootstrap_leader_node,
         &bootstrap_leader_ledger_path,

--- a/tests/replicator.rs
+++ b/tests/replicator.rs
@@ -21,7 +21,6 @@ use solana_sdk::hash::Hash;
 use solana_sdk::signature::{Keypair, KeypairUtil};
 use solana_sdk::system_transaction::SystemTransaction;
 use solana_sdk::transaction::Transaction;
-use solana_vote_signer::rpc::LocalVoteSigner;
 use std::fs::remove_dir_all;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::channel;
@@ -48,8 +47,7 @@ fn test_replicator_startup() {
         tmp_copy_ledger(&leader_ledger_path, "replicator_test_validator_ledger");
 
     {
-        let signer_proxy =
-            VoteSignerProxy::new(&leader_keypair, Box::new(LocalVoteSigner::default()));
+        let signer_proxy = VoteSignerProxy::new_local(&leader_keypair);
 
         let leader = Fullnode::new_with_storage_rotate(
             leader_node,
@@ -66,8 +64,7 @@ fn test_replicator_startup() {
         );
 
         let validator_keypair = Arc::new(Keypair::new());
-        let signer_proxy =
-            VoteSignerProxy::new(&validator_keypair, Box::new(LocalVoteSigner::default()));
+        let signer_proxy = VoteSignerProxy::new_local(&validator_keypair);
 
         let mut leader_client = mk_client(&leader_info);
 
@@ -277,8 +274,7 @@ fn test_replicator_startup_ledger_hang() {
         tmp_copy_ledger(&leader_ledger_path, "replicator_test_validator_ledger");
 
     {
-        let signer_proxy =
-            VoteSignerProxy::new(&leader_keypair, Box::new(LocalVoteSigner::default()));
+        let signer_proxy = VoteSignerProxy::new_local(&leader_keypair);
 
         let _ = Fullnode::new(
             leader_node,
@@ -294,8 +290,7 @@ fn test_replicator_startup_ledger_hang() {
         );
 
         let validator_keypair = Arc::new(Keypair::new());
-        let signer_proxy =
-            VoteSignerProxy::new(&validator_keypair, Box::new(LocalVoteSigner::default()));
+        let signer_proxy = VoteSignerProxy::new_local(&validator_keypair);
         let validator_node = Node::new_localhost_with_pubkey(validator_keypair.pubkey());
 
         let _ = Fullnode::new(

--- a/tests/rpc.rs
+++ b/tests/rpc.rs
@@ -14,7 +14,6 @@ use solana::vote_signer_proxy::VoteSignerProxy;
 use solana_sdk::signature::{Keypair, KeypairUtil};
 use solana_sdk::system_transaction::SystemTransaction;
 use solana_sdk::transaction::Transaction;
-use solana_vote_signer::rpc::LocalVoteSigner;
 use std::fs::remove_dir_all;
 use std::sync::{Arc, RwLock};
 use std::thread::sleep;
@@ -42,8 +41,7 @@ fn test_rpc_send_tx() {
     bank.leader_scheduler = leader_scheduler;
 
     let vote_account_keypair = Arc::new(Keypair::new());
-    let vote_signer =
-        VoteSignerProxy::new(&vote_account_keypair, Box::new(LocalVoteSigner::default()));
+    let vote_signer = VoteSignerProxy::new_local(&vote_account_keypair);
     let entry_height = 0;
     let server = Fullnode::new_with_bank(
         leader_keypair,

--- a/wallet/tests/deploy.rs
+++ b/wallet/tests/deploy.rs
@@ -11,7 +11,6 @@ use solana::vote_signer_proxy::VoteSignerProxy;
 use solana_drone::drone::run_local_drone;
 use solana_sdk::bpf_loader;
 use solana_sdk::signature::{Keypair, KeypairUtil};
-use solana_vote_signer::rpc::LocalVoteSigner;
 use solana_wallet::wallet::{process_command, WalletCommand, WalletConfig};
 use std::fs::{remove_dir_all, File};
 use std::io::Read;
@@ -41,8 +40,7 @@ fn test_wallet_deploy_program() {
     )));
     bank.leader_scheduler = leader_scheduler;
     let vote_account_keypair = Arc::new(Keypair::new());
-    let vote_signer =
-        VoteSignerProxy::new(&vote_account_keypair, Box::new(LocalVoteSigner::default()));
+    let vote_signer = VoteSignerProxy::new_local(&vote_account_keypair);
     let last_id = bank.last_id();
     let server = Fullnode::new_with_bank(
         leader_keypair,

--- a/wallet/tests/pay.rs
+++ b/wallet/tests/pay.rs
@@ -12,7 +12,6 @@ use solana::vote_signer_proxy::VoteSignerProxy;
 use solana_drone::drone::run_local_drone;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::{Keypair, KeypairUtil};
-use solana_vote_signer::rpc::LocalVoteSigner;
 use solana_wallet::wallet::{
     process_command, request_and_confirm_airdrop, WalletCommand, WalletConfig,
 };
@@ -46,8 +45,7 @@ fn test_wallet_timestamp_tx() {
     )));
     bank.leader_scheduler = leader_scheduler;
     let vote_account_keypair = Arc::new(Keypair::new());
-    let vote_signer =
-        VoteSignerProxy::new(&vote_account_keypair, Box::new(LocalVoteSigner::default()));
+    let vote_signer = VoteSignerProxy::new_local(&vote_account_keypair);
     let last_id = bank.last_id();
     let server = Fullnode::new_with_bank(
         leader_keypair,
@@ -142,8 +140,7 @@ fn test_wallet_witness_tx() {
     )));
     bank.leader_scheduler = leader_scheduler;
     let vote_account_keypair = Arc::new(Keypair::new());
-    let vote_signer =
-        VoteSignerProxy::new(&vote_account_keypair, Box::new(LocalVoteSigner::default()));
+    let vote_signer = VoteSignerProxy::new_local(&vote_account_keypair);
     let last_id = bank.last_id();
     let server = Fullnode::new_with_bank(
         leader_keypair,
@@ -234,8 +231,7 @@ fn test_wallet_cancel_tx() {
     )));
     bank.leader_scheduler = leader_scheduler;
     let vote_account_keypair = Arc::new(Keypair::new());
-    let vote_signer =
-        VoteSignerProxy::new(&vote_account_keypair, Box::new(LocalVoteSigner::default()));
+    let vote_signer = VoteSignerProxy::new_local(&vote_account_keypair);
     let last_id = bank.last_id();
     let server = Fullnode::new_with_bank(
         leader_keypair,

--- a/wallet/tests/request_airdrop.rs
+++ b/wallet/tests/request_airdrop.rs
@@ -10,7 +10,6 @@ use solana::storage_stage::STORAGE_ROTATE_TEST_COUNT;
 use solana::vote_signer_proxy::VoteSignerProxy;
 use solana_drone::drone::run_local_drone;
 use solana_sdk::signature::{Keypair, KeypairUtil};
-use solana_vote_signer::rpc::LocalVoteSigner;
 use solana_wallet::wallet::{process_command, WalletCommand, WalletConfig};
 use std::fs::remove_dir_all;
 use std::sync::mpsc::channel;
@@ -32,8 +31,7 @@ fn test_wallet_request_airdrop() {
     )));
     bank.leader_scheduler = leader_scheduler;
     let vote_account_keypair = Arc::new(Keypair::new());
-    let vote_signer =
-        VoteSignerProxy::new(&vote_account_keypair, Box::new(LocalVoteSigner::default()));
+    let vote_signer = VoteSignerProxy::new_local(&vote_account_keypair);
     let last_id = bank.last_id();
     let server = Fullnode::new_with_bank(
         leader_keypair,


### PR DESCRIPTION
#### Problem

Tests hard to read.

#### Summary of Changes

Add a `new_local` constructor to have it use the default `LocalVoteSigner`
