### PR TITLE
Clear progress map on squash

### DIFF
--- a/core/src/bank_forks.rs
+++ b/core/src/bank_forks.rs
@@ -68,6 +68,7 @@ impl BankForks {
             .map(|(k, _v)| *k)
             .collect()
     }
+
     pub fn get(&self, bank_slot: u64) -> Option<&Arc<Bank>> {
         self.banks.get(&bank_slot)
     }

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -172,6 +172,7 @@ impl ReplayStage {
                             );
                             if let Some(new_root) = locktower.record_vote(bank.slot()) {
                                 bank_forks.write().unwrap().set_root(new_root);
+                                Self::handle_new_root(&bank_forks, &mut progress);
                             }
                             locktower.update_epoch(&bank);
                             cluster_info.write().unwrap().push_vote(vote);
@@ -377,6 +378,14 @@ impl ReplayStage {
         blocktree_processor::process_entries(bank, entries)?;
 
         Ok(())
+    }
+
+    fn handle_new_root(
+        bank_forks: &Arc<RwLock<BankForks>>,
+        progress: &mut HashMap<u64, (Hash, usize)>,
+    ) {
+        let r_bank_forks = bank_forks.read().unwrap();
+        progress.retain(|k, _| r_bank_forks.get(*k).is_some());
     }
 
     fn process_completed_bank(
@@ -608,5 +617,15 @@ mod test {
         }
 
         let _ignored = remove_dir_all(&ledger_path);
+    }
+
+    #[test]
+    fn test_handle_new_root() {
+        let bank0 = Bank::default();
+        let bank_forks = Arc::new(RwLock::new(BankForks::new(0, bank0)));
+        let mut progress = HashMap::new();
+        progress.insert(5, (Hash::default(), 0));
+        ReplayStage::handle_new_root(&bank_forks, &mut progress);
+        assert!(progress.is_empty());
     }
 }


### PR DESCRIPTION
#### Problem
The progress map in ReplayStage won't clear any dead forks after a squash

#### Summary of Changes
Clear the progress map of dead forks after we squash

Fixes #
