### PR TITLE
Support local SSDs on fullnodes

### DIFF
--- a/multinode-demo/fullnode.sh
+++ b/multinode-demo/fullnode.sh
@@ -44,7 +44,8 @@ fi
 fullnode_id_path=$SOLANA_CONFIG_DIR/fullnode-id$label.json
 fullnode_vote_id_path=$SOLANA_CONFIG_DIR/fullnode-vote-id$label.json
 ledger_config_dir=$SOLANA_CONFIG_DIR/fullnode-ledger$label
-accounts_config_dir=$SOLANA_CONFIG_DIR/fullnode-accounts$label
+#accounts_config_dir=$SOLANA_CONFIG_DIR/fullnode-accounts$label
+accounts_config_dir=/mnt/disks/nvme0n1,/mnt/disks/nvme0n2,/mnt/disks/nvme0n3,/mnt/disks/nvme0n4
 
 mkdir -p "$SOLANA_CONFIG_DIR"
 [[ -r "$fullnode_id_path" ]] || $solana_keygen -o "$fullnode_id_path"

--- a/net/scripts/gce-provider.sh
+++ b/net/scripts/gce-provider.sh
@@ -126,6 +126,7 @@ cloud_CreateInstances() {
   declare optionalStartupScript="$8"
   declare optionalAddress="$9"
   declare optionalBootDiskType="${10}"
+  declare optionalLocalSSD="${11}"
 
   if $enableGpu; then
     # Custom Ubuntu 18.04 LTS image with CUDA 9.2 and CUDA 10.0 installed
@@ -157,6 +158,7 @@ cloud_CreateInstances() {
     --image "$imageName"
     --maintenance-policy TERMINATE
     --no-restart-on-failure
+    $optionalLocalSSD
   )
 
   # shellcheck disable=SC2206 # Do not want to quote $imageName as it may contain extra args

--- a/net/scripts/setup_gce_ssd.sh
+++ b/net/scripts/setup_gce_ssd.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -e
+set -x
+
+# Create ext4 filesystem and mount all nvme-type SSDs
+
+ssd_list="$(lsblk | grep nvme | cut -f 1 -d " ")"
+
+for ssd in $ssd_list ; do
+  sudo mkfs.ext4 -F /dev/"$ssd"
+  sudo mkdir -p /mnt/disks/"$ssd"
+  sudo mount /dev/"$ssd" /mnt/disks/"$ssd"
+  sudo chmod a+w /mnt/disks/"$ssd"
+done
+
+df -h /mnt/disks/*


### PR DESCRIPTION
A few tweaks to run local SSDs on the GPU nodes.  Not necessarily planning to merge this code, but wanted to have it as a ref for the next time we want to do local SSDs, or make it better to actually go in the code base.

 - run gce.sh with "-s" to add 4 local SSDs to each fullnode.
 - The file setup_gce_ssd.sh needs to be copied to and run on each VM after it is created with gce.sh create -s ...
- Account config dir is hard coded to point at 4 SSDs of known type.  Run net.sh as normal.
