### PR TITLE
Make MAX_RECENT_BLOCKHASHES <= MAX_HASH_AGE_IN_SECONDS

### DIFF
--- a/sdk/src/timing.rs
+++ b/sdk/src/timing.rs
@@ -21,8 +21,8 @@ pub const NUM_CONSECUTIVE_LEADER_SLOTS: u64 = 8;
 /// not be processed by the network.
 pub const MAX_HASH_AGE_IN_SECONDS: usize = 120;
 
-pub const MAX_RECENT_BLOCKHASHES: usize =
-    (NUM_TICKS_PER_SECOND * MAX_HASH_AGE_IN_SECONDS as u64 / DEFAULT_TICKS_PER_SLOT) as usize;
+// This must be <= MAX_HASH_AGE_IN_SECONDS, otherwise there's risk for DuplicateSignature errors
+pub const MAX_RECENT_BLOCKHASHES: usize = 120;
 
 pub fn duration_as_us(d: &Duration) -> u64 {
     (d.as_secs() * 1000 * 1000) + (u64::from(d.subsec_nanos()) / 1_000)

--- a/sdk/src/timing.rs
+++ b/sdk/src/timing.rs
@@ -22,7 +22,7 @@ pub const NUM_CONSECUTIVE_LEADER_SLOTS: u64 = 8;
 pub const MAX_HASH_AGE_IN_SECONDS: usize = 120;
 
 // This must be <= MAX_HASH_AGE_IN_SECONDS, otherwise there's risk for DuplicateSignature errors
-pub const MAX_RECENT_BLOCKHASHES: usize = 120;
+pub const MAX_RECENT_BLOCKHASHES: usize = MAX_HASH_AGE_IN_SECONDS;
 
 pub fn duration_as_us(d: &Duration) -> u64 {
     (d.as_secs() * 1000 * 1000) + (u64::from(d.subsec_nanos()) / 1_000)


### PR DESCRIPTION
#### Problem
DuplicateSignatures can show up on validators if the leader is squashing aggressively. This is because a transaction can make it through the last id check, but fail the duplicate signature check because the maximum history of blockhashes is currently longer than the maximum history of status_cache roots

#### Summary of Changes

Fixes #
