### PR TITLE
Cleanup stragglers from move-to-transfer rename

### DIFF
--- a/book/src/drones.md
+++ b/book/src/drones.md
@@ -10,7 +10,7 @@ client's account.
 A drone is a simple signing service. It listens for requests to sign
 *transaction data*.  Once received, the drone validates the request however it
 sees fit. It may, for example, only accept transaction data with a
-`SystemInstruction::Move` instruction transferring only up to a certain amount
+`SystemInstruction::Transfer` instruction transferring only up to a certain amount
 of tokens. If the drone accepts the transaction, it returns an `Ok(Signature)`
 where `Signature` is a signature of the transaction data using the drone's
 private key. If it rejects the transaction data, it returns a `DroneError`
@@ -76,7 +76,7 @@ beyond a certain *age*.
 
 If the transaction data size is smaller than the size of the returned signature
 (or descriptive error), a single client can flood the network.  Considering
-that a simple `Move` operation requires two public keys (each 32 bytes) and a
+that a simple `Transfer` operation requires two public keys (each 32 bytes) and a
 `fee` field, and that the returned signature is 64 bytes (and a byte to
 indicate `Ok`), consideration for this attack may not be required.
 

--- a/book/src/programs.md
+++ b/book/src/programs.md
@@ -3,8 +3,8 @@
 A client *app* interacts with a Solana cluster by sending it *transactions*
 with one or more *instructions*. The Solana *runtime* passes those instructions
 to user-contributed *programs*. An instruction might, for example, tell a
-program to move *lamports* from one *account* to another or create an interactive
-contract that governs how lamports are moved. Instructions are executed
+program to transfer *lamports* from one *account* to another or create an interactive
+contract that governs how lamports are transfered. Instructions are executed
 atomically. If any instruction is invalid, any changes made within the
 transaction are discarded.
 

--- a/book/src/runtime.md
+++ b/book/src/runtime.md
@@ -67,7 +67,7 @@ data array and assign it to a Program.
 
 * `Assign` - Allows the user to assign an existing account to a program.
 
-* `Move`  - Moves lamports between accounts.
+* `Transfer`  - Transfers lamports between accounts.
 
 ## Program State Security
 

--- a/programs/config_api/src/config_processor.rs
+++ b/programs/config_api/src/config_processor.rs
@@ -158,7 +158,8 @@ mod tests {
         bank.transfer(42, &mint_keypair, &system_pubkey).unwrap();
         let (bank_client, from_keypair, config_keypair) = create_config_client(bank, mint_keypair);
 
-        let move_instruction = system_instruction::transfer(&system_pubkey, &Pubkey::default(), 42);
+        let transfer_instruction =
+            system_instruction::transfer(&system_pubkey, &Pubkey::default(), 42);
         let my_config = MyConfig::new(42);
         let mut store_instruction =
             config_instruction::store(&from_keypair.pubkey(), &config_keypair.pubkey(), &my_config);
@@ -166,7 +167,7 @@ mod tests {
         store_instruction.accounts[1].is_signer = false;
 
         // Don't sign the transaction with `config_client`
-        let message = Message::new(vec![move_instruction, store_instruction]);
+        let message = Message::new(vec![transfer_instruction, store_instruction]);
         bank_client
             .send_message(&[&system_keypair], message)
             .unwrap_err();

--- a/programs/vote_api/src/vote_instruction.rs
+++ b/programs/vote_api/src/vote_instruction.rs
@@ -202,8 +202,8 @@ mod tests {
         // Sneak in an instruction so that the transaction is signed but
         // the 0th account in the second instruction is not! The program
         // needs to check that it's signed.
-        let move_ix = system_instruction::transfer(&mallory_id, &vote_id, 1);
-        let message = Message::new(vec![move_ix, vote_ix]);
+        let transfer_ix = system_instruction::transfer(&mallory_id, &vote_id, 1);
+        let message = Message::new(vec![transfer_ix, vote_ix]);
         let result = bank_client.send_message(&[&mallory_keypair], message);
 
         // And ensure there's no vote.

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1593,14 +1593,14 @@ mod tests {
         let key2 = Keypair::new();
         let parent = Arc::new(Bank::new(&genesis_block));
 
-        let tx_move_mint_to_1 =
+        let tx_transfer_mint_to_1 =
             system_transaction::transfer(&mint_keypair, &key1.pubkey(), 1, genesis_block.hash(), 0);
         trace!("parent process tx ");
-        assert_eq!(parent.process_transaction(&tx_move_mint_to_1), Ok(()));
+        assert_eq!(parent.process_transaction(&tx_transfer_mint_to_1), Ok(()));
         trace!("done parent process tx ");
         assert_eq!(parent.transaction_count(), 1);
         assert_eq!(
-            parent.get_signature_status(&tx_move_mint_to_1.signatures[0]),
+            parent.get_signature_status(&tx_transfer_mint_to_1.signatures[0]),
             Some(Ok(()))
         );
 
@@ -1608,18 +1608,18 @@ mod tests {
         let bank = new_from_parent(&parent);
         trace!("done new form parent");
         assert_eq!(
-            bank.get_signature_status(&tx_move_mint_to_1.signatures[0]),
+            bank.get_signature_status(&tx_transfer_mint_to_1.signatures[0]),
             Some(Ok(()))
         );
 
         assert_eq!(bank.transaction_count(), parent.transaction_count());
-        let tx_move_1_to_2 =
+        let tx_transfer_1_to_2 =
             system_transaction::transfer(&key1, &key2.pubkey(), 1, genesis_block.hash(), 0);
-        assert_eq!(bank.process_transaction(&tx_move_1_to_2), Ok(()));
+        assert_eq!(bank.process_transaction(&tx_transfer_1_to_2), Ok(()));
         assert_eq!(bank.transaction_count(), 2);
         assert_eq!(parent.transaction_count(), 1);
         assert_eq!(
-            parent.get_signature_status(&tx_move_1_to_2.signatures[0]),
+            parent.get_signature_status(&tx_transfer_1_to_2.signatures[0]),
             None
         );
 
@@ -1630,11 +1630,11 @@ mod tests {
             assert_eq!(bank.get_balance(&key2.pubkey()), 1);
             trace!("start");
             assert_eq!(
-                bank.get_signature_status(&tx_move_mint_to_1.signatures[0]),
+                bank.get_signature_status(&tx_transfer_mint_to_1.signatures[0]),
                 Some(Ok(()))
             );
             assert_eq!(
-                bank.get_signature_status(&tx_move_1_to_2.signatures[0]),
+                bank.get_signature_status(&tx_transfer_1_to_2.signatures[0]),
                 Some(Ok(()))
             );
 
@@ -1731,13 +1731,13 @@ mod tests {
         bank.fee_calculator.lamports_per_signature = 2;
         let key = Keypair::new();
 
-        let mut move_instruction =
+        let mut transfer_instruction =
             system_instruction::transfer(&mint_keypair.pubkey(), &key.pubkey(), 0);
-        move_instruction.accounts[0].is_signer = false;
+        transfer_instruction.accounts[0].is_signer = false;
 
         let tx = Transaction::new_signed_instructions(
             &Vec::<&Keypair>::new(),
-            vec![move_instruction],
+            vec![transfer_instruction],
             bank.last_blockhash(),
         );
 
@@ -1813,9 +1813,9 @@ mod tests {
         let (genesis_block, mint_keypair) = GenesisBlock::new(500);
         let bank = Arc::new(Bank::new(&genesis_block));
         let key1 = Keypair::new();
-        let tx_move_mint_to_1 =
+        let tx_transfer_mint_to_1 =
             system_transaction::transfer(&mint_keypair, &key1.pubkey(), 1, genesis_block.hash(), 0);
-        assert_eq!(bank.process_transaction(&tx_move_mint_to_1), Ok(()));
+        assert_eq!(bank.process_transaction(&tx_transfer_mint_to_1), Ok(()));
         assert_eq!(bank.is_delta.load(Ordering::Relaxed), true);
     }
 
@@ -1827,9 +1827,9 @@ mod tests {
         assert_eq!(bank.is_votable(), false);
 
         // Set is_delta to true
-        let tx_move_mint_to_1 =
+        let tx_transfer_mint_to_1 =
             system_transaction::transfer(&mint_keypair, &key1.pubkey(), 1, genesis_block.hash(), 0);
-        assert_eq!(bank.process_transaction(&tx_move_mint_to_1), Ok(()));
+        assert_eq!(bank.process_transaction(&tx_transfer_mint_to_1), Ok(()));
         assert_eq!(bank.is_votable(), false);
 
         // Register enough ticks to hit max tick height

--- a/runtime/src/bank_client.rs
+++ b/runtime/src/bank_client.rs
@@ -160,12 +160,12 @@ mod tests {
 
         // Create 2-2 Multisig Transfer instruction.
         let bob_pubkey = Pubkey::new_rand();
-        let mut move_instruction = system_instruction::transfer(&john_pubkey, &bob_pubkey, 42);
-        move_instruction
+        let mut transfer_instruction = system_instruction::transfer(&john_pubkey, &bob_pubkey, 42);
+        transfer_instruction
             .accounts
             .push(AccountMeta::new(jane_pubkey, true));
 
-        let message = Message::new(vec![move_instruction]);
+        let message = Message::new(vec![transfer_instruction]);
         bank_client.send_message(&doe_keypairs, message).unwrap();
         assert_eq!(bank_client.get_balance(&bob_pubkey).unwrap(), 42);
     }

--- a/sdk/src/system_transaction.rs
+++ b/sdk/src/system_transaction.rs
@@ -66,7 +66,7 @@ pub fn transfer(
     _fee: u64,
 ) -> Transaction {
     let from_pubkey = from_keypair.pubkey();
-    let move_instruction = system_instruction::transfer(&from_pubkey, to, lamports);
-    let instructions = vec![move_instruction];
+    let transfer_instruction = system_instruction::transfer(&from_pubkey, to, lamports);
+    let instructions = vec![transfer_instruction];
     Transaction::new_signed_instructions(&[from_keypair], instructions, recent_blockhash)
 }


### PR DESCRIPTION
#### Problem

I renamed `SystemInstruction::Move` to `Transfer` a while back and missed the book and some variables.

#### Summary of Changes

Rename remaining instances of "move" to "transfer".
