### PR TITLE
Migrate BankClient to Message

### DIFF
--- a/core/src/blocktree_processor.rs
+++ b/core/src/blocktree_processor.rs
@@ -568,14 +568,8 @@ mod tests {
         let keypair3 = Keypair::new();
 
         // fund: put 4 in each of 1 and 2
-        assert_matches!(
-            bank.transfer(4, &mint_keypair, &keypair1.pubkey(), bank.last_blockhash()),
-            Ok(_)
-        );
-        assert_matches!(
-            bank.transfer(4, &mint_keypair, &keypair2.pubkey(), bank.last_blockhash()),
-            Ok(_)
-        );
+        assert_matches!(bank.transfer(4, &mint_keypair, &keypair1.pubkey()), Ok(_));
+        assert_matches!(bank.transfer(4, &mint_keypair, &keypair2.pubkey()), Ok(_));
 
         // construct an Entry whose 2nd transaction would cause a lock conflict with previous entry
         let entry_1_to_mint = next_entry(

--- a/core/src/leader_confirmation_service.rs
+++ b/core/src/leader_confirmation_service.rs
@@ -144,8 +144,6 @@ mod tests {
             bank = Arc::new(Bank::new_from_parent(&bank, &Pubkey::default(), slot));
         }
 
-        let blockhash = bank.last_blockhash();
-
         // Create a total of 10 vote accounts, each will have a balance of 1 (after giving 1 to
         // their vote account), for a total staking pool of 10 lamports.
         let vote_accounts: Vec<_> = (0..10)
@@ -156,7 +154,7 @@ mod tests {
                 let voting_pubkey = voting_keypair.pubkey();
 
                 // Give the validator some lamports
-                bank.transfer(2, &mint_keypair, &validator_keypair.pubkey(), blockhash)
+                bank.transfer(2, &mint_keypair, &validator_keypair.pubkey())
                     .unwrap();
                 new_vote_account(&validator_keypair, &voting_pubkey, &bank, 1);
 
@@ -177,6 +175,7 @@ mod tests {
         assert_eq!(last_confirmation_time, 0);
 
         // Get another validator to vote, so we now have 2/3 consensus
+        let blockhash = bank.last_blockhash();
         let voting_keypair = &vote_accounts[7].0;
         let vote = Vote::new(MAX_RECENT_BLOCKHASHES as u64);
         let vote_ix = VoteInstruction::new_vote(&voting_keypair.pubkey(), vote);

--- a/core/src/staking_utils.rs
+++ b/core/src/staking_utils.rs
@@ -193,7 +193,7 @@ mod tests {
         // Give the validator some stake but don't setup a staking account
         // Validator has no lamports staked, so they get filtered out. Only the bootstrap leader
         // created by the genesis block will get included
-        bank.transfer(1, &mint_keypair, &validator.pubkey(), genesis_block.hash())
+        bank.transfer(1, &mint_keypair, &validator.pubkey())
             .unwrap();
 
         // Make a mint vote account. Because the mint has nonzero stake, this

--- a/programs/budget_api/src/budget_processor.rs
+++ b/programs/budget_api/src/budget_processor.rs
@@ -149,8 +149,9 @@ mod tests {
     use solana_runtime::bank_client::BankClient;
     use solana_sdk::genesis_block::GenesisBlock;
     use solana_sdk::instruction::InstructionError;
+    use solana_sdk::message::Message;
     use solana_sdk::signature::{Keypair, KeypairUtil};
-    use solana_sdk::transaction::{Transaction, TransactionError};
+    use solana_sdk::transaction::TransactionError;
 
     fn create_bank(lamports: u64) -> (Bank, Keypair) {
         let (genesis_block, mint_keypair) = GenesisBlock::new(lamports);
@@ -196,15 +197,15 @@ mod tests {
         alice_client.transfer(1, &mallory_pubkey).unwrap();
         let instruction =
             BudgetInstruction::new_apply_signature(&mallory_pubkey, &budget_pubkey, &bob_pubkey);
-        let mut transaction = Transaction::new_unsigned_instructions(vec![instruction]);
+        let mut message = Message::new(vec![instruction]);
 
         // Attack! Part 2: Point the instruction to the expected, but unsigned, key.
-        transaction.account_keys.push(alice_pubkey);
-        transaction.instructions[0].accounts[0] = 3;
+        message.account_keys.push(alice_pubkey);
+        message.instructions[0].accounts[0] = 3;
 
         // Ensure the transaction fails because of the unsigned key.
         assert_eq!(
-            mallory_client.process_transaction(transaction),
+            mallory_client.process_message(message),
             Err(TransactionError::InstructionError(
                 0,
                 InstructionError::MissingRequiredSignature
@@ -243,15 +244,15 @@ mod tests {
             &bob_pubkey,
             dt,
         );
-        let mut transaction = Transaction::new_unsigned_instructions(vec![instruction]);
+        let mut message = Message::new(vec![instruction]);
 
         // Attack! Part 2: Point the instruction to the expected, but unsigned, key.
-        transaction.account_keys.push(alice_pubkey);
-        transaction.instructions[0].accounts[0] = 3;
+        message.account_keys.push(alice_pubkey);
+        message.instructions[0].accounts[0] = 3;
 
         // Ensure the transaction fails because of the unsigned key.
         assert_eq!(
-            mallory_client.process_transaction(transaction),
+            mallory_client.process_message(message),
             Err(TransactionError::InstructionError(
                 0,
                 InstructionError::MissingRequiredSignature

--- a/programs/budget_api/src/budget_processor.rs
+++ b/programs/budget_api/src/budget_processor.rs
@@ -167,7 +167,8 @@ mod tests {
         let alice_pubkey = alice_client.pubkey();
         let bob_pubkey = Keypair::new().pubkey();
         let instructions = BudgetInstruction::new_payment(&alice_pubkey, &bob_pubkey, 100);
-        alice_client.process_instructions(instructions).unwrap();
+        let message = Message::new(instructions);
+        alice_client.process_message(message).unwrap();
         assert_eq!(bank.get_balance(&bob_pubkey), 100);
     }
 
@@ -189,7 +190,8 @@ mod tests {
             None,
             1,
         );
-        alice_client.process_instructions(instructions).unwrap();
+        let message = Message::new(instructions);
+        alice_client.process_message(message).unwrap();
 
         // Attack! Part 1: Sign a witness transaction with a random key.
         let mallory_client = BankClient::new(&bank, Keypair::new());
@@ -232,7 +234,8 @@ mod tests {
             None,
             1,
         );
-        alice_client.process_instructions(instructions).unwrap();
+        let message = Message::new(instructions);
+        alice_client.process_message(message).unwrap();
 
         // Attack! Part 1: Sign a timestamp transaction with a random key.
         let mallory_client = BankClient::new(&bank, Keypair::new());
@@ -278,7 +281,8 @@ mod tests {
             None,
             1,
         );
-        alice_client.process_instructions(instructions).unwrap();
+        let message = Message::new(instructions);
+        alice_client.process_message(message).unwrap();
         assert_eq!(bank.get_balance(&alice_pubkey), 1);
         assert_eq!(bank.get_balance(&budget_pubkey), 1);
 
@@ -337,7 +341,8 @@ mod tests {
             Some(alice_pubkey),
             1,
         );
-        alice_client.process_instructions(instructions).unwrap();
+        let message = Message::new(instructions);
+        alice_client.process_message(message).unwrap();
         assert_eq!(bank.get_balance(&alice_pubkey), 2);
         assert_eq!(bank.get_balance(&budget_pubkey), 1);
 

--- a/programs/config_api/src/config_processor.rs
+++ b/programs/config_api/src/config_processor.rs
@@ -142,8 +142,7 @@ mod tests {
         let (bank, mint_keypair) = create_bank(10_000);
         let system_keypair = Keypair::new();
         let system_pubkey = system_keypair.pubkey();
-        bank.transfer(42, &mint_keypair, &system_pubkey, bank.last_blockhash())
-            .unwrap();
+        bank.transfer(42, &mint_keypair, &system_pubkey).unwrap();
         let (_config_client, from_pubkey, config_pubkey) =
             create_config_client(&bank, mint_keypair);
 

--- a/programs/vote_api/src/vote_processor.rs
+++ b/programs/vote_api/src/vote_processor.rs
@@ -51,6 +51,7 @@ mod tests {
     use solana_runtime::bank_client::BankClient;
     use solana_sdk::genesis_block::GenesisBlock;
     use solana_sdk::instruction::{AccountMeta, Instruction, InstructionError};
+    use solana_sdk::message::Message;
     use solana_sdk::pubkey::Pubkey;
     use solana_sdk::signature::{Keypair, KeypairUtil};
     use solana_sdk::system_instruction::SystemInstruction;
@@ -69,7 +70,8 @@ mod tests {
         lamports: u64,
     ) -> Result<()> {
         let ixs = VoteInstruction::new_account(&bank_client.pubkey(), vote_id, lamports);
-        bank_client.process_instructions(ixs)
+        let message = Message::new(ixs);
+        bank_client.process_message(message)
     }
 
     fn create_vote_account_with_delegate(
@@ -81,7 +83,8 @@ mod tests {
         let mut ixs = VoteInstruction::new_account(&bank_client.pubkey(), &vote_id, lamports);
         let delegate_ix = VoteInstruction::new_delegate_stake(&vote_id, delegate_id);
         ixs.push(delegate_ix);
-        bank_client.process_instructions(ixs)
+        let message = Message::new(ixs);
+        bank_client.process_message(message)
     }
 
     fn submit_vote(
@@ -142,7 +145,8 @@ mod tests {
         // the 0th account in the second instruction is not! The program
         // needs to check that it's signed.
         let move_ix = SystemInstruction::new_move(&mallory_id, &vote_id, 1);
-        let result = mallory_client.process_instructions(vec![move_ix, vote_ix]);
+        let message = Message::new(vec![move_ix, vote_ix]);
+        let result = mallory_client.process_message(message);
 
         // And ensure there's no vote.
         let vote_account = bank.get_account(&vote_id).unwrap();

--- a/runtime/src/bank_client.rs
+++ b/runtime/src/bank_client.rs
@@ -36,17 +36,10 @@ impl<'a> BankClient<'a> {
         self.bank.process_transaction(&transaction)
     }
 
-    /// Create and process a transaction from a list of instructions.
-    pub fn process_instructions(
-        &self,
-        instructions: Vec<Instruction>,
-    ) -> Result<(), TransactionError> {
-        self.process_message(Message::new(instructions))
-    }
-
     /// Create and process a transaction from a single instruction.
     pub fn process_instruction(&self, instruction: Instruction) -> Result<(), TransactionError> {
-        self.process_instructions(vec![instruction])
+        let message = Message::new(vec![instruction]);
+        self.process_message(message)
     }
 
     /// Transfer lamports to pubkey


### PR DESCRIPTION
#### Problem

BankClient can sign unsigned Transactions and so is a big reason why Transaction still supports creating unsigned transactions.

#### Summary of Changes

* Replace BankClient's `process_transaction()` and `process_instructions()` with `process_message()`
* Removed blockhash parameter from `Bank::transfer()`

