### PR TITLE
Add Confirmations parameter to RPC Subscriptions

### DIFF
--- a/book/src/jsonrpc-api.md
+++ b/book/src/jsonrpc-api.md
@@ -316,6 +316,14 @@ curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1, "m
 After connect to the RPC PubSub websocket at `ws://<ADDRESS>/`:
 - Submit subscription requests to the websocket using the methods below
 - Multiple subscriptions may be active at once
+- All subscriptions take an optional `confirmations` parameter, which defines
+  how many confirmed blocks the node should wait before sending a notification.
+  The greater the number, the more likely the notification is to represent
+  consensus across the cluster, and the less likely it is to be affected by
+  forking or rollbacks. If unspecified, the default value is 0; the node will
+  send a notification as soon as it witnesses the event. The maximum
+  `confirmations` wait length is the cluster's `MAX_LOCKOUT_HISTORY`, which
+  represents the economic finality of the chain.
 
 ---
 
@@ -325,6 +333,8 @@ for a given account public key changes
 
 ##### Parameters:
 * `string` - account Pubkey, as base-58 encoded string
+* `integer` - optional, number of confirmed blocks to wait before notification.
+  Default: 0, Max: `MAX_LOCKOUT_HISTORY` (greater integers rounded down)
 
 ##### Results:
 * `integer` - Subscription id (needed to unsubscribe)
@@ -333,6 +343,8 @@ for a given account public key changes
 ```bash
 // Request
 {"jsonrpc":"2.0", "id":1, "method":"accountSubscribe", "params":["CM78CPUeXjn8o3yroDHxUtKsZZgoy4GPkPPXfouKNH12"]}
+
+{"jsonrpc":"2.0", "id":1, "method":"accountSubscribe", "params":["CM78CPUeXjn8o3yroDHxUtKsZZgoy4GPkPPXfouKNH12", 15]}
 
 // Result
 {"jsonrpc": "2.0","result": 0,"id": 1}
@@ -371,6 +383,8 @@ for a given account owned by the program changes
 
 ##### Parameters:
 * `string` - program_id Pubkey, as base-58 encoded string
+* `integer` - optional, number of confirmed blocks to wait before notification.
+  Default: 0, Max: `MAX_LOCKOUT_HISTORY` (greater integers rounded down)
 
 ##### Results:
 * `integer` - Subscription id (needed to unsubscribe)
@@ -379,6 +393,8 @@ for a given account owned by the program changes
 ```bash
 // Request
 {"jsonrpc":"2.0", "id":1, "method":"programSubscribe", "params":["9gZbPtbtHrs6hEWgd6MbVY9VPFtS5Z8xKtnYwA2NynHV"]}
+
+{"jsonrpc":"2.0", "id":1, "method":"programSubscribe", "params":["9gZbPtbtHrs6hEWgd6MbVY9VPFtS5Z8xKtnYwA2NynHV", 15]}
 
 // Result
 {"jsonrpc": "2.0","result": 0,"id": 1}
@@ -419,6 +435,8 @@ On `signatureNotification`, the subscription is automatically cancelled
 
 ##### Parameters:
 * `string` - Transaction Signature, as base-58 encoded string
+* `integer` - optional, number of confirmed blocks to wait before notification.
+  Default: 0, Max: `MAX_LOCKOUT_HISTORY` (greater integers rounded down)
 
 ##### Results:
 * `integer` - subscription id (needed to unsubscribe)
@@ -427,6 +445,8 @@ On `signatureNotification`, the subscription is automatically cancelled
 ```bash
 // Request
 {"jsonrpc":"2.0", "id":1, "method":"signatureSubscribe", "params":["2EBVM6cB8vAAD93Ktr6Vd8p67XPbQzCJX47MpReuiCXJAtcjaxpvWpcg9Ege1Nr5Tk3a2GFrByT7WPBjdsTycY9b"]}
+
+{"jsonrpc":"2.0", "id":1, "method":"signatureSubscribe", "params":["2EBVM6cB8vAAD93Ktr6Vd8p67XPbQzCJX47MpReuiCXJAtcjaxpvWpcg9Ege1Nr5Tk3a2GFrByT7WPBjdsTycY9b", 15]}
 
 // Result
 {"jsonrpc": "2.0","result": 0,"id": 1}

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -146,7 +146,7 @@ impl ReplayStage {
                         Self::generate_votable_banks(&bank_forks, &locktower, &mut progress);
 
                     if let Some((_, bank)) = votable.last() {
-                        subscriptions.notify_subscribers(&bank);
+                        subscriptions.notify_subscribers(bank.slot(), &bank_forks);
 
                         Self::handle_votable_bank(
                             &bank,

--- a/core/src/rpc_pubsub.rs
+++ b/core/src/rpc_pubsub.rs
@@ -1,6 +1,6 @@
 //! The `pubsub` module implements a threaded subscription service on client RPC request
 
-use crate::rpc_subscriptions::{Depth, RpcSubscriptions};
+use crate::rpc_subscriptions::{Confirmations, RpcSubscriptions};
 use bs58;
 use jsonrpc_core::{Error, ErrorCode, Result};
 use jsonrpc_derive::rpc;
@@ -29,7 +29,7 @@ pub trait RpcSolPubSub {
         _: Self::Metadata,
         _: Subscriber<Account>,
         _: String,
-        _: Option<Depth>,
+        _: Option<Confirmations>,
     );
 
     // Unsubscribe from account notification subscription.
@@ -52,7 +52,7 @@ pub trait RpcSolPubSub {
         _: Self::Metadata,
         _: Subscriber<(String, Account)>,
         _: String,
-        _: Option<Depth>,
+        _: Option<Confirmations>,
     );
 
     // Unsubscribe from account notification subscription.
@@ -75,7 +75,7 @@ pub trait RpcSolPubSub {
         _: Self::Metadata,
         _: Subscriber<transaction::Result<()>>,
         _: String,
-        _: Option<Depth>,
+        _: Option<Confirmations>,
     );
 
     // Unsubscribe from signature notification subscription.
@@ -108,7 +108,7 @@ impl RpcSolPubSub for RpcSolPubSubImpl {
         _meta: Self::Metadata,
         subscriber: Subscriber<Account>,
         pubkey_str: String,
-        depth: Option<Depth>,
+        confirmations: Option<Confirmations>,
     ) {
         let pubkey_vec = bs58::decode(pubkey_str).into_vec().unwrap();
         if pubkey_vec.len() != mem::size_of::<Pubkey>() {
@@ -129,7 +129,7 @@ impl RpcSolPubSub for RpcSolPubSubImpl {
         let sink = subscriber.assign_id(sub_id.clone()).unwrap();
 
         self.subscriptions
-            .add_account_subscription(&pubkey, depth, &sub_id, &sink)
+            .add_account_subscription(&pubkey, confirmations, &sub_id, &sink)
     }
 
     fn account_unsubscribe(
@@ -154,7 +154,7 @@ impl RpcSolPubSub for RpcSolPubSubImpl {
         _meta: Self::Metadata,
         subscriber: Subscriber<(String, Account)>,
         pubkey_str: String,
-        depth: Option<Depth>,
+        confirmations: Option<Confirmations>,
     ) {
         let pubkey_vec = bs58::decode(pubkey_str).into_vec().unwrap();
         if pubkey_vec.len() != mem::size_of::<Pubkey>() {
@@ -175,7 +175,7 @@ impl RpcSolPubSub for RpcSolPubSubImpl {
         let sink = subscriber.assign_id(sub_id.clone()).unwrap();
 
         self.subscriptions
-            .add_program_subscription(&pubkey, depth, &sub_id, &sink)
+            .add_program_subscription(&pubkey, confirmations, &sub_id, &sink)
     }
 
     fn program_unsubscribe(
@@ -200,7 +200,7 @@ impl RpcSolPubSub for RpcSolPubSubImpl {
         _meta: Self::Metadata,
         subscriber: Subscriber<transaction::Result<()>>,
         signature_str: String,
-        depth: Option<Depth>,
+        confirmations: Option<Confirmations>,
     ) {
         info!("signature_subscribe");
         let signature_vec = bs58::decode(signature_str).into_vec().unwrap();
@@ -225,7 +225,7 @@ impl RpcSolPubSub for RpcSolPubSubImpl {
         let sink = subscriber.assign_id(sub_id.clone()).unwrap();
 
         self.subscriptions
-            .add_signature_subscription(&signature, depth, &sub_id, &sink);
+            .add_signature_subscription(&signature, confirmations, &sub_id, &sink);
     }
 
     fn signature_unsubscribe(

--- a/core/src/rpc_pubsub.rs
+++ b/core/src/rpc_pubsub.rs
@@ -73,7 +73,7 @@ pub trait RpcSolPubSub {
     fn signature_subscribe(
         &self,
         _: Self::Metadata,
-        _: Subscriber<Option<transaction::Result<()>>>,
+        _: Subscriber<transaction::Result<()>>,
         _: String,
         _: Option<Depth>,
     );
@@ -198,7 +198,7 @@ impl RpcSolPubSub for RpcSolPubSubImpl {
     fn signature_subscribe(
         &self,
         _meta: Self::Metadata,
-        subscriber: Subscriber<Option<transaction::Result<()>>>,
+        subscriber: Subscriber<transaction::Result<()>>,
         signature_str: String,
         depth: Option<Depth>,
     ) {

--- a/core/src/rpc_pubsub.rs
+++ b/core/src/rpc_pubsub.rs
@@ -122,7 +122,6 @@ impl RpcSolPubSub for RpcSolPubSubImpl {
             return;
         }
         let pubkey = Pubkey::new(&pubkey_vec);
-        let depth = depth.unwrap_or(0);
 
         let id = self.uid.fetch_add(1, atomic::Ordering::SeqCst);
         let sub_id = SubscriptionId::Number(id as u64);
@@ -169,7 +168,6 @@ impl RpcSolPubSub for RpcSolPubSubImpl {
             return;
         }
         let pubkey = Pubkey::new(&pubkey_vec);
-        let depth = depth.unwrap_or(0);
 
         let id = self.uid.fetch_add(1, atomic::Ordering::SeqCst);
         let sub_id = SubscriptionId::Number(id as u64);
@@ -217,7 +215,6 @@ impl RpcSolPubSub for RpcSolPubSubImpl {
             return;
         }
         let signature = Signature::new(&signature_vec);
-        let depth = depth.unwrap_or(0);
 
         let id = self.uid.fetch_add(1, atomic::Ordering::SeqCst);
         let sub_id = SubscriptionId::Number(id as u64);

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -259,15 +259,20 @@ impl AccountsDB {
         ancestors: &HashMap<Fork, usize>,
         accounts_index: &AccountsIndex<AccountInfo>,
         pubkey: &Pubkey,
-    ) -> Option<Account> {
-        let info = accounts_index.get(pubkey, ancestors)?;
+    ) -> Option<(Account, Fork)> {
+        let (info, fork) = accounts_index.get(pubkey, ancestors)?;
         //TODO: thread this as a ref
         storage
             .get(&info.id)
             .and_then(|store| Some(store.accounts.get_account(info.offset)?.0.clone_account()))
+            .map(|account| (account, fork))
     }
 
-    pub fn load_slow(&self, ancestors: &HashMap<Fork, usize>, pubkey: &Pubkey) -> Option<Account> {
+    pub fn load_slow(
+        &self,
+        ancestors: &HashMap<Fork, usize>,
+        pubkey: &Pubkey,
+    ) -> Option<(Account, Fork)> {
         let accounts_index = self.accounts_index.read().unwrap();
         let storage = self.storage.read().unwrap();
         Self::load(&storage, ancestors, &accounts_index, pubkey)

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -485,7 +485,7 @@ mod tests {
         db.store(0, &[(&key, &account0)]);
         db.add_root(0);
         let ancestors = vec![(1, 1)].into_iter().collect();
-        assert_eq!(db.load_slow(&ancestors, &key), Some(account0));
+        assert_eq!(db.load_slow(&ancestors, &key), Some((account0, 0)));
     }
 
     #[test]
@@ -502,10 +502,10 @@ mod tests {
         db.store(1, &[(&key, &account1)]);
 
         let ancestors = vec![(1, 1)].into_iter().collect();
-        assert_eq!(&db.load_slow(&ancestors, &key).unwrap(), &account1);
+        assert_eq!(&db.load_slow(&ancestors, &key).unwrap().0, &account1);
 
         let ancestors = vec![(1, 1), (0, 0)].into_iter().collect();
-        assert_eq!(&db.load_slow(&ancestors, &key).unwrap(), &account1);
+        assert_eq!(&db.load_slow(&ancestors, &key).unwrap().0, &account1);
     }
 
     #[test]
@@ -523,10 +523,10 @@ mod tests {
         db.add_root(0);
 
         let ancestors = vec![(1, 1)].into_iter().collect();
-        assert_eq!(&db.load_slow(&ancestors, &key).unwrap(), &account1);
+        assert_eq!(&db.load_slow(&ancestors, &key).unwrap().0, &account1);
 
         let ancestors = vec![(1, 1), (0, 0)].into_iter().collect();
-        assert_eq!(&db.load_slow(&ancestors, &key).unwrap(), &account1);
+        assert_eq!(&db.load_slow(&ancestors, &key).unwrap().0, &account1);
     }
 
     #[test]
@@ -557,18 +557,18 @@ mod tests {
         // original account (but could also accept "None", which is implemented
         // at the Accounts level)
         let ancestors = vec![(0, 0), (1, 1)].into_iter().collect();
-        assert_eq!(&db.load_slow(&ancestors, &key).unwrap(), &account1);
+        assert_eq!(&db.load_slow(&ancestors, &key).unwrap().0, &account1);
 
         // we should see 1 token in fork 2
         let ancestors = vec![(0, 0), (2, 2)].into_iter().collect();
-        assert_eq!(&db.load_slow(&ancestors, &key).unwrap(), &account0);
+        assert_eq!(&db.load_slow(&ancestors, &key).unwrap().0, &account0);
 
         db.add_root(0);
 
         let ancestors = vec![(1, 1)].into_iter().collect();
-        assert_eq!(db.load_slow(&ancestors, &key), Some(account1));
+        assert_eq!(db.load_slow(&ancestors, &key), Some((account1, 1)));
         let ancestors = vec![(2, 2)].into_iter().collect();
-        assert_eq!(db.load_slow(&ancestors, &key), Some(account0)); // original value
+        assert_eq!(db.load_slow(&ancestors, &key), Some((account0, 0))); // original value
     }
 
     #[test]
@@ -584,7 +584,7 @@ mod tests {
             let account = db.load_slow(&ancestors, &pubkeys[idx]).unwrap();
             let mut default_account = Account::default();
             default_account.lamports = (idx + 1) as u64;
-            assert_eq!(default_account, account);
+            assert_eq!((default_account, 0), account);
         }
 
         db.add_root(0);
@@ -598,8 +598,8 @@ mod tests {
             let account1 = db.load_slow(&ancestors, &pubkeys[idx]).unwrap();
             let mut default_account = Account::default();
             default_account.lamports = (idx + 1) as u64;
-            assert_eq!(&default_account, &account0);
-            assert_eq!(&default_account, &account1);
+            assert_eq!(&default_account, &account0.0);
+            assert_eq!(&default_account, &account1.0);
         }
     }
 
@@ -655,9 +655,9 @@ mod tests {
         // masking accounts is done at the Accounts level, at accountsDB we see
         // original account
         let ancestors = vec![(0, 0), (1, 1)].into_iter().collect();
-        assert_eq!(db0.load_slow(&ancestors, &key), Some(account1));
+        assert_eq!(db0.load_slow(&ancestors, &key), Some((account1, 1)));
         let ancestors = vec![(0, 0)].into_iter().collect();
-        assert_eq!(db0.load_slow(&ancestors, &key), Some(account0));
+        assert_eq!(db0.load_slow(&ancestors, &key), Some((account0, 0)));
     }
 
     fn create_account(
@@ -690,7 +690,7 @@ mod tests {
         for _ in 1..1000 {
             let idx = thread_rng().gen_range(0, range);
             let ancestors = vec![(fork, 0)].into_iter().collect();
-            if let Some(mut account) = accounts.load_slow(&ancestors, &pubkeys[idx]) {
+            if let Some((mut account, _)) = accounts.load_slow(&ancestors, &pubkeys[idx]) {
                 account.lamports = account.lamports + 1;
                 accounts.store(fork, &[(&pubkeys[idx], &account)]);
                 if account.lamports == 0 {
@@ -719,7 +719,7 @@ mod tests {
             let account = accounts.load_slow(&ancestors, &pubkeys[idx]).unwrap();
             let mut default_account = Account::default();
             default_account.lamports = (idx + 1) as u64;
-            assert_eq!(default_account, account);
+            assert_eq!((default_account, 0), account);
         }
     }
 
@@ -733,7 +733,7 @@ mod tests {
         let account = accounts.load_slow(&ancestors, &pubkeys[0]).unwrap();
         let mut default_account = Account::default();
         default_account.lamports = 1;
-        assert_eq!(default_account, account);
+        assert_eq!((default_account, 0), account);
     }
 
     #[test]
@@ -770,7 +770,7 @@ mod tests {
         for (i, key) in keys.iter().enumerate() {
             let ancestors = vec![(0, 0)].into_iter().collect();
             assert_eq!(
-                accounts.load_slow(&ancestors, &key).unwrap().lamports,
+                accounts.load_slow(&ancestors, &key).unwrap().0.lamports,
                 (i as u64) + 1
             );
         }
@@ -815,8 +815,14 @@ mod tests {
             assert_eq!(stores[&1].status(), AccountStorageStatus::StorageAvailable);
         }
         let ancestors = vec![(0, 0)].into_iter().collect();
-        assert_eq!(accounts.load_slow(&ancestors, &pubkey1).unwrap(), account1);
-        assert_eq!(accounts.load_slow(&ancestors, &pubkey2).unwrap(), account2);
+        assert_eq!(
+            accounts.load_slow(&ancestors, &pubkey1).unwrap().0,
+            account1
+        );
+        assert_eq!(
+            accounts.load_slow(&ancestors, &pubkey2).unwrap().0,
+            account2
+        );
 
         // lots of stores, but 3 storages should be enough for everything
         for i in 0..25 {
@@ -833,8 +839,14 @@ mod tests {
                 assert_eq!(stores[&2].status(), status[0]);
             }
             let ancestors = vec![(0, 0)].into_iter().collect();
-            assert_eq!(accounts.load_slow(&ancestors, &pubkey1).unwrap(), account1);
-            assert_eq!(accounts.load_slow(&ancestors, &pubkey2).unwrap(), account2);
+            assert_eq!(
+                accounts.load_slow(&ancestors, &pubkey1).unwrap().0,
+                account1
+            );
+            assert_eq!(
+                accounts.load_slow(&ancestors, &pubkey2).unwrap().0,
+                account2
+            );
         }
     }
 
@@ -880,6 +892,7 @@ mod tests {
             .unwrap()
             .get(&pubkey, &ancestors)
             .unwrap()
+            .0
             .clone();
         //fork 0 is behind root, but it is not root, therefore it is purged
         accounts.add_root(1);
@@ -896,7 +909,7 @@ mod tests {
 
         //new value is there
         let ancestors = vec![(1, 1)].into_iter().collect();
-        assert_eq!(accounts.load_slow(&ancestors, &pubkey), Some(account));;
+        assert_eq!(accounts.load_slow(&ancestors, &pubkey), Some((account, 1)));
     }
 
 }

--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -123,7 +123,7 @@ mod tests {
         assert!(gc.is_empty());
 
         let ancestors = vec![(0, 0)].into_iter().collect();
-        assert_eq!(index.get(&key.pubkey(), &ancestors), Some(&true));
+        assert_eq!(index.get(&key.pubkey(), &ancestors), Some((&true, 0)));
     }
 
     #[test]
@@ -143,7 +143,7 @@ mod tests {
 
         let ancestors = vec![].into_iter().collect();
         index.add_root(0);
-        assert_eq!(index.get(&key.pubkey(), &ancestors), Some(&true));
+        assert_eq!(index.get(&key.pubkey(), &ancestors), Some((&true, 0)));
     }
 
     #[test]
@@ -197,11 +197,11 @@ mod tests {
         let ancestors = vec![(0, 0)].into_iter().collect();
         let gc = index.insert(0, &key.pubkey(), true);
         assert!(gc.is_empty());
-        assert_eq!(index.get(&key.pubkey(), &ancestors), Some(&true));
+        assert_eq!(index.get(&key.pubkey(), &ancestors), Some((&true, 0)));
 
         let gc = index.insert(0, &key.pubkey(), false);
         assert_eq!(gc, vec![(0, true)]);
-        assert_eq!(index.get(&key.pubkey(), &ancestors), Some(&false));
+        assert_eq!(index.get(&key.pubkey(), &ancestors), Some((&false, 0)));
     }
 
     #[test]
@@ -213,9 +213,9 @@ mod tests {
         assert!(gc.is_empty());
         let gc = index.insert(1, &key.pubkey(), false);
         assert!(gc.is_empty());
-        assert_eq!(index.get(&key.pubkey(), &ancestors), Some(&true));
+        assert_eq!(index.get(&key.pubkey(), &ancestors), Some((&true, 0)));
         let ancestors = vec![(1, 0)].into_iter().collect();
-        assert_eq!(index.get(&key.pubkey(), &ancestors), Some(&false));
+        assert_eq!(index.get(&key.pubkey(), &ancestors), Some((&false, 1)));
     }
 
     #[test]
@@ -228,6 +228,6 @@ mod tests {
         let gc = index.insert(1, &key.pubkey(), false);
         assert_eq!(gc, vec![(0, true)]);
         let ancestors = vec![].into_iter().collect();
-        assert_eq!(index.get(&key.pubkey(), &ancestors), Some(&false));
+        assert_eq!(index.get(&key.pubkey(), &ancestors), Some((&false, 1)));
     }
 }

--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -15,21 +15,21 @@ pub struct AccountsIndex<T> {
 impl<T: Clone> AccountsIndex<T> {
     /// Get an account
     /// The latest account that appears in `ancestors` or `roots` is returned.
-    pub fn get(&self, pubkey: &Pubkey, ancestors: &HashMap<Fork, usize>) -> Option<&T> {
+    pub fn get(&self, pubkey: &Pubkey, ancestors: &HashMap<Fork, usize>) -> Option<(&T, Fork)> {
         let list = self.account_maps.get(pubkey)?;
         let mut max = 0;
         let mut rv = None;
         for e in list.iter().rev() {
             if e.0 >= max && (ancestors.get(&e.0).is_some() || self.is_root(e.0)) {
                 trace!("GET {} {:?}", e.0, ancestors);
-                rv = Some(&e.1);
+                rv = Some((&e.1, e.0));
                 max = e.0;
             }
         }
         rv
     }
 
-    /// Insert a new fork.  
+    /// Insert a new fork.
     /// @retval - The return value contains any squashed accounts that can freed from storage.
     pub fn insert(&mut self, fork: Fork, pubkey: &Pubkey, account_info: T) -> Vec<(Fork, T)> {
         let mut rv = vec![];

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5,6 +5,7 @@
 
 use crate::accounts::Accounts;
 use crate::accounts_db::{ErrorCounters, InstructionAccounts, InstructionLoaders};
+use crate::accounts_index::Fork;
 use crate::blockhash_queue::BlockhashQueue;
 use crate::locked_accounts_results::LockedAccountsResults;
 use crate::message_processor::{MessageProcessor, ProcessInstruction};
@@ -888,7 +889,9 @@ impl Bank {
     }
 
     pub fn get_account(&self, pubkey: &Pubkey) -> Option<Account> {
-        self.accounts.load_slow(&self.ancestors, pubkey)
+        self.accounts
+            .load_slow(&self.ancestors, pubkey)
+            .map(|(account, _)| account)
     }
 
     pub fn get_program_accounts_modified_since_parent(
@@ -898,7 +901,7 @@ impl Bank {
         self.accounts.load_by_program(self.slot(), program_id)
     }
 
-    pub fn get_account_modified_since_parent(&self, pubkey: &Pubkey) -> Option<Account> {
+    pub fn get_account_modified_since_parent(&self, pubkey: &Pubkey) -> Option<(Account, Fork)> {
         let just_self: HashMap<u64, usize> = vec![(self.slot(), 0)].into_iter().collect();
         self.accounts.load_slow(&just_self, pubkey)
     }


### PR DESCRIPTION
#### Problem
Account, Program, and Signature notifications currently represent the instantaneous state of a single node, which means they may not represent the ultimately confirmed state of the cluster. 
Clients may want to specify a level of confidence (number of confirmations) so that notifications present less rollback churn.

Also, Account notifications are sent every time the account exists in a root, which leads to a weird "back-in-time" experience for clients as the slots in which account changes actually happened are squashed.

#### Summary of Changes
- Store Confirmations parameter in RPC subscriptions
- Add optional Confirmations param to pubsub JSON-RPC requests: if None, defaults to 0
- Use bank_forks in pubsub to determine if Confirmations are fulfilled
- Plumb fork id through accounts in order to prevent repeated Account notifications on from account simply existing in root

Toward #2474 (implements a fix for RPC subscriptions only)
