### PR TITLE
Rename active_window_length to active_window_num_slots

### DIFF
--- a/src/fullnode.rs
+++ b/src/fullnode.rs
@@ -595,9 +595,9 @@ mod tests {
         // epoch, check that the same leader knows to shut down and restart as a leader again.
         let ticks_per_slot = 5;
         let slots_per_epoch = 2;
-        let active_window_length = 10;
+        let active_window_num_slots = 10;
         let leader_scheduler_config =
-            LeaderSchedulerConfig::new(ticks_per_slot, slots_per_epoch, active_window_length);
+            LeaderSchedulerConfig::new(ticks_per_slot, slots_per_epoch, active_window_num_slots);
 
         let bootstrap_leader_keypair = Arc::new(bootstrap_leader_keypair);
         let voting_keypair = VotingKeypair::new_local(&bootstrap_leader_keypair);

--- a/tests/multinode.rs
+++ b/tests/multinode.rs
@@ -1788,7 +1788,9 @@ fn test_fullnode_rotate(
     */
 
     let blocktree_config = fullnode_config.ledger_config();
-    fullnode_config.leader_scheduler_config.active_window_length = std::u64::MAX;
+    fullnode_config
+        .leader_scheduler_config
+        .active_window_num_slots = std::u64::MAX;
 
     // Create the leader node information
     let leader_keypair = Arc::new(Keypair::new());


### PR DESCRIPTION
#### Problem
active_window_length doesn't communicate the units being measured

#### Summary of Changes
Rename active_window_length to active_window_num_slots

Fixes #
