### PR TITLE
enable leader rotation in beta testnet

### DIFF
--- a/ci/testnet-manager.sh
+++ b/ci/testnet-manager.sh
@@ -211,7 +211,6 @@ start() {
       RUST_LOG=solana=info \
         ci/testnet-deploy.sh beta-testnet-solana-com ec2 us-west-1a \
           -t "$CHANNEL_OR_TAG" -n 3 -c 0 -u -P -a eipalloc-0f286cf8a0771ce35 \
-          -b \
           ${maybeReuseLedger:+-r} \
           ${maybeDelete:+-D}
     )


### PR DESCRIPTION
#### Problem
Leader rotation is disabled in beta testnet

#### Summary of Changes
Enable it.