### PR TITLE
Check if poh recorder has over stepped the leader slot

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -460,7 +460,7 @@ pub fn create_test_recorder(
         bank.slot(),
         Some(4),
         bank.ticks_per_slot(),
-        Pubkey::default(),
+        &Pubkey::default(),
     );
     poh_recorder.set_bank(&bank);
 
@@ -701,7 +701,7 @@ mod tests {
             bank.slot(),
             None,
             bank.ticks_per_slot(),
-            Pubkey::default(),
+            &Pubkey::default(),
         );
         let poh_recorder = Arc::new(Mutex::new(poh_recorder));
 
@@ -760,7 +760,7 @@ mod tests {
             bank.slot(),
             Some(4),
             bank.ticks_per_slot(),
-            pubkey,
+            &pubkey,
         );
         let poh_recorder = Arc::new(Mutex::new(poh_recorder));
 

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -18,6 +18,7 @@ use crate::sigverify_stage::VerifiedPackets;
 use bincode::deserialize;
 use solana_metrics::counter::Counter;
 use solana_runtime::bank::{self, Bank};
+use solana_sdk::pubkey::Pubkey;
 use solana_sdk::timing::{self, duration_as_us, MAX_RECENT_BLOCKHASHES};
 use solana_sdk::transaction::{Transaction, TransactionError};
 use std::net::UdpSocket;
@@ -459,6 +460,7 @@ pub fn create_test_recorder(
         bank.slot(),
         Some(4),
         bank.ticks_per_slot(),
+        Pubkey::default(),
     );
     poh_recorder.set_bank(&bank);
 
@@ -699,6 +701,7 @@ mod tests {
             bank.slot(),
             None,
             bank.ticks_per_slot(),
+            Pubkey::default(),
         );
         let poh_recorder = Arc::new(Mutex::new(poh_recorder));
 
@@ -757,6 +760,7 @@ mod tests {
             bank.slot(),
             Some(4),
             bank.ticks_per_slot(),
+            pubkey,
         );
         let poh_recorder = Arc::new(Mutex::new(poh_recorder));
 

--- a/core/src/fullnode.rs
+++ b/core/src/fullnode.rs
@@ -109,7 +109,7 @@ impl Fullnode {
             bank.slot(),
             leader_schedule_utils::next_leader_slot(&id, bank.slot(), &bank),
             bank.ticks_per_slot(),
-            id,
+            &id,
         );
         let poh_recorder = Arc::new(Mutex::new(poh_recorder));
         let poh_service = PohService::new(poh_recorder.clone(), &config.tick_config, &exit);

--- a/core/src/fullnode.rs
+++ b/core/src/fullnode.rs
@@ -109,6 +109,7 @@ impl Fullnode {
             bank.slot(),
             leader_schedule_utils::next_leader_slot(&id, bank.slot(), &bank),
             bank.ticks_per_slot(),
+            id,
         );
         let poh_recorder = Arc::new(Mutex::new(poh_recorder));
         let poh_service = PohService::new(poh_recorder.clone(), &config.tick_config, &exit);

--- a/core/src/poh_recorder.rs
+++ b/core/src/poh_recorder.rs
@@ -249,7 +249,7 @@ impl PohRecorder {
         start_slot: u64,
         my_leader_slot_index: Option<u64>,
         ticks_per_slot: u64,
-        id: Pubkey,
+        id: &Pubkey,
     ) -> (Self, Receiver<WorkingBankEntries>) {
         let poh = Poh::new(last_entry_hash, tick_height);
         let (sender, receiver) = channel();
@@ -271,7 +271,7 @@ impl PohRecorder {
                     })
                     .unwrap_or(None),
                 max_last_leader_grace_ticks: ticks_per_slot / MAX_LAST_LEADER_GRACE_TICKS_FACTOR,
-                id,
+                id: *id,
             },
             receiver,
         )
@@ -330,7 +330,7 @@ mod tests {
             0,
             Some(4),
             DEFAULT_TICKS_PER_SLOT,
-            Pubkey::default(),
+            &Pubkey::default(),
         );
         poh_recorder.tick();
         assert_eq!(poh_recorder.tick_cache.len(), 1);
@@ -347,7 +347,7 @@ mod tests {
             0,
             Some(4),
             DEFAULT_TICKS_PER_SLOT,
-            Pubkey::default(),
+            &Pubkey::default(),
         );
         poh_recorder.tick();
         poh_recorder.tick();
@@ -364,7 +364,7 @@ mod tests {
             0,
             Some(4),
             DEFAULT_TICKS_PER_SLOT,
-            Pubkey::default(),
+            &Pubkey::default(),
         );
         poh_recorder.tick();
         assert_eq!(poh_recorder.tick_cache.len(), 1);
@@ -383,7 +383,7 @@ mod tests {
             0,
             Some(4),
             bank.ticks_per_slot(),
-            Pubkey::default(),
+            &Pubkey::default(),
         );
 
         let working_bank = WorkingBank {
@@ -408,7 +408,7 @@ mod tests {
             0,
             Some(4),
             bank.ticks_per_slot(),
-            Pubkey::default(),
+            &Pubkey::default(),
         );
 
         let working_bank = WorkingBank {
@@ -445,7 +445,7 @@ mod tests {
             0,
             Some(4),
             bank.ticks_per_slot(),
-            Pubkey::default(),
+            &Pubkey::default(),
         );
 
         poh_recorder.tick();
@@ -480,7 +480,7 @@ mod tests {
             0,
             Some(4),
             bank.ticks_per_slot(),
-            Pubkey::default(),
+            &Pubkey::default(),
         );
 
         let working_bank = WorkingBank {
@@ -507,7 +507,7 @@ mod tests {
             0,
             Some(4),
             bank.ticks_per_slot(),
-            Pubkey::default(),
+            &Pubkey::default(),
         );
 
         let working_bank = WorkingBank {
@@ -543,7 +543,7 @@ mod tests {
             0,
             Some(4),
             bank.ticks_per_slot(),
-            Pubkey::default(),
+            &Pubkey::default(),
         );
 
         let working_bank = WorkingBank {
@@ -576,7 +576,7 @@ mod tests {
             0,
             Some(4),
             bank.ticks_per_slot(),
-            Pubkey::default(),
+            &Pubkey::default(),
         );
 
         let working_bank = WorkingBank {
@@ -602,7 +602,7 @@ mod tests {
             0,
             Some(4),
             DEFAULT_TICKS_PER_SLOT,
-            Pubkey::default(),
+            &Pubkey::default(),
         );
         poh_recorder.tick();
         poh_recorder.tick();
@@ -625,7 +625,7 @@ mod tests {
             0,
             Some(4),
             DEFAULT_TICKS_PER_SLOT,
-            Pubkey::default(),
+            &Pubkey::default(),
         );
         poh_recorder.tick();
         poh_recorder.tick();
@@ -648,7 +648,7 @@ mod tests {
             0,
             Some(4),
             DEFAULT_TICKS_PER_SLOT,
-            Pubkey::default(),
+            &Pubkey::default(),
         );
         poh_recorder.tick();
         poh_recorder.tick();
@@ -671,7 +671,7 @@ mod tests {
             0,
             Some(4),
             bank.ticks_per_slot(),
-            Pubkey::default(),
+            &Pubkey::default(),
         );
         let ticks_per_slot = bank.ticks_per_slot();
         let working_bank = WorkingBank {
@@ -694,7 +694,7 @@ mod tests {
             0,
             None,
             bank.ticks_per_slot(),
-            Pubkey::default(),
+            &Pubkey::default(),
         );
         let (sender, receiver) = sync_channel(1);
         poh_recorder.set_bank(&bank);
@@ -717,7 +717,7 @@ mod tests {
             0,
             Some(4),
             bank.ticks_per_slot(),
-            Pubkey::default(),
+            &Pubkey::default(),
         );
 
         let end_slot = 3;
@@ -752,7 +752,7 @@ mod tests {
             0,
             None,
             bank.ticks_per_slot(),
-            Pubkey::default(),
+            &Pubkey::default(),
         );
 
         // Test that with no leader slot, we don't reach the leader tick

--- a/core/src/poh_recorder.rs
+++ b/core/src/poh_recorder.rs
@@ -54,15 +54,13 @@ pub struct PohRecorder {
 
 impl PohRecorder {
     pub fn clear_bank(&mut self) {
-        if let Some(bank) = &self.working_bank {
+        if let Some(working_bank) = self.working_bank.take() {
+            let bank = working_bank.bank;
             let next_leader_slot =
-                leader_schedule_utils::next_leader_slot(&self.id, bank.bank.slot(), &bank.bank);
+                leader_schedule_utils::next_leader_slot(&self.id, bank.slot(), &bank);
             self.start_leader_at_tick = next_leader_slot
-                .map(|slot| {
-                    Some(slot * bank.bank.ticks_per_slot() + self.max_last_leader_grace_ticks)
-                })
+                .map(|slot| Some(slot * bank.ticks_per_slot() + self.max_last_leader_grace_ticks))
                 .unwrap_or(None);
-            self.working_bank = None;
         }
         if let Some(ref signal) = self.clear_bank_signal {
             let _ = signal.try_send(true);

--- a/core/src/poh_service.rs
+++ b/core/src/poh_service.rs
@@ -104,6 +104,7 @@ mod tests {
     use solana_runtime::bank::Bank;
     use solana_sdk::genesis_block::GenesisBlock;
     use solana_sdk::hash::hash;
+    use solana_sdk::pubkey::Pubkey;
 
     #[test]
     fn test_poh_service() {
@@ -116,6 +117,7 @@ mod tests {
             bank.slot(),
             Some(4),
             bank.ticks_per_slot(),
+            Pubkey::default(),
         );
         let poh_recorder = Arc::new(Mutex::new(poh_recorder));
         let exit = Arc::new(AtomicBool::new(false));

--- a/core/src/poh_service.rs
+++ b/core/src/poh_service.rs
@@ -117,7 +117,7 @@ mod tests {
             bank.slot(),
             Some(4),
             bank.ticks_per_slot(),
-            Pubkey::default(),
+            &Pubkey::default(),
         );
         let poh_recorder = Arc::new(Mutex::new(poh_recorder));
         let exit = Arc::new(AtomicBool::new(false));


### PR DESCRIPTION
#### Problem
The Poh recorder can potentially tell replay stage to be leader when it has overshoot it's leader slot

#### Summary of Changes
Check for slot boundary to make sure the current slot is still a valid leader slot