### PR TITLE
solana-install improvements

### DIFF
--- a/install/src/main.rs
+++ b/install/src/main.rs
@@ -70,6 +70,11 @@ fn main() -> Result<(), String> {
                         .validator(url_validator)
                         .help("JSON RPC URL for the solana cluster"),
                 )
+                .arg(
+                    Arg::with_name("no_modify_path")
+                        .long("no-modify-path")
+                        .help("Don't configure the PATH environment variable"),
+                )
                 .arg({
                     let arg = Arg::with_name("update_manifest_pubkey")
                         .short("p")
@@ -176,7 +181,15 @@ fn main() -> Result<(), String> {
                 .parse::<Pubkey>()
                 .unwrap();
             let data_dir = matches.value_of("data_dir").unwrap();
-            command::init(config_file, data_dir, json_rpc_url, &update_manifest_pubkey)
+            let no_modify_path = matches.is_present("no_modify_path");
+
+            command::init(
+                config_file,
+                data_dir,
+                json_rpc_url,
+                &update_manifest_pubkey,
+                no_modify_path,
+            )
         }
         ("info", Some(matches)) => {
             let local_info_only = matches.is_present("local_info_only");

--- a/install/testnet-deploy.sh
+++ b/install/testnet-deploy.sh
@@ -32,6 +32,9 @@ edge|beta)
 stable)
   URL=https://api.testnet.solana.com
   ;;
+localhost)
+  URL=http://localhost:8899
+  ;;
 *)
   echo "Error: unknown channel: $CHANNEL"
   exit 1


### PR DESCRIPTION
* `solana-install init` now automatically update PATH for the user
* `solana-install deploy` now fails cleanly if the source account balance is 0
* `install/testnet-deploy.sh` can now be used to deploy to a local cluster