### PR TITLE
Integrate Message into Transaction

### DIFF
--- a/bench-tps/src/bench.rs
+++ b/bench-tps/src/bench.rs
@@ -508,7 +508,7 @@ fn do_tx_transfers(
 }
 
 fn verify_funding_transfer(client: &ThinClient, tx: &Transaction, amount: u64) -> bool {
-    for a in &tx.account_keys[1..] {
+    for a in &tx.message().account_keys[1..] {
         if client.get_balance(a).unwrap_or(0) >= amount {
             return true;
         }
@@ -577,7 +577,7 @@ fn fund_keys(client: &ThinClient, source: &Keypair, dests: &[Keypair], lamports:
             while !to_fund_txs.is_empty() {
                 let receivers = to_fund_txs
                     .iter()
-                    .fold(0, |len, (_, tx)| len + tx.instructions.len());
+                    .fold(0, |len, (_, tx)| len + tx.message().instructions.len());
 
                 println!(
                     "{} {} to {} in {} txs",

--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -196,7 +196,7 @@ impl RpcClient {
 
             // Re-sign any failed transactions with a new blockhash and retry
             let blockhash =
-                self.get_new_blockhash(&transactions_signatures[0].0.recent_blockhash)?;
+                self.get_new_blockhash(&transactions_signatures[0].0.message().recent_blockhash)?;
             transactions = transactions_signatures
                 .into_iter()
                 .map(|(mut transaction, _)| {
@@ -212,7 +212,7 @@ impl RpcClient {
         tx: &mut Transaction,
         signer_key: &T,
     ) -> Result<(), Box<dyn error::Error>> {
-        let blockhash = self.get_new_blockhash(&tx.recent_blockhash)?;
+        let blockhash = self.get_new_blockhash(&tx.message().recent_blockhash)?;
         tx.sign(&[signer_key], blockhash);
         Ok(())
     }
@@ -744,10 +744,10 @@ mod tests {
 
         assert_ne!(prev_tx, tx);
         assert_ne!(prev_tx.signatures, tx.signatures);
-        assert_ne!(prev_tx.recent_blockhash, tx.recent_blockhash);
-        assert_eq!(prev_tx.fee, tx.fee);
-        assert_eq!(prev_tx.account_keys, tx.account_keys);
-        assert_eq!(prev_tx.instructions, tx.instructions);
+        assert_ne!(
+            prev_tx.message().recent_blockhash,
+            tx.message().recent_blockhash
+        );
     }
 
 }

--- a/core/benches/banking_stage.rs
+++ b/core/benches/banking_stage.rs
@@ -67,8 +67,8 @@ fn bench_banking_stage_multi_accounts(bencher: &mut Bencher) {
             let from: Vec<u8> = (0..64).map(|_| thread_rng().gen()).collect();
             let to: Vec<u8> = (0..64).map(|_| thread_rng().gen()).collect();
             let sig: Vec<u8> = (0..64).map(|_| thread_rng().gen()).collect();
-            new.account_keys[0] = Pubkey::new(&from[0..32]);
-            new.account_keys[1] = Pubkey::new(&to[0..32]);
+            new.message.account_keys[0] = Pubkey::new(&from[0..32]);
+            new.message.account_keys[1] = Pubkey::new(&to[0..32]);
             new.signatures = vec![Signature::new(&sig[0..64])];
             new
         })
@@ -77,7 +77,7 @@ fn bench_banking_stage_multi_accounts(bencher: &mut Bencher) {
     transactions.iter().for_each(|tx| {
         let fund = SystemTransaction::new_move(
             &mint_keypair,
-            &tx.account_keys[0],
+            &tx.message.account_keys[0],
             mint_total / txes as u64,
             genesis_block.hash(),
             0,
@@ -159,25 +159,25 @@ fn bench_banking_stage_multi_programs(bencher: &mut Bencher) {
             let from: Vec<u8> = (0..32).map(|_| thread_rng().gen()).collect();
             let sig: Vec<u8> = (0..64).map(|_| thread_rng().gen()).collect();
             let to: Vec<u8> = (0..32).map(|_| thread_rng().gen()).collect();
-            new.account_keys[0] = Pubkey::new(&from[0..32]);
-            new.account_keys[1] = Pubkey::new(&to[0..32]);
-            let prog = new.instructions[0].clone();
+            new.message.account_keys[0] = Pubkey::new(&from[0..32]);
+            new.message.account_keys[1] = Pubkey::new(&to[0..32]);
+            let prog = new.message.instructions[0].clone();
             for i in 1..progs {
                 //generate programs that spend to random keys
                 let to: Vec<u8> = (0..32).map(|_| thread_rng().gen()).collect();
                 let to_key = Pubkey::new(&to[0..32]);
-                new.account_keys.push(to_key);
-                assert_eq!(new.account_keys.len(), i + 2);
-                new.instructions.push(prog.clone());
-                assert_eq!(new.instructions.len(), i + 1);
-                new.instructions[i].accounts[1] = 1 + i as u8;
+                new.message.account_keys.push(to_key);
+                assert_eq!(new.message.account_keys.len(), i + 2);
+                new.message.instructions.push(prog.clone());
+                assert_eq!(new.message.instructions.len(), i + 1);
+                new.message.instructions[i].accounts[1] = 1 + i as u8;
                 assert_eq!(new.key(i, 1), Some(&to_key));
                 assert_eq!(
-                    new.account_keys[new.instructions[i].accounts[1] as usize],
+                    new.message.account_keys[new.message.instructions[i].accounts[1] as usize],
                     to_key
                 );
             }
-            assert_eq!(new.instructions.len(), progs);
+            assert_eq!(new.message.instructions.len(), progs);
             new.signatures = vec![Signature::new(&sig[0..64])];
             new
         })
@@ -185,7 +185,7 @@ fn bench_banking_stage_multi_programs(bencher: &mut Bencher) {
     transactions.iter().for_each(|tx| {
         let fund = SystemTransaction::new_move(
             &mint_keypair,
-            &tx.account_keys[0],
+            &tx.message.account_keys[0],
             mint_total / txes as u64,
             genesis_block.hash(),
             0,

--- a/core/src/chacha.rs
+++ b/core/src/chacha.rs
@@ -164,7 +164,7 @@ mod tests {
         use bs58;
         //  golden needs to be updated if blob stuff changes....
         let golden = Hash::new(
-            &bs58::decode("7CESTE6TiU1kz3HXoDA6fYUhfnneqbSm75zLYCBdczzp")
+            &bs58::decode("GnNzHbBRnn1WbrAXudmyxcqhaFiXQdzYWZpi6ToMM4pW")
                 .into_vec()
                 .unwrap(),
         );

--- a/core/src/sigverify.rs
+++ b/core/src/sigverify.rs
@@ -356,7 +356,7 @@ mod tests {
     fn test_system_transaction_layout() {
         let tx = test_tx();
         let tx_bytes = serialize(&tx).unwrap();
-        let message = tx.message();
+        let message_data = tx.message_data();
         let packet = sigverify::make_packet_from_transaction(tx.clone());
 
         let (sig_len, sig_start, msg_start_offset, pubkey_offset) =
@@ -371,7 +371,7 @@ mod tests {
             Some(pubkey_offset as usize)
         );
         assert_eq!(
-            memfind(&tx_bytes, &message),
+            memfind(&tx_bytes, &message_data),
             Some(msg_start_offset as usize)
         );
         assert_eq!(
@@ -386,7 +386,7 @@ mod tests {
         use crate::packet::PACKET_DATA_SIZE;
         let mut tx0 = test_tx();
         tx0.instructions[0].data = vec![1, 2, 3];
-        let message0a = tx0.message();
+        let message0a = tx0.message_data();
         let tx_bytes = serialize(&tx0).unwrap();
         assert!(tx_bytes.len() < PACKET_DATA_SIZE);
         assert_eq!(
@@ -398,7 +398,7 @@ mod tests {
         assert_eq!(tx1.instructions[0].data, vec![1, 2, 3]);
 
         tx0.instructions[0].data = vec![1, 2, 4];
-        let message0b = tx0.message();
+        let message0b = tx0.message_data();
         assert_ne!(message0a, message0b);
     }
 

--- a/core/src/sigverify.rs
+++ b/core/src/sigverify.rs
@@ -16,6 +16,9 @@ use std::mem::size_of;
 
 type TxOffsets = (Vec<u32>, Vec<u32>, Vec<u32>, Vec<u32>, Vec<Vec<u32>>);
 
+// The serialized size of Message::num_required_signatures.
+const NUM_REQUIRED_SIGNATURES_SIZE: usize = 1;
+
 #[cfg(feature = "cuda")]
 #[repr(C)]
 struct Elems {
@@ -128,7 +131,7 @@ pub fn get_packet_offsets(packet: &Packet, current_offset: u32) -> (u32, u32, u3
 
     let sig_start = current_offset as usize + sig_size;
     let msg_start = current_offset as usize + msg_start_offset;
-    let pubkey_start = msg_start + 1 + pubkey_size;
+    let pubkey_start = msg_start + NUM_REQUIRED_SIGNATURES_SIZE + pubkey_size;
 
     (
         sig_len as u32,

--- a/core/src/storage_stage.rs
+++ b/core/src/storage_stage.rs
@@ -401,9 +401,10 @@ impl StorageStage {
             // Go through the transactions, find proofs, and use them to update
             // the storage_keys with their signatures
             for tx in entry.transactions {
-                for (i, program_id) in tx.program_ids.iter().enumerate() {
+                let message = tx.message();
+                for (i, program_id) in message.program_ids.iter().enumerate() {
                     if solana_storage_api::check_id(&program_id) {
-                        match deserialize(&tx.instructions[i].data) {
+                        match deserialize(&message.instructions[i].data) {
                             Ok(StorageInstruction::SubmitMiningProof {
                                 entry_height: proof_entry_height,
                                 signature,
@@ -436,7 +437,7 @@ impl StorageStage {
                                         (proof_entry_height / ENTRIES_PER_SEGMENT) as usize;
                                     if proof_segment_index < statew.replicator_map.len() {
                                         statew.replicator_map[proof_segment_index]
-                                            .insert(tx.account_keys[0]);
+                                            .insert(message.account_keys[0]);
                                     }
                                 }
                                 debug!("storage proof: entry_height: {}", entry_height);

--- a/drone/src/drone.rs
+++ b/drone/src/drone.rs
@@ -352,13 +352,14 @@ mod tests {
         let mut drone = Drone::new(mint, None, None);
 
         let tx = drone.build_airdrop_transaction(request).unwrap();
+        let message = tx.message();
 
         assert_eq!(tx.signatures.len(), 1);
-        assert_eq!(tx.account_keys, vec![mint_pubkey, to]);
-        assert_eq!(tx.recent_blockhash, blockhash);
+        assert_eq!(message.account_keys, vec![mint_pubkey, to]);
+        assert_eq!(message.recent_blockhash, blockhash);
 
-        assert_eq!(tx.instructions.len(), 1);
-        let instruction: SystemInstruction = deserialize(&tx.instructions[0].data).unwrap();
+        assert_eq!(message.instructions.len(), 1);
+        let instruction: SystemInstruction = deserialize(&message.instructions[0].data).unwrap();
         assert_eq!(
             instruction,
             SystemInstruction::CreateAccount {

--- a/programs/exchange_api/src/exchange_transaction.rs
+++ b/programs/exchange_api/src/exchange_transaction.rs
@@ -21,10 +21,12 @@ impl ExchangeTransaction {
         let space = mem::size_of::<ExchangeState>() as u64;
         let create_ix = SystemInstruction::new_program_account(owner_id, new, 1, space, &id());
         let request_ix = ExchangeInstruction::new_account_request(owner_id, new);
-        let mut tx = Transaction::new_unsigned_instructions(vec![create_ix, request_ix]);
-        tx.fee = fee;
-        tx.sign(&[owner], recent_blockhash);
-        tx
+        Transaction::new_signed_instructions(
+            &[owner],
+            vec![create_ix, request_ix],
+            recent_blockhash,
+            fee,
+        )
     }
 
     pub fn new_transfer_request(
@@ -39,10 +41,7 @@ impl ExchangeTransaction {
         let owner_id = &owner.pubkey();
         let request_ix =
             ExchangeInstruction::new_transfer_request(owner_id, to, from, token, tokens);
-        let mut tx = Transaction::new_unsigned_instructions(vec![request_ix]);
-        tx.fee = fee;
-        tx.sign(&[owner], recent_blockhash);
-        tx
+        Transaction::new_signed_instructions(&[owner], vec![request_ix], recent_blockhash, fee)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -71,10 +70,12 @@ impl ExchangeTransaction {
             src_account,
             dst_account,
         );
-        let mut tx = Transaction::new_unsigned_instructions(vec![create_ix, request_ix]);
-        tx.fee = fee;
-        tx.sign(&[owner], recent_blockhash);
-        tx
+        Transaction::new_signed_instructions(
+            &[owner],
+            vec![create_ix, request_ix],
+            recent_blockhash,
+            fee,
+        )
     }
 
     pub fn new_trade_cancellation(
@@ -86,10 +87,7 @@ impl ExchangeTransaction {
     ) -> Transaction {
         let owner_id = &owner.pubkey();
         let request_ix = ExchangeInstruction::new_trade_cancellation(owner_id, trade, account);
-        let mut tx = Transaction::new_unsigned_instructions(vec![request_ix]);
-        tx.fee = fee;
-        tx.sign(&[owner], recent_blockhash);
-        tx
+        Transaction::new_signed_instructions(&[owner], vec![request_ix], recent_blockhash, fee)
     }
 
     pub fn new_swap_request(
@@ -115,9 +113,11 @@ impl ExchangeTransaction {
             from_trade_account,
             profit_account,
         );
-        let mut tx = Transaction::new_unsigned_instructions(vec![create_ix, request_ix]);
-        tx.fee = fee;
-        tx.sign(&[owner], recent_blockhash);
-        tx
+        Transaction::new_signed_instructions(
+            &[owner],
+            vec![create_ix, request_ix],
+            recent_blockhash,
+            fee,
+        )
     }
 }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -500,7 +500,9 @@ impl Bank {
         txs.iter()
             .zip(lock_results.into_iter())
             .map(|(tx, lock_res)| {
-                if lock_res.is_ok() && !hash_queue.check_hash_age(tx.recent_blockhash, max_age) {
+                if lock_res.is_ok()
+                    && !hash_queue.check_hash_age(tx.message().recent_blockhash, max_age)
+                {
                     error_counters.reserve_blockhash += 1;
                     Err(TransactionError::BlockhashNotFound)
                 } else {
@@ -561,7 +563,7 @@ impl Bank {
                 Err(e) => Err(e.clone()),
                 Ok((ref mut accounts, ref mut loaders)) => {
                     self.runtime
-                        .execute_transaction(tx, loaders, accounts, tick_height)
+                        .process_message(tx.message(), loaders, accounts, tick_height)
                 }
             })
             .collect();
@@ -647,18 +649,21 @@ impl Bank {
         let results = txs
             .iter()
             .zip(executed.iter())
-            .map(|(tx, res)| match *res {
-                Err(TransactionError::InstructionError(_, _)) => {
-                    // Charge the transaction fee even in case of InstructionError
-                    self.withdraw(&tx.account_keys[0], tx.fee)?;
-                    fees += tx.fee;
-                    Ok(())
+            .map(|(tx, res)| {
+                let message = tx.message();
+                match *res {
+                    Err(TransactionError::InstructionError(_, _)) => {
+                        // Charge the transaction fee even in case of InstructionError
+                        self.withdraw(&message.account_keys[0], message.fee)?;
+                        fees += message.fee;
+                        Ok(())
+                    }
+                    Ok(()) => {
+                        fees += message.fee;
+                        Ok(())
+                    }
+                    _ => res.clone(),
                 }
-                Ok(()) => {
-                    fees += tx.fee;
-                    Ok(())
-                }
-                _ => res.clone(),
             })
             .collect();
         self.deposit(&self.collector_id, fees);
@@ -1303,14 +1308,14 @@ mod tests {
         );
 
         let mut tx_invalid_program_index = tx.clone();
-        tx_invalid_program_index.instructions[0].program_ids_index = 42;
+        tx_invalid_program_index.message.instructions[0].program_ids_index = 42;
         assert_eq!(
             bank.process_transaction(&tx_invalid_program_index),
             Err(TransactionError::InvalidAccountIndex)
         );
 
         let mut tx_invalid_account_index = tx.clone();
-        tx_invalid_account_index.instructions[0].accounts[0] = 42;
+        tx_invalid_account_index.message.instructions[0].accounts[0] = 42;
         assert_eq!(
             bank.process_transaction(&tx_invalid_account_index),
             Err(TransactionError::InvalidAccountIndex)
@@ -1577,7 +1582,7 @@ mod tests {
 
         // Set the fee to 0, this should give an InstructionError
         // but since no signature we cannot look up the error.
-        tx.fee = 0;
+        tx.message.fee = 0;
 
         assert_eq!(bank.process_transaction(&tx), Ok(()));
         assert_eq!(bank.get_balance(&key.pubkey()), 0);

--- a/runtime/src/runtime.rs
+++ b/runtime/src/runtime.rs
@@ -129,7 +129,7 @@ impl Runtime {
             .map(|&index| {
                 let index = index as usize;
                 let key = &message.account_keys[index];
-                (key, index < message.num_signatures as usize)
+                (key, index < message.num_required_signatures as usize)
             })
             .zip(program_accounts.iter_mut())
             .map(|((key, is_signer), account)| KeyedAccount::new(key, is_signer, account))

--- a/sdk/src/transaction.rs
+++ b/sdk/src/transaction.rs
@@ -174,26 +174,31 @@ impl Transaction {
         let program_ids_index = self.instructions[instruction_index].program_ids_index;
         &self.program_ids[program_ids_index as usize]
     }
-    /// Get the transaction data to sign.
-    pub fn message(&self) -> Vec<u8> {
-        let message = Message {
+
+    /// Return a message containing all data that should be signed.
+    pub fn message(&self) -> Message {
+        Message {
             num_signatures: self.signatures.len() as u8,
             account_keys: self.account_keys.clone(),
             recent_blockhash: self.recent_blockhash,
             fee: self.fee,
             program_ids: self.program_ids.clone(),
             instructions: self.instructions.clone(),
-        };
-        serialize(&message).unwrap()
+        }
+    }
+
+    /// Return the serialized message data to sign.
+    pub fn message_data(&self) -> Vec<u8> {
+        serialize(&self.message()).unwrap()
     }
 
     /// Sign this transaction.
     pub fn sign_unchecked<T: KeypairUtil>(&mut self, keypairs: &[&T], recent_blockhash: Hash) {
         self.recent_blockhash = recent_blockhash;
-        let message = self.message();
+        let message_data = self.message_data();
         self.signatures = keypairs
             .iter()
-            .map(|keypair| keypair.sign_message(&message))
+            .map(|keypair| keypair.sign_message(&message_data))
             .collect();
     }
 

--- a/wallet/src/wallet.rs
+++ b/wallet/src/wallet.rs
@@ -693,7 +693,7 @@ impl KeypairUtil for DroneKeypair {
 
     /// Return the public key of the keypair used to sign votes
     fn pubkey(&self) -> Pubkey {
-        self.transaction.account_keys[0]
+        self.transaction.message().account_keys[0]
     }
 
     fn sign_message(&self, _msg: &[u8]) -> Signature {


### PR DESCRIPTION
#### Problem

We construct a Transaction from a Message, but Transaction doesn't store it. Instead, it copies over all the same information. Then to sign that information, we reconstruct the original message, serialize it and sign that.  It works and but anytime you want to make a change to Message, you need to make the same change in Transaction. It's a maintenance burden.

#### Summary of Changes

Integrate Message into Transaction

Towards: #3312