### PR TITLE
Enable PoHService to receive leader banks expecting ticks.

### DIFF
--- a/src/banking_stage.rs
+++ b/src/banking_stage.rs
@@ -6,7 +6,7 @@ use crate::entry::Entry;
 use crate::leader_confirmation_service::LeaderConfirmationService;
 use crate::packet::Packets;
 use crate::packet::SharedPackets;
-use crate::poh_recorder::{PohRecorder, PohRecorderError};
+use crate::poh_recorder::{PohRecorder, PohRecorderError, WorkingLeader};
 use crate::poh_service::{PohService, PohServiceConfig};
 use crate::result::{Error, Result};
 use crate::service::Service;
@@ -20,7 +20,7 @@ use solana_sdk::pubkey::Pubkey;
 use solana_sdk::timing::{self, duration_as_us, MAX_ENTRY_IDS};
 use solana_sdk::transaction::Transaction;
 use std::sync::atomic::AtomicBool;
-use std::sync::mpsc::{channel, Receiver, RecvTimeoutError, Sender};
+use std::sync::mpsc::{channel, Receiver, RecvTimeoutError};
 use std::sync::{Arc, Mutex};
 use std::thread::{self, Builder, JoinHandle};
 use std::time::Duration;
@@ -52,19 +52,26 @@ impl BankingStage {
     ) -> (Self, Receiver<Vec<Entry>>) {
         let (entry_sender, entry_receiver) = channel();
         let shared_verified_receiver = Arc::new(Mutex::new(verified_receiver));
-        let poh_recorder = PohRecorder::new(bank.tick_height(), *last_entry_id, max_tick_height);
+        let working_leader = WorkingLeader {
+            bank: bank.clone(),
+            sender: entry_sender,
+            min_tick_height: bank.tick_height(),
+            max_tick_height,
+        };
+
+        let poh_recorder = PohRecorder::new(bank.tick_height(), *last_entry_id);
 
         // Single thread to generate entries from many banks.
         // This thread talks to poh_service and broadcasts the entries once they have been recorded.
         // Once an entry has been recorded, its last_id is registered with the bank.
         let poh_exit = Arc::new(AtomicBool::new(false));
-        let poh_service = PohService::new(
-            bank.clone(),
-            entry_sender.clone(),
-            poh_recorder.clone(),
-            config,
-            poh_exit.clone(),
-        );
+
+        let (poh_service, leader_sender) =
+            PohService::new(poh_recorder.clone(), config, poh_exit.clone());
+
+        leader_sender
+            .send(working_leader.clone())
+            .expect("failed to send leader to poh_service");
 
         // Single thread to compute confirmation
         let leader_confirmation_service =
@@ -76,7 +83,7 @@ impl BankingStage {
                 let thread_bank = bank.clone();
                 let thread_verified_receiver = shared_verified_receiver.clone();
                 let thread_poh_recorder = poh_recorder.clone();
-                let thread_sender = entry_sender.clone();
+                let thread_leader = working_leader.clone();
                 Builder::new()
                     .name("solana-banking-stage-tx".to_string())
                     .spawn(move || {
@@ -86,7 +93,7 @@ impl BankingStage {
                                 &thread_bank,
                                 &thread_verified_receiver,
                                 &thread_poh_recorder,
-                                &thread_sender,
+                                &thread_leader,
                             ) {
                                 Err(Error::RecvTimeoutError(RecvTimeoutError::Timeout)) => (),
                                 Ok(more_unprocessed_packets) => {
@@ -129,7 +136,7 @@ impl BankingStage {
         txs: &[Transaction],
         results: &[bank::Result<()>],
         poh: &PohRecorder,
-        entry_sender: &Sender<Vec<Entry>>,
+        working_leader: &WorkingLeader,
     ) -> Result<()> {
         let processed_transactions: Vec<_> = results
             .iter()
@@ -151,7 +158,7 @@ impl BankingStage {
         if !processed_transactions.is_empty() {
             let hash = Transaction::hash(&processed_transactions);
             // record and unlock will unlock all the successfull transactions
-            poh.record(hash, processed_transactions, entry_sender)?;
+            poh.record(hash, processed_transactions, working_leader)?;
         }
         Ok(())
     }
@@ -160,7 +167,7 @@ impl BankingStage {
         bank: &Bank,
         txs: &[Transaction],
         poh: &PohRecorder,
-        entry_sender: &Sender<Vec<Entry>>,
+        working_leader: &WorkingLeader,
     ) -> Result<()> {
         let now = Instant::now();
         // Once accounts are locked, other threads cannot encode transactions that will modify the
@@ -179,7 +186,7 @@ impl BankingStage {
 
         let record_time = {
             let now = Instant::now();
-            Self::record_transactions(txs, &results, poh, entry_sender)?;
+            Self::record_transactions(txs, &results, poh, working_leader)?;
             now.elapsed()
         };
 
@@ -213,7 +220,7 @@ impl BankingStage {
         bank: &Arc<Bank>,
         transactions: &[Transaction],
         poh: &PohRecorder,
-        entry_sender: &Sender<Vec<Entry>>,
+        working_leader: &WorkingLeader,
     ) -> Result<(usize)> {
         let mut chunk_start = 0;
         while chunk_start != transactions.len() {
@@ -223,7 +230,7 @@ impl BankingStage {
                 bank,
                 &transactions[chunk_start..chunk_end],
                 poh,
-                entry_sender,
+                working_leader,
             );
             if let Err(Error::PohRecorderError(PohRecorderError::MaxHeightReached)) = result {
                 break;
@@ -239,7 +246,7 @@ impl BankingStage {
         bank: &Arc<Bank>,
         verified_receiver: &Arc<Mutex<Receiver<VerifiedPackets>>>,
         poh: &PohRecorder,
-        entry_sender: &Sender<Vec<Entry>>,
+        working_leader: &WorkingLeader,
     ) -> Result<UnprocessedPackets> {
         let recv_start = Instant::now();
         let mms = verified_receiver
@@ -291,7 +298,7 @@ impl BankingStage {
             debug!("verified transactions {}", verified_transactions.len());
 
             let processed =
-                Self::process_transactions(bank, &verified_transactions, poh, entry_sender)?;
+                Self::process_transactions(bank, &verified_transactions, poh, working_leader)?;
             if processed < verified_transactions.len() {
                 bank_shutdown = true;
                 // Collect any unprocessed transactions in this batch for forwarding
@@ -596,7 +603,14 @@ mod tests {
         let (genesis_block, mint_keypair) = GenesisBlock::new(10_000);
         let bank = Arc::new(Bank::new(&genesis_block));
         let (entry_sender, entry_receiver) = channel();
-        let poh_recorder = PohRecorder::new(bank.tick_height(), bank.last_id(), std::u64::MAX);
+        let working_leader = WorkingLeader {
+            bank: bank.clone(),
+            sender: entry_sender,
+            min_tick_height: bank.tick_height(),
+            max_tick_height: std::u64::MAX,
+        };
+
+        let poh_recorder = PohRecorder::new(bank.tick_height(), bank.last_id());
         let pubkey = Keypair::new().pubkey();
 
         let transactions = vec![
@@ -605,7 +619,7 @@ mod tests {
         ];
 
         let mut results = vec![Ok(()), Ok(())];
-        BankingStage::record_transactions(&transactions, &results, &poh_recorder, &entry_sender)
+        BankingStage::record_transactions(&transactions, &results, &poh_recorder, &working_leader)
             .unwrap();
         let entries = entry_receiver.recv().unwrap();
         assert_eq!(entries[0].transactions.len(), transactions.len());
@@ -615,14 +629,14 @@ mod tests {
             1,
             ProgramError::ResultWithNegativeTokens,
         ));
-        BankingStage::record_transactions(&transactions, &results, &poh_recorder, &entry_sender)
+        BankingStage::record_transactions(&transactions, &results, &poh_recorder, &working_leader)
             .unwrap();
         let entries = entry_receiver.recv().unwrap();
         assert_eq!(entries[0].transactions.len(), transactions.len());
 
         // Other BankErrors should not be recorded
         results[0] = Err(BankError::AccountNotFound);
-        BankingStage::record_transactions(&transactions, &results, &poh_recorder, &entry_sender)
+        BankingStage::record_transactions(&transactions, &results, &poh_recorder, &working_leader)
             .unwrap();
         let entries = entry_receiver.recv().unwrap();
         assert_eq!(entries[0].transactions.len(), transactions.len() - 1);
@@ -643,17 +657,22 @@ mod tests {
         )];
 
         let (entry_sender, entry_receiver) = channel();
-        let mut poh_recorder =
-            PohRecorder::new(bank.tick_height(), bank.last_id(), bank.tick_height() + 1);
+        let working_leader = WorkingLeader {
+            bank: bank.clone(),
+            sender: entry_sender,
+            min_tick_height: bank.tick_height(),
+            max_tick_height: bank.tick_height() + 1,
+        };
+        let poh_recorder = PohRecorder::new(bank.tick_height(), bank.last_id());
 
         BankingStage::process_and_record_transactions(
             &bank,
             &transactions,
             &poh_recorder,
-            &entry_sender,
+            &working_leader,
         )
         .unwrap();
-        poh_recorder.tick(&bank, &entry_sender).unwrap();
+        poh_recorder.tick(&working_leader).unwrap();
 
         let mut need_tick = true;
         // read entries until I find mine, might be ticks...
@@ -682,7 +701,7 @@ mod tests {
                 &bank,
                 &transactions,
                 &poh_recorder,
-                &entry_sender
+                &working_leader
             ),
             Err(Error::PohRecorderError(PohRecorderError::MaxHeightReached))
         );

--- a/src/poh_recorder.rs
+++ b/src/poh_recorder.rs
@@ -44,7 +44,6 @@ impl PohRecorder {
         let mut cache = vec![];
         std::mem::swap(&mut cache, &mut self.tick_cache.lock().unwrap());
         if !cache.is_empty() {
-            println!("flushing {}", cache.len());
             for t in &cache {
                 leader.bank.register_tick(&t.id);
             }

--- a/src/poh_recorder.rs
+++ b/src/poh_recorder.rs
@@ -14,70 +14,87 @@ use std::sync::{Arc, Mutex};
 pub enum PohRecorderError {
     InvalidCallingObject,
     MaxHeightReached,
+    MinHeightNotReached,
+}
+
+#[derive(Clone)]
+pub struct WorkingLeader {
+    pub bank: Arc<Bank>,
+    pub sender: Sender<Vec<Entry>>,
+    pub min_tick_height: u64,
+    pub max_tick_height: u64,
 }
 
 #[derive(Clone)]
 pub struct PohRecorder {
     poh: Arc<Mutex<Poh>>,
-    max_tick_height: u64,
+    tick_cache: Arc<Mutex<Vec<Entry>>>,
 }
 
 impl PohRecorder {
-    pub fn max_tick_height(&self) -> u64 {
-        self.max_tick_height
-    }
-
-    pub fn hash(&self) -> Result<()> {
+    pub fn hash(&self) {
         // TODO: amortize the cost of this lock by doing the loop in here for
         // some min amount of hashes
         let mut poh = self.poh.lock().unwrap();
 
-        self.check_tick_height(&poh)?;
-
         poh.hash();
+    }
 
+    fn flush_cache(&self, leader: &WorkingLeader) -> Result<()> {
+        let mut cache = vec![];
+        std::mem::swap(&mut cache, &mut self.tick_cache.lock().unwrap());
+        if !cache.is_empty() {
+            for t in &cache {
+                leader.bank.register_tick(&t.id);
+            }
+            leader.sender.send(cache)?;
+        }
         Ok(())
     }
 
-    pub fn tick(&mut self, bank: &Arc<Bank>, sender: &Sender<Vec<Entry>>) -> Result<()> {
+    pub fn tick(&self, leader: &WorkingLeader) -> Result<()> {
         // Register and send the entry out while holding the lock if the max PoH height
         // hasn't been reached.
         // This guarantees PoH order and Entry production and banks LastId queue is the same
         let mut poh = self.poh.lock().unwrap();
 
-        self.check_tick_height(&poh)?;
+        Self::check_tick_height(&poh, leader).map_err(|e| {
+            let tick = Self::generate_tick(&mut poh);
+            self.tick_cache.lock().unwrap().push(tick);
+            e
+        })?;
+                                                      ;
+        self.flush_cache(leader)?;
 
-        self.register_and_send_tick(&mut *poh, bank, sender)
+        Self::register_and_send_tick(&mut *poh, leader)
     }
 
-    pub fn record(
-        &self,
-        mixin: Hash,
-        txs: Vec<Transaction>,
-        sender: &Sender<Vec<Entry>>,
-    ) -> Result<()> {
+    pub fn record(&self, mixin: Hash, txs: Vec<Transaction>, leader: &WorkingLeader) -> Result<()> {
         // Register and send the entry out while holding the lock.
         // This guarantees PoH order and Entry production and banks LastId queue is the same.
         let mut poh = self.poh.lock().unwrap();
 
-        self.check_tick_height(&poh)?;
+        Self::check_tick_height(&poh, leader)?;
+        self.flush_cache(leader)?;
 
-        self.record_and_send_txs(&mut *poh, mixin, txs, sender)
+        Self::record_and_send_txs(&mut *poh, mixin, txs, leader)
     }
 
     /// A recorder to synchronize PoH with the following data structures
     /// * bank - the LastId's queue is updated on `tick` and `record` events
     /// * sender - the Entry channel that outputs to the ledger
-    pub fn new(tick_height: u64, last_entry_id: Hash, max_tick_height: u64) -> Self {
+    pub fn new(tick_height: u64, last_entry_id: Hash) -> Self {
         let poh = Arc::new(Mutex::new(Poh::new(last_entry_id, tick_height)));
-        PohRecorder {
-            poh,
-            max_tick_height,
-        }
+        let tick_cache = Arc::new(Mutex::new(vec![]));
+        PohRecorder { poh, tick_cache }
     }
 
-    fn check_tick_height(&self, poh: &Poh) -> Result<()> {
-        if poh.tick_height >= self.max_tick_height {
+    fn check_tick_height(poh: &Poh, leader: &WorkingLeader) -> Result<()> {
+        if poh.tick_height < leader.min_tick_height {
+            Err(Error::PohRecorderError(
+                PohRecorderError::MinHeightNotReached,
+            ))
+        } else if poh.tick_height >= leader.max_tick_height {
             Err(Error::PohRecorderError(PohRecorderError::MaxHeightReached))
         } else {
             Ok(())
@@ -85,11 +102,10 @@ impl PohRecorder {
     }
 
     fn record_and_send_txs(
-        &self,
         poh: &mut Poh,
         mixin: Hash,
         txs: Vec<Transaction>,
-        sender: &Sender<Vec<Entry>>,
+        leader: &WorkingLeader,
     ) -> Result<()> {
         let entry = poh.record(mixin);
         assert!(!txs.is_empty(), "Entries without transactions are used to track real-time passing in the ledger and can only be generated with PohRecorder::tick function");
@@ -99,25 +115,24 @@ impl PohRecorder {
             id: entry.id,
             transactions: txs,
         };
-        sender.send(vec![entry])?;
+        leader.sender.send(vec![entry])?;
         Ok(())
     }
 
-    fn register_and_send_tick(
-        &self,
-        poh: &mut Poh,
-        bank: &Arc<Bank>,
-        sender: &Sender<Vec<Entry>>,
-    ) -> Result<()> {
+    fn generate_tick(poh: &mut Poh) -> Entry {
         let tick = poh.tick();
-        let tick = Entry {
+        Entry {
             tick_height: tick.tick_height,
             num_hashes: tick.num_hashes,
             id: tick.id,
             transactions: vec![],
-        };
-        bank.register_tick(&tick.id);
-        sender.send(vec![tick])?;
+        }
+    }
+
+    fn register_and_send_tick(poh: &mut Poh, leader: &WorkingLeader) -> Result<()> {
+        let tick = Self::generate_tick(poh);
+        leader.bank.register_tick(&tick.id);
+        leader.sender.send(vec![tick])?;
         Ok(())
     }
 }
@@ -137,32 +152,65 @@ mod tests {
         let bank = Arc::new(Bank::new(&genesis_block));
         let prev_id = bank.last_id();
         let (entry_sender, entry_receiver) = channel();
-        let mut poh_recorder = PohRecorder::new(0, prev_id, 2);
+        let poh_recorder = PohRecorder::new(0, prev_id);
+
+        let leader = WorkingLeader {
+            bank,
+            sender: entry_sender,
+            min_tick_height: 0,
+            max_tick_height: 2,
+        };
 
         //send some data
         let h1 = hash(b"hello world!");
         let tx = test_tx();
-        poh_recorder
-            .record(h1, vec![tx.clone()], &entry_sender)
-            .unwrap();
+        poh_recorder.record(h1, vec![tx.clone()], &leader).unwrap();
         //get some events
         let e = entry_receiver.recv().unwrap();
         assert_eq!(e[0].tick_height, 0); // super weird case, but ok!
 
-        poh_recorder.tick(&bank, &entry_sender).unwrap();
+        poh_recorder.tick(&leader).unwrap();
         let e = entry_receiver.recv().unwrap();
         assert_eq!(e[0].tick_height, 1);
 
-        poh_recorder.tick(&bank, &entry_sender).unwrap();
+        poh_recorder.tick(&leader).unwrap();
         let e = entry_receiver.recv().unwrap();
         assert_eq!(e[0].tick_height, 2);
 
         // max tick height reached
-        assert!(poh_recorder.tick(&bank, &entry_sender).is_err());
-        assert!(poh_recorder.record(h1, vec![tx], &entry_sender).is_err());
+        assert!(poh_recorder.tick(&leader).is_err());
+        assert!(poh_recorder.record(h1, vec![tx], &leader).is_err());
 
         //make sure it handles channel close correctly
         drop(entry_receiver);
-        assert!(poh_recorder.tick(&bank, &entry_sender).is_err());
+        assert!(poh_recorder.tick(&leader).is_err());
+    }
+
+    #[test]
+    fn test_poh_recorder_tick_cache() {
+        let (genesis_block, _mint_keypair) = GenesisBlock::new(2);
+        let bank = Arc::new(Bank::new(&genesis_block));
+        let prev_id = bank.last_id();
+        let (entry_sender, entry_receiver) = channel();
+        let poh_recorder = PohRecorder::new(0, prev_id);
+
+        let leader = WorkingLeader {
+            bank,
+            sender: entry_sender,
+            min_tick_height: 1,
+            max_tick_height: 2,
+        };
+
+        // tick should be cached
+        assert!(poh_recorder.tick(&leader).is_err());
+        assert!(entry_receiver.try_recv().is_err());
+
+        // leader should be at the right height
+        poh_recorder.tick(&leader).unwrap();
+
+        let e = entry_receiver.recv().unwrap();
+        assert_eq!(e[0].tick_height, 1);
+        let e = entry_receiver.recv().unwrap();
+        assert_eq!(e[0].tick_height, 2);
     }
 }

--- a/src/poh_service.rs
+++ b/src/poh_service.rs
@@ -1,14 +1,12 @@
 //! The `poh_service` module implements a service that records the passing of
 //! "ticks", a measure of time in the PoH stream
 
-use crate::entry::Entry;
-use crate::poh_recorder::PohRecorder;
-use crate::result::Result;
+use crate::poh_recorder::{PohRecorder, PohRecorderError, WorkingLeader};
+use crate::result::{Error, Result};
 use crate::service::Service;
-use solana_runtime::bank::Bank;
 use solana_sdk::timing::NUM_TICKS_PER_SECOND;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::mpsc::Sender;
+use std::sync::mpsc::{channel, Receiver, Sender, TryRecvError};
 use std::sync::Arc;
 use std::thread::{self, sleep, Builder, JoinHandle};
 use std::time::Duration;
@@ -46,55 +44,72 @@ impl PohService {
     }
 
     pub fn new(
-        bank: Arc<Bank>,
-        sender: Sender<Vec<Entry>>,
         poh_recorder: PohRecorder,
         config: PohServiceConfig,
         poh_exit: Arc<AtomicBool>,
-    ) -> Self {
+    ) -> (Self, Sender<WorkingLeader>) {
         // PohService is a headless producer, so when it exits it should notify the banking stage.
         // Since channel are not used to talk between these threads an AtomicBool is used as a
         // signal.
         let poh_exit_ = poh_exit.clone();
+        let (leader_sender, leader_receiver) = channel();
         // Single thread to generate ticks
         let tick_producer = Builder::new()
             .name("solana-poh-service-tick_producer".to_string())
             .spawn(move || {
-                let mut poh_recorder_ = poh_recorder;
-                let sender = sender.clone();
-                let bank = bank.clone();
+                let mut poh_recorder = poh_recorder;
+                let leader_receiver = leader_receiver;
                 let return_value =
-                    Self::tick_producer(&bank, &sender, &mut poh_recorder_, config, &poh_exit_);
+                    Self::tick_producer(&leader_receiver, &mut poh_recorder, config, &poh_exit_);
                 poh_exit_.store(true, Ordering::Relaxed);
                 return_value
             })
             .unwrap();
 
-        Self {
-            tick_producer,
-            poh_exit,
-        }
+        (
+            Self {
+                tick_producer,
+                poh_exit,
+            },
+            leader_sender,
+        )
     }
 
     fn tick_producer(
-        bank: &Arc<Bank>,
-        sender: &Sender<Vec<Entry>>,
+        leader_receiver: &Receiver<WorkingLeader>,
         poh: &mut PohRecorder,
         config: PohServiceConfig,
         poh_exit: &AtomicBool,
     ) -> Result<()> {
+        let mut leader = None;
         loop {
+            if leader.is_none() {
+                let e = leader_receiver.try_recv();
+                leader = match e {
+                    Err(TryRecvError::Empty) => None,
+                    _ => Some(e?),
+                };
+            }
             match config {
                 PohServiceConfig::Tick(num) => {
                     for _ in 1..num {
-                        poh.hash()?;
+                        poh.hash();
                     }
                 }
                 PohServiceConfig::Sleep(duration) => {
                     sleep(duration);
                 }
             }
-            poh.tick(&bank, sender)?;
+            let e = if let Some(ref current_leader) = leader {
+                poh.tick(current_leader)
+            } else {
+                Ok(())
+            };
+            match e {
+                Err(Error::PohRecorderError(PohRecorderError::MinHeightNotReached)) => (),
+                Err(Error::PohRecorderError(PohRecorderError::MaxHeightReached)) => leader = None,
+                e => e?,
+            };
             if poh_exit.load(Ordering::Relaxed) {
                 return Ok(());
             }
@@ -114,6 +129,7 @@ impl Service for PohService {
 mod tests {
     use super::*;
     use crate::test_tx::test_tx;
+    use solana_runtime::bank::Bank;
     use solana_sdk::genesis_block::GenesisBlock;
     use solana_sdk::hash::hash;
     use std::sync::mpsc::channel;
@@ -124,12 +140,18 @@ mod tests {
         let bank = Arc::new(Bank::new(&genesis_block));
         let prev_id = bank.last_id();
         let (entry_sender, entry_receiver) = channel();
-        let poh_recorder = PohRecorder::new(bank.tick_height(), prev_id, std::u64::MAX);
+        let poh_recorder = PohRecorder::new(bank.tick_height(), prev_id);
         let exit = Arc::new(AtomicBool::new(false));
+        let working_leader = WorkingLeader {
+            bank: bank.clone(),
+            sender: entry_sender,
+            min_tick_height: bank.tick_height(),
+            max_tick_height: std::u64::MAX,
+        };
 
         let entry_producer: JoinHandle<Result<()>> = {
             let poh_recorder = poh_recorder.clone();
-            let entry_sender = entry_sender.clone();
+            let working_leader = working_leader.clone();
             let exit = exit.clone();
 
             Builder::new()
@@ -139,7 +161,7 @@ mod tests {
                         // send some data
                         let h1 = hash(b"hello world!");
                         let tx = test_tx();
-                        poh_recorder.record(h1, vec![tx], &entry_sender).unwrap();
+                        poh_recorder.record(h1, vec![tx], &working_leader).unwrap();
 
                         if exit.load(Ordering::Relaxed) {
                             break Ok(());
@@ -150,13 +172,13 @@ mod tests {
         };
 
         const HASHES_PER_TICK: u64 = 2;
-        let poh_service = PohService::new(
-            bank,
-            entry_sender,
-            poh_recorder,
+        let (poh_service, leader_sender) = PohService::new(
+            poh_recorder.clone(),
             PohServiceConfig::Tick(HASHES_PER_TICK as usize),
             Arc::new(AtomicBool::new(false)),
         );
+
+        leader_sender.send(working_leader.clone()).expect("send");
 
         // get some events
         let mut hashes = 0;

--- a/src/result.rs
+++ b/src/result.rs
@@ -20,6 +20,7 @@ pub enum Error {
     JoinError(Box<dyn Any + Send + 'static>),
     RecvError(std::sync::mpsc::RecvError),
     RecvTimeoutError(std::sync::mpsc::RecvTimeoutError),
+    TryRecvError(std::sync::mpsc::TryRecvError),
     Serialize(std::boxed::Box<bincode::ErrorKind>),
     BankError(bank::BankError),
     ClusterInfoError(cluster_info::ClusterInfoError),
@@ -44,6 +45,11 @@ impl std::error::Error for Error {}
 impl std::convert::From<std::sync::mpsc::RecvError> for Error {
     fn from(e: std::sync::mpsc::RecvError) -> Error {
         Error::RecvError(e)
+    }
+}
+impl std::convert::From<std::sync::mpsc::TryRecvError> for Error {
+    fn from(e: std::sync::mpsc::TryRecvError) -> Error {
+        Error::TryRecvError(e)
     }
 }
 impl std::convert::From<std::sync::mpsc::RecvTimeoutError> for Error {


### PR DESCRIPTION
#### Problem


A persistent PoHRecorder will always be generating ticks.  Those ticks need to be synchronously cached or cleared with respect to record and tick generation for a leader's bank.  For a TVU those ticks indicate that the slot to be a leader has been reached.  For a TPU those ticks indicate that the leader slot is complete.  The TPU's bank will also need to process the ticks connecting it to the previous bank and encode them into a block.

#### Summary of Changes

* Cache ticks in PoH Record
* PoH Service receives a scheduled leader and generates ticks for it until max height is reached.

Next step is to move out PoHService out of TPU and pass it a Sender<Leader> channel that connects it to the persistant PoHService.

Fixes #
