### PR TITLE
Rename new_account to new_user_account

### DIFF
--- a/bench-tps/src/bench.rs
+++ b/bench-tps/src/bench.rs
@@ -321,7 +321,7 @@ fn send_barrier_transaction(
         *blockhash = barrier_client.get_recent_blockhash().unwrap();
 
         let transaction =
-            SystemTransaction::new_account(&source_keypair, dest_id, 0, *blockhash, 0);
+            SystemTransaction::new_user_account(&source_keypair, dest_id, 0, *blockhash, 0);
         let signature = barrier_client
             .transfer_signed(&transaction)
             .expect("Unable to send barrier transaction");
@@ -399,7 +399,7 @@ fn generate_txs(
         .par_iter()
         .map(|(id, keypair)| {
             (
-                SystemTransaction::new_account(id, &keypair.pubkey(), 1, blockhash, 0),
+                SystemTransaction::new_user_account(id, &keypair.pubkey(), 1, blockhash, 0),
                 timestamp(),
             )
         })

--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -662,7 +662,7 @@ mod tests {
         let key = Keypair::new();
         let to = Pubkey::new_rand();
         let blockhash = Hash::default();
-        let tx = SystemTransaction::new_account(&key, &to, 50, blockhash, 0);
+        let tx = SystemTransaction::new_user_account(&key, &to, 50, blockhash, 0);
 
         let signature = rpc_client.send_transaction(&tx);
         assert_eq!(signature.unwrap(), SIGNATURE.to_string());
@@ -713,7 +713,7 @@ mod tests {
         let key = Keypair::new();
         let to = Pubkey::new_rand();
         let blockhash = Hash::default();
-        let mut tx = SystemTransaction::new_account(&key, &to, 50, blockhash, 0);
+        let mut tx = SystemTransaction::new_user_account(&key, &to, 50, blockhash, 0);
 
         let result = rpc_client.send_and_confirm_transaction(&mut tx, &key);
         result.unwrap();
@@ -737,8 +737,8 @@ mod tests {
             .into_vec()
             .unwrap();
         let blockhash = Hash::new(&vec);
-        let prev_tx = SystemTransaction::new_account(&key, &to, 50, blockhash, 0);
-        let mut tx = SystemTransaction::new_account(&key, &to, 50, blockhash, 0);
+        let prev_tx = SystemTransaction::new_user_account(&key, &to, 50, blockhash, 0);
+        let mut tx = SystemTransaction::new_user_account(&key, &to, 50, blockhash, 0);
 
         rpc_client.resign_transaction(&mut tx, &key).unwrap();
 

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -593,22 +593,27 @@ mod tests {
 
             // fund another account so we can send 2 good transactions in a single batch.
             let keypair = Keypair::new();
-            let fund_tx =
-                SystemTransaction::new_account(&mint_keypair, &keypair.pubkey(), 2, start_hash, 0);
+            let fund_tx = SystemTransaction::new_user_account(
+                &mint_keypair,
+                &keypair.pubkey(),
+                2,
+                start_hash,
+                0,
+            );
             bank.process_transaction(&fund_tx).unwrap();
 
             // good tx
             let to = Pubkey::new_rand();
-            let tx = SystemTransaction::new_account(&mint_keypair, &to, 1, start_hash, 0);
+            let tx = SystemTransaction::new_user_account(&mint_keypair, &to, 1, start_hash, 0);
 
             // good tx, but no verify
             let to2 = Pubkey::new_rand();
-            let tx_no_ver = SystemTransaction::new_account(&keypair, &to2, 2, start_hash, 0);
+            let tx_no_ver = SystemTransaction::new_user_account(&keypair, &to2, 2, start_hash, 0);
 
             // bad tx, AccountNotFound
             let keypair = Keypair::new();
             let to3 = Pubkey::new_rand();
-            let tx_anf = SystemTransaction::new_account(&keypair, &to3, 1, start_hash, 0);
+            let tx_anf = SystemTransaction::new_user_account(&keypair, &to3, 1, start_hash, 0);
 
             // send 'em over
             let packets = to_packets(&[tx_no_ver, tx_anf, tx]);
@@ -671,7 +676,7 @@ mod tests {
 
         // Process a batch that includes a transaction that receives two lamports.
         let alice = Keypair::new();
-        let tx = SystemTransaction::new_account(
+        let tx = SystemTransaction::new_user_account(
             &mint_keypair,
             &alice.pubkey(),
             2,
@@ -685,7 +690,7 @@ mod tests {
             .unwrap();
 
         // Process a second batch that spends one of those lamports.
-        let tx = SystemTransaction::new_account(
+        let tx = SystemTransaction::new_user_account(
             &alice,
             &mint_keypair.pubkey(),
             1,

--- a/core/src/blockstream_service.rs
+++ b/core/src/blockstream_service.rs
@@ -141,7 +141,8 @@ mod test {
 
         let keypair = Keypair::new();
         let mut blockhash = entries[3].hash;
-        let tx = SystemTransaction::new_account(&keypair, &keypair.pubkey(), 1, Hash::default(), 0);
+        let tx =
+            SystemTransaction::new_user_account(&keypair, &keypair.pubkey(), 1, Hash::default(), 0);
         let entry = Entry::new(&mut blockhash, 1, vec![tx]);
         blockhash = entry.hash;
         entries.push(entry);

--- a/core/src/blocktree_processor.rs
+++ b/core/src/blocktree_processor.rs
@@ -421,7 +421,7 @@ mod tests {
         let bank = Bank::new(&genesis_block);
         let keypair = Keypair::new();
         let slot_entries = create_ticks(genesis_block.ticks_per_slot - 1, genesis_block.hash());
-        let tx = SystemTransaction::new_account(
+        let tx = SystemTransaction::new_user_account(
             &mint_keypair,
             &keypair.pubkey(),
             1,
@@ -453,8 +453,13 @@ mod tests {
         for _ in 0..3 {
             // Transfer one token from the mint to a random account
             let keypair = Keypair::new();
-            let tx =
-                SystemTransaction::new_account(&mint_keypair, &keypair.pubkey(), 1, blockhash, 0);
+            let tx = SystemTransaction::new_user_account(
+                &mint_keypair,
+                &keypair.pubkey(),
+                1,
+                blockhash,
+                0,
+            );
             let entry = Entry::new(&last_entry_hash, 1, vec![tx]);
             last_entry_hash = entry.hash;
             entries.push(entry);
@@ -462,7 +467,8 @@ mod tests {
             // Add a second Transaction that will produce a
             // InstructionError<0, ResultWithNegativeLamports> error when processed
             let keypair2 = Keypair::new();
-            let tx = SystemTransaction::new_account(&keypair, &keypair2.pubkey(), 42, blockhash, 0);
+            let tx =
+                SystemTransaction::new_user_account(&keypair, &keypair2.pubkey(), 42, blockhash, 0);
             let entry = Entry::new(&last_entry_hash, 1, vec![tx]);
             last_entry_hash = entry.hash;
             entries.push(entry);
@@ -539,7 +545,7 @@ mod tests {
         let blockhash = bank.last_blockhash();
 
         // ensure bank can process 2 entries that have a common account and no tick is registered
-        let tx = SystemTransaction::new_account(
+        let tx = SystemTransaction::new_user_account(
             &mint_keypair,
             &keypair1.pubkey(),
             2,
@@ -547,7 +553,7 @@ mod tests {
             0,
         );
         let entry_1 = next_entry(&blockhash, 1, vec![tx]);
-        let tx = SystemTransaction::new_account(
+        let tx = SystemTransaction::new_user_account(
             &mint_keypair,
             &keypair2.pubkey(),
             2,
@@ -577,7 +583,7 @@ mod tests {
         let entry_1_to_mint = next_entry(
             &bank.last_blockhash(),
             1,
-            vec![SystemTransaction::new_account(
+            vec![SystemTransaction::new_user_account(
                 &keypair1,
                 &mint_keypair.pubkey(),
                 1,
@@ -590,14 +596,14 @@ mod tests {
             &entry_1_to_mint.hash,
             1,
             vec![
-                SystemTransaction::new_account(
+                SystemTransaction::new_user_account(
                     &keypair2,
                     &keypair3.pubkey(),
                     2,
                     bank.last_blockhash(),
                     0,
                 ), // should be fine
-                SystemTransaction::new_account(
+                SystemTransaction::new_user_account(
                     &keypair1,
                     &mint_keypair.pubkey(),
                     2,
@@ -636,7 +642,7 @@ mod tests {
             &bank.last_blockhash(),
             1,
             vec![
-                SystemTransaction::new_account(
+                SystemTransaction::new_user_account(
                     &keypair1,
                     &mint_keypair.pubkey(),
                     1,
@@ -657,14 +663,14 @@ mod tests {
             &entry_1_to_mint.hash,
             1,
             vec![
-                SystemTransaction::new_account(
+                SystemTransaction::new_user_account(
                     &keypair2,
                     &keypair3.pubkey(),
                     2,
                     bank.last_blockhash(),
                     0,
                 ), // should be fine
-                SystemTransaction::new_account(
+                SystemTransaction::new_user_account(
                     &keypair1,
                     &mint_keypair.pubkey(),
                     2,
@@ -709,7 +715,7 @@ mod tests {
         let keypair4 = Keypair::new();
 
         //load accounts
-        let tx = SystemTransaction::new_account(
+        let tx = SystemTransaction::new_user_account(
             &mint_keypair,
             &keypair1.pubkey(),
             1,
@@ -717,7 +723,7 @@ mod tests {
             0,
         );
         assert_eq!(bank.process_transaction(&tx), Ok(()));
-        let tx = SystemTransaction::new_account(
+        let tx = SystemTransaction::new_user_account(
             &mint_keypair,
             &keypair2.pubkey(),
             1,
@@ -728,7 +734,7 @@ mod tests {
 
         // ensure bank can process 2 entries that do not have a common account and no tick is registered
         let blockhash = bank.last_blockhash();
-        let tx = SystemTransaction::new_account(
+        let tx = SystemTransaction::new_user_account(
             &keypair1,
             &keypair3.pubkey(),
             1,
@@ -736,7 +742,7 @@ mod tests {
             0,
         );
         let entry_1 = next_entry(&blockhash, 1, vec![tx]);
-        let tx = SystemTransaction::new_account(
+        let tx = SystemTransaction::new_user_account(
             &keypair2,
             &keypair4.pubkey(),
             1,
@@ -760,7 +766,7 @@ mod tests {
         let keypair4 = Keypair::new();
 
         //load accounts
-        let tx = SystemTransaction::new_account(
+        let tx = SystemTransaction::new_user_account(
             &mint_keypair,
             &keypair1.pubkey(),
             1,
@@ -768,7 +774,7 @@ mod tests {
             0,
         );
         assert_eq!(bank.process_transaction(&tx), Ok(()));
-        let tx = SystemTransaction::new_account(
+        let tx = SystemTransaction::new_user_account(
             &mint_keypair,
             &keypair2.pubkey(),
             1,
@@ -783,10 +789,11 @@ mod tests {
         }
 
         // ensure bank can process 2 entries that do not have a common account and tick is registered
-        let tx = SystemTransaction::new_account(&keypair2, &keypair3.pubkey(), 1, blockhash, 0);
+        let tx =
+            SystemTransaction::new_user_account(&keypair2, &keypair3.pubkey(), 1, blockhash, 0);
         let entry_1 = next_entry(&blockhash, 1, vec![tx]);
         let tick = next_entry(&entry_1.hash, 1, vec![]);
-        let tx = SystemTransaction::new_account(
+        let tx = SystemTransaction::new_user_account(
             &keypair1,
             &keypair4.pubkey(),
             1,
@@ -802,7 +809,7 @@ mod tests {
         assert_eq!(bank.get_balance(&keypair4.pubkey()), 1);
 
         // ensure that an error is returned for an empty account (keypair2)
-        let tx = SystemTransaction::new_account(
+        let tx = SystemTransaction::new_user_account(
             &keypair2,
             &keypair3.pubkey(),
             1,

--- a/core/src/chacha.rs
+++ b/core/src/chacha.rs
@@ -124,7 +124,7 @@ mod tests {
                 Entry::new_mut(
                     &mut id,
                     &mut num_hashes,
-                    vec![SystemTransaction::new_account(
+                    vec![SystemTransaction::new_user_account(
                         &keypair,
                         &keypair.pubkey(),
                         1,

--- a/core/src/entry.rs
+++ b/core/src/entry.rs
@@ -494,8 +494,8 @@ mod tests {
 
         // First, verify entries
         let keypair = Keypair::new();
-        let tx0 = SystemTransaction::new_account(&keypair, &keypair.pubkey(), 0, zero, 0);
-        let tx1 = SystemTransaction::new_account(&keypair, &keypair.pubkey(), 1, zero, 0);
+        let tx0 = SystemTransaction::new_user_account(&keypair, &keypair.pubkey(), 0, zero, 0);
+        let tx1 = SystemTransaction::new_user_account(&keypair, &keypair.pubkey(), 1, zero, 0);
         let mut e0 = Entry::new(&zero, 0, vec![tx0.clone(), tx1.clone()]);
         assert!(e0.verify(&zero));
 
@@ -545,7 +545,7 @@ mod tests {
     fn test_next_entry_panic() {
         let zero = Hash::default();
         let keypair = Keypair::new();
-        let tx = SystemTransaction::new_account(&keypair, &keypair.pubkey(), 0, zero, 0);
+        let tx = SystemTransaction::new_user_account(&keypair, &keypair.pubkey(), 0, zero, 0);
         next_entry(&zero, 0, vec![tx]);
     }
 
@@ -553,7 +553,7 @@ mod tests {
     fn test_serialized_size() {
         let zero = Hash::default();
         let keypair = Keypair::new();
-        let tx = SystemTransaction::new_account(&keypair, &keypair.pubkey(), 0, zero, 0);
+        let tx = SystemTransaction::new_user_account(&keypair, &keypair.pubkey(), 0, zero, 0);
         let entry = next_entry(&zero, 1, vec![tx.clone()]);
         assert_eq!(
             Entry::serialized_size(&[tx]),

--- a/core/src/fullnode.rs
+++ b/core/src/fullnode.rs
@@ -318,7 +318,7 @@ pub fn make_active_set_entries(
     num_ending_ticks: u64,
 ) -> (Vec<Entry>, Keypair) {
     // 1) Assume the active_keypair node has no lamports staked
-    let transfer_tx = SystemTransaction::new_account(
+    let transfer_tx = SystemTransaction::new_user_account(
         &lamport_source,
         &active_keypair.pubkey(),
         stake,

--- a/core/src/local_cluster.rs
+++ b/core/src/local_cluster.rs
@@ -296,8 +296,13 @@ impl LocalCluster {
     ) -> u64 {
         trace!("getting leader blockhash");
         let blockhash = client.get_recent_blockhash().unwrap();
-        let mut tx =
-            SystemTransaction::new_account(&source_keypair, dest_pubkey, lamports, blockhash, 0);
+        let mut tx = SystemTransaction::new_user_account(
+            &source_keypair,
+            dest_pubkey,
+            lamports,
+            blockhash,
+            0,
+        );
         info!(
             "executing transfer of {} from {} to {}",
             lamports,

--- a/core/src/packet.rs
+++ b/core/src/packet.rs
@@ -612,7 +612,7 @@ mod tests {
     fn test_to_packets() {
         let keypair = Keypair::new();
         let hash = Hash::new(&[1; 32]);
-        let tx = SystemTransaction::new_account(&keypair, &keypair.pubkey(), 1, hash, 0);
+        let tx = SystemTransaction::new_user_account(&keypair, &keypair.pubkey(), 1, hash, 0);
         let rv = to_packets(&vec![tx.clone(); 1]);
         assert_eq!(rv.len(), 1);
         assert_eq!(rv[0].read().unwrap().packets.len(), 1);

--- a/core/src/replicator.rs
+++ b/core/src/replicator.rs
@@ -434,7 +434,7 @@ impl Replicator {
         {
             let blockhash = client.get_recent_blockhash().expect("blockhash");
             //TODO the account space needs to be well defined somewhere
-            let tx = SystemTransaction::new_program_account(
+            let tx = SystemTransaction::new_account(
                 keypair,
                 &storage_keypair.pubkey(),
                 blockhash,

--- a/core/src/rpc_pubsub.rs
+++ b/core/src/rpc_pubsub.rs
@@ -354,7 +354,8 @@ mod tests {
         let (subscriber, _id_receiver, mut receiver) = Subscriber::new_test("accountNotification");
         rpc.account_subscribe(session, subscriber, contract_state.pubkey().to_string());
 
-        let tx = SystemTransaction::new_account(&alice, &contract_funds.pubkey(), 51, blockhash, 0);
+        let tx =
+            SystemTransaction::new_user_account(&alice, &contract_funds.pubkey(), 51, blockhash, 0);
         let arc_bank = process_transaction_and_notify(&arc_bank, &tx, &rpc.subscriptions).unwrap();
 
         let ixs = BudgetInstruction::new_when_signed(
@@ -390,7 +391,7 @@ mod tests {
             assert_eq!(serde_json::to_string(&expected).unwrap(), response);
         }
 
-        let tx = SystemTransaction::new_account(&alice, &witness.pubkey(), 1, blockhash, 0);
+        let tx = SystemTransaction::new_user_account(&alice, &witness.pubkey(), 1, blockhash, 0);
         let arc_bank = process_transaction_and_notify(&arc_bank, &tx, &rpc.subscriptions).unwrap();
         sleep(Duration::from_millis(200));
         let ix = BudgetInstruction::new_apply_signature(

--- a/core/src/rpc_subscriptions.rs
+++ b/core/src/rpc_subscriptions.rs
@@ -211,7 +211,7 @@ mod tests {
         let bank = Bank::new(&genesis_block);
         let alice = Keypair::new();
         let blockhash = bank.last_blockhash();
-        let tx = SystemTransaction::new_program_account(
+        let tx = SystemTransaction::new_account(
             &mint_keypair,
             &alice.pubkey(),
             blockhash,
@@ -257,7 +257,7 @@ mod tests {
         let bank = Bank::new(&genesis_block);
         let alice = Keypair::new();
         let blockhash = bank.last_blockhash();
-        let tx = SystemTransaction::new_program_account(
+        let tx = SystemTransaction::new_account(
             &mint_keypair,
             &alice.pubkey(),
             blockhash,

--- a/core/src/storage_stage.rs
+++ b/core/src/storage_stage.rs
@@ -279,7 +279,7 @@ impl StorageStage {
             if let Some(account) = account_to_create {
                 if client.get_account_data(&account).is_err() {
                     // TODO the account space needs to be well defined somewhere
-                    let tx = SystemTransaction::new_program_account(
+                    let tx = SystemTransaction::new_account(
                         keypair,
                         &storage_keypair.pubkey(),
                         blockhash,

--- a/core/src/test_tx.rs
+++ b/core/src/test_tx.rs
@@ -10,7 +10,7 @@ pub fn test_tx() -> Transaction {
     let keypair1 = Keypair::new();
     let pubkey1 = keypair1.pubkey();
     let zero = Hash::default();
-    SystemTransaction::new_account(&keypair1, &pubkey1, 42, zero, 0)
+    SystemTransaction::new_user_account(&keypair1, &pubkey1, 42, zero, 0)
 }
 
 pub fn test_multisig_tx() -> Transaction {

--- a/core/tests/tvu.rs
+++ b/core/tests/tvu.rs
@@ -140,7 +140,7 @@ fn test_replay() {
             let entry0 = next_entry_mut(&mut cur_hash, i, vec![]);
             let entry_tick0 = next_entry_mut(&mut cur_hash, i + 1, vec![]);
 
-            let tx0 = SystemTransaction::new_account(
+            let tx0 = SystemTransaction::new_user_account(
                 &mint_keypair,
                 &bob_keypair.pubkey(),
                 transfer_amount,

--- a/drone/src/drone.rs
+++ b/drone/src/drone.rs
@@ -127,8 +127,11 @@ impl Drone {
 
                     info!("Requesting airdrop of {} to {:?}", lamports, to);
 
-                    let create_instruction =
-                        SystemInstruction::new_account(&self.mint_keypair.pubkey(), &to, lamports);
+                    let create_instruction = SystemInstruction::new_user_account(
+                        &self.mint_keypair.pubkey(),
+                        &to,
+                        lamports,
+                    );
                     let message = Message::new(vec![create_instruction]);
                     Ok(Transaction::new(&[&self.mint_keypair], message, blockhash))
                 } else {
@@ -390,7 +393,8 @@ mod tests {
         bytes.put(&req[..]);
 
         let keypair = Keypair::new();
-        let expected_instruction = SystemInstruction::new_account(&keypair.pubkey(), &to, lamports);
+        let expected_instruction =
+            SystemInstruction::new_user_account(&keypair.pubkey(), &to, lamports);
         let message = Message::new(vec![expected_instruction]);
         let expected_tx = Transaction::new(&[&keypair], message, blockhash);
         let expected_bytes = serialize(&expected_tx).unwrap();

--- a/drone/src/drone_mock.rs
+++ b/drone/src/drone_mock.rs
@@ -18,6 +18,6 @@ pub fn request_airdrop_transaction(
     let key = Keypair::new();
     let to = Pubkey::new_rand();
     let blockhash = Hash::default();
-    let tx = SystemTransaction::new_account(&key, &to, lamports, blockhash, 0);
+    let tx = SystemTransaction::new_user_account(&key, &to, lamports, blockhash, 0);
     Ok(tx)
 }

--- a/drone/tests/local-drone.rs
+++ b/drone/tests/local-drone.rs
@@ -13,7 +13,7 @@ fn test_local_drone() {
     let to = Pubkey::new_rand();
     let lamports = 50;
     let blockhash = Hash::new(&to.as_ref());
-    let create_instruction = SystemInstruction::new_account(&keypair.pubkey(), &to, lamports);
+    let create_instruction = SystemInstruction::new_user_account(&keypair.pubkey(), &to, lamports);
     let message = Message::new(vec![create_instruction]);
     let expected_tx = Transaction::new(&[&keypair], message, blockhash);
 

--- a/programs/budget_api/src/budget_instruction.rs
+++ b/programs/budget_api/src/budget_instruction.rs
@@ -51,7 +51,7 @@ impl BudgetInstruction {
         }
         let space = serialized_size(&BudgetState::new(expr.clone())).unwrap();
         vec![
-            SystemInstruction::new_program_account(&from, contract, lamports, space, &id()),
+            SystemInstruction::new_account(&from, contract, lamports, space, &id()),
             BudgetInstruction::new_initialize_account(contract, expr),
         ]
     }

--- a/programs/config_api/src/config_instruction.rs
+++ b/programs/config_api/src/config_instruction.rs
@@ -13,7 +13,7 @@ impl ConfigInstruction {
         config_account_pubkey: &Pubkey,
         lamports: u64,
     ) -> Instruction {
-        SystemInstruction::new_program_account(
+        SystemInstruction::new_account(
             from_account_pubkey,
             config_account_pubkey,
             lamports,

--- a/programs/exchange_api/src/exchange_processor.rs
+++ b/programs/exchange_api/src/exchange_processor.rs
@@ -527,7 +527,7 @@ mod test {
 
     fn create_account(client: &BankClient, owner: &Keypair) -> Pubkey {
         let new = Pubkey::new_rand();
-        let instruction = SystemInstruction::new_program_account(
+        let instruction = SystemInstruction::new_account(
             &owner.pubkey(),
             &new,
             1,
@@ -542,7 +542,7 @@ mod test {
 
     fn create_token_account(client: &BankClient, owner: &Keypair) -> Pubkey {
         let new = Pubkey::new_rand();
-        let instruction = SystemInstruction::new_program_account(
+        let instruction = SystemInstruction::new_account(
             &owner.pubkey(),
             &new,
             1,

--- a/programs/exchange_api/src/exchange_transaction.rs
+++ b/programs/exchange_api/src/exchange_transaction.rs
@@ -19,7 +19,7 @@ impl ExchangeTransaction {
     ) -> Transaction {
         let owner_id = &owner.pubkey();
         let space = mem::size_of::<ExchangeState>() as u64;
-        let create_ix = SystemInstruction::new_program_account(owner_id, new, 1, space, &id());
+        let create_ix = SystemInstruction::new_account(owner_id, new, 1, space, &id());
         let request_ix = ExchangeInstruction::new_account_request(owner_id, new);
         Transaction::new_signed_instructions(
             &[owner],
@@ -58,7 +58,7 @@ impl ExchangeTransaction {
     ) -> Transaction {
         let owner_id = &owner.pubkey();
         let space = mem::size_of::<ExchangeState>() as u64;
-        let create_ix = SystemInstruction::new_program_account(owner_id, trade, 1, space, &id());
+        let create_ix = SystemInstruction::new_account(owner_id, trade, 1, space, &id());
         let request_ix = ExchangeInstruction::new_trade_request(
             owner_id,
             trade,
@@ -101,7 +101,7 @@ impl ExchangeTransaction {
     ) -> Transaction {
         let owner_id = &owner.pubkey();
         let space = mem::size_of::<ExchangeState>() as u64;
-        let create_ix = SystemInstruction::new_program_account(owner_id, swap, 1, space, &id());
+        let create_ix = SystemInstruction::new_account(owner_id, swap, 1, space, &id());
         let request_ix = ExchangeInstruction::new_swap_request(
             owner_id,
             swap,

--- a/programs/stake_api/src/stake_instruction.rs
+++ b/programs/stake_api/src/stake_instruction.rs
@@ -24,7 +24,7 @@ pub enum StakeInstruction {
 
 impl StakeInstruction {
     pub fn new_account(from_id: &Pubkey, staker_id: &Pubkey, lamports: u64) -> Vec<Instruction> {
-        vec![SystemInstruction::new_program_account(
+        vec![SystemInstruction::new_account(
             from_id,
             staker_id,
             lamports,

--- a/programs/storage_api/src/storage_processor.rs
+++ b/programs/storage_api/src/storage_processor.rs
@@ -386,8 +386,7 @@ mod tests {
             .transfer(10, &alice_keypair, &jack_pubkey)
             .unwrap();
 
-        let ix =
-            SystemInstruction::new_program_account(&alice_pubkey, &bob_pubkey, 1, 4 * 1024, &id());
+        let ix = SystemInstruction::new_account(&alice_pubkey, &bob_pubkey, 1, 4 * 1024, &id());
 
         bank_client.process_instruction(&alice_keypair, ix).unwrap();
 

--- a/programs/vote_api/src/vote_instruction.rs
+++ b/programs/vote_api/src/vote_instruction.rs
@@ -45,8 +45,7 @@ impl VoteInstruction {
 
     pub fn new_account(from_id: &Pubkey, staker_id: &Pubkey, lamports: u64) -> Vec<Instruction> {
         let space = VoteState::max_size() as u64;
-        let create_ix =
-            SystemInstruction::new_program_account(&from_id, staker_id, lamports, space, &id());
+        let create_ix = SystemInstruction::new_account(&from_id, staker_id, lamports, space, &id());
         let init_ix = VoteInstruction::new_initialize_account(staker_id);
         vec![create_ix, init_ix]
     }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -777,7 +777,7 @@ impl Bank {
     /// `n` lamports where `blockhash` is the last Entry ID observed by the client.
     pub fn transfer(&self, n: u64, keypair: &Keypair, to: &Pubkey) -> Result<Signature> {
         let blockhash = self.last_blockhash();
-        let tx = SystemTransaction::new_account(keypair, to, n, blockhash, 0);
+        let tx = SystemTransaction::new_user_account(keypair, to, n, blockhash, 0);
         let signature = tx.signatures[0];
         self.process_transaction(&tx).map(|_| signature)
     }
@@ -1098,7 +1098,7 @@ mod tests {
         let dest = Keypair::new();
 
         // source with 0 program context
-        let tx = SystemTransaction::new_account(
+        let tx = SystemTransaction::new_user_account(
             &mint_keypair,
             &dest.pubkey(),
             2,
@@ -1267,14 +1267,14 @@ mod tests {
         let (genesis_block, mint_keypair) = GenesisBlock::new(2);
         let bank = Bank::new(&genesis_block);
         let keypair = Keypair::new();
-        let tx0 = SystemTransaction::new_account(
+        let tx0 = SystemTransaction::new_user_account(
             &mint_keypair,
             &keypair.pubkey(),
             2,
             genesis_block.hash(),
             0,
         );
-        let tx1 = SystemTransaction::new_account(
+        let tx1 = SystemTransaction::new_user_account(
             &keypair,
             &mint_keypair.pubkey(),
             1,
@@ -1307,7 +1307,7 @@ mod tests {
         let alice = Keypair::new();
         let bob = Keypair::new();
 
-        let tx1 = SystemTransaction::new_account(
+        let tx1 = SystemTransaction::new_user_account(
             &mint_keypair,
             &alice.pubkey(),
             1,

--- a/runtime/src/loader_utils.rs
+++ b/runtime/src/loader_utils.rs
@@ -15,7 +15,7 @@ pub fn load_program(
     let program_keypair = Keypair::new();
     let program_pubkey = program_keypair.pubkey();
 
-    let instruction = SystemInstruction::new_program_account(
+    let instruction = SystemInstruction::new_account(
         &from_keypair.pubkey(),
         &program_pubkey,
         1,

--- a/sdk/src/system_instruction.rs
+++ b/sdk/src/system_instruction.rs
@@ -32,7 +32,7 @@ pub enum SystemInstruction {
 }
 
 impl SystemInstruction {
-    pub fn new_program_account(
+    pub fn new_account(
         from_id: &Pubkey,
         to_id: &Pubkey,
         lamports: u64,
@@ -55,9 +55,9 @@ impl SystemInstruction {
     }
 
     /// Create and sign a transaction to create a system account
-    pub fn new_account(from_id: &Pubkey, to_id: &Pubkey, lamports: u64) -> Instruction {
+    pub fn new_user_account(from_id: &Pubkey, to_id: &Pubkey, lamports: u64) -> Instruction {
         let program_id = system_program::id();
-        Self::new_program_account(from_id, to_id, lamports, 0, &program_id)
+        Self::new_account(from_id, to_id, lamports, 0, &program_id)
     }
 
     pub fn new_assign(from_id: &Pubkey, program_id: &Pubkey) -> Instruction {

--- a/sdk/src/system_transaction.rs
+++ b/sdk/src/system_transaction.rs
@@ -11,7 +11,7 @@ pub struct SystemTransaction {}
 
 impl SystemTransaction {
     /// Create and sign new SystemInstruction::CreateAccount transaction
-    pub fn new_program_account(
+    pub fn new_account(
         from_keypair: &Keypair,
         to: &Pubkey,
         recent_blockhash: Hash,
@@ -22,13 +22,13 @@ impl SystemTransaction {
     ) -> Transaction {
         let from_pubkey = from_keypair.pubkey();
         let create_instruction =
-            SystemInstruction::new_program_account(&from_pubkey, to, lamports, space, program_id);
+            SystemInstruction::new_account(&from_pubkey, to, lamports, space, program_id);
         let instructions = vec![create_instruction];
         Transaction::new_signed_instructions(&[from_keypair], instructions, recent_blockhash)
     }
 
     /// Create and sign a transaction to create a system account
-    pub fn new_account(
+    pub fn new_user_account(
         from_keypair: &Keypair,
         to: &Pubkey,
         lamports: u64,
@@ -36,7 +36,7 @@ impl SystemTransaction {
         fee: u64,
     ) -> Transaction {
         let program_id = system_program::id();
-        Self::new_program_account(
+        Self::new_account(
             from_keypair,
             to,
             recent_blockhash,

--- a/tests/thin_client.rs
+++ b/tests/thin_client.rs
@@ -32,7 +32,7 @@ pub fn transfer(
         to,
         blockhash
     );
-    let transaction = SystemTransaction::new_account(keypair, to, lamports, *blockhash, 0);
+    let transaction = SystemTransaction::new_user_account(keypair, to, lamports, *blockhash, 0);
     thin_client.transfer_signed(&transaction)
 }
 
@@ -76,13 +76,13 @@ fn test_bad_sig() {
 
     let blockhash = client.get_recent_blockhash().unwrap();
 
-    let tx = SystemTransaction::new_account(&alice, &bob_pubkey, 500, blockhash, 0);
+    let tx = SystemTransaction::new_user_account(&alice, &bob_pubkey, 500, blockhash, 0);
 
     let _sig = client.transfer_signed(&tx).unwrap();
 
     let blockhash = client.get_recent_blockhash().unwrap();
 
-    let mut tr2 = SystemTransaction::new_account(&alice, &bob_pubkey, 501, blockhash, 0);
+    let mut tr2 = SystemTransaction::new_user_account(&alice, &bob_pubkey, 501, blockhash, 0);
     let mut instruction2 = deserialize(tr2.data(0)).unwrap();
     if let SystemInstruction::Move { ref mut lamports } = instruction2 {
         *lamports = 502;

--- a/wallet/src/wallet.rs
+++ b/wallet/src/wallet.rs
@@ -390,7 +390,7 @@ fn process_deploy(
         )
     })?;
 
-    let mut tx = SystemTransaction::new_program_account(
+    let mut tx = SystemTransaction::new_account(
         &config.keypair,
         &program_id.pubkey(),
         blockhash,


### PR DESCRIPTION
#### Problem

The term "program" in the function name "new_program_account" is confusing. A "program account" isn't a thing. It's an account where some instruction processor identified by `Account::program_id` knows how to parse and interpret `Account::data`.  Furthermore, a user account is a special case that's currently constructed using the generic name `new_account()`.

#### Summary of Changes

* Rename 'new_account' to 'new_user_account'
* Rename 'new_program_account' to 'new_account'

