### PR TITLE
Broadcast Service should handle SendError

### DIFF
--- a/src/broadcast_service.rs
+++ b/src/broadcast_service.rs
@@ -223,7 +223,7 @@ impl BroadcastService {
                 blob_sender,
             ) {
                 match e {
-                    Error::RecvTimeoutError(RecvTimeoutError::Disconnected) => {
+                    Error::RecvTimeoutError(RecvTimeoutError::Disconnected) | Error::SendError => {
                         return BroadcastServiceReturnType::ChannelDisconnected;
                     }
                     Error::RecvTimeoutError(RecvTimeoutError::Timeout) => (),


### PR DESCRIPTION
#### Problem
After TVU shuts down, the brroadcast service will get a SendError when it tries to send blobs to it. Currently, the broadcast service is treating it as an error and printing an error message.

#### Summary of Changes
Handle SendError similar to channel Disconnected error.
