### PR TITLE
Make stake sorting more deterministic for data plane

### DIFF
--- a/src/cluster_info.rs
+++ b/src/cluster_info.rs
@@ -373,8 +373,14 @@ impl ClusterInfo {
             .iter()
             .map(|c| (*stakes.get(&c.id).unwrap_or(&0), c.clone()))
             .collect();
-        peers_with_stakes.sort_unstable();
-        peers_with_stakes.reverse();
+        peers_with_stakes.sort_unstable_by(|(l_stake, l_info), (r_stake, r_info)| {
+            if r_stake == l_stake {
+                r_info.id.cmp(&l_info.id)
+            } else {
+                r_stake.cmp(&l_stake)
+            }
+        });
+        peers_with_stakes.dedup();
         peers_with_stakes
     }
 


### PR DESCRIPTION
#### Problem

Cluster Info's stake sorting function was using `sort_unstable()` followed by a `reverse()` to make sure stakes were sorted in descending order. Sort unstable might result in different nodes coming up with slightly different network layouts.

#### Summary of Changes

Use `sort_unstable_by()` to customize the sorting. This eliminates `reverse()` and ensures all nodes come up with the same network layout. 
