### PR TITLE
net/: Set warn log level only for perf testnets

### DIFF
--- a/ci/testnet-manager.sh
+++ b/ci/testnet-manager.sh
@@ -203,7 +203,6 @@ start() {
     (
       set -x
       NO_VALIDATOR_SANITY=1 \
-      RUST_LOG=solana=info \
         ci/testnet-deploy.sh -p edge-testnet-solana-com -C ec2 -z us-west-1a \
           -t "$CHANNEL_OR_TAG" -n 3 -c 0 -u -P -a eipalloc-0ccd4f2239886fa94 \
           ${maybeReuseLedger:+-r} \
@@ -215,6 +214,7 @@ start() {
       set -x
       NO_LEDGER_VERIFY=1 \
       NO_VALIDATOR_SANITY=1 \
+      RUST_LOG=solana=warn \
         ci/testnet-deploy.sh -p edge-perf-testnet-solana-com -C ec2 -z us-west-2b \
           -g -t "$CHANNEL_OR_TAG" -c 2 \
           -b \
@@ -244,14 +244,12 @@ start() {
 
       # shellcheck disable=SC2068
       NO_VALIDATOR_SANITY=1 \
-      RUST_LOG=solana=info \
         ci/testnet-deploy.sh -p beta-testnet-solana-com -C ec2 ${EC2_ZONE_ARGS[@]} \
           -t "$CHANNEL_OR_TAG" -n "$EC2_NODE_COUNT" -c 0 -s -u -P -a eipalloc-0f286cf8a0771ce35 \
           ${maybeReuseLedger:+-r} \
           ${maybeDelete:+-D}
       # shellcheck disable=SC2068
       NO_VALIDATOR_SANITY=1 \
-      RUST_LOG=solana=info \
         ci/testnet-deploy.sh -p beta-testnet-solana-com -C gce ${GCE_ZONE_ARGS[@]} \
           -t "$CHANNEL_OR_TAG" -n "$GCE_NODE_COUNT" -c 0 -x -P \
           ${maybeReuseLedger:+-r} \
@@ -263,6 +261,7 @@ start() {
       set -x
       NO_LEDGER_VERIFY=1 \
       NO_VALIDATOR_SANITY=1 \
+      RUST_LOG=solana=warn \
         ci/testnet-deploy.sh -p beta-perf-testnet-solana-com -C ec2 -z us-west-2b \
           -g -t "$CHANNEL_OR_TAG" -c 2 \
           -b \
@@ -274,7 +273,6 @@ start() {
     (
       set -x
       NO_VALIDATOR_SANITY=1 \
-      RUST_LOG=solana=info \
         ci/testnet-deploy.sh -p testnet-solana-com -C ec2 -z us-west-1a \
           -t "$CHANNEL_OR_TAG" -n 3 -c 0 -u -P -a eipalloc-0fa502bf95f6f18b2 \
           -b \
@@ -291,6 +289,7 @@ start() {
       set -x
       NO_LEDGER_VERIFY=1 \
       NO_VALIDATOR_SANITY=1 \
+      RUST_LOG=solana=warn \
         ci/testnet-deploy.sh -p perf-testnet-solana-com -C gce -z us-west1-b \
           -G "n1-standard-16 --accelerator count=2,type=nvidia-tesla-v100" \
           -t "$CHANNEL_OR_TAG" -c 2 \

--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -13,7 +13,7 @@ RUST_LOG="$6"
 skipSetup="$7"
 leaderRotation="$8"
 set +x
-export RUST_LOG=${RUST_LOG:-solana=warn} # if RUST_LOG is unset, default to warn
+export RUST_LOG
 
 missing() {
   echo "Error: $1 not specified"
@@ -42,7 +42,6 @@ case $deployMethod in
 local|tar)
   PATH="$HOME"/.cargo/bin:"$PATH"
   export USE_INSTALL=1
-  export RUST_LOG
   export SOLANA_METRICS_DISPLAY_HOSTNAME=1
 
   # Setup `/var/snap/solana/current` symlink so rsyncing the genesis


### PR DESCRIPTION
#### Problem
There's a sneaky RUST_LOG override in `net/remote/remote-node.sh`, only used to reduce log levels only for -perf testnets, that's bothering devs

#### Summary of Changes
Move the RUST_LOG override to where it belongs: `ci/testnet-manager.sh`.
