### PR TITLE
increment-cargo-version.sh: Fix up bash array handling

### DIFF
--- a/scripts/increment-cargo-version.sh
+++ b/scripts/increment-cargo-version.sh
@@ -28,12 +28,12 @@ readCargoVariable() {
   echo "Unable to locate $variable in $Cargo_toml" 1>&2
 }
 
-# shellcheck disable=2044 # Disable 'For loops over find output are fragile...'
-Cargo_tomls="$(find . -name Cargo.toml)"
+# shellcheck disable=2207
+Cargo_tomls=($(find . -name Cargo.toml))
 
 # Collect the name of all the internal crates
 crates=()
-for Cargo_toml in $Cargo_tomls; do
+for Cargo_toml in "${Cargo_tomls[@]}"; do
   crates+=("$(readCargoVariable name "$Cargo_toml")")
 done
 
@@ -42,6 +42,7 @@ MAJOR=0
 MINOR=0
 PATCH=0
 SPECIAL=""
+
 semverParseInto "$(readCargoVariable version "${Cargo_tomls[0]}")" MAJOR MINOR PATCH SPECIAL
 [[ -n $MAJOR ]] || usage
 
@@ -76,7 +77,7 @@ esac
 newVersion="$MAJOR.$MINOR.$PATCH$SPECIAL"
 
 # Update all the Cargo.toml files
-for Cargo_toml in $Cargo_tomls; do
+for Cargo_toml in "${Cargo_tomls[@]}"; do
   # Set new crate version
   (
     set -x


### PR DESCRIPTION
I broke increment-cargo-version.sh a while ago, just noticed it now while preparing for the 0.13 branch 😊 