### PR TITLE
Fewer unsafe hacks for AppendVec

### DIFF
--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -281,7 +281,7 @@ impl AccountsDB {
     fn hash_account(stored_account: &StoredAccount) -> Hash {
         let mut hasher = Hasher::default();
         hasher.hash(&serialize(&stored_account.balance).unwrap());
-        hasher.hash(&serialize(&stored_account.data).unwrap());
+        hasher.hash(stored_account.data);
         hasher.result()
     }
 

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -19,7 +19,7 @@
 //! commit for each fork entry would be indexed.
 
 use crate::accounts_index::{AccountsIndex, Fork};
-use crate::append_vec::{AppendVec, StoredAccount};
+use crate::append_vec::{AppendVec, StorageMeta, StoredAccount};
 use crate::message_processor::has_duplicates;
 use bincode::serialize;
 use hashbrown::{HashMap, HashSet};
@@ -29,7 +29,7 @@ use rayon::prelude::*;
 use solana_metrics::counter::Counter;
 use solana_sdk::account::Account;
 use solana_sdk::fee_calculator::FeeCalculator;
-use solana_sdk::hash::{hash, Hash, Hasher};
+use solana_sdk::hash::{Hash, Hasher};
 use solana_sdk::native_loader;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::{Keypair, KeypairUtil};
@@ -278,14 +278,23 @@ impl AccountsDB {
             .collect()
     }
 
+    fn hash_account(stored_account: &StoredAccount) -> Hash {
+        let mut hasher = Hasher::default();
+        hasher.hash(&serialize(&stored_account.account.lamports).unwrap());
+        hasher.hash(&serialize(&stored_account.account.owner).unwrap());
+        hasher.hash(&serialize(&stored_account.account.executable).unwrap());
+        hasher.hash(&serialize(&stored_account.data).unwrap());
+        hasher.result()
+    }
+
     pub fn hash_internal_state(&self, fork_id: Fork) -> Option<Hash> {
         let accumulator: Vec<Vec<(Pubkey, u64, Hash)>> = self.scan_account_storage(
             fork_id,
             |stored_account: &StoredAccount, accum: &mut Vec<(Pubkey, u64, Hash)>| {
                 accum.push((
-                    stored_account.pubkey,
-                    stored_account.write_version,
-                    hash(&serialize(&stored_account.account).unwrap()),
+                    stored_account.meta.pubkey,
+                    stored_account.meta.write_version,
+                    Self::hash_account(stored_account),
                 ));
             },
         );
@@ -313,7 +322,7 @@ impl AccountsDB {
         //TODO: thread this as a ref
         storage
             .get(info.id)
-            .map(|store| store.accounts.get_account(info.offset).account.clone())
+            .and_then(|store| Some(store.accounts.get_account(info.offset)?.0.clone_account()))
     }
 
     fn load_tx_accounts(
@@ -530,13 +539,12 @@ impl AccountsDB {
             {
                 let accounts = &self.storage.read().unwrap()[id];
                 let write_version = self.write_version.fetch_add(1, Ordering::Relaxed) as u64;
-                let stored_account = StoredAccount {
+                let meta = StorageMeta {
                     write_version,
                     pubkey: *pubkey,
-                    //TODO: fix all this copy
-                    account: account.clone(),
+                    data_len: account.data.len() as u64,
                 };
-                result = accounts.accounts.append_account(&stored_account);
+                result = accounts.accounts.append_account(meta, account);
                 accounts.add_account();
             }
             if let Some(val) = result {
@@ -691,21 +699,24 @@ impl Accounts {
     }
 
     pub fn load_by_program(&self, fork: Fork, program_id: &Pubkey) -> Vec<(Pubkey, Account)> {
-        let accumulator: Vec<Vec<StoredAccount>> = self.accounts_db.scan_account_storage(
+        let accumulator: Vec<Vec<(Pubkey, u64, Account)>> = self.accounts_db.scan_account_storage(
             fork,
-            |stored_account: &StoredAccount, accum: &mut Vec<StoredAccount>| {
+            |stored_account: &StoredAccount, accum: &mut Vec<(Pubkey, u64, Account)>| {
                 if stored_account.account.owner == *program_id {
-                    accum.push(stored_account.clone())
+                    let val = (
+                        stored_account.meta.pubkey,
+                        stored_account.meta.write_version,
+                        stored_account.clone_account(),
+                    );
+                    accum.push(val)
                 }
             },
         );
-        let mut versions: Vec<StoredAccount> = accumulator.into_iter().flat_map(|x| x).collect();
-        versions.sort_by_key(|s| (s.pubkey, (s.write_version as i64).neg()));
-        versions.dedup_by_key(|s| s.pubkey);
-        versions
-            .into_iter()
-            .map(|s| (s.pubkey, s.account))
-            .collect()
+        let mut versions: Vec<(Pubkey, u64, Account)> =
+            accumulator.into_iter().flat_map(|x| x).collect();
+        versions.sort_by_key(|s| (s.0, (s.1 as i64).neg()));
+        versions.dedup_by_key(|s| s.0);
+        versions.into_iter().map(|s| (s.0, s.2)).collect()
     }
 
     /// Slow because lock is held for 1 operation instead of many

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -253,7 +253,7 @@ impl AccountsDB {
     // PERF: Sequentially read each storage entry in parallel
     pub fn scan_account_storage<F, B>(&self, fork_id: Fork, scan_func: F) -> Vec<B>
     where
-        F: Fn(&mut StoredAccount, &mut B) -> (),
+        F: Fn(&StoredAccount, &mut B) -> (),
         F: Send + Sync,
         B: Send + Default,
     {
@@ -268,10 +268,10 @@ impl AccountsDB {
         storage_maps
             .into_par_iter()
             .map(|storage| {
-                let mut accounts = storage.accounts.accounts(0);
+                let accounts = storage.accounts.accounts(0);
                 let mut retval = B::default();
                 accounts
-                    .iter_mut()
+                    .iter()
                     .for_each(|stored_account| scan_func(stored_account, &mut retval));
                 retval
             })
@@ -280,9 +280,7 @@ impl AccountsDB {
 
     fn hash_account(stored_account: &StoredAccount) -> Hash {
         let mut hasher = Hasher::default();
-        hasher.hash(&serialize(&stored_account.account.lamports).unwrap());
-        hasher.hash(&serialize(&stored_account.account.owner).unwrap());
-        hasher.hash(&serialize(&stored_account.account.executable).unwrap());
+        hasher.hash(&serialize(&stored_account.balance).unwrap());
         hasher.hash(&serialize(&stored_account.data).unwrap());
         hasher.result()
     }
@@ -290,7 +288,7 @@ impl AccountsDB {
     pub fn hash_internal_state(&self, fork_id: Fork) -> Option<Hash> {
         let accumulator: Vec<Vec<(Pubkey, u64, Hash)>> = self.scan_account_storage(
             fork_id,
-            |stored_account: &mut StoredAccount, accum: &mut Vec<(Pubkey, u64, Hash)>| {
+            |stored_account: &StoredAccount, accum: &mut Vec<(Pubkey, u64, Hash)>| {
                 accum.push((
                     stored_account.meta.pubkey,
                     stored_account.meta.write_version,
@@ -701,8 +699,8 @@ impl Accounts {
     pub fn load_by_program(&self, fork: Fork, program_id: &Pubkey) -> Vec<(Pubkey, Account)> {
         let accumulator: Vec<Vec<(Pubkey, u64, Account)>> = self.accounts_db.scan_account_storage(
             fork,
-            |stored_account: &mut StoredAccount, accum: &mut Vec<(Pubkey, u64, Account)>| {
-                if stored_account.account.owner == *program_id {
+            |stored_account: &StoredAccount, accum: &mut Vec<(Pubkey, u64, Account)>| {
+                if stored_account.balance.owner == *program_id {
                     let val = (
                         stored_account.meta.pubkey,
                         stored_account.meta.write_version,

--- a/runtime/src/append_vec.rs
+++ b/runtime/src/append_vec.rs
@@ -180,13 +180,9 @@ impl AppendVec {
 
     pub fn accounts<'a>(&'a self, mut start: usize) -> Vec<StoredAccount<'a>> {
         let mut accounts = vec![];
-        loop {
-            if let Some((account, next)) = self.get_account(start) {
-                accounts.push(account);
-                start = next;
-            } else {
-                break;
-            }
+        while let Some((account, next)) = self.get_account(start) {
+            accounts.push(account);
+            start = next;
         }
         accounts
     }

--- a/runtime/src/append_vec.rs
+++ b/runtime/src/append_vec.rs
@@ -130,6 +130,7 @@ impl AppendVec {
         //crash on some architectures.
         let pos = align_up!(*offset as usize, mem::size_of::<u64>());
         let data = &self.map[pos..(pos + len)];
+        //this mut append is safe because only 1 thread can append at a time
         unsafe {
             let dst = data.as_ptr() as *mut u8;
             std::ptr::copy(src, dst, len);

--- a/runtime/src/append_vec.rs
+++ b/runtime/src/append_vec.rs
@@ -33,7 +33,7 @@ pub struct StoredAccount<'a> {
 }
 
 impl<'a> StoredAccount<'a> {
-    pub fn clone_account(&self) -> Account {
+    pub fn clone_account(&mut self) -> Account {
         let mut account = self.account.clone();
         let mut data: Vec<u8> = unsafe {
             Vec::from_raw_parts(self.data.as_mut_ptr(), self.data.len(), self.data.len())

--- a/runtime/src/append_vec.rs
+++ b/runtime/src/append_vec.rs
@@ -15,6 +15,8 @@ macro_rules! align_up {
         ($addr + ($align - 1)) & !($align - 1)
     };
 }
+
+/// StorageMeta contains enough context to recover the index from storage itself
 #[derive(Clone, PartialEq, Debug)]
 pub struct StorageMeta {
     /// global write version
@@ -23,8 +25,9 @@ pub struct StorageMeta {
     pub pubkey: Pubkey,
     pub data_len: u64,
 }
-//TODO: This structure should contain references
-/// StoredAccount contains enough context to recover the index from storage itself
+
+/// References to Memory Mapped memory
+/// The Account is stored separately from its data, so getting the actual account requires a clone
 pub struct StoredAccount<'a> {
     pub meta: &'a StorageMeta,
     /// account data

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -14,3 +14,6 @@ mod system_instruction_processor;
 
 #[macro_use]
 extern crate solana_metrics;
+
+#[macro_use]
+extern crate serde_derive;


### PR DESCRIPTION
#### Problem

Account structure contains an embedded Vec which makes it hard to store in memory.

#### Summary of Changes

* AppendVec stores the Account in several structures which are flat.  In memory pointer fixups are no longer required.  
* Allow the compiler to track lifetimes.

Fixes #
