### PR TITLE
slot_height considered harmful

### DIFF
--- a/core/src/broadcast_stage.rs
+++ b/core/src/broadcast_stage.rs
@@ -52,7 +52,6 @@ impl Broadcast {
         broadcast_table.truncate(DATA_PLANE_FANOUT);
         inc_new_counter_info!("broadcast_service-num_peers", broadcast_table.len() + 1);
 
-        let slot_height = bank.slot();
         let max_tick_height = (bank.slot() + 1) * bank.ticks_per_slot() - 1;
         // TODO: Fix BankingStage/BroadcastStage to operate on `slot` directly instead of
         // `max_tick_height`
@@ -91,8 +90,7 @@ impl Broadcast {
             })
             .collect();
 
-        // TODO: blob_index should be slot-relative...
-        index_blobs(&blobs, &self.id, &mut blob_index, slot_height);
+        index_blobs(&blobs, &self.id, &mut blob_index, bank.slot());
         let parent = bank.parents().first().map(|bank| bank.slot()).unwrap_or(0);
         for b in blobs.iter() {
             b.write().unwrap().set_parent(parent);

--- a/core/src/db_window.rs
+++ b/core/src/db_window.rs
@@ -360,10 +360,10 @@ mod test {
             .collect();
 
         // For each slot, find all missing indexes in the range [0, num_entries_per_slot * nth]
-        for slot_height in 0..num_slots {
+        for slot in 0..num_slots {
             assert_eq!(
                 blocktree.find_missing_data_indexes(
-                    slot_height as u64,
+                    slot as u64,
                     0,
                     (num_entries_per_slot * nth) as u64,
                     num_entries_per_slot * nth as usize
@@ -373,10 +373,10 @@ mod test {
         }
 
         // Test with a limit on the number of returned entries
-        for slot_height in 0..num_slots {
+        for slot in 0..num_slots {
             assert_eq!(
                 blocktree.find_missing_data_indexes(
-                    slot_height as u64,
+                    slot as u64,
                     0,
                     (num_entries_per_slot * nth) as u64,
                     num_entries_per_slot * (nth - 1)
@@ -392,10 +392,10 @@ mod test {
         expected.extend(extra_entries);
 
         // For each slot, find all missing indexes in the range [0, num_entries_per_slot * nth]
-        for slot_height in 0..num_slots {
+        for slot in 0..num_slots {
             assert_eq!(
                 blocktree.find_missing_data_indexes(
-                    slot_height as u64,
+                    slot as u64,
                     0,
                     (num_entries_per_slot * (nth + 1)) as u64,
                     num_entries_per_slot * (nth + 1),
@@ -441,8 +441,8 @@ mod test {
         // Setup the window
         let offset = 0;
         let num_blobs = NUM_DATA + 2;
-        let slot_height = 0;
-        let mut window = setup_window_ledger(offset, num_blobs, false, slot_height);
+        let slot = 0;
+        let mut window = setup_window_ledger(offset, num_blobs, false, slot);
         let end_index = (offset + num_blobs) % window.len();
 
         // Test erasing a data block and an erasure block
@@ -466,7 +466,7 @@ mod test {
         {
             let data_blobs: Vec<_> = window[erased_index..end_index]
                 .iter()
-                .map(|slot| slot.data.clone().unwrap())
+                .map(|entry| entry.data.clone().unwrap())
                 .collect();
 
             let locks: Vec<_> = data_blobs.iter().map(|blob| blob.read().unwrap()).collect();
@@ -490,7 +490,7 @@ mod test {
         let erased_coding_l = erased_coding.read().unwrap();
         assert_eq!(
             &blocktree
-                .get_coding_blob_bytes(slot_height, erased_index as u64)
+                .get_coding_blob_bytes(slot, erased_index as u64)
                 .unwrap()
                 .unwrap()[BLOB_HEADER_SIZE..],
             &erased_coding_l.data()[..erased_coding_l.size() as usize],

--- a/core/src/fullnode.rs
+++ b/core/src/fullnode.rs
@@ -331,7 +331,7 @@ pub fn make_active_set_entries(
     active_keypair: &Arc<Keypair>,
     token_source: &Keypair,
     stake: u64,
-    slot_height_to_vote_on: u64,
+    slot_to_vote_on: u64,
     blockhash: &Hash,
     num_ending_ticks: u64,
 ) -> (Vec<Entry>, Keypair) {
@@ -360,7 +360,7 @@ pub fn make_active_set_entries(
     let new_vote_account_entry = next_entry_mut(&mut last_entry_hash, 1, vec![new_vote_account_tx]);
 
     // 3) Create vote entry
-    let vote_tx = VoteTransaction::new_vote(&voting_keypair, slot_height_to_vote_on, *blockhash, 0);
+    let vote_tx = VoteTransaction::new_vote(&voting_keypair, slot_to_vote_on, *blockhash, 0);
     let vote_entry = next_entry_mut(&mut last_entry_hash, 1, vec![vote_tx]);
 
     // 4) Create `num_ending_ticks` empty ticks

--- a/core/src/voting_keypair.rs
+++ b/core/src/voting_keypair.rs
@@ -114,9 +114,9 @@ pub mod tests {
         bank.process_transaction(&tx).unwrap();
     }
 
-    pub fn push_vote<T: KeypairUtil>(voting_keypair: &T, bank: &Bank, slot_height: u64) {
+    pub fn push_vote<T: KeypairUtil>(voting_keypair: &T, bank: &Bank, slot: u64) {
         let blockhash = bank.last_blockhash();
-        let tx = VoteTransaction::new_vote(voting_keypair, slot_height, blockhash, 0);
+        let tx = VoteTransaction::new_vote(voting_keypair, slot, blockhash, 0);
         bank.process_transaction(&tx).unwrap();
     }
 
@@ -125,9 +125,9 @@ pub mod tests {
         voting_keypair: &T,
         bank: &Bank,
         num_tokens: u64,
-        slot_height: u64,
+        slot: u64,
     ) {
         new_vote_account(from_keypair, &voting_keypair.pubkey(), bank, num_tokens);
-        push_vote(voting_keypair, bank, slot_height);
+        push_vote(voting_keypair, bank, slot);
     }
 }

--- a/programs/vote_api/src/vote_instruction.rs
+++ b/programs/vote_api/src/vote_instruction.rs
@@ -6,13 +6,13 @@ use solana_sdk::transaction_builder::BuilderInstruction;
 #[derive(Serialize, Default, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub struct Vote {
     // TODO: add signature of the state here as well
-    /// A vote for height slot_height
-    pub slot_height: u64,
+    /// A vote for height slot
+    pub slot: u64,
 }
 
 impl Vote {
-    pub fn new(slot_height: u64) -> Self {
-        Self { slot_height }
+    pub fn new(slot: u64) -> Self {
+        Self { slot }
     }
 }
 

--- a/programs/vote_api/src/vote_transaction.rs
+++ b/programs/vote_api/src/vote_transaction.rs
@@ -17,11 +17,11 @@ pub struct VoteTransaction {}
 impl VoteTransaction {
     pub fn new_vote<T: KeypairUtil>(
         voting_keypair: &T,
-        slot_height: u64,
+        slot: u64,
         recent_blockhash: Hash,
         fee: u64,
     ) -> Transaction {
-        let vote = Vote { slot_height };
+        let vote = Vote { slot };
         TransactionBuilder::new(fee)
             .push(VoteInstruction::new_vote(voting_keypair.pubkey(), vote))
             .sign(&[voting_keypair], recent_blockhash)
@@ -94,12 +94,12 @@ mod tests {
     #[test]
     fn test_get_votes() {
         let keypair = Keypair::new();
-        let slot_height = 1;
+        let slot = 1;
         let recent_blockhash = Hash::default();
-        let transaction = VoteTransaction::new_vote(&keypair, slot_height, recent_blockhash, 0);
+        let transaction = VoteTransaction::new_vote(&keypair, slot, recent_blockhash, 0);
         assert_eq!(
             VoteTransaction::get_votes(&transaction),
-            vec![(keypair.pubkey(), Vote::new(slot_height), recent_blockhash)]
+            vec![(keypair.pubkey(), Vote::new(slot), recent_blockhash)]
         );
     }
 }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -342,7 +342,7 @@ impl Bank {
         // Sort by slot height
         slots_and_stakes.sort_by(|a, b| a.0.cmp(&b.0));
 
-        let max_slot = self.slot_height();
+        let max_slot = self.slot();
         let min_slot = max_slot.saturating_sub(MAX_RECENT_BLOCKHASHES as u64);
 
         let mut total_stake = 0;
@@ -757,7 +757,7 @@ impl Bank {
         self.stakers_slot_offset
     }
 
-    /// Return the number of ticks per slot that should be used calls to slot_height().
+    /// Return the number of ticks per slot
     pub fn ticks_per_slot(&self) -> u64 {
         self.ticks_per_slot
     }
@@ -774,11 +774,6 @@ impl Bank {
     /// Return the number of ticks since the last slot boundary.
     pub fn tick_index(&self) -> u64 {
         self.tick_height() % self.ticks_per_slot()
-    }
-
-    /// Return the slot_height of the last registered tick.
-    pub fn slot_height(&self) -> u64 {
-        self.tick_height() / self.ticks_per_slot()
     }
 
     /// Return the number of slots per tick.
@@ -804,12 +799,12 @@ impl Bank {
 
     /// Return the number of slots since the last epoch boundary.
     pub fn slot_index(&self) -> u64 {
-        self.slot_height() % self.slots_per_epoch()
+        self.slot() % self.slots_per_epoch()
     }
 
     /// Return the epoch height of the last registered tick.
     pub fn epoch_height(&self) -> u64 {
-        self.slot_height() / self.slots_per_epoch()
+        self.slot() / self.slots_per_epoch()
     }
 }
 


### PR DESCRIPTION
#### Problem
slot_height has had a short life, but in that time has established itself as a source of confusion and error

### Proposed Solution
kill it with fire.

or:
As a first step to epoch warmups, remove confusing names for things

there's no data structure called "slot", and "slot_height" was something that implies a calculation, and the calculation was in error (should never have existed).

remove slot_height from the codebase