### PR TITLE
[V0.12] Remove rewards crate from publishing script

### DIFF
--- a/ci/publish-crate.sh
+++ b/ci/publish-crate.sh
@@ -18,9 +18,9 @@ CRATES=(
   metrics
   client
   drone
-  programs/{budget_api,rewards_api,storage_api,token_api,vote_api}
+  programs/{budget_api,storage_api,token_api,vote_api}
   runtime
-  programs/{budget,bpf_loader,vote,rewards,storage,token,vote}
+  programs/{budget,bpf_loader,storage,token,vote}
   vote-signer
   core
   fullnode


### PR DESCRIPTION
#### Problem
Deprecated rewards crate is breaking crate publishing,

#### Summary of Changes
Remove the deprecated crate.