### PR TITLE
Adjust noop/failure program names to be consistent with all other programs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2338,7 +2338,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-failure"
+name = "solana-failure-program"
 version = "0.13.0"
 dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2491,7 +2491,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-noop"
+name = "solana-noop-program"
 version = "0.13.0"
 dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/programs/failure_program/Cargo.toml
+++ b/programs/failure_program/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "solana-failure"
+name = "solana-failure-program"
 version = "0.13.0"
 description = "Solana failure program"
 authors = ["Solana Maintainers <maintainers@solana.com>"]
@@ -16,6 +16,6 @@ log = "0.4.2"
 solana-runtime = { path = "../../runtime", version = "0.13.0" }
 
 [lib]
-name = "failure"
+name = "solana_failure_program"
 crate-type = ["cdylib"]
 

--- a/programs/failure_program/tests/failure.rs
+++ b/programs/failure_program/tests/failure.rs
@@ -14,7 +14,7 @@ fn test_program_native_failure() {
     let bank = Bank::new(&genesis_block);
     let bank_client = BankClient::new(&bank);
 
-    let program = "failure".as_bytes().to_vec();
+    let program = "solana_failure_program".as_bytes().to_vec();
     let program_id = load_program(&bank_client, &alice_keypair, &native_loader::id(), program);
 
     // Call user program

--- a/programs/noop_program/Cargo.toml
+++ b/programs/noop_program/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "solana-noop"
+name = "solana-noop-program"
 version = "0.13.0"
 description = "Solana noop program"
 authors = ["Solana Maintainers <maintainers@solana.com>"]
@@ -17,6 +17,6 @@ log = "0.4.2"
 solana-runtime = { path = "../../runtime", version = "0.13.0" }
 
 [lib]
-name = "noop"
+name = "solana_noop_program"
 crate-type = ["cdylib"]
 

--- a/programs/noop_program/tests/noop.rs
+++ b/programs/noop_program/tests/noop.rs
@@ -14,7 +14,7 @@ fn test_program_native_noop() {
     let bank = Bank::new(&genesis_block);
     let bank_client = BankClient::new(&bank);
 
-    let program = "noop".as_bytes().to_vec();
+    let program = "solana_noop_program".as_bytes().to_vec();
     let program_id = load_program(&bank_client, &alice_keypair, &native_loader::id(), program);
 
     // Call user program

--- a/scripts/cargo-install-all.sh
+++ b/scripts/cargo-install-all.sh
@@ -50,7 +50,7 @@ for crate in "${BIN_CRATES[@]}"; do
 done
 
 for dir in programs/*; do
-  for program in echo target/release/deps/lib{,solana_}"$(basename "$dir")"{,_program}.{so,dylib,dll}; do
+  for program in echo target/release/deps/libsolana_"$(basename "$dir")".{so,dylib,dll}; do
     if [[ -f $program ]]; then
       mkdir -p "$installDir/bin/deps"
       rm -f "$installDir/bin/deps/$(basename "$program")"


### PR DESCRIPTION
@CriesofCarrots, I see libsolana_noop_program.so and libsolana_failure_program.so in the list of files installed into the docker image now.