### PR TITLE
Decouple VoteSignerProxy::new_vote_account from client-side keypair

### DIFF
--- a/src/compute_leader_confirmation_service.rs
+++ b/src/compute_leader_confirmation_service.rs
@@ -162,6 +162,7 @@ pub mod tests {
     use crate::vote_signer_proxy::VoteSignerProxy;
 
     use crate::genesis_block::GenesisBlock;
+    use crate::leader_scheduler::tests::new_vote_account;
     use bincode::serialize;
     use solana_sdk::hash::hash;
     use solana_sdk::signature::{Keypair, KeypairUtil};
@@ -201,9 +202,7 @@ pub mod tests {
                 // Give the validator some tokens
                 bank.transfer(2, &mint_keypair, validator_keypair.pubkey(), last_id)
                     .unwrap();
-                vote_signer
-                    .new_vote_account(&bank, 1, last_id)
-                    .expect("Expected successful creation of account");
+                new_vote_account(&validator_keypair, &vote_signer, &bank, 1, last_id);
 
                 if i < 6 {
                     let vote_tx = Transaction::vote_new(&vote_signer, (i + 1) as u64, last_id, 0);

--- a/src/leader_scheduler.rs
+++ b/src/leader_scheduler.rs
@@ -702,7 +702,7 @@ mod tests {
             // Create a vote account
             let vote_signer = VoteSignerProxy::new_local(&Arc::new(new_keypair));
             vote_signer
-                .new_vote_account(&bank, 1 as u64, genesis_block.last_id())
+                .new_vote_account(&bank, 1, genesis_block.last_id())
                 .unwrap();
 
             // Push a vote for the account
@@ -723,7 +723,7 @@ mod tests {
             // Create a vote account
             let vote_signer = VoteSignerProxy::new_local(&Arc::new(new_keypair));
             vote_signer
-                .new_vote_account(&bank, 1 as u64, genesis_block.last_id())
+                .new_vote_account(&bank, 1, genesis_block.last_id())
                 .unwrap();
 
             push_vote(
@@ -1049,7 +1049,7 @@ mod tests {
         let vote_signer = VoteSignerProxy::new_local(&Arc::new(leader_keypair));
         // Create a vote account
         vote_signer
-            .new_vote_account(&bank, 1 as u64, genesis_block.last_id())
+            .new_vote_account(&bank, 1, genesis_block.last_id())
             .unwrap();
 
         // Vote twice
@@ -1195,7 +1195,7 @@ mod tests {
             // Create a vote account
             let vote_signer = VoteSignerProxy::new_local(&Arc::new(validator_keypair));
             vote_signer
-                .new_vote_account(&bank, 1 as u64, genesis_block.last_id())
+                .new_vote_account(&bank, 1, genesis_block.last_id())
                 .unwrap();
 
             push_vote(
@@ -1212,13 +1212,7 @@ mod tests {
         // [(validator, 1), (leader, leader_stake)]. Thus we just need to make sure that
         // seed % (leader_stake + 1) > 0 to make sure that the leader is picked again.
         let seed = LeaderScheduler::calculate_seed(bootstrap_height);
-        let leader_stake = {
-            if seed % 3 == 0 {
-                3
-            } else {
-                2
-            }
-        };
+        let leader_stake = if seed % 3 == 0 { 3 } else { 2 };
 
         let vote_account_tokens = 1;
         bank.transfer(
@@ -1355,7 +1349,7 @@ mod tests {
             .unwrap();
         let vote_signer = VoteSignerProxy::new_local(&Arc::new(validator_keypair));
         vote_signer
-            .new_vote_account(&bank, 1 as u64, genesis_block.last_id())
+            .new_vote_account(&bank, 1, genesis_block.last_id())
             .unwrap();
         push_vote(
             &vote_signer,
@@ -1369,7 +1363,7 @@ mod tests {
             .unwrap();
         let vote_signer = VoteSignerProxy::new_local(&Arc::new(bootstrap_leader_keypair));
         vote_signer
-            .new_vote_account(&bank, 1 as u64, genesis_block.last_id())
+            .new_vote_account(&bank, 1, genesis_block.last_id())
             .unwrap();
 
         // Add leader to the active set

--- a/src/vote_signer_proxy.rs
+++ b/src/vote_signer_proxy.rs
@@ -10,7 +10,6 @@ use crate::rpc_request::{RpcClient, RpcRequest};
 use crate::streamer::BlobSender;
 use bincode::serialize;
 use log::Level;
-use solana_sdk::hash::Hash;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::{Keypair, KeypairUtil, Signature};
 use solana_sdk::transaction::Transaction;
@@ -117,14 +116,6 @@ impl VoteSignerProxy {
 
     pub fn new_local(keypair: &Arc<Keypair>) -> Self {
         Self::new_with_signer(keypair, Box::new(LocalVoteSigner::default()))
-    }
-
-    pub fn new_vote_account(&self, bank: &Bank, num_tokens: u64, last_id: Hash) -> Result<()> {
-        // Create and register the new vote account
-        let tx =
-            Transaction::vote_account_new(&self.keypair, self.vote_account, last_id, num_tokens, 0);
-        bank.process_transaction(&tx)?;
-        Ok(())
     }
 
     pub fn send_validator_vote(


### PR DESCRIPTION
#### Problem

The utility function in VoteSigner funds vote accounts using the VoteSigner's client-side keypair (the *operator* keypair). The coupling forces tests to first transfer tokens into that ephemeral keypair just to transfer them a second time into the vote account.

#### Summary of Changes

No functional changes here. Just decoupling the `new_vote_account` utility function from the VoteSignerProxy's client-side keypair so that a followup PR can update tests to transfer tokens straight from the mint to vote accounts.

