### PR TITLE
Always give Fullnode a vote signer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2014,6 +2014,7 @@ dependencies = [
  "solana-metrics 0.12.0",
  "solana-netutil 0.12.0",
  "solana-sdk 0.12.0",
+ "solana-vote-signer 0.12.0",
 ]
 
 [[package]]

--- a/fullnode/Cargo.toml
+++ b/fullnode/Cargo.toml
@@ -19,6 +19,7 @@ solana-logger = { path = "../logger", version = "0.12.0" }
 solana-netutil = { path = "../netutil", version = "0.12.0" }
 solana-metrics = { path = "../metrics", version = "0.12.0" }
 solana-sdk = { path = "../sdk", version = "0.12.0" }
+solana-vote-signer = { path = "../vote-signer", version = "0.12.0" }
 
 [features]
 chacha = ["solana/chacha"]

--- a/fullnode/src/main.rs
+++ b/fullnode/src/main.rs
@@ -264,7 +264,7 @@ fn main() {
     let gossip_addr = node.info.gossip;
     let mut fullnode = Fullnode::new(
         node,
-        keypair.clone(),
+        &keypair,
         ledger_path,
         Arc::new(RwLock::new(leader_scheduler)),
         vote_signer,

--- a/src/fullnode.rs
+++ b/src/fullnode.rs
@@ -105,7 +105,7 @@ pub struct Fullnode {
 impl Fullnode {
     pub fn new(
         mut node: Node,
-        keypair: Arc<Keypair>,
+        keypair: &Arc<Keypair>,
         ledger_path: &str,
         leader_scheduler: Arc<RwLock<LeaderScheduler>>,
         vote_signer: VoteSignerProxy,
@@ -477,7 +477,7 @@ mod tests {
 
         let validator = Fullnode::new(
             validator_node,
-            Arc::new(validator_keypair),
+            &Arc::new(validator_keypair),
             &validator_ledger_path,
             Arc::new(RwLock::new(LeaderScheduler::new(&Default::default()))),
             VoteSignerProxy::new(),
@@ -509,7 +509,7 @@ mod tests {
 
                 Fullnode::new(
                     validator_node,
-                    Arc::new(validator_keypair),
+                    &Arc::new(validator_keypair),
                     &validator_ledger_path,
                     Arc::new(RwLock::new(LeaderScheduler::new(&Default::default()))),
                     VoteSignerProxy::new(),
@@ -573,7 +573,7 @@ mod tests {
         // Start up the leader
         let mut bootstrap_leader = Fullnode::new(
             bootstrap_leader_node,
-            bootstrap_leader_keypair,
+            &bootstrap_leader_keypair,
             &bootstrap_leader_ledger_path,
             Arc::new(RwLock::new(LeaderScheduler::new(&leader_scheduler_config))),
             signer,
@@ -658,7 +658,7 @@ mod tests {
             // Test that a node knows to transition to a validator based on parsing the ledger
             let bootstrap_leader = Fullnode::new(
                 bootstrap_leader_node,
-                bootstrap_leader_keypair,
+                &bootstrap_leader_keypair,
                 &bootstrap_leader_ledger_path,
                 Arc::new(RwLock::new(LeaderScheduler::new(&leader_scheduler_config))),
                 VoteSignerProxy::new(),
@@ -671,7 +671,7 @@ mod tests {
             // Test that a node knows to transition to a leader based on parsing the ledger
             let validator = Fullnode::new(
                 validator_node,
-                validator_keypair,
+                &validator_keypair,
                 &validator_ledger_path,
                 Arc::new(RwLock::new(LeaderScheduler::new(&leader_scheduler_config))),
                 VoteSignerProxy::new(),
@@ -755,7 +755,7 @@ mod tests {
         // Start the validator
         let validator = Fullnode::new(
             validator_node,
-            validator_keypair,
+            &validator_keypair,
             &validator_ledger_path,
             Arc::new(RwLock::new(LeaderScheduler::new(&leader_scheduler_config))),
             vote_signer,

--- a/src/thin_client.rs
+++ b/src/thin_client.rs
@@ -458,7 +458,7 @@ pub fn new_fullnode(ledger_name: &'static str) -> (Fullnode, NodeInfo, Keypair, 
         node_keypair,
         &ledger_path,
         Arc::new(RwLock::new(leader_scheduler)),
-        Some(Arc::new(vote_signer)),
+        vote_signer,
         None,
         Default::default(),
     );

--- a/src/thin_client.rs
+++ b/src/thin_client.rs
@@ -455,7 +455,7 @@ pub fn new_fullnode(ledger_name: &'static str) -> (Fullnode, NodeInfo, Keypair, 
     let vote_signer = VoteSignerProxy::new_local(&vote_account_keypair);
     let node = Fullnode::new(
         node,
-        node_keypair,
+        &node_keypair,
         &ledger_path,
         Arc::new(RwLock::new(leader_scheduler)),
         vote_signer,

--- a/src/tvu.rs
+++ b/src/tvu.rs
@@ -23,7 +23,7 @@ use crate::service::Service;
 use crate::storage_stage::{StorageStage, StorageState};
 use crate::vote_signer_proxy::VoteSignerProxy;
 use solana_sdk::hash::Hash;
-use solana_sdk::signature::Keypair;
+use solana_sdk::signature::{Keypair, KeypairUtil};
 use std::net::UdpSocket;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, RwLock};
@@ -113,7 +113,7 @@ impl Tvu {
         let l_last_entry_id = Arc::new(RwLock::new(last_entry_id));
 
         let (replay_stage, ledger_entry_receiver) = ReplayStage::new(
-            keypair.clone(),
+            keypair.pubkey(),
             vote_signer,
             bank.clone(),
             cluster_info.clone(),

--- a/tests/multinode.rs
+++ b/tests/multinode.rs
@@ -161,7 +161,7 @@ fn test_multi_node_ledger_window() -> result::Result<()> {
         Arc::new(RwLock::new(LeaderScheduler::from_bootstrap_leader(
             leader_pubkey,
         ))),
-        Some(Arc::new(signer_proxy)),
+        signer_proxy,
         None,
         Default::default(),
     );
@@ -180,7 +180,7 @@ fn test_multi_node_ledger_window() -> result::Result<()> {
         Arc::new(RwLock::new(LeaderScheduler::from_bootstrap_leader(
             leader_pubkey,
         ))),
-        Some(Arc::new(signer_proxy)),
+        signer_proxy,
         Some(&leader_data),
         Default::default(),
     );
@@ -264,7 +264,7 @@ fn test_multi_node_validator_catchup_from_zero() -> result::Result<()> {
         Arc::new(RwLock::new(LeaderScheduler::from_bootstrap_leader(
             leader_pubkey,
         ))),
-        Some(Arc::new(signer_proxy)),
+        signer_proxy,
         None,
         Default::default(),
     );
@@ -297,7 +297,7 @@ fn test_multi_node_validator_catchup_from_zero() -> result::Result<()> {
             Arc::new(RwLock::new(LeaderScheduler::from_bootstrap_leader(
                 leader_pubkey,
             ))),
-            Some(Arc::new(signer_proxy)),
+            signer_proxy,
             Some(&leader_data),
             Default::default(),
         );
@@ -359,7 +359,7 @@ fn test_multi_node_validator_catchup_from_zero() -> result::Result<()> {
         Arc::new(RwLock::new(LeaderScheduler::from_bootstrap_leader(
             leader_pubkey,
         ))),
-        Some(Arc::new(signer_proxy)),
+        signer_proxy,
         Some(&leader_data),
         Default::default(),
     );
@@ -448,7 +448,7 @@ fn test_multi_node_basic() {
         Arc::new(RwLock::new(LeaderScheduler::from_bootstrap_leader(
             leader_pubkey,
         ))),
-        Some(Arc::new(signer_proxy)),
+        signer_proxy,
         None,
         Default::default(),
     );
@@ -477,7 +477,7 @@ fn test_multi_node_basic() {
             Arc::new(RwLock::new(LeaderScheduler::from_bootstrap_leader(
                 leader_pubkey,
             ))),
-            Some(Arc::new(signer_proxy)),
+            signer_proxy,
             Some(&leader_data),
             Default::default(),
         );
@@ -556,7 +556,7 @@ fn test_boot_validator_from_file() -> result::Result<()> {
         Arc::new(RwLock::new(LeaderScheduler::from_bootstrap_leader(
             leader_pubkey,
         ))),
-        Some(Arc::new(signer_proxy)),
+        signer_proxy,
         None,
         Default::default(),
     );
@@ -580,7 +580,7 @@ fn test_boot_validator_from_file() -> result::Result<()> {
         Arc::new(RwLock::new(LeaderScheduler::from_bootstrap_leader(
             leader_pubkey,
         ))),
-        Some(Arc::new(signer_proxy)),
+        signer_proxy,
         Some(&leader_data),
         Default::default(),
     );
@@ -601,7 +601,7 @@ fn test_boot_validator_from_file() -> result::Result<()> {
 fn create_leader(
     ledger_path: &str,
     leader_keypair: Arc<Keypair>,
-    signer: Arc<VoteSignerProxy>,
+    signer: VoteSignerProxy,
 ) -> (NodeInfo, Fullnode) {
     let leader = Node::new_localhost_with_pubkey(leader_keypair.pubkey());
     let leader_data = leader.info.clone();
@@ -612,7 +612,7 @@ fn create_leader(
         Arc::new(RwLock::new(LeaderScheduler::from_bootstrap_leader(
             leader_data.id,
         ))),
-        Some(signer),
+        signer,
         None,
         Default::default(),
     );
@@ -637,11 +637,10 @@ fn test_leader_restart_validator_start_from_old_ledger() -> result::Result<()> {
     );
     let bob_pubkey = Keypair::new().pubkey();
 
-    let signer_proxy = Arc::new(VoteSignerProxy::new_local(&leader_keypair));
-
     {
+        let signer_proxy = VoteSignerProxy::new_local(&leader_keypair);
         let (leader_data, leader_fullnode) =
-            create_leader(&ledger_path, leader_keypair.clone(), signer_proxy.clone());
+            create_leader(&ledger_path, leader_keypair.clone(), signer_proxy);
 
         // lengthen the ledger
         let leader_balance =
@@ -660,8 +659,9 @@ fn test_leader_restart_validator_start_from_old_ledger() -> result::Result<()> {
     );
 
     {
+        let signer_proxy = VoteSignerProxy::new_local(&leader_keypair);
         let (leader_data, leader_fullnode) =
-            create_leader(&ledger_path, leader_keypair.clone(), signer_proxy.clone());
+            create_leader(&ledger_path, leader_keypair.clone(), signer_proxy);
 
         // lengthen the ledger
         let leader_balance =
@@ -673,8 +673,8 @@ fn test_leader_restart_validator_start_from_old_ledger() -> result::Result<()> {
         leader_fullnode.close()?;
     }
 
-    let (leader_data, leader_fullnode) =
-        create_leader(&ledger_path, leader_keypair, signer_proxy.clone());
+    let signer_proxy = VoteSignerProxy::new_local(&leader_keypair);
+    let (leader_data, leader_fullnode) = create_leader(&ledger_path, leader_keypair, signer_proxy);
 
     // start validator from old ledger
     let keypair = Arc::new(Keypair::new());
@@ -689,7 +689,7 @@ fn test_leader_restart_validator_start_from_old_ledger() -> result::Result<()> {
         Arc::new(RwLock::new(LeaderScheduler::from_bootstrap_leader(
             leader_data.id,
         ))),
-        Some(Arc::new(signer_proxy)),
+        signer_proxy,
         Some(&leader_data),
         Default::default(),
     );
@@ -762,7 +762,7 @@ fn test_multi_node_dynamic_network() {
         Arc::new(RwLock::new(LeaderScheduler::from_bootstrap_leader(
             leader_pubkey,
         ))),
-        Some(Arc::new(signer_proxy)),
+        signer_proxy,
         None,
         Default::default(),
     );
@@ -836,7 +836,7 @@ fn test_multi_node_dynamic_network() {
                         Arc::new(RwLock::new(LeaderScheduler::from_bootstrap_leader(
                             leader_pubkey,
                         ))),
-                        Some(Arc::new(signer_proxy)),
+                        signer_proxy,
                         Some(&leader_data),
                         Default::default(),
                     );
@@ -1011,7 +1011,7 @@ fn test_leader_to_validator_transition() {
         leader_keypair,
         &leader_ledger_path,
         Arc::new(RwLock::new(LeaderScheduler::new(&leader_scheduler_config))),
-        Some(Arc::new(signer_proxy)),
+        signer_proxy,
         Some(&leader_info),
         Default::default(),
     );
@@ -1160,7 +1160,7 @@ fn test_leader_validator_basic() {
         validator_keypair,
         &validator_ledger_path,
         Arc::new(RwLock::new(LeaderScheduler::new(&leader_scheduler_config))),
-        Some(Arc::new(signer_proxy)),
+        signer_proxy,
         Some(&leader_info),
         Default::default(),
     );
@@ -1172,7 +1172,7 @@ fn test_leader_validator_basic() {
         leader_keypair,
         &leader_ledger_path,
         Arc::new(RwLock::new(LeaderScheduler::new(&leader_scheduler_config))),
-        Some(Arc::new(signer_proxy)),
+        signer_proxy,
         Some(&leader_info),
         Default::default(),
     );
@@ -1359,7 +1359,7 @@ fn test_dropped_handoff_recovery() {
         bootstrap_leader_keypair,
         &bootstrap_leader_ledger_path,
         Arc::new(RwLock::new(LeaderScheduler::new(&leader_scheduler_config))),
-        Some(Arc::new(signer_proxy)),
+        signer_proxy,
         Some(&bootstrap_leader_info),
         Default::default(),
     );
@@ -1381,7 +1381,7 @@ fn test_dropped_handoff_recovery() {
             keypair,
             &validator_ledger_path,
             Arc::new(RwLock::new(LeaderScheduler::new(&leader_scheduler_config))),
-            Some(Arc::new(signer_proxy)),
+            signer_proxy,
             Some(&bootstrap_leader_info),
             Default::default(),
         );
@@ -1407,7 +1407,7 @@ fn test_dropped_handoff_recovery() {
         next_leader_keypair,
         &next_leader_ledger_path,
         Arc::new(RwLock::new(LeaderScheduler::new(&leader_scheduler_config))),
-        Some(Arc::new(signer_proxy)),
+        signer_proxy,
         Some(&bootstrap_leader_info),
         Default::default(),
     );
@@ -1545,7 +1545,7 @@ fn test_full_leader_validator_network() {
             kp.clone(),
             &validator_ledger_path,
             leader_scheduler.clone(),
-            Some(Arc::new(signer_proxy)),
+            signer_proxy,
             Some(&bootstrap_leader_info),
             Default::default(),
         );
@@ -1562,7 +1562,7 @@ fn test_full_leader_validator_network() {
         leader_keypair.clone(),
         &bootstrap_leader_ledger_path,
         leader_scheduler.clone(),
-        Some(Arc::new(signer_proxy)),
+        signer_proxy,
         Some(&bootstrap_leader_info),
         Default::default(),
     );
@@ -1734,7 +1734,7 @@ fn test_broadcast_last_tick() {
         bootstrap_leader_keypair,
         &bootstrap_leader_ledger_path,
         Arc::new(RwLock::new(LeaderScheduler::new(&leader_scheduler_config))),
-        Some(Arc::new(signer_proxy)),
+        signer_proxy,
         Some(&bootstrap_leader_info),
         Default::default(),
     );

--- a/tests/multinode.rs
+++ b/tests/multinode.rs
@@ -156,7 +156,7 @@ fn test_multi_node_ledger_window() -> result::Result<()> {
     let signer_proxy = VoteSignerProxy::new_local(&leader_keypair);
     let leader = Fullnode::new(
         leader,
-        leader_keypair,
+        &leader_keypair,
         &leader_ledger_path,
         Arc::new(RwLock::new(LeaderScheduler::from_bootstrap_leader(
             leader_pubkey,
@@ -175,7 +175,7 @@ fn test_multi_node_ledger_window() -> result::Result<()> {
     let signer_proxy = VoteSignerProxy::new_local(&keypair);
     let validator = Fullnode::new(
         validator,
-        keypair,
+        &keypair,
         &zero_ledger_path,
         Arc::new(RwLock::new(LeaderScheduler::from_bootstrap_leader(
             leader_pubkey,
@@ -259,7 +259,7 @@ fn test_multi_node_validator_catchup_from_zero() -> result::Result<()> {
     let signer_proxy = VoteSignerProxy::new_local(&leader_keypair);
     let server = Fullnode::new(
         leader,
-        leader_keypair,
+        &leader_keypair,
         &leader_ledger_path,
         Arc::new(RwLock::new(LeaderScheduler::from_bootstrap_leader(
             leader_pubkey,
@@ -292,7 +292,7 @@ fn test_multi_node_validator_catchup_from_zero() -> result::Result<()> {
         let signer_proxy = VoteSignerProxy::new_local(&keypair);
         let val = Fullnode::new(
             validator,
-            keypair,
+            &keypair,
             &ledger_path,
             Arc::new(RwLock::new(LeaderScheduler::from_bootstrap_leader(
                 leader_pubkey,
@@ -354,7 +354,7 @@ fn test_multi_node_validator_catchup_from_zero() -> result::Result<()> {
 
     let val = Fullnode::new(
         validator,
-        keypair,
+        &keypair,
         &zero_ledger_path,
         Arc::new(RwLock::new(LeaderScheduler::from_bootstrap_leader(
             leader_pubkey,
@@ -443,7 +443,7 @@ fn test_multi_node_basic() {
     let signer_proxy = VoteSignerProxy::new_local(&leader_keypair);
     let server = Fullnode::new(
         leader,
-        leader_keypair,
+        &leader_keypair,
         &leader_ledger_path,
         Arc::new(RwLock::new(LeaderScheduler::from_bootstrap_leader(
             leader_pubkey,
@@ -472,7 +472,7 @@ fn test_multi_node_basic() {
         let signer_proxy = VoteSignerProxy::new_local(&keypair);
         let val = Fullnode::new(
             validator,
-            keypair,
+            &keypair,
             &ledger_path,
             Arc::new(RwLock::new(LeaderScheduler::from_bootstrap_leader(
                 leader_pubkey,
@@ -551,7 +551,7 @@ fn test_boot_validator_from_file() -> result::Result<()> {
     let signer_proxy = VoteSignerProxy::new_local(&leader_keypair);
     let leader_fullnode = Fullnode::new(
         leader,
-        leader_keypair,
+        &leader_keypair,
         &leader_ledger_path,
         Arc::new(RwLock::new(LeaderScheduler::from_bootstrap_leader(
             leader_pubkey,
@@ -575,7 +575,7 @@ fn test_boot_validator_from_file() -> result::Result<()> {
     let signer_proxy = VoteSignerProxy::new_local(&keypair);
     let val_fullnode = Fullnode::new(
         validator,
-        keypair,
+        &keypair,
         &ledger_path,
         Arc::new(RwLock::new(LeaderScheduler::from_bootstrap_leader(
             leader_pubkey,
@@ -607,7 +607,7 @@ fn create_leader(
     let leader_data = leader.info.clone();
     let leader_fullnode = Fullnode::new(
         leader,
-        leader_keypair,
+        &leader_keypair,
         &ledger_path,
         Arc::new(RwLock::new(LeaderScheduler::from_bootstrap_leader(
             leader_data.id,
@@ -684,7 +684,7 @@ fn test_leader_restart_validator_start_from_old_ledger() -> result::Result<()> {
     let signer_proxy = VoteSignerProxy::new_local(&keypair);
     let val_fullnode = Fullnode::new(
         validator,
-        keypair,
+        &keypair,
         &stale_ledger_path,
         Arc::new(RwLock::new(LeaderScheduler::from_bootstrap_leader(
             leader_data.id,
@@ -757,7 +757,7 @@ fn test_multi_node_dynamic_network() {
     let signer_proxy = VoteSignerProxy::new_local(&leader_keypair);
     let server = Fullnode::new(
         leader,
-        leader_keypair,
+        &leader_keypair,
         &leader_ledger_path,
         Arc::new(RwLock::new(LeaderScheduler::from_bootstrap_leader(
             leader_pubkey,
@@ -831,7 +831,7 @@ fn test_multi_node_dynamic_network() {
                     let signer_proxy = VoteSignerProxy::new_local(&keypair);
                     let val = Fullnode::new(
                         validator,
-                        keypair,
+                        &keypair,
                         &ledger_path,
                         Arc::new(RwLock::new(LeaderScheduler::from_bootstrap_leader(
                             leader_pubkey,
@@ -1008,7 +1008,7 @@ fn test_leader_to_validator_transition() {
     let signer_proxy = VoteSignerProxy::new_local(&leader_keypair);
     let mut leader = Fullnode::new(
         leader_node,
-        leader_keypair,
+        &leader_keypair,
         &leader_ledger_path,
         Arc::new(RwLock::new(LeaderScheduler::new(&leader_scheduler_config))),
         signer_proxy,
@@ -1157,7 +1157,7 @@ fn test_leader_validator_basic() {
     let signer_proxy = VoteSignerProxy::new_local(&validator_keypair);
     let mut validator = Fullnode::new(
         validator_node,
-        validator_keypair,
+        &validator_keypair,
         &validator_ledger_path,
         Arc::new(RwLock::new(LeaderScheduler::new(&leader_scheduler_config))),
         signer_proxy,
@@ -1169,7 +1169,7 @@ fn test_leader_validator_basic() {
     let signer_proxy = VoteSignerProxy::new_local(&leader_keypair);
     let mut leader = Fullnode::new(
         leader_node,
-        leader_keypair,
+        &leader_keypair,
         &leader_ledger_path,
         Arc::new(RwLock::new(LeaderScheduler::new(&leader_scheduler_config))),
         signer_proxy,
@@ -1356,7 +1356,7 @@ fn test_dropped_handoff_recovery() {
     ledger_paths.push(bootstrap_leader_ledger_path.clone());
     let bootstrap_leader = Fullnode::new(
         bootstrap_leader_node,
-        bootstrap_leader_keypair,
+        &bootstrap_leader_keypair,
         &bootstrap_leader_ledger_path,
         Arc::new(RwLock::new(LeaderScheduler::new(&leader_scheduler_config))),
         signer_proxy,
@@ -1378,7 +1378,7 @@ fn test_dropped_handoff_recovery() {
         let signer_proxy = VoteSignerProxy::new_local(&keypair);
         let validator = Fullnode::new(
             validator_node,
-            keypair,
+            &keypair,
             &validator_ledger_path,
             Arc::new(RwLock::new(LeaderScheduler::new(&leader_scheduler_config))),
             signer_proxy,
@@ -1404,7 +1404,7 @@ fn test_dropped_handoff_recovery() {
     let signer_proxy = VoteSignerProxy::new_local(&next_leader_keypair);
     let next_leader = Fullnode::new(
         next_leader_node,
-        next_leader_keypair,
+        &next_leader_keypair,
         &next_leader_ledger_path,
         Arc::new(RwLock::new(LeaderScheduler::new(&leader_scheduler_config))),
         signer_proxy,
@@ -1542,7 +1542,7 @@ fn test_full_leader_validator_network() {
             Arc::new(RwLock::new(LeaderScheduler::new(&leader_scheduler_config)));
         let validator = Fullnode::new(
             validator_node,
-            kp.clone(),
+            &kp,
             &validator_ledger_path,
             leader_scheduler.clone(),
             signer_proxy,
@@ -1559,7 +1559,7 @@ fn test_full_leader_validator_network() {
     let leader_scheduler = Arc::new(RwLock::new(LeaderScheduler::new(&leader_scheduler_config)));
     let bootstrap_leader = Fullnode::new(
         bootstrap_leader_node,
-        leader_keypair.clone(),
+        &leader_keypair,
         &bootstrap_leader_ledger_path,
         leader_scheduler.clone(),
         signer_proxy,
@@ -1731,7 +1731,7 @@ fn test_broadcast_last_tick() {
     let signer_proxy = VoteSignerProxy::new_local(&bootstrap_leader_keypair);
     let mut bootstrap_leader = Fullnode::new(
         bootstrap_leader_node,
-        bootstrap_leader_keypair,
+        &bootstrap_leader_keypair,
         &bootstrap_leader_ledger_path,
         Arc::new(RwLock::new(LeaderScheduler::new(&leader_scheduler_config))),
         signer_proxy,

--- a/tests/replicator.rs
+++ b/tests/replicator.rs
@@ -58,7 +58,7 @@ fn test_replicator_startup() {
             Arc::new(RwLock::new(LeaderScheduler::from_bootstrap_leader(
                 leader_info.id.clone(),
             ))),
-            Some(Arc::new(signer_proxy)),
+            signer_proxy,
             None,
             fullnode_config,
         );
@@ -88,7 +88,7 @@ fn test_replicator_startup() {
             Arc::new(RwLock::new(LeaderScheduler::from_bootstrap_leader(
                 leader_info.id,
             ))),
-            Some(Arc::new(signer_proxy)),
+            signer_proxy,
             Some(&leader_info),
             fullnode_config,
         );
@@ -283,7 +283,7 @@ fn test_replicator_startup_ledger_hang() {
             Arc::new(RwLock::new(LeaderScheduler::from_bootstrap_leader(
                 leader_info.id.clone(),
             ))),
-            Some(Arc::new(signer_proxy)),
+            signer_proxy,
             None,
             Default::default(),
         );
@@ -299,7 +299,7 @@ fn test_replicator_startup_ledger_hang() {
             Arc::new(RwLock::new(LeaderScheduler::from_bootstrap_leader(
                 leader_info.id,
             ))),
-            Some(Arc::new(signer_proxy)),
+            signer_proxy,
             Some(&leader_info),
             Default::default(),
         );

--- a/tests/replicator.rs
+++ b/tests/replicator.rs
@@ -53,7 +53,7 @@ fn test_replicator_startup() {
         fullnode_config.storage_rotate_count = STORAGE_ROTATE_TEST_COUNT;
         let leader = Fullnode::new(
             leader_node,
-            leader_keypair,
+            &leader_keypair,
             &leader_ledger_path,
             Arc::new(RwLock::new(LeaderScheduler::from_bootstrap_leader(
                 leader_info.id.clone(),
@@ -83,7 +83,7 @@ fn test_replicator_startup() {
         fullnode_config.storage_rotate_count = STORAGE_ROTATE_TEST_COUNT;
         let validator = Fullnode::new(
             validator_node,
-            validator_keypair,
+            &validator_keypair,
             &validator_ledger_path,
             Arc::new(RwLock::new(LeaderScheduler::from_bootstrap_leader(
                 leader_info.id,
@@ -278,7 +278,7 @@ fn test_replicator_startup_ledger_hang() {
 
         let _ = Fullnode::new(
             leader_node,
-            leader_keypair,
+            &leader_keypair,
             &leader_ledger_path,
             Arc::new(RwLock::new(LeaderScheduler::from_bootstrap_leader(
                 leader_info.id.clone(),
@@ -294,7 +294,7 @@ fn test_replicator_startup_ledger_hang() {
 
         let _ = Fullnode::new(
             validator_node,
-            validator_keypair,
+            &validator_keypair,
             &validator_ledger_path,
             Arc::new(RwLock::new(LeaderScheduler::from_bootstrap_leader(
                 leader_info.id,


### PR DESCRIPTION
#### Problem

Fullnode has an identity crisis. Is it the `self.keypair.pubkey()` or `vote_signer.pubkey()`? 

#### Summary of Changes

Working towards making it `vote_signer.pubkey()` by always passing in a vote signer.

See: https://github.com/solana-labs/solana/pull/2606/files#diff-21255577786bba557100b7ab93ff6e17R52
