### PR TITLE
Update leader slot in poh recorder if we skipped it

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -194,6 +194,23 @@ impl ReplayStage {
         trace!("{} checking poh slot {}", my_id, poh_slot);
         if blocktree.meta(poh_slot).unwrap().is_some() {
             // We've already broadcasted entries for this slot, skip it
+
+            // Since we are skipping our leader slot, let's tell poh recorder when we should be
+            // leader again
+            if reached_leader_tick {
+                let _ = bank_forks.read().unwrap().get(poh_slot).map(|bank| {
+                    let next_leader_slot =
+                        leader_schedule_utils::next_leader_slot(&my_id, bank.slot(), &bank);
+                    poh_recorder.lock().unwrap().reset(
+                        bank.tick_height(),
+                        bank.last_blockhash(),
+                        bank.slot(),
+                        next_leader_slot,
+                        bank.ticks_per_slot(),
+                    );
+                });
+            }
+
             return;
         }
         if bank_forks.read().unwrap().get(poh_slot).is_none() {

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -201,10 +201,12 @@ impl ReplayStage {
                 let _ = bank_forks.read().unwrap().get(poh_slot).map(|bank| {
                     let next_leader_slot =
                         leader_schedule_utils::next_leader_slot(&my_id, bank.slot(), &bank);
-                    poh_recorder.lock().unwrap().reset(
+                    let mut poh = poh_recorder.lock().unwrap();
+                    let start_slot = poh.start_slot();
+                    poh.reset(
                         bank.tick_height(),
                         bank.last_blockhash(),
-                        bank.slot(),
+                        start_slot,
                         next_leader_slot,
                         bank.ticks_per_slot(),
                     );


### PR DESCRIPTION
#### Problem
In a single node setup with existing ledger, the leader skip its leader slot without voting. The Poh recorder doesn't know when the node should become the leader again.

#### Summary of Changes
Reset the poh recorder if the node is skipping its leader slot.