### PR TITLE
Rename SystemInstruction::Move to SystemInstruction::Transfer

### DIFF
--- a/bench-tps/src/bench.rs
+++ b/bench-tps/src/bench.rs
@@ -551,10 +551,9 @@ fn fund_keys(client: &ThinClient, source: &Keypair, dests: &[Keypair], lamports:
                 .map(|(k, m)| {
                     (
                         k.clone(),
-                        Transaction::new_unsigned_instructions(SystemInstruction::new_move_many(
-                            &k.pubkey(),
-                            &m,
-                        )),
+                        Transaction::new_unsigned_instructions(
+                            SystemInstruction::new_transfer_many(&k.pubkey(), &m),
+                        ),
                     )
                 })
                 .collect();

--- a/core/benches/banking_stage.rs
+++ b/core/benches/banking_stage.rs
@@ -56,7 +56,7 @@ fn bench_banking_stage_multi_accounts(bencher: &mut Bencher) {
 
     let (verified_sender, verified_receiver) = channel();
     let bank = Arc::new(Bank::new(&genesis_block));
-    let dummy = SystemTransaction::new_move(
+    let dummy = SystemTransaction::new_transfer(
         &mint_keypair,
         &mint_keypair.pubkey(),
         1,
@@ -78,7 +78,7 @@ fn bench_banking_stage_multi_accounts(bencher: &mut Bencher) {
         .collect();
     // fund all the accounts
     transactions.iter().for_each(|tx| {
-        let fund = SystemTransaction::new_move(
+        let fund = SystemTransaction::new_transfer(
             &mint_keypair,
             &tx.message.account_keys[0],
             mint_total / txes as u64,
@@ -156,7 +156,7 @@ fn bench_banking_stage_multi_programs(bencher: &mut Bencher) {
 
     let (verified_sender, verified_receiver) = channel();
     let bank = Arc::new(Bank::new(&genesis_block));
-    let dummy = SystemTransaction::new_move(
+    let dummy = SystemTransaction::new_transfer(
         &mint_keypair,
         &mint_keypair.pubkey(),
         1,
@@ -194,7 +194,7 @@ fn bench_banking_stage_multi_programs(bencher: &mut Bencher) {
         })
         .collect();
     transactions.iter().for_each(|tx| {
-        let fund = SystemTransaction::new_move(
+        let fund = SystemTransaction::new_transfer(
             &mint_keypair,
             &tx.message.account_keys[0],
             mint_total / txes as u64,

--- a/core/benches/ledger.rs
+++ b/core/benches/ledger.rs
@@ -13,7 +13,7 @@ fn bench_block_to_blobs_to_block(bencher: &mut Bencher) {
     let zero = Hash::default();
     let one = hash(&zero.as_ref());
     let keypair = Keypair::new();
-    let tx0 = SystemTransaction::new_move(&keypair, &keypair.pubkey(), 1, one, 0);
+    let tx0 = SystemTransaction::new_transfer(&keypair, &keypair.pubkey(), 1, one, 0);
     let transactions = vec![tx0; 10];
     let entries = next_entries(&zero, 1, transactions);
 

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -783,8 +783,8 @@ mod tests {
             let pubkey = Pubkey::new_rand();
 
             let transactions = vec![
-                SystemTransaction::new_move(&mint_keypair, &pubkey, 1, genesis_block.hash(), 0),
-                SystemTransaction::new_move(&mint_keypair, &pubkey, 1, genesis_block.hash(), 0),
+                SystemTransaction::new_transfer(&mint_keypair, &pubkey, 1, genesis_block.hash(), 0),
+                SystemTransaction::new_transfer(&mint_keypair, &pubkey, 1, genesis_block.hash(), 0),
             ];
 
             let mut results = vec![Ok(()), Ok(())];
@@ -820,7 +820,7 @@ mod tests {
         let bank = Arc::new(Bank::new(&genesis_block));
         let pubkey = Pubkey::new_rand();
 
-        let transactions = vec![SystemTransaction::new_move(
+        let transactions = vec![SystemTransaction::new_transfer(
             &mint_keypair,
             &pubkey,
             1,
@@ -873,7 +873,7 @@ mod tests {
 
             assert_eq!(done, true);
 
-            let transactions = vec![SystemTransaction::new_move(
+            let transactions = vec![SystemTransaction::new_transfer(
                 &mint_keypair,
                 &pubkey,
                 2,

--- a/core/src/blockstream.rs
+++ b/core/src/blockstream.rs
@@ -183,8 +183,10 @@ mod test {
 
         let keypair0 = Keypair::new();
         let keypair1 = Keypair::new();
-        let tx0 = SystemTransaction::new_move(&keypair0, &keypair1.pubkey(), 1, Hash::default(), 0);
-        let tx1 = SystemTransaction::new_move(&keypair1, &keypair0.pubkey(), 2, Hash::default(), 0);
+        let tx0 =
+            SystemTransaction::new_transfer(&keypair0, &keypair1.pubkey(), 1, Hash::default(), 0);
+        let tx1 =
+            SystemTransaction::new_transfer(&keypair1, &keypair0.pubkey(), 2, Hash::default(), 0);
         let serialized_tx0 = serialize(&tx0).unwrap();
         let serialized_tx1 = serialize(&tx1).unwrap();
         let entry = Entry::new(&Hash::default(), 1, vec![tx0, tx1]);

--- a/core/src/blocktree_processor.rs
+++ b/core/src/blocktree_processor.rs
@@ -649,7 +649,7 @@ mod tests {
                     bank.last_blockhash(),
                     0,
                 ),
-                SystemTransaction::new_move(
+                SystemTransaction::new_transfer(
                     &keypair4,
                     &keypair4.pubkey(),
                     1,

--- a/core/src/cluster_tests.rs
+++ b/core/src/cluster_tests.rs
@@ -37,7 +37,7 @@ pub fn spend_and_verify_all_nodes(
             .poll_get_balance(&funding_keypair.pubkey())
             .expect("balance in source");
         assert!(bal > 0);
-        let mut transaction = SystemTransaction::new_move(
+        let mut transaction = SystemTransaction::new_transfer(
             &funding_keypair,
             &random_keypair.pubkey(),
             1,
@@ -63,7 +63,7 @@ pub fn send_many_transactions(node: &ContactInfo, funding_keypair: &Keypair, num
             .poll_get_balance(&funding_keypair.pubkey())
             .expect("balance in source");
         assert!(bal > 0);
-        let mut transaction = SystemTransaction::new_move(
+        let mut transaction = SystemTransaction::new_transfer(
             &funding_keypair,
             &random_keypair.pubkey(),
             1,
@@ -183,7 +183,7 @@ pub fn kill_entry_and_spend_and_verify_rest(
             }
 
             let random_keypair = Keypair::new();
-            let mut transaction = SystemTransaction::new_move(
+            let mut transaction = SystemTransaction::new_transfer(
                 &funding_keypair,
                 &random_keypair.pubkey(),
                 1,

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -463,7 +463,7 @@ mod tests {
         let exit = Arc::new(AtomicBool::new(false));
 
         let blockhash = bank.last_blockhash();
-        let tx = SystemTransaction::new_move(&alice, pubkey, 20, blockhash, 0);
+        let tx = SystemTransaction::new_transfer(&alice, pubkey, 20, blockhash, 0);
         bank.process_transaction(&tx).expect("process transaction");
 
         let request_processor = Arc::new(RwLock::new(JsonRpcRequestProcessor::new(
@@ -503,7 +503,7 @@ mod tests {
         );
         thread::spawn(move || {
             let blockhash = bank.last_blockhash();
-            let tx = SystemTransaction::new_move(&alice, &bob_pubkey, 20, blockhash, 0);
+            let tx = SystemTransaction::new_transfer(&alice, &bob_pubkey, 20, blockhash, 0);
             bank.process_transaction(&tx).expect("process transaction");
         })
         .join()
@@ -575,7 +575,7 @@ mod tests {
     fn test_rpc_confirm_tx() {
         let bob_pubkey = Pubkey::new_rand();
         let (io, meta, blockhash, alice) = start_rpc_handler_with_tx(&bob_pubkey);
-        let tx = SystemTransaction::new_move(&alice, &bob_pubkey, 20, blockhash, 0);
+        let tx = SystemTransaction::new_transfer(&alice, &bob_pubkey, 20, blockhash, 0);
 
         let req = format!(
             r#"{{"jsonrpc":"2.0","id":1,"method":"confirmTransaction","params":["{}"]}}"#,
@@ -594,7 +594,7 @@ mod tests {
     fn test_rpc_get_signature_status() {
         let bob_pubkey = Pubkey::new_rand();
         let (io, meta, blockhash, alice) = start_rpc_handler_with_tx(&bob_pubkey);
-        let tx = SystemTransaction::new_move(&alice, &bob_pubkey, 20, blockhash, 0);
+        let tx = SystemTransaction::new_transfer(&alice, &bob_pubkey, 20, blockhash, 0);
 
         let req = format!(
             r#"{{"jsonrpc":"2.0","id":1,"method":"getSignatureStatus","params":["{}"]}}"#,
@@ -609,7 +609,7 @@ mod tests {
         assert_eq!(expected, result);
 
         // Test getSignatureStatus request on unprocessed tx
-        let tx = SystemTransaction::new_move(&alice, &bob_pubkey, 10, blockhash, 0);
+        let tx = SystemTransaction::new_transfer(&alice, &bob_pubkey, 10, blockhash, 0);
         let req = format!(
             r#"{{"jsonrpc":"2.0","id":1,"method":"getSignatureStatus","params":["{}"]}}"#,
             tx.signatures[0]
@@ -716,8 +716,13 @@ mod tests {
 
     #[test]
     fn test_rpc_verify_signature() {
-        let tx =
-            SystemTransaction::new_move(&Keypair::new(), &Pubkey::new_rand(), 20, hash(&[0]), 0);
+        let tx = SystemTransaction::new_transfer(
+            &Keypair::new(),
+            &Pubkey::new_rand(),
+            20,
+            hash(&[0]),
+            0,
+        );
         assert_eq!(
             verify_signature(&tx.signatures[0].to_string()).unwrap(),
             tx.signatures[0]

--- a/core/src/rpc_pubsub.rs
+++ b/core/src/rpc_pubsub.rs
@@ -270,7 +270,7 @@ mod tests {
         let rpc = RpcSolPubSubImpl::default();
 
         // Test signature subscriptions
-        let tx = SystemTransaction::new_move(&alice, &bob_pubkey, 20, blockhash, 0);
+        let tx = SystemTransaction::new_transfer(&alice, &bob_pubkey, 20, blockhash, 0);
 
         let session = create_session();
         let (subscriber, _id_receiver, mut receiver) =
@@ -302,7 +302,7 @@ mod tests {
         let rpc = RpcSolPubSubImpl::default();
         io.extend_with(rpc.to_delegate());
 
-        let tx = SystemTransaction::new_move(&alice, &bob_pubkey, 20, blockhash, 0);
+        let tx = SystemTransaction::new_transfer(&alice, &bob_pubkey, 20, blockhash, 0);
         let req = format!(
             r#"{{"jsonrpc":"2.0","id":1,"method":"signatureSubscribe","params":["{}"]}}"#,
             tx.signatures[0].to_string()

--- a/core/src/rpc_subscriptions.rs
+++ b/core/src/rpc_subscriptions.rs
@@ -302,7 +302,7 @@ mod tests {
         let bank = Bank::new(&genesis_block);
         let alice = Keypair::new();
         let blockhash = bank.last_blockhash();
-        let tx = SystemTransaction::new_move(&mint_keypair, &alice.pubkey(), 20, blockhash, 0);
+        let tx = SystemTransaction::new_transfer(&mint_keypair, &alice.pubkey(), 20, blockhash, 0);
         let signature = tx.signatures[0];
         bank.process_transaction(&tx).unwrap();
 

--- a/core/src/test_tx.rs
+++ b/core/src/test_tx.rs
@@ -20,7 +20,7 @@ pub fn test_multisig_tx() -> Transaction {
     let lamports = 5;
     let blockhash = Hash::default();
 
-    let system_instruction = SystemInstruction::Move { lamports };
+    let system_instruction = SystemInstruction::Transfer { lamports };
 
     let program_ids = vec![system_program::id(), solana_budget_api::id()];
 

--- a/core/tests/rpc.rs
+++ b/core/tests/rpc.rs
@@ -41,7 +41,7 @@ fn test_rpc_send_tx() {
     let blockhash = Hash::new(&blockhash_vec);
 
     info!("blockhash: {:?}", blockhash);
-    let tx = SystemTransaction::new_move(&alice, &bob_pubkey, 20, blockhash, 0);
+    let tx = SystemTransaction::new_transfer(&alice, &bob_pubkey, 20, blockhash, 0);
     let serial_tx = serialize(&tx).unwrap();
 
     let client = reqwest::Client::new();

--- a/programs/config_api/src/config_processor.rs
+++ b/programs/config_api/src/config_processor.rs
@@ -155,7 +155,8 @@ mod tests {
         bank.transfer(42, &mint_keypair, &system_pubkey).unwrap();
         let (bank_client, from_keypair, config_keypair) = create_config_client(&bank, mint_keypair);
 
-        let move_instruction = SystemInstruction::new_move(&system_pubkey, &Pubkey::default(), 42);
+        let move_instruction =
+            SystemInstruction::new_transfer(&system_pubkey, &Pubkey::default(), 42);
         let my_config = MyConfig::new(42);
         let mut store_instruction = ConfigInstruction::new_store(
             &from_keypair.pubkey(),

--- a/programs/vote_api/src/vote_processor.rs
+++ b/programs/vote_api/src/vote_processor.rs
@@ -148,7 +148,7 @@ mod tests {
         // Sneak in an instruction so that the transaction is signed but
         // the 0th account in the second instruction is not! The program
         // needs to check that it's signed.
-        let move_ix = SystemInstruction::new_move(&mallory_id, &vote_id, 1);
+        let move_ix = SystemInstruction::new_transfer(&mallory_id, &vote_id, 1);
         let message = Message::new(vec![move_ix, vote_ix]);
         let result = bank_client.process_message(&[&mallory_keypair], message);
 

--- a/runtime/benches/bank.rs
+++ b/runtime/benches/bank.rs
@@ -21,7 +21,7 @@ fn bench_process_transaction(bencher: &mut Bencher) {
         .map(|_| {
             // Seed the 'from' account.
             let rando0 = Keypair::new();
-            let tx = SystemTransaction::new_move(
+            let tx = SystemTransaction::new_transfer(
                 &mint_keypair,
                 &rando0.pubkey(),
                 10_000,
@@ -32,8 +32,13 @@ fn bench_process_transaction(bencher: &mut Bencher) {
 
             // Seed the 'to' account and a cell for its signature.
             let rando1 = Keypair::new();
-            let tx =
-                SystemTransaction::new_move(&rando0, &rando1.pubkey(), 1, bank.last_blockhash(), 0);
+            let tx = SystemTransaction::new_transfer(
+                &rando0,
+                &rando1.pubkey(),
+                1,
+                bank.last_blockhash(),
+                0,
+            );
             assert_eq!(bank.process_transaction(&tx), Ok(()));
 
             // Finally, return the transaction to the benchmark.

--- a/runtime/src/bank_client.rs
+++ b/runtime/src/bank_client.rs
@@ -42,7 +42,7 @@ impl<'a> BankClient<'a> {
         keypair: &Keypair,
         pubkey: &Pubkey,
     ) -> Result<(), TransactionError> {
-        let move_instruction = SystemInstruction::new_move(&keypair.pubkey(), pubkey, lamports);
+        let move_instruction = SystemInstruction::new_transfer(&keypair.pubkey(), pubkey, lamports);
         self.process_instruction(keypair, move_instruction)
     }
 }
@@ -63,9 +63,9 @@ mod tests {
         let bank = Bank::new(&genesis_block);
         let bank_client = BankClient::new(&bank);
 
-        // Create 2-2 Multisig Move instruction.
+        // Create 2-2 Multisig Transfer instruction.
         let bob_pubkey = Pubkey::new_rand();
-        let mut move_instruction = SystemInstruction::new_move(&john_pubkey, &bob_pubkey, 42);
+        let mut move_instruction = SystemInstruction::new_transfer(&john_pubkey, &bob_pubkey, 42);
         move_instruction
             .accounts
             .push(AccountMeta::new(jane_pubkey, true));

--- a/runtime/src/system_instruction_processor.rs
+++ b/runtime/src/system_instruction_processor.rs
@@ -54,7 +54,7 @@ fn assign_account_to_program(
 fn move_lamports(keyed_accounts: &mut [KeyedAccount], lamports: u64) -> Result<(), SystemError> {
     if lamports > keyed_accounts[FROM_ACCOUNT_INDEX].account.lamports {
         debug!(
-            "Move: insufficient lamports ({}, need {})",
+            "Transfer: insufficient lamports ({}, need {})",
             keyed_accounts[FROM_ACCOUNT_INDEX].account.lamports, lamports
         );
         Err(SystemError::ResultWithNegativeLamports)?;
@@ -92,7 +92,7 @@ pub fn process_instruction(
                 }
                 assign_account_to_program(keyed_accounts, &program_id)
             }
-            SystemInstruction::Move { lamports } => move_lamports(keyed_accounts, lamports),
+            SystemInstruction::Transfer { lamports } => move_lamports(keyed_accounts, lamports),
         }
         .map_err(|e| InstructionError::CustomError(serialize(&e).unwrap()))
     } else {
@@ -297,7 +297,7 @@ mod tests {
         ];
         let malicious_instruction = Instruction::new(
             system_program::id(),
-            &SystemInstruction::Move { lamports: 10 },
+            &SystemInstruction::Transfer { lamports: 10 },
             account_metas,
         );
         assert_eq!(

--- a/sdk/src/fee_calculator.rs
+++ b/sdk/src/fee_calculator.rs
@@ -35,13 +35,13 @@ mod tests {
         // One signature, a fee.
         let pubkey0 = Pubkey::new(&[0; 32]);
         let pubkey1 = Pubkey::new(&[1; 32]);
-        let ix0 = SystemInstruction::new_move(&pubkey0, &pubkey1, 1);
+        let ix0 = SystemInstruction::new_transfer(&pubkey0, &pubkey1, 1);
         let message = Message::new(vec![ix0]);
         assert_eq!(FeeCalculator::new(2).calculate_fee(&message), 2);
 
         // Two signatures, double the fee.
-        let ix0 = SystemInstruction::new_move(&pubkey0, &pubkey1, 1);
-        let ix1 = SystemInstruction::new_move(&pubkey1, &pubkey0, 1);
+        let ix0 = SystemInstruction::new_transfer(&pubkey0, &pubkey1, 1);
+        let ix1 = SystemInstruction::new_transfer(&pubkey1, &pubkey0, 1);
         let message = Message::new(vec![ix0, ix1]);
         assert_eq!(FeeCalculator::new(2).calculate_fee(&message), 4);
     }

--- a/sdk/src/system_instruction.rs
+++ b/sdk/src/system_instruction.rs
@@ -25,10 +25,10 @@ pub enum SystemInstruction {
     /// Assign account to a program
     /// * Transaction::keys[0] - account to assign
     Assign { program_id: Pubkey },
-    /// Move lamports
+    /// Transfer lamports
     /// * Transaction::keys[0] - source
     /// * Transaction::keys[1] - destination
-    Move { lamports: u64 },
+    Transfer { lamports: u64 },
 }
 
 impl SystemInstruction {
@@ -71,23 +71,23 @@ impl SystemInstruction {
         )
     }
 
-    pub fn new_move(from_id: &Pubkey, to_id: &Pubkey, lamports: u64) -> Instruction {
+    pub fn new_transfer(from_id: &Pubkey, to_id: &Pubkey, lamports: u64) -> Instruction {
         let account_metas = vec![
             AccountMeta::new(*from_id, true),
             AccountMeta::new(*to_id, false),
         ];
         Instruction::new(
             system_program::id(),
-            &SystemInstruction::Move { lamports },
+            &SystemInstruction::Transfer { lamports },
             account_metas,
         )
     }
 
-    /// Create and sign new SystemInstruction::Move transaction to many destinations
-    pub fn new_move_many(from_id: &Pubkey, to_lamports: &[(Pubkey, u64)]) -> Vec<Instruction> {
+    /// Create and sign new SystemInstruction::Transfer transaction to many destinations
+    pub fn new_transfer_many(from_id: &Pubkey, to_lamports: &[(Pubkey, u64)]) -> Vec<Instruction> {
         to_lamports
             .iter()
-            .map(|(to_id, lamports)| SystemInstruction::new_move(from_id, to_id, *lamports))
+            .map(|(to_id, lamports)| SystemInstruction::new_transfer(from_id, to_id, *lamports))
             .collect()
     }
 }
@@ -107,7 +107,7 @@ mod tests {
         let carol_pubkey = Pubkey::new_rand();
         let to_lamports = vec![(bob_pubkey, 1), (carol_pubkey, 2)];
 
-        let instructions = SystemInstruction::new_move_many(&alice_pubkey, &to_lamports);
+        let instructions = SystemInstruction::new_transfer_many(&alice_pubkey, &to_lamports);
         assert_eq!(instructions.len(), 2);
         assert_eq!(get_keys(&instructions[0]), vec![alice_pubkey, bob_pubkey]);
         assert_eq!(get_keys(&instructions[1]), vec![alice_pubkey, carol_pubkey]);

--- a/sdk/src/system_transaction.rs
+++ b/sdk/src/system_transaction.rs
@@ -60,8 +60,8 @@ impl SystemTransaction {
         Transaction::new_signed_instructions(&[from_keypair], instructions, recent_blockhash)
     }
 
-    /// Create and sign new SystemInstruction::Move transaction
-    pub fn new_move(
+    /// Create and sign new SystemInstruction::Transfer transaction
+    pub fn new_transfer(
         from_keypair: &Keypair,
         to: &Pubkey,
         lamports: u64,
@@ -69,7 +69,7 @@ impl SystemTransaction {
         _fee: u64,
     ) -> Transaction {
         let from_pubkey = from_keypair.pubkey();
-        let move_instruction = SystemInstruction::new_move(&from_pubkey, to, lamports);
+        let move_instruction = SystemInstruction::new_transfer(&from_pubkey, to, lamports);
         let instructions = vec![move_instruction];
         Transaction::new_signed_instructions(&[from_keypair], instructions, recent_blockhash)
     }

--- a/sdk/src/transaction.rs
+++ b/sdk/src/transaction.rs
@@ -321,7 +321,7 @@ mod tests {
         let alice_keypair = Keypair::new();
         let alice_pubkey = alice_keypair.pubkey();
         let bob_pubkey = Pubkey::new_rand();
-        let ix = SystemInstruction::new_move(&alice_pubkey, &bob_pubkey, 42);
+        let ix = SystemInstruction::new_transfer(&alice_pubkey, &bob_pubkey, 42);
 
         let expected_data_size = size_of::<u32>() + size_of::<u64>();
         assert_eq!(expected_data_size, 12);

--- a/tests/thin_client.rs
+++ b/tests/thin_client.rs
@@ -84,7 +84,7 @@ fn test_bad_sig() {
 
     let mut tr2 = SystemTransaction::new_user_account(&alice, &bob_pubkey, 501, blockhash, 0);
     let mut instruction2 = deserialize(tr2.data(0)).unwrap();
-    if let SystemInstruction::Move { ref mut lamports } = instruction2 {
+    if let SystemInstruction::Transfer { ref mut lamports } = instruction2 {
         *lamports = 502;
     }
     tr2.instructions[0].data = serialize(&instruction2).unwrap();

--- a/wallet/src/wallet.rs
+++ b/wallet/src/wallet.rs
@@ -450,7 +450,7 @@ fn process_pay(
     let blockhash = rpc_client.get_recent_blockhash()?;
 
     if timestamp == None && *witnesses == None {
-        let mut tx = SystemTransaction::new_move(&config.keypair, to, lamports, blockhash, 0);
+        let mut tx = SystemTransaction::new_transfer(&config.keypair, to, lamports, blockhash, 0);
         let signature_str = rpc_client.send_and_confirm_transaction(&mut tx, &config.keypair)?;
         Ok(signature_str.to_string())
     } else if *witnesses == None {


### PR DESCRIPTION
#### Problem

We use three terms for the same thing, "transfer", "move", and "pay".  "transfer" in the one with the strongest blockchain industry precedent (ERC-20).  "pay" is appealing, but might imply an exchange for some good or service. "move" conflicts with a Rust keyword.

#### Summary of Changes

* Of the three terms, boot the worst one "move". Change it to "transfer", favoring industry precedent.
