### PR TITLE
Update CustomError codes from Vec->u32

### DIFF
--- a/programs/budget_api/src/budget_processor.rs
+++ b/programs/budget_api/src/budget_processor.rs
@@ -2,7 +2,7 @@
 use crate::budget_expr::Witness;
 use crate::budget_instruction::BudgetInstruction;
 use crate::budget_state::{BudgetError, BudgetState};
-use bincode::{deserialize, serialize};
+use bincode::deserialize;
 use chrono::prelude::{DateTime, Utc};
 use log::*;
 use solana_sdk::account::KeyedAccount;
@@ -115,7 +115,7 @@ pub fn process_instruction(
             }
             trace!("apply timestamp");
             apply_timestamp(&mut budget_state, keyed_accounts, dt)
-                .map_err(|e| InstructionError::CustomError(serialize(&e).unwrap()))?;
+                .map_err(|e| InstructionError::CustomError(e as u32))?;
             trace!("apply timestamp committed");
             budget_state.serialize(&mut keyed_accounts[1].account.data)
         }
@@ -133,7 +133,7 @@ pub fn process_instruction(
             }
             trace!("apply signature");
             apply_signature(&mut budget_state, keyed_accounts)
-                .map_err(|e| InstructionError::CustomError(serialize(&e).unwrap()))?;
+                .map_err(|e| InstructionError::CustomError(e as u32))?;
             trace!("apply signature committed");
             budget_state.serialize(&mut keyed_accounts[1].account.data)
         }
@@ -312,7 +312,7 @@ mod tests {
                 .unwrap(),
             TransactionError::InstructionError(
                 0,
-                InstructionError::CustomError(serialize(&BudgetError::DestinationMissing).unwrap())
+                InstructionError::CustomError(BudgetError::DestinationMissing as u32)
             )
         );
         assert_eq!(bank_client.get_balance(&alice_pubkey).unwrap(), 1);

--- a/programs/token_api/src/token_processor.rs
+++ b/programs/token_api/src/token_processor.rs
@@ -1,5 +1,4 @@
 use crate::token_state::TokenState;
-use bincode::serialize;
 use log::*;
 use solana_sdk::account::KeyedAccount;
 use solana_sdk::instruction::InstructionError;
@@ -15,6 +14,6 @@ pub fn process_instruction(
 
     TokenState::process(program_id, info, input).map_err(|e| {
         error!("error: {:?}", e);
-        InstructionError::CustomError(serialize(&e).unwrap())
+        InstructionError::CustomError(e as u32)
     })
 }

--- a/runtime/src/system_instruction_processor.rs
+++ b/runtime/src/system_instruction_processor.rs
@@ -1,4 +1,3 @@
-use bincode::serialize;
 use log::*;
 use solana_sdk::account::KeyedAccount;
 use solana_sdk::instruction::InstructionError;
@@ -94,7 +93,7 @@ pub fn process_instruction(
             }
             SystemInstruction::Transfer { lamports } => move_lamports(keyed_accounts, lamports),
         }
-        .map_err(|e| InstructionError::CustomError(serialize(&e).unwrap()))
+        .map_err(|e| InstructionError::CustomError(e as u32))
     } else {
         debug!("Invalid instruction data: {:?}", data);
         Err(InstructionError::InvalidInstructionData)
@@ -106,6 +105,7 @@ mod tests {
     use super::*;
     use crate::bank::Bank;
     use crate::bank_client::BankClient;
+    use bincode::serialize;
     use solana_sdk::account::Account;
     use solana_sdk::client::SyncClient;
     use solana_sdk::genesis_block::GenesisBlock;

--- a/sdk/src/instruction.rs
+++ b/sdk/src/instruction.rs
@@ -53,17 +53,14 @@ pub enum InstructionError {
     DuplicateAccountIndex,
 
     /// CustomError allows on-chain programs to implement program-specific error types and see
-    /// them returned by the Solana runtime. A CustomError may be any type that is serialized
-    /// to a Vec of bytes, max length 32 bytes. Any CustomError Vec greater than this length will
-    /// be truncated by the runtime.
-    CustomError(Vec<u8>),
+    /// them returned by the Solana runtime. A CustomError may be any type that is represented
+    /// as or serialized to a u32 integer.
+    CustomError(u32),
 }
 
 impl InstructionError {
     pub fn new_result_with_negative_lamports() -> Self {
-        let serialized_error =
-            bincode::serialize(&SystemError::ResultWithNegativeLamports).unwrap();
-        InstructionError::CustomError(serialized_error)
+        InstructionError::CustomError(SystemError::ResultWithNegativeLamports as u32)
     }
 }
 


### PR DESCRIPTION
#### Problem
`CustomError(Vec<u8>)` requires an allocation. Such a complex return type is not really needed here.

#### Summary of Changes
Change to `CustomError(u32)` and update our native programs using CustomError to represent their error enums as integers.

Fixes #1993 
