### PR TITLE
Hard code testnet-perf branch and tag

### DIFF
--- a/ci/testnet-manager.sh
+++ b/ci/testnet-manager.sh
@@ -75,32 +75,31 @@ source scripts/configure-metrics.sh
 ci/channel-info.sh
 eval "$(ci/channel-info.sh)"
 
-case $TESTNET in
-testnet-edge|testnet-edge-perf)
-  CHANNEL_OR_TAG=edge
-  CHANNEL_BRANCH=$EDGE_CHANNEL
-  ;;
-testnet-beta|testnet-beta-perf)
-  CHANNEL_OR_TAG=beta
-  CHANNEL_BRANCH=$BETA_CHANNEL
-  ;;
-testnet)
-  CHANNEL_OR_TAG=$STABLE_CHANNEL_LATEST_TAG
-  CHANNEL_BRANCH=$STABLE_CHANNEL
-  ;;
-testnet-perf)
-  CHANNEL_OR_TAG=v0.11.0
-  CHANNEL_BRANCH=v0.11
-  ;;
-*)
-  echo "Error: Invalid TESTNET=$TESTNET"
-  exit 1
-  ;;
-esac
+if [[ -n $TESTNET_TAG ]]; then
+  CHANNEL_OR_TAG=$TESTNET_TAG
+else
+  case $TESTNET in
+  testnet-edge|testnet-edge-perf)
+    CHANNEL_OR_TAG=edge
+    CHANNEL_BRANCH=$EDGE_CHANNEL
+    ;;
+  testnet-beta|testnet-beta-perf)
+    CHANNEL_OR_TAG=beta
+    CHANNEL_BRANCH=$BETA_CHANNEL
+    ;;
+  testnet|testnet-perf)
+    CHANNEL_OR_TAG=$STABLE_CHANNEL_LATEST_TAG
+    CHANNEL_BRANCH=$STABLE_CHANNEL
+    ;;
+  *)
+    echo "Error: Invalid TESTNET=$TESTNET"
+    exit 1
+    ;;
+  esac
 
-if [[ $BUILDKITE_BRANCH != "$CHANNEL_BRANCH" ]]; then
-  (
-    cat <<EOF
+  if [[ $BUILDKITE_BRANCH != "$CHANNEL_BRANCH" ]]; then
+    (
+      cat <<EOF
 steps:
   - trigger: "$BUILDKITE_PIPELINE_SLUG"
     async: true
@@ -114,10 +113,10 @@ steps:
         EC2_NODE_COUNT: "$EC2_NODE_COUNT"
         GCE_NODE_COUNT: "$GCE_NODE_COUNT"
 EOF
-  ) | buildkite-agent pipeline upload
-  exit 0
+    ) | buildkite-agent pipeline upload
+    exit 0
+  fi
 fi
-
 
 sanity() {
   echo "--- sanity $TESTNET"

--- a/ci/testnet-manager.sh
+++ b/ci/testnet-manager.sh
@@ -84,9 +84,13 @@ testnet-beta|testnet-beta-perf)
   CHANNEL_OR_TAG=beta
   CHANNEL_BRANCH=$BETA_CHANNEL
   ;;
-testnet|testnet-perf)
+testnet)
   CHANNEL_OR_TAG=$STABLE_CHANNEL_LATEST_TAG
   CHANNEL_BRANCH=$STABLE_CHANNEL
+  ;;
+testnet-perf)
+  CHANNEL_OR_TAG=v0.11.0
+  CHANNEL_BRANCH=v0.11
   ;;
 *)
   echo "Error: Invalid TESTNET=$TESTNET"


### PR DESCRIPTION
#### Problem

Third party users are viewing and using testnet-perf, currently based on v0.11.  Performance is poorer on v0.12 and it is desired that testnet-perf not be automatically migrated to 0.12 when we branch to 0.13.

#### Summary of Changes

Hard code the testnet-perf branch and tag selection so that it will be manually iterated.  This change could be reverted in the future once the overall product and release cycle is more stable.

Fixes # https://github.com/solana-labs/solana/issues/3688
