### PR TITLE
Record poh ticks even when the node is not in leader schedule

### DIFF
--- a/core/src/poh_recorder.rs
+++ b/core/src/poh_recorder.rs
@@ -1027,16 +1027,6 @@ mod tests {
             // Test that with no leader slot, we don't reach the leader tick
             assert_eq!(poh_recorder.reached_leader_tick().0, false);
 
-            for _ in 0..bank.ticks_per_slot() {
-                poh_recorder.tick();
-            }
-
-            // Tick should not be recorded
-            assert_eq!(poh_recorder.tick_height(), 0);
-
-            // Test that with no leader slot, we don't reach the leader tick after sending some ticks
-            assert_eq!(poh_recorder.reached_leader_tick().0, false);
-
             poh_recorder.reset(
                 poh_recorder.tick_height(),
                 bank.last_blockhash(),
@@ -1196,16 +1186,6 @@ mod tests {
             );
 
             // Test that with no leader slot, we don't reach the leader tick
-            assert_eq!(
-                poh_recorder.would_be_leader(2 * bank.ticks_per_slot()),
-                false
-            );
-
-            for _ in 0..bank.ticks_per_slot() {
-                poh_recorder.tick();
-            }
-
-            // Test that with no leader slot, we don't reach the leader tick after sending some ticks
             assert_eq!(
                 poh_recorder.would_be_leader(2 * bank.ticks_per_slot()),
                 false

--- a/core/src/poh_recorder.rs
+++ b/core/src/poh_recorder.rs
@@ -272,12 +272,13 @@ impl PohRecorder {
     }
 
     pub fn tick(&mut self) {
+        let tick = self.generate_tick();
+        trace!("tick {}", tick.1);
+
         if self.start_leader_at_tick.is_none() {
             return;
         }
 
-        let tick = self.generate_tick();
-        trace!("tick {}", tick.1);
         self.tick_cache.push(tick);
         let _ = self.flush_cache(true);
     }


### PR DESCRIPTION
#### Problem
The node stops recording PoH ticks when its next leader slot is unknown.

#### Summary of Changes
Record the tick, but don't cache it.

Fixes #3558
