### PR TITLE
Add solana-install deployments to the testnets

### DIFF
--- a/ci/testnet-deploy.sh
+++ b/ci/testnet-deploy.sh
@@ -257,9 +257,20 @@ if ! $skipStart; then
       op=start
     fi
 
-    # shellcheck disable=SC2086 # Don't want to double quote maybeRejectExtraNodes
+    maybeUpdateManifestKeypairFile=
+    # shellcheck disable=SC2154 # SOLANA_INSTALL_UPDATE_MANIFEST_KEYPAIR_x86_64_unknown_linux_gnu comes from .buildkite/env/
+    if [[ -n $SOLANA_INSTALL_UPDATE_MANIFEST_KEYPAIR_x86_64_unknown_linux_gnu ]]; then
+      echo "$SOLANA_INSTALL_UPDATE_MANIFEST_KEYPAIR_x86_64_unknown_linux_gnu" > update_manifest_keypair.json
+      maybeUpdateManifestKeypairFile="-i update_manifest_keypair.json"
+    fi
+
+    # shellcheck disable=SC2086 # Don't want to double quote the $maybeXYZ variables
     time net/net.sh $op -t "$tarChannelOrTag" \
-      $maybeSkipSetup $maybeRejectExtraNodes $maybeNoValidatorSanity $maybeNoLedgerVerify
+      $maybeUpdateManifestKeypairFile \
+      $maybeSkipSetup \
+      $maybeRejectExtraNodes \
+      $maybeNoValidatorSanity \
+      $maybeNoLedgerVerify
   ) || ok=false
 
   net/net.sh logs

--- a/net/remote/remote-deploy-update.sh
+++ b/net/remote/remote-deploy-update.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -e
+#
+# This script is to be run on the bootstrap full node
+#
+
+cd "$(dirname "$0")"/../..
+
+updateDownloadUrl=$1
+
+[[ -r deployConfig ]] || {
+  echo deployConfig missing
+  exit 1
+}
+# shellcheck source=/dev/null # deployConfig is written by remote-node.sh
+source deployConfig
+
+missing() {
+  echo "Error: $1 not specified"
+  exit 1
+}
+
+[[ -n $updateDownloadUrl ]] || missing updateDownloadUrl
+
+RUST_LOG="$2"
+export RUST_LOG=${RUST_LOG:-solana=info} # if RUST_LOG is unset, default to info
+
+source net/common.sh
+loadConfigFile
+
+PATH="$HOME"/.cargo/bin:"$PATH"
+
+set -x
+solana-wallet airdrop 42
+solana-install deploy "$updateDownloadUrl" update_manifest_keypair.json \
+  --url http://localhost:8899


### PR DESCRIPTION
Once we deploy a tar-based testnet downloaded from AWS, `solana-install deploy` is used to advertise the deployed tarball on the cluster.   Users then can use `solana-install update` to fetch and install that tarball on their machine.

Fixes more of #3261.  


