### PR TITLE
Fix Retransmit slamming the leader with its own blobs

### DIFF
--- a/core/src/replicator.rs
+++ b/core/src/replicator.rs
@@ -235,6 +235,7 @@ impl Replicator {
 
         let window_service = WindowService::new(
             None, //TODO: need a way to validate blobs... https://github.com/solana-labs/solana/issues/3924
+            None,
             blocktree.clone(),
             cluster_info.clone(),
             blob_fetch_receiver,

--- a/core/src/replicator.rs
+++ b/core/src/replicator.rs
@@ -235,7 +235,7 @@ impl Replicator {
 
         let window_service = WindowService::new(
             None, //TODO: need a way to validate blobs... https://github.com/solana-labs/solana/issues/3924
-            None,
+            None, //TODO: see above ^
             blocktree.clone(),
             cluster_info.clone(),
             blob_fetch_receiver,

--- a/core/src/retransmit_stage.rs
+++ b/core/src/retransmit_stage.rs
@@ -5,6 +5,7 @@ use crate::blocktree::Blocktree;
 use crate::cluster_info::{
     compute_retransmit_peers, ClusterInfo, GROW_LAYER_CAPACITY, NEIGHBORHOOD_SIZE,
 };
+use crate::leader_schedule_cache::LeaderScheduleCache;
 use crate::result::{Error, Result};
 use crate::service::Service;
 use crate::staking_utils;
@@ -22,19 +23,20 @@ use std::time::Duration;
 
 fn retransmit(
     bank_forks: &Arc<RwLock<BankForks>>,
+    leader_schedule_cache: &Arc<LeaderScheduleCache>,
     cluster_info: &Arc<RwLock<ClusterInfo>>,
     r: &BlobReceiver,
     sock: &UdpSocket,
 ) -> Result<()> {
     let timer = Duration::new(1, 0);
-    let mut dq = r.recv_timeout(timer)?;
+    let mut blobs = r.recv_timeout(timer)?;
     while let Ok(mut nq) = r.try_recv() {
-        dq.append(&mut nq);
+        blobs.append(&mut nq);
     }
 
     submit(
         influxdb::Point::new("retransmit-stage")
-            .add_field("count", influxdb::Value::Integer(dq.len() as i64))
+            .add_field("count", influxdb::Value::Integer(blobs.len() as i64))
             .to_owned(),
     );
     let r_bank = bank_forks.read().unwrap().working_bank();
@@ -46,12 +48,14 @@ fn retransmit(
         NEIGHBORHOOD_SIZE,
         GROW_LAYER_CAPACITY,
     );
-    for b in &dq {
-        if b.read().unwrap().meta.forward {
-            ClusterInfo::retransmit_to(&cluster_info, &neighbors, b, sock, true)?;
-            ClusterInfo::retransmit_to(&cluster_info, &children, b, sock, false)?;
+    for blob in &blobs {
+        let leader = leader_schedule_cache
+            .slot_leader_at_else_compute(blob.read().unwrap().slot(), r_bank.as_ref());
+        if blob.read().unwrap().meta.forward {
+            ClusterInfo::retransmit_to(&cluster_info, &neighbors, blob, leader, sock, true)?;
+            ClusterInfo::retransmit_to(&cluster_info, &children, blob, leader, sock, false)?;
         } else {
-            ClusterInfo::retransmit_to(&cluster_info, &children, b, sock, true)?;
+            ClusterInfo::retransmit_to(&cluster_info, &children, blob, leader, sock, true)?;
         }
     }
     Ok(())
@@ -68,16 +72,24 @@ fn retransmit(
 fn retransmitter(
     sock: Arc<UdpSocket>,
     bank_forks: Arc<RwLock<BankForks>>,
+    leader_schedule_cache: &Arc<LeaderScheduleCache>,
     cluster_info: Arc<RwLock<ClusterInfo>>,
     r: BlobReceiver,
 ) -> JoinHandle<()> {
     let bank_forks = bank_forks.clone();
+    let leader_schedule_cache = leader_schedule_cache.clone();
     Builder::new()
         .name("solana-retransmitter".to_string())
         .spawn(move || {
             trace!("retransmitter started");
             loop {
-                if let Err(e) = retransmit(&bank_forks, &cluster_info, &r, &sock) {
+                if let Err(e) = retransmit(
+                    &bank_forks,
+                    &leader_schedule_cache,
+                    &cluster_info,
+                    &r,
+                    &sock,
+                ) {
                     match e {
                         Error::RecvTimeoutError(RecvTimeoutError::Disconnected) => break,
                         Error::RecvTimeoutError(RecvTimeoutError::Timeout) => (),
@@ -101,6 +113,7 @@ impl RetransmitStage {
     #[allow(clippy::new_ret_no_self)]
     pub fn new(
         bank_forks: Arc<RwLock<BankForks>>,
+        leader_schedule_cache: &Arc<LeaderScheduleCache>,
         blocktree: Arc<Blocktree>,
         cluster_info: &Arc<RwLock<ClusterInfo>>,
         retransmit_socket: Arc<UdpSocket>,
@@ -113,11 +126,13 @@ impl RetransmitStage {
         let t_retransmit = retransmitter(
             retransmit_socket,
             bank_forks.clone(),
+            leader_schedule_cache,
             cluster_info.clone(),
             retransmit_receiver,
         );
         let window_service = WindowService::new(
             Some(bank_forks),
+            Some(leader_schedule_cache.clone()),
             blocktree,
             cluster_info.clone(),
             fetch_stage_receiver,

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -103,6 +103,7 @@ impl Tvu {
         //then sent to the window, which does the erasure coding reconstruction
         let retransmit_stage = RetransmitStage::new(
             bank_forks.clone(),
+            leader_schedule_cache,
             blocktree.clone(),
             &cluster_info,
             Arc::new(retransmit_socket),

--- a/core/tests/gossip.rs
+++ b/core/tests/gossip.rs
@@ -176,7 +176,8 @@ pub fn cluster_info_retransmit() -> result::Result<()> {
     assert!(done);
     let b = SharedBlob::default();
     b.write().unwrap().meta.size = 10;
-    ClusterInfo::retransmit(&c1, &b, &tn1, false)?;
+    let peers = c1.read().unwrap().retransmit_peers();
+    ClusterInfo::retransmit_to(&c1, &peers, &b, None, &tn1, false)?;
     let res: Vec<_> = [tn1, tn2, tn3]
         .into_par_iter()
         .map(|s| {


### PR DESCRIPTION
#### Problem

Nodes currently do not refrain from sending a blob received via broadcast, back to the leader that sent them. This can lead to all the broadcasted blobs coming right back to the leader's tvu.

#### Summary of Changes

Filter the blob's slot leader from retransmit.

