### PR TITLE
More HashQueue generalizing

### DIFF
--- a/benches/banking_stage.rs
+++ b/benches/banking_stage.rs
@@ -15,7 +15,7 @@ use solana_sdk::hash::hash;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::{KeypairUtil, Signature};
 use solana_sdk::system_transaction::SystemTransaction;
-use solana_sdk::timing::MAX_ENTRY_IDS;
+use solana_sdk::timing::MAX_RECENT_TICK_HASHES;
 use std::iter;
 use std::sync::atomic::AtomicBool;
 use std::sync::mpsc::{channel, Receiver};
@@ -127,7 +127,7 @@ fn bench_banking_stage_multi_accounts(bencher: &mut Bencher) {
     );
 
     let mut id = genesis_block.hash();
-    for _ in 0..MAX_ENTRY_IDS {
+    for _ in 0..MAX_RECENT_TICK_HASHES {
         id = hash(&id.as_ref());
         bank.register_tick(&id);
     }
@@ -236,7 +236,7 @@ fn bench_banking_stage_multi_programs(bencher: &mut Bencher) {
     );
 
     let mut id = genesis_block.hash();
-    for _ in 0..MAX_ENTRY_IDS {
+    for _ in 0..MAX_RECENT_TICK_HASHES {
         id = hash(&id.as_ref());
         bank.register_tick(&id);
     }

--- a/runtime/benches/bank.rs
+++ b/runtime/benches/bank.rs
@@ -7,7 +7,7 @@ use solana_sdk::genesis_block::GenesisBlock;
 use solana_sdk::hash::hash;
 use solana_sdk::signature::{Keypair, KeypairUtil};
 use solana_sdk::system_transaction::SystemTransaction;
-use solana_sdk::timing::MAX_ENTRY_IDS;
+use solana_sdk::timing::MAX_RECENT_TICK_HASHES;
 use test::Bencher;
 
 #[bench]
@@ -42,7 +42,7 @@ fn bench_process_transaction(bencher: &mut Bencher) {
 
     let mut id = bank.last_id();
 
-    for _ in 0..(MAX_ENTRY_IDS - 1) {
+    for _ in 0..(MAX_RECENT_TICK_HASHES - 1) {
         bank.register_tick(&id);
         id = hash(&id.as_ref())
     }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -343,7 +343,7 @@ impl Bank {
             tick_hash_queue.register_hash(hash);
             tick_hash_queue.hash_height()
         };
-        if current_tick_height % NUM_TICKS_PER_SECOND as u64 == 0 {
+        if current_tick_height % NUM_TICKS_PER_SECOND == 0 {
             self.status_cache.write().unwrap().new_cache(hash);
         }
     }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -322,8 +322,8 @@ impl Bank {
         ticks_and_stakes: &mut [(u64, u64)],
         supermajority_stake: u64,
     ) -> Option<u64> {
-        let last_ids = self.tick_hash_queue.read().unwrap();
-        last_ids.get_confirmation_timestamp(ticks_and_stakes, supermajority_stake)
+        let hash_queue = self.tick_hash_queue.read().unwrap();
+        hash_queue.get_confirmation_timestamp(ticks_and_stakes, supermajority_stake)
     }
 
     /// Tell the bank which Entry IDs exist on the ledger. This function
@@ -389,11 +389,11 @@ impl Bank {
         max_age: usize,
         error_counters: &mut ErrorCounters,
     ) -> Vec<Result<()>> {
-        let last_ids = self.tick_hash_queue.read().unwrap();
+        let hash_queue = self.tick_hash_queue.read().unwrap();
         txs.iter()
             .zip(lock_results.into_iter())
             .map(|(tx, lock_res)| {
-                if lock_res.is_ok() && !last_ids.check_entry_id_age(tx.last_id, max_age) {
+                if lock_res.is_ok() && !hash_queue.check_entry_id_age(tx.last_id, max_age) {
                     error_counters.reserve_last_id += 1;
                     Err(BankError::LastIdNotFound)
                 } else {
@@ -790,11 +790,6 @@ impl Bank {
     /// Return the epoch height of the last registered tick.
     pub fn epoch_height(&self) -> u64 {
         self.slot_height() / self.slots_per_epoch()
-    }
-
-    #[cfg(test)]
-    pub fn last_ids(&self) -> &RwLock<HashQueue> {
-        &self.tick_hash_queue
     }
 }
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -393,7 +393,7 @@ impl Bank {
         txs.iter()
             .zip(lock_results.into_iter())
             .map(|(tx, lock_res)| {
-                if lock_res.is_ok() && !hash_queue.check_entry_id_age(tx.last_id, max_age) {
+                if lock_res.is_ok() && !hash_queue.check_entry_age(tx.last_id, max_age) {
                     error_counters.reserve_last_id += 1;
                     Err(BankError::LastIdNotFound)
                 } else {
@@ -594,7 +594,8 @@ impl Bank {
     #[must_use]
     pub fn process_transactions(&self, txs: &[Transaction]) -> Vec<Result<()>> {
         let lock_results = self.lock_accounts(txs);
-        let results = self.load_execute_and_commit_transactions(txs, lock_results, MAX_RECENT_TICK_HASHES);
+        let results =
+            self.load_execute_and_commit_transactions(txs, lock_results, MAX_RECENT_TICK_HASHES);
         self.unlock_accounts(txs, &results);
         results
     }
@@ -1200,8 +1201,11 @@ mod tests {
         let pay_alice = vec![tx1];
 
         let lock_result = bank.lock_accounts(&pay_alice);
-        let results_alice =
-            bank.load_execute_and_commit_transactions(&pay_alice, lock_result, MAX_RECENT_TICK_HASHES);
+        let results_alice = bank.load_execute_and_commit_transactions(
+            &pay_alice,
+            lock_result,
+            MAX_RECENT_TICK_HASHES,
+        );
         assert_eq!(results_alice[0], Ok(()));
 
         // try executing an interleaved transfer twice

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -23,7 +23,7 @@ use solana_sdk::signature::{Keypair, Signature};
 use solana_sdk::storage_program;
 use solana_sdk::system_program;
 use solana_sdk::system_transaction::SystemTransaction;
-use solana_sdk::timing::{duration_as_us, MAX_ENTRY_IDS, NUM_TICKS_PER_SECOND};
+use solana_sdk::timing::{duration_as_us, MAX_RECENT_TICK_HASHES, NUM_TICKS_PER_SECOND};
 use solana_sdk::token_program;
 use solana_sdk::transaction::Transaction;
 use solana_sdk::vote_program::{self, VoteState};
@@ -594,7 +594,7 @@ impl Bank {
     #[must_use]
     pub fn process_transactions(&self, txs: &[Transaction]) -> Vec<Result<()>> {
         let lock_results = self.lock_accounts(txs);
-        let results = self.load_execute_and_commit_transactions(txs, lock_results, MAX_ENTRY_IDS);
+        let results = self.load_execute_and_commit_transactions(txs, lock_results, MAX_RECENT_TICK_HASHES);
         self.unlock_accounts(txs, &results);
         results
     }
@@ -1201,7 +1201,7 @@ mod tests {
 
         let lock_result = bank.lock_accounts(&pay_alice);
         let results_alice =
-            bank.load_execute_and_commit_transactions(&pay_alice, lock_result, MAX_ENTRY_IDS);
+            bank.load_execute_and_commit_transactions(&pay_alice, lock_result, MAX_RECENT_TICK_HASHES);
         assert_eq!(results_alice[0], Ok(()));
 
         // try executing an interleaved transfer twice

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -337,11 +337,11 @@ impl Bank {
         // TODO: put this assert back in
         // assert!(!self.is_frozen());
         let current_tick_height = {
-            //atomic register and read the tick
+            // Atomic register and read the tick
             let mut tick_hash_queue = self.tick_hash_queue.write().unwrap();
             inc_new_counter_info!("bank-register_tick-registered", 1);
             tick_hash_queue.register_hash(hash);
-            tick_hash_queue.tick_height()
+            tick_hash_queue.hash_height()
         };
         if current_tick_height % NUM_TICKS_PER_SECOND as u64 == 0 {
             self.status_cache.write().unwrap().new_cache(hash);
@@ -722,7 +722,7 @@ impl Bank {
 
     /// Return the number of ticks since genesis.
     pub fn tick_height(&self) -> u64 {
-        self.tick_hash_queue.read().unwrap().tick_height()
+        self.tick_hash_queue.read().unwrap().hash_height()
     }
 
     /// Return the number of ticks since the last slot boundary.

--- a/runtime/src/hash_queue.rs
+++ b/runtime/src/hash_queue.rs
@@ -88,32 +88,8 @@ impl HashQueue {
         self.last_hash = Some(*hash);
     }
 
-    /// Looks through a list of hash heights and stakes, and finds the latest
-    /// hash that has achieved confirmation
-    pub fn get_confirmation_timestamp(
-        &self,
-        hashes_and_stakes: &mut [(u64, u64)],
-        supermajority_stake: u64,
-    ) -> Option<u64> {
-        // Sort by hash height
-        hashes_and_stakes.sort_by(|a, b| a.0.cmp(&b.0));
-        let current_hash_height = self.hash_height;
-        let mut total = 0;
-        for (hash_height, stake) in hashes_and_stakes.iter() {
-            if current_hash_height >= *hash_height
-                && ((current_hash_height - hash_height) as usize) < MAX_RECENT_TICK_HASHES
-            {
-                total += stake;
-                if total > supermajority_stake {
-                    return self.hash_height_to_timestamp(*hash_height);
-                }
-            }
-        }
-        None
-    }
-
     /// Maps a hash height to a timestamp
-    fn hash_height_to_timestamp(&self, hash_height: u64) -> Option<u64> {
+    pub fn hash_height_to_timestamp(&self, hash_height: u64) -> Option<u64> {
         for entry in self.entries.values() {
             if entry.hash_height == hash_height {
                 return Some(entry.timestamp);

--- a/runtime/src/hash_queue.rs
+++ b/runtime/src/hash_queue.rs
@@ -38,10 +38,10 @@ impl HashQueue {
         self.last_hash.expect("no hash has been set")
     }
 
-    /// Check if the age of the entry_id is within the max_age
+    /// Check if the age of the entry is within the max_age
     /// return false for any entries with an age equal to or above max_age
-    pub fn check_entry_id_age(&self, entry_id: Hash, max_age: usize) -> bool {
-        let entry = self.entries.get(&entry_id);
+    pub fn check_entry_age(&self, entry: Hash, max_age: usize) -> bool {
+        let entry = self.entries.get(&entry);
         match entry {
             Some(entry) => self.hash_height - entry.hash_height < max_age as u64,
             _ => false,
@@ -49,8 +49,8 @@ impl HashQueue {
     }
     /// check if entry is valid
     #[cfg(test)]
-    pub fn check_entry(&self, entry_id: Hash) -> bool {
-        self.entries.get(&entry_id).is_some()
+    pub fn check_entry(&self, entry: Hash) -> bool {
+        self.entries.get(&entry).is_some()
     }
 
     pub fn genesis_hash(&mut self, hash: &Hash) {
@@ -72,8 +72,9 @@ impl HashQueue {
         // this clean up can be deferred until sigs gets larger
         //  because we verify entry.nth every place we check for validity
         if self.entries.len() >= MAX_RECENT_TICK_HASHES as usize {
-            self.entries
-                .retain(|_, entry| hash_height - entry.hash_height <= MAX_RECENT_TICK_HASHES as u64);
+            self.entries.retain(|_, entry| {
+                hash_height - entry.hash_height <= MAX_RECENT_TICK_HASHES as u64
+            });
         }
 
         self.entries.insert(

--- a/runtime/src/hash_queue.rs
+++ b/runtime/src/hash_queue.rs
@@ -120,13 +120,6 @@ impl HashQueue {
         }
         None
     }
-
-    #[cfg(test)]
-    pub fn clear(&mut self) {
-        self.entries = HashMap::new();
-        self.tick_height = 0;
-        self.last_hash = None;
-    }
 }
 #[cfg(test)]
 mod tests {

--- a/runtime/src/hash_queue.rs
+++ b/runtime/src/hash_queue.rs
@@ -71,7 +71,7 @@ impl HashQueue {
 
         // this clean up can be deferred until sigs gets larger
         //  because we verify entry.nth every place we check for validity
-        if self.entries.len() >= MAX_RECENT_TICK_HASHES as usize {
+        if self.entries.len() >= MAX_RECENT_TICK_HASHES {
             self.entries.retain(|_, entry| {
                 hash_height - entry.hash_height <= MAX_RECENT_TICK_HASHES as u64
             });

--- a/runtime/src/hash_queue.rs
+++ b/runtime/src/hash_queue.rs
@@ -1,6 +1,6 @@
 use hashbrown::HashMap;
 use solana_sdk::hash::Hash;
-use solana_sdk::timing::{timestamp, MAX_ENTRY_IDS};
+use solana_sdk::timing::{timestamp, MAX_RECENT_TICK_HASHES};
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 struct HashQueueEntry {
@@ -71,9 +71,9 @@ impl HashQueue {
 
         // this clean up can be deferred until sigs gets larger
         //  because we verify entry.nth every place we check for validity
-        if self.entries.len() >= MAX_ENTRY_IDS as usize {
+        if self.entries.len() >= MAX_RECENT_TICK_HASHES as usize {
             self.entries
-                .retain(|_, entry| hash_height - entry.hash_height <= MAX_ENTRY_IDS as u64);
+                .retain(|_, entry| hash_height - entry.hash_height <= MAX_RECENT_TICK_HASHES as u64);
         }
 
         self.entries.insert(
@@ -100,7 +100,7 @@ impl HashQueue {
         let mut total = 0;
         for (hash_height, stake) in hashes_and_stakes.iter() {
             if current_hash_height >= *hash_height
-                && ((current_hash_height - hash_height) as usize) < MAX_ENTRY_IDS
+                && ((current_hash_height - hash_height) as usize) < MAX_RECENT_TICK_HASHES
             {
                 total += stake;
                 if total > supermajority_stake {
@@ -139,7 +139,7 @@ mod tests {
     fn test_reject_old_last_hash() {
         let last_hash = Hash::default();
         let mut entry_queue = HashQueue::default();
-        for i in 0..MAX_ENTRY_IDS {
+        for i in 0..MAX_RECENT_TICK_HASHES {
             let last_hash = hash(&serialize(&i).unwrap()); // Unique hash
             entry_queue.register_hash(&last_hash);
         }

--- a/runtime/src/status_cache.rs
+++ b/runtime/src/status_cache.rs
@@ -2,14 +2,13 @@ use crate::bloom::{Bloom, BloomHashIndex};
 use hashbrown::HashMap;
 use solana_sdk::hash::Hash;
 use solana_sdk::signature::Signature;
-use solana_sdk::timing::{MAX_ENTRY_IDS, NUM_TICKS_PER_SECOND};
 use std::collections::VecDeque;
 use std::ops::Deref;
 #[cfg(test)]
 use std::ops::DerefMut;
 
-/// This cache is designed to last 1 second
-const MAX_CACHE_ENTRIES: usize = MAX_ENTRY_IDS / NUM_TICKS_PER_SECOND;
+/// Each cache entry is designed to span ~1 second of signatures
+const MAX_CACHE_ENTRIES: usize = solana_sdk::timing::MAX_HASH_AGE_IN_SECONDS;
 
 type FailureMap<T> = HashMap<Signature, T>;
 

--- a/sdk/src/timing.rs
+++ b/sdk/src/timing.rs
@@ -2,7 +2,7 @@
 use std::time::Duration;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-pub const NUM_TICKS_PER_SECOND: usize = 10;
+pub const NUM_TICKS_PER_SECOND: u64 = 10;
 
 // At 10 ticks/s, 8 ticks per slot implies that leader rotation and voting will happen
 // every 800 ms. A fast voting cadence ensures faster finality and convergence
@@ -17,7 +17,7 @@ pub const DEFAULT_SLOTS_PER_EPOCH: u64 = 64;
 /// not be processed by the network.
 pub const MAX_HASH_AGE_IN_SECONDS: usize = 120;
 
-pub const MAX_RECENT_TICK_HASHES: usize = NUM_TICKS_PER_SECOND * MAX_HASH_AGE_IN_SECONDS;
+pub const MAX_RECENT_TICK_HASHES: usize = NUM_TICKS_PER_SECOND as usize * MAX_HASH_AGE_IN_SECONDS;
 
 pub fn duration_as_us(d: &Duration) -> u64 {
     (d.as_secs() * 1000 * 1000) + (u64::from(d.subsec_nanos()) / 1_000)

--- a/sdk/src/timing.rs
+++ b/sdk/src/timing.rs
@@ -9,13 +9,15 @@ pub const NUM_TICKS_PER_SECOND: usize = 10;
 pub const DEFAULT_TICKS_PER_SLOT: u64 = 80;
 pub const DEFAULT_SLOTS_PER_EPOCH: u64 = 64;
 
-/// The number of most recent `last_id` values that the bank will track the signatures
-/// of. Once the bank discards a `last_id`, it will reject any transactions that use
+/// The time window of recent `last_id` values that the bank will track the signatures
+/// of over. Once the bank discards a `last_id`, it will reject any transactions that use
 /// that `last_id` in a transaction. Lowering this value reduces memory consumption,
 /// but requires clients to update its `last_id` more frequently. Raising the value
 /// lengthens the time a client must wait to be certain a missing transaction will
 /// not be processed by the network.
-pub const MAX_ENTRY_IDS: usize = NUM_TICKS_PER_SECOND * 120;
+pub const MAX_HASH_AGE_IN_SECONDS: usize = 120;
+
+pub const MAX_RECENT_TICK_HASHES: usize = NUM_TICKS_PER_SECOND * MAX_HASH_AGE_IN_SECONDS;
 
 pub fn duration_as_us(d: &Duration) -> u64 {
     (d.as_secs() * 1000 * 1000) + (u64::from(d.subsec_nanos()) / 1_000)

--- a/src/banking_stage.rs
+++ b/src/banking_stage.rs
@@ -172,8 +172,11 @@ impl BankingStage {
         // the likelihood of any single thread getting starved and processing old ids.
         // TODO: Banking stage threads should be prioritized to complete faster then this queue
         // expires.
-        let (loaded_accounts, results) =
-            bank.load_and_execute_transactions(txs, lock_results, MAX_RECENT_TICK_HASHES as usize / 2);
+        let (loaded_accounts, results) = bank.load_and_execute_transactions(
+            txs,
+            lock_results,
+            MAX_RECENT_TICK_HASHES as usize / 2,
+        );
         let load_execute_time = now.elapsed();
 
         let record_time = {

--- a/src/banking_stage.rs
+++ b/src/banking_stage.rs
@@ -172,11 +172,8 @@ impl BankingStage {
         // the likelihood of any single thread getting starved and processing old ids.
         // TODO: Banking stage threads should be prioritized to complete faster then this queue
         // expires.
-        let (loaded_accounts, results) = bank.load_and_execute_transactions(
-            txs,
-            lock_results,
-            MAX_RECENT_TICK_HASHES as usize / 2,
-        );
+        let (loaded_accounts, results) =
+            bank.load_and_execute_transactions(txs, lock_results, MAX_RECENT_TICK_HASHES / 2);
         let load_execute_time = now.elapsed();
 
         let record_time = {

--- a/src/banking_stage.rs
+++ b/src/banking_stage.rs
@@ -14,7 +14,7 @@ use bincode::deserialize;
 use solana_metrics::counter::Counter;
 use solana_runtime::bank::{self, Bank, BankError};
 use solana_sdk::pubkey::Pubkey;
-use solana_sdk::timing::{self, duration_as_us, MAX_ENTRY_IDS};
+use solana_sdk::timing::{self, duration_as_us, MAX_RECENT_TICK_HASHES};
 use solana_sdk::transaction::Transaction;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::{channel, Receiver, RecvTimeoutError};
@@ -173,7 +173,7 @@ impl BankingStage {
         // TODO: Banking stage threads should be prioritized to complete faster then this queue
         // expires.
         let (loaded_accounts, results) =
-            bank.load_and_execute_transactions(txs, lock_results, MAX_ENTRY_IDS as usize / 2);
+            bank.load_and_execute_transactions(txs, lock_results, MAX_RECENT_TICK_HASHES as usize / 2);
         let load_execute_time = now.elapsed();
 
         let record_time = {

--- a/src/blocktree_processor.rs
+++ b/src/blocktree_processor.rs
@@ -7,7 +7,7 @@ use solana_metrics::counter::Counter;
 use solana_runtime::bank::{Bank, BankError, Result};
 use solana_sdk::genesis_block::GenesisBlock;
 use solana_sdk::timing::duration_as_ms;
-use solana_sdk::timing::MAX_ENTRY_IDS;
+use solana_sdk::timing::MAX_RECENT_TICK_HASHES;
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -35,7 +35,7 @@ fn par_execute_entries(bank: &Bank, entries: &[(&Entry, Vec<Result<()>>)]) -> Re
             let results = bank.load_execute_and_commit_transactions(
                 &e.transactions,
                 lock_results.to_vec(),
-                MAX_ENTRY_IDS,
+                MAX_RECENT_TICK_HASHES,
             );
             bank.unlock_accounts(&e.transactions, &results);
             first_err(&results)

--- a/src/leader_confirmation_service.rs
+++ b/src/leader_confirmation_service.rs
@@ -37,30 +37,22 @@ impl LeaderConfirmationService {
         // the vote states
         let vote_states = bank.vote_states(|_, vote_state| leader_id != vote_state.delegate_id);
 
-        let mut ticks_and_stakes: Vec<(u64, u64)> = vote_states
+        let slots_and_stakes: Vec<(u64, u64)> = vote_states
             .iter()
             .filter_map(|(_, vote_state)| {
                 let validator_stake = bank.get_balance(&vote_state.delegate_id);
                 total_stake += validator_stake;
-                // Filter out any validators that don't have at least one vote
-                // by returning None
                 vote_state
                     .votes
                     .back()
-                    // A vote for a slot is like a vote for the last tick in that slot
-                    .map(|vote| {
-                        (
-                            (vote.slot_height + 1) * bank.ticks_per_slot() - 1,
-                            validator_stake,
-                        )
-                    })
+                    .map(|vote| (vote.slot_height, validator_stake))
             })
             .collect();
 
         let super_majority_stake = (2 * total_stake) / 3;
 
         if let Some(last_valid_validator_timestamp) =
-            bank.get_confirmation_timestamp(&mut ticks_and_stakes, super_majority_stake)
+            bank.get_confirmation_timestamp(slots_and_stakes, super_majority_stake)
         {
             return Ok(last_valid_validator_timestamp);
         }

--- a/src/poh_service.rs
+++ b/src/poh_service.rs
@@ -25,7 +25,7 @@ pub enum PohServiceConfig {
 impl Default for PohServiceConfig {
     fn default() -> PohServiceConfig {
         // TODO: Change this to Tick to enable PoH
-        PohServiceConfig::Sleep(Duration::from_millis(1000 / NUM_TICKS_PER_SECOND as u64))
+        PohServiceConfig::Sleep(Duration::from_millis(1000 / NUM_TICKS_PER_SECOND))
     }
 }
 

--- a/src/rpc_request.rs
+++ b/src/rpc_request.rs
@@ -88,7 +88,7 @@ impl RpcClient {
 
                     // Sleep for approximately half a slot
                     sleep(Duration::from_millis(
-                        500 * DEFAULT_TICKS_PER_SLOT / NUM_TICKS_PER_SECOND as u64,
+                        500 * DEFAULT_TICKS_PER_SLOT / NUM_TICKS_PER_SECOND,
                     ));
                 }
             }

--- a/wallet/src/wallet.rs
+++ b/wallet/src/wallet.rs
@@ -754,7 +754,7 @@ fn get_next_last_id(
         next_last_id_retries -= 1;
         // Retry ~twice during a slot
         sleep(Duration::from_millis(
-            500 * DEFAULT_TICKS_PER_SLOT / NUM_TICKS_PER_SECOND as u64,
+            500 * DEFAULT_TICKS_PER_SLOT / NUM_TICKS_PER_SECOND,
         ));
     }
 }
@@ -816,7 +816,7 @@ fn send_and_confirm_transaction(
             if cfg!(not(test)) {
                 // Retry ~twice during a slot
                 sleep(Duration::from_millis(
-                    500 * DEFAULT_TICKS_PER_SLOT / NUM_TICKS_PER_SECOND as u64,
+                    500 * DEFAULT_TICKS_PER_SLOT / NUM_TICKS_PER_SECOND,
                 ));
             }
         };
@@ -857,7 +857,7 @@ fn send_and_confirm_transactions(
             if cfg!(not(test)) {
                 // Delay ~1 tick between write transactions in an attempt to reduce AccountInUse errors
                 // since all the write transactions modify the same program account
-                sleep(Duration::from_millis(1000 / NUM_TICKS_PER_SECOND as u64));
+                sleep(Duration::from_millis(1000 / NUM_TICKS_PER_SECOND));
             }
 
             let signature = send_transaction(&rpc_client, &transaction).ok();
@@ -871,7 +871,7 @@ fn send_and_confirm_transactions(
             if cfg!(not(test)) {
                 // Retry ~twice during a slot
                 sleep(Duration::from_millis(
-                    500 * DEFAULT_TICKS_PER_SLOT / NUM_TICKS_PER_SECOND as u64,
+                    500 * DEFAULT_TICKS_PER_SLOT / NUM_TICKS_PER_SECOND,
                 ));
             }
 


### PR DESCRIPTION
* Move HashQueue internally from tick_height to hash_height, it counts hashes not ticks
* Remove get_confirmation_timestamp() from HashQueue, this belongs in Bank not HashQueue
* Refine timing constants

Towards #2710