### PR TITLE
Deprecate create_tmp_sample_ledger

### DIFF
--- a/src/blocktree.rs
+++ b/src/blocktree.rs
@@ -1297,18 +1297,12 @@ pub fn get_tmp_ledger_path(name: &str) -> String {
     path
 }
 
-pub fn create_tmp_sample_ledger(
+pub fn create_tmp_sample_blocktree(
     name: &str,
-    num_tokens: u64,
+    genesis_block: &GenesisBlock,
     num_extra_ticks: u64,
-    bootstrap_leader_id: Pubkey,
-    bootstrap_leader_tokens: u64,
-    ticks_per_slot: u64,
-) -> (Keypair, String, u64, u64, Hash, Hash) {
-    // TODO: Pass in a genesis block instead of all its parameters.
-    let (mut genesis_block, mint_keypair) =
-        GenesisBlock::new_with_leader(num_tokens, bootstrap_leader_id, bootstrap_leader_tokens);
-    genesis_block.ticks_per_slot = ticks_per_slot;
+) -> (String, u64, u64, Hash, Hash) {
+    let ticks_per_slot = genesis_block.ticks_per_slot;
 
     let ledger_path = get_tmp_ledger_path(name);
     let (mut entry_height, mut tick_height, mut last_entry_id) =
@@ -1327,6 +1321,30 @@ pub fn create_tmp_sample_ledger(
         last_id = entries.last().unwrap().id;
         last_entry_id = last_id;
     }
+    (
+        ledger_path,
+        tick_height,
+        entry_height,
+        last_id,
+        last_entry_id,
+    )
+}
+
+// Deprecated! Please use create_tmp_sample_blocktree() instead.
+pub fn create_tmp_sample_ledger(
+    name: &str,
+    num_tokens: u64,
+    num_extra_tokens: u64,
+    bootstrap_leader_id: Pubkey,
+    bootstrap_leader_tokens: u64,
+    ticks_per_slot: u64,
+) -> (Keypair, String, u64, u64, Hash, Hash) {
+    let (mut genesis_block, mint_keypair) =
+        GenesisBlock::new_with_leader(num_tokens, bootstrap_leader_id, bootstrap_leader_tokens);
+    genesis_block.ticks_per_slot = ticks_per_slot;
+
+    let (ledger_path, tick_height, entry_height, last_id, last_entry_id) =
+        create_tmp_sample_blocktree(name, &genesis_block, num_extra_tokens);
     (
         mint_keypair,
         ledger_path,


### PR DESCRIPTION
#### Problem

create_tmp_sample_ledger takes parameters for all of GenesisBlock's parameters, which means you can't make use any of GenesisBlock's default values. As a result, soooo much copypasta.

#### Summary of Changes

Deprecate create_tmp_sample_ledger. Offer a slimmer create_tmp_sample_blocktree. Implement the old with the new.
