### PR TITLE
Boot unused confirmation_time from Bank

### DIFF
--- a/src/compute_leader_confirmation_service.rs
+++ b/src/compute_leader_confirmation_service.rs
@@ -105,7 +105,6 @@ impl ComputeLeaderConfirmationService {
             let confirmation_ms = now - super_majority_timestamp;
 
             *last_valid_validator_timestamp = super_majority_timestamp;
-            bank.set_confirmation_time(confirmation_ms as usize);
 
             submit(
                 influxdb::Point::new(&"leader-confirmation")
@@ -215,7 +214,6 @@ pub mod tests {
             genesis_block.bootstrap_leader_id,
             &mut last_confirmation_time,
         );
-        assert_eq!(bank.confirmation_time(), std::usize::MAX);
 
         // Get another validator to vote, so we now have 2/3 consensus
         let voting_keypair = &vote_accounts[7].0;
@@ -227,7 +225,6 @@ pub mod tests {
             genesis_block.bootstrap_leader_id,
             &mut last_confirmation_time,
         );
-        assert!(bank.confirmation_time() != std::usize::MAX);
         assert!(last_confirmation_time > 0);
     }
 }

--- a/src/thin_client.rs
+++ b/src/thin_client.rs
@@ -193,28 +193,6 @@ impl ThinClient {
             })
     }
 
-    /// Request the confirmation time from the leader node
-    pub fn get_confirmation_time(&mut self) -> usize {
-        trace!("get_confirmation_time");
-        loop {
-            debug!("get_confirmation_time send_to {}", &self.rpc_addr);
-
-            let response =
-                self.rpc_client
-                    .make_rpc_request(1, RpcRequest::GetConfirmationTime, None);
-
-            match response {
-                Ok(value) => {
-                    let confirmation = value.as_u64().unwrap() as usize;
-                    return confirmation;
-                }
-                Err(error) => {
-                    debug!("thin_client get_confirmation_time error: {:?}", error);
-                }
-            };
-        }
-    }
-
     /// Request the transaction count.  If the response packet is dropped by the network,
     /// this method will try again 5 times.
     pub fn transaction_count(&mut self) -> u64 {
@@ -530,9 +508,6 @@ mod tests {
 
         let transaction_count = client.transaction_count();
         assert_eq!(transaction_count, 0);
-
-        let confirmation = client.get_confirmation_time();
-        assert_eq!(confirmation, 18446744073709551615);
 
         let last_id = client.get_last_id();
         info!("test_thin_client last_id: {:?}", last_id);


### PR DESCRIPTION
#### Problem

Bank state should only be the results of interpreting transactions. The `confirmation_time` member variable appears to view the Bank as a convenient place to put stuff. 

#### Summary of Changes

Instead of moving that variable, first attempt to boot it entirely. This broken metric is already submitted to influx. Why make it available via RPC too? If so, why store it in the bank and not in the RPC service?

