### PR TITLE
Delete cluster_info::get_gossip_top_leader()

### DIFF
--- a/bench-tps/src/main.rs
+++ b/bench-tps/src/main.rs
@@ -40,7 +40,7 @@ fn main() {
     } = cfg;
 
     let cluster_entrypoint = ContactInfo::new_entry_point(&network);
-    let (_leader, nodes) = discover(&cluster_entrypoint, num_nodes).unwrap_or_else(|err| {
+    let nodes = discover(&cluster_entrypoint, num_nodes).unwrap_or_else(|err| {
         eprintln!("Failed to discover {} nodes: {:?}", num_nodes, err);
         exit(1);
     });

--- a/core/src/cluster_tests.rs
+++ b/core/src/cluster_tests.rs
@@ -22,7 +22,7 @@ pub fn spend_and_verify_all_nodes(
     funding_keypair: &Keypair,
     nodes: usize,
 ) {
-    let (_leader_id, cluster_nodes) = discover(&entry_point_info, nodes).unwrap();
+    let cluster_nodes = discover(&entry_point_info, nodes).unwrap();
     assert!(cluster_nodes.len() >= nodes);
     for ingress_node in &cluster_nodes {
         let random_keypair = Keypair::new();
@@ -49,7 +49,7 @@ pub fn spend_and_verify_all_nodes(
 }
 
 pub fn fullnode_exit(entry_point_info: &ContactInfo, nodes: usize) {
-    let (_leader_id, cluster_nodes) = discover(&entry_point_info, nodes).unwrap();
+    let cluster_nodes = discover(&entry_point_info, nodes).unwrap();
     assert!(cluster_nodes.len() >= nodes);
     for node in &cluster_nodes {
         let mut client = mk_client(&node);
@@ -101,7 +101,7 @@ pub fn kill_entry_and_spend_and_verify_rest(
     nodes: usize,
 ) {
     solana_logger::setup();
-    let (_leader_id, cluster_nodes) = discover(&entry_point_info, nodes).unwrap();
+    let cluster_nodes = discover(&entry_point_info, nodes).unwrap();
     assert!(cluster_nodes.len() >= nodes);
     let mut client = mk_client(&entry_point_info);
     info!("sleeping for an epoch");

--- a/core/src/gossip_service.rs
+++ b/core/src/gossip_service.rs
@@ -49,10 +49,7 @@ impl GossipService {
     }
 }
 
-pub fn discover(
-    entry_point_info: &NodeInfo,
-    num_nodes: usize,
-) -> std::io::Result<(Option<NodeInfo>, Vec<NodeInfo>)> {
+pub fn discover(entry_point_info: &NodeInfo, num_nodes: usize) -> std::io::Result<Vec<NodeInfo>> {
     let exit = Arc::new(AtomicBool::new(false));
     let (gossip_service, spy_ref) = make_spy_node(entry_point_info, &exit);
     let id = spy_ref.read().unwrap().keypair.pubkey();
@@ -74,10 +71,9 @@ pub fn discover(
                 spy_ref.read().unwrap().node_info_trace()
             );
 
-            let leader = spy_ref.read().unwrap().get_gossip_top_leader().cloned();
             exit.store(true, Ordering::Relaxed);
             gossip_service.join().unwrap();
-            return Ok((leader, rpc_peers));
+            return Ok(rpc_peers);
         }
         if i % 20 == 0 {
             info!(


### PR DESCRIPTION
`get_gossip_top_leader()` is now dead code, 🍄 

Progress towards #3188