### PR TITLE
entry_stream: add message terminator to socket write format

### DIFF
--- a/src/entry_stream.rs
+++ b/src/entry_stream.rs
@@ -47,10 +47,13 @@ pub struct EntrySocket {
     socket: String,
 }
 
+const MESSAGE_TERMINATOR: &str = "\n";
+
 impl EntryWriter for EntrySocket {
     fn write(&self, payload: String) -> Result<()> {
         let mut socket = UnixStream::connect(Path::new(&self.socket))?;
         socket.write_all(payload.as_bytes())?;
+        socket.write_all(MESSAGE_TERMINATOR.as_bytes())?;
         socket.shutdown(Shutdown::Write)?;
         Ok(())
     }


### PR DESCRIPTION
#### Problem

* nodejs (and potentially other) client(s) of entry_stream may receive partial data from socket

#### Summary of Changes

* add a double newline message terminator to socket output format

