### PR TITLE
Remove bootstrap_leader_vote_account_id from GenesisBlock

### DIFF
--- a/core/src/staking_utils.rs
+++ b/core/src/staking_utils.rs
@@ -162,7 +162,7 @@ mod tests {
         assert_eq!(vote_account_balances_at_epoch(&bank, 10), None);
 
         // First epoch has the bootstrap leader
-        expected.insert(genesis_block.bootstrap_leader_vote_account_id, 1);
+        expected.insert(genesis_block.bootstrap_leader_id, bootstrap_lamports);
         let expected = Some(expected);
         assert_eq!(vote_account_balances_at_epoch(&bank, 0), expected);
 

--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -3,7 +3,7 @@
 use clap::{crate_version, value_t_or_exit, App, Arg};
 use solana::blocktree::create_new_ledger;
 use solana_sdk::genesis_block::GenesisBlock;
-use solana_sdk::signature::{read_keypair, Keypair, KeypairUtil};
+use solana_sdk::signature::{read_keypair, KeypairUtil};
 use std::error;
 
 /**
@@ -66,14 +66,12 @@ fn main() -> Result<(), Box<dyn error::Error>> {
     let bootstrap_leader_keypair = read_keypair(bootstrap_leader_keypair_file)?;
     let mint_keypair = read_keypair(mint_keypair_file)?;
 
-    let bootstrap_leader_vote_account_keypair = Keypair::new();
     let (mut genesis_block, _mint_keypair) = GenesisBlock::new_with_leader(
         lamports,
         bootstrap_leader_keypair.pubkey(),
         BOOTSTRAP_LEADER_LAMPORTS,
     );
     genesis_block.mint_id = mint_keypair.pubkey();
-    genesis_block.bootstrap_leader_vote_account_id = bootstrap_leader_vote_account_keypair.pubkey();
 
     create_new_ledger(ledger_path, &genesis_block)?;
     Ok(())

--- a/sdk/src/genesis_block.rs
+++ b/sdk/src/genesis_block.rs
@@ -9,15 +9,13 @@ use std::io::Write;
 use std::path::Path;
 
 // The default (and minimal) amount of lamports given to the bootstrap leader:
-// * 2 lamports for the bootstrap leader ID account to later setup another vote account
 // * 1 lamport for the bootstrap leader vote account
-pub const BOOTSTRAP_LEADER_LAMPORTS: u64 = 3;
+pub const BOOTSTRAP_LEADER_LAMPORTS: u64 = 1;
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct GenesisBlock {
     pub bootstrap_leader_id: Pubkey,
     pub bootstrap_leader_lamports: u64,
-    pub bootstrap_leader_vote_account_id: Pubkey,
     pub mint_id: Pubkey,
     pub lamports: u64,
     pub ticks_per_slot: u64,
@@ -40,12 +38,10 @@ impl GenesisBlock {
         bootstrap_leader_lamports: u64,
     ) -> (Self, Keypair) {
         let mint_keypair = Keypair::new();
-        let bootstrap_leader_vote_account_keypair = Keypair::new();
         (
             Self {
                 bootstrap_leader_id,
                 bootstrap_leader_lamports,
-                bootstrap_leader_vote_account_id: bootstrap_leader_vote_account_keypair.pubkey(),
                 mint_id: mint_keypair.pubkey(),
                 lamports,
                 ticks_per_slot: DEFAULT_TICKS_PER_SLOT,
@@ -84,7 +80,6 @@ mod tests {
         assert_eq!(genesis_block.lamports, 10_000 + BOOTSTRAP_LEADER_LAMPORTS);
         assert_eq!(genesis_block.mint_id, mint.pubkey());
         assert!(genesis_block.bootstrap_leader_id != Pubkey::default());
-        assert!(genesis_block.bootstrap_leader_vote_account_id != Pubkey::default());
         assert_eq!(
             genesis_block.bootstrap_leader_lamports,
             BOOTSTRAP_LEADER_LAMPORTS


### PR DESCRIPTION
#### Problem

GenesisBlock is separating the bootstrap staking account from the bootstrap validator for legacy reasons.

#### Summary of Changes

Create the inaugural staking account using the bootstrap leader id.