### PR TITLE
Fix roots never being purged 

### DIFF
--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -60,7 +60,7 @@ impl<T: Clone> AccountsIndex<T> {
         rv
     }
     pub fn is_purged(&self, fork: Fork) -> bool {
-        !self.is_root(fork) && fork < self.last_root
+        fork < self.last_root
     }
     pub fn is_root(&self, fork: Fork) -> bool {
         self.roots.contains(&fork)
@@ -152,6 +152,8 @@ mod tests {
         assert!(!index.is_purged(0));
         index.add_root(1);
         assert!(index.is_purged(0));
+        index.add_root(2);
+        assert!(index.is_purged(1));
     }
 
     #[test]


### PR DESCRIPTION
#### Problem
AccountStorageEntry's for forks that were roots in AccountsDb never get purged and old root slots tracked in AccountsDb never get purged

Summary of Changes
Changed the is_purged() definition to allow old root slots to be purged

Fixes #
