### PR TITLE
Default solana-gossip log-level to 'info'

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2386,8 +2386,9 @@ name = "solana-gossip"
 version = "0.13.0"
 dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana 0.13.0",
- "solana-logger 0.13.0",
  "solana-sdk 0.13.0",
 ]
 

--- a/core/src/gossip_service.rs
+++ b/core/src/gossip_service.rs
@@ -68,6 +68,7 @@ pub fn discover(
     let exit = Arc::new(AtomicBool::new(false));
     let (gossip_service, spy_ref) = make_spy_node(gossip_addr, &exit);
     let id = spy_ref.read().unwrap().keypair.pubkey();
+    info!("Gossip entry point: {:?}", gossip_addr);
     trace!(
         "discover: spy_node {} looking for at least {:?} nodes",
         id,

--- a/gossip/Cargo.toml
+++ b/gossip/Cargo.toml
@@ -10,8 +10,8 @@ homepage = "https://solana.com/"
 
 [dependencies]
 clap = "2.33.0"
+env_logger = "0.6.1"
 solana = { path = "../core", version = "0.13.0" }
-solana-logger = { path = "../logger", version = "0.13.0" }
 solana-sdk = { path = "../sdk", version = "0.13.0" }
 
 [features]

--- a/gossip/src/main.rs
+++ b/gossip/src/main.rs
@@ -15,7 +15,8 @@ fn pubkey_validator(pubkey: String) -> Result<(), String> {
 }
 
 fn main() -> Result<(), Box<dyn error::Error>> {
-    solana_logger::setup();
+    env_logger::Builder::from_env(env_logger::Env::new().default_filter_or("solana=info")).init();
+
     let mut network_addr = SocketAddr::from(([127, 0, 0, 1], 8001));
     let network_string = network_addr.to_string();
     let matches = App::new(crate_name!())


### PR DESCRIPTION
#### Problem
If the RUST_LOG level is not set by the user solana-gossip outputs nothing and appears to be stuck even though it may be working just fine.

#### Summary of Changes
Default solana-gossip's log level to info instead of warn

Fixes #3687
