### PR TITLE
Add usage to net.sh when it encounters an invalid argument

### DIFF
--- a/net/net.sh
+++ b/net/net.sh
@@ -621,5 +621,6 @@ logs)
 
 *)
   echo "Internal error: Unknown command: $command"
+  usage
   exit 1
 esac


### PR DESCRIPTION
#### Problem

net.sh -h doesn't print anything but  "Unknown command -h".

#### Summary of Changes

This will print the usage whenever this invalid command condition occurs.

Fixes #