### PR TITLE
Only check CHANNEL_BRANCH if TARGET_TAG is not set

### DIFF
--- a/ci/testnet-manager.sh
+++ b/ci/testnet-manager.sh
@@ -68,33 +68,31 @@ echo "SOLANA_METRICS_CONFIG: $SOLANA_METRICS_CONFIG"
 ci/channel-info.sh
 eval "$(ci/channel-info.sh)"
 
-case $TESTNET in
-testnet-edge|testnet-edge-perf)
-  CHANNEL_OR_TAG=edge
-  CHANNEL_BRANCH=$EDGE_CHANNEL
-  ;;
-testnet-beta|testnet-beta-perf)
-  CHANNEL_OR_TAG=beta
-  CHANNEL_BRANCH=$BETA_CHANNEL
-  ;;
-testnet|testnet-perf)
-  if [[ -n $BETA_CHANNEL_LATEST_TAG ]]; then
-    CHANNEL_OR_TAG=$BETA_CHANNEL_LATEST_TAG
+if [[ -n $TESTNET_TAG ]]; then
+  CHANNEL_OR_TAG=$TESTNET_TAG
+else
+  case $TESTNET in
+  testnet-edge|testnet-edge-perf)
+    CHANNEL_OR_TAG=edge
+    CHANNEL_BRANCH=$EDGE_CHANNEL
+    ;;
+  testnet-beta|testnet-beta-perf)
+    CHANNEL_OR_TAG=beta
     CHANNEL_BRANCH=$BETA_CHANNEL
-  else
+    ;;
+  testnet|testnet-perf)
     CHANNEL_OR_TAG=$STABLE_CHANNEL_LATEST_TAG
     CHANNEL_BRANCH=$STABLE_CHANNEL
-  fi
-  ;;
-*)
-  echo "Error: Invalid TESTNET=$TESTNET"
-  exit 1
-  ;;
-esac
+    ;;
+  *)
+    echo "Error: Invalid TESTNET=$TESTNET"
+    exit 1
+    ;;
+  esac
 
-if [[ $BUILDKITE_BRANCH != "$CHANNEL_BRANCH" ]]; then
-  (
-    cat <<EOF
+  if [[ $BUILDKITE_BRANCH != "$CHANNEL_BRANCH" ]]; then
+    (
+      cat <<EOF
 steps:
   - trigger: "$BUILDKITE_PIPELINE_SLUG"
     async: true
@@ -105,8 +103,9 @@ steps:
         TESTNET: "$TESTNET"
         TESTNET_OP: "$TESTNET_OP"
 EOF
-  ) | buildkite-agent pipeline upload
-  exit 0
+    ) | buildkite-agent pipeline upload
+    exit 0
+  fi
 fi
 
 


### PR DESCRIPTION
Problem

Third party users are viewing and using testnet-perf, currently based on v0.11. Performance is poorer on v0.12 and it is desired that testnet-perf not be automatically migrated to 0.12 when we branch to 0.13.

Summary of Changes

Set a new env var in buildkite TARGET_TAG to specify which tag the build should be running on for testnet-perf, negating the need for the testnet switch case block.

Fixes # #3688
