### PR TITLE
.unwrap() in tests instead of assert!()ing .is_ok() for a better failure message

### DIFF
--- a/benches/banking_stage.rs
+++ b/benches/banking_stage.rs
@@ -80,7 +80,7 @@ fn bench_banking_stage_multi_accounts(bencher: &mut Bencher) {
             0,
         );
         let x = bank.process_transaction(&fund);
-        assert!(x.is_ok());
+        x.unwrap();
     });
     //sanity check, make sure all the transactions can execute sequentially
     transactions.iter().for_each(|tx| {
@@ -190,7 +190,7 @@ fn bench_banking_stage_multi_programs(bencher: &mut Bencher) {
             genesis_block.last_id(),
             0,
         );
-        assert!(bank.process_transaction(&fund).is_ok());
+        bank.process_transaction(&fund).unwrap();
     });
     //sanity check, make sure all the transactions can execute sequentially
     transactions.iter().for_each(|tx| {

--- a/drone/src/drone.rs
+++ b/drone/src/drone.rs
@@ -424,8 +424,6 @@ mod tests {
 
         let mut drone = Drone::new(keypair, None, None);
         let response = drone.process_drone_request(&bytes);
-        assert!(response.is_ok());
-
         let response_vec = response.unwrap().to_vec();
         assert_eq!(expected_vec_with_length, response_vec);
 

--- a/programs/native/erc20/src/token_program.rs
+++ b/programs/native/erc20/src/token_program.rs
@@ -494,7 +494,7 @@ mod test {
             amount: 123,
             delegate: None,
         });
-        assert!(account.serialize(&mut userdata).is_ok());
+        account.serialize(&mut userdata).unwrap();
         assert_eq!(TokenProgram::deserialize(&userdata), Ok(account));
 
         let account = TokenProgram::Token(TokenInfo {
@@ -503,7 +503,7 @@ mod test {
             name: "A test token".to_string(),
             symbol: "TEST".to_string(),
         });
-        assert!(account.serialize(&mut userdata).is_ok());
+        account.serialize(&mut userdata).unwrap();
         assert_eq!(TokenProgram::deserialize(&userdata), Ok(account));
     }
 

--- a/programs/native/storage/src/lib.rs
+++ b/programs/native/storage/src/lib.rs
@@ -307,7 +307,7 @@ mod test {
             ENTRIES_PER_SEGMENT,
         );
 
-        assert!(test_transaction(&tx, &mut accounts).is_ok());
+        test_transaction(&tx, &mut accounts).unwrap();
 
         let tx = Transaction::storage_new_mining_proof(
             &keypair,
@@ -317,7 +317,7 @@ mod test {
             Signature::default(),
         );
 
-        assert!(test_transaction(&tx, &mut accounts).is_ok());
+        test_transaction(&tx, &mut accounts).unwrap();
     }
 
     #[test]
@@ -336,7 +336,7 @@ mod test {
             ENTRIES_PER_SEGMENT,
         );
 
-        assert!(test_transaction(&tx, &mut accounts).is_ok());
+        test_transaction(&tx, &mut accounts).unwrap();
 
         let tx = Transaction::storage_new_mining_proof(
             &keypair,
@@ -345,7 +345,7 @@ mod test {
             entry_height,
             Signature::default(),
         );
-        assert!(test_transaction(&tx, &mut accounts).is_ok());
+        test_transaction(&tx, &mut accounts).unwrap();
 
         let tx = Transaction::storage_new_advertise_last_id(
             &keypair,
@@ -353,7 +353,7 @@ mod test {
             Hash::default(),
             ENTRIES_PER_SEGMENT * 2,
         );
-        assert!(test_transaction(&tx, &mut accounts).is_ok());
+        test_transaction(&tx, &mut accounts).unwrap();
 
         let tx = Transaction::storage_new_proof_validation(
             &keypair,
@@ -361,7 +361,7 @@ mod test {
             entry_height,
             vec![ProofStatus::Valid],
         );
-        assert!(test_transaction(&tx, &mut accounts).is_ok());
+        test_transaction(&tx, &mut accounts).unwrap();
 
         let tx = Transaction::storage_new_advertise_last_id(
             &keypair,
@@ -369,10 +369,10 @@ mod test {
             Hash::default(),
             ENTRIES_PER_SEGMENT * 3,
         );
-        assert!(test_transaction(&tx, &mut accounts).is_ok());
+        test_transaction(&tx, &mut accounts).unwrap();
 
         let tx = Transaction::storage_new_reward_claim(&keypair, Hash::default(), entry_height);
-        assert!(test_transaction(&tx, &mut accounts).is_ok());
+        test_transaction(&tx, &mut accounts).unwrap();
 
         assert!(accounts[0].tokens == TOTAL_VALIDATOR_REWARDS);
     }

--- a/src/bank.rs
+++ b/src/bank.rs
@@ -1866,7 +1866,7 @@ mod tests {
             ENTRIES_PER_SEGMENT,
         );
 
-        assert!(bank.process_transaction(&tx).is_ok());
+        bank.process_transaction(&tx).unwrap();
 
         let entry_height = 0;
 
@@ -1878,7 +1878,7 @@ mod tests {
             Signature::default(),
         );
 
-        assert!(bank.process_transaction(&tx).is_ok());
+        bank.process_transaction(&tx).unwrap();
 
         assert_eq!(bank.get_storage_entry_height(), ENTRIES_PER_SEGMENT);
         assert_eq!(bank.get_storage_last_id(), storage_last_id);

--- a/src/chacha.rs
+++ b/src/chacha.rs
@@ -157,7 +157,7 @@ mod tests {
             "abcd1234abcd1234abcd1234abcd1234 abcd1234abcd1234abcd1234abcd1234
                             abcd1234abcd1234abcd1234abcd1234 abcd1234abcd1234abcd1234abcd1234"
         );
-        assert!(chacha_cbc_encrypt_ledger(&db_ledger, 0, out_path, &mut key).is_ok());
+        chacha_cbc_encrypt_ledger(&db_ledger, 0, out_path, &mut key).unwrap();
         let mut out_file = File::open(out_path).unwrap();
         let mut buf = vec![];
         let size = out_file.read_to_end(&mut buf).unwrap();

--- a/src/chacha_cuda.rs
+++ b/src/chacha_cuda.rs
@@ -141,7 +141,7 @@ mod tests {
         );
 
         let mut cpu_iv = ivecs.clone();
-        assert!(chacha_cbc_encrypt_ledger(&db_ledger, 0, out_path, &mut cpu_iv,).is_ok());
+        chacha_cbc_encrypt_ledger(&db_ledger, 0, out_path, &mut cpu_iv).unwrap();
 
         let ref_hash = sample_file(&out_path, &samples).unwrap();
 
@@ -178,7 +178,7 @@ mod tests {
             );
             ivec[0] = i;
             ivecs.extend(ivec.clone().iter());
-            assert!(chacha_cbc_encrypt_ledger(&db_ledger.clone(), 0, out_path, &mut ivec,).is_ok());
+            chacha_cbc_encrypt_ledger(&db_ledger.clone(), 0, out_path, &mut ivec).unwrap();
 
             ref_hashes.push(sample_file(&out_path, &samples).unwrap());
             info!(

--- a/src/crds_gossip.rs
+++ b/src/crds_gossip.rs
@@ -540,7 +540,7 @@ mod test {
         assert_eq!(res.err(), Some(CrdsGossipError::BadPruneDestination));
         //correct dest
         res = crds_gossip.process_prune_msg(ci.id, id, &[prune_pubkey], now, now);
-        assert!(res.is_ok());
+        res.unwrap();
         //test timeout
         let timeout = now + crds_gossip.push.prune_timeout * 2;
         res = crds_gossip.process_prune_msg(ci.id, id, &[prune_pubkey], now, timeout);

--- a/src/db_ledger.rs
+++ b/src/db_ledger.rs
@@ -1365,7 +1365,7 @@ mod tests {
 
         let ledger_path = get_tmp_ledger_path("test_genesis_and_entry_iterator");
         {
-            assert!(genesis(&ledger_path, &Keypair::new(), &entries).is_ok());
+            genesis(&ledger_path, &Keypair::new(), &entries).unwrap();
 
             let ledger = DbLedger::open(&ledger_path).expect("open failed");
 
@@ -1383,7 +1383,7 @@ mod tests {
         let ledger_path = get_tmp_ledger_path("test_genesis_and_entry_iterator");
         {
             // put entries except last 2 into ledger
-            assert!(genesis(&ledger_path, &Keypair::new(), &entries[..entries.len() - 2]).is_ok());
+            genesis(&ledger_path, &Keypair::new(), &entries[..entries.len() - 2]).unwrap();
 
             let ledger = DbLedger::open(&ledger_path).expect("open failed");
 

--- a/src/poh_recorder.rs
+++ b/src/poh_recorder.rs
@@ -132,16 +132,16 @@ mod tests {
         //send some data
         let h1 = hash(b"hello world!");
         let tx = test_tx();
-        assert!(poh_recorder.record(h1, vec![tx.clone()]).is_ok());
+        poh_recorder.record(h1, vec![tx.clone()]).unwrap();
         //get some events
         let e = entry_receiver.recv().unwrap();
         assert_eq!(e[0].tick_height, 1);
 
-        assert!(poh_recorder.tick().is_ok());
+        poh_recorder.tick().unwrap();
         let e = entry_receiver.recv().unwrap();
         assert_eq!(e[0].tick_height, 2);
 
-        assert!(poh_recorder.tick().is_ok());
+        poh_recorder.tick().unwrap();
         let e = entry_receiver.recv().unwrap();
         assert_eq!(e[0].tick_height, 3);
 

--- a/src/poh_service.rs
+++ b/src/poh_service.rs
@@ -152,7 +152,7 @@ mod tests {
                         // send some data
                         let h1 = hash(b"hello world!");
                         let tx = test_tx();
-                        assert!(poh_recorder.record(h1, vec![tx]).is_ok());
+                        poh_recorder.record(h1, vec![tx]).unwrap();
 
                         if exit.load(Ordering::Relaxed) {
                             break Ok(());
@@ -198,8 +198,8 @@ mod tests {
         }
         exit.store(true, Ordering::Relaxed);
         poh_service.exit();
-        assert!(poh_service.join().is_ok());
-        assert!(entry_producer.join().is_ok());
+        let _ = poh_service.join().unwrap();
+        let _ = entry_producer.join().unwrap();
     }
 
 }

--- a/src/replicator.rs
+++ b/src/replicator.rs
@@ -433,7 +433,6 @@ mod tests {
         let num_samples = (string.len() * num_strings / size_of::<Hash>()) as u64;
         let samples: Vec<_> = (0..num_samples).collect();
         let res = sample_file(&in_path, samples.as_slice());
-        assert!(res.is_ok());
         let ref_hash: Hash = Hash::new(&[
             173, 251, 182, 165, 10, 54, 33, 150, 133, 226, 106, 150, 99, 192, 179, 1, 230, 144,
             151, 126, 18, 191, 54, 67, 249, 140, 230, 160, 56, 30, 170, 52,

--- a/src/rpc_pubsub.rs
+++ b/src/rpc_pubsub.rs
@@ -434,7 +434,6 @@ mod tests {
 
         // Test signature confirmation notification
         let string = receiver.poll();
-        assert!(string.is_ok());
         if let Async::Ready(Some(response)) = string.unwrap() {
             let expected = format!(r#"{{"jsonrpc":"2.0","method":"signatureNotification","params":{{"result":"Confirmed","subscription":0}}}}"#);
             assert_eq!(expected, response);
@@ -540,7 +539,6 @@ mod tests {
 
         // Test signature confirmation notification #1
         let string = receiver.poll();
-        assert!(string.is_ok());
 
         let expected_userdata = arc_bank
             .get_account(&contract_state.pubkey())
@@ -583,7 +581,6 @@ mod tests {
 
         // Test signature confirmation notification #2
         let string = receiver.poll();
-        assert!(string.is_ok());
         let expected_userdata = arc_bank
             .get_account(&contract_state.pubkey())
             .unwrap()
@@ -642,7 +639,6 @@ mod tests {
            }
         });
         let string = receiver.poll();
-        assert!(string.is_ok());
         if let Async::Ready(Some(response)) = string.unwrap() {
             assert_eq!(serde_json::to_string(&expected).unwrap(), response);
         }
@@ -728,7 +724,6 @@ mod tests {
         let account = bank.get_account(&alice.pubkey()).unwrap();
         subscriptions.check_account(&alice.pubkey(), &account);
         let string = transport_receiver.poll();
-        assert!(string.is_ok());
         if let Async::Ready(Some(response)) = string.unwrap() {
             let expected = format!(r#"{{"jsonrpc":"2.0","method":"accountNotification","params":{{"result":{{"executable":false,"loader":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"owner":[129,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"tokens":1,"userdata":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]}},"subscription":0}}}}"#);
             assert_eq!(expected, response);
@@ -766,7 +761,6 @@ mod tests {
 
         subscriptions.check_signature(&signature, &Ok(()));
         let string = transport_receiver.poll();
-        assert!(string.is_ok());
         if let Async::Ready(Some(response)) = string.unwrap() {
             let expected = format!(r#"{{"jsonrpc":"2.0","method":"signatureNotification","params":{{"result":"Confirmed","subscription":0}}}}"#);
             assert_eq!(expected, response);

--- a/src/rpc_request.rs
+++ b/src/rpc_request.rs
@@ -269,11 +269,9 @@ mod tests {
             RpcRequest::GetBalance,
             Some(json!(["deadbeefXjn8o3yroDHxUtKsZZgoy4GPkPPXfouKNHhx"])),
         );
-        assert!(balance.is_ok());
         assert_eq!(balance.unwrap().as_u64().unwrap(), 50);
 
         let last_id = rpc_client.make_rpc_request(2, RpcRequest::GetLastId, None);
-        assert!(last_id.is_ok());
         assert_eq!(
             last_id.unwrap().as_str().unwrap(),
             "deadbeefXjn8o3yroDHxUtKsZZgoy4GPkPPXfouKNHhx"
@@ -321,7 +319,6 @@ mod tests {
             Some(json!(["deadbeefXjn8o3yroDHxUtKsZZgoy4GPkPPXfouKNHhw"])),
             10,
         );
-        assert!(balance.is_ok());
         assert_eq!(balance.unwrap().as_u64().unwrap(), 5);
     }
 }

--- a/src/thin_client.rs
+++ b/src/thin_client.rs
@@ -564,7 +564,7 @@ mod tests {
         let last_id = client.get_last_id();
         let signature = client.transfer(500, &alice, bob_pubkey, &last_id).unwrap();
 
-        assert!(client.poll_for_signature(&signature).is_ok());
+        client.poll_for_signature(&signature).unwrap();
 
         server.close().unwrap();
         remove_dir_all(ledger_path).unwrap();
@@ -584,7 +584,7 @@ mod tests {
             .transfer(500, &alice, validator_keypair.pubkey(), &last_id)
             .unwrap();
 
-        assert!(client.poll_for_signature(&signature).is_ok());
+        client.poll_for_signature(&signature).unwrap();
 
         // Create and register the vote account
         let validator_vote_account_keypair = Keypair::new();
@@ -594,7 +594,7 @@ mod tests {
         let transaction =
             VoteTransaction::vote_account_new(&validator_keypair, vote_account_id, last_id, 1, 1);
         let signature = client.transfer_signed(&transaction).unwrap();
-        assert!(client.poll_for_signature(&signature).is_ok());
+        client.poll_for_signature(&signature).unwrap();
 
         let balance = retry_get_balance(&mut client, &vote_account_id, Some(1))
             .expect("Expected balance for new account to exist");
@@ -648,17 +648,16 @@ mod tests {
         let signature = client
             .transfer(500, &alice, bob_keypair.pubkey(), &last_id)
             .unwrap();
-        assert!(client.poll_for_signature(&signature).is_ok());
+        client.poll_for_signature(&signature).unwrap();
 
         let balance = client.poll_get_balance(&bob_keypair.pubkey());
-        assert!(balance.is_ok());
         assert_eq!(balance.unwrap(), 500);
 
         // take them away
         let signature = client
             .transfer(500, &bob_keypair, alice.pubkey(), &last_id)
             .unwrap();
-        assert!(client.poll_for_signature(&signature).is_ok());
+        client.poll_for_signature(&signature).unwrap();
         let balance = client.poll_get_balance(&alice.pubkey());
         assert_eq!(balance.unwrap(), 10_000);
 

--- a/src/vote_signer_proxy.rs
+++ b/src/vote_signer_proxy.rs
@@ -254,7 +254,7 @@ mod test {
         assert!(signer
             .send_validator_vote(&bank, &cluster_info, &sender)
             .is_ok());
-        assert!(receiver.recv_timeout(Duration::from_millis(400)).is_ok());
+        receiver.recv_timeout(Duration::from_millis(400)).unwrap();
 
         assert_eq!(signer.unsent_votes.read().unwrap().len(), 0);
     }

--- a/wallet/src/wallet.rs
+++ b/wallet/src/wallet.rs
@@ -1192,7 +1192,6 @@ mod tests {
         let bob_pubkey = Keypair::new().pubkey();
         config.command = WalletCommand::Pay(10, bob_pubkey, None, None, None, None);
         let signature = process_command(&config);
-        assert!(signature.is_ok());
         assert_eq!(signature.unwrap(), SIGNATURE.to_string());
 
         let date_string = "\"2018-09-19T17:30:59Z\"";
@@ -1206,7 +1205,6 @@ mod tests {
             None,
         );
         let result = process_command(&config);
-        assert!(result.is_ok());
         let json: Value = serde_json::from_str(&result.unwrap()).unwrap();
         assert_eq!(
             json.as_object()
@@ -1228,7 +1226,6 @@ mod tests {
             Some(config.id.pubkey()),
         );
         let result = process_command(&config);
-        assert!(result.is_ok());
         let json: Value = serde_json::from_str(&result.unwrap()).unwrap();
         assert_eq!(
             json.as_object()
@@ -1243,13 +1240,11 @@ mod tests {
         let process_id = Keypair::new().pubkey();
         config.command = WalletCommand::TimeElapsed(bob_pubkey, process_id, dt);
         let signature = process_command(&config);
-        assert!(signature.is_ok());
         assert_eq!(signature.unwrap(), SIGNATURE.to_string());
 
         let witness = Keypair::new().pubkey();
         config.command = WalletCommand::Witness(bob_pubkey, witness);
         let signature = process_command(&config);
-        assert!(signature.is_ok());
         assert_eq!(signature.unwrap(), SIGNATURE.to_string());
 
         // Need airdrop cases
@@ -1259,13 +1254,11 @@ mod tests {
         config.rpc_client = Some(RpcClient::new("airdrop".to_string()));
         config.command = WalletCommand::TimeElapsed(bob_pubkey, process_id, dt);
         let signature = process_command(&config);
-        assert!(signature.is_ok());
         assert_eq!(signature.unwrap(), SIGNATURE.to_string());
 
         let witness = Keypair::new().pubkey();
         config.command = WalletCommand::Witness(bob_pubkey, witness);
         let signature = process_command(&config);
-        assert!(signature.is_ok());
         assert_eq!(signature.unwrap(), SIGNATURE.to_string());
 
         // Failture cases
@@ -1325,7 +1318,6 @@ mod tests {
 
         config.command = WalletCommand::Deploy(pathbuf.to_str().unwrap().to_string());
         let result = process_command(&config);
-        assert!(result.is_ok());
         let json: Value = serde_json::from_str(&result.unwrap()).unwrap();
         let program_id = json
             .as_object()
@@ -1360,7 +1352,7 @@ mod tests {
         let keypair_vec: Vec<u8> = serde_json::from_str(&serialized_keypair).unwrap();
         assert!(Path::new(&outfile).exists());
         assert_eq!(keypair_vec, read_pkcs8(&outfile).unwrap());
-        assert!(read_keypair(&outfile).is_ok());
+        read_keypair(&outfile).unwrap();
         assert_eq!(
             read_keypair(&outfile).unwrap().pubkey().as_ref().len(),
             mem::size_of::<Pubkey>()
@@ -1377,7 +1369,6 @@ mod tests {
         let expected_last_id = Hash::new(&vec);
 
         let last_id = get_last_id(&rpc_client);
-        assert!(last_id.is_ok());
         assert_eq!(last_id.unwrap(), expected_last_id);
 
         let rpc_client = RpcClient::new("fails".to_string());
@@ -1396,7 +1387,6 @@ mod tests {
         let tx = Transaction::system_new(&key, to, 50, last_id);
 
         let signature = send_tx(&rpc_client, &tx);
-        assert!(signature.is_ok());
         assert_eq!(signature.unwrap(), SIGNATURE.to_string());
 
         let rpc_client = RpcClient::new("fails".to_string());
@@ -1410,7 +1400,6 @@ mod tests {
         let rpc_client = RpcClient::new("succeeds".to_string());
         let signature = "good_signature";
         let status = confirm_tx(&rpc_client, &signature);
-        assert!(status.is_ok());
         assert_eq!(status.unwrap(), RpcSignatureStatus::Confirmed);
 
         let rpc_client = RpcClient::new("bad_sig_status".to_string());
@@ -1436,7 +1425,7 @@ mod tests {
         let signer = Keypair::new();
 
         let result = send_and_confirm_tx(&rpc_client, &mut tx, &signer);
-        assert!(result.is_ok());
+        result.unwrap();
 
         let rpc_client = RpcClient::new("account_in_use".to_string());
         let result = send_and_confirm_tx(&rpc_client, &mut tx, &signer);

--- a/wallet/tests/deploy.rs
+++ b/wallet/tests/deploy.rs
@@ -30,13 +30,11 @@ fn test_wallet_deploy_program() {
     config.drone_port = drone_addr.port();
     config.rpc_port = leader_data.rpc.port();
     config.command = WalletCommand::Airdrop(50);
-    let response = process_command(&config);
-    assert!(response.is_ok());
+    process_command(&config).unwrap();
 
     config.command = WalletCommand::Deploy(pathbuf.to_str().unwrap().to_string());
 
     let response = process_command(&config);
-    assert!(response.is_ok());
     let json: Value = serde_json::from_str(&response.unwrap()).unwrap();
     let program_id_str = json
         .as_object()

--- a/wallet/tests/request_airdrop.rs
+++ b/wallet/tests/request_airdrop.rs
@@ -22,7 +22,7 @@ fn test_wallet_request_airdrop() {
     bob_config.command = WalletCommand::Airdrop(50);
 
     let sig_response = process_command(&bob_config);
-    assert!(sig_response.is_ok());
+    sig_response.unwrap();
 
     let rpc_client = RpcClient::new_from_socket(leader_data.rpc);
 


### PR DESCRIPTION
1. `foo.unwrap()` produces a panic message that includes the error details
2. `assert!(foo.is_ok())` panics with an unhelpful `assertion failed: foo.is_ok()`

1 is better.
