### PR TITLE
remove ticks_per_slot from blocktree

### DIFF
--- a/core/src/blockstream_service.rs
+++ b/core/src/blockstream_service.rs
@@ -127,7 +127,7 @@ mod test {
         genesis_block.ticks_per_slot = ticks_per_slot;
 
         let (ledger_path, _blockhash) = create_new_tmp_ledger!(&genesis_block);
-        let blocktree = Blocktree::open_config(&ledger_path, ticks_per_slot).unwrap();
+        let blocktree = Blocktree::open(&ledger_path).unwrap();
 
         // Set up blockstream
         let mut blockstream = Blockstream::new("test_stream".to_string());
@@ -150,7 +150,9 @@ mod test {
         let expected_entries = entries.clone();
         let expected_tick_heights = [5, 6, 7, 8, 8, 9];
 
-        blocktree.write_entries(1, 0, 0, &entries).unwrap();
+        blocktree
+            .write_entries(1, 0, 0, ticks_per_slot, &entries)
+            .unwrap();
 
         slot_full_sender.send((1, leader_id)).unwrap();
         BlockstreamService::process_entries(

--- a/core/src/blocktree/rocks.rs
+++ b/core/src/blocktree/rocks.rs
@@ -12,7 +12,6 @@ use rocksdb::{
 };
 
 use solana_sdk::hash::Hash;
-use solana_sdk::timing::DEFAULT_TICKS_PER_SLOT;
 
 use std::fs;
 use std::io;
@@ -105,14 +104,12 @@ impl Blocktree {
         // Create the erasure column family
         let erasure_cf = ErasureCf::new(db.clone());
 
-        let ticks_per_slot = DEFAULT_TICKS_PER_SLOT;
         Ok(Blocktree {
             db,
             meta_cf,
             data_cf,
             erasure_cf,
             new_blobs_signals: vec![],
-            ticks_per_slot,
         })
     }
 

--- a/core/src/blocktree_processor.rs
+++ b/core/src/blocktree_processor.rs
@@ -274,8 +274,8 @@ mod tests {
         let (ledger_path, mut blockhash) = create_new_tmp_ledger!(&genesis_block);
         debug!("ledger_path: {:?}", ledger_path);
 
-        let blocktree = Blocktree::open_config(&ledger_path, ticks_per_slot)
-            .expect("Expected to successfully open database ledger");
+        let blocktree =
+            Blocktree::open(&ledger_path).expect("Expected to successfully open database ledger");
 
         // Write slot 1
         // slot 1, points at slot 0.  Missing one tick
@@ -334,8 +334,8 @@ mod tests {
                    slot 4
 
         */
-        let blocktree = Blocktree::open_config(&ledger_path, ticks_per_slot)
-            .expect("Expected to successfully open database ledger");
+        let blocktree =
+            Blocktree::open(&ledger_path).expect("Expected to successfully open database ledger");
 
         // Fork 1, ending at slot 3
         let last_slot1_entry_hash =
@@ -472,7 +472,9 @@ mod tests {
 
         let blocktree =
             Blocktree::open(&ledger_path).expect("Expected to successfully open database ledger");
-        blocktree.write_entries(1, 0, 0, &entries).unwrap();
+        blocktree
+            .write_entries(1, 0, 0, genesis_block.ticks_per_slot, &entries)
+            .unwrap();
         let entry_height = genesis_block.ticks_per_slot + entries.len() as u64;
         let (bank_forks, bank_forks_info) =
             process_blocktree(&genesis_block, &blocktree, None).unwrap();

--- a/core/src/chacha.rs
+++ b/core/src/chacha.rs
@@ -142,11 +142,13 @@ mod tests {
         let ledger_dir = "chacha_test_encrypt_file";
         let ledger_path = get_tmp_ledger_path(ledger_dir);
         let ticks_per_slot = 16;
-        let blocktree = Arc::new(Blocktree::open_config(&ledger_path, ticks_per_slot).unwrap());
+        let blocktree = Arc::new(Blocktree::open(&ledger_path).unwrap());
         let out_path = Path::new("test_chacha_encrypt_file_output.txt.enc");
 
         let entries = make_tiny_deterministic_test_entries(32);
-        blocktree.write_entries(0, 0, 0, &entries).unwrap();
+        blocktree
+            .write_entries(0, 0, 0, ticks_per_slot, &entries)
+            .unwrap();
 
         let mut key = hex!(
             "abcd1234abcd1234abcd1234abcd1234 abcd1234abcd1234abcd1234abcd1234

--- a/core/src/chacha_cuda.rs
+++ b/core/src/chacha_cuda.rs
@@ -127,9 +127,11 @@ mod tests {
         let ledger_dir = "test_encrypt_file_many_keys_single";
         let ledger_path = get_tmp_ledger_path(ledger_dir);
         let ticks_per_slot = 16;
-        let blocktree = Arc::new(Blocktree::open_config(&ledger_path, ticks_per_slot).unwrap());
+        let blocktree = Arc::new(Blocktree::open(&ledger_path).unwrap());
 
-        blocktree.write_entries(0, 0, 0, &entries).unwrap();
+        blocktree
+            .write_entries(0, 0, 0, ticks_per_slot, &entries)
+            .unwrap();
 
         let out_path = Path::new("test_chacha_encrypt_file_many_keys_single_output.txt.enc");
 
@@ -161,8 +163,10 @@ mod tests {
         let ledger_dir = "test_encrypt_file_many_keys_multiple";
         let ledger_path = get_tmp_ledger_path(ledger_dir);
         let ticks_per_slot = 16;
-        let blocktree = Arc::new(Blocktree::open_config(&ledger_path, ticks_per_slot).unwrap());
-        blocktree.write_entries(0, 0, 0, &entries).unwrap();
+        let blocktree = Arc::new(Blocktree::open(&ledger_path).unwrap());
+        blocktree
+            .write_entries(0, 0, 0, ticks_per_slot, &entries)
+            .unwrap();
 
         let out_path = Path::new("test_chacha_encrypt_file_many_keys_multiple_output.txt.enc");
 

--- a/core/src/fullnode.rs
+++ b/core/src/fullnode.rs
@@ -282,9 +282,8 @@ pub fn new_banks_from_blocktree(
     let genesis_block =
         GenesisBlock::load(blocktree_path).expect("Expected to successfully open genesis block");
 
-    let (blocktree, ledger_signal_receiver) =
-        Blocktree::open_with_config_signal(blocktree_path, genesis_block.ticks_per_slot)
-            .expect("Expected to successfully open database ledger");
+    let (blocktree, ledger_signal_receiver) = Blocktree::open_with_signal(blocktree_path)
+        .expect("Expected to successfully open database ledger");
 
     let (bank_forks, bank_forks_info) =
         blocktree_processor::process_blocktree(&genesis_block, &blocktree, account_paths)

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -440,7 +440,9 @@ mod test {
 
             info!("Send ReplayStage an entry, should see it on the ledger writer receiver");
             let next_tick = create_ticks(1, bank.last_blockhash());
-            blocktree.write_entries(1, 0, 0, next_tick.clone()).unwrap();
+            blocktree
+                .write_entries(1, 0, 0, genesis_block.ticks_per_slot, next_tick.clone())
+                .unwrap();
 
             let received_tick = ledger_writer_recv
                 .recv()

--- a/core/src/storage_stage.rs
+++ b/core/src/storage_stage.rs
@@ -513,8 +513,10 @@ mod tests {
         let (ledger_path, _blockhash) = create_new_tmp_ledger!(&genesis_block);
 
         let entries = make_tiny_test_entries(64);
-        let blocktree = Blocktree::open_config(&ledger_path, ticks_per_slot).unwrap();
-        blocktree.write_entries(1, 0, 0, &entries).unwrap();
+        let blocktree = Blocktree::open(&ledger_path).unwrap();
+        blocktree
+            .write_entries(1, 0, 0, ticks_per_slot, &entries)
+            .unwrap();
 
         let cluster_info = test_cluster_info(&keypair.pubkey());
 
@@ -575,8 +577,10 @@ mod tests {
         let (ledger_path, _blockhash) = create_new_tmp_ledger!(&genesis_block);
 
         let entries = make_tiny_test_entries(128);
-        let blocktree = Blocktree::open_config(&ledger_path, ticks_per_slot).unwrap();
-        blocktree.write_entries(1, 0, 0, &entries).unwrap();
+        let blocktree = Blocktree::open(&ledger_path).unwrap();
+        blocktree
+            .write_entries(1, 0, 0, ticks_per_slot, &entries)
+            .unwrap();
 
         let cluster_info = test_cluster_info(&keypair.pubkey());
 


### PR DESCRIPTION
#### Problem
 blocktree carries around ticks_per_slot, which it only uses for tests, now

 #### Summary of Changes
 remove ticks_per_slot from blocktree, move management to tests