### PR TITLE
Add EntryMeta wrapper

### DIFF
--- a/src/blockstream_service.rs
+++ b/src/blockstream_service.rs
@@ -8,12 +8,11 @@ use crate::blockstream::MockBlockstream as Blockstream;
 use crate::blockstream::SocketBlockstream as Blockstream;
 use crate::blockstream::{BlockData, BlockstreamEvents};
 use crate::entry::{EntryReceiver, EntrySender};
-use crate::leader_scheduler::LeaderScheduler;
 use crate::result::{Error, Result};
 use crate::service::Service;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::{channel, RecvTimeoutError};
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 use std::thread::{self, Builder, JoinHandle};
 use std::time::Duration;
 
@@ -26,12 +25,10 @@ impl BlockstreamService {
     pub fn new(
         ledger_entry_receiver: EntryReceiver,
         blockstream_socket: String,
-        mut tick_height: u64,
-        leader_scheduler: Arc<RwLock<LeaderScheduler>>,
         exit: Arc<AtomicBool>,
     ) -> (Self, EntryReceiver) {
         let (blockstream_sender, blockstream_receiver) = channel();
-        let mut blockstream = Blockstream::new(blockstream_socket, leader_scheduler);
+        let mut blockstream = Blockstream::new(blockstream_socket);
         let t_blockstream = Builder::new()
             .name("solana-blockstream".to_string())
             .spawn(move || loop {
@@ -41,7 +38,6 @@ impl BlockstreamService {
                 if let Err(e) = Self::process_entries(
                     &ledger_entry_receiver,
                     &blockstream_sender,
-                    &mut tick_height,
                     &mut blockstream,
                 ) {
                     match e {
@@ -57,50 +53,46 @@ impl BlockstreamService {
     fn process_entries(
         ledger_entry_receiver: &EntryReceiver,
         blockstream_sender: &EntrySender,
-        tick_height: &mut u64,
         blockstream: &mut Blockstream,
     ) -> Result<()> {
         let timeout = Duration::new(1, 0);
-        let entries = ledger_entry_receiver.recv_timeout(timeout)?;
-        let leader_scheduler = blockstream.leader_scheduler.read().unwrap();
+        let entries_with_meta = ledger_entry_receiver.recv_timeout(timeout)?;
 
-        for entry in &entries {
-            if entry.is_tick() {
-                *tick_height += 1
-            }
-            let slot = leader_scheduler.tick_height_to_slot(*tick_height);
-            let leader_id = leader_scheduler
-                .get_leader_for_slot(slot)
-                .map(|leader| leader.to_string())
-                .unwrap_or_else(|| "None".to_string());
-
-            if entry.is_tick() && blockstream.queued_block.is_some() {
+        for entry_meta in &entries_with_meta {
+            if entry_meta.entry.is_tick() && blockstream.queued_block.is_some() {
                 let queued_block = blockstream.queued_block.as_ref();
                 let block_slot = queued_block.unwrap().slot;
                 let block_tick_height = queued_block.unwrap().tick_height;
                 let block_id = queued_block.unwrap().id;
+                let block_leader = queued_block.unwrap().leader_id;
                 blockstream
-                    .emit_block_event(block_slot, block_tick_height, &leader_id, block_id)
+                    .emit_block_event(block_slot, block_tick_height, block_leader, block_id)
                     .unwrap_or_else(|e| {
                         debug!("Blockstream error: {:?}, {:?}", e, blockstream.output);
                     });
                 blockstream.queued_block = None;
             }
             blockstream
-                .emit_entry_event(slot, *tick_height, &leader_id, &entry)
+                .emit_entry_event(
+                    entry_meta.slot,
+                    entry_meta.tick_height,
+                    entry_meta.slot_leader,
+                    &entry_meta.entry,
+                )
                 .unwrap_or_else(|e| {
                     debug!("Blockstream error: {:?}, {:?}", e, blockstream.output);
                 });
-            if 0 == leader_scheduler.num_ticks_left_in_slot(*tick_height) {
+            if 0 == entry_meta.num_ticks_left_in_slot {
                 blockstream.queued_block = Some(BlockData {
-                    slot,
-                    tick_height: *tick_height,
-                    id: entry.id,
+                    slot: entry_meta.slot,
+                    tick_height: entry_meta.tick_height,
+                    id: entry_meta.entry.id,
+                    leader_id: entry_meta.slot_leader,
                 });
             }
         }
 
-        blockstream_sender.send(entries)?;
+        blockstream_sender.send(entries_with_meta)?;
         Ok(())
     }
 }
@@ -116,31 +108,20 @@ impl Service for BlockstreamService {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::entry::Entry;
+    use crate::entry::{Entry, EntryMeta};
     use chrono::{DateTime, FixedOffset};
     use serde_json::Value;
-    use solana_runtime::bank::Bank;
-    use solana_sdk::genesis_block::GenesisBlock;
     use solana_sdk::hash::Hash;
     use solana_sdk::signature::{Keypair, KeypairUtil};
     use solana_sdk::system_transaction::SystemTransaction;
 
     #[test]
-    fn test_blockstream_stage_process_entries() {
-        // Set up the bank and leader_scheduler
+    fn test_blockstream_service_process_entries() {
         let ticks_per_slot = 5;
-        let starting_tick_height = 1;
-
-        let (mut genesis_block, _mint_keypair) = GenesisBlock::new(1_000_000);
-        genesis_block.ticks_per_slot = ticks_per_slot;
-        genesis_block.slots_per_epoch = 2;
-
-        let bank = Bank::new(&genesis_block);
-        let leader_scheduler = LeaderScheduler::new_with_bank(&bank);
-        let leader_scheduler = Arc::new(RwLock::new(leader_scheduler));
+        let leader_id = Keypair::new().pubkey();
 
         // Set up blockstream
-        let mut blockstream = Blockstream::new("test_stream".to_string(), leader_scheduler.clone());
+        let mut blockstream = Blockstream::new("test_stream".to_string());
 
         // Set up dummy channels to host an BlockstreamService
         let (ledger_entry_sender, ledger_entry_receiver) = channel();
@@ -153,25 +134,46 @@ mod test {
         for x in 0..6 {
             let entry = Entry::new(&mut last_id, 1, vec![]); //just ticks
             last_id = entry.id;
-            expected_entries.push(entry.clone());
-            expected_tick_heights.push(starting_tick_height + x);
-            entries.push(entry);
+            let slot_height = x / ticks_per_slot;
+            let parent_slot = if slot_height > 0 {
+                Some(slot_height - 1)
+            } else {
+                None
+            };
+            let entry_meta = EntryMeta {
+                tick_height: x,
+                slot: slot_height,
+                slot_leader: leader_id,
+                num_ticks_left_in_slot: ticks_per_slot - ((x + 1) % ticks_per_slot),
+                parent_slot,
+                entry,
+            };
+            expected_entries.push(entry_meta.clone());
+            expected_tick_heights.push(x);
+            entries.push(entry_meta);
         }
         let keypair = Keypair::new();
         let tx = SystemTransaction::new_account(&keypair, keypair.pubkey(), 1, Hash::default(), 0);
         let entry = Entry::new(&mut last_id, 1, vec![tx]);
-        expected_entries.insert(ticks_per_slot as usize, entry.clone());
+        let entry_meta = EntryMeta {
+            tick_height: ticks_per_slot - 1,
+            slot: 0,
+            slot_leader: leader_id,
+            num_ticks_left_in_slot: 0,
+            parent_slot: None,
+            entry,
+        };
+        expected_entries.insert(ticks_per_slot as usize, entry_meta.clone());
         expected_tick_heights.insert(
             ticks_per_slot as usize,
-            starting_tick_height + ticks_per_slot - 1, // Populated entries should share the tick height of the previous tick.
+            ticks_per_slot - 1, // Populated entries should share the tick height of the previous tick.
         );
-        entries.insert(ticks_per_slot as usize, entry);
+        entries.insert(ticks_per_slot as usize, entry_meta);
 
         ledger_entry_sender.send(entries).unwrap();
         BlockstreamService::process_entries(
             &ledger_entry_receiver,
             &blockstream_sender,
-            &mut (starting_tick_height - 1),
             &mut blockstream,
         )
         .unwrap();
@@ -201,7 +203,7 @@ mod test {
                 // `serde_json::from_str` does not work for populated Entries.
                 // Remove this `if` when fixed.
                 let entry: Entry = serde_json::from_value(entry_obj).unwrap();
-                assert_eq!(entry, expected_entries[i]);
+                assert_eq!(entry, expected_entries[i].entry);
             }
         }
         for json in block_events {

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -21,8 +21,31 @@ use std::mem::size_of;
 use std::sync::mpsc::{Receiver, Sender};
 use std::sync::{Arc, RwLock};
 
-pub type EntrySender = Sender<Vec<Entry>>;
-pub type EntryReceiver = Receiver<Vec<Entry>>;
+pub type EntrySender = Sender<Vec<EntryMeta>>;
+pub type EntryReceiver = Receiver<Vec<EntryMeta>>;
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct EntryMeta {
+    pub tick_height: u64,
+    pub slot: u64,
+    pub slot_leader: Pubkey,
+    pub num_ticks_left_in_slot: u64,
+    pub parent_slot: Option<u64>,
+    pub entry: Entry,
+}
+
+impl EntryMeta {
+    pub fn default_with_entry(entry: &Entry) -> Self {
+        EntryMeta {
+            tick_height: 0,
+            slot: 0,
+            slot_leader: Pubkey::default(),
+            num_ticks_left_in_slot: 0,
+            parent_slot: None,
+            entry: entry.clone(),
+        }
+    }
+}
 
 /// Each Entry contains three pieces of data. The `num_hashes` field is the number
 /// of hashes performed since the previous entry.  The `id` field is the result

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -35,14 +35,14 @@ pub struct EntryMeta {
 }
 
 impl EntryMeta {
-    pub fn default_with_entry(entry: &Entry) -> Self {
-        EntryMeta {
+    pub fn new(entry: Entry) -> Self {
+        Self {
             tick_height: 0,
             slot: 0,
             slot_leader: Pubkey::default(),
             num_ticks_left_in_slot: 0,
             parent_slot: None,
-            entry: entry.clone(),
+            entry,
         }
     }
 }

--- a/src/storage_stage.rs
+++ b/src/storage_stage.rs
@@ -532,10 +532,7 @@ mod tests {
             STORAGE_ROTATE_TEST_COUNT,
             &cluster_info,
         );
-        let entries_meta: Vec<EntryMeta> = entries
-            .iter()
-            .map(|entry| EntryMeta::default_with_entry(entry))
-            .collect();
+        let entries_meta: Vec<EntryMeta> = entries.into_iter().map(EntryMeta::new).collect();
         storage_entry_sender.send(entries_meta.clone()).unwrap();
 
         let keypair = Keypair::new();
@@ -601,10 +598,7 @@ mod tests {
             STORAGE_ROTATE_TEST_COUNT,
             &cluster_info,
         );
-        let entries_meta: Vec<EntryMeta> = entries
-            .iter()
-            .map(|entry| EntryMeta::default_with_entry(entry))
-            .collect();
+        let entries_meta: Vec<EntryMeta> = entries.into_iter().map(EntryMeta::new).collect();
         storage_entry_sender.send(entries_meta.clone()).unwrap();
 
         let mut reference_keys;
@@ -617,11 +611,7 @@ mod tests {
         let keypair = Keypair::new();
         let vote_tx = VoteTransaction::new_vote(&keypair, 123456, Hash::default(), 1);
         vote_txs.push(vote_tx);
-        let vote_entries = vec![EntryMeta::default_with_entry(&Entry::new(
-            &Hash::default(),
-            1,
-            vote_txs,
-        ))];
+        let vote_entries = vec![EntryMeta::new(Entry::new(&Hash::default(), 1, vote_txs))];
         storage_entry_sender.send(vote_entries).unwrap();
 
         for _ in 0..5 {

--- a/src/tvu.rs
+++ b/src/tvu.rs
@@ -138,8 +138,6 @@ impl Tvu {
             let (blockstream_service, blockstream_receiver) = BlockstreamService::new(
                 previous_receiver,
                 blockstream.unwrap().to_string(),
-                bank_forks.read().unwrap().working_bank().tick_height(), // TODO: BlockstreamService needs to deal with BankForks somehow still
-                leader_scheduler,
                 exit.clone(),
             );
             previous_receiver = blockstream_receiver;


### PR DESCRIPTION
#### Problem
Blockstream depends on LeaderScheduler unnecessarily, and can only understand a single-fork bank (currently uses a tick height counter 🤢 ).

#### Summary of Changes
- Add EntryMeta wrapper to pass block metadata into blockstream
- Pass slot and parent_slot into ReplayStage::process_entries. I plan to keep an eye on ReplayStage and implement a better way to do this, but for now it is accurate and shouldn't mess with #2884 too much.
- Update StorageStage to strip out EntryMeta. (@sakridge , if this data isn't useful for forking StorageStage, I can strip it out earlier.)
