### PR TITLE
Add 1 decimal to validator confirmation

### DIFF
--- a/metrics/testnet-monitor.json
+++ b/metrics/testnet-monitor.json
@@ -1921,7 +1921,8 @@
           "logBase": 1,
           "max": null,
           "min": null,
-          "show": true
+          "show": true,
+          "decimals": 1
         },
         {
           "format": "short",


### PR DESCRIPTION
#### Problem

Validator confirmation time y axis is only 1 second resolution and 1.5 seconds looks like 1 second.

#### Summary of Changes

Add 1 decimal point to the confirmation graph so that 1.5 seconds will show as 1 second, 500 ms.

Fixes #
