### PR TITLE
ci: Less --verbose by default

### DIFF
--- a/ci/test-bench.sh
+++ b/ci/test-bench.sh
@@ -39,7 +39,7 @@ fi
 
 BENCH_FILE=bench_output.log
 BENCH_ARTIFACT=current_bench_results.log
-_ cargo +nightly bench --features=unstable --verbose \
+_ cargo +nightly bench --features=unstable ${V:+--verbose} \
   -- -Z unstable-options --format=json | tee "$BENCH_FILE"
 
 # Run bpf_loader bench with bpf_c feature enabled

--- a/ci/test-stable.sh
+++ b/ci/test-stable.sh
@@ -27,7 +27,7 @@ for program in programs/native/*; do
   (
     set -x
     cd "$program"
-    cargo test --verbose -- --nocapture
+    cargo test ${V:+--verbose} -- --nocapture
   )
 done
 


### PR DESCRIPTION
Follow up from eb3ba5ce2d53d4ae5ccd276977c719481d41a277, missed a couple `--verbose`s