### PR TITLE
Write bench-tps in terms of client

### DIFF
--- a/sdk/src/transport.rs
+++ b/sdk/src/transport.rs
@@ -1,10 +1,22 @@
 use crate::transaction::TransactionError;
+use std::error;
+use std::fmt;
 use std::io;
 
 #[derive(Debug)]
 pub enum TransportError {
     IoError(io::Error),
     TransactionError(TransactionError),
+}
+
+impl error::Error for TransportError {}
+impl fmt::Display for TransportError {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            TransportError::IoError(err) => write!(formatter, "{:?}", err),
+            TransportError::TransactionError(err) => write!(formatter, "{:?}", err),
+        }
+    }
 }
 
 impl TransportError {


### PR DESCRIPTION
#### Problem

bench-tps currently requires a cluster. If the same benchmark can be written using just a Bank, we could generate I/O-free flamegraphs and have an easier time optimizing the bank.

#### Summary of Changes

Implement bench-tps in terms of the the Client trait instead of specialized to ThinClient

TODO:
- [ ] Figure out if these changes are functional changes and if so, if it breaks the benchmark.


