### PR TITLE
Create UDP socket once per process_loop for forwarding transactions

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -98,7 +98,11 @@ impl BankingStage {
                 Err(Error::RecvTimeoutError(RecvTimeoutError::Timeout)) => (),
                 Ok(unprocessed_packets) => {
                     if let Some(leader) = cluster_info.read().unwrap().leader_data() {
-                        let _ = Self::forward_unprocessed_packets(&socket, &leader.tpu, unprocessed_packets);
+                        let _ = Self::forward_unprocessed_packets(
+                            &socket,
+                            &leader.tpu,
+                            unprocessed_packets,
+                        );
                     }
                 }
                 Err(err) => {


### PR DESCRIPTION
#### Problem
The sender UDP socket is created every time the packets are forwarded. If done in quick succession, this seems to create problems with the UDP stack and cause packet drops.

#### Summary of Changes
Create a UDP socket per process_loop() and reuse it.

Fixes #3150 
