### PR TITLE
Repurpose is_rooted as indicated root chain

### DIFF
--- a/core/src/replicator.rs
+++ b/core/src/replicator.rs
@@ -315,7 +315,7 @@ impl Replicator {
         'outer: loop {
             while let Ok(meta) = blocktree.meta(current_slot) {
                 if let Some(meta) = meta {
-                    if meta.is_rooted {
+                    if meta.is_connected {
                         current_slot += 1;
                         warn!("current slot: {}", current_slot);
                         if current_slot >= start_slot + ENTRIES_PER_SEGMENT {


### PR DESCRIPTION
#### Problem

bank_forks and blocktree both use 'root' or 'rooted' to mean different things.

#### Summary of Changes

is_rooted is now is_connected

Fixes #
