### PR TITLE
Don't vote for empty leader transmissions

### DIFF
--- a/core/src/poh_recorder.rs
+++ b/core/src/poh_recorder.rs
@@ -448,7 +448,7 @@ mod tests {
         poh_recorder.tick();
         assert_eq!(poh_recorder.tick_cache.len(), 2);
         poh_recorder.reset(poh_recorder.poh.tick_height, poh_recorder.poh.hash, 0);
-        assert_eq!(poh_recorder.tick_cache.len(), 2);
+        assert_eq!(poh_recorder.tick_cache.len(), 0);
     }
 
     #[test]
@@ -462,28 +462,7 @@ mod tests {
             poh_recorder.tick_cache[0].0.hash,
             0,
         );
-        assert_eq!(poh_recorder.tick_cache.len(), 2);
-        poh_recorder.reset(
-            poh_recorder.tick_cache[1].1,
-            poh_recorder.tick_cache[1].0.hash,
-            0,
-        );
-        assert_eq!(poh_recorder.tick_cache.len(), 2);
-    }
-
-    #[test]
-    #[should_panic]
-    fn test_reset_with_cached_bad_height() {
-        let (mut poh_recorder, _entry_receiver) = PohRecorder::new(0, Hash::default(), 0);
-        poh_recorder.tick();
-        poh_recorder.tick();
-        assert_eq!(poh_recorder.tick_cache.len(), 2);
-        //mixed up heights
-        poh_recorder.reset(
-            poh_recorder.tick_cache[0].1,
-            poh_recorder.tick_cache[1].0.hash,
-            0,
-        );
+        assert_eq!(poh_recorder.tick_cache.len(), 0);
     }
 
     #[test]

--- a/core/src/poh_recorder.rs
+++ b/core/src/poh_recorder.rs
@@ -97,27 +97,6 @@ impl PohRecorder {
         self.set_working_bank(working_bank);
     }
 
-    // Checks to see if the Poh Recorder has already generate this hash, If so,
-    // this implies the hash is the last id in a slot of all ticks (an empty transmission)
-    // from the leader and should not be voted on.
-    pub fn is_votable(&self, tick_height: u64, blockhash: Hash) -> bool {
-        let existing = self.tick_cache.iter().any(|(entry, entry_tick_height)| {
-            if entry.hash == blockhash {
-                assert_eq!(*entry_tick_height, tick_height);
-            }
-            entry.hash == blockhash
-        });
-        if existing {
-            info!(
-                "reset skipped for: {},{}",
-                self.poh.hash, self.poh.tick_height
-            );
-            return false;
-        }
-
-        true
-    }
-
     // Flush cache will delay flushing the cache for a bank until it past the WorkingBank::min_tick_height
     // On a record flush will flush the cache at the WorkingBank::min_tick_height, since a record
     // occurs after the min_tick_height was generated

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -116,7 +116,9 @@ impl ReplayStage {
                             {
                                 info!("{} slot_full alert failed: {:?}", my_id, e);
                             }
-                            votable.push(bank);
+                            if bank.is_votable() {
+                                votable.push(bank);
+                            }
                         }
                     }
 

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -20,7 +20,7 @@ use solana_sdk::timing::duration_as_ms;
 use solana_vote_api::vote_transaction::VoteTransaction;
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::mpsc::{channel, Receiver, RecvTimeoutError};
+use std::sync::mpsc::{channel, Receiver, RecvTimeoutError, Sender};
 use std::sync::{Arc, Mutex, RwLock};
 use std::thread::{self, Builder, JoinHandle};
 use std::time::Duration;
@@ -108,17 +108,13 @@ impl ReplayStage {
                         }
                         let max_tick_height = (*bank_slot + 1) * bank.ticks_per_slot() - 1;
                         if bank.tick_height() == max_tick_height {
-                            bank.freeze();
-                            info!("bank frozen {}", bank.slot());
-                            progress.remove(bank_slot);
-                            if let Err(e) =
-                                slot_full_sender.send((bank.slot(), bank.collector_id()))
-                            {
-                                info!("{} slot_full alert failed: {:?}", my_id, e);
-                            }
-                            if bank.is_votable() {
-                                votable.push(bank);
-                            }
+                            Self::process_completed_bank(
+                                &my_id,
+                                bank,
+                                &mut progress,
+                                &mut votable,
+                                &slot_full_sender,
+                            );
                         }
                     }
 
@@ -317,6 +313,24 @@ impl ReplayStage {
         Ok(())
     }
 
+    fn process_completed_bank(
+        my_id: &Pubkey,
+        bank: Arc<Bank>,
+        progress: &mut HashMap<u64, (Hash, usize)>,
+        votable: &mut Vec<Arc<Bank>>,
+        slot_full_sender: &Sender<(u64, Pubkey)>,
+    ) {
+        bank.freeze();
+        info!("bank frozen {}", bank.slot());
+        progress.remove(&bank.slot());
+        if let Err(e) = slot_full_sender.send((bank.slot(), bank.collector_id())) {
+            info!("{} slot_full alert failed: {:?}", my_id, e);
+        }
+        if bank.is_votable() {
+            votable.push(bank);
+        }
+    }
+
     fn generate_new_bank_forks(blocktree: &Blocktree, forks: &mut BankForks) {
         // Find the next slot that chains to the old slot
         let frozen_banks = forks.frozen_banks();
@@ -439,6 +453,42 @@ mod test {
             poh_service.join().unwrap();
         }
         let _ignored = remove_dir_all(&my_ledger_path);
+    }
+
+    #[test]
+    fn test_no_vote_empty_transmission() {
+        let genesis_block = GenesisBlock::new(10_000).0;
+        let bank = Arc::new(Bank::new(&genesis_block));
+        let mut blockhash = bank.last_blockhash();
+        let mut entries = Vec::new();
+        for _ in 0..genesis_block.ticks_per_slot {
+            let entry = next_entry_mut(&mut blockhash, 1, vec![]); //just ticks
+            entries.push(entry);
+        }
+        let (sender, _receiver) = channel();
+
+        let mut progress = HashMap::new();
+        let (forward_entry_sender, _forward_entry_receiver) = channel();
+        ReplayStage::replay_entries_into_bank(
+            &bank,
+            entries.clone(),
+            &mut progress,
+            &forward_entry_sender,
+            0,
+        )
+        .unwrap();
+
+        let mut votable = vec![];
+        ReplayStage::process_completed_bank(
+            &Pubkey::default(),
+            bank,
+            &mut progress,
+            &mut votable,
+            &sender,
+        );
+        assert!(progress.is_empty());
+        // Don't vote on slot that only contained ticks
+        assert!(votable.is_empty());
     }
 
     #[test]

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -844,7 +844,6 @@ impl Bank {
         // tick_height is using an AtomicUSize because AtomicU64 is not yet a stable API.
         // Until we can switch to AtomicU64, fail if usize is not the same as u64
         assert_eq!(std::usize::MAX, 0xFFFF_FFFF_FFFF_FFFF);
-
         self.tick_height.load(Ordering::SeqCst) as u64
     }
 
@@ -889,6 +888,7 @@ mod tests {
     use super::*;
     use bincode::serialize;
     use solana_sdk::genesis_block::{GenesisBlock, BOOTSTRAP_LEADER_LAMPORTS};
+    use solana_sdk::hash;
     use solana_sdk::native_program::ProgramError;
     use solana_sdk::signature::{Keypair, KeypairUtil};
     use solana_sdk::system_instruction::SystemInstruction;
@@ -1608,5 +1608,37 @@ mod tests {
             // assert that we got to "normal" mode
             assert!(last_slots_in_epoch == slots_per_epoch);
         }
+    }
+
+    #[test]
+    fn test_is_delta_true() {
+        let (genesis_block, mint_keypair) = GenesisBlock::new(500);
+        let bank = Arc::new(Bank::new(&genesis_block));
+        let key1 = Keypair::new();
+        let tx_move_mint_to_1 =
+            SystemTransaction::new_move(&mint_keypair, &key1.pubkey(), 1, genesis_block.hash(), 0);
+        assert_eq!(bank.process_transaction(&tx_move_mint_to_1), Ok(()));
+        assert_eq!(bank.is_delta.load(Ordering::Relaxed), true);
+    }
+
+    #[test]
+    fn test_is_votable() {
+        let (genesis_block, mint_keypair) = GenesisBlock::new(500);
+        let bank = Arc::new(Bank::new(&genesis_block));
+        let key1 = Keypair::new();
+        assert_eq!(bank.is_votable(), false);
+
+        // Set is_delta to true
+        let tx_move_mint_to_1 =
+            SystemTransaction::new_move(&mint_keypair, &key1.pubkey(), 1, genesis_block.hash(), 0);
+        assert_eq!(bank.process_transaction(&tx_move_mint_to_1), Ok(()));
+        assert_eq!(bank.is_votable(), false);
+
+        // Register enough ticks to hit max tick height
+        for i in 0..genesis_block.ticks_per_slot - 1 {
+            bank.register_tick(&hash::hash(format!("hello world {}", i).as_bytes()));
+        }
+
+        assert_eq!(bank.is_votable(), true);
     }
 }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -879,7 +879,7 @@ impl Bank {
     }
 
     pub fn is_votable(&self) -> bool {
-        let max_tick_height = self.slot * self.ticks_per_slot;
+        let max_tick_height = (self.slot + 1) * self.ticks_per_slot - 1;
         self.is_delta.load(Ordering::Relaxed) && self.tick_height() == max_tick_height
     }
 }


### PR DESCRIPTION
#### Problem
Currently there's a check in pohrecorder -> reset() that skips resetting to a specific hash, slot index if the PohRecorder has already generated that hash in its tick cache.

However, this causes a bug when a node votes on an empty leader transmission (a slot full of ticks):

Example: 

A validator votes at slot 1, and thus starts a PohRecorder for slot 1. Then they receive nothing but ticks for slot 2. Meanwhile the local PohRecorder also ticks past 2 with all ticks, so we vote on slot 2, but don't reset the PohRecorder due to that check in PohRecorder. Now if the validator is leader at slot 3, then our current code will set parent to 2, but PohRecorder will send all the ticks from slot 1 + 2 b/c it was never reset.


#### Summary of Changes

Don't vote for empty leader transmissions.  This and the change here: https://github.com/solana-labs/solana/pull/3238 should fix the problem.

Fixes #
