### PR TITLE
Create transactions from messages

### DIFF
--- a/bench-tps/src/bench.rs
+++ b/bench-tps/src/bench.rs
@@ -564,7 +564,10 @@ fn fund_keys(client: &ThinClient, source: &Keypair, dests: &[Keypair], lamports:
                 .map(|(k, m)| {
                     (
                         k.clone(),
-                        Transaction::new(SystemInstruction::new_move_many(&k.pubkey(), &m)),
+                        Transaction::new_unsigned_instructions(SystemInstruction::new_move_many(
+                            &k.pubkey(),
+                            &m,
+                        )),
                     )
                 })
                 .collect();

--- a/core/src/replicator.rs
+++ b/core/src/replicator.rs
@@ -410,7 +410,7 @@ impl Replicator {
             self.slot,
             Signature::new(self.signature.as_ref()),
         );
-        let mut tx = Transaction::new(vec![ix]);
+        let mut tx = Transaction::new_unsigned_instructions(vec![ix]);
         client
             .retry_transfer(&self.keypair, &mut tx, 10)
             .expect("transfer didn't work!");

--- a/core/src/storage_stage.rs
+++ b/core/src/storage_stage.rs
@@ -293,7 +293,7 @@ impl StorageStage {
             entry_id,
             entry_height,
         );
-        let tx = Transaction::new(vec![ix]);
+        let tx = Transaction::new_unsigned_instructions(vec![ix]);
         tx_sender.send(tx)?;
 
         seed.copy_from_slice(&signature.as_ref()[..32]);
@@ -611,7 +611,7 @@ mod tests {
             0,
             keypair.sign_message(b"test"),
         );
-        let mining_proof_tx = Transaction::new(vec![mining_proof_ix]);
+        let mining_proof_tx = Transaction::new_unsigned_instructions(vec![mining_proof_ix]);
         let mining_txs = vec![mining_proof_tx];
 
         let proof_entries = vec![Entry::new(&Hash::default(), 1, mining_txs)];

--- a/install/src/command.rs
+++ b/install/src/command.rs
@@ -203,7 +203,7 @@ fn new_update_manifest(
             &update_manifest_keypair.pubkey(),
             1, // lamports
         );
-        let mut transaction = Transaction::new(vec![new_account]);
+        let mut transaction = Transaction::new_unsigned_instructions(vec![new_account]);
         transaction.sign(&[from_keypair], recect_blockhash);
 
         rpc_client.send_and_confirm_transaction(&mut transaction, from_keypair)?;
@@ -225,7 +225,7 @@ fn store_update_manifest(
         &update_manifest_keypair.pubkey(),
         update_manifest,
     );
-    let mut transaction = Transaction::new(vec![new_store]);
+    let mut transaction = Transaction::new_unsigned_instructions(vec![new_store]);
     transaction.sign(&[from_keypair, update_manifest_keypair], recect_blockhash);
     rpc_client.send_and_confirm_transaction(&mut transaction, from_keypair)?;
     Ok(())

--- a/programs/budget_api/src/budget_processor.rs
+++ b/programs/budget_api/src/budget_processor.rs
@@ -196,7 +196,7 @@ mod tests {
         alice_client.transfer(1, &mallory_pubkey).unwrap();
         let instruction =
             BudgetInstruction::new_apply_signature(&mallory_pubkey, &budget_pubkey, &bob_pubkey);
-        let mut transaction = Transaction::new(vec![instruction]);
+        let mut transaction = Transaction::new_unsigned_instructions(vec![instruction]);
 
         // Attack! Part 2: Point the instruction to the expected, but unsigned, key.
         transaction.account_keys.push(alice_pubkey);
@@ -243,7 +243,7 @@ mod tests {
             &bob_pubkey,
             dt,
         );
-        let mut transaction = Transaction::new(vec![instruction]);
+        let mut transaction = Transaction::new_unsigned_instructions(vec![instruction]);
 
         // Attack! Part 2: Point the instruction to the expected, but unsigned, key.
         transaction.account_keys.push(alice_pubkey);

--- a/programs/config_api/src/config_processor.rs
+++ b/programs/config_api/src/config_processor.rs
@@ -131,7 +131,7 @@ mod tests {
         let instruction = ConfigInstruction::new_store(&from_pubkey, &config_pubkey, &my_config);
 
         // Replace instruction data with a vector that's too large
-        let mut transaction = Transaction::new(vec![instruction]);
+        let mut transaction = Transaction::new_unsigned_instructions(vec![instruction]);
         transaction.instructions[0].data = vec![0; 123];
         config_client.process_transaction(transaction).unwrap_err();
     }
@@ -153,7 +153,8 @@ mod tests {
             ConfigInstruction::new_store(&from_pubkey, &config_pubkey, &my_config);
 
         // Don't sign the transaction with `config_client`
-        let mut transaction = Transaction::new(vec![move_instruction, store_instruction]);
+        let mut transaction =
+            Transaction::new_unsigned_instructions(vec![move_instruction, store_instruction]);
         transaction.sign_unchecked(&[&system_keypair], bank.last_blockhash());
         let system_client = BankClient::new(&bank, system_keypair);
         system_client.process_transaction(transaction).unwrap_err();

--- a/programs/exchange_api/src/exchange_transaction.rs
+++ b/programs/exchange_api/src/exchange_transaction.rs
@@ -21,7 +21,7 @@ impl ExchangeTransaction {
         let space = mem::size_of::<ExchangeState>() as u64;
         let create_ix = SystemInstruction::new_program_account(owner_id, new, 1, space, &id());
         let request_ix = ExchangeInstruction::new_account_request(owner_id, new);
-        let mut tx = Transaction::new(vec![create_ix, request_ix]);
+        let mut tx = Transaction::new_unsigned_instructions(vec![create_ix, request_ix]);
         tx.fee = fee;
         tx.sign(&[owner], recent_blockhash);
         tx
@@ -39,7 +39,7 @@ impl ExchangeTransaction {
         let owner_id = &owner.pubkey();
         let request_ix =
             ExchangeInstruction::new_transfer_request(owner_id, to, from, token, tokens);
-        let mut tx = Transaction::new(vec![request_ix]);
+        let mut tx = Transaction::new_unsigned_instructions(vec![request_ix]);
         tx.fee = fee;
         tx.sign(&[owner], recent_blockhash);
         tx
@@ -71,7 +71,7 @@ impl ExchangeTransaction {
             src_account,
             dst_account,
         );
-        let mut tx = Transaction::new(vec![create_ix, request_ix]);
+        let mut tx = Transaction::new_unsigned_instructions(vec![create_ix, request_ix]);
         tx.fee = fee;
         tx.sign(&[owner], recent_blockhash);
         tx
@@ -86,7 +86,7 @@ impl ExchangeTransaction {
     ) -> Transaction {
         let owner_id = &owner.pubkey();
         let request_ix = ExchangeInstruction::new_trade_cancellation(owner_id, trade, account);
-        let mut tx = Transaction::new(vec![request_ix]);
+        let mut tx = Transaction::new_unsigned_instructions(vec![request_ix]);
         tx.fee = fee;
         tx.sign(&[owner], recent_blockhash);
         tx
@@ -115,7 +115,7 @@ impl ExchangeTransaction {
             from_trade_account,
             profit_account,
         );
-        let mut tx = Transaction::new(vec![create_ix, request_ix]);
+        let mut tx = Transaction::new_unsigned_instructions(vec![create_ix, request_ix]);
         tx.fee = fee;
         tx.sign(&[owner], recent_blockhash);
         tx

--- a/runtime/src/bank_client.rs
+++ b/runtime/src/bank_client.rs
@@ -43,7 +43,7 @@ impl<'a> BankClient<'a> {
         &self,
         instructions: Vec<Instruction>,
     ) -> Result<(), TransactionError> {
-        self.process_transaction(Transaction::new(instructions))
+        self.process_transaction(Transaction::new_unsigned_instructions(instructions))
     }
 
     /// Create and process a transaction from a single instruction.

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -4,7 +4,7 @@ pub mod genesis_block;
 pub mod hash;
 pub mod instruction;
 pub mod loader_instruction;
-mod message;
+pub mod message;
 pub mod native_loader;
 pub mod native_program;
 pub mod packet;

--- a/sdk/src/transaction.rs
+++ b/sdk/src/transaction.rs
@@ -72,7 +72,7 @@ pub struct Transaction {
 }
 
 impl Transaction {
-    fn new_unsigned_message(message: Message) -> Self {
+    pub fn new_unsigned(message: Message) -> Self {
         Self {
             signatures: Vec::with_capacity(message.num_signatures as usize),
             account_keys: message.account_keys,
@@ -85,7 +85,7 @@ impl Transaction {
 
     pub fn new_unsigned_instructions(instructions: Vec<Instruction>) -> Self {
         let message = Message::new(instructions);
-        Self::new_unsigned_message(message)
+        Self::new_unsigned(message)
     }
 
     pub fn new<T: KeypairUtil>(
@@ -93,7 +93,7 @@ impl Transaction {
         message: Message,
         recent_blockhash: Hash,
     ) -> Transaction {
-        let mut tx = Self::new_unsigned_message(message);
+        let mut tx = Self::new_unsigned(message);
         tx.sign(from_keypairs, recent_blockhash);
         tx
     }

--- a/sdk/src/transaction.rs
+++ b/sdk/src/transaction.rs
@@ -83,7 +83,7 @@ impl Transaction {
         }
     }
 
-    pub fn new(instructions: Vec<Instruction>) -> Self {
+    pub fn new_unsigned_instructions(instructions: Vec<Instruction>) -> Self {
         let message = Message::new(instructions);
         Self::new_unsigned_message(message)
     }
@@ -576,7 +576,7 @@ mod tests {
     #[should_panic]
     fn test_transaction_missing_key() {
         let keypair = Keypair::new();
-        Transaction::new(vec![]).sign(&[&keypair], Hash::default());
+        Transaction::new_unsigned_instructions(vec![]).sign(&[&keypair], Hash::default());
     }
 
     #[test]
@@ -586,7 +586,8 @@ mod tests {
         let keypair0 = Keypair::new();
         let id0 = keypair0.pubkey();
         let ix = Instruction::new(program_id, &0, vec![AccountMeta::new(id0, true)]);
-        Transaction::new(vec![ix]).sign(&Vec::<&Keypair>::new(), Hash::default());
+        Transaction::new_unsigned_instructions(vec![ix])
+            .sign(&Vec::<&Keypair>::new(), Hash::default());
     }
 
     #[test]
@@ -596,7 +597,7 @@ mod tests {
         let keypair0 = Keypair::new();
         let wrong_id = Pubkey::default();
         let ix = Instruction::new(program_id, &0, vec![AccountMeta::new(wrong_id, true)]);
-        Transaction::new(vec![ix]).sign(&[&keypair0], Hash::default());
+        Transaction::new_unsigned_instructions(vec![ix]).sign(&[&keypair0], Hash::default());
     }
 
     #[test]
@@ -605,7 +606,7 @@ mod tests {
         let keypair0 = Keypair::new();
         let id0 = keypair0.pubkey();
         let ix = Instruction::new(program_id, &0, vec![AccountMeta::new(id0, true)]);
-        let mut tx = Transaction::new(vec![ix]);
+        let mut tx = Transaction::new_unsigned_instructions(vec![ix]);
         tx.sign(&[&keypair0], Hash::default());
         assert_eq!(tx.instructions[0], CompiledInstruction::new(0, &0, vec![0]));
     }


### PR DESCRIPTION
#### Problem

Transaction currently has two sets of constructors, one for creating unsigned transactions, and one for creating signed transactions. There's a new data type Message that can represent all unsigned transactions, but it's currently a private module.

#### Summary of Changes

* Rename `Transaction::new to Transaction::new_unsigned_instructions`
* pub message
* Add `Transaction::new(keypairs, message, recent_blockhash)`
* Add `Transaction::new_unsigned(message)`
