### PR TITLE
net/ testnet nodes now stake more lamports

### DIFF
--- a/book/src/testnet-participation.md
+++ b/book/src/testnet-participation.md
@@ -96,18 +96,18 @@ The following command will start a new validator node.
 
 If this is a `solana-install`-installation:
 ```bash
-$ fullnode-x.sh --public-address --no-stake --poll-for-new-genesis-block beta.testnet.solana.com:8001
+$ fullnode-x.sh --public-address --poll-for-new-genesis-block beta.testnet.solana.com:8001
 ```
 
 Alternatively, the `solana-install run` command can be used to run the validator
 node while periodically checking for and applying software updates:
 ```bash
-$ solana-install run fullnode-x.sh --public-address --no-stake --poll-for-new-genesis-block beta.testnet.solana.com:8001
+$ solana-install run fullnode-x.sh --public-address --poll-for-new-genesis-block beta.testnet.solana.com:8001
 ```
 
 When not using `solana-install`:
 ```bash
-$ USE_INSTALL=1 ./multinode-demo/fullnode-x.sh --public-address --no-stake --poll-for-new-genesis-block beta.testnet.solana.com:8001
+$ USE_INSTALL=1 ./multinode-demo/fullnode-x.sh --public-address --poll-for-new-genesis-block beta.testnet.solana.com:8001
 ```
 
 Then from another console, confirm the IP address if your node is now visible in

--- a/ci/localnet-sanity.sh
+++ b/ci/localnet-sanity.sh
@@ -55,7 +55,7 @@ while getopts "ch?i:k:brxR" opt; do
     restartInterval=$OPTARG
     ;;
   b)
-    maybeNoLeaderRotation="--no-stake"
+    maybeNoLeaderRotation="--stake 0"
     ;;
   x)
     extraNodes=$((extraNodes + 1))

--- a/core/src/staking_utils.rs
+++ b/core/src/staking_utils.rs
@@ -42,7 +42,7 @@ pub fn vote_account_balances_at_epoch(
     node_staked_accounts.map(|epoch_state| epoch_state.map(|(id, stake, _)| (*id, stake)).collect())
 }
 
-/// At the specified epoch, collect the delgate account balance and vote states for delegates
+/// At the specified epoch, collect the delegate account balance and vote states for delegates
 /// that have non-zero balance in any of their managed staking accounts
 pub fn delegated_stakes_at_epoch(bank: &Bank, epoch_height: u64) -> Option<HashMap<Pubkey, u64>> {
     let node_staked_accounts = node_staked_accounts_at_epoch(bank, epoch_height);

--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -14,6 +14,7 @@ use std::error;
 pub const BOOTSTRAP_LEADER_LAMPORTS: u64 = 43;
 
 fn main() -> Result<(), Box<dyn error::Error>> {
+    let default_bootstrap_leader_lamports = &BOOTSTRAP_LEADER_LAMPORTS.to_string();
     let matches = App::new(crate_name!())
         .about(crate_description!())
         .version(crate_version!())
@@ -62,6 +63,15 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                 .required(true)
                 .help("Path to file containing the bootstrap leader's staking keypair"),
         )
+        .arg(
+            Arg::with_name("bootstrap_leader_lamports")
+                .long("bootstrap-leader-lamports")
+                .value_name("LAMPORTS")
+                .takes_value(true)
+                .default_value(default_bootstrap_leader_lamports)
+                .required(true)
+                .help("Number of lamports to assign to the bootstrap leader"),
+        )
         .get_matches();
 
     let bootstrap_leader_keypair_file = matches.value_of("bootstrap_leader_keypair_file").unwrap();
@@ -69,6 +79,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
     let ledger_path = matches.value_of("ledger_path").unwrap();
     let mint_keypair_file = matches.value_of("mint_keypair_file").unwrap();
     let lamports = value_t_or_exit!(matches, "lamports", u64);
+    let bootstrap_leader_lamports = value_t_or_exit!(matches, "bootstrap_leader_lamports", u64);
 
     let bootstrap_leader_keypair = read_keypair(bootstrap_leader_keypair_file)?;
     let bootstrap_vote_keypair = read_keypair(bootstrap_vote_keypair_file)?;
@@ -77,7 +88,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
     let (mut genesis_block, _mint_keypair) = GenesisBlock::new_with_leader(
         lamports,
         &bootstrap_leader_keypair.pubkey(),
-        BOOTSTRAP_LEADER_LAMPORTS,
+        bootstrap_leader_lamports,
     );
     genesis_block.mint_id = mint_keypair.pubkey();
     genesis_block.bootstrap_leader_vote_account_id = bootstrap_vote_keypair.pubkey();

--- a/multinode-demo/fullnode.sh
+++ b/multinode-demo/fullnode.sh
@@ -16,7 +16,7 @@ fi
 gossip_port=
 extra_fullnode_args=()
 self_setup=0
-setup_stakes=1
+stake=43 # number of lamports to assign as stake
 poll_for_new_genesis_block=0
 
 while [[ ${1:0:1} = - ]]; do
@@ -32,7 +32,7 @@ while [[ ${1:0:1} = - ]]; do
     poll_for_new_genesis_block=1
     shift
   elif [[ $1 = --blockstream ]]; then
-    setup_stakes=0
+    stake=0
     extra_fullnode_args+=("$1" "$2")
     shift 2
   elif [[ $1 = --enable-rpc-exit ]]; then
@@ -41,9 +41,9 @@ while [[ ${1:0:1} = - ]]; do
   elif [[ $1 = --init-complete-file ]]; then
     extra_fullnode_args+=("$1" "$2")
     shift 2
-  elif [[ $1 = --no-stake ]]; then
-    setup_stakes=0
-    shift
+  elif [[ $1 = --stake ]]; then
+    stake="$2"
+    shift 2
   elif [[ $1 = --public-address ]]; then
     extra_fullnode_args+=("$1")
     shift
@@ -183,8 +183,8 @@ while true; do
   pid=$!
   oom_score_adj "$pid" 1000
 
-  if ((setup_stakes)); then
-    setup_vote_account "${leader_address%:*}" "$fullnode_id_path" "$fullnode_vote_id_path"
+  if ((stake)); then
+    setup_vote_account "${leader_address%:*}" "$fullnode_id_path" "$fullnode_vote_id_path" "$stake"
   fi
   set +x
 

--- a/multinode-demo/fullnode.sh
+++ b/multinode-demo/fullnode.sh
@@ -16,7 +16,7 @@ fi
 gossip_port=
 extra_fullnode_args=()
 self_setup=0
-stake=43 # number of lamports to assign as stake
+stake=43 # number of lamports to assign as stake (plus transaction fee to setup the stake)
 poll_for_new_genesis_block=0
 
 while [[ ${1:0:1} = - ]]; do

--- a/multinode-demo/fullnode.sh
+++ b/multinode-demo/fullnode.sh
@@ -170,6 +170,11 @@ while true; do
   fi
 
   trap 'kill "$pid" && wait "$pid"' INT TERM ERR
+
+  if ((stake)); then
+    setup_vote_account "${leader_address%:*}" "$fullnode_id_path" "$fullnode_vote_id_path" "$stake"
+  fi
+
   $program \
     --identity "$fullnode_id_path" \
     --voting-keypair "$fullnode_vote_id_path" \
@@ -183,9 +188,6 @@ while true; do
   pid=$!
   oom_score_adj "$pid" 1000
 
-  if ((stake)); then
-    setup_vote_account "${leader_address%:*}" "$fullnode_id_path" "$fullnode_vote_id_path" "$stake"
-  fi
   set +x
 
   while true; do

--- a/multinode-demo/setup.sh
+++ b/multinode-demo/setup.sh
@@ -29,8 +29,10 @@ EOF
 
 lamports=1000000000
 bootstrap_leader=true
+bootstrap_leader_lamports=
+
 fullnode=true
-while getopts "h?n:lpt:" opt; do
+while getopts "h?n:b:lpt:" opt; do
   case $opt in
   h|\?)
     usage
@@ -38,6 +40,9 @@ while getopts "h?n:lpt:" opt; do
     ;;
   n)
     lamports="$OPTARG"
+    ;;
+  b)
+    bootstrap_leader_lamports="$OPTARG"
     ;;
   t)
     node_type="$OPTARG"
@@ -77,12 +82,20 @@ if $bootstrap_leader; then
     $solana_keygen -o "$SOLANA_CONFIG_DIR"/mint-id.json
     $solana_keygen -o "$SOLANA_CONFIG_DIR"/bootstrap-leader-id.json
     $solana_keygen -o "$SOLANA_CONFIG_DIR"/bootstrap-leader-vote-id.json
-    $solana_genesis \
-      --bootstrap-leader-keypair "$SOLANA_CONFIG_DIR"/bootstrap-leader-id.json \
-      --bootstrap-vote-keypair "$SOLANA_CONFIG_DIR"/bootstrap-leader-vote-id.json \
-      --ledger "$SOLANA_RSYNC_CONFIG_DIR"/ledger \
-      --mint "$SOLANA_CONFIG_DIR"/mint-id.json \
+
+    args=(
+      --bootstrap-leader-keypair "$SOLANA_CONFIG_DIR"/bootstrap-leader-id.json
+      --bootstrap-vote-keypair "$SOLANA_CONFIG_DIR"/bootstrap-leader-vote-id.json
+      --ledger "$SOLANA_RSYNC_CONFIG_DIR"/ledger
+      --mint "$SOLANA_CONFIG_DIR"/mint-id.json
       --lamports "$lamports"
+    )
+
+    if [[ -n $bootstrap_leader_lamports ]]; then
+      args+=(--bootstrap-leader-lamports "$bootstrap_leader_lamports")
+    fi
+
+    $solana_genesis "${args[@]}"
     cp -a "$SOLANA_RSYNC_CONFIG_DIR"/ledger "$SOLANA_CONFIG_DIR"/bootstrap-leader-ledger
   )
 fi

--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -15,6 +15,14 @@ leaderRotation="$8"
 set +x
 export RUST_LOG
 
+# Use a very large stake (relative to the default multinode-demo/ stake of 43)
+# for the testnet fullnodes setup by net/.  This make it less likely that
+# low-staked ephemeral validator a random user may attach to testnet will cause
+# trouble
+#
+# Ref: https://github.com/solana-labs/solana/issues/3798
+stake=424243
+
 missing() {
   echo "Error: $1 not specified"
   exit 1
@@ -69,7 +77,7 @@ local|tar)
     fi
     set -x
     if [[ $skipSetup != true ]]; then
-      ./multinode-demo/setup.sh -t bootstrap-leader
+      ./multinode-demo/setup.sh -t bootstrap-leader -b $stake
     fi
     ./multinode-demo/drone.sh > drone.log 2>&1 &
 
@@ -90,9 +98,6 @@ local|tar)
     fi
 
     args=()
-    if ! $leaderRotation; then
-      args+=("--stake" 0)
-    fi
     if $publicNetwork; then
       args+=("--public-address")
     fi
@@ -100,7 +105,14 @@ local|tar)
       args+=(
         --blockstream /tmp/solana-blockstream.sock
         --no-voting
+        --stake 0
       )
+    else
+      if $leaderRotation; then
+        args+=("--stake" "$stake")
+      else
+        args+=("--stake" 0)
+      fi
     fi
 
     args+=(

--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -91,7 +91,7 @@ local|tar)
 
     args=()
     if ! $leaderRotation; then
-      args+=("--no-stake")
+      args+=("--stake" 0)
     fi
     if $publicNetwork; then
       args+=("--public-address")

--- a/net/remote/remote-sanity.sh
+++ b/net/remote/remote-sanity.sh
@@ -133,7 +133,7 @@ echo "--- $entrypointIp: validator sanity"
 if $validatorSanity; then
   (
     set -x -o pipefail
-    timeout 10s ./multinode-demo/fullnode-x.sh --no-stake \
+    timeout 10s ./multinode-demo/fullnode-x.sh --stake 0 \
       "$entrypointRsyncUrl" \
       "$entrypointIp:8001" 2>&1 | tee validator-sanity.log
   ) || {


### PR DESCRIPTION
#### Problem
All testnet nodes shared a default stake of 42 with ephemeral nodes that a user may attach/detach at any time while the cluster is running.  With an equal stake, the ephemeral nodes will make their way into the leader schedule with equal priority to the permanent nodes.  This eventually fills the leader schedule with dead nodes and brings down the cluster

#### Summary of Changes
Permanent testnet nodes now get a stake of 424242, while (by default) ephemeral nodes still get a stake of 42 (overridable by the user so they could still break the testnet if they tried) so that ephemeral nodes are almost certain to never be selected as the leader

Fixes #3798
