### PR TITLE
Add stop node command to solana-gossip

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2483,6 +2483,7 @@ dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana 0.14.0",
+ "solana-client 0.14.0",
  "solana-netutil 0.14.0",
  "solana-sdk 0.14.0",
 ]

--- a/book/src/testnet-participation.md
+++ b/book/src/testnet-participation.md
@@ -41,7 +41,7 @@ Inspect the blockexplorer at [http://beta.testnet.solana.com/](http://beta.testn
 
 Run the following command to join the gossip network and view all the other nodes in the cluster:
 ```bash
-$ solana-gossip --network beta.testnet.solana.com:8001
+$ solana-gossip --network beta.testnet.solana.com:8001 spy
 ```
 
 View the [metrics dashboard](

--- a/ci/localnet-sanity.sh
+++ b/ci/localnet-sanity.sh
@@ -306,8 +306,7 @@ while [[ $iteration -le $iterations ]]; do
     set -x
     client_id=/tmp/client-id.json-$$
     $solana_keygen -o $client_id || exit $?
-    $solana_gossip \
-      --num-nodes-exactly $numNodes || exit $?
+    $solana_gossip spy --num-nodes-exactly $numNodes || exit $?
     rm -rf $client_id
   ) || flag_error
 

--- a/gossip/Cargo.toml
+++ b/gossip/Cargo.toml
@@ -12,6 +12,7 @@ homepage = "https://solana.com/"
 clap = "2.33.0"
 env_logger = "0.6.1"
 solana = { path = "../core", version = "0.14.0" }
+solana-client = { path = "../client", version = "0.14.0"  }
 solana-netutil = { path = "../netutil", version = "0.14.0" }
 solana-sdk = { path = "../sdk", version = "0.14.0" }
 

--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -81,12 +81,13 @@ local|tar)
     fi
     ./multinode-demo/drone.sh > drone.log 2>&1 &
 
-    maybePublicAddress=
+    args=()
     if $publicNetwork; then
-      maybePublicAddress="--public-address"
+      args+=(--public-address)
     fi
+    args+=(--enable-rpc-exit)
 
-    ./multinode-demo/bootstrap-leader.sh $maybePublicAddress > bootstrap-leader.log 2>&1 &
+    ./multinode-demo/bootstrap-leader.sh "${args[@]}" > bootstrap-leader.log 2>&1 &
     ln -sTf bootstrap-leader.log fullnode.log
     ;;
   fullnode|blockstreamer)
@@ -116,6 +117,7 @@ local|tar)
     fi
 
     args+=(
+      --enable-rpc-exit
       --gossip-port 8001
       --rpc-port 8899
     )
@@ -147,7 +149,9 @@ local|tar)
       # Confirm the blockexplorer is now globally accessible
       curl --head "$(curl ifconfig.io)"
     fi
-    ./multinode-demo/fullnode.sh "${args[@]}" "$entrypointIp":~/solana "$entrypointIp:8001" > fullnode.log 2>&1 &
+
+    args+=("$entrypointIp":~/solana "$entrypointIp:8001")
+    ./multinode-demo/fullnode.sh "${args[@]}" > fullnode.log 2>&1 &
     ;;
   *)
     echo "Error: unknown node type: $nodeType"

--- a/net/remote/remote-sanity.sh
+++ b/net/remote/remote-sanity.sh
@@ -89,9 +89,8 @@ echo "+++ $entrypointIp: node count ($numNodes expected)"
     nodeArg="num-nodes-exactly"
   fi
 
-  timeout 2m $solana_gossip \
-    --network "$entrypointIp:8001" \
-    --$nodeArg "$numNodes" \
+  timeout 2m $solana_gossip --network "$entrypointIp:8001" \
+    spy --$nodeArg "$numNodes" \
 )
 
 echo "--- RPC API: getTransactionCount"


### PR DESCRIPTION
#### Problem
We don't have a nice way to kill nodes on demand

#### Summary of Changes
If a node has been started with `--enable-rpc-exit`, the `solana-gossip stop <pubkey>` command can now be used to request that the node exit.

To make room for this new command, the previous `solana-gossip` behaviour has been moved under a new `solana-gossip spy` subcommand.

Part of #3879
