### PR TITLE
Replicator fixes

### DIFF
--- a/core/src/retransmit_stage.rs
+++ b/core/src/retransmit_stage.rs
@@ -7,6 +7,7 @@ use crate::cluster_info::{
     NEIGHBORHOOD_SIZE,
 };
 use crate::packet::SharedBlob;
+use crate::repair_service::RepairSlotRange;
 use crate::result::{Error, Result};
 use crate::service::Service;
 use crate::staking_utils;
@@ -130,6 +131,7 @@ impl RetransmitStage {
             retransmit_sender,
             repair_socket,
             exit,
+            RepairSlotRange::default(),
         );
 
         let thread_hdls = vec![t_retransmit];

--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -3,7 +3,7 @@
 use crate::blocktree::Blocktree;
 use crate::cluster_info::ClusterInfo;
 use crate::db_window::*;
-use crate::repair_service::RepairService;
+use crate::repair_service::{RepairService, RepairSlotRange};
 use crate::result::{Error, Result};
 use crate::service::Service;
 use crate::streamer::{BlobReceiver, BlobSender};
@@ -103,9 +103,15 @@ impl WindowService {
         retransmit: BlobSender,
         repair_socket: Arc<UdpSocket>,
         exit: &Arc<AtomicBool>,
+        repair_slot_range: RepairSlotRange,
     ) -> WindowService {
-        let repair_service =
-            RepairService::new(blocktree.clone(), exit, repair_socket, cluster_info.clone());
+        let repair_service = RepairService::new(
+            blocktree.clone(),
+            exit,
+            repair_socket,
+            cluster_info.clone(),
+            repair_slot_range,
+        );
         let exit = exit.clone();
         let t_window = Builder::new()
             .name("solana-window".to_string())
@@ -153,6 +159,7 @@ mod test {
     use crate::blocktree::Blocktree;
     use crate::cluster_info::{ClusterInfo, Node};
     use crate::entry::make_consecutive_blobs;
+    use crate::repair_service::RepairSlotRange;
     use crate::service::Service;
     use crate::streamer::{blob_receiver, responder};
     use crate::window_service::WindowService;
@@ -190,6 +197,7 @@ mod test {
             s_retransmit,
             Arc::new(leader_node.sockets.repair),
             &exit,
+            RepairSlotRange::default(),
         );
         let t_responder = {
             let (s_responder, r_responder) = channel();
@@ -261,6 +269,7 @@ mod test {
             s_retransmit,
             Arc::new(leader_node.sockets.repair),
             &exit,
+            RepairSlotRange::default(),
         );
         let t_responder = {
             let (s_responder, r_responder) = channel();

--- a/replicator/src/main.rs
+++ b/replicator/src/main.rs
@@ -82,8 +82,10 @@ fn main() {
 
     let leader_info = ContactInfo::new_gossip_entry_point(&network_addr);
 
-    let replicator =
-        Replicator::new(ledger_path, node, &leader_info, &Arc::new(keypair), None).unwrap();
+    let mut replicator =
+        Replicator::new(ledger_path, node, leader_info, Arc::new(keypair), None).unwrap();
 
-    replicator.join();
+    replicator.run();
+
+    replicator.close();
 }


### PR DESCRIPTION
#### Problem

Replicator needs to download a portion of the ledger. Also, the replicator_startup_test is ignored, since the replicator does not know how to wait for the ledger to download from blocktree.

#### Summary of Changes

Add RepairSlotRange in window service to download a range of slots and break up replicator::new() into more functions so hopefully can test them independently.

Fixes #
