### PR TITLE
Cache ticks until a working bank can pick them up

### DIFF
--- a/src/banking_stage.rs
+++ b/src/banking_stage.rs
@@ -6,7 +6,7 @@ use crate::entry::Entry;
 use crate::leader_confirmation_service::LeaderConfirmationService;
 use crate::packet::Packets;
 use crate::packet::SharedPackets;
-use crate::poh_recorder::{PohRecorder, PohRecorderError};
+use crate::poh_recorder::{PohRecorder, PohRecorderError, WorkingBank};
 use crate::poh_service::{PohService, PohServiceConfig};
 use crate::result::{Error, Result};
 use crate::service::Service;
@@ -20,7 +20,7 @@ use solana_sdk::pubkey::Pubkey;
 use solana_sdk::timing::{self, duration_as_us, MAX_ENTRY_IDS};
 use solana_sdk::transaction::Transaction;
 use std::sync::atomic::AtomicBool;
-use std::sync::mpsc::{channel, Receiver, RecvTimeoutError, Sender};
+use std::sync::mpsc::{channel, Receiver, RecvTimeoutError};
 use std::sync::{Arc, Mutex};
 use std::thread::{self, Builder, JoinHandle};
 use std::time::Duration;
@@ -52,19 +52,26 @@ impl BankingStage {
     ) -> (Self, Receiver<Vec<Entry>>) {
         let (entry_sender, entry_receiver) = channel();
         let shared_verified_receiver = Arc::new(Mutex::new(verified_receiver));
-        let poh_recorder = PohRecorder::new(bank.tick_height(), *last_entry_id, max_tick_height);
+        let working_bank = WorkingBank {
+            bank: bank.clone(),
+            sender: entry_sender,
+            min_tick_height: bank.tick_height(),
+            max_tick_height,
+        };
+
+        let poh_recorder = PohRecorder::new(bank.tick_height(), *last_entry_id);
 
         // Single thread to generate entries from many banks.
         // This thread talks to poh_service and broadcasts the entries once they have been recorded.
         // Once an entry has been recorded, its last_id is registered with the bank.
         let poh_exit = Arc::new(AtomicBool::new(false));
-        let poh_service = PohService::new(
-            bank.clone(),
-            entry_sender.clone(),
-            poh_recorder.clone(),
-            config,
-            poh_exit.clone(),
-        );
+
+        let (poh_service, leader_sender) =
+            PohService::new(poh_recorder.clone(), config, poh_exit.clone());
+
+        leader_sender
+            .send(working_bank.clone())
+            .expect("failed to send leader to poh_service");
 
         // Single thread to compute confirmation
         let leader_confirmation_service =
@@ -76,7 +83,7 @@ impl BankingStage {
                 let thread_bank = bank.clone();
                 let thread_verified_receiver = shared_verified_receiver.clone();
                 let thread_poh_recorder = poh_recorder.clone();
-                let thread_sender = entry_sender.clone();
+                let thread_leader = working_bank.clone();
                 Builder::new()
                     .name("solana-banking-stage-tx".to_string())
                     .spawn(move || {
@@ -86,7 +93,7 @@ impl BankingStage {
                                 &thread_bank,
                                 &thread_verified_receiver,
                                 &thread_poh_recorder,
-                                &thread_sender,
+                                &thread_leader,
                             ) {
                                 Err(Error::RecvTimeoutError(RecvTimeoutError::Timeout)) => (),
                                 Ok(more_unprocessed_packets) => {
@@ -129,7 +136,7 @@ impl BankingStage {
         txs: &[Transaction],
         results: &[bank::Result<()>],
         poh: &PohRecorder,
-        entry_sender: &Sender<Vec<Entry>>,
+        working_bank: &WorkingBank,
     ) -> Result<()> {
         let processed_transactions: Vec<_> = results
             .iter()
@@ -151,7 +158,7 @@ impl BankingStage {
         if !processed_transactions.is_empty() {
             let hash = Transaction::hash(&processed_transactions);
             // record and unlock will unlock all the successfull transactions
-            poh.record(hash, processed_transactions, entry_sender)?;
+            poh.record(hash, processed_transactions, working_bank)?;
         }
         Ok(())
     }
@@ -160,7 +167,7 @@ impl BankingStage {
         bank: &Bank,
         txs: &[Transaction],
         poh: &PohRecorder,
-        entry_sender: &Sender<Vec<Entry>>,
+        working_bank: &WorkingBank,
     ) -> Result<()> {
         let now = Instant::now();
         // Once accounts are locked, other threads cannot encode transactions that will modify the
@@ -179,7 +186,7 @@ impl BankingStage {
 
         let record_time = {
             let now = Instant::now();
-            Self::record_transactions(txs, &results, poh, entry_sender)?;
+            Self::record_transactions(txs, &results, poh, working_bank)?;
             now.elapsed()
         };
 
@@ -213,7 +220,7 @@ impl BankingStage {
         bank: &Arc<Bank>,
         transactions: &[Transaction],
         poh: &PohRecorder,
-        entry_sender: &Sender<Vec<Entry>>,
+        working_bank: &WorkingBank,
     ) -> Result<(usize)> {
         let mut chunk_start = 0;
         while chunk_start != transactions.len() {
@@ -223,7 +230,7 @@ impl BankingStage {
                 bank,
                 &transactions[chunk_start..chunk_end],
                 poh,
-                entry_sender,
+                working_bank,
             );
             if let Err(Error::PohRecorderError(PohRecorderError::MaxHeightReached)) = result {
                 break;
@@ -239,7 +246,7 @@ impl BankingStage {
         bank: &Arc<Bank>,
         verified_receiver: &Arc<Mutex<Receiver<VerifiedPackets>>>,
         poh: &PohRecorder,
-        entry_sender: &Sender<Vec<Entry>>,
+        working_bank: &WorkingBank,
     ) -> Result<UnprocessedPackets> {
         let recv_start = Instant::now();
         let mms = verified_receiver
@@ -291,7 +298,7 @@ impl BankingStage {
             debug!("verified transactions {}", verified_transactions.len());
 
             let processed =
-                Self::process_transactions(bank, &verified_transactions, poh, entry_sender)?;
+                Self::process_transactions(bank, &verified_transactions, poh, working_bank)?;
             if processed < verified_transactions.len() {
                 bank_shutdown = true;
                 // Collect any unprocessed transactions in this batch for forwarding
@@ -596,7 +603,14 @@ mod tests {
         let (genesis_block, mint_keypair) = GenesisBlock::new(10_000);
         let bank = Arc::new(Bank::new(&genesis_block));
         let (entry_sender, entry_receiver) = channel();
-        let poh_recorder = PohRecorder::new(bank.tick_height(), bank.last_id(), std::u64::MAX);
+        let working_bank = WorkingBank {
+            bank: bank.clone(),
+            sender: entry_sender,
+            min_tick_height: bank.tick_height(),
+            max_tick_height: std::u64::MAX,
+        };
+
+        let poh_recorder = PohRecorder::new(bank.tick_height(), bank.last_id());
         let pubkey = Keypair::new().pubkey();
 
         let transactions = vec![
@@ -605,7 +619,7 @@ mod tests {
         ];
 
         let mut results = vec![Ok(()), Ok(())];
-        BankingStage::record_transactions(&transactions, &results, &poh_recorder, &entry_sender)
+        BankingStage::record_transactions(&transactions, &results, &poh_recorder, &working_bank)
             .unwrap();
         let entries = entry_receiver.recv().unwrap();
         assert_eq!(entries[0].transactions.len(), transactions.len());
@@ -615,14 +629,14 @@ mod tests {
             1,
             ProgramError::ResultWithNegativeTokens,
         ));
-        BankingStage::record_transactions(&transactions, &results, &poh_recorder, &entry_sender)
+        BankingStage::record_transactions(&transactions, &results, &poh_recorder, &working_bank)
             .unwrap();
         let entries = entry_receiver.recv().unwrap();
         assert_eq!(entries[0].transactions.len(), transactions.len());
 
         // Other BankErrors should not be recorded
         results[0] = Err(BankError::AccountNotFound);
-        BankingStage::record_transactions(&transactions, &results, &poh_recorder, &entry_sender)
+        BankingStage::record_transactions(&transactions, &results, &poh_recorder, &working_bank)
             .unwrap();
         let entries = entry_receiver.recv().unwrap();
         assert_eq!(entries[0].transactions.len(), transactions.len() - 1);
@@ -643,17 +657,22 @@ mod tests {
         )];
 
         let (entry_sender, entry_receiver) = channel();
-        let mut poh_recorder =
-            PohRecorder::new(bank.tick_height(), bank.last_id(), bank.tick_height() + 1);
+        let working_bank = WorkingBank {
+            bank: bank.clone(),
+            sender: entry_sender,
+            min_tick_height: bank.tick_height(),
+            max_tick_height: bank.tick_height() + 1,
+        };
+        let poh_recorder = PohRecorder::new(bank.tick_height(), bank.last_id());
 
         BankingStage::process_and_record_transactions(
             &bank,
             &transactions,
             &poh_recorder,
-            &entry_sender,
+            &working_bank,
         )
         .unwrap();
-        poh_recorder.tick(&bank, &entry_sender).unwrap();
+        poh_recorder.tick(&working_bank).unwrap();
 
         let mut need_tick = true;
         // read entries until I find mine, might be ticks...
@@ -682,7 +701,7 @@ mod tests {
                 &bank,
                 &transactions,
                 &poh_recorder,
-                &entry_sender
+                &working_bank
             ),
             Err(Error::PohRecorderError(PohRecorderError::MaxHeightReached))
         );

--- a/src/poh_recorder.rs
+++ b/src/poh_recorder.rs
@@ -14,70 +14,92 @@ use std::sync::{Arc, Mutex};
 pub enum PohRecorderError {
     InvalidCallingObject,
     MaxHeightReached,
+    MinHeightNotReached,
+}
+
+#[derive(Clone)]
+pub struct WorkingBank {
+    pub bank: Arc<Bank>,
+    pub sender: Sender<Vec<Entry>>,
+    pub min_tick_height: u64,
+    pub max_tick_height: u64,
 }
 
 #[derive(Clone)]
 pub struct PohRecorder {
     poh: Arc<Mutex<Poh>>,
-    max_tick_height: u64,
+    tick_cache: Arc<Mutex<Vec<Entry>>>,
 }
 
 impl PohRecorder {
-    pub fn max_tick_height(&self) -> u64 {
-        self.max_tick_height
-    }
-
-    pub fn hash(&self) -> Result<()> {
+    pub fn hash(&self) {
         // TODO: amortize the cost of this lock by doing the loop in here for
         // some min amount of hashes
         let mut poh = self.poh.lock().unwrap();
 
-        self.check_tick_height(&poh)?;
-
         poh.hash();
+    }
 
+    fn flush_cache(&self, working_bank: &WorkingBank) -> Result<()> {
+        let mut cache = vec![];
+        std::mem::swap(&mut cache, &mut self.tick_cache.lock().unwrap());
+        if !cache.is_empty() {
+            for t in &cache {
+                working_bank.bank.register_tick(&t.id);
+            }
+            working_bank.sender.send(cache)?;
+        }
         Ok(())
     }
 
-    pub fn tick(&mut self, bank: &Arc<Bank>, sender: &Sender<Vec<Entry>>) -> Result<()> {
+    pub fn tick(&self, working_bank: &WorkingBank) -> Result<()> {
         // Register and send the entry out while holding the lock if the max PoH height
         // hasn't been reached.
         // This guarantees PoH order and Entry production and banks LastId queue is the same
         let mut poh = self.poh.lock().unwrap();
 
-        self.check_tick_height(&poh)?;
+        Self::check_tick_height(&poh, working_bank).map_err(|e| {
+            let tick = Self::generate_tick(&mut poh);
+            self.tick_cache.lock().unwrap().push(tick);
+            e
+        })?;
+                                                      ;
+        self.flush_cache(working_bank)?;
 
-        self.register_and_send_tick(&mut *poh, bank, sender)
+        Self::register_and_send_tick(&mut *poh, working_bank)
     }
 
     pub fn record(
         &self,
         mixin: Hash,
         txs: Vec<Transaction>,
-        sender: &Sender<Vec<Entry>>,
+        working_bank: &WorkingBank,
     ) -> Result<()> {
         // Register and send the entry out while holding the lock.
         // This guarantees PoH order and Entry production and banks LastId queue is the same.
         let mut poh = self.poh.lock().unwrap();
 
-        self.check_tick_height(&poh)?;
+        Self::check_tick_height(&poh, working_bank)?;
+        self.flush_cache(working_bank)?;
 
-        self.record_and_send_txs(&mut *poh, mixin, txs, sender)
+        Self::record_and_send_txs(&mut *poh, mixin, txs, working_bank)
     }
 
     /// A recorder to synchronize PoH with the following data structures
     /// * bank - the LastId's queue is updated on `tick` and `record` events
     /// * sender - the Entry channel that outputs to the ledger
-    pub fn new(tick_height: u64, last_entry_id: Hash, max_tick_height: u64) -> Self {
+    pub fn new(tick_height: u64, last_entry_id: Hash) -> Self {
         let poh = Arc::new(Mutex::new(Poh::new(last_entry_id, tick_height)));
-        PohRecorder {
-            poh,
-            max_tick_height,
-        }
+        let tick_cache = Arc::new(Mutex::new(vec![]));
+        PohRecorder { poh, tick_cache }
     }
 
-    fn check_tick_height(&self, poh: &Poh) -> Result<()> {
-        if poh.tick_height >= self.max_tick_height {
+    fn check_tick_height(poh: &Poh, working_bank: &WorkingBank) -> Result<()> {
+        if poh.tick_height < working_bank.min_tick_height {
+            Err(Error::PohRecorderError(
+                PohRecorderError::MinHeightNotReached,
+            ))
+        } else if poh.tick_height >= working_bank.max_tick_height {
             Err(Error::PohRecorderError(PohRecorderError::MaxHeightReached))
         } else {
             Ok(())
@@ -85,11 +107,10 @@ impl PohRecorder {
     }
 
     fn record_and_send_txs(
-        &self,
         poh: &mut Poh,
         mixin: Hash,
         txs: Vec<Transaction>,
-        sender: &Sender<Vec<Entry>>,
+        working_bank: &WorkingBank,
     ) -> Result<()> {
         let entry = poh.record(mixin);
         assert!(!txs.is_empty(), "Entries without transactions are used to track real-time passing in the ledger and can only be generated with PohRecorder::tick function");
@@ -98,24 +119,23 @@ impl PohRecorder {
             id: entry.id,
             transactions: txs,
         };
-        sender.send(vec![entry])?;
+        working_bank.sender.send(vec![entry])?;
         Ok(())
     }
 
-    fn register_and_send_tick(
-        &self,
-        poh: &mut Poh,
-        bank: &Arc<Bank>,
-        sender: &Sender<Vec<Entry>>,
-    ) -> Result<()> {
+    fn generate_tick(poh: &mut Poh) -> Entry {
         let tick = poh.tick();
-        let tick = Entry {
+        Entry {
             num_hashes: tick.num_hashes,
             id: tick.id,
             transactions: vec![],
-        };
-        bank.register_tick(&tick.id);
-        sender.send(vec![tick])?;
+        }
+    }
+
+    fn register_and_send_tick(poh: &mut Poh, working_bank: &WorkingBank) -> Result<()> {
+        let tick = Self::generate_tick(poh);
+        working_bank.bank.register_tick(&tick.id);
+        working_bank.sender.send(vec![tick])?;
         Ok(())
     }
 }
@@ -135,29 +155,97 @@ mod tests {
         let bank = Arc::new(Bank::new(&genesis_block));
         let prev_id = bank.last_id();
         let (entry_sender, entry_receiver) = channel();
-        let mut poh_recorder = PohRecorder::new(0, prev_id, 2);
+        let poh_recorder = PohRecorder::new(0, prev_id);
+
+        let working_bank = WorkingBank {
+            bank,
+            sender: entry_sender,
+            min_tick_height: 0,
+            max_tick_height: 2,
+        };
 
         //send some data
         let h1 = hash(b"hello world!");
         let tx = test_tx();
         poh_recorder
-            .record(h1, vec![tx.clone()], &entry_sender)
+            .record(h1, vec![tx.clone()], &working_bank)
             .unwrap();
         //get some events
         let _e = entry_receiver.recv().unwrap();
 
-        poh_recorder.tick(&bank, &entry_sender).unwrap();
+        poh_recorder.tick(&working_bank).unwrap();
         let _e = entry_receiver.recv().unwrap();
 
-        poh_recorder.tick(&bank, &entry_sender).unwrap();
+        poh_recorder.tick(&working_bank).unwrap();
         let _e = entry_receiver.recv().unwrap();
 
         // max tick height reached
-        assert!(poh_recorder.tick(&bank, &entry_sender).is_err());
-        assert!(poh_recorder.record(h1, vec![tx], &entry_sender).is_err());
+        assert!(poh_recorder.tick(&working_bank).is_err());
+        assert!(poh_recorder.record(h1, vec![tx], &working_bank).is_err());
 
         //make sure it handles channel close correctly
         drop(entry_receiver);
-        assert!(poh_recorder.tick(&bank, &entry_sender).is_err());
+        assert!(poh_recorder.tick(&working_bank).is_err());
+    }
+
+    #[test]
+    fn test_poh_recorder_tick_cache() {
+        let (genesis_block, _mint_keypair) = GenesisBlock::new(2);
+        let bank = Arc::new(Bank::new(&genesis_block));
+        let prev_id = bank.last_id();
+        let (entry_sender, entry_receiver) = channel();
+        let poh_recorder = PohRecorder::new(0, prev_id);
+
+        let working_bank = WorkingBank {
+            bank,
+            sender: entry_sender,
+            min_tick_height: 1,
+            max_tick_height: 2,
+        };
+
+        // tick should be cached
+        assert!(poh_recorder.tick(&working_bank).is_err());
+        assert!(entry_receiver.try_recv().is_err());
+
+        // working_bank should be at the right height
+        poh_recorder.tick(&working_bank).unwrap();
+
+        let entries = entry_receiver.recv().unwrap();
+        assert_eq!(entries.len(), 1);
+        let entries = entry_receiver.recv().unwrap();
+        assert_eq!(entries.len(), 1);
+    }
+
+    #[test]
+    fn test_poh_recorder_tick_cache_old_working_bank() {
+        let (genesis_block, _mint_keypair) = GenesisBlock::new(2);
+        let bank = Arc::new(Bank::new(&genesis_block));
+        let prev_id = bank.last_id();
+        let (entry_sender, entry_receiver) = channel();
+        let poh_recorder = PohRecorder::new(0, prev_id);
+
+        let working_bank = WorkingBank {
+            bank,
+            sender: entry_sender,
+            min_tick_height: 1,
+            max_tick_height: 1,
+        };
+
+        // tick should be cached
+        assert_matches!(
+            poh_recorder.tick(&working_bank),
+            Err(Error::PohRecorderError(
+                PohRecorderError::MinHeightNotReached
+            ))
+        );
+
+        // working_bank should be past MaxHeight
+        assert_matches!(
+            poh_recorder.tick(&working_bank),
+            Err(Error::PohRecorderError(PohRecorderError::MaxHeightReached))
+        );
+        assert_eq!(poh_recorder.tick_cache.lock().unwrap().len(), 2);
+
+        assert!(entry_receiver.try_recv().is_err());
     }
 }

--- a/src/result.rs
+++ b/src/result.rs
@@ -20,6 +20,7 @@ pub enum Error {
     JoinError(Box<dyn Any + Send + 'static>),
     RecvError(std::sync::mpsc::RecvError),
     RecvTimeoutError(std::sync::mpsc::RecvTimeoutError),
+    TryRecvError(std::sync::mpsc::TryRecvError),
     Serialize(std::boxed::Box<bincode::ErrorKind>),
     BankError(bank::BankError),
     ClusterInfoError(cluster_info::ClusterInfoError),
@@ -44,6 +45,11 @@ impl std::error::Error for Error {}
 impl std::convert::From<std::sync::mpsc::RecvError> for Error {
     fn from(e: std::sync::mpsc::RecvError) -> Error {
         Error::RecvError(e)
+    }
+}
+impl std::convert::From<std::sync::mpsc::TryRecvError> for Error {
+    fn from(e: std::sync::mpsc::TryRecvError) -> Error {
+        Error::TryRecvError(e)
     }
 }
 impl std::convert::From<std::sync::mpsc::RecvTimeoutError> for Error {


### PR DESCRIPTION
#### Problem

PohRecorder only operates during the leader slot. If it needs to fill the slot of a previous leader that went down, it will not have produced any ticks during that time.

#### Summary of Changes

* Cache ticks before leader slot
* Stop generating ticks after leader slot completes