### PR TITLE
Update solana-vote-signer to Rust 2018

### DIFF
--- a/vote-signer/Cargo.toml
+++ b/vote-signer/Cargo.toml
@@ -1,8 +1,9 @@
 [package]
-name = "solana-vote-signer"
-version = "0.12.0"
-description = "Solana Vote Signing Service"
 authors = ["Solana Maintainers <maintainers@solana.com>"]
+edition = "2018"
+name = "solana-vote-signer"
+description = "Solana Vote Signing Service"
+version = "0.12.0"
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 homepage = "https://solana.com/"

--- a/vote-signer/src/bin/main.rs
+++ b/vote-signer/src/bin/main.rs
@@ -1,11 +1,4 @@
-#[macro_use]
-extern crate clap;
-extern crate log;
-extern crate solana_metrics;
-extern crate solana_sdk;
-extern crate solana_vote_signer;
-
-use clap::{App, Arg};
+use clap::{crate_version, App, Arg};
 use solana_vote_signer::rpc::VoteSignerRpcService;
 use std::error;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};

--- a/vote-signer/src/lib.rs
+++ b/vote-signer/src/lib.rs
@@ -1,6 +1,5 @@
 pub mod rpc;
 
-extern crate bs58;
 #[macro_use]
 extern crate log;
 extern crate solana_jsonrpc_core as jsonrpc_core;

--- a/vote-signer/src/rpc.rs
+++ b/vote-signer/src/rpc.rs
@@ -1,7 +1,7 @@
 //! The `rpc` module implements the Vote signing service RPC interface.
 
-use jsonrpc_core::*;
-use jsonrpc_http_server::*;
+use crate::jsonrpc_core::*;
+use crate::jsonrpc_http_server::*;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::{Keypair, KeypairUtil, Signature};
 use std::collections::HashMap;
@@ -178,7 +178,7 @@ impl Default for LocalVoteSigner {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use jsonrpc_core::Response;
+    use crate::jsonrpc_core::Response;
     use solana_sdk::signature::{Keypair, KeypairUtil};
     use std::mem;
 


### PR DESCRIPTION
#### Problem
The `solana-vote-signer` module is the only one not using Rust 2018, causing problems for a solana-wide update of jsonrpc

#### Summary of Changes
Add 2018 edition to `solana-vote-signer` Cargo.toml, and apply fixes

Fixes #
