### PR TITLE
pass Pubkeys as refs, copy only where values needed

### DIFF
--- a/bench-tps/src/bench.rs
+++ b/bench-tps/src/bench.rs
@@ -120,7 +120,7 @@ pub fn send_barrier_transaction(
 
         *blockhash = barrier_client.get_recent_blockhash();
         let signature = barrier_client
-            .transfer(0, &source_keypair, *dest_id, blockhash)
+            .transfer(0, &source_keypair, dest_id, blockhash)
             .expect("Unable to send barrier transaction");
 
         let confirmatiom = barrier_client.poll_for_signature(&signature);
@@ -196,7 +196,7 @@ pub fn generate_txs(
         .par_iter()
         .map(|(id, keypair)| {
             (
-                SystemTransaction::new_account(id, keypair.pubkey(), 1, blockhash, 0),
+                SystemTransaction::new_account(id, &keypair.pubkey(), 1, blockhash, 0),
                 timestamp(),
             )
         })

--- a/benches/append_vec.rs
+++ b/benches/append_vec.rs
@@ -200,7 +200,7 @@ fn append_vec_concurrent_get_append(bencher: &mut Bencher) {
 #[bench]
 fn bench_account_serialize(bencher: &mut Bencher) {
     let num: usize = 1000;
-    let account = Account::new(2, 100, Keypair::new().pubkey());
+    let account = Account::new(2, 100, &Keypair::new().pubkey());
     let len = get_serialized_size(&account);
     let ser_len = align_up!(len + std::mem::size_of::<u64>(), std::mem::size_of::<u64>());
     let mut memory = vec![0; num * ser_len];
@@ -225,7 +225,7 @@ fn bench_account_serialize(bencher: &mut Bencher) {
 #[bench]
 fn bench_account_serialize_bincode(bencher: &mut Bencher) {
     let num: usize = 1000;
-    let account = Account::new(2, 100, Keypair::new().pubkey());
+    let account = Account::new(2, 100, &Keypair::new().pubkey());
     let len = serialized_size(&account).unwrap() as usize;
     let mut memory = vec![0u8; num * len];
     bencher.iter(|| {

--- a/benches/banking_stage.rs
+++ b/benches/banking_stage.rs
@@ -55,7 +55,7 @@ fn bench_banking_stage_multi_accounts(bencher: &mut Bencher) {
     let bank = Arc::new(Bank::new(&genesis_block));
     let dummy = SystemTransaction::new_move(
         &mint_keypair,
-        mint_keypair.pubkey(),
+        &mint_keypair.pubkey(),
         1,
         genesis_block.hash(),
         0,
@@ -77,7 +77,7 @@ fn bench_banking_stage_multi_accounts(bencher: &mut Bencher) {
     transactions.iter().for_each(|tx| {
         let fund = SystemTransaction::new_move(
             &mint_keypair,
-            tx.account_keys[0],
+            &tx.account_keys[0],
             mint_total / txes as u64,
             genesis_block.hash(),
             0,
@@ -147,7 +147,7 @@ fn bench_banking_stage_multi_programs(bencher: &mut Bencher) {
     let bank = Arc::new(Bank::new(&genesis_block));
     let dummy = SystemTransaction::new_move(
         &mint_keypair,
-        mint_keypair.pubkey(),
+        &mint_keypair.pubkey(),
         1,
         genesis_block.hash(),
         0,
@@ -185,7 +185,7 @@ fn bench_banking_stage_multi_programs(bencher: &mut Bencher) {
     transactions.iter().for_each(|tx| {
         let fund = SystemTransaction::new_move(
             &mint_keypair,
-            tx.account_keys[0],
+            &tx.account_keys[0],
             mint_total / txes as u64,
             genesis_block.hash(),
             0,

--- a/benches/ledger.rs
+++ b/benches/ledger.rs
@@ -13,7 +13,7 @@ fn bench_block_to_blobs_to_block(bencher: &mut Bencher) {
     let zero = Hash::default();
     let one = hash(&zero.as_ref());
     let keypair = Keypair::new();
-    let tx0 = SystemTransaction::new_move(&keypair, keypair.pubkey(), 1, one, 0);
+    let tx0 = SystemTransaction::new_move(&keypair, &keypair.pubkey(), 1, one, 0);
     let transactions = vec![tx0; 10];
     let entries = next_entries(&zero, 1, transactions);
 

--- a/core/src/bank_forks.rs
+++ b/core/src/bank_forks.rs
@@ -101,7 +101,7 @@ mod tests {
         let (genesis_block, _) = GenesisBlock::new(10_000);
         let bank = Bank::new(&genesis_block);
         let mut bank_forks = BankForks::new(0, bank);
-        let child_bank = Bank::new_from_parent(&bank_forks[0u64], Pubkey::default(), 1);
+        let child_bank = Bank::new_from_parent(&bank_forks[0u64], &Pubkey::default(), 1);
         child_bank.register_tick(&Hash::default());
         bank_forks.insert(1, child_bank);
         assert_eq!(bank_forks[1u64].tick_height(), 1);
@@ -113,7 +113,7 @@ mod tests {
         let (genesis_block, _) = GenesisBlock::new(10_000);
         let bank = Bank::new(&genesis_block);
         let mut bank_forks = BankForks::new(0, bank);
-        let child_bank = Bank::new_from_parent(&bank_forks[0u64], Pubkey::default(), 1);
+        let child_bank = Bank::new_from_parent(&bank_forks[0u64], &Pubkey::default(), 1);
         bank_forks.insert(1, child_bank);
         assert!(bank_forks.frozen_banks().get(&0).is_some());
         assert!(bank_forks.frozen_banks().get(&1).is_none());
@@ -124,7 +124,7 @@ mod tests {
         let (genesis_block, _) = GenesisBlock::new(10_000);
         let bank = Bank::new(&genesis_block);
         let mut bank_forks = BankForks::new(0, bank);
-        let child_bank = Bank::new_from_parent(&bank_forks[0u64], Pubkey::default(), 1);
+        let child_bank = Bank::new_from_parent(&bank_forks[0u64], &Pubkey::default(), 1);
         bank_forks.insert(1, child_bank);
         assert_eq!(bank_forks.active_banks(), vec![1]);
     }

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -440,15 +440,15 @@ mod tests {
 
         // good tx
         let keypair = mint_keypair;
-        let tx = SystemTransaction::new_account(&keypair, keypair.pubkey(), 1, start_hash, 0);
+        let tx = SystemTransaction::new_account(&keypair, &keypair.pubkey(), 1, start_hash, 0);
 
         // good tx, but no verify
         let tx_no_ver =
-            SystemTransaction::new_account(&keypair, keypair.pubkey(), 1, start_hash, 0);
+            SystemTransaction::new_account(&keypair, &keypair.pubkey(), 1, start_hash, 0);
 
         // bad tx, AccountNotFound
         let keypair = Keypair::new();
-        let tx_anf = SystemTransaction::new_account(&keypair, keypair.pubkey(), 1, start_hash, 0);
+        let tx_anf = SystemTransaction::new_account(&keypair, &keypair.pubkey(), 1, start_hash, 0);
 
         // send 'em over
         let packets = to_packets(&[tx, tx_no_ver, tx_anf]);
@@ -500,7 +500,7 @@ mod tests {
         let alice = Keypair::new();
         let tx = SystemTransaction::new_account(
             &mint_keypair,
-            alice.pubkey(),
+            &alice.pubkey(),
             2,
             genesis_block.hash(),
             0,
@@ -514,7 +514,7 @@ mod tests {
         // Process a second batch that spends one of those lamports.
         let tx = SystemTransaction::new_account(
             &alice,
-            mint_keypair.pubkey(),
+            &mint_keypair.pubkey(),
             1,
             genesis_block.hash(),
             0,
@@ -567,8 +567,8 @@ mod tests {
         let pubkey = Keypair::new().pubkey();
 
         let transactions = vec![
-            SystemTransaction::new_move(&mint_keypair, pubkey, 1, genesis_block.hash(), 0),
-            SystemTransaction::new_move(&mint_keypair, pubkey, 1, genesis_block.hash(), 0),
+            SystemTransaction::new_move(&mint_keypair, &pubkey, 1, genesis_block.hash(), 0),
+            SystemTransaction::new_move(&mint_keypair, &pubkey, 1, genesis_block.hash(), 0),
         ];
 
         let mut results = vec![Ok(()), Ok(())];
@@ -601,7 +601,7 @@ mod tests {
 
         let transactions = vec![SystemTransaction::new_move(
             &mint_keypair,
-            pubkey,
+            &pubkey,
             1,
             genesis_block.hash(),
             0,
@@ -642,7 +642,7 @@ mod tests {
 
         let transactions = vec![SystemTransaction::new_move(
             &mint_keypair,
-            pubkey,
+            &pubkey,
             2,
             genesis_block.hash(),
             0,

--- a/core/src/blockstream.rs
+++ b/core/src/blockstream.rs
@@ -63,14 +63,14 @@ pub trait BlockstreamEvents {
         &self,
         slot: u64,
         tick_height: u64,
-        leader_id: Pubkey,
+        leader_id: &Pubkey,
         entries: &Entry,
     ) -> Result<()>;
     fn emit_block_event(
         &self,
         slot: u64,
         tick_height: u64,
-        leader_id: Pubkey,
+        leader_id: &Pubkey,
         blockhash: Hash,
     ) -> Result<()>;
 }
@@ -88,7 +88,7 @@ where
         &self,
         slot: u64,
         tick_height: u64,
-        leader_id: Pubkey,
+        leader_id: &Pubkey,
         entry: &Entry,
     ) -> Result<()> {
         let json_entry = serde_json::to_string(&entry)?;
@@ -108,7 +108,7 @@ where
         &self,
         slot: u64,
         tick_height: u64,
-        leader_id: Pubkey,
+        leader_id: &Pubkey,
         blockhash: Hash,
     ) -> Result<()> {
         let payload = format!(
@@ -175,14 +175,14 @@ mod test {
         for tick_height in tick_height_initial..=tick_height_final {
             if tick_height == 5 {
                 blockstream
-                    .emit_block_event(curr_slot, tick_height - 1, leader_id, blockhash)
+                    .emit_block_event(curr_slot, tick_height - 1, &leader_id, blockhash)
                     .unwrap();
                 curr_slot += 1;
             }
             let entry = Entry::new(&mut blockhash, 1, vec![]); // just ticks
             blockhash = entry.hash;
             blockstream
-                .emit_entry_event(curr_slot, tick_height, leader_id, &entry)
+                .emit_entry_event(curr_slot, tick_height, &leader_id, &entry)
                 .unwrap();
             expected_entries.push(entry.clone());
             entries.push(entry);

--- a/core/src/blockstream_service.rs
+++ b/core/src/blockstream_service.rs
@@ -80,13 +80,13 @@ impl BlockstreamService {
                 tick_height += 1;
             }
             blockstream
-                .emit_entry_event(slot, tick_height, slot_leader, &entry)
+                .emit_entry_event(slot, tick_height, &slot_leader, &entry)
                 .unwrap_or_else(|e| {
                     debug!("Blockstream error: {:?}, {:?}", e, blockstream.output);
                 });
             if i == entries.len() - 1 {
                 blockstream
-                    .emit_block_event(slot, tick_height, slot_leader, entry.hash)
+                    .emit_block_event(slot, tick_height, &slot_leader, entry.hash)
                     .unwrap_or_else(|e| {
                         debug!("Blockstream error: {:?}, {:?}", e, blockstream.output);
                     });
@@ -140,7 +140,7 @@ mod test {
 
         let keypair = Keypair::new();
         let mut blockhash = entries[3].hash;
-        let tx = SystemTransaction::new_account(&keypair, keypair.pubkey(), 1, Hash::default(), 0);
+        let tx = SystemTransaction::new_account(&keypair, &keypair.pubkey(), 1, Hash::default(), 0);
         let entry = Entry::new(&mut blockhash, 1, vec![tx]);
         blockhash = entry.hash;
         entries.push(entry);

--- a/core/src/broadcast_stage.rs
+++ b/core/src/broadcast_stage.rs
@@ -281,7 +281,7 @@ mod test {
     }
 
     fn setup_dummy_broadcast_service(
-        leader_pubkey: Pubkey,
+        leader_pubkey: &Pubkey,
         ledger_path: &str,
         entry_receiver: Receiver<WorkingBankEntries>,
     ) -> MockBroadcastStage {
@@ -293,7 +293,7 @@ mod test {
 
         // Make a node to broadcast to
         let buddy_keypair = Keypair::new();
-        let broadcast_buddy = Node::new_localhost_with_pubkey(buddy_keypair.pubkey());
+        let broadcast_buddy = Node::new_localhost_with_pubkey(&buddy_keypair.pubkey());
 
         // Fill the cluster_info with the buddy's info
         let mut cluster_info = ClusterInfo::new_with_invalid_keypair(leader_info.info.clone());
@@ -332,7 +332,7 @@ mod test {
 
             let (entry_sender, entry_receiver) = channel();
             let broadcast_service = setup_dummy_broadcast_service(
-                leader_keypair.pubkey(),
+                &leader_keypair.pubkey(),
                 &ledger_path,
                 entry_receiver,
             );

--- a/core/src/chacha.rs
+++ b/core/src/chacha.rs
@@ -126,7 +126,7 @@ mod tests {
                     &mut num_hashes,
                     vec![SystemTransaction::new_account(
                         &keypair,
-                        keypair.pubkey(),
+                        &keypair.pubkey(),
                         1,
                         one,
                         0,

--- a/core/src/cluster_tests.rs
+++ b/core/src/cluster_tests.rs
@@ -33,7 +33,7 @@ pub fn spend_and_verify_all_nodes(
         assert!(bal > 0);
         let mut transaction = SystemTransaction::new_move(
             &funding_keypair,
-            random_keypair.pubkey(),
+            &random_keypair.pubkey(),
             1,
             client.get_recent_blockhash(),
             0,
@@ -124,7 +124,7 @@ pub fn kill_entry_and_spend_and_verify_rest(
         assert!(bal > 0);
         let mut transaction = SystemTransaction::new_move(
             &funding_keypair,
-            random_keypair.pubkey(),
+            &random_keypair.pubkey(),
             1,
             client.get_recent_blockhash(),
             0,

--- a/core/src/contact_info.rs
+++ b/core/src/contact_info.rs
@@ -83,7 +83,7 @@ impl Default for ContactInfo {
 
 impl ContactInfo {
     pub fn new(
-        id: Pubkey,
+        id: &Pubkey,
         gossip: SocketAddr,
         tvu: SocketAddr,
         tpu: SocketAddr,
@@ -93,7 +93,7 @@ impl ContactInfo {
         now: u64,
     ) -> Self {
         Self {
-            id,
+            id: *id,
             signature: Signature::default(),
             gossip,
             tvu,
@@ -105,7 +105,7 @@ impl ContactInfo {
         }
     }
 
-    pub fn new_localhost(id: Pubkey, now: u64) -> Self {
+    pub fn new_localhost(id: &Pubkey, now: u64) -> Self {
         Self::new(
             id,
             socketaddr!("127.0.0.1:1234"),
@@ -124,7 +124,7 @@ impl ContactInfo {
         let addr = socketaddr!("224.0.1.255:1000");
         assert!(addr.ip().is_multicast());
         Self::new(
-            Keypair::new().pubkey(),
+            &Keypair::new().pubkey(),
             addr,
             addr,
             addr,
@@ -139,7 +139,7 @@ impl ContactInfo {
         nxt_addr.set_port(addr.port() + nxt);
         nxt_addr
     }
-    fn new_with_pubkey_socketaddr(pubkey: Pubkey, bind_addr: &SocketAddr) -> Self {
+    fn new_with_pubkey_socketaddr(pubkey: &Pubkey, bind_addr: &SocketAddr) -> Self {
         let tpu_addr = *bind_addr;
         let gossip_addr = Self::next_port(&bind_addr, 1);
         let tvu_addr = Self::next_port(&bind_addr, 2);
@@ -158,14 +158,14 @@ impl ContactInfo {
     }
     pub fn new_with_socketaddr(bind_addr: &SocketAddr) -> Self {
         let keypair = Keypair::new();
-        Self::new_with_pubkey_socketaddr(keypair.pubkey(), bind_addr)
+        Self::new_with_pubkey_socketaddr(&keypair.pubkey(), bind_addr)
     }
 
     // Construct a ContactInfo that's only usable for gossip
     pub fn new_gossip_entry_point(gossip_addr: &SocketAddr) -> Self {
         let daddr: SocketAddr = socketaddr!("0.0.0.0:0");
         Self::new(
-            Pubkey::default(),
+            &Pubkey::default(),
             *gossip_addr,
             daddr,
             daddr,
@@ -292,7 +292,7 @@ mod tests {
     fn replayed_data_new_with_socketaddr_with_pubkey() {
         let keypair = Keypair::new();
         let d1 = ContactInfo::new_with_pubkey_socketaddr(
-            keypair.pubkey().clone(),
+            &keypair.pubkey(),
             &socketaddr!("127.0.0.1:1234"),
         );
         assert_eq!(d1.id, keypair.pubkey());

--- a/core/src/crds.rs
+++ b/core/src/crds.rs
@@ -135,7 +135,7 @@ impl Crds {
     }
 
     /// Update the timestamp's of all the labels that are assosciated with Pubkey
-    pub fn update_record_timestamp(&mut self, pubkey: Pubkey, now: u64) {
+    pub fn update_record_timestamp(&mut self, pubkey: &Pubkey, now: u64) {
         for label in &CrdsValue::record_labels(pubkey) {
             self.update_label_timestamp(label, now);
         }
@@ -187,9 +187,9 @@ mod test {
     #[test]
     fn test_update_new() {
         let mut crds = Crds::default();
-        let original = CrdsValue::ContactInfo(ContactInfo::new_localhost(Pubkey::default(), 0));
+        let original = CrdsValue::ContactInfo(ContactInfo::new_localhost(&Pubkey::default(), 0));
         assert_matches!(crds.insert(original.clone(), 0), Ok(_));
-        let val = CrdsValue::ContactInfo(ContactInfo::new_localhost(Pubkey::default(), 1));
+        let val = CrdsValue::ContactInfo(ContactInfo::new_localhost(&Pubkey::default(), 1));
         assert_eq!(
             crds.insert(val.clone(), 1).unwrap().unwrap().value,
             original
@@ -199,7 +199,7 @@ mod test {
     #[test]
     fn test_update_timestamp() {
         let mut crds = Crds::default();
-        let val = CrdsValue::ContactInfo(ContactInfo::new_localhost(Pubkey::default(), 0));
+        let val = CrdsValue::ContactInfo(ContactInfo::new_localhost(&Pubkey::default(), 0));
         assert_eq!(crds.insert(val.clone(), 0), Ok(None));
 
         crds.update_label_timestamp(&val.label(), 1);
@@ -210,13 +210,13 @@ mod test {
         assert_eq!(val2.label().pubkey(), val.label().pubkey());
         assert_matches!(crds.insert(val2.clone(), 0), Ok(Some(_)));
 
-        crds.update_record_timestamp(val.label().pubkey(), 2);
+        crds.update_record_timestamp(&val.label().pubkey(), 2);
         assert_eq!(crds.table[&val.label()].local_timestamp, 2);
         assert_eq!(crds.table[&val.label()].insert_timestamp, 0);
         assert_eq!(crds.table[&val2.label()].local_timestamp, 2);
         assert_eq!(crds.table[&val2.label()].insert_timestamp, 0);
 
-        crds.update_record_timestamp(val.label().pubkey(), 1);
+        crds.update_record_timestamp(&val.label().pubkey(), 1);
         assert_eq!(crds.table[&val.label()].local_timestamp, 2);
         assert_eq!(crds.table[&val.label()].insert_timestamp, 0);
 
@@ -259,10 +259,10 @@ mod test {
     fn test_hash_order() {
         let v1 = VersionedCrdsValue::new(
             1,
-            CrdsValue::ContactInfo(ContactInfo::new_localhost(Pubkey::default(), 0)),
+            CrdsValue::ContactInfo(ContactInfo::new_localhost(&Pubkey::default(), 0)),
         );
         let v2 = VersionedCrdsValue::new(1, {
-            let mut contact_info = ContactInfo::new_localhost(Pubkey::default(), 0);
+            let mut contact_info = ContactInfo::new_localhost(&Pubkey::default(), 0);
             contact_info.rpc = socketaddr!("0.0.0.0:0");
             CrdsValue::ContactInfo(contact_info)
         });
@@ -286,11 +286,11 @@ mod test {
     fn test_wallclock_order() {
         let v1 = VersionedCrdsValue::new(
             1,
-            CrdsValue::ContactInfo(ContactInfo::new_localhost(Pubkey::default(), 1)),
+            CrdsValue::ContactInfo(ContactInfo::new_localhost(&Pubkey::default(), 1)),
         );
         let v2 = VersionedCrdsValue::new(
             1,
-            CrdsValue::ContactInfo(ContactInfo::new_localhost(Pubkey::default(), 0)),
+            CrdsValue::ContactInfo(ContactInfo::new_localhost(&Pubkey::default(), 0)),
         );
         assert_eq!(v1.value.label(), v2.value.label());
         assert!(v1 > v2);
@@ -302,11 +302,11 @@ mod test {
     fn test_label_order() {
         let v1 = VersionedCrdsValue::new(
             1,
-            CrdsValue::ContactInfo(ContactInfo::new_localhost(Keypair::new().pubkey(), 0)),
+            CrdsValue::ContactInfo(ContactInfo::new_localhost(&Keypair::new().pubkey(), 0)),
         );
         let v2 = VersionedCrdsValue::new(
             1,
-            CrdsValue::ContactInfo(ContactInfo::new_localhost(Keypair::new().pubkey(), 0)),
+            CrdsValue::ContactInfo(ContactInfo::new_localhost(&Keypair::new().pubkey(), 0)),
         );
         assert_ne!(v1, v2);
         assert!(!(v1 == v2));

--- a/core/src/crds_value.rs
+++ b/core/src/crds_value.rs
@@ -108,8 +108,11 @@ impl CrdsValue {
         }
     }
     /// Return all the possible labels for a record identified by Pubkey.
-    pub fn record_labels(key: Pubkey) -> [CrdsValueLabel; 2] {
-        [CrdsValueLabel::ContactInfo(key), CrdsValueLabel::Vote(key)]
+    pub fn record_labels(key: &Pubkey) -> [CrdsValueLabel; 2] {
+        [
+            CrdsValueLabel::ContactInfo(*key),
+            CrdsValueLabel::Vote(*key),
+        ]
     }
 }
 
@@ -159,7 +162,7 @@ mod test {
     fn test_labels() {
         let mut hits = [false; 2];
         // this method should cover all the possible labels
-        for v in &CrdsValue::record_labels(Pubkey::default()) {
+        for v in &CrdsValue::record_labels(&Pubkey::default()) {
             match v {
                 CrdsValueLabel::ContactInfo(_) => hits[0] = true,
                 CrdsValueLabel::Vote(_) => hits[1] = true,
@@ -184,7 +187,7 @@ mod test {
         let keypair = Keypair::new();
         let fake_keypair = Keypair::new();
         let mut v =
-            CrdsValue::ContactInfo(ContactInfo::new_localhost(keypair.pubkey(), timestamp()));
+            CrdsValue::ContactInfo(ContactInfo::new_localhost(&keypair.pubkey(), timestamp()));
         v.sign(&keypair);
         assert!(v.verify());
         v.sign(&fake_keypair);

--- a/core/src/entry.rs
+++ b/core/src/entry.rs
@@ -400,8 +400,8 @@ pub fn make_tiny_test_entries_from_hash(start: &Hash, num: usize) -> Vec<Entry> 
                 &mut num_hashes,
                 vec![BudgetTransaction::new_timestamp(
                     &keypair,
-                    keypair.pubkey(),
-                    keypair.pubkey(),
+                    &keypair.pubkey(),
+                    &keypair.pubkey(),
                     Utc::now(),
                     *start,
                 )],
@@ -423,8 +423,8 @@ pub fn make_large_test_entries(num_entries: usize) -> Vec<Entry> {
 
     let tx = BudgetTransaction::new_timestamp(
         &keypair,
-        keypair.pubkey(),
-        keypair.pubkey(),
+        &keypair.pubkey(),
+        &keypair.pubkey(),
         Utc::now(),
         one,
     );
@@ -496,8 +496,8 @@ mod tests {
 
         // First, verify entries
         let keypair = Keypair::new();
-        let tx0 = SystemTransaction::new_account(&keypair, keypair.pubkey(), 0, zero, 0);
-        let tx1 = SystemTransaction::new_account(&keypair, keypair.pubkey(), 1, zero, 0);
+        let tx0 = SystemTransaction::new_account(&keypair, &keypair.pubkey(), 0, zero, 0);
+        let tx1 = SystemTransaction::new_account(&keypair, &keypair.pubkey(), 1, zero, 0);
         let mut e0 = Entry::new(&zero, 0, vec![tx0.clone(), tx1.clone()]);
         assert!(e0.verify(&zero));
 
@@ -515,13 +515,13 @@ mod tests {
         let keypair = Keypair::new();
         let tx0 = BudgetTransaction::new_timestamp(
             &keypair,
-            keypair.pubkey(),
-            keypair.pubkey(),
+            &keypair.pubkey(),
+            &keypair.pubkey(),
             Utc::now(),
             zero,
         );
         let tx1 =
-            BudgetTransaction::new_signature(&keypair, keypair.pubkey(), keypair.pubkey(), zero);
+            BudgetTransaction::new_signature(&keypair, &keypair.pubkey(), &keypair.pubkey(), zero);
         let mut e0 = Entry::new(&zero, 0, vec![tx0.clone(), tx1.clone()]);
         assert!(e0.verify(&zero));
 
@@ -545,8 +545,8 @@ mod tests {
         let keypair = Keypair::new();
         let tx0 = BudgetTransaction::new_timestamp(
             &keypair,
-            keypair.pubkey(),
-            keypair.pubkey(),
+            &keypair.pubkey(),
+            &keypair.pubkey(),
             Utc::now(),
             zero,
         );
@@ -560,7 +560,7 @@ mod tests {
     fn test_next_entry_panic() {
         let zero = Hash::default();
         let keypair = Keypair::new();
-        let tx = SystemTransaction::new_account(&keypair, keypair.pubkey(), 0, zero, 0);
+        let tx = SystemTransaction::new_account(&keypair, &keypair.pubkey(), 0, zero, 0);
         next_entry(&zero, 0, vec![tx]);
     }
 
@@ -568,7 +568,7 @@ mod tests {
     fn test_serialized_size() {
         let zero = Hash::default();
         let keypair = Keypair::new();
-        let tx = SystemTransaction::new_account(&keypair, keypair.pubkey(), 0, zero, 0);
+        let tx = SystemTransaction::new_account(&keypair, &keypair.pubkey(), 0, zero, 0);
         let entry = next_entry(&zero, 1, vec![tx.clone()]);
         assert_eq!(
             Entry::serialized_size(&[tx]),
@@ -596,11 +596,11 @@ mod tests {
         let one = hash(&zero.as_ref());
         let keypair = Keypair::new();
         let vote_account = Keypair::new();
-        let tx0 = VoteTransaction::new_vote(vote_account.pubkey(), &vote_account, 1, one, 1);
+        let tx0 = VoteTransaction::new_vote(&vote_account.pubkey(), &vote_account, 1, one, 1);
         let tx1 = BudgetTransaction::new_timestamp(
             &keypair,
-            keypair.pubkey(),
-            keypair.pubkey(),
+            &keypair.pubkey(),
+            &keypair.pubkey(),
             Utc::now(),
             one,
         );
@@ -645,8 +645,8 @@ mod tests {
         let keypair = Keypair::new();
         let vote_account = Keypair::new();
         let tx_small =
-            VoteTransaction::new_vote(vote_account.pubkey(), &vote_account, 1, next_hash, 2);
-        let tx_large = BudgetTransaction::new_payment(&keypair, keypair.pubkey(), 1, next_hash, 0);
+            VoteTransaction::new_vote(&vote_account.pubkey(), &vote_account, 1, next_hash, 2);
+        let tx_large = BudgetTransaction::new_payment(&keypair, &keypair.pubkey(), 1, next_hash, 0);
 
         let tx_small_size = tx_small.serialized_size().unwrap() as usize;
         let tx_large_size = tx_large.serialized_size().unwrap() as usize;

--- a/core/src/fullnode.rs
+++ b/core/src/fullnode.rs
@@ -81,7 +81,7 @@ impl Fullnode {
         mut node: Node,
         keypair: &Arc<Keypair>,
         ledger_path: &str,
-        vote_account: Pubkey,
+        vote_account: &Pubkey,
         voting_keypair: T,
         entrypoint_info_option: Option<&ContactInfo>,
         config: &FullnodeConfig,
@@ -208,7 +208,7 @@ impl Fullnode {
             &exit,
         );
         let tpu = Tpu::new(
-            id,
+            &id,
             &cluster_info,
             &poh_recorder,
             entry_receiver,
@@ -325,7 +325,7 @@ pub fn make_active_set_entries(
     // 1) Assume the active_keypair node has no lamports staked
     let transfer_tx = SystemTransaction::new_account(
         &lamport_source,
-        active_keypair.pubkey(),
+        &active_keypair.pubkey(),
         stake,
         *blockhash,
         0,
@@ -339,7 +339,7 @@ pub fn make_active_set_entries(
 
     let new_vote_account_tx = VoteTransaction::new_account(
         active_keypair,
-        vote_account_id,
+        &vote_account_id,
         *blockhash,
         stake.saturating_sub(2),
         1,
@@ -348,7 +348,7 @@ pub fn make_active_set_entries(
 
     // 3) Create vote entry
     let vote_tx = VoteTransaction::new_vote(
-        voting_keypair.pubkey(),
+        &voting_keypair.pubkey(),
         &voting_keypair,
         slot_to_vote_on,
         *blockhash,
@@ -373,12 +373,12 @@ mod tests {
     #[test]
     fn validator_exit() {
         let leader_keypair = Keypair::new();
-        let leader_node = Node::new_localhost_with_pubkey(leader_keypair.pubkey());
+        let leader_node = Node::new_localhost_with_pubkey(&leader_keypair.pubkey());
 
         let validator_keypair = Keypair::new();
-        let validator_node = Node::new_localhost_with_pubkey(validator_keypair.pubkey());
+        let validator_node = Node::new_localhost_with_pubkey(&validator_keypair.pubkey());
         let (genesis_block, _mint_keypair) =
-            GenesisBlock::new_with_leader(10_000, leader_keypair.pubkey(), 1000);
+            GenesisBlock::new_with_leader(10_000, &leader_keypair.pubkey(), 1000);
         let (validator_ledger_path, _blockhash) = create_new_tmp_ledger!(&genesis_block);
 
         let voting_keypair = Keypair::new();
@@ -386,7 +386,7 @@ mod tests {
             validator_node,
             &Arc::new(validator_keypair),
             &validator_ledger_path,
-            voting_keypair.pubkey(),
+            &voting_keypair.pubkey(),
             voting_keypair,
             Some(&leader_node.info),
             &FullnodeConfig::default(),
@@ -398,15 +398,15 @@ mod tests {
     #[test]
     fn validator_parallel_exit() {
         let leader_keypair = Keypair::new();
-        let leader_node = Node::new_localhost_with_pubkey(leader_keypair.pubkey());
+        let leader_node = Node::new_localhost_with_pubkey(&leader_keypair.pubkey());
 
         let mut ledger_paths = vec![];
         let validators: Vec<Fullnode> = (0..2)
             .map(|_| {
                 let validator_keypair = Keypair::new();
-                let validator_node = Node::new_localhost_with_pubkey(validator_keypair.pubkey());
+                let validator_node = Node::new_localhost_with_pubkey(&validator_keypair.pubkey());
                 let (genesis_block, _mint_keypair) =
-                    GenesisBlock::new_with_leader(10_000, leader_keypair.pubkey(), 1000);
+                    GenesisBlock::new_with_leader(10_000, &leader_keypair.pubkey(), 1000);
                 let (validator_ledger_path, _blockhash) = create_new_tmp_ledger!(&genesis_block);
                 ledger_paths.push(validator_ledger_path.clone());
                 let voting_keypair = Keypair::new();
@@ -414,7 +414,7 @@ mod tests {
                     validator_node,
                     &Arc::new(validator_keypair),
                     &validator_ledger_path,
-                    voting_keypair.pubkey(),
+                    &voting_keypair.pubkey(),
                     voting_keypair,
                     Some(&leader_node.info),
                     &FullnodeConfig::default(),

--- a/core/src/leader_confirmation_service.rs
+++ b/core/src/leader_confirmation_service.rs
@@ -139,7 +139,7 @@ mod tests {
                 bank.register_tick(&tick_hash);
             }
 
-            bank = Arc::new(Bank::new_from_parent(&bank, Pubkey::default(), slot));
+            bank = Arc::new(Bank::new_from_parent(&bank, &Pubkey::default(), slot));
         }
 
         let blockhash = bank.last_blockhash();
@@ -154,7 +154,7 @@ mod tests {
                 let voting_pubkey = voting_keypair.pubkey();
 
                 // Give the validator some lamports
-                bank.transfer(2, &mint_keypair, validator_keypair.pubkey(), blockhash)
+                bank.transfer(2, &mint_keypair, &validator_keypair.pubkey(), blockhash)
                     .unwrap();
                 new_vote_account(&validator_keypair, &voting_pubkey, &bank, 1);
 
@@ -173,7 +173,7 @@ mod tests {
         // Get another validator to vote, so we now have 2/3 consensus
         let voting_keypair = &vote_accounts[7].0;
         let vote_tx =
-            VoteTransaction::new_vote(voting_keypair.pubkey(), voting_keypair, 7, blockhash, 0);
+            VoteTransaction::new_vote(&voting_keypair.pubkey(), voting_keypair, 7, blockhash, 0);
         bank.process_transaction(&vote_tx).unwrap();
 
         LeaderConfirmationService::compute_confirmation(&bank, &mut last_confirmation_time);

--- a/core/src/leader_schedule_utils.rs
+++ b/core/src/leader_schedule_utils.rs
@@ -59,7 +59,7 @@ mod tests {
         let pubkey = Keypair::new().pubkey();
         let (genesis_block, _mint_keypair) = GenesisBlock::new_with_leader(
             BOOTSTRAP_LEADER_LAMPORTS,
-            pubkey,
+            &pubkey,
             BOOTSTRAP_LEADER_LAMPORTS,
         );
         let bank = Bank::new(&genesis_block);
@@ -79,7 +79,7 @@ mod tests {
         let pubkey = Keypair::new().pubkey();
         let genesis_block = GenesisBlock::new_with_leader(
             BOOTSTRAP_LEADER_LAMPORTS,
-            pubkey,
+            &pubkey,
             BOOTSTRAP_LEADER_LAMPORTS,
         )
         .0;

--- a/core/src/local_cluster.rs
+++ b/core/src/local_cluster.rs
@@ -39,9 +39,9 @@ impl LocalCluster {
     ) -> Self {
         let leader_keypair = Arc::new(Keypair::new());
         let leader_pubkey = leader_keypair.pubkey();
-        let leader_node = Node::new_localhost_with_pubkey(leader_keypair.pubkey());
+        let leader_node = Node::new_localhost_with_pubkey(&leader_keypair.pubkey());
         let (genesis_block, mint_keypair) =
-            GenesisBlock::new_with_leader(cluster_lamports, leader_pubkey, node_stakes[0]);
+            GenesisBlock::new_with_leader(cluster_lamports, &leader_pubkey, node_stakes[0]);
         let (genesis_ledger_path, _blockhash) = create_new_tmp_ledger!(&genesis_block);
         let leader_ledger_path = tmp_copy_blocktree!(&genesis_ledger_path);
         let mut ledger_paths = vec![];
@@ -53,7 +53,7 @@ impl LocalCluster {
             leader_node,
             &leader_keypair,
             &leader_ledger_path,
-            voting_keypair.pubkey(),
+            &voting_keypair.pubkey(),
             voting_keypair,
             None,
             fullnode_config,
@@ -66,7 +66,7 @@ impl LocalCluster {
             let validator_keypair = Arc::new(Keypair::new());
             let voting_keypair = Keypair::new();
             let validator_pubkey = validator_keypair.pubkey();
-            let validator_node = Node::new_localhost_with_pubkey(validator_keypair.pubkey());
+            let validator_node = Node::new_localhost_with_pubkey(&validator_keypair.pubkey());
             let ledger_path = tmp_copy_blocktree!(&genesis_ledger_path);
             ledger_paths.push(ledger_path.clone());
 
@@ -89,7 +89,7 @@ impl LocalCluster {
                 validator_node,
                 &validator_keypair,
                 &ledger_path,
-                voting_keypair.pubkey(),
+                &voting_keypair.pubkey(),
                 voting_keypair,
                 Some(&leader_contact_info),
                 fullnode_config,
@@ -134,7 +134,7 @@ impl LocalCluster {
         trace!("getting leader blockhash");
         let blockhash = client.get_recent_blockhash();
         let mut tx =
-            SystemTransaction::new_account(&source_keypair, *dest_pubkey, lamports, blockhash, 0);
+            SystemTransaction::new_account(&source_keypair, dest_pubkey, lamports, blockhash, 0);
         info!(
             "executing transfer of {} from {} to {}",
             lamports,
@@ -160,7 +160,7 @@ impl LocalCluster {
             // 1) Create vote account
             let mut transaction = VoteTransaction::new_account(
                 from_account,
-                vote_account_pubkey,
+                &vote_account_pubkey,
                 client.get_recent_blockhash(),
                 amount,
                 1,
@@ -175,7 +175,7 @@ impl LocalCluster {
             let mut transaction = VoteTransaction::delegate_vote_account(
                 vote_account,
                 client.get_recent_blockhash(),
-                delegate_id,
+                &delegate_id,
                 0,
             );
 

--- a/core/src/packet.rs
+++ b/core/src/packet.rs
@@ -524,7 +524,7 @@ mod tests {
     fn test_to_packets() {
         let keypair = Keypair::new();
         let hash = Hash::new(&[1; 32]);
-        let tx = SystemTransaction::new_account(&keypair, keypair.pubkey(), 1, hash, 0);
+        let tx = SystemTransaction::new_account(&keypair, &keypair.pubkey(), 1, hash, 0);
         let rv = to_packets(&vec![tx.clone(); 1]);
         assert_eq!(rv.len(), 1);
         assert_eq!(rv[0].read().unwrap().packets.len(), 1);

--- a/core/src/rpc_mock.rs
+++ b/core/src/rpc_mock.rs
@@ -28,7 +28,7 @@ impl MockRpcClient {
     pub fn retry_get_balance(
         &self,
         id: u64,
-        pubkey: Pubkey,
+        pubkey: &Pubkey,
         retries: usize,
     ) -> Result<Option<u64>, Box<dyn error::Error>> {
         let params = json!([format!("{}", pubkey)]);
@@ -106,6 +106,6 @@ pub fn request_airdrop_transaction(
     let key = Keypair::new();
     let to = Keypair::new().pubkey();
     let blockhash = Hash::default();
-    let tx = SystemTransaction::new_account(&key, to, lamports, blockhash, 0);
+    let tx = SystemTransaction::new_account(&key, &to, lamports, blockhash, 0);
     Ok(tx)
 }

--- a/core/src/rpc_pubsub.rs
+++ b/core/src/rpc_pubsub.rs
@@ -249,7 +249,7 @@ mod tests {
         // Simulate a block boundary
         Ok(Arc::new(Bank::new_from_parent(
             &bank,
-            Pubkey::default(),
+            &Pubkey::default(),
             bank.slot() + 1,
         )))
     }
@@ -270,7 +270,7 @@ mod tests {
         let rpc = RpcSolPubSubImpl::default();
 
         // Test signature subscriptions
-        let tx = SystemTransaction::new_move(&alice, bob_pubkey, 20, blockhash, 0);
+        let tx = SystemTransaction::new_move(&alice, &bob_pubkey, 20, blockhash, 0);
 
         let session = create_session();
         let (subscriber, _id_receiver, mut receiver) =
@@ -302,7 +302,7 @@ mod tests {
         let rpc = RpcSolPubSubImpl::default();
         io.extend_with(rpc.to_delegate());
 
-        let tx = SystemTransaction::new_move(&alice, bob_pubkey, 20, blockhash, 0);
+        let tx = SystemTransaction::new_move(&alice, &bob_pubkey, 20, blockhash, 0);
         let req = format!(
             r#"{{"jsonrpc":"2.0","id":1,"method":"signatureSubscribe","params":["{}"]}}"#,
             tx.signatures[0].to_string()
@@ -348,14 +348,14 @@ mod tests {
         let (subscriber, _id_receiver, mut receiver) = Subscriber::new_test("accountNotification");
         rpc.account_subscribe(session, subscriber, contract_state.pubkey().to_string());
 
-        let tx = SystemTransaction::new_account(&alice, contract_funds.pubkey(), 51, blockhash, 0);
+        let tx = SystemTransaction::new_account(&alice, &contract_funds.pubkey(), 51, blockhash, 0);
         let arc_bank = process_transaction_and_notify(&arc_bank, &tx, &rpc.subscriptions).unwrap();
 
         let tx = BudgetTransaction::new_when_signed(
             &contract_funds,
-            bob_pubkey,
-            contract_state.pubkey(),
-            witness.pubkey(),
+            &bob_pubkey,
+            &contract_state.pubkey(),
+            &witness.pubkey(),
             None,
             51,
             blockhash,
@@ -387,13 +387,13 @@ mod tests {
             assert_eq!(serde_json::to_string(&expected).unwrap(), response);
         }
 
-        let tx = SystemTransaction::new_account(&alice, witness.pubkey(), 1, blockhash, 0);
+        let tx = SystemTransaction::new_account(&alice, &witness.pubkey(), 1, blockhash, 0);
         let arc_bank = process_transaction_and_notify(&arc_bank, &tx, &rpc.subscriptions).unwrap();
         sleep(Duration::from_millis(200));
         let tx = BudgetTransaction::new_signature(
             &witness,
-            contract_state.pubkey(),
-            bob_pubkey,
+            &contract_state.pubkey(),
+            &bob_pubkey,
             blockhash,
         );
         let arc_bank = process_transaction_and_notify(&arc_bank, &tx, &rpc.subscriptions).unwrap();

--- a/core/src/rpc_request.rs
+++ b/core/src/rpc_request.rs
@@ -39,7 +39,7 @@ impl RpcClient {
     pub fn retry_get_balance(
         &self,
         id: u64,
-        pubkey: Pubkey,
+        pubkey: &Pubkey,
         retries: usize,
     ) -> Result<Option<u64>, Box<dyn error::Error>> {
         let params = json!([format!("{}", pubkey)]);

--- a/core/src/rpc_service.rs
+++ b/core/src/rpc_service.rs
@@ -123,7 +123,7 @@ mod tests {
                 .request_processor
                 .read()
                 .unwrap()
-                .get_balance(alice.pubkey())
+                .get_balance(&alice.pubkey())
                 .unwrap()
         );
         exit.store(true, Ordering::Relaxed);

--- a/core/src/rpc_subscriptions.rs
+++ b/core/src/rpc_subscriptions.rs
@@ -210,11 +210,11 @@ mod tests {
         let blockhash = bank.last_blockhash();
         let tx = SystemTransaction::new_program_account(
             &mint_keypair,
-            alice.pubkey(),
+            &alice.pubkey(),
             blockhash,
             1,
             16,
-            solana_budget_api::id(),
+            &solana_budget_api::id(),
             0,
         );
         bank.process_transaction(&tx).unwrap();
@@ -256,11 +256,11 @@ mod tests {
         let blockhash = bank.last_blockhash();
         let tx = SystemTransaction::new_program_account(
             &mint_keypair,
-            alice.pubkey(),
+            &alice.pubkey(),
             blockhash,
             1,
             16,
-            solana_budget_api::id(),
+            &solana_budget_api::id(),
             0,
         );
         bank.process_transaction(&tx).unwrap();
@@ -299,7 +299,7 @@ mod tests {
         let bank = Bank::new(&genesis_block);
         let alice = Keypair::new();
         let blockhash = bank.last_blockhash();
-        let tx = SystemTransaction::new_move(&mint_keypair, alice.pubkey(), 20, blockhash, 0);
+        let tx = SystemTransaction::new_move(&mint_keypair, &alice.pubkey(), 20, blockhash, 0);
         let signature = tx.signatures[0];
         bank.process_transaction(&tx).unwrap();
 

--- a/core/src/staking_utils.rs
+++ b/core/src/staking_utils.rs
@@ -146,7 +146,7 @@ mod tests {
     use std::sync::Arc;
 
     fn new_from_parent(parent: &Arc<Bank>, slot: u64) -> Bank {
-        Bank::new_from_parent(parent, Pubkey::default(), slot)
+        Bank::new_from_parent(parent, &Pubkey::default(), slot)
     }
 
     #[test]
@@ -154,7 +154,7 @@ mod tests {
         let pubkey = Keypair::new().pubkey();
         let bootstrap_lamports = 3;
         let (genesis_block, _) =
-            GenesisBlock::new_with_leader(bootstrap_lamports, pubkey, bootstrap_lamports);
+            GenesisBlock::new_with_leader(bootstrap_lamports, &pubkey, bootstrap_lamports);
         let bank = Bank::new(&genesis_block);
 
         // Epoch doesn't exist
@@ -184,7 +184,7 @@ mod tests {
         // Give the validator some stake but don't setup a staking account
         // Validator has no lamports staked, so they get filtered out. Only the bootstrap leader
         // created by the genesis block will get included
-        bank.transfer(1, &mint_keypair, validator.pubkey(), genesis_block.hash())
+        bank.transfer(1, &mint_keypair, &validator.pubkey(), genesis_block.hash())
             .unwrap();
 
         // Make a mint vote account. Because the mint has nonzero stake, this
@@ -266,11 +266,11 @@ mod tests {
 
         // Delegate 1 has stake of 3
         for i in 0..3 {
-            stakes.push((i, VoteState::new(delegate1)));
+            stakes.push((i, VoteState::new(&delegate1)));
         }
 
         // Delegate 1 has stake of 5
-        stakes.push((5, VoteState::new(delegate2)));
+        stakes.push((5, VoteState::new(&delegate2)));
 
         let result = to_delegated_stakes(stakes.into_iter());
         assert_eq!(result.len(), 2);

--- a/core/src/storage_stage.rs
+++ b/core/src/storage_stage.rs
@@ -474,7 +474,7 @@ mod tests {
         let keypair = Arc::new(Keypair::new());
         let exit = Arc::new(AtomicBool::new(false));
 
-        let cluster_info = test_cluster_info(keypair.pubkey());
+        let cluster_info = test_cluster_info(&keypair.pubkey());
 
         let (_storage_entry_sender, storage_entry_receiver) = channel();
         let storage_state = StorageState::new();
@@ -492,7 +492,7 @@ mod tests {
         storage_stage.join().unwrap();
     }
 
-    fn test_cluster_info(id: Pubkey) -> Arc<RwLock<ClusterInfo>> {
+    fn test_cluster_info(id: &Pubkey) -> Arc<RwLock<ClusterInfo>> {
         let contact_info = ContactInfo::new_localhost(id, 0);
         let cluster_info = ClusterInfo::new_with_invalid_keypair(contact_info);
         Arc::new(RwLock::new(cluster_info))
@@ -512,7 +512,7 @@ mod tests {
         let blocktree = Blocktree::open_config(&ledger_path, ticks_per_slot).unwrap();
         blocktree.write_entries(1, 0, 0, &entries).unwrap();
 
-        let cluster_info = test_cluster_info(keypair.pubkey());
+        let cluster_info = test_cluster_info(&keypair.pubkey());
 
         let (storage_entry_sender, storage_entry_receiver) = channel();
         let storage_state = StorageState::new();
@@ -574,7 +574,7 @@ mod tests {
         let blocktree = Blocktree::open_config(&ledger_path, ticks_per_slot).unwrap();
         blocktree.write_entries(1, 0, 0, &entries).unwrap();
 
-        let cluster_info = test_cluster_info(keypair.pubkey());
+        let cluster_info = test_cluster_info(&keypair.pubkey());
 
         let (storage_entry_sender, storage_entry_receiver) = channel();
         let storage_state = StorageState::new();
@@ -599,7 +599,7 @@ mod tests {
         let mut vote_txs: Vec<_> = Vec::new();
         let keypair = Keypair::new();
         let vote_tx =
-            VoteTransaction::new_vote(keypair.pubkey(), &keypair, 123456, Hash::default(), 1);
+            VoteTransaction::new_vote(&keypair.pubkey(), &keypair, 123456, Hash::default(), 1);
         vote_txs.push(vote_tx);
         let vote_entries = vec![Entry::new(&Hash::default(), 1, vote_txs)];
         storage_entry_sender.send(vote_entries).unwrap();

--- a/core/src/test_tx.rs
+++ b/core/src/test_tx.rs
@@ -7,5 +7,5 @@ pub fn test_tx() -> Transaction {
     let keypair1 = Keypair::new();
     let pubkey1 = keypair1.pubkey();
     let zero = Hash::default();
-    SystemTransaction::new_account(&keypair1, pubkey1, 42, zero, 0)
+    SystemTransaction::new_account(&keypair1, &pubkey1, 42, zero, 0)
 }

--- a/core/src/thin_client.rs
+++ b/core/src/thin_client.rs
@@ -119,7 +119,7 @@ impl ThinClient {
         &self,
         lamports: u64,
         keypair: &Keypair,
-        to: Pubkey,
+        to: &Pubkey,
         blockhash: &Hash,
     ) -> io::Result<Signature> {
         debug!(
@@ -420,10 +420,10 @@ pub fn new_fullnode() -> (Fullnode, ContactInfo, Keypair, String) {
     use solana_sdk::signature::KeypairUtil;
 
     let node_keypair = Arc::new(Keypair::new());
-    let node = Node::new_localhost_with_pubkey(node_keypair.pubkey());
+    let node = Node::new_localhost_with_pubkey(&node_keypair.pubkey());
     let contact_info = node.info.clone();
 
-    let (genesis_block, mint_keypair) = GenesisBlock::new_with_leader(10_000, contact_info.id, 42);
+    let (genesis_block, mint_keypair) = GenesisBlock::new_with_leader(10_000, &contact_info.id, 42);
     let (ledger_path, _blockhash) = create_new_tmp_ledger!(&genesis_block);
 
     let voting_keypair = Keypair::new();
@@ -431,7 +431,7 @@ pub fn new_fullnode() -> (Fullnode, ContactInfo, Keypair, String) {
         node,
         &node_keypair,
         &ledger_path,
-        voting_keypair.pubkey(),
+        &voting_keypair.pubkey(),
         voting_keypair,
         None,
         &FullnodeConfig::default(),
@@ -467,7 +467,7 @@ mod tests {
         info!("test_thin_client blockhash: {:?}", blockhash);
 
         let signature = client
-            .transfer(500, &alice, bob_pubkey, &blockhash)
+            .transfer(500, &alice, &bob_pubkey, &blockhash)
             .unwrap();
         info!("test_thin_client signature: {:?}", signature);
         client.poll_for_signature(&signature).unwrap();
@@ -493,13 +493,13 @@ mod tests {
 
         let blockhash = client.get_recent_blockhash();
 
-        let tx = SystemTransaction::new_account(&alice, bob_pubkey, 500, blockhash, 0);
+        let tx = SystemTransaction::new_account(&alice, &bob_pubkey, 500, blockhash, 0);
 
         let _sig = client.transfer_signed(&tx).unwrap();
 
         let blockhash = client.get_recent_blockhash();
 
-        let mut tr2 = SystemTransaction::new_account(&alice, bob_pubkey, 501, blockhash, 0);
+        let mut tr2 = SystemTransaction::new_account(&alice, &bob_pubkey, 501, blockhash, 0);
         let mut instruction2 = deserialize(tr2.userdata(0)).unwrap();
         if let SystemInstruction::Move { ref mut lamports } = instruction2 {
             *lamports = 502;
@@ -526,7 +526,7 @@ mod tests {
         let validator_keypair = Keypair::new();
         let blockhash = client.get_recent_blockhash();
         let signature = client
-            .transfer(500, &alice, validator_keypair.pubkey(), &blockhash)
+            .transfer(500, &alice, &validator_keypair.pubkey(), &blockhash)
             .unwrap();
 
         client.poll_for_signature(&signature).unwrap();
@@ -537,7 +537,7 @@ mod tests {
         let blockhash = client.get_recent_blockhash();
 
         let transaction =
-            VoteTransaction::new_account(&validator_keypair, vote_account_id, blockhash, 1, 1);
+            VoteTransaction::new_account(&validator_keypair, &vote_account_id, blockhash, 1, 1);
         let signature = client.transfer_signed(&transaction).unwrap();
         client.poll_for_signature(&signature).unwrap();
 
@@ -595,7 +595,7 @@ mod tests {
 
         info!("Give Bob 500 lamports");
         let signature = client
-            .transfer(500, &alice, bob_keypair.pubkey(), &blockhash)
+            .transfer(500, &alice, &bob_keypair.pubkey(), &blockhash)
             .unwrap();
         client.poll_for_signature(&signature).unwrap();
 
@@ -604,7 +604,7 @@ mod tests {
 
         info!("Take Bob's 500 lamports away");
         let signature = client
-            .transfer(500, &bob_keypair, alice.pubkey(), &blockhash)
+            .transfer(500, &bob_keypair, &alice.pubkey(), &blockhash)
             .unwrap();
         client.poll_for_signature(&signature).unwrap();
         let alice_balance = client.poll_get_balance(&alice.pubkey()).unwrap();

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -27,7 +27,7 @@ pub struct Tpu {
 
 impl Tpu {
     pub fn new(
-        id: Pubkey,
+        id: &Pubkey,
         cluster_info: &Arc<RwLock<ClusterInfo>>,
         poh_recorder: &Arc<Mutex<PohRecorder>>,
         entry_receiver: Receiver<WorkingBankEntries>,

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -55,7 +55,7 @@ impl Tvu {
     /// * `blocktree` - the ledger itself
     #[allow(clippy::new_ret_no_self, clippy::too_many_arguments)]
     pub fn new<T>(
-        vote_account: Pubkey,
+        vote_account: &Pubkey,
         voting_keypair: Option<Arc<T>>,
         bank_forks: &Arc<RwLock<BankForks>>,
         bank_forks_info: &[BankForksInfo],
@@ -107,7 +107,7 @@ impl Tvu {
         );
 
         let (replay_stage, slot_full_receiver, forward_entry_receiver) = ReplayStage::new(
-            keypair.pubkey(),
+            &keypair.pubkey(),
             vote_account,
             voting_keypair,
             blocktree.clone(),
@@ -183,7 +183,7 @@ pub mod tests {
         solana_logger::setup();
         let leader = Node::new_localhost();
         let target1_keypair = Keypair::new();
-        let target1 = Node::new_localhost_with_pubkey(target1_keypair.pubkey());
+        let target1 = Node::new_localhost_with_pubkey(&target1_keypair.pubkey());
 
         let starting_balance = 10_000;
         let (genesis_block, _mint_keypair) = GenesisBlock::new(starting_balance);
@@ -206,7 +206,7 @@ pub mod tests {
         let (exit, poh_recorder, poh_service, _entry_receiver) = create_test_recorder(&bank);
         let voting_keypair = Keypair::new();
         let tvu = Tvu::new(
-            voting_keypair.pubkey(),
+            &voting_keypair.pubkey(),
             Some(Arc::new(voting_keypair)),
             &Arc::new(RwLock::new(bank_forks)),
             &bank_forks_info,

--- a/core/src/voting_keypair.rs
+++ b/core/src/voting_keypair.rs
@@ -23,7 +23,7 @@ impl RemoteVoteSigner {
 impl VoteSigner for RemoteVoteSigner {
     fn register(
         &self,
-        pubkey: Pubkey,
+        pubkey: &Pubkey,
         sig: &Signature,
         msg: &[u8],
     ) -> jsonrpc_core::Result<Pubkey> {
@@ -35,7 +35,12 @@ impl VoteSigner for RemoteVoteSigner {
         let vote_account: Pubkey = serde_json::from_value(resp).unwrap();
         Ok(vote_account)
     }
-    fn sign(&self, pubkey: Pubkey, sig: &Signature, msg: &[u8]) -> jsonrpc_core::Result<Signature> {
+    fn sign(
+        &self,
+        pubkey: &Pubkey,
+        sig: &Signature,
+        msg: &[u8],
+    ) -> jsonrpc_core::Result<Signature> {
         let params = json!([pubkey, sig, msg]);
         let resp = self
             .rpc_client
@@ -44,7 +49,7 @@ impl VoteSigner for RemoteVoteSigner {
         let vote_signature: Signature = serde_json::from_value(resp).unwrap();
         Ok(vote_signature)
     }
-    fn deregister(&self, pubkey: Pubkey, sig: &Signature, msg: &[u8]) -> jsonrpc_core::Result<()> {
+    fn deregister(&self, pubkey: &Pubkey, sig: &Signature, msg: &[u8]) -> jsonrpc_core::Result<()> {
         let params = json!([pubkey, sig, msg]);
         let _resp = self
             .rpc_client
@@ -70,7 +75,9 @@ impl KeypairUtil for VotingKeypair {
 
     fn sign_message(&self, msg: &[u8]) -> Signature {
         let sig = self.keypair.sign_message(msg);
-        self.signer.sign(self.keypair.pubkey(), &sig, &msg).unwrap()
+        self.signer
+            .sign(&self.keypair.pubkey(), &sig, &msg)
+            .unwrap()
     }
 }
 
@@ -85,7 +92,7 @@ impl VotingKeypair {
         let msg = "Registering a new node";
         let sig = keypair.sign_message(msg.as_bytes());
         let vote_account = signer
-            .register(keypair.pubkey(), &sig, msg.as_bytes())
+            .register(&keypair.pubkey(), &sig, msg.as_bytes())
             .unwrap();
         Self {
             keypair: keypair.clone(),
@@ -109,14 +116,14 @@ pub mod tests {
         lamports: u64,
     ) {
         let blockhash = bank.last_blockhash();
-        let tx = VoteTransaction::new_account(from_keypair, *voting_pubkey, blockhash, lamports, 0);
+        let tx = VoteTransaction::new_account(from_keypair, voting_pubkey, blockhash, lamports, 0);
         bank.process_transaction(&tx).unwrap();
     }
 
     pub fn push_vote<T: KeypairUtil>(voting_keypair: &T, bank: &Bank, slot: u64) {
         let blockhash = bank.last_blockhash();
         let tx =
-            VoteTransaction::new_vote(voting_keypair.pubkey(), voting_keypair, slot, blockhash, 0);
+            VoteTransaction::new_vote(&voting_keypair.pubkey(), voting_keypair, slot, blockhash, 0);
         bank.process_transaction(&tx).unwrap();
     }
 

--- a/drone/src/drone.rs
+++ b/drone/src/drone.rs
@@ -135,7 +135,7 @@ impl Drone {
                     let mut transaction = Transaction::new(
                         &self.mint_keypair,
                         &[to],
-                        system_program::id(),
+                        &system_program::id(),
                         &create_instruction,
                         blockhash,
                         0, /*fee*/
@@ -411,7 +411,7 @@ mod tests {
         let mut expected_tx = Transaction::new(
             &keypair,
             &[to],
-            system_program::id(),
+            &system_program::id(),
             &expected_instruction,
             blockhash,
             0,

--- a/drone/tests/local-drone.rs
+++ b/drone/tests/local-drone.rs
@@ -20,7 +20,7 @@ fn test_local_drone() {
     let mut expected_tx = Transaction::new(
         &keypair,
         &[to],
-        system_program::id(),
+        &system_program::id(),
         &expected_instruction,
         blockhash,
         0,

--- a/fullnode/src/main.rs
+++ b/fullnode/src/main.rs
@@ -229,7 +229,7 @@ fn main() {
     fullnode_config.blockstream = matches.value_of("blockstream").map(|s| s.to_string());
 
     let keypair = Arc::new(keypair);
-    let mut node = Node::new_with_external_ip(keypair.pubkey(), &gossip_addr);
+    let mut node = Node::new_with_external_ip(&keypair.pubkey(), &gossip_addr);
     node.info.rpc.set_port(rpc_port);
     node.info.rpc_pubsub.set_port(rpc_pubsub_port);
 
@@ -242,7 +242,7 @@ fn main() {
         node,
         &keypair,
         ledger_path,
-        staking_account,
+        &staking_account,
         voting_keypair,
         cluster_entrypoint.as_ref(),
         &fullnode_config,

--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -69,7 +69,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
     let bootstrap_leader_vote_account_keypair = Keypair::new();
     let (mut genesis_block, _mint_keypair) = GenesisBlock::new_with_leader(
         lamports,
-        bootstrap_leader_keypair.pubkey(),
+        &bootstrap_leader_keypair.pubkey(),
         BOOTSTRAP_LEADER_LAMPORTS,
     );
     genesis_block.mint_id = mint_keypair.pubkey();

--- a/ledger-tool/tests/basic.rs
+++ b/ledger-tool/tests/basic.rs
@@ -35,7 +35,7 @@ fn bad_arguments() {
 #[test]
 fn nominal() {
     let keypair = Arc::new(Keypair::new());
-    let (genesis_block, _mint_keypair) = GenesisBlock::new_with_leader(100, keypair.pubkey(), 50);
+    let (genesis_block, _mint_keypair) = GenesisBlock::new_with_leader(100, &keypair.pubkey(), 50);
     let ticks_per_slot = genesis_block.ticks_per_slot;
 
     let (ledger_path, _blockhash) = create_new_tmp_ledger!(&genesis_block);

--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -42,11 +42,11 @@ mod bpf {
             let bank = Bank::new(&genesis_block);
 
             // Call user program
-            let program_id = load_program(&bank, &mint_keypair, bpf_loader::id(), elf);
+            let program_id = load_program(&bank, &mint_keypair, &bpf_loader::id(), elf);
             let tx = Transaction::new(
                 &mint_keypair,
                 &[],
-                program_id,
+                &program_id,
                 &vec![1u8],
                 bank.last_blockhash(),
                 0,
@@ -80,16 +80,16 @@ mod bpf {
                 let loader_id = load_program(
                     &bank,
                     &mint_keypair,
-                    native_loader::id(),
+                    &native_loader::id(),
                     "solana_bpf_loader".as_bytes().to_vec(),
                 );
 
                 // Call user program
-                let program_id = load_program(&bank, &mint_keypair, loader_id, elf);
+                let program_id = load_program(&bank, &mint_keypair, &loader_id, elf);
                 let tx = Transaction::new(
                     &mint_keypair,
                     &[],
-                    program_id,
+                    &program_id,
                     &vec![1u8],
                     bank.last_blockhash(),
                     0,
@@ -126,16 +126,16 @@ mod bpf {
                 let loader_id = load_program(
                     &bank,
                     &mint_keypair,
-                    native_loader::id(),
+                    &native_loader::id(),
                     "solana_bpf_loader".as_bytes().to_vec(),
                 );
 
                 // Call user program
-                let program_id = load_program(&bank, &mint_keypair, loader_id, elf);
+                let program_id = load_program(&bank, &mint_keypair, &loader_id, elf);
                 let tx = Transaction::new(
                     &mint_keypair,
                     &[],
-                    program_id,
+                    &program_id,
                     &vec![1u8],
                     bank.last_blockhash(),
                     0,

--- a/programs/budget/tests/budget.rs
+++ b/programs/budget/tests/budget.rs
@@ -14,7 +14,7 @@ impl<'a> BudgetBank<'a> {
         Self { bank }
     }
 
-    fn pay(&self, from_keypair: &Keypair, to_id: Pubkey, lamports: u64) -> Result<()> {
+    fn pay(&self, from_keypair: &Keypair, to_id: &Pubkey, lamports: u64) -> Result<()> {
         let blockhash = self.bank.last_blockhash();
         let tx = BudgetTransaction::new_payment(from_keypair, to_id, lamports, blockhash, 0);
         self.bank.process_transaction(&tx)
@@ -27,6 +27,6 @@ fn test_budget_payment_via_bank() {
     let bank = Bank::new(&genesis_block);
     let budget_bank = BudgetBank::new(&bank);
     let to_id = Keypair::new().pubkey();
-    budget_bank.pay(&from_keypair, to_id, 100).unwrap();
+    budget_bank.pay(&from_keypair, &to_id, 100).unwrap();
     assert_eq!(bank.get_balance(&to_id), 100);
 }

--- a/programs/budget_api/src/budget_instruction.rs
+++ b/programs/budget_api/src/budget_instruction.rs
@@ -28,32 +28,36 @@ pub enum BudgetInstruction {
 }
 
 impl BudgetInstruction {
-    pub fn new_initialize_account(contract: Pubkey, expr: BudgetExpr) -> BuilderInstruction {
+    pub fn new_initialize_account(contract: &Pubkey, expr: BudgetExpr) -> BuilderInstruction {
         let mut keys = vec![];
         if let BudgetExpr::Pay(payment) = &expr {
             keys.push((payment.to, false));
         }
-        keys.push((contract, false));
+        keys.push((*contract, false));
         BuilderInstruction::new(id(), &BudgetInstruction::InitializeAccount(expr), keys)
     }
 
     pub fn new_apply_timestamp(
-        from: Pubkey,
-        contract: Pubkey,
-        to: Pubkey,
+        from: &Pubkey,
+        contract: &Pubkey,
+        to: &Pubkey,
         dt: DateTime<Utc>,
     ) -> BuilderInstruction {
-        let mut keys = vec![(from, true), (contract, false)];
+        let mut keys = vec![(*from, true), (*contract, false)];
         if from != to {
-            keys.push((to, false));
+            keys.push((*to, false));
         }
         BuilderInstruction::new(id(), &BudgetInstruction::ApplyTimestamp(dt), keys)
     }
 
-    pub fn new_apply_signature(from: Pubkey, contract: Pubkey, to: Pubkey) -> BuilderInstruction {
-        let mut keys = vec![(from, true), (contract, false)];
+    pub fn new_apply_signature(
+        from: &Pubkey,
+        contract: &Pubkey,
+        to: &Pubkey,
+    ) -> BuilderInstruction {
+        let mut keys = vec![(*from, true), (*contract, false)];
         if from != to {
-            keys.push((to, false));
+            keys.push((*to, false));
         }
         BuilderInstruction::new(id(), &BudgetInstruction::ApplySignature, keys)
     }

--- a/programs/budget_api/src/budget_state.rs
+++ b/programs/budget_api/src/budget_state.rs
@@ -54,7 +54,7 @@ mod test {
 
     #[test]
     fn test_serializer() {
-        let mut a = Account::new(0, 512, id());
+        let mut a = Account::new(0, 512, &id());
         let b = BudgetState::default();
         b.serialize(&mut a.userdata).unwrap();
         let c = BudgetState::deserialize(&a.userdata).unwrap();
@@ -63,7 +63,7 @@ mod test {
 
     #[test]
     fn test_serializer_userdata_too_small() {
-        let mut a = Account::new(0, 1, id());
+        let mut a = Account::new(0, 1, &id());
         let b = BudgetState::default();
         assert_eq!(
             b.serialize(&mut a.userdata),

--- a/programs/budget_api/src/budget_transaction.rs
+++ b/programs/budget_api/src/budget_transaction.rs
@@ -20,7 +20,7 @@ impl BudgetTransaction {
     #[allow(clippy::new_ret_no_self)]
     fn new(
         from_keypair: &Keypair,
-        contract: Pubkey,
+        contract: &Pubkey,
         expr: BudgetExpr,
         lamports: u64,
         recent_blockhash: Hash,
@@ -30,11 +30,11 @@ impl BudgetTransaction {
         let space = serialized_size(&BudgetState::new(expr.clone())).unwrap();
         TransactionBuilder::new(fee)
             .push(SystemInstruction::new_program_account(
-                from,
+                &from,
                 contract,
                 lamports,
                 space,
-                id(),
+                &id(),
             ))
             .push(BudgetInstruction::new_initialize_account(contract, expr))
             .sign(&[from_keypair], recent_blockhash)
@@ -43,7 +43,7 @@ impl BudgetTransaction {
     /// Create and sign a new Transaction. Used for unit-testing.
     pub fn new_payment(
         from_keypair: &Keypair,
-        to: Pubkey,
+        to: &Pubkey,
         lamports: u64,
         recent_blockhash: Hash,
         fee: u64,
@@ -52,7 +52,7 @@ impl BudgetTransaction {
         let expr = BudgetExpr::new_payment(lamports, to);
         Self::new(
             from_keypair,
-            contract,
+            &contract,
             expr,
             lamports,
             recent_blockhash,
@@ -63,15 +63,15 @@ impl BudgetTransaction {
     /// Create and sign a new Witness Timestamp. Used for unit-testing.
     pub fn new_timestamp(
         from_keypair: &Keypair,
-        contract: Pubkey,
-        to: Pubkey,
+        contract: &Pubkey,
+        to: &Pubkey,
         dt: DateTime<Utc>,
         recent_blockhash: Hash,
     ) -> Transaction {
         let from = from_keypair.pubkey();
         TransactionBuilder::default()
             .push(BudgetInstruction::new_apply_timestamp(
-                from, contract, to, dt,
+                &from, contract, to, dt,
             ))
             .sign(&[from_keypair], recent_blockhash)
     }
@@ -79,23 +79,23 @@ impl BudgetTransaction {
     /// Create and sign a new Witness Signature. Used for unit-testing.
     pub fn new_signature(
         from_keypair: &Keypair,
-        contract: Pubkey,
-        to: Pubkey,
+        contract: &Pubkey,
+        to: &Pubkey,
         recent_blockhash: Hash,
     ) -> Transaction {
         let from = from_keypair.pubkey();
         TransactionBuilder::default()
-            .push(BudgetInstruction::new_apply_signature(from, contract, to))
+            .push(BudgetInstruction::new_apply_signature(&from, contract, to))
             .sign(&[from_keypair], recent_blockhash)
     }
 
     /// Create and sign a postdated Transaction. Used for unit-testing.
     pub fn new_on_date(
         from_keypair: &Keypair,
-        to: Pubkey,
-        contract: Pubkey,
+        to: &Pubkey,
+        contract: &Pubkey,
         dt: DateTime<Utc>,
-        dt_pubkey: Pubkey,
+        dt_pubkey: &Pubkey,
         cancelable: Option<Pubkey>,
         lamports: u64,
         recent_blockhash: Hash,
@@ -103,17 +103,17 @@ impl BudgetTransaction {
         let expr = if let Some(from) = cancelable {
             BudgetExpr::Or(
                 (
-                    Condition::Timestamp(dt, dt_pubkey),
+                    Condition::Timestamp(dt, *dt_pubkey),
                     Box::new(BudgetExpr::new_payment(lamports, to)),
                 ),
                 (
                     Condition::Signature(from),
-                    Box::new(BudgetExpr::new_payment(lamports, from)),
+                    Box::new(BudgetExpr::new_payment(lamports, &from)),
                 ),
             )
         } else {
             BudgetExpr::After(
-                Condition::Timestamp(dt, dt_pubkey),
+                Condition::Timestamp(dt, *dt_pubkey),
                 Box::new(BudgetExpr::new_payment(lamports, to)),
             )
         };
@@ -123,9 +123,9 @@ impl BudgetTransaction {
     /// Create and sign a multisig Transaction.
     pub fn new_when_signed(
         from_keypair: &Keypair,
-        to: Pubkey,
-        contract: Pubkey,
-        witness: Pubkey,
+        to: &Pubkey,
+        contract: &Pubkey,
+        witness: &Pubkey,
         cancelable: Option<Pubkey>,
         lamports: u64,
         recent_blockhash: Hash,
@@ -133,17 +133,17 @@ impl BudgetTransaction {
         let expr = if let Some(from) = cancelable {
             BudgetExpr::Or(
                 (
-                    Condition::Signature(witness),
+                    Condition::Signature(*witness),
                     Box::new(BudgetExpr::new_payment(lamports, to)),
                 ),
                 (
                     Condition::Signature(from),
-                    Box::new(BudgetExpr::new_payment(lamports, from)),
+                    Box::new(BudgetExpr::new_payment(lamports, &from)),
                 ),
             )
         } else {
             BudgetExpr::After(
-                Condition::Signature(witness),
+                Condition::Signature(*witness),
                 Box::new(BudgetExpr::new_payment(lamports, to)),
             )
         };
@@ -184,7 +184,7 @@ mod tests {
     fn test_claim() {
         let keypair = Keypair::new();
         let zero = Hash::default();
-        let tx0 = BudgetTransaction::new_payment(&keypair, keypair.pubkey(), 42, zero, 0);
+        let tx0 = BudgetTransaction::new_payment(&keypair, &keypair.pubkey(), 42, zero, 0);
         assert!(BudgetTransaction::verify_plan(&tx0));
     }
 
@@ -194,7 +194,7 @@ mod tests {
         let keypair0 = Keypair::new();
         let keypair1 = Keypair::new();
         let pubkey1 = keypair1.pubkey();
-        let tx0 = BudgetTransaction::new_payment(&keypair0, pubkey1, 42, zero, 0);
+        let tx0 = BudgetTransaction::new_payment(&keypair0, &pubkey1, 42, zero, 0);
         assert!(BudgetTransaction::verify_plan(&tx0));
     }
 
@@ -203,7 +203,7 @@ mod tests {
         let zero = Hash::default();
         let keypair0 = Keypair::new();
         let pubkey1 = Keypair::new().pubkey();
-        let tx0 = BudgetTransaction::new_payment(&keypair0, pubkey1, 1, zero, 1);
+        let tx0 = BudgetTransaction::new_payment(&keypair0, &pubkey1, 1, zero, 1);
         assert!(BudgetTransaction::verify_plan(&tx0));
     }
 
@@ -212,7 +212,7 @@ mod tests {
         let zero = Hash::default();
         let keypair0 = Keypair::new();
         let pubkey1 = Keypair::new().pubkey();
-        let tx0 = BudgetTransaction::new_payment(&keypair0, pubkey1, 1, zero, 1);
+        let tx0 = BudgetTransaction::new_payment(&keypair0, &pubkey1, 1, zero, 1);
         let buf = serialize(&tx0).unwrap();
         let tx1: Transaction = deserialize(&buf).unwrap();
         assert_eq!(tx1, tx0);
@@ -223,7 +223,7 @@ mod tests {
         let zero = Hash::default();
         let keypair = Keypair::new();
         let pubkey = keypair.pubkey();
-        let mut tx = BudgetTransaction::new_payment(&keypair, pubkey, 42, zero, 0);
+        let mut tx = BudgetTransaction::new_payment(&keypair, &pubkey, 42, zero, 0);
         let mut system_instruction = BudgetTransaction::system_instruction(&tx, 0).unwrap();
         if let SystemInstruction::CreateAccount {
             ref mut lamports, ..
@@ -250,7 +250,7 @@ mod tests {
         let thief_keypair = Keypair::new();
         let pubkey1 = keypair1.pubkey();
         let zero = Hash::default();
-        let mut tx = BudgetTransaction::new_payment(&keypair0, pubkey1, 42, zero, 0);
+        let mut tx = BudgetTransaction::new_payment(&keypair0, &pubkey1, 42, zero, 0);
         let mut instruction = BudgetTransaction::instruction(&tx, 1);
         if let Some(BudgetInstruction::InitializeAccount(ref mut expr)) = instruction {
             if let BudgetExpr::Pay(ref mut payment) = expr {
@@ -267,7 +267,7 @@ mod tests {
         let keypair0 = Keypair::new();
         let keypair1 = Keypair::new();
         let zero = Hash::default();
-        let mut tx = BudgetTransaction::new_payment(&keypair0, keypair1.pubkey(), 1, zero, 0);
+        let mut tx = BudgetTransaction::new_payment(&keypair0, &keypair1.pubkey(), 1, zero, 0);
         let mut instruction = BudgetTransaction::instruction(&tx, 1).unwrap();
         if let BudgetInstruction::InitializeAccount(ref mut expr) = instruction {
             if let BudgetExpr::Pay(ref mut payment) = expr {

--- a/programs/failure/tests/failure.rs
+++ b/programs/failure/tests/failure.rs
@@ -12,13 +12,13 @@ fn test_program_native_failure() {
     let bank = Bank::new(&genesis_block);
 
     let program = "failure".as_bytes().to_vec();
-    let program_id = load_program(&bank, &mint_keypair, native_loader::id(), program);
+    let program_id = load_program(&bank, &mint_keypair, &native_loader::id(), program);
 
     // Call user program
     let tx = Transaction::new(
         &mint_keypair,
         &[],
-        program_id,
+        &program_id,
         &1u8,
         bank.last_blockhash(),
         0,

--- a/programs/noop/tests/noop.rs
+++ b/programs/noop/tests/noop.rs
@@ -12,13 +12,13 @@ fn test_program_native_noop() {
     let bank = Bank::new(&genesis_block);
 
     let program = "noop".as_bytes().to_vec();
-    let program_id = load_program(&bank, &mint_keypair, native_loader::id(), program);
+    let program_id = load_program(&bank, &mint_keypair, &native_loader::id(), program);
 
     // Call user program
     let tx = Transaction::new(
         &mint_keypair,
         &[],
-        program_id,
+        &program_id,
         &1u8,
         bank.last_blockhash(),
         0,

--- a/programs/rewards/src/lib.rs
+++ b/programs/rewards/src/lib.rs
@@ -92,7 +92,7 @@ mod tests {
 
     fn create_rewards_account(lamports: u64) -> Account {
         let space = RewardsState::max_size();
-        Account::new(lamports, space, solana_rewards_api::id())
+        Account::new(lamports, space, &solana_rewards_api::id())
     }
 
     fn redeem_vote_credits_(

--- a/programs/rewards_api/src/rewards_instruction.rs
+++ b/programs/rewards_api/src/rewards_instruction.rs
@@ -9,11 +9,11 @@ pub enum RewardsInstruction {
 }
 
 impl RewardsInstruction {
-    pub fn new_redeem_vote_credits(vote_id: Pubkey, rewards_id: Pubkey) -> BuilderInstruction {
+    pub fn new_redeem_vote_credits(vote_id: &Pubkey, rewards_id: &Pubkey) -> BuilderInstruction {
         BuilderInstruction::new(
             id(),
             &RewardsInstruction::RedeemVoteCredits,
-            vec![(vote_id, true), (rewards_id, false)],
+            vec![(*vote_id, true), (*rewards_id, false)],
         )
     }
 }

--- a/programs/rewards_api/src/rewards_transaction.rs
+++ b/programs/rewards_api/src/rewards_transaction.rs
@@ -17,7 +17,7 @@ pub struct RewardsTransaction {}
 impl RewardsTransaction {
     pub fn new_account(
         from_keypair: &Keypair,
-        rewards_id: Pubkey,
+        rewards_id: &Pubkey,
         blockhash: Hash,
         lamports: u64,
         fee: u64,
@@ -28,23 +28,23 @@ impl RewardsTransaction {
             blockhash,
             lamports,
             RewardsState::max_size() as u64,
-            id(),
+            &id(),
             fee,
         )
     }
 
     pub fn new_redeem_credits(
         vote_keypair: &Keypair,
-        rewards_id: Pubkey,
+        rewards_id: &Pubkey,
         blockhash: Hash,
         fee: u64,
     ) -> Transaction {
         let vote_id = vote_keypair.pubkey();
         TransactionBuilder::new(fee)
             .push(RewardsInstruction::new_redeem_vote_credits(
-                vote_id, rewards_id,
+                &vote_id, rewards_id,
             ))
-            .push(VoteInstruction::new_clear_credits(vote_id))
+            .push(VoteInstruction::new_clear_credits(&vote_id))
             .sign(&[vote_keypair], blockhash)
     }
 }

--- a/programs/storage/tests/storage.rs
+++ b/programs/storage/tests/storage.rs
@@ -8,7 +8,7 @@ use solana_sdk::signature::{Keypair, KeypairUtil};
 use solana_sdk::system_transaction::SystemTransaction;
 use solana_storage_api::{StorageTransaction, ENTRIES_PER_SEGMENT};
 
-fn get_storage_entry_height(bank: &Bank, account: Pubkey) -> u64 {
+fn get_storage_entry_height(bank: &Bank, account: &Pubkey) -> u64 {
     match bank.get_account(&account) {
         Some(storage_system_account) => {
             let state = deserialize(&storage_system_account.userdata);
@@ -24,7 +24,7 @@ fn get_storage_entry_height(bank: &Bank, account: Pubkey) -> u64 {
     0
 }
 
-fn get_storage_blockhash(bank: &Bank, account: Pubkey) -> Hash {
+fn get_storage_blockhash(bank: &Bank, account: &Pubkey) -> Hash {
     if let Some(storage_system_account) = bank.get_account(&account) {
         let state = deserialize(&storage_system_account.userdata);
         if let Ok(state) = state {
@@ -51,18 +51,20 @@ fn test_bank_storage() {
 
     bank.register_tick(&blockhash);
 
-    bank.transfer(10, &alice, jill.pubkey(), blockhash).unwrap();
+    bank.transfer(10, &alice, &jill.pubkey(), blockhash)
+        .unwrap();
 
-    bank.transfer(10, &alice, bob.pubkey(), blockhash).unwrap();
-    bank.transfer(10, &alice, jack.pubkey(), blockhash).unwrap();
+    bank.transfer(10, &alice, &bob.pubkey(), blockhash).unwrap();
+    bank.transfer(10, &alice, &jack.pubkey(), blockhash)
+        .unwrap();
 
     let tx = SystemTransaction::new_program_account(
         &alice,
-        bob.pubkey(),
+        &bob.pubkey(),
         blockhash,
         1,
         4 * 1024,
-        solana_storage_api::id(),
+        &solana_storage_api::id(),
         0,
     );
 
@@ -90,11 +92,11 @@ fn test_bank_storage() {
     //let _result = bank.process_transaction(&tx).unwrap();
 
     assert_eq!(
-        get_storage_entry_height(&bank, bob.pubkey()),
+        get_storage_entry_height(&bank, &bob.pubkey()),
         ENTRIES_PER_SEGMENT
     );
     assert_eq!(
-        get_storage_blockhash(&bank, bob.pubkey()),
+        get_storage_blockhash(&bank, &bob.pubkey()),
         storage_blockhash
     );
 }

--- a/programs/storage_api/src/lib.rs
+++ b/programs/storage_api/src/lib.rs
@@ -90,7 +90,7 @@ impl StorageTransaction {
             entry_height,
             signature,
         };
-        Transaction::new(from_keypair, &[], id(), &program, recent_blockhash, 0)
+        Transaction::new(from_keypair, &[], &id(), &program, recent_blockhash, 0)
     }
 
     pub fn new_advertise_recent_blockhash(
@@ -103,7 +103,7 @@ impl StorageTransaction {
             hash: storage_hash,
             entry_height,
         };
-        Transaction::new(from_keypair, &[], id(), &program, recent_blockhash, 0)
+        Transaction::new(from_keypair, &[], &id(), &program, recent_blockhash, 0)
     }
 
     pub fn new_proof_validation(
@@ -116,7 +116,7 @@ impl StorageTransaction {
             entry_height,
             proof_mask,
         };
-        Transaction::new(from_keypair, &[], id(), &program, recent_blockhash, 0)
+        Transaction::new(from_keypair, &[], &id(), &program, recent_blockhash, 0)
     }
 
     pub fn new_reward_claim(
@@ -125,6 +125,6 @@ impl StorageTransaction {
         entry_height: u64,
     ) -> Transaction {
         let program = StorageProgram::ClaimStorageReward { entry_height };
-        Transaction::new(from_keypair, &[], id(), &program, recent_blockhash, 0)
+        Transaction::new(from_keypair, &[], &id(), &program, recent_blockhash, 0)
     }
 }

--- a/programs/system/tests/system.rs
+++ b/programs/system/tests/system.rs
@@ -27,8 +27,8 @@ fn test_system_unsigned_transaction() {
     let blockhash = system_bank.bank.last_blockhash();
     let tx = TransactionBuilder::default()
         .push(SystemInstruction::new_move(
-            from_keypair.pubkey(),
-            to_keypair.pubkey(),
+            &from_keypair.pubkey(),
+            &to_keypair.pubkey(),
             50,
         ))
         .sign(&[&from_keypair], blockhash);

--- a/programs/vote/src/lib.rs
+++ b/programs/vote/src/lib.rs
@@ -25,10 +25,10 @@ fn entrypoint(
     match deserialize(data).map_err(|_| ProgramError::InvalidUserdata)? {
         VoteInstruction::InitializeAccount => vote_state::initialize_account(keyed_accounts),
         VoteInstruction::DelegateStake(delegate_id) => {
-            vote_state::delegate_stake(keyed_accounts, delegate_id)
+            vote_state::delegate_stake(keyed_accounts, &delegate_id)
         }
         VoteInstruction::AuthorizeVoter(voter_id) => {
-            vote_state::authorize_voter(keyed_accounts, voter_id)
+            vote_state::authorize_voter(keyed_accounts, &voter_id)
         }
         VoteInstruction::Vote(vote) => {
             debug!("{:?} by {}", vote, keyed_accounts[0].signer_key().unwrap());

--- a/programs/vote/tests/vote.rs
+++ b/programs/vote/tests/vote.rs
@@ -24,7 +24,7 @@ impl<'a> VoteBank<'a> {
     fn create_vote_account(
         &self,
         from_keypair: &Keypair,
-        vote_id: Pubkey,
+        vote_id: &Pubkey,
         lamports: u64,
     ) -> Result<()> {
         let blockhash = self.bank.last_blockhash();
@@ -36,7 +36,7 @@ impl<'a> VoteBank<'a> {
         &self,
         from_keypair: &Keypair,
         vote_keypair: &Keypair,
-        delegate_id: Pubkey,
+        delegate_id: &Pubkey,
         lamports: u64,
     ) -> Result<()> {
         let blockhash = self.bank.last_blockhash();
@@ -53,7 +53,7 @@ impl<'a> VoteBank<'a> {
 
     fn submit_vote(
         &self,
-        staking_account: Pubkey,
+        staking_account: &Pubkey,
         vote_keypair: &Keypair,
         tick_height: u64,
     ) -> Result<VoteState> {
@@ -77,10 +77,10 @@ fn test_vote_bank_basic() {
     let vote_keypair = Keypair::new();
     let vote_id = vote_keypair.pubkey();
     vote_bank
-        .create_vote_account(&from_keypair, vote_id, 100)
+        .create_vote_account(&from_keypair, &vote_id, 100)
         .unwrap();
 
-    let vote_state = vote_bank.submit_vote(vote_id, &vote_keypair, 0).unwrap();
+    let vote_state = vote_bank.submit_vote(&vote_id, &vote_keypair, 0).unwrap();
     assert_eq!(vote_state.votes.len(), 1);
 }
 
@@ -93,7 +93,7 @@ fn test_vote_bank_delegate() {
     let delegate_keypair = Keypair::new();
     let delegate_id = delegate_keypair.pubkey();
     vote_bank
-        .create_vote_account_with_delegate(&from_keypair, &vote_keypair, delegate_id, 100)
+        .create_vote_account_with_delegate(&from_keypair, &vote_keypair, &delegate_id, 100)
         .unwrap();
 }
 
@@ -106,7 +106,7 @@ fn test_vote_via_bank_with_no_signature() {
     let vote_keypair = Keypair::new();
     let vote_id = vote_keypair.pubkey();
     vote_bank
-        .create_vote_account(&mallory_keypair, vote_id, 100)
+        .create_vote_account(&mallory_keypair, &vote_id, 100)
         .unwrap();
 
     let mallory_id = mallory_keypair.pubkey();
@@ -121,7 +121,7 @@ fn test_vote_via_bank_with_no_signature() {
     // the 0th account in the second instruction is not! The program
     // needs to check that it's signed.
     let tx = TransactionBuilder::default()
-        .push(SystemInstruction::new_move(mallory_id, vote_id, 1))
+        .push(SystemInstruction::new_move(&mallory_id, &vote_id, 1))
         .push(vote_ix)
         .sign(&[&mallory_keypair], blockhash);
 

--- a/programs/vote_api/src/vote_instruction.rs
+++ b/programs/vote_api/src/vote_instruction.rs
@@ -32,31 +32,34 @@ pub enum VoteInstruction {
 }
 
 impl VoteInstruction {
-    pub fn new_clear_credits(vote_id: Pubkey) -> BuilderInstruction {
-        BuilderInstruction::new(id(), &VoteInstruction::ClearCredits, vec![(vote_id, true)])
+    pub fn new_clear_credits(vote_id: &Pubkey) -> BuilderInstruction {
+        BuilderInstruction::new(id(), &VoteInstruction::ClearCredits, vec![(*vote_id, true)])
     }
-    pub fn new_delegate_stake(vote_id: Pubkey, delegate_id: Pubkey) -> BuilderInstruction {
+    pub fn new_delegate_stake(vote_id: &Pubkey, delegate_id: &Pubkey) -> BuilderInstruction {
         BuilderInstruction::new(
             id(),
-            &VoteInstruction::DelegateStake(delegate_id),
-            vec![(vote_id, true)],
+            &VoteInstruction::DelegateStake(*delegate_id),
+            vec![(*vote_id, true)],
         )
     }
-    pub fn new_authorize_voter(vote_id: Pubkey, authorized_voter_id: Pubkey) -> BuilderInstruction {
+    pub fn new_authorize_voter(
+        vote_id: &Pubkey,
+        authorized_voter_id: &Pubkey,
+    ) -> BuilderInstruction {
         BuilderInstruction::new(
             id(),
-            &VoteInstruction::AuthorizeVoter(authorized_voter_id),
-            vec![(vote_id, true)],
+            &VoteInstruction::AuthorizeVoter(*authorized_voter_id),
+            vec![(*vote_id, true)],
         )
     }
-    pub fn new_initialize_account(vote_id: Pubkey) -> BuilderInstruction {
+    pub fn new_initialize_account(vote_id: &Pubkey) -> BuilderInstruction {
         BuilderInstruction::new(
             id(),
             &VoteInstruction::InitializeAccount,
-            vec![(vote_id, false)],
+            vec![(*vote_id, false)],
         )
     }
-    pub fn new_vote(vote_id: Pubkey, vote: Vote) -> BuilderInstruction {
-        BuilderInstruction::new(id(), &VoteInstruction::Vote(vote), vec![(vote_id, true)])
+    pub fn new_vote(vote_id: &Pubkey, vote: Vote) -> BuilderInstruction {
+        BuilderInstruction::new(id(), &VoteInstruction::Vote(vote), vec![(*vote_id, true)])
     }
 }

--- a/programs/vote_api/src/vote_transaction.rs
+++ b/programs/vote_api/src/vote_transaction.rs
@@ -15,7 +15,7 @@ pub struct VoteTransaction {}
 
 impl VoteTransaction {
     pub fn new_vote<T: KeypairUtil>(
-        staking_account: Pubkey,
+        staking_account: &Pubkey,
         authorized_voter_keypair: &T,
         slot: u64,
         recent_blockhash: Hash,
@@ -30,7 +30,7 @@ impl VoteTransaction {
     /// Fund or create the staking account with lamports
     pub fn new_account(
         from_keypair: &Keypair,
-        staker_id: Pubkey,
+        staker_id: &Pubkey,
         recent_blockhash: Hash,
         lamports: u64,
         fee: u64,
@@ -39,11 +39,11 @@ impl VoteTransaction {
         let space = VoteState::max_size() as u64;
         TransactionBuilder::new(fee)
             .push(SystemInstruction::new_program_account(
-                from_id,
+                &from_id,
                 staker_id,
                 lamports,
                 space,
-                id(),
+                &id(),
             ))
             .push(VoteInstruction::new_initialize_account(staker_id))
             .sign(&[from_keypair], recent_blockhash)
@@ -53,7 +53,7 @@ impl VoteTransaction {
     pub fn new_account_with_delegate(
         from_keypair: &Keypair,
         voter_keypair: &Keypair,
-        delegate_id: Pubkey,
+        delegate_id: &Pubkey,
         recent_blockhash: Hash,
         lamports: u64,
         fee: u64,
@@ -63,14 +63,14 @@ impl VoteTransaction {
         let space = VoteState::max_size() as u64;
         TransactionBuilder::new(fee)
             .push(SystemInstruction::new_program_account(
-                from_id,
-                voter_id,
+                &from_id,
+                &voter_id,
                 lamports,
                 space,
-                id(),
+                &id(),
             ))
-            .push(VoteInstruction::new_initialize_account(voter_id))
-            .push(VoteInstruction::new_delegate_stake(voter_id, delegate_id))
+            .push(VoteInstruction::new_initialize_account(&voter_id))
+            .push(VoteInstruction::new_delegate_stake(&voter_id, &delegate_id))
             .sign(&[from_keypair, voter_keypair], recent_blockhash)
     }
 
@@ -78,12 +78,12 @@ impl VoteTransaction {
     pub fn new_authorize_voter(
         vote_keypair: &Keypair,
         recent_blockhash: Hash,
-        authorized_voter_id: Pubkey,
+        authorized_voter_id: &Pubkey,
         fee: u64,
     ) -> Transaction {
         TransactionBuilder::new(fee)
             .push(VoteInstruction::new_authorize_voter(
-                vote_keypair.pubkey(),
+                &vote_keypair.pubkey(),
                 authorized_voter_id,
             ))
             .sign(&[vote_keypair], recent_blockhash)
@@ -93,12 +93,12 @@ impl VoteTransaction {
     pub fn delegate_vote_account<T: KeypairUtil>(
         vote_keypair: &T,
         recent_blockhash: Hash,
-        node_id: Pubkey,
+        node_id: &Pubkey,
         fee: u64,
     ) -> Transaction {
         TransactionBuilder::new(fee)
             .push(VoteInstruction::new_delegate_stake(
-                vote_keypair.pubkey(),
+                &vote_keypair.pubkey(),
                 node_id,
             ))
             .sign(&[vote_keypair], recent_blockhash)
@@ -133,7 +133,7 @@ mod tests {
         let slot = 1;
         let recent_blockhash = Hash::default();
         let transaction =
-            VoteTransaction::new_vote(keypair.pubkey(), &keypair, slot, recent_blockhash, 0);
+            VoteTransaction::new_vote(&keypair.pubkey(), &keypair, slot, recent_blockhash, 0);
         assert_eq!(
             VoteTransaction::get_votes(&transaction),
             vec![(keypair.pubkey(), Vote::new(slot), recent_blockhash)]

--- a/replicator/src/main.rs
+++ b/replicator/src/main.rs
@@ -67,7 +67,7 @@ fn main() {
         }
         addr
     };
-    let node = Node::new_with_external_ip(keypair.pubkey(), &gossip_addr);
+    let node = Node::new_with_external_ip(&keypair.pubkey(), &gossip_addr);
 
     println!(
         "replicating the data with keypair={:?} gossip_addr={:?}",

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -635,11 +635,12 @@ impl AccountsDB {
     fn load_executable_accounts(
         &self,
         fork: Fork,
-        mut program_id: Pubkey,
+        program_id: &Pubkey,
         error_counters: &mut ErrorCounters,
     ) -> Result<Vec<(Pubkey, Account)>> {
         let mut accounts = Vec::new();
         let mut depth = 0;
+        let mut program_id = *program_id;
         loop {
             if native_loader::check_id(&program_id) {
                 // at the root of the chain, ready to dispatch
@@ -687,7 +688,7 @@ impl AccountsDB {
                     return Err(BankError::AccountNotFound);
                 }
                 let program_id = tx.program_ids[ix.program_ids_index as usize];
-                self.load_executable_accounts(fork, program_id, error_counters)
+                self.load_executable_accounts(fork, &program_id, error_counters)
             })
             .collect()
     }
@@ -1092,10 +1093,10 @@ mod tests {
         let key0 = keypair.pubkey();
         let key1 = Pubkey::new(&[5u8; 32]);
 
-        let account = Account::new(1, 1, Pubkey::default());
+        let account = Account::new(1, 1, &Pubkey::default());
         accounts.push((key0, account));
 
-        let account = Account::new(2, 1, Pubkey::default());
+        let account = Account::new(2, 1, &Pubkey::default());
         accounts.push((key1, account));
 
         let instructions = vec![Instruction::new(1, &(), vec![0])];
@@ -1123,7 +1124,7 @@ mod tests {
         let keypair = Keypair::new();
         let key0 = keypair.pubkey();
 
-        let account = Account::new(1, 1, Pubkey::default());
+        let account = Account::new(1, 1, &Pubkey::default());
         accounts.push((key0, account));
 
         let instructions = vec![Instruction::new(1, &(), vec![0])];
@@ -1152,10 +1153,10 @@ mod tests {
         let key0 = keypair.pubkey();
         let key1 = Pubkey::new(&[5u8; 32]);
 
-        let account = Account::new(1, 1, Pubkey::default());
+        let account = Account::new(1, 1, &Pubkey::default());
         accounts.push((key0, account));
 
-        let account = Account::new(2, 1, Pubkey::default());
+        let account = Account::new(2, 1, &Pubkey::default());
         accounts.push((key1, account));
 
         let instructions = vec![Instruction::new(0, &(), vec![0, 1])];
@@ -1197,35 +1198,35 @@ mod tests {
         let key5 = Pubkey::new(&[9u8; 32]);
         let key6 = Pubkey::new(&[10u8; 32]);
 
-        let account = Account::new(1, 1, Pubkey::default());
+        let account = Account::new(1, 1, &Pubkey::default());
         accounts.push((key0, account));
 
-        let mut account = Account::new(40, 1, Pubkey::default());
+        let mut account = Account::new(40, 1, &Pubkey::default());
         account.executable = true;
         account.owner = native_loader::id();
         accounts.push((key1, account));
 
-        let mut account = Account::new(41, 1, Pubkey::default());
+        let mut account = Account::new(41, 1, &Pubkey::default());
         account.executable = true;
         account.owner = key1;
         accounts.push((key2, account));
 
-        let mut account = Account::new(42, 1, Pubkey::default());
+        let mut account = Account::new(42, 1, &Pubkey::default());
         account.executable = true;
         account.owner = key2;
         accounts.push((key3, account));
 
-        let mut account = Account::new(43, 1, Pubkey::default());
+        let mut account = Account::new(43, 1, &Pubkey::default());
         account.executable = true;
         account.owner = key3;
         accounts.push((key4, account));
 
-        let mut account = Account::new(44, 1, Pubkey::default());
+        let mut account = Account::new(44, 1, &Pubkey::default());
         account.executable = true;
         account.owner = key4;
         accounts.push((key5, account));
 
-        let mut account = Account::new(45, 1, Pubkey::default());
+        let mut account = Account::new(45, 1, &Pubkey::default());
         account.executable = true;
         account.owner = key5;
         accounts.push((key6, account));
@@ -1256,10 +1257,10 @@ mod tests {
         let key0 = keypair.pubkey();
         let key1 = Pubkey::new(&[5u8; 32]);
 
-        let account = Account::new(1, 1, Pubkey::default());
+        let account = Account::new(1, 1, &Pubkey::default());
         accounts.push((key0, account));
 
-        let mut account = Account::new(40, 1, Pubkey::default());
+        let mut account = Account::new(40, 1, &Pubkey::default());
         account.executable = true;
         account.owner = Pubkey::default();
         accounts.push((key1, account));
@@ -1290,10 +1291,10 @@ mod tests {
         let key0 = keypair.pubkey();
         let key1 = Pubkey::new(&[5u8; 32]);
 
-        let account = Account::new(1, 1, Pubkey::default());
+        let account = Account::new(1, 1, &Pubkey::default());
         accounts.push((key0, account));
 
-        let mut account = Account::new(40, 1, Pubkey::default());
+        let mut account = Account::new(40, 1, &Pubkey::default());
         account.owner = native_loader::id();
         accounts.push((key1, account));
 
@@ -1325,20 +1326,20 @@ mod tests {
         let key2 = Pubkey::new(&[6u8; 32]);
         let key3 = Pubkey::new(&[7u8; 32]);
 
-        let account = Account::new(1, 1, Pubkey::default());
+        let account = Account::new(1, 1, &Pubkey::default());
         accounts.push((key0, account));
 
-        let mut account = Account::new(40, 1, Pubkey::default());
+        let mut account = Account::new(40, 1, &Pubkey::default());
         account.executable = true;
         account.owner = native_loader::id();
         accounts.push((key1, account));
 
-        let mut account = Account::new(41, 1, Pubkey::default());
+        let mut account = Account::new(41, 1, &Pubkey::default());
         account.executable = true;
         account.owner = key1;
         accounts.push((key2, account));
 
-        let mut account = Account::new(42, 1, Pubkey::default());
+        let mut account = Account::new(42, 1, &Pubkey::default());
         account.executable = true;
         account.owner = key2;
         accounts.push((key3, account));
@@ -1386,7 +1387,7 @@ mod tests {
         let keypair = Keypair::new();
         let pubkey = keypair.pubkey();
 
-        let account = Account::new(10, 1, Pubkey::default());
+        let account = Account::new(10, 1, &Pubkey::default());
         accounts.push((pubkey, account));
 
         let instructions = vec![Instruction::new(0, &(), vec![0, 1])];
@@ -1448,7 +1449,7 @@ mod tests {
         let paths = get_tmp_accounts_path!();
         let db = AccountsDB::new(0, &paths.paths);
         let key = Pubkey::default();
-        let account0 = Account::new(1, 0, key);
+        let account0 = Account::new(1, 0, &key);
 
         // store value 1 in the "root", i.e. db zero
         db.store(0, &key, &account0);
@@ -1466,7 +1467,7 @@ mod tests {
         //                                       (via root0)
 
         // store value 0 in one child
-        let account1 = Account::new(0, 0, key);
+        let account1 = Account::new(0, 0, &key);
         db.store(1, &key, &account1);
 
         // masking accounts is done at the Accounts level, at accountsDB we see
@@ -1546,12 +1547,12 @@ mod tests {
         // 1 token in the "root", i.e. db zero
         let paths = get_tmp_accounts_path!();
         let db0 = AccountsDB::new(0, &paths.paths);
-        let account0 = Account::new(1, 0, key);
+        let account0 = Account::new(1, 0, &key);
         db0.store(0, &key, &account0);
 
         db0.add_fork(1, Some(0));
         // 0 lamports in the child
-        let account1 = Account::new(0, 0, key);
+        let account1 = Account::new(0, 0, &key);
         db0.store(1, &key, &account1);
 
         // masking accounts is done at the Accounts level, at accountsDB we see
@@ -1670,7 +1671,7 @@ mod tests {
         let mut keys = vec![];
         for i in 0..9 {
             let key = Keypair::new().pubkey();
-            let account = Account::new(i + 1, size as usize / 4, key);
+            let account = Account::new(i + 1, size as usize / 4, &key);
             accounts.store(0, &key, &account);
             keys.push(key);
         }
@@ -1703,7 +1704,7 @@ mod tests {
             AccountStorageStatus::StorageFull,
         ];
         let pubkey1 = Keypair::new().pubkey();
-        let account1 = Account::new(1, ACCOUNT_DATA_FILE_SIZE as usize / 2, pubkey1);
+        let account1 = Account::new(1, ACCOUNT_DATA_FILE_SIZE as usize / 2, &pubkey1);
         accounts.store(0, &pubkey1, &account1);
         {
             let stores = accounts.storage.read().unwrap();
@@ -1713,7 +1714,7 @@ mod tests {
         }
 
         let pubkey2 = Keypair::new().pubkey();
-        let account2 = Account::new(1, ACCOUNT_DATA_FILE_SIZE as usize / 2, pubkey2);
+        let account2 = Account::new(1, ACCOUNT_DATA_FILE_SIZE as usize / 2, &pubkey2);
         accounts.store(0, &pubkey2, &account2);
         {
             let stores = accounts.storage.read().unwrap();
@@ -1747,7 +1748,7 @@ mod tests {
     #[test]
     fn test_accounts_vote_filter() {
         let accounts = Accounts::new(0, None);
-        let mut vote_account = Account::new(1, 0, solana_vote_api::id());
+        let mut vote_account = Account::new(1, 0, &solana_vote_api::id());
         let key = Keypair::new().pubkey();
         accounts.store_slow(0, &key, &vote_account);
 
@@ -1762,7 +1763,7 @@ mod tests {
         vote_accounts = accounts.get_vote_accounts(1).collect();
         assert_eq!(vote_accounts.len(), 0);
 
-        let mut vote_account1 = Account::new(2, 0, solana_vote_api::id());
+        let mut vote_account1 = Account::new(2, 0, &solana_vote_api::id());
         let key1 = Keypair::new().pubkey();
         accounts.store_slow(1, &key1, &vote_account1);
 
@@ -1792,7 +1793,7 @@ mod tests {
             assert_eq!(account.owner, solana_vote_api::id());
         });
         let lastkey = Keypair::new().pubkey();
-        let mut lastaccount = Account::new(1, 0, solana_vote_api::id());
+        let mut lastaccount = Account::new(1, 0, &solana_vote_api::id());
         accounts_db.store(0, &lastkey, &lastaccount);
         assert_eq!(accounts_db.get_vote_accounts(0).len(), 2);
 
@@ -1862,7 +1863,7 @@ mod tests {
         let accounts = AccountsDB::new(0, &paths.paths);
         let mut error_counters = ErrorCounters::default();
         assert_eq!(
-            accounts.load_executable_accounts(0, Keypair::new().pubkey(), &mut error_counters),
+            accounts.load_executable_accounts(0, &Keypair::new().pubkey(), &mut error_counters),
             Err(BankError::AccountNotFound)
         );
         assert_eq!(error_counters.account_not_found, 1);
@@ -1894,13 +1895,13 @@ mod tests {
 
         // Load accounts owned by various programs into AccountsDB
         let pubkey0 = Keypair::new().pubkey();
-        let account0 = Account::new(1, 0, Pubkey::new(&[2; 32]));
+        let account0 = Account::new(1, 0, &Pubkey::new(&[2; 32]));
         accounts_db.store(0, &pubkey0, &account0);
         let pubkey1 = Keypair::new().pubkey();
-        let account1 = Account::new(1, 0, Pubkey::new(&[2; 32]));
+        let account1 = Account::new(1, 0, &Pubkey::new(&[2; 32]));
         accounts_db.store(0, &pubkey1, &account1);
         let pubkey2 = Keypair::new().pubkey();
-        let account2 = Account::new(1, 0, Pubkey::new(&[3; 32]));
+        let account2 = Account::new(1, 0, &Pubkey::new(&[3; 32]));
         accounts_db.store(0, &pubkey2, &account2);
 
         let accounts = accounts_db.load_by_program(0, &Pubkey::new(&[2; 32]), false);

--- a/runtime/src/loader_utils.rs
+++ b/runtime/src/loader_utils.rs
@@ -4,12 +4,12 @@ use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::{Keypair, KeypairUtil};
 use solana_sdk::system_transaction::SystemTransaction;
 
-pub fn load_program(bank: &Bank, from: &Keypair, loader_id: Pubkey, program: Vec<u8>) -> Pubkey {
+pub fn load_program(bank: &Bank, from: &Keypair, loader_id: &Pubkey, program: Vec<u8>) -> Pubkey {
     let program_account = Keypair::new();
 
     let tx = SystemTransaction::new_program_account(
         from,
-        program_account.pubkey(),
+        &program_account.pubkey(),
         bank.last_blockhash(),
         1,
         program.len() as u64,

--- a/sdk/src/account.rs
+++ b/sdk/src/account.rs
@@ -40,11 +40,11 @@ impl fmt::Debug for Account {
 
 impl Account {
     // TODO do we want to add executable and leader_owner even though they should always be false/default?
-    pub fn new(lamports: u64, space: usize, owner: Pubkey) -> Account {
+    pub fn new(lamports: u64, space: usize, owner: &Pubkey) -> Account {
         Account {
             lamports,
             userdata: vec![0u8; space],
-            owner,
+            owner: *owner,
             executable: false,
         }
     }

--- a/sdk/src/genesis_block.rs
+++ b/sdk/src/genesis_block.rs
@@ -32,19 +32,23 @@ impl GenesisBlock {
         let lamports = lamports
             .checked_add(BOOTSTRAP_LEADER_LAMPORTS)
             .unwrap_or(lamports);
-        Self::new_with_leader(lamports, Keypair::new().pubkey(), BOOTSTRAP_LEADER_LAMPORTS)
+        Self::new_with_leader(
+            lamports,
+            &Keypair::new().pubkey(),
+            BOOTSTRAP_LEADER_LAMPORTS,
+        )
     }
 
     pub fn new_with_leader(
         lamports: u64,
-        bootstrap_leader_id: Pubkey,
+        bootstrap_leader_id: &Pubkey,
         bootstrap_leader_lamports: u64,
     ) -> (Self, Keypair) {
         let mint_keypair = Keypair::new();
         let bootstrap_leader_vote_account_keypair = Keypair::new();
         (
             Self {
-                bootstrap_leader_id,
+                bootstrap_leader_id: *bootstrap_leader_id,
                 bootstrap_leader_lamports,
                 bootstrap_leader_vote_account_id: bootstrap_leader_vote_account_keypair.pubkey(),
                 mint_id: mint_keypair.pubkey(),
@@ -97,7 +101,7 @@ mod tests {
     fn test_genesis_block_new_with_leader() {
         let leader_keypair = Keypair::new();
         let (genesis_block, mint) =
-            GenesisBlock::new_with_leader(20_000, leader_keypair.pubkey(), 123);
+            GenesisBlock::new_with_leader(20_000, &leader_keypair.pubkey(), 123);
 
         assert_eq!(genesis_block.lamports, 20_000);
         assert_eq!(genesis_block.mint_id, mint.pubkey());

--- a/sdk/src/loader_transaction.rs
+++ b/sdk/src/loader_transaction.rs
@@ -11,7 +11,7 @@ pub struct LoaderTransaction {}
 impl LoaderTransaction {
     pub fn new_write(
         from_keypair: &Keypair,
-        loader: Pubkey,
+        loader: &Pubkey,
         offset: u32,
         bytes: Vec<u8>,
         recent_blockhash: Hash,
@@ -30,7 +30,7 @@ impl LoaderTransaction {
 
     pub fn new_finalize(
         from_keypair: &Keypair,
-        loader: Pubkey,
+        loader: &Pubkey,
         recent_blockhash: Hash,
         fee: u64,
     ) -> Transaction {

--- a/sdk/src/system_instruction.rs
+++ b/sdk/src/system_instruction.rs
@@ -26,28 +26,28 @@ pub enum SystemInstruction {
 
 impl SystemInstruction {
     pub fn new_program_account(
-        from_id: Pubkey,
-        to_id: Pubkey,
+        from_id: &Pubkey,
+        to_id: &Pubkey,
         lamports: u64,
         space: u64,
-        program_id: Pubkey,
+        program_id: &Pubkey,
     ) -> BuilderInstruction {
         BuilderInstruction::new(
             system_program::id(),
             &SystemInstruction::CreateAccount {
                 lamports,
                 space,
-                program_id,
+                program_id: *program_id,
             },
-            vec![(from_id, true), (to_id, false)],
+            vec![(*from_id, true), (*to_id, false)],
         )
     }
 
-    pub fn new_move(from_id: Pubkey, to_id: Pubkey, lamports: u64) -> BuilderInstruction {
+    pub fn new_move(from_id: &Pubkey, to_id: &Pubkey, lamports: u64) -> BuilderInstruction {
         BuilderInstruction::new(
             system_program::id(),
             &SystemInstruction::Move { lamports },
-            vec![(from_id, true), (to_id, false)],
+            vec![(*from_id, true), (*to_id, false)],
         )
     }
 }

--- a/sdk/src/system_transaction.rs
+++ b/sdk/src/system_transaction.rs
@@ -13,22 +13,22 @@ impl SystemTransaction {
     /// Create and sign new SystemInstruction::CreateAccount transaction
     pub fn new_program_account(
         from_keypair: &Keypair,
-        to: Pubkey,
+        to: &Pubkey,
         recent_blockhash: Hash,
         lamports: u64,
         space: u64,
-        program_id: Pubkey,
+        program_id: &Pubkey,
         fee: u64,
     ) -> Transaction {
         let create = SystemInstruction::CreateAccount {
             lamports, //TODO, the lamports to allocate might need to be higher then 0 in the future
             space,
-            program_id,
+            program_id: *program_id,
         };
         Transaction::new(
             from_keypair,
-            &[to],
-            system_program::id(),
+            &[*to],
+            &system_program::id(),
             &create,
             recent_blockhash,
             fee,
@@ -38,7 +38,7 @@ impl SystemTransaction {
     /// Create and sign a transaction to create a system account
     pub fn new_account(
         from_keypair: &Keypair,
-        to: Pubkey,
+        to: &Pubkey,
         lamports: u64,
         recent_blockhash: Hash,
         fee: u64,
@@ -50,7 +50,7 @@ impl SystemTransaction {
             recent_blockhash,
             lamports,
             0,
-            program_id,
+            &program_id,
             fee,
         )
     }
@@ -58,14 +58,16 @@ impl SystemTransaction {
     pub fn new_assign(
         from_keypair: &Keypair,
         recent_blockhash: Hash,
-        program_id: Pubkey,
+        program_id: &Pubkey,
         fee: u64,
     ) -> Transaction {
-        let assign = SystemInstruction::Assign { program_id };
+        let assign = SystemInstruction::Assign {
+            program_id: *program_id,
+        };
         Transaction::new(
             from_keypair,
             &[],
-            system_program::id(),
+            &system_program::id(),
             &assign,
             recent_blockhash,
             fee,
@@ -74,7 +76,7 @@ impl SystemTransaction {
     /// Create and sign new SystemInstruction::Move transaction
     pub fn new_move(
         from_keypair: &Keypair,
-        to: Pubkey,
+        to: &Pubkey,
         lamports: u64,
         recent_blockhash: Hash,
         fee: u64,
@@ -82,8 +84,8 @@ impl SystemTransaction {
         let move_lamports = SystemInstruction::Move { lamports };
         Transaction::new(
             from_keypair,
-            &[to],
-            system_program::id(),
+            &[*to],
+            &system_program::id(),
             &move_lamports,
             recent_blockhash,
             fee,

--- a/sdk/src/transaction.rs
+++ b/sdk/src/transaction.rs
@@ -99,12 +99,12 @@ impl Transaction {
     pub fn new<S: Serialize, T: KeypairUtil>(
         from_keypair: &T,
         transaction_keys: &[Pubkey],
-        program_id: Pubkey,
+        program_id: &Pubkey,
         userdata: &S,
         recent_blockhash: Hash,
         fee: u64,
     ) -> Self {
-        let program_ids = vec![program_id];
+        let program_ids = vec![*program_id];
         let accounts = (0..=transaction_keys.len() as u8).collect();
         let instructions = vec![Instruction::new(0, userdata, accounts)];
         Self::new_with_instructions(
@@ -119,12 +119,12 @@ impl Transaction {
     pub fn new_unsigned<T: Serialize>(
         from_pubkey: &Pubkey,
         transaction_keys: &[Pubkey],
-        program_id: Pubkey,
+        program_id: &Pubkey,
         userdata: &T,
         recent_blockhash: Hash,
         fee: u64,
     ) -> Self {
-        let program_ids = vec![program_id];
+        let program_ids = vec![*program_id];
         let accounts = (0..=transaction_keys.len() as u8).collect();
         let instructions = vec![Instruction::new(0, userdata, accounts)];
         let mut keys = vec![*from_pubkey];
@@ -492,7 +492,7 @@ mod tests {
         let tx = Transaction::new(
             &keypair,
             &[keypair.pubkey(), to],
-            program_id,
+            &program_id,
             &(1u8, 2u8, 3u8),
             Hash::default(),
             99,
@@ -511,7 +511,7 @@ mod tests {
         let tx = Transaction::new(
             &keypair,
             &[keypair.pubkey(), to],
-            program_id,
+            &program_id,
             &(1u8, 2u8, 3u8),
             Hash::default(),
             99,
@@ -557,7 +557,7 @@ mod tests {
         let tx = Transaction::new(
             &keypair,
             &[keypair.pubkey(), to],
-            program_id,
+            &program_id,
             &(1u8, 2u8, 3u8),
             Hash::default(),
             99,

--- a/sdk/src/transaction_builder.rs
+++ b/sdk/src/transaction_builder.rs
@@ -8,8 +8,8 @@ use itertools::Itertools;
 
 pub type BuilderInstruction = Instruction<Pubkey, (Pubkey, bool)>;
 
-fn position(keys: &[Pubkey], key: Pubkey) -> u8 {
-    keys.iter().position(|&k| k == key).unwrap() as u8
+fn position(keys: &[Pubkey], key: &Pubkey) -> u8 {
+    keys.iter().position(|k| k == key).unwrap() as u8
 }
 
 fn compile_instruction(
@@ -17,13 +17,9 @@ fn compile_instruction(
     keys: &[Pubkey],
     program_ids: &[Pubkey],
 ) -> Instruction<u8, u8> {
-    let accounts: Vec<_> = ix
-        .accounts
-        .iter()
-        .map(|&(k, _)| position(keys, k))
-        .collect();
+    let accounts: Vec<_> = ix.accounts.iter().map(|(k, _)| position(keys, k)).collect();
     Instruction {
-        program_ids_index: position(program_ids, ix.program_ids_index),
+        program_ids_index: position(program_ids, &ix.program_ids_index),
         userdata: ix.userdata.clone(),
         accounts,
     }

--- a/tests/cluster_info.rs
+++ b/tests/cluster_info.rs
@@ -36,7 +36,7 @@ fn run_simulation(num_nodes: u64, fanout: usize, hood_size: usize) {
     let timeout = 60 * 5;
 
     // describe the leader
-    let leader_info = ContactInfo::new_localhost(Keypair::new().pubkey(), 0);
+    let leader_info = ContactInfo::new_localhost(&Keypair::new().pubkey(), 0);
     let mut cluster_info = ClusterInfo::new_with_invalid_keypair(leader_info.clone());
 
     // setup stakes
@@ -59,7 +59,7 @@ fn run_simulation(num_nodes: u64, fanout: usize, hood_size: usize) {
         chunk.into_iter().for_each(|i| {
             //distribute neighbors across threads to maximize parallel compute
             let batch_ix = *i as usize % batches.len();
-            let node = ContactInfo::new_localhost(Keypair::new().pubkey(), 0);
+            let node = ContactInfo::new_localhost(&Keypair::new().pubkey(), 0);
             stakes.insert(node.id, *i);
             cluster_info.insert_info(node.clone());
             let (s, r) = channel();
@@ -103,7 +103,7 @@ fn run_simulation(num_nodes: u64, fanout: usize, hood_size: usize) {
         while remaining > 0 {
             for (id, (recv, r)) in batch.iter_mut() {
                 assert!(now.elapsed().as_secs() < timeout, "Timed out");
-                cluster.gossip.set_self(*id);
+                cluster.gossip.set_self(&*id);
                 if !mapped_peers.contains_key(id) {
                     let (neighbors, children) = compute_retransmit_peers(
                         &stakes,

--- a/tests/gossip.rs
+++ b/tests/gossip.rs
@@ -18,7 +18,7 @@ use std::time::Duration;
 
 fn test_node(exit: &Arc<AtomicBool>) -> (Arc<RwLock<ClusterInfo>>, GossipService, UdpSocket) {
     let keypair = Arc::new(Keypair::new());
-    let mut test_node = Node::new_localhost_with_pubkey(keypair.pubkey());
+    let mut test_node = Node::new_localhost_with_pubkey(&keypair.pubkey());
     let cluster_info = Arc::new(RwLock::new(ClusterInfo::new(
         test_node.info.clone(),
         keypair,
@@ -76,7 +76,7 @@ fn gossip_ring() -> result::Result<()> {
             let x = (n + 1) % listen.len();
             let mut xv = listen[x].0.write().unwrap();
             let yv = listen[y].0.read().unwrap();
-            let mut d = yv.lookup(yv.id()).unwrap().clone();
+            let mut d = yv.lookup(&yv.id()).unwrap().clone();
             d.wallclock = timestamp();
             xv.insert_info(d);
         }
@@ -97,7 +97,7 @@ fn gossip_ring_large() -> result::Result<()> {
             let x = (n + 1) % listen.len();
             let mut xv = listen[x].0.write().unwrap();
             let yv = listen[y].0.read().unwrap();
-            let mut d = yv.lookup(yv.id()).unwrap().clone();
+            let mut d = yv.lookup(&yv.id()).unwrap().clone();
             d.wallclock = timestamp();
             xv.insert_info(d);
         }
@@ -116,7 +116,7 @@ fn gossip_star() {
             let y = (n + 1) % listen.len();
             let mut xv = listen[x].0.write().unwrap();
             let yv = listen[y].0.read().unwrap();
-            let mut yd = yv.lookup(yv.id()).unwrap().clone();
+            let mut yd = yv.lookup(&yv.id()).unwrap().clone();
             yd.wallclock = timestamp();
             xv.insert_info(yd);
             trace!("star leader {}", &xv.id());
@@ -132,7 +132,7 @@ fn gossip_rstar() {
         let num = listen.len();
         let xd = {
             let xv = listen[0].0.read().unwrap();
-            xv.lookup(xv.id()).unwrap().clone()
+            xv.lookup(&xv.id()).unwrap().clone()
         };
         trace!("rstar leader {}", xd.id);
         for n in 0..(num - 1) {

--- a/tests/replicator.rs
+++ b/tests/replicator.rs
@@ -39,11 +39,11 @@ fn test_replicator_startup_basic() {
 
     info!("starting leader node");
     let leader_keypair = Arc::new(Keypair::new());
-    let leader_node = Node::new_localhost_with_pubkey(leader_keypair.pubkey());
+    let leader_node = Node::new_localhost_with_pubkey(&leader_keypair.pubkey());
     let leader_info = leader_node.info.clone();
 
     let (genesis_block, mint_keypair) =
-        GenesisBlock::new_with_leader(1_000_000_000, leader_info.id, 42);
+        GenesisBlock::new_with_leader(1_000_000_000, &leader_info.id, 42);
     let (leader_ledger_path, _blockhash) = create_new_tmp_ledger!(&genesis_block);
 
     let validator_ledger_path = tmp_copy_blocktree!(&leader_ledger_path);
@@ -57,7 +57,7 @@ fn test_replicator_startup_basic() {
             leader_node,
             &leader_keypair,
             &leader_ledger_path,
-            voting_keypair.pubkey(),
+            &voting_keypair.pubkey(),
             voting_keypair,
             None,
             &fullnode_config,
@@ -74,10 +74,10 @@ fn test_replicator_startup_basic() {
         debug!("blockhash: {:?}", blockhash);
 
         leader_client
-            .transfer(10, &mint_keypair, validator_keypair.pubkey(), &blockhash)
+            .transfer(10, &mint_keypair, &validator_keypair.pubkey(), &blockhash)
             .unwrap();
 
-        let validator_node = Node::new_localhost_with_pubkey(validator_keypair.pubkey());
+        let validator_node = Node::new_localhost_with_pubkey(&validator_keypair.pubkey());
         #[cfg(feature = "chacha")]
         let validator_contact_info = validator_node.info.clone();
 
@@ -85,7 +85,7 @@ fn test_replicator_startup_basic() {
             validator_node,
             &validator_keypair,
             &validator_ledger_path,
-            voting_keypair.pubkey(),
+            &voting_keypair.pubkey(),
             voting_keypair,
             Some(&leader_info),
             &fullnode_config,
@@ -98,7 +98,7 @@ fn test_replicator_startup_basic() {
             debug!("transfer {}", i);
             let blockhash = leader_client.get_recent_blockhash();
             let mut transaction =
-                SystemTransaction::new_account(&mint_keypair, bob.pubkey(), 1, blockhash, 0);
+                SystemTransaction::new_account(&mint_keypair, &bob.pubkey(), 1, blockhash, 0);
             leader_client
                 .retry_transfer(&mint_keypair, &mut transaction, 5)
                 .unwrap();
@@ -118,7 +118,7 @@ fn test_replicator_startup_basic() {
         // Give the replicator some lamports
         let mut tx = SystemTransaction::new_account(
             &mint_keypair,
-            replicator_keypair.pubkey(),
+            &replicator_keypair.pubkey(),
             1,
             blockhash,
             0,
@@ -128,7 +128,7 @@ fn test_replicator_startup_basic() {
             .unwrap();
 
         info!("starting replicator node");
-        let replicator_node = Node::new_localhost_with_pubkey(replicator_keypair.pubkey());
+        let replicator_node = Node::new_localhost_with_pubkey(&replicator_keypair.pubkey());
         let replicator_info = replicator_node.info.clone();
 
         let leader_info = ContactInfo::new_gossip_entry_point(&leader_info.gossip);
@@ -242,7 +242,7 @@ fn test_replicator_startup_leader_hang() {
         let replicator_keypair = Arc::new(Keypair::new());
 
         info!("starting replicator node");
-        let replicator_node = Node::new_localhost_with_pubkey(replicator_keypair.pubkey());
+        let replicator_node = Node::new_localhost_with_pubkey(&replicator_keypair.pubkey());
 
         let fake_gossip = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 0);
         let leader_info = ContactInfo::new_gossip_entry_point(&fake_gossip);
@@ -272,11 +272,11 @@ fn test_replicator_startup_ledger_hang() {
     let leader_keypair = Arc::new(Keypair::new());
 
     let (genesis_block, _mint_keypair) =
-        GenesisBlock::new_with_leader(100, leader_keypair.pubkey(), 42);
+        GenesisBlock::new_with_leader(100, &leader_keypair.pubkey(), 42);
     let (replicator_ledger_path, _blockhash) = create_new_tmp_ledger!(&genesis_block);
 
     info!("starting leader node");
-    let leader_node = Node::new_localhost_with_pubkey(leader_keypair.pubkey());
+    let leader_node = Node::new_localhost_with_pubkey(&leader_keypair.pubkey());
     let leader_info = leader_node.info.clone();
 
     let (leader_ledger_path, _blockhash) = create_new_tmp_ledger!(&genesis_block);
@@ -290,7 +290,7 @@ fn test_replicator_startup_ledger_hang() {
             leader_node,
             &leader_keypair,
             &leader_ledger_path,
-            voting_keypair.pubkey(),
+            &voting_keypair.pubkey(),
             voting_keypair,
             None,
             &fullnode_config,
@@ -298,13 +298,13 @@ fn test_replicator_startup_ledger_hang() {
 
         let validator_keypair = Arc::new(Keypair::new());
         let voting_keypair = Keypair::new();
-        let validator_node = Node::new_localhost_with_pubkey(validator_keypair.pubkey());
+        let validator_node = Node::new_localhost_with_pubkey(&validator_keypair.pubkey());
 
         let _ = Fullnode::new(
             validator_node,
             &validator_keypair,
             &validator_ledger_path,
-            voting_keypair.pubkey(),
+            &voting_keypair.pubkey(),
             voting_keypair,
             Some(&leader_info),
             &FullnodeConfig::default(),
@@ -312,7 +312,7 @@ fn test_replicator_startup_ledger_hang() {
 
         info!("starting replicator node");
         let bad_keys = Arc::new(Keypair::new());
-        let mut replicator_node = Node::new_localhost_with_pubkey(bad_keys.pubkey());
+        let mut replicator_node = Node::new_localhost_with_pubkey(&bad_keys.pubkey());
 
         // Pass bad TVU sockets to prevent successful ledger download
         replicator_node.sockets.tvu = vec![std::net::UdpSocket::bind("0.0.0.0:0").unwrap()];

--- a/tests/rpc.rs
+++ b/tests/rpc.rs
@@ -41,7 +41,7 @@ fn test_rpc_send_tx() {
     let blockhash = Hash::new(&blockhash_vec);
 
     info!("blockhash: {:?}", blockhash);
-    let tx = SystemTransaction::new_move(&alice, bob_pubkey, 20, blockhash, 0);
+    let tx = SystemTransaction::new_move(&alice, &bob_pubkey, 20, blockhash, 0);
     let serial_tx = serialize(&tx).unwrap();
 
     let client = reqwest::Client::new();

--- a/tests/tvu.rs
+++ b/tests/tvu.rs
@@ -42,7 +42,7 @@ fn test_replay() {
     solana_logger::setup();
     let leader = Node::new_localhost();
     let target1_keypair = Keypair::new();
-    let target1 = Node::new_localhost_with_pubkey(target1_keypair.pubkey());
+    let target1 = Node::new_localhost_with_pubkey(&target1_keypair.pubkey());
     let target2 = Node::new_localhost();
     let exit = Arc::new(AtomicBool::new(false));
 
@@ -109,7 +109,7 @@ fn test_replay() {
     let (poh_service_exit, poh_recorder, poh_service, _entry_receiver) =
         create_test_recorder(&bank);
     let tvu = Tvu::new(
-        voting_keypair.pubkey(),
+        &voting_keypair.pubkey(),
         Some(Arc::new(voting_keypair)),
         &Arc::new(RwLock::new(bank_forks)),
         &bank_forks_info,
@@ -144,7 +144,7 @@ fn test_replay() {
 
         let tx0 = SystemTransaction::new_account(
             &mint_keypair,
-            bob_keypair.pubkey(),
+            &bob_keypair.pubkey(),
             transfer_amount,
             blockhash,
             0,

--- a/wallet/src/main.rs
+++ b/wallet/src/main.rs
@@ -61,7 +61,7 @@ pub fn parse_args(matches: &ArgMatches<'_>) -> Result<WalletConfig, Box<dyn erro
         )))
     })?;
 
-    let command = parse_command(id.pubkey(), &matches)?;
+    let command = parse_command(&id.pubkey(), &matches)?;
 
     Ok(WalletConfig {
         id,

--- a/wallet/tests/pay.rs
+++ b/wallet/tests/pay.rs
@@ -13,7 +13,7 @@ use std::sync::mpsc::channel;
 #[cfg(test)]
 use solana::thin_client::new_fullnode;
 
-fn check_balance(expected_balance: u64, client: &RpcClient, pubkey: Pubkey) {
+fn check_balance(expected_balance: u64, client: &RpcClient, pubkey: &Pubkey) {
     let balance = client.retry_get_balance(1, pubkey, 1).unwrap().unwrap();
     assert_eq!(balance, expected_balance);
 }
@@ -40,7 +40,7 @@ fn test_wallet_timestamp_tx() {
     assert_ne!(config_payer.id.pubkey(), config_witness.id.pubkey());
 
     request_and_confirm_airdrop(&rpc_client, &drone_addr, &config_payer.id, 50).unwrap();
-    check_balance(50, &rpc_client, config_payer.id.pubkey());
+    check_balance(50, &rpc_client, &config_payer.id.pubkey());
 
     // Make transaction (from config_payer to bob_pubkey) requiring timestamp from config_witness
     let date_string = "\"2018-09-19T17:30:59Z\"";
@@ -62,17 +62,17 @@ fn test_wallet_timestamp_tx() {
         .expect("base58-encoded public key");
     let process_id = Pubkey::new(&process_id_vec);
 
-    check_balance(40, &rpc_client, config_payer.id.pubkey()); // config_payer balance
-    check_balance(10, &rpc_client, process_id); // contract balance
-    check_balance(0, &rpc_client, bob_pubkey); // recipient balance
+    check_balance(40, &rpc_client, &config_payer.id.pubkey()); // config_payer balance
+    check_balance(10, &rpc_client, &process_id); // contract balance
+    check_balance(0, &rpc_client, &bob_pubkey); // recipient balance
 
     // Sign transaction by config_witness
     config_witness.command = WalletCommand::TimeElapsed(bob_pubkey, process_id, dt);
     process_command(&config_witness).unwrap();
 
-    check_balance(40, &rpc_client, config_payer.id.pubkey()); // config_payer balance
-    check_balance(0, &rpc_client, process_id); // contract balance
-    check_balance(10, &rpc_client, bob_pubkey); // recipient balance
+    check_balance(40, &rpc_client, &config_payer.id.pubkey()); // config_payer balance
+    check_balance(0, &rpc_client, &process_id); // contract balance
+    check_balance(10, &rpc_client, &bob_pubkey); // recipient balance
 
     server.close().unwrap();
     remove_dir_all(ledger_path).unwrap();
@@ -119,17 +119,17 @@ fn test_wallet_witness_tx() {
         .expect("base58-encoded public key");
     let process_id = Pubkey::new(&process_id_vec);
 
-    check_balance(40, &rpc_client, config_payer.id.pubkey()); // config_payer balance
-    check_balance(10, &rpc_client, process_id); // contract balance
-    check_balance(0, &rpc_client, bob_pubkey); // recipient balance
+    check_balance(40, &rpc_client, &config_payer.id.pubkey()); // config_payer balance
+    check_balance(10, &rpc_client, &process_id); // contract balance
+    check_balance(0, &rpc_client, &bob_pubkey); // recipient balance
 
     // Sign transaction by config_witness
     config_witness.command = WalletCommand::Witness(bob_pubkey, process_id);
     process_command(&config_witness).unwrap();
 
-    check_balance(40, &rpc_client, config_payer.id.pubkey()); // config_payer balance
-    check_balance(0, &rpc_client, process_id); // contract balance
-    check_balance(10, &rpc_client, bob_pubkey); // recipient balance
+    check_balance(40, &rpc_client, &config_payer.id.pubkey()); // config_payer balance
+    check_balance(0, &rpc_client, &process_id); // contract balance
+    check_balance(10, &rpc_client, &bob_pubkey); // recipient balance
 
     server.close().unwrap();
     remove_dir_all(ledger_path).unwrap();
@@ -176,17 +176,17 @@ fn test_wallet_cancel_tx() {
         .expect("base58-encoded public key");
     let process_id = Pubkey::new(&process_id_vec);
 
-    check_balance(40, &rpc_client, config_payer.id.pubkey()); // config_payer balance
-    check_balance(10, &rpc_client, process_id); // contract balance
-    check_balance(0, &rpc_client, bob_pubkey); // recipient balance
+    check_balance(40, &rpc_client, &config_payer.id.pubkey()); // config_payer balance
+    check_balance(10, &rpc_client, &process_id); // contract balance
+    check_balance(0, &rpc_client, &bob_pubkey); // recipient balance
 
     // Sign transaction by config_witness
     config_payer.command = WalletCommand::Cancel(process_id);
     process_command(&config_payer).unwrap();
 
-    check_balance(50, &rpc_client, config_payer.id.pubkey()); // config_payer balance
-    check_balance(0, &rpc_client, process_id); // contract balance
-    check_balance(0, &rpc_client, bob_pubkey); // recipient balance
+    check_balance(50, &rpc_client, &config_payer.id.pubkey()); // config_payer balance
+    check_balance(0, &rpc_client, &process_id); // contract balance
+    check_balance(0, &rpc_client, &bob_pubkey); // recipient balance
 
     server.close().unwrap();
     remove_dir_all(ledger_path).unwrap();

--- a/wallet/tests/request_airdrop.rs
+++ b/wallet/tests/request_airdrop.rs
@@ -24,7 +24,7 @@ fn test_wallet_request_airdrop() {
     let rpc_client = RpcClient::new_from_socket(leader_data.rpc);
 
     let balance = rpc_client
-        .retry_get_balance(1, bob_config.id.pubkey(), 1)
+        .retry_get_balance(1, &bob_config.id.pubkey(), 1)
         .unwrap()
         .unwrap();
     assert_eq!(balance, 50);


### PR DESCRIPTION
#### Problem
 current codebase mixes conventions for passing pubkeys by value or ref


 #### Summary of Changes
 update everything to passing Pubkey by ref, copying only where a value is needed