### PR TITLE
Blockstreamer annotation fix for non buildkite deployments

### DIFF
--- a/net/net.sh
+++ b/net/net.sh
@@ -188,9 +188,9 @@ else
 fi
 
 annotate() {
-  ${BUILDKITE:-false} && {
+  [[ -z $BUILDKITE ]] || {
     buildkite-agent annotate "$@"
-  } || true
+  }
 }
 
 annotateBlockexplorerUrl() {

--- a/net/net.sh
+++ b/net/net.sh
@@ -190,7 +190,7 @@ fi
 annotate() {
   ${BUILDKITE:-false} && {
     buildkite-agent annotate "$@"
-  }
+  } || true
 }
 
 annotateBlockexplorerUrl() {


### PR DESCRIPTION
#### Problem
Bench clients do not launch for dev tesnet when blockstreamer is deployed

#### Summary of Changes
Blockstream annotate returns failure when the testnet is deployed from buildkite. This stops the script before clients are deployed. Fixed the script