### PR TITLE
Change write_entries() and create_tmp_ledger() to take ticks_per_slot

### DIFF
--- a/ledger-tool/tests/basic.rs
+++ b/ledger-tool/tests/basic.rs
@@ -32,8 +32,15 @@ fn bad_arguments() {
 #[test]
 fn nominal() {
     let keypair = Arc::new(Keypair::new());
-    let (_mint_keypair, ledger_path, _last_entry_height, _last_id, _last_entry_id) =
-        create_tmp_sample_ledger("test_ledger_tool_nominal", 100, 9, keypair.pubkey(), 50);
+    let (_mint_keypair, ledger_path, _tick_height, _last_entry_height, _last_id, _last_entry_id) =
+        create_tmp_sample_ledger(
+            "test_ledger_tool_nominal",
+            100,
+            9,
+            keypair.pubkey(),
+            50,
+            std::u64::MAX,
+        );
 
     // Basic validation
     let output = run_ledger_tool(&["-l", &ledger_path, "verify"]);

--- a/src/blocktree.rs
+++ b/src/blocktree.rs
@@ -1346,7 +1346,7 @@ pub fn create_tmp_sample_ledger(
 
         let blocktree = Blocktree::open(&ledger_path).unwrap();
 
-        //create_new_ledger creates one beginning tick
+        // create_new_ledger creates one beginning tick
         tick_height += num_extra_ticks;
         blocktree
             .write_entries(

--- a/src/chacha.rs
+++ b/src/chacha.rs
@@ -148,8 +148,9 @@ mod tests {
         let out_path = Path::new("test_chacha_encrypt_file_output.txt.enc");
 
         let entries = make_tiny_deterministic_test_entries(32);
+        let ticks_per_slot = 16;
         blocktree
-            .write_entries(DEFAULT_SLOT_HEIGHT, 0, &entries)
+            .write_entries(DEFAULT_SLOT_HEIGHT, 0, ticks_per_slot, 0, &entries)
             .unwrap();
 
         let mut key = hex!(

--- a/src/chacha_cuda.rs
+++ b/src/chacha_cuda.rs
@@ -128,8 +128,10 @@ mod tests {
         let ledger_dir = "test_encrypt_file_many_keys_single";
         let ledger_path = get_tmp_ledger_path(ledger_dir);
         let blocktree = Arc::new(Blocktree::open(&ledger_path).unwrap());
+        let ticks_per_slot = 16;
+
         blocktree
-            .write_entries(DEFAULT_SLOT_HEIGHT, 0, &entries)
+            .write_entries(DEFAULT_SLOT_HEIGHT, 0, ticks_per_slot, 0, &entries)
             .unwrap();
 
         let out_path = Path::new("test_chacha_encrypt_file_many_keys_single_output.txt.enc");
@@ -162,8 +164,9 @@ mod tests {
         let ledger_dir = "test_encrypt_file_many_keys_multiple";
         let ledger_path = get_tmp_ledger_path(ledger_dir);
         let blocktree = Arc::new(Blocktree::open(&ledger_path).unwrap());
+        let ticks_per_slot = 16;
         blocktree
-            .write_entries(DEFAULT_SLOT_HEIGHT, 0, &entries)
+            .write_entries(DEFAULT_SLOT_HEIGHT, 0, ticks_per_slot, 0, &entries)
             .unwrap();
 
         let out_path = Path::new("test_chacha_encrypt_file_many_keys_multiple_output.txt.enc");

--- a/src/storage_stage.rs
+++ b/src/storage_stage.rs
@@ -491,20 +491,28 @@ mod tests {
         solana_logger::setup();
         let keypair = Arc::new(Keypair::new());
         let exit = Arc::new(AtomicBool::new(false));
+        let ticks_per_slot = std::u64::MAX;
 
-        let (_mint, ledger_path, genesis_entry_height, _last_id, _last_entry_id) =
+        let (_mint, ledger_path, tick_height, genesis_entry_height, _last_id, _last_entry_id) =
             create_tmp_sample_ledger(
                 "storage_stage_process_entries",
                 1000,
                 1,
                 Keypair::new().pubkey(),
                 1,
+                ticks_per_slot,
             );
 
         let entries = make_tiny_test_entries(64);
         let blocktree = Blocktree::open(&ledger_path).unwrap();
         blocktree
-            .write_entries(DEFAULT_SLOT_HEIGHT, genesis_entry_height, &entries)
+            .write_entries(
+                DEFAULT_SLOT_HEIGHT,
+                tick_height,
+                ticks_per_slot,
+                genesis_entry_height,
+                &entries,
+            )
             .unwrap();
 
         let cluster_info = test_cluster_info(keypair.pubkey());
@@ -560,20 +568,28 @@ mod tests {
         solana_logger::setup();
         let keypair = Arc::new(Keypair::new());
         let exit = Arc::new(AtomicBool::new(false));
+        let ticks_per_slot = std::u64::MAX;
 
-        let (_mint, ledger_path, genesis_entry_height, _last_id, _last_entry_id) =
+        let (_mint, ledger_path, tick_height, genesis_entry_height, _last_id, _last_entry_id) =
             create_tmp_sample_ledger(
                 "storage_stage_process_entries",
                 1000,
                 1,
                 Keypair::new().pubkey(),
                 1,
+                ticks_per_slot,
             );
 
         let entries = make_tiny_test_entries(128);
         let blocktree = Blocktree::open(&ledger_path).unwrap();
         blocktree
-            .write_entries(DEFAULT_SLOT_HEIGHT, genesis_entry_height, &entries)
+            .write_entries(
+                DEFAULT_SLOT_HEIGHT,
+                tick_height,
+                ticks_per_slot,
+                genesis_entry_height,
+                &entries,
+            )
             .unwrap();
 
         let cluster_info = test_cluster_info(keypair.pubkey());

--- a/src/thin_client.rs
+++ b/src/thin_client.rs
@@ -464,8 +464,16 @@ pub fn new_fullnode(ledger_name: &'static str) -> (Fullnode, NodeInfo, Keypair, 
     let node = Node::new_localhost_with_pubkey(node_keypair.pubkey());
     let node_info = node.info.clone();
 
-    let (mint_keypair, ledger_path, _last_entry_height, _last_id, _last_entry_id) =
-        create_tmp_sample_ledger(ledger_name, 10_000, 0, node_info.id, 42);
+    let fullnode_config = &FullnodeConfig::default();
+    let (mint_keypair, ledger_path, _tick_height, _last_entry_height, _last_id, _last_entry_id) =
+        create_tmp_sample_ledger(
+            ledger_name,
+            10_000,
+            0,
+            node_info.id,
+            42,
+            fullnode_config.leader_scheduler_config.ticks_per_slot,
+        );
 
     let vote_account_keypair = Arc::new(Keypair::new());
     let voting_keypair = VotingKeypair::new_local(&vote_account_keypair);

--- a/tests/replicator.rs
+++ b/tests/replicator.rs
@@ -40,8 +40,22 @@ fn test_replicator_startup_basic() {
     let leader_info = leader_node.info.clone();
 
     let leader_ledger_path = "replicator_test_leader_ledger";
-    let (mint_keypair, leader_ledger_path, _last_entry_height, _last_id, _last_entry_id) =
-        create_tmp_sample_ledger(leader_ledger_path, 1_000_000_000, 0, leader_info.id, 42);
+    let mut fullnode_config = FullnodeConfig::default();
+    let (
+        mint_keypair,
+        leader_ledger_path,
+        _tick_height,
+        _last_entry_height,
+        _last_id,
+        _last_entry_id,
+    ) = create_tmp_sample_ledger(
+        leader_ledger_path,
+        1_000_000_000,
+        0,
+        leader_info.id,
+        42,
+        fullnode_config.leader_scheduler_config.ticks_per_slot,
+    );
 
     let validator_ledger_path =
         tmp_copy_ledger(&leader_ledger_path, "replicator_test_validator_ledger");
@@ -49,7 +63,6 @@ fn test_replicator_startup_basic() {
     {
         let voting_keypair = VotingKeypair::new_local(&leader_keypair);
 
-        let mut fullnode_config = FullnodeConfig::default();
         fullnode_config.storage_rotate_count = STORAGE_ROTATE_TEST_COUNT;
         let leader = Fullnode::new(
             leader_node,
@@ -277,8 +290,22 @@ fn test_replicator_startup_ledger_hang() {
     let leader_info = leader_node.info.clone();
 
     let leader_ledger_path = "replicator_test_leader_ledger";
-    let (_mint_keypair, leader_ledger_path, _last_entry_height, _last_id, _last_entry_id) =
-        create_tmp_sample_ledger(leader_ledger_path, 100, 0, leader_info.id, 42);
+    let fullnode_config = FullnodeConfig::default();
+    let (
+        _mint_keypair,
+        leader_ledger_path,
+        _tick_height,
+        _last_entry_height,
+        _last_id,
+        _last_entry_id,
+    ) = create_tmp_sample_ledger(
+        leader_ledger_path,
+        100,
+        0,
+        leader_info.id,
+        42,
+        fullnode_config.leader_scheduler_config.ticks_per_slot,
+    );
 
     let validator_ledger_path =
         tmp_copy_ledger(&leader_ledger_path, "replicator_test_validator_ledger");
@@ -292,7 +319,7 @@ fn test_replicator_startup_ledger_hang() {
             &leader_ledger_path,
             voting_keypair,
             None,
-            &FullnodeConfig::default(),
+            &fullnode_config,
         );
 
         let validator_keypair = Arc::new(Keypair::new());


### PR DESCRIPTION
#### Problem
Many tests were calling write_entries() and create_tmp_sample_ledger(), which dumped all the entries 
into the first slot, which is incompatible with the new slot-based structure of the Blocktree.

#### Summary of Changes
Change write_entries() and create_tmp_ledger() to account for ticks_per_slot

Fixes #
