### PR TITLE
Boot leader scheduler from the bank

### DIFF
--- a/src/bank.rs
+++ b/src/bank.rs
@@ -830,14 +830,6 @@ impl Bank {
             .collect()
     }
 
-    #[cfg(test)]
-    fn get_current_leader(&self) -> Option<Pubkey> {
-        let tick_height = self.tick_height();
-        let leader_scheduler = self.leader_scheduler.read().unwrap();
-        let slot = leader_scheduler.tick_height_to_slot(tick_height);
-        leader_scheduler.get_leader_for_slot(slot)
-    }
-
     pub fn tick_height(&self) -> u64 {
         self.last_id_queue.read().unwrap().tick_height
     }
@@ -1142,7 +1134,6 @@ mod tests {
         let bank = Bank::new(&genesis_block);
         assert_eq!(bank.get_balance(&genesis_block.mint_id), 3);
         assert_eq!(bank.get_balance(&dummy_leader_id), 1);
-        assert_eq!(bank.get_current_leader(), Some(dummy_leader_id));
     }
 
     fn create_sample_block_with_next_entries_using_keypairs(

--- a/src/bank.rs
+++ b/src/bank.rs
@@ -123,18 +123,6 @@ impl Bank {
         bank
     }
 
-    pub fn new_with_leader_scheduler(
-        genesis_block: &GenesisBlock,
-        leader_scheduler: Arc<RwLock<LeaderScheduler>>,
-    ) -> Self {
-        let bank = Bank::new(genesis_block);
-        leader_scheduler
-            .write()
-            .unwrap()
-            .update_tick_height(0, &bank);
-        bank
-    }
-
     pub fn set_subscriptions(&self, subscriptions: Arc<RpcSubscriptions>) {
         let mut sub = self.subscriptions.write().unwrap();
         *sub = Some(subscriptions)

--- a/src/entry_stream.rs
+++ b/src/entry_stream.rs
@@ -166,9 +166,10 @@ mod test {
         // Set up bank and leader_scheduler
         let leader_scheduler_config = LeaderSchedulerConfig::new(5, 2, 10);
         let (genesis_block, _mint_keypair) = GenesisBlock::new(1_000_000);
-        let leader_scheduler =
-            Arc::new(RwLock::new(LeaderScheduler::new(&leader_scheduler_config)));
-        let bank = Bank::new_with_leader_scheduler(&genesis_block, leader_scheduler.clone());
+        let bank = Bank::new(&genesis_block);
+        let leader_scheduler = LeaderScheduler::new_with_bank(&leader_scheduler_config, &bank);
+        let leader_scheduler = Arc::new(RwLock::new(leader_scheduler));
+
         // Set up entry stream
         let entry_stream =
             MockEntryStream::new("test_stream".to_string(), leader_scheduler.clone());

--- a/src/entry_stream_stage.rs
+++ b/src/entry_stream_stage.rs
@@ -124,13 +124,12 @@ mod test {
     fn test_entry_stream_stage_process_entries() {
         // Set up the bank and leader_scheduler
         let ticks_per_slot = 5;
-        let leader_scheduler_config = LeaderSchedulerConfig::new(ticks_per_slot, 2, 10);
-        let leader_scheduler =
-            Arc::new(RwLock::new(LeaderScheduler::new(&leader_scheduler_config)));
 
-        // Side-effect: Register a bank with the leader_scheduler
         let (genesis_block, _mint_keypair) = GenesisBlock::new(1_000_000);
-        Bank::new_with_leader_scheduler(&genesis_block, leader_scheduler.clone());
+        let bank = Bank::new(&genesis_block);
+        let leader_scheduler_config = LeaderSchedulerConfig::new(ticks_per_slot, 2, 10);
+        let leader_scheduler = LeaderScheduler::new_with_bank(&leader_scheduler_config, &bank);
+        let leader_scheduler = Arc::new(RwLock::new(leader_scheduler));
 
         // Set up entry stream
         let mut entry_stream =

--- a/src/fullnode.rs
+++ b/src/fullnode.rs
@@ -466,7 +466,11 @@ pub fn new_bank_from_ledger(
             .expect("Expected to successfully open database ledger");
     let genesis_block =
         GenesisBlock::load(ledger_path).expect("Expected to successfully open genesis block");
-    let bank = Bank::new_with_leader_scheduler(&genesis_block, leader_scheduler.clone());
+    let bank = Bank::new(&genesis_block);
+    leader_scheduler
+        .write()
+        .unwrap()
+        .update_tick_height(0, &bank);
 
     let now = Instant::now();
     info!("processing ledger...");

--- a/src/fullnode.rs
+++ b/src/fullnode.rs
@@ -471,7 +471,8 @@ pub fn new_bank_from_ledger(
     let now = Instant::now();
     info!("processing ledger...");
     let (entry_height, last_entry_id) =
-        blocktree_processor::process_blocktree(&bank, &blocktree).expect("process_blocktree");
+        blocktree_processor::process_blocktree(&bank, &blocktree, leader_scheduler)
+            .expect("process_blocktree");
     info!(
         "processed {} ledger entries in {}ms, tick_height={}...",
         entry_height,

--- a/src/leader_scheduler.rs
+++ b/src/leader_scheduler.rs
@@ -592,6 +592,19 @@ pub mod tests {
     }
 
     #[test]
+    fn test_leader_after_genesis() {
+        solana_logger::setup();
+        let leader_id = Keypair::new().pubkey();
+        let leader_tokens = 2;
+        let (genesis_block, _) = GenesisBlock::new_with_leader(5, leader_id, leader_tokens);
+        let leader_scheduler = Arc::new(RwLock::new(LeaderScheduler::default()));
+        let bank = Bank::new_with_leader_scheduler(&genesis_block, leader_scheduler.clone());
+        let leader_scheduler = leader_scheduler.read().unwrap();
+        let slot = leader_scheduler.tick_height_to_slot(bank.tick_height());
+        assert_eq!(leader_scheduler.get_leader_for_slot(slot), Some(leader_id));
+    }
+
+    #[test]
     fn test_num_ticks_left_in_block() {
         let leader_scheduler = LeaderScheduler::new(&LeaderSchedulerConfig::new(10, 2, 1));
 

--- a/src/replay_stage.rs
+++ b/src/replay_stage.rs
@@ -783,13 +783,12 @@ mod test {
         }
 
         let genesis_block = GenesisBlock::new(10_000).0;
-        let leader_scheduler = Arc::new(RwLock::new(LeaderScheduler::default()));
         let my_keypair = Arc::new(my_keypair);
         let voting_keypair = Arc::new(VotingKeypair::new_local(&my_keypair));
-        let bank = Arc::new(Bank::new_with_leader_scheduler(
-            &genesis_block,
-            leader_scheduler.clone(),
-        ));
+        let bank = Arc::new(Bank::new(&genesis_block));
+        let leader_scheduler_config = LeaderSchedulerConfig::default();
+        let leader_scheduler = LeaderScheduler::new_with_bank(&leader_scheduler_config, &bank);
+        let leader_scheduler = Arc::new(RwLock::new(leader_scheduler));
         let res = ReplayStage::process_entries(
             entries.clone(),
             &bank,
@@ -812,10 +811,9 @@ mod test {
             entries.push(entry);
         }
 
-        let bank = Arc::new(Bank::new_with_leader_scheduler(
-            &genesis_block,
-            leader_scheduler.clone(),
-        ));
+        let bank = Arc::new(Bank::new(&genesis_block));
+        let leader_scheduler = LeaderScheduler::new_with_bank(&leader_scheduler_config, &bank);
+        let leader_scheduler = Arc::new(RwLock::new(leader_scheduler));
         let res = ReplayStage::process_entries(
             entries.clone(),
             &bank,

--- a/src/replay_stage.rs
+++ b/src/replay_stage.rs
@@ -110,7 +110,7 @@ impl ReplayStage {
             // If we don't process the entry now, the for loop will exit and the entry
             // will be dropped.
             if 0 == num_ticks_to_next_vote || (i + 1) == entries.len() {
-                res = bank.process_entries(&entries[0..=i]);
+                res = bank.process_entries(&entries[0..=i], leader_scheduler);
 
                 if res.is_err() {
                     // TODO: This will return early from the first entry that has an erroneous

--- a/src/tvu.rs
+++ b/src/tvu.rs
@@ -245,11 +245,10 @@ pub mod tests {
 
         let starting_balance = 10_000;
         let (genesis_block, _mint_keypair) = GenesisBlock::new(starting_balance);
-        let leader_scheduler = Arc::new(RwLock::new(LeaderScheduler::default()));
-        let bank = Arc::new(Bank::new_with_leader_scheduler(
-            &genesis_block,
-            leader_scheduler.clone(),
-        ));
+        let bank = Arc::new(Bank::new(&genesis_block));
+        let leader_scheduler_config = LeaderSchedulerConfig::default();
+        let leader_scheduler = LeaderScheduler::new_with_bank(&leader_scheduler_config, &bank);
+        let leader_scheduler = Arc::new(RwLock::new(leader_scheduler));
 
         //start cluster_info1
         let mut cluster_info1 = ClusterInfo::new(target1.info.clone());
@@ -340,12 +339,11 @@ pub mod tests {
         let starting_balance = 10_000;
         let (genesis_block, mint_keypair) = GenesisBlock::new(starting_balance);
         let tvu_addr = target1.info.tvu;
-        let leader_scheduler =
-            Arc::new(RwLock::new(LeaderScheduler::new(&leader_scheduler_config)));
-        let bank = Arc::new(Bank::new_with_leader_scheduler(
-            &genesis_block,
-            leader_scheduler.clone(),
-        ));
+        let bank = Arc::new(Bank::new(&genesis_block));
+        let leader_scheduler = Arc::new(RwLock::new(LeaderScheduler::new_with_bank(
+            &leader_scheduler_config,
+            &bank,
+        )));
         assert_eq!(bank.get_balance(&mint_keypair.pubkey()), starting_balance);
 
         // start cluster_info1


### PR DESCRIPTION
#### Problem

Leader scheduler is implicitly updated from `Bank::register_tick()`. It should only be updated at epoch boundaries. 

### Proposed changes

* Make leader scheduler updates explicit. It's used in process_entries() under the assumption that is pulled out of the bank and turned into process_blobs(), where it should reject blobs from unexpected leaders.  Until then, it's just there doing the same useless thing it was doing before.
* Functional change: the leader scheduler is no longer implicitly
updated by PohRecorder via register_tick(). That's intended to
be a "feature" (crossing fingers).
* Flip the dependencies between LeaderScheduler and Bank constructers; Bank first