### PR TITLE
Hoist EntrySender in ReplayStage

### DIFF
--- a/src/blockstream_service.rs
+++ b/src/blockstream_service.rs
@@ -82,7 +82,7 @@ impl BlockstreamService {
                 .unwrap_or_else(|e| {
                     debug!("Blockstream error: {:?}, {:?}", e, blockstream.output);
                 });
-            if 0 == entry_meta.num_ticks_left_in_slot {
+            if entry_meta.is_end_of_slot {
                 blockstream.queued_block = Some(BlockData {
                     slot: entry_meta.slot,
                     tick_height: entry_meta.tick_height,
@@ -144,7 +144,7 @@ mod test {
                 tick_height: x,
                 slot: slot_height,
                 slot_leader: leader_id,
-                num_ticks_left_in_slot: ticks_per_slot - ((x + 1) % ticks_per_slot),
+                is_end_of_slot: x == ticks_per_slot - 1,
                 parent_slot,
                 entry,
             };
@@ -159,7 +159,7 @@ mod test {
             tick_height: ticks_per_slot - 1,
             slot: 0,
             slot_leader: leader_id,
-            num_ticks_left_in_slot: 0,
+            is_end_of_slot: true,
             parent_slot: None,
             entry,
         };

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -29,7 +29,7 @@ pub struct EntryMeta {
     pub tick_height: u64,
     pub slot: u64,
     pub slot_leader: Pubkey,
-    pub num_ticks_left_in_slot: u64,
+    pub is_end_of_slot: bool,
     pub parent_slot: Option<u64>,
     pub entry: Entry,
 }
@@ -40,7 +40,7 @@ impl EntryMeta {
             tick_height: 0,
             slot: 0,
             slot_leader: Pubkey::default(),
-            num_ticks_left_in_slot: 0,
+            is_end_of_slot: false,
             parent_slot: None,
             entry,
         }


### PR DESCRIPTION
#### Problem
The inclusion of the blockstream and storage EntrySender in `ReplayStage::process_entries` is making ReplayStage refactoring difficult.

#### Summary of Changes
Hoist EntrySender out of `process_entries`
Encapsulate EntryMeta logic in helper function `forward_entries`
Rename inappropriately named ledger_entry_sender/receiver
Change blockstream end-of-block test to be more better
