### PR TITLE
Replace transaction traits with structs

### DIFF
--- a/bench-tps/src/bench.rs
+++ b/bench-tps/src/bench.rs
@@ -190,7 +190,7 @@ pub fn generate_txs(
         .par_iter()
         .map(|(id, keypair)| {
             (
-                Transaction::system_new(id, keypair.pubkey(), 1, last_id),
+                SystemTransaction::new_account(id, keypair.pubkey(), 1, last_id, 0),
                 timestamp(),
             )
         })
@@ -342,7 +342,7 @@ pub fn fund_keys(client: &mut ThinClient, source: &Keypair, dests: &[Keypair], t
                 .map(|(k, m)| {
                     (
                         k.clone(),
-                        Transaction::system_move_many(k, &m, Default::default(), 0),
+                        SystemTransaction::new_move_many(k, &m, Default::default(), 0),
                     )
                 })
                 .collect();

--- a/benches/bank.rs
+++ b/benches/bank.rs
@@ -8,7 +8,6 @@ use solana::last_id_queue::MAX_ENTRY_IDS;
 use solana_sdk::hash::hash;
 use solana_sdk::signature::{Keypair, KeypairUtil};
 use solana_sdk::system_transaction::SystemTransaction;
-use solana_sdk::transaction::Transaction;
 use test::Bencher;
 
 #[bench]
@@ -22,13 +21,18 @@ fn bench_process_transaction(bencher: &mut Bencher) {
         .map(|_| {
             // Seed the 'from' account.
             let rando0 = Keypair::new();
-            let tx =
-                Transaction::system_move(&mint_keypair, rando0.pubkey(), 10_000, bank.last_id(), 0);
+            let tx = SystemTransaction::new_move(
+                &mint_keypair,
+                rando0.pubkey(),
+                10_000,
+                bank.last_id(),
+                0,
+            );
             assert_eq!(bank.process_transaction(&tx), Ok(()));
 
             // Seed the 'to' account and a cell for its signature.
             let rando1 = Keypair::new();
-            let tx = Transaction::system_move(&rando0, rando1.pubkey(), 1, bank.last_id(), 0);
+            let tx = SystemTransaction::new_move(&rando0, rando1.pubkey(), 1, bank.last_id(), 0);
             assert_eq!(bank.process_transaction(&tx), Ok(()));
 
             // Finally, return the transaction to the benchmark.

--- a/benches/banking_stage.rs
+++ b/benches/banking_stage.rs
@@ -14,7 +14,6 @@ use solana_sdk::hash::hash;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::{Keypair, KeypairUtil, Signature};
 use solana_sdk::system_transaction::SystemTransaction;
-use solana_sdk::transaction::Transaction;
 use std::iter;
 use std::sync::mpsc::{channel, Receiver};
 use std::sync::Arc;
@@ -50,7 +49,7 @@ fn bench_banking_stage_multi_accounts(bencher: &mut Bencher) {
     let (verified_sender, verified_receiver) = channel();
     let bank = Arc::new(Bank::new(&genesis_block));
     let dummy_leader_id = Keypair::new().pubkey();
-    let dummy = Transaction::system_move(
+    let dummy = SystemTransaction::new_move(
         &mint_keypair,
         mint_keypair.pubkey(),
         1,
@@ -72,7 +71,7 @@ fn bench_banking_stage_multi_accounts(bencher: &mut Bencher) {
         .collect();
     // fund all the accounts
     transactions.iter().for_each(|tx| {
-        let fund = Transaction::system_move(
+        let fund = SystemTransaction::new_move(
             &mint_keypair,
             tx.account_keys[0],
             mint_total / txes as u64,
@@ -145,7 +144,7 @@ fn bench_banking_stage_multi_programs(bencher: &mut Bencher) {
     let (verified_sender, verified_receiver) = channel();
     let bank = Arc::new(Bank::new(&genesis_block));
     let dummy_leader_id = Keypair::new().pubkey();
-    let dummy = Transaction::system_move(
+    let dummy = SystemTransaction::new_move(
         &mint_keypair,
         mint_keypair.pubkey(),
         1,
@@ -183,7 +182,7 @@ fn bench_banking_stage_multi_programs(bencher: &mut Bencher) {
         })
         .collect();
     transactions.iter().for_each(|tx| {
-        let fund = Transaction::system_move(
+        let fund = SystemTransaction::new_move(
             &mint_keypair,
             tx.account_keys[0],
             mint_total / txes as u64,

--- a/benches/ledger.rs
+++ b/benches/ledger.rs
@@ -6,7 +6,6 @@ use solana::entry::{next_entries, reconstruct_entries_from_blobs, EntrySlice};
 use solana_sdk::hash::{hash, Hash};
 use solana_sdk::signature::{Keypair, KeypairUtil};
 use solana_sdk::system_transaction::SystemTransaction;
-use solana_sdk::transaction::Transaction;
 use test::Bencher;
 
 #[bench]
@@ -14,7 +13,7 @@ fn bench_block_to_blobs_to_block(bencher: &mut Bencher) {
     let zero = Hash::default();
     let one = hash(&zero.as_ref());
     let keypair = Keypair::new();
-    let tx0 = Transaction::system_move(&keypair, keypair.pubkey(), 1, one, 0);
+    let tx0 = SystemTransaction::new_move(&keypair, keypair.pubkey(), 1, one, 0);
     let transactions = vec![tx0; 10];
     let entries = next_entries(&zero, 1, transactions);
 

--- a/fullnode/src/main.rs
+++ b/fullnode/src/main.rs
@@ -79,7 +79,7 @@ fn create_and_fund_vote_account(
             let last_id = client.get_last_id();
             info!("create_and_fund_vote_account last_id={:?}", last_id);
             let transaction =
-                VoteTransaction::vote_account_new(node_keypair, vote_account, last_id, 1, 1);
+                VoteTransaction::new_account(node_keypair, vote_account, last_id, 1, 1);
 
             match client.transfer_signed(&transaction) {
                 Ok(signature) => {

--- a/programs/native/budget/src/budget_program.rs
+++ b/programs/native/budget/src/budget_program.rs
@@ -313,7 +313,7 @@ mod test {
         let contract = Keypair::new().pubkey();
         let to = Keypair::new().pubkey();
         let witness = Keypair::new().pubkey();
-        let tx = Transaction::budget_new_when_signed(
+        let tx = BudgetTransaction::new_when_signed(
             &from,
             to,
             contract,
@@ -326,7 +326,7 @@ mod test {
 
         // Attack! Part 1: Sign a witness transaction with a random key.
         let rando = Keypair::new();
-        let mut tx = Transaction::budget_new_signature(&rando, contract, to, Hash::default());
+        let mut tx = BudgetTransaction::new_signature(&rando, contract, to, Hash::default());
 
         // Attack! Part 2: Point the instruction to the expected, but unsigned, key.
         tx.account_keys.push(from.pubkey());
@@ -352,7 +352,7 @@ mod test {
         let contract = Keypair::new().pubkey();
         let to = Keypair::new().pubkey();
         let dt = Utc::now();
-        let tx = Transaction::budget_new_on_date(
+        let tx = BudgetTransaction::new_on_date(
             &from,
             to,
             contract,
@@ -366,7 +366,7 @@ mod test {
 
         // Attack! Part 1: Sign a timestamp transaction with a random key.
         let rando = Keypair::new();
-        let mut tx = Transaction::budget_new_timestamp(&rando, contract, to, dt, Hash::default());
+        let mut tx = BudgetTransaction::new_timestamp(&rando, contract, to, dt, Hash::default());
 
         // Attack! Part 2: Point the instruction to the expected, but unsigned, key.
         tx.account_keys.push(from.pubkey());
@@ -394,7 +394,7 @@ mod test {
         let to = Keypair::new();
         let rando = Keypair::new();
         let dt = Utc::now();
-        let tx = Transaction::budget_new_on_date(
+        let tx = BudgetTransaction::new_on_date(
             &from,
             to.pubkey(),
             contract.pubkey(),
@@ -411,7 +411,7 @@ mod test {
         assert!(program.is_pending());
 
         // Attack! Try to payout to a rando key
-        let tx = Transaction::budget_new_timestamp(
+        let tx = BudgetTransaction::new_timestamp(
             &from,
             contract.pubkey(),
             rando.pubkey(),
@@ -431,7 +431,7 @@ mod test {
 
         // Now, acknowledge the time in the condition occurred and
         // that pubkey's funds are now available.
-        let tx = Transaction::budget_new_timestamp(
+        let tx = BudgetTransaction::new_timestamp(
             &from,
             contract.pubkey(),
             to.pubkey(),
@@ -469,7 +469,7 @@ mod test {
         let contract = Keypair::new();
         let to = Keypair::new();
         let dt = Utc::now();
-        let tx = Transaction::budget_new_on_date(
+        let tx = BudgetTransaction::new_on_date(
             &from,
             to.pubkey(),
             contract.pubkey(),
@@ -487,7 +487,7 @@ mod test {
 
         // Attack! try to put the tokens into the wrong account with cancel
         let tx =
-            Transaction::budget_new_signature(&to, contract.pubkey(), to.pubkey(), Hash::default());
+            BudgetTransaction::new_signature(&to, contract.pubkey(), to.pubkey(), Hash::default());
         // unit test hack, the `from account` is passed instead of the `to` account to avoid
         // creating more account vectors
         process_transaction(&tx, &mut accounts).unwrap();
@@ -498,7 +498,7 @@ mod test {
         assert_eq!(accounts[pay_account].tokens, 0);
 
         // Now, cancel the transaction. from gets her funds back
-        let tx = Transaction::budget_new_signature(
+        let tx = BudgetTransaction::new_signature(
             &from,
             contract.pubkey(),
             from.pubkey(),
@@ -510,7 +510,7 @@ mod test {
         assert_eq!(accounts[pay_account].tokens, 1);
 
         // try to replay the signature contract
-        let tx = Transaction::budget_new_signature(
+        let tx = BudgetTransaction::new_signature(
             &from,
             contract.pubkey(),
             from.pubkey(),
@@ -535,7 +535,7 @@ mod test {
         let from = Keypair::new();
         let contract = Keypair::new();
         let to = Keypair::new();
-        let tx = Transaction::budget_new_on_date(
+        let tx = BudgetTransaction::new_on_date(
             &from,
             to.pubkey(),
             contract.pubkey(),
@@ -549,7 +549,7 @@ mod test {
         assert!(process_transaction(&tx, &mut accounts).is_err());
         assert!(BudgetProgram::deserialize(&accounts[1].userdata).is_err());
 
-        let tx = Transaction::budget_new_timestamp(
+        let tx = BudgetTransaction::new_timestamp(
             &from,
             contract.pubkey(),
             to.pubkey(),

--- a/programs/native/storage/src/lib.rs
+++ b/programs/native/storage/src/lib.rs
@@ -242,7 +242,7 @@ mod test {
         keyed_accounts.push(KeyedAccount::new(&pubkey, true, &mut user_account));
         keyed_accounts.push(KeyedAccount::new(&system_key, false, &mut system_account));
 
-        let tx = Transaction::storage_new_advertise_last_id(
+        let tx = StorageTransaction::new_advertise_last_id(
             &keypair,
             Hash::default(),
             Hash::default(),
@@ -260,7 +260,7 @@ mod test {
         let keypair = Keypair::new();
         let mut accounts = [Default::default()];
 
-        let tx = Transaction::storage_new_mining_proof(
+        let tx = StorageTransaction::new_mining_proof(
             &keypair,
             Hash::default(),
             Hash::default(),
@@ -281,7 +281,7 @@ mod test {
         let mut accounts = [Account::default(), Account::default()];
         accounts[1].userdata.resize(16 * 1024, 0);
 
-        let tx = Transaction::storage_new_mining_proof(
+        let tx = StorageTransaction::new_mining_proof(
             &keypair,
             Hash::default(),
             Hash::default(),
@@ -300,7 +300,7 @@ mod test {
         let mut accounts = [Account::default(), Account::default()];
         accounts[1].userdata.resize(16 * 1024, 0);
 
-        let tx = Transaction::storage_new_advertise_last_id(
+        let tx = StorageTransaction::new_advertise_last_id(
             &keypair,
             Hash::default(),
             Hash::default(),
@@ -309,7 +309,7 @@ mod test {
 
         test_transaction(&tx, &mut accounts).unwrap();
 
-        let tx = Transaction::storage_new_mining_proof(
+        let tx = StorageTransaction::new_mining_proof(
             &keypair,
             Hash::default(),
             Hash::default(),
@@ -329,7 +329,7 @@ mod test {
 
         let entry_height = 0;
 
-        let tx = Transaction::storage_new_advertise_last_id(
+        let tx = StorageTransaction::new_advertise_last_id(
             &keypair,
             Hash::default(),
             Hash::default(),
@@ -338,7 +338,7 @@ mod test {
 
         test_transaction(&tx, &mut accounts).unwrap();
 
-        let tx = Transaction::storage_new_mining_proof(
+        let tx = StorageTransaction::new_mining_proof(
             &keypair,
             Hash::default(),
             Hash::default(),
@@ -347,7 +347,7 @@ mod test {
         );
         test_transaction(&tx, &mut accounts).unwrap();
 
-        let tx = Transaction::storage_new_advertise_last_id(
+        let tx = StorageTransaction::new_advertise_last_id(
             &keypair,
             Hash::default(),
             Hash::default(),
@@ -355,7 +355,7 @@ mod test {
         );
         test_transaction(&tx, &mut accounts).unwrap();
 
-        let tx = Transaction::storage_new_proof_validation(
+        let tx = StorageTransaction::new_proof_validation(
             &keypair,
             Hash::default(),
             entry_height,
@@ -363,7 +363,7 @@ mod test {
         );
         test_transaction(&tx, &mut accounts).unwrap();
 
-        let tx = Transaction::storage_new_advertise_last_id(
+        let tx = StorageTransaction::new_advertise_last_id(
             &keypair,
             Hash::default(),
             Hash::default(),
@@ -371,7 +371,7 @@ mod test {
         );
         test_transaction(&tx, &mut accounts).unwrap();
 
-        let tx = Transaction::storage_new_reward_claim(&keypair, Hash::default(), entry_height);
+        let tx = StorageTransaction::new_reward_claim(&keypair, Hash::default(), entry_height);
         test_transaction(&tx, &mut accounts).unwrap();
 
         assert!(accounts[0].tokens == TOTAL_VALIDATOR_REWARDS);

--- a/sdk/src/budget_transaction.rs
+++ b/sdk/src/budget_transaction.rs
@@ -13,68 +13,17 @@ use crate::transaction::{self, Transaction};
 use bincode::deserialize;
 use chrono::prelude::*;
 
-pub trait BudgetTransaction {
-    fn budget_new_taxed(
-        from_keypair: &Keypair,
-        to: Pubkey,
-        tokens: u64,
-        fee: u64,
-        last_id: Hash,
-    ) -> Self;
+pub struct BudgetTransaction {}
 
-    fn budget_new(from_keypair: &Keypair, to: Pubkey, tokens: u64, last_id: Hash) -> Self;
-
-    fn budget_new_timestamp(
-        from_keypair: &Keypair,
-        contract: Pubkey,
-        to: Pubkey,
-        dt: DateTime<Utc>,
-        last_id: Hash,
-    ) -> Self;
-
-    fn budget_new_signature(
-        from_keypair: &Keypair,
-        contract: Pubkey,
-        to: Pubkey,
-        last_id: Hash,
-    ) -> Self;
-
-    fn budget_new_on_date(
-        from_keypair: &Keypair,
-        to: Pubkey,
-        contract: Pubkey,
-        dt: DateTime<Utc>,
-        dt_pubkey: Pubkey,
-        cancelable: Option<Pubkey>,
-        tokens: u64,
-        last_id: Hash,
-    ) -> Self;
-
-    fn budget_new_when_signed(
-        from_keypair: &Keypair,
-        to: Pubkey,
-        contract: Pubkey,
-        witness: Pubkey,
-        cancelable: Option<Pubkey>,
-        tokens: u64,
-        last_id: Hash,
-    ) -> Self;
-
-    fn instruction(&self, program_index: usize) -> Option<Instruction>;
-    fn system_instruction(&self, program_index: usize) -> Option<SystemInstruction>;
-
-    fn verify_plan(&self) -> bool;
-}
-
-impl BudgetTransaction for Transaction {
+impl BudgetTransaction {
     /// Create and sign a new Transaction. Used for unit-testing.
-    fn budget_new_taxed(
+    pub fn new_payment(
         from_keypair: &Keypair,
         to: Pubkey,
         tokens: u64,
-        fee: u64,
         last_id: Hash,
-    ) -> Self {
+        fee: u64,
+    ) -> Transaction {
         let contract = Keypair::new().pubkey();
         let keys = vec![from_keypair.pubkey(), contract];
 
@@ -93,7 +42,7 @@ impl BudgetTransaction for Transaction {
             transaction::Instruction::new(1, &budget_instruction, vec![1]),
         ];
 
-        Self::new_with_instructions(
+        Transaction::new_with_instructions(
             &[from_keypair],
             &keys,
             last_id,
@@ -104,20 +53,21 @@ impl BudgetTransaction for Transaction {
     }
 
     /// Create and sign a new Transaction. Used for unit-testing.
-    fn budget_new(from_keypair: &Keypair, to: Pubkey, tokens: u64, last_id: Hash) -> Self {
-        Self::budget_new_taxed(from_keypair, to, tokens, 0, last_id)
+    #[allow(clippy::new_ret_no_self)]
+    pub fn new(from_keypair: &Keypair, to: Pubkey, tokens: u64, last_id: Hash) -> Transaction {
+        Self::new_payment(from_keypair, to, tokens, last_id, 0)
     }
 
     /// Create and sign a new Witness Timestamp. Used for unit-testing.
-    fn budget_new_timestamp(
+    pub fn new_timestamp(
         from_keypair: &Keypair,
         contract: Pubkey,
         to: Pubkey,
         dt: DateTime<Utc>,
         last_id: Hash,
-    ) -> Self {
+    ) -> Transaction {
         let instruction = Instruction::ApplyTimestamp(dt);
-        Self::new(
+        Transaction::new(
             from_keypair,
             &[contract, to],
             budget_program::id(),
@@ -128,14 +78,14 @@ impl BudgetTransaction for Transaction {
     }
 
     /// Create and sign a new Witness Signature. Used for unit-testing.
-    fn budget_new_signature(
+    pub fn new_signature(
         from_keypair: &Keypair,
         contract: Pubkey,
         to: Pubkey,
         last_id: Hash,
-    ) -> Self {
+    ) -> Transaction {
         let instruction = Instruction::ApplySignature;
-        Self::new(
+        Transaction::new(
             from_keypair,
             &[contract, to],
             budget_program::id(),
@@ -146,7 +96,7 @@ impl BudgetTransaction for Transaction {
     }
 
     /// Create and sign a postdated Transaction. Used for unit-testing.
-    fn budget_new_on_date(
+    pub fn new_on_date(
         from_keypair: &Keypair,
         to: Pubkey,
         contract: Pubkey,
@@ -155,7 +105,7 @@ impl BudgetTransaction for Transaction {
         cancelable: Option<Pubkey>,
         tokens: u64,
         last_id: Hash,
-    ) -> Self {
+    ) -> Transaction {
         let expr = if let Some(from) = cancelable {
             BudgetExpr::Or(
                 (
@@ -174,7 +124,7 @@ impl BudgetTransaction for Transaction {
             )
         };
         let instruction = Instruction::NewBudget(expr);
-        Self::new(
+        Transaction::new(
             from_keypair,
             &[contract],
             budget_program::id(),
@@ -184,7 +134,7 @@ impl BudgetTransaction for Transaction {
         )
     }
     /// Create and sign a multisig Transaction.
-    fn budget_new_when_signed(
+    pub fn new_when_signed(
         from_keypair: &Keypair,
         to: Pubkey,
         contract: Pubkey,
@@ -192,7 +142,7 @@ impl BudgetTransaction for Transaction {
         cancelable: Option<Pubkey>,
         tokens: u64,
         last_id: Hash,
-    ) -> Self {
+    ) -> Transaction {
         let expr = if let Some(from) = cancelable {
             BudgetExpr::Or(
                 (
@@ -211,7 +161,7 @@ impl BudgetTransaction for Transaction {
             )
         };
         let instruction = Instruction::NewBudget(expr);
-        Self::new(
+        Transaction::new(
             from_keypair,
             &[contract],
             budget_program::id(),
@@ -221,19 +171,19 @@ impl BudgetTransaction for Transaction {
         )
     }
 
-    fn instruction(&self, instruction_index: usize) -> Option<Instruction> {
-        deserialize(&self.userdata(instruction_index)).ok()
+    pub fn system_instruction(tx: &Transaction, index: usize) -> Option<SystemInstruction> {
+        deserialize(&tx.userdata(index)).ok()
     }
 
-    fn system_instruction(&self, instruction_index: usize) -> Option<SystemInstruction> {
-        deserialize(&self.userdata(instruction_index)).ok()
+    pub fn instruction(tx: &Transaction, index: usize) -> Option<Instruction> {
+        deserialize(&tx.userdata(index)).ok()
     }
 
     /// Verify only the payment plan.
-    fn verify_plan(&self) -> bool {
-        if let Some(SystemInstruction::Move { tokens }) = self.system_instruction(0) {
-            if let Some(Instruction::NewBudget(expr)) = self.instruction(1) {
-                if !(self.fee <= tokens && expr.verify(tokens - self.fee)) {
+    pub fn verify_plan(tx: &Transaction) -> bool {
+        if let Some(SystemInstruction::Move { tokens }) = Self::system_instruction(tx, 0) {
+            if let Some(Instruction::NewBudget(expr)) = BudgetTransaction::instruction(&tx, 1) {
+                if !(tx.fee <= tokens && expr.verify(tokens - tx.fee)) {
                     return false;
                 }
             }
@@ -251,26 +201,27 @@ mod tests {
     fn test_claim() {
         let keypair = Keypair::new();
         let zero = Hash::default();
-        let tx0 = Transaction::budget_new(&keypair, keypair.pubkey(), 42, zero);
-        assert!(tx0.verify_plan());
+        let tx0 = BudgetTransaction::new(&keypair, keypair.pubkey(), 42, zero);
+        assert!(BudgetTransaction::verify_plan(&tx0));
     }
 
     #[test]
-    fn test_transfer() {
+    fn test_payment() {
         let zero = Hash::default();
         let keypair0 = Keypair::new();
         let keypair1 = Keypair::new();
         let pubkey1 = keypair1.pubkey();
-        let tx0 = Transaction::budget_new(&keypair0, pubkey1, 42, zero);
-        assert!(tx0.verify_plan());
+        let tx0 = BudgetTransaction::new(&keypair0, pubkey1, 42, zero);
+        assert!(BudgetTransaction::verify_plan(&tx0));
     }
 
     #[test]
-    fn test_transfer_with_fee() {
+    fn test_payment_with_fee() {
         let zero = Hash::default();
         let keypair0 = Keypair::new();
         let pubkey1 = Keypair::new().pubkey();
-        assert!(Transaction::budget_new_taxed(&keypair0, pubkey1, 1, 1, zero).verify_plan());
+        let tx0 = BudgetTransaction::new_payment(&keypair0, pubkey1, 1, zero, 1);
+        assert!(BudgetTransaction::verify_plan(&tx0));
     }
 
     #[test]
@@ -299,11 +250,11 @@ mod tests {
         let zero = Hash::default();
         let keypair = Keypair::new();
         let pubkey = keypair.pubkey();
-        let mut tx = Transaction::budget_new(&keypair, pubkey, 42, zero);
-        let mut system_instruction = tx.system_instruction(0).unwrap();
+        let mut tx = BudgetTransaction::new(&keypair, pubkey, 42, zero);
+        let mut system_instruction = BudgetTransaction::system_instruction(&tx, 0).unwrap();
         if let SystemInstruction::Move { ref mut tokens } = system_instruction {
             *tokens = 1_000_000; // <-- attack, part 1!
-            let mut instruction = tx.instruction(1).unwrap();
+            let mut instruction = BudgetTransaction::instruction(&tx, 1).unwrap();
             if let Instruction::NewBudget(ref mut expr) = instruction {
                 if let BudgetExpr::Pay(ref mut payment) = expr {
                     payment.tokens = *tokens; // <-- attack, part 2!
@@ -312,7 +263,7 @@ mod tests {
             tx.instructions[1].userdata = serialize(&instruction).unwrap();
         }
         tx.instructions[0].userdata = serialize(&system_instruction).unwrap();
-        assert!(tx.verify_plan());
+        assert!(BudgetTransaction::verify_plan(&tx));
         assert!(!tx.verify_signature());
     }
 
@@ -323,15 +274,15 @@ mod tests {
         let thief_keypair = Keypair::new();
         let pubkey1 = keypair1.pubkey();
         let zero = Hash::default();
-        let mut tx = Transaction::budget_new(&keypair0, pubkey1, 42, zero);
-        let mut instruction = tx.instruction(1);
+        let mut tx = BudgetTransaction::new(&keypair0, pubkey1, 42, zero);
+        let mut instruction = BudgetTransaction::instruction(&tx, 1);
         if let Some(Instruction::NewBudget(ref mut expr)) = instruction {
             if let BudgetExpr::Pay(ref mut payment) = expr {
                 payment.to = thief_keypair.pubkey(); // <-- attack!
             }
         }
         tx.instructions[1].userdata = serialize(&instruction).unwrap();
-        assert!(tx.verify_plan());
+        assert!(BudgetTransaction::verify_plan(&tx));
         assert!(!tx.verify_signature());
     }
 
@@ -340,24 +291,24 @@ mod tests {
         let keypair0 = Keypair::new();
         let keypair1 = Keypair::new();
         let zero = Hash::default();
-        let mut tx = Transaction::budget_new(&keypair0, keypair1.pubkey(), 1, zero);
-        let mut instruction = tx.instruction(1).unwrap();
+        let mut tx = BudgetTransaction::new(&keypair0, keypair1.pubkey(), 1, zero);
+        let mut instruction = BudgetTransaction::instruction(&tx, 1).unwrap();
         if let Instruction::NewBudget(ref mut expr) = instruction {
             if let BudgetExpr::Pay(ref mut payment) = expr {
                 payment.tokens = 2; // <-- attack!
             }
         }
         tx.instructions[1].userdata = serialize(&instruction).unwrap();
-        assert!(!tx.verify_plan());
+        assert!(!BudgetTransaction::verify_plan(&tx));
 
         // Also, ensure all branchs of the plan spend all tokens
-        let mut instruction = tx.instruction(1).unwrap();
+        let mut instruction = BudgetTransaction::instruction(&tx, 1).unwrap();
         if let Instruction::NewBudget(ref mut expr) = instruction {
             if let BudgetExpr::Pay(ref mut payment) = expr {
                 payment.tokens = 0; // <-- whoops!
             }
         }
         tx.instructions[1].userdata = serialize(&instruction).unwrap();
-        assert!(!tx.verify_plan());
+        assert!(!BudgetTransaction::verify_plan(&tx));
     }
 }

--- a/sdk/src/loader_transaction.rs
+++ b/sdk/src/loader_transaction.rs
@@ -6,33 +6,27 @@ use crate::pubkey::Pubkey;
 use crate::signature::Keypair;
 use crate::transaction::Transaction;
 
-pub trait LoaderTransaction {
-    fn loader_write(
+pub struct LoaderTransaction {}
+
+impl LoaderTransaction {
+    pub fn new_write(
         from_keypair: &Keypair,
         loader: Pubkey,
         offset: u32,
         bytes: Vec<u8>,
         last_id: Hash,
         fee: u64,
-    ) -> Self;
-
-    fn loader_finalize(from_keypair: &Keypair, loader: Pubkey, last_id: Hash, fee: u64) -> Self;
-}
-
-impl LoaderTransaction for Transaction {
-    fn loader_write(
-        from_keypair: &Keypair,
-        loader: Pubkey,
-        offset: u32,
-        bytes: Vec<u8>,
-        last_id: Hash,
-        fee: u64,
-    ) -> Self {
+    ) -> Transaction {
         let instruction = LoaderInstruction::Write { offset, bytes };
         Transaction::new(from_keypair, &[], loader, &instruction, last_id, fee)
     }
 
-    fn loader_finalize(from_keypair: &Keypair, loader: Pubkey, last_id: Hash, fee: u64) -> Self {
+    pub fn new_finalize(
+        from_keypair: &Keypair,
+        loader: Pubkey,
+        last_id: Hash,
+        fee: u64,
+    ) -> Transaction {
         let instruction = LoaderInstruction::Finalize;
         Transaction::new(from_keypair, &[], loader, &instruction, last_id, fee)
     }

--- a/sdk/src/storage_program.rs
+++ b/sdk/src/storage_program.rs
@@ -83,40 +83,16 @@ pub fn system_id() -> Pubkey {
     Pubkey::new(&STORAGE_SYSTEM_ACCOUNT_ID)
 }
 
-pub trait StorageTransaction {
-    fn storage_new_mining_proof(
+pub struct StorageTransaction {}
+
+impl StorageTransaction {
+    pub fn new_mining_proof(
         from_keypair: &Keypair,
         sha_state: Hash,
         last_id: Hash,
         entry_height: u64,
         signature: Signature,
-    ) -> Self;
-
-    fn storage_new_advertise_last_id(
-        from_keypair: &Keypair,
-        storage_last_id: Hash,
-        last_id: Hash,
-        entry_height: u64,
-    ) -> Self;
-
-    fn storage_new_proof_validation(
-        from_keypair: &Keypair,
-        last_id: Hash,
-        entry_height: u64,
-        proof_mask: Vec<ProofStatus>,
-    ) -> Self;
-
-    fn storage_new_reward_claim(from_keypair: &Keypair, last_id: Hash, entry_height: u64) -> Self;
-}
-
-impl StorageTransaction for Transaction {
-    fn storage_new_mining_proof(
-        from_keypair: &Keypair,
-        sha_state: Hash,
-        last_id: Hash,
-        entry_height: u64,
-        signature: Signature,
-    ) -> Self {
+    ) -> Transaction {
         let program = StorageProgram::SubmitMiningProof {
             sha_state,
             entry_height,
@@ -132,12 +108,12 @@ impl StorageTransaction for Transaction {
         )
     }
 
-    fn storage_new_advertise_last_id(
+    pub fn new_advertise_last_id(
         from_keypair: &Keypair,
         storage_id: Hash,
         last_id: Hash,
         entry_height: u64,
-    ) -> Self {
+    ) -> Transaction {
         let program = StorageProgram::AdvertiseStorageLastId {
             id: storage_id,
             entry_height,
@@ -152,12 +128,12 @@ impl StorageTransaction for Transaction {
         )
     }
 
-    fn storage_new_proof_validation(
+    pub fn new_proof_validation(
         from_keypair: &Keypair,
         last_id: Hash,
         entry_height: u64,
         proof_mask: Vec<ProofStatus>,
-    ) -> Self {
+    ) -> Transaction {
         let program = StorageProgram::ProofValidation {
             entry_height,
             proof_mask,
@@ -172,7 +148,11 @@ impl StorageTransaction for Transaction {
         )
     }
 
-    fn storage_new_reward_claim(from_keypair: &Keypair, last_id: Hash, entry_height: u64) -> Self {
+    pub fn new_reward_claim(
+        from_keypair: &Keypair,
+        last_id: Hash,
+        entry_height: u64,
+    ) -> Transaction {
         let program = StorageProgram::ClaimStorageReward { entry_height };
         Transaction::new(
             from_keypair,

--- a/sdk/src/transaction.rs
+++ b/sdk/src/transaction.rs
@@ -174,6 +174,7 @@ impl Transaction {
     pub fn userdata(&self, instruction_index: usize) -> &[u8] {
         &self.instructions[instruction_index].userdata
     }
+
     fn key_index(&self, instruction_index: usize, accounts_index: usize) -> Option<usize> {
         self.instructions
             .get(instruction_index)

--- a/sdk/src/vote_transaction.rs
+++ b/sdk/src/vote_transaction.rs
@@ -9,31 +9,15 @@ use crate::transaction::{Instruction, Transaction};
 use crate::vote_program::{self, Vote, VoteInstruction};
 use bincode::deserialize;
 
-pub trait VoteTransaction {
-    fn vote_new<T: KeypairUtil>(
+pub struct VoteTransaction {}
+
+impl VoteTransaction {
+    pub fn new_vote<T: KeypairUtil>(
         vote_account: &T,
         tick_height: u64,
         last_id: Hash,
         fee: u64,
-    ) -> Self;
-    fn vote_account_new(
-        validator_id: &Keypair,
-        vote_account_id: Pubkey,
-        last_id: Hash,
-        num_tokens: u64,
-        fee: u64,
-    ) -> Self;
-
-    fn get_votes(&self) -> Vec<(Pubkey, Vote, Hash)>;
-}
-
-impl VoteTransaction for Transaction {
-    fn vote_new<T: KeypairUtil>(
-        vote_account: &T,
-        tick_height: u64,
-        last_id: Hash,
-        fee: u64,
-    ) -> Self {
+    ) -> Transaction {
         let vote = Vote { tick_height };
         let instruction = VoteInstruction::NewVote(vote);
         Transaction::new(
@@ -46,13 +30,13 @@ impl VoteTransaction for Transaction {
         )
     }
 
-    fn vote_account_new(
+    pub fn new_account(
         validator_id: &Keypair,
         vote_account_id: Pubkey,
         last_id: Hash,
         num_tokens: u64,
         fee: u64,
-    ) -> Self {
+    ) -> Transaction {
         Transaction::new_with_instructions(
             &[validator_id],
             &[vote_account_id],
@@ -74,13 +58,13 @@ impl VoteTransaction for Transaction {
         )
     }
 
-    fn get_votes(&self) -> Vec<(Pubkey, Vote, Hash)> {
+    pub fn get_votes(tx: &Transaction) -> Vec<(Pubkey, Vote, Hash)> {
         let mut votes = vec![];
-        for i in 0..self.instructions.len() {
-            let tx_program_id = self.program_id(i);
+        for i in 0..tx.instructions.len() {
+            let tx_program_id = tx.program_id(i);
             if vote_program::check_id(&tx_program_id) {
-                if let Ok(Some(VoteInstruction::NewVote(vote))) = deserialize(&self.userdata(i)) {
-                    votes.push((self.account_keys[0], vote, self.last_id))
+                if let Ok(Some(VoteInstruction::NewVote(vote))) = deserialize(&tx.userdata(i)) {
+                    votes.push((tx.account_keys[0], vote, tx.last_id))
                 }
             }
         }

--- a/src/banking_stage.rs
+++ b/src/banking_stage.rs
@@ -303,7 +303,6 @@ mod tests {
     use crate::packet::to_packets;
     use solana_sdk::signature::{Keypair, KeypairUtil};
     use solana_sdk::system_transaction::SystemTransaction;
-    use solana_sdk::transaction::Transaction;
     use std::thread::sleep;
 
     #[test]
@@ -402,14 +401,15 @@ mod tests {
 
         // good tx
         let keypair = mint_keypair;
-        let tx = Transaction::system_new(&keypair, keypair.pubkey(), 1, start_hash);
+        let tx = SystemTransaction::new_account(&keypair, keypair.pubkey(), 1, start_hash, 0);
 
         // good tx, but no verify
-        let tx_no_ver = Transaction::system_new(&keypair, keypair.pubkey(), 1, start_hash);
+        let tx_no_ver =
+            SystemTransaction::new_account(&keypair, keypair.pubkey(), 1, start_hash, 0);
 
         // bad tx, AccountNotFound
         let keypair = Keypair::new();
-        let tx_anf = Transaction::system_new(&keypair, keypair.pubkey(), 1, start_hash);
+        let tx_anf = SystemTransaction::new_account(&keypair, keypair.pubkey(), 1, start_hash, 0);
 
         // send 'em over
         let packets = to_packets(&[tx, tx_no_ver, tx_anf]);
@@ -460,7 +460,13 @@ mod tests {
 
         // Process a batch that includes a transaction that receives two tokens.
         let alice = Keypair::new();
-        let tx = Transaction::system_new(&mint_keypair, alice.pubkey(), 2, genesis_block.last_id());
+        let tx = SystemTransaction::new_account(
+            &mint_keypair,
+            alice.pubkey(),
+            2,
+            genesis_block.last_id(),
+            0,
+        );
 
         let packets = to_packets(&[tx]);
         verified_sender
@@ -468,7 +474,13 @@ mod tests {
             .unwrap();
 
         // Process a second batch that spends one of those tokens.
-        let tx = Transaction::system_new(&alice, mint_keypair.pubkey(), 1, genesis_block.last_id());
+        let tx = SystemTransaction::new_account(
+            &alice,
+            mint_keypair.pubkey(),
+            1,
+            genesis_block.last_id(),
+            0,
+        );
         let packets = to_packets(&[tx]);
         verified_sender
             .send(vec![(packets[0].clone(), vec![1u8])])

--- a/src/chacha.rs
+++ b/src/chacha.rs
@@ -102,7 +102,6 @@ mod tests {
     use solana_sdk::budget_transaction::BudgetTransaction;
     use solana_sdk::hash::{hash, Hash, Hasher};
     use solana_sdk::signature::KeypairUtil;
-    use solana_sdk::transaction::Transaction;
     use std::fs::remove_file;
     use std::fs::File;
     use std::io::Read;
@@ -129,7 +128,7 @@ mod tests {
                 Entry::new_mut(
                     &mut id,
                     &mut num_hashes,
-                    vec![Transaction::budget_new_signature(
+                    vec![BudgetTransaction::new_signature(
                         &keypair,
                         keypair.pubkey(),
                         keypair.pubkey(),

--- a/src/compute_leader_confirmation_service.rs
+++ b/src/compute_leader_confirmation_service.rs
@@ -166,7 +166,6 @@ pub mod tests {
     use bincode::serialize;
     use solana_sdk::hash::hash;
     use solana_sdk::signature::{Keypair, KeypairUtil};
-    use solana_sdk::transaction::Transaction;
     use solana_sdk::vote_transaction::VoteTransaction;
     use std::sync::Arc;
     use std::thread::sleep;
@@ -206,7 +205,7 @@ pub mod tests {
 
                 if i < 6 {
                     let vote_tx =
-                        Transaction::vote_new(&voting_keypair, (i + 1) as u64, last_id, 0);
+                        VoteTransaction::new_vote(&voting_keypair, (i + 1) as u64, last_id, 0);
                     bank.process_transaction(&vote_tx).unwrap();
                 }
                 (voting_keypair, validator_keypair)
@@ -224,7 +223,7 @@ pub mod tests {
 
         // Get another validator to vote, so we now have 2/3 consensus
         let voting_keypair = &vote_accounts[7].0;
-        let vote_tx = Transaction::vote_new(voting_keypair, 7, ids[6], 0);
+        let vote_tx = VoteTransaction::new_vote(voting_keypair, 7, ids[6], 0);
         bank.process_transaction(&vote_tx).unwrap();
 
         ComputeLeaderConfirmationService::compute_confirmation(

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -407,7 +407,7 @@ pub fn make_tiny_test_entries_from_id(start: &Hash, num: usize) -> Vec<Entry> {
             Entry::new_mut(
                 &mut id,
                 &mut num_hashes,
-                vec![Transaction::budget_new_timestamp(
+                vec![BudgetTransaction::new_timestamp(
                     &keypair,
                     keypair.pubkey(),
                     keypair.pubkey(),
@@ -430,7 +430,7 @@ pub fn make_large_test_entries(num_entries: usize) -> Vec<Entry> {
     let one = hash(&zero.as_ref());
     let keypair = Keypair::new();
 
-    let tx = Transaction::budget_new_timestamp(
+    let tx = BudgetTransaction::new_timestamp(
         &keypair,
         keypair.pubkey(),
         keypair.pubkey(),
@@ -484,11 +484,9 @@ mod tests {
     use super::*;
     use crate::entry::Entry;
     use crate::packet::{to_blobs, BLOB_DATA_SIZE, PACKET_DATA_SIZE};
-    use solana_sdk::budget_transaction::BudgetTransaction;
     use solana_sdk::hash::hash;
     use solana_sdk::signature::{Keypair, KeypairUtil};
     use solana_sdk::system_transaction::SystemTransaction;
-    use solana_sdk::transaction::Transaction;
     use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
     #[test]
@@ -507,8 +505,8 @@ mod tests {
 
         // First, verify entries
         let keypair = Keypair::new();
-        let tx0 = Transaction::system_new(&keypair, keypair.pubkey(), 0, zero);
-        let tx1 = Transaction::system_new(&keypair, keypair.pubkey(), 1, zero);
+        let tx0 = SystemTransaction::new_account(&keypair, keypair.pubkey(), 0, zero, 0);
+        let tx1 = SystemTransaction::new_account(&keypair, keypair.pubkey(), 1, zero, 0);
         let mut e0 = Entry::new(&zero, 0, 0, vec![tx0.clone(), tx1.clone()]);
         assert!(e0.verify(&zero));
 
@@ -524,7 +522,7 @@ mod tests {
 
         // First, verify entries
         let keypair = Keypair::new();
-        let tx0 = Transaction::budget_new_timestamp(
+        let tx0 = BudgetTransaction::new_timestamp(
             &keypair,
             keypair.pubkey(),
             keypair.pubkey(),
@@ -532,7 +530,7 @@ mod tests {
             zero,
         );
         let tx1 =
-            Transaction::budget_new_signature(&keypair, keypair.pubkey(), keypair.pubkey(), zero);
+            BudgetTransaction::new_signature(&keypair, keypair.pubkey(), keypair.pubkey(), zero);
         let mut e0 = Entry::new(&zero, 0, 0, vec![tx0.clone(), tx1.clone()]);
         assert!(e0.verify(&zero));
 
@@ -554,7 +552,7 @@ mod tests {
         assert_eq!(tick.id, zero);
 
         let keypair = Keypair::new();
-        let tx0 = Transaction::budget_new_timestamp(
+        let tx0 = BudgetTransaction::new_timestamp(
             &keypair,
             keypair.pubkey(),
             keypair.pubkey(),
@@ -571,7 +569,7 @@ mod tests {
     fn test_next_entry_panic() {
         let zero = Hash::default();
         let keypair = Keypair::new();
-        let tx = Transaction::system_new(&keypair, keypair.pubkey(), 0, zero);
+        let tx = SystemTransaction::new_account(&keypair, keypair.pubkey(), 0, zero, 0);
         next_entry(&zero, 0, vec![tx]);
     }
 
@@ -579,7 +577,7 @@ mod tests {
     fn test_serialized_size() {
         let zero = Hash::default();
         let keypair = Keypair::new();
-        let tx = Transaction::system_new(&keypair, keypair.pubkey(), 0, zero);
+        let tx = SystemTransaction::new_account(&keypair, keypair.pubkey(), 0, zero, 0);
         let entry = next_entry(&zero, 1, vec![tx.clone()]);
         assert_eq!(
             Entry::serialized_size(&[tx]),
@@ -607,8 +605,8 @@ mod tests {
         let one = hash(&zero.as_ref());
         let keypair = Keypair::new();
         let vote_account = Keypair::new();
-        let tx0 = Transaction::vote_new(&vote_account, 1, one, 1);
-        let tx1 = Transaction::budget_new_timestamp(
+        let tx0 = VoteTransaction::new_vote(&vote_account, 1, one, 1);
+        let tx1 = BudgetTransaction::new_timestamp(
             &keypair,
             keypair.pubkey(),
             keypair.pubkey(),
@@ -655,8 +653,8 @@ mod tests {
         let next_id = hash(&id.as_ref());
         let keypair = Keypair::new();
         let vote_account = Keypair::new();
-        let tx_small = Transaction::vote_new(&vote_account, 1, next_id, 2);
-        let tx_large = Transaction::budget_new(&keypair, keypair.pubkey(), 1, next_id);
+        let tx_small = VoteTransaction::new_vote(&vote_account, 1, next_id, 2);
+        let tx_large = BudgetTransaction::new(&keypair, keypair.pubkey(), 1, next_id);
 
         let tx_small_size = tx_small.serialized_size().unwrap() as usize;
         let tx_large_size = tx_large.serialized_size().unwrap() as usize;

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -464,7 +464,6 @@ mod tests {
     use solana_sdk::hash::Hash;
     use solana_sdk::signature::{Keypair, KeypairUtil};
     use solana_sdk::system_transaction::SystemTransaction;
-    use solana_sdk::transaction::Transaction;
     use std::io;
     use std::io::Write;
     use std::net::{Ipv4Addr, SocketAddr, UdpSocket};
@@ -503,7 +502,7 @@ mod tests {
     fn test_to_packets() {
         let keypair = Keypair::new();
         let hash = Hash::new(&[1; 32]);
-        let tx = Transaction::system_new(&keypair, keypair.pubkey(), 1, hash);
+        let tx = SystemTransaction::new_account(&keypair, keypair.pubkey(), 1, hash, 0);
         let rv = to_packets(&vec![tx.clone(); 1]);
         assert_eq!(rv.len(), 1);
         assert_eq!(rv[0].read().unwrap().packets.len(), 1);

--- a/src/replay_stage.rs
+++ b/src/replay_stage.rs
@@ -21,7 +21,6 @@ use solana_metrics::{influxdb, submit};
 use solana_sdk::hash::Hash;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::timing::duration_as_ms;
-use solana_sdk::transaction::Transaction;
 use solana_sdk::vote_transaction::VoteTransaction;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::mpsc::channel;
@@ -146,8 +145,12 @@ impl ReplayStage {
                 if 0 == num_ticks_to_next_vote {
                     if let Some(voting_keypair) = voting_keypair {
                         let keypair = voting_keypair.as_ref();
-                        let vote =
-                            Transaction::vote_new(keypair, bank.tick_height(), bank.last_id(), 0);
+                        let vote = VoteTransaction::new_vote(
+                            keypair,
+                            bank.tick_height(),
+                            bank.last_id(),
+                            0,
+                        );
                         cluster_info.write().unwrap().push_vote(vote);
                     }
                 }
@@ -478,7 +481,7 @@ mod test {
         );
 
         let keypair = voting_keypair.as_ref();
-        let vote = Transaction::vote_new(keypair, bank.tick_height(), bank.last_id(), 0);
+        let vote = VoteTransaction::new_vote(keypair, bank.tick_height(), bank.last_id(), 0);
         cluster_info_me.write().unwrap().push_vote(vote);
 
         // Send ReplayStage an entry, should see it on the ledger writer receiver
@@ -585,7 +588,7 @@ mod test {
         );
 
         let keypair = voting_keypair.as_ref();
-        let vote = Transaction::vote_new(keypair, bank.tick_height(), bank.last_id(), 0);
+        let vote = VoteTransaction::new_vote(keypair, bank.tick_height(), bank.last_id(), 0);
         cluster_info_me.write().unwrap().push_vote(vote);
 
         // Send enough ticks to trigger leader rotation

--- a/src/replicator.rs
+++ b/src/replicator.rs
@@ -19,7 +19,6 @@ use solana_drone::drone::{request_airdrop_transaction, DRONE_PORT};
 use solana_sdk::hash::{Hash, Hasher};
 use solana_sdk::signature::{Keypair, KeypairUtil, Signature};
 use solana_sdk::storage_program::StorageTransaction;
-use solana_sdk::transaction::Transaction;
 use std::fs::File;
 use std::io;
 use std::io::BufReader;
@@ -262,7 +261,7 @@ impl Replicator {
             Ok(hash) => {
                 let last_id = client.get_last_id();
                 info!("sampled hash: {}", hash);
-                let mut tx = Transaction::storage_new_mining_proof(
+                let mut tx = StorageTransaction::new_mining_proof(
                     &keypair,
                     hash,
                     last_id,

--- a/src/rpc_mock.rs
+++ b/src/rpc_mock.rs
@@ -93,6 +93,6 @@ pub fn request_airdrop_transaction(
     let key = Keypair::new();
     let to = Keypair::new().pubkey();
     let last_id = Hash::default();
-    let tx = Transaction::system_new(&key, to, 50, last_id);
+    let tx = SystemTransaction::new_account(&key, to, 50, last_id, 0);
     Ok(tx)
 }

--- a/src/rpc_pubsub.rs
+++ b/src/rpc_pubsub.rs
@@ -391,7 +391,6 @@ mod tests {
     use solana_sdk::budget_transaction::BudgetTransaction;
     use solana_sdk::signature::{Keypair, KeypairUtil};
     use solana_sdk::system_transaction::SystemTransaction;
-    use solana_sdk::transaction::Transaction;
     use std::net::{IpAddr, Ipv4Addr};
     use tokio::prelude::{Async, Stream};
 
@@ -420,7 +419,7 @@ mod tests {
         arc_bank.set_subscriptions(Box::new(subscription));
 
         // Test signature subscription
-        let tx = Transaction::system_move(&alice, bob_pubkey, 20, last_id, 0);
+        let tx = SystemTransaction::new_move(&alice, bob_pubkey, 20, last_id, 0);
 
         let (subscriber, _id_receiver, mut receiver) =
             Subscriber::new_test("signatureNotification");
@@ -455,7 +454,7 @@ mod tests {
         let rpc = RpcSolPubSubImpl::new(rpc_bank.clone());
         io.extend_with(rpc.to_delegate());
 
-        let tx = Transaction::system_move(&alice, bob_pubkey, 20, last_id, 0);
+        let tx = SystemTransaction::new_move(&alice, bob_pubkey, 20, last_id, 0);
         let req = format!(
             r#"{{"jsonrpc":"2.0","id":1,"method":"signatureSubscribe","params":["{}"]}}"#,
             tx.signatures[0].to_string()
@@ -509,7 +508,7 @@ mod tests {
         let (subscriber, _id_receiver, mut receiver) = Subscriber::new_test("accountNotification");
         rpc.subscribe_to_account_updates(subscriber, contract_state.pubkey().to_string());
 
-        let tx = Transaction::system_create(
+        let tx = SystemTransaction::new_program_account(
             &alice,
             contract_funds.pubkey(),
             last_id,
@@ -522,7 +521,7 @@ mod tests {
             .process_transaction(&tx)
             .expect("process transaction");
 
-        let tx = Transaction::system_create(
+        let tx = SystemTransaction::new_program_account(
             &alice,
             contract_state.pubkey(),
             last_id,
@@ -564,7 +563,7 @@ mod tests {
             assert_eq!(serde_json::to_string(&expected).unwrap(), response);
         }
 
-        let tx = Transaction::budget_new_when_signed(
+        let tx = BudgetTransaction::new_when_signed(
             &contract_funds,
             bob_pubkey,
             contract_state.pubkey(),
@@ -603,12 +602,12 @@ mod tests {
             assert_eq!(serde_json::to_string(&expected).unwrap(), response);
         }
 
-        let tx = Transaction::system_new(&alice, witness.pubkey(), 1, last_id);
+        let tx = SystemTransaction::new_account(&alice, witness.pubkey(), 1, last_id, 0);
         arc_bank
             .process_transaction(&tx)
             .expect("process transaction");
         sleep(Duration::from_millis(200));
-        let tx = Transaction::budget_new_signature(
+        let tx = BudgetTransaction::new_signature(
             &witness,
             contract_state.pubkey(),
             bob_pubkey,
@@ -696,7 +695,7 @@ mod tests {
         let bank = Bank::new(&genesis_block);
         let alice = Keypair::new();
         let last_id = bank.last_id();
-        let tx = Transaction::system_create(
+        let tx = SystemTransaction::new_program_account(
             &mint_keypair,
             alice.pubkey(),
             last_id,
@@ -741,7 +740,7 @@ mod tests {
         let bank = Bank::new(&genesis_block);
         let alice = Keypair::new();
         let last_id = bank.last_id();
-        let tx = Transaction::system_move(&mint_keypair, alice.pubkey(), 20, last_id, 0);
+        let tx = SystemTransaction::new_move(&mint_keypair, alice.pubkey(), 20, last_id, 0);
         let signature = tx.signatures[0];
         bank.process_transaction(&tx).unwrap();
 

--- a/src/storage_stage.rs
+++ b/src/storage_stage.rs
@@ -15,22 +15,17 @@ use rand::{Rng, SeedableRng};
 use rand_chacha::ChaChaRng;
 use solana_sdk::hash::Hash;
 use solana_sdk::pubkey::Pubkey;
-use solana_sdk::signature::Keypair;
-use solana_sdk::signature::Signature;
-use solana_sdk::storage_program;
-use solana_sdk::storage_program::StorageProgram;
-use solana_sdk::storage_program::StorageTransaction;
+use solana_sdk::signature::{Keypair, Signature};
+use solana_sdk::storage_program::{self, StorageProgram, StorageTransaction};
 use solana_sdk::transaction::Transaction;
 use solana_sdk::vote_program;
 use std::collections::HashSet;
 use std::io;
 use std::mem::size_of;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::mpsc::RecvTimeoutError;
-use std::sync::mpsc::{channel, Sender};
+use std::sync::mpsc::{channel, RecvTimeoutError, Sender};
 use std::sync::{Arc, RwLock};
-use std::thread::sleep;
-use std::thread::{self, Builder, JoinHandle};
+use std::thread::{self, sleep, Builder, JoinHandle};
 use std::time::Duration;
 
 // Block of hash answers to validate against
@@ -277,7 +272,7 @@ impl StorageStage {
         let mut seed = [0u8; 32];
         let signature = keypair.sign(&entry_id.as_ref());
 
-        let tx = Transaction::storage_new_advertise_last_id(
+        let tx = StorageTransaction::new_advertise_last_id(
             keypair,
             entry_id,
             Hash::default(),
@@ -453,7 +448,6 @@ mod tests {
     use solana_sdk::hash::Hasher;
     use solana_sdk::pubkey::Pubkey;
     use solana_sdk::signature::{Keypair, KeypairUtil};
-    use solana_sdk::transaction::Transaction;
     use solana_sdk::vote_transaction::VoteTransaction;
     use std::cmp::{max, min};
     use std::fs::remove_dir_all;
@@ -602,9 +596,9 @@ mod tests {
             reference_keys = vec![0; keys.len()];
             reference_keys.copy_from_slice(keys);
         }
-        let mut vote_txs: Vec<Transaction> = Vec::new();
+        let mut vote_txs: Vec<_> = Vec::new();
         let keypair = Keypair::new();
-        let vote_tx = Transaction::vote_new(&keypair, 123456, Hash::default(), 1);
+        let vote_tx = VoteTransaction::new_vote(&keypair, 123456, Hash::default(), 1);
         vote_txs.push(vote_tx);
         let vote_entries = vec![Entry::new(&Hash::default(), 0, 1, vote_txs)];
         storage_entry_sender.send(vote_entries).unwrap();

--- a/src/test_tx.rs
+++ b/src/test_tx.rs
@@ -1,11 +1,11 @@
 use solana_sdk::hash::Hash;
 use solana_sdk::signature::{Keypair, KeypairUtil};
-use solana_sdk::system_transaction::*;
+use solana_sdk::system_transaction::SystemTransaction;
 use solana_sdk::transaction::Transaction;
 
 pub fn test_tx() -> Transaction {
     let keypair1 = Keypair::new();
     let pubkey1 = keypair1.pubkey();
     let zero = Hash::default();
-    Transaction::system_new(&keypair1, pubkey1, 42, zero)
+    SystemTransaction::new_account(&keypair1, pubkey1, 42, zero, 0)
 }

--- a/src/thin_client.rs
+++ b/src/thin_client.rs
@@ -137,7 +137,7 @@ impl ThinClient {
         last_id: &Hash,
     ) -> io::Result<Signature> {
         let now = Instant::now();
-        let tx = Transaction::system_new(keypair, to, n, *last_id);
+        let tx = SystemTransaction::new_account(keypair, to, n, *last_id, 0);
         let result = self.transfer_signed(&tx);
         solana_metrics::submit(
             influxdb::Point::new("thinclient")
@@ -518,13 +518,13 @@ mod tests {
 
         let last_id = client.get_last_id();
 
-        let tx = Transaction::system_new(&alice, bob_pubkey, 500, last_id);
+        let tx = SystemTransaction::new_account(&alice, bob_pubkey, 500, last_id, 0);
 
         let _sig = client.transfer_signed(&tx).unwrap();
 
         let last_id = client.get_last_id();
 
-        let mut tr2 = Transaction::system_new(&alice, bob_pubkey, 501, last_id);
+        let mut tr2 = SystemTransaction::new_account(&alice, bob_pubkey, 501, last_id, 0);
         let mut instruction2 = deserialize(tr2.userdata(0)).unwrap();
         if let SystemInstruction::Move { ref mut tokens } = instruction2 {
             *tokens = 502;
@@ -577,7 +577,7 @@ mod tests {
         let last_id = client.get_last_id();
 
         let transaction =
-            VoteTransaction::vote_account_new(&validator_keypair, vote_account_id, last_id, 1, 1);
+            VoteTransaction::new_account(&validator_keypair, vote_account_id, last_id, 1, 1);
         let signature = client.transfer_signed(&transaction).unwrap();
         client.poll_for_signature(&signature).unwrap();
 

--- a/src/tvu.rs
+++ b/src/tvu.rs
@@ -210,7 +210,6 @@ pub mod tests {
     use solana_sdk::hash::Hash;
     use solana_sdk::signature::{Keypair, KeypairUtil};
     use solana_sdk::system_transaction::SystemTransaction;
-    use solana_sdk::transaction::Transaction;
     use std::fs::remove_dir_all;
     use std::net::UdpSocket;
     use std::sync::atomic::{AtomicBool, Ordering};
@@ -326,11 +325,12 @@ pub mod tests {
             let entry_tick0 = Entry::new(&cur_hash, 0, i + 1, vec![]);
             cur_hash = entry_tick0.id;
 
-            let tx0 = Transaction::system_new(
+            let tx0 = SystemTransaction::new_account(
                 &mint_keypair,
                 bob_keypair.pubkey(),
                 transfer_amount,
                 cur_hash,
+                0,
             );
             bank.register_tick(&cur_hash);
             let entry_tick1 = Entry::new(&cur_hash, 0, i + 1, vec![]);

--- a/tests/multinode.rs
+++ b/tests/multinode.rs
@@ -23,7 +23,6 @@ use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::{Keypair, KeypairUtil};
 use solana_sdk::system_transaction::SystemTransaction;
 use solana_sdk::timing::duration_as_s;
-use solana_sdk::transaction::Transaction;
 use std::collections::{HashSet, VecDeque};
 use std::env;
 use std::fs::remove_dir_all;
@@ -1817,7 +1816,7 @@ fn send_tx_and_retry_get_balance(
     let mut client = mk_client(leader);
     trace!("getting leader last_id");
     let last_id = client.get_last_id();
-    let mut tx = Transaction::system_new(&alice, *bob_pubkey, transfer_amount, last_id);
+    let mut tx = SystemTransaction::new_account(&alice, *bob_pubkey, transfer_amount, last_id, 0);
     info!(
         "executing transfer of {} from {} to {}",
         transfer_amount,

--- a/tests/programs.rs
+++ b/tests/programs.rs
@@ -56,7 +56,7 @@ impl Loader {
 
         // allocate, populate, finalize, and spawn loader
 
-        let tx = Transaction::system_create(
+        let tx = SystemTransaction::new_program_account(
             &mint_keypair,
             loader.pubkey(),
             genesis_block.last_id(),
@@ -68,7 +68,7 @@ impl Loader {
         check_tx_results(&bank, &tx, bank.process_transactions(&vec![tx.clone()]));
 
         let name = String::from(loader_name);
-        let tx = Transaction::loader_write(
+        let tx = LoaderTransaction::new_write(
             &loader,
             solana_native_loader::id(),
             0,
@@ -78,7 +78,7 @@ impl Loader {
         );
         check_tx_results(&bank, &tx, bank.process_transactions(&vec![tx.clone()]));
 
-        let tx = Transaction::loader_finalize(
+        let tx = LoaderTransaction::new_finalize(
             &loader,
             solana_native_loader::id(),
             genesis_block.last_id(),
@@ -86,7 +86,7 @@ impl Loader {
         );
         check_tx_results(&bank, &tx, bank.process_transactions(&vec![tx.clone()]));
 
-        let tx = Transaction::system_spawn(&loader, genesis_block.last_id(), 0);
+        let tx = SystemTransaction::new_spawn(&loader, genesis_block.last_id(), 0);
         check_tx_results(&bank, &tx, bank.process_transactions(&vec![tx.clone()]));
 
         Loader {
@@ -135,7 +135,7 @@ impl Program {
 
         // allocate, populate, finalize and spawn program
 
-        let tx = Transaction::system_create(
+        let tx = SystemTransaction::new_program_account(
             &loader.mint_keypair,
             program.pubkey(),
             loader.genesis_block.last_id(),
@@ -153,7 +153,7 @@ impl Program {
         let chunk_size = 256; // Size of chunk just needs to fit into tx
         let mut offset = 0;
         for chunk in userdata.chunks(chunk_size) {
-            let tx = Transaction::loader_write(
+            let tx = LoaderTransaction::new_write(
                 &program,
                 loader.loader,
                 offset,
@@ -169,7 +169,7 @@ impl Program {
             offset += chunk_size as u32;
         }
 
-        let tx = Transaction::loader_finalize(
+        let tx = LoaderTransaction::new_finalize(
             &program,
             loader.loader,
             loader.genesis_block.last_id(),
@@ -181,7 +181,7 @@ impl Program {
             loader.bank.process_transactions(&vec![tx.clone()]),
         );
 
-        let tx = Transaction::system_spawn(&program, loader.genesis_block.last_id(), 0);
+        let tx = SystemTransaction::new_spawn(&program, loader.genesis_block.last_id(), 0);
         check_tx_results(
             &loader.bank,
             &tx,
@@ -236,7 +236,7 @@ fn test_program_lua_move_funds() {
 
     // Call user program with two accounts
 
-    let tx = Transaction::system_create(
+    let tx = SystemTransaction::new_program_account(
         &loader.mint_keypair,
         from.pubkey(),
         loader.genesis_block.last_id(),
@@ -251,7 +251,7 @@ fn test_program_lua_move_funds() {
         loader.bank.process_transactions(&vec![tx.clone()]),
     );
 
-    let tx = Transaction::system_create(
+    let tx = SystemTransaction::new_program_account(
         &loader.mint_keypair,
         to,
         loader.genesis_block.last_id(),

--- a/tests/replicator.rs
+++ b/tests/replicator.rs
@@ -20,7 +20,6 @@ use solana::voting_keypair::VotingKeypair;
 use solana_sdk::hash::Hash;
 use solana_sdk::signature::{Keypair, KeypairUtil};
 use solana_sdk::system_transaction::SystemTransaction;
-use solana_sdk::transaction::Transaction;
 use std::fs::remove_dir_all;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::channel;
@@ -110,8 +109,13 @@ fn test_replicator_startup() {
         let last_id = leader_client.get_last_id();
         // Give the replicator some tokens
         let amount = 1;
-        let mut tx =
-            Transaction::system_new(&mint_keypair, replicator_keypair.pubkey(), amount, last_id);
+        let mut tx = SystemTransaction::new_account(
+            &mint_keypair,
+            replicator_keypair.pubkey(),
+            amount,
+            last_id,
+            0,
+        );
         leader_client
             .retry_transfer(&mint_keypair, &mut tx, 5)
             .unwrap();

--- a/tests/rpc.rs
+++ b/tests/rpc.rs
@@ -8,7 +8,6 @@ use solana::thin_client::new_fullnode;
 use solana_sdk::hash::Hash;
 use solana_sdk::signature::{Keypair, KeypairUtil};
 use solana_sdk::system_transaction::SystemTransaction;
-use solana_sdk::transaction::Transaction;
 use std::fs::remove_dir_all;
 use std::thread::sleep;
 use std::time::Duration;
@@ -42,7 +41,7 @@ fn test_rpc_send_tx() {
     let last_id = Hash::new(&last_id_vec);
 
     info!("last_id: {:?}", last_id);
-    let tx = Transaction::system_move(&alice, bob_pubkey, 20, last_id, 0);
+    let tx = SystemTransaction::new_move(&alice, bob_pubkey, 20, last_id, 0);
     let serial_tx = serialize(&tx).unwrap();
 
     let client = reqwest::Client::new();


### PR DESCRIPTION
#### Problem

A long, long time ago, `Transaction` contained constructors for every program's transactions. We created "namespaces" by prefixing each constructor with the program name. Then, to minimize the churn when I split that up, I created traits for each program and let Rust magic connect the dots.  The namespacing convention allowed that to comfortably coexist with all other traits, but this has always been a misuse of traits. The namespacing is ugly, has no place is Rust code, and sent folks in different directions on how to name methods - some add `new`, others don't.

#### Summary of Changes

* Replace all the transaction traits with structs
* SystemTransaction::new -> new_account
* SystemTransaction::new_create -> new_program_account
