### PR TITLE
Add sleep for check_signature

### DIFF
--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -400,13 +400,12 @@ impl RpcClient {
         Ok(())
     }
 
-    /// Check a signature in the bank. This method blocks
-    /// until the server sends a response.
+    /// Check a signature in the bank.
     pub fn check_signature(&self, signature: &Signature) -> bool {
         trace!("check_signature: {:?}", signature);
         let params = json!([format!("{}", signature)]);
 
-        loop {
+        for _ in 0..30 {
             let response =
                 self.client
                     .send(&RpcRequest::ConfirmTransaction, Some(params.clone()), 0);
@@ -426,7 +425,10 @@ impl RpcClient {
                     debug!("check_signature request failed: {:?}", err);
                 }
             };
+            sleep(Duration::from_millis(250));
         }
+
+        panic!("Couldn't check signature of {}", signature);
     }
 
     /// Poll the server to confirm a transaction.


### PR DESCRIPTION
#### Problem

check_signature loops at the fastest speed to check for signatures causing overhead on server and client. Also, it never exits which is a problem when you are talking to a server which may be down or unavailable.

#### Summary of Changes

Add sleep to loop and fixed number of iterations.

Fixes #
