### PR TITLE
Don't set socket as blocking in recvmmsg for non Linux targets

### DIFF
--- a/src/recvmmsg.rs
+++ b/src/recvmmsg.rs
@@ -10,7 +10,6 @@ pub const NUM_RCVMMSGS: usize = 16;
 #[cfg(not(target_os = "linux"))]
 pub fn recv_mmsg(socket: &UdpSocket, packets: &mut [Packet]) -> io::Result<usize> {
     let mut i = 0;
-    socket.set_nonblocking(false)?;
     let count = cmp::min(NUM_RCVMMSGS, packets.len());
     for p in packets.iter_mut().take(count) {
         p.meta.size = 0;


### PR DESCRIPTION
#### Problem
For non Linux target, the recvmmsg implementation is setting socket to blocking. In certain conditions (e.g. when the function is called multiple times) it causes function to block for timeout even if it had previously received some data.

#### Summary of Changes
Remove set_nonblocking(false) call from recvmmsg for non Linux targets.
