### PR TITLE
Accept variable number of zones in testnet-deploy argument list

### DIFF
--- a/ci/testnet-deploy.sh
+++ b/ci/testnet-deploy.sh
@@ -27,13 +27,13 @@ usage() {
     echo "Error: $*"
   fi
   cat <<EOF
-usage: $0 [name] [cloud] [zone] [options...]
+usage: $0 [options...] [name] [cloud] [zone...]
 
 Deploys a CD testnet
 
   name  - name of the network
   cloud - cloud provider to use (gce, ec2)
-  zone  - cloud provider zone to deploy the network into
+  zone  - cloud provider zones to deploy the network into.
 
   options:
    -t edge|beta|stable|vX.Y.Z  - Deploy the latest tarball release for the
@@ -58,14 +58,6 @@ Deploys a CD testnet
 EOF
   exit $exitcode
 }
-
-netName=$1
-cloudProvider=$2
-zone=$3
-[[ -n $netName ]] || usage
-[[ -n $cloudProvider ]] || usage "Cloud provider not specified"
-[[ -n $zone ]] || usage "Zone not specified"
-shift 3
 
 while getopts "h?p:Pn:c:t:gG:a:Dbd:rusx" opt; do
   case $opt in
@@ -127,6 +119,14 @@ while getopts "h?p:Pn:c:t:gG:a:Dbd:rusx" opt; do
     ;;
   esac
 done
+
+netName=${@:$OPTIND:1}
+cloudProvider=${@:$OPTIND+1:1}
+zone=${@:$OPTIND+2}
+
+[[ -n $netName ]] || usage "Network name not specified"
+[[ -n $cloudProvider ]] || usage "Cloud provider not specified"
+[[ -n $zone ]] || usage "Zone not specified"
 
 shutdown() {
   exitcode=$?

--- a/ci/testnet-manager.sh
+++ b/ci/testnet-manager.sh
@@ -215,27 +215,27 @@ start() {
       NO_VALIDATOR_SANITY=1 \
       RUST_LOG=solana=info \
         ci/testnet-deploy.sh \
-          -t "$CHANNEL_OR_TAG" -n 35 -c 0 -s -u -P -a eipalloc-0f286cf8a0771ce35 -D \
-          beta-testnet-solana-com ec2 us-west-1a us-west-1b
+          -t "$CHANNEL_OR_TAG" -n 50 -c 0 -s -u -P -a eipalloc-0f286cf8a0771ce35 -D \
+          beta-testnet-solana-com ec2 sa-east-1a us-west-1a ap-northeast-2a eu-central-1a ca-central-1a
       NO_VALIDATOR_SANITY=1 \
       RUST_LOG=solana=info \
         ci/testnet-deploy.sh \
-          -t "$CHANNEL_OR_TAG" -n 65 -c 0 -x -P -D \
-          beta-testnet-solana-com gce us-west1-a
+          -t "$CHANNEL_OR_TAG" -n 50 -c 0 -x -P -D \
+          beta-testnet-solana-com gce us-west1-b asia-east2-a europe-west4-a southamerica-east1-b us-east4-c
       NO_VALIDATOR_SANITY=1 \
       RUST_LOG=solana=info \
         ci/testnet-deploy.sh \
-          -t "$CHANNEL_OR_TAG" -n 35 -c 0 -s -u -P -a eipalloc-0f286cf8a0771ce35 \
+          -t "$CHANNEL_OR_TAG" -n 50 -c 0 -s -u -P -a eipalloc-0f286cf8a0771ce35 \
           ${maybeReuseLedger:+-r} \
           ${maybeDelete:+-D} \
-          beta-testnet-solana-com ec2 us-west-1a
+          beta-testnet-solana-com ec2 sa-east-1a us-west-1a ap-northeast-2a eu-central-1a ca-central-1a
       NO_VALIDATOR_SANITY=1 \
       RUST_LOG=solana=info \
         ci/testnet-deploy.sh \
-          -t "$CHANNEL_OR_TAG" -n 65 -c 0 -x -P \
+          -t "$CHANNEL_OR_TAG" -n 50 -c 0 -x -P \
           ${maybeReuseLedger:+-r} \
           ${maybeDelete:+-D} \
-          beta-testnet-solana-com gce us-west1-a
+          beta-testnet-solana-com gce us-west1-b asia-east2-a europe-west4-a southamerica-east1-b us-east4-c
     )
     ;;
   testnet-beta-perf)

--- a/ci/testnet-manager.sh
+++ b/ci/testnet-manager.sh
@@ -186,10 +186,11 @@ start() {
       set -x
       NO_VALIDATOR_SANITY=1 \
       RUST_LOG=solana=info \
-        ci/testnet-deploy.sh edge-testnet-solana-com ec2 us-west-1a \
+        ci/testnet-deploy.sh \
           -t "$CHANNEL_OR_TAG" -n 3 -c 0 -u -P -a eipalloc-0ccd4f2239886fa94 \
           ${maybeReuseLedger:+-r} \
-          ${maybeDelete:+-D}
+          ${maybeDelete:+-D} \
+          edge-testnet-solana-com ec2 us-west-1a
     )
     ;;
   testnet-edge-perf)
@@ -197,11 +198,12 @@ start() {
       set -x
       NO_LEDGER_VERIFY=1 \
       NO_VALIDATOR_SANITY=1 \
-        ci/testnet-deploy.sh edge-perf-testnet-solana-com ec2 us-west-2b \
+        ci/testnet-deploy.sh \
           -g -t "$CHANNEL_OR_TAG" -c 2 \
           -b \
           ${maybeReuseLedger:+-r} \
-          ${maybeDelete:+-D}
+          ${maybeDelete:+-D} \
+          edge-perf-testnet-solana-com ec2 us-west-2b
     )
     ;;
   testnet-beta)
@@ -212,24 +214,28 @@ start() {
       #  and the leader might be in that subset)
       NO_VALIDATOR_SANITY=1 \
       RUST_LOG=solana=info \
-        ci/testnet-deploy.sh beta-testnet-solana-com ec2 us-west-1a \
-          -t "$CHANNEL_OR_TAG" -n 35 -c 0 -s -u -P -a eipalloc-0f286cf8a0771ce35 -D
+        ci/testnet-deploy.sh \
+          -t "$CHANNEL_OR_TAG" -n 35 -c 0 -s -u -P -a eipalloc-0f286cf8a0771ce35 -D \
+          beta-testnet-solana-com ec2 us-west-1a us-west-1b
       NO_VALIDATOR_SANITY=1 \
       RUST_LOG=solana=info \
-        ci/testnet-deploy.sh beta-testnet-solana-com gce us-west1-a \
-          -t "$CHANNEL_OR_TAG" -n 65 -c 0 -x -P -D
+        ci/testnet-deploy.sh \
+          -t "$CHANNEL_OR_TAG" -n 65 -c 0 -x -P -D \
+          beta-testnet-solana-com gce us-west1-a us-west1-b
 
       if ! $maybeDelete; then
         NO_VALIDATOR_SANITY=1 \
         RUST_LOG=solana=info \
-          ci/testnet-deploy.sh beta-testnet-solana-com ec2 us-west-1a \
+          ci/testnet-deploy.sh \
             -t "$CHANNEL_OR_TAG" -n 35 -c 0 -s -u -P -a eipalloc-0f286cf8a0771ce35 \
-            ${maybeReuseLedger:+-r}
+            ${maybeReuseLedger:+-r} \
+            beta-testnet-solana-com ec2 us-west-1a us-west-1b
         NO_VALIDATOR_SANITY=1 \
         RUST_LOG=solana=info \
-          ci/testnet-deploy.sh beta-testnet-solana-com gce us-west1-a \
+          ci/testnet-deploy.sh \
             -t "$CHANNEL_OR_TAG" -n 65 -c 0 -x -P \
-            ${maybeReuseLedger:+-r}
+            ${maybeReuseLedger:+-r} \
+            beta-testnet-solana-com gce us-west1-a us-west1-b
       fi
     )
     ;;
@@ -238,11 +244,12 @@ start() {
       set -x
       NO_LEDGER_VERIFY=1 \
       NO_VALIDATOR_SANITY=1 \
-        ci/testnet-deploy.sh beta-perf-testnet-solana-com ec2 us-west-2b \
+        ci/testnet-deploy.sh \
           -g -t "$CHANNEL_OR_TAG" -c 2 \
           -b \
           ${maybeReuseLedger:+-r} \
-          ${maybeDelete:+-D}
+          ${maybeDelete:+-D} \
+          beta-perf-testnet-solana-com ec2 us-west-2b
     )
     ;;
   testnet)
@@ -250,15 +257,17 @@ start() {
       set -x
       NO_VALIDATOR_SANITY=1 \
       RUST_LOG=solana=info \
-        ci/testnet-deploy.sh testnet-solana-com ec2 us-west-1a \
+        ci/testnet-deploy.sh \
           -t "$CHANNEL_OR_TAG" -n 3 -c 0 -u -P -a eipalloc-0fa502bf95f6f18b2 \
           -b \
           ${maybeReuseLedger:+-r} \
-          ${maybeDelete:+-D}
-        #ci/testnet-deploy.sh testnet-solana-com gce us-east1-c \
+          ${maybeDelete:+-D} \
+          testnet-solana-com ec2 us-west-1a
+        #ci/testnet-deploy.sh \
         #  -t "$CHANNEL_OR_TAG" -n 3 -c 0 -P -a testnet-solana-com  \
         #  ${maybeReuseLedger:+-r} \
-        #  ${maybeDelete:+-D}
+        #  ${maybeDelete:+-D} \
+        #  testnet-solana-com gce us-east1-c
     )
     ;;
   testnet-perf)
@@ -266,18 +275,20 @@ start() {
       set -x
       NO_LEDGER_VERIFY=1 \
       NO_VALIDATOR_SANITY=1 \
-        ci/testnet-deploy.sh perf-testnet-solana-com gce us-west1-b \
+        ci/testnet-deploy.sh \
           -G "n1-standard-16 --accelerator count=2,type=nvidia-tesla-v100" \
           -t "$CHANNEL_OR_TAG" -c 2 \
           -b \
           -d pd-ssd \
           ${maybeReuseLedger:+-r} \
-          ${maybeDelete:+-D}
-        #ci/testnet-deploy.sh perf-testnet-solana-com ec2 us-east-1a \
+          ${maybeDelete:+-D} \
+          perf-testnet-solana-com gce us-west1-b
+        #ci/testnet-deploy.sh \
         #  -g \
         #  -t "$CHANNEL_OR_TAG" -c 2 \
         #  ${maybeReuseLedger:+-r} \
-        #  ${maybeDelete:+-D}
+        #  ${maybeDelete:+-D} \
+        #  perf-testnet-solana-com ec2 us-east-1a
     )
     ;;
   *)


### PR DESCRIPTION
#### Problem

Testnet-deploy did not allow for multiple zones to be passed in the command line

#### Summary of Changes

Refactored options and positional arguments.   Added additional zone to testnet beta deploy in testnet-manager start()