### PR TITLE
Better drone error when cap is hit.

### DIFF
--- a/drone/src/drone.rs
+++ b/drone/src/drone.rs
@@ -138,7 +138,7 @@ impl Drone {
                     Err(Error::new(
                         ErrorKind::Other,
                         format!(
-                            "token limit reached req: {} current: {} cap: {}",
+                            "token limit reached; req: {} current: {} cap: {}",
                             lamports, self.request_current, self.request_cap
                         ),
                     ))

--- a/drone/src/drone.rs
+++ b/drone/src/drone.rs
@@ -135,7 +135,13 @@ impl Drone {
                     let message = Message::new(vec![create_instruction]);
                     Ok(Transaction::new(&[&self.mint_keypair], message, blockhash))
                 } else {
-                    Err(Error::new(ErrorKind::Other, "token limit reached"))
+                    Err(Error::new(
+                        ErrorKind::Other,
+                        format!(
+                            "token limit reached req: {} current: {} cap: {}",
+                            lamports, self.request_current, self.request_cap
+                        ),
+                    ))
                 }
             }
         }


### PR DESCRIPTION
#### Problem

Drone doesn't print any information about its current cap or status when hit.

#### Summary of Changes

Add more information to the error.

Fixes #
