### PR TITLE
Move PohService and PohRecorder out of banking_stage and into fullnode

### DIFF
--- a/sdk/src/timing.rs
+++ b/sdk/src/timing.rs
@@ -6,7 +6,7 @@ pub const NUM_TICKS_PER_SECOND: usize = 10;
 
 // At 10 ticks/s, 8 ticks per slot implies that leader rotation and voting will happen
 // every 800 ms. A fast voting cadence ensures faster finality and convergence
-pub const DEFAULT_TICKS_PER_SLOT: u64 = 8;
+pub const DEFAULT_TICKS_PER_SLOT: u64 = 80;
 pub const DEFAULT_SLOTS_PER_EPOCH: u64 = 64;
 
 /// The number of most recent `last_id` values that the bank will track the signatures

--- a/src/fullnode.rs
+++ b/src/fullnode.rs
@@ -6,7 +6,8 @@ use crate::blocktree_processor::{self, BankForksInfo};
 use crate::cluster_info::{ClusterInfo, Node, NodeInfo};
 use crate::gossip_service::GossipService;
 use crate::leader_scheduler::{LeaderScheduler, LeaderSchedulerConfig};
-use crate::poh_service::PohServiceConfig;
+use crate::poh_recorder::PohRecorder;
+use crate::poh_service::{PohService, PohServiceConfig};
 use crate::rpc_pubsub_service::PubSubService;
 use crate::rpc_service::JsonRpcService;
 use crate::rpc_subscriptions::RpcSubscriptions;
@@ -24,7 +25,7 @@ use std::net::UdpSocket;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::{channel, Receiver, RecvTimeoutError, Sender};
-use std::sync::{Arc, RwLock};
+use std::sync::{Arc, Mutex, RwLock};
 use std::thread::{spawn, Result};
 use std::time::Duration;
 
@@ -103,6 +104,8 @@ pub struct Fullnode {
     blocktree: Arc<Blocktree>,
     bank_forks: Arc<RwLock<BankForks>>,
     leader_scheduler: Arc<RwLock<LeaderScheduler>>,
+    poh_service: PohService,
+    poh_recorder: Arc<Mutex<PohRecorder>>,
 }
 
 impl Fullnode {
@@ -125,8 +128,24 @@ impl Fullnode {
         let leader_scheduler = Arc::new(RwLock::new(LeaderScheduler::new(
             &config.leader_scheduler_config,
         )));
-        let (bank_forks, bank_forks_info, blocktree, ledger_signal_receiver) =
+        let (mut bank_forks, bank_forks_info, blocktree, ledger_signal_receiver) =
             new_banks_from_blocktree(ledger_path, config.ticks_per_slot(), &leader_scheduler);
+
+        let exit = Arc::new(AtomicBool::new(false));
+        let bank_info = &bank_forks_info[0];
+        bank_forks.set_working_bank_id(bank_info.bank_id);
+        let bank = bank_forks.working_bank();
+
+        info!(
+            "starting PoH... {} {}",
+            bank.tick_height(),
+            bank_info.last_entry_id
+        );
+        let poh_recorder = Arc::new(Mutex::new(PohRecorder::new(
+            bank.tick_height(),
+            bank_info.last_entry_id,
+        )));
+        let poh_service = PohService::new(poh_recorder.clone(), &config.tick_config, exit.clone());
 
         info!("node info: {:?}", node.info);
         info!("node entrypoint_info: {:?}", entrypoint_info_option);
@@ -135,7 +154,6 @@ impl Fullnode {
             node.sockets.gossip.local_addr().unwrap()
         );
 
-        let exit = Arc::new(AtomicBool::new(false));
         let blocktree = Arc::new(blocktree);
         let bank_forks = Arc::new(RwLock::new(bank_forks));
 
@@ -254,6 +272,8 @@ impl Fullnode {
             blocktree,
             bank_forks,
             leader_scheduler,
+            poh_service,
+            poh_recorder,
         }
     }
 
@@ -294,7 +314,7 @@ impl Fullnode {
             };
             self.node_services.tpu.switch_to_leader(
                 self.bank_forks.read().unwrap().working_bank(),
-                PohServiceConfig::default(),
+                &self.poh_recorder,
                 self.tpu_sockets
                     .iter()
                     .map(|s| s.try_clone().expect("Failed to clone TPU sockets"))
@@ -304,7 +324,6 @@ impl Fullnode {
                     .expect("Failed to clone broadcast socket"),
                 self.sigverify_disabled,
                 rotation_info.slot,
-                rotation_info.last_entry_id,
                 &self.blocktree,
             );
             transition
@@ -340,6 +359,13 @@ impl Fullnode {
 
             match self.rotation_receiver.recv_timeout(timeout) {
                 Ok(rotation_info) => {
+                    trace!("{:?}: rotate at slot={}", self.id, rotation_info.slot);
+                    //TODO: this will be called by the TVU every time it votes
+                    //instead of here
+                    self.poh_recorder.lock().unwrap().reset(
+                        rotation_info.bank.tick_height(),
+                        rotation_info.last_entry_id,
+                    );
                     let slot = rotation_info.slot;
                     let transition = self.rotate(rotation_info);
                     debug!("role transition complete: {:?}", transition);
@@ -361,16 +387,25 @@ impl Fullnode {
     // Used for notifying many nodes in parallel to exit
     fn exit(&self) {
         self.exit.store(true, Ordering::Relaxed);
+        // Need to force the poh_recorder to drop the WorkingBank,
+        // which contains the channel to BroadcastStage. This should be
+        // sufficient as long as no other rotations are happening that
+        // can cause the Tpu to restart a BankingStage and reset a
+        // WorkingBank in poh_recorder. It follows no other rotations can be
+        // in motion because exit()/close() are only called by the run() loop
+        // which is the sole initiator of rotations.
+        self.poh_recorder.lock().unwrap().clear_bank();
         if let Some(ref rpc_service) = self.rpc_service {
             rpc_service.exit();
         }
         if let Some(ref rpc_pubsub_service) = self.rpc_pubsub_service {
             rpc_pubsub_service.exit();
         }
-        self.node_services.exit()
+        self.node_services.exit();
+        self.poh_service.exit()
     }
 
-    pub fn close(self) -> Result<()> {
+    fn close(self) -> Result<()> {
         self.exit();
         self.join()
     }
@@ -412,6 +447,9 @@ impl Service for Fullnode {
 
         self.gossip_service.join()?;
         self.node_services.join()?;
+        trace!("exit node_services!");
+        self.poh_service.join()?;
+        trace!("exit poh!");
         Ok(())
     }
 }

--- a/src/poh_recorder.rs
+++ b/src/poh_recorder.rs
@@ -35,7 +35,7 @@ pub struct WorkingBank {
 }
 
 pub struct PohRecorder {
-    poh: Poh,
+    pub poh: Poh,
     tick_cache: Vec<(Entry, u64)>,
     working_bank: Option<WorkingBank>,
 }

--- a/src/thin_client.rs
+++ b/src/thin_client.rs
@@ -256,13 +256,18 @@ impl ThinClient {
     /// Request a new last Entry ID from the server. This method blocks
     /// until the server sends a response.
     pub fn get_next_last_id(&mut self, previous_last_id: &Hash) -> Hash {
+        self.get_next_last_id_ext(previous_last_id, &|| {
+            sleep(Duration::from_millis(100));
+        })
+    }
+    pub fn get_next_last_id_ext(&mut self, previous_last_id: &Hash, func: &Fn()) -> Hash {
         loop {
             let last_id = self.get_last_id();
             if last_id != *previous_last_id {
                 break last_id;
             }
             debug!("Got same last_id ({:?}), will retry...", last_id);
-            sleep(Duration::from_millis(100));
+            func()
         }
     }
 


### PR DESCRIPTION
#### Problem

PohService and PohRecorder are not shared between the TPU and TVU. 

This is part of design for https://solana-labs.github.io/book-edge/leader-validator-transition.html

#### Summary of Changes

* Move the PohRecorder and PohService to the fullnode.
* poh_service always produces ticks

Fixes #

##### Failures

Tracking #2932

tag: @garious 