### PR TITLE
Replace Transaction::fee with Bank::fee_calculator

### DIFF
--- a/core/src/chacha.rs
+++ b/core/src/chacha.rs
@@ -164,7 +164,7 @@ mod tests {
         use bs58;
         //  golden needs to be updated if blob stuff changes....
         let golden = Hash::new(
-            &bs58::decode("GnNzHbBRnn1WbrAXudmyxcqhaFiXQdzYWZpi6ToMM4pW")
+            &bs58::decode("P5ZZcpRopdqU4ZVZz1Kmck5zykiNSxc9T3iPZzF3rMc")
                 .into_vec()
                 .unwrap(),
         );

--- a/core/src/entry.rs
+++ b/core/src/entry.rs
@@ -381,7 +381,7 @@ pub fn make_tiny_test_entries_from_hash(start: &Hash, num: usize) -> Vec<Entry> 
     (0..num)
         .map(|_| {
             let ix = BudgetInstruction::new_apply_timestamp(&pubkey, &pubkey, &pubkey, Utc::now());
-            let tx = Transaction::new_signed_instructions(&[&keypair], vec![ix], *start, 0);
+            let tx = Transaction::new_signed_instructions(&[&keypair], vec![ix], *start);
             Entry::new_mut(&mut hash, &mut num_hashes, vec![tx])
         })
         .collect()
@@ -400,7 +400,7 @@ pub fn make_large_test_entries(num_entries: usize) -> Vec<Entry> {
     let pubkey = keypair.pubkey();
 
     let ix = BudgetInstruction::new_apply_timestamp(&pubkey, &pubkey, &pubkey, Utc::now());
-    let tx = Transaction::new_signed_instructions(&[&keypair], vec![ix], one, 0);
+    let tx = Transaction::new_signed_instructions(&[&keypair], vec![ix], one);
 
     let serialized_size = serialized_size(&tx).unwrap();
     let num_txs = BLOB_DATA_SIZE / serialized_size as usize;
@@ -457,25 +457,25 @@ mod tests {
     fn create_sample_payment(keypair: &Keypair, hash: Hash) -> Transaction {
         let pubkey = keypair.pubkey();
         let ixs = BudgetInstruction::new_payment(&pubkey, &pubkey, 1);
-        Transaction::new_signed_instructions(&[keypair], ixs, hash, 0)
+        Transaction::new_signed_instructions(&[keypair], ixs, hash)
     }
 
     fn create_sample_timestamp(keypair: &Keypair, hash: Hash) -> Transaction {
         let pubkey = keypair.pubkey();
         let ix = BudgetInstruction::new_apply_timestamp(&pubkey, &pubkey, &pubkey, Utc::now());
-        Transaction::new_signed_instructions(&[keypair], vec![ix], hash, 0)
+        Transaction::new_signed_instructions(&[keypair], vec![ix], hash)
     }
 
     fn create_sample_signature(keypair: &Keypair, hash: Hash) -> Transaction {
         let pubkey = keypair.pubkey();
         let ix = BudgetInstruction::new_apply_signature(&pubkey, &pubkey, &pubkey);
-        Transaction::new_signed_instructions(&[keypair], vec![ix], hash, 0)
+        Transaction::new_signed_instructions(&[keypair], vec![ix], hash)
     }
 
     fn create_sample_vote(keypair: &Keypair, hash: Hash) -> Transaction {
         let pubkey = keypair.pubkey();
         let ix = VoteInstruction::new_vote(&pubkey, Vote::new(1));
-        Transaction::new_signed_instructions(&[keypair], vec![ix], hash, 0)
+        Transaction::new_signed_instructions(&[keypair], vec![ix], hash)
     }
 
     #[test]

--- a/core/src/fullnode.rs
+++ b/core/src/fullnode.rs
@@ -340,14 +340,13 @@ pub fn make_active_set_entries(
         &[active_keypair.as_ref()],
         new_vote_account_ixs,
         *blockhash,
-        1,
     );
     let new_vote_account_entry = next_entry_mut(&mut last_entry_hash, 1, vec![new_vote_account_tx]);
 
     // 3) Create vote entry
     let vote_ix = VoteInstruction::new_vote(&voting_keypair.pubkey(), Vote::new(slot_to_vote_on));
     let vote_tx =
-        Transaction::new_signed_instructions(&[&voting_keypair], vec![vote_ix], *blockhash, 0);
+        Transaction::new_signed_instructions(&[&voting_keypair], vec![vote_ix], *blockhash);
     let vote_entry = next_entry_mut(&mut last_entry_hash, 1, vec![vote_tx]);
 
     // 4) Create `num_ending_ticks` empty ticks

--- a/core/src/local_cluster.rs
+++ b/core/src/local_cluster.rs
@@ -329,7 +329,6 @@ impl LocalCluster {
                 &[from_account.as_ref()],
                 instructions,
                 client.get_recent_blockhash().unwrap(),
-                1,
             );
 
             client
@@ -347,7 +346,6 @@ impl LocalCluster {
                 &[vote_account],
                 vec![vote_instruction],
                 client.get_recent_blockhash().unwrap(),
-                1,
             );
 
             client

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -316,7 +316,6 @@ impl ReplayStage {
                 &[voting_keypair.as_ref()],
                 vec![vote_ix],
                 bank.last_blockhash(),
-                0,
             );
             if let Some(new_root) = locktower.record_vote(bank.slot()) {
                 bank_forks.write().unwrap().set_root(new_root);
@@ -653,7 +652,6 @@ mod test {
                 &[voting_keypair.as_ref()],
                 vec![vote_ix],
                 bank.last_blockhash(),
-                0,
             );
             cluster_info_me.write().unwrap().push_vote(vote_tx);
 

--- a/core/src/rpc_pubsub.rs
+++ b/core/src/rpc_pubsub.rs
@@ -365,7 +365,7 @@ mod tests {
             None,
             51,
         );
-        let tx = Transaction::new_signed_instructions(&[&contract_funds], ixs, blockhash, 0);
+        let tx = Transaction::new_signed_instructions(&[&contract_funds], ixs, blockhash);
         let arc_bank = process_transaction_and_notify(&arc_bank, &tx, &rpc.subscriptions).unwrap();
         sleep(Duration::from_millis(200));
 
@@ -398,7 +398,7 @@ mod tests {
             &contract_state.pubkey(),
             &bob_pubkey,
         );
-        let tx = Transaction::new_signed_instructions(&[&witness], vec![ix], blockhash, 0);
+        let tx = Transaction::new_signed_instructions(&[&witness], vec![ix], blockhash);
         let arc_bank = process_transaction_and_notify(&arc_bank, &tx, &rpc.subscriptions).unwrap();
         sleep(Duration::from_millis(200));
 

--- a/core/src/test_tx.rs
+++ b/core/src/test_tx.rs
@@ -18,7 +18,6 @@ pub fn test_multisig_tx() -> Transaction {
     let keypair1 = Keypair::new();
     let keypairs = vec![&keypair0, &keypair1];
     let lamports = 5;
-    let fee = 2;
     let blockhash = Hash::default();
 
     let system_instruction = SystemInstruction::Move { lamports };
@@ -31,7 +30,6 @@ pub fn test_multisig_tx() -> Transaction {
         &keypairs,
         &[],
         blockhash,
-        fee,
         program_ids,
         instructions,
     )

--- a/core/src/voting_keypair.rs
+++ b/core/src/voting_keypair.rs
@@ -114,7 +114,7 @@ pub mod tests {
 
     fn process_instructions<T: KeypairUtil>(bank: &Bank, keypairs: &[&T], ixs: Vec<Instruction>) {
         let blockhash = bank.last_blockhash();
-        let tx = Transaction::new_signed_instructions(keypairs, ixs, blockhash, 0);
+        let tx = Transaction::new_signed_instructions(keypairs, ixs, blockhash);
         bank.process_transaction(&tx).unwrap();
     }
 

--- a/programs/exchange_api/src/exchange_transaction.rs
+++ b/programs/exchange_api/src/exchange_transaction.rs
@@ -15,7 +15,7 @@ impl ExchangeTransaction {
         owner: &Keypair,
         new: &Pubkey,
         recent_blockhash: Hash,
-        fee: u64,
+        _fee: u64,
     ) -> Transaction {
         let owner_id = &owner.pubkey();
         let space = mem::size_of::<ExchangeState>() as u64;
@@ -25,7 +25,6 @@ impl ExchangeTransaction {
             &[owner],
             vec![create_ix, request_ix],
             recent_blockhash,
-            fee,
         )
     }
 
@@ -36,12 +35,12 @@ impl ExchangeTransaction {
         token: Token,
         tokens: u64,
         recent_blockhash: Hash,
-        fee: u64,
+        _fee: u64,
     ) -> Transaction {
         let owner_id = &owner.pubkey();
         let request_ix =
             ExchangeInstruction::new_transfer_request(owner_id, to, from, token, tokens);
-        Transaction::new_signed_instructions(&[owner], vec![request_ix], recent_blockhash, fee)
+        Transaction::new_signed_instructions(&[owner], vec![request_ix], recent_blockhash)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -55,7 +54,7 @@ impl ExchangeTransaction {
         src_account: &Pubkey,
         dst_account: &Pubkey,
         recent_blockhash: Hash,
-        fee: u64,
+        _fee: u64,
     ) -> Transaction {
         let owner_id = &owner.pubkey();
         let space = mem::size_of::<ExchangeState>() as u64;
@@ -74,7 +73,6 @@ impl ExchangeTransaction {
             &[owner],
             vec![create_ix, request_ix],
             recent_blockhash,
-            fee,
         )
     }
 
@@ -83,11 +81,11 @@ impl ExchangeTransaction {
         trade: &Pubkey,
         account: &Pubkey,
         recent_blockhash: Hash,
-        fee: u64,
+        _fee: u64,
     ) -> Transaction {
         let owner_id = &owner.pubkey();
         let request_ix = ExchangeInstruction::new_trade_cancellation(owner_id, trade, account);
-        Transaction::new_signed_instructions(&[owner], vec![request_ix], recent_blockhash, fee)
+        Transaction::new_signed_instructions(&[owner], vec![request_ix], recent_blockhash)
     }
 
     pub fn new_swap_request(
@@ -99,7 +97,7 @@ impl ExchangeTransaction {
         from_trade_account: &Pubkey,
         profit_account: &Pubkey,
         recent_blockhash: Hash,
-        fee: u64,
+        _fee: u64,
     ) -> Transaction {
         let owner_id = &owner.pubkey();
         let space = mem::size_of::<ExchangeState>() as u64;
@@ -117,7 +115,6 @@ impl ExchangeTransaction {
             &[owner],
             vec![create_ix, request_ix],
             recent_blockhash,
-            fee,
         )
     }
 }

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -1045,7 +1045,6 @@ mod tests {
             &[],
             &[],
             Hash::default(),
-            0,
             vec![native_loader::id()],
             instructions,
         );
@@ -1069,7 +1068,6 @@ mod tests {
             &[&keypair],
             &[],
             Hash::default(),
-            0,
             vec![native_loader::id()],
             instructions,
         );
@@ -1101,7 +1099,6 @@ mod tests {
             &[&keypair],
             &[],
             Hash::default(),
-            0,
             vec![Pubkey::default()],
             instructions,
         );
@@ -1129,7 +1126,6 @@ mod tests {
             &[&keypair],
             &[],
             Hash::default(),
-            10,
             vec![native_loader::id()],
             instructions,
         );
@@ -1168,7 +1164,6 @@ mod tests {
             &[&keypair],
             &[key1],
             Hash::default(),
-            0,
             vec![native_loader::id()],
             instructions,
         );
@@ -1240,7 +1235,6 @@ mod tests {
             &[&keypair],
             &[],
             Hash::default(),
-            0,
             vec![key6],
             instructions,
         );
@@ -1274,7 +1268,6 @@ mod tests {
             &[&keypair],
             &[],
             Hash::default(),
-            0,
             vec![key1],
             instructions,
         );
@@ -1307,7 +1300,6 @@ mod tests {
             &[&keypair],
             &[],
             Hash::default(),
-            0,
             vec![key1],
             instructions,
         );
@@ -1356,7 +1348,6 @@ mod tests {
             &[&keypair],
             &[],
             Hash::default(),
-            0,
             vec![key1, key2],
             instructions,
         );
@@ -1400,7 +1391,6 @@ mod tests {
             &[&keypair],
             &[pubkey],
             Hash::default(),
-            0,
             vec![native_loader::id()],
             instructions,
         );

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1031,7 +1031,6 @@ mod tests {
             &[&mint_keypair],
             instructions,
             genesis_block.hash(),
-            0,
         );
         assert_eq!(
             bank.process_transaction(&tx).unwrap_err(),
@@ -1057,7 +1056,6 @@ mod tests {
             &[&mint_keypair],
             instructions,
             genesis_block.hash(),
-            0,
         );
         bank.process_transaction(&tx).unwrap();
         assert_eq!(bank.get_balance(&mint_keypair.pubkey()), 0);
@@ -1614,7 +1612,6 @@ mod tests {
             &Vec::<&Keypair>::new(),
             vec![move_instruction],
             bank.last_blockhash(),
-            0,
         );
 
         assert_eq!(bank.process_transaction(&tx), Ok(()));

--- a/sdk/src/fee_calculator.rs
+++ b/sdk/src/fee_calculator.rs
@@ -1,0 +1,48 @@
+use crate::message::Message;
+
+#[derive(Default)]
+pub struct FeeCalculator {
+    pub lamports_per_signature: u64,
+}
+
+impl FeeCalculator {
+    pub fn new(lamports_per_signature: u64) -> Self {
+        Self {
+            lamports_per_signature,
+        }
+    }
+
+    pub fn calculate_fee(&self, message: &Message) -> u64 {
+        self.lamports_per_signature * u64::from(message.num_required_signatures)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pubkey::Pubkey;
+    use crate::system_instruction::SystemInstruction;
+
+    #[test]
+    fn test_fee_calculator_calculate_fee() {
+        // Default: no fee.
+        let message = Message::new(vec![]);
+        assert_eq!(FeeCalculator::default().calculate_fee(&message), 0);
+
+        // No signature, no fee.
+        assert_eq!(FeeCalculator::new(1).calculate_fee(&message), 0);
+
+        // One signature, a fee.
+        let pubkey0 = Pubkey::new(&[0; 32]);
+        let pubkey1 = Pubkey::new(&[1; 32]);
+        let ix0 = SystemInstruction::new_move(&pubkey0, &pubkey1, 1);
+        let message = Message::new(vec![ix0]);
+        assert_eq!(FeeCalculator::new(2).calculate_fee(&message), 2);
+
+        // Two signatures, double the fee.
+        let ix0 = SystemInstruction::new_move(&pubkey0, &pubkey1, 1);
+        let ix1 = SystemInstruction::new_move(&pubkey1, &pubkey0, 1);
+        let message = Message::new(vec![ix0, ix1]);
+        assert_eq!(FeeCalculator::new(2).calculate_fee(&message), 4);
+    }
+}

--- a/sdk/src/instruction.rs
+++ b/sdk/src/instruction.rs
@@ -67,7 +67,7 @@ impl InstructionError {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct Instruction {
     /// Pubkey of the instruction processor that executes this instruction
     pub program_ids_index: Pubkey,
@@ -93,7 +93,7 @@ impl Instruction {
 }
 
 /// Account metadata used to define Instructions
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub struct AccountMeta {
     /// An account's public key
     pub pubkey: Pubkey,

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod account;
 pub mod bpf_loader;
+pub mod fee_calculator;
 pub mod genesis_block;
 pub mod hash;
 pub mod instruction;

--- a/sdk/src/message.rs
+++ b/sdk/src/message.rs
@@ -81,9 +81,6 @@ pub struct Message {
     /// The id of a recent ledger entry.
     pub recent_blockhash: Hash,
 
-    /// The number of lamports paid for processing and storing of this transaction.
-    pub fee: u64,
-
     /// All the program id keys used to execute this transaction's instructions
     #[serde(with = "short_vec")]
     pub program_ids: Vec<Pubkey>,
@@ -99,7 +96,6 @@ impl Message {
         num_required_signatures: u8,
         account_keys: Vec<Pubkey>,
         recent_blockhash: Hash,
-        fee: u64,
         program_ids: Vec<Pubkey>,
         instructions: Vec<CompiledInstruction>,
     ) -> Self {
@@ -107,7 +103,6 @@ impl Message {
             num_required_signatures,
             account_keys,
             recent_blockhash,
-            fee,
             program_ids,
             instructions,
         }
@@ -123,7 +118,6 @@ impl Message {
             num_required_signatures,
             signed_keys,
             Hash::default(),
-            0,
             program_ids,
             instructions,
         )

--- a/sdk/src/system_transaction.rs
+++ b/sdk/src/system_transaction.rs
@@ -18,13 +18,13 @@ impl SystemTransaction {
         lamports: u64,
         space: u64,
         program_id: &Pubkey,
-        fee: u64,
+        _fee: u64,
     ) -> Transaction {
         let from_pubkey = from_keypair.pubkey();
         let create_instruction =
             SystemInstruction::new_program_account(&from_pubkey, to, lamports, space, program_id);
         let instructions = vec![create_instruction];
-        Transaction::new_signed_instructions(&[from_keypair], instructions, recent_blockhash, fee)
+        Transaction::new_signed_instructions(&[from_keypair], instructions, recent_blockhash)
     }
 
     /// Create and sign a transaction to create a system account
@@ -52,12 +52,12 @@ impl SystemTransaction {
         from_keypair: &Keypair,
         recent_blockhash: Hash,
         program_id: &Pubkey,
-        fee: u64,
+        _fee: u64,
     ) -> Transaction {
         let from_pubkey = from_keypair.pubkey();
         let assign_instruction = SystemInstruction::new_assign(&from_pubkey, program_id);
         let instructions = vec![assign_instruction];
-        Transaction::new_signed_instructions(&[from_keypair], instructions, recent_blockhash, fee)
+        Transaction::new_signed_instructions(&[from_keypair], instructions, recent_blockhash)
     }
 
     /// Create and sign new SystemInstruction::Move transaction
@@ -66,11 +66,11 @@ impl SystemTransaction {
         to: &Pubkey,
         lamports: u64,
         recent_blockhash: Hash,
-        fee: u64,
+        _fee: u64,
     ) -> Transaction {
         let from_pubkey = from_keypair.pubkey();
         let move_instruction = SystemInstruction::new_move(&from_pubkey, to, lamports);
         let instructions = vec![move_instruction];
-        Transaction::new_signed_instructions(&[from_keypair], instructions, recent_blockhash, fee)
+        Transaction::new_signed_instructions(&[from_keypair], instructions, recent_blockhash)
     }
 }

--- a/sdk/src/transaction.rs
+++ b/sdk/src/transaction.rs
@@ -49,7 +49,7 @@ pub enum TransactionError {
 /// An atomic transaction
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
 pub struct Transaction {
-    /// A set of digital signatures of `account_keys`, `program_ids`, `recent_blockhash`, `fee` and `instructions`, signed by the first
+    /// A set of digital signatures of `account_keys`, `program_ids`, `recent_blockhash`, and `instructions`, signed by the first
     /// signatures.len() keys of account_keys
     #[serde(with = "short_vec")]
     pub signatures: Vec<Signature>,
@@ -85,10 +85,9 @@ impl Transaction {
         from_keypairs: &[&T],
         instructions: Vec<Instruction>,
         recent_blockhash: Hash,
-        fee: u64,
+        _fee: u64,
     ) -> Transaction {
-        let mut message = Message::new(instructions);
-        message.fee = fee;
+        let message = Message::new(instructions);
         Self::new(from_keypairs, message, recent_blockhash)
     }
 
@@ -104,7 +103,7 @@ impl Transaction {
         from_keypairs: &[&T],
         keys: &[Pubkey],
         recent_blockhash: Hash,
-        fee: u64,
+        _fee: u64,
         program_ids: Vec<Pubkey>,
         instructions: Vec<CompiledInstruction>,
     ) -> Self {
@@ -117,7 +116,6 @@ impl Transaction {
             from_keypairs.len() as u8,
             account_keys,
             Hash::default(),
-            fee,
             program_ids,
             instructions,
         );
@@ -308,8 +306,7 @@ mod tests {
             AccountMeta::new(to, false),
         ];
         let instruction = Instruction::new(program_id, &(1u8, 2u8, 3u8), account_metas);
-        let mut message = Message::new(vec![instruction]);
-        message.fee = 99;
+        let message = Message::new(vec![instruction]);
         Transaction::new(&[&keypair], message, Hash::default())
     }
 
@@ -352,19 +349,17 @@ mod tests {
         let len_size = 1;
         let num_required_sigs_size = 1;
         let blockhash_size = size_of::<Hash>();
-        let fee_size = size_of::<u64>();
         let expected_transaction_size = len_size
             + (tx.signatures.len() * size_of::<Signature>())
             + num_required_sigs_size
             + len_size
             + (tx.message.account_keys.len() * size_of::<Pubkey>())
             + blockhash_size
-            + fee_size
             + len_size
             + (tx.message.program_ids.len() * size_of::<Pubkey>())
             + len_size
             + expected_instruction_size;
-        assert_eq!(expected_transaction_size, 222);
+        assert_eq!(expected_transaction_size, 214);
 
         assert_eq!(
             serialized_size(&tx).unwrap() as usize,
@@ -380,16 +375,16 @@ mod tests {
         assert_eq!(
             serialize(&create_sample_transaction()).unwrap(),
             vec![
-                1, 102, 197, 120, 176, 192, 35, 190, 233, 5, 135, 30, 114, 209, 105, 219, 212, 203,
-                242, 72, 150, 205, 68, 30, 188, 119, 31, 212, 40, 43, 88, 45, 239, 83, 45, 208,
-                103, 108, 239, 82, 185, 160, 161, 111, 112, 51, 254, 61, 254, 131, 206, 221, 117,
-                124, 50, 1, 6, 38, 218, 9, 95, 28, 46, 49, 5, 1, 2, 36, 100, 158, 252, 33, 161, 97,
+                1, 0, 30, 236, 164, 222, 77, 89, 244, 36, 92, 35, 192, 25, 100, 18, 61, 155, 111,
+                89, 189, 154, 90, 255, 217, 203, 105, 50, 243, 208, 179, 89, 146, 122, 222, 91, 34,
+                106, 93, 82, 147, 213, 223, 184, 32, 204, 61, 227, 227, 41, 211, 67, 5, 156, 236,
+                251, 178, 235, 234, 174, 123, 15, 26, 145, 3, 1, 2, 36, 100, 158, 252, 33, 161, 97,
                 185, 62, 89, 99, 195, 250, 249, 187, 189, 171, 118, 241, 90, 248, 14, 68, 219, 231,
                 62, 157, 5, 142, 27, 210, 117, 1, 1, 1, 4, 5, 6, 7, 8, 9, 9, 9, 9, 9, 9, 9, 9, 9,
                 9, 9, 9, 9, 9, 9, 9, 8, 7, 6, 5, 4, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 99, 0, 0, 0, 0, 0, 0, 0,
-                1, 2, 2, 2, 4, 5, 6, 7, 8, 9, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 9, 8, 7, 6,
-                5, 4, 2, 2, 2, 1, 0, 2, 0, 1, 3, 1, 2, 3
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 2, 2, 4, 5, 6, 7, 8,
+                9, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 9, 8, 7, 6, 5, 4, 2, 2, 2, 1, 0, 2, 0,
+                1, 3, 1, 2, 3
             ]
         );
     }

--- a/sdk/src/transaction.rs
+++ b/sdk/src/transaction.rs
@@ -85,7 +85,6 @@ impl Transaction {
         from_keypairs: &[&T],
         instructions: Vec<Instruction>,
         recent_blockhash: Hash,
-        _fee: u64,
     ) -> Transaction {
         let message = Message::new(instructions);
         Self::new(from_keypairs, message, recent_blockhash)
@@ -93,17 +92,15 @@ impl Transaction {
 
     /// Create a signed transaction
     /// * `from_keypairs` - The keys used to sign the transaction.
-    /// * `account_keys` - The keys for the transaction.  These are the program state
+    /// * `keys` - The keys for the transaction.  These are the program state
     ///    instances or lamport recipient keys.
     /// * `recent_blockhash` - The PoH hash.
-    /// * `fee` - The transaction fee.
     /// * `program_ids` - The keys that identify programs used in the `instruction` vector.
     /// * `instructions` - Instructions that will be executed atomically.
     pub fn new_with_compiled_instructions<T: KeypairUtil>(
         from_keypairs: &[&T],
         keys: &[Pubkey],
         recent_blockhash: Hash,
-        _fee: u64,
         program_ids: Vec<Pubkey>,
         instructions: Vec<CompiledInstruction>,
     ) -> Self {
@@ -225,7 +222,6 @@ mod tests {
             &[&key],
             &[key1, key2],
             Hash::default(),
-            0,
             vec![prog1, prog2],
             instructions,
         );
@@ -260,7 +256,6 @@ mod tests {
             &[&key],
             &[],
             Hash::default(),
-            0,
             vec![],
             instructions,
         );
@@ -274,7 +269,6 @@ mod tests {
             &[&key],
             &[],
             Hash::default(),
-            0,
             vec![Pubkey::default()],
             instructions,
         );

--- a/tests/thin_client.rs
+++ b/tests/thin_client.rs
@@ -127,7 +127,7 @@ fn test_register_vote_account() {
     let instructions =
         VoteInstruction::new_account(&validator_keypair.pubkey(), &vote_account_id, 1);
     let transaction =
-        Transaction::new_signed_instructions(&[&validator_keypair], instructions, blockhash, 1);
+        Transaction::new_signed_instructions(&[&validator_keypair], instructions, blockhash);
     let signature = client.transfer_signed(&transaction).unwrap();
     client.poll_for_signature(&signature).unwrap();
 

--- a/wallet/src/wallet.rs
+++ b/wallet/src/wallet.rs
@@ -344,7 +344,7 @@ fn process_configure_staking(
             &authorized_voter_id,
         ));
     }
-    let mut tx = Transaction::new_signed_instructions(&[&config.id], ixs, recent_blockhash, 0);
+    let mut tx = Transaction::new_signed_instructions(&[&config.id], ixs, recent_blockhash);
     let signature_str = rpc_client.send_and_confirm_transaction(&mut tx, &config.id)?;
     Ok(signature_str.to_string())
 }
@@ -357,7 +357,7 @@ fn process_create_staking(
 ) -> ProcessResult {
     let recent_blockhash = rpc_client.get_recent_blockhash()?;
     let ixs = VoteInstruction::new_account(&config.id.pubkey(), voting_account_id, lamports);
-    let mut tx = Transaction::new_signed_instructions(&[&config.id], ixs, recent_blockhash, 0);
+    let mut tx = Transaction::new_signed_instructions(&[&config.id], ixs, recent_blockhash);
     let signature_str = rpc_client.send_and_confirm_transaction(&mut tx, &config.id)?;
     Ok(signature_str.to_string())
 }
@@ -417,15 +417,14 @@ fn process_deploy(
                 (i * USERDATA_CHUNK_SIZE) as u32,
                 chunk.to_vec(),
             );
-            Transaction::new_signed_instructions(&[&program_id], vec![instruction], blockhash, 0)
+            Transaction::new_signed_instructions(&[&program_id], vec![instruction], blockhash)
         })
         .collect();
     rpc_client.send_and_confirm_transactions(write_transactions, &program_id)?;
 
     trace!("Finalizing program account");
     let instruction = LoaderInstruction::new_finalize(&program_id.pubkey(), &bpf_loader::id());
-    let mut tx =
-        Transaction::new_signed_instructions(&[&program_id], vec![instruction], blockhash, 0);
+    let mut tx = Transaction::new_signed_instructions(&[&program_id], vec![instruction], blockhash);
     rpc_client
         .send_and_confirm_transaction(&mut tx, &program_id)
         .map_err(|_| {
@@ -473,7 +472,7 @@ fn process_pay(
             cancelable,
             lamports,
         );
-        let mut tx = Transaction::new_signed_instructions(&[&config.id], ixs, blockhash, 0);
+        let mut tx = Transaction::new_signed_instructions(&[&config.id], ixs, blockhash);
         let signature_str = rpc_client.send_and_confirm_transaction(&mut tx, &config.id)?;
 
         Ok(json!({
@@ -503,7 +502,7 @@ fn process_pay(
             cancelable,
             lamports,
         );
-        let mut tx = Transaction::new_signed_instructions(&[&config.id], ixs, blockhash, 0);
+        let mut tx = Transaction::new_signed_instructions(&[&config.id], ixs, blockhash);
         let signature_str = rpc_client.send_and_confirm_transaction(&mut tx, &config.id)?;
 
         Ok(json!({
@@ -520,7 +519,7 @@ fn process_cancel(rpc_client: &RpcClient, config: &WalletConfig, pubkey: &Pubkey
     let blockhash = rpc_client.get_recent_blockhash()?;
     let ix =
         BudgetInstruction::new_apply_signature(&config.id.pubkey(), pubkey, &config.id.pubkey());
-    let mut tx = Transaction::new_signed_instructions(&[&config.id], vec![ix], blockhash, 0);
+    let mut tx = Transaction::new_signed_instructions(&[&config.id], vec![ix], blockhash);
     let signature_str = rpc_client.send_and_confirm_transaction(&mut tx, &config.id)?;
     Ok(signature_str.to_string())
 }
@@ -547,7 +546,7 @@ fn process_time_elapsed(
     let blockhash = rpc_client.get_recent_blockhash()?;
 
     let ix = BudgetInstruction::new_apply_timestamp(&config.id.pubkey(), pubkey, to, dt);
-    let mut tx = Transaction::new_signed_instructions(&[&config.id], vec![ix], blockhash, 0);
+    let mut tx = Transaction::new_signed_instructions(&[&config.id], vec![ix], blockhash);
     let signature_str = rpc_client.send_and_confirm_transaction(&mut tx, &config.id)?;
 
     Ok(signature_str.to_string())
@@ -568,7 +567,7 @@ fn process_witness(
 
     let blockhash = rpc_client.get_recent_blockhash()?;
     let ix = BudgetInstruction::new_apply_signature(&config.id.pubkey(), pubkey, to);
-    let mut tx = Transaction::new_signed_instructions(&[&config.id], vec![ix], blockhash, 0);
+    let mut tx = Transaction::new_signed_instructions(&[&config.id], vec![ix], blockhash);
     let signature_str = rpc_client.send_and_confirm_transaction(&mut tx, &config.id)?;
 
     Ok(signature_str.to_string())


### PR DESCRIPTION
#### Problem

Transactions currently include a fee field that indicates the maximum fee field
a slot leader is permitted to charge to process a transaction. The cluster, on
the other hand, agrees on a minimum fee. If the network is congested, the slot
leader may prioritize the transactions offering higher fees. That means the
 client won't know how much was collected until the transaction is confirmed by
the cluster and the remaining balance is checked. It smells of exactly what we
dislike about Ethereum's "gas", non-determinism.

#### Summary of Changes

* Add a very basic FeeCalculator to the SDK and use it in the Bank
* Drop Transaction size by 8 bytes - down to 214.

Fixes #2635
Towards #3277 