### PR TITLE
client/ grooming

### DIFF
--- a/bench-tps/src/bench.rs
+++ b/bench-tps/src/bench.rs
@@ -52,7 +52,7 @@ pub fn sample_tx_count(
     v: &ContactInfo,
     sample_period: u64,
 ) {
-    let mut client = create_client(v.client_facing_addr(), FULLNODE_PORT_RANGE);
+    let client = create_client(v.client_facing_addr(), FULLNODE_PORT_RANGE);
     let mut now = Instant::now();
     let mut initial_tx_count = client.transaction_count();
     let mut max_tps = 0.0;
@@ -182,7 +182,7 @@ pub fn generate_txs(
     reclaim: bool,
     contact_info: &ContactInfo,
 ) {
-    let mut client = create_client(contact_info.client_facing_addr(), FULLNODE_PORT_RANGE);
+    let client = create_client(contact_info.client_facing_addr(), FULLNODE_PORT_RANGE);
     let blockhash = client.get_recent_blockhash();
     let tx_count = source.len();
     println!("Signing transactions... {} (reclaim={})", tx_count, reclaim);
@@ -292,7 +292,7 @@ pub fn do_tx_transfers(
     }
 }
 
-pub fn verify_funding_transfer(client: &mut ThinClient, tx: &Transaction, amount: u64) -> bool {
+pub fn verify_funding_transfer(client: &ThinClient, tx: &Transaction, amount: u64) -> bool {
     for a in &tx.account_keys[1..] {
         if client.get_balance(a).unwrap_or(0) >= amount {
             return true;
@@ -305,7 +305,7 @@ pub fn verify_funding_transfer(client: &mut ThinClient, tx: &Transaction, amount
 /// fund the dests keys by spending all of the source keys into MAX_SPENDS_PER_TX
 /// on every iteration.  This allows us to replay the transfers because the source is either empty,
 /// or full
-pub fn fund_keys(client: &mut ThinClient, source: &Keypair, dests: &[Keypair], lamports: u64) {
+pub fn fund_keys(client: &ThinClient, source: &Keypair, dests: &[Keypair], lamports: u64) {
     let total = lamports * dests.len() as u64;
     let mut funded: Vec<(&Keypair, u64)> = vec![(source, total)];
     let mut notfunded: Vec<&Keypair> = dests.iter().collect();
@@ -398,12 +398,7 @@ pub fn fund_keys(client: &mut ThinClient, source: &Keypair, dests: &[Keypair], l
     }
 }
 
-pub fn airdrop_lamports(
-    client: &mut ThinClient,
-    drone_addr: &SocketAddr,
-    id: &Keypair,
-    tx_count: u64,
-) {
+pub fn airdrop_lamports(client: &ThinClient, drone_addr: &SocketAddr, id: &Keypair, tx_count: u64) {
     let starting_balance = client.poll_get_balance(&id.pubkey()).unwrap_or(0);
     metrics_submit_lamport_balance(starting_balance);
     println!("starting balance {}", starting_balance);

--- a/bench-tps/src/main.rs
+++ b/bench-tps/src/main.rs
@@ -63,7 +63,7 @@ fn main() {
     }
     let cluster_entrypoint = nodes[0].clone(); // Pick the first node, why not?
 
-    let mut client = create_client(cluster_entrypoint.client_facing_addr(), FULLNODE_PORT_RANGE);
+    let client = create_client(cluster_entrypoint.client_facing_addr(), FULLNODE_PORT_RANGE);
     let mut barrier_client =
         create_client(cluster_entrypoint.client_facing_addr(), FULLNODE_PORT_RANGE);
 
@@ -94,13 +94,13 @@ fn main() {
     if num_lamports_per_account > keypair0_balance {
         let extra = num_lamports_per_account - keypair0_balance;
         let total = extra * (gen_keypairs.len() as u64);
-        airdrop_lamports(&mut client, &drone_addr, &id, total);
+        airdrop_lamports(&client, &drone_addr, &id, total);
         println!("adding more lamports {}", extra);
-        fund_keys(&mut client, &id, &gen_keypairs, extra);
+        fund_keys(&client, &id, &gen_keypairs, extra);
     }
     let start = gen_keypairs.len() - (tx_count * 2) as usize;
     let keypairs = &gen_keypairs[start..];
-    airdrop_lamports(&mut barrier_client, &drone_addr, &barrier_source_keypair, 1);
+    airdrop_lamports(&barrier_client, &drone_addr, &barrier_source_keypair, 1);
 
     println!("Get last ID...");
     let mut blockhash = client.get_recent_blockhash();

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -13,5 +13,5 @@ pub fn create_client_with_timeout(
     timeout: Duration,
 ) -> ThinClient {
     let (_, transactions_socket) = solana_netutil::bind_in_range(range).unwrap();
-    ThinClient::new_with_timeout(rpc, tpu, transactions_socket, timeout)
+    ThinClient::new_socket_with_timeout(rpc, tpu, transactions_socket, timeout)
 }

--- a/client/src/rpc_mock.rs
+++ b/client/src/rpc_mock.rs
@@ -17,12 +17,12 @@ pub const SIGNATURE: &str =
 
 #[derive(Clone)]
 pub struct MockRpcClient {
-    pub addr: String,
+    pub url: String,
 }
 
 impl MockRpcClient {
-    pub fn new(addr: String) -> Self {
-        MockRpcClient { addr }
+    pub fn new(url: String) -> Self {
+        MockRpcClient { url }
     }
 
     pub fn retry_get_balance(
@@ -45,7 +45,7 @@ impl MockRpcClient {
         params: Option<Value>,
         mut _retries: usize,
     ) -> Result<Value, Box<dyn error::Error>> {
-        if self.addr == "fails" {
+        if self.url == "fails" {
             return Ok(Value::Null);
         }
         let val = match request {
@@ -61,14 +61,14 @@ impl MockRpcClient {
                 }
             }
             RpcRequest::GetBalance => {
-                let n = if self.addr == "airdrop" { 0 } else { 50 };
+                let n = if self.url == "airdrop" { 0 } else { 50 };
                 Value::Number(Number::from(n))
             }
             RpcRequest::GetRecentBlockhash => Value::String(PUBKEY.to_string()),
             RpcRequest::GetSignatureStatus => {
-                let str = if self.addr == "account_in_use" {
+                let str = if self.url == "account_in_use" {
                     "AccountInUse"
-                } else if self.addr == "bad_sig_status" {
+                } else if self.url == "bad_sig_status" {
                     "Nonexistent"
                 } else {
                     "Confirmed"

--- a/client/src/rpc_mock.rs
+++ b/client/src/rpc_mock.rs
@@ -27,20 +27,18 @@ impl MockRpcClient {
 
     pub fn retry_get_balance(
         &self,
-        id: u64,
         pubkey: &Pubkey,
         retries: usize,
     ) -> Result<Option<u64>, Box<dyn error::Error>> {
         let params = json!([format!("{}", pubkey)]);
         let res = self
-            .retry_make_rpc_request(id, &RpcRequest::GetBalance, Some(params), retries)?
+            .retry_make_rpc_request(&RpcRequest::GetBalance, Some(params), retries)?
             .as_u64();
         Ok(res)
     }
 
     pub fn retry_make_rpc_request(
         &self,
-        _id: u64,
         request: &RpcRequest,
         params: Option<Value>,
         mut _retries: usize,
@@ -86,11 +84,10 @@ impl MockRpcClient {
 impl RpcRequestHandler for MockRpcClient {
     fn make_rpc_request(
         &self,
-        id: u64,
         request: RpcRequest,
         params: Option<Value>,
     ) -> Result<Value, Box<dyn error::Error>> {
-        self.retry_make_rpc_request(id, &request, params, 0)
+        self.retry_make_rpc_request(&request, params, 0)
     }
 }
 

--- a/client/src/rpc_request.rs
+++ b/client/src/rpc_request.rs
@@ -1,14 +1,18 @@
+use bs58;
 use log::*;
 use reqwest;
 use reqwest::header::CONTENT_TYPE;
 use serde_json::{json, Value};
+use solana_sdk::account::Account;
+use solana_sdk::hash::Hash;
+use solana_sdk::pubkey::Pubkey;
+use solana_sdk::signature::Signature;
 use solana_sdk::timing::{DEFAULT_TICKS_PER_SLOT, NUM_TICKS_PER_SECOND};
+use std::io;
 use std::net::SocketAddr;
 use std::thread::sleep;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use std::{error, fmt};
-
-use solana_sdk::pubkey::Pubkey;
 
 #[derive(Clone)]
 pub struct RpcClient {
@@ -47,6 +51,202 @@ impl RpcClient {
             .retry_make_rpc_request(&RpcRequest::GetBalance, Some(params), retries)?
             .as_u64();
         Ok(res)
+    }
+
+    pub fn get_account_data(&self, pubkey: &Pubkey) -> io::Result<Option<Vec<u8>>> {
+        let params = json!([format!("{}", pubkey)]);
+        let response = self.make_rpc_request(RpcRequest::GetAccountInfo, Some(params));
+        match response {
+            Ok(account_json) => {
+                let account: Account =
+                    serde_json::from_value(account_json).expect("deserialize account");
+                Ok(Some(account.data))
+            }
+            Err(error) => {
+                debug!("get_account_data failed: {:?}", error);
+                Err(io::Error::new(
+                    io::ErrorKind::Other,
+                    "get_account_data failed",
+                ))
+            }
+        }
+    }
+
+    /// Request the balance of the user holding `pubkey`. This method blocks
+    /// until the server sends a response. If the response packet is dropped
+    /// by the network, this method will hang indefinitely.
+    pub fn get_balance(&self, pubkey: &Pubkey) -> io::Result<u64> {
+        let params = json!([format!("{}", pubkey)]);
+        let response = self.make_rpc_request(RpcRequest::GetAccountInfo, Some(params));
+
+        response
+            .and_then(|account_json| {
+                let account: Account =
+                    serde_json::from_value(account_json).expect("deserialize account");
+                trace!("Response account {:?} {:?}", pubkey, account);
+                trace!("get_balance {:?}", account.lamports);
+                Ok(account.lamports)
+            })
+            .map_err(|error| {
+                debug!("Response account {}: None (error: {:?})", pubkey, error);
+                io::Error::new(io::ErrorKind::Other, "AccountNotFound")
+            })
+    }
+
+    /// Request the transaction count.  If the response packet is dropped by the network,
+    /// this method will try again 5 times.
+    pub fn transaction_count(&self) -> u64 {
+        debug!("transaction_count");
+        for _tries in 0..5 {
+            let response = self.make_rpc_request(RpcRequest::GetTransactionCount, None);
+
+            match response {
+                Ok(value) => {
+                    debug!("transaction_count response: {:?}", value);
+                    let transaction_count = value.as_u64().unwrap();
+                    return transaction_count;
+                }
+                Err(error) => {
+                    debug!("transaction_count failed: {:?}", error);
+                }
+            };
+        }
+        0
+    }
+
+    /// Request the last Entry ID from the server without blocking.
+    /// Returns the blockhash Hash or None if there was no response from the server.
+    pub fn try_get_recent_blockhash(&self, mut num_retries: u64) -> Option<Hash> {
+        loop {
+            let response = self.make_rpc_request(RpcRequest::GetRecentBlockhash, None);
+
+            match response {
+                Ok(value) => {
+                    let blockhash_str = value.as_str().unwrap();
+                    let blockhash_vec = bs58::decode(blockhash_str).into_vec().unwrap();
+                    return Some(Hash::new(&blockhash_vec));
+                }
+                Err(error) => {
+                    debug!("thin_client get_recent_blockhash error: {:?}", error);
+                    num_retries -= 1;
+                    if num_retries == 0 {
+                        return None;
+                    }
+                }
+            }
+        }
+    }
+
+    /// Request the last Entry ID from the server. This method blocks
+    /// until the server sends a response.
+    pub fn get_recent_blockhash(&self) -> Hash {
+        loop {
+            if let Some(hash) = self.try_get_recent_blockhash(10) {
+                return hash;
+            }
+        }
+    }
+
+    /// Request a new last Entry ID from the server. This method blocks
+    /// until the server sends a response.
+    pub fn get_next_blockhash(&self, previous_blockhash: &Hash) -> Hash {
+        self.get_next_blockhash_ext(previous_blockhash, &|| {
+            sleep(Duration::from_millis(100));
+        })
+    }
+
+    fn get_next_blockhash_ext(&self, previous_blockhash: &Hash, func: &Fn()) -> Hash {
+        loop {
+            let blockhash = self.get_recent_blockhash();
+            if blockhash != *previous_blockhash {
+                break blockhash;
+            }
+            debug!("Got same blockhash ({:?}), will retry...", blockhash);
+            func()
+        }
+    }
+
+    pub fn poll_balance_with_timeout(
+        &self,
+        pubkey: &Pubkey,
+        polling_frequency: &Duration,
+        timeout: &Duration,
+    ) -> io::Result<u64> {
+        let now = Instant::now();
+        loop {
+            match self.get_balance(&pubkey) {
+                Ok(bal) => {
+                    return Ok(bal);
+                }
+                Err(e) => {
+                    sleep(*polling_frequency);
+                    if now.elapsed() > *timeout {
+                        return Err(e);
+                    }
+                }
+            };
+        }
+    }
+
+    pub fn poll_get_balance(&self, pubkey: &Pubkey) -> io::Result<u64> {
+        self.poll_balance_with_timeout(pubkey, &Duration::from_millis(100), &Duration::from_secs(1))
+    }
+
+    /// Poll the server to confirm a transaction.
+    pub fn poll_for_signature(&self, signature: &Signature) -> io::Result<()> {
+        let now = Instant::now();
+        while !self.check_signature(signature) {
+            if now.elapsed().as_secs() > 15 {
+                // TODO: Return a better error.
+                return Err(io::Error::new(io::ErrorKind::Other, "signature not found"));
+            }
+            sleep(Duration::from_millis(250));
+        }
+        Ok(())
+    }
+
+    /// Check a signature in the bank. This method blocks
+    /// until the server sends a response.
+    pub fn check_signature(&self, signature: &Signature) -> bool {
+        trace!("check_signature: {:?}", signature);
+        let params = json!([format!("{}", signature)]);
+
+        loop {
+            let response =
+                self.make_rpc_request(RpcRequest::ConfirmTransaction, Some(params.clone()));
+
+            match response {
+                Ok(confirmation) => {
+                    let signature_status = confirmation.as_bool().unwrap();
+                    if signature_status {
+                        trace!("Response found signature");
+                    } else {
+                        trace!("Response signature not found");
+                    }
+
+                    return signature_status;
+                }
+                Err(err) => {
+                    debug!("check_signature request failed: {:?}", err);
+                }
+            };
+        }
+    }
+    pub fn fullnode_exit(&self) -> io::Result<bool> {
+        let response = self
+            .make_rpc_request(RpcRequest::FullnodeExit, None)
+            .map_err(|err| {
+                io::Error::new(
+                    io::ErrorKind::Other,
+                    format!("FullnodeExit request failure: {:?}", err),
+                )
+            })?;
+        serde_json::from_value(response).map_err(|err| {
+            io::Error::new(
+                io::ErrorKind::Other,
+                format!("FullnodeExit parse failure: {:?}", err),
+            )
+        })
     }
 
     pub fn retry_make_rpc_request(

--- a/client/src/rpc_request.rs
+++ b/client/src/rpc_request.rs
@@ -53,14 +53,14 @@ impl RpcClient {
         Ok(res)
     }
 
-    pub fn get_account_data(&self, pubkey: &Pubkey) -> io::Result<Option<Vec<u8>>> {
+    pub fn get_account_data(&self, pubkey: &Pubkey) -> io::Result<Vec<u8>> {
         let params = json!([format!("{}", pubkey)]);
         let response = self.make_rpc_request(RpcRequest::GetAccountInfo, Some(params));
         match response {
             Ok(account_json) => {
                 let account: Account =
                     serde_json::from_value(account_json).expect("deserialize account");
-                Ok(Some(account.data))
+                Ok(account.data)
             }
             Err(error) => {
                 debug!("get_account_data failed: {:?}", error);

--- a/client/src/rpc_request.rs
+++ b/client/src/rpc_request.rs
@@ -13,27 +13,27 @@ use solana_sdk::pubkey::Pubkey;
 #[derive(Clone)]
 pub struct RpcClient {
     pub client: reqwest::Client,
-    pub addr: String,
+    pub url: String,
 }
 
 impl RpcClient {
-    pub fn new(addr: String) -> Self {
+    pub fn new(url: String) -> Self {
         RpcClient {
             client: reqwest::Client::new(),
-            addr,
+            url,
         }
     }
 
-    pub fn new_with_timeout(addr: SocketAddr, timeout: Duration) -> Self {
-        let addr = get_rpc_request_str(addr, false);
+    pub fn new_socket_with_timeout(addr: SocketAddr, timeout: Duration) -> Self {
+        let url = get_rpc_request_str(addr, false);
         let client = reqwest::Client::builder()
             .timeout(timeout)
             .build()
             .expect("build rpc client");
-        RpcClient { client, addr }
+        RpcClient { client, url }
     }
 
-    pub fn new_from_socket(addr: SocketAddr) -> Self {
+    pub fn new_socket(addr: SocketAddr) -> Self {
         Self::new(get_rpc_request_str(addr, false))
     }
 
@@ -62,7 +62,7 @@ impl RpcClient {
         loop {
             match self
                 .client
-                .post(&self.addr)
+                .post(&self.url)
                 .header(CONTENT_TYPE, "application/json")
                 .body(request_json.to_string())
                 .send()
@@ -269,7 +269,7 @@ mod tests {
         });
 
         let rpc_addr = receiver.recv().unwrap();
-        let rpc_client = RpcClient::new_from_socket(rpc_addr);
+        let rpc_client = RpcClient::new_socket(rpc_addr);
 
         let balance = rpc_client.make_rpc_request(
             1,
@@ -318,7 +318,7 @@ mod tests {
         });
 
         let rpc_addr = receiver.recv().unwrap();
-        let rpc_client = RpcClient::new_from_socket(rpc_addr);
+        let rpc_client = RpcClient::new_socket(rpc_addr);
 
         let balance = rpc_client.retry_make_rpc_request(
             1,

--- a/client/src/thin_client.rs
+++ b/client/src/thin_client.rs
@@ -45,17 +45,17 @@ impl ThinClient {
             rpc_addr,
             transactions_addr,
             transactions_socket,
-            RpcClient::new_from_socket(rpc_addr),
+            RpcClient::new_socket(rpc_addr),
         )
     }
 
-    pub fn new_with_timeout(
+    pub fn new_socket_with_timeout(
         rpc_addr: SocketAddr,
         transactions_addr: SocketAddr,
         transactions_socket: UdpSocket,
         timeout: Duration,
     ) -> Self {
-        let rpc_client = RpcClient::new_with_timeout(rpc_addr, timeout);
+        let rpc_client = RpcClient::new_socket_with_timeout(rpc_addr, timeout);
         Self::new_from_client(rpc_addr, transactions_addr, transactions_socket, rpc_client)
     }
 

--- a/client/src/thin_client.rs
+++ b/client/src/thin_client.rs
@@ -133,7 +133,7 @@ impl ThinClient {
         result
     }
 
-    pub fn get_account_data(&self, pubkey: &Pubkey) -> io::Result<Option<Vec<u8>>> {
+    pub fn get_account_data(&self, pubkey: &Pubkey) -> io::Result<Vec<u8>> {
         self.rpc_client.get_account_data(pubkey)
     }
 

--- a/client/src/thin_client.rs
+++ b/client/src/thin_client.rs
@@ -144,9 +144,9 @@ impl ThinClient {
 
     pub fn get_account_data(&mut self, pubkey: &Pubkey) -> io::Result<Option<Vec<u8>>> {
         let params = json!([format!("{}", pubkey)]);
-        let response =
-            self.rpc_client
-                .make_rpc_request(1, RpcRequest::GetAccountInfo, Some(params));
+        let response = self
+            .rpc_client
+            .make_rpc_request(RpcRequest::GetAccountInfo, Some(params));
         match response {
             Ok(account_json) => {
                 let account: Account =
@@ -169,9 +169,9 @@ impl ThinClient {
     pub fn get_balance(&mut self, pubkey: &Pubkey) -> io::Result<u64> {
         trace!("get_balance sending request to {}", self.rpc_addr);
         let params = json!([format!("{}", pubkey)]);
-        let response =
-            self.rpc_client
-                .make_rpc_request(1, RpcRequest::GetAccountInfo, Some(params));
+        let response = self
+            .rpc_client
+            .make_rpc_request(RpcRequest::GetAccountInfo, Some(params));
 
         response
             .and_then(|account_json| {
@@ -192,9 +192,9 @@ impl ThinClient {
     pub fn transaction_count(&mut self) -> u64 {
         debug!("transaction_count");
         for _tries in 0..5 {
-            let response =
-                self.rpc_client
-                    .make_rpc_request(1, RpcRequest::GetTransactionCount, None);
+            let response = self
+                .rpc_client
+                .make_rpc_request(RpcRequest::GetTransactionCount, None);
 
             match response {
                 Ok(value) => {
@@ -215,9 +215,9 @@ impl ThinClient {
     pub fn try_get_recent_blockhash(&mut self, mut num_retries: u64) -> Option<Hash> {
         loop {
             trace!("try_get_recent_blockhash send_to {}", &self.rpc_addr);
-            let response =
-                self.rpc_client
-                    .make_rpc_request(1, RpcRequest::GetRecentBlockhash, None);
+            let response = self
+                .rpc_client
+                .make_rpc_request(RpcRequest::GetRecentBlockhash, None);
 
             match response {
                 Ok(value) => {
@@ -326,11 +326,9 @@ impl ThinClient {
         let now = Instant::now();
 
         loop {
-            let response = self.rpc_client.make_rpc_request(
-                1,
-                RpcRequest::ConfirmTransaction,
-                Some(params.clone()),
-            );
+            let response = self
+                .rpc_client
+                .make_rpc_request(RpcRequest::ConfirmTransaction, Some(params.clone()));
 
             match response {
                 Ok(confirmation) => {
@@ -363,7 +361,7 @@ impl ThinClient {
         trace!("fullnode_exit sending request to {}", self.rpc_addr);
         let response = self
             .rpc_client
-            .make_rpc_request(1, RpcRequest::FullnodeExit, None)
+            .make_rpc_request(RpcRequest::FullnodeExit, None)
             .map_err(|error| {
                 debug!("Response from {} fullndoe_exit: {}", self.rpc_addr, error);
                 io::Error::new(io::ErrorKind::Other, "FullodeExit request failure")

--- a/core/src/cluster_tests.rs
+++ b/core/src/cluster_tests.rs
@@ -28,7 +28,7 @@ pub fn spend_and_verify_all_nodes(
     assert!(cluster_nodes.len() >= nodes);
     for ingress_node in &cluster_nodes {
         let random_keypair = Keypair::new();
-        let mut client = create_client(ingress_node.client_facing_addr(), FULLNODE_PORT_RANGE);
+        let client = create_client(ingress_node.client_facing_addr(), FULLNODE_PORT_RANGE);
         let bal = client
             .poll_get_balance(&funding_keypair.pubkey())
             .expect("balance in source");
@@ -44,14 +44,14 @@ pub fn spend_and_verify_all_nodes(
             .retry_transfer(&funding_keypair, &mut transaction, 5)
             .unwrap();
         for validator in &cluster_nodes {
-            let mut client = create_client(validator.client_facing_addr(), FULLNODE_PORT_RANGE);
+            let client = create_client(validator.client_facing_addr(), FULLNODE_PORT_RANGE);
             client.poll_for_signature(&sig).unwrap();
         }
     }
 }
 
 pub fn send_many_transactions(node: &ContactInfo, funding_keypair: &Keypair, num_txs: u64) {
-    let mut client = create_client(node.client_facing_addr(), FULLNODE_PORT_RANGE);
+    let client = create_client(node.client_facing_addr(), FULLNODE_PORT_RANGE);
     for _ in 0..num_txs {
         let random_keypair = Keypair::new();
         let bal = client
@@ -75,12 +75,12 @@ pub fn fullnode_exit(entry_point_info: &ContactInfo, nodes: usize) {
     let cluster_nodes = discover(&entry_point_info.gossip, nodes).unwrap();
     assert!(cluster_nodes.len() >= nodes);
     for node in &cluster_nodes {
-        let mut client = create_client(node.client_facing_addr(), FULLNODE_PORT_RANGE);
+        let client = create_client(node.client_facing_addr(), FULLNODE_PORT_RANGE);
         assert!(client.fullnode_exit().unwrap());
     }
     sleep(Duration::from_millis(SLOT_MILLIS));
     for node in &cluster_nodes {
-        let mut client = create_client(node.client_facing_addr(), FULLNODE_PORT_RANGE);
+        let client = create_client(node.client_facing_addr(), FULLNODE_PORT_RANGE);
         assert!(client.fullnode_exit().is_err());
     }
 }
@@ -126,7 +126,7 @@ pub fn kill_entry_and_spend_and_verify_rest(
     solana_logger::setup();
     let cluster_nodes = discover(&entry_point_info.gossip, nodes).unwrap();
     assert!(cluster_nodes.len() >= nodes);
-    let mut client = create_client(entry_point_info.client_facing_addr(), FULLNODE_PORT_RANGE);
+    let client = create_client(entry_point_info.client_facing_addr(), FULLNODE_PORT_RANGE);
     info!("sleeping for an epoch");
     sleep(Duration::from_millis(SLOT_MILLIS * DEFAULT_SLOTS_PER_EPOCH));
     info!("done sleeping for an epoch");
@@ -140,7 +140,7 @@ pub fn kill_entry_and_spend_and_verify_rest(
             continue;
         }
 
-        let mut client = create_client(ingress_node.client_facing_addr(), FULLNODE_PORT_RANGE);
+        let client = create_client(ingress_node.client_facing_addr(), FULLNODE_PORT_RANGE);
         let bal = client
             .poll_get_balance(&funding_keypair.pubkey())
             .expect("balance in source");
@@ -195,7 +195,7 @@ fn poll_all_nodes_for_signature(
         if validator.id == entry_point_info.id {
             continue;
         }
-        let mut client = create_client(validator.client_facing_addr(), FULLNODE_PORT_RANGE);
+        let client = create_client(validator.client_facing_addr(), FULLNODE_PORT_RANGE);
         client.poll_for_signature(&sig)?;
     }
 

--- a/core/src/local_cluster.rs
+++ b/core/src/local_cluster.rs
@@ -115,7 +115,7 @@ impl LocalCluster {
     }
 
     fn add_validator(&mut self, fullnode_config: &FullnodeConfig, stake: u64) {
-        let mut client = create_client(
+        let client = create_client(
             self.entry_point_info.client_facing_addr(),
             FULLNODE_PORT_RANGE,
         );
@@ -131,19 +131,14 @@ impl LocalCluster {
 
         // Send each validator some lamports to vote
         let validator_balance =
-            Self::transfer(&mut client, &self.funding_keypair, &validator_pubkey, stake);
+            Self::transfer(&client, &self.funding_keypair, &validator_pubkey, stake);
         info!(
             "validator {} balance {}",
             validator_pubkey, validator_balance
         );
 
-        Self::create_and_fund_vote_account(
-            &mut client,
-            &voting_keypair,
-            &validator_keypair,
-            stake - 1,
-        )
-        .unwrap();
+        Self::create_and_fund_vote_account(&client, &voting_keypair, &validator_keypair, stake - 1)
+            .unwrap();
 
         let validator_server = Fullnode::new(
             validator_node,
@@ -160,13 +155,13 @@ impl LocalCluster {
 
     fn add_replicator(&mut self) {
         let replicator_keypair = Arc::new(Keypair::new());
-        let mut client = create_client(
+        let client = create_client(
             self.entry_point_info.client_facing_addr(),
             FULLNODE_PORT_RANGE,
         );
 
         Self::transfer(
-            &mut client,
+            &client,
             &self.funding_keypair,
             &replicator_keypair.pubkey(),
             1,
@@ -196,7 +191,7 @@ impl LocalCluster {
     }
 
     fn transfer(
-        client: &mut ThinClient,
+        client: &ThinClient,
         source_keypair: &Keypair,
         dest_pubkey: &Pubkey,
         lamports: u64,
@@ -218,7 +213,7 @@ impl LocalCluster {
     }
 
     fn create_and_fund_vote_account(
-        client: &mut ThinClient,
+        client: &ThinClient,
         vote_account: &Keypair,
         from_account: &Arc<Keypair>,
         amount: u64,

--- a/core/src/local_cluster.rs
+++ b/core/src/local_cluster.rs
@@ -251,7 +251,7 @@ impl LocalCluster {
 
         info!("Checking for vote account registration");
         let vote_account_user_data = client.get_account_data(&vote_account_pubkey);
-        if let Ok(Some(vote_account_user_data)) = vote_account_user_data {
+        if let Ok(vote_account_user_data) = vote_account_user_data {
             if let Ok(vote_state) = VoteState::deserialize(&vote_account_user_data) {
                 if vote_state.delegate_id == delegate_id {
                     return Ok(());

--- a/core/src/replicator.rs
+++ b/core/src/replicator.rs
@@ -310,11 +310,11 @@ impl Replicator {
     }
 
     fn submit_mining_proof(&self) {
-        let mut client = create_client(
+        let client = create_client(
             self.cluster_entrypoint.client_facing_addr(),
             FULLNODE_PORT_RANGE,
         );
-        Self::get_airdrop_lamports(&mut client, &self.keypair, &self.cluster_entrypoint);
+        Self::get_airdrop_lamports(&client, &self.keypair, &self.cluster_entrypoint);
 
         let blockhash = client.get_recent_blockhash();
         let mut tx = StorageTransaction::new_mining_proof(
@@ -378,7 +378,7 @@ impl Replicator {
     }
 
     fn get_airdrop_lamports(
-        client: &mut ThinClient,
+        client: &ThinClient,
         keypair: &Keypair,
         cluster_entrypoint: &ContactInfo,
     ) {

--- a/core/src/replicator.rs
+++ b/core/src/replicator.rs
@@ -357,11 +357,11 @@ impl Replicator {
                 RpcClient::new_socket(rpc_peers[node_idx].rpc)
             };
             let storage_blockhash = rpc_client
-                .make_rpc_request(2, RpcRequest::GetStorageBlockhash, None)
+                .make_rpc_request(RpcRequest::GetStorageBlockhash, None)
                 .expect("rpc request")
                 .to_string();
             let storage_entry_height = rpc_client
-                .make_rpc_request(2, RpcRequest::GetStorageEntryHeight, None)
+                .make_rpc_request(RpcRequest::GetStorageEntryHeight, None)
                 .expect("rpc request")
                 .as_u64()
                 .unwrap();

--- a/core/src/replicator.rs
+++ b/core/src/replicator.rs
@@ -354,7 +354,7 @@ impl Replicator {
                 let rpc_peers = cluster_info.rpc_peers();
                 debug!("rpc peers: {:?}", rpc_peers);
                 let node_idx = thread_rng().gen_range(0, rpc_peers.len());
-                RpcClient::new_from_socket(rpc_peers[node_idx].rpc)
+                RpcClient::new_socket(rpc_peers[node_idx].rpc)
             };
             let storage_blockhash = rpc_client
                 .make_rpc_request(2, RpcRequest::GetStorageBlockhash, None)

--- a/core/src/storage_stage.rs
+++ b/core/src/storage_stage.rs
@@ -228,7 +228,7 @@ impl StorageStage {
         account_to_create: Option<Pubkey>,
     ) -> io::Result<()> {
         let contact_info = cluster_info.read().unwrap().my_data();
-        let mut client = create_client_with_timeout(
+        let client = create_client_with_timeout(
             contact_info.client_facing_addr(),
             FULLNODE_PORT_RANGE,
             Duration::from_secs(5),

--- a/core/src/voting_keypair.rs
+++ b/core/src/voting_keypair.rs
@@ -15,7 +15,7 @@ pub struct RemoteVoteSigner {
 
 impl RemoteVoteSigner {
     pub fn new(signer: SocketAddr) -> Self {
-        let rpc_client = RpcClient::new_from_socket(signer);
+        let rpc_client = RpcClient::new_socket(signer);
         Self { rpc_client }
     }
 }

--- a/core/src/voting_keypair.rs
+++ b/core/src/voting_keypair.rs
@@ -30,7 +30,7 @@ impl VoteSigner for RemoteVoteSigner {
         let params = json!([pubkey, sig, msg]);
         let resp = self
             .rpc_client
-            .retry_make_rpc_request(1, &RpcRequest::RegisterNode, Some(params), 5)
+            .retry_make_rpc_request(&RpcRequest::RegisterNode, Some(params), 5)
             .unwrap();
         let vote_account: Pubkey = serde_json::from_value(resp).unwrap();
         Ok(vote_account)
@@ -44,7 +44,7 @@ impl VoteSigner for RemoteVoteSigner {
         let params = json!([pubkey, sig, msg]);
         let resp = self
             .rpc_client
-            .retry_make_rpc_request(1, &RpcRequest::SignVote, Some(params), 0)
+            .retry_make_rpc_request(&RpcRequest::SignVote, Some(params), 0)
             .unwrap();
         let vote_signature: Signature = serde_json::from_value(resp).unwrap();
         Ok(vote_signature)
@@ -53,7 +53,7 @@ impl VoteSigner for RemoteVoteSigner {
         let params = json!([pubkey, sig, msg]);
         let _resp = self
             .rpc_client
-            .retry_make_rpc_request(1, &RpcRequest::DeregisterNode, Some(params), 5)
+            .retry_make_rpc_request(&RpcRequest::DeregisterNode, Some(params), 5)
             .unwrap();
         Ok(())
     }

--- a/proposals/src/cluster-test-framework.md
+++ b/proposals/src/cluster-test-framework.md
@@ -102,7 +102,7 @@ pub fn test_large_invalid_gossip_nodes(
     let cluster = discover(&entry_point_info, num_nodes);
 
     // Poison the cluster.
-    let mut client = create_client(entry_point_info.client_facing_addr(), FULLNODE_PORT_RANGE);
+    let client = create_client(entry_point_info.client_facing_addr(), FULLNODE_PORT_RANGE);
     for _ in 0..(num_nodes * 100) {
         client.gossip_push(
             cluster_info::invalid_contact_info()
@@ -112,7 +112,7 @@ pub fn test_large_invalid_gossip_nodes(
 
     // Force refresh of the active set.
     for node in &cluster {
-        let mut client = create_client(node.client_facing_addr(), FULLNODE_PORT_RANGE);
+        let client = create_client(node.client_facing_addr(), FULLNODE_PORT_RANGE);
         client.gossip_refresh_active_set();
     }
 

--- a/tests/thin_client.rs
+++ b/tests/thin_client.rs
@@ -23,7 +23,7 @@ fn test_thin_client_basic() {
     let bob_pubkey = Keypair::new().pubkey();
     discover(&leader_data.gossip, 1).unwrap();
 
-    let mut client = create_client(leader_data.client_facing_addr(), FULLNODE_PORT_RANGE);
+    let client = create_client(leader_data.client_facing_addr(), FULLNODE_PORT_RANGE);
 
     let transaction_count = client.transaction_count();
     assert_eq!(transaction_count, 0);
@@ -54,7 +54,7 @@ fn test_bad_sig() {
     let bob_pubkey = Keypair::new().pubkey();
     discover(&leader_data.gossip, 1).unwrap();
 
-    let mut client = create_client(leader_data.client_facing_addr(), FULLNODE_PORT_RANGE);
+    let client = create_client(leader_data.client_facing_addr(), FULLNODE_PORT_RANGE);
 
     let blockhash = client.get_recent_blockhash();
 
@@ -85,7 +85,7 @@ fn test_register_vote_account() {
     let (server, leader_data, alice, ledger_path) = new_fullnode_for_tests();
     discover(&leader_data.gossip, 1).unwrap();
 
-    let mut client = create_client(leader_data.client_facing_addr(), FULLNODE_PORT_RANGE);
+    let client = create_client(leader_data.client_facing_addr(), FULLNODE_PORT_RANGE);
 
     // Create the validator account, transfer some lamports to that account
     let validator_keypair = Keypair::new();
@@ -106,7 +106,7 @@ fn test_register_vote_account() {
     let signature = client.transfer_signed(&transaction).unwrap();
     client.poll_for_signature(&signature).unwrap();
 
-    let balance = retry_get_balance(&mut client, &vote_account_id, Some(1))
+    let balance = retry_get_balance(&client, &vote_account_id, Some(1))
         .expect("Expected balance for new account to exist");
     assert_eq!(balance, 1);
 
@@ -139,7 +139,7 @@ fn test_transaction_count() {
     solana_logger::setup();
     let addr = "0.0.0.0:1234".parse().unwrap();
     let transactions_socket = UdpSocket::bind("0.0.0.0:0").unwrap();
-    let mut client = ThinClient::new_socket_with_timeout(
+    let client = ThinClient::new_socket_with_timeout(
         addr,
         addr,
         transactions_socket,
@@ -155,7 +155,7 @@ fn test_zero_balance_after_nonzero() {
     let bob_keypair = Keypair::new();
     discover(&leader_data.gossip, 1).unwrap();
 
-    let mut client = create_client(leader_data.client_facing_addr(), FULLNODE_PORT_RANGE);
+    let client = create_client(leader_data.client_facing_addr(), FULLNODE_PORT_RANGE);
     let blockhash = client.get_recent_blockhash();
     info!("test_thin_client blockhash: {:?}", blockhash);
 

--- a/tests/thin_client.rs
+++ b/tests/thin_client.rs
@@ -114,8 +114,7 @@ fn test_register_vote_account() {
     for run in 0..=LAST {
         let account_user_data = client
             .get_account_data(&vote_account_id)
-            .expect("Expected valid response for account data")
-            .expect("Expected valid account data to exist after account creation");
+            .expect("Expected valid response for account data");
 
         let vote_state = VoteState::deserialize(&account_user_data);
 

--- a/tests/thin_client.rs
+++ b/tests/thin_client.rs
@@ -139,8 +139,12 @@ fn test_transaction_count() {
     solana_logger::setup();
     let addr = "0.0.0.0:1234".parse().unwrap();
     let transactions_socket = UdpSocket::bind("0.0.0.0:0").unwrap();
-    let mut client =
-        ThinClient::new_socket_with_timeout(addr, addr, transactions_socket, Duration::from_secs(2));
+    let mut client = ThinClient::new_socket_with_timeout(
+        addr,
+        addr,
+        transactions_socket,
+        Duration::from_secs(2),
+    );
     assert_eq!(client.transaction_count(), 0);
 }
 

--- a/tests/thin_client.rs
+++ b/tests/thin_client.rs
@@ -140,7 +140,7 @@ fn test_transaction_count() {
     let addr = "0.0.0.0:1234".parse().unwrap();
     let transactions_socket = UdpSocket::bind("0.0.0.0:0").unwrap();
     let mut client =
-        ThinClient::new_with_timeout(addr, addr, transactions_socket, Duration::from_secs(2));
+        ThinClient::new_socket_with_timeout(addr, addr, transactions_socket, Duration::from_secs(2));
     assert_eq!(client.transaction_count(), 0);
 }
 

--- a/wallet/tests/deploy.rs
+++ b/wallet/tests/deploy.rs
@@ -47,7 +47,7 @@ fn test_wallet_deploy_program() {
 
     let params = json!([program_id_str]);
     let account_info = rpc_client
-        .make_rpc_request(1, RpcRequest::GetAccountInfo, Some(params))
+        .make_rpc_request(RpcRequest::GetAccountInfo, Some(params))
         .unwrap();
     let account_info_obj = account_info.as_object().unwrap();
     assert_eq!(

--- a/wallet/tests/deploy.rs
+++ b/wallet/tests/deploy.rs
@@ -25,7 +25,7 @@ fn test_wallet_deploy_program() {
     run_local_drone(alice, sender);
     let drone_addr = receiver.recv().unwrap();
 
-    let rpc_client = RpcClient::new_from_socket(leader_data.rpc);
+    let rpc_client = RpcClient::new_socket(leader_data.rpc);
 
     let mut config = WalletConfig::default();
     config.drone_port = drone_addr.port();

--- a/wallet/tests/pay.rs
+++ b/wallet/tests/pay.rs
@@ -14,7 +14,7 @@ use std::sync::mpsc::channel;
 use solana::fullnode::new_fullnode_for_tests;
 
 fn check_balance(expected_balance: u64, client: &RpcClient, pubkey: &Pubkey) {
-    let balance = client.retry_get_balance(1, pubkey, 1).unwrap().unwrap();
+    let balance = client.retry_get_balance(pubkey, 1).unwrap().unwrap();
     assert_eq!(balance, expected_balance);
 }
 

--- a/wallet/tests/pay.rs
+++ b/wallet/tests/pay.rs
@@ -27,7 +27,7 @@ fn test_wallet_timestamp_tx() {
     run_local_drone(alice, sender);
     let drone_addr = receiver.recv().unwrap();
 
-    let rpc_client = RpcClient::new_from_socket(leader_data.rpc);
+    let rpc_client = RpcClient::new_socket(leader_data.rpc);
 
     let mut config_payer = WalletConfig::default();
     config_payer.drone_port = drone_addr.port();
@@ -87,7 +87,7 @@ fn test_wallet_witness_tx() {
     run_local_drone(alice, sender);
     let drone_addr = receiver.recv().unwrap();
 
-    let rpc_client = RpcClient::new_from_socket(leader_data.rpc);
+    let rpc_client = RpcClient::new_socket(leader_data.rpc);
 
     let mut config_payer = WalletConfig::default();
     config_payer.drone_port = drone_addr.port();
@@ -144,7 +144,7 @@ fn test_wallet_cancel_tx() {
     run_local_drone(alice, sender);
     let drone_addr = receiver.recv().unwrap();
 
-    let rpc_client = RpcClient::new_from_socket(leader_data.rpc);
+    let rpc_client = RpcClient::new_socket(leader_data.rpc);
 
     let mut config_payer = WalletConfig::default();
     config_payer.drone_port = drone_addr.port();

--- a/wallet/tests/request_airdrop.rs
+++ b/wallet/tests/request_airdrop.rs
@@ -21,7 +21,7 @@ fn test_wallet_request_airdrop() {
     let sig_response = process_command(&bob_config);
     sig_response.unwrap();
 
-    let rpc_client = RpcClient::new_from_socket(leader_data.rpc);
+    let rpc_client = RpcClient::new_socket(leader_data.rpc);
 
     let balance = rpc_client
         .retry_get_balance(1, &bob_config.id.pubkey(), 1)

--- a/wallet/tests/request_airdrop.rs
+++ b/wallet/tests/request_airdrop.rs
@@ -24,7 +24,7 @@ fn test_wallet_request_airdrop() {
     let rpc_client = RpcClient::new_socket(leader_data.rpc);
 
     let balance = rpc_client
-        .retry_get_balance(1, &bob_config.id.pubkey(), 1)
+        .retry_get_balance(&bob_config.id.pubkey(), 1)
         .unwrap()
         .unwrap();
     assert_eq!(balance, 50);


### PR DESCRIPTION
* `RpcClient`: clarify `url` vs `addr` usage
* `RpcClient`: relieve the caller of having to care about the rpc request id
* move `ThinClient` RPC requests into `RpcClient` (and shim them back into `ThinClient` for now), to make all the RPC request functionality available solely from `RpcClient`.   
* de-`mut` `ThinClient`
