### PR TITLE
Fix leader rotation counter

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -12,6 +12,7 @@ use crate::result;
 use crate::rpc_subscriptions::RpcSubscriptions;
 use crate::service::Service;
 use solana_metrics::counter::Counter;
+use solana_metrics::influxdb;
 use solana_runtime::bank::Bank;
 use solana_sdk::hash::Hash;
 use solana_sdk::pubkey::Pubkey;
@@ -241,7 +242,13 @@ impl ReplayStage {
                     cluster_info.write().unwrap().set_leader(&next_leader);
                     if next_leader == *my_id && reached_leader_tick {
                         debug!("{} starting tpu for slot {}", my_id, poh_slot);
-                        inc_new_counter_info!("replay_stage-new_leader", poh_slot as usize);
+                        solana_metrics::submit(
+                            influxdb::Point::new("counter-replay_stage-new_leader")
+                                .add_field(
+                                    "count",
+                                    influxdb::Value::Integer(poh_slot as i64),
+                                )
+                                .to_owned(),);
                         let tpu_bank = Bank::new_from_parent(parent, my_id, poh_slot);
                         bank_forks.write().unwrap().insert(poh_slot, tpu_bank);
                         if let Some(tpu_bank) = bank_forks.read().unwrap().get(poh_slot).cloned() {


### PR DESCRIPTION
#### Problem

The leader rotation counter was not accurate. It would not honor reporting times. 

#### Summary of Changes

Use an influxdb point instead of a counter.


