### PR TITLE
Write to ledger in BroadcastService

### DIFF
--- a/src/broadcast_service.rs
+++ b/src/broadcast_service.rs
@@ -90,7 +90,7 @@ impl Broadcast {
 
         inc_new_counter_info!("streamer-broadcast-sent", blobs.len());
 
-        blocktree.write_shared_blobs(blobs.clone())?;
+        blocktree.write_shared_blobs(&blobs)?;
 
         // Send out data
         ClusterInfo::broadcast(&self.id, last_tick, &broadcast_table, sock, &blobs)?;

--- a/src/fullnode.rs
+++ b/src/fullnode.rs
@@ -12,7 +12,6 @@ use crate::rpc::JsonRpcService;
 use crate::rpc_pubsub::PubSubService;
 use crate::service::Service;
 use crate::storage_stage::StorageState;
-use crate::streamer::BlobSender;
 use crate::tpu::{Tpu, TpuRotationReceiver, TpuRotationSender};
 use crate::tvu::{Sockets, Tvu};
 use crate::voting_keypair::VotingKeypair;
@@ -106,7 +105,7 @@ pub struct Fullnode {
     node_services: NodeServices,
     rotation_sender: TpuRotationSender,
     rotation_receiver: TpuRotationReceiver,
-    blob_sender: BlobSender,
+    blocktree: Arc<Blocktree>,
 }
 
 impl Fullnode {
@@ -258,7 +257,7 @@ impl Fullnode {
         // Setup channel for rotation indications
         let (rotation_sender, rotation_receiver) = channel();
 
-        let (tvu, blob_sender) = Tvu::new(
+        let tvu = Tvu::new(
             voting_keypair_option,
             &bank,
             blob_index,
@@ -293,7 +292,7 @@ impl Fullnode {
             &last_entry_id,
             id,
             &rotation_sender,
-            &blob_sender,
+            &blocktree,
             scheduled_leader == id,
         );
 
@@ -313,7 +312,7 @@ impl Fullnode {
             broadcast_socket: node.sockets.broadcast,
             rotation_sender,
             rotation_receiver,
-            blob_sender,
+            blocktree,
         }
     }
 
@@ -395,7 +394,7 @@ impl Fullnode {
                 &last_entry_id,
                 self.id,
                 &self.rotation_sender,
-                &self.blob_sender,
+                &self.blocktree,
             );
 
             transition

--- a/src/tpu.rs
+++ b/src/tpu.rs
@@ -3,6 +3,7 @@
 
 use crate::bank::Bank;
 use crate::banking_stage::BankingStage;
+use crate::blocktree::Blocktree;
 use crate::broadcast_service::BroadcastService;
 use crate::cluster_info::ClusterInfo;
 use crate::cluster_info_vote_listener::ClusterInfoVoteListener;
@@ -10,7 +11,6 @@ use crate::fetch_stage::FetchStage;
 use crate::poh_service::PohServiceConfig;
 use crate::service::Service;
 use crate::sigverify_stage::SigVerifyStage;
-use crate::streamer::BlobSender;
 use crate::tpu_forwarder::TpuForwarder;
 use solana_sdk::hash::Hash;
 use solana_sdk::pubkey::Pubkey;
@@ -84,7 +84,7 @@ impl Tpu {
         last_entry_id: &Hash,
         leader_id: Pubkey,
         to_validator_sender: &TpuRotationSender,
-        blob_sender: &BlobSender,
+        blocktree: &Arc<Blocktree>,
         is_leader: bool,
     ) -> Self {
         let mut tpu = Self {
@@ -105,7 +105,7 @@ impl Tpu {
                 last_entry_id,
                 leader_id,
                 to_validator_sender,
-                blob_sender,
+                blocktree,
             );
         } else {
             tpu.switch_to_forwarder(transactions_sockets, cluster_info);
@@ -150,7 +150,7 @@ impl Tpu {
         last_entry_id: &Hash,
         leader_id: Pubkey,
         to_validator_sender: &TpuRotationSender,
-        blob_sender: &BlobSender,
+        blocktree: &Arc<Blocktree>,
     ) {
         self.tpu_mode_close();
 
@@ -186,7 +186,7 @@ impl Tpu {
             entry_receiver,
             max_tick_height,
             self.exit.clone(),
-            blob_sender,
+            blocktree,
         );
 
         let svcs = LeaderServices::new(

--- a/src/tvu.rs
+++ b/src/tvu.rs
@@ -343,7 +343,7 @@ pub mod tests {
         let vote_account_keypair = Arc::new(Keypair::new());
         let voting_keypair = VotingKeypair::new_local(&vote_account_keypair);
         let (sender, _) = channel();
-        let (tvu, _) = Tvu::new(
+        let tvu = Tvu::new(
             Some(Arc::new(voting_keypair)),
             &bank,
             0,

--- a/src/tvu.rs
+++ b/src/tvu.rs
@@ -21,7 +21,6 @@ use crate::replay_stage::ReplayStage;
 use crate::retransmit_stage::RetransmitStage;
 use crate::service::Service;
 use crate::storage_stage::{StorageStage, StorageState};
-use crate::streamer::BlobSender;
 use crate::tpu::{TpuReturnType, TpuRotationReceiver, TpuRotationSender};
 use crate::voting_keypair::VotingKeypair;
 use solana_sdk::hash::Hash;
@@ -79,7 +78,7 @@ impl Tvu {
         entry_stream: Option<&String>,
         ledger_signal_sender: SyncSender<bool>,
         ledger_signal_receiver: Receiver<bool>,
-    ) -> (Self, BlobSender) {
+    ) -> Self {
         let exit = Arc::new(AtomicBool::new(false));
         let keypair: Arc<Keypair> = cluster_info
             .read()
@@ -156,18 +155,15 @@ impl Tvu {
             &cluster_info,
         );
 
-        (
-            Tvu {
-                fetch_stage,
-                retransmit_stage,
-                replay_stage,
-                entry_stream_stage,
-                storage_stage,
-                exit,
-                last_entry_id: l_last_entry_id,
-            },
-            blob_fetch_sender,
-        )
+        Tvu {
+            fetch_stage,
+            retransmit_stage,
+            replay_stage,
+            entry_stream_stage,
+            storage_stage,
+            exit,
+            last_entry_id: l_last_entry_id,
+        }
     }
 
     #[cfg(test)]
@@ -260,7 +256,7 @@ pub mod tests {
         let vote_account_keypair = Arc::new(Keypair::new());
         let voting_keypair = VotingKeypair::new_local(&vote_account_keypair);
         let (sender, _receiver) = channel();
-        let (tvu, _blob_sender) = Tvu::new(
+        let tvu = Tvu::new(
             Some(Arc::new(voting_keypair)),
             &bank,
             0,


### PR DESCRIPTION
#### Problem
The TPU in leader should not directly send blobs to TVU. Instead it should write it to Blocktree and let replay stage pick from it.

#### Summary of Changes
Added code to write to blocktree in Broadcast Service. Also disconnect the channel between TPU and TVU

Fixes #
