### PR TITLE
Kill Bank::copy_for_tpu in favor of Bank::new_from_parent

### DIFF
--- a/src/bank.rs
+++ b/src/bank.rs
@@ -139,16 +139,6 @@ impl Bank {
         *sub = Some(subscriptions)
     }
 
-    pub fn copy_for_tpu(&self) -> Self {
-        Self {
-            accounts: self.accounts.copy_for_tpu(),
-            status_cache: RwLock::new(self.status_cache.read().unwrap().clone()),
-            last_id_queue: RwLock::new(self.last_id_queue.read().unwrap().clone()),
-            subscriptions: RwLock::new(None),
-            parent: self.parent.clone(),
-        }
-    }
-
     pub fn process_genesis_block(&self, genesis_block: &GenesisBlock) {
         assert!(genesis_block.mint_id != Pubkey::default());
         assert!(genesis_block.bootstrap_leader_id != Pubkey::default());

--- a/src/bank.rs
+++ b/src/bank.rs
@@ -122,10 +122,10 @@ impl Bank {
         bank
     }
 
-    pub fn new_from_parent(parent: Arc<Bank>) -> Self {
+    pub fn new_from_parent(parent: &Arc<Bank>) -> Self {
         let mut bank = Self::default();
         bank.last_id_queue = RwLock::new(parent.last_id_queue.read().unwrap().clone());
-        bank.parent = Some(parent);
+        bank.parent = Some(parent.clone());
         bank
     }
 
@@ -1102,7 +1102,7 @@ mod tests {
         let (genesis_block, _) = GenesisBlock::new(1);
         let parent = Arc::new(Bank::new(&genesis_block));
 
-        let bank = Bank::new_from_parent(parent.clone());
+        let bank = Bank::new_from_parent(&parent);
         assert!(Arc::ptr_eq(&bank.parents()[0], &parent));
     }
 
@@ -1121,7 +1121,7 @@ mod tests {
             0,
         );
         assert_eq!(parent.process_transaction(&tx), Ok(()));
-        let bank = Bank::new_from_parent(parent);
+        let bank = Bank::new_from_parent(&parent);
         assert_eq!(
             bank.process_transaction(&tx),
             Err(BankError::DuplicateSignature)
@@ -1144,9 +1144,10 @@ mod tests {
             0,
         );
         assert_eq!(parent.process_transaction(&tx), Ok(()));
-        let bank = Bank::new_from_parent(parent);
+        let bank = Bank::new_from_parent(&parent);
         let tx = SystemTransaction::new_move(&key1, key2.pubkey(), 1, genesis_block.last_id(), 0);
         assert_eq!(bank.process_transaction(&tx), Ok(()));
+        assert_eq!(parent.get_signature_status(&tx.signatures[0]), None);
     }
 
 }

--- a/src/bank_forks.rs
+++ b/src/bank_forks.rs
@@ -64,7 +64,7 @@ mod tests {
         let bank = Bank::default();
         let finalized_bank_id = bank.tick_height();
         let mut bank_forks = BankForks::new(bank);
-        let child_bank = Bank::new_from_parent(bank_forks.working_bank());
+        let child_bank = Bank::new_from_parent(&bank_forks.working_bank());
         child_bank.register_tick(&Hash::default());
         let child_bank_id = bank_forks.insert(child_bank);
         bank_forks.set_working_bank_id(child_bank_id);

--- a/src/fullnode.rs
+++ b/src/fullnode.rs
@@ -363,10 +363,9 @@ impl Fullnode {
                 }
                 None => FullnodeReturnType::LeaderToLeaderRotation, // value doesn't matter here...
             };
-            let mut new: Arc<Bank> = Arc::new(Bank::new_from_parent(self.bank.clone()));
-            std::mem::swap(&mut self.bank, &mut new);
+            let tpu_bank = Arc::new(Bank::new_from_parent(self.bank.clone()));
             self.node_services.tpu.switch_to_leader(
-                &self.bank,
+                &tpu_bank,
                 PohServiceConfig::default(),
                 self.tpu_sockets
                     .iter()

--- a/src/fullnode.rs
+++ b/src/fullnode.rs
@@ -363,7 +363,7 @@ impl Fullnode {
                 }
                 None => FullnodeReturnType::LeaderToLeaderRotation, // value doesn't matter here...
             };
-            let tpu_bank = Arc::new(Bank::new_from_parent(self.bank.clone()));
+            let tpu_bank = Arc::new(Bank::new_from_parent(&self.bank));
             self.node_services.tpu.switch_to_leader(
                 &tpu_bank,
                 PohServiceConfig::default(),

--- a/src/fullnode.rs
+++ b/src/fullnode.rs
@@ -363,9 +363,10 @@ impl Fullnode {
                 }
                 None => FullnodeReturnType::LeaderToLeaderRotation, // value doesn't matter here...
             };
-
+            let mut new: Arc<Bank> = Arc::new(Bank::new_from_parent(self.bank.clone()));
+            std::mem::swap(&mut self.bank, &mut new);
             self.node_services.tpu.switch_to_leader(
-                &Arc::new(self.bank.copy_for_tpu()),
+                &self.bank,
                 PohServiceConfig::default(),
                 self.tpu_sockets
                     .iter()


### PR DESCRIPTION
#### Problem

copy_for_tpu is not a real fork and just clones the bank.  

#### Summary of Changes

Use Bank::new_from_parent

Fixes #