### PR TITLE
Don't push empty vecs into the unprocessed buffers

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -170,9 +170,11 @@ impl BankingStage {
             if processed < verified_txs_len {
                 bank_shutdown = true;
             }
-            rebuffered_packets += new_unprocessed_indexes.len();
             // Collect any unprocessed transactions in this batch for forwarding
-            unprocessed_packets.push((msgs.to_owned(), new_unprocessed_indexes));
+            if !new_unprocessed_indexes.is_empty() {
+                rebuffered_packets += new_unprocessed_indexes.len();
+                unprocessed_packets.push((msgs.to_owned(), new_unprocessed_indexes));
+            }
         }
 
         inc_new_counter_info!("banking_stage-rebuffered_packets", rebuffered_packets);
@@ -608,7 +610,9 @@ impl BankingStage {
                 bank_shutdown = true;
             }
             // Collect any unprocessed transactions in this batch for forwarding
-            unprocessed_packets.push((msgs, unprocessed_indexes));
+            if !unprocessed_indexes.is_empty() {
+                unprocessed_packets.push((msgs, unprocessed_indexes));
+            }
 
             new_tx_count += processed;
         }


### PR DESCRIPTION
#### Problem

Pushing empty vecs can cause the buffered_packets buffers to become very large and slow down banking stage.

#### Summary of Changes

Don't push into unprocessed_packets if there are none to push.

Fixes #
