### PR TITLE
Remove second block streamer from testnet beta

### DIFF
--- a/ci/testnet-manager.sh
+++ b/ci/testnet-manager.sh
@@ -216,7 +216,7 @@ start() {
       NO_VALIDATOR_SANITY=1 \
       RUST_LOG=solana=info \
         ci/testnet-deploy.sh beta-testnet-solana-com gce us-west1-a \
-          -t "$CHANNEL_OR_TAG" -n 65 -c 0 -x -u -P \
+          -t "$CHANNEL_OR_TAG" -n 65 -c 0 -x -P \
           ${maybeReuseLedger:+-r} \
           ${maybeDelete:+-D}
     )


### PR DESCRIPTION
#### Problem
Testnet beta is running with two blockstreamers. Only one is required.

#### Summary of Changes
The second got added when multi cloud support was introduced. Removed the blockstreamer from GCP nodes.