### PR TITLE
Increase node count in beta testnet

### DIFF
--- a/ci/testnet-manager.sh
+++ b/ci/testnet-manager.sh
@@ -210,7 +210,7 @@ start() {
       NO_VALIDATOR_SANITY=1 \
       RUST_LOG=solana=info \
         ci/testnet-deploy.sh beta-testnet-solana-com ec2 us-west-1a \
-          -t "$CHANNEL_OR_TAG" -n 3 -c 0 -u -P -a eipalloc-0f286cf8a0771ce35 \
+          -t "$CHANNEL_OR_TAG" -n 35 -c 0 -u -P -a eipalloc-0f286cf8a0771ce35 \
           ${maybeReuseLedger:+-r} \
           ${maybeDelete:+-D}
     )

--- a/net/gce.sh
+++ b/net/gce.sh
@@ -26,7 +26,7 @@ ec2)
   cpuBootstrapLeaderMachineType=m4.4xlarge
   gpuBootstrapLeaderMachineType=p2.xlarge
   bootstrapLeaderMachineType=$cpuBootstrapLeaderMachineType
-  fullNodeMachineType=m4.2xlarge
+  fullNodeMachineType=$cpuBootstrapLeaderMachineType
   clientMachineType=m4.2xlarge
   blockstreamerMachineType=m4.2xlarge
   ;;


### PR DESCRIPTION
#### Problem
Beta testnet is using only 3 validator nodes. The system needs more nodes.
 
#### Summary of Changes
Got more quota from AWS. It's enough to start 35 nodes in beta testnet.
Awaiting for quota to be further increased.