### PR TITLE
Add a constructor to generate random pubkeys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2456,6 +2456,7 @@ dependencies = [
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "ring 0.13.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/bench-tps/src/bench.rs
+++ b/bench-tps/src/bench.rs
@@ -96,7 +96,7 @@ pub fn do_bench_tps(config: Config) {
     }
     let gen_keypairs = rnd.gen_n_keypairs(total_keys as u64);
     let barrier_source_keypair = Keypair::new();
-    let barrier_dest_id = Keypair::new().pubkey();
+    let barrier_dest_id = Pubkey::new_rand();
 
     println!("Get lamports...");
     let num_lamports_per_account = 20;

--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -660,7 +660,7 @@ mod tests {
         let rpc_client = RpcClient::new_mock("succeeds".to_string());
 
         let key = Keypair::new();
-        let to = Keypair::new().pubkey();
+        let to = Pubkey::new_rand();
         let blockhash = Hash::default();
         let tx = SystemTransaction::new_account(&key, &to, 50, blockhash, 0);
 
@@ -711,7 +711,7 @@ mod tests {
         let rpc_client = RpcClient::new_mock("succeeds".to_string());
 
         let key = Keypair::new();
-        let to = Keypair::new().pubkey();
+        let to = Pubkey::new_rand();
         let blockhash = Hash::default();
         let mut tx = SystemTransaction::new_account(&key, &to, 50, blockhash, 0);
 
@@ -732,7 +732,7 @@ mod tests {
         let rpc_client = RpcClient::new_mock("succeeds".to_string());
 
         let key = Keypair::new();
-        let to = Keypair::new().pubkey();
+        let to = Pubkey::new_rand();
         let vec = bs58::decode("HUu3LwEzGRsUkuJS121jzkPJW39Kq62pXCTmTa1F9jDL")
             .into_vec()
             .unwrap();

--- a/core/benches/append_vec.rs
+++ b/core/benches/append_vec.rs
@@ -9,7 +9,7 @@ use solana_runtime::append_vec::{
     deserialize_account, get_serialized_size, serialize_account, AppendVec,
 };
 use solana_sdk::account::Account;
-use solana_sdk::signature::{Keypair, KeypairUtil};
+use solana_sdk::pubkey::Pubkey;
 use std::env;
 use std::io::Cursor;
 use std::path::PathBuf;
@@ -200,7 +200,7 @@ fn append_vec_concurrent_get_append(bencher: &mut Bencher) {
 #[bench]
 fn bench_account_serialize(bencher: &mut Bencher) {
     let num: usize = 1000;
-    let account = Account::new(2, 100, &Keypair::new().pubkey());
+    let account = Account::new(2, 100, &Pubkey::new_rand());
     let len = get_serialized_size(&account);
     let ser_len = align_up!(len + std::mem::size_of::<u64>(), std::mem::size_of::<u64>());
     let mut memory = vec![0; num * ser_len];
@@ -225,7 +225,7 @@ fn bench_account_serialize(bencher: &mut Bencher) {
 #[bench]
 fn bench_account_serialize_bincode(bencher: &mut Bencher) {
     let num: usize = 1000;
-    let account = Account::new(2, 100, &Keypair::new().pubkey());
+    let account = Account::new(2, 100, &Pubkey::new_rand());
     let len = serialized_size(&account).unwrap() as usize;
     let mut memory = vec![0u8; num * len];
     bencher.iter(|| {

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -600,16 +600,16 @@ mod tests {
             bank.process_transaction(&fund_tx).unwrap();
 
             // good tx
-            let to = Keypair::new().pubkey();
+            let to = Pubkey::new_rand();
             let tx = SystemTransaction::new_account(&mint_keypair, &to, 1, start_hash, 0);
 
             // good tx, but no verify
-            let to2 = Keypair::new().pubkey();
+            let to2 = Pubkey::new_rand();
             let tx_no_ver = SystemTransaction::new_account(&keypair, &to2, 2, start_hash, 0);
 
             // bad tx, AccountNotFound
             let keypair = Keypair::new();
-            let to3 = Keypair::new().pubkey();
+            let to3 = Pubkey::new_rand();
             let tx_anf = SystemTransaction::new_account(&keypair, &to3, 1, start_hash, 0);
 
             // send 'em over
@@ -777,7 +777,7 @@ mod tests {
             let poh_recorder = Arc::new(Mutex::new(poh_recorder));
 
             poh_recorder.lock().unwrap().set_working_bank(working_bank);
-            let pubkey = Keypair::new().pubkey();
+            let pubkey = Pubkey::new_rand();
 
             let transactions = vec![
                 SystemTransaction::new_move(&mint_keypair, &pubkey, 1, genesis_block.hash(), 0),
@@ -815,7 +815,7 @@ mod tests {
         solana_logger::setup();
         let (genesis_block, mint_keypair) = GenesisBlock::new(10_000);
         let bank = Arc::new(Bank::new(&genesis_block));
-        let pubkey = Keypair::new().pubkey();
+        let pubkey = Pubkey::new_rand();
 
         let transactions = vec![SystemTransaction::new_move(
             &mint_keypair,

--- a/core/src/blockstream.rs
+++ b/core/src/blockstream.rs
@@ -206,7 +206,7 @@ mod test {
         let tick_height_initial = 0;
         let tick_height_final = tick_height_initial + ticks_per_slot + 2;
         let mut curr_slot = 0;
-        let leader_id = Keypair::new().pubkey();
+        let leader_id = Pubkey::new_rand();
 
         for tick_height in tick_height_initial..=tick_height_final {
             if tick_height == 5 {

--- a/core/src/blockstream_service.rs
+++ b/core/src/blockstream_service.rs
@@ -121,7 +121,7 @@ mod test {
     #[test]
     fn test_blockstream_service_process_entries() {
         let ticks_per_slot = 5;
-        let leader_id = Keypair::new().pubkey();
+        let leader_id = Pubkey::new_rand();
 
         // Set up genesis block and blocktree
         let (mut genesis_block, _mint_keypair) = GenesisBlock::new(1000);

--- a/core/src/blocktree.rs
+++ b/core/src/blocktree.rs
@@ -1085,6 +1085,7 @@ pub mod tests {
     use rand::seq::SliceRandom;
     use rand::thread_rng;
     use solana_sdk::hash::Hash;
+    use solana_sdk::pubkey::Pubkey;
     use std::cmp::min;
     use std::collections::HashSet;
     use std::iter::once;
@@ -1255,7 +1256,7 @@ pub mod tests {
     fn test_read_blobs_bytes() {
         let shared_blobs = make_tiny_test_entries(10).to_single_entry_shared_blobs();
         let slot = 0;
-        packet::index_blobs(&shared_blobs, &Keypair::new().pubkey(), 0, slot, 0);
+        packet::index_blobs(&shared_blobs, &Pubkey::new_rand(), 0, slot, 0);
 
         let blob_locks: Vec<_> = shared_blobs.iter().map(|b| b.read().unwrap()).collect();
         let blobs: Vec<&Blob> = blob_locks.iter().map(|b| &**b).collect();
@@ -2379,7 +2380,7 @@ pub mod tests {
         let num_entries = 10;
         let shared_blobs = make_tiny_test_entries(num_entries).to_single_entry_shared_blobs();
 
-        crate::packet::index_blobs(&shared_blobs, &Keypair::new().pubkey(), 0, slot, 0);
+        crate::packet::index_blobs(&shared_blobs, &Pubkey::new_rand(), 0, slot, 0);
 
         let blob_locks: Vec<_> = shared_blobs.iter().map(|b| b.read().unwrap()).collect();
         let blobs: Vec<&Blob> = blob_locks.iter().map(|b| &**b).collect();

--- a/core/src/blocktree_processor.rs
+++ b/core/src/blocktree_processor.rs
@@ -230,6 +230,7 @@ mod tests {
     use crate::entry::{create_ticks, next_entry, Entry};
     use solana_sdk::genesis_block::GenesisBlock;
     use solana_sdk::hash::Hash;
+    use solana_sdk::pubkey::Pubkey;
     use solana_sdk::signature::{Keypair, KeypairUtil};
     use solana_sdk::system_transaction::SystemTransaction;
     use solana_sdk::transaction::TransactionError;
@@ -441,7 +442,7 @@ mod tests {
     #[test]
     fn test_process_ledger_simple() {
         solana_logger::setup();
-        let leader_pubkey = Keypair::new().pubkey();
+        let leader_pubkey = Pubkey::new_rand();
         let (genesis_block, mint_keypair) = GenesisBlock::new_with_leader(100, &leader_pubkey, 50);
         let (ledger_path, mut last_entry_hash) = create_new_tmp_ledger!(&genesis_block);
         debug!("ledger_path: {:?}", ledger_path);

--- a/core/src/contact_info.rs
+++ b/core/src/contact_info.rs
@@ -130,7 +130,7 @@ impl ContactInfo {
         let addr = socketaddr!("224.0.1.255:1000");
         assert!(addr.ip().is_multicast());
         Self::new(
-            &Keypair::new().pubkey(),
+            &Pubkey::new_rand(),
             addr,
             addr,
             addr,

--- a/core/src/crds.rs
+++ b/core/src/crds.rs
@@ -165,7 +165,6 @@ impl Crds {
 mod test {
     use super::*;
     use crate::contact_info::ContactInfo;
-    use solana_sdk::signature::{Keypair, KeypairUtil};
 
     #[test]
     fn test_insert() {
@@ -302,11 +301,11 @@ mod test {
     fn test_label_order() {
         let v1 = VersionedCrdsValue::new(
             1,
-            CrdsValue::ContactInfo(ContactInfo::new_localhost(&Keypair::new().pubkey(), 0)),
+            CrdsValue::ContactInfo(ContactInfo::new_localhost(&Pubkey::new_rand(), 0)),
         );
         let v2 = VersionedCrdsValue::new(
             1,
-            CrdsValue::ContactInfo(ContactInfo::new_localhost(&Keypair::new().pubkey(), 0)),
+            CrdsValue::ContactInfo(ContactInfo::new_localhost(&Pubkey::new_rand(), 0)),
         );
         assert_ne!(v1, v2);
         assert!(!(v1 == v2));

--- a/core/src/crds_gossip_pull.rs
+++ b/core/src/crds_gossip_pull.rs
@@ -209,18 +209,16 @@ impl CrdsGossipPull {
 mod test {
     use super::*;
     use crate::contact_info::ContactInfo;
-    use solana_sdk::signature::{Keypair, KeypairUtil};
 
     #[test]
     fn test_new_pull_with_stakes() {
         let mut crds = Crds::default();
         let mut stakes = HashMap::new();
         let node = CrdsGossipPull::default();
-        let me = CrdsValue::ContactInfo(ContactInfo::new_localhost(&Keypair::new().pubkey(), 0));
+        let me = CrdsValue::ContactInfo(ContactInfo::new_localhost(&Pubkey::new_rand(), 0));
         crds.insert(me.clone(), 0).unwrap();
         for i in 1..=30 {
-            let entry =
-                CrdsValue::ContactInfo(ContactInfo::new_localhost(&Keypair::new().pubkey(), 0));
+            let entry = CrdsValue::ContactInfo(ContactInfo::new_localhost(&Pubkey::new_rand(), 0));
             let id = entry.label().pubkey();
             crds.insert(entry.clone(), 0).unwrap();
             stakes.insert(id, i * 100);
@@ -239,7 +237,7 @@ mod test {
     #[test]
     fn test_new_pull_request() {
         let mut crds = Crds::default();
-        let entry = CrdsValue::ContactInfo(ContactInfo::new_localhost(&Keypair::new().pubkey(), 0));
+        let entry = CrdsValue::ContactInfo(ContactInfo::new_localhost(&Pubkey::new_rand(), 0));
         let id = entry.label().pubkey();
         let node = CrdsGossipPull::default();
         assert_eq!(
@@ -253,7 +251,7 @@ mod test {
             Err(CrdsGossipError::NoPeers)
         );
 
-        let new = CrdsValue::ContactInfo(ContactInfo::new_localhost(&Keypair::new().pubkey(), 0));
+        let new = CrdsValue::ContactInfo(ContactInfo::new_localhost(&Pubkey::new_rand(), 0));
         crds.insert(new.clone(), 0).unwrap();
         let req = node.new_pull_request(&crds, &id, 0, &HashMap::new());
         let (to, _, self_info) = req.unwrap();
@@ -264,13 +262,13 @@ mod test {
     #[test]
     fn test_new_mark_creation_time() {
         let mut crds = Crds::default();
-        let entry = CrdsValue::ContactInfo(ContactInfo::new_localhost(&Keypair::new().pubkey(), 0));
+        let entry = CrdsValue::ContactInfo(ContactInfo::new_localhost(&Pubkey::new_rand(), 0));
         let node_id = entry.label().pubkey();
         let mut node = CrdsGossipPull::default();
         crds.insert(entry.clone(), 0).unwrap();
-        let old = CrdsValue::ContactInfo(ContactInfo::new_localhost(&Keypair::new().pubkey(), 0));
+        let old = CrdsValue::ContactInfo(ContactInfo::new_localhost(&Pubkey::new_rand(), 0));
         crds.insert(old.clone(), 0).unwrap();
-        let new = CrdsValue::ContactInfo(ContactInfo::new_localhost(&Keypair::new().pubkey(), 0));
+        let new = CrdsValue::ContactInfo(ContactInfo::new_localhost(&Pubkey::new_rand(), 0));
         crds.insert(new.clone(), 0).unwrap();
 
         // set request creation time to max_value
@@ -288,11 +286,11 @@ mod test {
     #[test]
     fn test_process_pull_request() {
         let mut node_crds = Crds::default();
-        let entry = CrdsValue::ContactInfo(ContactInfo::new_localhost(&Keypair::new().pubkey(), 0));
+        let entry = CrdsValue::ContactInfo(ContactInfo::new_localhost(&Pubkey::new_rand(), 0));
         let node_id = entry.label().pubkey();
         let node = CrdsGossipPull::default();
         node_crds.insert(entry.clone(), 0).unwrap();
-        let new = CrdsValue::ContactInfo(ContactInfo::new_localhost(&Keypair::new().pubkey(), 0));
+        let new = CrdsValue::ContactInfo(ContactInfo::new_localhost(&Pubkey::new_rand(), 0));
         node_crds.insert(new.clone(), 0).unwrap();
         let req = node.new_pull_request(&node_crds, &node_id, 0, &HashMap::new());
 
@@ -320,17 +318,17 @@ mod test {
     #[test]
     fn test_process_pull_request_response() {
         let mut node_crds = Crds::default();
-        let entry = CrdsValue::ContactInfo(ContactInfo::new_localhost(&Keypair::new().pubkey(), 0));
+        let entry = CrdsValue::ContactInfo(ContactInfo::new_localhost(&Pubkey::new_rand(), 0));
         let node_id = entry.label().pubkey();
         let mut node = CrdsGossipPull::default();
         node_crds.insert(entry.clone(), 0).unwrap();
 
-        let new = CrdsValue::ContactInfo(ContactInfo::new_localhost(&Keypair::new().pubkey(), 0));
+        let new = CrdsValue::ContactInfo(ContactInfo::new_localhost(&Pubkey::new_rand(), 0));
         node_crds.insert(new.clone(), 0).unwrap();
 
         let mut dest = CrdsGossipPull::default();
         let mut dest_crds = Crds::default();
-        let new_id = Keypair::new().pubkey();
+        let new_id = Pubkey::new_rand();
         let new = CrdsValue::ContactInfo(ContactInfo::new_localhost(&new_id, 1));
         dest_crds.insert(new.clone(), 0).unwrap();
 
@@ -384,12 +382,12 @@ mod test {
     #[test]
     fn test_gossip_purge() {
         let mut node_crds = Crds::default();
-        let entry = CrdsValue::ContactInfo(ContactInfo::new_localhost(&Keypair::new().pubkey(), 0));
+        let entry = CrdsValue::ContactInfo(ContactInfo::new_localhost(&Pubkey::new_rand(), 0));
         let node_label = entry.label();
         let node_id = node_label.pubkey();
         let mut node = CrdsGossipPull::default();
         node_crds.insert(entry.clone(), 0).unwrap();
-        let old = CrdsValue::ContactInfo(ContactInfo::new_localhost(&Keypair::new().pubkey(), 0));
+        let old = CrdsValue::ContactInfo(ContactInfo::new_localhost(&Pubkey::new_rand(), 0));
         node_crds.insert(old.clone(), 0).unwrap();
         let value_hash = node_crds.lookup_versioned(&old.label()).unwrap().value_hash;
 

--- a/core/src/crds_gossip_push.rs
+++ b/core/src/crds_gossip_push.rs
@@ -266,13 +266,12 @@ impl CrdsGossipPush {
 mod test {
     use super::*;
     use crate::contact_info::ContactInfo;
-    use solana_sdk::signature::{Keypair, KeypairUtil};
 
     #[test]
     fn test_process_push() {
         let mut crds = Crds::default();
         let mut push = CrdsGossipPush::default();
-        let value = CrdsValue::ContactInfo(ContactInfo::new_localhost(&Keypair::new().pubkey(), 0));
+        let value = CrdsValue::ContactInfo(ContactInfo::new_localhost(&Pubkey::new_rand(), 0));
         let label = value.label();
         // push a new message
         assert_eq!(
@@ -291,7 +290,7 @@ mod test {
     fn test_process_push_old_version() {
         let mut crds = Crds::default();
         let mut push = CrdsGossipPush::default();
-        let mut ci = ContactInfo::new_localhost(&Keypair::new().pubkey(), 0);
+        let mut ci = ContactInfo::new_localhost(&Pubkey::new_rand(), 0);
         ci.wallclock = 1;
         let value = CrdsValue::ContactInfo(ci.clone());
 
@@ -311,7 +310,7 @@ mod test {
         let mut crds = Crds::default();
         let mut push = CrdsGossipPush::default();
         let timeout = push.msg_timeout;
-        let mut ci = ContactInfo::new_localhost(&Keypair::new().pubkey(), 0);
+        let mut ci = ContactInfo::new_localhost(&Pubkey::new_rand(), 0);
 
         // push a version to far in the future
         ci.wallclock = timeout + 1;
@@ -333,7 +332,7 @@ mod test {
     fn test_process_push_update() {
         let mut crds = Crds::default();
         let mut push = CrdsGossipPush::default();
-        let mut ci = ContactInfo::new_localhost(&Keypair::new().pubkey(), 0);
+        let mut ci = ContactInfo::new_localhost(&Pubkey::new_rand(), 0);
         ci.wallclock = 0;
         let value_old = CrdsValue::ContactInfo(ci.clone());
 
@@ -366,15 +365,13 @@ mod test {
         solana_logger::setup();
         let mut crds = Crds::default();
         let mut push = CrdsGossipPush::default();
-        let value1 =
-            CrdsValue::ContactInfo(ContactInfo::new_localhost(&Keypair::new().pubkey(), 0));
+        let value1 = CrdsValue::ContactInfo(ContactInfo::new_localhost(&Pubkey::new_rand(), 0));
 
         assert_eq!(crds.insert(value1.clone(), 0), Ok(None));
         push.refresh_push_active_set(&crds, &HashMap::new(), &Pubkey::default(), 1, 1);
 
         assert!(push.active_set.get(&value1.label().pubkey()).is_some());
-        let value2 =
-            CrdsValue::ContactInfo(ContactInfo::new_localhost(&Keypair::new().pubkey(), 0));
+        let value2 = CrdsValue::ContactInfo(ContactInfo::new_localhost(&Pubkey::new_rand(), 0));
         assert!(push.active_set.get(&value2.label().pubkey()).is_none());
         assert_eq!(crds.insert(value2.clone(), 0), Ok(None));
         for _ in 0..30 {
@@ -386,8 +383,7 @@ mod test {
         assert!(push.active_set.get(&value2.label().pubkey()).is_some());
 
         for _ in 0..push.num_active {
-            let value2 =
-                CrdsValue::ContactInfo(ContactInfo::new_localhost(&Keypair::new().pubkey(), 0));
+            let value2 = CrdsValue::ContactInfo(ContactInfo::new_localhost(&Pubkey::new_rand(), 0));
             assert_eq!(crds.insert(value2.clone(), 0), Ok(None));
         }
         push.refresh_push_active_set(&crds, &HashMap::new(), &Pubkey::default(), 1, 1);
@@ -401,7 +397,7 @@ mod test {
         let mut stakes = HashMap::new();
         for i in 1..=100 {
             let peer =
-                CrdsValue::ContactInfo(ContactInfo::new_localhost(&Keypair::new().pubkey(), time));
+                CrdsValue::ContactInfo(ContactInfo::new_localhost(&Pubkey::new_rand(), time));
             let id = peer.label().pubkey();
             crds.insert(peer.clone(), time).unwrap();
             stakes.insert(id, i * 100);
@@ -419,12 +415,11 @@ mod test {
     fn test_new_push_messages() {
         let mut crds = Crds::default();
         let mut push = CrdsGossipPush::default();
-        let peer = CrdsValue::ContactInfo(ContactInfo::new_localhost(&Keypair::new().pubkey(), 0));
+        let peer = CrdsValue::ContactInfo(ContactInfo::new_localhost(&Pubkey::new_rand(), 0));
         assert_eq!(crds.insert(peer.clone(), 0), Ok(None));
         push.refresh_push_active_set(&crds, &HashMap::new(), &Pubkey::default(), 1, 1);
 
-        let new_msg =
-            CrdsValue::ContactInfo(ContactInfo::new_localhost(&Keypair::new().pubkey(), 0));
+        let new_msg = CrdsValue::ContactInfo(ContactInfo::new_localhost(&Pubkey::new_rand(), 0));
         assert_eq!(
             push.process_push_message(&mut crds, new_msg.clone(), 0),
             Ok(None)
@@ -439,12 +434,11 @@ mod test {
     fn test_process_prune() {
         let mut crds = Crds::default();
         let mut push = CrdsGossipPush::default();
-        let peer = CrdsValue::ContactInfo(ContactInfo::new_localhost(&Keypair::new().pubkey(), 0));
+        let peer = CrdsValue::ContactInfo(ContactInfo::new_localhost(&Pubkey::new_rand(), 0));
         assert_eq!(crds.insert(peer.clone(), 0), Ok(None));
         push.refresh_push_active_set(&crds, &HashMap::new(), &Pubkey::default(), 1, 1);
 
-        let new_msg =
-            CrdsValue::ContactInfo(ContactInfo::new_localhost(&Keypair::new().pubkey(), 0));
+        let new_msg = CrdsValue::ContactInfo(ContactInfo::new_localhost(&Pubkey::new_rand(), 0));
         assert_eq!(
             push.process_push_message(&mut crds, new_msg.clone(), 0),
             Ok(None)
@@ -459,11 +453,11 @@ mod test {
     fn test_purge_old_pending_push_messages() {
         let mut crds = Crds::default();
         let mut push = CrdsGossipPush::default();
-        let peer = CrdsValue::ContactInfo(ContactInfo::new_localhost(&Keypair::new().pubkey(), 0));
+        let peer = CrdsValue::ContactInfo(ContactInfo::new_localhost(&Pubkey::new_rand(), 0));
         assert_eq!(crds.insert(peer.clone(), 0), Ok(None));
         push.refresh_push_active_set(&crds, &HashMap::new(), &Pubkey::default(), 1, 1);
 
-        let mut ci = ContactInfo::new_localhost(&Keypair::new().pubkey(), 0);
+        let mut ci = ContactInfo::new_localhost(&Pubkey::new_rand(), 0);
         ci.wallclock = 1;
         let new_msg = CrdsValue::ContactInfo(ci.clone());
         assert_eq!(
@@ -481,7 +475,7 @@ mod test {
     fn test_purge_old_pushed_once_messages() {
         let mut crds = Crds::default();
         let mut push = CrdsGossipPush::default();
-        let mut ci = ContactInfo::new_localhost(&Keypair::new().pubkey(), 0);
+        let mut ci = ContactInfo::new_localhost(&Pubkey::new_rand(), 0);
         ci.wallclock = 0;
         let value = CrdsValue::ContactInfo(ci.clone());
         let label = value.label();

--- a/core/src/db_window.rs
+++ b/core/src/db_window.rs
@@ -56,7 +56,6 @@ mod test {
     use crate::blocktree::get_tmp_ledger_path;
     use crate::entry::{make_tiny_test_entries, EntrySlice};
     use crate::packet::index_blobs;
-    use solana_sdk::signature::{Keypair, KeypairUtil};
     use std::sync::Arc;
 
     #[test]
@@ -67,7 +66,7 @@ mod test {
         let original_entries = make_tiny_test_entries(num_entries);
         let shared_blobs = original_entries.clone().to_shared_blobs();
 
-        index_blobs(&shared_blobs, &Keypair::new().pubkey(), 0, 0, 0);
+        index_blobs(&shared_blobs, &Pubkey::new_rand(), 0, 0, 0);
 
         for blob in shared_blobs.iter().rev() {
             process_blob(&blocktree, blob).expect("Expect successful processing of blob");

--- a/core/src/erasure.rs
+++ b/core/src/erasure.rs
@@ -502,9 +502,8 @@ pub mod test {
     use crate::blocktree::get_tmp_ledger_path;
     use crate::blocktree::Blocktree;
     use crate::entry::{make_tiny_test_entries, EntrySlice};
-
     use crate::packet::{index_blobs, SharedBlob};
-    use solana_sdk::signature::{Keypair, KeypairUtil};
+    use solana_sdk::pubkey::Pubkey;
 
     /// Specifies the contents of a 16-data-blob and 4-coding-blob erasure set
     /// Exists to be passed to `generate_blocktree_with_coding`
@@ -793,13 +792,7 @@ pub mod test {
                 let start_index = set_index * NUM_DATA;
 
                 let mut blobs = make_tiny_test_entries(NUM_DATA).to_single_entry_shared_blobs();
-                index_blobs(
-                    &blobs,
-                    &Keypair::new().pubkey(),
-                    start_index as u64,
-                    slot,
-                    0,
-                );
+                index_blobs(&blobs, &Pubkey::new_rand(), start_index as u64, slot, 0);
 
                 let mut coding_generator = CodingGenerator::new();
                 let mut coding_blobs = coding_generator.next(&blobs).unwrap();
@@ -831,7 +824,7 @@ pub mod test {
     fn generate_test_blobs(offset: usize, num_blobs: usize) -> Vec<SharedBlob> {
         let blobs = make_tiny_test_entries(num_blobs).to_single_entry_shared_blobs();
 
-        index_blobs(&blobs, &Keypair::new().pubkey(), offset as u64, 0, 0);
+        index_blobs(&blobs, &Pubkey::new_rand(), offset as u64, 0, 0);
         blobs
     }
 

--- a/core/src/leader_schedule.rs
+++ b/core/src/leader_schedule.rs
@@ -42,12 +42,11 @@ impl Index<u64> for LeaderSchedule {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use solana_sdk::signature::{Keypair, KeypairUtil};
 
     #[test]
     fn test_leader_schedule_index() {
-        let pubkey0 = Keypair::new().pubkey();
-        let pubkey1 = Keypair::new().pubkey();
+        let pubkey0 = Pubkey::new_rand();
+        let pubkey1 = Pubkey::new_rand();
         let leader_schedule = LeaderSchedule {
             slot_leaders: vec![pubkey0, pubkey1],
         };
@@ -59,11 +58,9 @@ mod tests {
     #[test]
     fn test_leader_schedule_basic() {
         let num_keys = 10;
-        let stakes: Vec<_> = (0..num_keys)
-            .map(|i| (Keypair::new().pubkey(), i))
-            .collect();
+        let stakes: Vec<_> = (0..num_keys).map(|i| (Pubkey::new_rand(), i)).collect();
 
-        let seed = Keypair::new().pubkey();
+        let seed = Pubkey::new_rand();
         let mut seed_bytes = [0u8; 32];
         seed_bytes.copy_from_slice(seed.as_ref());
         let len = num_keys * 10;
@@ -77,11 +74,9 @@ mod tests {
     #[test]
     fn test_repeated_leader_schedule() {
         let num_keys = 10;
-        let stakes: Vec<_> = (0..num_keys)
-            .map(|i| (Keypair::new().pubkey(), i))
-            .collect();
+        let stakes: Vec<_> = (0..num_keys).map(|i| (Pubkey::new_rand(), i)).collect();
 
-        let seed = Keypair::new().pubkey();
+        let seed = Pubkey::new_rand();
         let mut seed_bytes = [0u8; 32];
         seed_bytes.copy_from_slice(seed.as_ref());
         let len = num_keys * 10;
@@ -100,8 +95,8 @@ mod tests {
 
     #[test]
     fn test_repeated_leader_schedule_specific() {
-        let alice_pubkey = Keypair::new().pubkey();
-        let bob_pubkey = Keypair::new().pubkey();
+        let alice_pubkey = Pubkey::new_rand();
+        let bob_pubkey = Pubkey::new_rand();
         let stakes = vec![(alice_pubkey, 2), (bob_pubkey, 1)];
 
         let seed = Pubkey::default();

--- a/core/src/leader_schedule_utils.rs
+++ b/core/src/leader_schedule_utils.rs
@@ -107,7 +107,7 @@ mod tests {
 
     #[test]
     fn test_next_leader_slot() {
-        let pubkey = Keypair::new().pubkey();
+        let pubkey = Pubkey::new_rand();
         let mut genesis_block = GenesisBlock::new_with_leader(
             BOOTSTRAP_LEADER_LAMPORTS,
             &pubkey,
@@ -132,7 +132,7 @@ mod tests {
 
         assert_eq!(
             next_leader_slot(
-                &Keypair::new().pubkey(), // not in leader_schedule
+                &Pubkey::new_rand(), // not in leader_schedule
                 0,
                 &bank,
                 None
@@ -143,7 +143,7 @@ mod tests {
 
     #[test]
     fn test_next_leader_slot_blocktree() {
-        let pubkey = Keypair::new().pubkey();
+        let pubkey = Pubkey::new_rand();
         let mut genesis_block = GenesisBlock::new_with_leader(
             BOOTSTRAP_LEADER_LAMPORTS,
             &pubkey,
@@ -198,7 +198,7 @@ mod tests {
 
             assert_eq!(
                 next_leader_slot(
-                    &Keypair::new().pubkey(), // not in leader_schedule
+                    &Pubkey::new_rand(), // not in leader_schedule
                     0,
                     &bank,
                     Some(&blocktree)
@@ -211,7 +211,7 @@ mod tests {
 
     #[test]
     fn test_next_leader_slot_next_epoch() {
-        let pubkey = Keypair::new().pubkey();
+        let pubkey = Pubkey::new_rand();
         let (mut genesis_block, mint_keypair) = GenesisBlock::new_with_leader(
             2 * BOOTSTRAP_LEADER_LAMPORTS,
             &pubkey,
@@ -220,7 +220,7 @@ mod tests {
         genesis_block.epoch_warmup = false;
 
         let bank = Bank::new(&genesis_block);
-        let delegate_id = Keypair::new().pubkey();
+        let delegate_id = Pubkey::new_rand();
 
         // Create new vote account
         let new_voting_keypair = Keypair::new();
@@ -263,7 +263,7 @@ mod tests {
 
     #[test]
     fn test_leader_schedule_via_bank() {
-        let pubkey = Keypair::new().pubkey();
+        let pubkey = Pubkey::new_rand();
         let (genesis_block, _mint_keypair) = GenesisBlock::new_with_leader(
             BOOTSTRAP_LEADER_LAMPORTS,
             &pubkey,
@@ -287,7 +287,7 @@ mod tests {
 
     #[test]
     fn test_leader_scheduler1_basic() {
-        let pubkey = Keypair::new().pubkey();
+        let pubkey = Pubkey::new_rand();
         let genesis_block = GenesisBlock::new_with_leader(
             BOOTSTRAP_LEADER_LAMPORTS,
             &pubkey,
@@ -300,8 +300,8 @@ mod tests {
 
     #[test]
     fn test_sort_stakes_basic() {
-        let pubkey0 = Keypair::new().pubkey();
-        let pubkey1 = Keypair::new().pubkey();
+        let pubkey0 = Pubkey::new_rand();
+        let pubkey1 = Pubkey::new_rand();
         let mut stakes = vec![(pubkey0, 1), (pubkey1, 2)];
         sort_stakes(&mut stakes);
         assert_eq!(stakes, vec![(pubkey1, 2), (pubkey0, 1)]);
@@ -309,8 +309,8 @@ mod tests {
 
     #[test]
     fn test_sort_stakes_with_dup() {
-        let pubkey0 = Keypair::new().pubkey();
-        let pubkey1 = Keypair::new().pubkey();
+        let pubkey0 = Pubkey::new_rand();
+        let pubkey1 = Pubkey::new_rand();
         let mut stakes = vec![(pubkey0, 1), (pubkey1, 2), (pubkey0, 1)];
         sort_stakes(&mut stakes);
         assert_eq!(stakes, vec![(pubkey1, 2), (pubkey0, 1)]);
@@ -319,7 +319,7 @@ mod tests {
     #[test]
     fn test_sort_stakes_with_equal_stakes() {
         let pubkey0 = Pubkey::default();
-        let pubkey1 = Keypair::new().pubkey();
+        let pubkey1 = Pubkey::new_rand();
         let mut stakes = vec![(pubkey0, 1), (pubkey1, 1)];
         sort_stakes(&mut stakes);
         assert_eq!(stakes, vec![(pubkey1, 1), (pubkey0, 1)]);

--- a/core/src/locktower.rs
+++ b/core/src/locktower.rs
@@ -369,7 +369,6 @@ impl Locktower {
 #[cfg(test)]
 mod test {
     use super::*;
-    use solana_sdk::signature::{Keypair, KeypairUtil};
 
     fn gen_accounts(stake_votes: &[(u64, &[u64])]) -> Vec<(Pubkey, Account)> {
         let mut accounts = vec![];
@@ -384,7 +383,7 @@ mod test {
             vote_state
                 .serialize(&mut account.data)
                 .expect("serialize state");
-            accounts.push((Keypair::new().pubkey(), account));
+            accounts.push((Pubkey::new_rand(), account));
         }
         accounts
     }

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -599,7 +599,7 @@ mod test {
         let my_node = Node::new_localhost_with_pubkey(&my_id);
 
         // Create keypair for the leader
-        let leader_id = Keypair::new().pubkey();
+        let leader_id = Pubkey::new_rand();
 
         let (genesis_block, _mint_keypair) = GenesisBlock::new_with_leader(10_000, &leader_id, 500);
 

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -491,7 +491,7 @@ mod tests {
 
     #[test]
     fn test_rpc_request_processor_new() {
-        let bob_pubkey = Keypair::new().pubkey();
+        let bob_pubkey = Pubkey::new_rand();
         let exit = Arc::new(AtomicBool::new(false));
         let (bank_forks, alice) = new_bank_forks();
         let bank = bank_forks.read().unwrap().working_bank();
@@ -513,7 +513,7 @@ mod tests {
 
     #[test]
     fn test_rpc_get_balance() {
-        let bob_pubkey = Keypair::new().pubkey();
+        let bob_pubkey = Pubkey::new_rand();
         let (io, meta, _blockhash, _alice) = start_rpc_handler_with_tx(&bob_pubkey);
 
         let req = format!(
@@ -531,7 +531,7 @@ mod tests {
 
     #[test]
     fn test_rpc_get_tx_count() {
-        let bob_pubkey = Keypair::new().pubkey();
+        let bob_pubkey = Pubkey::new_rand();
         let (io, meta, _blockhash, _alice) = start_rpc_handler_with_tx(&bob_pubkey);
 
         let req = format!(r#"{{"jsonrpc":"2.0","id":1,"method":"getTransactionCount"}}"#);
@@ -546,7 +546,7 @@ mod tests {
 
     #[test]
     fn test_rpc_get_account_info() {
-        let bob_pubkey = Keypair::new().pubkey();
+        let bob_pubkey = Pubkey::new_rand();
         let (io, meta, _blockhash, _alice) = start_rpc_handler_with_tx(&bob_pubkey);
 
         let req = format!(
@@ -573,7 +573,7 @@ mod tests {
 
     #[test]
     fn test_rpc_confirm_tx() {
-        let bob_pubkey = Keypair::new().pubkey();
+        let bob_pubkey = Pubkey::new_rand();
         let (io, meta, blockhash, alice) = start_rpc_handler_with_tx(&bob_pubkey);
         let tx = SystemTransaction::new_move(&alice, &bob_pubkey, 20, blockhash, 0);
 
@@ -592,7 +592,7 @@ mod tests {
 
     #[test]
     fn test_rpc_get_signature_status() {
-        let bob_pubkey = Keypair::new().pubkey();
+        let bob_pubkey = Pubkey::new_rand();
         let (io, meta, blockhash, alice) = start_rpc_handler_with_tx(&bob_pubkey);
         let tx = SystemTransaction::new_move(&alice, &bob_pubkey, 20, blockhash, 0);
 
@@ -625,7 +625,7 @@ mod tests {
 
     #[test]
     fn test_rpc_get_recent_blockhash() {
-        let bob_pubkey = Keypair::new().pubkey();
+        let bob_pubkey = Pubkey::new_rand();
         let (io, meta, blockhash, _alice) = start_rpc_handler_with_tx(&bob_pubkey);
 
         let req = format!(r#"{{"jsonrpc":"2.0","id":1,"method":"getRecentBlockhash"}}"#);
@@ -640,7 +640,7 @@ mod tests {
 
     #[test]
     fn test_rpc_fail_request_airdrop() {
-        let bob_pubkey = Keypair::new().pubkey();
+        let bob_pubkey = Pubkey::new_rand();
         let (io, meta, _blockhash, _alice) = start_rpc_handler_with_tx(&bob_pubkey);
 
         // Expect internal error because no drone is available
@@ -705,7 +705,7 @@ mod tests {
 
     #[test]
     fn test_rpc_verify_pubkey() {
-        let pubkey = Keypair::new().pubkey();
+        let pubkey = Pubkey::new_rand();
         assert_eq!(verify_pubkey(pubkey.to_string()).unwrap(), pubkey);
         let bad_pubkey = "a1b2c3d4";
         assert_eq!(
@@ -716,13 +716,8 @@ mod tests {
 
     #[test]
     fn test_rpc_verify_signature() {
-        let tx = SystemTransaction::new_move(
-            &Keypair::new(),
-            &Keypair::new().pubkey(),
-            20,
-            hash(&[0]),
-            0,
-        );
+        let tx =
+            SystemTransaction::new_move(&Keypair::new(), &Pubkey::new_rand(), 20, hash(&[0]), 0);
         assert_eq!(
             verify_signature(&tx.signatures[0].to_string()).unwrap(),
             tx.signatures[0]

--- a/core/src/rpc_pubsub.rs
+++ b/core/src/rpc_pubsub.rs
@@ -291,7 +291,7 @@ mod tests {
     #[test]
     fn test_signature_unsubscribe() {
         let (genesis_block, alice) = GenesisBlock::new(10_000);
-        let bob_pubkey = Keypair::new().pubkey();
+        let bob_pubkey = Pubkey::new_rand();
         let bank = Bank::new(&genesis_block);
         let arc_bank = Arc::new(bank);
         let blockhash = arc_bank.last_blockhash();
@@ -339,7 +339,7 @@ mod tests {
             .native_programs
             .push(("solana_budget_program".to_string(), solana_budget_api::id()));
 
-        let bob_pubkey = Keypair::new().pubkey();
+        let bob_pubkey = Pubkey::new_rand();
         let witness = Keypair::new();
         let contract_funds = Keypair::new();
         let contract_state = Keypair::new();
@@ -407,7 +407,7 @@ mod tests {
 
     #[test]
     fn test_account_unsubscribe() {
-        let bob_pubkey = Keypair::new().pubkey();
+        let bob_pubkey = Pubkey::new_rand();
         let session = create_session();
 
         let mut io = PubSubHandler::default();

--- a/core/src/staking_utils.rs
+++ b/core/src/staking_utils.rs
@@ -160,7 +160,7 @@ mod tests {
 
     #[test]
     fn test_bank_staked_nodes_at_epoch() {
-        let pubkey = Keypair::new().pubkey();
+        let pubkey = Pubkey::new_rand();
         let bootstrap_lamports = 2;
         let (genesis_block, _) =
             GenesisBlock::new_with_leader(bootstrap_lamports, &pubkey, bootstrap_lamports);
@@ -276,8 +276,8 @@ mod tests {
     #[test]
     fn test_to_delegated_stakes() {
         let mut stakes = Vec::new();
-        let delegate1 = Keypair::new().pubkey();
-        let delegate2 = Keypair::new().pubkey();
+        let delegate1 = Pubkey::new_rand();
+        let delegate2 = Pubkey::new_rand();
 
         // Delegate 1 has stake of 3
         for i in 0..3 {

--- a/core/tests/cluster_info.rs
+++ b/core/tests/cluster_info.rs
@@ -7,7 +7,6 @@ use solana::cluster_info::{
 };
 use solana::contact_info::ContactInfo;
 use solana_sdk::pubkey::Pubkey;
-use solana_sdk::signature::{Keypair, KeypairUtil};
 use std::sync::mpsc::channel;
 use std::sync::mpsc::TryRecvError;
 use std::sync::mpsc::{Receiver, Sender};
@@ -36,7 +35,7 @@ fn run_simulation(num_nodes: u64, fanout: usize, hood_size: usize) {
     let timeout = 60 * 5;
 
     // describe the leader
-    let leader_info = ContactInfo::new_localhost(&Keypair::new().pubkey(), 0);
+    let leader_info = ContactInfo::new_localhost(&Pubkey::new_rand(), 0);
     let mut cluster_info = ClusterInfo::new_with_invalid_keypair(leader_info.clone());
 
     // setup stakes
@@ -59,7 +58,7 @@ fn run_simulation(num_nodes: u64, fanout: usize, hood_size: usize) {
         chunk.into_iter().for_each(|i| {
             //distribute neighbors across threads to maximize parallel compute
             let batch_ix = *i as usize % batches.len();
-            let node = ContactInfo::new_localhost(&Keypair::new().pubkey(), 0);
+            let node = ContactInfo::new_localhost(&Pubkey::new_rand(), 0);
             stakes.insert(node.id, *i);
             cluster_info.insert_info(node.clone());
             let (s, r) = channel();

--- a/core/tests/crds_gossip.rs
+++ b/core/tests/crds_gossip.rs
@@ -10,18 +10,16 @@ use solana::crds_value::CrdsValue;
 use solana::crds_value::CrdsValueLabel;
 use solana_sdk::hash::hash;
 use solana_sdk::pubkey::Pubkey;
-use solana_sdk::signature::{Keypair, KeypairUtil};
 use solana_sdk::timing::timestamp;
 use std::sync::{Arc, Mutex};
 
 type Node = Arc<Mutex<CrdsGossip>>;
 type Network = HashMap<Pubkey, Node>;
 fn star_network_create(num: usize) -> Network {
-    let entry = CrdsValue::ContactInfo(ContactInfo::new_localhost(&Keypair::new().pubkey(), 0));
+    let entry = CrdsValue::ContactInfo(ContactInfo::new_localhost(&Pubkey::new_rand(), 0));
     let mut network: HashMap<_, _> = (1..num)
         .map(|_| {
-            let new =
-                CrdsValue::ContactInfo(ContactInfo::new_localhost(&Keypair::new().pubkey(), 0));
+            let new = CrdsValue::ContactInfo(ContactInfo::new_localhost(&Pubkey::new_rand(), 0));
             let id = new.label().pubkey();
             let mut node = CrdsGossip::default();
             node.crds.insert(new.clone(), 0).unwrap();
@@ -39,15 +37,14 @@ fn star_network_create(num: usize) -> Network {
 }
 
 fn rstar_network_create(num: usize) -> Network {
-    let entry = CrdsValue::ContactInfo(ContactInfo::new_localhost(&Keypair::new().pubkey(), 0));
+    let entry = CrdsValue::ContactInfo(ContactInfo::new_localhost(&Pubkey::new_rand(), 0));
     let mut origin = CrdsGossip::default();
     let id = entry.label().pubkey();
     origin.crds.insert(entry.clone(), 0).unwrap();
     origin.set_self(&id);
     let mut network: HashMap<_, _> = (1..num)
         .map(|_| {
-            let new =
-                CrdsValue::ContactInfo(ContactInfo::new_localhost(&Keypair::new().pubkey(), 0));
+            let new = CrdsValue::ContactInfo(ContactInfo::new_localhost(&Pubkey::new_rand(), 0));
             let id = new.label().pubkey();
             let mut node = CrdsGossip::default();
             node.crds.insert(new.clone(), 0).unwrap();
@@ -63,8 +60,7 @@ fn rstar_network_create(num: usize) -> Network {
 fn ring_network_create(num: usize) -> Network {
     let mut network: HashMap<_, _> = (0..num)
         .map(|_| {
-            let new =
-                CrdsValue::ContactInfo(ContactInfo::new_localhost(&Keypair::new().pubkey(), 0));
+            let new = CrdsValue::ContactInfo(ContactInfo::new_localhost(&Pubkey::new_rand(), 0));
             let id = new.label().pubkey();
             let mut node = CrdsGossip::default();
             node.crds.insert(new.clone(), 0).unwrap();

--- a/core/tests/rpc.rs
+++ b/core/tests/rpc.rs
@@ -6,7 +6,7 @@ use serde_json::{json, Value};
 use solana::fullnode::new_fullnode_for_tests;
 use solana_client::rpc_client::get_rpc_request_str;
 use solana_sdk::hash::Hash;
-use solana_sdk::signature::{Keypair, KeypairUtil};
+use solana_sdk::pubkey::Pubkey;
 use solana_sdk::system_transaction::SystemTransaction;
 use std::fs::remove_dir_all;
 use std::thread::sleep;
@@ -17,7 +17,7 @@ fn test_rpc_send_tx() {
     solana_logger::setup();
 
     let (server, leader_data, alice, ledger_path) = new_fullnode_for_tests();
-    let bob_pubkey = Keypair::new().pubkey();
+    let bob_pubkey = Pubkey::new_rand();
 
     let client = reqwest::Client::new();
     let request = json!({

--- a/drone/src/drone.rs
+++ b/drone/src/drone.rs
@@ -339,7 +339,7 @@ mod tests {
 
     #[test]
     fn test_drone_build_airdrop_transaction() {
-        let to = Keypair::new().pubkey();
+        let to = Pubkey::new_rand();
         let blockhash = Hash::default();
         let request = DroneRequest::GetAirdrop {
             lamports: 2,
@@ -377,7 +377,7 @@ mod tests {
 
     #[test]
     fn test_process_drone_request() {
-        let to = Keypair::new().pubkey();
+        let to = Pubkey::new_rand();
         let blockhash = Hash::new(&to.as_ref());
         let lamports = 50;
         let req = DroneRequest::GetAirdrop {

--- a/drone/src/drone_mock.rs
+++ b/drone/src/drone_mock.rs
@@ -16,7 +16,7 @@ pub fn request_airdrop_transaction(
         Err(Error::new(ErrorKind::Other, "Airdrop failed"))?
     }
     let key = Keypair::new();
-    let to = Keypair::new().pubkey();
+    let to = Pubkey::new_rand();
     let blockhash = Hash::default();
     let tx = SystemTransaction::new_account(&key, &to, lamports, blockhash, 0);
     Ok(tx)

--- a/drone/tests/local-drone.rs
+++ b/drone/tests/local-drone.rs
@@ -1,6 +1,7 @@
 use solana_drone::drone::{request_airdrop_transaction, run_local_drone};
 use solana_sdk::hash::Hash;
 use solana_sdk::message::Message;
+use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::{Keypair, KeypairUtil};
 use solana_sdk::system_instruction::SystemInstruction;
 use solana_sdk::transaction::Transaction;
@@ -9,7 +10,7 @@ use std::sync::mpsc::channel;
 #[test]
 fn test_local_drone() {
     let keypair = Keypair::new();
-    let to = Keypair::new().pubkey();
+    let to = Pubkey::new_rand();
     let lamports = 50;
     let blockhash = Hash::new(&to.as_ref());
     let create_instruction = SystemInstruction::new_account(&keypair.pubkey(), &to, lamports);

--- a/programs/budget_api/src/budget_expr.rs
+++ b/programs/budget_api/src/budget_expr.rs
@@ -214,7 +214,6 @@ impl BudgetExpr {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use solana_sdk::signature::{Keypair, KeypairUtil};
 
     #[test]
     fn test_signature_satisfied() {
@@ -258,8 +257,8 @@ mod tests {
     #[test]
     fn test_future_payment() {
         let dt = Utc.ymd(2014, 11, 14).and_hms(8, 9, 10);
-        let from = Keypair::new().pubkey();
-        let to = Keypair::new().pubkey();
+        let from = Pubkey::new_rand();
+        let to = Pubkey::new_rand();
 
         let mut expr = BudgetExpr::new_future_payment(dt, &from, 42, &to);
         expr.apply_witness(&Witness::Timestamp(dt), &from);
@@ -271,8 +270,8 @@ mod tests {
         // Ensure timestamp will only be acknowledged if it came from the
         // whitelisted public key.
         let dt = Utc.ymd(2014, 11, 14).and_hms(8, 9, 10);
-        let from = Keypair::new().pubkey();
-        let to = Keypair::new().pubkey();
+        let from = Pubkey::new_rand();
+        let to = Pubkey::new_rand();
 
         let mut expr = BudgetExpr::new_future_payment(dt, &from, 42, &to);
         let orig_expr = expr.clone();
@@ -296,8 +295,8 @@ mod tests {
     }
     #[test]
     fn test_2_2_multisig_payment() {
-        let from0 = Keypair::new().pubkey();
-        let from1 = Keypair::new().pubkey();
+        let from0 = Pubkey::new_rand();
+        let from1 = Pubkey::new_rand();
         let to = Pubkey::default();
 
         let mut expr = BudgetExpr::new_2_2_multisig_payment(&from0, &from1, 42, &to);
@@ -307,9 +306,9 @@ mod tests {
 
     #[test]
     fn test_multisig_after_sig() {
-        let from0 = Keypair::new().pubkey();
-        let from1 = Keypair::new().pubkey();
-        let from2 = Keypair::new().pubkey();
+        let from0 = Pubkey::new_rand();
+        let from1 = Pubkey::new_rand();
+        let from2 = Pubkey::new_rand();
         let to = Pubkey::default();
 
         let expr = BudgetExpr::new_2_2_multisig_payment(&from0, &from1, 42, &to);
@@ -322,8 +321,8 @@ mod tests {
 
     #[test]
     fn test_multisig_after_ts() {
-        let from0 = Keypair::new().pubkey();
-        let from1 = Keypair::new().pubkey();
+        let from0 = Pubkey::new_rand();
+        let from1 = Pubkey::new_rand();
         let dt = Utc.ymd(2014, 11, 11).and_hms(7, 7, 7);
         let to = Pubkey::default();
 

--- a/programs/budget_api/src/budget_instruction.rs
+++ b/programs/budget_api/src/budget_instruction.rs
@@ -6,7 +6,6 @@ use chrono::prelude::{DateTime, Utc};
 use serde_derive::{Deserialize, Serialize};
 use solana_sdk::instruction::{AccountMeta, Instruction};
 use solana_sdk::pubkey::Pubkey;
-use solana_sdk::signature::{Keypair, KeypairUtil};
 use solana_sdk::system_instruction::SystemInstruction;
 
 /// A smart contract.
@@ -59,7 +58,7 @@ impl BudgetInstruction {
 
     /// Create a new payment script.
     pub fn new_payment(from: &Pubkey, to: &Pubkey, lamports: u64) -> Vec<Instruction> {
-        let contract = Keypair::new().pubkey();
+        let contract = Pubkey::new_rand();
         let expr = BudgetExpr::new_payment(lamports, to);
         Self::new_account(from, &contract, lamports, expr)
     }
@@ -127,17 +126,17 @@ mod tests {
 
     #[test]
     fn test_budget_instruction_verify() {
-        let alice_pubkey = Keypair::new().pubkey();
-        let bob_pubkey = Keypair::new().pubkey();
+        let alice_pubkey = Pubkey::new_rand();
+        let bob_pubkey = Pubkey::new_rand();
         BudgetInstruction::new_payment(&alice_pubkey, &bob_pubkey, 1); // No panic! indicates success.
     }
 
     #[test]
     #[should_panic]
     fn test_budget_instruction_overspend() {
-        let alice_pubkey = Keypair::new().pubkey();
-        let bob_pubkey = Keypair::new().pubkey();
-        let budget_pubkey = Keypair::new().pubkey();
+        let alice_pubkey = Pubkey::new_rand();
+        let bob_pubkey = Pubkey::new_rand();
+        let budget_pubkey = Pubkey::new_rand();
         let expr = BudgetExpr::new_payment(2, &bob_pubkey);
         BudgetInstruction::new_account(&alice_pubkey, &budget_pubkey, 1, expr);
     }
@@ -145,9 +144,9 @@ mod tests {
     #[test]
     #[should_panic]
     fn test_budget_instruction_underspend() {
-        let alice_pubkey = Keypair::new().pubkey();
-        let bob_pubkey = Keypair::new().pubkey();
-        let budget_pubkey = Keypair::new().pubkey();
+        let alice_pubkey = Pubkey::new_rand();
+        let bob_pubkey = Pubkey::new_rand();
+        let budget_pubkey = Pubkey::new_rand();
         let expr = BudgetExpr::new_payment(1, &bob_pubkey);
         BudgetInstruction::new_account(&alice_pubkey, &budget_pubkey, 2, expr);
     }

--- a/programs/budget_api/src/budget_processor.rs
+++ b/programs/budget_api/src/budget_processor.rs
@@ -165,7 +165,7 @@ mod tests {
         let (bank, alice_keypair) = create_bank(10_000);
         let bank_client = BankClient::new(&bank);
         let alice_pubkey = alice_keypair.pubkey();
-        let bob_pubkey = Keypair::new().pubkey();
+        let bob_pubkey = Pubkey::new_rand();
         let instructions = BudgetInstruction::new_payment(&alice_pubkey, &bob_pubkey, 100);
         let message = Message::new(instructions);
         bank_client
@@ -181,9 +181,9 @@ mod tests {
         let alice_pubkey = alice_keypair.pubkey();
 
         // Initialize BudgetState
-        let budget_pubkey = Keypair::new().pubkey();
-        let bob_pubkey = Keypair::new().pubkey();
-        let witness = Keypair::new().pubkey();
+        let budget_pubkey = Pubkey::new_rand();
+        let bob_pubkey = Pubkey::new_rand();
+        let witness = Pubkey::new_rand();
         let instructions = BudgetInstruction::new_when_signed(
             &alice_pubkey,
             &bob_pubkey,
@@ -228,8 +228,8 @@ mod tests {
         let alice_pubkey = alice_keypair.pubkey();
 
         // Initialize BudgetState
-        let budget_pubkey = Keypair::new().pubkey();
-        let bob_pubkey = Keypair::new().pubkey();
+        let budget_pubkey = Pubkey::new_rand();
+        let bob_pubkey = Pubkey::new_rand();
         let dt = Utc::now();
         let instructions = BudgetInstruction::new_on_date(
             &alice_pubkey,
@@ -278,9 +278,9 @@ mod tests {
         let (bank, alice_keypair) = create_bank(2);
         let bank_client = BankClient::new(&bank);
         let alice_pubkey = alice_keypair.pubkey();
-        let budget_pubkey = Keypair::new().pubkey();
-        let bob_pubkey = Keypair::new().pubkey();
-        let mallory_pubkey = Keypair::new().pubkey();
+        let budget_pubkey = Pubkey::new_rand();
+        let bob_pubkey = Pubkey::new_rand();
+        let mallory_pubkey = Pubkey::new_rand();
         let dt = Utc::now();
         let instructions = BudgetInstruction::new_on_date(
             &alice_pubkey,
@@ -344,8 +344,8 @@ mod tests {
         let (bank, alice_keypair) = create_bank(3);
         let bank_client = BankClient::new(&bank);
         let alice_pubkey = alice_keypair.pubkey();
-        let budget_pubkey = Keypair::new().pubkey();
-        let bob_pubkey = Keypair::new().pubkey();
+        let budget_pubkey = Pubkey::new_rand();
+        let bob_pubkey = Pubkey::new_rand();
         let dt = Utc::now();
 
         let instructions = BudgetInstruction::new_on_date(

--- a/programs/exchange_api/src/exchange_processor.rs
+++ b/programs/exchange_api/src/exchange_processor.rs
@@ -522,7 +522,7 @@ mod test {
     }
 
     fn create_account(client: &BankClient, owner: &Keypair) -> Pubkey {
-        let new = Keypair::new().pubkey();
+        let new = Pubkey::new_rand();
         let instruction = SystemInstruction::new_program_account(
             &owner.pubkey(),
             &new,
@@ -537,7 +537,7 @@ mod test {
     }
 
     fn create_token_account(client: &BankClient, owner: &Keypair) -> Pubkey {
-        let new = Keypair::new().pubkey();
+        let new = Pubkey::new_rand();
         let instruction = SystemInstruction::new_program_account(
             &owner.pubkey(),
             &new,

--- a/programs/storage_api/src/storage_processor.rs
+++ b/programs/storage_api/src/storage_processor.rs
@@ -203,7 +203,7 @@ mod tests {
 
     #[test]
     fn test_storage_tx() {
-        let pubkey = Keypair::new().pubkey();
+        let pubkey = Pubkey::new_rand();
         let mut accounts = [(pubkey, Account::default())];
         let mut keyed_accounts = create_keyed_accounts(&mut accounts);
         assert!(process_instruction(&id(), &mut keyed_accounts, &[], 42).is_err());
@@ -211,7 +211,7 @@ mod tests {
 
     #[test]
     fn test_serialize_overflow() {
-        let pubkey = Keypair::new().pubkey();
+        let pubkey = Pubkey::new_rand();
         let mut keyed_accounts = Vec::new();
         let mut user_account = Account::default();
         keyed_accounts.push(KeyedAccount::new(&pubkey, true, &mut user_account));
@@ -230,7 +230,7 @@ mod tests {
 
     #[test]
     fn test_invalid_accounts_len() {
-        let pubkey = Keypair::new().pubkey();
+        let pubkey = Pubkey::new_rand();
         let mut accounts = [Account::default()];
 
         let ix =
@@ -245,7 +245,7 @@ mod tests {
     #[test]
     fn test_submit_mining_invalid_entry_height() {
         solana_logger::setup();
-        let pubkey = Keypair::new().pubkey();
+        let pubkey = Pubkey::new_rand();
         let mut accounts = [Account::default(), Account::default()];
         accounts[1].data.resize(16 * 1024, 0);
 
@@ -259,7 +259,7 @@ mod tests {
     #[test]
     fn test_submit_mining_ok() {
         solana_logger::setup();
-        let pubkey = Keypair::new().pubkey();
+        let pubkey = Pubkey::new_rand();
         let mut accounts = [Account::default(), Account::default()];
         accounts[0].data.resize(16 * 1024, 0);
 
@@ -280,7 +280,7 @@ mod tests {
     #[test]
     fn test_validate_mining() {
         solana_logger::setup();
-        let pubkey = Keypair::new().pubkey();
+        let pubkey = Pubkey::new_rand();
         let mut accounts = [Account::default(), Account::default()];
         accounts[0].data.resize(16 * 1024, 0);
 
@@ -362,8 +362,8 @@ mod tests {
         let alice_pubkey = alice_keypair.pubkey();
         let bob_keypair = Keypair::new();
         let bob_pubkey = bob_keypair.pubkey();
-        let jack_pubkey = Keypair::new().pubkey();
-        let jill_pubkey = Keypair::new().pubkey();
+        let jack_pubkey = Pubkey::new_rand();
+        let jill_pubkey = Pubkey::new_rand();
 
         let mut bank = Bank::new(&genesis_block);
         bank.add_instruction_processor(id(), process_instruction);

--- a/programs/vote_api/src/vote_processor.rs
+++ b/programs/vote_api/src/vote_processor.rs
@@ -120,7 +120,7 @@ mod tests {
         let (bank, from_keypair) = create_bank(10_000);
         let vote_keypair = Keypair::new();
         let bank_client = BankClient::new(&bank);
-        let delegate_id = Keypair::new().pubkey();
+        let delegate_id = Pubkey::new_rand();
         create_vote_account_with_delegate(
             &bank_client,
             &from_keypair,

--- a/programs/vote_api/src/vote_state.rs
+++ b/programs/vote_api/src/vote_state.rs
@@ -312,14 +312,13 @@ pub fn vote_and_deserialize(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use solana_sdk::signature::{Keypair, KeypairUtil};
 
     #[test]
     fn test_initialize_vote_account() {
-        let vote_account_id = Keypair::new().pubkey();
+        let vote_account_id = Pubkey::new_rand();
         let mut vote_account = create_vote_account(100);
 
-        let bogus_account_id = Keypair::new().pubkey();
+        let bogus_account_id = Pubkey::new_rand();
         let mut bogus_account = Account::new(100, 0, &id());
 
         let mut keyed_accounts = [KeyedAccount::new(
@@ -351,7 +350,7 @@ mod tests {
 
     #[test]
     fn test_voter_registration() {
-        let vote_id = Keypair::new().pubkey();
+        let vote_id = Pubkey::new_rand();
         let mut vote_account = create_vote_account(100);
 
         let vote_state = initialize_and_deserialize(&vote_id, &mut vote_account).unwrap();
@@ -361,7 +360,7 @@ mod tests {
 
     #[test]
     fn test_vote() {
-        let vote_id = Keypair::new().pubkey();
+        let vote_id = Pubkey::new_rand();
         let mut vote_account = create_vote_account(100);
         initialize_and_deserialize(&vote_id, &mut vote_account).unwrap();
 
@@ -373,7 +372,7 @@ mod tests {
 
     #[test]
     fn test_vote_signature() {
-        let vote_id = Keypair::new().pubkey();
+        let vote_id = Pubkey::new_rand();
         let mut vote_account = create_vote_account(100);
         initialize_and_deserialize(&vote_id, &mut vote_account).unwrap();
 
@@ -385,7 +384,7 @@ mod tests {
 
     #[test]
     fn test_vote_without_initialization() {
-        let vote_id = Keypair::new().pubkey();
+        let vote_id = Pubkey::new_rand();
         let mut vote_account = create_vote_account(100);
 
         let vote = Vote::new(1);
@@ -395,7 +394,7 @@ mod tests {
 
     #[test]
     fn test_vote_lockout() {
-        let voter_id = Keypair::new().pubkey();
+        let voter_id = Pubkey::new_rand();
         let mut vote_state = VoteState::new(&voter_id);
 
         for i in 0..(MAX_LOCKOUT_HISTORY + 1) {
@@ -425,7 +424,7 @@ mod tests {
 
     #[test]
     fn test_vote_double_lockout_after_expiration() {
-        let voter_id = Keypair::new().pubkey();
+        let voter_id = Pubkey::new_rand();
         let mut vote_state = VoteState::new(&voter_id);
 
         for i in 0..3 {
@@ -451,7 +450,7 @@ mod tests {
 
     #[test]
     fn test_vote_credits() {
-        let voter_id = Keypair::new().pubkey();
+        let voter_id = Pubkey::new_rand();
         let mut vote_state = VoteState::new(&voter_id);
 
         for i in 0..MAX_LOCKOUT_HISTORY {
@@ -472,7 +471,7 @@ mod tests {
 
     #[test]
     fn test_duplicate_vote() {
-        let voter_id = Keypair::new().pubkey();
+        let voter_id = Pubkey::new_rand();
         let mut vote_state = VoteState::new(&voter_id);
         vote_state.process_vote(Vote::new(0));
         vote_state.process_vote(Vote::new(1));
@@ -484,7 +483,7 @@ mod tests {
 
     #[test]
     fn test_nth_recent_vote() {
-        let voter_id = Keypair::new().pubkey();
+        let voter_id = Pubkey::new_rand();
         let mut vote_state = VoteState::new(&voter_id);
         for i in 0..MAX_LOCKOUT_HISTORY {
             vote_state.process_vote(Vote::new(i as u64));

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -1570,7 +1570,7 @@ mod tests {
         num_vote: usize,
     ) {
         for t in 0..num {
-            let pubkey = Keypair::new().pubkey();
+            let pubkey = Pubkey::new_rand();
             let mut default_account = Account::default();
             pubkeys.push(pubkey.clone());
             default_account.lamports = (t + 1) as u64;
@@ -1578,7 +1578,7 @@ mod tests {
             accounts.store(fork, &pubkey, &default_account);
         }
         for t in 0..num_vote {
-            let pubkey = Keypair::new().pubkey();
+            let pubkey = Pubkey::new_rand();
             let mut default_account = Account::default();
             pubkeys.push(pubkey.clone());
             default_account.owner = solana_vote_api::id();
@@ -1681,7 +1681,7 @@ mod tests {
         let accounts = AccountsDB::new_with_file_size(0, &paths.paths, size, 0);
         let mut keys = vec![];
         for i in 0..9 {
-            let key = Keypair::new().pubkey();
+            let key = Pubkey::new_rand();
             let account = Account::new(i + 1, size as usize / 4, &key);
             accounts.store(0, &key, &account);
             keys.push(key);
@@ -1713,7 +1713,7 @@ mod tests {
             AccountStorageStatus::StorageAvailable,
             AccountStorageStatus::StorageFull,
         ];
-        let pubkey1 = Keypair::new().pubkey();
+        let pubkey1 = Pubkey::new_rand();
         let account1 = Account::new(1, ACCOUNT_DATA_FILE_SIZE as usize / 2, &pubkey1);
         accounts.store(0, &pubkey1, &account1);
         {
@@ -1723,7 +1723,7 @@ mod tests {
             assert_eq!(stores[0].get_status(), status[0]);
         }
 
-        let pubkey2 = Keypair::new().pubkey();
+        let pubkey2 = Pubkey::new_rand();
         let account2 = Account::new(1, ACCOUNT_DATA_FILE_SIZE as usize / 2, &pubkey2);
         accounts.store(0, &pubkey2, &account2);
         {
@@ -1785,7 +1785,7 @@ mod tests {
     fn test_accounts_vote_filter() {
         let accounts = Accounts::new(0, None);
         let mut vote_account = Account::new(1, 0, &solana_vote_api::id());
-        let key = Keypair::new().pubkey();
+        let key = Pubkey::new_rand();
         accounts.store_slow(0, &key, &vote_account);
 
         accounts.new_from_parent(1, 0);
@@ -1800,7 +1800,7 @@ mod tests {
         assert_eq!(vote_accounts.len(), 0);
 
         let mut vote_account1 = Account::new(2, 0, &solana_vote_api::id());
-        let key1 = Keypair::new().pubkey();
+        let key1 = Pubkey::new_rand();
         accounts.store_slow(1, &key1, &vote_account1);
 
         accounts.squash(1);
@@ -1828,7 +1828,7 @@ mod tests {
         accounts.iter().for_each(|(_, account)| {
             assert_eq!(account.owner, solana_vote_api::id());
         });
-        let lastkey = Keypair::new().pubkey();
+        let lastkey = Pubkey::new_rand();
         let mut lastaccount = Account::new(1, 0, &solana_vote_api::id());
         accounts_db.store(0, &lastkey, &lastaccount);
         assert_eq!(accounts_db.get_vote_accounts(0).len(), 2);
@@ -1890,7 +1890,7 @@ mod tests {
         let accounts = AccountsDB::new(0, &paths.paths);
         let mut error_counters = ErrorCounters::default();
         assert_eq!(
-            accounts.load_executable_accounts(0, &Keypair::new().pubkey(), &mut error_counters),
+            accounts.load_executable_accounts(0, &Pubkey::new_rand(), &mut error_counters),
             Err(TransactionError::AccountNotFound)
         );
         assert_eq!(error_counters.account_not_found, 1);
@@ -1921,13 +1921,13 @@ mod tests {
         let accounts_db = AccountsDB::new(0, &paths.paths);
 
         // Load accounts owned by various programs into AccountsDB
-        let pubkey0 = Keypair::new().pubkey();
+        let pubkey0 = Pubkey::new_rand();
         let account0 = Account::new(1, 0, &Pubkey::new(&[2; 32]));
         accounts_db.store(0, &pubkey0, &account0);
-        let pubkey1 = Keypair::new().pubkey();
+        let pubkey1 = Pubkey::new_rand();
         let account1 = Account::new(1, 0, &Pubkey::new(&[2; 32]));
         accounts_db.store(0, &pubkey1, &account1);
-        let pubkey2 = Keypair::new().pubkey();
+        let pubkey2 = Pubkey::new_rand();
         let account2 = Account::new(1, 0, &Pubkey::new(&[3; 32]));
         accounts_db.store(0, &pubkey2, &account2);
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -978,7 +978,7 @@ mod tests {
 
     #[test]
     fn test_bank_new_with_leader() {
-        let dummy_leader_id = Keypair::new().pubkey();
+        let dummy_leader_id = Pubkey::new_rand();
         let dummy_leader_lamports = BOOTSTRAP_LEADER_LAMPORTS;
         let (genesis_block, _) =
             GenesisBlock::new_with_leader(10_000, &dummy_leader_id, dummy_leader_lamports);
@@ -1000,7 +1000,7 @@ mod tests {
     #[test]
     fn test_two_payments_to_one_party() {
         let (genesis_block, mint_keypair) = GenesisBlock::new(10_000);
-        let pubkey = Keypair::new().pubkey();
+        let pubkey = Pubkey::new_rand();
         let bank = Bank::new(&genesis_block);
         assert_eq!(bank.last_blockhash(), genesis_block.hash());
 
@@ -1015,8 +1015,8 @@ mod tests {
     #[test]
     fn test_one_source_two_tx_one_batch() {
         let (genesis_block, mint_keypair) = GenesisBlock::new(1);
-        let key1 = Keypair::new().pubkey();
-        let key2 = Keypair::new().pubkey();
+        let key1 = Pubkey::new_rand();
+        let key2 = Pubkey::new_rand();
         let bank = Bank::new(&genesis_block);
         assert_eq!(bank.last_blockhash(), genesis_block.hash());
 
@@ -1040,8 +1040,8 @@ mod tests {
     #[test]
     fn test_one_tx_two_out_atomic_fail() {
         let (genesis_block, mint_keypair) = GenesisBlock::new(1);
-        let key1 = Keypair::new().pubkey();
-        let key2 = Keypair::new().pubkey();
+        let key1 = Pubkey::new_rand();
+        let key2 = Pubkey::new_rand();
         let bank = Bank::new(&genesis_block);
         let instructions =
             SystemInstruction::new_move_many(&mint_keypair.pubkey(), &[(key1, 1), (key2, 1)]);
@@ -1065,8 +1065,8 @@ mod tests {
     #[test]
     fn test_one_tx_two_out_atomic_pass() {
         let (genesis_block, mint_keypair) = GenesisBlock::new(2);
-        let key1 = Keypair::new().pubkey();
-        let key2 = Keypair::new().pubkey();
+        let key1 = Pubkey::new_rand();
+        let key2 = Pubkey::new_rand();
         let bank = Bank::new(&genesis_block);
         let instructions =
             SystemInstruction::new_move_many(&mint_keypair.pubkey(), &[(key1, 1), (key2, 1)]);
@@ -1132,7 +1132,7 @@ mod tests {
     fn test_insufficient_funds() {
         let (genesis_block, mint_keypair) = GenesisBlock::new(11_000);
         let bank = Bank::new(&genesis_block);
-        let pubkey = Keypair::new().pubkey();
+        let pubkey = Pubkey::new_rand();
         bank.transfer(1_000, &mint_keypair, &pubkey).unwrap();
         assert_eq!(bank.transaction_count(), 1);
         assert_eq!(bank.get_balance(&pubkey), 1_000);
@@ -1154,7 +1154,7 @@ mod tests {
     fn test_transfer_to_newb() {
         let (genesis_block, mint_keypair) = GenesisBlock::new(10_000);
         let bank = Bank::new(&genesis_block);
-        let pubkey = Keypair::new().pubkey();
+        let pubkey = Pubkey::new_rand();
         bank.transfer(500, &mint_keypair, &pubkey).unwrap();
         assert_eq!(bank.get_balance(&pubkey), 500);
     }
@@ -1202,7 +1202,7 @@ mod tests {
 
     #[test]
     fn test_bank_tx_fee() {
-        let leader = Keypair::new().pubkey();
+        let leader = Pubkey::new_rand();
         let (genesis_block, mint_keypair) = GenesisBlock::new_with_leader(100, &leader, 3);
         let mut bank = Bank::new(&genesis_block);
         bank.fee_calculator.lamports_per_signature = 3;
@@ -1229,7 +1229,7 @@ mod tests {
 
     #[test]
     fn test_filter_program_errors_and_collect_fee() {
-        let leader = Keypair::new().pubkey();
+        let leader = Pubkey::new_rand();
         let (genesis_block, mint_keypair) = GenesisBlock::new_with_leader(100, &leader, 3);
         let mut bank = Bank::new(&genesis_block);
 
@@ -1284,7 +1284,7 @@ mod tests {
 
     #[test]
     fn test_process_genesis() {
-        let dummy_leader_id = Keypair::new().pubkey();
+        let dummy_leader_id = Pubkey::new_rand();
         let dummy_leader_lamports = 2;
         let (genesis_block, _) =
             GenesisBlock::new_with_leader(5, &dummy_leader_id, dummy_leader_lamports);
@@ -1440,7 +1440,7 @@ mod tests {
         let initial_state = bank0.hash_internal_state();
         assert_eq!(bank1.hash_internal_state(), initial_state);
 
-        let pubkey = Keypair::new().pubkey();
+        let pubkey = Pubkey::new_rand();
         bank0.transfer(1_000, &mint_keypair, &pubkey).unwrap();
         assert_ne!(bank0.hash_internal_state(), initial_state);
         bank1.transfer(1_000, &mint_keypair, &pubkey).unwrap();
@@ -1554,7 +1554,7 @@ mod tests {
 
     #[test]
     fn test_bank_epoch_vote_accounts() {
-        let leader_id = Keypair::new().pubkey();
+        let leader_id = Pubkey::new_rand();
         let leader_lamports = 3;
         let (mut genesis_block, _) = GenesisBlock::new_with_leader(5, &leader_id, leader_lamports);
 

--- a/runtime/src/bank_client.rs
+++ b/runtime/src/bank_client.rs
@@ -64,7 +64,7 @@ mod tests {
         let bank_client = BankClient::new(&bank);
 
         // Create 2-2 Multisig Move instruction.
-        let bob_pubkey = Keypair::new().pubkey();
+        let bob_pubkey = Pubkey::new_rand();
         let mut move_instruction = SystemInstruction::new_move(&john_pubkey, &bob_pubkey, 42);
         move_instruction
             .accounts

--- a/runtime/src/runtime.rs
+++ b/runtime/src/runtime.rs
@@ -235,7 +235,6 @@ impl Runtime {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use solana_sdk::signature::{Keypair, KeypairUtil};
 
     #[test]
     fn test_has_duplicates() {
@@ -282,8 +281,8 @@ mod tests {
         }
 
         let system_program_id = system_program::id();
-        let alice_program_id = Keypair::new().pubkey();
-        let mallory_program_id = Keypair::new().pubkey();
+        let alice_program_id = Pubkey::new_rand();
+        let mallory_program_id = Pubkey::new_rand();
 
         assert_eq!(
             change_program_id(&system_program_id, &system_program_id, &alice_program_id),
@@ -300,13 +299,13 @@ mod tests {
     #[test]
     fn test_verify_instruction_change_data() {
         fn change_data(program_id: &Pubkey) -> Result<(), InstructionError> {
-            let alice_program_id = Keypair::new().pubkey();
+            let alice_program_id = Pubkey::new_rand();
             let account = Account::new(0, 0, &alice_program_id);
             verify_instruction(&program_id, &alice_program_id, 0, &[42], &account)
         }
 
         let system_program_id = system_program::id();
-        let mallory_program_id = Keypair::new().pubkey();
+        let mallory_program_id = Pubkey::new_rand();
 
         assert_eq!(
             change_data(&system_program_id),

--- a/runtime/src/system_program.rs
+++ b/runtime/src/system_program.rs
@@ -117,10 +117,10 @@ mod tests {
     #[test]
     fn test_create_system_account() {
         let new_program_owner = Pubkey::new(&[9; 32]);
-        let from = Keypair::new().pubkey();
+        let from = Pubkey::new_rand();
         let mut from_account = Account::new(100, 0, &system_program::id());
 
-        let to = Keypair::new().pubkey();
+        let to = Pubkey::new_rand();
         let mut to_account = Account::new(0, 0, &Pubkey::default());
 
         let mut keyed_accounts = [
@@ -142,10 +142,10 @@ mod tests {
     fn test_create_negative_lamports() {
         // Attempt to create account with more lamports than remaining in from_account
         let new_program_owner = Pubkey::new(&[9; 32]);
-        let from = Keypair::new().pubkey();
+        let from = Pubkey::new_rand();
         let mut from_account = Account::new(100, 0, &system_program::id());
 
-        let to = Keypair::new().pubkey();
+        let to = Pubkey::new_rand();
         let mut to_account = Account::new(0, 0, &Pubkey::default());
         let unchanged_account = to_account.clone();
 
@@ -164,11 +164,11 @@ mod tests {
     fn test_create_already_owned() {
         // Attempt to create system account in account already owned by another program
         let new_program_owner = Pubkey::new(&[9; 32]);
-        let from = Keypair::new().pubkey();
+        let from = Pubkey::new_rand();
         let mut from_account = Account::new(100, 0, &system_program::id());
 
         let original_program_owner = Pubkey::new(&[5; 32]);
-        let owned_key = Keypair::new().pubkey();
+        let owned_key = Pubkey::new_rand();
         let mut owned_account = Account::new(0, 0, &original_program_owner);
         let unchanged_account = owned_account.clone();
 
@@ -187,10 +187,10 @@ mod tests {
     fn test_create_data_populated() {
         // Attempt to create system account in account with populated data
         let new_program_owner = Pubkey::new(&[9; 32]);
-        let from = Keypair::new().pubkey();
+        let from = Pubkey::new_rand();
         let mut from_account = Account::new(100, 0, &system_program::id());
 
-        let populated_key = Keypair::new().pubkey();
+        let populated_key = Pubkey::new_rand();
         let mut populated_account = Account {
             lamports: 0,
             data: vec![0, 1, 2, 3],
@@ -213,9 +213,9 @@ mod tests {
     fn test_create_not_system_account() {
         let other_program = Pubkey::new(&[9; 32]);
 
-        let from = Keypair::new().pubkey();
+        let from = Pubkey::new_rand();
         let mut from_account = Account::new(100, 0, &other_program);
-        let to = Keypair::new().pubkey();
+        let to = Pubkey::new_rand();
         let mut to_account = Account::new(0, 0, &Pubkey::default());
         let mut keyed_accounts = [
             KeyedAccount::new(&from, true, &mut from_account),
@@ -229,7 +229,7 @@ mod tests {
     fn test_assign_account_to_program() {
         let new_program_owner = Pubkey::new(&[9; 32]);
 
-        let from = Keypair::new().pubkey();
+        let from = Pubkey::new_rand();
         let mut from_account = Account::new(100, 0, &system_program::id());
         let mut keyed_accounts = [KeyedAccount::new(&from, true, &mut from_account)];
         assign_account_to_program(&mut keyed_accounts, &new_program_owner).unwrap();
@@ -250,9 +250,9 @@ mod tests {
 
     #[test]
     fn test_move_lamports() {
-        let from = Keypair::new().pubkey();
+        let from = Pubkey::new_rand();
         let mut from_account = Account::new(100, 0, &Pubkey::new(&[2; 32])); // account owner should not matter
-        let to = Keypair::new().pubkey();
+        let to = Pubkey::new_rand();
         let mut to_account = Account::new(1, 0, &Pubkey::new(&[3; 32])); // account owner should not matter
         let mut keyed_accounts = [
             KeyedAccount::new(&from, true, &mut from_account),

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -17,6 +17,7 @@ chrono = { version = "0.4.0", features = ["serde"] }
 generic-array = { version = "0.12.0", default-features = false, features = ["serde"] }
 itertools = "0.8.0"
 log = "0.4.2"
+rand = "0.6.5"
 ring = "0.13.2"
 sha2 = "0.8.0"
 serde = "1.0.89"

--- a/sdk/src/genesis_block.rs
+++ b/sdk/src/genesis_block.rs
@@ -33,11 +33,7 @@ impl GenesisBlock {
         let lamports = lamports
             .checked_add(BOOTSTRAP_LEADER_LAMPORTS)
             .unwrap_or(lamports);
-        Self::new_with_leader(
-            lamports,
-            &Keypair::new().pubkey(),
-            BOOTSTRAP_LEADER_LAMPORTS,
-        )
+        Self::new_with_leader(lamports, &Pubkey::new_rand(), BOOTSTRAP_LEADER_LAMPORTS)
     }
 
     pub fn new_with_leader(

--- a/sdk/src/message.rs
+++ b/sdk/src/message.rs
@@ -148,7 +148,7 @@ mod tests {
     #[test]
     fn test_message_unique_program_ids_not_adjacent() {
         let program_id0 = Pubkey::default();
-        let program_id1 = Keypair::new().pubkey();
+        let program_id1 = Pubkey::new_rand();
         let program_ids = get_program_ids(&[
             Instruction::new(program_id0, &0, vec![]),
             Instruction::new(program_id1, &0, vec![]),
@@ -159,7 +159,7 @@ mod tests {
 
     #[test]
     fn test_message_unique_program_ids_order_preserved() {
-        let program_id0 = Keypair::new().pubkey();
+        let program_id0 = Pubkey::new_rand();
         let program_id1 = Pubkey::default(); // Key less than program_id0
         let program_ids = get_program_ids(&[
             Instruction::new(program_id0, &0, vec![]),
@@ -194,7 +194,7 @@ mod tests {
     #[test]
     fn test_message_unique_keys_order_preserved() {
         let program_id = Pubkey::default();
-        let id0 = Keypair::new().pubkey();
+        let id0 = Pubkey::new_rand();
         let id1 = Pubkey::default(); // Key less than id0
         let keys = get_keys(&[
             Instruction::new(program_id, &0, vec![AccountMeta::new(id0, false)]),
@@ -207,7 +207,7 @@ mod tests {
     fn test_message_unique_keys_not_adjacent() {
         let program_id = Pubkey::default();
         let id0 = Pubkey::default();
-        let id1 = Keypair::new().pubkey();
+        let id1 = Pubkey::new_rand();
         let keys = get_keys(&[
             Instruction::new(program_id, &0, vec![AccountMeta::new(id0, false)]),
             Instruction::new(program_id, &0, vec![AccountMeta::new(id1, false)]),
@@ -220,7 +220,7 @@ mod tests {
     fn test_message_signed_keys_first() {
         let program_id = Pubkey::default();
         let id0 = Pubkey::default();
-        let id1 = Keypair::new().pubkey();
+        let id1 = Pubkey::new_rand();
         let keys = get_keys(&[
             Instruction::new(program_id, &0, vec![AccountMeta::new(id0, false)]),
             Instruction::new(program_id, &0, vec![AccountMeta::new(id1, true)]),
@@ -245,7 +245,7 @@ mod tests {
     #[test]
     fn test_message_kitchen_sink() {
         let program_id0 = Pubkey::default();
-        let program_id1 = Keypair::new().pubkey();
+        let program_id1 = Pubkey::new_rand();
         let id0 = Pubkey::default();
         let keypair1 = Keypair::new();
         let id1 = keypair1.pubkey();

--- a/sdk/src/pubkey.rs
+++ b/sdk/src/pubkey.rs
@@ -45,6 +45,10 @@ impl Pubkey {
     pub fn new(pubkey_vec: &[u8]) -> Self {
         Pubkey(GenericArray::clone_from_slice(&pubkey_vec))
     }
+
+    pub fn new_rand() -> Self {
+        Self::new(&rand::random::<[u8; 32]>())
+    }
 }
 
 impl AsRef<[u8]> for Pubkey {
@@ -87,12 +91,11 @@ pub fn read_pubkey(infile: &str) -> Result<Pubkey, Box<error::Error>> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::signature::{Keypair, KeypairUtil};
     use std::fs::remove_file;
 
     #[test]
     fn pubkey_fromstr() {
-        let pubkey = Keypair::new().pubkey();
+        let pubkey = Pubkey::new_rand();
         let mut pubkey_base58_str = bs58::encode(pubkey.0).into_string();
 
         assert_eq!(pubkey_base58_str.parse::<Pubkey>(), Ok(pubkey));
@@ -126,7 +129,7 @@ mod tests {
     #[test]
     fn test_read_write_pubkey() -> Result<(), Box<error::Error>> {
         let filename = "test_pubkey.json";
-        let pubkey = Keypair::new().pubkey();
+        let pubkey = Pubkey::new_rand();
         write_pubkey(filename, pubkey)?;
         let read = read_pubkey(filename)?;
         assert_eq!(read, pubkey);

--- a/sdk/src/system_instruction.rs
+++ b/sdk/src/system_instruction.rs
@@ -95,7 +95,6 @@ impl SystemInstruction {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::signature::{Keypair, KeypairUtil};
 
     fn get_keys(instruction: &Instruction) -> Vec<Pubkey> {
         instruction.accounts.iter().map(|x| x.pubkey).collect()
@@ -103,9 +102,9 @@ mod tests {
 
     #[test]
     fn test_move_many() {
-        let alice_pubkey = Keypair::new().pubkey();
-        let bob_pubkey = Keypair::new().pubkey();
-        let carol_pubkey = Keypair::new().pubkey();
+        let alice_pubkey = Pubkey::new_rand();
+        let bob_pubkey = Pubkey::new_rand();
+        let carol_pubkey = Pubkey::new_rand();
         let to_lamports = vec![(bob_pubkey, 1), (carol_pubkey, 2)];
 
         let instructions = SystemInstruction::new_move_many(&alice_pubkey, &to_lamports);

--- a/sdk/src/transaction.rs
+++ b/sdk/src/transaction.rs
@@ -210,10 +210,10 @@ mod tests {
     #[test]
     fn test_refs() {
         let key = Keypair::new();
-        let key1 = Keypair::new().pubkey();
-        let key2 = Keypair::new().pubkey();
-        let prog1 = Keypair::new().pubkey();
-        let prog2 = Keypair::new().pubkey();
+        let key1 = Pubkey::new_rand();
+        let key2 = Pubkey::new_rand();
+        let prog1 = Pubkey::new_rand();
+        let prog2 = Pubkey::new_rand();
         let instructions = vec![
             CompiledInstruction::new(0, &(), vec![0, 1]),
             CompiledInstruction::new(1, &(), vec![0, 2]),
@@ -317,7 +317,7 @@ mod tests {
     fn test_transaction_minimum_serialized_size() {
         let alice_keypair = Keypair::new();
         let alice_pubkey = alice_keypair.pubkey();
-        let bob_pubkey = Keypair::new().pubkey();
+        let bob_pubkey = Pubkey::new_rand();
         let ix = SystemInstruction::new_move(&alice_pubkey, &bob_pubkey, 42);
 
         let expected_data_size = size_of::<u32>() + size_of::<u64>();

--- a/tests/thin_client.rs
+++ b/tests/thin_client.rs
@@ -40,7 +40,7 @@ pub fn transfer(
 fn test_thin_client_basic() {
     solana_logger::setup();
     let (server, leader_data, alice, ledger_path) = new_fullnode_for_tests();
-    let bob_pubkey = Keypair::new().pubkey();
+    let bob_pubkey = Pubkey::new_rand();
     discover(&leader_data.gossip, 1).unwrap();
 
     let client = create_client(leader_data.client_facing_addr(), FULLNODE_PORT_RANGE);
@@ -69,7 +69,7 @@ fn test_thin_client_basic() {
 fn test_bad_sig() {
     solana_logger::setup();
     let (server, leader_data, alice, ledger_path) = new_fullnode_for_tests();
-    let bob_pubkey = Keypair::new().pubkey();
+    let bob_pubkey = Pubkey::new_rand();
     discover(&leader_data.gossip, 1).unwrap();
 
     let client = create_client(leader_data.client_facing_addr(), FULLNODE_PORT_RANGE);

--- a/vote-signer/src/rpc.rs
+++ b/vote-signer/src/rpc.rs
@@ -330,7 +330,7 @@ mod tests {
         let res = io.handle_request_sync(&req.to_string(), meta.clone());
         let result: Response = serde_json::from_str(&res.expect("actual response"))
             .expect("actual response deserialization");
-        let mut vote_pubkey = Keypair::new().pubkey();
+        let mut vote_pubkey = Pubkey::new_rand();
         if let Response::Single(out) = result {
             if let Output::Success(succ) = out {
                 assert_eq!(succ.jsonrpc.unwrap(), Version::V2);

--- a/wallet/src/wallet.rs
+++ b/wallet/src/wallet.rs
@@ -949,11 +949,11 @@ mod tests {
                             .help("Optional arbitrary timestamp to apply"),
                     ),
             );
-        let pubkey = Keypair::new().pubkey();
+        let pubkey = Pubkey::new_rand();
         let pubkey_string = format!("{}", pubkey);
-        let witness0 = Keypair::new().pubkey();
+        let witness0 = Pubkey::new_rand();
         let witness0_string = format!("{}", witness0);
-        let witness1 = Keypair::new().pubkey();
+        let witness1 = Pubkey::new_rand();
         let witness1_string = format!("{}", witness1);
         let dt = Utc.ymd(2018, 9, 19).and_hms(17, 30, 59);
 
@@ -997,7 +997,7 @@ mod tests {
         assert!(parse_command(&pubkey, &test_bad_signature).is_err());
 
         // Test ConfigureStakingAccount Subcommand
-        let second_pubkey = Keypair::new().pubkey();
+        let second_pubkey = Pubkey::new_rand();
         let second_pubkey_string = format!("{}", second_pubkey);
         let test_configure_staking_account = test_commands.clone().get_matches_from(vec![
             "test",
@@ -1174,7 +1174,7 @@ mod tests {
         config.command = WalletCommand::Balance(config.id.pubkey());
         assert_eq!(process_command(&config).unwrap(), "50 lamports");
 
-        let process_id = Keypair::new().pubkey();
+        let process_id = Pubkey::new_rand();
         config.command = WalletCommand::Cancel(process_id);
         assert_eq!(process_command(&config).unwrap(), SIGNATURE);
 
@@ -1182,7 +1182,7 @@ mod tests {
         config.command = WalletCommand::Confirm(good_signature);
         assert_eq!(process_command(&config).unwrap(), "Confirmed");
 
-        let bob_pubkey = Keypair::new().pubkey();
+        let bob_pubkey = Pubkey::new_rand();
         config.command = WalletCommand::ConfigureStakingAccount(None, Some(bob_pubkey));
         let signature = process_command(&config);
         assert_eq!(signature.unwrap(), SIGNATURE.to_string());
@@ -1220,7 +1220,7 @@ mod tests {
             SIGNATURE.to_string()
         );
 
-        let witness = Keypair::new().pubkey();
+        let witness = Pubkey::new_rand();
         config.command = WalletCommand::Pay(
             10,
             bob_pubkey,
@@ -1241,12 +1241,12 @@ mod tests {
             SIGNATURE.to_string()
         );
 
-        let process_id = Keypair::new().pubkey();
+        let process_id = Pubkey::new_rand();
         config.command = WalletCommand::TimeElapsed(bob_pubkey, process_id, dt);
         let signature = process_command(&config);
         assert_eq!(signature.unwrap(), SIGNATURE.to_string());
 
-        let witness = Keypair::new().pubkey();
+        let witness = Pubkey::new_rand();
         config.command = WalletCommand::Witness(bob_pubkey, witness);
         let signature = process_command(&config);
         assert_eq!(signature.unwrap(), SIGNATURE.to_string());
@@ -1260,7 +1260,7 @@ mod tests {
         let signature = process_command(&config);
         assert_eq!(signature.unwrap(), SIGNATURE.to_string());
 
-        let witness = Keypair::new().pubkey();
+        let witness = Pubkey::new_rand();
         config.command = WalletCommand::Witness(bob_pubkey, witness);
         let signature = process_command(&config);
         assert_eq!(signature.unwrap(), SIGNATURE.to_string());

--- a/wallet/tests/pay.rs
+++ b/wallet/tests/pay.rs
@@ -3,7 +3,7 @@ use serde_json::Value;
 use solana_client::rpc_client::RpcClient;
 use solana_drone::drone::run_local_drone;
 use solana_sdk::pubkey::Pubkey;
-use solana_sdk::signature::{Keypair, KeypairUtil};
+use solana_sdk::signature::KeypairUtil;
 use solana_wallet::wallet::{
     process_command, request_and_confirm_airdrop, WalletCommand, WalletConfig,
 };
@@ -21,7 +21,7 @@ fn check_balance(expected_balance: u64, client: &RpcClient, pubkey: &Pubkey) {
 #[test]
 fn test_wallet_timestamp_tx() {
     let (server, leader_data, alice, ledger_path) = new_fullnode_for_tests();
-    let bob_pubkey = Keypair::new().pubkey();
+    let bob_pubkey = Pubkey::new_rand();
 
     let (sender, receiver) = channel();
     run_local_drone(alice, sender);
@@ -81,7 +81,7 @@ fn test_wallet_timestamp_tx() {
 #[test]
 fn test_wallet_witness_tx() {
     let (server, leader_data, alice, ledger_path) = new_fullnode_for_tests();
-    let bob_pubkey = Keypair::new().pubkey();
+    let bob_pubkey = Pubkey::new_rand();
 
     let (sender, receiver) = channel();
     run_local_drone(alice, sender);
@@ -138,7 +138,7 @@ fn test_wallet_witness_tx() {
 #[test]
 fn test_wallet_cancel_tx() {
     let (server, leader_data, alice, ledger_path) = new_fullnode_for_tests();
-    let bob_pubkey = Keypair::new().pubkey();
+    let bob_pubkey = Pubkey::new_rand();
 
     let (sender, receiver) = channel();
     run_local_drone(alice, sender);


### PR DESCRIPTION
#### Problem

A lot of modules indirectly depend on `ring` just for the `KeypairUtil` constructor that generates a random number.

#### Summary of Changes

* Add `Pubkey::new_rand()`
* Replace all instances of `Keypair::new().pubkey()` with `Pubkey::new_rand()`
