### PR TITLE
Repair by weighted forks

### DIFF
--- a/core/src/blocktree.rs
+++ b/core/src/blocktree.rs
@@ -28,7 +28,7 @@ use std::fs;
 use std::io;
 use std::rc::Rc;
 use std::sync::mpsc::{sync_channel, Receiver, SyncSender};
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 
 mod db;
 #[cfg(feature = "kvstore")]
@@ -142,6 +142,7 @@ pub struct Blocktree {
     data_cf: DataCf,
     erasure_cf: ErasureCf,
     pub new_blobs_signals: Vec<SyncSender<bool>>,
+    pub slots_of_interest: RwLock<Vec<(u128, u64)>>,
 }
 
 // Column family for metadata about a leader slot
@@ -610,6 +611,10 @@ impl Blocktree {
             .collect();
 
         Ok(result)
+    }
+
+    pub fn set_slots_of_interest(&self, slots_of_interest: Vec<(u128, u64)>) {
+        *self.slots_of_interest.write().unwrap() = slots_of_interest;
     }
 
     fn deserialize_blobs<I>(blob_datas: &[I]) -> Vec<Entry>

--- a/core/src/blocktree/rocks.rs
+++ b/core/src/blocktree/rocks.rs
@@ -17,7 +17,7 @@ use std::collections::VecDeque;
 use std::fs;
 use std::io;
 use std::path::Path;
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 
 use super::db::{
     Cursor, Database, IDataCf, IErasureCf, IMetaCf, IWriteBatch, LedgerColumnFamily,
@@ -112,6 +112,7 @@ impl Blocktree {
             data_cf,
             erasure_cf,
             new_blobs_signals: vec![],
+            slots_of_interest: RwLock::new(vec![]),
         })
     }
 

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -153,12 +153,17 @@ impl ReplayStage {
                         })
                         .collect();
 
-                    votable.sort_by_key(|b| b.0);
+                    votable.sort_by(|a, b| a.0.cmp(&b.0).reverse());
+                    let slots_of_interest: Vec<_> =
+                        votable.iter().map(|(w, b)| (*w, b.slot())).collect();
+                    if !slots_of_interest.is_empty() {
+                        blocktree.set_slots_of_interest(slots_of_interest);
+                    }
                     let ms = timing::duration_as_ms(&locktower_start.elapsed());
                     info!("@{:?} locktower duration: {:?}", timing::timestamp(), ms,);
                     inc_new_counter_info!("replay_stage-locktower_duration", ms as usize);
 
-                    if let Some((_, bank)) = votable.last() {
+                    if let Some((_, bank)) = votable.first() {
                         subscriptions.notify_subscribers(&bank);
 
                         if let Some(ref voting_keypair) = voting_keypair {


### PR DESCRIPTION
#### Problem
Repair currently conducts an inefficient, unguided iteration across all slots in Blocktree, looking for any holes to repair. It does not prioritize slots based on fork weight.

#### Summary of Changes
Communicate to repair service an ordering on forks it should prioritize. 

@rob-solana, @aeyakovenko, please see below comments to see areas that needs to be hashed out.

Fixes #
