### PR TITLE
Start bench tps clients as default

### DIFF
--- a/net/net.sh
+++ b/net/net.sh
@@ -167,6 +167,7 @@ numClients=${#clientIpList[@]}
 numClientsRequested=$((numBenchTpsClients+numBenchExchangeClients))
 if [[ "$numClientsRequested" -eq 0 ]]; then
   numBenchTpsClients=$numClients
+  numClientsRequested=$((numBenchTpsClients+numBenchExchangeClients))
 else
   if [[ "$numClientsRequested" -gt "$numClients" ]]; then
     echo "Error: More clients requested ($numClientsRequested) then available ($numClients)"


### PR DESCRIPTION
#### Problem
The bench tps clients are not getting started.

#### Summary of Changes
The total number of clients were not calculated when -c option was not provided.