### PR TITLE
Fix dupe port in cluster_info test

### DIFF
--- a/core/src/cluster_info.rs
+++ b/core/src/cluster_info.rs
@@ -1805,10 +1805,11 @@ mod tests {
 
     #[test]
     fn new_replicator_external_ip_test() {
-        let ip = IpAddr::V4(Ipv4Addr::from(0));
+        let ip = Ipv4Addr::from(0);
         let node =
-            Node::new_replicator_with_external_ip(&Keypair::new().pubkey(), &socketaddr!(0, 8050));
+            Node::new_replicator_with_external_ip(&Keypair::new().pubkey(), &socketaddr!(ip, 0));
 
+        let ip = IpAddr::V4(ip);
         check_socket(&node.sockets.storage.unwrap(), ip, FULLNODE_PORT_RANGE);
         check_socket(&node.sockets.gossip, ip, FULLNODE_PORT_RANGE);
         check_socket(&node.sockets.repair, ip, FULLNODE_PORT_RANGE);

--- a/core/src/cluster_info.rs
+++ b/core/src/cluster_info.rs
@@ -1796,11 +1796,16 @@ mod tests {
     #[test]
     fn new_with_external_ip_test_gossip() {
         let ip = IpAddr::V4(Ipv4Addr::from(0));
-        let node = Node::new_with_external_ip(&Keypair::new().pubkey(), &socketaddr!(0, 8050));
+        let port = {
+            bind_in_range(FULLNODE_PORT_RANGE)
+                .expect("Failed to bind")
+                .0
+        };
+        let node = Node::new_with_external_ip(&Keypair::new().pubkey(), &socketaddr!(0, port));
 
         check_node_sockets(&node, ip, FULLNODE_PORT_RANGE);
 
-        assert_eq!(node.sockets.gossip.local_addr().unwrap().port(), 8050);
+        assert_eq!(node.sockets.gossip.local_addr().unwrap().port(), port);
     }
 
     #[test]


### PR DESCRIPTION
#### Problem

Another test uses 8050, this was 8050 by accident, should be port 0.

#### Summary of Changes

Change port and and remove unintended grow file.

Fixes #
