### PR TITLE
Remove vote when bank processes a genesis block

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -230,13 +230,11 @@ impl Bank {
             executable: false,
         };
 
-        let mut vote_state = VoteState::new(
+        let vote_state = VoteState::new(
             genesis_block.bootstrap_leader_id,
-            genesis_block.bootstrap_leader_id,
+            genesis_block.bootstrap_leader_vote_account_id,
         );
-        vote_state
-            .votes
-            .push_back(vote_program::Lockout::new(&vote_program::Vote::new(0)));
+
         vote_state
             .serialize(&mut bootstrap_leader_vote_account.userdata)
             .unwrap();


### PR DESCRIPTION
#### Problem

When processing genesis blocks in the bank, the vote on behalf of the leader was no longer required for leader schedule generation.

#### Summary of Changes

- Removed the vote from `process_genesis_block()`. 
- Updated the "staker id" to the vote account instead of the leader's pubkey. @garious, is this right? 
- Unfortunately the vote state still needs to be initialized and shoved into the Account. 

