### PR TITLE
Core depends on vote and budget program directly

### DIFF
--- a/bench-exchange/src/bench.rs
+++ b/bench-exchange/src/bench.rs
@@ -925,10 +925,10 @@ mod tests {
 
         let mut config = Config::default();
         config.identity = Keypair::new();
-        config.duration = Duration::from_secs(1);
+        config.duration = Duration::from_secs(1000);
         config.fund_amount = 100_000;
         config.threads = 1;
-        config.transfer_delay = 20; // 15
+        config.transfer_delay = 100; // 15
         config.batch_size = 100; // 1000;
         config.chunk_size = 10; // 200;
         config.account_groups = 1; // 10;

--- a/bench-exchange/src/bench.rs
+++ b/bench-exchange/src/bench.rs
@@ -925,10 +925,10 @@ mod tests {
 
         let mut config = Config::default();
         config.identity = Keypair::new();
-        config.duration = Duration::from_secs(1000);
+        config.duration = Duration::from_secs(1);
         config.fund_amount = 100_000;
         config.threads = 1;
-        config.transfer_delay = 100; // 15
+        config.transfer_delay = 20; // 15
         config.batch_size = 100; // 1000;
         config.chunk_size = 10; // 200;
         config.account_groups = 1; // 10;

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -48,6 +48,7 @@ serde = "1.0.89"
 serde_derive = "1.0.88"
 serde_json = "1.0.39"
 solana-budget-api = { path = "../programs/budget_api", version = "0.15.0"  }
+solana-budget-program = { path = "../programs/budget_program", version = "0.15.0"  }
 solana-client = { path = "../client", version = "0.15.0"  }
 solana-drone = { path = "../drone", version = "0.15.0"  }
 solana-kvstore = { path = "../kvstore", version = "0.15.0" , optional = true  }
@@ -58,6 +59,7 @@ solana-runtime = { path = "../runtime", version = "0.15.0"  }
 solana-sdk = { path = "../sdk", version = "0.15.0"  }
 solana-storage-api = { path = "../programs/storage_api", version = "0.15.0"  }
 solana-vote-api = { path = "../programs/vote_api", version = "0.15.0"  }
+solana-vote-program = { path = "../programs/vote_program", version = "0.15.0"  }
 solana-vote-signer = { path = "../vote-signer", version = "0.15.0"  }
 sys-info = "0.5.6"
 tokio = "0.1"
@@ -67,8 +69,7 @@ untrusted = "0.6.2"
 [dev-dependencies]
 hex-literal = "0.2.0"
 matches = "0.1.6"
-solana-vote-program = { path = "../programs/vote_program", version = "0.15.0"  }
-solana-budget-program = { path = "../programs/budget_program", version = "0.15.0"  }
+
 
 [[bench]]
 name = "banking_stage"


### PR DESCRIPTION
#### Problem

Core requires vote and budget programs to operate.  Removes the need to seperatly `build -all` to get vote and budget program built.

#### Summary of Changes

Fixes #
