### PR TITLE
Fix the custom programs command in net.sh

### DIFF
--- a/net/net.sh
+++ b/net/net.sh
@@ -154,7 +154,7 @@ build() {
     $MAYBE_DOCKER bash -c "
       set -ex
       scripts/cargo-install-all.sh farf \"$cargoFeatures\"
-      if [[ -n $customPrograms ]]; then
+      if [[ -n \"$customPrograms\" ]]; then
         scripts/cargo-install-custom-programs.sh farf $customPrograms
       fi
     "


### PR DESCRIPTION
#### Problem
net.sh was returning an error while launching testnet.

#### Summary of Changes
The customPrograms variable needed quotes. Otherwise command expansion was failing.

Fixes #2831 
