### PR TITLE
ci/publish-crate.sh: Ensure current crate versions match the tag before publishing to crates.io

### DIFF
--- a/ci/publish-bpf-sdk.sh
+++ b/ci/publish-bpf-sdk.sh
@@ -2,15 +2,7 @@
 set -e
 
 cd "$(dirname "$0")/.."
-
 eval "$(ci/channel-info.sh)"
-if [[ $BUILDKITE_BRANCH = "$STABLE_CHANNEL" ]]; then
-  CHANNEL=stable
-elif [[ $BUILDKITE_BRANCH = "$EDGE_CHANNEL" ]]; then
-  CHANNEL=edge
-elif [[ $BUILDKITE_BRANCH = "$BETA_CHANNEL" ]]; then
-  CHANNEL=beta
-fi
 
 echo --- Creating tarball
 (

--- a/ci/publish-crate.sh
+++ b/ci/publish-crate.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 cd "$(dirname "$0")/.."
-
+source ci/semver_bash/semver.sh
 
 # List of internal crates to publish
 #
@@ -38,6 +38,9 @@ CRATES=(
   exit 0
 }
 
+semverParseInto "$TRIGGERED_BUILDKITE_TAG" MAJOR MINOR PATCH SPECIAL
+expectedCrateVersion="$MAJOR.$MINOR.$PATCH$SPECIAL"
+
 [[ -n "$CRATES_IO_TOKEN" ]] || {
   echo CRATES_IO_TOKEN undefined
   exit 1
@@ -51,8 +54,11 @@ for crate in "${CRATES[@]}"; do
     exit 1
   fi
   echo "-- $crate"
-  # TODO: Ensure the published version matches the contents of
-  # TRIGGERED_BUILDKITE_TAG
+  grep -q "^version = \"$expectedCrateVersion\"$" Cargo.toml || {
+    echo "Error: $crate/Cargo.toml version is not $expectedCrateVersion"
+    exit 1
+  }
+
   (
     set -x
     # TODO: the rocksdb package does not build with the stock rust docker image,


### PR DESCRIPTION
This ensures we are publishing the version we think we are, and allows us to create pre release tags that don't get published to crates.io (by intentionally not bumping the Cargo.toml versions before tagging a pre release)