### PR TITLE
Remove Vote Account ID from GenesisBlock

### DIFF
--- a/core/src/leader_schedule_utils.rs
+++ b/core/src/leader_schedule_utils.rs
@@ -101,14 +101,14 @@ pub fn num_ticks_left_in_slot(bank: &Bank, tick_height: u64) -> u64 {
 mod tests {
     use super::*;
     use crate::staking_utils;
-    use solana_sdk::genesis_block::{GenesisBlock, BOOTSTRAP_LEADER_TOKENS};
+    use solana_sdk::genesis_block::{GenesisBlock, BOOTSTRAP_LEADER_STAKE};
     use solana_sdk::signature::{Keypair, KeypairUtil};
 
     #[test]
     fn test_leader_schedule_via_bank() {
         let pubkey = Keypair::new().pubkey();
         let (genesis_block, _mint_keypair) =
-            GenesisBlock::new_with_leader(BOOTSTRAP_LEADER_TOKENS, pubkey, BOOTSTRAP_LEADER_TOKENS);
+            GenesisBlock::new_with_leader(BOOTSTRAP_LEADER_STAKE, pubkey, BOOTSTRAP_LEADER_STAKE);
         let bank = Bank::new(&genesis_block);
 
         let ids_and_stakes: Vec<_> = staking_utils::delegated_stakes(&bank).into_iter().collect();
@@ -125,8 +125,7 @@ mod tests {
     fn test_leader_scheduler1_basic() {
         let pubkey = Keypair::new().pubkey();
         let genesis_block =
-            GenesisBlock::new_with_leader(BOOTSTRAP_LEADER_TOKENS, pubkey, BOOTSTRAP_LEADER_TOKENS)
-                .0;
+            GenesisBlock::new_with_leader(BOOTSTRAP_LEADER_STAKE, pubkey, BOOTSTRAP_LEADER_STAKE).0;
         let bank = Bank::new(&genesis_block);
         assert_eq!(slot_leader(&bank), pubkey);
     }

--- a/core/src/staking_utils.rs
+++ b/core/src/staking_utils.rs
@@ -152,9 +152,9 @@ mod tests {
     #[test]
     fn test_bank_staked_nodes_at_epoch() {
         let pubkey = Keypair::new().pubkey();
-        let bootstrap_tokens = 3;
+        let bootstrap_stake = 2;
         let (genesis_block, _) =
-            GenesisBlock::new_with_leader(bootstrap_tokens, pubkey, bootstrap_tokens);
+            GenesisBlock::new_with_leader(bootstrap_stake, pubkey, bootstrap_stake);
         let bank = Bank::new(&genesis_block);
 
         // Epoch doesn't exist
@@ -162,7 +162,7 @@ mod tests {
         assert_eq!(vote_account_balances_at_epoch(&bank, 10), None);
 
         // First epoch has the bootstrap leader
-        expected.insert(genesis_block.bootstrap_leader_vote_account_id, 1);
+        expected.insert(genesis_block.bootstrap_leader_id, 2);
         let expected = Some(expected);
         assert_eq!(vote_account_balances_at_epoch(&bank, 0), expected);
 
@@ -199,10 +199,10 @@ mod tests {
         let bank = new_from_parent(&Arc::new(bank), epoch_slot_offset);
 
         let result: Vec<_> = epoch_stakes_and_lockouts(&bank, 0);
-        assert_eq!(result, vec![(1, None)]);
+        assert_eq!(result, vec![(2, None)]);
 
         let result: HashSet<_> = HashSet::from_iter(epoch_stakes_and_lockouts(&bank, epoch));
-        let expected: HashSet<_> = HashSet::from_iter(vec![(1, None), (499, None)]);
+        let expected: HashSet<_> = HashSet::from_iter(vec![(2, None), (499, None)]);
         assert_eq!(result, expected);
     }
 

--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -3,7 +3,7 @@
 use clap::{crate_version, value_t_or_exit, App, Arg};
 use solana::blocktree::create_new_ledger;
 use solana_sdk::genesis_block::GenesisBlock;
-use solana_sdk::signature::{read_keypair, Keypair, KeypairUtil};
+use solana_sdk::signature::{read_keypair, KeypairUtil};
 use std::error;
 
 /**
@@ -15,7 +15,7 @@ use std::error;
 //pub const BOOTSTRAP_LEADER_TOKENS: u64 = 3;
 // TODO: Until https://github.com/solana-labs/solana/issues/2355 is resolved the bootstrap leader
 // needs N tokens as its vote account gets re-created on every node restart, costing it tokens
-pub const BOOTSTRAP_LEADER_TOKENS: u64 = 1_000_000;
+pub const BOOTSTRAP_LEADER_STAKE: u64 = 1_000_000;
 
 fn main() -> Result<(), Box<dyn error::Error>> {
     let matches = App::new("solana-genesis")
@@ -66,14 +66,12 @@ fn main() -> Result<(), Box<dyn error::Error>> {
     let bootstrap_leader_keypair = read_keypair(bootstrap_leader_keypair_file)?;
     let mint_keypair = read_keypair(mint_keypair_file)?;
 
-    let bootstrap_leader_vote_account_keypair = Keypair::new();
     let (mut genesis_block, _mint_keypair) = GenesisBlock::new_with_leader(
         num_tokens,
         bootstrap_leader_keypair.pubkey(),
-        BOOTSTRAP_LEADER_TOKENS,
+        BOOTSTRAP_LEADER_STAKE,
     );
     genesis_block.mint_id = mint_keypair.pubkey();
-    genesis_block.bootstrap_leader_vote_account_id = bootstrap_leader_vote_account_keypair.pubkey();
 
     create_new_ledger(ledger_path, &genesis_block)?;
     Ok(())

--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -72,6 +72,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
         BOOTSTRAP_LEADER_STAKE,
     );
     genesis_block.mint_id = mint_keypair.pubkey();
+    genesis_block.link_vote_account = false;
 
     create_new_ledger(ledger_path, &genesis_block)?;
     Ok(())

--- a/sdk/src/genesis_block.rs
+++ b/sdk/src/genesis_block.rs
@@ -22,6 +22,9 @@ pub struct GenesisBlock {
     pub ticks_per_slot: u64,
     pub slots_per_epoch: u64,
     pub stakers_slot_offset: u64,
+    /// use the same account for the bootstrap_leader as well as its vote_account
+    /// Or Else, create a separate vote_account and set the leader as the delegate
+    pub link_vote_account: bool,
 }
 
 impl GenesisBlock {
@@ -46,6 +49,7 @@ impl GenesisBlock {
                 ticks_per_slot: DEFAULT_TICKS_PER_SLOT,
                 slots_per_epoch: DEFAULT_SLOTS_PER_EPOCH,
                 stakers_slot_offset: DEFAULT_SLOTS_PER_EPOCH,
+                link_vote_account: true,
             },
             mint_keypair,
         )

--- a/sdk/src/genesis_block.rs
+++ b/sdk/src/genesis_block.rs
@@ -22,8 +22,8 @@ pub struct GenesisBlock {
     pub ticks_per_slot: u64,
     pub slots_per_epoch: u64,
     pub stakers_slot_offset: u64,
-    /// use the same account for the bootstrap_leader as well as its vote_account
-    /// Or Else, create a separate vote_account and set the leader as the delegate
+    /// Use the same account for the bootstrap_leader as well as its vote_account
+    /// Else, create a separate vote_account and set the leader as the delegate
     pub link_vote_account: bool,
 }
 


### PR DESCRIPTION
#### Problem

`GenesisBlock` was setting up a temporary staking account for the bootstrap leader. This leader would sometimes go and create its own staking account further down the road resulting in two staking accounts. While not a problem by itself, it's unnecessary to setup two accounts, leader's account _and_ a staking account, when they can be one and the same

#### Summary of Changes

Deleted the `vote_account_id` from `GenesisBlock`. Bootstrap leader's staking account and identity are the same. 
