### PR TITLE
Fix validator confirmation graph y axis scale

### DIFF
--- a/metrics/testnet-monitor.json
+++ b/metrics/testnet-monitor.json
@@ -1916,7 +1916,7 @@
       },
       "yaxes": [
         {
-          "format": "dtdurationms",
+          "format": "ms",
           "label": "",
           "logBase": 1,
           "max": null,


### PR DESCRIPTION
#### Problem
Validator confirmation graph's y axis scale is taking up a lot of space in dashboard.

#### Summary of Changes
Changed this 
![image](https://user-images.githubusercontent.com/40076733/57117020-e1b13400-6d0d-11e9-84bd-8c045597b956.png)

to that
![image](https://user-images.githubusercontent.com/40076733/57117041-18874a00-6d0e-11e9-914f-339f389d3b90.png)


Fixes #
