### PR TITLE
Refactor bank get vote accounts 

### DIFF
--- a/benches/banking_stage.rs
+++ b/benches/banking_stage.rs
@@ -118,13 +118,8 @@ fn bench_banking_stage_multi_accounts(bencher: &mut Bencher) {
         })
         .collect();
     let (poh_recorder, poh_service) = create_test_recorder(&bank);
-    let (_stage, signal_receiver) = BankingStage::new(
-        &bank,
-        &poh_recorder,
-        verified_receiver,
-        std::u64::MAX,
-        genesis_block.bootstrap_leader_id,
-    );
+    let (_stage, signal_receiver) =
+        BankingStage::new(&bank, &poh_recorder, verified_receiver, std::u64::MAX);
 
     let mut id = genesis_block.hash();
     for _ in 0..MAX_RECENT_TICK_HASHES {
@@ -227,13 +222,8 @@ fn bench_banking_stage_multi_programs(bencher: &mut Bencher) {
         })
         .collect();
     let (poh_recorder, poh_service) = create_test_recorder(&bank);
-    let (_stage, signal_receiver) = BankingStage::new(
-        &bank,
-        &poh_recorder,
-        verified_receiver,
-        std::u64::MAX,
-        genesis_block.bootstrap_leader_id,
-    );
+    let (_stage, signal_receiver) =
+        BankingStage::new(&bank, &poh_recorder, verified_receiver, std::u64::MAX);
 
     let mut id = genesis_block.hash();
     for _ in 0..MAX_RECENT_TICK_HASHES {

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -379,7 +379,6 @@ mod tests {
             &poh_recorder,
             verified_receiver,
             DEFAULT_TICKS_PER_SLOT,
-            genesis_block.bootstrap_leader_id,
         );
         drop(verified_sender);
         banking_stage.join().unwrap();
@@ -399,7 +398,6 @@ mod tests {
             &poh_recorder,
             verified_receiver,
             genesis_block.ticks_per_slot - 1,
-            genesis_block.bootstrap_leader_id,
         );
         sleep(Duration::from_millis(600));
         drop(verified_sender);
@@ -427,7 +425,6 @@ mod tests {
             &poh_recorder,
             verified_receiver,
             DEFAULT_TICKS_PER_SLOT,
-            genesis_block.bootstrap_leader_id,
         );
 
         // good tx
@@ -486,7 +483,6 @@ mod tests {
             &poh_recorder,
             verified_receiver,
             DEFAULT_TICKS_PER_SLOT,
-            genesis_block.bootstrap_leader_id,
         );
 
         // Process a batch that includes a transaction that receives two tokens.
@@ -549,13 +545,8 @@ mod tests {
         let (verified_sender, verified_receiver) = channel();
         let max_tick_height = 10;
         let (poh_recorder, poh_service) = create_test_recorder(&bank);
-        let (banking_stage, _entry_receiver) = BankingStage::new(
-            &bank,
-            &poh_recorder,
-            verified_receiver,
-            max_tick_height,
-            genesis_block.bootstrap_leader_id,
-        );
+        let (banking_stage, _entry_receiver) =
+            BankingStage::new(&bank, &poh_recorder, verified_receiver, max_tick_height);
 
         loop {
             let bank_tick_height = bank.tick_height();
@@ -578,13 +569,8 @@ mod tests {
         let ticks_per_slot = 1;
         let (verified_sender, verified_receiver) = channel();
         let (poh_recorder, poh_service) = create_test_recorder(&bank);
-        let (mut banking_stage, _entry_receiver) = BankingStage::new(
-            &bank,
-            &poh_recorder,
-            verified_receiver,
-            ticks_per_slot,
-            genesis_block.bootstrap_leader_id,
-        );
+        let (mut banking_stage, _entry_receiver) =
+            BankingStage::new(&bank, &poh_recorder, verified_receiver, ticks_per_slot);
 
         // Wait for Poh recorder to hit max height
         loop {

--- a/core/src/leader_confirmation_service.rs
+++ b/core/src/leader_confirmation_service.rs
@@ -37,13 +37,13 @@ impl LeaderConfirmationService {
         bank.vote_accounts().for_each(|(_, account)| {
             total_stake += account.tokens;
             let vote_state = VoteState::deserialize(&account.userdata).unwrap();
-            slots_and_stakes.push(
-                vote_state
-                    .votes
-                    .back()
-                    .map(|vote| (vote.slot_height, account.tokens))
-                    .unwrap(),
-            );
+            if let Some(stake_and_state) = vote_state
+                .votes
+                .back()
+                .map(|vote| (vote.slot_height, account.tokens))
+            {
+                slots_and_stakes.push(stake_and_state);
+            }
         });
 
         let super_majority_stake = (2 * total_stake) / 3;

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -226,13 +226,8 @@ impl Tpu {
             .map(|meta| meta.consumed)
             .unwrap_or(0);
 
-        let (banking_stage, entry_receiver) = BankingStage::new(
-            &bank,
-            poh_recorder,
-            verified_receiver,
-            max_tick_height,
-            self.id,
-        );
+        let (banking_stage, entry_receiver) =
+            BankingStage::new(&bank, poh_recorder, verified_receiver, max_tick_height);
 
         let broadcast_stage = BroadcastStage::new(
             slot,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -787,9 +787,9 @@ impl Bank {
     }
 
     /// current vote accounts for this bank
-    pub fn vote_accounts<F, T>(&self, filter: F) -> HashMap<Pubkey, T>
+    pub fn vote_accounts<F, T>(&self, mut filter: F) -> HashMap<Pubkey, T>
     where
-        F: Fn(&Pubkey, &Account) -> Option<(Pubkey, T)>,
+        F: FnMut(&Pubkey, &Account) -> Option<(Pubkey, T)>,
     {
         self.accounts()
             .get_vote_accounts(self.accounts_id)

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -142,7 +142,7 @@ impl Bank {
 
         // genesis needs stakes for all epochs up to the epoch implied by
         //  slot = 0 and genesis configuration
-        let vote_accounts = bank.vote_accounts(|k, v| Some((*k, v.clone())));
+        let vote_accounts: HashMap<_, _> = bank.vote_accounts().collect();
         for i in 0..=bank.epoch_from_stakers_slot_offset() {
             bank.epoch_vote_accounts.insert(i, vote_accounts.clone());
         }
@@ -182,7 +182,7 @@ impl Bank {
             //  if my parent didn't populate for this epoch, we've
             //  crossed a boundary
             if epoch_vote_accounts.get(&epoch).is_none() {
-                epoch_vote_accounts.insert(epoch, bank.vote_accounts(|k, v| Some((*k, v.clone()))));
+                epoch_vote_accounts.insert(epoch, bank.vote_accounts().collect());
             }
             epoch_vote_accounts
         };
@@ -787,15 +787,8 @@ impl Bank {
     }
 
     /// current vote accounts for this bank
-    pub fn vote_accounts<F, T>(&self, mut filter: F) -> HashMap<Pubkey, T>
-    where
-        F: FnMut(&Pubkey, &Account) -> Option<(Pubkey, T)>,
-    {
-        self.accounts()
-            .get_vote_accounts(self.accounts_id)
-            .iter()
-            .filter_map(|(pubkey, account)| filter(pubkey, account))
-            .collect()
+    pub fn vote_accounts(&self) -> impl Iterator<Item = (Pubkey, Account)> {
+        self.accounts().get_vote_accounts(self.accounts_id)
     }
 
     ///  vote accounts for the specific epoch
@@ -817,11 +810,10 @@ impl Bank {
     {
         self.accounts()
             .get_vote_accounts(self.accounts_id)
-            .iter()
             .filter_map(|(p, account)| {
                 if let Ok(vote_state) = VoteState::deserialize(&account.userdata) {
                     if cond(&p, &vote_state) {
-                        return Some((*p, vote_state));
+                        return Some((p, vote_state));
                     }
                 }
                 None


### PR DESCRIPTION
#### Problem

Requiring a closure to filter out elements makes `bank::vote_accounts` and `accounts::get_vote_accounts` unnecessarily complicated. Instead returning an iterator allows for much more flexibility.

#### Summary of Changes

Refactored the two fns mentioned above, and cleaned up `leader_confirmation_service::get_last_supermajority_timestamp`

