### PR TITLE
bump release version in testnet participation document

### DIFF
--- a/book/src/testnet-participation.md
+++ b/book/src/testnet-participation.md
@@ -29,7 +29,7 @@ MacOS or WSL users may build from source.
 The shell commands in this section assume the following environment variables are
 set:
 ```bash
-$ export release=0.12.3
+$ export release=0.12.4
 $ export ip=$(dig +short beta.testnet.solana.com)
 $ export USE_INSTALL=1
 ```


### PR DESCRIPTION
#### Problem
The release version in testnet participation document is outdated.

#### Summary of Changes
Updated the release version to the latest release.
