### PR TITLE
Add swapper back-off

### DIFF
--- a/bench-exchange/src/bench.rs
+++ b/bench-exchange/src/bench.rs
@@ -1018,7 +1018,6 @@ mod tests {
         config.batch_size = 100; // 1000;
         config.chunk_size = 10; // 200;
         config.account_groups = 1; // 10;
-
         let Config {
             fund_amount,
             batch_size,

--- a/bench-exchange/src/bench.rs
+++ b/bench-exchange/src/bench.rs
@@ -397,7 +397,7 @@ fn swapper<T>(
                 == 0
             {
                 tries += 1;
-                if tries > max_tries {
+                if tries >= max_tries {
                     if exit_signal.load(Ordering::Relaxed) {
                         break 'outer;
                     }
@@ -417,6 +417,7 @@ fn swapper<T>(
                 trade_index = thread_rng().gen_range(0, trade_infos.len());
             }
             max_tries = CHECK_TX_TIMEOUT_MAX_MS / CHECK_TX_DELAY_MS;
+            dumps = 0;
 
             trade_infos.iter().for_each(|info| {
                 order_book
@@ -1011,9 +1012,9 @@ mod tests {
 
         let mut config = Config::default();
         config.identity = Keypair::new();
-        config.threads = 1;
         config.duration = Duration::from_secs(1);
         config.fund_amount = 100_000;
+        config.threads = 1;
         config.transfer_delay = 20; // 15
         config.batch_size = 100; // 1000;
         config.chunk_size = 10; // 200;
@@ -1083,9 +1084,9 @@ mod tests {
 
         let mut config = Config::default();
         config.identity = identity;
-        config.threads = 1;
         config.duration = Duration::from_secs(1);
         config.fund_amount = 100_000;
+        config.threads = 1;
         config.transfer_delay = 20; // 0;
         config.batch_size = 100; // 1500;
         config.chunk_size = 10; // 1500;


### PR DESCRIPTION
#### Problem

Bench-exchange's swapper waits for a long time for trade confirmation before sending swaps in order to deal with long network transaction back-logs.  Problem is it waits so long that if there is a dead node all the transactions in that slot are dropped and the swapper never catches up because its waiting a long time for each dropped batch

#### Summary of Changes

Put a back-off mechanism in, if the swapper waits an enitre timeout and has to drop a packet then half the timeout next time, and the next time, etc..  Eventually it will start dropping packets until it finds a good one.  Also added a delay in the swapper that is half the delay of the trader.  This way the swapper won't flood the network when it starts swapping again.

One problem is this conflicts with network back-log where the swapper will start dropping lots of packets while the backlog is long, if the backlog stays large the swapper will never catch up.  Probably need to ping pong between long waits and the back-off.  Input welcome.

Fixes #
