### PR TITLE
slot 0 now contains the same number of ticks as all subsequent slots

### DIFF
--- a/ledger-tool/tests/basic.rs
+++ b/ledger-tool/tests/basic.rs
@@ -32,7 +32,7 @@ fn bad_arguments() {
 #[test]
 fn nominal() {
     let keypair = Arc::new(Keypair::new());
-    let (_, ledger_path, _, _) =
+    let (_mint_keypair, ledger_path, _last_entry_height, _last_id, _last_entry_id) =
         create_tmp_sample_ledger("test_ledger_tool_nominal", 100, 9, keypair.pubkey(), 50);
 
     // Basic validation

--- a/src/fullnode.rs
+++ b/src/fullnode.rs
@@ -567,7 +567,7 @@ mod tests {
 
         let validator_keypair = Keypair::new();
         let validator_node = Node::new_localhost_with_pubkey(validator_keypair.pubkey());
-        let (_, validator_ledger_path, _, _) =
+        let (_mint_keypair, validator_ledger_path, _last_entry_height, _last_id, _last_entry_id) =
             create_tmp_sample_ledger("validator_exit", 10_000, 0, leader_keypair.pubkey(), 1000);
 
         let validator = Fullnode::new(
@@ -592,7 +592,13 @@ mod tests {
             .map(|i| {
                 let validator_keypair = Keypair::new();
                 let validator_node = Node::new_localhost_with_pubkey(validator_keypair.pubkey());
-                let (_, validator_ledger_path, _, _) = create_tmp_sample_ledger(
+                let (
+                    _mint_keypair,
+                    validator_ledger_path,
+                    _last_entry_height,
+                    _last_id,
+                    _last_entry_id,
+                ) = create_tmp_sample_ledger(
                     &format!("validator_parallel_exit_{}", i),
                     10_000,
                     0,
@@ -632,14 +638,19 @@ mod tests {
         let bootstrap_leader_node =
             Node::new_localhost_with_pubkey(bootstrap_leader_keypair.pubkey());
 
-        let (_mint_keypair, bootstrap_leader_ledger_path, _genesis_entry_height, _last_id) =
-            create_tmp_sample_ledger(
-                "test_leader_to_leader_transition",
-                10_000,
-                1,
-                bootstrap_leader_keypair.pubkey(),
-                500,
-            );
+        let (
+            _mint_keypair,
+            bootstrap_leader_ledger_path,
+            _genesis_entry_height,
+            _last_id,
+            _last_entry_id,
+        ) = create_tmp_sample_ledger(
+            "test_leader_to_leader_transition",
+            10_000,
+            1,
+            bootstrap_leader_keypair.pubkey(),
+            500,
+        );
 
         // Once the bootstrap leader hits the second epoch, because there are no other choices in
         // the active set, this leader will remain the leader in the second epoch. In the second
@@ -960,13 +971,14 @@ mod tests {
 
         // Create validator identity
         assert!(num_genesis_ticks <= ticks_per_block);
-        let (mint_keypair, ledger_path, genesis_entry_height, last_id) = create_tmp_sample_ledger(
-            test_name,
-            10_000,
-            num_genesis_ticks,
-            leader_node.info.id,
-            500,
-        );
+        let (mint_keypair, ledger_path, genesis_entry_height, last_id, last_entry_id) =
+            create_tmp_sample_ledger(
+                test_name,
+                10_000,
+                num_genesis_ticks,
+                leader_node.info.id,
+                500,
+            );
 
         let validator_node = Node::new_localhost_with_pubkey(validator_keypair.pubkey());
 
@@ -982,7 +994,7 @@ mod tests {
             &mint_keypair,
             10,
             1,
-            &last_id,
+            &last_entry_id,
             &last_id,
             num_ending_ticks,
         );

--- a/src/replay_stage.rs
+++ b/src/replay_stage.rs
@@ -81,6 +81,7 @@ impl ReplayStage {
         let mut res = Ok(());
         let mut num_entries_to_write = entries.len();
         let now = Instant::now();
+
         if !entries.as_slice().verify(&last_entry_id.read().unwrap()) {
             inc_new_counter_info!("replicate_stage-verify-fail", entries.len());
             return Err(Error::BlobError(BlobError::VerificationFailed));
@@ -388,7 +389,7 @@ mod test {
         let old_leader_id = Keypair::new().pubkey();
 
         // Create a ledger
-        let (mint_keypair, my_ledger_path, genesis_entry_height, mut last_id) =
+        let (mint_keypair, my_ledger_path, genesis_entry_height, mut last_id, last_entry_id) =
             create_tmp_sample_ledger(
                 "test_replay_stage_leader_rotation_exit",
                 10_000,
@@ -410,7 +411,7 @@ mod test {
             &mint_keypair,
             100,
             ticks_per_slot, // add a vote for tick_height = ticks_per_slot
-            &last_id,
+            &last_entry_id,
             &last_id,
             0,
         );
@@ -515,13 +516,14 @@ mod test {
         // Create keypair for the leader
         let leader_id = Keypair::new().pubkey();
 
-        let (_, my_ledger_path, _, _) = create_tmp_sample_ledger(
-            "test_vote_error_replay_stage_correctness",
-            10_000,
-            1,
-            leader_id,
-            500,
-        );
+        let (_mint_keypair, my_ledger_path, _last_entry_height, _last_id, _last_entry_id) =
+            create_tmp_sample_ledger(
+                "test_vote_error_replay_stage_correctness",
+                10_000,
+                1,
+                leader_id,
+                500,
+            );
 
         // Set up the cluster info
         let cluster_info_me = Arc::new(RwLock::new(ClusterInfo::new(my_node.info.clone())));
@@ -560,7 +562,7 @@ mod test {
             let vote = VoteTransaction::new_vote(keypair, bank.tick_height(), bank.last_id(), 0);
             cluster_info_me.write().unwrap().push_vote(vote);
 
-            // Send ReplayStage an entry, should see it on the ledger writer receiver
+            info!("Send ReplayStage an entry, should see it on the ledger writer receiver");
             let next_tick = create_ticks(1, last_entry_id);
 
             blocktree
@@ -569,7 +571,7 @@ mod test {
 
             let received_tick = ledger_writer_recv
                 .recv()
-                .expect("Expected to recieve an entry on the ledger writer receiver");
+                .expect("Expected to receive an entry on the ledger writer receiver");
 
             assert_eq!(next_tick, received_tick);
 
@@ -594,7 +596,7 @@ mod test {
         let leader_id = Keypair::new().pubkey();
 
         // Create the ledger
-        let (mint_keypair, my_ledger_path, genesis_entry_height, last_id) =
+        let (mint_keypair, my_ledger_path, genesis_entry_height, last_id, last_entry_id) =
             create_tmp_sample_ledger(
                 "test_vote_error_replay_stage_leader_rotation",
                 10_000,
@@ -607,8 +609,15 @@ mod test {
         // Write two entries to the ledger so that the validator is in the active set:
         // 1) Give the validator a nonzero number of tokens 2) A vote from the validator.
         // This will cause leader rotation after the bootstrap height
-        let (active_set_entries, voting_keypair) =
-            make_active_set_entries(&my_keypair, &mint_keypair, 100, 1, &last_id, &last_id, 0);
+        let (active_set_entries, voting_keypair) = make_active_set_entries(
+            &my_keypair,
+            &mint_keypair,
+            100,
+            1,
+            &last_entry_id,
+            &last_id,
+            0,
+        );
         let mut last_id = active_set_entries.last().unwrap().id;
         let initial_tick_height = genesis_entry_height;
 

--- a/src/storage_stage.rs
+++ b/src/storage_stage.rs
@@ -492,13 +492,14 @@ mod tests {
         let keypair = Arc::new(Keypair::new());
         let exit = Arc::new(AtomicBool::new(false));
 
-        let (_mint, ledger_path, genesis_entry_height, _last_id) = create_tmp_sample_ledger(
-            "storage_stage_process_entries",
-            1000,
-            1,
-            Keypair::new().pubkey(),
-            1,
-        );
+        let (_mint, ledger_path, genesis_entry_height, _last_id, _last_entry_id) =
+            create_tmp_sample_ledger(
+                "storage_stage_process_entries",
+                1000,
+                1,
+                Keypair::new().pubkey(),
+                1,
+            );
 
         let entries = make_tiny_test_entries(64);
         let blocktree = Blocktree::open(&ledger_path).unwrap();
@@ -560,13 +561,14 @@ mod tests {
         let keypair = Arc::new(Keypair::new());
         let exit = Arc::new(AtomicBool::new(false));
 
-        let (_mint, ledger_path, genesis_entry_height, _last_id) = create_tmp_sample_ledger(
-            "storage_stage_process_entries",
-            1000,
-            1,
-            Keypair::new().pubkey(),
-            1,
-        );
+        let (_mint, ledger_path, genesis_entry_height, _last_id, _last_entry_id) =
+            create_tmp_sample_ledger(
+                "storage_stage_process_entries",
+                1000,
+                1,
+                Keypair::new().pubkey(),
+                1,
+            );
 
         let entries = make_tiny_test_entries(128);
         let blocktree = Blocktree::open(&ledger_path).unwrap();

--- a/src/thin_client.rs
+++ b/src/thin_client.rs
@@ -464,7 +464,7 @@ pub fn new_fullnode(ledger_name: &'static str) -> (Fullnode, NodeInfo, Keypair, 
     let node = Node::new_localhost_with_pubkey(node_keypair.pubkey());
     let node_info = node.info.clone();
 
-    let (mint_keypair, ledger_path, _, _) =
+    let (mint_keypair, ledger_path, _last_entry_height, _last_id, _last_entry_id) =
         create_tmp_sample_ledger(ledger_name, 10_000, 0, node_info.id, 42);
 
     let vote_account_keypair = Arc::new(Keypair::new());

--- a/tests/multinode.rs
+++ b/tests/multinode.rs
@@ -120,7 +120,7 @@ fn test_multi_node_ledger_window() -> result::Result<()> {
     let bob_pubkey = Keypair::new().pubkey();
     let mut ledger_paths = Vec::new();
 
-    let (alice, leader_ledger_path, mut last_entry_height, mut last_entry_id) =
+    let (alice, leader_ledger_path, mut last_entry_height, _last_id, mut last_entry_id) =
         create_tmp_sample_ledger("multi_node_ledger_window", 10_000, 0, leader_data.id, 500);
     ledger_paths.push(leader_ledger_path.clone());
 
@@ -141,7 +141,7 @@ fn test_multi_node_ledger_window() -> result::Result<()> {
         let blocktree = Blocktree::open(&leader_ledger_path).unwrap();
 
         let entries = solana::entry::create_ticks(
-            fullnode_config.leader_scheduler_config.ticks_per_slot - last_entry_height - 2,
+            fullnode_config.leader_scheduler_config.ticks_per_slot - last_entry_height - 1,
             last_entry_id,
         );
         blocktree
@@ -240,13 +240,14 @@ fn test_multi_node_validator_catchup_from_zero() -> result::Result<()> {
     let bob_pubkey = Keypair::new().pubkey();
     let mut ledger_paths = Vec::new();
 
-    let (alice, genesis_ledger_path, _last_entry_height, _last_entry_id) = create_tmp_sample_ledger(
-        "multi_node_validator_catchup_from_zero",
-        10_000,
-        0,
-        leader_data.id,
-        500,
-    );
+    let (alice, genesis_ledger_path, _last_entry_height, _last_id, _last_entry_id) =
+        create_tmp_sample_ledger(
+            "multi_node_validator_catchup_from_zero",
+            10_000,
+            0,
+            leader_data.id,
+            500,
+        );
     ledger_paths.push(genesis_ledger_path.clone());
 
     let zero_ledger_path = tmp_copy_ledger(
@@ -429,7 +430,7 @@ fn test_multi_node_basic() {
     let bob_pubkey = Keypair::new().pubkey();
     let mut ledger_paths = Vec::new();
 
-    let (alice, genesis_ledger_path, _last_entry_height, _last_entry_id) =
+    let (alice, genesis_ledger_path, _last_entry_height, _last_id, _last_entry_id) =
         create_tmp_sample_ledger("multi_node_basic", 10_000, 0, leader_data.id, 500);
     ledger_paths.push(genesis_ledger_path.clone());
 
@@ -529,7 +530,7 @@ fn test_boot_validator_from_file() -> result::Result<()> {
     let bob_pubkey = Keypair::new().pubkey();
     let mut ledger_paths = Vec::new();
 
-    let (alice, genesis_ledger_path, _last_entry_height, _last_entry_id) =
+    let (alice, genesis_ledger_path, _last_entry_height, _last_id, _last_entry_id) =
         create_tmp_sample_ledger("boot_validator_from_file", 100_000, 0, leader_pubkey, 1000);
     ledger_paths.push(genesis_ledger_path.clone());
 
@@ -608,13 +609,14 @@ fn test_leader_restart_validator_start_from_old_ledger() -> result::Result<()> {
 
     let leader_keypair = Arc::new(Keypair::new());
     let initial_leader_balance = 500;
-    let (alice, ledger_path, _last_entry_height, _last_entry_id) = create_tmp_sample_ledger(
-        "leader_restart_validator_start_from_old_ledger",
-        100_000 + 500 * solana::window_service::MAX_REPAIR_BACKOFF as u64,
-        0,
-        leader_keypair.pubkey(),
-        initial_leader_balance,
-    );
+    let (alice, ledger_path, _last_entry_height, _last_id, _last_entry_id) =
+        create_tmp_sample_ledger(
+            "leader_restart_validator_start_from_old_ledger",
+            100_000 + 500 * solana::window_service::MAX_REPAIR_BACKOFF as u64,
+            0,
+            leader_keypair.pubkey(),
+            initial_leader_balance,
+        );
     let bob_pubkey = Keypair::new().pubkey();
 
     {
@@ -717,13 +719,14 @@ fn test_multi_node_dynamic_network() {
     let leader_pubkey = leader_keypair.pubkey().clone();
     let leader = Node::new_localhost_with_pubkey(leader_keypair.pubkey());
     let bob_pubkey = Keypair::new().pubkey();
-    let (alice, genesis_ledger_path, _last_entry_height, _last_entry_id) = create_tmp_sample_ledger(
-        "multi_node_dynamic_network",
-        10_000_000,
-        0,
-        leader_pubkey,
-        500,
-    );
+    let (alice, genesis_ledger_path, _last_entry_height, _last_id, _last_entry_id) =
+        create_tmp_sample_ledger(
+            "multi_node_dynamic_network",
+            10_000_000,
+            0,
+            leader_pubkey,
+            500,
+        );
 
     let mut ledger_paths = Vec::new();
     ledger_paths.push(genesis_ledger_path.clone());
@@ -938,7 +941,7 @@ fn test_leader_to_validator_transition() {
 
     // Initialize the leader ledger. Make a mint and a genesis entry
     // in the leader ledger
-    let (mint_keypair, leader_ledger_path, genesis_entry_height, last_id) =
+    let (mint_keypair, leader_ledger_path, genesis_entry_height, last_id, last_entry_id) =
         create_tmp_sample_ledger(
             "test_leader_to_validator_transition",
             10_000,
@@ -954,7 +957,7 @@ fn test_leader_to_validator_transition() {
         &mint_keypair,
         100,
         ticks_per_slot,
-        &last_id,
+        &last_entry_id,
         &last_id,
         0,
     );
@@ -1039,7 +1042,7 @@ fn test_leader_validator_basic() {
     info!("validator id: {}", validator_keypair.pubkey());
 
     // Make a common mint and a genesis entry for both leader + validator ledgers
-    let (mint_keypair, leader_ledger_path, genesis_entry_height, last_id) =
+    let (mint_keypair, leader_ledger_path, genesis_entry_height, last_id, last_entry_id) =
         create_tmp_sample_ledger(
             "test_leader_validator_basic",
             10_000,
@@ -1054,7 +1057,7 @@ fn test_leader_validator_basic() {
         &mint_keypair,
         100,
         1,
-        &last_id,
+        &last_entry_id,
         &last_id,
         0,
     );
@@ -1112,27 +1115,37 @@ fn test_leader_validator_basic() {
 
     converge(&leader_info, 2);
 
-    info!("Waiting for slot 0 -> slot 1: bootstrap leader will remain the leader");
-    assert_eq!(
-        leader_rotation_receiver.recv().unwrap(),
-        (FullnodeReturnType::LeaderToLeaderRotation, ticks_per_slot,)
-    );
-
-    info!("Waiting for slot 1 -> slot 2: bootstrap leader becomes a validator");
+    info!("Waiting for slot 0 -> slot 1: bootstrap leader and the validator rotate");
     assert_eq!(
         leader_rotation_receiver.recv().unwrap(),
         (
             FullnodeReturnType::LeaderToValidatorRotation,
-            ticks_per_slot * 2,
+            ticks_per_slot,
         )
     );
-
-    info!("Waiting for slot 1 -> slot 2: validator becomes the leader");
     assert_eq!(
         validator_rotation_receiver.recv().unwrap(),
         (
             FullnodeReturnType::ValidatorToLeaderRotation,
+            ticks_per_slot,
+        )
+    );
+
+    info!("Waiting for slot 1 -> slot 2: validator remains the slot leader due to no votes");
+    assert_eq!(
+        validator_rotation_receiver.recv().unwrap(),
+        (
+            FullnodeReturnType::LeaderToLeaderRotation,
             ticks_per_slot * 2,
+        )
+    );
+
+    info!("Waiting for slot 2 -> slot 3: validator remains the slot leader due to no votes");
+    assert_eq!(
+        validator_rotation_receiver.recv().unwrap(),
+        (
+            FullnodeReturnType::LeaderToLeaderRotation,
+            ticks_per_slot * 3,
         )
     );
 
@@ -1185,7 +1198,7 @@ fn test_dropped_handoff_recovery() {
 
     // Make a common mint and a genesis entry for both leader + validator's ledgers
     let num_ending_ticks = 1;
-    let (mint_keypair, genesis_ledger_path, genesis_entry_height, last_id) =
+    let (mint_keypair, genesis_ledger_path, genesis_entry_height, last_id, last_entry_id) =
         create_tmp_sample_ledger(
             "test_dropped_handoff_recovery",
             10_000,
@@ -1210,7 +1223,7 @@ fn test_dropped_handoff_recovery() {
         &mint_keypair,
         100,
         ticks_per_slot,
-        &last_id,
+        &last_entry_id,
         &last_id,
         0,
     );
@@ -1344,17 +1357,19 @@ fn test_full_leader_validator_network() {
 
     // Make a common mint and a genesis entry for both leader + validator's ledgers
     let num_ending_ticks = 1;
-    let (mint_keypair, bootstrap_leader_ledger_path, genesis_entry_height, last_id) =
-        create_tmp_sample_ledger(
-            "test_full_leader_validator_network",
-            10_000,
-            num_ending_ticks,
-            bootstrap_leader_info.id,
-            500,
-        );
-
-    let last_tick_id = last_id;
-    let mut last_entry_id = last_id;
+    let (
+        mint_keypair,
+        bootstrap_leader_ledger_path,
+        genesis_entry_height,
+        last_id,
+        mut last_entry_id,
+    ) = create_tmp_sample_ledger(
+        "test_full_leader_validator_network",
+        10_000,
+        num_ending_ticks,
+        bootstrap_leader_info.id,
+        500,
+    );
 
     // Create a common ledger with entries in the beginnging that will add all the validators
     // to the active set for leader election.
@@ -1371,7 +1386,7 @@ fn test_full_leader_validator_network() {
             100,
             1,
             &last_entry_id,
-            &last_tick_id,
+            &last_id,
             0,
         );
 
@@ -1551,14 +1566,19 @@ fn test_broadcast_last_tick() {
     let bootstrap_leader_info = bootstrap_leader_node.info.clone();
 
     // Create leader ledger
-    let (_mint_keypair, bootstrap_leader_ledger_path, genesis_entry_height, _last_id) =
-        create_tmp_sample_ledger(
-            "test_broadcast_last_tick",
-            10_000,
-            0,
-            bootstrap_leader_info.id,
-            500,
-        );
+    let (
+        _mint_keypair,
+        bootstrap_leader_ledger_path,
+        genesis_entry_height,
+        _last_id,
+        _last_entry_id,
+    ) = create_tmp_sample_ledger(
+        "test_broadcast_last_tick",
+        10_000,
+        0,
+        bootstrap_leader_info.id,
+        500,
+    );
 
     let genesis_ledger_len = genesis_entry_height;
     debug!("genesis_ledger_len: {}", genesis_ledger_len);
@@ -1626,7 +1646,7 @@ fn test_broadcast_last_tick() {
     bootstrap_leader_exit();
 
     // Index of the last tick must be at least ticks_per_slot - 1
-    let last_tick_entry_index = ticks_per_slot as usize - 2;
+    let last_tick_entry_index = ticks_per_slot as usize - 1;
     let entries = read_ledger(&bootstrap_leader_ledger_path);
     assert!(entries.len() >= last_tick_entry_index + 1);
     let expected_last_tick = &entries[last_tick_entry_index];

--- a/tests/replicator.rs
+++ b/tests/replicator.rs
@@ -40,7 +40,7 @@ fn test_replicator_startup_basic() {
     let leader_info = leader_node.info.clone();
 
     let leader_ledger_path = "replicator_test_leader_ledger";
-    let (mint_keypair, leader_ledger_path, _last_entry_height, _last_entry_id) =
+    let (mint_keypair, leader_ledger_path, _last_entry_height, _last_id, _last_entry_id) =
         create_tmp_sample_ledger(leader_ledger_path, 1_000_000_000, 0, leader_info.id, 42);
 
     let validator_ledger_path =
@@ -277,7 +277,7 @@ fn test_replicator_startup_ledger_hang() {
     let leader_info = leader_node.info.clone();
 
     let leader_ledger_path = "replicator_test_leader_ledger";
-    let (_mint_keypair, leader_ledger_path, _last_entry_height, _last_entry_id) =
+    let (_mint_keypair, leader_ledger_path, _last_entry_height, _last_id, _last_entry_id) =
         create_tmp_sample_ledger(leader_ledger_path, 100, 0, leader_info.id, 42);
 
     let validator_ledger_path =


### PR DESCRIPTION
* blocktree no longer needs to special case slot 0
* `solana-ledger-tool` now shows a proper tick entry with `tick_height = 1`