### PR TITLE
ci/test-stable-perf.sh:  Disable BPF tests temporarily

### DIFF
--- a/ci/buildkite.yml
+++ b/ci/buildkite.yml
@@ -16,7 +16,7 @@ steps:
     timeout_in_minutes: 30
   - command: "ci/docker-run.sh solanalabs/rust:1.31.0 ci/test-stable.sh"
     name: "stable"
-    timeout_in_minutes: 30
+    timeout_in_minutes: 40
   - command: "ci/docker-run.sh solanalabs/rust-nightly:2019-01-31 ci/test-coverage.sh"
     name: "coverage"
     timeout_in_minutes: 40

--- a/ci/test-stable-perf.sh
+++ b/ci/test-stable-perf.sh
@@ -24,9 +24,9 @@ ci/affects-files.sh \
 make -C programs/bpf/c tests
 
 # Must be built out of band
-make -C programs/bpf/rust/noop/ all
+#make -C programs/bpf/rust/noop/ all
 
-FEATURES=bpf_c,bpf_rust,erasure,chacha
+FEATURES=bpf_c,erasure,chacha
 if [[ $(uname) = Darwin ]]; then
   ./build-perf-libs.sh
 else


### PR DESCRIPTION
It seems that something outside the tree has broken these tests, and now all CI is stuck.  Disabling them while we debug to get CI back online