### PR TITLE
multinode-demo,net: Ensure genesis ledger directory is populated on all validator nodes

### DIFF
--- a/multinode-demo/fullnode.sh
+++ b/multinode-demo/fullnode.sh
@@ -167,14 +167,13 @@ rsync_url() { # adds the 'rsync://` prefix to URLs that need it
 
 rsync_leader_url=$(rsync_url "$leader")
 set -ex
-if [[ ! -d "$ledger_config_dir" ]]; then
-  $rsync -vPr "$rsync_leader_url"/config/ledger/ "$ledger_config_dir"
-  [[ -d $ledger_config_dir ]] || {
-    echo "Unable to retrieve ledger from $rsync_leader_url"
-    exit 1
-  }
-  $solana_ledger_tool --ledger "$ledger_config_dir" verify
+if [[ ! -d "$SOLANA_RSYNC_CONFIG_DIR"/ledger ]]; then
+  $rsync -vPr "$rsync_leader_url"/config/ledger "$SOLANA_RSYNC_CONFIG_DIR"/ledger
+fi
 
+if [[ ! -d "$ledger_config_dir" ]]; then
+  cp -a "$SOLANA_RSYNC_CONFIG_DIR"/ledger/ "$ledger_config_dir"
+  $solana_ledger_tool --ledger "$ledger_config_dir" verify
 fi
 
 trap 'kill "$pid" && wait "$pid"' INT TERM ERR

--- a/net/remote/remote-sanity.sh
+++ b/net/remote/remote-sanity.sh
@@ -72,7 +72,7 @@ local|tar)
   solana_keygen=solana-keygen
 
   ledger=config-local/bootstrap-leader-ledger
-  client_id=config/client-id.json
+  client_id=config-local/client-id.json
   ;;
 *)
   echo "Unknown deployment method: $deployMethod"


### PR DESCRIPTION
This allows all nodes to serve the genesis ledger over rsync instead of
just the bootstrap leader