### PR TITLE
Parallelize cloud node deployment commands in case of multiple zones

### DIFF
--- a/net/gce.sh
+++ b/net/gce.sh
@@ -517,8 +517,10 @@ EOF
     fi
     cloud_CreateInstances "$prefix" "$prefix-$zone-fullnode" "$numNodesPerZone" \
       "$enableGpu" "$fullNodeMachineType" "$zone" "$fullNodeBootDiskSizeInGb" \
-      "$startupScript" "" "$bootDiskType"
+      "$startupScript" "" "$bootDiskType" &
   done
+
+  wait
 
   if [[ $clientNodeCount -gt 0 ]]; then
     cloud_CreateInstances "$prefix" "$prefix-client" "$clientNodeCount" \


### PR DESCRIPTION
#### Problem
Multi zone testnet bootup takes long time.

#### Summary of Changes
Create nodes in different zones in parallel
