### PR TITLE
Remove pub from program ids

### DIFF
--- a/programs/native/budget_api/src/lib.rs
+++ b/programs/native/budget_api/src/lib.rs
@@ -5,7 +5,7 @@ pub mod payment_plan;
 
 use solana_sdk::pubkey::Pubkey;
 
-pub const BUDGET_PROGRAM_ID: [u8; 32] = [
+const BUDGET_PROGRAM_ID: [u8; 32] = [
     129, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0,
 ];

--- a/programs/native/rewards_api/src/lib.rs
+++ b/programs/native/rewards_api/src/lib.rs
@@ -4,7 +4,7 @@ pub mod rewards_transaction;
 
 use solana_sdk::pubkey::Pubkey;
 
-pub const REWARDS_PROGRAM_ID: [u8; 32] = [
+const REWARDS_PROGRAM_ID: [u8; 32] = [
     133, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0,
 ];

--- a/programs/native/vote_api/src/lib.rs
+++ b/programs/native/vote_api/src/lib.rs
@@ -4,7 +4,7 @@ pub mod vote_transaction;
 
 use solana_sdk::pubkey::Pubkey;
 
-pub const VOTE_PROGRAM_ID: [u8; 32] = [
+const VOTE_PROGRAM_ID: [u8; 32] = [
     132, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0,
 ];

--- a/sdk/src/bpf_loader.rs
+++ b/sdk/src/bpf_loader.rs
@@ -1,6 +1,6 @@
 use crate::pubkey::Pubkey;
 
-pub const BPF_LOADER_PROGRAM_ID: [u8; 32] = [
+const BPF_LOADER_PROGRAM_ID: [u8; 32] = [
     128, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0,
 ];

--- a/sdk/src/native_loader.rs
+++ b/sdk/src/native_loader.rs
@@ -1,7 +1,7 @@
 use crate::account::Account;
 use crate::pubkey::Pubkey;
 
-pub const NATIVE_LOADER_PROGRAM_ID: [u8; 32] = [
+const NATIVE_LOADER_PROGRAM_ID: [u8; 32] = [
     1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 ];
 

--- a/sdk/src/storage_program.rs
+++ b/sdk/src/storage_program.rs
@@ -61,7 +61,7 @@ pub enum StorageProgram {
     },
 }
 
-pub const STORAGE_PROGRAM_ID: [u8; 32] = [
+const STORAGE_PROGRAM_ID: [u8; 32] = [
     130, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0,
 ];

--- a/sdk/src/system_program.rs
+++ b/sdk/src/system_program.rs
@@ -1,6 +1,6 @@
 use crate::pubkey::Pubkey;
 
-pub const SYSTEM_PROGRAM_ID: [u8; 32] = [0u8; 32];
+const SYSTEM_PROGRAM_ID: [u8; 32] = [0u8; 32];
 
 pub fn id() -> Pubkey {
     Pubkey::new(&SYSTEM_PROGRAM_ID)


### PR DESCRIPTION
id() is the only function programs *need* to publish. check_id() is a nice little optimization.
