### PR TITLE
Add/use get_tmp_ledger_path!() and tmp_copy_blocktree!()

### DIFF
--- a/benches/blocktree.rs
+++ b/benches/blocktree.rs
@@ -3,6 +3,9 @@ use rand;
 
 extern crate test;
 
+#[macro_use]
+extern crate solana;
+
 use rand::seq::SliceRandom;
 use rand::{thread_rng, Rng};
 use solana::blocktree::{get_tmp_ledger_path, Blocktree};
@@ -62,7 +65,7 @@ fn setup_read_bench(
 #[bench]
 #[ignore]
 fn bench_write_small(bench: &mut Bencher) {
-    let ledger_path = get_tmp_ledger_path("bench_write_small");
+    let ledger_path = get_tmp_ledger_path!();
     let num_entries = 32 * 1024;
     let entries = make_tiny_test_entries(num_entries);
     let mut blobs = entries.to_blobs();
@@ -76,7 +79,7 @@ fn bench_write_small(bench: &mut Bencher) {
 #[bench]
 #[ignore]
 fn bench_write_big(bench: &mut Bencher) {
-    let ledger_path = get_tmp_ledger_path("bench_write_big");
+    let ledger_path = get_tmp_ledger_path!();
     let num_entries = 32 * 1024;
     let entries = make_large_test_entries(num_entries);
     let mut blobs = entries.to_blobs();
@@ -90,7 +93,7 @@ fn bench_write_big(bench: &mut Bencher) {
 #[bench]
 #[ignore]
 fn bench_read_sequential(bench: &mut Bencher) {
-    let ledger_path = get_tmp_ledger_path("bench_read_sequential");
+    let ledger_path = get_tmp_ledger_path!();
     let mut blocktree =
         Blocktree::open(&ledger_path).expect("Expected to be able to open database ledger");
 
@@ -117,7 +120,7 @@ fn bench_read_sequential(bench: &mut Bencher) {
 #[bench]
 #[ignore]
 fn bench_read_random(bench: &mut Bencher) {
-    let ledger_path = get_tmp_ledger_path("bench_read_random");
+    let ledger_path = get_tmp_ledger_path!();
     let mut blocktree =
         Blocktree::open(&ledger_path).expect("Expected to be able to open database ledger");
 
@@ -148,7 +151,7 @@ fn bench_read_random(bench: &mut Bencher) {
 #[bench]
 #[ignore]
 fn bench_insert_data_blob_small(bench: &mut Bencher) {
-    let ledger_path = get_tmp_ledger_path("bench_insert_data_blob_small");
+    let ledger_path = get_tmp_ledger_path!();
     let blocktree =
         Blocktree::open(&ledger_path).expect("Expected to be able to open database ledger");
     let num_entries = 32 * 1024;
@@ -171,7 +174,7 @@ fn bench_insert_data_blob_small(bench: &mut Bencher) {
 #[bench]
 #[ignore]
 fn bench_insert_data_blob_big(bench: &mut Bencher) {
-    let ledger_path = get_tmp_ledger_path("bench_insert_data_blob_big");
+    let ledger_path = get_tmp_ledger_path!();
     let blocktree =
         Blocktree::open(&ledger_path).expect("Expected to be able to open database ledger");
     let num_entries = 32 * 1024;

--- a/src/blocktree.rs
+++ b/src/blocktree.rs
@@ -1279,12 +1279,26 @@ where
     Ok(())
 }
 
+#[macro_export]
+macro_rules! tmp_ledger_name {
+    () => {
+        &format!("{}-{}", file!(), line!())
+    };
+}
+
+#[macro_export]
+macro_rules! get_tmp_ledger_path {
+    () => {
+        get_tmp_ledger_path(tmp_ledger_name!())
+    };
+}
+
 pub fn get_tmp_ledger_path(name: &str) -> String {
     use std::env;
     let out_dir = env::var("OUT_DIR").unwrap_or_else(|_| "target".to_string());
     let keypair = Keypair::new();
 
-    let path = format!("{}/tmp/ledger-{}-{}", out_dir, name, keypair.pubkey());
+    let path = format!("{}/tmp/ledger/{}-{}", out_dir, name, keypair.pubkey());
 
     // whack any possible collision
     let _ignored = fs::remove_dir_all(&path);
@@ -1325,6 +1339,13 @@ pub fn create_tmp_sample_blocktree(
     )
 }
 
+#[macro_export]
+macro_rules! tmp_copy_blocktree {
+    ($from:expr) => {
+        tmp_copy_blocktree($from, tmp_ledger_name!())
+    };
+}
+
 pub fn tmp_copy_blocktree(from: &str, name: &str) -> String {
     let path = get_tmp_ledger_path(name);
 
@@ -1357,7 +1378,8 @@ pub mod tests {
 
     #[test]
     fn test_write_entries() {
-        let ledger_path = get_tmp_ledger_path("test_write_entries");
+        solana_logger::setup();
+        let ledger_path = get_tmp_ledger_path!();
         {
             let ticks_per_slot = 10;
             let num_slots = 10;

--- a/src/broadcast_service.rs
+++ b/src/broadcast_service.rs
@@ -276,8 +276,7 @@ impl Service for BroadcastService {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::blocktree::get_tmp_ledger_path;
-    use crate::blocktree::Blocktree;
+    use crate::blocktree::{get_tmp_ledger_path, Blocktree};
     use crate::cluster_info::{ClusterInfo, Node};
     use crate::entry::create_ticks;
     use crate::leader_scheduler::LeaderScheduler;

--- a/src/cluster_info.rs
+++ b/src/cluster_info.rs
@@ -1562,7 +1562,7 @@ mod tests {
     #[test]
     fn run_window_request() {
         solana_logger::setup();
-        let ledger_path = get_tmp_ledger_path("run_window_request");
+        let ledger_path = get_tmp_ledger_path!();
         {
             let blocktree = Arc::new(Blocktree::open(&ledger_path).unwrap());
             let me = NodeInfo::new(
@@ -1620,7 +1620,7 @@ mod tests {
     #[test]
     fn run_highest_window_request() {
         solana_logger::setup();
-        let ledger_path = get_tmp_ledger_path("run_highest_window_request");
+        let ledger_path = get_tmp_ledger_path!();
         {
             let blocktree = Arc::new(Blocktree::open(&ledger_path).unwrap());
             let rv =

--- a/src/db_window.rs
+++ b/src/db_window.rs
@@ -246,7 +246,7 @@ mod test {
     pub fn test_find_missing_data_indexes_sanity() {
         let slot = 0;
 
-        let blocktree_path = get_tmp_ledger_path("test_find_missing_data_indexes_sanity");
+        let blocktree_path = get_tmp_ledger_path!();
         let blocktree = Blocktree::open(&blocktree_path).unwrap();
 
         // Early exit conditions
@@ -290,7 +290,7 @@ mod test {
     #[test]
     pub fn test_find_missing_data_indexes() {
         let slot = 0;
-        let blocktree_path = get_tmp_ledger_path("test_find_missing_data_indexes");
+        let blocktree_path = get_tmp_ledger_path!();
         let blocktree = Blocktree::open(&blocktree_path).unwrap();
 
         // Write entries
@@ -373,7 +373,7 @@ mod test {
 
     #[test]
     pub fn test_find_missing_data_indexes_slots() {
-        let blocktree_path = get_tmp_ledger_path("test_find_missing_data_indexes_slots");
+        let blocktree_path = get_tmp_ledger_path!();
         let blocktree = Blocktree::open(&blocktree_path).unwrap();
 
         let num_entries_per_slot = 10;
@@ -442,7 +442,7 @@ mod test {
     #[test]
     pub fn test_no_missing_blob_indexes() {
         let slot = 0;
-        let blocktree_path = get_tmp_ledger_path("test_find_missing_data_indexes");
+        let blocktree_path = get_tmp_ledger_path!();
         let blocktree = Blocktree::open(&blocktree_path).unwrap();
 
         // Write entries
@@ -491,7 +491,7 @@ mod test {
         window[erased_index].coding = None;
 
         // Generate the blocktree from the window
-        let ledger_path = get_tmp_ledger_path("test_try_erasure");
+        let ledger_path = get_tmp_ledger_path!();
         let blocktree = Arc::new(generate_blocktree_from_window(&ledger_path, &window, false));
 
         try_erasure(&blocktree, 0).expect("Expected successful erasure attempt");
@@ -536,7 +536,7 @@ mod test {
         let mut leader_scheduler = LeaderScheduler::default();
         leader_scheduler.set_leader_schedule(vec![Keypair::new().pubkey()]);
 
-        let blocktree_path = get_tmp_ledger_path("test_process_blob");
+        let blocktree_path = get_tmp_ledger_path!();
         let blocktree = Arc::new(Blocktree::open(&blocktree_path).unwrap());
 
         let leader_scheduler = Arc::new(RwLock::new(leader_scheduler));

--- a/src/erasure.rs
+++ b/src/erasure.rs
@@ -960,7 +960,7 @@ pub mod test {
         window[erase_offset].data = None;
 
         // Generate the blocktree from the window
-        let ledger_path = get_tmp_ledger_path("test_window_recover_basic");
+        let ledger_path = get_tmp_ledger_path!();
         let blocktree = Arc::new(generate_blocktree_from_window(&ledger_path, &window, true));
 
         // Recover it from coding
@@ -1009,7 +1009,7 @@ pub mod test {
         let refwindowcoding = window[erase_offset].coding.clone();
         window[erase_offset].data = None;
         window[erase_offset].coding = None;
-        let ledger_path = get_tmp_ledger_path("test_window_recover_basic2");
+        let ledger_path = get_tmp_ledger_path!();
         let blocktree = Arc::new(generate_blocktree_from_window(&ledger_path, &window, true));
 
         // Recover it from coding

--- a/src/fullnode.rs
+++ b/src/fullnode.rs
@@ -627,8 +627,7 @@ mod tests {
             );
         let bootstrap_leader_info = bootstrap_leader_node.info.clone();
 
-        let validator_ledger_path =
-            tmp_copy_blocktree(&bootstrap_leader_ledger_path, "test_wrong_role_transition");
+        let validator_ledger_path = tmp_copy_blocktree!(&bootstrap_leader_ledger_path);
 
         let ledger_paths = vec![
             bootstrap_leader_ledger_path.clone(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,7 @@ pub mod crds_value;
 pub mod contact_info;
 pub mod blockstream;
 pub mod blockstream_service;
+#[macro_use]
 pub mod blocktree;
 pub mod blocktree_processor;
 pub mod cluster_info;

--- a/src/repair_service.rs
+++ b/src/repair_service.rs
@@ -210,7 +210,7 @@ mod test {
 
     #[test]
     pub fn test_repair_missed_future_slot() {
-        let blocktree_path = get_tmp_ledger_path("test_repair_missed_future_slot");
+        let blocktree_path = get_tmp_ledger_path!();
         {
             let blocktree = Blocktree::open(&blocktree_path).unwrap();
 
@@ -259,7 +259,7 @@ mod test {
 
     #[test]
     pub fn test_repair_empty_slot() {
-        let blocktree_path = get_tmp_ledger_path("test_repair_empty_slot");
+        let blocktree_path = get_tmp_ledger_path!();
         {
             let blocktree = Blocktree::open(&blocktree_path).unwrap();
 
@@ -283,7 +283,7 @@ mod test {
 
     #[test]
     pub fn test_generate_repairs() {
-        let blocktree_path = get_tmp_ledger_path("test_generate_repairs");
+        let blocktree_path = get_tmp_ledger_path!();
         {
             let blocktree = Blocktree::open(&blocktree_path).unwrap();
 
@@ -332,7 +332,7 @@ mod test {
 
     #[test]
     pub fn test_generate_highest_repair() {
-        let blocktree_path = get_tmp_ledger_path("test_generate_repairs");
+        let blocktree_path = get_tmp_ledger_path!();
         {
             let blocktree = Blocktree::open(&blocktree_path).unwrap();
 

--- a/src/tvu.rs
+++ b/src/tvu.rs
@@ -235,7 +235,7 @@ pub mod tests {
         cluster_info1.set_leader(leader.info.id);
         let cref1 = Arc::new(RwLock::new(cluster_info1));
 
-        let blocktree_path = get_tmp_ledger_path("test_tvu_exit");
+        let blocktree_path = get_tmp_ledger_path!();
         let (blocktree, l_receiver) = Blocktree::open_with_signal(&blocktree_path)
             .expect("Expected to successfully open ledger");
         let (sender, _receiver) = channel();

--- a/src/window_service.rs
+++ b/src/window_service.rs
@@ -190,7 +190,7 @@ mod test {
         let t_receiver =
             blob_receiver(Arc::new(leader_node.sockets.gossip), exit.clone(), s_reader);
         let (s_retransmit, r_retransmit) = channel();
-        let blocktree_path = get_tmp_ledger_path("window_send_test");
+        let blocktree_path = get_tmp_ledger_path!();
         let blocktree = Arc::new(
             Blocktree::open(&blocktree_path).expect("Expected to be able to open database ledger"),
         );
@@ -260,7 +260,7 @@ mod test {
         let t_receiver =
             blob_receiver(Arc::new(leader_node.sockets.gossip), exit.clone(), s_reader);
         let (s_retransmit, r_retransmit) = channel();
-        let blocktree_path = get_tmp_ledger_path("window_send_late_leader_test");
+        let blocktree_path = get_tmp_ledger_path!();
         let blocktree = Arc::new(
             Blocktree::open(&blocktree_path).expect("Expected to be able to open database ledger"),
         );

--- a/tests/multinode.rs
+++ b/tests/multinode.rs
@@ -1,3 +1,6 @@
+#[macro_use]
+extern crate solana;
+
 use log::*;
 use solana::blob_fetch_stage::BlobFetchStage;
 use solana::blocktree::{create_tmp_sample_blocktree, tmp_copy_blocktree, Blocktree};
@@ -54,7 +57,7 @@ fn test_multi_node_ledger_window() -> result::Result<()> {
     ledger_paths.push(leader_ledger_path.clone());
 
     // make a copy at zero
-    let zero_ledger_path = tmp_copy_blocktree(&leader_ledger_path, "multi_node_ledger_window");
+    let zero_ledger_path = tmp_copy_blocktree!(&leader_ledger_path);
     ledger_paths.push(zero_ledger_path.clone());
 
     // Write some into leader's ledger, this should populate the leader's window
@@ -170,16 +173,10 @@ fn test_multi_node_validator_catchup_from_zero() -> result::Result<()> {
         create_tmp_sample_blocktree("multi_node_validator_catchup_from_zero", &genesis_block, 0);
     ledger_paths.push(genesis_ledger_path.clone());
 
-    let zero_ledger_path = tmp_copy_blocktree(
-        &genesis_ledger_path,
-        "multi_node_validator_catchup_from_zero",
-    );
+    let zero_ledger_path = tmp_copy_blocktree!(&genesis_ledger_path);
     ledger_paths.push(zero_ledger_path.clone());
 
-    let leader_ledger_path = tmp_copy_blocktree(
-        &genesis_ledger_path,
-        "multi_node_validator_catchup_from_zero",
-    );
+    let leader_ledger_path = tmp_copy_blocktree!(&genesis_ledger_path);
     ledger_paths.push(leader_ledger_path.clone());
     let fullnode_config = FullnodeConfig::default();
     let voting_keypair = VotingKeypair::new_local(&leader_keypair);
@@ -197,10 +194,7 @@ fn test_multi_node_validator_catchup_from_zero() -> result::Result<()> {
         let keypair = Arc::new(Keypair::new());
         let validator_pubkey = keypair.pubkey().clone();
         let validator = Node::new_localhost_with_pubkey(keypair.pubkey());
-        let ledger_path = tmp_copy_blocktree(
-            &genesis_ledger_path,
-            "multi_node_validator_catchup_from_zero_validator",
-        );
+        let ledger_path = tmp_copy_blocktree!(&genesis_ledger_path);
         ledger_paths.push(ledger_path.clone());
 
         // Send each validator some tokens to vote
@@ -356,7 +350,7 @@ fn test_multi_node_basic() {
         create_tmp_sample_blocktree("multi_node_basic", &genesis_block, 0);
     ledger_paths.push(genesis_ledger_path.clone());
 
-    let leader_ledger_path = tmp_copy_blocktree(&genesis_ledger_path, "multi_node_basic");
+    let leader_ledger_path = tmp_copy_blocktree!(&genesis_ledger_path);
     ledger_paths.push(leader_ledger_path.clone());
 
     let fullnode_config = FullnodeConfig::default();
@@ -375,7 +369,7 @@ fn test_multi_node_basic() {
         let keypair = Arc::new(Keypair::new());
         let validator_pubkey = keypair.pubkey().clone();
         let validator = Node::new_localhost_with_pubkey(keypair.pubkey());
-        let ledger_path = tmp_copy_blocktree(&genesis_ledger_path, "multi_node_basic");
+        let ledger_path = tmp_copy_blocktree!(&genesis_ledger_path);
         ledger_paths.push(ledger_path.clone());
 
         // Send each validator some tokens to vote
@@ -459,7 +453,7 @@ fn test_boot_validator_from_file() {
         create_tmp_sample_blocktree("boot_validator_from_file", &genesis_block, 0);
     ledger_paths.push(genesis_ledger_path.clone());
 
-    let leader_ledger_path = tmp_copy_blocktree(&genesis_ledger_path, "boot_validator_from_file");
+    let leader_ledger_path = tmp_copy_blocktree!(&genesis_ledger_path);
     ledger_paths.push(leader_ledger_path.clone());
 
     let leader_data = leader.info.clone();
@@ -487,7 +481,7 @@ fn test_boot_validator_from_file() {
     let keypair = Arc::new(Keypair::new());
     let validator = Node::new_localhost_with_pubkey(keypair.pubkey());
     let validator_data = validator.info.clone();
-    let ledger_path = tmp_copy_blocktree(&genesis_ledger_path, "boot_validator_from_file");
+    let ledger_path = tmp_copy_blocktree!(&genesis_ledger_path);
     ledger_paths.push(ledger_path.clone());
     let voting_keypair = VotingKeypair::new_local(&keypair);
     let val_fullnode = Fullnode::new(
@@ -596,10 +590,7 @@ fn test_leader_restart_validator_start_from_old_ledger() -> result::Result<()> {
     }
 
     // Create a "stale" ledger by copying current ledger where bob only has 500 tokens
-    let stale_ledger_path = tmp_copy_blocktree(
-        &ledger_path,
-        "leader_restart_validator_start_from_old_ledger",
-    );
+    let stale_ledger_path = tmp_copy_blocktree!(&ledger_path);
 
     {
         let voting_keypair = VotingKeypair::new_local(&leader_keypair);
@@ -692,7 +683,7 @@ fn test_multi_node_dynamic_network() {
     let mut ledger_paths = Vec::new();
     ledger_paths.push(genesis_ledger_path.clone());
 
-    let leader_ledger_path = tmp_copy_blocktree(&genesis_ledger_path, "multi_node_dynamic_network");
+    let leader_ledger_path = tmp_copy_blocktree!(&genesis_ledger_path);
 
     let alice_arc = Arc::new(RwLock::new(alice));
     let leader_data = leader.info.clone();
@@ -762,8 +753,7 @@ fn test_multi_node_dynamic_network() {
         .into_iter()
         .map(|keypair| {
             let leader_data = leader_data.clone();
-            let ledger_path =
-                tmp_copy_blocktree(&genesis_ledger_path, "multi_node_dynamic_network");
+            let ledger_path = tmp_copy_blocktree!(&genesis_ledger_path);
             ledger_paths.push(ledger_path.clone());
             Builder::new()
                 .name("validator-launch-thread".to_string())
@@ -1030,8 +1020,7 @@ fn test_leader_validator_basic() {
     // Initialize both leader + validator ledger
     let mut ledger_paths = Vec::new();
     ledger_paths.push(leader_ledger_path.clone());
-    let validator_ledger_path =
-        tmp_copy_blocktree(&leader_ledger_path, "test_leader_validator_basic");
+    let validator_ledger_path = tmp_copy_blocktree!(&leader_ledger_path);
     ledger_paths.push(validator_ledger_path.clone());
 
     // Start the validator node
@@ -1177,8 +1166,7 @@ fn test_dropped_handoff_recovery() {
             .unwrap();
     }
 
-    let next_leader_ledger_path =
-        tmp_copy_blocktree(&genesis_ledger_path, "test_dropped_handoff_recovery");
+    let next_leader_ledger_path = tmp_copy_blocktree!(&genesis_ledger_path);
     ledger_paths.push(next_leader_ledger_path.clone());
 
     info!("bootstrap_leader: {}", bootstrap_leader_keypair.pubkey());
@@ -1186,8 +1174,7 @@ fn test_dropped_handoff_recovery() {
 
     let voting_keypair = VotingKeypair::new_local(&bootstrap_leader_keypair);
     // Start up the bootstrap leader fullnode
-    let bootstrap_leader_ledger_path =
-        tmp_copy_blocktree(&genesis_ledger_path, "test_dropped_handoff_recovery");
+    let bootstrap_leader_ledger_path = tmp_copy_blocktree!(&genesis_ledger_path);
     ledger_paths.push(bootstrap_leader_ledger_path.clone());
 
     let bootstrap_leader = Fullnode::new(
@@ -1205,8 +1192,7 @@ fn test_dropped_handoff_recovery() {
     // Start up the validators other than the "next_leader" validator
     for i in 0..(N - 1) {
         let keypair = Arc::new(Keypair::new());
-        let validator_ledger_path =
-            tmp_copy_blocktree(&genesis_ledger_path, "test_dropped_handoff_recovery");
+        let validator_ledger_path = tmp_copy_blocktree!(&genesis_ledger_path);
         ledger_paths.push(validator_ledger_path.clone());
         let validator_id = keypair.pubkey();
         info!("validator {}: {}", i, validator_id);
@@ -1350,10 +1336,7 @@ fn test_full_leader_validator_network() {
     info!("Start up the validators");
     // Start up the validators
     for kp in node_keypairs.into_iter() {
-        let validator_ledger_path = tmp_copy_blocktree(
-            &bootstrap_leader_ledger_path,
-            "test_full_leader_validator_network",
-        );
+        let validator_ledger_path = tmp_copy_blocktree!(&bootstrap_leader_ledger_path);
 
         ledger_paths.push(validator_ledger_path.clone());
 
@@ -1781,7 +1764,7 @@ fn test_fullnode_rotate(
 
     let (validator_rotation_sender, validator_rotation_receiver) = channel();
     if include_validator {
-        let validator_ledger_path = tmp_copy_blocktree(&leader_ledger_path, "test_fullnode_rotate");
+        let validator_ledger_path = tmp_copy_blocktree!(&leader_ledger_path);
         ledger_paths.push(validator_ledger_path.clone());
         let validator_fullnode = Fullnode::new(
             validator,

--- a/tests/replicator.rs
+++ b/tests/replicator.rs
@@ -5,6 +5,9 @@ extern crate log;
 #[macro_use]
 extern crate serde_json;
 
+#[macro_use]
+extern crate solana;
+
 use bincode::deserialize;
 use solana::blocktree::{
     create_tmp_sample_blocktree, get_tmp_ledger_path, tmp_copy_blocktree, Blocktree,
@@ -32,7 +35,7 @@ use std::time::Duration;
 fn test_replicator_startup_basic() {
     solana_logger::setup();
     info!("starting replicator test");
-    let replicator_ledger_path = &get_tmp_ledger_path("replicator_test_replicator_ledger");
+    let replicator_ledger_path = &get_tmp_ledger_path!();
 
     info!("starting leader node");
     let leader_keypair = Arc::new(Keypair::new());
@@ -47,8 +50,7 @@ fn test_replicator_startup_basic() {
     let (leader_ledger_path, _tick_height, _last_entry_height, _last_id, _last_entry_id) =
         create_tmp_sample_blocktree(leader_ledger_path, &genesis_block, 0);
 
-    let validator_ledger_path =
-        tmp_copy_blocktree(&leader_ledger_path, "replicator_test_validator_ledger");
+    let validator_ledger_path = tmp_copy_blocktree!(&leader_ledger_path);
 
     {
         let voting_keypair = VotingKeypair::new_local(&leader_keypair);
@@ -238,7 +240,7 @@ fn test_replicator_startup_leader_hang() {
     solana_logger::setup();
     info!("starting replicator test");
 
-    let replicator_ledger_path = &get_tmp_ledger_path("replicator_test_replicator_ledger");
+    let replicator_ledger_path = &get_tmp_ledger_path!();
     let leader_ledger_path = "replicator_test_leader_ledger";
 
     {
@@ -273,7 +275,7 @@ fn test_replicator_startup_ledger_hang() {
 
     solana_logger::setup();
     info!("starting replicator test");
-    let replicator_ledger_path = &get_tmp_ledger_path("replicator_test_replicator_ledger");
+    let replicator_ledger_path = &get_tmp_ledger_path!();
 
     info!("starting leader node");
     let leader_keypair = Arc::new(Keypair::new());
@@ -285,8 +287,7 @@ fn test_replicator_startup_ledger_hang() {
     let (leader_ledger_path, _tick_height, _last_entry_height, _last_id, _last_entry_id) =
         create_tmp_sample_blocktree(leader_ledger_path, &genesis_block, 0);
 
-    let validator_ledger_path =
-        tmp_copy_blocktree(&leader_ledger_path, "replicator_test_validator_ledger");
+    let validator_ledger_path = tmp_copy_blocktree!(&leader_ledger_path);
 
     {
         let voting_keypair = VotingKeypair::new_local(&leader_keypair);

--- a/tests/tvu.rs
+++ b/tests/tvu.rs
@@ -1,3 +1,6 @@
+#[macro_use]
+extern crate solana;
+
 use log::trace;
 use solana::bank_forks::BankForks;
 use solana::blocktree::{get_tmp_ledger_path, Blocktree};
@@ -104,7 +107,7 @@ fn test_replay() {
     let cref1 = Arc::new(RwLock::new(cluster_info1));
     let dr_1 = new_gossip(cref1.clone(), target1.sockets.gossip, exit.clone());
 
-    let blocktree_path = get_tmp_ledger_path("test_replay");
+    let blocktree_path = get_tmp_ledger_path!();
 
     let (blocktree, ledger_signal_receiver) =
         Blocktree::open_with_config_signal(&blocktree_path, ticks_per_slot)


### PR DESCRIPTION
Users of `get_tmp_ledger_path()` and `tmp_copy_blocktree()` were forced to supply and maintain a name for their temporary ledger, how inconvenient!  We now have macro equivalents that instead derive that name using the file/line number of the call site.

Note: `create_tmp_sample_blocktree()` will get this treatment as well, after #2963 lands