### PR TITLE
counter.rs: Adjust create_counter to avoid imposing an AtomicUsize import on users

### DIFF
--- a/src/accounts.rs
+++ b/src/accounts.rs
@@ -12,7 +12,6 @@ use solana_sdk::pubkey::Pubkey;
 use solana_sdk::transaction::Transaction;
 use std::collections::BTreeMap;
 use std::ops::Deref;
-use std::sync::atomic::AtomicUsize;
 use std::sync::{Mutex, RwLock};
 
 pub type InstructionAccounts = Vec<Account>;

--- a/src/banking_stage.rs
+++ b/src/banking_stage.rs
@@ -19,7 +19,7 @@ use solana_sdk::hash::Hash;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::timing;
 use solana_sdk::transaction::Transaction;
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::Ordering;
 use std::sync::mpsc::{channel, Receiver, RecvTimeoutError};
 use std::sync::{Arc, Mutex};
 use std::thread::{self, Builder, JoinHandle};

--- a/src/broadcast_service.rs
+++ b/src/broadcast_service.rs
@@ -18,7 +18,7 @@ use solana_metrics::{influxdb, submit};
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::timing::duration_as_ms;
 use std::net::UdpSocket;
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::{Receiver, RecvTimeoutError};
 use std::sync::{Arc, RwLock};
 use std::thread::{self, Builder, JoinHandle};

--- a/src/cluster_info.rs
+++ b/src/cluster_info.rs
@@ -41,7 +41,7 @@ use std::cmp::min;
 use std::fmt;
 use std::io;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr, UdpSocket};
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, RwLock};
 use std::thread::{sleep, Builder, JoinHandle};
 use std::time::{Duration, Instant};

--- a/src/cluster_info_vote_listener.rs
+++ b/src/cluster_info_vote_listener.rs
@@ -5,7 +5,7 @@ use crate::result::Result;
 use crate::service::Service;
 use crate::streamer::PacketSender;
 use log::Level;
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, RwLock};
 use std::thread::{self, sleep, Builder, JoinHandle};
 use std::time::Duration;

--- a/src/counter.rs
+++ b/src/counter.rs
@@ -20,10 +20,10 @@ macro_rules! create_counter {
     ($name:expr, $lograte:expr) => {
         Counter {
             name: $name,
-            counts: AtomicUsize::new(0),
-            times: AtomicUsize::new(0),
-            lastlog: AtomicUsize::new(0),
-            lograte: AtomicUsize::new($lograte),
+            counts: std::sync::atomic::AtomicUsize::new(0),
+            times: std::sync::atomic::AtomicUsize::new(0),
+            lastlog: std::sync::atomic::AtomicUsize::new(0),
+            lograte: std::sync::atomic::AtomicUsize::new($lograte),
             point: None,
         }
     };
@@ -116,7 +116,7 @@ mod tests {
     use crate::counter::{Counter, DEFAULT_LOG_RATE};
     use log::Level;
     use std::env;
-    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::atomic::Ordering;
     use std::sync::{Once, RwLock, ONCE_INIT};
 
     fn get_env_lock() -> &'static RwLock<()> {

--- a/src/db_window.rs
+++ b/src/db_window.rs
@@ -11,7 +11,6 @@ use log::Level;
 use solana_metrics::{influxdb, submit};
 use solana_sdk::pubkey::Pubkey;
 use std::borrow::Borrow;
-use std::sync::atomic::AtomicUsize;
 use std::sync::{Arc, RwLock};
 
 pub const MAX_REPAIR_LENGTH: usize = 128;

--- a/src/fullnode.rs
+++ b/src/fullnode.rs
@@ -22,7 +22,7 @@ use solana_sdk::signature::{Keypair, KeypairUtil};
 use solana_sdk::timing::{duration_as_ms, timestamp};
 use std::net::UdpSocket;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::{channel, Receiver, RecvTimeoutError, Sender, SyncSender};
 use std::sync::{Arc, RwLock};
 use std::thread::{sleep, spawn, Result};

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -12,7 +12,6 @@ use std::fmt;
 use std::io;
 use std::mem::size_of;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, UdpSocket};
-use std::sync::atomic::AtomicUsize;
 use std::sync::{Arc, RwLock};
 
 pub type SharedPackets = Arc<RwLock<Packets>>;

--- a/src/replay_stage.rs
+++ b/src/replay_stage.rs
@@ -16,7 +16,7 @@ use solana_sdk::hash::Hash;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::timing::duration_as_ms;
 use solana_sdk::vote_transaction::VoteTransaction;
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::{channel, Receiver, SyncSender};
 use std::sync::{Arc, RwLock};
 #[cfg(test)]

--- a/src/retransmit_stage.rs
+++ b/src/retransmit_stage.rs
@@ -16,7 +16,7 @@ use core::cmp;
 use log::Level;
 use solana_metrics::{influxdb, submit};
 use std::net::UdpSocket;
-use std::sync::atomic::{AtomicBool, AtomicUsize};
+use std::sync::atomic::AtomicBool;
 use std::sync::mpsc::channel;
 use std::sync::mpsc::RecvTimeoutError;
 use std::sync::{Arc, RwLock};

--- a/src/sigverify.rs
+++ b/src/sigverify.rs
@@ -15,7 +15,6 @@ use solana_sdk::signature::Signature;
 use solana_sdk::transaction::Transaction;
 use std::io::Cursor;
 use std::mem::size_of;
-use std::sync::atomic::AtomicUsize;
 
 pub const TX_OFFSET: usize = 0;
 

--- a/src/sigverify_stage.rs
+++ b/src/sigverify_stage.rs
@@ -16,7 +16,6 @@ use log::Level;
 use rand::{thread_rng, Rng};
 use solana_metrics::{influxdb, submit};
 use solana_sdk::timing;
-use std::sync::atomic::AtomicUsize;
 use std::sync::mpsc::{channel, Receiver, RecvTimeoutError, Sender};
 use std::sync::{Arc, Mutex};
 use std::thread::{self, spawn, JoinHandle};

--- a/src/tpu_forwarder.rs
+++ b/src/tpu_forwarder.rs
@@ -11,7 +11,7 @@ use crate::streamer::{self, PacketReceiver};
 use log::Level;
 use solana_sdk::pubkey::Pubkey;
 use std::net::{SocketAddr, UdpSocket};
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::channel;
 use std::sync::{Arc, RwLock};
 use std::thread::{self, Builder, JoinHandle};

--- a/src/window_service.rs
+++ b/src/window_service.rs
@@ -14,7 +14,7 @@ use solana_metrics::{influxdb, submit};
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::timing::duration_as_ms;
 use std::net::UdpSocket;
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::RecvTimeoutError;
 use std::sync::{Arc, RwLock};
 use std::thread::{self, Builder, JoinHandle};


### PR DESCRIPTION
A bunch of files needed `use std::sync::atomic::AtomicUsize;` because `create_counter!` didn't properly encapsulate itself. 