### PR TITLE
Update rust-bpf-sysroot to pull in latest core,stdsimd

### DIFF
--- a/sdk/bpf/scripts/install.sh
+++ b/sdk/bpf/scripts/install.sh
@@ -88,7 +88,7 @@ if [[ ! -f rust-bpf-$machine-$version.md ]]; then
 fi
 
 # Install Rust-BPF Sysroot
-version=v0.0.1
+version=v0.0.2
 if [[ ! -f rust-bpf-sysroot-$version.md ]]; then
   (
     filename=solana-rust-bpf-sysroot.tar.bz2


### PR DESCRIPTION
#### Problem

Libcore and stdsimd were outdated and behind the version used by the version of Rust used to build BPF modules.  This was causing warnings and in general, is not advisable.

#### Summary of Changes

Sync the versions of libcore and stdsimd between BPF's sysroot and the Rust BPF compiler.

Fixes #
