### PR TITLE
Filter out banks that have an older epoch

### DIFF
--- a/core/src/locktower.rs
+++ b/core/src/locktower.rs
@@ -142,12 +142,27 @@ impl Locktower {
         stake_lockouts
     }
 
+    pub fn is_recent_epoch(&self, bank: &Bank) -> bool {
+        let bank_epoch = bank.get_epoch_and_slot_index(bank.slot()).0;
+        bank_epoch >= self.epoch_stakes.slot
+    }
+
     pub fn update_epoch(&mut self, bank: &Bank) {
+        trace!(
+            "updating bank epoch {} {}",
+            bank.slot(),
+            self.epoch_stakes.slot
+        );
         let bank_epoch = bank.get_epoch_and_slot_index(bank.slot()).0;
         if bank_epoch != self.epoch_stakes.slot {
             assert!(
-                bank_epoch > self.epoch_stakes.slot,
+                self.is_recent_epoch(bank),
                 "epoch_stakes cannot move backwards"
+            );
+            info!(
+                "Locktower updated epoch bank {} {}",
+                bank.slot(),
+                self.epoch_stakes.slot
             );
             self.epoch_stakes = EpochStakes::new_from_bank(bank);
         }

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -386,6 +386,11 @@ impl ReplayStage {
                 is_votable
             })
             .filter(|b| {
+                let is_recent_epoch = locktower.is_recent_epoch(b);
+                trace!("bank is is_recent_epoch: {} {}", b.slot(), is_recent_epoch);
+                is_recent_epoch
+            })
+            .filter(|b| {
                 let has_voted = locktower.has_voted(b.slot());
                 trace!("bank is has_voted: {} {}", b.slot(), has_voted);
                 !has_voted


### PR DESCRIPTION
#### Problem

Locktower initializes itself with the oldest frozen bank, but during epoch warmup, old frozen banks maybe presented as valid votes, even though they are from an older epoch.

#### Summary of Changes

Filter out old epochs.

Fixes #
