### PR TITLE
Switch version file from .txt to .yaml; add target tuple to version.yml

### DIFF
--- a/ci/publish-tarball.sh
+++ b/ci/publish-tarball.sh
@@ -30,10 +30,25 @@ echo --- Creating tarball
   set -x
   rm -rf solana-release/
   mkdir solana-release/
+
+  case "$(uname)" in
+  Darwin)
+    TARGET=x86_64-apple-darwin
+    ;;
+  Linux)
+    TARGET=x86_64-unknown-linux-gnu
+    ;;
+  *)
+    TARGET=unknown-unknown-unknown
+    ;;
+  esac
+  COMMIT="$(git rev-parse HEAD)"
+
   (
-    echo "$CHANNEL_OR_TAG"
-    git rev-parse HEAD
-  ) > solana-release/version.txt
+    echo "channel: $CHANNEL"
+    echo "commit: $COMMIT"
+    echo "target: $TARGET"
+  ) > solana-release/version.yml
 
   scripts/cargo-install-all.sh solana-release
 

--- a/net/net.sh
+++ b/net/net.sh
@@ -285,7 +285,7 @@ start() {
       set -x
       rm -rf "$SOLANA_ROOT"/solana-release
       (cd "$SOLANA_ROOT"; tar jxv) < "$tarballFilename"
-      cat "$SOLANA_ROOT"/solana-release/version.txt
+      cat "$SOLANA_ROOT"/solana-release/version.yml
     )
     ;;
   local)
@@ -370,7 +370,10 @@ start() {
   case $deployMethod in
   tar)
     networkVersion="$(
-      tail -n1 "$SOLANA_ROOT"/solana-release/version.txt || echo "tar-unknown"
+      (
+        set -o pipefail
+        grep "^version: " "$SOLANA_ROOT"/solana-release/version.yml | head -n1 | cut -d\  -f2
+      ) || echo "tar-unknown"
     )"
     ;;
   local)


### PR DESCRIPTION
The version.txt file in the release tarballs are hard and error-prone to parse.  Replace with version.yml.  

Also include the target tuple in version.yml to advertise the supported architecture of a given release tarball


