### PR TITLE
Reduce bootstrap leader stake

### DIFF
--- a/core/src/staking_utils.rs
+++ b/core/src/staking_utils.rs
@@ -152,7 +152,7 @@ mod tests {
     #[test]
     fn test_bank_staked_nodes_at_epoch() {
         let pubkey = Keypair::new().pubkey();
-        let bootstrap_lamports = 3;
+        let bootstrap_lamports = 2;
         let (genesis_block, _) =
             GenesisBlock::new_with_leader(bootstrap_lamports, &pubkey, bootstrap_lamports);
         let bank = Bank::new(&genesis_block);

--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -8,14 +8,10 @@ use std::error;
 
 /**
  * Bootstrap leader gets two lamports:
- * - one lamport to create an instance of the vote_program with
- * - one lamport for the transaction fee
- * - one second lamport to keep the node identity public key valid
+ * - one lamport to use as stake
+ * - one lamport to keep the node identity public key valid
  */
-//pub const BOOTSTRAP_LEADER_LAMPORTS: u64 = 3;
-// TODO: Until https://github.com/solana-labs/solana/issues/2355 is resolved the bootstrap leader
-// needs N lamports as its vote account gets re-created on every node restart, costing it lamports
-pub const BOOTSTRAP_LEADER_LAMPORTS: u64 = 10;
+pub const BOOTSTRAP_LEADER_LAMPORTS: u64 = 2;
 
 fn main() -> Result<(), Box<dyn error::Error>> {
     let matches = App::new("solana-genesis")

--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -15,7 +15,7 @@ use std::error;
 //pub const BOOTSTRAP_LEADER_LAMPORTS: u64 = 3;
 // TODO: Until https://github.com/solana-labs/solana/issues/2355 is resolved the bootstrap leader
 // needs N lamports as its vote account gets re-created on every node restart, costing it lamports
-pub const BOOTSTRAP_LEADER_LAMPORTS: u64 = 1_000_000;
+pub const BOOTSTRAP_LEADER_LAMPORTS: u64 = 10;
 
 fn main() -> Result<(), Box<dyn error::Error>> {
     let matches = App::new("solana-genesis")

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -315,7 +315,7 @@ impl Bank {
         assert!(genesis_block.bootstrap_leader_id != Pubkey::default());
         assert!(genesis_block.bootstrap_leader_vote_account_id != Pubkey::default());
         assert!(genesis_block.lamports >= genesis_block.bootstrap_leader_lamports);
-        assert!(genesis_block.bootstrap_leader_lamports >= 3);
+        assert!(genesis_block.bootstrap_leader_lamports >= 2);
 
         // Bootstrap leader collects fees until `new_from_parent` is called.
         self.collector_id = genesis_block.bootstrap_leader_id;
@@ -323,7 +323,7 @@ impl Bank {
         let mint_lamports = genesis_block.lamports - genesis_block.bootstrap_leader_lamports;
         self.deposit(&genesis_block.mint_id, mint_lamports);
 
-        let bootstrap_leader_lamports = 2;
+        let bootstrap_leader_lamports = 1;
         let bootstrap_leader_stake =
             genesis_block.bootstrap_leader_lamports - bootstrap_leader_lamports;
         self.deposit(
@@ -1230,12 +1230,12 @@ mod tests {
     #[test]
     fn test_process_genesis() {
         let dummy_leader_id = Keypair::new().pubkey();
-        let dummy_leader_lamports = 3;
+        let dummy_leader_lamports = 2;
         let (genesis_block, _) =
             GenesisBlock::new_with_leader(5, &dummy_leader_id, dummy_leader_lamports);
         let bank = Bank::new(&genesis_block);
-        assert_eq!(bank.get_balance(&genesis_block.mint_id), 2);
-        assert_eq!(bank.get_balance(&dummy_leader_id), 2);
+        assert_eq!(bank.get_balance(&genesis_block.mint_id), 3);
+        assert_eq!(bank.get_balance(&dummy_leader_id), 1);
     }
 
     #[test]

--- a/sdk/src/genesis_block.rs
+++ b/sdk/src/genesis_block.rs
@@ -9,9 +9,9 @@ use std::io::Write;
 use std::path::Path;
 
 // The default (and minimal) amount of lamports given to the bootstrap leader:
-// * 2 lamports for the bootstrap leader ID account to later setup another vote account
+// * 1 lamports for the bootstrap leader ID account
 // * 1 lamport for the bootstrap leader vote account
-pub const BOOTSTRAP_LEADER_LAMPORTS: u64 = 3;
+pub const BOOTSTRAP_LEADER_LAMPORTS: u64 = 2;
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct GenesisBlock {


### PR DESCRIPTION
#### Problem

In multinode demo, the bootstrap leader started out with far more stake than the validators, resulting in basically no leader rotation. 

#### Summary of Changes

Reduced the bootstrap stake to allow leader rotation.
