### PR TITLE
Implement finalizer so that all locked accounts are dropped

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5,6 +5,7 @@
 
 use crate::accounts::{Accounts, ErrorCounters, InstructionAccounts, InstructionLoaders};
 use crate::blockhash_queue::BlockhashQueue;
+use crate::locked_accounts_results::LockedAccountsResults;
 use crate::runtime::{ProcessInstruction, Runtime};
 use crate::status_cache::StatusCache;
 use bincode::serialize;
@@ -467,13 +468,17 @@ impl Bank {
             .map_or(Ok(()), |sig| self.get_signature_status(sig).unwrap())
     }
 
-    pub fn lock_accounts(&self, txs: &[Transaction]) -> Vec<Result<()>> {
+    pub fn lock_accounts<'a, 'b>(
+        &'a self,
+        txs: &'b [Transaction],
+    ) -> LockedAccountsResults<'a, 'b> {
         if self.is_frozen() {
             warn!("=========== FIXME: lock_accounts() working on a frozen bank! ================");
         }
         // TODO: put this assert back in
         // assert!(!self.is_frozen());
-        self.accounts.lock_accounts(self.accounts_id, txs)
+        let results = self.accounts.lock_accounts(self.accounts_id, txs);
+        LockedAccountsResults::new(results, &self, txs)
     }
 
     pub fn unlock_accounts(&self, txs: &[Transaction], results: &[Result<()>]) {
@@ -498,17 +503,17 @@ impl Bank {
     fn check_refs(
         &self,
         txs: &[Transaction],
-        lock_results: Vec<Result<()>>,
+        lock_results: &LockedAccountsResults,
         error_counters: &mut ErrorCounters,
     ) -> Vec<Result<()>> {
         txs.iter()
-            .zip(lock_results.into_iter())
+            .zip(lock_results.locked_accounts_results())
             .map(|(tx, lock_res)| {
                 if lock_res.is_ok() && !tx.verify_refs() {
                     error_counters.invalid_account_index += 1;
                     Err(TransactionError::InvalidAccountIndex)
                 } else {
-                    lock_res
+                    lock_res.clone()
                 }
             })
             .collect()
@@ -575,7 +580,7 @@ impl Bank {
     pub fn load_and_execute_transactions(
         &self,
         txs: &[Transaction],
-        lock_results: Vec<Result<()>>,
+        lock_results: &LockedAccountsResults,
         max_age: usize,
     ) -> (
         Vec<Result<(InstructionAccounts, InstructionLoaders)>>,
@@ -741,7 +746,7 @@ impl Bank {
     pub fn load_execute_and_commit_transactions(
         &self,
         txs: &[Transaction],
-        lock_results: Vec<Result<()>>,
+        lock_results: &LockedAccountsResults,
         max_age: usize,
     ) -> Vec<Result<()>> {
         let (loaded_accounts, executed) =
@@ -754,7 +759,7 @@ impl Bank {
     pub fn process_transactions(&self, txs: &[Transaction]) -> Vec<Result<()>> {
         let lock_results = self.lock_accounts(txs);
         let results =
-            self.load_execute_and_commit_transactions(txs, lock_results, MAX_RECENT_BLOCKHASHES);
+            self.load_execute_and_commit_transactions(txs, &lock_results, MAX_RECENT_BLOCKHASHES);
         self.unlock_accounts(txs, &results);
         results
     }
@@ -1312,7 +1317,7 @@ mod tests {
         let lock_result = bank.lock_accounts(&pay_alice);
         let results_alice = bank.load_execute_and_commit_transactions(
             &pay_alice,
-            lock_result,
+            &lock_result,
             MAX_RECENT_BLOCKHASHES,
         );
         assert_eq!(results_alice[0], Ok(()));

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -5,6 +5,7 @@ pub mod bank_client;
 mod blockhash_queue;
 pub mod bloom;
 pub mod loader_utils;
+pub mod locked_accounts_results;
 mod native_loader;
 pub mod runtime;
 mod status_cache;

--- a/runtime/src/locked_accounts_results.rs
+++ b/runtime/src/locked_accounts_results.rs
@@ -1,0 +1,35 @@
+use crate::bank::{Bank, Result};
+use solana_sdk::transaction::Transaction;
+
+// Represents the results of trying to lock a set of accounts
+pub struct LockedAccountsResults<'a, 'b> {
+    locked_accounts_results: Vec<Result<()>>,
+    bank: &'a Bank,
+    transactions: &'b [Transaction],
+}
+
+impl<'a, 'b> LockedAccountsResults<'a, 'b> {
+    pub fn new(
+        locked_accounts_results: Vec<Result<()>>,
+        bank: &'a Bank,
+        transactions: &'b [Transaction],
+    ) -> Self {
+        Self {
+            locked_accounts_results,
+            bank,
+            transactions,
+        }
+    }
+
+    pub fn locked_accounts_results(&self) -> &Vec<Result<()>> {
+        &self.locked_accounts_results
+    }
+}
+
+// Unlock all locked accounts in destructor.
+impl<'a, 'b> Drop for LockedAccountsResults<'a, 'b> {
+    fn drop(&mut self) {
+        self.bank
+            .unlock_accounts(self.transactions, &self.locked_accounts_results[..])
+    }
+}

--- a/runtime/src/locked_accounts_results.rs
+++ b/runtime/src/locked_accounts_results.rs
@@ -6,6 +6,7 @@ pub struct LockedAccountsResults<'a, 'b> {
     locked_accounts_results: Vec<Result<()>>,
     bank: &'a Bank,
     transactions: &'b [Transaction],
+    pub(crate) needs_unlock: bool,
 }
 
 impl<'a, 'b> LockedAccountsResults<'a, 'b> {
@@ -18,18 +19,24 @@ impl<'a, 'b> LockedAccountsResults<'a, 'b> {
             locked_accounts_results,
             bank,
             transactions,
+            needs_unlock: true,
         }
     }
 
     pub fn locked_accounts_results(&self) -> &Vec<Result<()>> {
         &self.locked_accounts_results
     }
+
+    pub fn transactions(&self) -> &[Transaction] {
+        self.transactions
+    }
 }
 
 // Unlock all locked accounts in destructor.
 impl<'a, 'b> Drop for LockedAccountsResults<'a, 'b> {
     fn drop(&mut self) {
-        self.bank
-            .unlock_accounts(self.transactions, &self.locked_accounts_results[..])
+        if self.needs_unlock {
+            self.bank.unlock_accounts(self)
+        }
     }
 }


### PR DESCRIPTION
#### Problem
If this line: https://github.com/solana-labs/solana/blob/master/core/src/blocktree_processor.rs#L61 early exits, then the set of locked accounts locked here: https://github.com/solana-labs/solana/blob/master/core/src/blocktree_processor.rs#L57
will not be unlocked.

#### Summary of Changes
Implement finalizer for locked accounts so that these types of errors will no longer happen. Thanks @sagar-solana for being my code parser xD
Fixes #3463 
