### PR TITLE
Add LeaderSchedule struct

### DIFF
--- a/src/leader_schedule.rs
+++ b/src/leader_schedule.rs
@@ -1,0 +1,46 @@
+use crate::leader_scheduler::LeaderScheduler;
+
+use solana_sdk::pubkey::Pubkey;
+
+pub struct LeaderSchedule {
+    slot_leaders: Vec<Pubkey>,
+    ticks_per_slot: u64,
+    ticks_per_epoch: u64,
+    current_epoch: u64,
+}
+
+impl LeaderSchedule {
+    pub fn new(
+        slot_leaders: Vec<Pubkey>,
+        current_epoch: u64,
+        ticks_per_slot: u64,
+        ticks_per_epoch: u64,
+    ) -> LeaderSchedule {
+        LeaderSchedule {
+            current_epoch,
+            slot_leaders,
+            ticks_per_slot,
+            ticks_per_epoch,
+        }
+    }
+
+    pub fn get_leader_for_slot(&self, slot_height: u64) -> Option<Pubkey> {
+        let tick_height = slot_height * self.ticks_per_slot;
+        let epoch = LeaderScheduler::tick_height_to_epoch(tick_height, self.ticks_per_slot);
+
+        if epoch != self.current_epoch {
+            warn!(
+                "get_leader_for_slot: leader unknown for epoch {}, which is not equal to {}",
+                epoch, self.current_epoch
+            );
+            None
+        } else {
+            let first_tick_in_epoch = epoch * self.ticks_per_epoch;
+
+            let slot_index = (tick_height - first_tick_in_epoch) / self.ticks_per_slot;
+
+            // Round robin through each node in the schedule
+            Some(self.slot_leaders[slot_index as usize % self.slot_leaders.len()])
+        }
+    }
+}

--- a/src/leader_schedule.rs
+++ b/src/leader_schedule.rs
@@ -15,8 +15,8 @@ impl LeaderSchedule {
         current_epoch: u64,
         ticks_per_slot: u64,
         ticks_per_epoch: u64,
-    ) -> LeaderSchedule {
-        LeaderSchedule {
+    ) -> Self {
+        Self {
             current_epoch,
             slot_leaders,
             ticks_per_slot,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,7 @@ pub mod genesis_block;
 pub mod gossip_service;
 pub mod last_id_queue;
 pub mod leader_confirmation_service;
+pub mod leader_schedule;
 pub mod leader_scheduler;
 pub mod local_vote_signer_service;
 pub mod packet;


### PR DESCRIPTION
#### Problem
Updating the LeaderScheduler multiple times per epoch is unnecessary when it holds read-only data for the whole epoch. 

#### Summary of Changes
1) Add a LeaderSchedule struct containing the schedule for an epoch
2) Given a bank and a tick height, generate a LeaderSchedule struct for the epoch containing the tick_height

Fixes #
