### PR TITLE
Mark book's javascript library as binary

### DIFF
--- a/book/.gitattributes
+++ b/book/.gitattributes
@@ -1,0 +1,1 @@
+theme/highlight.js binary


### PR DESCRIPTION
#### Problem

highlight.js has a big dictionary of words. When git-grep includes
one of those words, it floods the screen with the whole dictionary.

#### Summary of Changes

Mark it as binary so that it'll now just report one line:

     Binary file book/theme/highlight.js matches