### PR TITLE
test for debit of TX fees on full process_transaction()

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1231,11 +1231,23 @@ mod tests {
 
         bank.fee_calculator.lamports_per_signature = 1;
         let tx = system_transaction::transfer(&key1, &key2.pubkey(), 1, genesis_block.hash(), 0);
+
         assert_eq!(bank.process_transaction(&tx), Ok(()));
         assert_eq!(bank.get_balance(&leader), initial_balance + 4);
         assert_eq!(bank.get_balance(&key1.pubkey()), 0);
         assert_eq!(bank.get_balance(&key2.pubkey()), 1);
         assert_eq!(bank.get_balance(&mint_keypair.pubkey()), 100 - 5 - 3);
+
+        // verify that an InstructionError collects fees, too
+        let mut tx =
+            system_transaction::transfer(&mint_keypair, &key2.pubkey(), 1, genesis_block.hash(), 0);
+        // send a bogus instruction to system_program, cause an instruction error
+        tx.message.instructions[0].data[0] = 40;
+
+        bank.process_transaction(&tx).is_err(); // fails with an instruction error
+        assert_eq!(bank.get_balance(&leader), initial_balance + 5); // gots our bucks
+        assert_eq!(bank.get_balance(&key2.pubkey()), 1); //  our fee ------V
+        assert_eq!(bank.get_balance(&mint_keypair.pubkey()), 100 - 5 - 3 - 1);
     }
 
     #[test]

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -706,9 +706,11 @@ impl Bank {
             .zip(executed.iter())
             .map(|(tx, res)| {
                 let fee = self.fee_calculator.calculate_fee(tx.message());
+                let message = tx.message();
                 match *res {
                     Err(TransactionError::InstructionError(_, _)) => {
                         // credit the transaction fee even in case of InstructionError
+                        self.withdraw(&message.account_keys[0], fee)?;
                         fees += fee;
                         Ok(())
                     }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -706,11 +706,9 @@ impl Bank {
             .zip(executed.iter())
             .map(|(tx, res)| {
                 let fee = self.fee_calculator.calculate_fee(tx.message());
-                let message = tx.message();
                 match *res {
                     Err(TransactionError::InstructionError(_, _)) => {
-                        // Charge the transaction fee even in case of InstructionError
-                        self.withdraw(&message.account_keys[0], fee)?;
+                        // credit the transaction fee even in case of InstructionError
                         fees += fee;
                         Ok(())
                     }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -710,6 +710,8 @@ impl Bank {
                 match *res {
                     Err(TransactionError::InstructionError(_, _)) => {
                         // credit the transaction fee even in case of InstructionError
+                        // necessary to withdraw from account[0] here because previous
+                        // work of doing so (in accounts.load()) is ignored by store()
                         self.withdraw(&message.account_keys[0], fee)?;
                         fees += fee;
                         Ok(())


### PR DESCRIPTION
#### Problem
 TX fees are debited from account[0] in account.rs on successful load
   https://github.com/solana-labs/solana/blob/9f046a023e72c703529ad6f4ee9703c8def26c4c/runtime/src/accounts.rs#L647
 AND in bank.rs


 #### Summary of Changes
 remove the bank.rs debit