### PR TITLE
Temporarily bump DEFAULT_TICKS_PER_SLOT to 64

### DIFF
--- a/src/leader_scheduler.rs
+++ b/src/leader_scheduler.rs
@@ -21,7 +21,7 @@ use std::sync::Arc;
 // every 800 ms. A fast voting cadence ensures faster finality and convergence
 pub const DEFAULT_TICKS_PER_SLOT: u64 = 8;
 */
-pub const DEFAULT_TICKS_PER_SLOT: u64 = 32; // TODO: DEFAULT_TICKS_PER_SLOT = 8 causes instability in the integration tests.
+pub const DEFAULT_TICKS_PER_SLOT: u64 = 64; // TODO: DEFAULT_TICKS_PER_SLOT = 8 causes instability in the integration tests.
 pub const DEFAULT_SLOTS_PER_EPOCH: u64 = 64;
 pub const DEFAULT_SEED_ROTATION_INTERVAL: u64 = DEFAULT_SLOTS_PER_EPOCH * DEFAULT_TICKS_PER_SLOT;
 pub const DEFAULT_ACTIVE_WINDOW_LENGTH: u64 = DEFAULT_SEED_ROTATION_INTERVAL;


### PR DESCRIPTION
Integration tests and nightly iteration testing are not always happy with the temporary setting of 32 ticks per slot.

Rather than tolerating flaking tests until we can fix the root cause and restore 8 ticks per slot (see #2675), let's bump up the ticks per slot to get tests green more often to interfere less with unrelated work. 