### PR TITLE
net/: Use same gossip port for all testnet nodes

### DIFF
--- a/multinode-demo/fullnode.sh
+++ b/multinode-demo/fullnode.sh
@@ -45,6 +45,9 @@ while [[ ${1:0:1} = - ]]; do
   elif [[ $1 = --no-voting ]]; then
     extra_fullnode_args+=("$1")
     shift
+  elif [[ $1 = --gossip-port ]]; then
+    gossip_port=$2
+    shift 2
   elif [[ $1 = --rpc-port ]]; then
     extra_fullnode_args+=("$1" "$2")
     shift 2

--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -109,6 +109,7 @@ local|tar)
     fi
 
     args+=(
+      --gossip-port 8001
       --rpc-port 8899
     )
 


### PR DESCRIPTION
The non-bootstrap leader testnet nodes gossip on port 9000 whereas the bootstrap leader uses port 8001.  This is a footgun that I gleefully discharged on myself earlier.  It's so much more sane for all nodes to use the same gossip port if at all possible (ie, when they aren't running on the same machine.)
