### PR TITLE
Clean up stage exit handling

### DIFF
--- a/bench-streamer/src/main.rs
+++ b/bench-streamer/src/main.rs
@@ -81,12 +81,7 @@ fn main() -> Result<()> {
 
         let (s_reader, r_reader) = channel();
         read_channels.push(r_reader);
-        read_threads.push(receiver(
-            Arc::new(read),
-            exit.clone(),
-            s_reader,
-            "bench-streamer",
-        ));
+        read_threads.push(receiver(Arc::new(read), &exit, s_reader, "bench-streamer"));
     }
 
     let t_producer1 = producer(&addr, exit.clone());

--- a/core/src/blockstream_service.rs
+++ b/core/src/blockstream_service.rs
@@ -27,9 +27,10 @@ impl BlockstreamService {
         slot_full_receiver: Receiver<(u64, Pubkey)>,
         blocktree: Arc<Blocktree>,
         blockstream_socket: String,
-        exit: Arc<AtomicBool>,
+        exit: &Arc<AtomicBool>,
     ) -> Self {
         let mut blockstream = Blockstream::new(blockstream_socket);
+        let exit = exit.clone();
         let t_blockstream = Builder::new()
             .name("solana-blockstream".to_string())
             .spawn(move || loop {

--- a/core/src/broadcast_stage.rs
+++ b/core/src/broadcast_stage.rs
@@ -224,14 +224,15 @@ impl BroadcastStage {
         sock: UdpSocket,
         cluster_info: Arc<RwLock<ClusterInfo>>,
         receiver: Receiver<WorkingBankEntries>,
-        exit_sender: Arc<AtomicBool>,
+        exit_sender: &Arc<AtomicBool>,
         blocktree: &Arc<Blocktree>,
     ) -> Self {
         let blocktree = blocktree.clone();
+        let exit_sender = exit_sender.clone();
         let thread_hdl = Builder::new()
             .name("solana-broadcaster".to_string())
             .spawn(move || {
-                let _exit = Finalizer::new(exit_sender);
+                let _finalizer = Finalizer::new(exit_sender);
                 Self::run(&sock, &cluster_info, &receiver, &blocktree)
             })
             .unwrap();
@@ -299,7 +300,7 @@ mod test {
             leader_info.sockets.broadcast,
             cluster_info,
             entry_receiver,
-            exit_sender,
+            &exit_sender,
             &blocktree,
         );
 

--- a/core/src/cluster_info.rs
+++ b/core/src/cluster_info.rs
@@ -868,8 +868,9 @@ impl ClusterInfo {
         obj: Arc<RwLock<Self>>,
         bank_forks: Option<Arc<RwLock<BankForks>>>,
         blob_sender: BlobSender,
-        exit: Arc<AtomicBool>,
+        exit: &Arc<AtomicBool>,
     ) -> JoinHandle<()> {
+        let exit = exit.clone();
         Builder::new()
             .name("solana-gossip".to_string())
             .spawn(move || {
@@ -1243,8 +1244,9 @@ impl ClusterInfo {
         blocktree: Option<Arc<Blocktree>>,
         requests_receiver: BlobReceiver,
         response_sender: BlobSender,
-        exit: Arc<AtomicBool>,
+        exit: &Arc<AtomicBool>,
     ) -> JoinHandle<()> {
+        let exit = exit.clone();
         Builder::new()
             .name("solana-listen".to_string())
             .spawn(move || loop {

--- a/core/src/db_window.rs
+++ b/core/src/db_window.rs
@@ -134,12 +134,7 @@ mod test {
         let send = UdpSocket::bind("127.0.0.1:0").expect("bind");
         let exit = Arc::new(AtomicBool::new(false));
         let (s_reader, r_reader) = channel();
-        let t_receiver = receiver(
-            Arc::new(read),
-            exit.clone(),
-            s_reader,
-            "window-streamer-test",
-        );
+        let t_receiver = receiver(Arc::new(read), &exit, s_reader, "window-streamer-test");
         let t_responder = {
             let (s_responder, r_responder) = channel();
             let t_responder = responder("streamer_send_test", Arc::new(send), r_responder);

--- a/core/src/fetch_stage.rs
+++ b/core/src/fetch_stage.rs
@@ -33,7 +33,7 @@ impl FetchStage {
     ) -> Self {
         let thread_hdls: Vec<_> = sockets
             .into_iter()
-            .map(|socket| streamer::receiver(socket, exit.clone(), sender.clone(), "fetch-stage"))
+            .map(|socket| streamer::receiver(socket, &exit, sender.clone(), "fetch-stage"))
             .collect();
 
         Self { thread_hdls }

--- a/core/src/fetch_stage.rs
+++ b/core/src/fetch_stage.rs
@@ -14,13 +14,13 @@ pub struct FetchStage {
 
 impl FetchStage {
     #[allow(clippy::new_ret_no_self)]
-    pub fn new(sockets: Vec<UdpSocket>, exit: Arc<AtomicBool>) -> (Self, PacketReceiver) {
+    pub fn new(sockets: Vec<UdpSocket>, exit: &Arc<AtomicBool>) -> (Self, PacketReceiver) {
         let (sender, receiver) = channel();
         (Self::new_with_sender(sockets, exit, &sender), receiver)
     }
     pub fn new_with_sender(
         sockets: Vec<UdpSocket>,
-        exit: Arc<AtomicBool>,
+        exit: &Arc<AtomicBool>,
         sender: &PacketSender,
     ) -> Self {
         let tx_sockets = sockets.into_iter().map(Arc::new).collect();
@@ -28,7 +28,7 @@ impl FetchStage {
     }
     fn new_multi_socket(
         sockets: Vec<Arc<UdpSocket>>,
-        exit: Arc<AtomicBool>,
+        exit: &Arc<AtomicBool>,
         sender: &PacketSender,
     ) -> Self {
         let thread_hdls: Vec<_> = sockets

--- a/core/src/fetch_stage.rs
+++ b/core/src/fetch_stage.rs
@@ -3,13 +3,12 @@
 use crate::service::Service;
 use crate::streamer::{self, PacketReceiver, PacketSender};
 use std::net::UdpSocket;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::AtomicBool;
 use std::sync::mpsc::channel;
 use std::sync::Arc;
 use std::thread::{self, JoinHandle};
 
 pub struct FetchStage {
-    exit: Arc<AtomicBool>,
     thread_hdls: Vec<JoinHandle<()>>,
 }
 
@@ -37,11 +36,7 @@ impl FetchStage {
             .map(|socket| streamer::receiver(socket, exit.clone(), sender.clone(), "fetch-stage"))
             .collect();
 
-        Self { exit, thread_hdls }
-    }
-
-    pub fn close(&self) {
-        self.exit.store(true, Ordering::Relaxed);
+        Self { thread_hdls }
     }
 }
 

--- a/core/src/fullnode.rs
+++ b/core/src/fullnode.rs
@@ -168,7 +168,7 @@ impl Fullnode {
             drone_addr,
             storage_state.clone(),
             config.rpc_config.clone(),
-            exit.clone(),
+            &exit,
         );
 
         let subscriptions = Arc::new(RpcSubscriptions::default());
@@ -293,9 +293,6 @@ impl Fullnode {
         // which is the sole initiator of rotations.
         self.poh_recorder.lock().unwrap().clear_bank();
         self.poh_service.exit();
-        if let Some(ref rpc_service) = self.rpc_service {
-            rpc_service.exit();
-        }
         self.node_services.exit();
     }
 

--- a/core/src/fullnode.rs
+++ b/core/src/fullnode.rs
@@ -264,6 +264,7 @@ impl Fullnode {
     // Used for notifying many nodes in parallel to exit
     pub fn exit(&self) {
         self.exit.store(true, Ordering::Relaxed);
+
         // Need to force the poh_recorder to drop the WorkingBank,
         // which contains the channel to BroadcastStage. This should be
         // sufficient as long as no other rotations are happening that
@@ -272,7 +273,6 @@ impl Fullnode {
         // in motion because exit()/close() are only called by the run() loop
         // which is the sole initiator of rotations.
         self.poh_recorder.lock().unwrap().clear_bank();
-        self.poh_service.exit();
     }
 
     pub fn close(self) -> Result<()> {

--- a/core/src/gossip_service.rs
+++ b/core/src/gossip_service.rs
@@ -34,8 +34,7 @@ impl GossipService {
             &cluster_info.read().unwrap().my_data().id,
             gossip_socket.local_addr().unwrap()
         );
-        let t_receiver =
-            streamer::blob_receiver(gossip_socket.clone(), exit.clone(), request_sender);
+        let t_receiver = streamer::blob_receiver(gossip_socket.clone(), &exit, request_sender);
         let (response_sender, response_receiver) = channel();
         let t_responder = streamer::responder("gossip", gossip_socket, response_receiver);
         let t_listen = ClusterInfo::listen(
@@ -43,14 +42,9 @@ impl GossipService {
             blocktree,
             request_receiver,
             response_sender.clone(),
-            exit.clone(),
+            exit,
         );
-        let t_gossip = ClusterInfo::gossip(
-            cluster_info.clone(),
-            bank_forks,
-            response_sender,
-            exit.clone(),
-        );
+        let t_gossip = ClusterInfo::gossip(cluster_info.clone(), bank_forks, response_sender, exit);
         let thread_hdls = vec![t_receiver, t_responder, t_listen, t_gossip];
         Self { thread_hdls }
     }

--- a/core/src/repair_service.rs
+++ b/core/src/repair_service.rs
@@ -45,7 +45,7 @@ pub struct RepairService {
 impl RepairService {
     fn run(
         blocktree: &Arc<Blocktree>,
-        exit: &Arc<AtomicBool>,
+        exit: Arc<AtomicBool>,
         repair_socket: &Arc<UdpSocket>,
         cluster_info: &Arc<RwLock<ClusterInfo>>,
     ) {
@@ -112,13 +112,14 @@ impl RepairService {
 
     pub fn new(
         blocktree: Arc<Blocktree>,
-        exit: Arc<AtomicBool>,
+        exit: &Arc<AtomicBool>,
         repair_socket: Arc<UdpSocket>,
         cluster_info: Arc<RwLock<ClusterInfo>>,
     ) -> Self {
+        let exit = exit.clone();
         let t_repair = Builder::new()
             .name("solana-repair-service".to_string())
-            .spawn(move || Self::run(&blocktree, &exit, &repair_socket, &cluster_info))
+            .spawn(move || Self::run(&blocktree, exit, &repair_socket, &cluster_info))
             .unwrap();
 
         RepairService { t_repair }

--- a/core/src/replicator.rs
+++ b/core/src/replicator.rs
@@ -171,8 +171,7 @@ impl Replicator {
             node.sockets.tvu.into_iter().map(Arc::new).collect();
         blob_sockets.push(repair_socket.clone());
         let (blob_fetch_sender, blob_fetch_receiver) = channel();
-        let fetch_stage =
-            BlobFetchStage::new_multi_socket(blob_sockets, &blob_fetch_sender, exit.clone());
+        let fetch_stage = BlobFetchStage::new_multi_socket(blob_sockets, &blob_fetch_sender, &exit);
 
         // todo: pull blobs off the retransmit_receiver and recycle them?
         let (retransmit_sender, retransmit_receiver) = channel();
@@ -183,7 +182,7 @@ impl Replicator {
             blob_fetch_receiver,
             retransmit_sender,
             repair_socket,
-            exit.clone(),
+            &exit,
         );
 
         info!("window created, waiting for ledger download done");

--- a/core/src/retransmit_stage.rs
+++ b/core/src/retransmit_stage.rs
@@ -113,7 +113,7 @@ impl RetransmitStage {
         retransmit_socket: Arc<UdpSocket>,
         repair_socket: Arc<UdpSocket>,
         fetch_stage_receiver: BlobReceiver,
-        exit: Arc<AtomicBool>,
+        exit: &Arc<AtomicBool>,
     ) -> Self {
         let (retransmit_sender, retransmit_receiver) = channel();
 

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -78,9 +78,9 @@ impl Tpu {
 
         let (packet_sender, packet_receiver) = channel();
         let fetch_stage =
-            FetchStage::new_with_sender(transactions_sockets, exit.clone(), &packet_sender.clone());
+            FetchStage::new_with_sender(transactions_sockets, &exit, &packet_sender.clone());
         let cluster_info_vote_listener =
-            ClusterInfoVoteListener::new(exit.clone(), cluster_info.clone(), packet_sender);
+            ClusterInfoVoteListener::new(&exit, cluster_info.clone(), packet_sender);
 
         let (sigverify_stage, verified_receiver) =
             SigVerifyStage::new(packet_receiver, sigverify_disabled);
@@ -91,7 +91,7 @@ impl Tpu {
             broadcast_socket,
             cluster_info.clone(),
             entry_receiver,
-            exit.clone(),
+            &exit,
             blocktree,
         );
 

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -12,7 +12,7 @@ use crate::service::Service;
 use crate::sigverify_stage::SigVerifyStage;
 use solana_sdk::pubkey::Pubkey;
 use std::net::UdpSocket;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::AtomicBool;
 use std::sync::mpsc::{channel, Receiver};
 use std::sync::{Arc, Mutex, RwLock};
 use std::thread;
@@ -42,11 +42,7 @@ impl LeaderServices {
         }
     }
 
-    pub fn exit(&self) {
-        self.fetch_stage.close();
-    }
-
-    fn join(self) -> thread::Result<()> {
+    pub fn join(self) -> thread::Result<()> {
         let mut results = vec![];
         results.push(self.fetch_stage.join());
         results.push(self.sigverify_stage.join());
@@ -59,16 +55,10 @@ impl LeaderServices {
         let _ = broadcast_result?;
         Ok(())
     }
-
-    pub fn close(self) -> thread::Result<()> {
-        self.exit();
-        self.join()
-    }
 }
 
 pub struct Tpu {
     leader_services: LeaderServices,
-    exit: Arc<AtomicBool>,
     pub id: Pubkey,
 }
 
@@ -114,22 +104,8 @@ impl Tpu {
         );
         Self {
             leader_services,
-            exit: exit.clone(),
             id,
         }
-    }
-
-    pub fn exit(&self) {
-        self.exit.store(true, Ordering::Relaxed);
-    }
-
-    pub fn is_exited(&self) -> bool {
-        self.exit.load(Ordering::Relaxed)
-    }
-
-    pub fn close(self) -> thread::Result<()> {
-        self.exit();
-        self.join()
     }
 }
 

--- a/core/src/window.rs
+++ b/core/src/window.rs
@@ -214,12 +214,7 @@ mod test {
         let send = UdpSocket::bind("127.0.0.1:0").expect("bind");
         let exit = Arc::new(AtomicBool::new(false));
         let (s_reader, r_reader) = channel();
-        let t_receiver = receiver(
-            Arc::new(read),
-            exit.clone(),
-            s_reader,
-            "window-streamer-test",
-        );
+        let t_receiver = receiver(Arc::new(read), &exit, s_reader, "window-streamer-test");
         let t_responder = {
             let (s_responder, r_responder) = channel();
             let t_responder = responder("streamer_send_test", Arc::new(send), r_responder);

--- a/tests/replicator.rs
+++ b/tests/replicator.rs
@@ -156,7 +156,7 @@ fn test_replicator_startup_basic() {
         let exit = Arc::new(AtomicBool::new(false));
         let (s_reader, r_reader) = channel();
         let repair_socket = Arc::new(tn.sockets.repair);
-        let t_receiver = blob_receiver(repair_socket.clone(), exit.clone(), s_reader);
+        let t_receiver = blob_receiver(repair_socket.clone(), &exit, s_reader);
 
         info!(
             "Sending repair requests from: {} to: {}",

--- a/tests/tvu.rs
+++ b/tests/tvu.rs
@@ -184,9 +184,9 @@ fn test_replay() {
     let bob_balance = bank.get_balance(&bob_keypair.pubkey());
     assert_eq!(bob_balance, starting_balance - alice_ref_balance);
 
-    poh_service.close().expect("close");
-    tvu.close().expect("close");
     exit.store(true, Ordering::Relaxed);
+    poh_service.close().expect("close");
+    tvu.join().expect("join");
     dr_l.join().expect("join");
     dr_2.join().expect("join");
     dr_1.join().expect("join");


### PR DESCRIPTION
* Uniformly pass the exit signal as a reference, defer cloning until actually needed (ie, a new thread is spawned)
* Remove a lot of the `exit()'/`close()` function copy pasta.   Most stages don't need 2-3 ways to exit
* Scrapped away a bit of dead code as a result of the previous two items