### PR TITLE
Remove rewards crate from publishing script

### DIFF
--- a/ci/publish-crate.sh
+++ b/ci/publish-crate.sh
@@ -21,7 +21,7 @@ CRATES=(
   drone
   programs/{budget_api,config_api,storage_api,token_api,vote_api}
   runtime
-  programs/{budget,bpf_loader,config,vote,rewards,storage,token,vote}
+  programs/{budget,bpf_loader,config,vote,storage,token,vote}
   vote-signer
   core
   fullnode


### PR DESCRIPTION
#### Problem
Rewards crates is being published, even though it's been depricated. In V0.12 it's dependencies are coming out to be unmet.

#### Summary of Changes
Removed the rewards crate from publish script.