### PR TITLE
Update Storage Program to support multiple accounts

### DIFF
--- a/programs/storage_api/src/storage_contract.rs
+++ b/programs/storage_api/src/storage_contract.rs
@@ -3,11 +3,17 @@ use solana_sdk::hash::Hash;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::Signature;
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub enum ProofStatus {
+    Skipped,
     Valid,
     NotValid,
-    Skipped,
+}
+
+impl Default for ProofStatus {
+    fn default() -> Self {
+        ProofStatus::Skipped
+    }
 }
 
 #[derive(Default, Debug, Serialize, Deserialize, Clone)]
@@ -15,6 +21,7 @@ pub struct ProofInfo {
     pub id: Pubkey,
     pub signature: Signature,
     pub sha_state: Hash,
+    pub status: ProofStatus,
 }
 
 #[derive(Default, Debug, Serialize, Deserialize, Clone)]
@@ -23,14 +30,19 @@ pub struct ValidationInfo {
     pub proof_mask: Vec<ProofStatus>,
 }
 
-#[derive(Default, Debug, Serialize, Deserialize)]
-pub struct StorageContract {
-    pub entry_height: u64,
-    pub hash: Hash,
+#[derive(Debug, Serialize, Deserialize)]
+pub enum StorageContract {
+    //don't move this
+    Default,
 
-    pub proofs: Vec<Vec<ProofInfo>>,
-    pub previous_proofs: Vec<Vec<ProofInfo>>,
-
-    pub lockout_validations: Vec<Vec<ValidationInfo>>,
-    pub reward_validations: Vec<Vec<ValidationInfo>>,
+    ValidatorStorage {
+        entry_height: u64,
+        hash: Hash,
+        lockout_validations: Vec<Vec<ProofInfo>>,
+        reward_validations: Vec<Vec<ProofInfo>>,
+    },
+    ReplicatorStorage {
+        proofs: Vec<ProofInfo>,
+        reward_validations: Vec<Vec<ProofInfo>>,
+    },
 }

--- a/programs/storage_api/src/storage_contract.rs
+++ b/programs/storage_api/src/storage_contract.rs
@@ -17,17 +17,16 @@ impl Default for ProofStatus {
 }
 
 #[derive(Default, Debug, Serialize, Deserialize, Clone)]
-pub struct ProofInfo {
+pub struct Proof {
     pub id: Pubkey,
     pub signature: Signature,
     pub sha_state: Hash,
-    pub status: ProofStatus,
 }
 
 #[derive(Default, Debug, Serialize, Deserialize, Clone)]
-pub struct ValidationInfo {
-    pub id: Pubkey,
-    pub proof_mask: Vec<ProofStatus>,
+pub struct CheckedProof {
+    pub proof: Proof,
+    pub status: ProofStatus,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -38,11 +37,11 @@ pub enum StorageContract {
     ValidatorStorage {
         entry_height: u64,
         hash: Hash,
-        lockout_validations: Vec<Vec<ProofInfo>>,
-        reward_validations: Vec<Vec<ProofInfo>>,
+        lockout_validations: Vec<Vec<CheckedProof>>,
+        reward_validations: Vec<Vec<CheckedProof>>,
     },
     ReplicatorStorage {
-        proofs: Vec<ProofInfo>,
-        reward_validations: Vec<Vec<ProofInfo>>,
+        proofs: Vec<Proof>,
+        reward_validations: Vec<Vec<CheckedProof>>,
     },
 }

--- a/programs/storage_api/src/storage_instruction.rs
+++ b/programs/storage_api/src/storage_instruction.rs
@@ -1,5 +1,5 @@
 use crate::id;
-use crate::storage_contract::ProofInfo;
+use crate::storage_contract::CheckedProof;
 use serde_derive::{Deserialize, Serialize};
 use solana_sdk::hash::Hash;
 use solana_sdk::instruction::{AccountMeta, Instruction};
@@ -23,7 +23,7 @@ pub enum StorageInstruction {
     },
     ProofValidation {
         entry_height: u64,
-        proofs: Vec<ProofInfo>,
+        proofs: Vec<CheckedProof>,
     },
 }
 
@@ -58,12 +58,12 @@ pub fn advertise_recent_blockhash(
 pub fn proof_validation(
     from_pubkey: &Pubkey,
     entry_height: u64,
-    proofs: Vec<ProofInfo>,
+    proofs: Vec<CheckedProof>,
 ) -> Instruction {
     let mut account_metas = vec![AccountMeta::new(*from_pubkey, true)];
-    proofs
-        .iter()
-        .for_each(|proof| account_metas.push(AccountMeta::new(proof.id, false)));
+    proofs.iter().for_each(|checked_proof| {
+        account_metas.push(AccountMeta::new(checked_proof.proof.id, false))
+    });
     let storage_instruction = StorageInstruction::ProofValidation {
         entry_height,
         proofs,

--- a/programs/storage_api/src/storage_processor.rs
+++ b/programs/storage_api/src/storage_processor.rs
@@ -219,7 +219,7 @@ pub fn process_instruction(
                     let current_index = get_segment_from_entry(tick_height);
                     let claims_index = get_segment_from_entry(entry_height);
                     if current_index <= claims_index || claims_index >= reward_validations.len() {
-                        println!(
+                        debug!(
                             "current {:?}, claim {:?}, rewards {:?}",
                             current_index,
                             claims_index,


### PR DESCRIPTION
#### Problem

Storage Program runs with the assumption that there is only one global account state for all Storage work. This is no longer true, Replicators and Validators each have their own Storage Accounts and Storage Program is not equipped to handle this setup

#### Summary of Changes

Modified Storage Program such that it can handle dealing with Replicator and Validator Accounts. 
Updated what Validators submit as proofs.
Updated some tests to use a bank.
Disabled rewards for the time being. 

Fixes #3369
