### PR TITLE
Buffer unprocessed packets if next leader is the current node

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -77,7 +77,7 @@ impl BankingStage {
 
     fn forward_unprocessed_packets(
         socket: &std::net::UdpSocket,
-        forwarder: &std::net::SocketAddr,
+        tpu_via_blobs: &std::net::SocketAddr,
         unprocessed_packets: &[(SharedPackets, usize)],
     ) -> std::io::Result<()> {
         let locked_packets: Vec<_> = unprocessed_packets
@@ -91,7 +91,7 @@ impl BankingStage {
         let blobs = packet::packets_to_blobs(&packets);
 
         for blob in blobs {
-            socket.send_to(&blob.data[..blob.meta.size], forwarder)?;
+            socket.send_to(&blob.data[..blob.meta.size], tpu_via_blobs)?;
         }
 
         Ok(())
@@ -118,7 +118,7 @@ impl BankingStage {
         if forward {
             let _ = Self::forward_unprocessed_packets(
                 &socket,
-                &rcluster_info.leader_data().unwrap().forwarder,
+                &rcluster_info.leader_data().unwrap().tpu_via_blobs,
                 &buffered_packets,
             );
         }
@@ -173,7 +173,7 @@ impl BankingStage {
                     if let Some(leader) = cluster_info.read().unwrap().leader_data() {
                         let _ = Self::forward_unprocessed_packets(
                             &socket,
-                            &leader.forwarder,
+                            &leader.tpu_via_blobs,
                             &unprocessed_packets,
                         );
                     }

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -77,7 +77,7 @@ impl BankingStage {
     fn forward_unprocessed_packets(
         socket: &std::net::UdpSocket,
         tpu: &std::net::SocketAddr,
-        unprocessed_packets: &UnprocessedPackets,
+        unprocessed_packets: &[(SharedPackets, usize)],
     ) -> std::io::Result<()> {
         for (packets, start_index) in unprocessed_packets {
             let packets = packets.read().unwrap();
@@ -92,7 +92,7 @@ impl BankingStage {
         socket: &std::net::UdpSocket,
         poh_recorder: &Arc<Mutex<PohRecorder>>,
         cluster_info: &Arc<RwLock<ClusterInfo>>,
-        buffered_packets: &UnprocessedPackets,
+        buffered_packets: &[(SharedPackets, usize)],
     ) -> bool {
         let (leader, my_id) = {
             let rcluster_info = cluster_info.read().unwrap();

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -89,7 +89,7 @@ impl BankingStage {
             .iter()
             .flat_map(|(p, start_index)| &p.packets[**start_index..])
             .collect();
-        let blobs = packet::packets_to_blobs(&packets[..]);
+        let blobs = packet::packets_to_blobs(&packets);
 
         for blob in blobs {
             socket.send_to(&blob.data[..blob.meta.size], forwarder)?;

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -124,7 +124,7 @@ impl BankingStage {
             return true;
         }
 
-        return false;
+        false
     }
 
     fn should_buffer_packets(
@@ -148,7 +148,7 @@ impl BankingStage {
             }
         }
 
-        return false;
+        false
     }
 
     pub fn process_loop(

--- a/core/src/cluster_info.rs
+++ b/core/src/cluster_info.rs
@@ -1341,7 +1341,7 @@ pub struct Sockets {
     pub gossip: UdpSocket,
     pub tvu: Vec<UdpSocket>,
     pub tpu: Vec<UdpSocket>,
-    pub forwarder: Vec<UdpSocket>,
+    pub tpu_via_blobs: Vec<UdpSocket>,
     pub broadcast: UdpSocket,
     pub repair: UdpSocket,
     pub retransmit: UdpSocket,
@@ -1362,7 +1362,7 @@ impl Node {
         let tpu = UdpSocket::bind("127.0.0.1:0").unwrap();
         let gossip = UdpSocket::bind("127.0.0.1:0").unwrap();
         let tvu = UdpSocket::bind("127.0.0.1:0").unwrap();
-        let forwarder = UdpSocket::bind("127.0.0.1:0").unwrap();
+        let tpu_via_blobs = UdpSocket::bind("127.0.0.1:0").unwrap();
         let repair = UdpSocket::bind("127.0.0.1:0").unwrap();
         let rpc_port = find_available_port_in_range((1024, 65535)).unwrap();
         let rpc_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), rpc_port);
@@ -1378,7 +1378,7 @@ impl Node {
             gossip.local_addr().unwrap(),
             tvu.local_addr().unwrap(),
             tpu.local_addr().unwrap(),
-            forwarder.local_addr().unwrap(),
+            tpu_via_blobs.local_addr().unwrap(),
             storage.local_addr().unwrap(),
             rpc_addr,
             rpc_pubsub_addr,
@@ -1390,7 +1390,7 @@ impl Node {
                 gossip,
                 tvu: vec![tvu],
                 tpu: vec![tpu],
-                forwarder: vec![forwarder],
+                tpu_via_blobs: vec![tpu_via_blobs],
                 broadcast,
                 repair,
                 retransmit,
@@ -1419,7 +1419,7 @@ impl Node {
         let (tpu_port, tpu_sockets) =
             multi_bind_in_range(FULLNODE_PORT_RANGE, 32).expect("tpu multi_bind");
 
-        let (forwarder_port, forwarder_sockets) =
+        let (tpu_via_blobs_port, tpu_via_blobs_sockets) =
             multi_bind_in_range(FULLNODE_PORT_RANGE, 8).expect("tpu multi_bind");
 
         let (_, repair) = bind();
@@ -1432,7 +1432,7 @@ impl Node {
             SocketAddr::new(gossip_addr.ip(), gossip_port),
             SocketAddr::new(gossip_addr.ip(), tvu_port),
             SocketAddr::new(gossip_addr.ip(), tpu_port),
-            SocketAddr::new(gossip_addr.ip(), forwarder_port),
+            SocketAddr::new(gossip_addr.ip(), tpu_via_blobs_port),
             SocketAddr::new(gossip_addr.ip(), storage_port),
             SocketAddr::new(gossip_addr.ip(), RPC_PORT),
             SocketAddr::new(gossip_addr.ip(), RPC_PORT + 1),
@@ -1446,7 +1446,7 @@ impl Node {
                 gossip,
                 tvu: tvu_sockets,
                 tpu: tpu_sockets,
-                forwarder: forwarder_sockets,
+                tpu_via_blobs: tpu_via_blobs_sockets,
                 broadcast,
                 repair,
                 retransmit,

--- a/core/src/cluster_info.rs
+++ b/core/src/cluster_info.rs
@@ -1273,7 +1273,7 @@ impl ClusterInfo {
         let daddr = socketaddr_any!();
 
         let node = ContactInfo::new(
-            *id,
+            id,
             daddr,
             daddr,
             daddr,

--- a/core/src/cluster_tests.rs
+++ b/core/src/cluster_tests.rs
@@ -58,7 +58,7 @@ pub fn send_many_transactions(node: &ContactInfo, funding_keypair: &Keypair, num
         assert!(bal > 0);
         let mut transaction = SystemTransaction::new_move(
             &funding_keypair,
-            random_keypair.pubkey(),
+            &random_keypair.pubkey(),
             1,
             client.get_recent_blockhash(),
             0,

--- a/core/src/contact_info.rs
+++ b/core/src/contact_info.rs
@@ -18,6 +18,8 @@ pub struct ContactInfo {
     pub tvu: SocketAddr,
     /// transactions address
     pub tpu: SocketAddr,
+    // forwarer address
+    pub forwarder: SocketAddr,
     /// storage data address
     pub storage_addr: SocketAddr,
     /// address to which to send JSON-RPC requests
@@ -72,6 +74,7 @@ impl Default for ContactInfo {
             gossip: socketaddr_any!(),
             tvu: socketaddr_any!(),
             tpu: socketaddr_any!(),
+            forwarder: socketaddr_any!(),
             storage_addr: socketaddr_any!(),
             rpc: socketaddr_any!(),
             rpc_pubsub: socketaddr_any!(),
@@ -87,6 +90,7 @@ impl ContactInfo {
         gossip: SocketAddr,
         tvu: SocketAddr,
         tpu: SocketAddr,
+        forwarder: SocketAddr,
         storage_addr: SocketAddr,
         rpc: SocketAddr,
         rpc_pubsub: SocketAddr,
@@ -98,6 +102,7 @@ impl ContactInfo {
             gossip,
             tvu,
             tpu,
+            forwarder,
             storage_addr,
             rpc,
             rpc_pubsub,
@@ -114,6 +119,7 @@ impl ContactInfo {
             socketaddr!("127.0.0.1:1237"),
             socketaddr!("127.0.0.1:1238"),
             socketaddr!("127.0.0.1:1239"),
+            socketaddr!("127.0.0.1:1240"),
             now,
         )
     }
@@ -125,6 +131,7 @@ impl ContactInfo {
         assert!(addr.ip().is_multicast());
         Self::new(
             &Keypair::new().pubkey(),
+            addr,
             addr,
             addr,
             addr,
@@ -143,6 +150,7 @@ impl ContactInfo {
         let tpu_addr = *bind_addr;
         let gossip_addr = Self::next_port(&bind_addr, 1);
         let tvu_addr = Self::next_port(&bind_addr, 2);
+        let forwarder_addr = Self::next_port(&bind_addr, 3);
         let rpc_addr = SocketAddr::new(bind_addr.ip(), RPC_PORT);
         let rpc_pubsub_addr = SocketAddr::new(bind_addr.ip(), RPC_PORT + 1);
         Self::new(
@@ -150,6 +158,7 @@ impl ContactInfo {
             gossip_addr,
             tvu_addr,
             tpu_addr,
+            forwarder_addr,
             "0.0.0.0:0".parse().unwrap(),
             rpc_addr,
             rpc_pubsub_addr,
@@ -167,6 +176,7 @@ impl ContactInfo {
         Self::new(
             &Pubkey::default(),
             *gossip_addr,
+            daddr,
             daddr,
             daddr,
             daddr,
@@ -251,6 +261,7 @@ mod tests {
         let ci = ContactInfo::default();
         assert!(ci.gossip.ip().is_unspecified());
         assert!(ci.tvu.ip().is_unspecified());
+        assert!(ci.forwarder.ip().is_unspecified());
         assert!(ci.rpc.ip().is_unspecified());
         assert!(ci.rpc_pubsub.ip().is_unspecified());
         assert!(ci.tpu.ip().is_unspecified());
@@ -261,6 +272,7 @@ mod tests {
         let ci = ContactInfo::new_multicast();
         assert!(ci.gossip.ip().is_multicast());
         assert!(ci.tvu.ip().is_multicast());
+        assert!(ci.forwarder.ip().is_multicast());
         assert!(ci.rpc.ip().is_multicast());
         assert!(ci.rpc_pubsub.ip().is_multicast());
         assert!(ci.tpu.ip().is_multicast());
@@ -272,6 +284,7 @@ mod tests {
         let ci = ContactInfo::new_gossip_entry_point(&addr);
         assert_eq!(ci.gossip, addr);
         assert!(ci.tvu.ip().is_unspecified());
+        assert!(ci.forwarder.ip().is_unspecified());
         assert!(ci.rpc.ip().is_unspecified());
         assert!(ci.rpc_pubsub.ip().is_unspecified());
         assert!(ci.tpu.ip().is_unspecified());
@@ -284,6 +297,7 @@ mod tests {
         assert_eq!(ci.tpu, addr);
         assert_eq!(ci.gossip.port(), 11);
         assert_eq!(ci.tvu.port(), 12);
+        assert_eq!(ci.forwarder.port(), 13);
         assert_eq!(ci.rpc.port(), 8899);
         assert_eq!(ci.rpc_pubsub.port(), 8900);
         assert!(ci.storage_addr.ip().is_unspecified());
@@ -298,6 +312,7 @@ mod tests {
         assert_eq!(d1.id, keypair.pubkey());
         assert_eq!(d1.gossip, socketaddr!("127.0.0.1:1235"));
         assert_eq!(d1.tvu, socketaddr!("127.0.0.1:1236"));
+        assert_eq!(d1.forwarder, socketaddr!("127.0.0.1:1237"));
         assert_eq!(d1.tpu, socketaddr!("127.0.0.1:1234"));
         assert_eq!(d1.rpc, socketaddr!("127.0.0.1:8899"));
         assert_eq!(d1.rpc_pubsub, socketaddr!("127.0.0.1:8900"));

--- a/core/src/contact_info.rs
+++ b/core/src/contact_info.rs
@@ -18,8 +18,8 @@ pub struct ContactInfo {
     pub tvu: SocketAddr,
     /// transactions address
     pub tpu: SocketAddr,
-    // forwarder address
-    pub forwarder: SocketAddr,
+    /// address to forward unprocessed transactions to
+    pub tpu_via_blobs: SocketAddr,
     /// storage data address
     pub storage_addr: SocketAddr,
     /// address to which to send JSON-RPC requests
@@ -74,7 +74,7 @@ impl Default for ContactInfo {
             gossip: socketaddr_any!(),
             tvu: socketaddr_any!(),
             tpu: socketaddr_any!(),
-            forwarder: socketaddr_any!(),
+            tpu_via_blobs: socketaddr_any!(),
             storage_addr: socketaddr_any!(),
             rpc: socketaddr_any!(),
             rpc_pubsub: socketaddr_any!(),
@@ -90,7 +90,7 @@ impl ContactInfo {
         gossip: SocketAddr,
         tvu: SocketAddr,
         tpu: SocketAddr,
-        forwarder: SocketAddr,
+        tpu_via_blobs: SocketAddr,
         storage_addr: SocketAddr,
         rpc: SocketAddr,
         rpc_pubsub: SocketAddr,
@@ -102,7 +102,7 @@ impl ContactInfo {
             gossip,
             tvu,
             tpu,
-            forwarder,
+            tpu_via_blobs,
             storage_addr,
             rpc,
             rpc_pubsub,
@@ -150,7 +150,7 @@ impl ContactInfo {
         let tpu_addr = *bind_addr;
         let gossip_addr = Self::next_port(&bind_addr, 1);
         let tvu_addr = Self::next_port(&bind_addr, 2);
-        let forwarder_addr = Self::next_port(&bind_addr, 3);
+        let tpu_via_blobs_addr = Self::next_port(&bind_addr, 3);
         let rpc_addr = SocketAddr::new(bind_addr.ip(), RPC_PORT);
         let rpc_pubsub_addr = SocketAddr::new(bind_addr.ip(), RPC_PORT + 1);
         Self::new(
@@ -158,7 +158,7 @@ impl ContactInfo {
             gossip_addr,
             tvu_addr,
             tpu_addr,
-            forwarder_addr,
+            tpu_via_blobs_addr,
             "0.0.0.0:0".parse().unwrap(),
             rpc_addr,
             rpc_pubsub_addr,
@@ -261,7 +261,7 @@ mod tests {
         let ci = ContactInfo::default();
         assert!(ci.gossip.ip().is_unspecified());
         assert!(ci.tvu.ip().is_unspecified());
-        assert!(ci.forwarder.ip().is_unspecified());
+        assert!(ci.tpu_via_blobs.ip().is_unspecified());
         assert!(ci.rpc.ip().is_unspecified());
         assert!(ci.rpc_pubsub.ip().is_unspecified());
         assert!(ci.tpu.ip().is_unspecified());
@@ -272,7 +272,7 @@ mod tests {
         let ci = ContactInfo::new_multicast();
         assert!(ci.gossip.ip().is_multicast());
         assert!(ci.tvu.ip().is_multicast());
-        assert!(ci.forwarder.ip().is_multicast());
+        assert!(ci.tpu_via_blobs.ip().is_multicast());
         assert!(ci.rpc.ip().is_multicast());
         assert!(ci.rpc_pubsub.ip().is_multicast());
         assert!(ci.tpu.ip().is_multicast());
@@ -284,7 +284,7 @@ mod tests {
         let ci = ContactInfo::new_gossip_entry_point(&addr);
         assert_eq!(ci.gossip, addr);
         assert!(ci.tvu.ip().is_unspecified());
-        assert!(ci.forwarder.ip().is_unspecified());
+        assert!(ci.tpu_via_blobs.ip().is_unspecified());
         assert!(ci.rpc.ip().is_unspecified());
         assert!(ci.rpc_pubsub.ip().is_unspecified());
         assert!(ci.tpu.ip().is_unspecified());
@@ -297,7 +297,7 @@ mod tests {
         assert_eq!(ci.tpu, addr);
         assert_eq!(ci.gossip.port(), 11);
         assert_eq!(ci.tvu.port(), 12);
-        assert_eq!(ci.forwarder.port(), 13);
+        assert_eq!(ci.tpu_via_blobs.port(), 13);
         assert_eq!(ci.rpc.port(), 8899);
         assert_eq!(ci.rpc_pubsub.port(), 8900);
         assert!(ci.storage_addr.ip().is_unspecified());
@@ -312,7 +312,7 @@ mod tests {
         assert_eq!(d1.id, keypair.pubkey());
         assert_eq!(d1.gossip, socketaddr!("127.0.0.1:1235"));
         assert_eq!(d1.tvu, socketaddr!("127.0.0.1:1236"));
-        assert_eq!(d1.forwarder, socketaddr!("127.0.0.1:1237"));
+        assert_eq!(d1.tpu_via_blobs, socketaddr!("127.0.0.1:1237"));
         assert_eq!(d1.tpu, socketaddr!("127.0.0.1:1234"));
         assert_eq!(d1.rpc, socketaddr!("127.0.0.1:8899"));
         assert_eq!(d1.rpc_pubsub, socketaddr!("127.0.0.1:8900"));

--- a/core/src/contact_info.rs
+++ b/core/src/contact_info.rs
@@ -18,7 +18,7 @@ pub struct ContactInfo {
     pub tvu: SocketAddr,
     /// transactions address
     pub tpu: SocketAddr,
-    // forwarer address
+    // forwarder address
     pub forwarder: SocketAddr,
     /// storage data address
     pub storage_addr: SocketAddr,

--- a/core/src/fetch_stage.rs
+++ b/core/src/fetch_stage.rs
@@ -14,12 +14,20 @@ pub struct FetchStage {
 
 impl FetchStage {
     #[allow(clippy::new_ret_no_self)]
-    pub fn new(sockets: Vec<UdpSocket>, exit: &Arc<AtomicBool>) -> (Self, PacketReceiver) {
+    pub fn new(
+        sockets: Vec<UdpSocket>,
+        forwarder_sockets: Vec<UdpSocket>,
+        exit: &Arc<AtomicBool>,
+    ) -> (Self, PacketReceiver) {
         let (sender, receiver) = channel();
-        (Self::new_with_sender(sockets, exit, &sender), receiver)
+        (
+            Self::new_with_sender(sockets, forwarder_sockets, exit, &sender),
+            receiver,
+        )
     }
     pub fn new_with_sender(
         sockets: Vec<UdpSocket>,
+        forwarder_sockets: Vec<UdpSocket>,
         exit: &Arc<AtomicBool>,
         sender: &PacketSender,
     ) -> Self {

--- a/core/src/fullnode.rs
+++ b/core/src/fullnode.rs
@@ -213,6 +213,7 @@ impl Fullnode {
             &poh_recorder,
             entry_receiver,
             node.sockets.tpu,
+            node.sockets.forwarder,
             node.sockets.broadcast,
             config.sigverify_disabled,
             &blocktree,

--- a/core/src/fullnode.rs
+++ b/core/src/fullnode.rs
@@ -213,7 +213,7 @@ impl Fullnode {
             &poh_recorder,
             entry_receiver,
             node.sockets.tpu,
-            node.sockets.forwarder,
+            node.sockets.tpu_via_blobs,
             node.sockets.broadcast,
             config.sigverify_disabled,
             &blocktree,

--- a/core/src/local_cluster.rs
+++ b/core/src/local_cluster.rs
@@ -214,8 +214,7 @@ mod test {
     #[test]
     fn test_local_cluster_start_and_exit() {
         solana_logger::setup();
-        let cluster = LocalCluster::new(1, 100, 3);
-        drop(cluster)
+        let _cluster = LocalCluster::new(1, 100, 3);
     }
 
     #[test]
@@ -223,7 +222,6 @@ mod test {
         solana_logger::setup();
         let mut fullnode_exit = FullnodeConfig::default();
         fullnode_exit.rpc_config.enable_fullnode_exit = true;
-        let cluster = LocalCluster::new_with_config(&[3], 100, &fullnode_exit);
-        drop(cluster)
+        let _cluster = LocalCluster::new_with_config(&[3], 100, &fullnode_exit);
     }
 }

--- a/core/src/packet.rs
+++ b/core/src/packet.rs
@@ -44,7 +44,7 @@ pub struct Packet {
 
 impl Packet {
     pub fn new(data: [u8; PACKET_DATA_SIZE], meta: Meta) -> Self {
-        Packet { data, meta }
+        Self { data, meta }
     }
 }
 

--- a/core/src/packet.rs
+++ b/core/src/packet.rs
@@ -115,6 +115,10 @@ impl Default for Packets {
 }
 
 impl Packets {
+    pub fn new(packets: Vec<Packet>) -> Self {
+        Self { packets }
+    }
+
     pub fn set_addr(&mut self, addr: &SocketAddr) {
         for m in self.packets.iter_mut() {
             m.meta.set_addr(&addr);

--- a/core/src/streamer.rs
+++ b/core/src/streamer.rs
@@ -308,7 +308,7 @@ mod test {
             .collect();
 
         let mut blob = Blob::default();
-        blob.store_packets(&packets[..]).unwrap();
+        assert_eq!(blob.store_packets(&packets[..]), num_packets);
         let result = deserialize_packets_in_blob(
             &blob.data()[..blob.size()],
             serialized_packet_size,

--- a/core/src/streamer.rs
+++ b/core/src/streamer.rs
@@ -1,9 +1,9 @@
 //! The `streamer` module defines a set of services for efficiently pulling data from UDP sockets.
 //!
 
-use crate::packet::{Blob, Packet, Packets, SharedBlobs, SharedPackets};
+use crate::packet::{Blob, Meta, Packet, Packets, SharedBlobs, SharedPackets, PACKET_DATA_SIZE};
 use crate::result::{Error, Result};
-use bincode::deserialize;
+use bincode::{deserialize, serialized_size};
 use solana_metrics::{influxdb, submit};
 use solana_sdk::timing::duration_as_ms;
 use std::net::UdpSocket;
@@ -140,19 +140,58 @@ pub fn blob_receiver(
         .unwrap()
 }
 
+fn deserialize_single_packet_in_blob(data: &[u8], serialized_meta_size: usize) -> Result<Packet> {
+    let meta = deserialize(&data[..serialized_meta_size])?;
+    let mut packet_data = [0; PACKET_DATA_SIZE];
+    packet_data
+        .copy_from_slice(&data[serialized_meta_size..serialized_meta_size + PACKET_DATA_SIZE]);
+    Ok(Packet::new(packet_data, meta))
+}
+
+fn deserialize_packets_in_blob(
+    data: &[u8],
+    serialized_packet_size: usize,
+    serialized_meta_size: usize,
+) -> Result<Vec<Packet>> {
+    let mut packets: Vec<Packet> = Vec::with_capacity(data.len() / serialized_packet_size);
+    let mut pos = 0;
+    while pos + serialized_packet_size <= data.len() {
+        let packet = deserialize_single_packet_in_blob(
+            &data[pos..pos + serialized_packet_size],
+            serialized_meta_size,
+        )?;
+        pos += serialized_packet_size;
+        packets.push(packet);
+    }
+    Ok(packets)
+}
+
 fn recv_blob_packets(sock: &UdpSocket, s: &PacketSender) -> Result<()> {
     trace!(
         "recv_blob_packets: receiving on {}",
         sock.local_addr().unwrap()
     );
+
+    let meta = Meta::default();
+    let serialized_meta_size = serialized_size(&meta)? as usize;
+    let serialized_packet_size = serialized_meta_size + PACKET_DATA_SIZE;
     let blobs = Blob::recv_from(sock)?;
     for blob in blobs {
-        let msgs: Vec<Packet> = {
-            let r_blob = blob.read().unwrap();
+        let r_blob = blob.read().unwrap();
+        let data = {
             let msg_size = r_blob.size();
-            deserialize(&r_blob.data()[..msg_size])?
+            &r_blob.data()[..msg_size]
         };
-        s.send(Arc::new(RwLock::new(Packets::new(msgs))))?;
+
+        let packets =
+            deserialize_packets_in_blob(data, serialized_packet_size, serialized_meta_size);
+
+        if packets.is_err() {
+            continue;
+        }
+
+        let packets = packets?;
+        s.send(Arc::new(RwLock::new(Packets::new(packets))))?;
     }
 
     Ok(())
@@ -182,9 +221,10 @@ pub fn blob_packet_receiver(
 
 #[cfg(test)]
 mod test {
-    use crate::packet::{Blob, Packet, Packets, SharedBlob, PACKET_DATA_SIZE};
-    use crate::streamer::PacketReceiver;
+    use super::*;
+    use crate::packet::{Blob, Meta, Packet, Packets, SharedBlob, PACKET_DATA_SIZE};
     use crate::streamer::{receiver, responder};
+    use rand::Rng;
     use std::io;
     use std::io::Write;
     use std::net::UdpSocket;
@@ -245,5 +285,37 @@ mod test {
         exit.store(true, Ordering::Relaxed);
         t_receiver.join().expect("join");
         t_responder.join().expect("join");
+    }
+
+    #[test]
+    pub fn streamer_test_deserialize_packets_in_blob() {
+        let meta = Meta::default();
+        let serialized_meta_size = serialized_size(&meta).unwrap() as usize;
+        let serialized_packet_size = serialized_meta_size + PACKET_DATA_SIZE;
+        let num_packets = 10;
+        let mut rng = rand::thread_rng();
+        let packets: Vec<_> = (0..num_packets)
+            .map(|_| {
+                let mut packet = Packet::default();
+                for i in 0..packet.meta.addr.len() {
+                    packet.meta.addr[i] = rng.gen_range(1, std::u16::MAX);
+                }
+                for i in 0..packet.data.len() {
+                    packet.data[i] = rng.gen_range(1, std::u8::MAX);
+                }
+                packet
+            })
+            .collect();
+
+        let mut blob = Blob::default();
+        blob.store_packets(&packets[..]).unwrap();
+        let result = deserialize_packets_in_blob(
+            &blob.data()[..blob.size()],
+            serialized_packet_size,
+            serialized_meta_size,
+        )
+        .unwrap();
+
+        assert_eq!(result, packets);
     }
 }

--- a/core/src/streamer.rs
+++ b/core/src/streamer.rs
@@ -246,13 +246,13 @@ mod test {
         }
     }
     #[test]
-    pub fn streamer_debug() {
+    fn streamer_debug() {
         write!(io::sink(), "{:?}", Packet::default()).unwrap();
         write!(io::sink(), "{:?}", Packets::default()).unwrap();
         write!(io::sink(), "{:?}", Blob::default()).unwrap();
     }
     #[test]
-    pub fn streamer_send_test() {
+    fn streamer_send_test() {
         let read = UdpSocket::bind("127.0.0.1:0").expect("bind");
         read.set_read_timeout(Some(Duration::new(1, 0))).unwrap();
 
@@ -288,7 +288,7 @@ mod test {
     }
 
     #[test]
-    pub fn streamer_test_deserialize_packets_in_blob() {
+    fn test_streamer_deserialize_packets_in_blob() {
         let meta = Meta::default();
         let serialized_meta_size = serialized_size(&meta).unwrap() as usize;
         let serialized_packet_size = serialized_meta_size + PACKET_DATA_SIZE;

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -33,7 +33,7 @@ impl Tpu {
         poh_recorder: &Arc<Mutex<PohRecorder>>,
         entry_receiver: Receiver<WorkingBankEntries>,
         transactions_sockets: Vec<UdpSocket>,
-        forwarder_sockets: Vec<UdpSocket>,
+        tpu_via_blobs_sockets: Vec<UdpSocket>,
         broadcast_socket: UdpSocket,
         sigverify_disabled: bool,
         blocktree: &Arc<Blocktree>,
@@ -44,7 +44,7 @@ impl Tpu {
         let (packet_sender, packet_receiver) = channel();
         let fetch_stage = FetchStage::new_with_sender(
             transactions_sockets,
-            forwarder_sockets,
+            tpu_via_blobs_sockets,
             &exit,
             &packet_sender.clone(),
         );

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -26,6 +26,7 @@ pub struct Tpu {
 }
 
 impl Tpu {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         id: &Pubkey,
         cluster_info: &Arc<RwLock<ClusterInfo>>,

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -32,6 +32,7 @@ impl Tpu {
         poh_recorder: &Arc<Mutex<PohRecorder>>,
         entry_receiver: Receiver<WorkingBankEntries>,
         transactions_sockets: Vec<UdpSocket>,
+        forwarder_sockets: Vec<UdpSocket>,
         broadcast_socket: UdpSocket,
         sigverify_disabled: bool,
         blocktree: &Arc<Blocktree>,
@@ -40,8 +41,12 @@ impl Tpu {
         cluster_info.write().unwrap().set_leader(id);
 
         let (packet_sender, packet_receiver) = channel();
-        let fetch_stage =
-            FetchStage::new_with_sender(transactions_sockets, &exit, &packet_sender.clone());
+        let fetch_stage = FetchStage::new_with_sender(
+            transactions_sockets,
+            forwarder_sockets,
+            &exit,
+            &packet_sender.clone(),
+        );
         let cluster_info_vote_listener =
             ClusterInfoVoteListener::new(&exit, cluster_info.clone(), packet_sender);
 

--- a/tests/local_cluster.rs
+++ b/tests/local_cluster.rs
@@ -107,14 +107,12 @@ fn test_two_unbalanced_stakes() {
     cluster.close_preserve_ledgers();
     let leader_ledger = cluster.ledger_paths[1].clone();
     cluster_tests::verify_ledger_ticks(&leader_ledger, DEFAULT_TICKS_PER_SLOT as usize);
-
-    drop(cluster);
 }
 
 #[test]
 fn test_forwarding() {
     // Set up a cluster where one node is never the leader, so all txs sent to this node
-    // will be have to be forwarded
+    // will be have to be forwarded in order to be confirmed
     let fullnode_config = FullnodeConfig::default();
     let cluster = LocalCluster::new_with_config(&[999_990, 3], 2_000_000, &fullnode_config);
 
@@ -124,7 +122,7 @@ fn test_forwarding() {
     let leader_id = cluster.entry_point_info.id;
 
     let validator_info = cluster_nodes.iter().find(|c| c.id != leader_id).unwrap();
-    cluster_tests::send_many_transactions(&validator_info, &cluster.funding_keypair, 20);
 
-    drop(cluster);
+    // Confirm that transactions were forwarded to and processed by the leader.
+    cluster_tests::send_many_transactions(&validator_info, &cluster.funding_keypair, 20);
 }


### PR DESCRIPTION
#### Problem
The old leader node is forwarding packets to the new leader node, while the new leader has not detected itself to be the leader. The problem gets worse if the new and old leader is the same node. In such cases, the node repeatedly forwards the same packets to itself causing UDP stack to fail over.

#### Summary of Changes
The node detects if the next leader may not be available. In such cases, it buffers the packets and tries to send them at a latter time.
