### PR TITLE
Squash test to test parent bank after squash

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1450,4 +1450,20 @@ mod tests {
             bank.squash();
         }
     }
+
+    #[test]
+    fn test_bank_get_account_in_parent_after_squash() {
+        let (genesis_block, mint_keypair) = GenesisBlock::new(500);
+        let parent = Arc::new(Bank::new(&genesis_block));
+
+        let key1 = Keypair::new();
+
+        parent
+            .transfer(1, &mint_keypair, key1.pubkey(), genesis_block.last_id())
+            .unwrap();
+        assert_eq!(parent.get_balance(&key1.pubkey()), 1);
+        let bank = Bank::new_from_parent(&parent);
+        bank.squash();
+        assert_eq!(parent.get_balance(&key1.pubkey()), 1);
+    }
 }


### PR DESCRIPTION
#### Problem

Missing test for when a parent's account set is still valid after a child squash.

#### Summary of Changes

Add a test for this scenario. Impetus is that the persistant accounts PR does not pass this test yet and that causes problems when the bank the RPC module is looking at doesn't match the one that is the latest which has been squashed.

Fixes #
