### PR TITLE
Remove manual step from runtime build

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1932,7 +1932,11 @@ mod tests {
         let (mut genesis_block, _) =
             GenesisBlock::new_with_leader(500, &bootstrap_leader.pubkey(), 100);
         genesis_block.bootstrap_leader_vote_account_id = voting_keypair.pubkey();
-        let bank = Bank::new(&genesis_block);
+        let mut bank = Bank::new(&genesis_block);
+        bank.add_instruction_processor(
+            solana_vote_api::id(),
+            vote_instruction::process_instruction,
+        );
         let instructions = vote_instruction::vote(&voting_keypair.pubkey(), Vote::new(1));
         let transaction = Transaction::new_signed_instructions(
             &[&voting_keypair],

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1924,26 +1924,4 @@ mod tests {
         bank.tick_height.store(max_tick_height, Ordering::Relaxed);
         assert!(bank.is_votable());
     }
-
-    #[test]
-    fn test_genesis_vote_processing() {
-        let bootstrap_leader = Keypair::new();
-        let voting_keypair = Keypair::new();
-        let (mut genesis_block, _) =
-            GenesisBlock::new_with_leader(500, &bootstrap_leader.pubkey(), 100);
-        genesis_block.bootstrap_leader_vote_account_id = voting_keypair.pubkey();
-        let mut bank = Bank::new(&genesis_block);
-        bank.add_instruction_processor(
-            solana_vote_api::id(),
-            vote_instruction::process_instruction,
-        );
-        let instructions = vote_instruction::vote(&voting_keypair.pubkey(), Vote::new(1));
-        let transaction = Transaction::new_signed_instructions(
-            &[&voting_keypair],
-            vec![instructions],
-            bank.last_blockhash(),
-        );
-        bank.process_transaction(&transaction).unwrap()
-    }
-
 }


### PR DESCRIPTION
#### Problem

A recent bank test added a dependency on the dynamically loaded Vote instruction processor, so running the runtime build will fail unless you manually rebuild `vote_program` first.

#### Summary of Changes

An even more recent test by @rob-solana tests the same functionality in the Vote program. Remove the runtime test.

@sagar-solana, fyi
