### PR TITLE
Replicator download test

### DIFF
--- a/core/src/blocktree.rs
+++ b/core/src/blocktree.rs
@@ -612,6 +612,11 @@ impl Blocktree {
         Ok(result)
     }
 
+    pub fn deserialize_blob_data(data: &[u8]) -> Result<Vec<Entry>> {
+        let entries = deserialize(data)?;
+        Ok(entries)
+    }
+
     fn deserialize_blobs<I>(blob_datas: &[I]) -> Vec<Entry>
     where
         I: Borrow<[u8]>,
@@ -620,9 +625,8 @@ impl Blocktree {
             .iter()
             .flat_map(|blob_data| {
                 let serialized_entries_data = &blob_data.borrow()[BLOB_HEADER_SIZE..];
-                let entries: Vec<Entry> = deserialize(serialized_entries_data)
-                    .expect("Ledger should only contain well formed data");
-                entries
+                Self::deserialize_blob_data(serialized_entries_data)
+                    .expect("Ledger should only contain well formed data")
             })
             .collect()
     }

--- a/core/src/gossip_service.rs
+++ b/core/src/gossip_service.rs
@@ -65,8 +65,8 @@ pub fn discover(gossip_addr: &SocketAddr, num_nodes: usize) -> std::io::Result<V
     let now = Instant::now();
     let mut i = 0;
     while now.elapsed() < Duration::from_secs(30) {
-        let rpc_peers = spy_ref.read().unwrap().rpc_peers();
-        if rpc_peers.len() >= num_nodes {
+        let tvu_peers = spy_ref.read().unwrap().tvu_peers();
+        if tvu_peers.len() >= num_nodes {
             info!(
                 "discover success in {}s...\n{}",
                 now.elapsed().as_secs(),
@@ -75,7 +75,7 @@ pub fn discover(gossip_addr: &SocketAddr, num_nodes: usize) -> std::io::Result<V
 
             exit.store(true, Ordering::Relaxed);
             gossip_service.join().unwrap();
-            return Ok(rpc_peers);
+            return Ok(tvu_peers);
         }
         if i % 20 == 0 {
             info!(

--- a/core/src/local_cluster.rs
+++ b/core/src/local_cluster.rs
@@ -196,7 +196,7 @@ impl LocalCluster {
             &replicator_keypair.pubkey(),
             1,
         );
-        let replicator_node = Node::new_localhost_with_pubkey(&replicator_keypair.pubkey());
+        let replicator_node = Node::new_localhost_replicator(&replicator_keypair.pubkey());
 
         let (replicator_ledger_path, _blockhash) = create_new_tmp_ledger!(&self.genesis_block);
         let replicator = Replicator::new(

--- a/core/src/replicator.rs
+++ b/core/src/replicator.rs
@@ -122,12 +122,19 @@ impl Replicator {
     #[allow(clippy::new_ret_no_self)]
     pub fn new(
         ledger_path: &str,
-        node: Node,
+        mut node: Node,
         cluster_entrypoint: ContactInfo,
         keypair: Arc<Keypair>,
         _timeout: Option<Duration>,
     ) -> Result<Self> {
         let exit = Arc::new(AtomicBool::new(false));
+
+        // replicator cannot give information on rpc and
+        // cannot be leader so tpu/rpc ports are cleared
+        node.info.rpc = "0.0.0.0:0".parse().unwrap();
+        node.info.rpc_pubsub = "0.0.0.0:0".parse().unwrap();
+        node.info.tpu = "0.0.0.0:0".parse().unwrap();
+        node.info.tpu_via_blobs = "0.0.0.0:0".parse().unwrap();
 
         info!("Replicator: id: {}", keypair.pubkey());
         info!("Creating cluster info....");

--- a/core/tests/replicator.rs
+++ b/core/tests/replicator.rs
@@ -8,7 +8,6 @@ use bincode::{deserialize, serialize};
 use solana::blocktree::{create_new_tmp_ledger, tmp_copy_blocktree, Blocktree};
 use solana::cluster_info::{ClusterInfo, Node};
 use solana::contact_info::ContactInfo;
-use solana::entry::Entry;
 use solana::fullnode::{Fullnode, FullnodeConfig};
 use solana::gossip_service::discover;
 use solana::local_cluster::LocalCluster;
@@ -82,10 +81,13 @@ fn download_from_replicator(replicator_info: &ContactInfo) {
             for b in blobs {
                 let br = b.read().unwrap();
                 assert!(br.index() == repair_index);
-                let entry: Entry = deserialize(&br.data()[..br.meta.size]).unwrap();
-                info!("entry: {:?}", entry);
-                assert_ne!(entry.hash, Hash::default());
-                received_blob = true;
+                info!("br: {:?}", br);
+                let entries = Blocktree::deserialize_blob_data(&br.data()).unwrap();
+                for entry in &entries {
+                    info!("entry: {:?}", entry);
+                    assert_ne!(entry.hash, Hash::default());
+                    received_blob = true;
+                }
             }
             break;
         }

--- a/core/tests/replicator.rs
+++ b/core/tests/replicator.rs
@@ -8,6 +8,7 @@ use solana::blocktree::{create_new_tmp_ledger, tmp_copy_blocktree, Blocktree};
 use solana::cluster_info::Node;
 use solana::contact_info::ContactInfo;
 use solana::fullnode::{Fullnode, FullnodeConfig};
+use solana::gossip_service::discover;
 use solana::local_cluster::LocalCluster;
 use solana::replicator::Replicator;
 use solana::storage_stage::STORAGE_ROTATE_TEST_COUNT;
@@ -35,6 +36,17 @@ fn test_replicator_startup_basic() {
         DEFAULT_TICKS_PER_SLOT,
         DEFAULT_SLOTS_PER_EPOCH,
     );
+
+    let cluster_nodes = discover(&cluster.entry_point_info.gossip, 3).unwrap();
+    assert_eq!(cluster_nodes.len(), 3);
+    let mut replicator_count = 0;
+    for node in &cluster_nodes {
+        info!("storage: {:?} rpc: {:?}", node.storage_addr, node.rpc);
+        if ContactInfo::is_valid_address(&node.storage_addr) {
+            replicator_count += 1;
+        }
+    }
+    assert_eq!(replicator_count, 1);
 }
 
 #[test]

--- a/core/tests/replicator.rs
+++ b/core/tests/replicator.rs
@@ -4,21 +4,97 @@ extern crate log;
 #[macro_use]
 extern crate solana;
 
+use bincode::{deserialize, serialize};
 use solana::blocktree::{create_new_tmp_ledger, tmp_copy_blocktree, Blocktree};
-use solana::cluster_info::Node;
+use solana::cluster_info::{ClusterInfo, Node};
 use solana::contact_info::ContactInfo;
+use solana::entry::Entry;
 use solana::fullnode::{Fullnode, FullnodeConfig};
 use solana::gossip_service::discover;
 use solana::local_cluster::LocalCluster;
 use solana::replicator::Replicator;
+use solana::replicator::ReplicatorRequest;
 use solana::storage_stage::STORAGE_ROTATE_TEST_COUNT;
+use solana::streamer::blob_receiver;
 use solana_sdk::genesis_block::GenesisBlock;
+use solana_sdk::hash::Hash;
 use solana_sdk::signature::{Keypair, KeypairUtil};
 use solana_sdk::timing::DEFAULT_SLOTS_PER_EPOCH;
 use solana_sdk::timing::DEFAULT_TICKS_PER_SLOT;
 use std::fs::remove_dir_all;
+use std::net::SocketAddr;
+use std::net::UdpSocket;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc::channel;
 use std::sync::Arc;
+use std::thread::sleep;
 use std::time::Duration;
+
+fn get_slot_height(to: SocketAddr) -> u64 {
+    let socket = UdpSocket::bind("0.0.0.0:0").unwrap();
+    socket
+        .set_read_timeout(Some(Duration::from_secs(5)))
+        .unwrap();
+
+    let req = ReplicatorRequest::GetSlotHeight(socket.local_addr().unwrap());
+    let serialized_req = serialize(&req).unwrap();
+    for _ in 0..10 {
+        socket.send_to(&serialized_req, to).unwrap();
+        let mut buf = [0; 1024];
+        if let Ok((size, _addr)) = socket.recv_from(&mut buf) {
+            return deserialize(&buf[..size]).unwrap();
+        }
+        sleep(Duration::from_millis(500));
+    }
+    panic!("Couldn't get slot height!");
+}
+
+fn download_from_replicator(replicator_info: &ContactInfo) {
+    // Create a client which downloads from the replicator and see that it
+    // can respond with blobs.
+    let tn = Node::new_localhost();
+    let cluster_info = ClusterInfo::new_with_invalid_keypair(tn.info.clone());
+    let mut repair_index = get_slot_height(replicator_info.storage_addr);
+    info!("repair index: {}", repair_index);
+
+    repair_index = 0;
+    let req = cluster_info
+        .window_index_request_bytes(0, repair_index)
+        .unwrap();
+
+    let exit = Arc::new(AtomicBool::new(false));
+    let (s_reader, r_reader) = channel();
+    let repair_socket = Arc::new(tn.sockets.repair);
+    let t_receiver = blob_receiver(repair_socket.clone(), &exit, s_reader);
+
+    info!(
+        "Sending repair requests from: {} to: {}",
+        tn.info.id, replicator_info.gossip
+    );
+
+    let mut received_blob = false;
+    for _ in 0..5 {
+        repair_socket.send_to(&req, replicator_info.gossip).unwrap();
+
+        let x = r_reader.recv_timeout(Duration::new(1, 0));
+
+        if let Ok(blobs) = x {
+            for b in blobs {
+                let br = b.read().unwrap();
+                assert!(br.index() == repair_index);
+                let entry: Entry = deserialize(&br.data()[..br.meta.size]).unwrap();
+                info!("entry: {:?}", entry);
+                assert_ne!(entry.hash, Hash::default());
+                received_blob = true;
+            }
+            break;
+        }
+    }
+    exit.store(true, Ordering::Relaxed);
+    t_receiver.join().unwrap();
+
+    assert!(received_blob);
+}
 
 #[test]
 fn test_replicator_startup_basic() {
@@ -26,27 +102,36 @@ fn test_replicator_startup_basic() {
     info!("starting replicator test");
 
     const NUM_NODES: usize = 2;
+    let num_replicators = 1;
     let mut fullnode_config = FullnodeConfig::default();
     fullnode_config.storage_rotate_count = STORAGE_ROTATE_TEST_COUNT;
-    let _cluster = LocalCluster::new_with_config_replicators(
+    let cluster = LocalCluster::new_with_config_replicators(
         &[100; NUM_NODES],
         10_000,
         &fullnode_config,
-        1,
+        num_replicators,
         DEFAULT_TICKS_PER_SLOT,
         DEFAULT_SLOTS_PER_EPOCH,
     );
 
-    let cluster_nodes = discover(&cluster.entry_point_info.gossip, 3).unwrap();
-    assert_eq!(cluster_nodes.len(), 3);
+    let cluster_nodes = discover(
+        &cluster.entry_point_info.gossip,
+        NUM_NODES + num_replicators,
+    )
+    .unwrap();
+    assert_eq!(cluster_nodes.len(), NUM_NODES + num_replicators);
     let mut replicator_count = 0;
+    let mut replicator_info = ContactInfo::default();
     for node in &cluster_nodes {
         info!("storage: {:?} rpc: {:?}", node.storage_addr, node.rpc);
         if ContactInfo::is_valid_address(&node.storage_addr) {
             replicator_count += 1;
+            replicator_info = node.clone();
         }
     }
-    assert_eq!(replicator_count, 1);
+    assert_eq!(replicator_count, num_replicators);
+
+    download_from_replicator(&replicator_info);
 }
 
 #[test]

--- a/replicator/src/main.rs
+++ b/replicator/src/main.rs
@@ -67,7 +67,7 @@ fn main() {
         }
         addr
     };
-    let node = Node::new_with_external_ip(&keypair.pubkey(), &gossip_addr);
+    let node = Node::new_replicator_with_external_ip(&keypair.pubkey(), &gossip_addr);
 
     println!(
         "replicating the data with keypair={:?} gossip_addr={:?}",


### PR DESCRIPTION
#### Problem

Nothing testing that replicator can download ledger and also serve to others. Also, a replicator kind of looks like a validator on gossip, but it can't really respond to RPC requests, or use its TPU ports or do  things that fullnodes can.

#### Summary of Changes

Clear out the TPU/RPC ports for replicators and fill in storage_addr and use it as an interface to query replicator for what ledger segment it has.
Add the test logic to find the replicator on gossip and ask it for the segment it's storing.

Fixes #
