### PR TITLE
Test cleanup

### DIFF
--- a/src/entry.rs
+++ b/src/entry.rs
@@ -311,6 +311,12 @@ impl EntrySlice for [Entry] {
     }
 }
 
+pub fn next_entry_mut(start: &mut Hash, num_hashes: u64, transactions: Vec<Transaction>) -> Entry {
+    let entry = Entry::new(&start, 0, num_hashes, transactions);
+    *start = entry.id;
+    entry
+}
+
 /// Creates the next entries for given transactions, outputs
 /// updates start_hash to id of last Entry, sets num_hashes to 0
 pub fn next_entries_mut(
@@ -389,8 +395,7 @@ pub fn next_entries(
 pub fn create_ticks(num_ticks: u64, mut hash: Hash) -> Vec<Entry> {
     let mut ticks = Vec::with_capacity(num_ticks as usize);
     for _ in 0..num_ticks {
-        let new_tick = Entry::new(&hash, 0, 1, vec![]);
-        hash = new_tick.id;
+        let new_tick = next_entry_mut(&mut hash, 1, vec![]);
         ticks.push(new_tick);
     }
 

--- a/src/replay_stage.rs
+++ b/src/replay_stage.rs
@@ -363,7 +363,7 @@ mod test {
     };
     use crate::cluster_info::{ClusterInfo, Node};
     use crate::entry::create_ticks;
-    use crate::entry::Entry;
+    use crate::entry::{next_entry_mut, Entry};
     use crate::fullnode::new_bank_from_ledger;
     use crate::genesis_block::GenesisBlock;
     use crate::leader_scheduler::{make_active_set_entries, LeaderSchedulerConfig};
@@ -469,8 +469,7 @@ mod test {
             let total_entries_to_send = 2 * ticks_per_slot as usize - 2;
             let mut entries_to_send = vec![];
             while entries_to_send.len() < total_entries_to_send {
-                let entry = Entry::new(&mut last_id, 0, 1, vec![]);
-                last_id = entry.id;
+                let entry = next_entry_mut(&mut last_id, 1, vec![]);
                 entries_to_send.push(entry);
             }
 
@@ -706,8 +705,7 @@ mod test {
             let leader_rotation_index = (active_window_tick_length - tick_height - 1) as usize;
             let mut expected_last_id = Hash::default();
             for i in 0..total_entries_to_send {
-                let entry = Entry::new(&mut last_id, 0, num_hashes, vec![]);
-                last_id = entry.id;
+                let entry = next_entry_mut(&mut last_id, num_hashes, vec![]);
                 blocktree
                     .write_entries(
                         DEFAULT_SLOT_HEIGHT,
@@ -758,8 +756,7 @@ mod test {
         let mut last_id = Hash::default();
         let mut entries = Vec::new();
         for _ in 0..5 {
-            let entry = Entry::new(&mut last_id, 0, 1, vec![]); //just ticks
-            last_id = entry.id;
+            let entry = next_entry_mut(&mut last_id, 1, vec![]); //just ticks
             entries.push(entry);
         }
 


### PR DESCRIPTION
#### Problem

* window_send_test can hang because the vector it puts blobs into can be reset if it doesn't succeed in the first try and it expects a certain length.
* window_send_leader_test2 can infinite loop if it receives no blobs.
* Use of custom shared blob logic when there exists helper functions to create those from entries.
* Extra logic around common idiom of generating entries and updating the current hash.

#### Summary of Changes

* Fix window_send_test logic
* Use recv_timeout for window_send_test2
* Use blob creation helpers
* Helper function for creating entries/updating last_id.

Fixes #
