### PR TITLE
Stop using VoteTransaction in Vote processor

### DIFF
--- a/programs/vote_api/src/lib.rs
+++ b/programs/vote_api/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod vote_instruction;
 pub mod vote_processor;
+pub mod vote_script;
 pub mod vote_state;
 pub mod vote_transaction;
 

--- a/programs/vote_api/src/vote_script.rs
+++ b/programs/vote_api/src/vote_script.rs
@@ -1,0 +1,21 @@
+//! The `vote_script` module provides functionality for creating vote scripts.
+
+use crate::id;
+use crate::vote_instruction::VoteInstruction;
+use crate::vote_state::VoteState;
+use solana_sdk::pubkey::Pubkey;
+use solana_sdk::script::Script;
+use solana_sdk::system_instruction::SystemInstruction;
+
+pub struct VoteScript;
+
+impl VoteScript {
+    /// Fund or create the staking account with lamports
+    pub fn new_account(from_id: &Pubkey, staker_id: &Pubkey, lamports: u64) -> Script {
+        let space = VoteState::max_size() as u64;
+        let create_ix =
+            SystemInstruction::new_program_account(&from_id, staker_id, lamports, space, &id());
+        let init_ix = VoteInstruction::new_initialize_account(staker_id);
+        Script::new(vec![create_ix, init_ix])
+    }
+}

--- a/programs/vote_api/src/vote_transaction.rs
+++ b/programs/vote_api/src/vote_transaction.rs
@@ -1,6 +1,7 @@
 //! The `vote_transaction` module provides functionality for creating vote transactions.
 
 use crate::vote_instruction::{Vote, VoteInstruction};
+use crate::vote_script::VoteScript;
 use crate::vote_state::VoteState;
 use crate::{check_id, id};
 use bincode::deserialize;
@@ -37,11 +38,7 @@ impl VoteTransaction {
         fee: u64,
     ) -> Transaction {
         let from_id = from_keypair.pubkey();
-        let space = VoteState::max_size() as u64;
-        let create_ix =
-            SystemInstruction::new_program_account(&from_id, staker_id, lamports, space, &id());
-        let init_ix = VoteInstruction::new_initialize_account(staker_id);
-        let mut tx = Transaction::new(vec![create_ix, init_ix]);
+        let mut tx = VoteScript::new_account(&from_id, staker_id, lamports).compile();
         tx.fee = fee;
         tx.sign(&[from_keypair], recent_blockhash);
         tx

--- a/sdk/src/script.rs
+++ b/sdk/src/script.rs
@@ -48,6 +48,10 @@ impl Script {
         Self { instructions }
     }
 
+    pub fn push(&mut self, instruction: Instruction) {
+        self.instructions.push(instruction);
+    }
+
     /// Return pubkeys referenced by all instructions, with the ones needing signatures first.
     /// No duplicates and order is preserved.
     fn keys(&self) -> (Vec<Pubkey>, Vec<Pubkey>) {


### PR DESCRIPTION
#### Problem

`<NAME>Transaction` modules require keypairs, blockhashes and fees.

#### Summary of Changes

* Add VoteScript and migrate VoteTransaction to it
* Replace custom VoteBank with solana_runtime's BankClient
* Removed Vote program's dependencies on VoteTransaction

@rob-solana, fyi