### PR TITLE
Roots are added out of order to the accounts index

### DIFF
--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -66,11 +66,11 @@ impl<T: Clone> AccountsIndex<T> {
         self.roots.contains(&fork)
     }
     pub fn add_root(&mut self, fork: Fork) {
-        if fork > self.last_root {
-            self.last_root = fork;
-        } else {
-            assert!(fork == 0, "new roots must be increasing");
-        }
+        assert!(
+            fork == 0 || fork > self.last_root,
+            "new roots must be increasing"
+        );
+        self.last_root = fork;
         self.roots.insert(fork);
     }
     /// Remove the fork when the storage for the fork is freed

--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -67,7 +67,7 @@ impl<T: Clone> AccountsIndex<T> {
     }
     pub fn add_root(&mut self, fork: Fork) {
         assert!(
-            fork == 0 || fork > self.last_root,
+            (self.last_root == 0 && fork == 0) || (fork > self.last_root),
             "new roots must be increasing"
         );
         self.last_root = fork;

--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -158,8 +158,15 @@ mod tests {
     fn test_max_last_root() {
         let mut index = AccountsIndex::<bool>::default();
         index.add_root(1);
-        index.add_root(0);
         assert_eq!(index.last_root, 1);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_max_last_root_old() {
+        let mut index = AccountsIndex::<bool>::default();
+        index.add_root(1);
+        index.add_root(0);
     }
 
     #[test]

--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -68,6 +68,8 @@ impl<T: Clone> AccountsIndex<T> {
     pub fn add_root(&mut self, fork: Fork) {
         if fork > self.last_root {
             self.last_root = fork;
+        } else {
+            assert!(fork == 0, "new roots must be increasing");
         }
         self.roots.insert(fork);
     }

--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -172,8 +172,8 @@ mod tests {
     #[test]
     fn test_cleanup_first() {
         let mut index = AccountsIndex::<bool>::default();
-        index.add_root(1);
         index.add_root(0);
+        index.add_root(1);
         index.cleanup_dead_fork(0);
         assert!(index.is_root(1));
         assert!(!index.is_root(0));
@@ -183,8 +183,8 @@ mod tests {
     fn test_cleanup_last() {
         //this behavior might be undefined, clean up should only occur on older forks
         let mut index = AccountsIndex::<bool>::default();
-        index.add_root(1);
         index.add_root(0);
+        index.add_root(1);
         index.cleanup_dead_fork(1);
         assert!(!index.is_root(1));
         assert!(index.is_root(0));

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -293,7 +293,7 @@ impl Bank {
         *self.parent.write().unwrap() = None;
 
         let squash_accounts_start = Instant::now();
-        for p in &parents {
+        for p in parents.iter().rev() {
             // root forks cannot be purged
             self.accounts.add_root(p.slot());
         }


### PR DESCRIPTION
#### Problem

Bank adds roots out of order.

#### Summary of Changes

Add roots in order.  Assert roots are added in order.

Fixes #