### PR TITLE
More token to lamport renaming

### DIFF
--- a/book/src/programs.md
+++ b/book/src/programs.md
@@ -3,8 +3,8 @@
 A client *app* interacts with a Solana cluster by sending it *transactions*
 with one or more *instructions*. The Solana *runtime* passes those instructions
 to user-contributed *programs*. An instruction might, for example, tell a
-program to move *tokens* from one *account* to another or create an interactive
-contract that governs how tokens are moved. Instructions are executed
+program to move *lamports* from one *account* to another or create an interactive
+contract that governs how lamports are moved. Instructions are executed
 atomically. If any instruction is invalid, any changes made within the
 transaction are discarded.
 

--- a/book/src/runtime.md
+++ b/book/src/runtime.md
@@ -18,7 +18,7 @@ transaction fails to commit.
 
 ### Account Structure
 
-Accounts maintain a token balance and program-specific memory.
+Accounts maintain a lamport balance and program-specific memory.
 
 # Transaction Engine
 
@@ -33,7 +33,7 @@ memory is committed.
 
 The TVU runtime ensures that PoH verification occurs before the runtime
 processes any transactions.
- 
+
 <img alt="Runtime pipeline" src="img/runtime.svg" class="center"/>
 
 At the *execute* stage, the loaded accounts have no data dependencies, so all the
@@ -67,7 +67,7 @@ userdata array and assign it to a Program.
 
 * `Assign` - Allows the user to assign an existing account to a program.
 
-* `Move`  - Moves tokens between accounts.
+* `Move`  - Moves lamports between accounts.
 
 ## Program State Security
 
@@ -101,7 +101,7 @@ program, the Account's userdata is zero initialized.
 * Runtime guarantees that a program's code is the only code that can modify
 Account userdata that the Account is assigned to.
 
-* Runtime guarantees that the program can only spend tokens that are in
+* Runtime guarantees that the program can only spend lamports that are in
 accounts that are assigned to it.
 
 * Runtime guarantees the balances belonging to accounts are balanced before

--- a/book/src/tictactoe.md
+++ b/book/src/tictactoe.md
@@ -23,13 +23,13 @@ Next, follow the steps in the git repository's
 [README](https://github.com/solana-labs/example-tictactoe/blob/master/README.md).
 
 
-## Getting tokens to users
+## Getting lamports to users
 
 You may have noticed you interacted with the Solana cluster without first
-needing to acquire tokens to pay transaction fees. Under the hood, the web
+needing to acquire lamports to pay transaction fees. Under the hood, the web
 app creates a new ephemeral identity and sends a request to an off-chain
 service for a signed transaction authorizing a user to start a new game.
 The service is called a *drone*. When the app sends the signed transaction
-to the Solana cluster, the drone's tokens are spent to pay the transaction
+to the Solana cluster, the drone's lamports are spent to pay the transaction
 fee and start the game. In a real world app, the drone might request the user
-watch an ad or pass a CAPTCHA before signing over its tokens.
+watch an ad or pass a CAPTCHA before signing over its lamports.

--- a/book/src/wallet.md
+++ b/book/src/wallet.md
@@ -14,7 +14,7 @@ $ solana-wallet address
 <PUBKEY>
 ```
 
-#### Airdrop Tokens
+#### Airdrop Lamports
 
 ```sh
 // Command
@@ -78,7 +78,7 @@ $ solana-wallet pay <PUBKEY> 123 \
 
 #### Authorized Transfer
 
-A third party must send a signature to unlock the tokens.
+A third party must send a signature to unlock the lamports.
 ```sh
 // Command
 $ solana-wallet pay <PUBKEY> 123 \
@@ -188,7 +188,7 @@ OPTIONS:
 
 SUBCOMMANDS:
     address                  Get your public key
-    airdrop                  Request a batch of tokens
+    airdrop                  Request a batch of lamports
     balance                  Get your balance
     cancel                   Cancel a transfer
     confirm                  Confirm transaction by signature
@@ -214,7 +214,7 @@ FLAGS:
 
 ```manpage
 solana-wallet-airdrop
-Request a batch of tokens
+Request a batch of lamports
 
 USAGE:
     solana-wallet airdrop <NUM>
@@ -224,7 +224,7 @@ FLAGS:
     -V, --version    Prints version information
 
 ARGS:
-    <NUM>    The number of tokens to request
+    <NUM>    The number of lamports to request
 ```
 
 ```manpage
@@ -311,11 +311,11 @@ FLAGS:
 OPTIONS:
         --after <DATETIME>                      A timestamp after which transaction will execute
         --require-timestamp-from <PUBKEY>       Require timestamp from this third party
-        --require-signature-from <PUBKEY>...    Any third party signatures required to unlock the tokens
+        --require-signature-from <PUBKEY>...    Any third party signatures required to unlock the lamports
 
 ARGS:
     <PUBKEY>    The pubkey of recipient
-    <NUM>       The number of tokens to send
+    <NUM>       The number of lamports to send
 ```
 
 ```manpage

--- a/fullnode/src/main.rs
+++ b/fullnode/src/main.rs
@@ -29,18 +29,18 @@ fn create_and_fund_vote_account(
     if node_balance < 1 {
         return Err(Error::new(
             ErrorKind::Other,
-            "insufficient tokens, one token required",
+            "insufficient lamports, one lamport required",
         ));
     }
 
     // Create the vote account if necessary
     if client.poll_get_balance(&vote_account).unwrap_or(0) == 0 {
-        // Need at least two tokens as one token will be spent on a vote_account_new() transaction
+        // Need at least two lamports as one lamport will be spent on a vote_account_new() transaction
         if node_balance < 2 {
-            error!("insufficient tokens, two tokens required");
+            error!("insufficient lamports, two lamports required");
             return Err(Error::new(
                 ErrorKind::Other,
-                "insufficient tokens, two tokens required",
+                "insufficient lamports, two lamports required",
             ));
         }
         loop {

--- a/multinode-demo/fullnode.sh
+++ b/multinode-demo/fullnode.sh
@@ -192,9 +192,9 @@ if [[ ! -d "$ledger_config_dir" ]]; then
   $solana_wallet --keypair "$fullnode_id_path" address
 
   # A fullnode requires 3 lamports to function:
-  # - one token to create an instance of the vote_program with
-  # - one token for the transaction fee
-  # - one token to keep the node identity public key valid.
+  # - one lamport to create an instance of the vote_program with
+  # - one lamport for the transaction fee
+  # - one lamport to keep the node identity public key valid.
   retries=5
   while true; do
     # TODO: Until https://github.com/solana-labs/solana/issues/2355 is resolved

--- a/programs/bpf/c/src/move_funds/move_funds.c
+++ b/programs/bpf/c/src/move_funds/move_funds.c
@@ -24,13 +24,13 @@ extern bool entrypoint(const uint8_t *input) {
     return false;
   }
 
-  int64_t tokens = *(int64_t *)params.data;
-  if (*params.ka[0].tokens >= tokens) {
-    *params.ka[0].tokens -= tokens;
-    *params.ka[2].tokens += tokens;
-    // sol_log_64(0, 0, *ka[0].tokens, *ka[2].tokens, tokens);
+  int64_t lamports = *(int64_t *)params.data;
+  if (*params.ka[0].lamports >= lamports) {
+    *params.ka[0].lamports -= lamports;
+    *params.ka[2].lamports += lamports;
+    // sol_log_64(0, 0, *ka[0].lamports, *ka[2].lamports, lamports);
   } else {
-    // sol_log_64(0, 0, 0xFF, *ka[0].tokens, tokens);
+    // sol_log_64(0, 0, 0xFF, *ka[0].lamports, lamports);
   }
   return true;
 }

--- a/programs/bpf/rust/noop/src/solana_sdk.rs
+++ b/programs/bpf/rust/noop/src/solana_sdk.rs
@@ -121,8 +121,8 @@ pub fn sol_log_params(ka: &[SolKeyedAccount], data: &[u8]) {
         sol_log_64(0, 0, 0, 0, k.is_signer as u64);
         sol_log("- Key");
         sol_log_key(&k.key);
-        sol_log("- Tokens");
-        sol_log_64(0, 0, 0, 0, k.tokens);
+        sol_log("- Lamports");
+        sol_log_64(0, 0, 0, 0, k.lamports);
         sol_log("- Userdata");
         sol_log_slice(k.userdata);
         sol_log("- Owner");
@@ -145,8 +145,8 @@ pub struct SolKeyedAccount<'a> {
     pub key: SolPubkey<'a>,
     /// Public key of the account
     pub is_signer: u64,
-    /// Number of tokens owned by this account
-    pub tokens: u64,
+    /// Number of lamports owned by this account
+    pub lamports: u64,
     /// On-chain data within this account
     pub userdata: &'a [u8],
     /// Program that owns this account
@@ -193,10 +193,10 @@ pub extern "C" fn entrypoint(input: *mut u8) -> bool {
     let key = SolPubkey { key: &key_slice };
     offset += SIZE_PUBKEY;
 
-    let tokens = unsafe {
+    let lamports = unsafe {
         #[allow(clippy::cast_ptr_alignment)]
-        let tokens_ptr: *const u64 = input.add(offset) as *const u64;
-        *tokens_ptr
+        let lamports_ptr: *const u64 = input.add(offset) as *const u64;
+        *lamports_ptr
     };
     offset += size_of::<u64>();
 
@@ -217,7 +217,7 @@ pub extern "C" fn entrypoint(input: *mut u8) -> bool {
     let mut ka = [SolKeyedAccount {
         key,
         is_signer,
-        tokens,
+        lamports,
         userdata,
         owner,
     }];
@@ -385,7 +385,7 @@ mod tests {
         ];
         assert_eq!(SIZE_PUBKEY, ka[0].key.key.len());
         assert_eq!(key, ka[0].key.key);
-        assert_eq!(48, ka[0].tokens);
+        assert_eq!(48, ka[0].lamports);
         assert_eq!(1, ka[0].userdata.len());
         let owner = [0; 32];
         assert_eq!(SIZE_PUBKEY, ka[0].owner.key.len());

--- a/programs/budget/src/budget_program.rs
+++ b/programs/budget/src/budget_program.rs
@@ -27,8 +27,8 @@ fn apply_signature(
         if let Some(key) = keyed_accounts[0].signer_key() {
             if &payment.to == key {
                 budget_state.pending_budget = None;
-                keyed_accounts[1].account.lamports -= payment.tokens;
-                keyed_accounts[0].account.lamports += payment.tokens;
+                keyed_accounts[1].account.lamports -= payment.lamports;
+                keyed_accounts[0].account.lamports += payment.lamports;
                 return Ok(());
             }
         }
@@ -37,8 +37,8 @@ fn apply_signature(
             return Err(BudgetError::DestinationMissing);
         }
         budget_state.pending_budget = None;
-        keyed_accounts[1].account.lamports -= payment.tokens;
-        keyed_accounts[2].account.lamports += payment.tokens;
+        keyed_accounts[1].account.lamports -= payment.lamports;
+        keyed_accounts[2].account.lamports += payment.lamports;
     }
     Ok(())
 }
@@ -68,8 +68,8 @@ fn apply_timestamp(
             return Err(BudgetError::DestinationMissing);
         }
         budget_state.pending_budget = None;
-        keyed_accounts[1].account.lamports -= payment.tokens;
-        keyed_accounts[2].account.lamports += payment.tokens;
+        keyed_accounts[1].account.lamports -= payment.lamports;
+        keyed_accounts[2].account.lamports += payment.lamports;
     }
     Ok(())
 }
@@ -87,7 +87,7 @@ fn apply_debits(
             let expr = expr.clone();
             if let Some(payment) = expr.final_payment() {
                 keyed_accounts[1].account.lamports = 0;
-                keyed_accounts[0].account.lamports += payment.tokens;
+                keyed_accounts[0].account.lamports += payment.lamports;
                 Ok(())
             } else {
                 let existing = BudgetState::deserialize(&keyed_accounts[1].account.userdata).ok();

--- a/programs/budget_api/src/budget_instruction.rs
+++ b/programs/budget_api/src/budget_instruction.rs
@@ -8,8 +8,8 @@ use solana_sdk::transaction_builder::BuilderInstruction;
 /// A smart contract.
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub struct Contract {
-    /// The number of tokens allocated to the `BudgetExpr` and any transaction fees.
-    pub tokens: u64,
+    /// The number of lamports allocated to the `BudgetExpr` and any transaction fees.
+    pub lamports: u64,
     pub budget_expr: BudgetExpr,
 }
 

--- a/programs/budget_api/src/budget_state.rs
+++ b/programs/budget_api/src/budget_state.rs
@@ -10,7 +10,6 @@ pub enum BudgetError {
     ContractNotPending,
     SourceIsPendingContract,
     UninitializedContract,
-    NegativeTokens,
     DestinationMissing,
     FailedWitness,
     UserdataTooSmall,

--- a/programs/budget_api/src/payment_plan.rs
+++ b/programs/budget_api/src/payment_plan.rs
@@ -17,12 +17,12 @@ pub enum Witness {
     Signature,
 }
 
-/// Some amount of tokens that should be sent to the `to` `Pubkey`.
+/// Some amount of lamports that should be sent to the `to` `Pubkey`.
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub struct Payment {
     /// Amount to be paid.
-    pub tokens: u64,
+    pub lamports: u64,
 
-    /// The `Pubkey` that `tokens` should be paid to.
+    /// The `Pubkey` that `lamports` should be paid to.
     pub to: Pubkey,
 }

--- a/programs/rewards/tests/rewards.rs
+++ b/programs/rewards/tests/rewards.rs
@@ -64,7 +64,7 @@ fn test_redeem_vote_credits_via_bank() {
     let bank = Bank::new(&genesis_block);
     let rewards_bank = RewardsBank::new(&bank);
 
-    // Create a rewards account to hold all rewards pool tokens.
+    // Create a rewards account to hold all rewards pool lamports.
     let rewards_keypair = Keypair::new();
     let rewards_id = rewards_keypair.pubkey();
     rewards_bank
@@ -91,13 +91,13 @@ fn test_redeem_vote_credits_via_bank() {
     // TODO: Add VoteInstruction::RegisterStakerId so that we don't need to point the "to"
     // account to the "from" account.
     let to_id = vote_id;
-    let to_tokens = bank.get_balance(&vote_id);
+    let to_lamports = bank.get_balance(&vote_id);
 
     // Periodically, the staker sumbits its vote account to the rewards pool
     // to exchange its credits for lamports.
     let vote_state = rewards_bank
         .redeem_credits(rewards_id, &vote_keypair)
         .unwrap();
-    assert!(bank.get_balance(&to_id) > to_tokens);
+    assert!(bank.get_balance(&to_id) > to_lamports);
     assert_eq!(vote_state.credits(), 0);
 }

--- a/programs/rewards_api/src/rewards_transaction.rs
+++ b/programs/rewards_api/src/rewards_transaction.rs
@@ -19,14 +19,14 @@ impl RewardsTransaction {
         from_keypair: &Keypair,
         rewards_id: Pubkey,
         blockhash: Hash,
-        num_tokens: u64,
+        lamports: u64,
         fee: u64,
     ) -> Transaction {
         SystemTransaction::new_program_account(
             from_keypair,
             rewards_id,
             blockhash,
-            num_tokens,
+            lamports,
             RewardsState::max_size() as u64,
             id(),
             fee,

--- a/programs/token/Cargo.toml
+++ b/programs/token/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "solana-token-program"
 version = "0.12.0"
-description = "Solana token program implementing the ERC20 interface"
+description = "Solana token program"
 authors = ["Solana Maintainers <maintainers@solana.com>"]
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"

--- a/programs/token/src/lib.rs
+++ b/programs/token/src/lib.rs
@@ -1,5 +1,3 @@
-//! The `erc20` library implements a generic erc20-like token
-
 use log::*;
 use solana_sdk::account::KeyedAccount;
 use solana_sdk::native_program::ProgramError;

--- a/programs/token/src/token_program.rs
+++ b/programs/token/src/token_program.rs
@@ -1,5 +1,3 @@
-//! ERC20-like Token
-
 use bincode;
 use log::*;
 use serde_derive::{Deserialize, Serialize};

--- a/programs/token_api/src/lib.rs
+++ b/programs/token_api/src/lib.rs
@@ -1,4 +1,3 @@
-//! An ERC20-like Token
 use solana_sdk::pubkey::Pubkey;
 
 const TOKEN_PROGRAM_ID: [u8; 32] = [

--- a/programs/vote_api/src/vote_state.rs
+++ b/programs/vote_api/src/vote_state.rs
@@ -229,9 +229,9 @@ pub fn clear_credits(keyed_accounts: &mut [KeyedAccount]) -> Result<(), ProgramE
     Ok(())
 }
 
-pub fn create_vote_account(tokens: u64) -> Account {
+pub fn create_vote_account(lamports: u64) -> Account {
     let space = VoteState::max_size();
-    Account::new(tokens, space, id())
+    Account::new(lamports, space, id())
 }
 
 pub fn initialize_and_deserialize(

--- a/programs/vote_api/src/vote_transaction.rs
+++ b/programs/vote_api/src/vote_transaction.rs
@@ -26,12 +26,12 @@ impl VoteTransaction {
             .sign(&[voting_keypair], recent_blockhash)
     }
 
-    /// Fund or create the staking account with tokens
+    /// Fund or create the staking account with lamports
     pub fn new_account(
         from_keypair: &Keypair,
         voter_id: Pubkey,
         recent_blockhash: Hash,
-        num_tokens: u64,
+        lamports: u64,
         fee: u64,
     ) -> Transaction {
         let from_id = from_keypair.pubkey();
@@ -40,7 +40,7 @@ impl VoteTransaction {
             .push(SystemInstruction::new_program_account(
                 from_id,
                 voter_id,
-                num_tokens,
+                lamports,
                 space,
                 id(),
             ))
@@ -48,13 +48,13 @@ impl VoteTransaction {
             .sign(&[from_keypair], recent_blockhash)
     }
 
-    /// Fund or create the staking account with tokens
+    /// Fund or create the staking account with lamports
     pub fn new_account_with_delegate(
         from_keypair: &Keypair,
         voter_keypair: &Keypair,
         delegate_id: Pubkey,
         recent_blockhash: Hash,
-        num_tokens: u64,
+        lamports: u64,
         fee: u64,
     ) -> Transaction {
         let from_id = from_keypair.pubkey();
@@ -64,7 +64,7 @@ impl VoteTransaction {
             .push(SystemInstruction::new_program_account(
                 from_id,
                 voter_id,
-                num_tokens,
+                lamports,
                 space,
                 id(),
             ))

--- a/sdk/bpf/inc/solana_sdk.h
+++ b/sdk/bpf/inc/solana_sdk.h
@@ -112,7 +112,7 @@ SOL_FN_PREFIX bool SolPubkey_same(const SolPubkey *one, const SolPubkey *two) {
 typedef struct {
   SolPubkey *key;        /** Public key of the account */
   bool is_signer;        /** Transaction was signed by this account's key */
-  uint64_t *tokens;      /** Number of tokens owned by this account */
+  uint64_t *lamports;      /** Number of lamports owned by this account */
   uint64_t userdata_len; /** Length of data in bytes */
   uint8_t *userdata;     /** On-chain data within this account */
   SolPubkey *owner;      /** Program that owns this account */
@@ -209,7 +209,7 @@ typedef struct {
  * Use this function to deserialize the buffer passed to the program entrypoint
  * into usable types.  This function does not perform copy deserialization,
  * instead it populates the pointers and lengths in SolKeyedAccount and data so
- * that any modification to tokens or account data take place on the original
+ * that any modification to lamports or account data take place on the original
  * buffer.  Doing so also eliminates the need to serialize back into the buffer
  * at program end.
  *
@@ -238,8 +238,8 @@ SOL_FN_PREFIX bool sol_deserialize(
     params->ka[i].key = (SolPubkey *) input;
     input += sizeof(SolPubkey);
 
-    // tokens
-    params->ka[i].tokens = (uint64_t *) input;
+    // lamports
+    params->ka[i].lamports = (uint64_t *) input;
     input += sizeof(uint64_t);
 
     // account userdata
@@ -311,8 +311,8 @@ SOL_FN_PREFIX void sol_log_params(const SolParameters *params) {
     sol_log_64(0, 0, 0, 0, params->ka[i].is_signer);
     sol_log("  - Key");
     sol_log_key(params->ka[i].key);
-    sol_log("  - Tokens");
-    sol_log_64(0, 0, 0, 0, *params->ka[i].tokens);
+    sol_log("  - Lamports");
+    sol_log_64(0, 0, 0, 0, *params->ka[i].lamports);
     sol_log("  - Userdata");
     sol_log_array(params->ka[i].userdata, params->ka[i].userdata_len);
     sol_log("  - Owner");

--- a/tests/replicator.rs
+++ b/tests/replicator.rs
@@ -111,10 +111,10 @@ fn test_replicator_startup_basic() {
 
         let replicator_keypair = Keypair::new();
 
-        info!("giving replicator tokens..");
+        info!("giving replicator lamports..");
 
         let blockhash = leader_client.get_recent_blockhash();
-        // Give the replicator some tokens
+        // Give the replicator some lamports
         let mut tx = SystemTransaction::new_account(
             &mint_keypair,
             replicator_keypair.pubkey(),

--- a/wallet/src/main.rs
+++ b/wallet/src/main.rs
@@ -145,14 +145,14 @@ fn main() -> Result<(), Box<dyn error::Error>> {
         .subcommand(SubCommand::with_name("address").about("Get your public key"))
         .subcommand(
             SubCommand::with_name("airdrop")
-                .about("Request a batch of tokens")
+                .about("Request a batch of lamports")
                 .arg(
-                    Arg::with_name("tokens")
+                    Arg::with_name("lamports")
                         .index(1)
                         .value_name("NUM")
                         .takes_value(true)
                         .required(true)
-                        .help("The number of tokens to request"),
+                        .help("The number of lamports to request"),
                 ),
         )
         .subcommand(SubCommand::with_name("balance").about("Get your balance"))
@@ -207,12 +207,12 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                         .help("The pubkey of recipient"),
                 )
                 .arg(
-                    Arg::with_name("tokens")
+                    Arg::with_name("lamports")
                         .index(2)
                         .value_name("NUM")
                         .takes_value(true)
                         .required(true)
-                        .help("The number of tokens to send"),
+                        .help("The number of lamports to send"),
                 )
                 .arg(
                     Arg::with_name("timestamp")
@@ -236,7 +236,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                         .takes_value(true)
                         .multiple(true)
                         .use_delimiter(true)
-                        .help("Any third party signatures required to unlock the tokens"),
+                        .help("Any third party signatures required to unlock the lamports"),
                 )
                 .arg(
                     Arg::with_name("cancelable")


### PR DESCRIPTION
This is is a more sweeping rename of tokens to lamports
* The erc20 token program is obviously untouched
* The wallet cli and drone airdrops for now work on lamports, to keep this PR mechanical.  In the future we may want to change those two to instead work with sols.  

Fixes #1834 