### PR TITLE
Whitelist the metrics-solana-com buildkite agent from docker container cleanup

### DIFF
--- a/.buildkite/hooks/post-checkout
+++ b/.buildkite/hooks/post-checkout
@@ -7,8 +7,8 @@ export CI_BUILD_START
 #
 (
   containers=$(docker ps -q)
-  if [[ -n $containers ]]; then
-    echo "Killing stale docker containers"
+  if [[ $(hostname) != metrics-solana-com && -n $containers ]]; then
+    echo "+++ Killing stale docker containers"
     docker ps
 
     # shellcheck disable=SC2086 # Don't want to double quote $containers


### PR DESCRIPTION
Umm, metrics runs via docker 💥 
