### PR TITLE
Clean up budget

### DIFF
--- a/core/src/chacha.rs
+++ b/core/src/chacha.rs
@@ -95,9 +95,9 @@ mod tests {
     use crate::chacha::chacha_cbc_encrypt_ledger;
     use crate::entry::Entry;
     use ring::signature::Ed25519KeyPair;
-    use solana_budget_api::budget_transaction::BudgetTransaction;
     use solana_sdk::hash::{hash, Hash, Hasher};
     use solana_sdk::signature::KeypairUtil;
+    use solana_sdk::system_transaction::SystemTransaction;
     use std::fs::remove_file;
     use std::fs::File;
     use std::io::Read;
@@ -124,11 +124,12 @@ mod tests {
                 Entry::new_mut(
                     &mut id,
                     &mut num_hashes,
-                    vec![BudgetTransaction::new_signature(
+                    vec![SystemTransaction::new_account(
                         &keypair,
                         keypair.pubkey(),
-                        keypair.pubkey(),
+                        1,
                         one,
+                        0,
                     )],
                 )
             })
@@ -161,7 +162,7 @@ mod tests {
         use bs58;
         //  golden needs to be updated if blob stuff changes....
         let golden = Hash::new(
-            &bs58::decode("BCNVsE19CCpsvGseZTCEEM1qSiX1ridku2w155VveqEu")
+            &bs58::decode("B33zQ8Kc3Wr3vZAbB6GcWaB3sSGeG98nvm4QB9URpJhR")
                 .into_vec()
                 .unwrap(),
         );

--- a/core/src/entry.rs
+++ b/core/src/entry.rs
@@ -645,7 +645,7 @@ mod tests {
         let keypair = Keypair::new();
         let vote_account = Keypair::new();
         let tx_small = VoteTransaction::new_vote(&vote_account, 1, next_hash, 2);
-        let tx_large = BudgetTransaction::new(&keypair, keypair.pubkey(), 1, next_hash);
+        let tx_large = BudgetTransaction::new_payment(&keypair, keypair.pubkey(), 1, next_hash, 0);
 
         let tx_small_size = tx_small.serialized_size().unwrap() as usize;
         let tx_large_size = tx_large.serialized_size().unwrap() as usize;

--- a/core/src/rpc_pubsub.rs
+++ b/core/src/rpc_pubsub.rs
@@ -400,25 +400,6 @@ mod tests {
         sleep(Duration::from_millis(200));
 
         assert_eq!(arc_bank.get_account(&contract_state.pubkey()), None);
-
-        // TODO: Should we get a notification of an empty account?
-        //let expected = json!({
-        //   "jsonrpc": "2.0",
-        //   "method": "accountNotification",
-        //   "params": {
-        //       "result": {
-        //           "owner": budget_program_id,
-        //           "lamports": 1,
-        //           "userdata": expected_userdata,
-        //            "executable": executable,
-        //       },
-        //       "subscription": 0,
-        //   }
-        //});
-        //let string = receiver.poll();
-        //if let Async::Ready(Some(response)) = string.unwrap() {
-        //    assert_eq!(serde_json::to_string(&expected).unwrap(), response);
-        //}
     }
 
     #[test]

--- a/programs/budget/src/budget_program.rs
+++ b/programs/budget/src/budget_program.rs
@@ -168,7 +168,7 @@ mod test {
 
     fn process_transaction(
         tx: &Transaction,
-        tx_accounts: &mut [Account],
+        tx_accounts: &mut Vec<Account>,
     ) -> Result<(), BudgetError> {
         runtime::process_transaction(tx, tx_accounts, process_instruction)
     }
@@ -192,12 +192,7 @@ mod test {
 
     #[test]
     fn test_unsigned_witness_key() {
-        let mut accounts = vec![
-            Account::new(1, 0, system_program::id()),
-            Account::new(0, 0, system_program::id()),
-            Account::new(0, 0, system_program::id()),
-            Account::new(0, 0, system_program::id()),
-        ];
+        let mut accounts = vec![Account::new(1, 0, system_program::id())];
 
         // Initialize BudgetState
         let from = Keypair::new();
@@ -232,12 +227,7 @@ mod test {
 
     #[test]
     fn test_unsigned_timestamp() {
-        let mut accounts = vec![
-            Account::new(1, 0, system_program::id()),
-            Account::new(0, 0, system_program::id()),
-            Account::new(0, 0, system_program::id()),
-            Account::new(0, 0, system_program::id()),
-        ];
+        let mut accounts = vec![Account::new(1, 0, system_program::id())];
 
         // Initialize BudgetState
         let from = Keypair::new();
@@ -273,11 +263,7 @@ mod test {
 
     #[test]
     fn test_transfer_on_date() {
-        let mut accounts = vec![
-            Account::new(1, 0, system_program::id()),
-            Account::new(0, 0, system_program::id()),
-            Account::new(0, 0, system_program::id()),
-        ];
+        let mut accounts = vec![Account::new(1, 0, system_program::id())];
         let from_account = 0;
         let contract_account = 1;
         let to_account = 2;
@@ -349,11 +335,7 @@ mod test {
     }
     #[test]
     fn test_cancel_transfer() {
-        let mut accounts = vec![
-            Account::new(1, 0, system_program::id()),
-            Account::new(0, 0, system_program::id()),
-            Account::new(0, 0, system_program::id()),
-        ];
+        let mut accounts = vec![Account::new(1, 0, system_program::id())];
         let from_account = 0;
         let contract_account = 1;
         let pay_account = 2;
@@ -386,8 +368,7 @@ mod test {
         // nothing should be changed because apply witness didn't finalize a payment
         assert_eq!(accounts[from_account].lamports, 0);
         assert_eq!(accounts[contract_account].lamports, 1);
-        // this is the `to.pubkey()` account
-        assert_eq!(accounts[pay_account].lamports, 0);
+        assert_eq!(accounts.get(pay_account), None);
 
         // Now, cancel the transaction. from gets her funds back
         let tx = BudgetTransaction::new_signature(
@@ -399,7 +380,7 @@ mod test {
         process_transaction(&tx, &mut accounts).unwrap();
         assert_eq!(accounts[from_account].lamports, 1);
         assert_eq!(accounts[contract_account].lamports, 0);
-        assert_eq!(accounts[pay_account].lamports, 0);
+        assert_eq!(accounts.get(pay_account), None);
 
         // try to replay the cancel contract
         let tx = BudgetTransaction::new_signature(
@@ -414,6 +395,6 @@ mod test {
         );
         assert_eq!(accounts[from_account].lamports, 1);
         assert_eq!(accounts[contract_account].lamports, 0);
-        assert_eq!(accounts[pay_account].lamports, 0);
+        assert_eq!(accounts.get(pay_account), None);
     }
 }

--- a/programs/budget/src/budget_program.rs
+++ b/programs/budget/src/budget_program.rs
@@ -90,17 +90,15 @@ fn apply_debits(
                 keyed_accounts[0].account.lamports += payment.lamports;
                 Ok(())
             } else {
-                let existing = BudgetState::deserialize(&keyed_accounts[1].account.userdata).ok();
+                let existing = BudgetState::deserialize(&keyed_accounts[0].account.userdata).ok();
                 if Some(true) == existing.map(|x| x.initialized) {
                     trace!("contract already exists");
                     Err(BudgetError::ContractAlreadyExists)
                 } else {
                     let mut budget_state = BudgetState::default();
                     budget_state.pending_budget = Some(expr);
-                    keyed_accounts[1].account.lamports += keyed_accounts[0].account.lamports;
-                    keyed_accounts[0].account.lamports = 0;
                     budget_state.initialized = true;
-                    budget_state.serialize(&mut keyed_accounts[1].account.userdata)
+                    budget_state.serialize(&mut keyed_accounts[0].account.userdata)
                 }
             }
         }
@@ -173,6 +171,7 @@ mod test {
     use solana_sdk::signature::{Keypair, KeypairUtil};
     use solana_sdk::transaction::Transaction;
 
+    // TODO: This is wrong and will only work with single-instruction transactions.
     fn process_transaction(
         tx: &Transaction,
         tx_accounts: &mut [Account],

--- a/programs/budget/src/lib.rs
+++ b/programs/budget/src/lib.rs
@@ -9,7 +9,7 @@ use solana_sdk::solana_entrypoint;
 
 solana_entrypoint!(entrypoint);
 fn entrypoint(
-    _program_id: &Pubkey,
+    program_id: &Pubkey,
     keyed_accounts: &mut [KeyedAccount],
     data: &[u8],
     _tick_height: u64,
@@ -18,5 +18,5 @@ fn entrypoint(
 
     trace!("process_instruction: {:?}", data);
     trace!("keyed_accounts: {:?}", keyed_accounts);
-    process_instruction(keyed_accounts, data).map_err(|_| ProgramError::GenericError)
+    process_instruction(program_id, keyed_accounts, data).map_err(|_| ProgramError::GenericError)
 }

--- a/programs/budget_api/src/budget_instruction.rs
+++ b/programs/budget_api/src/budget_instruction.rs
@@ -32,10 +32,23 @@ impl BudgetInstruction {
         let mut keys = vec![];
         if let BudgetExpr::Pay(payment) = &expr {
             keys.push((payment.to, false));
-        } else {
-            panic!("unsupported Budget instruction");
         }
         keys.push((contract, false));
         BuilderInstruction::new(id(), &BudgetInstruction::InitializeAccount(expr), keys)
+    }
+
+    pub fn new_apply_timestamp(
+        from: Pubkey,
+        contract: Pubkey,
+        to: Pubkey,
+        dt: DateTime<Utc>,
+    ) -> BuilderInstruction {
+        let keys = vec![(from, true), (contract, false), (to, false)];
+        BuilderInstruction::new(id(), &BudgetInstruction::ApplyTimestamp(dt), keys)
+    }
+
+    pub fn new_apply_signature(from: Pubkey, contract: Pubkey, to: Pubkey) -> BuilderInstruction {
+        let keys = vec![(from, true), (contract, false), (to, false)];
+        BuilderInstruction::new(id(), &BudgetInstruction::ApplySignature, keys)
     }
 }

--- a/programs/budget_api/src/budget_instruction.rs
+++ b/programs/budget_api/src/budget_instruction.rs
@@ -43,12 +43,18 @@ impl BudgetInstruction {
         to: Pubkey,
         dt: DateTime<Utc>,
     ) -> BuilderInstruction {
-        let keys = vec![(from, true), (contract, false), (to, false)];
+        let mut keys = vec![(from, true), (contract, false)];
+        if from != to {
+            keys.push((to, false));
+        }
         BuilderInstruction::new(id(), &BudgetInstruction::ApplyTimestamp(dt), keys)
     }
 
     pub fn new_apply_signature(from: Pubkey, contract: Pubkey, to: Pubkey) -> BuilderInstruction {
-        let keys = vec![(from, true), (contract, false), (to, false)];
+        let mut keys = vec![(from, true), (contract, false)];
+        if from != to {
+            keys.push((to, false));
+        }
         BuilderInstruction::new(id(), &BudgetInstruction::ApplySignature, keys)
     }
 }

--- a/programs/budget_api/src/budget_transaction.rs
+++ b/programs/budget_api/src/budget_transaction.rs
@@ -40,17 +40,6 @@ impl BudgetTransaction {
             .sign(&[from_keypair], recent_blockhash)
     }
 
-    /// Create and sign a new Transaction. Used for unit-testing.
-    #[allow(clippy::new_ret_no_self)]
-    pub fn new(
-        from_keypair: &Keypair,
-        to: Pubkey,
-        lamports: u64,
-        recent_blockhash: Hash,
-    ) -> Transaction {
-        Self::new_payment(from_keypair, to, lamports, recent_blockhash, 0)
-    }
-
     /// Create and sign a new Witness Timestamp. Used for unit-testing.
     pub fn new_timestamp(
         from_keypair: &Keypair,
@@ -195,7 +184,7 @@ mod tests {
     fn test_claim() {
         let keypair = Keypair::new();
         let zero = Hash::default();
-        let tx0 = BudgetTransaction::new(&keypair, keypair.pubkey(), 42, zero);
+        let tx0 = BudgetTransaction::new_payment(&keypair, keypair.pubkey(), 42, zero, 0);
         assert!(BudgetTransaction::verify_plan(&tx0));
     }
 
@@ -205,7 +194,7 @@ mod tests {
         let keypair0 = Keypair::new();
         let keypair1 = Keypair::new();
         let pubkey1 = keypair1.pubkey();
-        let tx0 = BudgetTransaction::new(&keypair0, pubkey1, 42, zero);
+        let tx0 = BudgetTransaction::new_payment(&keypair0, pubkey1, 42, zero, 0);
         assert!(BudgetTransaction::verify_plan(&tx0));
     }
 
@@ -234,7 +223,7 @@ mod tests {
         let zero = Hash::default();
         let keypair = Keypair::new();
         let pubkey = keypair.pubkey();
-        let mut tx = BudgetTransaction::new(&keypair, pubkey, 42, zero);
+        let mut tx = BudgetTransaction::new_payment(&keypair, pubkey, 42, zero, 0);
         let mut system_instruction = BudgetTransaction::system_instruction(&tx, 0).unwrap();
         if let SystemInstruction::CreateAccount {
             ref mut lamports, ..
@@ -261,7 +250,7 @@ mod tests {
         let thief_keypair = Keypair::new();
         let pubkey1 = keypair1.pubkey();
         let zero = Hash::default();
-        let mut tx = BudgetTransaction::new(&keypair0, pubkey1, 42, zero);
+        let mut tx = BudgetTransaction::new_payment(&keypair0, pubkey1, 42, zero, 0);
         let mut instruction = BudgetTransaction::instruction(&tx, 1);
         if let Some(BudgetInstruction::InitializeAccount(ref mut expr)) = instruction {
             if let BudgetExpr::Pay(ref mut payment) = expr {
@@ -278,7 +267,7 @@ mod tests {
         let keypair0 = Keypair::new();
         let keypair1 = Keypair::new();
         let zero = Hash::default();
-        let mut tx = BudgetTransaction::new(&keypair0, keypair1.pubkey(), 1, zero);
+        let mut tx = BudgetTransaction::new_payment(&keypair0, keypair1.pubkey(), 1, zero, 0);
         let mut instruction = BudgetTransaction::instruction(&tx, 1).unwrap();
         if let BudgetInstruction::InitializeAccount(ref mut expr) = instruction {
             if let BudgetExpr::Pay(ref mut payment) = expr {

--- a/programs/budget_api/src/budget_transaction.rs
+++ b/programs/budget_api/src/budget_transaction.rs
@@ -166,7 +166,7 @@ impl BudgetTransaction {
             if let Some(BudgetInstruction::InitializeAccount(expr)) =
                 BudgetTransaction::instruction(&tx, 1)
             {
-                if !(tx.fee <= lamports && expr.verify(lamports - tx.fee)) {
+                if !expr.verify(lamports) {
                     return false;
                 }
             }

--- a/runtime/src/runtime.rs
+++ b/runtime/src/runtime.rs
@@ -192,12 +192,15 @@ pub fn execute_transaction(
 /// for easier usage and better stack traces.
 pub fn process_transaction<F, E>(
     tx: &Transaction,
-    tx_accounts: &mut [Account],
+    tx_accounts: &mut Vec<Account>,
     process_instruction: F,
 ) -> Result<(), E>
 where
     F: Fn(&Pubkey, &mut [KeyedAccount], &[u8]) -> Result<(), E>,
 {
+    for _ in tx_accounts.len()..tx.account_keys.len() {
+        tx_accounts.push(Account::new(0, 0, system_program::id()));
+    }
     for (i, ix) in tx.instructions.iter().enumerate() {
         let mut ix_accounts = get_subset_unchecked_mut(tx_accounts, &ix.accounts);
         let mut keyed_accounts: Vec<_> = ix

--- a/wallet/src/wallet.rs
+++ b/wallet/src/wallet.rs
@@ -567,37 +567,11 @@ fn process_pay(
             None => config.id.pubkey(),
         };
 
-        let contract_funds = Keypair::new();
         let contract_state = Keypair::new();
-        let budget_program_id = solana_budget_api::id();
-
-        // Create account for contract funds
-        let mut tx = SystemTransaction::new_program_account(
-            &config.id,
-            contract_funds.pubkey(),
-            blockhash,
-            lamports,
-            0,
-            budget_program_id,
-            0,
-        );
-        send_and_confirm_transaction(&rpc_client, &mut tx, &config.id)?;
-
-        // Create account for contract state
-        let mut tx = SystemTransaction::new_program_account(
-            &config.id,
-            contract_state.pubkey(),
-            blockhash,
-            1,
-            196,
-            budget_program_id,
-            0,
-        );
-        send_and_confirm_transaction(&rpc_client, &mut tx, &config.id)?;
 
         // Initializing contract
         let mut tx = BudgetTransaction::new_on_date(
-            &contract_funds,
+            &config.id,
             to,
             contract_state.pubkey(),
             dt,
@@ -624,37 +598,11 @@ fn process_pay(
             ))?
         };
 
-        let contract_funds = Keypair::new();
         let contract_state = Keypair::new();
-        let budget_program_id = solana_budget_api::id();
-
-        // Create account for contract funds
-        let mut tx = SystemTransaction::new_program_account(
-            &config.id,
-            contract_funds.pubkey(),
-            blockhash,
-            lamports,
-            0,
-            budget_program_id,
-            0,
-        );
-        send_and_confirm_transaction(&rpc_client, &mut tx, &config.id)?;
-
-        // Create account for contract state
-        let mut tx = SystemTransaction::new_program_account(
-            &config.id,
-            contract_state.pubkey(),
-            blockhash,
-            1,
-            196,
-            budget_program_id,
-            0,
-        );
-        send_and_confirm_transaction(&rpc_client, &mut tx, &config.id)?;
 
         // Initializing contract
         let mut tx = BudgetTransaction::new_when_signed(
-            &contract_funds,
+            &config.id,
             to,
             contract_state.pubkey(),
             witness,

--- a/wallet/tests/pay.rs
+++ b/wallet/tests/pay.rs
@@ -62,16 +62,16 @@ fn test_wallet_timestamp_tx() {
         .expect("base58-encoded public key");
     let process_id = Pubkey::new(&process_id_vec);
 
-    check_balance(39, &rpc_client, config_payer.id.pubkey()); // config_payer balance
-    check_balance(11, &rpc_client, process_id); // contract balance
+    check_balance(40, &rpc_client, config_payer.id.pubkey()); // config_payer balance
+    check_balance(10, &rpc_client, process_id); // contract balance
     check_balance(0, &rpc_client, bob_pubkey); // recipient balance
 
     // Sign transaction by config_witness
     config_witness.command = WalletCommand::TimeElapsed(bob_pubkey, process_id, dt);
     process_command(&config_witness).unwrap();
 
-    check_balance(39, &rpc_client, config_payer.id.pubkey()); // config_payer balance
-    check_balance(1, &rpc_client, process_id); // contract balance
+    check_balance(40, &rpc_client, config_payer.id.pubkey()); // config_payer balance
+    check_balance(0, &rpc_client, process_id); // contract balance
     check_balance(10, &rpc_client, bob_pubkey); // recipient balance
 
     server.close().unwrap();
@@ -119,16 +119,16 @@ fn test_wallet_witness_tx() {
         .expect("base58-encoded public key");
     let process_id = Pubkey::new(&process_id_vec);
 
-    check_balance(39, &rpc_client, config_payer.id.pubkey()); // config_payer balance
-    check_balance(11, &rpc_client, process_id); // contract balance
+    check_balance(40, &rpc_client, config_payer.id.pubkey()); // config_payer balance
+    check_balance(10, &rpc_client, process_id); // contract balance
     check_balance(0, &rpc_client, bob_pubkey); // recipient balance
 
     // Sign transaction by config_witness
     config_witness.command = WalletCommand::Witness(bob_pubkey, process_id);
     process_command(&config_witness).unwrap();
 
-    check_balance(39, &rpc_client, config_payer.id.pubkey()); // config_payer balance
-    check_balance(1, &rpc_client, process_id); // contract balance
+    check_balance(40, &rpc_client, config_payer.id.pubkey()); // config_payer balance
+    check_balance(0, &rpc_client, process_id); // contract balance
     check_balance(10, &rpc_client, bob_pubkey); // recipient balance
 
     server.close().unwrap();
@@ -167,25 +167,25 @@ fn test_wallet_cancel_tx() {
         Some(vec![config_witness.id.pubkey()]),
         Some(config_payer.id.pubkey()),
     );
-    let sig_response = process_command(&config_payer);
+    let sig_response = process_command(&config_payer).unwrap();
 
-    let object: Value = serde_json::from_str(&sig_response.unwrap()).unwrap();
+    let object: Value = serde_json::from_str(&sig_response).unwrap();
     let process_id_str = object.get("processId").unwrap().as_str().unwrap();
     let process_id_vec = bs58::decode(process_id_str)
         .into_vec()
         .expect("base58-encoded public key");
     let process_id = Pubkey::new(&process_id_vec);
 
-    check_balance(39, &rpc_client, config_payer.id.pubkey()); // config_payer balance
-    check_balance(11, &rpc_client, process_id); // contract balance
+    check_balance(40, &rpc_client, config_payer.id.pubkey()); // config_payer balance
+    check_balance(10, &rpc_client, process_id); // contract balance
     check_balance(0, &rpc_client, bob_pubkey); // recipient balance
 
     // Sign transaction by config_witness
     config_payer.command = WalletCommand::Cancel(process_id);
     process_command(&config_payer).unwrap();
 
-    check_balance(49, &rpc_client, config_payer.id.pubkey()); // config_payer balance
-    check_balance(1, &rpc_client, process_id); // contract balance
+    check_balance(50, &rpc_client, config_payer.id.pubkey()); // config_payer balance
+    check_balance(0, &rpc_client, process_id); // contract balance
     check_balance(0, &rpc_client, bob_pubkey); // recipient balance
 
     server.close().unwrap();


### PR DESCRIPTION
#### Problem
Spotted by @TristanDebrunner , Budget was implementing functionality that's only supposed to be allowed by System.

#### Summary of Changes
Get Budget's abuses out of the way so we can lock down the runtime.

Closes #3176  

@CriesofCarrots, fyi, the runtime is allowing native programs to allocate userdata.
