### PR TITLE
Remove Tpu::is_leader(), fullnode doesn't need it anymore

### DIFF
--- a/src/tpu.rs
+++ b/src/tpu.rs
@@ -255,14 +255,6 @@ impl Tpu {
         self.tpu_mode = Some(TpuMode::Leader(svcs));
     }
 
-    pub fn is_leader(&self) -> Option<bool> {
-        match self.tpu_mode {
-            Some(TpuMode::Leader(_)) => Some(true),
-            Some(TpuMode::Forwarder(_)) => Some(false),
-            None => None,
-        }
-    }
-
     pub fn exit(&self) {
         self.exit.store(true, Ordering::Relaxed);
     }

--- a/tests/multinode.rs
+++ b/tests/multinode.rs
@@ -479,8 +479,9 @@ fn test_boot_validator_from_file() {
     // TODO: it would be nice to determine the slot that the leader processed the transactions
     // in, and only wait for that slot here
     let expected_rotations = vec![
-        (FullnodeReturnType::LeaderToValidatorRotation, 1),
-        (FullnodeReturnType::LeaderToValidatorRotation, 2),
+        (FullnodeReturnType::ValidatorToValidatorRotation, 1),
+        (FullnodeReturnType::ValidatorToValidatorRotation, 2),
+        (FullnodeReturnType::ValidatorToValidatorRotation, 3),
     ];
 
     for expected_rotation in expected_rotations {


### PR DESCRIPTION
At rotation fullnode can now orient itself from the leader schedule without needing to rely on an independent and potentially wrong source (`Tpu::is_leader()`)
