### PR TITLE
Reduce packet recv batches

### DIFF
--- a/core/src/streamer.rs
+++ b/core/src/streamer.rs
@@ -19,7 +19,7 @@ pub type PacketSender = Sender<Packets>;
 pub type BlobSender = Sender<SharedBlobs>;
 pub type BlobReceiver = Receiver<SharedBlobs>;
 
-const RECV_BATCH_MAX: u64 = 60_000;
+const RECV_BATCH_MAX: usize = 60_000;
 
 fn recv_loop(sock: &UdpSocket, exit: Arc<AtomicBool>, channel: &PacketSender) -> Result<()> {
     loop {

--- a/core/src/streamer.rs
+++ b/core/src/streamer.rs
@@ -19,6 +19,8 @@ pub type PacketSender = Sender<Packets>;
 pub type BlobSender = Sender<SharedBlobs>;
 pub type BlobReceiver = Receiver<SharedBlobs>;
 
+const RECV_BATCH_MAX: u64 = 60_000;
+
 fn recv_loop(sock: &UdpSocket, exit: Arc<AtomicBool>, channel: &PacketSender) -> Result<()> {
     loop {
         let mut msgs = Packets::default();
@@ -73,7 +75,7 @@ pub fn recv_batch(recvr: &PacketReceiver) -> Result<(Vec<Packets>, usize, u64)> 
         len += more.packets.len();
         batch.push(more);
 
-        if len > 100_000 {
+        if len > RECV_BATCH_MAX {
             break;
         }
     }


### PR DESCRIPTION
#### Problem

Receivers can collect upto 100k packets before returning. It appears that this causes sigverify to take up more than 50% of a slot. 

#### Summary of Changes

Reduced sizes to 60k after numerous rounds of testing values between 15k-60k. 60k seems like the best balance right now. 
