### PR TITLE
v0.12: Retry more for a new blockhash

### DIFF
--- a/wallet/src/wallet.rs
+++ b/wallet/src/wallet.rs
@@ -788,7 +788,7 @@ fn get_next_blockhash(
     rpc_client: &RpcClient,
     previous_blockhash: &Hash,
 ) -> Result<Hash, Box<dyn error::Error>> {
-    let mut next_blockhash_retries = 3;
+    let mut next_blockhash_retries = 10;
     loop {
         let next_blockhash = get_recent_blockhash(rpc_client)?;
         if cfg!(not(test)) {


### PR DESCRIPTION
The retry timeout for fetching a new blockhash has been empirically observed to be too small on v0.12, causing airdrop failures.   Try harder.

cc: #3440