### PR TITLE
Give last leader some grace ticks to catch up

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -431,8 +431,13 @@ pub fn create_test_recorder(
     Receiver<WorkingBankEntries>,
 ) {
     let exit = Arc::new(AtomicBool::new(false));
-    let (poh_recorder, entry_receiver) =
-        PohRecorder::new(bank.tick_height(), bank.last_blockhash(), bank.slot());
+    let (poh_recorder, entry_receiver) = PohRecorder::new(
+        bank.tick_height(),
+        bank.last_blockhash(),
+        bank.slot(),
+        None,
+        bank.ticks_per_slot(),
+    );
     let poh_recorder = Arc::new(Mutex::new(poh_recorder));
     let poh_service = PohService::new(poh_recorder.clone(), &PohServiceConfig::default(), &exit);
     (exit, poh_recorder, poh_service, entry_receiver)

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -435,7 +435,7 @@ pub fn create_test_recorder(
         bank.tick_height(),
         bank.last_blockhash(),
         bank.slot(),
-        None,
+        Some(4),
         bank.ticks_per_slot(),
     );
     let poh_recorder = Arc::new(Mutex::new(poh_recorder));
@@ -669,8 +669,13 @@ mod tests {
             max_tick_height: std::u64::MAX,
         };
 
-        let (poh_recorder, entry_receiver) =
-            PohRecorder::new(bank.tick_height(), bank.last_blockhash(), bank.slot());
+        let (poh_recorder, entry_receiver) = PohRecorder::new(
+            bank.tick_height(),
+            bank.last_blockhash(),
+            bank.slot(),
+            None,
+            bank.ticks_per_slot(),
+        );
         let poh_recorder = Arc::new(Mutex::new(poh_recorder));
 
         poh_recorder.lock().unwrap().set_working_bank(working_bank);
@@ -722,8 +727,13 @@ mod tests {
             min_tick_height: bank.tick_height(),
             max_tick_height: bank.tick_height() + 1,
         };
-        let (poh_recorder, entry_receiver) =
-            PohRecorder::new(bank.tick_height(), bank.last_blockhash(), bank.slot());
+        let (poh_recorder, entry_receiver) = PohRecorder::new(
+            bank.tick_height(),
+            bank.last_blockhash(),
+            bank.slot(),
+            Some(4),
+            bank.ticks_per_slot(),
+        );
         let poh_recorder = Arc::new(Mutex::new(poh_recorder));
 
         poh_recorder.lock().unwrap().set_working_bank(working_bank);

--- a/core/src/fullnode.rs
+++ b/core/src/fullnode.rs
@@ -9,6 +9,7 @@ use crate::entry::create_ticks;
 use crate::entry::next_entry_mut;
 use crate::entry::Entry;
 use crate::gossip_service::GossipService;
+use crate::leader_schedule_utils;
 use crate::poh_recorder::PohRecorder;
 use crate::poh_service::{PohService, PohServiceConfig};
 use crate::rpc::JsonRpcConfig;
@@ -106,8 +107,13 @@ impl Fullnode {
             bank.tick_height(),
             bank.last_blockhash(),
         );
-        let (poh_recorder, entry_receiver) =
-            PohRecorder::new(bank.tick_height(), bank.last_blockhash(), bank.slot());
+        let (poh_recorder, entry_receiver) = PohRecorder::new(
+            bank.tick_height(),
+            bank.last_blockhash(),
+            bank.slot(),
+            leader_schedule_utils::next_leader_slot(&id, bank.slot(), &bank),
+            bank.ticks_per_slot(),
+        );
         let poh_recorder = Arc::new(Mutex::new(poh_recorder));
         let poh_service = PohService::new(poh_recorder.clone(), &config.tick_config, &exit);
         poh_recorder.lock().unwrap().clear_bank_signal =

--- a/core/src/poh_recorder.rs
+++ b/core/src/poh_recorder.rs
@@ -111,7 +111,7 @@ impl PohRecorder {
         );
         std::mem::swap(&mut cache, &mut self.tick_cache);
         self.start_slot = start_slot;
-        self.start_tick = tick_height;
+        self.start_tick = tick_height + 1;
         self.poh = Poh::new(blockhash, tick_height);
         self.max_last_leader_grace_ticks = ticks_per_slot / MAX_LAST_LEADER_GRACE_TICKS_FACTOR;
         self.start_leader_at_tick = my_next_leader_slot
@@ -233,7 +233,7 @@ impl PohRecorder {
                 sender,
                 clear_bank_signal: None,
                 start_slot,
-                start_tick: tick_height,
+                start_tick: tick_height + 1,
                 start_leader_at_tick: my_leader_slot_index
                     .map(|slot| {
                         Some(

--- a/core/src/poh_service.rs
+++ b/core/src/poh_service.rs
@@ -110,8 +110,13 @@ mod tests {
         let (genesis_block, _mint_keypair) = GenesisBlock::new(2);
         let bank = Arc::new(Bank::new(&genesis_block));
         let prev_hash = bank.last_blockhash();
-        let (poh_recorder, entry_receiver) =
-            PohRecorder::new(bank.tick_height(), prev_hash, bank.slot());
+        let (poh_recorder, entry_receiver) = PohRecorder::new(
+            bank.tick_height(),
+            prev_hash,
+            bank.slot(),
+            Some(4),
+            bank.ticks_per_slot(),
+        );
         let poh_recorder = Arc::new(Mutex::new(poh_recorder));
         let exit = Arc::new(AtomicBool::new(false));
         let working_bank = WorkingBank {


### PR DESCRIPTION
#### Problem
At leader rotation the new leader might not have received all blobs from the previous leader. In such case it will potentially assume the previous leader has died and use empty ticks to fill up its slot. If the blobs from previous leader were just delayed (and dropped) it'll result into unnecessary forks. We need a solution to avoid these unnecessary forks.

#### Summary of Changes
The new leader gives some grace time (ticks) to the previous leader. If the pending blobs are received within the duration it'll process them and avoid forks.

Fixes #
