### PR TITLE
disable staking of blockstreamer node

### DIFF
--- a/multinode-demo/fullnode.sh
+++ b/multinode-demo/fullnode.sh
@@ -32,6 +32,7 @@ while [[ ${1:0:1} = - ]]; do
     poll_for_new_genesis_block=1
     shift
   elif [[ $1 = --blockstream ]]; then
+    setup_stakes=0
     extra_fullnode_args+=("$1" "$2")
     shift 2
   elif [[ $1 = --enable-rpc-exit ]]; then


### PR DESCRIPTION
#### Problem
The blockstreamer node is getting scheduled as leader.

#### Summary of Changes
Disabled staking of block streamer node. This will stop it from entering leader rotation schedule

Fixes #
