### PR TITLE
Fix issues with bench-tps

### DIFF
--- a/bench-tps/src/bench.rs
+++ b/bench-tps/src/bench.rs
@@ -158,7 +158,6 @@ pub fn do_bench_tps<T>(
             &keypairs[len..],
             threads,
             reclaim_lamports_back_to_source_account,
-            &client,
         );
         // In sustained mode overlap the transfers with generation
         // this has higher average performance but lower peak performance
@@ -280,7 +279,6 @@ fn generate_txs<T: Client>(
     dest: &[Keypair],
     threads: usize,
     reclaim: bool,
-    client: &Arc<T>,
 ) {
     let tx_count = source.len();
     println!("Signing transactions... {} (reclaim={})", tx_count, reclaim);

--- a/bench-tps/src/bench.rs
+++ b/bench-tps/src/bench.rs
@@ -272,7 +272,7 @@ fn sample_tx_count<T: Client>(
     }
 }
 
-fn generate_txs<T: Client>(
+fn generate_txs(
     shared_txs: &SharedTransactions,
     blockhash: &Hash,
     source: &[Keypair],

--- a/bench-tps/src/bench.rs
+++ b/bench-tps/src/bench.rs
@@ -140,9 +140,6 @@ pub fn do_bench_tps<T>(
     let mut i = keypair0_balance;
     let mut blockhash = Hash::default();
     while start.elapsed() < duration {
-        let balance = client.get_balance(&id.pubkey()).unwrap_or(0);
-        metrics_submit_lamport_balance(balance);
-
         // ping-pong between source and destination accounts for each loop iteration
         // this seems to be faster than trying to determine the balance of individual
         // accounts
@@ -155,6 +152,8 @@ pub fn do_bench_tps<T>(
             sleep(Duration::from_millis(100));
             continue;
         }
+        let balance = client.get_balance(&id.pubkey()).unwrap_or(0);
+        metrics_submit_lamport_balance(balance);
         blockhash_time = Instant::now();
         blockhash = new_blockhash;
         generate_txs(

--- a/bench-tps/src/bench.rs
+++ b/bench-tps/src/bench.rs
@@ -5,6 +5,7 @@ use solana::gen_keys::GenKeys;
 use solana_drone::drone::request_airdrop_transaction;
 use solana_metrics::influxdb;
 use solana_sdk::client::Client;
+use solana_sdk::hash::Hash;
 use solana_sdk::signature::{Keypair, KeypairUtil};
 use solana_sdk::system_instruction;
 use solana_sdk::system_transaction;
@@ -136,6 +137,7 @@ pub fn do_bench_tps<T>(
     let start = Instant::now();
     let mut reclaim_lamports_back_to_source_account = false;
     let mut i = keypair0_balance;
+    let mut blockhash = Hash::default();
     while start.elapsed() < duration {
         let balance = client.get_balance(&id.pubkey()).unwrap_or(0);
         metrics_submit_lamport_balance(balance);
@@ -144,8 +146,14 @@ pub fn do_bench_tps<T>(
         // this seems to be faster than trying to determine the balance of individual
         // accounts
         let len = tx_count as usize;
+        let mut new_blockhash = client.get_recent_blockhash().unwrap();
+        while new_blockhash == blockhash {
+            new_blockhash = client.get_recent_blockhash().unwrap();
+        }
+        blockhash = new_blockhash;
         generate_txs(
             &shared_txs,
+            &blockhash,
             &keypairs[..len],
             &keypairs[len..],
             threads,
@@ -267,13 +275,13 @@ fn sample_tx_count<T: Client>(
 
 fn generate_txs<T: Client>(
     shared_txs: &SharedTransactions,
+    blockhash: &Hash,
     source: &[Keypair],
     dest: &[Keypair],
     threads: usize,
     reclaim: bool,
     client: &Arc<T>,
 ) {
-    let blockhash = client.get_recent_blockhash().unwrap();
     let tx_count = source.len();
     println!("Signing transactions... {} (reclaim={})", tx_count, reclaim);
     let signing_start = Instant::now();
@@ -287,7 +295,7 @@ fn generate_txs<T: Client>(
         .par_iter()
         .map(|(id, keypair)| {
             (
-                system_transaction::create_user_account(id, &keypair.pubkey(), 1, blockhash, 0),
+                system_transaction::create_user_account(id, &keypair.pubkey(), 1, *blockhash, 0),
                 timestamp(),
             )
         })
@@ -630,9 +638,13 @@ pub fn generate_keypairs(id: &Keypair, tx_count: usize) -> Vec<Keypair> {
 
     let mut total_keys = 0;
     let mut target = tx_count * 2;
-    while target > 0 {
+    while target > 1 {
         total_keys += target;
-        target /= MAX_SPENDS_PER_TX;
+        // Use the upper bound for this division otherwise it may not generate enough keys
+        target = match target.checked_rem(MAX_SPENDS_PER_TX) {
+            Some(0) => target / MAX_SPENDS_PER_TX,
+            _ => target / MAX_SPENDS_PER_TX + 1,
+        };
     }
     rnd.gen_n_keypairs(total_keys as u64)
 }

--- a/bench-tps/src/bench.rs
+++ b/bench-tps/src/bench.rs
@@ -135,6 +135,7 @@ pub fn do_bench_tps<T>(
 
     // generate and send transactions for the specified duration
     let start = Instant::now();
+    let mut blockhash_time = Instant::now();
     let mut reclaim_lamports_back_to_source_account = false;
     let mut i = keypair0_balance;
     let mut blockhash = Hash::default();
@@ -146,11 +147,15 @@ pub fn do_bench_tps<T>(
         // this seems to be faster than trying to determine the balance of individual
         // accounts
         let len = tx_count as usize;
-        let mut new_blockhash = client.get_recent_blockhash().unwrap();
+        let new_blockhash = client.get_recent_blockhash().unwrap_or_default();
         if new_blockhash == blockhash {
+            if blockhash_time.elapsed().as_secs() > 10 {
+                println!("Blockhash has not updating");
+            }
             sleep(Duration::from_millis(100));
             continue;
         }
+        blockhash_time = Instant::now();
         blockhash = new_blockhash;
         generate_txs(
             &shared_txs,

--- a/bench-tps/src/bench.rs
+++ b/bench-tps/src/bench.rs
@@ -147,9 +147,9 @@ pub fn do_bench_tps<T>(
         // accounts
         let len = tx_count as usize;
         let mut new_blockhash = client.get_recent_blockhash().unwrap();
-        while new_blockhash == blockhash {
+        if new_blockhash == blockhash {
             sleep(Duration::from_millis(100));
-            new_blockhash = client.get_recent_blockhash().unwrap();
+            continue;
         }
         blockhash = new_blockhash;
         generate_txs(

--- a/bench-tps/src/bench.rs
+++ b/bench-tps/src/bench.rs
@@ -148,7 +148,7 @@ pub fn do_bench_tps<T>(
             blockhash = new_blockhash;
         } else {
             if blockhash_time.elapsed().as_secs() > 30 {
-                panic!("Blockhash has not updating");
+                panic!("Blockhash is not updating");
             }
             sleep(Duration::from_millis(100));
             continue;

--- a/bench-tps/src/bench.rs
+++ b/bench-tps/src/bench.rs
@@ -148,6 +148,7 @@ pub fn do_bench_tps<T>(
         let len = tx_count as usize;
         let mut new_blockhash = client.get_recent_blockhash().unwrap();
         while new_blockhash == blockhash {
+            sleep(Duration::from_millis(100));
             new_blockhash = client.get_recent_blockhash().unwrap();
         }
         blockhash = new_blockhash;

--- a/bench-tps/src/main.rs
+++ b/bench-tps/src/main.rs
@@ -79,10 +79,6 @@ fn main() {
     }
     // `generate_keypairs` generates more keys than we care about. filter down to tx_count * 2 for correct spends later
     keypairs.truncate(2 * tx_count);
-    // make sure every keypair has balance, otherwise we end up sending invalid(AccountNotFound) txs to the cluster
-    for key in &keypairs {
-        clients[0].get_balance(&key.pubkey()).unwrap();
-    }
 
     let config = Config {
         id,

--- a/bench-tps/src/main.rs
+++ b/bench-tps/src/main.rs
@@ -67,7 +67,7 @@ fn main() {
     // Sample the first keypair, see if it has lamports, if so then resume.
     // This logic is to prevent lamport loss on repeated solana-bench-tps executions
     let keypair0_balance = clients[0]
-        .get_balance(&keypairs.last().unwrap().pubkey())
+        .get_balance(&keypairs[tx_count * 2 - 1].pubkey())
         .unwrap_or(0);
 
     if NUM_LAMPORTS_PER_ACCOUNT > keypair0_balance {
@@ -77,7 +77,7 @@ fn main() {
         println!("adding more lamports {}", extra);
         fund_keys(&clients[0], &id, &keypairs, extra);
     }
-    // `generate_keypairs` generates more keys than we care about. filter down to tx_count * 2 for correct spends later
+    // 'generate_keypairs' generates extra keys to be able to have size-aligned funding batches for fund_keys.
     keypairs.truncate(2 * tx_count);
 
     let config = Config {

--- a/bench-tps/src/main.rs
+++ b/bench-tps/src/main.rs
@@ -60,7 +60,7 @@ fn main() {
         .collect();
 
     println!("Creating {} keypairs...", tx_count * 2);
-    let keypairs = generate_keypairs(&id, tx_count);
+    let mut keypairs = generate_keypairs(&id, tx_count);
 
     println!("Get lamports...");
 
@@ -76,6 +76,12 @@ fn main() {
         airdrop_lamports(&clients[0], &drone_addr, &id, total);
         println!("adding more lamports {}", extra);
         fund_keys(&clients[0], &id, &keypairs, extra);
+    }
+    // `generate_keypairs` generates more keys than we care about. filter down to tx_count * 2 for correct spends later
+    keypairs.truncate(2 * tx_count);
+    // make sure every keypair has balance, otherwise we end up sending invalid(AccountNotFound) txs to the cluster
+    for key in &keypairs {
+        clients[0].get_balance(&key.pubkey()).unwrap();
     }
 
     let config = Config {

--- a/client/src/thin_client.rs
+++ b/client/src/thin_client.rs
@@ -115,10 +115,6 @@ impl ThinClient {
         ))
     }
 
-    pub fn get_new_blockhash(&self, blockhash: &Hash) -> io::Result<Hash> {
-        self.rpc_client.get_new_blockhash(blockhash)
-    }
-
     pub fn poll_balance_with_timeout(
         &self,
         pubkey: &Pubkey,
@@ -237,6 +233,11 @@ impl SyncClient for ThinClient {
 
     fn poll_for_signature(&self, signature: &Signature) -> TransportResult<()> {
         Ok(self.rpc_client.poll_for_signature(signature)?)
+    }
+
+    fn get_new_blockhash(&self, blockhash: &Hash) -> TransportResult<Hash> {
+        let new_blockhash = self.rpc_client.get_new_blockhash(blockhash)?;
+        Ok(new_blockhash)
     }
 }
 

--- a/runtime/src/bank_client.rs
+++ b/runtime/src/bank_client.rs
@@ -179,8 +179,7 @@ impl BankClient {
         }
     }
 
-    pub fn new(bank: Bank) -> Self {
-        let bank = Arc::new(bank);
+    pub fn new_shared(bank: &Arc<Bank>) -> Self {
         let (transaction_sender, transaction_receiver) = channel();
         let transaction_sender = Mutex::new(transaction_sender);
         let thread_bank = bank.clone();
@@ -193,6 +192,10 @@ impl BankClient {
             bank,
             transaction_sender,
         }
+    }
+
+    pub fn new(bank: Bank) -> Self {
+        Self::new_shared(&Arc::new(bank))
     }
 }
 

--- a/sdk/src/client.rs
+++ b/sdk/src/client.rs
@@ -60,6 +60,8 @@ pub trait SyncClient {
 
     /// Poll to confirm a transaction.
     fn poll_for_signature(&self, signature: &Signature) -> Result<()>;
+
+    fn get_new_blockhash(&self, blockhash: &Hash) -> Result<Hash>;
 }
 
 pub trait AsyncClient {


### PR DESCRIPTION
#### Problems

1. Bench tps doesn't make sure all generated keys are actually funded and alive. Resulting in numerous account not found errors. 

2. Bench tps doesn't wait for transaction signatures and aggressively loops while trying to send new transactions with a new blockhash. Our blockhashes don't cycle fast enough and so it floods the network with duplicate transactions. 

#### Summary of Changes

- [X] Fix account not found errors by fixing how many keys are generated to make sure the minimum set of accounts we care about (--tx_count *  2) are always funded. 
- [X] Fix duplicate transactions by waiting for a new blockhash in the generate_txs loop. 

Thanks for all the help @pgarg66

Fixes #3983
