### PR TITLE
Fix invalid Barrier transactions

### DIFF
--- a/bench-tps/src/bench.rs
+++ b/bench-tps/src/bench.rs
@@ -7,6 +7,7 @@ use solana::thin_client::ThinClient;
 use solana_drone::drone::request_airdrop_transaction;
 use solana_metrics::influxdb;
 use solana_sdk::hash::Hash;
+use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::{Keypair, KeypairUtil};
 use solana_sdk::system_transaction::SystemTransaction;
 use solana_sdk::timing::timestamp;
@@ -103,7 +104,8 @@ pub fn sample_tx_count(
 pub fn send_barrier_transaction(
     barrier_client: &mut ThinClient,
     blockhash: &mut Hash,
-    id: &Keypair,
+    source: &Keypair,
+    dest: &Pubkey,
 ) {
     let transfer_start = Instant::now();
 
@@ -118,7 +120,7 @@ pub fn send_barrier_transaction(
 
         *blockhash = barrier_client.get_recent_blockhash();
         let signature = barrier_client
-            .transfer(0, &id, id.pubkey(), blockhash)
+            .transfer(0, &source, *dest, blockhash)
             .expect("Unable to send barrier transaction");
 
         let confirmatiom = barrier_client.poll_for_signature(&signature);
@@ -140,7 +142,7 @@ pub fn send_barrier_transaction(
             // Sanity check that the client balance is still 1
             let balance = barrier_client
                 .poll_balance_with_timeout(
-                    &id.pubkey(),
+                    &source.pubkey(),
                     &Duration::from_millis(100),
                     &Duration::from_secs(10),
                 )

--- a/bench-tps/src/bench.rs
+++ b/bench-tps/src/bench.rs
@@ -104,8 +104,8 @@ pub fn sample_tx_count(
 pub fn send_barrier_transaction(
     barrier_client: &mut ThinClient,
     blockhash: &mut Hash,
-    source: &Keypair,
-    dest: &Pubkey,
+    source_keypair: &Keypair,
+    dest_id: &Pubkey,
 ) {
     let transfer_start = Instant::now();
 
@@ -120,7 +120,7 @@ pub fn send_barrier_transaction(
 
         *blockhash = barrier_client.get_recent_blockhash();
         let signature = barrier_client
-            .transfer(0, &source, *dest, blockhash)
+            .transfer(0, &source_keypair, *dest_id, blockhash)
             .expect("Unable to send barrier transaction");
 
         let confirmatiom = barrier_client.poll_for_signature(&signature);
@@ -142,7 +142,7 @@ pub fn send_barrier_transaction(
             // Sanity check that the client balance is still 1
             let balance = barrier_client
                 .poll_balance_with_timeout(
-                    &source.pubkey(),
+                    &source_keypair.pubkey(),
                     &Duration::from_millis(100),
                     &Duration::from_secs(10),
                 )

--- a/bench-tps/src/main.rs
+++ b/bench-tps/src/main.rs
@@ -255,7 +255,12 @@ fn main() {
         // It's not feasible (would take too much time) to confirm each of the `tx_count / 2`
         // transactions sent by `generate_txs()` so instead send and confirm a single transaction
         // to validate the network is still functional.
-        send_barrier_transaction(&mut barrier_client, &mut blockhash, &barrier_source_id, &barrier_dest_id);
+        send_barrier_transaction(
+            &mut barrier_client,
+            &mut blockhash,
+            &barrier_source_id,
+            &barrier_dest_id,
+        );
 
         i += 1;
         if should_switch_directions(num_tokens_per_account, i) {

--- a/bench-tps/src/main.rs
+++ b/bench-tps/src/main.rs
@@ -146,7 +146,7 @@ fn main() {
         target /= MAX_SPENDS_PER_TX;
     }
     let gen_keypairs = rnd.gen_n_keypairs(total_keys as u64);
-    let barrier_keypair = Keypair::new();
+    let barrier_source_keypair = Keypair::new();
     let barrier_dest_id = Keypair::new().pubkey();
 
     println!("Get tokens...");
@@ -167,7 +167,7 @@ fn main() {
     }
     let start = gen_keypairs.len() - (tx_count * 2) as usize;
     let keypairs = &gen_keypairs[start..];
-    airdrop_tokens(&mut barrier_client, &drone_addr, &barrier_keypair, 1);
+    airdrop_tokens(&mut barrier_client, &drone_addr, &barrier_source_keypair, 1);
 
     println!("Get last ID...");
     let mut blockhash = client.get_recent_blockhash();
@@ -257,7 +257,7 @@ fn main() {
         send_barrier_transaction(
             &mut barrier_client,
             &mut blockhash,
-            &barrier_keypair,
+            &barrier_source_keypair,
             &barrier_dest_id,
         );
 

--- a/bench-tps/src/main.rs
+++ b/bench-tps/src/main.rs
@@ -9,7 +9,7 @@ use solana::gen_keys::GenKeys;
 use solana::service::Service;
 use solana::thin_client::poll_gossip_for_leader;
 use solana_metrics;
-use solana_sdk::signature::KeypairUtil;
+use solana_sdk::signature::{Keypair, KeypairUtil};
 
 use std::collections::VecDeque;
 use std::process::exit;
@@ -146,9 +146,8 @@ fn main() {
         target /= MAX_SPENDS_PER_TX;
     }
     let gen_keypairs = rnd.gen_n_keypairs(total_keys as u64);
-    let mut barrier_ids = rnd.gen_n_keypairs(2);
-    let barrier_source_id = barrier_ids.pop().unwrap();
-    let barrier_dest_id = barrier_ids.pop().unwrap().pubkey();
+    let barrier_keypair = Keypair::new();
+    let barrier_dest_id = Keypair::new().pubkey();
 
     println!("Get tokens...");
     let num_tokens_per_account = 20;
@@ -168,7 +167,7 @@ fn main() {
     }
     let start = gen_keypairs.len() - (tx_count * 2) as usize;
     let keypairs = &gen_keypairs[start..];
-    airdrop_tokens(&mut barrier_client, &drone_addr, &barrier_source_id, 1);
+    airdrop_tokens(&mut barrier_client, &drone_addr, &barrier_keypair, 1);
 
     println!("Get last ID...");
     let mut blockhash = client.get_recent_blockhash();
@@ -258,7 +257,7 @@ fn main() {
         send_barrier_transaction(
             &mut barrier_client,
             &mut blockhash,
-            &barrier_source_id,
+            &barrier_keypair,
             &barrier_dest_id,
         );
 

--- a/bench-tps/src/main.rs
+++ b/bench-tps/src/main.rs
@@ -146,7 +146,9 @@ fn main() {
         target /= MAX_SPENDS_PER_TX;
     }
     let gen_keypairs = rnd.gen_n_keypairs(total_keys as u64);
-    let barrier_id = rnd.gen_n_keypairs(1).pop().unwrap();
+    let mut barrier_ids = rnd.gen_n_keypairs(2);
+    let barrier_source_id = barrier_ids.pop().unwrap();
+    let barrier_dest_id = barrier_ids.pop().unwrap().pubkey();
 
     println!("Get tokens...");
     let num_tokens_per_account = 20;
@@ -166,7 +168,7 @@ fn main() {
     }
     let start = gen_keypairs.len() - (tx_count * 2) as usize;
     let keypairs = &gen_keypairs[start..];
-    airdrop_tokens(&mut barrier_client, &drone_addr, &barrier_id, 1);
+    airdrop_tokens(&mut barrier_client, &drone_addr, &barrier_source_id, 1);
 
     println!("Get last ID...");
     let mut blockhash = client.get_recent_blockhash();
@@ -253,7 +255,7 @@ fn main() {
         // It's not feasible (would take too much time) to confirm each of the `tx_count / 2`
         // transactions sent by `generate_txs()` so instead send and confirm a single transaction
         // to validate the network is still functional.
-        send_barrier_transaction(&mut barrier_client, &mut blockhash, &barrier_id);
+        send_barrier_transaction(&mut barrier_client, &mut blockhash, &barrier_source_id, &barrier_dest_id);
 
         i += 1;
         if should_switch_directions(num_tokens_per_account, i) {


### PR DESCRIPTION
#### Problem

Barrier Txs' "from_keypair" and "to_pubkey " were set to the same account. This is explicitly disallowed by the runtime. 

#### Summary of Changes

Send barrier txs to a different account. 

