### PR TITLE
Re-enable test but remove replicators from config

### DIFF
--- a/core/src/local_cluster.rs
+++ b/core/src/local_cluster.rs
@@ -422,13 +422,12 @@ mod test {
     }
 
     #[test]
-    #[ignore]
     fn test_local_cluster_start_and_exit_with_config() {
         solana_logger::setup();
         let mut fullnode_exit = FullnodeConfig::default();
         fullnode_exit.rpc_config.enable_fullnode_exit = true;
         const NUM_NODES: usize = 1;
-        let num_replicators = 1;
+        let num_replicators = 0;
         let cluster = LocalCluster::new_with_config_replicators(
             &[3; NUM_NODES],
             100,


### PR DESCRIPTION
#### Problem

`test_local_cluster_start_and_exit_with_config` is disabled

#### Summary of Changes

enable it but remove replicators from its config for the time being, see #3592
