### PR TITLE
Refactor Vote Program Account setup

### DIFF
--- a/fullnode/src/main.rs
+++ b/fullnode/src/main.rs
@@ -77,7 +77,7 @@ fn create_and_fund_vote_account(
             let last_id = client.get_last_id();
             info!("create_and_fund_vote_account last_id={:?}", last_id);
             let transaction =
-                VoteTransaction::new_account(node_keypair, vote_account, last_id, 1, 1);
+                VoteTransaction::fund_staking_account(node_keypair, vote_account, last_id, 1, 1);
 
             match client.transfer_signed(&transaction) {
                 Ok(signature) => {
@@ -110,7 +110,7 @@ fn create_and_fund_vote_account(
     let vote_account_user_data = client.get_account_userdata(&vote_account);
     if let Ok(Some(vote_account_user_data)) = vote_account_user_data {
         if let Ok(vote_state) = VoteState::deserialize(&vote_account_user_data) {
-            if vote_state.node_id == pubkey {
+            if vote_state.delegate_id == pubkey {
                 return Ok(());
             }
         }

--- a/programs/native/rewards_api/src/rewards_instruction.rs
+++ b/programs/native/rewards_api/src/rewards_instruction.rs
@@ -9,15 +9,11 @@ pub enum RewardsInstruction {
 }
 
 impl RewardsInstruction {
-    pub fn new_redeem_vote_credits(
-        vote_id: Pubkey,
-        rewards_id: Pubkey,
-        to_id: Pubkey,
-    ) -> BuilderInstruction {
+    pub fn new_redeem_vote_credits(vote_id: Pubkey, rewards_id: Pubkey) -> BuilderInstruction {
         BuilderInstruction::new(
             rewards_program::id(),
             &RewardsInstruction::RedeemVoteCredits,
-            vec![(vote_id, true), (rewards_id, false), (to_id, false)],
+            vec![(vote_id, true), (rewards_id, false)],
         )
     }
 }

--- a/programs/native/rewards_api/src/rewards_transaction.rs
+++ b/programs/native/rewards_api/src/rewards_transaction.rs
@@ -35,14 +35,13 @@ impl RewardsTransaction {
     pub fn new_redeem_credits(
         vote_keypair: &Keypair,
         rewards_id: Pubkey,
-        to_id: Pubkey,
         last_id: Hash,
         fee: u64,
     ) -> Transaction {
         let vote_id = vote_keypair.pubkey();
         TransactionBuilder::new(fee)
             .push(RewardsInstruction::new_redeem_vote_credits(
-                vote_id, rewards_id, to_id,
+                vote_id, rewards_id,
             ))
             .push(VoteInstruction::new_clear_credits(vote_id))
             .sign(&[vote_keypair], last_id)

--- a/programs/native/vote/src/lib.rs
+++ b/programs/native/vote/src/lib.rs
@@ -28,7 +28,10 @@ fn entrypoint(
     }
 
     match deserialize(data).map_err(|_| ProgramError::InvalidUserdata)? {
-        VoteInstruction::RegisterAccount => vote_program::register(keyed_accounts),
+        VoteInstruction::InitializeAccount => vote_program::initialize_account(keyed_accounts),
+        VoteInstruction::DelegateStake(delegate_id) => {
+            vote_program::delegate_stake(keyed_accounts, delegate_id)
+        }
         VoteInstruction::Vote(vote) => {
             debug!("{:?} by {}", vote, keyed_accounts[0].signer_key().unwrap());
             solana_metrics::submit(

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -246,13 +246,19 @@ impl AccountsDB {
         )))
     }
 
-    fn get_vote_accounts(&self, fork: Fork) -> Vec<Account> {
+    fn get_vote_accounts(&self, fork: Fork) -> HashMap<Pubkey, Account> {
         self.index_info
             .vote_index
             .read()
             .unwrap()
             .iter()
-            .filter_map(|pubkey| self.load(fork, pubkey, true))
+            .filter_map(|pubkey| {
+                if let Some(account) = self.load(fork, pubkey, true) {
+                    Some((*pubkey, account))
+                } else {
+                    None
+                }
+            })
             .collect()
     }
 
@@ -1605,7 +1611,7 @@ mod tests {
         create_account(&accounts_db, &mut pubkeys, 100, 6);
         let accounts = accounts_db.get_vote_accounts(0);
         assert_eq!(accounts.len(), 6);
-        accounts.iter().for_each(|account| {
+        accounts.iter().for_each(|(_, account)| {
             assert_eq!(account.owner, vote_program::id());
         });
         let lastkey = Keypair::new().pubkey();

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -892,11 +892,11 @@ impl Accounts {
         self.accounts_db.squash(fork);
     }
 
-    pub fn get_vote_accounts(&self, fork: Fork) -> Vec<Account> {
+    pub fn get_vote_accounts(&self, fork: Fork) -> HashMap<Pubkey, Account> {
         self.accounts_db
             .get_vote_accounts(fork)
             .into_iter()
-            .filter(|acc| acc.tokens != 0)
+            .filter(|(_, acc)| acc.tokens != 0)
             .collect()
     }
 }

--- a/src/broadcast_service.rs
+++ b/src/broadcast_service.rs
@@ -190,7 +190,7 @@ impl BroadcastService {
             let mut broadcast_table = cluster_info
                 .read()
                 .unwrap()
-                .sorted_tvu_peers(&staking_utils::staked_nodes(&bank));
+                .sorted_tvu_peers(&staking_utils::node_stakes(&bank));
             // Layer 1, leader nodes are limited to the fanout size.
             broadcast_table.truncate(DATA_PLANE_FANOUT);
             inc_new_counter_info!("broadcast_service-num_peers", broadcast_table.len() + 1);

--- a/src/cluster_info.rs
+++ b/src/cluster_info.rs
@@ -878,7 +878,7 @@ impl ClusterInfo {
                     let start = timestamp();
                     let stakes: HashMap<_, _> = match bank_forks {
                         Some(ref bank_forks) => {
-                            staking_utils::staked_nodes(&bank_forks.read().unwrap().working_bank())
+                            staking_utils::node_stakes(&bank_forks.read().unwrap().working_bank())
                         }
                         None => HashMap::new(),
                     };

--- a/src/fullnode.rs
+++ b/src/fullnode.rs
@@ -462,7 +462,7 @@ pub fn make_active_set_entries(
     let vote_account_id = voting_keypair.pubkey();
 
     let new_vote_account_tx =
-        VoteTransaction::new_account(active_keypair, vote_account_id, *last_id, 1, 1);
+        VoteTransaction::fund_staking_account(active_keypair, vote_account_id, *last_id, 1, 1);
     let new_vote_account_entry = next_entry_mut(&mut last_entry_id, 1, vec![new_vote_account_tx]);
 
     // 3) Create vote entry

--- a/src/leader_confirmation_service.rs
+++ b/src/leader_confirmation_service.rs
@@ -35,12 +35,12 @@ impl LeaderConfirmationService {
 
         // Hold an accounts_db read lock as briefly as possible, just long enough to collect all
         // the vote states
-        let vote_states = bank.vote_states(|vote_state| leader_id != vote_state.node_id);
+        let vote_states = bank.vote_states(|_, vote_state| leader_id != vote_state.delegate_id);
 
         let mut ticks_and_stakes: Vec<(u64, u64)> = vote_states
             .iter()
-            .filter_map(|vote_state| {
-                let validator_stake = bank.get_balance(&vote_state.node_id);
+            .filter_map(|(_, vote_state)| {
+                let validator_stake = bank.get_balance(&vote_state.delegate_id);
                 total_stake += validator_stake;
                 // Filter out any validators that don't have at least one vote
                 // by returning None

--- a/src/retransmit_stage.rs
+++ b/src/retransmit_stage.rs
@@ -40,7 +40,7 @@ fn retransmit(
             .to_owned(),
     );
     let (neighbors, children) = compute_retransmit_peers(
-        &staking_utils::staked_nodes(&bank_forks.read().unwrap().working_bank()),
+        &staking_utils::node_stakes(&bank_forks.read().unwrap().working_bank()),
         cluster_info,
         DATA_PLANE_FANOUT,
         NEIGHBORHOOD_SIZE,

--- a/src/thin_client.rs
+++ b/src/thin_client.rs
@@ -590,8 +590,13 @@ mod tests {
         let vote_account_id = validator_vote_account_keypair.pubkey();
         let last_id = client.get_last_id();
 
-        let transaction =
-            VoteTransaction::new_account(&validator_keypair, vote_account_id, last_id, 1, 1);
+        let transaction = VoteTransaction::fund_staking_account(
+            &validator_keypair,
+            vote_account_id,
+            last_id,
+            1,
+            1,
+        );
         let signature = client.transfer_signed(&transaction).unwrap();
         client.poll_for_signature(&signature).unwrap();
 
@@ -608,7 +613,8 @@ mod tests {
 
             let vote_state = VoteState::deserialize(&account_user_data);
 
-            if vote_state.map(|vote_state| vote_state.node_id) == Ok(validator_keypair.pubkey()) {
+            if vote_state.map(|vote_state| vote_state.delegate_id) == Ok(validator_keypair.pubkey())
+            {
                 break;
             }
 

--- a/src/voting_keypair.rs
+++ b/src/voting_keypair.rs
@@ -110,7 +110,13 @@ pub mod tests {
         num_tokens: u64,
     ) {
         let last_id = bank.last_id();
-        let tx = VoteTransaction::new_account(from_keypair, *voting_pubkey, last_id, num_tokens, 0);
+        let tx = VoteTransaction::fund_staking_account(
+            from_keypair,
+            *voting_pubkey,
+            last_id,
+            num_tokens,
+            0,
+        );
         bank.process_transaction(&tx).unwrap();
     }
 


### PR DESCRIPTION
#### Summary of Changes
* Split `new_account()` into `fund_vote_account()`, `initialize_account()`, and `delegate_account()`.
* Ensure rewards are paid into the `staker account` from the `rewards account`
* Re-introduce stake sorting when generating the leader schedule. This is needed because without it, the leader schedule is dependent on the order in which vote accounts were inserted. 

Fixes #2513 

Hopeful alternative to #2973