### PR TITLE
Check for no entries left in blocktree in a given slot

### DIFF
--- a/core/src/chacha_cuda.rs
+++ b/core/src/chacha_cuda.rs
@@ -54,6 +54,9 @@ pub fn chacha_cbc_encrypt_file_many_keys(
                     "chacha_cuda: encrypting segment: {} num_entries: {} entry_len: {}",
                     segment, num_entries, entry_len
                 );
+                if num_entries == 0 {
+                    break;
+                }
                 let entry_len_usz = entry_len as usize;
                 unsafe {
                     chacha_cbc_encrypt_many_sample(


### PR DESCRIPTION
#### Problem

There may not be ENTRIES_PER_SEGMENT entries a slot, if so
then we will hang waiting for more.

#### Summary of Changes

Add a check for 0 entries from blocktree.

Fixes #
