### PR TITLE
Unblock Testnet.  Create a new status cache every second worth of ticks.

### DIFF
--- a/benches/bank.rs
+++ b/benches/bank.rs
@@ -51,6 +51,6 @@ fn bench_process_transaction(bencher: &mut Bencher) {
         // Since benchmarker runs this multiple times, we need to clear the signatures.
         bank.clear_signatures();
         let results = bank.process_transactions(&transactions);
-        assert!(results.iter().all(Result::is_ok));
+        results.iter().for_each(|r| assert_eq!(*r, Ok(())));
     })
 }

--- a/src/bank.rs
+++ b/src/bank.rs
@@ -154,7 +154,7 @@ impl Bank {
 
     pub fn copy_for_tpu(&self) -> Self {
         let mut status_cache = BankStatusCache::default();
-        status_cache.merge_into_root(self.status_cache.read().unwrap().clone());
+        status_cache.merge_from_root(self.status_cache.read().unwrap().clone());
         Self {
             accounts: self.accounts.copy_for_tpu(),
             status_cache: RwLock::new(status_cache),
@@ -345,7 +345,7 @@ impl Bank {
             // and bank_cache is a default
             std::mem::swap(&mut old_cache, &mut bank_cache);
             // old bank cache is now held inside the bank_cache queue
-            bank_cache.merge_into_root(old_cache);
+            bank_cache.merge_from_root(old_cache);
         }
         self.leader_scheduler
             .write()

--- a/src/bank.rs
+++ b/src/bank.rs
@@ -339,11 +339,10 @@ impl Bank {
         if current_tick_height % NUM_TICKS_PER_SECOND as u64 == 0 {
             //TODO: this is a fix until proper forking is implemented
             let mut bank_cache = self.status_cache.write().unwrap();
-            let old_cache = bank_cache.clone();
-            let mut new_cache = BankStatusCache::default();
+            let mut old_cache = BankStatusCache::default();
+            std::mem::swap(&mut old_cache, &mut bank_cache);
             // old_queue is stored inside the new queue as a cache that gets checked
-            new_cache.merge_into_root(old_cache);
-            *bank_cache = new_cache;
+            bank_cache.merge_into_root(old_cache);
         }
         self.leader_scheduler
             .write()

--- a/src/bank.rs
+++ b/src/bank.rs
@@ -154,7 +154,7 @@ impl Bank {
 
     pub fn copy_for_tpu(&self) -> Self {
         let mut status_cache = BankStatusCache::default();
-        status_cache.merge_from_root(self.status_cache.read().unwrap().clone());
+        status_cache.merge_into_root(self.status_cache.read().unwrap().clone());
         Self {
             accounts: self.accounts.copy_for_tpu(),
             status_cache: RwLock::new(status_cache),

--- a/src/bank.rs
+++ b/src/bank.rs
@@ -154,7 +154,7 @@ impl Bank {
 
     pub fn copy_for_tpu(&self) -> Self {
         let mut status_cache = BankStatusCache::default();
-        status_cache.merge_into_root(self.status_cache.read().unwrap().clone());
+        status_cache.merge_from_root(self.status_cache.read().unwrap().clone());
         Self {
             accounts: self.accounts.copy_for_tpu(),
             status_cache: RwLock::new(status_cache),

--- a/src/bank.rs
+++ b/src/bank.rs
@@ -340,8 +340,11 @@ impl Bank {
             //TODO: this is a fix until proper forking is implemented
             let mut bank_cache = self.status_cache.write().unwrap();
             let mut old_cache = BankStatusCache::default();
+            // swap the two variables
+            // old_cache becomes the old bank cache
+            // and bank_cache is a default
             std::mem::swap(&mut old_cache, &mut bank_cache);
-            // old_queue is stored inside the new queue as a cache that gets checked
+            // old bank cache is now held inside the bank_cache queue
             bank_cache.merge_into_root(old_cache);
         }
         self.leader_scheduler

--- a/src/status_cache.rs
+++ b/src/status_cache.rs
@@ -85,7 +85,7 @@ impl<T: Clone> StatusCache<T> {
         // which cannot be rolled back
         assert!(other.merges.is_empty());
         self.merges.push_front(other);
-        if self.merges.len() > MAX_ENTRY_IDS {
+        if self.merges.len() > MAX_ENTRY_IDS / NUM_TICKS_PER_SECOND {
             //TODO check if this is the right size ^
             self.merges.pop_back();
         }

--- a/src/status_cache.rs
+++ b/src/status_cache.rs
@@ -61,6 +61,7 @@ impl<T: Clone> StatusCache<T> {
     pub fn clear(&mut self) {
         self.failures.clear();
         self.signatures.clear();
+        self.merges = VecDeque::new();
     }
     fn get_signature_status_merged(&self, sig: &Signature) -> Option<Result<(), T>> {
         for c in &self.merges {
@@ -190,6 +191,9 @@ mod tests {
         third.merge_from_root(second);
         assert_eq!(third.get_signature_status(&sig), Some(Ok(())),);
         assert!(third.has_signature(&sig));
+        third.clear();
+        assert_eq!(third.get_signature_status(&sig), None);
+        assert!(!third.has_signature(&sig));
     }
 
     #[test]

--- a/src/status_cache.rs
+++ b/src/status_cache.rs
@@ -1,5 +1,6 @@
 use crate::bloom::{Bloom, BloomHashIndex};
 use crate::last_id_queue::MAX_ENTRY_IDS;
+use crate::poh_service::NUM_TICKS_PER_SECOND;
 use hashbrown::HashMap;
 use solana_sdk::hash::Hash;
 use solana_sdk::signature::Signature;

--- a/src/status_cache.rs
+++ b/src/status_cache.rs
@@ -182,10 +182,14 @@ mod tests {
         first.add(&sig);
         assert_eq!(first.get_signature_status(&sig), Some(Ok(())));
         let last_id = hash(last_id.as_ref());
-        let second = BankStatusCache::new(&last_id);
-        first.merge_from_root(second);
-        assert_eq!(first.get_signature_status(&sig), Some(Ok(())),);
-        assert!(first.has_signature(&sig));
+        let mut second = BankStatusCache::new(&last_id);
+        second.merge_from_root(first);
+        assert_eq!(second.get_signature_status(&sig), Some(Ok(())),);
+        assert!(second.has_signature(&sig));
+        let mut third = BankStatusCache::new(&last_id);
+        third.merge_from_root(second);
+        assert_eq!(third.get_signature_status(&sig), Some(Ok(())),);
+        assert!(third.has_signature(&sig));
     }
 
     #[test]


### PR DESCRIPTION
#### Problem

Status cache is designed for only 1 second worth of signatures.  Right now the bank just keeps a single one for the lifetime.  This should be fixed by proper forking, but in the meantime this allows the bank to move forward.

#### Summary of Changes

Create a new status cache every second.  It becomes a "root" cache, which means it maintains the history of the previous caches internally.

Fixes #
