### PR TITLE
Add ActiveStakers and primitive LeaderSchedule

### DIFF
--- a/src/active_stakers.rs
+++ b/src/active_stakers.rs
@@ -68,34 +68,35 @@ impl ActiveStakers {
 
 pub mod tests {
     use solana_runtime::bank::Bank;
-    use solana_sdk::hash::Hash;
+    use solana_sdk::pubkey::Pubkey;
     use solana_sdk::signature::{Keypair, KeypairUtil};
     use solana_sdk::vote_transaction::VoteTransaction;
 
-    pub fn new_vote_account<T: KeypairUtil>(
+    pub fn new_vote_account(
+        from_keypair: &Keypair,
+        voting_pubkey: &Pubkey,
+        bank: &Bank,
+        num_tokens: u64,
+    ) {
+        let last_id = bank.last_id();
+        let tx = VoteTransaction::new_account(from_keypair, *voting_pubkey, last_id, num_tokens, 0);
+        bank.process_transaction(&tx).unwrap();
+    }
+
+    pub fn push_vote<T: KeypairUtil>(voting_keypair: &T, bank: &Bank, tick_height: u64) {
+        let last_id = bank.last_id();
+        let tx = VoteTransaction::new_vote(voting_keypair, tick_height, last_id, 0);
+        bank.process_transaction(&tx).unwrap();
+    }
+
+    pub fn new_vote_account_with_vote<T: KeypairUtil>(
         from_keypair: &Keypair,
         voting_keypair: &T,
         bank: &Bank,
         num_tokens: u64,
-        last_id: Hash,
-    ) {
-        let tx = VoteTransaction::new_account(
-            from_keypair,
-            voting_keypair.pubkey(),
-            last_id,
-            num_tokens,
-            0,
-        );
-        bank.process_transaction(&tx).unwrap();
-    }
-
-    pub fn push_vote<T: KeypairUtil>(
-        voting_keypair: &T,
-        bank: &Bank,
         tick_height: u64,
-        last_id: Hash,
     ) {
-        let new_vote_tx = VoteTransaction::new_vote(voting_keypair, tick_height, last_id, 0);
-        bank.process_transaction(&new_vote_tx).unwrap();
+        new_vote_account(from_keypair, &voting_keypair.pubkey(), bank, num_tokens);
+        push_vote(voting_keypair, bank, tick_height);
     }
 }

--- a/src/active_stakers.rs
+++ b/src/active_stakers.rs
@@ -65,3 +65,37 @@ impl ActiveStakers {
         LeaderSchedule::new(self.pubkeys())
     }
 }
+
+pub mod tests {
+    use solana_runtime::bank::Bank;
+    use solana_sdk::hash::Hash;
+    use solana_sdk::signature::{Keypair, KeypairUtil};
+    use solana_sdk::vote_transaction::VoteTransaction;
+
+    pub fn new_vote_account<T: KeypairUtil>(
+        from_keypair: &Keypair,
+        voting_keypair: &T,
+        bank: &Bank,
+        num_tokens: u64,
+        last_id: Hash,
+    ) {
+        let tx = VoteTransaction::new_account(
+            from_keypair,
+            voting_keypair.pubkey(),
+            last_id,
+            num_tokens,
+            0,
+        );
+        bank.process_transaction(&tx).unwrap();
+    }
+
+    pub fn push_vote<T: KeypairUtil>(
+        voting_keypair: &T,
+        bank: &Bank,
+        tick_height: u64,
+        last_id: Hash,
+    ) {
+        let new_vote_tx = VoteTransaction::new_vote(voting_keypair, tick_height, last_id, 0);
+        bank.process_transaction(&new_vote_tx).unwrap();
+    }
+}

--- a/src/active_stakers.rs
+++ b/src/active_stakers.rs
@@ -1,5 +1,4 @@
 use crate::leader_schedule::LeaderSchedule;
-use hashbrown::{HashMap, HashSet};
 use solana_runtime::bank::Bank;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::vote_program::VoteState;
@@ -13,14 +12,30 @@ fn is_active_staker(vote_state: &VoteState, lower_bound: u64, upper_bound: u64) 
         .is_some()
 }
 
+fn rank_stakes(stakes: &mut Vec<(Pubkey, u64)>) {
+    // Rank first by stake. If stakes are the same we rank by pubkey to ensure a
+    // deterministic result.
+    // Note: Use unstable sort, because we dedup right after to remove the equal elements.
+    stakes.sort_unstable_by(|(pubkey0, stake0), (pubkey1, stake1)| {
+        if stake0 == stake1 {
+            pubkey0.cmp(&pubkey1)
+        } else {
+            stake0.cmp(&stake1)
+        }
+    });
+
+    // Now that it's sorted, we can do an O(n) dedup.
+    stakes.dedup();
+}
+
 /// The set of stakers that have voted near the time of construction
 pub struct ActiveStakers {
-    stakes: HashMap<Pubkey, u64>,
+    stakes: Vec<(Pubkey, u64)>,
 }
 
 impl ActiveStakers {
     pub fn new_with_upper_bound(bank: &Bank, lower_bound: u64, upper_bound: u64) -> Self {
-        let stakes = bank
+        let mut stakes: Vec<_> = bank
             .vote_states(|vote_state| is_active_staker(vote_state, lower_bound, upper_bound))
             .iter()
             .filter_map(|vote_state| {
@@ -33,6 +48,7 @@ impl ActiveStakers {
                 }
             })
             .collect();
+        rank_stakes(&mut stakes);
         Self { stakes }
     }
 
@@ -40,19 +56,12 @@ impl ActiveStakers {
         Self::new_with_upper_bound(bank, lower_bound, bank.tick_height())
     }
 
-    /// Return a map from staker pubkeys to their respective stakes.
-    pub fn stakes(&self) -> HashMap<Pubkey, u64> {
-        self.stakes.clone()
-    }
-
     /// Return the pubkeys of each staker.
-    pub fn stakers(&self) -> HashSet<Pubkey> {
-        self.stakes.keys().cloned().collect()
+    pub fn pubkeys(&self) -> Vec<Pubkey> {
+        self.stakes.iter().map(|(pubkey, _stake)| *pubkey).collect()
     }
 
     pub fn leader_schedule(&self) -> LeaderSchedule {
-        let mut stakers: Vec<_> = self.stakes.keys().cloned().collect();
-        stakers.sort();
-        LeaderSchedule::new(stakers)
+        LeaderSchedule::new(self.pubkeys())
     }
 }

--- a/src/active_stakers.rs
+++ b/src/active_stakers.rs
@@ -60,6 +60,10 @@ impl ActiveStakers {
         Self::new_with_bounds(bank, DEFAULT_ACTIVE_WINDOW_TICK_LENGTH, bank.tick_height())
     }
 
+    pub fn ranked_stakes(&self) -> Vec<(Pubkey, u64)> {
+        self.stakes.clone()
+    }
+
     /// Return the pubkeys of each staker.
     pub fn pubkeys(&self) -> Vec<Pubkey> {
         self.stakes.iter().map(|(pubkey, _stake)| *pubkey).collect()
@@ -77,6 +81,7 @@ impl ActiveStakers {
     }
 }
 
+#[cfg(test)]
 pub mod tests {
     use super::*;
     use solana_runtime::bank::Bank;
@@ -293,5 +298,32 @@ pub mod tests {
             .sorted_pubkeys();
             assert_eq!(result.len(), 0);
         }
+    }
+
+    #[test]
+    fn test_rank_stakes_basic() {
+        let pubkey0 = Keypair::new().pubkey();
+        let pubkey1 = Keypair::new().pubkey();
+        let mut stakes = vec![(pubkey0, 2), (pubkey1, 1)];
+        rank_stakes(&mut stakes);
+        assert_eq!(stakes, vec![(pubkey1, 1), (pubkey0, 2)]);
+    }
+
+    #[test]
+    fn test_rank_stakes_with_dup() {
+        let pubkey0 = Keypair::new().pubkey();
+        let pubkey1 = Keypair::new().pubkey();
+        let mut stakes = vec![(pubkey0, 1), (pubkey1, 2), (pubkey0, 1)];
+        rank_stakes(&mut stakes);
+        assert_eq!(stakes, vec![(pubkey0, 1), (pubkey1, 2)]);
+    }
+
+    #[test]
+    fn test_rank_stakes_with_equal_stakes() {
+        let pubkey0 = Pubkey::default();
+        let pubkey1 = Keypair::new().pubkey();
+        let mut stakes = vec![(pubkey0, 1), (pubkey1, 1)];
+        rank_stakes(&mut stakes);
+        assert_eq!(stakes, vec![(pubkey0, 1), (pubkey1, 1)]);
     }
 }

--- a/src/active_stakers.rs
+++ b/src/active_stakers.rs
@@ -1,0 +1,58 @@
+use crate::leader_schedule::LeaderSchedule;
+use hashbrown::{HashMap, HashSet};
+use solana_runtime::bank::Bank;
+use solana_sdk::pubkey::Pubkey;
+use solana_sdk::vote_program::VoteState;
+
+// Return true of the latest vote is between the lower and upper bounds (inclusive)
+fn is_active_staker(vote_state: &VoteState, lower_bound: u64, upper_bound: u64) -> bool {
+    vote_state
+        .votes
+        .back()
+        .filter(|vote| vote.tick_height >= lower_bound && vote.tick_height <= upper_bound)
+        .is_some()
+}
+
+/// The set of stakers that have voted near the time of construction
+pub struct ActiveStakers {
+    stakes: HashMap<Pubkey, u64>,
+}
+
+impl ActiveStakers {
+    pub fn new_with_upper_bound(bank: &Bank, lower_bound: u64, upper_bound: u64) -> Self {
+        let stakes = bank
+            .vote_states(|vote_state| is_active_staker(vote_state, lower_bound, upper_bound))
+            .iter()
+            .filter_map(|vote_state| {
+                let pubkey = vote_state.staker_id;
+                let stake = bank.get_balance(&pubkey);
+                if stake > 0 {
+                    Some((pubkey, stake))
+                } else {
+                    None
+                }
+            })
+            .collect();
+        Self { stakes }
+    }
+
+    pub fn new(bank: &Bank, lower_bound: u64) -> Self {
+        Self::new_with_upper_bound(bank, lower_bound, bank.tick_height())
+    }
+
+    /// Return a map from staker pubkeys to their respective stakes.
+    pub fn stakes(&self) -> HashMap<Pubkey, u64> {
+        self.stakes.clone()
+    }
+
+    /// Return the pubkeys of each staker.
+    pub fn stakers(&self) -> HashSet<Pubkey> {
+        self.stakes.keys().cloned().collect()
+    }
+
+    pub fn leader_schedule(&self) -> LeaderSchedule {
+        let mut stakers: Vec<_> = self.stakes.keys().cloned().collect();
+        stakers.sort();
+        LeaderSchedule::new(stakers)
+    }
+}

--- a/src/active_stakers.rs
+++ b/src/active_stakers.rs
@@ -15,7 +15,7 @@ fn is_active_staker(vote_state: &VoteState, lower_bound: u64, upper_bound: u64) 
         .is_some()
 }
 
-fn rank_stakes(stakes: &mut Vec<(Pubkey, u64)>) {
+pub fn rank_stakes(stakes: &mut Vec<(Pubkey, u64)>) {
     // Rank first by stake. If stakes are the same we rank by pubkey to ensure a
     // deterministic result.
     // Note: Use unstable sort, because we dedup right after to remove the equal elements.

--- a/src/leader_confirmation_service.rs
+++ b/src/leader_confirmation_service.rs
@@ -133,7 +133,7 @@ impl Service for LeaderConfirmationService {
 #[cfg(test)]
 pub mod tests {
     use super::*;
-    use crate::active_stakers::tests::new_vote_account;
+    use crate::active_stakers::tests::{new_vote_account, push_vote};
     use crate::voting_keypair::VotingKeypair;
     use bincode::serialize;
     use solana_sdk::genesis_block::GenesisBlock;
@@ -169,16 +169,15 @@ pub mod tests {
                 let validator_keypair = Arc::new(Keypair::new());
                 let last_id = ids[i];
                 let voting_keypair = VotingKeypair::new_local(&validator_keypair);
+                let voting_pubkey = voting_keypair.pubkey();
 
                 // Give the validator some tokens
                 bank.transfer(2, &mint_keypair, validator_keypair.pubkey(), last_id)
                     .unwrap();
-                new_vote_account(&validator_keypair, &voting_keypair, &bank, 1, last_id);
+                new_vote_account(&validator_keypair, &voting_pubkey, &bank, 1);
 
                 if i < 6 {
-                    let vote_tx =
-                        VoteTransaction::new_vote(&voting_keypair, (i + 1) as u64, last_id, 0);
-                    bank.process_transaction(&vote_tx).unwrap();
+                    push_vote(&voting_keypair, &bank, (i + 1) as u64);
                 }
                 (voting_keypair, validator_keypair)
             })

--- a/src/leader_confirmation_service.rs
+++ b/src/leader_confirmation_service.rs
@@ -133,7 +133,7 @@ impl Service for LeaderConfirmationService {
 #[cfg(test)]
 pub mod tests {
     use super::*;
-    use crate::leader_scheduler::tests::new_vote_account;
+    use crate::active_stakers::tests::new_vote_account;
     use crate::voting_keypair::VotingKeypair;
     use bincode::serialize;
     use solana_sdk::genesis_block::GenesisBlock;

--- a/src/leader_schedule.rs
+++ b/src/leader_schedule.rs
@@ -1,0 +1,35 @@
+use solana_sdk::pubkey::Pubkey;
+use std::ops::Index;
+
+/// Round-robin leader schedule.
+pub struct LeaderSchedule {
+    slot_leaders: Vec<Pubkey>,
+}
+
+impl LeaderSchedule {
+    pub fn new(slot_leaders: Vec<Pubkey>) -> Self {
+        Self { slot_leaders }
+    }
+}
+
+impl Index<usize> for LeaderSchedule {
+    type Output = Pubkey;
+    fn index(&self, index: usize) -> &Pubkey {
+        &self.slot_leaders[index % self.slot_leaders.len()]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use solana_sdk::signature::{Keypair, KeypairUtil};
+    #[test]
+    fn test_leader_schedule_index() {
+        let pubkey0 = Keypair::new().pubkey();
+        let pubkey1 = Keypair::new().pubkey();
+        let leader_schedule = LeaderSchedule::new(vec![pubkey0, pubkey1]);
+        assert_eq!(leader_schedule[0], pubkey0);
+        assert_eq!(leader_schedule[1], pubkey1);
+        assert_eq!(leader_schedule[2], pubkey0);
+    }
+}

--- a/src/leader_scheduler.rs
+++ b/src/leader_scheduler.rs
@@ -424,6 +424,7 @@ pub fn make_active_set_entries(
 #[cfg(test)]
 pub mod tests {
     use super::*;
+    use crate::active_stakers::tests::{new_vote_account, push_vote};
     use hashbrown::HashSet;
     use solana_sdk::genesis_block::{GenesisBlock, BOOTSTRAP_LEADER_TOKENS};
     use std::hash::Hash as StdHash;
@@ -435,28 +436,6 @@ pub mod tests {
         T: Eq + StdHash + Clone,
     {
         HashSet::from_iter(slice.iter().cloned())
-    }
-
-    pub fn new_vote_account(
-        from_keypair: &Keypair,
-        voting_keypair: &VotingKeypair,
-        bank: &Bank,
-        num_tokens: u64,
-        last_id: Hash,
-    ) {
-        let tx = VoteTransaction::new_account(
-            from_keypair,
-            voting_keypair.pubkey(),
-            last_id,
-            num_tokens,
-            0,
-        );
-        bank.process_transaction(&tx).unwrap();
-    }
-
-    fn push_vote(voting_keypair: &VotingKeypair, bank: &Bank, tick_height: u64, last_id: Hash) {
-        let new_vote_tx = VoteTransaction::new_vote(voting_keypair, tick_height, last_id, 0);
-        bank.process_transaction(&new_vote_tx).unwrap();
     }
 
     fn run_scheduler_test(num_validators: usize, ticks_per_slot: u64, ticks_per_epoch: u64) {

--- a/src/leader_scheduler.rs
+++ b/src/leader_scheduler.rs
@@ -1,7 +1,7 @@
 //! The `leader_scheduler` module implements a structure and functions for tracking and
 //! managing the schedule for leader rotation
 
-use crate::active_stakers::{ActiveStakers, DEFAULT_ACTIVE_WINDOW_TICK_LENGTH};
+use crate::active_stakers::{self, ActiveStakers, DEFAULT_ACTIVE_WINDOW_TICK_LENGTH};
 use crate::entry::{create_ticks, next_entry_mut, Entry};
 use crate::voting_keypair::VotingKeypair;
 use bincode::serialize;
@@ -296,14 +296,7 @@ impl LeaderScheduler {
                 }
             })
             .collect();
-
-        active_accounts.sort_by(|(pubkey1, stake1), (pubkey2, stake2)| {
-            if stake1 == stake2 {
-                pubkey1.cmp(&pubkey2)
-            } else {
-                stake1.cmp(&stake2)
-            }
-        });
+        active_stakers::rank_stakes(&mut active_accounts);
         active_accounts
     }
 

--- a/src/leader_scheduler.rs
+++ b/src/leader_scheduler.rs
@@ -424,7 +424,7 @@ pub fn make_active_set_entries(
 #[cfg(test)]
 pub mod tests {
     use super::*;
-    use crate::active_stakers::tests::{new_vote_account, push_vote};
+    use crate::active_stakers::tests::{new_vote_account_with_vote, push_vote};
     use hashbrown::HashSet;
     use solana_sdk::genesis_block::{GenesisBlock, BOOTSTRAP_LEADER_TOKENS};
     use std::hash::Hash as StdHash;
@@ -473,22 +473,14 @@ pub mod tests {
             bank.transfer(stake, &mint_keypair, new_pubkey, last_id)
                 .unwrap();
 
-            // Create a vote account
-            new_vote_account(
+            // Vote to make the validator part of the active set for the entire test
+            // (we made the active_window_tick_length large enough at the beginning of the test)
+            new_vote_account_with_vote(
                 &new_validator,
                 &voting_keypair,
                 &bank,
                 num_vote_account_tokens as u64,
-                genesis_block.last_id(),
-            );
-
-            // Vote to make the validator part of the active set for the entire test
-            // (we made the active_window_tick_length large enough at the beginning of the test)
-            push_vote(
-                &voting_keypair,
-                &bank,
                 ticks_per_epoch,
-                genesis_block.last_id(),
             );
         }
 
@@ -632,23 +624,8 @@ pub mod tests {
             bank.transfer(5, &mint_keypair, pk, genesis_block.last_id())
                 .unwrap();
 
-            // Create a vote account
-            let voting_keypair = Keypair::new();
-            new_vote_account(
-                &new_keypair,
-                &voting_keypair,
-                &bank,
-                1,
-                genesis_block.last_id(),
-            );
-
-            // Push a vote for the account
-            push_vote(
-                &voting_keypair,
-                &bank,
-                start_height,
-                genesis_block.last_id(),
-            );
+            // Create a vote account and push a vote
+            new_vote_account_with_vote(&new_keypair, &Keypair::new(), &bank, 1, start_height);
         }
 
         // Insert a bunch of votes at height "start_height + active_window_tick_length"
@@ -662,22 +639,9 @@ pub mod tests {
             bank.transfer(5, &mint_keypair, pk, genesis_block.last_id())
                 .unwrap();
 
-            // Create a vote account
-            let voting_keypair = Keypair::new();
-            new_vote_account(
-                &new_keypair,
-                &voting_keypair,
-                &bank,
-                1,
-                genesis_block.last_id(),
-            );
-
-            push_vote(
-                &voting_keypair,
-                &bank,
-                start_height + active_window_tick_length + 1,
-                genesis_block.last_id(),
-            );
+            // Create a vote account and push a vote
+            let tick_height = start_height + active_window_tick_length + 1;
+            new_vote_account_with_vote(&new_keypair, &Keypair::new(), &bank, 1, tick_height);
         }
 
         // Query for the active set at various heights
@@ -928,21 +892,9 @@ pub mod tests {
             )
             .unwrap();
 
-            // Create a vote account
-            new_vote_account(
-                &new_validator,
-                &voting_keypair,
-                &bank,
-                num_vote_account_tokens as u64,
-                genesis_block.last_id(),
-            );
-
-            push_vote(
-                &voting_keypair,
-                &bank,
-                (i + 2) * active_window_tick_length - 1,
-                genesis_block.last_id(),
-            );
+            // Create a vote account and push a vote
+            let tick_height = (i + 2) * active_window_tick_length - 1;
+            new_vote_account_with_vote(&new_validator, &voting_keypair, &bank, 1, tick_height);
         }
 
         // Generate schedule every active_window_tick_length entries and check that
@@ -1002,18 +954,9 @@ pub mod tests {
         // Check that a node that votes twice in a row will get included in the active
         // window
 
-        let voting_keypair = Keypair::new();
         // Create a vote account
-        new_vote_account(
-            &leader_keypair,
-            &voting_keypair,
-            &bank,
-            1,
-            genesis_block.last_id(),
-        );
-
-        // Vote at tick_height 1
-        push_vote(&voting_keypair, &bank, 1, genesis_block.last_id());
+        let voting_keypair = Keypair::new();
+        new_vote_account_with_vote(&leader_keypair, &voting_keypair, &bank, 1, 1);
 
         {
             let mut leader_scheduler = leader_scheduler.write().unwrap();
@@ -1025,7 +968,7 @@ pub mod tests {
         }
 
         // Vote at tick_height 2
-        push_vote(&voting_keypair, &bank, 2, genesis_block.last_id());
+        push_vote(&voting_keypair, &bank, 2);
 
         {
             let mut leader_scheduler = leader_scheduler.write().unwrap();
@@ -1199,21 +1142,14 @@ pub mod tests {
         if add_validator {
             bank.transfer(5, &mint_keypair, validator_id, last_id)
                 .unwrap();
-            // Create a vote account
-            let voting_keypair = VotingKeypair::new_local(&validator_keypair);
-            new_vote_account(
+
+            // Create a vote account and push a vote
+            new_vote_account_with_vote(
                 &validator_keypair,
-                &voting_keypair,
+                &Keypair::new(),
                 &bank,
                 1,
-                genesis_block.last_id(),
-            );
-
-            push_vote(
-                &voting_keypair,
-                &bank,
                 initial_vote_height,
-                genesis_block.last_id(),
             );
         }
 
@@ -1234,22 +1170,14 @@ pub mod tests {
         )
         .unwrap();
 
-        // Create a vote account
-        let voting_keypair = VotingKeypair::new_local(&bootstrap_leader_keypair);
-        new_vote_account(
+        // Create a vote account and push a vote to add the leader to the active set
+        let voting_keypair = Keypair::new();
+        new_vote_account_with_vote(
             &bootstrap_leader_keypair,
             &voting_keypair,
             &bank,
             vote_account_tokens as u64,
-            genesis_block.last_id(),
-        );
-
-        // Add leader to the active set
-        push_vote(
-            &voting_keypair,
-            &bank,
             initial_vote_height,
-            genesis_block.last_id(),
         );
 
         let leader_scheduler_config =

--- a/src/leader_scheduler.rs
+++ b/src/leader_scheduler.rs
@@ -1,7 +1,7 @@
 //! The `leader_scheduler` module implements a structure and functions for tracking and
 //! managing the schedule for leader rotation
 
-use crate::active_stakers::{self, ActiveStakers, DEFAULT_ACTIVE_WINDOW_TICK_LENGTH};
+use crate::active_stakers::{ActiveStakers, DEFAULT_ACTIVE_WINDOW_TICK_LENGTH};
 use crate::entry::{create_ticks, next_entry_mut, Entry};
 use crate::voting_keypair::VotingKeypair;
 use bincode::serialize;
@@ -224,10 +224,9 @@ impl LeaderScheduler {
         }
 
         self.seed = Self::calculate_seed(tick_height);
-        let active_set =
+        let ranked_active_set =
             ActiveStakers::new_with_bounds(&bank, self.active_window_tick_length, tick_height)
-                .pubkeys();
-        let ranked_active_set = Self::rank_active_set(bank, active_set);
+                .ranked_stakes();
 
         if ranked_active_set.is_empty() {
             info!(
@@ -282,22 +281,6 @@ impl LeaderScheduler {
             tick_height + self.ticks_per_epoch,
             self.epoch_schedule[0]
         );
-    }
-
-    fn rank_active_set(bank: &Bank, active: Vec<Pubkey>) -> Vec<(Pubkey, u64)> {
-        let mut active_accounts: Vec<_> = active
-            .into_iter()
-            .filter_map(|pubkey| {
-                let stake = bank.get_balance(&pubkey);
-                if stake > 0 {
-                    Some((pubkey, stake as u64))
-                } else {
-                    None
-                }
-            })
-            .collect();
-        active_stakers::rank_stakes(&mut active_accounts);
-        active_accounts
     }
 
     fn calculate_seed(tick_height: u64) -> u64 {
@@ -571,93 +554,6 @@ pub mod tests {
             let seed = LeaderScheduler::calculate_seed(i);
             assert!(!old_seeds.contains(&seed));
             old_seeds.insert(seed);
-        }
-    }
-
-    #[test]
-    fn test_rank_active_set() {
-        let num_validators: usize = 101;
-        // Give genesis_block sum(1..num_validators) tokens
-        let (genesis_block, mint_keypair) =
-            GenesisBlock::new((((num_validators + 1) / 2) * (num_validators + 1)) as u64);
-        let bank = Bank::new(&genesis_block);
-        let mut validators = vec![];
-        let last_id = genesis_block.last_id();
-        for i in 0..num_validators {
-            let new_validator = Keypair::new();
-            let new_pubkey = new_validator.pubkey();
-            validators.push(new_validator);
-            bank.transfer(
-                (num_validators - i) as u64,
-                &mint_keypair,
-                new_pubkey,
-                last_id,
-            )
-            .unwrap();
-        }
-
-        let validator_pubkeys: Vec<_> = validators.iter().map(Keypair::pubkey).collect();
-        let result = LeaderScheduler::rank_active_set(&bank, validator_pubkeys);
-
-        assert_eq!(result.len(), validators.len());
-
-        // Expect the result to be the reverse of the list we passed into the rank_active_set()
-        for (i, (pubkey, stake)) in result.into_iter().enumerate() {
-            assert_eq!(stake, i as u64 + 1);
-            assert_eq!(pubkey, validators[num_validators - i - 1].pubkey());
-        }
-
-        // Transfer all the tokens to a new set of validators, old validators should now
-        // have balance of zero and get filtered out of the rankings
-        let mut new_validators = vec![];
-        for i in 0..num_validators {
-            let new_validator = Keypair::new();
-            let new_pubkey = new_validator.pubkey();
-            new_validators.push(new_validator);
-            bank.transfer(
-                (num_validators - i) as u64,
-                &validators[i],
-                new_pubkey,
-                last_id,
-            )
-            .unwrap();
-        }
-
-        let all_validators: Vec<Pubkey> = validators
-            .iter()
-            .chain(new_validators.iter())
-            .map(Keypair::pubkey)
-            .collect();
-        let result = LeaderScheduler::rank_active_set(&bank, all_validators);
-        assert_eq!(result.len(), new_validators.len());
-
-        for (i, (pubkey, balance)) in result.into_iter().enumerate() {
-            assert_eq!(balance, i as u64 + 1);
-            assert_eq!(pubkey, new_validators[num_validators - i - 1].pubkey());
-        }
-
-        // Break ties between validators with the same balances using public key
-        let (genesis_block, mint_keypair) = GenesisBlock::new((num_validators + 1) as u64);
-        let bank = Bank::new(&genesis_block);
-        let mut tied_validators_pk = vec![];
-        let last_id = genesis_block.last_id();
-
-        for _i in 0..num_validators {
-            let new_validator = Keypair::new();
-            let new_pubkey = new_validator.pubkey();
-            tied_validators_pk.push(new_pubkey);
-            assert!(bank.get_balance(&mint_keypair.pubkey()) > 1);
-            bank.transfer(1, &mint_keypair, new_pubkey, last_id)
-                .unwrap();
-        }
-
-        let mut sorted = tied_validators_pk.clone();
-        sorted.sort_by(|pk1, pk2| pk1.cmp(pk2));
-        let result = LeaderScheduler::rank_active_set(&bank, tied_validators_pk);
-        assert_eq!(result.len(), sorted.len());
-        for (i, (pk, s)) in result.into_iter().enumerate() {
-            assert_eq!(s, 1);
-            assert_eq!(pk, sorted[i]);
         }
     }
 

--- a/src/leader_scheduler.rs
+++ b/src/leader_scheduler.rs
@@ -227,7 +227,7 @@ impl LeaderScheduler {
         let active_set =
             ActiveStakers::new_with_bounds(&bank, self.active_window_tick_length, tick_height)
                 .pubkeys();
-        let ranked_active_set = Self::rank_active_set(bank, active_set.iter());
+        let ranked_active_set = Self::rank_active_set(bank, active_set);
 
         if ranked_active_set.is_empty() {
             info!(
@@ -238,7 +238,7 @@ impl LeaderScheduler {
             let (mut validator_rankings, total_stake) = ranked_active_set.iter().fold(
                 (Vec::with_capacity(ranked_active_set.len()), 0),
                 |(mut ids, total_stake), (pubkey, stake)| {
-                    ids.push(**pubkey);
+                    ids.push(*pubkey);
                     (ids, total_stake + stake)
                 },
             );
@@ -284,13 +284,11 @@ impl LeaderScheduler {
         );
     }
 
-    fn rank_active_set<'a, I>(bank: &Bank, active: I) -> Vec<(&'a Pubkey, u64)>
-    where
-        I: Iterator<Item = &'a Pubkey>,
-    {
-        let mut active_accounts: Vec<(&'a Pubkey, u64)> = active
+    fn rank_active_set(bank: &Bank, active: Vec<Pubkey>) -> Vec<(Pubkey, u64)> {
+        let mut active_accounts: Vec<_> = active
+            .into_iter()
             .filter_map(|pubkey| {
-                let stake = bank.get_balance(pubkey);
+                let stake = bank.get_balance(&pubkey);
                 if stake > 0 {
                     Some((pubkey, stake as u64))
                 } else {
@@ -605,15 +603,15 @@ pub mod tests {
             .unwrap();
         }
 
-        let validators_pubkey: Vec<Pubkey> = validators.iter().map(Keypair::pubkey).collect();
-        let result = LeaderScheduler::rank_active_set(&bank, validators_pubkey.iter());
+        let validator_pubkeys: Vec<_> = validators.iter().map(Keypair::pubkey).collect();
+        let result = LeaderScheduler::rank_active_set(&bank, validator_pubkeys);
 
         assert_eq!(result.len(), validators.len());
 
         // Expect the result to be the reverse of the list we passed into the rank_active_set()
         for (i, (pubkey, stake)) in result.into_iter().enumerate() {
             assert_eq!(stake, i as u64 + 1);
-            assert_eq!(*pubkey, validators[num_validators - i - 1].pubkey());
+            assert_eq!(pubkey, validators[num_validators - i - 1].pubkey());
         }
 
         // Transfer all the tokens to a new set of validators, old validators should now
@@ -637,12 +635,12 @@ pub mod tests {
             .chain(new_validators.iter())
             .map(Keypair::pubkey)
             .collect();
-        let result = LeaderScheduler::rank_active_set(&bank, all_validators.iter());
+        let result = LeaderScheduler::rank_active_set(&bank, all_validators);
         assert_eq!(result.len(), new_validators.len());
 
         for (i, (pubkey, balance)) in result.into_iter().enumerate() {
             assert_eq!(balance, i as u64 + 1);
-            assert_eq!(*pubkey, new_validators[num_validators - i - 1].pubkey());
+            assert_eq!(pubkey, new_validators[num_validators - i - 1].pubkey());
         }
 
         // Break ties between validators with the same balances using public key
@@ -660,13 +658,13 @@ pub mod tests {
                 .unwrap();
         }
 
-        let result = LeaderScheduler::rank_active_set(&bank, tied_validators_pk.iter());
-        let mut sorted: Vec<&Pubkey> = tied_validators_pk.iter().map(|x| x).collect();
+        let mut sorted = tied_validators_pk.clone();
         sorted.sort_by(|pk1, pk2| pk1.cmp(pk2));
-        assert_eq!(result.len(), tied_validators_pk.len());
+        let result = LeaderScheduler::rank_active_set(&bank, tied_validators_pk);
+        assert_eq!(result.len(), sorted.len());
         for (i, (pk, s)) in result.into_iter().enumerate() {
             assert_eq!(s, 1);
-            assert_eq!(*pk, *sorted[i]);
+            assert_eq!(pk, sorted[i]);
         }
     }
 

--- a/src/leader_scheduler.rs
+++ b/src/leader_scheduler.rs
@@ -1,7 +1,7 @@
 //! The `leader_scheduler` module implements a structure and functions for tracking and
 //! managing the schedule for leader rotation
 
-use crate::active_stakers::ActiveStakers;
+use crate::active_stakers::{ActiveStakers, DEFAULT_ACTIVE_WINDOW_TICK_LENGTH};
 use crate::entry::{create_ticks, next_entry_mut, Entry};
 use crate::voting_keypair::VotingKeypair;
 use bincode::serialize;
@@ -15,8 +15,6 @@ use solana_sdk::timing::{DEFAULT_SLOTS_PER_EPOCH, DEFAULT_TICKS_PER_SLOT};
 use solana_sdk::vote_transaction::VoteTransaction;
 use std::io::Cursor;
 use std::sync::Arc;
-
-pub const DEFAULT_ACTIVE_WINDOW_TICK_LENGTH: u64 = DEFAULT_SLOTS_PER_EPOCH * DEFAULT_TICKS_PER_SLOT;
 
 #[derive(Clone)]
 pub struct LeaderSchedulerConfig {
@@ -197,18 +195,6 @@ impl LeaderScheduler {
         }
     }
 
-    fn get_active_set(&mut self, tick_height: u64, bank: &Bank) -> Vec<Pubkey> {
-        let upper_bound = tick_height;
-        let lower_bound = tick_height.saturating_sub(self.active_window_tick_length);
-        trace!(
-            "get_active_set: vote bounds ({}, {})",
-            lower_bound,
-            upper_bound
-        );
-
-        ActiveStakers::new_with_upper_bound(&bank, lower_bound, upper_bound).pubkeys()
-    }
-
     // Updates the leader schedule to include ticks from tick_height to the first tick of the next epoch
     fn generate_schedule(&mut self, tick_height: u64, bank: &Bank) {
         let epoch = self.tick_height_to_epoch(tick_height);
@@ -238,7 +224,9 @@ impl LeaderScheduler {
         }
 
         self.seed = Self::calculate_seed(tick_height);
-        let active_set = self.get_active_set(tick_height, &bank);
+        let active_set =
+            ActiveStakers::new_with_bounds(&bank, self.active_window_tick_length, tick_height)
+                .pubkeys();
         let ranked_active_set = Self::rank_active_set(bank, active_set.iter());
 
         if ranked_active_set.is_empty() {
@@ -419,10 +407,9 @@ pub fn make_active_set_entries(
 #[cfg(test)]
 pub mod tests {
     use super::*;
-    use crate::active_stakers::tests::{new_vote_account_with_vote, push_vote};
+    use crate::active_stakers::tests::new_vote_account_with_vote;
     use hashbrown::HashSet;
     use solana_sdk::genesis_block::{GenesisBlock, BOOTSTRAP_LEADER_TOKENS};
-    use std::sync::RwLock;
 
     fn run_scheduler_test(num_validators: usize, ticks_per_slot: u64, ticks_per_epoch: u64) {
         info!(
@@ -582,91 +569,6 @@ pub mod tests {
         assert_eq!(leader_scheduler.num_ticks_left_in_slot(19), 0);
         assert_eq!(leader_scheduler.num_ticks_left_in_slot(20), 9);
         assert_eq!(leader_scheduler.num_ticks_left_in_slot(21), 8);
-    }
-
-    #[test]
-    fn test_active_set() {
-        solana_logger::setup();
-
-        let leader_id = Keypair::new().pubkey();
-        let active_window_tick_length = 1000;
-        let leader_scheduler_config = LeaderSchedulerConfig::new(100, 1, active_window_tick_length);
-        let (genesis_block, mint_keypair) = GenesisBlock::new_with_leader(10000, leader_id, 500);
-        let bank = Bank::new(&genesis_block);
-        let mut leader_scheduler = LeaderScheduler::new_with_bank(&leader_scheduler_config, &bank);
-
-        let bootstrap_ids = vec![genesis_block.bootstrap_leader_id];
-
-        // Insert a bunch of votes at height "start_height"
-        let start_height = 3;
-        let num_old_ids = 20;
-        let mut old_ids = vec![];
-        for _ in 0..num_old_ids {
-            let new_keypair = Keypair::new();
-            let pk = new_keypair.pubkey();
-            old_ids.push(pk);
-
-            // Give the account some stake
-            bank.transfer(5, &mint_keypair, pk, genesis_block.last_id())
-                .unwrap();
-
-            // Create a vote account and push a vote
-            new_vote_account_with_vote(&new_keypair, &Keypair::new(), &bank, 1, start_height);
-        }
-        old_ids.sort();
-
-        // Insert a bunch of votes at height "start_height + active_window_tick_length"
-        let num_new_ids = 10;
-        let mut new_ids = vec![];
-        for _ in 0..num_new_ids {
-            let new_keypair = Keypair::new();
-            let pk = new_keypair.pubkey();
-            new_ids.push(pk);
-            // Give the account some stake
-            bank.transfer(5, &mint_keypair, pk, genesis_block.last_id())
-                .unwrap();
-
-            // Create a vote account and push a vote
-            let tick_height = start_height + active_window_tick_length + 1;
-            new_vote_account_with_vote(&new_keypair, &Keypair::new(), &bank, 1, tick_height);
-        }
-        new_ids.sort();
-
-        // Query for the active set at various heights
-        let result = leader_scheduler.get_active_set(0, &bank);
-        assert_eq!(result, bootstrap_ids);
-
-        let result = leader_scheduler.get_active_set(start_height - 1, &bank);
-        assert_eq!(result, bootstrap_ids);
-
-        let mut result =
-            leader_scheduler.get_active_set(active_window_tick_length + start_height - 1, &bank);
-        result.sort();
-        assert_eq!(result, old_ids);
-
-        let mut result =
-            leader_scheduler.get_active_set(active_window_tick_length + start_height, &bank);
-        result.sort();
-        assert_eq!(result, old_ids);
-
-        let mut result =
-            leader_scheduler.get_active_set(active_window_tick_length + start_height + 1, &bank);
-        result.sort();
-        assert_eq!(result, new_ids);
-
-        let mut result =
-            leader_scheduler.get_active_set(2 * active_window_tick_length + start_height, &bank);
-        result.sort();
-        assert_eq!(result, new_ids);
-
-        let mut result = leader_scheduler
-            .get_active_set(2 * active_window_tick_length + start_height + 1, &bank);
-        result.sort();
-        assert_eq!(result, new_ids);
-
-        let result = leader_scheduler
-            .get_active_set(2 * active_window_tick_length + start_height + 2, &bank);
-        assert!(result.is_empty());
     }
 
     #[test]
@@ -915,61 +817,6 @@ pub mod tests {
                     leader_scheduler.epoch_schedule[0],
                 );
             };
-        }
-    }
-
-    #[test]
-    fn test_multiple_vote() {
-        let leader_keypair = Keypair::new();
-        let leader_id = leader_keypair.pubkey();
-        let active_window_tick_length = 1000;
-        let (genesis_block, _mint_keypair) = GenesisBlock::new_with_leader(10000, leader_id, 500);
-        let bank = Bank::new(&genesis_block);
-        let leader_scheduler_config = LeaderSchedulerConfig::new(100, 1, active_window_tick_length);
-        let leader_scheduler = Arc::new(RwLock::new(LeaderScheduler::new_with_bank(
-            &leader_scheduler_config,
-            &bank,
-        )));
-
-        // Bootstrap leader should be in the active set even without explicit votes
-        {
-            let mut leader_scheduler = leader_scheduler.write().unwrap();
-            let result = leader_scheduler.get_active_set(0, &bank);
-            assert_eq!(result, vec![leader_id]);
-
-            let result = leader_scheduler.get_active_set(active_window_tick_length, &bank);
-            assert_eq!(result, vec![leader_id]);
-
-            let result = leader_scheduler.get_active_set(active_window_tick_length + 1, &bank);
-            assert!(result.is_empty());
-        }
-
-        // Check that a node that votes twice in a row will get included in the active
-        // window
-
-        // Create a vote account
-        let voting_keypair = Keypair::new();
-        new_vote_account_with_vote(&leader_keypair, &voting_keypair, &bank, 1, 1);
-
-        {
-            let mut leader_scheduler = leader_scheduler.write().unwrap();
-            let result = leader_scheduler.get_active_set(active_window_tick_length + 1, &bank);
-            assert_eq!(result, vec![leader_id]);
-
-            let result = leader_scheduler.get_active_set(active_window_tick_length + 2, &bank);
-            assert!(result.is_empty());
-        }
-
-        // Vote at tick_height 2
-        push_vote(&voting_keypair, &bank, 2);
-
-        {
-            let mut leader_scheduler = leader_scheduler.write().unwrap();
-            let result = leader_scheduler.get_active_set(active_window_tick_length + 2, &bank);
-            assert_eq!(result, vec![leader_id]);
-
-            let result = leader_scheduler.get_active_set(active_window_tick_length + 3, &bank);
-            assert!(result.is_empty());
         }
     }
 

--- a/src/leader_scheduler.rs
+++ b/src/leader_scheduler.rs
@@ -463,9 +463,9 @@ pub mod tests {
         let mut validators = vec![];
         let last_id = genesis_block.last_id();
         for i in 0..num_validators {
-            let new_validator = Arc::new(Keypair::new());
+            let new_validator = Keypair::new();
             let new_pubkey = new_validator.pubkey();
-            let voting_keypair = VotingKeypair::new_local(&new_validator);
+            let voting_keypair = Keypair::new();
             validators.push(new_pubkey);
             let stake = (i + 42) as u64;
             info!("validator {}: stake={} pubkey={}", i, stake, new_pubkey);
@@ -624,7 +624,7 @@ pub mod tests {
         let num_old_ids = 20;
         let mut old_ids = HashSet::new();
         for _ in 0..num_old_ids {
-            let new_keypair = Arc::new(Keypair::new());
+            let new_keypair = Keypair::new();
             let pk = new_keypair.pubkey();
             old_ids.insert(pk.clone());
 
@@ -633,7 +633,7 @@ pub mod tests {
                 .unwrap();
 
             // Create a vote account
-            let voting_keypair = VotingKeypair::new_local(&new_keypair);
+            let voting_keypair = Keypair::new();
             new_vote_account(
                 &new_keypair,
                 &voting_keypair,
@@ -655,7 +655,7 @@ pub mod tests {
         let num_new_ids = 10;
         let mut new_ids = HashSet::new();
         for _ in 0..num_new_ids {
-            let new_keypair = Arc::new(Keypair::new());
+            let new_keypair = Keypair::new();
             let pk = new_keypair.pubkey();
             new_ids.insert(pk);
             // Give the account some stake
@@ -663,7 +663,7 @@ pub mod tests {
                 .unwrap();
 
             // Create a vote account
-            let voting_keypair = VotingKeypair::new_local(&new_keypair);
+            let voting_keypair = Keypair::new();
             new_vote_account(
                 &new_keypair,
                 &voting_keypair,
@@ -915,9 +915,9 @@ pub mod tests {
         let mut validators = vec![];
         let last_id = genesis_block.last_id();
         for i in 0..num_validators {
-            let new_validator = Arc::new(Keypair::new());
+            let new_validator = Keypair::new();
             let new_pubkey = new_validator.pubkey();
-            let voting_keypair = VotingKeypair::new_local(&new_validator);
+            let voting_keypair = Keypair::new();
             validators.push(new_pubkey);
             // Give the validator some tokens
             bank.transfer(
@@ -975,7 +975,7 @@ pub mod tests {
 
     #[test]
     fn test_multiple_vote() {
-        let leader_keypair = Arc::new(Keypair::new());
+        let leader_keypair = Keypair::new();
         let leader_id = leader_keypair.pubkey();
         let active_window_tick_length = 1000;
         let (genesis_block, _mint_keypair) = GenesisBlock::new_with_leader(10000, leader_id, 500);
@@ -1002,7 +1002,7 @@ pub mod tests {
         // Check that a node that votes twice in a row will get included in the active
         // window
 
-        let voting_keypair = VotingKeypair::new_local(&leader_keypair);
+        let voting_keypair = Keypair::new();
         // Create a vote account
         new_vote_account(
             &leader_keypair,

--- a/src/leader_scheduler.rs
+++ b/src/leader_scheduler.rs
@@ -1,6 +1,7 @@
 //! The `leader_scheduler` module implements a structure and functions for tracking and
 //! managing the schedule for leader rotation
 
+use crate::active_stakers::ActiveStakers;
 use crate::entry::{create_ticks, next_entry_mut, Entry};
 use crate::voting_keypair::VotingKeypair;
 use bincode::serialize;
@@ -12,7 +13,6 @@ use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::{Keypair, KeypairUtil};
 use solana_sdk::system_transaction::SystemTransaction;
 use solana_sdk::timing::{DEFAULT_SLOTS_PER_EPOCH, DEFAULT_TICKS_PER_SLOT};
-use solana_sdk::vote_program::VoteState;
 use solana_sdk::vote_transaction::VoteTransaction;
 use std::io::Cursor;
 use std::sync::Arc;
@@ -198,15 +198,6 @@ impl LeaderScheduler {
         }
     }
 
-    // Return true of the latest vote is between the lower and upper bounds (inclusive)
-    fn is_active_staker(vote_state: &VoteState, lower_bound: u64, upper_bound: u64) -> bool {
-        vote_state
-            .votes
-            .back()
-            .filter(|vote| vote.tick_height >= lower_bound && vote.tick_height <= upper_bound)
-            .is_some()
-    }
-
     // TODO: We use a HashSet for now because a single validator could potentially register
     // multiple vote account. Once that is no longer possible (see the TODO in vote_program.rs,
     // process_transaction(), case VoteInstruction::RegisterAccount), we can use a vector.
@@ -219,10 +210,7 @@ impl LeaderScheduler {
             upper_bound
         );
 
-        bank.vote_states(|vote_state| Self::is_active_staker(vote_state, lower_bound, upper_bound))
-            .iter()
-            .map(|vote_state| vote_state.staker_id)
-            .collect()
+        ActiveStakers::new_with_upper_bound(&bank, lower_bound, upper_bound).stakers()
     }
 
     // Updates the leader schedule to include ticks from tick_height to the first tick of the next epoch

--- a/src/leader_scheduler.rs
+++ b/src/leader_scheduler.rs
@@ -210,7 +210,8 @@ impl LeaderScheduler {
             upper_bound
         );
 
-        ActiveStakers::new_with_upper_bound(&bank, lower_bound, upper_bound).stakers()
+        let active_stakers = ActiveStakers::new_with_upper_bound(&bank, lower_bound, upper_bound);
+        active_stakers.pubkeys().into_iter().collect()
     }
 
     // Updates the leader schedule to include ticks from tick_height to the first tick of the next epoch

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@
 //!
 
 #![cfg_attr(feature = "unstable", feature(test))]
+pub mod active_stakers;
 pub mod bank_forks;
 pub mod banking_stage;
 pub mod blob_fetch_stage;
@@ -39,6 +40,7 @@ pub mod fullnode;
 pub mod gen_keys;
 pub mod gossip_service;
 pub mod leader_confirmation_service;
+pub mod leader_schedule;
 pub mod leader_scheduler;
 pub mod local_vote_signer_service;
 pub mod packet;


### PR DESCRIPTION
#### Problem

LeaderScheduler is too complex for a system where the Bank is frozen at epoch boundaries

#### Summary of Changes

* Add new ActiveStakers object for calculating an active set sorted by stake
* Integrate ActiveStakers into LeaderScheduler
* Use ActiveStakers to generate a primitive LeaderSchedule that does a round-robin between everyone that's staked