### PR TITLE
Add Gossip CLI module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2302,6 +2302,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-gossip"
+version = "0.13.0"
+dependencies = [
+ "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana 0.13.0",
+ "solana-logger 0.13.0",
+ "solana-sdk 0.13.0",
+]
+
+[[package]]
 name = "solana-install"
 version = "0.13.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "drone",
     "fullnode",
     "genesis",
+    "gossip",
     "install",
     "keygen",
     "kvstore",

--- a/bench-tps/src/bench.rs
+++ b/bench-tps/src/bench.rs
@@ -5,7 +5,7 @@ use rayon::prelude::*;
 use solana::cluster_info::FULLNODE_PORT_RANGE;
 use solana::contact_info::ContactInfo;
 use solana::gen_keys::GenKeys;
-use solana::gossip_service::discover;
+use solana::gossip_service::discover_nodes;
 use solana_client::thin_client::create_client;
 use solana_client::thin_client::ThinClient;
 use solana_drone::drone::request_airdrop_transaction;
@@ -55,7 +55,7 @@ pub fn do_bench_tps(config: Config) {
         converge_only,
     } = config;
 
-    let nodes = discover(&network, num_nodes).unwrap_or_else(|err| {
+    let nodes = discover_nodes(&network, num_nodes).unwrap_or_else(|err| {
         eprintln!("Failed to discover {} nodes: {:?}", num_nodes, err);
         exit(1);
     });

--- a/bench-tps/src/bench.rs
+++ b/bench-tps/src/bench.rs
@@ -51,8 +51,6 @@ pub fn do_bench_tps(config: Config) {
         duration,
         tx_count,
         sustained,
-        reject_extra_nodes,
-        converge_only,
     } = config;
 
     let nodes = discover_nodes(&network, num_nodes).unwrap_or_else(|err| {
@@ -65,17 +63,6 @@ pub fn do_bench_tps(config: Config) {
             num_nodes
         );
         exit(1);
-    }
-    if reject_extra_nodes && nodes.len() > num_nodes {
-        eprintln!(
-            "Error: Extra nodes discovered.  Expecting exactly {}",
-            num_nodes
-        );
-        exit(1);
-    }
-
-    if converge_only {
-        return;
     }
     let cluster_entrypoint = nodes[0].clone(); // Pick the first node, why not?
 

--- a/bench-tps/src/cli.rs
+++ b/bench-tps/src/cli.rs
@@ -17,8 +17,6 @@ pub struct Config {
     pub tx_count: usize,
     pub thread_batch_sleep_ms: usize,
     pub sustained: bool,
-    pub reject_extra_nodes: bool,
-    pub converge_only: bool,
 }
 
 impl Default for Config {
@@ -33,8 +31,6 @@ impl Default for Config {
             tx_count: 500_000,
             thread_batch_sleep_ms: 0,
             sustained: false,
-            reject_extra_nodes: false,
-            converge_only: false,
         }
     }
 }
@@ -76,11 +72,6 @@ pub fn build_args<'a, 'b>() -> App<'a, 'b> {
                 .help("Wait for NUM nodes to converge"),
         )
         .arg(
-            Arg::with_name("reject-extra-nodes")
-                .long("reject-extra-nodes")
-                .help("Require exactly `num-nodes` on convergence. Appropriate only for internal networks"),
-        )
-        .arg(
             Arg::with_name("threads")
                 .short("t")
                 .long("threads")
@@ -94,11 +85,6 @@ pub fn build_args<'a, 'b>() -> App<'a, 'b> {
                 .value_name("SECS")
                 .takes_value(true)
                 .help("Seconds to run benchmark, then exit; default is forever"),
-        )
-        .arg(
-            Arg::with_name("converge-only")
-                .long("converge-only")
-                .help("Exit immediately after converging"),
         )
         .arg(
             Arg::with_name("sustained")
@@ -176,8 +162,6 @@ pub fn extract_args<'a>(matches: &ArgMatches<'a>) -> Config {
     }
 
     args.sustained = matches.is_present("sustained");
-    args.converge_only = matches.is_present("converge-only");
-    args.reject_extra_nodes = matches.is_present("reject-extra-nodes");
 
     args
 }

--- a/book/src/cluster-test-framework.md
+++ b/book/src/cluster-test-framework.md
@@ -51,10 +51,10 @@ At test start, the cluster has already been established and is fully connected.
 The test can discover most of the available nodes over a few second.
 
 ```rust,ignore
-use crate::gossip_service::discover;
+use crate::gossip_service::discover_nodes;
 
 // Discover the cluster over a few seconds.
-let cluster_nodes = discover(&entry_point_info, num_nodes);
+let cluster_nodes = discover_nodes(&entry_point_info, num_nodes);
 ```
 
 ## Cluster Configuration
@@ -99,7 +99,7 @@ pub fn test_large_invalid_gossip_nodes(
     funding_keypair: &Keypair,
     num_nodes: usize,
 ) {
-    let cluster = discover(&entry_point_info, num_nodes);
+    let cluster = discover_nodes(&entry_point_info, num_nodes);
 
     // Poison the cluster.
     let client = create_client(entry_point_info.client_facing_addr(), FULLNODE_PORT_RANGE);

--- a/book/src/testnet-participation.md
+++ b/book/src/testnet-participation.md
@@ -73,7 +73,7 @@ Inspect the blockexplorer at http://beta.testnet.solana.com/ for activity.
 
 Run the following command to join the gossip network and view all the other nodes in the cluster:
 ```bash
-$ RUST_LOG=info solana-bench-tps --converge-only --num-nodes 100000 --network ${ip:?}:8001
+$ RUST_LOG=info solana-gossip --network ${ip:?}:8001
 ```
 
 #### Starting The Validator
@@ -85,7 +85,7 @@ $ RUST_LOG=warn ./multinode-demo/fullnode-x.sh --public-address --poll-for-new-g
 Then from another console, confirm the IP address if your node is now visible in
 the gossip network by running:
 ```bash
-$ RUST_LOG=info solana-bench-tps --converge-only --num-nodes 100000 --network ${ip:?}:8001
+$ RUST_LOG=info solana-gossip --network ${ip:?}:8001
 ```
 
 Congratulations, you're now participating in the testnet cluster!
@@ -102,7 +102,7 @@ source scripts/configure-metrics.sh
 Inspect for your contributions to our [metrics dashboard](https://metrics.solana.com:3000/d/U9-26Cqmk/testnet-monitor-cloud?refresh=60s&orgId=2&var-hostid=All).
 
 #### Metrics Server Maintenance
-Sometimes the dashboard becomes unresponsive. This happens due to glitch in the metrics server. 
+Sometimes the dashboard becomes unresponsive. This happens due to glitch in the metrics server.
 The current solution is to reset the metrics server. Use the following steps.
 
 1. The server is hosted in a GCP VM instance. Check if the VM instance is down by trying to SSH

--- a/ci/localnet-sanity.sh
+++ b/ci/localnet-sanity.sh
@@ -307,11 +307,8 @@ while [[ $iteration -le $iterations ]]; do
     set -x
     client_id=/tmp/client-id.json-$$
     $solana_keygen -o $client_id || exit $?
-    $solana_bench_tps \
-      --identity $client_id \
-      --num-nodes $numNodes \
-      --reject-extra-nodes \
-      --converge-only || exit $?
+    $solana_gossip \
+      --num-nodes-exactly $numNodes || exit $?
     rm -rf $client_id
   ) || flag_error
 

--- a/ci/publish-crate.sh
+++ b/ci/publish-crate.sh
@@ -26,6 +26,7 @@ CRATES=(
   core
   fullnode
   genesis
+  gossip
   ledger-tool
   wallet
   install

--- a/core/src/cluster_tests.rs
+++ b/core/src/cluster_tests.rs
@@ -6,7 +6,7 @@ use crate::blocktree::Blocktree;
 use crate::cluster_info::FULLNODE_PORT_RANGE;
 use crate::contact_info::ContactInfo;
 use crate::entry::{Entry, EntrySlice};
-use crate::gossip_service::discover;
+use crate::gossip_service::discover_nodes;
 use crate::locktower::VOTE_THRESHOLD_DEPTH;
 use crate::poh_service::PohServiceConfig;
 use solana_client::thin_client::create_client;
@@ -28,7 +28,7 @@ pub fn spend_and_verify_all_nodes(
     funding_keypair: &Keypair,
     nodes: usize,
 ) {
-    let cluster_nodes = discover(&entry_point_info.gossip, nodes).unwrap();
+    let cluster_nodes = discover_nodes(&entry_point_info.gossip, nodes).unwrap();
     assert!(cluster_nodes.len() >= nodes);
     for ingress_node in &cluster_nodes {
         let random_keypair = Keypair::new();
@@ -77,7 +77,7 @@ pub fn send_many_transactions(node: &ContactInfo, funding_keypair: &Keypair, num
 }
 
 pub fn fullnode_exit(entry_point_info: &ContactInfo, nodes: usize) {
-    let cluster_nodes = discover(&entry_point_info.gossip, nodes).unwrap();
+    let cluster_nodes = discover_nodes(&entry_point_info.gossip, nodes).unwrap();
     assert!(cluster_nodes.len() >= nodes);
     for node in &cluster_nodes {
         let client = create_client(node.client_facing_addr(), FULLNODE_PORT_RANGE);
@@ -148,7 +148,7 @@ pub fn kill_entry_and_spend_and_verify_rest(
     nodes: usize,
 ) {
     solana_logger::setup();
-    let cluster_nodes = discover(&entry_point_info.gossip, nodes).unwrap();
+    let cluster_nodes = discover_nodes(&entry_point_info.gossip, nodes).unwrap();
     assert!(cluster_nodes.len() >= nodes);
     let client = create_client(entry_point_info.client_facing_addr(), FULLNODE_PORT_RANGE);
     info!("sleeping for 2 leader fortnights");

--- a/core/src/gossip_service.rs
+++ b/core/src/gossip_service.rs
@@ -6,6 +6,7 @@ use crate::cluster_info::ClusterInfo;
 use crate::contact_info::ContactInfo;
 use crate::service::Service;
 use crate::streamer;
+use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::{Keypair, KeypairUtil};
 use std::net::SocketAddr;
 use std::net::UdpSocket;
@@ -51,31 +52,95 @@ impl GossipService {
     }
 }
 
-pub fn discover(gossip_addr: &SocketAddr, num_nodes: usize) -> std::io::Result<Vec<ContactInfo>> {
+pub fn discover_nodes(
+    gossip_addr: &SocketAddr,
+    num_nodes: usize,
+) -> std::io::Result<Vec<ContactInfo>> {
+    discover(gossip_addr, Some(num_nodes), Some(30), None)
+}
+
+pub fn discover(
+    gossip_addr: &SocketAddr,
+    num_nodes: Option<usize>,
+    timeout: Option<u64>,
+    find_node: Option<Pubkey>,
+) -> std::io::Result<Vec<ContactInfo>> {
     let exit = Arc::new(AtomicBool::new(false));
     let (gossip_service, spy_ref) = make_spy_node(gossip_addr, &exit);
     let id = spy_ref.read().unwrap().keypair.pubkey();
     trace!(
-        "discover: spy_node {} looking for at least {} nodes",
+        "discover: spy_node {} looking for at least {:?} nodes",
         id,
         num_nodes
     );
 
-    // Wait for the cluster to converge
-    let now = Instant::now();
-    let mut i = 0;
-    while now.elapsed() < Duration::from_secs(30) {
-        let tvu_peers = spy_ref.read().unwrap().tvu_peers();
-        if tvu_peers.len() >= num_nodes {
-            info!(
-                "discover success in {}s...\n{}",
-                now.elapsed().as_secs(),
-                spy_ref.read().unwrap().contact_info_trace()
-            );
+    let (met_criteria, secs, tvu_peers) = spy(spy_ref.clone(), num_nodes, timeout, find_node);
 
-            exit.store(true, Ordering::Relaxed);
-            gossip_service.join().unwrap();
-            return Ok(tvu_peers);
+    exit.store(true, Ordering::Relaxed);
+    gossip_service.join().unwrap();
+
+    if met_criteria {
+        info!(
+            "discover success in {}s...\n{}",
+            secs,
+            spy_ref.read().unwrap().contact_info_trace()
+        );
+        return Ok(tvu_peers);
+    }
+
+    if !tvu_peers.is_empty() {
+        info!(
+            "discover failed to match criteria by timeout...\n{}",
+            spy_ref.read().unwrap().contact_info_trace()
+        );
+        return Ok(tvu_peers);
+    }
+
+    info!(
+        "discover failed...\n{}",
+        spy_ref.read().unwrap().contact_info_trace()
+    );
+    Err(std::io::Error::new(
+        std::io::ErrorKind::Other,
+        "Failed to converge",
+    ))
+}
+
+fn spy(
+    spy_ref: Arc<RwLock<ClusterInfo>>,
+    num_nodes: Option<usize>,
+    timeout: Option<u64>,
+    find_node: Option<Pubkey>,
+) -> (bool, u64, Vec<ContactInfo>) {
+    let now = Instant::now();
+    let mut met_criteria = false;
+    let mut tvu_peers: Vec<ContactInfo> = Vec::new();
+    let mut i = 0;
+    loop {
+        if let Some(secs) = timeout {
+            if now.elapsed() >= Duration::from_secs(secs) {
+                break;
+            }
+        }
+        tvu_peers = spy_ref.read().unwrap().tvu_peers();
+        if let Some(num) = num_nodes {
+            if tvu_peers.len() >= num {
+                if let Some(pubkey) = find_node {
+                    if tvu_peers.iter().any(|x| x.id == pubkey) {
+                        met_criteria = true;
+                        break;
+                    }
+                } else {
+                    met_criteria = true;
+                    break;
+                }
+            }
+        }
+        if let Some(pubkey) = find_node {
+            if num_nodes.is_none() && tvu_peers.iter().any(|x| x.id == pubkey) {
+                met_criteria = true;
+                break;
+            }
         }
         if i % 20 == 0 {
             info!(
@@ -88,17 +153,7 @@ pub fn discover(gossip_addr: &SocketAddr, num_nodes: usize) -> std::io::Result<V
         ));
         i += 1;
     }
-
-    exit.store(true, Ordering::Relaxed);
-    gossip_service.join().unwrap();
-    info!(
-        "discover failed...\n{}",
-        spy_ref.read().unwrap().contact_info_trace()
-    );
-    Err(std::io::Error::new(
-        std::io::ErrorKind::Other,
-        "Failed to converge",
-    ))
+    (met_criteria, now.elapsed().as_secs(), tvu_peers)
 }
 
 fn make_spy_node(
@@ -144,5 +199,45 @@ mod tests {
         let d = GossipService::new(&c, None, None, tn.sockets.gossip, &exit);
         exit.store(true, Ordering::Relaxed);
         d.join().unwrap();
+    }
+
+    #[test]
+    fn test_gossip_services_spy() {
+        let keypair = Keypair::new();
+        let peer0 = Pubkey::new_rand();
+        let peer1 = Pubkey::new_rand();
+        let contact_info = ContactInfo::new_localhost(&keypair.pubkey(), 0);
+        let peer0_info = ContactInfo::new_localhost(&peer0, 0);
+        let peer1_info = ContactInfo::new_localhost(&peer1, 0);
+        let mut cluster_info = ClusterInfo::new(contact_info.clone(), Arc::new(keypair));
+        cluster_info.insert_info(peer0_info);
+        cluster_info.insert_info(peer1_info);
+
+        let spy_ref = Arc::new(RwLock::new(cluster_info));
+
+        let (met_criteria, secs, tvu_peers) = spy(spy_ref.clone(), None, Some(1), None);
+        assert_eq!(met_criteria, false);
+        assert_eq!(secs, 1);
+        assert_eq!(tvu_peers, spy_ref.read().unwrap().tvu_peers());
+
+        // Find num_nodes
+        let (met_criteria, _, _) = spy(spy_ref.clone(), Some(1), None, None);
+        assert_eq!(met_criteria, true);
+        let (met_criteria, _, _) = spy(spy_ref.clone(), Some(2), None, None);
+        assert_eq!(met_criteria, true);
+
+        // Find specific node by pubkey
+        let (met_criteria, _, _) = spy(spy_ref.clone(), None, None, Some(peer0));
+        assert_eq!(met_criteria, true);
+        let (met_criteria, _, _) = spy(spy_ref.clone(), None, Some(0), Some(Pubkey::new_rand()));
+        assert_eq!(met_criteria, false);
+
+        // Find num_nodes *and* specific node by pubkey
+        let (met_criteria, _, _) = spy(spy_ref.clone(), Some(1), None, Some(peer0));
+        assert_eq!(met_criteria, true);
+        let (met_criteria, _, _) = spy(spy_ref.clone(), Some(3), Some(0), Some(peer0));
+        assert_eq!(met_criteria, false);
+        let (met_criteria, _, _) = spy(spy_ref.clone(), Some(1), Some(0), Some(Pubkey::new_rand()));
+        assert_eq!(met_criteria, false);
     }
 }

--- a/core/src/local_cluster.rs
+++ b/core/src/local_cluster.rs
@@ -3,7 +3,7 @@ use crate::cluster::Cluster;
 use crate::cluster_info::{Node, FULLNODE_PORT_RANGE};
 use crate::contact_info::ContactInfo;
 use crate::fullnode::{Fullnode, FullnodeConfig};
-use crate::gossip_service::discover;
+use crate::gossip_service::discover_nodes;
 use crate::replicator::Replicator;
 use crate::service::Service;
 use solana_client::thin_client::create_client;
@@ -156,13 +156,13 @@ impl LocalCluster {
             cluster.add_validator(&fullnode_config, *stake);
         }
 
-        discover(&cluster.entry_point_info.gossip, node_stakes.len()).unwrap();
+        discover_nodes(&cluster.entry_point_info.gossip, node_stakes.len()).unwrap();
 
         for _ in 0..num_replicators {
             cluster.add_replicator();
         }
 
-        discover(
+        discover_nodes(
             &cluster.entry_point_info.gossip,
             node_stakes.len() + num_replicators,
         )

--- a/core/src/replicator.rs
+++ b/core/src/replicator.rs
@@ -215,7 +215,7 @@ impl Replicator {
         );
 
         info!("Looking for leader at {:?}", cluster_entrypoint);
-        crate::gossip_service::discover(&cluster_entrypoint.gossip, 1)?;
+        crate::gossip_service::discover_nodes(&cluster_entrypoint.gossip, 1)?;
 
         let (storage_blockhash, storage_entry_height) =
             Self::poll_for_blockhash_and_entry_height(&cluster_info)?;

--- a/core/tests/local_cluster.rs
+++ b/core/tests/local_cluster.rs
@@ -3,7 +3,7 @@ extern crate solana;
 use solana::cluster::Cluster;
 use solana::cluster_tests;
 use solana::fullnode::FullnodeConfig;
-use solana::gossip_service::discover;
+use solana::gossip_service::discover_nodes;
 use solana::local_cluster::LocalCluster;
 use solana::poh_service::PohServiceConfig;
 use solana_sdk::timing;
@@ -115,7 +115,7 @@ fn test_forwarding() {
     let fullnode_config = FullnodeConfig::default();
     let cluster = LocalCluster::new_with_config(&[999_990, 3], 2_000_000, &fullnode_config);
 
-    let cluster_nodes = discover(&cluster.entry_point_info.gossip, 2).unwrap();
+    let cluster_nodes = discover_nodes(&cluster.entry_point_info.gossip, 2).unwrap();
     assert!(cluster_nodes.len() >= 2);
 
     let leader_id = cluster.entry_point_info.id;

--- a/core/tests/replicator.rs
+++ b/core/tests/replicator.rs
@@ -9,7 +9,7 @@ use solana::blocktree::{create_new_tmp_ledger, Blocktree};
 use solana::cluster_info::{ClusterInfo, Node, FULLNODE_PORT_RANGE};
 use solana::contact_info::ContactInfo;
 use solana::fullnode::FullnodeConfig;
-use solana::gossip_service::discover;
+use solana::gossip_service::discover_nodes;
 use solana::local_cluster::LocalCluster;
 use solana::replicator::Replicator;
 use solana::replicator::ReplicatorRequest;
@@ -116,7 +116,7 @@ fn run_replicator_startup_basic(num_nodes: usize, num_replicators: usize) {
         DEFAULT_SLOTS_PER_EPOCH,
     );
 
-    let cluster_nodes = discover(
+    let cluster_nodes = discover_nodes(
         &cluster.entry_point_info.gossip,
         num_nodes + num_replicators,
     )
@@ -230,7 +230,7 @@ fn test_account_setup() {
         DEFAULT_SLOTS_PER_EPOCH,
     );
 
-    let _ = discover(
+    let _ = discover_nodes(
         &cluster.entry_point_info.gossip,
         num_nodes + num_replicators,
     )

--- a/gossip/Cargo.toml
+++ b/gossip/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+authors = ["Solana Maintainers <maintainers@solana.com>"]
+edition = "2018"
+name = "solana-gossip"
+description = "Blockchain, Rebuilt for Scale"
+version = "0.13.0"
+repository = "https://github.com/solana-labs/solana"
+license = "Apache-2.0"
+homepage = "https://solana.com/"
+
+[dependencies]
+clap = "2.32.0"
+solana = { path = "../core", version = "0.13.0" }
+solana-logger = { path = "../logger", version = "0.13.0" }
+solana-sdk = { path = "../sdk", version = "0.13.0" }

--- a/gossip/src/main.rs
+++ b/gossip/src/main.rs
@@ -1,0 +1,118 @@
+//! A command-line executable for monitoring a network's gossip plane.
+
+use clap::{crate_description, crate_name, crate_version, App, Arg};
+use solana::gossip_service::discover;
+use solana_sdk::pubkey::Pubkey;
+use std::error;
+use std::net::SocketAddr;
+use std::process::exit;
+
+fn pubkey_validator(pubkey: String) -> Result<(), String> {
+    match pubkey.parse::<Pubkey>() {
+        Ok(_) => Ok(()),
+        Err(err) => Err(format!("{:?}", err)),
+    }
+}
+
+fn main() -> Result<(), Box<dyn error::Error>> {
+    solana_logger::setup();
+    let mut network_addr = SocketAddr::from(([127, 0, 0, 1], 8001));
+    let network_string = network_addr.to_string();
+    let matches = App::new(crate_name!())
+        .about(crate_description!())
+        .version(crate_version!())
+        .arg(
+            Arg::with_name("network")
+                .short("n")
+                .long("network")
+                .value_name("HOST:PORT")
+                .takes_value(true)
+                .default_value(&network_string)
+                .help("Rendezvous with the network at this gossip entry point; defaults to 127.0.0.1:8001"),
+        )
+        .arg(
+            Arg::with_name("num_nodes")
+                .short("N")
+                .long("num-nodes")
+                .value_name("NUM")
+                .takes_value(true)
+                .conflicts_with("num_nodes_exactly")
+                .help("Wait for at least NUM nodes to converge"),
+        )
+        .arg(
+            Arg::with_name("num_nodes_exactly")
+                .short("E")
+                .long("num-nodes-exactly")
+                .value_name("NUM")
+                .takes_value(true)
+                .help("Wait for exactly NUM nodes to converge"),
+        )
+        .arg(
+            Arg::with_name("node_pubkey")
+                .short("p")
+                .long("pubkey")
+                .value_name("PUBKEY")
+                .takes_value(true)
+                .validator(pubkey_validator)
+                .help("Public key of a specific node to wait for"),
+        )
+        .arg(
+            Arg::with_name("timeout")
+                .long("timeout")
+                .value_name("SECS")
+                .takes_value(true)
+                .help("Seconds to wait for cluster to converge, then exit; default is forever"),
+        )
+        .get_matches();
+
+    if let Some(addr) = matches.value_of("network") {
+        network_addr = addr.parse().unwrap_or_else(|e| {
+            eprintln!("failed to parse network: {}", e);
+            exit(1)
+        });
+    }
+
+    let num_nodes_exactly = matches
+        .value_of("num_nodes_exactly")
+        .map(|num| num.to_string().parse().unwrap());
+    let num_nodes = matches
+        .value_of("num_nodes")
+        .map(|num| num.to_string().parse().unwrap())
+        .or(num_nodes_exactly);
+    let timeout = matches
+        .value_of("timeout")
+        .map(|secs| secs.to_string().parse().unwrap());
+    let pubkey = matches
+        .value_of("node_pubkey")
+        .map(|pubkey_str| pubkey_str.parse::<Pubkey>().unwrap());
+
+    let nodes = discover(&network_addr, num_nodes, timeout, pubkey)?;
+
+    if timeout.is_some() {
+        if let Some(num) = num_nodes {
+            if nodes.len() < num {
+                let add = if num_nodes_exactly.is_some() {
+                    ""
+                } else {
+                    " or more"
+                };
+                eprintln!(
+                    "Error: Insufficient nodes discovered.  Expecting {}{}",
+                    num, add,
+                );
+            }
+        }
+        if let Some(node) = pubkey {
+            if nodes.iter().find(|x| x.id == node).is_none() {
+                eprintln!("Error: Could not find node {:?}", node);
+            }
+        }
+    }
+    if num_nodes_exactly.is_some() && nodes.len() > num_nodes_exactly.unwrap() {
+        eprintln!(
+            "Error: Extra nodes discovered.  Expecting exactly {}",
+            num_nodes_exactly.unwrap()
+        );
+    }
+    Ok(())
+}

--- a/multinode-demo/common.sh
+++ b/multinode-demo/common.sh
@@ -59,13 +59,14 @@ else
 fi
 
 solana_bench_tps=$(solana_program bench-tps)
-solana_wallet=$(solana_program wallet)
 solana_drone=$(solana_program drone)
 solana_fullnode=$(solana_program fullnode)
 solana_fullnode_cuda=$(solana_program fullnode-cuda)
 solana_genesis=$(solana_program genesis)
+solana_gossip=$(solana_program gossip)
 solana_keygen=$(solana_program keygen)
 solana_ledger_tool=$(solana_program ledger-tool)
+solana_wallet=$(solana_program wallet)
 
 export RUST_LOG=${RUST_LOG:-solana=info} # if RUST_LOG is unset, default to info
 export RUST_BACKTRACE=1

--- a/net/remote/remote-sanity.sh
+++ b/net/remote/remote-sanity.sh
@@ -67,7 +67,7 @@ local|tar)
 
   entrypointRsyncUrl="$entrypointIp:~/solana"
 
-  solana_bench_tps=solana-bench-tps
+  solana_gossip=solana-gossip
   solana_ledger_tool=solana-ledger-tool
   solana_keygen=solana-keygen
 
@@ -84,18 +84,14 @@ echo "+++ $entrypointIp: node count ($numNodes expected)"
   set -x
   $solana_keygen -o "$client_id"
 
-  maybeRejectExtraNodes=
+  nodeArg="--num-nodes"
   if $rejectExtraNodes; then
-    maybeRejectExtraNodes="--reject-extra-nodes"
+    nodeArg="--num-nodes-exactly"
   fi
 
-  timeout 2m $solana_bench_tps \
+  timeout 2m $solana_gossip \
     --network "$entrypointIp:8001" \
-    --drone "$entrypointIp:9900" \
-    --identity "$client_id" \
-    --num-nodes "$numNodes" \
-    $maybeRejectExtraNodes \
-    --converge-only
+    --$nodeArg "$numNodes" \
 )
 
 echo "--- RPC API: getTransactionCount"

--- a/tests/thin_client.rs
+++ b/tests/thin_client.rs
@@ -2,7 +2,7 @@ use bincode::{deserialize, serialize};
 use log::*;
 use solana::cluster_info::FULLNODE_PORT_RANGE;
 use solana::fullnode::new_fullnode_for_tests;
-use solana::gossip_service::discover;
+use solana::gossip_service::discover_nodes;
 use solana_client::thin_client::create_client;
 use solana_client::thin_client::ThinClient;
 use solana_logger;
@@ -41,7 +41,7 @@ fn test_thin_client_basic() {
     solana_logger::setup();
     let (server, leader_data, alice, ledger_path) = new_fullnode_for_tests();
     let bob_pubkey = Pubkey::new_rand();
-    discover(&leader_data.gossip, 1).unwrap();
+    discover_nodes(&leader_data.gossip, 1).unwrap();
 
     let client = create_client(leader_data.client_facing_addr(), FULLNODE_PORT_RANGE);
 
@@ -70,7 +70,7 @@ fn test_bad_sig() {
     solana_logger::setup();
     let (server, leader_data, alice, ledger_path) = new_fullnode_for_tests();
     let bob_pubkey = Pubkey::new_rand();
-    discover(&leader_data.gossip, 1).unwrap();
+    discover_nodes(&leader_data.gossip, 1).unwrap();
 
     let client = create_client(leader_data.client_facing_addr(), FULLNODE_PORT_RANGE);
 
@@ -101,7 +101,7 @@ fn test_bad_sig() {
 fn test_register_vote_account() {
     solana_logger::setup();
     let (server, leader_data, alice, ledger_path) = new_fullnode_for_tests();
-    discover(&leader_data.gossip, 1).unwrap();
+    discover_nodes(&leader_data.gossip, 1).unwrap();
 
     let client = create_client(leader_data.client_facing_addr(), FULLNODE_PORT_RANGE);
 
@@ -178,7 +178,7 @@ fn test_zero_balance_after_nonzero() {
     solana_logger::setup();
     let (server, leader_data, alice, ledger_path) = new_fullnode_for_tests();
     let bob_keypair = Keypair::new();
-    discover(&leader_data.gossip, 1).unwrap();
+    discover_nodes(&leader_data.gossip, 1).unwrap();
 
     let client = create_client(leader_data.client_facing_addr(), FULLNODE_PORT_RANGE);
     let blockhash = client.get_recent_blockhash().unwrap();


### PR DESCRIPTION
#### Problem
We've been using the `--converge-only` option on `solana-bench-tps` as our de facto gossip cli tool, but it's not really designed for that purpose.

#### Summary of Changes
Rework gossip-services to handle additional discover args. Also, rearrange to make a big chunk of this unit-testable (wasn't being tested at all before).

Add solana-gossip module. Arg options are:
- network; network entry point, required
- timeout; no timeout means app will continue to monitor gossip forever, or until other arg cases are met
- num-nodes OR num-nodes-exactly; returns when finds >=nodes or =nodes, respectively
- pubkey; returns when finds node with specific pubkey
- if a num-nodes option and pubkey are both specified, app continues to monitor gossip until both cases are met 

Remove `converge-only` and `reject-extra-nodes` from bench-tps

Fixes #3434 
