### PR TITLE
Pay program loading fees from a system account

### DIFF
--- a/install/src/command.rs
+++ b/install/src/command.rs
@@ -206,7 +206,7 @@ fn new_update_manifest(
         let mut transaction = Transaction::new_unsigned_instructions(vec![new_account]);
         transaction.sign(&[from_keypair], recect_blockhash);
 
-        rpc_client.send_and_confirm_transaction(&mut transaction, from_keypair)?;
+        rpc_client.send_and_confirm_transaction(&mut transaction, &[from_keypair])?;
     }
     Ok(())
 }
@@ -227,7 +227,7 @@ fn store_update_manifest(
     );
     let mut transaction = Transaction::new_unsigned_instructions(vec![new_store]);
     transaction.sign(&[from_keypair, update_manifest_keypair], recect_blockhash);
-    rpc_client.send_and_confirm_transaction(&mut transaction, from_keypair)?;
+    rpc_client.send_and_confirm_transaction(&mut transaction, &[from_keypair])?;
     Ok(())
 }
 


### PR DESCRIPTION
The transactions use to load programs are not setup correctly to handle non-zero transaction fees.  Restructure the transaction signer_keys so that the program loading fees are withdrawn from the system account that wants to load the program, instead of trying to withdraw fees from the program account itself

Part of #4189
