### PR TITLE
Fix resetting PohRecorder to wrong bank

### DIFF
--- a/core/src/fullnode.rs
+++ b/core/src/fullnode.rs
@@ -105,13 +105,15 @@ impl Fullnode {
             bank.tick_height(),
             bank.last_blockhash(),
         );
+        let blocktree = Arc::new(blocktree);
         let (poh_recorder, entry_receiver) = PohRecorder::new(
             bank.tick_height(),
             bank.last_blockhash(),
             bank.slot(),
-            leader_schedule_utils::next_leader_slot(&id, bank.slot(), &bank),
+            leader_schedule_utils::next_leader_slot(&id, bank.slot(), &bank, Some(&blocktree)),
             bank.ticks_per_slot(),
             &id,
+            &blocktree,
         );
         let poh_recorder = Arc::new(Mutex::new(poh_recorder));
         let poh_service = PohService::new(poh_recorder.clone(), &config.tick_config, &exit);
@@ -130,7 +132,6 @@ impl Fullnode {
             node.sockets.gossip.local_addr().unwrap()
         );
 
-        let blocktree = Arc::new(blocktree);
         let bank_forks = Arc::new(RwLock::new(bank_forks));
 
         node.info.wallclock = timestamp();

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -206,29 +206,38 @@ impl ReplayStage {
         grace_ticks: u64,
     ) {
         trace!("{} checking poh slot {}", my_id, poh_slot);
-        if blocktree.meta(poh_slot).unwrap().is_some() {
-            // We've already broadcasted entries for this slot, skip it
+        if reached_leader_tick && blocktree.meta(poh_slot).unwrap().is_some() {
+            // We've already broadcasted entries for this slot, skip it. Since
+            // we are skipping our leader slot, also tell poh recorder when we
+            // should be leader again
+            let start_slot = poh_recorder.lock().unwrap().start_slot();
+            let r_bank_forks = bank_forks.read().unwrap();
 
-            // Since we are skipping our leader slot, let's tell poh recorder when we should be
-            // leader again
-            if reached_leader_tick {
-                let _ = bank_forks.read().unwrap().get(poh_slot).map(|bank| {
-                    let next_leader_slot =
-                        leader_schedule_utils::next_leader_slot(&my_id, bank.slot(), &bank);
-                    let mut poh = poh_recorder.lock().unwrap();
-                    let start_slot = poh.start_slot();
-                    poh.reset(
-                        bank.tick_height(),
-                        bank.last_blockhash(),
-                        start_slot,
-                        next_leader_slot,
-                        bank.ticks_per_slot(),
-                    );
-                });
-            }
+            // Start slot must be frozen by the time start_leader() is called.
+            let start_slot_bank = r_bank_forks
+                .get(start_slot)
+                .expect("start slot doesn't exist");
+
+            assert!(start_slot_bank.is_frozen());
+
+            let next_leader_slot = leader_schedule_utils::next_leader_slot(
+                &my_id,
+                start_slot_bank.slot(),
+                &start_slot_bank,
+            );
+            trace!("poh slot skipped, reset start slot to: {}", start_slot);
+            let mut poh = poh_recorder.lock().unwrap();
+            poh.reset(
+                start_slot_bank.tick_height(),
+                start_slot_bank.last_blockhash(),
+                start_slot,
+                next_leader_slot,
+                start_slot_bank.ticks_per_slot(),
+            );
 
             return;
         }
+
         if bank_forks.read().unwrap().get(poh_slot).is_none() {
             let frozen = bank_forks.read().unwrap().frozen_banks();
             let parent_slot = poh_recorder.lock().unwrap().start_slot();

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -220,11 +220,8 @@ impl ReplayStage {
 
             assert!(start_slot_bank.is_frozen());
 
-            let next_leader_slot = leader_schedule_utils::next_leader_slot(
-                &my_id,
-                start_slot_bank.slot(),
-                &start_slot_bank,
-            );
+            let next_leader_slot =
+                leader_schedule_utils::next_leader_slot(&my_id, poh_slot, &start_slot_bank);
             trace!("poh slot skipped, reset start slot to: {}", start_slot);
             let mut poh = poh_recorder.lock().unwrap();
             poh.reset(

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -208,8 +208,10 @@ pub mod tests {
         let blocktree_path = get_tmp_ledger_path!();
         let (blocktree, l_receiver) = Blocktree::open_with_signal(&blocktree_path)
             .expect("Expected to successfully open ledger");
+        let blocktree = Arc::new(blocktree);
         let bank = bank_forks.working_bank();
-        let (exit, poh_recorder, poh_service, _entry_receiver) = create_test_recorder(&bank);
+        let (exit, poh_recorder, poh_service, _entry_receiver) =
+            create_test_recorder(&bank, &blocktree);
         let voting_keypair = Keypair::new();
         let (storage_entry_sender, storage_entry_receiver) = channel();
         let tvu = Tvu::new(
@@ -225,7 +227,7 @@ pub mod tests {
                     fetch: target1.sockets.tvu,
                 }
             },
-            Arc::new(blocktree),
+            blocktree,
             STORAGE_ROTATE_TEST_COUNT,
             &StorageState::default(),
             None,


### PR DESCRIPTION
#### Problem
Resetting the PohRecorder to the wrong bank on skipping slots causes future PohRecorder tick height to be out of sync with bank tick heights for future leader slots.

#### Summary of Changes
Reset PohRecorder to correct bank.

Fixes #
