### PR TITLE
Remove ipv6 feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ codecov = { repository = "solana-labs/solana", branch = "master", service = "git
 chacha = ["solana/chacha"]
 cuda = ["solana/cuda"]
 erasure = ["solana/erasure"]
-ipv6 = ["solana/ipv6", "solana-netutil/ipv6"]
 
 [dev-dependencies]
 bincode = "1.1.2"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -17,7 +17,6 @@ codecov = { repository = "solana-labs/solana", branch = "master", service = "git
 chacha = []
 cuda = []
 erasure = []
-ipv6 = ["solana-netutil/ipv6"]
 
 [dependencies]
 bincode = "1.1.2"

--- a/fullnode-config/src/lib.rs
+++ b/fullnode-config/src/lib.rs
@@ -24,7 +24,7 @@ impl Config {
         let mut bind_addr =
             solana_netutil::parse_port_or_addr(&self.bind_port_or_address, default_port);
         if self.use_local_address {
-            let ip = solana_netutil::get_ip_addr().unwrap();
+            let ip = solana_netutil::get_ip_addr(false).unwrap();
             bind_addr.set_ip(ip);
         }
         if self.use_public_address {

--- a/fullnode/Cargo.toml
+++ b/fullnode/Cargo.toml
@@ -27,4 +27,3 @@ solana-vote-signer = { path = "../vote-signer", version = "0.12.0" }
 chacha = ["solana/chacha"]
 cuda = ["solana/cuda"]
 erasure = ["solana/erasure"]
-ipv6 = ["solana/ipv6"]

--- a/netutil/Cargo.toml
+++ b/netutil/Cargo.toml
@@ -8,9 +8,6 @@ license = "Apache-2.0"
 homepage = "https://solana.com/"
 edition = "2018"
 
-[features]
-ipv6 = []
-
 [dependencies]
 log = "0.4.2"
 ipnetwork = "0.12.7"

--- a/netutil/src/lib.rs
+++ b/netutil/src/lib.rs
@@ -48,7 +48,10 @@ pub fn parse_port_or_addr(optstr: &Option<String>, default_port: u16) -> SocketA
     }
 }
 
-fn find_eth0ish_ip_addr(ifaces: &mut Vec<datalink::NetworkInterface>) -> Option<IpAddr> {
+fn find_eth0ish_ip_addr(
+    ifaces: &mut Vec<datalink::NetworkInterface>,
+    enable_ipv6: bool,
+) -> Option<IpAddr> {
     // put eth0 and wifi0, etc. up front of our list of candidates
     ifaces.sort_by(|a, b| {
         a.name
@@ -84,9 +87,8 @@ fn find_eth0ish_ip_addr(ifaces: &mut Vec<datalink::NetworkInterface>) -> Option<
                     return Some(p.ip());
                 }
                 IpAddr::V6(_addr) => {
-                    // Select an ipv6 address if the config is selected
-                    #[cfg(feature = "ipv6")]
-                    {
+                    // Select an ipv6 address if requested
+                    if enable_ipv6 {
                         if p.ip().is_loopback() {
                             trace!("    loopback");
                             lo = Some(p.ip());
@@ -102,10 +104,9 @@ fn find_eth0ish_ip_addr(ifaces: &mut Vec<datalink::NetworkInterface>) -> Option<
     lo
 }
 
-pub fn get_ip_addr() -> Option<IpAddr> {
+pub fn get_ip_addr(enable_ipv6: bool) -> Option<IpAddr> {
     let mut ifaces = datalink::interfaces();
-
-    find_eth0ish_ip_addr(&mut ifaces)
+    find_eth0ish_ip_addr(&mut ifaces, enable_ipv6)
 }
 
 fn udp_socket(reuseaddr: bool) -> io::Result<Socket> {
@@ -224,56 +225,68 @@ mod tests {
 
         // loopback bad when alternatives exist
         assert_eq!(
-            find_eth0ish_ip_addr(&mut vec![
-                mock_interface!(eth0, "192.168.137.1/8"),
-                mock_interface!(lo, "127.0.0.1/24")
-            ]),
+            find_eth0ish_ip_addr(
+                &mut vec![
+                    mock_interface!(eth0, "192.168.137.1/8"),
+                    mock_interface!(lo, "127.0.0.1/24")
+                ],
+                false
+            ),
             Some(mock_interface!(eth0, "192.168.137.1/8").ips[0].ip())
         );
         // find loopback as a last resort
         assert_eq!(
-            find_eth0ish_ip_addr(&mut vec![mock_interface!(lo, "127.0.0.1/24")]),
+            find_eth0ish_ip_addr(&mut vec![mock_interface!(lo, "127.0.0.1/24")], false),
             Some(mock_interface!(lo, "127.0.0.1/24").ips[0].ip()),
         );
         // multicast bad
         assert_eq!(
-            find_eth0ish_ip_addr(&mut vec![mock_interface!(eth0, "224.0.1.5/24")]),
+            find_eth0ish_ip_addr(&mut vec![mock_interface!(eth0, "224.0.1.5/24")], false),
             None
         );
 
         // finds "wifi0"
         assert_eq!(
-            find_eth0ish_ip_addr(&mut vec![
-                mock_interface!(eth0, "224.0.1.5/24"),
-                mock_interface!(eth2, "192.168.137.1/8"),
-                mock_interface!(eth3, "10.0.75.1/8"),
-                mock_interface!(eth4, "172.22.140.113/4"),
-                mock_interface!(lo, "127.0.0.1/24"),
-                mock_interface!(wifi0, "192.168.1.184/8"),
-            ]),
+            find_eth0ish_ip_addr(
+                &mut vec![
+                    mock_interface!(eth0, "224.0.1.5/24"),
+                    mock_interface!(eth2, "192.168.137.1/8"),
+                    mock_interface!(eth3, "10.0.75.1/8"),
+                    mock_interface!(eth4, "172.22.140.113/4"),
+                    mock_interface!(lo, "127.0.0.1/24"),
+                    mock_interface!(wifi0, "192.168.1.184/8"),
+                ],
+                false
+            ),
             Some(mock_interface!(wifi0, "192.168.1.184/8").ips[0].ip())
         );
         // finds "wifi0" in the middle
         assert_eq!(
-            find_eth0ish_ip_addr(&mut vec![
-                mock_interface!(eth0, "224.0.1.5/24"),
-                mock_interface!(eth2, "192.168.137.1/8"),
-                mock_interface!(eth3, "10.0.75.1/8"),
-                mock_interface!(wifi0, "192.168.1.184/8"),
-                mock_interface!(eth4, "172.22.140.113/4"),
-                mock_interface!(lo, "127.0.0.1/24"),
-            ]),
+            find_eth0ish_ip_addr(
+                &mut vec![
+                    mock_interface!(eth0, "224.0.1.5/24"),
+                    mock_interface!(eth2, "192.168.137.1/8"),
+                    mock_interface!(eth3, "10.0.75.1/8"),
+                    mock_interface!(wifi0, "192.168.1.184/8"),
+                    mock_interface!(eth4, "172.22.140.113/4"),
+                    mock_interface!(lo, "127.0.0.1/24"),
+                ],
+                false
+            ),
             Some(mock_interface!(wifi0, "192.168.1.184/8").ips[0].ip())
         );
         // picks "eth2", is lowest valid "eth"
         assert_eq!(
-            find_eth0ish_ip_addr(&mut vec![
-                mock_interface!(eth0, "224.0.1.5/24"),
-                mock_interface!(eth2, "192.168.137.1/8"),
-                mock_interface!(eth3, "10.0.75.1/8"),
-                mock_interface!(eth4, "172.22.140.113/4"),
-                mock_interface!(lo, "127.0.0.1/24"),
-            ]),
+            find_eth0ish_ip_addr(
+                &mut vec![
+                    mock_interface!(eth0, "224.0.1.5/24"),
+                    mock_interface!(eth2, "192.168.137.1/8"),
+                    mock_interface!(eth3, "10.0.75.1/8"),
+                    mock_interface!(eth4, "172.22.140.113/4"),
+                    mock_interface!(lo, "127.0.0.1/24"),
+                ],
+                false
+            ),
             Some(mock_interface!(eth2, "192.168.137.1/8").ips[0].ip())
         );
     }


### PR DESCRIPTION
#### Problem
Random feature flag doing nothing

#### Summary of Changes
Remove it.  If/when we want an ipv6 address, the appropriate way to restore this is to add a command-line argument to the fullnode binary.  No conditional compilation.
 