### PR TITLE
Add bench-exchange to installed bins

### DIFF
--- a/scripts/cargo-install-all.sh
+++ b/scripts/cargo-install-all.sh
@@ -29,6 +29,7 @@ SECONDS=0
 )
 
 BIN_CRATES=(
+  bench-exchange
   bench-streamer
   bench-tps
   drone


### PR DESCRIPTION
#### Problem

Need to run exchange clients on remote machines.

#### Summary of Changes

Add solana-bench-exchange to list of bins to install.

Fixes #
