### PR TITLE
Restructure ReplayStage to handle new forking bank structure

### DIFF
--- a/src/fullnode.rs
+++ b/src/fullnode.rs
@@ -102,6 +102,7 @@ pub struct Fullnode {
     rotation_receiver: TvuRotationReceiver,
     blocktree: Arc<Blocktree>,
     leader_scheduler: Arc<RwLock<LeaderScheduler>>,
+    bank_forks: Arc<RwLock<BankForks>>,
 }
 
 impl Fullnode {
@@ -252,6 +253,7 @@ impl Fullnode {
             rotation_receiver,
             blocktree,
             leader_scheduler,
+            bank_forks,
         }
     }
 
@@ -278,7 +280,7 @@ impl Fullnode {
                 None => FullnodeReturnType::LeaderToLeaderRotation, // value doesn't matter here...
             };
             self.node_services.tpu.switch_to_leader(
-                Arc::new(rotation_info.bank),
+                self.bank_forks.read().unwrap().working_bank(),
                 PohServiceConfig::default(),
                 self.tpu_sockets
                     .iter()

--- a/src/replay_stage.rs
+++ b/src/replay_stage.rs
@@ -201,7 +201,7 @@ impl ReplayStage {
                 bank,
                 tick_height,
                 bank_forks_info[0].last_entry_id,
-                bank_forks_info[0].entry_height,
+                bank_forks_info[0].next_blob_index,
             )
         };
 

--- a/src/tvu.rs
+++ b/src/tvu.rs
@@ -226,6 +226,7 @@ pub mod tests {
             bank_id: 0,
             entry_height: 0,
             last_entry_id: Hash::default(),
+            next_blob_index: 0,
         }];
         let leader_scheduler = LeaderScheduler::new_with_bank(&bank_forks.working_bank());
         let leader_scheduler = Arc::new(RwLock::new(leader_scheduler));

--- a/src/tvu.rs
+++ b/src/tvu.rs
@@ -35,7 +35,7 @@ use std::sync::{Arc, RwLock};
 use std::thread;
 
 pub struct TvuRotationInfo {
-    pub bank: Bank,          // Bank to use
+    pub bank: Arc<Bank>,     // Bank to use
     pub last_entry_id: Hash, // last_entry_id of that bank
     pub slot: u64,           // slot height to initiate a rotation
     pub leader_id: Pubkey,   // leader upon rotation

--- a/tests/tvu.rs
+++ b/tests/tvu.rs
@@ -90,6 +90,7 @@ fn test_replay() {
         bank_id: 0,
         entry_height: 0,
         last_entry_id: cur_hash,
+        next_blob_index: 0,
     }];
 
     let bank = bank_forks.working_bank();


### PR DESCRIPTION
#### Problem
1) Checking Blocktree for entry height is racy in replay_stage, symptoms and root cause described here: https://github.com/solana-labs/solana/issues/2885

2) Replay stage doesn't skip processing slots that the node is a leader for,  but also breaks if it attempts to process a leader slot (race between bank.tick_height() and reading entries from Blocktree)

3) Replay stage doesn't initialize new banks, set working banks or interact with the BankForks structure to handle forks in any way.

4) vote_states() function in bank.rs did not check parent banks for valid votes, causing tests that voted in one slot, and referred to those slots after many rotations/slots later for determining validators' leader candidacy, to fail

#### Summary of Changes
1) Fix racy check in ReplayStage
2) Restructure ReplayStage to skip slots that the node is a leader for
3) Interoperate with BankForks by creating banks and setting a working bank per slot.
4) Update vote_states() function to look through parent banks for relevant votes.

Fixes #
https://github.com/solana-labs/solana/issues/2885