### PR TITLE
SystemInstruction::CreateAccount bug

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2316,6 +2316,7 @@ dependencies = [
  "bincode 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-runtime 0.12.0",
  "solana-sdk 0.12.0",
 ]
 

--- a/ci/test-stable.sh
+++ b/ci/test-stable.sh
@@ -26,6 +26,7 @@ test-stable)
 
   _ cargo build --all ${V:+--verbose}
   _ cargo test --all ${V:+--verbose} -- --nocapture --test-threads=1
+  _ cargo test --manifest-path programs/system/Cargo.toml
   ;;
 test-stable-perf)
   echo "Executing $testName"
@@ -68,6 +69,7 @@ test-stable-perf)
   # Run root package library tests
   _ cargo build --all ${V:+--verbose} --features="$ROOT_FEATURES"
   _ cargo test --all --lib ${V:+--verbose} --features="$ROOT_FEATURES" -- --nocapture --test-threads=1
+  _ cargo test --manifest-path programs/system/Cargo.toml
 
   # Run root package integration tests
   for test in tests/*.rs; do

--- a/programs/system/Cargo.toml
+++ b/programs/system/Cargo.toml
@@ -14,6 +14,9 @@ log = "0.4.2"
 serde = "1.0.89"
 solana-sdk = { path = "../../sdk", version = "0.12.0" }
 
+[dev-dependencies]
+solana-runtime = { path = "../../runtime", version = "0.12.0" }
+
 [lib]
 name = "solana_system_program"
 
@@ -21,4 +24,3 @@ name = "solana_system_program"
 # allocates Rust memory.
 # cc: https://github.com/solana-labs/solana/issues/2004#issuecomment-444570081
 crate-type = ["lib"]
-

--- a/programs/system/src/lib.rs
+++ b/programs/system/src/lib.rs
@@ -36,15 +36,21 @@ pub fn entrypoint(
                     Err(ProgramError::InvalidArgument)?;
                 }
 
-                if space > 0
-                    && (!keyed_accounts[to].account.userdata.is_empty()
-                        || !system_program::check_id(&keyed_accounts[to].account.owner))
+                if !keyed_accounts[to].account.userdata.is_empty()
+                    || !system_program::check_id(&keyed_accounts[to].account.owner)
                 {
-                    info!(
-                        "CreateAccount: invalid argument space: {} accounts.userdata.len(): {}",
-                        space,
-                        keyed_accounts[to].account.userdata.len(),
-                    );
+                    if space > 0 {
+                        info!(
+                            "CreateAccount: invalid argument space: {} accounts.userdata.len(): {}",
+                            space,
+                            keyed_accounts[to].account.userdata.len(),
+                        );
+                    } else {
+                        info!(
+                            "CreateAccount: invalid argument; account {} already in use",
+                            keyed_accounts[to].unsigned_key()
+                        );
+                    }
                     Err(ProgramError::InvalidArgument)?;
                 }
                 if tokens > keyed_accounts[from].account.tokens {

--- a/programs/system/tests/system.rs
+++ b/programs/system/tests/system.rs
@@ -1,0 +1,104 @@
+use solana_runtime::bank::{Bank, Result};
+use solana_sdk::genesis_block::GenesisBlock;
+use solana_sdk::pubkey::Pubkey;
+use solana_sdk::signature::{Keypair, KeypairUtil};
+use solana_sdk::system_program;
+use solana_sdk::system_transaction::SystemTransaction;
+
+struct SystemBank<'a> {
+    bank: &'a Bank,
+}
+
+impl<'a> SystemBank<'a> {
+    fn new(bank: &'a Bank) -> Self {
+        bank.add_native_program("solana_system_program", &system_program::id());
+        Self { bank }
+    }
+    fn create_account(&self, from_keypair: &Keypair, to: Pubkey, lamports: u64) -> Result<()> {
+        let blockhash = self.bank.last_blockhash();
+        let tx = SystemTransaction::new_account(from_keypair, to, lamports, blockhash, 0);
+        self.bank.process_transaction(&tx)
+    }
+    fn move_lamports(&self, from_keypair: &Keypair, to: Pubkey, lamports: u64) -> Result<()> {
+        let blockhash = self.bank.last_blockhash();
+        let tx = SystemTransaction::new_move(from_keypair, to, lamports, blockhash, 0);
+        self.bank.process_transaction(&tx)
+    }
+}
+
+#[test]
+fn test_create_cannot_overwrite_used_account() {
+    let (genesis_block, from_keypair) = GenesisBlock::new(10_000);
+    let bank = Bank::new(&genesis_block);
+    let system_bank = SystemBank::new(&bank);
+
+    // create_account on uninitialized account should work
+    let system_account = Keypair::new().pubkey();
+    system_bank
+        .create_account(&from_keypair, system_account, 100)
+        .unwrap();
+    assert_eq!(system_bank.bank.get_balance(&system_account), 100);
+
+    // Create an account assigned to another program
+    let other_account = Keypair::new().pubkey();
+    let program_id = Pubkey::new(&[9; 32]);
+    let tx = SystemTransaction::new_program_account(
+        &from_keypair,
+        other_account,
+        system_bank.bank.last_blockhash(),
+        1,
+        0,
+        program_id,
+        0,
+    );
+    system_bank.bank.process_transaction(&tx).unwrap();
+    assert_eq!(system_bank.bank.get_balance(&other_account), 1);
+    assert_eq!(
+        system_bank.bank.get_account(&other_account).unwrap().owner,
+        program_id
+    );
+
+    // create_account on an initialized account should fail
+    system_bank
+        .create_account(&from_keypair, other_account, 100)
+        .unwrap();
+    assert_eq!(system_bank.bank.get_balance(&other_account), 1);
+    assert_eq!(
+        system_bank.bank.get_account(&other_account).unwrap().owner,
+        program_id
+    );
+}
+#[test]
+fn test_move_can_fund_used_account() {
+    let (genesis_block, from_keypair) = GenesisBlock::new(10_000);
+    let bank = Bank::new(&genesis_block);
+    let system_bank = SystemBank::new(&bank);
+
+    // Create an account assigned to another program
+    let other_account = Keypair::new().pubkey();
+    let program_id = Pubkey::new(&[9; 32]);
+    let tx = SystemTransaction::new_program_account(
+        &from_keypair,
+        other_account,
+        system_bank.bank.last_blockhash(),
+        1,
+        0,
+        program_id,
+        0,
+    );
+    system_bank.bank.process_transaction(&tx).unwrap();
+    assert_eq!(system_bank.bank.get_balance(&other_account), 1);
+    assert_eq!(
+        system_bank.bank.get_account(&other_account).unwrap().owner,
+        program_id
+    );
+
+    system_bank
+        .move_lamports(&from_keypair, other_account, 100)
+        .unwrap();
+    assert_eq!(system_bank.bank.get_balance(&other_account), 101);
+    assert_eq!(
+        system_bank.bank.get_account(&other_account).unwrap().owner,
+        program_id
+    );
+}

--- a/programs/system/tests/system.rs
+++ b/programs/system/tests/system.rs
@@ -59,9 +59,9 @@ fn test_create_cannot_overwrite_used_account() {
     );
 
     // create_account on an initialized account should fail
-    system_bank
+    assert!(system_bank
         .create_account(&from_keypair, other_account, 100)
-        .unwrap();
+        .is_err());
     assert_eq!(system_bank.bank.get_balance(&other_account), 1);
     assert_eq!(
         system_bank.bank.get_account(&other_account).unwrap().owner,

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -55,7 +55,7 @@ pub struct ErrorCounters {
 // The only required in memory data structure with a write lock is the index,
 // which should be fast to update.
 //
-// To garbage collect, data can be re-appended to defragmnted and truncated from
+// To garbage collect, data can be re-appended to defragmented and truncated from
 // the start. The AccountsDB data structure would allow for
 // - multiple readers
 // - multiple writers

--- a/wallet/src/wallet.rs
+++ b/wallet/src/wallet.rs
@@ -471,7 +471,7 @@ fn process_pay(
     let blockhash = get_recent_blockhash(&rpc_client)?;
 
     if timestamp == None && *witnesses == None {
-        let mut tx = SystemTransaction::new_account(&config.id, to, tokens, blockhash, 0);
+        let mut tx = SystemTransaction::new_move(&config.id, to, tokens, blockhash, 0);
         let signature_str = send_and_confirm_transaction(&rpc_client, &mut tx, &config.id)?;
         Ok(signature_str.to_string())
     } else if *witnesses == None {


### PR DESCRIPTION
#### Problem
@jackcmay pointed out that the Wallet `process_pay` function was using the wrong SystemInstruction. This exposed a bug in the System program, whereby any signer could wipe out a populated account owned by any program by submitting a CreateAccount system transaction where `to: <populated_account>` and `space: 0`

#### Summary of Changes
Fix bug by returning an error on any CreateAccount attempt on an account that either contains userdata or is owned by another program (instead of just when the SystemInstruction space > 0)

