### PR TITLE
Add staking commands to wallet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2407,6 +2407,7 @@ dependencies = [
  "solana-drone 0.12.0",
  "solana-logger 0.12.0",
  "solana-sdk 0.12.0",
+ "solana-vote-api 0.12.0",
  "solana-vote-signer 0.12.0",
 ]
 

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -21,6 +21,7 @@ solana-budget-api = { path = "../programs/budget_api", version = "0.12.0" }
 solana-drone = { path = "../drone", version = "0.12.0" }
 solana-logger = { path = "../logger", version = "0.12.0" }
 solana-sdk = { path = "../sdk", version = "0.12.0" }
+solana-vote-api = { path = "../programs/vote_api", version = "0.12.0" }
 solana-vote-signer = { path = "../vote-signer", version = "0.12.0" }
 
 [features]

--- a/wallet/src/main.rs
+++ b/wallet/src/main.rs
@@ -1,4 +1,4 @@
-use clap::{crate_version, App, Arg, ArgMatches, SubCommand};
+use clap::{crate_version, App, Arg, ArgGroup, ArgMatches, SubCommand};
 use solana_sdk::signature::{gen_keypair_file, read_keypair, KeypairUtil};
 use solana_wallet::wallet::{parse_command, process_command, WalletConfig, WalletError};
 use std::error;
@@ -178,6 +178,50 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                         .takes_value(true)
                         .required(true)
                         .help("The transaction signature to confirm"),
+                ),
+        )
+        .subcommand(
+            SubCommand::with_name("configure-staking-account")
+                .about("Configure staking account for node")
+                .group(
+                    ArgGroup::with_name("options")
+                        .args(&["delegate", "authorized_voter"])
+                        .multiple(true)
+                        .required(true),
+                )
+                .arg(
+                    Arg::with_name("delegate")
+                        .long("delegate-account")
+                        .value_name("PUBKEY")
+                        .takes_value(true)
+                        .help("Address to delegate this vote account to"),
+                )
+                .arg(
+                    Arg::with_name("authorized_voter")
+                        .long("authorize-voter")
+                        .value_name("PUBKEY")
+                        .takes_value(true)
+                        .help("Vote signer to authorize"),
+                ),
+        )
+        .subcommand(
+            SubCommand::with_name("create-staking-account")
+                .about("Create staking account for node")
+                .arg(
+                    Arg::with_name("voting_account_id")
+                        .index(1)
+                        .value_name("PUBKEY")
+                        .takes_value(true)
+                        .required(true)
+                        .help("Staking account address to fund"),
+                )
+                .arg(
+                    Arg::with_name("lamports")
+                        .index(2)
+                        .value_name("NUM")
+                        .takes_value(true)
+                        .required(true)
+                        .help("The number of lamports to send to staking account"),
                 ),
         )
         .subcommand(


### PR DESCRIPTION
#### Problem
Fullnodes need a way to set up stakes properly

#### Summary of Changes
Add create-staking-account and configure-staking-account commands to Wallet
Configure-staking-account takes and/or arguments `delegate-account` and `authorize-voter`

I haven't plumbed this through the Wallet unit test suite yet, and it really needs an integration test to make sure these commands are working properly. I will do that next. But if you want to build on this it "should work"....
