### PR TITLE
Dial down CI timeouts

### DIFF
--- a/ci/buildkite.yml
+++ b/ci/buildkite.yml
@@ -1,10 +1,10 @@
 steps:
   - command: "ci/shellcheck.sh"
     name: "shellcheck"
-    timeout_in_minutes: 20
+    timeout_in_minutes: 5
   - command: "ci/docker-run.sh solanalabs/rust:1.32.0 ci/test-checks.sh"
     name: "checks"
-    timeout_in_minutes: 30
+    timeout_in_minutes: 15
   - wait
   - command: "ci/test-stable-perf.sh"
     name: "stable-perf"
@@ -13,13 +13,13 @@ steps:
       - "queue=cuda"
   - command: "ci/test-bench.sh"
     name: "bench"
-    timeout_in_minutes: 30
+    timeout_in_minutes: 20
   - command: "ci/docker-run.sh solanalabs/rust:1.32.0 ci/test-stable.sh"
     name: "stable"
-    timeout_in_minutes: 40
+    timeout_in_minutes: 20
   - command: "ci/docker-run.sh solanalabs/rust-nightly:2019-01-31 ci/test-coverage.sh"
     name: "coverage"
-    timeout_in_minutes: 40
+    timeout_in_minutes: 20
   # TODO: Fix and re-enable test-large-network.sh
   # - command: "ci/test-large-network.sh || true"
   #   name: "large-network [ignored]"


### PR DESCRIPTION
Our CI timeouts are way to conservative, where one PR with a bad test can easily generate a large backlog.  This hopefully helps.