### PR TITLE
Pass a BlocktreeConfig into all ledger helper functions

### DIFF
--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -75,6 +75,10 @@ fn main() -> Result<(), Box<dyn error::Error>> {
         bootstrap_leader_vote_account_id: bootstrap_leader_vote_account_keypair.pubkey(),
     };
 
-    create_new_ledger(ledger_path, &genesis_block)?;
+    create_new_ledger(
+        ledger_path,
+        &genesis_block,
+        &solana::blocktree::BlocktreeConfig::default(),
+    )?;
     Ok(())
 }

--- a/ledger-tool/tests/basic.rs
+++ b/ledger-tool/tests/basic.rs
@@ -1,4 +1,4 @@
-use solana::blocktree::create_tmp_sample_ledger;
+use solana::blocktree::{create_tmp_sample_ledger, BlocktreeConfig};
 use solana_sdk::signature::{Keypair, KeypairUtil};
 
 use assert_cmd::prelude::*;
@@ -39,7 +39,7 @@ fn nominal() {
             9,
             keypair.pubkey(),
             50,
-            std::u64::MAX,
+            &BlocktreeConfig::default(),
         );
 
     // Basic validation

--- a/src/blocktree.rs
+++ b/src/blocktree.rs
@@ -413,7 +413,7 @@ impl Blocktree {
         Ok((blocktree, signal_sender, signal_receiver))
     }
 
-    pub fn open_config(ledger_path: &str, config: BlocktreeConfig) -> Result<Self> {
+    pub fn open_config(ledger_path: &str, config: &BlocktreeConfig) -> Result<Self> {
         let mut blocktree = Self::open(ledger_path)?;
         blocktree.ticks_per_slot = config.ticks_per_slot;
         Ok(blocktree)
@@ -421,7 +421,7 @@ impl Blocktree {
 
     pub fn open_with_config_signal(
         ledger_path: &str,
-        config: BlocktreeConfig,
+        config: &BlocktreeConfig,
     ) -> Result<(Self, SyncSender<bool>, Receiver<bool>)> {
         let mut blocktree = Self::open(ledger_path)?;
         let (signal_sender, signal_receiver) = sync_channel(1);
@@ -1872,7 +1872,7 @@ mod tests {
         let ledger_path = get_tmp_ledger_path("test_new_blobs_signal");
         let ticks_per_slot = 10;
         let config = BlocktreeConfig::new(ticks_per_slot);
-        let (ledger, _, recvr) = Blocktree::open_with_config_signal(&ledger_path, config).unwrap();
+        let (ledger, _, recvr) = Blocktree::open_with_config_signal(&ledger_path, &config).unwrap();
         let ledger = Arc::new(ledger);
 
         // Create ticks for slot 0
@@ -1979,7 +1979,7 @@ mod tests {
         {
             let ticks_per_slot = 2;
             let config = BlocktreeConfig::new(ticks_per_slot);
-            let blocktree = Blocktree::open_config(&blocktree_path, config).unwrap();
+            let blocktree = Blocktree::open_config(&blocktree_path, &config).unwrap();
 
             let entries = create_ticks(6, Hash::default());
             let mut blobs = entries.to_blobs();

--- a/src/blocktree.rs
+++ b/src/blocktree.rs
@@ -413,12 +413,14 @@ impl Blocktree {
         Ok((blocktree, signal_sender, signal_receiver))
     }
 
+    #[allow(clippy::trivially_copy_pass_by_ref)]
     pub fn open_config(ledger_path: &str, config: &BlocktreeConfig) -> Result<Self> {
         let mut blocktree = Self::open(ledger_path)?;
         blocktree.ticks_per_slot = config.ticks_per_slot;
         Ok(blocktree)
     }
 
+    #[allow(clippy::trivially_copy_pass_by_ref)]
     pub fn open_with_config_signal(
         ledger_path: &str,
         config: &BlocktreeConfig,
@@ -1275,6 +1277,7 @@ impl Iterator for EntryIterator {
 // Returns a tuple (entry_height, tick_height, last_id), corresponding to the
 // total number of entries, the number of ticks, and the last id generated in the
 // new ledger
+#[allow(clippy::trivially_copy_pass_by_ref)]
 pub fn create_new_ledger(
     ledger_path: &str,
     genesis_block: &GenesisBlock,
@@ -1327,6 +1330,7 @@ pub fn get_tmp_ledger_path(name: &str) -> String {
     path
 }
 
+#[allow(clippy::trivially_copy_pass_by_ref)]
 pub fn create_tmp_sample_ledger(
     name: &str,
     num_tokens: u64,
@@ -1372,6 +1376,7 @@ pub fn create_tmp_sample_ledger(
     )
 }
 
+#[allow(clippy::trivially_copy_pass_by_ref)]
 pub fn tmp_copy_ledger(from: &str, name: &str, config: &BlocktreeConfig) -> String {
     let path = get_tmp_ledger_path(name);
 

--- a/src/chacha.rs
+++ b/src/chacha.rs
@@ -95,7 +95,7 @@ pub fn chacha_cbc_encrypt_ledger(
 #[cfg(test)]
 mod tests {
     use crate::blocktree::get_tmp_ledger_path;
-    use crate::blocktree::{Blocktree, DEFAULT_SLOT_HEIGHT};
+    use crate::blocktree::{Blocktree, BlocktreeConfig, DEFAULT_SLOT_HEIGHT};
     use crate::chacha::chacha_cbc_encrypt_ledger;
     use crate::entry::Entry;
     use ring::signature::Ed25519KeyPair;
@@ -144,13 +144,15 @@ mod tests {
         solana_logger::setup();
         let ledger_dir = "chacha_test_encrypt_file";
         let ledger_path = get_tmp_ledger_path(ledger_dir);
-        let blocktree = Arc::new(Blocktree::open(&ledger_path).unwrap());
+        let ticks_per_slot = 16;
+        let blocktree = Arc::new(
+            Blocktree::open_config(&ledger_path, &BlocktreeConfig::new(ticks_per_slot)).unwrap(),
+        );
         let out_path = Path::new("test_chacha_encrypt_file_output.txt.enc");
 
         let entries = make_tiny_deterministic_test_entries(32);
-        let ticks_per_slot = 16;
         blocktree
-            .write_entries(DEFAULT_SLOT_HEIGHT, 0, ticks_per_slot, 0, &entries)
+            .write_entries(DEFAULT_SLOT_HEIGHT, 0, 0, &entries)
             .unwrap();
 
         let mut key = hex!(

--- a/src/chacha_cuda.rs
+++ b/src/chacha_cuda.rs
@@ -110,7 +110,7 @@ pub fn chacha_cbc_encrypt_file_many_keys(
 #[cfg(test)]
 mod tests {
     use crate::blocktree::get_tmp_ledger_path;
-    use crate::blocktree::{Blocktree, DEFAULT_SLOT_HEIGHT};
+    use crate::blocktree::{Blocktree, BlocktreeConfig, DEFAULT_SLOT_HEIGHT};
     use crate::chacha::chacha_cbc_encrypt_ledger;
     use crate::chacha_cuda::chacha_cbc_encrypt_file_many_keys;
     use crate::entry::make_tiny_test_entries;
@@ -127,11 +127,13 @@ mod tests {
         let entries = make_tiny_test_entries(32);
         let ledger_dir = "test_encrypt_file_many_keys_single";
         let ledger_path = get_tmp_ledger_path(ledger_dir);
-        let blocktree = Arc::new(Blocktree::open(&ledger_path).unwrap());
         let ticks_per_slot = 16;
+        let blocktree = Arc::new(
+            Blocktree::open_config(&ledger_path, &BlocktreeConfig::new(ticks_per_slot)).unwrap(),
+        );
 
         blocktree
-            .write_entries(DEFAULT_SLOT_HEIGHT, 0, ticks_per_slot, 0, &entries)
+            .write_entries(DEFAULT_SLOT_HEIGHT, 0, 0, &entries)
             .unwrap();
 
         let out_path = Path::new("test_chacha_encrypt_file_many_keys_single_output.txt.enc");
@@ -163,10 +165,12 @@ mod tests {
         let entries = make_tiny_test_entries(32);
         let ledger_dir = "test_encrypt_file_many_keys_multiple";
         let ledger_path = get_tmp_ledger_path(ledger_dir);
-        let blocktree = Arc::new(Blocktree::open(&ledger_path).unwrap());
         let ticks_per_slot = 16;
+        let blocktree = Arc::new(
+            Blocktree::open_config(&ledger_path, &BlocktreeConfig::new(ticks_per_slot)).unwrap(),
+        );
         blocktree
-            .write_entries(DEFAULT_SLOT_HEIGHT, 0, ticks_per_slot, 0, &entries)
+            .write_entries(DEFAULT_SLOT_HEIGHT, 0, 0, &entries)
             .unwrap();
 
         let out_path = Path::new("test_chacha_encrypt_file_many_keys_multiple_output.txt.enc");

--- a/src/fullnode.rs
+++ b/src/fullnode.rs
@@ -1044,7 +1044,6 @@ mod tests {
             .write_entries(
                 DEFAULT_SLOT_HEIGHT,
                 tick_height,
-                ticks_per_slot,
                 entry_height,
                 active_set_entries,
             )

--- a/src/fullnode.rs
+++ b/src/fullnode.rs
@@ -467,6 +467,7 @@ impl Fullnode {
     }
 }
 
+#[allow(clippy::trivially_copy_pass_by_ref)]
 pub fn new_bank_from_ledger(
     ledger_path: &str,
     ledger_config: &BlocktreeConfig,

--- a/src/fullnode.rs
+++ b/src/fullnode.rs
@@ -131,7 +131,7 @@ impl Fullnode {
             ledger_signal_receiver,
         ) = new_bank_from_ledger(
             ledger_path,
-            config.ledger_config(),
+            &config.ledger_config(),
             &config.leader_scheduler_config,
         );
 
@@ -469,7 +469,7 @@ impl Fullnode {
 
 pub fn new_bank_from_ledger(
     ledger_path: &str,
-    ledger_config: BlocktreeConfig,
+    ledger_config: &BlocktreeConfig,
     leader_scheduler_config: &LeaderSchedulerConfig,
 ) -> (Bank, u64, Hash, Blocktree, SyncSender<bool>, Receiver<bool>) {
     let (blocktree, ledger_signal_sender, ledger_signal_receiver) =
@@ -832,7 +832,7 @@ mod tests {
         validator_exit();
         let (bank, entry_height, _, _, _, _) = new_bank_from_ledger(
             &validator_ledger_path,
-            BlocktreeConfig::default(),
+            &BlocktreeConfig::default(),
             &LeaderSchedulerConfig::default(),
         );
 

--- a/src/repair_service.rs
+++ b/src/repair_service.rs
@@ -219,7 +219,7 @@ mod test {
         {
             let num_ticks_per_slot = 1;
             let blocktree_config = BlocktreeConfig::new(num_ticks_per_slot);
-            let blocktree = Blocktree::open_config(&blocktree_path, blocktree_config).unwrap();
+            let blocktree = Blocktree::open_config(&blocktree_path, &blocktree_config).unwrap();
 
             let mut blobs = create_ticks(1, Hash::default()).to_blobs();
             blobs[0].set_index(0);
@@ -268,7 +268,7 @@ mod test {
         {
             let num_ticks_per_slot = 10;
             let blocktree_config = BlocktreeConfig::new(num_ticks_per_slot);
-            let blocktree = Blocktree::open_config(&blocktree_path, blocktree_config).unwrap();
+            let blocktree = Blocktree::open_config(&blocktree_path, &blocktree_config).unwrap();
 
             let mut blobs = make_tiny_test_entries(1).to_blobs();
             blobs[0].set_index(1);
@@ -294,7 +294,7 @@ mod test {
         {
             let num_ticks_per_slot = 10;
             let blocktree_config = BlocktreeConfig::new(num_ticks_per_slot);
-            let blocktree = Blocktree::open_config(&blocktree_path, blocktree_config).unwrap();
+            let blocktree = Blocktree::open_config(&blocktree_path, &blocktree_config).unwrap();
 
             let num_entries_per_slot = 10;
             let num_slots = 2;

--- a/src/replay_stage.rs
+++ b/src/replay_stage.rs
@@ -433,7 +433,6 @@ mod test {
                 .write_entries(
                     DEFAULT_SLOT_HEIGHT,
                     tick_height,
-                    ticks_per_slot,
                     entry_height,
                     active_set_entries,
                 )
@@ -480,7 +479,6 @@ mod test {
                 .write_entries(
                     DEFAULT_SLOT_HEIGHT,
                     tick_height,
-                    ticks_per_slot,
                     meta.consumed,
                     &entries_to_send,
                 )
@@ -525,7 +523,6 @@ mod test {
         // Create keypair for the leader
         let leader_id = Keypair::new().pubkey();
 
-        let ticks_per_slot = std::u64::MAX;
         let (
             _mint_keypair,
             my_ledger_path,
@@ -584,7 +581,6 @@ mod test {
                 .write_entries(
                     DEFAULT_SLOT_HEIGHT,
                     tick_height,
-                    ticks_per_slot,
                     entry_height,
                     next_tick.clone(),
                 )
@@ -658,7 +654,6 @@ mod test {
                 .write_entries(
                     DEFAULT_SLOT_HEIGHT,
                     tick_height,
-                    ticks_per_slot,
                     genesis_entry_height,
                     &active_set_entries,
                 )
@@ -717,7 +712,6 @@ mod test {
                     .write_entries(
                         DEFAULT_SLOT_HEIGHT,
                         tick_height + i as u64,
-                        ticks_per_slot,
                         meta.consumed + i as u64,
                         vec![entry.clone()],
                     )

--- a/src/replay_stage.rs
+++ b/src/replay_stage.rs
@@ -445,7 +445,7 @@ mod test {
             // Set up the bank
             let blocktree_config = BlocktreeConfig::new(ticks_per_slot);
             let (bank, _entry_height, last_entry_id, blocktree, l_sender, l_receiver) =
-                new_bank_from_ledger(&my_ledger_path, blocktree_config, &leader_scheduler_config);
+                new_bank_from_ledger(&my_ledger_path, &blocktree_config, &leader_scheduler_config);
 
             // Set up the replay stage
             let (rotation_sender, rotation_receiver) = channel();
@@ -554,7 +554,7 @@ mod test {
             let (bank, entry_height, last_entry_id, blocktree, l_sender, l_receiver) =
                 new_bank_from_ledger(
                     &my_ledger_path,
-                    BlocktreeConfig::default(),
+                    &BlocktreeConfig::default(),
                     &LeaderSchedulerConfig::default(),
                 );
 
@@ -675,7 +675,7 @@ mod test {
         {
             let blocktree_config = BlocktreeConfig::new(ticks_per_slot);
             let (bank, _entry_height, last_entry_id, blocktree, l_sender, l_receiver) =
-                new_bank_from_ledger(&my_ledger_path, blocktree_config, &leader_scheduler_config);
+                new_bank_from_ledger(&my_ledger_path, &blocktree_config, &leader_scheduler_config);
 
             let meta = blocktree
                 .meta(0)

--- a/src/storage_stage.rs
+++ b/src/storage_stage.rs
@@ -432,11 +432,11 @@ impl Service for StorageStage {
 
 #[cfg(test)]
 mod tests {
-    use crate::blocktree::create_tmp_sample_ledger;
-    use crate::blocktree::{Blocktree, DEFAULT_SLOT_HEIGHT};
-    use crate::entry::{make_tiny_test_entries, Entry};
-
+    use crate::blocktree::{
+        create_tmp_sample_ledger, Blocktree, BlocktreeConfig, DEFAULT_SLOT_HEIGHT,
+    };
     use crate::cluster_info::{ClusterInfo, NodeInfo};
+    use crate::entry::{make_tiny_test_entries, Entry};
     use crate::service::Service;
     use crate::storage_stage::StorageState;
     use crate::storage_stage::NUM_IDENTITIES;
@@ -493,6 +493,7 @@ mod tests {
         let exit = Arc::new(AtomicBool::new(false));
         let ticks_per_slot = std::u64::MAX;
 
+        let blocktree_config = BlocktreeConfig::default();
         let (_mint, ledger_path, tick_height, genesis_entry_height, _last_id, _last_entry_id) =
             create_tmp_sample_ledger(
                 "storage_stage_process_entries",
@@ -500,11 +501,11 @@ mod tests {
                 1,
                 Keypair::new().pubkey(),
                 1,
-                ticks_per_slot,
+                &blocktree_config,
             );
 
         let entries = make_tiny_test_entries(64);
-        let blocktree = Blocktree::open(&ledger_path).unwrap();
+        let blocktree = Blocktree::open_config(&ledger_path, &blocktree_config).unwrap();
         blocktree
             .write_entries(
                 DEFAULT_SLOT_HEIGHT,
@@ -570,6 +571,7 @@ mod tests {
         let exit = Arc::new(AtomicBool::new(false));
         let ticks_per_slot = std::u64::MAX;
 
+        let blocktree_config = BlocktreeConfig::default();
         let (_mint, ledger_path, tick_height, genesis_entry_height, _last_id, _last_entry_id) =
             create_tmp_sample_ledger(
                 "storage_stage_process_entries",
@@ -577,11 +579,11 @@ mod tests {
                 1,
                 Keypair::new().pubkey(),
                 1,
-                ticks_per_slot,
+                &blocktree_config,
             );
 
         let entries = make_tiny_test_entries(128);
-        let blocktree = Blocktree::open(&ledger_path).unwrap();
+        let blocktree = Blocktree::open_config(&ledger_path, &blocktree_config).unwrap();
         blocktree
             .write_entries(
                 DEFAULT_SLOT_HEIGHT,

--- a/src/storage_stage.rs
+++ b/src/storage_stage.rs
@@ -491,7 +491,6 @@ mod tests {
         solana_logger::setup();
         let keypair = Arc::new(Keypair::new());
         let exit = Arc::new(AtomicBool::new(false));
-        let ticks_per_slot = std::u64::MAX;
 
         let blocktree_config = BlocktreeConfig::default();
         let (_mint, ledger_path, tick_height, genesis_entry_height, _last_id, _last_entry_id) =
@@ -510,7 +509,6 @@ mod tests {
             .write_entries(
                 DEFAULT_SLOT_HEIGHT,
                 tick_height,
-                ticks_per_slot,
                 genesis_entry_height,
                 &entries,
             )
@@ -569,7 +567,6 @@ mod tests {
         solana_logger::setup();
         let keypair = Arc::new(Keypair::new());
         let exit = Arc::new(AtomicBool::new(false));
-        let ticks_per_slot = std::u64::MAX;
 
         let blocktree_config = BlocktreeConfig::default();
         let (_mint, ledger_path, tick_height, genesis_entry_height, _last_id, _last_entry_id) =
@@ -588,7 +585,6 @@ mod tests {
             .write_entries(
                 DEFAULT_SLOT_HEIGHT,
                 tick_height,
-                ticks_per_slot,
                 genesis_entry_height,
                 &entries,
             )

--- a/src/thin_client.rs
+++ b/src/thin_client.rs
@@ -487,7 +487,7 @@ pub fn new_fullnode(ledger_name: &'static str) -> (Fullnode, NodeInfo, Keypair, 
             0,
             node_info.id,
             42,
-            fullnode_config.leader_scheduler_config.ticks_per_slot,
+            &fullnode_config.ledger_config(),
         );
 
     let vote_account_keypair = Arc::new(Keypair::new());

--- a/tests/multinode.rs
+++ b/tests/multinode.rs
@@ -91,7 +91,6 @@ fn test_multi_node_ledger_window() -> result::Result<()> {
             .write_entries(
                 DEFAULT_SLOT_HEIGHT,
                 tick_height,
-                blocktree_config.ticks_per_slot,
                 last_entry_height,
                 &entries,
             )
@@ -969,7 +968,6 @@ fn test_leader_to_validator_transition() {
             .write_entries(
                 DEFAULT_SLOT_HEIGHT,
                 tick_height,
-                ticks_per_slot,
                 genesis_entry_height,
                 &active_set_entries,
             )
@@ -1082,7 +1080,6 @@ fn test_leader_validator_basic() {
             .write_entries(
                 DEFAULT_SLOT_HEIGHT,
                 tick_height,
-                ticks_per_slot,
                 genesis_entry_height,
                 &active_set_entries,
             )
@@ -1252,7 +1249,6 @@ fn test_dropped_handoff_recovery() {
             .write_entries(
                 DEFAULT_SLOT_HEIGHT,
                 tick_height,
-                ticks_per_slot,
                 genesis_entry_height,
                 &active_set_entries,
             )
@@ -1440,7 +1436,6 @@ fn test_full_leader_validator_network() {
                 .write_entries(
                     DEFAULT_SLOT_HEIGHT,
                     tick_height,
-                    ticks_per_slot,
                     entry_height,
                     &active_set_entries,
                 )
@@ -1823,9 +1818,7 @@ fn test_fullnode_rotate(ticks_per_slot: u64, slots_per_epoch: u64) {
         let entries = solana::entry::create_ticks(1, last_entry_id);
 
         let blocktree = Blocktree::open_config(&leader_ledger_path, &blocktree_config).unwrap();
-        blocktree
-            .write_entries(1, 0, blocktree_config.ticks_per_slot, 0, &entries)
-            .unwrap();
+        blocktree.write_entries(1, 0, 0, &entries).unwrap();
         tick_height_of_next_rotation += 1;
     }
 

--- a/tests/multinode.rs
+++ b/tests/multinode.rs
@@ -985,7 +985,7 @@ fn test_leader_to_validator_transition() {
     info!("Check the ledger to make sure it's the right height...");
     let bank = new_bank_from_ledger(
         &leader_ledger_path,
-        BlocktreeConfig::default(),
+        &BlocktreeConfig::default(),
         &LeaderSchedulerConfig::default(),
     )
     .0;
@@ -1778,7 +1778,7 @@ fn test_fullnode_rotate(ticks_per_slot: u64, slots_per_epoch: u64) {
 
         let blocktree = solana::blocktree::Blocktree::open_config(
             &leader_ledger_path,
-            fullnode_config.ledger_config(),
+            &fullnode_config.ledger_config(),
         )
         .unwrap();
         blocktree

--- a/tests/replicator.rs
+++ b/tests/replicator.rs
@@ -6,9 +6,8 @@ extern crate log;
 extern crate serde_json;
 
 use bincode::deserialize;
-use solana::blocktree::Blocktree;
 use solana::blocktree::{
-    create_tmp_sample_ledger, get_tmp_ledger_path, tmp_copy_ledger, DEFAULT_SLOT_HEIGHT,
+    create_tmp_sample_ledger, get_tmp_ledger_path, tmp_copy_ledger, Blocktree, DEFAULT_SLOT_HEIGHT,
 };
 use solana::client::mk_client;
 use solana::cluster_info::{ClusterInfo, Node, NodeInfo};
@@ -41,6 +40,8 @@ fn test_replicator_startup_basic() {
 
     let leader_ledger_path = "replicator_test_leader_ledger";
     let mut fullnode_config = FullnodeConfig::default();
+    let blocktree_config = fullnode_config.ledger_config();
+
     let (
         mint_keypair,
         leader_ledger_path,
@@ -54,11 +55,14 @@ fn test_replicator_startup_basic() {
         0,
         leader_info.id,
         42,
-        fullnode_config.leader_scheduler_config.ticks_per_slot,
+        &blocktree_config,
     );
 
-    let validator_ledger_path =
-        tmp_copy_ledger(&leader_ledger_path, "replicator_test_validator_ledger");
+    let validator_ledger_path = tmp_copy_ledger(
+        &leader_ledger_path,
+        "replicator_test_validator_ledger",
+        &blocktree_config,
+    );
 
     {
         let voting_keypair = VotingKeypair::new_local(&leader_keypair);
@@ -291,6 +295,7 @@ fn test_replicator_startup_ledger_hang() {
 
     let leader_ledger_path = "replicator_test_leader_ledger";
     let fullnode_config = FullnodeConfig::default();
+    let blocktree_config = fullnode_config.ledger_config();
     let (
         _mint_keypair,
         leader_ledger_path,
@@ -304,11 +309,14 @@ fn test_replicator_startup_ledger_hang() {
         0,
         leader_info.id,
         42,
-        fullnode_config.leader_scheduler_config.ticks_per_slot,
+        &blocktree_config,
     );
 
-    let validator_ledger_path =
-        tmp_copy_ledger(&leader_ledger_path, "replicator_test_validator_ledger");
+    let validator_ledger_path = tmp_copy_ledger(
+        &leader_ledger_path,
+        "replicator_test_validator_ledger",
+        &blocktree_config,
+    );
 
     {
         let voting_keypair = VotingKeypair::new_local(&leader_keypair);


### PR DESCRIPTION
Building a blocktree using the default config then manipulating ticks_per_slot later breaks in non-obvious ways.

@carllin fyi