### PR TITLE
Default to Docker based testnet deployment on unsupported Ubuntu versions

### DIFF
--- a/net/net.sh
+++ b/net/net.sh
@@ -178,7 +178,7 @@ fi
 build() {
   supported=("18.04")
   declare MAYBE_DOCKER=
-  if [[ $(uname) != Linux || ! " ${supported[@]} " =~ " $(lsb_release -sr) " ]]; then
+  if [[ $(uname) != Linux || ! " ${supported[*]} " =~ $(lsb_release -sr) ]]; then
     # shellcheck source=ci/rust-version.sh
     source "$SOLANA_ROOT"/ci/rust-version.sh
     MAYBE_DOCKER="ci/docker-run.sh $rust_stable_docker_image"

--- a/net/net.sh
+++ b/net/net.sh
@@ -176,8 +176,9 @@ else
 fi
 
 build() {
+  supported=("18.04")
   declare MAYBE_DOCKER=
-  if [[ $(uname) != Linux ]]; then
+  if [[ $(uname) != Linux || ! " ${supported[@]} " =~ " $(lsb_release -sr) " ]]; then
     # shellcheck source=ci/rust-version.sh
     source "$SOLANA_ROOT"/ci/rust-version.sh
     MAYBE_DOCKER="ci/docker-run.sh $rust_stable_docker_image"


### PR DESCRIPTION
#### Problem

Testnet deployment fails on some Ubuntu versions because local tooling can differ from what the cloud machines use.

#### Summary of Changes

Added a check to default to Docker based deployment if running on unsupported Ubuntu versions. Current "list" of supported versions is Ubuntu 18.04 only.

