### PR TITLE
leader_scheduler: replace older terminology with ticks, slots and epochs

### DIFF
--- a/ci/integration-tests.sh
+++ b/ci/integration-tests.sh
@@ -19,7 +19,7 @@ for test in {,*/}tests/*.rs; do
   (
     export RUST_LOG="$test"=trace,$RUST_LOG
     # shellcheck disable=SC2086 # Don't want to double quote $maybeFeatures
-    _ cargo test --all --verbose $maybeFeatures --test="$test" \
+    _ cargo test --all ${V:+--verbose} $maybeFeatures --test="$test" \
       -- --test-threads=1 --nocapture
   )
 done

--- a/ci/iterations-localnet.sh
+++ b/ci/iterations-localnet.sh
@@ -26,8 +26,7 @@ build() {
   $genPipeline && return
   ci/version-check-with-upgrade.sh stable
   _ scripts/ulimit-n.sh
-  FEATURES=""
-  _ cargo build --all --features="$FEATURES"
+  _ cargo build --all
 }
 
 runTest() {

--- a/ci/test-bench.sh
+++ b/ci/test-bench.sh
@@ -47,7 +47,7 @@ echo --- program/native/bpf_loader bench --features=bpf_c
 (
   set -x
   cd programs/native/bpf_loader
-  cargo +nightly bench --verbose --features="bpf_c" \
+  cargo +nightly bench ${V:+--verbose} --features="bpf_c" \
     -- -Z unstable-options --format=json --nocapture | tee -a ../../../"$BENCH_FILE"
 )
 

--- a/ci/test-stable.sh
+++ b/ci/test-stable.sh
@@ -12,8 +12,8 @@ export RUST_BACKTRACE=1
 export RUSTFLAGS="-D warnings"
 
 source scripts/ulimit-n.sh
-_ cargo build --all --verbose --features="$FEATURES"
-_ cargo test --all --verbose --features="$FEATURES" --lib -- --nocapture --test-threads=1
+_ cargo build --all ${V:+--verbose} --features="$FEATURES"
+_ cargo test --all ${V:+--verbose} --features="$FEATURES" --lib -- --nocapture --test-threads=1
 
 # Run native program tests (without $FEATURES)
 for program in programs/native/*; do

--- a/ci/test-stable.sh
+++ b/ci/test-stable.sh
@@ -12,8 +12,14 @@ export RUST_BACKTRACE=1
 export RUSTFLAGS="-D warnings"
 
 source scripts/ulimit-n.sh
-_ cargo build --all ${V:+--verbose} --features="$FEATURES"
-_ cargo test --all ${V:+--verbose} --features="$FEATURES" --lib -- --nocapture --test-threads=1
+maybeFeatures=
+if [[ -n $FEATURES ]]; then
+  maybeFeatures="--features=$FEATURES"
+fi
+# shellcheck disable=SC2086 # Don't want to double quote $maybeFeatures
+_ cargo build --all ${V:+--verbose} $maybeFeatures
+# shellcheck disable=SC2086 # Don't want to double quote $maybeFeatures
+_ cargo test --all ${V:+--verbose} $maybeFeatures --lib -- --nocapture --test-threads=1
 
 # Run native program tests (without $FEATURES)
 for program in programs/native/*; do

--- a/src/broadcast_service.rs
+++ b/src/broadcast_service.rs
@@ -370,7 +370,7 @@ mod test {
             // Mock the tick height to look like the tick height right after a leader transition
             leader_scheduler.set_leader_schedule(vec![leader_keypair.pubkey()]);
             let start_tick_height = 0;
-            let max_tick_height = start_tick_height + leader_scheduler.seed_rotation_interval;
+            let max_tick_height = start_tick_height + leader_scheduler.ticks_per_epoch;
             let entry_height = 2 * start_tick_height;
 
             let leader_scheduler = Arc::new(RwLock::new(leader_scheduler));

--- a/src/db_window.rs
+++ b/src/db_window.rs
@@ -55,7 +55,7 @@ pub fn repair(
             // 1) The replay stage hasn't caught up to the "consumed" entries we sent,
             // in which case it will eventually catch up
             //
-            // 2) We are on the border between seed_rotation_intervals, so the
+            // 2) We are on the border between ticks_per_epochs, so the
             // schedule won't be known until the entry on that cusp is received
             // by the replay stage (which comes after this stage). Hence, the next
             // leader at the beginning of that next epoch will not know they are the

--- a/src/window.rs
+++ b/src/window.rs
@@ -140,7 +140,7 @@ impl WindowUtil for Window {
                 // 1) The replay stage hasn't caught up to the "consumed" entries we sent,
                 // in which case it will eventually catch up
                 //
-                // 2) We are on the border between seed_rotation_intervals, so the
+                // 2) We are on the border between ticks_per_epochs, so the
                 // schedule won't be known until the entry on that cusp is received
                 // by the replay stage (which comes after this stage). Hence, the next
                 // leader at the beginning of that next epoch will not know they are the


### PR DESCRIPTION
* `leader_rotation_interval` ▶️`ticks_per_slot`
* `seed_rotation_interval` ▶️`ticks_per_epoch`
* `active_window_length` ▶️`active_window_tick_length` (clarify units)