### PR TITLE
Remove thin_client::poll_gossip_for_leader()

### DIFF
--- a/core/src/gossip_service.rs
+++ b/core/src/gossip_service.rs
@@ -52,7 +52,7 @@ impl GossipService {
 pub fn discover(
     entry_point_info: &NodeInfo,
     num_nodes: usize,
-) -> Result<(Option<NodeInfo>, Vec<NodeInfo>), &'static str> {
+) -> std::io::Result<(Option<NodeInfo>, Vec<NodeInfo>)> {
     let exit = Arc::new(AtomicBool::new(false));
     let (gossip_service, spy_ref) = make_spy_node(entry_point_info, &exit);
     let id = spy_ref.read().unwrap().keypair.pubkey();
@@ -97,10 +97,13 @@ pub fn discover(
         "discover failed...\n{}",
         spy_ref.read().unwrap().node_info_trace()
     );
-    Err("Failed to converge")
+    Err(std::io::Error::new(
+        std::io::ErrorKind::Other,
+        "Failed to converge",
+    ))
 }
 
-pub fn make_spy_node(
+fn make_spy_node(
     entry_point: &NodeInfo,
     exit: &Arc<AtomicBool>,
 ) -> (GossipService, Arc<RwLock<ClusterInfo>>) {

--- a/tests/replicator.rs
+++ b/tests/replicator.rs
@@ -61,11 +61,8 @@ fn test_replicator_startup_basic() {
             &fullnode_config,
         );
 
-        debug!(
-            "leader: {:?}",
-            solana::thin_client::poll_gossip_for_leader(leader_info.gossip, Duration::from_secs(5))
-                .unwrap()
-        );
+        debug!("Looking for leader on gossip...");
+        solana::gossip_service::discover(&leader_info, 1).unwrap();
 
         let validator_keypair = Arc::new(Keypair::new());
         let voting_keypair = Keypair::new();


### PR DESCRIPTION
Turns out `poll_gossip_for_leader()` really isn't used by anything in a meaningful way

Progress towards #3188