### PR TITLE
Remove tick counting from broadcast service

### DIFF
--- a/benches/banking_stage.rs
+++ b/benches/banking_stage.rs
@@ -21,12 +21,12 @@ use std::sync::Arc;
 use std::time::Duration;
 use test::Bencher;
 
-fn check_txs(receiver: &Receiver<Vec<Entry>>, ref_tx_count: usize) {
+fn check_txs(receiver: &Receiver<Vec<(Entry, u64)>>, ref_tx_count: usize) {
     let mut total = 0;
     loop {
         let entries = receiver.recv_timeout(Duration::new(1, 0));
         if let Ok(entries) = entries {
-            for entry in &entries {
+            for (entry, _) in &entries {
                 total += entry.transactions.len();
             }
         } else {

--- a/src/blocktree.rs
+++ b/src/blocktree.rs
@@ -1483,7 +1483,7 @@ pub mod tests {
     fn test_read_blobs_bytes() {
         let shared_blobs = make_tiny_test_entries(10).to_shared_blobs();
         let slot = 0;
-        index_blobs(&shared_blobs, &mut 0, &[slot; 10]);
+        index_blobs(&shared_blobs, &mut 0, slot);
 
         let blob_locks: Vec<_> = shared_blobs.iter().map(|b| b.read().unwrap()).collect();
         let blobs: Vec<&Blob> = blob_locks.iter().map(|b| &**b).collect();

--- a/src/db_window.rs
+++ b/src/db_window.rs
@@ -450,7 +450,7 @@ mod test {
         let num_entries = 10;
         let shared_blobs = make_tiny_test_entries(num_entries).to_shared_blobs();
 
-        index_blobs(&shared_blobs, &mut 0, &vec![slot; num_entries]);
+        index_blobs(&shared_blobs, &mut 0, slot);
 
         let blob_locks: Vec<_> = shared_blobs.iter().map(|b| b.read().unwrap()).collect();
         let blobs: Vec<&Blob> = blob_locks.iter().map(|b| &**b).collect();
@@ -545,7 +545,7 @@ mod test {
         let original_entries = make_tiny_test_entries(num_entries);
         let shared_blobs = original_entries.clone().to_shared_blobs();
 
-        index_blobs(&shared_blobs, &mut 0, &vec![0; num_entries]);
+        index_blobs(&shared_blobs, &mut 0, 0);
 
         for blob in shared_blobs.iter().rev() {
             process_blob(&leader_scheduler, &blocktree, blob)

--- a/src/erasure.rs
+++ b/src/erasure.rs
@@ -889,7 +889,7 @@ pub mod test {
         }
 
         // Make some dummy slots
-        index_blobs(&blobs, &mut (offset as u64), &vec![slot; blobs.len()]);
+        index_blobs(&blobs, &mut (offset as u64), slot);
 
         for b in blobs {
             let idx = b.read().unwrap().index() as usize % WINDOW_SIZE;
@@ -902,7 +902,7 @@ pub mod test {
     fn generate_test_blobs(offset: usize, num_blobs: usize) -> Vec<SharedBlob> {
         let blobs = make_tiny_test_entries(num_blobs).to_shared_blobs();
 
-        index_blobs(&blobs, &mut (offset as u64), &vec![0; blobs.len()]);
+        index_blobs(&blobs, &mut (offset as u64), 0);
         blobs
     }
 

--- a/src/fullnode.rs
+++ b/src/fullnode.rs
@@ -101,7 +101,6 @@ pub struct Fullnode {
     node_services: NodeServices,
     rotation_receiver: TvuRotationReceiver,
     blocktree: Arc<Blocktree>,
-    leader_scheduler: Arc<RwLock<LeaderScheduler>>,
     bank_forks: Arc<RwLock<BankForks>>,
 }
 
@@ -252,7 +251,6 @@ impl Fullnode {
             broadcast_socket: node.sockets.broadcast,
             rotation_receiver,
             blocktree,
-            leader_scheduler,
             bank_forks,
         }
     }
@@ -293,7 +291,6 @@ impl Fullnode {
                 rotation_info.slot,
                 rotation_info.last_entry_id,
                 &self.blocktree,
-                &self.leader_scheduler,
             );
             transition
         } else {

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -452,13 +452,13 @@ impl Blob {
     }
 }
 
-pub fn index_blobs(blobs: &[SharedBlob], blob_index: &mut u64, slots: &[u64]) {
+pub fn index_blobs(blobs: &[SharedBlob], blob_index: &mut u64, slot: u64) {
     // enumerate all the blobs, those are the indices
-    for (blob, slot) in blobs.iter().zip(slots) {
+    for blob in blobs.iter() {
         let mut blob = blob.write().unwrap();
 
         blob.set_index(*blob_index);
-        blob.set_slot(*slot);
+        blob.set_slot(slot);
         blob.forward(true);
         *blob_index += 1;
     }

--- a/src/poh_service.rs
+++ b/src/poh_service.rs
@@ -162,6 +162,7 @@ mod tests {
 
         while need_tick || need_entry || need_partial {
             for entry in entry_receiver.recv().unwrap() {
+                let entry = &entry.0;
                 if entry.is_tick() {
                     assert!(entry.num_hashes <= HASHES_PER_TICK);
 

--- a/src/tpu.rs
+++ b/src/tpu.rs
@@ -7,7 +7,6 @@ use crate::broadcast_service::BroadcastService;
 use crate::cluster_info::ClusterInfo;
 use crate::cluster_info_vote_listener::ClusterInfoVoteListener;
 use crate::fetch_stage::FetchStage;
-use crate::leader_scheduler::LeaderScheduler;
 use crate::poh_service::PohServiceConfig;
 use crate::service::Service;
 use crate::sigverify_stage::SigVerifyStage;
@@ -199,7 +198,6 @@ impl Tpu {
         slot: u64,
         last_entry_id: Hash,
         blocktree: &Arc<Blocktree>,
-        leader_scheduler: &Arc<RwLock<LeaderScheduler>>,
     ) {
         self.close_and_forward_unprocessed_packets();
 
@@ -240,13 +238,12 @@ impl Tpu {
         );
 
         let broadcast_service = BroadcastService::new(
+            slot,
             bank,
             broadcast_socket,
             self.cluster_info.clone(),
             blob_index,
-            leader_scheduler.clone(),
             entry_receiver,
-            max_tick_height,
             self.exit.clone(),
             blocktree,
         );

--- a/tests/tvu.rs
+++ b/tests/tvu.rs
@@ -159,7 +159,7 @@ fn test_replay() {
 
         let entries = vec![entry0, entry_tick0, entry_tick1, entry1, entry_tick2];
         let blobs = entries.to_shared_blobs();
-        index_blobs(&blobs, &mut blob_idx, &vec![0; blobs.len()]);
+        index_blobs(&blobs, &mut blob_idx, 0);
         blobs
             .iter()
             .for_each(|b| b.write().unwrap().meta.set_addr(&tvu_addr));


### PR DESCRIPTION
#### Problem

Poh recorder controls the ticks that are sent to the bank, and therefore the broadcast service doesn't need to do any counting, and any counting it does right now doesn't seem to be in sync.

#### Summary of Changes

Send the tick_height with the Entry or Tick.

Fixes #

tag: @sagar-solana @carllin (very wip)