### PR TITLE
Enable bench exchange test

### DIFF
--- a/bench-exchange/src/bench.rs
+++ b/bench-exchange/src/bench.rs
@@ -1016,7 +1016,6 @@ mod tests {
     use std::sync::mpsc::channel;
 
     #[test]
-    #[ignore] // TODO Issue #3825
     fn test_exchange_local_cluster() {
         solana_logger::setup();
 


### PR DESCRIPTION
#### Problem

Bench exchange test was ignored due to erasure error that caused it to panic.

#### Summary of Changes

Erasure has been reverted, enable the test

Fixes #
