### PR TITLE
Reduce Fullnode public API surface

### DIFF
--- a/src/fullnode.rs
+++ b/src/fullnode.rs
@@ -101,7 +101,7 @@ pub struct Fullnode {
     sigverify_disabled: bool,
     tpu_sockets: Vec<UdpSocket>,
     broadcast_socket: UdpSocket,
-    pub node_services: NodeServices,
+    node_services: NodeServices,
     pub role_notifiers: (TvuRotationReceiver, TpuRotationReceiver),
     blob_sender: BlobSender,
 }
@@ -125,7 +125,7 @@ impl Fullnode {
             db_ledger,
             ledger_signal_sender,
             ledger_signal_receiver,
-        ) = Self::new_bank_from_ledger(ledger_path, &config.leader_scheduler_config);
+        ) = new_bank_from_ledger(ledger_path, &config.leader_scheduler_config);
 
         info!("node info: {:?}", node.info);
         info!("node entrypoint_info: {:?}", entrypoint_info_option);
@@ -300,7 +300,7 @@ impl Fullnode {
         }
     }
 
-    pub fn leader_to_validator(&mut self, tick_height: u64) -> FullnodeReturnType {
+    fn leader_to_validator(&mut self, tick_height: u64) -> FullnodeReturnType {
         trace!(
             "leader_to_validator({:?}): tick_height={}",
             self.id,
@@ -341,12 +341,7 @@ impl Fullnode {
         }
     }
 
-    pub fn validator_to_leader(
-        &mut self,
-        tick_height: u64,
-        entry_height: u64,
-        last_entry_id: Hash,
-    ) {
+    fn validator_to_leader(&mut self, tick_height: u64, entry_height: u64, last_entry_id: Hash) {
         trace!(
             "validator_to_leader({:?}): tick_height={} entry_height={} last_entry_id={}",
             self.id,
@@ -462,7 +457,7 @@ impl Fullnode {
     }
 
     // Used for notifying many nodes in parallel to exit
-    pub fn exit(&self) {
+    fn exit(&self) {
         self.exit.store(true, Ordering::Relaxed);
         if let Some(ref rpc_service) = self.rpc_service {
             rpc_service.exit();
@@ -477,39 +472,38 @@ impl Fullnode {
         self.exit();
         self.join()
     }
+}
 
-    pub fn new_bank_from_ledger(
-        ledger_path: &str,
-        leader_scheduler_config: &LeaderSchedulerConfig,
-    ) -> (Bank, u64, Hash, DbLedger, SyncSender<bool>, Receiver<bool>) {
-        let (db_ledger, ledger_signal_sender, ledger_signal_receiver) =
-            DbLedger::open_with_signal(ledger_path)
-                .expect("Expected to successfully open database ledger");
-        let genesis_block =
-            GenesisBlock::load(ledger_path).expect("Expected to successfully open genesis block");
-        let mut bank =
-            Bank::new_with_leader_scheduler_config(&genesis_block, leader_scheduler_config);
+pub fn new_bank_from_ledger(
+    ledger_path: &str,
+    leader_scheduler_config: &LeaderSchedulerConfig,
+) -> (Bank, u64, Hash, DbLedger, SyncSender<bool>, Receiver<bool>) {
+    let (db_ledger, ledger_signal_sender, ledger_signal_receiver) =
+        DbLedger::open_with_signal(ledger_path)
+            .expect("Expected to successfully open database ledger");
+    let genesis_block =
+        GenesisBlock::load(ledger_path).expect("Expected to successfully open genesis block");
+    let mut bank = Bank::new_with_leader_scheduler_config(&genesis_block, leader_scheduler_config);
 
-        let now = Instant::now();
-        let entries = db_ledger.read_ledger().expect("opening ledger");
-        info!("processing ledger...");
-        let (entry_height, last_entry_id) = bank.process_ledger(entries).expect("process_ledger");
-        info!(
-            "processed {} ledger entries in {}ms, tick_height={}...",
-            entry_height,
-            duration_as_ms(&now.elapsed()),
-            bank.tick_height()
-        );
+    let now = Instant::now();
+    let entries = db_ledger.read_ledger().expect("opening ledger");
+    info!("processing ledger...");
+    let (entry_height, last_entry_id) = bank.process_ledger(entries).expect("process_ledger");
+    info!(
+        "processed {} ledger entries in {}ms, tick_height={}...",
+        entry_height,
+        duration_as_ms(&now.elapsed()),
+        bank.tick_height()
+    );
 
-        (
-            bank,
-            entry_height,
-            last_entry_id,
-            db_ledger,
-            ledger_signal_sender,
-            ledger_signal_receiver,
-        )
-    }
+    (
+        bank,
+        entry_height,
+        last_entry_id,
+        db_ledger,
+        ledger_signal_sender,
+        ledger_signal_receiver,
+    )
 }
 
 impl Service for Fullnode {
@@ -829,10 +823,8 @@ mod tests {
 
         // Close the validator so that rocksdb has locks available
         validator_exit();
-        let (bank, entry_height, _, _, _, _) = Fullnode::new_bank_from_ledger(
-            &validator_ledger_path,
-            &LeaderSchedulerConfig::default(),
-        );
+        let (bank, entry_height, _, _, _, _) =
+            new_bank_from_ledger(&validator_ledger_path, &LeaderSchedulerConfig::default());
 
         assert!(
             bank.tick_height()

--- a/src/replay_stage.rs
+++ b/src/replay_stage.rs
@@ -341,7 +341,7 @@ mod test {
     use crate::db_ledger::{DbLedger, DEFAULT_SLOT_HEIGHT};
     use crate::entry::create_ticks;
     use crate::entry::Entry;
-    use crate::fullnode::Fullnode;
+    use crate::fullnode::new_bank_from_ledger;
     use crate::genesis_block::GenesisBlock;
     use crate::leader_scheduler::{make_active_set_entries, LeaderSchedulerConfig};
     use crate::replay_stage::ReplayStage;
@@ -416,7 +416,7 @@ mod test {
         {
             // Set up the bank
             let (bank, _entry_height, last_entry_id, db_ledger, l_sender, l_receiver) =
-                Fullnode::new_bank_from_ledger(&my_ledger_path, &leader_scheduler_config);
+                new_bank_from_ledger(&my_ledger_path, &leader_scheduler_config);
 
             // Set up the replay stage
             let (rotation_sender, rotation_receiver) = channel();
@@ -520,7 +520,7 @@ mod test {
         let (to_leader_sender, _) = channel();
         {
             let (bank, entry_height, last_entry_id, db_ledger, l_sender, l_receiver) =
-                Fullnode::new_bank_from_ledger(&my_ledger_path, &LeaderSchedulerConfig::default());
+                new_bank_from_ledger(&my_ledger_path, &LeaderSchedulerConfig::default());
 
             let bank = Arc::new(bank);
             let db_ledger = Arc::new(db_ledger);
@@ -629,7 +629,7 @@ mod test {
         let exit = Arc::new(AtomicBool::new(false));
         {
             let (bank, _entry_height, last_entry_id, db_ledger, l_sender, l_receiver) =
-                Fullnode::new_bank_from_ledger(&my_ledger_path, &leader_scheduler_config);
+                new_bank_from_ledger(&my_ledger_path, &leader_scheduler_config);
 
             let meta = db_ledger
                 .meta()

--- a/tests/multinode.rs
+++ b/tests/multinode.rs
@@ -5,7 +5,7 @@ use solana::cluster_info::{ClusterInfo, Node, NodeInfo};
 use solana::db_ledger::{create_tmp_sample_ledger, tmp_copy_ledger};
 use solana::db_ledger::{DbLedger, DEFAULT_SLOT_HEIGHT};
 use solana::entry::{reconstruct_entries_from_blobs, Entry};
-use solana::fullnode::{Fullnode, FullnodeConfig, FullnodeReturnType};
+use solana::fullnode::{new_bank_from_ledger, Fullnode, FullnodeConfig, FullnodeReturnType};
 use solana::gossip_service::GossipService;
 use solana::leader_scheduler::{make_active_set_entries, LeaderSchedulerConfig};
 use solana::packet::SharedBlob;
@@ -1018,8 +1018,7 @@ fn test_leader_to_validator_transition() {
     leader_exit();
 
     info!("Check the ledger to make sure it's the right height...");
-    let bank =
-        Fullnode::new_bank_from_ledger(&leader_ledger_path, &LeaderSchedulerConfig::default()).0;
+    let bank = new_bank_from_ledger(&leader_ledger_path, &LeaderSchedulerConfig::default()).0;
 
     assert_eq!(
         bank.tick_height(),


### PR DESCRIPTION
#### Problem
Excessive use of `pub`, helper functions pretending to be Fullnode methods

#### Summary of Changes
Remove the `pub`, 👢 unrelated helper function from Fullnode impl 

