### PR TITLE
Fix testnet automation scripts

### DIFF
--- a/ci/testnet-automation.sh
+++ b/ci/testnet-automation.sh
@@ -14,7 +14,7 @@ source ci/upload-ci-artifact.sh
 [[ -n $ITERATION_WAIT ]] || ITERATION_WAIT=300
 [[ -n $NUMBER_OF_NODES ]] || NUMBER_OF_NODES="10 25 50 100"
 [[ -n $LEADER_CPU_MACHINE_TYPE ]] ||
-  LEADER_CPU_MACHINE_TYPE="n1-standard-16 --accelerator count=2,type=nvidia-tesla-v100"
+  LEADER_CPU_MACHINE_TYPE="--machine-type n1-standard-16 --accelerator count=2,type=nvidia-tesla-v100"
 [[ -n $CLIENT_COUNT ]] || CLIENT_COUNT=2
 [[ -n $TESTNET_TAG ]] || TESTNET_TAG=testnet-automation
 [[ -n $TESTNET_ZONES ]] || TESTNET_ZONES="us-west1-b"

--- a/ci/testnet-manager.sh
+++ b/ci/testnet-manager.sh
@@ -294,7 +294,7 @@ start() {
       NO_VALIDATOR_SANITY=1 \
       RUST_LOG=solana=warn \
         ci/testnet-deploy.sh -p perf-testnet-solana-com -C gce -z us-west1-b \
-          -G "n1-standard-16 --accelerator count=2,type=nvidia-tesla-v100" \
+          -G "--machine-type n1-standard-16 --accelerator count=2,type=nvidia-tesla-v100" \
           -t "$CHANNEL_OR_TAG" -c 2 \
           -b \
           -d pd-ssd \


### PR DESCRIPTION
#### Problem
Testnet automation scripts are broken since gce.sh changed parameters

#### Summary of Changes
Include --machine-type in the GPU parameter.