### PR TITLE
treat genesis special

### DIFF
--- a/src/fullnode.rs
+++ b/src/fullnode.rs
@@ -391,9 +391,7 @@ impl Fullnode {
         let entries = db_ledger.read_ledger().expect("opening ledger");
         info!("processing ledger...");
 
-        let (entry_height, last_entry_id) = bank
-            .process_ledger(genesis_block, entries)
-            .expect("process_ledger");
+        let (entry_height, last_entry_id) = bank.process_ledger(entries).expect("process_ledger");
         // entry_height is the network-wide agreed height of the ledger.
         //  initialize it from the input ledger
         info!(

--- a/src/last_id_queue.rs
+++ b/src/last_id_queue.rs
@@ -52,6 +52,19 @@ impl LastIdQueue {
     pub fn check_entry(&self, entry_id: Hash) -> bool {
         self.entries.get(&entry_id).is_some()
     }
+
+    pub fn genesis_last_id(&mut self, last_id: &Hash) {
+        self.entries.insert(
+            *last_id,
+            LastIdEntry {
+                tick_height: 0,
+                timestamp: timestamp(),
+            },
+        );
+
+        self.last_id = Some(*last_id);
+    }
+
     /// Tell the bank which Entry IDs exist on the ledger. This function
     /// assumes subsequent calls correspond to later entries, and will boot
     /// the oldest ones once its internal cache is full. Once boot, the


### PR DESCRIPTION
#### Problem
we want ticks to come only from the ledger, but we also need a bank last_id at genesis, we were jumping through hoops in process_ledger() to accomplish

 #### Summary of Changes
 treat genesis block as special: record it as a valid last_id, but not as a tick