### PR TITLE
Simplify storage interface in blocktree

### DIFF
--- a/core/src/blocktree/db.rs
+++ b/core/src/blocktree/db.rs
@@ -11,8 +11,8 @@ use std::sync::Arc;
 
 pub trait Database: Sized + Send + Sync {
     type Error: Into<Error>;
-    type Key: Borrow<Self::KeyRef>;
-    type KeyRef: ?Sized;
+    type Key: ?Sized;
+    type OwnedKey: Borrow<Self::Key>;
     type ColumnFamily;
     type Cursor: Cursor<Self>;
     type EntryIter: Iterator<Item = Entry>;
@@ -20,11 +20,11 @@ pub trait Database: Sized + Send + Sync {
 
     fn cf_handle(&self, cf: &str) -> Option<Self::ColumnFamily>;
 
-    fn get_cf(&self, cf: Self::ColumnFamily, key: &Self::KeyRef) -> Result<Option<Vec<u8>>>;
+    fn get_cf(&self, cf: Self::ColumnFamily, key: &Self::Key) -> Result<Option<Vec<u8>>>;
 
-    fn put_cf(&self, cf: Self::ColumnFamily, key: &Self::KeyRef, data: &[u8]) -> Result<()>;
+    fn put_cf(&self, cf: Self::ColumnFamily, key: &Self::Key, data: &[u8]) -> Result<()>;
 
-    fn delete_cf(&self, cf: Self::ColumnFamily, key: &Self::KeyRef) -> Result<()>;
+    fn delete_cf(&self, cf: Self::ColumnFamily, key: &Self::Key) -> Result<()>;
 
     fn raw_iterator_cf(&self, cf: Self::ColumnFamily) -> Result<Self::Cursor>;
 
@@ -36,93 +36,25 @@ pub trait Database: Sized + Send + Sync {
 pub trait Cursor<D: Database> {
     fn valid(&self) -> bool;
 
-    fn seek(&mut self, key: &D::KeyRef);
+    fn seek(&mut self, key: &D::Key);
 
     fn seek_to_first(&mut self);
 
     fn next(&mut self);
 
-    fn key(&self) -> Option<D::Key>;
+    fn key(&self) -> Option<D::OwnedKey>;
 
     fn value(&self) -> Option<Vec<u8>>;
 }
 
 pub trait IWriteBatch<D: Database> {
-    fn put_cf(&mut self, cf: D::ColumnFamily, key: &D::KeyRef, data: &[u8]) -> Result<()>;
+    fn put_cf(&mut self, cf: D::ColumnFamily, key: &D::Key, data: &[u8]) -> Result<()>;
 }
 
-pub trait IDataCf<D: Database>: LedgerColumnFamilyRaw<D> {
-    fn new(db: Arc<D>) -> Self;
-
-    fn get_by_slot_index(&self, slot: u64, index: u64) -> Result<Option<Vec<u8>>> {
-        let key = Self::key(slot, index);
-        self.get(key.borrow())
-    }
-
-    fn delete_by_slot_index(&self, slot: u64, index: u64) -> Result<()> {
-        let key = Self::key(slot, index);
-        self.delete(&key.borrow())
-    }
-
-    fn put_by_slot_index(&self, slot: u64, index: u64, serialized_value: &[u8]) -> Result<()> {
-        let key = Self::key(slot, index);
-        self.put(key.borrow(), serialized_value)
-    }
-
-    fn key(slot: u64, index: u64) -> D::Key;
-
-    fn slot_from_key(key: &D::KeyRef) -> Result<u64>;
-
-    fn index_from_key(key: &D::KeyRef) -> Result<u64>;
-}
-
-pub trait IErasureCf<D: Database>: LedgerColumnFamilyRaw<D> {
-    fn new(db: Arc<D>) -> Self;
-
-    fn delete_by_slot_index(&self, slot: u64, index: u64) -> Result<()> {
-        let key = Self::key(slot, index);
-        self.delete(key.borrow())
-    }
-
-    fn get_by_slot_index(&self, slot: u64, index: u64) -> Result<Option<Vec<u8>>> {
-        let key = Self::key(slot, index);
-        self.get(key.borrow())
-    }
-
-    fn put_by_slot_index(&self, slot: u64, index: u64, serialized_value: &[u8]) -> Result<()> {
-        let key = Self::key(slot, index);
-        self.put(key.borrow(), serialized_value)
-    }
-
-    fn key(slot: u64, index: u64) -> D::Key;
-
-    fn slot_from_key(key: &D::KeyRef) -> Result<u64>;
-
-    fn index_from_key(key: &D::KeyRef) -> Result<u64>;
-}
-
-pub trait IMetaCf<D: Database>: LedgerColumnFamily<D, ValueType = super::SlotMeta> {
-    fn new(db: Arc<D>) -> Self;
-
-    fn key(slot: u64) -> D::Key;
-
-    fn get_slot_meta(&self, slot: u64) -> Result<Option<super::SlotMeta>> {
-        let key = Self::key(slot);
-        self.get(key.borrow())
-    }
-
-    fn put_slot_meta(&self, slot: u64, slot_meta: &super::SlotMeta) -> Result<()> {
-        let key = Self::key(slot);
-        self.put(key.borrow(), slot_meta)
-    }
-
-    fn index_from_key(key: &D::KeyRef) -> Result<u64>;
-}
-
-pub trait LedgerColumnFamily<D: Database> {
+pub trait LedgerColumnFamily<D: Database>: LedgerColumnFamilyRaw<D> {
     type ValueType: DeserializeOwned + Serialize;
 
-    fn get(&self, key: &D::KeyRef) -> Result<Option<Self::ValueType>> {
+    fn get(&self, key: &D::Key) -> Result<Option<Self::ValueType>> {
         let db = self.db();
         let data_bytes = db.get_cf(self.handle(), key)?;
 
@@ -134,52 +66,30 @@ pub trait LedgerColumnFamily<D: Database> {
         }
     }
 
-    fn get_bytes(&self, key: &D::KeyRef) -> Result<Option<Vec<u8>>> {
-        let db = self.db();
-        let data_bytes = db.get_cf(self.handle(), key)?;
-        Ok(data_bytes.map(|x| x.to_vec()))
-    }
-
-    fn put_bytes(&self, key: &D::KeyRef, serialized_value: &[u8]) -> Result<()> {
-        let db = self.db();
-        db.put_cf(self.handle(), key, &serialized_value)?;
-        Ok(())
-    }
-
-    fn put(&self, key: &D::KeyRef, value: &Self::ValueType) -> Result<()> {
+    fn put(&self, key: &D::Key, value: &Self::ValueType) -> Result<()> {
         let db = self.db();
         let serialized = serialize(value)?;
         db.put_cf(self.handle(), key, &serialized)?;
         Ok(())
     }
-
-    fn delete(&self, key: &D::KeyRef) -> Result<()> {
-        let db = self.db();
-        db.delete_cf(self.handle(), key)?;
-        Ok(())
-    }
-
-    fn db(&self) -> &Arc<D>;
-
-    fn handle(&self) -> D::ColumnFamily;
 }
 
 pub trait LedgerColumnFamilyRaw<D: Database> {
-    fn get(&self, key: &D::KeyRef) -> Result<Option<Vec<u8>>> {
+    fn get_bytes(&self, key: &D::Key) -> Result<Option<Vec<u8>>> {
         let db = self.db();
-        let data_bytes = db.get_cf(self.handle(), key)?;
+        let data_bytes = db.get_cf(self.handle(), key.borrow())?;
         Ok(data_bytes.map(|x| x.to_vec()))
     }
 
-    fn put(&self, key: &D::KeyRef, serialized_value: &[u8]) -> Result<()> {
+    fn put_bytes(&self, key: &D::Key, serialized_value: &[u8]) -> Result<()> {
         let db = self.db();
-        db.put_cf(self.handle(), &key, &serialized_value)?;
+        db.put_cf(self.handle(), key.borrow(), &serialized_value)?;
         Ok(())
     }
 
-    fn delete(&self, key: &D::KeyRef) -> Result<()> {
+    fn delete(&self, key: &D::Key) -> Result<()> {
         let db = self.db();
-        db.delete_cf(self.handle(), &key)?;
+        db.delete_cf(self.handle(), key.borrow())?;
         Ok(())
     }
 
@@ -192,4 +102,28 @@ pub trait LedgerColumnFamilyRaw<D: Database> {
     fn handle(&self) -> D::ColumnFamily;
 
     fn db(&self) -> &Arc<D>;
+}
+
+pub trait IndexColumn<D: Database>: LedgerColumnFamilyRaw<D> {
+    type Index;
+
+    fn get_by_index(&self, index: &Self::Index) -> Result<Option<Vec<u8>>> {
+        let db = self.db();
+        let data_bytes = db.get_cf(self.handle(), Self::key(index).borrow())?;
+        Ok(data_bytes.map(|x| x.to_vec()))
+    }
+
+    fn put_by_index(&self, index: &Self::Index, serialized_value: &[u8]) -> Result<()> {
+        let db = self.db();
+        db.put_cf(self.handle(), Self::key(index).borrow(), &serialized_value)?;
+        Ok(())
+    }
+
+    fn delete_by_index(&self, index: &Self::Index) -> Result<()> {
+        self.delete(Self::key(index).borrow())
+    }
+
+    fn index(key: &D::Key) -> Self::Index;
+
+    fn key(index: &Self::Index) -> D::OwnedKey;
 }

--- a/core/src/blocktree/kvs.rs
+++ b/core/src/blocktree/kvs.rs
@@ -1,13 +1,12 @@
 use crate::entry::Entry;
 use crate::packet::Blob;
 use crate::result::{Error, Result};
+use byteorder::{BigEndian, ByteOrder};
 use solana_kvstore::{self as kvstore, Key, KvStore};
-
 use std::sync::Arc;
 
 use super::db::{
-    Cursor, Database, IDataCf, IErasureCf, IMetaCf, IWriteBatch, LedgerColumnFamily,
-    LedgerColumnFamilyRaw,
+    Cursor, Database, IWriteBatch, IndexColumn, LedgerColumnFamily, LedgerColumnFamilyRaw,
 };
 use super::{Blocktree, BlocktreeError};
 
@@ -68,7 +67,7 @@ impl Blocktree {
 impl Database for Kvs {
     type Error = kvstore::Error;
     type Key = Key;
-    type KeyRef = Key;
+    type OwnedKey = Key;
     type ColumnFamily = ColumnFamily;
     type Cursor = KvsCursor;
     type EntryIter = EntryIterator;
@@ -135,88 +134,6 @@ impl IWriteBatch<Kvs> for KvsWriteBatch {
     }
 }
 
-impl IDataCf<Kvs> for DataCf {
-    fn new(db: Arc<Kvs>) -> Self {
-        DataCf { db }
-    }
-
-    fn get_by_slot_index(&self, _slot: u64, _index: u64) -> Result<Option<Vec<u8>>> {
-        unimplemented!()
-    }
-
-    fn delete_by_slot_index(&self, _slot: u64, _index: u64) -> Result<()> {
-        unimplemented!()
-    }
-
-    fn put_by_slot_index(&self, _slot: u64, _index: u64, _serialized_value: &[u8]) -> Result<()> {
-        unimplemented!()
-    }
-
-    fn key(_slot: u64, _index: u64) -> Key {
-        unimplemented!()
-    }
-
-    fn slot_from_key(_key: &Key) -> Result<u64> {
-        unimplemented!()
-    }
-
-    fn index_from_key(_key: &Key) -> Result<u64> {
-        unimplemented!()
-    }
-}
-
-impl IErasureCf<Kvs> for ErasureCf {
-    fn new(db: Arc<Kvs>) -> Self {
-        ErasureCf { db }
-    }
-
-    fn delete_by_slot_index(&self, _slot: u64, _index: u64) -> Result<()> {
-        unimplemented!()
-    }
-
-    fn get_by_slot_index(&self, _slot: u64, _index: u64) -> Result<Option<Vec<u8>>> {
-        unimplemented!()
-    }
-
-    fn put_by_slot_index(&self, _slot: u64, _index: u64, _serialized_value: &[u8]) -> Result<()> {
-        unimplemented!()
-    }
-
-    fn key(slot: u64, index: u64) -> Key {
-        DataCf::key(slot, index)
-    }
-
-    fn slot_from_key(key: &Key) -> Result<u64> {
-        DataCf::slot_from_key(key)
-    }
-
-    fn index_from_key(key: &Key) -> Result<u64> {
-        DataCf::index_from_key(key)
-    }
-}
-
-impl IMetaCf<Kvs> for MetaCf {
-    fn new(db: Arc<Kvs>) -> Self {
-        MetaCf { db }
-    }
-
-    fn key(_slot: u64) -> Key {
-        unimplemented!()
-    }
-
-    fn get_slot_meta(&self, _slot: u64) -> Result<Option<super::SlotMeta>> {
-        unimplemented!()
-    }
-
-    fn put_slot_meta(&self, _slot: u64, _slot_meta: &super::SlotMeta) -> Result<()> {
-        unimplemented!()
-    }
-
-    fn index_from_key(_key: &Key) -> Result<u64> {
-        unimplemented!()
-    }
-}
-
 impl LedgerColumnFamilyRaw<Kvs> for DataCf {
     fn db(&self) -> &Arc<Kvs> {
         &self.db
@@ -224,6 +141,20 @@ impl LedgerColumnFamilyRaw<Kvs> for DataCf {
 
     fn handle(&self) -> ColumnFamily {
         self.db.cf_handle(super::DATA_CF).unwrap()
+    }
+}
+
+impl IndexColumn<Kvs> for DataCf {
+    type Index = (u64, u64);
+
+    fn index(key: &Key) -> (u64, u64) {
+        let slot = BigEndian::read_u64(&key.0[8..16]);
+        let index = BigEndian::read_u64(&key.0[16..24]);
+        (slot, index)
+    }
+
+    fn key(idx: &(u64, u64)) -> Key {
+        Key::from((0, idx.0, idx.1))
     }
 }
 
@@ -237,15 +168,43 @@ impl LedgerColumnFamilyRaw<Kvs> for ErasureCf {
     }
 }
 
-impl LedgerColumnFamily<Kvs> for MetaCf {
-    type ValueType = super::SlotMeta;
+impl IndexColumn<Kvs> for ErasureCf {
+    type Index = (u64, u64);
 
+    fn index(key: &Key) -> (u64, u64) {
+        DataCf::index(key)
+    }
+
+    fn key(idx: &(u64, u64)) -> Key {
+        DataCf::key(idx)
+    }
+}
+
+impl LedgerColumnFamilyRaw<Kvs> for MetaCf {
     fn db(&self) -> &Arc<Kvs> {
         &self.db
     }
 
     fn handle(&self) -> ColumnFamily {
         self.db.cf_handle(super::META_CF).unwrap()
+    }
+}
+
+impl LedgerColumnFamily<Kvs> for MetaCf {
+    type ValueType = super::SlotMeta;
+}
+
+impl IndexColumn<Kvs> for MetaCf {
+    type Index = u64;
+
+    fn index(key: &Key) -> u64 {
+        BigEndian::read_u64(&key.0[8..16])
+    }
+
+    fn key(slot: &u64) -> Key {
+        let mut key = Key::default();
+        BigEndian::write_u64(&mut key.0[8..16], *slot);
+        key
     }
 }
 


### PR DESCRIPTION
#### Problem
unnecessarily complex and unneeded types
#### Summary of Changes
get rid of `I(Meta|Data|Erasure)Cf` traits because they all just added a notion of mapping to the key type
No functional changes
