### PR TITLE
persist set_root() and use it in blocktree_processor to limit squashes

### DIFF
--- a/core/src/blocktree/meta.rs
+++ b/core/src/blocktree/meta.rs
@@ -24,6 +24,8 @@ pub struct SlotMeta {
     // True if this slot is full (consumed == last_index + 1) and if every
     // slot that is a parent of this slot is also connected.
     pub is_connected: bool,
+    // True if this slot is a root
+    pub is_root: bool,
 }
 
 impl SlotMeta {
@@ -51,6 +53,7 @@ impl SlotMeta {
             parent_slot,
             next_slots: vec![],
             is_connected: slot == 0,
+            is_root: false,
             last_index: std::u64::MAX,
         }
     }


### PR DESCRIPTION
#### Problem
 blocktree_processor squash()es every bank on startup, leading to multiple roots

 it does this because we don't persist any information in blocktree about locktower's root choice

 #### Summary of Changes
 persist blocktree.set_root() to slot meta
 add blocktree.is_root()
 use is_root() in blocktree_processor to squash just roots
 add tests for expected bank_forks structure

fixes #3132 