### PR TITLE
Add on-demand functionality to all testnets

### DIFF
--- a/ci/testnet-deploy.sh
+++ b/ci/testnet-deploy.sh
@@ -65,7 +65,7 @@ EOF
 
 zone=()
 
-while getopts "h?p:Pn:c:t:gG:a:Dbd:rusxz:p:C:" opt; do
+while getopts "h?p:Pn:c:t:gG:a:Dbd:rusxz:p:C:S" opt; do
   case $opt in
   h | \?)
     usage
@@ -169,7 +169,7 @@ for val in "${zone[@]}"; do
 done
 
 if $stopNetwork; then
-  $skipSetup=true
+  skipSetup=true
 fi
 
 # Create the network

--- a/ci/testnet-deploy.sh
+++ b/ci/testnet-deploy.sh
@@ -53,6 +53,9 @@ Deploys a CD testnet
    -D                   - Delete the network
    -r                   - Reuse existing node/ledger configuration from a
                           previous |start| (ie, don't run ./multinode-demo/setup.sh).
+   -x                   - External node.  Default: false
+   -s                   - Skip start.  Nodes will still be created or configured, but network software will not be started.
+   -S                   - Stop network software without tearing down nodes.
 
    Note: the SOLANA_METRICS_CONFIG environment variable is used to configure
          metrics
@@ -126,6 +129,9 @@ while getopts "h?p:Pn:c:t:gG:a:Dbd:rusxz:p:C:" opt; do
   u)
     blockstreamer=true
     ;;
+  S)
+    stopNetwork=true
+    ;;
   *)
     usage "Error: unhandled option: $opt"
     ;;
@@ -162,6 +168,11 @@ for val in "${zone[@]}"; do
   zone_args+=("-z $val")
 done
 
+if $stopNetwork; then
+  $skipSetup=true
+fi
+
+# Create the network
 if ! $skipSetup; then
   echo "--- $cloudProvider.sh delete"
   # shellcheck disable=SC2068
@@ -226,6 +237,12 @@ net/init-metrics.sh -e
 
 echo "+++ $cloudProvider.sh info"
 net/"$cloudProvider".sh info
+
+if $stopNetwork; then
+  echo --- net.sh stop
+  time net/net.sh stop
+  exit 0
+fi
 
 echo --- net.sh start
 maybeRejectExtraNodes=

--- a/ci/testnet-manager.sh
+++ b/ci/testnet-manager.sh
@@ -284,14 +284,15 @@ deploy() {
       done
 
       if [[ -n $EC2_NODE_COUNT ]]; then
-        if [[ -n $GCE_NODE_COUNT ]]; then
-          skipStart="skip"
+        if [[ -n $GCE_NODE_COUNT ]] || [[ -n $skipStart ]]; then
+          maybeSkipStart="skip"
         fi
+
         # shellcheck disable=SC2068
         ci/testnet-deploy.sh -p beta-testnet-solana-com -C ec2 ${EC2_ZONE_ARGS[@]} \
           -t "$CHANNEL_OR_TAG" -n "$EC2_NODE_COUNT" -c 0 -u -P -a eipalloc-0f286cf8a0771ce35 \
           ${skipCreate:+-r} \
-          ${skipStart:+-s} \
+          ${maybeSkipStart:+-s} \
           ${maybeStop:+-S} \
           ${maybeDelete:+-D}
       fi


### PR DESCRIPTION
#### Problem

We need to manage high level behavior for multiple testnets and be able to create/delete and start/stop the network on-demand as needed, not just on an hourly or daily cadence.

#### Summary of Changes

Enhance the range of values of TESTNET_OP for more granular behavior that can easily be triggered from buildkite by just setting the testnet name and desired operation.  Tried to leave existing plumbing as unchanged as possible, but it's rather clunky.

Fixes #3691 #
