### PR TITLE
Add a way to make a DAG of checkpointed Banks

### DIFF
--- a/src/bank.rs
+++ b/src/bank.rs
@@ -98,6 +98,8 @@ pub struct Bank {
     last_id_queue: RwLock<LastIdQueue>,
 
     subscriptions: RwLock<Option<Arc<RpcSubscriptions>>>,
+
+    parent: Option<Arc<Bank>>,
 }
 
 impl Default for Bank {
@@ -107,6 +109,7 @@ impl Default for Bank {
             last_id_queue: RwLock::new(LastIdQueue::default()),
             status_cache: RwLock::new(BankStatusCache::default()),
             subscriptions: RwLock::new(None),
+            parent: None,
         }
     }
 }
@@ -117,6 +120,17 @@ impl Bank {
         bank.process_genesis_block(genesis_block);
         bank.add_builtin_programs();
         bank
+    }
+
+    pub fn new_from_parent(parent: Arc<Bank>) -> Self {
+        let mut bank = Self::default();
+        bank.parent = Some(parent);
+        bank
+    }
+
+    /// Return the more recent checkpoint of this bank instance.
+    pub fn parent(&self) -> Option<Arc<Bank>> {
+        self.parent.clone()
     }
 
     pub fn set_subscriptions(&self, subscriptions: Arc<RpcSubscriptions>) {
@@ -130,6 +144,7 @@ impl Bank {
             status_cache: RwLock::new(self.status_cache.read().unwrap().clone()),
             last_id_queue: RwLock::new(self.last_id_queue.read().unwrap().clone()),
             subscriptions: RwLock::new(None),
+            parent: self.parent.clone(),
         }
     }
 

--- a/src/bank_forks.rs
+++ b/src/bank_forks.rs
@@ -1,0 +1,74 @@
+//! The `bank_forks` module implments BankForks a DAG of checkpointed Banks
+
+use crate::bank::Bank;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+pub struct BankForks {
+    working_bank_id: u64,
+    banks: HashMap<u64, Arc<Bank>>,
+}
+
+impl BankForks {
+    pub fn new(bank: Bank) -> Self {
+        let mut banks = HashMap::new();
+        let working_bank_id = bank.tick_height();
+        banks.insert(working_bank_id, Arc::new(bank));
+        Self {
+            working_bank_id,
+            banks,
+        }
+    }
+
+    pub fn working_bank(&self) -> Arc<Bank> {
+        self.banks[&self.working_bank_id].clone()
+    }
+
+    pub fn finalized_bank(&self) -> Arc<Bank> {
+        let mut bank = self.working_bank();
+        while let Some(parent) = bank.parent() {
+            bank = parent;
+        }
+        bank
+    }
+
+    pub fn insert(&mut self, bank: Bank) -> u64 {
+        let bank_id = bank.tick_height();
+        self.banks.insert(bank_id, Arc::new(bank));
+        bank_id
+    }
+
+    pub fn set_working_bank_id(&mut self, bank_id: u64) {
+        if self.banks.contains_key(&bank_id) {
+            self.working_bank_id = bank_id;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use solana_sdk::hash::Hash;
+
+    #[test]
+    fn test_bank_forks_root() {
+        let bank = Bank::default();
+        let tick_height = bank.tick_height();
+        let bank_forks = BankForks::new(bank);
+        assert_eq!(bank_forks.working_bank().tick_height(), tick_height);
+        assert_eq!(bank_forks.finalized_bank().tick_height(), tick_height);
+    }
+
+    #[test]
+    fn test_bank_forks_parent() {
+        let bank = Bank::default();
+        let finalized_bank_id = bank.tick_height();
+        let mut bank_forks = BankForks::new(bank);
+        let child_bank = Bank::new_from_parent(bank_forks.working_bank());
+        child_bank.register_tick(&Hash::default());
+        let child_bank_id = bank_forks.insert(child_bank);
+        bank_forks.set_working_bank_id(child_bank_id);
+        assert_eq!(bank_forks.working_bank().tick_height(), child_bank_id);
+        assert_eq!(bank_forks.finalized_bank().tick_height(), finalized_bank_id);
+    }
+}

--- a/src/blocktree_processor.rs
+++ b/src/blocktree_processor.rs
@@ -1,4 +1,5 @@
 use crate::bank::{Bank, BankError, Result};
+use crate::bank_forks::BankForks;
 use crate::blocktree::Blocktree;
 use crate::counter::Counter;
 use crate::entry::{Entry, EntrySlice};
@@ -188,12 +189,12 @@ where
 }
 
 pub fn process_blocktree(
-    bank: &Bank,
+    bank_forks: &BankForks,
     blocktree: &Blocktree,
     leader_scheduler: &Arc<RwLock<LeaderScheduler>>,
 ) -> Result<(u64, Hash)> {
     let entries = blocktree.read_ledger().expect("opening ledger");
-    process_ledger(&bank, entries, leader_scheduler)
+    process_ledger(&bank_forks.working_bank(), entries, leader_scheduler)
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@
 pub mod counter;
 pub mod accounts;
 pub mod bank;
+pub mod bank_forks;
 pub mod banking_stage;
 pub mod blob_fetch_stage;
 pub mod bloom;

--- a/src/replay_stage.rs
+++ b/src/replay_stage.rs
@@ -467,7 +467,6 @@ mod test {
             let (rotation_sender, rotation_receiver) = channel();
             let meta = blocktree.meta(0).unwrap().unwrap();
             let exit = Arc::new(AtomicBool::new(false));
-            let bank = Arc::new(bank);
             let blocktree = Arc::new(blocktree);
             let (replay_stage, ledger_writer_recv) = ReplayStage::new(
                 my_id,
@@ -573,7 +572,6 @@ mod test {
                     &leader_scheduler,
                 );
 
-            let bank = Arc::new(bank);
             let blocktree = Arc::new(blocktree);
             let (replay_stage, ledger_writer_recv) = ReplayStage::new(
                 my_keypair.pubkey(),
@@ -700,7 +698,6 @@ mod test {
                 .expect("First slot metadata must exist");
 
             let voting_keypair = Arc::new(voting_keypair);
-            let bank = Arc::new(bank);
             let blocktree = Arc::new(blocktree);
             let (replay_stage, ledger_writer_recv) = ReplayStage::new(
                 my_keypair.pubkey(),


### PR DESCRIPTION
#### Problem

If a Blocktree contains forks, there's no way to represent it with a single bank, which is what `blocktree_processor::process_blocktree()` returns.

Also, pubsub is in the Bank, but it should be up a level, somewhere with access to multiple forks.

#### Summary of Changes

Add an object, BankForks, that can manage multiple Bank instances. This isn't much, just a shell, but we can flesh it out in several different directions. We can do checkpointing, rollback, pubsub over multiple forks, leader rotation on finalized checkpoints, and finish up `process_blocktree()` to support Blocktrees with forks.

Note: I didn't end up using the names from book. Instead of `active_fork()`, I used `working_bank()` (it feels like git's working directory). Instead of `root()`, I used `finalized_bank()` (it just seemed more concrete).