### PR TITLE
Add trait representing structures that can be packaged into a blob

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -8,7 +8,7 @@ use crate::leader_confirmation_service::LeaderConfirmationService;
 use crate::leader_schedule_utils;
 use crate::packet;
 use crate::packet::SharedPackets;
-use crate::packet::{Packet, Packets};
+use crate::packet::{Meta, Packet, Packets};
 use crate::poh_recorder::{PohRecorder, PohRecorderError, WorkingBankEntries};
 use crate::poh_service::{PohService, PohServiceConfig};
 use crate::result::{Error, Result};
@@ -88,7 +88,7 @@ impl BankingStage {
             .iter()
             .flat_map(|(p, start_index)| &p.packets[**start_index..])
             .collect();
-        let blobs = packet::packets_to_blobs(&packets);
+        let blobs = packet::packables_to_blobs::<Meta, _, Packet>(&packets);
 
         for blob in blobs {
             socket.send_to(&blob.data[..blob.meta.size], tpu_via_blobs)?;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -44,6 +44,7 @@ pub mod leader_schedule;
 pub mod leader_schedule_utils;
 pub mod local_cluster;
 pub mod local_vote_signer_service;
+pub mod packable;
 pub mod packet;
 pub mod poh;
 pub mod poh_recorder;

--- a/core/src/result.rs
+++ b/core/src/result.rs
@@ -4,6 +4,7 @@ use crate::blocktree;
 use crate::cluster_info;
 #[cfg(feature = "erasure")]
 use crate::erasure;
+use crate::packable;
 use crate::packet;
 use crate::poh_recorder;
 use bincode;
@@ -30,6 +31,7 @@ pub enum Error {
     SendError,
     PohRecorderError(poh_recorder::PohRecorderError),
     BlocktreeError(blocktree::BlocktreeError),
+    PackableError(packable::PackableError),
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -111,6 +113,11 @@ impl std::convert::From<poh_recorder::PohRecorderError> for Error {
 impl std::convert::From<blocktree::BlocktreeError> for Error {
     fn from(e: blocktree::BlocktreeError) -> Error {
         Error::BlocktreeError(e)
+    }
+}
+impl std::convert::From<packable::PackableError> for Error {
+    fn from(e: packable::PackableError) -> Error {
+        Error::PackableError(e)
     }
 }
 


### PR DESCRIPTION
#### Problem
There's currently no common way to represent structures that need to be packaged into blobs. This causes a lot of code duplication for different structures (entries, packets) that need to be stored and transmitted in a blob format. 

#### Summary of Changes
1) Add a trait `Packable` representing things that can be packaged together in a blob
2) Plumb Packable through the current code that converts packets to blobs

Fixes #
Should make packaging multiple entries into a blob straightforward
