### PR TITLE
tpu now hangs on to its cluster_info

### DIFF
--- a/src/fullnode.rs
+++ b/src/fullnode.rs
@@ -286,7 +286,7 @@ impl Fullnode {
                 .broadcast
                 .try_clone()
                 .expect("Failed to clone broadcast socket"),
-            cluster_info.clone(),
+            &cluster_info,
             config.sigverify_disabled,
             max_tick_height,
             blob_index,
@@ -389,7 +389,6 @@ impl Fullnode {
                 self.broadcast_socket
                     .try_clone()
                     .expect("Failed to clone broadcast socket"),
-                self.cluster_info.clone(),
                 self.sigverify_disabled,
                 max_tick_height,
                 0,
@@ -407,7 +406,6 @@ impl Fullnode {
                     .iter()
                     .map(|s| s.try_clone().expect("Failed to clone TPU sockets"))
                     .collect(),
-                self.cluster_info.clone(),
             );
             FullnodeReturnType::LeaderToValidatorRotation
         }


### PR DESCRIPTION
No need for fullnode to continually pass in the same `cluster_info` on each rotation.

Just some yak shaving that gets me closer to fixing #2675
