### PR TITLE
Add weighted sampling based on stakes

### DIFF
--- a/src/active_stakers.rs
+++ b/src/active_stakers.rs
@@ -360,6 +360,12 @@ pub mod tests {
         let bank = Bank::new(&genesis_block);
         let slots_per_epoch = num_keys * 10;
         let leader_schedule = active_stakers.leader_schedule(&bank, slots_per_epoch);
+        let leader_schedule2 = active_stakers.leader_schedule(&bank, slots_per_epoch);
         assert_eq!(leader_schedule.slot_leaders().len() as u64, slots_per_epoch);
+        // Check that the same schedule is reproducibly generated
+        assert_eq!(
+            leader_schedule.slot_leaders(),
+            leader_schedule2.slot_leaders()
+        );
     }
 }

--- a/src/active_stakers.rs
+++ b/src/active_stakers.rs
@@ -63,12 +63,8 @@ impl ActiveStakers {
         ActiveStakers { stakes }
     }
 
-    pub fn ranked_stakes(&self) -> Vec<(Pubkey, u64)> {
+    pub fn sorted_stakes(&self) -> Vec<(Pubkey, u64)> {
         self.stakes.clone()
-    }
-
-    pub fn stakes(&self) -> Vec<u64> {
-        self.stakes.iter().map(|(_pubkey, stake)| *stake).collect()
     }
 
     /// Return the pubkeys of each staker.

--- a/src/active_stakers.rs
+++ b/src/active_stakers.rs
@@ -1,4 +1,7 @@
 use crate::leader_schedule::LeaderSchedule;
+use rand::distributions::{Distribution, WeightedIndex};
+use rand::SeedableRng;
+use rand_chacha::ChaChaRng;
 use solana_runtime::bank::Bank;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::timing::{DEFAULT_SLOTS_PER_EPOCH, DEFAULT_TICKS_PER_SLOT};
@@ -64,6 +67,10 @@ impl ActiveStakers {
         self.stakes.clone()
     }
 
+    pub fn stakes(&self) -> Vec<u64> {
+        self.stakes.iter().map(|(_pubkey, stake)| *stake).collect()
+    }
+
     /// Return the pubkeys of each staker.
     pub fn pubkeys(&self) -> Vec<Pubkey> {
         self.stakes.iter().map(|(pubkey, _stake)| *pubkey).collect()
@@ -76,8 +83,22 @@ impl ActiveStakers {
         pubkeys
     }
 
-    pub fn leader_schedule(&self) -> LeaderSchedule {
-        LeaderSchedule::new(self.pubkeys())
+    pub fn leader_schedule(&self, bank: &Bank, len: u64) -> LeaderSchedule {
+        let stakes = self.stakes();
+        let pubkeys = self.pubkeys();
+        let mut seed = [0u8; 32];
+        seed.copy_from_slice(&bank.last_id().as_ref()[..32]);
+        let mut rng = ChaChaRng::from_seed(seed);
+        // Should have no zero weighted stakes
+        let weighted_index = WeightedIndex::new(stakes).unwrap();
+        let schedule = (0..len)
+            .map(|_| {
+                let i = weighted_index.sample(&mut rng);
+                pubkeys[i]
+            })
+            .collect();
+
+        LeaderSchedule::new(schedule)
     }
 }
 
@@ -325,5 +346,20 @@ pub mod tests {
         let mut stakes = vec![(pubkey0, 1), (pubkey1, 1)];
         rank_stakes(&mut stakes);
         assert_eq!(stakes, vec![(pubkey0, 1), (pubkey1, 1)]);
+    }
+
+    #[test]
+    fn test_leader_schedule() {
+        let num_keys = 10;
+        let stakes = (0..num_keys)
+            .map(|i| (Keypair::new().pubkey(), i))
+            .collect();
+        let active_stakers = ActiveStakers { stakes };
+
+        let (genesis_block, _) = GenesisBlock::new_with_leader(10000, Keypair::new().pubkey(), 500);
+        let bank = Bank::new(&genesis_block);
+        let slots_per_epoch = num_keys * 10;
+        let leader_schedule = active_stakers.leader_schedule(&bank, slots_per_epoch);
+        assert_eq!(leader_schedule.slot_leaders().len() as u64, slots_per_epoch);
     }
 }

--- a/src/active_stakers.rs
+++ b/src/active_stakers.rs
@@ -59,10 +59,6 @@ impl ActiveStakers {
         Self::new_with_bounds(bank, DEFAULT_ACTIVE_WINDOW_TICK_LENGTH, bank.tick_height())
     }
 
-    pub fn from_stakes(stakes: Vec<(Pubkey, u64)>) -> Self {
-        ActiveStakers { stakes }
-    }
-
     pub fn sorted_stakes(&self) -> Vec<(Pubkey, u64)> {
         self.stakes.clone()
     }

--- a/src/leader_schedule.rs
+++ b/src/leader_schedule.rs
@@ -1,3 +1,7 @@
+use crate::active_stakers::ActiveStakers;
+use rand::distributions::{Distribution, WeightedIndex};
+use rand::SeedableRng;
+use rand_chacha::ChaChaRng;
 use solana_sdk::pubkey::Pubkey;
 use std::ops::Index;
 
@@ -7,13 +11,24 @@ pub struct LeaderSchedule {
 }
 
 impl LeaderSchedule {
-    pub fn new(slot_leaders: Vec<Pubkey>) -> Self {
+    pub fn from_schedule(slot_leaders: Vec<Pubkey>) -> Self {
         Self { slot_leaders }
     }
 
-    #[cfg(test)]
-    pub fn slot_leaders(&self) -> &Vec<Pubkey> {
-        &self.slot_leaders
+    pub fn new(active_stakers: &ActiveStakers, seed: &[u8; 32], slots_per_epoch: u64) -> Self {
+        let stakes = active_stakers.stakes();
+        let pubkeys = active_stakers.pubkeys();
+        let mut rng = ChaChaRng::from_seed(*seed);
+        // Should have no zero weighted stakes
+        let weighted_index = WeightedIndex::new(stakes).unwrap();
+        let slot_leaders = (0..slots_per_epoch)
+            .map(|_| {
+                let i = weighted_index.sample(&mut rng);
+                pubkeys[i]
+            })
+            .collect();
+
+        LeaderSchedule { slot_leaders }
     }
 }
 
@@ -32,9 +47,28 @@ mod tests {
     fn test_leader_schedule_index() {
         let pubkey0 = Keypair::new().pubkey();
         let pubkey1 = Keypair::new().pubkey();
-        let leader_schedule = LeaderSchedule::new(vec![pubkey0, pubkey1]);
+        let leader_schedule = LeaderSchedule::from_schedule(vec![pubkey0, pubkey1]);
         assert_eq!(leader_schedule[0], pubkey0);
         assert_eq!(leader_schedule[1], pubkey1);
         assert_eq!(leader_schedule[2], pubkey0);
+    }
+
+    #[test]
+    fn test_new_leader_schedule() {
+        let num_keys = 10;
+        let stakes = (0..num_keys)
+            .map(|i| (Keypair::new().pubkey(), i))
+            .collect();
+        let active_stakers = ActiveStakers::from_stakes(stakes);
+
+        let seed = Keypair::new().pubkey();
+        let mut seed_bytes = [0u8; 32];
+        seed_bytes.copy_from_slice(seed.as_ref());
+        let slots_per_epoch = num_keys * 10;
+        let leader_schedule = LeaderSchedule::new(&active_stakers, &seed_bytes, slots_per_epoch);
+        let leader_schedule2 = LeaderSchedule::new(&active_stakers, &seed_bytes, slots_per_epoch);
+        assert_eq!(leader_schedule.slot_leaders.len() as u64, slots_per_epoch);
+        // Check that the same schedule is reproducibly generated
+        assert_eq!(leader_schedule.slot_leaders, leader_schedule2.slot_leaders);
     }
 }

--- a/src/leader_schedule.rs
+++ b/src/leader_schedule.rs
@@ -10,6 +10,11 @@ impl LeaderSchedule {
     pub fn new(slot_leaders: Vec<Pubkey>) -> Self {
         Self { slot_leaders }
     }
+
+    #[cfg(test)]
+    pub fn slot_leaders(&self) -> &Vec<Pubkey> {
+        &self.slot_leaders
+    }
 }
 
 impl Index<usize> for LeaderSchedule {

--- a/src/leader_schedule.rs
+++ b/src/leader_schedule.rs
@@ -16,8 +16,8 @@ impl LeaderSchedule {
     }
 
     pub fn new(active_stakers: &ActiveStakers, seed: &[u8; 32], slots_per_epoch: u64) -> Self {
-        let stakes = active_stakers.stakes();
-        let pubkeys = active_stakers.pubkeys();
+        let (pubkeys, stakes): (Vec<Pubkey>, Vec<u64>) =
+            active_stakers.sorted_stakes().into_iter().unzip();
         let mut rng = ChaChaRng::from_seed(*seed);
         // Should have no zero weighted stakes
         let weighted_index = WeightedIndex::new(stakes).unwrap();

--- a/src/leader_schedule.rs
+++ b/src/leader_schedule.rs
@@ -22,7 +22,10 @@ impl LeaderSchedule {
         seed: &[u8; 32],
         slots_per_epoch: u64,
     ) -> Vec<Pubkey> {
-        let (pubkeys, stakes): (Vec<Pubkey>, Vec<u64>) = ids_and_stakes.iter().cloned().unzip();
+        let (pubkeys, stakes): (Vec<Pubkey>, Vec<u64>) = ids_and_stakes
+            .iter()
+            .map(|&(ref id, ref stake)| (id, stake))
+            .unzip();
         let mut rng = ChaChaRng::from_seed(*seed);
         // Should have no zero weighted stakes
         let weighted_index = WeightedIndex::new(stakes).unwrap();

--- a/src/leader_scheduler.rs
+++ b/src/leader_scheduler.rs
@@ -230,7 +230,7 @@ impl LeaderScheduler {
         self.seed = Self::calculate_seed(tick_height);
         let ranked_active_set =
             ActiveStakers::new_with_bounds(&bank, self.active_window_tick_length, tick_height)
-                .ranked_stakes();
+                .sorted_stakes();
 
         if ranked_active_set.is_empty() {
             info!(


### PR DESCRIPTION
#### Problem
The current implementation of ActiveStakers is missing a weighted sampling of validators to make the leader scheduler

#### Summary of Changes
Sample leaders for slots based on stake weight

Fixes #
