### PR TITLE
Impl SyncClient and AsyncClient for ThinClient

### DIFF
--- a/bench-tps/src/bench.rs
+++ b/bench-tps/src/bench.rs
@@ -13,6 +13,7 @@ use solana_metrics::influxdb;
 use solana_sdk::hash::Hash;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::{Keypair, KeypairUtil};
+use solana_sdk::sync_client::SyncClient;
 use solana_sdk::system_instruction;
 use solana_sdk::system_transaction;
 use solana_sdk::timing::timestamp;

--- a/client/src/thin_client.rs
+++ b/client/src/thin_client.rs
@@ -66,19 +66,6 @@ impl ThinClient {
         }
     }
 
-    /// Send a signed Transaction to the server for processing. This method
-    /// does not wait for a response.
-    pub fn transfer_signed(&self, transaction: &Transaction) -> io::Result<Signature> {
-        let mut buf = vec![0; serialized_size(&transaction).unwrap() as usize];
-        let mut wr = std::io::Cursor::new(&mut buf[..]);
-        serialize_into(&mut wr, &transaction)
-            .expect("serialize Transaction in pub fn transfer_signed");
-        assert!(buf.len() < PACKET_DATA_SIZE);
-        self.transactions_socket
-            .send_to(&buf[..], &self.transactions_addr)?;
-        Ok(transaction.signatures[0])
-    }
-
     /// Retry a sending a signed Transaction to the server for processing.
     pub fn retry_transfer_until_confirmed(
         &self,

--- a/core/src/local_cluster.rs
+++ b/core/src/local_cluster.rs
@@ -11,6 +11,7 @@ use solana_client::thin_client::ThinClient;
 use solana_sdk::genesis_block::GenesisBlock;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::{Keypair, KeypairUtil};
+use solana_sdk::sync_client::SyncClient;
 use solana_sdk::system_transaction;
 use solana_sdk::timing::DEFAULT_SLOTS_PER_EPOCH;
 use solana_sdk::timing::DEFAULT_TICKS_PER_SLOT;
@@ -363,7 +364,7 @@ impl LocalCluster {
 
         info!("Checking for vote account registration");
         let vote_account_user_data = client.get_account_data(&vote_account_pubkey);
-        if let Ok(vote_account_user_data) = vote_account_user_data {
+        if let Ok(Some(vote_account_user_data)) = vote_account_user_data {
             if let Ok(vote_state) = VoteState::deserialize(&vote_account_user_data) {
                 if vote_state.delegate_id == delegate_id {
                     return Ok(());

--- a/core/src/replicator.rs
+++ b/core/src/replicator.rs
@@ -19,6 +19,7 @@ use rand::Rng;
 use solana_client::rpc_client::RpcClient;
 use solana_client::rpc_request::RpcRequest;
 use solana_client::thin_client::{create_client, ThinClient};
+use solana_sdk::async_client::AsyncClient;
 use solana_sdk::hash::{Hash, Hasher};
 use solana_sdk::signature::{Keypair, KeypairUtil, Signature};
 use solana_sdk::system_transaction;
@@ -428,7 +429,7 @@ impl Replicator {
                 &solana_storage_api::id(),
                 0,
             );
-            let signature = client.transfer_signed(&tx)?;
+            let signature = client.async_send_transaction(tx)?;
             client.poll_for_signature(&signature)?;
         }
         Ok(())

--- a/core/src/storage_stage.rs
+++ b/core/src/storage_stage.rs
@@ -16,6 +16,7 @@ use solana_client::thin_client::{create_client_with_timeout, ThinClient};
 use solana_sdk::hash::Hash;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::{Keypair, KeypairUtil, Signature};
+use solana_sdk::sync_client::SyncClient;
 use solana_sdk::system_transaction;
 use solana_sdk::transaction::Transaction;
 use solana_storage_api::storage_instruction::{self, StorageInstruction};

--- a/core/src/storage_stage.rs
+++ b/core/src/storage_stage.rs
@@ -13,6 +13,7 @@ use bincode::deserialize;
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaChaRng;
 use solana_client::thin_client::{create_client_with_timeout, ThinClient};
+use solana_sdk::async_client::AsyncClient;
 use solana_sdk::hash::Hash;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::{Keypair, KeypairUtil, Signature};
@@ -289,7 +290,7 @@ impl StorageStage {
                         &solana_storage_api::id(),
                         0,
                     );
-                    let signature = client.transfer_signed(&tx).unwrap();
+                    let signature = client.async_send_transaction(tx).unwrap();
                     Self::check_signature(&client, &signature, &exit)?;
                 }
             }
@@ -299,7 +300,7 @@ impl StorageStage {
                 Err(io::Error::new(io::ErrorKind::Other, "exit signaled"))?;
             }
 
-            if let Ok(signature) = client.transfer_signed(&transaction) {
+            if let Ok(signature) = client.async_send_transaction(transaction.clone()) {
                 Self::check_signature(&client, &signature, &exit)?;
                 return Ok(());
             }

--- a/tests/thin_client.rs
+++ b/tests/thin_client.rs
@@ -33,7 +33,7 @@ pub fn transfer(
         blockhash
     );
     let transaction = system_transaction::create_user_account(keypair, to, lamports, *blockhash, 0);
-    thin_client.transfer_signed(&transaction)
+    thin_client.async_send_transaction(&transaction)
 }
 
 #[test]
@@ -78,7 +78,7 @@ fn test_bad_sig() {
 
     let tx = system_transaction::create_user_account(&alice, &bob_pubkey, 500, blockhash, 0);
 
-    let _sig = client.transfer_signed(&tx).unwrap();
+    let _sig = client.async_send_transaction(&tx).unwrap();
 
     let blockhash = client.get_recent_blockhash().unwrap();
 
@@ -88,7 +88,7 @@ fn test_bad_sig() {
         *lamports = 502;
     }
     tr2.instructions[0].data = serialize(&instruction2).unwrap();
-    let signature = client.transfer_signed(&tr2).unwrap();
+    let signature = client.async_send_transaction(&tr2).unwrap();
     client.poll_for_signature(&signature).unwrap();
 
     let balance = client.get_balance(&bob_pubkey);
@@ -128,7 +128,7 @@ fn test_register_vote_account() {
         vote_instruction::create_account(&validator_keypair.pubkey(), &vote_account_id, 1);
     let transaction =
         Transaction::new_signed_instructions(&[&validator_keypair], instructions, blockhash);
-    let signature = client.transfer_signed(&transaction).unwrap();
+    let signature = client.async_send_transaction(&transaction).unwrap();
     client.poll_for_signature(&signature).unwrap();
 
     let balance = client


### PR DESCRIPTION
This PR is part of work to make it easier for users to switch between different client environments.
It does not, at this point, do much refactoring of ThinClient, but offers a straight replacement of redundant methods. A systematic reworking of retries is still needed.
It does remove a small amount of duplicated code in `retry_transfer_until_confirmed`, but similar cleanup is still needed in rpc_client around `poll_for_signature/_confirmation`.
