### PR TITLE
fullnode: Set the correct bank on rotation

### DIFF
--- a/src/fullnode.rs
+++ b/src/fullnode.rs
@@ -282,10 +282,7 @@ impl Fullnode {
         let was_leader = leader_schedule_utils::slot_leader(&rotation_info.bank) == self.id;
 
         if let Some(ref mut rpc_service) = self.rpc_service {
-            // TODO: This is not the correct bank.  Instead TVU should pass along the
-            // frozen Bank for each completed block for RPC to use from it's notion of the "best"
-            // available fork (until we want to surface multiple forks to RPC)
-            rpc_service.set_bank(&self.bank_forks.read().unwrap().working_bank());
+            rpc_service.set_bank(&rotation_info.bank);
         }
 
         if rotation_info.leader_id == self.id {


### PR DESCRIPTION
Turns out the tvu rotation signal already provides fullnode with the right bank to pass along to RPC so use it.
(@carllin must have cherrypicked that from #2884 when I was looking the other way ❤️)