### PR TITLE
Rename BankForks to Banktree

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -35,7 +35,7 @@
   - [Fork Selection](fork-selection.md)
   - [Data Plane Fanout](data-plane-fanout.md)
   - [Reliable Vote Transmission](reliable-vote-transmission.md)
-  - [Bank Forks](bank-forks.md)
+  - [Banktree](banktree.md)
   - [Blocktree Validation](fullnode-with-ledger-notifications.md)
   - [Cluster Economics](ed_overview.md)
     - [Validation-client Economics](ed_validation_client_economics.md)

--- a/book/src/banktree.md
+++ b/book/src/banktree.md
@@ -1,4 +1,4 @@
-# Bank Fork
+# Banktree
 
 This design describes a way to checkpoint the bank state such that it can track
 multiple forks without duplicating data.  It addresses the following
@@ -14,9 +14,9 @@ challenges:
 The basic design idea is to maintain a DAG of forks. The DAG is initialized with
 a *root*.  Each subsequent fork must descend from the root.
 
-## Active Forks
+## Working Forks
 
-An *active fork* is a direct list of connected forks that descend from the
+An *fork* is a direct list of connected checkpoints that descend from the
 current root to a specific fork without any descendants.
 
 For example:

--- a/src/banktree.rs
+++ b/src/banktree.rs
@@ -1,15 +1,15 @@
-//! The `bank_forks` module implments BankForks a DAG of checkpointed Banks
+//! The `banktree` module implments Banktree a DAG of checkpointed Banks
 
 use solana_runtime::bank::Bank;
 use std::collections::HashMap;
 use std::sync::Arc;
 
-pub struct BankForks {
+pub struct Banktree {
     working_bank_id: u64,
     banks: HashMap<u64, Arc<Bank>>,
 }
 
-impl BankForks {
+impl Banktree {
     pub fn new(working_bank_id: u64, bank: Bank) -> Self {
         let mut banks = HashMap::new();
         banks.insert(working_bank_id, Arc::new(bank));
@@ -40,22 +40,22 @@ mod tests {
     use solana_sdk::hash::Hash;
 
     #[test]
-    fn test_bank_forks_root() {
+    fn test_banktree_root() {
         let bank = Bank::default();
         let tick_height = bank.tick_height();
-        let bank_forks = BankForks::new(0, bank);
-        assert_eq!(bank_forks.working_bank().tick_height(), tick_height);
+        let banktree = Banktree::new(0, bank);
+        assert_eq!(banktree.working_bank().tick_height(), tick_height);
     }
 
     #[test]
-    fn test_bank_forks_parent() {
+    fn test_banktree_parent() {
         let bank = Bank::default();
-        let mut bank_forks = BankForks::new(0, bank);
-        let child_bank = Bank::new_from_parent(&bank_forks.working_bank());
+        let mut banktree = Banktree::new(0, bank);
+        let child_bank = Bank::new_from_parent(&banktree.working_bank());
         child_bank.register_tick(&Hash::default());
         let child_bank_id = 1;
-        bank_forks.insert(child_bank_id, child_bank);
-        bank_forks.set_working_bank_id(child_bank_id);
-        assert_eq!(bank_forks.working_bank().tick_height(), child_bank_id);
+        banktree.insert(child_bank_id, child_bank);
+        banktree.set_working_bank_id(child_bank_id);
+        assert_eq!(banktree.working_bank().tick_height(), child_bank_id);
     }
 }

--- a/src/blocktree.rs
+++ b/src/blocktree.rs
@@ -1,4 +1,4 @@
-//! The `block_tree` module provides functions for parallel verification of the
+//! The `blocktree` module provides functions for parallel verification of the
 //! Proof of History ledger as well as iterative read, append write, and random
 //! access read to a persistent file-based ledger.
 

--- a/src/cluster_info.rs
+++ b/src/cluster_info.rs
@@ -12,7 +12,7 @@
 //! * layer 2 - Everyone else, if layer 1 is `2^10`, layer 2 should be able to fit `2^20` number of nodes.
 //!
 //! Bank needs to provide an interface for us to query the stake weight
-use crate::bank_forks::BankForks;
+use crate::banktree::Banktree;
 use crate::blocktree::Blocktree;
 use crate::contact_info::ContactInfo;
 use crate::crds_gossip::CrdsGossip;
@@ -860,7 +860,7 @@ impl ClusterInfo {
     /// randomly pick a node and ask them for updates asynchronously
     pub fn gossip(
         obj: Arc<RwLock<Self>>,
-        bank_forks: Option<Arc<RwLock<BankForks>>>,
+        banktree: Option<Arc<RwLock<Banktree>>>,
         blob_sender: BlobSender,
         exit: Arc<AtomicBool>,
     ) -> JoinHandle<()> {
@@ -870,9 +870,9 @@ impl ClusterInfo {
                 let mut last_push = timestamp();
                 loop {
                     let start = timestamp();
-                    let stakes: HashMap<_, _> = match bank_forks {
-                        Some(ref bank_forks) => {
-                            bank_forks.read().unwrap().working_bank().staked_nodes()
+                    let stakes: HashMap<_, _> = match banktree {
+                        Some(ref banktree) => {
+                            banktree.read().unwrap().working_bank().staked_nodes()
                         }
                         None => HashMap::new(),
                     };

--- a/src/gossip_service.rs
+++ b/src/gossip_service.rs
@@ -1,6 +1,6 @@
 //! The `gossip_service` module implements the network control plane.
 
-use crate::bank_forks::BankForks;
+use crate::banktree::Banktree;
 use crate::blocktree::Blocktree;
 use crate::cluster_info::{ClusterInfo, Node, NodeInfo};
 use crate::service::Service;
@@ -24,7 +24,7 @@ impl GossipService {
     pub fn new(
         cluster_info: &Arc<RwLock<ClusterInfo>>,
         blocktree: Option<Arc<Blocktree>>,
-        bank_forks: Option<Arc<RwLock<BankForks>>>,
+        banktree: Option<Arc<RwLock<Banktree>>>,
         gossip_socket: UdpSocket,
         exit: Arc<AtomicBool>,
     ) -> Self {
@@ -48,7 +48,7 @@ impl GossipService {
         );
         let t_gossip = ClusterInfo::gossip(
             cluster_info.clone(),
-            bank_forks,
+            banktree,
             response_sender,
             exit.clone(),
         );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,8 +8,8 @@
 
 #![cfg_attr(feature = "unstable", feature(test))]
 pub mod active_stakers;
-pub mod bank_forks;
 pub mod banking_stage;
+pub mod banktree;
 pub mod blob_fetch_stage;
 pub mod broadcast_service;
 #[cfg(feature = "chacha")]

--- a/src/rpc_service.rs
+++ b/src/rpc_service.rs
@@ -1,6 +1,6 @@
 //! The `rpc_service` module implements the Solana JSON RPC service.
 
-use crate::bank_forks::BankForks;
+use crate::banktree::Banktree;
 use crate::cluster_info::ClusterInfo;
 use crate::rpc::*;
 use crate::service::Service;
@@ -23,7 +23,7 @@ pub struct JsonRpcService {
 
 impl JsonRpcService {
     pub fn new(
-        bank_forks: &Arc<RwLock<BankForks>>,
+        banktree: &Arc<RwLock<Banktree>>,
         cluster_info: &Arc<RwLock<ClusterInfo>>,
         rpc_addr: SocketAddr,
         drone_addr: SocketAddr,
@@ -32,7 +32,7 @@ impl JsonRpcService {
         info!("rpc bound to {:?}", rpc_addr);
         let exit = Arc::new(AtomicBool::new(false));
         let request_processor = Arc::new(RwLock::new(JsonRpcRequestProcessor::new(
-            bank_forks.clone(),
+            banktree.clone(),
             storage_state,
         )));
         let request_processor_ = request_processor.clone();
@@ -105,7 +105,7 @@ mod tests {
     #[test]
     fn test_rpc_new() {
         let (genesis_block, alice) = GenesisBlock::new(10_000);
-        let bank_forks = BankForks::new(0, Bank::new(&genesis_block));
+        let banktree = Banktree::new(0, Bank::new(&genesis_block));
         let cluster_info = Arc::new(RwLock::new(ClusterInfo::new(NodeInfo::default())));
         let rpc_addr = SocketAddr::new(
             IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)),
@@ -116,7 +116,7 @@ mod tests {
             solana_netutil::find_available_port_in_range((10000, 65535)).unwrap(),
         );
         let rpc_service = JsonRpcService::new(
-            &Arc::new(RwLock::new(bank_forks)),
+            &Arc::new(RwLock::new(banktree)),
             &cluster_info,
             rpc_addr,
             drone_addr,


### PR DESCRIPTION
#### Problem

When we interpret a Blocktree and get a tree of banks, we oddly don't call that thing a Banktree.

#### Summary of Changes

Now we do.
