### PR TITLE
pick up logs as artifacts

### DIFF
--- a/ci/buildkite.yml
+++ b/ci/buildkite.yml
@@ -9,6 +9,7 @@ steps:
   - command: "ci/test-stable-perf.sh"
     name: "stable-perf"
     timeout_in_minutes: 20
+    artifact_paths: "log-*.txt"
     agents:
       - "queue=cuda"
   - command: "ci/test-bench.sh"
@@ -17,6 +18,7 @@ steps:
   - command: ". ci/rust-version.sh; ci/docker-run.sh $$rust_stable_docker_image ci/test-stable.sh"
     name: "stable"
     timeout_in_minutes: 25
+    artifact_paths: "log-*.txt"
   - command: ". ci/rust-version.sh; ci/docker-run.sh $$rust_nightly_docker_image ci/test-coverage.sh"
     name: "coverage"
     timeout_in_minutes: 20


### PR DESCRIPTION
#### Problem
 localnet sanity failures are evident when one examines the nodes' logs, but CI doesn't hang onto 'em for us in the build artifacts

 #### Summary of Changes
 add the node logs to artifacts for stable and stable-perf, which run localnet-sanity