### PR TITLE
wallet deploy now sends program write transactions concurrently

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2366,6 +2366,7 @@ dependencies = [
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana 0.12.0",
  "solana-drone 0.12.0",

--- a/src/rpc_request.rs
+++ b/src/rpc_request.rs
@@ -1,6 +1,7 @@
 use reqwest;
 use reqwest::header::CONTENT_TYPE;
 use serde_json::{self, Value};
+use solana_sdk::timing::{DEFAULT_TICKS_PER_SLOT, NUM_TICKS_PER_SECOND};
 use std::net::SocketAddr;
 use std::thread::sleep;
 use std::time::Duration;
@@ -84,8 +85,11 @@ impl RpcClient {
                         Err(e)?;
                     }
                     retries -= 1;
-                    // TODO: Make the caller supply their desired retry frequency?
-                    sleep(Duration::from_millis(500));
+
+                    // Sleep for approximately half a slot
+                    sleep(Duration::from_millis(
+                        500 * DEFAULT_TICKS_PER_SLOT / NUM_TICKS_PER_SECOND as u64,
+                    ));
                 }
             }
         }

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -14,6 +14,7 @@ bs58 = "0.2.0"
 clap = "2.32.0"
 chrono = { version = "0.4.0", features = ["serde"] }
 dirs = "1.0.5"
+log = "0.4.2"
 serde_json = "1.0.38"
 solana = { path = "..", version = "0.12.0" }
 solana-drone = { path = "../drone", version = "0.12.0" }


### PR DESCRIPTION
With slowmo slots (cc: #2981) and a RPC API using the correct bank (#2978), it could take hours for the wallet to deploy a program as it was sending and confirming each write transaction in series.

Instead, send all the writes at once (slightly spaced out in an attempt to reduce account in-use errors), then collect results from all of them.  Repeat until all the writes make it.

NB: The sdk equivalent doesn't have this bug.