### PR TITLE
Boot BankError::MaxHeightReached

### DIFF
--- a/src/bank.rs
+++ b/src/bank.rs
@@ -73,9 +73,6 @@ pub enum BankError {
 
     /// Transaction has a fee but has no signature present
     MissingSignatureForFee,
-
-    // Poh recorder hit the maximum tick height before leader rotation
-    MaxHeightReached,
 }
 
 pub type Result<T> = result::Result<T, BankError>;


### PR DESCRIPTION
#### Problem

`record_transactions()` used to be in the Bank and all bank functions return BankError. That code was therefore awkwardly shoehorning PohRecorderErrors into BankErrors. Yesterday, I hoisted that function up to BankingStage, where it's straightforward to use the PohRecorderError directly.

#### Summary of Changes

Remove the translation to BankError