### PR TITLE
Add voting call flow art

### DIFF
--- a/book/art/voting.bob
+++ b/book/art/voting.bob
@@ -1,0 +1,16 @@
+                 .------------.        .------------.     .------------.     .------------.
+                 |   Staker   |        |  Network   |     | VoteSigner |     |  Validator |
+                 `------------`        `------------`     `------------`     `------------`
+                       |                     |                  |                  | boot...
+                       |                     |                  |   register(node_id)
+                       |                     |                  |.<----------------|
+               create-staking-account($$)    |           ???    ||  voting_pubkey  |
+                       |-------------------->|                  |`---------------->|
+                       |                     |                  |                  | vote...
+                       |                     |                  |   sign_please(vote)
+                       |                     |                  |.<----------------|
+  config-staking-account(delegate, signer)   |         chugga.. ||  signed_vote    |
+                       |-------------------->|                  |`---------------->|
+                       |                     |                  |                  |
+                       |                     | process < - - -  |  - - - - - - - - | gossip(vote)
+                                               gossip(vote)


### PR DESCRIPTION
In order to get stakes back to validators, we need to get staking accounts set up for them.  Picture shows what I currently understand of the call flow, but has obvious holes...

Questions:

- [ ] how does the Staker (wallet as currently proposed) learn of the VoteSigner's Pubkey?  Is authorized_voter_id this necessary for the VoteProgram to function?
- [ ] is VoteSigner the correct API for this call flow?
- [ ] is VoteSigner necessary for Beacons? 
