### PR TITLE
Change Blocktree to consume last blob flag

### DIFF
--- a/book/src/blocktree.md
+++ b/book/src/blocktree.md
@@ -51,10 +51,10 @@ slot index and blob index for an entry, and the value is the entry data. Note bl
       * `next_slots` - A list of future slots this slot could chain to. Used when rebuilding
       the ledger to find possible fork points.
       * `consumed_ticks` - Tick height of the highest received blob (used to identify when a slot is full)
-      * `is_trunk` - True iff every block from 0...slot forms a full sequence without any holes. We can derive is_trunk for each slot with the following rules. Let slot(n) be the slot with index `n`, and slot(n).contains_all_ticks() is true if the slot with index `n` has all the ticks expected for that slot. Let is_trunk(n) be the statement that "the slot(n).is_trunk is true". Then:
+      * `is_trunk` - True iff every block from 0...slot forms a full sequence without any holes. We can derive is_trunk for each slot with the following rules. Let slot(n) be the slot with index `n`, and slot(n).is_full() is true if the slot with index `n` has all the ticks expected for that slot. Let is_trunk(n) be the statement that "the slot(n).is_trunk is true". Then:
       
       is_trunk(0)
-      is_trunk(n+1) iff (is_trunk(n) and slot(n).contains_all_ticks()
+      is_trunk(n+1) iff (is_trunk(n) and slot(n).is_full()
 
 3. Chaining - When a blob for a new slot `x` arrives, we check the number of blocks (`num_blocks`) for that new slot (this information is encoded in the blob). We then know that this new slot chains to slot `x - num_blocks`.
 

--- a/book/src/blocktree.md
+++ b/book/src/blocktree.md
@@ -50,7 +50,7 @@ slot index and blob index for an entry, and the value is the entry data. Note bl
       * `received` - The highest received blob index for the slot
       * `next_slots` - A list of future slots this slot could chain to. Used when rebuilding
       the ledger to find possible fork points.
-      * `consumed_ticks` - Tick height of the highest received blob (used to identify when a slot is full)
+      * `last_index` - The index of the blob that is flagged as the last blob for this slot. This flag on a blob will be set by the leader for a slot when they are transmitting the last blob for a slot.
       * `is_trunk` - True iff every block from 0...slot forms a full sequence without any holes. We can derive is_trunk for each slot with the following rules. Let slot(n) be the slot with index `n`, and slot(n).is_full() is true if the slot with index `n` has all the ticks expected for that slot. Let is_trunk(n) be the statement that "the slot(n).is_trunk is true". Then:
       
       is_trunk(0)

--- a/src/broadcast_service.rs
+++ b/src/broadcast_service.rs
@@ -83,6 +83,16 @@ impl Broadcast {
 
         // TODO: blob_index should be slot-relative...
         index_blobs(&blobs, &mut self.blob_index, &slots);
+        let parent = {
+            if slots[0] == 0 {
+                0
+            } else {
+                slots[0] - 1
+            }
+        };
+        for b in blobs.iter() {
+            b.write().unwrap().set_parent(parent);
+        }
 
         let to_blobs_elapsed = duration_as_ms(&to_blobs_start.elapsed());
 

--- a/src/repair_service.rs
+++ b/src/repair_service.rs
@@ -118,10 +118,10 @@ impl RepairService {
         slot: &SlotMeta,
         max_repairs: usize,
     ) -> Result<Vec<(u64, u64)>> {
-        if slot.contains_all_ticks() {
+        if slot.is_full() {
             Ok(vec![])
         } else {
-            let num_unreceived_ticks = {
+            /*let num_unreceived_ticks = {
                 if slot.consumed == slot.received {
                     let num_expected_ticks = slot.num_expected_ticks(blocktree);
                     if num_expected_ticks == 0 {
@@ -141,9 +141,9 @@ impl RepairService {
                 } else {
                     0
                 }
-            };
+            };*/
 
-            let upper = slot.received + num_unreceived_ticks;
+            let upper = slot.received;
 
             let reqs =
                 blocktree.find_missing_data_indexes(slot_height, slot.consumed, upper, max_repairs);

--- a/src/repair_service.rs
+++ b/src/repair_service.rs
@@ -118,7 +118,7 @@ impl RepairService {
         slot: &SlotMeta,
         max_repairs: usize,
     ) -> Result<Vec<(u64, u64)>> {
-        if slot.contains_all_ticks(blocktree) {
+        if slot.contains_all_ticks() {
             Ok(vec![])
         } else {
             let num_unreceived_ticks = {


### PR DESCRIPTION
#### Problem
Blocktree counts ticks in order to figure out when slots are completed, but this leaks unnecessary complexity into the Blcoktree

#### Summary of Changes
The leader should signal the end of a slot by marking the last blob as with the "BLOB_FLAG_IS_LAST_IN_SLOT" flag. Change Blocktree to consume this flag.

Fixes #
