### PR TITLE
Bump kvstore version to 0.13.0 to match all other solana crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2029,7 +2029,7 @@ dependencies = [
  "solana-budget-program 0.13.0",
  "solana-client 0.13.0",
  "solana-drone 0.13.0",
- "solana-kvstore 0.0.1",
+ "solana-kvstore 0.13.0",
  "solana-logger 0.13.0",
  "solana-metrics 0.13.0",
  "solana-netutil 0.13.0",
@@ -2259,7 +2259,7 @@ dependencies = [
 
 [[package]]
 name = "solana-kvstore"
-version = "0.0.1"
+version = "0.13.0"
 dependencies = [
  "bincode 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -48,7 +48,7 @@ serde_json = "1.0.39"
 solana-budget-api = { path = "../programs/budget_api", version = "0.13.0" }
 solana-client = { path = "../client", version = "0.13.0" }
 solana-drone = { path = "../drone", version = "0.13.0" }
-solana-kvstore = { path = "../kvstore", version = "0.0.1", optional = true }
+solana-kvstore = { path = "../kvstore", version = "0.13.0", optional = true }
 solana-logger = { path = "../logger", version = "0.13.0" }
 solana-metrics = { path = "../metrics", version = "0.13.0" }
 solana-netutil = { path = "../netutil", version = "0.13.0" }

--- a/kvstore/Cargo.toml
+++ b/kvstore/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "solana-kvstore"
 description = "Embedded Key-Value store for solana"
-version = "0.0.1"
+version = "0.13.0"
 homepage = "https://solana.com/"
 repository = "https://github.com/solana-labs/solana"
 authors = ["Solana Maintainers <maintainers@solana.com>"]


### PR DESCRIPTION
I missed this in the review of #3327.  Our release engineering process assumes that all our crates have the same version number for simplicity