### PR TITLE
requestAirdrop RPC API is now optional

### DIFF
--- a/core/src/fullnode.rs
+++ b/core/src/fullnode.rs
@@ -237,10 +237,7 @@ impl Fullnode {
             }
             let bank = bank_forks_.read().unwrap().working_bank();
             trace!("rpc working bank {} {}", bank.slot(), bank.last_blockhash());
-            rpc_service_rp
-                .write()
-                .unwrap()
-                .set_bank(&bank_forks_.read().unwrap().working_bank());
+            rpc_service_rp.write().unwrap().set_bank(&bank);
             let timer = Duration::from_millis(100);
             sleep(timer);
         });

--- a/core/src/fullnode.rs
+++ b/core/src/fullnode.rs
@@ -125,25 +125,11 @@ impl Fullnode {
             keypair.clone(),
         )));
 
-        // TODO: The RPC service assumes that there is a drone running on the cluster
-        //       entrypoint, which is a bad assumption.
-        //       See https://github.com/solana-labs/solana/issues/1830 for the removal of drone
-        //       from the RPC API
-        let drone_addr = {
-            let mut entrypoint_drone_addr = match entrypoint_info_option {
-                Some(entrypoint_info_info) => entrypoint_info_info.rpc,
-                None => node.info.rpc,
-            };
-            entrypoint_drone_addr.set_port(solana_drone::drone::DRONE_PORT);
-            entrypoint_drone_addr
-        };
-
         let storage_state = StorageState::new();
 
         let rpc_service = JsonRpcService::new(
             &cluster_info,
             SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), node.info.rpc.port()),
-            drone_addr,
             storage_state.clone(),
             config.rpc_config.clone(),
             &exit,

--- a/core/src/local_cluster.rs
+++ b/core/src/local_cluster.rs
@@ -211,7 +211,6 @@ impl Drop for LocalCluster {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::rpc::JsonRpcConfig;
 
     #[test]
     fn test_local_cluster_start_and_exit() {
@@ -224,7 +223,7 @@ mod test {
     fn test_local_cluster_start_and_exit_with_config() {
         solana_logger::setup();
         let mut fullnode_exit = FullnodeConfig::default();
-        fullnode_exit.rpc_config = JsonRpcConfig::TestOnlyAllowRpcFullnodeExit;
+        fullnode_exit.rpc_config.enable_fullnode_exit = true;
         let cluster = LocalCluster::new_with_config(1, 100, 3, &fullnode_exit);
         drop(cluster)
     }

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -170,7 +170,6 @@ fn verify_signature(input: &str) -> Result<Signature> {
 pub struct Meta {
     pub request_processor: Arc<RwLock<JsonRpcRequestProcessor>>,
     pub cluster_info: Arc<RwLock<ClusterInfo>>,
-    pub rpc_addr: SocketAddr,
     pub drone_addr: SocketAddr,
 }
 impl Metadata for Meta {}
@@ -436,7 +435,6 @@ mod tests {
 
         cluster_info.write().unwrap().insert_info(leader.clone());
         cluster_info.write().unwrap().set_leader(leader.id);
-        let rpc_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 0);
         let drone_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 0);
 
         let mut io = MetaIoHandler::default();
@@ -446,7 +444,6 @@ mod tests {
             request_processor,
             cluster_info,
             drone_addr,
-            rpc_addr,
         };
         (io, meta, blockhash, alice)
     }
@@ -638,7 +635,6 @@ mod tests {
             },
             cluster_info: Arc::new(RwLock::new(ClusterInfo::new(NodeInfo::default()))),
             drone_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 0),
-            rpc_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 0),
         };
 
         let req =

--- a/core/src/rpc_service.rs
+++ b/core/src/rpc_service.rs
@@ -24,12 +24,12 @@ impl JsonRpcService {
     pub fn new(
         cluster_info: &Arc<RwLock<ClusterInfo>>,
         rpc_addr: SocketAddr,
-        drone_addr: SocketAddr,
         storage_state: StorageState,
         config: JsonRpcConfig,
         exit: &Arc<AtomicBool>,
     ) -> Self {
         info!("rpc bound to {:?}", rpc_addr);
+        info!("rpc configuration: {:?}", config);
         let request_processor = Arc::new(RwLock::new(JsonRpcRequestProcessor::new(
             storage_state,
             config,
@@ -51,7 +51,6 @@ impl JsonRpcService {
                     ServerBuilder::with_meta_extractor(io, move |_req: &hyper::Request<hyper::Body>| Meta {
                         request_processor: request_processor_.clone(),
                         cluster_info: info.clone(),
-                        drone_addr,
                     }).threads(4)
                         .cors(DomainsValidation::AllowOnly(vec![
                             AccessControlAllowOrigin::Any,
@@ -105,14 +104,9 @@ mod tests {
             IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)),
             solana_netutil::find_available_port_in_range((10000, 65535)).unwrap(),
         );
-        let drone_addr = SocketAddr::new(
-            IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)),
-            solana_netutil::find_available_port_in_range((10000, 65535)).unwrap(),
-        );
         let mut rpc_service = JsonRpcService::new(
             &cluster_info,
             rpc_addr,
-            drone_addr,
             StorageState::default(),
             JsonRpcConfig::default(),
             &exit,

--- a/core/src/rpc_service.rs
+++ b/core/src/rpc_service.rs
@@ -52,7 +52,6 @@ impl JsonRpcService {
                         request_processor: request_processor_.clone(),
                         cluster_info: info.clone(),
                         drone_addr,
-                        rpc_addr,
                     }).threads(4)
                         .cors(DomainsValidation::AllowOnly(vec![
                             AccessControlAllowOrigin::Any,

--- a/fullnode/src/main.rs
+++ b/fullnode/src/main.rs
@@ -217,7 +217,7 @@ fn main() {
     let use_only_bootstrap_leader = matches.is_present("no_leader_rotation");
 
     if matches.is_present("enable_rpc_exit") {
-        fullnode_config.rpc_config = solana::rpc::JsonRpcConfig::TestOnlyAllowRpcFullnodeExit;
+        fullnode_config.rpc_config.enable_fullnode_exit = true;
     }
 
     let gossip_addr = {

--- a/multinode-demo/bootstrap-leader.sh
+++ b/multinode-demo/bootstrap-leader.sh
@@ -28,12 +28,12 @@ tune_system
 trap 'kill "$pid" && wait "$pid"' INT TERM
 $solana_ledger_tool --ledger "$SOLANA_CONFIG_DIR"/bootstrap-leader-ledger verify
 
-# shellcheck disable=SC2086 # Don't want to double quote maybe_blockstream or maybe_init_complete_file
 $program \
   --identity "$SOLANA_CONFIG_DIR"/bootstrap-leader-id.json \
   --ledger "$SOLANA_CONFIG_DIR"/bootstrap-leader-ledger \
   --accounts "$SOLANA_CONFIG_DIR"/bootstrap-leader-accounts \
   --rpc-port 8899 \
+  --rpc-drone-address 127.0.0.1:9900 \
   "$@" \
   > >($bootstrap_leader_logger) 2>&1 &
 pid=$!

--- a/multinode-demo/fullnode.sh
+++ b/multinode-demo/fullnode.sh
@@ -222,6 +222,7 @@ $program \
   --network "$leader_address" \
   --ledger "$ledger_config_dir" \
   --accounts "$accounts_config_dir" \
+  --rpc-drone-address "${leader_address%:*}:9900" \
   "${extra_fullnode_args[@]}" \
   > >($fullnode_logger) 2>&1 &
 pid=$!

--- a/run.sh
+++ b/run.sh
@@ -55,6 +55,7 @@ args=(
   --identity "$dataDir"/config/leader-keypair.json
   --ledger "$dataDir"/ledger/
   --rpc-port 8899
+  --rpc-drone-address 127.0.0.1:9900
 )
 if [[ -n $blockstreamSocket ]]; then
   args+=(--blockstream "$blockstreamSocket")

--- a/tests/local_cluster.rs
+++ b/tests/local_cluster.rs
@@ -3,7 +3,6 @@ extern crate solana;
 use solana::cluster_tests;
 use solana::fullnode::FullnodeConfig;
 use solana::local_cluster::LocalCluster;
-use solana::rpc::JsonRpcConfig;
 
 #[test]
 fn test_spend_and_verify_all_nodes_1() {
@@ -54,18 +53,18 @@ fn test_fullnode_exit_default_config_should_panic() {
 fn test_fullnode_exit_2() {
     solana_logger::setup();
     let num_nodes = 2;
-    let mut fullnode_exit = FullnodeConfig::default();
-    fullnode_exit.rpc_config = JsonRpcConfig::TestOnlyAllowRpcFullnodeExit;
-    let local = LocalCluster::new_with_config(num_nodes, 10_000, 100, &fullnode_exit);
+    let mut fullnode_config = FullnodeConfig::default();
+    fullnode_config.rpc_config.enable_fullnode_exit = true;
+    let local = LocalCluster::new_with_config(num_nodes, 10_000, 100, &fullnode_config);
     cluster_tests::fullnode_exit(&local.entry_point_info, num_nodes);
 }
 
 #[test]
 fn test_leader_failure_2() {
     let num_nodes = 2;
-    let mut fullnode_exit = FullnodeConfig::default();
-    fullnode_exit.rpc_config = JsonRpcConfig::TestOnlyAllowRpcFullnodeExit;
-    let local = LocalCluster::new_with_config(num_nodes, 10_000, 100, &fullnode_exit);
+    let mut fullnode_config = FullnodeConfig::default();
+    fullnode_config.rpc_config.enable_fullnode_exit = true;
+    let local = LocalCluster::new_with_config(num_nodes, 10_000, 100, &fullnode_config);
     cluster_tests::kill_entry_and_spend_and_verify_rest(
         &local.entry_point_info,
         &local.funding_keypair,
@@ -76,9 +75,9 @@ fn test_leader_failure_2() {
 #[test]
 fn test_leader_failure_3() {
     let num_nodes = 3;
-    let mut fullnode_exit = FullnodeConfig::default();
-    fullnode_exit.rpc_config = JsonRpcConfig::TestOnlyAllowRpcFullnodeExit;
-    let local = LocalCluster::new_with_config(num_nodes, 10_000, 100, &fullnode_exit);
+    let mut fullnode_config = FullnodeConfig::default();
+    fullnode_config.rpc_config.enable_fullnode_exit = true;
+    let local = LocalCluster::new_with_config(num_nodes, 10_000, 100, &fullnode_config);
     cluster_tests::kill_entry_and_spend_and_verify_rest(
         &local.entry_point_info,
         &local.funding_keypair,


### PR DESCRIPTION
The hard coded assumption in the RPC API that a drone will be available is problematic for a main net. #1830 proposes removing the requestAirdrop RPC API entirely, this PR takes more subdued approach by:
1. Making the drone address (and thus `requestAirdrop`) optional within the RPC subsystem
2. Removes the hard coded drone address from fullnode
3. Shifts the knowledge of whether a drone exists or not way up to bash scripts used to start a cluster