### PR TITLE
Charge transaction fee even in case of ProgramError

### DIFF
--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -130,7 +130,7 @@ fn main() {
                 last_id = entry.id;
                 num_entries += 1;
 
-                if let Err(e) = blocktree_processor::process_entry(&bank, &entry).0 {
+                if let Err(e) = blocktree_processor::process_entry(&bank, &entry) {
                     eprintln!("verify failed at entry[{}], err: {:?}", i + 2, e);
                     if !matches.is_present("continue") {
                         exit(1);

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -579,6 +579,12 @@ impl Bank {
         parents
     }
 
+    pub fn withdraw(&self, pubkey: &Pubkey, tokens: u64) {
+        let mut account = self.get_account(pubkey).unwrap_or_default();
+        account.tokens -= tokens;
+        self.accounts.store_slow(true, pubkey, &account);
+    }
+
     pub fn deposit(&self, pubkey: &Pubkey, tokens: u64) {
         let mut account = self.get_account(pubkey).unwrap_or_default();
         account.tokens += tokens;

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -145,7 +145,7 @@ impl Bank {
         if *parent.hash.read().unwrap() == Hash::default() {
             *parent.hash.write().unwrap() = parent.hash_internal_state();
         }
-        bank.leader = leader.clone();
+        bank.leader = *leader;
         bank
     }
 
@@ -521,7 +521,7 @@ impl Bank {
         let mut fees = 0;
         let results = txs
             .iter()
-            .zip(executed.into_iter())
+            .zip(executed.iter())
             .map(|(tx, res)| match *res {
                 Err(BankError::ProgramError(_, _)) => {
                     // Charge the transaction fee even in case of ProgramError

--- a/src/bank_forks.rs
+++ b/src/bank_forks.rs
@@ -38,6 +38,7 @@ impl BankForks {
 mod tests {
     use super::*;
     use solana_sdk::hash::Hash;
+    use solana_sdk::pubkey::Pubkey;
 
     #[test]
     fn test_bank_forks_root() {
@@ -51,7 +52,7 @@ mod tests {
     fn test_bank_forks_parent() {
         let bank = Bank::default();
         let mut bank_forks = BankForks::new(0, bank);
-        let child_bank = Bank::new_from_parent(&bank_forks.working_bank());
+        let child_bank = Bank::new_from_parent(&bank_forks.working_bank(), &Pubkey::default());
         child_bank.register_tick(&Hash::default());
         let child_bank_id = 1;
         bank_forks.insert(child_bank_id, child_bank);

--- a/src/fullnode.rs
+++ b/src/fullnode.rs
@@ -319,8 +319,7 @@ impl Fullnode {
                 }
                 None => FullnodeReturnType::LeaderToLeaderRotation, // value doesn't matter here...
             };
-
-            let tpu_bank = Arc::new(Bank::new_from_parent(bank));
+            let tpu_bank = Arc::new(Bank::new_from_parent(bank, &leader));
             self.node_services.tpu.switch_to_leader(
                 &tpu_bank,
                 PohServiceConfig::default(),

--- a/src/rpc_pubsub.rs
+++ b/src/rpc_pubsub.rs
@@ -168,6 +168,7 @@ mod tests {
     use solana_sdk::budget_program;
     use solana_sdk::budget_transaction::BudgetTransaction;
     use solana_sdk::genesis_block::GenesisBlock;
+    use solana_sdk::pubkey::Pubkey;
     use solana_sdk::signature::{Keypair, KeypairUtil};
     use solana_sdk::system_transaction::SystemTransaction;
     use solana_sdk::transaction::Transaction;
@@ -184,7 +185,7 @@ mod tests {
         subscriptions.notify_subscribers(&bank);
 
         // Simulate a block boundary
-        Ok(Arc::new(Bank::new_from_parent(&bank)))
+        Ok(Arc::new(Bank::new_from_parent(&bank, &Pubkey::default())))
     }
 
     fn create_session() -> Arc<Session> {


### PR DESCRIPTION
#### Problem
The fee is not charged when a transaction fails due to ProgramError

#### Summary of Changes
Check if the result is a ProgramError. If so, withdraw transaction fee from account 0.
 
Fixes #2526
