### PR TITLE
Fix pay-to-self Accounts bug

### DIFF
--- a/sdk/src/budget_transaction.rs
+++ b/sdk/src/budget_transaction.rs
@@ -85,9 +85,13 @@ impl BudgetTransaction {
         last_id: Hash,
     ) -> Transaction {
         let instruction = Instruction::ApplySignature;
+        let mut keys = vec![contract];
+        if from_keypair.pubkey() != to {
+            keys.push(to);
+        }
         Transaction::new(
             from_keypair,
-            &[contract, to],
+            &keys,
             budget_program::id(),
             &instruction,
             last_id,

--- a/src/bank.rs
+++ b/src/bank.rs
@@ -46,6 +46,10 @@ pub enum BankError {
     /// This Pubkey is being processed in another transaction
     AccountInUse,
 
+    /// Pubkey appears twice in the same transaction, typically in a pay-to-self
+    /// transaction.
+    AccountLoadedTwice,
+
     /// Attempt to debit from `Pubkey`, but no found no record of a prior credit.
     AccountNotFound,
 
@@ -641,6 +645,12 @@ impl Bank {
             inc_new_counter_info!(
                 "bank-process_transactions-error-insufficient_funds",
                 error_counters.insufficient_funds
+            );
+        }
+        if 0 != error_counters.account_loaded_twice {
+            inc_new_counter_info!(
+                "bank-process_transactions-account_loaded_twice",
+                error_counters.account_loaded_twice
             );
         }
         (loaded_accounts, executed)

--- a/src/bank.rs
+++ b/src/bank.rs
@@ -1852,5 +1852,19 @@ mod tests {
 
         assert_eq!(bank.get_balance(&pubkey), 1);
     }
+    #[test]
+    fn test_bank_pay_to_self() {
+        let (genesis_block, mint_keypair) = GenesisBlock::new(1 + BOOTSTRAP_LEADER_TOKENS);
+        let key1 = Keypair::new();
+        let bank = Bank::new(&genesis_block);
 
+        bank.transfer(1, &mint_keypair, key1.pubkey(), genesis_block.last_id())
+            .unwrap();
+        assert_eq!(bank.get_balance(&key1.pubkey()), 1);
+        let tx = SystemTransaction::new_move(&key1, key1.pubkey(), 1, genesis_block.last_id(), 0);
+        let res = bank.process_transactions(&vec![tx.clone()]);
+        assert_eq!(res.len(), 1);
+        assert_eq!(bank.get_balance(&key1.pubkey()), 1);
+        res[0].clone().unwrap_err();
+    }
 }

--- a/src/chacha.rs
+++ b/src/chacha.rs
@@ -166,7 +166,7 @@ mod tests {
         use bs58;
         //  golden needs to be updated if blob stuff changes....
         let golden = Hash::new(
-            &bs58::decode("BES6jpfVwayNKq9YZbYjbZbyX3GLzFzeQJ7fksm6LifE")
+            &bs58::decode("nzxMWDQVsftBZbMGA1ika8X6bAKy7vya1jfXnVZSErt")
                 .into_vec()
                 .unwrap(),
         );

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -120,6 +120,7 @@ impl Metadata for Meta {}
 #[derive(Copy, Clone, PartialEq, Serialize, Debug)]
 pub enum RpcSignatureStatus {
     AccountInUse,
+    AccountLoadedTwice,
     Confirmed,
     GenericFailure,
     ProgramRuntimeError,
@@ -131,6 +132,7 @@ impl FromStr for RpcSignatureStatus {
     fn from_str(s: &str) -> Result<RpcSignatureStatus> {
         match s {
             "AccountInUse" => Ok(RpcSignatureStatus::AccountInUse),
+            "AccountLoadedTwice" => Ok(RpcSignatureStatus::AccountLoadedTwice),
             "Confirmed" => Ok(RpcSignatureStatus::Confirmed),
             "GenericFailure" => Ok(RpcSignatureStatus::GenericFailure),
             "ProgramRuntimeError" => Ok(RpcSignatureStatus::ProgramRuntimeError),
@@ -235,6 +237,7 @@ impl RpcSol for RpcSolImpl {
                 match res.unwrap() {
                     Ok(_) => RpcSignatureStatus::Confirmed,
                     Err(BankError::AccountInUse) => RpcSignatureStatus::AccountInUse,
+                    Err(BankError::AccountLoadedTwice) => RpcSignatureStatus::AccountLoadedTwice,
                     Err(BankError::ProgramError(_, _)) => RpcSignatureStatus::ProgramRuntimeError,
                     Err(err) => {
                         trace!("mapping {:?} to GenericFailure", err);


### PR DESCRIPTION
#### Problem
Top level bug: Given an account with a positive token balance, it is possible to magically increase your balance by paying tokens to yourself (bank processes a `SystemTransaction::new_move` or `SystemTransaction::new_account`, where the signing keypair and recipient pubkey are the same account).

Root cause: When the same account is listed as both the "from" keypair and "to" pubkey, the account is loaded into the tx accounts vector twice. When `runtime::execute_instruction` is called, the pre_total:post_total check passes, because the debit is applied to one instance of the account, and the credit to the other. Then when the accounts are re-stored, the 2nd account instance overwrites the first, saving the credited account.

#### Summary of Changes
Add check for unique keys when loading accounts for a discrete transaction.

... There are other potential ways to solve this bug, but I have yet to think of any legitimate reasons why one transaction would need to load the same account twice. I believe that is why Instructions index into the accounts array, after all.

Fixes #
