### PR TITLE
Rename VoteSignerProxy to VotingKeypair

### DIFF
--- a/fullnode/src/main.rs
+++ b/fullnode/src/main.rs
@@ -7,7 +7,7 @@ use solana::leader_scheduler::LeaderScheduler;
 use solana::local_vote_signer_service::LocalVoteSignerService;
 use solana::socketaddr;
 use solana::thin_client::{poll_gossip_for_leader, ThinClient};
-use solana::vote_signer_proxy::{RemoteVoteSigner, VoteSignerProxy};
+use solana::voting_keypair::{RemoteVoteSigner, VotingKeypair};
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::{Keypair, KeypairUtil};
 use solana_sdk::vote_program::VoteProgram;
@@ -257,7 +257,7 @@ fn main() {
     } else {
         Box::new(LocalVoteSigner::default())
     };
-    let vote_signer = VoteSignerProxy::new_with_signer(&keypair, vote_signer);
+    let vote_signer = VotingKeypair::new_with_signer(&keypair, vote_signer);
     let vote_account_id = vote_signer.pubkey();
     info!("New vote account ID is {:?}", vote_account_id);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,7 +70,7 @@ pub mod thin_client;
 pub mod tpu;
 pub mod tpu_forwarder;
 pub mod tvu;
-pub mod vote_signer_proxy;
+pub mod voting_keypair;
 #[cfg(test)]
 pub mod window;
 pub mod window_service;
@@ -94,7 +94,6 @@ use solana_jsonrpc_http_server as jsonrpc_http_server;
 extern crate solana_jsonrpc_macros as jsonrpc_macros;
 use solana_jsonrpc_pubsub as jsonrpc_pubsub;
 use solana_jsonrpc_ws_server as jsonrpc_ws_server;
-//use solana_vote_signer;
 
 #[cfg(test)]
 #[macro_use]

--- a/src/result.rs
+++ b/src/result.rs
@@ -7,7 +7,6 @@ use crate::db_ledger;
 use crate::erasure;
 use crate::packet;
 use crate::poh_recorder;
-use crate::vote_signer_proxy;
 use bincode;
 use serde_json;
 use std;
@@ -29,7 +28,6 @@ pub enum Error {
     ErasureError(erasure::ErasureError),
     SendError,
     PohRecorderError(poh_recorder::PohRecorderError),
-    VoteError(vote_signer_proxy::VoteError),
     DbLedgerError(db_ledger::DbLedgerError),
 }
 
@@ -102,11 +100,6 @@ impl std::convert::From<std::boxed::Box<bincode::ErrorKind>> for Error {
 impl std::convert::From<poh_recorder::PohRecorderError> for Error {
     fn from(e: poh_recorder::PohRecorderError) -> Error {
         Error::PohRecorderError(e)
-    }
-}
-impl std::convert::From<vote_signer_proxy::VoteError> for Error {
-    fn from(e: vote_signer_proxy::VoteError) -> Error {
-        Error::VoteError(e)
     }
 }
 impl std::convert::From<db_ledger::DbLedgerError> for Error {

--- a/src/thin_client.rs
+++ b/src/thin_client.rs
@@ -440,7 +440,7 @@ pub fn new_fullnode(ledger_name: &'static str) -> (Fullnode, NodeInfo, Keypair, 
     use crate::cluster_info::Node;
     use crate::db_ledger::create_tmp_sample_ledger;
     use crate::leader_scheduler::LeaderScheduler;
-    use crate::vote_signer_proxy::VoteSignerProxy;
+    use crate::voting_keypair::VotingKeypair;
     use solana_sdk::signature::KeypairUtil;
 
     let node_keypair = Arc::new(Keypair::new());
@@ -452,13 +452,13 @@ pub fn new_fullnode(ledger_name: &'static str) -> (Fullnode, NodeInfo, Keypair, 
 
     let leader_scheduler = LeaderScheduler::from_bootstrap_leader(node_info.id);
     let vote_account_keypair = Arc::new(Keypair::new());
-    let vote_signer = VoteSignerProxy::new_local(&vote_account_keypair);
+    let voting_keypair = VotingKeypair::new_local(&vote_account_keypair);
     let node = Fullnode::new(
         node,
         &node_keypair,
         &ledger_path,
         Arc::new(RwLock::new(leader_scheduler)),
-        vote_signer,
+        voting_keypair,
         None,
         Default::default(),
     );

--- a/src/tvu.rs
+++ b/src/tvu.rs
@@ -22,7 +22,7 @@ use crate::retransmit_stage::RetransmitStage;
 use crate::service::Service;
 use crate::storage_stage::{StorageStage, StorageState};
 use crate::streamer::BlobSender;
-use crate::vote_signer_proxy::VoteSignerProxy;
+use crate::voting_keypair::VotingKeypair;
 use solana_sdk::hash::Hash;
 use solana_sdk::signature::{Keypair, KeypairUtil};
 use std::net::UdpSocket;
@@ -64,7 +64,7 @@ impl Tvu {
     /// * `db_ledger` - the ledger itself
     #[allow(clippy::new_ret_no_self, clippy::too_many_arguments)]
     pub fn new(
-        vote_signer: Option<Arc<VoteSignerProxy>>,
+        voting_keypair: Option<Arc<VotingKeypair>>,
         bank: &Arc<Bank>,
         entry_height: u64,
         last_entry_id: Hash,
@@ -119,7 +119,7 @@ impl Tvu {
 
         let (replay_stage, ledger_entry_receiver) = ReplayStage::new(
             keypair.pubkey(),
-            vote_signer,
+            voting_keypair,
             bank.clone(),
             cluster_info.clone(),
             blob_window_receiver,
@@ -205,7 +205,7 @@ pub mod tests {
     use crate::storage_stage::{StorageState, STORAGE_ROTATE_TEST_COUNT};
     use crate::streamer;
     use crate::tvu::{Sockets, Tvu};
-    use crate::vote_signer_proxy::VoteSignerProxy;
+    use crate::voting_keypair::VotingKeypair;
     use bincode::serialize;
     use solana_sdk::hash::Hash;
     use solana_sdk::signature::{Keypair, KeypairUtil};
@@ -291,10 +291,10 @@ pub mod tests {
         let db_ledger =
             DbLedger::open(&db_ledger_path).expect("Expected to successfully open ledger");
         let vote_account_keypair = Arc::new(Keypair::new());
-        let vote_signer = VoteSignerProxy::new_local(&vote_account_keypair);
+        let voting_keypair = VotingKeypair::new_local(&vote_account_keypair);
         let (sender, _) = channel();
         let (tvu, _) = Tvu::new(
-            Some(Arc::new(vote_signer)),
+            Some(Arc::new(voting_keypair)),
             &bank,
             0,
             cur_hash,

--- a/src/voting_keypair.rs
+++ b/src/voting_keypair.rs
@@ -54,8 +54,8 @@ impl VoteSigner for RemoteVoteSigner {
     }
 }
 
-impl KeypairUtil for VoteSignerProxy {
-    /// Return a local VoteSignerProxy with a new keypair. Used for unit-tests.
+impl KeypairUtil for VotingKeypair {
+    /// Return a local VotingKeypair with a new keypair. Used for unit-tests.
     fn new() -> Self {
         Self::new_local(&Arc::new(Keypair::new()))
     }
@@ -71,13 +71,13 @@ impl KeypairUtil for VoteSignerProxy {
     }
 }
 
-pub struct VoteSignerProxy {
+pub struct VotingKeypair {
     keypair: Arc<Keypair>,
     signer: Box<VoteSigner + Send + Sync>,
     vote_account: Pubkey,
 }
 
-impl VoteSignerProxy {
+impl VotingKeypair {
     pub fn new_with_signer(keypair: &Arc<Keypair>, signer: Box<VoteSigner + Send + Sync>) -> Self {
         let msg = "Registering a new node";
         let sig = keypair.sign_message(msg.as_bytes());

--- a/tests/multinode.rs
+++ b/tests/multinode.rs
@@ -17,7 +17,7 @@ use solana::service::Service;
 use solana::thin_client::{poll_gossip_for_leader, retry_get_balance, ThinClient};
 use solana::tpu::TpuReturnType;
 use solana::tvu::TvuReturnType;
-use solana::vote_signer_proxy::VoteSignerProxy;
+use solana::voting_keypair::VotingKeypair;
 use solana_sdk::hash::Hash;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::{Keypair, KeypairUtil};
@@ -154,7 +154,7 @@ fn test_multi_node_ledger_window() -> result::Result<()> {
             .unwrap();
     }
 
-    let signer_proxy = VoteSignerProxy::new_local(&leader_keypair);
+    let voting_keypair = VotingKeypair::new_local(&leader_keypair);
     let leader = Fullnode::new(
         leader,
         &leader_keypair,
@@ -162,7 +162,7 @@ fn test_multi_node_ledger_window() -> result::Result<()> {
         Arc::new(RwLock::new(LeaderScheduler::from_bootstrap_leader(
             leader_pubkey,
         ))),
-        signer_proxy,
+        voting_keypair,
         None,
         Default::default(),
     );
@@ -173,7 +173,7 @@ fn test_multi_node_ledger_window() -> result::Result<()> {
     let validator_pubkey = keypair.pubkey().clone();
     let validator = Node::new_localhost_with_pubkey(keypair.pubkey());
     let validator_data = validator.info.clone();
-    let signer_proxy = VoteSignerProxy::new_local(&keypair);
+    let voting_keypair = VotingKeypair::new_local(&keypair);
     let validator = Fullnode::new(
         validator,
         &keypair,
@@ -181,7 +181,7 @@ fn test_multi_node_ledger_window() -> result::Result<()> {
         Arc::new(RwLock::new(LeaderScheduler::from_bootstrap_leader(
             leader_pubkey,
         ))),
-        signer_proxy,
+        voting_keypair,
         Some(&leader_data),
         Default::default(),
     );
@@ -257,7 +257,7 @@ fn test_multi_node_validator_catchup_from_zero() -> result::Result<()> {
         "multi_node_validator_catchup_from_zero",
     );
     ledger_paths.push(leader_ledger_path.clone());
-    let signer_proxy = VoteSignerProxy::new_local(&leader_keypair);
+    let voting_keypair = VotingKeypair::new_local(&leader_keypair);
     let server = Fullnode::new(
         leader,
         &leader_keypair,
@@ -265,7 +265,7 @@ fn test_multi_node_validator_catchup_from_zero() -> result::Result<()> {
         Arc::new(RwLock::new(LeaderScheduler::from_bootstrap_leader(
             leader_pubkey,
         ))),
-        signer_proxy,
+        voting_keypair,
         None,
         Default::default(),
     );
@@ -290,7 +290,7 @@ fn test_multi_node_validator_catchup_from_zero() -> result::Result<()> {
             validator_pubkey, validator_balance
         );
 
-        let signer_proxy = VoteSignerProxy::new_local(&keypair);
+        let voting_keypair = VotingKeypair::new_local(&keypair);
         let val = Fullnode::new(
             validator,
             &keypair,
@@ -298,7 +298,7 @@ fn test_multi_node_validator_catchup_from_zero() -> result::Result<()> {
             Arc::new(RwLock::new(LeaderScheduler::from_bootstrap_leader(
                 leader_pubkey,
             ))),
-            signer_proxy,
+            voting_keypair,
             Some(&leader_data),
             Default::default(),
         );
@@ -350,7 +350,7 @@ fn test_multi_node_validator_catchup_from_zero() -> result::Result<()> {
     let keypair = Arc::new(Keypair::new());
     let validator_pubkey = keypair.pubkey().clone();
     let validator = Node::new_localhost_with_pubkey(keypair.pubkey());
-    let signer_proxy = VoteSignerProxy::new_local(&keypair);
+    let voting_keypair = VotingKeypair::new_local(&keypair);
     info!("created start from zero validator {:?}", validator_pubkey);
 
     let val = Fullnode::new(
@@ -360,7 +360,7 @@ fn test_multi_node_validator_catchup_from_zero() -> result::Result<()> {
         Arc::new(RwLock::new(LeaderScheduler::from_bootstrap_leader(
             leader_pubkey,
         ))),
-        signer_proxy,
+        voting_keypair,
         Some(&leader_data),
         Default::default(),
     );
@@ -441,7 +441,7 @@ fn test_multi_node_basic() {
     let leader_ledger_path = tmp_copy_ledger(&genesis_ledger_path, "multi_node_basic");
     ledger_paths.push(leader_ledger_path.clone());
 
-    let signer_proxy = VoteSignerProxy::new_local(&leader_keypair);
+    let voting_keypair = VotingKeypair::new_local(&leader_keypair);
     let server = Fullnode::new(
         leader,
         &leader_keypair,
@@ -449,7 +449,7 @@ fn test_multi_node_basic() {
         Arc::new(RwLock::new(LeaderScheduler::from_bootstrap_leader(
             leader_pubkey,
         ))),
-        signer_proxy,
+        voting_keypair,
         None,
         Default::default(),
     );
@@ -470,7 +470,7 @@ fn test_multi_node_basic() {
             "validator {}, balance {}",
             validator_pubkey, validator_balance
         );
-        let signer_proxy = VoteSignerProxy::new_local(&keypair);
+        let voting_keypair = VotingKeypair::new_local(&keypair);
         let val = Fullnode::new(
             validator,
             &keypair,
@@ -478,7 +478,7 @@ fn test_multi_node_basic() {
             Arc::new(RwLock::new(LeaderScheduler::from_bootstrap_leader(
                 leader_pubkey,
             ))),
-            signer_proxy,
+            voting_keypair,
             Some(&leader_data),
             Default::default(),
         );
@@ -549,7 +549,7 @@ fn test_boot_validator_from_file() -> result::Result<()> {
     ledger_paths.push(leader_ledger_path.clone());
 
     let leader_data = leader.info.clone();
-    let signer_proxy = VoteSignerProxy::new_local(&leader_keypair);
+    let voting_keypair = VotingKeypair::new_local(&leader_keypair);
     let leader_fullnode = Fullnode::new(
         leader,
         &leader_keypair,
@@ -557,7 +557,7 @@ fn test_boot_validator_from_file() -> result::Result<()> {
         Arc::new(RwLock::new(LeaderScheduler::from_bootstrap_leader(
             leader_pubkey,
         ))),
-        signer_proxy,
+        voting_keypair,
         None,
         Default::default(),
     );
@@ -573,7 +573,7 @@ fn test_boot_validator_from_file() -> result::Result<()> {
     let validator_data = validator.info.clone();
     let ledger_path = tmp_copy_ledger(&genesis_ledger_path, "boot_validator_from_file");
     ledger_paths.push(ledger_path.clone());
-    let signer_proxy = VoteSignerProxy::new_local(&keypair);
+    let voting_keypair = VotingKeypair::new_local(&keypair);
     let val_fullnode = Fullnode::new(
         validator,
         &keypair,
@@ -581,7 +581,7 @@ fn test_boot_validator_from_file() -> result::Result<()> {
         Arc::new(RwLock::new(LeaderScheduler::from_bootstrap_leader(
             leader_pubkey,
         ))),
-        signer_proxy,
+        voting_keypair,
         Some(&leader_data),
         Default::default(),
     );
@@ -602,7 +602,7 @@ fn test_boot_validator_from_file() -> result::Result<()> {
 fn create_leader(
     ledger_path: &str,
     leader_keypair: Arc<Keypair>,
-    signer: VoteSignerProxy,
+    voting_keypair: VotingKeypair,
 ) -> (NodeInfo, Fullnode) {
     let leader = Node::new_localhost_with_pubkey(leader_keypair.pubkey());
     let leader_data = leader.info.clone();
@@ -613,7 +613,7 @@ fn create_leader(
         Arc::new(RwLock::new(LeaderScheduler::from_bootstrap_leader(
             leader_data.id,
         ))),
-        signer,
+        voting_keypair,
         None,
         Default::default(),
     );
@@ -639,9 +639,9 @@ fn test_leader_restart_validator_start_from_old_ledger() -> result::Result<()> {
     let bob_pubkey = Keypair::new().pubkey();
 
     {
-        let signer_proxy = VoteSignerProxy::new_local(&leader_keypair);
+        let voting_keypair = VotingKeypair::new_local(&leader_keypair);
         let (leader_data, leader_fullnode) =
-            create_leader(&ledger_path, leader_keypair.clone(), signer_proxy);
+            create_leader(&ledger_path, leader_keypair.clone(), voting_keypair);
 
         // lengthen the ledger
         let leader_balance =
@@ -660,9 +660,9 @@ fn test_leader_restart_validator_start_from_old_ledger() -> result::Result<()> {
     );
 
     {
-        let signer_proxy = VoteSignerProxy::new_local(&leader_keypair);
+        let voting_keypair = VotingKeypair::new_local(&leader_keypair);
         let (leader_data, leader_fullnode) =
-            create_leader(&ledger_path, leader_keypair.clone(), signer_proxy);
+            create_leader(&ledger_path, leader_keypair.clone(), voting_keypair);
 
         // lengthen the ledger
         let leader_balance =
@@ -674,15 +674,16 @@ fn test_leader_restart_validator_start_from_old_ledger() -> result::Result<()> {
         leader_fullnode.close()?;
     }
 
-    let signer_proxy = VoteSignerProxy::new_local(&leader_keypair);
-    let (leader_data, leader_fullnode) = create_leader(&ledger_path, leader_keypair, signer_proxy);
+    let voting_keypair = VotingKeypair::new_local(&leader_keypair);
+    let (leader_data, leader_fullnode) =
+        create_leader(&ledger_path, leader_keypair, voting_keypair);
 
     // start validator from old ledger
     let keypair = Arc::new(Keypair::new());
     let validator = Node::new_localhost_with_pubkey(keypair.pubkey());
     let validator_data = validator.info.clone();
 
-    let signer_proxy = VoteSignerProxy::new_local(&keypair);
+    let voting_keypair = VotingKeypair::new_local(&keypair);
     let val_fullnode = Fullnode::new(
         validator,
         &keypair,
@@ -690,7 +691,7 @@ fn test_leader_restart_validator_start_from_old_ledger() -> result::Result<()> {
         Arc::new(RwLock::new(LeaderScheduler::from_bootstrap_leader(
             leader_data.id,
         ))),
-        signer_proxy,
+        voting_keypair,
         Some(&leader_data),
         Default::default(),
     );
@@ -755,7 +756,7 @@ fn test_multi_node_dynamic_network() {
 
     let leader_ledger_path = tmp_copy_ledger(&genesis_ledger_path, "multi_node_dynamic_network");
     ledger_paths.push(leader_ledger_path.clone());
-    let signer_proxy = VoteSignerProxy::new_local(&leader_keypair);
+    let voting_keypair = VotingKeypair::new_local(&leader_keypair);
     let server = Fullnode::new(
         leader,
         &leader_keypair,
@@ -763,7 +764,7 @@ fn test_multi_node_dynamic_network() {
         Arc::new(RwLock::new(LeaderScheduler::from_bootstrap_leader(
             leader_pubkey,
         ))),
-        signer_proxy,
+        voting_keypair,
         None,
         Default::default(),
     );
@@ -829,7 +830,7 @@ fn test_multi_node_dynamic_network() {
                     let rd = validator.info.clone();
                     info!("starting {} {}", keypair.pubkey(), rd.id);
                     let keypair = Arc::new(keypair);
-                    let signer_proxy = VoteSignerProxy::new_local(&keypair);
+                    let voting_keypair = VotingKeypair::new_local(&keypair);
                     let val = Fullnode::new(
                         validator,
                         &keypair,
@@ -837,7 +838,7 @@ fn test_multi_node_dynamic_network() {
                         Arc::new(RwLock::new(LeaderScheduler::from_bootstrap_leader(
                             leader_pubkey,
                         ))),
-                        signer_proxy,
+                        voting_keypair,
                         Some(&leader_data),
                         Default::default(),
                     );
@@ -1006,13 +1007,13 @@ fn test_leader_to_validator_transition() {
         bootstrap_height,
     );
 
-    let signer_proxy = VoteSignerProxy::new_local(&leader_keypair);
+    let voting_keypair = VotingKeypair::new_local(&leader_keypair);
     let mut leader = Fullnode::new(
         leader_node,
         &leader_keypair,
         &leader_ledger_path,
         Arc::new(RwLock::new(LeaderScheduler::new(&leader_scheduler_config))),
-        signer_proxy,
+        voting_keypair,
         Some(&leader_info),
         Default::default(),
     );
@@ -1155,25 +1156,25 @@ fn test_leader_validator_basic() {
     );
 
     // Start the validator node
-    let signer_proxy = VoteSignerProxy::new_local(&validator_keypair);
+    let voting_keypair = VotingKeypair::new_local(&validator_keypair);
     let mut validator = Fullnode::new(
         validator_node,
         &validator_keypair,
         &validator_ledger_path,
         Arc::new(RwLock::new(LeaderScheduler::new(&leader_scheduler_config))),
-        signer_proxy,
+        voting_keypair,
         Some(&leader_info),
         Default::default(),
     );
 
     // Start the leader fullnode
-    let signer_proxy = VoteSignerProxy::new_local(&leader_keypair);
+    let voting_keypair = VotingKeypair::new_local(&leader_keypair);
     let mut leader = Fullnode::new(
         leader_node,
         &leader_keypair,
         &leader_ledger_path,
         Arc::new(RwLock::new(LeaderScheduler::new(&leader_scheduler_config))),
-        signer_proxy,
+        voting_keypair,
         Some(&leader_info),
         Default::default(),
     );
@@ -1349,7 +1350,7 @@ fn test_dropped_handoff_recovery() {
     info!("bootstrap_leader: {}", bootstrap_leader_keypair.pubkey());
     info!("'next leader': {}", next_leader_keypair.pubkey());
 
-    let signer_proxy = VoteSignerProxy::new_local(&bootstrap_leader_keypair);
+    let voting_keypair = VotingKeypair::new_local(&bootstrap_leader_keypair);
     // Start up the bootstrap leader fullnode
     let bootstrap_leader_ledger_path =
         tmp_copy_ledger(&genesis_ledger_path, "test_dropped_handoff_recovery");
@@ -1359,7 +1360,7 @@ fn test_dropped_handoff_recovery() {
         &bootstrap_leader_keypair,
         &bootstrap_leader_ledger_path,
         Arc::new(RwLock::new(LeaderScheduler::new(&leader_scheduler_config))),
-        signer_proxy,
+        voting_keypair,
         Some(&bootstrap_leader_info),
         Default::default(),
     );
@@ -1375,13 +1376,13 @@ fn test_dropped_handoff_recovery() {
         let validator_id = keypair.pubkey();
         info!("validator {}: {}", i, validator_id);
         let validator_node = Node::new_localhost_with_pubkey(validator_id);
-        let signer_proxy = VoteSignerProxy::new_local(&keypair);
+        let voting_keypair = VotingKeypair::new_local(&keypair);
         let validator = Fullnode::new(
             validator_node,
             &keypair,
             &validator_ledger_path,
             Arc::new(RwLock::new(LeaderScheduler::new(&leader_scheduler_config))),
-            signer_proxy,
+            voting_keypair,
             Some(&bootstrap_leader_info),
             Default::default(),
         );
@@ -1401,13 +1402,13 @@ fn test_dropped_handoff_recovery() {
 
     info!("Starting the 'next leader' node");
     let next_leader_node = Node::new_localhost_with_pubkey(next_leader_keypair.pubkey());
-    let signer_proxy = VoteSignerProxy::new_local(&next_leader_keypair);
+    let voting_keypair = VotingKeypair::new_local(&next_leader_keypair);
     let next_leader = Fullnode::new(
         next_leader_node,
         &next_leader_keypair,
         &next_leader_ledger_path,
         Arc::new(RwLock::new(LeaderScheduler::new(&leader_scheduler_config))),
-        signer_proxy,
+        voting_keypair,
         Some(&bootstrap_leader_info),
         Default::default(),
     );
@@ -1537,7 +1538,7 @@ fn test_full_leader_validator_network() {
 
         let validator_id = kp.pubkey();
         let validator_node = Node::new_localhost_with_pubkey(validator_id);
-        let signer_proxy = VoteSignerProxy::new_local(&kp);
+        let voting_keypair = VotingKeypair::new_local(&kp);
         let leader_scheduler =
             Arc::new(RwLock::new(LeaderScheduler::new(&leader_scheduler_config)));
         let validator = Fullnode::new(
@@ -1545,7 +1546,7 @@ fn test_full_leader_validator_network() {
             &kp,
             &validator_ledger_path,
             leader_scheduler.clone(),
-            signer_proxy,
+            voting_keypair,
             Some(&bootstrap_leader_info),
             Default::default(),
         );
@@ -1555,14 +1556,14 @@ fn test_full_leader_validator_network() {
     }
 
     info!("Start up the bootstrap leader");
-    let signer_proxy = VoteSignerProxy::new_local(&leader_keypair);
+    let voting_keypair = VotingKeypair::new_local(&leader_keypair);
     let leader_scheduler = Arc::new(RwLock::new(LeaderScheduler::new(&leader_scheduler_config)));
     let bootstrap_leader = Fullnode::new(
         bootstrap_leader_node,
         &leader_keypair,
         &bootstrap_leader_ledger_path,
         leader_scheduler.clone(),
-        signer_proxy,
+        voting_keypair,
         Some(&bootstrap_leader_info),
         Default::default(),
     );
@@ -1733,13 +1734,13 @@ fn test_broadcast_last_tick() {
 
     // Start up the bootstrap leader fullnode
     let bootstrap_leader_keypair = Arc::new(bootstrap_leader_keypair);
-    let signer_proxy = VoteSignerProxy::new_local(&bootstrap_leader_keypair);
+    let voting_keypair = VotingKeypair::new_local(&bootstrap_leader_keypair);
     let mut bootstrap_leader = Fullnode::new(
         bootstrap_leader_node,
         &bootstrap_leader_keypair,
         &bootstrap_leader_ledger_path,
         Arc::new(RwLock::new(LeaderScheduler::new(&leader_scheduler_config))),
-        signer_proxy,
+        voting_keypair,
         Some(&bootstrap_leader_info),
         Default::default(),
     );

--- a/tests/replicator.rs
+++ b/tests/replicator.rs
@@ -16,7 +16,7 @@ use solana::leader_scheduler::LeaderScheduler;
 use solana::replicator::Replicator;
 use solana::storage_stage::STORAGE_ROTATE_TEST_COUNT;
 use solana::streamer::blob_receiver;
-use solana::vote_signer_proxy::VoteSignerProxy;
+use solana::voting_keypair::VotingKeypair;
 use solana_sdk::hash::Hash;
 use solana_sdk::signature::{Keypair, KeypairUtil};
 use solana_sdk::system_transaction::SystemTransaction;
@@ -47,7 +47,7 @@ fn test_replicator_startup() {
         tmp_copy_ledger(&leader_ledger_path, "replicator_test_validator_ledger");
 
     {
-        let signer_proxy = VoteSignerProxy::new_local(&leader_keypair);
+        let voting_keypair = VotingKeypair::new_local(&leader_keypair);
 
         let mut fullnode_config = FullnodeConfig::default();
         fullnode_config.storage_rotate_count = STORAGE_ROTATE_TEST_COUNT;
@@ -58,13 +58,13 @@ fn test_replicator_startup() {
             Arc::new(RwLock::new(LeaderScheduler::from_bootstrap_leader(
                 leader_info.id.clone(),
             ))),
-            signer_proxy,
+            voting_keypair,
             None,
             fullnode_config,
         );
 
         let validator_keypair = Arc::new(Keypair::new());
-        let signer_proxy = VoteSignerProxy::new_local(&validator_keypair);
+        let voting_keypair = VotingKeypair::new_local(&validator_keypair);
 
         let mut leader_client = mk_client(&leader_info);
 
@@ -88,7 +88,7 @@ fn test_replicator_startup() {
             Arc::new(RwLock::new(LeaderScheduler::from_bootstrap_leader(
                 leader_info.id,
             ))),
-            signer_proxy,
+            voting_keypair,
             Some(&leader_info),
             fullnode_config,
         );
@@ -274,7 +274,7 @@ fn test_replicator_startup_ledger_hang() {
         tmp_copy_ledger(&leader_ledger_path, "replicator_test_validator_ledger");
 
     {
-        let signer_proxy = VoteSignerProxy::new_local(&leader_keypair);
+        let voting_keypair = VotingKeypair::new_local(&leader_keypair);
 
         let _ = Fullnode::new(
             leader_node,
@@ -283,13 +283,13 @@ fn test_replicator_startup_ledger_hang() {
             Arc::new(RwLock::new(LeaderScheduler::from_bootstrap_leader(
                 leader_info.id.clone(),
             ))),
-            signer_proxy,
+            voting_keypair,
             None,
             Default::default(),
         );
 
         let validator_keypair = Arc::new(Keypair::new());
-        let signer_proxy = VoteSignerProxy::new_local(&validator_keypair);
+        let voting_keypair = VotingKeypair::new_local(&validator_keypair);
         let validator_node = Node::new_localhost_with_pubkey(validator_keypair.pubkey());
 
         let _ = Fullnode::new(
@@ -299,7 +299,7 @@ fn test_replicator_startup_ledger_hang() {
             Arc::new(RwLock::new(LeaderScheduler::from_bootstrap_leader(
                 leader_info.id,
             ))),
-            signer_proxy,
+            voting_keypair,
             Some(&leader_info),
             Default::default(),
         );


### PR DESCRIPTION
#### Problem

@pgarg66 and I never liked the name VoteSignerProxy, but couldn't think of a better name. After implementing KeypairUtil earlier this week, we started passing VoteSignerProxy into functions that accepted `T: KeypairUtil`. With a few small changes (in this PR), that's now the only thing we do with it. It's now awkward to call it a Proxy or a VoteSigner. It needs a new name.

#### Summary of Changes

* Inline the remaining nearly trivial non-KeypairUtil methods
* Rename VoteSignerProxy to VotingKeypair

