### PR TITLE
Actually disable leader-rotation

### DIFF
--- a/ci/localnet-sanity.sh
+++ b/ci/localnet-sanity.sh
@@ -55,7 +55,7 @@ while getopts "ch?i:k:brxR" opt; do
     restartInterval=$OPTARG
     ;;
   b)
-    maybeNoLeaderRotation="--no-leader-rotation"
+    maybeNoLeaderRotation="--only-bootstrap-stake"
     ;;
   x)
     extraNodes=$((extraNodes + 1))

--- a/fullnode/src/main.rs
+++ b/fullnode/src/main.rs
@@ -71,11 +71,6 @@ fn main() {
                 .help("Rendezvous with the cluster at this gossip entry point"),
         )
         .arg(
-            Arg::with_name("no_leader_rotation")
-                .long("no-leader-rotation")
-                .help("Disable leader rotation"),
-        )
-        .arg(
             Arg::with_name("no_voting")
                 .long("no-voting")
                 .takes_value(false)
@@ -169,8 +164,6 @@ fn main() {
 
     fullnode_config.voting_disabled = matches.is_present("no_voting");
 
-    let use_only_bootstrap_leader = matches.is_present("no_leader_rotation");
-
     if matches.is_present("enable_rpc_exit") {
         fullnode_config.rpc_config.enable_fullnode_exit = true;
     }
@@ -234,9 +227,6 @@ fn main() {
     node.info.rpc_pubsub.set_port(rpc_pubsub_port);
 
     let genesis_block = GenesisBlock::load(ledger_path).expect("Unable to load genesis block");
-    if use_only_bootstrap_leader && node.info.id != genesis_block.bootstrap_leader_id {
-        fullnode_config.voting_disabled = true;
-    }
 
     let fullnode = Fullnode::new(
         node,

--- a/fullnode/src/main.rs
+++ b/fullnode/src/main.rs
@@ -226,8 +226,6 @@ fn main() {
     node.info.rpc.set_port(rpc_port);
     node.info.rpc_pubsub.set_port(rpc_pubsub_port);
 
-    let genesis_block = GenesisBlock::load(ledger_path).expect("Unable to load genesis block");
-
     let fullnode = Fullnode::new(
         node,
         &keypair,

--- a/fullnode/src/main.rs
+++ b/fullnode/src/main.rs
@@ -5,7 +5,6 @@ use solana::contact_info::ContactInfo;
 use solana::fullnode::{Fullnode, FullnodeConfig};
 use solana::local_vote_signer_service::LocalVoteSignerService;
 use solana::service::Service;
-use solana_sdk::genesis_block::GenesisBlock;
 use solana_sdk::signature::{read_keypair, Keypair, KeypairUtil};
 use std::fs::File;
 use std::process::exit;

--- a/multinode-demo/bootstrap-leader.sh
+++ b/multinode-demo/bootstrap-leader.sh
@@ -85,7 +85,7 @@ $program \
 pid=$!
 oom_score_adj "$pid" 1000
 
-if [[ ${leader_rotation} = true ]] ; then
+if [[ $setup_stakes = true ]] ; then
   setup_fullnode_staking 127.0.0.1 "$bootstrap_leader_id_path" "$bootstrap_leader_staker_id_path" "${extra_fullnode_args[@]}"
 fi
 

--- a/multinode-demo/bootstrap-leader.sh
+++ b/multinode-demo/bootstrap-leader.sh
@@ -86,7 +86,7 @@ pid=$!
 oom_score_adj "$pid" 1000
 
 if [[ $setup_stakes = true ]] ; then
-  setup_fullnode_staking 127.0.0.1 "$bootstrap_leader_id_path" "$bootstrap_leader_staker_id_path" "${extra_fullnode_args[@]}"
+  setup_fullnode_staking 127.0.0.1 "$bootstrap_leader_id_path" "$bootstrap_leader_staker_id_path"
 fi
 
 wait "$pid"

--- a/multinode-demo/bootstrap-leader.sh
+++ b/multinode-demo/bootstrap-leader.sh
@@ -47,6 +47,16 @@ $program \
 pid=$!
 oom_score_adj "$pid" 1000
 
-setup_fullnode_staking 127.0.0.1 "$bootstrap_leader_id_path" "$bootstrap_leader_staker_id_path"
+leader_rotation=true
+for i in "$@"; do
+if [[ ${i} == --no-leader-rotation ]] ; then
+    leader_rotation=false
+    break
+fi
+done
+
+if [[ ${leader_rotation} = true ]] ; then
+  setup_fullnode_staking 127.0.0.1 "$bootstrap_leader_id_path" "$bootstrap_leader_staker_id_path" "$@"
+fi
 
 wait "$pid"

--- a/multinode-demo/bootstrap-leader.sh
+++ b/multinode-demo/bootstrap-leader.sh
@@ -27,7 +27,7 @@ while [[ ${1:0:1} = - ]]; do
   elif [[ $1 = --init-complete-file ]]; then
     extra_fullnode_args+=("$1" "$2")
     shift 2
-  elif [[ $1 = --no-leader-rotation ]]; then
+  elif [[ $1 = --only-bootstrap-stake ]]; then
     setup_stakes=false
     shift
   elif [[ $1 = --public-address ]]; then

--- a/multinode-demo/bootstrap-leader.sh
+++ b/multinode-demo/bootstrap-leader.sh
@@ -11,7 +11,7 @@ source "$here"/common.sh
 source "$here"/../scripts/oom-score-adj.sh
 
 if [[ $1 = -h ]]; then
-  fullnode_usage
+  fullnode_usage "$@"
 fi
 
 extra_fullnode_args=()
@@ -46,7 +46,7 @@ while [[ ${1:0:1} = - ]]; do
 done
 
 if [[ -n $3 ]]; then
-  fullnode_usage
+  fullnode_usage "$@"
 fi
 
 

--- a/multinode-demo/bootstrap-leader.sh
+++ b/multinode-demo/bootstrap-leader.sh
@@ -10,6 +10,46 @@ source "$here"/common.sh
 # shellcheck source=scripts/oom-score-adj.sh
 source "$here"/../scripts/oom-score-adj.sh
 
+if [[ $1 = -h ]]; then
+  fullnode_usage
+fi
+
+extra_fullnode_args=()
+setup_stakes=true
+
+while [[ ${1:0:1} = - ]]; do
+  if [[ $1 = --blockstream ]]; then
+    extra_fullnode_args+=("$1" "$2")
+    shift 2
+  elif [[ $1 = --enable-rpc-exit ]]; then
+    extra_fullnode_args+=("$1")
+    shift
+  elif [[ $1 = --init-complete-file ]]; then
+    extra_fullnode_args+=("$1" "$2")
+    shift 2
+  elif [[ $1 = --no-leader-rotation ]]; then
+    setup_stakes=false
+    shift
+  elif [[ $1 = --public-address ]]; then
+    extra_fullnode_args+=("$1")
+    shift
+  elif [[ $1 = --no-signer ]]; then
+    extra_fullnode_args+=("$1")
+    shift
+  elif [[ $1 = --rpc-port ]]; then
+    extra_fullnode_args+=("$1" "$2")
+    shift 2
+  else
+    echo "Unknown argument: $1"
+    exit 1
+  fi
+done
+
+if [[ -n $3 ]]; then
+  fullnode_usage
+fi
+
+
 [[ -f "$SOLANA_CONFIG_DIR"/bootstrap-leader-id.json ]] || {
   echo "$SOLANA_CONFIG_DIR/bootstrap-leader-id.json not found, create it by running:"
   echo
@@ -27,12 +67,10 @@ tune_system
 
 $solana_ledger_tool --ledger "$SOLANA_CONFIG_DIR"/bootstrap-leader-ledger verify
 
-
 bootstrap_leader_id_path="$SOLANA_CONFIG_DIR"/bootstrap-leader-id.json
 bootstrap_leader_staker_id_path="$SOLANA_CONFIG_DIR"/bootstrap-leader-staker-id.json
 bootstrap_leader_staker_id=$($solana_wallet --keypair "$bootstrap_leader_staker_id_path" address)
 
-set -x
 trap 'kill "$pid" && wait "$pid"' INT TERM ERR
 $program \
   --identity "$bootstrap_leader_id_path" \
@@ -42,21 +80,13 @@ $program \
   --accounts "$SOLANA_CONFIG_DIR"/bootstrap-leader-accounts \
   --rpc-port 8899 \
   --rpc-drone-address 127.0.0.1:9900 \
-  "$@" \
+  "${extra_fullnode_args[@]}" \
   > >($bootstrap_leader_logger) 2>&1 &
 pid=$!
 oom_score_adj "$pid" 1000
 
-leader_rotation=true
-for i in "$@"; do
-if [[ ${i} == --no-leader-rotation ]] ; then
-    leader_rotation=false
-    break
-fi
-done
-
 if [[ ${leader_rotation} = true ]] ; then
-  setup_fullnode_staking 127.0.0.1 "$bootstrap_leader_id_path" "$bootstrap_leader_staker_id_path" "$@"
+  setup_fullnode_staking 127.0.0.1 "$bootstrap_leader_id_path" "$bootstrap_leader_staker_id_path" "${extra_fullnode_args[@]}"
 fi
 
 wait "$pid"

--- a/multinode-demo/common.sh
+++ b/multinode-demo/common.sh
@@ -195,9 +195,9 @@ usage: $0 [-x] [--blockstream PATH] [--init-complete-file FILE] [--no-leader-rot
 
 Start a full node on the specified network
 
-  -x                    - start a new, dynamically-configured full node
+  -x                    - start a new, dynamically-configured full node. Does not apply to the bootstrap leader
   -X [label]            - start or restart a dynamically-configured full node with
-                          the specified label
+                          the specified label. Does not apply to the bootstrap leader
   --blockstream PATH    - open blockstream at this unix domain socket location
   --init-complete-file FILE - create this file, if it doesn't already exist, once node initialization is complete
   --no-leader-rotation  - disable leader rotation

--- a/multinode-demo/common.sh
+++ b/multinode-demo/common.sh
@@ -171,20 +171,6 @@ setup_fullnode_staking() {
   return 0
 }
 
-parse_extra_args() {
-    declare leader_rotation=true
-    declare extra_args
-        echo $@
-    for i in "$@"; do
-    if [[ ${i} == --no-leader-rotation ]]; then
-        leader_rotation=false
-    else
-        extra_args+=(${i})
-    fi
-
-    done
-}
-
 fullnode_usage() {
   if [[ -n $1 ]]; then
     echo "$*"

--- a/multinode-demo/common.sh
+++ b/multinode-demo/common.sh
@@ -171,6 +171,43 @@ setup_fullnode_staking() {
   return 0
 }
 
+parse_extra_args() {
+    declare leader_rotation=true
+    declare extra_args
+        echo $@
+    for i in "$@"; do
+    if [[ ${i} == --no-leader-rotation ]]; then
+        leader_rotation=false
+    else
+        extra_args+=(${i})
+    fi
+
+    done
+}
+
+fullnode_usage() {
+  if [[ -n $1 ]]; then
+    echo "$*"
+    echo
+  fi
+  cat <<EOF
+usage: $0 [-x] [--blockstream PATH] [--init-complete-file FILE] [--no-leader-rotation] [--no-signer] [--rpc-port port] [rsync network path to bootstrap leader configuration] [network entry point]
+
+Start a full node on the specified network
+
+  -x                    - start a new, dynamically-configured full node
+  -X [label]            - start or restart a dynamically-configured full node with
+                          the specified label
+  --blockstream PATH    - open blockstream at this unix domain socket location
+  --init-complete-file FILE - create this file, if it doesn't already exist, once node initialization is complete
+  --no-leader-rotation  - disable leader rotation
+  --public-address      - advertise public machine address in gossip.  By default the local machine address is advertised
+  --no-signer           - start node without vote signer
+  --rpc-port port       - custom RPC port for this node
+
+EOF
+  exit 1
+}
 
 # The directory on the bootstrap leader that is rsynced by other full nodes as
 # they boot (TODO: Eventually this should go away)

--- a/multinode-demo/common.sh
+++ b/multinode-demo/common.sh
@@ -177,19 +177,19 @@ fullnode_usage() {
     echo
   fi
   cat <<EOF
-usage: $0 [-x] [--blockstream PATH] [--init-complete-file FILE] [--no-leader-rotation] [--no-signer] [--rpc-port port] [rsync network path to bootstrap leader configuration] [network entry point]
+usage: $0 [-x] [--blockstream PATH] [--init-complete-file FILE] [--only-bootstrap-stake] [--no-signer] [--rpc-port port] [rsync network path to bootstrap leader configuration] [network entry point]
 
 Start a full node on the specified network
 
-  -x                    - start a new, dynamically-configured full node. Does not apply to the bootstrap leader
-  -X [label]            - start or restart a dynamically-configured full node with
-                          the specified label. Does not apply to the bootstrap leader
-  --blockstream PATH    - open blockstream at this unix domain socket location
+  -x                        - start a new, dynamically-configured full node. Does not apply to the bootstrap leader
+  -X [label]                - start or restart a dynamically-configured full node with
+                              the specified label. Does not apply to the bootstrap leader
+  --blockstream PATH        - open blockstream at this unix domain socket location
   --init-complete-file FILE - create this file, if it doesn't already exist, once node initialization is complete
-  --no-leader-rotation  - disable leader rotation
-  --public-address      - advertise public machine address in gossip.  By default the local machine address is advertised
-  --no-signer           - start node without vote signer
-  --rpc-port port       - custom RPC port for this node
+  --only-bootstrap-stake    - Only stake the bootstrap leader, effectively disabling leader rotation
+  --public-address          - advertise public machine address in gossip.  By default the local machine address is advertised
+  --no-signer               - start node without vote signer
+  --rpc-port port           - custom RPC port for this node
 
 EOF
   exit 1

--- a/multinode-demo/fullnode.sh
+++ b/multinode-demo/fullnode.sh
@@ -215,6 +215,15 @@ $program \
 pid=$!
 oom_score_adj "$pid" 1000
 
-setup_fullnode_staking "${leader_address%:*}" "$fullnode_id_path" "$fullnode_staker_id_path"
+leader_rotation=true
+for i in ${extra_fullnode_args[@]}; do
+  if [[ ${i} == --no-leader-rotation ]] ; then
+    leader_rotation=false
+    break
+  fi
+done
 
+if [[ ${leader_rotation} = true ]] ; then
+  setup_fullnode_staking "${leader_address%:*}" "$fullnode_id_path" "$fullnode_staker_id_path"
+fi
 wait "$pid"

--- a/multinode-demo/fullnode.sh
+++ b/multinode-demo/fullnode.sh
@@ -36,7 +36,7 @@ while [[ ${1:0:1} = - ]]; do
   elif [[ $1 = --init-complete-file ]]; then
     extra_fullnode_args+=("$1" "$2")
     shift 2
-  elif [[ $1 = --no-leader-rotation ]]; then
+  elif [[ $1 = --only-bootstrap-stake ]]; then
     setup_stakes=false
     shift
   elif [[ $1 = --public-address ]]; then

--- a/multinode-demo/fullnode.sh
+++ b/multinode-demo/fullnode.sh
@@ -10,7 +10,7 @@ source "$here"/common.sh
 source "$here"/../scripts/oom-score-adj.sh
 
 if [[ $1 = -h ]]; then
-  fullnode_usage
+  fullnode_usage "$@"
 fi
 
 gossip_port=9000
@@ -55,7 +55,7 @@ while [[ ${1:0:1} = - ]]; do
 done
 
 if [[ -n $3 ]]; then
-  fullnode_usage
+  fullnode_usage "$@"
 fi
 
 find_leader() {

--- a/multinode-demo/fullnode.sh
+++ b/multinode-demo/fullnode.sh
@@ -9,37 +9,14 @@ source "$here"/common.sh
 # shellcheck source=scripts/oom-score-adj.sh
 source "$here"/../scripts/oom-score-adj.sh
 
-usage() {
-  if [[ -n $1 ]]; then
-    echo "$*"
-    echo
-  fi
-  cat <<EOF
-usage: $0 [-x] [--blockstream PATH] [--init-complete-file FILE] [--no-leader-rotation] [--no-signer] [--rpc-port port] [rsync network path to bootstrap leader configuration] [network entry point]
-
-Start a full node on the specified network
-
-  -x                    - start a new, dynamically-configured full node
-  -X [label]            - start or restart a dynamically-configured full node with
-                          the specified label
-  --blockstream PATH    - open blockstream at this unix domain socket location
-  --init-complete-file FILE - create this file, if it doesn't already exist, once node initialization is complete
-  --no-leader-rotation  - disable leader rotation
-  --public-address      - advertise public machine address in gossip.  By default the local machine address is advertised
-  --no-signer           - start node without vote signer
-  --rpc-port port       - custom RPC port for this node
-
-EOF
-  exit 1
-}
-
 if [[ $1 = -h ]]; then
-  usage
+  fullnode_usage
 fi
 
 gossip_port=9000
 extra_fullnode_args=()
 self_setup=0
+setup_stakes=true
 
 while [[ ${1:0:1} = - ]]; do
   if [[ $1 = -X ]]; then
@@ -60,7 +37,7 @@ while [[ ${1:0:1} = - ]]; do
     extra_fullnode_args+=("$1" "$2")
     shift 2
   elif [[ $1 = --no-leader-rotation ]]; then
-    extra_fullnode_args+=("$1")
+    setup_stakes=false
     shift
   elif [[ $1 = --public-address ]]; then
     extra_fullnode_args+=("$1")
@@ -78,7 +55,7 @@ while [[ ${1:0:1} = - ]]; do
 done
 
 if [[ -n $3 ]]; then
-  usage
+  fullnode_usage
 fi
 
 find_leader() {
@@ -215,15 +192,8 @@ $program \
 pid=$!
 oom_score_adj "$pid" 1000
 
-leader_rotation=true
-for i in ${extra_fullnode_args[@]}; do
-  if [[ ${i} == --no-leader-rotation ]] ; then
-    leader_rotation=false
-    break
-  fi
-done
-
-if [[ ${leader_rotation} = true ]] ; then
+if [[ $setup_stakes = true ]]; then
   setup_fullnode_staking "${leader_address%:*}" "$fullnode_id_path" "$fullnode_staker_id_path"
 fi
+
 wait "$pid"

--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -76,7 +76,7 @@ local|tar)
 
     maybeNoLeaderRotation=
     if ! $leaderRotation; then
-      maybeNoLeaderRotation="--no-leader-rotation"
+      maybeNoLeaderRotation="--only-bootstrap-stake"
     fi
     maybePublicAddress=
     if $publicNetwork; then
@@ -96,7 +96,7 @@ local|tar)
 
     args=()
     if ! $leaderRotation; then
-      args+=("--no-leader-rotation")
+      args+=("--only-bootstrap-stake")
     fi
     if $publicNetwork; then
       args+=("--public-address")

--- a/scripts/wallet-sanity.sh
+++ b/scripts/wallet-sanity.sh
@@ -48,8 +48,8 @@ $solana_keygen
 node_readiness=false
 timeout=60
 while [[ $timeout -gt 0 ]]; do
-  output="$solana_wallet "${entrypoint[@]}" get-transaction-count"
-  if [[ $output ]]; then
+  output=$($solana_wallet "${entrypoint[@]}" get-transaction-count)
+  if [[ -n $output ]]; then
     node_readiness=true
     break
   fi

--- a/scripts/wallet-sanity.sh
+++ b/scripts/wallet-sanity.sh
@@ -48,10 +48,8 @@ $solana_keygen
 node_readiness=false
 timeout=60
 while [[ $timeout -gt 0 ]]; do
-  expected_output="Leader ready"
-  exec 42>&1
-  output=$($solana_wallet "${entrypoint[@]}" get-transaction-count | tee >(cat - >&42))
-  if [[ $output -gt 0 ]]; then
+  output="$solana_wallet "${entrypoint[@]}" get-transaction-count"
+  if [[ $output ]]; then
     node_readiness=true
     break
   fi


### PR DESCRIPTION
#### Problem

The ''--no-leader-rotation" flag disables voting but voting is no longer a criteria for leader rotation selection.

#### Summary of Changes

Updated the flag to disable staking the fullnodes instead. 

~@rob-solana, Justification for leaving the name "--no-leader-rotation" is that "--no-staking-accounts" hides the fact that it disables rotation. There is basically no other use for those staking accounts right now.~

Fixes #3231
