### PR TITLE
Implement default for &Pubkey

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2494,6 +2494,7 @@ dependencies = [
  "generic-array 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "ring 0.13.5 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -16,6 +16,7 @@ byteorder = "1.2.1"
 chrono = { version = "0.4.0", features = ["serde"] }
 generic-array = { version = "0.12.0", default-features = false, features = ["serde"] }
 itertools = "0.8.0"
+lazy_static = "1.3.0"
 log = "0.4.2"
 rand = "0.6.5"
 ring = "0.13.2"

--- a/sdk/src/pubkey.rs
+++ b/sdk/src/pubkey.rs
@@ -1,5 +1,6 @@
 use generic_array::typenum::U32;
 use generic_array::GenericArray;
+use lazy_static::lazy_static;
 use std::error;
 use std::fmt;
 use std::fs::{self, File};
@@ -11,6 +12,16 @@ use std::str::FromStr;
 #[repr(C)]
 #[derive(Serialize, Deserialize, Clone, Copy, Default, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct Pubkey(GenericArray<u8, U32>);
+
+lazy_static! {
+    static ref PUBKEY_DEFAULT: Pubkey = Pubkey::default();
+}
+
+impl Default for &Pubkey {
+    fn default() -> Self {
+        &PUBKEY_DEFAULT
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ParsePubkeyError {
@@ -135,5 +146,12 @@ mod tests {
         assert_eq!(read, pubkey);
         remove_file(filename)?;
         Ok(())
+    }
+
+    #[test]
+    fn test_pubkey_default_ref() {
+        let xs = vec![Pubkey::new_rand()];
+        assert_ne!(xs.get(0).unwrap_or_default(), &Pubkey::default());
+        assert_eq!(xs.get(1).unwrap_or_default(), &Pubkey::default());
     }
 }


### PR DESCRIPTION
Without this, it's painful to get a pubkey from a vector, when
Pubkey::default() is a reasonable default.

