### PR TITLE
wallet: Add show-vote-account command

### DIFF
--- a/multinode-demo/common.sh
+++ b/multinode-demo/common.sh
@@ -148,19 +148,15 @@ setup_vote_account() {
 
   if [[ -f "$vote_id_path".configured ]]; then
     echo "Vote account has already been configured"
-    return 0
+  else
+    airdrop "$node_id_path" "$drone_address" "$stake" || return $?
+
+    # Fund the vote account from the node, with the node as the node_id
+    $solana_wallet --keypair "$node_id_path" --host "$drone_address" \
+      create-vote-account "$vote_id" "$node_id" $((stake - 1)) || return $?
   fi
 
-  # A fullnode requires 43 lamports to function:
-  # - one lamport to keep the node identity public key valid. TODO: really??
-  # - 42 more for the vote account we fund
-  airdrop "$node_id_path" "$drone_address" "$stake" || return $?
-
-  # Fund the vote account from the node, with the node as the node_id
-  $solana_wallet --keypair "$node_id_path" --host "$drone_address" \
-    create-vote-account "$vote_id" "$node_id" $((stake - 1)) || return $?
-
-  touch "$vote_id_path".configured
+  $solana_wallet --host "$drone_address" show-vote-account "$vote_id"
   return 0
 }
 

--- a/wallet/src/main.rs
+++ b/wallet/src/main.rs
@@ -269,6 +269,19 @@ fn main() -> Result<(), Box<dyn error::Error>> {
 
         )
         .subcommand(
+            SubCommand::with_name("show-vote-account")
+                .about("Show the contents of a vote account")
+                .arg(
+                    Arg::with_name("voting_account_id")
+                        .index(1)
+                        .value_name("PUBKEY")
+                        .takes_value(true)
+                        .required(true)
+                        .validator(is_pubkey)
+                        .help("Vote account pubkey"),
+                )
+        )
+        .subcommand(
             SubCommand::with_name("deploy")
                 .about("Deploy a program")
                 .arg(


### PR DESCRIPTION
#### Problem
A validator is unable to easily view their staking account

#### Summary of Changes
```
$ solana-wallet show-vote-account 7yvFtwnqUuXChF6tnD2aKpGESJwSG6hfbCJ4MYz1VB6j
account lamports: 42
node id: FA9zGu8woPQK9pxzDZjc36Gn8Zk9HM3czzNzueKEY1V2
authorized voter id: 7yvFtwnqUuXChF6tnD2aKpGESJwSG6hfbCJ4MYz1VB6j
credits: 15
commission: 0
root slot: 14
votes:
- slot=15, confirmation count=31
- slot=16, confirmation count=30
- slot=17, confirmation count=29
- slot=18, confirmation count=28
- slot=19, confirmation count=27
- slot=20, confirmation count=26
- slot=21, confirmation count=25
- slot=22, confirmation count=24
- slot=23, confirmation count=23
- slot=24, confirmation count=22
- slot=25, confirmation count=21
- slot=26, confirmation count=20
- slot=27, confirmation count=19
- slot=28, confirmation count=18
- slot=29, confirmation count=17
- slot=30, confirmation count=16
- slot=31, confirmation count=15
- slot=32, confirmation count=14
- slot=33, confirmation count=13
- slot=34, confirmation count=12
- slot=35, confirmation count=11
- slot=36, confirmation count=10
- slot=37, confirmation count=9
- slot=38, confirmation count=8
- slot=39, confirmation count=7
- slot=40, confirmation count=6
- slot=41, confirmation count=5
- slot=42, confirmation count=4
- slot=43, confirmation count=3
- slot=44, confirmation count=2
- slot=45, confirmation count=1
```

Part of #3481