### PR TITLE
solana-gossip: Display tvu_peers() since validators no longer run an RPC port by default

### DIFF
--- a/core/src/cluster_info.rs
+++ b/core/src/cluster_info.rs
@@ -246,7 +246,7 @@ impl ClusterInfo {
     pub fn contact_info_trace(&self) -> String {
         let leader_id = self.gossip_leader_id;
         let nodes: Vec<_> = self
-            .rpc_peers()
+            .tvu_peers()
             .into_iter()
             .map(|node| {
                 let mut annotation = String::new();
@@ -262,7 +262,11 @@ impl ClusterInfo {
                     node.id,
                     annotation,
                     node.tpu.to_string(),
-                    node.rpc.to_string()
+                    if ContactInfo::is_valid_address(&node.rpc) {
+                        node.rpc.to_string()
+                    } else {
+                        "none".to_string()
+                    }
                 )
             })
             .collect();


### PR DESCRIPTION
#### Problem
`solana-gossip` not displaying the correct node count

#### Summary of Changes
Display tvu_peers() instead of rpc_peers() since validators no longer run the RPC service by default (as of #3753)
