### PR TITLE
Add protocol request for requesting the highest blob in a slot

### DIFF
--- a/src/repair_service.rs
+++ b/src/repair_service.rs
@@ -59,7 +59,7 @@ impl RepairService {
                         cluster_info
                             .read()
                             .unwrap()
-                            .window_index_request(slot_height, blob_index)
+                            .window_index_request(slot_height, blob_index, false)
                             .map(|result| (result, slot_height, blob_index))
                             .ok()
                     })


### PR DESCRIPTION
#### Problem
After removing tick count from the BlockTree, we need a way to unblock slots where slot.consumed == slot.received, but the slot doesn't contain all the ticks. Otherwise, the slot won't know what blobs to repair past slot.received

#### Summary of Changes
Add a protocol request that allows nodes to ask for the highest blob for a slot.

Fixes #
