### PR TITLE
Bank snapshots

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -180,6 +180,11 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "bitintr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "blake2-rfc"
 version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2244,6 +2249,7 @@ name = "solana-runtime"
 version = "0.12.0"
 dependencies = [
  "bincode 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitintr 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bv 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2967,6 +2973,7 @@ dependencies = [
 "checksum bit-vec 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "02b4ff8b16e6076c3e14220b39fbc1fabb6737522281a388998046859400895f"
 "checksum bit-vec 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4440d5cb623bb7390ae27fec0bb6c61111969860f8e3ae198bfa0663645e67cf"
 "checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
+"checksum bitintr 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f80c754495ef07b4554134bbfb23fc1e31a775113b49acccbe35076d57cba145"
 "checksum blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "5d6d530bdd2d52966a6d03b7a964add7ae1a288d25214066fd4b600f0f796400"
 "checksum block-buffer 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a076c298b9ecdb530ed9d967e74a6027d6a7478924520acddcddc24c1c8ab3ab"
 "checksum block-buffer 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "49665c62e0e700857531fa5d3763e91b539ff1abeebd56808d378b495870d60d"

--- a/core/src/bank_forks.rs
+++ b/core/src/bank_forks.rs
@@ -5,6 +5,12 @@ use std::collections::HashMap;
 use std::ops::Index;
 use std::sync::Arc;
 
+use solana_runtime::accounts::{deserialize_object, serialize_object, Accounts};
+use std::fs;
+use std::fs::File;
+use std::io::{BufReader, BufWriter};
+use std::path::{Path, PathBuf};
+
 pub struct BankForks {
     banks: HashMap<u64, Arc<Bank>>,
     working_bank: Arc<Bank>,
@@ -87,6 +93,64 @@ impl BankForks {
     pub fn working_bank(&self) -> Arc<Bank> {
         self.working_bank.clone()
     }
+
+    pub fn save_snapshot(&self, path: &str) -> Result<(), ()> {
+        let mut bank_index: HashMap<u64, PathBuf> = HashMap::new();
+        let path = Path::new(&path);
+        fs::create_dir_all(path).unwrap();
+        for (slot, bank) in &self.frozen_banks() {
+            let bank_file = format!("bank-{}.snapshot", slot);
+            let bank_file_path = path.join(bank_file);
+            bank_index.insert(*slot, bank_file_path.clone());
+            let file = File::create(bank_file_path).unwrap();
+            let mut stream = BufWriter::new(file);
+            bank.serialize_into(&mut stream).unwrap();
+        }
+        let temp_path = path.join("bank.index.tmp");
+        {
+            let file = File::create(temp_path.clone()).unwrap();
+            let mut stream = BufWriter::new(file);
+            serialize_object(&bank_index, &mut stream).unwrap();
+            let banks = self.frozen_banks();
+            if !banks.is_empty() {
+                banks
+                    .values()
+                    .next()
+                    .unwrap()
+                    .accounts()
+                    .serialize_into(&mut stream)
+                    .unwrap();
+            }
+        }
+        fs::rename(temp_path, path.join("bank.index")).unwrap();
+        Ok(())
+    }
+
+    pub fn load_from_snapshot(path: &str) -> Result<Self, ()> {
+        let (bank_index, accounts) = {
+            let path = Path::new(path).join("bank.index");
+            let index_file = File::open(path).unwrap();
+            let mut stream = BufReader::new(index_file);
+            let bank_index: HashMap<u64, PathBuf> = deserialize_object(&mut stream).unwrap();
+            assert!(!bank_index.is_empty());
+            let accounts = Arc::new(Accounts::deserialize_from(&mut stream).unwrap());
+            (bank_index, accounts)
+        };
+
+        let mut banks: HashMap<u64, Arc<Bank>> = HashMap::new();
+        for (slot, bank_path) in &bank_index {
+            let file = File::open(bank_path).unwrap();
+            let mut stream = BufReader::new(file);
+            let mut bank = Bank::deserialize_from(&mut stream).unwrap();
+            bank.set_accounts(accounts.clone());
+            banks.insert(*slot, Arc::new(bank));
+        }
+        let working_bank = banks[&0].clone();
+        Ok(BankForks {
+            banks,
+            working_bank,
+        })
+    }
 }
 
 #[cfg(test)]
@@ -127,6 +191,25 @@ mod tests {
         let child_bank = Bank::new_from_parent(&bank_forks[0u64], Pubkey::default(), 1);
         bank_forks.insert(1, child_bank);
         assert_eq!(bank_forks.active_banks(), vec![1]);
+    }
+
+    #[test]
+    fn test_bank_forks_snapshot() {
+        solana_logger::setup();
+        let (genesis_block, _) = GenesisBlock::new(10_000);
+        let bank = Bank::new(&genesis_block);
+        bank.freeze();
+        let tick_height = bank.tick_height();
+        let mut bank_forks = BankForks::new(0, bank);
+        let child_bank = Bank::new_from_parent(&bank_forks[0u64], Pubkey::default(), 1);
+        child_bank.freeze();
+        bank_forks.insert(1, child_bank);
+        let snapshot_path = "snapshots";
+        bank_forks.save_snapshot(snapshot_path).unwrap();
+        drop(bank_forks);
+        let new = BankForks::load_from_snapshot(snapshot_path).unwrap();
+        assert_eq!(new[0].tick_height(), tick_height);
+        let _ = fs::remove_dir_all(snapshot_path);
     }
 
 }

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -380,7 +380,7 @@ mod test {
         {
             let voting_keypair = Arc::new(Keypair::new());
             let (bank_forks, _bank_forks_info, blocktree, l_receiver) =
-                new_banks_from_blocktree(&my_ledger_path, None);
+                new_banks_from_blocktree(&my_ledger_path, None, false);
             let bank = bank_forks.working_bank();
 
             let blocktree = Arc::new(blocktree);

--- a/core/src/staking_utils.rs
+++ b/core/src/staking_utils.rs
@@ -63,7 +63,7 @@ fn node_staked_accounts_at_epoch(
     epoch_height: u64,
 ) -> Option<impl Iterator<Item = (&Pubkey, u64, &Account)>> {
     bank.epoch_vote_accounts(epoch_height).map(|epoch_state| {
-        epoch_state.into_iter().filter_map(|(account_id, account)| {
+        epoch_state.iter().filter_map(|(account_id, account)| {
             filter_zero_balances(account).map(|stake| (account_id, stake, account))
         })
     })

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -30,6 +30,7 @@ solana-system-program = { path = "../programs/system", version = "0.12.0" }
 solana-storage-api = { path = "../programs/storage_api", version = "0.12.0" }
 solana-token-api = { path = "../programs/token_api", version = "0.12.0" }
 solana-vote-api = { path = "../programs/vote_api", version = "0.12.0" }
+bitintr = "0.2.0"
 
 [lib]
 name = "solana_runtime"

--- a/runtime/src/hash_queue.rs
+++ b/runtime/src/hash_queue.rs
@@ -1,15 +1,16 @@
-use hashbrown::HashMap;
+use serde::{Deserialize, Serialize};
 use solana_sdk::hash::Hash;
 use solana_sdk::timing::timestamp;
+use std::collections::HashMap;
 
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 struct HashQueueEntry {
     timestamp: u64,
     hash_height: u64,
 }
 
 /// Low memory overhead, so can be cloned for every checkpoint
-#[derive(Clone)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct HashQueue {
     /// updated whenever an hash is registered
     hash_height: u64,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1,4 +1,4 @@
-mod accounts;
+pub mod accounts;
 pub mod append_vec;
 pub mod bank;
 pub mod bloom;

--- a/sdk/src/native_program.rs
+++ b/sdk/src/native_program.rs
@@ -3,7 +3,7 @@ use crate::pubkey::Pubkey;
 use std;
 
 /// Reasons a program might have rejected an instruction.
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub enum ProgramError {
     /// The program instruction returned an error
     GenericError,


### PR DESCRIPTION
#### Problem

Full node startup is slow when many transactions have been processed.

#### Summary of Changes

Serialize a bunch of bank state into a snapshot and try to restore from that on boot.

TODO:
- [ ] error handling
- [ ] test more complicated forkings
- [ ] StatusCache::merges
- [ ] BankForkInfo generation
- [ ] snapshot flag plumbing

Fixes #2475 
