### PR TITLE
Add multi-region deploy functionality

### DIFF
--- a/ci/testnet-deploy.sh
+++ b/ci/testnet-deploy.sh
@@ -164,6 +164,7 @@ done
 
 if ! $skipSetup; then
   echo "--- $cloudProvider.sh delete"
+  # shellcheck disable=SC2068
   time net/"$cloudProvider".sh delete ${zone_args[@]} -p "$netName" ${externalNode:+-x}
   if $delete; then
     exit 0
@@ -176,6 +177,7 @@ if ! $skipSetup; then
     -c "$clientNodeCount"
     -n "$additionalFullNodeCount"
   )
+  # shellcheck disable=SC2206
   create_args+=(${zone_args[@]})
 
   if $blockstreamer; then
@@ -212,6 +214,7 @@ else
   config_args=(
     -p "$netName"
   )
+  # shellcheck disable=SC2206
   config_args+=(${zone_args[@]})
   if $publicNetwork; then
     config_args+=(-P)

--- a/ci/testnet-deploy.sh
+++ b/ci/testnet-deploy.sh
@@ -158,7 +158,7 @@ set -x
 
 # Build a string to pass zone opts to $cloudProvider.sh: "-z zone1 -z zone2 ..."
 for val in "${zone[@]}"; do
-  zone_args="-z $val $zone_args"
+  zone_args="-z $zone_args $val"
 done
 
 if ! $skipSetup; then

--- a/ci/testnet-deploy.sh
+++ b/ci/testnet-deploy.sh
@@ -27,12 +27,12 @@ usage() {
     echo "Error: $*"
   fi
   cat <<EOF
-usage: $0 -N name -C cloud -z zone1 [-z zone2] ... [-z zoneN] [options...]
+usage: $0 -p network-name -C cloud -z zone1 [-z zone2] ... [-z zoneN] [options...]
 
 Deploys a CD testnet
 
   mandatory arguments:
-  -N [name]  - name of the network
+  -p [network-name]  - name of the network
   -C [cloud] - cloud provider to use (gce, ec2)
   -z [zone]  - cloud provider zone to deploy the network into.  Must specify at least one zone
 
@@ -62,12 +62,12 @@ EOF
 
 zone=()
 
-while getopts "h?p:Pn:c:t:gG:a:Dbd:rusxz:N:C:" opt; do
+while getopts "h?p:Pn:c:t:gG:a:Dbd:rusxz:p:C:" opt; do
   case $opt in
   h | \?)
     usage
     ;;
-  N)
+  p)
     netName=$OPTARG
     ;;
   C)
@@ -158,7 +158,7 @@ set -x
 
 # Build a string to pass zone opts to $cloudProvider.sh: "-z zone1 -z zone2 ..."
 for val in "${zone[@]}"; do
-  zone_args="-z $zone_args $val"
+  zone_args="$zone_args -z $val"
 done
 
 if ! $skipSetup; then
@@ -175,7 +175,7 @@ if ! $skipSetup; then
     -c "$clientNodeCount"
     -n "$additionalFullNodeCount"
   )
-  create_args+=("$zone_args ")
+  create_args+=("$zone_args")
 
   if $blockstreamer; then
     create_args+=(-u)
@@ -211,7 +211,7 @@ else
   config_args=(
     -p "$netName"
   )
-  config_args+=("$zone_args ")
+  config_args+=("$zone_args")
   if $publicNetwork; then
     config_args+=(-P)
   fi

--- a/ci/testnet-deploy.sh
+++ b/ci/testnet-deploy.sh
@@ -159,12 +159,12 @@ set -x
 # Build a string to pass zone opts to $cloudProvider.sh: "-z zone1 -z zone2 ..."
 zone_args=()
 for val in "${zone[@]}"; do
-  zone_args+="-z $val "
+  zone_args+=("-z $val")
 done
 
 if ! $skipSetup; then
   echo "--- $cloudProvider.sh delete"
-  time net/"$cloudProvider".sh delete ${zone_args[*]} -p "$netName" ${externalNode:+-x}
+  time net/"$cloudProvider".sh delete ${zone_args[@]} -p "$netName" ${externalNode:+-x}
   if $delete; then
     exit 0
   fi
@@ -176,7 +176,7 @@ if ! $skipSetup; then
     -c "$clientNodeCount"
     -n "$additionalFullNodeCount"
   )
-  create_args+=(${zone_args[*]})
+  create_args+=(${zone_args[@]})
 
   if $blockstreamer; then
     create_args+=(-u)
@@ -212,7 +212,7 @@ else
   config_args=(
     -p "$netName"
   )
-  config_args+=(${zone_args[*]})
+  config_args+=(${zone_args[@]})
   if $publicNetwork; then
     config_args+=(-P)
   fi

--- a/ci/testnet-deploy.sh
+++ b/ci/testnet-deploy.sh
@@ -27,13 +27,14 @@ usage() {
     echo "Error: $*"
   fi
   cat <<EOF
-usage: $0 [name] [cloud] [zone] [options...]
+usage: $0 -N name -C cloud -z zone1 [-z zone2] ... [-z zoneN] [options...]
 
 Deploys a CD testnet
 
-  name  - name of the network
-  cloud - cloud provider to use (gce, ec2)
-  zone  - cloud provider zone to deploy the network into
+  mandatory arguments:
+  -N [name]  - name of the network
+  -C [cloud] - cloud provider to use (gce, ec2)
+  -z [zone]  - cloud provider zone to deploy the network into.  Must specify at least one zone
 
   options:
    -t edge|beta|stable|vX.Y.Z  - Deploy the latest tarball release for the
@@ -59,18 +60,21 @@ EOF
   exit $exitcode
 }
 
-netName=$1
-cloudProvider=$2
-zone=$3
-[[ -n $netName ]] || usage
-[[ -n $cloudProvider ]] || usage "Cloud provider not specified"
-[[ -n $zone ]] || usage "Zone not specified"
-shift 3
+zone=()
 
-while getopts "h?p:Pn:c:t:gG:a:Dbd:rusx" opt; do
+while getopts "h?p:Pn:c:t:gG:a:Dbd:rusxz:N:C:" opt; do
   case $opt in
   h | \?)
     usage
+    ;;
+  N)
+    netName=$OPTARG
+    ;;
+  C)
+    cloudProvider=$OPTARG
+    ;;
+  z)
+    zone+=("$OPTARG")
     ;;
   P)
     publicNetwork=true
@@ -127,6 +131,10 @@ while getopts "h?p:Pn:c:t:gG:a:Dbd:rusx" opt; do
     ;;
   esac
 done
+
+[[ -n $netName ]] || usage
+[[ -n $cloudProvider ]] || usage "Cloud provider not specified"
+[[ -n $zone ]] || usage "Zone not specified"
 
 shutdown() {
   exitcode=$?

--- a/ci/testnet-deploy.sh
+++ b/ci/testnet-deploy.sh
@@ -157,13 +157,14 @@ trap shutdown EXIT INT
 set -x
 
 # Build a string to pass zone opts to $cloudProvider.sh: "-z zone1 -z zone2 ..."
+zone_args=()
 for val in "${zone[@]}"; do
-  zone_args="$zone_args -z $val"
+  zone_args+="-z $val "
 done
 
 if ! $skipSetup; then
   echo "--- $cloudProvider.sh delete"
-  time net/"$cloudProvider".sh delete "$zone_args" -p "$netName" ${externalNode:+-x}
+  time net/"$cloudProvider".sh delete ${zone_args[*]} -p "$netName" ${externalNode:+-x}
   if $delete; then
     exit 0
   fi
@@ -175,7 +176,7 @@ if ! $skipSetup; then
     -c "$clientNodeCount"
     -n "$additionalFullNodeCount"
   )
-  create_args+=("$zone_args")
+  create_args+=(${zone_args[*]})
 
   if $blockstreamer; then
     create_args+=(-u)
@@ -211,7 +212,7 @@ else
   config_args=(
     -p "$netName"
   )
-  config_args+=("$zone_args")
+  config_args+=(${zone_args[*]})
   if $publicNetwork; then
     config_args+=(-P)
   fi

--- a/ci/testnet-manager.sh
+++ b/ci/testnet-manager.sh
@@ -186,7 +186,7 @@ start() {
       set -x
       NO_VALIDATOR_SANITY=1 \
       RUST_LOG=solana=info \
-        ci/testnet-deploy.sh edge-testnet-solana-com ec2 us-west-1a \
+        ci/testnet-deploy.sh -N edge-testnet-solana-com -C ec2 -z us-west-1a \
           -t "$CHANNEL_OR_TAG" -n 3 -c 0 -u -P -a eipalloc-0ccd4f2239886fa94 \
           ${maybeReuseLedger:+-r} \
           ${maybeDelete:+-D}
@@ -197,7 +197,7 @@ start() {
       set -x
       NO_LEDGER_VERIFY=1 \
       NO_VALIDATOR_SANITY=1 \
-        ci/testnet-deploy.sh edge-perf-testnet-solana-com ec2 us-west-2b \
+        ci/testnet-deploy.sh -N edge-perf-testnet-solana-com -C ec2 -z us-west-2b \
           -g -t "$CHANNEL_OR_TAG" -c 2 \
           -b \
           ${maybeReuseLedger:+-r} \
@@ -207,27 +207,30 @@ start() {
   testnet-beta)
     (
       set -x
-      # Force delete the network, as two different cloud providers are being used
-      # (otherwise, a subset of the nodes stay up while first cloud is deleted,
-      #  and the leader might be in that subset)
+
+      # List of zones to deploy for each cloud provider
+      GCE_ZONES=(us-west1-b asia-east2-a europe-west4-a southamerica-east1-b us-east4-c)
+      EC2_ZONES=(sa-east-1a us-west-1a ap-northeast-2a eu-central-1a ca-central-1a)
+
+      # Build a string to pass as opts to testnet-deploy.sh: "-z zone1 -z zone2 ..."
+      for val in "${GCE_ZONES[@]}"; do
+        GCE_ZONE_ARGS="-z $val $GCE_ZONE_ARGS"
+      done
+
+      for val in "${EC2_ZONES[@]}"; do
+        EC2_ZONE_ARGS="-z $val $EC2_ZONE_ARGS"
+      done
+
       NO_VALIDATOR_SANITY=1 \
       RUST_LOG=solana=info \
-        ci/testnet-deploy.sh beta-testnet-solana-com ec2 us-west-1a \
-          -t "$CHANNEL_OR_TAG" -n 35 -c 0 -s -u -P -a eipalloc-0f286cf8a0771ce35 -D
-      NO_VALIDATOR_SANITY=1 \
-      RUST_LOG=solana=info \
-        ci/testnet-deploy.sh beta-testnet-solana-com gce us-west1-a \
-          -t "$CHANNEL_OR_TAG" -n 65 -c 0 -x -P -D
-      NO_VALIDATOR_SANITY=1 \
-      RUST_LOG=solana=info \
-        ci/testnet-deploy.sh beta-testnet-solana-com ec2 us-west-1a \
-          -t "$CHANNEL_OR_TAG" -n 35 -c 0 -s -u -P -a eipalloc-0f286cf8a0771ce35 \
+        ci/testnet-deploy.sh -N beta-testnet-solana-com -C ec2 "$EC2_ZONE_ARGS"\
+          -t "$CHANNEL_OR_TAG" -n 60 -c 0 -s -u -P -a eipalloc-0f286cf8a0771ce35 \
           ${maybeReuseLedger:+-r} \
           ${maybeDelete:+-D}
       NO_VALIDATOR_SANITY=1 \
       RUST_LOG=solana=info \
-        ci/testnet-deploy.sh beta-testnet-solana-com gce us-west1-a \
-          -t "$CHANNEL_OR_TAG" -n 65 -c 0 -x -P \
+        ci/testnet-deploy.sh -N beta-testnet-solana-com -C gce "$GCE_ZONE_ARGS"\
+          -t "$CHANNEL_OR_TAG" -n 40 -c 0 -x -P \
           ${maybeReuseLedger:+-r} \
           ${maybeDelete:+-D}
     )
@@ -237,7 +240,7 @@ start() {
       set -x
       NO_LEDGER_VERIFY=1 \
       NO_VALIDATOR_SANITY=1 \
-        ci/testnet-deploy.sh beta-perf-testnet-solana-com ec2 us-west-2b \
+        ci/testnet-deploy.sh -N beta-perf-testnet-solana-com -C ec2 -z us-west-2b \
           -g -t "$CHANNEL_OR_TAG" -c 2 \
           -b \
           ${maybeReuseLedger:+-r} \
@@ -249,12 +252,12 @@ start() {
       set -x
       NO_VALIDATOR_SANITY=1 \
       RUST_LOG=solana=info \
-        ci/testnet-deploy.sh testnet-solana-com ec2 us-west-1a \
+        ci/testnet-deploy.sh -N testnet-solana-com -C ec2 -z us-west-1a \
           -t "$CHANNEL_OR_TAG" -n 3 -c 0 -u -P -a eipalloc-0fa502bf95f6f18b2 \
           -b \
           ${maybeReuseLedger:+-r} \
           ${maybeDelete:+-D}
-        #ci/testnet-deploy.sh testnet-solana-com gce us-east1-c \
+        #ci/testnet-deploy.sh -N testnet-solana-com -C gce -z us-east1-c \
         #  -t "$CHANNEL_OR_TAG" -n 3 -c 0 -P -a testnet-solana-com  \
         #  ${maybeReuseLedger:+-r} \
         #  ${maybeDelete:+-D}
@@ -265,14 +268,14 @@ start() {
       set -x
       NO_LEDGER_VERIFY=1 \
       NO_VALIDATOR_SANITY=1 \
-        ci/testnet-deploy.sh perf-testnet-solana-com gce us-west1-b \
+        ci/testnet-deploy.sh -N perf-testnet-solana-com -C gce -z us-west1-b \
           -G "n1-standard-16 --accelerator count=2,type=nvidia-tesla-v100" \
           -t "$CHANNEL_OR_TAG" -c 2 \
           -b \
           -d pd-ssd \
           ${maybeReuseLedger:+-r} \
           ${maybeDelete:+-D}
-        #ci/testnet-deploy.sh perf-testnet-solana-com ec2 us-east-1a \
+        #ci/testnet-deploy.sh -N perf-testnet-solana-com -C ec2 -z us-east-1a \
         #  -g \
         #  -t "$CHANNEL_OR_TAG" -c 2 \
         #  ${maybeReuseLedger:+-r} \

--- a/ci/testnet-manager.sh
+++ b/ci/testnet-manager.sh
@@ -212,24 +212,26 @@ start() {
       GCE_ZONES=(us-west1-b asia-east2-a europe-west4-a southamerica-east1-b us-east4-c)
       EC2_ZONES=(sa-east-1a us-west-1a ap-northeast-2a eu-central-1a ca-central-1a)
 
-      # Build a string to pass as opts to testnet-deploy.sh: "-z zone1 -z zone2 ..."
+      # Build an array to pass as opts to testnet-deploy.sh: "-z zone1 -z zone2 ..."
+      GCE_ZONE_ARGS=()
       for val in "${GCE_ZONES[@]}"; do
-        GCE_ZONE_ARGS="$GCE_ZONE_ARGS -z $val"
+        GCE_ZONE_ARGS+="-z $val "
       done
 
+      EC2_ZONE_ARGS=()
       for val in "${EC2_ZONES[@]}"; do
-        EC2_ZONE_ARGS="$EC2_ZONE_ARGS -z $val"
+        EC2_ZONE_ARGS+="-z $val "
       done
 
       NO_VALIDATOR_SANITY=1 \
       RUST_LOG=solana=info \
-        ci/testnet-deploy.sh -p beta-testnet-solana-com -C ec2 "$EC2_ZONE_ARGS"\
+        ci/testnet-deploy.sh -p beta-testnet-solana-com -C ec2 ${EC2_ZONE_ARGS[*]} \
           -t "$CHANNEL_OR_TAG" -n 60 -c 0 -s -u -P -a eipalloc-0f286cf8a0771ce35 \
           ${maybeReuseLedger:+-r} \
           ${maybeDelete:+-D}
       NO_VALIDATOR_SANITY=1 \
       RUST_LOG=solana=info \
-        ci/testnet-deploy.sh -p beta-testnet-solana-com -C gce "$GCE_ZONE_ARGS"\
+        ci/testnet-deploy.sh -p beta-testnet-solana-com -C gce ${GCE_ZONE_ARGS[*]} \
           -t "$CHANNEL_OR_TAG" -n 40 -c 0 -x -P \
           ${maybeReuseLedger:+-r} \
           ${maybeDelete:+-D}

--- a/ci/testnet-manager.sh
+++ b/ci/testnet-manager.sh
@@ -215,23 +215,23 @@ start() {
       # Build an array to pass as opts to testnet-deploy.sh: "-z zone1 -z zone2 ..."
       GCE_ZONE_ARGS=()
       for val in "${GCE_ZONES[@]}"; do
-        GCE_ZONE_ARGS+="-z $val "
+        GCE_ZONE_ARGS+=("-z $val")
       done
 
       EC2_ZONE_ARGS=()
       for val in "${EC2_ZONES[@]}"; do
-        EC2_ZONE_ARGS+="-z $val "
+        EC2_ZONE_ARGS+=("-z $val")
       done
 
       NO_VALIDATOR_SANITY=1 \
       RUST_LOG=solana=info \
-        ci/testnet-deploy.sh -p beta-testnet-solana-com -C ec2 ${EC2_ZONE_ARGS[*]} \
+        ci/testnet-deploy.sh -p beta-testnet-solana-com -C ec2 ${EC2_ZONE_ARGS[@]} \
           -t "$CHANNEL_OR_TAG" -n 60 -c 0 -s -u -P -a eipalloc-0f286cf8a0771ce35 \
           ${maybeReuseLedger:+-r} \
           ${maybeDelete:+-D}
       NO_VALIDATOR_SANITY=1 \
       RUST_LOG=solana=info \
-        ci/testnet-deploy.sh -p beta-testnet-solana-com -C gce ${GCE_ZONE_ARGS[*]} \
+        ci/testnet-deploy.sh -p beta-testnet-solana-com -C gce ${GCE_ZONE_ARGS[@]} \
           -t "$CHANNEL_OR_TAG" -n 40 -c 0 -x -P \
           ${maybeReuseLedger:+-r} \
           ${maybeDelete:+-D}

--- a/ci/testnet-manager.sh
+++ b/ci/testnet-manager.sh
@@ -186,7 +186,7 @@ start() {
       set -x
       NO_VALIDATOR_SANITY=1 \
       RUST_LOG=solana=info \
-        ci/testnet-deploy.sh -N edge-testnet-solana-com -C ec2 -z us-west-1a \
+        ci/testnet-deploy.sh -p edge-testnet-solana-com -C ec2 -z us-west-1a \
           -t "$CHANNEL_OR_TAG" -n 3 -c 0 -u -P -a eipalloc-0ccd4f2239886fa94 \
           ${maybeReuseLedger:+-r} \
           ${maybeDelete:+-D}
@@ -197,7 +197,7 @@ start() {
       set -x
       NO_LEDGER_VERIFY=1 \
       NO_VALIDATOR_SANITY=1 \
-        ci/testnet-deploy.sh -N edge-perf-testnet-solana-com -C ec2 -z us-west-2b \
+        ci/testnet-deploy.sh -p edge-perf-testnet-solana-com -C ec2 -z us-west-2b \
           -g -t "$CHANNEL_OR_TAG" -c 2 \
           -b \
           ${maybeReuseLedger:+-r} \
@@ -223,13 +223,13 @@ start() {
 
       NO_VALIDATOR_SANITY=1 \
       RUST_LOG=solana=info \
-        ci/testnet-deploy.sh -N beta-testnet-solana-com -C ec2 "$EC2_ZONE_ARGS"\
+        ci/testnet-deploy.sh -p beta-testnet-solana-com -C ec2 "$EC2_ZONE_ARGS"\
           -t "$CHANNEL_OR_TAG" -n 60 -c 0 -s -u -P -a eipalloc-0f286cf8a0771ce35 \
           ${maybeReuseLedger:+-r} \
           ${maybeDelete:+-D}
       NO_VALIDATOR_SANITY=1 \
       RUST_LOG=solana=info \
-        ci/testnet-deploy.sh -N beta-testnet-solana-com -C gce "$GCE_ZONE_ARGS"\
+        ci/testnet-deploy.sh -p beta-testnet-solana-com -C gce "$GCE_ZONE_ARGS"\
           -t "$CHANNEL_OR_TAG" -n 40 -c 0 -x -P \
           ${maybeReuseLedger:+-r} \
           ${maybeDelete:+-D}
@@ -240,7 +240,7 @@ start() {
       set -x
       NO_LEDGER_VERIFY=1 \
       NO_VALIDATOR_SANITY=1 \
-        ci/testnet-deploy.sh -N beta-perf-testnet-solana-com -C ec2 -z us-west-2b \
+        ci/testnet-deploy.sh -p beta-perf-testnet-solana-com -C ec2 -z us-west-2b \
           -g -t "$CHANNEL_OR_TAG" -c 2 \
           -b \
           ${maybeReuseLedger:+-r} \
@@ -252,12 +252,12 @@ start() {
       set -x
       NO_VALIDATOR_SANITY=1 \
       RUST_LOG=solana=info \
-        ci/testnet-deploy.sh -N testnet-solana-com -C ec2 -z us-west-1a \
+        ci/testnet-deploy.sh -p testnet-solana-com -C ec2 -z us-west-1a \
           -t "$CHANNEL_OR_TAG" -n 3 -c 0 -u -P -a eipalloc-0fa502bf95f6f18b2 \
           -b \
           ${maybeReuseLedger:+-r} \
           ${maybeDelete:+-D}
-        #ci/testnet-deploy.sh -N testnet-solana-com -C gce -z us-east1-c \
+        #ci/testnet-deploy.sh -p testnet-solana-com -C gce -z us-east1-c \
         #  -t "$CHANNEL_OR_TAG" -n 3 -c 0 -P -a testnet-solana-com  \
         #  ${maybeReuseLedger:+-r} \
         #  ${maybeDelete:+-D}
@@ -268,14 +268,14 @@ start() {
       set -x
       NO_LEDGER_VERIFY=1 \
       NO_VALIDATOR_SANITY=1 \
-        ci/testnet-deploy.sh -N perf-testnet-solana-com -C gce -z us-west1-b \
+        ci/testnet-deploy.sh -p perf-testnet-solana-com -C gce -z us-west1-b \
           -G "n1-standard-16 --accelerator count=2,type=nvidia-tesla-v100" \
           -t "$CHANNEL_OR_TAG" -c 2 \
           -b \
           -d pd-ssd \
           ${maybeReuseLedger:+-r} \
           ${maybeDelete:+-D}
-        #ci/testnet-deploy.sh -N perf-testnet-solana-com -C ec2 -z us-east-1a \
+        #ci/testnet-deploy.sh -p perf-testnet-solana-com -C ec2 -z us-east-1a \
         #  -g \
         #  -t "$CHANNEL_OR_TAG" -c 2 \
         #  ${maybeReuseLedger:+-r} \

--- a/ci/testnet-manager.sh
+++ b/ci/testnet-manager.sh
@@ -223,12 +223,14 @@ start() {
         EC2_ZONE_ARGS+=("-z $val")
       done
 
+      # shellcheck disable=SC2068
       NO_VALIDATOR_SANITY=1 \
       RUST_LOG=solana=info \
         ci/testnet-deploy.sh -p beta-testnet-solana-com -C ec2 ${EC2_ZONE_ARGS[@]} \
           -t "$CHANNEL_OR_TAG" -n 60 -c 0 -s -u -P -a eipalloc-0f286cf8a0771ce35 \
           ${maybeReuseLedger:+-r} \
           ${maybeDelete:+-D}
+      # shellcheck disable=SC2068
       NO_VALIDATOR_SANITY=1 \
       RUST_LOG=solana=info \
         ci/testnet-deploy.sh -p beta-testnet-solana-com -C gce ${GCE_ZONE_ARGS[@]} \

--- a/ci/testnet-manager.sh
+++ b/ci/testnet-manager.sh
@@ -214,11 +214,11 @@ start() {
 
       # Build a string to pass as opts to testnet-deploy.sh: "-z zone1 -z zone2 ..."
       for val in "${GCE_ZONES[@]}"; do
-        GCE_ZONE_ARGS="-z $GCE_ZONE_ARGS $val"
+        GCE_ZONE_ARGS="$GCE_ZONE_ARGS -z $val"
       done
 
       for val in "${EC2_ZONES[@]}"; do
-        EC2_ZONE_ARGS="-z $EC2_ZONE_ARGS $val"
+        EC2_ZONE_ARGS="$EC2_ZONE_ARGS -z $val"
       done
 
       NO_VALIDATOR_SANITY=1 \

--- a/ci/testnet-manager.sh
+++ b/ci/testnet-manager.sh
@@ -214,11 +214,11 @@ start() {
 
       # Build a string to pass as opts to testnet-deploy.sh: "-z zone1 -z zone2 ..."
       for val in "${GCE_ZONES[@]}"; do
-        GCE_ZONE_ARGS="-z $val $GCE_ZONE_ARGS"
+        GCE_ZONE_ARGS="-z $GCE_ZONE_ARGS $val"
       done
 
       for val in "${EC2_ZONES[@]}"; do
-        EC2_ZONE_ARGS="-z $val $EC2_ZONE_ARGS"
+        EC2_ZONE_ARGS="-z $EC2_ZONE_ARGS $val"
       done
 
       NO_VALIDATOR_SANITY=1 \


### PR DESCRIPTION
#### Problem

Testnet-deploy and testnet-manager scripts can only handle a single zone/region to deploy the beta-testnet

#### Summary of Changes

Expand the option parsing in testnet-deploy to handle multiple zones to pass to gce.sh/ec2.sh and update the calls to this script in testnet-manager.sh

Fixes #
