### PR TITLE
fullnode: Merge leader_to_validator/validator_to_leader

### DIFF
--- a/src/poh_service.rs
+++ b/src/poh_service.rs
@@ -5,7 +5,7 @@ use crate::poh_recorder::{PohRecorder, PohRecorderError};
 use crate::result::Error;
 use crate::result::Result;
 use crate::service::Service;
-use crate::tpu::{TpuReturnType, TpuRotationSender};
+use crate::tpu::TpuRotationSender;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::thread::sleep;
@@ -92,8 +92,7 @@ impl PohService {
                         let res = poh.hash();
                         if let Err(e) = res {
                             if let Error::PohRecorderError(PohRecorderError::MaxHeightReached) = e {
-                                to_validator_sender
-                                    .send(TpuReturnType::LeaderRotation(max_tick_height))?;
+                                to_validator_sender.send(max_tick_height)?;
                             }
                             return Err(e);
                         }
@@ -106,8 +105,7 @@ impl PohService {
             let res = poh.tick();
             if let Err(e) = res {
                 if let Error::PohRecorderError(PohRecorderError::MaxHeightReached) = e {
-                    // Leader rotation should only happen if a max_tick_height was specified
-                    to_validator_sender.send(TpuReturnType::LeaderRotation(max_tick_height))?;
+                    to_validator_sender.send(max_tick_height)?;
                 }
                 return Err(e);
             }

--- a/src/tpu.rs
+++ b/src/tpu.rs
@@ -20,10 +20,7 @@ use std::sync::mpsc::{channel, Receiver, Sender};
 use std::sync::{Arc, RwLock};
 use std::thread;
 
-pub enum TpuReturnType {
-    LeaderRotation(u64),
-}
-
+pub type TpuReturnType = u64; // tick_height to initiate a rotation
 pub type TpuRotationSender = Sender<TpuReturnType>;
 pub type TpuRotationReceiver = Receiver<TpuReturnType>;
 

--- a/src/tvu.rs
+++ b/src/tvu.rs
@@ -21,22 +21,19 @@ use crate::retransmit_stage::RetransmitStage;
 use crate::service::Service;
 use crate::storage_stage::{StorageStage, StorageState};
 use crate::streamer::BlobSender;
+use crate::tpu::{TpuReturnType, TpuRotationReceiver, TpuRotationSender};
 use crate::voting_keypair::VotingKeypair;
 use solana_sdk::hash::Hash;
 use solana_sdk::signature::{Keypair, KeypairUtil};
 use std::net::UdpSocket;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::mpsc::{channel, Receiver, Sender, SyncSender};
+use std::sync::mpsc::{channel, Receiver, SyncSender};
 use std::sync::{Arc, RwLock};
 use std::thread;
 
-#[derive(Debug, PartialEq, Eq, Clone)]
-pub enum TvuReturnType {
-    LeaderRotation(u64, Hash),
-}
-
-pub type TvuRotationSender = Sender<TvuReturnType>;
-pub type TvuRotationReceiver = Receiver<TvuReturnType>;
+pub type TvuReturnType = TpuReturnType;
+pub type TvuRotationSender = TpuRotationSender;
+pub type TvuRotationReceiver = TpuRotationReceiver;
 
 pub struct Tvu {
     fetch_stage: BlobFetchStage,
@@ -75,7 +72,7 @@ impl Tvu {
         sockets: Sockets,
         blocktree: Arc<Blocktree>,
         storage_rotate_count: u64,
-        to_leader_sender: TvuRotationSender,
+        to_leader_sender: &TvuRotationSender,
         storage_state: &StorageState,
         entry_stream: Option<&String>,
         ledger_signal_sender: SyncSender<bool>,
@@ -261,7 +258,7 @@ pub mod tests {
             },
             Arc::new(blocktree),
             STORAGE_ROTATE_TEST_COUNT,
-            sender,
+            &sender,
             &StorageState::default(),
             None,
             l_sender,
@@ -348,7 +345,7 @@ pub mod tests {
             },
             Arc::new(blocktree),
             STORAGE_ROTATE_TEST_COUNT,
-            sender,
+            &sender,
             &StorageState::default(),
             None,
             l_sender,


### PR DESCRIPTION
This simplifies fullnode rotation implementation by merging the TVU and TPU "rotate" signals. Fullnode doesn't really need to differentiate between them, in all cases it can consult the leader scheduler to determine if it should be leader or not for the next slot.