### PR TITLE
Replace recursive status cache with a single global fast status cache

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -179,10 +179,6 @@ impl Bank {
         for i in 0..=bank.get_stakers_epoch(bank.slot) {
             bank.epoch_vote_accounts.insert(i, vote_accounts.clone());
         }
-        bank.status_cache
-            .write()
-            .unwrap()
-            .register_hash(bank.last_blockhash(), bank.slot());
         bank
     }
 
@@ -437,10 +433,6 @@ impl Bank {
         // Register a new block hash if at the last tick in the slot
         if current_tick_height % self.ticks_per_slot == self.ticks_per_slot - 1 {
             self.blockhash_queue.write().unwrap().register_hash(hash);
-            self.status_cache
-                .write()
-                .unwrap()
-                .register_hash(self.last_blockhash(), self.slot());
         }
     }
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -117,7 +117,7 @@ pub struct Bank {
     accounts_id: u64,
 
     /// A cache of signature statuses
-    status_cache: RwLock<BankStatusCache>,
+    status_cache: Arc<RwLock<BankStatusCache>>,
 
     /// FIFO queue of `recent_blockhash` items
     blockhash_queue: RwLock<BlockhashQueue>,
@@ -191,6 +191,7 @@ impl Bank {
 
         let mut bank = Self::default();
         bank.blockhash_queue = RwLock::new(parent.blockhash_queue.read().unwrap().clone());
+        bank.status_cache = parent.status_cache.clone();
         bank.tick_height
             .store(parent.tick_height.load(Ordering::SeqCst), Ordering::SeqCst);
         bank.ticks_per_slot = parent.ticks_per_slot;

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -259,11 +259,15 @@ impl Bank {
 
         self.accounts.squash(self.accounts_id);
 
-        let wcache = self.status_cache.write().unwrap();
-        parents
-            .iter()
-            .flat_map(|p| p.blockhash_queue.read().unwrap().expired_hashes.iter())
-            .for_each(|hash| wcache.remove_expired_blockhash(hash))
+        let mut wcache = self.status_cache.write().unwrap();
+        parents.iter().for_each(|p| {
+            p.blockhash_queue
+                .read()
+                .unwrap()
+                .expired_hashes
+                .iter()
+                .for_each(|hash| wcache.remove_expired_blockhash(hash))
+        })
     }
 
     /// Return the more recent checkpoint of this bank instance.
@@ -521,7 +525,7 @@ impl Bank {
         self.parents().iter().enumerate().for_each(|(i, p)| {
             ancestors.insert(p.slot(), i + 1);
         });
- 
+
         let rcache = self.status_cache.read().unwrap();
         txs.iter()
             .zip(lock_results.into_iter())

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -352,7 +352,7 @@ impl Bank {
 
     /// Forget all signatures. Useful for benchmarking.
     pub fn clear_signatures(&self) {
-        self.status_cache.write().unwrap().clear();
+        self.status_cache.write().unwrap().clear_signatures();
     }
 
     fn update_transaction_statuses(&self, txs: &[Transaction], res: &[Result<()>]) {
@@ -436,10 +436,7 @@ impl Bank {
 
         // Register a new block hash if at the last tick in the slot
         if current_tick_height % self.ticks_per_slot == self.ticks_per_slot - 1 {
-            {
-                let mut blockhash_queue = self.blockhash_queue.write().unwrap();
-                blockhash_queue.register_hash(hash);
-            }
+            self.blockhash_queue.write().unwrap().register_hash(hash);
             self.status_cache
                 .write()
                 .unwrap()

--- a/runtime/src/blockhash_queue.rs
+++ b/runtime/src/blockhash_queue.rs
@@ -73,7 +73,7 @@ impl BlockhashQueue {
         self.last_hash = Some(*hash);
     }
 
-    pub fn check_age(hash_height: u64, max_age: usize, age: &HashAge) -> bool {
+    fn check_age(hash_height: u64, max_age: usize, age: &HashAge) -> bool {
         hash_height - age.hash_height <= max_age as u64
     }
 

--- a/runtime/src/blockhash_queue.rs
+++ b/runtime/src/blockhash_queue.rs
@@ -88,7 +88,8 @@ impl BlockhashQueue {
             self.expired_hashes.extend(
                 self.ages
                     .iter()
-                    .filter(|(_,age)| !Self::check_age(hash_height, max_age, age)).map(|(hash,_)| hash)
+                    .filter(|(_, age)| !Self::check_age(hash_height, max_age, age))
+                    .map(|(hash, _)| hash),
             );
             self.ages
                 .retain(|_, age| !Self::check_age(hash_height, max_age, age))

--- a/runtime/src/status_cache.rs
+++ b/runtime/src/status_cache.rs
@@ -1,4 +1,5 @@
 use hashbrown::HashMap;
+use log::*;
 use solana_sdk::hash::Hash;
 use solana_sdk::signature::Signature;
 
@@ -47,8 +48,11 @@ impl<T: Clone> StatusCache<T> {
         sig: &Signature,
         ancestors: &HashMap<ForkId, usize>,
     ) -> Option<(usize, T)> {
+        trace!("get_signature_status_slow");
         for blockhash in self.cache.keys() {
+            trace!("get_signature_status_slow: trying {}", blockhash);
             if let Some((forkid, res)) = self.get_signature_status(sig, blockhash, ancestors) {
+                trace!("get_signature_status_slow: got {}", forkid);
                 return ancestors.get(&forkid).map(|id| (*id, res));
             }
         }
@@ -67,6 +71,7 @@ impl<T: Clone> StatusCache<T> {
 
     /// Remove an expired blockhash
     pub fn remove_expired_blockhash(&mut self, hash: &Hash) {
+        trace!("remove_expired_blockhash {}", hash);
         self.cache.remove(hash);
     }
 

--- a/runtime/src/status_cache.rs
+++ b/runtime/src/status_cache.rs
@@ -97,187 +97,121 @@ impl<T: Clone> StatusCache<T> {
     }
 }
 
-// #[cfg(test)]
-// mod tests {
-//     use super::*;
-//     use solana_sdk::hash::hash;
-//     use solana_sdk::transaction::TransactionError;
-//
-//     type BankStatusCache = StatusCache<TransactionError>;
-//
-//     #[test]
-//     fn test_has_signature() {
-//         let sig = Signature::default();
-//         let blockhash = hash(Hash::default().as_ref());
-//         let mut status_cache = BankStatusCache::new(&blockhash);
-//         assert_eq!(status_cache.has_signature(&sig), false);
-//         assert_eq!(status_cache.get_signature_status(&sig), None);
-//         status_cache.add(&sig);
-//         assert_eq!(status_cache.has_signature(&sig), true);
-//         assert_eq!(status_cache.get_signature_status(&sig), Some(Ok(())));
-//     }
-//
-//     #[test]
-//     fn test_has_signature_checkpoint() {
-//         let sig = Signature::default();
-//         let blockhash = hash(Hash::default().as_ref());
-//         let mut first = BankStatusCache::new(&blockhash);
-//         first.add(&sig);
-//         assert_eq!(first.get_signature_status(&sig), Some(Ok(())));
-//         let blockhash = hash(blockhash.as_ref());
-//         let second = StatusCache::new(&blockhash);
-//         let checkpoints = [&second, &first];
-//         assert_eq!(
-//             BankStatusCache::get_signature_status_all(&checkpoints, &sig),
-//             Some((1, Ok(()))),
-//         );
-//         assert!(StatusCache::has_signature_all(&checkpoints, &sig));
-//     }
-//
-//     #[test]
-//     fn test_new_cache() {
-//         let sig = Signature::default();
-//         let blockhash = hash(Hash::default().as_ref());
-//         let mut first = BankStatusCache::new(&blockhash);
-//         first.add(&sig);
-//         assert_eq!(first.get_signature_status(&sig), Some(Ok(())));
-//         let blockhash = hash(blockhash.as_ref());
-//         first.new_cache(&blockhash);
-//         assert_eq!(first.get_signature_status(&sig), Some(Ok(())));
-//         assert!(first.has_signature(&sig));
-//         first.clear();
-//         assert_eq!(first.get_signature_status(&sig), None);
-//         assert!(!first.has_signature(&sig));
-//     }
-//
-//     #[test]
-//     fn test_new_cache_full() {
-//         let sig = Signature::default();
-//         let blockhash = hash(Hash::default().as_ref());
-//         let mut first = BankStatusCache::new(&blockhash);
-//         first.add(&sig);
-//         assert_eq!(first.get_signature_status(&sig), Some(Ok(())));
-//         for _ in 0..(MAX_CACHE_ENTRIES + 1) {
-//             let blockhash = hash(blockhash.as_ref());
-//             first.new_cache(&blockhash);
-//         }
-//         assert_eq!(first.get_signature_status(&sig), None);
-//         assert!(!first.has_signature(&sig));
-//     }
-//
-//     #[test]
-//     fn test_status_cache_squash_has_signature() {
-//         let sig = Signature::default();
-//         let blockhash = hash(Hash::default().as_ref());
-//         let mut first = BankStatusCache::new(&blockhash);
-//         first.add(&sig);
-//         assert_eq!(first.get_signature_status(&sig), Some(Ok(())));
-//
-//         // give first a merge
-//         let blockhash = hash(blockhash.as_ref());
-//         first.new_cache(&blockhash);
-//
-//         let blockhash = hash(blockhash.as_ref());
-//         let mut second = BankStatusCache::new(&blockhash);
-//         first.freeze();
-//         second.squash(&[&first]);
-//
-//         assert_eq!(second.get_signature_status(&sig), Some(Ok(())));
-//         assert!(second.has_signature(&sig));
-//     }
-//
-//     #[test]
-//     fn test_status_cache_squash_overflow() {
-//         let mut blockhash = hash(Hash::default().as_ref());
-//         let mut cache = BankStatusCache::new(&blockhash);
-//
-//         let parents: Vec<_> = (0..MAX_CACHE_ENTRIES)
-//             .map(|_| {
-//                 blockhash = hash(blockhash.as_ref());
-//
-//                 let mut p = BankStatusCache::new(&blockhash);
-//                 p.freeze();
-//                 p
-//             })
-//             .collect();
-//
-//         let mut parents_refs: Vec<_> = parents.iter().collect();
-//
-//         blockhash = hash(Hash::default().as_ref());
-//         let mut root = BankStatusCache::new(&blockhash);
-//
-//         let sig = Signature::default();
-//         root.add(&sig);
-//
-//         parents_refs.push(&root);
-//
-//         assert_eq!(root.get_signature_status(&sig), Some(Ok(())));
-//         assert!(root.has_signature(&sig));
-//
-//         // will overflow
-//         cache.squash(&parents_refs);
-//
-//         assert_eq!(cache.get_signature_status(&sig), None);
-//         assert!(!cache.has_signature(&sig));
-//     }
-//
-//     #[test]
-//     fn test_failure_status() {
-//         let sig = Signature::default();
-//         let blockhash = hash(Hash::default().as_ref());
-//         let mut first = StatusCache::new(&blockhash);
-//         first.add(&sig);
-//         first.save_failure_status(&sig, TransactionError::DuplicateSignature);
-//         assert_eq!(first.has_signature(&sig), true);
-//         assert_eq!(
-//             first.get_signature_status(&sig),
-//             Some(Err(TransactionError::DuplicateSignature)),
-//         );
-//     }
-//
-//     #[test]
-//     fn test_clear_signatures() {
-//         let sig = Signature::default();
-//         let blockhash = hash(Hash::default().as_ref());
-//         let mut first = StatusCache::new(&blockhash);
-//         first.add(&sig);
-//         assert_eq!(first.has_signature(&sig), true);
-//         first.save_failure_status(&sig, TransactionError::DuplicateSignature);
-//         assert_eq!(
-//             first.get_signature_status(&sig),
-//             Some(Err(TransactionError::DuplicateSignature)),
-//         );
-//         first.clear();
-//         assert_eq!(first.has_signature(&sig), false);
-//         assert_eq!(first.get_signature_status(&sig), None);
-//     }
-//     #[test]
-//     fn test_clear_signatures_all() {
-//         let sig = Signature::default();
-//         let blockhash = hash(Hash::default().as_ref());
-//         let mut first = StatusCache::new(&blockhash);
-//         first.add(&sig);
-//         assert_eq!(first.has_signature(&sig), true);
-//         let mut second = StatusCache::new(&blockhash);
-//         let mut checkpoints = [&mut second, &mut first];
-//         BankStatusCache::clear_all(&mut checkpoints);
-//         assert_eq!(
-//             BankStatusCache::has_signature_all(&checkpoints, &sig),
-//             false
-//         );
-//     }
-//
-//     #[test]
-//     fn test_status_cache_freeze() {
-//         let sig = Signature::default();
-//         let blockhash = hash(Hash::default().as_ref());
-//         let mut cache: StatusCache<()> = StatusCache::new(&blockhash);
-//
-//         cache.freeze();
-//         cache.freeze();
-//
-//         cache.add(&sig);
-//         assert_eq!(cache.has_signature(&sig), false);
-//     }
-//
-// }
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use solana_sdk::hash::hash;
+
+    type BankStatusCache = StatusCache<()>;
+
+    #[test]
+    fn test_empty_has_no_sigs() {
+        let sig = Signature::default();
+        let blockhash = hash(Hash::default().as_ref());
+        let mut status_cache = BankStatusCache::default();
+        assert_eq!(
+            status_cache.get_signature_status(&sig, &blockhash, &HashMap::new()),
+            None
+        );
+        assert_eq!(
+            status_cache.get_signature_status_slow(&sig, &HashMap::new()),
+            None
+        );
+    }
+
+    #[test]
+    fn test_find_sig_with_ancestor_fork() {
+        let sig = Signature::default();
+        let mut status_cache = BankStatusCache::default();
+        let blockhash = hash(Hash::default().as_ref());
+        let ancestors = vec![(0, 1)].into_iter().collect();
+        status_cache.register_hash(blockhash, 0);
+        status_cache.insert(&blockhash, &sig, 0, ());
+        assert_eq!(
+            status_cache.get_signature_status(&sig, &blockhash, &ancestors),
+            Some((0, ()))
+        );
+        assert_eq!(
+            status_cache.get_signature_status_slow(&sig, &ancestors),
+            Some((1, ()))
+        );
+    }
+
+    #[test]
+    fn test_find_sig_without_ancestor_fork() {
+        let sig = Signature::default();
+        let mut status_cache = BankStatusCache::default();
+        let blockhash = hash(Hash::default().as_ref());
+        let ancestors = HashMap::new();
+        status_cache.register_hash(blockhash, 0);
+        status_cache.insert(&blockhash, &sig, 0, ());
+        assert_eq!(
+            status_cache.get_signature_status(&sig, &blockhash, &ancestors),
+            None
+        );
+        assert_eq!(
+            status_cache.get_signature_status_slow(&sig, &ancestors),
+            None
+        );
+    }
+
+    #[test]
+    fn test_find_sig_with_root_ancestor_fork() {
+        let sig = Signature::default();
+        let mut status_cache = BankStatusCache::default();
+        let blockhash = hash(Hash::default().as_ref());
+        let ancestors = vec![(2, 2)].into_iter().collect();
+        status_cache.register_hash(blockhash, 0);
+        status_cache.insert(&blockhash, &sig, 0, ());
+        status_cache.add_root(0);
+        assert_eq!(
+            status_cache.get_signature_status(&sig, &blockhash, &ancestors),
+            Some((0, ()))
+        );
+        assert_eq!(
+            status_cache.get_signature_status_slow(&sig, &ancestors),
+            Some((1, ()))
+        );
+    }
+
+    #[test]
+    fn test_root_expires() {
+        let sig = Signature::default();
+        let mut status_cache = BankStatusCache::default();
+        let blockhash = hash(Hash::default().as_ref());
+        let ancestors = HashMap::new();
+        status_cache.register_hash(blockhash, 0);
+        status_cache.insert(&blockhash, &sig, 0, ());
+        for i in 0..(MAX_CACHE_ENTRIES + 1) {
+            status_cache.add_root(i as u64);
+        }
+        assert_eq!(
+            status_cache.get_signature_status(&sig, &blockhash, &ancestors),
+            None
+        );
+        assert_eq!(
+            status_cache.get_signature_status_slow(&sig, &ancestors),
+            None
+        );
+    }
+
+    #[test]
+    fn test_clear() {
+        let sig = Signature::default();
+        let mut status_cache = BankStatusCache::default();
+        let blockhash = hash(Hash::default().as_ref());
+        let ancestors = HashMap::new();
+        status_cache.register_hash(blockhash, 0);
+        status_cache.insert(&blockhash, &sig, 0, ());
+        status_cache.add_root(0);
+        status_cache.clear();
+        assert_eq!(
+            status_cache.get_signature_status(&sig, &blockhash, &ancestors),
+            None
+        );
+        assert_eq!(
+            status_cache.get_signature_status_slow(&sig, &ancestors),
+            None
+        );
+    }
+}

--- a/runtime/src/status_cache.rs
+++ b/runtime/src/status_cache.rs
@@ -108,7 +108,7 @@ mod tests {
     fn test_empty_has_no_sigs() {
         let sig = Signature::default();
         let blockhash = hash(Hash::default().as_ref());
-        let mut status_cache = BankStatusCache::default();
+        let status_cache = BankStatusCache::default();
         assert_eq!(
             status_cache.get_signature_status(&sig, &blockhash, &HashMap::new()),
             None

--- a/runtime/src/status_cache.rs
+++ b/runtime/src/status_cache.rs
@@ -95,8 +95,10 @@ impl<T: Clone> StatusCache<T> {
     }
 
     /// Clear for testing
-    pub fn clear(&mut self) {
-        self.cache.clear();
+    pub fn clear_signatures(&mut self) {
+        for v in self.cache.values_mut() {
+            v.1 = HashMap::new();
+        }
     }
 }
 
@@ -227,7 +229,7 @@ mod tests {
     }
 
     #[test]
-    fn test_clear() {
+    fn test_clear_signatures_sigs_are_gone() {
         let sig = Signature::default();
         let mut status_cache = BankStatusCache::default();
         let blockhash = hash(Hash::default().as_ref());
@@ -235,14 +237,25 @@ mod tests {
         status_cache.register_hash(blockhash, 0);
         status_cache.insert(&blockhash, &sig, 0, ());
         status_cache.add_root(0);
-        status_cache.clear();
+        status_cache.clear_signatures();
         assert_eq!(
             status_cache.get_signature_status(&sig, &blockhash, &ancestors),
             None
         );
-        assert_eq!(
-            status_cache.get_signature_status_slow(&sig, &ancestors),
-            None
-        );
+    }
+
+    #[test]
+    fn test_clear_signatures_insert_works() {
+        let sig = Signature::default();
+        let mut status_cache = BankStatusCache::default();
+        let blockhash = hash(Hash::default().as_ref());
+        let ancestors = HashMap::new();
+        status_cache.register_hash(blockhash, 0);
+        status_cache.add_root(0);
+        status_cache.clear_signatures();
+        status_cache.insert(&blockhash, &sig, 0, ());
+        assert!(status_cache
+            .get_signature_status(&sig, &blockhash, &ancestors)
+            .is_some());
     }
 }

--- a/runtime/src/status_cache.rs
+++ b/runtime/src/status_cache.rs
@@ -35,7 +35,7 @@ impl<T: Clone> StatusCache<T> {
             .and_then(|stored_forks| {
                 stored_forks
                     .iter()
-                    .filter(|(f, r)| ancestors.get(f).is_some())
+                    .filter(|(f, _)| ancestors.get(f).is_some())
                     .nth(0)
             })
             .cloned()

--- a/runtime/src/status_cache.rs
+++ b/runtime/src/status_cache.rs
@@ -67,8 +67,11 @@ impl<T: Clone> StatusCache<T> {
     }
 
     pub fn register_hash(&mut self, blockhash: Hash, fork: ForkId) {
-        let hash = self.cache.entry(blockhash).or_insert((fork, HashMap::new()));
-        hash.0 = std::cmp::max(fork, hash.0); 
+        let hash = self
+            .cache
+            .entry(blockhash)
+            .or_insert((fork, HashMap::new()));
+        hash.0 = std::cmp::max(fork, hash.0);
     }
 
     pub fn add_root(&mut self, fork: ForkId) {
@@ -169,7 +172,7 @@ mod tests {
             Some((0, ()))
         );
     }
- 
+
     #[test]
     fn test_find_sig_with_root_ancestor_fork_max_len() {
         let sig = Signature::default();
@@ -184,7 +187,7 @@ mod tests {
             Some((ancestors.len(), ()))
         );
     }
- 
+
     #[test]
     fn test_register_picks_latest() {
         let sig = Signature::default();
@@ -197,11 +200,11 @@ mod tests {
         for i in 0..(MAX_CACHE_ENTRIES + 1) {
             status_cache.add_root(i as u64);
         }
-        assert!(
-            status_cache.get_signature_status(&sig, &blockhash, &ancestors).is_some()
-        );
+        assert!(status_cache
+            .get_signature_status(&sig, &blockhash, &ancestors)
+            .is_some());
     }
- 
+
     #[test]
     fn test_root_expires() {
         let sig = Signature::default();

--- a/runtime/src/status_cache.rs
+++ b/runtime/src/status_cache.rs
@@ -60,7 +60,7 @@ impl<T: Clone> StatusCache<T> {
                 return ancestors
                     .get(&forkid)
                     .map(|id| (*id, res.clone()))
-                    .or(Some((ancestors.len(), res)));
+                    .or_else(|| Some((ancestors.len(), res)));
             }
         }
         None

--- a/runtime/src/status_cache.rs
+++ b/runtime/src/status_cache.rs
@@ -9,403 +9,229 @@ use std::ops::Deref;
 use std::ops::DerefMut;
 use std::sync::Arc;
 
-/// Each cache entry is designed to span ~1 second of signatures
-const MAX_CACHE_ENTRIES: usize = solana_sdk::timing::MAX_HASH_AGE_IN_SECONDS;
+// Blockhash found in the transaction
+type TransactionBlockHash = Hash
+// Store forks in a single chunk of memory to avoid another lookup.
+type ForkStatus<T> = Vec<(ForkId, T)>;
+type SignatureMap<T> = HashMap<Signature, ForkStatusMap<T>>;
+type StatusMap<T> = StatusMap<TransactionBlockHash, SignatureMap<T>>;
 
-type FailureMap<T> = HashMap<Signature, T>;
-
-#[derive(Clone)]
-struct Status<T> {
+#[derive(Clone, Default)]
+struct StatusCache<T: Default + Clone> {
     /// all signatures seen during a hash period
-    signatures: Bloom<Signature>,
+    cache: StatusMap<T>,
 
-    /// failures
-    failures: FailureMap<T>,
-}
-
-impl<T: Clone> Status<T> {
-    // new needs to be called once per second to be useful for the Bank
-    // 1M TPS * 1s (length of block in sigs) == 1M items in filter
-    // 1.0E-8 false positive rate
-    // https://hur.st/bloomfilter/?n=1000000&p=1.0E-8&m=&k=
-    fn new(blockhash: &Hash) -> Self {
-        let keys = (0..27).map(|i| blockhash.hash_at_index(i)).collect();
-        Status {
-            signatures: Bloom::new(38_340_234, keys),
-            failures: HashMap::default(),
-        }
-    }
-    fn has_signature(&self, sig: &Signature) -> bool {
-        self.signatures.contains(&sig)
-    }
-
-    fn add(&mut self, sig: &Signature) {
-        self.signatures.add(&sig);
-    }
-
-    fn clear(&mut self) {
-        self.failures.clear();
-        self.signatures.clear();
-    }
-    pub fn get_signature_status(&self, sig: &Signature) -> Option<Result<(), T>> {
-        if let Some(res) = self.failures.get(sig) {
-            return Some(Err(res.clone()));
-        } else if self.signatures.contains(sig) {
-            return Some(Ok(()));
-        }
-        None
-    }
-}
-
-#[derive(Clone)]
-pub struct StatusCache<T> {
-    /// currently active status
-    active: Option<Status<T>>,
-
-    /// merges cover previous periods, and are read-only
-    merges: VecDeque<Arc<Status<T>>>,
-}
-
-impl<T: Clone> Default for StatusCache<T> {
-    fn default() -> Self {
-        Self::new(&Hash::default())
-    }
 }
 
 impl<T: Clone> StatusCache<T> {
-    pub fn new(blockhash: &Hash) -> Self {
-        Self {
-            active: Some(Status::new(blockhash)),
-            merges: VecDeque::default(),
-        }
+    /// Check if the signature from a transaction is in any of the forks in the ancestors set.
+    pub fn get_signature_status(&self, sig: &Signature, blockhash: TransactionBlockHash, ancestors: &HashSet<u64>) -> Option<T> {
+        self.cache
+            .get(blockhash)
+            .and_then(|sigmap| sigmap.get(signature))
+            .and_then(|stored_forks|
+                      stored_forks.iter().filter(|(f,r)| ancestors.contains(f)).map(|(_,r) r.clone()).first())
     }
-    fn has_signature_merged(&self, sig: &Signature) -> bool {
-        for c in &self.merges {
-            if c.has_signature(sig) {
-                return true;
-            }
-        }
-        false
-    }
-    /// test if a signature is known
-    pub fn has_signature(&self, sig: &Signature) -> bool {
-        self.active
-            .as_ref()
-            .map_or(false, |active| active.has_signature(&sig))
-            || self.has_signature_merged(sig)
+ 
+    /// Insert a new signature for a specific fork.
+    pub fn insert(&mut self, hash: &TransactionBlockHash, sig: &Signature, fork: u64, res: T) {
+        let sig_map = self.cache.entry(hash).or_insert(HashMap::new());
+        let sig_forks = sig_map.entry(sig).or_insert(vec![]);
+        sig_forks.push((fork, T));
     }
 
-    /// add a signature
-    pub fn add(&mut self, sig: &Signature) {
-        if let Some(active) = self.active.as_mut() {
-            active.add(&sig);
-        }
+    /// Remove an expired blockhash 
+    pub fn remove_blockhash(&mut self, hash: &TransactionBlockHash) {
+        self.cache.remove(hash);
     }
 
-    /// Save an error status for a signature
-    pub fn save_failure_status(&mut self, sig: &Signature, err: T) {
-        assert!(
-            self.active
-                .as_ref()
-                .map_or(false, |active| active.has_signature(sig)),
-            "sig not found"
-        );
-
-        self.active
-            .as_mut()
-            .map(|active| active.failures.insert(*sig, err));
-    }
-    /// Forget all signatures. Useful for benchmarking.
+    /// Clear for testing
     pub fn clear(&mut self) {
-        if let Some(active) = self.active.as_mut() {
-            active.clear();
-        }
-        self.merges = VecDeque::new();
-    }
-
-    fn get_signature_status_merged(&self, sig: &Signature) -> Option<Result<(), T>> {
-        for c in &self.merges {
-            if c.has_signature(sig) {
-                return c.get_signature_status(sig);
-            }
-        }
-        None
-    }
-    pub fn get_signature_status(&self, sig: &Signature) -> Option<Result<(), T>> {
-        self.active
-            .as_ref()
-            .and_then(|active| active.get_signature_status(sig))
-            .or_else(|| self.get_signature_status_merged(sig))
-    }
-
-    fn squash_parent_is_full(&mut self, parent: &Self) -> bool {
-        // flatten and squash the parent and its merges into self.merges,
-        //  returns true if self is full
-        if parent.active.is_some() {
-            warn!("=========== FIXME: squash() on an active parent! ================");
-        }
-        // TODO: put this assert back in
-        //assert!(parent.active.is_none());
-
-        if self.merges.len() < MAX_CACHE_ENTRIES {
-            for merge in parent
-                .merges
-                .iter()
-                .take(MAX_CACHE_ENTRIES - self.merges.len())
-            {
-                self.merges.push_back(merge.clone());
-            }
-        }
-        self.merges.len() == MAX_CACHE_ENTRIES
-    }
-
-    /// copy the parents and parents' merges up to this instance, up to
-    ///   MAX_CACHE_ENTRIES deep
-    pub fn squash<U>(&mut self, parents: &[U])
-    where
-        U: Deref<Target = Self>,
-    {
-        for parent in parents {
-            if self.squash_parent_is_full(parent) {
-                break;
-            }
-        }
-    }
-
-    /// Crate a new cache, pushing the old cache into the merged queue
-    pub fn new_cache(&mut self, blockhash: &Hash) {
-        assert!(self.active.is_some());
-        let merge = self.active.replace(Status::new(blockhash));
-
-        self.merges.push_front(Arc::new(merge.unwrap()));
-        if self.merges.len() > MAX_CACHE_ENTRIES {
-            self.merges.pop_back();
-        }
-    }
-
-    pub fn freeze(&mut self) {
-        if let Some(active) = self.active.take() {
-            self.merges.push_front(Arc::new(active));
-        }
-    }
-
-    pub fn get_signature_status_all<U>(
-        checkpoints: &[U],
-        signature: &Signature,
-    ) -> Option<(usize, Result<(), T>)>
-    where
-        U: Deref<Target = Self>,
-    {
-        for (i, c) in checkpoints.iter().enumerate() {
-            if let Some(status) = c.get_signature_status(signature) {
-                return Some((i, status));
-            }
-        }
-        None
-    }
-    pub fn has_signature_all<U>(checkpoints: &[U], signature: &Signature) -> bool
-    where
-        U: Deref<Target = Self>,
-    {
-        for c in checkpoints {
-            if c.has_signature(signature) {
-                return true;
-            }
-        }
-        false
-    }
-    #[cfg(test)]
-    pub fn clear_all<U>(checkpoints: &mut [U]) -> bool
-    where
-        U: DerefMut<Target = Self>,
-    {
-        for c in checkpoints.iter_mut() {
-            c.clear();
-        }
-        false
-    }
+        self.cache.clear();
+    } 
 }
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use solana_sdk::hash::hash;
-    use solana_sdk::transaction::TransactionError;
 
-    type BankStatusCache = StatusCache<TransactionError>;
-
-    #[test]
-    fn test_has_signature() {
-        let sig = Signature::default();
-        let blockhash = hash(Hash::default().as_ref());
-        let mut status_cache = BankStatusCache::new(&blockhash);
-        assert_eq!(status_cache.has_signature(&sig), false);
-        assert_eq!(status_cache.get_signature_status(&sig), None);
-        status_cache.add(&sig);
-        assert_eq!(status_cache.has_signature(&sig), true);
-        assert_eq!(status_cache.get_signature_status(&sig), Some(Ok(())));
-    }
-
-    #[test]
-    fn test_has_signature_checkpoint() {
-        let sig = Signature::default();
-        let blockhash = hash(Hash::default().as_ref());
-        let mut first = BankStatusCache::new(&blockhash);
-        first.add(&sig);
-        assert_eq!(first.get_signature_status(&sig), Some(Ok(())));
-        let blockhash = hash(blockhash.as_ref());
-        let second = StatusCache::new(&blockhash);
-        let checkpoints = [&second, &first];
-        assert_eq!(
-            BankStatusCache::get_signature_status_all(&checkpoints, &sig),
-            Some((1, Ok(()))),
-        );
-        assert!(StatusCache::has_signature_all(&checkpoints, &sig));
-    }
-
-    #[test]
-    fn test_new_cache() {
-        let sig = Signature::default();
-        let blockhash = hash(Hash::default().as_ref());
-        let mut first = BankStatusCache::new(&blockhash);
-        first.add(&sig);
-        assert_eq!(first.get_signature_status(&sig), Some(Ok(())));
-        let blockhash = hash(blockhash.as_ref());
-        first.new_cache(&blockhash);
-        assert_eq!(first.get_signature_status(&sig), Some(Ok(())));
-        assert!(first.has_signature(&sig));
-        first.clear();
-        assert_eq!(first.get_signature_status(&sig), None);
-        assert!(!first.has_signature(&sig));
-    }
-
-    #[test]
-    fn test_new_cache_full() {
-        let sig = Signature::default();
-        let blockhash = hash(Hash::default().as_ref());
-        let mut first = BankStatusCache::new(&blockhash);
-        first.add(&sig);
-        assert_eq!(first.get_signature_status(&sig), Some(Ok(())));
-        for _ in 0..(MAX_CACHE_ENTRIES + 1) {
-            let blockhash = hash(blockhash.as_ref());
-            first.new_cache(&blockhash);
-        }
-        assert_eq!(first.get_signature_status(&sig), None);
-        assert!(!first.has_signature(&sig));
-    }
-
-    #[test]
-    fn test_status_cache_squash_has_signature() {
-        let sig = Signature::default();
-        let blockhash = hash(Hash::default().as_ref());
-        let mut first = BankStatusCache::new(&blockhash);
-        first.add(&sig);
-        assert_eq!(first.get_signature_status(&sig), Some(Ok(())));
-
-        // give first a merge
-        let blockhash = hash(blockhash.as_ref());
-        first.new_cache(&blockhash);
-
-        let blockhash = hash(blockhash.as_ref());
-        let mut second = BankStatusCache::new(&blockhash);
-        first.freeze();
-        second.squash(&[&first]);
-
-        assert_eq!(second.get_signature_status(&sig), Some(Ok(())));
-        assert!(second.has_signature(&sig));
-    }
-
-    #[test]
-    fn test_status_cache_squash_overflow() {
-        let mut blockhash = hash(Hash::default().as_ref());
-        let mut cache = BankStatusCache::new(&blockhash);
-
-        let parents: Vec<_> = (0..MAX_CACHE_ENTRIES)
-            .map(|_| {
-                blockhash = hash(blockhash.as_ref());
-
-                let mut p = BankStatusCache::new(&blockhash);
-                p.freeze();
-                p
-            })
-            .collect();
-
-        let mut parents_refs: Vec<_> = parents.iter().collect();
-
-        blockhash = hash(Hash::default().as_ref());
-        let mut root = BankStatusCache::new(&blockhash);
-
-        let sig = Signature::default();
-        root.add(&sig);
-
-        parents_refs.push(&root);
-
-        assert_eq!(root.get_signature_status(&sig), Some(Ok(())));
-        assert!(root.has_signature(&sig));
-
-        // will overflow
-        cache.squash(&parents_refs);
-
-        assert_eq!(cache.get_signature_status(&sig), None);
-        assert!(!cache.has_signature(&sig));
-    }
-
-    #[test]
-    fn test_failure_status() {
-        let sig = Signature::default();
-        let blockhash = hash(Hash::default().as_ref());
-        let mut first = StatusCache::new(&blockhash);
-        first.add(&sig);
-        first.save_failure_status(&sig, TransactionError::DuplicateSignature);
-        assert_eq!(first.has_signature(&sig), true);
-        assert_eq!(
-            first.get_signature_status(&sig),
-            Some(Err(TransactionError::DuplicateSignature)),
-        );
-    }
-
-    #[test]
-    fn test_clear_signatures() {
-        let sig = Signature::default();
-        let blockhash = hash(Hash::default().as_ref());
-        let mut first = StatusCache::new(&blockhash);
-        first.add(&sig);
-        assert_eq!(first.has_signature(&sig), true);
-        first.save_failure_status(&sig, TransactionError::DuplicateSignature);
-        assert_eq!(
-            first.get_signature_status(&sig),
-            Some(Err(TransactionError::DuplicateSignature)),
-        );
-        first.clear();
-        assert_eq!(first.has_signature(&sig), false);
-        assert_eq!(first.get_signature_status(&sig), None);
-    }
-    #[test]
-    fn test_clear_signatures_all() {
-        let sig = Signature::default();
-        let blockhash = hash(Hash::default().as_ref());
-        let mut first = StatusCache::new(&blockhash);
-        first.add(&sig);
-        assert_eq!(first.has_signature(&sig), true);
-        let mut second = StatusCache::new(&blockhash);
-        let mut checkpoints = [&mut second, &mut first];
-        BankStatusCache::clear_all(&mut checkpoints);
-        assert_eq!(
-            BankStatusCache::has_signature_all(&checkpoints, &sig),
-            false
-        );
-    }
-
-    #[test]
-    fn test_status_cache_freeze() {
-        let sig = Signature::default();
-        let blockhash = hash(Hash::default().as_ref());
-        let mut cache: StatusCache<()> = StatusCache::new(&blockhash);
-
-        cache.freeze();
-        cache.freeze();
-
-        cache.add(&sig);
-        assert_eq!(cache.has_signature(&sig), false);
-    }
-
-}
+// #[cfg(test)]
+// mod tests {
+//     use super::*;
+//     use solana_sdk::hash::hash;
+//     use solana_sdk::transaction::TransactionError;
+// 
+//     type BankStatusCache = StatusCache<TransactionError>;
+// 
+//     #[test]
+//     fn test_has_signature() {
+//         let sig = Signature::default();
+//         let blockhash = hash(Hash::default().as_ref());
+//         let mut status_cache = BankStatusCache::new(&blockhash);
+//         assert_eq!(status_cache.has_signature(&sig), false);
+//         assert_eq!(status_cache.get_signature_status(&sig), None);
+//         status_cache.add(&sig);
+//         assert_eq!(status_cache.has_signature(&sig), true);
+//         assert_eq!(status_cache.get_signature_status(&sig), Some(Ok(())));
+//     }
+// 
+//     #[test]
+//     fn test_has_signature_checkpoint() {
+//         let sig = Signature::default();
+//         let blockhash = hash(Hash::default().as_ref());
+//         let mut first = BankStatusCache::new(&blockhash);
+//         first.add(&sig);
+//         assert_eq!(first.get_signature_status(&sig), Some(Ok(())));
+//         let blockhash = hash(blockhash.as_ref());
+//         let second = StatusCache::new(&blockhash);
+//         let checkpoints = [&second, &first];
+//         assert_eq!(
+//             BankStatusCache::get_signature_status_all(&checkpoints, &sig),
+//             Some((1, Ok(()))),
+//         );
+//         assert!(StatusCache::has_signature_all(&checkpoints, &sig));
+//     }
+// 
+//     #[test]
+//     fn test_new_cache() {
+//         let sig = Signature::default();
+//         let blockhash = hash(Hash::default().as_ref());
+//         let mut first = BankStatusCache::new(&blockhash);
+//         first.add(&sig);
+//         assert_eq!(first.get_signature_status(&sig), Some(Ok(())));
+//         let blockhash = hash(blockhash.as_ref());
+//         first.new_cache(&blockhash);
+//         assert_eq!(first.get_signature_status(&sig), Some(Ok(())));
+//         assert!(first.has_signature(&sig));
+//         first.clear();
+//         assert_eq!(first.get_signature_status(&sig), None);
+//         assert!(!first.has_signature(&sig));
+//     }
+// 
+//     #[test]
+//     fn test_new_cache_full() {
+//         let sig = Signature::default();
+//         let blockhash = hash(Hash::default().as_ref());
+//         let mut first = BankStatusCache::new(&blockhash);
+//         first.add(&sig);
+//         assert_eq!(first.get_signature_status(&sig), Some(Ok(())));
+//         for _ in 0..(MAX_CACHE_ENTRIES + 1) {
+//             let blockhash = hash(blockhash.as_ref());
+//             first.new_cache(&blockhash);
+//         }
+//         assert_eq!(first.get_signature_status(&sig), None);
+//         assert!(!first.has_signature(&sig));
+//     }
+// 
+//     #[test]
+//     fn test_status_cache_squash_has_signature() {
+//         let sig = Signature::default();
+//         let blockhash = hash(Hash::default().as_ref());
+//         let mut first = BankStatusCache::new(&blockhash);
+//         first.add(&sig);
+//         assert_eq!(first.get_signature_status(&sig), Some(Ok(())));
+// 
+//         // give first a merge
+//         let blockhash = hash(blockhash.as_ref());
+//         first.new_cache(&blockhash);
+// 
+//         let blockhash = hash(blockhash.as_ref());
+//         let mut second = BankStatusCache::new(&blockhash);
+//         first.freeze();
+//         second.squash(&[&first]);
+// 
+//         assert_eq!(second.get_signature_status(&sig), Some(Ok(())));
+//         assert!(second.has_signature(&sig));
+//     }
+// 
+//     #[test]
+//     fn test_status_cache_squash_overflow() {
+//         let mut blockhash = hash(Hash::default().as_ref());
+//         let mut cache = BankStatusCache::new(&blockhash);
+// 
+//         let parents: Vec<_> = (0..MAX_CACHE_ENTRIES)
+//             .map(|_| {
+//                 blockhash = hash(blockhash.as_ref());
+// 
+//                 let mut p = BankStatusCache::new(&blockhash);
+//                 p.freeze();
+//                 p
+//             })
+//             .collect();
+// 
+//         let mut parents_refs: Vec<_> = parents.iter().collect();
+// 
+//         blockhash = hash(Hash::default().as_ref());
+//         let mut root = BankStatusCache::new(&blockhash);
+// 
+//         let sig = Signature::default();
+//         root.add(&sig);
+// 
+//         parents_refs.push(&root);
+// 
+//         assert_eq!(root.get_signature_status(&sig), Some(Ok(())));
+//         assert!(root.has_signature(&sig));
+// 
+//         // will overflow
+//         cache.squash(&parents_refs);
+// 
+//         assert_eq!(cache.get_signature_status(&sig), None);
+//         assert!(!cache.has_signature(&sig));
+//     }
+// 
+//     #[test]
+//     fn test_failure_status() {
+//         let sig = Signature::default();
+//         let blockhash = hash(Hash::default().as_ref());
+//         let mut first = StatusCache::new(&blockhash);
+//         first.add(&sig);
+//         first.save_failure_status(&sig, TransactionError::DuplicateSignature);
+//         assert_eq!(first.has_signature(&sig), true);
+//         assert_eq!(
+//             first.get_signature_status(&sig),
+//             Some(Err(TransactionError::DuplicateSignature)),
+//         );
+//     }
+// 
+//     #[test]
+//     fn test_clear_signatures() {
+//         let sig = Signature::default();
+//         let blockhash = hash(Hash::default().as_ref());
+//         let mut first = StatusCache::new(&blockhash);
+//         first.add(&sig);
+//         assert_eq!(first.has_signature(&sig), true);
+//         first.save_failure_status(&sig, TransactionError::DuplicateSignature);
+//         assert_eq!(
+//             first.get_signature_status(&sig),
+//             Some(Err(TransactionError::DuplicateSignature)),
+//         );
+//         first.clear();
+//         assert_eq!(first.has_signature(&sig), false);
+//         assert_eq!(first.get_signature_status(&sig), None);
+//     }
+//     #[test]
+//     fn test_clear_signatures_all() {
+//         let sig = Signature::default();
+//         let blockhash = hash(Hash::default().as_ref());
+//         let mut first = StatusCache::new(&blockhash);
+//         first.add(&sig);
+//         assert_eq!(first.has_signature(&sig), true);
+//         let mut second = StatusCache::new(&blockhash);
+//         let mut checkpoints = [&mut second, &mut first];
+//         BankStatusCache::clear_all(&mut checkpoints);
+//         assert_eq!(
+//             BankStatusCache::has_signature_all(&checkpoints, &sig),
+//             false
+//         );
+//     }
+// 
+//     #[test]
+//     fn test_status_cache_freeze() {
+//         let sig = Signature::default();
+//         let blockhash = hash(Hash::default().as_ref());
+//         let mut cache: StatusCache<()> = StatusCache::new(&blockhash);
+// 
+//         cache.freeze();
+//         cache.freeze();
+// 
+//         cache.add(&sig);
+//         assert_eq!(cache.has_signature(&sig), false);
+//     }
+// 
+// }

--- a/runtime/src/status_cache.rs
+++ b/runtime/src/status_cache.rs
@@ -1,23 +1,27 @@
-use hashbrown::HashMap;
+use hashbrown::{HashMap, HashSet};
 use log::*;
 use solana_sdk::hash::Hash;
 use solana_sdk::signature::Signature;
+
+const MAX_CACHE_ENTRIES: usize = solana_sdk::timing::MAX_HASH_AGE_IN_SECONDS;
 
 // Store forks in a single chunk of memory to avoid another lookup.
 pub type ForkId = u64;
 pub type ForkStatus<T> = Vec<(ForkId, T)>;
 type SignatureMap<T> = HashMap<Signature, ForkStatus<T>>;
-type StatusMap<T> = HashMap<Hash, SignatureMap<T>>;
+type StatusMap<T> = HashMap<Hash, (ForkId, SignatureMap<T>)>;
 
 pub struct StatusCache<T: Clone> {
     /// all signatures seen during a hash period
     cache: StatusMap<T>,
+    roots: HashSet<ForkId>,
 }
 
 impl<T: Clone> Default for StatusCache<T> {
     fn default() -> Self {
         Self {
             cache: HashMap::default(),
+            roots: HashSet::default(),
         }
     }
 }
@@ -32,11 +36,11 @@ impl<T: Clone> StatusCache<T> {
     ) -> Option<(ForkId, T)> {
         self.cache
             .get(transaction_blockhash)
-            .and_then(|sigmap| sigmap.get(sig))
+            .and_then(|(_, sigmap)| sigmap.get(sig))
             .and_then(|stored_forks| {
                 stored_forks
                     .iter()
-                    .filter(|(f, _)| ancestors.get(f).is_some())
+                    .filter(|(f, _)| ancestors.get(f).is_some() || self.roots.get(f).is_some())
                     .nth(0)
             })
             .cloned()
@@ -53,26 +57,38 @@ impl<T: Clone> StatusCache<T> {
             trace!("get_signature_status_slow: trying {}", blockhash);
             if let Some((forkid, res)) = self.get_signature_status(sig, blockhash, ancestors) {
                 trace!("get_signature_status_slow: got {}", forkid);
-                return ancestors.get(&forkid).map(|id| (*id, res));
+                return ancestors
+                    .get(&forkid)
+                    .map(|id| (*id, res.clone()))
+                    .or(Some((ancestors.len(), res)));
             }
         }
         None
+    }
+
+    pub fn register_hash(&mut self, blockhash: Hash, fork: ForkId) {
+        let prev = self.cache.insert(blockhash, (fork, HashMap::new()));
+        assert!(prev.is_none(), "expecting new blockhash");
+    }
+
+    pub fn add_root(&mut self, fork: ForkId) {
+        self.roots.insert(fork);
+        if self.roots.len() > MAX_CACHE_ENTRIES {
+            if let Some(min) = self.roots.iter().min().cloned() {
+                self.roots.remove(&min);
+                self.cache.retain(|_, (fork, _)| *fork > min);
+            }
+        }
     }
 
     /// Insert a new signature for a specific fork.
     pub fn insert(&mut self, transaction_blockhash: &Hash, sig: &Signature, fork: ForkId, res: T) {
         let sig_map = self
             .cache
-            .entry(*transaction_blockhash)
-            .or_insert(HashMap::new());
-        let sig_forks = sig_map.entry(*sig).or_insert(vec![]);
+            .get_mut(transaction_blockhash)
+            .expect("new map should be created with register_hash");
+        let sig_forks = sig_map.1.entry(*sig).or_insert(vec![]);
         sig_forks.push((fork, res));
-    }
-
-    /// Remove an expired blockhash
-    pub fn remove_expired_blockhash(&mut self, hash: &Hash) {
-        trace!("remove_expired_blockhash {}", hash);
-        self.cache.remove(hash);
     }
 
     /// Clear for testing

--- a/runtime/src/status_cache.rs
+++ b/runtime/src/status_cache.rs
@@ -34,15 +34,12 @@ impl<T: Clone> StatusCache<T> {
         transaction_blockhash: &Hash,
         ancestors: &HashMap<ForkId, usize>,
     ) -> Option<(ForkId, T)> {
-        self.cache
-            .get(transaction_blockhash)
-            .and_then(|(_, sigmap)| sigmap.get(sig))
-            .and_then(|stored_forks| {
-                stored_forks
-                    .iter()
-                    .filter(|(f, _)| ancestors.get(f).is_some() || self.roots.get(f).is_some())
-                    .nth(0)
-            })
+        let (_, sigmap) = self.cache.get(transaction_blockhash)?;
+        let stored_forks = sigmap.get(sig)?;
+        stored_forks
+            .iter()
+            .filter(|(f, _)| ancestors.get(f).is_some() || self.roots.get(f).is_some())
+            .nth(0)
             .cloned()
     }
 


### PR DESCRIPTION
#### Problem

Recursive status cache is to slow (@sakridge).

#### Summary of Changes

Use a single data structure to minimize the number of lookups.

Fixes #2497 

tag: @rob-solana @sakridge 