### PR TITLE
Fix stakes not being setup correctly in tests

### DIFF
--- a/core/src/fullnode.rs
+++ b/core/src/fullnode.rs
@@ -459,8 +459,13 @@ pub fn make_active_set_entries(
     let voting_keypair = VotingKeypair::new_local(active_keypair);
     let vote_account_id = voting_keypair.pubkey();
 
-    let new_vote_account_tx =
-        VoteTransaction::fund_staking_account(active_keypair, vote_account_id, *blockhash, 1, 1);
+    let new_vote_account_tx = VoteTransaction::fund_staking_account(
+        active_keypair,
+        vote_account_id,
+        *blockhash,
+        stake.saturating_sub(2),
+        1,
+    );
     let new_vote_account_entry = next_entry_mut(&mut last_entry_hash, 1, vec![new_vote_account_tx]);
 
     // 3) Create vote entry

--- a/core/src/leader_schedule_utils.rs
+++ b/core/src/leader_schedule_utils.rs
@@ -100,13 +100,14 @@ pub fn num_ticks_left_in_slot(bank: &Bank, tick_height: u64) -> u64 {
 mod tests {
     use super::*;
     use crate::staking_utils;
-    use solana_sdk::genesis_block::GenesisBlock;
+    use solana_sdk::genesis_block::{GenesisBlock, BOOTSTRAP_LEADER_TOKENS};
     use solana_sdk::signature::{Keypair, KeypairUtil};
 
     #[test]
     fn test_leader_schedule_via_bank() {
         let pubkey = Keypair::new().pubkey();
-        let (genesis_block, _mint_keypair) = GenesisBlock::new_with_leader(2, pubkey, 2);
+        let (genesis_block, _mint_keypair) =
+            GenesisBlock::new_with_leader(BOOTSTRAP_LEADER_TOKENS, pubkey, BOOTSTRAP_LEADER_TOKENS);
         let bank = Bank::new(&genesis_block);
 
         let ids_and_stakes: Vec<_> = staking_utils::node_stakes(&bank).into_iter().collect();
@@ -122,7 +123,9 @@ mod tests {
     #[test]
     fn test_leader_scheduler1_basic() {
         let pubkey = Keypair::new().pubkey();
-        let genesis_block = GenesisBlock::new_with_leader(2, pubkey, 2).0;
+        let genesis_block =
+            GenesisBlock::new_with_leader(BOOTSTRAP_LEADER_TOKENS, pubkey, BOOTSTRAP_LEADER_TOKENS)
+                .0;
         let bank = Bank::new(&genesis_block);
         assert_eq!(slot_leader(&bank), pubkey);
     }

--- a/core/src/local_cluster.rs
+++ b/core/src/local_cluster.rs
@@ -189,7 +189,7 @@ mod test {
     #[test]
     fn test_local_cluster_start_and_exit() {
         solana_logger::setup();
-        let network = LocalCluster::new(1, 100, 2);
+        let network = LocalCluster::new(1, 100, 3);
         drop(network)
     }
 }

--- a/core/src/staking_utils.rs
+++ b/core/src/staking_utils.rs
@@ -158,8 +158,9 @@ mod tests {
     #[test]
     fn test_bank_staked_nodes_at_epoch() {
         let pubkey = Keypair::new().pubkey();
-        let bootstrap_tokens = 2;
-        let (genesis_block, _) = GenesisBlock::new_with_leader(2, pubkey, bootstrap_tokens);
+        let bootstrap_tokens = 3;
+        let (genesis_block, _) =
+            GenesisBlock::new_with_leader(bootstrap_tokens, pubkey, bootstrap_tokens);
         let bank = Bank::new(&genesis_block);
         let bank = new_from_parent(&Arc::new(bank));
         let ticks_per_offset = bank.stakers_slot_offset() * bank.ticks_per_slot();
@@ -167,7 +168,7 @@ mod tests {
         assert_eq!(bank.slot_height(), bank.stakers_slot_offset());
 
         let mut expected = HashMap::new();
-        expected.insert(pubkey, vec![bootstrap_tokens - 1]);
+        expected.insert(pubkey, vec![bootstrap_tokens - 2]);
         let bank = new_from_parent(&Arc::new(bank));
         assert_eq!(
             node_stakes_at_slot_extractor(&bank, bank.slot_height(), |s, _| s),

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -238,7 +238,7 @@ impl Bank {
         assert!(genesis_block.bootstrap_leader_id != Pubkey::default());
         assert!(genesis_block.bootstrap_leader_vote_account_id != Pubkey::default());
         assert!(genesis_block.tokens >= genesis_block.bootstrap_leader_tokens);
-        assert!(genesis_block.bootstrap_leader_tokens >= 2);
+        assert!(genesis_block.bootstrap_leader_tokens >= 3);
 
         // Bootstrap leader collects fees until `new_from_parent` is called.
         self.collector_id = genesis_block.bootstrap_leader_id;
@@ -246,13 +246,15 @@ impl Bank {
         let mint_tokens = genesis_block.tokens - genesis_block.bootstrap_leader_tokens;
         self.deposit(&genesis_block.mint_id, mint_tokens);
 
-        let bootstrap_leader_tokens = genesis_block.bootstrap_leader_tokens - 1;
+        let bootstrap_leader_tokens = 2;
+        let bootstrap_leader_stake =
+            genesis_block.bootstrap_leader_tokens - bootstrap_leader_tokens;
         self.deposit(&genesis_block.bootstrap_leader_id, bootstrap_leader_tokens);
 
         // Construct a vote account for the bootstrap_leader such that the leader_scheduler
         // will be forced to select it as the leader for height 0
-        let mut bootstrap_leader_vote_account = Account {
-            tokens: 1,
+        let mut bootstrap_leader_staking_account = Account {
+            tokens: bootstrap_leader_stake,
             userdata: vec![0; vote_program::get_max_size() as usize],
             owner: vote_program::id(),
             executable: false,
@@ -263,13 +265,13 @@ impl Bank {
             .votes
             .push_back(vote_program::Lockout::new(&vote_program::Vote::new(0)));
         vote_state
-            .serialize(&mut bootstrap_leader_vote_account.userdata)
+            .serialize(&mut bootstrap_leader_staking_account.userdata)
             .unwrap();
 
         self.accounts().store_slow(
             self.accounts_id,
             &genesis_block.bootstrap_leader_vote_account_id,
-            &bootstrap_leader_vote_account,
+            &bootstrap_leader_staking_account,
         );
 
         self.blockhash_queue
@@ -1103,9 +1105,8 @@ mod tests {
     #[test]
     fn test_bank_tx_fee() {
         let leader = Keypair::new().pubkey();
-        let (genesis_block, mint_keypair) = GenesisBlock::new_with_leader(100, leader, 2);
+        let (genesis_block, mint_keypair) = GenesisBlock::new_with_leader(100, leader, 3);
         let bank = Bank::new(&genesis_block);
-
         let key1 = Keypair::new();
         let key2 = Keypair::new();
 
@@ -1115,20 +1116,20 @@ mod tests {
         assert_eq!(bank.process_transaction(&tx), Ok(()));
         assert_eq!(bank.get_balance(&leader), initial_balance + 3);
         assert_eq!(bank.get_balance(&key1.pubkey()), 2);
-        assert_eq!(bank.get_balance(&mint_keypair.pubkey()), 100 - 4 - 3);
+        assert_eq!(bank.get_balance(&mint_keypair.pubkey()), 100 - 5 - 3);
 
         let tx = SystemTransaction::new_move(&key1, key2.pubkey(), 1, genesis_block.hash(), 1);
         assert_eq!(bank.process_transaction(&tx), Ok(()));
         assert_eq!(bank.get_balance(&leader), initial_balance + 4);
         assert_eq!(bank.get_balance(&key1.pubkey()), 0);
         assert_eq!(bank.get_balance(&key2.pubkey()), 1);
-        assert_eq!(bank.get_balance(&mint_keypair.pubkey()), 100 - 4 - 3);
+        assert_eq!(bank.get_balance(&mint_keypair.pubkey()), 100 - 5 - 3);
     }
 
     #[test]
     fn test_filter_program_errors_and_collect_fee() {
         let leader = Keypair::new().pubkey();
-        let (genesis_block, mint_keypair) = GenesisBlock::new_with_leader(100, leader, 2);
+        let (genesis_block, mint_keypair) = GenesisBlock::new_with_leader(100, leader, 3);
         let bank = Bank::new(&genesis_block);
 
         let key = Keypair::new();
@@ -1182,12 +1183,12 @@ mod tests {
     #[test]
     fn test_process_genesis() {
         let dummy_leader_id = Keypair::new().pubkey();
-        let dummy_leader_tokens = 2;
+        let dummy_leader_tokens = 3;
         let (genesis_block, _) =
             GenesisBlock::new_with_leader(5, dummy_leader_id, dummy_leader_tokens);
         let bank = Bank::new(&genesis_block);
-        assert_eq!(bank.get_balance(&genesis_block.mint_id), 3);
-        assert_eq!(bank.get_balance(&dummy_leader_id), 1);
+        assert_eq!(bank.get_balance(&genesis_block.mint_id), 2);
+        assert_eq!(bank.get_balance(&dummy_leader_id), 2);
     }
 
     // Register n ticks and return the tick, slot and epoch indexes.
@@ -1496,7 +1497,7 @@ mod tests {
     #[test]
     fn test_bank_epoch_vote_accounts() {
         let leader_id = Keypair::new().pubkey();
-        let leader_tokens = 2;
+        let leader_tokens = 3;
         let (mut genesis_block, _) = GenesisBlock::new_with_leader(5, leader_id, leader_tokens);
 
         // set this up weird, forces:

--- a/sdk/src/genesis_block.rs
+++ b/sdk/src/genesis_block.rs
@@ -9,9 +9,9 @@ use std::io::Write;
 use std::path::Path;
 
 // The default (and minimal) amount of tokens given to the bootstrap leader:
-// * 1 token for the bootstrap leader ID account
+// * 2 tokens for the bootstrap leader ID account to later setup another vote account
 // * 1 token for the bootstrap leader vote account
-pub const BOOTSTRAP_LEADER_TOKENS: u64 = 2;
+pub const BOOTSTRAP_LEADER_TOKENS: u64 = 3;
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct GenesisBlock {


### PR DESCRIPTION
#### Problem

Stakes were being assigned to Node accounts instead of their staking accounts. 

#### Summary of Changes

Reversed the logic such that Node account balances are 1 and the tokens are all transferred to the staking account instead. Tests that were sensitive to this have been disabled and so I'm not adding them back right away.
