### PR TITLE
Fix propagation of incorrectly signed messages in Gossip

### DIFF
--- a/core/src/cluster_info.rs
+++ b/core/src/cluster_info.rs
@@ -201,7 +201,6 @@ impl ClusterInfo {
         self.gossip.process_push_message(&[entry], now);
     }
     // TODO kill insert_info, only used by tests
-    #[cfg(test)]
     pub fn insert_info(&mut self, node_info: NodeInfo) {
         let mut value = CrdsValue::ContactInfo(node_info);
         value.sign(&self.keypair);

--- a/core/src/crds_gossip.rs
+++ b/core/src/crds_gossip.rs
@@ -21,7 +21,7 @@ pub struct CrdsGossip {
     pub crds: Crds,
     pub id: Pubkey,
     pub push: CrdsGossipPush,
-    pull: CrdsGossipPull,
+    pub pull: CrdsGossipPull,
 }
 
 impl Default for CrdsGossip {

--- a/core/src/crds_gossip_pull.rs
+++ b/core/src/crds_gossip_pull.rs
@@ -148,7 +148,7 @@ impl CrdsGossipPull {
         failed
     }
     /// build a filter of the current crds table
-    fn build_crds_filter(&self, crds: &Crds) -> Bloom<Hash> {
+    pub fn build_crds_filter(&self, crds: &Crds) -> Bloom<Hash> {
         let num = cmp::max(
             CRDS_GOSSIP_BLOOM_SIZE,
             crds.table.values().count() + self.purged_values.len(),

--- a/core/src/crds_value.rs
+++ b/core/src/crds_value.rs
@@ -27,7 +27,6 @@ pub struct LeaderId {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct Vote {
     pub transaction: Transaction,
-    pub signature: Signature,
     pub wallclock: u64,
 }
 
@@ -61,30 +60,25 @@ impl Signable for LeaderId {
 }
 
 impl Signable for Vote {
+    fn sign(&mut self, _keypair: &Keypair) {}
+
+    fn verify(&self) -> bool {
+        self.transaction.verify_signature()
+    }
+
     fn pubkey(&self) -> Pubkey {
         self.transaction.account_keys[0]
     }
 
     fn signable_data(&self) -> Vec<u8> {
-        #[derive(Serialize)]
-        struct SignData {
-            transaction: Transaction,
-            wallclock: u64,
-        }
-        let data = SignData {
-            transaction: self.transaction.clone(),
-            wallclock: self.wallclock,
-        };
-        serialize(&data).expect("unable to serialize Vote")
+        vec![]
     }
 
     fn get_signature(&self) -> Signature {
-        self.signature
+        Signature::default()
     }
 
-    fn set_signature(&mut self, signature: Signature) {
-        self.signature = signature
-    }
+    fn set_signature(&mut self, _signature: Signature) {}
 }
 
 /// Type of the replicated value
@@ -132,7 +126,6 @@ impl Vote {
     pub fn new(transaction: Transaction, wallclock: u64) -> Self {
         Vote {
             transaction,
-            signature: Signature::default(),
             wallclock,
         }
     }

--- a/core/src/fullnode.rs
+++ b/core/src/fullnode.rs
@@ -155,11 +155,12 @@ impl Fullnode {
 
         // Insert the entrypoint info, should only be None if this node
         // is the bootstrap leader
+
         if let Some(entrypoint_info) = entrypoint_info_option {
             cluster_info
                 .write()
                 .unwrap()
-                .insert_info(entrypoint_info.clone());
+                .set_entrypoint(entrypoint_info.clone());
         }
 
         let sockets = Sockets {

--- a/core/src/gossip_service.rs
+++ b/core/src/gossip_service.rs
@@ -108,7 +108,7 @@ fn make_spy_node(
     let keypair = Arc::new(Keypair::new());
     let (node, gossip_socket) = ClusterInfo::spy_node(&keypair.pubkey());
     let mut cluster_info = ClusterInfo::new(node, keypair);
-    cluster_info.set_entrypoint(entry_point.clone());
+    cluster_info.set_entrypoint(ContactInfo::new_gossip_entry_point(gossip_addr));
     let cluster_info = Arc::new(RwLock::new(cluster_info));
     let gossip_service =
         GossipService::new(&cluster_info.clone(), None, None, gossip_socket, &exit);

--- a/core/src/gossip_service.rs
+++ b/core/src/gossip_service.rs
@@ -2,7 +2,7 @@
 
 use crate::bank_forks::BankForks;
 use crate::blocktree::Blocktree;
-use crate::cluster_info::{ClusterInfo, NodeInfo};
+use crate::cluster_info::ClusterInfo;
 use crate::contact_info::ContactInfo;
 use crate::service::Service;
 use crate::streamer;
@@ -51,7 +51,7 @@ impl GossipService {
     }
 }
 
-pub fn discover(gossip_addr: &SocketAddr, num_nodes: usize) -> std::io::Result<Vec<NodeInfo>> {
+pub fn discover(gossip_addr: &SocketAddr, num_nodes: usize) -> std::io::Result<Vec<ContactInfo>> {
     let exit = Arc::new(AtomicBool::new(false));
     let (gossip_service, spy_ref) = make_spy_node(gossip_addr, &exit);
     let id = spy_ref.read().unwrap().keypair.pubkey();
@@ -67,7 +67,7 @@ pub fn discover(gossip_addr: &SocketAddr, num_nodes: usize) -> std::io::Result<V
     while now.elapsed() < Duration::from_secs(30) {
         let rpc_peers = spy_ref.read().unwrap().rpc_peers();
         if rpc_peers.len() >= num_nodes {
-            info!(
+            trace!(
                 "discover success in {}s...\n{}",
                 now.elapsed().as_secs(),
                 spy_ref.read().unwrap().node_info_trace()
@@ -108,8 +108,7 @@ fn make_spy_node(
     let keypair = Arc::new(Keypair::new());
     let (node, gossip_socket) = ClusterInfo::spy_node(&keypair.pubkey());
     let mut cluster_info = ClusterInfo::new(node, keypair);
-    cluster_info.insert_info(ContactInfo::new_gossip_entry_point(gossip_addr));
-
+    cluster_info.set_entrypoint(entry_point.clone());
     let cluster_info = Arc::new(RwLock::new(cluster_info));
     let gossip_service =
         GossipService::new(&cluster_info.clone(), None, None, gossip_socket, &exit);

--- a/core/src/replicator.rs
+++ b/core/src/replicator.rs
@@ -118,7 +118,7 @@ impl Replicator {
         info!("Replicator: id: {}", keypair.pubkey());
         info!("Creating cluster info....");
         let mut cluster_info = ClusterInfo::new(node.info.clone(), keypair.clone());
-        cluster_info.insert_info(leader_info.clone());
+        cluster_info.set_entrypoint(leader_info.clone());
         cluster_info.set_leader(leader_info.id);
         let cluster_info = Arc::new(RwLock::new(cluster_info));
 
@@ -202,7 +202,7 @@ impl Replicator {
         node_info.tvu = "0.0.0.0:0".parse().unwrap();
         {
             let mut cluster_info_w = cluster_info.write().unwrap();
-            cluster_info_w.insert_info(node_info);
+            cluster_info_w.insert_self(node_info);
         }
 
         let mut client = mk_client(leader_info);


### PR DESCRIPTION
#### Problem

- ClusterInfo needed support for network entrypoints. The current implementation of shoving the entrypoint's ContactInfo into the Crds table was resulting in broken signatures. 
- Vote signature verification is incorrect. Vote messages are signed by the sender but are being verified against the staker_id
- Repair requests were also pushing unsigned ContactInfos into gossip.

#### Summary of Changes

- Added support for a network entrypoint such that gossip will pull from that entrypoint until it joins the gossip network. 
- Disabled vote message signatures, vote messages only check if the inner vote is signed correctly. This is only a temporary fix since we want the wallclock to move into the signed data of the vote transaction. 
- Repair requests will update the timestamps for already discovered nodes, not add new ones. Only gossip should do that.

