### PR TITLE
Boot airdrop support from JSON RPC

### DIFF
--- a/book/src/jsonrpc-api.md
+++ b/book/src/jsonrpc-api.md
@@ -27,7 +27,6 @@ Methods
 * [getRecentBlockhash](#getrecentblockhash)
 * [getSignatureStatus](#getsignaturestatus)
 * [getTransactionCount](#gettransactioncount)
-* [requestAirdrop](#requestairdrop)
 * [sendTransaction](#sendtransaction)
 * [startSubscriptionChannel](#startsubscriptionchannel)
 
@@ -205,26 +204,6 @@ curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1, "m
 
 ---
 
-### requestAirdrop
-Requests an airdrop of lamports to a Pubkey
-
-##### Parameters:
-* `string` - Pubkey of account to receive lamports, as base-58 encoded string
-* `integer` - lamports, as a signed 64-bit integer
-
-##### Results:
-* `string` - Transaction Signature of airdrop, as base-58 encoded string
-
-##### Example:
-```bash
-// Request
-curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1, "method":"requestAirdrop", "params":["83astBRguLMdt2h5U1Tpdq5tjFoJ6noeGwaY3mDLVcri", 50]}' http://localhost:8899
-
-// Result
-{"jsonrpc":"2.0","result":"5VERv8NMvzbJMEkV8xnrLkEaWRtSz9CosKDYjCJjBRnbJLgp8uirBgmQpjKhoR4tjF3ZpRzrFmBV6UjKdiSZkQUW","id":1}
-```
-
----
 
 ### sendTransaction
 Creates new transaction

--- a/client/src/rpc_request.rs
+++ b/client/src/rpc_request.rs
@@ -9,7 +9,6 @@ pub enum RpcRequest {
     GetRecentBlockhash,
     GetSignatureStatus,
     GetTransactionCount,
-    RequestAirdrop,
     SendTransaction,
     RegisterNode,
     SignVote,
@@ -30,7 +29,6 @@ impl RpcRequest {
             RpcRequest::GetRecentBlockhash => "getRecentBlockhash",
             RpcRequest::GetSignatureStatus => "getSignatureStatus",
             RpcRequest::GetTransactionCount => "getTransactionCount",
-            RpcRequest::RequestAirdrop => "requestAirdrop",
             RpcRequest::SendTransaction => "sendTransaction",
             RpcRequest::RegisterNode => "registerNode",
             RpcRequest::SignVote => "signVote",
@@ -97,10 +95,6 @@ mod tests {
         let test_request = RpcRequest::GetTransactionCount;
         let request = test_request.build_request_json(1, None);
         assert_eq!(request["method"], "getTransactionCount");
-
-        let test_request = RpcRequest::RequestAirdrop;
-        let request = test_request.build_request_json(1, None);
-        assert_eq!(request["method"], "requestAirdrop");
 
         let test_request = RpcRequest::SendTransaction;
         let request = test_request.build_request_json(1, None);

--- a/fullnode/src/main.rs
+++ b/fullnode/src/main.rs
@@ -96,13 +96,6 @@ fn main() {
                 .help("Enable the JSON RPC 'fullnodeExit' API.  Only enable in a debug environment"),
         )
         .arg(
-            Arg::with_name("rpc_drone_address")
-                .long("rpc-drone-address")
-                .value_name("HOST:PORT")
-                .takes_value(true)
-                .help("Enable the JSON RPC 'requestAirdrop' API with this drone address."),
-        )
-        .arg(
             Arg::with_name("signer")
                 .short("s")
                 .long("signer")
@@ -166,9 +159,6 @@ fn main() {
     if matches.is_present("enable_rpc_exit") {
         fullnode_config.rpc_config.enable_fullnode_exit = true;
     }
-    fullnode_config.rpc_config.drone_addr = matches
-        .value_of("rpc_drone_address")
-        .map(|address| address.parse().expect("failed to parse drone address"));
 
     let gossip_addr = {
         let mut addr = solana_netutil::parse_port_or_addr(


### PR DESCRIPTION
#### Problem

When we first implemented airdrops, we hadn't implemented the off-chain drone. After we did, it looks like someone (possibly me) made a shim to keep the original API alive. Since then, everyone has migrated to the drone but the shim is still there.

#### Summary of Changes

Remove `requestAirdrop` from JSON RPC.

Fixes #1830