### PR TITLE
Rename tokens to lamports in sdk/

### DIFF
--- a/book/src/jsonrpc-api.md
+++ b/book/src/jsonrpc-api.md
@@ -120,7 +120,7 @@ Returns all information associated with the account of provided Pubkey
 ##### Results:
 The result field will be a JSON object with the following sub fields:
 
-* `tokens`, number of tokens assigned to this account, as a signed 64-bit integer
+* `lamports`, number of lamports assigned to this account, as a signed 64-bit integer
 * `owner`, array of 32 bytes representing the program this account has been assigned to
 * `userdata`, array of bytes representing any userdata associated with the account
 * `executable`, boolean indicating if the account contains a program (and is strictly read-only)
@@ -132,7 +132,7 @@ The result field will be a JSON object with the following sub fields:
 curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0", "id":1, "method":"getAccountInfo", "params":["2gVkYWexTHR5Hb2aLeQN3tnngvWzisFKXDUPrgMHpdST"]}' http://localhost:8899
 
 // Result
-{"jsonrpc":"2.0","result":{"executable":false,"loader":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"owner":[1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"tokens":1,"userdata":[3,0,0,0,0,0,0,0,1,0,0,0,0,0,1,0,0,0,0,0,0,0,20,0,0,0,0,0,0,0,50,48,53,48,45,48,49,45,48,49,84,48,48,58,48,48,58,48,48,90,252,10,7,28,246,140,88,177,98,82,10,227,89,81,18,30,194,101,199,16,11,73,133,20,246,62,114,39,20,113,189,32,50,0,0,0,0,0,0,0,247,15,36,102,167,83,225,42,133,127,82,34,36,224,207,130,109,230,224,188,163,33,213,13,5,117,211,251,65,159,197,51,0,0,0,0,0,0]},"id":1}
+{"jsonrpc":"2.0","result":{"executable":false,"loader":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"owner":[1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"lamports":1,"userdata":[3,0,0,0,0,0,0,0,1,0,0,0,0,0,1,0,0,0,0,0,0,0,20,0,0,0,0,0,0,0,50,48,53,48,45,48,49,45,48,49,84,48,48,58,48,48,58,48,48,90,252,10,7,28,246,140,88,177,98,82,10,227,89,81,18,30,194,101,199,16,11,73,133,20,246,62,114,39,20,113,189,32,50,0,0,0,0,0,0,0,247,15,36,102,167,83,225,42,133,127,82,34,36,224,207,130,109,230,224,188,163,33,213,13,5,117,211,251,65,159,197,51,0,0,0,0,0,0]},"id":1}
 ```
 
 ---
@@ -204,11 +204,11 @@ curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1, "m
 ---
 
 ### requestAirdrop
-Requests an airdrop of tokens to a Pubkey
+Requests an airdrop of lamports to a Pubkey
 
 ##### Parameters:
-* `string` - Pubkey of account to receive tokens, as base-58 encoded string
-* `integer` - token quantity, as a signed 64-bit integer
+* `string` - Pubkey of account to receive lamports, as base-58 encoded string
+* `integer` - lamports, as a signed 64-bit integer
 
 ##### Results:
 * `string` - Transaction Signature of airdrop, as base-58 encoded string
@@ -271,7 +271,7 @@ Subscribe to an account to receive notifications when the userdata for a given a
 
 ##### Notification Format:
 ```bash
-{"jsonrpc": "2.0","method": "accountNotification", "params": {"result": {"executable":false,"loader":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"owner":[1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"tokens":1,"userdata":[3,0,0,0,0,0,0,0,1,0,0,0,0,0,1,0,0,0,0,0,0,0,20,0,0,0,0,0,0,0,50,48,53,48,45,48,49,45,48,49,84,48,48,58,48,48,58,48,48,90,252,10,7,28,246,140,88,177,98,82,10,227,89,81,18,30,194,101,199,16,11,73,133,20,246,62,114,39,20,113,189,32,50,0,0,0,0,0,0,0,247,15,36,102,167,83,225,42,133,127,82,34,36,224,207,130,109,230,224,188,163,33,213,13,5,117,211,251,65,159,197,51,0,0,0,0,0,0]},"subscription":0}}
+{"jsonrpc": "2.0","method": "accountNotification", "params": {"result": {"executable":false,"loader":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"owner":[1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"lamports":1,"userdata":[3,0,0,0,0,0,0,0,1,0,0,0,0,0,1,0,0,0,0,0,0,0,20,0,0,0,0,0,0,0,50,48,53,48,45,48,49,45,48,49,84,48,48,58,48,48,58,48,48,90,252,10,7,28,246,140,88,177,98,82,10,227,89,81,18,30,194,101,199,16,11,73,133,20,246,62,114,39,20,113,189,32,50,0,0,0,0,0,0,0,247,15,36,102,167,83,225,42,133,127,82,34,36,224,207,130,109,230,224,188,163,33,213,13,5,117,211,251,65,159,197,51,0,0,0,0,0,0]},"subscription":0}}
 ```
 
 ---

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -574,7 +574,7 @@ mod tests {
         // ProgramErrors should still be recorded
         results[0] = Err(BankError::ProgramError(
             1,
-            ProgramError::ResultWithNegativeTokens,
+            ProgramError::ResultWithNegativeLamports,
         ));
         BankingStage::record_transactions(&transactions, &results, &poh_recorder).unwrap();
         let (_, entries) = entry_receiver.recv().unwrap();

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -491,7 +491,7 @@ mod tests {
         poh_recorder.lock().unwrap().set_bank(&bank);
         let _banking_stage = BankingStage::new(&cluster_info, &poh_recorder, verified_receiver);
 
-        // Process a batch that includes a transaction that receives two tokens.
+        // Process a batch that includes a transaction that receives two lamports.
         let alice = Keypair::new();
         let tx = SystemTransaction::new_account(
             &mint_keypair,
@@ -506,7 +506,7 @@ mod tests {
             .send(vec![(packets[0].clone(), vec![1u8])])
             .unwrap();
 
-        // Process a second batch that spends one of those tokens.
+        // Process a second batch that spends one of those lamports.
         let tx = SystemTransaction::new_account(
             &alice,
             mint_keypair.pubkey(),
@@ -532,7 +532,7 @@ mod tests {
         // same assertion as running through the bank, really...
         assert!(entries.len() >= 2);
 
-        // Assert the user holds one token, not two. If the stage only outputs one
+        // Assert the user holds one lamport, not two. If the stage only outputs one
         // entry, then the second transaction will be rejected, because it drives
         // the account balance below zero before the credit is added.
         let bank = Bank::new(&genesis_block);

--- a/core/src/blocktree_processor.rs
+++ b/core/src/blocktree_processor.rs
@@ -476,7 +476,7 @@ mod tests {
             entries.push(entry);
 
             // Add a second Transaction that will produce a
-            // ProgramError<0, ResultWithNegativeTokens> error when processed
+            // ProgramError<0, ResultWithNegativeLamports> error when processed
             let keypair2 = Keypair::new();
             let tx = SystemTransaction::new_account(&keypair, keypair2.pubkey(), 42, blockhash, 0);
             let entry = Entry::new(&last_entry_hash, 1, vec![tx]);

--- a/core/src/fullnode.rs
+++ b/core/src/fullnode.rs
@@ -329,15 +329,15 @@ impl Service for Fullnode {
 // leader selection, and append `num_ending_ticks` empty tick entries.
 pub fn make_active_set_entries(
     active_keypair: &Arc<Keypair>,
-    token_source: &Keypair,
+    lamport_source: &Keypair,
     stake: u64,
     slot_to_vote_on: u64,
     blockhash: &Hash,
     num_ending_ticks: u64,
 ) -> (Vec<Entry>, Keypair) {
-    // 1) Assume the active_keypair node has no tokens staked
+    // 1) Assume the active_keypair node has no lamports staked
     let transfer_tx = SystemTransaction::new_account(
-        &token_source,
+        &lamport_source,
         active_keypair.pubkey(),
         stake,
         *blockhash,

--- a/core/src/leader_confirmation_service.rs
+++ b/core/src/leader_confirmation_service.rs
@@ -32,12 +32,12 @@ impl LeaderConfirmationService {
         // Hold an accounts_db read lock as briefly as possible, just long enough to collect all
         // the vote states
         bank.vote_accounts().for_each(|(_, account)| {
-            total_stake += account.tokens;
+            total_stake += account.lamports;
             let vote_state = VoteState::deserialize(&account.userdata).unwrap();
             if let Some(stake_and_state) = vote_state
                 .votes
                 .back()
-                .map(|vote| (vote.slot, account.tokens))
+                .map(|vote| (vote.slot, account.lamports))
             {
                 slots_and_stakes.push(stake_and_state);
             }
@@ -145,7 +145,7 @@ mod tests {
         let blockhash = bank.last_blockhash();
 
         // Create a total of 10 vote accounts, each will have a balance of 1 (after giving 1 to
-        // their vote account), for a total staking pool of 10 tokens.
+        // their vote account), for a total staking pool of 10 lamports.
         let vote_accounts: Vec<_> = (0..10)
             .map(|i| {
                 // Create new validator to vote
@@ -153,7 +153,7 @@ mod tests {
                 let voting_keypair = Keypair::new();
                 let voting_pubkey = voting_keypair.pubkey();
 
-                // Give the validator some tokens
+                // Give the validator some lamports
                 bank.transfer(2, &mint_keypair, validator_keypair.pubkey(), blockhash)
                     .unwrap();
                 new_vote_account(&validator_keypair, &voting_pubkey, &bank, 1);

--- a/core/src/leader_schedule_utils.rs
+++ b/core/src/leader_schedule_utils.rs
@@ -49,14 +49,17 @@ pub fn num_ticks_left_in_slot(bank: &Bank, tick_height: u64) -> u64 {
 mod tests {
     use super::*;
     use crate::staking_utils;
-    use solana_sdk::genesis_block::{GenesisBlock, BOOTSTRAP_LEADER_TOKENS};
+    use solana_sdk::genesis_block::{GenesisBlock, BOOTSTRAP_LEADER_LAMPORTS};
     use solana_sdk::signature::{Keypair, KeypairUtil};
 
     #[test]
     fn test_leader_schedule_via_bank() {
         let pubkey = Keypair::new().pubkey();
-        let (genesis_block, _mint_keypair) =
-            GenesisBlock::new_with_leader(BOOTSTRAP_LEADER_TOKENS, pubkey, BOOTSTRAP_LEADER_TOKENS);
+        let (genesis_block, _mint_keypair) = GenesisBlock::new_with_leader(
+            BOOTSTRAP_LEADER_LAMPORTS,
+            pubkey,
+            BOOTSTRAP_LEADER_LAMPORTS,
+        );
         let bank = Bank::new(&genesis_block);
 
         let ids_and_stakes: Vec<_> = staking_utils::delegated_stakes(&bank).into_iter().collect();
@@ -72,9 +75,12 @@ mod tests {
     #[test]
     fn test_leader_scheduler1_basic() {
         let pubkey = Keypair::new().pubkey();
-        let genesis_block =
-            GenesisBlock::new_with_leader(BOOTSTRAP_LEADER_TOKENS, pubkey, BOOTSTRAP_LEADER_TOKENS)
-                .0;
+        let genesis_block = GenesisBlock::new_with_leader(
+            BOOTSTRAP_LEADER_LAMPORTS,
+            pubkey,
+            BOOTSTRAP_LEADER_LAMPORTS,
+        )
+        .0;
         let bank = Bank::new(&genesis_block);
         assert_eq!(slot_leader_at(bank.slot(), &bank), pubkey);
     }

--- a/core/src/local_cluster.rs
+++ b/core/src/local_cluster.rs
@@ -71,7 +71,7 @@ impl LocalCluster {
             let ledger_path = tmp_copy_blocktree!(&genesis_ledger_path);
             ledger_paths.push(ledger_path.clone());
 
-            // Send each validator some tokens to vote
+            // Send each validator some lamports to vote
             let validator_balance = Self::transfer(
                 &mut client,
                 &mint_keypair,

--- a/core/src/replicator.rs
+++ b/core/src/replicator.rs
@@ -214,7 +214,7 @@ impl Replicator {
 
         let mut client = mk_client(&leader);
 
-        Self::get_airdrop_tokens(&mut client, keypair, &leader_info);
+        Self::get_airdrop_lamports(&mut client, keypair, &leader_info);
         info!("Done downloading ledger at {}", ledger_path);
 
         let ledger_path = Path::new(ledger_path);
@@ -358,7 +358,7 @@ impl Replicator {
         ))?
     }
 
-    fn get_airdrop_tokens(client: &mut ThinClient, keypair: &Keypair, leader_info: &NodeInfo) {
+    fn get_airdrop_lamports(client: &mut ThinClient, keypair: &Keypair, leader_info: &NodeInfo) {
         if retry_get_balance(client, &keypair.pubkey(), None).is_none() {
             let mut drone_addr = leader_info.tpu;
             drone_addr.set_port(DRONE_PORT);

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -292,8 +292,8 @@ impl RpcSol for RpcSolImpl {
             .get_transaction_count()
     }
 
-    fn request_airdrop(&self, meta: Self::Metadata, id: String, tokens: u64) -> Result<String> {
-        trace!("request_airdrop id={} tokens={}", id, tokens);
+    fn request_airdrop(&self, meta: Self::Metadata, id: String, lamports: u64) -> Result<String> {
+        trace!("request_airdrop id={} lamports={}", id, lamports);
         let pubkey = verify_pubkey(id)?;
 
         let blockhash = meta
@@ -302,11 +302,13 @@ impl RpcSol for RpcSolImpl {
             .unwrap()
             .bank()?
             .last_blockhash();
-        let transaction = request_airdrop_transaction(&meta.drone_addr, &pubkey, tokens, blockhash)
-            .map_err(|err| {
-                info!("request_airdrop_transaction failed: {:?}", err);
-                Error::internal_error()
-            })?;;
+        let transaction =
+            request_airdrop_transaction(&meta.drone_addr, &pubkey, lamports, blockhash).map_err(
+                |err| {
+                    info!("request_airdrop_transaction failed: {:?}", err);
+                    Error::internal_error()
+                },
+            )?;;
 
         let data = serialize(&transaction).map_err(|err| {
             info!("request_airdrop: serialize error: {:?}", err);
@@ -517,7 +519,7 @@ mod tests {
             "jsonrpc":"2.0",
             "result":{
                 "owner": [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],
-                "tokens": 20,
+                "lamports": 20,
                 "userdata": [],
                 "executable": false
             },

--- a/core/src/rpc_mock.rs
+++ b/core/src/rpc_mock.rs
@@ -97,10 +97,10 @@ impl RpcRequestHandler for MockRpcClient {
 pub fn request_airdrop_transaction(
     _drone_addr: &SocketAddr,
     _id: &Pubkey,
-    tokens: u64,
+    lamports: u64,
     _blockhash: Hash,
 ) -> Result<Transaction, Error> {
-    if tokens == 0 {
+    if lamports == 0 {
         Err(Error::new(ErrorKind::Other, "Airdrop failed"))?
     }
     let key = Keypair::new();

--- a/core/src/rpc_mock.rs
+++ b/core/src/rpc_mock.rs
@@ -106,6 +106,6 @@ pub fn request_airdrop_transaction(
     let key = Keypair::new();
     let to = Keypair::new().pubkey();
     let blockhash = Hash::default();
-    let tx = SystemTransaction::new_account(&key, to, 50, blockhash, 0);
+    let tx = SystemTransaction::new_account(&key, to, lamports, blockhash, 0);
     Ok(tx)
 }

--- a/core/src/rpc_pubsub.rs
+++ b/core/src/rpc_pubsub.rs
@@ -323,7 +323,7 @@ mod tests {
            "params": {
                "result": {
                    "owner": budget_program_id,
-                   "tokens": 1,
+                   "lamports": 1,
                    "userdata": expected_userdata,
                    "executable": executable,
 
@@ -359,7 +359,7 @@ mod tests {
            "params": {
                "result": {
                    "owner": budget_program_id,
-                   "tokens": 51,
+                   "lamports": 51,
                    "userdata": expected_userdata,
                     "executable": executable,
                },
@@ -393,7 +393,7 @@ mod tests {
            "params": {
                "result": {
                    "owner": budget_program_id,
-                   "tokens": 1,
+                   "lamports": 1,
                    "userdata": expected_userdata,
                     "executable": executable,
                },

--- a/core/src/rpc_subscriptions.rs
+++ b/core/src/rpc_subscriptions.rs
@@ -185,7 +185,7 @@ mod tests {
         subscriptions.check_account(&alice.pubkey(), &account);
         let string = transport_receiver.poll();
         if let Async::Ready(Some(response)) = string.unwrap() {
-            let expected = format!(r#"{{"jsonrpc":"2.0","method":"accountNotification","params":{{"result":{{"executable":false,"owner":[129,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"tokens":1,"userdata":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]}},"subscription":0}}}}"#);
+            let expected = format!(r#"{{"jsonrpc":"2.0","method":"accountNotification","params":{{"result":{{"executable":false,"lamports":1,"owner":[129,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"userdata":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]}},"subscription":0}}}}"#);
             assert_eq!(expected, response);
         }
 

--- a/core/src/sigverify.rs
+++ b/core/src/sigverify.rs
@@ -493,13 +493,13 @@ mod tests {
         let keypair0 = Keypair::new();
         let keypair1 = Keypair::new();
         let keypairs = vec![&keypair0, &keypair1];
-        let tokens = 5;
+        let lamports = 5;
         let fee = 2;
         let blockhash = Hash::default();
 
         let keys = vec![keypair0.pubkey(), keypair1.pubkey()];
 
-        let system_instruction = SystemInstruction::Move { tokens };
+        let system_instruction = SystemInstruction::Move { lamports };
 
         let program_ids = vec![system_program::id(), solana_budget_api::id()];
 

--- a/core/src/staking_utils.rs
+++ b/core/src/staking_utils.rs
@@ -152,9 +152,9 @@ mod tests {
     #[test]
     fn test_bank_staked_nodes_at_epoch() {
         let pubkey = Keypair::new().pubkey();
-        let bootstrap_tokens = 3;
+        let bootstrap_lamports = 3;
         let (genesis_block, _) =
-            GenesisBlock::new_with_leader(bootstrap_tokens, pubkey, bootstrap_tokens);
+            GenesisBlock::new_with_leader(bootstrap_lamports, pubkey, bootstrap_lamports);
         let bank = Bank::new(&genesis_block);
 
         // Epoch doesn't exist
@@ -181,7 +181,7 @@ mod tests {
         let bank_voter = Keypair::new();
 
         // Give the validator some stake but don't setup a staking account
-        // Validator has no tokens staked, so they get filtered out. Only the bootstrap leader
+        // Validator has no lamports staked, so they get filtered out. Only the bootstrap leader
         // created by the genesis block will get included
         bank.transfer(1, &mint_keypair, validator.pubkey(), genesis_block.hash())
             .unwrap();

--- a/core/src/voting_keypair.rs
+++ b/core/src/voting_keypair.rs
@@ -106,11 +106,10 @@ pub mod tests {
         from_keypair: &Keypair,
         voting_pubkey: &Pubkey,
         bank: &Bank,
-        num_tokens: u64,
+        lamports: u64,
     ) {
         let blockhash = bank.last_blockhash();
-        let tx =
-            VoteTransaction::new_account(from_keypair, *voting_pubkey, blockhash, num_tokens, 0);
+        let tx = VoteTransaction::new_account(from_keypair, *voting_pubkey, blockhash, lamports, 0);
         bank.process_transaction(&tx).unwrap();
     }
 
@@ -124,10 +123,10 @@ pub mod tests {
         from_keypair: &Keypair,
         voting_keypair: &T,
         bank: &Bank,
-        num_tokens: u64,
+        lamports: u64,
         slot: u64,
     ) {
-        new_vote_account(from_keypair, &voting_keypair.pubkey(), bank, num_tokens);
+        new_vote_account(from_keypair, &voting_keypair.pubkey(), bank, lamports);
         push_vote(voting_keypair, bank, slot);
     }
 }

--- a/drone/tests/local-drone.rs
+++ b/drone/tests/local-drone.rs
@@ -10,10 +10,10 @@ use std::sync::mpsc::channel;
 fn test_local_drone() {
     let keypair = Keypair::new();
     let to = Keypair::new().pubkey();
-    let tokens = 50;
+    let lamports = 50;
     let blockhash = Hash::new(&to.as_ref());
     let expected_instruction = SystemInstruction::CreateAccount {
-        tokens,
+        lamports,
         space: 0,
         program_id: system_program::id(),
     };
@@ -31,6 +31,6 @@ fn test_local_drone() {
     run_local_drone(keypair, sender);
     let drone_addr = receiver.recv().unwrap();
 
-    let result = request_airdrop_transaction(&drone_addr, &to, tokens, blockhash);
+    let result = request_airdrop_transaction(&drone_addr, &to, lamports, blockhash);
     assert_eq!(expected_tx, result.unwrap());
 }

--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -7,14 +7,14 @@ use solana_sdk::signature::{read_keypair, Keypair, KeypairUtil};
 use std::error;
 
 /**
- * Bootstrap leader gets two tokens:
- * - one token to create an instance of the vote_program with
- * - one token for the transaction fee
- * - one second token to keep the node identity public key valid
+ * Bootstrap leader gets two lamports:
+ * - one lamport to create an instance of the vote_program with
+ * - one lamport for the transaction fee
+ * - one second lamport to keep the node identity public key valid
  */
 //pub const BOOTSTRAP_LEADER_LAMPORTS: u64 = 3;
 // TODO: Until https://github.com/solana-labs/solana/issues/2355 is resolved the bootstrap leader
-// needs N tokens as its vote account gets re-created on every node restart, costing it tokens
+// needs N lamports as its vote account gets re-created on every node restart, costing it lamports
 pub const BOOTSTRAP_LEADER_LAMPORTS: u64 = 1_000_000;
 
 fn main() -> Result<(), Box<dyn error::Error>> {
@@ -39,13 +39,13 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                 .help("Use directory as persistent ledger location"),
         )
         .arg(
-            Arg::with_name("num_tokens")
+            Arg::with_name("lamports")
                 .short("t")
-                .long("num_tokens")
-                .value_name("TOKENS")
+                .long("lamports")
+                .value_name("LAMPORTS")
                 .takes_value(true)
                 .required(true)
-                .help("Number of tokens to create in the mint"),
+                .help("Number of lamports to create in the mint"),
         )
         .arg(
             Arg::with_name("mint_keypair_file")
@@ -61,14 +61,14 @@ fn main() -> Result<(), Box<dyn error::Error>> {
     let bootstrap_leader_keypair_file = matches.value_of("bootstrap_leader_keypair_file").unwrap();
     let ledger_path = matches.value_of("ledger_path").unwrap();
     let mint_keypair_file = matches.value_of("mint_keypair_file").unwrap();
-    let num_tokens = value_t_or_exit!(matches, "num_tokens", u64);
+    let lamports = value_t_or_exit!(matches, "lamports", u64);
 
     let bootstrap_leader_keypair = read_keypair(bootstrap_leader_keypair_file)?;
     let mint_keypair = read_keypair(mint_keypair_file)?;
 
     let bootstrap_leader_vote_account_keypair = Keypair::new();
     let (mut genesis_block, _mint_keypair) = GenesisBlock::new_with_leader(
-        num_tokens,
+        lamports,
         bootstrap_leader_keypair.pubkey(),
         BOOTSTRAP_LEADER_LAMPORTS,
     );

--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -12,10 +12,10 @@ use std::error;
  * - one token for the transaction fee
  * - one second token to keep the node identity public key valid
  */
-//pub const BOOTSTRAP_LEADER_TOKENS: u64 = 3;
+//pub const BOOTSTRAP_LEADER_LAMPORTS: u64 = 3;
 // TODO: Until https://github.com/solana-labs/solana/issues/2355 is resolved the bootstrap leader
 // needs N tokens as its vote account gets re-created on every node restart, costing it tokens
-pub const BOOTSTRAP_LEADER_TOKENS: u64 = 1_000_000;
+pub const BOOTSTRAP_LEADER_LAMPORTS: u64 = 1_000_000;
 
 fn main() -> Result<(), Box<dyn error::Error>> {
     let matches = App::new("solana-genesis")
@@ -70,7 +70,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
     let (mut genesis_block, _mint_keypair) = GenesisBlock::new_with_leader(
         num_tokens,
         bootstrap_leader_keypair.pubkey(),
-        BOOTSTRAP_LEADER_TOKENS,
+        BOOTSTRAP_LEADER_LAMPORTS,
     );
     genesis_block.mint_id = mint_keypair.pubkey();
     genesis_block.bootstrap_leader_vote_account_id = bootstrap_leader_vote_account_keypair.pubkey();

--- a/multinode-demo/fullnode.sh
+++ b/multinode-demo/fullnode.sh
@@ -191,15 +191,15 @@ if [[ ! -d "$ledger_config_dir" ]]; then
 
   $solana_wallet --keypair "$fullnode_id_path" address
 
-  # A fullnode requires 3 tokens to function:
+  # A fullnode requires 3 lamports to function:
   # - one token to create an instance of the vote_program with
   # - one token for the transaction fee
   # - one token to keep the node identity public key valid.
   retries=5
   while true; do
     # TODO: Until https://github.com/solana-labs/solana/issues/2355 is resolved
-    # a fullnode needs N tokens as its vote account gets re-created on every
-    # node restart, costing it tokens
+    # a fullnode needs N lamports as its vote account gets re-created on every
+    # node restart, costing it lamports
     if $solana_wallet --keypair "$fullnode_id_path" --host "${leader_address%:*}" airdrop 1000000; then
       break
     fi

--- a/multinode-demo/setup.sh
+++ b/multinode-demo/setup.sh
@@ -14,11 +14,11 @@ usage () {
     echo "Error: $*"
   fi
   cat <<EOF
-usage: $0 [-n num_tokens] [-l] [-p] [-t node_type]
+usage: $0 [-n lamports] [-l] [-p] [-t node_type]
 
 Creates a fullnode configuration
 
- -n num_tokens  - Number of tokens to create
+ -n lamports    - Number of lamports to create
  -t node_type   - Create configuration files only for this kind of node.  Valid
                   options are bootstrap-leader or fullnode.  Creates configuration files
                   for both by default
@@ -27,7 +27,7 @@ EOF
   exit $exitcode
 }
 
-num_tokens=1000000000
+lamports=1000000000
 bootstrap_leader=true
 fullnode=true
 while getopts "h?n:lpt:" opt; do
@@ -37,7 +37,7 @@ while getopts "h?n:lpt:" opt; do
     exit 0
     ;;
   n)
-    num_tokens="$OPTARG"
+    lamports="$OPTARG"
     ;;
   t)
     node_type="$OPTARG"
@@ -80,7 +80,7 @@ if $bootstrap_leader; then
       --bootstrap-leader-keypair "$SOLANA_CONFIG_DIR"/bootstrap-leader-id.json \
       --ledger "$SOLANA_RSYNC_CONFIG_DIR"/ledger \
       --mint "$SOLANA_CONFIG_DIR"/mint-id.json \
-      --num_tokens "$num_tokens"
+      --lamports "$lamports"
     cp -a "$SOLANA_RSYNC_CONFIG_DIR"/ledger "$SOLANA_CONFIG_DIR"/bootstrap-leader-ledger
   )
 fi

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -147,7 +147,7 @@ fn serialize_parameters(
         v.write_u64::<LittleEndian>(info.signer_key().is_some() as u64)
             .unwrap();
         v.write_all(info.unsigned_key().as_ref()).unwrap();
-        v.write_u64::<LittleEndian>(info.account.tokens).unwrap();
+        v.write_u64::<LittleEndian>(info.account.lamports).unwrap();
         v.write_u64::<LittleEndian>(info.account.userdata.len() as u64)
             .unwrap();
         v.write_all(&info.account.userdata).unwrap();
@@ -167,9 +167,9 @@ fn deserialize_parameters(keyed_accounts: &mut [KeyedAccount], buffer: &[u8]) {
     for info in keyed_accounts.iter_mut() {
         start += mem::size_of::<u64>(); // skip signer_key boolean
         start += mem::size_of::<Pubkey>(); // skip pubkey
-        info.account.tokens = LittleEndian::read_u64(&buffer[start..]);
+        info.account.lamports = LittleEndian::read_u64(&buffer[start..]);
 
-        start += mem::size_of::<u64>() // skip tokens
+        start += mem::size_of::<u64>() // skip lamports
                   + mem::size_of::<u64>(); // skip length tag
         let end = start + info.account.userdata.len();
         info.account.userdata.clone_from_slice(&buffer[start..end]);

--- a/programs/rewards/src/lib.rs
+++ b/programs/rewards/src/lib.rs
@@ -48,7 +48,7 @@ fn redeem_vote_credits(keyed_accounts: &mut [KeyedAccount]) -> Result<(), Progra
 
     // TODO: This assumes the stake is static. If not, it should use the account value
     // at the time of voting, not at credit redemption.
-    let stake = keyed_accounts[0].account.tokens;
+    let stake = keyed_accounts[0].account.lamports;
     if stake == 0 {
         error!("staking account has no stake");
         Err(ProgramError::InvalidArgument)?;
@@ -57,8 +57,8 @@ fn redeem_vote_credits(keyed_accounts: &mut [KeyedAccount]) -> Result<(), Progra
     let lamports = calc_vote_reward(vote_state.credits(), stake)?;
 
     // Transfer rewards from the rewards pool to the staking account.
-    keyed_accounts[1].account.tokens -= lamports;
-    keyed_accounts[0].account.tokens += lamports;
+    keyed_accounts[1].account.lamports -= lamports;
+    keyed_accounts[0].account.lamports += lamports;
 
     Ok(())
 }
@@ -90,9 +90,9 @@ mod tests {
     use solana_vote_api::vote_instruction::Vote;
     use solana_vote_api::vote_state;
 
-    fn create_rewards_account(tokens: u64) -> Account {
+    fn create_rewards_account(lamports: u64) -> Account {
         let space = RewardsState::max_size();
-        Account::new(tokens, space, solana_rewards_api::id())
+        Account::new(lamports, space, solana_rewards_api::id())
     }
 
     fn redeem_vote_credits_(
@@ -130,7 +130,7 @@ mod tests {
         let rewards_id = Keypair::new().pubkey();
         let mut rewards_account = create_rewards_account(100);
 
-        let tokens_before = vote_account.tokens;
+        let lamports_before = vote_account.lamports;
 
         redeem_vote_credits_(
             &rewards_id,
@@ -139,6 +139,6 @@ mod tests {
             &mut vote_account,
         )
         .unwrap();
-        assert!(vote_account.tokens > tokens_before);
+        assert!(vote_account.lamports > lamports_before);
     }
 }

--- a/programs/storage/src/lib.rs
+++ b/programs/storage/src/lib.rs
@@ -152,7 +152,7 @@ fn entrypoint(
                 }
                 total_validations += num_validations;
                 if total_validations > 0 {
-                    keyed_accounts[0].account.tokens +=
+                    keyed_accounts[0].account.lamports +=
                         (TOTAL_VALIDATOR_REWARDS * num_validations) / total_validations;
                 }
             }
@@ -360,6 +360,6 @@ mod test {
         let tx = StorageTransaction::new_reward_claim(&keypair, Hash::default(), entry_height);
         test_transaction(&tx, &mut accounts).unwrap();
 
-        assert!(accounts[0].tokens == TOTAL_VALIDATOR_REWARDS);
+        assert!(accounts[0].lamports == TOTAL_VALIDATOR_REWARDS);
     }
 }

--- a/programs/system/tests/system.rs
+++ b/programs/system/tests/system.rs
@@ -40,7 +40,7 @@ fn test_system_unsigned_transaction() {
     let tx = TransactionBuilder::default()
         .push(BuilderInstruction::new(
             system_program::id(),
-            &SystemInstruction::Move { tokens: 10 },
+            &SystemInstruction::Move { lamports: 10 },
             vec![(from_keypair.pubkey(), false), (to_keypair.pubkey(), true)],
         ))
         .sign(&[&to_keypair], blockhash);

--- a/run.sh
+++ b/run.sh
@@ -43,7 +43,7 @@ solana-keygen -o "$dataDir"/config/leader-keypair.json
 solana-keygen -o "$dataDir"/config/drone-keypair.json
 
 solana-genesis \
-  --num_tokens 1000000000 \
+  --lamports 1000000000 \
   --mint "$dataDir"/config/drone-keypair.json \
   --bootstrap-leader-keypair "$dataDir"/config/leader-keypair.json \
   --ledger "$dataDir"/ledger

--- a/runtime/src/append_vec.rs
+++ b/runtime/src/append_vec.rs
@@ -40,7 +40,7 @@ pub fn serialize_account(dst_slice: &mut [u8], account: &Account, len: usize) {
     let mut at = 0;
 
     write_u64(&mut at, dst_slice, len as u64);
-    write_u64(&mut at, dst_slice, account.tokens);
+    write_u64(&mut at, dst_slice, account.lamports);
     write_bytes(&mut at, dst_slice, &account.userdata);
     write_bytes(&mut at, dst_slice, account.owner.as_ref());
     write_bytes(&mut at, dst_slice, &[account.executable as u8]);
@@ -81,7 +81,7 @@ pub fn deserialize_account(
     let len = size as usize;
     assert!(current_offset >= at + len);
 
-    let tokens = read_u64(&mut at, &src_slice);
+    let lamports = read_u64(&mut at, &src_slice);
 
     let userdata_len = len - get_account_size_static();
     let mut userdata = vec![0; userdata_len];
@@ -96,7 +96,7 @@ pub fn deserialize_account(
     let executable: bool = exec[0] != 0;
 
     Ok(Account {
-        tokens,
+        lamports,
         userdata,
         owner,
         executable,
@@ -255,7 +255,7 @@ pub mod tests {
         let av: AppendVec<Account> = AppendVec::new(path, true, START_SIZE, INC_SIZE);
         let v1 = vec![1u8; 32];
         let mut account1 = Account {
-            tokens: 1,
+            lamports: 1,
             userdata: v1,
             owner: Pubkey::default(),
             executable: false,
@@ -266,7 +266,7 @@ pub mod tests {
 
         let v2 = vec![4u8; 32];
         let mut account2 = Account {
-            tokens: 1,
+            lamports: 1,
             userdata: v2,
             owner: Pubkey::default(),
             executable: false,

--- a/sdk/src/account.rs
+++ b/sdk/src/account.rs
@@ -5,8 +5,8 @@ use std::{cmp, fmt};
 #[repr(C)]
 #[derive(Serialize, Deserialize, Clone, Default, Eq, PartialEq)]
 pub struct Account {
-    /// tokens in the account
-    pub tokens: u64,
+    /// lamports in the account
+    pub lamports: u64,
     /// data held in this account
     pub userdata: Vec<u8>,
     /// the program that owns this account. If executable, the program that loads this account.
@@ -28,8 +28,8 @@ impl fmt::Debug for Account {
         };
         write!(
             f,
-            "Account {{ tokens: {} userdata.len: {} owner: {} executable: {}{} }}",
-            self.tokens,
+            "Account {{ lamports: {} userdata.len: {} owner: {} executable: {}{} }}",
+            self.lamports,
             self.userdata.len(),
             self.owner,
             self.executable,
@@ -40,9 +40,9 @@ impl fmt::Debug for Account {
 
 impl Account {
     // TODO do we want to add executable and leader_owner even though they should always be false/default?
-    pub fn new(tokens: u64, space: usize, owner: Pubkey) -> Account {
+    pub fn new(lamports: u64, space: usize, owner: Pubkey) -> Account {
         Account {
-            tokens,
+            lamports,
             userdata: vec![0u8; space],
             owner,
             executable: false,

--- a/sdk/src/genesis_block.rs
+++ b/sdk/src/genesis_block.rs
@@ -8,18 +8,18 @@ use std::fs::File;
 use std::io::Write;
 use std::path::Path;
 
-// The default (and minimal) amount of tokens given to the bootstrap leader:
-// * 2 tokens for the bootstrap leader ID account to later setup another vote account
-// * 1 token for the bootstrap leader vote account
-pub const BOOTSTRAP_LEADER_TOKENS: u64 = 3;
+// The default (and minimal) amount of lamports given to the bootstrap leader:
+// * 2 lamports for the bootstrap leader ID account to later setup another vote account
+// * 1 lamport for the bootstrap leader vote account
+pub const BOOTSTRAP_LEADER_LAMPORTS: u64 = 3;
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct GenesisBlock {
     pub bootstrap_leader_id: Pubkey,
-    pub bootstrap_leader_tokens: u64,
+    pub bootstrap_leader_lamports: u64,
     pub bootstrap_leader_vote_account_id: Pubkey,
     pub mint_id: Pubkey,
-    pub tokens: u64,
+    pub lamports: u64,
     pub ticks_per_slot: u64,
     pub slots_per_epoch: u64,
     pub stakers_slot_offset: u64,
@@ -27,27 +27,27 @@ pub struct GenesisBlock {
 
 impl GenesisBlock {
     #[allow(clippy::new_ret_no_self)]
-    pub fn new(tokens: u64) -> (Self, Keypair) {
-        let tokens = tokens
-            .checked_add(BOOTSTRAP_LEADER_TOKENS)
-            .unwrap_or(tokens);
-        Self::new_with_leader(tokens, Keypair::new().pubkey(), BOOTSTRAP_LEADER_TOKENS)
+    pub fn new(lamports: u64) -> (Self, Keypair) {
+        let lamports = lamports
+            .checked_add(BOOTSTRAP_LEADER_LAMPORTS)
+            .unwrap_or(lamports);
+        Self::new_with_leader(lamports, Keypair::new().pubkey(), BOOTSTRAP_LEADER_LAMPORTS)
     }
 
     pub fn new_with_leader(
-        tokens: u64,
+        lamports: u64,
         bootstrap_leader_id: Pubkey,
-        bootstrap_leader_tokens: u64,
+        bootstrap_leader_lamports: u64,
     ) -> (Self, Keypair) {
         let mint_keypair = Keypair::new();
         let bootstrap_leader_vote_account_keypair = Keypair::new();
         (
             Self {
                 bootstrap_leader_id,
-                bootstrap_leader_tokens,
+                bootstrap_leader_lamports,
                 bootstrap_leader_vote_account_id: bootstrap_leader_vote_account_keypair.pubkey(),
                 mint_id: mint_keypair.pubkey(),
-                tokens,
+                lamports,
                 ticks_per_slot: DEFAULT_TICKS_PER_SLOT,
                 slots_per_epoch: DEFAULT_SLOTS_PER_EPOCH,
                 stakers_slot_offset: DEFAULT_SLOTS_PER_EPOCH,
@@ -81,13 +81,13 @@ mod tests {
     #[test]
     fn test_genesis_block_new() {
         let (genesis_block, mint) = GenesisBlock::new(10_000);
-        assert_eq!(genesis_block.tokens, 10_000 + BOOTSTRAP_LEADER_TOKENS);
+        assert_eq!(genesis_block.lamports, 10_000 + BOOTSTRAP_LEADER_LAMPORTS);
         assert_eq!(genesis_block.mint_id, mint.pubkey());
         assert!(genesis_block.bootstrap_leader_id != Pubkey::default());
         assert!(genesis_block.bootstrap_leader_vote_account_id != Pubkey::default());
         assert_eq!(
-            genesis_block.bootstrap_leader_tokens,
-            BOOTSTRAP_LEADER_TOKENS
+            genesis_block.bootstrap_leader_lamports,
+            BOOTSTRAP_LEADER_LAMPORTS
         );
     }
 
@@ -97,9 +97,9 @@ mod tests {
         let (genesis_block, mint) =
             GenesisBlock::new_with_leader(20_000, leader_keypair.pubkey(), 123);
 
-        assert_eq!(genesis_block.tokens, 20_000);
+        assert_eq!(genesis_block.lamports, 20_000);
         assert_eq!(genesis_block.mint_id, mint.pubkey());
         assert_eq!(genesis_block.bootstrap_leader_id, leader_keypair.pubkey());
-        assert_eq!(genesis_block.bootstrap_leader_tokens, 123);
+        assert_eq!(genesis_block.bootstrap_leader_lamports, 123);
     }
 }

--- a/sdk/src/native_loader.rs
+++ b/sdk/src/native_loader.rs
@@ -16,7 +16,7 @@ pub fn check_id(program_id: &Pubkey) -> bool {
 /// Create an executable account with the given shared object name.
 pub fn create_program_account(name: &str) -> Account {
     Account {
-        tokens: 1,
+        lamports: 1,
         owner: id(),
         userdata: name.as_bytes().to_vec(),
         executable: true,

--- a/sdk/src/native_program.rs
+++ b/sdk/src/native_program.rs
@@ -14,16 +14,16 @@ pub enum ProgramError {
     /// An instruction resulted in an account with a negative balance
     /// The difference from InsufficientFundsForFee is that the transaction was executed by the
     /// contract
-    ResultWithNegativeTokens,
+    ResultWithNegativeLamports,
 
-    /// Program's instruction token balance does not equal the balance after the instruction
+    /// Program's instruction lamport balance does not equal the balance after the instruction
     UnbalancedInstruction,
 
     /// Program modified an account's program id
     ModifiedProgramId,
 
-    /// Program spent the tokens of an account that doesn't belong to it
-    ExternalAccountTokenSpend,
+    /// Program spent the lamports of an account that doesn't belong to it
+    ExternalAccountLamportSpend,
 
     /// Program modified the userdata of an account that doesn't belong to it
     ExternalAccountUserdataModified,

--- a/sdk/src/system_instruction.rs
+++ b/sdk/src/system_instruction.rs
@@ -7,35 +7,35 @@ pub enum SystemInstruction {
     /// Create a new account
     /// * Transaction::keys[0] - source
     /// * Transaction::keys[1] - new account key
-    /// * tokens - number of tokens to transfer to the new account
+    /// * lamports - number of lamports to transfer to the new account
     /// * space - memory to allocate if greater then zero
     /// * program_id - the program id of the new account
     CreateAccount {
-        tokens: u64,
+        lamports: u64,
         space: u64,
         program_id: Pubkey,
     },
     /// Assign account to a program
     /// * Transaction::keys[0] - account to assign
     Assign { program_id: Pubkey },
-    /// Move tokens
+    /// Move lamports
     /// * Transaction::keys[0] - source
     /// * Transaction::keys[1] - destination
-    Move { tokens: u64 },
+    Move { lamports: u64 },
 }
 
 impl SystemInstruction {
     pub fn new_program_account(
         from_id: Pubkey,
         to_id: Pubkey,
-        tokens: u64,
+        lamports: u64,
         space: u64,
         program_id: Pubkey,
     ) -> BuilderInstruction {
         BuilderInstruction::new(
             system_program::id(),
             &SystemInstruction::CreateAccount {
-                tokens,
+                lamports,
                 space,
                 program_id,
             },
@@ -43,10 +43,10 @@ impl SystemInstruction {
         )
     }
 
-    pub fn new_move(from_id: Pubkey, to_id: Pubkey, tokens: u64) -> BuilderInstruction {
+    pub fn new_move(from_id: Pubkey, to_id: Pubkey, lamports: u64) -> BuilderInstruction {
         BuilderInstruction::new(
             system_program::id(),
-            &SystemInstruction::Move { tokens },
+            &SystemInstruction::Move { lamports },
             vec![(from_id, true), (to_id, false)],
         )
     }

--- a/sdk/src/system_transaction.rs
+++ b/sdk/src/system_transaction.rs
@@ -15,13 +15,13 @@ impl SystemTransaction {
         from_keypair: &Keypair,
         to: Pubkey,
         recent_blockhash: Hash,
-        tokens: u64,
+        lamports: u64,
         space: u64,
         program_id: Pubkey,
         fee: u64,
     ) -> Transaction {
         let create = SystemInstruction::CreateAccount {
-            tokens, //TODO, the tokens to allocate might need to be higher then 0 in the future
+            lamports, //TODO, the lamports to allocate might need to be higher then 0 in the future
             space,
             program_id,
         };
@@ -39,7 +39,7 @@ impl SystemTransaction {
     pub fn new_account(
         from_keypair: &Keypair,
         to: Pubkey,
-        tokens: u64,
+        lamports: u64,
         recent_blockhash: Hash,
         fee: u64,
     ) -> Transaction {
@@ -48,7 +48,7 @@ impl SystemTransaction {
             from_keypair,
             to,
             recent_blockhash,
-            tokens,
+            lamports,
             0,
             program_id,
             fee,
@@ -75,16 +75,16 @@ impl SystemTransaction {
     pub fn new_move(
         from_keypair: &Keypair,
         to: Pubkey,
-        tokens: u64,
+        lamports: u64,
         recent_blockhash: Hash,
         fee: u64,
     ) -> Transaction {
-        let move_tokens = SystemInstruction::Move { tokens };
+        let move_lamports = SystemInstruction::Move { lamports };
         Transaction::new(
             from_keypair,
             &[to],
             system_program::id(),
-            &move_tokens,
+            &move_lamports,
             recent_blockhash,
             fee,
         )
@@ -100,7 +100,7 @@ impl SystemTransaction {
             .iter()
             .enumerate()
             .map(|(i, (_, amount))| {
-                let spend = SystemInstruction::Move { tokens: *amount };
+                let spend = SystemInstruction::Move { lamports: *amount };
                 Instruction::new(0, &spend, vec![0, i as u8 + 1])
             })
             .collect();

--- a/sdk/src/transaction.rs
+++ b/sdk/src/transaction.rs
@@ -86,7 +86,7 @@ pub struct Transaction {
     pub account_keys: Vec<Pubkey>,
     /// The id of a recent ledger entry.
     pub recent_blockhash: Hash,
-    /// The number of tokens paid for processing and storing of this transaction.
+    /// The number of lamports paid for processing and storing of this transaction.
     pub fee: u64,
     /// All the program id keys used to execute this transaction's instructions
     pub program_ids: Vec<Pubkey>,
@@ -141,7 +141,7 @@ impl Transaction {
     /// Create a signed transaction
     /// * `from_keypair` - The key used to sign the transaction.  This key is stored as keys[0]
     /// * `account_keys` - The keys for the transaction.  These are the program state
-    ///    instances or token recipient keys.
+    ///    instances or lamport recipient keys.
     /// * `recent_blockhash` - The PoH hash.
     /// * `fee` - The transaction fee.
     /// * `program_ids` - The keys that identify programs used in the `instruction` vector.

--- a/wallet/tests/deploy.rs
+++ b/wallet/tests/deploy.rs
@@ -50,7 +50,10 @@ fn test_wallet_deploy_program() {
         .make_rpc_request(1, RpcRequest::GetAccountInfo, Some(params))
         .unwrap();
     let account_info_obj = account_info.as_object().unwrap();
-    assert_eq!(account_info_obj.get("tokens").unwrap().as_u64().unwrap(), 1);
+    assert_eq!(
+        account_info_obj.get("lamports").unwrap().as_u64().unwrap(),
+        1
+    );
     let owner_array = account_info.get("owner").unwrap();
     assert_eq!(owner_array, &json!(bpf_loader::id()));
     assert_eq!(


### PR DESCRIPTION
This patch renames tokens to lamports under sdk/, and then updates all affected references outside of sdk/ to match.

Part of #1834