### PR TITLE
Remove keypairs from BankClient

### DIFF
--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -28,6 +28,7 @@ mod bpf {
     mod bpf_c {
         use super::*;
         use solana_sdk::bpf_loader;
+        use solana_sdk::signature::KeypairUtil;
         use std::io::Read;
 
         #[test]
@@ -38,14 +39,16 @@ mod bpf {
             let mut elf = Vec::new();
             file.read_to_end(&mut elf).unwrap();
 
-            let (genesis_block, mint_keypair) = GenesisBlock::new(50);
+            let (genesis_block, alice_keypair) = GenesisBlock::new(50);
             let bank = Bank::new(&genesis_block);
-            let alice_client = BankClient::new(&bank, mint_keypair);
+            let bank_client = BankClient::new(&bank);
 
             // Call user program
-            let program_id = load_program(&bank, &alice_client, &bpf_loader::id(), elf);
-            let instruction = create_invoke_instruction(alice_client.pubkey(), program_id, &1u8);
-            alice_client.process_instruction(instruction).unwrap();
+            let program_id = load_program(&bank_client, &alice_keypair, &bpf_loader::id(), elf);
+            let instruction = create_invoke_instruction(alice_keypair.pubkey(), program_id, &1u8);
+            bank_client
+                .process_instruction(&alice_keypair, instruction)
+                .unwrap();
         }
 
         #[test]
@@ -67,22 +70,24 @@ mod bpf {
                 let mut elf = Vec::new();
                 file.read_to_end(&mut elf).unwrap();
 
-                let (genesis_block, mint_keypair) = GenesisBlock::new(50);
+                let (genesis_block, alice_keypair) = GenesisBlock::new(50);
                 let bank = Bank::new(&genesis_block);
-                let alice_client = BankClient::new(&bank, mint_keypair);
+                let bank_client = BankClient::new(&bank);
 
                 let loader_id = load_program(
-                    &bank,
-                    &alice_client,
+                    &bank_client,
+                    &alice_keypair,
                     &native_loader::id(),
                     "solana_bpf_loader".as_bytes().to_vec(),
                 );
 
                 // Call user program
-                let program_id = load_program(&bank, &alice_client, &loader_id, elf);
+                let program_id = load_program(&bank_client, &alice_keypair, &loader_id, elf);
                 let instruction =
-                    create_invoke_instruction(alice_client.pubkey(), program_id, &1u8);
-                alice_client.process_instruction(instruction).unwrap();
+                    create_invoke_instruction(alice_keypair.pubkey(), program_id, &1u8);
+                bank_client
+                    .process_instruction(&alice_keypair, instruction)
+                    .unwrap();
             }
         }
     }
@@ -94,6 +99,7 @@ mod bpf {
     #[cfg(feature = "bpf_rust")]
     mod bpf_rust {
         use super::*;
+        use solana_sdk::signature::KeypairUtil;
         use std::io::Read;
 
         #[test]
@@ -108,22 +114,24 @@ mod bpf {
                 let mut elf = Vec::new();
                 file.read_to_end(&mut elf).unwrap();
 
-                let (genesis_block, mint_keypair) = GenesisBlock::new(50);
+                let (genesis_block, alice_keypair) = GenesisBlock::new(50);
                 let bank = Bank::new(&genesis_block);
-                let alice_client = BankClient::new(&bank, mint_keypair);
+                let bank_client = BankClient::new(&bank);
 
                 let loader_id = load_program(
-                    &bank,
-                    &alice_client,
+                    &bank_client,
+                    &alice_keypair,
                     &native_loader::id(),
                     "solana_bpf_loader".as_bytes().to_vec(),
                 );
 
                 // Call user program
-                let program_id = load_program(&bank, &alice_client, &loader_id, elf);
+                let program_id = load_program(&bank_client, &alice_keypair, &loader_id, elf);
                 let instruction =
-                    create_invoke_instruction(alice_client.pubkey(), program_id, &1u8);
-                alice_client.process_instruction(instruction).unwrap();
+                    create_invoke_instruction(alice_keypair.pubkey(), program_id, &1u8);
+                bank_client
+                    .process_instruction(&alice_keypair, instruction)
+                    .unwrap();
             }
         }
     }

--- a/programs/failure_program/tests/failure.rs
+++ b/programs/failure_program/tests/failure.rs
@@ -4,21 +4,22 @@ use solana_runtime::loader_utils::{create_invoke_instruction, load_program};
 use solana_sdk::genesis_block::GenesisBlock;
 use solana_sdk::instruction::InstructionError;
 use solana_sdk::native_loader;
+use solana_sdk::signature::KeypairUtil;
 use solana_sdk::transaction::TransactionError;
 
 #[test]
 fn test_program_native_failure() {
-    let (genesis_block, mint_keypair) = GenesisBlock::new(50);
+    let (genesis_block, alice_keypair) = GenesisBlock::new(50);
     let bank = Bank::new(&genesis_block);
-    let alice_client = BankClient::new(&bank, mint_keypair);
+    let bank_client = BankClient::new(&bank);
 
     let program = "failure".as_bytes().to_vec();
-    let program_id = load_program(&bank, &alice_client, &native_loader::id(), program);
+    let program_id = load_program(&bank_client, &alice_keypair, &native_loader::id(), program);
 
     // Call user program
-    let instruction = create_invoke_instruction(alice_client.pubkey(), program_id, &1u8);
+    let instruction = create_invoke_instruction(alice_keypair.pubkey(), program_id, &1u8);
     assert_eq!(
-        alice_client.process_instruction(instruction),
+        bank_client.process_instruction(&alice_keypair, instruction),
         Err(TransactionError::InstructionError(
             0,
             InstructionError::GenericError

--- a/programs/noop_program/tests/noop.rs
+++ b/programs/noop_program/tests/noop.rs
@@ -3,19 +3,22 @@ use solana_runtime::bank_client::BankClient;
 use solana_runtime::loader_utils::{create_invoke_instruction, load_program};
 use solana_sdk::genesis_block::GenesisBlock;
 use solana_sdk::native_loader;
+use solana_sdk::signature::KeypairUtil;
 
 #[test]
 fn test_program_native_noop() {
     solana_logger::setup();
 
-    let (genesis_block, mint_keypair) = GenesisBlock::new(50);
+    let (genesis_block, alice_keypair) = GenesisBlock::new(50);
     let bank = Bank::new(&genesis_block);
-    let alice_client = BankClient::new(&bank, mint_keypair);
+    let bank_client = BankClient::new(&bank);
 
     let program = "noop".as_bytes().to_vec();
-    let program_id = load_program(&bank, &alice_client, &native_loader::id(), program);
+    let program_id = load_program(&bank_client, &alice_keypair, &native_loader::id(), program);
 
     // Call user program
-    let instruction = create_invoke_instruction(alice_client.pubkey(), program_id, &1u8);
-    alice_client.process_instruction(instruction).unwrap();
+    let instruction = create_invoke_instruction(alice_keypair.pubkey(), program_id, &1u8);
+    bank_client
+        .process_instruction(&alice_keypair, instruction)
+        .unwrap();
 }

--- a/programs/vote_api/src/vote_processor.rs
+++ b/programs/vote_api/src/vote_processor.rs
@@ -50,7 +50,7 @@ mod tests {
     use solana_runtime::bank::{Bank, Result};
     use solana_runtime::bank_client::BankClient;
     use solana_sdk::genesis_block::GenesisBlock;
-    use solana_sdk::instruction::{AccountMeta, Instruction, InstructionError};
+    use solana_sdk::instruction::InstructionError;
     use solana_sdk::message::Message;
     use solana_sdk::pubkey::Pubkey;
     use solana_sdk::signature::{Keypair, KeypairUtil};
@@ -66,49 +66,51 @@ mod tests {
 
     fn create_vote_account(
         bank_client: &BankClient,
+        from_keypair: &Keypair,
         vote_id: &Pubkey,
         lamports: u64,
     ) -> Result<()> {
-        let ixs = VoteInstruction::new_account(&bank_client.pubkey(), vote_id, lamports);
+        let ixs = VoteInstruction::new_account(&from_keypair.pubkey(), vote_id, lamports);
         let message = Message::new(ixs);
-        bank_client.process_message(message)
+        bank_client.process_message(&[from_keypair], message)
     }
 
     fn create_vote_account_with_delegate(
         bank_client: &BankClient,
+        from_keypair: &Keypair,
+        vote_keypair: &Keypair,
         delegate_id: &Pubkey,
         lamports: u64,
     ) -> Result<()> {
-        let vote_id = bank_client.pubkeys()[1];
-        let mut ixs = VoteInstruction::new_account(&bank_client.pubkey(), &vote_id, lamports);
+        let vote_id = vote_keypair.pubkey();
+        let mut ixs = VoteInstruction::new_account(&from_keypair.pubkey(), &vote_id, lamports);
         let delegate_ix = VoteInstruction::new_delegate_stake(&vote_id, delegate_id);
         ixs.push(delegate_ix);
         let message = Message::new(ixs);
-        bank_client.process_message(message)
+        bank_client.process_message(&[&from_keypair, vote_keypair], message)
     }
 
     fn submit_vote(
         bank_client: &BankClient,
-        staking_account: &Pubkey,
+        vote_keypair: &Keypair,
         tick_height: u64,
     ) -> Result<()> {
-        let vote_ix = VoteInstruction::new_vote(staking_account, Vote::new(tick_height));
-        bank_client.process_instruction(vote_ix)
+        let vote_ix = VoteInstruction::new_vote(&vote_keypair.pubkey(), Vote::new(tick_height));
+        bank_client.process_instruction(&vote_keypair, vote_ix)
     }
 
     #[test]
     fn test_vote_bank_basic() {
         let (bank, from_keypair) = create_bank(10_000);
-        let alice_client = BankClient::new(&bank, from_keypair);
+        let bank_client = BankClient::new(&bank);
 
         let vote_keypair = Keypair::new();
-        let vote_client = BankClient::new(&bank, vote_keypair);
-        let vote_id = vote_client.pubkey();
+        let vote_id = vote_keypair.pubkey();
 
-        create_vote_account(&alice_client, &vote_id, 100).unwrap();
-        submit_vote(&vote_client, &vote_id, 0).unwrap();
+        create_vote_account(&bank_client, &from_keypair, &vote_id, 100).unwrap();
+        submit_vote(&bank_client, &vote_keypair, 0).unwrap();
 
-        let vote_account = bank.get_account(&vote_client.pubkey()).unwrap();
+        let vote_account = bank.get_account(&vote_id).unwrap();
         let vote_state = VoteState::deserialize(&vote_account.data).unwrap();
         assert_eq!(vote_state.votes.len(), 1);
     }
@@ -117,36 +119,38 @@ mod tests {
     fn test_vote_bank_delegate() {
         let (bank, from_keypair) = create_bank(10_000);
         let vote_keypair = Keypair::new();
-        let alice_and_vote_client =
-            BankClient::new_with_keypairs(&bank, vec![from_keypair, vote_keypair]);
+        let bank_client = BankClient::new(&bank);
         let delegate_id = Keypair::new().pubkey();
-        create_vote_account_with_delegate(&alice_and_vote_client, &delegate_id, 100).unwrap();
+        create_vote_account_with_delegate(
+            &bank_client,
+            &from_keypair,
+            &vote_keypair,
+            &delegate_id,
+            100,
+        )
+        .unwrap();
     }
 
     #[test]
     fn test_vote_via_bank_with_no_signature() {
-        let (bank, from_keypair) = create_bank(10_000);
-        let mallory_client = BankClient::new(&bank, from_keypair);
+        let (bank, mallory_keypair) = create_bank(10_000);
+        let bank_client = BankClient::new(&bank);
 
         let vote_keypair = Keypair::new();
-        let vote_client = BankClient::new(&bank, vote_keypair);
-        let vote_id = vote_client.pubkey();
+        let vote_id = vote_keypair.pubkey();
 
-        create_vote_account(&mallory_client, &vote_id, 100).unwrap();
+        create_vote_account(&bank_client, &mallory_keypair, &vote_id, 100).unwrap();
 
-        let mallory_id = mallory_client.pubkey();
-        let vote_ix = Instruction::new(
-            id(),
-            &VoteInstruction::Vote(Vote::new(0)),
-            vec![AccountMeta::new(vote_id, false)], // <--- attack!! No signer required.
-        );
+        let mallory_id = mallory_keypair.pubkey();
+        let mut vote_ix = VoteInstruction::new_vote(&vote_id, Vote::new(0));
+        vote_ix.accounts[0].is_signer = false; // <--- attack!! No signer required.
 
         // Sneak in an instruction so that the transaction is signed but
         // the 0th account in the second instruction is not! The program
         // needs to check that it's signed.
         let move_ix = SystemInstruction::new_move(&mallory_id, &vote_id, 1);
         let message = Message::new(vec![move_ix, vote_ix]);
-        let result = mallory_client.process_message(message);
+        let result = bank_client.process_message(&[&mallory_keypair], message);
 
         // And ensure there's no vote.
         let vote_account = bank.get_account(&vote_id).unwrap();

--- a/runtime/src/bank_client.rs
+++ b/runtime/src/bank_client.rs
@@ -8,44 +8,42 @@ use solana_sdk::transaction::{Transaction, TransactionError};
 
 pub struct BankClient<'a> {
     bank: &'a Bank,
-    keypairs: Vec<Keypair>,
 }
 
 impl<'a> BankClient<'a> {
-    pub fn new_with_keypairs(bank: &'a Bank, keypairs: Vec<Keypair>) -> Self {
-        assert!(!keypairs.is_empty());
-        Self { bank, keypairs }
+    pub fn new(bank: &'a Bank) -> Self {
+        Self { bank }
     }
 
-    pub fn new(bank: &'a Bank, keypair: Keypair) -> Self {
-        Self::new_with_keypairs(bank, vec![keypair])
-    }
-
-    pub fn pubkey(&self) -> Pubkey {
-        self.keypairs[0].pubkey()
-    }
-
-    pub fn pubkeys(&self) -> Vec<Pubkey> {
-        self.keypairs.iter().map(|x| x.pubkey()).collect()
-    }
-
-    pub fn process_message(&self, message: Message) -> Result<(), TransactionError> {
-        let keypairs: Vec<_> = self.keypairs.iter().collect();
+    pub fn process_message(
+        &self,
+        keypairs: &[&Keypair],
+        message: Message,
+    ) -> Result<(), TransactionError> {
         let blockhash = self.bank.last_blockhash();
         let transaction = Transaction::new(&keypairs, message, blockhash);
         self.bank.process_transaction(&transaction)
     }
 
     /// Create and process a transaction from a single instruction.
-    pub fn process_instruction(&self, instruction: Instruction) -> Result<(), TransactionError> {
+    pub fn process_instruction(
+        &self,
+        keypair: &Keypair,
+        instruction: Instruction,
+    ) -> Result<(), TransactionError> {
         let message = Message::new(vec![instruction]);
-        self.process_message(message)
+        self.process_message(&[keypair], message)
     }
 
-    /// Transfer lamports to pubkey
-    pub fn transfer(&self, lamports: u64, pubkey: &Pubkey) -> Result<(), TransactionError> {
-        let move_instruction = SystemInstruction::new_move(&self.pubkey(), pubkey, lamports);
-        self.process_instruction(move_instruction)
+    /// Transfer `lamports` from `keypair` to `pubkey`
+    pub fn transfer(
+        &self,
+        lamports: u64,
+        keypair: &Keypair,
+        pubkey: &Pubkey,
+    ) -> Result<(), TransactionError> {
+        let move_instruction = SystemInstruction::new_move(&keypair.pubkey(), pubkey, lamports);
+        self.process_instruction(keypair, move_instruction)
     }
 }
 
@@ -58,21 +56,22 @@ mod tests {
     #[test]
     fn test_bank_client_new_with_keypairs() {
         let (genesis_block, john_doe_keypair) = GenesisBlock::new(10_000);
+        let john_pubkey = john_doe_keypair.pubkey();
         let jane_doe_keypair = Keypair::new();
-        let doe_keypairs = vec![john_doe_keypair, jane_doe_keypair];
+        let jane_pubkey = jane_doe_keypair.pubkey();
+        let doe_keypairs = vec![&john_doe_keypair, &jane_doe_keypair];
         let bank = Bank::new(&genesis_block);
-        let doe_client = BankClient::new_with_keypairs(&bank, doe_keypairs);
-        let jane_pubkey = doe_client.pubkeys()[1];
+        let bank_client = BankClient::new(&bank);
 
         // Create 2-2 Multisig Move instruction.
         let bob_pubkey = Keypair::new().pubkey();
-        let mut move_instruction =
-            SystemInstruction::new_move(&doe_client.pubkey(), &bob_pubkey, 42);
+        let mut move_instruction = SystemInstruction::new_move(&john_pubkey, &bob_pubkey, 42);
         move_instruction
             .accounts
             .push(AccountMeta::new(jane_pubkey, true));
 
-        doe_client.process_instruction(move_instruction).unwrap();
+        let message = Message::new(vec![move_instruction]);
+        bank_client.process_message(&doe_keypairs, message).unwrap();
         assert_eq!(bank.get_balance(&bob_pubkey), 42);
     }
 }

--- a/runtime/src/loader_utils.rs
+++ b/runtime/src/loader_utils.rs
@@ -1,4 +1,3 @@
-use crate::bank::Bank;
 use crate::bank_client::BankClient;
 use serde::Serialize;
 use solana_sdk::instruction::{AccountMeta, Instruction};
@@ -8,8 +7,8 @@ use solana_sdk::signature::{Keypair, KeypairUtil};
 use solana_sdk::system_instruction::SystemInstruction;
 
 pub fn load_program(
-    bank: &Bank,
-    from_client: &BankClient,
+    bank_client: &BankClient,
+    from_keypair: &Keypair,
     loader_id: &Pubkey,
     program: Vec<u8>,
 ) -> Pubkey {
@@ -17,27 +16,31 @@ pub fn load_program(
     let program_pubkey = program_keypair.pubkey();
 
     let instruction = SystemInstruction::new_program_account(
-        &from_client.pubkey(),
+        &from_keypair.pubkey(),
         &program_pubkey,
         1,
         program.len() as u64,
         loader_id,
     );
-    from_client.process_instruction(instruction).unwrap();
-
-    let program_client = BankClient::new(bank, program_keypair);
+    bank_client
+        .process_instruction(&from_keypair, instruction)
+        .unwrap();
 
     let chunk_size = 256; // Size of chunk just needs to fit into tx
     let mut offset = 0;
     for chunk in program.chunks(chunk_size) {
         let instruction =
             LoaderInstruction::new_write(&program_pubkey, loader_id, offset, chunk.to_vec());
-        program_client.process_instruction(instruction).unwrap();
+        bank_client
+            .process_instruction(&program_keypair, instruction)
+            .unwrap();
         offset += chunk_size as u32;
     }
 
     let instruction = LoaderInstruction::new_finalize(&program_pubkey, loader_id);
-    program_client.process_instruction(instruction).unwrap();
+    bank_client
+        .process_instruction(&program_keypair, instruction)
+        .unwrap();
 
     program_pubkey
 }


### PR DESCRIPTION
#### Problem

BankClient is conceptually different than the other clients (except Wallet).  All clients should at least abstract away getting new blockhashes, resigning and resending transactions. BankClient and Wallet go a step further and attempt to encapsulate keypairs. That's nice for the single-keypair usecase, but a big pain when dealing with multiple keypairs. And it's a dealbreaker entirely if you have 2 keypairs and need both to sign one transaction and only 1 for another.

#### Summary of Changes

Remove keypairs from BankClient.

Towards #3058
