### PR TITLE
fullnode: add --dynamic-port-range option

### DIFF
--- a/book/src/testnet-participation.md
+++ b/book/src/testnet-participation.md
@@ -1,6 +1,6 @@
 ## Testnet Participation
-This document describes how to participate in a public testnet as a
-validator node using the *Grandview v0.13* release.
+This document describes how to participate in the beta testnet as a
+validator node.
 
 Please note some of the information and instructions described here may change
 in future releases.
@@ -124,6 +124,12 @@ $ RUST_LOG=info solana-gossip --network ${ip:?}:8001
 ```
 
 Congratulations, you're now participating in the testnet cluster!
+
+#### Controlling local network port allocation
+By default the validator will dynamically select available network ports in the
+8000-10000 range, and may be overridden with `--dynamic-port-range`.  For
+example, `fullnode-x.sh --dynamic-port-range 11000-11010 ...` will restrict the
+validator to ports 11000-11011.
 
 ### Sharing Metrics From Your Validator
 If you'd like to share metrics perform the following steps before starting the

--- a/ci/publish-tarball.sh
+++ b/ci/publish-tarball.sh
@@ -66,6 +66,19 @@ echo --- Creating tarball
   cp solana-release-cuda/bin/solana-fullnode solana-release/bin/solana-fullnode-cuda
   cp -a scripts multinode-demo solana-release/
 
+  # Add a wrapper script for fullnode.sh
+  # TODO: Remove multinode/... from tarball
+  cat > solana-release/bin/fullnode.sh <<'EOF'
+#!/usr/bin/env bash
+set -e
+cd "$(dirname "$0")"/..
+export USE_INSTALL=1
+exec multinode-demo/fullnode.sh "$@"
+EOF
+  chmod +x solana-release/bin/fullnode.sh
+
+  # Add a wrapper script for fullnode-x.sh
+  # TODO: Remove multinode/... from tarball
   cat > solana-release/bin/fullnode-x.sh <<'EOF'
 #!/usr/bin/env bash
 set -e

--- a/core/src/fullnode.rs
+++ b/core/src/fullnode.rs
@@ -142,24 +142,32 @@ impl Fullnode {
 
         let storage_state = StorageState::new();
 
-        let rpc_service = JsonRpcService::new(
-            &cluster_info,
-            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), node.info.rpc.port()),
-            storage_state.clone(),
-            config.rpc_config.clone(),
-            bank_forks.clone(),
-            &exit,
-        );
+        let rpc_service = if node.info.rpc.port() == 0 {
+            None
+        } else {
+            Some(JsonRpcService::new(
+                &cluster_info,
+                SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), node.info.rpc.port()),
+                storage_state.clone(),
+                config.rpc_config.clone(),
+                bank_forks.clone(),
+                &exit,
+            ))
+        };
 
         let subscriptions = Arc::new(RpcSubscriptions::default());
-        let rpc_pubsub_service = PubSubService::new(
-            &subscriptions,
-            SocketAddr::new(
-                IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)),
-                node.info.rpc_pubsub.port(),
-            ),
-            &exit,
-        );
+        let rpc_pubsub_service = if node.info.rpc_pubsub.port() == 0 {
+            None
+        } else {
+            Some(PubSubService::new(
+                &subscriptions,
+                SocketAddr::new(
+                    IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)),
+                    node.info.rpc_pubsub.port(),
+                ),
+                &exit,
+            ))
+        };
 
         let gossip_service = GossipService::new(
             &cluster_info,
@@ -243,8 +251,8 @@ impl Fullnode {
         Self {
             id,
             gossip_service,
-            rpc_service: Some(rpc_service),
-            rpc_pubsub_service: Some(rpc_pubsub_service),
+            rpc_service,
+            rpc_pubsub_service,
             tpu,
             tvu,
             exit,

--- a/core/src/local_vote_signer_service.rs
+++ b/core/src/local_vote_signer_service.rs
@@ -1,7 +1,7 @@
 //! The `local_vote_signer_service` can be started locally to sign fullnode votes
 
-use crate::cluster_info::FULLNODE_PORT_RANGE;
 use crate::service::Service;
+use solana_netutil::PortRange;
 use solana_vote_signer::rpc::VoteSignerRpcService;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -24,8 +24,8 @@ impl Service for LocalVoteSignerService {
 
 impl LocalVoteSignerService {
     #[allow(clippy::new_ret_no_self)]
-    pub fn new() -> (Self, SocketAddr) {
-        let addr = match solana_netutil::find_available_port_in_range(FULLNODE_PORT_RANGE) {
+    pub fn new(port_range: PortRange) -> (Self, SocketAddr) {
+        let addr = match solana_netutil::find_available_port_in_range(port_range) {
             Ok(port) => SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), port),
             Err(_e) => panic!("Failed to find an available port for local vote signer service"),
         };

--- a/multinode-demo/bootstrap-leader.sh
+++ b/multinode-demo/bootstrap-leader.sh
@@ -35,6 +35,9 @@ while [[ ${1:0:1} = - ]]; do
   elif [[ $1 = --rpc-port ]]; then
     extra_fullnode_args+=("$1" "$2")
     shift 2
+  elif [[ $1 = --dynamic-port-range ]]; then
+    extra_fullnode_args+=("$1" "$2")
+    shift 2
   else
     echo "Unknown argument: $1"
     exit 1
@@ -74,6 +77,7 @@ $program \
   --vote-account  "$bootstrap_leader_vote_id" \
   --ledger "$SOLANA_CONFIG_DIR"/bootstrap-leader-ledger \
   --accounts "$SOLANA_CONFIG_DIR"/bootstrap-leader-accounts \
+  --gossip-port 8001 \
   --rpc-port 8899 \
   --rpc-drone-address 127.0.0.1:9900 \
   "${extra_fullnode_args[@]}" \

--- a/multinode-demo/bootstrap-leader.sh
+++ b/multinode-demo/bootstrap-leader.sh
@@ -65,7 +65,7 @@ $solana_ledger_tool --ledger "$SOLANA_CONFIG_DIR"/bootstrap-leader-ledger verify
 
 bootstrap_leader_id_path="$SOLANA_CONFIG_DIR"/bootstrap-leader-id.json
 bootstrap_leader_vote_id_path="$SOLANA_CONFIG_DIR"/bootstrap-leader-vote-id.json
-bootstrap_leader_vote_id=$($solana_wallet --keypair "$bootstrap_leader_vote_id_path" address)
+bootstrap_leader_vote_id=$($solana_keygen pubkey "$bootstrap_leader_vote_id_path")
 
 trap 'kill "$pid" && wait "$pid"' INT TERM ERR
 $program \

--- a/multinode-demo/fullnode.sh
+++ b/multinode-demo/fullnode.sh
@@ -141,8 +141,7 @@ else
   accounts_config_dir=$SOLANA_CONFIG_DIR/fullnode-accounts-x$self_setup_label
 fi
 
-fullnode_vote_id=$($solana_wallet --keypair "$fullnode_vote_id_path" address)
-
+fullnode_vote_id=$($solana_keygen pubkey "$fullnode_vote_id_path")
 
 [[ -r $fullnode_id_path ]] || {
   echo "$fullnode_id_path does not exist"

--- a/replicator/src/main.rs
+++ b/replicator/src/main.rs
@@ -1,5 +1,5 @@
 use clap::{crate_description, crate_name, crate_version, App, Arg};
-use solana::cluster_info::Node;
+use solana::cluster_info::{Node, FULLNODE_PORT_RANGE};
 use solana::contact_info::ContactInfo;
 use solana::replicator::Replicator;
 use solana::socketaddr;
@@ -67,7 +67,8 @@ fn main() {
         }
         addr
     };
-    let node = Node::new_replicator_with_external_ip(&keypair.pubkey(), &gossip_addr);
+    let node =
+        Node::new_replicator_with_external_ip(&keypair.pubkey(), &gossip_addr, FULLNODE_PORT_RANGE);
 
     println!(
         "replicating the data with keypair={:?} gossip_addr={:?}",


### PR DESCRIPTION
Fullnode now accepts a --dynamic-port-range option that overrides the 8000-10,000 port range used for the dynamically assigned network ports.

Fixes #3719