### PR TITLE
Write bench-tps in terms of client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2293,6 +2293,7 @@ dependencies = [
  "solana-logger 0.14.0",
  "solana-metrics 0.14.0",
  "solana-netutil 0.14.0",
+ "solana-runtime 0.14.0",
  "solana-sdk 0.14.0",
 ]
 

--- a/bench-tps/Cargo.toml
+++ b/bench-tps/Cargo.toml
@@ -17,6 +17,7 @@ solana-drone = { path = "../drone", version = "0.14.0" }
 solana-logger = { path = "../logger", version = "0.14.0" }
 solana-metrics = { path = "../metrics", version = "0.14.0" }
 solana-netutil = { path = "../netutil", version = "0.14.0" }
+solana-runtime = { path = "../runtime", version = "0.14.0" }
 solana-sdk = { path = "../sdk", version = "0.14.0" }
 
 [features]

--- a/bench-tps/src/bench.rs
+++ b/bench-tps/src/bench.rs
@@ -7,10 +7,9 @@ use solana::contact_info::ContactInfo;
 use solana::gen_keys::GenKeys;
 use solana::gossip_service::discover_nodes;
 use solana_client::thin_client::create_client;
-use solana_client::thin_client::ThinClient;
 use solana_drone::drone::request_airdrop_transaction;
 use solana_metrics::influxdb;
-use solana_sdk::client::{AsyncClient, SyncClient};
+use solana_sdk::client::{AsyncClient, Client, SyncClient};
 use solana_sdk::signature::{Keypair, KeypairUtil};
 use solana_sdk::system_instruction;
 use solana_sdk::system_transaction;
@@ -86,7 +85,7 @@ pub fn do_bench_tps(config: Config) {
     // Sample the first keypair, see if it has lamports, if so then resume
     // to avoid lamport loss
     let keypair0_balance = client
-        .poll_get_balance(&gen_keypairs.last().unwrap().pubkey())
+        .get_balance(&gen_keypairs.last().unwrap().pubkey())
         .unwrap_or(0);
 
     if num_lamports_per_account > keypair0_balance {
@@ -156,7 +155,7 @@ pub fn do_bench_tps(config: Config) {
     let mut reclaim_lamports_back_to_source_account = false;
     let mut i = keypair0_balance;
     while start.elapsed() < duration {
-        let balance = client.poll_get_balance(&id.pubkey()).unwrap_or(0);
+        let balance = client.get_balance(&id.pubkey()).unwrap_or(0);
         metrics_submit_lamport_balance(balance);
 
         // ping-pong between source and destination accounts for each loop iteration
@@ -204,7 +203,7 @@ pub fn do_bench_tps(config: Config) {
         }
     }
 
-    let balance = client.poll_get_balance(&id.pubkey()).unwrap_or(0);
+    let balance = client.get_balance(&id.pubkey()).unwrap_or(0);
     metrics_submit_lamport_balance(balance);
 
     compute_and_report_stats(
@@ -399,7 +398,7 @@ fn do_tx_transfers(
     }
 }
 
-fn verify_funding_transfer(client: &ThinClient, tx: &Transaction, amount: u64) -> bool {
+fn verify_funding_transfer<T: Client>(client: &T, tx: &Transaction, amount: u64) -> bool {
     for a in &tx.message().account_keys[1..] {
         if client.get_balance(a).unwrap_or(0) >= amount {
             return true;
@@ -412,7 +411,7 @@ fn verify_funding_transfer(client: &ThinClient, tx: &Transaction, amount: u64) -
 /// fund the dests keys by spending all of the source keys into MAX_SPENDS_PER_TX
 /// on every iteration.  This allows us to replay the transfers because the source is either empty,
 /// or full
-fn fund_keys(client: &ThinClient, source: &Keypair, dests: &[Keypair], lamports: u64) {
+fn fund_keys<T: Client>(client: &T, source: &Keypair, dests: &[Keypair], lamports: u64) {
     let total = lamports * dests.len() as u64;
     let mut funded: Vec<(&Keypair, u64)> = vec![(source, total)];
     let mut notfunded: Vec<&Keypair> = dests.iter().collect();
@@ -514,8 +513,8 @@ fn fund_keys(client: &ThinClient, source: &Keypair, dests: &[Keypair], lamports:
     }
 }
 
-fn airdrop_lamports(client: &ThinClient, drone_addr: &SocketAddr, id: &Keypair, tx_count: u64) {
-    let starting_balance = client.poll_get_balance(&id.pubkey()).unwrap_or(0);
+fn airdrop_lamports<T: Client>(client: &T, drone_addr: &SocketAddr, id: &Keypair, tx_count: u64) {
+    let starting_balance = client.get_balance(&id.pubkey()).unwrap_or(0);
     metrics_submit_lamport_balance(starting_balance);
     println!("starting balance {}", starting_balance);
 
@@ -532,7 +531,7 @@ fn airdrop_lamports(client: &ThinClient, drone_addr: &SocketAddr, id: &Keypair, 
         match request_airdrop_transaction(&drone_addr, &id.pubkey(), airdrop_amount, blockhash) {
             Ok(transaction) => {
                 let signature = client.async_send_transaction(transaction).unwrap();
-                client.poll_for_signature(&signature).unwrap();
+                client.get_signature_status(&signature).unwrap();
             }
             Err(err) => {
                 panic!(
@@ -542,7 +541,7 @@ fn airdrop_lamports(client: &ThinClient, drone_addr: &SocketAddr, id: &Keypair, 
             }
         };
 
-        let current_balance = client.poll_get_balance(&id.pubkey()).unwrap_or_else(|e| {
+        let current_balance = client.get_balance(&id.pubkey()).unwrap_or_else(|e| {
             println!("airdrop error {}", e);
             starting_balance
         });

--- a/bench-tps/src/main.rs
+++ b/bench-tps/src/main.rs
@@ -1,15 +1,102 @@
 mod bench;
 mod cli;
 
-use crate::bench::do_bench_tps;
+use crate::bench::{
+    airdrop_lamports, do_bench_tps, fund_keys, Config, MAX_SPENDS_PER_TX, NUM_LAMPORTS_PER_ACCOUNT,
+};
+use solana::cluster_info::FULLNODE_PORT_RANGE;
+use solana::contact_info::ContactInfo;
+use solana::gen_keys::GenKeys;
+use solana::gossip_service::discover_nodes;
+use solana_client::thin_client::create_client;
+use solana_sdk::client::SyncClient;
+use solana_sdk::signature::KeypairUtil;
+use std::process::exit;
 
 fn main() {
     solana_logger::setup();
     solana_metrics::set_panic_hook("bench-tps");
 
     let matches = cli::build_args().get_matches();
+    let cli_config = cli::extract_args(&matches);
 
-    let cfg = cli::extract_args(&matches);
+    let cli::Config {
+        network_addr,
+        drone_addr,
+        id,
+        threads,
+        num_nodes,
+        duration,
+        tx_count,
+        thread_batch_sleep_ms,
+        sustained,
+    } = cli_config;
 
-    do_bench_tps(cfg);
+    println!("Connecting to the cluster");
+    let nodes = discover_nodes(&network_addr, num_nodes).unwrap_or_else(|err| {
+        eprintln!("Failed to discover {} nodes: {:?}", num_nodes, err);
+        exit(1);
+    });
+    if nodes.len() < num_nodes {
+        eprintln!(
+            "Error: Insufficient nodes discovered.  Expecting {} or more",
+            num_nodes
+        );
+        exit(1);
+    }
+    let clients: Vec<_> = nodes
+        .iter()
+        .filter_map(|node| {
+            let cluster_entrypoint = node.clone();
+            let cluster_addrs = cluster_entrypoint.client_facing_addr();
+            if ContactInfo::is_valid_address(&cluster_addrs.0)
+                && ContactInfo::is_valid_address(&cluster_addrs.1)
+            {
+                let client = create_client(cluster_addrs, FULLNODE_PORT_RANGE);
+                Some(client)
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    let mut seed = [0u8; 32];
+    seed.copy_from_slice(&id.to_bytes()[..32]);
+    let mut rnd = GenKeys::new(seed);
+
+    println!("Creating {} keypairs...", tx_count * 2);
+    let mut total_keys = 0;
+    let mut target = tx_count * 2;
+    while target > 0 {
+        total_keys += target;
+        target /= MAX_SPENDS_PER_TX;
+    }
+    let keypairs = rnd.gen_n_keypairs(total_keys as u64);
+
+    println!("Get lamports...");
+
+    // Sample the first keypair, see if it has lamports, if so then resume.
+    // This logic is to prevent lamport loss on repeated solana-bench-tps executions
+    let keypair0_balance = clients[0]
+        .get_balance(&keypairs.last().unwrap().pubkey())
+        .unwrap_or(0);
+
+    if NUM_LAMPORTS_PER_ACCOUNT > keypair0_balance {
+        let extra = NUM_LAMPORTS_PER_ACCOUNT - keypair0_balance;
+        let total = extra * (keypairs.len() as u64);
+        airdrop_lamports(&clients[0], &drone_addr, &id, total);
+        println!("adding more lamports {}", extra);
+        fund_keys(&clients[0], &id, &keypairs, extra);
+    }
+
+    let config = Config {
+        id,
+        threads,
+        thread_batch_sleep_ms,
+        duration,
+        tx_count,
+        sustained,
+    };
+
+    do_bench_tps(clients, config, keypairs, keypair0_balance);
 }

--- a/bench-tps/src/main.rs
+++ b/bench-tps/src/main.rs
@@ -2,11 +2,10 @@ mod bench;
 mod cli;
 
 use crate::bench::{
-    airdrop_lamports, do_bench_tps, fund_keys, Config, MAX_SPENDS_PER_TX, NUM_LAMPORTS_PER_ACCOUNT,
+    airdrop_lamports, do_bench_tps, fund_keys, generate_keypairs, Config, NUM_LAMPORTS_PER_ACCOUNT,
 };
 use solana::cluster_info::FULLNODE_PORT_RANGE;
 use solana::contact_info::ContactInfo;
-use solana::gen_keys::GenKeys;
 use solana::gossip_service::discover_nodes;
 use solana_client::thin_client::create_client;
 use solana_sdk::client::SyncClient;
@@ -60,18 +59,8 @@ fn main() {
         })
         .collect();
 
-    let mut seed = [0u8; 32];
-    seed.copy_from_slice(&id.to_bytes()[..32]);
-    let mut rnd = GenKeys::new(seed);
-
     println!("Creating {} keypairs...", tx_count * 2);
-    let mut total_keys = 0;
-    let mut target = tx_count * 2;
-    while target > 0 {
-        total_keys += target;
-        target /= MAX_SPENDS_PER_TX;
-    }
-    let keypairs = rnd.gen_n_keypairs(total_keys as u64);
+    let keypairs = generate_keypairs(&id, tx_count);
 
     println!("Get lamports...");
 

--- a/client/src/thin_client.rs
+++ b/client/src/thin_client.rs
@@ -168,7 +168,11 @@ impl ThinClient {
     }
 }
 
-impl Client for ThinClient {}
+impl Client for ThinClient {
+    fn transactions_addr(&self) -> String {
+        self.transactions_addr.to_string()
+    }
+}
 
 impl SyncClient for ThinClient {
     fn send_message(&self, keypairs: &[&Keypair], message: Message) -> TransportResult<Signature> {

--- a/runtime/src/bank_client.rs
+++ b/runtime/src/bank_client.rs
@@ -20,7 +20,11 @@ pub struct BankClient {
     transaction_sender: Mutex<Sender<Transaction>>,
 }
 
-impl Client for BankClient {}
+impl Client for BankClient {
+    fn transactions_addr(&self) -> String {
+        "Local BankClient".to_string()
+    }
+}
 
 impl AsyncClient for BankClient {
     fn async_send_transaction(&self, transaction: Transaction) -> io::Result<Signature> {

--- a/sdk/src/client.rs
+++ b/sdk/src/client.rs
@@ -16,7 +16,9 @@ use crate::transaction;
 use crate::transport::Result;
 use std::io;
 
-pub trait Client: SyncClient + AsyncClient {}
+pub trait Client: SyncClient + AsyncClient {
+    fn transactions_addr(&self) -> String;
+}
 
 pub trait SyncClient {
     /// Create a transaction from the given message, and send it to the

--- a/sdk/src/transport.rs
+++ b/sdk/src/transport.rs
@@ -1,10 +1,22 @@
 use crate::transaction::TransactionError;
+use std::error;
+use std::fmt;
 use std::io;
 
 #[derive(Debug)]
 pub enum TransportError {
     IoError(io::Error),
     TransactionError(TransactionError),
+}
+
+impl error::Error for TransportError {}
+impl fmt::Display for TransportError {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            TransportError::IoError(err) => write!(formatter, "{:?}", err),
+            TransportError::TransactionError(err) => write!(formatter, "{:?}", err),
+        }
+    }
 }
 
 impl TransportError {


### PR DESCRIPTION
#### Problem
Continuation of #3745 , with the goal of enabling bench-tps to generate I/O-free flamegraphs and have an easier time optimizing the bank.

#### Summary of Changes

- Implement bench-tps in terms of the the Client trait instead of specialized to ThinClient. (There might be a little flakiness in the `get_balance()` methods. I'll keep an eye on it. I'd like to address this by improving ThinClient, rather than using special cases in bench-tps.)
- Move cluster- and ThinClient-specific code outside bench methods
- Write bench-tps test against BankClient as poc

Closes #3745 

Note: there is a bunch of copy-pasta between bench-tps and bench-exchange. @jackcmay, I'd like to clean that up next, if it won't get in your way.