### PR TITLE
Remove superfluous set_leader() usage

### DIFF
--- a/core/src/db_window.rs
+++ b/core/src/db_window.rs
@@ -160,54 +160,6 @@ mod test {
         t_receiver.join().expect("join");
         t_responder.join().expect("join");
     }
-    /*
-        #[test]
-        pub fn test_send_to_retransmit_stage() {
-            let leader = Keypair::new().pubkey();
-            let nonleader = Keypair::new().pubkey();
-            let mut leader_scheduler = LeaderScheduler::default();
-            leader_scheduler.set_leader_schedule(vec![leader]);
-            let leader_scheduler = Arc::new(RwLock::new(leader_scheduler));
-            let blob = SharedBlob::default();
-
-            let (blob_sender, blob_receiver) = channel();
-
-            // Expect all blobs to be sent to retransmit_stage
-            blob.write().unwrap().forward(false);
-            retransmit_blobs(
-                &vec![blob.clone()],
-                &leader_scheduler,
-                &blob_sender,
-                &nonleader,
-            )
-            .expect("Expect successful retransmit");
-            let _ = blob_receiver
-                .try_recv()
-                .expect("Expect input blob to be retransmitted");
-
-            blob.write().unwrap().forward(true);
-            retransmit_blobs(
-                &vec![blob.clone()],
-                &leader_scheduler,
-                &blob_sender,
-                &nonleader,
-            )
-            .expect("Expect successful retransmit");
-            let output_blob = blob_receiver
-                .try_recv()
-                .expect("Expect input blob to be retransmitted");
-
-            // retransmit_blobs shouldn't be modifying the blob. That is retransmit stage's job now
-            assert_eq!(*output_blob[0].read().unwrap(), *blob.read().unwrap());
-
-            // Expect blob from leader while currently leader to not be retransmitted
-            // Even when forward is set
-            blob.write().unwrap().forward(true);
-            retransmit_blobs(&vec![blob], &leader_scheduler, &blob_sender, &leader)
-                .expect("Expect successful retransmit");
-            assert!(blob_receiver.try_recv().is_err());
-        }
-    */
     #[test]
     pub fn test_find_missing_data_indexes_sanity() {
         let slot = 0;

--- a/core/src/replicator.rs
+++ b/core/src/replicator.rs
@@ -120,7 +120,6 @@ impl Replicator {
         info!("Creating cluster info....");
         let mut cluster_info = ClusterInfo::new(node.info.clone(), keypair.clone());
         cluster_info.set_entrypoint(leader_info.clone());
-        cluster_info.set_leader(leader_info.id);
         let cluster_info = Arc::new(RwLock::new(cluster_info));
 
         // Create Blocktree, eventually will simply repurpose the input

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -435,7 +435,6 @@ mod tests {
         let leader = ContactInfo::new_with_socketaddr(&socketaddr!("127.0.0.1:1234"));
 
         cluster_info.write().unwrap().insert_info(leader.clone());
-        cluster_info.write().unwrap().set_leader(leader.id);
 
         let mut io = MetaIoHandler::default();
         let rpc = RpcSolImpl;

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -18,7 +18,6 @@ use std::sync::{Arc, Mutex, RwLock};
 use std::thread;
 
 pub struct Tpu {
-    pub id: Pubkey,
     fetch_stage: FetchStage,
     sigverify_stage: SigVerifyStage,
     banking_stage: BankingStage,
@@ -60,7 +59,6 @@ impl Tpu {
         );
 
         Self {
-            id,
             fetch_stage,
             sigverify_stage,
             banking_stage,

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -197,7 +197,6 @@ pub mod tests {
         //start cluster_info1
         let mut cluster_info1 = ClusterInfo::new_with_invalid_keypair(target1.info.clone());
         cluster_info1.insert_info(leader.info.clone());
-        cluster_info1.set_leader(leader.info.id);
         let cref1 = Arc::new(RwLock::new(cluster_info1));
 
         let blocktree_path = get_tmp_ledger_path!();

--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -172,10 +172,8 @@ mod test {
         let leader_node = Node::new_localhost();
         let validator_node = Node::new_localhost();
         let exit = Arc::new(AtomicBool::new(false));
-        let mut cluster_info_me =
-            ClusterInfo::new_with_invalid_keypair(validator_node.info.clone());
+        let cluster_info_me = ClusterInfo::new_with_invalid_keypair(validator_node.info.clone());
         let me_id = leader_node.info.id;
-        cluster_info_me.set_leader(me_id);
         let subs = Arc::new(RwLock::new(cluster_info_me));
 
         let (s_reader, r_reader) = channel();
@@ -279,7 +277,6 @@ mod test {
             }
             s_responder.send(msgs).expect("send");
 
-            subs.write().unwrap().set_leader(me_id);
             let mut msgs1 = Vec::new();
             for v in 1..5 {
                 let i = 9 + v;

--- a/tests/cluster_info.rs
+++ b/tests/cluster_info.rs
@@ -38,7 +38,6 @@ fn run_simulation(num_nodes: u64, fanout: usize, hood_size: usize) {
     // describe the leader
     let leader_info = ContactInfo::new_localhost(Keypair::new().pubkey(), 0);
     let mut cluster_info = ClusterInfo::new_with_invalid_keypair(leader_info.clone());
-    cluster_info.set_leader(leader_info.id);
 
     // setup stakes
     let mut stakes = HashMap::new();

--- a/tests/gossip.rs
+++ b/tests/gossip.rs
@@ -155,13 +155,10 @@ pub fn cluster_info_retransmit() -> result::Result<()> {
     trace!("c3:");
     let (c3, dr3, tn3) = test_node(&exit);
     let c1_data = c1.read().unwrap().my_data().clone();
-    c1.write().unwrap().set_leader(c1_data.id);
 
     c2.write().unwrap().insert_info(c1_data.clone());
     c3.write().unwrap().insert_info(c1_data.clone());
 
-    c2.write().unwrap().set_leader(c1_data.id);
-    c3.write().unwrap().set_leader(c1_data.id);
     let num = 3;
 
     //wait to converge

--- a/tests/tvu.rs
+++ b/tests/tvu.rs
@@ -47,8 +47,7 @@ fn test_replay() {
     let exit = Arc::new(AtomicBool::new(false));
 
     // start cluster_info_l
-    let mut cluster_info_l = ClusterInfo::new_with_invalid_keypair(leader.info.clone());
-    cluster_info_l.set_leader(leader.info.id);
+    let cluster_info_l = ClusterInfo::new_with_invalid_keypair(leader.info.clone());
 
     let cref_l = Arc::new(RwLock::new(cluster_info_l));
     let dr_l = new_gossip(cref_l, leader.sockets.gossip, &exit);
@@ -56,7 +55,6 @@ fn test_replay() {
     // start cluster_info2
     let mut cluster_info2 = ClusterInfo::new_with_invalid_keypair(target2.info.clone());
     cluster_info2.insert_info(leader.info.clone());
-    cluster_info2.set_leader(leader.info.id);
     let cref2 = Arc::new(RwLock::new(cluster_info2));
     let dr_2 = new_gossip(cref2, target2.sockets.gossip, &exit);
 
@@ -99,7 +97,6 @@ fn test_replay() {
     // start cluster_info1
     let mut cluster_info1 = ClusterInfo::new_with_invalid_keypair(target1.info.clone());
     cluster_info1.insert_info(leader.info.clone());
-    cluster_info1.set_leader(leader.info.id);
     let cref1 = Arc::new(RwLock::new(cluster_info1));
     let dr_1 = new_gossip(cref1.clone(), target1.sockets.gossip, &exit);
 


### PR DESCRIPTION
Lots of test code was calling cluster_info::set_leader() for no reason.  Delete it all!

With that yak cleanly shaved we can now plainly see that `cluster_info::set_leader()/cluster_info::leader_data()` is used exclusively as a funky rendezvous between the Replay and Banking stage, which sets the stage nicely for some more refactoring to completely eliminate the notion of the leader from cluster_info/gossip