### PR TITLE
Push and query the ClusterInfo for votes.

### DIFF
--- a/src/crds_value.rs
+++ b/src/crds_value.rs
@@ -10,8 +10,7 @@ use std::fmt;
 pub enum CrdsValue {
     /// * Merge Strategy - Latest wallclock is picked
     ContactInfo(ContactInfo),
-    /// TODO, Votes need a height potentially in the userdata
-    /// * Merge Strategy - Latest height is picked
+    /// * Merge Strategy - Latest wallclock is picked
     Vote(Vote),
     /// * Merge Strategy - Latest wallclock is picked
     LeaderId(LeaderId),
@@ -29,7 +28,6 @@ pub struct LeaderId {
 pub struct Vote {
     pub transaction: Transaction,
     pub signature: Signature,
-    pub height: u64,
     pub wallclock: u64,
 }
 
@@ -71,12 +69,10 @@ impl Signable for Vote {
         #[derive(Serialize)]
         struct SignData {
             transaction: Transaction,
-            height: u64,
             wallclock: u64,
         }
         let data = SignData {
             transaction: self.transaction.clone(),
-            height: self.height,
             wallclock: self.wallclock,
         };
         serialize(&data).expect("unable to serialize Vote")
@@ -132,11 +128,11 @@ impl LeaderId {
 }
 
 impl Vote {
-    pub fn new(transaction: Transaction, height: u64, wallclock: u64) -> Self {
+    // TODO: it might make sense for the transaction to encode the wallclock in the userdata
+    pub fn new(transaction: Transaction, wallclock: u64) -> Self {
         Vote {
             transaction,
             signature: Signature::default(),
-            height,
             wallclock,
         }
     }
@@ -260,7 +256,7 @@ mod test {
         let key = v.clone().contact_info().unwrap().id;
         assert_eq!(v.label(), CrdsValueLabel::ContactInfo(key));
 
-        let v = CrdsValue::Vote(Vote::new(test_tx(), 1, 0));
+        let v = CrdsValue::Vote(Vote::new(test_tx(), 0));
         assert_eq!(v.wallclock(), 0);
         let key = v.clone().vote().unwrap().transaction.account_keys[0];
         assert_eq!(v.label(), CrdsValueLabel::Vote(key));


### PR DESCRIPTION
#### Problem

Need a way for the cluster to receive and send all the votes in the network regardless of leader failures.

#### Summary of Changes

Push votes into the crds, which will propagate them around the network.  Leaders should call ClusterInfo::get_votes periodically (like on every tick) and process the vector like a batch of transactions.  The bank will naturally drop any old or invalid votes.

Fixes #
