### PR TITLE
Cleanup consecutive entries code from window_service

### DIFF
--- a/src/blocktree.rs
+++ b/src/blocktree.rs
@@ -849,7 +849,7 @@ impl Blocktree {
         // Return error if there was a database error during lookup of any of the
         // slot indexes
         let slots: Result<Vec<Option<SlotMeta>>> = slot_heights
-            .into_iter()
+            .iter()
             .map(|slot_height| self.meta_cf.get_slot_meta(*slot_height))
             .collect();
 

--- a/src/blocktree.rs
+++ b/src/blocktree.rs
@@ -462,7 +462,7 @@ impl Blocktree {
         }
     }
 
-    pub fn write_shared_blobs<I>(&self, shared_blobs: I) -> Result<Vec<Entry>>
+    pub fn write_shared_blobs<I>(&self, shared_blobs: I) -> Result<()>
     where
         I: IntoIterator,
         I::Item: Borrow<SharedBlob>,
@@ -476,21 +476,19 @@ impl Blocktree {
 
         let blobs = r_blobs.iter().map(|s| &**s);
 
-        let new_entries = self.insert_data_blobs(blobs)?;
-        Ok(new_entries)
+        self.insert_data_blobs(blobs)
     }
 
-    pub fn write_blobs<I>(&self, blobs: I) -> Result<Vec<Entry>>
+    pub fn write_blobs<I>(&self, blobs: I) -> Result<()>
     where
         I: IntoIterator,
         I::Item: Borrow<Blob>,
     {
         //let blobs = blobs.into_iter().map(|b| *b.borrow());
-        let entries = self.insert_data_blobs(blobs)?;
-        Ok(entries)
+        self.insert_data_blobs(blobs)
     }
 
-    pub fn write_entries<I>(&self, slot: u64, index: u64, entries: I) -> Result<Vec<Entry>>
+    pub fn write_entries<I>(&self, slot: u64, index: u64, entries: I) -> Result<()>
     where
         I: IntoIterator,
         I::Item: Borrow<Entry>,
@@ -509,7 +507,7 @@ impl Blocktree {
         self.write_blobs(&blobs)
     }
 
-    pub fn insert_data_blobs<I>(&self, new_blobs: I) -> Result<Vec<Entry>>
+    pub fn insert_data_blobs<I>(&self, new_blobs: I) -> Result<()>
     where
         I: IntoIterator,
         I::Item: Borrow<Blob>,
@@ -521,7 +519,6 @@ impl Blocktree {
         let new_blobs: Vec<_> = new_blobs.into_iter().collect();
         let mut prev_inserted_blob_datas = HashMap::new();
 
-        let mut consecutive_entries = vec![];
         for blob in new_blobs.iter() {
             let blob = blob.borrow();
             let blob_slot = blob.slot();
@@ -562,15 +559,12 @@ impl Blocktree {
                 continue;
             }
 
-            let entries = self.insert_data_blob(
+            let _ = self.insert_data_blob(
                 blob,
                 &mut prev_inserted_blob_datas,
                 slot_meta,
                 &mut write_batch,
             );
-            if let Ok(entries) = entries {
-                consecutive_entries.extend(entries);
-            }
         }
 
         // Handle chaining for the working set
@@ -599,11 +593,7 @@ impl Blocktree {
             }
         }
 
-        // TODO: Delete returning these entries and instead have replay_stage query blocktree
-        // for updates. Returning these entries is to temporarily support current API as to
-        // not break functionality in db_window.
-        // Issue: https://github.com/solana-labs/solana/issues/2444
-        Ok(consecutive_entries)
+        Ok(())
     }
 
     // Fill 'buf' with num_blobs or most number of consecutive
@@ -1100,7 +1090,7 @@ impl Blocktree {
         prev_inserted_blob_datas: &mut HashMap<(u64, u64), &'a [u8]>,
         slot_meta: &mut SlotMeta,
         write_batch: &mut WriteBatch,
-    ) -> Result<Vec<Entry>> {
+    ) -> Result<()> {
         let blob_index = blob_to_insert.index();
         let blob_slot = blob_to_insert.slot();
         let blob_size = blob_to_insert.size();
@@ -1111,7 +1101,7 @@ impl Blocktree {
             return Err(Error::BlocktreeError(BlocktreeError::BlobForIndexExists));
         }
 
-        let (new_consumed, new_consumed_ticks, blob_datas) = {
+        let (new_consumed, new_consumed_ticks) = {
             if slot_meta.consumed == blob_index {
                 let blob_datas = self.get_slot_consecutive_blobs(
                     blob_slot,
@@ -1125,7 +1115,6 @@ impl Blocktree {
 
                 let blob_to_insert = Cow::Borrowed(&blob_to_insert.data[..]);
                 let mut new_consumed_ticks = 0;
-                let mut entries = vec![];
                 // Check all the consecutive blobs for ticks
                 for blob_data in once(&blob_to_insert).chain(blob_datas.iter()) {
                     let serialized_entry_data = &blob_data[BLOB_HEADER_SIZE..];
@@ -1135,7 +1124,6 @@ impl Blocktree {
                     if entry.is_tick() {
                         new_consumed_ticks += 1;
                     }
-                    entries.push(entry);
                 }
 
                 (
@@ -1143,10 +1131,9 @@ impl Blocktree {
                     // get_slot_consecutive_blobs() earlier
                     slot_meta.consumed + blob_datas.len() as u64 + 1,
                     new_consumed_ticks,
-                    entries,
                 )
             } else {
-                (slot_meta.consumed, 0, vec![])
+                (slot_meta.consumed, 0)
             }
         };
 
@@ -1162,11 +1149,7 @@ impl Blocktree {
         slot_meta.received = cmp::max(blob_index + 1, slot_meta.received);
         slot_meta.consumed = new_consumed;
         slot_meta.consumed_ticks += new_consumed_ticks;
-        // TODO: Remove returning these entries and instead have replay_stage query blocktree
-        // for updates. Returning these entries is to temporarily support current API as to
-        // not break functionality in db_window.
-        // Issue: https://github.com/solana-labs/solana/issues/2444
-        Ok(blob_datas)
+        Ok(())
     }
 
     /// Returns the next consumed index and the number of ticks in the new consumed

--- a/src/blocktree.rs
+++ b/src/blocktree.rs
@@ -484,7 +484,6 @@ impl Blocktree {
         I: IntoIterator,
         I::Item: Borrow<Blob>,
     {
-        //let blobs = blobs.into_iter().map(|b| *b.borrow());
         self.insert_data_blobs(blobs)
     }
 

--- a/src/db_window.rs
+++ b/src/db_window.rs
@@ -11,51 +11,10 @@ use log::Level;
 use solana_metrics::{influxdb, submit};
 use solana_sdk::pubkey::Pubkey;
 use std::borrow::Borrow;
-use std::cmp;
 use std::sync::atomic::AtomicUsize;
 use std::sync::{Arc, RwLock};
 
 pub const MAX_REPAIR_LENGTH: usize = 128;
-
-pub fn generate_repairs(blocktree: &Blocktree, max_repairs: usize) -> Result<Vec<(u64, u64)>> {
-    // Slot height and blob indexes for blobs we want to repair
-    let mut repairs: Vec<(u64, u64)> = vec![];
-    let mut slots = vec![0];
-    while repairs.len() < max_repairs && !slots.is_empty() {
-        let slot_height = slots.pop().unwrap();
-        let slot = blocktree.meta(slot_height)?;
-        if slot.is_none() {
-            continue;
-        }
-        let slot = slot.unwrap();
-        slots.extend(slot.next_slots.clone());
-
-        if slot.contains_all_ticks(blocktree) {
-            continue;
-        } else {
-            let num_unreceived_ticks = {
-                if slot.consumed == slot.received {
-                    slot.num_expected_ticks(blocktree) - slot.consumed_ticks
-                } else {
-                    0
-                }
-            };
-
-            let upper = slot.received + num_unreceived_ticks;
-
-            let reqs = blocktree.find_missing_data_indexes(
-                0,
-                slot.consumed,
-                upper,
-                max_repairs - repairs.len(),
-            );
-
-            repairs.extend(reqs.into_iter().map(|i| (slot_height, i)))
-        }
-    }
-
-    Ok(repairs)
-}
 
 pub fn retransmit_all_leader_blocks(
     dq: &[SharedBlob],
@@ -154,26 +113,6 @@ pub fn process_blob(
     }
 
     Ok(())
-}
-
-pub fn calculate_max_repair_entry_height(
-    num_peers: u64,
-    consumed: u64,
-    received: u64,
-    times: usize,
-    is_next_leader: bool,
-) -> u64 {
-    // Calculate the highest blob index that this node should have already received
-    // via avalanche. The avalanche splits data stream into nodes and each node retransmits
-    // the data to their peer nodes. So there's a possibility that a blob (with index lower
-    // than current received index) is being retransmitted by a peer node.
-    if times >= 8 || is_next_leader {
-        // If repair backoff is getting high, or if we are the next leader,
-        // don't wait for avalanche. received - 1 is the index of the highest blob.
-        received
-    } else {
-        cmp::max(consumed, received.saturating_sub(num_peers))
-    }
 }
 
 #[cfg(feature = "erasure")]
@@ -280,23 +219,6 @@ mod test {
     }
 
     #[test]
-    pub fn test_calculate_max_repair_entry_height() {
-        assert_eq!(calculate_max_repair_entry_height(20, 4, 11, 0, false), 4);
-        assert_eq!(calculate_max_repair_entry_height(0, 10, 90, 0, false), 90);
-        assert_eq!(calculate_max_repair_entry_height(15, 10, 90, 32, false), 90);
-        assert_eq!(calculate_max_repair_entry_height(15, 10, 90, 0, false), 75);
-        assert_eq!(calculate_max_repair_entry_height(90, 10, 90, 0, false), 10);
-        assert_eq!(calculate_max_repair_entry_height(90, 10, 50, 0, false), 10);
-        assert_eq!(calculate_max_repair_entry_height(90, 10, 99, 0, false), 10);
-        assert_eq!(calculate_max_repair_entry_height(90, 10, 101, 0, false), 11);
-        assert_eq!(calculate_max_repair_entry_height(90, 10, 101, 0, true), 101);
-        assert_eq!(
-            calculate_max_repair_entry_height(90, 10, 101, 30, true),
-            101
-        );
-    }
-
-    #[test]
     pub fn test_retransmit() {
         let leader = Keypair::new().pubkey();
         let nonleader = Keypair::new().pubkey();
@@ -342,79 +264,6 @@ mod test {
         retransmit_all_leader_blocks(&vec![blob], &leader_scheduler, &blob_sender, &leader)
             .expect("Expect successful retransmit");
         assert!(blob_receiver.try_recv().is_err());
-    }
-
-    #[test]
-    pub fn test_generate_repairs() {
-        let blocktree_path = get_tmp_ledger_path("test_generate_repairs");
-        let num_ticks_per_slot = 10;
-        let blocktree_config = BlocktreeConfig::new(num_ticks_per_slot);
-        let blocktree = Blocktree::open_config(&blocktree_path, blocktree_config).unwrap();
-
-        let num_entries_per_slot = 10;
-        let num_slots = 2;
-        let mut blobs = make_tiny_test_entries(num_slots * num_entries_per_slot).to_blobs();
-
-        // Insert every nth entry for each slot
-        let nth = 3;
-        for (i, b) in blobs.iter_mut().enumerate() {
-            b.set_index(((i % num_entries_per_slot) * nth) as u64);
-            b.set_slot((i / num_entries_per_slot) as u64);
-        }
-
-        blocktree.write_blobs(&blobs).unwrap();
-
-        let missing_indexes_per_slot: Vec<u64> = (0..num_entries_per_slot - 1)
-            .flat_map(|x| ((nth * x + 1) as u64..(nth * x + nth) as u64))
-            .collect();
-
-        let expected: Vec<(u64, u64)> = (0..num_slots)
-            .flat_map(|slot_height| {
-                missing_indexes_per_slot
-                    .iter()
-                    .map(move |blob_index| (slot_height as u64, *blob_index))
-            })
-            .collect();
-
-        // Across all slots, find all missing indexes in the range [0, num_entries_per_slot * nth]
-        assert_eq!(
-            generate_repairs(&blocktree, std::usize::MAX).unwrap(),
-            expected
-        );
-
-        assert_eq!(
-            generate_repairs(&blocktree, expected.len() - 2).unwrap()[..],
-            expected[0..expected.len() - 2]
-        );
-
-        // Now fill in all the holes for each slot such that for each slot, consumed == received.
-        // Because none of the slots contain ticks, we should see that the repair requests
-        // ask for ticks, starting from the last received index for that slot
-        for (slot_height, blob_index) in expected {
-            let mut b = make_tiny_test_entries(1).to_blobs().pop().unwrap();
-            b.set_index(blob_index);
-            b.set_slot(slot_height);
-            blocktree.write_blobs(&vec![b]).unwrap();
-        }
-
-        let last_index_per_slot = ((num_entries_per_slot - 1) * nth) as u64;
-        let missing_indexes_per_slot: Vec<u64> =
-            (last_index_per_slot + 1..last_index_per_slot + 1 + num_ticks_per_slot).collect();
-        let expected: Vec<(u64, u64)> = (0..num_slots)
-            .flat_map(|slot_height| {
-                missing_indexes_per_slot
-                    .iter()
-                    .map(move |blob_index| (slot_height as u64, *blob_index))
-            })
-            .collect();
-        assert_eq!(
-            generate_repairs(&blocktree, std::usize::MAX).unwrap(),
-            expected
-        );
-        assert_eq!(
-            generate_repairs(&blocktree, expected.len() - 2).unwrap()[..],
-            expected[0..expected.len() - 2]
-        );
     }
 
     #[test]

--- a/src/replicator.rs
+++ b/src/replicator.rs
@@ -116,7 +116,6 @@ impl Replicator {
         timeout: Option<Duration>,
     ) -> Result<Self> {
         let exit = Arc::new(AtomicBool::new(false));
-        let done = Arc::new(AtomicBool::new(false));
         let timeout = timeout.unwrap_or_else(|| Duration::new(30, 0));
 
         info!("Replicator: id: {}", keypair.pubkey());
@@ -156,7 +155,7 @@ impl Replicator {
             Self::poll_for_last_id_and_entry_height(&cluster_info)?;
 
         let signature = keypair.sign(storage_last_id.as_ref());
-        let (entry_height, max_entry_height) =
+        let (entry_height, _max_entry_height) =
             get_entry_heights_from_last_id(&signature, storage_entry_height);
 
         info!("replicating entry_height: {}", entry_height);
@@ -175,13 +174,10 @@ impl Replicator {
         let window_service = WindowService::new(
             blocktree.clone(),
             cluster_info.clone(),
-            0,
-            max_entry_height,
             blob_fetch_receiver,
             retransmit_sender,
             repair_socket,
             Arc::new(RwLock::new(LeaderScheduler::default())),
-            done.clone(),
             exit.clone(),
         );
 

--- a/src/replicator.rs
+++ b/src/replicator.rs
@@ -82,7 +82,7 @@ pub fn sample_file(in_path: &Path, sample_offsets: &[u64]) -> io::Result<Hash> {
 fn get_entry_heights_from_last_id(
     signature: &ring::signature::Signature,
     storage_entry_height: u64,
-) -> (u64, u64) {
+) -> u64 {
     let signature_vec = signature.as_ref();
     let mut segment_index = u64::from(signature_vec[0])
         | (u64::from(signature_vec[1]) << 8)
@@ -90,10 +90,7 @@ fn get_entry_heights_from_last_id(
         | (u64::from(signature_vec[2]) << 24);
     let max_segment_index = get_segment_from_entry(storage_entry_height);
     segment_index %= max_segment_index as u64;
-    let entry_height = segment_index * ENTRIES_PER_SEGMENT;
-    let max_entry_height = entry_height + ENTRIES_PER_SEGMENT;
-
-    (entry_height, max_entry_height)
+    segment_index * ENTRIES_PER_SEGMENT
 }
 
 impl Replicator {
@@ -155,8 +152,7 @@ impl Replicator {
             Self::poll_for_last_id_and_entry_height(&cluster_info)?;
 
         let signature = keypair.sign(storage_last_id.as_ref());
-        let (entry_height, _max_entry_height) =
-            get_entry_heights_from_last_id(&signature, storage_entry_height);
+        let entry_height = get_entry_heights_from_last_id(&signature, storage_entry_height);
 
         info!("replicating entry_height: {}", entry_height);
 

--- a/src/retransmit_stage.rs
+++ b/src/retransmit_stage.rs
@@ -128,7 +128,6 @@ impl RetransmitStage {
         bank: &Arc<Bank>,
         blocktree: Arc<Blocktree>,
         cluster_info: &Arc<RwLock<ClusterInfo>>,
-        tick_height: u64,
         retransmit_socket: Arc<UdpSocket>,
         repair_socket: Arc<UdpSocket>,
         fetch_stage_receiver: BlobReceiver,
@@ -143,17 +142,13 @@ impl RetransmitStage {
             cluster_info.clone(),
             retransmit_receiver,
         );
-        let done = Arc::new(AtomicBool::new(false));
         let window_service = WindowService::new(
             blocktree,
             cluster_info.clone(),
-            tick_height,
-            0,
             fetch_stage_receiver,
             retransmit_sender,
             repair_socket,
             leader_scheduler,
-            done,
             exit,
         );
 

--- a/src/sigverify.rs
+++ b/src/sigverify.rs
@@ -154,7 +154,7 @@ pub fn generate_offsets(batches: &[SharedPackets]) -> Result<TxOffsets> {
     let mut msg_sizes: Vec<_> = Vec::new();
     let mut current_packet = 0;
     let mut v_sig_lens = Vec::new();
-    batches.into_iter().for_each(|p| {
+    batches.iter().for_each(|p| {
         let mut sig_lens = Vec::new();
         p.read().unwrap().packets.iter().for_each(|packet| {
             let current_offset = current_packet as u32 * size_of::<Packet>() as u32;

--- a/src/tvu.rs
+++ b/src/tvu.rs
@@ -110,7 +110,6 @@ impl Tvu {
             bank,
             blocktree.clone(),
             &cluster_info,
-            bank.tick_height(),
             Arc::new(retransmit_socket),
             repair_socket,
             blob_fetch_receiver,


### PR DESCRIPTION
#### Problem
WindowService and DbWindow have a lot of unused code from when WindowService used to forward consecutive entries to DbLedger.

#### Summary of Changes
Remove entries being returned on insertion from DbLedger, ReplayStage now queries the ledger for entries.

Remove the logic in DbWindow and WindowService surrounding managing and returning consecutive entries.

Remove the "max_height" logic from WindowService as it no longer tracks consecutive entries in the DbLedger. @sakridge 

Fixes #
