### PR TITLE
earlyoom: Stop using unsupported -k option

### DIFF
--- a/net/scripts/install-earlyoom.sh
+++ b/net/scripts/install-earlyoom.sh
@@ -18,8 +18,8 @@ else
   apt install --quiet --yes ./earlyoom_1.2-*_amd64.deb
 
   cat > earlyoom <<OOM
-  # use the kernel OOM killer, trigger at 20% available RAM,
-  EARLYOOM_ARGS="-k -m 20"
+  # trigger at 20% available RAM,
+  EARLYOOM_ARGS="-m 20"
 OOM
   cp earlyoom /etc/default/
   rm earlyoom

--- a/scripts/oom-monitor.sh
+++ b/scripts/oom-monitor.sh
@@ -30,7 +30,7 @@ while read -r victim; do
   ./metrics-write-datapoint.sh "oom-killer,victim=$victim,hostname=$HOSTNAME killed=1"
 done < <( \
   tail --follow=name --retry -n0 $syslog \
-  | sed --unbuffered -n 's/^.* Out of memory: Kill process [1-9][0-9]* (\([^)]*\)) .*/\1/p' \
+  | sed --unbuffered -n "s/^.* earlyoom\[[0-9]*\]: Killing process .\(.*\). with signal .*/\1/p" \
 )
 
 exit 1


### PR DESCRIPTION
#### Problem
oom detector isn't working

#### Summary of Changes
stop using the unsupported earlyoom `-k` option

Fixes #4090
