### PR TITLE
Deploy beta testnet with 100 nodes across AWS and GCP

### DIFF
--- a/ci/testnet-manager.sh
+++ b/ci/testnet-manager.sh
@@ -210,7 +210,13 @@ start() {
       NO_VALIDATOR_SANITY=1 \
       RUST_LOG=solana=info \
         ci/testnet-deploy.sh beta-testnet-solana-com ec2 us-west-1a \
-          -t "$CHANNEL_OR_TAG" -n 35 -c 0 -u -P -a eipalloc-0f286cf8a0771ce35 \
+          -t "$CHANNEL_OR_TAG" -n 35 -c 0 -s -u -P -a eipalloc-0f286cf8a0771ce35 \
+          ${maybeReuseLedger:+-r} \
+          ${maybeDelete:+-D}
+      NO_VALIDATOR_SANITY=1 \
+      RUST_LOG=solana=info \
+        ci/testnet-deploy.sh beta-testnet-solana-com gce us-west1-a \
+          -t "$CHANNEL_OR_TAG" -n 65 -c 0 -x -u -P \
           ${maybeReuseLedger:+-r} \
           ${maybeDelete:+-D}
     )


### PR DESCRIPTION
#### Problem
The testnet manager scripts do not support deployment across multiple cloud providers.

#### Summary of Changes
Deploy script will let user configure nodes without starting the testnet. The user can configure nodes on different cloud providers, and start the testnet once all nodes are configured. 