### PR TITLE
Use PohRecorder as the Poh synchronization point.

### DIFF
--- a/src/banking_stage.rs
+++ b/src/banking_stage.rs
@@ -66,12 +66,9 @@ impl BankingStage {
         // Once an entry has been recorded, its last_id is registered with the bank.
         let poh_exit = Arc::new(AtomicBool::new(false));
 
-        let (poh_service, leader_sender) =
-            PohService::new(poh_recorder.clone(), config, poh_exit.clone());
+        let poh_service = PohService::new(poh_recorder.clone(), config, poh_exit.clone());
 
-        leader_sender
-            .send(working_bank.clone())
-            .expect("failed to send leader to poh_service");
+        poh_recorder.set_working_bank(working_bank.clone());
 
         // Single thread to compute confirmation
         let leader_confirmation_service =

--- a/src/banking_stage.rs
+++ b/src/banking_stage.rs
@@ -340,7 +340,7 @@ impl Service for BankingStage {
             bank_thread_hdl.join()?;
         }
         self.leader_confirmation_service.join()?;
-         self.poh_service.join()?;
+        self.poh_service.join()?;
         Ok(())
     }
 }

--- a/src/banking_stage.rs
+++ b/src/banking_stage.rs
@@ -340,7 +340,7 @@ impl Service for BankingStage {
             bank_thread_hdl.join()?;
         }
         self.leader_confirmation_service.join()?;
-        let _ = self.poh_service.join()?;
+         self.poh_service.join()?;
         Ok(())
     }
 }

--- a/src/poh.rs
+++ b/src/poh.rs
@@ -3,7 +3,7 @@
 use solana_sdk::hash::{hash, hashv, Hash};
 
 pub struct Poh {
-    id: Hash,
+    pub id: Hash,
     num_hashes: u64,
     pub tick_height: u64,
 }


### PR DESCRIPTION
#### Problem

#2852 is getting too big

PohRecorder and PohService have an awkward synchronization point using a channel.

#### Summary of Changes

Use PohRecorder as the synchronization point.
Tests that confirm the expected PohRecorder behavior for ticks and entries.

* ticks are sent only if poh.tick_height > WorkingBank::min_tick_height and <= WorkingBank::max_tick_height
* entries are recorded only if poh.tick_height >= WorkingBank::min_tick_height and < WorkingBank::max_tick_height

Fixes #
