### PR TITLE
delete leader rotation signal from banking stage

### DIFF
--- a/benches/banking_stage.rs
+++ b/benches/banking_stage.rs
@@ -100,7 +100,6 @@ fn bench_banking_stage_multi_accounts(bencher: &mut Bencher) {
             (x, iter::repeat(1).take(len).collect())
         })
         .collect();
-    let (to_leader_sender, _to_leader_recvr) = channel();
     let (_stage, signal_receiver) = BankingStage::new(
         &bank,
         verified_receiver,
@@ -108,7 +107,6 @@ fn bench_banking_stage_multi_accounts(bencher: &mut Bencher) {
         &genesis_block.last_id(),
         std::u64::MAX,
         genesis_block.bootstrap_leader_id,
-        &to_leader_sender,
     );
 
     let mut id = genesis_block.last_id();
@@ -209,7 +207,6 @@ fn bench_banking_stage_multi_programs(bencher: &mut Bencher) {
             (x, iter::repeat(1).take(len).collect())
         })
         .collect();
-    let (to_leader_sender, _to_leader_recvr) = channel();
     let (_stage, signal_receiver) = BankingStage::new(
         &bank,
         verified_receiver,
@@ -217,7 +214,6 @@ fn bench_banking_stage_multi_programs(bencher: &mut Bencher) {
         &genesis_block.last_id(),
         std::u64::MAX,
         genesis_block.bootstrap_leader_id,
-        &to_leader_sender,
     );
 
     let mut id = genesis_block.last_id();

--- a/src/banking_stage.rs
+++ b/src/banking_stage.rs
@@ -14,7 +14,6 @@ use crate::poh_service::{PohService, PohServiceConfig};
 use crate::result::{Error, Result};
 use crate::service::Service;
 use crate::sigverify_stage::VerifiedPackets;
-use crate::tpu::TpuRotationSender;
 use bincode::deserialize;
 use log::Level;
 use solana_sdk::hash::Hash;
@@ -51,7 +50,6 @@ impl BankingStage {
         last_entry_id: &Hash,
         max_tick_height: u64,
         leader_id: Pubkey,
-        to_validator_sender: &TpuRotationSender,
     ) -> (Self, Receiver<Vec<Entry>>) {
         let (entry_sender, entry_receiver) = channel();
         let shared_verified_receiver = Arc::new(Mutex::new(verified_receiver));
@@ -61,8 +59,7 @@ impl BankingStage {
         // Single thread to generate entries from many banks.
         // This thread talks to poh_service and broadcasts the entries once they have been recorded.
         // Once an entry has been recorded, its last_id is registered with the bank.
-        let poh_service =
-            PohService::new(poh_recorder.clone(), config, to_validator_sender.clone());
+        let poh_service = PohService::new(poh_recorder.clone(), config);
 
         // Single thread to compute confirmation
         let compute_confirmation_service = ComputeLeaderConfirmationService::new(
@@ -365,7 +362,6 @@ mod tests {
         let (genesis_block, _mint_keypair) = GenesisBlock::new(2);
         let bank = Arc::new(Bank::new(&genesis_block));
         let (verified_sender, verified_receiver) = channel();
-        let (to_validator_sender, _) = channel();
         let (banking_stage, _entry_receiver) = BankingStage::new(
             &bank,
             verified_receiver,
@@ -373,7 +369,6 @@ mod tests {
             &bank.last_id(),
             DEFAULT_TICKS_PER_SLOT,
             genesis_block.bootstrap_leader_id,
-            &to_validator_sender,
         );
         drop(verified_sender);
         banking_stage.join().unwrap();
@@ -385,7 +380,6 @@ mod tests {
         let bank = Arc::new(Bank::new(&genesis_block));
         let start_hash = bank.last_id();
         let (verified_sender, verified_receiver) = channel();
-        let (to_validator_sender, _) = channel();
         let (banking_stage, entry_receiver) = BankingStage::new(
             &bank,
             verified_receiver,
@@ -393,7 +387,6 @@ mod tests {
             &bank.last_id(),
             DEFAULT_TICKS_PER_SLOT,
             genesis_block.bootstrap_leader_id,
-            &to_validator_sender,
         );
         sleep(Duration::from_millis(500));
         drop(verified_sender);
@@ -411,7 +404,6 @@ mod tests {
         let bank = Arc::new(Bank::new(&genesis_block));
         let start_hash = bank.last_id();
         let (verified_sender, verified_receiver) = channel();
-        let (to_validator_sender, _) = channel();
         let (banking_stage, entry_receiver) = BankingStage::new(
             &bank,
             verified_receiver,
@@ -419,7 +411,6 @@ mod tests {
             &bank.last_id(),
             DEFAULT_TICKS_PER_SLOT,
             genesis_block.bootstrap_leader_id,
-            &to_validator_sender,
         );
 
         // good tx
@@ -466,7 +457,6 @@ mod tests {
         let (genesis_block, mint_keypair) = GenesisBlock::new(2);
         let bank = Arc::new(Bank::new(&genesis_block));
         let (verified_sender, verified_receiver) = channel();
-        let (to_validator_sender, _) = channel();
         let (banking_stage, entry_receiver) = BankingStage::new(
             &bank,
             verified_receiver,
@@ -474,7 +464,6 @@ mod tests {
             &bank.last_id(),
             DEFAULT_TICKS_PER_SLOT,
             genesis_block.bootstrap_leader_id,
-            &to_validator_sender,
         );
 
         // Process a batch that includes a transaction that receives two tokens.
@@ -530,7 +519,6 @@ mod tests {
         let (genesis_block, _mint_keypair) = GenesisBlock::new(2);
         let bank = Arc::new(Bank::new(&genesis_block));
         let (verified_sender, verified_receiver) = channel();
-        let (to_validator_sender, to_validator_receiver) = channel();
         let max_tick_height = 10;
         let (banking_stage, _entry_receiver) = BankingStage::new(
             &bank,
@@ -539,9 +527,16 @@ mod tests {
             &bank.last_id(),
             max_tick_height,
             genesis_block.bootstrap_leader_id,
-            &to_validator_sender,
         );
-        assert_eq!(to_validator_receiver.recv().unwrap(), max_tick_height);
+
+        loop {
+            let bank_tick_height = bank.tick_height();
+            if bank_tick_height >= max_tick_height {
+                break;
+            }
+            sleep(Duration::from_millis(10));
+        }
+
         drop(verified_sender);
         banking_stage.join().unwrap();
     }
@@ -553,7 +548,6 @@ mod tests {
         let bank = Arc::new(Bank::new(&genesis_block));
         let ticks_per_slot = 1;
         let (verified_sender, verified_receiver) = channel();
-        let (to_validator_sender, to_validator_receiver) = channel();
         let (mut banking_stage, _entry_receiver) = BankingStage::new(
             &bank,
             verified_receiver,
@@ -561,11 +555,16 @@ mod tests {
             &bank.last_id(),
             ticks_per_slot,
             genesis_block.bootstrap_leader_id,
-            &to_validator_sender,
         );
 
         // Wait for Poh recorder to hit max height
-        assert_eq!(to_validator_receiver.recv().unwrap(), ticks_per_slot);
+        loop {
+            let bank_tick_height = bank.tick_height();
+            if bank_tick_height >= leader_scheduler_config.ticks_per_slot {
+                break;
+            }
+            sleep(Duration::from_millis(10));
+        }
 
         // Now send a transaction to the banking stage
         let transaction = SystemTransaction::new_account(

--- a/src/banking_stage.rs
+++ b/src/banking_stage.rs
@@ -560,7 +560,7 @@ mod tests {
         // Wait for Poh recorder to hit max height
         loop {
             let bank_tick_height = bank.tick_height();
-            if bank_tick_height >= leader_scheduler_config.ticks_per_slot {
+            if bank_tick_height >= ticks_per_slot {
                 break;
             }
             sleep(Duration::from_millis(10));

--- a/src/replay_stage.rs
+++ b/src/replay_stage.rs
@@ -288,7 +288,7 @@ impl ReplayStage {
                             );
                             if my_id == leader_id || my_id == last_leader_id {
                                 to_leader_sender.send(current_tick_height).unwrap();
-                            } else {
+                            } else if leader_id != last_leader_id {
                                 // TODO: Remove this soon once we boot the leader from ClusterInfo
                                 cluster_info.write().unwrap().set_leader(leader_id);
                             }

--- a/src/replay_stage.rs
+++ b/src/replay_stage.rs
@@ -286,14 +286,11 @@ impl ReplayStage {
                                 bank.tick_height(),
                                 &leader_scheduler_,
                             );
-
-                            if leader_id != last_leader_id {
-                                if my_id == leader_id {
-                                    to_leader_sender.send(current_tick_height).unwrap();
-                                } else {
-                                    // TODO: Remove this soon once we boot the leader from ClusterInfo
-                                    cluster_info.write().unwrap().set_leader(leader_id);
-                                }
+                            if my_id == leader_id || my_id == last_leader_id {
+                                to_leader_sender.send(current_tick_height).unwrap();
+                            } else {
+                                // TODO: Remove this soon once we boot the leader from ClusterInfo
+                                cluster_info.write().unwrap().set_leader(leader_id);
                             }
 
                             // Check for any slots that chain to this one

--- a/src/tpu.rs
+++ b/src/tpu.rs
@@ -151,7 +151,6 @@ impl Tpu {
         max_tick_height: u64,
         blob_index: u64,
         last_entry_id: &Hash,
-        to_validator_sender: &TpuRotationSender,
         blocktree: &Arc<Blocktree>,
         leader_scheduler: &Arc<RwLock<LeaderScheduler>>,
     ) {
@@ -182,7 +181,6 @@ impl Tpu {
             last_entry_id,
             max_tick_height,
             self.id,
-            &to_validator_sender,
         );
 
         let broadcast_service = BroadcastService::new(


### PR DESCRIPTION
#### Problem
Sending leader rotation signals from both banking stage and tvu causes/leaves potential for races between different events that rely on either one/both of these signals

#### Summary of Changes
Centralize the rotation signals to just the replay_stage

Fixes #
