### PR TITLE
Consume Bank in BankClient

### DIFF
--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -42,7 +42,7 @@ mod bpf {
 
             let (genesis_block, alice_keypair) = GenesisBlock::new(50);
             let bank = Bank::new(&genesis_block);
-            let bank_client = BankClient::new(&bank);
+            let bank_client = BankClient::new(bank);
 
             // Call user program
             let program_id = load_program(&bank_client, &alice_keypair, &bpf_loader::id(), elf);
@@ -73,7 +73,7 @@ mod bpf {
 
                 let (genesis_block, alice_keypair) = GenesisBlock::new(50);
                 let bank = Bank::new(&genesis_block);
-                let bank_client = BankClient::new(&bank);
+                let bank_client = BankClient::new(bank);
 
                 let loader_id = load_program(
                     &bank_client,
@@ -118,7 +118,7 @@ mod bpf {
 
                 let (genesis_block, alice_keypair) = GenesisBlock::new(50);
                 let bank = Bank::new(&genesis_block);
-                let bank_client = BankClient::new(&bank);
+                let bank_client = BankClient::new(bank);
 
                 let loader_id = load_program(
                     &bank_client,

--- a/programs/budget_api/src/budget_processor.rs
+++ b/programs/budget_api/src/budget_processor.rs
@@ -164,7 +164,7 @@ mod tests {
     #[test]
     fn test_budget_payment() {
         let (bank, alice_keypair) = create_bank(10_000);
-        let bank_client = BankClient::new(&bank);
+        let bank_client = BankClient::new(bank);
         let alice_pubkey = alice_keypair.pubkey();
         let bob_pubkey = Pubkey::new_rand();
         let instructions = budget_instruction::payment(&alice_pubkey, &bob_pubkey, 100);
@@ -178,7 +178,7 @@ mod tests {
     #[test]
     fn test_unsigned_witness_key() {
         let (bank, alice_keypair) = create_bank(10_000);
-        let bank_client = BankClient::new(&bank);
+        let bank_client = BankClient::new(bank);
         let alice_pubkey = alice_keypair.pubkey();
 
         // Initialize BudgetState
@@ -225,7 +225,7 @@ mod tests {
     #[test]
     fn test_unsigned_timestamp() {
         let (bank, alice_keypair) = create_bank(10_000);
-        let bank_client = BankClient::new(&bank);
+        let bank_client = BankClient::new(bank);
         let alice_pubkey = alice_keypair.pubkey();
 
         // Initialize BudgetState
@@ -273,7 +273,7 @@ mod tests {
     #[test]
     fn test_pay_on_date() {
         let (bank, alice_keypair) = create_bank(2);
-        let bank_client = BankClient::new(&bank);
+        let bank_client = BankClient::new(bank);
         let alice_pubkey = alice_keypair.pubkey();
         let budget_pubkey = Pubkey::new_rand();
         let bob_pubkey = Pubkey::new_rand();
@@ -342,7 +342,7 @@ mod tests {
     #[test]
     fn test_cancel_payment() {
         let (bank, alice_keypair) = create_bank(3);
-        let bank_client = BankClient::new(&bank);
+        let bank_client = BankClient::new(bank);
         let alice_pubkey = alice_keypair.pubkey();
         let budget_pubkey = Pubkey::new_rand();
         let bob_pubkey = Pubkey::new_rand();

--- a/programs/exchange_api/src/exchange_processor.rs
+++ b/programs/exchange_api/src/exchange_processor.rs
@@ -553,9 +553,9 @@ mod test {
         (bank, mint_keypair)
     }
 
-    fn create_client(bank: &Bank, mint_keypair: Keypair) -> (BankClient, Keypair) {
+    fn create_client(bank: Bank, mint_keypair: Keypair) -> (BankClient, Keypair) {
         let owner = Keypair::new();
-        let bank_client = BankClient::new(&bank);
+        let bank_client = BankClient::new(bank);
         bank_client
             .transfer(42, &mint_keypair, &owner.pubkey())
             .unwrap();
@@ -649,7 +649,7 @@ mod test {
     fn test_exchange_new_account() {
         solana_logger::setup();
         let (bank, mint_keypair) = create_bank(10_000);
-        let (client, owner) = create_client(&bank, mint_keypair);
+        let (client, owner) = create_client(bank, mint_keypair);
 
         let new = create_token_account(&client, &owner);
         let new_account_data = client.get_account_data(&new).unwrap().unwrap();
@@ -668,7 +668,7 @@ mod test {
     fn test_exchange_new_account_not_unallocated() {
         solana_logger::setup();
         let (bank, mint_keypair) = create_bank(10_000);
-        let (client, owner) = create_client(&bank, mint_keypair);
+        let (client, owner) = create_client(bank, mint_keypair);
 
         let new = create_token_account(&client, &owner);
         let instruction = exchange_instruction::account_request(&owner.pubkey(), &new);
@@ -681,7 +681,7 @@ mod test {
     fn test_exchange_new_transfer_request() {
         solana_logger::setup();
         let (bank, mint_keypair) = create_bank(10_000);
-        let (client, owner) = create_client(&bank, mint_keypair);
+        let (client, owner) = create_client(bank, mint_keypair);
 
         let new = create_token_account(&client, &owner);
 
@@ -707,7 +707,7 @@ mod test {
     fn test_exchange_new_trade_request() {
         solana_logger::setup();
         let (bank, mint_keypair) = create_bank(10_000);
-        let (client, owner) = create_client(&bank, mint_keypair);
+        let (client, owner) = create_client(bank, mint_keypair);
 
         let (trade, src, dst) = trade(
             &client,
@@ -756,7 +756,7 @@ mod test {
     fn test_exchange_new_swap_request() {
         solana_logger::setup();
         let (bank, mint_keypair) = create_bank(10_000);
-        let (client, owner) = create_client(&bank, mint_keypair);
+        let (client, owner) = create_client(bank, mint_keypair);
 
         let swap = create_account(&client, &owner);
         let profit = create_token_account(&client, &owner);

--- a/programs/failure_program/tests/failure.rs
+++ b/programs/failure_program/tests/failure.rs
@@ -12,7 +12,7 @@ use solana_sdk::transaction::TransactionError;
 fn test_program_native_failure() {
     let (genesis_block, alice_keypair) = GenesisBlock::new(50);
     let bank = Bank::new(&genesis_block);
-    let bank_client = BankClient::new(&bank);
+    let bank_client = BankClient::new(bank);
 
     let program = "failure".as_bytes().to_vec();
     let program_id = load_program(&bank_client, &alice_keypair, &native_loader::id(), program);

--- a/programs/noop_program/tests/noop.rs
+++ b/programs/noop_program/tests/noop.rs
@@ -12,7 +12,7 @@ fn test_program_native_noop() {
 
     let (genesis_block, alice_keypair) = GenesisBlock::new(50);
     let bank = Bank::new(&genesis_block);
-    let bank_client = BankClient::new(&bank);
+    let bank_client = BankClient::new(bank);
 
     let program = "noop".as_bytes().to_vec();
     let program_id = load_program(&bank_client, &alice_keypair, &native_loader::id(), program);

--- a/programs/vote_api/src/vote_instruction.rs
+++ b/programs/vote_api/src/vote_instruction.rs
@@ -154,7 +154,7 @@ mod tests {
     #[test]
     fn test_vote_bank_basic() {
         let (bank, from_keypair) = create_bank(10_000);
-        let bank_client = BankClient::new(&bank);
+        let bank_client = BankClient::new(bank);
 
         let vote_keypair = Keypair::new();
         let vote_id = vote_keypair.pubkey();
@@ -170,7 +170,7 @@ mod tests {
     #[test]
     fn test_vote_via_bank_authorize_voter() {
         let (bank, mallory_keypair) = create_bank(10_000);
-        let bank_client = BankClient::new(&bank);
+        let bank_client = BankClient::new(bank);
 
         let vote_keypair = Keypair::new();
         let vote_id = vote_keypair.pubkey();
@@ -187,7 +187,7 @@ mod tests {
     #[test]
     fn test_vote_via_bank_with_no_signature() {
         let (bank, mallory_keypair) = create_bank(10_000);
-        let bank_client = BankClient::new(&bank);
+        let bank_client = BankClient::new(bank);
 
         let vote_keypair = Keypair::new();
         let vote_id = vote_keypair.pubkey();

--- a/runtime/src/bank_client.rs
+++ b/runtime/src/bank_client.rs
@@ -11,11 +11,11 @@ use solana_sdk::transaction::{self, Transaction};
 use solana_sdk::transport::Result;
 use std::io;
 
-pub struct BankClient<'a> {
-    bank: &'a Bank,
+pub struct BankClient {
+    bank: Bank,
 }
 
-impl<'a> AsyncClient for BankClient<'a> {
+impl AsyncClient for BankClient {
     fn async_send_transaction(&self, transaction: Transaction) -> io::Result<Signature> {
         // Ignore the result. Client must use get_signature_status() instead.
         let _ = self.bank.process_transaction(&transaction);
@@ -57,7 +57,7 @@ impl<'a> AsyncClient for BankClient<'a> {
     }
 }
 
-impl<'a> SyncClient for BankClient<'a> {
+impl SyncClient for BankClient {
     fn send_message(&self, keypairs: &[&Keypair], message: Message) -> Result<Signature> {
         let blockhash = self.bank.last_blockhash();
         let transaction = Transaction::new(&keypairs, message, blockhash);
@@ -103,8 +103,8 @@ impl<'a> SyncClient for BankClient<'a> {
     }
 }
 
-impl<'a> BankClient<'a> {
-    pub fn new(bank: &'a Bank) -> Self {
+impl BankClient {
+    pub fn new(bank: Bank) -> Self {
         Self { bank }
     }
 }
@@ -123,7 +123,7 @@ mod tests {
         let jane_pubkey = jane_doe_keypair.pubkey();
         let doe_keypairs = vec![&john_doe_keypair, &jane_doe_keypair];
         let bank = Bank::new(&genesis_block);
-        let bank_client = BankClient::new(&bank);
+        let bank_client = BankClient::new(bank);
 
         // Create 2-2 Multisig Transfer instruction.
         let bob_pubkey = Pubkey::new_rand();

--- a/runtime/src/system_instruction_processor.rs
+++ b/runtime/src/system_instruction_processor.rs
@@ -284,7 +284,7 @@ mod tests {
 
         // Fund to account to bypass AccountNotFound error
         let bank = Bank::new(&genesis_block);
-        let bank_client = BankClient::new(&bank);
+        let bank_client = BankClient::new(bank);
         bank_client
             .transfer(50, &alice_keypair, &mallory_pubkey)
             .unwrap();


### PR DESCRIPTION
#### Problem

BankClient can't Arc its Bank and use it from a thread. Arc consumes its parameter and Bank is passed into BankClient via reference.

#### Summary of Changes

Consume Bank in BankClient.  This will allow BankClient to spin up a thread to use the Bank. It'll also ease the transaction from BankClient to ThinClient since it won't let you depend on Bank.

Drawback, you the transition from Bank to BankClient will be harder because the Bank methods are inaccessible.
