### PR TITLE
Label tuple with AccountMeta

### DIFF
--- a/programs/budget_api/src/budget_instruction.rs
+++ b/programs/budget_api/src/budget_instruction.rs
@@ -31,9 +31,9 @@ impl BudgetInstruction {
     pub fn new_initialize_account(contract: &Pubkey, expr: BudgetExpr) -> Instruction {
         let mut keys = vec![];
         if let BudgetExpr::Pay(payment) = &expr {
-            keys.push(AccountMeta(payment.to, false));
+            keys.push(AccountMeta::new(payment.to, false));
         }
-        keys.push(AccountMeta(*contract, false));
+        keys.push(AccountMeta::new(*contract, false));
         Instruction::new(id(), &BudgetInstruction::InitializeAccount(expr), keys)
     }
 
@@ -43,18 +43,24 @@ impl BudgetInstruction {
         to: &Pubkey,
         dt: DateTime<Utc>,
     ) -> Instruction {
-        let mut keys = vec![AccountMeta(*from, true), AccountMeta(*contract, false)];
+        let mut account_metas = vec![
+            AccountMeta::new(*from, true),
+            AccountMeta::new(*contract, false),
+        ];
         if from != to {
-            keys.push(AccountMeta(*to, false));
+            account_metas.push(AccountMeta::new(*to, false));
         }
-        Instruction::new(id(), &BudgetInstruction::ApplyTimestamp(dt), keys)
+        Instruction::new(id(), &BudgetInstruction::ApplyTimestamp(dt), account_metas)
     }
 
     pub fn new_apply_signature(from: &Pubkey, contract: &Pubkey, to: &Pubkey) -> Instruction {
-        let mut keys = vec![AccountMeta(*from, true), AccountMeta(*contract, false)];
+        let mut account_metas = vec![
+            AccountMeta::new(*from, true),
+            AccountMeta::new(*contract, false),
+        ];
         if from != to {
-            keys.push(AccountMeta(*to, false));
+            account_metas.push(AccountMeta::new(*to, false));
         }
-        Instruction::new(id(), &BudgetInstruction::ApplySignature, keys)
+        Instruction::new(id(), &BudgetInstruction::ApplySignature, account_metas)
     }
 }

--- a/programs/budget_api/src/budget_instruction.rs
+++ b/programs/budget_api/src/budget_instruction.rs
@@ -3,7 +3,7 @@ use crate::id;
 use chrono::prelude::{DateTime, Utc};
 use serde_derive::{Deserialize, Serialize};
 use solana_sdk::pubkey::Pubkey;
-use solana_sdk::transaction::Instruction;
+use solana_sdk::transaction::{AccountMeta, Instruction};
 
 /// A smart contract.
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
@@ -31,9 +31,9 @@ impl BudgetInstruction {
     pub fn new_initialize_account(contract: &Pubkey, expr: BudgetExpr) -> Instruction {
         let mut keys = vec![];
         if let BudgetExpr::Pay(payment) = &expr {
-            keys.push((payment.to, false));
+            keys.push(AccountMeta(payment.to, false));
         }
-        keys.push((*contract, false));
+        keys.push(AccountMeta(*contract, false));
         Instruction::new(id(), &BudgetInstruction::InitializeAccount(expr), keys)
     }
 
@@ -43,17 +43,17 @@ impl BudgetInstruction {
         to: &Pubkey,
         dt: DateTime<Utc>,
     ) -> Instruction {
-        let mut keys = vec![(*from, true), (*contract, false)];
+        let mut keys = vec![AccountMeta(*from, true), AccountMeta(*contract, false)];
         if from != to {
-            keys.push((*to, false));
+            keys.push(AccountMeta(*to, false));
         }
         Instruction::new(id(), &BudgetInstruction::ApplyTimestamp(dt), keys)
     }
 
     pub fn new_apply_signature(from: &Pubkey, contract: &Pubkey, to: &Pubkey) -> Instruction {
-        let mut keys = vec![(*from, true), (*contract, false)];
+        let mut keys = vec![AccountMeta(*from, true), AccountMeta(*contract, false)];
         if from != to {
-            keys.push((*to, false));
+            keys.push(AccountMeta(*to, false));
         }
         Instruction::new(id(), &BudgetInstruction::ApplySignature, keys)
     }

--- a/programs/config_api/src/config_instruction.rs
+++ b/programs/config_api/src/config_instruction.rs
@@ -2,7 +2,7 @@ use crate::id;
 use crate::ConfigState;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::system_instruction::SystemInstruction;
-use solana_sdk::transaction::Instruction;
+use solana_sdk::transaction::{AccountMeta, Instruction};
 
 pub struct ConfigInstruction {}
 
@@ -28,10 +28,10 @@ impl ConfigInstruction {
         config_account_pubkey: &Pubkey,
         data: &T,
     ) -> Instruction {
-        Instruction::new(
-            id(),
-            data,
-            vec![(*from_account_pubkey, true), (*config_account_pubkey, true)],
-        )
+        let account_metas = vec![
+            AccountMeta(*from_account_pubkey, true),
+            AccountMeta(*config_account_pubkey, true),
+        ];
+        Instruction::new(id(), data, account_metas)
     }
 }

--- a/programs/config_api/src/config_instruction.rs
+++ b/programs/config_api/src/config_instruction.rs
@@ -29,8 +29,8 @@ impl ConfigInstruction {
         data: &T,
     ) -> Instruction {
         let account_metas = vec![
-            AccountMeta(*from_account_pubkey, true),
-            AccountMeta(*config_account_pubkey, true),
+            AccountMeta::new(*from_account_pubkey, true),
+            AccountMeta::new(*config_account_pubkey, true),
         ];
         Instruction::new(id(), data, account_metas)
     }

--- a/programs/rewards_api/src/rewards_instruction.rs
+++ b/programs/rewards_api/src/rewards_instruction.rs
@@ -1,7 +1,7 @@
 use crate::id;
 use serde_derive::{Deserialize, Serialize};
 use solana_sdk::pubkey::Pubkey;
-use solana_sdk::transaction::Instruction;
+use solana_sdk::transaction::{AccountMeta, Instruction};
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub enum RewardsInstruction {
@@ -10,10 +10,7 @@ pub enum RewardsInstruction {
 
 impl RewardsInstruction {
     pub fn new_redeem_vote_credits(vote_id: &Pubkey, rewards_id: &Pubkey) -> Instruction {
-        Instruction::new(
-            id(),
-            &RewardsInstruction::RedeemVoteCredits,
-            vec![(*vote_id, true), (*rewards_id, false)],
-        )
+        let account_metas = vec![AccountMeta(*vote_id, true), AccountMeta(*rewards_id, false)];
+        Instruction::new(id(), &RewardsInstruction::RedeemVoteCredits, account_metas)
     }
 }

--- a/programs/rewards_api/src/rewards_instruction.rs
+++ b/programs/rewards_api/src/rewards_instruction.rs
@@ -10,7 +10,10 @@ pub enum RewardsInstruction {
 
 impl RewardsInstruction {
     pub fn new_redeem_vote_credits(vote_id: &Pubkey, rewards_id: &Pubkey) -> Instruction {
-        let account_metas = vec![AccountMeta(*vote_id, true), AccountMeta(*rewards_id, false)];
+        let account_metas = vec![
+            AccountMeta::new(*vote_id, true),
+            AccountMeta::new(*rewards_id, false),
+        ];
         Instruction::new(id(), &RewardsInstruction::RedeemVoteCredits, account_metas)
     }
 }

--- a/programs/vote/tests/vote.rs
+++ b/programs/vote/tests/vote.rs
@@ -114,7 +114,7 @@ fn test_vote_via_bank_with_no_signature() {
     let vote_ix = Instruction::new(
         solana_vote_api::id(),
         &VoteInstruction::Vote(Vote::new(0)),
-        vec![AccountMeta(vote_id, false)], // <--- attack!! No signature.
+        vec![AccountMeta::new(vote_id, false)], // <--- attack!! No signer required.
     );
 
     // Sneak in an instruction so that the transaction is signed but

--- a/programs/vote/tests/vote.rs
+++ b/programs/vote/tests/vote.rs
@@ -4,7 +4,9 @@ use solana_sdk::hash::hash;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::{Keypair, KeypairUtil};
 use solana_sdk::system_instruction::SystemInstruction;
-use solana_sdk::transaction::{Instruction, InstructionError, Transaction, TransactionError};
+use solana_sdk::transaction::{
+    AccountMeta, Instruction, InstructionError, Transaction, TransactionError,
+};
 use solana_vote_api::vote_instruction::{Vote, VoteInstruction};
 use solana_vote_api::vote_state::VoteState;
 use solana_vote_api::vote_transaction::VoteTransaction;
@@ -112,7 +114,7 @@ fn test_vote_via_bank_with_no_signature() {
     let vote_ix = Instruction::new(
         solana_vote_api::id(),
         &VoteInstruction::Vote(Vote::new(0)),
-        vec![(vote_id, false)], // <--- attack!! No signature.
+        vec![AccountMeta(vote_id, false)], // <--- attack!! No signature.
     );
 
     // Sneak in an instruction so that the transaction is signed but

--- a/programs/vote_api/src/vote_instruction.rs
+++ b/programs/vote_api/src/vote_instruction.rs
@@ -33,11 +33,11 @@ pub enum VoteInstruction {
 
 impl VoteInstruction {
     pub fn new_clear_credits(vote_id: &Pubkey) -> Instruction {
-        let account_metas = vec![AccountMeta(*vote_id, true)];
+        let account_metas = vec![AccountMeta::new(*vote_id, true)];
         Instruction::new(id(), &VoteInstruction::ClearCredits, account_metas)
     }
     pub fn new_delegate_stake(vote_id: &Pubkey, delegate_id: &Pubkey) -> Instruction {
-        let account_metas = vec![AccountMeta(*vote_id, true)];
+        let account_metas = vec![AccountMeta::new(*vote_id, true)];
         Instruction::new(
             id(),
             &VoteInstruction::DelegateStake(*delegate_id),
@@ -45,7 +45,7 @@ impl VoteInstruction {
         )
     }
     pub fn new_authorize_voter(vote_id: &Pubkey, authorized_voter_id: &Pubkey) -> Instruction {
-        let account_metas = vec![AccountMeta(*vote_id, true)];
+        let account_metas = vec![AccountMeta::new(*vote_id, true)];
         Instruction::new(
             id(),
             &VoteInstruction::AuthorizeVoter(*authorized_voter_id),
@@ -53,11 +53,11 @@ impl VoteInstruction {
         )
     }
     pub fn new_initialize_account(vote_id: &Pubkey) -> Instruction {
-        let account_metas = vec![AccountMeta(*vote_id, false)];
+        let account_metas = vec![AccountMeta::new(*vote_id, false)];
         Instruction::new(id(), &VoteInstruction::InitializeAccount, account_metas)
     }
     pub fn new_vote(vote_id: &Pubkey, vote: Vote) -> Instruction {
-        let account_metas = vec![AccountMeta(*vote_id, true)];
+        let account_metas = vec![AccountMeta::new(*vote_id, true)];
         Instruction::new(id(), &VoteInstruction::Vote(vote), account_metas)
     }
 }

--- a/programs/vote_api/src/vote_instruction.rs
+++ b/programs/vote_api/src/vote_instruction.rs
@@ -1,7 +1,7 @@
 use crate::id;
 use serde_derive::{Deserialize, Serialize};
 use solana_sdk::pubkey::Pubkey;
-use solana_sdk::transaction::Instruction;
+use solana_sdk::transaction::{AccountMeta, Instruction};
 
 #[derive(Serialize, Default, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub struct Vote {
@@ -33,30 +33,31 @@ pub enum VoteInstruction {
 
 impl VoteInstruction {
     pub fn new_clear_credits(vote_id: &Pubkey) -> Instruction {
-        Instruction::new(id(), &VoteInstruction::ClearCredits, vec![(*vote_id, true)])
+        let account_metas = vec![AccountMeta(*vote_id, true)];
+        Instruction::new(id(), &VoteInstruction::ClearCredits, account_metas)
     }
     pub fn new_delegate_stake(vote_id: &Pubkey, delegate_id: &Pubkey) -> Instruction {
+        let account_metas = vec![AccountMeta(*vote_id, true)];
         Instruction::new(
             id(),
             &VoteInstruction::DelegateStake(*delegate_id),
-            vec![(*vote_id, true)],
+            account_metas,
         )
     }
     pub fn new_authorize_voter(vote_id: &Pubkey, authorized_voter_id: &Pubkey) -> Instruction {
+        let account_metas = vec![AccountMeta(*vote_id, true)];
         Instruction::new(
             id(),
             &VoteInstruction::AuthorizeVoter(*authorized_voter_id),
-            vec![(*vote_id, true)],
+            account_metas,
         )
     }
     pub fn new_initialize_account(vote_id: &Pubkey) -> Instruction {
-        Instruction::new(
-            id(),
-            &VoteInstruction::InitializeAccount,
-            vec![(*vote_id, false)],
-        )
+        let account_metas = vec![AccountMeta(*vote_id, false)];
+        Instruction::new(id(), &VoteInstruction::InitializeAccount, account_metas)
     }
     pub fn new_vote(vote_id: &Pubkey, vote: Vote) -> Instruction {
-        Instruction::new(id(), &VoteInstruction::Vote(vote), vec![(*vote_id, true)])
+        let account_metas = vec![AccountMeta(*vote_id, true)];
+        Instruction::new(id(), &VoteInstruction::Vote(vote), account_metas)
     }
 }

--- a/runtime/src/bank_client.rs
+++ b/runtime/src/bank_client.rs
@@ -67,6 +67,7 @@ impl<'a> BankClient<'a> {
 mod tests {
     use super::*;
     use solana_sdk::genesis_block::GenesisBlock;
+    use solana_sdk::transaction::AccountMeta;
 
     #[test]
     fn test_bank_client_new_with_keypairs() {
@@ -81,7 +82,9 @@ mod tests {
         let bob_pubkey = Keypair::new().pubkey();
         let mut move_instruction =
             SystemInstruction::new_move(&doe_client.pubkey(), &bob_pubkey, 42);
-        move_instruction.accounts.push((jane_pubkey, true));
+        move_instruction
+            .accounts
+            .push(AccountMeta(jane_pubkey, true));
 
         doe_client.process_instruction(move_instruction).unwrap();
         assert_eq!(bank.get_balance(&bob_pubkey), 42);

--- a/runtime/src/bank_client.rs
+++ b/runtime/src/bank_client.rs
@@ -84,7 +84,7 @@ mod tests {
             SystemInstruction::new_move(&doe_client.pubkey(), &bob_pubkey, 42);
         move_instruction
             .accounts
-            .push(AccountMeta(jane_pubkey, true));
+            .push(AccountMeta::new(jane_pubkey, true));
 
         doe_client.process_instruction(move_instruction).unwrap();
         assert_eq!(bank.get_balance(&bob_pubkey), 42);

--- a/runtime/src/system_program.rs
+++ b/runtime/src/system_program.rs
@@ -292,8 +292,8 @@ mod tests {
         // Erroneously sign transaction with recipient account key
         // No signature case is tested by bank `test_zero_signatures()`
         let account_metas = vec![
-            AccountMeta(alice_pubkey, false),
-            AccountMeta(mallory_pubkey, true),
+            AccountMeta::new(alice_pubkey, false),
+            AccountMeta::new(mallory_pubkey, true),
         ];
         let malicious_script = Script::new(vec![Instruction::new(
             system_program::id(),

--- a/runtime/src/system_program.rs
+++ b/runtime/src/system_program.rs
@@ -112,7 +112,7 @@ mod tests {
     use solana_sdk::signature::{Keypair, KeypairUtil};
     use solana_sdk::system_instruction::SystemInstruction;
     use solana_sdk::system_program;
-    use solana_sdk::transaction::{Instruction, InstructionError, TransactionError};
+    use solana_sdk::transaction::{AccountMeta, Instruction, InstructionError, TransactionError};
 
     #[test]
     fn test_create_system_account() {
@@ -291,10 +291,14 @@ mod tests {
 
         // Erroneously sign transaction with recipient account key
         // No signature case is tested by bank `test_zero_signatures()`
+        let account_metas = vec![
+            AccountMeta(alice_pubkey, false),
+            AccountMeta(mallory_pubkey, true),
+        ];
         let malicious_script = Script::new(vec![Instruction::new(
             system_program::id(),
             &SystemInstruction::Move { lamports: 10 },
-            vec![(alice_pubkey, false), (mallory_pubkey, true)],
+            account_metas,
         )]);
         assert_eq!(
             mallory_client.process_script(malicious_script),

--- a/sdk/src/system_instruction.rs
+++ b/sdk/src/system_instruction.rs
@@ -1,6 +1,6 @@
 use crate::pubkey::Pubkey;
 use crate::system_program;
-use crate::transaction::Instruction;
+use crate::transaction::{AccountMeta, Instruction};
 
 #[derive(Serialize, Debug, Clone, PartialEq)]
 pub enum SystemError {
@@ -46,7 +46,7 @@ impl SystemInstruction {
                 space,
                 program_id: *program_id,
             },
-            vec![(*from_id, true), (*to_id, false)],
+            vec![AccountMeta(*from_id, true), AccountMeta(*to_id, false)],
         )
     }
 
@@ -54,7 +54,7 @@ impl SystemInstruction {
         Instruction::new(
             system_program::id(),
             &SystemInstruction::Move { lamports },
-            vec![(*from_id, true), (*to_id, false)],
+            vec![AccountMeta(*from_id, true), AccountMeta(*to_id, false)],
         )
     }
 }

--- a/sdk/src/system_instruction.rs
+++ b/sdk/src/system_instruction.rs
@@ -39,6 +39,10 @@ impl SystemInstruction {
         space: u64,
         program_id: &Pubkey,
     ) -> Instruction {
+        let account_metas = vec![
+            AccountMeta::new(*from_id, true),
+            AccountMeta::new(*to_id, false),
+        ];
         Instruction::new(
             system_program::id(),
             &SystemInstruction::CreateAccount {
@@ -46,15 +50,19 @@ impl SystemInstruction {
                 space,
                 program_id: *program_id,
             },
-            vec![AccountMeta(*from_id, true), AccountMeta(*to_id, false)],
+            account_metas,
         )
     }
 
     pub fn new_move(from_id: &Pubkey, to_id: &Pubkey, lamports: u64) -> Instruction {
+        let account_metas = vec![
+            AccountMeta::new(*from_id, true),
+            AccountMeta::new(*to_id, false),
+        ];
         Instruction::new(
             system_program::id(),
             &SystemInstruction::Move { lamports },
-            vec![AccountMeta(*from_id, true), AccountMeta(*to_id, false)],
+            account_metas,
         )
     }
 }


### PR DESCRIPTION
#### Problem

Undocumented tuples used to define new instructions

#### Summary of Changes

Use a struct tuple instead. It's the smallest change I could make that leads to a quick grep to find what the heck those fields are used for.  Better would be a normal struct, but that can be done a little later.
