### PR TITLE
Remove stake from `./net sanity` ephemeral validator

### DIFF
--- a/book/src/testnet-participation.md
+++ b/book/src/testnet-participation.md
@@ -96,18 +96,18 @@ The following command will start a new validator node.
 
 If this is a `solana-install`-installation:
 ```bash
-$ fullnode-x.sh --public-address --poll-for-new-genesis-block beta.testnet.solana.com:8001
+$ fullnode-x.sh --public-address --no-stake --poll-for-new-genesis-block beta.testnet.solana.com:8001
 ```
 
 Alternatively, the `solana-install run` command can be used to run the validator
 node while periodically checking for and applying software updates:
 ```bash
-$ solana-install run fullnode-x.sh --public-address --poll-for-new-genesis-block beta.testnet.solana.com:8001
+$ solana-install run fullnode-x.sh --public-address --no-stake --poll-for-new-genesis-block beta.testnet.solana.com:8001
 ```
 
 When not using `solana-install`:
 ```bash
-$ USE_INSTALL=1 ./multinode-demo/fullnode-x.sh --public-address --poll-for-new-genesis-block beta.testnet.solana.com:8001
+$ USE_INSTALL=1 ./multinode-demo/fullnode-x.sh --public-address --no-stake --poll-for-new-genesis-block beta.testnet.solana.com:8001
 ```
 
 Then from another console, confirm the IP address if your node is now visible in

--- a/ci/localnet-sanity.sh
+++ b/ci/localnet-sanity.sh
@@ -55,7 +55,7 @@ while getopts "ch?i:k:brxR" opt; do
     restartInterval=$OPTARG
     ;;
   b)
-    maybeNoLeaderRotation="--only-bootstrap-stake"
+    maybeNoLeaderRotation="--no-stake"
     ;;
   x)
     extraNodes=$((extraNodes + 1))
@@ -78,7 +78,6 @@ source scripts/configure-metrics.sh
 nodes=(
   "multinode-demo/drone.sh"
   "multinode-demo/bootstrap-leader.sh \
-    $maybeNoLeaderRotation \
     --enable-rpc-exit \
     --init-complete-file init-complete-node1.log"
   "multinode-demo/fullnode.sh \

--- a/multinode-demo/common.sh
+++ b/multinode-demo/common.sh
@@ -169,7 +169,7 @@ fullnode_usage() {
     echo
   fi
   cat <<EOF
-usage: $0 [-x] [--blockstream PATH] [--init-complete-file FILE] [--only-bootstrap-stake] [--no-voting] [--rpc-port port] [rsync network path to bootstrap leader configuration] [network entry point]
+usage: $0 [-x] [--blockstream PATH] [--init-complete-file FILE] [--no-stake] [--no-voting] [--rpc-port port] [rsync network path to bootstrap leader configuration] [network entry point]
 
 Start a full node on the specified network
 
@@ -178,7 +178,7 @@ Start a full node on the specified network
                               the specified label. Does not apply to the bootstrap leader
   --blockstream PATH        - open blockstream at this unix domain socket location
   --init-complete-file FILE - create this file, if it doesn't already exist, once node initialization is complete
-  --only-bootstrap-stake    - Only stake the bootstrap leader, effectively disabling leader rotation
+  --no-stake                - Only stake the bootstrap leader, effectively disabling leader rotation
   --public-address          - advertise public machine address in gossip.  By default the local machine address is advertised
   --no-voting               - start node without vote signer
   --rpc-port port           - custom RPC port for this node

--- a/multinode-demo/fullnode.sh
+++ b/multinode-demo/fullnode.sh
@@ -41,7 +41,7 @@ while [[ ${1:0:1} = - ]]; do
   elif [[ $1 = --init-complete-file ]]; then
     extra_fullnode_args+=("$1" "$2")
     shift 2
-  elif [[ $1 = --only-bootstrap-stake ]]; then
+  elif [[ $1 = --no-stake ]]; then
     setup_stakes=0
     shift
   elif [[ $1 = --public-address ]]; then

--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -73,16 +73,12 @@ local|tar)
     fi
     ./multinode-demo/drone.sh > drone.log 2>&1 &
 
-    maybeNoLeaderRotation=
-    if ! $leaderRotation; then
-      maybeNoLeaderRotation="--only-bootstrap-stake"
-    fi
     maybePublicAddress=
     if $publicNetwork; then
       maybePublicAddress="--public-address"
     fi
 
-    ./multinode-demo/bootstrap-leader.sh $maybeNoLeaderRotation $maybePublicAddress > bootstrap-leader.log 2>&1 &
+    ./multinode-demo/bootstrap-leader.sh $maybePublicAddress > bootstrap-leader.log 2>&1 &
     ln -sTf bootstrap-leader.log fullnode.log
     ;;
   fullnode|blockstreamer)
@@ -95,7 +91,7 @@ local|tar)
 
     args=()
     if ! $leaderRotation; then
-      args+=("--only-bootstrap-stake")
+      args+=("--no-stake")
     fi
     if $publicNetwork; then
       args+=("--public-address")

--- a/net/remote/remote-sanity.sh
+++ b/net/remote/remote-sanity.sh
@@ -133,7 +133,7 @@ echo "--- $entrypointIp: validator sanity"
 if $validatorSanity; then
   (
     set -x -o pipefail
-    timeout 10s ./multinode-demo/fullnode-x.sh \
+    timeout 10s ./multinode-demo/fullnode-x.sh --no-stake \
       "$entrypointRsyncUrl" \
       "$entrypointIp:8001" 2>&1 | tee validator-sanity.log
   ) || {


### PR DESCRIPTION
#### Problem
The cluster doesn't yet recover from staked validators that disappear

#### Summary of Changes
Work around by:
* `./net/net.sh sanity` no longer stakes its  ephemeral validator
* For v0.13 suggest that validators don't stake (until we can really fix)

Fixes #3794 