### PR TITLE
eliminate re-use of a TX here, we're testing for empty account balance

### DIFF
--- a/src/bank.rs
+++ b/src/bank.rs
@@ -1510,15 +1510,17 @@ mod tests {
         let tx = Transaction::system_new(&keypair1, keypair4.pubkey(), 1, tick.id);
         let entry_2 = next_entry(&tick.id, 1, vec![tx]);
         assert_eq!(
-            bank.par_process_entries(&[entry_1.clone(), tick.clone(), entry_2]),
+            bank.par_process_entries(&[entry_1.clone(), tick.clone(), entry_2.clone()]),
             Ok(())
         );
         assert_eq!(bank.get_balance(&keypair3.pubkey()), 1);
         assert_eq!(bank.get_balance(&keypair4.pubkey()), 1);
         assert_eq!(bank.last_id(), tick.id);
-        // ensure that errors are returned
+        // ensure that an error is returned for an empty account (keypair2)
+        let tx = Transaction::system_new(&keypair2, keypair3.pubkey(), 1, tick.id);
+        let entry_3 = next_entry(&entry_2.id, 1, vec![tx]);
         assert_eq!(
-            bank.par_process_entries(&[entry_1]),
+            bank.par_process_entries(&[entry_3]),
             Err(BankError::AccountNotFound)
         );
     }


### PR DESCRIPTION
#### Problem
 this test re-uses a TX it expects to fail (and not have its signature recorded), which depends on internal bank processes for vetting TXes.  it's been fixed in other places (https://github.com/aeyakovenko/solana/commit/b0a815b7bcaac47a3c75102a6c41b8acc5efa8a6), but should land on master

 #### Summary of Changes
 construct a new TX and entry that can safely be played against the expected zero balance


