### PR TITLE
leader_scheduler: reduce the amount of special case handling for tick_height 0

### DIFF
--- a/src/fullnode.rs
+++ b/src/fullnode.rs
@@ -936,13 +936,10 @@ mod tests {
         // transition to a validator.
         info!("Unpause the Tvu");
         pause_tvu.store(false, Ordering::Relaxed);
-        let expected_rotations = vec![
-            (FullnodeReturnType::LeaderToLeaderRotation, ticks_per_slot),
-            (
-                FullnodeReturnType::LeaderToValidatorRotation,
-                2 * ticks_per_slot,
-            ),
-        ];
+        let expected_rotations = vec![(
+            FullnodeReturnType::LeaderToValidatorRotation,
+            ticks_per_slot,
+        )];
 
         for expected_rotation in expected_rotations {
             loop {

--- a/tests/multinode.rs
+++ b/tests/multinode.rs
@@ -911,16 +911,10 @@ fn test_leader_to_validator_transition() {
     let (rotation_sender, rotation_receiver) = channel();
     let leader_exit = leader.run(Some(rotation_sender));
 
-    // There will be two rotations:
-    // slot 0 -> slot 1: bootstrap leader remains the leader
-    // slot 1 -> slot 2: bootstrap leader to the validator
-    let expected_rotations = vec![
-        (FullnodeReturnType::LeaderToLeaderRotation, ticks_per_slot),
-        (
-            FullnodeReturnType::LeaderToValidatorRotation,
-            2 * ticks_per_slot,
-        ),
-    ];
+    let expected_rotations = vec![(
+        FullnodeReturnType::LeaderToValidatorRotation,
+        ticks_per_slot,
+    )];
 
     for expected_rotation in expected_rotations {
         loop {
@@ -944,7 +938,7 @@ fn test_leader_to_validator_transition() {
 
     assert_eq!(
         bank.tick_height(),
-        2 * fullnode_config.leader_scheduler_config.ticks_per_slot - 1
+        fullnode_config.leader_scheduler_config.ticks_per_slot - 1
     );
     remove_dir_all(leader_ledger_path).unwrap();
 }


### PR DESCRIPTION
tick_height 0 and tick_height 1 handling in the leader scheduler was super weird, and was broken in the degenerate case with ticks_per_slot = 1.  