### PR TITLE
Cleanup program ids

### DIFF
--- a/core/src/storage_stage.rs
+++ b/core/src/storage_stage.rs
@@ -402,9 +402,10 @@ impl StorageStage {
             // the storage_keys with their signatures
             for tx in entry.transactions {
                 let message = tx.message();
-                for (i, program_id) in message.program_ids().iter().enumerate() {
-                    if solana_storage_api::check_id(&program_id) {
-                        match deserialize(&message.instructions[i].data) {
+                for instruction in &message.instructions {
+                    let program_id = instruction.program_id(message.program_ids());
+                    if solana_storage_api::check_id(program_id) {
+                        match deserialize(&instruction.data) {
                             Ok(StorageInstruction::SubmitMiningProof {
                                 entry_height: proof_entry_height,
                                 signature,

--- a/core/src/storage_stage.rs
+++ b/core/src/storage_stage.rs
@@ -402,7 +402,7 @@ impl StorageStage {
             // the storage_keys with their signatures
             for tx in entry.transactions {
                 let message = tx.message();
-                for (i, program_id) in message.program_ids.iter().enumerate() {
+                for (i, program_id) in message.program_ids().iter().enumerate() {
                     if solana_storage_api::check_id(&program_id) {
                         match deserialize(&message.instructions[i].data) {
                             Ok(StorageInstruction::SubmitMiningProof {

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -707,11 +707,11 @@ impl AccountsDB {
             .instructions
             .iter()
             .map(|ix| {
-                if message.program_ids.len() <= ix.program_ids_index as usize {
+                if message.program_ids().len() <= ix.program_ids_index as usize {
                     error_counters.account_not_found += 1;
                     return Err(TransactionError::AccountNotFound);
                 }
-                let program_id = message.program_ids[ix.program_ids_index as usize];
+                let program_id = message.program_ids()[ix.program_ids_index as usize];
                 self.load_executable_accounts(fork, &program_id, error_counters)
             })
             .collect()

--- a/sdk/src/instruction.rs
+++ b/sdk/src/instruction.rs
@@ -129,4 +129,8 @@ impl CompiledInstruction {
             accounts,
         }
     }
+
+    pub fn program_id<'a>(&self, program_ids: &'a [Pubkey]) -> &'a Pubkey {
+        &program_ids[self.program_ids_index as usize]
+    }
 }

--- a/sdk/src/message.rs
+++ b/sdk/src/message.rs
@@ -83,7 +83,7 @@ pub struct Message {
 
     /// All the program id keys used to execute this transaction's instructions
     #[serde(with = "short_vec")]
-    pub program_ids: Vec<Pubkey>,
+    program_ids: Vec<Pubkey>,
 
     /// Programs that will be executed in sequence and committed in one atomic transaction if all
     /// succeed.
@@ -123,9 +123,8 @@ impl Message {
         )
     }
 
-    pub fn program_id(&self, instruction_index: usize) -> &Pubkey {
-        let program_ids_index = self.instructions[instruction_index].program_ids_index;
-        &self.program_ids[program_ids_index as usize]
+    pub fn program_ids(&self) -> &[Pubkey] {
+        &self.program_ids
     }
 }
 


### PR DESCRIPTION
#### Problem

Functions wanting an instruction's `program_id` drag around its container and index to call `Message::program_id(instruction_index)`.  Dragging around just the program_ids slice is sufficient.

#### Summary of Changes

* Added CompiledInstruction::program_id() so that we don't need to pass around instruction indexes just for Message::program_id().
* Added Message.program_ids() that returns a slice so that we can move those pubkeys into Message::account_keys.
* Fix StorageStage's single-instruction per transaction assumption

Better than this would be constructing CompiledInstruction with a reference to the Message's pubkeys. I don't know enough serde kung fu for that.