### PR TITLE
Migrate from tmp_copy_ledger to tmp_copy_blocktree

### DIFF
--- a/src/blocktree.rs
+++ b/src/blocktree.rs
@@ -1344,12 +1344,6 @@ pub fn tmp_copy_blocktree(from: &str, name: &str) -> String {
     path
 }
 
-// Deprecated! Please use tmp_copy_blocktree() instead.
-pub fn tmp_copy_ledger(from: &str, name: &str, _ticks_per_slot: u64) -> String {
-    // Ignore 'ticks_per_slot' because it's now encoded in the genesis block.
-    tmp_copy_blocktree(from, name)
-}
-
 #[cfg(test)]
 pub mod tests {
     use super::*;

--- a/src/fullnode.rs
+++ b/src/fullnode.rs
@@ -405,7 +405,7 @@ impl Service for Fullnode {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::blocktree::{create_tmp_sample_blocktree, tmp_copy_ledger, DEFAULT_SLOT_HEIGHT};
+    use crate::blocktree::{create_tmp_sample_blocktree, tmp_copy_blocktree, DEFAULT_SLOT_HEIGHT};
     use crate::entry::make_consecutive_blobs;
     use crate::leader_scheduler::make_active_set_entries;
     use crate::streamer::responder;
@@ -553,7 +553,6 @@ mod tests {
         let slots_per_epoch = 2;
         fullnode_config.leader_scheduler_config =
             LeaderSchedulerConfig::new(ticks_per_slot, slots_per_epoch, slots_per_epoch);
-        let ticks_per_slot = fullnode_config.ticks_per_slot();
 
         // Create the leader and validator nodes
         let bootstrap_leader_keypair = Arc::new(Keypair::new());
@@ -571,11 +570,8 @@ mod tests {
             );
         let bootstrap_leader_info = bootstrap_leader_node.info.clone();
 
-        let validator_ledger_path = tmp_copy_ledger(
-            &bootstrap_leader_ledger_path,
-            "test_wrong_role_transition",
-            ticks_per_slot,
-        );
+        let validator_ledger_path =
+            tmp_copy_blocktree(&bootstrap_leader_ledger_path, "test_wrong_role_transition");
 
         let ledger_paths = vec![
             bootstrap_leader_ledger_path.clone(),

--- a/tests/multinode.rs
+++ b/tests/multinode.rs
@@ -1,7 +1,7 @@
 use log::*;
 use solana::blob_fetch_stage::BlobFetchStage;
 use solana::blocktree::{
-    create_tmp_sample_blocktree, tmp_copy_ledger, Blocktree, DEFAULT_SLOT_HEIGHT,
+    create_tmp_sample_blocktree, tmp_copy_blocktree, Blocktree, DEFAULT_SLOT_HEIGHT,
 };
 use solana::client::mk_client;
 use solana::cluster_info::{Node, NodeInfo};
@@ -55,11 +55,7 @@ fn test_multi_node_ledger_window() -> result::Result<()> {
     ledger_paths.push(leader_ledger_path.clone());
 
     // make a copy at zero
-    let zero_ledger_path = tmp_copy_ledger(
-        &leader_ledger_path,
-        "multi_node_ledger_window",
-        ticks_per_slot,
-    );
+    let zero_ledger_path = tmp_copy_blocktree(&leader_ledger_path, "multi_node_ledger_window");
     ledger_paths.push(zero_ledger_path.clone());
 
     // Write some into leader's ledger, this should populate the leader's window
@@ -175,23 +171,20 @@ fn test_multi_node_validator_catchup_from_zero() -> result::Result<()> {
     let mut ledger_paths = Vec::new();
 
     let (genesis_block, alice) = GenesisBlock::new_with_leader(10_000, leader_data.id, 500);
-    let ticks_per_slot = genesis_block.ticks_per_slot;
 
     let (genesis_ledger_path, _tick_height, _last_entry_height, _last_id, _last_entry_id) =
         create_tmp_sample_blocktree("multi_node_validator_catchup_from_zero", &genesis_block, 0);
     ledger_paths.push(genesis_ledger_path.clone());
 
-    let zero_ledger_path = tmp_copy_ledger(
+    let zero_ledger_path = tmp_copy_blocktree(
         &genesis_ledger_path,
         "multi_node_validator_catchup_from_zero",
-        ticks_per_slot,
     );
     ledger_paths.push(zero_ledger_path.clone());
 
-    let leader_ledger_path = tmp_copy_ledger(
+    let leader_ledger_path = tmp_copy_blocktree(
         &genesis_ledger_path,
         "multi_node_validator_catchup_from_zero",
-        ticks_per_slot,
     );
     ledger_paths.push(leader_ledger_path.clone());
     let fullnode_config = FullnodeConfig::default();
@@ -210,10 +203,9 @@ fn test_multi_node_validator_catchup_from_zero() -> result::Result<()> {
         let keypair = Arc::new(Keypair::new());
         let validator_pubkey = keypair.pubkey().clone();
         let validator = Node::new_localhost_with_pubkey(keypair.pubkey());
-        let ledger_path = tmp_copy_ledger(
+        let ledger_path = tmp_copy_blocktree(
             &genesis_ledger_path,
             "multi_node_validator_catchup_from_zero_validator",
-            ticks_per_slot,
         );
         ledger_paths.push(ledger_path.clone());
 
@@ -365,14 +357,12 @@ fn test_multi_node_basic() {
     let mut ledger_paths = Vec::new();
 
     let (genesis_block, alice) = GenesisBlock::new_with_leader(10_000, leader_data.id, 500);
-    let ticks_per_slot = genesis_block.ticks_per_slot;
 
     let (genesis_ledger_path, _tick_height, _last_entry_height, _last_id, _last_entry_id) =
         create_tmp_sample_blocktree("multi_node_basic", &genesis_block, 0);
     ledger_paths.push(genesis_ledger_path.clone());
 
-    let leader_ledger_path =
-        tmp_copy_ledger(&genesis_ledger_path, "multi_node_basic", ticks_per_slot);
+    let leader_ledger_path = tmp_copy_blocktree(&genesis_ledger_path, "multi_node_basic");
     ledger_paths.push(leader_ledger_path.clone());
 
     let fullnode_config = FullnodeConfig::default();
@@ -391,7 +381,7 @@ fn test_multi_node_basic() {
         let keypair = Arc::new(Keypair::new());
         let validator_pubkey = keypair.pubkey().clone();
         let validator = Node::new_localhost_with_pubkey(keypair.pubkey());
-        let ledger_path = tmp_copy_ledger(&genesis_ledger_path, "multi_node_basic", ticks_per_slot);
+        let ledger_path = tmp_copy_blocktree(&genesis_ledger_path, "multi_node_basic");
         ledger_paths.push(ledger_path.clone());
 
         // Send each validator some tokens to vote
@@ -470,17 +460,12 @@ fn test_boot_validator_from_file() -> result::Result<()> {
     let mut ledger_paths = Vec::new();
 
     let (genesis_block, alice) = GenesisBlock::new_with_leader(100_000, leader_pubkey, 1000);
-    let ticks_per_slot = genesis_block.ticks_per_slot;
 
     let (genesis_ledger_path, _tick_height, _last_entry_height, _last_id, _last_entry_id) =
         create_tmp_sample_blocktree("boot_validator_from_file", &genesis_block, 0);
     ledger_paths.push(genesis_ledger_path.clone());
 
-    let leader_ledger_path = tmp_copy_ledger(
-        &genesis_ledger_path,
-        "boot_validator_from_file",
-        ticks_per_slot,
-    );
+    let leader_ledger_path = tmp_copy_blocktree(&genesis_ledger_path, "boot_validator_from_file");
     ledger_paths.push(leader_ledger_path.clone());
 
     let leader_data = leader.info.clone();
@@ -508,11 +493,7 @@ fn test_boot_validator_from_file() -> result::Result<()> {
     let keypair = Arc::new(Keypair::new());
     let validator = Node::new_localhost_with_pubkey(keypair.pubkey());
     let validator_data = validator.info.clone();
-    let ledger_path = tmp_copy_ledger(
-        &genesis_ledger_path,
-        "boot_validator_from_file",
-        ticks_per_slot,
-    );
+    let ledger_path = tmp_copy_blocktree(&genesis_ledger_path, "boot_validator_from_file");
     ledger_paths.push(ledger_path.clone());
     let voting_keypair = VotingKeypair::new_local(&keypair);
     let val_fullnode = Fullnode::new(
@@ -574,7 +555,6 @@ fn test_leader_restart_validator_start_from_old_ledger() -> result::Result<()> {
         leader_keypair.pubkey(),
         initial_leader_balance,
     );
-    let ticks_per_slot = genesis_block.ticks_per_slot;
 
     let (ledger_path, _tick_height, _last_entry_height, _last_id, _last_entry_id) =
         create_tmp_sample_blocktree(
@@ -602,10 +582,9 @@ fn test_leader_restart_validator_start_from_old_ledger() -> result::Result<()> {
     }
 
     // create a "stale" ledger by copying current ledger
-    let stale_ledger_path = tmp_copy_ledger(
+    let stale_ledger_path = tmp_copy_blocktree(
         &ledger_path,
         "leader_restart_validator_start_from_old_ledger",
-        ticks_per_slot,
     );
 
     {
@@ -693,7 +672,6 @@ fn test_multi_node_dynamic_network() {
     let bob_pubkey = Keypair::new().pubkey();
 
     let (genesis_block, alice) = GenesisBlock::new_with_leader(10_000_000, leader_pubkey, 500);
-    let ticks_per_slot = genesis_block.ticks_per_slot;
 
     let (genesis_ledger_path, _tick_height, _last_entry_height, _last_id, _last_entry_id) =
         create_tmp_sample_blocktree("multi_node_dynamic_network", &genesis_block, 0);
@@ -701,11 +679,7 @@ fn test_multi_node_dynamic_network() {
     let mut ledger_paths = Vec::new();
     ledger_paths.push(genesis_ledger_path.clone());
 
-    let leader_ledger_path = tmp_copy_ledger(
-        &genesis_ledger_path,
-        "multi_node_dynamic_network",
-        ticks_per_slot,
-    );
+    let leader_ledger_path = tmp_copy_blocktree(&genesis_ledger_path, "multi_node_dynamic_network");
 
     let alice_arc = Arc::new(RwLock::new(alice));
     let leader_data = leader.info.clone();
@@ -775,11 +749,8 @@ fn test_multi_node_dynamic_network() {
         .into_iter()
         .map(|keypair| {
             let leader_data = leader_data.clone();
-            let ledger_path = tmp_copy_ledger(
-                &genesis_ledger_path,
-                "multi_node_dynamic_network",
-                ticks_per_slot,
-            );
+            let ledger_path =
+                tmp_copy_blocktree(&genesis_ledger_path, "multi_node_dynamic_network");
             ledger_paths.push(ledger_path.clone());
             Builder::new()
                 .name("validator-launch-thread".to_string())
@@ -1056,11 +1027,8 @@ fn test_leader_validator_basic() {
     // Initialize both leader + validator ledger
     let mut ledger_paths = Vec::new();
     ledger_paths.push(leader_ledger_path.clone());
-    let validator_ledger_path = tmp_copy_ledger(
-        &leader_ledger_path,
-        "test_leader_validator_basic",
-        ticks_per_slot,
-    );
+    let validator_ledger_path =
+        tmp_copy_blocktree(&leader_ledger_path, "test_leader_validator_basic");
     ledger_paths.push(validator_ledger_path.clone());
 
     // Start the validator node
@@ -1211,11 +1179,8 @@ fn test_dropped_handoff_recovery() {
             .unwrap();
     }
 
-    let next_leader_ledger_path = tmp_copy_ledger(
-        &genesis_ledger_path,
-        "test_dropped_handoff_recovery",
-        ticks_per_slot,
-    );
+    let next_leader_ledger_path =
+        tmp_copy_blocktree(&genesis_ledger_path, "test_dropped_handoff_recovery");
     ledger_paths.push(next_leader_ledger_path.clone());
 
     info!("bootstrap_leader: {}", bootstrap_leader_keypair.pubkey());
@@ -1223,11 +1188,8 @@ fn test_dropped_handoff_recovery() {
 
     let voting_keypair = VotingKeypair::new_local(&bootstrap_leader_keypair);
     // Start up the bootstrap leader fullnode
-    let bootstrap_leader_ledger_path = tmp_copy_ledger(
-        &genesis_ledger_path,
-        "test_dropped_handoff_recovery",
-        ticks_per_slot,
-    );
+    let bootstrap_leader_ledger_path =
+        tmp_copy_blocktree(&genesis_ledger_path, "test_dropped_handoff_recovery");
     ledger_paths.push(bootstrap_leader_ledger_path.clone());
 
     let bootstrap_leader = Fullnode::new(
@@ -1245,11 +1207,8 @@ fn test_dropped_handoff_recovery() {
     // Start up the validators other than the "next_leader" validator
     for i in 0..(N - 1) {
         let keypair = Arc::new(Keypair::new());
-        let validator_ledger_path = tmp_copy_ledger(
-            &genesis_ledger_path,
-            "test_dropped_handoff_recovery",
-            ticks_per_slot,
-        );
+        let validator_ledger_path =
+            tmp_copy_blocktree(&genesis_ledger_path, "test_dropped_handoff_recovery");
         ledger_paths.push(validator_ledger_path.clone());
         let validator_id = keypair.pubkey();
         info!("validator {}: {}", i, validator_id);
@@ -1398,10 +1357,9 @@ fn test_full_leader_validator_network() {
     info!("Start up the validators");
     // Start up the validators
     for kp in node_keypairs.into_iter() {
-        let validator_ledger_path = tmp_copy_ledger(
+        let validator_ledger_path = tmp_copy_blocktree(
             &bootstrap_leader_ledger_path,
             "test_full_leader_validator_network",
-            ticks_per_slot,
         );
 
         ledger_paths.push(validator_ledger_path.clone());
@@ -1840,8 +1798,7 @@ fn test_fullnode_rotate(
 
     let (validator_rotation_sender, validator_rotation_receiver) = channel();
     if include_validator {
-        let validator_ledger_path =
-            tmp_copy_ledger(&leader_ledger_path, "test_fullnode_rotate", ticks_per_slot);
+        let validator_ledger_path = tmp_copy_blocktree(&leader_ledger_path, "test_fullnode_rotate");
         ledger_paths.push(validator_ledger_path.clone());
         let validator_fullnode = Fullnode::new(
             validator,

--- a/tests/replicator.rs
+++ b/tests/replicator.rs
@@ -7,7 +7,7 @@ extern crate serde_json;
 
 use bincode::deserialize;
 use solana::blocktree::{
-    create_tmp_sample_blocktree, get_tmp_ledger_path, tmp_copy_ledger, Blocktree,
+    create_tmp_sample_blocktree, get_tmp_ledger_path, tmp_copy_blocktree, Blocktree,
     DEFAULT_SLOT_HEIGHT,
 };
 use solana::client::mk_client;
@@ -44,16 +44,12 @@ fn test_replicator_startup_basic() {
 
     let (genesis_block, mint_keypair) =
         GenesisBlock::new_with_leader(1_000_000_000, leader_info.id, 42);
-    let ticks_per_slot = genesis_block.ticks_per_slot;
 
     let (leader_ledger_path, _tick_height, _last_entry_height, _last_id, _last_entry_id) =
         create_tmp_sample_blocktree(leader_ledger_path, &genesis_block, 0);
 
-    let validator_ledger_path = tmp_copy_ledger(
-        &leader_ledger_path,
-        "replicator_test_validator_ledger",
-        ticks_per_slot,
-    );
+    let validator_ledger_path =
+        tmp_copy_blocktree(&leader_ledger_path, "replicator_test_validator_ledger");
 
     {
         let voting_keypair = VotingKeypair::new_local(&leader_keypair);
@@ -287,15 +283,11 @@ fn test_replicator_startup_ledger_hang() {
 
     let leader_ledger_path = "replicator_test_leader_ledger";
     let (genesis_block, _mint_keypair) = GenesisBlock::new_with_leader(100, leader_info.id, 42);
-    let ticks_per_slot = genesis_block.ticks_per_slot;
     let (leader_ledger_path, _tick_height, _last_entry_height, _last_id, _last_entry_id) =
         create_tmp_sample_blocktree(leader_ledger_path, &genesis_block, 0);
 
-    let validator_ledger_path = tmp_copy_ledger(
-        &leader_ledger_path,
-        "replicator_test_validator_ledger",
-        ticks_per_slot,
-    );
+    let validator_ledger_path =
+        tmp_copy_blocktree(&leader_ledger_path, "replicator_test_validator_ledger");
 
     {
         let voting_keypair = VotingKeypair::new_local(&leader_keypair);


### PR DESCRIPTION
#### Problem

Lots of references to `ticks_per_slot` that are no longer needed now that `ticks_per_slot` is added to the blocktree via the genesis block.

#### Summary of Changes

* Move all uses of `tmp_copy_ledger` to `tmp_copy_blocktree`, which doesn't take a `ticks_per_slot` parameter
* Delete lots of `ticks_per_slot` references

Towards #2657. Ultimately need to move everything in the validation pipeline to the bank's copy of `ticks_per_slot`, not FullnodeConfig or LeaderSchedulerConfig.
