### PR TITLE
Do not enable rpc exit on the blockstreamer node

### DIFF
--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -114,10 +114,10 @@ local|tar)
       else
         args+=("--stake" 0)
       fi
+      args+=(--enable-rpc-exit)
     fi
 
     args+=(
-      --enable-rpc-exit
       --gossip-port 8001
       --rpc-port 8899
     )


### PR DESCRIPTION
The blockstreamer node hosts the blockexplorer UI, don't want to kill it by accident from that blockexplorer UI