### PR TITLE
Use VoteProgram account as staking account, take 2

### DIFF
--- a/fullnode/src/main.rs
+++ b/fullnode/src/main.rs
@@ -10,7 +10,6 @@ use solana::thin_client::{poll_gossip_for_leader, ThinClient};
 use solana::vote_signer_proxy::{RemoteVoteSigner, VoteSignerProxy};
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::{Keypair, KeypairUtil};
-use solana_sdk::vote_program::VoteProgram;
 use solana_sdk::vote_transaction::VoteTransaction;
 use solana_vote_signer::rpc::{LocalVoteSigner, VoteSigner};
 use std::fs::File;
@@ -111,12 +110,8 @@ fn create_and_fund_vote_account(
 
     info!("Checking for vote account registration");
     let vote_account_user_data = client.get_account_userdata(&vote_account);
-    if let Ok(Some(vote_account_user_data)) = vote_account_user_data {
-        if let Ok(vote_state) = VoteProgram::deserialize(&vote_account_user_data) {
-            if vote_state.node_id == pubkey {
-                return Ok(());
-            }
-        }
+    if let Ok(Some(_)) = vote_account_user_data {
+        return Ok(());
     }
 
     Err(Error::new(

--- a/programs/native/vote/src/lib.rs
+++ b/programs/native/vote/src/lib.rs
@@ -17,7 +17,7 @@ fn register(keyed_accounts: &mut [KeyedAccount]) -> Result<(), ProgramError> {
 
     // TODO: a single validator could register multiple "vote accounts"
     // which would clutter the "accounts" structure. See github issue 1654.
-    let vote_state = VoteProgram::new(*keyed_accounts[0].signer_key().unwrap());
+    let vote_state = VoteProgram::default();
     vote_state.serialize(&mut keyed_accounts[1].account.userdata)?;
 
     Ok(())
@@ -121,7 +121,6 @@ mod tests {
         ];
 
         let vote_state = register_and_deserialize(&mut keyed_accounts).unwrap();
-        assert_eq!(vote_state.node_id, voter_id);
         assert!(vote_state.votes.is_empty());
     }
 

--- a/sdk/src/vote_program.rs
+++ b/sdk/src/vote_program.rs
@@ -49,7 +49,6 @@ pub enum VoteInstruction {
 #[derive(Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct VoteProgram {
     pub votes: VecDeque<Vote>,
-    pub node_id: Pubkey,
 }
 
 pub fn get_max_size() -> usize {
@@ -61,11 +60,6 @@ pub fn get_max_size() -> usize {
 }
 
 impl VoteProgram {
-    pub fn new(node_id: Pubkey) -> Self {
-        let votes = VecDeque::new();
-        Self { votes, node_id }
-    }
-
     pub fn deserialize(input: &[u8]) -> Result<VoteProgram, ProgramError> {
         deserialize(input).map_err(|_| ProgramError::InvalidUserdata)
     }

--- a/sdk/src/vote_program.rs
+++ b/sdk/src/vote_program.rs
@@ -42,12 +42,18 @@ pub enum VoteInstruction {
     /// * Transaction::keys[0] - the new "vote account"
     /// identified by keys[0] for voting
     InitializeAccount,
+
+    /// Delegate block producing to the Fullnode with the given `node_id`
+    Delegate(Pubkey),
+
+    /// Commit to a fork by voting on a block
     Vote(Vote),
 }
 
 #[derive(Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct VoteProgram {
     pub votes: VecDeque<Vote>,
+    pub node_id: Pubkey,
 }
 
 pub fn get_max_size() -> usize {

--- a/sdk/src/vote_program.rs
+++ b/sdk/src/vote_program.rs
@@ -37,13 +37,12 @@ impl Vote {
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub enum VoteInstruction {
-    /// Register a new "vote account" to represent a particular validator in the Vote Contract,
+    /// Initialize a new "vote account" to represent a particular validator in the Vote Program,
     /// and initialize the VoteState for this "vote account"
-    /// * Transaction::keys[0] - the validator id
-    /// * Transaction::keys[1] - the new "vote account" to be associated with the validator
+    /// * Transaction::keys[0] - the new "vote account"
     /// identified by keys[0] for voting
-    RegisterAccount,
-    NewVote(Vote),
+    InitializeAccount,
+    Vote(Vote),
 }
 
 #[derive(Debug, Default, Serialize, Deserialize, PartialEq, Eq)]

--- a/sdk/src/vote_transaction.rs
+++ b/sdk/src/vote_transaction.rs
@@ -35,7 +35,7 @@ impl VoteTransaction for Transaction {
         fee: u64,
     ) -> Self {
         let vote = Vote { tick_height };
-        let instruction = VoteInstruction::NewVote(vote);
+        let instruction = VoteInstruction::Vote(vote);
         Transaction::new(
             vote_account,
             &[],
@@ -47,14 +47,14 @@ impl VoteTransaction for Transaction {
     }
 
     fn vote_account_new(
-        validator_id: &Keypair,
+        from_keypair: &Keypair,
         vote_account_id: Pubkey,
         last_id: Hash,
         num_tokens: u64,
         fee: u64,
     ) -> Self {
         Transaction::new_with_instructions(
-            &[validator_id],
+            &[from_keypair],
             &[vote_account_id],
             last_id,
             fee,
@@ -69,7 +69,7 @@ impl VoteTransaction for Transaction {
                     },
                     vec![0, 1],
                 ),
-                Instruction::new(1, &VoteInstruction::RegisterAccount, vec![0, 1]),
+                Instruction::new(1, &VoteInstruction::InitializeAccount, vec![1]),
             ],
         )
     }
@@ -79,7 +79,7 @@ impl VoteTransaction for Transaction {
         for i in 0..self.instructions.len() {
             let tx_program_id = self.program_id(i);
             if vote_program::check_id(&tx_program_id) {
-                if let Ok(Some(VoteInstruction::NewVote(vote))) = deserialize(&self.userdata(i)) {
+                if let Ok(Some(VoteInstruction::Vote(vote))) = deserialize(&self.userdata(i)) {
                     votes.push((self.account_keys[0], vote, self.last_id))
                 }
             }

--- a/src/leader_scheduler.rs
+++ b/src/leader_scheduler.rs
@@ -309,8 +309,7 @@ impl LeaderScheduler {
     }
 
     // TODO: We use a HashSet for now because a single validator could potentially register
-    // multiple vote account. Once that is no longer possible (see the TODO in vote_program.rs,
-    // process_transaction(), case VoteInstruction::RegisterAccount), we can use a vector.
+    // multiple vote account. Once that is no longer possible, we can use a vector.
     fn get_active_set(&mut self, height: u64, bank: &Bank) -> HashSet<Pubkey> {
         let upper_bound = height;
         let lower_bound = height.saturating_sub(self.active_window_length);

--- a/src/leader_scheduler.rs
+++ b/src/leader_scheduler.rs
@@ -321,8 +321,8 @@ impl LeaderScheduler {
             // TODO: iterate through checkpoints, too
             accounts
                 .accounts
-                .values()
-                .filter_map(|account| {
+                .iter()
+                .filter_map(|(node_id, account)| {
                     if vote_program::check_id(&account.owner) {
                         if let Ok(vote_state) = VoteProgram::deserialize(&account.userdata) {
                             return vote_state
@@ -332,7 +332,7 @@ impl LeaderScheduler {
                                     vote.tick_height > lower_bound
                                         && vote.tick_height <= upper_bound
                                 })
-                                .map(|_| vote_state.node_id);
+                                .map(|_| *node_id);
                         }
                     }
 

--- a/src/thin_client.rs
+++ b/src/thin_client.rs
@@ -473,7 +473,6 @@ mod tests {
     use bincode::{deserialize, serialize};
     use solana_sdk::signature::{Keypair, KeypairUtil};
     use solana_sdk::system_instruction::SystemInstruction;
-    use solana_sdk::vote_program::VoteProgram;
     use solana_sdk::vote_transaction::VoteTransaction;
     use std::fs::remove_dir_all;
 
@@ -584,25 +583,6 @@ mod tests {
         let balance = retry_get_balance(&mut client, &vote_account_id, Some(1))
             .expect("Expected balance for new account to exist");
         assert_eq!(balance, 1);
-
-        const LAST: usize = 30;
-        for run in 0..=LAST {
-            let account_user_data = client
-                .get_account_userdata(&vote_account_id)
-                .expect("Expected valid response for account userdata")
-                .expect("Expected valid account userdata to exist after account creation");
-
-            let vote_state = VoteProgram::deserialize(&account_user_data);
-
-            if vote_state.map(|vote_state| vote_state.node_id) == Ok(validator_keypair.pubkey()) {
-                break;
-            }
-
-            if run == LAST {
-                panic!("Expected successful vote account registration");
-            }
-            sleep(Duration::from_millis(900));
-        }
 
         server.close().unwrap();
         remove_dir_all(ledger_path).unwrap();


### PR DESCRIPTION
#### Problem

When we create the VoteProgram account, we point it to a pubkey, which is used as both a staking account and to delegate its block producing responsibility. That first part is a bug. It's the VoteProgram account that's guarded by the VoteSigner, not the fullnode's account.

#### Summary of Changes

* Replace `RegisterAccount` with simpler new `InitializeAccount`, which does not need to be signed
* Add new `Delegate` instruction, which must be signed by the staker
* Rename `NewVote` instruction to `Vote`

TODO:
- [ ] Allow leader rotation using the `VoteProgram`'s pubkey, if it hasn't chosen to delegate.
- [ ] Test multiple `Delegate` instructions. A staker should be able to change what fullnode does its bidding.
- [ ] Update tests to stop creating an extra account for staking. Use the `VoteProgram` account.
- [ ] Fix the half-dozen tests this breaks

Fixes #2551
