### PR TITLE
CustomProgram error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2317,6 +2317,7 @@ dependencies = [
  "bincode 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-runtime 0.12.0",
  "solana-sdk 0.12.0",
 ]

--- a/programs/budget/src/lib.rs
+++ b/programs/budget/src/lib.rs
@@ -5,7 +5,7 @@ use log::*;
 use solana_sdk::account::KeyedAccount;
 use solana_sdk::native_program::ProgramError;
 use solana_sdk::pubkey::Pubkey;
-use solana_sdk::solana_entrypoint;
+use solana_sdk::{custom_error, solana_entrypoint};
 
 solana_entrypoint!(entrypoint);
 fn entrypoint(
@@ -18,5 +18,6 @@ fn entrypoint(
 
     trace!("process_instruction: {:?}", data);
     trace!("keyed_accounts: {:?}", keyed_accounts);
-    process_instruction(program_id, keyed_accounts, data).map_err(|_| ProgramError::GenericError)
+    process_instruction(program_id, keyed_accounts, data)
+        .map_err(|e| ProgramError::CustomError(custom_error!(e)))
 }

--- a/programs/budget/src/lib.rs
+++ b/programs/budget/src/lib.rs
@@ -1,11 +1,12 @@
 mod budget_program;
 
 use crate::budget_program::process_instruction;
+use bincode::serialize;
 use log::*;
 use solana_sdk::account::KeyedAccount;
 use solana_sdk::native_program::ProgramError;
 use solana_sdk::pubkey::Pubkey;
-use solana_sdk::{custom_error, solana_entrypoint};
+use solana_sdk::solana_entrypoint;
 
 solana_entrypoint!(entrypoint);
 fn entrypoint(
@@ -19,5 +20,5 @@ fn entrypoint(
     trace!("process_instruction: {:?}", data);
     trace!("keyed_accounts: {:?}", keyed_accounts);
     process_instruction(program_id, keyed_accounts, data)
-        .map_err(|e| ProgramError::CustomError(custom_error!(e)))
+        .map_err(|e| ProgramError::CustomError(serialize(&e).unwrap()))
 }

--- a/programs/system/Cargo.toml
+++ b/programs/system/Cargo.toml
@@ -12,6 +12,7 @@ edition = "2018"
 bincode = "1.1.2"
 log = "0.4.2"
 serde = "1.0.89"
+serde_derive = "1.0.89"
 solana-sdk = { path = "../../sdk", version = "0.12.0" }
 
 [dev-dependencies]

--- a/programs/system/src/lib.rs
+++ b/programs/system/src/lib.rs
@@ -1,7 +1,7 @@
+use bincode::serialize;
 use log::*;
 use serde_derive::Serialize;
 use solana_sdk::account::KeyedAccount;
-use solana_sdk::custom_error;
 use solana_sdk::native_program::ProgramError;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::system_instruction::SystemInstruction;
@@ -101,7 +101,7 @@ pub fn entrypoint(
                     SystemError::ResultWithNegativeLamports => {
                         ProgramError::ResultWithNegativeLamports
                     }
-                    e => ProgramError::CustomError(custom_error!(e)),
+                    e => ProgramError::CustomError(serialize(&e).unwrap()),
                 }
             }),
             SystemInstruction::Assign { program_id } => {

--- a/programs/system/src/lib.rs
+++ b/programs/system/src/lib.rs
@@ -1,5 +1,7 @@
 use log::*;
+use serde_derive::Serialize;
 use solana_sdk::account::KeyedAccount;
+use solana_sdk::custom_error;
 use solana_sdk::native_program::ProgramError;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::system_instruction::SystemInstruction;
@@ -8,7 +10,7 @@ use solana_sdk::system_program;
 const FROM_ACCOUNT_INDEX: usize = 0;
 const TO_ACCOUNT_INDEX: usize = 1;
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Serialize, Debug, Clone, PartialEq)]
 enum SystemError {
     AccountAlreadyInUse,
     ResultWithNegativeLamports,
@@ -96,11 +98,10 @@ pub fn entrypoint(
                 program_id,
             } => create_system_account(keyed_accounts, lamports, space, &program_id).map_err(|e| {
                 match e {
-                    SystemError::AccountAlreadyInUse => ProgramError::InvalidArgument,
                     SystemError::ResultWithNegativeLamports => {
                         ProgramError::ResultWithNegativeLamports
                     }
-                    SystemError::SourceNotSystemAccount => ProgramError::InvalidArgument,
+                    e => ProgramError::CustomError(custom_error!(e)),
                 }
             }),
             SystemInstruction::Assign { program_id } => {

--- a/programs/token/src/lib.rs
+++ b/programs/token/src/lib.rs
@@ -1,8 +1,9 @@
+use bincode::serialize;
 use log::*;
 use solana_sdk::account::KeyedAccount;
 use solana_sdk::native_program::ProgramError;
 use solana_sdk::pubkey::Pubkey;
-use solana_sdk::{custom_error, solana_entrypoint};
+use solana_sdk::solana_entrypoint;
 
 mod token_program;
 
@@ -15,8 +16,8 @@ fn entrypoint(
 ) -> Result<(), ProgramError> {
     solana_logger::setup();
 
-    token_program::TokenProgram::process(program_id, info, input).map_err(|err| {
-        error!("error: {:?}", err);
-        ProgramError::CustomError(custom_error!(err))
+    token_program::TokenProgram::process(program_id, info, input).map_err(|e| {
+        error!("error: {:?}", e);
+        ProgramError::CustomError(serialize(&e).unwrap())
     })
 }

--- a/programs/token/src/lib.rs
+++ b/programs/token/src/lib.rs
@@ -2,7 +2,7 @@ use log::*;
 use solana_sdk::account::KeyedAccount;
 use solana_sdk::native_program::ProgramError;
 use solana_sdk::pubkey::Pubkey;
-use solana_sdk::solana_entrypoint;
+use solana_sdk::{custom_error, solana_entrypoint};
 
 mod token_program;
 
@@ -17,6 +17,6 @@ fn entrypoint(
 
     token_program::TokenProgram::process(program_id, info, input).map_err(|err| {
         error!("error: {:?}", err);
-        ProgramError::GenericError
+        ProgramError::CustomError(custom_error!(err))
     })
 }

--- a/programs/token/src/token_program.rs
+++ b/programs/token/src/token_program.rs
@@ -5,7 +5,7 @@ use solana_sdk::account::KeyedAccount;
 use solana_sdk::pubkey::Pubkey;
 use std;
 
-#[derive(Debug, PartialEq)]
+#[derive(Serialize, Debug, PartialEq)]
 pub enum Error {
     InvalidArgument,
     InsufficentFunds,

--- a/runtime/src/runtime.rs
+++ b/runtime/src/runtime.rs
@@ -107,7 +107,14 @@ fn execute_instruction(
         executable_accounts,
         program_accounts,
         tick_height,
-    )?;
+    )
+    .map_err(|err| match err {
+        ProgramError::CustomError(mut error) => {
+            error.truncate(32);
+            ProgramError::CustomError(error)
+        }
+        e => e,
+    })?;
 
     // Verify the instruction
     for ((pre_program_id, pre_lamports, pre_userdata), post_account) in

--- a/sdk/src/native_program.rs
+++ b/sdk/src/native_program.rs
@@ -51,20 +51,6 @@ impl std::fmt::Display for ProgramError {
 }
 impl std::error::Error for ProgramError {}
 
-// Convenience macro to serialize (and potentially truncate) a program-specific error to pass in
-// ProgramError::CustomError
-#[macro_export]
-macro_rules! custom_error(
-    ($program_error:expr) => ({
-        use bincode::serialize;
-        let mut error = serialize(&$program_error).expect("failed to serialize program error");
-        if error.len() > 32 {
-            error.truncate(32);
-        }
-        error
-    });
-);
-
 // All native programs export a symbol named process()
 pub const ENTRYPOINT: &str = "process";
 

--- a/sdk/src/native_program.rs
+++ b/sdk/src/native_program.rs
@@ -36,6 +36,12 @@ pub enum ProgramError {
 
     /// SystemInstruction::Assign was attempted on an account unowned by the system program
     AssignOfUnownedAccount,
+
+    /// CustomError allows on-chain programs to implement program-specific error types and see
+    /// them returned by the Solana runtime. A CustomError may be any type that is serialized
+    /// to a Vec of bytes, max length 32 bytes. Any CustomError Vec greater than this length will
+    /// be truncated by the runtime.
+    CustomError(Vec<u8>),
 }
 
 impl std::fmt::Display for ProgramError {

--- a/sdk/src/native_program.rs
+++ b/sdk/src/native_program.rs
@@ -51,6 +51,20 @@ impl std::fmt::Display for ProgramError {
 }
 impl std::error::Error for ProgramError {}
 
+// Convenience macro to serialize (and potentially truncate) a program-specific error to pass in
+// ProgramError::CustomError
+#[macro_export]
+macro_rules! custom_error(
+    ($program_error:expr) => ({
+        use bincode::serialize;
+        let mut error = serialize(&$program_error).expect("failed to serialize program error");
+        if error.len() > 32 {
+            error.truncate(32);
+        }
+        error
+    });
+);
+
 // All native programs export a symbol named process()
 pub const ENTRYPOINT: &str = "process";
 


### PR DESCRIPTION
#### Problem
As described succinctly in #3085, ProgramErrors produced at runtime are difficult to troubleshoot because they don't share any program-specific details. 

#### Summary of Changes
Add CustomError type to ProgramError enum, which takes up to 32 bytes of serialized data
Use simple serialization (and convenience macro) to pass current native program error enum types to CustomError.
...will implement CustomError in other native programs in a separate PR

Fixes #3085 
Toward #1993 
@mvines , if you would expand on your last comment on #1993 , I would be happy to include that clean-up here or in a quick follow-up PR.
