### PR TITLE
Replay Stage start_leader() can use wrong parent fork() (#3238)

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -432,7 +432,7 @@ pub fn create_test_recorder(
 ) {
     let exit = Arc::new(AtomicBool::new(false));
     let (poh_recorder, entry_receiver) =
-        PohRecorder::new(bank.tick_height(), bank.last_blockhash());
+        PohRecorder::new(bank.tick_height(), bank.last_blockhash(), bank.slot());
     let poh_recorder = Arc::new(Mutex::new(poh_recorder));
     let poh_service = PohService::new(poh_recorder.clone(), &PohServiceConfig::default(), &exit);
     (exit, poh_recorder, poh_service, entry_receiver)
@@ -641,7 +641,7 @@ mod tests {
         };
 
         let (poh_recorder, entry_receiver) =
-            PohRecorder::new(bank.tick_height(), bank.last_blockhash());
+            PohRecorder::new(bank.tick_height(), bank.last_blockhash(), bank.slot());
         let poh_recorder = Arc::new(Mutex::new(poh_recorder));
 
         poh_recorder.lock().unwrap().set_working_bank(working_bank);
@@ -694,7 +694,7 @@ mod tests {
             max_tick_height: bank.tick_height() + 1,
         };
         let (poh_recorder, entry_receiver) =
-            PohRecorder::new(bank.tick_height(), bank.last_blockhash());
+            PohRecorder::new(bank.tick_height(), bank.last_blockhash(), bank.slot());
         let poh_recorder = Arc::new(Mutex::new(poh_recorder));
 
         poh_recorder.lock().unwrap().set_working_bank(working_bank);

--- a/core/src/fullnode.rs
+++ b/core/src/fullnode.rs
@@ -107,7 +107,7 @@ impl Fullnode {
             bank.last_blockhash(),
         );
         let (poh_recorder, entry_receiver) =
-            PohRecorder::new(bank.tick_height(), bank.last_blockhash());
+            PohRecorder::new(bank.tick_height(), bank.last_blockhash(), bank.slot());
         let poh_recorder = Arc::new(Mutex::new(poh_recorder));
         let poh_service = PohService::new(poh_recorder.clone(), &config.tick_config, &exit);
         poh_recorder.lock().unwrap().clear_bank_signal =

--- a/core/src/leader_schedule_utils.rs
+++ b/core/src/leader_schedule_utils.rs
@@ -43,8 +43,8 @@ pub fn num_ticks_left_in_slot(bank: &Bank, tick_height: u64) -> u64 {
     bank.ticks_per_slot() - tick_height % bank.ticks_per_slot() - 1
 }
 
-pub fn tick_height_to_slot(bank: &Bank, tick_height: u64) -> u64 {
-    tick_height / bank.ticks_per_slot()
+pub fn tick_height_to_slot(ticks_per_slot: u64, tick_height: u64) -> u64 {
+    tick_height / ticks_per_slot
 }
 
 #[cfg(test)]

--- a/core/src/poh_service.rs
+++ b/core/src/poh_service.rs
@@ -110,7 +110,8 @@ mod tests {
         let (genesis_block, _mint_keypair) = GenesisBlock::new(2);
         let bank = Arc::new(Bank::new(&genesis_block));
         let prev_hash = bank.last_blockhash();
-        let (poh_recorder, entry_receiver) = PohRecorder::new(bank.tick_height(), prev_hash);
+        let (poh_recorder, entry_receiver) =
+            PohRecorder::new(bank.tick_height(), prev_hash, bank.slot());
         let poh_recorder = Arc::new(Mutex::new(poh_recorder));
         let exit = Arc::new(AtomicBool::new(false));
         let working_bank = WorkingBank {


### PR DESCRIPTION
*  Make sure start_leader starts on the last voted block, not necessarily the biggest indexed bank in frozen_slots()

* Fix tvu test

#### Problem

#### Summary of Changes

Fixes #
