### PR TITLE
Block until instances are confirmed to be deleted

### DIFF
--- a/net/gce.sh
+++ b/net/gce.sh
@@ -389,6 +389,14 @@ delete() {
       echo "No instances found matching '$filter'"
     else
       cloud_DeleteInstances true
+      while true; do
+        cloud_FindInstances "$filter"
+        if [[ ${#instances[@]} -eq 0 ]]; then
+          break;
+        fi
+        echo "(waiting for instances to be deleted)"
+        sleep 3
+      done
     fi
   done
   rm -f "$configFile"


### PR DESCRIPTION
AWS-based testnet restarts have been failing apparently because we don't ensure the previous instances are fully terminated before creating new instances.  