### PR TITLE
Add non_default_stream parameter to ed25519_verify_many

### DIFF
--- a/core/src/sigverify.rs
+++ b/core/src/sigverify.rs
@@ -42,6 +42,7 @@ extern "C" {
         signature_offsets: *const u32,
         signed_message_offsets: *const u32,
         out: *mut u8, //combined length of all the items in vecs
+        use_non_default_stream: u8,
     ) -> u32;
 
     pub fn chacha_cbc_encrypt_many_sample(
@@ -245,6 +246,7 @@ pub fn ed25519_verify(batches: &[Packets]) -> Vec<Vec<u8>> {
     trace!("elem len: {}", elems.len() as u32);
     trace!("packet sizeof: {}", size_of::<Packet>() as u32);
     trace!("len offset: {}", PACKET_DATA_SIZE as u32);
+    const USE_NON_DEFAULT_STREAM: u8 = 1;
     unsafe {
         let res = ed25519_verify_many(
             elems.as_ptr(),
@@ -257,6 +259,7 @@ pub fn ed25519_verify(batches: &[Packets]) -> Vec<Vec<u8>> {
             signature_offsets.as_ptr(),
             msg_start_offsets.as_ptr(),
             out.as_mut_ptr(),
+            USE_NON_DEFAULT_STREAM,
         );
         if res != 0 {
             trace!("RETURN!!!: {}", res);

--- a/fetch-perf-libs.sh
+++ b/fetch-perf-libs.sh
@@ -16,7 +16,7 @@ mkdir -p target/perf-libs
   cd target/perf-libs
   (
     set -x
-    curl https://solana-perf.s3.amazonaws.com/v0.11.1/x86_64-unknown-linux-gnu/solana-perf.tgz | tar zxvf -
+    curl https://solana-perf.s3.amazonaws.com/v0.12.0/x86_64-unknown-linux-gnu/solana-perf.tgz | tar zxvf -
   )
 
   if [[ -r solana-perf-CUDA_HOME.txt ]]; then


### PR DESCRIPTION
#### Problem

sigverify interface has a new argument for setting a knob to overlap gpu streams.

#### Summary of Changes

Add the argument and update the perf libs version.

Fixes #
