### PR TITLE
Fix Storage Stage not receiving entries when node is leader

### DIFF
--- a/core/src/local_cluster.rs
+++ b/core/src/local_cluster.rs
@@ -142,11 +142,11 @@ impl LocalCluster {
             cluster.add_validator(&fullnode_config, *stake);
         }
 
+        discover(&cluster.entry_point_info.gossip, node_stakes.len()).unwrap();
+
         for _ in 0..num_replicators {
             cluster.add_replicator();
         }
-
-        discover(&cluster.entry_point_info.gossip, node_stakes.len()).unwrap();
 
         cluster
     }

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -6,6 +6,7 @@ use crate::blocktree::Blocktree;
 use crate::broadcast_stage::BroadcastStage;
 use crate::cluster_info::ClusterInfo;
 use crate::cluster_info_vote_listener::ClusterInfoVoteListener;
+use crate::entry::EntrySender;
 use crate::fetch_stage::FetchStage;
 use crate::poh_recorder::{PohRecorder, WorkingBankEntries};
 use crate::service::Service;
@@ -37,6 +38,7 @@ impl Tpu {
         broadcast_socket: UdpSocket,
         sigverify_disabled: bool,
         blocktree: &Arc<Blocktree>,
+        storage_entry_sender: EntrySender,
         exit: &Arc<AtomicBool>,
     ) -> Self {
         cluster_info.write().unwrap().set_leader(id);
@@ -62,6 +64,7 @@ impl Tpu {
             entry_receiver,
             &exit,
             blocktree,
+            storage_entry_sender,
         );
 
         Self {

--- a/core/tests/replicator.rs
+++ b/core/tests/replicator.rs
@@ -98,6 +98,8 @@ fn download_from_replicator(replicator_info: &ContactInfo) {
     assert!(received_blob);
 }
 
+/// Start the cluster with the given configuration and wait till the replicators are discovered
+/// Then download blobs from one of them.
 fn run_replicator_startup_basic(num_nodes: usize, num_replicators: usize) {
     solana_logger::setup();
     info!("starting replicator test");
@@ -134,8 +136,12 @@ fn run_replicator_startup_basic(num_nodes: usize, num_replicators: usize) {
 }
 
 #[test]
-fn test_replicator_startup_basic() {
+fn test_replicator_startup_1_node() {
     run_replicator_startup_basic(1, 1);
+}
+
+#[test]
+fn test_replicator_startup_2_nodes() {
     run_replicator_startup_basic(2, 1);
 }
 

--- a/core/tests/replicator.rs
+++ b/core/tests/replicator.rs
@@ -98,17 +98,14 @@ fn download_from_replicator(replicator_info: &ContactInfo) {
     assert!(received_blob);
 }
 
-#[test]
-fn test_replicator_startup_basic() {
+fn run_replicator_startup_basic(num_nodes: usize, num_replicators: usize) {
     solana_logger::setup();
     info!("starting replicator test");
 
-    const NUM_NODES: usize = 2;
-    let num_replicators = 1;
     let mut fullnode_config = FullnodeConfig::default();
     fullnode_config.storage_rotate_count = STORAGE_ROTATE_TEST_COUNT;
     let cluster = LocalCluster::new_with_config_replicators(
-        &[100; NUM_NODES],
+        &vec![100; num_nodes],
         10_000,
         &fullnode_config,
         num_replicators,
@@ -118,10 +115,10 @@ fn test_replicator_startup_basic() {
 
     let cluster_nodes = discover(
         &cluster.entry_point_info.gossip,
-        NUM_NODES + num_replicators,
+        num_nodes + num_replicators,
     )
     .unwrap();
-    assert_eq!(cluster_nodes.len(), NUM_NODES + num_replicators);
+    assert_eq!(cluster_nodes.len(), num_nodes + num_replicators);
     let mut replicator_count = 0;
     let mut replicator_info = ContactInfo::default();
     for node in &cluster_nodes {
@@ -134,6 +131,12 @@ fn test_replicator_startup_basic() {
     assert_eq!(replicator_count, num_replicators);
 
     download_from_replicator(&replicator_info);
+}
+
+#[test]
+fn test_replicator_startup_basic() {
+    run_replicator_startup_basic(1, 1);
+    run_replicator_startup_basic(2, 1);
 }
 
 #[test]

--- a/core/tests/tvu.rs
+++ b/core/tests/tvu.rs
@@ -101,6 +101,7 @@ fn test_replay() {
     let voting_keypair = Keypair::new();
     let (poh_service_exit, poh_recorder, poh_service, _entry_receiver) =
         create_test_recorder(&bank);
+    let (storage_sender, storage_receiver) = channel();
     let tvu = Tvu::new(
         &voting_keypair.pubkey(),
         Some(Arc::new(voting_keypair)),
@@ -121,6 +122,8 @@ fn test_replay() {
         ledger_signal_receiver,
         &Arc::new(RpcSubscriptions::default()),
         &poh_recorder,
+        storage_sender,
+        storage_receiver,
         &exit,
     );
 


### PR DESCRIPTION
#### Problem

Storage stage is only receiving entries from replay stage's `replay_blocktree_into_bank`. However, when the node is running as the leader, it doesn't need to replay blocktree into the bank and as a result, storage_stage doesn't receive any entries. 

#### Summary of Changes

Added a channel from tpu's broadcast stage (which writes into blocktree when a node is the leader) to storage stage. 

