### PR TITLE
treat negatives like zero instead of crashing out

### DIFF
--- a/bench-tps/src/bench.rs
+++ b/bench-tps/src/bench.rs
@@ -241,13 +241,14 @@ fn sample_tx_count(
     let log_prefix = format!("{:21}:", v.tpu.to_string());
 
     loop {
-        let tx_count = client.get_transaction_count().expect("transaction count");
-        assert!(
-            tx_count >= initial_tx_count,
-            "expected tx_count({}) >= initial_tx_count({})",
-            tx_count,
-            initial_tx_count
-        );
+        let mut tx_count = client.get_transaction_count().expect("transaction count");
+        if tx_count < initial_tx_count {
+            println!(
+                "expected tx_count({}) >= initial_tx_count({})",
+                tx_count, initial_tx_count
+            );
+            tx_count = initial_tx_count;
+        }
         let duration = now.elapsed();
         now = Instant::now();
         let sample = tx_count - initial_tx_count;


### PR DESCRIPTION
#### Problem
 bench-tps observes tx count going negative and assert!()s out

 #### Summary of Changes
 treat backwards like zero