### PR TITLE
Add dependency on Vote program

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ solana-metrics = { path = "metrics", version = "0.12.0" }
 solana-netutil = { path = "netutil", version = "0.12.0" }
 solana-runtime = { path = "runtime", version = "0.12.0" }
 solana-sdk = { path = "sdk", version = "0.12.0" }
+solana-vote-program = { path = "programs/native/vote", version = "0.12.0" }
 solana-vote-signer = { path = "vote-signer", version = "0.12.0" }
 sys-info = "0.5.6"
 tokio = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ untrusted = "0.6.2"
 [dev-dependencies]
 hex-literal = "0.1.2"
 matches = "0.1.6"
+solana-budget-program = { path = "programs/native/budget", version = "0.12.0" }
 
 [[bench]]
 name = "banking_stage"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ serde = "1.0.88"
 serde_derive = "1.0.88"
 serde_json = "1.0.38"
 solana-drone = { path = "drone", version = "0.12.0" }
+solana-keygen = { path = "keygen", version = "0.12.0" }
 solana-logger = { path = "logger", version = "0.12.0" }
 solana-metrics = { path = "metrics", version = "0.12.0" }
 solana-netutil = { path = "netutil", version = "0.12.0" }


### PR DESCRIPTION
#### Problem

New build changes require us to be more diligent about runtime dependencies on on-chain programs.

#### Proposed changes

Add dependency up in the solana repo, where voting is part of the builtin protocol.