### PR TITLE
Add confirmed transaction lookups and always track roots

### DIFF
--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -74,7 +74,7 @@ impl JsonRpcRequestProcessor {
     }
 
     fn get_recent_blockhash(&self) -> String {
-        let id = self.bank().last_blockhash();
+        let id = self.bank().get_confirmed_blockhash();
         bs58::encode(id).into_string()
     }
 
@@ -329,7 +329,7 @@ impl RpcSol for RpcSolImpl {
             .read()
             .unwrap()
             .bank()
-            .last_blockhash();
+            .get_confirmed_blockhash();
         let transaction = request_airdrop_transaction(&drone_addr, &pubkey, lamports, blockhash)
             .map_err(|err| {
                 info!("request_airdrop_transaction failed: {:?}", err);
@@ -450,7 +450,7 @@ mod tests {
         let bank = bank_forks.read().unwrap().working_bank();
         let exit = Arc::new(AtomicBool::new(false));
 
-        let blockhash = bank.last_blockhash();
+        let blockhash = bank.get_confirmed_blockhash();
         let tx = system_transaction::transfer(&alice, pubkey, 20, blockhash, 0);
         bank.process_transaction(&tx).expect("process transaction");
 
@@ -493,7 +493,7 @@ mod tests {
             &exit,
         );
         thread::spawn(move || {
-            let blockhash = bank.last_blockhash();
+            let blockhash = bank.get_confirmed_blockhash();
             let tx = system_transaction::transfer(&alice, &bob_pubkey, 20, blockhash, 0);
             bank.process_transaction(&tx).expect("process transaction");
         })

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -74,7 +74,7 @@ impl JsonRpcRequestProcessor {
     }
 
     fn get_recent_blockhash(&self) -> String {
-        let id = self.bank().get_confirmed_blockhash();
+        let id = self.bank().confirmed_last_blockhash();
         bs58::encode(id).into_string()
     }
 
@@ -329,7 +329,7 @@ impl RpcSol for RpcSolImpl {
             .read()
             .unwrap()
             .bank()
-            .get_confirmed_blockhash();
+            .confirmed_last_blockhash();
         let transaction = request_airdrop_transaction(&drone_addr, &pubkey, lamports, blockhash)
             .map_err(|err| {
                 info!("request_airdrop_transaction failed: {:?}", err);
@@ -450,7 +450,7 @@ mod tests {
         let bank = bank_forks.read().unwrap().working_bank();
         let exit = Arc::new(AtomicBool::new(false));
 
-        let blockhash = bank.get_confirmed_blockhash();
+        let blockhash = bank.confirmed_last_blockhash();
         let tx = system_transaction::transfer(&alice, pubkey, 20, blockhash, 0);
         bank.process_transaction(&tx).expect("process transaction");
 
@@ -493,7 +493,7 @@ mod tests {
             &exit,
         );
         thread::spawn(move || {
-            let blockhash = bank.get_confirmed_blockhash();
+            let blockhash = bank.confirmed_last_blockhash();
             let tx = system_transaction::transfer(&alice, &bob_pubkey, 20, blockhash, 0);
             bank.process_transaction(&tx).expect("process transaction");
         })

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -383,7 +383,7 @@ impl Bank {
         self.blockhash_queue.read().unwrap().last_hash()
     }
     /// Return the root bank's blockhash
-    pub fn get_confirmed_blockhash(&self) -> Hash {
+    pub fn confirmed_last_blockhash(&self) -> Hash {
         if let Some(bank) = self.parents().last() {
             bank.last_blockhash()
         } else {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -382,6 +382,14 @@ impl Bank {
     pub fn last_blockhash(&self) -> Hash {
         self.blockhash_queue.read().unwrap().last_hash()
     }
+    /// Return the root bank's blockhash
+    pub fn get_confirmed_blockhash(&self) -> Hash {
+        if let Some(bank) = self.parents().last() {
+            bank.last_blockhash()
+        } else {
+            self.last_blockhash()
+        }
+    }
 
     /// Forget all signatures. Useful for benchmarking.
     pub fn clear_signatures(&self) {


### PR DESCRIPTION
#### Problem
Nodes use bleeding edge banks for all RPC APIs. This results in some apis reporting different results on different nodes
#### Summary of Changes
Ensure the root is always updated (even when no voting keypair is provided) and only provide confirmed blockhashes to rpc clients.
Fixes #3442
