### PR TITLE
pull leader_scheduler out of process_entries()

### DIFF
--- a/src/fullnode.rs
+++ b/src/fullnode.rs
@@ -602,14 +602,14 @@ mod tests {
     }
 
     #[test]
-    fn test_wrong_role_transition() {
+    fn test_ledger_role_transition() {
         solana_logger::setup();
 
         let mut fullnode_config = FullnodeConfig::default();
         let ticks_per_slot = 16;
         let slots_per_epoch = 2;
         fullnode_config.leader_scheduler_config =
-            LeaderSchedulerConfig::new(ticks_per_slot, slots_per_epoch, slots_per_epoch);
+            LeaderSchedulerConfig::new(ticks_per_slot, slots_per_epoch, std::u64::MAX);
 
         // Create the leader and validator nodes
         let bootstrap_leader_keypair = Arc::new(Keypair::new());

--- a/src/leader_scheduler.rs
+++ b/src/leader_scheduler.rs
@@ -198,12 +198,14 @@ impl LeaderScheduler {
 
     // Inform the leader scheduler about the current tick height of the cluster.  It may generate a
     // new schedule as a side-effect.
+    // TODO: Remove this function, use `update` instead
     pub fn update_tick_height(&mut self, tick_height: u64, bank: &Bank) {
         let epoch = self.tick_height_to_epoch(tick_height);
         trace!(
-            "update_tick_height: tick_height={} (epoch={})",
+            "update_tick_height: tick_height={} (epoch={}) bank.id()={}",
             tick_height,
             epoch,
+            bank.id(),
         );
 
         if tick_height == 0 {
@@ -216,6 +218,12 @@ impl LeaderScheduler {
         if self.tick_height_to_epoch(tick_height + 1) == epoch + 1 {
             self.generate_schedule(tick_height + 1, bank);
         }
+    }
+
+    // Update the leader scheduler with the given bank.  It may generate a
+    // new schedule as a side-effect.
+    pub fn update(&mut self, bank: &Bank) {
+        self.update_tick_height(bank.tick_height(), bank);
     }
 
     pub fn get_leader_for_tick(&self, tick: u64) -> Option<Pubkey> {

--- a/src/replay_stage.rs
+++ b/src/replay_stage.rs
@@ -125,7 +125,7 @@ impl ReplayStage {
             // If we don't process the entry now, the for loop will exit and the entry
             // will be dropped.
             if 0 == num_ticks_to_next_vote || (i + 1) == entries.len() {
-                res = blocktree_processor::process_entries(bank, &entries[0..=i], leader_scheduler);
+                res = blocktree_processor::process_entries(bank, &entries[0..=i]);
 
                 if res.is_err() {
                     // TODO: This will return early from the first entry that has an erroneous
@@ -137,6 +137,8 @@ impl ReplayStage {
                     inc_new_counter_info!("replicate-stage_failed_process_entries", i);
                     break;
                 }
+
+                leader_scheduler.write().unwrap().update(&bank);
 
                 if 0 == num_ticks_to_next_vote {
                     subscriptions.notify_subscribers(&bank);


### PR DESCRIPTION
#### Problem
 cleanup of replay_stage is complicated by propagation of leader_scheduler to layers that
 don't need to touch it

 #### Summary of Changes
 pull leader_scheduler up a level (or two)

