### PR TITLE
Remove non-essential programs from runtime/

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2143,9 +2143,14 @@ name = "solana-genesis"
 version = "0.13.0"
 dependencies = [
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hashbrown 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana 0.13.0",
+ "solana-budget-api 0.13.0",
  "solana-sdk 0.13.0",
+ "solana-storage-api 0.13.0",
+ "solana-token-api 0.13.0",
+ "solana-vote-api 0.13.0",
 ]
 
 [[package]]
@@ -2266,12 +2271,9 @@ dependencies = [
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-budget-api 0.13.0",
  "solana-logger 0.13.0",
  "solana-metrics 0.13.0",
  "solana-sdk 0.13.0",
- "solana-storage-api 0.13.0",
- "solana-token-api 0.13.0",
  "solana-vote-api 0.13.0",
 ]
 
@@ -2402,6 +2404,7 @@ dependencies = [
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana 0.13.0",
  "solana-budget-api 0.13.0",
+ "solana-budget-program 0.13.0",
  "solana-drone 0.13.0",
  "solana-logger 0.13.0",
  "solana-sdk 0.13.0",
@@ -2422,6 +2425,7 @@ dependencies = [
  "reqwest 0.9.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana 0.13.0",
+ "solana-budget-program 0.13.0",
  "solana-logger 0.13.0",
  "solana-netutil 0.13.0",
  "solana-runtime 0.13.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ solana = { path = "core", version = "0.13.0" }
 solana-logger = { path = "logger", version = "0.13.0" }
 solana-netutil = { path = "netutil", version = "0.13.0" }
 solana-runtime = { path = "runtime", version = "0.13.0" }
+solana-budget-program = { path = "programs/budget", version = "0.13.0" }
 solana-sdk = { path = "sdk", version = "0.13.0" }
 sys-info = "0.5.6"
 

--- a/core/src/rpc_pubsub.rs
+++ b/core/src/rpc_pubsub.rs
@@ -332,7 +332,13 @@ mod tests {
 
     #[test]
     fn test_account_subscribe() {
-        let (genesis_block, alice) = GenesisBlock::new(10_000);
+        let (mut genesis_block, alice) = GenesisBlock::new(10_000);
+
+        // This test depends on the budget program
+        genesis_block
+            .native_programs
+            .push(("solana_budget_program".to_string(), solana_budget_api::id()));
+
         let bob_pubkey = Keypair::new().pubkey();
         let witness = Keypair::new();
         let contract_funds = Keypair::new();

--- a/core/src/thin_client.rs
+++ b/core/src/thin_client.rs
@@ -423,7 +423,12 @@ pub fn new_fullnode() -> (Fullnode, ContactInfo, Keypair, String) {
     let node = Node::new_localhost_with_pubkey(&node_keypair.pubkey());
     let contact_info = node.info.clone();
 
-    let (genesis_block, mint_keypair) = GenesisBlock::new_with_leader(10_000, &contact_info.id, 42);
+    let (mut genesis_block, mint_keypair) =
+        GenesisBlock::new_with_leader(10_000, &contact_info.id, 42);
+    genesis_block
+        .native_programs
+        .push(("solana_budget_program".to_string(), solana_budget_api::id()));
+
     let (ledger_path, _blockhash) = create_new_tmp_ledger!(&genesis_block);
 
     let voting_keypair = Keypair::new();

--- a/genesis/Cargo.toml
+++ b/genesis/Cargo.toml
@@ -13,6 +13,13 @@ clap = "2.32.0"
 serde_json = "1.0.39"
 solana = { path = "../core", version = "0.13.0" }
 solana-sdk = { path = "../sdk", version = "0.13.0" }
+solana-budget-api = { path = "../programs/budget_api", version = "0.13.0" }
+solana-storage-api = { path = "../programs/storage_api", version = "0.13.0" }
+solana-token-api = { path = "../programs/token_api", version = "0.13.0" }
+
+[dev-dependencies]
+hashbrown = "0.1.8"
+solana-vote-api = { path = "../programs/vote_api", version = "0.13.0" }
 
 [features]
 cuda = ["solana/cuda"]

--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -70,7 +70,76 @@ fn main() -> Result<(), Box<dyn error::Error>> {
     );
     genesis_block.mint_id = mint_keypair.pubkey();
     genesis_block.bootstrap_leader_vote_account_id = bootstrap_leader_vote_account_keypair.pubkey();
+    genesis_block.native_programs.extend_from_slice(&[
+        ("solana_budget_program".to_string(), solana_budget_api::id()),
+        (
+            "solana_storage_program".to_string(),
+            solana_storage_api::id(),
+        ),
+        ("solana_token_program".to_string(), solana_token_api::id()),
+    ]);
 
     create_new_ledger(ledger_path, &genesis_block)?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use hashbrown::HashSet;
+    use solana_sdk::pubkey::Pubkey;
+
+    #[test]
+    fn test_program_ids() {
+        let system = Pubkey::new(&[
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0,
+        ]);
+        let native = Pubkey::new(&[
+            1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0,
+        ]);
+        let bpf = Pubkey::new(&[
+            128, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0,
+        ]);
+        let budget = Pubkey::new(&[
+            129, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0,
+        ]);
+        let storage = Pubkey::new(&[
+            130, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0,
+        ]);
+        let token = Pubkey::new(&[
+            131, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0,
+        ]);
+        let vote = Pubkey::new(&[
+            132, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0,
+        ]);
+
+        assert_eq!(solana_sdk::system_program::id(), system);
+        assert_eq!(solana_sdk::native_loader::id(), native);
+        assert_eq!(solana_sdk::bpf_loader::id(), bpf);
+        assert_eq!(solana_budget_api::id(), budget);
+        assert_eq!(solana_storage_api::id(), storage);
+        assert_eq!(solana_token_api::id(), token);
+        assert_eq!(solana_vote_api::id(), vote);
+    }
+
+    #[test]
+    fn test_program_id_uniqueness() {
+        let mut unique = HashSet::new();
+        let ids = vec![
+            solana_sdk::system_program::id(),
+            solana_sdk::native_loader::id(),
+            solana_sdk::bpf_loader::id(),
+            solana_budget_api::id(),
+            solana_storage_api::id(),
+            solana_token_api::id(),
+            solana_vote_api::id(),
+        ];
+        assert!(ids.into_iter().all(move |id| unique.insert(id)));
+    }
 }

--- a/programs/storage/tests/storage.rs
+++ b/programs/storage/tests/storage.rs
@@ -37,7 +37,11 @@ fn get_storage_blockhash(bank: &Bank, account: &Pubkey) -> Hash {
 
 #[test]
 fn test_bank_storage() {
-    let (genesis_block, alice) = GenesisBlock::new(1000);
+    let (mut genesis_block, alice) = GenesisBlock::new(1000);
+    genesis_block.native_programs.push((
+        "solana_storage_program".to_string(),
+        solana_storage_api::id(),
+    ));
     let bank = Bank::new(&genesis_block);
 
     let bob = Keypair::new();

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -22,12 +22,9 @@ rand = "0.6.5"
 serde = "1.0.88"
 serde_derive = "1.0.88"
 serde_json = "1.0.38"
-solana-budget-api = { path = "../programs/budget_api", version = "0.13.0" }
 solana-logger = { path = "../logger", version = "0.13.0" }
 solana-metrics = { path = "../metrics", version = "0.13.0" }
 solana-sdk = { path = "../sdk", version = "0.13.0" }
-solana-storage-api = { path = "../programs/storage_api", version = "0.13.0" }
-solana-token-api = { path = "../programs/token_api", version = "0.13.0" }
 solana-vote-api = { path = "../programs/vote_api", version = "0.13.0" }
 
 [lib]

--- a/sdk/src/genesis_block.rs
+++ b/sdk/src/genesis_block.rs
@@ -24,6 +24,7 @@ pub struct GenesisBlock {
     pub slots_per_epoch: u64,
     pub stakers_slot_offset: u64,
     pub epoch_warmup: bool,
+    pub native_programs: Vec<(String, Pubkey)>,
 }
 
 impl GenesisBlock {
@@ -57,6 +58,7 @@ impl GenesisBlock {
                 slots_per_epoch: DEFAULT_SLOTS_PER_EPOCH,
                 stakers_slot_offset: DEFAULT_SLOTS_PER_EPOCH,
                 epoch_warmup: true,
+                native_programs: vec![],
             },
             mint_keypair,
         )

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -24,5 +24,8 @@ solana-sdk = { path = "../sdk", version = "0.13.0" }
 solana-vote-api = { path = "../programs/vote_api", version = "0.13.0" }
 solana-vote-signer = { path = "../vote-signer", version = "0.13.0" }
 
+[dev-dependencies]
+solana-budget-program = { path = "../programs/budget", version = "0.13.0" }
+
 [features]
 cuda = ["solana/cuda"]


### PR DESCRIPTION
`runtime/` pulls in non-essential native programs like budget, token, storage which adds unwanted dependencies.  Instead the GenesisBlock can define additional native programs that a given cluster may assume are always present.

`runtime/` now only assumes system_program, native_loader, bpf_loader, and vote_program.   One day maybe we'll get to `runtime/` only depending on the first two, but baby steps...

Fixes #3233 

