### PR TITLE
Add getClusterNodes/getSlotLeader JSON RPC API

### DIFF
--- a/book/src/jsonrpc-api.md
+++ b/book/src/jsonrpc-api.md
@@ -24,8 +24,10 @@ Methods
 * [confirmTransaction](#confirmtransaction)
 * [getAccountInfo](#getaccountinfo)
 * [getBalance](#getbalance)
+* [getClusterNodes](#getclusternodes)
 * [getRecentBlockhash](#getrecentblockhash)
 * [getSignatureStatus](#getsignaturestatus)
+* [getSlotLeader](#getslotleader)
 * [getNumBlocksSinceSignatureConfirmation](#getnumblockssincesignatureconfirmation)
 * [getTransactionCount](#gettransactioncount)
 * [requestAirdrop](#requestairdrop)
@@ -114,6 +116,30 @@ curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0", "id":1, "
 
 ---
 
+### getClusterNodes
+Returns information about all the nodes participating in the cluster
+
+##### Parameters:
+None
+
+##### Results:
+The result field will be an array of JSON objects, each with the following sub fields:
+* `id` - Node identifier, as base-58 encoded string
+* `gossip` - Gossip network address for the node
+* `tpu` - TPU network address for the node
+* `rpc` - JSON RPC network address for the node, or `null` if the JSON RPC service is not enabled
+
+##### Example:
+```bash
+// Request
+curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0", "id":1, "method":"getClusterNodes"}' http://localhost:8899
+
+// Result
+{"jsonrpc":"2.0","result":[{"gossip":"10.239.6.48:8001","id":"9QzsJf7LPLj8GkXbYT3LFDKqsj2hHG7TA3xinJHu8epQ","rpc":"10.239.6.48:8899","tpu":"10.239.6.48:8856"}],"id":1}
+```
+
+---
+
 ### getAccountInfo
 Returns all information associated with the account of provided Pubkey
 
@@ -183,7 +209,27 @@ curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0", "id":1, "
 {"jsonrpc":"2.0","result":"SignatureNotFound","id":1}
 ```
 
----
+-----
+
+### getSlotLeader
+Returns the current slot leader
+
+##### Parameters:
+None
+
+##### Results:
+* `string` - Node Id as base-58 encoded string
+
+##### Example:
+```bash
+// Request
+curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1, "method":"getSlotLeader"}' http://localhost:8899
+
+// Result
+{"jsonrpc":"2.0","result":"ENvAW7JScgYq6o4zKZwewtkzzJgDzuJAFxYasvmEQdpS","id":1}
+```
+
+-----
 
 ### getNumBlocksSinceSignatureConfirmation
 Returns the current number of blocks since signature has been confirmed.

--- a/core/src/cluster_info.rs
+++ b/core/src/cluster_info.rs
@@ -348,7 +348,7 @@ impl ClusterInfo {
     }
 
     // All nodes in gossip, including spy nodes
-    fn all_peers(&self) -> Vec<ContactInfo> {
+    pub(crate) fn all_peers(&self) -> Vec<ContactInfo> {
         self.gossip
             .crds
             .table

--- a/core/src/cluster_info.rs
+++ b/core/src/cluster_info.rs
@@ -245,6 +245,7 @@ impl ClusterInfo {
     pub fn contact_info_trace(&self) -> String {
         let now = timestamp();
         let mut spy_nodes = 0;
+        let my_id = self.my_data().id;
         let nodes: Vec<_> = self
             .all_peers()
             .into_iter()
@@ -261,12 +262,13 @@ impl ClusterInfo {
                 }
 
                 format!(
-                    "- gossip: {:20} | {:5}ms | {}\n  \
+                    "- gossip: {:20} | {:5}ms | {} {}\n  \
                      tpu:    {:20} |         |\n  \
                      rpc:    {:20} |         |\n",
                     addr_to_string(&node.gossip),
                     now.saturating_sub(node.wallclock),
                     node.id,
+                    if node.id == my_id { "(me)" } else { "" }.to_string(),
                     addr_to_string(&node.tpu),
                     addr_to_string(&node.rpc),
                 )
@@ -347,13 +349,11 @@ impl ClusterInfo {
 
     // All nodes in gossip, including spy nodes
     fn all_peers(&self) -> Vec<ContactInfo> {
-        let me = self.my_data().id;
         self.gossip
             .crds
             .table
             .values()
             .filter_map(|x| x.value.contact_info())
-            .filter(|x| x.id != me)
             .cloned()
             .collect()
     }

--- a/core/src/rpc_service.rs
+++ b/core/src/rpc_service.rs
@@ -15,7 +15,9 @@ use std::time::Duration;
 
 pub struct JsonRpcService {
     thread_hdl: JoinHandle<()>,
-    pub request_processor: Arc<RwLock<JsonRpcRequestProcessor>>, // Used only by tests...
+
+    #[cfg(test)]
+    pub request_processor: Arc<RwLock<JsonRpcRequestProcessor>>, // Used only by test_rpc_new()...
 }
 
 impl JsonRpcService {
@@ -37,7 +39,7 @@ impl JsonRpcService {
         )));
         let request_processor_ = request_processor.clone();
 
-        let info = cluster_info.clone();
+        let cluster_info = cluster_info.clone();
         let exit_ = exit.clone();
 
         let thread_hdl = Builder::new()
@@ -50,7 +52,7 @@ impl JsonRpcService {
                 let server =
                     ServerBuilder::with_meta_extractor(io, move |_req: &hyper::Request<hyper::Body>| Meta {
                         request_processor: request_processor_.clone(),
-                        cluster_info: info.clone(),
+                        cluster_info: cluster_info.clone(),
                     }).threads(4)
                         .cors(DomainsValidation::AllowOnly(vec![
                             AccessControlAllowOrigin::Any,
@@ -68,6 +70,7 @@ impl JsonRpcService {
             .unwrap();
         Self {
             thread_hdl,
+            #[cfg(test)]
             request_processor,
         }
     }


### PR DESCRIPTION
#### Problem
You can't get the current slot leader and list of cluster nodes from the JSON RPC API.

#### Summary of Changes
Now you can.
