### PR TITLE
Fix EC2 scripts for blockstream startup

### DIFF
--- a/net/scripts/ec2-provider.sh
+++ b/net/scripts/ec2-provider.sh
@@ -249,12 +249,14 @@ cloud_CreateInstances() {
     fi
 
     declare instanceId
-    IFS=: read -r instanceId _ < <(echo "${instances[0]}")
+    IFS=: read -r instanceId publicIp privateIp zone < <(echo "${instances[0]}")
     (
       set -x
       # TODO: Poll that the instance has moved to the 'running' state instead of
       #       blindly sleeping for 30 seconds...
       sleep 30
+      declare region=
+      region=$(__cloud_GetRegion "$zone")
       aws ec2 associate-address \
         --instance-id "$instanceId" \
         --region "$region" \


### PR DESCRIPTION
#### Problem
The testnet with EC2 configuration is failing to start

#### Summary of Changes
The blockstream node is configured with a static IP address. A bug got introduced with multi region cloud support that used wrong region for blockstream node. Fixed the bug.