### PR TITLE
Wake up replay stage when the poh bank is cleared.

### DIFF
--- a/core/src/bank_forks.rs
+++ b/core/src/bank_forks.rs
@@ -68,9 +68,7 @@ impl BankForks {
         let prev = self.banks.insert(bank_slot, bank.clone());
         assert!(prev.is_none());
 
-        if bank_slot > self.working_bank.slot() {
-            self.working_bank = bank.clone()
-        }
+        self.working_bank = bank.clone();
 
         // TODO: this really only needs to look at the first
         //  parent if we're always calling insert()

--- a/core/src/blocktree.rs
+++ b/core/src/blocktree.rs
@@ -324,7 +324,7 @@ pub struct Blocktree {
     meta_cf: MetaCf,
     data_cf: DataCf,
     erasure_cf: ErasureCf,
-    new_blobs_signals: Vec<SyncSender<bool>>,
+    pub new_blobs_signals: Vec<SyncSender<bool>>,
     ticks_per_slot: u64,
 }
 

--- a/core/src/fullnode.rs
+++ b/core/src/fullnode.rs
@@ -110,7 +110,7 @@ impl Fullnode {
             PohRecorder::new(bank.tick_height(), bank.last_blockhash());
         let poh_recorder = Arc::new(Mutex::new(poh_recorder));
         let poh_service = PohService::new(poh_recorder.clone(), &config.tick_config, &exit);
-        poh_recorder.lock().unwrap().clear_bank_signal = blocktree.new_blobs_signals.first();
+        poh_recorder.lock().unwrap().clear_bank_signal = blocktree.new_blobs_signals.first().cloned();
         assert_eq!(
             blocktree.new_blobs_signals.len(),
             1,

--- a/core/src/fullnode.rs
+++ b/core/src/fullnode.rs
@@ -112,7 +112,7 @@ impl Fullnode {
         let poh_service = PohService::new(poh_recorder.clone(), &config.tick_config, &exit);
         poh_recorder.lock().unwrap().clear_bank_signal = blocktree.new_blobs_signals.first();
         assert_eq!(
-            blocktree.new_blob_signals.len(),
+            blocktree.new_blobs_signals.len(),
             1,
             "New blob signal for the TVU should be the same as the clear bank signal."
         );

--- a/core/src/fullnode.rs
+++ b/core/src/fullnode.rs
@@ -110,7 +110,7 @@ impl Fullnode {
             PohRecorder::new(bank.tick_height(), bank.last_blockhash());
         let poh_recorder = Arc::new(Mutex::new(poh_recorder));
         let poh_service = PohService::new(poh_recorder.clone(), &config.tick_config, &exit);
-        poh_recorder.lock().unwrap().clear_bank_signal = blocktree.new_blob_signals.first();
+        poh_recorder.lock().unwrap().clear_bank_signal = blocktree.new_blobs_signals.first();
         assert_eq!(
             blocktree.new_blob_signals.len(),
             1,

--- a/core/src/fullnode.rs
+++ b/core/src/fullnode.rs
@@ -110,7 +110,8 @@ impl Fullnode {
             PohRecorder::new(bank.tick_height(), bank.last_blockhash());
         let poh_recorder = Arc::new(Mutex::new(poh_recorder));
         let poh_service = PohService::new(poh_recorder.clone(), &config.tick_config, &exit);
-        poh_recorder.lock().unwrap().clear_bank_signal = blocktree.new_blobs_signals.first().cloned();
+        poh_recorder.lock().unwrap().clear_bank_signal =
+            blocktree.new_blobs_signals.first().cloned();
         assert_eq!(
             blocktree.new_blobs_signals.len(),
             1,

--- a/core/src/fullnode.rs
+++ b/core/src/fullnode.rs
@@ -110,6 +110,12 @@ impl Fullnode {
             PohRecorder::new(bank.tick_height(), bank.last_blockhash());
         let poh_recorder = Arc::new(Mutex::new(poh_recorder));
         let poh_service = PohService::new(poh_recorder.clone(), &config.tick_config, &exit);
+        poh_recorder.lock().unwrap().clear_bank_signal = blocktree.new_blob_signals.first();
+        assert_eq!(
+            blocktree.new_blob_signals.len(),
+            1,
+            "New blob signal for the TVU should be the same as the clear bank signal."
+        );
 
         info!("node info: {:?}", node.info);
         info!("node entrypoint_info: {:?}", entrypoint_info_option);

--- a/core/src/poh_recorder.rs
+++ b/core/src/poh_recorder.rs
@@ -40,7 +40,7 @@ pub struct PohRecorder {
     tick_cache: Vec<(Entry, u64)>,
     working_bank: Option<WorkingBank>,
     sender: Sender<WorkingBankEntries>,
-    clear_bank_signal: Option<SyncSender<bool>>,
+    pub clear_bank_signal: Option<SyncSender<bool>>,
 }
 
 impl PohRecorder {

--- a/core/src/poh_recorder.rs
+++ b/core/src/poh_recorder.rs
@@ -235,6 +235,7 @@ mod tests {
     use crate::test_tx::test_tx;
     use solana_sdk::genesis_block::GenesisBlock;
     use solana_sdk::hash::hash;
+    use std::sync::mpsc::sync_channel;
     use std::sync::Arc;
 
     #[test]
@@ -509,5 +510,17 @@ mod tests {
         poh_recorder.set_working_bank(working_bank);
         poh_recorder.reset(1, hash(b"hello"));
         assert!(poh_recorder.working_bank.is_none());
+    }
+
+    #[test]
+    pub fn test_clear_signal() {
+        let (genesis_block, _mint_keypair) = GenesisBlock::new(2);
+        let bank = Arc::new(Bank::new(&genesis_block));
+        let (mut poh_recorder, _entry_receiver) = PohRecorder::new(0, Hash::default());
+        let (sender, receiver) = sync_channel(1);
+        poh_recorder.set_bank(&bank);
+        poh_recorder.clear_bank_signal = Some(sender);
+        poh_recorder.clear_bank();
+        assert!(receiver.try_recv().is_ok());
     }
 }

--- a/core/src/poh_recorder.rs
+++ b/core/src/poh_recorder.rs
@@ -189,6 +189,7 @@ impl PohRecorder {
                 tick_cache: vec![],
                 working_bank: None,
                 sender,
+                clear_bank_signal: None,
             },
             receiver,
         )

--- a/core/src/poh_recorder.rs
+++ b/core/src/poh_recorder.rs
@@ -46,7 +46,7 @@ pub struct PohRecorder {
 impl PohRecorder {
     pub fn clear_bank(&mut self) {
         self.working_bank = None;
-        if let Some(signal) = self.clear_bank_signal {
+        if let Some(ref signal) = self.clear_bank_signal {
             let _ = signal.try_send(true);
         }
     }

--- a/core/src/poh_recorder.rs
+++ b/core/src/poh_recorder.rs
@@ -40,7 +40,7 @@ pub struct PohRecorder {
     tick_cache: Vec<(Entry, u64)>,
     working_bank: Option<WorkingBank>,
     sender: Sender<WorkingBankEntries>,
-    clear_bank_signal: Option<Sender<bool>>,
+    clear_bank_signal: Option<SyncSender<bool>>,
 }
 
 impl PohRecorder {

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -188,8 +188,11 @@ impl ReplayStage {
         if let Some((_, parent)) = newest_frozen.last() {
             let poh_tick_height = poh_recorder.lock().unwrap().tick_height();
             let poh_slot = leader_schedule_utils::tick_height_to_slot(parent, poh_tick_height + 1);
-            assert!(frozen.get(&poh_slot).is_none());
             trace!("checking poh slot for leader {}", poh_slot);
+            if frozen.get(&poh_slot).is_some() {
+                // Already been a leader for this slot, skip it
+                return;
+            }
             if bank_forks.read().unwrap().get(poh_slot).is_none() {
                 leader_schedule_utils::slot_leader_at(poh_slot, parent)
                     .map(|next_leader| {

--- a/sdk/src/timing.rs
+++ b/sdk/src/timing.rs
@@ -2,7 +2,7 @@
 use std::time::Duration;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-pub const NUM_TICKS_PER_SECOND: u64 = 10;
+pub const NUM_TICKS_PER_SECOND: u64 = 100;
 
 // At 10 ticks/s, 8 ticks per slot implies that leader rotation and voting will happen
 // every 800 ms. A fast voting cadence ensures faster finality and convergence

--- a/sdk/src/timing.rs
+++ b/sdk/src/timing.rs
@@ -6,7 +6,7 @@ pub const NUM_TICKS_PER_SECOND: u64 = 100;
 
 // At 10 ticks/s, 8 ticks per slot implies that leader rotation and voting will happen
 // every 800 ms. A fast voting cadence ensures faster finality and convergence
-pub const DEFAULT_TICKS_PER_SLOT: u64 = 16;
+pub const DEFAULT_TICKS_PER_SLOT: u64 = 160;
 pub const DEFAULT_SLOTS_PER_EPOCH: u64 = 16;
 
 /// The time window of recent block hash values that the bank will track the signatures


### PR DESCRIPTION
#### Problem

There is a gap between poh recorder marking the TPU bank as frozen, and the replay stage setting the next bank.  Replay stage should be notified asap when the TPU bank is no longer active according to the poh_recorder.

#### Summary of Changes

Wake up replay stage with the same signal as blocktree.  Bump ticks per second.

Fixes #
