### PR TITLE
Standardize on 'use log::*' for easy access to all log level macros

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2273,6 +2273,7 @@ dependencies = [
  "serde 1.0.88 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.88 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-logger 0.12.0",
  "solana-metrics 0.12.0",
  "solana-native-loader 0.12.0",
  "solana-sdk 0.12.0",

--- a/drone/src/bin/drone.rs
+++ b/drone/src/bin/drone.rs
@@ -1,5 +1,5 @@
 use clap::{crate_version, App, Arg};
-use log::info;
+use log::*;
 use solana_drone::drone::{Drone, DRONE_PORT};
 use solana_drone::socketaddr;
 use solana_sdk::signature::read_keypair;

--- a/drone/src/drone.rs
+++ b/drone/src/drone.rs
@@ -7,7 +7,7 @@
 use bincode::{deserialize, serialize};
 use byteorder::{ByteOrder, LittleEndian};
 use bytes::{Bytes, BytesMut};
-use log::{debug, info, trace, warn};
+use log::*;
 use serde_derive::{Deserialize, Serialize};
 use solana_metrics;
 use solana_metrics::influxdb;

--- a/metrics/src/counter.rs
+++ b/metrics/src/counter.rs
@@ -1,5 +1,5 @@
 use crate::{influxdb, submit};
-use log::{info, log_enabled};
+use log::*;
 use solana_sdk::timing;
 use std::env;
 use std::sync::atomic::{AtomicUsize, Ordering};

--- a/netutil/src/lib.rs
+++ b/netutil/src/lib.rs
@@ -1,5 +1,5 @@
 //! The `netutil` module assists with networking
-use log::trace;
+use log::*;
 use nix::sys::socket::setsockopt;
 use nix::sys::socket::sockopt::{ReuseAddr, ReusePort};
 use pnet_datalink as datalink;

--- a/programs/native/storage/tests/storage.rs
+++ b/programs/native/storage/tests/storage.rs
@@ -1,5 +1,5 @@
 use bincode::deserialize;
-use log::info;
+use log::*;
 use solana_runtime::bank::Bank;
 use solana_sdk::genesis_block::GenesisBlock;
 use solana_sdk::hash::{hash, Hash};

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -19,6 +19,7 @@ rand = "0.6.5"
 serde = "1.0.88"
 serde_derive = "1.0.88"
 serde_json = "1.0.38"
+solana-logger = { path = "../logger", version = "0.12.0" }
 solana-metrics = { path = "../metrics", version = "0.12.0" }
 solana-sdk = { path = "../sdk", version = "0.12.0" }
 solana-native-loader = { path = "../programs/native/native_loader", version = "0.12.0" }

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -3,7 +3,7 @@ use crate::bank::{BankError, Result};
 use crate::runtime::has_duplicates;
 use bincode::serialize;
 use hashbrown::{HashMap, HashSet};
-use log::debug;
+use log::*;
 use solana_metrics::counter::Counter;
 use solana_sdk::account::Account;
 use solana_sdk::hash::{hash, Hash};

--- a/runtime/src/appendvec.rs
+++ b/runtime/src/appendvec.rs
@@ -225,7 +225,7 @@ where
 #[cfg(test)]
 pub mod tests {
     use super::*;
-    use log::info;
+    use log::*;
     use rand::{thread_rng, Rng};
     use solana_sdk::timing::{duration_as_ms, duration_as_s};
     use std::sync::atomic::{AtomicUsize, Ordering};

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -9,7 +9,7 @@ use crate::runtime::{self, RuntimeError};
 use crate::status_cache::StatusCache;
 use bincode::serialize;
 use hashbrown::HashMap;
-use log::{debug, info, warn};
+use log::*;
 use solana_metrics::counter::Counter;
 use solana_sdk::account::Account;
 use solana_sdk::bpf_loader;

--- a/src/cluster_info.rs
+++ b/src/cluster_info.rs
@@ -26,7 +26,6 @@ use crate::streamer::{BlobReceiver, BlobSender};
 use bincode::{deserialize, serialize};
 use core::cmp;
 use hashbrown::HashMap;
-use log::Level;
 use rand::{thread_rng, Rng};
 use rayon::prelude::*;
 use solana_metrics::counter::Counter;
@@ -642,7 +641,7 @@ impl ClusterInfo {
             .flat_map(|(b, vs)| {
                 let blob = b.read().unwrap();
 
-                let ids_and_tvus = if log_enabled!(Level::Trace) {
+                let ids_and_tvus = if log_enabled!(log::Level::Trace) {
                     let v_ids = vs.iter().map(|v| v.id);
                     let tvus = vs.iter().map(|v| v.tvu);
                     let ids_and_tvus = v_ids.zip(tvus).collect();

--- a/src/thin_client.rs
+++ b/src/thin_client.rs
@@ -11,7 +11,6 @@ use crate::result::{Error, Result};
 use crate::rpc_request::{RpcClient, RpcRequest, RpcRequestHandler};
 use bincode::serialize_into;
 use bs58;
-use log::Level;
 use serde_json;
 use solana_metrics;
 use solana_metrics::influxdb;
@@ -410,7 +409,7 @@ pub fn poll_gossip_for_leader(leader_gossip: SocketAddr, timeout: Option<u64>) -
             break;
         }
 
-        if log_enabled!(Level::Trace) {
+        if log_enabled!(log::Level::Trace) {
             trace!("{}", cluster_info.read().unwrap().node_info_trace());
         }
 
@@ -423,7 +422,7 @@ pub fn poll_gossip_for_leader(leader_gossip: SocketAddr, timeout: Option<u64>) -
 
     gossip_service.close()?;
 
-    if log_enabled!(Level::Trace) {
+    if log_enabled!(log::Level::Trace) {
         trace!("{}", cluster_info.read().unwrap().node_info_trace());
     }
 

--- a/tests/crds_gossip.rs
+++ b/tests/crds_gossip.rs
@@ -1,6 +1,6 @@
 use bincode::serialized_size;
 use hashbrown::HashMap;
-use log::trace;
+use log::*;
 use rayon::prelude::*;
 use solana::cluster_info::NodeInfo;
 use solana::contact_info::ContactInfo;

--- a/tests/tvu.rs
+++ b/tests/tvu.rs
@@ -1,7 +1,7 @@
 #[macro_use]
 extern crate solana;
 
-use log::trace;
+use log::*;
 use solana::bank_forks::BankForks;
 use solana::blocktree::{get_tmp_ledger_path, Blocktree};
 use solana::blocktree_processor::BankForksInfo;


### PR DESCRIPTION
`use log::{debug, info, trace, warn};`, `use log::trace;`, `use log::{debug, info, warn};` and other variations get cumbersome when you want to use a not-yet-imported log level.  

Instead `use log::*` consistently.  It's shorter and prevents missing log level macros.
