### PR TITLE
Pull BPF enabled rustc and sysroot into SDK

### DIFF
--- a/ci/test-stable.sh
+++ b/ci/test-stable.sh
@@ -36,9 +36,11 @@ test-stable-perf)
   Cargo.toml$ \
   ci/test-stable-perf.sh \
   ci/test-stable.sh \
+  ^programs/ \
+  ^sdk/ \
 || {
   annotate --style info \
-    "Skipped tests as no relavant files were modified"
+    "Skipped test-stable-perf as no relavant files were modified"
   exit 0
 }
 

--- a/sdk/bpf/.gitignore
+++ b/sdk/bpf/.gitignore
@@ -1,2 +1,4 @@
 /criterion*
 /llvm-native*
+/rust-sysroot*
+/rust-toolchain*

--- a/sdk/bpf/scripts/install.sh
+++ b/sdk/bpf/scripts/install.sh
@@ -54,4 +54,54 @@ if [[ ! -f llvm-native-$machine-$version.md ]]; then
   fi
 fi
 
+# Install Rust-BPF
+version=v0.0.1
+if [[ ! -f rust-bpf-$machine-$version.md ]]; then
+  (
+    filename=solana-rust-bpf-$machine.tar.bz2
+
+    set -ex
+    rm -rf rust-bpf*
+    mkdir -p rust-bpf
+    cd rust-bpf
+    wget --progress=dot:giga https://github.com/solana-labs/rust-bpf-builder/releases/download/$version/$filename
+    tar -jxf $filename
+    rm -rf $filename
+
+    echo "https://github.com/solana-labs/rust-bpf-builder/releases/tag/$version" > ../rust-bpf-$machine-$version.md
+  )
+  exitcode=$?
+  if [[ $exitcode -ne 0 ]]; then
+    rm -rf rust-bpf
+    exit 1
+  fi
+  set +e
+  rustup toolchain uninstall bpf
+  set -e
+  rustup toolchain link bpf rust-bpf
+fi
+
+# Install Rust-BPF Sysroot
+version=v0.0.1
+if [[ ! -f rust-bpf-sysroot-$version.md ]]; then
+  (
+    filename=solana-rust-bpf-sysroot.tar.bz2
+
+    set -ex
+    rm -rf rust-bpf-sysroot*
+    mkdir -p rust-bpf-sysroot
+    cd rust-bpf-sysroot
+    wget --progress=dot:giga https://github.com/solana-labs/rust-bpf-sysroot/releases/download/$version/$filename
+    tar -jxf $filename
+    rm -rf $filename
+
+    echo "https://github.com/solana-labs/rust-bpf-sysroot/releases/tag/$version" > ../rust-bpf-sysroot-$version.md
+  )
+  exitcode=$?
+  if [[ $exitcode -ne 0 ]]; then
+    rm -rf rust-bpf-sysroot
+    exit 1
+  fi
+fi
+
 exit 0


### PR DESCRIPTION
#### Problem

Building BPF Rust modules require a BPF enabled rustc and customized sysroot (core libs, etc...)

#### Summary of Changes

Solana SDK pulls these binary releases from github and adds the new `bpf` toolchain to rustup.

Fixes #
