### PR TITLE
support cargo install in our docker environment

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -1,0 +1,2 @@
+# this file used for docker shells
+PATH=${CARGO_HOME}/bin:${PATH}

--- a/ci/docker-run.sh
+++ b/ci/docker-run.sh
@@ -41,15 +41,17 @@ ARGS=(
   --rm
 )
 
-if [[ -n $CI ]]; then
-  # Share the real ~/.cargo between docker containers in CI for speed
-  ARGS+=(--volume "$HOME:/home")
-else
-  # Avoid sharing ~/.cargo when building locally to avoid a mixed macOS/Linux
-  # ~/.cargo
-  ARGS+=(--volume "$PWD:/home")
-fi
-ARGS+=(--env "CARGO_HOME=/home/.cargo")
+# Avoid sharing ~/.cargo when building locally to avoid user-installed
+#   versions of tools
+# BASH_ENV=.bashrc puts ${CARGO_HOME}/bin on the PATH for us for
+#   non-interactive shells
+ARGS+=(
+  --volume "$PWD:/home"
+  --env "HOME=/home"
+  --env "BASH_ENV=/home/.bashrc"
+  --env "CARGO_HOME=/home/.cargo"
+)
+
 
 # kcov tries to set the personality of the binary which docker
 # doesn't allow by default.


### PR DESCRIPTION
#### Problem
 current docker environment doesn't support "cargo install X && X", which would be nice to have for parts of the build

 using real $HOME/.cargo, CARGO_HOME, and PATH=CARGO_HOME/bin will
  alias/hide rustc, cargo, etc. from the docker image (the whole point
  of the image)

 #### Summary of Changes
 use a workspace-based CARGO_HOME, add it's bin directory to the path for scripts and interactive shells


Fixes #4099