### PR TITLE
Query the bank for the current slot leader

### DIFF
--- a/src/leader_schedule.rs
+++ b/src/leader_schedule.rs
@@ -55,6 +55,9 @@ impl Index<usize> for LeaderSchedule {
 pub trait LeaderScheduleUtil {
     /// Return the leader schedule for the current epoch.
     fn leader_schedule(&self) -> LeaderSchedule;
+
+    /// Return the leader id for the current slot.
+    fn slot_leader(&self) -> Pubkey;
 }
 
 impl LeaderScheduleUtil for Bank {
@@ -63,6 +66,10 @@ impl LeaderScheduleUtil for Bank {
             None => LeaderSchedule::new_with_bank(self),
             Some(bank) => LeaderSchedule::new_with_bank(&bank),
         }
+    }
+
+    fn slot_leader(&self) -> Pubkey {
+        self.leader_schedule()[self.slot_index() as usize]
     }
 }
 
@@ -113,5 +120,12 @@ mod tests {
         let expected: Vec<_> = iter::repeat(pubkey).take(len).collect();
         assert_eq!(leader_schedule.slot_leaders, expected);
         assert_eq!(bank.leader_schedule().slot_leaders, expected); // Same thing, but with the trait
+    }
+
+    #[test]
+    fn test_leader_schedule_slot_leader_basic() {
+        let pubkey = Keypair::new().pubkey();
+        let bank = Bank::new(&GenesisBlock::new_with_leader(2, pubkey, 2).0);
+        assert_eq!(bank.slot_leader(), pubkey);
     }
 }


### PR DESCRIPTION
#### Problem

`LeaderScheduler::get_leader_from_slot()` requires intercepting `Bank::register_tick()` calls, which caches leader schedules as it crosses epoch boundaries. Then it attempts to map arbitrary slot heights to a leader in one of those schedules or return None if it can't find one. That's a lot of hoops to jump to through.

#### Summary of Changes

Add method `slot_leader()` to trait `LeaderScheduleUtil` (implemented by Bank) to return the leader for the current slot height.