### PR TITLE
Reduce locking in Blocktree

### DIFF
--- a/core/src/blocktree/kvs.rs
+++ b/core/src/blocktree/kvs.rs
@@ -119,6 +119,36 @@ impl TypedColumn<Kvs> for cf::Orphans {
     type Type = bool;
 }
 
+impl Column<Kvs> for cf::Root {
+    const NAME: &'static str = super::ROOT_CF;
+    type Index = ();
+
+    fn key(_: ()) -> Key {
+        Key::default()
+    }
+
+    fn index(_: &Key) {}
+}
+
+impl TypedColumn<Kvs> for cf::Root {
+    type Type = u64;
+}
+
+impl Column<Kvs> for cf::SlotMeta {
+    const NAME: &'static str = super::META_CF;
+    type Index = u64;
+
+    fn key(slot: u64) -> Key {
+        let mut key = Key::default();
+        BigEndian::write_u64(&mut key.0[8..16], slot);
+        key
+    }
+
+    fn index(key: &Key) -> u64 {
+        BigEndian::read_u64(&key.0[8..16])
+    }
+}
+
 impl Column<Kvs> for cf::SlotMeta {
     const NAME: &'static str = super::META_CF;
     type Index = u64;

--- a/core/src/blocktree/meta.rs
+++ b/core/src/blocktree/meta.rs
@@ -24,8 +24,6 @@ pub struct SlotMeta {
     // True if this slot is full (consumed == last_index + 1) and if every
     // slot that is a parent of this slot is also connected.
     pub is_connected: bool,
-    // True if this slot is a root
-    pub is_root: bool,
 }
 
 impl SlotMeta {
@@ -68,7 +66,6 @@ impl SlotMeta {
             parent_slot,
             next_slots: vec![],
             is_connected: slot == 0,
-            is_root: false,
             last_index: std::u64::MAX,
         }
     }

--- a/core/src/blocktree/rocks.rs
+++ b/core/src/blocktree/rocks.rs
@@ -170,6 +170,21 @@ impl TypedColumn<Rocks> for cf::Orphans {
     type Type = bool;
 }
 
+impl Column<Rocks> for cf::Root {
+    const NAME: &'static str = super::ROOT_CF;
+    type Index = ();
+
+    fn key(_: ()) -> Vec<u8> {
+        vec![0; 8]
+    }
+
+    fn index(_: &[u8]) {}
+}
+
+impl TypedColumn<Rocks> for cf::Root {
+    type Type = u64;
+}
+
 impl Column<Rocks> for cf::SlotMeta {
     const NAME: &'static str = super::META_CF;
     type Index = u64;

--- a/core/src/blocktree/rocks.rs
+++ b/core/src/blocktree/rocks.rs
@@ -30,7 +30,7 @@ impl Backend for Rocks {
     type Error = rocksdb::Error;
 
     fn open(path: &Path) -> Result<Rocks> {
-        use crate::blocktree::db::columns::{Coding, Data, ErasureMeta, Orphans, SlotMeta};
+        use crate::blocktree::db::columns::{Coding, Data, ErasureMeta, Orphans, Root, SlotMeta};
 
         fs::create_dir_all(&path)?;
 
@@ -44,6 +44,7 @@ impl Backend for Rocks {
         let erasure_meta_cf_descriptor =
             ColumnFamilyDescriptor::new(ErasureMeta::NAME, get_cf_options());
         let orphans_cf_descriptor = ColumnFamilyDescriptor::new(Orphans::NAME, get_cf_options());
+        let root_cf_descriptor = ColumnFamilyDescriptor::new(Root::NAME, get_cf_options());
 
         let cfs = vec![
             meta_cf_descriptor,
@@ -51,6 +52,7 @@ impl Backend for Rocks {
             erasure_cf_descriptor,
             erasure_meta_cf_descriptor,
             orphans_cf_descriptor,
+            root_cf_descriptor,
         ];
 
         // Open the database
@@ -60,13 +62,14 @@ impl Backend for Rocks {
     }
 
     fn columns(&self) -> Vec<&'static str> {
-        use crate::blocktree::db::columns::{Coding, Data, ErasureMeta, Orphans, SlotMeta};
+        use crate::blocktree::db::columns::{Coding, Data, ErasureMeta, Orphans, Root, SlotMeta};
 
         vec![
             Coding::NAME,
             ErasureMeta::NAME,
             Data::NAME,
             Orphans::NAME,
+            Root::NAME,
             SlotMeta::NAME,
         ]
     }

--- a/core/src/repair_service.rs
+++ b/core/src/repair_service.rs
@@ -201,7 +201,7 @@ impl RepairService {
     fn generate_repairs(blocktree: &Blocktree, max_repairs: usize) -> Result<(Vec<RepairType>)> {
         // Slot height and blob indexes for blobs we want to repair
         let mut repairs: Vec<RepairType> = vec![];
-        let slot = *blocktree.root_slot.read().unwrap();
+        let slot = blocktree.get_root()?;
         Self::generate_repairs_for_fork(blocktree, &mut repairs, max_repairs, slot);
 
         // TODO: Incorporate gossip to determine priorities for repair?


### PR DESCRIPTION
#### Problem
Unnecessary locking in Blocktree. See issue #4023 for more.

#### Summary of Changes
Create new `BatchProcessor` type to produc  and consume WriteBatches. It's now the only thing behind an `RwLock`.

Remove database argument from `LedgerColumn` methods since it's no longer behind a lock.

Fixes #4023
