### PR TITLE
Move Transaction::hash() out of SDK

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -4,7 +4,7 @@
 
 use crate::cluster_info::ClusterInfo;
 use crate::entry;
-use crate::entry::Entry;
+use crate::entry::{hash_transactions, Entry};
 use crate::leader_schedule_utils;
 use crate::packet;
 use crate::packet::SharedPackets;
@@ -236,7 +236,7 @@ impl BankingStage {
         debug!("processed: {} ", processed_transactions.len());
         // unlock all the accounts with errors which are filtered by the above `filter_map`
         if !processed_transactions.is_empty() {
-            let hash = Transaction::hash(&processed_transactions);
+            let hash = hash_transactions(&processed_transactions);
             // record and unlock will unlock all the successfull transactions
             poh.lock()
                 .unwrap()

--- a/core/src/sigverify.rs
+++ b/core/src/sigverify.rs
@@ -392,7 +392,6 @@ mod tests {
             Some(sig_start as usize)
         );
         assert_eq!(sig_len, 1);
-        assert!(tx.verify_signature());
     }
 
     #[test]

--- a/sdk/src/transaction.rs
+++ b/sdk/src/transaction.rs
@@ -1,6 +1,6 @@
 //! Defines a Transaction type to package an atomic sequence of instructions.
 
-use crate::hash::{Hash, Hasher};
+use crate::hash::Hash;
 use crate::instruction::{CompiledInstruction, Instruction, InstructionError};
 use crate::message::Message;
 use crate::packet::PACKET_DATA_SIZE;
@@ -215,13 +215,6 @@ impl Transaction {
         self.sign_unchecked(keypairs, recent_blockhash);
     }
 
-    /// Verify only the transaction signature.
-    pub fn verify_signature(&self) -> bool {
-        self.signatures
-            .iter()
-            .all(|s| s.verify(&self.from().as_ref(), &self.message()))
-    }
-
     /// Verify that references in the instructions are valid
     pub fn verify_refs(&self) -> bool {
         for instruction in &self.instructions {
@@ -235,21 +228,6 @@ impl Transaction {
             }
         }
         true
-    }
-
-    pub fn from(&self) -> &Pubkey {
-        &self.account_keys[0]
-    }
-
-    // a hash of a slice of transactions only needs to hash the signatures
-    pub fn hash(transactions: &[Transaction]) -> Hash {
-        let mut hasher = Hasher::default();
-        transactions.iter().for_each(|tx| {
-            if !tx.signatures.is_empty() {
-                hasher.hash(&tx.signatures[0].as_ref());
-            }
-        });
-        hasher.result()
     }
 
     pub fn serialized_size(&self) -> Result<u64, Error> {


### PR DESCRIPTION
#### Problem

verify_signature() was only used in a test that was testing binary layout. It only worked because the test transaction only had one signature.

from() was only used by verify_signature() and that's something we'd typically called `pubkey()`.

hash() didn't return the hash of the Transaction, as you might guess and it's only used for PoH.

#### Summary of Changes

* Delete `verify_signature()` and `from()`
* Move `hash()` into Entry