### PR TITLE
Add is_last_blob flag to blob to signal the end of a slot

### DIFF
--- a/src/broadcast_service.rs
+++ b/src/broadcast_service.rs
@@ -91,7 +91,7 @@ impl Broadcast {
         inc_new_counter_info!("streamer-broadcast-sent", blobs.len());
 
         if contains_last_tick {
-            blobs.last().unwrap().write().unwrap().set_is_last_blob();
+            blobs.last().unwrap().write().unwrap().set_is_last_in_slot();
         }
 
         blocktree.write_shared_blobs(&blobs)?;

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -292,7 +292,7 @@ macro_rules! align {
 
 pub const BLOB_HEADER_SIZE: usize = align!(SIZE_RANGE.end, 8);
 
-pub const BLOB_FLAG_IS_LAST: u32 = 0x2;
+pub const BLOB_FLAG_IS_LAST_IN_SLOT: u32 = 0x2;
 
 pub const BLOB_FLAG_IS_CODING: u32 = 0x1;
 
@@ -352,13 +352,13 @@ impl Blob {
         self.set_flags(flags | BLOB_FLAG_IS_CODING);
     }
 
-    pub fn set_is_last_blob(&mut self) {
+    pub fn set_is_last_in_slot(&mut self) {
         let flags = self.flags();
-        self.set_flags(flags | BLOB_FLAG_IS_LAST);
+        self.set_flags(flags | BLOB_FLAG_IS_LAST_IN_SLOT);
     }
 
-    pub fn is_last_blob(&self) -> bool {
-        (self.flags() & BLOB_FLAG_IS_LAST) != 0
+    pub fn is_last_in_slot(&self) -> bool {
+        (self.flags() & BLOB_FLAG_IS_LAST_IN_SLOT) != 0
     }
 
     pub fn data_size(&self) -> u64 {

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -292,6 +292,8 @@ macro_rules! align {
 
 pub const BLOB_HEADER_SIZE: usize = align!(SIZE_RANGE.end, 8);
 
+pub const BLOB_FLAG_IS_LAST: u32 = 0x2;
+
 pub const BLOB_FLAG_IS_CODING: u32 = 0x1;
 
 impl Blob {
@@ -348,6 +350,15 @@ impl Blob {
     pub fn set_coding(&mut self) {
         let flags = self.flags();
         self.set_flags(flags | BLOB_FLAG_IS_CODING);
+    }
+
+    pub fn set_is_last_blob(&mut self) {
+        let flags = self.flags();
+        self.set_flags(flags | BLOB_FLAG_IS_LAST);
+    }
+
+    pub fn is_last_blob(&self) -> bool {
+        (self.flags() & BLOB_FLAG_IS_LAST) != 0
     }
 
     pub fn data_size(&self) -> u64 {

--- a/tests/multinode.rs
+++ b/tests/multinode.rs
@@ -1751,13 +1751,14 @@ fn test_fullnode_rotate(ticks_per_slot: u64, slots_per_epoch: u64) {
     let leader_pubkey = leader_keypair.pubkey().clone();
     let leader = Node::new_localhost_with_pubkey(leader_keypair.pubkey());
     let leader_info = leader.info.clone();
-    let (_mint, leader_ledger_path, _last_entry_height, _last_id, last_entry_id) =
+    let (_mint, leader_ledger_path, _tick_height, _last_entry_height, _last_id, last_entry_id) =
         create_tmp_sample_ledger(
             "fullnode_transact_while_rotating_fast",
             1_000_000_000_000_000_000,
             0,
             leader_pubkey,
             123,
+            ticks_per_slot,
         );
     info!("ledger is {}", leader_ledger_path);
 
@@ -1779,7 +1780,9 @@ fn test_fullnode_rotate(ticks_per_slot: u64, slots_per_epoch: u64) {
             fullnode_config.ledger_config(),
         )
         .unwrap();
-        blocktree.write_entries(1, 0, &entries).unwrap();
+        blocktree
+            .write_entries(1, 0, ticks_per_slot, 0, &entries)
+            .unwrap();
         tick_height_of_next_rotation += 1;
     }
 

--- a/tests/multinode.rs
+++ b/tests/multinode.rs
@@ -1657,14 +1657,14 @@ fn test_broadcast_last_tick() {
         for b in blobs {
             let b_r = b.read().unwrap();
             if b_r.index() == last_tick_entry_index as u64 {
-                assert!(b_r.is_last_blob());
+                assert!(b_r.is_last_in_slot());
                 debug!("last_tick_blob: {:?}", b_r);
                 let actual_last_tick = &reconstruct_entries_from_blobs(vec![&*b_r])
                     .expect("Expected to be able to reconstruct entries from blob")
                     .0[0];
                 assert_eq!(actual_last_tick, expected_last_tick);
             } else {
-                assert!(!b_r.is_last_blob());
+                assert!(!b_r.is_last_in_slot());
             }
         }
     }

--- a/tests/multinode.rs
+++ b/tests/multinode.rs
@@ -1661,6 +1661,7 @@ fn test_broadcast_last_tick() {
             }
         }
         debug!("last_tick_blob: {:?}", last_tick_blob);
+        assert!(last_tick_blob.read().unwrap().is_last_blob());
         let actual_last_tick =
             &reconstruct_entries_from_blobs(vec![&*last_tick_blob.read().unwrap()])
                 .expect("Expected to be able to reconstruct entries from blob")


### PR DESCRIPTION
#### Problem
The Blocktree currently has to count ticks in order to figure out when a slot ends, leading to needless deserialization and complexity

#### Summary of Changes
Add flag to a blob signaling that a blob is the last one for a slot.

Fixes #
