### PR TITLE
Storage transactions are now paid for by a system account

### DIFF
--- a/core/src/local_cluster.rs
+++ b/core/src/local_cluster.rs
@@ -300,7 +300,6 @@ impl LocalCluster {
             self.entry_point_info.clone(),
             replicator_keypair,
             storage_keypair,
-            None,
         )
         .unwrap();
 

--- a/core/tests/replicator.rs
+++ b/core/tests/replicator.rs
@@ -147,7 +147,6 @@ fn test_replicator_startup_2_nodes() {
 #[test]
 fn test_replicator_startup_leader_hang() {
     use std::net::{IpAddr, Ipv4Addr, SocketAddr};
-    use std::time::Duration;
 
     solana_logger::setup();
     info!("starting replicator test");
@@ -172,7 +171,6 @@ fn test_replicator_startup_leader_hang() {
             leader_info,
             replicator_keypair,
             storage_keypair,
-            Some(Duration::from_secs(3)),
         );
 
         assert!(replicator_res.is_err());
@@ -207,7 +205,6 @@ fn test_replicator_startup_ledger_hang() {
         cluster.entry_point_info.clone(),
         bad_keys,
         storage_keypair,
-        Some(Duration::from_secs(3)),
     );
 
     assert!(replicator_res.is_err());

--- a/install/src/command.rs
+++ b/install/src/command.rs
@@ -206,7 +206,7 @@ fn new_update_manifest(
         let mut transaction = Transaction::new_unsigned_instructions(vec![new_account]);
         transaction.sign(&[from_keypair], recect_blockhash);
 
-        rpc_client.send_and_confirm_transaction(&mut transaction, from_keypair)?;
+        rpc_client.send_and_confirm_transaction(&mut transaction, &[from_keypair])?;
     }
     Ok(())
 }
@@ -227,7 +227,7 @@ fn store_update_manifest(
     );
     let mut transaction = Transaction::new_unsigned_instructions(vec![new_store]);
     transaction.sign(&[from_keypair, update_manifest_keypair], recect_blockhash);
-    rpc_client.send_and_confirm_transaction(&mut transaction, from_keypair)?;
+    rpc_client.send_and_confirm_transaction(&mut transaction, &[from_keypair])?;
     Ok(())
 }
 

--- a/replicator/src/main.rs
+++ b/replicator/src/main.rs
@@ -81,7 +81,6 @@ fn main() {
         entrypoint_info,
         Arc::new(keypair),
         storage_keypair,
-        None,
     )
     .unwrap();
 


### PR DESCRIPTION
The transactions used by replicators are not setup correctly to handle non-zero transaction fees. Restructure the transaction signer_keys so that the fees are withdrawn from the system account for the replicator rather than from the storage account itself.

cc: #3380 
