### PR TITLE
Add FeeCalculator to the genesis block

### DIFF
--- a/multinode-demo/fullnode.sh
+++ b/multinode-demo/fullnode.sh
@@ -154,7 +154,7 @@ default_fullnode_arg() {
 
 extra_fullnode_args=()
 bootstrap_leader=false
-stake=43 # number of lamports to assign as stake (plus transaction fee to setup the stake)
+stake=42 # number of lamports to assign as stake
 poll_for_new_genesis_block=0
 label=
 

--- a/multinode-demo/setup.sh
+++ b/multinode-demo/setup.sh
@@ -4,46 +4,6 @@ here=$(dirname "$0")
 # shellcheck source=multinode-demo/common.sh
 source "$here"/common.sh
 
-lamports=100000000000000
-bootstrap_leader_lamports=
-
-usage () {
-  exitcode=0
-  if [[ -n "$1" ]]; then
-    exitcode=1
-    echo "Error: $*"
-  fi
-  cat <<EOF
-usage: $0 [-n lamports] [-b lamports]
-
-Create a cluster configuration
-
- -n lamports    - Number of lamports to create [default: $lamports]
- -b lamports    - Override the number of lamports for the bootstrap leader's stake
-
-EOF
-  exit $exitcode
-}
-
-while getopts "h?n:b:" opt; do
-  case $opt in
-  h|\?)
-    usage
-    exit 0
-    ;;
-  n)
-    lamports="$OPTARG"
-    ;;
-  b)
-    bootstrap_leader_lamports="$OPTARG"
-    ;;
-  *)
-    usage "Error: unhandled option: $opt"
-    ;;
-  esac
-done
-
-
 set -e
 "$here"/clear-fullnode-config.sh
 
@@ -52,17 +12,32 @@ $solana_keygen -o "$SOLANA_CONFIG_DIR"/mint-id.json
 $solana_keygen -o "$SOLANA_CONFIG_DIR"/bootstrap-leader-id.json
 $solana_keygen -o "$SOLANA_CONFIG_DIR"/bootstrap-leader-vote-id.json
 
-args=(
-  --bootstrap-leader-keypair "$SOLANA_CONFIG_DIR"/bootstrap-leader-id.json
-  --bootstrap-vote-keypair "$SOLANA_CONFIG_DIR"/bootstrap-leader-vote-id.json
-  --ledger "$SOLANA_RSYNC_CONFIG_DIR"/ledger
-  --mint "$SOLANA_CONFIG_DIR"/mint-id.json
-  --lamports "$lamports"
-)
 
-if [[ -n $bootstrap_leader_lamports ]]; then
-  args+=(--bootstrap-leader-lamports "$bootstrap_leader_lamports")
-fi
+default_arg() {
+  declare name=$1
+  declare value=$2
+
+  for arg in "${args[@]}"; do
+    if [[ $arg = "$name" ]]; then
+      return
+    fi
+  done
+
+  if [[ -n $value ]]; then
+    args+=("$name" "$value")
+  else
+    args+=("$name")
+  fi
+}
+
+args=("$@")
+default_arg --bootstrap-leader-keypair "$SOLANA_CONFIG_DIR"/bootstrap-leader-id.json
+default_arg --bootstrap-vote-keypair "$SOLANA_CONFIG_DIR"/bootstrap-leader-vote-id.json
+default_arg --ledger "$SOLANA_RSYNC_CONFIG_DIR"/ledger
+default_arg --mint "$SOLANA_CONFIG_DIR"/mint-id.json
+default_arg --lamports 100000000000000
 
 $solana_genesis "${args[@]}"
+
+test -d "$SOLANA_RSYNC_CONFIG_DIR"/ledger
 cp -a "$SOLANA_RSYNC_CONFIG_DIR"/ledger "$SOLANA_CONFIG_DIR"/bootstrap-leader-ledger

--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -78,7 +78,7 @@ local|tar)
     fi
     set -x
     if [[ $skipSetup != true ]]; then
-      ./multinode-demo/setup.sh -b $stake
+      ./multinode-demo/setup.sh --bootstrap-leader-lamports $stake
     fi
     ./multinode-demo/drone.sh > drone.log 2>&1 &
 

--- a/run.sh
+++ b/run.sh
@@ -51,6 +51,8 @@ leaderVoteAccountPubkey=$(\
 
 solana-genesis \
   --lamports 1000000000 \
+  --bootstrap-leader-lamports 10000000 \
+  --lamports-per-signature 1 \
   --mint "$dataDir"/config/drone-keypair.json \
   --bootstrap-leader-keypair "$dataDir"/config/leader-keypair.json \
   --bootstrap-vote-keypair "$dataDir"/config/leader-vote-account-keypair.json \

--- a/sdk/src/fee_calculator.rs
+++ b/sdk/src/fee_calculator.rs
@@ -1,6 +1,6 @@
 use crate::message::Message;
 
-#[derive(Default)]
+#[derive(Serialize, Deserialize, Clone, Debug, Default)]
 pub struct FeeCalculator {
     pub lamports_per_signature: u64,
 }

--- a/sdk/src/genesis_block.rs
+++ b/sdk/src/genesis_block.rs
@@ -1,6 +1,7 @@
 //! The `genesis_block` module is a library for generating the chain's genesis block.
 
 use crate::account::Account;
+use crate::fee_calculator::FeeCalculator;
 use crate::hash::{hash, Hash};
 use crate::pubkey::Pubkey;
 use crate::signature::{Keypair, KeypairUtil};
@@ -12,13 +13,14 @@ use std::path::Path;
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct GenesisBlock {
+    pub accounts: Vec<(Pubkey, Account)>,
     pub bootstrap_leader_id: Pubkey,
-    pub ticks_per_slot: u64,
+    pub epoch_warmup: bool,
+    pub fee_calculator: FeeCalculator,
+    pub native_instruction_processors: Vec<(String, Pubkey)>,
     pub slots_per_epoch: u64,
     pub stakers_slot_offset: u64,
-    pub epoch_warmup: bool,
-    pub accounts: Vec<(Pubkey, Account)>,
-    pub native_instruction_processors: Vec<(String, Pubkey)>,
+    pub ticks_per_slot: u64,
 }
 
 // useful for basic tests
@@ -44,13 +46,14 @@ impl GenesisBlock {
         native_instruction_processors: &[(String, Pubkey)],
     ) -> Self {
         Self {
+            accounts: accounts.to_vec(),
             bootstrap_leader_id: *bootstrap_leader_id, // TODO: leader_schedule to derive from actual stakes, instead ;)
-            ticks_per_slot: DEFAULT_TICKS_PER_SLOT,
+            epoch_warmup: true,
+            fee_calculator: FeeCalculator::default(),
+            native_instruction_processors: native_instruction_processors.to_vec(),
             slots_per_epoch: DEFAULT_SLOTS_PER_EPOCH,
             stakers_slot_offset: DEFAULT_SLOTS_PER_EPOCH,
-            epoch_warmup: true,
-            accounts: accounts.to_vec(),
-            native_instruction_processors: native_instruction_processors.to_vec(),
+            ticks_per_slot: DEFAULT_TICKS_PER_SLOT,
         }
     }
 


### PR DESCRIPTION
#3684 shows that a default cluster fee of 0 is _best_ for unit tests, however a configurable fee is still desired when running a real cluster.  As a baby step towards #4167, the FeeCalculator is now derived from the GenesisBlock and can be configured by the `solana-genesis` tool.