### PR TITLE
Use slot height for BankForks ids

### DIFF
--- a/src/bank_forks.rs
+++ b/src/bank_forks.rs
@@ -10,9 +10,8 @@ pub struct BankForks {
 }
 
 impl BankForks {
-    pub fn new(bank: Bank) -> Self {
+    pub fn new(working_bank_id: u64, bank: Bank) -> Self {
         let mut banks = HashMap::new();
-        let working_bank_id = bank.tick_height();
         banks.insert(working_bank_id, Arc::new(bank));
         Self {
             working_bank_id,
@@ -32,10 +31,8 @@ impl BankForks {
         bank
     }
 
-    pub fn insert(&mut self, bank: Bank) -> u64 {
-        let bank_id = bank.tick_height();
+    pub fn insert(&mut self, bank_id: u64, bank: Bank) {
         self.banks.insert(bank_id, Arc::new(bank));
-        bank_id
     }
 
     pub fn set_working_bank_id(&mut self, bank_id: u64) {
@@ -54,7 +51,7 @@ mod tests {
     fn test_bank_forks_root() {
         let bank = Bank::default();
         let tick_height = bank.tick_height();
-        let bank_forks = BankForks::new(bank);
+        let bank_forks = BankForks::new(0, bank);
         assert_eq!(bank_forks.working_bank().tick_height(), tick_height);
         assert_eq!(bank_forks.finalized_bank().tick_height(), tick_height);
     }
@@ -63,10 +60,11 @@ mod tests {
     fn test_bank_forks_parent() {
         let bank = Bank::default();
         let finalized_bank_id = bank.tick_height();
-        let mut bank_forks = BankForks::new(bank);
+        let mut bank_forks = BankForks::new(0, bank);
         let child_bank = Bank::new_from_parent(&bank_forks.working_bank());
         child_bank.register_tick(&Hash::default());
-        let child_bank_id = bank_forks.insert(child_bank);
+        let child_bank_id = 1;
+        bank_forks.insert(child_bank_id, child_bank);
         bank_forks.set_working_bank_id(child_bank_id);
         assert_eq!(bank_forks.working_bank().tick_height(), child_bank_id);
         assert_eq!(bank_forks.finalized_bank().tick_height(), finalized_bank_id);

--- a/src/fullnode.rs
+++ b/src/fullnode.rs
@@ -457,7 +457,8 @@ fn new_banks_from_blocktree(
     let genesis_block =
         GenesisBlock::load(blocktree_path).expect("Expected to successfully open genesis block");
     let bank = Bank::new(&genesis_block);
-    let bank_forks = BankForks::new(bank);
+    let slot_height = 0; // Use the Bank's slot_height as its ID.
+    let bank_forks = BankForks::new(slot_height, bank);
     leader_scheduler
         .write()
         .unwrap()


### PR DESCRIPTION
#### Problem

BankForks was using `Bank::tick_height()` for its bank ids. That height is different depending on if you insert the bank before or after processing its block. If we use `slot_height` instead, it's the same in both cases.

#### Summary of Changes

No longer implicitly using `Bank::tick_height()`. Let the caller decide on the convention (which means BankForks doesn't have a LeaderScheduler dependency).
