### PR TITLE
Add SyncClient trait and Bank implementation

### DIFF
--- a/programs/failure_program/tests/failure.rs
+++ b/programs/failure_program/tests/failure.rs
@@ -1,24 +1,24 @@
 use solana_runtime::bank::Bank;
-use solana_runtime::bank_client::BankClient;
 use solana_runtime::loader_utils::{create_invoke_instruction, load_program};
+use solana_runtime::sync_client::SyncClient;
 use solana_sdk::genesis_block::GenesisBlock;
 use solana_sdk::instruction::InstructionError;
 use solana_sdk::native_loader;
+use solana_sdk::signature::KeypairUtil;
 use solana_sdk::transaction::TransactionError;
 
 #[test]
 fn test_program_native_failure() {
-    let (genesis_block, mint_keypair) = GenesisBlock::new(50);
+    let (genesis_block, alice_keypair) = GenesisBlock::new(50);
     let bank = Bank::new(&genesis_block);
-    let alice_client = BankClient::new(&bank, mint_keypair);
 
     let program = "failure".as_bytes().to_vec();
-    let program_id = load_program(&bank, &alice_client, &native_loader::id(), program);
+    let program_id = load_program(&bank, &alice_keypair, &native_loader::id(), program);
 
     // Call user program
-    let instruction = create_invoke_instruction(alice_client.pubkey(), program_id, &1u8);
+    let instruction = create_invoke_instruction(alice_keypair.pubkey(), program_id, &1u8);
     assert_eq!(
-        alice_client.process_instruction(instruction),
+        bank.send_instruction(&[&alice_keypair], instruction),
         Err(TransactionError::InstructionError(
             0,
             InstructionError::GenericError

--- a/programs/noop_program/tests/noop.rs
+++ b/programs/noop_program/tests/noop.rs
@@ -1,21 +1,22 @@
 use solana_runtime::bank::Bank;
-use solana_runtime::bank_client::BankClient;
 use solana_runtime::loader_utils::{create_invoke_instruction, load_program};
+use solana_runtime::sync_client::SyncClient;
 use solana_sdk::genesis_block::GenesisBlock;
 use solana_sdk::native_loader;
+use solana_sdk::signature::KeypairUtil;
 
 #[test]
 fn test_program_native_noop() {
     solana_logger::setup();
 
-    let (genesis_block, mint_keypair) = GenesisBlock::new(50);
+    let (genesis_block, alice_keypair) = GenesisBlock::new(50);
     let bank = Bank::new(&genesis_block);
-    let alice_client = BankClient::new(&bank, mint_keypair);
 
     let program = "noop".as_bytes().to_vec();
-    let program_id = load_program(&bank, &alice_client, &native_loader::id(), program);
+    let program_id = load_program(&bank, &alice_keypair, &native_loader::id(), program);
 
     // Call user program
-    let instruction = create_invoke_instruction(alice_client.pubkey(), program_id, &1u8);
-    alice_client.process_instruction(instruction).unwrap();
+    let instruction = create_invoke_instruction(alice_keypair.pubkey(), program_id, &1u8);
+    bank.send_instruction(&[&alice_keypair], instruction)
+        .unwrap();
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -8,7 +8,7 @@ pub mod loader_utils;
 mod native_loader;
 pub mod runtime;
 mod status_cache;
-mod sync_client;
+pub mod sync_client;
 mod system_program;
 
 #[macro_use]

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -8,6 +8,7 @@ pub mod loader_utils;
 mod native_loader;
 pub mod runtime;
 mod status_cache;
+mod sync_client;
 mod system_program;
 
 #[macro_use]

--- a/runtime/src/sync_client.rs
+++ b/runtime/src/sync_client.rs
@@ -1,0 +1,106 @@
+use crate::bank::Bank;
+use solana_sdk::instruction::Instruction;
+use solana_sdk::pubkey::Pubkey;
+use solana_sdk::signature::{Keypair, KeypairUtil};
+use solana_sdk::system_instruction::SystemInstruction;
+use solana_sdk::transaction::{Transaction, TransactionError};
+
+// A client where each method waits for the server to complete before returning.
+pub trait SyncClient {
+    fn send_transaction(
+        &self,
+        keypairs: &[&Keypair],
+        tx: Transaction,
+    ) -> Result<(), TransactionError>;
+
+    /// Create and process a transaction from a list of instructions.
+    fn send_instructions(
+        &self,
+        keypairs: &[&Keypair],
+        instructions: Vec<Instruction>,
+    ) -> Result<(), TransactionError>;
+
+    /// Create and process a transaction from a single instruction.
+    fn send_instruction(
+        &self,
+        keypairs: &[&Keypair],
+        instruction: Instruction,
+    ) -> Result<(), TransactionError>;
+
+    /// Transfer lamports to pubkey
+    fn pay(
+        &self,
+        from_keypair: &Keypair,
+        to_pubkey: &Pubkey,
+        lamports: u64,
+    ) -> Result<(), TransactionError>;
+}
+
+impl SyncClient for Bank {
+    fn send_transaction(
+        &self,
+        keypairs: &[&Keypair],
+        mut tx: Transaction,
+    ) -> Result<(), TransactionError> {
+        tx.sign(keypairs, self.last_blockhash());
+        self.process_transaction(&tx)
+    }
+
+    /// Create and process a transaction from a list of instructions.
+    fn send_instructions(
+        &self,
+        keypairs: &[&Keypair],
+        instructions: Vec<Instruction>,
+    ) -> Result<(), TransactionError> {
+        self.send_transaction(keypairs, Transaction::new(instructions))
+    }
+
+    /// Create and process a transaction from a single instruction.
+    fn send_instruction(
+        &self,
+        keypairs: &[&Keypair],
+        instruction: Instruction,
+    ) -> Result<(), TransactionError> {
+        self.send_instructions(keypairs, vec![instruction])
+    }
+
+    /// Transfer lamports to pubkey
+    fn pay(
+        &self,
+        from_keypair: &Keypair,
+        to_pubkey: &Pubkey,
+        lamports: u64,
+    ) -> Result<(), TransactionError> {
+        let move_instruction =
+            SystemInstruction::new_move(&from_keypair.pubkey(), to_pubkey, lamports);
+        self.send_instruction(&[from_keypair], move_instruction)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use solana_sdk::genesis_block::GenesisBlock;
+    use solana_sdk::instruction::AccountMeta;
+
+    #[test]
+    fn test_sync_client_new_with_keypairs() {
+        let (genesis_block, john_doe_keypair) = GenesisBlock::new(10_000);
+        let john_pubkey = john_doe_keypair.pubkey();
+        let jane_doe_keypair = Keypair::new();
+        let jane_pubkey = jane_doe_keypair.pubkey();
+        let doe_keypairs = vec![&john_doe_keypair, &jane_doe_keypair];
+        let bank = Bank::new(&genesis_block);
+
+        // Create 2-2 Multisig Move instruction.
+        let bob_pubkey = Keypair::new().pubkey();
+        let mut move_instruction = SystemInstruction::new_move(&john_pubkey, &bob_pubkey, 42);
+        move_instruction
+            .accounts
+            .push(AccountMeta::new(jane_pubkey, true));
+
+        bank.send_instruction(&doe_keypairs, move_instruction)
+            .unwrap();
+        assert_eq!(bank.get_balance(&bob_pubkey), 42);
+    }
+}


### PR DESCRIPTION
#### Problem

It's tricky to jump between solana_runtime and testnet. BankClient consumes keypairs, which is constraining and inconsistent with the other clients.

#### Summary of Changes

Introduce a SyncClient trait instead of wrapping Bank/Keypairs and implement that trait with Bank.  The role of a SyncClient would be to update the transaction's blockhash, sign it, and resend as needed.

TODO:
- [x] Attempt to replace uses of BankClient with this and see if this is better
- [ ] Replace all instances of BankClient
- [ ] Make Message pub
- [ ] Whittle down SyncClient to just send_message()
- [ ] Wrap TransactionError with a new TransportError type
- [ ] Move the trait definition into the SDK

Fixes #3058