### PR TITLE
Make gossip selection stake based

### DIFF
--- a/bench-tps/src/main.rs
+++ b/bench-tps/src/main.rs
@@ -41,7 +41,8 @@ fn converge(
     spy_cluster_info.insert_info(leader.clone());
     spy_cluster_info.set_leader(leader.id);
     let spy_ref = Arc::new(RwLock::new(spy_cluster_info));
-    let gossip_service = GossipService::new(&spy_ref, None, gossip_socket, exit_signal.clone());
+    let gossip_service =
+        GossipService::new(&spy_ref, None, None, gossip_socket, exit_signal.clone());
     let mut v: Vec<NodeInfo> = vec![];
     // wait for the network to converge, 30 seconds should be plenty
     for _ in 0..30 {

--- a/src/cluster_info.rs
+++ b/src/cluster_info.rs
@@ -758,7 +758,12 @@ impl ClusterInfo {
 
     fn new_pull_requests(&mut self, bank: Option<&Arc<Bank>>) -> Vec<(SocketAddr, Protocol)> {
         let now = timestamp();
-        let pulls: Vec<_> = self.gossip.new_pull_request(now, bank).ok().into_iter().collect();
+        let pulls: Vec<_> = self
+            .gossip
+            .new_pull_request(now, bank)
+            .ok()
+            .into_iter()
+            .collect();
 
         let pr: Vec<_> = pulls
             .into_iter()

--- a/src/crds_gossip.rs
+++ b/src/crds_gossip.rs
@@ -8,9 +8,12 @@ use crate::crds_gossip_error::CrdsGossipError;
 use crate::crds_gossip_pull::CrdsGossipPull;
 use crate::crds_gossip_push::{CrdsGossipPush, CRDS_GOSSIP_NUM_ACTIVE};
 use crate::crds_value::CrdsValue;
+use solana_runtime::bank::Bank;
 use solana_runtime::bloom::Bloom;
 use solana_sdk::hash::Hash;
 use solana_sdk::pubkey::Pubkey;
+use std::cmp;
+use std::sync::Arc;
 
 ///The min size for bloom filters
 pub const CRDS_GOSSIP_BLOOM_SIZE: usize = 1000;
@@ -92,9 +95,10 @@ impl CrdsGossip {
 
     /// refresh the push active set
     /// * ratio - number of actives to rotate
-    pub fn refresh_push_active_set(&mut self) {
+    pub fn refresh_push_active_set(&mut self, bank: Option<&Arc<Bank>>) {
         self.push.refresh_push_active_set(
             &self.crds,
+            bank,
             self.id,
             self.pull.pull_request_time.len(),
             CRDS_GOSSIP_NUM_ACTIVE,
@@ -105,8 +109,9 @@ impl CrdsGossip {
     pub fn new_pull_request(
         &self,
         now: u64,
+        bank: Option<&Arc<Bank>>,
     ) -> Result<(Pubkey, Bloom<Hash>, CrdsValue), CrdsGossipError> {
-        self.pull.new_pull_request(&self.crds, self.id, now)
+        self.pull.new_pull_request(&self.crds, self.id, now, bank)
     }
 
     /// time when a request to `from` was initiated
@@ -156,6 +161,32 @@ impl CrdsGossip {
     }
 }
 
+/// A function that computes a normalized(log of bank balance) stake
+pub fn get_stake(id: &Pubkey, bank: Option<&Arc<Bank>>) -> u32 {
+    match bank {
+        Some(bank) => {
+            // cap the max balance to u32 max (it should be plenty)
+            let bal = cmp::min(u64::from(u32::max_value()), bank.get_balance(id));
+            cmp::max(1, (bal as f32).ln().round() as u32)
+        }
+        _ => 1,
+    }
+}
+
+/// A function that computes bounded weight given some max, a time since last selected, and a stake value
+/// The minimum stake is 1 and not 0 to allow 'time since last' picked to factor in.
+pub fn get_weight(max_weight: u32, time_since_last_selected: u32, stake: u32) -> u32 {
+    cmp::max(
+        1,
+        cmp::min(
+            max_weight,
+            time_since_last_selected
+                .checked_mul(stake)
+                .unwrap_or(max_weight),
+        ),
+    )
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -174,7 +205,7 @@ mod test {
             .crds
             .insert(CrdsValue::ContactInfo(ci.clone()), 0)
             .unwrap();
-        crds_gossip.refresh_push_active_set();
+        crds_gossip.refresh_push_active_set(None);
         let now = timestamp();
         //incorrect dest
         let mut res = crds_gossip.process_prune_msg(

--- a/src/crds_gossip_pull.rs
+++ b/src/crds_gossip_pull.rs
@@ -226,7 +226,6 @@ mod test {
         // The min balance of the heaviest nodes is at least ln(3000) - 0.5
         // This is because the heaviest nodes will have very similar weights
         let min_balance = E.powf(3000_f32.ln() - 0.5);
-        println!("{:?}", min_balance);
         let now = 1024;
         // try upto 10 times because of rng
         for _ in 0..10 {

--- a/src/crds_gossip_pull.rs
+++ b/src/crds_gossip_pull.rs
@@ -9,8 +9,9 @@
 //! with random hash functions.  So each subsequent request will have a different distribution
 //! of false positives.
 
+use crate::contact_info::ContactInfo;
 use crate::crds::Crds;
-use crate::crds_gossip::CRDS_GOSSIP_BLOOM_SIZE;
+use crate::crds_gossip::{get_stake, get_weight, CRDS_GOSSIP_BLOOM_SIZE};
 use crate::crds_gossip_error::CrdsGossipError;
 use crate::crds_value::{CrdsValue, CrdsValueLabel};
 use crate::packet::BLOB_DATA_SIZE;
@@ -18,11 +19,13 @@ use bincode::serialized_size;
 use hashbrown::HashMap;
 use rand;
 use rand::distributions::{Distribution, WeightedIndex};
+use solana_runtime::bank::Bank;
 use solana_runtime::bloom::Bloom;
 use solana_sdk::hash::Hash;
 use solana_sdk::pubkey::Pubkey;
 use std::cmp;
 use std::collections::VecDeque;
+use std::sync::Arc;
 
 pub const CRDS_GOSSIP_PULL_CRDS_TIMEOUT_MS: u64 = 15000;
 
@@ -54,20 +57,19 @@ impl CrdsGossipPull {
         crds: &Crds,
         self_id: Pubkey,
         now: u64,
+        bank: Option<&Arc<Bank>>,
     ) -> Result<(Pubkey, Bloom<Hash>, CrdsValue), CrdsGossipError> {
         let options: Vec<_> = crds
             .table
             .values()
             .filter_map(|v| v.value.contact_info())
-            .filter(|v| {
-                v.id != self_id && !v.gossip.ip().is_unspecified() && !v.gossip.ip().is_multicast()
-            })
+            .filter(|v| v.id != self_id && ContactInfo::is_valid_address(&v.gossip))
             .map(|item| {
+                let max_weight = u32::from(u16::max_value()) - 1;
                 let req_time: u64 = *self.pull_request_time.get(&item.id).unwrap_or(&0);
-                let weight = cmp::max(
-                    1,
-                    cmp::min(u64::from(u16::max_value()) - 1, (now - req_time) / 1024) as u32,
-                );
+                let since = (now - req_time / 1024) as u32;
+                let stake = get_stake(&item.id, bank);
+                let weight = get_weight(max_weight, since, stake);
                 (weight, item)
             })
             .collect();
@@ -210,19 +212,19 @@ mod test {
         let id = entry.label().pubkey();
         let node = CrdsGossipPull::default();
         assert_eq!(
-            node.new_pull_request(&crds, id, 0),
+            node.new_pull_request(&crds, id, 0, None),
             Err(CrdsGossipError::NoPeers)
         );
 
         crds.insert(entry.clone(), 0).unwrap();
         assert_eq!(
-            node.new_pull_request(&crds, id, 0),
+            node.new_pull_request(&crds, id, 0, None),
             Err(CrdsGossipError::NoPeers)
         );
 
         let new = CrdsValue::ContactInfo(ContactInfo::new_localhost(Keypair::new().pubkey(), 0));
         crds.insert(new.clone(), 0).unwrap();
-        let req = node.new_pull_request(&crds, id, 0);
+        let req = node.new_pull_request(&crds, id, 0, None);
         let (to, _, self_info) = req.unwrap();
         assert_eq!(to, new.label().pubkey());
         assert_eq!(self_info, entry);
@@ -245,7 +247,7 @@ mod test {
 
         // odds of getting the other request should be 1 in u64::max_value()
         for _ in 0..10 {
-            let req = node.new_pull_request(&crds, node_id, u64::max_value());
+            let req = node.new_pull_request(&crds, node_id, u64::max_value(), None);
             let (to, _, self_info) = req.unwrap();
             assert_eq!(to, old.label().pubkey());
             assert_eq!(self_info, entry);
@@ -261,7 +263,7 @@ mod test {
         node_crds.insert(entry.clone(), 0).unwrap();
         let new = CrdsValue::ContactInfo(ContactInfo::new_localhost(Keypair::new().pubkey(), 0));
         node_crds.insert(new.clone(), 0).unwrap();
-        let req = node.new_pull_request(&node_crds, node_id, 0);
+        let req = node.new_pull_request(&node_crds, node_id, 0, None);
 
         let mut dest_crds = Crds::default();
         let mut dest = CrdsGossipPull::default();
@@ -313,7 +315,7 @@ mod test {
         let mut done = false;
         for _ in 0..30 {
             // there is a chance of a false positive with bloom filters
-            let req = node.new_pull_request(&node_crds, node_id, 0);
+            let req = node.new_pull_request(&node_crds, node_id, 0, None);
             let (_, filter, caller) = req.unwrap();
             let rsp = dest.process_pull_request(&mut dest_crds, caller, filter, 0);
             // if there is a false positive this is empty

--- a/src/crds_gossip_push.rs
+++ b/src/crds_gossip_push.rs
@@ -172,7 +172,7 @@ impl CrdsGossipPush {
         let need = Self::compute_need(self.num_active, self.active_set.len(), ratio);
         let mut new_items = HashMap::new();
 
-        let options: Vec<_> = crds
+        let mut options: Vec<_> = crds
             .table
             .values()
             .filter(|v| v.value.contact_info().is_some())
@@ -190,10 +190,15 @@ impl CrdsGossipPush {
         if options.is_empty() {
             return;
         }
-        let index = WeightedIndex::new(options.iter().map(|weighted| weighted.0)).unwrap();
         while new_items.len() < need {
+            let index = WeightedIndex::new(options.iter().map(|weighted| weighted.0));
+            if index.is_err() {
+                break;
+            }
+            let index = index.unwrap();
             let index = index.sample(&mut rand::thread_rng());
             let item = options[index].1;
+            options.remove(index);
             if self.active_set.get(&item.id).is_some() {
                 continue;
             }

--- a/src/fullnode.rs
+++ b/src/fullnode.rs
@@ -181,6 +181,7 @@ impl Fullnode {
         let gossip_service = GossipService::new(
             &cluster_info,
             Some(blocktree.clone()),
+            Some(bank.clone()),
             node.sockets.gossip,
             exit.clone(),
         );

--- a/src/replicator.rs
+++ b/src/replicator.rs
@@ -136,9 +136,11 @@ impl Replicator {
 
         let blocktree = Arc::new(blocktree);
 
+        //TODO(sagar) Does replicator need a bank also ?
         let gossip_service = GossipService::new(
             &cluster_info,
             Some(blocktree.clone()),
+            None,
             node.sockets.gossip,
             exit.clone(),
         );

--- a/src/thin_client.rs
+++ b/src/thin_client.rs
@@ -373,8 +373,13 @@ pub fn poll_gossip_for_leader(leader_gossip: SocketAddr, timeout: Option<u64>) -
     let (node, gossip_socket) = ClusterInfo::spy_node();
     let my_addr = gossip_socket.local_addr().unwrap();
     let cluster_info = Arc::new(RwLock::new(ClusterInfo::new(node)));
-    let gossip_service =
-        GossipService::new(&cluster_info.clone(), None, gossip_socket, exit.clone());
+    let gossip_service = GossipService::new(
+        &cluster_info.clone(),
+        None,
+        None,
+        gossip_socket,
+        exit.clone(),
+    );
 
     let leader_entry_point = NodeInfo::new_entry_point(&leader_gossip);
     cluster_info

--- a/tests/crds_gossip.rs
+++ b/tests/crds_gossip.rs
@@ -112,7 +112,7 @@ fn network_simulator(network: &mut Network) {
     // make sure there is someone in the active set
     let network_values: Vec<Node> = network.values().cloned().collect();
     network_values.par_iter().for_each(|node| {
-        node.lock().unwrap().refresh_push_active_set();
+        node.lock().unwrap().refresh_push_active_set(None);
     });
     let mut total_bytes = bytes_tx;
     for second in 1..num {
@@ -211,7 +211,7 @@ fn network_run_push(network: &mut Network, start: usize, end: usize) -> (usize, 
         }
         if now % CRDS_GOSSIP_PUSH_MSG_TIMEOUT_MS == 0 && now > 0 {
             network_values.par_iter().for_each(|node| {
-                node.lock().unwrap().refresh_push_active_set();
+                node.lock().unwrap().refresh_push_active_set(None);
             });
         }
         total = network_values
@@ -249,7 +249,7 @@ fn network_run_pull(
         let requests: Vec<_> = {
             network_values
                 .par_iter()
-                .filter_map(|from| from.lock().unwrap().new_pull_request(now).ok())
+                .filter_map(|from| from.lock().unwrap().new_pull_request(now, None).ok())
                 .collect()
         };
         let transfered: Vec<_> = requests

--- a/tests/crds_gossip.rs
+++ b/tests/crds_gossip.rs
@@ -372,7 +372,7 @@ fn test_prune_errors() {
         .crds
         .insert(CrdsValue::ContactInfo(ci.clone()), 0)
         .unwrap();
-    crds_gossip.refresh_push_active_set();
+    crds_gossip.refresh_push_active_set(None);
     let now = timestamp();
     //incorrect dest
     let mut res = crds_gossip.process_prune_msg(

--- a/tests/gossip.rs
+++ b/tests/gossip.rs
@@ -21,7 +21,7 @@ fn test_node(exit: Arc<AtomicBool>) -> (Arc<RwLock<ClusterInfo>>, GossipService,
     let mut tn = Node::new_localhost_with_pubkey(keypair.pubkey());
     let cluster_info = ClusterInfo::new_with_keypair(tn.info.clone(), Arc::new(keypair));
     let c = Arc::new(RwLock::new(cluster_info));
-    let d = GossipService::new(&c.clone(), None, tn.sockets.gossip, exit);
+    let d = GossipService::new(&c.clone(), None, None, tn.sockets.gossip, exit);
     let _ = c.read().unwrap().my_data();
     (c, d, tn.sockets.tvu.pop().unwrap())
 }

--- a/tests/tvu.rs
+++ b/tests/tvu.rs
@@ -32,7 +32,7 @@ fn new_gossip(
     gossip: UdpSocket,
     exit: Arc<AtomicBool>,
 ) -> GossipService {
-    GossipService::new(&cluster_info, None, gossip, exit)
+    GossipService::new(&cluster_info, None, None, gossip, exit)
 }
 
 /// Test that message sent from leader to target1 and replayed to target2


### PR DESCRIPTION
#### Problem

Both push and pull overlays pick peers at random. Which is susceptible to sybil attacks.

#### Summary of Changes

Added stake based peer selection to both push hand pull overlays. 
Weights are calculated based on (time since last picked) * (ln(stake weight)). Taking the log of the stake weight allows giving all nodes a fair chance of network coverage in a reasonable amount of time. This way a node with low stake, compared to a node with u32_max (4,294,967,295) will only have to wait 22 seconds (ln(u32_max) == 22) a few multiple of 22 seconds before it gets picked. 

- [x] Initial plumbing of bank into gossip
- [x] Update weighted selection of pull requests
- [x] Update weighted active set for push requests
- [x] Ensure existing tests are unaffected
- [x] Add new tests with the bank populated 

Fixes #1861
