### PR TITLE
Remove storage_state from the bank

### DIFF
--- a/src/bank.rs
+++ b/src/bank.rs
@@ -13,7 +13,6 @@ use crate::leader_scheduler::LeaderScheduler;
 use crate::poh_recorder::PohRecorder;
 use crate::runtime::{self, RuntimeError};
 use crate::status_deque::{Status, StatusDeque, MAX_ENTRY_IDS};
-use crate::storage_stage::StorageState;
 use bincode::deserialize;
 use itertools::Itertools;
 use log::Level;
@@ -112,8 +111,6 @@ pub struct Bank {
     /// processed by the bank
     pub leader_scheduler: Arc<RwLock<LeaderScheduler>>,
 
-    pub storage_state: StorageState,
-
     subscriptions: RwLock<Box<Arc<BankSubscriptions + Send + Sync>>>,
 }
 
@@ -124,7 +121,6 @@ impl Default for Bank {
             last_ids: RwLock::new(StatusDeque::default()),
             confirmation_time: AtomicUsize::new(std::usize::MAX),
             leader_scheduler: Arc::new(RwLock::new(LeaderScheduler::default())),
-            storage_state: StorageState::new(),
             subscriptions: RwLock::new(Box::new(Arc::new(LocalSubscriptions::default()))),
         }
     }
@@ -296,11 +292,6 @@ impl Bank {
             .unwrap()
             .last_id
             .expect("no last_id has been set")
-    }
-
-    pub fn get_pubkeys_for_entry_height(&self, entry_height: u64) -> Vec<Pubkey> {
-        self.storage_state
-            .get_pubkeys_for_entry_height(entry_height)
     }
 
     pub fn get_storage_entry_height(&self) -> u64 {
@@ -1882,7 +1873,6 @@ mod tests {
 
         assert_eq!(bank.get_storage_entry_height(), ENTRIES_PER_SEGMENT);
         assert_eq!(bank.get_storage_last_id(), storage_last_id);
-        assert_eq!(bank.get_pubkeys_for_entry_height(0), vec![]);
     }
 
     #[test]

--- a/src/fullnode.rs
+++ b/src/fullnode.rs
@@ -10,6 +10,7 @@ use crate::leader_scheduler::LeaderScheduler;
 use crate::rpc::JsonRpcService;
 use crate::rpc_pubsub::PubSubService;
 use crate::service::Service;
+use crate::storage_stage::StorageState;
 use crate::tpu::{Tpu, TpuReturnType};
 use crate::tvu::{Sockets, Tvu, TvuReturnType};
 use crate::vote_signer_proxy::VoteSignerProxy;
@@ -232,11 +233,14 @@ impl Fullnode {
             entrypoint_drone_addr
         };
 
+        let storage_state = StorageState::new();
+
         let rpc_service = JsonRpcService::new(
             &bank,
             &cluster_info,
             SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), rpc_addr.port()),
             drone_addr,
+            storage_state.clone(),
         );
 
         let rpc_pubsub_service = PubSubService::new(
@@ -304,6 +308,7 @@ impl Fullnode {
             db_ledger.clone(),
             storage_rotate_count,
             to_leader_sender,
+            &storage_state,
         );
         let max_tick_height = {
             let ls_lock = bank.leader_scheduler.read().unwrap();

--- a/src/storage_stage.rs
+++ b/src/storage_stage.rs
@@ -48,7 +48,7 @@ pub struct StorageStateInner {
     entry_height: u64,
 }
 
-#[derive(Default)]
+#[derive(Clone, Default)]
 pub struct StorageState {
     state: Arc<RwLock<StorageStateInner>>,
 }


### PR DESCRIPTION
#### Problem

People keep asking why/what storage_state is in bank.

#### Summary of Changes

Move storage_stage out of bank. Construct in fullnode and pass to RPC and TVU->StorageStage instead.

Fixes #
