### PR TITLE
Integrate Transaction compiler into Transaction module

### DIFF
--- a/core/src/sigverify.rs
+++ b/core/src/sigverify.rs
@@ -503,7 +503,7 @@ mod tests {
 
         let instructions = vec![CompiledInstruction::new(0, &system_instruction, vec![0, 1])];
 
-        let tx = Transaction::new_with_instructions(
+        let tx = Transaction::new_with_compiled_instructions(
             &keypairs,
             &[],
             blockhash,

--- a/core/src/sigverify.rs
+++ b/core/src/sigverify.rs
@@ -340,7 +340,7 @@ mod tests {
     use solana_sdk::signature::{Keypair, KeypairUtil};
     use solana_sdk::system_instruction::SystemInstruction;
     use solana_sdk::system_program;
-    use solana_sdk::transaction::{Instruction, Transaction};
+    use solana_sdk::transaction::{CompiledInstruction, Transaction};
 
     const SIG_OFFSET: usize = std::mem::size_of::<u64>() + 1;
 
@@ -501,7 +501,7 @@ mod tests {
 
         let program_ids = vec![system_program::id(), solana_budget_api::id()];
 
-        let instructions = vec![Instruction::new(0, &system_instruction, vec![0, 1])];
+        let instructions = vec![CompiledInstruction::new(0, &system_instruction, vec![0, 1])];
 
         let tx = Transaction::new_with_instructions(
             &keypairs,

--- a/drone/src/drone.rs
+++ b/drone/src/drone.rs
@@ -132,7 +132,7 @@ impl Drone {
                         space: 0,
                         program_id: system_program::id(),
                     };
-                    let mut transaction = Transaction::new(
+                    let mut transaction = Transaction::new_signed(
                         &self.mint_keypair,
                         &[to],
                         &system_program::id(),
@@ -408,7 +408,7 @@ mod tests {
             space: 0,
             program_id: system_program::id(),
         };
-        let mut expected_tx = Transaction::new(
+        let mut expected_tx = Transaction::new_signed(
             &keypair,
             &[to],
             &system_program::id(),

--- a/drone/tests/local-drone.rs
+++ b/drone/tests/local-drone.rs
@@ -17,7 +17,7 @@ fn test_local_drone() {
         space: 0,
         program_id: system_program::id(),
     };
-    let mut expected_tx = Transaction::new(
+    let mut expected_tx = Transaction::new_signed(
         &keypair,
         &[to],
         &system_program::id(),

--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -43,7 +43,7 @@ mod bpf {
 
             // Call user program
             let program_id = load_program(&bank, &mint_keypair, &bpf_loader::id(), elf);
-            let tx = Transaction::new(
+            let tx = Transaction::new_signed(
                 &mint_keypair,
                 &[],
                 &program_id,
@@ -86,7 +86,7 @@ mod bpf {
 
                 // Call user program
                 let program_id = load_program(&bank, &mint_keypair, &loader_id, elf);
-                let tx = Transaction::new(
+                let tx = Transaction::new_signed(
                     &mint_keypair,
                     &[],
                     &program_id,
@@ -132,7 +132,7 @@ mod bpf {
 
                 // Call user program
                 let program_id = load_program(&bank, &mint_keypair, &loader_id, elf);
-                let tx = Transaction::new(
+                let tx = Transaction::new_signed(
                     &mint_keypair,
                     &[],
                     &program_id,

--- a/programs/budget/src/budget_program.rs
+++ b/programs/budget/src/budget_program.rs
@@ -177,7 +177,7 @@ mod test {
         let from = Keypair::new();
         let contract = Keypair::new();
         let data = (1u8, 2u8, 3u8);
-        let tx = Transaction::new(
+        let tx = Transaction::new_signed(
             &from,
             &[contract.pubkey()],
             &id(),

--- a/programs/budget_api/src/budget_instruction.rs
+++ b/programs/budget_api/src/budget_instruction.rs
@@ -3,7 +3,7 @@ use crate::id;
 use chrono::prelude::{DateTime, Utc};
 use serde_derive::{Deserialize, Serialize};
 use solana_sdk::pubkey::Pubkey;
-use solana_sdk::transaction_builder::BuilderInstruction;
+use solana_sdk::transaction::Instruction;
 
 /// A smart contract.
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
@@ -28,13 +28,13 @@ pub enum BudgetInstruction {
 }
 
 impl BudgetInstruction {
-    pub fn new_initialize_account(contract: &Pubkey, expr: BudgetExpr) -> BuilderInstruction {
+    pub fn new_initialize_account(contract: &Pubkey, expr: BudgetExpr) -> Instruction {
         let mut keys = vec![];
         if let BudgetExpr::Pay(payment) = &expr {
             keys.push((payment.to, false));
         }
         keys.push((*contract, false));
-        BuilderInstruction::new(id(), &BudgetInstruction::InitializeAccount(expr), keys)
+        Instruction::new(id(), &BudgetInstruction::InitializeAccount(expr), keys)
     }
 
     pub fn new_apply_timestamp(
@@ -42,23 +42,19 @@ impl BudgetInstruction {
         contract: &Pubkey,
         to: &Pubkey,
         dt: DateTime<Utc>,
-    ) -> BuilderInstruction {
+    ) -> Instruction {
         let mut keys = vec![(*from, true), (*contract, false)];
         if from != to {
             keys.push((*to, false));
         }
-        BuilderInstruction::new(id(), &BudgetInstruction::ApplyTimestamp(dt), keys)
+        Instruction::new(id(), &BudgetInstruction::ApplyTimestamp(dt), keys)
     }
 
-    pub fn new_apply_signature(
-        from: &Pubkey,
-        contract: &Pubkey,
-        to: &Pubkey,
-    ) -> BuilderInstruction {
+    pub fn new_apply_signature(from: &Pubkey, contract: &Pubkey, to: &Pubkey) -> Instruction {
         let mut keys = vec![(*from, true), (*contract, false)];
         if from != to {
             keys.push((*to, false));
         }
-        BuilderInstruction::new(id(), &BudgetInstruction::ApplySignature, keys)
+        Instruction::new(id(), &BudgetInstruction::ApplySignature, keys)
     }
 }

--- a/programs/budget_api/src/budget_transaction.rs
+++ b/programs/budget_api/src/budget_transaction.rs
@@ -11,7 +11,6 @@ use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::{Keypair, KeypairUtil};
 use solana_sdk::system_instruction::SystemInstruction;
 use solana_sdk::transaction::Transaction;
-use solana_sdk::transaction_builder::TransactionBuilder;
 
 pub struct BudgetTransaction {}
 
@@ -31,7 +30,7 @@ impl BudgetTransaction {
         let create_ix =
             SystemInstruction::new_program_account(&from, contract, lamports, space, &id());
         let init_ix = BudgetInstruction::new_initialize_account(contract, expr);
-        let mut tx = TransactionBuilder::new(vec![create_ix, init_ix]).compile();
+        let mut tx = Transaction::new(vec![create_ix, init_ix]);
         tx.fee = fee;
         tx.sign(&[from_keypair], recent_blockhash);
         tx
@@ -67,7 +66,7 @@ impl BudgetTransaction {
     ) -> Transaction {
         let from = from_keypair.pubkey();
         let ix = BudgetInstruction::new_apply_timestamp(&from, contract, to, dt);
-        let mut tx = TransactionBuilder::new(vec![ix]).compile();
+        let mut tx = Transaction::new(vec![ix]);
         tx.sign(&[from_keypair], recent_blockhash);
         tx
     }
@@ -81,7 +80,7 @@ impl BudgetTransaction {
     ) -> Transaction {
         let from = from_keypair.pubkey();
         let ix = BudgetInstruction::new_apply_signature(&from, contract, to);
-        let mut tx = TransactionBuilder::new(vec![ix]).compile();
+        let mut tx = Transaction::new(vec![ix]);
         tx.sign(&[from_keypair], recent_blockhash);
         tx
     }

--- a/programs/failure/tests/failure.rs
+++ b/programs/failure/tests/failure.rs
@@ -14,7 +14,7 @@ fn test_program_native_failure() {
     let program_id = load_program(&bank, &mint_keypair, &native_loader::id(), program);
 
     // Call user program
-    let tx = Transaction::new(
+    let tx = Transaction::new_signed(
         &mint_keypair,
         &[],
         &program_id,

--- a/programs/noop/tests/noop.rs
+++ b/programs/noop/tests/noop.rs
@@ -15,7 +15,7 @@ fn test_program_native_noop() {
     let program_id = load_program(&bank, &mint_keypair, &native_loader::id(), program);
 
     // Call user program
-    let tx = Transaction::new(
+    let tx = Transaction::new_signed(
         &mint_keypair,
         &[],
         &program_id,

--- a/programs/rewards_api/src/rewards_instruction.rs
+++ b/programs/rewards_api/src/rewards_instruction.rs
@@ -1,7 +1,7 @@
 use crate::id;
 use serde_derive::{Deserialize, Serialize};
 use solana_sdk::pubkey::Pubkey;
-use solana_sdk::transaction_builder::BuilderInstruction;
+use solana_sdk::transaction::Instruction;
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub enum RewardsInstruction {
@@ -9,8 +9,8 @@ pub enum RewardsInstruction {
 }
 
 impl RewardsInstruction {
-    pub fn new_redeem_vote_credits(vote_id: &Pubkey, rewards_id: &Pubkey) -> BuilderInstruction {
-        BuilderInstruction::new(
+    pub fn new_redeem_vote_credits(vote_id: &Pubkey, rewards_id: &Pubkey) -> Instruction {
+        Instruction::new(
             id(),
             &RewardsInstruction::RedeemVoteCredits,
             vec![(*vote_id, true), (*rewards_id, false)],

--- a/programs/rewards_api/src/rewards_transaction.rs
+++ b/programs/rewards_api/src/rewards_transaction.rs
@@ -9,7 +9,6 @@ use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::{Keypair, KeypairUtil};
 use solana_sdk::system_transaction::SystemTransaction;
 use solana_sdk::transaction::Transaction;
-use solana_sdk::transaction_builder::TransactionBuilder;
 use solana_vote_api::vote_instruction::VoteInstruction;
 
 pub struct RewardsTransaction {}
@@ -42,7 +41,7 @@ impl RewardsTransaction {
         let vote_id = vote_keypair.pubkey();
         let redeem_ix = RewardsInstruction::new_redeem_vote_credits(&vote_id, rewards_id);
         let clear_ix = VoteInstruction::new_clear_credits(&vote_id);
-        let mut tx = TransactionBuilder::new(vec![redeem_ix, clear_ix]).compile();
+        let mut tx = Transaction::new(vec![redeem_ix, clear_ix]);
         tx.fee = fee;
         tx.sign(&[vote_keypair], blockhash);
         tx

--- a/programs/rewards_api/src/rewards_transaction.rs
+++ b/programs/rewards_api/src/rewards_transaction.rs
@@ -40,12 +40,10 @@ impl RewardsTransaction {
         fee: u64,
     ) -> Transaction {
         let vote_id = vote_keypair.pubkey();
-        let mut tx = TransactionBuilder::new(fee)
-            .push(RewardsInstruction::new_redeem_vote_credits(
-                &vote_id, rewards_id,
-            ))
-            .push(VoteInstruction::new_clear_credits(&vote_id))
-            .compile();
+        let redeem_ix = RewardsInstruction::new_redeem_vote_credits(&vote_id, rewards_id);
+        let clear_ix = VoteInstruction::new_clear_credits(&vote_id);
+        let mut tx = TransactionBuilder::new(vec![redeem_ix, clear_ix]).compile();
+        tx.fee = fee;
         tx.sign(&[vote_keypair], blockhash);
         tx
     }

--- a/programs/storage/src/lib.rs
+++ b/programs/storage/src/lib.rs
@@ -180,7 +180,7 @@ mod test {
     use solana_sdk::account::{create_keyed_accounts, Account};
     use solana_sdk::hash::Hash;
     use solana_sdk::signature::{Keypair, KeypairUtil, Signature};
-    use solana_sdk::transaction::{Instruction, Transaction};
+    use solana_sdk::transaction::{CompiledInstruction, Transaction};
     use solana_storage_api::{ProofStatus, StorageTransaction};
 
     fn test_transaction(
@@ -188,7 +188,7 @@ mod test {
         program_accounts: &mut [Account],
     ) -> Result<(), ProgramError> {
         assert_eq!(tx.instructions.len(), 1);
-        let Instruction {
+        let CompiledInstruction {
             ref accounts,
             ref data,
             ..

--- a/programs/storage_api/src/lib.rs
+++ b/programs/storage_api/src/lib.rs
@@ -90,7 +90,7 @@ impl StorageTransaction {
             entry_height,
             signature,
         };
-        Transaction::new(from_keypair, &[], &id(), &program, recent_blockhash, 0)
+        Transaction::new_signed(from_keypair, &[], &id(), &program, recent_blockhash, 0)
     }
 
     pub fn new_advertise_recent_blockhash(
@@ -103,7 +103,7 @@ impl StorageTransaction {
             hash: storage_hash,
             entry_height,
         };
-        Transaction::new(from_keypair, &[], &id(), &program, recent_blockhash, 0)
+        Transaction::new_signed(from_keypair, &[], &id(), &program, recent_blockhash, 0)
     }
 
     pub fn new_proof_validation(
@@ -116,7 +116,7 @@ impl StorageTransaction {
             entry_height,
             proof_mask,
         };
-        Transaction::new(from_keypair, &[], &id(), &program, recent_blockhash, 0)
+        Transaction::new_signed(from_keypair, &[], &id(), &program, recent_blockhash, 0)
     }
 
     pub fn new_reward_claim(
@@ -125,6 +125,6 @@ impl StorageTransaction {
         entry_height: u64,
     ) -> Transaction {
         let program = StorageProgram::ClaimStorageReward { entry_height };
-        Transaction::new(from_keypair, &[], &id(), &program, recent_blockhash, 0)
+        Transaction::new_signed(from_keypair, &[], &id(), &program, recent_blockhash, 0)
     }
 }

--- a/programs/vote/tests/vote.rs
+++ b/programs/vote/tests/vote.rs
@@ -5,8 +5,7 @@ use solana_sdk::native_program::ProgramError;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::{Keypair, KeypairUtil};
 use solana_sdk::system_instruction::SystemInstruction;
-use solana_sdk::transaction::{Instruction, InstructionError, TransactionError};
-use solana_sdk::transaction_builder::TransactionBuilder;
+use solana_sdk::transaction::{Instruction, InstructionError, Transaction, TransactionError};
 use solana_vote_api::vote_instruction::{Vote, VoteInstruction};
 use solana_vote_api::vote_state::VoteState;
 use solana_vote_api::vote_transaction::VoteTransaction;
@@ -120,10 +119,8 @@ fn test_vote_via_bank_with_no_signature() {
     // Sneak in an instruction so that the transaction is signed but
     // the 0th account in the second instruction is not! The program
     // needs to check that it's signed.
-    let mut tx = TransactionBuilder::default()
-        .push(SystemInstruction::new_move(&mallory_id, &vote_id, 1))
-        .push(vote_ix)
-        .compile();
+    let move_ix = SystemInstruction::new_move(&mallory_id, &vote_id, 1);
+    let mut tx = Transaction::new(vec![move_ix, vote_ix]);
     tx.sign(&[&mallory_keypair], blockhash);
 
     let result = bank.process_transaction(&tx);

--- a/programs/vote/tests/vote.rs
+++ b/programs/vote/tests/vote.rs
@@ -5,8 +5,8 @@ use solana_sdk::native_program::ProgramError;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::{Keypair, KeypairUtil};
 use solana_sdk::system_instruction::SystemInstruction;
-use solana_sdk::transaction::{InstructionError, TransactionError};
-use solana_sdk::transaction_builder::{BuilderInstruction, TransactionBuilder};
+use solana_sdk::transaction::{Instruction, InstructionError, TransactionError};
+use solana_sdk::transaction_builder::TransactionBuilder;
 use solana_vote_api::vote_instruction::{Vote, VoteInstruction};
 use solana_vote_api::vote_state::VoteState;
 use solana_vote_api::vote_transaction::VoteTransaction;
@@ -111,7 +111,7 @@ fn test_vote_via_bank_with_no_signature() {
 
     let mallory_id = mallory_keypair.pubkey();
     let blockhash = bank.last_blockhash();
-    let vote_ix = BuilderInstruction::new(
+    let vote_ix = Instruction::new(
         solana_vote_api::id(),
         &VoteInstruction::Vote(Vote::new(0)),
         vec![(vote_id, false)], // <--- attack!! No signature.

--- a/programs/vote_api/src/vote_instruction.rs
+++ b/programs/vote_api/src/vote_instruction.rs
@@ -1,7 +1,7 @@
 use crate::id;
 use serde_derive::{Deserialize, Serialize};
 use solana_sdk::pubkey::Pubkey;
-use solana_sdk::transaction_builder::BuilderInstruction;
+use solana_sdk::transaction::Instruction;
 
 #[derive(Serialize, Default, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub struct Vote {
@@ -32,34 +32,31 @@ pub enum VoteInstruction {
 }
 
 impl VoteInstruction {
-    pub fn new_clear_credits(vote_id: &Pubkey) -> BuilderInstruction {
-        BuilderInstruction::new(id(), &VoteInstruction::ClearCredits, vec![(*vote_id, true)])
+    pub fn new_clear_credits(vote_id: &Pubkey) -> Instruction {
+        Instruction::new(id(), &VoteInstruction::ClearCredits, vec![(*vote_id, true)])
     }
-    pub fn new_delegate_stake(vote_id: &Pubkey, delegate_id: &Pubkey) -> BuilderInstruction {
-        BuilderInstruction::new(
+    pub fn new_delegate_stake(vote_id: &Pubkey, delegate_id: &Pubkey) -> Instruction {
+        Instruction::new(
             id(),
             &VoteInstruction::DelegateStake(*delegate_id),
             vec![(*vote_id, true)],
         )
     }
-    pub fn new_authorize_voter(
-        vote_id: &Pubkey,
-        authorized_voter_id: &Pubkey,
-    ) -> BuilderInstruction {
-        BuilderInstruction::new(
+    pub fn new_authorize_voter(vote_id: &Pubkey, authorized_voter_id: &Pubkey) -> Instruction {
+        Instruction::new(
             id(),
             &VoteInstruction::AuthorizeVoter(*authorized_voter_id),
             vec![(*vote_id, true)],
         )
     }
-    pub fn new_initialize_account(vote_id: &Pubkey) -> BuilderInstruction {
-        BuilderInstruction::new(
+    pub fn new_initialize_account(vote_id: &Pubkey) -> Instruction {
+        Instruction::new(
             id(),
             &VoteInstruction::InitializeAccount,
             vec![(*vote_id, false)],
         )
     }
-    pub fn new_vote(vote_id: &Pubkey, vote: Vote) -> BuilderInstruction {
-        BuilderInstruction::new(id(), &VoteInstruction::Vote(vote), vec![(*vote_id, true)])
+    pub fn new_vote(vote_id: &Pubkey, vote: Vote) -> Instruction {
+        Instruction::new(id(), &VoteInstruction::Vote(vote), vec![(*vote_id, true)])
     }
 }

--- a/programs/vote_api/src/vote_transaction.rs
+++ b/programs/vote_api/src/vote_transaction.rs
@@ -22,9 +22,9 @@ impl VoteTransaction {
         fee: u64,
     ) -> Transaction {
         let vote = Vote { slot };
-        let mut tx = TransactionBuilder::new(fee)
-            .push(VoteInstruction::new_vote(staking_account, vote))
-            .compile();
+        let ix = VoteInstruction::new_vote(staking_account, vote);
+        let mut tx = TransactionBuilder::new(vec![ix]).compile();
+        tx.fee = fee;
         tx.sign(&[authorized_voter_keypair], recent_blockhash);
         tx
     }
@@ -39,16 +39,11 @@ impl VoteTransaction {
     ) -> Transaction {
         let from_id = from_keypair.pubkey();
         let space = VoteState::max_size() as u64;
-        let mut tx = TransactionBuilder::new(fee)
-            .push(SystemInstruction::new_program_account(
-                &from_id,
-                staker_id,
-                lamports,
-                space,
-                &id(),
-            ))
-            .push(VoteInstruction::new_initialize_account(staker_id))
-            .compile();
+        let create_ix =
+            SystemInstruction::new_program_account(&from_id, staker_id, lamports, space, &id());
+        let init_ix = VoteInstruction::new_initialize_account(staker_id);
+        let mut tx = TransactionBuilder::new(vec![create_ix, init_ix]).compile();
+        tx.fee = fee;
         tx.sign(&[from_keypair], recent_blockhash);
         tx
     }
@@ -65,17 +60,12 @@ impl VoteTransaction {
         let from_id = from_keypair.pubkey();
         let voter_id = voter_keypair.pubkey();
         let space = VoteState::max_size() as u64;
-        let mut tx = TransactionBuilder::new(fee)
-            .push(SystemInstruction::new_program_account(
-                &from_id,
-                &voter_id,
-                lamports,
-                space,
-                &id(),
-            ))
-            .push(VoteInstruction::new_initialize_account(&voter_id))
-            .push(VoteInstruction::new_delegate_stake(&voter_id, &delegate_id))
-            .compile();
+        let create_ix =
+            SystemInstruction::new_program_account(&from_id, &voter_id, lamports, space, &id());
+        let init_ix = VoteInstruction::new_initialize_account(&voter_id);
+        let delegate_ix = VoteInstruction::new_delegate_stake(&voter_id, &delegate_id);
+        let mut tx = TransactionBuilder::new(vec![create_ix, init_ix, delegate_ix]).compile();
+        tx.fee = fee;
         tx.sign(&[from_keypair, voter_keypair], recent_blockhash);
         tx
     }
@@ -87,12 +77,9 @@ impl VoteTransaction {
         authorized_voter_id: &Pubkey,
         fee: u64,
     ) -> Transaction {
-        let mut tx = TransactionBuilder::new(fee)
-            .push(VoteInstruction::new_authorize_voter(
-                &vote_keypair.pubkey(),
-                authorized_voter_id,
-            ))
-            .compile();
+        let ix = VoteInstruction::new_authorize_voter(&vote_keypair.pubkey(), authorized_voter_id);
+        let mut tx = TransactionBuilder::new(vec![ix]).compile();
+        tx.fee = fee;
         tx.sign(&[vote_keypair], recent_blockhash);
         tx
     }
@@ -104,12 +91,9 @@ impl VoteTransaction {
         node_id: &Pubkey,
         fee: u64,
     ) -> Transaction {
-        let mut tx = TransactionBuilder::new(fee)
-            .push(VoteInstruction::new_delegate_stake(
-                &vote_keypair.pubkey(),
-                node_id,
-            ))
-            .compile();
+        let ix = VoteInstruction::new_delegate_stake(&vote_keypair.pubkey(), node_id);
+        let mut tx = TransactionBuilder::new(vec![ix]).compile();
+        tx.fee = fee;
         tx.sign(&[vote_keypair], recent_blockhash);
         tx
     }

--- a/programs/vote_api/src/vote_transaction.rs
+++ b/programs/vote_api/src/vote_transaction.rs
@@ -9,7 +9,6 @@ use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::{Keypair, KeypairUtil};
 use solana_sdk::system_instruction::SystemInstruction;
 use solana_sdk::transaction::Transaction;
-use solana_sdk::transaction_builder::TransactionBuilder;
 
 pub struct VoteTransaction {}
 
@@ -23,7 +22,7 @@ impl VoteTransaction {
     ) -> Transaction {
         let vote = Vote { slot };
         let ix = VoteInstruction::new_vote(staking_account, vote);
-        let mut tx = TransactionBuilder::new(vec![ix]).compile();
+        let mut tx = Transaction::new(vec![ix]);
         tx.fee = fee;
         tx.sign(&[authorized_voter_keypair], recent_blockhash);
         tx
@@ -42,7 +41,7 @@ impl VoteTransaction {
         let create_ix =
             SystemInstruction::new_program_account(&from_id, staker_id, lamports, space, &id());
         let init_ix = VoteInstruction::new_initialize_account(staker_id);
-        let mut tx = TransactionBuilder::new(vec![create_ix, init_ix]).compile();
+        let mut tx = Transaction::new(vec![create_ix, init_ix]);
         tx.fee = fee;
         tx.sign(&[from_keypair], recent_blockhash);
         tx
@@ -64,7 +63,7 @@ impl VoteTransaction {
             SystemInstruction::new_program_account(&from_id, &voter_id, lamports, space, &id());
         let init_ix = VoteInstruction::new_initialize_account(&voter_id);
         let delegate_ix = VoteInstruction::new_delegate_stake(&voter_id, &delegate_id);
-        let mut tx = TransactionBuilder::new(vec![create_ix, init_ix, delegate_ix]).compile();
+        let mut tx = Transaction::new(vec![create_ix, init_ix, delegate_ix]);
         tx.fee = fee;
         tx.sign(&[from_keypair, voter_keypair], recent_blockhash);
         tx
@@ -78,7 +77,7 @@ impl VoteTransaction {
         fee: u64,
     ) -> Transaction {
         let ix = VoteInstruction::new_authorize_voter(&vote_keypair.pubkey(), authorized_voter_id);
-        let mut tx = TransactionBuilder::new(vec![ix]).compile();
+        let mut tx = Transaction::new(vec![ix]);
         tx.fee = fee;
         tx.sign(&[vote_keypair], recent_blockhash);
         tx
@@ -92,7 +91,7 @@ impl VoteTransaction {
         fee: u64,
     ) -> Transaction {
         let ix = VoteInstruction::new_delegate_stake(&vote_keypair.pubkey(), node_id);
-        let mut tx = TransactionBuilder::new(vec![ix]).compile();
+        let mut tx = Transaction::new(vec![ix]);
         tx.fee = fee;
         tx.sign(&[vote_keypair], recent_blockhash);
         tx

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -1047,7 +1047,7 @@ mod tests {
         let mut error_counters = ErrorCounters::default();
 
         let instructions = vec![CompiledInstruction::new(1, &(), vec![0])];
-        let tx = Transaction::new_with_instructions::<Keypair>(
+        let tx = Transaction::new_with_compiled_instructions::<Keypair>(
             &[],
             &[],
             Hash::default(),
@@ -1071,7 +1071,7 @@ mod tests {
         let keypair = Keypair::new();
 
         let instructions = vec![CompiledInstruction::new(1, &(), vec![0])];
-        let tx = Transaction::new_with_instructions(
+        let tx = Transaction::new_with_compiled_instructions(
             &[&keypair],
             &[],
             Hash::default(),
@@ -1103,7 +1103,7 @@ mod tests {
         accounts.push((key1, account));
 
         let instructions = vec![CompiledInstruction::new(1, &(), vec![0])];
-        let tx = Transaction::new_with_instructions(
+        let tx = Transaction::new_with_compiled_instructions(
             &[&keypair],
             &[],
             Hash::default(),
@@ -1131,7 +1131,7 @@ mod tests {
         accounts.push((key0, account));
 
         let instructions = vec![CompiledInstruction::new(1, &(), vec![0])];
-        let tx = Transaction::new_with_instructions(
+        let tx = Transaction::new_with_compiled_instructions(
             &[&keypair],
             &[],
             Hash::default(),
@@ -1166,7 +1166,7 @@ mod tests {
         accounts.push((key1, account));
 
         let instructions = vec![CompiledInstruction::new(0, &(), vec![0, 1])];
-        let tx = Transaction::new_with_instructions(
+        let tx = Transaction::new_with_compiled_instructions(
             &[&keypair],
             &[key1],
             Hash::default(),
@@ -1238,7 +1238,7 @@ mod tests {
         accounts.push((key6, account));
 
         let instructions = vec![CompiledInstruction::new(0, &(), vec![0])];
-        let tx = Transaction::new_with_instructions(
+        let tx = Transaction::new_with_compiled_instructions(
             &[&keypair],
             &[],
             Hash::default(),
@@ -1272,7 +1272,7 @@ mod tests {
         accounts.push((key1, account));
 
         let instructions = vec![CompiledInstruction::new(0, &(), vec![0])];
-        let tx = Transaction::new_with_instructions(
+        let tx = Transaction::new_with_compiled_instructions(
             &[&keypair],
             &[],
             Hash::default(),
@@ -1305,7 +1305,7 @@ mod tests {
         accounts.push((key1, account));
 
         let instructions = vec![CompiledInstruction::new(0, &(), vec![0])];
-        let tx = Transaction::new_with_instructions(
+        let tx = Transaction::new_with_compiled_instructions(
             &[&keypair],
             &[],
             Hash::default(),
@@ -1354,7 +1354,7 @@ mod tests {
             CompiledInstruction::new(0, &(), vec![0]),
             CompiledInstruction::new(1, &(), vec![0]),
         ];
-        let tx = Transaction::new_with_instructions(
+        let tx = Transaction::new_with_compiled_instructions(
             &[&keypair],
             &[],
             Hash::default(),
@@ -1398,7 +1398,7 @@ mod tests {
 
         let instructions = vec![CompiledInstruction::new(0, &(), vec![0, 1])];
         // Simulate pay-to-self transaction, which loads the same account twice
-        let tx = Transaction::new_with_instructions(
+        let tx = Transaction::new_with_compiled_instructions(
             &[&keypair],
             &[pubkey],
             Hash::default(),

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -1017,7 +1017,7 @@ mod tests {
     use solana_sdk::hash::Hash;
     use solana_sdk::signature::Keypair;
     use solana_sdk::signature::KeypairUtil;
-    use solana_sdk::transaction::Instruction;
+    use solana_sdk::transaction::CompiledInstruction;
     use solana_sdk::transaction::Transaction;
 
     fn cleanup_paths(paths: &str) {
@@ -1046,7 +1046,7 @@ mod tests {
         let accounts: Vec<(Pubkey, Account)> = Vec::new();
         let mut error_counters = ErrorCounters::default();
 
-        let instructions = vec![Instruction::new(1, &(), vec![0])];
+        let instructions = vec![CompiledInstruction::new(1, &(), vec![0])];
         let tx = Transaction::new_with_instructions::<Keypair>(
             &[],
             &[],
@@ -1070,7 +1070,7 @@ mod tests {
 
         let keypair = Keypair::new();
 
-        let instructions = vec![Instruction::new(1, &(), vec![0])];
+        let instructions = vec![CompiledInstruction::new(1, &(), vec![0])];
         let tx = Transaction::new_with_instructions(
             &[&keypair],
             &[],
@@ -1102,7 +1102,7 @@ mod tests {
         let account = Account::new(2, 1, &Pubkey::default());
         accounts.push((key1, account));
 
-        let instructions = vec![Instruction::new(1, &(), vec![0])];
+        let instructions = vec![CompiledInstruction::new(1, &(), vec![0])];
         let tx = Transaction::new_with_instructions(
             &[&keypair],
             &[],
@@ -1130,7 +1130,7 @@ mod tests {
         let account = Account::new(1, 1, &Pubkey::default());
         accounts.push((key0, account));
 
-        let instructions = vec![Instruction::new(1, &(), vec![0])];
+        let instructions = vec![CompiledInstruction::new(1, &(), vec![0])];
         let tx = Transaction::new_with_instructions(
             &[&keypair],
             &[],
@@ -1165,7 +1165,7 @@ mod tests {
         let account = Account::new(2, 1, &Pubkey::default());
         accounts.push((key1, account));
 
-        let instructions = vec![Instruction::new(0, &(), vec![0, 1])];
+        let instructions = vec![CompiledInstruction::new(0, &(), vec![0, 1])];
         let tx = Transaction::new_with_instructions(
             &[&keypair],
             &[key1],
@@ -1237,7 +1237,7 @@ mod tests {
         account.owner = key5;
         accounts.push((key6, account));
 
-        let instructions = vec![Instruction::new(0, &(), vec![0])];
+        let instructions = vec![CompiledInstruction::new(0, &(), vec![0])];
         let tx = Transaction::new_with_instructions(
             &[&keypair],
             &[],
@@ -1271,7 +1271,7 @@ mod tests {
         account.owner = Pubkey::default();
         accounts.push((key1, account));
 
-        let instructions = vec![Instruction::new(0, &(), vec![0])];
+        let instructions = vec![CompiledInstruction::new(0, &(), vec![0])];
         let tx = Transaction::new_with_instructions(
             &[&keypair],
             &[],
@@ -1304,7 +1304,7 @@ mod tests {
         account.owner = native_loader::id();
         accounts.push((key1, account));
 
-        let instructions = vec![Instruction::new(0, &(), vec![0])];
+        let instructions = vec![CompiledInstruction::new(0, &(), vec![0])];
         let tx = Transaction::new_with_instructions(
             &[&keypair],
             &[],
@@ -1351,8 +1351,8 @@ mod tests {
         accounts.push((key3, account));
 
         let instructions = vec![
-            Instruction::new(0, &(), vec![0]),
-            Instruction::new(1, &(), vec![0]),
+            CompiledInstruction::new(0, &(), vec![0]),
+            CompiledInstruction::new(1, &(), vec![0]),
         ];
         let tx = Transaction::new_with_instructions(
             &[&keypair],
@@ -1396,7 +1396,7 @@ mod tests {
         let account = Account::new(10, 1, &Pubkey::default());
         accounts.push((pubkey, account));
 
-        let instructions = vec![Instruction::new(0, &(), vec![0, 1])];
+        let instructions = vec![CompiledInstruction::new(0, &(), vec![0, 1])];
         // Simulate pay-to-self transaction, which loads the same account twice
         let tx = Transaction::new_with_instructions(
             &[&keypair],

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1484,7 +1484,7 @@ mod tests {
 
         let move_lamports = SystemInstruction::Move { lamports: 1 };
 
-        let mut tx = Transaction::new_unsigned(
+        let mut tx = Transaction::new_with_blockhash_and_fee(
             &mint_keypair.pubkey(),
             &[key.pubkey()],
             &system_program::id(),

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -847,7 +847,7 @@ mod tests {
     use solana_sdk::system_instruction::SystemInstruction;
     use solana_sdk::system_program;
     use solana_sdk::system_transaction::SystemTransaction;
-    use solana_sdk::transaction::{Instruction, InstructionError};
+    use solana_sdk::transaction::{CompiledInstruction, InstructionError};
 
     #[test]
     fn test_bank_new() {
@@ -927,12 +927,12 @@ mod tests {
         let bank = Bank::new(&genesis_block);
         let spend = SystemInstruction::Move { lamports: 1 };
         let instructions = vec![
-            Instruction {
+            CompiledInstruction {
                 program_ids_index: 0,
                 data: serialize(&spend).unwrap(),
                 accounts: vec![0, 1],
             },
-            Instruction {
+            CompiledInstruction {
                 program_ids_index: 0,
                 data: serialize(&spend).unwrap(),
                 accounts: vec![0, 2],

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -939,7 +939,7 @@ mod tests {
             },
         ];
 
-        let t1 = Transaction::new_with_instructions(
+        let t1 = Transaction::new_with_compiled_instructions(
             &[&mint_keypair],
             &[key1, key2],
             genesis_block.hash(),

--- a/runtime/tests/system.rs
+++ b/runtime/tests/system.rs
@@ -21,7 +21,7 @@ fn test_system_unsigned_transaction() {
 
     // Fund to account to bypass AccountNotFound error
     let ix = SystemInstruction::new_move(&from_pubkey, &to_pubkey, 50);
-    let mut tx = TransactionBuilder::new_with_instruction(ix);
+    let mut tx = TransactionBuilder::new(vec![ix]).compile();
     alice_client.process_transaction(&mut tx).unwrap();
 
     // Erroneously sign transaction with recipient account key
@@ -31,7 +31,7 @@ fn test_system_unsigned_transaction() {
         &SystemInstruction::Move { lamports: 10 },
         vec![(from_pubkey, false), (to_pubkey, true)],
     );
-    let mut tx = TransactionBuilder::new_with_instruction(ix);
+    let mut tx = TransactionBuilder::new(vec![ix]).compile();
     assert_eq!(
         mallory_client.process_transaction(&mut tx),
         Err(TransactionError::InstructionError(

--- a/runtime/tests/system.rs
+++ b/runtime/tests/system.rs
@@ -5,8 +5,7 @@ use solana_sdk::native_program::ProgramError;
 use solana_sdk::signature::{Keypair, KeypairUtil};
 use solana_sdk::system_instruction::SystemInstruction;
 use solana_sdk::system_program;
-use solana_sdk::transaction::{Instruction, InstructionError, TransactionError};
-use solana_sdk::transaction_builder::TransactionBuilder;
+use solana_sdk::transaction::{Instruction, InstructionError, Transaction, TransactionError};
 
 #[test]
 fn test_system_unsigned_transaction() {
@@ -21,7 +20,7 @@ fn test_system_unsigned_transaction() {
 
     // Fund to account to bypass AccountNotFound error
     let ix = SystemInstruction::new_move(&from_pubkey, &to_pubkey, 50);
-    let mut tx = TransactionBuilder::new(vec![ix]).compile();
+    let mut tx = Transaction::new(vec![ix]);
     alice_client.process_transaction(&mut tx).unwrap();
 
     // Erroneously sign transaction with recipient account key
@@ -31,7 +30,7 @@ fn test_system_unsigned_transaction() {
         &SystemInstruction::Move { lamports: 10 },
         vec![(from_pubkey, false), (to_pubkey, true)],
     );
-    let mut tx = TransactionBuilder::new(vec![ix]).compile();
+    let mut tx = Transaction::new(vec![ix]);
     assert_eq!(
         mallory_client.process_transaction(&mut tx),
         Err(TransactionError::InstructionError(

--- a/runtime/tests/system.rs
+++ b/runtime/tests/system.rs
@@ -5,8 +5,8 @@ use solana_sdk::native_program::ProgramError;
 use solana_sdk::signature::{Keypair, KeypairUtil};
 use solana_sdk::system_instruction::SystemInstruction;
 use solana_sdk::system_program;
-use solana_sdk::transaction::{InstructionError, TransactionError};
-use solana_sdk::transaction_builder::{BuilderInstruction, TransactionBuilder};
+use solana_sdk::transaction::{Instruction, InstructionError, TransactionError};
+use solana_sdk::transaction_builder::TransactionBuilder;
 
 #[test]
 fn test_system_unsigned_transaction() {
@@ -26,7 +26,7 @@ fn test_system_unsigned_transaction() {
 
     // Erroneously sign transaction with recipient account key
     // No signature case is tested by bank `test_zero_signatures()`
-    let ix = BuilderInstruction::new(
+    let ix = Instruction::new(
         system_program::id(),
         &SystemInstruction::Move { lamports: 10 },
         vec![(from_pubkey, false), (to_pubkey, true)],

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -15,7 +15,7 @@ pub mod system_program;
 pub mod system_transaction;
 pub mod timing;
 pub mod transaction;
-pub mod transaction_builder;
+mod transaction_builder;
 
 #[macro_use]
 extern crate serde_derive;

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -15,7 +15,7 @@ pub mod system_program;
 pub mod system_transaction;
 pub mod timing;
 pub mod transaction;
-mod transaction_builder;
+mod transaction_compiler;
 
 #[macro_use]
 extern crate serde_derive;

--- a/sdk/src/loader_transaction.rs
+++ b/sdk/src/loader_transaction.rs
@@ -18,7 +18,7 @@ impl LoaderTransaction {
         fee: u64,
     ) -> Transaction {
         let instruction = LoaderInstruction::Write { offset, bytes };
-        Transaction::new(
+        Transaction::new_signed(
             from_keypair,
             &[],
             loader,
@@ -35,7 +35,7 @@ impl LoaderTransaction {
         fee: u64,
     ) -> Transaction {
         let instruction = LoaderInstruction::Finalize;
-        Transaction::new(
+        Transaction::new_signed(
             from_keypair,
             &[],
             loader,

--- a/sdk/src/system_instruction.rs
+++ b/sdk/src/system_instruction.rs
@@ -1,6 +1,6 @@
 use crate::pubkey::Pubkey;
 use crate::system_program;
-use crate::transaction_builder::BuilderInstruction;
+use crate::transaction::Instruction;
 
 #[derive(Serialize, Debug, Clone, PartialEq)]
 pub enum SystemError {
@@ -38,8 +38,8 @@ impl SystemInstruction {
         lamports: u64,
         space: u64,
         program_id: &Pubkey,
-    ) -> BuilderInstruction {
-        BuilderInstruction::new(
+    ) -> Instruction {
+        Instruction::new(
             system_program::id(),
             &SystemInstruction::CreateAccount {
                 lamports,
@@ -50,8 +50,8 @@ impl SystemInstruction {
         )
     }
 
-    pub fn new_move(from_id: &Pubkey, to_id: &Pubkey, lamports: u64) -> BuilderInstruction {
-        BuilderInstruction::new(
+    pub fn new_move(from_id: &Pubkey, to_id: &Pubkey, lamports: u64) -> Instruction {
+        Instruction::new(
             system_program::id(),
             &SystemInstruction::Move { lamports },
             vec![(*from_id, true), (*to_id, false)],

--- a/sdk/src/system_transaction.rs
+++ b/sdk/src/system_transaction.rs
@@ -25,7 +25,7 @@ impl SystemTransaction {
             space,
             program_id: *program_id,
         };
-        Transaction::new(
+        Transaction::new_signed(
             from_keypair,
             &[*to],
             &system_program::id(),
@@ -64,7 +64,7 @@ impl SystemTransaction {
         let assign = SystemInstruction::Assign {
             program_id: *program_id,
         };
-        Transaction::new(
+        Transaction::new_signed(
             from_keypair,
             &[],
             &system_program::id(),
@@ -82,7 +82,7 @@ impl SystemTransaction {
         fee: u64,
     ) -> Transaction {
         let move_lamports = SystemInstruction::Move { lamports };
-        Transaction::new(
+        Transaction::new_signed(
             from_keypair,
             &[*to],
             &system_program::id(),
@@ -108,7 +108,7 @@ impl SystemTransaction {
             .collect();
         let to_keys: Vec<_> = moves.iter().map(|(to_key, _)| *to_key).collect();
 
-        Transaction::new_with_instructions(
+        Transaction::new_with_compiled_instructions(
             &[from],
             &to_keys,
             recent_blockhash,

--- a/sdk/src/system_transaction.rs
+++ b/sdk/src/system_transaction.rs
@@ -5,7 +5,7 @@ use crate::pubkey::Pubkey;
 use crate::signature::Keypair;
 use crate::system_instruction::SystemInstruction;
 use crate::system_program;
-use crate::transaction::{Instruction, Transaction};
+use crate::transaction::{CompiledInstruction, Transaction};
 
 pub struct SystemTransaction {}
 
@@ -103,7 +103,7 @@ impl SystemTransaction {
             .enumerate()
             .map(|(i, (_, amount))| {
                 let spend = SystemInstruction::Move { lamports: *amount };
-                Instruction::new(0, &spend, vec![0, i as u8 + 1])
+                CompiledInstruction::new(0, &spend, vec![0, i as u8 + 1])
             })
             .collect();
         let to_keys: Vec<_> = moves.iter().map(|(to_key, _)| *to_key).collect();

--- a/sdk/src/transaction.rs
+++ b/sdk/src/transaction.rs
@@ -199,7 +199,8 @@ impl Transaction {
             account_keys.push((*pubkey, false));
         }
         let instruction = Instruction::new(*program_id, data, account_keys);
-        let mut transaction = TransactionBuilder::new(fee).push(instruction).compile();
+        let mut transaction = TransactionBuilder::new(vec![instruction]).compile();
+        transaction.fee = fee;
         transaction.recent_blockhash = recent_blockhash;
         transaction
     }

--- a/sdk/src/transaction.rs
+++ b/sdk/src/transaction.rs
@@ -10,7 +10,7 @@ use crate::shortvec::{
 };
 use crate::signature::{KeypairUtil, Signature};
 use crate::system_instruction::SystemError;
-use crate::transaction_builder::TransactionBuilder;
+use crate::transaction_compiler::TransactionCompiler;
 use bincode::{serialize, Error};
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use serde::{Deserialize, Serialize, Serializer};
@@ -168,7 +168,7 @@ pub struct Transaction {
 
 impl Transaction {
     pub fn new(instructions: Vec<Instruction>) -> Self {
-        TransactionBuilder::new(instructions).compile()
+        TransactionCompiler::new(instructions).compile()
     }
 
     pub fn new_with_blockhash_and_fee<T: Serialize>(

--- a/sdk/src/transaction.rs
+++ b/sdk/src/transaction.rs
@@ -167,7 +167,7 @@ pub struct Transaction {
 }
 
 impl Transaction {
-    pub fn new<S: Serialize, T: KeypairUtil>(
+    pub fn new_signed<S: Serialize, T: KeypairUtil>(
         from_keypair: &T,
         transaction_keys: &[Pubkey],
         program_id: &Pubkey,
@@ -212,7 +212,7 @@ impl Transaction {
     /// * `fee` - The transaction fee.
     /// * `program_ids` - The keys that identify programs used in the `instruction` vector.
     /// * `instructions` - Instructions that will be executed atomically.
-    pub fn new_with_instructions<T: KeypairUtil>(
+    pub fn new_with_compiled_instructions<T: KeypairUtil>(
         from_keypairs: &[&T],
         keys: &[Pubkey],
         recent_blockhash: Hash,
@@ -500,7 +500,7 @@ mod tests {
             CompiledInstruction::new(0, &(), vec![0, 1]),
             CompiledInstruction::new(1, &(), vec![0, 2]),
         ];
-        let tx = Transaction::new_with_instructions(
+        let tx = Transaction::new_with_compiled_instructions(
             &[&key],
             &[key1, key2],
             Hash::default(),
@@ -535,7 +535,7 @@ mod tests {
     fn test_refs_invalid_program_id() {
         let key = Keypair::new();
         let instructions = vec![CompiledInstruction::new(1, &(), vec![])];
-        let tx = Transaction::new_with_instructions(
+        let tx = Transaction::new_with_compiled_instructions(
             &[&key],
             &[],
             Hash::default(),
@@ -549,7 +549,7 @@ mod tests {
     fn test_refs_invalid_account() {
         let key = Keypair::new();
         let instructions = vec![CompiledInstruction::new(0, &(), vec![1])];
-        let tx = Transaction::new_with_instructions(
+        let tx = Transaction::new_with_compiled_instructions(
             &[&key],
             &[],
             Hash::default(),
@@ -566,7 +566,7 @@ mod tests {
         let keypair = Keypair::new();
         let program_id = Pubkey::new(&[4; 32]);
         let to = Pubkey::new(&[5; 32]);
-        let tx = Transaction::new(
+        let tx = Transaction::new_signed(
             &keypair,
             &[keypair.pubkey(), to],
             &program_id,
@@ -585,7 +585,7 @@ mod tests {
         let keypair = Keypair::new();
         let program_id = Pubkey::new(&[4; 32]);
         let to = Pubkey::new(&[5; 32]);
-        let tx = Transaction::new(
+        let tx = Transaction::new_signed(
             &keypair,
             &[keypair.pubkey(), to],
             &program_id,
@@ -631,7 +631,7 @@ mod tests {
             2, 2, 2,
         ]);
 
-        let tx = Transaction::new(
+        let tx = Transaction::new_signed(
             &keypair,
             &[to],
             &program_id,

--- a/sdk/src/transaction_builder.rs
+++ b/sdk/src/transaction_builder.rs
@@ -35,28 +35,13 @@ fn compile_instructions(
 /// A utility for constructing transactions
 #[derive(Default)]
 pub struct TransactionBuilder {
-    fee: u64,
     instructions: Vec<Instruction>,
 }
 
 impl TransactionBuilder {
-    /// Create a new TransactionBuilder.
-    pub fn new(fee: u64) -> Self {
-        Self {
-            fee,
-            instructions: vec![],
-        }
-    }
-
     /// Create a new unsigned transaction from a single instruction
-    pub fn new_with_instruction(instruction: Instruction) -> Transaction {
-        Self::new_with_instructions(vec![instruction])
-    }
-
-    /// Create a new unsigned transaction from a single instruction
-    pub fn new_with_instructions(instructions: Vec<Instruction>) -> Transaction {
-        let fee = 0;
-        Self { fee, instructions }.compile()
+    pub fn new(instructions: Vec<Instruction>) -> Self {
+        Self { instructions }
     }
 
     /// Add an instruction.
@@ -107,7 +92,7 @@ impl TransactionBuilder {
             signatures: Vec::with_capacity(signed_len),
             account_keys: signed_keys,
             recent_blockhash: Hash::default(),
-            fee: self.fee,
+            fee: 0,
             program_ids,
             instructions,
         }
@@ -229,11 +214,6 @@ mod tests {
     }
 
     #[test]
-    fn test_transaction_builder_fee() {
-        assert_eq!(TransactionBuilder::new(42).compile().fee, 42);
-    }
-
-    #[test]
     fn test_transaction_builder_kitchen_sink() {
         let program_id0 = Pubkey::default();
         let program_id1 = Keypair::new().pubkey();
@@ -248,26 +228,5 @@ mod tests {
         assert_eq!(tx.instructions[0], CompiledInstruction::new(0, &0, vec![1]));
         assert_eq!(tx.instructions[1], CompiledInstruction::new(1, &0, vec![0]));
         assert_eq!(tx.instructions[2], CompiledInstruction::new(0, &0, vec![0]));
-    }
-
-    #[test]
-    fn test_transaction_builder_new_with_instruction() {
-        let ix = Instruction::new(Pubkey::default(), &0, vec![]);
-        assert_eq!(
-            TransactionBuilder::new_with_instruction(ix.clone()),
-            TransactionBuilder::default().push(ix.clone()).compile()
-        );
-    }
-
-    #[test]
-    fn test_transaction_builder_new_with_instructions() {
-        let ix = Instruction::new(Pubkey::default(), &0, vec![]);
-        assert_eq!(
-            TransactionBuilder::new_with_instructions(vec![ix.clone(), ix.clone()]),
-            TransactionBuilder::default()
-                .push(ix.clone())
-                .push(ix.clone())
-                .compile()
-        );
     }
 }

--- a/sdk/src/transaction_builder.rs
+++ b/sdk/src/transaction_builder.rs
@@ -33,7 +33,6 @@ fn compile_instructions(
 }
 
 /// A utility for constructing transactions
-#[derive(Default)]
 pub struct TransactionBuilder {
     instructions: Vec<Instruction>,
 }
@@ -42,12 +41,6 @@ impl TransactionBuilder {
     /// Create a new unsigned transaction from a single instruction
     pub fn new(instructions: Vec<Instruction>) -> Self {
         Self { instructions }
-    }
-
-    /// Add an instruction.
-    pub fn push(&mut self, instruction: Instruction) -> &mut Self {
-        self.instructions.push(instruction);
-        self
     }
 
     /// Return pubkeys referenced by all instructions, with the ones needing signatures first.
@@ -107,10 +100,11 @@ mod tests {
     #[test]
     fn test_transaction_builder_unique_program_ids() {
         let program_id0 = Pubkey::default();
-        let program_ids = TransactionBuilder::default()
-            .push(Instruction::new(program_id0, &0, vec![]))
-            .push(Instruction::new(program_id0, &0, vec![]))
-            .program_ids();
+        let program_ids = TransactionBuilder::new(vec![
+            Instruction::new(program_id0, &0, vec![]),
+            Instruction::new(program_id0, &0, vec![]),
+        ])
+        .program_ids();
         assert_eq!(program_ids, vec![program_id0]);
     }
 
@@ -118,11 +112,12 @@ mod tests {
     fn test_transaction_builder_unique_program_ids_not_adjacent() {
         let program_id0 = Pubkey::default();
         let program_id1 = Keypair::new().pubkey();
-        let program_ids = TransactionBuilder::default()
-            .push(Instruction::new(program_id0, &0, vec![]))
-            .push(Instruction::new(program_id1, &0, vec![]))
-            .push(Instruction::new(program_id0, &0, vec![]))
-            .program_ids();
+        let program_ids = TransactionBuilder::new(vec![
+            Instruction::new(program_id0, &0, vec![]),
+            Instruction::new(program_id1, &0, vec![]),
+            Instruction::new(program_id0, &0, vec![]),
+        ])
+        .program_ids();
         assert_eq!(program_ids, vec![program_id0, program_id1]);
     }
 
@@ -130,11 +125,12 @@ mod tests {
     fn test_transaction_builder_unique_program_ids_order_preserved() {
         let program_id0 = Keypair::new().pubkey();
         let program_id1 = Pubkey::default(); // Key less than program_id0
-        let program_ids = TransactionBuilder::default()
-            .push(Instruction::new(program_id0, &0, vec![]))
-            .push(Instruction::new(program_id1, &0, vec![]))
-            .push(Instruction::new(program_id0, &0, vec![]))
-            .program_ids();
+        let program_ids = TransactionBuilder::new(vec![
+            Instruction::new(program_id0, &0, vec![]),
+            Instruction::new(program_id1, &0, vec![]),
+            Instruction::new(program_id0, &0, vec![]),
+        ])
+        .program_ids();
         assert_eq!(program_ids, vec![program_id0, program_id1]);
     }
 
@@ -142,10 +138,11 @@ mod tests {
     fn test_transaction_builder_unique_keys_both_signed() {
         let program_id = Pubkey::default();
         let id0 = Pubkey::default();
-        let keys = TransactionBuilder::default()
-            .push(Instruction::new(program_id, &0, vec![(id0, true)]))
-            .push(Instruction::new(program_id, &0, vec![(id0, true)]))
-            .keys();
+        let keys = TransactionBuilder::new(vec![
+            Instruction::new(program_id, &0, vec![(id0, true)]),
+            Instruction::new(program_id, &0, vec![(id0, true)]),
+        ])
+        .keys();
         assert_eq!(keys, (vec![id0], vec![]));
     }
 
@@ -153,10 +150,11 @@ mod tests {
     fn test_transaction_builder_unique_keys_one_signed() {
         let program_id = Pubkey::default();
         let id0 = Pubkey::default();
-        let keys = TransactionBuilder::default()
-            .push(Instruction::new(program_id, &0, vec![(id0, false)]))
-            .push(Instruction::new(program_id, &0, vec![(id0, true)]))
-            .keys();
+        let keys = TransactionBuilder::new(vec![
+            Instruction::new(program_id, &0, vec![(id0, false)]),
+            Instruction::new(program_id, &0, vec![(id0, true)]),
+        ])
+        .keys();
         assert_eq!(keys, (vec![id0], vec![]));
     }
 
@@ -165,10 +163,11 @@ mod tests {
         let program_id = Pubkey::default();
         let id0 = Keypair::new().pubkey();
         let id1 = Pubkey::default(); // Key less than id0
-        let keys = TransactionBuilder::default()
-            .push(Instruction::new(program_id, &0, vec![(id0, false)]))
-            .push(Instruction::new(program_id, &0, vec![(id1, false)]))
-            .keys();
+        let keys = TransactionBuilder::new(vec![
+            Instruction::new(program_id, &0, vec![(id0, false)]),
+            Instruction::new(program_id, &0, vec![(id1, false)]),
+        ])
+        .keys();
         assert_eq!(keys, (vec![], vec![id0, id1]));
     }
 
@@ -177,11 +176,12 @@ mod tests {
         let program_id = Pubkey::default();
         let id0 = Pubkey::default();
         let id1 = Keypair::new().pubkey();
-        let keys = TransactionBuilder::default()
-            .push(Instruction::new(program_id, &0, vec![(id0, false)]))
-            .push(Instruction::new(program_id, &0, vec![(id1, false)]))
-            .push(Instruction::new(program_id, &0, vec![(id0, true)]))
-            .keys();
+        let keys = TransactionBuilder::new(vec![
+            Instruction::new(program_id, &0, vec![(id0, false)]),
+            Instruction::new(program_id, &0, vec![(id1, false)]),
+            Instruction::new(program_id, &0, vec![(id0, true)]),
+        ])
+        .keys();
         assert_eq!(keys, (vec![id0], vec![id1]));
     }
 
@@ -190,10 +190,11 @@ mod tests {
         let program_id = Pubkey::default();
         let id0 = Pubkey::default();
         let id1 = Keypair::new().pubkey();
-        let keys = TransactionBuilder::default()
-            .push(Instruction::new(program_id, &0, vec![(id0, false)]))
-            .push(Instruction::new(program_id, &0, vec![(id1, true)]))
-            .keys();
+        let keys = TransactionBuilder::new(vec![
+            Instruction::new(program_id, &0, vec![(id0, false)]),
+            Instruction::new(program_id, &0, vec![(id1, true)]),
+        ])
+        .keys();
         assert_eq!(keys, (vec![id1], vec![id0]));
     }
 
@@ -202,13 +203,12 @@ mod tests {
     fn test_transaction_builder_signed_keys_len() {
         let program_id = Pubkey::default();
         let id0 = Pubkey::default();
-        let tx = TransactionBuilder::default()
-            .push(Instruction::new(program_id, &0, vec![(id0, false)]))
-            .compile();
+        let tx =
+            TransactionBuilder::new(vec![Instruction::new(program_id, &0, vec![(id0, false)])])
+                .compile();
         assert_eq!(tx.signatures.capacity(), 0);
 
-        let tx = TransactionBuilder::default()
-            .push(Instruction::new(program_id, &0, vec![(id0, true)]))
+        let tx = TransactionBuilder::new(vec![Instruction::new(program_id, &0, vec![(id0, true)])])
             .compile();
         assert_eq!(tx.signatures.capacity(), 1);
     }
@@ -220,11 +220,12 @@ mod tests {
         let id0 = Pubkey::default();
         let keypair1 = Keypair::new();
         let id1 = keypair1.pubkey();
-        let tx = TransactionBuilder::default()
-            .push(Instruction::new(program_id0, &0, vec![(id0, false)]))
-            .push(Instruction::new(program_id1, &0, vec![(id1, true)]))
-            .push(Instruction::new(program_id0, &0, vec![(id1, false)]))
-            .compile();
+        let tx = TransactionBuilder::new(vec![
+            Instruction::new(program_id0, &0, vec![(id0, false)]),
+            Instruction::new(program_id1, &0, vec![(id1, true)]),
+            Instruction::new(program_id0, &0, vec![(id1, false)]),
+        ])
+        .compile();
         assert_eq!(tx.instructions[0], CompiledInstruction::new(0, &0, vec![1]));
         assert_eq!(tx.instructions[1], CompiledInstruction::new(1, &0, vec![0]));
         assert_eq!(tx.instructions[2], CompiledInstruction::new(0, &0, vec![0]));

--- a/sdk/src/transaction_compiler.rs
+++ b/sdk/src/transaction_compiler.rs
@@ -33,11 +33,11 @@ fn compile_instructions(
 }
 
 /// A utility for constructing transactions
-pub struct TransactionBuilder {
+pub struct TransactionCompiler {
     instructions: Vec<Instruction>,
 }
 
-impl TransactionBuilder {
+impl TransactionCompiler {
     /// Create a new unsigned transaction from a single instruction
     pub fn new(instructions: Vec<Instruction>) -> Self {
         Self { instructions }
@@ -100,7 +100,7 @@ mod tests {
     #[test]
     fn test_transaction_builder_unique_program_ids() {
         let program_id0 = Pubkey::default();
-        let program_ids = TransactionBuilder::new(vec![
+        let program_ids = TransactionCompiler::new(vec![
             Instruction::new(program_id0, &0, vec![]),
             Instruction::new(program_id0, &0, vec![]),
         ])
@@ -112,7 +112,7 @@ mod tests {
     fn test_transaction_builder_unique_program_ids_not_adjacent() {
         let program_id0 = Pubkey::default();
         let program_id1 = Keypair::new().pubkey();
-        let program_ids = TransactionBuilder::new(vec![
+        let program_ids = TransactionCompiler::new(vec![
             Instruction::new(program_id0, &0, vec![]),
             Instruction::new(program_id1, &0, vec![]),
             Instruction::new(program_id0, &0, vec![]),
@@ -125,7 +125,7 @@ mod tests {
     fn test_transaction_builder_unique_program_ids_order_preserved() {
         let program_id0 = Keypair::new().pubkey();
         let program_id1 = Pubkey::default(); // Key less than program_id0
-        let program_ids = TransactionBuilder::new(vec![
+        let program_ids = TransactionCompiler::new(vec![
             Instruction::new(program_id0, &0, vec![]),
             Instruction::new(program_id1, &0, vec![]),
             Instruction::new(program_id0, &0, vec![]),
@@ -138,7 +138,7 @@ mod tests {
     fn test_transaction_builder_unique_keys_both_signed() {
         let program_id = Pubkey::default();
         let id0 = Pubkey::default();
-        let keys = TransactionBuilder::new(vec![
+        let keys = TransactionCompiler::new(vec![
             Instruction::new(program_id, &0, vec![(id0, true)]),
             Instruction::new(program_id, &0, vec![(id0, true)]),
         ])
@@ -150,7 +150,7 @@ mod tests {
     fn test_transaction_builder_unique_keys_one_signed() {
         let program_id = Pubkey::default();
         let id0 = Pubkey::default();
-        let keys = TransactionBuilder::new(vec![
+        let keys = TransactionCompiler::new(vec![
             Instruction::new(program_id, &0, vec![(id0, false)]),
             Instruction::new(program_id, &0, vec![(id0, true)]),
         ])
@@ -163,7 +163,7 @@ mod tests {
         let program_id = Pubkey::default();
         let id0 = Keypair::new().pubkey();
         let id1 = Pubkey::default(); // Key less than id0
-        let keys = TransactionBuilder::new(vec![
+        let keys = TransactionCompiler::new(vec![
             Instruction::new(program_id, &0, vec![(id0, false)]),
             Instruction::new(program_id, &0, vec![(id1, false)]),
         ])
@@ -176,7 +176,7 @@ mod tests {
         let program_id = Pubkey::default();
         let id0 = Pubkey::default();
         let id1 = Keypair::new().pubkey();
-        let keys = TransactionBuilder::new(vec![
+        let keys = TransactionCompiler::new(vec![
             Instruction::new(program_id, &0, vec![(id0, false)]),
             Instruction::new(program_id, &0, vec![(id1, false)]),
             Instruction::new(program_id, &0, vec![(id0, true)]),
@@ -190,7 +190,7 @@ mod tests {
         let program_id = Pubkey::default();
         let id0 = Pubkey::default();
         let id1 = Keypair::new().pubkey();
-        let keys = TransactionBuilder::new(vec![
+        let keys = TransactionCompiler::new(vec![
             Instruction::new(program_id, &0, vec![(id0, false)]),
             Instruction::new(program_id, &0, vec![(id1, true)]),
         ])
@@ -204,12 +204,13 @@ mod tests {
         let program_id = Pubkey::default();
         let id0 = Pubkey::default();
         let tx =
-            TransactionBuilder::new(vec![Instruction::new(program_id, &0, vec![(id0, false)])])
+            TransactionCompiler::new(vec![Instruction::new(program_id, &0, vec![(id0, false)])])
                 .compile();
         assert_eq!(tx.signatures.capacity(), 0);
 
-        let tx = TransactionBuilder::new(vec![Instruction::new(program_id, &0, vec![(id0, true)])])
-            .compile();
+        let tx =
+            TransactionCompiler::new(vec![Instruction::new(program_id, &0, vec![(id0, true)])])
+                .compile();
         assert_eq!(tx.signatures.capacity(), 1);
     }
 
@@ -220,7 +221,7 @@ mod tests {
         let id0 = Pubkey::default();
         let keypair1 = Keypair::new();
         let id1 = keypair1.pubkey();
-        let tx = TransactionBuilder::new(vec![
+        let tx = TransactionCompiler::new(vec![
             Instruction::new(program_id0, &0, vec![(id0, false)]),
             Instruction::new(program_id1, &0, vec![(id1, true)]),
             Instruction::new(program_id0, &0, vec![(id1, false)]),

--- a/wallet/src/wallet.rs
+++ b/wallet/src/wallet.rs
@@ -442,7 +442,7 @@ fn process_configure_staking(
     authorized_voter_option: Option<Pubkey>,
 ) -> ProcessResult {
     let recent_blockhash = get_recent_blockhash(&rpc_client)?;
-    let mut tx = TransactionBuilder::new(0);
+    let mut tx = TransactionBuilder::default();
     if let Some(delegate_id) = delegate_option {
         tx.push(VoteInstruction::new_delegate_stake(
             &config.id.pubkey(),

--- a/wallet/src/wallet.rs
+++ b/wallet/src/wallet.rs
@@ -25,7 +25,6 @@ use solana_sdk::signature::{Keypair, KeypairUtil, Signature};
 use solana_sdk::system_transaction::SystemTransaction;
 use solana_sdk::timing::{DEFAULT_TICKS_PER_SLOT, NUM_TICKS_PER_SECOND};
 use solana_sdk::transaction::Transaction;
-use solana_sdk::transaction_builder::TransactionBuilder;
 use solana_vote_api::vote_instruction::VoteInstruction;
 use solana_vote_api::vote_transaction::VoteTransaction;
 use std::fs::File;
@@ -442,20 +441,20 @@ fn process_configure_staking(
     authorized_voter_option: Option<Pubkey>,
 ) -> ProcessResult {
     let recent_blockhash = get_recent_blockhash(&rpc_client)?;
-    let mut tx = TransactionBuilder::default();
+    let mut ixs = vec![];
     if let Some(delegate_id) = delegate_option {
-        tx.push(VoteInstruction::new_delegate_stake(
+        ixs.push(VoteInstruction::new_delegate_stake(
             &config.id.pubkey(),
             &delegate_id,
         ));
     }
     if let Some(authorized_voter_id) = authorized_voter_option {
-        tx.push(VoteInstruction::new_authorize_voter(
+        ixs.push(VoteInstruction::new_authorize_voter(
             &config.id.pubkey(),
             &authorized_voter_id,
         ));
     }
-    let mut tx = tx.compile();
+    let mut tx = Transaction::new(ixs);
     tx.sign(&[&config.id], recent_blockhash);
     let signature_str = send_and_confirm_transaction(&rpc_client, &mut tx, &config.id)?;
     Ok(signature_str.to_string())


### PR DESCRIPTION
#### Problem

It's too easy to construct Transactions the wrong way (with a keypair, blockhash, and fee) and too hard to construction them the right way (leaving that job to client objects).

#### Summary of Changes

* Make existing Transaction constructors more precise
* Add a much simpler default for Transaction::new
* Migrate from TransactionBuilder to Transaction
* Abandon the overly-verbose builder pattern
* Rename TransactionBuilder to TransactionCompiler
* Make TransactionCompiler a private module

cc #3312
