### PR TITLE
Add blockexplorer to non-perf testnets

### DIFF
--- a/ci/testnet-manager.sh
+++ b/ci/testnet-manager.sh
@@ -187,7 +187,7 @@ start() {
       NO_VALIDATOR_SANITY=1 \
       RUST_LOG=solana=info \
         ci/testnet-deploy.sh edge-testnet-solana-com ec2 us-west-1a \
-          -t "$CHANNEL_OR_TAG" -n 3 -c 0 -P -a eipalloc-0ccd4f2239886fa94 \
+          -t "$CHANNEL_OR_TAG" -n 3 -c 0 -u -P -a eipalloc-0ccd4f2239886fa94 \
           ${maybeReuseLedger:+-r} \
           ${maybeDelete:+-D}
     )
@@ -210,7 +210,7 @@ start() {
       NO_VALIDATOR_SANITY=1 \
       RUST_LOG=solana=info \
         ci/testnet-deploy.sh beta-testnet-solana-com ec2 us-west-1a \
-          -t "$CHANNEL_OR_TAG" -n 3 -c 0 -P -a eipalloc-0f286cf8a0771ce35 \
+          -t "$CHANNEL_OR_TAG" -n 3 -c 0 -u -P -a eipalloc-0f286cf8a0771ce35 \
           -b \
           ${maybeReuseLedger:+-r} \
           ${maybeDelete:+-D}
@@ -234,7 +234,7 @@ start() {
       NO_VALIDATOR_SANITY=1 \
       RUST_LOG=solana=info \
         ci/testnet-deploy.sh testnet-solana-com ec2 us-west-1a \
-          -t "$CHANNEL_OR_TAG" -n 3 -c 0 -P -a eipalloc-0fa502bf95f6f18b2 \
+          -t "$CHANNEL_OR_TAG" -n 3 -c 0 -u -P -a eipalloc-0fa502bf95f6f18b2 \
           -b \
           ${maybeReuseLedger:+-r} \
           ${maybeDelete:+-D}

--- a/net/common.sh
+++ b/net/common.sh
@@ -29,6 +29,8 @@ fullnodeIpList=()
 fullnodeIpListPrivate=()
 clientIpList=()
 clientIpListPrivate=()
+apiIpList=()
+apiIpListPrivate=()
 leaderRotation=
 
 buildSshOptions() {

--- a/net/ssh.sh
+++ b/net/ssh.sh
@@ -63,6 +63,15 @@ else
   done
 fi
 echo
+echo API nodes:
+if [[ ${#apiIpList[@]} -eq 0 ]]; then
+  echo "  None"
+else
+  for ipAddress in "${apiIpList[@]}"; do
+    printNode fullnode "$ipAddress"
+  done
+fi
+echo
 echo "Use |scp.sh| to transfer files to and from nodes"
 echo
 


### PR DESCRIPTION
The `net/` infra now supports creating a single "api node" for a testnet.  An api node is a non-voting fullnode that sports the standard RPC API as well as exports a local entry stream UNIX domain socket for use by the [block explorer](https://github.com/solana-labs/blockexplorer).   The latest blockexplorer [npmjs release](https://www.npmjs.com/package/@solana/blockexplorer) is also installed and started on the api node.

The three non-perf testnets, testnet-edge/testnet-beta/testnet, now run an api node (but of course this won't affect testnet-beta/testnet until the tip of master makes its way through the beta/stable release channels) 

