### PR TITLE
Cleanup bench-exchange

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2417,6 +2417,7 @@ dependencies = [
  "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-logger 0.14.0",
+ "solana-metrics 0.14.0",
  "solana-runtime 0.14.0",
  "solana-sdk 0.14.0",
 ]

--- a/bench-exchange/src/bench.rs
+++ b/bench-exchange/src/bench.rs
@@ -259,15 +259,16 @@ fn sample_tx_count<T>(
     let first_tx_count = initial_tx_count;
 
     loop {
-        let tx_count = client.get_transaction_count().expect("transaction count");
+        let mut tx_count = client.get_transaction_count().expect("transaction count");
         let duration = now.elapsed();
         now = Instant::now();
-        assert!(
-            tx_count >= initial_tx_count,
-            "expected tx_count({}) >= initial_tx_count({})",
-            tx_count,
-            initial_tx_count
-        );
+        if tx_count < initial_tx_count {
+            println!(
+                "expected tx_count({}) >= initial_tx_count({})",
+                tx_count, initial_tx_count
+            );
+            tx_count = initial_tx_count;
+        }
         let sample = tx_count - initial_tx_count;
         initial_tx_count = tx_count;
 
@@ -725,7 +726,7 @@ where
     for s in &tx.signatures {
         if let Ok(Some(r)) = sync_client.get_signature_status(s) {
             match r {
-                Ok(x) => {
+                Ok(_) => {
                     return true;
                 }
                 Err(e) => {

--- a/bench-exchange/src/bench.rs
+++ b/bench-exchange/src/bench.rs
@@ -507,6 +507,13 @@ fn swapper<T>(
             }
             trace!("  sw {:?} signed   {:.2} /s ", n, rate);
 
+            solana_metrics::submit(
+                influxdb::Point::new("bench-exchange")
+                    .add_tag("op", influxdb::Value::String("swaps".to_string()))
+                    .add_field("count", influxdb::Value::Integer(to_swap_txs.len() as i64))
+                    .to_owned(),
+            );
+
             let chunks: Vec<_> = to_swap_txs.chunks(CHUNK_LEN).collect();
             {
                 let mut shared_txs_wl = shared_txs.write().unwrap();
@@ -664,6 +671,13 @@ fn trader<T>(
             }
             trace!("  sw {:?} signed   {:.2} /s ", n, rate);
 
+            solana_metrics::submit(
+                influxdb::Point::new("bench-exchange")
+                    .add_tag("op", influxdb::Value::String("trades".to_string()))
+                    .add_field("count", influxdb::Value::Integer(trades_txs.len() as i64))
+                    .to_owned(),
+            );
+
             let chunks: Vec<_> = trades_txs.chunks(CHUNK_LEN).collect();
             {
                 let mut shared_txs_wl = shared_txs
@@ -709,8 +723,15 @@ where
     T: SyncClient + ?Sized,
 {
     for s in &tx.signatures {
-        if let Ok(Some(_)) = sync_client.get_signature_status(s) {
-            return true;
+        if let Ok(Some(r)) = sync_client.get_signature_status(s) {
+            match r {
+                Ok(x) => {
+                    return true;
+                }
+                Err(e) => {
+                    info!("error: {:?}", e);
+                }
+            }
         }
     }
     false
@@ -799,7 +820,7 @@ pub fn fund_keys(client: &Client, source: &Keypair, dests: &[Arc<Keypair>], lamp
 
                 let mut waits = 0;
                 loop {
-                    sleep(Duration::from_millis(50));
+                    sleep(Duration::from_millis(200));
                     to_fund_txs.retain(|(_, tx)| !verify_transfer(client, &tx));
                     if to_fund_txs.is_empty() {
                         break;
@@ -877,7 +898,7 @@ pub fn create_token_accounts(client: &Client, signers: &[Arc<Keypair>], accounts
 
                 let mut waits = 0;
                 while !to_create_txs.is_empty() {
-                    sleep(Duration::from_millis(50));
+                    sleep(Duration::from_millis(200));
                     to_create_txs.retain(|(_, tx)| !verify_transfer(client, &tx));
                     if to_create_txs.is_empty() {
                         break;
@@ -896,7 +917,7 @@ pub fn create_token_accounts(client: &Client, signers: &[Arc<Keypair>], accounts
                 if !to_create_txs.is_empty() {
                     retries += 1;
                     debug!("  Retry {:?}", retries);
-                    if retries >= 10 {
+                    if retries >= 20 {
                         error!("  Too many retries, give up");
                         exit(1);
                     }
@@ -969,7 +990,7 @@ fn generate_keypairs(num: u64) -> Vec<Keypair> {
 pub fn airdrop_lamports(client: &Client, drone_addr: &SocketAddr, id: &Keypair, amount: u64) {
     let balance = client.get_balance(&id.pubkey());
     let balance = balance.unwrap_or(0);
-    if balance > amount {
+    if balance >= amount {
         return;
     }
 
@@ -991,7 +1012,13 @@ pub fn airdrop_lamports(client: &Client, drone_addr: &SocketAddr, id: &Keypair, 
             Ok(transaction) => {
                 let signature = client.async_send_transaction(transaction).unwrap();
 
-                if let Ok(Some(_)) = client.get_signature_status(&signature) {
+                for _ in 0..30 {
+                    if let Ok(Some(_)) = client.get_signature_status(&signature) {
+                        break;
+                    }
+                    sleep(Duration::from_millis(100));
+                }
+                if client.get_balance(&id.pubkey()).unwrap_or(0) >= amount {
                     break;
                 }
             }
@@ -1008,6 +1035,7 @@ pub fn airdrop_lamports(client: &Client, drone_addr: &SocketAddr, id: &Keypair, 
             error!("Too many retries, give up");
             exit(1);
         }
+        sleep(Duration::from_secs(2));
     }
 }
 

--- a/bench-exchange/src/main.rs
+++ b/bench-exchange/src/main.rs
@@ -9,6 +9,7 @@ use solana_sdk::signature::KeypairUtil;
 
 fn main() {
     solana_logger::setup();
+    solana_metrics::set_panic_hook("bench-exchange");
 
     let matches = cli::build_args().get_matches();
     let cli_config = cli::extract_args(&matches);

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -547,7 +547,7 @@ impl BankingStage {
             timing::duration_as_ms(&recv_start.elapsed()),
             count,
         );
-        inc_new_counter_info!("banking_stage-entries_received", mms_len);
+        inc_new_counter_info!("banking_stage-transactions_received", count);
         let proc_start = Instant::now();
         let mut new_tx_count = 0;
 

--- a/net/remote/remote-client.sh
+++ b/net/remote/remote-client.sh
@@ -62,11 +62,16 @@ solana-bench-tps)
   "
   ;;
 solana-bench-exchange)
+  solana-keygen -o bench.keypair
   clientCommand="\
     solana-bench-exchange \
       --network $entrypointIp:8001 \
       --drone $entrypointIp:9900 \
       --threads $threadCount \
+      --batch-size 1000 \
+      --fund-amount 20000 \
+      --duration 7500 \
+      --identity bench.keypair \
   "
   ;;
 *)

--- a/programs/exchange_api/Cargo.toml
+++ b/programs/exchange_api/Cargo.toml
@@ -15,6 +15,7 @@ serde = "1.0.90"
 serde_derive = "1.0.90"
 solana-logger = { path = "../../logger", version = "0.14.0" }
 solana-sdk = { path = "../../sdk", version = "0.14.0" }
+solana-metrics = { path = "../../metrics", version = "0.14.0" }
 
 [dev-dependencies]
 solana-runtime = { path = "../../runtime", version = "0.14.0" }

--- a/programs/exchange_api/src/exchange_processor.rs
+++ b/programs/exchange_api/src/exchange_processor.rs
@@ -4,6 +4,7 @@ use crate::exchange_instruction::*;
 use crate::exchange_state::*;
 use crate::id;
 use log::*;
+use solana_metrics::counter::Counter;
 use solana_sdk::account::KeyedAccount;
 use solana_sdk::instruction::InstructionError;
 use solana_sdk::pubkey::Pubkey;
@@ -256,6 +257,8 @@ impl ExchangeProcessor {
         // Trade holds the tokens in escrow
         account.tokens[from_token] -= info.tokens;
 
+        inc_new_counter_info!("exchange_processor-trades", 1);
+
         Self::serialize(
             &ExchangeState::Trade(TradeOrderInfo {
                 owner: *keyed_accounts[OWNER_INDEX].unsigned_key(),
@@ -385,6 +388,8 @@ impl ExchangeProcessor {
             );
             Err(e)?
         }
+
+        inc_new_counter_info!("exchange_processor-swap", 1);
 
         Self::serialize(
             &ExchangeState::Swap(swap),

--- a/programs/exchange_api/src/lib.rs
+++ b/programs/exchange_api/src/lib.rs
@@ -2,6 +2,9 @@ pub mod exchange_instruction;
 pub mod exchange_processor;
 pub mod exchange_state;
 
+#[macro_use]
+extern crate solana_metrics;
+
 use solana_sdk::pubkey::Pubkey;
 
 pub const EXCHANGE_PROGRAM_ID: [u8; 32] = [


### PR DESCRIPTION
#### Problems

* Each bench-exchange client needs a new keypair for multiple client run.
* No bench-exchange swapper/trader bench-exchange metrics.
* Some network operations don't wait long enough for the network to complete and don't succeed regularly.

#### Summary of Changes

* Generate new keypair for each bench-exchange
* Add metrics
* Tweak network sleep parameters for better reliability.

