### PR TITLE
Make `LeaderScheduler::tick_per_slot` private

### DIFF
--- a/src/blockstream.rs
+++ b/src/blockstream.rs
@@ -177,15 +177,18 @@ mod test {
     #[test]
     fn test_blockstream() -> () {
         // Set up bank and leader_scheduler
-        let leader_scheduler_config = LeaderSchedulerConfig::new(5, 2, 10);
-        let (genesis_block, _mint_keypair) = GenesisBlock::new(1_000_000);
+        let (mut genesis_block, _mint_keypair) = GenesisBlock::new(1_000_000);
+        genesis_block.ticks_per_slot = 5;
+        let leader_scheduler_config =
+            LeaderSchedulerConfig::new(genesis_block.ticks_per_slot, 2, 10);
+
         let bank = Bank::new(&genesis_block);
         let leader_scheduler = LeaderScheduler::new_with_bank(&leader_scheduler_config, &bank);
         let leader_scheduler = Arc::new(RwLock::new(leader_scheduler));
 
         // Set up blockstream
         let blockstream = MockBlockstream::new("test_stream".to_string(), leader_scheduler.clone());
-        let ticks_per_slot = leader_scheduler.read().unwrap().ticks_per_slot;
+        let ticks_per_slot = bank.ticks_per_slot();
 
         let mut last_id = Hash::default();
         let mut entries = Vec::new();

--- a/src/broadcast_service.rs
+++ b/src/broadcast_service.rs
@@ -325,6 +325,7 @@ mod test {
     use crate::service::Service;
     use solana_sdk::hash::Hash;
     use solana_sdk::signature::{Keypair, KeypairUtil};
+    use solana_sdk::timing::DEFAULT_TICKS_PER_SLOT;
     use std::sync::atomic::AtomicBool;
     use std::sync::mpsc::channel;
     use std::sync::{Arc, RwLock};
@@ -394,7 +395,7 @@ mod test {
             // Mock the tick height to look like the tick height right after a leader transition
             leader_scheduler.set_leader_schedule(vec![leader_keypair.pubkey()]);
             let start_tick_height = 0;
-            let max_tick_height = start_tick_height + leader_scheduler.ticks_per_slot;
+            let max_tick_height = start_tick_height + DEFAULT_TICKS_PER_SLOT;
 
             let leader_scheduler = Arc::new(RwLock::new(leader_scheduler));
             let (entry_sender, entry_receiver) = channel();

--- a/src/fullnode.rs
+++ b/src/fullnode.rs
@@ -711,7 +711,7 @@ mod tests {
         let bank = bank_forks.working_bank();
         let entry_height = bank_forks_info[0].entry_height;
 
-        assert!(bank.tick_height() >= leader_scheduler.read().unwrap().ticks_per_epoch);
+        assert!(bank.tick_height() >= bank.ticks_per_slot() * bank.slots_per_epoch());
 
         assert!(entry_height >= ledger_initial_len);
 

--- a/src/leader_scheduler.rs
+++ b/src/leader_scheduler.rs
@@ -50,11 +50,11 @@ impl Default for LeaderSchedulerConfig {
 #[derive(Clone, Debug)]
 pub struct LeaderScheduler {
     // A leader slot duration in ticks
-    pub ticks_per_slot: u64,
+    ticks_per_slot: u64,
 
     // Duration of an epoch (one or more slots) in ticks.
     // This value must be divisible by ticks_per_slot
-    pub ticks_per_epoch: u64,
+    ticks_per_epoch: u64,
 
     // The number of slots for which a vote qualifies a candidate for leader
     // selection

--- a/src/replay_stage.rs
+++ b/src/replay_stage.rs
@@ -100,7 +100,7 @@ impl ReplayStage {
             inc_new_counter_info!("replicate-stage_bank-tick", bank.tick_height() as usize);
             if entry.is_tick() {
                 if num_ticks_to_next_vote == 0 {
-                    num_ticks_to_next_vote = leader_scheduler.read().unwrap().ticks_per_slot;
+                    num_ticks_to_next_vote = bank.ticks_per_slot();
                 }
                 num_ticks_to_next_vote -= 1;
             }
@@ -239,7 +239,7 @@ impl ReplayStage {
                     let tick_height = bank.tick_height();
                     let leader_scheduler = leader_scheduler_.read().unwrap();
                     let current_slot = leader_scheduler.tick_height_to_slot(tick_height + 1);
-                    let first_tick_in_current_slot = current_slot * leader_scheduler.ticks_per_slot;
+                    let first_tick_in_current_slot = current_slot * bank.ticks_per_slot();
                     (
                         Some(current_slot),
                         first_tick_in_current_slot
@@ -273,7 +273,7 @@ impl ReplayStage {
                             current_blob_index = 0;
                             let leader_scheduler = leader_scheduler_.read().unwrap();
                             let first_tick_in_current_slot =
-                                current_slot.unwrap() * leader_scheduler.ticks_per_slot;
+                                current_slot.unwrap() * bank.ticks_per_slot();
                             max_tick_height_for_slot = first_tick_in_current_slot
                                 + leader_scheduler
                                     .num_ticks_left_in_slot(first_tick_in_current_slot);

--- a/src/tpu.rs
+++ b/src/tpu.rs
@@ -223,7 +223,7 @@ impl Tpu {
 
         // TODO: Fix BankingStage/BroadcastService to operate on `slot` directly instead of
         // `max_tick_height`
-        let max_tick_height = (slot + 1) * leader_scheduler.read().unwrap().ticks_per_slot - 1;
+        let max_tick_height = (slot + 1) * bank.ticks_per_slot() - 1;
         let blob_index = blocktree
             .meta(slot)
             .expect("Database error")


### PR DESCRIPTION
#### Problem

Bank now has a `ticks_per_slot` that's initialized from `GenesisBlock` and can be updated via the ledger at most once per slot. The one LeaderScheduler is redundant and should no longer be used.

#### Summary of Changes

Make `LeaderScheduler::tick_per_slot` private. Move any references over to `Bank::ticks_per_slot()`.
