### PR TITLE
Fixup wallet-sanity to match new balance string

### DIFF
--- a/scripts/wallet-sanity.sh
+++ b/scripts/wallet-sanity.sh
@@ -62,13 +62,13 @@ if ! "$node_readiness"; then
 fi
 
 $solana_wallet "${entrypoint[@]}" address
-check_balance_output "No account found" "Your balance is: 0"
+check_balance_output "0 lamports"
 $solana_wallet "${entrypoint[@]}" airdrop 60
-check_balance_output "Your balance is: 60"
+check_balance_output "60 lamports"
 $solana_wallet "${entrypoint[@]}" airdrop 40
-check_balance_output "Your balance is: 100"
+check_balance_output "100 lamports"
 pay_and_confirm $garbage_address 99
-check_balance_output "Your balance is: 1"
+check_balance_output "1 lamport"
 
 echo PASS
 exit 0


### PR DESCRIPTION
#### Problem
Wallet sanity never passes on master, due to changes in `solana-wallet balance` returns (https://github.com/solana-labs/solana/commit/4247fa946e8f8c960cd38939d14333f9ef1f7b1a)

Note: wallet-sanity is currently being ignored in CI, which is why this issue didn't come to light sooner. (See https://github.com/solana-labs/solana/issues/2474)

#### Summary of Changes
Update expected strings
