### PR TITLE
Propagate cloud env variables to buildkite job

### DIFF
--- a/ci/testnet-manager.sh
+++ b/ci/testnet-manager.sh
@@ -107,6 +107,10 @@ steps:
         TESTNET: "$TESTNET"
         TESTNET_OP: "$TESTNET_OP"
         TESTNET_DB_HOST: "$TESTNET_DB_HOST"
+        EC2_ZONES: "${EC2_ZONES[*]}"
+        EC2_NODE_COUNT: "$EC2_NODE_COUNT"
+        GCE_ZONES: "${GCE_ZONES[*]}"
+        GCE_NODE_COUNT: "$GCE_NODE_COUNT"
 EOF
   ) | buildkite-agent pipeline upload
   exit 0


### PR DESCRIPTION
#### Problem
Beta testnet buildkite job is not picking up the env variables.

#### Summary of Changes
The primary job spawns a secondary build kite job. The environment variables need to be added to the second job.
