### PR TITLE
Facility to pass extra arguments to bench clients from net.sh command line

### DIFF
--- a/net/remote/remote-client.sh
+++ b/net/remote/remote-client.sh
@@ -9,6 +9,8 @@ deployMethod="$1"
 entrypointIp="$2"
 clientToRun="$3"
 RUST_LOG="$4"
+benchTpsExtraArgs="$5"
+benchExchangeExtraArgs="$6"
 export RUST_LOG=${RUST_LOG:-solana=info} # if RUST_LOG is unset, default to info
 
 missing() {
@@ -59,6 +61,7 @@ solana-bench-tps)
       --duration 7500 \
       --sustained \
       --threads $threadCount \
+      $benchTpsExtraArgs \
   "
   ;;
 solana-bench-exchange)
@@ -72,6 +75,7 @@ solana-bench-exchange)
       --fund-amount 20000 \
       --duration 7500 \
       --identity bench.keypair \
+      $benchExchangeExtraArgs \
   "
   ;;
 *)


### PR DESCRIPTION
#### Problem
Testnet without CUDA does not bootup.

#### Summary of Changes
The bench tps client is stuck in creating millions of accounts. It's controlled by tx_count command line variable. With this change, the user can supply extra arguments to bench clients from net.sh command line.