### PR TITLE
remove status_cache.freeze() from bank.freeze()

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -246,7 +246,7 @@ impl Bank {
             //  freeze is a one-way trip, idempotent
             *hash = self.hash_internal_state();
         }
-        self.status_cache.write().unwrap().freeze();
+        //        self.status_cache.write().unwrap().freeze();
     }
 
     /// squash the parent's state up into this Bank,


### PR DESCRIPTION
#### Problem
 status_cache can still be active in banking_stage after a bank.freeze()

 #### Summary of Changes
 remove freeze() (for now)