### PR TITLE
Register a new last_id once per slot

### DIFF
--- a/programs/native/storage/tests/storage.rs
+++ b/programs/native/storage/tests/storage.rs
@@ -46,7 +46,7 @@ fn test_bank_storage() {
     let jill = Keypair::new();
 
     let x = 42;
-    let last_id = hash(&[x]);
+    let last_id = genesis_block.hash();
     let x2 = x * 2;
     let storage_last_id = hash(&[x2]);
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -96,6 +96,9 @@ pub struct Bank {
     /// Hash of this Bank's parent's state
     parent_hash: Hash,
 
+    /// Bank tick height
+    tick_height: AtomicUsize, // TODO: Use AtomicU64 if/when available
+
     /// Bank fork (i.e. slot, i.e. block)
     slot: u64,
 
@@ -149,6 +152,8 @@ impl Bank {
 
         let mut bank = Self::default();
         bank.tick_hash_queue = RwLock::new(parent.tick_hash_queue.read().unwrap().clone());
+        bank.tick_height
+            .store(parent.tick_height.load(Ordering::SeqCst), Ordering::SeqCst);
         bank.ticks_per_slot = parent.ticks_per_slot;
         bank.slots_per_epoch = parent.slots_per_epoch;
         bank.stakers_slot_offset = parent.stakers_slot_offset;
@@ -347,15 +352,22 @@ impl Bank {
         if self.is_frozen() {
             warn!("=========== FIXME: register_tick() working on a frozen bank! ================");
         }
+
         // TODO: put this assert back in
         // assert!(!self.is_frozen());
+
         let current_tick_height = {
-            // Atomic register and read the tick
+            self.tick_height.fetch_add(1, Ordering::SeqCst);
+            self.tick_height.load(Ordering::SeqCst) as u64
+        };
+
+        {
             let mut tick_hash_queue = self.tick_hash_queue.write().unwrap();
             inc_new_counter_info!("bank-register_tick-registered", 1);
             tick_hash_queue.register_hash(hash);
-            tick_hash_queue.hash_height()
-        };
+            assert_eq!(current_tick_height, tick_hash_queue.hash_height())
+        }
+
         if current_tick_height % NUM_TICKS_PER_SECOND == 0 {
             self.status_cache.write().unwrap().new_cache(hash);
         }
@@ -736,7 +748,11 @@ impl Bank {
 
     /// Return the number of ticks since genesis.
     pub fn tick_height(&self) -> u64 {
-        self.tick_hash_queue.read().unwrap().hash_height()
+        // tick_height is using an AtomicUSize because AtomicU64 is not yet a stable API.
+        // Until we can switch to AtomicU64, fail if usize is not the same as u64
+        assert_eq!(std::usize::MAX, 0xFFFFFFFFFFFFFFFF);
+
+        self.tick_height.load(Ordering::SeqCst) as u64
     }
 
     /// Return the number of ticks since the last slot boundary.

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -116,6 +116,12 @@ pub struct Bank {
     epoch_vote_accounts: HashMap<u64, HashMap<Pubkey, Account>>,
 }
 
+impl Default for HashQueue {
+    fn default() -> Self {
+        Self::new(MAX_RECENT_TICK_HASHES)
+    }
+}
+
 impl Bank {
     pub fn new(genesis_block: &GenesisBlock) -> Self {
         Self::new_with_paths(&genesis_block, None)

--- a/runtime/src/hash_queue.rs
+++ b/runtime/src/hash_queue.rs
@@ -32,6 +32,7 @@ impl HashQueue {
         }
     }
 
+    #[allow(dead_code)]
     pub fn hash_height(&self) -> u64 {
         self.hash_height
     }
@@ -78,7 +79,6 @@ impl HashQueue {
             self.entries
                 .retain(|_, entry| hash_height - entry.hash_height <= max_entries as u64);
         }
-
         self.entries.insert(
             *hash,
             HashQueueEntry {

--- a/sdk/src/timing.rs
+++ b/sdk/src/timing.rs
@@ -18,6 +18,8 @@ pub const DEFAULT_SLOTS_PER_EPOCH: u64 = 64;
 pub const MAX_HASH_AGE_IN_SECONDS: usize = 120;
 
 pub const MAX_RECENT_TICK_HASHES: usize = NUM_TICKS_PER_SECOND as usize * MAX_HASH_AGE_IN_SECONDS;
+pub const MAX_RECENT_BLOCK_HASHES: usize =
+    MAX_RECENT_TICK_HASHES / (DEFAULT_TICKS_PER_SLOT as usize);
 
 pub fn duration_as_us(d: &Duration) -> u64 {
     (d.as_secs() * 1000 * 1000) + (u64::from(d.subsec_nanos()) / 1_000)

--- a/tests/tvu.rs
+++ b/tests/tvu.rs
@@ -86,7 +86,7 @@ fn test_replay() {
     let tvu_addr = target1.info.tvu;
 
     let bank = Bank::new(&genesis_block);
-    let mut cur_hash = bank.last_id();
+    let last_id = bank.last_id();
     let bank_forks = BankForks::new(0, bank);
     let bank_forks_info = vec![BankForksInfo {
         bank_id: 0,
@@ -136,8 +136,9 @@ fn test_replay() {
     let mut msgs = Vec::new();
     let mut blob_idx = 0;
     let num_transfers = 10;
-    let transfer_amount = 501;
+    let mut transfer_amount = 501;
     let bob_keypair = Keypair::new();
+    let mut cur_hash = last_id;
     for i in 0..num_transfers {
         let entry0 = next_entry_mut(&mut cur_hash, i, vec![]);
         let entry_tick0 = next_entry_mut(&mut cur_hash, i + 1, vec![]);
@@ -146,7 +147,7 @@ fn test_replay() {
             &mint_keypair,
             bob_keypair.pubkey(),
             transfer_amount,
-            cur_hash,
+            last_id,
             0,
         );
         let entry_tick1 = next_entry_mut(&mut cur_hash, i + 1, vec![]);
@@ -154,6 +155,7 @@ fn test_replay() {
         let entry_tick2 = next_entry_mut(&mut cur_hash, i + 1, vec![]);
 
         alice_ref_balance -= transfer_amount;
+        transfer_amount -= 1; // Sneaky: change transfer_amount slightly to avoid DuplicateSignature errors
 
         let entries = vec![entry0, entry_tick0, entry_tick1, entry1, entry_tick2];
         let blobs = entries.to_shared_blobs();


### PR DESCRIPTION
This PR moves last_id generation from once per tick to once per slot (the last tick in a slot is registered as a last_id).

TODO:
* [x] Clean up, fix up some tests