### PR TITLE
Add signature polling to SyncClient

### DIFF
--- a/bench-tps/src/bench.rs
+++ b/bench-tps/src/bench.rs
@@ -521,10 +521,12 @@ pub fn airdrop_lamports<T: Client>(
                 let signature = client.async_send_transaction(transaction).unwrap();
                 client
                     .poll_for_signature_confirmation(&signature, 1)
-                    .expect(&format!(
-                        "Error requesting airdrop: to addr: {:?} amount: {}",
-                        drone_addr, airdrop_amount
-                    ));
+                    .unwrap_or_else(|_| {
+                        panic!(
+                            "Error requesting airdrop: to addr: {:?} amount: {}",
+                            drone_addr, airdrop_amount
+                        )
+                    })
             }
             Err(err) => {
                 panic!(

--- a/bench-tps/src/bench.rs
+++ b/bench-tps/src/bench.rs
@@ -519,7 +519,12 @@ pub fn airdrop_lamports<T: Client>(
         match request_airdrop_transaction(&drone_addr, &id.pubkey(), airdrop_amount, blockhash) {
             Ok(transaction) => {
                 let signature = client.async_send_transaction(transaction).unwrap();
-                client.get_signature_status(&signature).unwrap();
+                client
+                    .poll_for_signature_confirmation(&signature, 1)
+                    .expect(&format!(
+                        "Error requesting airdrop: to addr: {:?} amount: {}",
+                        drone_addr, airdrop_amount
+                    ));
             }
             Err(err) => {
                 panic!(

--- a/client/src/thin_client.rs
+++ b/client/src/thin_client.rs
@@ -137,19 +137,6 @@ impl ThinClient {
         self.rpc_client.wait_for_balance(pubkey, expected_balance)
     }
 
-    pub fn poll_for_signature(&self, signature: &Signature) -> io::Result<()> {
-        self.rpc_client.poll_for_signature(signature)
-    }
-    /// Poll the server until the signature has been confirmed by at least `min_confirmed_blocks`
-    pub fn poll_for_signature_confirmation(
-        &self,
-        signature: &Signature,
-        min_confirmed_blocks: usize,
-    ) -> io::Result<()> {
-        self.rpc_client
-            .poll_for_signature_confirmation(signature, min_confirmed_blocks)
-    }
-
     /// Check a signature in the bank. This method blocks
     /// until the server sends a response.
     pub fn check_signature(&self, signature: &Signature) -> bool {
@@ -235,6 +222,21 @@ impl SyncClient for ThinClient {
     fn get_transaction_count(&self) -> TransportResult<u64> {
         let transaction_count = self.rpc_client.get_transaction_count()?;
         Ok(transaction_count)
+    }
+
+    /// Poll the server until the signature has been confirmed by at least `min_confirmed_blocks`
+    fn poll_for_signature_confirmation(
+        &self,
+        signature: &Signature,
+        min_confirmed_blocks: usize,
+    ) -> TransportResult<()> {
+        Ok(self
+            .rpc_client
+            .poll_for_signature_confirmation(signature, min_confirmed_blocks)?)
+    }
+
+    fn poll_for_signature(&self, signature: &Signature) -> TransportResult<()> {
+        Ok(self.rpc_client.poll_for_signature(signature)?)
     }
 }
 

--- a/core/src/cluster_tests.rs
+++ b/core/src/cluster_tests.rs
@@ -17,7 +17,7 @@ use solana_sdk::system_transaction;
 use solana_sdk::timing::{
     duration_as_ms, DEFAULT_TICKS_PER_SLOT, NUM_CONSECUTIVE_LEADER_SLOTS, NUM_TICKS_PER_SECOND,
 };
-use std::io;
+use solana_sdk::transport::TransportError;
 use std::thread::sleep;
 use std::time::Duration;
 
@@ -202,7 +202,7 @@ pub fn kill_entry_and_spend_and_verify_rest(
                 );
                 match sig {
                     Err(e) => {
-                        result = Err(e);
+                        result = Err(TransportError::IoError(e));
                         continue;
                     }
 
@@ -227,7 +227,7 @@ fn poll_all_nodes_for_signature(
     cluster_nodes: &[ContactInfo],
     sig: &Signature,
     confs: usize,
-) -> io::Result<()> {
+) -> Result<(), TransportError> {
     for validator in cluster_nodes {
         if validator.id == entry_point_info.id {
             continue;

--- a/runtime/src/bank_client.rs
+++ b/runtime/src/bank_client.rs
@@ -8,12 +8,13 @@ use solana_sdk::signature::Signature;
 use solana_sdk::signature::{Keypair, KeypairUtil};
 use solana_sdk::system_instruction;
 use solana_sdk::transaction::{self, Transaction};
-use solana_sdk::transport::Result;
+use solana_sdk::transport::{Result, TransportError};
 use std::io;
 use std::sync::mpsc::{channel, Receiver, Sender};
 use std::sync::Arc;
 use std::sync::Mutex;
-use std::thread::Builder;
+use std::thread::{sleep, Builder};
+use std::time::{Duration, Instant};
 
 pub struct BankClient {
     bank: Arc<Bank>,
@@ -111,6 +112,65 @@ impl SyncClient for BankClient {
 
     fn get_transaction_count(&self) -> Result<u64> {
         Ok(self.bank.transaction_count())
+    }
+
+    fn poll_for_signature_confirmation(
+        &self,
+        signature: &Signature,
+        min_confirmed_blocks: usize,
+    ) -> Result<()> {
+        let mut now = Instant::now();
+        let mut confirmed_blocks = 0;
+        loop {
+            let response = self.bank.get_signature_confirmation_status(signature);
+            match response {
+                Some((confirmations, res)) => match res {
+                    Ok(_) => {
+                        if confirmed_blocks != confirmations {
+                            now = Instant::now();
+                            confirmed_blocks = confirmations;
+                        }
+                        if confirmations >= min_confirmed_blocks {
+                            break;
+                        }
+                    }
+                    Err(_) => (),
+                },
+                None => (),
+            };
+            if now.elapsed().as_secs() > 15 {
+                // TODO: Return a better error.
+                return Err(TransportError::IoError(io::Error::new(
+                    io::ErrorKind::Other,
+                    "signature not found",
+                )));
+            }
+            sleep(Duration::from_millis(250));
+        }
+        Ok(())
+    }
+
+    fn poll_for_signature(&self, signature: &Signature) -> Result<()> {
+        let now = Instant::now();
+        loop {
+            let response = self.bank.get_signature_status(signature);
+            match response {
+                Some(res) => match res {
+                    Ok(_) => break,
+                    Err(_) => (),
+                },
+                None => (),
+            }
+            if now.elapsed().as_secs() > 15 {
+                // TODO: Return a better error.
+                return Err(TransportError::IoError(io::Error::new(
+                    io::ErrorKind::Other,
+                    "signature not found",
+                )));
+            }
+            sleep(Duration::from_millis(250));
+        }
+        Ok(())
     }
 }
 

--- a/runtime/src/bank_client.rs
+++ b/runtime/src/bank_client.rs
@@ -123,20 +123,16 @@ impl SyncClient for BankClient {
         let mut confirmed_blocks = 0;
         loop {
             let response = self.bank.get_signature_confirmation_status(signature);
-            match response {
-                Some((confirmations, res)) => match res {
-                    Ok(_) => {
-                        if confirmed_blocks != confirmations {
-                            now = Instant::now();
-                            confirmed_blocks = confirmations;
-                        }
-                        if confirmations >= min_confirmed_blocks {
-                            break;
-                        }
+            if let Some((confirmations, res)) = response {
+                if res.is_ok() {
+                    if confirmed_blocks != confirmations {
+                        now = Instant::now();
+                        confirmed_blocks = confirmations;
                     }
-                    Err(_) => (),
-                },
-                None => (),
+                    if confirmations >= min_confirmed_blocks {
+                        break;
+                    }
+                }
             };
             if now.elapsed().as_secs() > 15 {
                 // TODO: Return a better error.
@@ -154,12 +150,10 @@ impl SyncClient for BankClient {
         let now = Instant::now();
         loop {
             let response = self.bank.get_signature_status(signature);
-            match response {
-                Some(res) => match res {
-                    Ok(_) => break,
-                    Err(_) => (),
-                },
-                None => (),
+            if let Some(res) = response {
+                if res.is_ok() {
+                    break;
+                }
             }
             if now.elapsed().as_secs() > 15 {
                 // TODO: Return a better error.

--- a/sdk/src/client.rs
+++ b/sdk/src/client.rs
@@ -50,6 +50,16 @@ pub trait SyncClient {
 
     /// Get transaction count
     fn get_transaction_count(&self) -> Result<u64>;
+
+    /// Poll until the signature has been confirmed by at least `min_confirmed_blocks`
+    fn poll_for_signature_confirmation(
+        &self,
+        signature: &Signature,
+        min_confirmed_blocks: usize,
+    ) -> Result<()>;
+
+    /// Poll to confirm a transaction.
+    fn poll_for_signature(&self, signature: &Signature) -> Result<()>;
 }
 
 pub trait AsyncClient {


### PR DESCRIPTION
#### Problem

No way to poll for signatures via SyncClients. Bench-tps does an optimistic one-time check for its airdrop signature and exits if the signature is not found or not `Ok`. 

#### Summary of Changes

Fixed the initial airdrop failing by adding signature polling. 

