### PR TITLE
Add bench-exchange tx send metrics

### DIFF
--- a/sdk/src/timing.rs
+++ b/sdk/src/timing.rs
@@ -24,6 +24,10 @@ pub const MAX_HASH_AGE_IN_SECONDS: usize = 120;
 // This must be <= MAX_HASH_AGE_IN_SECONDS, otherwise there's risk for DuplicateSignature errors
 pub const MAX_RECENT_BLOCKHASHES: usize = MAX_HASH_AGE_IN_SECONDS;
 
+pub fn duration_as_ns(d: &Duration) -> u64 {
+    d.as_secs() * 1_000_000_000 + u64::from(d.subsec_nanos())
+}
+
 pub fn duration_as_us(d: &Duration) -> u64 {
     (d.as_secs() * 1000 * 1000) + (u64::from(d.subsec_nanos()) / 1_000)
 }


### PR DESCRIPTION
#### Problem

bench-exchange not filtering out nodes without good tpu/rpc ports for clients
no transfer metrics for bench-exchange
bench-exchange has lots of hand-coded timing math

#### Summary of Changes

Filter nodes without good tpu/rpc ports
add metrics to do_tx_transfers
name threads
use duration_as_x functions for duration conversion

Fixes #
