### PR TITLE
Try to delete nodes in all cloud zones

### DIFF
--- a/net/scripts/gce-provider.sh
+++ b/net/scripts/gce-provider.sh
@@ -208,10 +208,11 @@ cloud_DeleteInstances() {
   declare names=("${instances[@]/:*/}")
   declare zones=("${instances[@]/*:/}")
 
-  (
+  for zone in "${zones[@]}"; do
     set -x
-    gcloud beta compute instances delete --zone "${zones[0]}" --quiet "${names[@]}"
-  )
+    # Try deleting instances in all zones
+    gcloud beta compute instances delete --zone "$zone" --quiet "${names[@]}" || true
+  done
 }
 
 


### PR DESCRIPTION
#### Problem
Testnet automation is failing to cleanup nodes after completing the runs.

#### Summary of Changes
The testnet is being deployed in multiple regions. The cleanup script tries to delete all nodes assuming a single region. Changed the script to delete nodes in all zones.