### PR TITLE
Remove the signal sender since its superfluous to a recv error.

### DIFF
--- a/src/blocktree.rs
+++ b/src/blocktree.rs
@@ -393,12 +393,12 @@ impl Blocktree {
         })
     }
 
-    pub fn open_with_signal(ledger_path: &str) -> Result<(Self, SyncSender<bool>, Receiver<bool>)> {
+    pub fn open_with_signal(ledger_path: &str) -> Result<(Self, Receiver<bool>)> {
         let mut blocktree = Self::open(ledger_path)?;
         let (signal_sender, signal_receiver) = sync_channel(1);
-        blocktree.new_blobs_signals = vec![signal_sender.clone()];
+        blocktree.new_blobs_signals = vec![signal_sender];
 
-        Ok((blocktree, signal_sender, signal_receiver))
+        Ok((blocktree, signal_receiver))
     }
 
     #[allow(clippy::trivially_copy_pass_by_ref)]
@@ -412,13 +412,13 @@ impl Blocktree {
     pub fn open_with_config_signal(
         ledger_path: &str,
         config: &BlocktreeConfig,
-    ) -> Result<(Self, SyncSender<bool>, Receiver<bool>)> {
+    ) -> Result<(Self, Receiver<bool>)> {
         let mut blocktree = Self::open(ledger_path)?;
         let (signal_sender, signal_receiver) = sync_channel(1);
-        blocktree.new_blobs_signals = vec![signal_sender.clone()];
+        blocktree.new_blobs_signals = vec![signal_sender];
         blocktree.ticks_per_slot = config.ticks_per_slot;
 
-        Ok((blocktree, signal_sender, signal_receiver))
+        Ok((blocktree, signal_receiver))
     }
 
     pub fn meta(&self, slot_height: u64) -> Result<Option<SlotMeta>> {
@@ -1855,7 +1855,7 @@ mod tests {
     pub fn test_new_blobs_signal() {
         // Initialize ledger
         let ledger_path = get_tmp_ledger_path("test_new_blobs_signal");
-        let (ledger, _, recvr) = Blocktree::open_with_signal(&ledger_path).unwrap();
+        let (ledger, recvr) = Blocktree::open_with_signal(&ledger_path).unwrap();
         let ledger = Arc::new(ledger);
 
         let entries_per_slot = 10;

--- a/src/fullnode.rs
+++ b/src/fullnode.rs
@@ -127,13 +127,8 @@ impl Fullnode {
         let leader_scheduler = Arc::new(RwLock::new(LeaderScheduler::new(
             &config.leader_scheduler_config,
         )));
-        let (
-            bank,
-            entry_height,
-            last_entry_id,
-            blocktree,
-            ledger_signal_receiver,
-        ) = new_bank_from_ledger(ledger_path, &config.ledger_config(), &leader_scheduler);
+        let (bank, entry_height, last_entry_id, blocktree, ledger_signal_receiver) =
+            new_bank_from_ledger(ledger_path, &config.ledger_config(), &leader_scheduler);
 
         info!("node info: {:?}", node.info);
         info!("node entrypoint_info: {:?}", entrypoint_info_option);
@@ -458,13 +453,7 @@ fn new_banks_from_blocktree(
     blocktree_path: &str,
     blocktree_config: &BlocktreeConfig,
     leader_scheduler: &Arc<RwLock<LeaderScheduler>>,
-) -> (
-    BankForks,
-    u64,
-    Hash,
-    Blocktree,
-    Receiver<bool>,
-) {
+) -> (BankForks, u64, Hash, Blocktree, Receiver<bool>) {
     let (blocktree, ledger_signal_receiver) =
         Blocktree::open_with_config_signal(blocktree_path, blocktree_config)
             .expect("Expected to successfully open database ledger");
@@ -503,20 +492,9 @@ pub fn new_bank_from_ledger(
     ledger_path: &str,
     ledger_config: &BlocktreeConfig,
     leader_scheduler: &Arc<RwLock<LeaderScheduler>>,
-) -> (
-    Arc<Bank>,
-    u64,
-    Hash,
-    Blocktree,
-    Receiver<bool>,
-) {
-    let (
-        bank_forks,
-        entry_height,
-        last_entry_id,
-        blocktree,
-        ledger_signal_receiver,
-    ) = new_banks_from_blocktree(ledger_path, ledger_config, leader_scheduler);
+) -> (Arc<Bank>, u64, Hash, Blocktree, Receiver<bool>) {
+    let (bank_forks, entry_height, last_entry_id, blocktree, ledger_signal_receiver) =
+        new_banks_from_blocktree(ledger_path, ledger_config, leader_scheduler);
     (
         bank_forks.working_bank(),
         entry_height,

--- a/src/replay_stage.rs
+++ b/src/replay_stage.rs
@@ -226,7 +226,7 @@ impl ReplayStage {
                     let timer = Duration::from_millis(100);
                     let e = ledger_signal_receiver.recv_timeout(timer);
                     match e {
-                        Err(RecvTimeoutError::Disconnected) => continue,
+                        Err(RecvTimeoutError::Timeout) => continue,
                         Err(_) => break,
                         Ok(_) => (),
                     };

--- a/src/replay_stage.rs
+++ b/src/replay_stage.rs
@@ -6,7 +6,6 @@ use crate::blocktree_processor;
 use crate::cluster_info::ClusterInfo;
 use crate::counter::Counter;
 use crate::entry::{Entry, EntryReceiver, EntrySender, EntrySlice};
-use std::sync::mpsc::RecvTimeoutError;
 use crate::leader_scheduler::LeaderScheduler;
 use crate::packet::BlobError;
 use crate::result::{Error, Result};
@@ -20,6 +19,7 @@ use solana_sdk::pubkey::Pubkey;
 use solana_sdk::timing::duration_as_ms;
 use solana_sdk::vote_transaction::VoteTransaction;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc::RecvTimeoutError;
 use std::sync::mpsc::{channel, Receiver};
 use std::sync::{Arc, RwLock};
 #[cfg(test)]
@@ -559,12 +559,11 @@ mod test {
         let (to_leader_sender, _) = channel();
         {
             let leader_scheduler = Arc::new(RwLock::new(LeaderScheduler::default()));
-            let (bank, entry_height, last_entry_id, blocktree, l_receiver) =
-                new_bank_from_ledger(
-                    &my_ledger_path,
-                    &BlocktreeConfig::default(),
-                    &leader_scheduler,
-                );
+            let (bank, entry_height, last_entry_id, blocktree, l_receiver) = new_bank_from_ledger(
+                &my_ledger_path,
+                &BlocktreeConfig::default(),
+                &leader_scheduler,
+            );
 
             let blocktree = Arc::new(blocktree);
             let (replay_stage, ledger_writer_recv) = ReplayStage::new(

--- a/src/tvu.rs
+++ b/src/tvu.rs
@@ -28,7 +28,7 @@ use solana_sdk::hash::Hash;
 use solana_sdk::signature::{Keypair, KeypairUtil};
 use std::net::UdpSocket;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::mpsc::{channel, Receiver, SyncSender};
+use std::sync::mpsc::{channel, Receiver};
 use std::sync::{Arc, RwLock};
 use std::thread;
 
@@ -77,7 +77,6 @@ impl Tvu {
         to_leader_sender: &TvuRotationSender,
         storage_state: &StorageState,
         entry_stream: Option<&String>,
-        ledger_signal_sender: SyncSender<bool>,
         ledger_signal_receiver: Receiver<bool>,
         leader_scheduler: Arc<RwLock<LeaderScheduler>>,
     ) -> Self {
@@ -129,7 +128,6 @@ impl Tvu {
             blob_index,
             l_last_entry_id.clone(),
             to_leader_sender,
-            ledger_signal_sender,
             ledger_signal_receiver,
             &leader_scheduler,
         );
@@ -258,7 +256,7 @@ pub mod tests {
 
         let cur_hash = Hash::default();
         let blocktree_path = get_tmp_ledger_path("test_tvu_exit");
-        let (blocktree, l_sender, l_receiver) = Blocktree::open_with_signal(&blocktree_path)
+        let (blocktree, l_receiver) = Blocktree::open_with_signal(&blocktree_path)
             .expect("Expected to successfully open ledger");
         let vote_account_keypair = Arc::new(Keypair::new());
         let voting_keypair = VotingKeypair::new_local(&vote_account_keypair);
@@ -282,7 +280,6 @@ pub mod tests {
             &sender,
             &StorageState::default(),
             None,
-            l_sender,
             l_receiver,
             leader_scheduler,
         );
@@ -356,7 +353,7 @@ pub mod tests {
         let mut cur_hash = Hash::default();
         let blocktree_path = get_tmp_ledger_path("test_replay");
 
-        let (blocktree, l_sender, l_receiver) =
+        let (blocktree, l_receiver) =
             Blocktree::open_with_config_signal(&blocktree_path, &blocktree_config)
                 .expect("Expected to successfully open ledger");
         let vote_account_keypair = Arc::new(Keypair::new());
@@ -381,7 +378,6 @@ pub mod tests {
             &sender,
             &StorageState::default(),
             None,
-            l_sender,
             l_receiver,
             leader_scheduler,
         );


### PR DESCRIPTION
#### Problem

Blocktree returns a sender channel with its receive channel.  It's not needed since recv_timeout can be used.

#### Summary of Changes

Remove the signal sender.

Fixes #
