### PR TITLE
Fast bank ancestor check

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -124,7 +124,7 @@ pub struct Bank {
     parent: RwLock<Option<Arc<Bank>>>,
 
     /// The set of parents including this bank
-    ancestors: HashMap<u64, usize>,
+    pub ancestors: HashMap<u64, usize>,
 
     /// Hash of this Bank's state. Only meaningful after freezing.
     hash: RwLock<Hash>,


### PR DESCRIPTION
#### Problem

Parents check requires a lock.

#### Summary of Changes

Use the ancestor hashmap.

tag: @sakridge this might remove a big pile of thread contention

Fixes #
