### PR TITLE
Reduce submit frequency of counters that are very frequent and killing metrics DB

### DIFF
--- a/core/src/blocktree.rs
+++ b/core/src/blocktree.rs
@@ -1297,12 +1297,12 @@ fn try_erasure_recover(
                 Err(e) => return Err(e),
             }
         }
-        ErasureMetaStatus::StillNeed(needed) => {
-            inc_new_counter_info!("blocktree-erasure-blobs_needed", needed);
+        ErasureMetaStatus::StillNeed(_needed) => {
+            // inc_new_counter_info!("blocktree-erasure-blobs_needed", needed);
             None
         }
         ErasureMetaStatus::DataFull => {
-            inc_new_counter_info!("blocktree-erasure-complete", 1);
+            // inc_new_counter_info!("blocktree-erasure-complete", 1);
             None
         }
     };

--- a/core/src/blocktree.rs
+++ b/core/src/blocktree.rs
@@ -1297,12 +1297,12 @@ fn try_erasure_recover(
                 Err(e) => return Err(e),
             }
         }
-        ErasureMetaStatus::StillNeed(_needed) => {
-            // inc_new_counter_info!("blocktree-erasure-blobs_needed", needed);
+        ErasureMetaStatus::StillNeed(needed) => {
+            inc_new_counter_info!("blocktree-erasure-blobs_needed", needed, 0, 1000);
             None
         }
         ErasureMetaStatus::DataFull => {
-            // inc_new_counter_info!("blocktree-erasure-complete", 1);
+            inc_new_counter_info!("blocktree-erasure-complete", 1, 0, 1000);
             None
         }
     };

--- a/core/src/cluster_info.rs
+++ b/core/src/cluster_info.rs
@@ -1132,7 +1132,7 @@ impl ClusterInfo {
         data: &[CrdsValue],
     ) -> Vec<SharedBlob> {
         let self_id = me.read().unwrap().gossip.id;
-        // inc_new_counter_info!("cluster_info-push_message", 1);
+        inc_new_counter_info!("cluster_info-push_message", 1, 0, 1000);
         let prunes: Vec<_> = me
             .write()
             .unwrap()

--- a/core/src/cluster_info.rs
+++ b/core/src/cluster_info.rs
@@ -1132,7 +1132,7 @@ impl ClusterInfo {
         data: &[CrdsValue],
     ) -> Vec<SharedBlob> {
         let self_id = me.read().unwrap().gossip.id;
-        inc_new_counter_info!("cluster_info-push_message", 1);
+        // inc_new_counter_info!("cluster_info-push_message", 1);
         let prunes: Vec<_> = me
             .write()
             .unwrap()

--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -36,7 +36,7 @@ fn retransmit_blobs(blobs: &[SharedBlob], retransmit: &BlobSender, id: &Pubkey) 
     }
 
     if !retransmit_queue.is_empty() {
-        inc_new_counter_info!("streamer-recv_window-retransmit", retransmit_queue.len());
+        // inc_new_counter_info!("streamer-recv_window-retransmit", retransmit_queue.len());
         retransmit.send(retransmit_queue)?;
     }
     Ok(())
@@ -117,7 +117,7 @@ fn recv_window(
         blobs.append(&mut blob)
     }
     let now = Instant::now();
-    inc_new_counter_info!("streamer-recv_window-recv", blobs.len());
+    // inc_new_counter_info!("streamer-recv_window-recv", blobs.len());
 
     blobs.retain(|blob| {
         should_retransmit_and_persist(

--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -36,7 +36,12 @@ fn retransmit_blobs(blobs: &[SharedBlob], retransmit: &BlobSender, id: &Pubkey) 
     }
 
     if !retransmit_queue.is_empty() {
-        inc_new_counter_info!("streamer-recv_window-retransmit", retransmit_queue.len(), 0, 1000);
+        inc_new_counter_info!(
+            "streamer-recv_window-retransmit",
+            retransmit_queue.len(),
+            0,
+            1000
+        );
         retransmit.send(retransmit_queue)?;
     }
     Ok(())

--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -36,7 +36,7 @@ fn retransmit_blobs(blobs: &[SharedBlob], retransmit: &BlobSender, id: &Pubkey) 
     }
 
     if !retransmit_queue.is_empty() {
-        // inc_new_counter_info!("streamer-recv_window-retransmit", retransmit_queue.len());
+        inc_new_counter_info!("streamer-recv_window-retransmit", retransmit_queue.len(), 0, 1000);
         retransmit.send(retransmit_queue)?;
     }
     Ok(())
@@ -117,7 +117,7 @@ fn recv_window(
         blobs.append(&mut blob)
     }
     let now = Instant::now();
-    // inc_new_counter_info!("streamer-recv_window-recv", blobs.len());
+    inc_new_counter_info!("streamer-recv_window-recv", blobs.len(), 0, 1000);
 
     blobs.retain(|blob| {
         should_retransmit_and_persist(


### PR DESCRIPTION
#### Problem
Influx DB is crashing.

#### Summary of Changes
Some counters are flooding the influx DB with frequent updates. Reduced the frequency at which these counters are submitted to the metrics DB