### PR TITLE
Remove Instruction wrapper structs and name functions after enum fields

### DIFF
--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -556,7 +556,7 @@ mod tests {
     use serde_json::Number;
     use solana_logger;
     use solana_sdk::signature::{Keypair, KeypairUtil};
-    use solana_sdk::system_transaction::SystemTransaction;
+    use solana_sdk::system_transaction;
     use std::sync::mpsc::channel;
     use std::thread;
 
@@ -662,7 +662,7 @@ mod tests {
         let key = Keypair::new();
         let to = Pubkey::new_rand();
         let blockhash = Hash::default();
-        let tx = SystemTransaction::new_user_account(&key, &to, 50, blockhash, 0);
+        let tx = system_transaction::create_user_account(&key, &to, 50, blockhash, 0);
 
         let signature = rpc_client.send_transaction(&tx);
         assert_eq!(signature.unwrap(), SIGNATURE.to_string());
@@ -713,7 +713,7 @@ mod tests {
         let key = Keypair::new();
         let to = Pubkey::new_rand();
         let blockhash = Hash::default();
-        let mut tx = SystemTransaction::new_user_account(&key, &to, 50, blockhash, 0);
+        let mut tx = system_transaction::create_user_account(&key, &to, 50, blockhash, 0);
 
         let result = rpc_client.send_and_confirm_transaction(&mut tx, &key);
         result.unwrap();
@@ -737,8 +737,8 @@ mod tests {
             .into_vec()
             .unwrap();
         let blockhash = Hash::new(&vec);
-        let prev_tx = SystemTransaction::new_user_account(&key, &to, 50, blockhash, 0);
-        let mut tx = SystemTransaction::new_user_account(&key, &to, 50, blockhash, 0);
+        let prev_tx = system_transaction::create_user_account(&key, &to, 50, blockhash, 0);
+        let mut tx = system_transaction::create_user_account(&key, &to, 50, blockhash, 0);
 
         rpc_client.resign_transaction(&mut tx, &key).unwrap();
 

--- a/core/benches/banking_stage.rs
+++ b/core/benches/banking_stage.rs
@@ -18,7 +18,7 @@ use solana_sdk::genesis_block::GenesisBlock;
 use solana_sdk::hash::hash;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::{KeypairUtil, Signature};
-use solana_sdk::system_transaction::SystemTransaction;
+use solana_sdk::system_transaction;
 use solana_sdk::timing::{DEFAULT_TICKS_PER_SLOT, MAX_RECENT_BLOCKHASHES};
 use std::iter;
 use std::sync::atomic::Ordering;
@@ -56,7 +56,7 @@ fn bench_banking_stage_multi_accounts(bencher: &mut Bencher) {
 
     let (verified_sender, verified_receiver) = channel();
     let bank = Arc::new(Bank::new(&genesis_block));
-    let dummy = SystemTransaction::new_transfer(
+    let dummy = system_transaction::transfer(
         &mint_keypair,
         &mint_keypair.pubkey(),
         1,
@@ -78,7 +78,7 @@ fn bench_banking_stage_multi_accounts(bencher: &mut Bencher) {
         .collect();
     // fund all the accounts
     transactions.iter().for_each(|tx| {
-        let fund = SystemTransaction::new_transfer(
+        let fund = system_transaction::transfer(
             &mint_keypair,
             &tx.message.account_keys[0],
             mint_total / txes as u64,
@@ -156,7 +156,7 @@ fn bench_banking_stage_multi_programs(bencher: &mut Bencher) {
 
     let (verified_sender, verified_receiver) = channel();
     let bank = Arc::new(Bank::new(&genesis_block));
-    let dummy = SystemTransaction::new_transfer(
+    let dummy = system_transaction::transfer(
         &mint_keypair,
         &mint_keypair.pubkey(),
         1,
@@ -194,7 +194,7 @@ fn bench_banking_stage_multi_programs(bencher: &mut Bencher) {
         })
         .collect();
     transactions.iter().for_each(|tx| {
-        let fund = SystemTransaction::new_transfer(
+        let fund = system_transaction::transfer(
             &mint_keypair,
             &tx.message.account_keys[0],
             mint_total / txes as u64,

--- a/core/benches/ledger.rs
+++ b/core/benches/ledger.rs
@@ -5,7 +5,7 @@ extern crate test;
 use solana::entry::{next_entries, reconstruct_entries_from_blobs, EntrySlice};
 use solana_sdk::hash::{hash, Hash};
 use solana_sdk::signature::{Keypair, KeypairUtil};
-use solana_sdk::system_transaction::SystemTransaction;
+use solana_sdk::system_transaction;
 use test::Bencher;
 
 #[bench]
@@ -13,7 +13,7 @@ fn bench_block_to_blobs_to_block(bencher: &mut Bencher) {
     let zero = Hash::default();
     let one = hash(&zero.as_ref());
     let keypair = Keypair::new();
-    let tx0 = SystemTransaction::new_transfer(&keypair, &keypair.pubkey(), 1, one, 0);
+    let tx0 = system_transaction::transfer(&keypair, &keypair.pubkey(), 1, one, 0);
     let transactions = vec![tx0; 10];
     let entries = next_entries(&zero, 1, transactions);
 

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -507,7 +507,7 @@ mod tests {
     use solana_sdk::genesis_block::GenesisBlock;
     use solana_sdk::instruction::InstructionError;
     use solana_sdk::signature::{Keypair, KeypairUtil};
-    use solana_sdk::system_transaction::SystemTransaction;
+    use solana_sdk::system_transaction;
     use std::sync::mpsc::channel;
     use std::thread::sleep;
 
@@ -593,7 +593,7 @@ mod tests {
 
             // fund another account so we can send 2 good transactions in a single batch.
             let keypair = Keypair::new();
-            let fund_tx = SystemTransaction::new_user_account(
+            let fund_tx = system_transaction::create_user_account(
                 &mint_keypair,
                 &keypair.pubkey(),
                 2,
@@ -604,16 +604,17 @@ mod tests {
 
             // good tx
             let to = Pubkey::new_rand();
-            let tx = SystemTransaction::new_user_account(&mint_keypair, &to, 1, start_hash, 0);
+            let tx = system_transaction::create_user_account(&mint_keypair, &to, 1, start_hash, 0);
 
             // good tx, but no verify
             let to2 = Pubkey::new_rand();
-            let tx_no_ver = SystemTransaction::new_user_account(&keypair, &to2, 2, start_hash, 0);
+            let tx_no_ver =
+                system_transaction::create_user_account(&keypair, &to2, 2, start_hash, 0);
 
             // bad tx, AccountNotFound
             let keypair = Keypair::new();
             let to3 = Pubkey::new_rand();
-            let tx_anf = SystemTransaction::new_user_account(&keypair, &to3, 1, start_hash, 0);
+            let tx_anf = system_transaction::create_user_account(&keypair, &to3, 1, start_hash, 0);
 
             // send 'em over
             let packets = to_packets(&[tx_no_ver, tx_anf, tx]);
@@ -676,7 +677,7 @@ mod tests {
 
         // Process a batch that includes a transaction that receives two lamports.
         let alice = Keypair::new();
-        let tx = SystemTransaction::new_user_account(
+        let tx = system_transaction::create_user_account(
             &mint_keypair,
             &alice.pubkey(),
             2,
@@ -690,7 +691,7 @@ mod tests {
             .unwrap();
 
         // Process a second batch that spends one of those lamports.
-        let tx = SystemTransaction::new_user_account(
+        let tx = system_transaction::create_user_account(
             &alice,
             &mint_keypair.pubkey(),
             1,
@@ -783,8 +784,8 @@ mod tests {
             let pubkey = Pubkey::new_rand();
 
             let transactions = vec![
-                SystemTransaction::new_transfer(&mint_keypair, &pubkey, 1, genesis_block.hash(), 0),
-                SystemTransaction::new_transfer(&mint_keypair, &pubkey, 1, genesis_block.hash(), 0),
+                system_transaction::transfer(&mint_keypair, &pubkey, 1, genesis_block.hash(), 0),
+                system_transaction::transfer(&mint_keypair, &pubkey, 1, genesis_block.hash(), 0),
             ];
 
             let mut results = vec![Ok(()), Ok(())];
@@ -820,7 +821,7 @@ mod tests {
         let bank = Arc::new(Bank::new(&genesis_block));
         let pubkey = Pubkey::new_rand();
 
-        let transactions = vec![SystemTransaction::new_transfer(
+        let transactions = vec![system_transaction::transfer(
             &mint_keypair,
             &pubkey,
             1,
@@ -873,7 +874,7 @@ mod tests {
 
             assert_eq!(done, true);
 
-            let transactions = vec![SystemTransaction::new_transfer(
+            let transactions = vec![system_transaction::transfer(
                 &mint_keypair,
                 &pubkey,
                 2,

--- a/core/src/blockstream.rs
+++ b/core/src/blockstream.rs
@@ -172,7 +172,7 @@ mod test {
     use serde_json::Value;
     use solana_sdk::hash::Hash;
     use solana_sdk::signature::{Keypair, KeypairUtil};
-    use solana_sdk::system_transaction::SystemTransaction;
+    use solana_sdk::system_transaction;
     use std::collections::HashSet;
 
     #[test]
@@ -184,9 +184,9 @@ mod test {
         let keypair0 = Keypair::new();
         let keypair1 = Keypair::new();
         let tx0 =
-            SystemTransaction::new_transfer(&keypair0, &keypair1.pubkey(), 1, Hash::default(), 0);
+            system_transaction::transfer(&keypair0, &keypair1.pubkey(), 1, Hash::default(), 0);
         let tx1 =
-            SystemTransaction::new_transfer(&keypair1, &keypair0.pubkey(), 2, Hash::default(), 0);
+            system_transaction::transfer(&keypair1, &keypair0.pubkey(), 2, Hash::default(), 0);
         let serialized_tx0 = serialize(&tx0).unwrap();
         let serialized_tx1 = serialize(&tx1).unwrap();
         let entry = Entry::new(&Hash::default(), 1, vec![tx0, tx1]);

--- a/core/src/blockstream_service.rs
+++ b/core/src/blockstream_service.rs
@@ -115,7 +115,7 @@ mod test {
     use solana_sdk::genesis_block::GenesisBlock;
     use solana_sdk::hash::Hash;
     use solana_sdk::signature::{Keypair, KeypairUtil};
-    use solana_sdk::system_transaction::SystemTransaction;
+    use solana_sdk::system_transaction;
     use std::sync::mpsc::channel;
 
     #[test]
@@ -141,8 +141,13 @@ mod test {
 
         let keypair = Keypair::new();
         let mut blockhash = entries[3].hash;
-        let tx =
-            SystemTransaction::new_user_account(&keypair, &keypair.pubkey(), 1, Hash::default(), 0);
+        let tx = system_transaction::create_user_account(
+            &keypair,
+            &keypair.pubkey(),
+            1,
+            Hash::default(),
+            0,
+        );
         let entry = Entry::new(&mut blockhash, 1, vec![tx]);
         blockhash = entry.hash;
         entries.push(entry);

--- a/core/src/chacha.rs
+++ b/core/src/chacha.rs
@@ -97,7 +97,7 @@ mod tests {
     use ring::signature::Ed25519KeyPair;
     use solana_sdk::hash::{hash, Hash, Hasher};
     use solana_sdk::signature::KeypairUtil;
-    use solana_sdk::system_transaction::SystemTransaction;
+    use solana_sdk::system_transaction;
     use std::fs::remove_file;
     use std::fs::File;
     use std::io::Read;
@@ -124,7 +124,7 @@ mod tests {
                 Entry::new_mut(
                     &mut id,
                     &mut num_hashes,
-                    vec![SystemTransaction::new_user_account(
+                    vec![system_transaction::create_user_account(
                         &keypair,
                         &keypair.pubkey(),
                         1,

--- a/core/src/cluster_tests.rs
+++ b/core/src/cluster_tests.rs
@@ -12,7 +12,7 @@ use crate::poh_service::PohServiceConfig;
 use solana_client::thin_client::create_client;
 use solana_sdk::hash::Hash;
 use solana_sdk::signature::{Keypair, KeypairUtil, Signature};
-use solana_sdk::system_transaction::SystemTransaction;
+use solana_sdk::system_transaction;
 use solana_sdk::timing::{
     duration_as_ms, DEFAULT_TICKS_PER_SLOT, NUM_CONSECUTIVE_LEADER_SLOTS, NUM_TICKS_PER_SECOND,
 };
@@ -37,7 +37,7 @@ pub fn spend_and_verify_all_nodes(
             .poll_get_balance(&funding_keypair.pubkey())
             .expect("balance in source");
         assert!(bal > 0);
-        let mut transaction = SystemTransaction::new_transfer(
+        let mut transaction = system_transaction::transfer(
             &funding_keypair,
             &random_keypair.pubkey(),
             1,
@@ -63,7 +63,7 @@ pub fn send_many_transactions(node: &ContactInfo, funding_keypair: &Keypair, num
             .poll_get_balance(&funding_keypair.pubkey())
             .expect("balance in source");
         assert!(bal > 0);
-        let mut transaction = SystemTransaction::new_transfer(
+        let mut transaction = system_transaction::transfer(
             &funding_keypair,
             &random_keypair.pubkey(),
             1,
@@ -183,7 +183,7 @@ pub fn kill_entry_and_spend_and_verify_rest(
             }
 
             let random_keypair = Keypair::new();
-            let mut transaction = SystemTransaction::new_transfer(
+            let mut transaction = system_transaction::transfer(
                 &funding_keypair,
                 &random_keypair.pubkey(),
                 1,

--- a/core/src/packet.rs
+++ b/core/src/packet.rs
@@ -573,7 +573,7 @@ mod tests {
     use rand::Rng;
     use solana_sdk::hash::Hash;
     use solana_sdk::signature::{Keypair, KeypairUtil};
-    use solana_sdk::system_transaction::SystemTransaction;
+    use solana_sdk::system_transaction;
     use std::io;
     use std::io::Write;
     use std::net::{Ipv4Addr, SocketAddr, UdpSocket};
@@ -612,7 +612,7 @@ mod tests {
     fn test_to_packets() {
         let keypair = Keypair::new();
         let hash = Hash::new(&[1; 32]);
-        let tx = SystemTransaction::new_user_account(&keypair, &keypair.pubkey(), 1, hash, 0);
+        let tx = system_transaction::create_user_account(&keypair, &keypair.pubkey(), 1, hash, 0);
         let rv = to_packets(&vec![tx.clone(); 1]);
         assert_eq!(rv.len(), 1);
         assert_eq!(rv[0].read().unwrap().packets.len(), 1);

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -21,7 +21,7 @@ use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::KeypairUtil;
 use solana_sdk::timing::{self, duration_as_ms};
 use solana_sdk::transaction::Transaction;
-use solana_vote_api::vote_instruction::{Vote, VoteInstruction};
+use solana_vote_api::vote_instruction::{self, Vote};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::{channel, Receiver, RecvTimeoutError, Sender};
 use std::sync::{Arc, Mutex, RwLock};
@@ -296,7 +296,7 @@ impl ReplayStage {
         T: 'static + KeypairUtil + Send + Sync,
     {
         if let Some(ref voting_keypair) = voting_keypair {
-            let vote_ix = VoteInstruction::new_vote(&vote_account, Vote::new(bank.slot()));
+            let vote_ix = vote_instruction::vote(&vote_account, Vote::new(bank.slot()));
             let vote_tx = Transaction::new_signed_instructions(
                 &[voting_keypair.as_ref()],
                 vec![vote_ix],
@@ -635,7 +635,7 @@ mod test {
                 ledger_writer_sender,
             );
 
-            let vote_ix = VoteInstruction::new_vote(&voting_keypair.pubkey(), Vote::new(0));
+            let vote_ix = vote_instruction::vote(&voting_keypair.pubkey(), Vote::new(0));
             let vote_tx = Transaction::new_signed_instructions(
                 &[voting_keypair.as_ref()],
                 vec![vote_ix],

--- a/core/src/replicator.rs
+++ b/core/src/replicator.rs
@@ -22,9 +22,9 @@ use solana_client::thin_client::{create_client, ThinClient};
 use solana_drone::drone::{request_airdrop_transaction, DRONE_PORT};
 use solana_sdk::hash::{Hash, Hasher};
 use solana_sdk::signature::{Keypair, KeypairUtil, Signature};
-use solana_sdk::system_transaction::SystemTransaction;
+use solana_sdk::system_transaction;
 use solana_sdk::transaction::Transaction;
-use solana_storage_api::storage_instruction::StorageInstruction;
+use solana_storage_api::storage_instruction;
 use std::fs::File;
 use std::io;
 use std::io::BufReader;
@@ -434,7 +434,7 @@ impl Replicator {
         {
             let blockhash = client.get_recent_blockhash().expect("blockhash");
             //TODO the account space needs to be well defined somewhere
-            let tx = SystemTransaction::new_account(
+            let tx = system_transaction::create_account(
                 keypair,
                 &storage_keypair.pubkey(),
                 blockhash,
@@ -455,7 +455,7 @@ impl Replicator {
         );
         Self::get_airdrop_lamports(&client, &self.keypair, &self.cluster_entrypoint);
 
-        let ix = StorageInstruction::new_mining_proof(
+        let ix = storage_instruction::mining_proof(
             &self.storage_keypair.pubkey(),
             self.hash,
             self.slot,

--- a/core/src/rpc_subscriptions.rs
+++ b/core/src/rpc_subscriptions.rs
@@ -202,7 +202,7 @@ mod tests {
     use solana_budget_api;
     use solana_sdk::genesis_block::GenesisBlock;
     use solana_sdk::signature::{Keypair, KeypairUtil};
-    use solana_sdk::system_transaction::SystemTransaction;
+    use solana_sdk::system_transaction;
     use tokio::prelude::{Async, Stream};
 
     #[test]
@@ -211,7 +211,7 @@ mod tests {
         let bank = Bank::new(&genesis_block);
         let alice = Keypair::new();
         let blockhash = bank.last_blockhash();
-        let tx = SystemTransaction::new_account(
+        let tx = system_transaction::create_account(
             &mint_keypair,
             &alice.pubkey(),
             blockhash,
@@ -257,7 +257,7 @@ mod tests {
         let bank = Bank::new(&genesis_block);
         let alice = Keypair::new();
         let blockhash = bank.last_blockhash();
-        let tx = SystemTransaction::new_account(
+        let tx = system_transaction::create_account(
             &mint_keypair,
             &alice.pubkey(),
             blockhash,
@@ -302,7 +302,7 @@ mod tests {
         let bank = Bank::new(&genesis_block);
         let alice = Keypair::new();
         let blockhash = bank.last_blockhash();
-        let tx = SystemTransaction::new_transfer(&mint_keypair, &alice.pubkey(), 20, blockhash, 0);
+        let tx = system_transaction::transfer(&mint_keypair, &alice.pubkey(), 20, blockhash, 0);
         let signature = tx.signatures[0];
         bank.process_transaction(&tx).unwrap();
 

--- a/core/src/storage_stage.rs
+++ b/core/src/storage_stage.rs
@@ -16,9 +16,9 @@ use solana_client::thin_client::{create_client_with_timeout, ThinClient};
 use solana_sdk::hash::Hash;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::{Keypair, KeypairUtil, Signature};
-use solana_sdk::system_transaction::SystemTransaction;
+use solana_sdk::system_transaction;
 use solana_sdk::transaction::Transaction;
-use solana_storage_api::storage_instruction::StorageInstruction;
+use solana_storage_api::storage_instruction::{self, StorageInstruction};
 use std::collections::HashSet;
 use std::io;
 use std::mem::size_of;
@@ -279,7 +279,7 @@ impl StorageStage {
             if let Some(account) = account_to_create {
                 if client.get_account_data(&account).is_err() {
                     // TODO the account space needs to be well defined somewhere
-                    let tx = SystemTransaction::new_account(
+                    let tx = system_transaction::create_account(
                         keypair,
                         &storage_keypair.pubkey(),
                         blockhash,
@@ -318,7 +318,7 @@ impl StorageStage {
         let mut seed = [0u8; 32];
         let signature = keypair.sign(&entry_id.as_ref());
 
-        let ix = StorageInstruction::new_advertise_recent_blockhash(
+        let ix = storage_instruction::advertise_recent_blockhash(
             &keypair.pubkey(),
             entry_id,
             entry_height,
@@ -643,7 +643,7 @@ mod tests {
         }
 
         let keypair = Keypair::new();
-        let mining_proof_ix = StorageInstruction::new_mining_proof(
+        let mining_proof_ix = storage_instruction::mining_proof(
             &keypair.pubkey(),
             Hash::default(),
             0,

--- a/core/src/test_tx.rs
+++ b/core/src/test_tx.rs
@@ -3,14 +3,14 @@ use solana_sdk::instruction::CompiledInstruction;
 use solana_sdk::signature::{Keypair, KeypairUtil};
 use solana_sdk::system_instruction::SystemInstruction;
 use solana_sdk::system_program;
-use solana_sdk::system_transaction::SystemTransaction;
+use solana_sdk::system_transaction;
 use solana_sdk::transaction::Transaction;
 
 pub fn test_tx() -> Transaction {
     let keypair1 = Keypair::new();
     let pubkey1 = keypair1.pubkey();
     let zero = Hash::default();
-    SystemTransaction::new_user_account(&keypair1, &pubkey1, 42, zero, 0)
+    system_transaction::create_user_account(&keypair1, &pubkey1, 42, zero, 0)
 }
 
 pub fn test_multisig_tx() -> Transaction {
@@ -20,11 +20,15 @@ pub fn test_multisig_tx() -> Transaction {
     let lamports = 5;
     let blockhash = Hash::default();
 
-    let system_instruction = SystemInstruction::Transfer { lamports };
+    let transfer_instruction = SystemInstruction::Transfer { lamports };
 
     let program_ids = vec![system_program::id(), solana_budget_api::id()];
 
-    let instructions = vec![CompiledInstruction::new(0, &system_instruction, vec![0, 1])];
+    let instructions = vec![CompiledInstruction::new(
+        0,
+        &transfer_instruction,
+        vec![0, 1],
+    )];
 
     Transaction::new_with_compiled_instructions(
         &keypairs,

--- a/core/src/voting_keypair.rs
+++ b/core/src/voting_keypair.rs
@@ -110,7 +110,7 @@ pub mod tests {
     use solana_sdk::pubkey::Pubkey;
     use solana_sdk::signature::{Keypair, KeypairUtil};
     use solana_sdk::transaction::Transaction;
-    use solana_vote_api::vote_instruction::{Vote, VoteInstruction};
+    use solana_vote_api::vote_instruction::{self, Vote};
 
     fn process_instructions<T: KeypairUtil>(bank: &Bank, keypairs: &[&T], ixs: Vec<Instruction>) {
         let blockhash = bank.last_blockhash();
@@ -124,7 +124,7 @@ pub mod tests {
         bank: &Bank,
         lamports: u64,
     ) {
-        let ixs = VoteInstruction::new_account(&from_keypair.pubkey(), voting_pubkey, lamports);
+        let ixs = vote_instruction::create_account(&from_keypair.pubkey(), voting_pubkey, lamports);
         process_instructions(bank, &[from_keypair], ixs);
     }
 
@@ -137,16 +137,13 @@ pub mod tests {
     ) {
         let voting_pubkey = voting_keypair.pubkey();
         let mut ixs =
-            VoteInstruction::new_account(&from_keypair.pubkey(), &voting_pubkey, lamports);
-        ixs.push(VoteInstruction::new_delegate_stake(
-            &voting_pubkey,
-            delegate,
-        ));
+            vote_instruction::create_account(&from_keypair.pubkey(), &voting_pubkey, lamports);
+        ixs.push(vote_instruction::delegate_stake(&voting_pubkey, delegate));
         process_instructions(bank, &[from_keypair, voting_keypair], ixs);
     }
 
     pub fn push_vote<T: KeypairUtil>(voting_keypair: &T, bank: &Bank, slot: u64) {
-        let ix = VoteInstruction::new_vote(&voting_keypair.pubkey(), Vote::new(slot));
+        let ix = vote_instruction::vote(&voting_keypair.pubkey(), Vote::new(slot));
         process_instructions(bank, &[voting_keypair], vec![ix]);
     }
 
@@ -159,8 +156,8 @@ pub mod tests {
     ) {
         let voting_pubkey = voting_keypair.pubkey();
         let mut ixs =
-            VoteInstruction::new_account(&from_keypair.pubkey(), &voting_pubkey, lamports);
-        ixs.push(VoteInstruction::new_vote(&voting_pubkey, Vote::new(slot)));
+            vote_instruction::create_account(&from_keypair.pubkey(), &voting_pubkey, lamports);
+        ixs.push(vote_instruction::vote(&voting_pubkey, Vote::new(slot)));
         process_instructions(bank, &[from_keypair, voting_keypair], ixs);
     }
 }

--- a/core/tests/rpc.rs
+++ b/core/tests/rpc.rs
@@ -7,7 +7,7 @@ use solana::fullnode::new_fullnode_for_tests;
 use solana_client::rpc_client::get_rpc_request_str;
 use solana_sdk::hash::Hash;
 use solana_sdk::pubkey::Pubkey;
-use solana_sdk::system_transaction::SystemTransaction;
+use solana_sdk::system_transaction;
 use std::fs::remove_dir_all;
 use std::thread::sleep;
 use std::time::Duration;
@@ -41,7 +41,7 @@ fn test_rpc_send_tx() {
     let blockhash = Hash::new(&blockhash_vec);
 
     info!("blockhash: {:?}", blockhash);
-    let tx = SystemTransaction::new_transfer(&alice, &bob_pubkey, 20, blockhash, 0);
+    let tx = system_transaction::transfer(&alice, &bob_pubkey, 20, blockhash, 0);
     let serial_tx = serialize(&tx).unwrap();
 
     let client = reqwest::Client::new();

--- a/core/tests/tvu.rs
+++ b/core/tests/tvu.rs
@@ -18,7 +18,7 @@ use solana::streamer;
 use solana::tvu::{Sockets, Tvu};
 use solana_sdk::genesis_block::GenesisBlock;
 use solana_sdk::signature::{Keypair, KeypairUtil};
-use solana_sdk::system_transaction::SystemTransaction;
+use solana_sdk::system_transaction;
 use std::fs::remove_dir_all;
 use std::net::UdpSocket;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -140,7 +140,7 @@ fn test_replay() {
             let entry0 = next_entry_mut(&mut cur_hash, i, vec![]);
             let entry_tick0 = next_entry_mut(&mut cur_hash, i + 1, vec![]);
 
-            let tx0 = SystemTransaction::new_user_account(
+            let tx0 = system_transaction::create_user_account(
                 &mint_keypair,
                 &bob_keypair.pubkey(),
                 transfer_amount,

--- a/drone/src/drone.rs
+++ b/drone/src/drone.rs
@@ -16,7 +16,7 @@ use solana_sdk::message::Message;
 use solana_sdk::packet::PACKET_DATA_SIZE;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::{Keypair, KeypairUtil};
-use solana_sdk::system_instruction::SystemInstruction;
+use solana_sdk::system_instruction;
 use solana_sdk::transaction::Transaction;
 use std::io;
 use std::io::{Error, ErrorKind};
@@ -127,7 +127,7 @@ impl Drone {
 
                     info!("Requesting airdrop of {} to {:?}", lamports, to);
 
-                    let create_instruction = SystemInstruction::new_user_account(
+                    let create_instruction = system_instruction::create_user_account(
                         &self.mint_keypair.pubkey(),
                         &to,
                         lamports,
@@ -285,6 +285,7 @@ pub fn run_local_drone(mint_keypair: Keypair, sender: Sender<SocketAddr>) {
 mod tests {
     use super::*;
     use bytes::BufMut;
+    use solana_sdk::system_instruction::SystemInstruction;
     use std::time::Duration;
 
     #[test]
@@ -394,7 +395,7 @@ mod tests {
 
         let keypair = Keypair::new();
         let expected_instruction =
-            SystemInstruction::new_user_account(&keypair.pubkey(), &to, lamports);
+            system_instruction::create_user_account(&keypair.pubkey(), &to, lamports);
         let message = Message::new(vec![expected_instruction]);
         let expected_tx = Transaction::new(&[&keypair], message, blockhash);
         let expected_bytes = serialize(&expected_tx).unwrap();

--- a/drone/src/drone_mock.rs
+++ b/drone/src/drone_mock.rs
@@ -1,7 +1,7 @@
 use solana_sdk::hash::Hash;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::{Keypair, KeypairUtil};
-use solana_sdk::system_transaction::SystemTransaction;
+use solana_sdk::system_transaction;
 use solana_sdk::transaction::Transaction;
 use std::io::{Error, ErrorKind};
 use std::net::SocketAddr;
@@ -18,6 +18,6 @@ pub fn request_airdrop_transaction(
     let key = Keypair::new();
     let to = Pubkey::new_rand();
     let blockhash = Hash::default();
-    let tx = SystemTransaction::new_user_account(&key, &to, lamports, blockhash, 0);
+    let tx = system_transaction::create_user_account(&key, &to, lamports, blockhash, 0);
     Ok(tx)
 }

--- a/drone/tests/local-drone.rs
+++ b/drone/tests/local-drone.rs
@@ -3,7 +3,7 @@ use solana_sdk::hash::Hash;
 use solana_sdk::message::Message;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::{Keypair, KeypairUtil};
-use solana_sdk::system_instruction::SystemInstruction;
+use solana_sdk::system_instruction;
 use solana_sdk::transaction::Transaction;
 use std::sync::mpsc::channel;
 
@@ -13,7 +13,8 @@ fn test_local_drone() {
     let to = Pubkey::new_rand();
     let lamports = 50;
     let blockhash = Hash::new(&to.as_ref());
-    let create_instruction = SystemInstruction::new_user_account(&keypair.pubkey(), &to, lamports);
+    let create_instruction =
+        system_instruction::create_user_account(&keypair.pubkey(), &to, lamports);
     let message = Message::new(vec![create_instruction]);
     let expected_tx = Transaction::new(&[&keypair], message, blockhash);
 

--- a/install/src/command.rs
+++ b/install/src/command.rs
@@ -5,7 +5,7 @@ use console::{style, Emoji};
 use indicatif::{ProgressBar, ProgressStyle};
 use ring::digest::{Context, Digest, SHA256};
 use solana_client::rpc_client::RpcClient;
-use solana_config_api::ConfigInstruction;
+use solana_config_api::config_instruction;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::{read_keypair, Keypair, KeypairUtil, Signable};
 use solana_sdk::transaction::Transaction;
@@ -198,7 +198,7 @@ fn new_update_manifest(
     {
         let recect_blockhash = rpc_client.get_recent_blockhash()?;
 
-        let new_account = ConfigInstruction::new_account::<SignedUpdateManifest>(
+        let new_account = config_instruction::create_account::<SignedUpdateManifest>(
             &from_keypair.pubkey(),
             &update_manifest_keypair.pubkey(),
             1, // lamports
@@ -220,7 +220,7 @@ fn store_update_manifest(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let recect_blockhash = rpc_client.get_recent_blockhash()?;
 
-    let new_store = ConfigInstruction::new_store::<SignedUpdateManifest>(
+    let new_store = config_instruction::store::<SignedUpdateManifest>(
         &from_keypair.pubkey(),
         &update_manifest_keypair.pubkey(),
         update_manifest,

--- a/programs/budget_api/src/budget_instruction.rs
+++ b/programs/budget_api/src/budget_instruction.rs
@@ -6,7 +6,7 @@ use chrono::prelude::{DateTime, Utc};
 use serde_derive::{Deserialize, Serialize};
 use solana_sdk::instruction::{AccountMeta, Instruction};
 use solana_sdk::pubkey::Pubkey;
-use solana_sdk::system_instruction::SystemInstruction;
+use solana_sdk::system_instruction;
 
 /// A smart contract.
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
@@ -30,93 +30,90 @@ pub enum BudgetInstruction {
     ApplySignature,
 }
 
-impl BudgetInstruction {
-    fn new_initialize_account(contract: &Pubkey, expr: BudgetExpr) -> Instruction {
-        let mut keys = vec![];
-        if let BudgetExpr::Pay(payment) = &expr {
-            keys.push(AccountMeta::new(payment.to, false));
-        }
-        keys.push(AccountMeta::new(*contract, false));
-        Instruction::new(id(), &BudgetInstruction::InitializeAccount(expr), keys)
+fn initialize_account(contract: &Pubkey, expr: BudgetExpr) -> Instruction {
+    let mut keys = vec![];
+    if let BudgetExpr::Pay(payment) = &expr {
+        keys.push(AccountMeta::new(payment.to, false));
     }
+    keys.push(AccountMeta::new(*contract, false));
+    Instruction::new(id(), &BudgetInstruction::InitializeAccount(expr), keys)
+}
 
-    pub fn new_account(
-        from: &Pubkey,
-        contract: &Pubkey,
-        lamports: u64,
-        expr: BudgetExpr,
-    ) -> Vec<Instruction> {
-        if !expr.verify(lamports) {
-            panic!("invalid budget expression");
-        }
-        let space = serialized_size(&BudgetState::new(expr.clone())).unwrap();
-        vec![
-            SystemInstruction::new_account(&from, contract, lamports, space, &id()),
-            BudgetInstruction::new_initialize_account(contract, expr),
-        ]
+pub fn create_account(
+    from: &Pubkey,
+    contract: &Pubkey,
+    lamports: u64,
+    expr: BudgetExpr,
+) -> Vec<Instruction> {
+    if !expr.verify(lamports) {
+        panic!("invalid budget expression");
     }
+    let space = serialized_size(&BudgetState::new(expr.clone())).unwrap();
+    vec![
+        system_instruction::create_account(&from, contract, lamports, space, &id()),
+        initialize_account(contract, expr),
+    ]
+}
 
-    /// Create a new payment script.
-    pub fn new_payment(from: &Pubkey, to: &Pubkey, lamports: u64) -> Vec<Instruction> {
-        let contract = Pubkey::new_rand();
-        let expr = BudgetExpr::new_payment(lamports, to);
-        Self::new_account(from, &contract, lamports, expr)
-    }
+/// Create a new payment script.
+pub fn payment(from: &Pubkey, to: &Pubkey, lamports: u64) -> Vec<Instruction> {
+    let contract = Pubkey::new_rand();
+    let expr = BudgetExpr::new_payment(lamports, to);
+    create_account(from, &contract, lamports, expr)
+}
 
-    /// Create a future payment script.
-    pub fn new_on_date(
-        from: &Pubkey,
-        to: &Pubkey,
-        contract: &Pubkey,
-        dt: DateTime<Utc>,
-        dt_pubkey: &Pubkey,
-        cancelable: Option<Pubkey>,
-        lamports: u64,
-    ) -> Vec<Instruction> {
-        let expr =
-            BudgetExpr::new_cancelable_future_payment(dt, dt_pubkey, lamports, to, cancelable);
-        Self::new_account(from, contract, lamports, expr)
-    }
+/// Create a future payment script.
+pub fn on_date(
+    from: &Pubkey,
+    to: &Pubkey,
+    contract: &Pubkey,
+    dt: DateTime<Utc>,
+    dt_pubkey: &Pubkey,
+    cancelable: Option<Pubkey>,
+    lamports: u64,
+) -> Vec<Instruction> {
+    let expr = BudgetExpr::new_cancelable_future_payment(dt, dt_pubkey, lamports, to, cancelable);
+    create_account(from, contract, lamports, expr)
+}
 
-    /// Create a multisig payment script.
-    pub fn new_when_signed(
-        from: &Pubkey,
-        to: &Pubkey,
-        contract: &Pubkey,
-        witness: &Pubkey,
-        cancelable: Option<Pubkey>,
-        lamports: u64,
-    ) -> Vec<Instruction> {
-        let expr = BudgetExpr::new_cancelable_authorized_payment(witness, lamports, to, cancelable);
-        Self::new_account(from, contract, lamports, expr)
-    }
+/// Create a multisig payment script.
+pub fn when_signed(
+    from: &Pubkey,
+    to: &Pubkey,
+    contract: &Pubkey,
+    witness: &Pubkey,
+    cancelable: Option<Pubkey>,
+    lamports: u64,
+) -> Vec<Instruction> {
+    let expr = BudgetExpr::new_cancelable_authorized_payment(witness, lamports, to, cancelable);
+    create_account(from, contract, lamports, expr)
+}
 
-    pub fn new_apply_timestamp(
-        from: &Pubkey,
-        contract: &Pubkey,
-        to: &Pubkey,
-        dt: DateTime<Utc>,
-    ) -> Instruction {
-        let mut account_metas = vec![
-            AccountMeta::new(*from, true),
-            AccountMeta::new(*contract, false),
-        ];
-        if from != to {
-            account_metas.push(AccountMeta::new(*to, false));
-        }
-        Instruction::new(id(), &BudgetInstruction::ApplyTimestamp(dt), account_metas)
+pub fn apply_timestamp(
+    from: &Pubkey,
+    contract: &Pubkey,
+    to: &Pubkey,
+    dt: DateTime<Utc>,
+) -> Instruction {
+    let mut account_metas = vec![
+        AccountMeta::new(*from, true),
+        AccountMeta::new(*contract, false),
+    ];
+    if from != to {
+        account_metas.push(AccountMeta::new(*to, false));
     }
+    Instruction::new(id(), &BudgetInstruction::ApplyTimestamp(dt), account_metas)
+}
 
-    pub fn new_apply_signature(from: &Pubkey, contract: &Pubkey, to: &Pubkey) -> Instruction {
-        let mut account_metas = vec![
-            AccountMeta::new(*from, true),
-            AccountMeta::new(*contract, false),
-        ];
-        if from != to {
-            account_metas.push(AccountMeta::new(*to, false));
-        }
-        Instruction::new(id(), &BudgetInstruction::ApplySignature, account_metas)
+pub fn apply_signature(from: &Pubkey, contract: &Pubkey, to: &Pubkey) -> Instruction {
+    let mut account_metas = vec![
+        AccountMeta::new(*from, true),
+        AccountMeta::new(*contract, false),
+    ];
+    if from != to {
+        account_metas.push(AccountMeta::new(*to, false));
     }
+    Instruction::new(id(), &BudgetInstruction::ApplySignature, account_metas)
 }
 
 #[cfg(test)]
@@ -128,7 +125,7 @@ mod tests {
     fn test_budget_instruction_verify() {
         let alice_pubkey = Pubkey::new_rand();
         let bob_pubkey = Pubkey::new_rand();
-        BudgetInstruction::new_payment(&alice_pubkey, &bob_pubkey, 1); // No panic! indicates success.
+        payment(&alice_pubkey, &bob_pubkey, 1); // No panic! indicates success.
     }
 
     #[test]
@@ -138,7 +135,7 @@ mod tests {
         let bob_pubkey = Pubkey::new_rand();
         let budget_pubkey = Pubkey::new_rand();
         let expr = BudgetExpr::new_payment(2, &bob_pubkey);
-        BudgetInstruction::new_account(&alice_pubkey, &budget_pubkey, 1, expr);
+        create_account(&alice_pubkey, &budget_pubkey, 1, expr);
     }
 
     #[test]
@@ -148,6 +145,6 @@ mod tests {
         let bob_pubkey = Pubkey::new_rand();
         let budget_pubkey = Pubkey::new_rand();
         let expr = BudgetExpr::new_payment(1, &bob_pubkey);
-        BudgetInstruction::new_account(&alice_pubkey, &budget_pubkey, 2, expr);
+        create_account(&alice_pubkey, &budget_pubkey, 2, expr);
     }
 }

--- a/programs/config_api/src/config_instruction.rs
+++ b/programs/config_api/src/config_instruction.rs
@@ -2,36 +2,32 @@ use crate::id;
 use crate::ConfigState;
 use solana_sdk::instruction::{AccountMeta, Instruction};
 use solana_sdk::pubkey::Pubkey;
-use solana_sdk::system_instruction::SystemInstruction;
+use solana_sdk::system_instruction;
 
-pub struct ConfigInstruction {}
+/// Create a new, empty configuration account
+pub fn create_account<T: ConfigState>(
+    from_account_pubkey: &Pubkey,
+    config_account_pubkey: &Pubkey,
+    lamports: u64,
+) -> Instruction {
+    system_instruction::create_account(
+        from_account_pubkey,
+        config_account_pubkey,
+        lamports,
+        T::max_space(),
+        &id(),
+    )
+}
 
-impl ConfigInstruction {
-    /// Create a new, empty configuration account
-    pub fn new_account<T: ConfigState>(
-        from_account_pubkey: &Pubkey,
-        config_account_pubkey: &Pubkey,
-        lamports: u64,
-    ) -> Instruction {
-        SystemInstruction::new_account(
-            from_account_pubkey,
-            config_account_pubkey,
-            lamports,
-            T::max_space(),
-            &id(),
-        )
-    }
-
-    /// Store new data in a configuration account
-    pub fn new_store<T: ConfigState>(
-        from_account_pubkey: &Pubkey,
-        config_account_pubkey: &Pubkey,
-        data: &T,
-    ) -> Instruction {
-        let account_metas = vec![
-            AccountMeta::new(*from_account_pubkey, true),
-            AccountMeta::new(*config_account_pubkey, true),
-        ];
-        Instruction::new(id(), data, account_metas)
-    }
+/// Store new data in a configuration account
+pub fn store<T: ConfigState>(
+    from_account_pubkey: &Pubkey,
+    config_account_pubkey: &Pubkey,
+    data: &T,
+) -> Instruction {
+    let account_metas = vec![
+        AccountMeta::new(*from_account_pubkey, true),
+        AccountMeta::new(*config_account_pubkey, true),
+    ];
+    Instruction::new(id(), data, account_metas)
 }

--- a/programs/config_api/src/lib.rs
+++ b/programs/config_api/src/lib.rs
@@ -1,10 +1,8 @@
 use serde::Serialize;
 use solana_sdk::pubkey::Pubkey;
 
-mod config_instruction;
+pub mod config_instruction;
 pub mod config_processor;
-
-pub use config_instruction::ConfigInstruction;
 
 const CONFIG_PROGRAM_ID: [u8; 32] = [
     133, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,

--- a/programs/exchange_api/src/exchange_instruction.rs
+++ b/programs/exchange_api/src/exchange_instruction.rs
@@ -59,89 +59,88 @@ pub enum ExchangeInstruction {
     /// key 6 - Token account in which to deposit the brokers profit from the swap.
     SwapRequest,
 }
-impl ExchangeInstruction {
-    pub fn new_account_request(owner: &Pubkey, new: &Pubkey) -> Instruction {
-        let account_metas = vec![
-            AccountMeta::new(*owner, true),
-            AccountMeta::new(*new, false),
-        ];
-        Instruction::new(id(), &ExchangeInstruction::AccountRequest, account_metas)
-    }
 
-    pub fn new_transfer_request(
-        owner: &Pubkey,
-        to: &Pubkey,
-        from: &Pubkey,
-        token: Token,
-        tokens: u64,
-    ) -> Instruction {
-        let account_metas = vec![
-            AccountMeta::new(*owner, true),
-            AccountMeta::new(*to, false),
-            AccountMeta::new(*from, false),
-        ];
-        Instruction::new(
-            id(),
-            &ExchangeInstruction::TransferRequest(token, tokens),
-            account_metas,
-        )
-    }
+pub fn account_request(owner: &Pubkey, new: &Pubkey) -> Instruction {
+    let account_metas = vec![
+        AccountMeta::new(*owner, true),
+        AccountMeta::new(*new, false),
+    ];
+    Instruction::new(id(), &ExchangeInstruction::AccountRequest, account_metas)
+}
 
-    pub fn new_trade_request(
-        owner: &Pubkey,
-        trade: &Pubkey,
-        direction: Direction,
-        pair: TokenPair,
-        tokens: u64,
-        price: u64,
-        src_account: &Pubkey,
-        dst_account: &Pubkey,
-    ) -> Instruction {
-        let account_metas = vec![
-            AccountMeta::new(*owner, true),
-            AccountMeta::new(*trade, false),
-            AccountMeta::new(*src_account, false),
-        ];
-        Instruction::new(
-            id(),
-            &ExchangeInstruction::TradeRequest(TradeRequestInfo {
-                direction,
-                pair,
-                tokens,
-                price,
-                dst_account: *dst_account,
-            }),
-            account_metas,
-        )
-    }
+pub fn transfer_request(
+    owner: &Pubkey,
+    to: &Pubkey,
+    from: &Pubkey,
+    token: Token,
+    tokens: u64,
+) -> Instruction {
+    let account_metas = vec![
+        AccountMeta::new(*owner, true),
+        AccountMeta::new(*to, false),
+        AccountMeta::new(*from, false),
+    ];
+    Instruction::new(
+        id(),
+        &ExchangeInstruction::TransferRequest(token, tokens),
+        account_metas,
+    )
+}
 
-    pub fn new_trade_cancellation(owner: &Pubkey, trade: &Pubkey, account: &Pubkey) -> Instruction {
-        let account_metas = vec![
-            AccountMeta::new(*owner, true),
-            AccountMeta::new(*trade, false),
-            AccountMeta::new(*account, false),
-        ];
-        Instruction::new(id(), &ExchangeInstruction::TradeCancellation, account_metas)
-    }
+pub fn trade_request(
+    owner: &Pubkey,
+    trade: &Pubkey,
+    direction: Direction,
+    pair: TokenPair,
+    tokens: u64,
+    price: u64,
+    src_account: &Pubkey,
+    dst_account: &Pubkey,
+) -> Instruction {
+    let account_metas = vec![
+        AccountMeta::new(*owner, true),
+        AccountMeta::new(*trade, false),
+        AccountMeta::new(*src_account, false),
+    ];
+    Instruction::new(
+        id(),
+        &ExchangeInstruction::TradeRequest(TradeRequestInfo {
+            direction,
+            pair,
+            tokens,
+            price,
+            dst_account: *dst_account,
+        }),
+        account_metas,
+    )
+}
 
-    pub fn new_swap_request(
-        owner: &Pubkey,
-        swap: &Pubkey,
-        to_trade: &Pubkey,
-        from_trade: &Pubkey,
-        to_trade_account: &Pubkey,
-        from_trade_account: &Pubkey,
-        profit_account: &Pubkey,
-    ) -> Instruction {
-        let account_metas = vec![
-            AccountMeta::new(*owner, true),
-            AccountMeta::new(*swap, false),
-            AccountMeta::new(*to_trade, false),
-            AccountMeta::new(*from_trade, false),
-            AccountMeta::new(*to_trade_account, false),
-            AccountMeta::new(*from_trade_account, false),
-            AccountMeta::new(*profit_account, false),
-        ];
-        Instruction::new(id(), &ExchangeInstruction::SwapRequest, account_metas)
-    }
+pub fn trade_cancellation(owner: &Pubkey, trade: &Pubkey, account: &Pubkey) -> Instruction {
+    let account_metas = vec![
+        AccountMeta::new(*owner, true),
+        AccountMeta::new(*trade, false),
+        AccountMeta::new(*account, false),
+    ];
+    Instruction::new(id(), &ExchangeInstruction::TradeCancellation, account_metas)
+}
+
+pub fn swap_request(
+    owner: &Pubkey,
+    swap: &Pubkey,
+    to_trade: &Pubkey,
+    from_trade: &Pubkey,
+    to_trade_account: &Pubkey,
+    from_trade_account: &Pubkey,
+    profit_account: &Pubkey,
+) -> Instruction {
+    let account_metas = vec![
+        AccountMeta::new(*owner, true),
+        AccountMeta::new(*swap, false),
+        AccountMeta::new(*to_trade, false),
+        AccountMeta::new(*from_trade, false),
+        AccountMeta::new(*to_trade_account, false),
+        AccountMeta::new(*from_trade_account, false),
+        AccountMeta::new(*profit_account, false),
+    ];
+    Instruction::new(id(), &ExchangeInstruction::SwapRequest, account_metas)
 }

--- a/programs/exchange_api/src/exchange_processor.rs
+++ b/programs/exchange_api/src/exchange_processor.rs
@@ -412,11 +412,12 @@ pub fn process_instruction(
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::exchange_instruction;
     use solana_runtime::bank::Bank;
     use solana_runtime::bank_client::BankClient;
     use solana_sdk::genesis_block::GenesisBlock;
     use solana_sdk::signature::{Keypair, KeypairUtil};
-    use solana_sdk::system_instruction::SystemInstruction;
+    use solana_sdk::system_instruction;
     use std::mem;
 
     fn try_calc(
@@ -527,7 +528,7 @@ mod test {
 
     fn create_account(client: &BankClient, owner: &Keypair) -> Pubkey {
         let new = Pubkey::new_rand();
-        let instruction = SystemInstruction::new_account(
+        let instruction = system_instruction::create_account(
             &owner.pubkey(),
             &new,
             1,
@@ -542,7 +543,7 @@ mod test {
 
     fn create_token_account(client: &BankClient, owner: &Keypair) -> Pubkey {
         let new = Pubkey::new_rand();
-        let instruction = SystemInstruction::new_account(
+        let instruction = system_instruction::create_account(
             &owner.pubkey(),
             &new,
             1,
@@ -552,7 +553,7 @@ mod test {
         client
             .process_instruction(owner, instruction)
             .expect(&format!("{}:{}", line!(), file!()));
-        let instruction = ExchangeInstruction::new_account_request(&owner.pubkey(), &new);
+        let instruction = exchange_instruction::account_request(&owner.pubkey(), &new);
         client
             .process_instruction(owner, instruction)
             .expect(&format!("{}:{}", line!(), file!()));
@@ -561,7 +562,7 @@ mod test {
 
     fn transfer(client: &BankClient, owner: &Keypair, to: &Pubkey, token: Token, tokens: u64) {
         let instruction =
-            ExchangeInstruction::new_transfer_request(&owner.pubkey(), to, &id(), token, tokens);
+            exchange_instruction::transfer_request(&owner.pubkey(), to, &id(), token, tokens);
         client
             .process_instruction(owner, instruction)
             .expect(&format!("{}:{}", line!(), file!()));
@@ -582,7 +583,7 @@ mod test {
         let dst = create_token_account(&client, &owner);
         transfer(&client, &owner, &src, from_token, src_tokens);
 
-        let instruction = ExchangeInstruction::new_trade_request(
+        let instruction = exchange_instruction::trade_request(
             &owner.pubkey(),
             &trade,
             direction,
@@ -633,7 +634,7 @@ mod test {
         let (client, owner) = create_client(&bank, mint_keypair);
 
         let new = create_token_account(&client, &owner);
-        let instruction = ExchangeInstruction::new_account_request(&owner.pubkey(), &new);
+        let instruction = exchange_instruction::account_request(&owner.pubkey(), &new);
         client
             .process_instruction(&owner, instruction)
             .expect_err(&format!("{}:{}", line!(), file!()));
@@ -648,7 +649,7 @@ mod test {
         let new = create_token_account(&client, &owner);
 
         let instruction =
-            ExchangeInstruction::new_transfer_request(&owner.pubkey(), &new, &id(), Token::A, 42);
+            exchange_instruction::transfer_request(&owner.pubkey(), &new, &id(), Token::A, 42);
         client
             .process_instruction(&owner, instruction)
             .expect(&format!("{}:{}", line!(), file!()));
@@ -743,7 +744,7 @@ mod test {
             3000,
         );
 
-        let instruction = ExchangeInstruction::new_swap_request(
+        let instruction = exchange_instruction::swap_request(
             &owner.pubkey(),
             &swap,
             &to_trade,

--- a/programs/exchange_api/src/exchange_transaction.rs
+++ b/programs/exchange_api/src/exchange_transaction.rs
@@ -1,120 +1,103 @@
-use crate::exchange_instruction::*;
+use crate::exchange_instruction;
 use crate::exchange_state::*;
 use crate::id;
 use solana_sdk::hash::Hash;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::{Keypair, KeypairUtil};
-use solana_sdk::system_instruction::SystemInstruction;
+use solana_sdk::system_instruction;
 use solana_sdk::transaction::Transaction;
 use std::mem;
 
-pub struct ExchangeTransaction {}
+pub fn account_request(
+    owner: &Keypair,
+    new: &Pubkey,
+    recent_blockhash: Hash,
+    _fee: u64,
+) -> Transaction {
+    let owner_id = &owner.pubkey();
+    let space = mem::size_of::<ExchangeState>() as u64;
+    let create_ix = system_instruction::create_account(owner_id, new, 1, space, &id());
+    let request_ix = exchange_instruction::account_request(owner_id, new);
+    Transaction::new_signed_instructions(&[owner], vec![create_ix, request_ix], recent_blockhash)
+}
 
-impl ExchangeTransaction {
-    pub fn new_account_request(
-        owner: &Keypair,
-        new: &Pubkey,
-        recent_blockhash: Hash,
-        _fee: u64,
-    ) -> Transaction {
-        let owner_id = &owner.pubkey();
-        let space = mem::size_of::<ExchangeState>() as u64;
-        let create_ix = SystemInstruction::new_account(owner_id, new, 1, space, &id());
-        let request_ix = ExchangeInstruction::new_account_request(owner_id, new);
-        Transaction::new_signed_instructions(
-            &[owner],
-            vec![create_ix, request_ix],
-            recent_blockhash,
-        )
-    }
+pub fn transfer_request(
+    owner: &Keypair,
+    to: &Pubkey,
+    from: &Pubkey,
+    token: Token,
+    tokens: u64,
+    recent_blockhash: Hash,
+    _fee: u64,
+) -> Transaction {
+    let owner_id = &owner.pubkey();
+    let request_ix = exchange_instruction::transfer_request(owner_id, to, from, token, tokens);
+    Transaction::new_signed_instructions(&[owner], vec![request_ix], recent_blockhash)
+}
 
-    pub fn new_transfer_request(
-        owner: &Keypair,
-        to: &Pubkey,
-        from: &Pubkey,
-        token: Token,
-        tokens: u64,
-        recent_blockhash: Hash,
-        _fee: u64,
-    ) -> Transaction {
-        let owner_id = &owner.pubkey();
-        let request_ix =
-            ExchangeInstruction::new_transfer_request(owner_id, to, from, token, tokens);
-        Transaction::new_signed_instructions(&[owner], vec![request_ix], recent_blockhash)
-    }
+#[allow(clippy::too_many_arguments)]
+pub fn trade_request(
+    owner: &Keypair,
+    trade: &Pubkey,
+    direction: Direction,
+    pair: TokenPair,
+    tokens: u64,
+    price: u64,
+    src_account: &Pubkey,
+    dst_account: &Pubkey,
+    recent_blockhash: Hash,
+    _fee: u64,
+) -> Transaction {
+    let owner_id = &owner.pubkey();
+    let space = mem::size_of::<ExchangeState>() as u64;
+    let create_ix = system_instruction::create_account(owner_id, trade, 1, space, &id());
+    let request_ix = exchange_instruction::trade_request(
+        owner_id,
+        trade,
+        direction,
+        pair,
+        tokens,
+        price,
+        src_account,
+        dst_account,
+    );
+    Transaction::new_signed_instructions(&[owner], vec![create_ix, request_ix], recent_blockhash)
+}
 
-    #[allow(clippy::too_many_arguments)]
-    pub fn new_trade_request(
-        owner: &Keypair,
-        trade: &Pubkey,
-        direction: Direction,
-        pair: TokenPair,
-        tokens: u64,
-        price: u64,
-        src_account: &Pubkey,
-        dst_account: &Pubkey,
-        recent_blockhash: Hash,
-        _fee: u64,
-    ) -> Transaction {
-        let owner_id = &owner.pubkey();
-        let space = mem::size_of::<ExchangeState>() as u64;
-        let create_ix = SystemInstruction::new_account(owner_id, trade, 1, space, &id());
-        let request_ix = ExchangeInstruction::new_trade_request(
-            owner_id,
-            trade,
-            direction,
-            pair,
-            tokens,
-            price,
-            src_account,
-            dst_account,
-        );
-        Transaction::new_signed_instructions(
-            &[owner],
-            vec![create_ix, request_ix],
-            recent_blockhash,
-        )
-    }
+pub fn trade_cancellation(
+    owner: &Keypair,
+    trade: &Pubkey,
+    account: &Pubkey,
+    recent_blockhash: Hash,
+    _fee: u64,
+) -> Transaction {
+    let owner_id = &owner.pubkey();
+    let request_ix = exchange_instruction::trade_cancellation(owner_id, trade, account);
+    Transaction::new_signed_instructions(&[owner], vec![request_ix], recent_blockhash)
+}
 
-    pub fn new_trade_cancellation(
-        owner: &Keypair,
-        trade: &Pubkey,
-        account: &Pubkey,
-        recent_blockhash: Hash,
-        _fee: u64,
-    ) -> Transaction {
-        let owner_id = &owner.pubkey();
-        let request_ix = ExchangeInstruction::new_trade_cancellation(owner_id, trade, account);
-        Transaction::new_signed_instructions(&[owner], vec![request_ix], recent_blockhash)
-    }
-
-    pub fn new_swap_request(
-        owner: &Keypair,
-        swap: &Pubkey,
-        to_trade: &Pubkey,
-        from_trade: &Pubkey,
-        to_trade_account: &Pubkey,
-        from_trade_account: &Pubkey,
-        profit_account: &Pubkey,
-        recent_blockhash: Hash,
-        _fee: u64,
-    ) -> Transaction {
-        let owner_id = &owner.pubkey();
-        let space = mem::size_of::<ExchangeState>() as u64;
-        let create_ix = SystemInstruction::new_account(owner_id, swap, 1, space, &id());
-        let request_ix = ExchangeInstruction::new_swap_request(
-            owner_id,
-            swap,
-            to_trade,
-            from_trade,
-            to_trade_account,
-            from_trade_account,
-            profit_account,
-        );
-        Transaction::new_signed_instructions(
-            &[owner],
-            vec![create_ix, request_ix],
-            recent_blockhash,
-        )
-    }
+pub fn swap_request(
+    owner: &Keypair,
+    swap: &Pubkey,
+    to_trade: &Pubkey,
+    from_trade: &Pubkey,
+    to_trade_account: &Pubkey,
+    from_trade_account: &Pubkey,
+    profit_account: &Pubkey,
+    recent_blockhash: Hash,
+    _fee: u64,
+) -> Transaction {
+    let owner_id = &owner.pubkey();
+    let space = mem::size_of::<ExchangeState>() as u64;
+    let create_ix = system_instruction::create_account(owner_id, swap, 1, space, &id());
+    let request_ix = exchange_instruction::swap_request(
+        owner_id,
+        swap,
+        to_trade,
+        from_trade,
+        to_trade_account,
+        from_trade_account,
+        profit_account,
+    );
+    Transaction::new_signed_instructions(&[owner], vec![create_ix, request_ix], recent_blockhash)
 }

--- a/programs/stake_api/src/stake_instruction.rs
+++ b/programs/stake_api/src/stake_instruction.rs
@@ -6,7 +6,7 @@ use serde_derive::{Deserialize, Serialize};
 use solana_sdk::account::KeyedAccount;
 use solana_sdk::instruction::{AccountMeta, Instruction, InstructionError};
 use solana_sdk::pubkey::Pubkey;
-use solana_sdk::system_instruction::SystemInstruction;
+use solana_sdk::system_instruction;
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub enum StakeInstruction {
@@ -22,44 +22,38 @@ pub enum StakeInstruction {
     RedeemVoteCredits,
 }
 
-impl StakeInstruction {
-    pub fn new_account(from_id: &Pubkey, staker_id: &Pubkey, lamports: u64) -> Vec<Instruction> {
-        vec![SystemInstruction::new_account(
-            from_id,
-            staker_id,
-            lamports,
-            std::mem::size_of::<StakeState>() as u64,
-            &id(),
-        )]
-    }
+pub fn create_account(from_id: &Pubkey, staker_id: &Pubkey, lamports: u64) -> Vec<Instruction> {
+    vec![system_instruction::create_account(
+        from_id,
+        staker_id,
+        lamports,
+        std::mem::size_of::<StakeState>() as u64,
+        &id(),
+    )]
+}
 
-    pub fn new_redeem_vote_credits(
-        from_id: &Pubkey,
-        mining_pool_id: &Pubkey,
-        stake_id: &Pubkey,
-        vote_id: &Pubkey,
-    ) -> Instruction {
-        let account_metas = vec![
-            AccountMeta::new(*from_id, true),
-            AccountMeta::new(*mining_pool_id, false),
-            AccountMeta::new(*stake_id, false),
-            AccountMeta::new(*vote_id, false),
-        ];
-        Instruction::new(id(), &StakeInstruction::RedeemVoteCredits, account_metas)
-    }
+pub fn redeem_vote_credits(
+    from_id: &Pubkey,
+    mining_pool_id: &Pubkey,
+    stake_id: &Pubkey,
+    vote_id: &Pubkey,
+) -> Instruction {
+    let account_metas = vec![
+        AccountMeta::new(*from_id, true),
+        AccountMeta::new(*mining_pool_id, false),
+        AccountMeta::new(*stake_id, false),
+        AccountMeta::new(*vote_id, false),
+    ];
+    Instruction::new(id(), &StakeInstruction::RedeemVoteCredits, account_metas)
+}
 
-    pub fn new_delegate_stake(
-        from_id: &Pubkey,
-        stake_id: &Pubkey,
-        vote_id: &Pubkey,
-    ) -> Instruction {
-        let account_metas = vec![
-            AccountMeta::new(*from_id, true),
-            AccountMeta::new(*stake_id, true),
-            AccountMeta::new(*vote_id, false),
-        ];
-        Instruction::new(id(), &StakeInstruction::DelegateStake, account_metas)
-    }
+pub fn delegate_stake(from_id: &Pubkey, stake_id: &Pubkey, vote_id: &Pubkey) -> Instruction {
+    let account_metas = vec![
+        AccountMeta::new(*from_id, true),
+        AccountMeta::new(*stake_id, true),
+        AccountMeta::new(*vote_id, false),
+    ];
+    Instruction::new(id(), &StakeInstruction::DelegateStake, account_metas)
 }
 
 pub fn process_instruction(

--- a/programs/storage_api/src/storage_instruction.rs
+++ b/programs/storage_api/src/storage_instruction.rs
@@ -26,51 +26,49 @@ pub enum StorageInstruction {
     },
 }
 
-impl StorageInstruction {
-    pub fn new_mining_proof(
-        from_pubkey: &Pubkey,
-        sha_state: Hash,
-        entry_height: u64,
-        signature: Signature,
-    ) -> Instruction {
-        let storage_instruction = StorageInstruction::SubmitMiningProof {
-            sha_state,
-            entry_height,
-            signature,
-        };
-        let account_metas = vec![AccountMeta::new(*from_pubkey, true)];
-        Instruction::new(id(), &storage_instruction, account_metas)
-    }
+pub fn mining_proof(
+    from_pubkey: &Pubkey,
+    sha_state: Hash,
+    entry_height: u64,
+    signature: Signature,
+) -> Instruction {
+    let storage_instruction = StorageInstruction::SubmitMiningProof {
+        sha_state,
+        entry_height,
+        signature,
+    };
+    let account_metas = vec![AccountMeta::new(*from_pubkey, true)];
+    Instruction::new(id(), &storage_instruction, account_metas)
+}
 
-    pub fn new_advertise_recent_blockhash(
-        from_pubkey: &Pubkey,
-        storage_hash: Hash,
-        entry_height: u64,
-    ) -> Instruction {
-        let storage_instruction = StorageInstruction::AdvertiseStorageRecentBlockhash {
-            hash: storage_hash,
-            entry_height,
-        };
-        let account_metas = vec![AccountMeta::new(*from_pubkey, true)];
-        Instruction::new(id(), &storage_instruction, account_metas)
-    }
+pub fn advertise_recent_blockhash(
+    from_pubkey: &Pubkey,
+    storage_hash: Hash,
+    entry_height: u64,
+) -> Instruction {
+    let storage_instruction = StorageInstruction::AdvertiseStorageRecentBlockhash {
+        hash: storage_hash,
+        entry_height,
+    };
+    let account_metas = vec![AccountMeta::new(*from_pubkey, true)];
+    Instruction::new(id(), &storage_instruction, account_metas)
+}
 
-    pub fn new_proof_validation(
-        from_pubkey: &Pubkey,
-        entry_height: u64,
-        proof_mask: Vec<ProofStatus>,
-    ) -> Instruction {
-        let storage_instruction = StorageInstruction::ProofValidation {
-            entry_height,
-            proof_mask,
-        };
-        let account_metas = vec![AccountMeta::new(*from_pubkey, true)];
-        Instruction::new(id(), &storage_instruction, account_metas)
-    }
+pub fn proof_validation(
+    from_pubkey: &Pubkey,
+    entry_height: u64,
+    proof_mask: Vec<ProofStatus>,
+) -> Instruction {
+    let storage_instruction = StorageInstruction::ProofValidation {
+        entry_height,
+        proof_mask,
+    };
+    let account_metas = vec![AccountMeta::new(*from_pubkey, true)];
+    Instruction::new(id(), &storage_instruction, account_metas)
+}
 
-    pub fn new_reward_claim(from_pubkey: &Pubkey, entry_height: u64) -> Instruction {
-        let storage_instruction = StorageInstruction::ClaimStorageReward { entry_height };
-        let account_metas = vec![AccountMeta::new(*from_pubkey, true)];
-        Instruction::new(id(), &storage_instruction, account_metas)
-    }
+pub fn reward_claim(from_pubkey: &Pubkey, entry_height: u64) -> Instruction {
+    let storage_instruction = StorageInstruction::ClaimStorageReward { entry_height };
+    let account_metas = vec![AccountMeta::new(*from_pubkey, true)];
+    Instruction::new(id(), &storage_instruction, account_metas)
 }

--- a/programs/vote_api/src/vote_instruction.rs
+++ b/programs/vote_api/src/vote_instruction.rs
@@ -3,7 +3,7 @@ use crate::vote_state::VoteState;
 use serde_derive::{Deserialize, Serialize};
 use solana_sdk::instruction::{AccountMeta, Instruction};
 use solana_sdk::pubkey::Pubkey;
-use solana_sdk::system_instruction::SystemInstruction;
+use solana_sdk::system_instruction;
 
 #[derive(Serialize, Default, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub struct Vote {
@@ -37,44 +37,42 @@ pub enum VoteInstruction {
     ClearCredits,
 }
 
-impl VoteInstruction {
-    fn new_initialize_account(vote_id: &Pubkey) -> Instruction {
-        let account_metas = vec![AccountMeta::new(*vote_id, false)];
-        Instruction::new(id(), &VoteInstruction::InitializeAccount, account_metas)
-    }
+fn initialize_account(vote_id: &Pubkey) -> Instruction {
+    let account_metas = vec![AccountMeta::new(*vote_id, false)];
+    Instruction::new(id(), &VoteInstruction::InitializeAccount, account_metas)
+}
 
-    pub fn new_account(from_id: &Pubkey, staker_id: &Pubkey, lamports: u64) -> Vec<Instruction> {
-        let space = VoteState::max_size() as u64;
-        let create_ix = SystemInstruction::new_account(&from_id, staker_id, lamports, space, &id());
-        let init_ix = VoteInstruction::new_initialize_account(staker_id);
-        vec![create_ix, init_ix]
-    }
+pub fn create_account(from_id: &Pubkey, staker_id: &Pubkey, lamports: u64) -> Vec<Instruction> {
+    let space = VoteState::max_size() as u64;
+    let create_ix = system_instruction::create_account(&from_id, staker_id, lamports, space, &id());
+    let init_ix = initialize_account(staker_id);
+    vec![create_ix, init_ix]
+}
 
-    pub fn new_clear_credits(vote_id: &Pubkey) -> Instruction {
-        let account_metas = vec![AccountMeta::new(*vote_id, true)];
-        Instruction::new(id(), &VoteInstruction::ClearCredits, account_metas)
-    }
+pub fn clear_credits(vote_id: &Pubkey) -> Instruction {
+    let account_metas = vec![AccountMeta::new(*vote_id, true)];
+    Instruction::new(id(), &VoteInstruction::ClearCredits, account_metas)
+}
 
-    pub fn new_delegate_stake(vote_id: &Pubkey, delegate_id: &Pubkey) -> Instruction {
-        let account_metas = vec![AccountMeta::new(*vote_id, true)];
-        Instruction::new(
-            id(),
-            &VoteInstruction::DelegateStake(*delegate_id),
-            account_metas,
-        )
-    }
+pub fn delegate_stake(vote_id: &Pubkey, delegate_id: &Pubkey) -> Instruction {
+    let account_metas = vec![AccountMeta::new(*vote_id, true)];
+    Instruction::new(
+        id(),
+        &VoteInstruction::DelegateStake(*delegate_id),
+        account_metas,
+    )
+}
 
-    pub fn new_authorize_voter(vote_id: &Pubkey, authorized_voter_id: &Pubkey) -> Instruction {
-        let account_metas = vec![AccountMeta::new(*vote_id, true)];
-        Instruction::new(
-            id(),
-            &VoteInstruction::AuthorizeVoter(*authorized_voter_id),
-            account_metas,
-        )
-    }
+pub fn authorize_voter(vote_id: &Pubkey, authorized_voter_id: &Pubkey) -> Instruction {
+    let account_metas = vec![AccountMeta::new(*vote_id, true)];
+    Instruction::new(
+        id(),
+        &VoteInstruction::AuthorizeVoter(*authorized_voter_id),
+        account_metas,
+    )
+}
 
-    pub fn new_vote(vote_id: &Pubkey, vote: Vote) -> Instruction {
-        let account_metas = vec![AccountMeta::new(*vote_id, true)];
-        Instruction::new(id(), &VoteInstruction::Vote(vote), account_metas)
-    }
+pub fn vote(vote_id: &Pubkey, vote: Vote) -> Instruction {
+    let account_metas = vec![AccountMeta::new(*vote_id, true)];
+    Instruction::new(id(), &VoteInstruction::Vote(vote), account_metas)
 }

--- a/runtime/benches/bank.rs
+++ b/runtime/benches/bank.rs
@@ -6,7 +6,7 @@ use solana_runtime::bank::*;
 use solana_sdk::genesis_block::GenesisBlock;
 use solana_sdk::hash::hash;
 use solana_sdk::signature::{Keypair, KeypairUtil};
-use solana_sdk::system_transaction::SystemTransaction;
+use solana_sdk::system_transaction;
 use solana_sdk::timing::{DEFAULT_TICKS_PER_SLOT, MAX_RECENT_BLOCKHASHES};
 use test::Bencher;
 
@@ -21,7 +21,7 @@ fn bench_process_transaction(bencher: &mut Bencher) {
         .map(|_| {
             // Seed the 'from' account.
             let rando0 = Keypair::new();
-            let tx = SystemTransaction::new_transfer(
+            let tx = system_transaction::transfer(
                 &mint_keypair,
                 &rando0.pubkey(),
                 10_000,
@@ -32,7 +32,7 @@ fn bench_process_transaction(bencher: &mut Bencher) {
 
             // Seed the 'to' account and a cell for its signature.
             let rando1 = Keypair::new();
-            let tx = SystemTransaction::new_transfer(
+            let tx = system_transaction::transfer(
                 &rando0,
                 &rando1.pubkey(),
                 1,

--- a/runtime/src/bank_client.rs
+++ b/runtime/src/bank_client.rs
@@ -3,7 +3,7 @@ use solana_sdk::instruction::Instruction;
 use solana_sdk::message::Message;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::{Keypair, KeypairUtil};
-use solana_sdk::system_instruction::SystemInstruction;
+use solana_sdk::system_instruction;
 use solana_sdk::transaction::{Transaction, TransactionError};
 
 pub struct BankClient<'a> {
@@ -42,7 +42,7 @@ impl<'a> BankClient<'a> {
         keypair: &Keypair,
         pubkey: &Pubkey,
     ) -> Result<(), TransactionError> {
-        let move_instruction = SystemInstruction::new_transfer(&keypair.pubkey(), pubkey, lamports);
+        let move_instruction = system_instruction::transfer(&keypair.pubkey(), pubkey, lamports);
         self.process_instruction(keypair, move_instruction)
     }
 }
@@ -65,7 +65,7 @@ mod tests {
 
         // Create 2-2 Multisig Transfer instruction.
         let bob_pubkey = Pubkey::new_rand();
-        let mut move_instruction = SystemInstruction::new_transfer(&john_pubkey, &bob_pubkey, 42);
+        let mut move_instruction = system_instruction::transfer(&john_pubkey, &bob_pubkey, 42);
         move_instruction
             .accounts
             .push(AccountMeta::new(jane_pubkey, true));

--- a/runtime/src/loader_utils.rs
+++ b/runtime/src/loader_utils.rs
@@ -1,10 +1,10 @@
 use crate::bank_client::BankClient;
 use serde::Serialize;
 use solana_sdk::instruction::{AccountMeta, Instruction};
-use solana_sdk::loader_instruction::LoaderInstruction;
+use solana_sdk::loader_instruction;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::{Keypair, KeypairUtil};
-use solana_sdk::system_instruction::SystemInstruction;
+use solana_sdk::system_instruction;
 
 pub fn load_program(
     bank_client: &BankClient,
@@ -15,7 +15,7 @@ pub fn load_program(
     let program_keypair = Keypair::new();
     let program_pubkey = program_keypair.pubkey();
 
-    let instruction = SystemInstruction::new_account(
+    let instruction = system_instruction::create_account(
         &from_keypair.pubkey(),
         &program_pubkey,
         1,
@@ -30,14 +30,14 @@ pub fn load_program(
     let mut offset = 0;
     for chunk in program.chunks(chunk_size) {
         let instruction =
-            LoaderInstruction::new_write(&program_pubkey, loader_id, offset, chunk.to_vec());
+            loader_instruction::write(&program_pubkey, loader_id, offset, chunk.to_vec());
         bank_client
             .process_instruction(&program_keypair, instruction)
             .unwrap();
         offset += chunk_size as u32;
     }
 
-    let instruction = LoaderInstruction::new_finalize(&program_pubkey, loader_id);
+    let instruction = loader_instruction::finalize(&program_pubkey, loader_id);
     bank_client
         .process_instruction(&program_keypair, instruction)
         .unwrap();

--- a/runtime/src/system_instruction_processor.rs
+++ b/runtime/src/system_instruction_processor.rs
@@ -110,7 +110,6 @@ mod tests {
     use solana_sdk::genesis_block::GenesisBlock;
     use solana_sdk::instruction::{AccountMeta, Instruction, InstructionError};
     use solana_sdk::signature::{Keypair, KeypairUtil};
-    use solana_sdk::system_instruction::SystemInstruction;
     use solana_sdk::system_program;
     use solana_sdk::transaction::TransactionError;
 

--- a/sdk/src/fee_calculator.rs
+++ b/sdk/src/fee_calculator.rs
@@ -21,7 +21,7 @@ impl FeeCalculator {
 mod tests {
     use super::*;
     use crate::pubkey::Pubkey;
-    use crate::system_instruction::SystemInstruction;
+    use crate::system_instruction;
 
     #[test]
     fn test_fee_calculator_calculate_fee() {
@@ -35,13 +35,13 @@ mod tests {
         // One signature, a fee.
         let pubkey0 = Pubkey::new(&[0; 32]);
         let pubkey1 = Pubkey::new(&[1; 32]);
-        let ix0 = SystemInstruction::new_transfer(&pubkey0, &pubkey1, 1);
+        let ix0 = system_instruction::transfer(&pubkey0, &pubkey1, 1);
         let message = Message::new(vec![ix0]);
         assert_eq!(FeeCalculator::new(2).calculate_fee(&message), 2);
 
         // Two signatures, double the fee.
-        let ix0 = SystemInstruction::new_transfer(&pubkey0, &pubkey1, 1);
-        let ix1 = SystemInstruction::new_transfer(&pubkey1, &pubkey0, 1);
+        let ix0 = system_instruction::transfer(&pubkey0, &pubkey1, 1);
+        let ix1 = system_instruction::transfer(&pubkey1, &pubkey0, 1);
         let message = Message::new(vec![ix0, ix1]);
         assert_eq!(FeeCalculator::new(2).calculate_fee(&message), 4);
     }

--- a/sdk/src/loader_instruction.rs
+++ b/sdk/src/loader_instruction.rs
@@ -20,23 +20,16 @@ pub enum LoaderInstruction {
     Finalize,
 }
 
-impl LoaderInstruction {
-    pub fn new_write(
-        account_id: &Pubkey,
-        program_id: &Pubkey,
-        offset: u32,
-        bytes: Vec<u8>,
-    ) -> Instruction {
-        let account_metas = vec![AccountMeta::new(*account_id, true)];
-        Instruction::new(
-            *program_id,
-            &LoaderInstruction::Write { offset, bytes },
-            account_metas,
-        )
-    }
+pub fn write(account_id: &Pubkey, program_id: &Pubkey, offset: u32, bytes: Vec<u8>) -> Instruction {
+    let account_metas = vec![AccountMeta::new(*account_id, true)];
+    Instruction::new(
+        *program_id,
+        &LoaderInstruction::Write { offset, bytes },
+        account_metas,
+    )
+}
 
-    pub fn new_finalize(account_id: &Pubkey, program_id: &Pubkey) -> Instruction {
-        let account_metas = vec![AccountMeta::new(*account_id, true)];
-        Instruction::new(*program_id, &LoaderInstruction::Finalize, account_metas)
-    }
+pub fn finalize(account_id: &Pubkey, program_id: &Pubkey) -> Instruction {
+    let account_metas = vec![AccountMeta::new(*account_id, true)];
+    Instruction::new(*program_id, &LoaderInstruction::Finalize, account_metas)
 }

--- a/sdk/src/system_instruction.rs
+++ b/sdk/src/system_instruction.rs
@@ -31,65 +31,63 @@ pub enum SystemInstruction {
     Transfer { lamports: u64 },
 }
 
-impl SystemInstruction {
-    pub fn new_account(
-        from_id: &Pubkey,
-        to_id: &Pubkey,
-        lamports: u64,
-        space: u64,
-        program_id: &Pubkey,
-    ) -> Instruction {
-        let account_metas = vec![
-            AccountMeta::new(*from_id, true),
-            AccountMeta::new(*to_id, false),
-        ];
-        Instruction::new(
-            system_program::id(),
-            &SystemInstruction::CreateAccount {
-                lamports,
-                space,
-                program_id: *program_id,
-            },
-            account_metas,
-        )
-    }
+pub fn create_account(
+    from_id: &Pubkey,
+    to_id: &Pubkey,
+    lamports: u64,
+    space: u64,
+    program_id: &Pubkey,
+) -> Instruction {
+    let account_metas = vec![
+        AccountMeta::new(*from_id, true),
+        AccountMeta::new(*to_id, false),
+    ];
+    Instruction::new(
+        system_program::id(),
+        &SystemInstruction::CreateAccount {
+            lamports,
+            space,
+            program_id: *program_id,
+        },
+        account_metas,
+    )
+}
 
-    /// Create and sign a transaction to create a system account
-    pub fn new_user_account(from_id: &Pubkey, to_id: &Pubkey, lamports: u64) -> Instruction {
-        let program_id = system_program::id();
-        Self::new_account(from_id, to_id, lamports, 0, &program_id)
-    }
+/// Create and sign a transaction to create a system account
+pub fn create_user_account(from_id: &Pubkey, to_id: &Pubkey, lamports: u64) -> Instruction {
+    let program_id = system_program::id();
+    create_account(from_id, to_id, lamports, 0, &program_id)
+}
 
-    pub fn new_assign(from_id: &Pubkey, program_id: &Pubkey) -> Instruction {
-        let account_metas = vec![AccountMeta::new(*from_id, true)];
-        Instruction::new(
-            system_program::id(),
-            &SystemInstruction::Assign {
-                program_id: *program_id,
-            },
-            account_metas,
-        )
-    }
+pub fn assign(from_id: &Pubkey, program_id: &Pubkey) -> Instruction {
+    let account_metas = vec![AccountMeta::new(*from_id, true)];
+    Instruction::new(
+        system_program::id(),
+        &SystemInstruction::Assign {
+            program_id: *program_id,
+        },
+        account_metas,
+    )
+}
 
-    pub fn new_transfer(from_id: &Pubkey, to_id: &Pubkey, lamports: u64) -> Instruction {
-        let account_metas = vec![
-            AccountMeta::new(*from_id, true),
-            AccountMeta::new(*to_id, false),
-        ];
-        Instruction::new(
-            system_program::id(),
-            &SystemInstruction::Transfer { lamports },
-            account_metas,
-        )
-    }
+pub fn transfer(from_id: &Pubkey, to_id: &Pubkey, lamports: u64) -> Instruction {
+    let account_metas = vec![
+        AccountMeta::new(*from_id, true),
+        AccountMeta::new(*to_id, false),
+    ];
+    Instruction::new(
+        system_program::id(),
+        &SystemInstruction::Transfer { lamports },
+        account_metas,
+    )
+}
 
-    /// Create and sign new SystemInstruction::Transfer transaction to many destinations
-    pub fn new_transfer_many(from_id: &Pubkey, to_lamports: &[(Pubkey, u64)]) -> Vec<Instruction> {
-        to_lamports
-            .iter()
-            .map(|(to_id, lamports)| SystemInstruction::new_transfer(from_id, to_id, *lamports))
-            .collect()
-    }
+/// Create and sign new SystemInstruction::Transfer transaction to many destinations
+pub fn transfer_many(from_id: &Pubkey, to_lamports: &[(Pubkey, u64)]) -> Vec<Instruction> {
+    to_lamports
+        .iter()
+        .map(|(to_id, lamports)| transfer(from_id, to_id, *lamports))
+        .collect()
 }
 
 #[cfg(test)]
@@ -107,7 +105,7 @@ mod tests {
         let carol_pubkey = Pubkey::new_rand();
         let to_lamports = vec![(bob_pubkey, 1), (carol_pubkey, 2)];
 
-        let instructions = SystemInstruction::new_transfer_many(&alice_pubkey, &to_lamports);
+        let instructions = transfer_many(&alice_pubkey, &to_lamports);
         assert_eq!(instructions.len(), 2);
         assert_eq!(get_keys(&instructions[0]), vec![alice_pubkey, bob_pubkey]);
         assert_eq!(get_keys(&instructions[1]), vec![alice_pubkey, carol_pubkey]);

--- a/sdk/src/system_transaction.rs
+++ b/sdk/src/system_transaction.rs
@@ -3,74 +3,70 @@
 use crate::hash::Hash;
 use crate::pubkey::Pubkey;
 use crate::signature::{Keypair, KeypairUtil};
-use crate::system_instruction::SystemInstruction;
+use crate::system_instruction;
 use crate::system_program;
 use crate::transaction::Transaction;
 
-pub struct SystemTransaction {}
+/// Create and sign new SystemInstruction::CreateAccount transaction
+pub fn create_account(
+    from_keypair: &Keypair,
+    to: &Pubkey,
+    recent_blockhash: Hash,
+    lamports: u64,
+    space: u64,
+    program_id: &Pubkey,
+    _fee: u64,
+) -> Transaction {
+    let from_pubkey = from_keypair.pubkey();
+    let create_instruction =
+        system_instruction::create_account(&from_pubkey, to, lamports, space, program_id);
+    let instructions = vec![create_instruction];
+    Transaction::new_signed_instructions(&[from_keypair], instructions, recent_blockhash)
+}
 
-impl SystemTransaction {
-    /// Create and sign new SystemInstruction::CreateAccount transaction
-    pub fn new_account(
-        from_keypair: &Keypair,
-        to: &Pubkey,
-        recent_blockhash: Hash,
-        lamports: u64,
-        space: u64,
-        program_id: &Pubkey,
-        _fee: u64,
-    ) -> Transaction {
-        let from_pubkey = from_keypair.pubkey();
-        let create_instruction =
-            SystemInstruction::new_account(&from_pubkey, to, lamports, space, program_id);
-        let instructions = vec![create_instruction];
-        Transaction::new_signed_instructions(&[from_keypair], instructions, recent_blockhash)
-    }
+/// Create and sign a transaction to create a system account
+pub fn create_user_account(
+    from_keypair: &Keypair,
+    to: &Pubkey,
+    lamports: u64,
+    recent_blockhash: Hash,
+    fee: u64,
+) -> Transaction {
+    let program_id = system_program::id();
+    create_account(
+        from_keypair,
+        to,
+        recent_blockhash,
+        lamports,
+        0,
+        &program_id,
+        fee,
+    )
+}
 
-    /// Create and sign a transaction to create a system account
-    pub fn new_user_account(
-        from_keypair: &Keypair,
-        to: &Pubkey,
-        lamports: u64,
-        recent_blockhash: Hash,
-        fee: u64,
-    ) -> Transaction {
-        let program_id = system_program::id();
-        Self::new_account(
-            from_keypair,
-            to,
-            recent_blockhash,
-            lamports,
-            0,
-            &program_id,
-            fee,
-        )
-    }
+/// Create and sign new system_instruction::Assign transaction
+pub fn assign(
+    from_keypair: &Keypair,
+    recent_blockhash: Hash,
+    program_id: &Pubkey,
+    _fee: u64,
+) -> Transaction {
+    let from_pubkey = from_keypair.pubkey();
+    let assign_instruction = system_instruction::assign(&from_pubkey, program_id);
+    let instructions = vec![assign_instruction];
+    Transaction::new_signed_instructions(&[from_keypair], instructions, recent_blockhash)
+}
 
-    /// Create and sign new SystemInstruction::Assign transaction
-    pub fn new_assign(
-        from_keypair: &Keypair,
-        recent_blockhash: Hash,
-        program_id: &Pubkey,
-        _fee: u64,
-    ) -> Transaction {
-        let from_pubkey = from_keypair.pubkey();
-        let assign_instruction = SystemInstruction::new_assign(&from_pubkey, program_id);
-        let instructions = vec![assign_instruction];
-        Transaction::new_signed_instructions(&[from_keypair], instructions, recent_blockhash)
-    }
-
-    /// Create and sign new SystemInstruction::Transfer transaction
-    pub fn new_transfer(
-        from_keypair: &Keypair,
-        to: &Pubkey,
-        lamports: u64,
-        recent_blockhash: Hash,
-        _fee: u64,
-    ) -> Transaction {
-        let from_pubkey = from_keypair.pubkey();
-        let move_instruction = SystemInstruction::new_transfer(&from_pubkey, to, lamports);
-        let instructions = vec![move_instruction];
-        Transaction::new_signed_instructions(&[from_keypair], instructions, recent_blockhash)
-    }
+/// Create and sign new system_instruction::Transfer transaction
+pub fn transfer(
+    from_keypair: &Keypair,
+    to: &Pubkey,
+    lamports: u64,
+    recent_blockhash: Hash,
+    _fee: u64,
+) -> Transaction {
+    let from_pubkey = from_keypair.pubkey();
+    let move_instruction = system_instruction::transfer(&from_pubkey, to, lamports);
+    let instructions = vec![move_instruction];
+    Transaction::new_signed_instructions(&[from_keypair], instructions, recent_blockhash)
 }

--- a/sdk/src/transaction.rs
+++ b/sdk/src/transaction.rs
@@ -200,7 +200,7 @@ mod tests {
     use super::*;
     use crate::instruction::AccountMeta;
     use crate::signature::Keypair;
-    use crate::system_instruction::SystemInstruction;
+    use crate::system_instruction;
     use bincode::{deserialize, serialize, serialized_size};
     use std::mem::size_of;
 
@@ -321,7 +321,7 @@ mod tests {
         let alice_keypair = Keypair::new();
         let alice_pubkey = alice_keypair.pubkey();
         let bob_pubkey = Pubkey::new_rand();
-        let ix = SystemInstruction::new_transfer(&alice_pubkey, &bob_pubkey, 42);
+        let ix = system_instruction::transfer(&alice_pubkey, &bob_pubkey, 42);
 
         let expected_data_size = size_of::<u32>() + size_of::<u64>();
         assert_eq!(expected_data_size, 12);


### PR DESCRIPTION
#### Problem

Our convention for Instruction constructors carries a bunch of historical baggage. They used to be part of Transaction, then were extracted via traits, and then the traits were converted to structs.  Because they've always been attached to some struct they carry a `new_` prefix, which creates awkward naming since the instruction name is typically in the form `<verb><subject>`.

#### Summary of Changes

By getting rid of the wrapper structs, we can can get rid of the `new_` prefixes and blindly (and sensibly) give all functions the snake_case version of the instruction name.  Not in this PR, but if we could tag the Instruction enums with a bit of AccountMeta guidance, the creation of these functions can be fully automated.  This PR represents a big step in that direction.
