### PR TITLE
No longer use account funder as implicit staker

### DIFF
--- a/core/src/local_cluster.rs
+++ b/core/src/local_cluster.rs
@@ -172,7 +172,7 @@ impl LocalCluster {
         let vote_account_user_data = client.get_account_userdata(&vote_account);
         if let Ok(Some(vote_account_user_data)) = vote_account_user_data {
             if let Ok(vote_state) = VoteState::deserialize(&vote_account_user_data) {
-                if vote_state.delegate_id == from_account.pubkey() {
+                if vote_state.delegate_id == vote_account {
                     return Ok(());
                 }
             }

--- a/core/src/thin_client.rs
+++ b/core/src/thin_client.rs
@@ -619,8 +619,7 @@ mod tests {
 
             let vote_state = VoteState::deserialize(&account_user_data);
 
-            if vote_state.map(|vote_state| vote_state.delegate_id) == Ok(validator_keypair.pubkey())
-            {
+            if vote_state.map(|vote_state| vote_state.delegate_id) == Ok(vote_account_id) {
                 break;
             }
 

--- a/fullnode/src/main.rs
+++ b/fullnode/src/main.rs
@@ -80,7 +80,7 @@ fn create_and_fund_vote_account(
     let vote_account_user_data = client.get_account_userdata(&vote_account);
     if let Ok(Some(vote_account_user_data)) = vote_account_user_data {
         if let Ok(vote_state) = VoteState::deserialize(&vote_account_user_data) {
-            if vote_state.delegate_id == pubkey {
+            if vote_state.delegate_id == vote_account {
                 return Ok(());
             }
         }

--- a/programs/rewards/src/lib.rs
+++ b/programs/rewards/src/lib.rs
@@ -110,18 +110,9 @@ mod tests {
 
     #[test]
     fn test_redeem_vote_credits_via_program() {
-        let staker_id = Keypair::new().pubkey();
-        let mut staker_account = Account::new(100, 0, Pubkey::default());
-
         let vote_id = Keypair::new().pubkey();
         let mut vote_account = vote_state::create_vote_account(100);
-        vote_state::initialize_and_deserialize(
-            &staker_id,
-            &mut staker_account,
-            &vote_id,
-            &mut vote_account,
-        )
-        .unwrap();
+        vote_state::initialize_and_deserialize(&vote_id, &mut vote_account).unwrap();
 
         for i in 0..vote_state::MAX_LOCKOUT_HISTORY {
             let vote = Vote::new(i as u64);

--- a/programs/vote_api/src/vote_instruction.rs
+++ b/programs/vote_api/src/vote_instruction.rs
@@ -19,8 +19,7 @@ impl Vote {
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub enum VoteInstruction {
     /// Initialize the VoteState for this `vote account`
-    /// * Transaction::keys[0] - the staker id that is also assumed to be the delegate by default
-    /// * Transaction::keys[1] - the new "vote account" to be associated with the delegate
+    /// * Instruction::keys[0] - the new "vote account" to be associated with the delegate
     InitializeAccount,
     /// `Delegate` or `Assign` a vote account to a particular node
     DelegateStake(Pubkey),
@@ -41,11 +40,11 @@ impl VoteInstruction {
             vec![(vote_id, true)],
         )
     }
-    pub fn new_initialize_account(vote_id: Pubkey, staker_id: Pubkey) -> BuilderInstruction {
+    pub fn new_initialize_account(vote_id: Pubkey) -> BuilderInstruction {
         BuilderInstruction::new(
             id(),
             &VoteInstruction::InitializeAccount,
-            vec![(staker_id, true), (vote_id, false)],
+            vec![(vote_id, false)],
         )
     }
     pub fn new_vote(vote_id: Pubkey, vote: Vote) -> BuilderInstruction {

--- a/programs/vote_api/src/vote_transaction.rs
+++ b/programs/vote_api/src/vote_transaction.rs
@@ -48,7 +48,7 @@ impl VoteTransaction {
             vec![system_program::id(), id()],
             vec![
                 Instruction::new(0, &create_tx, vec![0, 1]),
-                Instruction::new(1, &VoteInstruction::InitializeAccount, vec![0, 1]),
+                Instruction::new(1, &VoteInstruction::InitializeAccount, vec![1]),
             ],
         )
     }


### PR DESCRIPTION
#### Problem

VoteInstruction::InitializeAccount was assuming the account that funded it was the default staker, not the account itself.

#### Summary of Changes

* Remove any references to the funder
* No longer require any signatures
* Update the test to check for the correct default staker and to ensure one can only initialize once

@sagar-solana, @pgarg66, fyi