### PR TITLE
Update current leader information in metrics and dashboard

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -217,6 +217,10 @@ impl ReplayStage {
                                     next_leader
                                 );
                                 poh_recorder.lock().unwrap().set_bank(&tpu_bank);
+                                inc_new_counter_info!(
+                                    "replay_stage-new_leader",
+                                    tpu_bank.slot() as usize
+                                );
                             }
                         }
                     })

--- a/metrics/testnet-monitor.json
+++ b/metrics/testnet-monitor.json
@@ -1412,7 +1412,7 @@
         }
       ],
       "thresholds": "",
-      "title": "Last Leader Rotation Tick",
+      "title": "Last Leader Rotation Slot",
       "type": "singlestat",
       "valueFontSize": "70%",
       "valueMaps": [


### PR DESCRIPTION
#### Problem
The dashboard has space to show current leader information, but nothing is being shown.

#### Summary of Changes
Push data to metrics whenever the leader changes. This will reflect into the dashboard.

Cherry pick from https://github.com/solana-labs/solana/pull/3226