### PR TITLE
Populate test ledgers with a full slots to reduce test boilerplate

### DIFF
--- a/ledger-tool/tests/basic.rs
+++ b/ledger-tool/tests/basic.rs
@@ -1,3 +1,6 @@
+#[macro_use]
+extern crate solana;
+
 use assert_cmd::prelude::*;
 use solana::blocktree::create_new_tmp_ledger;
 use solana_sdk::genesis_block::GenesisBlock;
@@ -35,8 +38,7 @@ fn nominal() {
     let (genesis_block, _mint_keypair) = GenesisBlock::new_with_leader(100, keypair.pubkey(), 50);
     let ticks_per_slot = genesis_block.ticks_per_slot;
 
-    let (ledger_path, _last_id) =
-        create_new_tmp_ledger("test_ledger_tool_nominal", &genesis_block).unwrap();
+    let (ledger_path, _last_id) = create_new_tmp_ledger!(&genesis_block).unwrap();
     let ticks = ticks_per_slot as usize;
 
     // Basic validation

--- a/ledger-tool/tests/basic.rs
+++ b/ledger-tool/tests/basic.rs
@@ -38,7 +38,7 @@ fn nominal() {
     let (genesis_block, _mint_keypair) = GenesisBlock::new_with_leader(100, keypair.pubkey(), 50);
     let ticks_per_slot = genesis_block.ticks_per_slot;
 
-    let (ledger_path, _last_id) = create_new_tmp_ledger!(&genesis_block).unwrap();
+    let (ledger_path, _last_id) = create_new_tmp_ledger!(&genesis_block);
     let ticks = ticks_per_slot as usize;
 
     // Basic validation

--- a/src/blocktree.rs
+++ b/src/blocktree.rs
@@ -1314,9 +1314,10 @@ macro_rules! create_new_tmp_ledger {
 //
 // Note: like `create_new_ledger` the returned ledger will have slot 0 full of ticks (and only
 // ticks)
-pub fn create_new_tmp_ledger(name: &str, genesis_block: &GenesisBlock) -> Result<(String, Hash)> {
+pub fn create_new_tmp_ledger(name: &str, genesis_block: &GenesisBlock) -> (String, Hash) {
     let ledger_path = get_tmp_ledger_path(name);
-    create_new_ledger(&ledger_path, genesis_block).and_then(|last_id| Ok((ledger_path, last_id)))
+    let last_id = create_new_ledger(&ledger_path, genesis_block).unwrap();
+    (ledger_path, last_id)
 }
 
 #[macro_export]

--- a/src/blocktree.rs
+++ b/src/blocktree.rs
@@ -1303,6 +1303,13 @@ pub fn get_tmp_ledger_path(name: &str) -> String {
     path
 }
 
+#[macro_export]
+macro_rules! create_new_tmp_ledger {
+    ($genesis_block:expr) => {
+        create_new_tmp_ledger(tmp_ledger_name!(), $genesis_block)
+    };
+}
+
 // Same as `create_new_ledger()` but use a temporary ledger name based on the provided `name`
 //
 // Note: like `create_new_ledger` the returned ledger will have slot 0 full of ticks (and only

--- a/src/blocktree_processor.rs
+++ b/src/blocktree_processor.rs
@@ -270,7 +270,7 @@ mod tests {
         */
 
         // Create a new ledger with slot 0 full of ticks
-        let (ledger_path, mut last_id) = create_new_tmp_ledger!(&genesis_block).unwrap();
+        let (ledger_path, mut last_id) = create_new_tmp_ledger!(&genesis_block);
         debug!("ledger_path: {:?}", ledger_path);
 
         let blocktree = Blocktree::open_config(&ledger_path, ticks_per_slot)
@@ -319,7 +319,7 @@ mod tests {
         let ticks_per_slot = genesis_block.ticks_per_slot;
 
         // Create a new ledger with slot 0 full of ticks
-        let (ledger_path, last_id) = create_new_tmp_ledger!(&genesis_block).unwrap();
+        let (ledger_path, last_id) = create_new_tmp_ledger!(&genesis_block);
         debug!("ledger_path: {:?}", ledger_path);
         let mut last_entry_id = last_id;
 
@@ -445,7 +445,7 @@ mod tests {
     fn test_process_ledger_simple() {
         let leader_pubkey = Keypair::new().pubkey();
         let (genesis_block, mint_keypair) = GenesisBlock::new_with_leader(100, leader_pubkey, 50);
-        let (ledger_path, last_id) = create_new_tmp_ledger!(&genesis_block).unwrap();
+        let (ledger_path, last_id) = create_new_tmp_ledger!(&genesis_block);
         debug!("ledger_path: {:?}", ledger_path);
 
         let mut entries = vec![];

--- a/src/blocktree_processor.rs
+++ b/src/blocktree_processor.rs
@@ -270,8 +270,7 @@ mod tests {
         */
 
         // Create a new ledger with slot 0 full of ticks
-        let (ledger_path, mut last_id) =
-            create_new_tmp_ledger("blocktree_with_two_forks", &genesis_block).unwrap();
+        let (ledger_path, mut last_id) = create_new_tmp_ledger!(&genesis_block).unwrap();
         debug!("ledger_path: {:?}", ledger_path);
 
         let blocktree = Blocktree::open_config(&ledger_path, ticks_per_slot)
@@ -320,8 +319,7 @@ mod tests {
         let ticks_per_slot = genesis_block.ticks_per_slot;
 
         // Create a new ledger with slot 0 full of ticks
-        let (ledger_path, last_id) =
-            create_new_tmp_ledger("blocktree_with_two_forks", &genesis_block).unwrap();
+        let (ledger_path, last_id) = create_new_tmp_ledger!(&genesis_block).unwrap();
         debug!("ledger_path: {:?}", ledger_path);
         let mut last_entry_id = last_id;
 
@@ -447,8 +445,7 @@ mod tests {
     fn test_process_ledger_simple() {
         let leader_pubkey = Keypair::new().pubkey();
         let (genesis_block, mint_keypair) = GenesisBlock::new_with_leader(100, leader_pubkey, 50);
-        let (ledger_path, last_id) =
-            create_new_tmp_ledger("process_ledger_simple", &genesis_block).unwrap();
+        let (ledger_path, last_id) = create_new_tmp_ledger!(&genesis_block).unwrap();
         debug!("ledger_path: {:?}", ledger_path);
 
         let mut entries = vec![];

--- a/src/fullnode.rs
+++ b/src/fullnode.rs
@@ -501,7 +501,7 @@ mod tests {
         let validator_node = Node::new_localhost_with_pubkey(validator_keypair.pubkey());
         let (genesis_block, _mint_keypair) =
             GenesisBlock::new_with_leader(10_000, leader_keypair.pubkey(), 1000);
-        let (validator_ledger_path, _last_id) = create_new_tmp_ledger!(&genesis_block).unwrap();
+        let (validator_ledger_path, _last_id) = create_new_tmp_ledger!(&genesis_block);
 
         let validator = Fullnode::new(
             validator_node,
@@ -522,16 +522,12 @@ mod tests {
 
         let mut ledger_paths = vec![];
         let validators: Vec<Fullnode> = (0..2)
-            .map(|i| {
+            .map(|_| {
                 let validator_keypair = Keypair::new();
                 let validator_node = Node::new_localhost_with_pubkey(validator_keypair.pubkey());
                 let (genesis_block, _mint_keypair) =
                     GenesisBlock::new_with_leader(10_000, leader_keypair.pubkey(), 1000);
-                let (validator_ledger_path, _last_id) = create_new_tmp_ledger(
-                    &format!("validator_parallel_exit_{}", i),
-                    &genesis_block,
-                )
-                .unwrap();
+                let (validator_ledger_path, _last_id) = create_new_tmp_ledger!(&genesis_block);
                 ledger_paths.push(validator_ledger_path.clone());
                 Fullnode::new(
                     validator_node,
@@ -579,8 +575,7 @@ mod tests {
         genesis_block.ticks_per_slot = ticks_per_slot;
         genesis_block.slots_per_epoch = slots_per_epoch;
 
-        let (bootstrap_leader_ledger_path, _last_id) =
-            create_new_tmp_ledger!(&genesis_block).unwrap();
+        let (bootstrap_leader_ledger_path, _last_id) = create_new_tmp_ledger!(&genesis_block);
 
         // Start the bootstrap leader
         let bootstrap_leader = Fullnode::new(
@@ -788,7 +783,7 @@ mod tests {
             GenesisBlock::new_with_leader(10_000, leader_node.info.id, 500);
         genesis_block.ticks_per_slot = ticks_per_slot;
 
-        let (ledger_path, last_id) = create_new_tmp_ledger(test_name, &genesis_block).unwrap();
+        let (ledger_path, last_id) = create_new_tmp_ledger!(&genesis_block);
 
         // Add entries so that the validator is in the active set, then finish up the slot with
         // ticks (and maybe add extra slots full of empty ticks)

--- a/src/fullnode.rs
+++ b/src/fullnode.rs
@@ -606,7 +606,6 @@ mod tests {
 
         let fullnode_config = FullnodeConfig::default();
         let ticks_per_slot = DEFAULT_TICKS_PER_SLOT;
-        let slots_per_epoch = DEFAULT_SLOTS_PER_EPOCH;
 
         // Create the leader and validator nodes
         let bootstrap_leader_keypair = Arc::new(Keypair::new());
@@ -689,12 +688,7 @@ mod tests {
         let validator_keypair = Arc::new(Keypair::new());
         let fullnode_config = FullnodeConfig::default();
         let (leader_node, validator_node, validator_ledger_path, ledger_initial_len, last_id) =
-            setup_leader_validator(
-                &leader_keypair,
-                &validator_keypair,
-                ticks_per_slot,
-                0,
-            );
+            setup_leader_validator(&leader_keypair, &validator_keypair, ticks_per_slot, 0);
 
         let leader_id = leader_keypair.pubkey();
         let validator_info = validator_node.info.clone();

--- a/src/fullnode.rs
+++ b/src/fullnode.rs
@@ -613,7 +613,6 @@ mod tests {
         let validator_keypair = Arc::new(Keypair::new());
         let (bootstrap_leader_node, validator_node, bootstrap_leader_ledger_path, _, _) =
             setup_leader_validator(
-                "test_wrong_role_transition",
                 &bootstrap_leader_keypair,
                 &validator_keypair,
                 ticks_per_slot,
@@ -691,7 +690,6 @@ mod tests {
         let fullnode_config = FullnodeConfig::default();
         let (leader_node, validator_node, validator_ledger_path, ledger_initial_len, last_id) =
             setup_leader_validator(
-                "test_validator_to_leader_transition",
                 &leader_keypair,
                 &validator_keypair,
                 ticks_per_slot,
@@ -767,7 +765,6 @@ mod tests {
     }
 
     fn setup_leader_validator(
-        test_name: &str,
         leader_keypair: &Arc<Keypair>,
         validator_keypair: &Arc<Keypair>,
         ticks_per_slot: u64,

--- a/src/fullnode.rs
+++ b/src/fullnode.rs
@@ -501,8 +501,7 @@ mod tests {
         let validator_node = Node::new_localhost_with_pubkey(validator_keypair.pubkey());
         let (genesis_block, _mint_keypair) =
             GenesisBlock::new_with_leader(10_000, leader_keypair.pubkey(), 1000);
-        let (validator_ledger_path, _last_id) =
-            create_new_tmp_ledger("validator_exit", &genesis_block).unwrap();
+        let (validator_ledger_path, _last_id) = create_new_tmp_ledger!(&genesis_block).unwrap();
 
         let validator = Fullnode::new(
             validator_node,
@@ -581,7 +580,7 @@ mod tests {
         genesis_block.slots_per_epoch = slots_per_epoch;
 
         let (bootstrap_leader_ledger_path, _last_id) =
-            create_new_tmp_ledger("test_leader_to_leader_transition", &genesis_block).unwrap();
+            create_new_tmp_ledger!(&genesis_block).unwrap();
 
         // Start the bootstrap leader
         let bootstrap_leader = Fullnode::new(

--- a/src/replay_stage.rs
+++ b/src/replay_stage.rs
@@ -489,9 +489,7 @@ mod test {
 
         let (genesis_block, _mint_keypair) = GenesisBlock::new_with_leader(10_000, leader_id, 500);
 
-        let (my_ledger_path, _last_id) =
-            create_new_tmp_ledger("test_vote_error_replay_stage_correctness", &genesis_block)
-                .unwrap();
+        let (my_ledger_path, _last_id) = create_new_tmp_ledger!(&genesis_block).unwrap();
 
         // Set up the cluster info
         let cluster_info_me = Arc::new(RwLock::new(ClusterInfo::new(my_node.info.clone())));

--- a/src/replay_stage.rs
+++ b/src/replay_stage.rs
@@ -466,7 +466,6 @@ mod test {
     use crate::cluster_info::{ClusterInfo, Node};
     use crate::entry::create_ticks;
     use crate::entry::{next_entry_mut, Entry};
-    use crate::fullnode::make_active_set_entries;
     use crate::fullnode::new_banks_from_blocktree;
     use crate::replay_stage::ReplayStage;
     use solana_sdk::genesis_block::GenesisBlock;

--- a/src/replay_stage.rs
+++ b/src/replay_stage.rs
@@ -489,7 +489,7 @@ mod test {
 
         let (genesis_block, _mint_keypair) = GenesisBlock::new_with_leader(10_000, leader_id, 500);
 
-        let (my_ledger_path, _last_id) = create_new_tmp_ledger!(&genesis_block).unwrap();
+        let (my_ledger_path, _last_id) = create_new_tmp_ledger!(&genesis_block);
 
         // Set up the cluster info
         let cluster_info_me = Arc::new(RwLock::new(ClusterInfo::new(my_node.info.clone())));

--- a/src/storage_stage.rs
+++ b/src/storage_stage.rs
@@ -509,7 +509,7 @@ mod tests {
 
         let (genesis_block, _mint_keypair) = GenesisBlock::new(1000);
         let ticks_per_slot = genesis_block.ticks_per_slot;
-        let (ledger_path, _last_id) = create_new_tmp_ledger!(&genesis_block).unwrap();
+        let (ledger_path, _last_id) = create_new_tmp_ledger!(&genesis_block);
 
         let entries = make_tiny_test_entries(64);
         let blocktree = Blocktree::open_config(&ledger_path, ticks_per_slot).unwrap();
@@ -572,7 +572,7 @@ mod tests {
 
         let (genesis_block, _mint_keypair) = GenesisBlock::new(1000);
         let ticks_per_slot = genesis_block.ticks_per_slot;;
-        let (ledger_path, _last_id) = create_new_tmp_ledger!(&genesis_block).unwrap();
+        let (ledger_path, _last_id) = create_new_tmp_ledger!(&genesis_block);
 
         let entries = make_tiny_test_entries(128);
         let blocktree = Blocktree::open_config(&ledger_path, ticks_per_slot).unwrap();

--- a/src/storage_stage.rs
+++ b/src/storage_stage.rs
@@ -448,7 +448,7 @@ impl Service for StorageStage {
 
 #[cfg(test)]
 mod tests {
-    use crate::blocktree::{create_tmp_sample_blocktree, Blocktree};
+    use crate::blocktree::{create_new_tmp_ledger, Blocktree};
     use crate::cluster_info::{ClusterInfo, NodeInfo};
     use crate::entry::{make_tiny_test_entries, Entry, EntryMeta};
     use crate::service::Service;
@@ -509,14 +509,12 @@ mod tests {
 
         let (genesis_block, _mint_keypair) = GenesisBlock::new(1000);
         let ticks_per_slot = genesis_block.ticks_per_slot;
-        let (ledger_path, tick_height, genesis_entry_height, _last_id, _last_entry_id) =
-            create_tmp_sample_blocktree("storage_stage_process_entries", &genesis_block, 1);
+        let (ledger_path, _last_id) =
+            create_new_tmp_ledger("storage_stage_process_entries", &genesis_block).unwrap();
 
         let entries = make_tiny_test_entries(64);
         let blocktree = Blocktree::open_config(&ledger_path, ticks_per_slot).unwrap();
-        blocktree
-            .write_entries(0, tick_height, genesis_entry_height, &entries)
-            .unwrap();
+        blocktree.write_entries(1, 0, 0, &entries).unwrap();
 
         let cluster_info = test_cluster_info(keypair.pubkey());
 
@@ -575,14 +573,12 @@ mod tests {
 
         let (genesis_block, _mint_keypair) = GenesisBlock::new(1000);
         let ticks_per_slot = genesis_block.ticks_per_slot;;
-        let (ledger_path, tick_height, genesis_entry_height, _last_id, _last_entry_id) =
-            create_tmp_sample_blocktree("storage_stage_process_entries", &genesis_block, 1);
+        let (ledger_path, _last_id) =
+            create_new_tmp_ledger("storage_stage_process_entries", &genesis_block).unwrap();
 
         let entries = make_tiny_test_entries(128);
         let blocktree = Blocktree::open_config(&ledger_path, ticks_per_slot).unwrap();
-        blocktree
-            .write_entries(0, tick_height, genesis_entry_height, &entries)
-            .unwrap();
+        blocktree.write_entries(1, 0, 0, &entries).unwrap();
 
         let cluster_info = test_cluster_info(keypair.pubkey());
 

--- a/src/storage_stage.rs
+++ b/src/storage_stage.rs
@@ -509,8 +509,7 @@ mod tests {
 
         let (genesis_block, _mint_keypair) = GenesisBlock::new(1000);
         let ticks_per_slot = genesis_block.ticks_per_slot;
-        let (ledger_path, _last_id) =
-            create_new_tmp_ledger("storage_stage_process_entries", &genesis_block).unwrap();
+        let (ledger_path, _last_id) = create_new_tmp_ledger!(&genesis_block).unwrap();
 
         let entries = make_tiny_test_entries(64);
         let blocktree = Blocktree::open_config(&ledger_path, ticks_per_slot).unwrap();
@@ -573,8 +572,7 @@ mod tests {
 
         let (genesis_block, _mint_keypair) = GenesisBlock::new(1000);
         let ticks_per_slot = genesis_block.ticks_per_slot;;
-        let (ledger_path, _last_id) =
-            create_new_tmp_ledger("storage_stage_process_entries", &genesis_block).unwrap();
+        let (ledger_path, _last_id) = create_new_tmp_ledger!(&genesis_block).unwrap();
 
         let entries = make_tiny_test_entries(128);
         let blocktree = Blocktree::open_config(&ledger_path, ticks_per_slot).unwrap();

--- a/src/thin_client.rs
+++ b/src/thin_client.rs
@@ -469,7 +469,7 @@ pub fn new_fullnode() -> (Fullnode, NodeInfo, Keypair, String) {
     let node_info = node.info.clone();
 
     let (genesis_block, mint_keypair) = GenesisBlock::new_with_leader(10_000, node_info.id, 42);
-    let (ledger_path, _last_id) = create_new_tmp_ledger!(&genesis_block).unwrap();
+    let (ledger_path, _last_id) = create_new_tmp_ledger!(&genesis_block);
 
     let vote_account_keypair = Arc::new(Keypair::new());
     let voting_keypair = VotingKeypair::new_local(&vote_account_keypair);

--- a/src/thin_client.rs
+++ b/src/thin_client.rs
@@ -456,7 +456,7 @@ pub fn retry_get_balance(
     None
 }
 
-pub fn new_fullnode(ledger_name: &'static str) -> (Fullnode, NodeInfo, Keypair, String) {
+pub fn new_fullnode() -> (Fullnode, NodeInfo, Keypair, String) {
     use crate::blocktree::create_new_tmp_ledger;
     use crate::cluster_info::Node;
     use crate::fullnode::Fullnode;
@@ -469,7 +469,7 @@ pub fn new_fullnode(ledger_name: &'static str) -> (Fullnode, NodeInfo, Keypair, 
     let node_info = node.info.clone();
 
     let (genesis_block, mint_keypair) = GenesisBlock::new_with_leader(10_000, node_info.id, 42);
-    let (ledger_path, _last_id) = create_new_tmp_ledger(ledger_name, &genesis_block).unwrap();
+    let (ledger_path, _last_id) = create_new_tmp_ledger!(&genesis_block).unwrap();
 
     let vote_account_keypair = Arc::new(Keypair::new());
     let voting_keypair = VotingKeypair::new_local(&vote_account_keypair);
@@ -498,7 +498,7 @@ mod tests {
     #[test]
     fn test_thin_client_basic() {
         solana_logger::setup();
-        let (server, leader_data, alice, ledger_path) = new_fullnode("test_thin_client_basic");
+        let (server, leader_data, alice, ledger_path) = new_fullnode();
         let server_exit = server.run(None);
         let bob_pubkey = Keypair::new().pubkey();
 
@@ -532,7 +532,7 @@ mod tests {
     #[ignore]
     fn test_bad_sig() {
         solana_logger::setup();
-        let (server, leader_data, alice, ledger_path) = new_fullnode("bad_sig");
+        let (server, leader_data, alice, ledger_path) = new_fullnode();
         let server_exit = server.run(None);
         let bob_pubkey = Keypair::new().pubkey();
         info!(
@@ -568,7 +568,7 @@ mod tests {
     #[test]
     fn test_register_vote_account() {
         solana_logger::setup();
-        let (server, leader_data, alice, ledger_path) = new_fullnode("test_register_vote_account");
+        let (server, leader_data, alice, ledger_path) = new_fullnode();
         let server_exit = server.run(None);
         info!(
             "found leader: {:?}",
@@ -637,8 +637,7 @@ mod tests {
     #[test]
     fn test_zero_balance_after_nonzero() {
         solana_logger::setup();
-        let (server, leader_data, alice, ledger_path) =
-            new_fullnode("test_zero_balance_after_nonzero");
+        let (server, leader_data, alice, ledger_path) = new_fullnode();
         let server_exit = server.run(None);
         let bob_keypair = Keypair::new();
 

--- a/tests/multinode.rs
+++ b/tests/multinode.rs
@@ -52,7 +52,7 @@ fn test_multi_node_ledger_window() -> result::Result<()> {
     let ticks_per_slot = genesis_block.ticks_per_slot;
     info!("ticks_per_slot: {}", ticks_per_slot);
 
-    let (leader_ledger_path, last_id) = create_new_tmp_ledger!(&genesis_block).unwrap();
+    let (leader_ledger_path, last_id) = create_new_tmp_ledger!(&genesis_block);
     ledger_paths.push(leader_ledger_path.clone());
 
     // make a copy at zero
@@ -152,7 +152,7 @@ fn test_multi_node_validator_catchup_from_zero() -> result::Result<()> {
     let mut ledger_paths = Vec::new();
 
     let (genesis_block, alice) = GenesisBlock::new_with_leader(10_000, leader_data.id, 500);
-    let (genesis_ledger_path, _last_id) = create_new_tmp_ledger!(&genesis_block).unwrap();
+    let (genesis_ledger_path, _last_id) = create_new_tmp_ledger!(&genesis_block);
     ledger_paths.push(genesis_ledger_path.clone());
 
     let zero_ledger_path = tmp_copy_blocktree!(&genesis_ledger_path);
@@ -328,7 +328,7 @@ fn test_multi_node_basic() {
 
     let (genesis_block, alice) = GenesisBlock::new_with_leader(10_000, leader_data.id, 500);
 
-    let (genesis_ledger_path, _last_id) = create_new_tmp_ledger!(&genesis_block).unwrap();
+    let (genesis_ledger_path, _last_id) = create_new_tmp_ledger!(&genesis_block);
     ledger_paths.push(genesis_ledger_path.clone());
 
     let leader_ledger_path = tmp_copy_blocktree!(&genesis_ledger_path);
@@ -429,7 +429,7 @@ fn test_boot_validator_from_file() {
     let mut ledger_paths = Vec::new();
 
     let (genesis_block, alice) = GenesisBlock::new_with_leader(100_000, leader_pubkey, 1000);
-    let (genesis_ledger_path, _last_id) = create_new_tmp_ledger!(&genesis_block).unwrap();
+    let (genesis_ledger_path, _last_id) = create_new_tmp_ledger!(&genesis_block);
     ledger_paths.push(genesis_ledger_path.clone());
 
     let leader_ledger_path = tmp_copy_blocktree!(&genesis_ledger_path);
@@ -541,11 +541,7 @@ fn test_leader_restart_validator_start_from_old_ledger() -> result::Result<()> {
         leader_keypair.pubkey(),
         initial_leader_balance,
     );
-    let (ledger_path, _last_id) = create_new_tmp_ledger(
-        "leader_restart_validator_start_from_old_ledger",
-        &genesis_block,
-    )
-    .unwrap();
+    let (ledger_path, _last_id) = create_new_tmp_ledger!(&genesis_block);
 
     let bob_pubkey = Keypair::new().pubkey();
 
@@ -653,7 +649,7 @@ fn test_multi_node_dynamic_network() {
     let bob_pubkey = Keypair::new().pubkey();
 
     let (genesis_block, alice) = GenesisBlock::new_with_leader(10_000_000, leader_pubkey, 500);
-    let (genesis_ledger_path, _last_id) = create_new_tmp_ledger!(&genesis_block).unwrap();
+    let (genesis_ledger_path, _last_id) = create_new_tmp_ledger!(&genesis_block);
 
     let mut ledger_paths = Vec::new();
     ledger_paths.push(genesis_ledger_path.clone());
@@ -866,7 +862,7 @@ fn test_leader_to_validator_transition() {
 
     // Initialize the leader ledger. Make a mint and a genesis entry
     // in the leader ledger
-    let (leader_ledger_path, last_id) = create_new_tmp_ledger!(&genesis_block).unwrap();
+    let (leader_ledger_path, last_id) = create_new_tmp_ledger!(&genesis_block);
 
     // Write the votes entries to the ledger that will cause leader rotation
     // to validator_keypair at slot 2
@@ -946,7 +942,7 @@ fn test_leader_validator_basic() {
     genesis_block.ticks_per_slot = ticks_per_slot;
 
     // Make a common mint and a genesis entry for both leader + validator ledgers
-    let (leader_ledger_path, last_id) = create_new_tmp_ledger!(&genesis_block).unwrap();
+    let (leader_ledger_path, last_id) = create_new_tmp_ledger!(&genesis_block);
 
     // Add validator vote on tick height 1
     {
@@ -1078,7 +1074,7 @@ fn test_dropped_handoff_recovery() {
     genesis_block.ticks_per_slot = ticks_per_slot;
 
     // Make a common mint and a genesis entry for both leader + validator's ledgers
-    let (genesis_ledger_path, last_id) = create_new_tmp_ledger!(&genesis_block).unwrap();
+    let (genesis_ledger_path, last_id) = create_new_tmp_ledger!(&genesis_block);
 
     // Create the validator keypair that will be the next leader in line
     let next_leader_keypair = Arc::new(Keypair::new());
@@ -1227,8 +1223,7 @@ fn test_full_leader_validator_network() {
     genesis_block.ticks_per_slot = ticks_per_slot;
 
     // Make a common mint and a genesis entry for both leader + validator's ledgers
-    let (bootstrap_leader_ledger_path, mut last_id) =
-        create_new_tmp_ledger!(&genesis_block).unwrap();
+    let (bootstrap_leader_ledger_path, mut last_id) = create_new_tmp_ledger!(&genesis_block);
 
     // Create a common ledger with entries in the beginnging that will add all the validators
     // to the active set for leader election.
@@ -1416,7 +1411,7 @@ fn test_broadcast_last_tick() {
     genesis_block.ticks_per_slot = ticks_per_slot;
 
     // Create leader ledger
-    let (bootstrap_leader_ledger_path, _last_id) = create_new_tmp_ledger!(&genesis_block).unwrap();
+    let (bootstrap_leader_ledger_path, _last_id) = create_new_tmp_ledger!(&genesis_block);
 
     let blob_receiver_exit = Arc::new(AtomicBool::new(false));
 
@@ -1608,7 +1603,7 @@ fn test_fullnode_rotate(
     genesis_block.slots_per_epoch = slots_per_epoch;
 
     // Make a common mint and a genesis entry for both leader + validator ledgers
-    let (leader_ledger_path, mut last_id) = create_new_tmp_ledger!(&genesis_block).unwrap();
+    let (leader_ledger_path, mut last_id) = create_new_tmp_ledger!(&genesis_block);
 
     let mut ledger_paths = Vec::new();
     ledger_paths.push(leader_ledger_path.clone());

--- a/tests/multinode.rs
+++ b/tests/multinode.rs
@@ -1617,7 +1617,7 @@ fn test_fullnode_rotate(
 
     let mut leader_slot_height_of_next_rotation = 1;
 
-    if fullnode_config.leader_scheduler_config.ticks_per_slot == 1 {
+    if ticks_per_slot == 1 {
         // Add another tick to the ledger if the cluster has been configured for 1 ticks_per_slot.
         // The "pseudo-tick" entry0 currently added by bank::process_ledger cannot be rotated on
         // since it has no last id (so at 1 ticks_per_slot rotation must start at a tick_height of

--- a/tests/multinode.rs
+++ b/tests/multinode.rs
@@ -52,8 +52,7 @@ fn test_multi_node_ledger_window() -> result::Result<()> {
     let ticks_per_slot = genesis_block.ticks_per_slot;
     info!("ticks_per_slot: {}", ticks_per_slot);
 
-    let (leader_ledger_path, last_id) =
-        create_new_tmp_ledger("multi_node_ledger_window", &genesis_block).unwrap();
+    let (leader_ledger_path, last_id) = create_new_tmp_ledger!(&genesis_block).unwrap();
     ledger_paths.push(leader_ledger_path.clone());
 
     // make a copy at zero
@@ -153,8 +152,7 @@ fn test_multi_node_validator_catchup_from_zero() -> result::Result<()> {
     let mut ledger_paths = Vec::new();
 
     let (genesis_block, alice) = GenesisBlock::new_with_leader(10_000, leader_data.id, 500);
-    let (genesis_ledger_path, _last_id) =
-        create_new_tmp_ledger("multi_node_validator_catchup_from_zero", &genesis_block).unwrap();
+    let (genesis_ledger_path, _last_id) = create_new_tmp_ledger!(&genesis_block).unwrap();
     ledger_paths.push(genesis_ledger_path.clone());
 
     let zero_ledger_path = tmp_copy_blocktree!(&genesis_ledger_path);
@@ -330,8 +328,7 @@ fn test_multi_node_basic() {
 
     let (genesis_block, alice) = GenesisBlock::new_with_leader(10_000, leader_data.id, 500);
 
-    let (genesis_ledger_path, _last_id) =
-        create_new_tmp_ledger("multi_node_basic", &genesis_block).unwrap();
+    let (genesis_ledger_path, _last_id) = create_new_tmp_ledger!(&genesis_block).unwrap();
     ledger_paths.push(genesis_ledger_path.clone());
 
     let leader_ledger_path = tmp_copy_blocktree!(&genesis_ledger_path);
@@ -432,8 +429,7 @@ fn test_boot_validator_from_file() {
     let mut ledger_paths = Vec::new();
 
     let (genesis_block, alice) = GenesisBlock::new_with_leader(100_000, leader_pubkey, 1000);
-    let (genesis_ledger_path, _last_id) =
-        create_new_tmp_ledger("boot_validator_from_file", &genesis_block).unwrap();
+    let (genesis_ledger_path, _last_id) = create_new_tmp_ledger!(&genesis_block).unwrap();
     ledger_paths.push(genesis_ledger_path.clone());
 
     let leader_ledger_path = tmp_copy_blocktree!(&genesis_ledger_path);
@@ -657,8 +653,7 @@ fn test_multi_node_dynamic_network() {
     let bob_pubkey = Keypair::new().pubkey();
 
     let (genesis_block, alice) = GenesisBlock::new_with_leader(10_000_000, leader_pubkey, 500);
-    let (genesis_ledger_path, _last_id) =
-        create_new_tmp_ledger("multi_node_dynamic_network", &genesis_block).unwrap();
+    let (genesis_ledger_path, _last_id) = create_new_tmp_ledger!(&genesis_block).unwrap();
 
     let mut ledger_paths = Vec::new();
     ledger_paths.push(genesis_ledger_path.clone());
@@ -871,8 +866,7 @@ fn test_leader_to_validator_transition() {
 
     // Initialize the leader ledger. Make a mint and a genesis entry
     // in the leader ledger
-    let (leader_ledger_path, last_id) =
-        create_new_tmp_ledger("test_leader_to_validator_transition", &genesis_block).unwrap();
+    let (leader_ledger_path, last_id) = create_new_tmp_ledger!(&genesis_block).unwrap();
 
     // Write the votes entries to the ledger that will cause leader rotation
     // to validator_keypair at slot 2
@@ -952,8 +946,7 @@ fn test_leader_validator_basic() {
     genesis_block.ticks_per_slot = ticks_per_slot;
 
     // Make a common mint and a genesis entry for both leader + validator ledgers
-    let (leader_ledger_path, last_id) =
-        create_new_tmp_ledger("test_leader_validator_basic", &genesis_block).unwrap();
+    let (leader_ledger_path, last_id) = create_new_tmp_ledger!(&genesis_block).unwrap();
 
     // Add validator vote on tick height 1
     {
@@ -1085,8 +1078,7 @@ fn test_dropped_handoff_recovery() {
     genesis_block.ticks_per_slot = ticks_per_slot;
 
     // Make a common mint and a genesis entry for both leader + validator's ledgers
-    let (genesis_ledger_path, last_id) =
-        create_new_tmp_ledger("test_dropped_handoff_recovery", &genesis_block).unwrap();
+    let (genesis_ledger_path, last_id) = create_new_tmp_ledger!(&genesis_block).unwrap();
 
     // Create the validator keypair that will be the next leader in line
     let next_leader_keypair = Arc::new(Keypair::new());
@@ -1236,7 +1228,7 @@ fn test_full_leader_validator_network() {
 
     // Make a common mint and a genesis entry for both leader + validator's ledgers
     let (bootstrap_leader_ledger_path, mut last_id) =
-        create_new_tmp_ledger("test_full_leader_validator_network", &genesis_block).unwrap();
+        create_new_tmp_ledger!(&genesis_block).unwrap();
 
     // Create a common ledger with entries in the beginnging that will add all the validators
     // to the active set for leader election.
@@ -1424,8 +1416,7 @@ fn test_broadcast_last_tick() {
     genesis_block.ticks_per_slot = ticks_per_slot;
 
     // Create leader ledger
-    let (bootstrap_leader_ledger_path, _last_id) =
-        create_new_tmp_ledger("test_broadcast_last_tick", &genesis_block).unwrap();
+    let (bootstrap_leader_ledger_path, _last_id) = create_new_tmp_ledger!(&genesis_block).unwrap();
 
     let blob_receiver_exit = Arc::new(AtomicBool::new(false));
 
@@ -1617,8 +1608,7 @@ fn test_fullnode_rotate(
     genesis_block.slots_per_epoch = slots_per_epoch;
 
     // Make a common mint and a genesis entry for both leader + validator ledgers
-    let (leader_ledger_path, mut last_id) =
-        create_new_tmp_ledger("test_fullnode_rotate", &genesis_block).unwrap();
+    let (leader_ledger_path, mut last_id) = create_new_tmp_ledger!(&genesis_block).unwrap();
 
     let mut ledger_paths = Vec::new();
     ledger_paths.push(leader_ledger_path.clone());

--- a/tests/replicator.rs
+++ b/tests/replicator.rs
@@ -42,13 +42,9 @@ fn test_replicator_startup_basic() {
     let leader_node = Node::new_localhost_with_pubkey(leader_keypair.pubkey());
     let leader_info = leader_node.info.clone();
 
-    let leader_ledger_path = "replicator_test_leader_ledger";
-
     let (genesis_block, mint_keypair) =
         GenesisBlock::new_with_leader(1_000_000_000, leader_info.id, 42);
-
-    let (leader_ledger_path, _last_id) =
-        create_new_tmp_ledger(leader_ledger_path, &genesis_block).unwrap();
+    let (leader_ledger_path, _last_id) = create_new_tmp_ledger!(&genesis_block);
 
     let validator_ledger_path = tmp_copy_blocktree!(&leader_ledger_path);
 
@@ -279,17 +275,13 @@ fn test_replicator_startup_ledger_hang() {
 
     let (genesis_block, _mint_keypair) =
         GenesisBlock::new_with_leader(100, leader_keypair.pubkey(), 42);
-    let (replicator_test_replicator_ledger, _last_id) =
-        create_new_tmp_ledger("replicator_test_replicator_ledger", &genesis_block).unwrap();
+    let (replicator_test_replicator_ledger, _last_id) = create_new_tmp_ledger!(&genesis_block);
 
     info!("starting leader node");
     let leader_node = Node::new_localhost_with_pubkey(leader_keypair.pubkey());
     let leader_info = leader_node.info.clone();
 
-    let leader_ledger_path = "replicator_test_leader_ledger";
-    let (leader_ledger_path, _last_id) =
-        create_new_tmp_ledger(leader_ledger_path, &genesis_block).unwrap();
-
+    let (leader_ledger_path, _last_id) = create_new_tmp_ledger!(&genesis_block);
     let validator_ledger_path = tmp_copy_blocktree!(&leader_ledger_path);
 
     {

--- a/tests/replicator.rs
+++ b/tests/replicator.rs
@@ -238,8 +238,7 @@ fn test_replicator_startup_leader_hang() {
 
     let leader_ledger_path = "replicator_test_leader_ledger";
     let (genesis_block, _mint_keypair) = GenesisBlock::new(10_000);
-    let (replicator_ledger_path, _tick_height, _last_entry_height, _last_id, _last_entry_id) =
-        create_tmp_sample_blocktree("replicator_test_replicator_ledger", &genesis_block, 0);
+    let (replicator_ledger_path, _last_id) = create_new_tmp_ledger!(&genesis_block);
 
     {
         let replicator_keypair = Keypair::new();
@@ -275,7 +274,7 @@ fn test_replicator_startup_ledger_hang() {
 
     let (genesis_block, _mint_keypair) =
         GenesisBlock::new_with_leader(100, leader_keypair.pubkey(), 42);
-    let (replicator_test_replicator_ledger, _last_id) = create_new_tmp_ledger!(&genesis_block);
+    let (replicator_ledger_path, _last_id) = create_new_tmp_ledger!(&genesis_block);
 
     info!("starting leader node");
     let leader_node = Node::new_localhost_with_pubkey(leader_keypair.pubkey());

--- a/tests/rpc.rs
+++ b/tests/rpc.rs
@@ -16,7 +16,7 @@ use std::time::Duration;
 fn test_rpc_send_tx() {
     solana_logger::setup();
 
-    let (server, leader_data, alice, ledger_path) = new_fullnode("test_rpc_send_tx");
+    let (server, leader_data, alice, ledger_path) = new_fullnode();
     let server_exit = server.run(None);
     let bob_pubkey = Keypair::new().pubkey();
 

--- a/wallet/tests/deploy.rs
+++ b/wallet/tests/deploy.rs
@@ -19,7 +19,7 @@ fn test_wallet_deploy_program() {
     pathbuf.push("noop");
     pathbuf.set_extension("so");
 
-    let (server, leader_data, alice, ledger_path) = new_fullnode("test_wallet_deploy_program");
+    let (server, leader_data, alice, ledger_path) = new_fullnode();
     let server_exit = server.run(None);
 
     let (sender, receiver) = channel();

--- a/wallet/tests/pay.rs
+++ b/wallet/tests/pay.rs
@@ -20,7 +20,7 @@ fn check_balance(expected_balance: u64, client: &RpcClient, pubkey: Pubkey) {
 
 #[test]
 fn test_wallet_timestamp_tx() {
-    let (server, leader_data, alice, ledger_path) = new_fullnode("test_wallet_timestamp_tx");
+    let (server, leader_data, alice, ledger_path) = new_fullnode();
     let server_exit = server.run(None);
     let bob_pubkey = Keypair::new().pubkey();
 
@@ -81,7 +81,7 @@ fn test_wallet_timestamp_tx() {
 
 #[test]
 fn test_wallet_witness_tx() {
-    let (server, leader_data, alice, ledger_path) = new_fullnode("test_wallet_witness_tx");
+    let (server, leader_data, alice, ledger_path) = new_fullnode();
     let server_exit = server.run(None);
     let bob_pubkey = Keypair::new().pubkey();
 
@@ -139,7 +139,7 @@ fn test_wallet_witness_tx() {
 
 #[test]
 fn test_wallet_cancel_tx() {
-    let (server, leader_data, alice, ledger_path) = new_fullnode("test_wallet_cancel_tx");
+    let (server, leader_data, alice, ledger_path) = new_fullnode();
     let server_exit = server.run(None);
     let bob_pubkey = Keypair::new().pubkey();
 

--- a/wallet/tests/request_airdrop.rs
+++ b/wallet/tests/request_airdrop.rs
@@ -8,7 +8,7 @@ use std::sync::mpsc::channel;
 
 #[test]
 fn test_wallet_request_airdrop() {
-    let (server, leader_data, alice, ledger_path) = new_fullnode("test_wallet_request_airdrop");
+    let (server, leader_data, alice, ledger_path) = new_fullnode();
     let server_exit = server.run(None);
     let (sender, receiver) = channel();
     run_local_drone(alice, sender);


### PR DESCRIPTION
The test changes needed for #2928 are quite large, and will work fine even without #2928 actually landed so I'm pulling these out into a separate PR and landing first to avoid rebase pain.

The changes here are to ensure tests always write out full ledger slots.  By doing so, we don't need to be concerned about ledger `last_entry_id`s in tests, since we can always use the `last_id`.   Slot-alignment should also be forward compatible for if/when we change `last_id` to be block based instead of tick based.

Funny story:  a couple long in the tooth `ignore`d replay_stage.rs tests looked at me funny while working on this patch so I deleted them for good measure.