### PR TITLE
Blocktree now only loads complete blocks (err, slots)

### DIFF
--- a/src/bank_forks.rs
+++ b/src/bank_forks.rs
@@ -28,6 +28,18 @@ impl BankForks {
         }
     }
 
+    pub fn new_from_banks(initial_banks: &[Arc<Bank>]) -> Self {
+        let mut banks = HashMap::new();
+        let working_bank = initial_banks[0].clone();
+        for bank in initial_banks {
+            banks.insert(bank.slot(), bank.clone());
+        }
+        Self {
+            banks,
+            working_bank,
+        }
+    }
+
     // TODO: use the bank's own ID instead of receiving a parameter?
     pub fn insert(&mut self, bank_id: u64, bank: Bank) {
         let mut bank = Arc::new(bank);

--- a/src/blocktree.rs
+++ b/src/blocktree.rs
@@ -1290,7 +1290,7 @@ impl Iterator for EntryIterator {
 
 // Creates a new ledger with slot 0 full of ticks (and only ticks).
 //
-// Returns the last_id that can be used to start slot 1 entries with.
+// Returns the last_id that can be used to append entries with.
 pub fn create_new_ledger(ledger_path: &str, genesis_block: &GenesisBlock) -> Result<Hash> {
     let ticks_per_slot = genesis_block.ticks_per_slot;
     Blocktree::destroy(ledger_path)?;
@@ -1298,7 +1298,7 @@ pub fn create_new_ledger(ledger_path: &str, genesis_block: &GenesisBlock) -> Res
 
     // Fill slot 0 with ticks that link back to the genesis_block to bootstrap the ledger.
     let blocktree = Blocktree::open_config(ledger_path, ticks_per_slot)?;
-    let entries = crate::entry::create_ticks(genesis_block.ticks_per_slot, genesis_block.last_id());
+    let entries = crate::entry::create_ticks(ticks_per_slot, genesis_block.last_id());
     blocktree.write_entries(0, 0, 0, &entries)?;
 
     Ok(entries.last().unwrap().id)

--- a/src/fullnode.rs
+++ b/src/fullnode.rs
@@ -131,14 +131,10 @@ impl Fullnode {
         let bank_info = &bank_forks_info[0];
         let bank = bank_forks[bank_info.bank_id].clone();
 
-        info!(
-            "starting PoH... {} {}",
-            bank.tick_height(),
-            bank_info.last_entry_id
-        );
+        info!("starting PoH... {} {}", bank.tick_height(), bank.last_id(),);
         let poh_recorder = Arc::new(Mutex::new(PohRecorder::new(
             bank.tick_height(),
-            bank_info.last_entry_id,
+            bank.last_id(),
         )));
         let poh_service = PohService::new(poh_recorder.clone(), &config.tick_config, exit.clone());
 
@@ -270,11 +266,10 @@ impl Fullnode {
 
     fn rotate(&mut self, rotation_info: TvuRotationInfo) -> FullnodeReturnType {
         trace!(
-            "{:?}: rotate for slot={} to leader={:?} using last_entry_id={:?}",
+            "{:?}: rotate for slot={} to leader={:?}",
             self.id,
             rotation_info.slot,
             rotation_info.leader_id,
-            rotation_info.last_entry_id,
         );
         let was_leader = leader_schedule_utils::slot_leader(&rotation_info.bank) == self.id;
 
@@ -351,7 +346,7 @@ impl Fullnode {
                     //instead of here
                     self.poh_recorder.lock().unwrap().reset(
                         rotation_info.bank.tick_height(),
-                        rotation_info.last_entry_id,
+                        rotation_info.bank.last_id(),
                     );
                     let slot = rotation_info.slot;
                     let transition = self.rotate(rotation_info);

--- a/src/replay_stage.rs
+++ b/src/replay_stage.rs
@@ -195,6 +195,7 @@ impl ReplayStage {
                 bank_forks_info[0].next_blob_index,
             )
         };
+        assert_eq!(bank.last_id(), last_entry_id); // TODO: remove last_entry_id, this assert proves it's unnecessary
 
         // Update Tpu and other fullnode components with the current bank
         let (mut current_slot, mut current_leader_id, mut max_tick_height_for_slot) = {
@@ -213,6 +214,7 @@ impl ReplayStage {
                 }
                 current_blob_index = 0;
             }
+            assert_eq!(current_blob_index, 0); // TODO: remove next_blob_index, this assert proves it's unnecessary
 
             // Send a rotation notification back to Fullnode to initialize the TPU to the right
             // state. After this point, the bank.tick_height() is live, which it means it can

--- a/src/tvu.rs
+++ b/src/tvu.rs
@@ -203,7 +203,6 @@ pub mod tests {
     use crate::storage_stage::STORAGE_ROTATE_TEST_COUNT;
     use solana_runtime::bank::Bank;
     use solana_sdk::genesis_block::GenesisBlock;
-    use solana_sdk::hash::Hash;
 
     #[test]
     fn test_tvu_exit() {
@@ -219,7 +218,7 @@ pub mod tests {
         let bank_forks_info = vec![BankForksInfo {
             bank_id: 0,
             entry_height: 0,
-            last_entry_id: Hash::default(),
+            last_entry_id: bank_forks.working_bank().last_id(),
             next_blob_index: 0,
         }];
 

--- a/src/tvu.rs
+++ b/src/tvu.rs
@@ -24,7 +24,6 @@ use crate::rpc_subscriptions::RpcSubscriptions;
 use crate::service::Service;
 use crate::storage_stage::{StorageStage, StorageState};
 use solana_runtime::bank::Bank;
-use solana_sdk::hash::Hash;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::{Keypair, KeypairUtil};
 use std::net::UdpSocket;
@@ -34,10 +33,9 @@ use std::sync::{Arc, RwLock};
 use std::thread;
 
 pub struct TvuRotationInfo {
-    pub bank: Arc<Bank>,     // Bank to use
-    pub last_entry_id: Hash, // last_entry_id of that bank
-    pub slot: u64,           // slot height to initiate a rotation
-    pub leader_id: Pubkey,   // leader upon rotation
+    pub bank: Arc<Bank>,   // Bank to use
+    pub slot: u64,         // slot height to initiate a rotation
+    pub leader_id: Pubkey, // leader upon rotation
 }
 pub type TvuRotationSender = Sender<TvuRotationInfo>;
 pub type TvuRotationReceiver = Receiver<TvuRotationInfo>;
@@ -218,8 +216,6 @@ pub mod tests {
         let bank_forks_info = vec![BankForksInfo {
             bank_id: 0,
             entry_height: 0,
-            last_entry_id: bank_forks.working_bank().last_id(),
-            next_blob_index: 0,
         }];
 
         //start cluster_info1

--- a/tests/tvu.rs
+++ b/tests/tvu.rs
@@ -19,7 +19,6 @@ use solana::tvu::{Sockets, Tvu};
 use solana::voting_keypair::VotingKeypair;
 use solana_runtime::bank::Bank;
 use solana_sdk::genesis_block::GenesisBlock;
-use solana_sdk::hash::Hash;
 use solana_sdk::signature::{Keypair, KeypairUtil};
 use solana_sdk::system_transaction::SystemTransaction;
 use std::fs::remove_dir_all;
@@ -86,8 +85,9 @@ fn test_replay() {
     let ticks_per_slot = genesis_block.ticks_per_slot;
     let tvu_addr = target1.info.tvu;
 
-    let mut cur_hash = Hash::default();
-    let bank_forks = BankForks::new(0, Bank::new(&genesis_block));
+    let bank = Bank::new(&genesis_block);
+    let mut cur_hash = bank.last_id();
+    let bank_forks = BankForks::new(0, bank);
     let bank_forks_info = vec![BankForksInfo {
         bank_id: 0,
         entry_height: 0,

--- a/tests/tvu.rs
+++ b/tests/tvu.rs
@@ -91,8 +91,6 @@ fn test_replay() {
     let bank_forks_info = vec![BankForksInfo {
         bank_id: 0,
         entry_height: 0,
-        last_entry_id: cur_hash,
-        next_blob_index: 0,
     }];
 
     let bank = bank_forks.working_bank();


### PR DESCRIPTION
Loading a Blocktree at node startup is tedious because the code needs to care about a `last_entry_id`, as the ledger may halt at any entry.   But once the node is running it never needs to care about a `last_entry_id` again as rotation always occurs on a last_id boundary (eg, `bank.last_id()`).

By restricting Blocktree to only load complete blocks, we can remove the usage of `last_entry_id` from all ledger processing at fullnode startup

Note that at present the same effect could have been accomplished by halting ledger loading at the last tick of a partially filled block.  However this approach would break when we move from a tick-based last_ids to a block-based last_ids.

TODO:
* [x] Land #2963
* [x] Wait for #2949 to land, rebase on it
* [x] Fix all broken ledger-based tests