### PR TITLE
Add scheduler config to genesis

### DIFF
--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -67,18 +67,14 @@ fn main() -> Result<(), Box<dyn error::Error>> {
     let mint_keypair = read_keypair(mint_keypair_file)?;
 
     let bootstrap_leader_vote_account_keypair = Keypair::new();
-    let genesis_block = GenesisBlock {
-        mint_id: mint_keypair.pubkey(),
-        tokens: num_tokens,
-        bootstrap_leader_id: bootstrap_leader_keypair.pubkey(),
-        bootstrap_leader_tokens: BOOTSTRAP_LEADER_TOKENS,
-        bootstrap_leader_vote_account_id: bootstrap_leader_vote_account_keypair.pubkey(),
-    };
+    let (mut genesis_block, _mint_keypair) = GenesisBlock::new_with_leader(
+        num_tokens,
+        bootstrap_leader_keypair.pubkey(),
+        BOOTSTRAP_LEADER_TOKENS,
+    );
+    genesis_block.mint_id = mint_keypair.pubkey();
+    genesis_block.bootstrap_leader_vote_account_id = bootstrap_leader_vote_account_keypair.pubkey();
 
-    create_new_ledger(
-        ledger_path,
-        &genesis_block,
-        &solana::blocktree::BlocktreeConfig::default(),
-    )?;
+    create_new_ledger(ledger_path, &genesis_block)?;
     Ok(())
 }

--- a/sdk/src/genesis_block.rs
+++ b/sdk/src/genesis_block.rs
@@ -3,6 +3,7 @@
 use crate::hash::{hash, Hash};
 use crate::pubkey::Pubkey;
 use crate::signature::{Keypair, KeypairUtil};
+use crate::timing::{DEFAULT_SLOTS_PER_EPOCH, DEFAULT_TICKS_PER_SLOT};
 use std::fs::File;
 use std::io::Write;
 use std::path::Path;
@@ -19,6 +20,9 @@ pub struct GenesisBlock {
     pub bootstrap_leader_vote_account_id: Pubkey,
     pub mint_id: Pubkey,
     pub tokens: u64,
+    pub ticks_per_slot: u64,
+    pub slots_per_epoch: u64,
+    pub leader_schedule_slot_offset: u64,
 }
 
 impl GenesisBlock {
@@ -44,6 +48,9 @@ impl GenesisBlock {
                 bootstrap_leader_vote_account_id: bootstrap_leader_vote_account_keypair.pubkey(),
                 mint_id: mint_keypair.pubkey(),
                 tokens,
+                ticks_per_slot: DEFAULT_TICKS_PER_SLOT,
+                slots_per_epoch: DEFAULT_SLOTS_PER_EPOCH,
+                leader_schedule_slot_offset: DEFAULT_SLOTS_PER_EPOCH,
             },
             mint_keypair,
         )


### PR DESCRIPTION
#### Problem

Blocktree processing config variables aren't shared between nodes, so the ledger can be interpreted differently if they set them differently. Anything that affects how the ledger is interpreted needs to be
someplace on the ledger before later parts of the ledger are interpreted. We currently don't have an
on-chain program for cluster parameters, so that leaves the genesis block as the only option.

#### Summary of Changes

Move all the bank's scheduler configuration variables to the genesis block. Also, configure Blocktree from the genesis block. In some cases, do a funky little jig to preserve compatibility with widely used interfaces.
