### PR TITLE
Add SystemInstruction::CheckSignature

### DIFF
--- a/runtime/src/system_program.rs
+++ b/runtime/src/system_program.rs
@@ -93,6 +93,7 @@ pub fn entrypoint(
                 assign_account_to_program(keyed_accounts, &program_id)
             }
             SystemInstruction::Move { lamports } => move_lamports(keyed_accounts, lamports),
+            SystemInstruction::CheckSignature => Ok(()),
         }
         .map_err(|e| InstructionError::CustomError(serialize(&e).unwrap()))
     } else {
@@ -309,5 +310,20 @@ mod tests {
         );
         assert_eq!(bank.get_balance(&alice_pubkey), 50);
         assert_eq!(bank.get_balance(&mallory_pubkey), 50);
+    }
+
+    #[test]
+    fn test_system_check_signature() {
+        let (genesis_block, alice_keypair) = GenesisBlock::new(100);
+        let alice_pubkey = alice_keypair.pubkey();
+
+        // Fund to account to bypass AccountNotFound error
+        let bank = Bank::new(&genesis_block);
+        let bank_client = BankClient::new(&bank);
+
+        let instruction = SystemInstruction::new_check_signature(&alice_pubkey);
+        bank_client
+            .process_instruction(&alice_keypair, instruction)
+            .unwrap();
     }
 }

--- a/sdk/src/system_instruction.rs
+++ b/sdk/src/system_instruction.rs
@@ -29,6 +29,8 @@ pub enum SystemInstruction {
     /// * Transaction::keys[0] - source
     /// * Transaction::keys[1] - destination
     Move { lamports: u64 },
+    /// Do nothing but require a signature
+    CheckSignature,
 }
 
 impl SystemInstruction {
@@ -89,6 +91,16 @@ impl SystemInstruction {
             .iter()
             .map(|(to_id, lamports)| SystemInstruction::new_move(from_id, to_id, *lamports))
             .collect()
+    }
+
+    /// Do nothing but require a signature
+    pub fn new_check_signature(from_id: &Pubkey) -> Instruction {
+        let account_metas = vec![AccountMeta::new(*from_id, true)];
+        Instruction::new(
+            system_program::id(),
+            &SystemInstruction::CheckSignature,
+            account_metas,
+        )
     }
 }
 


### PR DESCRIPTION
#### Problem

Sometimes a program doesn't require a signature to progress, but some signature corresponding to a system account needs to pay the transaction fee.

#### Summary of Changes

Add a system instruction that'll does nothing except ensures the pubkey is signed. If it's the first instruction in a transaction, that pubkey will pay the transaction fee.

