### PR TITLE
Fix mismatch between leader/validator bank votability

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -368,8 +368,7 @@ impl BankingStage {
             .iter()
             .zip(txs.iter())
             .filter_map(|(r, x)| {
-                Self::log_tx_errors(r);
-                if Bank::is_tx_committable(r) {
+                if Bank::can_commit(r) {
                     Some(x.clone())
                 } else {
                     None
@@ -425,19 +424,6 @@ impl BankingStage {
         );
 
         Ok(())
-    }
-
-    fn log_tx_errors(result: &transaction::Result<()>) {
-        match result {
-            Err(TransactionError::InstructionError(index, err)) => {
-                debug!("instruction error {:?}, {:?}", index, err);
-            }
-            Err(ref e) => {
-                debug!("process transaction failed {:?}", e);
-            }
-
-            _ => (),
-        }
     }
 
     pub fn process_and_record_transactions(

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -20,7 +20,7 @@ use solana_runtime::bank::Bank;
 use solana_runtime::locked_accounts_results::LockedAccountsResults;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::timing::{self, duration_as_us, DEFAULT_TICKS_PER_SLOT, MAX_RECENT_BLOCKHASHES};
-use solana_sdk::transaction::{self, Transaction, TransactionError};
+use solana_sdk::transaction::{self, Transaction};
 use std::cmp;
 use std::net::UdpSocket;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -663,6 +663,7 @@ mod tests {
     use solana_sdk::instruction::InstructionError;
     use solana_sdk::signature::{Keypair, KeypairUtil};
     use solana_sdk::system_transaction;
+    use solana_sdk::transaction::TransactionError;
     use std::sync::mpsc::channel;
     use std::thread::sleep;
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -423,10 +423,9 @@ impl Bank {
         self.status_cache.write().unwrap().clear_signatures();
     }
 
-    pub fn is_tx_committable(result: &Result<()>) -> bool {
+    pub fn can_commit(result: &Result<()>) -> bool {
         match result {
-            Ok(_) => true,
-            Err(TransactionError::InstructionError(_, _)) => true,
+            Ok(_) | Err(TransactionError::InstructionError(_, _)) => true,
             Err(_) => false,
         }
     }
@@ -434,7 +433,7 @@ impl Bank {
     fn update_transaction_statuses(&self, txs: &[Transaction], res: &[Result<()>]) {
         let mut status_cache = self.status_cache.write().unwrap();
         for (i, tx) in txs.iter().enumerate() {
-            if Self::is_tx_committable(&res[i]) && !tx.signatures.is_empty() {
+            if Self::can_commit(&res[i]) && !tx.signatures.is_empty() {
                 status_cache.insert(
                     &tx.message().recent_blockhash,
                     &tx.signatures[0],
@@ -762,11 +761,7 @@ impl Bank {
             warn!("=========== FIXME: commit_transactions() working on a frozen bank! ================");
         }
 
-        if executed
-            .iter()
-            .find(|res| Self::is_tx_committable(*res))
-            .is_some()
-        {
+        if executed.iter().any(|res| Self::can_commit(res)) {
             self.is_delta.store(true, Ordering::Relaxed);
         }
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -425,7 +425,8 @@ impl Bank {
 
     pub fn can_commit(result: &Result<()>) -> bool {
         match result {
-            Ok(_) | Err(TransactionError::InstructionError(_, _)) => true,
+            Ok(_) => true,
+            Err(TransactionError::InstructionError(_, _)) => true,
             Err(_) => false,
         }
     }


### PR DESCRIPTION
#### Problem
Leaders set the bank "is_delta" flag in commit_transactions() even if the only transactions to be committed are TransactionErrors. However, these transactions are not recorded and thus not broadcast to validators. This causes a potential mismatch on the votability of banks between leaders and validators

#### Summary of Changes
Check if a transaction passes the "is_tx_committable" check (implies the tx will be broadcast) before setting the "is_delta" flag in commit_transactions()

TODO: Write a test
Fixes #
