### PR TITLE
Add gossip to build script

### DIFF
--- a/net/remote/remote-sanity.sh
+++ b/net/remote/remote-sanity.sh
@@ -84,9 +84,9 @@ echo "+++ $entrypointIp: node count ($numNodes expected)"
   set -x
   $solana_keygen -o "$client_id"
 
-  nodeArg="--num-nodes"
+  nodeArg="num-nodes"
   if $rejectExtraNodes; then
-    nodeArg="--num-nodes-exactly"
+    nodeArg="num-nodes-exactly"
   fi
 
   timeout 2m $solana_gossip \

--- a/scripts/cargo-install-all.sh
+++ b/scripts/cargo-install-all.sh
@@ -34,6 +34,7 @@ BIN_CRATES=(
   drone
   fullnode
   genesis
+  gossip
   install
   keygen
   ledger-tool


### PR DESCRIPTION
#### Problem
Node sanity was failing on testnet deployment because solana-gossip wasn't built.

#### Summary of Changes
Build gossip
Also, fix arg string variable 
