### PR TITLE
add support for finding the next slot a node will be leader

### DIFF
--- a/core/src/leader_schedule.rs
+++ b/core/src/leader_schedule.rs
@@ -21,9 +21,10 @@ impl LeaderSchedule {
     }
 }
 
-impl Index<usize> for LeaderSchedule {
+impl Index<u64> for LeaderSchedule {
     type Output = Pubkey;
-    fn index(&self, index: usize) -> &Pubkey {
+    fn index(&self, index: u64) -> &Pubkey {
+        let index = index as usize;
         &self.slot_leaders[index % self.slot_leaders.len()]
     }
 }


### PR DESCRIPTION
#### Problem
 replay_stage asks poh_recorder if its "next tick" will be the current node's
   leader slot, but poh_recorder can race way ahead of replay_stage in ticks,
   and the node can potentially its slot

 poh_recorder should instead know what tick it's due to start having a bank,
  which means looking into the future of the leader schedule.

 with this, the poh_recorder can then just expose a "yeap, I'm due" to
  replay_stage

 #### Summary of Changes
 as a first step, add an API to look into the future of the leader schedule