### PR TITLE
Recover tick height for EntryStream entry-events

### DIFF
--- a/src/entry_stream_stage.rs
+++ b/src/entry_stream_stage.rs
@@ -80,14 +80,14 @@ impl EntryStreamStage {
                 let block_tick_height = queued_block.unwrap().tick_height;
                 let block_id = queued_block.unwrap().id;
                 entry_stream
-                    .emit_block_event(block_slot, &leader_id, block_tick_height, block_id)
+                    .emit_block_event(block_slot, block_tick_height, &leader_id, block_id)
                     .unwrap_or_else(|e| {
                         debug!("Entry Stream error: {:?}, {:?}", e, entry_stream.output);
                     });
                 entry_stream.queued_block = None;
             }
             entry_stream
-                .emit_entry_event(slot, &leader_id, &entry)
+                .emit_entry_event(slot, *tick_height, &leader_id, &entry)
                 .unwrap_or_else(|e| {
                     debug!("Entry Stream error: {:?}, {:?}", e, entry_stream.output);
                 });


### PR DESCRIPTION
#### Problem
Currently, blockexplorer needs to receive the tick height of an entry, but this data was just removed from the Entry struct.

#### Summary of Changes
Add tick-height field to entry-event payload
Change order of `emit_block_event` fields, for consistency with payload
Update EntryStreamStage test to ensure process_entries is producing the correct tick heights for both entry- and block-events (#2844 )
