### PR TITLE
Relocate transaction reference verification to join the other validity checks

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -388,7 +388,7 @@ impl BankingStage {
                     .filter_map(|((tx, ver), index)| match tx {
                         None => None,
                         Some(tx) => {
-                            if tx.verify_refs() && ver != 0 {
+                            if ver != 0 {
                                 Some((tx, index))
                             } else {
                                 None

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -32,6 +32,7 @@ pub struct ErrorCounters {
     pub blockhash_too_old: usize,
     pub reserve_blockhash: usize,
     pub insufficient_funds: usize,
+    pub invalid_account_index: usize,
     pub duplicate_signature: usize,
     pub call_chain_too_deep: usize,
     pub missing_signature_for_fee: usize,

--- a/sdk/src/transaction.rs
+++ b/sdk/src/transaction.rs
@@ -189,6 +189,9 @@ pub enum TransactionError {
 
     /// Transaction has a fee but has no signature present
     MissingSignatureForFee,
+
+    /// Transaction contains an invalid account reference
+    InvalidAccountIndex,
 }
 
 /// An atomic transaction


### PR DESCRIPTION
Transaction reference verification was still way over in the banking_stage, instead of alongside all the other validity checks in the bank.  