### PR TITLE
Fix manifest path for cargo commands

### DIFF
--- a/multinode-demo/common.sh
+++ b/multinode-demo/common.sh
@@ -42,7 +42,8 @@ else
     if [[ -n $NDEBUG ]]; then
       maybe_release=--release
     fi
-    printf "cargo run $maybe_release $maybe_package --bin solana-%s %s -- " "$program" "$features"
+    declare manifest_path="--manifest-path=$program/Cargo.toml"
+    printf "cargo run $manifest_path $maybe_release $maybe_package --bin solana-%s %s -- " "$program" "$features"
   }
   if [[ -n $SOLANA_CUDA ]]; then
     # shellcheck disable=2154 # 'here' is referenced but not assigned


### PR DESCRIPTION
#### Problem

Since our change to virtual manifests, the SOLANA_CUDA env variable was not being passed to the fullnode

#### Summary of Changes

Point to the correct manifest for all modules used by multinode-demo
