### PR TITLE
Fix potential crash in banking stage

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -150,7 +150,9 @@ impl BankingStage {
         // Buffer the packets if I am the next leader
         // or, if it was getting sent to me
         let leader_id = match poh_recorder.lock().unwrap().bank() {
-            Some(bank) => leader_schedule_utils::slot_leader_at(bank.slot() + 1, &bank).unwrap(),
+            Some(bank) => {
+                leader_schedule_utils::slot_leader_at(bank.slot() + 1, &bank).unwrap_or_default()
+            }
             None => rcluster_info
                 .leader_data()
                 .map(|x| x.id)


### PR DESCRIPTION
#### Problem
The should_buffer_packets() function will crash if leader for a given slot is not found

#### Summary of Changes
The intent of the function is to check if the current node is the leader. If a leader is not found, it should return false. The fix uses default key to check against the current node ID, that would cause it to return false.