### PR TITLE
Turn top-level Cargo.toml into a virtual manifest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2496,22 +2496,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-workspace"
-version = "0.13.0"
-dependencies = [
- "bincode 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana 0.13.0",
- "solana-budget-program 0.13.0",
- "solana-client 0.13.0",
- "solana-logger 0.13.0",
- "solana-netutil 0.13.0",
- "solana-runtime 0.13.0",
- "solana-sdk 0.13.0",
- "solana-vote-api 0.13.0",
-]
-
-[[package]]
 name = "solana_rbpf"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,36 +1,3 @@
-[package]
-name = "solana-workspace"
-description = "Blockchain, Rebuilt for Scale"
-version = "0.13.0"
-documentation = "https://docs.rs/solana"
-homepage = "https://solana.com/"
-readme = "README.md"
-repository = "https://github.com/solana-labs/solana"
-authors = ["Solana Maintainers <maintainers@solana.com>"]
-license = "Apache-2.0"
-edition = "2018"
-
-[badges]
-codecov = { repository = "solana-labs/solana", branch = "master", service = "github" }
-
-[features]
-chacha = ["solana/chacha"]
-cuda = ["solana/cuda"]
-erasure = ["solana/erasure"]
-
-[dev-dependencies]
-bincode = "1.1.2"
-log = "0.4.2"
-solana = { path = "core", version = "0.13.0" }
-solana-budget-program = { path = "programs/budget", version = "0.13.0" }
-solana-client = { path = "client", version = "0.13.0" }
-solana-logger = { path = "logger", version = "0.13.0" }
-solana-netutil = { path = "netutil", version = "0.13.0" }
-solana-runtime = { path = "runtime", version = "0.13.0" }
-solana-sdk = { path = "sdk", version = "0.13.0" }
-solana-vote-api = { path = "programs/vote_api", version = "0.13.0" }
-
-
 [workspace]
 members = [
     ".",

--- a/ci/crate-version.sh
+++ b/ci/crate-version.sh
@@ -1,17 +1,26 @@
 #!/usr/bin/env bash
 #
-# Outputs the current crate version
+# Outputs the current crate version from a given Cargo.toml
 #
 set -e
 
-cd "$(dirname "$0")"/..
+Cargo_toml=$1
+[[ -n $Cargo_toml ]] || {
+  echo "Usage: $0 path/to/Cargo.toml"
+  exit 0
+}
+
+[[ -r $Cargo_toml ]] || {
+  echo "Error: unable to read $Cargo_toml"
+  exit 1
+}
 
 while read -r name equals value _; do
   if [[ $name = version && $equals = = ]]; then
     echo "${value//\"/}"
     exit 0
   fi
-done < <(cat Cargo.toml)
+done < <(cat "$Cargo_toml")
 
 echo Unable to locate version in Cargo.toml 1>&2
 exit 1

--- a/scripts/increment-cargo-version.sh
+++ b/scripts/increment-cargo-version.sh
@@ -42,7 +42,7 @@ MAJOR=0
 MINOR=0
 PATCH=0
 SPECIAL=""
-semverParseInto "$(readCargoVariable version ./Cargo.toml)" MAJOR MINOR PATCH SPECIAL
+semverParseInto "$(readCargoVariable version "${Cargo_tomls[0]}")" MAJOR MINOR PATCH SPECIAL
 [[ -n $MAJOR ]] || usage
 
 currentVersion="$MAJOR.$MINOR.$PATCH$SPECIAL"

--- a/sdk/bpf/scripts/package.sh
+++ b/sdk/bpf/scripts/package.sh
@@ -8,7 +8,7 @@ mkdir bpf-sdk/
 cp LICENSE bpf-sdk/
 
 (
-  ci/crate-version.sh
+  ci/crate-version.sh sdk/Cargo.toml
   git rev-parse HEAD
 ) > bpf-sdk/version.txt
 


### PR DESCRIPTION
`cargo build` at the top of the tree now adds `--all` automatically!

Fixes #3263
