### PR TITLE
Send metrics data to the correct/configured database host

### DIFF
--- a/scripts/metrics-write-datapoint.sh
+++ b/scripts/metrics-write-datapoint.sh
@@ -15,6 +15,12 @@ if [[ -z $INFLUX_DATABASE || -z $INFLUX_USERNAME || -z $INFLUX_PASSWORD ]]; then
   exit 0
 fi
 
-echo "https://metrics.solana.com:8086/write?db=${INFLUX_DATABASE}&u=${INFLUX_USERNAME}&p=${INFLUX_PASSWORD}" \
+host="https://metrics.solana.com:8086"
+
+if [[ -n $INFLUX_HOST ]]; then
+  host="$INFLUX_HOST"
+fi
+
+echo "${host}/write?db=${INFLUX_DATABASE}&u=${INFLUX_USERNAME}&p=${INFLUX_PASSWORD}" \
   | xargs curl --max-time 5 -XPOST --data-binary "$point"
 exit 0


### PR DESCRIPTION
#### Problem
Network statistics data is not populated in dashboard if influx cloud is being used.

#### Summary of Changes
The influx database end point was hardcoded in metrics-write-datapoint script. This change uses the environment variable to find the correct database host.