### PR TITLE
Move Budget's runtime simulator to runtime.rs

### DIFF
--- a/programs/budget/src/budget_program.rs
+++ b/programs/budget/src/budget_program.rs
@@ -177,24 +177,9 @@ mod test {
         tx: &Transaction,
         tx_accounts: &mut [Account],
     ) -> Result<(), BudgetError> {
-        for ix in &tx.instructions {
-            let mut ix_accounts = runtime::get_subset_unchecked_mut(tx_accounts, &ix.accounts);
-            let mut keyed_accounts: Vec<_> = ix
-                .accounts
-                .iter()
-                .map(|&index| {
-                    let index = index as usize;
-                    let key = &tx.account_keys[index];
-                    (key, index < tx.signatures.len())
-                })
-                .zip(ix_accounts.iter_mut())
-                .map(|((key, is_signer), account)| KeyedAccount::new(key, is_signer, account))
-                .collect();
-
-            process_instruction(&mut keyed_accounts, &ix.userdata)?;
-        }
-        Ok(())
+        runtime::process_transaction(tx, tx_accounts, process_instruction)
     }
+
     #[test]
     fn test_invalid_instruction() {
         let mut accounts = vec![Account::new(1, 0, id()), Account::new(0, 512, id())];

--- a/programs/system/src/lib.rs
+++ b/programs/system/src/lib.rs
@@ -2,7 +2,6 @@ use log::*;
 use solana_sdk::account::KeyedAccount;
 use solana_sdk::native_program::ProgramError;
 use solana_sdk::pubkey::Pubkey;
-use solana_sdk::solana_entrypoint;
 use solana_sdk::system_instruction::SystemInstruction;
 use solana_sdk::system_program;
 
@@ -74,7 +73,6 @@ fn move_lamports(keyed_accounts: &mut [KeyedAccount], lamports: u64) -> Result<(
     Ok(())
 }
 
-solana_entrypoint!(entrypoint);
 pub fn entrypoint(
     _program_id: &Pubkey,
     keyed_accounts: &mut [KeyedAccount],

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -5,7 +5,7 @@ pub mod bloom;
 mod hash_queue;
 pub mod loader_utils;
 mod native_loader;
-mod runtime;
+pub mod runtime;
 mod status_cache;
 
 #[macro_use]

--- a/runtime/src/runtime.rs
+++ b/runtime/src/runtime.rs
@@ -143,7 +143,7 @@ pub fn has_duplicates<T: PartialEq>(xs: &[T]) -> bool {
 }
 
 /// Get mut references to a subset of elements.
-fn get_subset_unchecked_mut<'a, T>(xs: &'a mut [T], indexes: &[u8]) -> Vec<&'a mut T> {
+pub fn get_subset_unchecked_mut<'a, T>(xs: &'a mut [T], indexes: &[u8]) -> Vec<&'a mut T> {
     // Since the compiler doesn't know the indexes are unique, dereferencing
     // multiple mut elements is assumed to be unsafe. If, however, all
     // indexes are unique, it's perfectly safe. The returned elements will share


### PR DESCRIPTION
#### Problem

The Budget test suite included its own runtime simulator. It's a nice, concise way to write program unit-tests, but unfortunately didn't work for multi-instruction transactions.

#### Summary of Changes

Generalize Budget's `process_transaction()` utility and move it into runtime.rs where it's accessible to other programs.

Note: The benefit of using `runtime::process_transaction()` over `Bank::process_transaction()` is you bypass native_loader, which gets you better stack traces, and direct access to the program-specific error instead of digging through the signature cache for ProgramError.