### PR TITLE
Add type annotations for external crates

### DIFF
--- a/core/src/packet.rs
+++ b/core/src/packet.rs
@@ -73,7 +73,9 @@ impl Default for Packet {
 
 impl PartialEq for Packet {
     fn eq(&self, other: &Packet) -> bool {
-        self.meta == other.meta && self.data.as_ref() == other.data.as_ref()
+        let self_data: &[u8] = self.data.as_ref();
+        let other_data: &[u8] = other.data.as_ref();
+        self.meta == other.meta && self_data == other_data
     }
 }
 
@@ -164,7 +166,9 @@ impl Default for BlobData {
 
 impl PartialEq for BlobData {
     fn eq(&self, other: &BlobData) -> bool {
-        self.data.as_ref() == other.data.as_ref()
+        let self_data: &[u8] = self.data.as_ref();
+        let other_data: &[u8] = other.data.as_ref();
+        self_data == other_data
     }
 }
 


### PR DESCRIPTION
#### Problem

For reasons I don't understand, rustc can resolve `AsRef<[u8; 512],  [u8]>` within the solana repo, but then can't if building against it from an external crate.

#### Summary of Changes

Add explicit typo annotations.
