### PR TITLE
Use GPU nodes for blockstreamer as well if rest of testnet has GPUs

### DIFF
--- a/net/gce.sh
+++ b/net/gce.sh
@@ -163,11 +163,13 @@ while getopts "h?p:Pn:c:z:gG:a:d:buxf" opt; do
     enableGpu=true
     bootstrapLeaderMachineType=$gpuBootstrapLeaderMachineType
     fullNodeMachineType=$bootstrapLeaderMachineType
+    blockstreamerMachineType=$bootstrapLeaderMachineType
     ;;
   G)
     enableGpu=true
     bootstrapLeaderMachineType="$OPTARG"
     fullNodeMachineType=$bootstrapLeaderMachineType
+    blockstreamerMachineType=$bootstrapLeaderMachineType
     ;;
   a)
     customAddress=$OPTARG


### PR DESCRIPTION
#### Problem
The blockstreamer doesn't bootup in a GPU based testnet.

#### Summary of Changes
The blockstreamer node is configured without GPU. It crashes as sigverify() looks for CUDA libs

Fixes #
