### PR TITLE
Gossip-related code cleanup

### DIFF
--- a/bench-tps/src/main.rs
+++ b/bench-tps/src/main.rs
@@ -41,23 +41,26 @@ fn main() {
 
     println!("Looking for leader at {:?}", network);
     let leader = poll_gossip_for_leader(network, Some(30)).unwrap_or_else(|err| {
-        println!(
+        eprintln!(
             "Error: unable to find leader on network after 30 seconds: {:?}",
             err
         );
         exit(1);
     });
 
-    let nodes = discover(&leader, num_nodes);
+    let nodes = discover(&leader, num_nodes).unwrap_or_else(|err| {
+        eprintln!("{:?}", err);
+        exit(1);
+    });
     if nodes.len() < num_nodes {
-        println!(
+        eprintln!(
             "Error: Insufficient nodes discovered.  Expecting {} or more",
             num_nodes
         );
         exit(1);
     }
     if reject_extra_nodes && nodes.len() > num_nodes {
-        println!(
+        eprintln!(
             "Error: Extra nodes discovered.  Expecting exactly {}",
             num_nodes
         );

--- a/bench-tps/src/main.rs
+++ b/bench-tps/src/main.rs
@@ -40,7 +40,7 @@ fn main() {
     } = cfg;
 
     println!("Looking for leader at {:?}", network);
-    let leader = poll_gossip_for_leader(network, Some(30)).unwrap_or_else(|err| {
+    let leader = poll_gossip_for_leader(network, Duration::from_secs(30)).unwrap_or_else(|err| {
         eprintln!(
             "Error: unable to find leader on network after 30 seconds: {:?}",
             err

--- a/bench-tps/src/main.rs
+++ b/bench-tps/src/main.rs
@@ -37,7 +37,7 @@ fn converge(
     //lets spy on the network
     let (node, gossip_socket) = ClusterInfo::spy_node();
     println!("Spy node: {}", node.id);
-    let mut spy_cluster_info = ClusterInfo::new(node);
+    let mut spy_cluster_info = ClusterInfo::new_with_invalid_keypair(node);
     spy_cluster_info.insert_info(leader.clone());
     spy_cluster_info.set_leader(leader.id);
     let spy_ref = Arc::new(RwLock::new(spy_cluster_info));

--- a/benches/banking_stage.rs
+++ b/benches/banking_stage.rs
@@ -105,7 +105,7 @@ fn bench_banking_stage_multi_accounts(bencher: &mut Bencher) {
         })
         .collect();
     let (exit, poh_recorder, poh_service, signal_receiver) = create_test_recorder(&bank);
-    let cluster_info = ClusterInfo::new(Node::new_localhost().info);
+    let cluster_info = ClusterInfo::new_with_invalid_keypair(Node::new_localhost().info);
     let cluster_info = Arc::new(RwLock::new(cluster_info));
     let _banking_stage = BankingStage::new(&cluster_info, &poh_recorder, verified_receiver);
     poh_recorder.lock().unwrap().set_bank(&bank);
@@ -212,7 +212,7 @@ fn bench_banking_stage_multi_programs(bencher: &mut Bencher) {
         })
         .collect();
     let (exit, poh_recorder, poh_service, signal_receiver) = create_test_recorder(&bank);
-    let cluster_info = ClusterInfo::new(Node::new_localhost().info);
+    let cluster_info = ClusterInfo::new_with_invalid_keypair(Node::new_localhost().info);
     let cluster_info = Arc::new(RwLock::new(cluster_info));
     let _banking_stage = BankingStage::new(&cluster_info, &poh_recorder, verified_receiver);
     poh_recorder.lock().unwrap().set_bank(&bank);

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -385,7 +385,7 @@ mod tests {
         let bank = Arc::new(Bank::new(&genesis_block));
         let (verified_sender, verified_receiver) = channel();
         let (exit, poh_recorder, poh_service, _entry_receiever) = create_test_recorder(&bank);
-        let cluster_info = ClusterInfo::new(Node::new_localhost().info);
+        let cluster_info = ClusterInfo::new_with_invalid_keypair(Node::new_localhost().info);
         let cluster_info = Arc::new(RwLock::new(cluster_info));
         let banking_stage = BankingStage::new(&cluster_info, &poh_recorder, verified_receiver);
         drop(verified_sender);
@@ -403,7 +403,7 @@ mod tests {
         let start_hash = bank.last_blockhash();
         let (verified_sender, verified_receiver) = channel();
         let (exit, poh_recorder, poh_service, entry_receiver) = create_test_recorder(&bank);
-        let cluster_info = ClusterInfo::new(Node::new_localhost().info);
+        let cluster_info = ClusterInfo::new_with_invalid_keypair(Node::new_localhost().info);
         let cluster_info = Arc::new(RwLock::new(cluster_info));
         poh_recorder.lock().unwrap().set_bank(&bank);
         let banking_stage = BankingStage::new(&cluster_info, &poh_recorder, verified_receiver);
@@ -433,7 +433,7 @@ mod tests {
         let start_hash = bank.last_blockhash();
         let (verified_sender, verified_receiver) = channel();
         let (exit, poh_recorder, poh_service, entry_receiver) = create_test_recorder(&bank);
-        let cluster_info = ClusterInfo::new(Node::new_localhost().info);
+        let cluster_info = ClusterInfo::new_with_invalid_keypair(Node::new_localhost().info);
         let cluster_info = Arc::new(RwLock::new(cluster_info));
         poh_recorder.lock().unwrap().set_bank(&bank);
         let banking_stage = BankingStage::new(&cluster_info, &poh_recorder, verified_receiver);
@@ -491,7 +491,7 @@ mod tests {
         let bank = Arc::new(Bank::new(&genesis_block));
         let (verified_sender, verified_receiver) = channel();
         let (exit, poh_recorder, poh_service, entry_receiver) = create_test_recorder(&bank);
-        let cluster_info = ClusterInfo::new(Node::new_localhost().info);
+        let cluster_info = ClusterInfo::new_with_invalid_keypair(Node::new_localhost().info);
         let cluster_info = Arc::new(RwLock::new(cluster_info));
         poh_recorder.lock().unwrap().set_bank(&bank);
         let _banking_stage = BankingStage::new(&cluster_info, &poh_recorder, verified_receiver);

--- a/core/src/broadcast_stage.rs
+++ b/core/src/broadcast_stage.rs
@@ -286,7 +286,7 @@ mod test {
         let broadcast_buddy = Node::new_localhost_with_pubkey(buddy_keypair.pubkey());
 
         // Fill the cluster_info with the buddy's info
-        let mut cluster_info = ClusterInfo::new(leader_info.info.clone());
+        let mut cluster_info = ClusterInfo::new_with_invalid_keypair(leader_info.info.clone());
         cluster_info.insert_info(broadcast_buddy.info);
         let cluster_info = Arc::new(RwLock::new(cluster_info));
 

--- a/core/src/cluster_info.rs
+++ b/core/src/cluster_info.rs
@@ -305,9 +305,7 @@ impl ClusterInfo {
     pub fn purge(&mut self, now: u64) {
         self.gossip.purge(now);
     }
-    pub fn convergence(&self) -> usize {
-        self.gossip_peers().len() + 1
-    }
+
     pub fn rpc_peers(&self) -> Vec<NodeInfo> {
         let me = self.my_data().id;
         self.gossip

--- a/core/src/cluster_info.rs
+++ b/core/src/cluster_info.rs
@@ -164,9 +164,9 @@ enum Protocol {
 impl ClusterInfo {
     /// Without a valid keypair gossip will not function. Only useful for tests.
     pub fn new_with_invalid_keypair(node_info: NodeInfo) -> Self {
-        ClusterInfo::new_with_keypair(node_info, Arc::new(Keypair::new()))
+        ClusterInfo::new(node_info, Arc::new(Keypair::new()))
     }
-    pub fn new_with_keypair(node_info: NodeInfo, keypair: Arc<Keypair>) -> Self {
+    pub fn new(node_info: NodeInfo, keypair: Arc<Keypair>) -> Self {
         let mut me = ClusterInfo {
             gossip: CrdsGossip::default(),
             keypair,
@@ -1740,7 +1740,7 @@ mod tests {
         let node_info = NodeInfo::new_localhost(keypair.pubkey(), 0);
         let leader = NodeInfo::new_localhost(leader_keypair.pubkey(), 0);
         let peer = NodeInfo::new_localhost(peer_keypair.pubkey(), 0);
-        let mut cluster_info = ClusterInfo::new_with_keypair(node_info.clone(), Arc::new(keypair));
+        let mut cluster_info = ClusterInfo::new(node_info.clone(), Arc::new(keypair));
         cluster_info.set_leader(leader.id);
         cluster_info.insert_info(peer.clone());
         //check that all types of gossip messages are signed correctly

--- a/core/src/cluster_info.rs
+++ b/core/src/cluster_info.rs
@@ -164,10 +164,10 @@ enum Protocol {
 impl ClusterInfo {
     /// Without a valid keypair gossip will not function. Only useful for tests.
     pub fn new_with_invalid_keypair(node_info: NodeInfo) -> Self {
-        ClusterInfo::new(node_info, Arc::new(Keypair::new()))
+        Self::new(node_info, Arc::new(Keypair::new()))
     }
     pub fn new(node_info: NodeInfo, keypair: Arc<Keypair>) -> Self {
-        let mut me = ClusterInfo {
+        let mut me = Self {
             gossip: CrdsGossip::default(),
             keypair,
         };

--- a/core/src/cluster_info.rs
+++ b/core/src/cluster_info.rs
@@ -1257,21 +1257,11 @@ impl ClusterInfo {
             .unwrap()
     }
 
-    pub fn spy_node() -> (NodeInfo, UdpSocket) {
+    pub fn spy_node(id: &Pubkey) -> (NodeInfo, UdpSocket) {
         let (_, gossip_socket) = bind_in_range(FULLNODE_PORT_RANGE).unwrap();
-        let pubkey = Keypair::new().pubkey();
         let daddr = socketaddr_any!();
 
-        let node = NodeInfo::new(
-            pubkey,
-            daddr,
-            daddr,
-            daddr,
-            daddr,
-            daddr,
-            daddr,
-            timestamp(),
-        );
+        let node = NodeInfo::new(*id, daddr, daddr, daddr, daddr, daddr, daddr, timestamp());
         (node, gossip_socket)
     }
 }
@@ -1460,7 +1450,7 @@ mod tests {
     fn test_cluster_spy_gossip() {
         //check that gossip doesn't try to push to invalid addresses
         let node = Node::new_localhost();
-        let (spy, _) = ClusterInfo::spy_node();
+        let (spy, _) = ClusterInfo::spy_node(&Keypair::new().pubkey());
         let cluster_info = Arc::new(RwLock::new(ClusterInfo::new_with_invalid_keypair(
             node.info,
         )));

--- a/core/src/cluster_tests.rs
+++ b/core/src/cluster_tests.rs
@@ -19,7 +19,7 @@ pub fn spend_and_verify_all_nodes(
     funding_keypair: &Keypair,
     nodes: usize,
 ) {
-    let cluster_nodes = discover(&entry_point_info, nodes).unwrap();
+    let (_leader_id, cluster_nodes) = discover(&entry_point_info, nodes).unwrap();
     assert!(cluster_nodes.len() >= nodes);
     for ingress_node in &cluster_nodes {
         let random_keypair = Keypair::new();
@@ -46,7 +46,7 @@ pub fn spend_and_verify_all_nodes(
 }
 
 pub fn fullnode_exit(entry_point_info: &ContactInfo, nodes: usize) {
-    let cluster_nodes = discover(&entry_point_info, nodes).unwrap();
+    let (_leader_id, cluster_nodes) = discover(&entry_point_info, nodes).unwrap();
     assert!(cluster_nodes.len() >= nodes);
     for node in &cluster_nodes {
         let mut client = mk_client(&node);
@@ -65,7 +65,7 @@ pub fn kill_entry_and_spend_and_verify_rest(
     nodes: usize,
 ) {
     solana_logger::setup();
-    let cluster_nodes = discover(&entry_point_info, nodes).unwrap();
+    let (_leader_id, cluster_nodes) = discover(&entry_point_info, nodes).unwrap();
     assert!(cluster_nodes.len() >= nodes);
     let mut client = mk_client(&entry_point_info);
     info!("sleeping for an epoch");

--- a/core/src/cluster_tests.rs
+++ b/core/src/cluster_tests.rs
@@ -19,7 +19,7 @@ pub fn spend_and_verify_all_nodes(
     funding_keypair: &Keypair,
     nodes: usize,
 ) {
-    let cluster_nodes = discover(&entry_point_info, nodes);
+    let cluster_nodes = discover(&entry_point_info, nodes).unwrap();
     assert!(cluster_nodes.len() >= nodes);
     for ingress_node in &cluster_nodes {
         let random_keypair = Keypair::new();
@@ -46,7 +46,7 @@ pub fn spend_and_verify_all_nodes(
 }
 
 pub fn fullnode_exit(entry_point_info: &ContactInfo, nodes: usize) {
-    let cluster_nodes = discover(&entry_point_info, nodes);
+    let cluster_nodes = discover(&entry_point_info, nodes).unwrap();
     assert!(cluster_nodes.len() >= nodes);
     for node in &cluster_nodes {
         let mut client = mk_client(&node);
@@ -65,7 +65,7 @@ pub fn kill_entry_and_spend_and_verify_rest(
     nodes: usize,
 ) {
     solana_logger::setup();
-    let cluster_nodes = discover(&entry_point_info, nodes);
+    let cluster_nodes = discover(&entry_point_info, nodes).unwrap();
     assert!(cluster_nodes.len() >= nodes);
     let mut client = mk_client(&entry_point_info);
     info!("sleeping for an epoch");

--- a/core/src/fullnode.rs
+++ b/core/src/fullnode.rs
@@ -120,7 +120,7 @@ impl Fullnode {
         let bank_forks = Arc::new(RwLock::new(bank_forks));
 
         node.info.wallclock = timestamp();
-        let cluster_info = Arc::new(RwLock::new(ClusterInfo::new_with_keypair(
+        let cluster_info = Arc::new(RwLock::new(ClusterInfo::new(
             node.info.clone(),
             keypair.clone(),
         )));

--- a/core/src/gossip_service.rs
+++ b/core/src/gossip_service.rs
@@ -78,18 +78,12 @@ pub fn make_listening_node(
 }
 
 pub fn discover(entry_point_info: &NodeInfo, num_nodes: usize) -> Vec<NodeInfo> {
-    converge(entry_point_info, num_nodes)
-}
-
-//TODO: deprecate this in favor of discover
-pub fn converge(node: &NodeInfo, num_nodes: usize) -> Vec<NodeInfo> {
     info!("Wait for convergence with {} nodes", num_nodes);
 
     let exit = Arc::new(AtomicBool::new(false));
-    // Let's spy on the network
-    let (gossip_service, spy_ref, id) = make_spy_node(node, &exit);
+    let (gossip_service, spy_ref, id) = make_spy_node(entry_point_info, &exit);
     trace!(
-        "converge spy_node {} looking for at least {} nodes",
+        "discover: spy_node {} looking for at least {} nodes",
         id,
         num_nodes
     );
@@ -97,22 +91,19 @@ pub fn converge(node: &NodeInfo, num_nodes: usize) -> Vec<NodeInfo> {
     // Wait for the cluster to converge
     for _ in 0..15 {
         let rpc_peers = spy_ref.read().unwrap().rpc_peers();
+        info!(
+            "discover: spy_node {} found {}/{} nodes",
+            id,
+            rpc_peers.len(),
+            num_nodes,
+        );
         if rpc_peers.len() >= num_nodes {
-            debug!(
-                "converge found {}/{} nodes: {:?}",
-                rpc_peers.len(),
-                num_nodes,
-                rpc_peers
-            );
             exit.store(true, Ordering::Relaxed);
             gossip_service.join().unwrap();
             return rpc_peers;
         }
         debug!(
-            "spy_node: {} converge found {}/{} nodes, need {} more",
-            id,
-            rpc_peers.len(),
-            num_nodes,
+            "discover: expecting an additional {} nodes",
             num_nodes - rpc_peers.len()
         );
         sleep(Duration::new(1, 0));

--- a/core/src/gossip_service.rs
+++ b/core/src/gossip_service.rs
@@ -121,6 +121,9 @@ pub fn discover(
         ));
         i += 1;
     }
+
+    exit.store(true, Ordering::Relaxed);
+    gossip_service.join().unwrap();
     Err("Failed to converge")
 }
 

--- a/core/src/gossip_service.rs
+++ b/core/src/gossip_service.rs
@@ -117,8 +117,7 @@ fn make_spy_node(
 ) -> (GossipService, Arc<RwLock<ClusterInfo>>) {
     let keypair = Arc::new(Keypair::new());
     let (node, gossip_socket) = ClusterInfo::spy_node(&keypair.pubkey());
-
-    let mut cluster_info = ClusterInfo::new(node, keypair);
+    let mut cluster_info = ClusterInfo::new_with_invalid_keypair(node);
     cluster_info.insert_info(entry_point.clone());
 
     let cluster_info = Arc::new(RwLock::new(cluster_info));

--- a/core/src/gossip_service.rs
+++ b/core/src/gossip_service.rs
@@ -130,7 +130,7 @@ pub fn make_spy_node(
 ) -> (GossipService, Arc<RwLock<ClusterInfo>>) {
     let keypair = Arc::new(Keypair::new());
     let (node, gossip_socket) = ClusterInfo::spy_node(&keypair.pubkey());
-    let mut cluster_info = ClusterInfo::new_with_invalid_keypair(node);
+    let mut cluster_info = ClusterInfo::new(node, keypair);
     cluster_info.insert_info(entry_point.clone());
 
     let cluster_info = Arc::new(RwLock::new(cluster_info));

--- a/core/src/gossip_service.rs
+++ b/core/src/gossip_service.rs
@@ -164,7 +164,7 @@ mod tests {
     fn test_exit() {
         let exit = Arc::new(AtomicBool::new(false));
         let tn = Node::new_localhost();
-        let cluster_info = ClusterInfo::new(tn.info.clone());
+        let cluster_info = ClusterInfo::new_with_invalid_keypair(tn.info.clone());
         let c = Arc::new(RwLock::new(cluster_info));
         let d = GossipService::new(&c, None, None, tn.sockets.gossip, &exit);
         exit.store(true, Ordering::Relaxed);

--- a/core/src/local_cluster.rs
+++ b/core/src/local_cluster.rs
@@ -102,7 +102,7 @@ impl LocalCluster {
             );
             fullnodes.push(validator_server);
         }
-        discover(&leader_node_info, num_nodes);
+        discover(&leader_node_info, num_nodes).unwrap();
         Self {
             funding_keypair: mint_keypair,
             entry_point_info: leader_node_info,

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -361,7 +361,9 @@ mod test {
         let (my_ledger_path, _blockhash) = create_new_tmp_ledger!(&genesis_block);
 
         // Set up the cluster info
-        let cluster_info_me = Arc::new(RwLock::new(ClusterInfo::new_with_invalid_keypair(my_node.info.clone())));
+        let cluster_info_me = Arc::new(RwLock::new(ClusterInfo::new_with_invalid_keypair(
+            my_node.info.clone(),
+        )));
 
         // Set up the replay stage
         {

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -361,7 +361,7 @@ mod test {
         let (my_ledger_path, _blockhash) = create_new_tmp_ledger!(&genesis_block);
 
         // Set up the cluster info
-        let cluster_info_me = Arc::new(RwLock::new(ClusterInfo::new(my_node.info.clone())));
+        let cluster_info_me = Arc::new(RwLock::new(ClusterInfo::new_with_invalid_keypair(my_node.info.clone())));
 
         // Set up the replay stage
         {

--- a/core/src/replicator.rs
+++ b/core/src/replicator.rs
@@ -110,7 +110,7 @@ impl Replicator {
         ledger_path: &str,
         node: Node,
         leader_info: &NodeInfo,
-        keypair: &Keypair,
+        keypair: &Arc<Keypair>,
         timeout: Option<Duration>,
     ) -> Result<Self> {
         let exit = Arc::new(AtomicBool::new(false));
@@ -212,7 +212,7 @@ impl Replicator {
 
         let mut client = mk_client(&leader);
 
-        Self::get_airdrop_lamports(&mut client, keypair, &leader_info);
+        Self::get_airdrop_lamports(&mut client, &keypair, &leader_info);
         info!("Done downloading ledger at {}", ledger_path);
 
         let ledger_path = Path::new(ledger_path);

--- a/core/src/replicator.rs
+++ b/core/src/replicator.rs
@@ -118,14 +118,10 @@ impl Replicator {
 
         info!("Replicator: id: {}", keypair.pubkey());
         info!("Creating cluster info....");
-        let cluster_info = Arc::new(RwLock::new(ClusterInfo::new_with_invalid_keypair(node.info.clone())));
-
-        let leader_pubkey = leader_info.id;
-        {
-            let mut cluster_info_w = cluster_info.write().unwrap();
-            cluster_info_w.insert_info(leader_info.clone());
-            cluster_info_w.set_leader(leader_pubkey);
-        }
+        let mut cluster_info = ClusterInfo::new(node.info.clone(), keypair.clone());
+        cluster_info.insert_info(leader_info.clone());
+        cluster_info.set_leader(leader_info.id);
+        let cluster_info = Arc::new(RwLock::new(cluster_info));
 
         // Create Blocktree, eventually will simply repurpose the input
         // ledger path as the Blocktree path once we replace the ledger with

--- a/core/src/replicator.rs
+++ b/core/src/replicator.rs
@@ -118,7 +118,7 @@ impl Replicator {
 
         info!("Replicator: id: {}", keypair.pubkey());
         info!("Creating cluster info....");
-        let cluster_info = Arc::new(RwLock::new(ClusterInfo::new(node.info.clone())));
+        let cluster_info = Arc::new(RwLock::new(ClusterInfo::new_with_invalid_keypair(node.info.clone())));
 
         let leader_pubkey = leader_info.id;
         {

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -437,7 +437,9 @@ mod tests {
             &exit,
         )));
         request_processor.write().unwrap().set_bank(&bank);
-        let cluster_info = Arc::new(RwLock::new(ClusterInfo::new_with_invalid_keypair(NodeInfo::default())));
+        let cluster_info = Arc::new(RwLock::new(ClusterInfo::new_with_invalid_keypair(
+            NodeInfo::default(),
+        )));
         let leader = NodeInfo::new_with_socketaddr(&socketaddr!("127.0.0.1:1234"));
 
         cluster_info.write().unwrap().insert_info(leader.clone());
@@ -638,7 +640,9 @@ mod tests {
                 request_processor.set_bank(&bank);
                 Arc::new(RwLock::new(request_processor))
             },
-            cluster_info: Arc::new(RwLock::new(ClusterInfo::new_with_invalid_keypair(NodeInfo::default()))),
+            cluster_info: Arc::new(RwLock::new(ClusterInfo::new_with_invalid_keypair(
+                NodeInfo::default(),
+            ))),
         };
 
         let req =
@@ -655,7 +659,9 @@ mod tests {
 
     #[test]
     fn test_rpc_get_leader_addr() {
-        let cluster_info = Arc::new(RwLock::new(ClusterInfo::new_with_invalid_keypair(NodeInfo::default())));
+        let cluster_info = Arc::new(RwLock::new(ClusterInfo::new_with_invalid_keypair(
+            NodeInfo::default(),
+        )));
         assert_eq!(
             get_leader_addr(&cluster_info),
             Err(Error {

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -437,7 +437,7 @@ mod tests {
             &exit,
         )));
         request_processor.write().unwrap().set_bank(&bank);
-        let cluster_info = Arc::new(RwLock::new(ClusterInfo::new(NodeInfo::default())));
+        let cluster_info = Arc::new(RwLock::new(ClusterInfo::new_with_invalid_keypair(NodeInfo::default())));
         let leader = NodeInfo::new_with_socketaddr(&socketaddr!("127.0.0.1:1234"));
 
         cluster_info.write().unwrap().insert_info(leader.clone());
@@ -638,7 +638,7 @@ mod tests {
                 request_processor.set_bank(&bank);
                 Arc::new(RwLock::new(request_processor))
             },
-            cluster_info: Arc::new(RwLock::new(ClusterInfo::new(NodeInfo::default()))),
+            cluster_info: Arc::new(RwLock::new(ClusterInfo::new_with_invalid_keypair(NodeInfo::default()))),
         };
 
         let req =
@@ -655,7 +655,7 @@ mod tests {
 
     #[test]
     fn test_rpc_get_leader_addr() {
-        let cluster_info = Arc::new(RwLock::new(ClusterInfo::new(NodeInfo::default())));
+        let cluster_info = Arc::new(RwLock::new(ClusterInfo::new_with_invalid_keypair(NodeInfo::default())));
         assert_eq!(
             get_leader_addr(&cluster_info),
             Err(Error {

--- a/core/src/rpc_service.rs
+++ b/core/src/rpc_service.rs
@@ -99,7 +99,7 @@ mod tests {
         let (genesis_block, alice) = GenesisBlock::new(10_000);
         let exit = Arc::new(AtomicBool::new(false));
         let bank = Bank::new(&genesis_block);
-        let cluster_info = Arc::new(RwLock::new(ClusterInfo::new(NodeInfo::default())));
+        let cluster_info = Arc::new(RwLock::new(ClusterInfo::new_with_invalid_keypair(NodeInfo::default())));
         let rpc_addr = SocketAddr::new(
             IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)),
             solana_netutil::find_available_port_in_range((10000, 65535)).unwrap(),

--- a/core/src/rpc_service.rs
+++ b/core/src/rpc_service.rs
@@ -99,7 +99,9 @@ mod tests {
         let (genesis_block, alice) = GenesisBlock::new(10_000);
         let exit = Arc::new(AtomicBool::new(false));
         let bank = Bank::new(&genesis_block);
-        let cluster_info = Arc::new(RwLock::new(ClusterInfo::new_with_invalid_keypair(NodeInfo::default())));
+        let cluster_info = Arc::new(RwLock::new(ClusterInfo::new_with_invalid_keypair(
+            NodeInfo::default(),
+        )));
         let rpc_addr = SocketAddr::new(
             IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)),
             solana_netutil::find_available_port_in_range((10000, 65535)).unwrap(),

--- a/core/src/storage_stage.rs
+++ b/core/src/storage_stage.rs
@@ -492,7 +492,7 @@ mod tests {
 
     fn test_cluster_info(id: Pubkey) -> Arc<RwLock<ClusterInfo>> {
         let node_info = NodeInfo::new_localhost(id, 0);
-        let cluster_info = ClusterInfo::new(node_info);
+        let cluster_info = ClusterInfo::new_with_invalid_keypair(node_info);
         Arc::new(RwLock::new(cluster_info))
     }
 

--- a/core/src/thin_client.rs
+++ b/core/src/thin_client.rs
@@ -394,7 +394,7 @@ pub fn poll_gossip_for_leader(leader_gossip: SocketAddr, timeout: Option<u64>) -
     let exit = Arc::new(AtomicBool::new(false));
     let (node, gossip_socket) = ClusterInfo::spy_node();
     let my_addr = gossip_socket.local_addr().unwrap();
-    let cluster_info = Arc::new(RwLock::new(ClusterInfo::new(node)));
+    let cluster_info = Arc::new(RwLock::new(ClusterInfo::new_with_invalid_keypair(node)));
     let gossip_service =
         GossipService::new(&cluster_info.clone(), None, None, gossip_socket, &exit);
 

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -192,7 +192,7 @@ pub mod tests {
         }];
 
         //start cluster_info1
-        let mut cluster_info1 = ClusterInfo::new(target1.info.clone());
+        let mut cluster_info1 = ClusterInfo::new_with_invalid_keypair(target1.info.clone());
         cluster_info1.insert_info(leader.info.clone());
         cluster_info1.set_leader(leader.info.id);
         let cref1 = Arc::new(RwLock::new(cluster_info1));

--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -172,7 +172,8 @@ mod test {
         let leader_node = Node::new_localhost();
         let validator_node = Node::new_localhost();
         let exit = Arc::new(AtomicBool::new(false));
-        let mut cluster_info_me = ClusterInfo::new_with_invalid_keypair(validator_node.info.clone());
+        let mut cluster_info_me =
+            ClusterInfo::new_with_invalid_keypair(validator_node.info.clone());
         let me_id = leader_node.info.id;
         cluster_info_me.set_leader(me_id);
         let subs = Arc::new(RwLock::new(cluster_info_me));

--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -172,7 +172,7 @@ mod test {
         let leader_node = Node::new_localhost();
         let validator_node = Node::new_localhost();
         let exit = Arc::new(AtomicBool::new(false));
-        let mut cluster_info_me = ClusterInfo::new(validator_node.info.clone());
+        let mut cluster_info_me = ClusterInfo::new_with_invalid_keypair(validator_node.info.clone());
         let me_id = leader_node.info.id;
         cluster_info_me.set_leader(me_id);
         let subs = Arc::new(RwLock::new(cluster_info_me));
@@ -244,7 +244,7 @@ mod test {
         let leader_node = Node::new_localhost();
         let validator_node = Node::new_localhost();
         let exit = Arc::new(AtomicBool::new(false));
-        let cluster_info_me = ClusterInfo::new(validator_node.info.clone());
+        let cluster_info_me = ClusterInfo::new_with_invalid_keypair(validator_node.info.clone());
         let me_id = leader_node.info.id;
         let subs = Arc::new(RwLock::new(cluster_info_me));
 

--- a/replicator/src/main.rs
+++ b/replicator/src/main.rs
@@ -5,6 +5,7 @@ use solana::socketaddr;
 use solana_sdk::signature::{read_keypair, Keypair, KeypairUtil};
 use std::net::{Ipv4Addr, SocketAddr};
 use std::process::exit;
+use std::sync::Arc;
 
 fn main() {
     solana_logger::setup();

--- a/replicator/src/main.rs
+++ b/replicator/src/main.rs
@@ -81,7 +81,8 @@ fn main() {
 
     let leader_info = NodeInfo::new_entry_point(&network_addr);
 
-    let replicator = Replicator::new(ledger_path, node, &leader_info, &keypair, None).unwrap();
+    let replicator =
+        Replicator::new(ledger_path, node, &leader_info, &Arc::new(keypair), None).unwrap();
 
     replicator.join();
 }

--- a/tests/cluster_info.rs
+++ b/tests/cluster_info.rs
@@ -37,7 +37,7 @@ fn run_simulation(num_nodes: u64, fanout: usize, hood_size: usize) {
 
     // describe the leader
     let leader_info = ContactInfo::new_localhost(Keypair::new().pubkey(), 0);
-    let mut cluster_info = ClusterInfo::new(leader_info.clone());
+    let mut cluster_info = ClusterInfo::new_with_invalid_keypair(leader_info.clone());
     cluster_info.set_leader(leader_info.id);
 
     // setup stakes

--- a/tests/replicator.rs
+++ b/tests/replicator.rs
@@ -63,7 +63,8 @@ fn test_replicator_startup_basic() {
 
         debug!(
             "leader: {:?}",
-            solana::thin_client::poll_gossip_for_leader(leader_info.gossip, Some(5)).unwrap()
+            solana::thin_client::poll_gossip_for_leader(leader_info.gossip, Duration::from_secs(5))
+                .unwrap()
         );
 
         let validator_keypair = Arc::new(Keypair::new());

--- a/tests/replicator.rs
+++ b/tests/replicator.rs
@@ -109,7 +109,7 @@ fn test_replicator_startup_basic() {
             );
         }
 
-        let replicator_keypair = Keypair::new();
+        let replicator_keypair = Arc::new(Keypair::new());
 
         info!("giving replicator lamports..");
 
@@ -238,7 +238,7 @@ fn test_replicator_startup_leader_hang() {
     let (replicator_ledger_path, _blockhash) = create_new_tmp_ledger!(&genesis_block);
 
     {
-        let replicator_keypair = Keypair::new();
+        let replicator_keypair = Arc::new(Keypair::new());
 
         info!("starting replicator node");
         let replicator_node = Node::new_localhost_with_pubkey(replicator_keypair.pubkey());
@@ -308,7 +308,7 @@ fn test_replicator_startup_ledger_hang() {
         );
 
         info!("starting replicator node");
-        let bad_keys = Keypair::new();
+        let bad_keys = Arc::new(Keypair::new());
         let mut replicator_node = Node::new_localhost_with_pubkey(bad_keys.pubkey());
 
         // Pass bad TVU sockets to prevent successful ledger download

--- a/tests/replicator.rs
+++ b/tests/replicator.rs
@@ -146,7 +146,7 @@ fn test_replicator_startup_basic() {
         // Create a client which downloads from the replicator and see that it
         // can respond with blobs.
         let tn = Node::new_localhost();
-        let cluster_info = ClusterInfo::new(tn.info.clone());
+        let cluster_info = ClusterInfo::new_with_invalid_keypair(tn.info.clone());
         let repair_index = replicator.entry_height();
         let req = cluster_info
             .window_index_request_bytes(0, repair_index)

--- a/tests/tvu.rs
+++ b/tests/tvu.rs
@@ -47,14 +47,14 @@ fn test_replay() {
     let exit = Arc::new(AtomicBool::new(false));
 
     // start cluster_info_l
-    let mut cluster_info_l = ClusterInfo::new(leader.info.clone());
+    let mut cluster_info_l = ClusterInfo::new_with_invalid_keypair(leader.info.clone());
     cluster_info_l.set_leader(leader.info.id);
 
     let cref_l = Arc::new(RwLock::new(cluster_info_l));
     let dr_l = new_gossip(cref_l, leader.sockets.gossip, &exit);
 
     // start cluster_info2
-    let mut cluster_info2 = ClusterInfo::new(target2.info.clone());
+    let mut cluster_info2 = ClusterInfo::new_with_invalid_keypair(target2.info.clone());
     cluster_info2.insert_info(leader.info.clone());
     cluster_info2.set_leader(leader.info.id);
     let cref2 = Arc::new(RwLock::new(cluster_info2));
@@ -97,7 +97,7 @@ fn test_replay() {
     assert_eq!(bank.get_balance(&mint_keypair.pubkey()), starting_balance);
 
     // start cluster_info1
-    let mut cluster_info1 = ClusterInfo::new(target1.info.clone());
+    let mut cluster_info1 = ClusterInfo::new_with_invalid_keypair(target1.info.clone());
     cluster_info1.insert_info(leader.info.clone());
     cluster_info1.set_leader(leader.info.id);
     let cref1 = Arc::new(RwLock::new(cluster_info1));


### PR DESCRIPTION
* Various duplicated mechanisms for creating spy nodes, node discovery
* Confusing names: ClusterInfo::new() is now new function you *want* to use by default, ClusterInfo::new_with_invalid_keypair() is the special case new function for use in tests/spy nodes
* Remove unnecessary complexity: pass Arc references to simplify/clarify usage, drop unnecessary Option<> wrappers, clarify timeout units by using `Duration`, etc.   
* Give spy nodes a proper keypair

🤕 