### PR TITLE
Gossip the most recent votes

### DIFF
--- a/core/src/cluster_info.rs
+++ b/core/src/cluster_info.rs
@@ -324,7 +324,8 @@ impl ClusterInfo {
                         votes
                             .transactions
                             .iter()
-                            .map(|tx| tx.clone())
+                            .cloned()
+                            .map(|tx| tx)
                             .collect::<Vec<_>>(),
                     )
                 })


### PR DESCRIPTION
#### Problem

Since Gossip only keeps the newest vote arround, some votes could block older ones from being recorded on some nodes. This can result in different locktower results depending on what order votes reached the nodes

#### Summary of Changes

Always submit the last N(configurable) votes to gossip.

