### PR TITLE
install grcov

### DIFF
--- a/ci/docker-rust-nightly/Dockerfile
+++ b/ci/docker-rust-nightly/Dockerfile
@@ -4,9 +4,8 @@ ARG date
 RUN set -x \
  && rustup install nightly-$date \
  && rustup show \
- && rustup show \
  && rustc --version \
  && cargo --version \
+ && cargo install grcov \
  && rustc +nightly-$date --version \
  && cargo +nightly-$date --version
-


### PR DESCRIPTION
#### Problem
 we download and compile grcov in the top-level directory, which stinks a little

 grcov is available as a crate, so just stick it in the nightly Docker image

 #### Summary of Changes
 install grcov