### PR TITLE
Add notes on eclipse attack vectors and differences from plumtree.

### DIFF
--- a/book/src/gossip.md
+++ b/book/src/gossip.md
@@ -77,3 +77,35 @@ Nodes retain prior versions of values (those updated by a pull or push) and
 expired values (those older than `GOSSIP_PULL_CRDS_TIMEOUT_MS`) in
 `purged_values` (things I recently had).  Nodes purge `purged_values` that are
 older than `5 * GOSSIP_PULL_CRDS_TIMEOUT_MS`.
+
+## Eclipse Attacks
+
+An eclipse attack is an attempt to take over the set of node connections with
+adversarial endpoints.
+
+### Pull Message
+
+A node is selected as a pull target based on local time since last selection and
+the stake weight.  There is no way for an adversary to influence those
+parameters.
+
+### Push Message
+
+A prune message can only remove an adversary from a potential connection.
+
+Just like *pull message*, nodes are selected into the active set based on local
+time since last selection and the stake weight.  There is no way for an
+adversary to influence those parameters.
+
+## Notable differences from PlumTree
+
+The active push protocol described here is based on (Plum
+Tree)[https://haslab.uminho.pt/jop/files/lpr07a.pdf].  The main differences are:
+
+* Push messages have a wallclock that is signed by the originator.  Once the
+wallclock expires the message is dropped.  A hop limit is difficult to implement
+in an adversarial setting.
+
+* Lazy Push is not implemented because its not obvious how to prevent an
+adversary from forging the message fingerprint.  A naive approach would allow an
+adversary to be prioritized for pull based on their input.

--- a/book/src/gossip.md
+++ b/book/src/gossip.md
@@ -83,6 +83,16 @@ older than `5 * GOSSIP_PULL_CRDS_TIMEOUT_MS`.
 An eclipse attack is an attempt to take over the set of node connections with
 adversarial endpoints.
 
+This is relevant to our implementation in the following ways.
+
+* Pull messages select a random node from the network.  An eclipse attack on
+*pull* would require an attacker to influence the random selection in such a way
+that only adversarial nodes are selected for pull.
+
+* Push messages maintain an active set of nodes and select a random fanout for
+every push message.  An eclipse attack on *push* would influence the active set
+selection, or the random fanout selection.
+
 ### Pull Message
 
 A node is selected as a pull target based on local time since last selection and


### PR DESCRIPTION
#### Problem

Gossip design doc is missing description on how the protocol avoids eclipse attack vectors, and differences from plumtree.

#### Summary of Changes

Add the docs based on discussions with @carllin on discord.

Fixes #
