### PR TITLE
Stop using LocalVoteSigner

### DIFF
--- a/core/src/fullnode.rs
+++ b/core/src/fullnode.rs
@@ -18,7 +18,6 @@ use crate::service::Service;
 use crate::storage_stage::StorageState;
 use crate::tpu::Tpu;
 use crate::tvu::{Sockets, Tvu};
-use crate::voting_keypair::VotingKeypair;
 use solana_metrics::counter::Counter;
 use solana_sdk::genesis_block::GenesisBlock;
 use solana_sdk::hash::Hash;
@@ -335,7 +334,7 @@ pub fn make_active_set_entries(
     slot_height_to_vote_on: u64,
     blockhash: &Hash,
     num_ending_ticks: u64,
-) -> (Vec<Entry>, VotingKeypair) {
+) -> (Vec<Entry>, Keypair) {
     // 1) Assume the active_keypair node has no tokens staked
     let transfer_tx = SystemTransaction::new_account(
         &token_source,
@@ -348,7 +347,7 @@ pub fn make_active_set_entries(
     let transfer_entry = next_entry_mut(&mut last_entry_hash, 1, vec![transfer_tx]);
 
     // 2) Create and register a vote account for active_keypair
-    let voting_keypair = VotingKeypair::new_local(active_keypair);
+    let voting_keypair = Keypair::new();
     let vote_account_id = voting_keypair.pubkey();
 
     let new_vote_account_tx = VoteTransaction::new_account(

--- a/core/src/leader_confirmation_service.rs
+++ b/core/src/leader_confirmation_service.rs
@@ -113,7 +113,6 @@ impl LeaderConfirmationService {
 mod tests {
     use super::*;
     use crate::voting_keypair::tests::{new_vote_account, push_vote};
-    use crate::voting_keypair::VotingKeypair;
     use bincode::serialize;
     use solana_sdk::genesis_block::GenesisBlock;
     use solana_sdk::hash::hash;
@@ -142,7 +141,7 @@ mod tests {
             .map(|i| {
                 // Create new validator to vote
                 let validator_keypair = Arc::new(Keypair::new());
-                let voting_keypair = VotingKeypair::new_local(&validator_keypair);
+                let voting_keypair = Keypair::new();
                 let voting_pubkey = voting_keypair.pubkey();
 
                 // Give the validator some tokens

--- a/core/src/local_cluster.rs
+++ b/core/src/local_cluster.rs
@@ -6,7 +6,6 @@ use crate::gossip_service::discover;
 use crate::service::Service;
 use crate::thin_client::retry_get_balance;
 use crate::thin_client::ThinClient;
-use crate::voting_keypair::VotingKeypair;
 use solana_sdk::genesis_block::GenesisBlock;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::{Keypair, KeypairUtil};
@@ -52,7 +51,7 @@ impl LocalCluster {
         let mut ledger_paths = vec![];
         ledger_paths.push(genesis_ledger_path.clone());
         ledger_paths.push(leader_ledger_path.clone());
-        let voting_keypair = VotingKeypair::new_local(&leader_keypair);
+        let voting_keypair = Keypair::new();
         let leader_node_info = leader_node.info.clone();
         let leader_server = Fullnode::new(
             leader_node,
@@ -66,7 +65,7 @@ impl LocalCluster {
         let mut client = mk_client(&leader_node_info);
         for _ in 0..(num_nodes - 1) {
             let validator_keypair = Arc::new(Keypair::new());
-            let voting_keypair = VotingKeypair::new_local(&validator_keypair);
+            let voting_keypair = Keypair::new();
             let validator_pubkey = validator_keypair.pubkey();
             let validator_node = Node::new_localhost_with_pubkey(validator_keypair.pubkey());
             let ledger_path = tmp_copy_blocktree!(&genesis_ledger_path);

--- a/core/src/thin_client.rs
+++ b/core/src/thin_client.rs
@@ -473,7 +473,6 @@ pub fn new_fullnode() -> (Fullnode, NodeInfo, Keypair, String) {
     use crate::blocktree::create_new_tmp_ledger;
     use crate::cluster_info::Node;
     use crate::fullnode::Fullnode;
-    use crate::voting_keypair::VotingKeypair;
     use solana_sdk::genesis_block::GenesisBlock;
     use solana_sdk::signature::KeypairUtil;
 
@@ -484,8 +483,7 @@ pub fn new_fullnode() -> (Fullnode, NodeInfo, Keypair, String) {
     let (genesis_block, mint_keypair) = GenesisBlock::new_with_leader(10_000, node_info.id, 42);
     let (ledger_path, _blockhash) = create_new_tmp_ledger!(&genesis_block);
 
-    let vote_account_keypair = Arc::new(Keypair::new());
-    let voting_keypair = VotingKeypair::new_local(&vote_account_keypair);
+    let voting_keypair = Keypair::new();
     let node = Fullnode::new(
         node,
         &node_keypair,

--- a/core/src/voting_keypair.rs
+++ b/core/src/voting_keypair.rs
@@ -57,7 +57,10 @@ impl VoteSigner for RemoteVoteSigner {
 impl KeypairUtil for VotingKeypair {
     /// Return a local VotingKeypair with a new keypair. Used for unit-tests.
     fn new() -> Self {
-        Self::new_local(&Arc::new(Keypair::new()))
+        Self::new_with_signer(
+            &Arc::new(Keypair::new()),
+            Box::new(LocalVoteSigner::default()),
+        )
     }
 
     /// Return the public key of the keypair used to sign votes
@@ -89,10 +92,6 @@ impl VotingKeypair {
             signer,
             vote_account,
         }
-    }
-
-    pub fn new_local(keypair: &Arc<Keypair>) -> Self {
-        Self::new_with_signer(keypair, Box::new(LocalVoteSigner::default()))
     }
 }
 

--- a/tests/replicator.rs
+++ b/tests/replicator.rs
@@ -19,7 +19,6 @@ use solana::fullnode::{Fullnode, FullnodeConfig};
 use solana::replicator::Replicator;
 use solana::storage_stage::STORAGE_ROTATE_TEST_COUNT;
 use solana::streamer::blob_receiver;
-use solana::voting_keypair::VotingKeypair;
 use solana_sdk::genesis_block::GenesisBlock;
 use solana_sdk::hash::Hash;
 use solana_sdk::signature::{Keypair, KeypairUtil};
@@ -49,7 +48,7 @@ fn test_replicator_startup_basic() {
     let validator_ledger_path = tmp_copy_blocktree!(&leader_ledger_path);
 
     {
-        let voting_keypair = VotingKeypair::new_local(&leader_keypair);
+        let voting_keypair = Keypair::new();
 
         let mut fullnode_config = FullnodeConfig::default();
         fullnode_config.storage_rotate_count = STORAGE_ROTATE_TEST_COUNT;
@@ -68,7 +67,7 @@ fn test_replicator_startup_basic() {
         );
 
         let validator_keypair = Arc::new(Keypair::new());
-        let voting_keypair = VotingKeypair::new_local(&validator_keypair);
+        let voting_keypair = Keypair::new();
 
         let mut leader_client = mk_client(&leader_info);
         let blockhash = leader_client.get_recent_blockhash();
@@ -283,7 +282,7 @@ fn test_replicator_startup_ledger_hang() {
     let validator_ledger_path = tmp_copy_blocktree!(&leader_ledger_path);
 
     {
-        let voting_keypair = VotingKeypair::new_local(&leader_keypair);
+        let voting_keypair = Keypair::new();
 
         let fullnode_config = FullnodeConfig::default();
         let _ = Fullnode::new(
@@ -296,7 +295,7 @@ fn test_replicator_startup_ledger_hang() {
         );
 
         let validator_keypair = Arc::new(Keypair::new());
-        let voting_keypair = VotingKeypair::new_local(&validator_keypair);
+        let voting_keypair = Keypair::new();
         let validator_node = Node::new_localhost_with_pubkey(validator_keypair.pubkey());
 
         let _ = Fullnode::new(

--- a/tests/tvu.rs
+++ b/tests/tvu.rs
@@ -17,7 +17,6 @@ use solana::storage_stage::StorageState;
 use solana::storage_stage::STORAGE_ROTATE_TEST_COUNT;
 use solana::streamer;
 use solana::tvu::{Sockets, Tvu};
-use solana::voting_keypair::VotingKeypair;
 use solana_runtime::bank::Bank;
 use solana_sdk::genesis_block::GenesisBlock;
 use solana_sdk::signature::{Keypair, KeypairUtil};
@@ -109,8 +108,7 @@ fn test_replay() {
     let (blocktree, ledger_signal_receiver) =
         Blocktree::open_with_config_signal(&blocktree_path, ticks_per_slot)
             .expect("Expected to successfully open ledger");
-    let vote_account_keypair = Arc::new(Keypair::new());
-    let voting_keypair = VotingKeypair::new_local(&vote_account_keypair);
+    let voting_keypair = Keypair::new();
     let (poh_service_exit, poh_recorder, poh_service, _entry_receiver) =
         create_test_recorder(&bank);
     let tvu = Tvu::new(


### PR DESCRIPTION
#### Problem

LocalVoteSigner isn't the right interface. Like RemoteVoteSigner, its constructor was accepting the fullnode's keypair, but that's the client keypair. In RemoteVoteSigner, the client keypair signs messages to send to a server instance, which then resigns them with the keypair that's authorized by the staking account. In LocalVoteSigner, I'm not sure if it's using the client keypair or some random keypair, but both are wrong.

#### Summary of Changes

When not using RemoteVoteSigner, we should be using the keypair that the staking account authorized (not implemented, and currently called voting account). If the staking account has not authorized a keypair (which is currently not possible), then we should be voting . with the staking account's keypair.

This PR takes only the very first step, which is to rip out the clearly wrong code. Follow-up PRs will build back up correct usage.
