### PR TITLE
Move storage tests out of Bank

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2271,6 +2271,7 @@ dependencies = [
  "serde 1.0.88 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.88 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-logger 0.12.0",
+ "solana-runtime 0.12.0",
  "solana-sdk 0.12.0",
 ]
 

--- a/programs/native/storage/Cargo.toml
+++ b/programs/native/storage/Cargo.toml
@@ -16,6 +16,9 @@ serde_derive = "1.0.88"
 solana-logger = { path = "../../../logger", version = "0.12.0" }
 solana-sdk = { path = "../../../sdk", version = "0.12.0" }
 
+[dev-dependencies]
+solana-runtime = { path = "../../../runtime", version = "0.12.0" }
+
 [lib]
 name = "solana_storage_program"
 crate-type = ["cdylib"]

--- a/programs/native/storage/tests/storage.rs
+++ b/programs/native/storage/tests/storage.rs
@@ -1,0 +1,81 @@
+use bincode::deserialize;
+use log::info;
+use solana_runtime::bank::Bank;
+use solana_sdk::genesis_block::GenesisBlock;
+use solana_sdk::hash::{hash, Hash};
+use solana_sdk::signature::{Keypair, KeypairUtil, Signature};
+use solana_sdk::storage_program;
+use solana_sdk::storage_program::{StorageTransaction, ENTRIES_PER_SEGMENT};
+
+fn get_storage_entry_height(bank: &Bank) -> u64 {
+    match bank.get_account(&storage_program::system_id()) {
+        Some(storage_system_account) => {
+            let state = deserialize(&storage_system_account.userdata);
+            if let Ok(state) = state {
+                let state: storage_program::StorageProgramState = state;
+                return state.entry_height;
+            }
+        }
+        None => {
+            info!("error in reading entry_height");
+        }
+    }
+    0
+}
+
+fn get_storage_last_id(bank: &Bank) -> Hash {
+    if let Some(storage_system_account) = bank.get_account(&storage_program::system_id()) {
+        let state = deserialize(&storage_system_account.userdata);
+        if let Ok(state) = state {
+            let state: storage_program::StorageProgramState = state;
+            return state.id;
+        }
+    }
+    Hash::default()
+}
+
+#[test]
+fn test_bank_storage() {
+    let (genesis_block, alice) = GenesisBlock::new(1000);
+    let bank = Bank::new(&genesis_block);
+
+    let bob = Keypair::new();
+    let jack = Keypair::new();
+    let jill = Keypair::new();
+
+    let x = 42;
+    let last_id = hash(&[x]);
+    let x2 = x * 2;
+    let storage_last_id = hash(&[x2]);
+
+    bank.register_tick(&last_id);
+
+    bank.transfer(10, &alice, jill.pubkey(), last_id).unwrap();
+
+    bank.transfer(10, &alice, bob.pubkey(), last_id).unwrap();
+    bank.transfer(10, &alice, jack.pubkey(), last_id).unwrap();
+
+    let tx = StorageTransaction::new_advertise_last_id(
+        &bob,
+        storage_last_id,
+        last_id,
+        ENTRIES_PER_SEGMENT,
+    );
+
+    bank.process_transaction(&tx).unwrap();
+
+    let entry_height = 0;
+
+    let tx = StorageTransaction::new_mining_proof(
+        &jack,
+        Hash::default(),
+        last_id,
+        entry_height,
+        Signature::default(),
+    );
+
+    bank.process_transaction(&tx).unwrap();
+
+    assert_eq!(get_storage_entry_height(&bank), ENTRIES_PER_SEGMENT);
+    assert_eq!(get_storage_last_id(&bank), storage_last_id);
+}

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -615,11 +615,8 @@ mod tests {
     use super::*;
     use hashbrown::HashSet;
     use solana_sdk::genesis_block::BOOTSTRAP_LEADER_TOKENS;
-    use solana_sdk::hash::hash;
     use solana_sdk::native_program::ProgramError;
-    use solana_sdk::signature::Keypair;
-    use solana_sdk::signature::KeypairUtil;
-    use solana_sdk::storage_program::{StorageTransaction, ENTRIES_PER_SEGMENT};
+    use solana_sdk::signature::{Keypair, KeypairUtil};
     use solana_sdk::system_instruction::SystemInstruction;
     use solana_sdk::system_transaction::SystemTransaction;
     use solana_sdk::transaction::Instruction;
@@ -981,52 +978,6 @@ mod tests {
             storage_program::system_id(),
         ];
         assert!(ids.into_iter().all(move |id| unique.insert(id)));
-    }
-
-    #[test]
-    fn test_bank_storage() {
-        let (genesis_block, alice) = GenesisBlock::new(1000);
-        let bank = Bank::new(&genesis_block);
-
-        let bob = Keypair::new();
-        let jack = Keypair::new();
-        let jill = Keypair::new();
-
-        let x = 42;
-        let last_id = hash(&[x]);
-        let x2 = x * 2;
-        let storage_last_id = hash(&[x2]);
-
-        bank.register_tick(&last_id);
-
-        bank.transfer(10, &alice, jill.pubkey(), last_id).unwrap();
-
-        bank.transfer(10, &alice, bob.pubkey(), last_id).unwrap();
-        bank.transfer(10, &alice, jack.pubkey(), last_id).unwrap();
-
-        let tx = StorageTransaction::new_advertise_last_id(
-            &bob,
-            storage_last_id,
-            last_id,
-            ENTRIES_PER_SEGMENT,
-        );
-
-        bank.process_transaction(&tx).unwrap();
-
-        let entry_height = 0;
-
-        let tx = StorageTransaction::new_mining_proof(
-            &jack,
-            Hash::default(),
-            last_id,
-            entry_height,
-            Signature::default(),
-        );
-
-        bank.process_transaction(&tx).unwrap();
-
-        assert_eq!(bank.get_storage_entry_height(), ENTRIES_PER_SEGMENT);
-        assert_eq!(bank.get_storage_last_id(), storage_last_id);
     }
 
     #[test]


### PR DESCRIPTION
#### Problem

Storage program is cluttering the bank because that used to be the only way to test a program using the bank.

#### Summary of Changes

Move the storage tests to the storage crate and have it depend on solana-runtime for testing.
