### PR TITLE
HTLC Proposal 

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -59,6 +59,7 @@
   - [Credit-only Accounts](credit-only-credit-debit-accounts.md)
   - [Cluster Software Installation and Updates](installer.md)
   - [Deterministic Transaction Fees](transaction-fees.md)
+  - [Hashed Time-Locked Contract Transactions](htlc.md)
 
 - [Implemented Design Proposals](implemented-proposals.md)
   - [Fork Selection](fork-selection.md)

--- a/book/src/htlc.md
+++ b/book/src/htlc.md
@@ -12,6 +12,57 @@ The key requirements for HTLC is that a ledger supports time-locked transactions
 meaning a transaction that won't be executed until at a later point in time. And
 conditional transactions with message digest instructions.
 
+## Atomic Swaps
+
+One use case of HTLC is atomic swaps. It solves the problem of (at least) two
+parties wanting to exchange their DLT tokens or coins without having to trust
+a third party or a centralized exchange.
+
+A solution to this problem was [first suggested by Tier Nolan on the Bitcoin forum]
+where he described a risk-free within a time bound interactive protocol to exchange
+tokens across different DLTs.
+
+The protocol goes as follows:
+
+```ignore
+A picks a random number x
+
+ A creates TX1: "Pay w BTC to <B's public key> if (x for H(x) known and signed by B) or (signed by A & B)"
+
+ A creates TX2: "Pay w BTC from TX1 to <A's public key>, locked 48 hours in the future, signed by A"
+
+ A sends TX2 to B
+
+ B signs TX2 and returns to A
+
+ 1) A submits TX1 to the network
+
+ B creates TX3: "Pay v alt-coins to <A-public-key> if (x for H(x) known and signed by A) or (signed by A & B)"
+
+ B creates TX4: "Pay v alt-coins from TX3 to <B's public key>, locked 24 hours in the future, signed by B"
+
+ B sends TX4 to A
+
+ A signs TX4 and sends back to B
+
+ 2) B submits TX3 to the network
+
+ 3) A spends TX3, revealing x
+
+ 4) B spends TX1 using x
+
+ This is atomic (with timeout).  If the process is halted, it can be reversed no matter when it is stopped.
+
+ Before 1: Nothing public has been broadcast, so nothing happens
+ Between 1 & 2: A can use refund transaction after 48 hours to get his money back
+ Between 2 & 3: B can get refund after 24 hours.  A has 24 more hours to get his refund
+ After 3: Transaction is completed by 2
+ - A must spend his new coin within 24 hours or B can claim the refund and keep his coins
+ - B must spend his new coin within 48 hours or A can claim the refund and keep his coins
+
+ For safety, both should complete the process with lots of time until the deadlines.
+```
+
 ## Implementation
 
 There are a couple of ways to implement HTLC in Solana. We can implement HTLC
@@ -20,50 +71,29 @@ and `OP_SHA256` in bitcoin [Script].
 
 ### New Instructions
 
-In order to be compatible with [BIP-199] and [ERC-1630] we have to support 2 message
-digest algorithms, SHA-256 and Keccak-256 (SHA-3). I recommend that we also implement
-Blake2 and Shake message digest algorithms.
+In order to be compatible with many other DLTs HTLC implementations we have to
+support at least 2 message digest algorithms, SHA-256 and Keccak-256 (SHA-3).
+It is recommended to also implement Blake2 and Shake algorithms.
 
-We could implement these two instructions in Solana as [system instructions] as follows:
-
-```rust,ignore
-pub enum SystemInstruction {
-  /// Evaluates to true if period_in_seconds becomes zero.
-  /// Counter doesn't start until transaction is confirmed.
-  CheckElapsed { period_in_seconds: u64 },
-
-  /// SHA-256 hashing instruction.
-  /// Evaluates to the SHA-256 message digest.
-  SHA256 { data: &[u8] }
-}
-
-pub fn check_elapsed(account_id: &PubKey, period: u64) -> Instruction {
-  // Code here to store period variable in account data and decrement it
-  // by the amount of time passed since the last run.
-}
-
-pub fn hash_sha_256(data: &[u8]) -> Instruction {
-  // Code here to return the message digest of data.
-}
-```
-
-### New Transaction
-
-The [budget program] already implements time-locking capability but it is missing
-arbitrary conditionals including message digest verification. If we were to implement
-HTLC in the [budget program] we'll need to extend the [Condition enum] to include
-message digest verification as follows:
+The [budget program] currently lacks time-locking capability and message digest
+verification. If we were to implement HTLC in the [budget program] we'll need to
+extend the [Condition enum] to include the message digest verification and
+time-locking as follows:
 
 ```rust,ignore
 pub enum Condition {
   /// Evaluate whether a message digest of some data matches a particular hash.
   MDVerify { data: &[u8], hash: &[u8] },
 
+  /// Evaluate whether a condition has expired.
+  HasExpired { expiry_date: DateTime<Utc> },
+
   // ... other possible conditional types.
 }
 ```
 
-And update the `is_satisfied` method to carry out the digest verification.
+And update the `is_satisfied` method to carry out the digest verification and check
+whether the payment plan has expired.
 
 [Script]: https://en.bitcoin.it/wiki/Script
 [BIP-199]: https://github.com/bitcoin/bips/blob/master/bip-0199.mediawiki
@@ -72,3 +102,4 @@ And update the `is_satisfied` method to carry out the digest verification.
 [system instructions]: https://github.com/solana-labs/solana/tree/7da4142d338c61589c097d8edc52ff39d45060b9/programs/budget_api
 [counterparty risk]: https://www.investopedia.com/terms/c/counterpartyrisk.asp
 [Condition enum]: https://github.com/solana-labs/solana/blob/7da4142d338c61589c097d8edc52ff39d45060b9/programs/budget_api/src/budget_expr.rs#L31
+[first suggested by Tier Nolan on the Bitcoin forum]: https://bitcointalk.org/index.php?topic=193281.msg2224949#msg2224949

--- a/book/src/htlc.md
+++ b/book/src/htlc.md
@@ -1,0 +1,74 @@
+# Hashed Time-Locked Contract Transactions
+
+A Hashed Time-Locked Contract is a transaction that allows one party of a
+transaction to spend tokens by forced-disclosure of the preimage of a message
+digest, and allows the counterparty to spend the tokens after a predefined
+lockout period.
+
+Another way to look at HTLC is that it is a protocol to eliminate [counterparty
+risk] where one side of a trade could default on their obligation.
+
+The key requirements for HTLC is that a ledger supports time-locked transactions,
+meaning a transaction that won't be executed until at a later point in time. And
+conditional transactions with message digest instructions.
+
+## Implementation
+
+There are a couple of ways to implement HTLC in Solana. We can implement HTLC
+as a transaction type or as a set of instructions akin to `OP_CHECKSEQUENCEVERIFY`
+and `OP_SHA256` in bitcoin [Script].
+
+### New Instructions
+
+In order to be compatible with [BIP-199] and [ERC-1630] we have to support 2 message
+digest algorithms, SHA-256 and Keccak-256 (SHA-3). I recommend that we also implement
+Blake2 and Shake message digest algorithms.
+
+We could implement these two instructions in Solana as [system instructions] as follows:
+
+```rust
+pub enum SystemInstruction {
+  /// Evaluates to true if period_in_seconds becomes zero.
+  /// Counter doesn't start until transaction is confirmed.
+  CheckElapsed { period_in_seconds: u64 },
+
+  /// SHA-256 hashing instruction.
+  /// Evaluates to the SHA-256 message digest.
+  SHA256 { data: &[u8] }
+}
+
+pub fn check_elapsed(account_id: &PubKey, period: u64) -> Instruction {
+  // Code here to store period variable in account data and decrement it
+  // by the amount of time passed since the last run.
+}
+
+pub fn hash_sha_256(data: &[u8]) -> Instruction {
+  // Code here to return the message digest of data.
+}
+```
+
+### New Transaction
+
+The [budget program] already implements time-locking capability but it is missing
+arbitrary conditionals including message digest verification. If we were to implement
+HTLC in the [budget program] we'll need to extend the [Condition enum] to include
+message digest verification as follows:
+
+```rust
+pub enum Condition {
+  /// Evaluate whether a message digest of some data matches a particular hash.
+  MDVerify { data: &[u8], hash: &[u8] },
+
+  // ... other possible conditional types.
+}
+```
+
+And update the `is_satisfied` method to carry out the digest verification.
+
+[Script]: https://en.bitcoin.it/wiki/Script
+[BIP-199]: https://github.com/bitcoin/bips/blob/master/bip-0199.mediawiki
+[ERC-1630]: https://github.com/ethereum/EIPs/issues/1631
+[budget program]: https://github.com/solana-labs/solana/tree/7da4142d338c61589c097d8edc52ff39d45060b9/programs/budget_api
+[system instructions]: https://github.com/solana-labs/solana/tree/7da4142d338c61589c097d8edc52ff39d45060b9/programs/budget_api
+[counterparty risk]: https://www.investopedia.com/terms/c/counterpartyrisk.asp
+[Condition enum]: https://github.com/solana-labs/solana/blob/7da4142d338c61589c097d8edc52ff39d45060b9/programs/budget_api/src/budget_expr.rs#L31

--- a/book/src/htlc.md
+++ b/book/src/htlc.md
@@ -26,7 +26,7 @@ Blake2 and Shake message digest algorithms.
 
 We could implement these two instructions in Solana as [system instructions] as follows:
 
-```rust
+```rust,ignore
 pub enum SystemInstruction {
   /// Evaluates to true if period_in_seconds becomes zero.
   /// Counter doesn't start until transaction is confirmed.
@@ -54,7 +54,7 @@ arbitrary conditionals including message digest verification. If we were to impl
 HTLC in the [budget program] we'll need to extend the [Condition enum] to include
 message digest verification as follows:
 
-```rust
+```rust,ignore
 pub enum Condition {
   /// Evaluate whether a message digest of some data matches a particular hash.
   MDVerify { data: &[u8], hash: &[u8] },

--- a/book/src/htlc.md
+++ b/book/src/htlc.md
@@ -8,9 +8,9 @@ lockout period.
 Another way to look at HTLC is that it is a protocol to eliminate [counterparty
 risk] where one side of a trade could default on their obligation.
 
-The key requirements for HTLC is that a ledger supports time-locked transactions,
-meaning a transaction that won't be executed until at a later point in time. And
-conditional transactions with message digest instructions.
+The key requirements for HTLC is that a DLT supports time-locked transactions,
+meaning a transaction that won't be executed until a later point in time. And
+also supports message digest verification instruction.
 
 ## Atomic Swaps
 
@@ -19,7 +19,7 @@ parties wanting to exchange their DLT tokens or coins without having to trust
 a third party or a centralized exchange.
 
 A solution to this problem was [first suggested by Tier Nolan on the Bitcoin forum]
-where he described a risk-free within a time bound interactive protocol to exchange
+where he described a risk-free time-bounded interactive protocol to exchange
 tokens across different DLTs.
 
 The protocol goes as follows:
@@ -71,9 +71,10 @@ and `OP_SHA256` in bitcoin [Script].
 
 ### New Instructions
 
-In order to be compatible with many other DLTs HTLC implementations we have to
+In order to be compatible with many other HTLC implementations we have to
 support at least 2 message digest algorithms, SHA-256 and Keccak-256 (SHA-3).
-It is recommended to also implement Blake2 and Shake algorithms.
+It is noticable that newer DLTs also use Blake2 and Shake algorithms (e.g., Tezos),
+so for forward compatibility we might need to support these two algorithms.
 
 The [budget program] currently lacks time-locking capability and message digest
 verification. If we were to implement HTLC in the [budget program] we'll need to
@@ -82,11 +83,15 @@ time-locking as follows:
 
 ```rust,ignore
 pub enum Condition {
-  /// Evaluate whether a message digest of some data matches a particular hash.
+  /// Evaluate whether a message digest of input data matches a hash.
+  /// e.g., within a transaction it should be possible for a user to
+  /// specify that a transaction will execute if the conditional
+  /// MDVerify(input_data, "abc3234efab31....") evaluates to true.
   MDVerify { data: &[u8], hash: &[u8] },
 
-  /// Evaluate whether a condition has expired.
-  HasExpired { expiry_date: DateTime<Utc> },
+  /// Evaluate whether a certain number of ticks has elapsed since the
+  /// transaction was first confirmed.
+  HasElapsed { ticks: u64 },
 
   // ... other possible conditional types.
 }


### PR DESCRIPTION
This is a proposal for supporting Hashed Time-Locked Contracts/Agreements.

## Problem

To implement cross-chain atomic swaps between two parties all DLTs in the swap must at least support 1) a time-locking instruction 2) a message digest verification instruction.

Currently Solana only supports time-locking as part of the budget program or smart contract and no message digest verification instruction.

Also for HTLC to function across chains, Solana has to support the specific message digest algorithms that are supported on other chains. Specifically SHA-256 for Bitcoin and Keccak-256 for Ethereum. The more DLTs we want our HTLC to support and be compatible with the more message digest algorithms we have to support.

## Proposed Solution

This PR is a design proposal for one part of the problem, once implemented no other fundamental changes are needed to carry out atomic swaps between Solana and Bitcoin or more generally any blockchain that supports SHA-256 verification instruction. This design however doesn't address the interactivity problem of atomic swaps (i.e., exchange of HTLC secret nor wallet support) this part of the problem will be address in another proposal dedicated to atomic swaps.