### PR TITLE
Boot token and storage modules from the SDK

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1994,6 +1994,7 @@ dependencies = [
  "solana-netutil 0.12.0",
  "solana-runtime 0.12.0",
  "solana-sdk 0.12.0",
+ "solana-storage-api 0.12.0",
  "solana-vote-api 0.12.0",
  "solana-vote-program 0.12.0",
  "solana-vote-signer 0.12.0",
@@ -2258,6 +2259,7 @@ dependencies = [
  "solana-logger 0.12.0",
  "solana-metrics 0.12.0",
  "solana-sdk 0.12.0",
+ "solana-storage-api 0.12.0",
  "solana-system-program 0.12.0",
  "solana-token-api 0.12.0",
  "solana-vote-api 0.12.0",
@@ -2284,6 +2286,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-storage-api"
+version = "0.12.0"
+dependencies = [
+ "bincode 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-sdk 0.12.0",
+]
+
+[[package]]
 name = "solana-storage-program"
 version = "0.12.0"
 dependencies = [
@@ -2294,6 +2306,7 @@ dependencies = [
  "solana-logger 0.12.0",
  "solana-runtime 0.12.0",
  "solana-sdk 0.12.0",
+ "solana-storage-api 0.12.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2259,6 +2259,7 @@ dependencies = [
  "solana-metrics 0.12.0",
  "solana-sdk 0.12.0",
  "solana-system-program 0.12.0",
+ "solana-token-api 0.12.0",
  "solana-vote-api 0.12.0",
 ]
 
@@ -2302,6 +2303,16 @@ dependencies = [
  "bincode 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-sdk 0.12.0",
+]
+
+[[package]]
+name = "solana-token-api"
+version = "0.12.0"
+dependencies = [
+ "bincode 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-sdk 0.12.0",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,7 @@ members = [
     "programs/budget",
     "programs/budget_api",
     "programs/token",
+    "programs/token_api",
     "programs/failure",
     "programs/noop",
     "programs/rewards",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,7 @@ members = [
     "programs/rewards",
     "programs/rewards_api",
     "programs/storage",
+    "programs/storage_api",
     "programs/system",
     "programs/vote",
     "programs/vote_api",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -50,6 +50,7 @@ solana-metrics = { path = "../metrics", version = "0.12.0" }
 solana-netutil = { path = "../netutil", version = "0.12.0" }
 solana-runtime = { path = "../runtime", version = "0.12.0" }
 solana-sdk = { path = "../sdk", version = "0.12.0" }
+solana-storage-api = { path = "../programs/storage_api", version = "0.12.0" }
 solana-vote-api = { path = "../programs/vote_api", version = "0.12.0" }
 solana-vote-signer = { path = "../vote-signer", version = "0.12.0" }
 sys-info = "0.5.6"

--- a/core/src/replicator.rs
+++ b/core/src/replicator.rs
@@ -19,7 +19,7 @@ use solana_drone::drone::{request_airdrop_transaction, DRONE_PORT};
 use solana_sdk::genesis_block::GenesisBlock;
 use solana_sdk::hash::{Hash, Hasher};
 use solana_sdk::signature::{Keypair, KeypairUtil, Signature};
-use solana_sdk::storage_program::StorageTransaction;
+use solana_storage_api::StorageTransaction;
 use std::fs::File;
 use std::io;
 use std::io::BufReader;

--- a/core/src/storage_stage.rs
+++ b/core/src/storage_stage.rs
@@ -16,8 +16,8 @@ use rand_chacha::ChaChaRng;
 use solana_sdk::hash::Hash;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::{Keypair, Signature};
-use solana_sdk::storage_program::{self, StorageProgram, StorageTransaction};
 use solana_sdk::transaction::Transaction;
+use solana_storage_api::{self, StorageProgram, StorageTransaction};
 use std::collections::HashSet;
 use std::io;
 use std::mem::size_of;
@@ -377,7 +377,7 @@ impl StorageStage {
                             .copy_from_slice(tx.signatures[0].as_ref());
                         *current_key_idx += size_of::<Signature>();
                         *current_key_idx %= storage_keys.len();
-                    } else if storage_program::check_id(&program_id) {
+                    } else if solana_storage_api::check_id(&program_id) {
                         match deserialize(&tx.instructions[i].userdata) {
                             Ok(StorageProgram::SubmitMiningProof {
                                 entry_height: proof_entry_height,

--- a/programs/storage/Cargo.toml
+++ b/programs/storage/Cargo.toml
@@ -15,6 +15,7 @@ serde = "1.0.89"
 serde_derive = "1.0.89"
 solana-logger = { path = "../../logger", version = "0.12.0" }
 solana-sdk = { path = "../../sdk", version = "0.12.0" }
+solana-storage-api = { path = "../storage_api", version = "0.12.0" }
 
 [dev-dependencies]
 solana-runtime = { path = "../../runtime", version = "0.12.0" }

--- a/programs/storage/src/lib.rs
+++ b/programs/storage/src/lib.rs
@@ -9,7 +9,7 @@ use solana_sdk::account::KeyedAccount;
 use solana_sdk::native_program::ProgramError;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::solana_entrypoint;
-use solana_sdk::storage_program::*;
+use solana_storage_api::*;
 
 pub const TOTAL_VALIDATOR_REWARDS: u64 = 1000;
 pub const TOTAL_REPLICATOR_REWARDS: u64 = 1000;
@@ -180,9 +180,8 @@ mod test {
     use solana_sdk::account::{create_keyed_accounts, Account};
     use solana_sdk::hash::Hash;
     use solana_sdk::signature::{Keypair, KeypairUtil, Signature};
-    use solana_sdk::storage_program::ProofStatus;
-    use solana_sdk::storage_program::StorageTransaction;
     use solana_sdk::transaction::{Instruction, Transaction};
+    use solana_storage_api::{ProofStatus, StorageTransaction};
 
     fn test_transaction(
         tx: &Transaction,

--- a/programs/storage/tests/storage.rs
+++ b/programs/storage/tests/storage.rs
@@ -5,16 +5,15 @@ use solana_sdk::genesis_block::GenesisBlock;
 use solana_sdk::hash::{hash, Hash};
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::{Keypair, KeypairUtil};
-use solana_sdk::storage_program;
-use solana_sdk::storage_program::{StorageTransaction, ENTRIES_PER_SEGMENT};
 use solana_sdk::system_transaction::SystemTransaction;
+use solana_storage_api::{StorageTransaction, ENTRIES_PER_SEGMENT};
 
 fn get_storage_entry_height(bank: &Bank, account: Pubkey) -> u64 {
     match bank.get_account(&account) {
         Some(storage_system_account) => {
             let state = deserialize(&storage_system_account.userdata);
             if let Ok(state) = state {
-                let state: storage_program::StorageProgramState = state;
+                let state: solana_storage_api::StorageProgramState = state;
                 return state.entry_height;
             }
         }
@@ -29,7 +28,7 @@ fn get_storage_blockhash(bank: &Bank, account: Pubkey) -> Hash {
     if let Some(storage_system_account) = bank.get_account(&account) {
         let state = deserialize(&storage_system_account.userdata);
         if let Ok(state) = state {
-            let state: storage_program::StorageProgramState = state;
+            let state: solana_storage_api::StorageProgramState = state;
             return state.hash;
         }
     }
@@ -63,7 +62,7 @@ fn test_bank_storage() {
         blockhash,
         1,
         4 * 1024,
-        storage_program::id(),
+        solana_storage_api::id(),
         0,
     );
 

--- a/programs/storage_api/Cargo.toml
+++ b/programs/storage_api/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "solana-storage-api"
+version = "0.12.0"
+description = "Solana Storage program API"
+authors = ["Solana Maintainers <maintainers@solana.com>"]
+repository = "https://github.com/solana-labs/solana"
+license = "Apache-2.0"
+homepage = "https://solana.com/"
+edition = "2018"
+
+[dependencies]
+bincode = "1.1.2"
+serde = "1.0.89"
+serde_derive = "1.0.89"
+solana-sdk = { path = "../../sdk", version = "0.12.0" }
+
+[lib]
+name = "solana_storage_api"
+crate-type = ["lib"]

--- a/programs/storage_api/src/lib.rs
+++ b/programs/storage_api/src/lib.rs
@@ -1,7 +1,8 @@
-use crate::hash::Hash;
-use crate::pubkey::Pubkey;
-use crate::signature::{Keypair, Signature};
-use crate::transaction::Transaction;
+use serde_derive::{Deserialize, Serialize};
+use solana_sdk::hash::Hash;
+use solana_sdk::pubkey::Pubkey;
+use solana_sdk::signature::{Keypair, Signature};
+use solana_sdk::transaction::Transaction;
 
 pub const ENTRIES_PER_SEGMENT: u64 = 16;
 

--- a/programs/token_api/Cargo.toml
+++ b/programs/token_api/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "solana-token-api"
+version = "0.12.0"
+description = "Solana Token API"
+authors = ["Solana Maintainers <maintainers@solana.com>"]
+repository = "https://github.com/solana-labs/solana"
+license = "Apache-2.0"
+homepage = "https://solana.com/"
+edition = "2018"
+
+[dependencies]
+bincode = "1.1.2"
+serde = "1.0.89"
+serde_derive = "1.0.89"
+solana-sdk = { path = "../../sdk", version = "0.12.0" }
+
+[lib]
+name = "solana_token_api"
+crate-type = ["lib"]

--- a/programs/token_api/src/lib.rs
+++ b/programs/token_api/src/lib.rs
@@ -1,5 +1,5 @@
 //! An ERC20-like Token
-use crate::pubkey::Pubkey;
+use solana_sdk::pubkey::Pubkey;
 
 const TOKEN_PROGRAM_ID: [u8; 32] = [
     131, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -26,6 +26,7 @@ solana-logger = { path = "../logger", version = "0.12.0" }
 solana-metrics = { path = "../metrics", version = "0.12.0" }
 solana-sdk = { path = "../sdk", version = "0.12.0" }
 solana-system-program = { path = "../programs/system", version = "0.12.0" }
+solana-storage-api = { path = "../programs/storage_api", version = "0.12.0" }
 solana-token-api = { path = "../programs/token_api", version = "0.12.0" }
 solana-vote-api = { path = "../programs/vote_api", version = "0.12.0" }
 

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -26,6 +26,7 @@ solana-logger = { path = "../logger", version = "0.12.0" }
 solana-metrics = { path = "../metrics", version = "0.12.0" }
 solana-sdk = { path = "../sdk", version = "0.12.0" }
 solana-system-program = { path = "../programs/system", version = "0.12.0" }
+solana-token-api = { path = "../programs/token_api", version = "0.12.0" }
 solana-vote-api = { path = "../programs/vote_api", version = "0.12.0" }
 
 [lib]

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -10,7 +10,6 @@ use crate::status_cache::StatusCache;
 use bincode::serialize;
 use hashbrown::HashMap;
 use log::*;
-use solana_budget_api;
 use solana_metrics::counter::Counter;
 use solana_sdk::account::Account;
 use solana_sdk::bpf_loader;
@@ -24,9 +23,7 @@ use solana_sdk::storage_program;
 use solana_sdk::system_program;
 use solana_sdk::system_transaction::SystemTransaction;
 use solana_sdk::timing::{duration_as_us, MAX_RECENT_BLOCKHASHES, NUM_TICKS_PER_SECOND};
-use solana_sdk::token_program;
 use solana_sdk::transaction::Transaction;
-use solana_vote_api;
 use solana_vote_api::vote_instruction::Vote;
 use solana_vote_api::vote_state::{Lockout, VoteState};
 use std::result;
@@ -299,7 +296,7 @@ impl Bank {
         self.add_native_program("solana_storage_program", &storage_program::id());
         self.add_native_program("solana_bpf_loader", &bpf_loader::id());
         self.add_native_program("solana_budget_program", &solana_budget_api::id());
-        self.add_native_program("solana_token_program", &token_program::id());
+        self.add_native_program("solana_token_program", &solana_token_api::id());
     }
 
     /// Return the last block hash registered.
@@ -1275,7 +1272,7 @@ mod tests {
         assert_eq!(bpf_loader::id(), bpf);
         assert_eq!(solana_budget_api::id(), budget);
         assert_eq!(storage_program::id(), storage);
-        assert_eq!(token_program::id(), token);
+        assert_eq!(solana_token_api::id(), token);
         assert_eq!(solana_vote_api::id(), vote);
     }
 
@@ -1288,7 +1285,7 @@ mod tests {
             bpf_loader::id(),
             solana_budget_api::id(),
             storage_program::id(),
-            token_program::id(),
+            solana_token_api::id(),
             solana_vote_api::id(),
         ];
         assert!(ids.into_iter().all(move |id| unique.insert(id)));

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -19,7 +19,6 @@ use solana_sdk::native_loader;
 use solana_sdk::native_program::ProgramError;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::{Keypair, Signature};
-use solana_sdk::storage_program;
 use solana_sdk::system_program;
 use solana_sdk::system_transaction::SystemTransaction;
 use solana_sdk::timing::{duration_as_us, MAX_RECENT_BLOCKHASHES, NUM_TICKS_PER_SECOND};
@@ -293,7 +292,7 @@ impl Bank {
     fn add_builtin_programs(&self) {
         self.add_native_program("solana_system_program", &system_program::id());
         self.add_native_program("solana_vote_program", &solana_vote_api::id());
-        self.add_native_program("solana_storage_program", &storage_program::id());
+        self.add_native_program("solana_storage_program", &solana_storage_api::id());
         self.add_native_program("solana_bpf_loader", &bpf_loader::id());
         self.add_native_program("solana_budget_program", &solana_budget_api::id());
         self.add_native_program("solana_token_program", &solana_token_api::id());
@@ -1271,7 +1270,7 @@ mod tests {
         assert_eq!(native_loader::id(), native);
         assert_eq!(bpf_loader::id(), bpf);
         assert_eq!(solana_budget_api::id(), budget);
-        assert_eq!(storage_program::id(), storage);
+        assert_eq!(solana_storage_api::id(), storage);
         assert_eq!(solana_token_api::id(), token);
         assert_eq!(solana_vote_api::id(), vote);
     }
@@ -1284,7 +1283,7 @@ mod tests {
             native_loader::id(),
             bpf_loader::id(),
             solana_budget_api::id(),
-            storage_program::id(),
+            solana_storage_api::id(),
             solana_token_api::id(),
             solana_vote_api::id(),
         ];

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -10,7 +10,6 @@ pub mod packet;
 pub mod pubkey;
 pub mod shortvec;
 pub mod signature;
-pub mod storage_program;
 pub mod system_instruction;
 pub mod system_program;
 pub mod system_transaction;

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -15,7 +15,6 @@ pub mod system_instruction;
 pub mod system_program;
 pub mod system_transaction;
 pub mod timing;
-pub mod token_program;
 pub mod transaction;
 pub mod transaction_builder;
 


### PR DESCRIPTION
#### Problem

The SDK should only have modules needed to develop programs.

#### Summary of Changes

Move token_program.rs and storage_program.rs into new *_api crates.
