### PR TITLE
Persistent account store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1090,6 +1090,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "memmap"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.49 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "memoffset"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2250,6 +2259,7 @@ dependencies = [
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "hashbrown 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memmap 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.88 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.88 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2994,6 +3004,7 @@ dependencies = [
 "checksum make-cmd 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a8ca8afbe8af1785e09636acb5a41e08a765f5f0340568716c18a8700ba3c0d3"
 "checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 "checksum memchr 2.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "db4c41318937f6e76648f42826b1d9ade5c09cafb5aef7e351240a70f39206e9"
+"checksum memmap 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e2ffa2c986de11a9df78620c01eeaaf27d94d3ff02bf81bfcca953102dd0c6ff"
 "checksum memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0f9dc261e2b62d7a622bf416ea3c5245cdd5d9a7fcc428c0d06804dfce1775b3"
 "checksum mime 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ba626b8a6de5da682e1caa06bdb42a335aee5a84db8e5046a3e8ab17ba0a3ae0"
 "checksum mime 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)" = "3e27ca21f40a310bd06d9031785f4801710d566c184a6e15bad4f1d9b65f9425"

--- a/benches/appendvec.rs
+++ b/benches/appendvec.rs
@@ -1,0 +1,172 @@
+#![cfg_attr(feature = "unstable", feature(test))]
+extern crate rand;
+extern crate test;
+
+use rand::{thread_rng, Rng};
+use solana_runtime::appendvec::AppendVec;
+use std::path::Path;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, RwLock};
+use std::thread::spawn;
+use test::Bencher;
+
+const START_SIZE: u64 = 4 * 1024 * 1024;
+const INC_SIZE: u64 = 1 * 1024 * 1024;
+
+#[bench]
+fn appendvec_atomic_append(bencher: &mut Bencher) {
+    let path = Path::new("/media/nvme0/bench/bench_append");
+    let mut vec = AppendVec::<AtomicUsize>::new(path, true, START_SIZE, INC_SIZE);
+    bencher.iter(|| {
+        if vec.append(AtomicUsize::new(0)).is_none() {
+            assert!(vec.grow_file().is_ok());
+            assert!(vec.append(AtomicUsize::new(0)).is_some());
+        }
+    });
+    std::fs::remove_file(path).unwrap();
+}
+
+#[bench]
+fn appendvec_atomic_random_access(bencher: &mut Bencher) {
+    let path = Path::new("/media/nvme0/bench/bench_ra");
+    let mut vec = AppendVec::<AtomicUsize>::new(path, true, START_SIZE, INC_SIZE);
+    let size = 10_000_000;
+    for _ in 0..size {
+        if vec.append(AtomicUsize::new(0)).is_none() {
+            assert!(vec.grow_file().is_ok());
+            assert!(vec.append(AtomicUsize::new(0)).is_some());
+        }
+    }
+    bencher.iter(|| {
+        let index = thread_rng().gen_range(0, size as u64);
+        vec.get(index * std::mem::size_of::<AtomicUsize>() as u64);
+    });
+    std::fs::remove_file(path).unwrap();
+}
+
+#[bench]
+fn appendvec_atomic_random_change(bencher: &mut Bencher) {
+    let path = Path::new("/media/nvme0/bench/bench_rax");
+    let mut vec = AppendVec::<AtomicUsize>::new(path, true, START_SIZE, INC_SIZE);
+    let size = 10_000_000;
+    for _ in 0..size {
+        if vec.append(AtomicUsize::new(0)).is_none() {
+            assert!(vec.grow_file().is_ok());
+            assert!(vec.append(AtomicUsize::new(0)).is_some());
+        }
+    }
+    bencher.iter(|| {
+        let index = thread_rng().gen_range(0, size as u64);
+        let atomic1 = vec.get(index * std::mem::size_of::<AtomicUsize>() as u64);
+        let current1 = atomic1.load(Ordering::Relaxed);
+        let next = current1 + 1;
+        atomic1.store(next, Ordering::Relaxed);
+        let atomic2 = vec.get(index * std::mem::size_of::<AtomicUsize>() as u64);
+        let current2 = atomic2.load(Ordering::Relaxed);
+        assert_eq!(current2, next);
+    });
+    std::fs::remove_file(path).unwrap();
+}
+
+#[bench]
+fn appendvec_atomic_random_read(bencher: &mut Bencher) {
+    let path = Path::new("/media/nvme0/bench/bench_read");
+    let mut vec = AppendVec::<AtomicUsize>::new(path, true, START_SIZE, INC_SIZE);
+    let size = 100_000_000;
+    for _ in 0..size {
+        if vec.append(AtomicUsize::new(0)).is_none() {
+            assert!(vec.grow_file().is_ok());
+            assert!(vec.append(AtomicUsize::new(0)).is_some());
+        }
+    }
+    bencher.iter(|| {
+        let index = thread_rng().gen_range(0, size);
+        let atomic1 = vec.get((index * std::mem::size_of::<AtomicUsize>()) as u64);
+        let current1 = atomic1.load(Ordering::Relaxed);
+        assert_eq!(current1, 0);
+    });
+    std::fs::remove_file(path).unwrap();
+}
+
+#[bench]
+fn appendvec_concurrent_lock_append(bencher: &mut Bencher) {
+    let path = Path::new("bench_lock_append");
+    let vec = Arc::new(RwLock::new(AppendVec::<AtomicUsize>::new(
+        path, true, START_SIZE, INC_SIZE,
+    )));
+    let vec1 = vec.clone();
+    let size = 100_000_000;
+    let count = Arc::new(AtomicUsize::new(0));
+    let count1 = count.clone();
+    spawn(move || loop {
+        let mut len = count.load(Ordering::Relaxed);
+        {
+            let rlock = vec1.read().unwrap();
+            loop {
+                if rlock.append(AtomicUsize::new(0)).is_none() {
+                    break;
+                }
+                len = count.fetch_add(1, Ordering::Relaxed);
+            }
+            if len >= size {
+                break;
+            }
+        }
+        {
+            let mut wlock = vec1.write().unwrap();
+            if len >= size {
+                break;
+            }
+            assert!(wlock.grow_file().is_ok());
+        }
+    });
+    bencher.iter(|| {
+        let _rlock = vec.read().unwrap();
+        let len = count1.load(Ordering::Relaxed);
+        assert!(len < size * 2);
+    });
+    std::fs::remove_file(path).unwrap();
+}
+
+#[bench]
+fn appendvec_concurrent_get_append(bencher: &mut Bencher) {
+    let path = Path::new("bench_get_append");
+    let vec = Arc::new(RwLock::new(AppendVec::<AtomicUsize>::new(
+        path, true, START_SIZE, INC_SIZE,
+    )));
+    let vec1 = vec.clone();
+    let size = 100_000_000;
+    let count = Arc::new(AtomicUsize::new(0));
+    let count1 = count.clone();
+    spawn(move || loop {
+        let mut len = count.load(Ordering::Relaxed);
+        {
+            let rlock = vec1.read().unwrap();
+            loop {
+                if rlock.append(AtomicUsize::new(0)).is_none() {
+                    break;
+                }
+                len = count.fetch_add(1, Ordering::Relaxed);
+            }
+            if len >= size {
+                break;
+            }
+        }
+        {
+            let mut wlock = vec1.write().unwrap();
+            if len >= size {
+                break;
+            }
+            assert!(wlock.grow_file().is_ok());
+        }
+    });
+    bencher.iter(|| {
+        let rlock = vec.read().unwrap();
+        let len = count1.load(Ordering::Relaxed);
+        if len > 0 {
+            let index = thread_rng().gen_range(0, len);
+            rlock.get((index * std::mem::size_of::<AtomicUsize>()) as u64);
+        }
+    });
+    std::fs::remove_file(path).unwrap();
+}

--- a/fullnode/src/main.rs
+++ b/fullnode/src/main.rs
@@ -218,7 +218,9 @@ fn main() {
     let (keypair, gossip) = parse_identity(&matches);
     let ledger_path = matches.value_of("ledger").unwrap();
     if let Some(paths) = matches.value_of("accounts") {
-        fullnode_config.account_paths = paths.to_string();
+        fullnode_config.account_paths = Some(paths.to_string());
+    } else {
+        fullnode_config.account_paths = None;
     }
     let cluster_entrypoint = matches
         .value_of("network")

--- a/fullnode/src/main.rs
+++ b/fullnode/src/main.rs
@@ -200,6 +200,14 @@ fn main() {
                 .takes_value(true)
                 .help("Rendezvous with the vote signer at this RPC end point"),
         )
+        .arg(
+            Arg::with_name("accounts")
+                .short("a")
+                .long("accounts")
+                .value_name("PATHS")
+                .takes_value(true)
+                .help("Comma separated persistent accounts location"),
+        )
         .get_matches();
 
     let mut fullnode_config = FullnodeConfig::default();
@@ -209,6 +217,9 @@ fn main() {
     let use_only_bootstrap_leader = matches.is_present("no_leader_rotation");
     let (keypair, gossip) = parse_identity(&matches);
     let ledger_path = matches.value_of("ledger").unwrap();
+    if let Some(paths) = matches.value_of("accounts") {
+        fullnode_config.account_paths = paths.to_string();
+    }
     let cluster_entrypoint = matches
         .value_of("network")
         .map(|network| network.parse().expect("failed to parse network address"));

--- a/multinode-demo/bootstrap-leader.sh
+++ b/multinode-demo/bootstrap-leader.sh
@@ -68,6 +68,7 @@ $program \
   $maybe_no_leader_rotation \
   --identity "$SOLANA_CONFIG_DIR"/bootstrap-leader.json \
   --ledger "$SOLANA_CONFIG_DIR"/bootstrap-leader-ledger \
+  --accounts "$SOLANA_CONFIG_DIR"/bootstrap-leader-accounts \
   --rpc-port 8899 \
   > >($bootstrap_leader_logger) 2>&1 &
 pid=$!

--- a/multinode-demo/fullnode.sh
+++ b/multinode-demo/fullnode.sh
@@ -157,6 +157,7 @@ if ((!self_setup)); then
   fullnode_id_path=$SOLANA_CONFIG_DIR/fullnode-id.json
   fullnode_json_path=$SOLANA_CONFIG_DIR/fullnode.json
   ledger_config_dir=$SOLANA_CONFIG_DIR/fullnode-ledger
+  accounts_config_dir=$SOLANA_CONFIG_DIR/fullnode-accounts
 else
   mkdir -p "$SOLANA_CONFIG_DIR"
   fullnode_id_path=$SOLANA_CONFIG_DIR/fullnode-id-x$self_setup_label.json
@@ -181,6 +182,7 @@ else
   }
 
   ledger_config_dir=$SOLANA_CONFIG_DIR/fullnode-ledger-x$self_setup_label
+  accounts_config_dir=$SOLANA_CONFIG_DIR/fullnode-accounts-x$self_setup_label
 fi
 
 [[ -r $fullnode_id_path ]] || {
@@ -256,6 +258,7 @@ $program \
   --identity "$fullnode_json_path" \
   --network "$leader_address" \
   --ledger "$ledger_config_dir" \
+  --accounts "$accounts_config_dir" \
   > >($fullnode_logger) 2>&1 &
 pid=$!
 oom_score_adj "$pid" 1000

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -14,6 +14,7 @@ bv = { version = "0.11.0", features = ["serde"] }
 fnv = "1.0.6"
 hashbrown = "0.1.8"
 log = "0.4.2"
+memmap = "0.6.2"
 rand = "0.6.5"
 serde = "1.0.88"
 serde_derive = "1.0.88"

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -1,5 +1,4 @@
 use crate::appendvec::AppendVec;
-use solana_sdk::signature::{Keypair, KeypairUtil};
 use crate::bank::{BankError, Result};
 use crate::runtime::has_duplicates;
 use bincode::serialize;
@@ -10,10 +9,11 @@ use solana_sdk::account::Account;
 use solana_sdk::hash::{hash, Hash};
 use solana_sdk::native_loader;
 use solana_sdk::pubkey::Pubkey;
+use solana_sdk::signature::{Keypair, KeypairUtil};
 use solana_sdk::transaction::Transaction;
 use solana_sdk::vote_program;
 use std::collections::BTreeMap;
-use std::fs::{create_dir_all, remove_dir_all};
+use std::fs::{create_dir_all, read_dir, remove_dir_all};
 use std::path::Path;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex, RwLock};
@@ -67,14 +67,15 @@ pub struct ErrorCounters {
 
 const ACCOUNT_DATA_FILE_SIZE: u64 = 64 * 1024 * 1024;
 const ACCOUNT_DATA_FILE: &str = "data";
-const NUM_ACCOUNT_DIRS: usize = 1;
+const ACCOUNTSDB_DIR: &str = "accountsdb";
+const NUM_ACCOUNT_DIRS: usize = 4;
 
 /// An offset into the AccountsDB::storage vector
 type AppendVecId = usize;
 
 type Fork = u64;
 
-struct AccountMap(Vec<(Fork, (AppendVecId, u64))>);
+struct AccountMap(HashMap<Fork, (AppendVecId, u64)>);
 
 #[derive(Debug, PartialEq)]
 enum AccountStorageStatus {
@@ -130,6 +131,16 @@ impl AccountStorage {
     }
 }
 
+#[derive(Default)]
+struct AccountsForkInfo {
+    /// The number of transactions the bank has processed without error since the
+    /// start of the ledger.
+    transaction_count: u64,
+
+    /// List of all parents corresponding to this fork
+    parents: Vec<Fork>,
+}
+
 // This structure handles the load/store of the accounts
 pub struct AccountsDB {
     /// Keeps tracks of index into AppendVec on a per fork basis
@@ -141,24 +152,8 @@ pub struct AccountsDB {
     /// distribute the accounts across storage lists
     next_id: AtomicUsize,
 
-    /// The number of transactions the bank has processed without error since the
-    /// start of the ledger.
-    transaction_count: RwLock<HashMap<u64, u64>>,
-}
-
-impl Default for AccountsDB {
-    fn default() -> Self {
-        let index_info = AccountIndexInfo {
-            index: RwLock::new(HashMap::new()),
-            vote_index: RwLock::new(HashSet::new()),
-        };
-        AccountsDB {
-            index_info,
-            storage: RwLock::new(vec![]),
-            next_id: AtomicUsize::new(0),
-            transaction_count: RwLock::new(HashMap::new()),
-        }
-    }
+    /// Information related to the fork
+    fork_info: RwLock<HashMap<Fork, AccountsForkInfo>>,
 }
 
 /// This structure handles synchronization for db
@@ -166,7 +161,7 @@ pub struct Accounts {
     pub accounts_db: AccountsDB,
 
     /// set of accounts which are currently in the pipeline
-    account_locks: Mutex<HashSet<Pubkey>>,
+    account_locks: Mutex<HashMap<Fork, HashSet<Pubkey>>>,
 
     /// List of persistent stores
     paths: String,
@@ -177,12 +172,44 @@ impl Drop for Accounts {
         let paths: Vec<String> = self.paths.split(',').map(|s| s.to_string()).collect();
         paths.iter().for_each(|p| {
             let _ignored = remove_dir_all(p);
-        })
+        });
+        let entry = read_dir(ACCOUNTSDB_DIR);
+        if entry.is_ok() && entry.unwrap().count() == 0 {
+            let _ignored = remove_dir_all(ACCOUNTSDB_DIR);
+        }
     }
 }
 
 impl AccountsDB {
-    pub fn add_storage(&self, paths: &str) {
+    pub fn new(fork: Fork, paths: &str) -> Self {
+        let index_info = AccountIndexInfo {
+            index: RwLock::new(HashMap::new()),
+            vote_index: RwLock::new(HashSet::new()),
+        };
+        let accounts_db = AccountsDB {
+            index_info,
+            storage: RwLock::new(vec![]),
+            next_id: AtomicUsize::new(0),
+            fork_info: RwLock::new(HashMap::new()),
+        };
+        accounts_db.add_storage(paths);
+        accounts_db.add_fork(fork, None);
+        accounts_db
+    }
+
+    pub fn add_fork(&self, fork: Fork, parent: Option<Fork>) {
+        let mut info = self.fork_info.write().unwrap();
+        let mut fork_info = AccountsForkInfo::default();
+        if parent.is_some() {
+            fork_info.parents.push(parent.unwrap());
+            if let Some(list) = info.get(&parent.unwrap()) {
+                fork_info.parents.extend_from_slice(&list.parents);
+            }
+        }
+        info.insert(fork, fork_info);
+    }
+
+    fn add_storage(&self, paths: &str) {
         let paths: Vec<String> = paths.split(',').map(|s| s.to_string()).collect();
         let mut stores: Vec<AccountStorage> = vec![];
         paths.iter().for_each(|p| {
@@ -196,7 +223,6 @@ impl AccountsDB {
             };
             stores.push(storage);
         });
-        let _ignored = stores[0].appendvec.write().unwrap().grow_file();
         let mut storage = self.storage.write().unwrap();
         storage.append(&mut stores);
     }
@@ -224,20 +250,15 @@ impl AccountsDB {
             .iter()
             .for_each(|p| {
                 if let Some(forks) = self.index_info.index.read().unwrap().get(p) {
-                    for (v_fork, (id, index)) in forks.0.iter() {
-                        if fork == *v_fork {
-                            accounts.push(
-                                self.storage.read().unwrap()[*id]
-                                    .appendvec
-                                    .read()
-                                    .unwrap()
-                                    .get_account(*index)
-                                    .unwrap(),
-                            );
-                        }
-                        if fork > *v_fork {
-                            break;
-                        }
+                    if let Some((id, index)) = forks.0.get(&fork) {
+                        accounts.push(
+                            self.storage.read().unwrap()[*id]
+                                .appendvec
+                                .read()
+                                .unwrap()
+                                .get_account(*index)
+                                .unwrap(),
+                        );
                     }
                 }
             });
@@ -248,10 +269,8 @@ impl AccountsDB {
         let index = self.index_info.index.read().unwrap();
 
         for account_map in index.values() {
-            for (v_fork, _) in account_map.0.iter() {
-                if fork == *v_fork {
-                    return true;
-                }
+            if account_map.0.contains_key(&fork) {
+                return true;
             }
         }
         false
@@ -261,19 +280,14 @@ impl AccountsDB {
         let mut ordered_accounts = BTreeMap::new();
         let rindex = self.index_info.index.read().unwrap();
         rindex.iter().for_each(|(p, forks)| {
-            for (v_fork, (id, index)) in forks.0.iter() {
-                if fork == *v_fork {
-                    let account = self.storage.read().unwrap()[*id]
-                        .appendvec
-                        .read()
-                        .unwrap()
-                        .get_account(*index)
-                        .unwrap();
-                    ordered_accounts.insert(*p, account);
-                }
-                if fork > *v_fork {
-                    break;
-                }
+            if let Some((id, index)) = forks.0.get(&fork) {
+                let account = self.storage.read().unwrap()[*id]
+                    .appendvec
+                    .read()
+                    .unwrap()
+                    .get_account(*index)
+                    .unwrap();
+                ordered_accounts.insert(*p, account);
             }
         });
 
@@ -283,17 +297,27 @@ impl AccountsDB {
         Some(hash(&serialize(&ordered_accounts).unwrap()))
     }
 
-    fn load(&self, fork: Fork, pubkey: &Pubkey) -> Option<Account> {
+    fn get_account(&self, id: AppendVecId, offset: u64) -> Option<Account> {
+        let appendvec = &self.storage.read().unwrap()[id].appendvec;
+        let av = appendvec.read().unwrap();
+        Some(av.get_account(offset).unwrap())
+    }
+
+    fn load(&self, fork: Fork, pubkey: &Pubkey, walk_back: bool) -> Option<Account> {
         let index = self.index_info.index.read().unwrap();
         if let Some(forks) = index.get(pubkey) {
             // find most recent fork that is an ancestor of current_fork
-            for (v_fork, (id, offset)) in forks.0.iter() {
-                if *v_fork > fork {
-                    continue;
-                } else {
-                    let appendvec = &self.storage.read().unwrap()[*id].appendvec;
-                    let av = appendvec.read().unwrap();
-                    return Some(av.get_account(*offset).unwrap());
+            if let Some((id, offset)) = forks.0.get(&fork) {
+                return self.get_account(*id, *offset);
+            } else {
+                if !walk_back {
+                    return None;
+                }
+                let fork_info = self.fork_info.read().unwrap();
+                for parent_fork in fork_info.get(&fork).unwrap().parents.iter() {
+                    if let Some((id, offset)) = forks.0.get(&parent_fork) {
+                        return self.get_account(*id, *offset);
+                    }
                 }
             }
         }
@@ -366,16 +390,26 @@ impl AccountsDB {
         (id, offset)
     }
 
+    fn remove_account_entry(&self, fork: Fork, forks: &mut AccountMap) {
+        if let Some((id, _)) = forks.0.remove(&fork) {
+            let stores = self.storage.read().unwrap();
+            if stores[id].count.fetch_sub(1, Ordering::Relaxed) == 1 {
+                stores[id].appendvec.write().unwrap().reset();
+                stores[id].set_status(AccountStorageStatus::StorageAvailable);
+            }
+        }
+    }
+
     /// Store the account update.  If the update is to delete the account because the token balance
     /// is 0, purge needs to be set to true for the delete to occur in place.
     pub fn store(&self, fork: Fork, purge: bool, pubkey: &Pubkey, account: &Account) {
         if account.tokens == 0 && purge {
             // purge if balance is 0 and no checkpoints
             let mut index = self.index_info.index.write().unwrap();
-            if let Some(forks) = index.remove(pubkey) {
-                let stores = self.storage.read().unwrap();
-                for (_, (id, _)) in forks.0.iter() {
-                    stores[*id].count.fetch_sub(1, Ordering::Relaxed);
+            if let Some(mut forks) = index.get_mut(&pubkey) {
+                self.remove_account_entry(fork, &mut forks);
+                if forks.0.is_empty() {
+                    index.remove(pubkey);
                 }
             }
             if vote_program::check_id(&account.owner) {
@@ -393,34 +427,15 @@ impl AccountsDB {
                 }
             }
 
-            let mut result: Option<usize> = None;
+            let result: Option<(AppendVecId, u64)>;
             {
-                let mut insert: Option<usize> = None;
                 let mut windex = self.index_info.index.write().unwrap();
-                let forks = windex.entry(*pubkey).or_insert(AccountMap(vec![]));
-                for (i, (v_fork, (v_id, _))) in forks.0.iter().enumerate() {
-                    if *v_fork > fork {
-                        continue;
-                    }
-                    if *v_fork == fork {
-                        result = Some(*v_id);
-                        forks.0[i] = (fork, (id, offset));
-                        break;
-                    }
-                    insert = Some(i);
-                    break;
-                }
-                if result.is_none() {
-                    if let Some(index) = insert {
-                        forks.0.insert(index, (fork, (id, offset)));
-                    } else {
-                        forks.0.push((fork, (id, offset)));
-                    }
-                }
+                let forks = windex.entry(*pubkey).or_insert(AccountMap(HashMap::new()));
+                result = forks.0.insert(fork, (id, offset));
             }
             let stores = self.storage.read().unwrap();
             stores[id].count.fetch_add(1, Ordering::Relaxed);
-            if let Some(old_id) = result {
+            if let Some((old_id, _)) = result {
                 if stores[old_id].count.fetch_sub(1, Ordering::Relaxed) == 1 {
                     stores[old_id].appendvec.write().unwrap().reset();
                     stores[old_id].set_status(AccountStorageStatus::StorageAvailable);
@@ -428,7 +443,6 @@ impl AccountsDB {
             }
         }
     }
-
 
     pub fn store_accounts(
         &self,
@@ -471,7 +485,7 @@ impl AccountsDB {
             // If a fee can pay for execution then the program will be scheduled
             let mut called_accounts: Vec<Account> = vec![];
             for key in &tx.account_keys {
-                called_accounts.push(self.load(fork, key).unwrap_or_default());
+                called_accounts.push(self.load(fork, key, true).unwrap_or_default());
             }
             if called_accounts.is_empty() || called_accounts[0].tokens == 0 {
                 error_counters.account_not_found += 1;
@@ -506,7 +520,7 @@ impl AccountsDB {
             }
             depth += 1;
 
-            let program = match self.load(fork, &program_id) {
+            let program = match self.load(fork, &program_id, true) {
                 Some(program) => program,
                 None => {
                     error_counters.account_not_found += 1;
@@ -567,43 +581,70 @@ impl AccountsDB {
     }
 
     pub fn increment_transaction_count(&self, fork: Fork, tx_count: usize) {
-        let mut tx = self.transaction_count.write().unwrap();
-        let entry = tx.entry(fork).or_insert(0);
-        *entry += tx_count as u64;
+        let mut info = self.fork_info.write().unwrap();
+        let entry = info.entry(fork).or_insert(AccountsForkInfo::default());
+        entry.transaction_count += tx_count as u64;
     }
 
     pub fn transaction_count(&self, fork: Fork) -> u64 {
-        let tx = self.transaction_count.read().unwrap();
-        if let Some(entry) = tx.get(&fork) {
-            *entry
+        let info = self.fork_info.read().unwrap();
+        if let Some(entry) = info.get(&fork) {
+            entry.transaction_count
         } else {
             0
         }
     }
 
     /// become the root accountsDB
-    fn squash<U>(&mut self, parents: &[U])
-    where
-        U: std::ops::Deref<Target = Self>,
-    {
-        /*
-        self.transaction_count += parents
+    fn squash(&self, fork: Fork) {
+        let parents: Vec<Fork>;
+        {
+            let info = self.fork_info.read().unwrap();
+            let fork_info = info.get(&fork).unwrap();
+            parents = fork_info.parents.clone();
+        }
+        let tx_count = parents
             .iter()
-            .fold(0, |sum, parent| sum + parent.transaction_count);
+            .fold(0, |sum, parent| sum + self.transaction_count(*parent));
+        self.increment_transaction_count(fork, tx_count as usize);
 
         // for every account in all the parents, load latest and update self if
-        //   absent
-        for pubkey in parents.iter().flat_map(|parent| parent.accounts.keys()) {
-            // update self with data from parents unless in self
-            if self.accounts.get(pubkey).is_none() {
-                self.accounts
-                    .insert(pubkey.clone(), Self::load(parents, pubkey).unwrap().clone());
+        // absent
+        let mut index = self.index_info.index.write().unwrap();
+        index.iter_mut().for_each(|(_, mut forks)| {
+            if forks.0.get(&fork).is_none() {
+                for parent_fork in parents.iter() {
+                    if let Some((id, offset)) = forks.0.get(parent_fork) {
+                        forks.0.insert(fork, (*id, *offset));
+                        forks.0.remove(parent_fork);
+                        break;
+                    }
+                }
+            }
+            for parent_fork in parents.iter() {
+                self.remove_account_entry(*parent_fork, &mut forks);
+            }
+        });
+
+        {
+            let mut info = self.fork_info.write().unwrap();
+            let fork_info = info.get_mut(&fork).unwrap();
+            fork_info.parents = vec![];
+            for parent_fork in parents.iter() {
+                info.remove(parent_fork);
             }
         }
-
-        // toss any zero-balance accounts, since self is root now
-        self.accounts.retain(|_, account| account.tokens != 0);
-        */
+        index.iter_mut().for_each(|(pubkey, mut forks)| {
+            if let Some((id, offset)) = forks.0.get(&fork) {
+                let account = self.get_account(*id, *offset).unwrap();
+                if account.tokens == 0 {
+                    self.remove_account_entry(fork, &mut forks);
+                    if vote_program::check_id(&account.owner) {
+                        self.index_info.vote_index.write().unwrap().remove(pubkey);
+                    }
+                }
+            }
+        });
     }
 }
 
@@ -611,36 +652,47 @@ impl Accounts {
     fn make_new_dir() -> String {
         static ACCOUNT_DIR: AtomicUsize = AtomicUsize::new(0);
         let dir = ACCOUNT_DIR.fetch_add(1, Ordering::Relaxed);
-        format!("accountsdb/{}", dir.to_string())
+        format!("{}/{}", ACCOUNTSDB_DIR, dir.to_string())
     }
 
     fn make_default_paths() -> String {
-        let mut paths = Self::make_new_dir();
-        for _ in 1..NUM_ACCOUNT_DIRS {
-            paths.push_str(",");
+        let mut paths = "".to_string();
+        for index in 0..NUM_ACCOUNT_DIRS {
+            if index > 0 {
+                paths.push_str(",");
+            }
             paths.push_str(&Self::make_new_dir());
         }
         paths
     }
 
-    pub fn new(in_paths: &str) -> Self {
+    pub fn new(fork: Fork, in_paths: &str) -> Self {
         let paths = if !in_paths.is_empty() {
             in_paths.to_string()
         } else {
             Self::make_default_paths()
         };
-        let accounts_db = AccountsDB::default();
-        accounts_db.add_storage(&paths);
+        let accounts_db = AccountsDB::new(fork, &paths);
+        accounts_db.add_fork(fork, None);
         Accounts {
             accounts_db,
-            account_locks: Mutex::new(HashSet::new()),
+            account_locks: Mutex::new(HashMap::new()),
             paths,
         }
     }
 
+    pub fn new_from_parent(&self, fork: Fork, parent: Fork) {
+        self.accounts_db.add_fork(fork, Some(parent));
+    }
+
     /// Slow because lock is held for 1 operation insted of many
     pub fn load_slow(&self, fork: Fork, pubkey: &Pubkey) -> Option<Account> {
-        self.accounts_db.load(fork, pubkey)
+        self.accounts_db.load(fork, pubkey, true)
+    }
+
+    /// Slow because lock is held for 1 operation insted of many
+    pub fn load_slow_no_parent(&self, fork: Fork, pubkey: &Pubkey) -> Option<Account> {
+        self.accounts_db.load(fork, pubkey, false)
     }
 
     /// Slow because lock is held for 1 operation insted of many
@@ -651,29 +703,41 @@ impl Accounts {
     }
 
     fn lock_account(
-        account_locks: &mut HashSet<Pubkey>,
+        fork: Fork,
+        account_locks: &mut HashMap<Fork, HashSet<Pubkey>>,
         keys: &[Pubkey],
         error_counters: &mut ErrorCounters,
     ) -> Result<()> {
         // Copy all the accounts
+        let locks = account_locks.entry(fork).or_insert(HashSet::new());
         for k in keys {
-            if account_locks.contains(k) {
+            if locks.contains(k) {
                 error_counters.account_in_use += 1;
                 return Err(BankError::AccountInUse);
             }
         }
         for k in keys {
-            account_locks.insert(*k);
+            locks.insert(*k);
         }
         Ok(())
     }
 
-    fn unlock_account(tx: &Transaction, result: &Result<()>, account_locks: &mut HashSet<Pubkey>) {
+    fn unlock_account(
+        fork: Fork,
+        tx: &Transaction,
+        result: &Result<()>,
+        account_locks: &mut HashMap<Fork, HashSet<Pubkey>>,
+    ) {
         match result {
             Err(BankError::AccountInUse) => (),
             _ => {
-                for k in &tx.account_keys {
-                    account_locks.remove(k);
+                if let Some(locks) = account_locks.get_mut(&fork) {
+                    for k in &tx.account_keys {
+                        locks.remove(k);
+                    }
+                    if locks.is_empty() {
+                        account_locks.remove(&fork);
+                    }
                 }
             }
         }
@@ -686,12 +750,19 @@ impl Accounts {
     /// This function will prevent multiple threads from modifying the same account state at the
     /// same time
     #[must_use]
-    pub fn lock_accounts(&self, txs: &[Transaction]) -> Vec<Result<()>> {
+    pub fn lock_accounts(&self, fork: Fork, txs: &[Transaction]) -> Vec<Result<()>> {
         let mut account_locks = self.account_locks.lock().unwrap();
         let mut error_counters = ErrorCounters::default();
         let rv = txs
             .iter()
-            .map(|tx| Self::lock_account(&mut account_locks, &tx.account_keys, &mut error_counters))
+            .map(|tx| {
+                Self::lock_account(
+                    fork,
+                    &mut account_locks,
+                    &tx.account_keys,
+                    &mut error_counters,
+                )
+            })
             .collect();
         if error_counters.account_in_use != 0 {
             inc_new_counter_info!(
@@ -703,12 +774,12 @@ impl Accounts {
     }
 
     /// Once accounts are unlocked, new transactions that modify that state can enter the pipeline
-    pub fn unlock_accounts(&self, txs: &[Transaction], results: &[Result<()>]) {
+    pub fn unlock_accounts(&self, fork: Fork, txs: &[Transaction], results: &[Result<()>]) {
         let mut account_locks = self.account_locks.lock().unwrap();
         debug!("bank unlock accounts");
         txs.iter()
             .zip(results.iter())
-            .for_each(|(tx, result)| Self::unlock_account(tx, result, &mut account_locks));
+            .for_each(|(tx, result)| Self::unlock_account(fork, tx, result, &mut account_locks));
     }
 
     pub fn has_accounts(&self, fork: Fork) -> bool {
@@ -751,20 +822,9 @@ impl Accounts {
 
     /// accounts starts with an empty data structure for every child/fork
     ///   this function squashes all the parents into this instance
-    pub fn squash<U>(&self, parents: &[U])
-    where
-        U: std::ops::Deref<Target = Self>,
-    {
-        assert!(self.account_locks.lock().unwrap().is_empty());
-
-        /*
-        let dbs: Vec<_> = parents
-            .iter()
-            .map(|obj| obj.accounts_db.read().unwrap())
-            .collect();
-
-        self.accounts_db.write().unwrap().squash(&dbs);
-        */
+    pub fn squash(&self, fork: Fork) {
+        assert!(!self.account_locks.lock().unwrap().contains_key(&fork));
+        self.accounts_db.squash(fork);
     }
 }
 
@@ -784,16 +844,15 @@ mod tests {
     #[test]
     fn test_purge() {
         let paths = "purge".to_string();
-        let db = AccountsDB::default();
-        db.add_storage(&paths);
+        let db = AccountsDB::new(0, &paths);
         let key = Pubkey::default();
         let account = Account::new(0, 0, Pubkey::default());
         // accounts are deleted when their token value is 0 and purge is true
         db.store(0, false, &key, &account);
-        assert_eq!(db.load(0, &key), Some(account.clone()));
+        assert_eq!(db.load(0, &key, true), Some(account.clone()));
         // purge should be set to true for the root checkpoint
         db.store(0, true, &key, &account);
-        assert_eq!(db.load(0, &key), None);
+        assert_eq!(db.load(0, &key, true), None);
         cleanup_dirs(&paths);
     }
 
@@ -802,7 +861,7 @@ mod tests {
         ka: &Vec<(Pubkey, Account)>,
         error_counters: &mut ErrorCounters,
     ) -> Vec<Result<(InstructionAccounts, InstructionLoaders)>> {
-        let accounts = Accounts::new("");
+        let accounts = Accounts::new(0, "");
         for ka in ka.iter() {
             accounts.store_slow(0, true, &ka.0, &ka.1);
         }
@@ -1183,21 +1242,23 @@ mod tests {
 
     #[test]
     fn test_accounts_squash() {
-        let db0 = AccountsDB::default();
+        let paths = "merge".to_string();
+        let db0 = AccountsDB::new(0, &paths);
         let key = Pubkey::default();
         let account = Account::new(1, 0, key);
 
         // store value 1 in the "root", i.e. db zero
         db0.store(0, true, &key, &account);
 
+        db0.add_fork(1, Some(0));
         // store value 0 in the child, but don't purge (see purge test above)
-        let mut db1 = AccountsDB::default();
-        db1.store(0, false, &key, &Account::new(0, 0, key));
+        db0.store(1, false, &key, &Account::new(0, 0, key));
 
-        // squash, which should whack key's account
-        db1.squash(&[&db0]);
+        // merge, which should whack key's account
+        db0.squash(1);
 
-        assert_eq!(db1.load(0, &key), None);
+        assert_eq!(db0.load(1, &key, true), None);
+        cleanup_dirs(&paths);
     }
 
     fn create_account(
@@ -1216,7 +1277,7 @@ mod tests {
                 default_account.owner = vote_program::id();
                 nvote -= 1;
             }
-            assert!(accounts.load(0, &pubkey).is_none());
+            assert!(accounts.load(0, &pubkey, true).is_none());
             accounts.store(0, true, &pubkey, &default_account);
         }
     }
@@ -1224,11 +1285,11 @@ mod tests {
     fn update_accounts(accounts: &AccountsDB, pubkeys: Vec<Pubkey>, range: usize) {
         for _ in 1..1000 {
             let idx = thread_rng().gen_range(0, range);
-            if let Some(mut account) = accounts.load(0, &pubkeys[idx]) {
+            if let Some(mut account) = accounts.load(0, &pubkeys[idx], true) {
                 account.tokens = account.tokens + 1;
                 accounts.store(0, true, &pubkeys[idx], &account);
                 if account.tokens == 0 {
-                    assert!(accounts.load(0, &pubkeys[idx]).is_none());
+                    assert!(accounts.load(0, &pubkeys[idx], true).is_none());
                 } else {
                     let mut default_account = Account::default();
                     default_account.tokens = account.tokens;
@@ -1259,11 +1320,10 @@ mod tests {
     #[test]
     fn test_account_one() {
         let paths = "one".to_string();
-        let accounts = AccountsDB::default();
-        accounts.add_storage(&paths);
+        let accounts = AccountsDB::new(0, &paths);
         let mut pubkeys: Vec<Pubkey> = vec![];
         create_account(&accounts, &mut pubkeys, 1, 0);
-        let account = accounts.load(0, &pubkeys[0]).unwrap();
+        let account = accounts.load(0, &pubkeys[0], true).unwrap();
         let mut default_account = Account::default();
         default_account.tokens = 1;
         assert_eq!(compare_account(&default_account, &account), true);
@@ -1273,13 +1333,12 @@ mod tests {
     #[test]
     fn test_account_many() {
         let paths = "many0,many1".to_string();
-        let accounts = AccountsDB::default();
-        accounts.add_storage(&paths);
+        let accounts = AccountsDB::new(0, &paths);
         let mut pubkeys: Vec<Pubkey> = vec![];
         create_account(&accounts, &mut pubkeys, 100, 0);
         for _ in 1..100 {
             let idx = thread_rng().gen_range(0, 99);
-            let account = accounts.load(0, &pubkeys[idx]).unwrap();
+            let account = accounts.load(0, &pubkeys[idx], true).unwrap();
             let mut default_account = Account::default();
             default_account.tokens = (idx + 1) as u64;
             assert_eq!(compare_account(&default_account, &account), true);
@@ -1290,8 +1349,7 @@ mod tests {
     #[test]
     fn test_account_update() {
         let paths = "update0".to_string();
-        let accounts = AccountsDB::default();
-        accounts.add_storage(&paths);
+        let accounts = AccountsDB::new(0, &paths);
         let mut pubkeys: Vec<Pubkey> = vec![];
         create_account(&accounts, &mut pubkeys, 100, 0);
         update_accounts(&accounts, pubkeys, 99);
@@ -1310,8 +1368,7 @@ mod tests {
     #[test]
     fn test_account_grow() {
         let paths = "grow0".to_string();
-        let accounts = AccountsDB::default();
-        accounts.add_storage(&paths);
+        let accounts = AccountsDB::new(0, &paths);
         let count = [0, 1];
         let status = [
             AccountStorageStatus::StorageAvailable,
@@ -1338,8 +1395,8 @@ mod tests {
             assert_eq!(stores[1].count.load(Ordering::Relaxed), 1);
             assert_eq!(stores[1].get_status(), status[0]);
         }
-        assert_eq!(accounts.load(0, &pubkey1).unwrap(), account1);
-        assert_eq!(accounts.load(0, &pubkey2).unwrap(), account2);
+        assert_eq!(accounts.load(0, &pubkey1, true).unwrap(), account1);
+        assert_eq!(accounts.load(0, &pubkey2, true).unwrap(), account2);
 
         for i in 0..25 {
             let index = i % 2;
@@ -1354,8 +1411,8 @@ mod tests {
                 assert_eq!(stores[2].count.load(Ordering::Relaxed), count[index ^ 1]);
                 assert_eq!(stores[2].get_status(), status[0]);
             }
-            assert_eq!(accounts.load(0, &pubkey1).unwrap(), account1);
-            assert_eq!(accounts.load(0, &pubkey2).unwrap(), account2);
+            assert_eq!(accounts.load(0, &pubkey1, true).unwrap(), account1);
+            assert_eq!(accounts.load(0, &pubkey2, true).unwrap(), account2);
         }
         cleanup_dirs(&paths);
     }
@@ -1363,8 +1420,7 @@ mod tests {
     #[test]
     fn test_account_vote() {
         let paths = "vote0".to_string();
-        let accounts = AccountsDB::default();
-        accounts.add_storage(&paths);
+        let accounts = AccountsDB::new(0, &paths);
         let mut pubkeys: Vec<Pubkey> = vec![];
         create_account(&accounts, &mut pubkeys, 100, 6);
         let accounts = accounts.get_vote_accounts(0);

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -1,3 +1,4 @@
+use crate::appendvec::AppendVec;
 use crate::bank::{BankError, Result};
 use crate::runtime::has_duplicates;
 use bincode::serialize;
@@ -9,9 +10,12 @@ use solana_sdk::hash::{hash, Hash};
 use solana_sdk::native_loader;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::transaction::Transaction;
+use solana_sdk::vote_program;
 use std::collections::BTreeMap;
-use std::ops::Deref;
-use std::sync::{Mutex, RwLock};
+use std::fs::{create_dir_all, remove_dir_all};
+use std::path::Path;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex, RwLock};
 
 pub type InstructionAccounts = Vec<Account>;
 pub type InstructionLoaders = Vec<Vec<(Pubkey, Account)>>;
@@ -30,84 +34,389 @@ pub struct ErrorCounters {
     pub missing_signature_for_fee: usize,
 }
 
-/// This structure handles the load/store of the accounts
+//
+// Persistent accounts are stored in below path location:
+//  <path>/<pid>/data/
+//
+// Each account is stored in below format:
+//  <length><account>
+//
+// The persistent store would allow for this mode of operation:
+//  - Concurrent single thread append with many concurrent readers.
+//  - Exclusive resize or truncate from the start.
+//
+// The underlying memory is memory mapped to a file. The accounts would be
+// stored across multiple files and the mappings of file and offset of a
+// particular account would be stored in a shared index. This will allow for
+// concurrent commits without blocking reads, which will sequentially write
+// to memory, ssd or disk, and should be as fast as the hardware allow for.
+// The only required in memory data structure with a write lock is the index,
+// which should be fast to update.
+//
+// To garbage collect, data can be re-appended to defragmnted and truncated from
+// the start. The AccountsDB data structure would allow for
+// - multiple readers
+// - multiple writers
+// - persistent backed memory
+//
+// To bootstrap the index from a persistent store of AppendVec's, the entries should
+// also include a "commit counter".  A single global atomic that tracks the number
+// of commits to the entire data store. So the latest commit for each fork entry
+// would be indexed. (TODO)
+
+const ACCOUNT_DATA_FILE_SIZE: u64 = 64 * 1024 * 1024;
+const ACCOUNT_DATA_FILE: &str = "data";
+const NUM_ACCOUNT_DIRS: usize = 4;
+
+/// An offset into the AccountsDB::storage vector
+type AppendVecId = usize;
+
+type Fork = u64;
+
+struct AccountMap(Vec<(Fork, (AppendVecId, u64))>);
+
+#[derive(Debug, PartialEq)]
+enum AccountStorageStatus {
+    StorageAvailable = 0,
+    StorageFull = 1,
+}
+
+impl From<usize> for AccountStorageStatus {
+    fn from(status: usize) -> Self {
+        use self::AccountStorageStatus::*;
+        match status {
+            0 => StorageAvailable,
+            1 => StorageFull,
+            _ => unreachable!(),
+        }
+    }
+}
+
+struct AccountIndexInfo {
+    /// For each Pubkey, the account for a specific fork is in a specific
+    /// AppendVec at a specific index
+    index: RwLock<HashMap<Pubkey, AccountMap>>,
+
+    /// Cached index to vote accounts for performance reasons to avoid having
+    /// to iterate through the entire accounts each time
+    vote_index: RwLock<HashSet<Pubkey>>,
+}
+
+/// Persistent storage structure holding the accounts
+struct AccountStorage {
+    /// storage holding the accounts
+    appendvec: Arc<RwLock<AppendVec<Account>>>,
+
+    /// Keeps track of the number of accounts stored in a specific AppendVec.
+    /// This is periodically checked to reuse the stores that do not have
+    /// any accounts in it.
+    count: AtomicUsize,
+
+    /// status corresponding to the storage
+    status: AtomicUsize,
+
+    /// Path to the persistent store
+    path: String,
+}
+
+impl AccountStorage {
+    pub fn set_status(&self, status: AccountStorageStatus) {
+        self.status.store(status as usize, Ordering::Relaxed);
+    }
+
+    pub fn get_status(&self) -> AccountStorageStatus {
+        self.status.load(Ordering::Relaxed).into()
+    }
+}
+
+// This structure handles the load/store of the accounts
 pub struct AccountsDB {
-    /// Mapping of known public keys/IDs to accounts
-    pub accounts: HashMap<Pubkey, Account>,
+    /// Keeps tracks of index into AppendVec on a per fork basis
+    index_info: AccountIndexInfo,
+
+    /// Account storage
+    storage: RwLock<Vec<AccountStorage>>,
+
+    /// distribute the accounts across storage lists
+    next_id: AtomicUsize,
 
     /// The number of transactions the bank has processed without error since the
     /// start of the ledger.
-    transaction_count: u64,
-}
-
-/// This structure handles synchronization for db
-pub struct Accounts {
-    pub accounts_db: RwLock<AccountsDB>,
-
-    /// set of accounts which are currently in the pipeline
-    account_locks: Mutex<HashSet<Pubkey>>,
+    transaction_count: RwLock<u64>,
 }
 
 impl Default for AccountsDB {
     fn default() -> Self {
-        Self {
-            accounts: HashMap::new(),
-            transaction_count: 0,
+        let index_info = AccountIndexInfo {
+            index: RwLock::new(HashMap::new()),
+            vote_index: RwLock::new(HashSet::new()),
+        };
+        AccountsDB {
+            index_info,
+            storage: RwLock::new(vec![]),
+            next_id: AtomicUsize::new(0),
+            transaction_count: RwLock::new(0),
         }
     }
 }
 
-impl Default for Accounts {
-    fn default() -> Self {
-        Self {
-            account_locks: Mutex::new(HashSet::new()),
-            accounts_db: RwLock::new(AccountsDB::default()),
-        }
+/// This structure handles synchronization for db
+pub struct Accounts {
+    pub accounts_db: AccountsDB,
+
+    /// set of accounts which are currently in the pipeline
+    account_locks: Mutex<HashSet<Pubkey>>,
+
+    /// List of persistent stores
+    paths: String,
+}
+
+impl Drop for Accounts {
+    fn drop(&mut self) {
+        let paths: Vec<String> = self.paths.split(',').map(|s| s.to_string()).collect();
+        paths.iter().for_each(|p| {
+            let _ignored = remove_dir_all(p);
+        })
     }
 }
 
 impl AccountsDB {
-    pub fn hash_internal_state(&self) -> Hash {
-        let mut ordered_accounts = BTreeMap::new();
-
-        // only hash internal state of the part being voted upon, i.e. since last
-        //  checkpoint
-        for (pubkey, account) in &self.accounts {
-            ordered_accounts.insert(*pubkey, account.clone());
-        }
-
-        hash(&serialize(&ordered_accounts).unwrap())
+    pub fn add_storage(&self, paths: &str) {
+        let paths: Vec<String> = paths.split(',').map(|s| s.to_string()).collect();
+        let mut stores: Vec<AccountStorage> = vec![];
+        paths.iter().for_each(|p| {
+            let path = format!("{}/{}", p, std::process::id());
+            let storage = AccountStorage {
+                appendvec: self.new_account_storage(&path),
+                status: AtomicUsize::new(AccountStorageStatus::StorageAvailable as usize),
+                count: AtomicUsize::new(0),
+                path: path.to_string(),
+            };
+            stores.push(storage);
+        });
+        let _ignored = stores[0].appendvec.write().unwrap().grow_file();
+        let mut storage = self.storage.write().unwrap();
+        storage.append(&mut stores);
     }
 
-    fn load<U>(checkpoints: &[U], pubkey: &Pubkey) -> Option<Account>
-    where
-        U: Deref<Target = Self>,
-    {
-        for db in checkpoints {
-            if let Some(account) = db.accounts.get(pubkey) {
-                return Some(account.clone());
+    fn new_account_storage(&self, p: &str) -> Arc<RwLock<AppendVec<Account>>> {
+        let id = self.next_id.fetch_add(1, Ordering::Relaxed);
+        let p = format!("{}/{}", p, id);
+        let path = Path::new(&p);
+        let _ignored = remove_dir_all(path);
+        create_dir_all(path).expect("Create directory failed");
+        Arc::new(RwLock::new(AppendVec::<Account>::new(
+            &path.join(ACCOUNT_DATA_FILE),
+            true,
+            ACCOUNT_DATA_FILE_SIZE,
+            0,
+        )))
+    }
+
+    pub fn get_vote_accounts(&self, fork: Fork) -> Vec<Account> {
+        let mut accounts: Vec<Account> = vec![];
+        self.index_info
+            .vote_index
+            .read()
+            .unwrap()
+            .iter()
+            .for_each(|p| {
+                if let Some(forks) = self.index_info.index.read().unwrap().get(p) {
+                    for (v_fork, (id, index)) in forks.0.iter() {
+                        if fork == *v_fork {
+                            accounts.push(
+                                self.storage.read().unwrap()[*id]
+                                    .appendvec
+                                    .read()
+                                    .unwrap()
+                                    .get_account(*index)
+                                    .unwrap(),
+                            );
+                        }
+                        if fork > *v_fork {
+                            break;
+                        }
+                    }
+                }
+            });
+        accounts
+    }
+
+    pub fn hash_internal_state(&self, fork: Fork) -> Option<Hash> {
+        let mut ordered_accounts = BTreeMap::new();
+        let rindex = self.index_info.index.read().unwrap();
+        rindex.iter().for_each(|(p, forks)| {
+            for (v_fork, (id, index)) in forks.0.iter() {
+                if fork == *v_fork {
+                    let account = self.storage.read().unwrap()[*id]
+                        .appendvec
+                        .read()
+                        .unwrap()
+                        .get_account(*index)
+                        .unwrap();
+                    ordered_accounts.insert(*p, account);
+                }
+                if fork > *v_fork {
+                    break;
+                }
+            }
+        });
+
+        if ordered_accounts.is_empty() {
+            return None;
+        }
+        Some(hash(&serialize(&ordered_accounts).unwrap()))
+    }
+
+    fn load(&self, fork: Fork, pubkey: &Pubkey) -> Option<Account> {
+        let index = self.index_info.index.read().unwrap();
+        if let Some(forks) = index.get(pubkey) {
+            // find most recent fork that is an ancestor of current_fork
+            for (v_fork, (id, offset)) in forks.0.iter() {
+                if *v_fork > fork {
+                    continue;
+                } else {
+                    let appendvec = &self.storage.read().unwrap()[*id].appendvec;
+                    let av = appendvec.read().unwrap();
+                    return Some(av.get_account(*offset).unwrap());
+                }
             }
         }
         None
     }
+
+    fn get_storage_id(&self, start: usize, current: usize) -> usize {
+        let mut id = current;
+        let len: usize;
+        {
+            let stores = self.storage.read().unwrap();
+            len = stores.len();
+            if id == std::usize::MAX {
+                id = start % len;
+                if stores[id].get_status() == AccountStorageStatus::StorageAvailable {
+                    return id;
+                }
+            } else {
+                stores[id].set_status(AccountStorageStatus::StorageFull);
+            }
+
+            loop {
+                id = (id + 1) % len;
+                if stores[id].get_status() == AccountStorageStatus::StorageAvailable {
+                    break;
+                }
+                if id == start % len {
+                    break;
+                }
+            }
+        }
+        if id == start % len {
+            let mut stores = self.storage.write().unwrap();
+            // check if new store was already created
+            if stores.len() == len {
+                let storage = AccountStorage {
+                    appendvec: self.new_account_storage(&stores[id].path),
+                    count: AtomicUsize::new(0),
+                    status: AtomicUsize::new(AccountStorageStatus::StorageAvailable as usize),
+                    path: stores[id].path.clone(),
+                };
+                stores.push(storage);
+            }
+            id = stores.len() - 1;
+        }
+        id
+    }
+
+    fn append_account(&self, account: &Account) -> (usize, u64) {
+        let offset: u64;
+        let start = self.next_id.fetch_add(1, Ordering::Relaxed);
+        let mut id = self.get_storage_id(start, std::usize::MAX);
+        let mut acc = &Account::default();
+        loop {
+            let result: Option<u64>;
+            {
+                if account.tokens != 0 {
+                    acc = account;
+                }
+                let av = &self.storage.read().unwrap()[id].appendvec;
+                result = av.read().unwrap().append_account(&acc);
+            }
+            if let Some(val) = result {
+                offset = val;
+                break;
+            } else {
+                id = self.get_storage_id(start, id);
+            }
+        }
+        (id, offset)
+    }
+
     /// Store the account update.  If the update is to delete the account because the token balance
     /// is 0, purge needs to be set to true for the delete to occur in place.
-    pub fn store(&mut self, purge: bool, pubkey: &Pubkey, account: &Account) {
-        if account.tokens == 0 {
-            if purge {
-                // purge if balance is 0 and no checkpoints
-                self.accounts.remove(pubkey);
-            } else {
-                // store default account if balance is 0 and there's a checkpoint
-                self.accounts.insert(pubkey.clone(), Account::default());
+    pub fn store(&self, fork: Fork, purge: bool, pubkey: &Pubkey, account: &Account) {
+        if account.tokens == 0 && purge {
+            // purge if balance is 0 and no checkpoints
+            let mut index = self.index_info.index.write().unwrap();
+            if let Some(forks) = index.remove(pubkey) {
+                let stores = self.storage.read().unwrap();
+                for (_, (id, _)) in forks.0.iter() {
+                    stores[*id].count.fetch_sub(1, Ordering::Relaxed);
+                }
+            }
+            if vote_program::check_id(&account.owner) {
+                self.index_info.vote_index.write().unwrap().remove(pubkey);
             }
         } else {
-            self.accounts.insert(pubkey.clone(), account.clone());
+            let (id, offset) = self.append_account(&account);
+
+            if vote_program::check_id(&account.owner) {
+                let mut index = self.index_info.vote_index.write().unwrap();
+                if account.tokens == 0 {
+                    index.remove(pubkey);
+                } else {
+                    index.insert(*pubkey);
+                }
+            }
+
+            let mut result: Option<usize> = None;
+            {
+                let mut insert: Option<usize> = None;
+                let mut windex = self.index_info.index.write().unwrap();
+                let forks = windex.entry(*pubkey).or_insert(AccountMap(vec![]));
+                for (i, (v_fork, (v_id, _))) in forks.0.iter().enumerate() {
+                    if *v_fork > fork {
+                        continue;
+                    }
+                    if *v_fork == fork {
+                        result = Some(*v_id);
+                        forks.0[i] = (fork, (id, offset));
+                        break;
+                    }
+                    insert = Some(i);
+                    break;
+                }
+                if result.is_none() {
+                    if let Some(index) = insert {
+                        forks.0.insert(index, (fork, (id, offset)));
+                    } else {
+                        forks.0.push((fork, (id, offset)));
+                    }
+                }
+            }
+            let stores = self.storage.read().unwrap();
+            stores[id].count.fetch_add(1, Ordering::Relaxed);
+            if let Some(old_id) = result {
+                if stores[old_id].count.fetch_sub(1, Ordering::Relaxed) == 1 {
+                    stores[old_id].appendvec.write().unwrap().reset();
+                    stores[old_id].set_status(AccountStorageStatus::StorageAvailable);
+                }
+            }
         }
     }
 
     pub fn store_accounts(
-        &mut self,
+        &self,
+        fork: Fork,
         purge: bool,
         txs: &[Transaction],
         res: &[Result<()>],
@@ -121,18 +430,17 @@ impl AccountsDB {
             let tx = &txs[i];
             let acc = raccs.as_ref().unwrap();
             for (key, account) in tx.account_keys.iter().zip(acc.0.iter()) {
-                self.store(purge, key, account);
+                self.store(fork, purge, key, account);
             }
         }
     }
-    fn load_tx_accounts<U>(
-        checkpoints: &[U],
+
+    fn load_tx_accounts(
+        &self,
+        fork: Fork,
         tx: &Transaction,
         error_counters: &mut ErrorCounters,
-    ) -> Result<Vec<Account>>
-    where
-        U: Deref<Target = Self>,
-    {
+    ) -> Result<Vec<Account>> {
         // Copy all the accounts
         if tx.signatures.is_empty() && tx.fee != 0 {
             Err(BankError::MissingSignatureForFee)
@@ -147,7 +455,7 @@ impl AccountsDB {
             // If a fee can pay for execution then the program will be scheduled
             let mut called_accounts: Vec<Account> = vec![];
             for key in &tx.account_keys {
-                called_accounts.push(Self::load(checkpoints, key).unwrap_or_default());
+                called_accounts.push(self.load(fork, key).unwrap_or_default());
             }
             if called_accounts.is_empty() || called_accounts[0].tokens == 0 {
                 error_counters.account_not_found += 1;
@@ -162,14 +470,12 @@ impl AccountsDB {
         }
     }
 
-    fn load_executable_accounts<U>(
-        checkpoints: &[U],
+    fn load_executable_accounts(
+        &self,
+        fork: Fork,
         mut program_id: Pubkey,
         error_counters: &mut ErrorCounters,
-    ) -> Result<Vec<(Pubkey, Account)>>
-    where
-        U: Deref<Target = Self>,
-    {
+    ) -> Result<Vec<(Pubkey, Account)>> {
         let mut accounts = Vec::new();
         let mut depth = 0;
         loop {
@@ -184,7 +490,7 @@ impl AccountsDB {
             }
             depth += 1;
 
-            let program = match Self::load(checkpoints, &program_id) {
+            let program = match self.load(fork, &program_id) {
                 Some(program) => program,
                 None => {
                     error_counters.account_not_found += 1;
@@ -205,14 +511,12 @@ impl AccountsDB {
     }
 
     /// For each program_id in the transaction, load its loaders.
-    fn load_loaders<U>(
-        checkpoints: &[U],
+    fn load_loaders(
+        &self,
+        fork: Fork,
         tx: &Transaction,
         error_counters: &mut ErrorCounters,
-    ) -> Result<Vec<Vec<(Pubkey, Account)>>>
-    where
-        U: Deref<Target = Self>,
-    {
+    ) -> Result<Vec<Vec<(Pubkey, Account)>>> {
         tx.instructions
             .iter()
             .map(|ix| {
@@ -221,26 +525,24 @@ impl AccountsDB {
                     return Err(BankError::AccountNotFound);
                 }
                 let program_id = tx.program_ids[ix.program_ids_index as usize];
-                Self::load_executable_accounts(checkpoints, program_id, error_counters)
+                self.load_executable_accounts(fork, program_id, error_counters)
             })
             .collect()
     }
 
-    fn load_accounts<U>(
-        checkpoints: &[U],
+    fn load_accounts(
+        &self,
+        fork: Fork,
         txs: &[Transaction],
         lock_results: Vec<Result<()>>,
         error_counters: &mut ErrorCounters,
-    ) -> Vec<Result<(InstructionAccounts, InstructionLoaders)>>
-    where
-        U: Deref<Target = Self>,
-    {
+    ) -> Vec<Result<(InstructionAccounts, InstructionLoaders)>> {
         txs.iter()
             .zip(lock_results.into_iter())
             .map(|etx| match etx {
                 (tx, Ok(())) => {
-                    let accounts = Self::load_tx_accounts(checkpoints, tx, error_counters)?;
-                    let loaders = Self::load_loaders(checkpoints, tx, error_counters)?;
+                    let accounts = self.load_tx_accounts(fork, tx, error_counters)?;
+                    let loaders = self.load_loaders(fork, tx, error_counters)?;
                     Ok((accounts, loaders))
                 }
                 (_, Err(e)) => Err(e),
@@ -248,19 +550,22 @@ impl AccountsDB {
             .collect()
     }
 
-    pub fn increment_transaction_count(&mut self, tx_count: usize) {
-        self.transaction_count += tx_count as u64
+    pub fn increment_transaction_count(&self, tx_count: usize) {
+        let mut tx = self.transaction_count.write().unwrap();
+        *tx += tx_count as u64;
     }
 
     pub fn transaction_count(&self) -> u64 {
-        self.transaction_count
+        let tx = self.transaction_count.read().unwrap();
+        *tx
     }
 
     /// become the root accountsDB
     fn squash<U>(&mut self, parents: &[U])
     where
-        U: Deref<Target = Self>,
+        U: std::ops::Deref<Target = Self>,
     {
+        /*
         self.transaction_count += parents
             .iter()
             .fold(0, |sum, parent| sum + parent.transaction_count);
@@ -277,29 +582,44 @@ impl AccountsDB {
 
         // toss any zero-balance accounts, since self is root now
         self.accounts.retain(|_, account| account.tokens != 0);
+        */
     }
 }
 
 impl Accounts {
-    /// Slow because lock is held for 1 operation insted of many
-    pub fn load_slow<U>(checkpoints: &[U], pubkey: &Pubkey) -> Option<Account>
-    where
-        U: Deref<Target = Self>,
-    {
-        let dbs: Vec<_> = checkpoints
-            .iter()
-            .map(|obj| obj.accounts_db.read().unwrap())
-            .collect();
-        AccountsDB::load(&dbs, pubkey)
+    pub fn new(in_paths: &str) -> Self {
+        static ACCOUNT_DIR: AtomicUsize = AtomicUsize::new(0);
+        let paths = if !in_paths.is_empty() {
+            in_paths.to_string()
+        } else {
+            let mut dir: usize;
+            dir = ACCOUNT_DIR.fetch_add(1, Ordering::Relaxed);
+            let mut paths = dir.to_string();
+            for _ in 1..NUM_ACCOUNT_DIRS {
+                dir = ACCOUNT_DIR.fetch_add(1, Ordering::Relaxed);
+                paths = format!("{},{}", paths, dir.to_string());
+            }
+            paths
+        };
+        let accounts_db = AccountsDB::default();
+        accounts_db.add_storage(&paths);
+        Accounts {
+            accounts_db,
+            account_locks: Mutex::new(HashSet::new()),
+            paths,
+        }
     }
+
+    /// Slow because lock is held for 1 operation insted of many
+    pub fn load_slow(&self, fork: Fork, pubkey: &Pubkey) -> Option<Account> {
+        self.accounts_db.load(fork, pubkey)
+    }
+
     /// Slow because lock is held for 1 operation insted of many
     /// * purge - if the account token value is 0 and purge is true then delete the account.
     /// purge should be set to false for overlays, and true for the root checkpoint.
-    pub fn store_slow(&self, purge: bool, pubkey: &Pubkey, account: &Account) {
-        self.accounts_db
-            .write()
-            .unwrap()
-            .store(purge, pubkey, account)
+    pub fn store_slow(&self, fork: Fork, purge: bool, pubkey: &Pubkey, account: &Account) {
+        self.accounts_db.store(fork, purge, pubkey, account)
     }
 
     fn lock_account(
@@ -331,8 +651,8 @@ impl Accounts {
         }
     }
 
-    pub fn hash_internal_state(&self) -> Hash {
-        self.accounts_db.read().unwrap().hash_internal_state()
+    pub fn hash_internal_state(&self, fork: Fork) -> Option<Hash> {
+        self.accounts_db.hash_internal_state(fork)
     }
 
     /// This function will prevent multiple threads from modifying the same account state at the
@@ -363,20 +683,15 @@ impl Accounts {
             .for_each(|(tx, result)| Self::unlock_account(tx, result, &mut account_locks));
     }
 
-    pub fn load_accounts<U>(
-        checkpoints: &[U],
+    pub fn load_accounts(
+        &self,
+        fork: Fork,
         txs: &[Transaction],
         results: Vec<Result<()>>,
         error_counters: &mut ErrorCounters,
-    ) -> Vec<Result<(InstructionAccounts, InstructionLoaders)>>
-    where
-        U: Deref<Target = Self>,
-    {
-        let dbs: Vec<_> = checkpoints
-            .iter()
-            .map(|obj| obj.accounts_db.read().unwrap())
-            .collect();
-        AccountsDB::load_accounts(&dbs, txs, results, error_counters)
+    ) -> Vec<Result<(InstructionAccounts, InstructionLoaders)>> {
+        self.accounts_db
+            .load_accounts(fork, txs, results, error_counters)
     }
 
     /// Store the accounts into the DB
@@ -384,42 +699,44 @@ impl Accounts {
     /// purge should be set to false for overlays, and true for the root checkpoint.
     pub fn store_accounts(
         &self,
+        fork: Fork,
         purge: bool,
         txs: &[Transaction],
         res: &[Result<()>],
         loaded: &[Result<(InstructionAccounts, InstructionLoaders)>],
     ) {
         self.accounts_db
-            .write()
-            .unwrap()
-            .store_accounts(purge, txs, res, loaded)
+            .store_accounts(fork, purge, txs, res, loaded)
     }
 
     pub fn increment_transaction_count(&self, tx_count: usize) {
-        self.accounts_db
-            .write()
-            .unwrap()
-            .increment_transaction_count(tx_count)
+        self.accounts_db.increment_transaction_count(tx_count)
     }
 
     pub fn transaction_count(&self) -> u64 {
-        self.accounts_db.read().unwrap().transaction_count()
+        self.accounts_db.transaction_count()
     }
 
     /// accounts starts with an empty data structure for every child/fork
     ///   this function squashes all the parents into this instance
     pub fn squash<U>(&self, parents: &[U])
     where
-        U: Deref<Target = Self>,
+        U: std::ops::Deref<Target = Self>,
     {
         assert!(self.account_locks.lock().unwrap().is_empty());
 
+        /*
         let dbs: Vec<_> = parents
             .iter()
             .map(|obj| obj.accounts_db.read().unwrap())
             .collect();
 
         self.accounts_db.write().unwrap().squash(&dbs);
+        */
+    }
+
+    pub fn has_accounts(&self, fork: Fork) -> bool {
+        false
     }
 }
 
@@ -428,6 +745,7 @@ mod tests {
     // TODO: all the bank tests are bank specific, issue: 2194
 
     use super::*;
+    use rand::{thread_rng, Rng};
     use solana_sdk::account::Account;
     use solana_sdk::hash::Hash;
     use solana_sdk::signature::Keypair;
@@ -437,15 +755,18 @@ mod tests {
 
     #[test]
     fn test_purge() {
-        let mut db = AccountsDB::default();
+        let paths = "purge".to_string();
+        let db = AccountsDB::default();
+        db.add_storage(&paths);
         let key = Pubkey::default();
         let account = Account::new(0, 0, Pubkey::default());
         // accounts are deleted when their token value is 0 and purge is true
-        db.store(false, &key, &account);
-        assert_eq!(AccountsDB::load(&[&db], &key), Some(account.clone()));
+        db.store(0, false, &key, &account);
+        assert_eq!(db.load(0, &key), Some(account.clone()));
         // purge should be set to true for the root checkpoint
-        db.store(true, &key, &account);
-        assert_eq!(AccountsDB::load(&[&db], &key), None);
+        db.store(0, true, &key, &account);
+        assert_eq!(db.load(0, &key), None);
+        cleanup_dirs(&paths);
     }
 
     fn load_accounts(
@@ -453,12 +774,13 @@ mod tests {
         ka: &Vec<(Pubkey, Account)>,
         error_counters: &mut ErrorCounters,
     ) -> Vec<Result<(InstructionAccounts, InstructionLoaders)>> {
-        let accounts = Accounts::default();
+        let accounts = Accounts::new("");
         for ka in ka.iter() {
-            accounts.store_slow(true, &ka.0, &ka.1);
+            accounts.store_slow(0, true, &ka.0, &ka.1);
         }
 
-        Accounts::load_accounts(&[&accounts], &[tx], vec![Ok(())], error_counters)
+        let res = accounts.load_accounts(0, &[tx], vec![Ok(())], error_counters);
+        res
     }
 
     #[test]
@@ -833,21 +1155,195 @@ mod tests {
 
     #[test]
     fn test_accounts_squash() {
-        let mut db0 = AccountsDB::default();
+        let db0 = AccountsDB::default();
         let key = Pubkey::default();
         let account = Account::new(1, 0, key);
 
         // store value 1 in the "root", i.e. db zero
-        db0.store(true, &key, &account);
+        db0.store(0, true, &key, &account);
 
         // store value 0 in the child, but don't purge (see purge test above)
         let mut db1 = AccountsDB::default();
-        db1.store(false, &key, &Account::new(0, 0, key));
+        db1.store(0, false, &key, &Account::new(0, 0, key));
 
         // squash, which should whack key's account
         db1.squash(&[&db0]);
 
-        assert_eq!(AccountsDB::load(&[&db1], &key), None);
+        assert_eq!(db1.load(0, &key), None);
     }
 
+    fn create_account(
+        accounts: &AccountsDB,
+        pubkeys: &mut Vec<Pubkey>,
+        num: usize,
+        num_vote: usize,
+    ) {
+        let mut nvote = num_vote;
+        for t in 0..num {
+            let pubkey = Keypair::new().pubkey();
+            let mut default_account = Account::default();
+            pubkeys.push(pubkey.clone());
+            default_account.tokens = (t + 1) as u64;
+            if nvote > 0 && (t + 1) % nvote == 0 {
+                default_account.owner = vote_program::id();
+                nvote -= 1;
+            }
+            assert!(accounts.load(0, &pubkey).is_none());
+            accounts.store(0, true, &pubkey, &default_account);
+        }
+    }
+
+    fn update_accounts(accounts: &AccountsDB, pubkeys: Vec<Pubkey>, range: usize) {
+        for _ in 1..1000 {
+            let idx = thread_rng().gen_range(0, range);
+            if let Some(mut account) = accounts.load(0, &pubkeys[idx]) {
+                account.tokens = account.tokens + 1;
+                accounts.store(0, true, &pubkeys[idx], &account);
+                if account.tokens == 0 {
+                    assert!(accounts.load(0, &pubkeys[idx]).is_none());
+                } else {
+                    let mut default_account = Account::default();
+                    default_account.tokens = account.tokens;
+                    assert_eq!(compare_account(&default_account, &account), true);
+                }
+            }
+        }
+    }
+
+    fn compare_account(account1: &Account, account2: &Account) -> bool {
+        if account1.userdata != account2.userdata
+            || account1.owner != account2.owner
+            || account1.executable != account2.executable
+            || account1.tokens != account2.tokens
+        {
+            return false;
+        }
+        true
+    }
+
+    fn cleanup_dirs(paths: &str) {
+        let paths: Vec<String> = paths.split(',').map(|s| s.to_string()).collect();
+        paths.iter().for_each(|p| {
+            let _ignored = remove_dir_all(p);
+        })
+    }
+
+    #[test]
+    fn test_account_one() {
+        let paths = "one".to_string();
+        let accounts = AccountsDB::default();
+        accounts.add_storage(&paths);
+        let mut pubkeys: Vec<Pubkey> = vec![];
+        create_account(&accounts, &mut pubkeys, 1, 0);
+        let account = accounts.load(0, &pubkeys[0]).unwrap();
+        let mut default_account = Account::default();
+        default_account.tokens = 1;
+        assert_eq!(compare_account(&default_account, &account), true);
+        cleanup_dirs(&paths);
+    }
+
+    #[test]
+    fn test_account_many() {
+        let paths = "many0,many1".to_string();
+        let accounts = AccountsDB::default();
+        accounts.add_storage(&paths);
+        let mut pubkeys: Vec<Pubkey> = vec![];
+        create_account(&accounts, &mut pubkeys, 100, 0);
+        for _ in 1..100 {
+            let idx = thread_rng().gen_range(0, 99);
+            let account = accounts.load(0, &pubkeys[idx]).unwrap();
+            let mut default_account = Account::default();
+            default_account.tokens = (idx + 1) as u64;
+            assert_eq!(compare_account(&default_account, &account), true);
+        }
+        cleanup_dirs(&paths);
+    }
+
+    #[test]
+    fn test_account_update() {
+        let paths = "update0".to_string();
+        let accounts = AccountsDB::default();
+        accounts.add_storage(&paths);
+        let mut pubkeys: Vec<Pubkey> = vec![];
+        create_account(&accounts, &mut pubkeys, 100, 0);
+        update_accounts(&accounts, pubkeys, 99);
+        {
+            let stores = accounts.storage.read().unwrap();
+            assert_eq!(stores.len(), 1);
+            assert_eq!(stores[0].count.load(Ordering::Relaxed), 100);
+            assert_eq!(
+                stores[0].get_status(),
+                AccountStorageStatus::StorageAvailable
+            );
+        }
+        cleanup_dirs(&paths);
+    }
+
+    #[test]
+    fn test_account_grow() {
+        let paths = "grow0".to_string();
+        let accounts = AccountsDB::default();
+        accounts.add_storage(&paths);
+        let count = [0, 1];
+        let status = [
+            AccountStorageStatus::StorageAvailable,
+            AccountStorageStatus::StorageFull,
+        ];
+        let pubkey1 = Keypair::new().pubkey();
+        let account1 = Account::new(1, ACCOUNT_DATA_FILE_SIZE as usize / 2, pubkey1);
+        accounts.store(0, true, &pubkey1, &account1);
+        {
+            let stores = accounts.storage.read().unwrap();
+            assert_eq!(stores.len(), 1);
+            assert_eq!(stores[0].count.load(Ordering::Relaxed), 1);
+            assert_eq!(stores[0].get_status(), status[0]);
+        }
+
+        let pubkey2 = Keypair::new().pubkey();
+        let account2 = Account::new(1, ACCOUNT_DATA_FILE_SIZE as usize / 2, pubkey2);
+        accounts.store(0, true, &pubkey2, &account2);
+        {
+            let stores = accounts.storage.read().unwrap();
+            assert_eq!(stores.len(), 2);
+            assert_eq!(stores[0].count.load(Ordering::Relaxed), 1);
+            assert_eq!(stores[0].get_status(), status[1]);
+            assert_eq!(stores[1].count.load(Ordering::Relaxed), 1);
+            assert_eq!(stores[1].get_status(), status[0]);
+        }
+        assert_eq!(accounts.load(0, &pubkey1).unwrap(), account1);
+        assert_eq!(accounts.load(0, &pubkey2).unwrap(), account2);
+
+        for i in 0..25 {
+            let index = i % 2;
+            accounts.store(0, true, &pubkey1, &account1);
+            {
+                let stores = accounts.storage.read().unwrap();
+                assert_eq!(stores.len(), 3);
+                assert_eq!(stores[0].count.load(Ordering::Relaxed), count[index]);
+                assert_eq!(stores[0].get_status(), status[0]);
+                assert_eq!(stores[1].count.load(Ordering::Relaxed), 1);
+                assert_eq!(stores[1].get_status(), status[1]);
+                assert_eq!(stores[2].count.load(Ordering::Relaxed), count[index ^ 1]);
+                assert_eq!(stores[2].get_status(), status[0]);
+            }
+            assert_eq!(accounts.load(0, &pubkey1).unwrap(), account1);
+            assert_eq!(accounts.load(0, &pubkey2).unwrap(), account2);
+        }
+        cleanup_dirs(&paths);
+    }
+
+    #[test]
+    fn test_account_vote() {
+        let paths = "vote0".to_string();
+        let accounts = AccountsDB::default();
+        accounts.add_storage(&paths);
+        let mut pubkeys: Vec<Pubkey> = vec![];
+        create_account(&accounts, &mut pubkeys, 100, 6);
+        let accounts = accounts.get_vote_accounts(0);
+        assert_eq!(accounts.len(), 6);
+        accounts.iter().for_each(|account| {
+            assert_eq!(account.owner, vote_program::id());
+        });
+        cleanup_dirs(&paths);
+    }
 }

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -254,17 +254,19 @@ impl AccountsDB {
             .unwrap()
             .iter()
             .for_each(|p| {
-                if let Some(entry) = self.index_info.index.read().unwrap().get(p) {
-                    let forks = entry.0.read().unwrap();
-                    if let Some((id, index)) = forks.get(&fork) {
-                        accounts.push(
-                            self.storage.read().unwrap()[*id]
-                                .appendvec
-                                .read()
-                                .unwrap()
-                                .get_account(*index)
-                                .unwrap(),
-                        );
+                if let Some(map) = self.index_info.index.read().unwrap().get(p) {
+                    let forks = map.0.read().unwrap();
+                    if let Some((id, offset)) = forks.get(&fork) {
+                        accounts.push(self.get_account(*id, *offset));
+                    } else {
+                        let fork_info = self.fork_info.read().unwrap();
+                        if let Some(info) = fork_info.get(&fork) {
+                            for parent_fork in info.parents.iter() {
+                                if let Some((id, offset)) = forks.get(&parent_fork) {
+                                    accounts.push(self.get_account(*id, *offset));
+                                }
+                            }
+                        }
                     }
                 }
             });
@@ -305,10 +307,10 @@ impl AccountsDB {
         Some(hash(&serialize(&ordered_accounts).unwrap()))
     }
 
-    fn get_account(&self, id: AppendVecId, offset: u64) -> Option<Account> {
+    fn get_account(&self, id: AppendVecId, offset: u64) -> Account {
         let appendvec = &self.storage.read().unwrap()[id].appendvec;
         let av = appendvec.read().unwrap();
-        Some(av.get_account(offset).unwrap())
+        av.get_account(offset).unwrap()
     }
 
     fn load(&self, fork: Fork, pubkey: &Pubkey, walk_back: bool) -> Option<Account> {
@@ -317,7 +319,7 @@ impl AccountsDB {
             let forks = map.0.read().unwrap();
             // find most recent fork that is an ancestor of current_fork
             if let Some((id, offset)) = forks.get(&fork) {
-                return self.get_account(*id, *offset);
+                return Some(self.get_account(*id, *offset));
             } else {
                 if !walk_back {
                     return None;
@@ -326,7 +328,7 @@ impl AccountsDB {
                 if let Some(info) = fork_info.get(&fork) {
                     for parent_fork in info.parents.iter() {
                         if let Some((id, offset)) = forks.get(&parent_fork) {
-                            return self.get_account(*id, *offset);
+                            return Some(self.get_account(*id, *offset));
                         }
                     }
                 }
@@ -689,7 +691,7 @@ impl AccountsDB {
                             keys.push(pubkey.clone());
                         }
                     }
-                    let account = self.get_account(id, offset).unwrap();
+                    let account = self.get_account(id, offset);
                     if account.tokens == 0 {
                         if self.remove_account_entries(&[fork], &map) {
                             keys.push(pubkey.clone());
@@ -737,11 +739,11 @@ impl Accounts {
         paths
     }
 
-    pub fn new(fork: Fork, in_paths: &str) -> Self {
-        let paths = if !in_paths.is_empty() {
-            in_paths.to_string()
-        } else {
+    pub fn new(fork: Fork, in_paths: Option<String>) -> Self {
+        let paths = if in_paths.is_none() {
             Self::make_default_paths()
+        } else {
+            in_paths.unwrap()
         };
         let accounts_db = AccountsDB::new(fork, &paths);
         accounts_db.add_fork(fork, None);
@@ -932,7 +934,7 @@ mod tests {
         ka: &Vec<(Pubkey, Account)>,
         error_counters: &mut ErrorCounters,
     ) -> Vec<Result<(InstructionAccounts, InstructionLoaders)>> {
-        let accounts = Accounts::new(0, "");
+        let accounts = Accounts::new(0, None);
         for ka in ka.iter() {
             accounts.store_slow(0, true, &ka.0, &ka.1);
         }

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -13,7 +13,8 @@ use solana_sdk::signature::{Keypair, KeypairUtil};
 use solana_sdk::transaction::Transaction;
 use solana_sdk::vote_program;
 use std::collections::BTreeMap;
-use std::fs::{create_dir_all, read_dir, remove_dir_all};
+use std::env;
+use std::fs::{create_dir_all, remove_dir_all};
 use std::path::Path;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex, RwLock};
@@ -167,16 +168,20 @@ pub struct Accounts {
     paths: String,
 }
 
+fn get_paths_vec(paths: &str) -> Vec<String> {
+    paths.split(',').map(|s| s.to_string()).collect()
+}
+
+fn cleanup_dirs(paths: &str) {
+    let paths = get_paths_vec(&paths);
+    paths.iter().for_each(|p| {
+        let _ignored = remove_dir_all(p);
+    })
+}
+
 impl Drop for Accounts {
     fn drop(&mut self) {
-        let paths: Vec<String> = self.paths.split(',').map(|s| s.to_string()).collect();
-        paths.iter().for_each(|p| {
-            let _ignored = remove_dir_all(p);
-        });
-        let entry = read_dir(ACCOUNTSDB_DIR);
-        if entry.is_ok() && entry.unwrap().count() == 0 {
-            let _ignored = remove_dir_all(ACCOUNTSDB_DIR);
-        }
+        cleanup_dirs(&self.paths);
     }
 }
 
@@ -210,16 +215,14 @@ impl AccountsDB {
     }
 
     fn add_storage(&self, paths: &str) {
-        let paths: Vec<String> = paths.split(',').map(|s| s.to_string()).collect();
+        let paths = get_paths_vec(&paths);
         let mut stores: Vec<AccountStorage> = vec![];
         paths.iter().for_each(|p| {
-            let keypair = Keypair::new();
-            let path = format!("{}/{}", p, keypair.pubkey());
             let storage = AccountStorage {
-                appendvec: self.new_account_storage(&path),
+                appendvec: self.new_account_storage(&p),
                 status: AtomicUsize::new(AccountStorageStatus::StorageAvailable as usize),
                 count: AtomicUsize::new(0),
-                path: path.to_string(),
+                path: p.to_string(),
             };
             stores.push(storage);
         });
@@ -652,7 +655,15 @@ impl Accounts {
     fn make_new_dir() -> String {
         static ACCOUNT_DIR: AtomicUsize = AtomicUsize::new(0);
         let dir = ACCOUNT_DIR.fetch_add(1, Ordering::Relaxed);
-        format!("{}/{}", ACCOUNTSDB_DIR, dir.to_string())
+        let out_dir = env::var("OUT_DIR").unwrap_or_else(|_| "target".to_string());
+        let keypair = Keypair::new();
+        format!(
+            "{}/{}/{}/{}",
+            out_dir,
+            ACCOUNTSDB_DIR,
+            keypair.pubkey(),
+            dir.to_string()
+        )
     }
 
     fn make_default_paths() -> String {
@@ -1308,13 +1319,6 @@ mod tests {
             return false;
         }
         true
-    }
-
-    fn cleanup_dirs(paths: &str) {
-        let paths: Vec<String> = paths.split(',').map(|s| s.to_string()).collect();
-        paths.iter().for_each(|p| {
-            let _ignored = remove_dir_all(p);
-        })
     }
 
     #[test]

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -143,7 +143,7 @@ pub struct AccountsDB {
 
     /// The number of transactions the bank has processed without error since the
     /// start of the ledger.
-    transaction_count: RwLock<u64>,
+    transaction_count: RwLock<HashMap<u64, u64>>,
 }
 
 impl Default for AccountsDB {
@@ -156,7 +156,7 @@ impl Default for AccountsDB {
             index_info,
             storage: RwLock::new(vec![]),
             next_id: AtomicUsize::new(0),
-            transaction_count: RwLock::new(0),
+            transaction_count: RwLock::new(HashMap::new()),
         }
     }
 }
@@ -566,14 +566,19 @@ impl AccountsDB {
             .collect()
     }
 
-    pub fn increment_transaction_count(&self, tx_count: usize) {
+    pub fn increment_transaction_count(&self, fork: Fork, tx_count: usize) {
         let mut tx = self.transaction_count.write().unwrap();
-        *tx += tx_count as u64;
+        let entry = tx.entry(fork).or_insert(0);
+        *entry += tx_count as u64;
     }
 
-    pub fn transaction_count(&self) -> u64 {
+    pub fn transaction_count(&self, fork: Fork) -> u64 {
         let tx = self.transaction_count.read().unwrap();
-        *tx
+        if let Some(entry) = tx.get(&fork) {
+            *entry
+        } else {
+            0
+        }
     }
 
     /// become the root accountsDB
@@ -736,12 +741,12 @@ impl Accounts {
             .store_accounts(fork, purge, txs, res, loaded)
     }
 
-    pub fn increment_transaction_count(&self, tx_count: usize) {
-        self.accounts_db.increment_transaction_count(tx_count)
+    pub fn increment_transaction_count(&self, fork: Fork, tx_count: usize) {
+        self.accounts_db.increment_transaction_count(fork, tx_count)
     }
 
-    pub fn transaction_count(&self) -> u64 {
-        self.accounts_db.transaction_count()
+    pub fn transaction_count(&self, fork: Fork) -> u64 {
+        self.accounts_db.transaction_count(fork)
     }
 
     /// accounts starts with an empty data structure for every child/fork

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -1,4 +1,5 @@
 use crate::appendvec::AppendVec;
+use solana_sdk::signature::{Keypair, KeypairUtil};
 use crate::bank::{BankError, Result};
 use crate::runtime::has_duplicates;
 use bincode::serialize;
@@ -66,7 +67,7 @@ pub struct ErrorCounters {
 
 const ACCOUNT_DATA_FILE_SIZE: u64 = 64 * 1024 * 1024;
 const ACCOUNT_DATA_FILE: &str = "data";
-const NUM_ACCOUNT_DIRS: usize = 4;
+const NUM_ACCOUNT_DIRS: usize = 1;
 
 /// An offset into the AccountsDB::storage vector
 type AppendVecId = usize;
@@ -185,7 +186,8 @@ impl AccountsDB {
         let paths: Vec<String> = paths.split(',').map(|s| s.to_string()).collect();
         let mut stores: Vec<AccountStorage> = vec![];
         paths.iter().for_each(|p| {
-            let path = format!("{}/{}", p, std::process::id());
+            let keypair = Keypair::new();
+            let path = format!("{}/{}", p, keypair.pubkey());
             let storage = AccountStorage {
                 appendvec: self.new_account_storage(&path),
                 status: AtomicUsize::new(AccountStorageStatus::StorageAvailable as usize),
@@ -240,6 +242,19 @@ impl AccountsDB {
                 }
             });
         accounts
+    }
+
+    pub fn has_accounts(&self, fork: Fork) -> bool {
+        let index = self.index_info.index.read().unwrap();
+
+        for account_map in index.values() {
+            for (v_fork, _) in account_map.0.iter() {
+                if fork == *v_fork {
+                    return true;
+                }
+            }
+        }
+        false
     }
 
     pub fn hash_internal_state(&self, fork: Fork) -> Option<Hash> {
@@ -414,6 +429,7 @@ impl AccountsDB {
         }
     }
 
+
     pub fn store_accounts(
         &self,
         fork: Fork,
@@ -587,19 +603,26 @@ impl AccountsDB {
 }
 
 impl Accounts {
-    pub fn new(in_paths: &str) -> Self {
+    fn make_new_dir() -> String {
         static ACCOUNT_DIR: AtomicUsize = AtomicUsize::new(0);
+        let dir = ACCOUNT_DIR.fetch_add(1, Ordering::Relaxed);
+        format!("accountsdb/{}", dir.to_string())
+    }
+
+    fn make_default_paths() -> String {
+        let mut paths = Self::make_new_dir();
+        for _ in 1..NUM_ACCOUNT_DIRS {
+            paths.push_str(",");
+            paths.push_str(&Self::make_new_dir());
+        }
+        paths
+    }
+
+    pub fn new(in_paths: &str) -> Self {
         let paths = if !in_paths.is_empty() {
             in_paths.to_string()
         } else {
-            let mut dir: usize;
-            dir = ACCOUNT_DIR.fetch_add(1, Ordering::Relaxed);
-            let mut paths = dir.to_string();
-            for _ in 1..NUM_ACCOUNT_DIRS {
-                dir = ACCOUNT_DIR.fetch_add(1, Ordering::Relaxed);
-                paths = format!("{},{}", paths, dir.to_string());
-            }
-            paths
+            Self::make_default_paths()
         };
         let accounts_db = AccountsDB::default();
         accounts_db.add_storage(&paths);
@@ -683,6 +706,10 @@ impl Accounts {
             .for_each(|(tx, result)| Self::unlock_account(tx, result, &mut account_locks));
     }
 
+    pub fn has_accounts(&self, fork: Fork) -> bool {
+        self.accounts_db.has_accounts(fork)
+    }
+
     pub fn load_accounts(
         &self,
         fork: Fork,
@@ -733,10 +760,6 @@ impl Accounts {
 
         self.accounts_db.write().unwrap().squash(&dbs);
         */
-    }
-
-    pub fn has_accounts(&self, fork: Fork) -> bool {
-        false
     }
 }
 

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -434,7 +434,6 @@ impl AccountsDB {
     /// to occur in place.
     fn store_account(&self, fork: Fork, purge: bool, pubkey: &Pubkey, account: &Account) {
         if account.tokens == 0 && purge {
-            println!("store purge {} {:?}", fork, pubkey);
             // purge if balance is 0 and no checkpoints
             let index = self.index_info.index.read().unwrap();
             let map = index.get(&pubkey).unwrap();

--- a/runtime/src/appendvec.rs
+++ b/runtime/src/appendvec.rs
@@ -160,35 +160,43 @@ where
         }
 
         let mut at = data_at as usize;
+        let data = &self.map[at..at + mem::size_of::<u64>()];
+        #[allow(clippy::cast_ptr_alignment)]
+        let ptr = data.as_ptr() as *mut u64;
         unsafe {
-            let data = &self.map[at..at + mem::size_of::<u64>()];
-            #[allow(clippy::cast_ptr_alignment)]
-            let ptr = data.as_ptr() as *mut u64;
             std::ptr::write_unaligned(ptr, len as u64);
-            at += mem::size_of::<u64>();
+        }
+        at += mem::size_of::<u64>();
 
-            let data = &self.map[at..at + mem::size_of::<u64>()];
-            #[allow(clippy::cast_ptr_alignment)]
-            let ptr = data.as_ptr() as *mut u64;
+        let data = &self.map[at..at + mem::size_of::<u64>()];
+        #[allow(clippy::cast_ptr_alignment)]
+        let ptr = data.as_ptr() as *mut u64;
+        unsafe {
             std::ptr::write_unaligned(ptr, account.tokens);
-            at += mem::size_of::<u64>();
+        }
+        at += mem::size_of::<u64>();
 
-            let data = &self.map[at..at + account.userdata.len()];
-            let dst = data.as_ptr() as *mut u8;
-            let data = &account.userdata[0..account.userdata.len()];
-            let src = data.as_ptr();
+        let data = &self.map[at..at + account.userdata.len()];
+        let dst = data.as_ptr() as *mut u8;
+        let data = &account.userdata[0..account.userdata.len()];
+        let src = data.as_ptr();
+        unsafe {
             std::ptr::copy_nonoverlapping(src, dst, account.userdata.len());
-            at += account.userdata.len();
+        }
+        at += account.userdata.len();
 
-            let data = &self.map[at..at + mem::size_of::<Pubkey>()];
-            let ptr = data.as_ptr() as *mut Pubkey;
+        let data = &self.map[at..at + mem::size_of::<Pubkey>()];
+        let ptr = data.as_ptr() as *mut Pubkey;
+        unsafe {
             std::ptr::write(ptr, account.owner);
-            at += mem::size_of::<Pubkey>();
+        }
+        at += mem::size_of::<Pubkey>();
 
-            let data = &self.map[at..at + mem::size_of::<bool>()];
-            let ptr = data.as_ptr() as *mut bool;
+        let data = &self.map[at..at + mem::size_of::<bool>()];
+        let ptr = data.as_ptr() as *mut bool;
+        unsafe {
             std::ptr::write(ptr, account.executable);
-        };
+        }
 
         self.current_offset
             .fetch_add(len + SIZEOF_U64, Ordering::Relaxed);

--- a/runtime/src/appendvec.rs
+++ b/runtime/src/appendvec.rs
@@ -1,0 +1,336 @@
+use memmap::MmapMut;
+use solana_sdk::account::Account;
+use solana_sdk::pubkey::Pubkey;
+use std::fs::{File, OpenOptions};
+use std::io::{Error, ErrorKind, Result, Seek, SeekFrom, Write};
+use std::marker::PhantomData;
+use std::mem;
+use std::path::Path;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Mutex;
+
+const SIZEOF_U64: usize = mem::size_of::<u64>();
+
+pub struct AppendVec<T> {
+    data: File,
+    map: MmapMut,
+    current_offset: AtomicUsize,
+    append_lock: Mutex<()>,
+    file_size: u64,
+    inc_size: u64,
+    phantom: PhantomData<T>,
+}
+
+impl<T> AppendVec<T>
+where
+    T: Default,
+{
+    pub fn new(path: &Path, create: bool, size: u64, inc: u64) -> Self {
+        let mut data = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(create)
+            .open(path)
+            .expect("Unable to open data file");
+
+        data.seek(SeekFrom::Start(size)).unwrap();
+        data.write_all(&[0]).unwrap();
+        data.seek(SeekFrom::Start(0)).unwrap();
+        data.flush().unwrap();
+        let map = unsafe { MmapMut::map_mut(&data).expect("failed to map the data file") };
+
+        AppendVec {
+            data,
+            map,
+            current_offset: AtomicUsize::new(0),
+            append_lock: Mutex::new(()),
+            file_size: size,
+            inc_size: inc,
+            phantom: PhantomData,
+        }
+    }
+
+    pub fn reset(&mut self) {
+        let _append_lock = self.append_lock.lock().unwrap();
+        self.current_offset.store(0, Ordering::Relaxed);
+    }
+
+    #[allow(dead_code)]
+    pub fn get(&self, index: u64) -> &T {
+        let offset = self.current_offset.load(Ordering::Relaxed);
+        let at = index as usize;
+        assert!(offset >= at + mem::size_of::<T>());
+        let data = &self.map[at..at + mem::size_of::<T>()];
+        let ptr = data.as_ptr() as *const T;
+        let x: Option<&T> = unsafe { ptr.as_ref() };
+        x.unwrap()
+    }
+
+    #[allow(dead_code)]
+    pub fn grow_file(&mut self) -> Result<()> {
+        if self.inc_size == 0 {
+            return Err(Error::new(ErrorKind::WriteZero, "Grow not supported"));
+        }
+        let _append_lock = self.append_lock.lock().unwrap();
+        let index = self.current_offset.load(Ordering::Relaxed) + mem::size_of::<T>();
+        if index as u64 + self.inc_size < self.file_size {
+            // grow was already called
+            return Ok(());
+        }
+        let end = self.file_size + self.inc_size;
+        drop(self.map.to_owned());
+        self.data.seek(SeekFrom::Start(end))?;
+        self.data.write_all(&[0])?;
+        self.data.seek(SeekFrom::Start(0))?;
+        self.data.flush()?;
+        self.map = unsafe { MmapMut::map_mut(&self.data)? };
+        self.file_size = end;
+        Ok(())
+    }
+
+    #[allow(dead_code)]
+    pub fn append(&self, val: T) -> Option<u64> {
+        let _append_lock = self.append_lock.lock().unwrap();
+        let index = self.current_offset.load(Ordering::Relaxed);
+
+        if (self.file_size as usize) < index + mem::size_of::<T>() {
+            return None;
+        }
+
+        let data = &self.map[index..(index + mem::size_of::<T>())];
+        unsafe {
+            let ptr = data.as_ptr() as *mut T;
+            std::ptr::write(ptr, val)
+        };
+        self.current_offset
+            .fetch_add(mem::size_of::<T>(), Ordering::Relaxed);
+        Some(index as u64)
+    }
+
+    fn get_account_size_static() -> usize {
+        mem::size_of::<u64>()
+            + mem::size_of::<Pubkey>()
+            + mem::size_of::<bool>()
+            + mem::size_of::<Pubkey>()
+    }
+
+    pub fn get_account(&self, index: u64) -> Result<Account> {
+        let mut at = index as usize;
+        let data = &self.map[at..(at + mem::size_of::<u64>())];
+        #[allow(clippy::cast_ptr_alignment)]
+        let size: u64 = unsafe { std::ptr::read_unaligned(data.as_ptr() as *const _) };
+        let len = size as usize;
+        at += SIZEOF_U64 as usize;
+
+        let offset = self.current_offset.load(Ordering::Relaxed);
+        assert!(offset >= at + len);
+
+        let data = &self.map[at..(at + mem::size_of::<u64>())];
+        #[allow(clippy::cast_ptr_alignment)]
+        let tokens: u64 = unsafe { std::ptr::read_unaligned(data.as_ptr() as *const _) };
+        at += mem::size_of::<u64>();
+
+        let userdata_len = len - Self::get_account_size_static();
+        let mut userdata = vec![];
+        userdata.extend_from_slice(&self.map[at..at + userdata_len]);
+        at += userdata_len;
+
+        let data = &self.map[at..(at + mem::size_of::<Pubkey>())];
+        let owner: Pubkey = unsafe { std::ptr::read(data.as_ptr() as *const _) };
+        at += mem::size_of::<Pubkey>();
+
+        let data = &self.map[at..(at + mem::size_of::<bool>())];
+        let executable: bool = unsafe { std::ptr::read(data.as_ptr() as *const _) };
+
+        Ok(Account {
+            tokens,
+            userdata,
+            owner,
+            executable,
+        })
+    }
+
+    pub fn append_account(&self, account: &Account) -> Option<u64> {
+        let _append_lock = self.append_lock.lock().unwrap();
+        let data_at = self.current_offset.load(Ordering::Relaxed);
+        let len = Self::get_account_size_static() + account.userdata.len();
+
+        if (self.file_size as usize) < data_at + len + SIZEOF_U64 {
+            return None;
+        }
+
+        let mut at = data_at as usize;
+        unsafe {
+            let data = &self.map[at..at + mem::size_of::<u64>()];
+            #[allow(clippy::cast_ptr_alignment)]
+            let ptr = data.as_ptr() as *mut u64;
+            std::ptr::write_unaligned(ptr, len as u64);
+            at += mem::size_of::<u64>();
+
+            let data = &self.map[at..at + mem::size_of::<u64>()];
+            #[allow(clippy::cast_ptr_alignment)]
+            let ptr = data.as_ptr() as *mut u64;
+            std::ptr::write_unaligned(ptr, account.tokens);
+            at += mem::size_of::<u64>();
+
+            let data = &self.map[at..at + account.userdata.len()];
+            let dst = data.as_ptr() as *mut u8;
+            let data = &account.userdata[0..account.userdata.len()];
+            let src = data.as_ptr();
+            std::ptr::copy_nonoverlapping(src, dst, account.userdata.len());
+            at += account.userdata.len();
+
+            let data = &self.map[at..at + mem::size_of::<Pubkey>()];
+            let ptr = data.as_ptr() as *mut Pubkey;
+            std::ptr::write(ptr, account.owner);
+            at += mem::size_of::<Pubkey>();
+
+            let data = &self.map[at..at + mem::size_of::<bool>()];
+            let ptr = data.as_ptr() as *mut bool;
+            std::ptr::write(ptr, account.executable);
+        };
+
+        self.current_offset
+            .fetch_add(len + SIZEOF_U64, Ordering::Relaxed);
+        Some(data_at as u64)
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+    use log::info;
+    use rand::{thread_rng, Rng};
+    use solana_sdk::timing::{duration_as_ms, duration_as_s};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::time::Instant;
+
+    const START_SIZE: u64 = 4 * 1024 * 1024;
+    const INC_SIZE: u64 = 1 * 1024 * 1024;
+
+    #[test]
+    fn test_append_vec() {
+        let path = Path::new("append_vec");
+        let av = AppendVec::new(path, true, START_SIZE, INC_SIZE);
+        let val: u64 = 5;
+        let index = av.append(val).unwrap();
+        assert_eq!(*av.get(index), val);
+        let val1 = val + 1;
+        let index1 = av.append(val1).unwrap();
+        assert_eq!(*av.get(index), val);
+        assert_eq!(*av.get(index1), val1);
+        std::fs::remove_file(path).unwrap();
+    }
+
+    #[test]
+    fn test_append_vec_account() {
+        let path = Path::new("append_vec_account");
+        let av: AppendVec<Account> = AppendVec::new(path, true, START_SIZE, INC_SIZE);
+        let v1 = vec![1u8; 32];
+        let mut account1 = Account {
+            tokens: 1,
+            userdata: v1,
+            owner: Pubkey::default(),
+            executable: false,
+        };
+        let index1 = av.append_account(&account1).unwrap();
+        assert_eq!(index1, 0);
+        assert_eq!(av.get_account(index1).unwrap(), account1);
+
+        let v2 = vec![4u8; 32];
+        let mut account2 = Account {
+            tokens: 1,
+            userdata: v2,
+            owner: Pubkey::default(),
+            executable: false,
+        };
+        let index2 = av.append_account(&account2).unwrap();
+        let mut len = AppendVec::<Account>::get_account_size_static()
+            + account1.userdata.len()
+            + SIZEOF_U64 as usize;
+        assert_eq!(index2, len as u64);
+        assert_eq!(av.get_account(index2).unwrap(), account2);
+        assert_eq!(av.get_account(index1).unwrap(), account1);
+
+        account2.userdata.iter_mut().for_each(|e| *e *= 2);
+        let index3 = av.append_account(&account2).unwrap();
+        len += AppendVec::<Account>::get_account_size_static()
+            + account2.userdata.len()
+            + SIZEOF_U64 as usize;
+        assert_eq!(index3, len as u64);
+        assert_eq!(av.get_account(index3).unwrap(), account2);
+
+        account1.userdata.extend([1, 2, 3, 4, 5, 6].iter().cloned());
+        let index4 = av.append_account(&account1).unwrap();
+        len += AppendVec::<Account>::get_account_size_static()
+            + account2.userdata.len()
+            + SIZEOF_U64 as usize;
+        assert_eq!(index4, len as u64);
+        assert_eq!(av.get_account(index4).unwrap(), account1);
+        std::fs::remove_file(path).unwrap();
+    }
+
+    #[test]
+    fn test_grow_append_vec() {
+        let path = Path::new("grow");
+        let mut av = AppendVec::new(path, true, START_SIZE, INC_SIZE);
+        let mut val = [5u64; 32];
+        let size = 100_000;
+        let mut offsets = vec![0; size];
+
+        let now = Instant::now();
+        for index in 0..size {
+            if let Some(offset) = av.append(val) {
+                offsets[index] = offset;
+            } else {
+                assert!(av.grow_file().is_ok());
+                if let Some(offset) = av.append(val) {
+                    offsets[index] = offset;
+                } else {
+                    assert!(false);
+                }
+            }
+            val[0] += 1;
+        }
+        info!(
+            "time: {} ms {} / s",
+            duration_as_ms(&now.elapsed()),
+            ((mem::size_of::<[u64; 32]>() * size) as f32) / duration_as_s(&now.elapsed()),
+        );
+
+        let now = Instant::now();
+        let num_reads = 100_000;
+        for _ in 0..num_reads {
+            let index = thread_rng().gen_range(0, size);
+            assert_eq!(av.get(offsets[index])[0], (index + 5) as u64);
+        }
+        info!(
+            "time: {} ms {} / s",
+            duration_as_ms(&now.elapsed()),
+            (num_reads as f32) / duration_as_s(&now.elapsed()),
+        );
+        std::fs::remove_file(path).unwrap();
+    }
+
+    #[test]
+    fn random_atomic_change() {
+        let path = Path::new("random");
+        let mut vec = AppendVec::<AtomicUsize>::new(path, true, START_SIZE, INC_SIZE);
+        let size = 1_000;
+        for _ in 0..size {
+            if vec.append(AtomicUsize::new(0)).is_none() {
+                assert!(vec.grow_file().is_ok());
+                assert!(vec.append(AtomicUsize::new(0)).is_some());
+            }
+        }
+        let index = thread_rng().gen_range(0, size as u64);
+        let atomic1 = vec.get(index);
+        let current1 = atomic1.load(Ordering::Relaxed);
+        let next = current1 + 1;
+        atomic1.store(next, Ordering::Relaxed);
+        let atomic2 = vec.get(index);
+        let current2 = atomic2.load(Ordering::Relaxed);
+        assert_eq!(current2, next);
+        std::fs::remove_file(path).unwrap();
+    }
+}

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -464,7 +464,7 @@ impl Bank {
             inc_new_counter_info!("bank-process_transactions-error_count", err_count);
         }
 
-        self.accounts().increment_transaction_count(tx_count);
+        self.accounts().increment_transaction_count(self.id, tx_count);
 
         inc_new_counter_info!("bank-process_transactions-txs", tx_count);
         if 0 != error_counters.last_id_not_found {
@@ -655,7 +655,7 @@ impl Bank {
     }
 
     pub fn transaction_count(&self) -> u64 {
-        self.accounts().transaction_count()
+        self.accounts().transaction_count(self.id)
     }
 
     pub fn get_signature_status(&self, signature: &Signature) -> Option<Result<()>> {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -80,7 +80,7 @@ type BankStatusCache = StatusCache<BankError>;
 /// Manager for the state of all accounts and programs after processing its entries.
 #[derive(Default)]
 pub struct Bank {
-    accounts: Accounts,
+    accounts: Option<Arc<Accounts>>,
 
     /// A cache of signature statuses
     status_cache: RwLock<BankStatusCache>,
@@ -115,7 +115,12 @@ pub struct Bank {
 
 impl Bank {
     pub fn new(genesis_block: &GenesisBlock) -> Self {
+        Self::new_with_paths(&genesis_block, "")
+    }
+
+    pub fn new_with_paths(genesis_block: &GenesisBlock, paths: &str) -> Self {
         let mut bank = Self::default();
+        bank.accounts = Some(Arc::new(Accounts::new(&paths)));
         bank.process_genesis_block(genesis_block);
         bank.add_builtin_programs();
         bank
@@ -136,6 +141,7 @@ impl Bank {
         bank.parent_hash = parent.hash();
         bank.collector_id = collector_id;
 
+        bank.accounts = Some(parent.accounts());
         bank
     }
 
@@ -175,8 +181,8 @@ impl Bank {
         let parents = self.parents();
         *self.parent.write().unwrap() = None;
 
-        let parent_accounts: Vec<_> = parents.iter().map(|b| &b.accounts).collect();
-        self.accounts.squash(&parent_accounts);
+        let parent_accounts: Vec<_> = parents.iter().map(|b| b.accounts()).collect();
+        self.accounts().squash(&parent_accounts);
 
         let parent_caches: Vec<_> = parents
             .iter()
@@ -228,7 +234,8 @@ impl Bank {
             .serialize(&mut bootstrap_leader_vote_account.userdata)
             .unwrap();
 
-        self.accounts.store_slow(
+        self.accounts().store_slow(
+            self.id,
             self.is_root(),
             &genesis_block.bootstrap_leader_vote_account_id,
             &bootstrap_leader_vote_account,
@@ -246,8 +253,8 @@ impl Bank {
 
     pub fn add_native_program(&self, name: &str, program_id: &Pubkey) {
         let account = native_loader::create_program_account(name);
-        self.accounts
-            .store_slow(self.is_root(), program_id, &account);
+        self.accounts()
+            .store_slow(self.id, self.is_root(), program_id, &account);
     }
 
     fn add_builtin_programs(&self) {
@@ -336,11 +343,11 @@ impl Bank {
         }
         // TODO: put this assert back in
         // assert!(!self.is_frozen());
-        self.accounts.lock_accounts(txs)
+        self.accounts().lock_accounts(txs)
     }
 
     pub fn unlock_accounts(&self, txs: &[Transaction], results: &[Result<()>]) {
-        self.accounts.unlock_accounts(txs, results)
+        self.accounts().unlock_accounts(txs, results)
     }
 
     fn load_accounts(
@@ -349,10 +356,8 @@ impl Bank {
         results: Vec<Result<()>>,
         error_counters: &mut ErrorCounters,
     ) -> Vec<Result<(InstructionAccounts, InstructionLoaders)>> {
-        let parents = self.parents();
-        let mut accounts = vec![&self.accounts];
-        accounts.extend(parents.iter().map(|b| &b.accounts));
-        Accounts::load_accounts(&accounts, txs, results, error_counters)
+        self.accounts()
+            .load_accounts(self.id, txs, results, error_counters)
     }
     fn check_age(
         &self,
@@ -459,7 +464,7 @@ impl Bank {
             inc_new_counter_info!("bank-process_transactions-error_count", err_count);
         }
 
-        self.accounts.increment_transaction_count(tx_count);
+        self.accounts().increment_transaction_count(tx_count);
 
         inc_new_counter_info!("bank-process_transactions-txs", tx_count);
         if 0 != error_counters.last_id_not_found {
@@ -534,8 +539,8 @@ impl Bank {
         // TODO: put this assert back in
         // assert!(!self.is_frozen());
         let now = Instant::now();
-        self.accounts
-            .store_accounts(self.is_root(), txs, executed, loaded_accounts);
+        self.accounts()
+            .store_accounts(self.id, self.is_root(), txs, executed, loaded_accounts);
 
         // once committed there is no way to unroll
         let write_elapsed = now.elapsed();
@@ -620,7 +625,7 @@ impl Bank {
                 }
 
                 account.tokens -= tokens;
-                self.accounts.store_slow(true, pubkey, &account);
+                self.accounts().store_slow(self.id, true, pubkey, &account);
                 Ok(())
             }
             None => Err(BankError::AccountNotFound),
@@ -630,22 +635,27 @@ impl Bank {
     pub fn deposit(&self, pubkey: &Pubkey, tokens: u64) {
         let mut account = self.get_account(pubkey).unwrap_or_default();
         account.tokens += tokens;
-        self.accounts.store_slow(self.is_root(), pubkey, &account);
+        self.accounts().store_slow(self.id, self.is_root(), pubkey, &account);
+    }
+
+    fn accounts(&self) -> Arc<Accounts> {
+        if let Some(accounts) = &self.accounts {
+            accounts.clone()
+        } else {
+            Arc::new(Accounts::new(""))
+        }
     }
 
     pub fn get_account(&self, pubkey: &Pubkey) -> Option<Account> {
-        let parents = self.parents();
-        let mut accounts = vec![&self.accounts];
-        accounts.extend(parents.iter().map(|b| &b.accounts));
-        Accounts::load_slow(&accounts, pubkey)
+        self.accounts().load_slow(self.id, pubkey)
     }
 
     pub fn get_account_modified_since_parent(&self, pubkey: &Pubkey) -> Option<Account> {
-        Accounts::load_slow(&[&self.accounts], pubkey)
+        self.accounts().load_slow(self.id, pubkey)
     }
 
     pub fn transaction_count(&self) -> u64 {
-        self.accounts.transaction_count()
+        self.accounts().transaction_count()
     }
 
     pub fn get_signature_status(&self, signature: &Signature) -> Option<Result<()>> {
@@ -667,12 +677,11 @@ impl Bank {
     fn hash_internal_state(&self) -> Hash {
         // If there are no accounts, return the same hash as we did before
         // checkpointing.
-        let accounts = &self.accounts.accounts_db.read().unwrap().accounts;
-        if accounts.is_empty() {
+        if !self.accounts().has_accounts(self.id) {
             return self.parent_hash;
         }
 
-        let accounts_delta_hash = self.accounts.hash_internal_state();
+        let accounts_delta_hash = self.accounts().hash_internal_state(self.id);
         extend_and_hash(&self.parent_hash, &serialize(&accounts_delta_hash).unwrap())
     }
 
@@ -680,34 +689,17 @@ impl Bank {
     where
         F: Fn(&VoteState) -> bool,
     {
-        let parents = self.parents();
-        let mut accounts = vec![&self.accounts];
-        accounts.extend(parents.iter().map(|b| &b.accounts));
-        let mut exists = HashSet::new();
-        accounts
+        self.accounts()
+            .accounts_db
+            .get_vote_accounts(self.id)
             .iter()
-            .flat_map(|account| {
-                let accounts_db = account.accounts_db.read().unwrap();
-                let vote_states: Vec<_> = accounts_db
-                    .accounts
-                    .iter()
-                    .filter_map(|(key, account)| {
-                        if exists.contains(key) {
-                            None
-                        } else {
-                            exists.insert(key.clone());
-                            if vote_program::check_id(&account.owner) {
-                                if let Ok(vote_state) = VoteState::deserialize(&account.userdata) {
-                                    if cond(&vote_state) {
-                                        return Some(vote_state);
-                                    }
-                                }
-                            }
-                            None
-                        }
-                    })
-                    .collect();
-                vote_states
+            .filter_map(|account| {
+                if let Ok(vote_state) = VoteState::deserialize(&account.userdata) {
+                    if cond(&vote_state) {
+                        return Some(vote_state);
+                    }
+                }
+                None
             })
             .collect()
     }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -642,7 +642,7 @@ impl Bank {
         if let Some(accounts) = &self.accounts {
             accounts.clone()
         } else {
-            Arc::new(Accounts::new(""))
+            panic!("no accounts!");
         }
     }
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -115,12 +115,12 @@ pub struct Bank {
 
 impl Bank {
     pub fn new(genesis_block: &GenesisBlock) -> Self {
-        Self::new_with_paths(&genesis_block, "")
+        Self::new_with_paths(&genesis_block, None)
     }
 
-    pub fn new_with_paths(genesis_block: &GenesisBlock, paths: &str) -> Self {
+    pub fn new_with_paths(genesis_block: &GenesisBlock, paths: Option<String>) -> Self {
         let mut bank = Self::default();
-        bank.accounts = Some(Arc::new(Accounts::new(bank.id, &paths)));
+        bank.accounts = Some(Arc::new(Accounts::new(bank.id, paths)));
         bank.process_genesis_block(genesis_block);
         bank.add_builtin_programs();
         bank
@@ -151,7 +151,11 @@ impl Bank {
     pub fn new_from_parent(parent: &Arc<Bank>) -> Self {
         static BANK_ID: AtomicUsize = AtomicUsize::new(1);
         let collector_id = parent.collector_id;
-        Self::new_from_parent_and_id(parent, collector_id, BANK_ID.fetch_add(1, Ordering::Relaxed) as u64)
+        Self::new_from_parent_and_id(
+            parent,
+            collector_id,
+            BANK_ID.fetch_add(1, Ordering::Relaxed) as u64,
+        )
     }
 
     pub fn id(&self) -> u64 {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1,4 +1,5 @@
 mod accounts;
+pub mod appendvec;
 pub mod bank;
 pub mod bloom;
 mod last_id_queue;

--- a/src/bank_forks.rs
+++ b/src/bank_forks.rs
@@ -38,6 +38,8 @@ impl BankForks {
 mod tests {
     use super::*;
     use solana_sdk::hash::Hash;
+    use solana_sdk::pubkey::Pubkey;
+    use solana_sdk::genesis_block::GenesisBlock;
 
     #[test]
     fn test_bank_forks_root() {
@@ -49,7 +51,8 @@ mod tests {
 
     #[test]
     fn test_bank_forks_parent() {
-        let bank = Bank::default();
+        let (genesis_block, _) = GenesisBlock::new(10_000);
+        let bank = Bank::new(&genesis_block);
         let mut bank_forks = BankForks::new(0, bank);
         let child_bank = Bank::new_from_parent(&bank_forks.working_bank());
         child_bank.register_tick(&Hash::default());

--- a/src/bank_forks.rs
+++ b/src/bank_forks.rs
@@ -37,9 +37,8 @@ impl BankForks {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use solana_sdk::hash::Hash;
-    use solana_sdk::pubkey::Pubkey;
     use solana_sdk::genesis_block::GenesisBlock;
+    use solana_sdk::hash::Hash;
 
     #[test]
     fn test_bank_forks_root() {

--- a/src/blocktree_processor.rs
+++ b/src/blocktree_processor.rs
@@ -129,7 +129,7 @@ pub fn process_blocktree(
     genesis_block: &GenesisBlock,
     blocktree: &Blocktree,
     leader_scheduler: &Arc<RwLock<LeaderScheduler>>,
-    account_paths: &str,
+    account_paths: Option<String>,
 ) -> Result<(BankForks, Vec<BankForksInfo>)> {
     let now = Instant::now();
     info!("processing ledger...");
@@ -327,7 +327,7 @@ mod tests {
         info!("last_fork2_entry_id: {:?}", last_fork2_entry_id);
 
         let (mut bank_forks, bank_forks_info) =
-            process_blocktree(&genesis_block, &blocktree, &leader_scheduler, "").unwrap();
+            process_blocktree(&genesis_block, &blocktree, &leader_scheduler, None).unwrap();
 
         assert_eq!(bank_forks_info.len(), 2); // There are two forks
         assert_eq!(
@@ -455,7 +455,7 @@ mod tests {
         entry_height += entries.len() as u64;
 
         let (bank_forks, bank_forks_info) =
-            process_blocktree(&genesis_block, &blocktree, &leader_scheduler, "").unwrap();
+            process_blocktree(&genesis_block, &blocktree, &leader_scheduler, None).unwrap();
 
         assert_eq!(bank_forks_info.len(), 1);
         assert_eq!(

--- a/src/blocktree_processor.rs
+++ b/src/blocktree_processor.rs
@@ -129,13 +129,14 @@ pub fn process_blocktree(
     genesis_block: &GenesisBlock,
     blocktree: &Blocktree,
     leader_scheduler: &Arc<RwLock<LeaderScheduler>>,
+    account_paths: &str,
 ) -> Result<(BankForks, Vec<BankForksInfo>)> {
     let now = Instant::now();
     info!("processing ledger...");
 
     // Setup bank for slot 0
     let (mut bank_forks, mut pending_slots) = {
-        let bank0 = Bank::new(&genesis_block);
+        let bank0 = Bank::new_with_paths(&genesis_block, account_paths);
         let bank_id = 0;
         let slot = 0;
         let entry_height = 0;
@@ -326,7 +327,7 @@ mod tests {
         info!("last_fork2_entry_id: {:?}", last_fork2_entry_id);
 
         let (mut bank_forks, bank_forks_info) =
-            process_blocktree(&genesis_block, &blocktree, &leader_scheduler).unwrap();
+            process_blocktree(&genesis_block, &blocktree, &leader_scheduler, "").unwrap();
 
         assert_eq!(bank_forks_info.len(), 2); // There are two forks
         assert_eq!(
@@ -454,7 +455,7 @@ mod tests {
         entry_height += entries.len() as u64;
 
         let (bank_forks, bank_forks_info) =
-            process_blocktree(&genesis_block, &blocktree, &leader_scheduler).unwrap();
+            process_blocktree(&genesis_block, &blocktree, &leader_scheduler, "").unwrap();
 
         assert_eq!(bank_forks_info.len(), 1);
         assert_eq!(

--- a/src/fullnode.rs
+++ b/src/fullnode.rs
@@ -65,7 +65,7 @@ pub struct FullnodeConfig {
     pub storage_rotate_count: u64,
     pub leader_scheduler_config: LeaderSchedulerConfig,
     pub tick_config: PohServiceConfig,
-    pub account_paths: String,
+    pub account_paths: Option<String>,
 }
 impl Default for FullnodeConfig {
     fn default() -> Self {
@@ -80,7 +80,7 @@ impl Default for FullnodeConfig {
             storage_rotate_count: NUM_HASHES_FOR_STORAGE_ROTATE,
             leader_scheduler_config: LeaderSchedulerConfig::default(),
             tick_config: PohServiceConfig::default(),
-            account_paths: "".to_string(),
+            account_paths: None,
         }
     }
 }
@@ -132,7 +132,7 @@ impl Fullnode {
         let (mut bank_forks, bank_forks_info, blocktree, ledger_signal_receiver) =
             new_banks_from_blocktree(
                 ledger_path,
-                &config.account_paths,
+                config.account_paths.clone(),
                 config.ticks_per_slot(),
                 &leader_scheduler,
             );
@@ -419,7 +419,7 @@ impl Fullnode {
 
 pub fn new_banks_from_blocktree(
     blocktree_path: &str,
-    account_paths: &str,
+    account_paths: Option<String>,
     ticks_per_slot: u64,
     leader_scheduler: &Arc<RwLock<LeaderScheduler>>,
 ) -> (BankForks, Vec<BankForksInfo>, Blocktree, Receiver<bool>) {
@@ -764,7 +764,7 @@ mod tests {
         let leader_scheduler = Arc::new(RwLock::new(LeaderScheduler::default()));
         let (bank_forks, bank_forks_info, _, _) = new_banks_from_blocktree(
             &validator_ledger_path,
-            "",
+            None,
             DEFAULT_TICKS_PER_SLOT,
             &leader_scheduler,
         );

--- a/src/fullnode.rs
+++ b/src/fullnode.rs
@@ -80,7 +80,7 @@ impl Default for FullnodeConfig {
             storage_rotate_count: NUM_HASHES_FOR_STORAGE_ROTATE,
             leader_scheduler_config: LeaderSchedulerConfig::default(),
             tick_config: PohServiceConfig::default(),
-            account_paths: "0,1,2,3".to_string(),
+            account_paths: "".to_string(),
         }
     }
 }
@@ -424,8 +424,8 @@ pub fn new_banks_from_blocktree(
     let genesis_block =
         GenesisBlock::load(blocktree_path).expect("Expected to successfully open genesis block");
 
-    let (bank_forks, bank_forks_info) =
-        blocktree_processor::process_blocktree(&genesis_block, &blocktree, leader_scheduler)
+    let (mut bank_forks, bank_forks_info) =
+        blocktree_processor::process_blocktree(&genesis_block, &blocktree, leader_scheduler, account_paths)
             .expect("process_blocktree failed");
 
     (

--- a/src/fullnode.rs
+++ b/src/fullnode.rs
@@ -65,6 +65,7 @@ pub struct FullnodeConfig {
     pub storage_rotate_count: u64,
     pub leader_scheduler_config: LeaderSchedulerConfig,
     pub tick_config: PohServiceConfig,
+    pub account_paths: String,
 }
 impl Default for FullnodeConfig {
     fn default() -> Self {
@@ -79,6 +80,7 @@ impl Default for FullnodeConfig {
             storage_rotate_count: NUM_HASHES_FOR_STORAGE_ROTATE,
             leader_scheduler_config: LeaderSchedulerConfig::default(),
             tick_config: PohServiceConfig::default(),
+            account_paths: "0,1,2,3".to_string(),
         }
     }
 }
@@ -128,7 +130,7 @@ impl Fullnode {
             &config.leader_scheduler_config,
         )));
         let (mut bank_forks, bank_forks_info, blocktree, ledger_signal_receiver) =
-            new_banks_from_blocktree(ledger_path, config.ticks_per_slot(), &leader_scheduler);
+            new_banks_from_blocktree(ledger_path, &config.account_paths, config.ticks_per_slot(), &leader_scheduler);
 
         let exit = Arc::new(AtomicBool::new(false));
         let bank_info = &bank_forks_info[0];
@@ -412,6 +414,7 @@ impl Fullnode {
 
 pub fn new_banks_from_blocktree(
     blocktree_path: &str,
+    account_paths: &str,
     ticks_per_slot: u64,
     leader_scheduler: &Arc<RwLock<LeaderScheduler>>,
 ) -> (BankForks, Vec<BankForksInfo>, Blocktree, Receiver<bool>) {
@@ -752,6 +755,7 @@ mod tests {
         let leader_scheduler = Arc::new(RwLock::new(LeaderScheduler::default()));
         let (bank_forks, bank_forks_info, _, _) = new_banks_from_blocktree(
             &validator_ledger_path,
+            "accounts",
             DEFAULT_TICKS_PER_SLOT,
             &leader_scheduler,
         );

--- a/src/fullnode.rs
+++ b/src/fullnode.rs
@@ -764,7 +764,7 @@ mod tests {
         let leader_scheduler = Arc::new(RwLock::new(LeaderScheduler::default()));
         let (bank_forks, bank_forks_info, _, _) = new_banks_from_blocktree(
             &validator_ledger_path,
-            "accounts",
+            "",
             DEFAULT_TICKS_PER_SLOT,
             &leader_scheduler,
         );

--- a/src/fullnode.rs
+++ b/src/fullnode.rs
@@ -130,7 +130,12 @@ impl Fullnode {
             &config.leader_scheduler_config,
         )));
         let (mut bank_forks, bank_forks_info, blocktree, ledger_signal_receiver) =
-            new_banks_from_blocktree(ledger_path, &config.account_paths, config.ticks_per_slot(), &leader_scheduler);
+            new_banks_from_blocktree(
+                ledger_path,
+                &config.account_paths,
+                config.ticks_per_slot(),
+                &leader_scheduler,
+            );
 
         let exit = Arc::new(AtomicBool::new(false));
         let bank_info = &bank_forks_info[0];
@@ -424,9 +429,13 @@ pub fn new_banks_from_blocktree(
     let genesis_block =
         GenesisBlock::load(blocktree_path).expect("Expected to successfully open genesis block");
 
-    let (mut bank_forks, bank_forks_info) =
-        blocktree_processor::process_blocktree(&genesis_block, &blocktree, leader_scheduler, account_paths)
-            .expect("process_blocktree failed");
+    let (bank_forks, bank_forks_info) = blocktree_processor::process_blocktree(
+        &genesis_block,
+        &blocktree,
+        leader_scheduler,
+        account_paths,
+    )
+    .expect("process_blocktree failed");
 
     (
         bank_forks,

--- a/src/replay_stage.rs
+++ b/src/replay_stage.rs
@@ -560,7 +560,7 @@ mod test {
         {
             // Set up the bank
             let (bank_forks, bank_forks_info, blocktree, ledger_signal_receiver) =
-                new_banks_from_blocktree(&my_ledger_path, ticks_per_slot, &leader_scheduler);
+                new_banks_from_blocktree(&my_ledger_path, "", ticks_per_slot, &leader_scheduler);
 
             // Set up the replay stage
             let (rotation_sender, rotation_receiver) = channel();
@@ -659,6 +659,7 @@ mod test {
             let leader_scheduler = Arc::new(RwLock::new(LeaderScheduler::default()));
             let (bank_forks, bank_forks_info, blocktree, l_receiver) = new_banks_from_blocktree(
                 &my_ledger_path,
+                "",
                 DEFAULT_TICKS_PER_SLOT,
                 &leader_scheduler,
             );
@@ -767,7 +768,7 @@ mod test {
         let exit = Arc::new(AtomicBool::new(false));
         {
             let (bank_forks, bank_forks_info, blocktree, l_receiver) =
-                new_banks_from_blocktree(&my_ledger_path, ticks_per_slot, &leader_scheduler);
+                new_banks_from_blocktree(&my_ledger_path, "", ticks_per_slot, &leader_scheduler);
             let bank = bank_forks.working_bank();
             let meta = blocktree
                 .meta(0)

--- a/src/replay_stage.rs
+++ b/src/replay_stage.rs
@@ -560,7 +560,7 @@ mod test {
         {
             // Set up the bank
             let (bank_forks, bank_forks_info, blocktree, ledger_signal_receiver) =
-                new_banks_from_blocktree(&my_ledger_path, "", ticks_per_slot, &leader_scheduler);
+                new_banks_from_blocktree(&my_ledger_path, None, ticks_per_slot, &leader_scheduler);
 
             // Set up the replay stage
             let (rotation_sender, rotation_receiver) = channel();
@@ -659,7 +659,7 @@ mod test {
             let leader_scheduler = Arc::new(RwLock::new(LeaderScheduler::default()));
             let (bank_forks, bank_forks_info, blocktree, l_receiver) = new_banks_from_blocktree(
                 &my_ledger_path,
-                "",
+                None,
                 DEFAULT_TICKS_PER_SLOT,
                 &leader_scheduler,
             );
@@ -768,7 +768,7 @@ mod test {
         let exit = Arc::new(AtomicBool::new(false));
         {
             let (bank_forks, bank_forks_info, blocktree, l_receiver) =
-                new_banks_from_blocktree(&my_ledger_path, "", ticks_per_slot, &leader_scheduler);
+                new_banks_from_blocktree(&my_ledger_path, None, ticks_per_slot, &leader_scheduler);
             let bank = bank_forks.working_bank();
             let meta = blocktree
                 .meta(0)

--- a/tests/multinode.rs
+++ b/tests/multinode.rs
@@ -945,6 +945,7 @@ fn test_leader_to_validator_transition() {
     info!("Check the ledger to make sure it's the right height...");
     let bank_forks = new_banks_from_blocktree(
         &leader_ledger_path,
+        "",
         DEFAULT_TICKS_PER_SLOT,
         &Arc::new(RwLock::new(LeaderScheduler::default())),
     )

--- a/tests/multinode.rs
+++ b/tests/multinode.rs
@@ -945,7 +945,7 @@ fn test_leader_to_validator_transition() {
     info!("Check the ledger to make sure it's the right height...");
     let bank_forks = new_banks_from_blocktree(
         &leader_ledger_path,
-        "",
+        None,
         DEFAULT_TICKS_PER_SLOT,
         &Arc::new(RwLock::new(LeaderScheduler::default())),
     )

--- a/upload-perf/src/upload-perf.rs
+++ b/upload-perf/src/upload-perf.rs
@@ -101,9 +101,9 @@ fn main() {
                 "{}, {:#10?}, {:#10?}, {:#10?}, {:#10?}",
                 entry,
                 values.0,
-                values.2.parse::<i32>().unwrap(),
+                values.2.parse::<i32>().unwrap_or_default(),
                 values.1,
-                values.3.parse::<i32>().unwrap(),
+                values.3.parse::<i32>().unwrap_or_default(),
             );
         }
     } else {


### PR DESCRIPTION
#### Problem

The cost of RAM is much higher that adds up to the cost of operating a full node (16GB of RAM is the same cost as 500GB of high speed NVMe SSDs). Look into ways to reduce the RAM usage by moving some of the data onto SSDs and have them loaded / stored on demand.

#### Summary of Changes

Implements #2769

To help reduce RAM usage of the nodes, persist storage of accounts across NVMe SSDs and load / store them on a need basis from SSDs.

Store account information across two files: Index and Data
Index: Contains offset into data
Data: Contains the length followed by the account data

The accounts are split across NVMe SSDs using the pubkey as the key.

Fixes: #2499 