### PR TITLE
Add TPU forwarding of unprocessed but received packets, and restore 8 ticks per slot

### DIFF
--- a/ledger-tool/tests/basic.rs
+++ b/ledger-tool/tests/basic.rs
@@ -32,14 +32,15 @@ fn bad_arguments() {
 #[test]
 fn nominal() {
     let keypair = Arc::new(Keypair::new());
-    let (_mint_keypair, ledger_path, _tick_height, _last_entry_height, _last_id, _last_entry_id) =
+    let blocktree_config = BlocktreeConfig::default();
+    let (_mint_keypair, ledger_path, tick_height, _last_entry_height, _last_id, _last_entry_id) =
         create_tmp_sample_ledger(
             "test_ledger_tool_nominal",
             100,
-            9,
+            blocktree_config.ticks_per_slot - 2,
             keypair.pubkey(),
             50,
-            &BlocktreeConfig::default(),
+            &blocktree_config,
         );
 
     // Basic validation
@@ -49,7 +50,7 @@ fn nominal() {
     // Print everything
     let output = run_ledger_tool(&["-l", &ledger_path, "print"]);
     assert!(output.status.success());
-    assert_eq!(count_newlines(&output.stdout), 10);
+    assert_eq!(count_newlines(&output.stdout), tick_height as usize);
 
     // Only print the first 5 items
     let output = run_ledger_tool(&["-l", &ledger_path, "-n", "5", "print"]);
@@ -59,7 +60,7 @@ fn nominal() {
     // Skip entries with no hashes
     let output = run_ledger_tool(&["-l", &ledger_path, "-h", "1", "print"]);
     assert!(output.status.success());
-    assert_eq!(count_newlines(&output.stdout), 10);
+    assert_eq!(count_newlines(&output.stdout), tick_height as usize);
 
     // Skip entries with fewer than 2 hashes (skip everything)
     let output = run_ledger_tool(&["-l", &ledger_path, "-h", "2", "print"]);

--- a/src/banking_stage.rs
+++ b/src/banking_stage.rs
@@ -279,6 +279,7 @@ mod tests {
     use crate::banking_stage::BankingStageReturnType;
     use crate::entry::EntrySlice;
     use crate::genesis_block::GenesisBlock;
+    use crate::leader_scheduler::DEFAULT_TICKS_PER_SLOT;
     use crate::packet::to_packets;
     use solana_sdk::signature::{Keypair, KeypairUtil};
     use solana_sdk::system_transaction::SystemTransaction;
@@ -295,7 +296,7 @@ mod tests {
             verified_receiver,
             PohServiceConfig::default(),
             &bank.last_id(),
-            std::u64::MAX,
+            DEFAULT_TICKS_PER_SLOT,
             genesis_block.bootstrap_leader_id,
             &to_validator_sender,
         );
@@ -317,7 +318,7 @@ mod tests {
             verified_receiver,
             PohServiceConfig::default(),
             &bank.last_id(),
-            std::u64::MAX,
+            DEFAULT_TICKS_PER_SLOT,
             genesis_block.bootstrap_leader_id,
             &to_validator_sender,
         );
@@ -340,7 +341,7 @@ mod tests {
             verified_receiver,
             PohServiceConfig::Sleep(Duration::from_millis(1)),
             &bank.last_id(),
-            std::u64::MAX,
+            DEFAULT_TICKS_PER_SLOT,
             genesis_block.bootstrap_leader_id,
             &to_validator_sender,
         );
@@ -369,7 +370,7 @@ mod tests {
             verified_receiver,
             PohServiceConfig::default(),
             &bank.last_id(),
-            std::u64::MAX,
+            DEFAULT_TICKS_PER_SLOT,
             genesis_block.bootstrap_leader_id,
             &to_validator_sender,
         );
@@ -427,7 +428,7 @@ mod tests {
             verified_receiver,
             PohServiceConfig::default(),
             &bank.last_id(),
-            std::u64::MAX,
+            DEFAULT_TICKS_PER_SLOT,
             genesis_block.bootstrap_leader_id,
             &to_validator_sender,
         );

--- a/src/blocktree.rs
+++ b/src/blocktree.rs
@@ -1692,7 +1692,8 @@ mod tests {
     pub fn test_insert_data_blobs_consecutive() {
         let blocktree_path = get_tmp_ledger_path("test_insert_data_blobs_consecutive");
         {
-            let blocktree = Blocktree::open(&blocktree_path).unwrap();
+            let config = BlocktreeConfig::new(32);
+            let blocktree = Blocktree::open_config(&blocktree_path, &config).unwrap();
             let slot = 0;
             let parent_slot = 0;
             // Write entries

--- a/src/leader_scheduler.rs
+++ b/src/leader_scheduler.rs
@@ -16,12 +16,9 @@ use solana_sdk::vote_transaction::VoteTransaction;
 use std::io::Cursor;
 use std::sync::Arc;
 
-/*
 // At 10 ticks/s, 8 ticks per slot implies that leader rotation and voting will happen
 // every 800 ms. A fast voting cadence ensures faster finality and convergence
 pub const DEFAULT_TICKS_PER_SLOT: u64 = 8;
-*/
-pub const DEFAULT_TICKS_PER_SLOT: u64 = 64; // TODO: DEFAULT_TICKS_PER_SLOT = 8 causes instability in the integration tests.
 pub const DEFAULT_SLOTS_PER_EPOCH: u64 = 64;
 pub const DEFAULT_ACTIVE_WINDOW_TICK_LENGTH: u64 = DEFAULT_SLOTS_PER_EPOCH * DEFAULT_TICKS_PER_SLOT;
 

--- a/src/thin_client.rs
+++ b/src/thin_client.rs
@@ -332,11 +332,11 @@ impl ThinClient {
     pub fn poll_for_signature(&mut self, signature: &Signature) -> io::Result<()> {
         let now = Instant::now();
         while !self.check_signature(signature) {
-            if now.elapsed().as_secs() > 1 {
+            if now.elapsed().as_secs() > 4 {
                 // TODO: Return a better error.
                 return Err(io::Error::new(io::ErrorKind::Other, "signature not found"));
             }
-            sleep(Duration::from_millis(100));
+            sleep(Duration::from_millis(500));
         }
         Ok(())
     }

--- a/tests/multinode.rs
+++ b/tests/multinode.rs
@@ -1703,6 +1703,7 @@ fn test_broadcast_last_tick() {
                     .expect("Expected to be able to reconstruct entries from blob")
                     .0[0];
                 assert_eq!(actual_last_tick, expected_last_tick);
+                break;
             } else {
                 assert!(!b_r.is_last_in_slot());
             }
@@ -2078,13 +2079,12 @@ fn test_two_fullnodes_rotate_every_second_tick() {
 }
 
 #[test]
-#[ignore]
 fn test_one_fullnode_rotate_every_tick_with_transactions() {
     test_fullnode_rotate(1, 1, false, true);
 }
 
 #[test]
 #[ignore]
-fn test_two_fullnodes_rotate_every_tick_with_transacations() {
+fn test_two_fullnodes_rotate_every_tick_with_transactions() {
     test_fullnode_rotate(1, 1, true, true);
 }


### PR DESCRIPTION
With a quick slot leader rotation (~8 ticks per slot), clients that talk directly to a leader node are likely to experience a high rate to dropped transactions during the time that PoH max height is reached and the TPU switches into forwarding mode.   This is even worse for testnets with leader rotation disabled, where every ~800ms the leader accepts transactions but immediately drops them as it's going through its rotation gymnastics.   This wreaks havoc on integration tests and the SDK development environment.

Instead we can easily collect all transaction packets received by the fetch stage that have yet to make it into the bank, and forward them to the next leader (which may in fact be the same node).

TODO:
* [x] Integration tests and `ci/localnet-sanity.sh` seem to be happy with this PR, but there are a bunch of upset unit tests (banking_stage.rs in particular)
* [x] Add unit tests specifically for this new forwarding facility
* [x] Address TODO in banking_stage.rs

Fixes #2675
