### PR TITLE
Remove special casing of ProgramError in blocktree processor

### DIFF
--- a/src/blocktree_processor.rs
+++ b/src/blocktree_processor.rs
@@ -254,7 +254,6 @@ mod tests {
     use crate::blocktree::tests::entries_to_blobs;
     use crate::entry::{create_ticks, next_entry, Entry};
     use solana_sdk::genesis_block::GenesisBlock;
-    use solana_sdk::native_program::ProgramError;
     use solana_sdk::signature::{Keypair, KeypairUtil};
     use solana_sdk::system_transaction::SystemTransaction;
 


### PR DESCRIPTION
#### Problem
The ProgramError check in blocktree processor is redundant

#### Summary of Changes
Removed the check from blocktree processor. Also refactored bank's transaction fee processing. Added a test.
