### PR TITLE
[woot!] Route a channel to send banks from replay to banking

### DIFF
--- a/benches/banking_stage.rs
+++ b/benches/banking_stage.rs
@@ -4,12 +4,12 @@ extern crate test;
 
 use rand::{thread_rng, Rng};
 use rayon::prelude::*;
-use solana::banking_stage::{BankingStage, TpuBankEntries};
+use solana::banking_stage::{create_test_recorder, BankingStage};
 use solana::cluster_info::ClusterInfo;
 use solana::cluster_info::Node;
 use solana::packet::to_packets_chunked;
-use solana::poh_recorder::PohRecorder;
-use solana::poh_service::{PohService, PohServiceConfig};
+use solana::poh_recorder::WorkingBankEntries;
+use solana::service::Service;
 use solana_runtime::bank::Bank;
 use solana_sdk::genesis_block::GenesisBlock;
 use solana_sdk::hash::hash;
@@ -18,13 +18,12 @@ use solana_sdk::signature::{KeypairUtil, Signature};
 use solana_sdk::system_transaction::SystemTransaction;
 use solana_sdk::timing::MAX_RECENT_TICK_HASHES;
 use std::iter;
-use std::sync::atomic::AtomicBool;
 use std::sync::mpsc::{channel, Receiver};
-use std::sync::{Arc, Mutex, RwLock};
+use std::sync::{Arc, RwLock};
 use std::time::Duration;
 use test::Bencher;
 
-fn check_txs(receiver: &Receiver<TpuBankEntries>, ref_tx_count: usize) {
+fn check_txs(receiver: &Receiver<WorkingBankEntries>, ref_tx_count: usize) {
     let mut total = 0;
     loop {
         let entries = receiver.recv_timeout(Duration::new(1, 0));
@@ -40,20 +39,6 @@ fn check_txs(receiver: &Receiver<TpuBankEntries>, ref_tx_count: usize) {
         }
     }
     assert_eq!(total, ref_tx_count);
-}
-
-fn create_test_recorder(bank: &Arc<Bank>) -> (Arc<Mutex<PohRecorder>>, PohService) {
-    let exit = Arc::new(AtomicBool::new(false));
-    let poh_recorder = Arc::new(Mutex::new(PohRecorder::new(
-        bank.tick_height(),
-        bank.last_id(),
-    )));
-    let poh_service = PohService::new(
-        poh_recorder.clone(),
-        &PohServiceConfig::default(),
-        exit.clone(),
-    );
-    (poh_recorder, poh_service)
 }
 
 #[bench]
@@ -118,17 +103,11 @@ fn bench_banking_stage_multi_accounts(bencher: &mut Bencher) {
             (x, iter::repeat(1).take(len).collect())
         })
         .collect();
-    let (poh_recorder, poh_service) = create_test_recorder(&bank);
-    let (bank_sender, bank_receiver) = channel();
+    let (poh_recorder, poh_service, signal_receiver) = create_test_recorder(&bank);
     let cluster_info = ClusterInfo::new(Node::new_localhost().info);
     let cluster_info = Arc::new(RwLock::new(cluster_info));
-    let (banking_stage, signal_receiver) = BankingStage::new(
-        &cluster_info,
-        bank_receiver,
-        &poh_recorder,
-        verified_receiver,
-    );
-    bank_sender.send(bank.clone()).expect("sending bank");
+    let banking_stage = BankingStage::new(&cluster_info, &poh_recorder, verified_receiver);
+    poh_recorder.lock().unwrap().set_bank(&bank);
 
     let mut id = genesis_block.hash();
     for _ in 0..MAX_RECENT_TICK_HASHES {
@@ -150,7 +129,6 @@ fn bench_banking_stage_multi_accounts(bencher: &mut Bencher) {
         start %= verified.len();
     });
     poh_service.close().unwrap();
-    banking_stage.exit();
 }
 
 #[bench]
@@ -231,17 +209,11 @@ fn bench_banking_stage_multi_programs(bencher: &mut Bencher) {
             (x, iter::repeat(1).take(len).collect())
         })
         .collect();
-    let (poh_recorder, poh_service) = create_test_recorder(&bank);
-    let (bank_sender, bank_receiver) = channel();
+    let (poh_recorder, poh_service, signal_receiver) = create_test_recorder(&bank);
     let cluster_info = ClusterInfo::new(Node::new_localhost().info);
     let cluster_info = Arc::new(RwLock::new(cluster_info));
-    let (banking_stage, signal_receiver) = BankingStage::new(
-        &cluster_info,
-        bank_receiver,
-        &poh_recorder,
-        verified_receiver,
-    );
-    bank_sender.send(bank.clone()).expect("sending bank");
+    let banking_stage = BankingStage::new(&cluster_info, &poh_recorder, verified_receiver);
+    poh_recorder.lock().unwrap().set_bank(&bank);
 
     let mut id = genesis_block.hash();
     for _ in 0..MAX_RECENT_TICK_HASHES {
@@ -263,5 +235,4 @@ fn bench_banking_stage_multi_programs(bencher: &mut Bencher) {
         start %= verified.len();
     });
     poh_service.close().unwrap();
-    banking_stage.exit();
 }

--- a/benches/banking_stage.rs
+++ b/benches/banking_stage.rs
@@ -118,13 +118,16 @@ fn bench_banking_stage_multi_accounts(bencher: &mut Bencher) {
         })
         .collect();
     let (poh_recorder, poh_service) = create_test_recorder(&bank);
-    let (_stage, signal_receiver) = BankingStage::new(
-        &bank,
+    let (bank_sender, bank_receiver) = channel();
+    let cluster_info = ClusterInfo::new(Node::new_localhost().info);
+    let cluster_info = Arc::new(RwLock::new(cluster_info));
+    let (banking_stage, signal_receiver) = BankingStage::new(
+        &cluster_info,
+        bank_receiver,
         &poh_recorder,
         verified_receiver,
-        std::u64::MAX,
-        genesis_block.bootstrap_leader_id,
     );
+    bank_sender.send(bank.clone()).expect("sending bank");
 
     let mut id = genesis_block.hash();
     for _ in 0..MAX_RECENT_TICK_HASHES {
@@ -227,13 +230,16 @@ fn bench_banking_stage_multi_programs(bencher: &mut Bencher) {
         })
         .collect();
     let (poh_recorder, poh_service) = create_test_recorder(&bank);
-    let (_stage, signal_receiver) = BankingStage::new(
-        &bank,
+    let (bank_sender, bank_receiver) = channel();
+    let cluster_info = ClusterInfo::new(Node::new_localhost().info);
+    let cluster_info = Arc::new(RwLock::new(cluster_info));
+    let (banking_stage, signal_receiver) = BankingStage::new(
+        &cluster_info,
+        bank_receiver,
         &poh_recorder,
         verified_receiver,
-        std::u64::MAX,
-        genesis_block.bootstrap_leader_id,
     );
+    bank_sender.send(bank.clone()).expect("sending bank");
 
     let mut id = genesis_block.hash();
     for _ in 0..MAX_RECENT_TICK_HASHES {

--- a/src/banking_stage.rs
+++ b/src/banking_stage.rs
@@ -139,14 +139,14 @@ impl BankingStage {
                     return Ok(bank);
                 }
             }
-            if let Some(leader) = cluster_info.read().unwrap().leader_data() {
-                while let Ok(mms) = verified_receiver.lock().unwrap().try_recv() {
+            while let Ok(mms) = verified_receiver.lock().unwrap().try_recv() {
+                if let Some(leader) = cluster_info.read().unwrap().leader_data() {
                     let _ = Self::forward_verified_packets(&leader.tpu, mms);
-                    let result = bank_receiver.try_recv();
-                    if result.is_ok() {
-                        let bank = result?;
-                        return Ok(bank);
-                    }
+                }
+                let result = bank_receiver.try_recv();
+                if result.is_ok() {
+                    let bank = result?;
+                    return Ok(bank);
                 }
             }
         }

--- a/src/banking_stage.rs
+++ b/src/banking_stage.rs
@@ -33,7 +33,7 @@ pub const NUM_THREADS: u32 = 10;
 
 /// Stores the stage's thread handle and output receiver.
 pub struct BankingStage {
-    bank_thread_hdls: Vec<JoinHandle<UnprocessedPackets>>,
+    bank_thread_hdls: Vec<JoinHandle<Result<()>>>,
     exit: Arc<AtomicBool>,
     leader_confirmation_service: LeaderConfirmationService,
 }
@@ -60,42 +60,39 @@ impl BankingStage {
         let leader_confirmation_service = LeaderConfirmationService::new(leader_id, exit.clone());
 
         // Many banks that process transactions in parallel.
-        let bank_thread_hdls: Vec<JoinHandle<UnprocessedPackets>> = (0..Self::num_threads())
+        let bank_thread_hdls: Vec<JoinHandle<Result<()>>> = (0..Self::num_threads())
             .map(|_| {
                 let verified_receiver = verified_receiver.clone();
                 let poh_recorder = poh_recorder.clone();
+                let cluster_info = cluster_info.clone();
                 Builder::new()
                     .name("solana-banking-stage-tx".to_string())
-                    .spawn(move || {
-                        Self::start_forwarder(vec![]);
-                        loop {
-                            let bank = Self::forward_until_bank(
-                                &cluster_info,
-                                &bank_receiver,
-                                &verified_receiver,
-                            )?;
-                            let max_tick_height = (bank.slot() + 1) * bank.ticks_per_slot() - 1;
-                            let working_bank = WorkingBank {
-                                bank: bank.clone(),
-                                sender: entry_sender,
-                                min_tick_height: bank.tick_height(),
-                                max_tick_height,
-                            };
+                    .spawn(move || loop {
+                        let bank = Self::forward_until_bank(
+                            &cluster_info,
+                            &bank_receiver,
+                            &verified_receiver,
+                        )?;
+                        let max_tick_height = (bank.slot() + 1) * bank.ticks_per_slot() - 1;
+                        let working_bank = WorkingBank {
+                            bank: bank.clone(),
+                            sender: entry_sender,
+                            min_tick_height: bank.tick_height(),
+                            max_tick_height,
+                        };
 
-                            info!(
-                                "new working bank {} {} {}",
-                                working_bank.min_tick_height,
-                                working_bank.max_tick_height,
-                                poh_recorder.lock().unwrap().poh.tick_height
-                            );
-                            leader_confirmation_service.set_bank(bank.clone());
-                            poh_recorder.lock().unwrap().set_working_bank(working_bank);
+                        info!(
+                            "new working bank {} {} {}",
+                            working_bank.min_tick_height,
+                            working_bank.max_tick_height,
+                            poh_recorder.lock().unwrap().poh.tick_height
+                        );
+                        leader_confirmation_service.set_bank(bank.clone());
+                        poh_recorder.lock().unwrap().set_working_bank(working_bank);
 
-                            let packets =
-                                Self::process_loop(&bank, verified_receiver, poh_recorder);
-                            let tpu = cluster_info.read().unwrap().leader_data().unwrap().tpu;
-                            Self::forward_unprocessed_packets(tpu, packets);
-                        }
+                        let packets = Self::process_loop(&bank, &verified_receiver, &poh_recorder);
+                        let tpu = cluster_info.read().unwrap().leader_data().unwrap().tpu;
+                        Self::forward_unprocessed_packets(&tpu, packets);
                     })
                     .unwrap()
             })
@@ -118,14 +115,18 @@ impl BankingStage {
         loop {
             let result = bank_receiver.recv_timeout(Duration::from_millis(100));
             match result {
-                Err(Error::RecvTimeoutError(RecvTimeoutError::Timeout)) => (),
-                _ => return result,
+                Err(RecvTimeoutError::Timeout) => (),
+                _ => {
+                    let bank = result?;
+                    return Ok(bank);
+                }
             }
             let tpu = cluster_info.read().unwrap().leader_data().unwrap().tpu;
             while let Ok(mms) = verified_receiver.lock().unwrap().try_recv() {
-                let _ = Self::forward_verified_packets(tpu, mms);
-                let bank = bank_receiver.try_recv();
-                if bank.is_ok() {
+                let _ = Self::forward_verified_packets(&tpu, mms);
+                let result = bank_receiver.try_recv();
+                if result.is_ok() {
+                    let bank = result?;
                     return Ok(bank);
                 }
             }
@@ -140,7 +141,7 @@ impl BankingStage {
         for (packets, sigverify) in verified_packets {
             let packets = packets.read().unwrap();
             for (packet, valid) in packets.packets.iter().zip(&sigverify) {
-                if valid == 0 {
+                if *valid == 0 {
                     continue;
                 }
                 socket.send_to(&packet.data[..packet.meta.size], tpu)?;
@@ -387,17 +388,8 @@ impl BankingStage {
         Ok(unprocessed_packets)
     }
 
-    pub fn join_and_collect_unprocessed_packets(&mut self) -> UnprocessedPackets {
-        let mut unprocessed_packets: UnprocessedPackets = vec![];
-        for bank_thread_hdl in self.bank_thread_hdls.drain(..) {
-            match bank_thread_hdl.join() {
-                Ok(more_unprocessed_packets) => {
-                    unprocessed_packets.extend(more_unprocessed_packets)
-                }
-                err => warn!("bank_thread_hdl join failed: {:?}", err),
-            }
-        }
-        unprocessed_packets
+    pub fn exit(&self) -> () {
+        self.exit.store(true, Ordering::Relaxed);
     }
 }
 
@@ -406,7 +398,7 @@ impl Service for BankingStage {
 
     fn join(self) -> thread::Result<()> {
         for bank_thread_hdl in self.bank_thread_hdls {
-            bank_thread_hdl.join()?;
+            let _ = bank_thread_hdl.join()?;
         }
         self.exit.store(true, Ordering::Relaxed);
         self.leader_confirmation_service.join()?;
@@ -414,389 +406,389 @@ impl Service for BankingStage {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::entry::EntrySlice;
-    use crate::packet::to_packets;
-    use crate::poh_service::{PohService, PohServiceConfig};
-    use solana_sdk::genesis_block::GenesisBlock;
-    use solana_sdk::native_program::ProgramError;
-    use solana_sdk::signature::{Keypair, KeypairUtil};
-    use solana_sdk::system_transaction::SystemTransaction;
-    use solana_sdk::timing::DEFAULT_TICKS_PER_SLOT;
-    use std::thread::sleep;
-
-    fn create_test_recorder(bank: &Arc<Bank>) -> (Arc<Mutex<PohRecorder>>, PohService) {
-        let exit = Arc::new(AtomicBool::new(false));
-        let poh_recorder = Arc::new(Mutex::new(PohRecorder::new(
-            bank.tick_height(),
-            bank.last_id(),
-        )));
-        let poh_service = PohService::new(
-            poh_recorder.clone(),
-            &PohServiceConfig::default(),
-            exit.clone(),
-        );
-        (poh_recorder, poh_service)
-    }
-
-    #[test]
-    fn test_banking_stage_shutdown1() {
-        let (genesis_block, _mint_keypair) = GenesisBlock::new(2);
-        let bank = Arc::new(Bank::new(&genesis_block));
-        let (verified_sender, verified_receiver) = channel();
-        let (poh_recorder, poh_service) = create_test_recorder(&bank);
-        let (banking_stage, _entry_receiver) = BankingStage::new(
-            &bank,
-            &poh_recorder,
-            verified_receiver,
-            DEFAULT_TICKS_PER_SLOT,
-            genesis_block.bootstrap_leader_id,
-        );
-        drop(verified_sender);
-        banking_stage.join().unwrap();
-        poh_service.close().unwrap();
-    }
-
-    #[test]
-    fn test_banking_stage_tick() {
-        let (genesis_block, _mint_keypair) = GenesisBlock::new(2);
-        let bank = Arc::new(Bank::new(&genesis_block));
-        let start_hash = bank.last_id();
-        let (verified_sender, verified_receiver) = channel();
-        let (poh_recorder, poh_service) = create_test_recorder(&bank);
-        let (banking_stage, entry_receiver) = BankingStage::new(
-            &bank,
-            &poh_recorder,
-            verified_receiver,
-            DEFAULT_TICKS_PER_SLOT,
-            genesis_block.bootstrap_leader_id,
-        );
-        sleep(Duration::from_millis(500));
-        drop(verified_sender);
-
-        let entries: Vec<_> = entry_receiver
-            .iter()
-            .flat_map(|x| x.into_iter().map(|e| e.0))
-            .collect();
-        assert!(entries.len() != 0);
-        assert!(entries.verify(&start_hash));
-        assert_eq!(entries[entries.len() - 1].hash, bank.last_id());
-        banking_stage.join().unwrap();
-        poh_service.close().unwrap();
-    }
-
-    #[test]
-    fn test_banking_stage_entries_only() {
-        let (genesis_block, mint_keypair) = GenesisBlock::new(2);
-        let bank = Arc::new(Bank::new(&genesis_block));
-        let start_hash = bank.last_id();
-        let (verified_sender, verified_receiver) = channel();
-        let (poh_recorder, poh_service) = create_test_recorder(&bank);
-        let (banking_stage, entry_receiver) = BankingStage::new(
-            &bank,
-            &poh_recorder,
-            verified_receiver,
-            DEFAULT_TICKS_PER_SLOT,
-            genesis_block.bootstrap_leader_id,
-        );
-
-        // good tx
-        let keypair = mint_keypair;
-        let tx = SystemTransaction::new_account(&keypair, keypair.pubkey(), 1, start_hash, 0);
-
-        // good tx, but no verify
-        let tx_no_ver =
-            SystemTransaction::new_account(&keypair, keypair.pubkey(), 1, start_hash, 0);
-
-        // bad tx, AccountNotFound
-        let keypair = Keypair::new();
-        let tx_anf = SystemTransaction::new_account(&keypair, keypair.pubkey(), 1, start_hash, 0);
-
-        // send 'em over
-        let packets = to_packets(&[tx, tx_no_ver, tx_anf]);
-
-        // glad they all fit
-        assert_eq!(packets.len(), 1);
-        verified_sender // tx, no_ver, anf
-            .send(vec![(packets[0].clone(), vec![1u8, 0u8, 1u8])])
-            .unwrap();
-
-        drop(verified_sender);
-
-        //receive entries + ticks
-        let entries: Vec<Vec<Entry>> = entry_receiver
-            .iter()
-            .map(|x| x.into_iter().map(|e| e.0).collect())
-            .collect();
-
-        assert!(entries.len() >= 1);
-
-        let mut last_id = start_hash;
-        entries.iter().for_each(|entries| {
-            assert_eq!(entries.len(), 1);
-            assert!(entries.verify(&last_id));
-            last_id = entries.last().unwrap().hash;
-        });
-        drop(entry_receiver);
-        banking_stage.join().unwrap();
-        poh_service.close().unwrap();
-    }
-    #[test]
-    #[ignore] //flaky
-    fn test_banking_stage_entryfication() {
-        // In this attack we'll demonstrate that a verifier can interpret the ledger
-        // differently if either the server doesn't signal the ledger to add an
-        // Entry OR if the verifier tries to parallelize across multiple Entries.
-        let (genesis_block, mint_keypair) = GenesisBlock::new(2);
-        let bank = Arc::new(Bank::new(&genesis_block));
-        let (verified_sender, verified_receiver) = channel();
-        let (poh_recorder, poh_service) = create_test_recorder(&bank);
-        let (banking_stage, entry_receiver) = BankingStage::new(
-            &bank,
-            &poh_recorder,
-            verified_receiver,
-            DEFAULT_TICKS_PER_SLOT,
-            genesis_block.bootstrap_leader_id,
-        );
-
-        // Process a batch that includes a transaction that receives two tokens.
-        let alice = Keypair::new();
-        let tx = SystemTransaction::new_account(
-            &mint_keypair,
-            alice.pubkey(),
-            2,
-            genesis_block.hash(),
-            0,
-        );
-
-        let packets = to_packets(&[tx]);
-        verified_sender
-            .send(vec![(packets[0].clone(), vec![1u8])])
-            .unwrap();
-
-        // Process a second batch that spends one of those tokens.
-        let tx = SystemTransaction::new_account(
-            &alice,
-            mint_keypair.pubkey(),
-            1,
-            genesis_block.hash(),
-            0,
-        );
-        let packets = to_packets(&[tx]);
-        verified_sender
-            .send(vec![(packets[0].clone(), vec![1u8])])
-            .unwrap();
-        drop(verified_sender);
-        banking_stage.join().unwrap();
-
-        // Collect the ledger and feed it to a new bank.
-        let entries: Vec<_> = entry_receiver
-            .iter()
-            .flat_map(|x| x.into_iter().map(|e| e.0))
-            .collect();
-        // same assertion as running through the bank, really...
-        assert!(entries.len() >= 2);
-
-        // Assert the user holds one token, not two. If the stage only outputs one
-        // entry, then the second transaction will be rejected, because it drives
-        // the account balance below zero before the credit is added.
-        let bank = Bank::new(&genesis_block);
-        for entry in entries {
-            bank.process_transactions(&entry.transactions)
-                .iter()
-                .for_each(|x| assert_eq!(*x, Ok(())));
-        }
-        assert_eq!(bank.get_balance(&alice.pubkey()), 1);
-        poh_service.close().unwrap();
-    }
-
-    // Test that when the max_tick_height is reached, the banking stage exits
-    #[test]
-    fn test_max_tick_height_shutdown() {
-        solana_logger::setup();
-        let (genesis_block, _mint_keypair) = GenesisBlock::new(2);
-        let bank = Arc::new(Bank::new(&genesis_block));
-        let (verified_sender, verified_receiver) = channel();
-        let max_tick_height = 10;
-        let (poh_recorder, poh_service) = create_test_recorder(&bank);
-        let (banking_stage, _entry_receiver) = BankingStage::new(
-            &bank,
-            &poh_recorder,
-            verified_receiver,
-            max_tick_height,
-            genesis_block.bootstrap_leader_id,
-        );
-
-        loop {
-            let bank_tick_height = bank.tick_height();
-            if bank_tick_height >= max_tick_height {
-                break;
-            }
-            sleep(Duration::from_millis(10));
-        }
-
-        drop(verified_sender);
-        banking_stage.join().unwrap();
-        poh_service.close().unwrap();
-    }
-
-    #[test]
-    fn test_returns_unprocessed_packet() {
-        solana_logger::setup();
-        let (genesis_block, mint_keypair) = GenesisBlock::new(2);
-        let bank = Arc::new(Bank::new(&genesis_block));
-        let ticks_per_slot = 1;
-        let (verified_sender, verified_receiver) = channel();
-        let (poh_recorder, poh_service) = create_test_recorder(&bank);
-        let (mut banking_stage, _entry_receiver) = BankingStage::new(
-            &bank,
-            &poh_recorder,
-            verified_receiver,
-            ticks_per_slot,
-            genesis_block.bootstrap_leader_id,
-        );
-
-        // Wait for Poh recorder to hit max height
-        loop {
-            let bank_tick_height = bank.tick_height();
-            if bank_tick_height >= ticks_per_slot {
-                break;
-            }
-            sleep(Duration::from_millis(10));
-        }
-
-        // Now send a transaction to the banking stage
-        let transaction = SystemTransaction::new_account(
-            &mint_keypair,
-            Keypair::new().pubkey(),
-            2,
-            genesis_block.hash(),
-            0,
-        );
-
-        let packets = to_packets(&[transaction]);
-        verified_sender
-            .send(vec![(packets[0].clone(), vec![1u8])])
-            .unwrap();
-
-        // Shut down the banking stage, it should give back the transaction
-        drop(verified_sender);
-        let unprocessed_packets = banking_stage.join_and_collect_unprocessed_packets();
-        assert_eq!(unprocessed_packets.len(), 1);
-        let (packets, start_index) = &unprocessed_packets[0];
-        assert_eq!(packets.read().unwrap().packets.len(), 1); // TODO: maybe compare actual packet contents too
-        assert_eq!(*start_index, 0);
-        poh_service.close().unwrap();
-    }
-
-    #[test]
-    fn test_bank_record_transactions() {
-        let (genesis_block, mint_keypair) = GenesisBlock::new(10_000);
-        let bank = Arc::new(Bank::new(&genesis_block));
-        let (entry_sender, entry_receiver) = channel();
-        let working_bank = WorkingBank {
-            bank: bank.clone(),
-            sender: entry_sender,
-            min_tick_height: bank.tick_height(),
-            max_tick_height: std::u64::MAX,
-        };
-
-        let poh_recorder = Arc::new(Mutex::new(PohRecorder::new(
-            bank.tick_height(),
-            bank.last_id(),
-        )));
-        poh_recorder.lock().unwrap().set_working_bank(working_bank);
-        let pubkey = Keypair::new().pubkey();
-
-        let transactions = vec![
-            SystemTransaction::new_move(&mint_keypair, pubkey, 1, genesis_block.hash(), 0),
-            SystemTransaction::new_move(&mint_keypair, pubkey, 1, genesis_block.hash(), 0),
-        ];
-
-        let mut results = vec![Ok(()), Ok(())];
-        BankingStage::record_transactions(&transactions, &results, &poh_recorder).unwrap();
-        let entries = entry_receiver.recv().unwrap();
-        assert_eq!(entries[0].0.transactions.len(), transactions.len());
-
-        // ProgramErrors should still be recorded
-        results[0] = Err(BankError::ProgramError(
-            1,
-            ProgramError::ResultWithNegativeTokens,
-        ));
-        BankingStage::record_transactions(&transactions, &results, &poh_recorder).unwrap();
-        let entries = entry_receiver.recv().unwrap();
-        assert_eq!(entries[0].0.transactions.len(), transactions.len());
-
-        // Other BankErrors should not be recorded
-        results[0] = Err(BankError::AccountNotFound);
-        BankingStage::record_transactions(&transactions, &results, &poh_recorder).unwrap();
-        let entries = entry_receiver.recv().unwrap();
-        assert_eq!(entries[0].0.transactions.len(), transactions.len() - 1);
-    }
-
-    #[test]
-    fn test_bank_process_and_record_transactions() {
-        solana_logger::setup();
-        let (genesis_block, mint_keypair) = GenesisBlock::new(10_000);
-        let bank = Arc::new(Bank::new(&genesis_block));
-        let pubkey = Keypair::new().pubkey();
-
-        let transactions = vec![SystemTransaction::new_move(
-            &mint_keypair,
-            pubkey,
-            1,
-            genesis_block.hash(),
-            0,
-        )];
-
-        let (entry_sender, entry_receiver) = channel();
-        let working_bank = WorkingBank {
-            bank: bank.clone(),
-            sender: entry_sender,
-            min_tick_height: bank.tick_height(),
-            max_tick_height: bank.tick_height() + 1,
-        };
-        let poh_recorder = Arc::new(Mutex::new(PohRecorder::new(
-            bank.tick_height(),
-            bank.last_id(),
-        )));
-        poh_recorder.lock().unwrap().set_working_bank(working_bank);
-
-        BankingStage::process_and_record_transactions(&bank, &transactions, &poh_recorder).unwrap();
-        poh_recorder.lock().unwrap().tick();
-
-        let mut need_tick = true;
-        // read entries until I find mine, might be ticks...
-        while let Ok(entries) = entry_receiver.recv() {
-            for (entry, _) in entries {
-                if !entry.is_tick() {
-                    trace!("got entry");
-                    assert_eq!(entry.transactions.len(), transactions.len());
-                    assert_eq!(bank.get_balance(&pubkey), 1);
-                    need_tick = false;
-                } else {
-                    break;
-                }
-            }
-        }
-
-        assert_eq!(need_tick, false);
-
-        let transactions = vec![SystemTransaction::new_move(
-            &mint_keypair,
-            pubkey,
-            2,
-            genesis_block.hash(),
-            0,
-        )];
-
-        assert_matches!(
-            BankingStage::process_and_record_transactions(&bank, &transactions, &poh_recorder,),
-            Err(Error::PohRecorderError(PohRecorderError::MaxHeightReached))
-        );
-
-        assert_eq!(bank.get_balance(&pubkey), 1);
-    }
-}
+// #[cfg(test)]
+// mod tests {
+//     use super::*;
+//     use crate::entry::EntrySlice;
+//     use crate::packet::to_packets;
+//     use crate::poh_service::{PohService, PohServiceConfig};
+//     use solana_sdk::genesis_block::GenesisBlock;
+//     use solana_sdk::native_program::ProgramError;
+//     use solana_sdk::signature::{Keypair, KeypairUtil};
+//     use solana_sdk::system_transaction::SystemTransaction;
+//     use solana_sdk::timing::DEFAULT_TICKS_PER_SLOT;
+//     use std::thread::sleep;
+//
+//     fn create_test_recorder(bank: &Arc<Bank>) -> (Arc<Mutex<PohRecorder>>, PohService) {
+//         let exit = Arc::new(AtomicBool::new(false));
+//         let poh_recorder = Arc::new(Mutex::new(PohRecorder::new(
+//             bank.tick_height(),
+//             bank.last_id(),
+//         )));
+//         let poh_service = PohService::new(
+//             poh_recorder.clone(),
+//             &PohServiceConfig::default(),
+//             exit.clone(),
+//         );
+//         (poh_recorder, poh_service)
+//     }
+//
+//     #[test]
+//     fn test_banking_stage_shutdown1() {
+//         let (genesis_block, _mint_keypair) = GenesisBlock::new(2);
+//         let bank = Arc::new(Bank::new(&genesis_block));
+//         let (verified_sender, verified_receiver) = channel();
+//         let (poh_recorder, poh_service) = create_test_recorder(&bank);
+//         let (banking_stage, _entry_receiver) = BankingStage::new(
+//             &bank,
+//             &poh_recorder,
+//             verified_receiver,
+//             DEFAULT_TICKS_PER_SLOT,
+//             genesis_block.bootstrap_leader_id,
+//         );
+//         drop(verified_sender);
+//         banking_stage.join().unwrap();
+//         poh_service.close().unwrap();
+//     }
+//
+//     #[test]
+//     fn test_banking_stage_tick() {
+//         let (genesis_block, _mint_keypair) = GenesisBlock::new(2);
+//         let bank = Arc::new(Bank::new(&genesis_block));
+//         let start_hash = bank.last_id();
+//         let (verified_sender, verified_receiver) = channel();
+//         let (poh_recorder, poh_service) = create_test_recorder(&bank);
+//         let (banking_stage, entry_receiver) = BankingStage::new(
+//             &bank,
+//             &poh_recorder,
+//             verified_receiver,
+//             DEFAULT_TICKS_PER_SLOT,
+//             genesis_block.bootstrap_leader_id,
+//         );
+//         sleep(Duration::from_millis(500));
+//         drop(verified_sender);
+//
+//         let entries: Vec<_> = entry_receiver
+//             .iter()
+//             .flat_map(|x| x.into_iter().map(|e| e.0))
+//             .collect();
+//         assert!(entries.len() != 0);
+//         assert!(entries.verify(&start_hash));
+//         assert_eq!(entries[entries.len() - 1].hash, bank.last_id());
+//         banking_stage.join().unwrap();
+//         poh_service.close().unwrap();
+//     }
+//
+//     #[test]
+//     fn test_banking_stage_entries_only() {
+//         let (genesis_block, mint_keypair) = GenesisBlock::new(2);
+//         let bank = Arc::new(Bank::new(&genesis_block));
+//         let start_hash = bank.last_id();
+//         let (verified_sender, verified_receiver) = channel();
+//         let (poh_recorder, poh_service) = create_test_recorder(&bank);
+//         let (banking_stage, entry_receiver) = BankingStage::new(
+//             &bank,
+//             &poh_recorder,
+//             verified_receiver,
+//             DEFAULT_TICKS_PER_SLOT,
+//             genesis_block.bootstrap_leader_id,
+//         );
+//
+//         // good tx
+//         let keypair = mint_keypair;
+//         let tx = SystemTransaction::new_account(&keypair, keypair.pubkey(), 1, start_hash, 0);
+//
+//         // good tx, but no verify
+//         let tx_no_ver =
+//             SystemTransaction::new_account(&keypair, keypair.pubkey(), 1, start_hash, 0);
+//
+//         // bad tx, AccountNotFound
+//         let keypair = Keypair::new();
+//         let tx_anf = SystemTransaction::new_account(&keypair, keypair.pubkey(), 1, start_hash, 0);
+//
+//         // send 'em over
+//         let packets = to_packets(&[tx, tx_no_ver, tx_anf]);
+//
+//         // glad they all fit
+//         assert_eq!(packets.len(), 1);
+//         verified_sender // tx, no_ver, anf
+//             .send(vec![(packets[0].clone(), vec![1u8, 0u8, 1u8])])
+//             .unwrap();
+//
+//         drop(verified_sender);
+//
+//         //receive entries + ticks
+//         let entries: Vec<Vec<Entry>> = entry_receiver
+//             .iter()
+//             .map(|x| x.into_iter().map(|e| e.0).collect())
+//             .collect();
+//
+//         assert!(entries.len() >= 1);
+//
+//         let mut last_id = start_hash;
+//         entries.iter().for_each(|entries| {
+//             assert_eq!(entries.len(), 1);
+//             assert!(entries.verify(&last_id));
+//             last_id = entries.last().unwrap().hash;
+//         });
+//         drop(entry_receiver);
+//         banking_stage.join().unwrap();
+//         poh_service.close().unwrap();
+//     }
+//     #[test]
+//     #[ignore] //flaky
+//     fn test_banking_stage_entryfication() {
+//         // In this attack we'll demonstrate that a verifier can interpret the ledger
+//         // differently if either the server doesn't signal the ledger to add an
+//         // Entry OR if the verifier tries to parallelize across multiple Entries.
+//         let (genesis_block, mint_keypair) = GenesisBlock::new(2);
+//         let bank = Arc::new(Bank::new(&genesis_block));
+//         let (verified_sender, verified_receiver) = channel();
+//         let (poh_recorder, poh_service) = create_test_recorder(&bank);
+//         let (banking_stage, entry_receiver) = BankingStage::new(
+//             &bank,
+//             &poh_recorder,
+//             verified_receiver,
+//             DEFAULT_TICKS_PER_SLOT,
+//             genesis_block.bootstrap_leader_id,
+//         );
+//
+//         // Process a batch that includes a transaction that receives two tokens.
+//         let alice = Keypair::new();
+//         let tx = SystemTransaction::new_account(
+//             &mint_keypair,
+//             alice.pubkey(),
+//             2,
+//             genesis_block.hash(),
+//             0,
+//         );
+//
+//         let packets = to_packets(&[tx]);
+//         verified_sender
+//             .send(vec![(packets[0].clone(), vec![1u8])])
+//             .unwrap();
+//
+//         // Process a second batch that spends one of those tokens.
+//         let tx = SystemTransaction::new_account(
+//             &alice,
+//             mint_keypair.pubkey(),
+//             1,
+//             genesis_block.hash(),
+//             0,
+//         );
+//         let packets = to_packets(&[tx]);
+//         verified_sender
+//             .send(vec![(packets[0].clone(), vec![1u8])])
+//             .unwrap();
+//         drop(verified_sender);
+//         banking_stage.join().unwrap();
+//
+//         // Collect the ledger and feed it to a new bank.
+//         let entries: Vec<_> = entry_receiver
+//             .iter()
+//             .flat_map(|x| x.into_iter().map(|e| e.0))
+//             .collect();
+//         // same assertion as running through the bank, really...
+//         assert!(entries.len() >= 2);
+//
+//         // Assert the user holds one token, not two. If the stage only outputs one
+//         // entry, then the second transaction will be rejected, because it drives
+//         // the account balance below zero before the credit is added.
+//         let bank = Bank::new(&genesis_block);
+//         for entry in entries {
+//             bank.process_transactions(&entry.transactions)
+//                 .iter()
+//                 .for_each(|x| assert_eq!(*x, Ok(())));
+//         }
+//         assert_eq!(bank.get_balance(&alice.pubkey()), 1);
+//         poh_service.close().unwrap();
+//     }
+//
+//     // Test that when the max_tick_height is reached, the banking stage exits
+//     #[test]
+//     fn test_max_tick_height_shutdown() {
+//         solana_logger::setup();
+//         let (genesis_block, _mint_keypair) = GenesisBlock::new(2);
+//         let bank = Arc::new(Bank::new(&genesis_block));
+//         let (verified_sender, verified_receiver) = channel();
+//         let max_tick_height = 10;
+//         let (poh_recorder, poh_service) = create_test_recorder(&bank);
+//         let (banking_stage, _entry_receiver) = BankingStage::new(
+//             &bank,
+//             &poh_recorder,
+//             verified_receiver,
+//             max_tick_height,
+//             genesis_block.bootstrap_leader_id,
+//         );
+//
+//         loop {
+//             let bank_tick_height = bank.tick_height();
+//             if bank_tick_height >= max_tick_height {
+//                 break;
+//             }
+//             sleep(Duration::from_millis(10));
+//         }
+//
+//         drop(verified_sender);
+//         banking_stage.join().unwrap();
+//         poh_service.close().unwrap();
+//     }
+//
+//     #[test]
+//     fn test_returns_unprocessed_packet() {
+//         solana_logger::setup();
+//         let (genesis_block, mint_keypair) = GenesisBlock::new(2);
+//         let bank = Arc::new(Bank::new(&genesis_block));
+//         let ticks_per_slot = 1;
+//         let (verified_sender, verified_receiver) = channel();
+//         let (poh_recorder, poh_service) = create_test_recorder(&bank);
+//         let (mut banking_stage, _entry_receiver) = BankingStage::new(
+//             &bank,
+//             &poh_recorder,
+//             verified_receiver,
+//             ticks_per_slot,
+//             genesis_block.bootstrap_leader_id,
+//         );
+//
+//         // Wait for Poh recorder to hit max height
+//         loop {
+//             let bank_tick_height = bank.tick_height();
+//             if bank_tick_height >= ticks_per_slot {
+//                 break;
+//             }
+//             sleep(Duration::from_millis(10));
+//         }
+//
+//         // Now send a transaction to the banking stage
+//         let transaction = SystemTransaction::new_account(
+//             &mint_keypair,
+//             Keypair::new().pubkey(),
+//             2,
+//             genesis_block.hash(),
+//             0,
+//         );
+//
+//         let packets = to_packets(&[transaction]);
+//         verified_sender
+//             .send(vec![(packets[0].clone(), vec![1u8])])
+//             .unwrap();
+//
+//         // Shut down the banking stage, it should give back the transaction
+//         drop(verified_sender);
+//         let unprocessed_packets = banking_stage.join_and_collect_unprocessed_packets();
+//         assert_eq!(unprocessed_packets.len(), 1);
+//         let (packets, start_index) = &unprocessed_packets[0];
+//         assert_eq!(packets.read().unwrap().packets.len(), 1); // TODO: maybe compare actual packet contents too
+//         assert_eq!(*start_index, 0);
+//         poh_service.close().unwrap();
+//     }
+//
+//     #[test]
+//     fn test_bank_record_transactions() {
+//         let (genesis_block, mint_keypair) = GenesisBlock::new(10_000);
+//         let bank = Arc::new(Bank::new(&genesis_block));
+//         let (entry_sender, entry_receiver) = channel();
+//         let working_bank = WorkingBank {
+//             bank: bank.clone(),
+//             sender: entry_sender,
+//             min_tick_height: bank.tick_height(),
+//             max_tick_height: std::u64::MAX,
+//         };
+//
+//         let poh_recorder = Arc::new(Mutex::new(PohRecorder::new(
+//             bank.tick_height(),
+//             bank.last_id(),
+//         )));
+//         poh_recorder.lock().unwrap().set_working_bank(working_bank);
+//         let pubkey = Keypair::new().pubkey();
+//
+//         let transactions = vec![
+//             SystemTransaction::new_move(&mint_keypair, pubkey, 1, genesis_block.hash(), 0),
+//             SystemTransaction::new_move(&mint_keypair, pubkey, 1, genesis_block.hash(), 0),
+//         ];
+//
+//         let mut results = vec![Ok(()), Ok(())];
+//         BankingStage::record_transactions(&transactions, &results, &poh_recorder).unwrap();
+//         let entries = entry_receiver.recv().unwrap();
+//         assert_eq!(entries[0].0.transactions.len(), transactions.len());
+//
+//         // ProgramErrors should still be recorded
+//         results[0] = Err(BankError::ProgramError(
+//             1,
+//             ProgramError::ResultWithNegativeTokens,
+//         ));
+//         BankingStage::record_transactions(&transactions, &results, &poh_recorder).unwrap();
+//         let entries = entry_receiver.recv().unwrap();
+//         assert_eq!(entries[0].0.transactions.len(), transactions.len());
+//
+//         // Other BankErrors should not be recorded
+//         results[0] = Err(BankError::AccountNotFound);
+//         BankingStage::record_transactions(&transactions, &results, &poh_recorder).unwrap();
+//         let entries = entry_receiver.recv().unwrap();
+//         assert_eq!(entries[0].0.transactions.len(), transactions.len() - 1);
+//     }
+//
+//     #[test]
+//     fn test_bank_process_and_record_transactions() {
+//         solana_logger::setup();
+//         let (genesis_block, mint_keypair) = GenesisBlock::new(10_000);
+//         let bank = Arc::new(Bank::new(&genesis_block));
+//         let pubkey = Keypair::new().pubkey();
+//
+//         let transactions = vec![SystemTransaction::new_move(
+//             &mint_keypair,
+//             pubkey,
+//             1,
+//             genesis_block.hash(),
+//             0,
+//         )];
+//
+//         let (entry_sender, entry_receiver) = channel();
+//         let working_bank = WorkingBank {
+//             bank: bank.clone(),
+//             sender: entry_sender,
+//             min_tick_height: bank.tick_height(),
+//             max_tick_height: bank.tick_height() + 1,
+//         };
+//         let poh_recorder = Arc::new(Mutex::new(PohRecorder::new(
+//             bank.tick_height(),
+//             bank.last_id(),
+//         )));
+//         poh_recorder.lock().unwrap().set_working_bank(working_bank);
+//
+//         BankingStage::process_and_record_transactions(&bank, &transactions, &poh_recorder).unwrap();
+//         poh_recorder.lock().unwrap().tick();
+//
+//         let mut need_tick = true;
+//         // read entries until I find mine, might be ticks...
+//         while let Ok(entries) = entry_receiver.recv() {
+//             for (entry, _) in entries {
+//                 if !entry.is_tick() {
+//                     trace!("got entry");
+//                     assert_eq!(entry.transactions.len(), transactions.len());
+//                     assert_eq!(bank.get_balance(&pubkey), 1);
+//                     need_tick = false;
+//                 } else {
+//                     break;
+//                 }
+//             }
+//         }
+//
+//         assert_eq!(need_tick, false);
+//
+//         let transactions = vec![SystemTransaction::new_move(
+//             &mint_keypair,
+//             pubkey,
+//             2,
+//             genesis_block.hash(),
+//             0,
+//         )];
+//
+//         assert_matches!(
+//             BankingStage::process_and_record_transactions(&bank, &transactions, &poh_recorder,),
+//             Err(Error::PohRecorderError(PohRecorderError::MaxHeightReached))
+//         );
+//
+//         assert_eq!(bank.get_balance(&pubkey), 1);
+//     }
+// }

--- a/src/banking_stage.rs
+++ b/src/banking_stage.rs
@@ -76,7 +76,7 @@ impl BankingStage {
                             let packets =
                                 Self::process_loop(&bank, &verified_receiver, &poh_recorder);
                             let tpu = cluster_info.read().unwrap().leader_data().unwrap().tpu;
-                            Self::forward_unprocessed_packets(&tpu, packets);
+                            Self::forward_unprocessed_packets(&tpu, packets)?;
                         }
                     })
                     .unwrap()

--- a/src/banking_stage.rs
+++ b/src/banking_stage.rs
@@ -37,6 +37,8 @@ pub struct BankingStage {
     lcs_handle: JoinHandle<()>,
 }
 
+pub type TpuBankEntries = (Arc<Bank>, Vec<(Entry, u64)>);
+
 impl BankingStage {
     /// Create the stage using `bank`. Exit when `verified_receiver` is dropped.
     #[allow(clippy::new_ret_no_self)]
@@ -45,7 +47,7 @@ impl BankingStage {
         bank_receiver: Receiver<Arc<Bank>>,
         poh_recorder: &Arc<Mutex<PohRecorder>>,
         verified_receiver: Receiver<VerifiedPackets>,
-    ) -> (Self, Receiver<(Arc<Bank>, Vec<(Entry, u64)>)>) {
+    ) -> (Self, Receiver<TpuBankEntries>) {
         let (entry_sender, entry_receiver) = channel();
         let verified_receiver = Arc::new(Mutex::new(verified_receiver));
 
@@ -405,7 +407,7 @@ impl BankingStage {
         Ok(unprocessed_packets)
     }
 
-    pub fn exit(&self) -> () {
+    pub fn exit(&self) {
         self.exit.store(true, Ordering::Relaxed);
     }
 }

--- a/src/banking_stage.rs
+++ b/src/banking_stage.rs
@@ -19,7 +19,7 @@ use solana_sdk::timing::{self, duration_as_us, MAX_RECENT_TICK_HASHES};
 use solana_sdk::transaction::Transaction;
 use std::net::UdpSocket;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::mpsc::{channel, Receiver, RecvTimeoutError};
+use std::sync::mpsc::{Receiver, RecvTimeoutError};
 use std::sync::{Arc, Mutex, RwLock};
 use std::thread::{self, Builder, JoinHandle};
 use std::time::Duration;
@@ -373,6 +373,7 @@ mod tests {
     use solana_sdk::native_program::ProgramError;
     use solana_sdk::signature::{Keypair, KeypairUtil};
     use solana_sdk::system_transaction::SystemTransaction;
+    use std::sync::mpsc::channel;
     use std::thread::sleep;
 
     #[test]

--- a/src/banking_stage.rs
+++ b/src/banking_stage.rs
@@ -57,14 +57,15 @@ impl BankingStage {
         let exit = Arc::new(AtomicBool::new(false));
 
         // Single thread to compute confirmation
-        let (leader_confirmation_service, lcs_handle) = LeaderConfirmationService::new(leader_id, exit.clone());
+        let (leader_confirmation_service, lcs_handle) =
+            LeaderConfirmationService::new(leader_id, exit.clone());
         let (waiter, notifier) = sync_channel(Self::num_threads() as usize);
         // Many banks that process transactions in parallel.
         let mut bank_thread_hdls: Vec<JoinHandle<Result<()>>> = (0..Self::num_threads())
             .map(|_| {
                 let verified_receiver = verified_receiver.clone();
                 let poh_recorder = poh_recorder.clone();
-        		let cluster_info = cluster_info.clone();
+                let cluster_info = cluster_info.clone();
                 let waiter = waiter.clone();
                 Builder::new()
                     .name("solana-banking-stage-tx".to_string())

--- a/src/banking_stage.rs
+++ b/src/banking_stage.rs
@@ -52,7 +52,7 @@ impl BankingStage {
         let exit = Arc::new(AtomicBool::new(false));
 
         // Single thread to compute confirmation
-        let lcs_handle = LeaderConfirmationService::new(&poh_recorder, exit.clone());
+        let lcs_handle = LeaderConfirmationService::start(&poh_recorder, exit.clone());
         // Many banks that process transactions in parallel.
         let mut bank_thread_hdls: Vec<JoinHandle<()>> = (0..Self::num_threads())
             .map(|_| {

--- a/src/broadcast_stage.rs
+++ b/src/broadcast_stage.rs
@@ -318,6 +318,7 @@ mod test {
     }
 
     #[test]
+    #[ignore]
     //TODO this test won't work since broadcast stage no longer edits the ledger
     fn test_broadcast_ledger() {
         let ledger_path = get_tmp_ledger_path("test_broadcast_ledger");

--- a/src/broadcast_stage.rs
+++ b/src/broadcast_stage.rs
@@ -1,5 +1,6 @@
 //! A stage to broadcast data from a leader node to validators
 //!
+use crate::banking_stage::TpuBankEntries;
 use crate::blocktree::Blocktree;
 use crate::cluster_info::{ClusterInfo, ClusterInfoError, DATA_PLANE_FANOUT};
 use crate::entry::EntrySlice;
@@ -7,7 +8,6 @@ use crate::entry::EntrySlice;
 use crate::erasure::CodingGenerator;
 use crate::packet::index_blobs;
 use crate::result::{Error, Result};
-use crate::banking_stage::TpuBankEntries;
 use crate::service::Service;
 use crate::staking_utils;
 use rayon::prelude::*;

--- a/src/broadcast_stage.rs
+++ b/src/broadcast_stage.rs
@@ -1,12 +1,12 @@
 //! A stage to broadcast data from a leader node to validators
 //!
-use crate::banking_stage::TpuBankEntries;
 use crate::blocktree::Blocktree;
 use crate::cluster_info::{ClusterInfo, ClusterInfoError, DATA_PLANE_FANOUT};
 use crate::entry::EntrySlice;
 #[cfg(feature = "erasure")]
 use crate::erasure::CodingGenerator;
 use crate::packet::index_blobs;
+use crate::poh_recorder::WorkingBankEntries;
 use crate::result::{Error, Result};
 use crate::service::Service;
 use crate::staking_utils;
@@ -40,7 +40,7 @@ impl Broadcast {
     fn run(
         &mut self,
         cluster_info: &Arc<RwLock<ClusterInfo>>,
-        receiver: &Receiver<TpuBankEntries>,
+        receiver: &Receiver<WorkingBankEntries>,
         sock: &UdpSocket,
         blocktree: &Arc<Blocktree>,
     ) -> Result<()> {
@@ -178,7 +178,7 @@ impl BroadcastStage {
     fn run(
         sock: &UdpSocket,
         cluster_info: &Arc<RwLock<ClusterInfo>>,
-        receiver: &Receiver<TpuBankEntries>,
+        receiver: &Receiver<WorkingBankEntries>,
         exit_signal: &Arc<AtomicBool>,
         blocktree: &Arc<Blocktree>,
     ) -> BroadcastStageReturnType {
@@ -229,7 +229,7 @@ impl BroadcastStage {
     pub fn new(
         sock: UdpSocket,
         cluster_info: Arc<RwLock<ClusterInfo>>,
-        receiver: Receiver<TpuBankEntries>,
+        receiver: Receiver<WorkingBankEntries>,
         exit_sender: Arc<AtomicBool>,
         blocktree: &Arc<Blocktree>,
     ) -> Self {
@@ -281,7 +281,7 @@ mod test {
     fn setup_dummy_broadcast_service(
         leader_pubkey: Pubkey,
         ledger_path: &str,
-        entry_receiver: Receiver<TpuBankEntries>,
+        entry_receiver: Receiver<WorkingBankEntries>,
     ) -> MockBroadcastStage {
         // Make the database ledger
         let blocktree = Arc::new(Blocktree::open(ledger_path).unwrap());

--- a/src/broadcast_stage.rs
+++ b/src/broadcast_stage.rs
@@ -59,7 +59,7 @@ impl Broadcast {
         let max_tick_height = (bank.slot() + 1) * bank.ticks_per_slot() - 1;
         // TODO: Fix BankingStage/BroadcastStage to operate on `slot` directly instead of
         // `max_tick_height`
-        let blob_index = blocktree
+        let mut blob_index = blocktree
             .meta(bank.slot())
             .expect("Database error")
             .map(|meta| meta.consumed)

--- a/src/broadcast_stage.rs
+++ b/src/broadcast_stage.rs
@@ -1,7 +1,7 @@
 //! A stage to broadcast data from a leader node to validators
 //!
 use crate::blocktree::Blocktree;
-use crate::cluster_info::{ClusterInfo, ClusterInfoError, NodeInfo, DATA_PLANE_FANOUT};
+use crate::cluster_info::{ClusterInfo, ClusterInfoError, DATA_PLANE_FANOUT};
 use crate::entry::Entry;
 use crate::entry::EntrySlice;
 #[cfg(feature = "erasure")]
@@ -59,8 +59,7 @@ impl Broadcast {
         let max_tick_height = (bank.slot() + 1) * bank.ticks_per_slot() - 1;
         // TODO: Fix BankingStage/BroadcastStage to operate on `slot` directly instead of
         // `max_tick_height`
-        let blob_index = self
-            .blocktree
+        let blob_index = blocktree
             .meta(bank.slot())
             .expect("Database error")
             .map(|meta| meta.consumed)
@@ -96,8 +95,8 @@ impl Broadcast {
             .collect();
 
         // TODO: blob_index should be slot-relative...
-        index_blobs(&blobs, &self.id, &mut self.blob_index, slot_height);
-        let parent = bank.parent.map(|bank| bank.slot()).unwrap_or(0);
+        index_blobs(&blobs, &self.id, &mut blob_index, slot_height);
+        let parent = bank.parents().first().map(|bank| bank.slot()).unwrap_or(0);
         for b in blobs.iter() {
             b.write().unwrap().set_parent(parent);
         }
@@ -144,7 +143,7 @@ impl Broadcast {
             influxdb::Point::new("broadcast-service")
                 .add_field(
                     "transmit-index",
-                    influxdb::Value::Integer(self.blob_index as i64),
+                    influxdb::Value::Integer(blob_index as i64),
                 )
                 .to_owned(),
         );
@@ -180,7 +179,6 @@ impl BroadcastStage {
     fn run(
         sock: &UdpSocket,
         cluster_info: &Arc<RwLock<ClusterInfo>>,
-        blob_index: u64,
         receiver: &Receiver<(Arc<Bank>, Vec<(Entry, u64)>)>,
         exit_signal: &Arc<AtomicBool>,
         blocktree: &Arc<Blocktree>,
@@ -189,7 +187,6 @@ impl BroadcastStage {
 
         let mut broadcast = Broadcast {
             id: me.id,
-            blob_index,
             #[cfg(feature = "erasure")]
             coding_generator: CodingGenerator::new(),
         };
@@ -233,7 +230,7 @@ impl BroadcastStage {
     pub fn new(
         sock: UdpSocket,
         cluster_info: Arc<RwLock<ClusterInfo>>,
-        receiver: Receiver<Vec<(Entry, u64)>>,
+        receiver: Receiver<(Arc<Bank>, Vec<(Entry, u64)>)>,
         exit_sender: Arc<AtomicBool>,
         blocktree: &Arc<Blocktree>,
     ) -> Self {
@@ -259,116 +256,116 @@ impl Service for BroadcastStage {
     }
 }
 
-#[cfg(test)]
-mod test {
-    use super::*;
-    use crate::blocktree::{get_tmp_ledger_path, Blocktree};
-    use crate::cluster_info::{ClusterInfo, Node};
-    use crate::entry::create_ticks;
-    use crate::service::Service;
-    use solana_sdk::hash::Hash;
-    use solana_sdk::signature::{Keypair, KeypairUtil};
-    use solana_sdk::timing::DEFAULT_TICKS_PER_SLOT;
-    use std::sync::atomic::AtomicBool;
-    use std::sync::mpsc::channel;
-    use std::sync::{Arc, RwLock};
-    use std::thread::sleep;
-    use std::time::Duration;
-
-    struct MockBroadcastStage {
-        blocktree: Arc<Blocktree>,
-        broadcast_service: BroadcastStage,
-    }
-
-    fn setup_dummy_broadcast_service(
-        slot_height: u64,
-        leader_pubkey: Pubkey,
-        ledger_path: &str,
-        entry_receiver: Receiver<Vec<(Entry, u64)>>,
-        blob_index: u64,
-    ) -> MockBroadcastStage {
-        // Make the database ledger
-        let blocktree = Arc::new(Blocktree::open(ledger_path).unwrap());
-
-        // Make the leader node and scheduler
-        let leader_info = Node::new_localhost_with_pubkey(leader_pubkey);
-
-        // Make a node to broadcast to
-        let buddy_keypair = Keypair::new();
-        let broadcast_buddy = Node::new_localhost_with_pubkey(buddy_keypair.pubkey());
-
-        // Fill the cluster_info with the buddy's info
-        let mut cluster_info = ClusterInfo::new(leader_info.info.clone());
-        cluster_info.insert_info(broadcast_buddy.info);
-        let cluster_info = Arc::new(RwLock::new(cluster_info));
-
-        let exit_sender = Arc::new(AtomicBool::new(false));
-        let bank = Arc::new(Bank::default());
-
-        // Start up the broadcast stage
-        let broadcast_service = BroadcastStage::new(
-            slot_height,
-            &bank,
-            leader_info.sockets.broadcast,
-            cluster_info,
-            blob_index,
-            entry_receiver,
-            exit_sender,
-            &blocktree,
-        );
-
-        MockBroadcastStage {
-            blocktree,
-            broadcast_service,
-        }
-    }
-
-    #[test]
-    #[ignore]
-    //TODO this test won't work since broadcast stage no longer edits the ledger
-    fn test_broadcast_ledger() {
-        let ledger_path = get_tmp_ledger_path("test_broadcast_ledger");
-        {
-            // Create the leader scheduler
-            let leader_keypair = Keypair::new();
-            let start_tick_height = 0;
-            let max_tick_height = start_tick_height + DEFAULT_TICKS_PER_SLOT;
-
-            let (entry_sender, entry_receiver) = channel();
-            let broadcast_service = setup_dummy_broadcast_service(
-                0,
-                leader_keypair.pubkey(),
-                &ledger_path,
-                entry_receiver,
-                0,
-            );
-
-            let ticks = create_ticks(max_tick_height - start_tick_height, Hash::default());
-            for (i, tick) in ticks.into_iter().enumerate() {
-                entry_sender
-                    .send(vec![(tick, i as u64 + 1)])
-                    .expect("Expect successful send to broadcast service");
-            }
-
-            sleep(Duration::from_millis(2000));
-            let blocktree = broadcast_service.blocktree;
-            let mut blob_index = 0;
-            for i in 0..max_tick_height - start_tick_height {
-                let slot = (start_tick_height + i + 1) / DEFAULT_TICKS_PER_SLOT;
-
-                let result = blocktree.get_data_blob(slot, blob_index).unwrap();
-
-                blob_index += 1;
-                assert!(result.is_some());
-            }
-
-            drop(entry_sender);
-            broadcast_service
-                .broadcast_service
-                .join()
-                .expect("Expect successful join of broadcast service");
-        }
-
-        Blocktree::destroy(&ledger_path).expect("Expected successful database destruction");
-    }
-}
+// #[cfg(test)]
+// mod test {
+//     use super::*;
+//     use crate::blocktree::{get_tmp_ledger_path, Blocktree};
+//     use crate::cluster_info::{ClusterInfo, Node};
+//     use crate::entry::create_ticks;
+//     use crate::service::Service;
+//     use solana_sdk::hash::Hash;
+//     use solana_sdk::signature::{Keypair, KeypairUtil};
+//     use solana_sdk::timing::DEFAULT_TICKS_PER_SLOT;
+//     use std::sync::atomic::AtomicBool;
+//     use std::sync::mpsc::channel;
+//     use std::sync::{Arc, RwLock};
+//     use std::thread::sleep;
+//     use std::time::Duration;
+//
+//     struct MockBroadcastStage {
+//         blocktree: Arc<Blocktree>,
+//         broadcast_service: BroadcastStage,
+//     }
+//
+//     fn setup_dummy_broadcast_service(
+//         slot_height: u64,
+//         leader_pubkey: Pubkey,
+//         ledger_path: &str,
+//         entry_receiver: Receiver<Vec<(Entry, u64)>>,
+//         blob_index: u64,
+//     ) -> MockBroadcastStage {
+//         // Make the database ledger
+//         let blocktree = Arc::new(Blocktree::open(ledger_path).unwrap());
+//
+//         // Make the leader node and scheduler
+//         let leader_info = Node::new_localhost_with_pubkey(leader_pubkey);
+//
+//         // Make a node to broadcast to
+//         let buddy_keypair = Keypair::new();
+//         let broadcast_buddy = Node::new_localhost_with_pubkey(buddy_keypair.pubkey());
+//
+//         // Fill the cluster_info with the buddy's info
+//         let mut cluster_info = ClusterInfo::new(leader_info.info.clone());
+//         cluster_info.insert_info(broadcast_buddy.info);
+//         let cluster_info = Arc::new(RwLock::new(cluster_info));
+//
+//         let exit_sender = Arc::new(AtomicBool::new(false));
+//         let bank = Arc::new(Bank::default());
+//
+//         // Start up the broadcast stage
+//         let broadcast_service = BroadcastStage::new(
+//             slot_height,
+//             &bank,
+//             leader_info.sockets.broadcast,
+//             cluster_info,
+//             blob_index,
+//             entry_receiver,
+//             exit_sender,
+//             &blocktree,
+//         );
+//
+//         MockBroadcastStage {
+//             blocktree,
+//             broadcast_service,
+//         }
+//     }
+//
+//     #[test]
+//     #[ignore]
+//     //TODO this test won't work since broadcast stage no longer edits the ledger
+//     fn test_broadcast_ledger() {
+//         let ledger_path = get_tmp_ledger_path("test_broadcast_ledger");
+//         {
+//             // Create the leader scheduler
+//             let leader_keypair = Keypair::new();
+//             let start_tick_height = 0;
+//             let max_tick_height = start_tick_height + DEFAULT_TICKS_PER_SLOT;
+//
+//             let (entry_sender, entry_receiver) = channel();
+//             let broadcast_service = setup_dummy_broadcast_service(
+//                 0,
+//                 leader_keypair.pubkey(),
+//                 &ledger_path,
+//                 entry_receiver,
+//                 0,
+//             );
+//
+//             let ticks = create_ticks(max_tick_height - start_tick_height, Hash::default());
+//             for (i, tick) in ticks.into_iter().enumerate() {
+//                 entry_sender
+//                     .send(vec![(tick, i as u64 + 1)])
+//                     .expect("Expect successful send to broadcast service");
+//             }
+//
+//             sleep(Duration::from_millis(2000));
+//             let blocktree = broadcast_service.blocktree;
+//             let mut blob_index = 0;
+//             for i in 0..max_tick_height - start_tick_height {
+//                 let slot = (start_tick_height + i + 1) / DEFAULT_TICKS_PER_SLOT;
+//
+//                 let result = blocktree.get_data_blob(slot, blob_index).unwrap();
+//
+//                 blob_index += 1;
+//                 assert!(result.is_some());
+//             }
+//
+//             drop(entry_sender);
+//             broadcast_service
+//                 .broadcast_service
+//                 .join()
+//                 .expect("Expect successful join of broadcast service");
+//         }
+//
+//         Blocktree::destroy(&ledger_path).expect("Expected successful database destruction");
+//     }
+// }

--- a/src/broadcast_stage.rs
+++ b/src/broadcast_stage.rs
@@ -2,18 +2,17 @@
 //!
 use crate::blocktree::Blocktree;
 use crate::cluster_info::{ClusterInfo, ClusterInfoError, DATA_PLANE_FANOUT};
-use crate::entry::Entry;
 use crate::entry::EntrySlice;
 #[cfg(feature = "erasure")]
 use crate::erasure::CodingGenerator;
 use crate::packet::index_blobs;
 use crate::result::{Error, Result};
+use crate::banking_stage::TpuBankEntries;
 use crate::service::Service;
 use crate::staking_utils;
 use rayon::prelude::*;
 use solana_metrics::counter::Counter;
 use solana_metrics::{influxdb, submit};
-use solana_runtime::bank::Bank;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::timing::duration_as_ms;
 use std::net::UdpSocket;
@@ -41,7 +40,7 @@ impl Broadcast {
     fn run(
         &mut self,
         cluster_info: &Arc<RwLock<ClusterInfo>>,
-        receiver: &Receiver<(Arc<Bank>, Vec<(Entry, u64)>)>,
+        receiver: &Receiver<TpuBankEntries>,
         sock: &UdpSocket,
         blocktree: &Arc<Blocktree>,
     ) -> Result<()> {
@@ -179,7 +178,7 @@ impl BroadcastStage {
     fn run(
         sock: &UdpSocket,
         cluster_info: &Arc<RwLock<ClusterInfo>>,
-        receiver: &Receiver<(Arc<Bank>, Vec<(Entry, u64)>)>,
+        receiver: &Receiver<TpuBankEntries>,
         exit_signal: &Arc<AtomicBool>,
         blocktree: &Arc<Blocktree>,
     ) -> BroadcastStageReturnType {
@@ -230,7 +229,7 @@ impl BroadcastStage {
     pub fn new(
         sock: UdpSocket,
         cluster_info: Arc<RwLock<ClusterInfo>>,
-        receiver: Receiver<(Arc<Bank>, Vec<(Entry, u64)>)>,
+        receiver: Receiver<TpuBankEntries>,
         exit_sender: Arc<AtomicBool>,
         blocktree: &Arc<Blocktree>,
     ) -> Self {

--- a/src/fullnode.rs
+++ b/src/fullnode.rs
@@ -26,10 +26,9 @@ use solana_sdk::signature::{Keypair, KeypairUtil};
 use solana_sdk::system_transaction::SystemTransaction;
 use solana_sdk::timing::timestamp;
 use solana_sdk::vote_transaction::VoteTransaction;
-use std::net::UdpSocket;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::mpsc::{channel, Receiver, RecvTimeoutError, Sender};
+use std::sync::mpsc::{channel, Receiver};
 use std::sync::{Arc, Mutex, RwLock};
 use std::thread::sleep;
 use std::thread::JoinHandle;
@@ -93,6 +92,7 @@ pub struct Fullnode {
     gossip_service: GossipService,
     node_services: NodeServices,
     poh_service: PohService,
+    poh_recorder: Arc<Mutex<PohRecorder>>,
 }
 
 impl Fullnode {
@@ -226,8 +226,8 @@ impl Fullnode {
             sockets,
             blocktree.clone(),
             config.storage_rotate_count,
-            &bank_sender,
             &storage_state,
+            bank_sender,
             config.blockstream.as_ref(),
             ledger_signal_receiver,
             &subscriptions,
@@ -236,14 +236,14 @@ impl Fullnode {
             id,
             &cluster_info,
             bank_receiver,
-            poh_recorder,
+            &poh_recorder,
             node.sockets.tpu,
             node.sockets.broadcast,
             config.sigverify_disabled,
-            blocktree,
+            &blocktree,
         );
         let exit_ = exit.clone();
-        let bank_forks_ = exit.clone();
+        let bank_forks_ = bank_forks.clone();
         let rpc_working_bank_handle = spawn(move || loop {
             if exit_.load(Ordering::Relaxed) {
                 break;
@@ -263,11 +263,12 @@ impl Fullnode {
             node_services: NodeServices::new(tpu, tvu),
             exit,
             poh_service,
+            poh_recorder,
         }
     }
 
     // Used for notifying many nodes in parallel to exit
-    fn exit(&self) {
+    pub fn exit(&self) {
         self.exit.store(true, Ordering::Relaxed);
         // Need to force the poh_recorder to drop the WorkingBank,
         // which contains the channel to BroadcastStage. This should be
@@ -287,9 +288,30 @@ impl Fullnode {
         self.poh_service.exit()
     }
 
-    fn close(self) -> Result<()> {
+    pub fn close(&mut self) -> Result<()> {
         self.exit();
-        self.join()
+        self.join_mut_ref()
+    }
+    fn join_mut_ref(self) -> Result<()> {
+        if let Some(rpc_service) = self.rpc_service {
+            rpc_service.join()?;
+        }
+        if let Some(rpc_pubsub_service) = self.rpc_pubsub_service {
+            rpc_pubsub_service.join()?;
+        }
+
+        self.rpc_working_bank_handle.join()?;
+        self.gossip_service.join()?;
+        self.node_services.join()?;
+        trace!("exit node_services!");
+        self.poh_service.join()?;
+        trace!("exit poh!");
+        Ok(())
+    }
+}
+impl Drop for Fullnode {
+    fn drop(&mut self) {
+        self.close();
     }
 }
 
@@ -319,21 +341,8 @@ pub fn new_banks_from_blocktree(
 impl Service for Fullnode {
     type JoinReturnType = ();
 
-    fn join(self) -> Result<()> {
-        if let Some(rpc_service) = self.rpc_service {
-            rpc_service.join()?;
-        }
-        if let Some(rpc_pubsub_service) = self.rpc_pubsub_service {
-            rpc_pubsub_service.join()?;
-        }
-
-        self.rpc_working_bank_handle.join()?;
-        self.gossip_service.join()?;
-        self.node_services.join()?;
-        trace!("exit node_services!");
-        self.poh_service.join()?;
-        trace!("exit poh!");
-        Ok(())
+    fn join(mut self) -> Result<()> {
+        self.join_mut_ref()
     }
 }
 
@@ -373,311 +382,311 @@ pub fn make_active_set_entries(
     (entries, voting_keypair)
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::blocktree::{create_new_tmp_ledger, tmp_copy_blocktree};
-    use crate::entry::make_consecutive_blobs;
-    use crate::streamer::responder;
-    use solana_sdk::hash::Hash;
-    use solana_sdk::timing::DEFAULT_SLOTS_PER_EPOCH;
-    use solana_sdk::timing::DEFAULT_TICKS_PER_SLOT;
-    use std::fs::remove_dir_all;
-
-    #[test]
-    fn validator_exit() {
-        let leader_keypair = Keypair::new();
-        let leader_node = Node::new_localhost_with_pubkey(leader_keypair.pubkey());
-
-        let validator_keypair = Keypair::new();
-        let validator_node = Node::new_localhost_with_pubkey(validator_keypair.pubkey());
-        let (genesis_block, _mint_keypair) =
-            GenesisBlock::new_with_leader(10_000, leader_keypair.pubkey(), 1000);
-        let (validator_ledger_path, _last_id) = create_new_tmp_ledger!(&genesis_block);
-
-        let validator = Fullnode::new(
-            validator_node,
-            &Arc::new(validator_keypair),
-            &validator_ledger_path,
-            Keypair::new(),
-            Some(&leader_node.info),
-            &FullnodeConfig::default(),
-        );
-        validator.close().unwrap();
-        remove_dir_all(validator_ledger_path).unwrap();
-    }
-
-    #[test]
-    fn validator_parallel_exit() {
-        let leader_keypair = Keypair::new();
-        let leader_node = Node::new_localhost_with_pubkey(leader_keypair.pubkey());
-
-        let mut ledger_paths = vec![];
-        let validators: Vec<Fullnode> = (0..2)
-            .map(|_| {
-                let validator_keypair = Keypair::new();
-                let validator_node = Node::new_localhost_with_pubkey(validator_keypair.pubkey());
-                let (genesis_block, _mint_keypair) =
-                    GenesisBlock::new_with_leader(10_000, leader_keypair.pubkey(), 1000);
-                let (validator_ledger_path, _last_id) = create_new_tmp_ledger!(&genesis_block);
-                ledger_paths.push(validator_ledger_path.clone());
-                Fullnode::new(
-                    validator_node,
-                    &Arc::new(validator_keypair),
-                    &validator_ledger_path,
-                    Keypair::new(),
-                    Some(&leader_node.info),
-                    &FullnodeConfig::default(),
-                )
-            })
-            .collect();
-
-        // Each validator can exit in parallel to speed many sequential calls to `join`
-        validators.iter().for_each(|v| v.exit());
-        // While join is called sequentially, the above exit call notified all the
-        // validators to exit from all their threads
-        validators.into_iter().for_each(|validator| {
-            validator.join().unwrap();
-        });
-
-        for path in ledger_paths {
-            remove_dir_all(path).unwrap();
-        }
-    }
-
-    #[test]
-    fn test_leader_to_leader_transition() {
-        solana_logger::setup();
-
-        let bootstrap_leader_keypair = Keypair::new();
-        let bootstrap_leader_node =
-            Node::new_localhost_with_pubkey(bootstrap_leader_keypair.pubkey());
-
-        // Once the bootstrap leader hits the second epoch, because there are no other choices in
-        // the active set, this leader will remain the leader in the second epoch. In the second
-        // epoch, check that the same leader knows to shut down and restart as a leader again.
-        let ticks_per_slot = 5;
-        let slots_per_epoch = 2;
-
-        let voting_keypair = Keypair::new();
-        let fullnode_config = FullnodeConfig::default();
-
-        let (mut genesis_block, _mint_keypair) =
-            GenesisBlock::new_with_leader(10_000, bootstrap_leader_keypair.pubkey(), 500);
-        genesis_block.ticks_per_slot = ticks_per_slot;
-        genesis_block.slots_per_epoch = slots_per_epoch;
-
-        let (bootstrap_leader_ledger_path, _last_id) = create_new_tmp_ledger!(&genesis_block);
-
-        // Start the bootstrap leader
-        let bootstrap_leader = Fullnode::new(
-            bootstrap_leader_node,
-            &Arc::new(bootstrap_leader_keypair),
-            &bootstrap_leader_ledger_path,
-            voting_keypair,
-            None,
-            &fullnode_config,
-        );
-
-        let (rotation_sender, rotation_receiver) = channel();
-        let bootstrap_leader_exit = bootstrap_leader.run(Some(rotation_sender));
-
-        // Wait for the bootstrap leader to transition.  Since there are no other nodes in the
-        // cluster it will continue to be the leader
-        assert_eq!(rotation_receiver.recv().unwrap(), 1);
-        bootstrap_leader_exit();
-    }
-
-    #[test]
-    #[ignore]
-    fn test_ledger_role_transition() {
-        solana_logger::setup();
-
-        let fullnode_config = FullnodeConfig::default();
-        let ticks_per_slot = DEFAULT_TICKS_PER_SLOT;
-
-        // Create the leader and validator nodes
-        let bootstrap_leader_keypair = Arc::new(Keypair::new());
-        let validator_keypair = Arc::new(Keypair::new());
-        let (bootstrap_leader_node, validator_node, bootstrap_leader_ledger_path, _, _) =
-            setup_leader_validator(
-                &bootstrap_leader_keypair,
-                &validator_keypair,
-                ticks_per_slot,
-                0,
-            );
-        let bootstrap_leader_info = bootstrap_leader_node.info.clone();
-
-        let validator_ledger_path = tmp_copy_blocktree!(&bootstrap_leader_ledger_path);
-
-        let ledger_paths = vec![
-            bootstrap_leader_ledger_path.clone(),
-            validator_ledger_path.clone(),
-        ];
-
-        {
-            // Test that a node knows to transition to a validator based on parsing the ledger
-            let bootstrap_leader = Fullnode::new(
-                bootstrap_leader_node,
-                &bootstrap_leader_keypair,
-                &bootstrap_leader_ledger_path,
-                Keypair::new(),
-                Some(&bootstrap_leader_info),
-                &fullnode_config,
-            );
-            let (rotation_sender, rotation_receiver) = channel();
-            let bootstrap_leader_exit = bootstrap_leader.run(Some(rotation_sender));
-            assert_eq!(rotation_receiver.recv().unwrap(), (DEFAULT_SLOTS_PER_EPOCH));
-
-            // Test that a node knows to transition to a leader based on parsing the ledger
-            let validator = Fullnode::new(
-                validator_node,
-                &validator_keypair,
-                &validator_ledger_path,
-                Keypair::new(),
-                Some(&bootstrap_leader_info),
-                &fullnode_config,
-            );
-
-            let (rotation_sender, rotation_receiver) = channel();
-            let validator_exit = validator.run(Some(rotation_sender));
-            assert_eq!(rotation_receiver.recv().unwrap(), (DEFAULT_SLOTS_PER_EPOCH));
-
-            validator_exit();
-            bootstrap_leader_exit();
-        }
-        for path in ledger_paths {
-            Blocktree::destroy(&path).expect("Expected successful database destruction");
-            let _ignored = remove_dir_all(&path);
-        }
-    }
-
-    // TODO: Rework this test or TVU (make_consecutive_blobs sends blobs that can't be handled by
-    //       the replay_stage)
-    #[test]
-    #[ignore]
-    fn test_validator_to_leader_transition() {
-        solana_logger::setup();
-        // Make leader and validator node
-        let ticks_per_slot = 10;
-        let slots_per_epoch = 4;
-        let leader_keypair = Arc::new(Keypair::new());
-        let validator_keypair = Arc::new(Keypair::new());
-        let fullnode_config = FullnodeConfig::default();
-        let (leader_node, validator_node, validator_ledger_path, ledger_initial_len, last_id) =
-            setup_leader_validator(&leader_keypair, &validator_keypair, ticks_per_slot, 0);
-
-        let leader_id = leader_keypair.pubkey();
-        let validator_info = validator_node.info.clone();
-
-        info!("leader: {:?}", leader_id);
-        info!("validator: {:?}", validator_info.id);
-
-        let voting_keypair = Keypair::new();
-
-        // Start the validator
-        let validator = Fullnode::new(
-            validator_node,
-            &validator_keypair,
-            &validator_ledger_path,
-            voting_keypair,
-            Some(&leader_node.info),
-            &fullnode_config,
-        );
-
-        let blobs_to_send = slots_per_epoch * ticks_per_slot + ticks_per_slot;
-
-        // Send blobs to the validator from our mock leader
-        let t_responder = {
-            let (s_responder, r_responder) = channel();
-            let blob_sockets: Vec<Arc<UdpSocket>> =
-                leader_node.sockets.tvu.into_iter().map(Arc::new).collect();
-            let t_responder = responder(
-                "test_validator_to_leader_transition",
-                blob_sockets[0].clone(),
-                r_responder,
-            );
-
-            let tvu_address = &validator_info.tvu;
-
-            let msgs = make_consecutive_blobs(
-                &leader_id,
-                blobs_to_send,
-                ledger_initial_len,
-                last_id,
-                &tvu_address,
-            )
-            .into_iter()
-            .rev()
-            .collect();
-            s_responder.send(msgs).expect("send");
-            t_responder
-        };
-
-        info!("waiting for validator to rotate into the leader role");
-        let (rotation_sender, rotation_receiver) = channel();
-        let validator_exit = validator.run(Some(rotation_sender));
-        let rotation = rotation_receiver.recv().unwrap();
-        assert_eq!(rotation, blobs_to_send);
-
-        // Close the validator so that rocksdb has locks available
-        validator_exit();
-        let (bank_forks, bank_forks_info, _, _) =
-            new_banks_from_blocktree(&validator_ledger_path, None);
-        let bank = bank_forks.working_bank();
-        let entry_height = bank_forks_info[0].entry_height;
-
-        assert!(bank.tick_height() >= bank.ticks_per_slot() * bank.slots_per_epoch());
-
-        assert!(entry_height >= ledger_initial_len);
-
-        // Shut down
-        t_responder.join().expect("responder thread join");
-        Blocktree::destroy(&validator_ledger_path)
-            .expect("Expected successful database destruction");
-        let _ignored = remove_dir_all(&validator_ledger_path).unwrap();
-    }
-
-    fn setup_leader_validator(
-        leader_keypair: &Arc<Keypair>,
-        validator_keypair: &Arc<Keypair>,
-        ticks_per_slot: u64,
-        num_ending_slots: u64,
-    ) -> (Node, Node, String, u64, Hash) {
-        info!("validator: {}", validator_keypair.pubkey());
-        info!("leader: {}", leader_keypair.pubkey());
-
-        let leader_node = Node::new_localhost_with_pubkey(leader_keypair.pubkey());
-        let validator_node = Node::new_localhost_with_pubkey(validator_keypair.pubkey());
-
-        let (mut genesis_block, mint_keypair) =
-            GenesisBlock::new_with_leader(10_000, leader_node.info.id, 500);
-        genesis_block.ticks_per_slot = ticks_per_slot;
-
-        let (ledger_path, last_id) = create_new_tmp_ledger!(&genesis_block);
-
-        // Add entries so that the validator is in the active set, then finish up the slot with
-        // ticks (and maybe add extra slots full of empty ticks)
-        let (entries, _) = make_active_set_entries(
-            validator_keypair,
-            &mint_keypair,
-            10,
-            0,
-            &last_id,
-            ticks_per_slot * (num_ending_slots + 1),
-        );
-
-        let blocktree = Blocktree::open_config(&ledger_path, ticks_per_slot).unwrap();
-        let last_id = entries.last().unwrap().hash;
-        let entry_height = ticks_per_slot + entries.len() as u64;
-        blocktree.write_entries(1, 0, 0, entries).unwrap();
-
-        (
-            leader_node,
-            validator_node,
-            ledger_path,
-            entry_height,
-            last_id,
-        )
-    }
-}
+// #[cfg(test)]
+// mod tests {
+//     use super::*;
+//     use crate::blocktree::{create_new_tmp_ledger, tmp_copy_blocktree};
+//     use crate::entry::make_consecutive_blobs;
+//     use crate::streamer::responder;
+//     use solana_sdk::hash::Hash;
+//     use solana_sdk::timing::DEFAULT_SLOTS_PER_EPOCH;
+//     use solana_sdk::timing::DEFAULT_TICKS_PER_SLOT;
+//     use std::fs::remove_dir_all;
+//
+//     #[test]
+//     fn validator_exit() {
+//         let leader_keypair = Keypair::new();
+//         let leader_node = Node::new_localhost_with_pubkey(leader_keypair.pubkey());
+//
+//         let validator_keypair = Keypair::new();
+//         let validator_node = Node::new_localhost_with_pubkey(validator_keypair.pubkey());
+//         let (genesis_block, _mint_keypair) =
+//             GenesisBlock::new_with_leader(10_000, leader_keypair.pubkey(), 1000);
+//         let (validator_ledger_path, _last_id) = create_new_tmp_ledger!(&genesis_block);
+//
+//         let validator = Fullnode::new(
+//             validator_node,
+//             &Arc::new(validator_keypair),
+//             &validator_ledger_path,
+//             Keypair::new(),
+//             Some(&leader_node.info),
+//             &FullnodeConfig::default(),
+//         );
+//         validator.close().unwrap();
+//         remove_dir_all(validator_ledger_path).unwrap();
+//     }
+//
+//     #[test]
+//     fn validator_parallel_exit() {
+//         let leader_keypair = Keypair::new();
+//         let leader_node = Node::new_localhost_with_pubkey(leader_keypair.pubkey());
+//
+//         let mut ledger_paths = vec![];
+//         let validators: Vec<Fullnode> = (0..2)
+//             .map(|_| {
+//                 let validator_keypair = Keypair::new();
+//                 let validator_node = Node::new_localhost_with_pubkey(validator_keypair.pubkey());
+//                 let (genesis_block, _mint_keypair) =
+//                     GenesisBlock::new_with_leader(10_000, leader_keypair.pubkey(), 1000);
+//                 let (validator_ledger_path, _last_id) = create_new_tmp_ledger!(&genesis_block);
+//                 ledger_paths.push(validator_ledger_path.clone());
+//                 Fullnode::new(
+//                     validator_node,
+//                     &Arc::new(validator_keypair),
+//                     &validator_ledger_path,
+//                     Keypair::new(),
+//                     Some(&leader_node.info),
+//                     &FullnodeConfig::default(),
+//                 )
+//             })
+//             .collect();
+//
+//         // Each validator can exit in parallel to speed many sequential calls to `join`
+//         validators.iter().for_each(|v| v.exit());
+//         // While join is called sequentially, the above exit call notified all the
+//         // validators to exit from all their threads
+//         validators.into_iter().for_each(|validator| {
+//             validator.join().unwrap();
+//         });
+//
+//         for path in ledger_paths {
+//             remove_dir_all(path).unwrap();
+//         }
+//     }
+//
+//     #[test]
+//     fn test_leader_to_leader_transition() {
+//         solana_logger::setup();
+//
+//         let bootstrap_leader_keypair = Keypair::new();
+//         let bootstrap_leader_node =
+//             Node::new_localhost_with_pubkey(bootstrap_leader_keypair.pubkey());
+//
+//         // Once the bootstrap leader hits the second epoch, because there are no other choices in
+//         // the active set, this leader will remain the leader in the second epoch. In the second
+//         // epoch, check that the same leader knows to shut down and restart as a leader again.
+//         let ticks_per_slot = 5;
+//         let slots_per_epoch = 2;
+//
+//         let voting_keypair = Keypair::new();
+//         let fullnode_config = FullnodeConfig::default();
+//
+//         let (mut genesis_block, _mint_keypair) =
+//             GenesisBlock::new_with_leader(10_000, bootstrap_leader_keypair.pubkey(), 500);
+//         genesis_block.ticks_per_slot = ticks_per_slot;
+//         genesis_block.slots_per_epoch = slots_per_epoch;
+//
+//         let (bootstrap_leader_ledger_path, _last_id) = create_new_tmp_ledger!(&genesis_block);
+//
+//         // Start the bootstrap leader
+//         let bootstrap_leader = Fullnode::new(
+//             bootstrap_leader_node,
+//             &Arc::new(bootstrap_leader_keypair),
+//             &bootstrap_leader_ledger_path,
+//             voting_keypair,
+//             None,
+//             &fullnode_config,
+//         );
+//
+//         let (rotation_sender, rotation_receiver) = channel();
+//         let bootstrap_leader_exit = bootstrap_leader.run(Some(rotation_sender));
+//
+//         // Wait for the bootstrap leader to transition.  Since there are no other nodes in the
+//         // cluster it will continue to be the leader
+//         assert_eq!(rotation_receiver.recv().unwrap(), 1);
+//         bootstrap_leader_exit();
+//     }
+//
+//     #[test]
+//     #[ignore]
+//     fn test_ledger_role_transition() {
+//         solana_logger::setup();
+//
+//         let fullnode_config = FullnodeConfig::default();
+//         let ticks_per_slot = DEFAULT_TICKS_PER_SLOT;
+//
+//         // Create the leader and validator nodes
+//         let bootstrap_leader_keypair = Arc::new(Keypair::new());
+//         let validator_keypair = Arc::new(Keypair::new());
+//         let (bootstrap_leader_node, validator_node, bootstrap_leader_ledger_path, _, _) =
+//             setup_leader_validator(
+//                 &bootstrap_leader_keypair,
+//                 &validator_keypair,
+//                 ticks_per_slot,
+//                 0,
+//             );
+//         let bootstrap_leader_info = bootstrap_leader_node.info.clone();
+//
+//         let validator_ledger_path = tmp_copy_blocktree!(&bootstrap_leader_ledger_path);
+//
+//         let ledger_paths = vec![
+//             bootstrap_leader_ledger_path.clone(),
+//             validator_ledger_path.clone(),
+//         ];
+//
+//         {
+//             // Test that a node knows to transition to a validator based on parsing the ledger
+//             let bootstrap_leader = Fullnode::new(
+//                 bootstrap_leader_node,
+//                 &bootstrap_leader_keypair,
+//                 &bootstrap_leader_ledger_path,
+//                 Keypair::new(),
+//                 Some(&bootstrap_leader_info),
+//                 &fullnode_config,
+//             );
+//             let (rotation_sender, rotation_receiver) = channel();
+//             let bootstrap_leader_exit = bootstrap_leader.run(Some(rotation_sender));
+//             assert_eq!(rotation_receiver.recv().unwrap(), (DEFAULT_SLOTS_PER_EPOCH));
+//
+//             // Test that a node knows to transition to a leader based on parsing the ledger
+//             let validator = Fullnode::new(
+//                 validator_node,
+//                 &validator_keypair,
+//                 &validator_ledger_path,
+//                 Keypair::new(),
+//                 Some(&bootstrap_leader_info),
+//                 &fullnode_config,
+//             );
+//
+//             let (rotation_sender, rotation_receiver) = channel();
+//             let validator_exit = validator.run(Some(rotation_sender));
+//             assert_eq!(rotation_receiver.recv().unwrap(), (DEFAULT_SLOTS_PER_EPOCH));
+//
+//             validator_exit();
+//             bootstrap_leader_exit();
+//         }
+//         for path in ledger_paths {
+//             Blocktree::destroy(&path).expect("Expected successful database destruction");
+//             let _ignored = remove_dir_all(&path);
+//         }
+//     }
+//
+//     // TODO: Rework this test or TVU (make_consecutive_blobs sends blobs that can't be handled by
+//     //       the replay_stage)
+//     #[test]
+//     #[ignore]
+//     fn test_validator_to_leader_transition() {
+//         solana_logger::setup();
+//         // Make leader and validator node
+//         let ticks_per_slot = 10;
+//         let slots_per_epoch = 4;
+//         let leader_keypair = Arc::new(Keypair::new());
+//         let validator_keypair = Arc::new(Keypair::new());
+//         let fullnode_config = FullnodeConfig::default();
+//         let (leader_node, validator_node, validator_ledger_path, ledger_initial_len, last_id) =
+//             setup_leader_validator(&leader_keypair, &validator_keypair, ticks_per_slot, 0);
+//
+//         let leader_id = leader_keypair.pubkey();
+//         let validator_info = validator_node.info.clone();
+//
+//         info!("leader: {:?}", leader_id);
+//         info!("validator: {:?}", validator_info.id);
+//
+//         let voting_keypair = Keypair::new();
+//
+//         // Start the validator
+//         let validator = Fullnode::new(
+//             validator_node,
+//             &validator_keypair,
+//             &validator_ledger_path,
+//             voting_keypair,
+//             Some(&leader_node.info),
+//             &fullnode_config,
+//         );
+//
+//         let blobs_to_send = slots_per_epoch * ticks_per_slot + ticks_per_slot;
+//
+//         // Send blobs to the validator from our mock leader
+//         let t_responder = {
+//             let (s_responder, r_responder) = channel();
+//             let blob_sockets: Vec<Arc<UdpSocket>> =
+//                 leader_node.sockets.tvu.into_iter().map(Arc::new).collect();
+//             let t_responder = responder(
+//                 "test_validator_to_leader_transition",
+//                 blob_sockets[0].clone(),
+//                 r_responder,
+//             );
+//
+//             let tvu_address = &validator_info.tvu;
+//
+//             let msgs = make_consecutive_blobs(
+//                 &leader_id,
+//                 blobs_to_send,
+//                 ledger_initial_len,
+//                 last_id,
+//                 &tvu_address,
+//             )
+//             .into_iter()
+//             .rev()
+//             .collect();
+//             s_responder.send(msgs).expect("send");
+//             t_responder
+//         };
+//
+//         info!("waiting for validator to rotate into the leader role");
+//         let (rotation_sender, rotation_receiver) = channel();
+//         let validator_exit = validator.run(Some(rotation_sender));
+//         let rotation = rotation_receiver.recv().unwrap();
+//         assert_eq!(rotation, blobs_to_send);
+//
+//         // Close the validator so that rocksdb has locks available
+//         validator_exit();
+//         let (bank_forks, bank_forks_info, _, _) =
+//             new_banks_from_blocktree(&validator_ledger_path, None);
+//         let bank = bank_forks.working_bank();
+//         let entry_height = bank_forks_info[0].entry_height;
+//
+//         assert!(bank.tick_height() >= bank.ticks_per_slot() * bank.slots_per_epoch());
+//
+//         assert!(entry_height >= ledger_initial_len);
+//
+//         // Shut down
+//         t_responder.join().expect("responder thread join");
+//         Blocktree::destroy(&validator_ledger_path)
+//             .expect("Expected successful database destruction");
+//         let _ignored = remove_dir_all(&validator_ledger_path).unwrap();
+//     }
+//
+//     fn setup_leader_validator(
+//         leader_keypair: &Arc<Keypair>,
+//         validator_keypair: &Arc<Keypair>,
+//         ticks_per_slot: u64,
+//         num_ending_slots: u64,
+//     ) -> (Node, Node, String, u64, Hash) {
+//         info!("validator: {}", validator_keypair.pubkey());
+//         info!("leader: {}", leader_keypair.pubkey());
+//
+//         let leader_node = Node::new_localhost_with_pubkey(leader_keypair.pubkey());
+//         let validator_node = Node::new_localhost_with_pubkey(validator_keypair.pubkey());
+//
+//         let (mut genesis_block, mint_keypair) =
+//             GenesisBlock::new_with_leader(10_000, leader_node.info.id, 500);
+//         genesis_block.ticks_per_slot = ticks_per_slot;
+//
+//         let (ledger_path, last_id) = create_new_tmp_ledger!(&genesis_block);
+//
+//         // Add entries so that the validator is in the active set, then finish up the slot with
+//         // ticks (and maybe add extra slots full of empty ticks)
+//         let (entries, _) = make_active_set_entries(
+//             validator_keypair,
+//             &mint_keypair,
+//             10,
+//             0,
+//             &last_id,
+//             ticks_per_slot * (num_ending_slots + 1),
+//         );
+//
+//         let blocktree = Blocktree::open_config(&ledger_path, ticks_per_slot).unwrap();
+//         let last_id = entries.last().unwrap().hash;
+//         let entry_height = ticks_per_slot + entries.len() as u64;
+//         blocktree.write_entries(1, 0, 0, entries).unwrap();
+//
+//         (
+//             leader_node,
+//             validator_node,
+//             ledger_path,
+//             entry_height,
+//             last_id,
+//         )
+//     }
+// }

--- a/src/fullnode.rs
+++ b/src/fullnode.rs
@@ -250,6 +250,8 @@ impl Fullnode {
             if exit_.load(Ordering::Relaxed) {
                 break;
             }
+            let bank = bank_forks_.read().unwrap().working_bank();
+            trace!("rpc working bank {} {}", bank.slot(), bank.last_id());
             rpc_service_rp
                 .write()
                 .unwrap()

--- a/src/fullnode.rs
+++ b/src/fullnode.rs
@@ -231,6 +231,7 @@ impl Fullnode {
             config.blockstream.as_ref(),
             ledger_signal_receiver,
             &subscriptions,
+            &poh_recorder,
         );
         let tpu = Tpu::new(
             id,

--- a/src/fullnode.rs
+++ b/src/fullnode.rs
@@ -28,7 +28,7 @@ use solana_sdk::timing::timestamp;
 use solana_sdk::vote_transaction::VoteTransaction;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::mpsc::{channel, Receiver};
+use std::sync::mpsc::Receiver;
 use std::sync::{Arc, Mutex, RwLock};
 use std::thread::sleep;
 use std::thread::JoinHandle;

--- a/src/fullnode.rs
+++ b/src/fullnode.rs
@@ -157,7 +157,7 @@ impl Fullnode {
 
         let storage_state = StorageState::new();
 
-        let rpc_service = JsonRpcService::new(
+        let mut rpc_service = JsonRpcService::new(
             &cluster_info,
             SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), node.info.rpc.port()),
             drone_addr,

--- a/src/fullnode.rs
+++ b/src/fullnode.rs
@@ -379,311 +379,70 @@ pub fn make_active_set_entries(
     (entries, voting_keypair)
 }
 
-// #[cfg(test)]
-// mod tests {
-//     use super::*;
-//     use crate::blocktree::{create_new_tmp_ledger, tmp_copy_blocktree};
-//     use crate::entry::make_consecutive_blobs;
-//     use crate::streamer::responder;
-//     use solana_sdk::hash::Hash;
-//     use solana_sdk::timing::DEFAULT_SLOTS_PER_EPOCH;
-//     use solana_sdk::timing::DEFAULT_TICKS_PER_SLOT;
-//     use std::fs::remove_dir_all;
-//
-//     #[test]
-//     fn validator_exit() {
-//         let leader_keypair = Keypair::new();
-//         let leader_node = Node::new_localhost_with_pubkey(leader_keypair.pubkey());
-//
-//         let validator_keypair = Keypair::new();
-//         let validator_node = Node::new_localhost_with_pubkey(validator_keypair.pubkey());
-//         let (genesis_block, _mint_keypair) =
-//             GenesisBlock::new_with_leader(10_000, leader_keypair.pubkey(), 1000);
-//         let (validator_ledger_path, _last_id) = create_new_tmp_ledger!(&genesis_block);
-//
-//         let validator = Fullnode::new(
-//             validator_node,
-//             &Arc::new(validator_keypair),
-//             &validator_ledger_path,
-//             Keypair::new(),
-//             Some(&leader_node.info),
-//             &FullnodeConfig::default(),
-//         );
-//         validator.close().unwrap();
-//         remove_dir_all(validator_ledger_path).unwrap();
-//     }
-//
-//     #[test]
-//     fn validator_parallel_exit() {
-//         let leader_keypair = Keypair::new();
-//         let leader_node = Node::new_localhost_with_pubkey(leader_keypair.pubkey());
-//
-//         let mut ledger_paths = vec![];
-//         let validators: Vec<Fullnode> = (0..2)
-//             .map(|_| {
-//                 let validator_keypair = Keypair::new();
-//                 let validator_node = Node::new_localhost_with_pubkey(validator_keypair.pubkey());
-//                 let (genesis_block, _mint_keypair) =
-//                     GenesisBlock::new_with_leader(10_000, leader_keypair.pubkey(), 1000);
-//                 let (validator_ledger_path, _last_id) = create_new_tmp_ledger!(&genesis_block);
-//                 ledger_paths.push(validator_ledger_path.clone());
-//                 Fullnode::new(
-//                     validator_node,
-//                     &Arc::new(validator_keypair),
-//                     &validator_ledger_path,
-//                     Keypair::new(),
-//                     Some(&leader_node.info),
-//                     &FullnodeConfig::default(),
-//                 )
-//             })
-//             .collect();
-//
-//         // Each validator can exit in parallel to speed many sequential calls to `join`
-//         validators.iter().for_each(|v| v.exit());
-//         // While join is called sequentially, the above exit call notified all the
-//         // validators to exit from all their threads
-//         validators.into_iter().for_each(|validator| {
-//             validator.join().unwrap();
-//         });
-//
-//         for path in ledger_paths {
-//             remove_dir_all(path).unwrap();
-//         }
-//     }
-//
-//     #[test]
-//     fn test_leader_to_leader_transition() {
-//         solana_logger::setup();
-//
-//         let bootstrap_leader_keypair = Keypair::new();
-//         let bootstrap_leader_node =
-//             Node::new_localhost_with_pubkey(bootstrap_leader_keypair.pubkey());
-//
-//         // Once the bootstrap leader hits the second epoch, because there are no other choices in
-//         // the active set, this leader will remain the leader in the second epoch. In the second
-//         // epoch, check that the same leader knows to shut down and restart as a leader again.
-//         let ticks_per_slot = 5;
-//         let slots_per_epoch = 2;
-//
-//         let voting_keypair = Keypair::new();
-//         let fullnode_config = FullnodeConfig::default();
-//
-//         let (mut genesis_block, _mint_keypair) =
-//             GenesisBlock::new_with_leader(10_000, bootstrap_leader_keypair.pubkey(), 500);
-//         genesis_block.ticks_per_slot = ticks_per_slot;
-//         genesis_block.slots_per_epoch = slots_per_epoch;
-//
-//         let (bootstrap_leader_ledger_path, _last_id) = create_new_tmp_ledger!(&genesis_block);
-//
-//         // Start the bootstrap leader
-//         let bootstrap_leader = Fullnode::new(
-//             bootstrap_leader_node,
-//             &Arc::new(bootstrap_leader_keypair),
-//             &bootstrap_leader_ledger_path,
-//             voting_keypair,
-//             None,
-//             &fullnode_config,
-//         );
-//
-//         let (rotation_sender, rotation_receiver) = channel();
-//         let bootstrap_leader_exit = bootstrap_leader.run(Some(rotation_sender));
-//
-//         // Wait for the bootstrap leader to transition.  Since there are no other nodes in the
-//         // cluster it will continue to be the leader
-//         assert_eq!(rotation_receiver.recv().unwrap(), 1);
-//         bootstrap_leader_exit();
-//     }
-//
-//     #[test]
-//     #[ignore]
-//     fn test_ledger_role_transition() {
-//         solana_logger::setup();
-//
-//         let fullnode_config = FullnodeConfig::default();
-//         let ticks_per_slot = DEFAULT_TICKS_PER_SLOT;
-//
-//         // Create the leader and validator nodes
-//         let bootstrap_leader_keypair = Arc::new(Keypair::new());
-//         let validator_keypair = Arc::new(Keypair::new());
-//         let (bootstrap_leader_node, validator_node, bootstrap_leader_ledger_path, _, _) =
-//             setup_leader_validator(
-//                 &bootstrap_leader_keypair,
-//                 &validator_keypair,
-//                 ticks_per_slot,
-//                 0,
-//             );
-//         let bootstrap_leader_info = bootstrap_leader_node.info.clone();
-//
-//         let validator_ledger_path = tmp_copy_blocktree!(&bootstrap_leader_ledger_path);
-//
-//         let ledger_paths = vec![
-//             bootstrap_leader_ledger_path.clone(),
-//             validator_ledger_path.clone(),
-//         ];
-//
-//         {
-//             // Test that a node knows to transition to a validator based on parsing the ledger
-//             let bootstrap_leader = Fullnode::new(
-//                 bootstrap_leader_node,
-//                 &bootstrap_leader_keypair,
-//                 &bootstrap_leader_ledger_path,
-//                 Keypair::new(),
-//                 Some(&bootstrap_leader_info),
-//                 &fullnode_config,
-//             );
-//             let (rotation_sender, rotation_receiver) = channel();
-//             let bootstrap_leader_exit = bootstrap_leader.run(Some(rotation_sender));
-//             assert_eq!(rotation_receiver.recv().unwrap(), (DEFAULT_SLOTS_PER_EPOCH));
-//
-//             // Test that a node knows to transition to a leader based on parsing the ledger
-//             let validator = Fullnode::new(
-//                 validator_node,
-//                 &validator_keypair,
-//                 &validator_ledger_path,
-//                 Keypair::new(),
-//                 Some(&bootstrap_leader_info),
-//                 &fullnode_config,
-//             );
-//
-//             let (rotation_sender, rotation_receiver) = channel();
-//             let validator_exit = validator.run(Some(rotation_sender));
-//             assert_eq!(rotation_receiver.recv().unwrap(), (DEFAULT_SLOTS_PER_EPOCH));
-//
-//             validator_exit();
-//             bootstrap_leader_exit();
-//         }
-//         for path in ledger_paths {
-//             Blocktree::destroy(&path).expect("Expected successful database destruction");
-//             let _ignored = remove_dir_all(&path);
-//         }
-//     }
-//
-//     // TODO: Rework this test or TVU (make_consecutive_blobs sends blobs that can't be handled by
-//     //       the replay_stage)
-//     #[test]
-//     #[ignore]
-//     fn test_validator_to_leader_transition() {
-//         solana_logger::setup();
-//         // Make leader and validator node
-//         let ticks_per_slot = 10;
-//         let slots_per_epoch = 4;
-//         let leader_keypair = Arc::new(Keypair::new());
-//         let validator_keypair = Arc::new(Keypair::new());
-//         let fullnode_config = FullnodeConfig::default();
-//         let (leader_node, validator_node, validator_ledger_path, ledger_initial_len, last_id) =
-//             setup_leader_validator(&leader_keypair, &validator_keypair, ticks_per_slot, 0);
-//
-//         let leader_id = leader_keypair.pubkey();
-//         let validator_info = validator_node.info.clone();
-//
-//         info!("leader: {:?}", leader_id);
-//         info!("validator: {:?}", validator_info.id);
-//
-//         let voting_keypair = Keypair::new();
-//
-//         // Start the validator
-//         let validator = Fullnode::new(
-//             validator_node,
-//             &validator_keypair,
-//             &validator_ledger_path,
-//             voting_keypair,
-//             Some(&leader_node.info),
-//             &fullnode_config,
-//         );
-//
-//         let blobs_to_send = slots_per_epoch * ticks_per_slot + ticks_per_slot;
-//
-//         // Send blobs to the validator from our mock leader
-//         let t_responder = {
-//             let (s_responder, r_responder) = channel();
-//             let blob_sockets: Vec<Arc<UdpSocket>> =
-//                 leader_node.sockets.tvu.into_iter().map(Arc::new).collect();
-//             let t_responder = responder(
-//                 "test_validator_to_leader_transition",
-//                 blob_sockets[0].clone(),
-//                 r_responder,
-//             );
-//
-//             let tvu_address = &validator_info.tvu;
-//
-//             let msgs = make_consecutive_blobs(
-//                 &leader_id,
-//                 blobs_to_send,
-//                 ledger_initial_len,
-//                 last_id,
-//                 &tvu_address,
-//             )
-//             .into_iter()
-//             .rev()
-//             .collect();
-//             s_responder.send(msgs).expect("send");
-//             t_responder
-//         };
-//
-//         info!("waiting for validator to rotate into the leader role");
-//         let (rotation_sender, rotation_receiver) = channel();
-//         let validator_exit = validator.run(Some(rotation_sender));
-//         let rotation = rotation_receiver.recv().unwrap();
-//         assert_eq!(rotation, blobs_to_send);
-//
-//         // Close the validator so that rocksdb has locks available
-//         validator_exit();
-//         let (bank_forks, bank_forks_info, _, _) =
-//             new_banks_from_blocktree(&validator_ledger_path, None);
-//         let bank = bank_forks.working_bank();
-//         let entry_height = bank_forks_info[0].entry_height;
-//
-//         assert!(bank.tick_height() >= bank.ticks_per_slot() * bank.slots_per_epoch());
-//
-//         assert!(entry_height >= ledger_initial_len);
-//
-//         // Shut down
-//         t_responder.join().expect("responder thread join");
-//         Blocktree::destroy(&validator_ledger_path)
-//             .expect("Expected successful database destruction");
-//         let _ignored = remove_dir_all(&validator_ledger_path).unwrap();
-//     }
-//
-//     fn setup_leader_validator(
-//         leader_keypair: &Arc<Keypair>,
-//         validator_keypair: &Arc<Keypair>,
-//         ticks_per_slot: u64,
-//         num_ending_slots: u64,
-//     ) -> (Node, Node, String, u64, Hash) {
-//         info!("validator: {}", validator_keypair.pubkey());
-//         info!("leader: {}", leader_keypair.pubkey());
-//
-//         let leader_node = Node::new_localhost_with_pubkey(leader_keypair.pubkey());
-//         let validator_node = Node::new_localhost_with_pubkey(validator_keypair.pubkey());
-//
-//         let (mut genesis_block, mint_keypair) =
-//             GenesisBlock::new_with_leader(10_000, leader_node.info.id, 500);
-//         genesis_block.ticks_per_slot = ticks_per_slot;
-//
-//         let (ledger_path, last_id) = create_new_tmp_ledger!(&genesis_block);
-//
-//         // Add entries so that the validator is in the active set, then finish up the slot with
-//         // ticks (and maybe add extra slots full of empty ticks)
-//         let (entries, _) = make_active_set_entries(
-//             validator_keypair,
-//             &mint_keypair,
-//             10,
-//             0,
-//             &last_id,
-//             ticks_per_slot * (num_ending_slots + 1),
-//         );
-//
-//         let blocktree = Blocktree::open_config(&ledger_path, ticks_per_slot).unwrap();
-//         let last_id = entries.last().unwrap().hash;
-//         let entry_height = ticks_per_slot + entries.len() as u64;
-//         blocktree.write_entries(1, 0, 0, entries).unwrap();
-//
-//         (
-//             leader_node,
-//             validator_node,
-//             ledger_path,
-//             entry_height,
-//             last_id,
-//         )
-//     }
-// }
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::blocktree::create_new_tmp_ledger;
+    use std::fs::remove_dir_all;
+
+    #[test]
+    fn validator_exit() {
+        let leader_keypair = Keypair::new();
+        let leader_node = Node::new_localhost_with_pubkey(leader_keypair.pubkey());
+
+        let validator_keypair = Keypair::new();
+        let validator_node = Node::new_localhost_with_pubkey(validator_keypair.pubkey());
+        let (genesis_block, _mint_keypair) =
+            GenesisBlock::new_with_leader(10_000, leader_keypair.pubkey(), 1000);
+        let (validator_ledger_path, _last_id) = create_new_tmp_ledger!(&genesis_block);
+
+        let validator = Fullnode::new(
+            validator_node,
+            &Arc::new(validator_keypair),
+            &validator_ledger_path,
+            Keypair::new(),
+            Some(&leader_node.info),
+            &FullnodeConfig::default(),
+        );
+        validator.close().unwrap();
+        remove_dir_all(validator_ledger_path).unwrap();
+    }
+
+    #[test]
+    fn validator_parallel_exit() {
+        let leader_keypair = Keypair::new();
+        let leader_node = Node::new_localhost_with_pubkey(leader_keypair.pubkey());
+
+        let mut ledger_paths = vec![];
+        let validators: Vec<Fullnode> = (0..2)
+            .map(|_| {
+                let validator_keypair = Keypair::new();
+                let validator_node = Node::new_localhost_with_pubkey(validator_keypair.pubkey());
+                let (genesis_block, _mint_keypair) =
+                    GenesisBlock::new_with_leader(10_000, leader_keypair.pubkey(), 1000);
+                let (validator_ledger_path, _last_id) = create_new_tmp_ledger!(&genesis_block);
+                ledger_paths.push(validator_ledger_path.clone());
+                Fullnode::new(
+                    validator_node,
+                    &Arc::new(validator_keypair),
+                    &validator_ledger_path,
+                    Keypair::new(),
+                    Some(&leader_node.info),
+                    &FullnodeConfig::default(),
+                )
+            })
+            .collect();
+
+        // Each validator can exit in parallel to speed many sequential calls to `join`
+        validators.iter().for_each(|v| v.exit());
+        // While join is called sequentially, the above exit call notified all the
+        // validators to exit from all their threads
+        validators.into_iter().for_each(|validator| {
+            validator.join().unwrap();
+        });
+
+        for path in ledger_paths {
+            remove_dir_all(path).unwrap();
+        }
+    }
+}

--- a/src/leader_confirmation_service.rs
+++ b/src/leader_confirmation_service.rs
@@ -99,7 +99,7 @@ impl LeaderConfirmationService {
     /// Create a new LeaderConfirmationService for computing confirmation.
     pub fn new(poh_recorder: &Arc<Mutex<PohRecorder>>, exit: Arc<AtomicBool>) -> JoinHandle<()> {
         let poh_recorder = poh_recorder.clone();
-        let thread_hdl = Builder::new()
+        Builder::new()
             .name("solana-leader-confirmation-service".to_string())
             .spawn(move || {
                 let mut last_valid_validator_timestamp = 0;
@@ -115,9 +115,7 @@ impl LeaderConfirmationService {
                     sleep(Duration::from_millis(COMPUTE_CONFIRMATION_MS));
                 }
             })
-            .unwrap();
-
-        thread_hdl
+            .unwrap()
     }
 }
 

--- a/src/leader_confirmation_service.rs
+++ b/src/leader_confirmation_service.rs
@@ -102,11 +102,12 @@ impl LeaderConfirmationService {
     /// Create a new LeaderConfirmationService for computing confirmation.
     pub fn new(leader_id: Pubkey, exit: Arc<AtomicBool>) -> (Self, JoinHandle<()>) {
         let current_bank: Arc<Mutex<Option<Arc<Bank>>>> = Arc::new(Mutex::new(None));
+        let current_bank_ = current_bank.clone();
         let thread_hdl = Builder::new()
             .name("solana-leader-confirmation-service".to_string())
             .spawn(move || {
                 let mut last_valid_validator_timestamp = 0;
-                let current_bank = current_bank.clone();
+                let current_bank = current_bank_.clone();
                 loop {
                     if exit.load(Ordering::Relaxed) {
                         break;
@@ -125,11 +126,7 @@ impl LeaderConfirmationService {
             })
             .unwrap();
 
-        (Self {
-            current_bank,
-        },
-            thread_hdl,
-		)
+        (Self { current_bank }, thread_hdl)
     }
 }
 

--- a/src/leader_confirmation_service.rs
+++ b/src/leader_confirmation_service.rs
@@ -5,7 +5,6 @@
 use crate::leader_schedule_utils;
 use solana_metrics::{influxdb, submit};
 use solana_runtime::bank::Bank;
-use solana_sdk::pubkey::Pubkey;
 use solana_sdk::timing;
 use std::result;
 use std::sync::atomic::{AtomicBool, Ordering};

--- a/src/leader_confirmation_service.rs
+++ b/src/leader_confirmation_service.rs
@@ -97,7 +97,7 @@ impl LeaderConfirmationService {
     }
 
     /// Create a new LeaderConfirmationService for computing confirmation.
-    pub fn new(poh_recorder: &Arc<Mutex<PohRecorder>>, exit: Arc<AtomicBool>) -> JoinHandle<()> {
+    pub fn start(poh_recorder: &Arc<Mutex<PohRecorder>>, exit: Arc<AtomicBool>) -> JoinHandle<()> {
         let poh_recorder = poh_recorder.clone();
         Builder::new()
             .name("solana-leader-confirmation-service".to_string())

--- a/src/leader_confirmation_service.rs
+++ b/src/leader_confirmation_service.rs
@@ -28,7 +28,7 @@ pub struct LeaderConfirmationService {
 
 impl LeaderConfirmationService {
     fn get_last_supermajority_timestamp(
-        bank: &Arc<Bank>,
+        bank: &Bank,
         leader_id: Pubkey,
         last_valid_validator_timestamp: u64,
     ) -> result::Result<u64, ConfirmationError> {
@@ -103,7 +103,7 @@ impl LeaderConfirmationService {
 
     /// Create a new LeaderConfirmationService for computing confirmation.
     pub fn new(leader_id: Pubkey, exit: Arc<AtomicBool>) -> Self {
-        let current_bank = Arc::new(Mutex::new(None));
+        let current_bank: Arc<Mutex<Option<Arc<Bank>>>> = Arc::new(Mutex::new(None));
         let thread_hdl = Builder::new()
             .name("solana-leader-confirmation-service".to_string())
             .spawn(move || {
@@ -115,7 +115,7 @@ impl LeaderConfirmationService {
                     }
                     // dont hold this lock to long
                     let maybe_bank = current_bank.lock().unwrap().clone();
-                    if let Some(bank) = maybe_bank {
+                    if let Some(ref bank) = maybe_bank {
                         Self::compute_confirmation(
                             bank,
                             leader_id,

--- a/src/leader_confirmation_service.rs
+++ b/src/leader_confirmation_service.rs
@@ -108,7 +108,7 @@ impl LeaderConfirmationService {
                     if exit.load(Ordering::Relaxed) {
                         break;
                     }
-                    // dont hold this lock to long
+                    // dont hold this lock too long
                     let maybe_bank = current_bank.lock().unwrap().clone();
                     if let Some(ref bank) = maybe_bank {
                         Self::compute_confirmation(bank, &mut last_valid_validator_timestamp);

--- a/src/local_cluster.rs
+++ b/src/local_cluster.rs
@@ -105,7 +105,7 @@ impl LocalCluster {
     pub fn close(&mut self) {
         self.exit();
         while let Some(node) = self.fullnodes.pop() {
-            node.join();
+            node.join().unwrap();
         }
         for path in &self.ledger_paths {
             remove_dir_all(path).unwrap();

--- a/src/poh_recorder.rs
+++ b/src/poh_recorder.rs
@@ -220,230 +220,214 @@ impl PohRecorder {
     }
 }
 
-// #[cfg(test)]
-// mod tests {
-//     use super::*;
-//     use crate::test_tx::test_tx;
-//     use solana_sdk::genesis_block::GenesisBlock;
-//     use solana_sdk::hash::hash;
-//     use std::sync::mpsc::channel;
-//     use std::sync::Arc;
-//
-//     #[test]
-//     fn test_poh_recorder_no_zero_tick() {
-//         let prev_hash = Hash::default();
-//         let mut poh_recorder = PohRecorder::new(0, prev_hash);
-//         poh_recorder.tick();
-//         assert_eq!(poh_recorder.tick_cache.len(), 1);
-//         assert_eq!(poh_recorder.tick_cache[0].1, 1);
-//         assert_eq!(poh_recorder.poh.tick_height, 1);
-//     }
-//
-//     #[test]
-//     fn test_poh_recorder_tick_height_is_last_tick() {
-//         let prev_hash = Hash::default();
-//         let mut poh_recorder = PohRecorder::new(0, prev_hash);
-//         poh_recorder.tick();
-//         poh_recorder.tick();
-//         assert_eq!(poh_recorder.tick_cache.len(), 2);
-//         assert_eq!(poh_recorder.tick_cache[1].1, 2);
-//         assert_eq!(poh_recorder.poh.tick_height, 2);
-//     }
-//
-//     #[test]
-//     fn test_poh_recorder_reset_clears_cache() {
-//         let mut poh_recorder = PohRecorder::new(0, Hash::default());
-//         poh_recorder.tick();
-//         assert_eq!(poh_recorder.tick_cache.len(), 1);
-//         poh_recorder.reset(0, Hash::default());
-//         assert_eq!(poh_recorder.tick_cache.len(), 0);
-//     }
-//
-//     #[test]
-//     fn test_poh_recorder_clear() {
-//         let (genesis_block, _mint_keypair) = GenesisBlock::new(2);
-//         let bank = Arc::new(Bank::new(&genesis_block));
-//         let prev_hash = bank.last_id();
-//         let (entry_sender, _) = channel();
-//         let mut poh_recorder = PohRecorder::new(0, prev_hash);
-//
-//         let working_bank = WorkingBank {
-//             bank,
-//             sender: entry_sender,
-//             min_tick_height: 2,
-//             max_tick_height: 3,
-//         };
-//         poh_recorder.set_working_bank(working_bank);
-//         assert!(poh_recorder.working_bank.is_some());
-//         poh_recorder.clear_bank();
-//         assert!(poh_recorder.working_bank.is_none());
-//     }
-//
-//     #[test]
-//     fn test_poh_recorder_tick_sent_after_min() {
-//         let (genesis_block, _mint_keypair) = GenesisBlock::new(2);
-//         let bank = Arc::new(Bank::new(&genesis_block));
-//         let prev_hash = bank.last_id();
-//         let (entry_sender, entry_receiver) = channel();
-//         let mut poh_recorder = PohRecorder::new(0, prev_hash);
-//
-//         let working_bank = WorkingBank {
-//             bank: bank.clone(),
-//             sender: entry_sender,
-//             min_tick_height: 2,
-//             max_tick_height: 3,
-//         };
-//         poh_recorder.set_working_bank(working_bank);
-//         poh_recorder.tick();
-//         poh_recorder.tick();
-//         //tick height equal to min_tick_height
-//         //no tick has been sent
-//         assert_eq!(poh_recorder.tick_cache.last().unwrap().1, 2);
-//         assert!(entry_receiver.try_recv().is_err());
-//
-//         // all ticks are sent after height > min
-//         poh_recorder.tick();
-//         assert_eq!(poh_recorder.poh.tick_height, 3);
-//         assert_eq!(poh_recorder.tick_cache.len(), 0);
-//         let (bank_, e) = entry_receiver.recv().expect("recv 1");
-//         assert_eq!(e.len(), 3);
-//         assert_eq!(bank_.slot(), bank.slot());
-//         assert!(poh_recorder.working_bank.is_none());
-//     }
-//
-//     #[test]
-//     fn test_poh_recorder_tick_sent_upto_and_including_max() {
-//         let (genesis_block, _mint_keypair) = GenesisBlock::new(2);
-//         let bank = Arc::new(Bank::new(&genesis_block));
-//         let prev_hash = bank.last_id();
-//         let (entry_sender, entry_receiver) = channel();
-//         let mut poh_recorder = PohRecorder::new(0, prev_hash);
-//
-//         poh_recorder.tick();
-//         poh_recorder.tick();
-//         poh_recorder.tick();
-//         poh_recorder.tick();
-//         assert_eq!(poh_recorder.tick_cache.last().unwrap().1, 4);
-//         assert_eq!(poh_recorder.poh.tick_height, 4);
-//
-//         let working_bank = WorkingBank {
-//             bank,
-//             sender: entry_sender,
-//             min_tick_height: 2,
-//             max_tick_height: 3,
-//         };
-//         poh_recorder.set_working_bank(working_bank);
-//         poh_recorder.tick();
-//
-//         assert_eq!(poh_recorder.poh.tick_height, 5);
-//         assert!(poh_recorder.working_bank.is_none());
-//         let (_, e) = entry_receiver.recv().expect("recv 1");
-//         assert_eq!(e.len(), 3);
-//     }
-//
-//     #[test]
-//     fn test_poh_recorder_record_to_early() {
-//         let (genesis_block, _mint_keypair) = GenesisBlock::new(2);
-//         let bank = Arc::new(Bank::new(&genesis_block));
-//         let prev_hash = bank.last_id();
-//         let (entry_sender, entry_receiver) = channel();
-//         let mut poh_recorder = PohRecorder::new(0, prev_hash);
-//
-//         let working_bank = WorkingBank {
-//             bank,
-//             sender: entry_sender,
-//             min_tick_height: 2,
-//             max_tick_height: 3,
-//         };
-//         poh_recorder.set_working_bank(working_bank);
-//         poh_recorder.tick();
-//         let tx = test_tx();
-//         let h1 = hash(b"hello world!");
-//         assert!(poh_recorder.record(h1, vec![tx.clone()]).is_err());
-//         assert!(entry_receiver.try_recv().is_err());
-//     }
-//
-//     #[test]
-//     fn test_poh_recorder_record_at_min_passes() {
-//         let (genesis_block, _mint_keypair) = GenesisBlock::new(2);
-//         let bank = Arc::new(Bank::new(&genesis_block));
-//         let prev_hash = bank.last_id();
-//         let (entry_sender, entry_receiver) = channel();
-//         let mut poh_recorder = PohRecorder::new(0, prev_hash);
-//
-//         let working_bank = WorkingBank {
-//             bank,
-//             sender: entry_sender,
-//             min_tick_height: 1,
-//             max_tick_height: 2,
-//         };
-//         poh_recorder.set_working_bank(working_bank);
-//         poh_recorder.tick();
-//         assert_eq!(poh_recorder.tick_cache.len(), 1);
-//         assert_eq!(poh_recorder.poh.tick_height, 1);
-//         let tx = test_tx();
-//         let h1 = hash(b"hello world!");
-//         assert!(poh_recorder.record(h1, vec![tx.clone()]).is_ok());
-//         assert_eq!(poh_recorder.tick_cache.len(), 0);
-//
-//         //tick in the cache + entry
-//         let (_b, e) = entry_receiver.recv().expect("recv 1");
-//         assert_eq!(e.len(), 1);
-//         assert!(e[0].0.is_tick());
-//         let (_b, e) = entry_receiver.recv().expect("recv 2");
-//         assert!(!e[0].0.is_tick());
-//     }
-//
-//     #[test]
-//     fn test_poh_recorder_record_at_max_fails() {
-//         let (genesis_block, _mint_keypair) = GenesisBlock::new(2);
-//         let bank = Arc::new(Bank::new(&genesis_block));
-//         let prev_hash = bank.last_id();
-//         let (entry_sender, entry_receiver) = channel();
-//         let mut poh_recorder = PohRecorder::new(0, prev_hash);
-//
-//         let working_bank = WorkingBank {
-//             bank,
-//             sender: entry_sender,
-//             min_tick_height: 1,
-//             max_tick_height: 2,
-//         };
-//         poh_recorder.set_working_bank(working_bank);
-//         poh_recorder.tick();
-//         poh_recorder.tick();
-//         assert_eq!(poh_recorder.poh.tick_height, 2);
-//         let tx = test_tx();
-//         let h1 = hash(b"hello world!");
-//         assert!(poh_recorder.record(h1, vec![tx.clone()]).is_err());
-//
-//         let (bank, e) = entry_receiver.recv().expect("recv 1");
-//         assert_eq!(e.len(), 2);
-//         assert!(e[0].0.is_tick());
-//         assert!(e[1].0.is_tick());
-//         assert_eq!(e[1].0.hash, bank.last_id());
-//     }
-//
-//     #[test]
-//     fn test_poh_cache_on_disconnect() {
-//         let (genesis_block, _mint_keypair) = GenesisBlock::new(2);
-//         let bank = Arc::new(Bank::new(&genesis_block));
-//         let prev_hash = bank.last_id();
-//         let (entry_sender, entry_receiver) = channel();
-//         let mut poh_recorder = PohRecorder::new(0, prev_hash);
-//
-//         let working_bank = WorkingBank {
-//             bank,
-//             sender: entry_sender,
-//             min_tick_height: 2,
-//             max_tick_height: 3,
-//         };
-//         poh_recorder.set_working_bank(working_bank);
-//         poh_recorder.tick();
-//         poh_recorder.tick();
-//         assert_eq!(poh_recorder.poh.tick_height, 2);
-//         drop(entry_receiver);
-//         poh_recorder.tick();
-//         assert!(poh_recorder.working_bank.is_none());
-//         assert_eq!(poh_recorder.tick_cache.len(), 3);
-//     }
-// }
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_tx::test_tx;
+    use solana_sdk::genesis_block::GenesisBlock;
+    use solana_sdk::hash::hash;
+    use std::sync::Arc;
+
+    #[test]
+    fn test_poh_recorder_no_zero_tick() {
+        let prev_hash = Hash::default();
+        let (poh_recorder, _entry_receiver) = PohRecorder::new(0, prev_hash);
+        assert_eq!(poh_recorder.tick_cache.len(), 1);
+        assert_eq!(poh_recorder.tick_cache[0].1, 1);
+        assert_eq!(poh_recorder.poh.tick_height, 1);
+    }
+
+    #[test]
+    fn test_poh_recorder_tick_height_is_last_tick() {
+        let prev_hash = Hash::default();
+        let (mut poh_recorder, _entry_receiver) = PohRecorder::new(0, prev_hash);
+        poh_recorder.tick();
+        poh_recorder.tick();
+        assert_eq!(poh_recorder.tick_cache.len(), 2);
+        assert_eq!(poh_recorder.tick_cache[1].1, 2);
+        assert_eq!(poh_recorder.poh.tick_height, 2);
+    }
+
+    #[test]
+    fn test_poh_recorder_reset_clears_cache() {
+        let (mut poh_recorder, _entry_receiver) = PohRecorder::new(0, Hash::default());
+        poh_recorder.tick();
+        assert_eq!(poh_recorder.tick_cache.len(), 1);
+        poh_recorder.reset(0, Hash::default());
+        assert_eq!(poh_recorder.tick_cache.len(), 0);
+    }
+
+    #[test]
+    fn test_poh_recorder_clear() {
+        let (genesis_block, _mint_keypair) = GenesisBlock::new(2);
+        let bank = Arc::new(Bank::new(&genesis_block));
+        let prev_hash = bank.last_id();
+        let (mut poh_recorder, _entry_receiver) = PohRecorder::new(0, prev_hash);
+
+        let working_bank = WorkingBank {
+            bank,
+            min_tick_height: 2,
+            max_tick_height: 3,
+        };
+        poh_recorder.set_working_bank(working_bank);
+        assert!(poh_recorder.working_bank.is_some());
+        poh_recorder.clear_bank();
+        assert!(poh_recorder.working_bank.is_none());
+    }
+
+    #[test]
+    fn test_poh_recorder_tick_sent_after_min() {
+        let (genesis_block, _mint_keypair) = GenesisBlock::new(2);
+        let bank = Arc::new(Bank::new(&genesis_block));
+        let prev_hash = bank.last_id();
+        let (mut poh_recorder, entry_receiver) = PohRecorder::new(0, prev_hash);
+
+        let working_bank = WorkingBank {
+            bank: bank.clone(),
+            min_tick_height: 2,
+            max_tick_height: 3,
+        };
+        poh_recorder.set_working_bank(working_bank);
+        poh_recorder.tick();
+        poh_recorder.tick();
+        //tick height equal to min_tick_height
+        //no tick has been sent
+        assert_eq!(poh_recorder.tick_cache.last().unwrap().1, 2);
+        assert!(entry_receiver.try_recv().is_err());
+
+        // all ticks are sent after height > min
+        poh_recorder.tick();
+        assert_eq!(poh_recorder.poh.tick_height, 3);
+        assert_eq!(poh_recorder.tick_cache.len(), 0);
+        let (bank_, e) = entry_receiver.recv().expect("recv 1");
+        assert_eq!(e.len(), 3);
+        assert_eq!(bank_.slot(), bank.slot());
+        assert!(poh_recorder.working_bank.is_none());
+    }
+
+    #[test]
+    fn test_poh_recorder_tick_sent_upto_and_including_max() {
+        let (genesis_block, _mint_keypair) = GenesisBlock::new(2);
+        let bank = Arc::new(Bank::new(&genesis_block));
+        let prev_hash = bank.last_id();
+        let (mut poh_recorder, entry_receiver) = PohRecorder::new(0, prev_hash);
+
+        poh_recorder.tick();
+        poh_recorder.tick();
+        poh_recorder.tick();
+        poh_recorder.tick();
+        assert_eq!(poh_recorder.tick_cache.last().unwrap().1, 4);
+        assert_eq!(poh_recorder.poh.tick_height, 4);
+
+        let working_bank = WorkingBank {
+            bank,
+            min_tick_height: 2,
+            max_tick_height: 3,
+        };
+        poh_recorder.set_working_bank(working_bank);
+        poh_recorder.tick();
+
+        assert_eq!(poh_recorder.poh.tick_height, 5);
+        assert!(poh_recorder.working_bank.is_none());
+        let (_, e) = entry_receiver.recv().expect("recv 1");
+        assert_eq!(e.len(), 3);
+    }
+
+    #[test]
+    fn test_poh_recorder_record_to_early() {
+        let (genesis_block, _mint_keypair) = GenesisBlock::new(2);
+        let bank = Arc::new(Bank::new(&genesis_block));
+        let prev_hash = bank.last_id();
+        let (mut poh_recorder, entry_receiver) = PohRecorder::new(0, prev_hash);
+
+        let working_bank = WorkingBank {
+            bank,
+            min_tick_height: 2,
+            max_tick_height: 3,
+        };
+        poh_recorder.set_working_bank(working_bank);
+        poh_recorder.tick();
+        let tx = test_tx();
+        let h1 = hash(b"hello world!");
+        assert!(poh_recorder.record(h1, vec![tx.clone()]).is_err());
+        assert!(entry_receiver.try_recv().is_err());
+    }
+
+    #[test]
+    fn test_poh_recorder_record_at_min_passes() {
+        let (genesis_block, _mint_keypair) = GenesisBlock::new(2);
+        let bank = Arc::new(Bank::new(&genesis_block));
+        let prev_hash = bank.last_id();
+        let (mut poh_recorder, entry_receiver) = PohRecorder::new(0, prev_hash);
+
+        let working_bank = WorkingBank {
+            bank,
+            min_tick_height: 1,
+            max_tick_height: 2,
+        };
+        poh_recorder.set_working_bank(working_bank);
+        poh_recorder.tick();
+        assert_eq!(poh_recorder.tick_cache.len(), 1);
+        assert_eq!(poh_recorder.poh.tick_height, 1);
+        let tx = test_tx();
+        let h1 = hash(b"hello world!");
+        assert!(poh_recorder.record(h1, vec![tx.clone()]).is_ok());
+        assert_eq!(poh_recorder.tick_cache.len(), 0);
+
+        //tick in the cache + entry
+        let (_b, e) = entry_receiver.recv().expect("recv 1");
+        assert_eq!(e.len(), 1);
+        assert!(e[0].0.is_tick());
+        let (_b, e) = entry_receiver.recv().expect("recv 2");
+        assert!(!e[0].0.is_tick());
+    }
+
+    #[test]
+    fn test_poh_recorder_record_at_max_fails() {
+        let (genesis_block, _mint_keypair) = GenesisBlock::new(2);
+        let bank = Arc::new(Bank::new(&genesis_block));
+        let prev_hash = bank.last_id();
+        let (mut poh_recorder, entry_receiver) = PohRecorder::new(0, prev_hash);
+
+        let working_bank = WorkingBank {
+            bank,
+            min_tick_height: 1,
+            max_tick_height: 2,
+        };
+        poh_recorder.set_working_bank(working_bank);
+        poh_recorder.tick();
+        poh_recorder.tick();
+        assert_eq!(poh_recorder.poh.tick_height, 2);
+        let tx = test_tx();
+        let h1 = hash(b"hello world!");
+        assert!(poh_recorder.record(h1, vec![tx.clone()]).is_err());
+
+        let (bank, e) = entry_receiver.recv().expect("recv 1");
+        assert_eq!(e.len(), 2);
+        assert!(e[0].0.is_tick());
+        assert!(e[1].0.is_tick());
+        assert_eq!(e[1].0.hash, bank.last_id());
+    }
+
+    #[test]
+    fn test_poh_cache_on_disconnect() {
+        let (genesis_block, _mint_keypair) = GenesisBlock::new(2);
+        let bank = Arc::new(Bank::new(&genesis_block));
+        let prev_hash = bank.last_id();
+        let (mut poh_recorder, entry_receiver) = PohRecorder::new(0, prev_hash);
+
+        let working_bank = WorkingBank {
+            bank,
+            min_tick_height: 2,
+            max_tick_height: 3,
+        };
+        poh_recorder.set_working_bank(working_bank);
+        poh_recorder.tick();
+        poh_recorder.tick();
+        assert_eq!(poh_recorder.poh.tick_height, 2);
+        drop(entry_receiver);
+        poh_recorder.tick();
+        assert!(poh_recorder.working_bank.is_none());
+        assert_eq!(poh_recorder.tick_cache.len(), 3);
+    }
+}

--- a/src/poh_recorder.rs
+++ b/src/poh_recorder.rs
@@ -10,6 +10,7 @@
 //! For Entries:
 //! * recorded entry must be >= WorkingBank::min_tick_height && entry must be < WorkingBank::man_tick_height
 //!
+use crate::banking_stage::TpuBankEntries;
 use crate::entry::Entry;
 use crate::poh::Poh;
 use crate::result::{Error, Result};
@@ -29,7 +30,7 @@ pub enum PohRecorderError {
 #[derive(Clone)]
 pub struct WorkingBank {
     pub bank: Arc<Bank>,
-    pub sender: Sender<(Arc<Bank>, Vec<(Entry, u64)>)>,
+    pub sender: Sender<TpuBankEntries>,
     pub min_tick_height: u64,
     pub max_tick_height: u64,
 }

--- a/src/poh_recorder.rs
+++ b/src/poh_recorder.rs
@@ -106,7 +106,9 @@ impl PohRecorder {
             for t in cache {
                 working_bank.bank.register_tick(&t.0.hash);
             }
-            working_bank.sender.send(cache.to_vec())
+            working_bank
+                .sender
+                .send((working_bank.bank.clone(), cache.to_vec()))
         } else {
             Ok(())
         };
@@ -168,9 +170,10 @@ impl PohRecorder {
             transactions: txs,
         };
         trace!("sending entry {}", recorded_entry.is_tick());
-        working_bank
-            .sender
-            .send(vec![(recorded_entry, poh_entry.tick_height)])?;
+        working_bank.sender.send((
+            working_bank.bank.clone(),
+            vec![(recorded_entry, poh_entry.tick_height)],
+        ))?;
         Ok(())
     }
 
@@ -188,228 +191,228 @@ impl PohRecorder {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::test_tx::test_tx;
-    use solana_sdk::genesis_block::GenesisBlock;
-    use solana_sdk::hash::hash;
-    use std::sync::mpsc::channel;
-    use std::sync::Arc;
-
-    #[test]
-    fn test_poh_recorder_no_zero_tick() {
-        let prev_hash = Hash::default();
-        let mut poh_recorder = PohRecorder::new(0, prev_hash);
-        poh_recorder.tick();
-        assert_eq!(poh_recorder.tick_cache.len(), 1);
-        assert_eq!(poh_recorder.tick_cache[0].1, 1);
-        assert_eq!(poh_recorder.poh.tick_height, 1);
-    }
-
-    #[test]
-    fn test_poh_recorder_tick_height_is_last_tick() {
-        let prev_hash = Hash::default();
-        let mut poh_recorder = PohRecorder::new(0, prev_hash);
-        poh_recorder.tick();
-        poh_recorder.tick();
-        assert_eq!(poh_recorder.tick_cache.len(), 2);
-        assert_eq!(poh_recorder.tick_cache[1].1, 2);
-        assert_eq!(poh_recorder.poh.tick_height, 2);
-    }
-
-    #[test]
-    fn test_poh_recorder_reset_clears_cache() {
-        let mut poh_recorder = PohRecorder::new(0, Hash::default());
-        poh_recorder.tick();
-        assert_eq!(poh_recorder.tick_cache.len(), 1);
-        poh_recorder.reset(0, Hash::default());
-        assert_eq!(poh_recorder.tick_cache.len(), 0);
-    }
-
-    #[test]
-    fn test_poh_recorder_clear() {
-        let (genesis_block, _mint_keypair) = GenesisBlock::new(2);
-        let bank = Arc::new(Bank::new(&genesis_block));
-        let prev_hash = bank.last_id();
-        let (entry_sender, _) = channel();
-        let mut poh_recorder = PohRecorder::new(0, prev_hash);
-
-        let working_bank = WorkingBank {
-            bank,
-            sender: entry_sender,
-            min_tick_height: 2,
-            max_tick_height: 3,
-        };
-        poh_recorder.set_working_bank(working_bank);
-        assert!(poh_recorder.working_bank.is_some());
-        poh_recorder.clear_bank();
-        assert!(poh_recorder.working_bank.is_none());
-    }
-
-    #[test]
-    fn test_poh_recorder_tick_sent_after_min() {
-        let (genesis_block, _mint_keypair) = GenesisBlock::new(2);
-        let bank = Arc::new(Bank::new(&genesis_block));
-        let prev_hash = bank.last_id();
-        let (entry_sender, entry_receiver) = channel();
-        let mut poh_recorder = PohRecorder::new(0, prev_hash);
-
-        let working_bank = WorkingBank {
-            bank,
-            sender: entry_sender,
-            min_tick_height: 2,
-            max_tick_height: 3,
-        };
-        poh_recorder.set_working_bank(working_bank);
-        poh_recorder.tick();
-        poh_recorder.tick();
-        //tick height equal to min_tick_height
-        //no tick has been sent
-        assert_eq!(poh_recorder.tick_cache.last().unwrap().1, 2);
-        assert!(entry_receiver.try_recv().is_err());
-
-        // all ticks are sent after height > min
-        poh_recorder.tick();
-        assert_eq!(poh_recorder.poh.tick_height, 3);
-        assert_eq!(poh_recorder.tick_cache.len(), 0);
-        let e = entry_receiver.recv().expect("recv 1");
-        assert_eq!(e.len(), 3);
-        assert!(poh_recorder.working_bank.is_none());
-    }
-
-    #[test]
-    fn test_poh_recorder_tick_sent_upto_and_including_max() {
-        let (genesis_block, _mint_keypair) = GenesisBlock::new(2);
-        let bank = Arc::new(Bank::new(&genesis_block));
-        let prev_hash = bank.last_id();
-        let (entry_sender, entry_receiver) = channel();
-        let mut poh_recorder = PohRecorder::new(0, prev_hash);
-
-        poh_recorder.tick();
-        poh_recorder.tick();
-        poh_recorder.tick();
-        poh_recorder.tick();
-        assert_eq!(poh_recorder.tick_cache.last().unwrap().1, 4);
-        assert_eq!(poh_recorder.poh.tick_height, 4);
-
-        let working_bank = WorkingBank {
-            bank,
-            sender: entry_sender,
-            min_tick_height: 2,
-            max_tick_height: 3,
-        };
-        poh_recorder.set_working_bank(working_bank);
-        poh_recorder.tick();
-
-        assert_eq!(poh_recorder.poh.tick_height, 5);
-        assert!(poh_recorder.working_bank.is_none());
-        let e = entry_receiver.recv().expect("recv 1");
-        assert_eq!(e.len(), 3);
-    }
-
-    #[test]
-    fn test_poh_recorder_record_to_early() {
-        let (genesis_block, _mint_keypair) = GenesisBlock::new(2);
-        let bank = Arc::new(Bank::new(&genesis_block));
-        let prev_hash = bank.last_id();
-        let (entry_sender, entry_receiver) = channel();
-        let mut poh_recorder = PohRecorder::new(0, prev_hash);
-
-        let working_bank = WorkingBank {
-            bank,
-            sender: entry_sender,
-            min_tick_height: 2,
-            max_tick_height: 3,
-        };
-        poh_recorder.set_working_bank(working_bank);
-        poh_recorder.tick();
-        let tx = test_tx();
-        let h1 = hash(b"hello world!");
-        assert!(poh_recorder.record(h1, vec![tx.clone()]).is_err());
-        assert!(entry_receiver.try_recv().is_err());
-    }
-
-    #[test]
-    fn test_poh_recorder_record_at_min_passes() {
-        let (genesis_block, _mint_keypair) = GenesisBlock::new(2);
-        let bank = Arc::new(Bank::new(&genesis_block));
-        let prev_hash = bank.last_id();
-        let (entry_sender, entry_receiver) = channel();
-        let mut poh_recorder = PohRecorder::new(0, prev_hash);
-
-        let working_bank = WorkingBank {
-            bank,
-            sender: entry_sender,
-            min_tick_height: 1,
-            max_tick_height: 2,
-        };
-        poh_recorder.set_working_bank(working_bank);
-        poh_recorder.tick();
-        assert_eq!(poh_recorder.tick_cache.len(), 1);
-        assert_eq!(poh_recorder.poh.tick_height, 1);
-        let tx = test_tx();
-        let h1 = hash(b"hello world!");
-        assert!(poh_recorder.record(h1, vec![tx.clone()]).is_ok());
-        assert_eq!(poh_recorder.tick_cache.len(), 0);
-
-        //tick in the cache + entry
-        let e = entry_receiver.recv().expect("recv 1");
-        assert_eq!(e.len(), 1);
-        assert!(e[0].0.is_tick());
-        let e = entry_receiver.recv().expect("recv 2");
-        assert!(!e[0].0.is_tick());
-    }
-
-    #[test]
-    fn test_poh_recorder_record_at_max_fails() {
-        let (genesis_block, _mint_keypair) = GenesisBlock::new(2);
-        let bank = Arc::new(Bank::new(&genesis_block));
-        let prev_hash = bank.last_id();
-        let (entry_sender, entry_receiver) = channel();
-        let mut poh_recorder = PohRecorder::new(0, prev_hash);
-
-        let working_bank = WorkingBank {
-            bank,
-            sender: entry_sender,
-            min_tick_height: 1,
-            max_tick_height: 2,
-        };
-        poh_recorder.set_working_bank(working_bank);
-        poh_recorder.tick();
-        poh_recorder.tick();
-        assert_eq!(poh_recorder.poh.tick_height, 2);
-        let tx = test_tx();
-        let h1 = hash(b"hello world!");
-        assert!(poh_recorder.record(h1, vec![tx.clone()]).is_err());
-
-        let e = entry_receiver.recv().expect("recv 1");
-        assert_eq!(e.len(), 2);
-        assert!(e[0].0.is_tick());
-        assert!(e[1].0.is_tick());
-    }
-
-    #[test]
-    fn test_poh_cache_on_disconnect() {
-        let (genesis_block, _mint_keypair) = GenesisBlock::new(2);
-        let bank = Arc::new(Bank::new(&genesis_block));
-        let prev_hash = bank.last_id();
-        let (entry_sender, entry_receiver) = channel();
-        let mut poh_recorder = PohRecorder::new(0, prev_hash);
-
-        let working_bank = WorkingBank {
-            bank,
-            sender: entry_sender,
-            min_tick_height: 2,
-            max_tick_height: 3,
-        };
-        poh_recorder.set_working_bank(working_bank);
-        poh_recorder.tick();
-        poh_recorder.tick();
-        assert_eq!(poh_recorder.poh.tick_height, 2);
-        drop(entry_receiver);
-        poh_recorder.tick();
-        assert!(poh_recorder.working_bank.is_none());
-        assert_eq!(poh_recorder.tick_cache.len(), 3);
-    }
-}
+// #[cfg(test)]
+// mod tests {
+//     use super::*;
+//     use crate::test_tx::test_tx;
+//     use solana_sdk::genesis_block::GenesisBlock;
+//     use solana_sdk::hash::hash;
+//     use std::sync::mpsc::channel;
+//     use std::sync::Arc;
+//
+//     #[test]
+//     fn test_poh_recorder_no_zero_tick() {
+//         let prev_hash = Hash::default();
+//         let mut poh_recorder = PohRecorder::new(0, prev_hash);
+//         poh_recorder.tick();
+//         assert_eq!(poh_recorder.tick_cache.len(), 1);
+//         assert_eq!(poh_recorder.tick_cache[0].1, 1);
+//         assert_eq!(poh_recorder.poh.tick_height, 1);
+//     }
+//
+//     #[test]
+//     fn test_poh_recorder_tick_height_is_last_tick() {
+//         let prev_hash = Hash::default();
+//         let mut poh_recorder = PohRecorder::new(0, prev_hash);
+//         poh_recorder.tick();
+//         poh_recorder.tick();
+//         assert_eq!(poh_recorder.tick_cache.len(), 2);
+//         assert_eq!(poh_recorder.tick_cache[1].1, 2);
+//         assert_eq!(poh_recorder.poh.tick_height, 2);
+//     }
+//
+//     #[test]
+//     fn test_poh_recorder_reset_clears_cache() {
+//         let mut poh_recorder = PohRecorder::new(0, Hash::default());
+//         poh_recorder.tick();
+//         assert_eq!(poh_recorder.tick_cache.len(), 1);
+//         poh_recorder.reset(0, Hash::default());
+//         assert_eq!(poh_recorder.tick_cache.len(), 0);
+//     }
+//
+//     #[test]
+//     fn test_poh_recorder_clear() {
+//         let (genesis_block, _mint_keypair) = GenesisBlock::new(2);
+//         let bank = Arc::new(Bank::new(&genesis_block));
+//         let prev_hash = bank.last_id();
+//         let (entry_sender, _) = channel();
+//         let mut poh_recorder = PohRecorder::new(0, prev_hash);
+//
+//         let working_bank = WorkingBank {
+//             bank,
+//             sender: entry_sender,
+//             min_tick_height: 2,
+//             max_tick_height: 3,
+//         };
+//         poh_recorder.set_working_bank(working_bank);
+//         assert!(poh_recorder.working_bank.is_some());
+//         poh_recorder.clear_bank();
+//         assert!(poh_recorder.working_bank.is_none());
+//     }
+//
+//     #[test]
+//     fn test_poh_recorder_tick_sent_after_min() {
+//         let (genesis_block, _mint_keypair) = GenesisBlock::new(2);
+//         let bank = Arc::new(Bank::new(&genesis_block));
+//         let prev_hash = bank.last_id();
+//         let (entry_sender, entry_receiver) = channel();
+//         let mut poh_recorder = PohRecorder::new(0, prev_hash);
+//
+//         let working_bank = WorkingBank {
+//             bank,
+//             sender: entry_sender,
+//             min_tick_height: 2,
+//             max_tick_height: 3,
+//         };
+//         poh_recorder.set_working_bank(working_bank);
+//         poh_recorder.tick();
+//         poh_recorder.tick();
+//         //tick height equal to min_tick_height
+//         //no tick has been sent
+//         assert_eq!(poh_recorder.tick_cache.last().unwrap().1, 2);
+//         assert!(entry_receiver.try_recv().is_err());
+//
+//         // all ticks are sent after height > min
+//         poh_recorder.tick();
+//         assert_eq!(poh_recorder.poh.tick_height, 3);
+//         assert_eq!(poh_recorder.tick_cache.len(), 0);
+//         let e = entry_receiver.recv().expect("recv 1");
+//         assert_eq!(e.len(), 3);
+//         assert!(poh_recorder.working_bank.is_none());
+//     }
+//
+//     #[test]
+//     fn test_poh_recorder_tick_sent_upto_and_including_max() {
+//         let (genesis_block, _mint_keypair) = GenesisBlock::new(2);
+//         let bank = Arc::new(Bank::new(&genesis_block));
+//         let prev_hash = bank.last_id();
+//         let (entry_sender, entry_receiver) = channel();
+//         let mut poh_recorder = PohRecorder::new(0, prev_hash);
+//
+//         poh_recorder.tick();
+//         poh_recorder.tick();
+//         poh_recorder.tick();
+//         poh_recorder.tick();
+//         assert_eq!(poh_recorder.tick_cache.last().unwrap().1, 4);
+//         assert_eq!(poh_recorder.poh.tick_height, 4);
+//
+//         let working_bank = WorkingBank {
+//             bank,
+//             sender: entry_sender,
+//             min_tick_height: 2,
+//             max_tick_height: 3,
+//         };
+//         poh_recorder.set_working_bank(working_bank);
+//         poh_recorder.tick();
+//
+//         assert_eq!(poh_recorder.poh.tick_height, 5);
+//         assert!(poh_recorder.working_bank.is_none());
+//         let e = entry_receiver.recv().expect("recv 1");
+//         assert_eq!(e.len(), 3);
+//     }
+//
+//     #[test]
+//     fn test_poh_recorder_record_to_early() {
+//         let (genesis_block, _mint_keypair) = GenesisBlock::new(2);
+//         let bank = Arc::new(Bank::new(&genesis_block));
+//         let prev_hash = bank.last_id();
+//         let (entry_sender, entry_receiver) = channel();
+//         let mut poh_recorder = PohRecorder::new(0, prev_hash);
+//
+//         let working_bank = WorkingBank {
+//             bank,
+//             sender: entry_sender,
+//             min_tick_height: 2,
+//             max_tick_height: 3,
+//         };
+//         poh_recorder.set_working_bank(working_bank);
+//         poh_recorder.tick();
+//         let tx = test_tx();
+//         let h1 = hash(b"hello world!");
+//         assert!(poh_recorder.record(h1, vec![tx.clone()]).is_err());
+//         assert!(entry_receiver.try_recv().is_err());
+//     }
+//
+//     #[test]
+//     fn test_poh_recorder_record_at_min_passes() {
+//         let (genesis_block, _mint_keypair) = GenesisBlock::new(2);
+//         let bank = Arc::new(Bank::new(&genesis_block));
+//         let prev_hash = bank.last_id();
+//         let (entry_sender, entry_receiver) = channel();
+//         let mut poh_recorder = PohRecorder::new(0, prev_hash);
+//
+//         let working_bank = WorkingBank {
+//             bank,
+//             sender: entry_sender,
+//             min_tick_height: 1,
+//             max_tick_height: 2,
+//         };
+//         poh_recorder.set_working_bank(working_bank);
+//         poh_recorder.tick();
+//         assert_eq!(poh_recorder.tick_cache.len(), 1);
+//         assert_eq!(poh_recorder.poh.tick_height, 1);
+//         let tx = test_tx();
+//         let h1 = hash(b"hello world!");
+//         assert!(poh_recorder.record(h1, vec![tx.clone()]).is_ok());
+//         assert_eq!(poh_recorder.tick_cache.len(), 0);
+//
+//         //tick in the cache + entry
+//         let e = entry_receiver.recv().expect("recv 1");
+//         assert_eq!(e.len(), 1);
+//         assert!(e[0].0.is_tick());
+//         let e = entry_receiver.recv().expect("recv 2");
+//         assert!(!e[0].0.is_tick());
+//     }
+//
+//     #[test]
+//     fn test_poh_recorder_record_at_max_fails() {
+//         let (genesis_block, _mint_keypair) = GenesisBlock::new(2);
+//         let bank = Arc::new(Bank::new(&genesis_block));
+//         let prev_hash = bank.last_id();
+//         let (entry_sender, entry_receiver) = channel();
+//         let mut poh_recorder = PohRecorder::new(0, prev_hash);
+//
+//         let working_bank = WorkingBank {
+//             bank,
+//             sender: entry_sender,
+//             min_tick_height: 1,
+//             max_tick_height: 2,
+//         };
+//         poh_recorder.set_working_bank(working_bank);
+//         poh_recorder.tick();
+//         poh_recorder.tick();
+//         assert_eq!(poh_recorder.poh.tick_height, 2);
+//         let tx = test_tx();
+//         let h1 = hash(b"hello world!");
+//         assert!(poh_recorder.record(h1, vec![tx.clone()]).is_err());
+//
+//         let e = entry_receiver.recv().expect("recv 1");
+//         assert_eq!(e.len(), 2);
+//         assert!(e[0].0.is_tick());
+//         assert!(e[1].0.is_tick());
+//     }
+//
+//     #[test]
+//     fn test_poh_cache_on_disconnect() {
+//         let (genesis_block, _mint_keypair) = GenesisBlock::new(2);
+//         let bank = Arc::new(Bank::new(&genesis_block));
+//         let prev_hash = bank.last_id();
+//         let (entry_sender, entry_receiver) = channel();
+//         let mut poh_recorder = PohRecorder::new(0, prev_hash);
+//
+//         let working_bank = WorkingBank {
+//             bank,
+//             sender: entry_sender,
+//             min_tick_height: 2,
+//             max_tick_height: 3,
+//         };
+//         poh_recorder.set_working_bank(working_bank);
+//         poh_recorder.tick();
+//         poh_recorder.tick();
+//         assert_eq!(poh_recorder.poh.tick_height, 2);
+//         drop(entry_receiver);
+//         poh_recorder.tick();
+//         assert!(poh_recorder.working_bank.is_none());
+//         assert_eq!(poh_recorder.tick_cache.len(), 3);
+//     }
+// }

--- a/src/poh_recorder.rs
+++ b/src/poh_recorder.rs
@@ -57,6 +57,14 @@ impl PohRecorder {
     }
     // synchronize PoH with a bank
     pub fn reset(&mut self, tick_height: u64, last_id: Hash) {
+        if self.poh.hash == last_id {
+            assert_eq!(self.poh.tick_height, tick_height);
+            info!(
+                "reset skipped for: {},{}",
+                self.poh.hash, self.poh.tick_height
+            );
+            return;
+        }
         let mut cache = vec![];
         info!(
             "reset poh from: {},{} to: {},{}",
@@ -117,7 +125,10 @@ impl PohRecorder {
             Ok(())
         };
         if self.poh.tick_height >= working_bank.max_tick_height {
-            info!("poh_record: max_tick_height reached, setting working bank to None");
+            info!(
+                "poh_record: max_tick_height reached, setting working bank {} to None",
+                working_bank.bank.slot()
+            );
             self.working_bank = None;
         }
         if e.is_err() {

--- a/src/poh_recorder.rs
+++ b/src/poh_recorder.rs
@@ -51,6 +51,9 @@ impl PohRecorder {
         self.poh.hash();
     }
 
+    pub fn bank(&self) -> Option<Arc<Bank>> {
+        self.working_bank.map(|w| w.bank).cloned()
+    }
     // synchronize PoH with a bank
     pub fn reset(&mut self, tick_height: u64, last_id: Hash) {
         let mut cache = vec![];

--- a/src/poh_recorder.rs
+++ b/src/poh_recorder.rs
@@ -78,7 +78,7 @@ impl PohRecorder {
     pub fn set_working_bank(&mut self, working_bank: WorkingBank) {
         trace!("new working bank");
         self.working_bank = Some(working_bank);
-	}
+    }
     pub fn set_bank(&mut self, bank: &Arc<Bank>) {
         let max_tick_height = (bank.slot() + 1) * bank.ticks_per_slot() - 1;
         let working_bank = WorkingBank {
@@ -86,7 +86,7 @@ impl PohRecorder {
             min_tick_height: bank.tick_height(),
             max_tick_height,
         };
-		self.set_working_bank(working_bank);
+        self.set_working_bank(working_bank);
     }
 
     // Flush cache will delay flushing the cache for a bank until it past the WorkingBank::min_tick_height

--- a/src/poh_recorder.rs
+++ b/src/poh_recorder.rs
@@ -52,7 +52,7 @@ impl PohRecorder {
     }
 
     pub fn bank(&self) -> Option<Arc<Bank>> {
-        self.working_bank.map(|w| w.bank).clone()
+        self.working_bank.clone().map(|w| w.bank)
     }
     // synchronize PoH with a bank
     pub fn reset(&mut self, tick_height: u64, last_id: Hash) {

--- a/src/poh_recorder.rs
+++ b/src/poh_recorder.rs
@@ -78,6 +78,15 @@ impl PohRecorder {
     pub fn set_working_bank(&mut self, working_bank: WorkingBank) {
         trace!("new working bank");
         self.working_bank = Some(working_bank);
+	}
+    pub fn set_bank(&mut self, bank: &Arc<Bank>) {
+        let max_tick_height = (bank.slot() + 1) * bank.ticks_per_slot() - 1;
+        let working_bank = WorkingBank {
+            bank: bank.clone(),
+            min_tick_height: bank.tick_height(),
+            max_tick_height,
+        };
+		self.set_working_bank(working_bank);
     }
 
     // Flush cache will delay flushing the cache for a bank until it past the WorkingBank::min_tick_height

--- a/src/poh_recorder.rs
+++ b/src/poh_recorder.rs
@@ -224,199 +224,201 @@ mod tests {
         assert_eq!(poh_recorder.tick_cache[1].1, 2);
         assert_eq!(poh_recorder.poh.tick_height, 2);
     }
-    //
-    //     #[test]
-    //     fn test_poh_recorder_reset_clears_cache() {
-    //         let mut poh_recorder = PohRecorder::new(0, Hash::default());
-    //         poh_recorder.tick();
-    //         assert_eq!(poh_recorder.tick_cache.len(), 1);
-    //         poh_recorder.reset(0, Hash::default());
-    //         assert_eq!(poh_recorder.tick_cache.len(), 0);
-    //     }
-    //
-    //     #[test]
-    //     fn test_poh_recorder_clear() {
-    //         let (genesis_block, _mint_keypair) = GenesisBlock::new(2);
-    //         let bank = Arc::new(Bank::new(&genesis_block));
-    //         let prev_hash = bank.last_id();
-    //         let (entry_sender, _) = channel();
-    //         let mut poh_recorder = PohRecorder::new(0, prev_hash);
-    //
-    //         let working_bank = WorkingBank {
-    //             bank,
-    //             sender: entry_sender,
-    //             min_tick_height: 2,
-    //             max_tick_height: 3,
-    //         };
-    //         poh_recorder.set_working_bank(working_bank);
-    //         assert!(poh_recorder.working_bank.is_some());
-    //         poh_recorder.clear_bank();
-    //         assert!(poh_recorder.working_bank.is_none());
-    //     }
-    //
-    //     #[test]
-    //     fn test_poh_recorder_tick_sent_after_min() {
-    //         let (genesis_block, _mint_keypair) = GenesisBlock::new(2);
-    //         let bank = Arc::new(Bank::new(&genesis_block));
-    //         let prev_hash = bank.last_id();
-    //         let (entry_sender, entry_receiver) = channel();
-    //         let mut poh_recorder = PohRecorder::new(0, prev_hash);
-    //
-    //         let working_bank = WorkingBank {
-    //             bank,
-    //             sender: entry_sender,
-    //             min_tick_height: 2,
-    //             max_tick_height: 3,
-    //         };
-    //         poh_recorder.set_working_bank(working_bank);
-    //         poh_recorder.tick();
-    //         poh_recorder.tick();
-    //         //tick height equal to min_tick_height
-    //         //no tick has been sent
-    //         assert_eq!(poh_recorder.tick_cache.last().unwrap().1, 2);
-    //         assert!(entry_receiver.try_recv().is_err());
-    //
-    //         // all ticks are sent after height > min
-    //         poh_recorder.tick();
-    //         assert_eq!(poh_recorder.poh.tick_height, 3);
-    //         assert_eq!(poh_recorder.tick_cache.len(), 0);
-    //         let e = entry_receiver.recv().expect("recv 1");
-    //         assert_eq!(e.len(), 3);
-    //         assert!(poh_recorder.working_bank.is_none());
-    //     }
-    //
-    //     #[test]
-    //     fn test_poh_recorder_tick_sent_upto_and_including_max() {
-    //         let (genesis_block, _mint_keypair) = GenesisBlock::new(2);
-    //         let bank = Arc::new(Bank::new(&genesis_block));
-    //         let prev_hash = bank.last_id();
-    //         let (entry_sender, entry_receiver) = channel();
-    //         let mut poh_recorder = PohRecorder::new(0, prev_hash);
-    //
-    //         poh_recorder.tick();
-    //         poh_recorder.tick();
-    //         poh_recorder.tick();
-    //         poh_recorder.tick();
-    //         assert_eq!(poh_recorder.tick_cache.last().unwrap().1, 4);
-    //         assert_eq!(poh_recorder.poh.tick_height, 4);
-    //
-    //         let working_bank = WorkingBank {
-    //             bank,
-    //             sender: entry_sender,
-    //             min_tick_height: 2,
-    //             max_tick_height: 3,
-    //         };
-    //         poh_recorder.set_working_bank(working_bank);
-    //         poh_recorder.tick();
-    //
-    //         assert_eq!(poh_recorder.poh.tick_height, 5);
-    //         assert!(poh_recorder.working_bank.is_none());
-    //         let e = entry_receiver.recv().expect("recv 1");
-    //         assert_eq!(e.len(), 3);
-    //     }
-    //
-    //     #[test]
-    //     fn test_poh_recorder_record_to_early() {
-    //         let (genesis_block, _mint_keypair) = GenesisBlock::new(2);
-    //         let bank = Arc::new(Bank::new(&genesis_block));
-    //         let prev_hash = bank.last_id();
-    //         let (entry_sender, entry_receiver) = channel();
-    //         let mut poh_recorder = PohRecorder::new(0, prev_hash);
-    //
-    //         let working_bank = WorkingBank {
-    //             bank,
-    //             sender: entry_sender,
-    //             min_tick_height: 2,
-    //             max_tick_height: 3,
-    //         };
-    //         poh_recorder.set_working_bank(working_bank);
-    //         poh_recorder.tick();
-    //         let tx = test_tx();
-    //         let h1 = hash(b"hello world!");
-    //         assert!(poh_recorder.record(h1, vec![tx.clone()]).is_err());
-    //         assert!(entry_receiver.try_recv().is_err());
-    //     }
-    //
-    //     #[test]
-    //     fn test_poh_recorder_record_at_min_passes() {
-    //         let (genesis_block, _mint_keypair) = GenesisBlock::new(2);
-    //         let bank = Arc::new(Bank::new(&genesis_block));
-    //         let prev_hash = bank.last_id();
-    //         let (entry_sender, entry_receiver) = channel();
-    //         let mut poh_recorder = PohRecorder::new(0, prev_hash);
-    //
-    //         let working_bank = WorkingBank {
-    //             bank,
-    //             sender: entry_sender,
-    //             min_tick_height: 1,
-    //             max_tick_height: 2,
-    //         };
-    //         poh_recorder.set_working_bank(working_bank);
-    //         poh_recorder.tick();
-    //         assert_eq!(poh_recorder.tick_cache.len(), 1);
-    //         assert_eq!(poh_recorder.poh.tick_height, 1);
-    //         let tx = test_tx();
-    //         let h1 = hash(b"hello world!");
-    //         assert!(poh_recorder.record(h1, vec![tx.clone()]).is_ok());
-    //         assert_eq!(poh_recorder.tick_cache.len(), 0);
-    //
-    //         //tick in the cache + entry
-    //         let e = entry_receiver.recv().expect("recv 1");
-    //         assert_eq!(e.len(), 1);
-    //         assert!(e[0].0.is_tick());
-    //         let e = entry_receiver.recv().expect("recv 2");
-    //         assert!(!e[0].0.is_tick());
-    //     }
-    //
-    //     #[test]
-    //     fn test_poh_recorder_record_at_max_fails() {
-    //         let (genesis_block, _mint_keypair) = GenesisBlock::new(2);
-    //         let bank = Arc::new(Bank::new(&genesis_block));
-    //         let prev_hash = bank.last_id();
-    //         let (entry_sender, entry_receiver) = channel();
-    //         let mut poh_recorder = PohRecorder::new(0, prev_hash);
-    //
-    //         let working_bank = WorkingBank {
-    //             bank,
-    //             sender: entry_sender,
-    //             min_tick_height: 1,
-    //             max_tick_height: 2,
-    //         };
-    //         poh_recorder.set_working_bank(working_bank);
-    //         poh_recorder.tick();
-    //         poh_recorder.tick();
-    //         assert_eq!(poh_recorder.poh.tick_height, 2);
-    //         let tx = test_tx();
-    //         let h1 = hash(b"hello world!");
-    //         assert!(poh_recorder.record(h1, vec![tx.clone()]).is_err());
-    //
-    //         let e = entry_receiver.recv().expect("recv 1");
-    //         assert_eq!(e.len(), 2);
-    //         assert!(e[0].0.is_tick());
-    //         assert!(e[1].0.is_tick());
-    //     }
-    //
-    //     #[test]
-    //     fn test_poh_cache_on_disconnect() {
-    //         let (genesis_block, _mint_keypair) = GenesisBlock::new(2);
-    //         let bank = Arc::new(Bank::new(&genesis_block));
-    //         let prev_hash = bank.last_id();
-    //         let (entry_sender, entry_receiver) = channel();
-    //         let mut poh_recorder = PohRecorder::new(0, prev_hash);
-    //
-    //         let working_bank = WorkingBank {
-    //             bank,
-    //             sender: entry_sender,
-    //             min_tick_height: 2,
-    //             max_tick_height: 3,
-    //         };
-    //         poh_recorder.set_working_bank(working_bank);
-    //         poh_recorder.tick();
-    //         poh_recorder.tick();
-    //         assert_eq!(poh_recorder.poh.tick_height, 2);
-    //         drop(entry_receiver);
-    //         poh_recorder.tick();
-    //         assert!(poh_recorder.working_bank.is_none());
-    //         assert_eq!(poh_recorder.tick_cache.len(), 3);
-    //     }
+
+    #[test]
+    fn test_poh_recorder_reset_clears_cache() {
+        let mut poh_recorder = PohRecorder::new(0, Hash::default());
+        poh_recorder.tick();
+        assert_eq!(poh_recorder.tick_cache.len(), 1);
+        poh_recorder.reset(0, Hash::default());
+        assert_eq!(poh_recorder.tick_cache.len(), 0);
+    }
+
+    #[test]
+    fn test_poh_recorder_clear() {
+        let (genesis_block, _mint_keypair) = GenesisBlock::new(2);
+        let bank = Arc::new(Bank::new(&genesis_block));
+        let prev_hash = bank.last_id();
+        let (entry_sender, _) = channel();
+        let mut poh_recorder = PohRecorder::new(0, prev_hash);
+
+        let working_bank = WorkingBank {
+            bank,
+            sender: entry_sender,
+            min_tick_height: 2,
+            max_tick_height: 3,
+        };
+        poh_recorder.set_working_bank(working_bank);
+        assert!(poh_recorder.working_bank.is_some());
+        poh_recorder.clear_bank();
+        assert!(poh_recorder.working_bank.is_none());
+    }
+
+    #[test]
+    fn test_poh_recorder_tick_sent_after_min() {
+        let (genesis_block, _mint_keypair) = GenesisBlock::new(2);
+        let bank = Arc::new(Bank::new(&genesis_block));
+        let prev_hash = bank.last_id();
+        let (entry_sender, entry_receiver) = channel();
+        let mut poh_recorder = PohRecorder::new(0, prev_hash);
+
+        let working_bank = WorkingBank {
+            bank: bank.clone(),
+            sender: entry_sender,
+            min_tick_height: 2,
+            max_tick_height: 3,
+        };
+        poh_recorder.set_working_bank(working_bank);
+        poh_recorder.tick();
+        poh_recorder.tick();
+        //tick height equal to min_tick_height
+        //no tick has been sent
+        assert_eq!(poh_recorder.tick_cache.last().unwrap().1, 2);
+        assert!(entry_receiver.try_recv().is_err());
+
+        // all ticks are sent after height > min
+        poh_recorder.tick();
+        assert_eq!(poh_recorder.poh.tick_height, 3);
+        assert_eq!(poh_recorder.tick_cache.len(), 0);
+        let (bank_, e) = entry_receiver.recv().expect("recv 1");
+        assert_eq!(e.len(), 3);
+        assert_eq!(bank_.slot(), bank.slot());
+        assert!(poh_recorder.working_bank.is_none());
+    }
+
+    #[test]
+    fn test_poh_recorder_tick_sent_upto_and_including_max() {
+        let (genesis_block, _mint_keypair) = GenesisBlock::new(2);
+        let bank = Arc::new(Bank::new(&genesis_block));
+        let prev_hash = bank.last_id();
+        let (entry_sender, entry_receiver) = channel();
+        let mut poh_recorder = PohRecorder::new(0, prev_hash);
+
+        poh_recorder.tick();
+        poh_recorder.tick();
+        poh_recorder.tick();
+        poh_recorder.tick();
+        assert_eq!(poh_recorder.tick_cache.last().unwrap().1, 4);
+        assert_eq!(poh_recorder.poh.tick_height, 4);
+
+        let working_bank = WorkingBank {
+            bank,
+            sender: entry_sender,
+            min_tick_height: 2,
+            max_tick_height: 3,
+        };
+        poh_recorder.set_working_bank(working_bank);
+        poh_recorder.tick();
+
+        assert_eq!(poh_recorder.poh.tick_height, 5);
+        assert!(poh_recorder.working_bank.is_none());
+        let (_, e) = entry_receiver.recv().expect("recv 1");
+        assert_eq!(e.len(), 3);
+    }
+
+    #[test]
+    fn test_poh_recorder_record_to_early() {
+        let (genesis_block, _mint_keypair) = GenesisBlock::new(2);
+        let bank = Arc::new(Bank::new(&genesis_block));
+        let prev_hash = bank.last_id();
+        let (entry_sender, entry_receiver) = channel();
+        let mut poh_recorder = PohRecorder::new(0, prev_hash);
+
+        let working_bank = WorkingBank {
+            bank,
+            sender: entry_sender,
+            min_tick_height: 2,
+            max_tick_height: 3,
+        };
+        poh_recorder.set_working_bank(working_bank);
+        poh_recorder.tick();
+        let tx = test_tx();
+        let h1 = hash(b"hello world!");
+        assert!(poh_recorder.record(h1, vec![tx.clone()]).is_err());
+        assert!(entry_receiver.try_recv().is_err());
+    }
+
+    #[test]
+    fn test_poh_recorder_record_at_min_passes() {
+        let (genesis_block, _mint_keypair) = GenesisBlock::new(2);
+        let bank = Arc::new(Bank::new(&genesis_block));
+        let prev_hash = bank.last_id();
+        let (entry_sender, entry_receiver) = channel();
+        let mut poh_recorder = PohRecorder::new(0, prev_hash);
+
+        let working_bank = WorkingBank {
+            bank,
+            sender: entry_sender,
+            min_tick_height: 1,
+            max_tick_height: 2,
+        };
+        poh_recorder.set_working_bank(working_bank);
+        poh_recorder.tick();
+        assert_eq!(poh_recorder.tick_cache.len(), 1);
+        assert_eq!(poh_recorder.poh.tick_height, 1);
+        let tx = test_tx();
+        let h1 = hash(b"hello world!");
+        assert!(poh_recorder.record(h1, vec![tx.clone()]).is_ok());
+        assert_eq!(poh_recorder.tick_cache.len(), 0);
+
+        //tick in the cache + entry
+        let (_b, e) = entry_receiver.recv().expect("recv 1");
+        assert_eq!(e.len(), 1);
+        assert!(e[0].0.is_tick());
+        let (_b, e) = entry_receiver.recv().expect("recv 2");
+        assert!(!e[0].0.is_tick());
+    }
+
+    #[test]
+    fn test_poh_recorder_record_at_max_fails() {
+        let (genesis_block, _mint_keypair) = GenesisBlock::new(2);
+        let bank = Arc::new(Bank::new(&genesis_block));
+        let prev_hash = bank.last_id();
+        let (entry_sender, entry_receiver) = channel();
+        let mut poh_recorder = PohRecorder::new(0, prev_hash);
+
+        let working_bank = WorkingBank {
+            bank,
+            sender: entry_sender,
+            min_tick_height: 1,
+            max_tick_height: 2,
+        };
+        poh_recorder.set_working_bank(working_bank);
+        poh_recorder.tick();
+        poh_recorder.tick();
+        assert_eq!(poh_recorder.poh.tick_height, 2);
+        let tx = test_tx();
+        let h1 = hash(b"hello world!");
+        assert!(poh_recorder.record(h1, vec![tx.clone()]).is_err());
+
+        let (bank, e) = entry_receiver.recv().expect("recv 1");
+        assert_eq!(e.len(), 2);
+        assert!(e[0].0.is_tick());
+        assert!(e[1].0.is_tick());
+        assert_eq!(e[1].0.hash, bank.last_id());
+    }
+
+    #[test]
+    fn test_poh_cache_on_disconnect() {
+        let (genesis_block, _mint_keypair) = GenesisBlock::new(2);
+        let bank = Arc::new(Bank::new(&genesis_block));
+        let prev_hash = bank.last_id();
+        let (entry_sender, entry_receiver) = channel();
+        let mut poh_recorder = PohRecorder::new(0, prev_hash);
+
+        let working_bank = WorkingBank {
+            bank,
+            sender: entry_sender,
+            min_tick_height: 2,
+            max_tick_height: 3,
+        };
+        poh_recorder.set_working_bank(working_bank);
+        poh_recorder.tick();
+        poh_recorder.tick();
+        assert_eq!(poh_recorder.poh.tick_height, 2);
+        drop(entry_receiver);
+        poh_recorder.tick();
+        assert!(poh_recorder.working_bank.is_none());
+        assert_eq!(poh_recorder.tick_cache.len(), 3);
+    }
 }

--- a/src/poh_recorder.rs
+++ b/src/poh_recorder.rs
@@ -231,7 +231,8 @@ mod tests {
     #[test]
     fn test_poh_recorder_no_zero_tick() {
         let prev_hash = Hash::default();
-        let (poh_recorder, _entry_receiver) = PohRecorder::new(0, prev_hash);
+        let (mut poh_recorder, _entry_receiver) = PohRecorder::new(0, prev_hash);
+        poh_recorder.tick();
         assert_eq!(poh_recorder.tick_cache.len(), 1);
         assert_eq!(poh_recorder.tick_cache[0].1, 1);
         assert_eq!(poh_recorder.poh.tick_height, 1);

--- a/src/poh_recorder.rs
+++ b/src/poh_recorder.rs
@@ -52,7 +52,7 @@ impl PohRecorder {
     }
 
     pub fn bank(&self) -> Option<Arc<Bank>> {
-        self.working_bank.map(|w| w.bank).cloned()
+        self.working_bank.map(|w| w.bank).clone()
     }
     // synchronize PoH with a bank
     pub fn reset(&mut self, tick_height: u64, last_id: Hash) {

--- a/src/poh_recorder.rs
+++ b/src/poh_recorder.rs
@@ -29,7 +29,7 @@ pub enum PohRecorderError {
 #[derive(Clone)]
 pub struct WorkingBank {
     pub bank: Arc<Bank>,
-    pub sender: Sender<Vec<(Entry, u64)>>,
+    pub sender: Sender<(Arc<Bank>, Vec<(Entry, u64)>)>,
     pub min_tick_height: u64,
     pub max_tick_height: u64,
 }

--- a/src/poh_service.rs
+++ b/src/poh_service.rs
@@ -161,10 +161,7 @@ mod tests {
             &PohServiceConfig::Tick(HASHES_PER_TICK as usize),
             Arc::new(AtomicBool::new(false)),
         );
-        poh_recorder
-            .lock()
-            .unwrap()
-            .set_working_bank(working_bank);
+        poh_recorder.lock().unwrap().set_working_bank(working_bank);
 
         // get some events
         let mut hashes = 0;
@@ -222,10 +219,7 @@ mod tests {
             Arc::new(AtomicBool::new(false)),
         );
 
-        poh_recorder
-            .lock()
-            .unwrap()
-            .set_working_bank(working_bank);
+        poh_recorder.lock().unwrap().set_working_bank(working_bank);
 
         // all 5 ticks are expected, there is no tick 0
         // First 4 ticks must be sent all at once, since bank shouldn't see them until

--- a/src/poh_service.rs
+++ b/src/poh_service.rs
@@ -117,7 +117,6 @@ mod tests {
     use solana_runtime::bank::Bank;
     use solana_sdk::genesis_block::GenesisBlock;
     use solana_sdk::hash::hash;
-    use std::sync::mpsc::RecvError;
 
     #[test]
     fn test_poh_service() {

--- a/src/poh_service.rs
+++ b/src/poh_service.rs
@@ -125,12 +125,11 @@ mod tests {
         let (genesis_block, _mint_keypair) = GenesisBlock::new(2);
         let bank = Arc::new(Bank::new(&genesis_block));
         let prev_hash = bank.last_id();
-        let (entry_sender, entry_receiver) = channel();
-        let poh_recorder = Arc::new(Mutex::new(PohRecorder::new(bank.tick_height(), prev_hash)));
+        let (poh_recorder, entry_receiver) = PohRecorder::new(bank.tick_height(), prev_hash);
+        let poh_recorder = Arc::new(Mutex::new(poh_recorder));
         let exit = Arc::new(AtomicBool::new(false));
         let working_bank = WorkingBank {
             bank: bank.clone(),
-            sender: entry_sender,
             min_tick_height: bank.tick_height(),
             max_tick_height: std::u64::MAX,
         };
@@ -205,12 +204,11 @@ mod tests {
         let (genesis_block, _mint_keypair) = GenesisBlock::new(2);
         let bank = Arc::new(Bank::new(&genesis_block));
         let prev_hash = bank.last_id();
-        let (entry_sender, entry_receiver) = channel();
-        let poh_recorder = Arc::new(Mutex::new(PohRecorder::new(bank.tick_height(), prev_hash)));
+        let (poh_recorder, entry_receiver) = PohRecorder::new(bank.tick_height(), prev_hash);
+        let poh_recorder = Arc::new(Mutex::new(poh_recorder));
         let exit = Arc::new(AtomicBool::new(false));
         let working_bank = WorkingBank {
             bank: bank.clone(),
-            sender: entry_sender,
             min_tick_height: bank.tick_height() + 3,
             max_tick_height: bank.tick_height() + 5,
         };

--- a/src/poh_service.rs
+++ b/src/poh_service.rs
@@ -161,7 +161,10 @@ mod tests {
             &PohServiceConfig::Tick(HASHES_PER_TICK as usize),
             Arc::new(AtomicBool::new(false)),
         );
-        poh_recorder.lock().unwrap().set_working_bank(working_bank);
+        poh_recorder
+            .lock()
+            .unwrap()
+            .set_working_bank(working_bank);
 
         // get some events
         let mut hashes = 0;
@@ -219,7 +222,10 @@ mod tests {
             Arc::new(AtomicBool::new(false)),
         );
 
-        poh_recorder.lock().unwrap().set_working_bank(working_bank);
+        poh_recorder
+            .lock()
+            .unwrap()
+            .set_working_bank(working_bank);
 
         // all 5 ticks are expected, there is no tick 0
         // First 4 ticks must be sent all at once, since bank shouldn't see them until

--- a/src/poh_service.rs
+++ b/src/poh_service.rs
@@ -108,134 +108,134 @@ impl Service for PohService {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::poh_recorder::WorkingBank;
-    use crate::result::Result;
-    use crate::test_tx::test_tx;
-    use solana_runtime::bank::Bank;
-    use solana_sdk::genesis_block::GenesisBlock;
-    use solana_sdk::hash::hash;
-    use std::sync::mpsc::channel;
-    use std::sync::mpsc::RecvError;
-
-    #[test]
-    fn test_poh_service() {
-        let (genesis_block, _mint_keypair) = GenesisBlock::new(2);
-        let bank = Arc::new(Bank::new(&genesis_block));
-        let prev_hash = bank.last_id();
-        let (entry_sender, entry_receiver) = channel();
-        let poh_recorder = Arc::new(Mutex::new(PohRecorder::new(bank.tick_height(), prev_hash)));
-        let exit = Arc::new(AtomicBool::new(false));
-        let working_bank = WorkingBank {
-            bank: bank.clone(),
-            sender: entry_sender,
-            min_tick_height: bank.tick_height(),
-            max_tick_height: std::u64::MAX,
-        };
-
-        let entry_producer: JoinHandle<Result<()>> = {
-            let poh_recorder = poh_recorder.clone();
-            let exit = exit.clone();
-
-            Builder::new()
-                .name("solana-poh-service-entry_producer".to_string())
-                .spawn(move || {
-                    loop {
-                        // send some data
-                        let h1 = hash(b"hello world!");
-                        let tx = test_tx();
-                        poh_recorder.lock().unwrap().record(h1, vec![tx]).unwrap();
-
-                        if exit.load(Ordering::Relaxed) {
-                            break Ok(());
-                        }
-                    }
-                })
-                .unwrap()
-        };
-
-        const HASHES_PER_TICK: u64 = 2;
-        let poh_service = PohService::new(
-            poh_recorder.clone(),
-            &PohServiceConfig::Tick(HASHES_PER_TICK as usize),
-            Arc::new(AtomicBool::new(false)),
-        );
-        poh_recorder.lock().unwrap().set_working_bank(working_bank);
-
-        // get some events
-        let mut hashes = 0;
-        let mut need_tick = true;
-        let mut need_entry = true;
-        let mut need_partial = true;
-
-        while need_tick || need_entry || need_partial {
-            for entry in entry_receiver.recv().unwrap() {
-                let entry = &entry.0;
-                if entry.is_tick() {
-                    assert!(entry.num_hashes <= HASHES_PER_TICK);
-
-                    if entry.num_hashes == HASHES_PER_TICK {
-                        need_tick = false;
-                    } else {
-                        need_partial = false;
-                    }
-
-                    hashes += entry.num_hashes;
-
-                    assert_eq!(hashes, HASHES_PER_TICK);
-
-                    hashes = 0;
-                } else {
-                    assert!(entry.num_hashes >= 1);
-                    need_entry = false;
-                    hashes += entry.num_hashes - 1;
-                }
-            }
-        }
-        exit.store(true, Ordering::Relaxed);
-        poh_service.exit();
-        let _ = poh_service.join().unwrap();
-        let _ = entry_producer.join().unwrap();
-    }
-
-    #[test]
-    fn test_poh_service_drops_working_bank() {
-        let (genesis_block, _mint_keypair) = GenesisBlock::new(2);
-        let bank = Arc::new(Bank::new(&genesis_block));
-        let prev_hash = bank.last_id();
-        let (entry_sender, entry_receiver) = channel();
-        let poh_recorder = Arc::new(Mutex::new(PohRecorder::new(bank.tick_height(), prev_hash)));
-        let exit = Arc::new(AtomicBool::new(false));
-        let working_bank = WorkingBank {
-            bank: bank.clone(),
-            sender: entry_sender,
-            min_tick_height: bank.tick_height() + 3,
-            max_tick_height: bank.tick_height() + 5,
-        };
-
-        let poh_service = PohService::new(
-            poh_recorder.clone(),
-            &PohServiceConfig::default(),
-            Arc::new(AtomicBool::new(false)),
-        );
-
-        poh_recorder.lock().unwrap().set_working_bank(working_bank);
-
-        // all 5 ticks are expected, there is no tick 0
-        // First 4 ticks must be sent all at once, since bank shouldn't see them until
-        // the after bank's min_tick_height(3) is reached.
-        let entries = entry_receiver.recv().expect("recv 1");
-        assert_eq!(entries.len(), 4);
-        let entries = entry_receiver.recv().expect("recv 2");
-        assert_eq!(entries.len(), 1);
-
-        //WorkingBank should be dropped by the PohService thread as well
-        assert_eq!(entry_receiver.recv(), Err(RecvError));
-
-        exit.store(true, Ordering::Relaxed);
-        poh_service.exit();
-        let _ = poh_service.join().unwrap();
-    }
-}
+// #[cfg(test)]
+// mod tests {
+//     use super::*;
+//     use crate::poh_recorder::WorkingBank;
+//     use crate::result::Result;
+//     use crate::test_tx::test_tx;
+//     use solana_runtime::bank::Bank;
+//     use solana_sdk::genesis_block::GenesisBlock;
+//     use solana_sdk::hash::hash;
+//     use std::sync::mpsc::channel;
+//     use std::sync::mpsc::RecvError;
+//
+//     #[test]
+//     fn test_poh_service() {
+//         let (genesis_block, _mint_keypair) = GenesisBlock::new(2);
+//         let bank = Arc::new(Bank::new(&genesis_block));
+//         let prev_hash = bank.last_id();
+//         let (entry_sender, entry_receiver) = channel();
+//         let poh_recorder = Arc::new(Mutex::new(PohRecorder::new(bank.tick_height(), prev_hash)));
+//         let exit = Arc::new(AtomicBool::new(false));
+//         let working_bank = WorkingBank {
+//             bank: bank.clone(),
+//             sender: entry_sender,
+//             min_tick_height: bank.tick_height(),
+//             max_tick_height: std::u64::MAX,
+//         };
+//
+//         let entry_producer: JoinHandle<Result<()>> = {
+//             let poh_recorder = poh_recorder.clone();
+//             let exit = exit.clone();
+//
+//             Builder::new()
+//                 .name("solana-poh-service-entry_producer".to_string())
+//                 .spawn(move || {
+//                     loop {
+//                         // send some data
+//                         let h1 = hash(b"hello world!");
+//                         let tx = test_tx();
+//                         poh_recorder.lock().unwrap().record(h1, vec![tx]).unwrap();
+//
+//                         if exit.load(Ordering::Relaxed) {
+//                             break Ok(());
+//                         }
+//                     }
+//                 })
+//                 .unwrap()
+//         };
+//
+//         const HASHES_PER_TICK: u64 = 2;
+//         let poh_service = PohService::new(
+//             poh_recorder.clone(),
+//             &PohServiceConfig::Tick(HASHES_PER_TICK as usize),
+//             Arc::new(AtomicBool::new(false)),
+//         );
+//         poh_recorder.lock().unwrap().set_working_bank(working_bank);
+//
+//         // get some events
+//         let mut hashes = 0;
+//         let mut need_tick = true;
+//         let mut need_entry = true;
+//         let mut need_partial = true;
+//
+//         while need_tick || need_entry || need_partial {
+//             for entry in entry_receiver.recv().unwrap() {
+//                 let entry = &entry.0;
+//                 if entry.is_tick() {
+//                     assert!(entry.num_hashes <= HASHES_PER_TICK);
+//
+//                     if entry.num_hashes == HASHES_PER_TICK {
+//                         need_tick = false;
+//                     } else {
+//                         need_partial = false;
+//                     }
+//
+//                     hashes += entry.num_hashes;
+//
+//                     assert_eq!(hashes, HASHES_PER_TICK);
+//
+//                     hashes = 0;
+//                 } else {
+//                     assert!(entry.num_hashes >= 1);
+//                     need_entry = false;
+//                     hashes += entry.num_hashes - 1;
+//                 }
+//             }
+//         }
+//         exit.store(true, Ordering::Relaxed);
+//         poh_service.exit();
+//         let _ = poh_service.join().unwrap();
+//         let _ = entry_producer.join().unwrap();
+//     }
+//
+//     #[test]
+//     fn test_poh_service_drops_working_bank() {
+//         let (genesis_block, _mint_keypair) = GenesisBlock::new(2);
+//         let bank = Arc::new(Bank::new(&genesis_block));
+//         let prev_hash = bank.last_id();
+//         let (entry_sender, entry_receiver) = channel();
+//         let poh_recorder = Arc::new(Mutex::new(PohRecorder::new(bank.tick_height(), prev_hash)));
+//         let exit = Arc::new(AtomicBool::new(false));
+//         let working_bank = WorkingBank {
+//             bank: bank.clone(),
+//             sender: entry_sender,
+//             min_tick_height: bank.tick_height() + 3,
+//             max_tick_height: bank.tick_height() + 5,
+//         };
+//
+//         let poh_service = PohService::new(
+//             poh_recorder.clone(),
+//             &PohServiceConfig::default(),
+//             Arc::new(AtomicBool::new(false)),
+//         );
+//
+//         poh_recorder.lock().unwrap().set_working_bank(working_bank);
+//
+//         // all 5 ticks are expected, there is no tick 0
+//         // First 4 ticks must be sent all at once, since bank shouldn't see them until
+//         // the after bank's min_tick_height(3) is reached.
+//         let entries = entry_receiver.recv().expect("recv 1");
+//         assert_eq!(entries.len(), 4);
+//         let entries = entry_receiver.recv().expect("recv 2");
+//         assert_eq!(entries.len(), 1);
+//
+//         //WorkingBank should be dropped by the PohService thread as well
+//         assert_eq!(entry_receiver.recv(), Err(RecvError));
+//
+//         exit.store(true, Ordering::Relaxed);
+//         poh_service.exit();
+//         let _ = poh_service.join().unwrap();
+//     }
+// }

--- a/src/poh_service.rs
+++ b/src/poh_service.rs
@@ -117,7 +117,6 @@ mod tests {
     use solana_runtime::bank::Bank;
     use solana_sdk::genesis_block::GenesisBlock;
     use solana_sdk::hash::hash;
-    use std::sync::mpsc::channel;
     use std::sync::mpsc::RecvError;
 
     #[test]

--- a/src/replay_stage.rs
+++ b/src/replay_stage.rs
@@ -21,7 +21,7 @@ use solana_sdk::timing::duration_as_ms;
 use solana_sdk::vote_transaction::VoteTransaction;
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::mpsc::{channel, Receiver, RecvTimeoutError, Sender};
+use std::sync::mpsc::{channel, Receiver, RecvTimeoutError};
 use std::sync::{Arc, Mutex, RwLock};
 use std::thread::{self, Builder, JoinHandle};
 use std::time::Duration;

--- a/src/replay_stage.rs
+++ b/src/replay_stage.rs
@@ -8,7 +8,7 @@ use crate::cluster_info::ClusterInfo;
 use crate::entry::{Entry, EntryReceiver, EntrySender, EntrySlice};
 use crate::leader_schedule_utils;
 use crate::packet::BlobError;
-use crate::poh_recorder::{PohRecorder, WorkingBank};
+use crate::poh_recorder::PohRecorder;
 use crate::result;
 use crate::rpc_subscriptions::RpcSubscriptions;
 use crate::service::Service;
@@ -373,7 +373,7 @@ mod test {
             let bank = bank_forks.working_bank();
 
             let blocktree = Arc::new(blocktree);
-            let (poh_recorder, poh_service, entry_receiver) = create_test_recorder(&bank);
+            let (poh_recorder, poh_service, _entry_receiver) = create_test_recorder(&bank);
             let (replay_stage, _slot_full_receiver, ledger_writer_recv) = ReplayStage::new(
                 my_keypair.pubkey(),
                 Some(voting_keypair.clone()),

--- a/src/replay_stage.rs
+++ b/src/replay_stage.rs
@@ -121,7 +121,7 @@ impl ReplayStage {
                     if votable.is_empty()
                         && frozen.len() == 1
                         && active_banks.is_empty()
-                        && first_block == false
+                        && !first_block
                     {
                         first_block = true;
                         votable.extend(frozen.keys());

--- a/src/replay_stage.rs
+++ b/src/replay_stage.rs
@@ -382,67 +382,68 @@ mod test {
             replay_stage
                 .close()
                 .expect("Expect successful ReplayStage exit");
+            poh_service.close();
         }
         let _ignored = remove_dir_all(&my_ledger_path);
     }
 
-    //     #[test]
-    //     fn test_replay_stage_poh_ok_entry_receiver() {
-    //         let (forward_entry_sender, forward_entry_receiver) = channel();
-    //         let genesis_block = GenesisBlock::new(10_000).0;
-    //         let bank = Arc::new(Bank::new(&genesis_block));
-    //         let mut last_id = bank.last_id();
-    //         let mut entries = Vec::new();
-    //         for _ in 0..5 {
-    //             let entry = next_entry_mut(&mut last_id, 1, vec![]); //just ticks
-    //             entries.push(entry);
-    //         }
-    //
-    //         let mut progress = HashMap::new();
-    //         let res = ReplayStage::replay_entries_into_bank(
-    //             &bank,
-    //             entries.clone(),
-    //             &mut progress,
-    //             &forward_entry_sender,
-    //             0,
-    //         );
-    //         assert!(res.is_ok(), "replay failed {:?}", res);
-    //         let res = forward_entry_receiver.try_recv();
-    //         match res {
-    //             Ok(_) => (),
-    //             Err(e) => assert!(false, "Entries were not sent correctly {:?}", e),
-    //         }
-    //     }
-    //
-    //     #[test]
-    //     fn test_replay_stage_poh_error_entry_receiver() {
-    //         let (forward_entry_sender, forward_entry_receiver) = channel();
-    //         let mut entries = Vec::new();
-    //         for _ in 0..5 {
-    //             let entry = Entry::new(&mut Hash::default(), 1, vec![]); //just broken entries
-    //             entries.push(entry);
-    //         }
-    //
-    //         let genesis_block = GenesisBlock::new(10_000).0;
-    //         let bank = Arc::new(Bank::new(&genesis_block));
-    //         let mut progress = HashMap::new();
-    //         let res = ReplayStage::replay_entries_into_bank(
-    //             &bank,
-    //             entries.clone(),
-    //             &mut progress,
-    //             &forward_entry_sender,
-    //             0,
-    //         );
-    //
-    //         match res {
-    //             Ok(_) => assert!(false, "Should have failed because entries are broken"),
-    //             Err(Error::BlobError(BlobError::VerificationFailed)) => (),
-    //             Err(e) => assert!(
-    //                 false,
-    //                 "Should have failed because with blob error, instead, got {:?}",
-    //                 e
-    //             ),
-    //         }
-    //         assert!(forward_entry_receiver.try_recv().is_err());
-    //     }
+    #[test]
+    fn test_replay_stage_poh_ok_entry_receiver() {
+        let (forward_entry_sender, forward_entry_receiver) = channel();
+        let genesis_block = GenesisBlock::new(10_000).0;
+        let bank = Arc::new(Bank::new(&genesis_block));
+        let mut last_id = bank.last_id();
+        let mut entries = Vec::new();
+        for _ in 0..5 {
+            let entry = next_entry_mut(&mut last_id, 1, vec![]); //just ticks
+            entries.push(entry);
+        }
+
+        let mut progress = HashMap::new();
+        let res = ReplayStage::replay_entries_into_bank(
+            &bank,
+            entries.clone(),
+            &mut progress,
+            &forward_entry_sender,
+            0,
+        );
+        assert!(res.is_ok(), "replay failed {:?}", res);
+        let res = forward_entry_receiver.try_recv();
+        match res {
+            Ok(_) => (),
+            Err(e) => assert!(false, "Entries were not sent correctly {:?}", e),
+        }
+    }
+
+    #[test]
+    fn test_replay_stage_poh_error_entry_receiver() {
+        let (forward_entry_sender, forward_entry_receiver) = channel();
+        let mut entries = Vec::new();
+        for _ in 0..5 {
+            let entry = Entry::new(&mut Hash::default(), 1, vec![]); //just broken entries
+            entries.push(entry);
+        }
+
+        let genesis_block = GenesisBlock::new(10_000).0;
+        let bank = Arc::new(Bank::new(&genesis_block));
+        let mut progress = HashMap::new();
+        let res = ReplayStage::replay_entries_into_bank(
+            &bank,
+            entries.clone(),
+            &mut progress,
+            &forward_entry_sender,
+            0,
+        );
+
+        match res {
+            Ok(_) => assert!(false, "Should have failed because entries are broken"),
+            Err(Error::BlobError(BlobError::VerificationFailed)) => (),
+            Err(e) => assert!(
+                false,
+                "Should have failed because with blob error, instead, got {:?}",
+                e
+            ),
+        }
+        assert!(forward_entry_receiver.try_recv().is_err());
+    }
 }

--- a/src/replay_stage.rs
+++ b/src/replay_stage.rs
@@ -382,7 +382,7 @@ mod test {
             replay_stage
                 .close()
                 .expect("Expect successful ReplayStage exit");
-            poh_service.close();
+            poh_service.close().unwrap();
         }
         let _ignored = remove_dir_all(&my_ledger_path);
     }

--- a/src/replay_stage.rs
+++ b/src/replay_stage.rs
@@ -158,7 +158,7 @@ impl ReplayStage {
                             if let Some(tpu_bank) =
                                 bank_forks.read().unwrap().get(next_slot).cloned()
                             {
-                                banking_stage_sender.send(tpu_bank);
+                                banking_stage_sender.send(tpu_bank)?;
                             }
                         }
                     }

--- a/src/replay_stage.rs
+++ b/src/replay_stage.rs
@@ -176,14 +176,7 @@ impl ReplayStage {
                                     tpu_bank.slot(),
                                     next_leader
                                 );
-                			let max_tick_height = (tpu_bank.slot() + 1) * tpu_bank.ticks_per_slot() - 1;
-                			let working_bank = WorkingBank {
-                			    bank: tpu_bank.clone(),
-                			    min_tick_height: tpu_bank.tick_height(),
-                			    max_tick_height,
-                			};
-                			poh_recorder.lock().unwrap().set_working_bank(working_bank);
-
+                				poh_recorder.lock().unwrap().set_bank(&tpu_bank);
                             }
                         }
                     }

--- a/src/replay_stage.rs
+++ b/src/replay_stage.rs
@@ -332,7 +332,7 @@ mod test {
         // Set up the replay stage
         let exit = Arc::new(AtomicBool::new(false));
         let voting_keypair = Arc::new(Keypair::new());
-        let (to_leader_sender, _to_leader_receiver) = channel();
+        let (bank_sender, _bank_receiver) = channel();
         {
             let (bank_forks, bank_forks_info, blocktree, l_receiver) =
                 new_banks_from_blocktree(&my_ledger_path, None);
@@ -347,7 +347,7 @@ mod test {
                 &bank_forks_info,
                 cluster_info_me.clone(),
                 exit.clone(),
-                &to_leader_sender,
+                bank_sender,
                 l_receiver,
                 &Arc::new(RpcSubscriptions::default()),
             );

--- a/src/replay_stage.rs
+++ b/src/replay_stage.rs
@@ -11,7 +11,6 @@ use crate::packet::BlobError;
 use crate::result;
 use crate::rpc_subscriptions::RpcSubscriptions;
 use crate::service::Service;
-use crate::tvu::{TvuRotationInfo, TvuRotationSender};
 use solana_metrics::counter::Counter;
 use solana_runtime::bank::Bank;
 use solana_sdk::hash::Hash;

--- a/src/replay_stage.rs
+++ b/src/replay_stage.rs
@@ -143,7 +143,7 @@ impl ReplayStage {
                             );
                             cluster_info.write().unwrap().push_vote(vote);
                             poh_recorder
-                                .read()
+                                .lock()
                                 .unwrap()
                                 .reset(parent.tick_height(), parent.last_id());
                         }
@@ -155,8 +155,11 @@ impl ReplayStage {
                                 "banking_stage_sender: me: {} next_slot: {} next_leader: {}",
                                 my_id, next_slot, next_leader
                             );
-
-                            banking_stage_sender.send(tpu_bank);
+                            if let Some(tpu_bank) =
+                                bank_forks.read().unwrap().get(next_slot).cloned()
+                            {
+                                banking_stage_sender.send(tpu_bank);
+                            }
                         }
                     }
                     inc_new_counter_info!(
@@ -300,143 +303,143 @@ impl Service for ReplayStage {
     }
 }
 
-#[cfg(test)]
-mod test {
-    use super::*;
-    use crate::blocktree::create_new_tmp_ledger;
-    use crate::cluster_info::{ClusterInfo, Node};
-    use crate::entry::create_ticks;
-    use crate::entry::{next_entry_mut, Entry};
-    use crate::fullnode::new_banks_from_blocktree;
-    use crate::replay_stage::ReplayStage;
-    use crate::result::Error;
-    use solana_sdk::genesis_block::GenesisBlock;
-    use solana_sdk::hash::Hash;
-    use solana_sdk::signature::{Keypair, KeypairUtil};
-    use std::fs::remove_dir_all;
-    use std::sync::atomic::AtomicBool;
-    use std::sync::mpsc::channel;
-    use std::sync::{Arc, RwLock};
-
-    #[test]
-    fn test_vote_error_replay_stage_correctness() {
-        solana_logger::setup();
-        // Set up dummy node to host a ReplayStage
-        let my_keypair = Keypair::new();
-        let my_id = my_keypair.pubkey();
-        let my_node = Node::new_localhost_with_pubkey(my_id);
-
-        // Create keypair for the leader
-        let leader_id = Keypair::new().pubkey();
-
-        let (genesis_block, _mint_keypair) = GenesisBlock::new_with_leader(10_000, leader_id, 500);
-
-        let (my_ledger_path, _last_id) = create_new_tmp_ledger!(&genesis_block);
-
-        // Set up the cluster info
-        let cluster_info_me = Arc::new(RwLock::new(ClusterInfo::new(my_node.info.clone())));
-
-        // Set up the replay stage
-        let exit = Arc::new(AtomicBool::new(false));
-        let voting_keypair = Arc::new(Keypair::new());
-        let (bank_sender, _bank_receiver) = channel();
-        {
-            let (bank_forks, bank_forks_info, blocktree, l_receiver) =
-                new_banks_from_blocktree(&my_ledger_path, None);
-            let bank = bank_forks.working_bank();
-
-            let blocktree = Arc::new(blocktree);
-            let (replay_stage, _slot_full_receiver, ledger_writer_recv) = ReplayStage::new(
-                my_keypair.pubkey(),
-                Some(voting_keypair.clone()),
-                blocktree.clone(),
-                &Arc::new(RwLock::new(bank_forks)),
-                &bank_forks_info,
-                cluster_info_me.clone(),
-                exit.clone(),
-                bank_sender,
-                l_receiver,
-                &Arc::new(RpcSubscriptions::default()),
-            );
-
-            let keypair = voting_keypair.as_ref();
-            let vote = VoteTransaction::new_vote(keypair, 0, bank.last_id(), 0);
-            cluster_info_me.write().unwrap().push_vote(vote);
-
-            info!("Send ReplayStage an entry, should see it on the ledger writer receiver");
-            let next_tick = create_ticks(1, bank.last_id());
-            blocktree.write_entries(1, 0, 0, next_tick.clone()).unwrap();
-
-            let received_tick = ledger_writer_recv
-                .recv()
-                .expect("Expected to receive an entry on the ledger writer receiver");
-
-            assert_eq!(next_tick[0], received_tick[0]);
-
-            replay_stage
-                .close()
-                .expect("Expect successful ReplayStage exit");
-        }
-        let _ignored = remove_dir_all(&my_ledger_path);
-    }
-
-    #[test]
-    fn test_replay_stage_poh_ok_entry_receiver() {
-        let (forward_entry_sender, forward_entry_receiver) = channel();
-        let genesis_block = GenesisBlock::new(10_000).0;
-        let bank = Arc::new(Bank::new(&genesis_block));
-        let mut last_id = bank.last_id();
-        let mut entries = Vec::new();
-        for _ in 0..5 {
-            let entry = next_entry_mut(&mut last_id, 1, vec![]); //just ticks
-            entries.push(entry);
-        }
-
-        let mut progress = HashMap::new();
-        let res = ReplayStage::replay_entries_into_bank(
-            &bank,
-            entries.clone(),
-            &mut progress,
-            &forward_entry_sender,
-            0,
-        );
-        assert!(res.is_ok(), "replay failed {:?}", res);
-        let res = forward_entry_receiver.try_recv();
-        match res {
-            Ok(_) => (),
-            Err(e) => assert!(false, "Entries were not sent correctly {:?}", e),
-        }
-    }
-
-    #[test]
-    fn test_replay_stage_poh_error_entry_receiver() {
-        let (forward_entry_sender, forward_entry_receiver) = channel();
-        let mut entries = Vec::new();
-        for _ in 0..5 {
-            let entry = Entry::new(&mut Hash::default(), 1, vec![]); //just broken entries
-            entries.push(entry);
-        }
-
-        let genesis_block = GenesisBlock::new(10_000).0;
-        let bank = Arc::new(Bank::new(&genesis_block));
-        let mut progress = HashMap::new();
-        let res = ReplayStage::replay_entries_into_bank(
-            &bank,
-            entries.clone(),
-            &mut progress,
-            &forward_entry_sender,
-            0,
-        );
-
-        match res {
-            Ok(_) => assert!(false, "Should have failed because entries are broken"),
-            Err(Error::BlobError(BlobError::VerificationFailed)) => (),
-            Err(e) => assert!(
-                false,
-                "Should have failed because with blob error, instead, got {:?}",
-                e
-            ),
-        }
-        assert!(forward_entry_receiver.try_recv().is_err());
-    }
-}
+// #[cfg(test)]
+// mod test {
+//     use super::*;
+//     use crate::blocktree::create_new_tmp_ledger;
+//     use crate::cluster_info::{ClusterInfo, Node};
+//     use crate::entry::create_ticks;
+//     use crate::entry::{next_entry_mut, Entry};
+//     use crate::fullnode::new_banks_from_blocktree;
+//     use crate::replay_stage::ReplayStage;
+//     use crate::result::Error;
+//     use solana_sdk::genesis_block::GenesisBlock;
+//     use solana_sdk::hash::Hash;
+//     use solana_sdk::signature::{Keypair, KeypairUtil};
+//     use std::fs::remove_dir_all;
+//     use std::sync::atomic::AtomicBool;
+//     use std::sync::mpsc::channel;
+//     use std::sync::{Arc, RwLock};
+//
+//     #[test]
+//     fn test_vote_error_replay_stage_correctness() {
+//         solana_logger::setup();
+//         // Set up dummy node to host a ReplayStage
+//         let my_keypair = Keypair::new();
+//         let my_id = my_keypair.pubkey();
+//         let my_node = Node::new_localhost_with_pubkey(my_id);
+//
+//         // Create keypair for the leader
+//         let leader_id = Keypair::new().pubkey();
+//
+//         let (genesis_block, _mint_keypair) = GenesisBlock::new_with_leader(10_000, leader_id, 500);
+//
+//         let (my_ledger_path, _last_id) = create_new_tmp_ledger!(&genesis_block);
+//
+//         // Set up the cluster info
+//         let cluster_info_me = Arc::new(RwLock::new(ClusterInfo::new(my_node.info.clone())));
+//
+//         // Set up the replay stage
+//         let exit = Arc::new(AtomicBool::new(false));
+//         let voting_keypair = Arc::new(Keypair::new());
+//         let (bank_sender, _bank_receiver) = channel();
+//         {
+//             let (bank_forks, bank_forks_info, blocktree, l_receiver) =
+//                 new_banks_from_blocktree(&my_ledger_path, None);
+//             let bank = bank_forks.working_bank();
+//
+//             let blocktree = Arc::new(blocktree);
+//             let (replay_stage, _slot_full_receiver, ledger_writer_recv) = ReplayStage::new(
+//                 my_keypair.pubkey(),
+//                 Some(voting_keypair.clone()),
+//                 blocktree.clone(),
+//                 &Arc::new(RwLock::new(bank_forks)),
+//                 &bank_forks_info,
+//                 cluster_info_me.clone(),
+//                 exit.clone(),
+//                 bank_sender,
+//                 l_receiver,
+//                 &Arc::new(RpcSubscriptions::default()),
+//             );
+//
+//             let keypair = voting_keypair.as_ref();
+//             let vote = VoteTransaction::new_vote(keypair, 0, bank.last_id(), 0);
+//             cluster_info_me.write().unwrap().push_vote(vote);
+//
+//             info!("Send ReplayStage an entry, should see it on the ledger writer receiver");
+//             let next_tick = create_ticks(1, bank.last_id());
+//             blocktree.write_entries(1, 0, 0, next_tick.clone()).unwrap();
+//
+//             let received_tick = ledger_writer_recv
+//                 .recv()
+//                 .expect("Expected to receive an entry on the ledger writer receiver");
+//
+//             assert_eq!(next_tick[0], received_tick[0]);
+//
+//             replay_stage
+//                 .close()
+//                 .expect("Expect successful ReplayStage exit");
+//         }
+//         let _ignored = remove_dir_all(&my_ledger_path);
+//     }
+//
+//     #[test]
+//     fn test_replay_stage_poh_ok_entry_receiver() {
+//         let (forward_entry_sender, forward_entry_receiver) = channel();
+//         let genesis_block = GenesisBlock::new(10_000).0;
+//         let bank = Arc::new(Bank::new(&genesis_block));
+//         let mut last_id = bank.last_id();
+//         let mut entries = Vec::new();
+//         for _ in 0..5 {
+//             let entry = next_entry_mut(&mut last_id, 1, vec![]); //just ticks
+//             entries.push(entry);
+//         }
+//
+//         let mut progress = HashMap::new();
+//         let res = ReplayStage::replay_entries_into_bank(
+//             &bank,
+//             entries.clone(),
+//             &mut progress,
+//             &forward_entry_sender,
+//             0,
+//         );
+//         assert!(res.is_ok(), "replay failed {:?}", res);
+//         let res = forward_entry_receiver.try_recv();
+//         match res {
+//             Ok(_) => (),
+//             Err(e) => assert!(false, "Entries were not sent correctly {:?}", e),
+//         }
+//     }
+//
+//     #[test]
+//     fn test_replay_stage_poh_error_entry_receiver() {
+//         let (forward_entry_sender, forward_entry_receiver) = channel();
+//         let mut entries = Vec::new();
+//         for _ in 0..5 {
+//             let entry = Entry::new(&mut Hash::default(), 1, vec![]); //just broken entries
+//             entries.push(entry);
+//         }
+//
+//         let genesis_block = GenesisBlock::new(10_000).0;
+//         let bank = Arc::new(Bank::new(&genesis_block));
+//         let mut progress = HashMap::new();
+//         let res = ReplayStage::replay_entries_into_bank(
+//             &bank,
+//             entries.clone(),
+//             &mut progress,
+//             &forward_entry_sender,
+//             0,
+//         );
+//
+//         match res {
+//             Ok(_) => assert!(false, "Should have failed because entries are broken"),
+//             Err(Error::BlobError(BlobError::VerificationFailed)) => (),
+//             Err(e) => assert!(
+//                 false,
+//                 "Should have failed because with blob error, instead, got {:?}",
+//                 e
+//             ),
+//         }
+//         assert!(forward_entry_receiver.try_recv().is_err());
+//     }
+// }

--- a/src/thin_client.rs
+++ b/src/thin_client.rs
@@ -522,7 +522,7 @@ mod tests {
 
         let transaction_count = client.transaction_count();
         assert_eq!(transaction_count, 1);
-        server.close();
+        server.close().unwrap();
         remove_dir_all(ledger_path).unwrap();
     }
 
@@ -558,7 +558,7 @@ mod tests {
 
         let balance = client.get_balance(&bob_pubkey);
         assert_eq!(balance.unwrap(), 1001);
-        server.close();
+        server.close().unwrap();
         remove_dir_all(ledger_path).unwrap();
     }
 
@@ -621,7 +621,7 @@ mod tests {
             sleep(Duration::from_millis(900));
         }
 
-        server.close();
+        server.close().unwrap();
         remove_dir_all(ledger_path).unwrap();
     }
 
@@ -676,7 +676,7 @@ mod tests {
         info!("Bob's balance is {:?}", bob_balance);
         assert!(bob_balance.is_err(),);
 
-        server.close();
+        server.close().unwrap();
         remove_dir_all(ledger_path).unwrap();
     }
 }

--- a/src/thin_client.rs
+++ b/src/thin_client.rs
@@ -498,7 +498,6 @@ mod tests {
     fn test_thin_client_basic() {
         solana_logger::setup();
         let (server, leader_data, alice, ledger_path) = new_fullnode();
-        let server_exit = server.run(None);
         let bob_pubkey = Keypair::new().pubkey();
 
         info!(
@@ -523,7 +522,7 @@ mod tests {
 
         let transaction_count = client.transaction_count();
         assert_eq!(transaction_count, 1);
-        server_exit();
+        server.close();
         remove_dir_all(ledger_path).unwrap();
     }
 
@@ -532,7 +531,6 @@ mod tests {
     fn test_bad_sig() {
         solana_logger::setup();
         let (server, leader_data, alice, ledger_path) = new_fullnode();
-        let server_exit = server.run(None);
         let bob_pubkey = Keypair::new().pubkey();
         info!(
             "found leader: {:?}",
@@ -560,7 +558,7 @@ mod tests {
 
         let balance = client.get_balance(&bob_pubkey);
         assert_eq!(balance.unwrap(), 1001);
-        server_exit();
+        server.close();
         remove_dir_all(ledger_path).unwrap();
     }
 
@@ -568,7 +566,6 @@ mod tests {
     fn test_register_vote_account() {
         solana_logger::setup();
         let (server, leader_data, alice, ledger_path) = new_fullnode();
-        let server_exit = server.run(None);
         info!(
             "found leader: {:?}",
             poll_gossip_for_leader(leader_data.gossip, Some(5)).unwrap()
@@ -624,7 +621,7 @@ mod tests {
             sleep(Duration::from_millis(900));
         }
 
-        server_exit();
+        server.close();
         remove_dir_all(ledger_path).unwrap();
     }
 
@@ -643,7 +640,6 @@ mod tests {
     fn test_zero_balance_after_nonzero() {
         solana_logger::setup();
         let (server, leader_data, alice, ledger_path) = new_fullnode();
-        let server_exit = server.run(None);
         let bob_keypair = Keypair::new();
 
         info!(
@@ -680,7 +676,7 @@ mod tests {
         info!("Bob's balance is {:?}", bob_balance);
         assert!(bob_balance.is_err(),);
 
-        server_exit();
+        server.close();
         remove_dir_all(ledger_path).unwrap();
     }
 }

--- a/src/tpu.rs
+++ b/src/tpu.rs
@@ -10,7 +10,6 @@ use crate::fetch_stage::FetchStage;
 use crate::poh_recorder::{PohRecorder, WorkingBankEntries};
 use crate::service::Service;
 use crate::sigverify_stage::SigVerifyStage;
-use solana_runtime::bank::Bank;
 use solana_sdk::pubkey::Pubkey;
 use std::net::UdpSocket;
 use std::sync::atomic::{AtomicBool, Ordering};

--- a/src/tpu.rs
+++ b/src/tpu.rs
@@ -134,7 +134,7 @@ impl Tpu {
         self.exit.load(Ordering::Relaxed)
     }
 
-    pub fn close(mut self) -> thread::Result<()> {
+    pub fn close(self) -> thread::Result<()> {
         self.exit();
         self.join()
     }

--- a/src/tpu.rs
+++ b/src/tpu.rs
@@ -43,7 +43,7 @@ impl LeaderServices {
         }
     }
 
-    fn exit(&self) {
+    pub fn exit(&self) {
         self.fetch_stage.close();
     }
 
@@ -61,7 +61,7 @@ impl LeaderServices {
         Ok(())
     }
 
-    fn close(self) -> thread::Result<()> {
+    pub fn close(self) -> thread::Result<()> {
         self.exit();
         self.join()
     }
@@ -70,7 +70,7 @@ impl LeaderServices {
 pub struct Tpu {
     leader_services: LeaderServices,
     exit: Arc<AtomicBool>,
-    id: Pubkey,
+    pub id: Pubkey,
 }
 
 impl Tpu {

--- a/src/tpu.rs
+++ b/src/tpu.rs
@@ -77,13 +77,13 @@ impl Tpu {
     pub fn new(
         id: Pubkey,
         cluster_info: &Arc<RwLock<ClusterInfo>>,
-        bank_receiver: &Receiver<Bank>,
+        bank_receiver: Receiver<Arc<Bank>>,
         poh_recorder: &Arc<Mutex<PohRecorder>>,
         transactions_sockets: Vec<UdpSocket>,
         broadcast_socket: UdpSocket,
         sigverify_disabled: bool,
         blocktree: &Arc<Blocktree>,
-    ) {
+    ) -> Self {
         cluster_info.write().unwrap().set_leader(id);
 
         let exit = Arc::new(AtomicBool::new(false));

--- a/src/tpu.rs
+++ b/src/tpu.rs
@@ -96,8 +96,13 @@ impl Tpu {
         let (sigverify_stage, verified_receiver) =
             SigVerifyStage::new(packet_receiver, sigverify_disabled);
 
-        let (banking_stage, entry_receiver) =
-            BankingStage::new(bank_receiver, poh_recorder, verified_receiver, id);
+        let (banking_stage, entry_receiver) = BankingStage::new(
+            &cluster_info,
+            bank_receiver,
+            poh_recorder,
+            verified_receiver,
+            id,
+        );
 
         let broadcast_stage = BroadcastStage::new(
             broadcast_socket,

--- a/src/tpu.rs
+++ b/src/tpu.rs
@@ -101,7 +101,6 @@ impl Tpu {
             bank_receiver,
             poh_recorder,
             verified_receiver,
-            id,
         );
 
         let broadcast_stage = BroadcastStage::new(

--- a/src/tpu.rs
+++ b/src/tpu.rs
@@ -1,7 +1,7 @@
 //! The `tpu` module implements the Transaction Processing Unit, a
 //! multi-stage transaction processing pipeline in software.
 
-use crate::banking_stage::{BankingStage, UnprocessedPackets};
+use crate::banking_stage::BankingStage;
 use crate::blocktree::Blocktree;
 use crate::broadcast_stage::BroadcastStage;
 use crate::cluster_info::ClusterInfo;
@@ -10,7 +10,6 @@ use crate::fetch_stage::FetchStage;
 use crate::poh_recorder::PohRecorder;
 use crate::service::Service;
 use crate::sigverify_stage::SigVerifyStage;
-use crate::tpu_forwarder::TpuForwarder;
 use solana_runtime::bank::Bank;
 use solana_sdk::pubkey::Pubkey;
 use std::net::UdpSocket;

--- a/src/tpu.rs
+++ b/src/tpu.rs
@@ -15,14 +15,9 @@ use solana_runtime::bank::Bank;
 use solana_sdk::pubkey::Pubkey;
 use std::net::UdpSocket;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::mpsc::channel;
+use std::sync::mpsc::{channel, Receiver};
 use std::sync::{Arc, Mutex, RwLock};
 use std::thread;
-
-pub enum TpuMode {
-    Leader(LeaderServices),
-    Forwarder(ForwarderServices),
-}
 
 pub struct LeaderServices {
     fetch_stage: FetchStage,
@@ -73,186 +68,58 @@ impl LeaderServices {
     }
 }
 
-pub struct ForwarderServices {
-    tpu_forwarder: TpuForwarder,
-}
-
-impl ForwarderServices {
-    fn new(tpu_forwarder: TpuForwarder) -> Self {
-        ForwarderServices { tpu_forwarder }
-    }
-
-    fn exit(&self) {
-        self.tpu_forwarder.close();
-    }
-
-    fn join(self) -> thread::Result<()> {
-        self.tpu_forwarder.join()
-    }
-
-    fn close(self) -> thread::Result<()> {
-        self.exit();
-        self.join()
-    }
-}
-
 pub struct Tpu {
-    tpu_mode: Option<TpuMode>,
+    leader_services: LeaderServices,
     exit: Arc<AtomicBool>,
     id: Pubkey,
-    cluster_info: Arc<RwLock<ClusterInfo>>,
 }
 
 impl Tpu {
-    pub fn new(id: Pubkey, cluster_info: &Arc<RwLock<ClusterInfo>>) -> Self {
-        Self {
-            tpu_mode: None,
-            exit: Arc::new(AtomicBool::new(false)),
-            id,
-            cluster_info: cluster_info.clone(),
-        }
-    }
-
-    fn mode_exit(&mut self) {
-        match &mut self.tpu_mode {
-            Some(TpuMode::Leader(svcs)) => {
-                svcs.exit();
-            }
-            Some(TpuMode::Forwarder(svcs)) => {
-                svcs.exit();
-            }
-            None => (),
-        }
-    }
-
-    fn mode_close(&mut self) {
-        let tpu_mode = self.tpu_mode.take();
-        if let Some(tpu_mode) = tpu_mode {
-            match tpu_mode {
-                TpuMode::Leader(svcs) => {
-                    let _ = svcs.close();
-                }
-                TpuMode::Forwarder(svcs) => {
-                    let _ = svcs.close();
-                }
-            }
-        }
-    }
-
-    fn forward_unprocessed_packets(
-        tpu: &std::net::SocketAddr,
-        unprocessed_packets: UnprocessedPackets,
-    ) -> std::io::Result<()> {
-        let socket = UdpSocket::bind("0.0.0.0:0")?;
-        for (packets, start_index) in unprocessed_packets {
-            let packets = packets.read().unwrap();
-            for packet in packets.packets.iter().skip(start_index) {
-                socket.send_to(&packet.data[..packet.meta.size], tpu)?;
-            }
-        }
-        Ok(())
-    }
-
-    fn close_and_forward_unprocessed_packets(&mut self) {
-        self.mode_exit();
-
-        let unprocessed_packets = match self.tpu_mode.as_mut() {
-            Some(TpuMode::Leader(svcs)) => {
-                svcs.banking_stage.join_and_collect_unprocessed_packets()
-            }
-            Some(TpuMode::Forwarder(svcs)) => {
-                svcs.tpu_forwarder.join_and_collect_unprocessed_packets()
-            }
-            None => vec![],
-        };
-
-        if !unprocessed_packets.is_empty() {
-            let tpu = self.cluster_info.read().unwrap().leader_data().unwrap().tpu;
-            info!("forwarding unprocessed packets to new leader at {:?}", tpu);
-            Tpu::forward_unprocessed_packets(&tpu, unprocessed_packets).unwrap_or_else(|err| {
-                warn!("Failed to forward unprocessed transactions: {:?}", err)
-            });
-        }
-
-        self.mode_close();
-    }
-
-    pub fn switch_to_forwarder(&mut self, leader_id: Pubkey, transactions_sockets: Vec<UdpSocket>) {
-        self.close_and_forward_unprocessed_packets();
-
-        self.cluster_info.write().unwrap().set_leader(leader_id);
-
-        let tpu_forwarder = TpuForwarder::new(transactions_sockets, self.cluster_info.clone());
-        self.tpu_mode = Some(TpuMode::Forwarder(ForwarderServices::new(tpu_forwarder)));
-    }
-
-    #[allow(clippy::too_many_arguments)]
-    pub fn switch_to_leader(
-        &mut self,
-        bank: &Arc<Bank>,
+    pub fn new(
+        id: Pubkey,
+        cluster_info: &Arc<RwLock<ClusterInfo>>,
+        bank_receiver: &Receiver<Bank>,
         poh_recorder: &Arc<Mutex<PohRecorder>>,
         transactions_sockets: Vec<UdpSocket>,
         broadcast_socket: UdpSocket,
         sigverify_disabled: bool,
-        slot: u64,
         blocktree: &Arc<Blocktree>,
     ) {
-        self.close_and_forward_unprocessed_packets();
+        cluster_info.write().unwrap().set_leader(id);
 
-        self.cluster_info.write().unwrap().set_leader(self.id);
-
-        self.exit = Arc::new(AtomicBool::new(false));
+        let exit = Arc::new(AtomicBool::new(false));
         let (packet_sender, packet_receiver) = channel();
-        let fetch_stage = FetchStage::new_with_sender(
-            transactions_sockets,
-            self.exit.clone(),
-            &packet_sender.clone(),
-        );
-        let cluster_info_vote_listener = ClusterInfoVoteListener::new(
-            self.exit.clone(),
-            self.cluster_info.clone(),
-            packet_sender,
-        );
+        let fetch_stage =
+            FetchStage::new_with_sender(transactions_sockets, exit.clone(), &packet_sender.clone());
+        let cluster_info_vote_listener =
+            ClusterInfoVoteListener::new(exit.clone(), cluster_info.clone(), packet_sender);
 
         let (sigverify_stage, verified_receiver) =
             SigVerifyStage::new(packet_receiver, sigverify_disabled);
 
-        // TODO: Fix BankingStage/BroadcastStage to operate on `slot` directly instead of
-        // `max_tick_height`
-        let max_tick_height = (slot + 1) * bank.ticks_per_slot() - 1;
-        let blob_index = blocktree
-            .meta(slot)
-            .expect("Database error")
-            .map(|meta| meta.consumed)
-            .unwrap_or(0);
-
-        let (banking_stage, entry_receiver) = BankingStage::new(
-            &bank,
-            poh_recorder,
-            verified_receiver,
-            max_tick_height,
-            self.id,
-        );
+        let (banking_stage, entry_receiver) =
+            BankingStage::new(bank_receiver, poh_recorder, verified_receiver, id);
 
         let broadcast_stage = BroadcastStage::new(
-            slot,
-            bank,
             broadcast_socket,
-            self.cluster_info.clone(),
-            blob_index,
+            cluster_info.clone(),
             entry_receiver,
-            self.exit.clone(),
+            exit.clone(),
             blocktree,
         );
 
-        let svcs = LeaderServices::new(
+        let leader_services = LeaderServices::new(
             fetch_stage,
             sigverify_stage,
             banking_stage,
             cluster_info_vote_listener,
             broadcast_stage,
         );
-        self.tpu_mode = Some(TpuMode::Leader(svcs));
+        Self {
+            leader_services,
+            exit,
+            id,
+        }
     }
 
     pub fn exit(&self) {
@@ -264,7 +131,7 @@ impl Tpu {
     }
 
     pub fn close(mut self) -> thread::Result<()> {
-        self.mode_close();
+        self.exit();
         self.join()
     }
 }
@@ -273,11 +140,6 @@ impl Service for Tpu {
     type JoinReturnType = ();
 
     fn join(self) -> thread::Result<()> {
-        match self.tpu_mode {
-            Some(TpuMode::Leader(svcs)) => svcs.join()?,
-            Some(TpuMode::Forwarder(svcs)) => svcs.join()?,
-            None => (),
-        }
-        Ok(())
+        self.leader_services.join()
     }
 }

--- a/src/tvu.rs
+++ b/src/tvu.rs
@@ -32,15 +32,6 @@ use std::sync::mpsc::{channel, Receiver, Sender};
 use std::sync::{Arc, RwLock};
 use std::thread;
 
-pub struct TvuRotationInfo {
-    pub tick_height: u64,  // tick height, bank might not exist yet
-    pub last_id: Hash,     // last_id that was voted on
-    pub slot: u64,         // slot height to initiate a rotation
-    pub leader_id: Pubkey, // leader upon rotation
-}
-pub type TvuRotationSender = Sender<TvuRotationInfo>;
-pub type TvuRotationReceiver = Receiver<TvuRotationInfo>;
-
 pub struct Tvu {
     fetch_stage: BlobFetchStage,
     retransmit_stage: RetransmitStage,

--- a/src/tvu.rs
+++ b/src/tvu.rs
@@ -64,7 +64,6 @@ impl Tvu {
         blocktree: Arc<Blocktree>,
         storage_rotate_count: u64,
         storage_state: &StorageState,
-        bank_sender: Sender<Arc<Bank>>,
         blockstream: Option<&String>,
         ledger_signal_receiver: Receiver<bool>,
         subscriptions: &Arc<RpcSubscriptions>,
@@ -116,7 +115,6 @@ impl Tvu {
             &bank_forks_info,
             cluster_info.clone(),
             exit.clone(),
-            bank_sender,
             ledger_signal_receiver,
             subscriptions,
             poh_recorder,
@@ -187,66 +185,65 @@ impl Service for Tvu {
     }
 }
 
-#[cfg(test)]
-pub mod tests {
-    use super::*;
-    use crate::banking_stage::create_test_recorder;
-    use crate::blocktree::get_tmp_ledger_path;
-    use crate::cluster_info::{ClusterInfo, Node};
-    use crate::storage_stage::STORAGE_ROTATE_TEST_COUNT;
-    use solana_runtime::bank::Bank;
-    use solana_sdk::genesis_block::GenesisBlock;
-
-    #[test]
-    fn test_tvu_exit() {
-        solana_logger::setup();
-        let leader = Node::new_localhost();
-        let target1_keypair = Keypair::new();
-        let target1 = Node::new_localhost_with_pubkey(target1_keypair.pubkey());
-
-        let starting_balance = 10_000;
-        let (genesis_block, _mint_keypair) = GenesisBlock::new(starting_balance);
-
-        let bank_forks = BankForks::new(0, Bank::new(&genesis_block));
-        let bank_forks_info = vec![BankForksInfo {
-            bank_id: 0,
-            entry_height: 0,
-        }];
-
-        //start cluster_info1
-        let mut cluster_info1 = ClusterInfo::new(target1.info.clone());
-        cluster_info1.insert_info(leader.info.clone());
-        cluster_info1.set_leader(leader.info.id);
-        let cref1 = Arc::new(RwLock::new(cluster_info1));
-
-        let blocktree_path = get_tmp_ledger_path!();
-        let (blocktree, l_receiver) = Blocktree::open_with_signal(&blocktree_path)
-            .expect("Expected to successfully open ledger");
-        let (bank_sender, _bank_receiver) = channel();
-        let bank = bank_forks.working_bank();
-        let (poh_recorder, poh_service) = create_test_recorder(&bank);
-        let tvu = Tvu::new(
-            Some(Arc::new(Keypair::new())),
-            &Arc::new(RwLock::new(bank_forks)),
-            &bank_forks_info,
-            &cref1,
-            {
-                Sockets {
-                    repair: target1.sockets.repair,
-                    retransmit: target1.sockets.retransmit,
-                    fetch: target1.sockets.tvu,
-                }
-            },
-            Arc::new(blocktree),
-            STORAGE_ROTATE_TEST_COUNT,
-            &StorageState::default(),
-            bank_sender,
-            None,
-            l_receiver,
-            &Arc::new(RpcSubscriptions::default()),
-            &poh_recorder,
-        );
-        tvu.close().expect("close");
-        poh_service.close().expect("close");
-    }
-}
+// #[cfg(test)]
+// pub mod tests {
+//     use super::*;
+//     use crate::banking_stage::create_test_recorder;
+//     use crate::blocktree::get_tmp_ledger_path;
+//     use crate::cluster_info::{ClusterInfo, Node};
+//     use crate::storage_stage::STORAGE_ROTATE_TEST_COUNT;
+//     use solana_runtime::bank::Bank;
+//     use solana_sdk::genesis_block::GenesisBlock;
+//
+//     #[test]
+//     fn test_tvu_exit() {
+//         solana_logger::setup();
+//         let leader = Node::new_localhost();
+//         let target1_keypair = Keypair::new();
+//         let target1 = Node::new_localhost_with_pubkey(target1_keypair.pubkey());
+//
+//         let starting_balance = 10_000;
+//         let (genesis_block, _mint_keypair) = GenesisBlock::new(starting_balance);
+//
+//         let bank_forks = BankForks::new(0, Bank::new(&genesis_block));
+//         let bank_forks_info = vec![BankForksInfo {
+//             bank_id: 0,
+//             entry_height: 0,
+//         }];
+//
+//         //start cluster_info1
+//         let mut cluster_info1 = ClusterInfo::new(target1.info.clone());
+//         cluster_info1.insert_info(leader.info.clone());
+//         cluster_info1.set_leader(leader.info.id);
+//         let cref1 = Arc::new(RwLock::new(cluster_info1));
+//
+//         let blocktree_path = get_tmp_ledger_path!();
+//         let (blocktree, l_receiver) = Blocktree::open_with_signal(&blocktree_path)
+//             .expect("Expected to successfully open ledger");
+//         let bank = bank_forks.working_bank();
+//         let (poh_recorder, poh_service, entry_receiver) = create_test_recorder(&bank);
+//         let tvu = Tvu::new(
+//             Some(Arc::new(Keypair::new())),
+//             &Arc::new(RwLock::new(bank_forks)),
+//             &bank_forks_info,
+//             &cref1,
+//             {
+//                 Sockets {
+//                     repair: target1.sockets.repair,
+//                     retransmit: target1.sockets.retransmit,
+//                     fetch: target1.sockets.tvu,
+//                 }
+//             },
+//             Arc::new(blocktree),
+//             STORAGE_ROTATE_TEST_COUNT,
+//             &StorageState::default(),
+//             bank_sender,
+//             None,
+//             l_receiver,
+//             &Arc::new(RpcSubscriptions::default()),
+//             &poh_recorder,
+//         );
+//         tvu.close().expect("close");
+//         poh_service.close().expect("close");
+//     }
+// }

--- a/src/tvu.rs
+++ b/src/tvu.rs
@@ -187,61 +187,61 @@ impl Service for Tvu {
     }
 }
 
-#[cfg(test)]
-pub mod tests {
-    use super::*;
-    use crate::blocktree::get_tmp_ledger_path;
-    use crate::cluster_info::{ClusterInfo, Node};
-    use crate::storage_stage::STORAGE_ROTATE_TEST_COUNT;
-    use solana_runtime::bank::Bank;
-    use solana_sdk::genesis_block::GenesisBlock;
-
-    #[test]
-    fn test_tvu_exit() {
-        solana_logger::setup();
-        let leader = Node::new_localhost();
-        let target1_keypair = Keypair::new();
-        let target1 = Node::new_localhost_with_pubkey(target1_keypair.pubkey());
-
-        let starting_balance = 10_000;
-        let (genesis_block, _mint_keypair) = GenesisBlock::new(starting_balance);
-
-        let bank_forks = BankForks::new(0, Bank::new(&genesis_block));
-        let bank_forks_info = vec![BankForksInfo {
-            bank_id: 0,
-            entry_height: 0,
-        }];
-
-        //start cluster_info1
-        let mut cluster_info1 = ClusterInfo::new(target1.info.clone());
-        cluster_info1.insert_info(leader.info.clone());
-        cluster_info1.set_leader(leader.info.id);
-        let cref1 = Arc::new(RwLock::new(cluster_info1));
-
-        let blocktree_path = get_tmp_ledger_path!();
-        let (blocktree, l_receiver) = Blocktree::open_with_signal(&blocktree_path)
-            .expect("Expected to successfully open ledger");
-        let (sender, _receiver) = channel();
-        let tvu = Tvu::new(
-            Some(Arc::new(Keypair::new())),
-            &Arc::new(RwLock::new(bank_forks)),
-            &bank_forks_info,
-            &cref1,
-            {
-                Sockets {
-                    repair: target1.sockets.repair,
-                    retransmit: target1.sockets.retransmit,
-                    fetch: target1.sockets.tvu,
-                }
-            },
-            Arc::new(blocktree),
-            STORAGE_ROTATE_TEST_COUNT,
-            &sender,
-            &StorageState::default(),
-            None,
-            l_receiver,
-            &Arc::new(RpcSubscriptions::default()),
-        );
-        tvu.close().expect("close");
-    }
-}
+// #[cfg(test)]
+// pub mod tests {
+//     use super::*;
+//     use crate::blocktree::get_tmp_ledger_path;
+//     use crate::cluster_info::{ClusterInfo, Node};
+//     use crate::storage_stage::STORAGE_ROTATE_TEST_COUNT;
+//     use solana_runtime::bank::Bank;
+//     use solana_sdk::genesis_block::GenesisBlock;
+//
+//     #[test]
+//     fn test_tvu_exit() {
+//         solana_logger::setup();
+//         let leader = Node::new_localhost();
+//         let target1_keypair = Keypair::new();
+//         let target1 = Node::new_localhost_with_pubkey(target1_keypair.pubkey());
+//
+//         let starting_balance = 10_000;
+//         let (genesis_block, _mint_keypair) = GenesisBlock::new(starting_balance);
+//
+//         let bank_forks = BankForks::new(0, Bank::new(&genesis_block));
+//         let bank_forks_info = vec![BankForksInfo {
+//             bank_id: 0,
+//             entry_height: 0,
+//         }];
+//
+//         //start cluster_info1
+//         let mut cluster_info1 = ClusterInfo::new(target1.info.clone());
+//         cluster_info1.insert_info(leader.info.clone());
+//         cluster_info1.set_leader(leader.info.id);
+//         let cref1 = Arc::new(RwLock::new(cluster_info1));
+//
+//         let blocktree_path = get_tmp_ledger_path!();
+//         let (blocktree, l_receiver) = Blocktree::open_with_signal(&blocktree_path)
+//             .expect("Expected to successfully open ledger");
+//         let (sender, _receiver) = channel();
+//         let tvu = Tvu::new(
+//             Some(Arc::new(Keypair::new())),
+//             &Arc::new(RwLock::new(bank_forks)),
+//             &bank_forks_info,
+//             &cref1,
+//             {
+//                 Sockets {
+//                     repair: target1.sockets.repair,
+//                     retransmit: target1.sockets.retransmit,
+//                     fetch: target1.sockets.tvu,
+//                 }
+//             },
+//             Arc::new(blocktree),
+//             STORAGE_ROTATE_TEST_COUNT,
+//             &sender,
+//             &StorageState::default(),
+//             None,
+//             l_receiver,
+//             &Arc::new(RpcSubscriptions::default()),
+//         );
+//         tvu.close().expect("close");
+//     }
+// }

--- a/src/tvu.rs
+++ b/src/tvu.rs
@@ -23,8 +23,7 @@ use crate::retransmit_stage::RetransmitStage;
 use crate::rpc_subscriptions::RpcSubscriptions;
 use crate::service::Service;
 use crate::storage_stage::{StorageStage, StorageState};
-use solana_sdk::hash::Hash;
-use solana_sdk::pubkey::Pubkey;
+use solana_runtime::bank::Bank;
 use solana_sdk::signature::{Keypair, KeypairUtil};
 use std::net::UdpSocket;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -63,8 +62,8 @@ impl Tvu {
         sockets: Sockets,
         blocktree: Arc<Blocktree>,
         storage_rotate_count: u64,
-        to_leader_sender: &TvuRotationSender,
         storage_state: &StorageState,
+        bank_sender: Sender<Arc<Bank>>,
         blockstream: Option<&String>,
         ledger_signal_receiver: Receiver<bool>,
         subscriptions: &Arc<RpcSubscriptions>,
@@ -115,7 +114,6 @@ impl Tvu {
             &bank_forks_info,
             cluster_info.clone(),
             exit.clone(),
-            to_leader_sender,
             ledger_signal_receiver,
             subscriptions,
         );

--- a/src/tvu.rs
+++ b/src/tvu.rs
@@ -190,9 +190,9 @@ impl Service for Tvu {
 #[cfg(test)]
 pub mod tests {
     use super::*;
+    use crate::banking_stage::create_test_recorder;
     use crate::blocktree::get_tmp_ledger_path;
     use crate::cluster_info::{ClusterInfo, Node};
-    use crate::banking_stage::create_test_recorder;
     use crate::storage_stage::STORAGE_ROTATE_TEST_COUNT;
     use solana_runtime::bank::Bank;
     use solana_sdk::genesis_block::GenesisBlock;
@@ -223,7 +223,7 @@ pub mod tests {
         let (blocktree, l_receiver) = Blocktree::open_with_signal(&blocktree_path)
             .expect("Expected to successfully open ledger");
         let (bank_sender, _bank_receiver) = channel();
-		let bank = bank_forks.working_bank();
+        let bank = bank_forks.working_bank();
         let (poh_recorder, poh_service) = create_test_recorder(&bank);
         let tvu = Tvu::new(
             Some(Arc::new(Keypair::new())),
@@ -244,8 +244,9 @@ pub mod tests {
             None,
             l_receiver,
             &Arc::new(RpcSubscriptions::default()),
-			&poh_recorder,
+            &poh_recorder,
         );
         tvu.close().expect("close");
+        poh_service.close().expect("close");
     }
 }

--- a/src/tvu.rs
+++ b/src/tvu.rs
@@ -18,6 +18,7 @@ use crate::blockstream_service::BlockstreamService;
 use crate::blocktree::Blocktree;
 use crate::blocktree_processor::BankForksInfo;
 use crate::cluster_info::ClusterInfo;
+use crate::poh_recorder::PohRecorder;
 use crate::replay_stage::ReplayStage;
 use crate::retransmit_stage::RetransmitStage;
 use crate::rpc_subscriptions::RpcSubscriptions;
@@ -28,7 +29,7 @@ use solana_sdk::signature::{Keypair, KeypairUtil};
 use std::net::UdpSocket;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::{channel, Receiver, Sender};
-use std::sync::{Arc, RwLock};
+use std::sync::{Arc, Mutex, RwLock};
 use std::thread;
 
 pub struct Tvu {
@@ -67,6 +68,7 @@ impl Tvu {
         blockstream: Option<&String>,
         ledger_signal_receiver: Receiver<bool>,
         subscriptions: &Arc<RpcSubscriptions>,
+        poh_recorder: &Arc<Mutex<PohRecorder>>,
     ) -> Self
     where
         T: 'static + KeypairUtil + Sync + Send,
@@ -114,8 +116,10 @@ impl Tvu {
             &bank_forks_info,
             cluster_info.clone(),
             exit.clone(),
+            bank_sender,
             ledger_signal_receiver,
             subscriptions,
+            poh_recorder,
         );
 
         let blockstream_service = if blockstream.is_some() {

--- a/src/tvu.rs
+++ b/src/tvu.rs
@@ -24,11 +24,10 @@ use crate::retransmit_stage::RetransmitStage;
 use crate::rpc_subscriptions::RpcSubscriptions;
 use crate::service::Service;
 use crate::storage_stage::{StorageStage, StorageState};
-use solana_runtime::bank::Bank;
 use solana_sdk::signature::{Keypair, KeypairUtil};
 use std::net::UdpSocket;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::mpsc::{channel, Receiver, Sender};
+use std::sync::mpsc::{channel, Receiver};
 use std::sync::{Arc, Mutex, RwLock};
 use std::thread;
 
@@ -185,65 +184,64 @@ impl Service for Tvu {
     }
 }
 
-// #[cfg(test)]
-// pub mod tests {
-//     use super::*;
-//     use crate::banking_stage::create_test_recorder;
-//     use crate::blocktree::get_tmp_ledger_path;
-//     use crate::cluster_info::{ClusterInfo, Node};
-//     use crate::storage_stage::STORAGE_ROTATE_TEST_COUNT;
-//     use solana_runtime::bank::Bank;
-//     use solana_sdk::genesis_block::GenesisBlock;
-//
-//     #[test]
-//     fn test_tvu_exit() {
-//         solana_logger::setup();
-//         let leader = Node::new_localhost();
-//         let target1_keypair = Keypair::new();
-//         let target1 = Node::new_localhost_with_pubkey(target1_keypair.pubkey());
-//
-//         let starting_balance = 10_000;
-//         let (genesis_block, _mint_keypair) = GenesisBlock::new(starting_balance);
-//
-//         let bank_forks = BankForks::new(0, Bank::new(&genesis_block));
-//         let bank_forks_info = vec![BankForksInfo {
-//             bank_id: 0,
-//             entry_height: 0,
-//         }];
-//
-//         //start cluster_info1
-//         let mut cluster_info1 = ClusterInfo::new(target1.info.clone());
-//         cluster_info1.insert_info(leader.info.clone());
-//         cluster_info1.set_leader(leader.info.id);
-//         let cref1 = Arc::new(RwLock::new(cluster_info1));
-//
-//         let blocktree_path = get_tmp_ledger_path!();
-//         let (blocktree, l_receiver) = Blocktree::open_with_signal(&blocktree_path)
-//             .expect("Expected to successfully open ledger");
-//         let bank = bank_forks.working_bank();
-//         let (poh_recorder, poh_service, entry_receiver) = create_test_recorder(&bank);
-//         let tvu = Tvu::new(
-//             Some(Arc::new(Keypair::new())),
-//             &Arc::new(RwLock::new(bank_forks)),
-//             &bank_forks_info,
-//             &cref1,
-//             {
-//                 Sockets {
-//                     repair: target1.sockets.repair,
-//                     retransmit: target1.sockets.retransmit,
-//                     fetch: target1.sockets.tvu,
-//                 }
-//             },
-//             Arc::new(blocktree),
-//             STORAGE_ROTATE_TEST_COUNT,
-//             &StorageState::default(),
-//             bank_sender,
-//             None,
-//             l_receiver,
-//             &Arc::new(RpcSubscriptions::default()),
-//             &poh_recorder,
-//         );
-//         tvu.close().expect("close");
-//         poh_service.close().expect("close");
-//     }
-// }
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+    use crate::banking_stage::create_test_recorder;
+    use crate::blocktree::get_tmp_ledger_path;
+    use crate::cluster_info::{ClusterInfo, Node};
+    use crate::storage_stage::STORAGE_ROTATE_TEST_COUNT;
+    use solana_runtime::bank::Bank;
+    use solana_sdk::genesis_block::GenesisBlock;
+
+    #[test]
+    fn test_tvu_exit() {
+        solana_logger::setup();
+        let leader = Node::new_localhost();
+        let target1_keypair = Keypair::new();
+        let target1 = Node::new_localhost_with_pubkey(target1_keypair.pubkey());
+
+        let starting_balance = 10_000;
+        let (genesis_block, _mint_keypair) = GenesisBlock::new(starting_balance);
+
+        let bank_forks = BankForks::new(0, Bank::new(&genesis_block));
+        let bank_forks_info = vec![BankForksInfo {
+            bank_id: 0,
+            entry_height: 0,
+        }];
+
+        //start cluster_info1
+        let mut cluster_info1 = ClusterInfo::new(target1.info.clone());
+        cluster_info1.insert_info(leader.info.clone());
+        cluster_info1.set_leader(leader.info.id);
+        let cref1 = Arc::new(RwLock::new(cluster_info1));
+
+        let blocktree_path = get_tmp_ledger_path!();
+        let (blocktree, l_receiver) = Blocktree::open_with_signal(&blocktree_path)
+            .expect("Expected to successfully open ledger");
+        let bank = bank_forks.working_bank();
+        let (poh_recorder, poh_service, _entry_receiver) = create_test_recorder(&bank);
+        let tvu = Tvu::new(
+            Some(Arc::new(Keypair::new())),
+            &Arc::new(RwLock::new(bank_forks)),
+            &bank_forks_info,
+            &cref1,
+            {
+                Sockets {
+                    repair: target1.sockets.repair,
+                    retransmit: target1.sockets.retransmit,
+                    fetch: target1.sockets.tvu,
+                }
+            },
+            Arc::new(blocktree),
+            STORAGE_ROTATE_TEST_COUNT,
+            &StorageState::default(),
+            None,
+            l_receiver,
+            &Arc::new(RpcSubscriptions::default()),
+            &poh_recorder,
+        );
+        tvu.close().expect("close");
+        poh_service.close().expect("close");
+    }
+}

--- a/tests/replicator.rs
+++ b/tests/replicator.rs
@@ -61,7 +61,6 @@ fn test_replicator_startup_basic() {
             None,
             &fullnode_config,
         );
-        let leader_exit = leader.run(None);
 
         debug!(
             "leader: {:?}",
@@ -91,7 +90,6 @@ fn test_replicator_startup_basic() {
             Some(&leader_info),
             &fullnode_config,
         );
-        let validator_exit = validator.run(None);
 
         let bob = Keypair::new();
 
@@ -217,8 +215,8 @@ fn test_replicator_startup_basic() {
         }
 
         replicator.close();
-        validator_exit();
-        leader_exit();
+        validator.close().unwrap();
+        leader.close().unwrap();
     }
 
     info!("cleanup");

--- a/tests/rpc.rs
+++ b/tests/rpc.rs
@@ -17,7 +17,6 @@ fn test_rpc_send_tx() {
     solana_logger::setup();
 
     let (server, leader_data, alice, ledger_path) = new_fullnode();
-    let server_exit = server.run(None);
     let bob_pubkey = Keypair::new().pubkey();
 
     let client = reqwest::Client::new();
@@ -93,6 +92,6 @@ fn test_rpc_send_tx() {
 
     assert_eq!(confirmed_tx, true);
 
-    server_exit();
+    server.close().unwrap();
     remove_dir_all(ledger_path).unwrap();
 }

--- a/tests/tvu.rs
+++ b/tests/tvu.rs
@@ -11,8 +11,6 @@ use solana::entry::next_entry_mut;
 use solana::entry::EntrySlice;
 use solana::gossip_service::GossipService;
 use solana::packet::index_blobs;
-use solana::poh_recorder::PohRecorder;
-use solana::poh_service::{PohService, PohServiceConfig};
 use solana::rpc_subscriptions::RpcSubscriptions;
 use solana::service::Service;
 use solana::storage_stage::StorageState;
@@ -28,7 +26,6 @@ use std::fs::remove_dir_all;
 use std::net::UdpSocket;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::channel;
-use std::sync::Mutex;
 use std::sync::{Arc, RwLock};
 use std::time::Duration;
 

--- a/wallet/tests/deploy.rs
+++ b/wallet/tests/deploy.rs
@@ -20,7 +20,6 @@ fn test_wallet_deploy_program() {
     pathbuf.set_extension("so");
 
     let (server, leader_data, alice, ledger_path) = new_fullnode();
-    let server_exit = server.run(None);
 
     let (sender, receiver) = channel();
     run_local_drone(alice, sender);
@@ -76,6 +75,6 @@ fn test_wallet_deploy_program() {
         &elf
     );
 
-    server_exit();
+    server.close().unwrap();
     remove_dir_all(ledger_path).unwrap();
 }

--- a/wallet/tests/pay.rs
+++ b/wallet/tests/pay.rs
@@ -21,7 +21,6 @@ fn check_balance(expected_balance: u64, client: &RpcClient, pubkey: Pubkey) {
 #[test]
 fn test_wallet_timestamp_tx() {
     let (server, leader_data, alice, ledger_path) = new_fullnode();
-    let server_exit = server.run(None);
     let bob_pubkey = Keypair::new().pubkey();
 
     let (sender, receiver) = channel();
@@ -75,14 +74,13 @@ fn test_wallet_timestamp_tx() {
     check_balance(1, &rpc_client, process_id); // contract balance
     check_balance(10, &rpc_client, bob_pubkey); // recipient balance
 
-    server_exit();
+    server.close().unwrap();
     remove_dir_all(ledger_path).unwrap();
 }
 
 #[test]
 fn test_wallet_witness_tx() {
     let (server, leader_data, alice, ledger_path) = new_fullnode();
-    let server_exit = server.run(None);
     let bob_pubkey = Keypair::new().pubkey();
 
     let (sender, receiver) = channel();
@@ -133,14 +131,13 @@ fn test_wallet_witness_tx() {
     check_balance(1, &rpc_client, process_id); // contract balance
     check_balance(10, &rpc_client, bob_pubkey); // recipient balance
 
-    server_exit();
+    server.close().unwrap();
     remove_dir_all(ledger_path).unwrap();
 }
 
 #[test]
 fn test_wallet_cancel_tx() {
     let (server, leader_data, alice, ledger_path) = new_fullnode();
-    let server_exit = server.run(None);
     let bob_pubkey = Keypair::new().pubkey();
 
     let (sender, receiver) = channel();
@@ -191,6 +188,6 @@ fn test_wallet_cancel_tx() {
     check_balance(1, &rpc_client, process_id); // contract balance
     check_balance(0, &rpc_client, bob_pubkey); // recipient balance
 
-    server_exit();
+    server.close().unwrap();
     remove_dir_all(ledger_path).unwrap();
 }

--- a/wallet/tests/request_airdrop.rs
+++ b/wallet/tests/request_airdrop.rs
@@ -9,7 +9,6 @@ use std::sync::mpsc::channel;
 #[test]
 fn test_wallet_request_airdrop() {
     let (server, leader_data, alice, ledger_path) = new_fullnode();
-    let server_exit = server.run(None);
     let (sender, receiver) = channel();
     run_local_drone(alice, sender);
     let drone_addr = receiver.recv().unwrap();
@@ -30,6 +29,6 @@ fn test_wallet_request_airdrop() {
         .unwrap();
     assert_eq!(balance, 50);
 
-    server_exit();
+    server.close().unwrap();
     remove_dir_all(ledger_path).unwrap();
 }


### PR DESCRIPTION
#### Problem

The TPU/TVU mode transition is cumbersome and isn't necessary.  The replay stage can feed the banking stage and downstream units banks.  PohRecorder already guards against entries being recorded into those banks. 

#### Summary of Changes

Replay stage can feed the banking stage a bank directly.  This change has the following cascading effects:

1. Fullnode doesn't have a mode, so no rotation.
2. Banking stage always runs
3. Replay stage decides when to set a bank to generate entries
4. poh recorder ensures the bank only generates entries at the right time
5. Without a bank, banking stage forwards verified packets (there should probably be some QoS here or a fee check, or we are doing a blind proxy which is really easy to exploit for ddos).
5. Broadcast stage receives this ugly event, Bank + Entries.  While the data structure is ugly, it is kind of nice to have it all there so there is no synchronization step.

Fixes #
