### PR TITLE
Cache vote accounts for performance reasons

### DIFF
--- a/runtime/benches/accounts.rs
+++ b/runtime/benches/accounts.rs
@@ -1,0 +1,73 @@
+#![feature(test)]
+
+extern crate test;
+
+use solana_runtime::bank::*;
+use solana_sdk::account::Account;
+use solana_sdk::genesis_block::GenesisBlock;
+use solana_sdk::pubkey::Pubkey;
+use solana_sdk::signature::{Keypair, KeypairUtil};
+use std::sync::Arc;
+use test::Bencher;
+
+fn compare_account(account1: &Account, account2: &Account) -> bool {
+    if account1.data != account2.data
+        || account1.owner != account2.owner
+        || account1.executable != account2.executable
+        || account1.lamports != account2.lamports
+    {
+        return false;
+    }
+    true
+}
+
+fn create_account(bank: &Bank, pubkeys: &mut Vec<Pubkey>, num: usize) {
+    for t in 0..num {
+        let pubkey = Keypair::new().pubkey();
+        let mut default_account = Account::default();
+        pubkeys.push(pubkey.clone());
+        default_account.lamports = (t + 1) as u64;
+        assert!(bank.get_account(&pubkey).is_none());
+        bank.deposit(&pubkey, (t + 1) as u64);
+        assert_eq!(
+            compare_account(&bank.get_account(&pubkey).unwrap(), &default_account),
+            true
+        );
+    }
+}
+
+#[bench]
+fn test_accounts_create(bencher: &mut Bencher) {
+    let (genesis_block, _) = GenesisBlock::new(10_000);
+    let bank0 = Bank::new_with_paths(&genesis_block, Some("bench_a0".to_string()));
+    bencher.iter(|| {
+        let mut pubkeys: Vec<Pubkey> = vec![];
+        create_account(&bank0, &mut pubkeys, 1000);
+    });
+}
+
+#[bench]
+fn test_accounts_squash(bencher: &mut Bencher) {
+    let (genesis_block, _) = GenesisBlock::new(100_000);
+    let mut banks: Vec<Arc<Bank>> = Vec::with_capacity(50);
+    banks.push(Arc::new(Bank::new_with_paths(
+        &genesis_block,
+        Some("bench_a1".to_string()),
+    )));
+    let mut pubkeys: Vec<Pubkey> = vec![];
+    create_account(&banks[0], &mut pubkeys, 250000);
+    banks[0].freeze();
+    bencher.iter(|| {
+        for index in 1..10 {
+            banks.push(Arc::new(Bank::new_from_parent(
+                &banks[index - 1],
+                &Pubkey::default(),
+                index as u64,
+            )));
+            for accounts in 0..10000 {
+                banks[index].deposit(&pubkeys[accounts], (accounts + 1) as u64);
+            }
+            banks[index].squash();
+        }
+    });
+}

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -107,10 +107,6 @@ struct AccountInfo {
     /// lamports in the account used when squashing kept for optimization
     /// purposes to remove accounts with zero balance.
     lamports: u64,
-
-    /// keep track if this is a vote account for performance reasons to avoid
-    /// having to read the accounts from the storage
-    is_vote_account: bool,
 }
 
 // in a given a Fork, which AppendVecId and offset
@@ -589,7 +585,6 @@ impl AccountsDB {
                 id,
                 offset,
                 lamports: account.lamports,
-                is_vote_account: solana_vote_api::check_id(&account.owner),
             };
             self.insert_account_entry(&pubkey, &account_info, &mut account_map);
             if solana_vote_api::check_id(&account.owner) {

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -1532,7 +1532,7 @@ mod tests {
             let account = db.load(0, &pubkeys[idx], true).unwrap();
             let mut default_account = Account::default();
             default_account.lamports = (idx + 1) as u64;
-            assert_eq!(compare_account(&default_account, &account), true);
+            assert_eq!(default_account, account);
         }
         db.add_fork(1, Some(0));
 
@@ -1629,21 +1629,10 @@ mod tests {
                 } else {
                     let mut default_account = Account::default();
                     default_account.lamports = account.lamports;
-                    assert_eq!(compare_account(&default_account, &account), true);
+                    assert_eq!(default_account, account);
                 }
             }
         }
-    }
-
-    fn compare_account(account1: &Account, account2: &Account) -> bool {
-        if account1.data != account2.data
-            || account1.owner != account2.owner
-            || account1.executable != account2.executable
-            || account1.lamports != account2.lamports
-        {
-            return false;
-        }
-        true
     }
 
     fn check_storage(accounts: &AccountsDB, count: usize) -> bool {
@@ -1662,7 +1651,7 @@ mod tests {
             let account = accounts.load(fork, &pubkeys[idx], true).unwrap();
             let mut default_account = Account::default();
             default_account.lamports = (idx + 1) as u64;
-            assert_eq!(compare_account(&default_account, &account), true);
+            assert_eq!(default_account, account);
         }
     }
 
@@ -1682,7 +1671,7 @@ mod tests {
         let account = accounts.load(0, &pubkeys[0], true).unwrap();
         let mut default_account = Account::default();
         default_account.lamports = 1;
-        assert_eq!(compare_account(&default_account, &account), true);
+        assert_eq!(default_account, account);
     }
 
     #[test]


### PR DESCRIPTION
#### Problem
The vote accounts are retrieved at a higher frequency which results in the accounts being locked to retrieve all the accounts impacting the overall performance.

#### Summary of Changes
Cache the accounts on a per fork basis for easy retrieval with minimal locking of the accounts.

Fixes #
