### PR TITLE
remove new_from_parent_with_id()

### DIFF
--- a/src/bank_forks.rs
+++ b/src/bank_forks.rs
@@ -69,13 +69,14 @@ mod tests {
     use super::*;
     use solana_sdk::genesis_block::GenesisBlock;
     use solana_sdk::hash::Hash;
+    use solana_sdk::pubkey::Pubkey;
 
     #[test]
     fn test_bank_forks() {
         let (genesis_block, _) = GenesisBlock::new(10_000);
         let bank = Bank::new(&genesis_block);
         let mut bank_forks = BankForks::new(0, bank);
-        let child_bank = Bank::new_from_parent(&bank_forks[0u64]);
+        let child_bank = Bank::new_from_parent(&bank_forks[0u64], Pubkey::default(), 1);
         child_bank.register_tick(&Hash::default());
         bank_forks.insert(1, child_bank);
         assert_eq!(bank_forks[1u64].tick_height(), 1);

--- a/src/blocktree_processor.rs
+++ b/src/blocktree_processor.rs
@@ -124,7 +124,7 @@ pub fn process_blocktree(
         let (slot, starting_bank, starting_entry_height, mut last_entry_hash) =
             pending_slots.pop().unwrap();
 
-        let bank = Arc::new(Bank::new_from_parent_and_id(
+        let bank = Arc::new(Bank::new_from_parent(
             &starting_bank,
             leader_schedule_utils::slot_leader_at(slot, &starting_bank),
             starting_bank.slot(),
@@ -213,7 +213,7 @@ pub fn process_blocktree(
 
         // This is a fork point, create a new child bank for each fork
         pending_slots.extend(meta.next_slots.iter().map(|next_slot| {
-            let child_bank = Arc::new(Bank::new_from_parent_and_id(
+            let child_bank = Arc::new(Bank::new_from_parent(
                 &bank,
                 leader_schedule_utils::slot_leader_at(*next_slot, &bank),
                 *next_slot,

--- a/src/rpc_pubsub.rs
+++ b/src/rpc_pubsub.rs
@@ -168,6 +168,7 @@ mod tests {
     use solana_sdk::budget_program;
     use solana_sdk::budget_transaction::BudgetTransaction;
     use solana_sdk::genesis_block::GenesisBlock;
+    use solana_sdk::pubkey::Pubkey;
     use solana_sdk::signature::{Keypair, KeypairUtil};
     use solana_sdk::system_transaction::SystemTransaction;
     use solana_sdk::transaction::Transaction;
@@ -184,7 +185,11 @@ mod tests {
         subscriptions.notify_subscribers(&bank);
 
         // Simulate a block boundary
-        Ok(Arc::new(Bank::new_from_parent(&bank)))
+        Ok(Arc::new(Bank::new_from_parent(
+            &bank,
+            Pubkey::default(),
+            bank.slot() + 1,
+        )))
     }
 
     fn create_session() -> Arc<Session> {


### PR DESCRIPTION
#### Problem
 new_from_parent_with_id() isn't the only child bank constructor, and id() is wrong name

 #### Summary of Changes
 remove new_from_parent_with_id(), rename to new_from_parent(), takes all info required
 updated tests to consume right thing

Fixes #