### PR TITLE
Put test-bench back in a container

### DIFF
--- a/ci/buildkite.yml
+++ b/ci/buildkite.yml
@@ -11,7 +11,7 @@ steps:
     timeout_in_minutes: 20
     agents:
       - "queue=cuda"
-  - command: "ci/test-bench.sh"
+  - command: "ci/docker-run.sh solanalabs/rust-nightly:2019-01-31 ci/test-bench.sh"
     name: "bench"
     timeout_in_minutes: 20
   - command: "ci/docker-run.sh solanalabs/rust:1.32.0 ci/test-stable.sh"


### PR DESCRIPTION
#### Problem
Random rust nightly updates break CI

#### Summary of Changes
Use the nightly container so we can control updates

