### PR TITLE
Bump hashbrown to 0.2.0

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -25,7 +25,7 @@ bs58 = "0.2.0"
 byteorder = "1.3.1"
 chrono = { version = "0.4.0", features = ["serde"] }
 crc = { version = "1.8.1", optional = true }
-hashbrown = "0.1.8"
+hashbrown = "0.2.0"
 indexmap = "1.0"
 itertools = "0.8.0"
 jsonrpc-core = "10.1.0"

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -13,7 +13,7 @@ bincode = "1.1.2"
 bv = { version = "0.11.0", features = ["serde"] }
 byteorder = "1.3.1"
 fnv = "1.0.6"
-hashbrown = "0.1.8"
+hashbrown = "0.2.0"
 libc = "0.2.49"
 libloading = "0.5.0"
 log = "0.4.2"


### PR DESCRIPTION
#### Problem

Dependabot didn't update all instance of hashbrown. Not sure why.

#### Summary of Changes

Do it manually.
