### PR TITLE
fix broadcast to *always* call erasure generator, simplify generator, test slot reset a bit better

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2387,7 +2387,6 @@ version = "0.13.0"
 dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana 0.13.0",
  "solana-sdk 0.13.0",
 ]

--- a/core/src/blocktree.rs
+++ b/core/src/blocktree.rs
@@ -2760,7 +2760,7 @@ pub mod tests {
             assert_eq!(erasure_meta.coding, 0x0);
 
             let mut coding_generator = CodingGenerator::new();
-            let coding_blobs = coding_generator.next(&shared_blobs[..NUM_DATA]).unwrap();
+            let coding_blobs = coding_generator.next(&shared_blobs[..NUM_DATA]);
 
             for shared_coding_blob in coding_blobs {
                 let blob = shared_coding_blob.read().unwrap();
@@ -2799,7 +2799,7 @@ pub mod tests {
 
             for (set_index, data_blobs) in data_blobs.chunks_exact(NUM_DATA).enumerate() {
                 let focused_index = (set_index + 1) * NUM_DATA - 1;
-                let coding_blobs = coding_generator.next(&data_blobs).unwrap();
+                let coding_blobs = coding_generator.next(&data_blobs);
                 assert_eq!(coding_blobs.len(), NUM_CODING);
 
                 let deleted_data = data_blobs[NUM_DATA - 1].clone();


### PR DESCRIPTION
#### Problem
 erasure generator needs to be called with *all* the data blobs, whether they're
 being broadcast or not, in order to keep track of which block needs coding
 blobs

 #### Summary of Changes
 * re-order broadcast stage logic to run *every* blob through the coding generator
 * simplify generator.next() to just return a vector, as Result<> isn't useful to any customers
 * add a bit more verification to the slot reset test code