### PR TITLE
Collect and re-forward packets received while TpuForwarder is shutting down

### DIFF
--- a/src/replay_stage.rs
+++ b/src/replay_stage.rs
@@ -278,11 +278,13 @@ impl ReplayStage {
                             // Check for leader rotation
                             let leader_id = Self::get_leader_for_next_tick(&bank);
 
-                            // TODO: Remove this soon once we boot the leader from ClusterInfo
-                            cluster_info.write().unwrap().set_leader(leader_id);
-
-                            if leader_id != last_leader_id && my_id == leader_id {
-                                to_leader_sender.send(current_tick_height).unwrap();
+                            if leader_id != last_leader_id {
+                                if my_id == leader_id {
+                                    to_leader_sender.send(current_tick_height).unwrap();
+                                } else {
+                                    // TODO: Remove this soon once we boot the leader from ClusterInfo
+                                    cluster_info.write().unwrap().set_leader(leader_id);
+                                }
                             }
 
                             // Check for any slots that chain to this one

--- a/src/thin_client.rs
+++ b/src/thin_client.rs
@@ -332,11 +332,11 @@ impl ThinClient {
     pub fn poll_for_signature(&mut self, signature: &Signature) -> io::Result<()> {
         let now = Instant::now();
         while !self.check_signature(signature) {
-            if now.elapsed().as_secs() > 4 {
+            if now.elapsed().as_secs() > 15 {
                 // TODO: Return a better error.
                 return Err(io::Error::new(io::ErrorKind::Other, "signature not found"));
             }
-            sleep(Duration::from_millis(500));
+            sleep(Duration::from_millis(250));
         }
         Ok(())
     }

--- a/tests/multinode.rs
+++ b/tests/multinode.rs
@@ -2015,7 +2015,6 @@ fn test_fullnode_rotate(
                 .transfer(500, &mint_keypair, bob, &client_last_id)
                 .unwrap();
             debug!("transfer send, signature is {:?}", signature);
-            std::thread::sleep(std::time::Duration::from_millis(100));
             client.poll_for_signature(&signature).unwrap();
             debug!("transfer signature confirmed");
             let actual_bob_balance =
@@ -2030,7 +2029,6 @@ fn test_fullnode_rotate(
             } else {
                 trace!("waiting for leader to reach max tick height...");
             }
-            sleep(Duration::from_millis(100));
         }
     }
 

--- a/tests/multinode.rs
+++ b/tests/multinode.rs
@@ -1797,6 +1797,13 @@ fn test_fullnode_rotate(
     let mut fullnode_config = FullnodeConfig::default();
     fullnode_config.leader_scheduler_config.ticks_per_slot = ticks_per_slot;
     fullnode_config.leader_scheduler_config.slots_per_epoch = slots_per_epoch;
+
+    // Note: when debugging failures in this test, disabling voting can help keep the log noise
+    // down by removing the extra vote transactions
+    /*
+    fullnode_config.voting_disabled = true;
+    */
+
     let blocktree_config = fullnode_config.ledger_config();
     fullnode_config
         .leader_scheduler_config
@@ -2084,7 +2091,6 @@ fn test_one_fullnode_rotate_every_tick_with_transactions() {
 }
 
 #[test]
-#[ignore]
 fn test_two_fullnodes_rotate_every_tick_with_transactions() {
     test_fullnode_rotate(1, 1, true, true);
 }

--- a/tests/multinode.rs
+++ b/tests/multinode.rs
@@ -1946,7 +1946,7 @@ fn test_fullnode_rotate(
     let mut client = mk_client(&leader_info);
     let mut client_last_id = solana_sdk::hash::Hash::default();
 
-    let max_tick_height = 16;
+    let max_tick_height = 8;
     while leader_tick_height_of_next_rotation < max_tick_height
         && validator_tick_height_of_next_rotation < max_tick_height
     {


### PR DESCRIPTION
This is a follow-up to #2758 which unlocks the `test_two_fullnodes_rotate_every_tick_with_transactions` multinode test.

When a node is transitioning from validator to leader, the TpuForwarder may have inflight packets that should be retained (just like the BankingStage did when transitioning from leader to validator).  The fix is the same, collect all the inflight packets and pass them along once the transition is complete.

This PR contains a slight refactoring of how fullnode manages transitions to:
* Remove duplication between Fullnode::new() and Fullnode::rotate()
* Consolidate the calls to cluster_info::set_leader() that were occurring randomly about the tree into the Tpu, so that it aligns exactly with the state of the transition

Fixes #2675 even more than before.
