### PR TITLE
Merge InstructionError and ProgramError

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -697,7 +697,7 @@ mod tests {
         let (_, entries) = entry_receiver.recv().unwrap();
         assert_eq!(entries[0].0.transactions.len(), transactions.len());
 
-        // ProgramErrors should still be recorded
+        // InstructionErrors should still be recorded
         results[0] = Err(TransactionError::InstructionError(
             1,
             InstructionError::new_result_with_negative_lamports(),

--- a/core/src/blocktree_processor.rs
+++ b/core/src/blocktree_processor.rs
@@ -459,7 +459,7 @@ mod tests {
             entries.push(entry);
 
             // Add a second Transaction that will produce a
-            // ProgramError<0, ResultWithNegativeLamports> error when processed
+            // InstructionError<0, ResultWithNegativeLamports> error when processed
             let keypair2 = Keypair::new();
             let tx = SystemTransaction::new_account(&keypair, &keypair2.pubkey(), 42, blockhash, 0);
             let entry = Entry::new(&last_entry_hash, 1, vec![tx]);

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -6,9 +6,9 @@ use log::*;
 use solana_rbpf::{EbpfVmRaw, MemoryRegion};
 use solana_sdk::account::KeyedAccount;
 use solana_sdk::loader_instruction::LoaderInstruction;
-use solana_sdk::native_program::ProgramError;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::solana_entrypoint;
+use solana_sdk::transaction::InstructionError;
 use std::ffi::CStr;
 use std::io::prelude::*;
 use std::io::{Error, ErrorKind};
@@ -185,7 +185,7 @@ fn entrypoint(
     keyed_accounts: &mut [KeyedAccount],
     tx_data: &[u8],
     tick_height: u64,
-) -> Result<(), ProgramError> {
+) -> Result<(), InstructionError> {
     solana_logger::setup();
 
     if keyed_accounts[0].account.executable {
@@ -197,7 +197,7 @@ fn entrypoint(
             Ok(vm) => vm,
             Err(e) => {
                 warn!("Failed to create BPF VM: {}", e);
-                return Err(ProgramError::GenericError);
+                return Err(InstructionError::GenericError);
             }
         };
         let mut v = serialize_parameters(program_id, params, &tx_data, tick_height);
@@ -205,12 +205,12 @@ fn entrypoint(
             Ok(status) => {
                 if 0 == status {
                     warn!("BPF program failed: {}", status);
-                    return Err(ProgramError::GenericError);
+                    return Err(InstructionError::GenericError);
                 }
             }
             Err(e) => {
                 warn!("BPF VM failed to run program: {}", e);
-                return Err(ProgramError::GenericError);
+                return Err(InstructionError::GenericError);
             }
         }
         deserialize_parameters(params, &v);
@@ -221,7 +221,7 @@ fn entrypoint(
     } else if let Ok(instruction) = bincode::deserialize(tx_data) {
         if keyed_accounts[0].signer_key().is_none() {
             warn!("key[0] did not sign the transaction");
-            return Err(ProgramError::GenericError);
+            return Err(InstructionError::GenericError);
         }
         match instruction {
             LoaderInstruction::Write { offset, bytes } => {
@@ -234,7 +234,7 @@ fn entrypoint(
                         keyed_accounts[0].account.data.len(),
                         offset + len
                     );
-                    return Err(ProgramError::GenericError);
+                    return Err(InstructionError::GenericError);
                 }
                 keyed_accounts[0].account.data[offset..offset + len].copy_from_slice(&bytes);
             }
@@ -248,7 +248,7 @@ fn entrypoint(
         }
     } else {
         warn!("Invalid program transaction: {:?}", tx_data);
-        return Err(ProgramError::GenericError);
+        return Err(InstructionError::GenericError);
     }
     Ok(())
 }

--- a/programs/budget/src/lib.rs
+++ b/programs/budget/src/lib.rs
@@ -3,9 +3,9 @@ mod budget_processor;
 use crate::budget_processor::process_instruction;
 use log::*;
 use solana_sdk::account::KeyedAccount;
-use solana_sdk::native_program::ProgramError;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::solana_entrypoint;
+use solana_sdk::transaction::InstructionError;
 
 solana_entrypoint!(entrypoint);
 fn entrypoint(
@@ -13,7 +13,7 @@ fn entrypoint(
     keyed_accounts: &mut [KeyedAccount],
     data: &[u8],
     tick_height: u64,
-) -> Result<(), ProgramError> {
+) -> Result<(), InstructionError> {
     solana_logger::setup();
 
     trace!("process_instruction: {:?}", data);

--- a/programs/budget_api/src/budget_state.rs
+++ b/programs/budget_api/src/budget_state.rs
@@ -2,7 +2,7 @@
 use crate::budget_expr::BudgetExpr;
 use bincode::{self, deserialize, serialize_into};
 use serde_derive::{Deserialize, Serialize};
-use solana_sdk::native_program::ProgramError;
+use solana_sdk::transaction::InstructionError;
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub enum BudgetError {
@@ -27,12 +27,12 @@ impl BudgetState {
         self.pending_budget.is_some()
     }
 
-    pub fn serialize(&self, output: &mut [u8]) -> Result<(), ProgramError> {
-        serialize_into(output, self).map_err(|_| ProgramError::AccountDataTooSmall)
+    pub fn serialize(&self, output: &mut [u8]) -> Result<(), InstructionError> {
+        serialize_into(output, self).map_err(|_| InstructionError::AccountDataTooSmall)
     }
 
-    pub fn deserialize(input: &[u8]) -> Result<Self, ProgramError> {
-        deserialize(input).map_err(|_| ProgramError::InvalidAccountData)
+    pub fn deserialize(input: &[u8]) -> Result<Self, InstructionError> {
+        deserialize(input).map_err(|_| InstructionError::InvalidAccountData)
     }
 }
 
@@ -57,7 +57,7 @@ mod test {
         let b = BudgetState::default();
         assert_eq!(
             b.serialize(&mut a.data),
-            Err(ProgramError::AccountDataTooSmall)
+            Err(InstructionError::AccountDataTooSmall)
         );
     }
 }

--- a/programs/config/src/lib.rs
+++ b/programs/config/src/lib.rs
@@ -3,29 +3,29 @@
 use log::*;
 use solana_config_api::check_id;
 use solana_sdk::account::KeyedAccount;
-use solana_sdk::native_program::ProgramError;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::solana_entrypoint;
+use solana_sdk::transaction::InstructionError;
 
 fn process_instruction(
     _program_id: &Pubkey,
     keyed_accounts: &mut [KeyedAccount],
     data: &[u8],
     _tick_height: u64,
-) -> Result<(), ProgramError> {
+) -> Result<(), InstructionError> {
     if !check_id(&keyed_accounts[0].account.owner) {
         error!("account[0] is not assigned to the config program");
-        Err(ProgramError::IncorrectProgramId)?;
+        Err(InstructionError::IncorrectProgramId)?;
     }
 
     if keyed_accounts[0].signer_key().is_none() {
         error!("account[0] should sign the transaction");
-        Err(ProgramError::MissingRequiredSignature)?;
+        Err(InstructionError::MissingRequiredSignature)?;
     }
 
     if keyed_accounts[0].account.data.len() < data.len() {
         error!("instruction data too large");
-        Err(ProgramError::InvalidInstructionData)?;
+        Err(InstructionError::InvalidInstructionData)?;
     }
 
     keyed_accounts[0].account.data[0..data.len()].copy_from_slice(data);
@@ -38,7 +38,7 @@ fn entrypoint(
     keyed_accounts: &mut [KeyedAccount],
     data: &[u8],
     tick_height: u64,
-) -> Result<(), ProgramError> {
+) -> Result<(), InstructionError> {
     solana_logger::setup();
 
     trace!("process_instruction: {:?}", data);
@@ -163,7 +163,7 @@ mod tests {
             config_client.process_instruction(instruction),
             Err(TransactionError::InstructionError(
                 0,
-                InstructionError::ProgramError(ProgramError::IncorrectProgramId)
+                InstructionError::IncorrectProgramId
             ))
         );
     }

--- a/programs/failure/src/lib.rs
+++ b/programs/failure/src/lib.rs
@@ -1,7 +1,7 @@
 use solana_sdk::account::KeyedAccount;
-use solana_sdk::native_program::ProgramError;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::solana_entrypoint;
+use solana_sdk::transaction::InstructionError;
 
 solana_entrypoint!(entrypoint);
 fn entrypoint(
@@ -9,6 +9,6 @@ fn entrypoint(
     _keyed_accounts: &mut [KeyedAccount],
     _data: &[u8],
     _tick_height: u64,
-) -> Result<(), ProgramError> {
-    Err(ProgramError::GenericError)
+) -> Result<(), InstructionError> {
+    Err(InstructionError::GenericError)
 }

--- a/programs/failure/tests/failure.rs
+++ b/programs/failure/tests/failure.rs
@@ -2,7 +2,6 @@ use solana_runtime::bank::Bank;
 use solana_runtime::loader_utils::load_program;
 use solana_sdk::genesis_block::GenesisBlock;
 use solana_sdk::native_loader;
-use solana_sdk::native_program::ProgramError;
 use solana_sdk::transaction::{InstructionError, Transaction, TransactionError};
 
 #[test]
@@ -26,7 +25,7 @@ fn test_program_native_failure() {
         bank.process_transaction(&tx),
         Err(TransactionError::InstructionError(
             0,
-            InstructionError::ProgramError(ProgramError::GenericError)
+            InstructionError::GenericError
         ))
     );
 }

--- a/programs/noop/src/lib.rs
+++ b/programs/noop/src/lib.rs
@@ -1,8 +1,8 @@
 use log::*;
 use solana_sdk::account::KeyedAccount;
-use solana_sdk::native_program::ProgramError;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::solana_entrypoint;
+use solana_sdk::transaction::InstructionError;
 
 solana_entrypoint!(entrypoint);
 fn entrypoint(
@@ -10,7 +10,7 @@ fn entrypoint(
     keyed_accounts: &mut [KeyedAccount],
     data: &[u8],
     tick_height: u64,
-) -> Result<(), ProgramError> {
+) -> Result<(), InstructionError> {
     solana_logger::setup();
     info!("noop: program_id: {:?}", program_id);
     info!("noop: keyed_accounts: {:#?}", keyed_accounts);

--- a/programs/token/src/lib.rs
+++ b/programs/token/src/lib.rs
@@ -1,9 +1,9 @@
 use bincode::serialize;
 use log::*;
 use solana_sdk::account::KeyedAccount;
-use solana_sdk::native_program::ProgramError;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::solana_entrypoint;
+use solana_sdk::transaction::InstructionError;
 
 mod token_program;
 
@@ -13,11 +13,11 @@ fn entrypoint(
     info: &mut [KeyedAccount],
     input: &[u8],
     _tick_height: u64,
-) -> Result<(), ProgramError> {
+) -> Result<(), InstructionError> {
     solana_logger::setup();
 
     token_program::TokenProgram::process(program_id, info, input).map_err(|e| {
         error!("error: {:?}", e);
-        ProgramError::CustomError(serialize(&e).unwrap())
+        InstructionError::CustomError(serialize(&e).unwrap())
     })
 }

--- a/programs/vote/src/lib.rs
+++ b/programs/vote/src/lib.rs
@@ -4,9 +4,9 @@
 use bincode::deserialize;
 use log::*;
 use solana_sdk::account::KeyedAccount;
-use solana_sdk::native_program::ProgramError;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::solana_entrypoint;
+use solana_sdk::transaction::InstructionError;
 use solana_vote_api::vote_instruction::VoteInstruction;
 use solana_vote_api::vote_state;
 
@@ -16,13 +16,13 @@ fn entrypoint(
     keyed_accounts: &mut [KeyedAccount],
     data: &[u8],
     _tick_height: u64,
-) -> Result<(), ProgramError> {
+) -> Result<(), InstructionError> {
     solana_logger::setup();
 
     trace!("process_instruction: {:?}", data);
     trace!("keyed_accounts: {:?}", keyed_accounts);
 
-    match deserialize(data).map_err(|_| ProgramError::InvalidInstructionData)? {
+    match deserialize(data).map_err(|_| InstructionError::InvalidInstructionData)? {
         VoteInstruction::InitializeAccount => vote_state::initialize_account(keyed_accounts),
         VoteInstruction::DelegateStake(delegate_id) => {
             vote_state::delegate_stake(keyed_accounts, &delegate_id)

--- a/programs/vote/tests/vote.rs
+++ b/programs/vote/tests/vote.rs
@@ -1,7 +1,6 @@
 use solana_runtime::bank::{Bank, Result};
 use solana_sdk::genesis_block::GenesisBlock;
 use solana_sdk::hash::hash;
-use solana_sdk::native_program::ProgramError;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::{Keypair, KeypairUtil};
 use solana_sdk::system_instruction::SystemInstruction;
@@ -134,7 +133,7 @@ fn test_vote_via_bank_with_no_signature() {
         result,
         Err(TransactionError::InstructionError(
             1,
-            InstructionError::ProgramError(ProgramError::InvalidArgument)
+            InstructionError::InvalidArgument
         ))
     );
 }

--- a/sdk/src/native_program.rs
+++ b/sdk/src/native_program.rs
@@ -1,50 +1,6 @@
 use crate::account::KeyedAccount;
 use crate::pubkey::Pubkey;
-use std;
-
-/// Reasons a program might have rejected an instruction.
-#[derive(Debug, PartialEq, Eq, Clone)]
-pub enum ProgramError {
-    /// The program instruction returned an error
-    GenericError,
-
-    /// The arguments provided to a program instruction where invalid
-    InvalidArgument,
-
-    /// An instruction's data contents was invalid
-    InvalidInstructionData,
-
-    /// An account's data contents was invalid
-    InvalidAccountData,
-
-    /// An account's data was too small
-    AccountDataTooSmall,
-
-    /// The account did not have the expected program id
-    IncorrectProgramId,
-
-    /// A signature was required but not found
-    MissingRequiredSignature,
-
-    /// An initialize instruction was sent to an account that has already been initialized.
-    AccountAlreadyInitialized,
-
-    /// An attempt to operate on an account that hasn't been initialized.
-    UninitializedAccount,
-
-    /// CustomError allows on-chain programs to implement program-specific error types and see
-    /// them returned by the Solana runtime. A CustomError may be any type that is serialized
-    /// to a Vec of bytes, max length 32 bytes. Any CustomError Vec greater than this length will
-    /// be truncated by the runtime.
-    CustomError(Vec<u8>),
-}
-
-impl std::fmt::Display for ProgramError {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "error")
-    }
-}
-impl std::error::Error for ProgramError {}
+use crate::transaction::InstructionError;
 
 // All native programs export a symbol named process()
 pub const ENTRYPOINT: &str = "process";
@@ -55,7 +11,7 @@ pub type Entrypoint = unsafe extern "C" fn(
     keyed_accounts: &mut [KeyedAccount],
     data: &[u8],
     tick_height: u64,
-) -> Result<(), ProgramError>;
+) -> Result<(), InstructionError>;
 
 // Convenience macro to define the native program entrypoint.  Supply a fn to this macro that
 // conforms to the `Entrypoint` type signature.
@@ -68,7 +24,7 @@ macro_rules! solana_entrypoint(
             keyed_accounts: &mut [KeyedAccount],
             data: &[u8],
             tick_height: u64
-        ) -> Result<(), ProgramError> {
+        ) -> Result<(), InstructionError> {
             $entrypoint(program_id, keyed_accounts, data, tick_height)
         }
     )


### PR DESCRIPTION
#### Problem

Use of "ProgramError" within an "InstructionError" creates a long, confusing error message.  Did the instruction execute a program? Is the bug in the program or the instruction? What's a program again?

#### Summary of Changes

Merge the two enums. All those error codes are telling the user there's a problem in the instruction.