### PR TITLE
Fix race in erasure metadata tracking

### DIFF
--- a/core/src/blocktree.rs
+++ b/core/src/blocktree.rs
@@ -1048,7 +1048,6 @@ impl Blocktree {
         prev_inserted_blob_datas: &mut HashMap<(u64, u64), &'a [u8]>,
         write_batch: &mut WriteBatch,
     ) -> Result<bool> {
-        //let blob = blob.borrow();
         let blob_slot = blob.slot();
         let parent_slot = blob.parent();
 
@@ -1162,8 +1161,6 @@ impl Blocktree {
     ) -> Result<(Vec<Blob>, Vec<Blob>)> {
         use crate::erasure::ERASURE_SET_SIZE;
 
-        //let mut erasure_meta = self.erasure_meta_cf.get((slot, set_index))?.unwrap();
-
         let start_idx = erasure_meta.start_index();
         let size = erasure_meta.size();
 
@@ -1179,7 +1176,7 @@ impl Blocktree {
                     _ => self
                         .erasure_cf
                         .get_bytes((slot, i))?
-                        .expect("ErasureMeta must have no false positivies"),
+                        .expect("ErasureMeta must have no false positives"),
                 };
 
                 blob_bytes.drain(..BLOB_HEADER_SIZE);

--- a/core/src/blocktree.rs
+++ b/core/src/blocktree.rs
@@ -570,7 +570,7 @@ impl Blocktree {
                 slot_meta_working_set,
                 prev_inserted_blob_datas,
                 write_batch,
-            )?;
+            );
 
             if inserted {
                 erasure_meta_working_set
@@ -1066,14 +1066,15 @@ impl Blocktree {
         }
     }
 
-    /// Checks if this data blob is a duplicate. If  it's not, then inserts it.
+    /// Checks to see if the data blob passes integrity checks for insertion. Proceeds with
+    /// insertion if it does.
     fn check_insert_data_blob<'a>(
         &self,
         blob: &'a Blob,
         slot_meta_working_set: &mut HashMap<u64, (Rc<RefCell<SlotMeta>>, Option<SlotMeta>)>,
         prev_inserted_blob_datas: &mut HashMap<(u64, u64), &'a [u8]>,
         write_batch: &mut WriteBatch,
-    ) -> Result<bool> {
+    ) -> bool {
         let blob_slot = blob.slot();
         let parent_slot = blob.parent();
 
@@ -1106,11 +1107,11 @@ impl Blocktree {
 
         // This slot is full, skip the bogus blob
         if slot_meta.is_full() {
-            return Ok(false);
+            false
+        } else {
+            let _ = self.insert_data_blob(blob, prev_inserted_blob_datas, slot_meta, write_batch);
+            true
         }
-
-        let _ = self.insert_data_blob(blob, prev_inserted_blob_datas, slot_meta, write_batch);
-        Ok(true)
     }
 
     /// Insert a blob into ledger, updating the slot_meta if necessary

--- a/core/src/erasure.rs
+++ b/core/src/erasure.rs
@@ -41,7 +41,6 @@
 //!
 //!
 use crate::packet::{Blob, SharedBlob, BLOB_HEADER_SIZE};
-use crate::result::Result;
 use std::cmp;
 use std::convert::AsMut;
 use std::sync::{Arc, RwLock};
@@ -55,6 +54,8 @@ pub const NUM_DATA: usize = 16;
 pub const NUM_CODING: usize = 4;
 /// Total number of blobs in an erasure set; includes data and coding blobs
 pub const ERASURE_SET_SIZE: usize = NUM_DATA + NUM_CODING;
+
+type Result<T> = std::result::Result<T, reed_solomon_erasure::Error>;
 
 /// Represents an erasure "session" with a particular configuration and number of data and coding
 /// blobs


### PR DESCRIPTION
#### Problem
Erasure and recovery didn't do everything in the same  batch of writes as data blob insertion in general, and was vulnerable to race conditions on the ledger, which caused spurious failures of recovery or recovery to 'succeed' with 0 blobs recovered.

#### Summary of Changes
* Change recovery process and metadata tracking to take part within the same 'transaction'
* Add more tests to erasure-related metadata tracking and indexing logic
* change the multi_slot_multi_thread test to be racey enough to display the former behavior.

Fixes #
