### PR TITLE
Change forwarded metrics to be in line with fetch stage metrics

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -131,7 +131,7 @@ impl BankingStage {
             .iter()
             .flat_map(|(p, start_index)| &p.packets[**start_index..])
             .collect();
-        inc_new_counter_info!("banking_stage-forwarded_packets", packets.len());
+        inc_new_counter_info!("banking_stage-forwarded_packets", locked_packets.len());
         let blobs = packet::packets_to_blobs(&packets);
 
         for blob in blobs {


### PR DESCRIPTION
#### Problem
Forwarding metric counts Packet instead of Packets (fetch stage counts Packets), which inflates the number of forwarded Packets in the dashboard metric

#### Summary of Changes
Count Packets in forwarding metric

Fixes #
