### PR TITLE
Report correct transaction_count after squash

### DIFF
--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -624,9 +624,7 @@ impl AccountsDB {
     fn remove_parents(&self, fork: Fork) -> Vec<Fork> {
         let mut info = self.fork_info.write().unwrap();
         let fork_info = info.get_mut(&fork).unwrap();
-        let parents = fork_info.parents.split_off(0);
-        info.retain(|&f, _| !parents.contains(&f));
-        parents
+        fork_info.parents.split_off(0)
     }
 
     fn is_squashed(&self, fork: Fork) -> bool {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1418,10 +1418,14 @@ mod tests {
             0,
         );
         assert_eq!(parent.process_transaction(&tx_move_mint_to_1), Ok(()));
+        assert_eq!(parent.transaction_count(), 1);
+
         let bank = Bank::new_from_parent(&parent);
+        assert_eq!(bank.transaction_count(), 0);
         let tx_move_1_to_2 =
             SystemTransaction::new_move(&key1, key2.pubkey(), 1, genesis_block.last_id(), 0);
         assert_eq!(bank.process_transaction(&tx_move_1_to_2), Ok(()));
+        assert_eq!(bank.transaction_count(), 1);
         assert_eq!(
             parent.get_signature_status(&tx_move_1_to_2.signatures[0]),
             None
@@ -1443,6 +1447,9 @@ mod tests {
 
             // works iteration 0, no-ops on iteration 1 and 2
             bank.squash();
+
+            assert_eq!(parent.transaction_count(), 1);
+            assert_eq!(bank.transaction_count(), 2);
         }
     }
 


### PR DESCRIPTION
#### Problem
The transaction count reported for the parent forks are incorrect after the child fork is squashed.

#### Summary of Changes
The parent forks were being removed from the forks list when being squashed and hence the transaction count was being reported as 0 for all the parents. Do not remove the parent forks from the list when squashed.

Fixes #2996 
