### PR TITLE
Replicators start gossip only after setting up accounts

### DIFF
--- a/core/src/local_cluster.rs
+++ b/core/src/local_cluster.rs
@@ -435,7 +435,7 @@ mod test {
         let mut fullnode_exit = FullnodeConfig::default();
         fullnode_exit.rpc_config.enable_fullnode_exit = true;
         const NUM_NODES: usize = 1;
-        let num_replicators = 0;
+        let num_replicators = 1;
         let cluster = LocalCluster::new_with_config_replicators(
             &[3; NUM_NODES],
             100,


### PR DESCRIPTION
#### Problem

All current "readiness" checks are based around whether or not something is visible in gossip.
Replicators start their gossip service immediately and so they appear to be ready before they actually are.

#### Summary of Changes

Moved gossip startup to _after_ replicator accounts are setup. 

Fixes #3592