### PR TITLE
Add rpc request debug to make_rpc_request

### DIFF
--- a/client/src/rpc_client_request.rs
+++ b/client/src/rpc_client_request.rs
@@ -62,8 +62,8 @@ impl GenericRpcClientRequest for RpcClientRequest {
                 }
                 Err(e) => {
                     info!(
-                        "make_rpc_request() failed, {} retries left: {:?}",
-                        retries, e
+                        "make_rpc_request({:?}) failed, {} retries left: {:?}",
+                        request, retries, e
                     );
                     if retries == 0 {
                         Err(e)?;


### PR DESCRIPTION
#### Problem

When make_rpc_request fails no way to tell what request it is.

#### Summary of Changes

Add the request type that fails for easier debug.

Fixes #
