### PR TITLE
Simplify bank_forks, add squashing and pruning

### DIFF
--- a/core/src/locktower.rs
+++ b/core/src/locktower.rs
@@ -152,8 +152,14 @@ impl Locktower {
         }
     }
 
-    pub fn record_vote(&mut self, slot: u64) {
+    pub fn record_vote(&mut self, slot: u64) -> Option<u64> {
+        let root_slot = self.lockouts.root_slot;
         self.lockouts.process_vote(Vote { slot });
+        if root_slot != self.lockouts.root_slot {
+            Some(self.lockouts.root_slot.unwrap())
+        } else {
+            None
+        }
     }
 
     pub fn calculate_weight(&self, stake_lockouts: &HashMap<u64, StakeLockout>) -> u128 {

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -283,7 +283,7 @@ impl ReplayStage {
                                 )
                                 .to_owned(),);
                         let tpu_bank = Bank::new_from_parent(parent, my_id, poh_slot);
-                        bank_forks.write().unwrap().insert(poh_slot, tpu_bank);
+                        bank_forks.write().unwrap().insert(tpu_bank);
                         if let Some(tpu_bank) = bank_forks.read().unwrap().get(poh_slot).cloned() {
                             assert_eq!(
                                 bank_forks.read().unwrap().working_bank().slot(),
@@ -415,10 +415,7 @@ impl ReplayStage {
                 }
                 let leader = leader_schedule_utils::slot_leader_at(child_id, &parent_bank).unwrap();
                 info!("new fork:{} parent:{}", child_id, parent_id);
-                forks.insert(
-                    child_id,
-                    Bank::new_from_parent(&parent_bank, &leader, child_id),
-                );
+                forks.insert(Bank::new_from_parent(&parent_bank, &leader, child_id));
             }
         }
     }
@@ -599,7 +596,7 @@ mod test {
             ReplayStage::generate_new_bank_forks(&blocktree, &mut bank_forks);
             assert!(bank_forks.get(1).is_some());
 
-            // Inset blob for slot 3, generate new forks, check result
+            // Insert blob for slot 3, generate new forks, check result
             let mut blob_slot_2 = Blob::default();
             blob_slot_2.set_slot(2);
             blob_slot_2.set_parent(0);

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -860,7 +860,7 @@ impl Bank {
             .store_slow(self.accounts_id, &program_id, &bogus_account);
     }
 
-    pub fn is_descendant_of(&self, parent: u64) -> bool {
+    pub fn is_in_subtree_of(&self, parent: u64) -> bool {
         if self.slot() == parent {
             return true;
         }
@@ -1644,7 +1644,7 @@ mod tests {
     }
 
     #[test]
-    fn test_is_descendant_of() {
+    fn test_is_in_subtree_of() {
         let (genesis_block, _) = GenesisBlock::new(1);
         let parent = Arc::new(Bank::new(&genesis_block));
         // Bank 1
@@ -1655,15 +1655,15 @@ mod tests {
         let bank5 = Bank::new_from_parent(&bank, &Pubkey::default(), 5);
 
         // Parents of bank 2: 0 -> 1 -> 2
-        assert!(bank2.is_descendant_of(0));
-        assert!(bank2.is_descendant_of(1));
-        assert!(bank2.is_descendant_of(2));
-        assert!(!bank2.is_descendant_of(3));
+        assert!(bank2.is_in_subtree_of(0));
+        assert!(bank2.is_in_subtree_of(1));
+        assert!(bank2.is_in_subtree_of(2));
+        assert!(!bank2.is_in_subtree_of(3));
 
-        // Parents of bank 3: 0 -> 1 -> 5
-        assert!(bank5.is_descendant_of(0));
-        assert!(bank5.is_descendant_of(1));
-        assert!(!bank5.is_descendant_of(2));
-        assert!(!bank5.is_descendant_of(4));
+        // Parents of bank 5: 0 -> 1 -> 5
+        assert!(bank5.is_in_subtree_of(0));
+        assert!(bank5.is_in_subtree_of(1));
+        assert!(!bank5.is_in_subtree_of(2));
+        assert!(!bank5.is_in_subtree_of(4));
     }
 }


### PR DESCRIPTION
#### Problem
1) Removing parents of new banks from bank_forks on insert() makes using bank_forks clumsy whenever we want to perform operations/searches on a set of banks (always have to search parents of the stored set).

2) Banks are not squashed after max_lockout is reached in locktower

#### Summary of Changes
1) Stop pruning parents in bank_forks() on insert
2) Add squashing and pruning logic to bank_forks after we reach max lockout on a slot.

Thanks @rob-solana for the discussion.

Fixes #
