### PR TITLE
delay freeze of status_cache until squash

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -304,7 +304,11 @@ impl Bank {
 
         let parent_caches: Vec<_> = parents
             .iter()
-            .map(|b| b.status_cache.read().unwrap())
+            .map(|p| {
+                let mut parent = p.status_cache.write().unwrap();
+                parent.freeze();
+                parent
+            })
             .collect();
         self.status_cache.write().unwrap().squash(&parent_caches);
     }


### PR DESCRIPTION

#### Problem
 a race between the bank freezing and final transactions being committed exists in banking_stage that causes status updates to fail if the status_cache is frozen after a record, but while some transactions remain to be committed on other threads

 #### Summary of Changes
 delay status_cache freeze() until squash