### PR TITLE
Squash the new working bank to ensure zero-balance accounts get purged

### DIFF
--- a/src/replay_stage.rs
+++ b/src/replay_stage.rs
@@ -448,6 +448,7 @@ impl ReplayStage {
         parent: &Arc<Bank>,
     ) -> Arc<Bank> {
         let new_bank = Bank::new_from_parent(&parent);
+        new_bank.squash();
         let mut bank_forks = bank_forks.write().unwrap();
         bank_forks.insert(slot, new_bank);
         bank_forks.set_working_bank_id(slot);

--- a/src/thin_client.rs
+++ b/src/thin_client.rs
@@ -466,7 +466,7 @@ pub fn new_fullnode(ledger_name: &'static str) -> (Fullnode, NodeInfo, Keypair, 
     let (genesis_block, mint_keypair) = GenesisBlock::new_with_leader(10_000, node_info.id, 42);
 
     let (ledger_path, _tick_height, _last_entry_height, _last_id, _last_entry_id) =
-        create_tmp_sample_blocktree(ledger_name, &genesis_block, 0);
+        create_tmp_sample_blocktree(ledger_name, &genesis_block, genesis_block.ticks_per_slot);
 
     let vote_account_keypair = Arc::new(Keypair::new());
     let voting_keypair = VotingKeypair::new_local(&vote_account_keypair);


### PR DESCRIPTION
`test_zero_balance_after_nonzero` is green at the tip only because it completes before the first rotation occurs. 

1. Force a rotation during `test_zero_balance_after_nonzero` to show it fails
2. Add a `squash()` into replay stage to avoid hitting https://github.com/solana-labs/solana/blob/ec35c1fc79cda28941bb4575aa21820c2c1bd31d/runtime/src/accounts.rs#L101-L102