### PR TITLE
Don't depend on solana_native_loader for IDs in the SDK

### DIFF
--- a/programs/native/native_loader/src/lib.rs
+++ b/programs/native/native_loader/src/lib.rs
@@ -7,9 +7,7 @@ use libloading::os::windows::*;
 use log::*;
 use solana_sdk::account::KeyedAccount;
 use solana_sdk::loader_instruction::LoaderInstruction;
-pub use solana_sdk::native_loader::*;
-use solana_sdk::native_program;
-use solana_sdk::native_program::ProgramError;
+use solana_sdk::native_program::{self, ProgramError};
 use solana_sdk::pubkey::Pubkey;
 use std::env;
 use std::path::PathBuf;
@@ -46,10 +44,6 @@ fn create_path(name: &str) -> PathBuf {
         // `cargo build` places dependent libraries in the deps/ subdirectory
         current_exe_directory.join("deps").join(library_file_name)
     }
-}
-
-pub fn check_id(program_id: &Pubkey) -> bool {
-    program_id.as_ref() == NATIVE_LOADER_PROGRAM_ID
 }
 
 pub fn entrypoint(

--- a/programs/tests/programs.rs
+++ b/programs/tests/programs.rs
@@ -1,6 +1,7 @@
 use solana::bank::Bank;
 use solana::genesis_block::GenesisBlock;
 use solana_sdk::loader_transaction::LoaderTransaction;
+use solana_sdk::native_loader;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::{Keypair, KeypairUtil};
 use solana_sdk::system_transaction::SystemTransaction;
@@ -52,7 +53,7 @@ fn test_program_native_noop() {
     let bank = Bank::new(&genesis_block);
 
     let program = "noop".as_bytes().to_vec();
-    let program_id = load_program(&bank, &mint_keypair, solana_native_loader::id(), program);
+    let program_id = load_program(&bank, &mint_keypair, native_loader::id(), program);
 
     // Call user program
     let tx = Transaction::new(&mint_keypair, &[], program_id, &1u8, bank.last_id(), 0);
@@ -68,7 +69,7 @@ fn test_program_lua_move_funds() {
     let loader_id = load_program(
         &bank,
         &mint_keypair,
-        solana_native_loader::id(),
+        native_loader::id(),
         "solana_lua_loader".as_bytes().to_vec(),
     );
 
@@ -191,7 +192,7 @@ fn test_program_bpf_c() {
         let loader_id = load_program(
             &bank,
             &mint_keypair,
-            solana_native_loader::id(),
+            native_loader::id(),
             "solana_bpf_loader".as_bytes().to_vec(),
         );
 
@@ -230,7 +231,7 @@ fn test_program_bpf_rust() {
         let loader_id = load_program(
             &bank,
             &mint_keypair,
-            solana_native_loader::id(),
+            native_loader::id(),
             "solana_bpf_loader".as_bytes().to_vec(),
         );
 

--- a/sdk/src/native_loader.rs
+++ b/sdk/src/native_loader.rs
@@ -7,3 +7,7 @@ pub const NATIVE_LOADER_PROGRAM_ID: [u8; 32] = [
 pub fn id() -> Pubkey {
     Pubkey::new(&NATIVE_LOADER_PROGRAM_ID)
 }
+
+pub fn check_id(program_id: &Pubkey) -> bool {
+    program_id.as_ref() == NATIVE_LOADER_PROGRAM_ID
+}

--- a/src/accounts.rs
+++ b/src/accounts.rs
@@ -6,6 +6,7 @@ use hashbrown::{HashMap, HashSet};
 use log::Level;
 use solana_sdk::account::Account;
 use solana_sdk::hash::{hash, Hash};
+use solana_sdk::native_loader;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::transaction::Transaction;
 use std::collections::BTreeMap;
@@ -166,7 +167,7 @@ impl AccountsDB {
         let mut accounts = Vec::new();
         let mut depth = 0;
         loop {
-            if solana_native_loader::check_id(&program_id) {
+            if native_loader::check_id(&program_id) {
                 // at the root of the chain, ready to dispatch
                 break;
             }
@@ -454,7 +455,7 @@ mod tests {
             &[],
             Hash::default(),
             0,
-            vec![solana_native_loader::id()],
+            vec![native_loader::id()],
             instructions,
         );
 
@@ -478,7 +479,7 @@ mod tests {
             &[],
             Hash::default(),
             0,
-            vec![solana_native_loader::id()],
+            vec![native_loader::id()],
             instructions,
         );
 
@@ -538,7 +539,7 @@ mod tests {
             &[],
             Hash::default(),
             10,
-            vec![solana_native_loader::id()],
+            vec![native_loader::id()],
             instructions,
         );
 
@@ -570,7 +571,7 @@ mod tests {
             &[key1],
             Hash::default(),
             0,
-            vec![solana_native_loader::id()],
+            vec![native_loader::id()],
             instructions,
         );
 
@@ -608,7 +609,7 @@ mod tests {
 
         let mut account = Account::new(40, 1, Pubkey::default());
         account.executable = true;
-        account.loader = solana_native_loader::id();
+        account.loader = native_loader::id();
         accounts.push((key1, account));
 
         let mut account = Account::new(41, 1, Pubkey::default());
@@ -700,7 +701,7 @@ mod tests {
         accounts.push((key0, account));
 
         let mut account = Account::new(40, 1, Pubkey::default());
-        account.loader = solana_native_loader::id();
+        account.loader = native_loader::id();
         accounts.push((key1, account));
 
         let instructions = vec![Instruction::new(0, &(), vec![0])];
@@ -736,7 +737,7 @@ mod tests {
 
         let mut account = Account::new(40, 1, Pubkey::default());
         account.executable = true;
-        account.loader = solana_native_loader::id();
+        account.loader = native_loader::id();
         accounts.push((key1, account));
 
         let mut account = Account::new(41, 1, Pubkey::default());

--- a/src/bank.rs
+++ b/src/bank.rs
@@ -18,11 +18,11 @@ use bincode::deserialize;
 use itertools::Itertools;
 use log::Level;
 use rayon::prelude::*;
-use solana_native_loader;
 use solana_sdk::account::Account;
 use solana_sdk::bpf_loader;
 use solana_sdk::budget_program;
 use solana_sdk::hash::Hash;
+use solana_sdk::native_loader;
 use solana_sdk::native_program::ProgramError;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::Keypair;
@@ -232,7 +232,7 @@ impl Bank {
             owner: system_program::id(),
             userdata: b"solana_system_program".to_vec(),
             executable: true,
-            loader: solana_native_loader::id(),
+            loader: native_loader::id(),
         };
         self.accounts
             .store_slow(true, &system_program::id(), &system_program_account);
@@ -243,7 +243,7 @@ impl Bank {
             owner: vote_program::id(),
             userdata: b"solana_vote_program".to_vec(),
             executable: true,
-            loader: solana_native_loader::id(),
+            loader: native_loader::id(),
         };
         self.accounts
             .store_slow(true, &vote_program::id(), &vote_program_account);
@@ -254,7 +254,7 @@ impl Bank {
             owner: storage_program::id(),
             userdata: b"solana_storage_program".to_vec(),
             executable: true,
-            loader: solana_native_loader::id(),
+            loader: native_loader::id(),
         };
         self.accounts
             .store_slow(true, &storage_program::id(), &storage_program_account);
@@ -275,7 +275,7 @@ impl Bank {
             owner: bpf_loader::id(),
             userdata: b"solana_bpf_loader".to_vec(),
             executable: true,
-            loader: solana_native_loader::id(),
+            loader: native_loader::id(),
         };
 
         self.accounts
@@ -287,7 +287,7 @@ impl Bank {
             owner: budget_program::id(),
             userdata: b"solana_budget_program".to_vec(),
             executable: true,
-            loader: solana_native_loader::id(),
+            loader: native_loader::id(),
         };
         self.accounts
             .store_slow(true, &budget_program::id(), &budget_program_account);
@@ -298,7 +298,7 @@ impl Bank {
             owner: token_program::id(),
             userdata: b"solana_erc20".to_vec(),
             executable: true,
-            loader: solana_native_loader::id(),
+            loader: native_loader::id(),
         };
 
         self.accounts
@@ -1664,7 +1664,7 @@ mod tests {
         ]);
 
         assert_eq!(system_program::id(), system);
-        assert_eq!(solana_native_loader::id(), native);
+        assert_eq!(native_loader::id(), native);
         assert_eq!(bpf_loader::id(), bpf);
         assert_eq!(budget_program::id(), budget);
         assert_eq!(storage_program::id(), storage);
@@ -1678,7 +1678,7 @@ mod tests {
         let mut unique = HashSet::new();
         let ids = vec![
             system_program::id(),
-            solana_native_loader::id(),
+            native_loader::id(),
             bpf_loader::id(),
             budget_program::id(),
             storage_program::id(),


### PR DESCRIPTION
#### Problem

Only runtime.rs really depends on solana_native_loader. The rest of the references are just using reexports from the SDK's native_loader.

#### Summary of Changes

No longer reexport native_loader. Updated references.

