### PR TITLE
Add SyncClient and use from BankClient

### DIFF
--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -29,6 +29,7 @@ mod bpf {
         use super::*;
         use solana_sdk::bpf_loader;
         use solana_sdk::signature::KeypairUtil;
+        use solana_sdk::sync_client::SyncClient;
         use std::io::Read;
 
         #[test]
@@ -47,7 +48,7 @@ mod bpf {
             let program_id = load_program(&bank_client, &alice_keypair, &bpf_loader::id(), elf);
             let instruction = create_invoke_instruction(alice_keypair.pubkey(), program_id, &1u8);
             bank_client
-                .process_instruction(&alice_keypair, instruction)
+                .send_instruction(&alice_keypair, instruction)
                 .unwrap();
         }
 
@@ -86,7 +87,7 @@ mod bpf {
                 let instruction =
                     create_invoke_instruction(alice_keypair.pubkey(), program_id, &1u8);
                 bank_client
-                    .process_instruction(&alice_keypair, instruction)
+                    .send_instruction(&alice_keypair, instruction)
                     .unwrap();
             }
         }
@@ -100,6 +101,7 @@ mod bpf {
     mod bpf_rust {
         use super::*;
         use solana_sdk::signature::KeypairUtil;
+        use solana_sdk::sync_client::SyncClient;
         use std::io::Read;
 
         #[test]
@@ -130,7 +132,7 @@ mod bpf {
                 let instruction =
                     create_invoke_instruction(alice_keypair.pubkey(), program_id, &1u8);
                 bank_client
-                    .process_instruction(&alice_keypair, instruction)
+                    .send_instruction(&alice_keypair, instruction)
                     .unwrap();
             }
         }

--- a/programs/config_api/src/config_processor.rs
+++ b/programs/config_api/src/config_processor.rs
@@ -118,7 +118,10 @@ mod tests {
             .send_message(&[&from_keypair, &config_keypair], message)
             .unwrap();
 
-        let config_account_data = bank_client.get_account_data(&config_pubkey).unwrap();
+        let config_account_data = bank_client
+            .get_account_data(&config_pubkey)
+            .unwrap()
+            .unwrap();
         assert_eq!(
             my_config,
             MyConfig::deserialize(&config_account_data).unwrap()

--- a/programs/config_api/src/config_processor.rs
+++ b/programs/config_api/src/config_processor.rs
@@ -36,6 +36,7 @@ mod tests {
     use solana_sdk::genesis_block::GenesisBlock;
     use solana_sdk::message::Message;
     use solana_sdk::signature::{Keypair, KeypairUtil};
+    use solana_sdk::sync_client::SyncClient;
     use solana_sdk::system_instruction;
 
     #[derive(Serialize, Deserialize, Default, Debug, PartialEq)]
@@ -76,7 +77,7 @@ mod tests {
             .unwrap();
 
         bank_client
-            .process_instruction(
+            .send_instruction(
                 &mint_keypair,
                 config_instruction::create_account::<MyConfig>(
                     &mint_keypair.pubkey(),
@@ -114,7 +115,7 @@ mod tests {
             config_instruction::store(&from_keypair.pubkey(), &config_pubkey, &my_config);
         let message = Message::new(vec![instruction]);
         bank_client
-            .process_message(&[&from_keypair, &config_keypair], message)
+            .send_message(&[&from_keypair, &config_keypair], message)
             .unwrap();
 
         let config_account = bank.get_account(&config_pubkey).unwrap();
@@ -139,7 +140,7 @@ mod tests {
 
         let message = Message::new(vec![instruction]);
         bank_client
-            .process_message(&[&from_keypair, &config_keypair], message)
+            .send_message(&[&from_keypair, &config_keypair], message)
             .unwrap_err();
     }
 
@@ -162,7 +163,7 @@ mod tests {
         // Don't sign the transaction with `config_client`
         let message = Message::new(vec![move_instruction, store_instruction]);
         bank_client
-            .process_message(&[&system_keypair], message)
+            .send_message(&[&system_keypair], message)
             .unwrap_err();
     }
 }

--- a/programs/config_api/src/config_processor.rs
+++ b/programs/config_api/src/config_processor.rs
@@ -118,10 +118,10 @@ mod tests {
             .send_message(&[&from_keypair, &config_keypair], message)
             .unwrap();
 
-        let config_account = bank.get_account(&config_pubkey).unwrap();
+        let config_account_data = bank_client.get_account_data(&config_pubkey).unwrap();
         assert_eq!(
             my_config,
-            MyConfig::deserialize(&config_account.data).unwrap()
+            MyConfig::deserialize(&config_account_data).unwrap()
         );
     }
 

--- a/programs/exchange_api/src/exchange_processor.rs
+++ b/programs/exchange_api/src/exchange_processor.rs
@@ -652,7 +652,7 @@ mod test {
         let (client, owner) = create_client(&bank, mint_keypair);
 
         let new = create_token_account(&client, &owner);
-        let new_account_data = client.get_account_data(&new).unwrap();
+        let new_account_data = client.get_account_data(&new).unwrap().unwrap();
 
         // Check results
 
@@ -691,7 +691,7 @@ mod test {
             .send_instruction(&owner, instruction)
             .expect(&format!("{}:{}", line!(), file!()));
 
-        let new_account_data = client.get_account_data(&new).unwrap();
+        let new_account_data = client.get_account_data(&new).unwrap().unwrap();
 
         // Check results
 
@@ -720,9 +720,9 @@ mod test {
             1000,
         );
 
-        let trade_account_data = client.get_account_data(&trade).unwrap();
-        let src_account_data = client.get_account_data(&src).unwrap();
-        let dst_account_data = client.get_account_data(&dst).unwrap();
+        let trade_account_data = client.get_account_data(&trade).unwrap().unwrap();
+        let src_account_data = client.get_account_data(&src).unwrap().unwrap();
+        let dst_account_data = client.get_account_data(&dst).unwrap().unwrap();
 
         // check results
 
@@ -794,14 +794,14 @@ mod test {
             .send_instruction(&owner, instruction)
             .expect(&format!("{}:{}", line!(), file!()));
 
-        let to_trade_account_data = client.get_account_data(&to_trade).unwrap();
-        let to_src_account_data = client.get_account_data(&to_src).unwrap();
-        let to_dst_account_data = client.get_account_data(&to_dst).unwrap();
-        let from_trade_account_data = client.get_account_data(&from_trade).unwrap();
-        let from_src_account_data = client.get_account_data(&from_src).unwrap();
-        let from_dst_account_data = client.get_account_data(&from_dst).unwrap();
-        let profit_account_data = client.get_account_data(&profit).unwrap();
-        let swap_account_data = client.get_account_data(&swap).unwrap();
+        let to_trade_account_data = client.get_account_data(&to_trade).unwrap().unwrap();
+        let to_src_account_data = client.get_account_data(&to_src).unwrap().unwrap();
+        let to_dst_account_data = client.get_account_data(&to_dst).unwrap().unwrap();
+        let from_trade_account_data = client.get_account_data(&from_trade).unwrap().unwrap();
+        let from_src_account_data = client.get_account_data(&from_src).unwrap().unwrap();
+        let from_dst_account_data = client.get_account_data(&from_dst).unwrap().unwrap();
+        let profit_account_data = client.get_account_data(&profit).unwrap().unwrap();
+        let swap_account_data = client.get_account_data(&swap).unwrap().unwrap();
 
         // check results
 

--- a/programs/exchange_api/src/exchange_processor.rs
+++ b/programs/exchange_api/src/exchange_processor.rs
@@ -453,6 +453,7 @@ mod test {
     use solana_runtime::bank_client::BankClient;
     use solana_sdk::genesis_block::GenesisBlock;
     use solana_sdk::signature::{Keypair, KeypairUtil};
+    use solana_sdk::sync_client::SyncClient;
     use solana_sdk::system_instruction;
     use std::mem;
 
@@ -572,7 +573,7 @@ mod test {
             &id(),
         );
         client
-            .process_instruction(&owner, instruction)
+            .send_instruction(&owner, instruction)
             .expect(&format!("{}:{}", line!(), file!()));
         new
     }
@@ -587,11 +588,11 @@ mod test {
             &id(),
         );
         client
-            .process_instruction(owner, instruction)
+            .send_instruction(owner, instruction)
             .expect(&format!("{}:{}", line!(), file!()));
         let instruction = exchange_instruction::account_request(&owner.pubkey(), &new);
         client
-            .process_instruction(owner, instruction)
+            .send_instruction(owner, instruction)
             .expect(&format!("{}:{}", line!(), file!()));
         new
     }
@@ -600,7 +601,7 @@ mod test {
         let instruction =
             exchange_instruction::transfer_request(&owner.pubkey(), to, &id(), token, tokens);
         client
-            .process_instruction(owner, instruction)
+            .send_instruction(owner, instruction)
             .expect(&format!("{}:{}", line!(), file!()));
     }
 
@@ -630,7 +631,7 @@ mod test {
             &dst,
         );
         client
-            .process_instruction(owner, instruction)
+            .send_instruction(owner, instruction)
             .expect(&format!("{}:{}", line!(), file!()));
         (trade, src, dst)
     }
@@ -672,7 +673,7 @@ mod test {
         let new = create_token_account(&client, &owner);
         let instruction = exchange_instruction::account_request(&owner.pubkey(), &new);
         client
-            .process_instruction(&owner, instruction)
+            .send_instruction(&owner, instruction)
             .expect_err(&format!("{}:{}", line!(), file!()));
     }
 
@@ -687,7 +688,7 @@ mod test {
         let instruction =
             exchange_instruction::transfer_request(&owner.pubkey(), &new, &id(), Token::A, 42);
         client
-            .process_instruction(&owner, instruction)
+            .send_instruction(&owner, instruction)
             .expect(&format!("{}:{}", line!(), file!()));
 
         let new_account = bank.get_account(&new).unwrap();
@@ -790,7 +791,7 @@ mod test {
             &profit,
         );
         client
-            .process_instruction(&owner, instruction)
+            .send_instruction(&owner, instruction)
             .expect(&format!("{}:{}", line!(), file!()));
 
         let to_trade_account = bank.get_account(&to_trade).unwrap();

--- a/programs/exchange_api/src/exchange_processor.rs
+++ b/programs/exchange_api/src/exchange_processor.rs
@@ -652,7 +652,7 @@ mod test {
         let (client, owner) = create_client(&bank, mint_keypair);
 
         let new = create_token_account(&client, &owner);
-        let new_account = bank.get_account(&new).unwrap();
+        let new_account_data = client.get_account_data(&new).unwrap();
 
         // Check results
 
@@ -660,7 +660,7 @@ mod test {
             TokenAccountInfo::default()
                 .owner(&owner.pubkey())
                 .tokens(100_000, 100_000, 100_000, 100_000),
-            ExchangeProcessor::deserialize_account(&new_account.data).unwrap()
+            ExchangeProcessor::deserialize_account(&new_account_data).unwrap()
         );
     }
 
@@ -691,7 +691,7 @@ mod test {
             .send_instruction(&owner, instruction)
             .expect(&format!("{}:{}", line!(), file!()));
 
-        let new_account = bank.get_account(&new).unwrap();
+        let new_account_data = client.get_account_data(&new).unwrap();
 
         // Check results
 
@@ -699,7 +699,7 @@ mod test {
             TokenAccountInfo::default()
                 .owner(&owner.pubkey())
                 .tokens(100_042, 100_000, 100_000, 100_000),
-            ExchangeProcessor::deserialize_account(&new_account.data).unwrap()
+            ExchangeProcessor::deserialize_account(&new_account_data).unwrap()
         );
     }
 
@@ -720,9 +720,9 @@ mod test {
             1000,
         );
 
-        let trade_account = bank.get_account(&trade).unwrap();
-        let src_account = bank.get_account(&src).unwrap();
-        let dst_account = bank.get_account(&dst).unwrap();
+        let trade_account_data = client.get_account_data(&trade).unwrap();
+        let src_account_data = client.get_account_data(&src).unwrap();
+        let dst_account_data = client.get_account_data(&dst).unwrap();
 
         // check results
 
@@ -736,19 +736,19 @@ mod test {
                 src_account: src,
                 dst_account: dst
             },
-            ExchangeProcessor::deserialize_trade(&trade_account.data).unwrap()
+            ExchangeProcessor::deserialize_trade(&trade_account_data).unwrap()
         );
         assert_eq!(
             TokenAccountInfo::default()
                 .owner(&owner.pubkey())
                 .tokens(100_040, 100_000, 100_000, 100_000),
-            ExchangeProcessor::deserialize_account(&src_account.data).unwrap()
+            ExchangeProcessor::deserialize_account(&src_account_data).unwrap()
         );
         assert_eq!(
             TokenAccountInfo::default()
                 .owner(&owner.pubkey())
                 .tokens(100_000, 100_000, 100_000, 100_000),
-            ExchangeProcessor::deserialize_account(&dst_account.data).unwrap()
+            ExchangeProcessor::deserialize_account(&dst_account_data).unwrap()
         );
     }
 
@@ -794,14 +794,14 @@ mod test {
             .send_instruction(&owner, instruction)
             .expect(&format!("{}:{}", line!(), file!()));
 
-        let to_trade_account = bank.get_account(&to_trade).unwrap();
-        let to_src_account = bank.get_account(&to_src).unwrap();
-        let to_dst_account = bank.get_account(&to_dst).unwrap();
-        let from_trade_account = bank.get_account(&from_trade).unwrap();
-        let from_src_account = bank.get_account(&from_src).unwrap();
-        let from_dst_account = bank.get_account(&from_dst).unwrap();
-        let profit_account = bank.get_account(&profit).unwrap();
-        let swap_account = bank.get_account(&swap).unwrap();
+        let to_trade_account_data = client.get_account_data(&to_trade).unwrap();
+        let to_src_account_data = client.get_account_data(&to_src).unwrap();
+        let to_dst_account_data = client.get_account_data(&to_dst).unwrap();
+        let from_trade_account_data = client.get_account_data(&from_trade).unwrap();
+        let from_src_account_data = client.get_account_data(&from_src).unwrap();
+        let from_dst_account_data = client.get_account_data(&from_dst).unwrap();
+        let profit_account_data = client.get_account_data(&profit).unwrap();
+        let swap_account_data = client.get_account_data(&swap).unwrap();
 
         // check results
 
@@ -815,19 +815,19 @@ mod test {
                 src_account: to_src,
                 dst_account: to_dst
             },
-            ExchangeProcessor::deserialize_trade(&to_trade_account.data).unwrap()
+            ExchangeProcessor::deserialize_trade(&to_trade_account_data).unwrap()
         );
         assert_eq!(
             TokenAccountInfo::default()
                 .owner(&owner.pubkey())
                 .tokens(100_000, 100_000, 100_000, 100_000),
-            ExchangeProcessor::deserialize_account(&to_src_account.data).unwrap()
+            ExchangeProcessor::deserialize_account(&to_src_account_data).unwrap()
         );
         assert_eq!(
             TokenAccountInfo::default()
                 .owner(&owner.pubkey())
                 .tokens(100_000, 100_002, 100_000, 100_000),
-            ExchangeProcessor::deserialize_account(&to_dst_account.data).unwrap()
+            ExchangeProcessor::deserialize_account(&to_dst_account_data).unwrap()
         );
         assert_eq!(
             TradeOrderInfo {
@@ -839,25 +839,25 @@ mod test {
                 src_account: from_src,
                 dst_account: from_dst
             },
-            ExchangeProcessor::deserialize_trade(&from_trade_account.data).unwrap()
+            ExchangeProcessor::deserialize_trade(&from_trade_account_data).unwrap()
         );
         assert_eq!(
             TokenAccountInfo::default()
                 .owner(&owner.pubkey())
                 .tokens(100_000, 100_000, 100_000, 100_000),
-            ExchangeProcessor::deserialize_account(&from_src_account.data).unwrap()
+            ExchangeProcessor::deserialize_account(&from_src_account_data).unwrap()
         );
         assert_eq!(
             TokenAccountInfo::default()
                 .owner(&owner.pubkey())
                 .tokens(100_001, 100_000, 100_000, 100_000),
-            ExchangeProcessor::deserialize_account(&from_dst_account.data).unwrap()
+            ExchangeProcessor::deserialize_account(&from_dst_account_data).unwrap()
         );
         assert_eq!(
             TokenAccountInfo::default()
                 .owner(&owner.pubkey())
                 .tokens(100_000, 100_001, 100_000, 100_000),
-            ExchangeProcessor::deserialize_account(&profit_account.data).unwrap()
+            ExchangeProcessor::deserialize_account(&profit_account_data).unwrap()
         );
         assert_eq!(
             TradeSwapInfo {
@@ -869,7 +869,7 @@ mod test {
                 secondary_tokens: 3,
                 secondary_price: 3000,
             },
-            deserialize_swap(&swap_account.data)
+            deserialize_swap(&swap_account_data)
         );
     }
 }

--- a/programs/failure_program/tests/failure.rs
+++ b/programs/failure_program/tests/failure.rs
@@ -5,6 +5,7 @@ use solana_sdk::genesis_block::GenesisBlock;
 use solana_sdk::instruction::InstructionError;
 use solana_sdk::native_loader;
 use solana_sdk::signature::KeypairUtil;
+use solana_sdk::sync_client::SyncClient;
 use solana_sdk::transaction::TransactionError;
 
 #[test]
@@ -19,7 +20,7 @@ fn test_program_native_failure() {
     // Call user program
     let instruction = create_invoke_instruction(alice_keypair.pubkey(), program_id, &1u8);
     assert_eq!(
-        bank_client.process_instruction(&alice_keypair, instruction),
+        bank_client.send_instruction(&alice_keypair, instruction),
         Err(TransactionError::InstructionError(
             0,
             InstructionError::GenericError

--- a/programs/failure_program/tests/failure.rs
+++ b/programs/failure_program/tests/failure.rs
@@ -20,10 +20,10 @@ fn test_program_native_failure() {
     // Call user program
     let instruction = create_invoke_instruction(alice_keypair.pubkey(), program_id, &1u8);
     assert_eq!(
-        bank_client.send_instruction(&alice_keypair, instruction),
-        Err(TransactionError::InstructionError(
-            0,
-            InstructionError::GenericError
-        ))
+        bank_client
+            .send_instruction(&alice_keypair, instruction)
+            .unwrap_err()
+            .unwrap(),
+        TransactionError::InstructionError(0, InstructionError::GenericError)
     );
 }

--- a/programs/noop_program/tests/noop.rs
+++ b/programs/noop_program/tests/noop.rs
@@ -4,6 +4,7 @@ use solana_runtime::loader_utils::{create_invoke_instruction, load_program};
 use solana_sdk::genesis_block::GenesisBlock;
 use solana_sdk::native_loader;
 use solana_sdk::signature::KeypairUtil;
+use solana_sdk::sync_client::SyncClient;
 
 #[test]
 fn test_program_native_noop() {
@@ -19,6 +20,6 @@ fn test_program_native_noop() {
     // Call user program
     let instruction = create_invoke_instruction(alice_keypair.pubkey(), program_id, &1u8);
     bank_client
-        .process_instruction(&alice_keypair, instruction)
+        .send_instruction(&alice_keypair, instruction)
         .unwrap();
 }

--- a/programs/storage_api/src/storage_processor.rs
+++ b/programs/storage_api/src/storage_processor.rs
@@ -557,7 +557,7 @@ mod tests {
     }
 
     fn get_storage_entry_height<C: SyncClient>(client: &C, account: &Pubkey) -> u64 {
-        match client.get_account_data(&account) {
+        match client.get_account_data(&account).unwrap() {
             Some(storage_system_account_data) => {
                 let contract = deserialize(&storage_system_account_data);
                 if let Ok(contract) = contract {
@@ -577,7 +577,7 @@ mod tests {
     }
 
     fn get_storage_blockhash<C: SyncClient>(client: &C, account: &Pubkey) -> Hash {
-        if let Some(storage_system_account_data) = client.get_account_data(&account) {
+        if let Some(storage_system_account_data) = client.get_account_data(&account).unwrap() {
             let contract = deserialize(&storage_system_account_data);
             if let Ok(contract) = contract {
                 match contract {

--- a/programs/storage_api/src/storage_processor.rs
+++ b/programs/storage_api/src/storage_processor.rs
@@ -334,6 +334,7 @@ mod tests {
     use solana_sdk::instruction::Instruction;
     use solana_sdk::pubkey::Pubkey;
     use solana_sdk::signature::{Keypair, KeypairUtil, Signature};
+    use solana_sdk::sync_client::SyncClient;
     use solana_sdk::system_instruction;
 
     fn test_instruction(
@@ -474,10 +475,10 @@ mod tests {
         let bank_client = BankClient::new(&bank);
 
         let ix = system_instruction::create_account(&mint_pubkey, &validator, 10, 4 * 1042, &id());
-        bank_client.process_instruction(&mint_keypair, ix).unwrap();
+        bank_client.send_instruction(&mint_keypair, ix).unwrap();
 
         let ix = system_instruction::create_account(&mint_pubkey, &replicator, 10, 4 * 1042, &id());
-        bank_client.process_instruction(&mint_keypair, ix).unwrap();
+        bank_client.send_instruction(&mint_keypair, ix).unwrap();
 
         let ix = storage_instruction::advertise_recent_blockhash(
             &validator,
@@ -486,7 +487,7 @@ mod tests {
         );
 
         bank_client
-            .process_instruction(&validator_keypair, ix)
+            .send_instruction(&validator_keypair, ix)
             .unwrap();
 
         let ix = storage_instruction::mining_proof(
@@ -496,7 +497,7 @@ mod tests {
             Signature::default(),
         );
         bank_client
-            .process_instruction(&replicator_keypair, ix)
+            .send_instruction(&replicator_keypair, ix)
             .unwrap();
 
         let ix = storage_instruction::advertise_recent_blockhash(
@@ -505,7 +506,7 @@ mod tests {
             ENTRIES_PER_SEGMENT * 2,
         );
         bank_client
-            .process_instruction(&validator_keypair, ix)
+            .send_instruction(&validator_keypair, ix)
             .unwrap();
 
         let ix = storage_instruction::proof_validation(
@@ -521,7 +522,7 @@ mod tests {
             }],
         );
         bank_client
-            .process_instruction(&validator_keypair, ix)
+            .send_instruction(&validator_keypair, ix)
             .unwrap();
 
         let ix = storage_instruction::advertise_recent_blockhash(
@@ -530,12 +531,12 @@ mod tests {
             ENTRIES_PER_SEGMENT * 3,
         );
         bank_client
-            .process_instruction(&validator_keypair, ix)
+            .send_instruction(&validator_keypair, ix)
             .unwrap();
 
         let ix = storage_instruction::reward_claim(&validator, entry_height);
         bank_client
-            .process_instruction(&validator_keypair, ix)
+            .send_instruction(&validator_keypair, ix)
             .unwrap();
 
         // TODO enable when rewards are working
@@ -548,7 +549,7 @@ mod tests {
 
         let ix = storage_instruction::reward_claim(&replicator, entry_height);
         bank_client
-            .process_instruction(&replicator_keypair, ix)
+            .send_instruction(&replicator_keypair, ix)
             .unwrap();
 
         // TODO enable when rewards are working
@@ -622,12 +623,12 @@ mod tests {
             &id(),
         );
 
-        bank_client.process_instruction(&mint_keypair, ix).unwrap();
+        bank_client.send_instruction(&mint_keypair, ix).unwrap();
 
         let ix =
             system_instruction::create_account(&mint_pubkey, &validator_pubkey, 1, 4 * 1024, &id());
 
-        bank_client.process_instruction(&mint_keypair, ix).unwrap();
+        bank_client.send_instruction(&mint_keypair, ix).unwrap();
 
         let ix = storage_instruction::advertise_recent_blockhash(
             &validator_pubkey,
@@ -636,7 +637,7 @@ mod tests {
         );
 
         bank_client
-            .process_instruction(&validator_keypair, ix)
+            .send_instruction(&validator_keypair, ix)
             .unwrap();
 
         let entry_height = 0;
@@ -647,7 +648,7 @@ mod tests {
             Signature::default(),
         );
         let _result = bank_client
-            .process_instruction(&replicator_keypair, ix)
+            .send_instruction(&replicator_keypair, ix)
             .unwrap();
 
         assert_eq!(

--- a/programs/storage_api/src/storage_processor.rs
+++ b/programs/storage_api/src/storage_processor.rs
@@ -556,10 +556,10 @@ mod tests {
         // assert_eq!(bank.get_balance(&replicator), TOTAL_REPLICATOR_REWARDS);
     }
 
-    fn get_storage_entry_height(bank: &Bank, account: &Pubkey) -> u64 {
-        match bank.get_account(&account) {
-            Some(storage_system_account) => {
-                let contract = deserialize(&storage_system_account.data);
+    fn get_storage_entry_height<C: SyncClient>(client: &C, account: &Pubkey) -> u64 {
+        match client.get_account_data(&account) {
+            Some(storage_system_account_data) => {
+                let contract = deserialize(&storage_system_account_data);
                 if let Ok(contract) = contract {
                     match contract {
                         StorageContract::ValidatorStorage { entry_height, .. } => {
@@ -576,9 +576,9 @@ mod tests {
         0
     }
 
-    fn get_storage_blockhash(bank: &Bank, account: &Pubkey) -> Hash {
-        if let Some(storage_system_account) = bank.get_account(&account) {
-            let contract = deserialize(&storage_system_account.data);
+    fn get_storage_blockhash<C: SyncClient>(client: &C, account: &Pubkey) -> Hash {
+        if let Some(storage_system_account_data) = client.get_account_data(&account) {
+            let contract = deserialize(&storage_system_account_data);
             if let Ok(contract) = contract {
                 match contract {
                     StorageContract::ValidatorStorage { hash, .. } => {
@@ -652,11 +652,11 @@ mod tests {
             .unwrap();
 
         assert_eq!(
-            get_storage_entry_height(&bank, &validator_pubkey),
+            get_storage_entry_height(&bank_client, &validator_pubkey),
             ENTRIES_PER_SEGMENT
         );
         assert_eq!(
-            get_storage_blockhash(&bank, &validator_pubkey),
+            get_storage_blockhash(&bank_client, &validator_pubkey),
             storage_blockhash
         );
     }

--- a/programs/vote_api/src/vote_processor.rs
+++ b/programs/vote_api/src/vote_processor.rs
@@ -54,6 +54,7 @@ mod tests {
     use solana_sdk::message::Message;
     use solana_sdk::pubkey::Pubkey;
     use solana_sdk::signature::{Keypair, KeypairUtil};
+    use solana_sdk::sync_client::SyncClient;
     use solana_sdk::system_instruction;
     use solana_sdk::transaction::TransactionError;
 
@@ -72,7 +73,7 @@ mod tests {
     ) -> Result<()> {
         let ixs = vote_instruction::create_account(&from_keypair.pubkey(), vote_id, lamports);
         let message = Message::new(ixs);
-        bank_client.process_message(&[from_keypair], message)
+        bank_client.send_message(&[from_keypair], message)
     }
 
     fn create_vote_account_with_delegate(
@@ -87,7 +88,7 @@ mod tests {
         let delegate_ix = vote_instruction::delegate_stake(&vote_id, delegate_id);
         ixs.push(delegate_ix);
         let message = Message::new(ixs);
-        bank_client.process_message(&[&from_keypair, vote_keypair], message)
+        bank_client.send_message(&[&from_keypair, vote_keypair], message)
     }
 
     fn submit_vote(
@@ -96,7 +97,7 @@ mod tests {
         tick_height: u64,
     ) -> Result<()> {
         let vote_ix = vote_instruction::vote(&vote_keypair.pubkey(), Vote::new(tick_height));
-        bank_client.process_instruction(&vote_keypair, vote_ix)
+        bank_client.send_instruction(&vote_keypair, vote_ix)
     }
 
     #[test]
@@ -150,7 +151,7 @@ mod tests {
         // needs to check that it's signed.
         let move_ix = system_instruction::transfer(&mallory_id, &vote_id, 1);
         let message = Message::new(vec![move_ix, vote_ix]);
-        let result = bank_client.process_message(&[&mallory_keypair], message);
+        let result = bank_client.send_message(&[&mallory_keypair], message);
 
         // And ensure there's no vote.
         let vote_account = bank.get_account(&vote_id).unwrap();

--- a/runtime/src/loader_utils.rs
+++ b/runtime/src/loader_utils.rs
@@ -4,6 +4,7 @@ use solana_sdk::instruction::{AccountMeta, Instruction};
 use solana_sdk::loader_instruction;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::{Keypair, KeypairUtil};
+use solana_sdk::sync_client::SyncClient;
 use solana_sdk::system_instruction;
 
 pub fn load_program(
@@ -23,7 +24,7 @@ pub fn load_program(
         loader_id,
     );
     bank_client
-        .process_instruction(&from_keypair, instruction)
+        .send_instruction(&from_keypair, instruction)
         .unwrap();
 
     let chunk_size = 256; // Size of chunk just needs to fit into tx
@@ -32,14 +33,14 @@ pub fn load_program(
         let instruction =
             loader_instruction::write(&program_pubkey, loader_id, offset, chunk.to_vec());
         bank_client
-            .process_instruction(&program_keypair, instruction)
+            .send_instruction(&program_keypair, instruction)
             .unwrap();
         offset += chunk_size as u32;
     }
 
     let instruction = loader_instruction::finalize(&program_pubkey, loader_id);
     bank_client
-        .process_instruction(&program_keypair, instruction)
+        .send_instruction(&program_keypair, instruction)
         .unwrap();
 
     program_pubkey

--- a/runtime/src/system_instruction_processor.rs
+++ b/runtime/src/system_instruction_processor.rs
@@ -301,13 +301,13 @@ mod tests {
             account_metas,
         );
         assert_eq!(
-            bank_client.send_instruction(&mallory_keypair, malicious_instruction),
-            Err(TransactionError::InstructionError(
-                0,
-                InstructionError::MissingRequiredSignature
-            ))
+            bank_client
+                .send_instruction(&mallory_keypair, malicious_instruction)
+                .unwrap_err()
+                .unwrap(),
+            TransactionError::InstructionError(0, InstructionError::MissingRequiredSignature)
         );
-        assert_eq!(bank_client.get_balance(&alice_pubkey), 50);
-        assert_eq!(bank_client.get_balance(&mallory_pubkey), 50);
+        assert_eq!(bank_client.get_balance(&alice_pubkey).unwrap(), 50);
+        assert_eq!(bank_client.get_balance(&mallory_pubkey).unwrap(), 50);
     }
 }

--- a/runtime/src/system_instruction_processor.rs
+++ b/runtime/src/system_instruction_processor.rs
@@ -307,7 +307,7 @@ mod tests {
                 InstructionError::MissingRequiredSignature
             ))
         );
-        assert_eq!(bank.get_balance(&alice_pubkey), 50);
-        assert_eq!(bank.get_balance(&mallory_pubkey), 50);
+        assert_eq!(bank_client.get_balance(&alice_pubkey), 50);
+        assert_eq!(bank_client.get_balance(&mallory_pubkey), 50);
     }
 }

--- a/runtime/src/system_instruction_processor.rs
+++ b/runtime/src/system_instruction_processor.rs
@@ -110,6 +110,7 @@ mod tests {
     use solana_sdk::genesis_block::GenesisBlock;
     use solana_sdk::instruction::{AccountMeta, Instruction, InstructionError};
     use solana_sdk::signature::{Keypair, KeypairUtil};
+    use solana_sdk::sync_client::SyncClient;
     use solana_sdk::system_program;
     use solana_sdk::transaction::TransactionError;
 
@@ -300,7 +301,7 @@ mod tests {
             account_metas,
         );
         assert_eq!(
-            bank_client.process_instruction(&mallory_keypair, malicious_instruction),
+            bank_client.send_instruction(&mallory_keypair, malicious_instruction),
             Err(TransactionError::InstructionError(
                 0,
                 InstructionError::MissingRequiredSignature

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -13,6 +13,7 @@ pub mod pubkey;
 pub mod rpc_port;
 pub mod short_vec;
 pub mod signature;
+pub mod sync_client;
 pub mod system_instruction;
 pub mod system_program;
 pub mod system_transaction;

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -19,6 +19,7 @@ pub mod system_program;
 pub mod system_transaction;
 pub mod timing;
 pub mod transaction;
+pub mod transport;
 
 #[macro_use]
 extern crate serde_derive;

--- a/sdk/src/sync_client.rs
+++ b/sdk/src/sync_client.rs
@@ -6,37 +6,24 @@ use crate::instruction::Instruction;
 use crate::message::Message;
 use crate::pubkey::Pubkey;
 use crate::signature::{Keypair, Signature};
-use crate::transaction::TransactionError;
+use crate::transport::Result;
 
 pub trait SyncClient {
     /// Create a transaction from the given message, and send it to the
     /// server, retrying as-needed.
-    fn send_message(
-        &self,
-        keypairs: &[&Keypair],
-        message: Message,
-    ) -> Result<Signature, TransactionError>;
+    fn send_message(&self, keypairs: &[&Keypair], message: Message) -> Result<Signature>;
 
     /// Create a transaction from a single instruction that only requires
     /// a single signer. Then send it to the server, retrying as-needed.
-    fn send_instruction(
-        &self,
-        keypair: &Keypair,
-        instruction: Instruction,
-    ) -> Result<Signature, TransactionError>;
+    fn send_instruction(&self, keypair: &Keypair, instruction: Instruction) -> Result<Signature>;
 
     /// Transfer lamports from `keypair` to `pubkey`, retrying until the
     /// transfer completes or produces and error.
-    fn transfer(
-        &self,
-        lamports: u64,
-        keypair: &Keypair,
-        pubkey: &Pubkey,
-    ) -> Result<Signature, TransactionError>;
+    fn transfer(&self, lamports: u64, keypair: &Keypair, pubkey: &Pubkey) -> Result<Signature>;
 
     /// Get an account or None if not found.
-    fn get_account_data(&self, pubkey: &Pubkey) -> Option<Vec<u8>>;
+    fn get_account_data(&self, pubkey: &Pubkey) -> Result<Option<Vec<u8>>>;
 
     /// Get account balance or 0 if not found.
-    fn get_balance(&self, pubkey: &Pubkey) -> u64;
+    fn get_balance(&self, pubkey: &Pubkey) -> Result<u64>;
 }

--- a/sdk/src/sync_client.rs
+++ b/sdk/src/sync_client.rs
@@ -5,14 +5,17 @@
 use crate::instruction::Instruction;
 use crate::message::Message;
 use crate::pubkey::Pubkey;
-use crate::signature::Keypair;
+use crate::signature::{Keypair, Signature};
 use crate::transaction::TransactionError;
 
 pub trait SyncClient {
     /// Create a transaction from the given message, and send it to the
     /// server, retrying as-needed.
-    fn send_message(&self, keypairs: &[&Keypair], message: Message)
-        -> Result<(), TransactionError>;
+    fn send_message(
+        &self,
+        keypairs: &[&Keypair],
+        message: Message,
+    ) -> Result<Signature, TransactionError>;
 
     /// Create a transaction from a single instruction that only requires
     /// a single signer. Then send it to the server, retrying as-needed.
@@ -20,7 +23,7 @@ pub trait SyncClient {
         &self,
         keypair: &Keypair,
         instruction: Instruction,
-    ) -> Result<(), TransactionError>;
+    ) -> Result<Signature, TransactionError>;
 
     /// Transfer lamports from `keypair` to `pubkey`, retrying until the
     /// transfer completes or produces and error.
@@ -29,5 +32,11 @@ pub trait SyncClient {
         lamports: u64,
         keypair: &Keypair,
         pubkey: &Pubkey,
-    ) -> Result<(), TransactionError>;
+    ) -> Result<Signature, TransactionError>;
+
+    /// Get an account or None if not found.
+    fn get_account_data(&self, pubkey: &Pubkey) -> Option<Vec<u8>>;
+
+    /// Get account balance or 0 if not found.
+    fn get_balance(&self, pubkey: &Pubkey) -> u64;
 }

--- a/sdk/src/sync_client.rs
+++ b/sdk/src/sync_client.rs
@@ -1,0 +1,33 @@
+//! Defines a trait for blocking (synchronous) communication with a Solana server.
+//! Implementations are expected to create tranasctions, sign them, and send
+//! them with multiple retries, updating blockhashes and resigning as-needed.
+
+use crate::instruction::Instruction;
+use crate::message::Message;
+use crate::pubkey::Pubkey;
+use crate::signature::Keypair;
+use crate::transaction::TransactionError;
+
+pub trait SyncClient {
+    /// Create a transaction from the given message, and send it to the
+    /// server, retrying as-needed.
+    fn send_message(&self, keypairs: &[&Keypair], message: Message)
+        -> Result<(), TransactionError>;
+
+    /// Create a transaction from a single instruction that only requires
+    /// a single signer. Then send it to the server, retrying as-needed.
+    fn send_instruction(
+        &self,
+        keypair: &Keypair,
+        instruction: Instruction,
+    ) -> Result<(), TransactionError>;
+
+    /// Transfer lamports from `keypair` to `pubkey`, retrying until the
+    /// transfer completes or produces and error.
+    fn transfer(
+        &self,
+        lamports: u64,
+        keypair: &Keypair,
+        pubkey: &Pubkey,
+    ) -> Result<(), TransactionError>;
+}

--- a/sdk/src/transport.rs
+++ b/sdk/src/transport.rs
@@ -1,0 +1,32 @@
+use crate::transaction::TransactionError;
+use std::io;
+
+#[derive(Debug)]
+pub enum TransportError {
+    IoError(io::Error),
+    TransactionError(TransactionError),
+}
+
+impl TransportError {
+    pub fn unwrap(&self) -> TransactionError {
+        if let TransportError::TransactionError(err) = self {
+            err.clone()
+        } else {
+            panic!("unexpected transport error")
+        }
+    }
+}
+
+impl From<io::Error> for TransportError {
+    fn from(err: io::Error) -> TransportError {
+        TransportError::IoError(err)
+    }
+}
+
+impl From<TransactionError> for TransportError {
+    fn from(err: TransactionError) -> TransportError {
+        TransportError::TransactionError(err)
+    }
+}
+
+pub type Result<T> = std::result::Result<T, TransportError>;


### PR DESCRIPTION
#### Problem

It's easy to start sending transactions to a testnet, but not too easy to debug programs when it doesn't behave as expected. Likewise, it's easy to test and debug programs targeting the Bank, but not so easy to then transition that same test script to a testnet.

#### Summary of Changes

Move BankClient over to a new trait SyncClient, which could be implemented by ThinClient.  Update all consumers to depend only on SyncClient where possible.

TODO:
- [x] Add methods to query the Bank, like `get_balance()` or `get_account_data()`. Without those, tests require a local Bank, which means tests can't yet swap BankClient with ThinClient.
- [x] The SyncClient methods don't wrap TransactionError in any kind of TransportError.  ThinClient returns an `io::Error`. That's not what we want.

Fixes #3058
