### PR TITLE
Move entrypoint boilerplate into a macro

### DIFF
--- a/programs/budget/src/lib.rs
+++ b/programs/budget/src/lib.rs
@@ -1,22 +1,5 @@
 mod budget_processor;
 
 use crate::budget_processor::process_instruction;
-use log::*;
-use solana_sdk::account::KeyedAccount;
-use solana_sdk::pubkey::Pubkey;
-use solana_sdk::solana_entrypoint;
-use solana_sdk::transaction::InstructionError;
 
-solana_entrypoint!(entrypoint);
-fn entrypoint(
-    program_id: &Pubkey,
-    keyed_accounts: &mut [KeyedAccount],
-    data: &[u8],
-    tick_height: u64,
-) -> Result<(), InstructionError> {
-    solana_logger::setup();
-
-    trace!("process_instruction: {:?}", data);
-    trace!("keyed_accounts: {:?}", keyed_accounts);
-    process_instruction(program_id, keyed_accounts, data, tick_height)
-}
+solana_sdk::process_instruction_entrypoint!(process_instruction);

--- a/programs/config/src/lib.rs
+++ b/programs/config/src/lib.rs
@@ -3,9 +3,9 @@
 use log::*;
 use solana_sdk::account::KeyedAccount;
 use solana_sdk::pubkey::Pubkey;
-use solana_sdk::solana_entrypoint;
 use solana_sdk::transaction::InstructionError;
 
+solana_sdk::process_instruction_entrypoint!(process_instruction);
 fn process_instruction(
     _program_id: &Pubkey,
     keyed_accounts: &mut [KeyedAccount],
@@ -24,20 +24,6 @@ fn process_instruction(
 
     keyed_accounts[1].account.data[0..data.len()].copy_from_slice(data);
     Ok(())
-}
-
-solana_entrypoint!(entrypoint);
-fn entrypoint(
-    program_id: &Pubkey,
-    keyed_accounts: &mut [KeyedAccount],
-    data: &[u8],
-    tick_height: u64,
-) -> Result<(), InstructionError> {
-    solana_logger::setup();
-
-    trace!("process_instruction: {:?}", data);
-    trace!("keyed_accounts: {:?}", keyed_accounts);
-    process_instruction(program_id, keyed_accounts, data, tick_height)
 }
 
 #[cfg(test)]

--- a/sdk/src/native_program.rs
+++ b/sdk/src/native_program.rs
@@ -20,12 +20,32 @@ macro_rules! solana_entrypoint(
     ($entrypoint:ident) => (
         #[no_mangle]
         pub extern "C" fn process(
-            program_id: &Pubkey,
-            keyed_accounts: &mut [KeyedAccount],
+            program_id: &solana_sdk::pubkey::Pubkey,
+            keyed_accounts: &mut [solana_sdk::account::KeyedAccount],
             data: &[u8],
             tick_height: u64
-        ) -> Result<(), InstructionError> {
+        ) -> Result<(), solana_sdk::transaction::InstructionError> {
             $entrypoint(program_id, keyed_accounts, data, tick_height)
+        }
+    )
+);
+
+// Macro to define an entrypoint from a native `process_instruction` function.
+#[macro_export]
+macro_rules! process_instruction_entrypoint(
+    ($process_instruction:ident) => (
+        solana_sdk::solana_entrypoint!(process_instruction_entrypoint);
+        fn process_instruction_entrypoint(
+            program_id: &solana_sdk::pubkey::Pubkey,
+            keyed_accounts: &mut [solana_sdk::account::KeyedAccount],
+            data: &[u8],
+            tick_height: u64,
+        ) -> Result<(), solana_sdk::transaction::InstructionError> {
+            solana_logger::setup();
+
+            log::trace!("process_instruction: {:?}", data);
+            log::trace!("keyed_accounts: {:?}", keyed_accounts);
+            $process_instruction(program_id, keyed_accounts, data, tick_height)
         }
     )
 );


### PR DESCRIPTION
#### Problem

Now that Runtime allows you to inject Rust `process_instruction` functions, the program author needs to add the boilerplate of having the C entrypoint call the Rust function.

#### Summary of Changes

* Move the boilerplate code into a macro
* Use it in Budget and Config
