### PR TITLE
Use PohRecorder to synchronize instead of rotate.

### DIFF
--- a/core/src/local_cluster.rs
+++ b/core/src/local_cluster.rs
@@ -3,6 +3,7 @@ use crate::client::mk_client;
 use crate::cluster_info::{Node, NodeInfo};
 use crate::fullnode::{Fullnode, FullnodeConfig};
 use crate::gossip_service::discover;
+use crate::service::Service;
 use crate::thin_client::retry_get_balance;
 use crate::thin_client::ThinClient;
 use crate::voting_keypair::VotingKeypair;
@@ -14,16 +15,14 @@ use solana_vote_api::vote_state::VoteState;
 use solana_vote_api::vote_transaction::VoteTransaction;
 use std::fs::remove_dir_all;
 use std::io::{Error, ErrorKind, Result};
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
-use std::thread::JoinHandle;
 
 pub struct LocalCluster {
     /// Keypair with funding to particpiate in the network
     pub funding_keypair: Keypair,
     /// Entry point from which the rest of the network can be discovered
     pub entry_point_info: NodeInfo,
-    fullnode_hdls: Vec<(JoinHandle<()>, Arc<AtomicBool>)>,
+    fullnodes: Vec<Fullnode>,
     ledger_paths: Vec<String>,
 }
 
@@ -50,8 +49,7 @@ impl LocalCluster {
             None,
             &fullnode_config,
         );
-        let (thread, exit, _) = leader_server.start(None);
-        let mut fullnode_hdls = vec![(thread, exit)];
+        let mut fullnodes = vec![leader_server];
         let mut client = mk_client(&leader_node_info);
         for _ in 0..(num_nodes - 1) {
             let validator_keypair = Arc::new(Keypair::new());
@@ -88,27 +86,26 @@ impl LocalCluster {
                 Some(&leader_node_info),
                 &fullnode_config,
             );
-            let (thread, exit, _) = validator_server.start(None);
-            fullnode_hdls.push((thread, exit));
+            fullnodes.push(validator_server);
         }
         discover(&leader_node_info, num_nodes);
         Self {
             funding_keypair: mint_keypair,
             entry_point_info: leader_node_info,
-            fullnode_hdls,
+            fullnodes,
             ledger_paths,
         }
     }
 
     pub fn exit(&self) {
-        for node in &self.fullnode_hdls {
-            node.1.store(true, Ordering::Relaxed);
+        for node in &self.fullnodes {
+            node.exit();
         }
     }
     pub fn close(&mut self) {
         self.exit();
-        while let Some(node) = self.fullnode_hdls.pop() {
-            node.0.join().expect("join");
+        while let Some(node) = self.fullnodes.pop() {
+            node.join().unwrap();
         }
         for path in &self.ledger_paths {
             remove_dir_all(path).unwrap();

--- a/core/src/poh_service.rs
+++ b/core/src/poh_service.rs
@@ -117,20 +117,17 @@ mod tests {
     use solana_runtime::bank::Bank;
     use solana_sdk::genesis_block::GenesisBlock;
     use solana_sdk::hash::hash;
-    use std::sync::mpsc::channel;
-    use std::sync::mpsc::RecvError;
 
     #[test]
     fn test_poh_service() {
         let (genesis_block, _mint_keypair) = GenesisBlock::new(2);
         let bank = Arc::new(Bank::new(&genesis_block));
         let prev_hash = bank.last_blockhash();
-        let (entry_sender, entry_receiver) = channel();
-        let poh_recorder = Arc::new(Mutex::new(PohRecorder::new(bank.tick_height(), prev_hash)));
+        let (poh_recorder, entry_receiver) = PohRecorder::new(bank.tick_height(), prev_hash);
+        let poh_recorder = Arc::new(Mutex::new(poh_recorder));
         let exit = Arc::new(AtomicBool::new(false));
         let working_bank = WorkingBank {
             bank: bank.clone(),
-            sender: entry_sender,
             min_tick_height: bank.tick_height(),
             max_tick_height: std::u64::MAX,
         };
@@ -171,7 +168,7 @@ mod tests {
         let mut need_partial = true;
 
         while need_tick || need_entry || need_partial {
-            for entry in entry_receiver.recv().unwrap() {
+            for entry in entry_receiver.recv().unwrap().1 {
                 let entry = &entry.0;
                 if entry.is_tick() {
                     assert!(entry.num_hashes <= HASHES_PER_TICK);
@@ -198,44 +195,5 @@ mod tests {
         poh_service.exit();
         let _ = poh_service.join().unwrap();
         let _ = entry_producer.join().unwrap();
-    }
-
-    #[test]
-    fn test_poh_service_drops_working_bank() {
-        let (genesis_block, _mint_keypair) = GenesisBlock::new(2);
-        let bank = Arc::new(Bank::new(&genesis_block));
-        let prev_hash = bank.last_blockhash();
-        let (entry_sender, entry_receiver) = channel();
-        let poh_recorder = Arc::new(Mutex::new(PohRecorder::new(bank.tick_height(), prev_hash)));
-        let exit = Arc::new(AtomicBool::new(false));
-        let working_bank = WorkingBank {
-            bank: bank.clone(),
-            sender: entry_sender,
-            min_tick_height: bank.tick_height() + 3,
-            max_tick_height: bank.tick_height() + 5,
-        };
-
-        let poh_service = PohService::new(
-            poh_recorder.clone(),
-            &PohServiceConfig::default(),
-            Arc::new(AtomicBool::new(false)),
-        );
-
-        poh_recorder.lock().unwrap().set_working_bank(working_bank);
-
-        // all 5 ticks are expected, there is no tick 0
-        // First 4 ticks must be sent all at once, since bank shouldn't see them until
-        // the after bank's min_tick_height(3) is reached.
-        let entries = entry_receiver.recv().expect("recv 1");
-        assert_eq!(entries.len(), 4);
-        let entries = entry_receiver.recv().expect("recv 2");
-        assert_eq!(entries.len(), 1);
-
-        //WorkingBank should be dropped by the PohService thread as well
-        assert_eq!(entry_receiver.recv(), Err(RecvError));
-
-        exit.store(true, Ordering::Relaxed);
-        poh_service.exit();
-        let _ = poh_service.join().unwrap();
     }
 }

--- a/core/src/thin_client.rs
+++ b/core/src/thin_client.rs
@@ -498,7 +498,6 @@ mod tests {
     fn test_thin_client_basic() {
         solana_logger::setup();
         let (server, leader_data, alice, ledger_path) = new_fullnode();
-        let server_exit = server.run(None);
         let bob_pubkey = Keypair::new().pubkey();
 
         info!(
@@ -525,7 +524,7 @@ mod tests {
 
         let transaction_count = client.transaction_count();
         assert_eq!(transaction_count, 1);
-        server_exit();
+        server.close().unwrap();
         remove_dir_all(ledger_path).unwrap();
     }
 
@@ -534,7 +533,6 @@ mod tests {
     fn test_bad_sig() {
         solana_logger::setup();
         let (server, leader_data, alice, ledger_path) = new_fullnode();
-        let server_exit = server.run(None);
         let bob_pubkey = Keypair::new().pubkey();
         info!(
             "found leader: {:?}",
@@ -562,7 +560,7 @@ mod tests {
 
         let balance = client.get_balance(&bob_pubkey);
         assert_eq!(balance.unwrap(), 1001);
-        server_exit();
+        server.close().unwrap();
         remove_dir_all(ledger_path).unwrap();
     }
 
@@ -570,7 +568,6 @@ mod tests {
     fn test_register_vote_account() {
         solana_logger::setup();
         let (server, leader_data, alice, ledger_path) = new_fullnode();
-        let server_exit = server.run(None);
         info!(
             "found leader: {:?}",
             poll_gossip_for_leader(leader_data.gossip, Some(5)).unwrap()
@@ -626,7 +623,7 @@ mod tests {
             sleep(Duration::from_millis(900));
         }
 
-        server_exit();
+        server.close().unwrap();
         remove_dir_all(ledger_path).unwrap();
     }
 
@@ -645,7 +642,6 @@ mod tests {
     fn test_zero_balance_after_nonzero() {
         solana_logger::setup();
         let (server, leader_data, alice, ledger_path) = new_fullnode();
-        let server_exit = server.run(None);
         let bob_keypair = Keypair::new();
 
         info!(
@@ -682,7 +678,7 @@ mod tests {
         info!("Bob's balance is {:?}", bob_balance);
         assert!(bob_balance.is_err(),);
 
-        server_exit();
+        server.close().unwrap();
         remove_dir_all(ledger_path).unwrap();
     }
 }

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -1,28 +1,21 @@
 //! The `tpu` module implements the Transaction Processing Unit, a
 //! multi-stage transaction processing pipeline in software.
 
-use crate::banking_stage::{BankingStage, UnprocessedPackets};
+use crate::banking_stage::BankingStage;
 use crate::blocktree::Blocktree;
 use crate::broadcast_stage::BroadcastStage;
 use crate::cluster_info::ClusterInfo;
 use crate::cluster_info_vote_listener::ClusterInfoVoteListener;
 use crate::fetch_stage::FetchStage;
-use crate::poh_recorder::PohRecorder;
+use crate::poh_recorder::{PohRecorder, WorkingBankEntries};
 use crate::service::Service;
 use crate::sigverify_stage::SigVerifyStage;
-use crate::tpu_forwarder::TpuForwarder;
-use solana_runtime::bank::Bank;
 use solana_sdk::pubkey::Pubkey;
 use std::net::UdpSocket;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::mpsc::channel;
+use std::sync::mpsc::{channel, Receiver};
 use std::sync::{Arc, Mutex, RwLock};
 use std::thread;
-
-pub enum TpuMode {
-    Leader(LeaderServices),
-    Forwarder(ForwarderServices),
-}
 
 pub struct LeaderServices {
     fetch_stage: FetchStage,
@@ -49,7 +42,7 @@ impl LeaderServices {
         }
     }
 
-    fn exit(&self) {
+    pub fn exit(&self) {
         self.fetch_stage.close();
     }
 
@@ -67,187 +60,63 @@ impl LeaderServices {
         Ok(())
     }
 
-    fn close(self) -> thread::Result<()> {
-        self.exit();
-        self.join()
-    }
-}
-
-pub struct ForwarderServices {
-    tpu_forwarder: TpuForwarder,
-}
-
-impl ForwarderServices {
-    fn new(tpu_forwarder: TpuForwarder) -> Self {
-        ForwarderServices { tpu_forwarder }
-    }
-
-    fn exit(&self) {
-        self.tpu_forwarder.close();
-    }
-
-    fn join(self) -> thread::Result<()> {
-        self.tpu_forwarder.join()
-    }
-
-    fn close(self) -> thread::Result<()> {
+    pub fn close(self) -> thread::Result<()> {
         self.exit();
         self.join()
     }
 }
 
 pub struct Tpu {
-    tpu_mode: Option<TpuMode>,
+    leader_services: LeaderServices,
     exit: Arc<AtomicBool>,
-    id: Pubkey,
-    cluster_info: Arc<RwLock<ClusterInfo>>,
+    pub id: Pubkey,
 }
 
 impl Tpu {
-    pub fn new(id: Pubkey, cluster_info: &Arc<RwLock<ClusterInfo>>) -> Self {
-        Self {
-            tpu_mode: None,
-            exit: Arc::new(AtomicBool::new(false)),
-            id,
-            cluster_info: cluster_info.clone(),
-        }
-    }
-
-    fn mode_exit(&mut self) {
-        match &mut self.tpu_mode {
-            Some(TpuMode::Leader(svcs)) => {
-                svcs.exit();
-            }
-            Some(TpuMode::Forwarder(svcs)) => {
-                svcs.exit();
-            }
-            None => (),
-        }
-    }
-
-    fn mode_close(&mut self) {
-        let tpu_mode = self.tpu_mode.take();
-        if let Some(tpu_mode) = tpu_mode {
-            match tpu_mode {
-                TpuMode::Leader(svcs) => {
-                    let _ = svcs.close();
-                }
-                TpuMode::Forwarder(svcs) => {
-                    let _ = svcs.close();
-                }
-            }
-        }
-    }
-
-    fn forward_unprocessed_packets(
-        tpu: &std::net::SocketAddr,
-        unprocessed_packets: UnprocessedPackets,
-    ) -> std::io::Result<()> {
-        let socket = UdpSocket::bind("0.0.0.0:0")?;
-        for (packets, start_index) in unprocessed_packets {
-            let packets = packets.read().unwrap();
-            for packet in packets.packets.iter().skip(start_index) {
-                socket.send_to(&packet.data[..packet.meta.size], tpu)?;
-            }
-        }
-        Ok(())
-    }
-
-    fn close_and_forward_unprocessed_packets(&mut self) {
-        self.mode_exit();
-
-        let unprocessed_packets = match self.tpu_mode.as_mut() {
-            Some(TpuMode::Leader(svcs)) => {
-                svcs.banking_stage.join_and_collect_unprocessed_packets()
-            }
-            Some(TpuMode::Forwarder(svcs)) => {
-                svcs.tpu_forwarder.join_and_collect_unprocessed_packets()
-            }
-            None => vec![],
-        };
-
-        if !unprocessed_packets.is_empty() {
-            let tpu = self.cluster_info.read().unwrap().leader_data().unwrap().tpu;
-            info!("forwarding unprocessed packets to new leader at {:?}", tpu);
-            Tpu::forward_unprocessed_packets(&tpu, unprocessed_packets).unwrap_or_else(|err| {
-                warn!("Failed to forward unprocessed transactions: {:?}", err)
-            });
-        }
-
-        self.mode_close();
-    }
-
-    pub fn switch_to_forwarder(&mut self, leader_id: Pubkey, transactions_sockets: Vec<UdpSocket>) {
-        self.close_and_forward_unprocessed_packets();
-
-        self.cluster_info.write().unwrap().set_leader(leader_id);
-
-        let tpu_forwarder = TpuForwarder::new(transactions_sockets, self.cluster_info.clone());
-        self.tpu_mode = Some(TpuMode::Forwarder(ForwarderServices::new(tpu_forwarder)));
-    }
-
-    #[allow(clippy::too_many_arguments)]
-    pub fn switch_to_leader(
-        &mut self,
-        bank: &Arc<Bank>,
+    pub fn new(
+        id: Pubkey,
+        cluster_info: &Arc<RwLock<ClusterInfo>>,
         poh_recorder: &Arc<Mutex<PohRecorder>>,
+        entry_receiver: Receiver<WorkingBankEntries>,
         transactions_sockets: Vec<UdpSocket>,
         broadcast_socket: UdpSocket,
         sigverify_disabled: bool,
-        slot: u64,
         blocktree: &Arc<Blocktree>,
-    ) {
-        self.close_and_forward_unprocessed_packets();
+    ) -> Self {
+        cluster_info.write().unwrap().set_leader(id);
 
-        self.cluster_info.write().unwrap().set_leader(self.id);
-
-        self.exit = Arc::new(AtomicBool::new(false));
+        let exit = Arc::new(AtomicBool::new(false));
         let (packet_sender, packet_receiver) = channel();
-        let fetch_stage = FetchStage::new_with_sender(
-            transactions_sockets,
-            self.exit.clone(),
-            &packet_sender.clone(),
-        );
-        let cluster_info_vote_listener = ClusterInfoVoteListener::new(
-            self.exit.clone(),
-            self.cluster_info.clone(),
-            packet_sender,
-        );
+        let fetch_stage =
+            FetchStage::new_with_sender(transactions_sockets, exit.clone(), &packet_sender.clone());
+        let cluster_info_vote_listener =
+            ClusterInfoVoteListener::new(exit.clone(), cluster_info.clone(), packet_sender);
 
         let (sigverify_stage, verified_receiver) =
             SigVerifyStage::new(packet_receiver, sigverify_disabled);
 
-        // TODO: Fix BankingStage/BroadcastStage to operate on `slot` directly instead of
-        // `max_tick_height`
-        let max_tick_height = (slot + 1) * bank.ticks_per_slot() - 1;
-        let blob_index = blocktree
-            .meta(slot)
-            .expect("Database error")
-            .map(|meta| meta.consumed)
-            .unwrap_or(0);
-
-        let (banking_stage, entry_receiver) =
-            BankingStage::new(&bank, poh_recorder, verified_receiver, max_tick_height);
+        let banking_stage = BankingStage::new(&cluster_info, poh_recorder, verified_receiver);
 
         let broadcast_stage = BroadcastStage::new(
-            slot,
-            bank,
             broadcast_socket,
-            self.cluster_info.clone(),
-            blob_index,
+            cluster_info.clone(),
             entry_receiver,
-            self.exit.clone(),
+            exit.clone(),
             blocktree,
         );
 
-        let svcs = LeaderServices::new(
+        let leader_services = LeaderServices::new(
             fetch_stage,
             sigverify_stage,
             banking_stage,
             cluster_info_vote_listener,
             broadcast_stage,
         );
-        self.tpu_mode = Some(TpuMode::Leader(svcs));
+        Self {
+            leader_services,
+            exit,
+            id,
+        }
     }
 
     pub fn exit(&self) {
@@ -258,8 +127,8 @@ impl Tpu {
         self.exit.load(Ordering::Relaxed)
     }
 
-    pub fn close(mut self) -> thread::Result<()> {
-        self.mode_close();
+    pub fn close(self) -> thread::Result<()> {
+        self.exit();
         self.join()
     }
 }
@@ -268,11 +137,6 @@ impl Service for Tpu {
     type JoinReturnType = ();
 
     fn join(self) -> thread::Result<()> {
-        match self.tpu_mode {
-            Some(TpuMode::Leader(svcs)) => svcs.join()?,
-            Some(TpuMode::Forwarder(svcs)) => svcs.join()?,
-            None => (),
-        }
-        Ok(())
+        self.leader_services.join()
     }
 }

--- a/tests/replicator.rs
+++ b/tests/replicator.rs
@@ -61,7 +61,6 @@ fn test_replicator_startup_basic() {
             None,
             &fullnode_config,
         );
-        let leader_exit = leader.run(None);
 
         debug!(
             "leader: {:?}",
@@ -91,7 +90,6 @@ fn test_replicator_startup_basic() {
             Some(&leader_info),
             &fullnode_config,
         );
-        let validator_exit = validator.run(None);
 
         let bob = Keypair::new();
 
@@ -217,8 +215,8 @@ fn test_replicator_startup_basic() {
         }
 
         replicator.close();
-        validator_exit();
-        leader_exit();
+        validator.close().unwrap();
+        leader.close().unwrap();
     }
 
     info!("cleanup");

--- a/tests/rpc.rs
+++ b/tests/rpc.rs
@@ -17,7 +17,6 @@ fn test_rpc_send_tx() {
     solana_logger::setup();
 
     let (server, leader_data, alice, ledger_path) = new_fullnode();
-    let server_exit = server.run(None);
     let bob_pubkey = Keypair::new().pubkey();
 
     let client = reqwest::Client::new();
@@ -93,6 +92,6 @@ fn test_rpc_send_tx() {
 
     assert_eq!(confirmed_tx, true);
 
-    server_exit();
+    server.close().unwrap();
     remove_dir_all(ledger_path).unwrap();
 }

--- a/wallet/tests/deploy.rs
+++ b/wallet/tests/deploy.rs
@@ -20,7 +20,6 @@ fn test_wallet_deploy_program() {
     pathbuf.set_extension("so");
 
     let (server, leader_data, alice, ledger_path) = new_fullnode();
-    let server_exit = server.run(None);
 
     let (sender, receiver) = channel();
     run_local_drone(alice, sender);
@@ -76,6 +75,6 @@ fn test_wallet_deploy_program() {
         &elf
     );
 
-    server_exit();
+    server.close().unwrap();
     remove_dir_all(ledger_path).unwrap();
 }

--- a/wallet/tests/pay.rs
+++ b/wallet/tests/pay.rs
@@ -21,7 +21,6 @@ fn check_balance(expected_balance: u64, client: &RpcClient, pubkey: Pubkey) {
 #[test]
 fn test_wallet_timestamp_tx() {
     let (server, leader_data, alice, ledger_path) = new_fullnode();
-    let server_exit = server.run(None);
     let bob_pubkey = Keypair::new().pubkey();
 
     let (sender, receiver) = channel();
@@ -75,14 +74,13 @@ fn test_wallet_timestamp_tx() {
     check_balance(1, &rpc_client, process_id); // contract balance
     check_balance(10, &rpc_client, bob_pubkey); // recipient balance
 
-    server_exit();
+    server.close().unwrap();
     remove_dir_all(ledger_path).unwrap();
 }
 
 #[test]
 fn test_wallet_witness_tx() {
     let (server, leader_data, alice, ledger_path) = new_fullnode();
-    let server_exit = server.run(None);
     let bob_pubkey = Keypair::new().pubkey();
 
     let (sender, receiver) = channel();
@@ -133,14 +131,13 @@ fn test_wallet_witness_tx() {
     check_balance(1, &rpc_client, process_id); // contract balance
     check_balance(10, &rpc_client, bob_pubkey); // recipient balance
 
-    server_exit();
+    server.close().unwrap();
     remove_dir_all(ledger_path).unwrap();
 }
 
 #[test]
 fn test_wallet_cancel_tx() {
     let (server, leader_data, alice, ledger_path) = new_fullnode();
-    let server_exit = server.run(None);
     let bob_pubkey = Keypair::new().pubkey();
 
     let (sender, receiver) = channel();
@@ -191,6 +188,6 @@ fn test_wallet_cancel_tx() {
     check_balance(1, &rpc_client, process_id); // contract balance
     check_balance(0, &rpc_client, bob_pubkey); // recipient balance
 
-    server_exit();
+    server.close().unwrap();
     remove_dir_all(ledger_path).unwrap();
 }

--- a/wallet/tests/request_airdrop.rs
+++ b/wallet/tests/request_airdrop.rs
@@ -9,7 +9,6 @@ use std::sync::mpsc::channel;
 #[test]
 fn test_wallet_request_airdrop() {
     let (server, leader_data, alice, ledger_path) = new_fullnode();
-    let server_exit = server.run(None);
     let (sender, receiver) = channel();
     run_local_drone(alice, sender);
     let drone_addr = receiver.recv().unwrap();
@@ -30,6 +29,6 @@ fn test_wallet_request_airdrop() {
         .unwrap();
     assert_eq!(balance, 50);
 
-    server_exit();
+    server.close().unwrap();
     remove_dir_all(ledger_path).unwrap();
 }


### PR DESCRIPTION
#### Problem

The TPU/TVU mode transition is cumbersome and isn't necessary.  The replay stage can feed the banking stage and downstream units banks.  PohRecorder already guards against entries being recorded into those banks. 

#### Summary of Changes
(rebase of #3056)
Replay stage can feed the banking stage a bank directly with a shared PohRecorder.  This change has the following cascading effects:

1. Fullnode doesn't have a mode, so no rotation.
2. Banking stage always runs
3. Replay stage decides when to set a bank to generate entries
4. poh recorder ensures the bank only generates entries at the right time
5. Without a bank, banking stage forwards verified packets (there should probably be some QoS here or a fee check, or we are doing a blind proxy which is really easy to exploit for ddos).
5. Broadcast stage receives this ugly event, Bank + Entries.  While the data structure is ugly, it is kind of nice to have it all there so there is no synchronization step.

Fixes #
