### PR TITLE
Add get_supermajority_slot() function

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -304,33 +304,6 @@ impl Bank {
         last_ids.get_confirmation_timestamp(ticks_and_stakes, supermajority_stake)
     }
 
-    pub fn stakes_and_lockouts(&self) -> Vec<(u64, Option<u64>)> {
-        let vote_states: Vec<_> = self.vote_states(|_| true);
-        vote_states
-            .into_iter()
-            .filter_map(|state| {
-                let stake = self.get_balance(&state.staker_id);
-                if stake > 0 {
-                    Some((stake, state.root_slot))
-                } else {
-                    None
-                }
-            })
-            .collect()
-    }
-
-    /// Looks through vote accounts, and finds the latest slot that has achieved
-    /// supermajority lockout
-    pub fn get_supermajority_slot(&self) -> Option<u64> {
-        // Find the amount of stake needed for supermajority
-        let stakes_and_lockouts = self.stakes_and_lockouts();
-        let total_stake: u64 = stakes_and_lockouts.iter().map(|s| s.0).sum();
-        let supermajority_stake = total_stake * 2 / 3;
-
-        // Filter out the states that don't have a max lockout
-        Self::find_supermajority_slot(supermajority_stake, &stakes_and_lockouts)
-    }
-
     /// Tell the bank which Entry IDs exist on the ledger. This function
     /// assumes subsequent calls correspond to later entries, and will boot
     /// the oldest ones once its internal cache is full. Once boot, the
@@ -376,31 +349,6 @@ impl Bank {
 
     pub fn unlock_accounts(&self, txs: &[Transaction], results: &[Result<()>]) {
         self.accounts().unlock_accounts(self.id, txs, results)
-    }
-
-    fn find_supermajority_slot(
-        supermajority_stake: u64,
-        stakes_and_lockouts: &[(u64, Option<u64>)],
-    ) -> Option<u64> {
-        // Filter out the states that don't have a max lockout
-        let mut stakes_and_lockouts: Vec<_> = stakes_and_lockouts
-            .iter()
-            .filter_map(|(stake, slot)| slot.map(|s| (stake, s)))
-            .collect();
-
-        // Sort by the root slot, in descending order
-        stakes_and_lockouts.sort_unstable_by(|s1, s2| s1.1.cmp(&s2.1).reverse());
-
-        // Find if any slot has achieved sufficient votes for supermajority lockout
-        let mut total = 0;
-        for (stake, slot) in stakes_and_lockouts {
-            total += stake;
-            if total > supermajority_stake {
-                return Some(slot);
-            }
-        }
-
-        None
     }
 
     fn load_accounts(
@@ -840,8 +788,6 @@ mod tests {
     use solana_sdk::system_instruction::SystemInstruction;
     use solana_sdk::system_transaction::SystemTransaction;
     use solana_sdk::transaction::Instruction;
-    use solana_sdk::vote_transaction::VoteTransaction;
-    use std::iter::FromIterator;
 
     #[test]
     fn test_bank_new() {
@@ -1521,111 +1467,5 @@ mod tests {
         let bank = Bank::new_from_parent(&parent);
         bank.squash();
         assert_eq!(parent.get_balance(&key1.pubkey()), 1);
-    }
-
-    #[test]
-    fn test_stakes_and_lockouts() {
-        let validator = Keypair::new();
-        let voter = Keypair::new();
-
-        let (genesis_block, mint_keypair) = GenesisBlock::new(500);
-        let bank = Bank::new(&genesis_block);
-        let bank_voter = Keypair::new();
-
-        // Give the validator some stake
-        bank.transfer(
-            1,
-            &mint_keypair,
-            validator.pubkey(),
-            genesis_block.last_id(),
-        )
-        .unwrap();
-
-        new_vote_account_with_vote(&validator, &voter, &bank, 1, 0);
-        assert_eq!(bank.get_balance(&validator.pubkey()), 0);
-        // Validator has zero balance, so they get filtered out.Only the bootstrap leader
-        // created by the genesis block will get included
-        assert_eq!(bank.stakes_and_lockouts(), vec![(1, None)]);
-
-        new_vote_account_with_vote(&mint_keypair, &bank_voter, &bank, 1, 0);
-
-        let result: HashSet<_> = HashSet::from_iter(bank.stakes_and_lockouts().iter().cloned());
-        let expected: HashSet<_> = HashSet::from_iter(vec![(1, None), (498, None)]);
-        assert_eq!(result, expected);
-    }
-
-    #[test]
-    fn test_find_supermajority_slot() {
-        let supermajority = 10;
-
-        let stakes_and_slots = vec![];
-        assert_eq!(
-            Bank::find_supermajority_slot(supermajority, &stakes_and_slots),
-            None
-        );
-
-        let stakes_and_slots = vec![(5, None), (5, None)];
-        assert_eq!(
-            Bank::find_supermajority_slot(supermajority, &stakes_and_slots),
-            None
-        );
-
-        let stakes_and_slots = vec![(5, None), (5, None), (9, Some(2))];
-        assert_eq!(
-            Bank::find_supermajority_slot(supermajority, &stakes_and_slots),
-            None
-        );
-
-        let stakes_and_slots = vec![(5, None), (5, None), (9, Some(2)), (1, Some(3))];
-        assert_eq!(
-            Bank::find_supermajority_slot(supermajority, &stakes_and_slots),
-            None
-        );
-
-        let stakes_and_slots = vec![(5, None), (5, None), (9, Some(2)), (2, Some(3))];
-        assert_eq!(
-            Bank::find_supermajority_slot(supermajority, &stakes_and_slots),
-            Some(2)
-        );
-
-        let stakes_and_slots = vec![(9, Some(2)), (2, Some(3)), (9, None)];
-        assert_eq!(
-            Bank::find_supermajority_slot(supermajority, &stakes_and_slots),
-            Some(2)
-        );
-
-        let stakes_and_slots = vec![(9, Some(2)), (2, Some(3)), (9, Some(3))];
-        assert_eq!(
-            Bank::find_supermajority_slot(supermajority, &stakes_and_slots),
-            Some(3)
-        );
-    }
-
-    pub fn new_vote_account(
-        from_keypair: &Keypair,
-        voting_pubkey: &Pubkey,
-        bank: &Bank,
-        num_tokens: u64,
-    ) {
-        let last_id = bank.last_id();
-        let tx = VoteTransaction::new_account(from_keypair, *voting_pubkey, last_id, num_tokens, 0);
-        bank.process_transaction(&tx).unwrap();
-    }
-
-    pub fn push_vote<T: KeypairUtil>(voting_keypair: &T, bank: &Bank, slot_height: u64) {
-        let last_id = bank.last_id();
-        let tx = VoteTransaction::new_vote(voting_keypair, slot_height, last_id, 0);
-        bank.process_transaction(&tx).unwrap();
-    }
-
-    pub fn new_vote_account_with_vote<T: KeypairUtil>(
-        from_keypair: &Keypair,
-        voting_keypair: &T,
-        bank: &Bank,
-        num_tokens: u64,
-        slot_height: u64,
-    ) {
-        new_vote_account(from_keypair, &voting_keypair.pubkey(), bank, num_tokens);
-        push_vote(voting_keypair, bank, slot_height);
     }
 }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -304,6 +304,33 @@ impl Bank {
         last_ids.get_confirmation_timestamp(ticks_and_stakes, supermajority_stake)
     }
 
+    pub fn stakes_and_lockouts(&self) -> Vec<(u64, Option<u64>)> {
+        let vote_states: Vec<_> = self.vote_states(|_| true);
+        vote_states
+            .into_iter()
+            .filter_map(|state| {
+                let stake = self.get_balance(&state.staker_id);
+                if stake > 0 {
+                    Some((stake, state.root_slot))
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
+
+    /// Looks through vote accounts, and finds the latest slot that has achieved
+    /// supermajority lockout
+    pub fn get_supermajority_slot(&self) -> Option<u64> {
+        // Find the amount of stake needed for supermajority
+        let stakes_and_lockouts = self.stakes_and_lockouts();
+        let total_stake: u64 = stakes_and_lockouts.iter().map(|s| s.0).sum();
+        let supermajority_stake = total_stake * 2 / 3;
+
+        // Filter out the states that don't have a max lockout
+        Self::find_supermajority_slot(supermajority_stake, &stakes_and_lockouts)
+    }
+
     /// Tell the bank which Entry IDs exist on the ledger. This function
     /// assumes subsequent calls correspond to later entries, and will boot
     /// the oldest ones once its internal cache is full. Once boot, the
@@ -349,6 +376,31 @@ impl Bank {
 
     pub fn unlock_accounts(&self, txs: &[Transaction], results: &[Result<()>]) {
         self.accounts().unlock_accounts(self.id, txs, results)
+    }
+
+    fn find_supermajority_slot(
+        supermajority_stake: u64,
+        stakes_and_lockouts: &[(u64, Option<u64>)],
+    ) -> Option<u64> {
+        // Filter out the states that don't have a max lockout
+        let mut stakes_and_lockouts: Vec<_> = stakes_and_lockouts
+            .iter()
+            .filter_map(|(stake, slot)| slot.map(|s| (stake, s)))
+            .collect();
+
+        // Sort by the root slot, in descending order
+        stakes_and_lockouts.sort_unstable_by(|s1, s2| s1.1.cmp(&s2.1).reverse());
+
+        // Find if any slot has achieved sufficient votes for supermajority lockout
+        let mut total = 0;
+        for (stake, slot) in stakes_and_lockouts {
+            total += stake;
+            if total > supermajority_stake {
+                return Some(slot);
+            }
+        }
+
+        None
     }
 
     fn load_accounts(
@@ -788,6 +840,8 @@ mod tests {
     use solana_sdk::system_instruction::SystemInstruction;
     use solana_sdk::system_transaction::SystemTransaction;
     use solana_sdk::transaction::Instruction;
+    use solana_sdk::vote_transaction::VoteTransaction;
+    use std::iter::FromIterator;
 
     #[test]
     fn test_bank_new() {
@@ -1467,5 +1521,111 @@ mod tests {
         let bank = Bank::new_from_parent(&parent);
         bank.squash();
         assert_eq!(parent.get_balance(&key1.pubkey()), 1);
+    }
+
+    #[test]
+    fn test_stakes_and_lockouts() {
+        let validator = Keypair::new();
+        let voter = Keypair::new();
+
+        let (genesis_block, mint_keypair) = GenesisBlock::new(500);
+        let bank = Bank::new(&genesis_block);
+        let bank_voter = Keypair::new();
+
+        // Give the validator some stake
+        bank.transfer(
+            1,
+            &mint_keypair,
+            validator.pubkey(),
+            genesis_block.last_id(),
+        )
+        .unwrap();
+
+        new_vote_account_with_vote(&validator, &voter, &bank, 1, 0);
+        assert_eq!(bank.get_balance(&validator.pubkey()), 0);
+        // Validator has zero balance, so they get filtered out.Only the bootstrap leader
+        // created by the genesis block will get included
+        assert_eq!(bank.stakes_and_lockouts(), vec![(1, None)]);
+
+        new_vote_account_with_vote(&mint_keypair, &bank_voter, &bank, 1, 0);
+
+        let result: HashSet<_> = HashSet::from_iter(bank.stakes_and_lockouts().iter().cloned());
+        let expected: HashSet<_> = HashSet::from_iter(vec![(1, None), (498, None)]);
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_find_supermajority_slot() {
+        let supermajority = 10;
+
+        let stakes_and_slots = vec![];
+        assert_eq!(
+            Bank::find_supermajority_slot(supermajority, &stakes_and_slots),
+            None
+        );
+
+        let stakes_and_slots = vec![(5, None), (5, None)];
+        assert_eq!(
+            Bank::find_supermajority_slot(supermajority, &stakes_and_slots),
+            None
+        );
+
+        let stakes_and_slots = vec![(5, None), (5, None), (9, Some(2))];
+        assert_eq!(
+            Bank::find_supermajority_slot(supermajority, &stakes_and_slots),
+            None
+        );
+
+        let stakes_and_slots = vec![(5, None), (5, None), (9, Some(2)), (1, Some(3))];
+        assert_eq!(
+            Bank::find_supermajority_slot(supermajority, &stakes_and_slots),
+            None
+        );
+
+        let stakes_and_slots = vec![(5, None), (5, None), (9, Some(2)), (2, Some(3))];
+        assert_eq!(
+            Bank::find_supermajority_slot(supermajority, &stakes_and_slots),
+            Some(2)
+        );
+
+        let stakes_and_slots = vec![(9, Some(2)), (2, Some(3)), (9, None)];
+        assert_eq!(
+            Bank::find_supermajority_slot(supermajority, &stakes_and_slots),
+            Some(2)
+        );
+
+        let stakes_and_slots = vec![(9, Some(2)), (2, Some(3)), (9, Some(3))];
+        assert_eq!(
+            Bank::find_supermajority_slot(supermajority, &stakes_and_slots),
+            Some(3)
+        );
+    }
+
+    pub fn new_vote_account(
+        from_keypair: &Keypair,
+        voting_pubkey: &Pubkey,
+        bank: &Bank,
+        num_tokens: u64,
+    ) {
+        let last_id = bank.last_id();
+        let tx = VoteTransaction::new_account(from_keypair, *voting_pubkey, last_id, num_tokens, 0);
+        bank.process_transaction(&tx).unwrap();
+    }
+
+    pub fn push_vote<T: KeypairUtil>(voting_keypair: &T, bank: &Bank, slot_height: u64) {
+        let last_id = bank.last_id();
+        let tx = VoteTransaction::new_vote(voting_keypair, slot_height, last_id, 0);
+        bank.process_transaction(&tx).unwrap();
+    }
+
+    pub fn new_vote_account_with_vote<T: KeypairUtil>(
+        from_keypair: &Keypair,
+        voting_keypair: &T,
+        bank: &Bank,
+        num_tokens: u64,
+        slot_height: u64,
+    ) {
+        new_vote_account(from_keypair, &voting_keypair.pubkey(), bank, num_tokens);
+        push_vote(voting_keypair, bank, slot_height);
     }
 }

--- a/src/broadcast_service.rs
+++ b/src/broadcast_service.rs
@@ -9,6 +9,7 @@ use crate::erasure::CodingGenerator;
 use crate::packet::index_blobs;
 use crate::result::{Error, Result};
 use crate::service::Service;
+use crate::staking_utils;
 use rayon::prelude::*;
 use solana_metrics::counter::Counter;
 use solana_metrics::{influxdb, submit};
@@ -189,7 +190,7 @@ impl BroadcastService {
             let mut broadcast_table = cluster_info
                 .read()
                 .unwrap()
-                .sorted_tvu_peers(&bank.staked_nodes());
+                .sorted_tvu_peers(&staking_utils::staked_nodes(&bank));
             // Layer 1, leader nodes are limited to the fanout size.
             broadcast_table.truncate(DATA_PLANE_FANOUT);
             inc_new_counter_info!("broadcast_service-num_peers", broadcast_table.len() + 1);

--- a/src/cluster_info.rs
+++ b/src/cluster_info.rs
@@ -22,6 +22,7 @@ use crate::crds_value::{CrdsValue, CrdsValueLabel, LeaderId, Vote};
 use crate::packet::{to_shared_blob, Blob, SharedBlob, BLOB_SIZE};
 use crate::result::Result;
 use crate::rpc_service::RPC_PORT;
+use crate::staking_utils;
 use crate::streamer::{BlobReceiver, BlobSender};
 use bincode::{deserialize, serialize};
 use core::cmp;
@@ -877,7 +878,7 @@ impl ClusterInfo {
                     let start = timestamp();
                     let stakes: HashMap<_, _> = match bank_forks {
                         Some(ref bank_forks) => {
-                            bank_forks.read().unwrap().working_bank().staked_nodes()
+                            staking_utils::staked_nodes(&bank_forks.read().unwrap().working_bank())
                         }
                         None => HashMap::new(),
                     };

--- a/src/leader_schedule_utils.rs
+++ b/src/leader_schedule_utils.rs
@@ -1,10 +1,11 @@
 use crate::leader_schedule::LeaderSchedule;
+use crate::staking_utils;
 use solana_runtime::bank::Bank;
 use solana_sdk::pubkey::Pubkey;
 
 /// Return the leader schedule for the given epoch.
 fn leader_schedule(epoch_height: u64, bank: &Bank) -> LeaderSchedule {
-    let stakes = bank.staked_nodes_at_epoch(epoch_height);
+    let stakes = staking_utils::staked_nodes_at_epoch(bank, epoch_height);
     let mut seed = [0u8; 32];
     seed[0..8].copy_from_slice(&epoch_height.to_le_bytes());
     let stakes: Vec<_> = stakes.into_iter().collect();
@@ -80,6 +81,7 @@ pub fn num_ticks_left_in_slot(bank: &Bank, tick_height: u64) -> u64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::staking_utils;
     use solana_sdk::genesis_block::GenesisBlock;
     use solana_sdk::signature::{Keypair, KeypairUtil};
 
@@ -89,7 +91,7 @@ mod tests {
         let (genesis_block, _mint_keypair) = GenesisBlock::new_with_leader(2, pubkey, 2);
         let bank = Bank::new(&genesis_block);
 
-        let ids_and_stakes: Vec<_> = bank.staked_nodes().into_iter().collect();
+        let ids_and_stakes: Vec<_> = staking_utils::staked_nodes(&bank).into_iter().collect();
         let seed = [0u8; 32];
         let leader_schedule =
             LeaderSchedule::new(&ids_and_stakes, seed, genesis_block.slots_per_epoch);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,6 +64,7 @@ pub mod rpc_subscriptions;
 pub mod service;
 pub mod sigverify;
 pub mod sigverify_stage;
+pub mod staking_utils;
 pub mod storage_stage;
 pub mod streamer;
 pub mod test_tx;

--- a/src/retransmit_stage.rs
+++ b/src/retransmit_stage.rs
@@ -9,6 +9,7 @@ use crate::cluster_info::{
 use crate::packet::SharedBlob;
 use crate::result::{Error, Result};
 use crate::service::Service;
+use crate::staking_utils;
 use crate::streamer::BlobReceiver;
 use crate::window_service::WindowService;
 use solana_metrics::counter::Counter;
@@ -39,7 +40,7 @@ fn retransmit(
             .to_owned(),
     );
     let (neighbors, children) = compute_retransmit_peers(
-        &bank_forks.read().unwrap().working_bank().staked_nodes(),
+        &staking_utils::staked_nodes(&bank_forks.read().unwrap().working_bank()),
         cluster_info,
         DATA_PLANE_FANOUT,
         NEIGHBORHOOD_SIZE,

--- a/src/staking_utils.rs
+++ b/src/staking_utils.rs
@@ -56,7 +56,7 @@ where
 
     let bank = banks
         .iter()
-        .find(|bank| bank.slot_height() <= slot_height)
+        .find(|bank| bank.id() <= slot_height)
         .unwrap_or_else(|| banks.last().unwrap());
 
     staked_nodes_extractor(bank, state_extractor)

--- a/src/staking_utils.rs
+++ b/src/staking_utils.rs
@@ -1,24 +1,100 @@
+use hashbrown::HashMap;
 use solana_runtime::bank::Bank;
+use solana_sdk::pubkey::Pubkey;
+use solana_sdk::vote_program::VoteState;
 
 /// Looks through vote accounts, and finds the latest slot that has achieved
 /// supermajority lockout
-pub fn get_supermajority_slot(bank: &Bank) -> Option<u64> {
+pub fn get_supermajority_slot(bank: &Bank, epoch_height: u64) -> Option<u64> {
     // Find the amount of stake needed for supermajority
-    let stakes_and_lockouts = stakes_and_lockouts(bank);
-    let total_stake: u64 = stakes_and_lockouts.iter().map(|s| s.0).sum();
+    let stakes_and_lockouts = epoch_stakes_and_lockouts(bank, epoch_height);
+    let total_stake: u64 = stakes_and_lockouts.values().map(|s| s.0).sum();
     let supermajority_stake = total_stake * 2 / 3;
 
     // Filter out the states that don't have a max lockout
-    find_supermajority_slot(supermajority_stake, &stakes_and_lockouts)
+    find_supermajority_slot(supermajority_stake, stakes_and_lockouts.values())
 }
 
-fn find_supermajority_slot(
-    supermajority_stake: u64,
-    stakes_and_lockouts: &[(u64, Option<u64>)],
-) -> Option<u64> {
+pub fn staked_nodes(bank: &Bank) -> HashMap<Pubkey, u64> {
+    staked_nodes_extractor(bank, |stake, _| stake)
+}
+
+/// Return the checkpointed stakes that should be used to generate a leader schedule.
+pub fn staked_nodes_at_epoch(bank: &Bank, epoch_height: u64) -> HashMap<Pubkey, u64> {
+    staked_nodes_at_epoch_extractor(bank, epoch_height, |stake, _| stake)
+}
+
+/// Return the checkpointed stakes that should be used to generate a leader schedule.
+/// state_extractor takes (stake, vote_state) and maps to an output.
+fn staked_nodes_at_epoch_extractor<F, T>(
+    bank: &Bank,
+    epoch_height: u64,
+    state_extractor: F,
+) -> HashMap<Pubkey, T>
+where
+    F: Fn(u64, &VoteState) -> T,
+{
+    let epoch_slot_height = epoch_height * bank.slots_per_epoch();
+    staked_nodes_at_slot_extractor(bank, epoch_slot_height, state_extractor)
+}
+
+/// Return the checkpointed stakes that should be used to generate a leader schedule.
+/// state_extractor takes (stake, vote_state) and maps to an output
+fn staked_nodes_at_slot_extractor<F, T>(
+    bank: &Bank,
+    current_slot_height: u64,
+    state_extractor: F,
+) -> HashMap<Pubkey, T>
+where
+    F: Fn(u64, &VoteState) -> T,
+{
+    let slot_height = current_slot_height.saturating_sub(bank.stakers_slot_offset());
+
+    let parents = bank.parents();
+    let mut banks = vec![bank];
+    banks.extend(parents.iter().map(|x| x.as_ref()));
+
+    let bank = banks
+        .iter()
+        .find(|bank| bank.slot_height() <= slot_height)
+        .unwrap_or_else(|| banks.last().unwrap());
+
+    staked_nodes_extractor(bank, state_extractor)
+}
+
+/// Collect the node Pubkey and staker account balance for nodes
+/// that have non-zero balance in their corresponding staker accounts.
+/// state_extractor takes (stake, vote_state) and maps to an output
+fn staked_nodes_extractor<F, T>(bank: &Bank, state_extractor: F) -> HashMap<Pubkey, T>
+where
+    F: Fn(u64, &VoteState) -> T,
+{
+    bank.vote_states(|_| true)
+        .iter()
+        .filter_map(|state| {
+            let balance = bank.get_balance(&state.staker_id);
+            if balance > 0 {
+                Some((state.node_id, state_extractor(balance, &state)))
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+fn epoch_stakes_and_lockouts(
+    bank: &Bank,
+    epoch_height: u64,
+) -> HashMap<Pubkey, (u64, Option<u64>)> {
+    staked_nodes_at_epoch_extractor(bank, epoch_height, |stake, state| (stake, state.root_slot))
+}
+
+fn find_supermajority_slot<'a, I>(supermajority_stake: u64, stakes_and_lockouts: I) -> Option<u64>
+where
+    I: Iterator<Item = &'a (u64, Option<u64>)>,
+{
     // Filter out the states that don't have a max lockout
     let mut stakes_and_lockouts: Vec<_> = stakes_and_lockouts
-        .iter()
         .filter_map(|(stake, slot)| slot.map(|s| (stake, s)))
         .collect();
 
@@ -37,32 +113,46 @@ fn find_supermajority_slot(
     None
 }
 
-pub fn stakes_and_lockouts(bank: &Bank) -> Vec<(u64, Option<u64>)> {
-    let vote_states: Vec<_> = bank.vote_states(|_| true);
-    vote_states
-        .into_iter()
-        .filter_map(|state| {
-            let stake = bank.get_balance(&state.staker_id);
-            if stake > 0 {
-                Some((stake, state.root_slot))
-            } else {
-                None
-            }
-        })
-        .collect()
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::voting_keypair::tests as voting_keypair_tests;
     use hashbrown::HashSet;
     use solana_sdk::genesis_block::GenesisBlock;
+    use solana_sdk::hash::Hash;
     use solana_sdk::signature::{Keypair, KeypairUtil};
     use std::iter::FromIterator;
+    use std::sync::Arc;
+
+    fn register_ticks(bank: &Bank, n: u64) -> (u64, u64, u64) {
+        for _ in 0..n {
+            bank.register_tick(&Hash::default());
+        }
+        (bank.tick_index(), bank.slot_index(), bank.epoch_height())
+    }
 
     #[test]
-    fn test_stakes_and_lockouts() {
+    fn test_bank_staked_nodes_at_epoch() {
+        let pubkey = Keypair::new().pubkey();
+        let bootstrap_tokens = 2;
+        let (genesis_block, _) = GenesisBlock::new_with_leader(2, pubkey, bootstrap_tokens);
+        let bank = Bank::new(&genesis_block);
+        let bank = Bank::new_from_parent(&Arc::new(bank));
+        let ticks_per_offset = bank.stakers_slot_offset() * bank.ticks_per_slot();
+        register_ticks(&bank, ticks_per_offset);
+        assert_eq!(bank.slot_height(), bank.stakers_slot_offset());
+
+        let mut expected = HashMap::new();
+        expected.insert(pubkey, bootstrap_tokens - 1);
+        let bank = Bank::new_from_parent(&Arc::new(bank));
+        assert_eq!(
+            staked_nodes_at_slot_extractor(&bank, bank.slot_height(), |s, _| s),
+            expected
+        );
+    }
+
+    #[test]
+    fn test_epoch_stakes_and_lockouts() {
         let validator = Keypair::new();
         let voter = Keypair::new();
 
@@ -81,13 +171,18 @@ mod tests {
 
         voting_keypair_tests::new_vote_account_with_vote(&validator, &voter, &bank, 1, 0);
         assert_eq!(bank.get_balance(&validator.pubkey()), 0);
-        // Validator has zero balance, so they get filtered out.Only the bootstrap leader
+        // Validator has zero balance, so they get filtered out. Only the bootstrap leader
         // created by the genesis block will get included
-        assert_eq!(stakes_and_lockouts(&bank), vec![(1, None)]);
+        let expected: Vec<_> = epoch_stakes_and_lockouts(&bank, 0)
+            .values()
+            .cloned()
+            .collect();
+        assert_eq!(expected, vec![(1, None)]);
 
         voting_keypair_tests::new_vote_account_with_vote(&mint_keypair, &bank_voter, &bank, 1, 0);
 
-        let result: HashSet<_> = HashSet::from_iter(stakes_and_lockouts(&bank).iter().cloned());
+        let result: HashSet<_> =
+            HashSet::from_iter(epoch_stakes_and_lockouts(&bank, 0).values().cloned());
         let expected: HashSet<_> = HashSet::from_iter(vec![(1, None), (498, None)]);
         assert_eq!(result, expected);
     }
@@ -98,43 +193,43 @@ mod tests {
 
         let stakes_and_slots = vec![];
         assert_eq!(
-            find_supermajority_slot(supermajority, &stakes_and_slots),
+            find_supermajority_slot(supermajority, stakes_and_slots.iter()),
             None
         );
 
         let stakes_and_slots = vec![(5, None), (5, None)];
         assert_eq!(
-            find_supermajority_slot(supermajority, &stakes_and_slots),
+            find_supermajority_slot(supermajority, stakes_and_slots.iter()),
             None
         );
 
         let stakes_and_slots = vec![(5, None), (5, None), (9, Some(2))];
         assert_eq!(
-            find_supermajority_slot(supermajority, &stakes_and_slots),
+            find_supermajority_slot(supermajority, stakes_and_slots.iter()),
             None
         );
 
         let stakes_and_slots = vec![(5, None), (5, None), (9, Some(2)), (1, Some(3))];
         assert_eq!(
-            find_supermajority_slot(supermajority, &stakes_and_slots),
+            find_supermajority_slot(supermajority, stakes_and_slots.iter()),
             None
         );
 
         let stakes_and_slots = vec![(5, None), (5, None), (9, Some(2)), (2, Some(3))];
         assert_eq!(
-            find_supermajority_slot(supermajority, &stakes_and_slots),
+            find_supermajority_slot(supermajority, stakes_and_slots.iter()),
             Some(2)
         );
 
         let stakes_and_slots = vec![(9, Some(2)), (2, Some(3)), (9, None)];
         assert_eq!(
-            find_supermajority_slot(supermajority, &stakes_and_slots),
+            find_supermajority_slot(supermajority, stakes_and_slots.iter()),
             Some(2)
         );
 
         let stakes_and_slots = vec![(9, Some(2)), (2, Some(3)), (9, Some(3))];
         assert_eq!(
-            find_supermajority_slot(supermajority, &stakes_and_slots),
+            find_supermajority_slot(supermajority, stakes_and_slots.iter()),
             Some(3)
         );
     }

--- a/src/staking_utils.rs
+++ b/src/staking_utils.rs
@@ -1,0 +1,141 @@
+use solana_runtime::bank::Bank;
+
+/// Looks through vote accounts, and finds the latest slot that has achieved
+/// supermajority lockout
+pub fn get_supermajority_slot(bank: &Bank) -> Option<u64> {
+    // Find the amount of stake needed for supermajority
+    let stakes_and_lockouts = stakes_and_lockouts(bank);
+    let total_stake: u64 = stakes_and_lockouts.iter().map(|s| s.0).sum();
+    let supermajority_stake = total_stake * 2 / 3;
+
+    // Filter out the states that don't have a max lockout
+    find_supermajority_slot(supermajority_stake, &stakes_and_lockouts)
+}
+
+fn find_supermajority_slot(
+    supermajority_stake: u64,
+    stakes_and_lockouts: &[(u64, Option<u64>)],
+) -> Option<u64> {
+    // Filter out the states that don't have a max lockout
+    let mut stakes_and_lockouts: Vec<_> = stakes_and_lockouts
+        .iter()
+        .filter_map(|(stake, slot)| slot.map(|s| (stake, s)))
+        .collect();
+
+    // Sort by the root slot, in descending order
+    stakes_and_lockouts.sort_unstable_by(|s1, s2| s1.1.cmp(&s2.1).reverse());
+
+    // Find if any slot has achieved sufficient votes for supermajority lockout
+    let mut total = 0;
+    for (stake, slot) in stakes_and_lockouts {
+        total += stake;
+        if total > supermajority_stake {
+            return Some(slot);
+        }
+    }
+
+    None
+}
+
+pub fn stakes_and_lockouts(bank: &Bank) -> Vec<(u64, Option<u64>)> {
+    let vote_states: Vec<_> = bank.vote_states(|_| true);
+    vote_states
+        .into_iter()
+        .filter_map(|state| {
+            let stake = bank.get_balance(&state.staker_id);
+            if stake > 0 {
+                Some((stake, state.root_slot))
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::voting_keypair::tests as voting_keypair_tests;
+    use hashbrown::HashSet;
+    use solana_sdk::genesis_block::GenesisBlock;
+    use solana_sdk::signature::{Keypair, KeypairUtil};
+    use std::iter::FromIterator;
+
+    #[test]
+    fn test_stakes_and_lockouts() {
+        let validator = Keypair::new();
+        let voter = Keypair::new();
+
+        let (genesis_block, mint_keypair) = GenesisBlock::new(500);
+        let bank = Bank::new(&genesis_block);
+        let bank_voter = Keypair::new();
+
+        // Give the validator some stake
+        bank.transfer(
+            1,
+            &mint_keypair,
+            validator.pubkey(),
+            genesis_block.last_id(),
+        )
+        .unwrap();
+
+        voting_keypair_tests::new_vote_account_with_vote(&validator, &voter, &bank, 1, 0);
+        assert_eq!(bank.get_balance(&validator.pubkey()), 0);
+        // Validator has zero balance, so they get filtered out.Only the bootstrap leader
+        // created by the genesis block will get included
+        assert_eq!(stakes_and_lockouts(&bank), vec![(1, None)]);
+
+        voting_keypair_tests::new_vote_account_with_vote(&mint_keypair, &bank_voter, &bank, 1, 0);
+
+        let result: HashSet<_> = HashSet::from_iter(stakes_and_lockouts(&bank).iter().cloned());
+        let expected: HashSet<_> = HashSet::from_iter(vec![(1, None), (498, None)]);
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_find_supermajority_slot() {
+        let supermajority = 10;
+
+        let stakes_and_slots = vec![];
+        assert_eq!(
+            find_supermajority_slot(supermajority, &stakes_and_slots),
+            None
+        );
+
+        let stakes_and_slots = vec![(5, None), (5, None)];
+        assert_eq!(
+            find_supermajority_slot(supermajority, &stakes_and_slots),
+            None
+        );
+
+        let stakes_and_slots = vec![(5, None), (5, None), (9, Some(2))];
+        assert_eq!(
+            find_supermajority_slot(supermajority, &stakes_and_slots),
+            None
+        );
+
+        let stakes_and_slots = vec![(5, None), (5, None), (9, Some(2)), (1, Some(3))];
+        assert_eq!(
+            find_supermajority_slot(supermajority, &stakes_and_slots),
+            None
+        );
+
+        let stakes_and_slots = vec![(5, None), (5, None), (9, Some(2)), (2, Some(3))];
+        assert_eq!(
+            find_supermajority_slot(supermajority, &stakes_and_slots),
+            Some(2)
+        );
+
+        let stakes_and_slots = vec![(9, Some(2)), (2, Some(3)), (9, None)];
+        assert_eq!(
+            find_supermajority_slot(supermajority, &stakes_and_slots),
+            Some(2)
+        );
+
+        let stakes_and_slots = vec![(9, Some(2)), (2, Some(3)), (9, Some(3))];
+        assert_eq!(
+            find_supermajority_slot(supermajority, &stakes_and_slots),
+            Some(3)
+        );
+    }
+}


### PR DESCRIPTION
#### Problem
There's currently no way to calculate the latest slot on a fork that has reached supermajority lockout, which is needed for figuring out when to squash on ledger replay.

#### Summary of Changes
Introduce a function in the bank to calculate supermajority lockout

Fixes #
