### PR TITLE
Faster exit for storage_stage client

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1,7 +1,13 @@
 use crate::cluster_info::{NodeInfo, FULLNODE_PORT_RANGE};
 use crate::thin_client::ThinClient;
+use std::time::Duration;
 
 pub fn mk_client(r: &NodeInfo) -> ThinClient {
     let (_, transactions_socket) = solana_netutil::bind_in_range(FULLNODE_PORT_RANGE).unwrap();
     ThinClient::new(r.rpc, r.tpu, transactions_socket)
+}
+
+pub fn mk_client_with_timeout(r: &NodeInfo, timeout: Duration) -> ThinClient {
+    let (_, transactions_socket) = solana_netutil::bind_in_range(FULLNODE_PORT_RANGE).unwrap();
+    ThinClient::new_with_timeout(r.rpc, r.tpu, transactions_socket, timeout)
 }


### PR DESCRIPTION
#### Problem

storage_stage can take a long time to exit if there is no leader. Causes test_replay to hang for a bit because the default timeout is 30 seconds.

#### Summary of Changes

Change the client timeout to 5 seconds and check exit on each iteration.

Fixes #
