### PR TITLE
packet.rs optimizations

### DIFF
--- a/bench-streamer/src/main.rs
+++ b/bench-streamer/src/main.rs
@@ -83,7 +83,7 @@ fn main() -> Result<()> {
 
         let (s_reader, r_reader) = channel();
         read_channels.push(r_reader);
-        read_threads.push(receiver(Arc::new(read), &exit, s_reader, "bench-streamer"));
+        read_threads.push(receiver(Arc::new(read), &exit, s_reader));
     }
 
     let t_producer1 = producer(&addr, exit.clone());

--- a/core/src/fetch_stage.rs
+++ b/core/src/fetch_stage.rs
@@ -44,7 +44,7 @@ impl FetchStage {
     ) -> Self {
         let tpu_threads = sockets
             .into_iter()
-            .map(|socket| streamer::receiver(socket, &exit, sender.clone(), "fetch-stage"));
+            .map(|socket| streamer::receiver(socket, &exit, sender.clone()));
 
         let tpu_via_blobs_threads = tpu_via_blobs_sockets
             .into_iter()

--- a/core/src/replicator.rs
+++ b/core/src/replicator.rs
@@ -129,12 +129,7 @@ fn create_request_processor(
     let (s_reader, r_reader) = channel();
     let (s_responder, r_responder) = channel();
     let storage_socket = Arc::new(socket);
-    let t_receiver = receiver(
-        storage_socket.clone(),
-        exit,
-        s_reader,
-        "replicator-receiver",
-    );
+    let t_receiver = receiver(storage_socket.clone(), exit, s_reader);
     thread_handles.push(t_receiver);
 
     let t_responder = responder("replicator-responder", storage_socket.clone(), r_responder);

--- a/core/src/streamer.rs
+++ b/core/src/streamer.rs
@@ -35,11 +35,6 @@ fn recv_loop(
                 return Ok(());
             }
             if let Ok(len) = msgs.recv_from(sock) {
-                submit(
-                    influxdb::Point::new(channel_tag)
-                        .add_field("count", influxdb::Value::Integer(len as i64))
-                        .to_owned(),
-                );
                 channel.send(Arc::new(RwLock::new(msgs)))?;
                 break;
             }

--- a/metrics/src/counter.rs
+++ b/metrics/src/counter.rs
@@ -39,6 +39,13 @@ macro_rules! inc_counter {
 }
 
 #[macro_export]
+macro_rules! inc_counter_info {
+    ($name:expr, $count:expr) => {
+        unsafe { $name.inc(log::Level::Info, $count) };
+    };
+}
+
+#[macro_export]
 macro_rules! inc_new_counter {
     ($name:expr, $count:expr, $level:expr, $lograte:expr) => {{
         static mut INC_NEW_COUNTER: Counter = create_counter!($name, $lograte);
@@ -89,7 +96,7 @@ impl Counter {
             self.lograte.store(lograte, Ordering::Relaxed);
         }
         if times % lograte == 0 && times > 0 && log_enabled!(level) {
-            info!(
+            log!(level,
                 "COUNTER:{{\"name\": \"{}\", \"counts\": {}, \"samples\": {},  \"now\": {}, \"events\": {}}}",
                 self.name,
                 counts + events,


### PR DESCRIPTION
#### Problem
 solana-receiver (fetch stage) spends a lot of time (25%) in simd memmove() (probably memset)

 #### Summary of Changes
 stop initializing packet buffers
 prepare, but don't pre-allocate buffers enough for recv_mmsg(), but no more than that
 simplify recv_from()

Fixes #3817 (maybe ;) )