### PR TITLE
Expose Rpc methods to rpc_request

### DIFF
--- a/client/src/rpc_request.rs
+++ b/client/src/rpc_request.rs
@@ -19,6 +19,8 @@ pub enum RpcRequest {
     GetStoragePubkeysForEntryHeight,
     FullnodeExit,
     GetNumBlocksSinceSignatureConfirmation,
+    GetClusterNodes,
+    GetSlotLeader,
 }
 
 impl RpcRequest {
@@ -43,6 +45,8 @@ impl RpcRequest {
             RpcRequest::GetNumBlocksSinceSignatureConfirmation => {
                 "getNumBlocksSinceSignatureConfirmation"
             }
+            RpcRequest::GetClusterNodes => "getClusterNodes",
+            RpcRequest::GetSlotLeader => "getSlotLeader",
         };
         let mut request = json!({
            "jsonrpc": jsonrpc,

--- a/client/src/rpc_request.rs
+++ b/client/src/rpc_request.rs
@@ -4,23 +4,23 @@ use std::{error, fmt};
 #[derive(Debug, PartialEq)]
 pub enum RpcRequest {
     ConfirmTransaction,
+    DeregisterNode,
+    FullnodeExit,
     GetAccountInfo,
     GetBalance,
+    GetClusterNodes,
+    GetNumBlocksSinceSignatureConfirmation,
     GetRecentBlockhash,
     GetSignatureStatus,
-    GetTransactionCount,
-    RequestAirdrop,
-    SendTransaction,
-    RegisterNode,
-    SignVote,
-    DeregisterNode,
+    GetSlotLeader,
     GetStorageBlockhash,
     GetStorageEntryHeight,
     GetStoragePubkeysForEntryHeight,
-    FullnodeExit,
-    GetNumBlocksSinceSignatureConfirmation,
-    GetClusterNodes,
-    GetSlotLeader,
+    GetTransactionCount,
+    RegisterNode,
+    RequestAirdrop,
+    SendTransaction,
+    SignVote,
 }
 
 impl RpcRequest {
@@ -28,25 +28,25 @@ impl RpcRequest {
         let jsonrpc = "2.0";
         let method = match self {
             RpcRequest::ConfirmTransaction => "confirmTransaction",
+            RpcRequest::DeregisterNode => "deregisterNode",
+            RpcRequest::FullnodeExit => "fullnodeExit",
             RpcRequest::GetAccountInfo => "getAccountInfo",
             RpcRequest::GetBalance => "getBalance",
-            RpcRequest::GetRecentBlockhash => "getRecentBlockhash",
-            RpcRequest::GetSignatureStatus => "getSignatureStatus",
-            RpcRequest::GetTransactionCount => "getTransactionCount",
-            RpcRequest::RequestAirdrop => "requestAirdrop",
-            RpcRequest::SendTransaction => "sendTransaction",
-            RpcRequest::RegisterNode => "registerNode",
-            RpcRequest::SignVote => "signVote",
-            RpcRequest::DeregisterNode => "deregisterNode",
-            RpcRequest::GetStorageBlockhash => "getStorageBlockhash",
-            RpcRequest::GetStorageEntryHeight => "getStorageEntryHeight",
-            RpcRequest::GetStoragePubkeysForEntryHeight => "getStoragePubkeysForEntryHeight",
-            RpcRequest::FullnodeExit => "fullnodeExit",
+            RpcRequest::GetClusterNodes => "getClusterNodes",
             RpcRequest::GetNumBlocksSinceSignatureConfirmation => {
                 "getNumBlocksSinceSignatureConfirmation"
             }
-            RpcRequest::GetClusterNodes => "getClusterNodes",
+            RpcRequest::GetRecentBlockhash => "getRecentBlockhash",
+            RpcRequest::GetSignatureStatus => "getSignatureStatus",
             RpcRequest::GetSlotLeader => "getSlotLeader",
+            RpcRequest::GetStorageBlockhash => "getStorageBlockhash",
+            RpcRequest::GetStorageEntryHeight => "getStorageEntryHeight",
+            RpcRequest::GetStoragePubkeysForEntryHeight => "getStoragePubkeysForEntryHeight",
+            RpcRequest::GetTransactionCount => "getTransactionCount",
+            RpcRequest::RegisterNode => "registerNode",
+            RpcRequest::RequestAirdrop => "requestAirdrop",
+            RpcRequest::SendTransaction => "sendTransaction",
+            RpcRequest::SignVote => "signVote",
         };
         let mut request = json!({
            "jsonrpc": jsonrpc,


### PR DESCRIPTION
#### Problem
There are new rpc methods, but they aren't available via the rpc_request module 😢 . I would like to use them.

#### Summary of Changes
Add them: GetClusterNodes, GetSlotLeader
Also, alphabetize to improve my sanity
