### PR TITLE
cargo incremental builds breaks Rust BPF, locally disable it

### DIFF
--- a/ci/test-stable-perf.sh
+++ b/ci/test-stable-perf.sh
@@ -24,9 +24,9 @@ ci/affects-files.sh \
 make -C programs/bpf/c tests
 
 # Must be built out of band
-#make -C programs/bpf/rust/noop/ all
+make -C programs/bpf/rust/noop/ all
 
-FEATURES=bpf_c,erasure,chacha
+FEATURES=bpf_c,bpf_rust,erasure,chacha
 if [[ $(uname) = Darwin ]]; then
   ./build-perf-libs.sh
 else

--- a/programs/bpf/rust/noop/makefile
+++ b/programs/bpf/rust/noop/makefile
@@ -104,7 +104,7 @@ $(OUT_DIR)/%.ll: $(SRC_DIR)/*
 	@echo "[cargo] $@ ($<)"
 	$(_@)mkdir -p $(OUT_DIR)
 	$(_@)rm -f $(CARGO_OUT_DIR)/deps/$(TARGET_NAME)-*.ll
-	$(_@)$(CARGO) $(CARGO_FLAGS)
+	$(_@)export CARGO_INCREMENTAL=0; $(CARGO) $(CARGO_FLAGS)
 	$(_@)cp $(CARGO_OUT_DIR)/deps/$(TARGET_NAME)-*.ll $(OUT_DIR)/$(TARGET_NAME).ll
 
 .PRECIOUS: $(OUT_DIR)/%.o


### PR DESCRIPTION
#### Problem

Rust 1.24 enabled the incremental compiler by default.  The incremental compiler generates a bunch of LLMV-IR (`.ll`) files.  When building a rust program `llc` takes the `.ll` file as input but with many created we don't know which one we want.

#### Summary of Changes

Disable the incremental compiler locally when building Rust BPF programs.

Note: The way Rust BPF programs are built is being reworked to not rely on the `.ll` files so this issue will be a non-issue when that work comes in.

Fixes #
