### PR TITLE
Delete test_tvu_behind - bad ROI

### DIFF
--- a/src/tvu.rs
+++ b/src/tvu.rs
@@ -167,11 +167,6 @@ impl Tvu {
         }
     }
 
-    #[cfg(test)]
-    pub fn get_pause(&self) -> Arc<AtomicBool> {
-        self.replay_stage.get_pause()
-    }
-
     pub fn get_state(&self) -> Hash {
         *self.last_entry_id.read().unwrap()
     }


### PR DESCRIPTION
#### Problem

`test_tvu_behind` is in fullnode's unit-test suite, but it's an expensive integration test that creates a special test-only, pause-able version of the ReplayStage to run.

#### Summary of Changes

Delete it. We can consider resurrecting it as part of the integration test suite after we've reworked the new fork-aware pipeline. Alternatively, we might be able to leave it as only a fast-running unit-test in tvu.rs that doesn't interact with blocktree or any fetch stages.
