### PR TITLE
Add staking rewards design proposal for delegation

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -37,6 +37,7 @@
   - [Ledger Replication](ledger-replication-to-implement.md)
   - [Secure Vote Signing](vote-signing-to-implement.md)
   - [Staking Rewards](staking-rewards.md)
+  - [Passive Staking Delegation and Rewards](passive-stake-delegation-and-rewards.md)
   - [Fork Selection](fork-selection.md)
   - [Reliable Vote Transmission](reliable-vote-transmission.md)
   - [Bank Forks](bank-forks.md)

--- a/book/src/passive-stake-delegation-and-rewards.md
+++ b/book/src/passive-stake-delegation-and-rewards.md
@@ -2,7 +2,7 @@
 
 This design proposal focuses on the software architecture for the on-chain
 voting and staking programs.  Incentives for staking is covered in [staking
-rewardsd](staking-rewards.md).
+rewards](staking-rewards.md).
 
 The current architecture requires an active vote for each delegated stake from
 the validator, and therefore does not scale to allow for replicator clients

--- a/book/src/passive-stake-delegation-and-rewards.md
+++ b/book/src/passive-stake-delegation-and-rewards.md
@@ -4,10 +4,10 @@ This design proposal focuses on the software architecture for the on-chain
 voting and staking programs.  Incentives for staking is covered in [staking
 rewards](staking-rewards.md).
 
-The current architecture requires an active vote for each delegated stake from
-the validator, and therefore does not scale to allow for replicator clients
+The current architecture requires a vote for each delegated stake from the
+validator, and therefore does not scale to allow for replicator clients
 automatically delegate their rewards.
- 
+
 The design proposes a new set of programs for voting and stake delegation, The
 proposed programs allow many stakes to passively earn rewards with a single
 validator vote without permission from the validator.

--- a/book/src/passive-stake-delegation-and-rewards.md
+++ b/book/src/passive-stake-delegation-and-rewards.md
@@ -17,8 +17,9 @@ automatically delegate their rewards.
 The current design requires a validator to submit a different vote for each
 stake. Therefore the validator can censor stakes delegated to it, and the number
 of votes is equal to the number of stakers, and not the number of validators.
-The network expects the number of stakes to be large compared to the number of
-validators.
+Replicator clients are expected to automatically delegate their rewards, and
+therefore the number of stakes is expected to be large compared to the number of
+validators in a long running cluster.
 
 ## Terminology
 
@@ -29,7 +30,7 @@ validator votes.
 rewards for votes to the staker.
 
 * Staker - The lamport owner that is risking lamports with consensus votes in
-exchange for network rewards.  This is the owner of the RewardState program.
+exchange for cluster rewards.  This is the owner of the RewardState program.
 
 * Delegate - The validator that is submitting votes on behave of the staker.
 This is the owner of the VoteState program.

--- a/book/src/passive-stake-delegation-and-rewards.md
+++ b/book/src/passive-stake-delegation-and-rewards.md
@@ -113,7 +113,7 @@ deposited into the StakeState and as validator commission is proportional to
 reward.
 * `account[1]` - RW - The StakeState::State instance that is redeeming votes
 credits.
-* `account[1]` - R - The VoteState instance, must be the same as
+* `account[2]` - R - The VoteState instance, must be the same as
 `StakeState::voter_id`
 
 Reward is payed out for the difference between `VoteState::credits` to

--- a/book/src/passive-stake-delegation-and-rewards.md
+++ b/book/src/passive-stake-delegation-and-rewards.md
@@ -5,9 +5,8 @@ on-chain programs.  Incentives for staking is covered in [staking
 rewardsd](staking-rewards.md).
 
 
-This proposal is solving is to allow many delegated stakes to
-passively earn rewards with a single validator vote without permission from the
-validator.
+This proposal is solving is to allow many delegated stakes to passively earn
+rewards with a single validator vote without permission from the validator.
 
 The current architecture requires an active vote for each delegated stake from
 the validator, and therefore does not scale to allow for replicator clients
@@ -48,7 +47,8 @@ an instance of the VoteState program.
 
 ### VoteState
 
-VoteState contains the following state information:
+VoteState is the current state of all the votes the **delegate** has submitted
+to the bank.  VoteState contains the following state information:
 
 * votes - The submitted votes.
 
@@ -59,15 +59,21 @@ lifetime.
 rewards.
 
 * commission - The commission taken by this VoteState for any rewards claimed by
-delegated accounts.
+staker's RewardState accounts.
+
+* lamports - The accumulated lamports from the commission.  These do not count as
+stakes.
+
+* `authorized_voter_id` - Only this identity is authorized to submit votes.
 
 ### RewardState
 
-RewardState contains the following state information:
+RewardState is the current delegation preference of the **staker**. RewardState
+contains the following state information:
 
 * lamports - The staked lamports.
 
-* `vote_state_id` - The address of the vote state instance the lamports are
+* `vote_state_id` - The pubkey of the VoteState instance the lamports are
 delegated to.
 
 * `claimed_credits` - The total credits claimed over the lifetime of the

--- a/book/src/passive-stake-delegation-and-rewards.md
+++ b/book/src/passive-stake-delegation-and-rewards.md
@@ -27,17 +27,16 @@ the number of validators in a long running cluster.
 ## Proposed changes to the current design.
 
 The general idea is that instead of the staker, the validator will own the
-VoteState program, In this proposal, the VoteState program is there to track
-validator votes, count validator generated credits, and to provide any
+VoteState program. In this proposal the VoteState program is there to track
+validator votes, count validator generated credits and to provide any
 additional validator specific state.  The VoteState program is not aware of any
 stakes delegated to it, and has no staking weight.
 
-Stakes and rewards are related, Since the rewards generated are proportional to
-the amount of lamports staked.  The proposed change is to keep the stake state
-as part of the RewardsState program. This program is owned by the staker only.
-Lamports stored in this program are the stake.  Unlike the current design, this
-program contains a new field to indicate which VoteState program the stake is
-delegated to.
+The rewards generated are proportional to the amount of lamports staked.  In
+this proposal stake state is stored as part of the RewardsState program. This
+program is owned by the staker only.  Lamports stored in this program are the
+stake.  Unlike the current design, this program contains a new field to indicate
+which VoteState program the stake is delegated to.
 
 ### New VoteState
 

--- a/book/src/passive-stake-delegation-and-rewards.md
+++ b/book/src/passive-stake-delegation-and-rewards.md
@@ -9,8 +9,9 @@ validator, and therefore does not scale to allow for replicator clients
 automatically delegate their rewards.
 
 The design proposes a new set of programs for voting and stake delegation, The
-proposed programs allow many stakes to passively earn rewards with a single
-validator vote without permission from the validator.
+proposed programs allow many stake accounts to passively earn rewards with a
+single validator vote without permission or active involvement from the
+validator.
 
 ## Current Design Problems
 
@@ -121,17 +122,17 @@ Reward is payed out for the difference between `VoteState::credits` to
 balance, and the reward is deposited to the `StakeState` token balance.  The
 reward and the commission is weighted by the `StakeState::lamports`.
 
-The Staker, or the owner of the Reward program sends a transaction with this
+The Staker, or the owner of the Stake program sends a transaction with this
 instruction to claim the reward.
 
-### Collecting network fee's into the MiningPool
+### Collecting network fees into the MiningPool
 
 At the end of the block, before the bank is frozen, but after it processed all
 the transactions for the block, a virtual instruction is executed to collect
-the transaction fee's.
+the transaction fees.
 
-* A portion of the fee's are deposited into the leader's account. 
-* A portion of the fee's are deposited into the smallest StakeState::MiningPool
+* A portion of the fees are deposited into the leader's account. 
+* A portion of the fees are deposited into the smallest StakeState::MiningPool
 account.
 
 ### Benefits
@@ -155,7 +156,7 @@ VoteState program without an interactive action from the identity controlling
 the VoteState program or submitting votes to the program.
 
 The total stake allocated to a VoteState program can be calculated by the sum of
-all the Rewar:sState programs that have the VoteState pubkey as the
+all the StakeState programs that have the VoteState pubkey as the
 `StakeState::voter_id`.
  
 ## Future work

--- a/book/src/passive-stake-delegation-and-rewards.md
+++ b/book/src/passive-stake-delegation-and-rewards.md
@@ -1,0 +1,124 @@
+# Stake Delegation and Reward
+
+This design proposal focuses on the software architecture for the actual
+on-chain programs.  Incentives for staking is covered in [staking
+rewardsd](staking-rewards.md).
+
+
+This proposal is solving is to allow many delegated stakes to
+passively earn rewards with a single validator vote without permission from the
+validator.
+
+The current architecture requires an active vote for each delegated stake from
+the validator, and therefore does not scale to allow for replicator clients
+automatically delegate their rewards.
+
+## Current Problems
+
+The current design requires a validator to submit a different vote for each
+stake. Therefore the validator can censor stakes delegated to it, and the number
+of votes is equal to the number of stakers, and not the number of validators.
+The network expects the number of stakes to be large compared to the number of
+validators.
+
+## Terminology
+
+* VoteState - Instance of the vote program.  This program keeps track of
+validator votes.
+
+* RewardState - Instance of the reward state program.  This program pays out
+rewards for votes to the staker.
+
+* Staker - The lamport owner that is risking lamports with consensus votes in
+exchange for network rewards.  This is the owner of the RewardState program.
+
+* Delegate - The validator that is submitting votes on behave of the staker.
+This is the owner of the VoteState program.
+
+## Proposal
+
+The general idea is to store the delegation state in the reward program.  So
+many RewardState instances can independently assign a single VoteState.  Each
+RewardState can claim its reward independently with the VoteState program as
+well as pay the VoteState program a commission.
+
+VoteState instance is initialized by the validator.  RewardState is initialized
+by the staker, and passively delegates the tokens stored in the RewardState to
+an instance of the VoteState program.
+
+### VoteState
+
+VoteState contains the following state information:
+
+* votes - The submitted votes.
+
+* credits - The total number of rewards this vote program generated over its
+lifetime.
+
+* root\_slot - The last slot to reach the full lockout commitment necessary for
+rewards.
+
+* commission - The commission taken by this VoteState for any rewards claimed by
+delegated accounts.
+
+### RewardState
+
+RewardState contains the following state information:
+
+* lamports - The staked lamports.
+
+* `vote_state_id` - The address of the vote state instance the lamports are
+delegated to.
+
+* `claimed_credits` - The total credits claimed over the lifetime of the
+program.
+
+## Passive Delegation
+
+Any number of instances of RewardState programs can delegate to a single
+VoteState program without an interactive action from the identity controlling
+the VoteState program or submitting votes to the program.
+
+The total stake allocated to a VoteState program can be calculated by the sum of
+all the RewardState programs that have the VoteState pubkey as the
+`RewardState;:vote_state_id`.
+ 
+### RewardsInstruction::Initialize
+
+* `account[0]` - Out Param - The RewardState instance.  
+  `RewardState::claimed_credits` is initialized to `VoteState::credits`.  
+  `RewardState::vote_state_id` is initialized to `account[1]`
+
+* `account[1]` - In Param - The VoteState instance.
+
+### RewardsInstruction::RedeemVoteCredits
+
+
+* `account[0]` - Out Param - The RewardState instance.  
+
+* `account[1]` - In Param - The VoteState instance, must be the same as
+`RewardState::vote_state_id`
+
+
+Reward is payed out for the difference between `VoteState::credits` to
+`RewardState::claimed_credits`, and `claimed_credits` is updated to
+`VoteState::credits`.  The commission is deposited into the `VoteState` token
+balance, and the reward is deposited to the `RewardState` token balance.  The
+reward and the commission is weighted by the `RewardState::lamports`.
+
+The Staker, or the owner of the Reward program sends a transaction with this
+instruction to claim the reward.
+
+### Benefits
+
+* Single vote for all the stakers.
+
+* Clearing of the credit variable is not necessary for claiming rewards.
+
+* Each delegated stake can claim its rewards independently.
+
+* Commission for the work is deposited when a reward is claimed by the delegated
+stake.
+
+This proposal would benefit from the `read-only` accounts proposal to allow for
+many rewards to be claimed concurrently.

--- a/book/src/passive-stake-delegation-and-rewards.md
+++ b/book/src/passive-stake-delegation-and-rewards.md
@@ -132,6 +132,10 @@ let credits_to_claim = vote_state.credits - stake_state.credits_observed;
 stake_state.credits_observed = vote_state.credits;
 ```
 
+`credits_to_claim` is used to compute the reward and commission, and
+`StakeState::Stake.credits_observed` is updated to the latest
+`VoteState.credits` value.
+
 ### Collecting network fees into the MiningPool
 
 At the end of the block, before the bank is frozen, but after it processed all

--- a/book/src/passive-stake-delegation-and-rewards.md
+++ b/book/src/passive-stake-delegation-and-rewards.md
@@ -20,9 +20,9 @@ actively vote for each stake delegated to it, it can censor stakes by not voting
 for them.
 
 The number of votes is equal to the number of stakers, and not the number of
-validators.  Replicator clients are expected to automatically delegate their
-rewards, and therefore the number of stakes is expected to be large compared to
-the number of validators in a long running cluster.
+validators.  Replicator clients are expected to delegate their replication
+rewards as they are earned, and therefore the number of stakes is expected to be
+large compared to the number of validators in a long running cluster.
 
 ## Proposed changes to the current design.
 

--- a/book/src/passive-stake-delegation-and-rewards.md
+++ b/book/src/passive-stake-delegation-and-rewards.md
@@ -1,57 +1,50 @@
 # Stake Delegation and Reward
 
-This design proposal focuses on the software architecture for the actual
-on-chain programs.  Incentives for staking is covered in [staking
+This design proposal focuses on the software architecture for the on-chain
+voting and staking programs.  Incentives for staking is covered in [staking
 rewardsd](staking-rewards.md).
-
-
-This proposal is solving is to allow many delegated stakes to passively earn
-rewards with a single validator vote without permission from the validator.
 
 The current architecture requires an active vote for each delegated stake from
 the validator, and therefore does not scale to allow for replicator clients
 automatically delegate their rewards.
+ 
+The design proposes a new set of programs for voting and stake delegation, The
+proposed programs allow many stakes to passively earn rewards with a single
+validator vote without permission from the validator.
 
-## Current Problems
+## Current Design Problems
 
-The current design requires a validator to submit a different vote for each
-stake. Therefore the validator can censor stakes delegated to it, and the number
-of votes is equal to the number of stakers, and not the number of validators.
-Replicator clients are expected to automatically delegate their rewards, and
-therefore the number of stakes is expected to be large compared to the number of
-validators in a long running cluster.
+In the current design each staker creates their own VoteState, and assigns a
+**delegate** in the VoteState that can submit votes.  Since the validator has to
+actively vote for each stake delegated to it, it can censor stakes by not voting
+for them.
 
-## Terminology
+The number of votes is equal to the number of stakers, and not the number of
+validators.  Replicator clients are expected to automatically delegate their
+rewards, and therefore the number of stakes is expected to be large compared to
+the number of validators in a long running cluster.
 
-* VoteState - Instance of the vote program.  This program keeps track of
-validator votes.
+## Proposed changes to the current design.
 
-* RewardState - Instance of the reward state program.  This program pays out
-rewards for votes to the staker.
+The general idea is that instead of the staker, the validator will own the
+VoteState program, In this proposal, the VoteState program is there to track
+validator votes, count validator generated credits, and to provide any
+additional validator specific state.  The VoteState program is not aware of any
+stakes delegated to it, and has no staking weight.
 
-* Staker - The lamport owner that is risking lamports with consensus votes in
-exchange for cluster rewards.  This is the owner of the RewardState program.
+Stakes and rewards are related, Since the rewards generated are proportional to
+the amount of lamports staked.  The proposed change is to keep the stake state
+as part of the RewardsState program. This program is owned by the staker only.
+Lamports stored in this program are the stake.  Unlike the current design, this
+program contains a new field to indicate which VoteState program the stake is
+delegated to.
 
-* Delegate - The validator that is submitting votes on behave of the staker.
-This is the owner of the VoteState program.
-
-## Proposal
-
-The general idea is to store the delegation state in the reward program.  So
-many RewardState instances can independently assign a single VoteState.  Each
-RewardState can claim its reward independently with the VoteState program as
-well as pay the VoteState program a commission.
-
-VoteState instance is initialized by the validator.  RewardState is initialized
-by the staker, and passively delegates the tokens stored in the RewardState to
-an instance of the VoteState program.
-
-### VoteState
+### New VoteState
 
 VoteState is the current state of all the votes the **delegate** has submitted
 to the bank.  VoteState contains the following state information:
 
-* votes - The submitted votes.
+* votes - The submitted votes data structure.
 
 * credits - The total number of rewards this vote program generated over its
 lifetime.
@@ -60,58 +53,57 @@ lifetime.
 rewards.
 
 * commission - The commission taken by this VoteState for any rewards claimed by
-staker's RewardState accounts.
+staker's RewardsState accounts.
 
 * lamports - The accumulated lamports from the commission.  These do not count as
 stakes.
 
 * `authorized_voter_id` - Only this identity is authorized to submit votes.
 
-### RewardState
+### New RewardsState
 
-RewardState is the current delegation preference of the **staker**. RewardState
+RewardsState is the current delegation preference of the **staker**. RewardsState
 contains the following state information:
 
 * lamports - The staked lamports.
 
-* `vote_state_id` - The pubkey of the VoteState instance the lamports are
+* `delegate` - The pubkey of the VoteState instance the lamports are
 delegated to.
 
 * `claimed_credits` - The total credits claimed over the lifetime of the
 program.
 
-## Passive Delegation
 
-Any number of instances of RewardState programs can delegate to a single
-VoteState program without an interactive action from the identity controlling
-the VoteState program or submitting votes to the program.
+### Claiming Rewards
 
-The total stake allocated to a VoteState program can be calculated by the sum of
-all the RewardState programs that have the VoteState pubkey as the
-`RewardState;:vote_state_id`.
- 
+The VoteState program and the RewardsState programs maintain a lifetime counter
+of total rewards generated and claimed.  Therefore an explicit `Clear`
+instruction is not necessary.  When claiming rewards, the total lamports
+deposited into the RewardsState and as validator commission is proportional to
+`VoteState::credits - RewadsState::claimed_credits`.
+
 ### RewardsInstruction::Initialize
 
-* `account[0]` - Out Param - The RewardState instance.  
-  `RewardState::claimed_credits` is initialized to `VoteState::credits`.  
-  `RewardState::vote_state_id` is initialized to `account[1]`
+* `account[0]` - Out Param - The RewardsState instance.  
+  `RewardsState::claimed_credits` is initialized to `VoteState::credits`.  
+  `RewardsState::delegate` is initialized to `account[1]`
 
 * `account[1]` - In Param - The VoteState instance.
 
 ### RewardsInstruction::RedeemVoteCredits
 
 
-* `account[0]` - Out Param - The RewardState instance.  
+* `account[0]` - Out Param - The RewardsState instance.  
 
 * `account[1]` - In Param - The VoteState instance, must be the same as
-`RewardState::vote_state_id`
+`RewardsState::delegate`
 
 
 Reward is payed out for the difference between `VoteState::credits` to
-`RewardState::claimed_credits`, and `claimed_credits` is updated to
+`RewardsState::claimed_credits`, and `claimed_credits` is updated to
 `VoteState::credits`.  The commission is deposited into the `VoteState` token
-balance, and the reward is deposited to the `RewardState` token balance.  The
-reward and the commission is weighted by the `RewardState::lamports`.
+balance, and the reward is deposited to the `RewardsState` token balance.  The
+reward and the commission is weighted by the `RewardsState::lamports`.
 
 The Staker, or the owner of the Reward program sends a transaction with this
 instruction to claim the reward.
@@ -129,3 +121,30 @@ stake.
 
 This proposal would benefit from the `read-only` accounts proposal to allow for
 many rewards to be claimed concurrently.
+
+## Passive Delegation
+
+Any number of instances of RewardsState programs can delegate to a single
+VoteState program without an interactive action from the identity controlling
+the VoteState program or submitting votes to the program.
+
+The total stake allocated to a VoteState program can be calculated by the sum of
+all the RewardsState programs that have the VoteState pubkey as the
+`RewardsState;:delegate`.
+ 
+## Future work
+
+Validators may want to split the stake delegated to them amongst many validator
+nodes since stake is used as weight in the network control and data planes.  One
+way to implement this would be for the RewardsState to delegate to a pool of
+validators instead of a single one.
+
+### VoteStatePool
+
+* voters - Array of VoteState accounts that are generating rewards for this
+pool.
+
+A RewardsState program would claim a fraction of the reward from each voter in
+the `voters` array.  To support a VoteStatePool, `RewardsState::claimed_credits`
+would need to be an array of equal size to the `VoteStatePool::voters` array.
+


### PR DESCRIPTION
#### Problem

Current staking architecture requires a validator vote per delegated stake.  It has two main problems

* The number of votes is high, since the number of delegated stakes is expected to be much higher than the number of validators.
* The validators are actively acknowledging delegation.

#### Summary of Changes

Cover the current architecture and its problems and propose an alternative that allows for passive delegation and a single vote for many delegated stakes.

Fixes #

tag: @garious (I'll add you as the last reviewer)