### PR TITLE
Remove accounts when the fork is removed

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -648,7 +648,8 @@ mod test {
 
     #[test]
     fn test_handle_new_root() {
-        let bank0 = Bank::default();
+        let genesis_block = GenesisBlock::new(10_000).0;
+        let bank0 = Bank::new(&genesis_block);
         let bank_forks = Arc::new(RwLock::new(BankForks::new(0, bank0)));
         let mut progress = HashMap::new();
         progress.insert(5, (Hash::default(), 0));

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -904,6 +904,12 @@ impl Bank {
     }
 }
 
+impl Drop for Bank {
+    fn drop(&mut self) {
+        self.accounts.remove_accounts(self.accounts_id);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
#### Problem
When a bank is dropped, the accounts associated with the bank fork are not cleaned up and kept around infinitely.

#### Summary of Changes
Remove and free up memory / storage associated with the bank accounts that is being dropped.

Fixes #3155 
