### PR TITLE
entry_stream_stage: Remove dependency on Entry::tick_height

### DIFF
--- a/src/tvu.rs
+++ b/src/tvu.rs
@@ -139,6 +139,7 @@ impl Tvu {
             let (entry_stream_stage, entry_stream_receiver) = EntryStreamStage::new(
                 previous_receiver,
                 entry_stream.unwrap().to_string(),
+                bank.tick_height(),
                 leader_scheduler,
                 exit.clone(),
             );


### PR DESCRIPTION
entry_stream_stage uses Entry's tick_height field since it's convenient to do so.  But we want to remove tick_height from Entry so instead entry_stream_stage can count the ticks itself as they fly by.

Progress towards #2712