### PR TITLE
Forward transactions to the next slot leader

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -248,7 +248,7 @@ impl BankingStage {
                     {
                         if let Some(sock) = rcluster_info
                             .lookup(&leader_id)
-                            .map_or(None, |x| Some(x.tpu_via_blobs))
+                            .and_then(|x| Some(x.tpu_via_blobs))
                         {
                             let _ = Self::forward_unprocessed_packets(
                                 &socket,
@@ -356,7 +356,7 @@ impl BankingStage {
                         {
                             if let Some(sock) = rcluster_info
                                 .lookup(&leader_id)
-                                .map_or(None, |x| Some(x.tpu_via_blobs))
+                                .and_then(|x| Some(x.tpu_via_blobs))
                             {
                                 let _ = Self::forward_unprocessed_packets(
                                     &socket,

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -246,13 +246,10 @@ impl BankingStage {
                         .unwrap()
                         .next_slot_leader(DEFAULT_TICKS_PER_SLOT, None)
                     {
-                        if let Some(sock) = rcluster_info
-                            .lookup(&leader_id)
-                            .and_then(|x| Some(x.tpu_via_blobs))
-                        {
+                        if let Some(leader) = rcluster_info.lookup(&leader_id) {
                             let _ = Self::forward_unprocessed_packets(
                                 &socket,
-                                &sock,
+                                &leader.tpu_via_blobs,
                                 &buffered_packets,
                             );
                         }
@@ -354,13 +351,10 @@ impl BankingStage {
                             .unwrap()
                             .next_slot_leader(DEFAULT_TICKS_PER_SLOT, None)
                         {
-                            if let Some(sock) = rcluster_info
-                                .lookup(&leader_id)
-                                .and_then(|x| Some(x.tpu_via_blobs))
-                            {
+                            if let Some(leader) = rcluster_info.lookup(&leader_id) {
                                 let _ = Self::forward_unprocessed_packets(
                                     &socket,
-                                    &sock,
+                                    &leader.tpu_via_blobs,
                                     &unprocessed_packets,
                                 );
                             }

--- a/core/src/poh_recorder.rs
+++ b/core/src/poh_recorder.rs
@@ -13,6 +13,7 @@
 use crate::blocktree::Blocktree;
 use crate::entry::Entry;
 use crate::leader_schedule_cache::LeaderScheduleCache;
+use crate::leader_schedule_utils;
 use crate::poh::Poh;
 use crate::result::{Error, Result};
 use solana_runtime::bank::Bank;
@@ -89,6 +90,11 @@ impl PohRecorder {
         });
 
         self.working_bank.is_some() || close_to_leader_tick
+    }
+
+    pub fn next_slot_leader(&self, ticks_per_slot: u64, bank: Option<&Bank>) -> Option<Pubkey> {
+        let slot = leader_schedule_utils::tick_height_to_slot(ticks_per_slot, self.tick_height());
+        self.leader_schedule_cache.slot_leader_at(slot + 1, bank)
     }
 
     pub fn hash(&mut self) {


### PR DESCRIPTION
#### Problem
The forwarded transactions may not reach in time for the current leader to process them. It increases network load, but ends up in dropped transactions.

#### Summary of Changes
Forward the transactions to the next slot leader. The next slot leader buffers the transactions for one slot.

https://github.com/solana-labs/solana/issues/4071