### PR TITLE
Add provision in testnet scripts to ignore validator nodes that failed to bootup

### DIFF
--- a/net/gce.sh
+++ b/net/gce.sh
@@ -271,6 +271,15 @@ EOF
     declare failOnFailure="$5"
     declare arrayName="$6"
 
+    # This check should eventually be moved to cloud provider specific script 
+    if [ "$publicIp" = "TERMINATED" ] || [ "$privateIp" = "TERMINATED" ]; then
+      if $failOnFailure; then
+        exit 1
+      else
+        return 0
+      fi
+    fi
+
     ok=true
     echo "Waiting for $name to finish booting..."
     (

--- a/net/gce.sh
+++ b/net/gce.sh
@@ -273,23 +273,21 @@ EOF
 
     ok=false
     echo "Waiting for $name to finish booting..."
-    (
-      set -x +e
-      for i in $(seq 1 20); do
-        timeout --preserve-status --foreground 20s ssh "${sshOptions[@]}" "$publicIp" "ls -l /.instance-startup-complete"
-        ret=$?
-        if [[ $ret -eq 0 ]]; then
-          echo "$name has booted."
-          ok=true
-          break
-        fi
-        sleep 2
-        echo "Retry $i..."
-      done
-      echo "$name failed to boot."
-    )
+    set -x
+    for i in $(seq 1 20); do
+      timeout 20s ssh "${sshOptions[@]}" "$publicIp" "ls -l /.instance-startup-complete"
+      ret=$?
+      if [[ $ret -eq 0 ]]; then
+        echo "$name has booted."
+        ok=true
+        break
+      fi
+      sleep 2
+      echo "Retry $i..."
+    done
 
     if ! $ok; then
+      echo "$name failed to boot."
       if $failOnFailure; then
         exit 1
       else


### PR DESCRIPTION
#### Problem
Some nodes die (or don't bootup) during testnet creation. This makes testnet deployment with higher node count very flaky.

#### Summary of Changes
Ignore the validator nodes that failed to bootup. Failure of bootstrap leader, client, and blockstreamer nodes is still considered fatal for the testnet creation.

https://github.com/solana-labs/solana/issues/3970