### PR TITLE
fullnode.sh positional arguments may now be mixed with optional arguments

### DIFF
--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -106,6 +106,7 @@ local|tar)
         --stake 0
       )
     else
+      args+=("$entrypointIp":~/solana "$entrypointIp:8001")
       if $leaderRotation; then
         args+=("--stake" "$stake")
       else
@@ -148,7 +149,6 @@ local|tar)
       curl --head "$(curl ifconfig.io)"
     fi
 
-    args+=("$entrypointIp":~/solana "$entrypointIp:8001")
     ./multinode-demo/fullnode.sh "${args[@]}" > fullnode.log 2>&1 &
     ;;
   *)


### PR DESCRIPTION
A couple people have already been tripped up by how the positional arguments to `fullnode.sh` must always follow the options.   Now this is no longer the case.