### PR TITLE
Inline BlockConfig::ticks_per_slot

### DIFF
--- a/ledger-tool/tests/basic.rs
+++ b/ledger-tool/tests/basic.rs
@@ -1,7 +1,7 @@
-use solana::blocktree::{create_tmp_sample_ledger, BlocktreeConfig};
-use solana_sdk::signature::{Keypair, KeypairUtil};
-
 use assert_cmd::prelude::*;
+use solana::blocktree::create_tmp_sample_ledger;
+use solana_sdk::signature::{Keypair, KeypairUtil};
+use solana_sdk::timing::DEFAULT_TICKS_PER_SLOT;
 use std::process::Command;
 use std::process::Output;
 use std::sync::Arc;
@@ -32,15 +32,15 @@ fn bad_arguments() {
 #[test]
 fn nominal() {
     let keypair = Arc::new(Keypair::new());
-    let blocktree_config = BlocktreeConfig::default();
+    let ticks_per_slot = DEFAULT_TICKS_PER_SLOT;
     let (_mint_keypair, ledger_path, tick_height, _last_entry_height, _last_id, _last_entry_id) =
         create_tmp_sample_ledger(
             "test_ledger_tool_nominal",
             100,
-            blocktree_config.ticks_per_slot - 2,
+            ticks_per_slot - 2,
             keypair.pubkey(),
             50,
-            &blocktree_config,
+            ticks_per_slot,
         );
 
     // Basic validation

--- a/src/blocktree_processor.rs
+++ b/src/blocktree_processor.rs
@@ -274,22 +274,23 @@ pub fn process_blocktree(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::blocktree::create_tmp_sample_ledger;
     use crate::blocktree::tests::entries_to_blobs;
-    use crate::blocktree::{create_tmp_sample_ledger, BlocktreeConfig};
     use crate::entry::{create_ticks, next_entry, Entry};
     use solana_sdk::genesis_block::GenesisBlock;
     use solana_sdk::native_program::ProgramError;
     use solana_sdk::signature::{Keypair, KeypairUtil};
     use solana_sdk::system_transaction::SystemTransaction;
+    use solana_sdk::timing::DEFAULT_TICKS_PER_SLOT;
 
     fn fill_blocktree_slot_with_ticks(
         blocktree: &Blocktree,
-        blocktree_config: &BlocktreeConfig,
+        ticks_per_slot: u64,
         slot: u64,
         parent_slot: u64,
         last_entry_id: Hash,
     ) -> Hash {
-        let entries = create_ticks(blocktree_config.ticks_per_slot, last_entry_id);
+        let entries = create_ticks(ticks_per_slot, last_entry_id);
         let last_entry_id = entries.last().unwrap().id;
 
         let blobs = entries_to_blobs(&entries, slot, parent_slot);
@@ -303,20 +304,20 @@ mod tests {
         solana_logger::setup();
 
         let leader_scheduler = Arc::new(RwLock::new(LeaderScheduler::default()));
-        let blocktree_config = &BlocktreeConfig::default();
+        let ticks_per_slot = DEFAULT_TICKS_PER_SLOT;
 
         // Create a new ledger with slot 0 full of ticks
         let (_mint_keypair, ledger_path, tick_height, _entry_height, _last_id, mut last_entry_id) =
             create_tmp_sample_ledger(
                 "blocktree_with_two_forks",
                 10_000,
-                blocktree_config.ticks_per_slot - 1,
+                ticks_per_slot - 1,
                 Keypair::new().pubkey(),
                 123,
-                &blocktree_config,
+                ticks_per_slot,
             );
         debug!("ledger_path: {:?}", ledger_path);
-        assert_eq!(tick_height, blocktree_config.ticks_per_slot);
+        assert_eq!(tick_height, ticks_per_slot);
 
         /*
             Build a blocktree in the ledger with the following fork structure:
@@ -334,30 +335,20 @@ mod tests {
         */
         let genesis_block =
             GenesisBlock::load(&ledger_path).expect("Expected to successfully open genesis block");
-        let blocktree = Blocktree::open_config(&ledger_path, &blocktree_config)
+        let blocktree = Blocktree::open_config(&ledger_path, ticks_per_slot)
             .expect("Expected to successfully open database ledger");
 
         // Fork 1, ending at slot 3
         let last_slot1_entry_id =
-            fill_blocktree_slot_with_ticks(&blocktree, &blocktree_config, 1, 0, last_entry_id);
-        last_entry_id = fill_blocktree_slot_with_ticks(
-            &blocktree,
-            &blocktree_config,
-            2,
-            1,
-            last_slot1_entry_id,
-        );
+            fill_blocktree_slot_with_ticks(&blocktree, ticks_per_slot, 1, 0, last_entry_id);
+        last_entry_id =
+            fill_blocktree_slot_with_ticks(&blocktree, ticks_per_slot, 2, 1, last_slot1_entry_id);
         let last_fork1_entry_id =
-            fill_blocktree_slot_with_ticks(&blocktree, &blocktree_config, 3, 2, last_entry_id);
+            fill_blocktree_slot_with_ticks(&blocktree, ticks_per_slot, 3, 2, last_entry_id);
 
         // Fork 2, ending at slot 4
-        let last_fork2_entry_id = fill_blocktree_slot_with_ticks(
-            &blocktree,
-            &blocktree_config,
-            4,
-            1,
-            last_slot1_entry_id,
-        );
+        let last_fork2_entry_id =
+            fill_blocktree_slot_with_ticks(&blocktree, ticks_per_slot, 4, 1, last_slot1_entry_id);
 
         info!("last_fork1_entry_id: {:?}", last_fork1_entry_id);
         info!("last_fork2_entry_id: {:?}", last_fork2_entry_id);
@@ -370,7 +361,7 @@ mod tests {
             bank_forks_info[0],
             BankForksInfo {
                 bank_id: 2, // Fork 1 diverged with slot 2
-                entry_height: blocktree_config.ticks_per_slot * 4,
+                entry_height: ticks_per_slot * 4,
                 last_entry_id: last_fork1_entry_id,
             }
         );
@@ -378,7 +369,7 @@ mod tests {
             bank_forks_info[1],
             BankForksInfo {
                 bank_id: 4, // Fork 2 diverged with slot 4
-                entry_height: blocktree_config.ticks_per_slot * 3,
+                entry_height: ticks_per_slot * 3,
                 last_entry_id: last_fork2_entry_id,
             }
         );
@@ -472,7 +463,7 @@ mod tests {
 
     #[test]
     fn test_process_ledger_simple() {
-        let blocktree_config = BlocktreeConfig::default();
+        let ticks_per_slot = DEFAULT_TICKS_PER_SLOT;
         let leader_scheduler = Arc::new(RwLock::new(LeaderScheduler::default()));
 
         let (
@@ -488,7 +479,7 @@ mod tests {
             0,
             Keypair::new().pubkey(),
             50,
-            &blocktree_config,
+            ticks_per_slot,
         );
         debug!("ledger_path: {:?}", ledger_path);
         let genesis_block =
@@ -518,7 +509,7 @@ mod tests {
         last_id = last_entry_id;
         entries.push(tick);
 
-        let blocktree = Blocktree::open_config(&ledger_path, &blocktree_config)
+        let blocktree = Blocktree::open_config(&ledger_path, ticks_per_slot)
             .expect("Expected to successfully open database ledger");
 
         blocktree

--- a/src/chacha.rs
+++ b/src/chacha.rs
@@ -95,7 +95,7 @@ pub fn chacha_cbc_encrypt_ledger(
 #[cfg(test)]
 mod tests {
     use crate::blocktree::get_tmp_ledger_path;
-    use crate::blocktree::{Blocktree, BlocktreeConfig, DEFAULT_SLOT_HEIGHT};
+    use crate::blocktree::{Blocktree, DEFAULT_SLOT_HEIGHT};
     use crate::chacha::chacha_cbc_encrypt_ledger;
     use crate::entry::Entry;
     use ring::signature::Ed25519KeyPair;
@@ -145,9 +145,7 @@ mod tests {
         let ledger_dir = "chacha_test_encrypt_file";
         let ledger_path = get_tmp_ledger_path(ledger_dir);
         let ticks_per_slot = 16;
-        let blocktree = Arc::new(
-            Blocktree::open_config(&ledger_path, &BlocktreeConfig::new(ticks_per_slot)).unwrap(),
-        );
+        let blocktree = Arc::new(Blocktree::open_config(&ledger_path, ticks_per_slot).unwrap());
         let out_path = Path::new("test_chacha_encrypt_file_output.txt.enc");
 
         let entries = make_tiny_deterministic_test_entries(32);

--- a/src/chacha_cuda.rs
+++ b/src/chacha_cuda.rs
@@ -110,7 +110,7 @@ pub fn chacha_cbc_encrypt_file_many_keys(
 #[cfg(test)]
 mod tests {
     use crate::blocktree::get_tmp_ledger_path;
-    use crate::blocktree::{Blocktree, BlocktreeConfig, DEFAULT_SLOT_HEIGHT};
+    use crate::blocktree::{Blocktree, DEFAULT_SLOT_HEIGHT};
     use crate::chacha::chacha_cbc_encrypt_ledger;
     use crate::chacha_cuda::chacha_cbc_encrypt_file_many_keys;
     use crate::entry::make_tiny_test_entries;
@@ -128,9 +128,7 @@ mod tests {
         let ledger_dir = "test_encrypt_file_many_keys_single";
         let ledger_path = get_tmp_ledger_path(ledger_dir);
         let ticks_per_slot = 16;
-        let blocktree = Arc::new(
-            Blocktree::open_config(&ledger_path, &BlocktreeConfig::new(ticks_per_slot)).unwrap(),
-        );
+        let blocktree = Arc::new(Blocktree::open_config(&ledger_path, ticks_per_slot).unwrap());
 
         blocktree
             .write_entries(DEFAULT_SLOT_HEIGHT, 0, 0, &entries)
@@ -166,9 +164,7 @@ mod tests {
         let ledger_dir = "test_encrypt_file_many_keys_multiple";
         let ledger_path = get_tmp_ledger_path(ledger_dir);
         let ticks_per_slot = 16;
-        let blocktree = Arc::new(
-            Blocktree::open_config(&ledger_path, &BlocktreeConfig::new(ticks_per_slot)).unwrap(),
-        );
+        let blocktree = Arc::new(Blocktree::open_config(&ledger_path, ticks_per_slot).unwrap());
         blocktree
             .write_entries(DEFAULT_SLOT_HEIGHT, 0, 0, &entries)
             .unwrap();

--- a/src/storage_stage.rs
+++ b/src/storage_stage.rs
@@ -444,9 +444,7 @@ impl Service for StorageStage {
 
 #[cfg(test)]
 mod tests {
-    use crate::blocktree::{
-        create_tmp_sample_ledger, Blocktree, BlocktreeConfig, DEFAULT_SLOT_HEIGHT,
-    };
+    use crate::blocktree::{create_tmp_sample_ledger, Blocktree, DEFAULT_SLOT_HEIGHT};
     use crate::cluster_info::{ClusterInfo, NodeInfo};
     use crate::entry::{make_tiny_test_entries, Entry};
     use crate::service::Service;
@@ -460,6 +458,7 @@ mod tests {
     use solana_sdk::hash::Hasher;
     use solana_sdk::pubkey::Pubkey;
     use solana_sdk::signature::{Keypair, KeypairUtil};
+    use solana_sdk::timing::DEFAULT_TICKS_PER_SLOT;
     use solana_sdk::vote_transaction::VoteTransaction;
     use std::cmp::{max, min};
     use std::fs::remove_dir_all;
@@ -504,7 +503,7 @@ mod tests {
         let keypair = Arc::new(Keypair::new());
         let exit = Arc::new(AtomicBool::new(false));
 
-        let blocktree_config = BlocktreeConfig::default();
+        let ticks_per_slot = DEFAULT_TICKS_PER_SLOT;
         let (_mint, ledger_path, tick_height, genesis_entry_height, _last_id, _last_entry_id) =
             create_tmp_sample_ledger(
                 "storage_stage_process_entries",
@@ -512,11 +511,11 @@ mod tests {
                 1,
                 Keypair::new().pubkey(),
                 1,
-                &blocktree_config,
+                ticks_per_slot,
             );
 
         let entries = make_tiny_test_entries(64);
-        let blocktree = Blocktree::open_config(&ledger_path, &blocktree_config).unwrap();
+        let blocktree = Blocktree::open_config(&ledger_path, ticks_per_slot).unwrap();
         blocktree
             .write_entries(
                 DEFAULT_SLOT_HEIGHT,
@@ -580,7 +579,7 @@ mod tests {
         let keypair = Arc::new(Keypair::new());
         let exit = Arc::new(AtomicBool::new(false));
 
-        let blocktree_config = BlocktreeConfig::default();
+        let ticks_per_slot = DEFAULT_TICKS_PER_SLOT;
         let (_mint, ledger_path, tick_height, genesis_entry_height, _last_id, _last_entry_id) =
             create_tmp_sample_ledger(
                 "storage_stage_process_entries",
@@ -588,11 +587,11 @@ mod tests {
                 1,
                 Keypair::new().pubkey(),
                 1,
-                &blocktree_config,
+                ticks_per_slot,
             );
 
         let entries = make_tiny_test_entries(128);
-        let blocktree = Blocktree::open_config(&ledger_path, &blocktree_config).unwrap();
+        let blocktree = Blocktree::open_config(&ledger_path, ticks_per_slot).unwrap();
         blocktree
             .write_entries(
                 DEFAULT_SLOT_HEIGHT,

--- a/src/thin_client.rs
+++ b/src/thin_client.rs
@@ -470,7 +470,7 @@ pub fn new_fullnode(ledger_name: &'static str) -> (Fullnode, NodeInfo, Keypair, 
             0,
             node_info.id,
             42,
-            &fullnode_config.ledger_config(),
+            fullnode_config.ticks_per_slot(),
         );
 
     let vote_account_keypair = Arc::new(Keypair::new());

--- a/tests/replicator.rs
+++ b/tests/replicator.rs
@@ -40,7 +40,7 @@ fn test_replicator_startup_basic() {
 
     let leader_ledger_path = "replicator_test_leader_ledger";
     let mut fullnode_config = FullnodeConfig::default();
-    let blocktree_config = fullnode_config.ledger_config();
+    let ticks_per_slot = fullnode_config.ticks_per_slot();
 
     let (
         mint_keypair,
@@ -55,13 +55,13 @@ fn test_replicator_startup_basic() {
         0,
         leader_info.id,
         42,
-        &blocktree_config,
+        ticks_per_slot,
     );
 
     let validator_ledger_path = tmp_copy_ledger(
         &leader_ledger_path,
         "replicator_test_validator_ledger",
-        &blocktree_config,
+        ticks_per_slot,
     );
 
     {
@@ -295,7 +295,7 @@ fn test_replicator_startup_ledger_hang() {
 
     let leader_ledger_path = "replicator_test_leader_ledger";
     let fullnode_config = FullnodeConfig::default();
-    let blocktree_config = fullnode_config.ledger_config();
+    let ticks_per_slot = fullnode_config.ticks_per_slot();
     let (
         _mint_keypair,
         leader_ledger_path,
@@ -309,13 +309,13 @@ fn test_replicator_startup_ledger_hang() {
         0,
         leader_info.id,
         42,
-        &blocktree_config,
+        ticks_per_slot,
     );
 
     let validator_ledger_path = tmp_copy_ledger(
         &leader_ledger_path,
         "replicator_test_validator_ledger",
-        &blocktree_config,
+        ticks_per_slot,
     );
 
     {

--- a/tests/tvu.rs
+++ b/tests/tvu.rs
@@ -1,6 +1,6 @@
 use log::trace;
 use solana::bank_forks::BankForks;
-use solana::blocktree::{get_tmp_ledger_path, Blocktree, BlocktreeConfig};
+use solana::blocktree::{get_tmp_ledger_path, Blocktree};
 use solana::blocktree_processor::BankForksInfo;
 use solana::cluster_info::{ClusterInfo, Node};
 use solana::entry::next_entry_mut;
@@ -77,10 +77,10 @@ fn test_replay() {
     );
 
     // TODO: Fix this test so it always works with the default
-    // LeaderSchedulerConfig/BlocktreeConfig configuration
+    // LeaderSchedulerConfig configuration
     let mut leader_scheduler_config = LeaderSchedulerConfig::default();
     leader_scheduler_config.ticks_per_slot = 64;
-    let blocktree_config = BlocktreeConfig::new(leader_scheduler_config.ticks_per_slot);
+    let ticks_per_slot = leader_scheduler_config.ticks_per_slot;
 
     let starting_balance = 10_000;
     let (genesis_block, mint_keypair) = GenesisBlock::new(starting_balance);
@@ -111,7 +111,7 @@ fn test_replay() {
     let blocktree_path = get_tmp_ledger_path("test_replay");
 
     let (blocktree, ledger_signal_receiver) =
-        Blocktree::open_with_config_signal(&blocktree_path, &blocktree_config)
+        Blocktree::open_with_config_signal(&blocktree_path, ticks_per_slot)
             .expect("Expected to successfully open ledger");
     let vote_account_keypair = Arc::new(Keypair::new());
     let voting_keypair = VotingKeypair::new_local(&vote_account_keypair);


### PR DESCRIPTION
#### Problem

Blocktree has a config struct for just one u64, `ticks_per_slot`. That config is used for both reading and writing blocktrees. However, it should be using a GenesisBlock as the configuration file for writing, and it should be reading a GenesisBlock to set members like `self.ticks_per_slot`.  There doesn't look to be any reason for the config file, other than to future-proof a path we won't go down.

#### Summary of Changes

Inline the config file's only member, ticks_per_slot. This exposes all the places we're jumping through loops to override the default value with the default value. Still tons of work to do here, but @mvines put me in rebase hell already, so getting it off my filesystem.
