### PR TITLE
Rename Appendix to API Reference

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -22,6 +22,11 @@
   - [Gossip Service](gossip.md)
   - [The Runtime](runtime.md)
 
+- [API Reference](api-reference.md)
+  - [JSON RPC API](jsonrpc-api.md)
+  - [JavaScript API](javascript-api.md)
+  - [solana-wallet CLI](wallet.md)
+
 - [Proposed Architectural Changes](proposals.md)
   - [Ledger Replication](ledger-replication.md)
   - [Secure Vote Signing](vote-signer.md)
@@ -43,10 +48,3 @@
     - [Economic Sustainability](ed_economic_sustainability.md)
     - [Attack Vectors](ed_attack_vectors.md)
     - [References](ed_references.md)
-
-## Appendix
-
-- [Appendix](appendix.md)
-  - [JSON RPC API](jsonrpc-api.md)
-  - [JavaScript API](javascript-api.md)
-  - [solana-wallet CLI](wallet.md)

--- a/book/src/api-reference.md
+++ b/book/src/api-reference.md
@@ -1,0 +1,4 @@
+# API Reference
+
+The following sections contain API references material you may find useful
+when developing applications utilizing a Solana cluster.

--- a/book/src/appendix.md
+++ b/book/src/appendix.md
@@ -1,4 +1,0 @@
-# Appendix
-
-The following sections contain reference material you may find useful in your
-Solana journey.


### PR DESCRIPTION
#### Problem

The book is primarily split into two sections: all the stuff that's implemented; designs that are approved to be implemented. The Appendix was the one inconsistency, which is all API references for stuff that is already implemented.

#### Summary of Changes

* Rename Appendix to API Reference
* Move API Reference before the proposals
