### PR TITLE
Fix potential of checking tvu bank for truth when its behind

### DIFF
--- a/src/bank.rs
+++ b/src/bank.rs
@@ -873,6 +873,11 @@ impl Bank {
     pub fn tick_height(&self) -> u64 {
         self.last_ids.read().unwrap().tick_height
     }
+
+    #[cfg(test)]
+    pub fn last_ids(&self) -> &RwLock<StatusDeque<Result<()>>> {
+        &self.last_ids
+    }
 }
 
 #[cfg(test)]

--- a/src/poh_recorder.rs
+++ b/src/poh_recorder.rs
@@ -25,6 +25,10 @@ pub struct PohRecorder {
 }
 
 impl PohRecorder {
+    pub fn max_tick_height(&self) -> Option<u64> {
+        self.max_tick_height
+    }
+
     pub fn hash(&self) -> Result<()> {
         // TODO: amortize the cost of this lock by doing the loop in here for
         // some min amount of hashes

--- a/src/tpu.rs
+++ b/src/tpu.rs
@@ -19,7 +19,7 @@ use std::sync::{Arc, RwLock};
 use std::thread;
 
 pub enum TpuReturnType {
-    LeaderRotation,
+    LeaderRotation(u64),
 }
 
 pub enum TpuMode {
@@ -246,8 +246,8 @@ impl Service for Tpu {
                 svcs.fetch_stage.join()?;
                 svcs.sigverify_stage.join()?;
                 match svcs.banking_stage.join()? {
-                    Some(BankingStageReturnType::LeaderRotation) => {
-                        Ok(Some(TpuReturnType::LeaderRotation))
+                    Some(BankingStageReturnType::LeaderRotation(tick_height)) => {
+                        Ok(Some(TpuReturnType::LeaderRotation(tick_height)))
                     }
                     _ => Ok(None),
                 }

--- a/tests/multinode.rs
+++ b/tests/multinode.rs
@@ -1266,9 +1266,9 @@ fn run_node(id: Pubkey, mut fullnode: Fullnode, should_exit: Arc<AtomicBool>) ->
                     fullnode.validator_to_leader(tick_height, entry_height, last_entry_id);
                 }
                 Err(_) => match should_be_fwdr {
-                    Ok(TpuReturnType::LeaderRotation) => {
+                    Ok(TpuReturnType::LeaderRotation(tick_height)) => {
                         fullnode
-                            .leader_to_validator()
+                            .leader_to_validator(tick_height)
                             .expect("failed when transitioning to validator");
                     }
                     Err(_) => {


### PR DESCRIPTION
#### Problem
In leader_to_validator(), the node was checking the TVU bank to see who the next leader is, in case it needs to transition back to being a leader. However, the TVU bank could be some arbitrary number of ticks behind the TPU bank, so the get_current_leader() check in leader_to_validator() could potentially inaccurately say that the node is still the leader, causing it to transition back to being a leader and broadcast blobs during another node's slot.

#### Summary of Changes
Wait for tvu bank to catch up to the point of leader rotation before checking who the next leader is. This is necessary in case the next slot is the first slot of the next epoch, in which case the next leader won't be known until that last tick is received and processed by the TVU.

Fixes #
