### PR TITLE
Update blocktree API's

### DIFF
--- a/src/replay_stage.rs
+++ b/src/replay_stage.rs
@@ -442,7 +442,18 @@ impl ReplayStage {
     fn get_next_slot(blocktree: &Blocktree, slot_index: u64) -> Option<u64> {
         // Find the next slot that chains to the old slot
         let next_slots = blocktree.get_slots_since(&[slot_index]).expect("Db error");
-        next_slots.first().cloned()
+
+        next_slots
+            .values()
+            .next()
+            .map(|slots| {
+                if slots.is_empty() {
+                    None
+                } else {
+                    Some(slots[0])
+                }
+            })
+            .unwrap_or(None)
     }
 }
 


### PR DESCRIPTION
#### Problem
get_slots_since() API didn't convey enough information about how its output chained to the input slots.
#### Summary of Changes
1) Change get_slots_since() to return a hashmap mapping input slots to their children slots
2) Add get_slot_entries_with_blob_count() API to return the number of blobs before deserialization to entries

Fixes #
