### PR TITLE
Add lockouts to vote program

### DIFF
--- a/programs/native/rewards/src/lib.rs
+++ b/programs/native/rewards/src/lib.rs
@@ -131,15 +131,15 @@ mod tests {
         )
         .unwrap();
 
-        for _ in 0..vote_program::MAX_VOTE_HISTORY {
-            let vote = Vote::new(1);
+        for i in 0..vote_program::MAX_VOTE_HISTORY - 1 {
+            let vote = Vote::new(i as u64);
             let vote_state =
                 vote_program::vote_and_deserialize(&vote_id, &mut vote_account, vote.clone())
                     .unwrap();
             assert_eq!(vote_state.credits(), 0);
         }
 
-        let vote = Vote::new(1);
+        let vote = Vote::new(vote_program::MAX_VOTE_HISTORY as u64);
         let vote_state =
             vote_program::vote_and_deserialize(&vote_id, &mut vote_account, vote.clone()).unwrap();
         assert_eq!(vote_state.credits(), 1);

--- a/programs/native/rewards/src/lib.rs
+++ b/programs/native/rewards/src/lib.rs
@@ -131,7 +131,7 @@ mod tests {
         )
         .unwrap();
 
-        for i in 0..vote_program::MAX_VOTE_HISTORY - 1 {
+        for i in 0..vote_program::MAX_LOCKOUT_HISTORY {
             let vote = Vote::new(i as u64);
             let vote_state =
                 vote_program::vote_and_deserialize(&vote_id, &mut vote_account, vote.clone())
@@ -139,7 +139,7 @@ mod tests {
             assert_eq!(vote_state.credits(), 0);
         }
 
-        let vote = Vote::new(vote_program::MAX_VOTE_HISTORY as u64);
+        let vote = Vote::new(vote_program::MAX_LOCKOUT_HISTORY as u64 + 1);
         let vote_state =
             vote_program::vote_and_deserialize(&vote_id, &mut vote_account, vote.clone()).unwrap();
         assert_eq!(vote_state.credits(), 1);

--- a/programs/native/rewards/tests/rewards.rs
+++ b/programs/native/rewards/tests/rewards.rs
@@ -86,11 +86,13 @@ fn test_redeem_vote_credits_via_bank() {
         .unwrap();
 
     // The validator submits votes to accumulate credits.
-    for _ in 0..vote_program::MAX_VOTE_HISTORY {
-        let vote_state = rewards_bank.submit_vote(&vote_keypair, 1).unwrap();
+    for i in 0..vote_program::MAX_VOTE_HISTORY - 1 {
+        let vote_state = rewards_bank.submit_vote(&vote_keypair, i as u64).unwrap();
         assert_eq!(vote_state.credits(), 0);
     }
-    let vote_state = rewards_bank.submit_vote(&vote_keypair, 1).unwrap();
+    let vote_state = rewards_bank
+        .submit_vote(&vote_keypair, vote_program::MAX_VOTE_HISTORY as u64)
+        .unwrap();
     assert_eq!(vote_state.credits(), 1);
 
     // TODO: Add VoteInstruction::RegisterStakerId so that we don't need to point the "to"

--- a/programs/native/rewards/tests/rewards.rs
+++ b/programs/native/rewards/tests/rewards.rs
@@ -86,12 +86,12 @@ fn test_redeem_vote_credits_via_bank() {
         .unwrap();
 
     // The validator submits votes to accumulate credits.
-    for i in 0..vote_program::MAX_VOTE_HISTORY - 1 {
+    for i in 0..vote_program::MAX_LOCKOUT_HISTORY {
         let vote_state = rewards_bank.submit_vote(&vote_keypair, i as u64).unwrap();
         assert_eq!(vote_state.credits(), 0);
     }
     let vote_state = rewards_bank
-        .submit_vote(&vote_keypair, vote_program::MAX_VOTE_HISTORY as u64)
+        .submit_vote(&vote_keypair, vote_program::MAX_LOCKOUT_HISTORY as u64 + 1)
         .unwrap();
     assert_eq!(vote_state.credits(), 1);
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -225,7 +225,7 @@ impl Bank {
         );
         vote_state
             .votes
-            .push_back(vote_program::Commitment::new(&vote_program::Vote::new(0)));
+            .push_back(vote_program::Lockout::new(&vote_program::Vote::new(0)));
         vote_state
             .serialize(&mut bootstrap_leader_vote_account.userdata)
             .unwrap();

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -225,7 +225,7 @@ impl Bank {
         );
         vote_state
             .votes
-            .push_back(vote_program::Lockout::new(&vote_program::Vote::new(0)));
+            .push_back(vote_program::Commitment::new(&vote_program::Vote::new(0)));
         vote_state
             .serialize(&mut bootstrap_leader_vote_account.userdata)
             .unwrap();

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -225,7 +225,7 @@ impl Bank {
         );
         vote_state
             .votes
-            .push_back(vote_program::StoredVote::new(&vote_program::Vote::new(0)));
+            .push_back(vote_program::Lockout::new(&vote_program::Vote::new(0)));
         vote_state
             .serialize(&mut bootstrap_leader_vote_account.userdata)
             .unwrap();

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -223,7 +223,9 @@ impl Bank {
             genesis_block.bootstrap_leader_id,
             genesis_block.bootstrap_leader_id,
         );
-        vote_state.votes.push_back(vote_program::Vote::new(0));
+        vote_state
+            .votes
+            .push_back(vote_program::StoredVote::new(&vote_program::Vote::new(0)));
         vote_state
             .serialize(&mut bootstrap_leader_vote_account.userdata)
             .unwrap();

--- a/sdk/src/vote_program.rs
+++ b/sdk/src/vote_program.rs
@@ -23,6 +23,7 @@ pub fn id() -> Pubkey {
 
 // Maximum number of votes to keep around
 pub const MAX_VOTE_HISTORY: usize = 32;
+pub const INITIAL_LOCKOUT: usize = 2;
 
 #[derive(Serialize, Default, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub struct Vote {
@@ -34,6 +35,32 @@ pub struct Vote {
 impl Vote {
     pub fn new(slot_height: u64) -> Self {
         Self { slot_height }
+    }
+}
+
+#[derive(Serialize, Default, Deserialize, Debug, PartialEq, Eq, Clone)]
+pub struct StoredVote {
+    pub slot_height: u64,
+    pub confirmation_count: u32,
+}
+
+impl StoredVote {
+    pub fn new(vote: &Vote) -> Self {
+        Self {
+            slot_height: vote.slot_height,
+            confirmation_count: 1,
+        }
+    }
+
+    // The number of slots for which this vote is locked
+    pub fn lockout(&self) -> u64 {
+        (INITIAL_LOCKOUT as u64).pow(self.confirmation_count)
+    }
+
+    // The slot height at which this vote expires (cannot vote for any slot
+    // less than this)
+    pub fn lock_height(&self) -> u64 {
+        self.slot_height + self.lockout() as u64
     }
 }
 
@@ -53,7 +80,7 @@ pub enum VoteInstruction {
 
 #[derive(Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct VoteState {
-    pub votes: VecDeque<Vote>,
+    pub votes: VecDeque<StoredVote>,
     pub node_id: Pubkey,
     pub staker_id: Pubkey,
     credits: u64,
@@ -63,7 +90,7 @@ pub fn get_max_size() -> usize {
     // Upper limit on the size of the Vote State. Equal to
     // sizeof(VoteState) when votes.len() is MAX_VOTE_HISTORY
     let mut vote_state = VoteState::default();
-    vote_state.votes = VecDeque::from(vec![Vote::default(); MAX_VOTE_HISTORY]);
+    vote_state.votes = VecDeque::from(vec![StoredVote::default(); MAX_VOTE_HISTORY]);
     serialized_size(&vote_state).unwrap() as usize
 }
 
@@ -91,17 +118,29 @@ impl VoteState {
     }
 
     pub fn process_vote(&mut self, vote: Vote) {
-        // TODO: Integrity checks
-        // a) Verify the vote's bank hash matches what is expected
-        // b) Verify vote is older than previous votes
+        // Ignore votes for slots earlier than we already have votes for
+        if self
+            .votes
+            .back()
+            .map_or(false, |old_vote| old_vote.slot_height >= vote.slot_height)
+        {
+            return;
+        }
 
-        // Only keep around the most recent MAX_VOTE_HISTORY votes
+        let vote = StoredVote::new(&vote);
+
+        // TODO: Integrity checks
+        // Verify the vote's bank hash matches what is expected
+
+        self.pop_expired_votes(vote.slot_height);
+        self.votes.push_back(vote);
+        self.double_lockouts();
+
+        // Once the stack is full, pop the oldest vote and distribute rewards
         if self.votes.len() == MAX_VOTE_HISTORY {
             self.votes.pop_front();
             self.credits += 1;
         }
-
-        self.votes.push_back(vote);
     }
 
     /// Number of "credits" owed to this account from the mining pool. Submit this
@@ -113,6 +152,33 @@ impl VoteState {
     /// Clear any credits.
     pub fn clear_credits(&mut self) {
         self.credits = 0;
+    }
+
+    fn pop_expired_votes(&mut self, slot_height: u64) {
+        loop {
+            if self
+                .votes
+                .back()
+                .map_or(false, |v| v.lock_height() < slot_height)
+            {
+                self.votes.pop_back();
+            } else {
+                break;
+            }
+        }
+    }
+
+    fn double_lockouts(&mut self) {
+        let stack_depth = self.votes.len();
+        for (i, v) in self.votes.iter_mut().enumerate() {
+            // Don't increase the lockout for this vote until we get more confirmations
+            // than the max number of confirmations this vote has seen
+            if stack_depth > i + v.confirmation_count as usize {
+                v.confirmation_count += 1;
+            } else {
+                break;
+            }
+        }
     }
 }
 
@@ -203,22 +269,11 @@ mod tests {
     fn test_vote_serialize() {
         let mut buffer: Vec<u8> = vec![0; get_max_size()];
         let mut vote_state = VoteState::default();
-        vote_state.votes.resize(MAX_VOTE_HISTORY, Vote::default());
+        vote_state
+            .votes
+            .resize(MAX_VOTE_HISTORY, StoredVote::default());
         vote_state.serialize(&mut buffer).unwrap();
         assert_eq!(VoteState::deserialize(&buffer).unwrap(), vote_state);
-    }
-
-    #[test]
-    fn test_vote_credits() {
-        let mut vote_state = VoteState::default();
-        vote_state.votes.resize(MAX_VOTE_HISTORY, Vote::default());
-        assert_eq!(vote_state.credits(), 0);
-        vote_state.process_vote(Vote::new(42));
-        assert_eq!(vote_state.credits(), 1);
-        vote_state.process_vote(Vote::new(43));
-        assert_eq!(vote_state.credits(), 2);
-        vote_state.clear_credits();
-        assert_eq!(vote_state.credits(), 0);
     }
 
     #[test]
@@ -247,7 +302,7 @@ mod tests {
 
         let vote = Vote::new(1);
         let vote_state = vote_and_deserialize(&vote_id, &mut vote_account, vote.clone()).unwrap();
-        assert_eq!(vote_state.votes, vec![vote]);
+        assert_eq!(vote_state.votes, vec![StoredVote::new(&vote)]);
         assert_eq!(vote_state.credits(), 0);
     }
 
@@ -259,6 +314,89 @@ mod tests {
         let vote = Vote::new(1);
         let vote_state = vote_and_deserialize(&vote_id, &mut vote_account, vote.clone()).unwrap();
         assert_eq!(vote_state.node_id, Pubkey::default());
-        assert_eq!(vote_state.votes, vec![vote]);
+        assert_eq!(vote_state.votes, vec![StoredVote::new(&vote)]);
+    }
+
+    #[test]
+    fn test_vote_lockout() {
+        let voter_id = Keypair::new().pubkey();
+        let staker_id = Keypair::new().pubkey();
+        let mut vote_state = VoteState::new(voter_id, staker_id);
+
+        for i in 0..MAX_VOTE_HISTORY {
+            vote_state.process_vote(Vote::new((INITIAL_LOCKOUT as usize * i) as u64));
+        }
+
+        // The last vote should have been popped b/c it reached a depth of MAX_VOTE_HISTORY
+        assert_eq!(vote_state.votes.len(), MAX_VOTE_HISTORY - 1);
+        for (i, vote) in vote_state.votes.iter().enumerate() {
+            let num_lockouts = MAX_VOTE_HISTORY - 1 - i;
+            assert_eq!(
+                vote.lockout(),
+                INITIAL_LOCKOUT.pow(num_lockouts as u32) as u64
+            );
+        }
+
+        // Expire everything except the first vote
+        let vote = Vote::new(vote_state.votes.front().unwrap().lock_height());
+        vote_state.process_vote(vote);
+        // First vote and new vote are both stored for a total of 2 votes
+        assert_eq!(vote_state.votes.len(), 2);
+    }
+
+    #[test]
+    fn test_vote_double_lockout_after_expiration() {
+        let voter_id = Keypair::new().pubkey();
+        let staker_id = Keypair::new().pubkey();
+        let mut vote_state = VoteState::new(voter_id, staker_id);
+
+        for i in 0..3 {
+            let vote = Vote::new(i as u64);
+            vote_state.process_vote(vote);
+        }
+
+        // Check the lockouts for first and second votes. Lockouts should be
+        // INITIAL_LOCKOUT^3 and INITIAL_LOCKOUT^2 respectively
+        assert_eq!(vote_state.votes[0].lockout(), INITIAL_LOCKOUT.pow(3) as u64);
+        assert_eq!(vote_state.votes[1].lockout(), INITIAL_LOCKOUT.pow(2) as u64);
+
+        // Expire the third vote (which was a vote for slot 2). The height of the
+        // vote stack is unchanged, so none of the previous votes should have
+        // doubled in lockout
+        vote_state.process_vote(Vote::new((2 + INITIAL_LOCKOUT + 1) as u64));
+
+        assert_eq!(vote_state.votes[0].lockout(), INITIAL_LOCKOUT.pow(3) as u64);
+        assert_eq!(vote_state.votes[1].lockout(), INITIAL_LOCKOUT.pow(2) as u64);
+        assert_eq!(vote_state.votes[2].lockout(), INITIAL_LOCKOUT as u64);
+
+        // Vote again, this time the vote stack depth increases, so the lockouts should
+        // double for everybody
+        vote_state.process_vote(Vote::new((2 + INITIAL_LOCKOUT + 2) as u64));
+        assert_eq!(vote_state.votes[0].lockout(), INITIAL_LOCKOUT.pow(4) as u64);
+        assert_eq!(vote_state.votes[1].lockout(), INITIAL_LOCKOUT.pow(3) as u64);
+        assert_eq!(vote_state.votes[2].lockout(), INITIAL_LOCKOUT.pow(2) as u64);
+        assert_eq!(vote_state.votes[3].lockout(), INITIAL_LOCKOUT as u64);
+    }
+
+    #[test]
+    fn test_vote_credits() {
+        let voter_id = Keypair::new().pubkey();
+        let staker_id = Keypair::new().pubkey();
+        let mut vote_state = VoteState::new(voter_id, staker_id);
+
+        for i in 0..MAX_VOTE_HISTORY - 1 {
+            vote_state.process_vote(Vote::new(i as u64));
+        }
+
+        assert_eq!(vote_state.credits, 0);
+
+        vote_state.process_vote(Vote::new(MAX_VOTE_HISTORY as u64));
+        assert_eq!(vote_state.credits, 1);
+        vote_state.process_vote(Vote::new(MAX_VOTE_HISTORY as u64 + 1));
+        assert_eq!(vote_state.credits(), 2);
+        vote_state.process_vote(Vote::new(MAX_VOTE_HISTORY as u64 + 2));
+        assert_eq!(vote_state.credits(), 3);
+        vote_state.clear_credits();
+        assert_eq!(vote_state.credits(), 0);
     }
 }


### PR DESCRIPTION
#### Problem
VoteProgram state doesn't track lockouts, which is necessary for determining the commitment of the network to different forks

#### Summary of Changes
1) Track vote lockouts on each vote in the VoteProgram
2) Update the lockouts on each vote in process_vote()

Fixes #
