### PR TITLE
Configure cloud zones and nodes from buildkite for beta testnet

### DIFF
--- a/ci/testnet-manager.sh
+++ b/ci/testnet-manager.sh
@@ -134,7 +134,9 @@ sanity() {
   testnet-beta)
     (
       set -x
-      EC2_ZONES=(sa-east-1a us-west-1a ap-northeast-2a eu-central-1a ca-central-1a)
+      [[ -n $GCE_ZONES ]] || GCE_ZONES=(us-west1-b asia-east2-a europe-west4-a southamerica-east1-b us-east4-c)
+      [[ -n $EC2_ZONES ]] || EC2_ZONES=(us-west-1a sa-east-1a ap-northeast-2a eu-central-1a ca-central-1a)
+
       ok=true
       for zone in "${EC2_ZONES[@]}"; do
         if ! $ok; then
@@ -143,7 +145,6 @@ sanity() {
         ci/testnet-sanity.sh beta-testnet-solana-com ec2 "$zone" || ok=false
       done
 
-      GCE_ZONES=(us-west1-b asia-east2-a europe-west4-a southamerica-east1-b us-east4-c)
       for zone in "${GCE_ZONES[@]}"; do
         if ! $ok; then
           break
@@ -225,8 +226,8 @@ start() {
       set -x
 
       # List of zones to deploy for each cloud provider
-      GCE_ZONES=(us-west1-b asia-east2-a europe-west4-a southamerica-east1-b us-east4-c)
-      EC2_ZONES=(us-west-1a sa-east-1a ap-northeast-2a eu-central-1a ca-central-1a)
+      [[ -n $GCE_ZONES ]] || GCE_ZONES=(us-west1-b asia-east2-a europe-west4-a southamerica-east1-b us-east4-c)
+      [[ -n $EC2_ZONES ]] || EC2_ZONES=(us-west-1a sa-east-1a ap-northeast-2a eu-central-1a ca-central-1a)
 
       # Build an array to pass as opts to testnet-deploy.sh: "-z zone1 -z zone2 ..."
       GCE_ZONE_ARGS=()
@@ -239,18 +240,21 @@ start() {
         EC2_ZONE_ARGS+=("-z $val")
       done
 
+      [[ -n $EC2_NODE_COUNT ]] || EC2_NODE_COUNT=60
+      [[ -n $GCE_NODE_COUNT ]] || GCE_NODE_COUNT=40
+
       # shellcheck disable=SC2068
       NO_VALIDATOR_SANITY=1 \
       RUST_LOG=solana=info \
         ci/testnet-deploy.sh -p beta-testnet-solana-com -C ec2 ${EC2_ZONE_ARGS[@]} \
-          -t "$CHANNEL_OR_TAG" -n 60 -c 0 -s -u -P -a eipalloc-0f286cf8a0771ce35 \
+          -t "$CHANNEL_OR_TAG" -n "$EC2_NODE_COUNT" -c 0 -s -u -P -a eipalloc-0f286cf8a0771ce35 \
           ${maybeReuseLedger:+-r} \
           ${maybeDelete:+-D}
       # shellcheck disable=SC2068
       NO_VALIDATOR_SANITY=1 \
       RUST_LOG=solana=info \
         ci/testnet-deploy.sh -p beta-testnet-solana-com -C gce ${GCE_ZONE_ARGS[@]} \
-          -t "$CHANNEL_OR_TAG" -n 40 -c 0 -x -P \
+          -t "$CHANNEL_OR_TAG" -n "$GCE_NODE_COUNT" -c 0 -x -P \
           ${maybeReuseLedger:+-r} \
           ${maybeDelete:+-D}
     )

--- a/ci/testnet-manager.sh
+++ b/ci/testnet-manager.sh
@@ -134,8 +134,13 @@ sanity() {
   testnet-beta)
     (
       set -x
-      [[ -n $GCE_ZONES ]] || GCE_ZONES=(us-west1-b asia-east2-a europe-west4-a southamerica-east1-b us-east4-c)
-      [[ -n $EC2_ZONES ]] || EC2_ZONES=(us-west-1a sa-east-1a ap-northeast-2a eu-central-1a ca-central-1a)
+      if [[ -n $GCE_ZONES ]]; then
+        GCE_ZONES=(us-west1-b asia-east2-a europe-west4-a southamerica-east1-b us-east4-c)
+      fi
+
+      if [[ -n $EC2_ZONES ]]; then
+        EC2_ZONES=(us-west-1a sa-east-1a ap-northeast-2a eu-central-1a ca-central-1a)
+      fi
 
       ok=true
       for zone in "${EC2_ZONES[@]}"; do
@@ -226,8 +231,13 @@ start() {
       set -x
 
       # List of zones to deploy for each cloud provider
-      [[ -n $GCE_ZONES ]] || GCE_ZONES=(us-west1-b asia-east2-a europe-west4-a southamerica-east1-b us-east4-c)
-      [[ -n $EC2_ZONES ]] || EC2_ZONES=(us-west-1a sa-east-1a ap-northeast-2a eu-central-1a ca-central-1a)
+      if [[ -n $GCE_ZONES ]]; then
+        GCE_ZONES=(us-west1-b asia-east2-a europe-west4-a southamerica-east1-b us-east4-c)
+      fi
+
+      if [[ -n $EC2_ZONES ]]; then
+        EC2_ZONES=(us-west-1a sa-east-1a ap-northeast-2a eu-central-1a ca-central-1a)
+      fi
 
       # Build an array to pass as opts to testnet-deploy.sh: "-z zone1 -z zone2 ..."
       GCE_ZONE_ARGS=()

--- a/ci/testnet-manager.sh
+++ b/ci/testnet-manager.sh
@@ -134,11 +134,11 @@ sanity() {
   testnet-beta)
     (
       set -x
-      if [[ -n $GCE_ZONES ]]; then
+      if [ -z $GCE_ZONES ]; then
         GCE_ZONES=(us-west1-b asia-east2-a europe-west4-a southamerica-east1-b us-east4-c)
       fi
 
-      if [[ -n $EC2_ZONES ]]; then
+      if [ -z $EC2_ZONES ]; then
         EC2_ZONES=(us-west-1a sa-east-1a ap-northeast-2a eu-central-1a ca-central-1a)
       fi
 
@@ -231,11 +231,11 @@ start() {
       set -x
 
       # List of zones to deploy for each cloud provider
-      if [[ -n $GCE_ZONES ]]; then
+      if [ -z $GCE_ZONES ]; then
         GCE_ZONES=(us-west1-b asia-east2-a europe-west4-a southamerica-east1-b us-east4-c)
       fi
 
-      if [[ -n $EC2_ZONES ]]; then
+      if [ -z $EC2_ZONES ]; then
         EC2_ZONES=(us-west-1a sa-east-1a ap-northeast-2a eu-central-1a ca-central-1a)
       fi
 

--- a/ci/testnet-manager.sh
+++ b/ci/testnet-manager.sh
@@ -134,14 +134,6 @@ sanity() {
   testnet-beta)
     (
       set -x
-      if [ -z $GCE_ZONES ]; then
-        GCE_ZONES=(us-west1-b asia-east2-a europe-west4-a southamerica-east1-b us-east4-c)
-      fi
-
-      if [ -z $EC2_ZONES ]; then
-        EC2_ZONES=(us-west-1a sa-east-1a ap-northeast-2a eu-central-1a ca-central-1a)
-      fi
-
       ok=true
       for zone in "${EC2_ZONES[@]}"; do
         if ! $ok; then
@@ -229,15 +221,6 @@ start() {
   testnet-beta)
     (
       set -x
-
-      # List of zones to deploy for each cloud provider
-      if [ -z $GCE_ZONES ]; then
-        GCE_ZONES=(us-west1-b asia-east2-a europe-west4-a southamerica-east1-b us-east4-c)
-      fi
-
-      if [ -z $EC2_ZONES ]; then
-        EC2_ZONES=(us-west-1a sa-east-1a ap-northeast-2a eu-central-1a ca-central-1a)
-      fi
 
       # Build an array to pass as opts to testnet-deploy.sh: "-z zone1 -z zone2 ..."
       GCE_ZONE_ARGS=()


### PR DESCRIPTION
#### Problem
The cloud zones and number of nodes are hard coded in the script. It makes tweaking the testnet parameters very hard.

#### Summary of Changes
Configure these values from the buildkite job.