### PR TITLE
Implement demo testnet in testnet manager

### DIFF
--- a/ci/testnet-deploy.sh
+++ b/ci/testnet-deploy.sh
@@ -19,6 +19,7 @@ enableGpu=false
 bootDiskType=""
 leaderRotation=true
 blockstreamer=false
+stopNetwork=false
 
 usage() {
   exitcode=0

--- a/ci/testnet-manager.sh
+++ b/ci/testnet-manager.sh
@@ -207,6 +207,21 @@ sanity() {
       #ci/testnet-sanity.sh perf-testnet-solana-com ec2 us-east-1a
     )
     ;;
+  testnet-demo)
+    (
+      set -x
+
+      ok=true
+      if [[ -n $GCE_NODE_COUNT ]]; then
+        NO_LEDGER_VERIFY=1 \
+          ci/testnet-sanity.sh demo-testnet-solana-com gce "${GCE_ZONES[0]}" || ok=false
+      else
+        echo "Error: no GCE nodes"
+        ok=false
+      fi
+      $ok
+    )
+    ;;
   *)
     echo "Error: Invalid TESTNET=$TESTNET"
     exit 1

--- a/ci/testnet-manager.sh
+++ b/ci/testnet-manager.sh
@@ -399,7 +399,7 @@ deploy() {
 
       if [[ -n $GCE_NODE_COUNT ]]; then
         # shellcheck disable=SC2068
-        ci/testnet-deploy.sh -p demo-testnet-solana-com -C gce ${GCE_ZONE_ARGS[@]} \
+        ci/testnet-deploy.sh -p testnet-demo -C gce ${GCE_ZONE_ARGS[@]} \
           -t "$CHANNEL_OR_TAG" -n "$GCE_NODE_COUNT" -c 2 -P -u \
           -a demo-testnet-solana-com \
           ${skipCreate:+-r} \
@@ -417,33 +417,21 @@ deploy() {
 }
 
 ENABLED_LOCKFILE="${HOME}/${TESTNET}.is_enabled"
-CREATED_LOCKFILE="${HOME}/${TESTNET}.is_created"
 
 create-and-start() {
-  rm -f "${CREATED_LOCKFILE}"
   deploy create start
-  touch "${CREATED_LOCKFILE}"
 }
 create() {
-  rm -f "${CREATED_LOCKFILE}"
   deploy create
-  touch "${CREATED_LOCKFILE}"
 }
 start() {
-  if [[ -f ${CREATED_LOCKFILE} ]]; then
-    deploy "" start
-  else
-    echo "Unable to start ${TESTNET}.  Are the nodes created?
-    Re-run ci/testnet-manager.sh with \$TESTNET_OP=create or \$TESTNET_OP=create-and-start"
-    exit 1
-  fi
+  deploy "" start
 }
 stop() {
   deploy "" ""
 }
 delete() {
   deploy "" "" "" delete
-  rm -f "${CREATED_LOCKFILE}"
 }
 enable_testnet() {
   touch "${ENABLED_LOCKFILE}"

--- a/ci/testnet-manager.sh
+++ b/ci/testnet-manager.sh
@@ -371,8 +371,27 @@ deploy() {
   testnet-demo)
     (
       set -x
-      echo "Demo net not yet implemented!"
-      exit 1
+
+    # TODO: Increase zone list to maximum
+#      GCE_DEMO_ZONES=(us-west1-b asia-east2-a europe-west4-a southamerica-east1-b us-east4-c)
+      GCE_DEMO_ZONES=(us-west1-b us-east4-c)
+
+      # Build an array to pass as opts to testnet-deploy.sh: "-z zone1 -z zone2 ..."
+      GCE_ZONE_ARGS=()
+      for val in "${GCE_DEMO_ZONES[@]}"; do
+        GCE_ZONE_ARGS+=("-z $val")
+      done
+
+      if [[ -n $GCE_NODE_COUNT ]]; then
+        # shellcheck disable=SC2068
+        ci/testnet-deploy.sh -p demo-testnet-solana-com -C gce ${GCE_ZONE_ARGS[@]} \
+          -t "$CHANNEL_OR_TAG" -n "$GCE_NODE_COUNT" -c 2 -P -u \
+          -a demo-testnet-solana-com \
+          ${skipCreate:+-r} \
+          ${skipStart:+-s} \
+          ${maybeStop:+-S} \
+          ${maybeDelete:+-D}
+      fi
     )
     ;;
   *)


### PR DESCRIPTION
#### Problem
Need a demo testnet on as many regions as possible given current stability limitations

#### Summary of Changes
Implement demo testnet deployment in testnet manager so we can start/stop on demand from buildkite.

Fixes #3802 

