### PR TITLE
KvStore logging, error-detection, and thread-safety improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -230,6 +230,11 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "build_const"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "bv"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -368,6 +373,14 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "crc"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "build_const 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1973,6 +1986,7 @@ dependencies = [
  "bs58 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crc 1.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hashbrown 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex-literal 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2983,6 +2997,7 @@ dependencies = [
 "checksum block-padding 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4fc4358306e344bf9775d0197fd00d2603e5afb0771bb353538630f022068ea3"
 "checksum bloom 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d00ac8e5056d6d65376a3c1aa5c7c34850d6949ace17f0266953a254eb3d6fe8"
 "checksum bs58 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0de79cfb98e7aa9988188784d8664b4b5dad6eaaa0863b91d9a4ed871d4f7a42"
+"checksum build_const 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "39092a32794787acd8525ee150305ff051b0aa6cc2abaf193924f5ab05425f39"
 "checksum bv 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6cd4ae9e585e783756cd14b0ea21863acdfbb6383664ac2f7c9ef8d180a14727"
 "checksum byte-tools 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "560c32574a12a89ecd91f5e742165893f86e3ab98d21f8ea548658eb9eef5f40"
 "checksum byte-tools 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "980479e6fde23246dfb54d47580d66b4e99202e7579c5eaa9fe10ecb5ebd2182"
@@ -3001,6 +3016,7 @@ dependencies = [
 "checksum constant_time_eq 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8ff012e225ce166d4422e0e78419d901719760f62ae2b7969ca6b564d1b54a9e"
 "checksum core-foundation 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "286e0b41c3a20da26536c6000a280585d519fd07b3956b43aed8a79e9edce980"
 "checksum core-foundation-sys 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "716c271e8613ace48344f723b60b900a93150271e5be206212d052bbc0883efa"
+"checksum crc 1.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d663548de7f5cca343f1e0a48d14dcfb0e9eb4e079ec58883b7251539fa10aeb"
 "checksum crc32fast 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e91d5240c6975ef33aeb5f148f35275c25eda8e8a5f95abe421978b05b8bf192"
 "checksum crossbeam-channel 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "137bc235f622ffaa0428e3854e24acb53291fc0b3ff6fb2cb75a8be6fb02f06b"
 "checksum crossbeam-deque 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f739f8c5363aca78cfb059edf753d8f0d36908c348f3d8d1503f03d8b75d9cf3"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -17,12 +17,13 @@ codecov = { repository = "solana-labs/solana", branch = "master", service = "git
 chacha = []
 cuda = []
 erasure = []
-kvstore = ["memmap"]
+kvstore = ["crc", "memmap"]
 
 [dependencies]
 bincode = "1.1.2"
 bs58 = "0.2.0"
 byteorder = "1.3.1"
+crc = { version = "1.8.1", optional = true }
 chrono = { version = "0.4.0", features = ["serde"] }
 hashbrown = "0.1.8"
 indexmap = "1.0"

--- a/core/src/blocktree/kvs.rs
+++ b/core/src/blocktree/kvs.rs
@@ -1,5 +1,5 @@
 use crate::entry::Entry;
-use crate::kvstore::{self, Key};
+use crate::kvstore::{self, Key, KvStore};
 use crate::packet::Blob;
 use crate::result::{Error, Result};
 
@@ -12,7 +12,7 @@ use super::db::{
 use super::{Blocktree, BlocktreeError};
 
 #[derive(Debug)]
-pub struct Kvs(());
+pub struct Kvs(KvStore);
 
 /// The metadata column family
 #[derive(Debug)]

--- a/core/src/kvstore/io_utils.rs
+++ b/core/src/kvstore/io_utils.rs
@@ -1,7 +1,12 @@
+use byteorder::{BigEndian, ByteOrder};
+
+use crc::crc32;
+
 use memmap::Mmap;
 
+use std::cmp;
 use std::fs::File;
-use std::io::{self, BufWriter, Seek, SeekFrom, Write};
+use std::io::{self, BufWriter, Read, Seek, SeekFrom, Write};
 use std::ops::Deref;
 use std::sync::{Arc, RwLock};
 
@@ -25,9 +30,123 @@ pub struct SharedWriter {
     pos: u64,
 }
 
+#[derive(Debug)]
+pub struct CRCWriter<W: Write> {
+    wtr: W,
+    buf: Vec<u8>,
+    pos: usize,
+    cap: usize,
+}
+
+#[derive(Debug)]
+pub struct CRCReader<R: Read> {
+    rdr: R,
+    buf: Vec<u8>,
+    pos: usize,
+    chunk_size: usize,
+}
+
+impl<W: Write> CRCWriter<W> {
+    pub fn new(inner: W, chunk_size: usize) -> CRCWriter<W> {
+        if chunk_size <= 8 {
+            panic!("chunk_size must be > 8");
+        }
+
+        CRCWriter {
+            wtr: inner,
+            buf: vec![0; chunk_size],
+            pos: 0,
+            cap: chunk_size - 8,
+        }
+    }
+
+    #[allow(dead_code)]
+    pub fn into_inner(mut self) -> io::Result<W> {
+        self.flush()?;
+        Ok(self.wtr)
+    }
+
+    pub fn get_ref(&self) -> &W {
+        &self.wtr
+    }
+
+    pub fn get_mut(&mut self) -> &mut W {
+        &mut self.wtr
+    }
+}
+
+impl<R: Read> CRCReader<R> {
+    pub fn new(inner: R, chunk_size: usize) -> CRCReader<R> {
+        if chunk_size <= 8 {
+            panic!("chunk_size must be > 8");
+        }
+
+        CRCReader {
+            rdr: inner,
+            buf: vec![0; chunk_size - 8],
+            pos: chunk_size,
+            chunk_size,
+        }
+    }
+
+    #[allow(dead_code)]
+    pub fn into_inner(self) -> R {
+        self.rdr
+    }
+}
+
 impl SharedWriter {
     pub fn new(buf: Arc<RwLock<Vec<u8>>>) -> SharedWriter {
         SharedWriter { buf, pos: 0 }
+    }
+}
+
+impl<R> CRCReader<R>
+where
+    R: Read,
+{
+    fn load_block(&mut self) -> io::Result<()> {
+        self.buf.clear();
+        self.pos = 0;
+
+        let mut blk_buf = vec![0; self.chunk_size];
+        let mut bpos = 0;
+
+        while bpos < self.chunk_size {
+            let bytes_read = self.rdr.read(&mut blk_buf[bpos..])?;
+            if bytes_read == 0 {
+                break;
+            }
+            bpos += bytes_read
+        }
+
+        if bpos < self.chunk_size {
+            return Err(io::ErrorKind::UnexpectedEof.into());
+        }
+
+        assert_eq!(bpos, self.chunk_size);
+
+        let stored_digest = BigEndian::read_u32(&blk_buf[0..4]);
+        let payload_len = BigEndian::read_u32(&blk_buf[4..8]) as usize;
+        if payload_len + 8 > blk_buf.len() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "CRCReader: invalid block size",
+            ));
+        }
+        let payload = &blk_buf[8..8 + payload_len];
+        let computed_digest = crc32::checksum_ieee(&blk_buf[4..8 + payload_len]);
+
+        if computed_digest != stored_digest {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "CRCReader: CRC validation failed",
+            ));
+        }
+
+        self.buf.extend_from_slice(payload);
+
+        Ok(())
     }
 }
 
@@ -48,10 +167,73 @@ impl Deref for MemMap {
     }
 }
 
+impl<W> Write for CRCWriter<W>
+where
+    W: Write,
+{
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let mut written = 0;
+
+        while written < buf.len() {
+            let batch_len = (&mut self.buf[8 + self.pos..]).write(&buf[written..])?;
+
+            self.pos += batch_len;
+            written += batch_len;
+
+            if self.pos >= self.cap {
+                self.flush()?;
+            }
+        }
+
+        Ok(written)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        BigEndian::write_u32(&mut self.buf[4..8], self.pos as u32);
+        let total_len = self.pos + 8;
+
+        // crc over length + payload
+        let digest = crc32::checksum_ieee(&self.buf[4..total_len]);
+
+        BigEndian::write_u32(&mut self.buf[0..4], digest);
+        self.wtr.write_all(&self.buf)?;
+
+        self.pos = 0;
+        Ok(())
+    }
+}
+
+impl<R> Read for CRCReader<R>
+where
+    R: Read,
+{
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        let mut bytes_read = 0;
+        let mut write_pos = 0;
+
+        while write_pos < buf.len() {
+            if self.pos >= self.buf.len() {
+                self.load_block()?;
+            }
+
+            let bytes_available = self.buf.len() - self.pos;
+            let space_remaining = buf.len() - write_pos;
+            let copy_len = cmp::min(bytes_available, space_remaining);
+
+            (&mut buf[write_pos..write_pos + copy_len])
+                .copy_from_slice(&self.buf[self.pos..self.pos + copy_len]);
+
+            bytes_read += copy_len;
+            write_pos += copy_len;
+            self.pos += copy_len;
+        }
+
+        Ok(bytes_read)
+    }
+}
+
 impl Write for SharedWriter {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        use std::cmp;
-
         let mut vec = self.buf.write().expect(BACKING_ERR);
 
         // Calc ranges
@@ -127,5 +309,119 @@ impl Seek for Writer {
             Writer::Disk(ref mut wtr) => wtr.seek(pos),
             Writer::Mem(ref mut wtr) => wtr.seek(pos),
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_crc_write() {
+        let block_sizes = &[256, 512, 1024, 2048];
+        let byte_counts = &[8, 128, 1024, 1024 * 8];
+
+        for &block_size in block_sizes {
+            for &n_bytes in byte_counts {
+                let bytes: Vec<_> = (0..n_bytes).map(|x| (x % 255) as u8).collect();
+                let buf = Vec::new();
+
+                let mut wtr = CRCWriter::new(buf, block_size);
+                wtr.write_all(&bytes).unwrap();
+
+                let buf = wtr.into_inner().unwrap();
+
+                let space_per_block = block_size - 8;
+                let n_full_blocks = n_bytes / space_per_block;
+                let blocks_expected = n_full_blocks + (n_bytes % space_per_block != 0) as usize;
+                let expected_len = blocks_expected * block_size;
+
+                assert_eq!(buf.len(), expected_len);
+                assert_eq!(&buf[8..16], &[0, 1, 2, 3, 4, 5, 6, 7]);
+            }
+        }
+    }
+
+    #[test]
+    fn test_crc_io() {
+        const BLK_SIZE: usize = 1024;
+        let bytes: Vec<_> = (0..512 * 1024).map(|x| (x % 255) as u8).collect();
+        let buf = Vec::new();
+
+        let mut wtr = CRCWriter::new(buf, BLK_SIZE);
+        wtr.write_all(&bytes).unwrap();
+
+        let buf = wtr.into_inner().unwrap();
+        assert_eq!(&buf[8..16], &[0, 1, 2, 3, 4, 5, 6, 7]);
+
+        let mut rdr = CRCReader::new(&buf[..], BLK_SIZE);
+
+        let mut retrieved = Vec::with_capacity(512 * 1024);
+        let buffer = &mut [0; 1024];
+        while let Ok(amt) = rdr.read(buffer) {
+            if amt == 0 {
+                break;
+            }
+            retrieved.extend_from_slice(&buffer[..amt]);
+        }
+
+        assert_eq!(&retrieved[..8], &[0, 1, 2, 3, 4, 5, 6, 7]);
+
+        assert_eq!(bytes.len(), retrieved.len());
+        assert_eq!(bytes, retrieved);
+    }
+
+    #[test]
+    fn test_crc_validation() {
+        const BLK_SIZE: usize = 1024;
+        let n_bytes = 512 * 1024;
+        let bytes: Vec<_> = (0..n_bytes).map(|x| (x % 255) as u8).collect();
+        let buf = Vec::new();
+
+        let mut wtr = CRCWriter::new(buf, BLK_SIZE);
+        wtr.write_all(&bytes).unwrap();
+
+        let mut buf = wtr.into_inner().unwrap();
+        buf[BLK_SIZE / 2] += 1;
+
+        let mut rdr = CRCReader::new(&buf[..], BLK_SIZE);
+
+        let mut retrieved = vec![];
+        let res = rdr.read_to_end(&mut retrieved);
+        assert_eq!(res.unwrap_err().kind(), io::ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn test_crc_size_mismatch() {
+        const BLK_SIZE: usize = 1024;
+        let n_bytes = 512 * 1024;
+        let bytes: Vec<_> = (0..n_bytes).map(|x| (x % 255) as u8).collect();
+        let buf = Vec::new();
+
+        let mut wtr = CRCWriter::new(buf, BLK_SIZE);
+        wtr.write_all(&bytes).unwrap();
+
+        let mut buf = wtr.into_inner().unwrap();
+        buf.drain((n_bytes - 512)..n_bytes);
+
+        for &size_diff in &[100, 1, 25, BLK_SIZE - 9] {
+            let mut rdr = CRCReader::new(&buf[..], BLK_SIZE - size_diff);
+
+            let mut retrieved = vec![];
+            let res = rdr.read_to_end(&mut retrieved);
+            assert_eq!(res.unwrap_err().kind(), io::ErrorKind::InvalidData);
+        }
+    }
+
+    #[should_panic]
+    #[test]
+    fn test_crc_writer_invalid_chunk_size() {
+        let _ = CRCWriter::new(Vec::new(), 8);
+    }
+
+    #[should_panic]
+    #[test]
+    fn test_crc_reader_invalid_chunk_size() {
+        let _ = CRCReader::new(io::empty(), 8);
     }
 }

--- a/core/src/kvstore/writelog.rs
+++ b/core/src/kvstore/writelog.rs
@@ -1,105 +1,336 @@
+// TODO: document module, especially log format
 use crate::kvstore::error::Result;
+use crate::kvstore::io_utils::{CRCReader, CRCWriter};
 use crate::kvstore::sstable::Value;
 use crate::kvstore::Key;
 
-use byteorder::{BigEndian, ByteOrder, ReadBytesExt};
+use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
+
+use memmap::Mmap;
 
 use std::collections::BTreeMap;
 use std::fs::{self, File};
-use std::io::{BufReader, BufWriter, Read, Seek, SeekFrom, Write};
+use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
+use std::sync::RwLock;
+
+const BLOCK_SIZE: usize = 32 * 1024;
 
 #[derive(Debug)]
 pub struct WriteLog {
     log_path: PathBuf,
-    log_writer: BufWriter<File>,
-    max_batch_size: usize,
+    logger: RwLock<Logger>,
+    config: Config,
+    in_memory: bool,
+}
+
+#[derive(Debug)]
+pub struct Config {
+    pub use_fsync: bool,
+    pub sync_every_write: bool,
 }
 
 impl WriteLog {
-    pub fn open(path: &Path, max_batch_size: usize) -> Result<Self> {
-        let log_writer = BufWriter::new(
-            fs::OpenOptions::new()
-                .create(true)
-                .append(true)
-                .open(path)?,
-        );
-        let log_path = path.to_path_buf();
+    pub fn open(path: &Path, config: Config) -> Result<Self> {
+        let file = file_opts().open(path)?;
 
         Ok(WriteLog {
-            log_writer,
-            log_path,
-            max_batch_size,
+            config,
+            log_path: path.to_path_buf(),
+            logger: RwLock::new(Logger::disk(file)),
+            in_memory: false,
         })
     }
 
-    pub fn reset(&mut self) -> Result<()> {
-        self.log_writer.flush()?;
-        let file = self.log_writer.get_mut();
-        file.set_len(0)?;
-        file.seek(SeekFrom::Start(0))?;
-
-        Ok(())
-    }
-
-    pub fn log_put(&mut self, key: &Key, ts: i64, val: &[u8]) -> Result<()> {
-        let rec_len = 24 + 8 + 1 + val.len() as u64;
-        let mut buf = vec![0u8; rec_len as usize + 8];
-
-        log_to_buffer(&mut buf, rec_len, key, ts, val);
-
-        self.log_writer.write_all(&buf)?;
-        Ok(())
-    }
-
-    pub fn log_delete(&mut self, key: &Key, ts: i64) -> Result<()> {
-        self.log_put(key, ts, &[])
-    }
-
-    // TODO: decide how to configure/schedule calling this
     #[allow(dead_code)]
-    pub fn sync(&mut self) -> Result<()> {
-        self.log_writer.flush()?;
-        self.log_writer.get_mut().sync_all()?;
+    pub fn memory(config: Config) -> WriteLog {
+        WriteLog {
+            config,
+            logger: RwLock::new(Logger::memory()),
+            log_path: Path::new("").to_path_buf(),
+            in_memory: true,
+        }
+    }
+
+    pub fn reset(&self) -> Result<()> {
+        let new_logger = if self.in_memory {
+            Logger::memory()
+        } else {
+            let file = file_opts().truncate(true).open(&self.log_path)?;
+            Logger::disk(file)
+        };
+
+        *self.logger.write().unwrap() = new_logger;
+
         Ok(())
+    }
+
+    pub fn log_put(&self, key: &Key, ts: i64, val: &[u8]) -> Result<()> {
+        let mut logger = self.logger.write().unwrap();
+
+        log(&mut logger, key, ts, Some(val))?;
+
+        if self.config.sync_every_write {
+            sync(&mut logger, self.config.use_fsync)?;
+        }
+
+        Ok(())
+    }
+
+    pub fn log_delete(&self, key: &Key, ts: i64) -> Result<()> {
+        let mut logger = self.logger.write().unwrap();
+
+        log(&mut logger, key, ts, None)?;
+
+        if self.config.sync_every_write {
+            sync(&mut logger, self.config.use_fsync)?;
+        }
+
+        Ok(())
+    }
+
+    #[allow(dead_code)]
+    pub fn sync(&self) -> Result<()> {
+        let mut logger = self.logger.write().unwrap();
+
+        sync(&mut logger, self.config.use_fsync)
     }
 
     pub fn materialize(&self) -> Result<BTreeMap<Key, Value>> {
-        let mut table = BTreeMap::new();
-        if !self.log_path.exists() {
-            return Ok(table);
-        }
-
-        let mut rdr = BufReader::new(File::open(&self.log_path)?);
-        let mut buf = vec![];
-
-        while let Ok(rec_len) = rdr.read_u64::<BigEndian>() {
-            buf.resize(rec_len as usize, 0);
-            rdr.read_exact(&mut buf)?;
-
-            let key = Key::read(&buf[0..24]);
-            let ts = BigEndian::read_i64(&buf[24..32]);
-            let exists = buf[32] != 0;
-
-            let val = if exists {
-                Some(buf[33..].to_vec())
-            } else {
-                None
-            };
-            let value = Value { ts, val };
-
-            table.insert(key, value);
-        }
-
-        Ok(table)
+        let mmap = self.logger.write().unwrap().writer.mmap()?;
+        read_log(&mmap)
     }
 }
 
+impl Default for Config {
+    fn default() -> Config {
+        Config {
+            use_fsync: false,
+            sync_every_write: true,
+        }
+    }
+}
+
+trait LogWriter: std::fmt::Debug + Write + Send + Sync {
+    fn sync(&mut self, fsync: bool) -> Result<()>;
+    fn mmap(&self) -> Result<Mmap>;
+}
+
+/// Holds actual logging related state
+#[derive(Debug)]
+struct Logger {
+    writer: Box<LogWriter>,
+}
+
+impl Logger {
+    fn memory() -> Self {
+        Logger {
+            writer: Box::new(CRCWriter::new(vec![], BLOCK_SIZE)),
+        }
+    }
+
+    fn disk(file: File) -> Self {
+        Logger {
+            writer: Box::new(CRCWriter::new(file, BLOCK_SIZE)),
+        }
+    }
+}
+
+impl LogWriter for CRCWriter<Vec<u8>> {
+    fn sync(&mut self, _: bool) -> Result<()> {
+        Ok(self.flush()?)
+    }
+
+    fn mmap(&self) -> Result<Mmap> {
+        let mut map = memmap::MmapMut::map_anon(self.get_ref().len())?;
+        (&mut map[..]).copy_from_slice(self.get_ref());
+        Ok(map.make_read_only()?)
+    }
+}
+
+impl LogWriter for CRCWriter<File> {
+    fn sync(&mut self, fsync: bool) -> Result<()> {
+        self.flush()?;
+
+        let file = self.get_mut();
+        if fsync {
+            file.sync_all()?;
+        } else {
+            file.sync_data()?;
+        }
+
+        Ok(())
+    }
+
+    fn mmap(&self) -> Result<Mmap> {
+        let map = unsafe { Mmap::map(self.get_ref())? };
+        Ok(map)
+    }
+}
+
+fn log(logger: &mut Logger, key: &Key, commit: i64, data: Option<&[u8]>) -> Result<()> {
+    let wtr = &mut logger.writer;
+    write_value(wtr, key, commit, data)?;
+
+    Ok(())
+}
+
+fn sync(logger: &mut Logger, sync_all: bool) -> Result<()> {
+    let writer = &mut logger.writer;
+
+    writer.sync(sync_all)?;
+
+    Ok(())
+}
+
 #[inline]
-fn log_to_buffer(buf: &mut [u8], rec_len: u64, key: &Key, ts: i64, val: &[u8]) {
-    BigEndian::write_u64(&mut buf[..8], rec_len);
-    (&mut buf[8..32]).copy_from_slice(&key.0);
-    BigEndian::write_i64(&mut buf[32..40], ts);
-    buf[40] = (!val.is_empty()) as u8;
-    (&mut buf[41..]).copy_from_slice(val);
+fn file_opts() -> fs::OpenOptions {
+    let mut opts = fs::OpenOptions::new();
+    opts.read(true).write(true).create(true);
+    opts
+}
+
+fn read_log(wal: &[u8]) -> Result<BTreeMap<Key, Value>> {
+    let mut map = BTreeMap::new();
+    if wal.len() <= 8 + 24 + 8 + 1 {
+        return Ok(map);
+    }
+
+    let mut rdr = CRCReader::new(wal, BLOCK_SIZE);
+
+    while let Ok((key, val)) = read_value(&mut rdr) {
+        map.insert(key, val);
+    }
+
+    Ok(map)
+}
+
+#[inline]
+fn write_value<W: Write>(wtr: &mut W, key: &Key, commit: i64, data: Option<&[u8]>) -> Result<()> {
+    let len = 24 + 8 + 1 + data.map(<[u8]>::len).unwrap_or(0);
+
+    wtr.write_u64::<BigEndian>(len as u64)?;
+    wtr.write_all(&key.0)?;
+    wtr.write_i64::<BigEndian>(commit)?;
+
+    match data {
+        Some(data) => {
+            wtr.write_u8(1)?;
+            wtr.write_all(data)?;
+        }
+        None => {
+            wtr.write_u8(0)?;
+        }
+    }
+
+    Ok(())
+}
+
+#[inline]
+fn read_value<R: Read>(rdr: &mut R) -> Result<(Key, Value)> {
+    let len = rdr.read_u64::<BigEndian>()?;
+    let data_len = len as usize - (24 + 8 + 1);
+
+    let mut rdr = rdr.by_ref().take(len);
+
+    let mut key_buf = [0; 24];
+    rdr.read_exact(&mut key_buf)?;
+    let key = Key(key_buf);
+
+    let commit = rdr.read_i64::<BigEndian>()?;
+    let exists = rdr.read_u8()? != 0;
+
+    let data = if exists {
+        let mut buf = Vec::with_capacity(data_len);
+        rdr.read_to_end(&mut buf)?;
+        Some(buf)
+    } else {
+        None
+    };
+
+    let val = Value {
+        ts: commit,
+        val: data,
+    };
+    Ok((key, val))
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_log_serialization() {
+        let (key, commit, data) = (&Key::from((1, 2, 3)), 4, vec![0; 1024]);
+
+        let mut buf = vec![];
+
+        write_value(&mut buf, key, commit, Some(&data)).unwrap();
+
+        let (stored_key, stored_val) = read_value(&mut &buf[..]).unwrap();
+        assert_eq!(&stored_key, key);
+        assert_eq!(stored_val.val.as_ref().unwrap(), &data);
+        assert_eq!(stored_val.ts, commit);
+    }
+
+    #[test]
+    fn test_log_round_trip() {
+        let wal = WriteLog::memory(Config::default());
+
+        let values: BTreeMap<Key, Value> = (0u64..100)
+            .map(|n| {
+                let val = if n % 2 == 0 {
+                    Some(vec![0; 1024])
+                } else {
+                    None
+                };
+                (Key::from((n, n, n)), Value { ts: n as i64, val })
+            })
+            .collect();
+
+        for (k, v) in values.iter() {
+            if v.val.is_some() {
+                wal.log_put(k, v.ts, v.val.as_ref().unwrap())
+                    .expect("Wal::put");
+            } else {
+                wal.log_delete(k, v.ts).expect("Wal::delete");
+            }
+        }
+
+        let reloaded = wal.materialize().expect("Wal::materialize");
+
+        assert_eq!(values.len(), reloaded.len());
+        assert_eq!(values, reloaded);
+    }
+
+    #[test]
+    fn test_reset() {
+        use crate::kvstore::error::Error;
+
+        let wal = WriteLog::memory(Config::default());
+
+        let values: BTreeMap<Key, Value> = (0u64..100)
+            .map(|n| {
+                let val = Some(vec![0; 64]);
+                (Key::from((n, n, n)), Value { ts: n as i64, val })
+            })
+            .collect();
+
+        for (k, v) in values.iter() {
+            wal.log_put(k, v.ts, v.val.as_ref().unwrap())
+                .expect("Wal::put");
+        }
+
+        wal.reset().expect("Wal::reset");
+
+        // Should result in an error due to attempting to make a memory map of length 0
+        let result = wal.materialize();
+
+        assert!(result.is_err());
+        if let Err(Error::Io(e)) = result {
+            assert_eq!(e.kind(), std::io::ErrorKind::InvalidInput);
+        } else {
+            panic!("should fail to create 0-length memory-map with an empty log");
+        }
+    }
 }


### PR DESCRIPTION
#### Problem
See #3288 #3290
#### Summary of Changes
* `KvStore` is fully `Sync` thanks to the new log being `Sync` and putting channels behind Mutexes
* Add new `CRCReader<R: Read>` and `CRCWriter<W: Write>` I/O wrappers
* Add tests for the log
* Fix bug that caused log to attempt recovery even if no log is present

Fixes #3288 #3290 and simplifies fixing issue [3294](https://github.com/solana-labs/solana/issues/3294)
