### PR TITLE
Add top-level ./run.sh for quick local cluster bring-up

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,11 @@ Build
 $ cargo build --all
 ```
 
+Then to run a minimal local cluster
+```bash
+$ ./run.sh
+```
+
 Testing
 ---
 

--- a/ci/testnet-deploy.sh
+++ b/ci/testnet-deploy.sh
@@ -51,7 +51,7 @@ Deploys a CD testnet
    -d [disk-type]       - Specify a boot disk type (default None) Use pd-ssd to get ssd on GCE.
    -D                   - Delete the network
    -r                   - Reuse existing node/ledger configuration from a
-                          previous |start| (ie, don't run ./mulitnode-demo/setup.sh).
+                          previous |start| (ie, don't run ./multinode-demo/setup.sh).
 
    Note: the SOLANA_METRICS_CONFIG environment variable is used to configure
          metrics

--- a/fullnode-config/src/main.rs
+++ b/fullnode-config/src/main.rs
@@ -2,7 +2,7 @@ use solana_sdk::signature::read_pkcs8;
 use std::io;
 
 fn main() {
-    let matches = clap::App::new("fullnode-config")
+    let matches = clap::App::new("solana-fullnode-config")
         .version(clap::crate_version!())
         .arg(
             clap::Arg::with_name("local")

--- a/fullnode/src/main.rs
+++ b/fullnode/src/main.rs
@@ -126,7 +126,7 @@ fn main() {
     solana_logger::setup();
     solana_metrics::set_panic_hook("fullnode");
 
-    let matches = App::new("fullnode")
+    let matches = App::new("solana-fullnode")
         .version(crate_version!())
         .arg(
             Arg::with_name("entry_stream")

--- a/net/net.sh
+++ b/net/net.sh
@@ -35,7 +35,7 @@ Operate a configured testnet
    -f [cargoFeatures]          - List of |cargo --feaures=| to activate
                                  (ignored if -s or -S is specified)
    -r                          - Reuse existing node/ledger configuration from a
-                                 previous |start| (ie, don't run ./mulitnode-demo/setup.sh).
+                                 previous |start| (ie, don't run ./multinode-demo/setup.sh).
 
  sanity/start/update-specific options:
    -o noLedgerVerify    - Skip ledger verification

--- a/run.sh
+++ b/run.sh
@@ -8,7 +8,7 @@
 set -e
 
 # Prefer possible `cargo build --all` binaries over PATH binaries
-PATH=$PWD/target/debug:$PATH
+PATH=$PWD/targt/debug:$PATH
 
 ok=true
 for program in solana-{genesis,keygen,fullnode{,-config}}; do
@@ -16,7 +16,10 @@ for program in solana-{genesis,keygen,fullnode{,-config}}; do
 done
 $ok || {
   echo
-  echo "Unable to locate required programs.  Try running: cargo build --all"
+  echo "Unable to locate required programs.  Try building them first with:"
+  echo
+  echo "  $ cargo build --all"
+  echo
   exit 1
 }
 

--- a/sdk/docker-solana/Dockerfile
+++ b/sdk/docker-solana/Dockerfile
@@ -9,5 +9,5 @@ RUN apt update && \
     rm -rf /var/lib/apt/lists/*
 
 COPY usr/bin /usr/bin/
-ENTRYPOINT [ "/usr/bin/solana-entrypoint.sh" ]
+ENTRYPOINT [ "/usr/bin/solana-run.sh" ]
 CMD [""]

--- a/sdk/docker-solana/build.sh
+++ b/sdk/docker-solana/build.sh
@@ -14,7 +14,7 @@ rm -rf usr/
 ../../ci/docker-run.sh solanalabs/rust:1.31.0 \
   scripts/cargo-install-all.sh sdk/docker-solana/usr
 
-cp -f entrypoint.sh usr/bin/solana-entrypoint.sh
+cp -f ../../run.sh usr/bin/solana-run.sh
 
 docker build -t solanalabs/solana:"$CHANNEL" .
 


### PR DESCRIPTION
Starting up a local minimal cluster for basic integration/sdk/blockexplorer development and test was too hard.  The docker entrypoint script, `sdk/docker-solana/entrypoint.sh`, solved this problem nicely but was hiding within the docker container and not readily available for non-docker use.   This PR promotes this hidden gem to the root of the tree for easy use by both docker and humans.

#### Old method:
```bash
$ ./multinode-demo/setup.sh
$ ./multinode-demo/drone.sh  # <-- run in shell 1
$ ./multinode-demo/bootstrap-leader.sh # <-- run in shell 2
```
then when you kill `bootstrap-leader.sh` in shell 2 don't forget to kill `drone.sh` in shell 1.  Or worse run `drone.sh` in the background of shell 1.  Either way 🤕 

#### New method:
```bash
$ ./run.sh
```
