### PR TITLE
Organize accounts on a per fork basis

### DIFF
--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -106,22 +106,22 @@ struct AccountInfo {
     /// purposes to remove accounts with zero balance.
     lamports: u64,
 
-    /// Maintain vote accounts for performance reasons to avoid having
-    /// to iterate through the entire accounts each time
+    /// keep track if this is a vote account for performance reasons to avoid
+    /// having to read the accounts from the storage
     is_vote_account: bool,
 }
 
 // in a given a Fork, which AppendVecId and offset
 type AccountMap = RwLock<HashMap<Pubkey, AccountInfo>>;
 
-/// information about where Accounts are stored and which vote accounts are present
+/// information about where Accounts are stored
 /// keying hierarchy is:
 ///
-///    pubkey->fork->append_vec->offset
+///    fork->pubkey->append_vec->offset
 ///
 #[derive(Default)]
 struct AccountIndex {
-    /// For each Pubkey, the Account for a specific Fork is in a specific
+    /// For each Fork, the Account for a specific Pubkey is in a specific
     ///  AppendVec at a specific index.  There may be an Account for Pubkey
     ///  in any number of Forks.
     account_maps: RwLock<HashMap<Fork, AccountMap>>,


### PR DESCRIPTION
#### Problem
The verify operation performed through solana-ledger-tool seems to be slow. The bulk of time during this operation seems to be spent inside hash_internal_state() and squash() functions in accounts. Look at possible ways to optimize these routines.

#### Summary of Changes
The hash_internal_state() routine needs only the accounts of the current fork to calculate the hash but the way the accounts are stored, it needs to iterate through the entire list of pubkeys across all forks to calculate this and the same for squash where it needs to iterate only over the current and its parent forks. One possible way is to reorganize the accounts to store on a per fork basis which would help improve the performance in this case but it comes with increased memory usage as the pubkey values are now duplicated across forks.

Fixes #3155 
