### PR TITLE
Always use bootstrap vote account for leader

### DIFF
--- a/core/src/local_cluster.rs
+++ b/core/src/local_cluster.rs
@@ -116,6 +116,7 @@ impl LocalCluster {
         slots_per_epoch: u64,
         native_instruction_processors: &[(String, Pubkey)],
     ) -> Self {
+        let voting_keypair = Keypair::new();
         let leader_keypair = Arc::new(Keypair::new());
         let leader_pubkey = leader_keypair.pubkey();
         let leader_node = Node::new_localhost_with_pubkey(&leader_keypair.pubkey());
@@ -126,9 +127,9 @@ impl LocalCluster {
         genesis_block
             .native_instruction_processors
             .extend_from_slice(native_instruction_processors);
+        genesis_block.bootstrap_leader_vote_account_id = voting_keypair.pubkey();
         let (genesis_ledger_path, _blockhash) = create_new_tmp_ledger!(&genesis_block);
         let leader_ledger_path = tmp_copy_blocktree!(&genesis_ledger_path);
-        let voting_keypair = Keypair::new();
         let leader_contact_info = leader_node.info.clone();
 
         let leader_server = Fullnode::new(
@@ -457,4 +458,5 @@ mod test {
         assert_eq!(cluster.fullnodes.len(), NUM_NODES);
         assert_eq!(cluster.replicators.len(), num_replicators);
     }
+
 }

--- a/multinode-demo/bootstrap-leader.sh
+++ b/multinode-demo/bootstrap-leader.sh
@@ -15,7 +15,6 @@ if [[ $1 = -h ]]; then
 fi
 
 extra_fullnode_args=()
-setup_stakes=true
 
 while [[ ${1:0:1} = - ]]; do
   if [[ $1 = --blockstream ]]; then
@@ -27,9 +26,6 @@ while [[ ${1:0:1} = - ]]; do
   elif [[ $1 = --init-complete-file ]]; then
     extra_fullnode_args+=("$1" "$2")
     shift 2
-  elif [[ $1 = --only-bootstrap-stake ]]; then
-    setup_stakes=false
-    shift
   elif [[ $1 = --public-address ]]; then
     extra_fullnode_args+=("$1")
     shift
@@ -84,9 +80,5 @@ $program \
   > >($bootstrap_leader_logger) 2>&1 &
 pid=$!
 oom_score_adj "$pid" 1000
-
-if [[ $setup_stakes = true ]] ; then
-  setup_fullnode_staking 127.0.0.1 "$bootstrap_leader_id_path" "$bootstrap_leader_staker_id_path"
-fi
 
 wait "$pid"

--- a/multinode-demo/setup.sh
+++ b/multinode-demo/setup.sh
@@ -79,6 +79,7 @@ if $bootstrap_leader; then
     $solana_keygen -o "$SOLANA_CONFIG_DIR"/bootstrap-leader-staker-id.json
     $solana_genesis \
       --bootstrap-leader-keypair "$SOLANA_CONFIG_DIR"/bootstrap-leader-id.json \
+      --bootstrap-stake-keypair "$SOLANA_CONFIG_DIR"/bootstrap-leader-staker-id.json \
       --ledger "$SOLANA_RSYNC_CONFIG_DIR"/ledger \
       --mint "$SOLANA_CONFIG_DIR"/mint-id.json \
       --lamports "$lamports"

--- a/run.sh
+++ b/run.sh
@@ -58,6 +58,7 @@ solana-genesis \
   --lamports 1000000000 \
   --mint "$dataDir"/config/drone-keypair.json \
   --bootstrap-leader-keypair "$dataDir"/config/leader-keypair.json \
+  --bootstrap-stake-keypair "$dataDir"/config/leader-staking-account-keypair.json \
   --ledger "$dataDir"/ledger
 
 solana-drone --keypair "$dataDir"/config/drone-keypair.json &

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -330,6 +330,7 @@ impl Bank {
 
         let mut vote_state = VoteState::new(&genesis_block.bootstrap_leader_id);
         vote_state.votes.push_back(Lockout::new(&Vote::new(0)));
+        vote_state.authorized_voter_id = genesis_block.bootstrap_leader_vote_account_id;
         vote_state
             .serialize(&mut bootstrap_leader_vote_account.data)
             .unwrap();
@@ -345,6 +346,9 @@ impl Bank {
             .genesis_hash(&genesis_block.hash());
 
         self.ticks_per_slot = genesis_block.ticks_per_slot;
+
+        // make bank 0 votable
+        self.is_delta.store(true, Ordering::Relaxed);
 
         self.epoch_schedule = EpochSchedule::new(
             genesis_block.slots_per_epoch,


### PR DESCRIPTION
#### Problem

Bootstrap leader staking accounts were being setup in 2 external steps via wallet and could result in racey behavior.

This two step setup is ultimately not necessary since genesis can carry all the info we need.

#### Summary of Changes

Use the bootstrap leader's real staking keypair in the genesis block. 
