### PR TITLE
Retry more for a new blockhash

### DIFF
--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -327,7 +327,7 @@ impl RpcClient {
     }
 
     pub fn get_new_blockhash(&self, blockhash: &Hash) -> io::Result<Hash> {
-        let mut num_retries = 5;
+        let mut num_retries = 10;
         while num_retries > 0 {
             if let Ok(new_blockhash) = self.get_recent_blockhash() {
                 if new_blockhash != *blockhash {
@@ -344,7 +344,7 @@ impl RpcClient {
         }
         Err(io::Error::new(
             io::ErrorKind::Other,
-            "Unable to get next blockhash, too many retries",
+            "Unable to get new blockhash, too many retries",
         ))
     }
 


### PR DESCRIPTION
The retry timeout for fetching a new blockhash has been empirically observed to be too small on v0.12, causing airdrop failures.   Try harder.