### PR TITLE
Alphabetize and make consistent fullnode arguments

### DIFF
--- a/fullnode/src/main.rs
+++ b/fullnode/src/main.rs
@@ -131,17 +131,6 @@ fn main() {
     let matches = App::new("fullnode")
         .version(crate_version!())
         .arg(
-            Arg::with_name("nosigverify")
-                .short("v")
-                .long("nosigverify")
-                .help("Run without signature verification"),
-        )
-        .arg(
-            Arg::with_name("no-leader-rotation")
-                .long("no-leader-rotation")
-                .help("Disable leader rotation"),
-        )
-        .arg(
             Arg::with_name("identity")
                 .short("i")
                 .long("identity")
@@ -150,20 +139,11 @@ fn main() {
                 .help("Run with the identity found in FILE"),
         )
         .arg(
-            Arg::with_name("network")
-                .short("n")
-                .long("network")
-                .value_name("HOST:PORT")
+            Arg::with_name("init_complete_file")
+                .long("init-complete-file")
+                .value_name("FILE")
                 .takes_value(true)
-                .help("Rendezvous with the cluster at this gossip entry point"),
-        )
-        .arg(
-            Arg::with_name("signer")
-                .short("s")
-                .long("signer")
-                .value_name("HOST:PORT")
-                .takes_value(true)
-                .help("Rendezvous with the vote signer at this RPC end point"),
+                .help("Create this file, if it doesn't already exist, once node initialization is complete"),
         )
         .arg(
             Arg::with_name("ledger")
@@ -175,18 +155,17 @@ fn main() {
                 .help("Use DIR as persistent ledger location"),
         )
         .arg(
-            Arg::with_name("rpc_port")
-                .long("rpc-port")
-                .value_name("PORT")
+            Arg::with_name("network")
+                .short("n")
+                .long("network")
+                .value_name("HOST:PORT")
                 .takes_value(true)
-                .help("RPC port to use for this node"),
+                .help("Rendezvous with the cluster at this gossip entry point"),
         )
         .arg(
-            Arg::with_name("init_complete_file")
-                .long("init-complete-file")
-                .value_name("FILE")
-                .takes_value(true)
-                .help("Create this file, if it doesn't already exist, once node initialization is complete"),
+            Arg::with_name("no_leader_rotation")
+                .long("no-leader-rotation")
+                .help("Disable leader rotation"),
         )
         .arg(
             Arg::with_name("no_signer")
@@ -195,11 +174,32 @@ fn main() {
                 .conflicts_with("signer")
                 .help("Launch node without vote signer"),
         )
+        .arg(
+            Arg::with_name("no_sigverify")
+                .short("v")
+                .long("no-sigverify")
+                .help("Run without signature verification"),
+        )
+        .arg(
+            Arg::with_name("rpc_port")
+                .long("rpc-port")
+                .value_name("PORT")
+                .takes_value(true)
+                .help("RPC port to use for this node"),
+        )
+        .arg(
+            Arg::with_name("signer")
+                .short("s")
+                .long("signer")
+                .value_name("HOST:PORT")
+                .takes_value(true)
+                .help("Rendezvous with the vote signer at this RPC end point"),
+        )
         .get_matches();
 
-    let no_sigverify = matches.is_present("nosigverify");
+    let no_sigverify = matches.is_present("no_sigverify");
     let no_signer = matches.is_present("no_signer");
-    let use_only_bootstrap_leader = matches.is_present("no-leader-rotation");
+    let use_only_bootstrap_leader = matches.is_present("no_leader_rotation");
     let (keypair, gossip) = parse_identity(&matches);
     let ledger_path = matches.value_of("ledger").unwrap();
     let cluster_entrypoint = matches

--- a/multinode-demo/fullnode.sh
+++ b/multinode-demo/fullnode.sh
@@ -21,17 +21,17 @@ usage() {
     echo
   fi
   cat <<EOF
-usage: $0 [-x] [--no-leader-rotation] [--init-complete-file FILE] [--rpc-port port] [--no-signer] [rsync network path to bootstrap leader configuration] [network entry point]
+usage: $0 [-x] [--init-complete-file FILE] [--no-leader-rotation] [--no-signer] [--rpc-port port] [rsync network path to bootstrap leader configuration] [network entry point]
 
 Start a full node on the specified network
 
   -x                    - start a new, dynamically-configured full node
   -X [label]            - start or restart a dynamically-configured full node with
                           the specified label
-  --no-leader-rotation  - disable leader rotation
   --init-complete-file FILE - create this file, if it doesn't already exist, once node initialization is complete
-  --rpc-port port       - custom RPC port for this node
+  --no-leader-rotation  - disable leader rotation
   --no-signer           - start node without vote signer
+  --rpc-port port       - custom RPC port for this node
 
 EOF
   exit 1
@@ -43,9 +43,9 @@ fi
 
 maybe_init_complete_file=
 maybe_no_leader_rotation=
-self_setup=0
-maybe_rpc_port=
 maybe_no_signer=
+maybe_rpc_port=
+self_setup=0
 
 while [[ ${1:0:1} = - ]]; do
   if [[ $1 = -X ]]; then
@@ -62,12 +62,12 @@ while [[ ${1:0:1} = - ]]; do
   elif [[ $1 = --no-leader-rotation ]]; then
     maybe_no_leader_rotation="--no-leader-rotation"
     shift
-  elif [[ $1 = --rpc-port ]]; then
-    maybe_rpc_port="$1 $2"
-    shift 2
   elif [[ $1 = --no-signer ]]; then
     maybe_no_signer="--no-signer"
     shift
+  elif [[ $1 = --rpc-port ]]; then
+    maybe_rpc_port="$1 $2"
+    shift 2
   else
     echo "Unknown argument: $1"
     exit 1
@@ -241,12 +241,12 @@ if [[ ! -d "$ledger_config_dir" ]]; then
 fi
 
 trap 'kill "$pid" && wait "$pid"' INT TERM
-# shellcheck disable=SC2086 # Don't want to double quote maybe_rpc_port or maybe_init_complete_file or maybe_no_signer
+# shellcheck disable=SC2086 # Don't want to double quote maybe_init_complete_file or maybe_no_signer or maybe_rpc_port
 $program \
   $maybe_init_complete_file \
   $maybe_no_leader_rotation \
-  $maybe_rpc_port \
   $maybe_no_signer \
+  $maybe_rpc_port \
   --identity "$fullnode_json_path" \
   --network "$leader_address" \
   --ledger "$ledger_config_dir" \


### PR DESCRIPTION
#### Problem
Arguments used in fullnode launch have been added ad hoc, rather than in any purposeful order. This makes it difficult to trace functionality, or make adjustments.

#### Summary of Changes
Alphabetize fullnode args in all lists in fullnode module and bash launch script
Make fullnode clap args consistent, in terms of hyphenation and underscores

Fixes #
