### PR TITLE
Early exit if buffered packets is empty

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -115,6 +115,10 @@ impl BankingStage {
         cluster_info: &Arc<RwLock<ClusterInfo>>,
         buffered_packets: &[(SharedPackets, usize)],
     ) -> bool {
+        if buffered_packets.is_empty() {
+            return false;
+        }
+
         let rcluster_info = cluster_info.read().unwrap();
 
         // If there's a bank, and leader is available, forward the buffered packets


### PR DESCRIPTION
#### Problem

Doing a bunch of work even when buffered_packets is empty.

#### Summary of Changes

Add a check for early exit of forwarding packets.

Fixes #
