### PR TITLE
Move virtual genesis tick into the ledger proper as entry 0

### DIFF
--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -2,7 +2,7 @@
 
 use clap::{crate_version, value_t_or_exit, App, Arg};
 use serde_json;
-use solana::db_ledger::create_empty_ledger;
+use solana::db_ledger::create_new_ledger;
 use solana::genesis_block::GenesisBlock;
 use solana_sdk::signature::{read_keypair, KeypairUtil};
 use std::error;
@@ -74,6 +74,6 @@ fn main() -> Result<(), Box<dyn error::Error>> {
         bootstrap_leader_tokens: BOOTSTRAP_LEADER_TOKENS,
     };
 
-    create_empty_ledger(ledger_path, &genesis_block)?;
+    create_new_ledger(ledger_path, &genesis_block)?;
     Ok(())
 }

--- a/ledger-tool/tests/basic.rs
+++ b/ledger-tool/tests/basic.rs
@@ -32,7 +32,7 @@ fn bad_arguments() {
 #[test]
 fn nominal() {
     let keypair = Arc::new(Keypair::new());
-    let (_genesis_block, _mint, ledger_path, _genesis_entries) =
+    let (_, _, ledger_path, _, _) =
         create_tmp_sample_ledger("test_ledger_tool_nominal", 100, 10, keypair.pubkey(), 50);
 
     // Basic validation

--- a/ledger-tool/tests/basic.rs
+++ b/ledger-tool/tests/basic.rs
@@ -33,7 +33,7 @@ fn bad_arguments() {
 fn nominal() {
     let keypair = Arc::new(Keypair::new());
     let (_, ledger_path, _, _) =
-        create_tmp_sample_ledger("test_ledger_tool_nominal", 100, 10, keypair.pubkey(), 50);
+        create_tmp_sample_ledger("test_ledger_tool_nominal", 100, 9, keypair.pubkey(), 50);
 
     // Basic validation
     let output = run_ledger_tool(&["-l", &ledger_path, "verify"]);

--- a/ledger-tool/tests/basic.rs
+++ b/ledger-tool/tests/basic.rs
@@ -32,7 +32,7 @@ fn bad_arguments() {
 #[test]
 fn nominal() {
     let keypair = Arc::new(Keypair::new());
-    let (_, _, ledger_path, _, _) =
+    let (_, ledger_path, _, _) =
         create_tmp_sample_ledger("test_ledger_tool_nominal", 100, 10, keypair.pubkey(), 50);
 
     // Basic validation

--- a/src/db_ledger.rs
+++ b/src/db_ledger.rs
@@ -885,23 +885,23 @@ pub fn create_tmp_sample_ledger(
     num_extra_ticks: u64,
     bootstrap_leader_id: Pubkey,
     bootstrap_leader_tokens: u64,
-) -> (GenesisBlock, Keypair, String, u64, Hash) {
+) -> (Keypair, String, u64, Hash) {
     let (genesis_block, mint_keypair) =
         GenesisBlock::new_with_leader(num_tokens, bootstrap_leader_id, bootstrap_leader_tokens);
-    let path = get_tmp_ledger_path(name);
-    let (mut entry_height, mut last_id) = create_empty_ledger(&path, &genesis_block).unwrap();
+    let ledger_path = get_tmp_ledger_path(name);
+    let (mut entry_height, mut last_id) = create_new_ledger(&ledger_path, &genesis_block).unwrap();
 
     if num_extra_ticks > 0 {
         let entries = crate::entry::create_ticks(num_extra_ticks, last_id);
 
-        let db_ledger = DbLedger::open(&path).unwrap();
+        let db_ledger = DbLedger::open(&ledger_path).unwrap();
         db_ledger
             .write_entries(DEFAULT_SLOT_HEIGHT, entry_height, &entries)
             .unwrap();
         entry_height += entries.len() as u64;
         last_id = entries.last().unwrap().id
     }
-    (genesis_block, mint_keypair, path, entry_height, last_id)
+    (mint_keypair, ledger_path, entry_height, last_id)
 }
 
 pub fn tmp_copy_ledger(from: &str, name: &str) -> String {

--- a/src/db_ledger.rs
+++ b/src/db_ledger.rs
@@ -879,23 +879,10 @@ pub fn create_tmp_ledger(name: &str, genesis_block: &GenesisBlock) -> String {
     ledger_path
 }
 
-pub fn create_tmp_genesis(
-    name: &str,
-    num: u64,
-    bootstrap_leader_id: Pubkey,
-    bootstrap_leader_tokens: u64,
-) -> (GenesisBlock, Keypair, String) {
-    let (genesis_block, mint_keypair) =
-        GenesisBlock::new_with_leader(num, bootstrap_leader_id, bootstrap_leader_tokens);
-    let ledger_path = create_tmp_ledger(name, &genesis_block);
-
-    (genesis_block, mint_keypair, ledger_path)
-}
-
 pub fn create_tmp_sample_ledger(
     name: &str,
     num_tokens: u64,
-    num_ending_ticks: u64,
+    num_extra_ticks: u64,
     bootstrap_leader_id: Pubkey,
     bootstrap_leader_tokens: u64,
 ) -> (GenesisBlock, Keypair, String, u64, Hash) {
@@ -904,8 +891,8 @@ pub fn create_tmp_sample_ledger(
     let path = get_tmp_ledger_path(name);
     let (mut entry_height, mut last_id) = create_empty_ledger(&path, &genesis_block).unwrap();
 
-    if num_ending_ticks > 0 {
-        let entries = crate::entry::create_ticks(num_ending_ticks, last_id);
+    if num_extra_ticks > 0 {
+        let entries = crate::entry::create_ticks(num_extra_ticks, last_id);
 
         let db_ledger = DbLedger::open(&path).unwrap();
         db_ledger

--- a/src/fullnode.rs
+++ b/src/fullnode.rs
@@ -384,7 +384,9 @@ impl Fullnode {
         let entries = db_ledger.read_ledger().expect("opening ledger");
         info!("processing ledger...");
 
-        let (entry_height, last_entry_id) = bank.process_ledger(entries).expect("process_ledger");
+        let (entry_height, last_entry_id) = bank
+            .process_ledger(genesis_block, entries)
+            .expect("process_ledger");
         // entry_height is the network-wide agreed height of the ledger.
         //  initialize it from the input ledger
         info!(

--- a/src/fullnode.rs
+++ b/src/fullnode.rs
@@ -463,7 +463,7 @@ mod tests {
 
         let validator_keypair = Keypair::new();
         let validator_node = Node::new_localhost_with_pubkey(validator_keypair.pubkey());
-        let (_, _, validator_ledger_path, _, _) =
+        let (_, validator_ledger_path, _, _) =
             create_tmp_sample_ledger("validator_exit", 10_000, 0, leader_keypair.pubkey(), 1000);
 
         let validator = Fullnode::new(
@@ -489,7 +489,7 @@ mod tests {
             .map(|i| {
                 let validator_keypair = Keypair::new();
                 let validator_node = Node::new_localhost_with_pubkey(validator_keypair.pubkey());
-                let (_, _, validator_ledger_path, _, _) = create_tmp_sample_ledger(
+                let (_, validator_ledger_path, _, _) = create_tmp_sample_ledger(
                     &format!("validator_parallel_exit_{}", i),
                     10_000,
                     0,
@@ -532,19 +532,14 @@ mod tests {
         let bootstrap_leader_info = bootstrap_leader_node.info.clone();
 
         // Make a mint and a genesis entries for leader ledger
-        let (
-            _genesis_block,
-            _mint_keypair,
-            bootstrap_leader_ledger_path,
-            _genesis_entry_height,
-            _last_id,
-        ) = create_tmp_sample_ledger(
-            "test_leader_to_leader_transition",
-            10_000,
-            1,
-            bootstrap_leader_keypair.pubkey(),
-            500,
-        );
+        let (_mint_keypair, bootstrap_leader_ledger_path, _genesis_entry_height, _last_id) =
+            create_tmp_sample_ledger(
+                "test_leader_to_leader_transition",
+                10_000,
+                1,
+                bootstrap_leader_keypair.pubkey(),
+                500,
+            );
 
         // Create the common leader scheduling configuration
         let num_slots_per_epoch = 3;
@@ -604,19 +599,14 @@ mod tests {
         let validator_node = Node::new_localhost_with_pubkey(validator_keypair.pubkey());
 
         // Make a common mint and a genesis entry for both leader + validator's ledgers
-        let (
-            _genesis_block,
-            mint_keypair,
-            bootstrap_leader_ledger_path,
-            genesis_entry_height,
-            last_id,
-        ) = create_tmp_sample_ledger(
-            "test_wrong_role_transition",
-            10_000,
-            0,
-            bootstrap_leader_keypair.pubkey(),
-            500,
-        );
+        let (mint_keypair, bootstrap_leader_ledger_path, genesis_entry_height, last_id) =
+            create_tmp_sample_ledger(
+                "test_wrong_role_transition",
+                10_000,
+                0,
+                bootstrap_leader_keypair.pubkey(),
+                500,
+            );
 
         // Write the entries to the ledger that will cause leader rotation
         // after the bootstrap height
@@ -701,7 +691,7 @@ mod tests {
         let leader_id = leader_node.info.id;
 
         // Create validator identity
-        let (_genesis_block, mint_keypair, validator_ledger_path, genesis_entry_height, last_id) =
+        let (mint_keypair, validator_ledger_path, genesis_entry_height, last_id) =
             create_tmp_sample_ledger(
                 "test_validator_to_leader_transition",
                 10_000,

--- a/src/fullnode.rs
+++ b/src/fullnode.rs
@@ -463,8 +463,8 @@ mod tests {
 
         let validator_keypair = Keypair::new();
         let validator_node = Node::new_localhost_with_pubkey(validator_keypair.pubkey());
-        let (_, _, validator_ledger_path) =
-            create_tmp_genesis("validator_exit", 10_000, leader_keypair.pubkey(), 1000);
+        let (_, _, validator_ledger_path, _, _) =
+            create_tmp_sample_ledger("validator_exit", 10_000, 0, leader_keypair.pubkey(), 1000);
 
         let validator = Fullnode::new(
             validator_node,
@@ -489,9 +489,10 @@ mod tests {
             .map(|i| {
                 let validator_keypair = Keypair::new();
                 let validator_node = Node::new_localhost_with_pubkey(validator_keypair.pubkey());
-                let (_, _, validator_ledger_path) = create_tmp_genesis(
+                let (_, _, validator_ledger_path, _, _) = create_tmp_sample_ledger(
                     &format!("validator_parallel_exit_{}", i),
                     10_000,
+                    0,
                     leader_keypair.pubkey(),
                     1000,
                 );

--- a/src/replay_stage.rs
+++ b/src/replay_stage.rs
@@ -328,7 +328,7 @@ mod test {
 
         // Create a ledger
         let num_ending_ticks = 3;
-        let (_, mint_keypair, my_ledger_path, genesis_entry_height, mut last_id) =
+        let (mint_keypair, my_ledger_path, genesis_entry_height, mut last_id) =
             create_tmp_sample_ledger(
                 "test_replay_stage_leader_rotation_exit",
                 10_000,
@@ -461,7 +461,7 @@ mod test {
         let leader_scheduler = Arc::new(RwLock::new(LeaderScheduler::default()));
 
         let num_ending_ticks = 1;
-        let (_, _, my_ledger_path, _, _) = create_tmp_sample_ledger(
+        let (_, my_ledger_path, _, _) = create_tmp_sample_ledger(
             "test_vote_error_replay_stage_correctness",
             10_000,
             num_ending_ticks,
@@ -530,7 +530,7 @@ mod test {
         let leader_id = Keypair::new().pubkey();
 
         // Create the ledger
-        let (_genesis_block, mint_keypair, my_ledger_path, genesis_entry_height, last_id) =
+        let (mint_keypair, my_ledger_path, genesis_entry_height, last_id) =
             create_tmp_sample_ledger(
                 "test_vote_error_replay_stage_leader_rotation",
                 10_000,

--- a/src/storage_stage.rs
+++ b/src/storage_stage.rs
@@ -498,18 +498,19 @@ mod tests {
         let keypair = Arc::new(Keypair::new());
         let exit = Arc::new(AtomicBool::new(false));
 
-        let (_genesis_block, _mint, ledger_path, genesis_entries) = create_tmp_sample_ledger(
-            "storage_stage_process_entries",
-            1000,
-            1,
-            Keypair::new().pubkey(),
-            1,
-        );
+        let (_genesis_block, _mint, ledger_path, genesis_entry_height, _last_id) =
+            create_tmp_sample_ledger(
+                "storage_stage_process_entries",
+                1000,
+                1,
+                Keypair::new().pubkey(),
+                1,
+            );
 
         let entries = make_tiny_test_entries(64);
         let db_ledger = DbLedger::open(&ledger_path).unwrap();
         db_ledger
-            .write_entries(DEFAULT_SLOT_HEIGHT, genesis_entries.len() as u64, &entries)
+            .write_entries(DEFAULT_SLOT_HEIGHT, genesis_entry_height, &entries)
             .unwrap();
 
         let cluster_info = test_cluster_info(keypair.pubkey());
@@ -566,18 +567,19 @@ mod tests {
         let keypair = Arc::new(Keypair::new());
         let exit = Arc::new(AtomicBool::new(false));
 
-        let (_genesis_block, _mint, ledger_path, genesis_entries) = create_tmp_sample_ledger(
-            "storage_stage_process_entries",
-            1000,
-            1,
-            Keypair::new().pubkey(),
-            1,
-        );
+        let (_genesis_block, _mint, ledger_path, genesis_entry_height, _last_id) =
+            create_tmp_sample_ledger(
+                "storage_stage_process_entries",
+                1000,
+                1,
+                Keypair::new().pubkey(),
+                1,
+            );
 
         let entries = make_tiny_test_entries(128);
         let db_ledger = DbLedger::open(&ledger_path).unwrap();
         db_ledger
-            .write_entries(DEFAULT_SLOT_HEIGHT, genesis_entries.len() as u64, &entries)
+            .write_entries(DEFAULT_SLOT_HEIGHT, genesis_entry_height, &entries)
             .unwrap();
 
         let cluster_info = test_cluster_info(keypair.pubkey());

--- a/src/storage_stage.rs
+++ b/src/storage_stage.rs
@@ -498,14 +498,13 @@ mod tests {
         let keypair = Arc::new(Keypair::new());
         let exit = Arc::new(AtomicBool::new(false));
 
-        let (_genesis_block, _mint, ledger_path, genesis_entry_height, _last_id) =
-            create_tmp_sample_ledger(
-                "storage_stage_process_entries",
-                1000,
-                1,
-                Keypair::new().pubkey(),
-                1,
-            );
+        let (_mint, ledger_path, genesis_entry_height, _last_id) = create_tmp_sample_ledger(
+            "storage_stage_process_entries",
+            1000,
+            1,
+            Keypair::new().pubkey(),
+            1,
+        );
 
         let entries = make_tiny_test_entries(64);
         let db_ledger = DbLedger::open(&ledger_path).unwrap();
@@ -567,14 +566,13 @@ mod tests {
         let keypair = Arc::new(Keypair::new());
         let exit = Arc::new(AtomicBool::new(false));
 
-        let (_genesis_block, _mint, ledger_path, genesis_entry_height, _last_id) =
-            create_tmp_sample_ledger(
-                "storage_stage_process_entries",
-                1000,
-                1,
-                Keypair::new().pubkey(),
-                1,
-            );
+        let (_mint, ledger_path, genesis_entry_height, _last_id) = create_tmp_sample_ledger(
+            "storage_stage_process_entries",
+            1000,
+            1,
+            Keypair::new().pubkey(),
+            1,
+        );
 
         let entries = make_tiny_test_entries(128);
         let db_ledger = DbLedger::open(&ledger_path).unwrap();

--- a/src/thin_client.rs
+++ b/src/thin_client.rs
@@ -447,7 +447,7 @@ pub fn new_fullnode(ledger_name: &'static str) -> (Fullnode, NodeInfo, Keypair, 
     let node = Node::new_localhost_with_pubkey(node_keypair.pubkey());
     let node_info = node.info.clone();
 
-    let (_genesis_block, mint_keypair, ledger_path, _, _) =
+    let (mint_keypair, ledger_path, _, _) =
         create_tmp_sample_ledger(ledger_name, 10_000, 0, node_info.id, 42);
 
     let leader_scheduler = LeaderScheduler::from_bootstrap_leader(node_info.id);

--- a/src/thin_client.rs
+++ b/src/thin_client.rs
@@ -6,7 +6,6 @@
 use crate::bank::Bank;
 use crate::cluster_info::{ClusterInfo, ClusterInfoError, NodeInfo};
 use crate::fullnode::Fullnode;
-use crate::genesis_block::GenesisBlock;
 use crate::gossip_service::GossipService;
 use crate::packet::PACKET_DATA_SIZE;
 use crate::result::{Error, Result};
@@ -439,7 +438,7 @@ pub fn retry_get_balance(
 
 pub fn new_fullnode(ledger_name: &'static str) -> (Fullnode, NodeInfo, Keypair, String) {
     use crate::cluster_info::Node;
-    use crate::db_ledger::create_tmp_ledger;
+    use crate::db_ledger::create_tmp_sample_ledger;
     use crate::leader_scheduler::LeaderScheduler;
     use crate::vote_signer_proxy::VoteSignerProxy;
     use solana_sdk::signature::KeypairUtil;
@@ -448,8 +447,8 @@ pub fn new_fullnode(ledger_name: &'static str) -> (Fullnode, NodeInfo, Keypair, 
     let node = Node::new_localhost_with_pubkey(node_keypair.pubkey());
     let node_info = node.info.clone();
 
-    let (genesis_block, mint_keypair) = GenesisBlock::new_with_leader(10_000, node_info.id, 42);
-    let ledger_path = create_tmp_ledger(ledger_name, &genesis_block);
+    let (_genesis_block, mint_keypair, ledger_path, _, _) =
+        create_tmp_sample_ledger(ledger_name, 10_000, 0, node_info.id, 42);
 
     let leader_scheduler = LeaderScheduler::from_bootstrap_leader(node_info.id);
     let vote_account_keypair = Arc::new(Keypair::new());

--- a/tests/multinode.rs
+++ b/tests/multinode.rs
@@ -4,7 +4,7 @@ extern crate log;
 use solana::blob_fetch_stage::BlobFetchStage;
 use solana::cluster_info::{ClusterInfo, Node, NodeInfo};
 use solana::contact_info::ContactInfo;
-use solana::db_ledger::{create_tmp_genesis, create_tmp_sample_ledger, tmp_copy_ledger};
+use solana::db_ledger::{create_tmp_sample_ledger, tmp_copy_ledger};
 use solana::db_ledger::{DbLedger, DEFAULT_SLOT_HEIGHT};
 use solana::entry::{reconstruct_entries_from_blobs, Entry};
 use solana::fullnode::{Fullnode, FullnodeReturnType};
@@ -135,8 +135,8 @@ fn test_multi_node_ledger_window() -> result::Result<()> {
     let bob_pubkey = Keypair::new().pubkey();
     let mut ledger_paths = Vec::new();
 
-    let (genesis_block, alice, leader_ledger_path) =
-        create_tmp_genesis("multi_node_ledger_window", 10_000, leader_data.id, 500);
+    let (genesis_block, alice, leader_ledger_path, _last_entry_height, _last_entry_id) =
+        create_tmp_sample_ledger("multi_node_ledger_window", 10_000, 0, leader_data.id, 500);
     ledger_paths.push(leader_ledger_path.clone());
 
     // make a copy at zero
@@ -236,12 +236,14 @@ fn test_multi_node_validator_catchup_from_zero() -> result::Result<()> {
     let bob_pubkey = Keypair::new().pubkey();
     let mut ledger_paths = Vec::new();
 
-    let (_genesis_block, alice, genesis_ledger_path) = create_tmp_genesis(
-        "multi_node_validator_catchup_from_zero",
-        10_000,
-        leader_data.id,
-        500,
-    );
+    let (_genesis_block, alice, genesis_ledger_path, _last_entry_height, _last_entry_id) =
+        create_tmp_sample_ledger(
+            "multi_node_validator_catchup_from_zero",
+            10_000,
+            0,
+            leader_data.id,
+            500,
+        );
     ledger_paths.push(genesis_ledger_path.clone());
 
     let zero_ledger_path = tmp_copy_ledger(
@@ -432,8 +434,8 @@ fn test_multi_node_basic() {
     let bob_pubkey = Keypair::new().pubkey();
     let mut ledger_paths = Vec::new();
 
-    let (_genesis_block, alice, genesis_ledger_path) =
-        create_tmp_genesis("multi_node_basic", 10_000, leader_data.id, 500);
+    let (_genesis_block, alice, genesis_ledger_path, _last_entry_height, _last_entry_id) =
+        create_tmp_sample_ledger("multi_node_basic", 10_000, 0, leader_data.id, 500);
     ledger_paths.push(genesis_ledger_path.clone());
 
     let leader_ledger_path = tmp_copy_ledger(&genesis_ledger_path, "multi_node_basic");
@@ -539,8 +541,8 @@ fn test_boot_validator_from_file() -> result::Result<()> {
     let bob_pubkey = Keypair::new().pubkey();
     let mut ledger_paths = Vec::new();
 
-    let (_genesis_block, alice, genesis_ledger_path) =
-        create_tmp_genesis("boot_validator_from_file", 100_000, leader_pubkey, 1000);
+    let (_genesis_block, alice, genesis_ledger_path, _last_entry_height, _last_entry_id) =
+        create_tmp_sample_ledger("boot_validator_from_file", 100_000, 0, leader_pubkey, 1000);
     ledger_paths.push(genesis_ledger_path.clone());
 
     let leader_ledger_path = tmp_copy_ledger(&genesis_ledger_path, "multi_node_basic");
@@ -627,12 +629,14 @@ fn test_leader_restart_validator_start_from_old_ledger() -> result::Result<()> {
 
     let leader_keypair = Arc::new(Keypair::new());
     let initial_leader_balance = 500;
-    let (_genesis_block, alice, ledger_path) = create_tmp_genesis(
-        "leader_restart_validator_start_from_old_ledger",
-        100_000 + 500 * solana::window_service::MAX_REPAIR_BACKOFF as u64,
-        leader_keypair.pubkey(),
-        initial_leader_balance,
-    );
+    let (_genesis_block, alice, ledger_path, _last_entry_height, _last_entry_id) =
+        create_tmp_sample_ledger(
+            "leader_restart_validator_start_from_old_ledger",
+            100_000 + 500 * solana::window_service::MAX_REPAIR_BACKOFF as u64,
+            0,
+            leader_keypair.pubkey(),
+            initial_leader_balance,
+        );
     let bob_pubkey = Keypair::new().pubkey();
 
     let signer_proxy = Arc::new(VoteSignerProxy::new_local(&leader_keypair));
@@ -736,8 +740,14 @@ fn test_multi_node_dynamic_network() {
     let leader_pubkey = leader_keypair.pubkey().clone();
     let leader = Node::new_localhost_with_pubkey(leader_keypair.pubkey());
     let bob_pubkey = Keypair::new().pubkey();
-    let (_genesis_block, alice, genesis_ledger_path) =
-        create_tmp_genesis("multi_node_dynamic_network", 10_000_000, leader_pubkey, 500);
+    let (_genesis_block, alice, genesis_ledger_path, _last_entry_height, _last_entry_id) =
+        create_tmp_sample_ledger(
+            "multi_node_dynamic_network",
+            10_000_000,
+            0,
+            leader_pubkey,
+            500,
+        );
 
     let mut ledger_paths = Vec::new();
     ledger_paths.push(genesis_ledger_path.clone());

--- a/tests/multinode.rs
+++ b/tests/multinode.rs
@@ -135,7 +135,7 @@ fn test_multi_node_ledger_window() -> result::Result<()> {
     let bob_pubkey = Keypair::new().pubkey();
     let mut ledger_paths = Vec::new();
 
-    let (alice, leader_ledger_path, _last_entry_height, _last_entry_id) =
+    let (alice, leader_ledger_path, last_entry_height, last_entry_id) =
         create_tmp_sample_ledger("multi_node_ledger_window", 10_000, 0, leader_data.id, 500);
     ledger_paths.push(leader_ledger_path.clone());
 
@@ -146,10 +146,10 @@ fn test_multi_node_ledger_window() -> result::Result<()> {
     // write a bunch more ledger into leader's ledger, this should populate the leader's window
     // and force it to respond to repair from the ledger window
     {
-        let entries = make_tiny_test_entries(genesis_block.last_id(), 100);
+        let entries = make_tiny_test_entries(last_entry_id, 100);
         let db_ledger = DbLedger::open(&leader_ledger_path).unwrap();
         db_ledger
-            .write_entries(DEFAULT_SLOT_HEIGHT, 0, &entries)
+            .write_entries(DEFAULT_SLOT_HEIGHT, last_entry_height, &entries)
             .unwrap();
     }
 

--- a/tests/multinode.rs
+++ b/tests/multinode.rs
@@ -135,7 +135,7 @@ fn test_multi_node_ledger_window() -> result::Result<()> {
     let bob_pubkey = Keypair::new().pubkey();
     let mut ledger_paths = Vec::new();
 
-    let (genesis_block, alice, leader_ledger_path, _last_entry_height, _last_entry_id) =
+    let (alice, leader_ledger_path, _last_entry_height, _last_entry_id) =
         create_tmp_sample_ledger("multi_node_ledger_window", 10_000, 0, leader_data.id, 500);
     ledger_paths.push(leader_ledger_path.clone());
 
@@ -236,14 +236,13 @@ fn test_multi_node_validator_catchup_from_zero() -> result::Result<()> {
     let bob_pubkey = Keypair::new().pubkey();
     let mut ledger_paths = Vec::new();
 
-    let (_genesis_block, alice, genesis_ledger_path, _last_entry_height, _last_entry_id) =
-        create_tmp_sample_ledger(
-            "multi_node_validator_catchup_from_zero",
-            10_000,
-            0,
-            leader_data.id,
-            500,
-        );
+    let (alice, genesis_ledger_path, _last_entry_height, _last_entry_id) = create_tmp_sample_ledger(
+        "multi_node_validator_catchup_from_zero",
+        10_000,
+        0,
+        leader_data.id,
+        500,
+    );
     ledger_paths.push(genesis_ledger_path.clone());
 
     let zero_ledger_path = tmp_copy_ledger(
@@ -434,7 +433,7 @@ fn test_multi_node_basic() {
     let bob_pubkey = Keypair::new().pubkey();
     let mut ledger_paths = Vec::new();
 
-    let (_genesis_block, alice, genesis_ledger_path, _last_entry_height, _last_entry_id) =
+    let (alice, genesis_ledger_path, _last_entry_height, _last_entry_id) =
         create_tmp_sample_ledger("multi_node_basic", 10_000, 0, leader_data.id, 500);
     ledger_paths.push(genesis_ledger_path.clone());
 
@@ -541,7 +540,7 @@ fn test_boot_validator_from_file() -> result::Result<()> {
     let bob_pubkey = Keypair::new().pubkey();
     let mut ledger_paths = Vec::new();
 
-    let (_genesis_block, alice, genesis_ledger_path, _last_entry_height, _last_entry_id) =
+    let (alice, genesis_ledger_path, _last_entry_height, _last_entry_id) =
         create_tmp_sample_ledger("boot_validator_from_file", 100_000, 0, leader_pubkey, 1000);
     ledger_paths.push(genesis_ledger_path.clone());
 
@@ -629,14 +628,13 @@ fn test_leader_restart_validator_start_from_old_ledger() -> result::Result<()> {
 
     let leader_keypair = Arc::new(Keypair::new());
     let initial_leader_balance = 500;
-    let (_genesis_block, alice, ledger_path, _last_entry_height, _last_entry_id) =
-        create_tmp_sample_ledger(
-            "leader_restart_validator_start_from_old_ledger",
-            100_000 + 500 * solana::window_service::MAX_REPAIR_BACKOFF as u64,
-            0,
-            leader_keypair.pubkey(),
-            initial_leader_balance,
-        );
+    let (alice, ledger_path, _last_entry_height, _last_entry_id) = create_tmp_sample_ledger(
+        "leader_restart_validator_start_from_old_ledger",
+        100_000 + 500 * solana::window_service::MAX_REPAIR_BACKOFF as u64,
+        0,
+        leader_keypair.pubkey(),
+        initial_leader_balance,
+    );
     let bob_pubkey = Keypair::new().pubkey();
 
     let signer_proxy = Arc::new(VoteSignerProxy::new_local(&leader_keypair));
@@ -740,14 +738,13 @@ fn test_multi_node_dynamic_network() {
     let leader_pubkey = leader_keypair.pubkey().clone();
     let leader = Node::new_localhost_with_pubkey(leader_keypair.pubkey());
     let bob_pubkey = Keypair::new().pubkey();
-    let (_genesis_block, alice, genesis_ledger_path, _last_entry_height, _last_entry_id) =
-        create_tmp_sample_ledger(
-            "multi_node_dynamic_network",
-            10_000_000,
-            0,
-            leader_pubkey,
-            500,
-        );
+    let (alice, genesis_ledger_path, _last_entry_height, _last_entry_id) = create_tmp_sample_ledger(
+        "multi_node_dynamic_network",
+        10_000_000,
+        0,
+        leader_pubkey,
+        500,
+    );
 
     let mut ledger_paths = Vec::new();
     ledger_paths.push(genesis_ledger_path.clone());
@@ -975,7 +972,7 @@ fn test_leader_to_validator_transition() {
     // Initialize the leader ledger. Make a mint and a genesis entry
     // in the leader ledger
     let num_ending_ticks = 1;
-    let (_genesis_block, mint_keypair, leader_ledger_path, genesis_entry_height, last_id) =
+    let (mint_keypair, leader_ledger_path, genesis_entry_height, last_id) =
         create_tmp_sample_ledger(
             "test_leader_to_validator_transition",
             10_000,
@@ -1115,7 +1112,7 @@ fn test_leader_validator_basic() {
 
     // Make a common mint and a genesis entry for both leader + validator ledgers
     let num_ending_ticks = 1;
-    let (_genesis_block, mint_keypair, leader_ledger_path, genesis_entry_height, last_id) =
+    let (mint_keypair, leader_ledger_path, genesis_entry_height, last_id) =
         create_tmp_sample_ledger(
             "test_leader_validator_basic",
             10_000,
@@ -1298,7 +1295,7 @@ fn test_dropped_handoff_recovery() {
 
     // Make a common mint and a genesis entry for both leader + validator's ledgers
     let num_ending_ticks = 1;
-    let (_genesis_block, mint_keypair, genesis_ledger_path, genesis_entry_height, last_id) =
+    let (mint_keypair, genesis_ledger_path, genesis_entry_height, last_id) =
         create_tmp_sample_ledger(
             "test_dropped_handoff_recovery",
             10_000,
@@ -1459,7 +1456,7 @@ fn test_full_leader_validator_network() {
 
     // Make a common mint and a genesis entry for both leader + validator's ledgers
     let num_ending_ticks = 1;
-    let (_genesis_block, mint_keypair, bootstrap_leader_ledger_path, genesis_entry_height, last_id) =
+    let (mint_keypair, bootstrap_leader_ledger_path, genesis_entry_height, last_id) =
         create_tmp_sample_ledger(
             "test_full_leader_validator_network",
             10_000,
@@ -1690,19 +1687,14 @@ fn test_broadcast_last_tick() {
     let bootstrap_leader_info = bootstrap_leader_node.info.clone();
 
     // Create leader ledger
-    let (
-        _genesis_block,
-        _mint_keypair,
-        bootstrap_leader_ledger_path,
-        genesis_entry_height,
-        _last_id,
-    ) = create_tmp_sample_ledger(
-        "test_broadcast_last_tick",
-        10_000,
-        1,
-        bootstrap_leader_info.id,
-        500,
-    );
+    let (_mint_keypair, bootstrap_leader_ledger_path, genesis_entry_height, _last_id) =
+        create_tmp_sample_ledger(
+            "test_broadcast_last_tick",
+            10_000,
+            1,
+            bootstrap_leader_info.id,
+            500,
+        );
 
     let genesis_ledger_len = genesis_entry_height;
     debug!("genesis_ledger_len: {}", genesis_ledger_len);

--- a/tests/replicator.rs
+++ b/tests/replicator.rs
@@ -9,7 +9,7 @@ use bincode::deserialize;
 use solana::client::mk_client;
 use solana::cluster_info::{ClusterInfo, Node, NodeInfo};
 use solana::db_ledger::DbLedger;
-use solana::db_ledger::{create_tmp_genesis, get_tmp_ledger_path, tmp_copy_ledger};
+use solana::db_ledger::{create_tmp_sample_ledger, get_tmp_ledger_path, tmp_copy_ledger};
 use solana::entry::Entry;
 use solana::fullnode::{Fullnode, FullnodeConfig};
 use solana::leader_scheduler::LeaderScheduler;
@@ -40,8 +40,8 @@ fn test_replicator_startup() {
     let leader_info = leader_node.info.clone();
 
     let leader_ledger_path = "replicator_test_leader_ledger";
-    let (_genesis_block, mint_keypair, leader_ledger_path) =
-        create_tmp_genesis(leader_ledger_path, 1_000_000_000, leader_info.id, 1);
+    let (_genesis_block, mint_keypair, leader_ledger_path, _last_entry_height, _last_entry_id) =
+        create_tmp_sample_ledger(leader_ledger_path, 1_000_000_000, 0, leader_info.id, 1);
 
     let validator_ledger_path =
         tmp_copy_ledger(&leader_ledger_path, "replicator_test_validator_ledger");
@@ -267,8 +267,8 @@ fn test_replicator_startup_ledger_hang() {
     let leader_info = leader_node.info.clone();
 
     let leader_ledger_path = "replicator_test_leader_ledger";
-    let (_genesis_block, _mint_keypair, leader_ledger_path) =
-        create_tmp_genesis(leader_ledger_path, 100, leader_info.id, 1);
+    let (_genesis_block, _mint_keypair, leader_ledger_path, _last_entry_height, _last_entry_id) =
+        create_tmp_sample_ledger(leader_ledger_path, 100, 0, leader_info.id, 1);
 
     let validator_ledger_path =
         tmp_copy_ledger(&leader_ledger_path, "replicator_test_validator_ledger");

--- a/tests/replicator.rs
+++ b/tests/replicator.rs
@@ -40,7 +40,7 @@ fn test_replicator_startup() {
     let leader_info = leader_node.info.clone();
 
     let leader_ledger_path = "replicator_test_leader_ledger";
-    let (_genesis_block, mint_keypair, leader_ledger_path, _last_entry_height, _last_entry_id) =
+    let (mint_keypair, leader_ledger_path, _last_entry_height, _last_entry_id) =
         create_tmp_sample_ledger(leader_ledger_path, 1_000_000_000, 0, leader_info.id, 1);
 
     let validator_ledger_path =
@@ -267,7 +267,7 @@ fn test_replicator_startup_ledger_hang() {
     let leader_info = leader_node.info.clone();
 
     let leader_ledger_path = "replicator_test_leader_ledger";
-    let (_genesis_block, _mint_keypair, leader_ledger_path, _last_entry_height, _last_entry_id) =
+    let (_mint_keypair, leader_ledger_path, _last_entry_height, _last_entry_id) =
         create_tmp_sample_ledger(leader_ledger_path, 100, 0, leader_info.id, 1);
 
     let validator_ledger_path =


### PR DESCRIPTION
Start off the ledger with a tick linked to the genesis block so that the ledger entry height and the status_queue entry height match.

`solana-ledger-tool` backs me up:
```bash
$ solana-ledger-tool --ledger config/ledger print
Entry { tick_height: 0, num_hashes: 1, id: CxfBBarYyA3Sy4FkAPV1Mkrj9KXPzMkeJqAJ5QKra7DD, transactions: [] }
```
previously a newly created ledger would have no entries.

This PR includes a little bit of semi-related cleanup.  I'll point out the interesting bits.