### PR TITLE
 Preserve extra dependency annotations (optional=,features=…rsion bump) during version bump

### DIFF
--- a/scripts/increment-cargo-version.sh
+++ b/scripts/increment-cargo-version.sh
@@ -89,7 +89,7 @@ for Cargo_toml in "${Cargo_tomls[@]}"; do
     (
       set -x
       sed -i "$Cargo_toml" -e "
-        s/^$crate = .*path = \"\([^\"]*\)\".*\$/$crate = \{ path = \"\1\", version = \"$newVersion\" \}/
+        s/^$crate = { *path *= *\"\([^\"]*\)\" *, *version *= *\"[^\"]*\"\(.*\)} *\$/$crate = \{ path = \"\1\", version = \"$newVersion\"\2 \}/
       "
     )
   done


### PR DESCRIPTION
#### Problem
`solana-kvstore = { path = "../kvstore", version = "0.14.0" , optional = true }` was more than the sed substitution in `scripts/increment_cargo_version.sh` could handle.

#### Summary of Changes
Add random alphanumeric characters until that write-only sed expression does the needful.

Fixes #3795
