### PR TITLE
Rename Wallet's id to keypair

### DIFF
--- a/wallet/src/main.rs
+++ b/wallet/src/main.rs
@@ -58,17 +58,17 @@ pub fn parse_args(matches: &ArgMatches<'_>) -> Result<WalletConfig, Box<dyn erro
 
         path.to_str().unwrap()
     };
-    let id = read_keypair(id_path).or_else(|err| {
+    let keypair = read_keypair(id_path).or_else(|err| {
         Err(WalletError::BadParameter(format!(
             "{}: Unable to open keypair file: {}",
             err, id_path
         )))
     })?;
 
-    let command = parse_command(&id.pubkey(), &matches)?;
+    let command = parse_command(&keypair.pubkey(), &matches)?;
 
     Ok(WalletConfig {
-        id,
+        keypair,
         command,
         drone_host,
         drone_port,

--- a/wallet/tests/pay.rs
+++ b/wallet/tests/pay.rs
@@ -37,10 +37,14 @@ fn test_wallet_timestamp_tx() {
     config_witness.drone_port = drone_addr.port();
     config_witness.rpc_port = leader_data.rpc.port();
 
-    assert_ne!(config_payer.id.pubkey(), config_witness.id.pubkey());
+    assert_ne!(
+        config_payer.keypair.pubkey(),
+        config_witness.keypair.pubkey()
+    );
 
-    request_and_confirm_airdrop(&rpc_client, &drone_addr, &config_payer.id.pubkey(), 50).unwrap();
-    check_balance(50, &rpc_client, &config_payer.id.pubkey());
+    request_and_confirm_airdrop(&rpc_client, &drone_addr, &config_payer.keypair.pubkey(), 50)
+        .unwrap();
+    check_balance(50, &rpc_client, &config_payer.keypair.pubkey());
 
     // Make transaction (from config_payer to bob_pubkey) requiring timestamp from config_witness
     let date_string = "\"2018-09-19T17:30:59Z\"";
@@ -49,7 +53,7 @@ fn test_wallet_timestamp_tx() {
         10,
         bob_pubkey,
         Some(dt),
-        Some(config_witness.id.pubkey()),
+        Some(config_witness.keypair.pubkey()),
         None,
         None,
     );
@@ -62,7 +66,7 @@ fn test_wallet_timestamp_tx() {
         .expect("base58-encoded public key");
     let process_id = Pubkey::new(&process_id_vec);
 
-    check_balance(40, &rpc_client, &config_payer.id.pubkey()); // config_payer balance
+    check_balance(40, &rpc_client, &config_payer.keypair.pubkey()); // config_payer balance
     check_balance(10, &rpc_client, &process_id); // contract balance
     check_balance(0, &rpc_client, &bob_pubkey); // recipient balance
 
@@ -70,7 +74,7 @@ fn test_wallet_timestamp_tx() {
     config_witness.command = WalletCommand::TimeElapsed(bob_pubkey, process_id, dt);
     process_command(&config_witness).unwrap();
 
-    check_balance(40, &rpc_client, &config_payer.id.pubkey()); // config_payer balance
+    check_balance(40, &rpc_client, &config_payer.keypair.pubkey()); // config_payer balance
     check_balance(0, &rpc_client, &process_id); // contract balance
     check_balance(10, &rpc_client, &bob_pubkey); // recipient balance
 
@@ -97,9 +101,13 @@ fn test_wallet_witness_tx() {
     config_witness.drone_port = drone_addr.port();
     config_witness.rpc_port = leader_data.rpc.port();
 
-    assert_ne!(config_payer.id.pubkey(), config_witness.id.pubkey());
+    assert_ne!(
+        config_payer.keypair.pubkey(),
+        config_witness.keypair.pubkey()
+    );
 
-    request_and_confirm_airdrop(&rpc_client, &drone_addr, &config_payer.id.pubkey(), 50).unwrap();
+    request_and_confirm_airdrop(&rpc_client, &drone_addr, &config_payer.keypair.pubkey(), 50)
+        .unwrap();
 
     // Make transaction (from config_payer to bob_pubkey) requiring witness signature from config_witness
     config_payer.command = WalletCommand::Pay(
@@ -107,7 +115,7 @@ fn test_wallet_witness_tx() {
         bob_pubkey,
         None,
         None,
-        Some(vec![config_witness.id.pubkey()]),
+        Some(vec![config_witness.keypair.pubkey()]),
         None,
     );
     let sig_response = process_command(&config_payer);
@@ -119,7 +127,7 @@ fn test_wallet_witness_tx() {
         .expect("base58-encoded public key");
     let process_id = Pubkey::new(&process_id_vec);
 
-    check_balance(40, &rpc_client, &config_payer.id.pubkey()); // config_payer balance
+    check_balance(40, &rpc_client, &config_payer.keypair.pubkey()); // config_payer balance
     check_balance(10, &rpc_client, &process_id); // contract balance
     check_balance(0, &rpc_client, &bob_pubkey); // recipient balance
 
@@ -127,7 +135,7 @@ fn test_wallet_witness_tx() {
     config_witness.command = WalletCommand::Witness(bob_pubkey, process_id);
     process_command(&config_witness).unwrap();
 
-    check_balance(40, &rpc_client, &config_payer.id.pubkey()); // config_payer balance
+    check_balance(40, &rpc_client, &config_payer.keypair.pubkey()); // config_payer balance
     check_balance(0, &rpc_client, &process_id); // contract balance
     check_balance(10, &rpc_client, &bob_pubkey); // recipient balance
 
@@ -154,9 +162,13 @@ fn test_wallet_cancel_tx() {
     config_witness.drone_port = drone_addr.port();
     config_witness.rpc_port = leader_data.rpc.port();
 
-    assert_ne!(config_payer.id.pubkey(), config_witness.id.pubkey());
+    assert_ne!(
+        config_payer.keypair.pubkey(),
+        config_witness.keypair.pubkey()
+    );
 
-    request_and_confirm_airdrop(&rpc_client, &drone_addr, &config_payer.id.pubkey(), 50).unwrap();
+    request_and_confirm_airdrop(&rpc_client, &drone_addr, &config_payer.keypair.pubkey(), 50)
+        .unwrap();
 
     // Make transaction (from config_payer to bob_pubkey) requiring witness signature from config_witness
     config_payer.command = WalletCommand::Pay(
@@ -164,8 +176,8 @@ fn test_wallet_cancel_tx() {
         bob_pubkey,
         None,
         None,
-        Some(vec![config_witness.id.pubkey()]),
-        Some(config_payer.id.pubkey()),
+        Some(vec![config_witness.keypair.pubkey()]),
+        Some(config_payer.keypair.pubkey()),
     );
     let sig_response = process_command(&config_payer).unwrap();
 
@@ -176,7 +188,7 @@ fn test_wallet_cancel_tx() {
         .expect("base58-encoded public key");
     let process_id = Pubkey::new(&process_id_vec);
 
-    check_balance(40, &rpc_client, &config_payer.id.pubkey()); // config_payer balance
+    check_balance(40, &rpc_client, &config_payer.keypair.pubkey()); // config_payer balance
     check_balance(10, &rpc_client, &process_id); // contract balance
     check_balance(0, &rpc_client, &bob_pubkey); // recipient balance
 
@@ -184,7 +196,7 @@ fn test_wallet_cancel_tx() {
     config_payer.command = WalletCommand::Cancel(process_id);
     process_command(&config_payer).unwrap();
 
-    check_balance(50, &rpc_client, &config_payer.id.pubkey()); // config_payer balance
+    check_balance(50, &rpc_client, &config_payer.keypair.pubkey()); // config_payer balance
     check_balance(0, &rpc_client, &process_id); // contract balance
     check_balance(0, &rpc_client, &bob_pubkey); // recipient balance
 

--- a/wallet/tests/request_airdrop.rs
+++ b/wallet/tests/request_airdrop.rs
@@ -24,7 +24,7 @@ fn test_wallet_request_airdrop() {
     let rpc_client = RpcClient::new_socket(leader_data.rpc);
 
     let balance = rpc_client
-        .retry_get_balance(&bob_config.id.pubkey(), 1)
+        .retry_get_balance(&bob_config.keypair.pubkey(), 1)
         .unwrap()
         .unwrap();
     assert_eq!(balance, 50);


### PR DESCRIPTION
#### Problem

Too many things called "id".

#### Summary of Changes

"Call it what it is" - rename Wallet's Keypair from `id` to `keypair`.

@CriesofCarrots, fyi