### PR TITLE
Derive client retry timeouts from slot duration

### DIFF
--- a/tests/rpc.rs
+++ b/tests/rpc.rs
@@ -73,7 +73,7 @@ fn test_rpc_send_tx() {
        "params": [signature],
     });
 
-    for _ in 0..10 {
+    for _ in 0..solana_sdk::timing::DEFAULT_TICKS_PER_SLOT {
         let mut response = client
             .post(&rpc_string)
             .header(CONTENT_TYPE, "application/json")

--- a/wallet/src/wallet.rs
+++ b/wallet/src/wallet.rs
@@ -22,6 +22,7 @@ use solana_sdk::loader_transaction::LoaderTransaction;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::{Keypair, KeypairUtil, Signature};
 use solana_sdk::system_transaction::SystemTransaction;
+use solana_sdk::timing::{DEFAULT_TICKS_PER_SLOT, NUM_TICKS_PER_SECOND};
 use solana_sdk::transaction::Transaction;
 use std::fs::File;
 use std::io::Read;
@@ -775,7 +776,10 @@ fn send_and_confirm_tx(
                 break status;
             }
             if cfg!(not(test)) {
-                sleep(Duration::from_millis(500));
+                // Retry ~twice during a slot
+                sleep(Duration::from_millis(
+                    500 * DEFAULT_TICKS_PER_SLOT / NUM_TICKS_PER_SECOND as u64,
+                ));
             }
         };
         match status {
@@ -823,7 +827,10 @@ fn resign_tx(
             ))?;
         }
         next_last_id_retries -= 1;
-        sleep(Duration::from_secs(1));
+        // Retry ~twice during a slot
+        sleep(Duration::from_millis(
+            500 * DEFAULT_TICKS_PER_SLOT / NUM_TICKS_PER_SECOND as u64,
+        ));
     };
 
     tx.sign(&[signer_key], last_id);


### PR DESCRIPTION
Take advantage of 8 second slots (cc: #2981) to improve some client retry logic to use SDK timing constants.

Hopefully this helps with some of the recent timing-related CI integration test failures that have been occurring since we went back to slowmo slots.