### PR TITLE
Remove usage of unsafe while serialize / deserialize of Account

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2244,6 +2244,7 @@ version = "0.12.0"
 dependencies = [
  "bincode 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bv 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "hashbrown 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.49 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2018"
 [dependencies]
 bincode = "1.1.2"
 bv = { version = "0.11.0", features = ["serde"] }
+byteorder = "1.3.1"
 fnv = "1.0.6"
 hashbrown = "0.1.8"
 libc = "0.2.49"


### PR DESCRIPTION
#### Problem
Eliminate usage of unsafe calls used while trying to serialize / deserialize the Account to / from the persistent storage.

#### Summary of Changes
The persistent storage implementation for Accounts uses a bunch of unsafe calls to directly move around the memory using pointers. This was required as a result of operating with immutable instance of memory mapped slices where the unsafe calls was used to get a mutable pointer. Instead keep a copy of memory mapped file inside the mutex to get a mutable slice to operate on while serializing.

Fixes #
