### PR TITLE
Migrate from create_tmp_sample_ledger -> create_tmp_sample_blocktree

### DIFF
--- a/ledger-tool/tests/basic.rs
+++ b/ledger-tool/tests/basic.rs
@@ -1,7 +1,7 @@
 use assert_cmd::prelude::*;
-use solana::blocktree::create_tmp_sample_ledger;
+use solana::blocktree::create_tmp_sample_blocktree;
+use solana_sdk::genesis_block::GenesisBlock;
 use solana_sdk::signature::{Keypair, KeypairUtil};
-use solana_sdk::timing::DEFAULT_TICKS_PER_SLOT;
 use std::process::Command;
 use std::process::Output;
 use std::sync::Arc;
@@ -32,15 +32,13 @@ fn bad_arguments() {
 #[test]
 fn nominal() {
     let keypair = Arc::new(Keypair::new());
-    let ticks_per_slot = DEFAULT_TICKS_PER_SLOT;
-    let (_mint_keypair, ledger_path, tick_height, _last_entry_height, _last_id, _last_entry_id) =
-        create_tmp_sample_ledger(
+    let (genesis_block, _mint_keypair) = GenesisBlock::new_with_leader(100, keypair.pubkey(), 50);
+    let ticks_per_slot = genesis_block.ticks_per_slot;
+    let (ledger_path, tick_height, _last_entry_height, _last_id, _last_entry_id) =
+        create_tmp_sample_blocktree(
             "test_ledger_tool_nominal",
-            100,
+            &genesis_block,
             ticks_per_slot - 2,
-            keypair.pubkey(),
-            50,
-            ticks_per_slot,
         );
 
     // Basic validation

--- a/src/blocktree.rs
+++ b/src/blocktree.rs
@@ -15,7 +15,6 @@ use serde::de::DeserializeOwned;
 use serde::Serialize;
 use solana_sdk::genesis_block::GenesisBlock;
 use solana_sdk::hash::Hash;
-use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::{Keypair, KeypairUtil};
 use solana_sdk::timing::DEFAULT_TICKS_PER_SLOT;
 use std::borrow::{Borrow, Cow};
@@ -1322,31 +1321,6 @@ pub fn create_tmp_sample_blocktree(
         last_entry_id = last_id;
     }
     (
-        ledger_path,
-        tick_height,
-        entry_height,
-        last_id,
-        last_entry_id,
-    )
-}
-
-// Deprecated! Please use create_tmp_sample_blocktree() instead.
-pub fn create_tmp_sample_ledger(
-    name: &str,
-    num_tokens: u64,
-    num_extra_tokens: u64,
-    bootstrap_leader_id: Pubkey,
-    bootstrap_leader_tokens: u64,
-    ticks_per_slot: u64,
-) -> (Keypair, String, u64, u64, Hash, Hash) {
-    let (mut genesis_block, mint_keypair) =
-        GenesisBlock::new_with_leader(num_tokens, bootstrap_leader_id, bootstrap_leader_tokens);
-    genesis_block.ticks_per_slot = ticks_per_slot;
-
-    let (ledger_path, tick_height, entry_height, last_id, last_entry_id) =
-        create_tmp_sample_blocktree(name, &genesis_block, num_extra_tokens);
-    (
-        mint_keypair,
         ledger_path,
         tick_height,
         entry_height,

--- a/src/storage_stage.rs
+++ b/src/storage_stage.rs
@@ -444,7 +444,7 @@ impl Service for StorageStage {
 
 #[cfg(test)]
 mod tests {
-    use crate::blocktree::{create_tmp_sample_ledger, Blocktree, DEFAULT_SLOT_HEIGHT};
+    use crate::blocktree::{create_tmp_sample_blocktree, Blocktree, DEFAULT_SLOT_HEIGHT};
     use crate::cluster_info::{ClusterInfo, NodeInfo};
     use crate::entry::{make_tiny_test_entries, Entry};
     use crate::service::Service;
@@ -454,11 +454,11 @@ mod tests {
         get_identity_index_from_signature, StorageStage, STORAGE_ROTATE_TEST_COUNT,
     };
     use rayon::prelude::*;
+    use solana_sdk::genesis_block::GenesisBlock;
     use solana_sdk::hash::Hash;
     use solana_sdk::hash::Hasher;
     use solana_sdk::pubkey::Pubkey;
     use solana_sdk::signature::{Keypair, KeypairUtil};
-    use solana_sdk::timing::DEFAULT_TICKS_PER_SLOT;
     use solana_sdk::vote_transaction::VoteTransaction;
     use std::cmp::{max, min};
     use std::fs::remove_dir_all;
@@ -503,16 +503,10 @@ mod tests {
         let keypair = Arc::new(Keypair::new());
         let exit = Arc::new(AtomicBool::new(false));
 
-        let ticks_per_slot = DEFAULT_TICKS_PER_SLOT;
-        let (_mint, ledger_path, tick_height, genesis_entry_height, _last_id, _last_entry_id) =
-            create_tmp_sample_ledger(
-                "storage_stage_process_entries",
-                1000,
-                1,
-                Keypair::new().pubkey(),
-                1,
-                ticks_per_slot,
-            );
+        let (genesis_block, _mint_keypair) = GenesisBlock::new(1000);
+        let ticks_per_slot = genesis_block.ticks_per_slot;
+        let (ledger_path, tick_height, genesis_entry_height, _last_id, _last_entry_id) =
+            create_tmp_sample_blocktree("storage_stage_process_entries", &genesis_block, 1);
 
         let entries = make_tiny_test_entries(64);
         let blocktree = Blocktree::open_config(&ledger_path, ticks_per_slot).unwrap();
@@ -579,16 +573,10 @@ mod tests {
         let keypair = Arc::new(Keypair::new());
         let exit = Arc::new(AtomicBool::new(false));
 
-        let ticks_per_slot = DEFAULT_TICKS_PER_SLOT;
-        let (_mint, ledger_path, tick_height, genesis_entry_height, _last_id, _last_entry_id) =
-            create_tmp_sample_ledger(
-                "storage_stage_process_entries",
-                1000,
-                1,
-                Keypair::new().pubkey(),
-                1,
-                ticks_per_slot,
-            );
+        let (genesis_block, _mint_keypair) = GenesisBlock::new(1000);
+        let ticks_per_slot = genesis_block.ticks_per_slot;;
+        let (ledger_path, tick_height, genesis_entry_height, _last_id, _last_entry_id) =
+            create_tmp_sample_blocktree("storage_stage_process_entries", &genesis_block, 1);
 
         let entries = make_tiny_test_entries(128);
         let blocktree = Blocktree::open_config(&ledger_path, ticks_per_slot).unwrap();

--- a/src/thin_client.rs
+++ b/src/thin_client.rs
@@ -452,26 +452,21 @@ pub fn retry_get_balance(
 }
 
 pub fn new_fullnode(ledger_name: &'static str) -> (Fullnode, NodeInfo, Keypair, String) {
-    use crate::blocktree::create_tmp_sample_ledger;
+    use crate::blocktree::create_tmp_sample_blocktree;
     use crate::cluster_info::Node;
     use crate::fullnode::Fullnode;
     use crate::voting_keypair::VotingKeypair;
+    use solana_sdk::genesis_block::GenesisBlock;
     use solana_sdk::signature::KeypairUtil;
 
     let node_keypair = Arc::new(Keypair::new());
     let node = Node::new_localhost_with_pubkey(node_keypair.pubkey());
     let node_info = node.info.clone();
 
-    let fullnode_config = &FullnodeConfig::default();
-    let (mint_keypair, ledger_path, _tick_height, _last_entry_height, _last_id, _last_entry_id) =
-        create_tmp_sample_ledger(
-            ledger_name,
-            10_000,
-            0,
-            node_info.id,
-            42,
-            fullnode_config.ticks_per_slot(),
-        );
+    let (genesis_block, mint_keypair) = GenesisBlock::new_with_leader(10_000, node_info.id, 42);
+
+    let (ledger_path, _tick_height, _last_entry_height, _last_id, _last_entry_id) =
+        create_tmp_sample_blocktree(ledger_name, &genesis_block, 0);
 
     let vote_account_keypair = Arc::new(Keypair::new());
     let voting_keypair = VotingKeypair::new_local(&vote_account_keypair);


### PR DESCRIPTION
#### Problem

Deprecated function `create_tmp_sample_ledger` is in the way.

#### Summary of Changes

Move all usages over to its replacement `create_tmp_sample_blocktree`.
