### PR TITLE
Revive payments via Budget

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2076,6 +2076,7 @@ dependencies = [
  "serde_derive 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-budget-api 0.12.0",
  "solana-logger 0.12.0",
+ "solana-runtime 0.12.0",
  "solana-sdk 0.12.0",
 ]
 

--- a/programs/budget/Cargo.toml
+++ b/programs/budget/Cargo.toml
@@ -18,6 +18,9 @@ solana-budget-api = { path = "../budget_api", version = "0.12.0" }
 solana-logger = { path = "../../logger", version = "0.12.0" }
 solana-sdk = { path = "../../sdk", version = "0.12.0" }
 
+[dev-dependencies]
+solana-runtime = { path = "../../runtime", version = "0.12.0" }
+
 [lib]
 name = "solana_budget_program"
 crate-type = ["cdylib"]

--- a/programs/budget/src/budget_program.rs
+++ b/programs/budget/src/budget_program.rs
@@ -1,9 +1,9 @@
 //! budget program
-use crate::budget_state::{BudgetError, BudgetState};
 use bincode::deserialize;
 use chrono::prelude::{DateTime, Utc};
 use log::*;
 use solana_budget_api::budget_instruction::BudgetInstruction;
+use solana_budget_api::budget_state::{BudgetError, BudgetState};
 use solana_budget_api::payment_plan::Witness;
 use solana_sdk::account::KeyedAccount;
 
@@ -86,7 +86,8 @@ fn apply_debits(
         BudgetInstruction::InitializeAccount(expr) => {
             let expr = expr.clone();
             if let Some(payment) = expr.final_payment() {
-                keyed_accounts[1].account.tokens += payment.tokens;
+                keyed_accounts[1].account.tokens = 0;
+                keyed_accounts[0].account.tokens += payment.tokens;
                 Ok(())
             } else {
                 let existing = BudgetState::deserialize(&keyed_accounts[1].account.userdata).ok();

--- a/programs/budget/src/lib.rs
+++ b/programs/budget/src/lib.rs
@@ -1,5 +1,4 @@
 mod budget_program;
-mod budget_state;
 
 use crate::budget_program::process_instruction;
 use log::*;

--- a/programs/budget/tests/budget.rs
+++ b/programs/budget/tests/budget.rs
@@ -1,0 +1,32 @@
+use solana_budget_api::budget_transaction::BudgetTransaction;
+use solana_runtime::bank::{Bank, Result};
+use solana_sdk::genesis_block::GenesisBlock;
+use solana_sdk::pubkey::Pubkey;
+use solana_sdk::signature::{Keypair, KeypairUtil};
+
+struct BudgetBank<'a> {
+    bank: &'a Bank,
+}
+
+impl<'a> BudgetBank<'a> {
+    fn new(bank: &'a Bank) -> Self {
+        bank.add_native_program("solana_budget_program", &solana_budget_api::id());
+        Self { bank }
+    }
+
+    fn pay(&self, from_keypair: &Keypair, to_id: Pubkey, lamports: u64) -> Result<()> {
+        let blockhash = self.bank.last_blockhash();
+        let tx = BudgetTransaction::new_payment(from_keypair, to_id, lamports, blockhash, 0);
+        self.bank.process_transaction(&tx)
+    }
+}
+
+#[test]
+fn test_budget_payment_via_bank() {
+    let (genesis_block, from_keypair) = GenesisBlock::new(10_000);
+    let bank = Bank::new(&genesis_block);
+    let budget_bank = BudgetBank::new(&bank);
+    let to_id = Keypair::new().pubkey();
+    budget_bank.pay(&from_keypair, to_id, 100).unwrap();
+    assert_eq!(bank.get_balance(&to_id), 100);
+}

--- a/programs/budget_api/src/budget_instruction.rs
+++ b/programs/budget_api/src/budget_instruction.rs
@@ -29,10 +29,13 @@ pub enum BudgetInstruction {
 
 impl BudgetInstruction {
     pub fn new_initialize_account(contract: Pubkey, expr: BudgetExpr) -> BuilderInstruction {
-        BuilderInstruction::new(
-            id(),
-            &BudgetInstruction::InitializeAccount(expr),
-            vec![(contract, false)],
-        )
+        let mut keys = vec![];
+        if let BudgetExpr::Pay(payment) = &expr {
+            keys.push((payment.to, false));
+        } else {
+            panic!("unsupported Budget instruction");
+        }
+        keys.push((contract, false));
+        BuilderInstruction::new(id(), &BudgetInstruction::InitializeAccount(expr), keys)
     }
 }

--- a/programs/budget_api/src/budget_state.rs
+++ b/programs/budget_api/src/budget_state.rs
@@ -1,7 +1,7 @@
 //! budget state
+use crate::budget_expr::BudgetExpr;
 use bincode::{self, deserialize, serialize_into};
 use serde_derive::{Deserialize, Serialize};
-use solana_budget_api::budget_expr::BudgetExpr;
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub enum BudgetError {
@@ -25,6 +25,13 @@ pub struct BudgetState {
 }
 
 impl BudgetState {
+    pub fn new(budget_expr: BudgetExpr) -> Self {
+        Self {
+            initialized: true,
+            pending_budget: Some(budget_expr),
+        }
+    }
+
     pub fn is_pending(&self) -> bool {
         self.pending_budget.is_some()
     }
@@ -43,7 +50,7 @@ impl BudgetState {
 #[cfg(test)]
 mod test {
     use super::*;
-    use solana_budget_api::id;
+    use crate::id;
     use solana_sdk::account::Account;
 
     #[test]

--- a/programs/budget_api/src/lib.rs
+++ b/programs/budget_api/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod budget_expr;
 pub mod budget_instruction;
+pub mod budget_state;
 pub mod budget_transaction;
 pub mod payment_plan;
 

--- a/sdk/src/system_instruction.rs
+++ b/sdk/src/system_instruction.rs
@@ -25,6 +25,24 @@ pub enum SystemInstruction {
 }
 
 impl SystemInstruction {
+    pub fn new_program_account(
+        from_id: Pubkey,
+        to_id: Pubkey,
+        tokens: u64,
+        space: u64,
+        program_id: Pubkey,
+    ) -> BuilderInstruction {
+        BuilderInstruction::new(
+            system_program::id(),
+            &SystemInstruction::CreateAccount {
+                tokens,
+                space,
+                program_id,
+            },
+            vec![(from_id, true), (to_id, false)],
+        )
+    }
+
     pub fn new_move(from_id: Pubkey, to_id: Pubkey, tokens: u64) -> BuilderInstruction {
         BuilderInstruction::new(
             system_program::id(),


### PR DESCRIPTION
#### Problem

Budget used to be part of the bank and was well-tested at that time. When we added `userdata` to accounts, we moved it out and added a bunch of unit-tests, but no integration tests. Then we added support for batched instructions, and the current code doesn't reflect that. It still assumes `key[0]` was the account that funded the program account. Also, BudgetTransaction doesn't allocate space for the program account.

#### Summary of Changes

* Update BudgetTransaction to use SystemInstruction::CreateAccount instead of Move
* Move `budget_state.rs` to budget_api, where it can be used to calculate its serialized size to create the transaction
* Add an integration test for a simple payment

Still quite a bit of work to do in a follow-up PR. It doesn't support more advanced contracts. BudgetInstruction needs to collect all potential Payment Pubkeys.