### PR TITLE
Process votes from gossip only in leader node

### DIFF
--- a/core/src/cluster_info_vote_listener.rs
+++ b/core/src/cluster_info_vote_listener.rs
@@ -1,4 +1,5 @@
 use crate::cluster_info::{ClusterInfo, GOSSIP_SLEEP_MILLIS};
+use crate::poh_recorder::PohRecorder;
 use crate::result::Result;
 use crate::service::Service;
 use crate::sigverify_stage::VerifiedPackets;
@@ -6,7 +7,7 @@ use crate::{packet, sigverify};
 use solana_metrics::counter::Counter;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::Sender;
-use std::sync::{Arc, RwLock};
+use std::sync::{Arc, Mutex, RwLock};
 use std::thread::{self, sleep, Builder, JoinHandle};
 use std::time::Duration;
 
@@ -20,12 +21,20 @@ impl ClusterInfoVoteListener {
         cluster_info: Arc<RwLock<ClusterInfo>>,
         sigverify_disabled: bool,
         sender: Sender<VerifiedPackets>,
+        poh_recorder: &Arc<Mutex<PohRecorder>>,
     ) -> Self {
         let exit = exit.clone();
+        let poh_recorder = poh_recorder.clone();
         let thread = Builder::new()
             .name("solana-cluster_info_vote_listener".to_string())
             .spawn(move || {
-                let _ = Self::recv_loop(exit, &cluster_info, sigverify_disabled, &sender);
+                let _ = Self::recv_loop(
+                    exit,
+                    &cluster_info,
+                    sigverify_disabled,
+                    &sender,
+                    poh_recorder,
+                );
             })
             .unwrap();
         Self {
@@ -37,6 +46,7 @@ impl ClusterInfoVoteListener {
         cluster_info: &Arc<RwLock<ClusterInfo>>,
         sigverify_disabled: bool,
         sender: &Sender<VerifiedPackets>,
+        poh_recorder: Arc<Mutex<PohRecorder>>,
     ) -> Result<()> {
         let mut last_ts = 0;
         loop {
@@ -44,15 +54,17 @@ impl ClusterInfoVoteListener {
                 return Ok(());
             }
             let (votes, new_ts) = cluster_info.read().unwrap().get_votes(last_ts);
-            last_ts = new_ts;
-            inc_new_counter_info!("cluster_info_vote_listener-recv_count", votes.len());
-            let msgs = packet::to_packets(&votes);
-            let r = if sigverify_disabled {
-                sigverify::ed25519_verify_disabled(&msgs)
-            } else {
-                sigverify::ed25519_verify_cpu(&msgs)
-            };
-            sender.send(msgs.into_iter().zip(r).collect())?;
+            if poh_recorder.lock().unwrap().bank().is_some() {
+                last_ts = new_ts;
+                inc_new_counter_info!("cluster_info_vote_listener-recv_count", votes.len());
+                let msgs = packet::to_packets(&votes);
+                let r = if sigverify_disabled {
+                    sigverify::ed25519_verify_disabled(&msgs)
+                } else {
+                    sigverify::ed25519_verify_cpu(&msgs)
+                };
+                sender.send(msgs.into_iter().zip(r).collect())?;
+            }
             sleep(Duration::from_millis(GOSSIP_SLEEP_MILLIS));
         }
     }

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -60,6 +60,7 @@ impl Tpu {
             cluster_info.clone(),
             sigverify_disabled,
             verified_sender,
+            &poh_recorder,
         );
 
         let banking_stage = BankingStage::new(&cluster_info, poh_recorder, verified_receiver);


### PR DESCRIPTION
#### Problem
The validators are pulling votes from gossip and forwarding it to the leader nodes. This is redundant and overwhelming the leader node.

#### Summary of Changes
Process votes from gossip only when the current node is the leader.