### PR TITLE
Remove Entry::tick_height field

### DIFF
--- a/src/blocktree_processor.rs
+++ b/src/blocktree_processor.rs
@@ -433,7 +433,7 @@ mod tests {
 
         // Start off the ledger with the psuedo-tick linked to the genesis block
         // (see entry0 in `process_ledger`)
-        let tick = Entry::new(&genesis_block.last_id(), 0, 1, vec![]);
+        let tick = Entry::new(&genesis_block.last_id(), 1, vec![]);
         let mut hash = tick.id;
         entries.push(tick);
 
@@ -444,7 +444,7 @@ mod tests {
             let mut e = next_entries(&hash, 0, txs);
             entries.append(&mut e);
             hash = entries.last().unwrap().id;
-            let tick = Entry::new(&hash, 0, num_hashes, vec![]);
+            let tick = Entry::new(&hash, num_hashes, vec![]);
             hash = tick.id;
             last_id = hash;
             entries.push(tick);
@@ -532,7 +532,7 @@ mod tests {
 
         // Start off the ledger with the psuedo-tick linked to the genesis block
         // (see entry0 in `process_ledger`)
-        let tick = Entry::new(&genesis_block.last_id(), 0, 1, vec![]);
+        let tick = Entry::new(&genesis_block.last_id(), 1, vec![]);
         let mut hash = tick.id;
         entries.push(tick);
 
@@ -540,7 +540,7 @@ mod tests {
             // Transfer one token from the mint to a random account
             let keypair = Keypair::new();
             let tx = SystemTransaction::new_account(mint_keypair, keypair.pubkey(), 1, last_id, 0);
-            let entry = Entry::new(&hash, 0, 1, vec![tx]);
+            let entry = Entry::new(&hash, 1, vec![tx]);
             hash = entry.id;
             entries.push(entry);
 
@@ -548,12 +548,12 @@ mod tests {
             // ProgramError<0, ResultWithNegativeTokens> error when processed
             let keypair2 = Keypair::new();
             let tx = SystemTransaction::new_account(&keypair, keypair2.pubkey(), 42, last_id, 0);
-            let entry = Entry::new(&hash, 0, 1, vec![tx]);
+            let entry = Entry::new(&hash, 1, vec![tx]);
             hash = entry.id;
             entries.push(entry);
 
             if (i + 1) % tick_interval == 0 {
-                let tick = Entry::new(&hash, 0, 1, vec![]);
+                let tick = Entry::new(&hash, 1, vec![]);
                 hash = tick.id;
                 last_id = hash;
                 entries.push(tick);

--- a/src/broadcast_service.rs
+++ b/src/broadcast_service.rs
@@ -405,9 +405,7 @@ mod test {
             );
 
             let ticks = create_ticks(max_tick_height - start_tick_height, Hash::default());
-            for (i, mut tick) in ticks.into_iter().enumerate() {
-                // Simulate the tick heights generated in poh.rs
-                tick.tick_height = start_tick_height + i as u64 + 1;
+            for (_, tick) in ticks.into_iter().enumerate() {
                 entry_sender
                     .send(vec![tick])
                     .expect("Expect successful send to broadcast service");

--- a/src/chacha.rs
+++ b/src/chacha.rs
@@ -169,7 +169,7 @@ mod tests {
         use bs58;
         //  golden needs to be updated if blob stuff changes....
         let golden = Hash::new(
-            &bs58::decode("8NMJBwpXoBoA7YrA5CemRtGtfAqoY15bvnCqVjh4LYpS")
+            &bs58::decode("3hY6c5V5R6ho3k5KBYkDg2nZTtkuBpvu9n421nGntHrg")
                 .into_vec()
                 .unwrap(),
         );

--- a/src/entry_stream.rs
+++ b/src/entry_stream.rs
@@ -206,7 +206,7 @@ mod test {
                     .emit_block_event(previous_slot, &leader_id, tick_height - 1, last_id)
                     .unwrap();
             }
-            let entry = Entry::new(&mut last_id, tick_height, 1, vec![]); // just ticks
+            let entry = Entry::new(&mut last_id, 1, vec![]); // just ticks
             last_id = entry.id;
             previous_slot = curr_slot;
             entry_stream

--- a/src/entry_stream_stage.rs
+++ b/src/entry_stream_stage.rs
@@ -148,15 +148,15 @@ mod test {
         let mut last_id = Hash::default();
         let mut entries = Vec::new();
         let mut expected_entries = Vec::new();
-        for x in 0..6 {
-            let entry = Entry::new(&mut last_id, x, 1, vec![]); //just ticks
+        for _ in 0..6 {
+            let entry = Entry::new(&mut last_id, 1, vec![]); //just ticks
             last_id = entry.id;
             expected_entries.push(entry.clone());
             entries.push(entry);
         }
         let keypair = Keypair::new();
         let tx = SystemTransaction::new_account(&keypair, keypair.pubkey(), 1, Hash::default(), 0);
-        let entry = Entry::new(&mut last_id, ticks_per_slot - 1, 1, vec![tx]);
+        let entry = Entry::new(&mut last_id, 1, vec![tx]);
         expected_entries.insert(ticks_per_slot as usize, entry.clone());
         entries.insert(ticks_per_slot as usize, entry);
 

--- a/src/poh_recorder.rs
+++ b/src/poh_recorder.rs
@@ -94,7 +94,6 @@ impl PohRecorder {
         let entry = poh.record(mixin);
         assert!(!txs.is_empty(), "Entries without transactions are used to track real-time passing in the ledger and can only be generated with PohRecorder::tick function");
         let entry = Entry {
-            tick_height: entry.tick_height,
             num_hashes: entry.num_hashes,
             id: entry.id,
             transactions: txs,
@@ -111,7 +110,6 @@ impl PohRecorder {
     ) -> Result<()> {
         let tick = poh.tick();
         let tick = Entry {
-            tick_height: tick.tick_height,
             num_hashes: tick.num_hashes,
             id: tick.id,
             transactions: vec![],
@@ -146,16 +144,13 @@ mod tests {
             .record(h1, vec![tx.clone()], &entry_sender)
             .unwrap();
         //get some events
-        let e = entry_receiver.recv().unwrap();
-        assert_eq!(e[0].tick_height, 0); // super weird case, but ok!
+        let _e = entry_receiver.recv().unwrap();
 
         poh_recorder.tick(&bank, &entry_sender).unwrap();
-        let e = entry_receiver.recv().unwrap();
-        assert_eq!(e[0].tick_height, 1);
+        let _e = entry_receiver.recv().unwrap();
 
         poh_recorder.tick(&bank, &entry_sender).unwrap();
-        let e = entry_receiver.recv().unwrap();
-        assert_eq!(e[0].tick_height, 2);
+        let _e = entry_receiver.recv().unwrap();
 
         // max tick height reached
         assert!(poh_recorder.tick(&bank, &entry_sender).is_err());

--- a/src/replay_stage.rs
+++ b/src/replay_stage.rs
@@ -793,7 +793,7 @@ mod test {
 
         entries.clear();
         for _ in 0..5 {
-            let entry = Entry::new(&mut Hash::default(), 0, 1, vec![]); //just broken entries
+            let entry = Entry::new(&mut Hash::default(), 1, vec![]); //just broken entries
             entries.push(entry);
         }
 

--- a/src/storage_stage.rs
+++ b/src/storage_stage.rs
@@ -628,7 +628,7 @@ mod tests {
         let keypair = Keypair::new();
         let vote_tx = VoteTransaction::new_vote(&keypair, 123456, Hash::default(), 1);
         vote_txs.push(vote_tx);
-        let vote_entries = vec![Entry::new(&Hash::default(), 0, 1, vote_txs)];
+        let vote_entries = vec![Entry::new(&Hash::default(), 1, vote_txs)];
         storage_entry_sender.send(vote_entries).unwrap();
 
         for _ in 0..5 {


### PR DESCRIPTION
Depends-on: #2845, #2844 
Fixes #2712

Less painful than expected.  Only the top commit is a part of this PR.