### PR TITLE
Revert to more consistent naming

### DIFF
--- a/core/src/fullnode.rs
+++ b/core/src/fullnode.rs
@@ -377,7 +377,7 @@ pub fn make_active_set_entries(
     let voting_keypair = VotingKeypair::new_local(active_keypair);
     let vote_account_id = voting_keypair.pubkey();
 
-    let new_vote_account_tx = VoteTransaction::fund_staking_account(
+    let new_vote_account_tx = VoteTransaction::new_account(
         active_keypair,
         vote_account_id,
         *blockhash,

--- a/core/src/local_cluster.rs
+++ b/core/src/local_cluster.rs
@@ -155,7 +155,7 @@ impl LocalCluster {
     ) -> Result<()> {
         // Create the vote account if necessary
         if client.poll_get_balance(&vote_account).unwrap_or(0) == 0 {
-            let mut transaction = VoteTransaction::fund_staking_account(
+            let mut transaction = VoteTransaction::new_account(
                 from_account,
                 vote_account,
                 client.get_recent_blockhash(),

--- a/core/src/thin_client.rs
+++ b/core/src/thin_client.rs
@@ -606,13 +606,8 @@ mod tests {
         let vote_account_id = validator_vote_account_keypair.pubkey();
         let blockhash = client.get_recent_blockhash();
 
-        let transaction = VoteTransaction::fund_staking_account(
-            &validator_keypair,
-            vote_account_id,
-            blockhash,
-            1,
-            1,
-        );
+        let transaction =
+            VoteTransaction::new_account(&validator_keypair, vote_account_id, blockhash, 1, 1);
         let signature = client.transfer_signed(&transaction).unwrap();
         client.poll_for_signature(&signature).unwrap();
 

--- a/core/src/voting_keypair.rs
+++ b/core/src/voting_keypair.rs
@@ -110,13 +110,8 @@ pub mod tests {
         num_tokens: u64,
     ) {
         let blockhash = bank.last_blockhash();
-        let tx = VoteTransaction::fund_staking_account(
-            from_keypair,
-            *voting_pubkey,
-            blockhash,
-            num_tokens,
-            0,
-        );
+        let tx =
+            VoteTransaction::new_account(from_keypair, *voting_pubkey, blockhash, num_tokens, 0);
         bank.process_transaction(&tx).unwrap();
     }
 

--- a/fullnode/src/main.rs
+++ b/fullnode/src/main.rs
@@ -77,7 +77,7 @@ fn create_and_fund_vote_account(
             let blockhash = client.get_recent_blockhash();
             info!("create_and_fund_vote_account blockhash={:?}", blockhash);
             let transaction =
-                VoteTransaction::fund_staking_account(node_keypair, vote_account, blockhash, 1, 1);
+                VoteTransaction::new_account(node_keypair, vote_account, blockhash, 1, 1);
 
             match client.transfer_signed(&transaction) {
                 Ok(signature) => {

--- a/programs/rewards/tests/rewards.rs
+++ b/programs/rewards/tests/rewards.rs
@@ -35,8 +35,7 @@ impl<'a> RewardsBank<'a> {
         lamports: u64,
     ) -> Result<()> {
         let blockhash = self.bank.last_blockhash();
-        let tx =
-            VoteTransaction::fund_staking_account(from_keypair, vote_id, blockhash, lamports, 0);
+        let tx = VoteTransaction::new_account(from_keypair, vote_id, blockhash, lamports, 0);
         self.bank.process_transaction(&tx)
     }
 

--- a/programs/vote/src/lib.rs
+++ b/programs/vote/src/lib.rs
@@ -24,7 +24,9 @@ fn entrypoint(
 
     match deserialize(data).map_err(|_| ProgramError::InvalidUserdata)? {
         VoteInstruction::InitializeAccount => vote_state::initialize_account(keyed_accounts),
-        VoteInstruction::Delegate(delegate_id) => vote_state::delegate(keyed_accounts, delegate_id),
+        VoteInstruction::DelegateStake(delegate_id) => {
+            vote_state::delegate_stake(keyed_accounts, delegate_id)
+        }
         VoteInstruction::Vote(vote) => {
             debug!("{:?} by {}", vote, keyed_accounts[0].signer_key().unwrap());
             solana_metrics::submit(

--- a/programs/vote/src/lib.rs
+++ b/programs/vote/src/lib.rs
@@ -24,9 +24,7 @@ fn entrypoint(
 
     match deserialize(data).map_err(|_| ProgramError::InvalidUserdata)? {
         VoteInstruction::InitializeAccount => vote_state::initialize_account(keyed_accounts),
-        VoteInstruction::DelegateStake(delegate_id) => {
-            vote_state::delegate_stake(keyed_accounts, delegate_id)
-        }
+        VoteInstruction::Delegate(delegate_id) => vote_state::delegate(keyed_accounts, delegate_id),
         VoteInstruction::Vote(vote) => {
             debug!("{:?} by {}", vote, keyed_accounts[0].signer_key().unwrap());
             solana_metrics::submit(

--- a/programs/vote/tests/vote.rs
+++ b/programs/vote/tests/vote.rs
@@ -28,8 +28,7 @@ impl<'a> VoteBank<'a> {
         lamports: u64,
     ) -> Result<()> {
         let blockhash = self.bank.last_blockhash();
-        let tx =
-            VoteTransaction::fund_staking_account(from_keypair, vote_id, blockhash, lamports, 0);
+        let tx = VoteTransaction::new_account(from_keypair, vote_id, blockhash, lamports, 0);
         self.bank.process_transaction(&tx)
     }
 

--- a/programs/vote_api/src/vote_instruction.rs
+++ b/programs/vote_api/src/vote_instruction.rs
@@ -23,7 +23,7 @@ pub enum VoteInstruction {
     /// * Transaction::keys[1] - the new "vote account" to be associated with the delegate
     InitializeAccount,
     /// `Delegate` or `Assign` a vote account to a particular node
-    Delegate(Pubkey),
+    DelegateStake(Pubkey),
     Vote(Vote),
     /// Clear the credits in the vote account
     /// * Transaction::keys[0] - the "vote account"
@@ -34,10 +34,10 @@ impl VoteInstruction {
     pub fn new_clear_credits(vote_id: Pubkey) -> BuilderInstruction {
         BuilderInstruction::new(id(), &VoteInstruction::ClearCredits, vec![(vote_id, true)])
     }
-    pub fn new_delegate(vote_id: Pubkey, delegate_id: Pubkey) -> BuilderInstruction {
+    pub fn new_delegate_stake(vote_id: Pubkey, delegate_id: Pubkey) -> BuilderInstruction {
         BuilderInstruction::new(
             id(),
-            &VoteInstruction::Delegate(delegate_id),
+            &VoteInstruction::DelegateStake(delegate_id),
             vec![(vote_id, true)],
         )
     }

--- a/programs/vote_api/src/vote_instruction.rs
+++ b/programs/vote_api/src/vote_instruction.rs
@@ -22,8 +22,8 @@ pub enum VoteInstruction {
     /// * Transaction::keys[0] - the staker id that is also assumed to be the delegate by default
     /// * Transaction::keys[1] - the new "vote account" to be associated with the delegate
     InitializeAccount,
-    /// `Delegate` or `Assign` A staking account to a particular node
-    DelegateStake(Pubkey),
+    /// `Delegate` or `Assign` a vote account to a particular node
+    Delegate(Pubkey),
     Vote(Vote),
     /// Clear the credits in the vote account
     /// * Transaction::keys[0] - the "vote account"
@@ -34,10 +34,10 @@ impl VoteInstruction {
     pub fn new_clear_credits(vote_id: Pubkey) -> BuilderInstruction {
         BuilderInstruction::new(id(), &VoteInstruction::ClearCredits, vec![(vote_id, true)])
     }
-    pub fn new_delegate_stake(vote_id: Pubkey, delegate_id: Pubkey) -> BuilderInstruction {
+    pub fn new_delegate(vote_id: Pubkey, delegate_id: Pubkey) -> BuilderInstruction {
         BuilderInstruction::new(
             id(),
-            &VoteInstruction::DelegateStake(delegate_id),
+            &VoteInstruction::Delegate(delegate_id),
             vec![(vote_id, true)],
         )
     }

--- a/programs/vote_api/src/vote_state.rs
+++ b/programs/vote_api/src/vote_state.rs
@@ -147,7 +147,10 @@ impl VoteState {
     }
 }
 
-pub fn delegate_stake(keyed_accounts: &mut [KeyedAccount], node_id: Pubkey) -> Result<(), ProgramError> {
+pub fn delegate_stake(
+    keyed_accounts: &mut [KeyedAccount],
+    node_id: Pubkey,
+) -> Result<(), ProgramError> {
     if !check_id(&keyed_accounts[0].account.owner) {
         error!("account[0] is not assigned to the VOTE_PROGRAM");
         Err(ProgramError::InvalidArgument)?;

--- a/programs/vote_api/src/vote_state.rs
+++ b/programs/vote_api/src/vote_state.rs
@@ -147,7 +147,7 @@ impl VoteState {
     }
 }
 
-pub fn delegate(keyed_accounts: &mut [KeyedAccount], node_id: Pubkey) -> Result<(), ProgramError> {
+pub fn delegate_stake(keyed_accounts: &mut [KeyedAccount], node_id: Pubkey) -> Result<(), ProgramError> {
     if !check_id(&keyed_accounts[0].account.owner) {
         error!("account[0] is not assigned to the VOTE_PROGRAM");
         Err(ProgramError::InvalidArgument)?;

--- a/programs/vote_api/src/vote_state.rs
+++ b/programs/vote_api/src/vote_state.rs
@@ -147,10 +147,7 @@ impl VoteState {
     }
 }
 
-pub fn delegate_stake(
-    keyed_accounts: &mut [KeyedAccount],
-    node_id: Pubkey,
-) -> Result<(), ProgramError> {
+pub fn delegate(keyed_accounts: &mut [KeyedAccount], node_id: Pubkey) -> Result<(), ProgramError> {
     if !check_id(&keyed_accounts[0].account.owner) {
         error!("account[0] is not assigned to the VOTE_PROGRAM");
         Err(ProgramError::InvalidArgument)?;
@@ -173,7 +170,7 @@ pub fn delegate_stake(
     Ok(())
 }
 
-/// Initialize the vote_state for a staking account
+/// Initialize the vote_state for a vote account
 /// Assumes that the account is being init as part of a account creation or balance transfer and
 /// that the transaction must be signed by the staker's keys
 pub fn initialize_account(keyed_accounts: &mut [KeyedAccount]) -> Result<(), ProgramError> {
@@ -271,13 +268,13 @@ mod tests {
     use solana_sdk::signature::{Keypair, KeypairUtil};
 
     #[test]
-    fn test_initialize_staking_account() {
+    fn test_initialize_vote_account() {
         let staker_id = Keypair::new().pubkey();
         let mut staker_account = Account::new(100, 0, Pubkey::default());
         let mut bogus_staker_account = Account::new(100, 0, Pubkey::default());
 
-        let staking_account_id = Keypair::new().pubkey();
-        let mut staking_account = create_vote_account(100);
+        let vote_account_id = Keypair::new().pubkey();
+        let mut vote_account = create_vote_account(100);
 
         let bogus_account_id = Keypair::new().pubkey();
         let mut bogus_account = Account::new(100, 0, id());
@@ -297,7 +294,7 @@ mod tests {
         assert_eq!(res, Err(ProgramError::InvalidUserdata));
 
         //init should pass
-        keyed_accounts[1] = KeyedAccount::new(&staking_account_id, false, &mut staking_account);
+        keyed_accounts[1] = KeyedAccount::new(&vote_account_id, false, &mut vote_account);
         let res = initialize_account(&mut keyed_accounts);
         assert_eq!(res, Ok(()));
 

--- a/programs/vote_api/src/vote_transaction.rs
+++ b/programs/vote_api/src/vote_transaction.rs
@@ -61,7 +61,7 @@ impl VoteTransaction {
         fee: u64,
     ) -> Transaction {
         TransactionBuilder::new(fee)
-            .push(VoteInstruction::new_delegate(
+            .push(VoteInstruction::new_delegate_stake(
                 vote_keypair.pubkey(),
                 node_id,
             ))

--- a/programs/vote_api/src/vote_transaction.rs
+++ b/programs/vote_api/src/vote_transaction.rs
@@ -28,7 +28,7 @@ impl VoteTransaction {
     }
 
     /// Fund or create the staking account with tokens
-    pub fn fund_staking_account(
+    pub fn new_account(
         from_keypair: &Keypair,
         vote_account_id: Pubkey,
         recent_blockhash: Hash,
@@ -61,7 +61,7 @@ impl VoteTransaction {
         fee: u64,
     ) -> Transaction {
         TransactionBuilder::new(fee)
-            .push(VoteInstruction::new_delegate_stake(
+            .push(VoteInstruction::new_delegate(
                 vote_keypair.pubkey(),
                 node_id,
             ))

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -254,7 +254,7 @@ impl Bank {
 
         // Construct a vote account for the bootstrap_leader such that the leader_scheduler
         // will be forced to select it as the leader for height 0
-        let mut bootstrap_leader_staking_account = Account {
+        let mut bootstrap_leader_vote_account = Account {
             tokens: bootstrap_leader_stake,
             userdata: vec![0; VoteState::max_size() as usize],
             owner: solana_vote_api::id(),
@@ -264,13 +264,13 @@ impl Bank {
         let mut vote_state = VoteState::new(genesis_block.bootstrap_leader_id);
         vote_state.votes.push_back(Lockout::new(&Vote::new(0)));
         vote_state
-            .serialize(&mut bootstrap_leader_staking_account.userdata)
+            .serialize(&mut bootstrap_leader_vote_account.userdata)
             .unwrap();
 
         self.accounts().store_slow(
             self.accounts_id,
             &genesis_block.bootstrap_leader_vote_account_id,
-            &bootstrap_leader_staking_account,
+            &bootstrap_leader_vote_account,
         );
 
         self.blockhash_queue


### PR DESCRIPTION
#### Problem

Reverting name updates from Vote to Stake. Incremental name updates lead to more confusion.

#### Summary of Changes

Reverted some of the names so that VoteProgram is in a consistent state. Will need more wide sweeping changes to take VoteProgram to StakeProgram or something else in a single PR.  
