### PR TITLE
ec2: automatically create security group and use public AMI for non-GPU testnets

### DIFF
--- a/net/gce.sh
+++ b/net/gce.sh
@@ -476,6 +476,8 @@ EOF
     bootstrapLeaderAddress=$customAddress
   fi
 
+  cloud_Initialize "$prefix"
+
   cloud_CreateInstances "$prefix" "$prefix-bootstrap-leader" 1 \
     "$imageName" "$bootstrapLeaderMachineType" "$fullNodeBootDiskSizeInGb" \
     "$startupScript" "$bootstrapLeaderAddress" "$bootDiskType"

--- a/net/gce.sh
+++ b/net/gce.sh
@@ -168,6 +168,11 @@ case $cloudProvider in
 gce)
   if $enableGpu; then
     # Custom Ubuntu 18.04 LTS image with CUDA 9.2 and CUDA 10.0 installed
+    #
+    # TODO: Unfortunately this image is not public.  When this becomes an issue,
+    # use the stock Ubuntu 18.04 image and programmatically install CUDA after the
+    # instance boots
+    #
     imageName="ubuntu-1804-bionic-v20181029-with-cuda-10-and-cuda-9-2"
   else
     # Upstream Ubuntu 18.04 LTS image
@@ -175,23 +180,45 @@ gce)
   fi
   ;;
 ec2)
-  #
-  # Custom Ubuntu 18.04 LTS image with CUDA 9.2 and CUDA 10.0 installed
-  #
-  case $region in # (region global variable is set by cloud_SetZone)
-  us-east-1)
-    imageName="ami-0a8bd6fb204473f78"
-    ;;
-  us-west-1)
-    imageName="ami-07011f0795513c59d"
-    ;;
-  us-west-2)
-    imageName="ami-0a11ef42b62b82b68"
-    ;;
-  *)
-    usage "Unsupported region: $region"
-    ;;
-  esac
+  if $enableGpu; then
+    #
+    # Custom Ubuntu 18.04 LTS image with CUDA 9.2 and CUDA 10.0 installed
+    #
+    # TODO: Unfortunately these AMIs are not public.  When this becomes an issue,
+    # use the stock Ubuntu 18.04 image and programmatically install CUDA after the
+    # instance boots
+    #
+    case $region in
+    us-east-1)
+      imageName="ami-0a8bd6fb204473f78"
+      ;;
+    us-west-1)
+      imageName="ami-07011f0795513c59d"
+      ;;
+    us-west-2)
+      imageName="ami-0a11ef42b62b82b68"
+      ;;
+    *)
+      usage "Unsupported region: $region"
+      ;;
+    esac
+  else
+    # Select an upstream Ubuntu 18.04 AMI from https://cloud-images.ubuntu.com/locator/ec2/
+    case $region in
+    us-east-1)
+      imageName="ami-0a313d6098716f372"
+      ;;
+    us-west-1)
+      imageName="ami-06397100adf427136"
+      ;;
+    us-west-2)
+      imageName="ami-0dc34f4b016c9ce49"
+      ;;
+    *)
+      usage "Unsupported region: $region"
+      ;;
+    esac
+  fi
   ;;
 *)
   echo "Error: Unknown cloud provider: $cloudProvider"

--- a/net/scripts/ec2-security-group-config.json
+++ b/net/scripts/ec2-security-group-config.json
@@ -1,0 +1,137 @@
+{
+    "IpPermissions": [
+        {
+            "PrefixListIds": [],
+            "FromPort": 80,
+            "IpRanges": [
+                {
+                    "CidrIp": "0.0.0.0/0",
+                    "Description": "http for block explorer"
+                }
+            ],
+            "ToPort": 80,
+            "IpProtocol": "tcp",
+            "UserIdGroupPairs": [],
+            "Ipv6Ranges": [
+                {
+                    "CidrIpv6": "::/0",
+                    "Description": "http for block explorer"
+                }
+            ]
+        },
+        {
+            "PrefixListIds": [],
+            "FromPort": 8000,
+            "IpRanges": [
+                {
+                    "Description": "fullnode UDP range",
+                    "CidrIp": "0.0.0.0/0"
+                }
+            ],
+            "ToPort": 10000,
+            "IpProtocol": "udp",
+            "UserIdGroupPairs": [],
+            "Ipv6Ranges": [
+                {
+                    "CidrIpv6": "::/0",
+                    "Description": "fullnode UDP range"
+                }
+            ]
+        },
+        {
+            "PrefixListIds": [],
+            "FromPort": 22,
+            "IpRanges": [
+                {
+                    "CidrIp": "0.0.0.0/0",
+                    "Description": "ssh"
+                }
+            ],
+            "ToPort": 22,
+            "IpProtocol": "tcp",
+            "UserIdGroupPairs": [],
+            "Ipv6Ranges": [
+                {
+                    "CidrIpv6": "::/0",
+                    "Description": "ssh"
+                }
+            ]
+        },
+        {
+            "PrefixListIds": [],
+            "FromPort": 873,
+            "IpRanges": [
+                {
+                    "Description": "rsync",
+                    "CidrIp": "0.0.0.0/0"
+                }
+            ],
+            "ToPort": 873,
+            "IpProtocol": "tcp",
+            "UserIdGroupPairs": [],
+            "Ipv6Ranges": [
+                {
+                    "CidrIpv6": "::/0",
+                    "Description": "rsync"
+                }
+            ]
+        },
+        {
+            "PrefixListIds": [],
+            "FromPort": 3001,
+            "IpRanges": [
+                {
+                    "Description": "blockexplorer API port",
+                    "CidrIp": "0.0.0.0/0"
+                }
+            ],
+            "ToPort": 3001,
+            "IpProtocol": "tcp",
+            "UserIdGroupPairs": [],
+            "Ipv6Ranges": [
+                {
+                    "CidrIpv6": "::/0",
+                    "Description": "blockexplorer API port"
+                }
+            ]
+        },
+        {
+            "PrefixListIds": [],
+            "FromPort": 8000,
+            "IpRanges": [
+                {
+                    "Description": "fullnode TCP range",
+                    "CidrIp": "0.0.0.0/0"
+                }
+            ],
+            "ToPort": 10000,
+            "IpProtocol": "tcp",
+            "UserIdGroupPairs": [],
+            "Ipv6Ranges": [
+                {
+                    "CidrIpv6": "::/0",
+                    "Description": "fullnode TCP range"
+                }
+            ]
+        },
+        {
+            "PrefixListIds": [],
+            "FromPort": 8,
+            "IpRanges": [
+                {
+                    "CidrIp": "0.0.0.0/0",
+                    "Description": "allow ping"
+                }
+            ],
+            "ToPort": -1,
+            "IpProtocol": "icmp",
+            "UserIdGroupPairs": [],
+            "Ipv6Ranges": [
+                {
+                    "CidrIpv6": "::/0",
+                    "Description": "allow ping"
+                }
+            ]
+        }
+    ]
+}

--- a/net/scripts/gce-provider.sh
+++ b/net/scripts/gce-provider.sh
@@ -77,6 +77,21 @@ cloud_FindInstance() {
 }
 
 #
+# cloud_Initialize [networkName]
+#
+# Perform one-time initialization that may be required for the given testnet.
+#
+# networkName   - unique name of this testnet
+#
+# This function will be called before |cloud_CreateInstances|
+cloud_Initialize() {
+  declare networkName="$1"
+  # ec2-provider.sh creates firewall rules programmatically, should to the same
+  # here.
+  echo "TODO: create $networkName firewall rules programmatically instead of assuming the 'testnet' tag exists"
+}
+
+#
 # cloud_CreateInstances [networkName] [namePrefix] [numNodes] [imageName]
 #                       [machineType] [bootDiskSize] [enableGpu]
 #                       [startupScript] [address]

--- a/net/scripts/gce-provider.sh
+++ b/net/scripts/gce-provider.sh
@@ -86,7 +86,7 @@ cloud_FindInstance() {
 # This function will be called before |cloud_CreateInstances|
 cloud_Initialize() {
   declare networkName="$1"
-  # ec2-provider.sh creates firewall rules programmatically, should to the same
+  # ec2-provider.sh creates firewall rules programmatically, should do the same
   # here.
   echo "TODO: create $networkName firewall rules programmatically instead of assuming the 'testnet' tag exists"
 }


### PR DESCRIPTION
For non-GPU testnets, this should remove all the magic EC2 configuration in the Solana AWS account.  We still have a bit of work to do for the GPU testnet, as well as for GCP (all marked as TODOs in the code)

@CriesofCarrots I'll cherrypick into v0.11 once this lands on master