### PR TITLE
Generify streamer, recvmmsg, and aspects of `Packet` and `Blob`

### DIFF
--- a/core/src/recvmmsg.rs
+++ b/core/src/recvmmsg.rs
@@ -1,14 +1,24 @@
 //! The `recvmmsg` module provides recvmmsg() API implementation
 
-use crate::packet::Packet;
+use crate::packet::Meta;
 use std::cmp;
 use std::io;
 use std::net::UdpSocket;
 
 pub const NUM_RCVMMSGS: usize = 16;
 
+pub trait RecvM: Clone + Default {
+    const CAPACITY: usize;
+
+    fn meta(&self) -> &Meta;
+    fn meta_mut(&mut self) -> &mut Meta;
+
+    fn content(&self) -> &[u8];
+    fn content_mut(&mut self) -> &mut [u8];
+}
+
 #[cfg(not(target_os = "linux"))]
-pub fn recv_mmsg(socket: &UdpSocket, packets: &mut [Packet]) -> io::Result<usize> {
+pub fn recv_mmsg<M: RecvM>(socket: &UdpSocket, packets: &mut [M]) -> io::Result<usize> {
     let mut i = 0;
     let count = cmp::min(NUM_RCVMMSGS, packets.len());
     for p in packets.iter_mut().take(count) {
@@ -34,7 +44,7 @@ pub fn recv_mmsg(socket: &UdpSocket, packets: &mut [Packet]) -> io::Result<usize
 }
 
 #[cfg(target_os = "linux")]
-pub fn recv_mmsg(sock: &UdpSocket, packets: &mut [Packet]) -> io::Result<usize> {
+pub fn recv_mmsg<M: RecvM>(sock: &UdpSocket, packets: &mut [M]) -> io::Result<usize> {
     use libc::{
         c_void, iovec, mmsghdr, recvmmsg, sockaddr_in, socklen_t, time_t, timespec, MSG_WAITFORONE,
     };
@@ -52,8 +62,8 @@ pub fn recv_mmsg(sock: &UdpSocket, packets: &mut [Packet]) -> io::Result<usize> 
     let count = cmp::min(iovs.len(), packets.len());
 
     for i in 0..count {
-        iovs[i].iov_base = packets[i].data.as_mut_ptr() as *mut c_void;
-        iovs[i].iov_len = packets[i].data.len();
+        iovs[i].iov_base = packets[i].content_mut().as_mut_ptr() as *mut c_void;
+        iovs[i].iov_len = packets[i].content().len();
 
         hdrs[i].msg_hdr.msg_name = &mut addr[i] as *mut _ as *mut _;
         hdrs[i].msg_hdr.msg_namelen = addrlen;
@@ -70,10 +80,10 @@ pub fn recv_mmsg(sock: &UdpSocket, packets: &mut [Packet]) -> io::Result<usize> 
             -1 => return Err(io::Error::last_os_error()),
             n => {
                 for i in 0..n as usize {
-                    let mut p = &mut packets[i];
-                    p.meta.size = hdrs[i].msg_len as usize;
+                    let meta = packets[i].meta_mut();
+                    meta.size = hdrs[i].msg_len as usize;
                     let inet_addr = InetAddr::V4(addr[i]);
-                    p.meta.set_addr(&inet_addr.to_std());
+                    meta.set_addr(&inet_addr.to_std());
                 }
                 n as usize
             }
@@ -84,129 +94,150 @@ pub fn recv_mmsg(sock: &UdpSocket, packets: &mut [Packet]) -> io::Result<usize> 
 
 #[cfg(test)]
 mod tests {
-    use crate::packet::PACKET_DATA_SIZE;
+    use crate::packet::{Blob, Packet};
     use crate::recvmmsg::*;
     use std::time::{Duration, Instant};
 
     #[test]
     pub fn test_recv_mmsg_one_iter() {
-        let reader = UdpSocket::bind("127.0.0.1:0").expect("bind");
-        let addr = reader.local_addr().unwrap();
-        let sender = UdpSocket::bind("127.0.0.1:0").expect("bind");
-        let saddr = sender.local_addr().unwrap();
-        let sent = NUM_RCVMMSGS - 1;
-        for _ in 0..sent {
-            let data = [0; PACKET_DATA_SIZE];
-            sender.send_to(&data[..], &addr).unwrap();
+        fn helper<M: RecvM>() {
+            let reader = UdpSocket::bind("127.0.0.1:0").expect("bind");
+            let addr = reader.local_addr().unwrap();
+            let sender = UdpSocket::bind("127.0.0.1:0").expect("bind");
+            let saddr = sender.local_addr().unwrap();
+            let sent = NUM_RCVMMSGS - 1;
+
+            for _ in 0..sent {
+                let data = vec![0; M::CAPACITY];
+                sender.send_to(&data[..], &addr).unwrap();
+            }
+
+            let mut packets = vec![M::default(); NUM_RCVMMSGS];
+            let recv = recv_mmsg(&reader, &mut packets[..]).unwrap();
+            assert_eq!(sent, recv);
+            for i in 0..recv {
+                assert_eq!(packets[i].meta().size, M::CAPACITY);
+                assert_eq!(packets[i].meta().addr(), saddr);
+            }
         }
 
-        let mut packets = vec![Packet::default(); NUM_RCVMMSGS];
-        let recv = recv_mmsg(&reader, &mut packets[..]).unwrap();
-        assert_eq!(sent, recv);
-        for i in 0..recv {
-            assert_eq!(packets[i].meta.size, PACKET_DATA_SIZE);
-            assert_eq!(packets[i].meta.addr(), saddr);
-        }
+        helper::<Packet>();
+        helper::<Blob>();
     }
 
     #[test]
     pub fn test_recv_mmsg_multi_iter() {
-        let reader = UdpSocket::bind("127.0.0.1:0").expect("bind");
-        let addr = reader.local_addr().unwrap();
-        let sender = UdpSocket::bind("127.0.0.1:0").expect("bind");
-        let saddr = sender.local_addr().unwrap();
-        let sent = NUM_RCVMMSGS + 10;
-        for _ in 0..sent {
-            let data = [0; PACKET_DATA_SIZE];
-            sender.send_to(&data[..], &addr).unwrap();
+        fn helper<M: RecvM>() {
+            let reader = UdpSocket::bind("127.0.0.1:0").expect("bind");
+            let addr = reader.local_addr().unwrap();
+            let sender = UdpSocket::bind("127.0.0.1:0").expect("bind");
+            let saddr = sender.local_addr().unwrap();
+            let sent = NUM_RCVMMSGS + 10;
+            for _ in 0..sent {
+                let data = vec![0; M::CAPACITY];
+                sender.send_to(&data[..], &addr).unwrap();
+            }
+
+            let mut packets = vec![M::default(); NUM_RCVMMSGS * 2];
+            let recv = recv_mmsg(&reader, &mut packets[..]).unwrap();
+            assert_eq!(NUM_RCVMMSGS, recv);
+            for i in 0..recv {
+                assert_eq!(packets[i].meta().size, M::CAPACITY);
+                assert_eq!(packets[i].meta().addr(), saddr);
+            }
+
+            let recv = recv_mmsg(&reader, &mut packets[..]).unwrap();
+            assert_eq!(sent - NUM_RCVMMSGS, recv);
+            for i in 0..recv {
+                assert_eq!(packets[i].meta().size, M::CAPACITY);
+                assert_eq!(packets[i].meta().addr(), saddr);
+            }
         }
 
-        let mut packets = vec![Packet::default(); NUM_RCVMMSGS * 2];
-        let recv = recv_mmsg(&reader, &mut packets[..]).unwrap();
-        assert_eq!(NUM_RCVMMSGS, recv);
-        for i in 0..recv {
-            assert_eq!(packets[i].meta.size, PACKET_DATA_SIZE);
-            assert_eq!(packets[i].meta.addr(), saddr);
-        }
-
-        let recv = recv_mmsg(&reader, &mut packets[..]).unwrap();
-        assert_eq!(sent - NUM_RCVMMSGS, recv);
-        for i in 0..recv {
-            assert_eq!(packets[i].meta.size, PACKET_DATA_SIZE);
-            assert_eq!(packets[i].meta.addr(), saddr);
-        }
+        helper::<Packet>();
+        helper::<Blob>();
     }
 
     #[test]
     pub fn test_recv_mmsg_multi_iter_timeout() {
-        let reader = UdpSocket::bind("127.0.0.1:0").expect("bind");
-        let addr = reader.local_addr().unwrap();
-        reader.set_read_timeout(Some(Duration::new(5, 0))).unwrap();
-        reader.set_nonblocking(false).unwrap();
-        let sender = UdpSocket::bind("127.0.0.1:0").expect("bind");
-        let saddr = sender.local_addr().unwrap();
-        let sent = NUM_RCVMMSGS;
-        for _ in 0..sent {
-            let data = [0; PACKET_DATA_SIZE];
-            sender.send_to(&data[..], &addr).unwrap();
+        fn helper<M: RecvM>() {
+            let reader = UdpSocket::bind("127.0.0.1:0").expect("bind");
+            let addr = reader.local_addr().unwrap();
+            reader.set_read_timeout(Some(Duration::new(5, 0))).unwrap();
+            reader.set_nonblocking(false).unwrap();
+            let sender = UdpSocket::bind("127.0.0.1:0").expect("bind");
+            let saddr = sender.local_addr().unwrap();
+            let sent = NUM_RCVMMSGS;
+            for _ in 0..sent {
+                let data = vec![0; M::CAPACITY];
+                sender.send_to(&data[..], &addr).unwrap();
+            }
+
+            let start = Instant::now();
+            let mut packets = vec![M::default(); NUM_RCVMMSGS * 2];
+            let recv = recv_mmsg(&reader, &mut packets[..]).unwrap();
+            assert_eq!(NUM_RCVMMSGS, recv);
+            for i in 0..recv {
+                assert_eq!(packets[i].meta().size, M::CAPACITY);
+                assert_eq!(packets[i].meta().addr(), saddr);
+            }
+            reader.set_nonblocking(true).unwrap();
+
+            let _recv = recv_mmsg(&reader, &mut packets[..]);
+            assert!(start.elapsed().as_secs() < 5);
         }
 
-        let start = Instant::now();
-        let mut packets = vec![Packet::default(); NUM_RCVMMSGS * 2];
-        let recv = recv_mmsg(&reader, &mut packets[..]).unwrap();
-        assert_eq!(NUM_RCVMMSGS, recv);
-        for i in 0..recv {
-            assert_eq!(packets[i].meta.size, PACKET_DATA_SIZE);
-            assert_eq!(packets[i].meta.addr(), saddr);
-        }
-        reader.set_nonblocking(true).unwrap();
-
-        let _recv = recv_mmsg(&reader, &mut packets[..]);
-        assert!(start.elapsed().as_secs() < 5);
+        helper::<Packet>();
+        helper::<Blob>();
     }
 
     #[test]
     pub fn test_recv_mmsg_multi_addrs() {
-        let reader = UdpSocket::bind("127.0.0.1:0").expect("bind");
-        let addr = reader.local_addr().unwrap();
+        fn helper<M: RecvM>() {
+            let reader = UdpSocket::bind("127.0.0.1:0").expect("bind");
+            let addr = reader.local_addr().unwrap();
 
-        let sender1 = UdpSocket::bind("127.0.0.1:0").expect("bind");
-        let saddr1 = sender1.local_addr().unwrap();
-        let sent1 = NUM_RCVMMSGS - 1;
+            let sender1 = UdpSocket::bind("127.0.0.1:0").expect("bind");
+            let saddr1 = sender1.local_addr().unwrap();
+            let sent1 = NUM_RCVMMSGS - 1;
 
-        let sender2 = UdpSocket::bind("127.0.0.1:0").expect("bind");
-        let saddr2 = sender2.local_addr().unwrap();
-        let sent2 = NUM_RCVMMSGS + 1;
+            let sender2 = UdpSocket::bind("127.0.0.1:0").expect("bind");
+            let saddr2 = sender2.local_addr().unwrap();
+            let sent2 = NUM_RCVMMSGS + 1;
 
-        for _ in 0..sent1 {
-            let data = [0; PACKET_DATA_SIZE];
-            sender1.send_to(&data[..], &addr).unwrap();
+            for _ in 0..sent1 {
+                let data = vec![0; M::CAPACITY];
+                sender1.send_to(&data[..], &addr).unwrap();
+            }
+
+            for _ in 0..sent2 {
+                let data = vec![0; M::CAPACITY];
+                sender2.send_to(&data[..], &addr).unwrap();
+            }
+
+            let mut packets = vec![M::default(); NUM_RCVMMSGS * 2];
+
+            let recv = recv_mmsg(&reader, &mut packets[..]).unwrap();
+            assert_eq!(NUM_RCVMMSGS, recv);
+            for i in 0..sent1 {
+                assert_eq!(packets[i].meta().size, M::CAPACITY);
+                assert_eq!(packets[i].meta().addr(), saddr1);
+            }
+
+            for i in sent1..recv {
+                assert_eq!(packets[i].meta().size, M::CAPACITY);
+                assert_eq!(packets[i].meta().addr(), saddr2);
+            }
+
+            let recv = recv_mmsg(&reader, &mut packets[..]).unwrap();
+            assert_eq!(sent1 + sent2 - NUM_RCVMMSGS, recv);
+            for i in 0..recv {
+                assert_eq!(packets[i].meta().size, M::CAPACITY);
+                assert_eq!(packets[i].meta().addr(), saddr2);
+            }
         }
 
-        for _ in 0..sent2 {
-            let data = [0; PACKET_DATA_SIZE];
-            sender2.send_to(&data[..], &addr).unwrap();
-        }
-
-        let mut packets = vec![Packet::default(); NUM_RCVMMSGS * 2];
-
-        let recv = recv_mmsg(&reader, &mut packets[..]).unwrap();
-        assert_eq!(NUM_RCVMMSGS, recv);
-        for i in 0..sent1 {
-            assert_eq!(packets[i].meta.size, PACKET_DATA_SIZE);
-            assert_eq!(packets[i].meta.addr(), saddr1);
-        }
-
-        for i in sent1..recv {
-            assert_eq!(packets[i].meta.size, PACKET_DATA_SIZE);
-            assert_eq!(packets[i].meta.addr(), saddr2);
-        }
-
-        let recv = recv_mmsg(&reader, &mut packets[..]).unwrap();
-        assert_eq!(sent1 + sent2 - NUM_RCVMMSGS, recv);
-        for i in 0..recv {
-            assert_eq!(packets[i].meta.size, PACKET_DATA_SIZE);
-            assert_eq!(packets[i].meta.addr(), saddr2);
-        }
+        helper::<Packet>();
+        helper::<Blob>();
     }
 }

--- a/core/src/replicator.rs
+++ b/core/src/replicator.rs
@@ -5,7 +5,7 @@ use crate::chacha::{chacha_cbc_encrypt_ledger, CHACHA_BLOCK_SIZE};
 use crate::cluster_info::{ClusterInfo, Node, FULLNODE_PORT_RANGE};
 use crate::contact_info::ContactInfo;
 use crate::gossip_service::GossipService;
-use crate::packet::to_shared_blob;
+use crate::packet::{to_shared_blob, Packets};
 use crate::repair_service::RepairSlotRange;
 use crate::result::Result;
 use crate::service::Service;
@@ -129,7 +129,7 @@ fn create_request_processor(
     let (s_reader, r_reader) = channel();
     let (s_responder, r_responder) = channel();
     let storage_socket = Arc::new(socket);
-    let t_receiver = receiver(storage_socket.clone(), exit, s_reader);
+    let t_receiver = receiver::<Packets>(storage_socket.clone(), exit, s_reader);
     thread_handles.push(t_receiver);
 
     let t_responder = responder("replicator-responder", storage_socket.clone(), r_responder);

--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -333,7 +333,11 @@ mod test {
             let blob_sockets: Vec<Arc<UdpSocket>> =
                 leader_node.sockets.tvu.into_iter().map(Arc::new).collect();
 
-            let t_responder = responder("window_send_test", blob_sockets[0].clone(), r_responder);
+            let t_responder = responder::<Vec<SharedBlob>>(
+                "window_send_test",
+                blob_sockets[0].clone(),
+                r_responder,
+            );
             let num_blobs_to_make = 10;
             let gossip_address = &leader_node.info.gossip;
             let msgs = make_consecutive_blobs(


### PR DESCRIPTION
#### Problem
`Blob`s and `Packet`s share a lot of functionality and have  essentially duplicate code in many places that could have the same implementation.

#### Summary of Changes
Create a `RecvM` trait, implement it for Blobs and Packets, and use it in `solana::recvmmsg`.
Create `Message` and `Mailbox` traits.
Implement `Message` for `Blob`, `Packet`, and `Arc<RwLock<T>> where T: Message`.
Implement `Mailbox` for `Packets` and `Vec<T> where T: Message`.

Fixes #2762
