### PR TITLE
Use bank for leader scheduler's config

### DIFF
--- a/src/blockstream.rs
+++ b/src/blockstream.rs
@@ -166,7 +166,6 @@ pub struct BlockData {
 mod test {
     use super::*;
     use crate::entry::Entry;
-    use crate::leader_scheduler::LeaderSchedulerConfig;
     use chrono::{DateTime, FixedOffset};
     use serde_json::Value;
     use solana_runtime::bank::Bank;
@@ -179,11 +178,10 @@ mod test {
         // Set up bank and leader_scheduler
         let (mut genesis_block, _mint_keypair) = GenesisBlock::new(1_000_000);
         genesis_block.ticks_per_slot = 5;
-        let leader_scheduler_config =
-            LeaderSchedulerConfig::new(genesis_block.ticks_per_slot, 2, 10);
+        genesis_block.slots_per_epoch = 2;
 
         let bank = Bank::new(&genesis_block);
-        let leader_scheduler = LeaderScheduler::new_with_bank(&leader_scheduler_config, &bank);
+        let leader_scheduler = LeaderScheduler::new_with_window_len(10, &bank);
         let leader_scheduler = Arc::new(RwLock::new(leader_scheduler));
 
         // Set up blockstream

--- a/src/blockstream.rs
+++ b/src/blockstream.rs
@@ -181,7 +181,7 @@ mod test {
         genesis_block.slots_per_epoch = 2;
 
         let bank = Bank::new(&genesis_block);
-        let leader_scheduler = LeaderScheduler::new_with_window_len(10, &bank);
+        let leader_scheduler = LeaderScheduler::new_with_bank(&bank);
         let leader_scheduler = Arc::new(RwLock::new(leader_scheduler));
 
         // Set up blockstream

--- a/src/blockstream_service.rs
+++ b/src/blockstream_service.rs
@@ -117,7 +117,6 @@ impl Service for BlockstreamService {
 mod test {
     use super::*;
     use crate::entry::Entry;
-    use crate::leader_scheduler::LeaderSchedulerConfig;
     use chrono::{DateTime, FixedOffset};
     use serde_json::Value;
     use solana_runtime::bank::Bank;
@@ -132,10 +131,12 @@ mod test {
         let ticks_per_slot = 5;
         let starting_tick_height = 1;
 
-        let (genesis_block, _mint_keypair) = GenesisBlock::new(1_000_000);
+        let (mut genesis_block, _mint_keypair) = GenesisBlock::new(1_000_000);
+        genesis_block.ticks_per_slot = ticks_per_slot;
+        genesis_block.slots_per_epoch = 2;
+
         let bank = Bank::new(&genesis_block);
-        let leader_scheduler_config = LeaderSchedulerConfig::new(ticks_per_slot, 2, 10);
-        let leader_scheduler = LeaderScheduler::new_with_bank(&leader_scheduler_config, &bank);
+        let leader_scheduler = LeaderScheduler::new_with_window_len(10, &bank);
         let leader_scheduler = Arc::new(RwLock::new(leader_scheduler));
 
         // Set up blockstream

--- a/src/blockstream_service.rs
+++ b/src/blockstream_service.rs
@@ -136,7 +136,7 @@ mod test {
         genesis_block.slots_per_epoch = 2;
 
         let bank = Bank::new(&genesis_block);
-        let leader_scheduler = LeaderScheduler::new_with_window_len(10, &bank);
+        let leader_scheduler = LeaderScheduler::new_with_bank(&bank);
         let leader_scheduler = Arc::new(RwLock::new(leader_scheduler));
 
         // Set up blockstream

--- a/src/leader_scheduler.rs
+++ b/src/leader_scheduler.rs
@@ -105,7 +105,9 @@ impl LeaderScheduler {
         }
     }
 
-    pub fn new_with_window_len(active_window_slot_len: u64, bank: &Bank) -> Self {
+    // Same as new_with_bank() but allows caller to override `active_window_slot_len`.
+    // Used by unit-tests.
+    fn new_with_window_len(active_window_slot_len: u64, bank: &Bank) -> Self {
         let config = LeaderSchedulerConfig::new(
             bank.ticks_per_slot(),
             bank.slots_per_epoch(),

--- a/src/replay_stage.rs
+++ b/src/replay_stage.rs
@@ -777,8 +777,7 @@ mod test {
 
         let genesis_block = GenesisBlock::new(10_000).0;
         let bank = Arc::new(Bank::new(&genesis_block));
-        let leader_scheduler_config = LeaderSchedulerConfig::default();
-        let leader_scheduler = LeaderScheduler::new_with_bank(&leader_scheduler_config, &bank);
+        let leader_scheduler = LeaderScheduler::new_with_bank(&bank);
         let leader_scheduler = Arc::new(RwLock::new(leader_scheduler));
         let voting_keypair = Some(Arc::new(Keypair::new()));
         let res = ReplayStage::process_entries(
@@ -805,7 +804,7 @@ mod test {
         }
 
         let bank = Arc::new(Bank::new(&genesis_block));
-        let leader_scheduler = LeaderScheduler::new_with_bank(&leader_scheduler_config, &bank);
+        let leader_scheduler = LeaderScheduler::new_with_bank(&bank);
         let leader_scheduler = Arc::new(RwLock::new(leader_scheduler));
         let res = ReplayStage::process_entries(
             entries.clone(),

--- a/src/tvu.rs
+++ b/src/tvu.rs
@@ -206,7 +206,6 @@ pub mod tests {
     use super::*;
     use crate::blocktree::get_tmp_ledger_path;
     use crate::cluster_info::{ClusterInfo, Node};
-    use crate::leader_scheduler::LeaderSchedulerConfig;
     use crate::storage_stage::STORAGE_ROTATE_TEST_COUNT;
     use solana_runtime::bank::Bank;
     use solana_sdk::genesis_block::GenesisBlock;
@@ -228,9 +227,7 @@ pub mod tests {
             entry_height: 0,
             last_entry_id: Hash::default(),
         }];
-        let leader_scheduler_config = LeaderSchedulerConfig::default();
-        let leader_scheduler =
-            LeaderScheduler::new_with_bank(&leader_scheduler_config, &bank_forks.working_bank());
+        let leader_scheduler = LeaderScheduler::new_with_bank(&bank_forks.working_bank());
         let leader_scheduler = Arc::new(RwLock::new(leader_scheduler));
 
         //start cluster_info1

--- a/tests/tvu.rs
+++ b/tests/tvu.rs
@@ -7,7 +7,6 @@ use solana::entry::next_entry_mut;
 use solana::entry::EntrySlice;
 use solana::gossip_service::GossipService;
 use solana::leader_scheduler::LeaderScheduler;
-use solana::leader_scheduler::LeaderSchedulerConfig;
 use solana::packet::index_blobs;
 use solana::rpc_subscriptions::RpcSubscriptions;
 use solana::service::Service;
@@ -76,14 +75,13 @@ fn test_replay() {
         r_responder,
     );
 
-    // TODO: Fix this test so it always works with the default
-    // LeaderSchedulerConfig configuration
-    let mut leader_scheduler_config = LeaderSchedulerConfig::default();
-    leader_scheduler_config.ticks_per_slot = 64;
-    let ticks_per_slot = leader_scheduler_config.ticks_per_slot;
-
     let starting_balance = 10_000;
-    let (genesis_block, mint_keypair) = GenesisBlock::new(starting_balance);
+    let (mut genesis_block, mint_keypair) = GenesisBlock::new(starting_balance);
+
+    // TODO: Fix this test so it always works with the default GenesisBlock configuration
+    genesis_block.ticks_per_slot = 64;
+
+    let ticks_per_slot = genesis_block.ticks_per_slot;
     let tvu_addr = target1.info.tvu;
 
     let mut cur_hash = Hash::default();
@@ -95,10 +93,7 @@ fn test_replay() {
     }];
 
     let bank = bank_forks.working_bank();
-    let leader_scheduler = Arc::new(RwLock::new(LeaderScheduler::new_with_bank(
-        &leader_scheduler_config,
-        &bank,
-    )));
+    let leader_scheduler = Arc::new(RwLock::new(LeaderScheduler::new_with_bank(&bank)));
     assert_eq!(bank.get_balance(&mint_keypair.pubkey()), starting_balance);
 
     // start cluster_info1


### PR DESCRIPTION
#### Problem

ticks_per_slot in LeaderScheduler needs to come from GenesisBlock, but currently they come from LeaderSchedulerConfig, which sometimes and sometimes isn't built from the GenesisBlock data.

#### Summary of Changes

* Remove the LeaderSchedulerConfig parameter from LeaderScheduler::new_with_bank constructor.
* Add a new private constructor for the unit-tests that want to override `active_window_num_slots`.
* Stop hardcoding active_window_num_slots=10 in Blockstream and BlockstreamService

Towards #2657 
