### PR TITLE
Fix the release number in testnet participation document

### DIFF
--- a/book/src/testnet-participation.md
+++ b/book/src/testnet-participation.md
@@ -29,7 +29,7 @@ MacOS or WSL users may build from source.
 The shell commands in this section assume the following environment variables are
 set:
 ```bash
-$ export release=0.12.1
+$ export release=0.12.3
 $ export ip=$(dig +short beta.testnet.solana.com)
 $ export USE_INSTALL=1
 ```


### PR DESCRIPTION
#### Problem
The testnet participation document is pointing at the old release. It may not be compatible with the beta testnet.

#### Summary of Changes
Update the release tag to the latest beacons release.