### PR TITLE
Support old repair strategy for replicators

### DIFF
--- a/core/src/replicator.rs
+++ b/core/src/replicator.rs
@@ -244,7 +244,7 @@ impl Replicator {
             retransmit_sender,
             repair_socket,
             &exit,
-            repair_slot_range,
+            Some(repair_slot_range),
         );
 
         let client = create_client(cluster_entrypoint.client_facing_addr(), FULLNODE_PORT_RANGE);

--- a/core/src/retransmit_stage.rs
+++ b/core/src/retransmit_stage.rs
@@ -7,7 +7,6 @@ use crate::cluster_info::{
     NEIGHBORHOOD_SIZE,
 };
 use crate::packet::SharedBlob;
-use crate::repair_service::RepairSlotRange;
 use crate::result::{Error, Result};
 use crate::service::Service;
 use crate::staking_utils;
@@ -131,7 +130,7 @@ impl RetransmitStage {
             retransmit_sender,
             repair_socket,
             exit,
-            RepairSlotRange::default(),
+            None,
         );
 
         let thread_hdls = vec![t_retransmit];

--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -103,7 +103,7 @@ impl WindowService {
         retransmit: BlobSender,
         repair_socket: Arc<UdpSocket>,
         exit: &Arc<AtomicBool>,
-        repair_slot_range: RepairSlotRange,
+        repair_slot_range: Option<RepairSlotRange>,
     ) -> WindowService {
         let repair_service = RepairService::new(
             blocktree.clone(),
@@ -159,7 +159,6 @@ mod test {
     use crate::blocktree::Blocktree;
     use crate::cluster_info::{ClusterInfo, Node};
     use crate::entry::make_consecutive_blobs;
-    use crate::repair_service::RepairSlotRange;
     use crate::service::Service;
     use crate::streamer::{blob_receiver, responder};
     use crate::window_service::WindowService;
@@ -197,7 +196,7 @@ mod test {
             s_retransmit,
             Arc::new(leader_node.sockets.repair),
             &exit,
-            RepairSlotRange::default(),
+            None,
         );
         let t_responder = {
             let (s_responder, r_responder) = channel();
@@ -269,7 +268,7 @@ mod test {
             s_retransmit,
             Arc::new(leader_node.sockets.repair),
             &exit,
-            RepairSlotRange::default(),
+            None,
         );
         let t_responder = {
             let (s_responder, r_responder) = channel();


### PR DESCRIPTION
#### Problem
Replicators rely on old style of repair where we repair all slots in a range

#### Summary of Changes
Give repair service a switch to support old-style repair for replicators

Fixes #
