### PR TITLE
Rename EntryTree to Blocktree

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -27,7 +27,7 @@
   - [Secure Enclave](enclave.md)
   - [Staking Rewards](staking-rewards.md)
   - [Fork Selection](fork-selection.md)
-  - [Entry Tree](entry-tree.md)
+  - [Blocktree](blocktree.md)
   - [Data Plane Fanout](data-plane-fanout.md)
 
 - [Economic Design](ed_overview.md)

--- a/src/db_ledger.rs
+++ b/src/db_ledger.rs
@@ -791,11 +791,11 @@ impl DbLedger {
     }
 }
 
-// TODO: all this goes away with EntryTree
+// TODO: all this goes away with Blocktree
 struct EntryIterator {
     db_iterator: DBRawIterator,
 
-    // TODO: remove me when replay_stage is iterating by block (EntryTree)
+    // TODO: remove me when replay_stage is iterating by block (Blocktree)
     //    this verification is duplicating that of replay_stage, which
     //    can do this in parallel
     last_id: Option<Hash>,


### PR DESCRIPTION
#### Problem

Validators only vote on blocks, not entries. Therefore forks can only occur at block boundaries and so the data structure will be a tree of blocks.

#### Summary of Changes

* Rename EntryTree to Blocktree
* Following the precedent set by the term "blockchain", make it a single word, "blocktree" (not "BlockTree" or "block-tree").
