### PR TITLE
Add solana-install usage info to Testnet Participation document

### DIFF
--- a/book/src/testnet-participation.md
+++ b/book/src/testnet-participation.md
@@ -1,6 +1,6 @@
 ## Testnet Participation
 This document describes how to participate in a public testnet as a
-validator node using the *Beacons v0.12* release.
+validator node using the *Grandview v0.13* release.
 
 Please note some of the information and instructions described here may change
 in future releases.
@@ -33,16 +33,32 @@ $ export ip=$(dig +short beta.testnet.solana.com)
 ```
 
 #### Obtaining The Software
+
+##### Bootstrap with `solana-install`
+
+The `solana-install` tool can be used to easily install and upgrade the cluster
+software on Linux x86_64 systems.
+
+Install the latest release with a single shell command:
+```bash
+$ curl -sSf https://raw.githubusercontent.com/solana-labs/solana/v0.13.0/install/solana-install-init.sh | \
+  sh -c - --url https://api.beta.testnet.solana.com
+```
+
+Alternatively build the `solana-install` program from source and run the
+following command to obtain the same result:
+```bash
+$ solana-install init --url https://api.beta.testnet.solana.com
+```
+
+After a successful install, `solana-install update` may be used to easily update the cluster
+software to a newer version.
+
 ##### Download Prebuilt Binaries
-Binaries are available for Linux x86_64 systems.  Download the binaries by navigating to:
+Binaries are available for Linux x86_64 systems.
 
-> https://github.com/solana-labs/solana/releases/latest
-
-Download the binary file from our latest release tag:
-
-> solana-release-x86_64-unknown-linux-gnu.tar.bz2
-
-Extract the package:
+Download the binaries by navigating to https://github.com/solana-labs/solana/releases/latest, download
+**solana-release-x86_64-unknown-linux-gnu.tar.bz2**, then extract the archive:
 ```bash
 $ tar jxf solana-release-x86_64-unknown-linux-gnu.tar.bz2
 $ cd solana-release/
@@ -83,9 +99,22 @@ $ RUST_LOG=info solana-gossip --network ${ip:?}:8001
 ```
 
 ### Starting The Validator
-The following command will start a new validator node:
+The following command will start a new validator node.
+
+If this is a `solana-install`-installation:
 ```bash
-$ RUST_LOG=warn USE_INSTALL=1 ./multinode-demo/fullnode-x.sh --public-address --poll-for-new-genesis-block ${ip:?}
+$ fullnode-x.sh --public-address --poll-for-new-genesis-block ${ip:?}
+```
+
+Alternatively, the `solana-install run` command can be used to run the validator
+node while periodically checking for and applying software updates:
+```bash
+$ solana-install run fullnode-x.sh --public-address --poll-for-new-genesis-block ${ip:?}
+```
+
+When not using `solana-install`:
+```bash
+$ USE_INSTALL=1 ./multinode-demo/fullnode-x.sh --public-address --poll-for-new-genesis-block ${ip:?}
 ```
 
 Then from another console, confirm the IP address if your node is now visible in

--- a/ci/publish-tarball.sh
+++ b/ci/publish-tarball.sh
@@ -66,6 +66,15 @@ echo --- Creating tarball
   cp solana-release-cuda/bin/solana-fullnode solana-release/bin/solana-fullnode-cuda
   cp -a scripts multinode-demo solana-release/
 
+  cat > solana-release/bin/fullnode-x.sh <<'EOF'
+#!/usr/bin/env bash
+set -e
+cd "$(dirname "$0")"/..
+export USE_INSTALL=1
+exec multinode-demo/fullnode-x.sh "$@"
+EOF
+  chmod +x solana-release/bin/fullnode-x.sh
+
   tar jvcf solana-release-$TARGET.tar.bz2 solana-release/
   cp solana-release/bin/solana-install solana-install-$TARGET
 )

--- a/install/src/config.rs
+++ b/install/src/config.rs
@@ -12,7 +12,7 @@ pub struct Config {
     pub current_update_manifest: Option<UpdateManifest>,
     pub update_poll_secs: u64,
     releases_dir: PathBuf,
-    bin_dir: PathBuf,
+    active_release_dir: PathBuf,
 }
 
 impl Config {
@@ -23,7 +23,7 @@ impl Config {
             current_update_manifest: None,
             update_poll_secs: 60, // check for updates once a minute
             releases_dir: PathBuf::from(data_dir).join("releases"),
-            bin_dir: PathBuf::from(data_dir).join("bin"),
+            active_release_dir: PathBuf::from(data_dir).join("active_release"),
         }
     }
 
@@ -56,8 +56,12 @@ impl Config {
             .map_err(|err| format!("Unable to save {}: {:?}", config_file, err))
     }
 
-    pub fn bin_dir(&self) -> &PathBuf {
-        &self.bin_dir
+    pub fn active_release_dir(&self) -> &PathBuf {
+        &self.active_release_dir
+    }
+
+    pub fn active_release_bin_dir(&self) -> PathBuf {
+        self.active_release_dir.join("bin")
     }
 
     pub fn release_dir(&self, release_sha256: &str) -> PathBuf {


### PR DESCRIPTION
`solana-install`-based software updates are now live on the edge testnet and seem to be working well.  Let's advertise it a little more to encourage validators to give it a try.
 
Fixes #3261
