### PR TITLE
Ignore slow benchmarks

### DIFF
--- a/benches/banking_stage.rs
+++ b/benches/banking_stage.rs
@@ -40,6 +40,7 @@ fn check_txs(receiver: &Receiver<Vec<Entry>>, ref_tx_count: usize) {
 }
 
 #[bench]
+#[ignore]
 fn bench_banking_stage_multi_accounts(bencher: &mut Bencher) {
     let num_threads = BankingStage::num_threads() as usize;
     //   a multiple of packet chunk  2X duplicates to avoid races
@@ -131,6 +132,7 @@ fn bench_banking_stage_multi_accounts(bencher: &mut Bencher) {
 }
 
 #[bench]
+#[ignore]
 fn bench_banking_stage_multi_programs(bencher: &mut Bencher) {
     let progs = 4;
     let num_threads = BankingStage::num_threads() as usize;


### PR DESCRIPTION
#### Problem

BankingStage benchmarks are so slow that they cause the benches CI build to time out.

#### Summary of Changes

Disable them.
