### PR TITLE
Remove broken read().unwrap() call to a non-shared packet

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -278,9 +278,7 @@ impl BankingStage {
                     if Self::should_buffer_packets(poh_recorder, cluster_info) {
                         let num = unprocessed_packets
                             .iter()
-                            .map(|(x, start, _)| {
-                                x.read().unwrap().packets.len().saturating_sub(*start)
-                            })
+                            .map(|(x, start, _)| x.packets.len().saturating_sub(*start))
                             .sum();
                         inc_new_counter_info!("banking_stage-buffered_packets", num);
                         buffered_packets.extend_from_slice(&unprocessed_packets);


### PR DESCRIPTION
#### Problem
`SharedPackets` gone as of  #3843 but `banking_stage` still had a a `packets.read().unwrap()` call.
#### Summary of Changes
delete it

Fixes #
