### PR TITLE
Add optional deploy of custom programs

### DIFF
--- a/net/net.sh
+++ b/net/net.sh
@@ -154,7 +154,7 @@ build() {
     $MAYBE_DOCKER bash -c "
       set -ex
       scripts/cargo-install-all.sh farf \"$cargoFeatures\"
-      if [[ -n \"$customPrograms\" ]]; then
+      if [[ -n $customPrograms ]]; then
         scripts/cargo-install-custom-programs.sh farf $customPrograms
       fi
     "

--- a/net/net.sh
+++ b/net/net.sh
@@ -36,6 +36,7 @@ Operate a configured testnet
                                  (ignored if -s or -S is specified)
    -r                          - Reuse existing node/ledger configuration from a
                                  previous |start| (ie, don't run ./multinode-demo/setup.sh).
+   -D /path/to/programs        - Deploy custom programs from this location
 
  sanity/start/update-specific options:
    -o noLedgerVerify    - Skip ledger verification
@@ -62,12 +63,13 @@ sanityExtraArgs=
 cargoFeatures=
 skipSetup=false
 updateNodes=false
+customPrograms=
 
 command=$1
 [[ -n $command ]] || usage
 shift
 
-while getopts "h?S:s:T:t:o:f:r" opt; do
+while getopts "h?S:s:T:t:o:f:r:D:" opt; do
   case $opt in
   h | \?)
     usage
@@ -110,6 +112,9 @@ while getopts "h?S:s:T:t:o:f:r" opt; do
   r)
     skipSetup=true
     ;;
+  D)
+    customPrograms=$OPTARG
+    ;;
   o)
     case $OPTARG in
     noLedgerVerify|noValidatorSanity|rejectExtraNodes)
@@ -149,6 +154,9 @@ build() {
     $MAYBE_DOCKER bash -c "
       set -ex
       scripts/cargo-install-all.sh farf \"$cargoFeatures\"
+      if [[ -n \"$customPrograms\" ]]; then
+        scripts/cargo-install-custom-programs.sh farf $customPrograms
+      fi
     "
   )
   echo "Build took $SECONDS seconds"

--- a/scripts/cargo-install-custom-programs.sh
+++ b/scripts/cargo-install-custom-programs.sh
@@ -17,7 +17,7 @@ programDir="$2"
 )
 
 for dir in "$programDir"/*; do
-  for program in echo $programDir/target/release/deps/lib"$(basename "$dir")".{so,dylib,dll}; do
+  for program in $programDir/target/release/deps/lib"$(basename "$dir")".{so,dylib,dll}; do
     if [[ -f $program ]]; then
       (
         set -x

--- a/scripts/cargo-install-custom-programs.sh
+++ b/scripts/cargo-install-custom-programs.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+#
+# This script will install all cargo workspace libraries found in
+# `programDir` as native programs.
+set -e
+
+# Directory to install libraries into
+installDir="$(mkdir -p "$1"; cd "$1"; pwd)"
+
+# Where to find custom programs
+programDir="$2"
+
+(
+  set -x
+  cd "$programDir"
+  cargo build --all --release
+)
+
+for dir in "$programDir"/*; do
+  for program in echo $programDir/target/release/deps/lib"$(basename "$dir")".{so,dylib,dll}; do
+    if [[ -f $program ]]; then
+      (
+        set -x
+        mkdir -p "$installDir/bin/deps"
+        rm -f "$installDir/bin/deps/$(basename "$program")"
+        cp -v "$program" "$installDir"/bin/deps
+      )
+    fi
+  done
+done


### PR DESCRIPTION
I found myself writing patches for `net/net.sh` to load custom "native" programs into a solana testnet. This pr generalizes that functionality for anyone to use by passing `-D /path/to/programs` with a `net.sh start` of `net.sh restart` command.
