### PR TITLE
little fixes

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -481,7 +481,7 @@ impl ReplayStage {
         info!("bank frozen {}", bank.slot());
         progress.remove(&bank.slot());
         if let Err(e) = slot_full_sender.send((bank.slot(), bank.collector_id())) {
-            info!("{} slot_full alert failed: {:?}", my_id, e);
+            trace!("{} slot_full alert failed: {:?}", my_id, e);
         }
     }
 

--- a/multinode-demo/common.sh
+++ b/multinode-demo/common.sh
@@ -151,6 +151,11 @@ setup_fullnode_staking() {
   declare staker_id
   staker_id=$($solana_wallet --keypair "$staker_id_path" address)
 
+  if [[ -f "$staker_id_path".configured ]]; then
+    echo "Staking account has already been configured"
+    return 0
+  fi
+
   # A fullnode requires 43 lamports to function:
   # - one lamport to keep the node identity public key valid. TODO: really??
   # - 42 more for the staker account we fund
@@ -169,6 +174,8 @@ setup_fullnode_staking() {
                  --delegate-account "$fullnode_id" \
                  --authorize-voter "$staker_id"  || return $?
 
+
+  touch "$staker_id_path".configured
   return 0
 }
 


### PR DESCRIPTION
* Demote a spammy and misleading log
* `setup_fullnode_staking()` - Refrain from trying to configure a staking account that was previously configured to avoid misleading errors when a node restarts

cc: #3455
