### PR TITLE
Add metrics rate knob

### DIFF
--- a/programs/exchange_api/src/exchange_processor.rs
+++ b/programs/exchange_api/src/exchange_processor.rs
@@ -296,7 +296,7 @@ impl ExchangeProcessor {
         // Trade holds the tokens in escrow
         account.tokens[from_token] -= info.tokens;
 
-        inc_new_counter_info!("exchange_processor-trades", 1);
+        inc_new_counter_info!("exchange_processor-trades", 1, 1000, 1000);
 
         Self::serialize(
             &ExchangeState::Trade(TradeOrderInfo {
@@ -390,7 +390,7 @@ impl ExchangeProcessor {
             Err(e)?
         }
 
-        inc_new_counter_info!("exchange_processor-swap", 1);
+        inc_new_counter_info!("exchange_processor-swap", 1, 1000, 1000);
 
         if to_trade.tokens == 0 {
             // Turn into token account


### PR DESCRIPTION
#### Problem

Submitting metrics in a contract when it can be 10s-100s of times a second can lead to incorrect metrics numbers.

#### Summary of Changes

Allow for configurable metrics rate per-counter and change the exchange contract counters to reduce their metrics rate.

Fixes #
