### PR TITLE
account storage is not in sync with the index after gc

### DIFF
--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -1,6 +1,6 @@
 use crate::accounts_db::{
-    get_paths_vec, AccountInfo, AccountStorageSlice, AccountsDB, ErrorCounters,
-    InstructionAccounts, InstructionLoaders,
+    get_paths_vec, AccountInfo, AccountStorage, AccountsDB, ErrorCounters, InstructionAccounts,
+    InstructionLoaders,
 };
 use crate::accounts_index::{AccountsIndex, Fork};
 use crate::append_vec::StoredAccount;
@@ -140,7 +140,7 @@ impl Accounts {
     }
 
     fn load_tx_accounts(
-        storage: &AccountStorageSlice,
+        storage: &AccountStorage,
         ancestors: &HashMap<Fork, usize>,
         accounts_index: &AccountsIndex<AccountInfo>,
         tx: &Transaction,
@@ -180,7 +180,7 @@ impl Accounts {
     }
 
     fn load_executable_accounts(
-        storage: &AccountStorageSlice,
+        storage: &AccountStorage,
         ancestors: &HashMap<Fork, usize>,
         accounts_index: &AccountsIndex<AccountInfo>,
         program_id: &Pubkey,
@@ -222,7 +222,7 @@ impl Accounts {
 
     /// For each program_id in the transaction, load its loaders.
     fn load_loaders(
-        storage: &AccountStorageSlice,
+        storage: &AccountStorage,
         ancestors: &HashMap<Fork, usize>,
         accounts_index: &AccountsIndex<AccountInfo>,
         tx: &Transaction,

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -394,9 +394,9 @@ impl AccountsDB {
         let reclaims = self.update_index(fork_id, infos, accounts);
         trace!("reclaim: {}", reclaims.len());
         let mut dead_forks = self.remove_dead_accounts(reclaims);
-        println!("dead_forks: {}", dead_forks.len());
+        trace!("dead_forks: {}", dead_forks.len());
         self.cleanup_dead_forks(&mut dead_forks);
-        println!("purge_forks: {}", dead_forks.len());
+        trace!("purge_forks: {}", dead_forks.len());
         for fork in dead_forks {
             self.purge_fork(fork);
         }

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -587,7 +587,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
     fn test_accountsdb_count_stores() {
         let paths = get_tmp_accounts_path!();
         let db = AccountsDB::new(&paths.paths);

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -358,6 +358,7 @@ impl AccountsDB {
                 store.remove_account();
             }
         }
+        //TODO: performance here could be improved if AccountsDB::storage was organized by fork
         let dead_forks: HashSet<Fork> = storage
             .values()
             .filter_map(|x| {
@@ -382,6 +383,7 @@ impl AccountsDB {
     }
     fn cleanup_dead_forks(&self, dead_forks: &mut HashSet<Fork>) {
         let mut index = self.accounts_index.write().unwrap();
+        // a fork is not totally dead until it is older than the root
         dead_forks.retain(|fork| *fork < index.last_root);
         for fork in dead_forks.iter() {
             index.cleanup_dead_fork(*fork);
@@ -771,7 +773,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
     fn test_account_grow() {
         let paths = get_tmp_accounts_path!();
         let accounts = AccountsDB::new(&paths.paths);

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -256,14 +256,15 @@ impl AccountsDB {
         let mut candidates: Vec<Arc<AccountStorageEntry>> = stores
             .values()
             .filter_map(|x| {
-                if x.get_status() == AccountStorageStatus::StorageAvailable && x.fork_id == fork_id {
+                if x.get_status() == AccountStorageStatus::StorageAvailable && x.fork_id == fork_id
+                {
                     Some(x.clone())
                 } else {
                     None
                 }
             })
             .collect();
-        if candidates.len() == 0 {
+        if candidates.is_empty() {
             let path_idx = thread_rng().gen_range(0, self.paths.len());
             let storage = self.new_storage_entry(fork_id, &self.paths[path_idx]);
             candidates.push(Arc::new(storage));
@@ -302,7 +303,7 @@ impl AccountsDB {
         let is_root = self.accounts_index.read().unwrap().is_root(fork);
         trace!("PURGING {} {}", fork, is_root);
         if !is_root {
-            self.storage.write().unwrap().retain(|_,v| {
+            self.storage.write().unwrap().retain(|_, v| {
                 trace!("PURGING {} {}", v.fork_id, fork);
                 v.fork_id != fork
             });
@@ -334,7 +335,12 @@ impl AccountsDB {
         infos
     }
 
-    fn update_index(&self, fork_id: Fork, infos: Vec<AccountInfo>, accounts: &[(&Pubkey, &Account)]) -> Vec<(Fork, AccountInfo)> {
+    fn update_index(
+        &self,
+        fork_id: Fork,
+        infos: Vec<AccountInfo>,
+        accounts: &[(&Pubkey, &Account)],
+    ) -> Vec<(Fork, AccountInfo)> {
         let mut index = self.accounts_index.write().unwrap();
         let mut reclaims = vec![];
         for (i, info) in infos.into_iter().enumerate() {
@@ -737,7 +743,7 @@ mod tests {
             );
         }
 
-        let mut append_vec_histogram = HashMap::new();           
+        let mut append_vec_histogram = HashMap::new();
         for storage in accounts.storage.read().unwrap().values() {
             *append_vec_histogram.entry(storage.fork_id).or_insert(0) += 1;
         }

--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -59,7 +59,7 @@ impl<T: Clone> AccountsIndex<T> {
         };
         rv
     }
-    fn is_purged(&self, fork: Fork) -> bool {
+    pub fn is_purged(&self, fork: Fork) -> bool {
         !self.is_root(fork) && fork < self.last_root
     }
     pub fn is_root(&self, fork: Fork) -> bool {

--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -9,7 +9,7 @@ pub struct AccountsIndex<T> {
     account_maps: HashMap<Pubkey, Vec<(Fork, T)>>,
     roots: HashSet<Fork>,
     //This value that needs to be stored to recover the index from AppendVec
-    last_root: Fork,
+    pub last_root: Fork,
 }
 
 impl<T: Clone> AccountsIndex<T> {


### PR DESCRIPTION
#### Problem

AccountsIndex::insert returns a list of accounts to cleanup.  The accounts reference the storage by index into the storage vector.  Removing an entry in the vector will invalidate any references since the storage vector is reordered.

#### Summary of Changes

1. Use a HashMap to track storage.
2. storing the accounts acquires an exclusive storage entry for a single batch, which should remove some write contention

not sure why this fails in CI @rob-solana, locally it runs fine

```
running 1 test
test blocktree_processor::tests::test_process_ledger_simple ... ok
```
Fixes #
