### PR TITLE
Reduce Tvu/Tpu service return types to ()

### DIFF
--- a/src/tvu.rs
+++ b/src/tvu.rs
@@ -194,28 +194,19 @@ impl Service for Tvu {
 
 #[cfg(test)]
 pub mod tests {
+    use super::*;
     use crate::bank::Bank;
     use crate::blocktree::get_tmp_ledger_path;
-    use crate::blocktree::Blocktree;
     use crate::cluster_info::{ClusterInfo, Node};
     use crate::entry::Entry;
     use crate::genesis_block::GenesisBlock;
     use crate::gossip_service::GossipService;
     use crate::packet::SharedBlob;
-    use crate::service::Service;
-    use crate::storage_stage::{StorageState, STORAGE_ROTATE_TEST_COUNT};
+    use crate::storage_stage::STORAGE_ROTATE_TEST_COUNT;
     use crate::streamer;
-    use crate::tvu::{Sockets, Tvu};
-    use crate::voting_keypair::VotingKeypair;
     use bincode::serialize;
-    use solana_sdk::hash::Hash;
-    use solana_sdk::signature::{Keypair, KeypairUtil};
     use solana_sdk::system_transaction::SystemTransaction;
     use std::fs::remove_dir_all;
-    use std::net::UdpSocket;
-    use std::sync::atomic::{AtomicBool, Ordering};
-    use std::sync::mpsc::channel;
-    use std::sync::{Arc, RwLock};
     use std::time::Duration;
 
     fn new_gossip(

--- a/src/tvu.rs
+++ b/src/tvu.rs
@@ -174,22 +174,21 @@ impl Tvu {
         self.replay_stage.exit();
     }
 
-    pub fn close(self) -> thread::Result<Option<TvuReturnType>> {
+    pub fn close(self) -> thread::Result<()> {
         self.exit();
         self.join()
     }
 }
 
 impl Service for Tvu {
-    type JoinReturnType = Option<TvuReturnType>;
+    type JoinReturnType = ();
 
-    fn join(self) -> thread::Result<Option<TvuReturnType>> {
+    fn join(self) -> thread::Result<()> {
         self.retransmit_stage.join()?;
         self.fetch_stage.join()?;
         self.storage_stage.join()?;
-        match self.replay_stage.join()? {
-            _ => Ok(None),
-        }
+        self.replay_stage.join()?;
+        Ok(())
     }
 }
 


### PR DESCRIPTION
The Tvu and Tpu services both return an interesting looking return type from their respective `join()`s: `Option<TpuReturnType>` and `Option<TvuReturnType>` respectively.   However for all that effort nobody cares to consume it, making it dead code.  Better to return good old `()` to avoid potential confusion/misdirection.