### PR TITLE
v0.12: Avoid panic on duplicate account indices

### DIFF
--- a/sdk/src/native_program.rs
+++ b/sdk/src/native_program.rs
@@ -40,6 +40,9 @@ pub enum ProgramError {
     /// SystemInstruction::Assign was attempted on an account unowned by the system program
     AssignOfUnownedAccount,
 
+    /// An account was referenced more than once in a single instruction
+    DuplicateAccountIndex,
+
     /// CustomError allows on-chain programs to implement program-specific error types and see
     /// them returned by the Solana runtime. A CustomError may be any type that is serialized
     /// to a Vec of bytes, max length 32 bytes. Any CustomError Vec greater than this length will


### PR DESCRIPTION
Prevents malformed `Instruction`s from panicking the runtime