### PR TITLE
Various fixes to get external validators able to attach to a testnet using the release tarball

### DIFF
--- a/ci/publish-tarball.sh
+++ b/ci/publish-tarball.sh
@@ -64,6 +64,7 @@ echo --- Creating tarball
     cargo install --path . --features=cuda --root ../solana-release-cuda
   )
   cp solana-release-cuda/bin/solana-fullnode solana-release/bin/solana-fullnode-cuda
+  cp -a scripts multinode-demo solana-release/
 
   tar jvcf solana-release-$TARGET.tar.bz2 solana-release/
   cp solana-release/bin/solana-install solana-install-$TARGET

--- a/multinode-demo/common.sh
+++ b/multinode-demo/common.sh
@@ -21,7 +21,8 @@ if [[ $(uname) != Linux ]]; then
   fi
 fi
 
-if [[ -n $USE_INSTALL ]]; then # Assume |./scripts/cargo-install-all.sh| was run
+
+if [[ -n $USE_INSTALL || ! -f "$(dirname "${BASH_SOURCE[0]}")"/../Cargo.toml ]]; then
   solana_program() {
     declare program="$1"
     printf "solana-%s" "$program"

--- a/net/net.sh
+++ b/net/net.sh
@@ -411,7 +411,7 @@ stopNode() {
         pgid=\$(ps opgid= \$(cat \$pid) | tr -d '[:space:]')
         sudo kill -- -\$pgid
       done
-      for pattern in solana- remote-; do
+      for pattern in node solana- remote-; do
         pkill -9 \$pattern
       done
     "

--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -118,6 +118,13 @@ local|tar)
     fi
 
     if [[ $nodeType = blockstreamer ]]; then
+      # Sneak the mint-id.json from the bootstrap leader and run another drone
+      # with it on the blockstreamer node.  Typically the blockstreamer node has
+      # a static IP/DNS name for hosting the blockexplorer web app, and is
+      # a location that somebody would expect to be able to airdrop from
+      scp "$entrypointIp":~/solana/config-local/mint-id.json config-local/
+      ./multinode-demo/drone.sh > drone.log 2>&1 &
+
       npm install @solana/blockexplorer@1
       npx solana-blockexplorer > blockexplorer.log 2>&1 &
 


### PR DESCRIPTION
* Run a drone on blockstreamer testnet nodes (the blockstreamer node is the one with a DNS entry, not the bootstrap leader)
* Include `multinode-demo/` scripts in release tarball (🤢but it's the shortest path for v0.12) 