### PR TITLE
install cargo audit

### DIFF
--- a/ci/docker-rust/Dockerfile
+++ b/ci/docker-rust/Dockerfile
@@ -21,9 +21,9 @@ RUN set -x \
       rsync \
       sudo \
       \
+ && rm -rf /var/lib/apt/lists/* \
  && rustup component add rustfmt \
  && rustup component add clippy \
- && rm -rf /var/lib/apt/lists/* \
+ && cargo install cargo-audit \
  && rustc --version \
  && cargo --version
-


### PR DESCRIPTION
#### Problem
 ci installs cargo audit into CARGO_HOME

 #### Summary of Changes
 update docker-rust stable to include cargo audit

CC #4113 (first part of fix)