### PR TITLE
Remove the drone dependency from replicators

### DIFF
--- a/core/src/local_cluster.rs
+++ b/core/src/local_cluster.rs
@@ -435,7 +435,7 @@ mod test {
         let mut fullnode_exit = FullnodeConfig::default();
         fullnode_exit.rpc_config.enable_fullnode_exit = true;
         const NUM_NODES: usize = 1;
-        let num_replicators = 0;
+        let num_replicators = 1;
         let cluster = LocalCluster::new_with_config_replicators(
             &[3; NUM_NODES],
             100,


### PR DESCRIPTION
#### Problem

Replicators rely on having a drone around to keep their account balances in check.

#### Summary of Changes

Removed the drone dependency from replicators. Replicators will now assume there's some balance in their primary accounts from which they can setup storage accounts. This is a stopgap solution until we have persistent storage accounts (currently they're generated on the fly).

Removing the Drone dependency simplifies replicator participation in a local cluster as well. Good things
all around. 

Fixes #3592
