### PR TITLE
Make Genesis block handle extra tokens for the leader

### DIFF
--- a/src/banking_stage.rs
+++ b/src/banking_stage.rs
@@ -278,7 +278,7 @@ mod tests {
     use crate::bank::Bank;
     use crate::banking_stage::BankingStageReturnType;
     use crate::entry::EntrySlice;
-    use crate::genesis_block::{GenesisBlock, BOOTSTRAP_LEADER_TOKENS};
+    use crate::genesis_block::GenesisBlock;
     use crate::packet::to_packets;
     use solana_sdk::signature::{Keypair, KeypairUtil};
     use solana_sdk::system_transaction::SystemTransaction;
@@ -286,7 +286,7 @@ mod tests {
 
     #[test]
     fn test_banking_stage_shutdown1() {
-        let (genesis_block, _mint_keypair) = GenesisBlock::new(2 + BOOTSTRAP_LEADER_TOKENS);
+        let (genesis_block, _mint_keypair) = GenesisBlock::new(2);
         let bank = Arc::new(Bank::new(&genesis_block));
         let (verified_sender, verified_receiver) = channel();
         let (to_validator_sender, _) = channel();
@@ -308,7 +308,7 @@ mod tests {
 
     #[test]
     fn test_banking_stage_shutdown2() {
-        let (genesis_block, _mint_keypair) = GenesisBlock::new(2 + BOOTSTRAP_LEADER_TOKENS);
+        let (genesis_block, _mint_keypair) = GenesisBlock::new(2);
         let bank = Arc::new(Bank::new(&genesis_block));
         let (_verified_sender, verified_receiver) = channel();
         let (to_validator_sender, _) = channel();
@@ -330,7 +330,7 @@ mod tests {
 
     #[test]
     fn test_banking_stage_tick() {
-        let (genesis_block, _mint_keypair) = GenesisBlock::new(2 + BOOTSTRAP_LEADER_TOKENS);
+        let (genesis_block, _mint_keypair) = GenesisBlock::new(2);
         let bank = Arc::new(Bank::new(&genesis_block));
         let start_hash = bank.last_id();
         let (verified_sender, verified_receiver) = channel();
@@ -359,7 +359,7 @@ mod tests {
 
     #[test]
     fn test_banking_stage_entries_only() {
-        let (genesis_block, mint_keypair) = GenesisBlock::new(2 + BOOTSTRAP_LEADER_TOKENS);
+        let (genesis_block, mint_keypair) = GenesisBlock::new(2);
         let bank = Arc::new(Bank::new(&genesis_block));
         let start_hash = bank.last_id();
         let (verified_sender, verified_receiver) = channel();
@@ -418,7 +418,7 @@ mod tests {
         // In this attack we'll demonstrate that a verifier can interpret the ledger
         // differently if either the server doesn't signal the ledger to add an
         // Entry OR if the verifier tries to parallelize across multiple Entries.
-        let (genesis_block, mint_keypair) = GenesisBlock::new(2 + BOOTSTRAP_LEADER_TOKENS);
+        let (genesis_block, mint_keypair) = GenesisBlock::new(2);
         let bank = Arc::new(Bank::new(&genesis_block));
         let (verified_sender, verified_receiver) = channel();
         let (to_validator_sender, _) = channel();
@@ -486,7 +486,7 @@ mod tests {
     // with reason BankingStageReturnType::LeaderRotation
     #[test]
     fn test_max_tick_height_shutdown() {
-        let (genesis_block, _mint_keypair) = GenesisBlock::new(2 + BOOTSTRAP_LEADER_TOKENS);
+        let (genesis_block, _mint_keypair) = GenesisBlock::new(2);
         let bank = Arc::new(Bank::new(&genesis_block));
         let (_verified_sender_, verified_receiver) = channel();
         let (to_validator_sender, _to_validator_receiver) = channel();

--- a/src/genesis_block.rs
+++ b/src/genesis_block.rs
@@ -24,7 +24,9 @@ pub struct GenesisBlock {
 impl GenesisBlock {
     #[allow(clippy::new_ret_no_self)]
     pub fn new(tokens: u64) -> (Self, Keypair) {
-        assert!(tokens >= 2);
+        let tokens = tokens
+            .checked_add(BOOTSTRAP_LEADER_TOKENS)
+            .unwrap_or(tokens);
         let mint_keypair = Keypair::new();
         let bootstrap_leader_keypair = Keypair::new();
         let bootstrap_leader_vote_account_keypair = Keypair::new();
@@ -84,7 +86,7 @@ mod tests {
     #[test]
     fn test_genesis_block_new() {
         let (genesis_block, mint) = GenesisBlock::new(10_000);
-        assert_eq!(genesis_block.tokens, 10_000);
+        assert_eq!(genesis_block.tokens, 10_000 + BOOTSTRAP_LEADER_TOKENS);
         assert_eq!(genesis_block.mint_id, mint.pubkey());
         assert!(genesis_block.bootstrap_leader_id != Pubkey::default());
         assert!(genesis_block.bootstrap_leader_vote_account_id != Pubkey::default());

--- a/src/leader_scheduler.rs
+++ b/src/leader_scheduler.rs
@@ -758,9 +758,8 @@ pub mod tests {
     fn test_rank_active_set() {
         let num_validators: usize = 101;
         // Give genesis_block sum(1..num_validators) tokens
-        let (genesis_block, mint_keypair) = GenesisBlock::new(
-            BOOTSTRAP_LEADER_TOKENS + (((num_validators + 1) / 2) * (num_validators + 1)) as u64,
-        );
+        let (genesis_block, mint_keypair) =
+            GenesisBlock::new((((num_validators + 1) / 2) * (num_validators + 1)) as u64);
         let bank = Bank::new(&genesis_block);
         let mut validators = vec![];
         let last_id = genesis_block.last_id();
@@ -818,8 +817,7 @@ pub mod tests {
         }
 
         // Break ties between validators with the same balances using public key
-        let (genesis_block, mint_keypair) =
-            GenesisBlock::new(BOOTSTRAP_LEADER_TOKENS + (num_validators + 1) as u64);
+        let (genesis_block, mint_keypair) = GenesisBlock::new((num_validators + 1) as u64);
         let bank = Bank::new(&genesis_block);
         let mut tied_validators_pk = vec![];
         let last_id = genesis_block.last_id();
@@ -939,9 +937,8 @@ pub mod tests {
 
         // Create the bank and validators
         let (genesis_block, mint_keypair) = GenesisBlock::new(
-            BOOTSTRAP_LEADER_TOKENS
-                + ((((num_validators + 1) / 2) * (num_validators + 1))
-                    + (num_vote_account_tokens * num_validators)) as u64,
+            ((((num_validators + 1) / 2) * (num_validators + 1))
+                + (num_vote_account_tokens * num_validators)) as u64,
         );
         let bank = Bank::new_with_leader_scheduler_config(&genesis_block, &leader_scheduler_config);
         let mut validators = vec![];

--- a/src/retransmit_stage.rs
+++ b/src/retransmit_stage.rs
@@ -245,7 +245,7 @@ mod tests {
         let required_balance = num_nodes * (num_nodes + 1) / 2;
 
         // create a genesis block
-        let (genesis_block, mint_keypair) = GenesisBlock::new(required_balance + 2);
+        let (genesis_block, mint_keypair) = GenesisBlock::new(required_balance);
 
         // describe the leader
         let leader_info = ContactInfo::new_localhost(Keypair::new().pubkey(), 0);

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -496,8 +496,7 @@ mod tests {
 
     #[test]
     fn test_rpc_new() {
-        let (genesis_block, alice) =
-            GenesisBlock::new(10_000 + crate::genesis_block::BOOTSTRAP_LEADER_TOKENS);
+        let (genesis_block, alice) = GenesisBlock::new(10_000);
         let bank = Bank::new(&genesis_block);
         let cluster_info = Arc::new(RwLock::new(ClusterInfo::new(NodeInfo::default())));
         let rpc_addr = SocketAddr::new(

--- a/src/tvu.rs
+++ b/src/tvu.rs
@@ -326,8 +326,6 @@ pub mod tests {
         let (genesis_block, mint_keypair) = GenesisBlock::new(starting_balance);
         let tvu_addr = target1.info.tvu;
         let bank = Arc::new(Bank::new(&genesis_block));
-        // 2 tokens are consumed by the genesis
-        let starting_balance = starting_balance - 2;
         assert_eq!(bank.get_balance(&mint_keypair.pubkey()), starting_balance);
 
         //start cluster_info1


### PR DESCRIPTION
#### Problem

Genesis block silently requires 2 extra tokens when constructed without a leader (`GenesisBlock::new(tokens)`). This results in tests needing to know about inner GenesisBlock functionality, resulting in ugly subtractions all over the place to make sure the correct balances are observed.

#### Summary of Changes

Since GenesisBlock::new() is used only for testing, I made it add 2 tokens to the input so that the mint's balance is always what the caller asked for. 
