### PR TITLE
replay_stage can figure out its starting blob_index itself

### DIFF
--- a/src/fullnode.rs
+++ b/src/fullnode.rs
@@ -252,12 +252,9 @@ impl Fullnode {
         // Setup channel for rotation indications
         let (rotation_sender, rotation_receiver) = channel();
 
-        let blob_index = Self::get_consumed_for_slot(&blocktree, slot_height);
-
         let (tvu, blob_sender) = Tvu::new(
             voting_keypair_option,
             &bank,
-            blob_index,
             entry_height,
             last_entry_id,
             &cluster_info,
@@ -270,6 +267,7 @@ impl Fullnode {
             ledger_signal_sender,
             ledger_signal_receiver,
         );
+
         let tpu = Tpu::new(
             &Arc::new(bank.copy_for_tpu()),
             PohServiceConfig::default(),
@@ -285,7 +283,7 @@ impl Fullnode {
             cluster_info.clone(),
             config.sigverify_disabled,
             max_tpu_tick_height,
-            blob_index,
+            Self::get_consumed_for_slot(&blocktree, slot_height),
             &last_entry_id,
             id,
             &rotation_sender,

--- a/src/tvu.rs
+++ b/src/tvu.rs
@@ -58,7 +58,6 @@ impl Tvu {
     /// # Arguments
     /// * `bank` - The bank state.
     /// * `entry_height` - Initial ledger height
-    /// * `blob_index` - Index of last processed blob
     /// * `last_entry_id` - Hash of the last entry
     /// * `cluster_info` - The cluster_info state.
     /// * `sockets` - My fetch, repair, and restransmit sockets
@@ -67,7 +66,6 @@ impl Tvu {
     pub fn new(
         voting_keypair: Option<Arc<VotingKeypair>>,
         bank: &Arc<Bank>,
-        blob_index: u64,
         entry_height: u64,
         last_entry_id: Hash,
         cluster_info: &Arc<RwLock<ClusterInfo>>,
@@ -125,7 +123,6 @@ impl Tvu {
             bank.clone(),
             cluster_info.clone(),
             exit.clone(),
-            blob_index,
             l_last_entry_id.clone(),
             to_leader_sender,
             ledger_signal_sender,
@@ -264,7 +261,6 @@ pub mod tests {
             Some(Arc::new(voting_keypair)),
             &bank,
             0,
-            0,
             cur_hash,
             &cref1,
             {
@@ -350,7 +346,6 @@ pub mod tests {
         let (tvu, _) = Tvu::new(
             Some(Arc::new(voting_keypair)),
             &bank,
-            0,
             0,
             cur_hash,
             &cref1,


### PR DESCRIPTION
ReplayStage needed to trust that Fullnode sent Tvu sent it the correct BlockTree blob_index for the current slot.   But ReplayStage can compute that value itself and avoid some error-prone 🍝