### PR TITLE
Reduce udp read/write buffer sizes

### DIFF
--- a/multinode-demo/common.sh
+++ b/multinode-demo/common.sh
@@ -88,16 +88,16 @@ tune_system() {
       # test the existence of the sysctls before trying to set them
       # go ahead and return true and don't exit if these calls fail
       sysctl net.core.rmem_max 2>/dev/null 1>/dev/null &&
-          sudo sysctl -w net.core.rmem_max=1610612736 1>/dev/null 2>/dev/null
+          sudo sysctl -w net.core.rmem_max=161061273 1>/dev/null 2>/dev/null
 
       sysctl net.core.rmem_default 2>/dev/null 1>/dev/null &&
-          sudo sysctl -w net.core.rmem_default=1610612736 1>/dev/null 2>/dev/null
+          sudo sysctl -w net.core.rmem_default=161061273 1>/dev/null 2>/dev/null
 
       sysctl net.core.wmem_max 2>/dev/null 1>/dev/null &&
-          sudo sysctl -w net.core.wmem_max=1610612736 1>/dev/null 2>/dev/null
+          sudo sysctl -w net.core.wmem_max=161061273 1>/dev/null 2>/dev/null
 
       sysctl net.core.wmem_default 2>/dev/null 1>/dev/null &&
-          sudo sysctl -w net.core.wmem_default=1610612736 1>/dev/null 2>/dev/null
+          sudo sysctl -w net.core.wmem_default=161061273 1>/dev/null 2>/dev/null
     ) || true
   fi
 


### PR DESCRIPTION
#### Problem

With Ubuntu 18.04, these large values cause packet errors and mess up the system.

#### Summary of Changes

Lower rmem/wmem sizes.

Fixes #
