### PR TITLE
Delete redundant code

### DIFF
--- a/src/active_stakers.rs
+++ b/src/active_stakers.rs
@@ -1,4 +1,3 @@
-use crate::leader_schedule::LeaderSchedule;
 use solana_runtime::bank::Bank;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::timing::DEFAULT_SLOTS_PER_EPOCH;
@@ -57,11 +56,7 @@ impl ActiveStakers {
     }
 
     pub fn new(bank: &Bank) -> Self {
-        Self::new_with_bounds(
-            bank,
-            DEFAULT_ACTIVE_WINDOW_NUM_SLOTS,
-            LeaderSchedule::tick_height_to_slot(bank.tick_height(), bank.ticks_per_slot()),
-        )
+        Self::new_with_bounds(bank, DEFAULT_ACTIVE_WINDOW_NUM_SLOTS, bank.slot_height())
     }
 
     pub fn sorted_stakes(&self) -> Vec<(Pubkey, u64)> {

--- a/src/leader_schedule.rs
+++ b/src/leader_schedule.rs
@@ -39,10 +39,6 @@ impl LeaderSchedule {
             bank.slots_per_epoch(),
         )
     }
-
-    pub fn tick_height_to_slot(tick_height: u64, ticks_per_slot: u64) -> u64 {
-        tick_height / ticks_per_slot
-    }
 }
 
 impl Index<usize> for LeaderSchedule {


### PR DESCRIPTION
#### Problem

ActiveStakers adds a circular dependency on LeaderSchedule to do integer division.

#### Summary of Changes

Replace that code with the existing bank method `Bank::slot_height()`.
