### PR TITLE
reset coding generator on slot boundaries

### DIFF
--- a/core/src/broadcast_stage.rs
+++ b/core/src/broadcast_stage.rs
@@ -53,7 +53,7 @@ impl Broadcast {
         let mut last_tick = entries.last().map(|v| v.1).unwrap_or(0);
         ventries.push(entries);
 
-        assert!(last_tick <= max_tick_height,);
+        assert!(last_tick <= max_tick_height);
         if last_tick != max_tick_height {
             while let Ok((same_bank, entries)) = receiver.try_recv() {
                 // If the bank changed, that implies the previous slot was interrupted and we do not have to


### PR DESCRIPTION
#### Problem
 a slot may contain a non-integral multiple of NUM_DATA blobs, when
  broadcast crosses slots, the coding generator should start from 0

 #### Summary of Changes
 detect slot changes in generator, forget leftovers