### PR TITLE
Rename Runtime to MessageProcessor

### DIFF
--- a/runtime/benches/message_processor.rs
+++ b/runtime/benches/message_processor.rs
@@ -2,7 +2,7 @@
 
 extern crate test;
 
-use solana_runtime::runtime::*;
+use solana_runtime::message_processor::*;
 use test::Bencher;
 
 #[bench]

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -1,6 +1,6 @@
 use crate::append_vec::AppendVec;
 use crate::bank::Result;
-use crate::runtime::has_duplicates;
+use crate::message_processor::has_duplicates;
 use bincode::serialize;
 use hashbrown::{HashMap, HashSet};
 use log::*;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -6,8 +6,8 @@ mod blockhash_queue;
 pub mod bloom;
 pub mod loader_utils;
 pub mod locked_accounts_results;
+pub mod message_processor;
 mod native_loader;
-pub mod runtime;
 mod status_cache;
 mod system_instruction_processor;
 

--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -10,7 +10,7 @@ use solana_sdk::transaction::TransactionError;
 /// Return true if the slice has any duplicate elements
 pub fn has_duplicates<T: PartialEq>(xs: &[T]) -> bool {
     // Note: This is an O(n^2) algorithm, but requires no heap allocations. The benchmark
-    // `bench_has_duplicates` in benches/runtime.rs shows that this implementation is
+    // `bench_has_duplicates` in benches/message_processor.rs shows that this implementation is
     // ~50 times faster than using HashSet for very short slices.
     for i in 1..xs.len() {
         if xs[i..].contains(&xs[i - 1]) {
@@ -85,11 +85,11 @@ fn verify_error(err: InstructionError) -> InstructionError {
 pub type ProcessInstruction =
     fn(&Pubkey, &mut [KeyedAccount], &[u8], u64) -> Result<(), InstructionError>;
 
-pub struct Runtime {
+pub struct MessageProcessor {
     instruction_processors: Vec<(Pubkey, ProcessInstruction)>,
 }
 
-impl Default for Runtime {
+impl Default for MessageProcessor {
     fn default() -> Self {
         let instruction_processors: Vec<(Pubkey, ProcessInstruction)> = vec![(
             system_program::id(),
@@ -102,7 +102,7 @@ impl Default for Runtime {
     }
 }
 
-impl Runtime {
+impl MessageProcessor {
     /// Add a static entrypoint to intercept intructions before the dynamic loader.
     pub fn add_instruction_processor(
         &mut self,


### PR DESCRIPTION
#### Problem

In the Solana book, we use the term "runtime" to mean "runtime library". In the implementation, it's used two ways: both a module named runtime.rs (with struct Runtime) and a crate called "solana_runtime", which is a static library.

#### Summary of Changes

* Rename Runtime to MessageProcessor (because that's all it does)
