### PR TITLE
Make RPC exit API actually work, and use it in ci/localnet-sanity.sh

### DIFF
--- a/ci/localnet-sanity.sh
+++ b/ci/localnet-sanity.sh
@@ -79,9 +79,11 @@ nodes=(
   "multinode-demo/drone.sh"
   "multinode-demo/bootstrap-leader.sh \
     $maybeNoLeaderRotation \
+    --enable-rpc-exit \
     --init-complete-file init-complete-node1.log"
   "multinode-demo/fullnode.sh \
     $maybeNoLeaderRotation \
+    --enable-rpc-exit \
     --init-complete-file init-complete-node2.log \
     --rpc-port 18899"
 )
@@ -177,6 +179,24 @@ killNode() {
 }
 
 killNodes() {
+  [[ ${#pids[@]} -gt 0 ]] || return
+
+  # Try to use the RPC exit API to cleanly exit the first two nodes
+  # (dynamic nodes, -x, are just killed since their RPC port is not known)
+  echo "--- RPC exit"
+  for port in 8899 18899; do
+    (
+      set -x
+      curl --retry 5 --retry-delay 2 --retry-connrefused \
+        -X POST -H 'Content-Type: application/json' \
+        -d '{"jsonrpc":"2.0","id":1, "method":"fullnodeExit"}' \
+        http://localhost:$port
+    )
+  done
+
+  # Give the nodes a splash of time to cleanly exit before killing them
+  sleep 2
+
   echo "--- Killing nodes"
   for pid in "${pids[@]}"; do
     killNode "$pid"

--- a/core/src/fullnode.rs
+++ b/core/src/fullnode.rs
@@ -48,7 +48,6 @@ impl NodeServices {
 
     fn join(self) -> Result<()> {
         self.tpu.join()?;
-        //tvu will never stop unless exit is signaled
         self.tvu.join()?;
         Ok(())
     }
@@ -179,6 +178,7 @@ impl Fullnode {
                 IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)),
                 node.info.rpc_pubsub.port(),
             ),
+            &exit,
         );
 
         let gossip_service = GossipService::new(
@@ -296,9 +296,6 @@ impl Fullnode {
         if let Some(ref rpc_service) = self.rpc_service {
             rpc_service.exit();
         }
-        if let Some(ref rpc_pubsub_service) = self.rpc_pubsub_service {
-            rpc_pubsub_service.exit();
-        }
         self.node_services.exit();
     }
 
@@ -347,7 +344,6 @@ impl Service for Fullnode {
         self.rpc_working_bank_handle.join()?;
         self.gossip_service.join()?;
         self.node_services.join()?;
-        trace!("exit node_services!");
         Ok(())
     }
 }

--- a/multinode-demo/fullnode.sh
+++ b/multinode-demo/fullnode.sh
@@ -53,6 +53,9 @@ while [[ ${1:0:1} = - ]]; do
   elif [[ $1 = --blockstream ]]; then
     extra_fullnode_args+=("$1" "$2")
     shift 2
+  elif [[ $1 = --enable-rpc-exit ]]; then
+    extra_fullnode_args+=("$1")
+    shift
   elif [[ $1 = --init-complete-file ]]; then
     extra_fullnode_args+=("$1" "$2")
     shift 2

--- a/multinode-demo/fullnode.sh
+++ b/multinode-demo/fullnode.sh
@@ -38,12 +38,7 @@ if [[ $1 = -h ]]; then
 fi
 
 gossip_port=9000
-maybe_blockstream=
-maybe_public_address=
-maybe_init_complete_file=
-maybe_no_leader_rotation=
-maybe_no_signer=
-maybe_rpc_port=
+extra_fullnode_args=()
 self_setup=0
 
 while [[ ${1:0:1} = - ]]; do
@@ -56,22 +51,22 @@ while [[ ${1:0:1} = - ]]; do
     self_setup_label=$$
     shift
   elif [[ $1 = --blockstream ]]; then
-    maybe_blockstream="$1 $2"
+    extra_fullnode_args+=("$1" "$2")
     shift 2
   elif [[ $1 = --init-complete-file ]]; then
-    maybe_init_complete_file="$1 $2"
+    extra_fullnode_args+=("$1" "$2")
     shift 2
   elif [[ $1 = --no-leader-rotation ]]; then
-    maybe_no_leader_rotation=$1
+    extra_fullnode_args+=("$1")
     shift
   elif [[ $1 = --public-address ]]; then
-    maybe_public_address=$1
+    extra_fullnode_args+=("$1")
     shift
   elif [[ $1 = --no-signer ]]; then
-    maybe_no_signer=$1
+    extra_fullnode_args+=("$1")
     shift
   elif [[ $1 = --rpc-port ]]; then
-    maybe_rpc_port="$1 $2"
+    extra_fullnode_args+=("$1" "$2")
     shift 2
   else
     echo "Unknown argument: $1"
@@ -218,19 +213,13 @@ if [[ ! -d "$ledger_config_dir" ]]; then
 fi
 
 trap 'kill "$pid" && wait "$pid"' INT TERM
-# shellcheck disable=SC2086 # Don't want to double quote maybe_blockstream or maybe_init_complete_file or ...
 $program \
-  $maybe_blockstream \
-  $maybe_init_complete_file \
-  $maybe_no_leader_rotation \
-  $maybe_no_signer \
-  $maybe_rpc_port \
-  $maybe_public_address \
   --gossip-port "$gossip_port" \
   --identity "$fullnode_id_path" \
   --network "$leader_address" \
   --ledger "$ledger_config_dir" \
   --accounts "$accounts_config_dir" \
+  "${extra_fullnode_args[@]}" \
   > >($fullnode_logger) 2>&1 &
 pid=$!
 oom_score_adj "$pid" 1000


### PR DESCRIPTION
Be polite and use the `fullnodeExit` API to request that nodes exit in `ci/localnet-sanity.sh` before killing them.