### PR TITLE
xargo requires sysroot as source to build dependent crates

### DIFF
--- a/sdk/bpf/scripts/install.sh
+++ b/sdk/bpf/scripts/install.sh
@@ -87,8 +87,8 @@ if [[ ! -f rust-bpf-$machine-$version.md ]]; then
   fi
 fi
 
-# Install Rust-BPF Sysroot
-version=v0.0.2
+# Install Rust-BPF Sysroot sources
+version=058c3e1a311b18228166ed34592284df5ce38c43
 if [[ ! -f rust-bpf-sysroot-$version.md ]]; then
   (
     filename=solana-rust-bpf-sysroot.tar.bz2
@@ -97,9 +97,13 @@ if [[ ! -f rust-bpf-sysroot-$version.md ]]; then
     rm -rf rust-bpf-sysroot*
     mkdir -p rust-bpf-sysroot
     cd rust-bpf-sysroot
-    wget --progress=dot:giga https://github.com/solana-labs/rust-bpf-sysroot/releases/download/$version/$filename
-    tar -jxf $filename
-    rm -rf $filename
+
+    git init
+    git remote add origin https://github.com/solana-labs/rust-bpf-sysroot.git
+    git pull origin master
+    git checkout "$version"
+    git submodule init
+    git submodule update
 
     echo "https://github.com/solana-labs/rust-bpf-sysroot/releases/tag/$version" > ../rust-bpf-sysroot-$version.md
   )


### PR DESCRIPTION
#### Problem

Cargo can take a sysroot as a collection of binary libraries but that sysroot seems to only apply to the current project, any dependent crates fallback to using the default sysroot.  Xargo uses the same sysroot for dependent crates but requires it in source.

#### Summary of Changes

Pull sysroot as source into the sdk

Fixes #
