### PR TITLE
Fix runtime benches

### DIFF
--- a/ci/test-bench.sh
+++ b/ci/test-bench.sh
@@ -40,6 +40,10 @@ fi
 BENCH_FILE=bench_output.log
 BENCH_ARTIFACT=current_bench_results.log
 
+# Run runtime benches
+_ cargo +$rust_nightly bench --manifest-path runtime/Cargo.toml ${V:+--verbose} \
+  -- -Z unstable-options --format=json | tee "$BENCH_FILE"
+
 # Run core benches
 _ cargo +$rust_nightly bench --manifest-path core/Cargo.toml ${V:+--verbose} \
   -- -Z unstable-options --format=json | tee "$BENCH_FILE"

--- a/runtime/benches/bank.rs
+++ b/runtime/benches/bank.rs
@@ -23,7 +23,7 @@ fn bench_process_transaction(bencher: &mut Bencher) {
             let rando0 = Keypair::new();
             let tx = SystemTransaction::new_move(
                 &mint_keypair,
-                rando0.pubkey(),
+                &rando0.pubkey(),
                 10_000,
                 bank.last_blockhash(),
                 0,
@@ -33,7 +33,7 @@ fn bench_process_transaction(bencher: &mut Bencher) {
             // Seed the 'to' account and a cell for its signature.
             let rando1 = Keypair::new();
             let tx =
-                SystemTransaction::new_move(&rando0, rando1.pubkey(), 1, bank.last_blockhash(), 0);
+                SystemTransaction::new_move(&rando0, &rando1.pubkey(), 1, bank.last_blockhash(), 0);
             assert_eq!(bank.process_transaction(&tx), Ok(()));
 
             // Finally, return the transaction to the benchmark.

--- a/runtime/benches/runtime.rs
+++ b/runtime/benches/runtime.rs
@@ -2,7 +2,7 @@
 
 extern crate test;
 
-use solana_runtime::*;
+use solana_runtime::runtime::*;
 use test::Bencher;
 
 #[bench]

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -6,7 +6,7 @@ mod blockhash_queue;
 pub mod bloom;
 pub mod loader_utils;
 mod native_loader;
-mod runtime;
+pub mod runtime;
 mod status_cache;
 mod system_program;
 


### PR DESCRIPTION
#### Problem

Runtime benchmarks aren't run by CI and are starting to bitrot.

#### Summary of Changes

* Add runtime benchmarks to the build
* Fix the bitrotted ones

Why don't we?

```
_ cargo +$rust_nightly bench
```

