### PR TITLE
Move mock request_airdrop_transaction into drone/, closer to the real impl

### DIFF
--- a/client/src/rpc_mock.rs
+++ b/client/src/rpc_mock.rs
@@ -2,14 +2,8 @@
 
 use crate::rpc_request::{RpcRequest, RpcRequestHandler};
 use serde_json::{json, Number, Value};
-use solana_sdk::hash::Hash;
 use solana_sdk::pubkey::Pubkey;
-use solana_sdk::signature::{Keypair, KeypairUtil};
-use solana_sdk::system_transaction::SystemTransaction;
-use solana_sdk::transaction::Transaction;
 use std::error;
-use std::io::{Error, ErrorKind};
-use std::net::SocketAddr;
 
 pub const PUBKEY: &str = "7RoSF9fUmdphVCpabEoefH81WwrW7orsWonXWqTXkKV8";
 pub const SIGNATURE: &str =
@@ -89,20 +83,4 @@ impl RpcRequestHandler for MockRpcClient {
     ) -> Result<Value, Box<dyn error::Error>> {
         self.retry_make_rpc_request(&request, params, 0)
     }
-}
-
-pub fn request_airdrop_transaction(
-    _drone_addr: &SocketAddr,
-    _id: &Pubkey,
-    lamports: u64,
-    _blockhash: Hash,
-) -> Result<Transaction, Error> {
-    if lamports == 0 {
-        Err(Error::new(ErrorKind::Other, "Airdrop failed"))?
-    }
-    let key = Keypair::new();
-    let to = Keypair::new().pubkey();
-    let blockhash = Hash::default();
-    let tx = SystemTransaction::new_account(&key, &to, lamports, blockhash, 0);
-    Ok(tx)
 }

--- a/drone/src/drone_mock.rs
+++ b/drone/src/drone_mock.rs
@@ -1,0 +1,23 @@
+use solana_sdk::hash::Hash;
+use solana_sdk::pubkey::Pubkey;
+use solana_sdk::signature::{Keypair, KeypairUtil};
+use solana_sdk::system_transaction::SystemTransaction;
+use solana_sdk::transaction::Transaction;
+use std::io::{Error, ErrorKind};
+use std::net::SocketAddr;
+
+pub fn request_airdrop_transaction(
+    _drone_addr: &SocketAddr,
+    _id: &Pubkey,
+    lamports: u64,
+    _blockhash: Hash,
+) -> Result<Transaction, Error> {
+    if lamports == 0 {
+        Err(Error::new(ErrorKind::Other, "Airdrop failed"))?
+    }
+    let key = Keypair::new();
+    let to = Keypair::new().pubkey();
+    let blockhash = Hash::default();
+    let tx = SystemTransaction::new_account(&key, &to, lamports, blockhash, 0);
+    Ok(tx)
+}

--- a/drone/src/lib.rs
+++ b/drone/src/lib.rs
@@ -1,1 +1,2 @@
 pub mod drone;
+pub mod drone_mock;

--- a/wallet/src/wallet.rs
+++ b/wallet/src/wallet.rs
@@ -8,7 +8,7 @@ use serde_json::json;
 use solana_budget_api;
 use solana_budget_api::budget_transaction::BudgetTransaction;
 #[cfg(test)]
-use solana_client::rpc_mock::{request_airdrop_transaction, MockRpcClient as RpcClient};
+use solana_client::rpc_mock::MockRpcClient as RpcClient;
 #[cfg(not(test))]
 use solana_client::rpc_request::RpcClient;
 use solana_client::rpc_request::{get_rpc_request_str, RpcRequest};
@@ -16,6 +16,8 @@ use solana_client::rpc_signature_status::RpcSignatureStatus;
 #[cfg(not(test))]
 use solana_drone::drone::request_airdrop_transaction;
 use solana_drone::drone::DRONE_PORT;
+#[cfg(test)]
+use solana_drone::drone_mock::request_airdrop_transaction;
 use solana_sdk::bpf_loader;
 use solana_sdk::hash::Hash;
 use solana_sdk::loader_transaction::LoaderTransaction;


### PR DESCRIPTION
More 🐃 towards `client/` cleanup