### PR TITLE
Don't use external node ssh key if one is not configured

### DIFF
--- a/net/net.sh
+++ b/net/net.sh
@@ -163,7 +163,7 @@ startCommon() {
       mkdir -p ~/.cargo/bin
     "
   fi
-  ssh-copy-id -f -i "$externalNodeSshKey" "${sshOptions[@]}" "solana@$ipAddress"
+  [[ -z "$externalNodeSshKey" ]] || ssh-copy-id -f -i "$externalNodeSshKey" "${sshOptions[@]}" "solana@$ipAddress"
   rsync -vPrc -e "ssh ${sshOptions[*]}" \
     "$SOLANA_ROOT"/{fetch-perf-libs.sh,scripts,net,multinode-demo} \
     "$ipAddress":~/solana/


### PR DESCRIPTION
#### Problem
The testnet for single cloud setup fails to bootup

#### Summary of Changes
The multi cloud support broke net.sh script. Fixed the script.