### PR TITLE
check for open udp port range

### DIFF
--- a/scripts/test-udp-nat.sh
+++ b/scripts/test-udp-nat.sh
@@ -1,0 +1,2 @@
+ip=$(curl ifconfig.me/ip)
+nc -vzu $ip 8000-8005


### PR DESCRIPTION
#### Problem

Users don't have an easy way to check if the required UDP ports are open.

#### Summary of Changes

Implements a script that checks for open ports.

Fixes #

tag: @rob-solana @pgarg66 