### PR TITLE
Encapsulate Bank's LeaderScheduler

### DIFF
--- a/src/bank.rs
+++ b/src/bank.rs
@@ -121,20 +121,28 @@ impl Default for Bank {
 }
 
 impl Bank {
-    pub fn new_with_leader_scheduler_config(
+    pub fn new_with_leader_scheduler(
         genesis_block: &GenesisBlock,
-        leader_scheduler_config: &LeaderSchedulerConfig,
+        leader_scheduler: Arc<RwLock<LeaderScheduler>>,
     ) -> Self {
         let mut bank = Self::default();
-        bank.leader_scheduler =
-            Arc::new(RwLock::new(LeaderScheduler::new(leader_scheduler_config)));
+        bank.leader_scheduler = leader_scheduler;
         bank.process_genesis_block(genesis_block);
         bank.add_builtin_programs();
         bank
     }
 
+    pub fn new_with_leader_scheduler_config(
+        genesis_block: &GenesisBlock,
+        leader_scheduler_config: &LeaderSchedulerConfig,
+    ) -> Self {
+        let leader_scheduler = Arc::new(RwLock::new(LeaderScheduler::new(leader_scheduler_config)));
+        Self::new_with_leader_scheduler(genesis_block, leader_scheduler)
+    }
+
     pub fn new(genesis_block: &GenesisBlock) -> Self {
-        Self::new_with_leader_scheduler_config(genesis_block, &LeaderSchedulerConfig::default())
+        let leader_scheduler = Arc::new(RwLock::new(LeaderScheduler::default()));
+        Self::new_with_leader_scheduler(genesis_block, leader_scheduler)
     }
 
     pub fn set_subscriptions(&self, subscriptions: Arc<RpcSubscriptions>) {

--- a/src/bank.rs
+++ b/src/bank.rs
@@ -103,7 +103,7 @@ pub struct Bank {
 
     /// Tracks and updates the leader schedule based on the votes and account stakes
     /// processed by the bank
-    pub leader_scheduler: Arc<RwLock<LeaderScheduler>>,
+    leader_scheduler: Arc<RwLock<LeaderScheduler>>,
 
     subscriptions: RwLock<Option<Arc<RpcSubscriptions>>>,
 }

--- a/src/bank.rs
+++ b/src/bank.rs
@@ -8,7 +8,7 @@ use crate::counter::Counter;
 use crate::entry::Entry;
 use crate::genesis_block::GenesisBlock;
 use crate::last_id_queue::{LastIdQueue, MAX_ENTRY_IDS};
-use crate::leader_scheduler::{LeaderScheduler, LeaderSchedulerConfig};
+use crate::leader_scheduler::LeaderScheduler;
 use crate::poh_recorder::{PohRecorder, PohRecorderError};
 use crate::result::Error;
 use crate::rpc_pubsub::RpcSubscriptions;
@@ -130,14 +130,6 @@ impl Bank {
         bank.process_genesis_block(genesis_block);
         bank.add_builtin_programs();
         bank
-    }
-
-    pub fn new_with_leader_scheduler_config(
-        genesis_block: &GenesisBlock,
-        leader_scheduler_config: &LeaderSchedulerConfig,
-    ) -> Self {
-        let leader_scheduler = Arc::new(RwLock::new(LeaderScheduler::new(leader_scheduler_config)));
-        Self::new_with_leader_scheduler(genesis_block, leader_scheduler)
     }
 
     pub fn new(genesis_block: &GenesisBlock) -> Self {

--- a/src/banking_stage.rs
+++ b/src/banking_stage.rs
@@ -262,10 +262,11 @@ mod tests {
     use super::*;
     use crate::entry::EntrySlice;
     use crate::genesis_block::GenesisBlock;
-    use crate::leader_scheduler::{LeaderSchedulerConfig, DEFAULT_TICKS_PER_SLOT};
+    use crate::leader_scheduler::{LeaderScheduler, LeaderSchedulerConfig, DEFAULT_TICKS_PER_SLOT};
     use crate::packet::to_packets;
     use solana_sdk::signature::{Keypair, KeypairUtil};
     use solana_sdk::system_transaction::SystemTransaction;
+    use std::sync::RwLock;
     use std::thread::sleep;
 
     #[test]
@@ -459,9 +460,11 @@ mod tests {
         solana_logger::setup();
         let (genesis_block, mint_keypair) = GenesisBlock::new(2);
         let leader_scheduler_config = LeaderSchedulerConfig::new(1, 1, 1);
-        let bank = Arc::new(Bank::new_with_leader_scheduler_config(
+        let leader_scheduler =
+            Arc::new(RwLock::new(LeaderScheduler::new(&leader_scheduler_config)));
+        let bank = Arc::new(Bank::new_with_leader_scheduler(
             &genesis_block,
-            &leader_scheduler_config,
+            leader_scheduler,
         ));
         let (verified_sender, verified_receiver) = channel();
         let (to_validator_sender, to_validator_receiver) = channel();

--- a/src/entry_stream_stage.rs
+++ b/src/entry_stream_stage.rs
@@ -122,14 +122,19 @@ mod test {
 
     #[test]
     fn test_entry_stream_stage_process_entries() {
-        // Set up bank and leader_scheduler
+        // Set up the bank and leader_scheduler
         let ticks_per_slot = 5;
         let leader_scheduler_config = LeaderSchedulerConfig::new(ticks_per_slot, 2, 10);
+        let leader_scheduler =
+            Arc::new(RwLock::new(LeaderScheduler::new(&leader_scheduler_config)));
+
+        // Side-effect: Register a bank with the leader_scheduler
         let (genesis_block, _mint_keypair) = GenesisBlock::new(1_000_000);
-        let bank = Bank::new_with_leader_scheduler_config(&genesis_block, &leader_scheduler_config);
+        Bank::new_with_leader_scheduler(&genesis_block, leader_scheduler.clone());
+
         // Set up entry stream
         let mut entry_stream =
-            EntryStream::new("test_stream".to_string(), bank.leader_scheduler.clone());
+            EntryStream::new("test_stream".to_string(), leader_scheduler.clone());
 
         // Set up dummy channels to host an EntryStreamStage
         let (ledger_entry_sender, ledger_entry_receiver) = channel();

--- a/src/tpu.rs
+++ b/src/tpu.rs
@@ -8,6 +8,7 @@ use crate::broadcast_service::BroadcastService;
 use crate::cluster_info::ClusterInfo;
 use crate::cluster_info_vote_listener::ClusterInfoVoteListener;
 use crate::fetch_stage::FetchStage;
+use crate::leader_scheduler::LeaderScheduler;
 use crate::poh_service::PohServiceConfig;
 use crate::service::Service;
 use crate::sigverify_stage::SigVerifyStage;
@@ -152,6 +153,7 @@ impl Tpu {
         last_entry_id: &Hash,
         to_validator_sender: &TpuRotationSender,
         blocktree: &Arc<Blocktree>,
+        leader_scheduler: &Arc<RwLock<LeaderScheduler>>,
     ) {
         self.close_and_forward_unprocessed_packets();
 
@@ -188,7 +190,7 @@ impl Tpu {
             broadcast_socket,
             self.cluster_info.clone(),
             blob_index,
-            bank.leader_scheduler.clone(),
+            leader_scheduler.clone(),
             entry_receiver,
             max_tick_height,
             self.exit.clone(),

--- a/tests/multinode.rs
+++ b/tests/multinode.rs
@@ -8,7 +8,7 @@ use solana::cluster_info::{Node, NodeInfo};
 use solana::entry::{reconstruct_entries_from_blobs, Entry};
 use solana::fullnode::{new_bank_from_ledger, Fullnode, FullnodeConfig, FullnodeReturnType};
 use solana::gossip_service::{converge, make_listening_node};
-use solana::leader_scheduler::{make_active_set_entries, LeaderSchedulerConfig};
+use solana::leader_scheduler::{make_active_set_entries, LeaderScheduler, LeaderSchedulerConfig};
 use solana::result;
 use solana::service::Service;
 use solana::thin_client::{poll_gossip_for_leader, retry_get_balance};
@@ -1010,7 +1010,7 @@ fn test_leader_to_validator_transition() {
     let bank = new_bank_from_ledger(
         &leader_ledger_path,
         &BlocktreeConfig::default(),
-        &LeaderSchedulerConfig::default(),
+        &Arc::new(RwLock::new(LeaderScheduler::default())),
     )
     .0;
 


### PR DESCRIPTION
#### Problem

The bank is updating state in the leader scheduler every tick, but the leader scheduler should only be used to generate leader schedules, which happens once an epoch.

#### Summary of Changes

This is the first in what hopefully will be a landslide of related changes. Ultimately, we should end up with:

```rust
if tick_height % (ticks_per_slot * ticks_per_epoch) == 0 {
    let slot_leaders: Vec<Pubkey> = leader_scheduler.refresh(tick_height, &bank);
}
```

and that list should become active at the start of the following epoch
