### PR TITLE
Rename --network argument to --entrypoint

### DIFF
--- a/bench-exchange/src/cli.rs
+++ b/bench-exchange/src/cli.rs
@@ -7,7 +7,7 @@ use std::process::exit;
 use std::time::Duration;
 
 pub struct Config {
-    pub network_addr: SocketAddr,
+    pub entrypoint_addr: SocketAddr,
     pub drone_addr: SocketAddr,
     pub identity: Keypair,
     pub threads: usize,
@@ -23,7 +23,7 @@ pub struct Config {
 impl Default for Config {
     fn default() -> Self {
         Self {
-            network_addr: SocketAddr::from(([127, 0, 0, 1], 8001)),
+            entrypoint_addr: SocketAddr::from(([127, 0, 0, 1], 8001)),
             drone_addr: SocketAddr::from(([127, 0, 0, 1], DRONE_PORT)),
             identity: Keypair::new(),
             num_nodes: 1,
@@ -43,14 +43,14 @@ pub fn build_args<'a, 'b>() -> App<'a, 'b> {
         .about(crate_description!())
         .version(crate_version!())
         .arg(
-            Arg::with_name("network")
+            Arg::with_name("entrypoint")
                 .short("n")
-                .long("network")
+                .long("entrypoint")
                 .value_name("HOST:PORT")
                 .takes_value(true)
                 .required(false)
                 .default_value("127.0.0.1:8001")
-                .help("Network's gossip entry point; defaults to 127.0.0.1:8001"),
+                .help("Cluster entry point; defaults to 127.0.0.1:8001"),
         )
         .arg(
             Arg::with_name("drone")
@@ -146,9 +146,9 @@ pub fn build_args<'a, 'b>() -> App<'a, 'b> {
 pub fn extract_args<'a>(matches: &ArgMatches<'a>) -> Config {
     let mut args = Config::default();
 
-    args.network_addr = solana_netutil::parse_host_port(matches.value_of("network").unwrap())
+    args.entrypoint_addr = solana_netutil::parse_host_port(matches.value_of("entrypoint").unwrap())
         .unwrap_or_else(|e| {
-            eprintln!("failed to parse network address: {}", e);
+            eprintln!("failed to parse entrypoint address: {}", e);
             exit(1)
         });
 

--- a/bench-exchange/src/main.rs
+++ b/bench-exchange/src/main.rs
@@ -15,7 +15,7 @@ fn main() {
     let cli_config = cli::extract_args(&matches);
 
     let cli::Config {
-        network_addr,
+        entrypoint_addr,
         drone_addr,
         identity,
         threads,
@@ -30,7 +30,7 @@ fn main() {
     } = cli_config;
 
     info!("Connecting to the cluster");
-    let nodes = discover_nodes(&network_addr, num_nodes).unwrap_or_else(|_| {
+    let nodes = discover_nodes(&entrypoint_addr, num_nodes).unwrap_or_else(|_| {
         panic!("Failed to discover nodes");
     });
 

--- a/bench-tps/src/cli.rs
+++ b/bench-tps/src/cli.rs
@@ -8,7 +8,7 @@ use solana_sdk::signature::{read_keypair, Keypair, KeypairUtil};
 
 /// Holds the configuration for a single run of the benchmark
 pub struct Config {
-    pub network_addr: SocketAddr,
+    pub entrypoint_addr: SocketAddr,
     pub drone_addr: SocketAddr,
     pub id: Keypair,
     pub threads: usize,
@@ -22,7 +22,7 @@ pub struct Config {
 impl Default for Config {
     fn default() -> Config {
         Config {
-            network_addr: SocketAddr::from(([127, 0, 0, 1], 8001)),
+            entrypoint_addr: SocketAddr::from(([127, 0, 0, 1], 8001)),
             drone_addr: SocketAddr::from(([127, 0, 0, 1], DRONE_PORT)),
             id: Keypair::new(),
             threads: 4,
@@ -40,12 +40,12 @@ pub fn build_args<'a, 'b>() -> App<'a, 'b> {
     App::new(crate_name!()).about(crate_description!())
         .version(crate_version!())
         .arg(
-            Arg::with_name("network")
+            Arg::with_name("entrypoint")
                 .short("n")
-                .long("network")
+                .long("entrypoint")
                 .value_name("HOST:PORT")
                 .takes_value(true)
-                .help("Rendezvous with the network at this gossip entry point; defaults to 127.0.0.1:8001"),
+                .help("Rendezvous with the cluster at this entry point; defaults to 127.0.0.1:8001"),
         )
         .arg(
             Arg::with_name("drone")
@@ -53,7 +53,7 @@ pub fn build_args<'a, 'b>() -> App<'a, 'b> {
                 .long("drone")
                 .value_name("HOST:PORT")
                 .takes_value(true)
-                .help("Location of the drone; defaults to network:DRONE_PORT"),
+                .help("Location of the drone; defaults to entrypoint:DRONE_PORT"),
         )
         .arg(
             Arg::with_name("identity")
@@ -116,9 +116,9 @@ pub fn build_args<'a, 'b>() -> App<'a, 'b> {
 pub fn extract_args<'a>(matches: &ArgMatches<'a>) -> Config {
     let mut args = Config::default();
 
-    if let Some(addr) = matches.value_of("network") {
-        args.network_addr = solana_netutil::parse_host_port(addr).unwrap_or_else(|e| {
-            eprintln!("failed to parse network address: {}", e);
+    if let Some(addr) = matches.value_of("entrypoint") {
+        args.entrypoint_addr = solana_netutil::parse_host_port(addr).unwrap_or_else(|e| {
+            eprintln!("failed to parse entrypoint address: {}", e);
             exit(1)
         });
     }

--- a/bench-tps/src/main.rs
+++ b/bench-tps/src/main.rs
@@ -13,7 +13,7 @@ fn main() {
     let cli_config = cli::extract_args(&matches);
 
     let cli::Config {
-        network_addr,
+        entrypoint_addr,
         drone_addr,
         id,
         threads,
@@ -25,7 +25,7 @@ fn main() {
     } = cli_config;
 
     println!("Connecting to the cluster");
-    let nodes = discover_nodes(&network_addr, num_nodes).unwrap_or_else(|err| {
+    let nodes = discover_nodes(&entrypoint_addr, num_nodes).unwrap_or_else(|err| {
         eprintln!("Failed to discover {} nodes: {:?}", num_nodes, err);
         exit(1);
     });

--- a/book/src/getting-started.md
+++ b/book/src/getting-started.md
@@ -161,7 +161,7 @@ This will dump all the threads stack traces into gdb.txt
 In this example the client connects to our public testnet. To run validators on the testnet you would need to open udp ports `8000-10000`.
 
 ```bash
-$ ./multinode-demo/client.sh --network testnet.solana.com:8001 --duration 60
+$ ./multinode-demo/client.sh --entrypoint testnet.solana.com:8001 --duration 60
 ```
 
 You can observe the effects of your client's transactions on our [dashboard](https://metrics.solana.com:3000/d/testnet/testnet-hud?orgId=2&from=now-30m&to=now&refresh=5s&var-testnet=testnet)

--- a/book/src/testnet-participation.md
+++ b/book/src/testnet-participation.md
@@ -110,7 +110,7 @@ $ solana-wallet -n testnet.solana.com balance
 
 Also try running following command to join the gossip network and view all the other nodes in the cluster:
 ```bash
-$ solana-gossip --network testnet.solana.com:8001 spy --public-address
+$ solana-gossip --entrypoint testnet.solana.com:8001 spy
 # Press ^C to exit
 ```
 
@@ -145,7 +145,7 @@ validator to ports 11000-11011.
 From another console, confirm the IP address of your validator is visible in the
 gossip network by running:
 ```bash
-$ solana-gossip --network edge.testnet.solana.com:8001 spy --public-address
+$ solana-gossip --entrypoint testnet.solana.com:8001 spy
 ```
 
 When `fullnode.sh` starts, it will output a fullnode configuration that looks

--- a/fullnode/src/main.rs
+++ b/fullnode/src/main.rs
@@ -76,12 +76,12 @@ fn main() {
                 .help("Use DIR as persistent ledger location"),
         )
         .arg(
-            Arg::with_name("network")
+            Arg::with_name("entrypoint")
                 .short("n")
-                .long("network")
+                .long("entrypoint")
                 .value_name("HOST:PORT")
                 .takes_value(true)
-                .help("Rendezvous with the cluster at this gossip entry point"),
+                .help("Rendezvous with the cluster at this entry point"),
         )
         .arg(
             Arg::with_name("no_voting")
@@ -204,9 +204,9 @@ fn main() {
     } else {
         fullnode_config.account_paths = None;
     }
-    let cluster_entrypoint = matches.value_of("network").map(|network| {
-        let entrypoint_addr =
-            solana_netutil::parse_host_port(network).expect("failed to parse network address");
+    let cluster_entrypoint = matches.value_of("entrypoint").map(|entrypoint| {
+        let entrypoint_addr = solana_netutil::parse_host_port(entrypoint)
+            .expect("failed to parse entrypoint address");
         gossip_addr.set_ip(solana_netutil::get_public_ip_addr(&entrypoint_addr).unwrap());
 
         ContactInfo::new_gossip_entry_point(&entrypoint_addr)

--- a/multinode-demo/client.sh
+++ b/multinode-demo/client.sh
@@ -21,7 +21,7 @@ usage() {
 
 if [[ -z $1 ]]; then # default behavior
   $solana_bench_tps \
-    --network 127.0.0.1:8001 \
+    --entrypoint 127.0.0.1:8001 \
     --drone 127.0.0.1:9900 \
     --duration 90 \
     --tx_count 50000 \

--- a/multinode-demo/fullnode.sh
+++ b/multinode-demo/fullnode.sh
@@ -243,7 +243,7 @@ else
   [[ -r "$fullnode_id_path" ]] || $solana_keygen -o "$fullnode_id_path"
   [[ -r "$fullnode_vote_id_path" ]] || $solana_keygen -o "$fullnode_vote_id_path"
 
-  default_fullnode_arg --network "$leader_address"
+  default_fullnode_arg --entrypoint "$leader_address"
   default_fullnode_arg --rpc-drone-address "${leader_address%:*}:9900"
 fi
 

--- a/net/remote/remote-client.sh
+++ b/net/remote/remote-client.sh
@@ -56,7 +56,7 @@ case $clientToRun in
 solana-bench-tps)
   clientCommand="\
     solana-bench-tps \
-      --network $entrypointIp:8001 \
+      --entrypoint $entrypointIp:8001 \
       --drone $entrypointIp:9900 \
       --duration 7500 \
       --sustained \
@@ -68,7 +68,7 @@ solana-bench-exchange)
   solana-keygen -o bench.keypair
   clientCommand="\
     solana-bench-exchange \
-      --network $entrypointIp:8001 \
+      --entrypoint $entrypointIp:8001 \
       --drone $entrypointIp:9900 \
       --threads $threadCount \
       --batch-size 1000 \

--- a/net/remote/remote-sanity.sh
+++ b/net/remote/remote-sanity.sh
@@ -101,7 +101,7 @@ echo "+++ $entrypointIp: node count ($numSanityNodes expected)"
     nodeArg="num-nodes-exactly"
   fi
 
-  timeout 2m $solana_gossip --network "$entrypointIp:8001" \
+  timeout 2m $solana_gossip --entrypoint "$entrypointIp:8001" \
     spy --$nodeArg "$numSanityNodes" \
 )
 

--- a/replicator/src/main.rs
+++ b/replicator/src/main.rs
@@ -22,13 +22,13 @@ fn main() {
                 .help("File containing an identity (keypair)"),
         )
         .arg(
-            Arg::with_name("network")
+            Arg::with_name("entrypoint")
                 .short("n")
-                .long("network")
+                .long("entrypoint")
                 .value_name("HOST:PORT")
                 .takes_value(true)
                 .required(true)
-                .help("Rendezvous with the network at this gossip entry point"),
+                .help("Rendezvous with the cluster at this entry point"),
         )
         .arg(
             Arg::with_name("ledger")
@@ -52,16 +52,16 @@ fn main() {
         Keypair::new()
     };
 
-    let network_addr = matches
-        .value_of("network")
-        .map(|network| {
-            solana_netutil::parse_host_port(network).expect("failed to parse network address")
+    let entrypoint_addr = matches
+        .value_of("entrypoint")
+        .map(|entrypoint| {
+            solana_netutil::parse_host_port(entrypoint).expect("failed to parse entrypoint address")
         })
         .unwrap();
 
     let gossip_addr = {
         let mut addr = socketaddr!([127, 0, 0, 1], 8700);
-        addr.set_ip(solana_netutil::get_public_ip_addr(&network_addr).unwrap());
+        addr.set_ip(solana_netutil::get_public_ip_addr(&entrypoint_addr).unwrap());
         addr
     };
     let node =
@@ -73,12 +73,12 @@ fn main() {
         gossip_addr
     );
 
-    let leader_info = ContactInfo::new_gossip_entry_point(&network_addr);
+    let entrypoint_info = ContactInfo::new_gossip_entry_point(&entrypoint_addr);
     let storage_keypair = Arc::new(Keypair::new());
     let mut replicator = Replicator::new(
         ledger_path,
         node,
-        leader_info,
+        entrypoint_info,
         Arc::new(keypair),
         storage_keypair,
         None,


### PR DESCRIPTION
The `--network` argument name really doesn't correctly capture what it is.   This argument specifies the location of a cluster node that should be contacted first to enter gossip.  aka, the cluster `--entrypoint`
