### PR TITLE
Filter vote accounts with no delegate from being selected in Rotation

### DIFF
--- a/core/src/staking_utils.rs
+++ b/core/src/staking_utils.rs
@@ -198,7 +198,13 @@ mod tests {
 
         // Make a mint vote account. Because the mint has nonzero stake, this
         // should show up in the active set
-        voting_keypair_tests::new_vote_account_with_vote(&mint_keypair, &bank_voter, &bank, 499, 0);
+        voting_keypair_tests::new_vote_account_with_delegate(
+            &mint_keypair,
+            &bank_voter,
+            &mint_keypair.pubkey(),
+            &bank,
+            499,
+        );
 
         // soonest slot that could be a new epoch is 1
         let mut slot = 1;

--- a/core/src/voting_keypair.rs
+++ b/core/src/voting_keypair.rs
@@ -120,6 +120,25 @@ pub mod tests {
         bank.process_transaction(&tx).unwrap();
     }
 
+    pub fn new_vote_account_with_delegate(
+        from_keypair: &Keypair,
+        voting_keypair: &Keypair,
+        delegate: &Pubkey,
+        bank: &Bank,
+        lamports: u64,
+    ) {
+        let blockhash = bank.last_blockhash();
+        let tx = VoteTransaction::new_account_with_delegate(
+            from_keypair,
+            voting_keypair,
+            delegate,
+            blockhash,
+            lamports,
+            0,
+        );
+        bank.process_transaction(&tx).unwrap();
+    }
+
     pub fn push_vote<T: KeypairUtil>(voting_keypair: &T, bank: &Bank, slot: u64) {
         let blockhash = bank.last_blockhash();
         let tx =


### PR DESCRIPTION
#### Problem

Since #3211, wallet can't fund and delegate accounts fast enough and the staking account id ends up in rotation and the network never recovers 

#### Summary of Changes

Since a lot of the stake design is going to change in the coming weeks, this is a stopgap solution that disallows staking accounts that are "delegated" to themselves from being considered in rotation.

@garious, this or ~we need to revive your PR with a single instruction to create and delegate~ wallet commands need to use `vote_transaction::new_account_with_delegate`
