### PR TITLE
Fix flaky tests by waiting for test node to boot

### DIFF
--- a/core/src/fullnode.rs
+++ b/core/src/fullnode.rs
@@ -8,7 +8,7 @@ use crate::contact_info::ContactInfo;
 use crate::entry::create_ticks;
 use crate::entry::next_entry_mut;
 use crate::entry::Entry;
-use crate::gossip_service::GossipService;
+use crate::gossip_service::{discover_nodes, GossipService};
 use crate::leader_schedule_utils;
 use crate::poh_recorder::PohRecorder;
 use crate::poh_service::{PohService, PohServiceConfig};
@@ -395,7 +395,7 @@ pub fn new_fullnode_for_tests() -> (Fullnode, ContactInfo, Keypair, String) {
         None,
         &FullnodeConfig::default(),
     );
-
+    discover_nodes(&contact_info.gossip, 1).expect("Node startup failed");
     (node, contact_info, mint_keypair, ledger_path)
 }
 


### PR DESCRIPTION
#### Problem

Tests that rely on setting up a fullnode can fail if the node isn't ready in time. Mostly seems to happen when running on my laptop

#### Summary of Changes

Wait for the test node to come up.
