### PR TITLE
More hash info

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2104,6 +2104,8 @@ dependencies = [
  "jsonrpc-http-server 10.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.9.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-logger 0.12.1",
  "solana-metrics 0.12.1",

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -13,6 +13,8 @@ bincode = "1.1.2"
 bs58 = "0.2.0"
 log = "0.4.2"
 reqwest = "0.9.11"
+serde = "1.0.89"
+serde_derive = "1.0.89"
 serde_json = "1.0.39"
 solana-metrics = { path = "../metrics", version = "0.12.1" }
 solana-netutil = { path = "../netutil", version = "0.12.1" }

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -2,3 +2,5 @@ pub mod client;
 pub mod rpc_mock;
 pub mod rpc_request;
 pub mod thin_client;
+
+extern crate serde_derive;

--- a/client/src/rpc_request.rs
+++ b/client/src/rpc_request.rs
@@ -1,9 +1,12 @@
 use log::*;
 use reqwest;
 use reqwest::header::CONTENT_TYPE;
+use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
+use solana_sdk::hash::Hash;
 use solana_sdk::timing::{DEFAULT_TICKS_PER_SLOT, NUM_TICKS_PER_SECOND};
 use std::net::SocketAddr;
+use std::str::FromStr;
 use std::thread::sleep;
 use std::time::Duration;
 use std::{error, fmt};
@@ -14,6 +17,21 @@ use solana_sdk::pubkey::Pubkey;
 pub struct RpcClient {
     pub client: reqwest::Client,
     pub addr: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct BlockhashInfo {
+    pub recent: String,
+    pub recent_slot: u64,
+    pub root: String,
+    pub root_slot: u64,
+    pub root_distance: u64,
+}
+
+impl BlockhashInfo {
+    pub fn recent_hash(&self) -> Hash {
+        Hash::from_str(&self.recent).unwrap()
+    }
 }
 
 impl RpcClient {

--- a/client/src/thin_client.rs
+++ b/client/src/thin_client.rs
@@ -226,10 +226,8 @@ impl ThinClient {
                 Ok(value) => {
                     let ((latest, latest_slot), (root, root_slot)): ((String, u64), (String, u64)) =
                         serde_json::from_value(value).unwrap();
-                    let latest = bs58::decode(latest).into_vec().unwrap();
-                    let latest = Hash::new(&latest);
-                    let root = bs58::decode(root).into_vec().unwrap();
-                    let root = Hash::new(&root);
+                    let latest = Hash::from_str(latest).unwrap();
+                    let root = Hash::from_str(root).unwrap();
                     return Some(((latest, latest_slot), (root, root_slot)));
                 }
                 Err(error) => {

--- a/client/src/thin_client.rs
+++ b/client/src/thin_client.rs
@@ -5,7 +5,6 @@
 
 use crate::rpc_request::{RpcClient, RpcRequest, RpcRequestHandler};
 use bincode::serialize_into;
-use bs58;
 use log::*;
 use serde_json::json;
 use solana_metrics;
@@ -227,8 +226,8 @@ impl ThinClient {
                 Ok(value) => {
                     let ((latest, latest_slot), (root, root_slot)): ((String, u64), (String, u64)) =
                         serde_json::from_value(value).unwrap();
-                    let latest = Hash::from_str(latest).unwrap();
-                    let root = Hash::from_str(root).unwrap();
+                    let latest = Hash::from_str(&latest).unwrap();
+                    let root = Hash::from_str(&root).unwrap();
                     return Some(((latest, latest_slot), (root, root_slot)));
                 }
                 Err(error) => {

--- a/client/src/thin_client.rs
+++ b/client/src/thin_client.rs
@@ -224,7 +224,7 @@ impl ThinClient {
 
             match response {
                 Ok(value) => {
-                    let ((latest, latest_slot), (root, root_slot)) =
+                    let ((latest, latest_slot), (root, root_slot)): ((String, u64), (String, u64)) =
                         serde_json::from_value(value).unwrap();
                     let latest = bs58::decode(latest).into_vec().unwrap();
                     let latest = Hash::new(&latest);
@@ -250,7 +250,7 @@ impl ThinClient {
             trace!("get_recent_blockhash send_to {}", &self.rpc_addr);
             if let Some(((hash, slot), (root, root_slot))) = self.try_get_recent_blockhash(10) {
                 trace!(
-                    "get_recent_blockhash returned {}",
+                    "get_recent_blockhash returned recent: {},{} root: {},{}",
                     hash,
                     slot,
                     root,

--- a/client/src/thin_client.rs
+++ b/client/src/thin_client.rs
@@ -21,6 +21,7 @@ use solana_sdk::transaction::Transaction;
 use std;
 use std::io;
 use std::net::{SocketAddr, UdpSocket};
+use std::str::FromStr;
 use std::thread::sleep;
 use std::time::Duration;
 use std::time::Instant;

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -95,8 +95,8 @@ impl JsonRpcRequestProcessor {
             .map(|b| Self::bank_blockhash_and_slot(b))
             .unwrap_or(current.clone());
         info!(
-            "get_recent_blockhash response current: {:?} root: {:?}",
-            current, root
+            "get_recent_blockhash response current: {:?} root: {:?} length: {}",
+            current, root, self.bank()?.parents().len()
         );
         Ok((current, root))
     }

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -94,6 +94,10 @@ impl JsonRpcRequestProcessor {
             .last()
             .map(|b| Self::bank_blockhash_and_slot(b))
             .unwrap_or(current.clone());
+        info!(
+            "get_recent_blockhash response current: {} root: {}",
+            current, root
+        );
         Ok((current, root))
     }
 

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -90,7 +90,7 @@ impl JsonRpcRequestProcessor {
         let current = Self::bank_blockhash_and_slot(self.bank()?);
         let root = self
             .bank()?
-            .parents
+            .parents()
             .last()
             .map(|b| Self::bank_blockhash_and_slot(b))
             .unwrap_or(current.clone());

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -95,7 +95,7 @@ impl JsonRpcRequestProcessor {
             .map(|b| Self::bank_blockhash_and_slot(b))
             .unwrap_or(current.clone());
         info!(
-            "get_recent_blockhash response current: {} root: {}",
+            "get_recent_blockhash response current: {:?} root: {:?}",
             current, root
         );
         Ok((current, root))

--- a/core/src/storage_stage.rs
+++ b/core/src/storage_stage.rs
@@ -13,6 +13,7 @@ use bincode::deserialize;
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaChaRng;
 use solana_client::client::create_client_with_timeout;
+use solana_client::thin_client::ThinClient;
 use solana_sdk::hash::Hash;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::{Keypair, Signature};
@@ -242,7 +243,8 @@ impl StorageStage {
 
         let mut blockhash = None;
         for _ in 0..10 {
-            if let Some(new_blockhash) = client.try_get_recent_blockhash(1) {
+            if let Some(new_blockhash) = ThinClient::try_get_recent_blockhash(&client.rpc_client, 1)
+            {
                 blockhash = Some(new_blockhash);
                 break;
             }

--- a/core/src/storage_stage.rs
+++ b/core/src/storage_stage.rs
@@ -252,8 +252,8 @@ impl StorageStage {
             }
         }
 
-        if let Some(((blockhash, _), _)) = blockhash {
-            transaction.sign(&[keypair.as_ref()], blockhash);
+        if let Some(blockhash) = blockhash {
+            transaction.sign(&[keypair.as_ref()], blockhash.recent_hash());
 
             if exit.load(Ordering::Relaxed) {
                 Err(io::Error::new(io::ErrorKind::Other, "exit signaled"))?;

--- a/core/src/storage_stage.rs
+++ b/core/src/storage_stage.rs
@@ -252,7 +252,7 @@ impl StorageStage {
             }
         }
 
-        if let Some(blockhash) = blockhash {
+        if let Some(((blockhash, _), _)) = blockhash {
             transaction.sign(&[keypair.as_ref()], blockhash);
 
             if exit.load(Ordering::Relaxed) {

--- a/run.sh
+++ b/run.sh
@@ -8,7 +8,6 @@
 set -e
 
 # Prefer possible `cargo build --all` binaries over PATH binaries
-PATH=$PWD/target/debug:$PATH
 
 ok=true
 for program in solana-{genesis,keygen,fullnode}; do

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -892,7 +892,7 @@ impl Bank {
 
     pub fn is_votable(&self) -> bool {
         let max_tick_height = (self.slot + 1) * self.ticks_per_slot - 1;
-        self.is_delta.load(Ordering::Relaxed) && self.tick_height() == max_tick_height
+        self.is_delta.load(Ordering::Relaxed) && self.tick_height() == max_tick_height || (self.slot() == 0 && self.is_frozen())
     }
 
     pub fn is_in_subtree_of(&self, parent: u64) -> bool {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -892,7 +892,8 @@ impl Bank {
 
     pub fn is_votable(&self) -> bool {
         let max_tick_height = (self.slot + 1) * self.ticks_per_slot - 1;
-        self.is_delta.load(Ordering::Relaxed) && self.tick_height() == max_tick_height || (self.slot() == 0 && self.is_frozen())
+        self.is_delta.load(Ordering::Relaxed) && self.tick_height() == max_tick_height
+            || (self.slot() == 0 && self.is_frozen())
     }
 
     pub fn is_in_subtree_of(&self, parent: u64) -> bool {

--- a/scripts/blockhash-monitor.sh
+++ b/scripts/blockhash-monitor.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Usage: blockhash-monitor.sh <rpc address 1> <rpc address 2> ...  <rpc address N>
+while true; do
+  echo -
+  for rpc in "$@"; do
+    printf "%-20s | " "$rpc"
+    curl -X POST -H 'Content-Type: application/json' \
+      -d '{"jsonrpc":"2.0","id":1, "method":"getRecentBlockhash"}' "$rpc"
+  done
+  sleep 1
+done


### PR DESCRIPTION
#### Problem

Hashes need slot info.

#### Summary of Changes

Add slot info, and return the root slot hash as well.

Fixes #
tag: @pgarg66 @carllin 


```
 export RUST_LOG=solana::banking_stage=trace,solana::replay_stage=info,solana::locktower=trace,solana_runtime::bank=trace,solana::rpc=trace
```

no squashing
```
[2019-03-25T19:26:18.693700000Z INFO  solana::rpc] get_recent_blockhash response current: ("7FAwb1pFm78VR3GJWRHV5GRtD3WuuEVw8wj9sm7B5u6t", 88) root: ("2LneuLouFojuRTGninRQnG8EixShnbA41Yy41NAo6gKG", 0) length: 88
```