### PR TITLE
Find unique zones and delete nodes in each zone

### DIFF
--- a/net/scripts/gce-provider.sh
+++ b/net/scripts/gce-provider.sh
@@ -207,10 +207,10 @@ cloud_DeleteInstances() {
 
   declare names=("${instances[@]/:*/}")
   declare zones=("${instances[@]/*:/}")
-  declare uniq_zones=()
-  read -r -a uniq_zones <<< "$(echo "${zones[@]}" | tr ' ' '\n' | sort -u | tr '\n' ' ')"
+  declare unique_zones=()
+  read -r -a unique_zones <<< "$(echo "${zones[@]}" | tr ' ' '\n' | sort -u | tr '\n' ' ')"
 
-  for zone in "${uniq_zones[@]}"; do
+  for zone in "${unique_zones[@]}"; do
     set -x
     # Try deleting instances in all zones
     gcloud beta compute instances delete --zone "$zone" --quiet "${names[@]}" || true

--- a/net/scripts/gce-provider.sh
+++ b/net/scripts/gce-provider.sh
@@ -207,8 +207,9 @@ cloud_DeleteInstances() {
 
   declare names=("${instances[@]/:*/}")
   declare zones=("${instances[@]/*:/}")
+  declare unique_zones=($(echo "${zones[@]}" | tr ' ' '\n' | sort -u | tr '\n' ' '))
 
-  for zone in "${zones[@]}"; do
+  for zone in "${unique_zones[@]}"; do
     set -x
     # Try deleting instances in all zones
     gcloud beta compute instances delete --zone "$zone" --quiet "${names[@]}" || true

--- a/net/scripts/gce-provider.sh
+++ b/net/scripts/gce-provider.sh
@@ -207,7 +207,8 @@ cloud_DeleteInstances() {
 
   declare names=("${instances[@]/:*/}")
   declare zones=("${instances[@]/*:/}")
-  declare unique_zones=($(echo "${zones[@]}" | tr ' ' '\n' | sort -u | tr '\n' ' '))
+  declare uniq_zones=()
+  read -a uniq_zones <<< "$(echo "${zones[@]}" | tr ' ' '\n' | sort -u | tr '\n' ' ')"
 
   for zone in "${unique_zones[@]}"; do
     set -x

--- a/net/scripts/gce-provider.sh
+++ b/net/scripts/gce-provider.sh
@@ -208,9 +208,9 @@ cloud_DeleteInstances() {
   declare names=("${instances[@]/:*/}")
   declare zones=("${instances[@]/*:/}")
   declare uniq_zones=()
-  read -a uniq_zones <<< "$(echo "${zones[@]}" | tr ' ' '\n' | sort -u | tr '\n' ' ')"
+  read -r -a uniq_zones <<< "$(echo "${zones[@]}" | tr ' ' '\n' | sort -u | tr '\n' ' ')"
 
-  for zone in "${unique_zones[@]}"; do
+  for zone in "${uniq_zones[@]}"; do
     set -x
     # Try deleting instances in all zones
     gcloud beta compute instances delete --zone "$zone" --quiet "${names[@]}" || true


### PR DESCRIPTION
#### Problem
The GCP testnet delete iterates over the same zone multiple times to delete nodes.

#### Summary of Changes
The delete code is computing the zone list from the name of the nodes. If there are multiple nodes in the same zone, the list will contain that zone multiple times.

The change finds unique zones in the list.