### PR TITLE
Don't use default ticks per slot in calculating next slot leader

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -221,7 +221,7 @@ impl BankingStage {
 
         let (decision, next_leader) = {
             let poh = poh_recorder.lock().unwrap();
-            let next_leader = poh.next_slot_leader(DEFAULT_TICKS_PER_SLOT, None);
+            let next_leader = poh.next_slot_leader();
             (
                 Self::consume_or_forward_packets(
                     next_leader,


### PR DESCRIPTION
#### Problem
The calculation for next slot leader is assuming default ticks per slot. Some tests use non default value for ticks per slot, and this could break such tests.

#### Summary of Changes
Use the ticks per slot from the bank.