### PR TITLE
Don't use barrier transaction in testnet for perf testing

### DIFF
--- a/bench-tps/src/bench.rs
+++ b/bench-tps/src/bench.rs
@@ -189,16 +189,17 @@ pub fn do_bench_tps(config: Config) {
             while shared_tx_active_thread_count.load(Ordering::Relaxed) > 0 {
                 sleep(Duration::from_millis(100));
             }
+        } else {
+            // It's not feasible (would take too much time) to confirm each of the `tx_count / 2`
+            // transactions sent by `generate_txs()` so instead send and confirm a single transaction
+            // to validate the network is still functional.
+            send_barrier_transaction(
+                &mut barrier_client,
+                &mut blockhash,
+                &barrier_source_keypair,
+                &barrier_dest_id,
+            );
         }
-        // It's not feasible (would take too much time) to confirm each of the `tx_count / 2`
-        // transactions sent by `generate_txs()` so instead send and confirm a single transaction
-        // to validate the network is still functional.
-        send_barrier_transaction(
-            &mut barrier_client,
-            &mut blockhash,
-            &barrier_source_keypair,
-            &barrier_dest_id,
-        );
 
         i += 1;
         if should_switch_directions(num_lamports_per_account, i) {

--- a/bench-tps/src/bench.rs
+++ b/bench-tps/src/bench.rs
@@ -11,8 +11,6 @@ use solana_client::thin_client::ThinClient;
 use solana_drone::drone::request_airdrop_transaction;
 use solana_metrics::influxdb;
 use solana_sdk::client::{AsyncClient, SyncClient};
-use solana_sdk::hash::Hash;
-use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::{Keypair, KeypairUtil};
 use solana_sdk::system_instruction;
 use solana_sdk::system_transaction;
@@ -68,8 +66,6 @@ pub fn do_bench_tps(config: Config) {
     let cluster_entrypoint = nodes[0].clone(); // Pick the first node, why not?
 
     let client = create_client(cluster_entrypoint.client_facing_addr(), FULLNODE_PORT_RANGE);
-    let mut barrier_client =
-        create_client(cluster_entrypoint.client_facing_addr(), FULLNODE_PORT_RANGE);
 
     let mut seed = [0u8; 32];
     seed.copy_from_slice(&id.public_key_bytes()[..32]);
@@ -83,8 +79,6 @@ pub fn do_bench_tps(config: Config) {
         target /= MAX_SPENDS_PER_TX;
     }
     let gen_keypairs = rnd.gen_n_keypairs(total_keys as u64);
-    let barrier_source_keypair = Keypair::new();
-    let barrier_dest_id = Pubkey::new_rand();
 
     println!("Get lamports...");
     let num_lamports_per_account = 20;
@@ -104,11 +98,6 @@ pub fn do_bench_tps(config: Config) {
     }
     let start = gen_keypairs.len() - (tx_count * 2) as usize;
     let keypairs = &gen_keypairs[start..];
-    airdrop_lamports(&barrier_client, &drone_addr, &barrier_source_keypair, 1);
-
-    println!("Get last ID...");
-    let mut blockhash = client.get_recent_blockhash().unwrap();
-    println!("Got last ID {:?}", blockhash);
 
     let first_tx_count = client.get_transaction_count().expect("transaction count");
     println!("Initial transaction count {}", first_tx_count);

--- a/net/remote/remote-client.sh
+++ b/net/remote/remote-client.sh
@@ -55,7 +55,6 @@ clientCommand="\
     --network $entrypointIp:8001 \
     --drone $entrypointIp:9900 \
     --duration 7500 \
-    --sustained \
     --threads $threadCount \
 "
 

--- a/net/remote/remote-client.sh
+++ b/net/remote/remote-client.sh
@@ -55,6 +55,7 @@ clientCommand="\
     --network $entrypointIp:8001 \
     --drone $entrypointIp:9900 \
     --duration 7500 \
+    --sustained \
     --threads $threadCount \
 "
 


### PR DESCRIPTION
#### Problem
Barrier transactions are causing gaps in transaction processing

#### Summary of Changes
The TPS is calculated using fullnode metrics now. Barrier transactions are not required to guard against false TPS reporting. In non sustained client configuration, barrier transactions won't be sent.