### PR TITLE
Change remote node's ssh config to allow more login retries

### DIFF
--- a/net/scripts/network-config.sh
+++ b/net/scripts/network-config.sh
@@ -9,3 +9,7 @@ sudo sysctl -w net.core.rmem_max=1610612736
 
 sudo sysctl -w net.core.wmem_default=1610612736
 sudo sysctl -w net.core.wmem_max=1610612736
+
+echo "MaxAuthTries 60" | sudo tee -a /etc/ssh/sshd_config
+sudo service sshd restart
+sudo systemctl restart sshd


### PR DESCRIPTION
#### Problem
The ssh access to cloud VMs is returning this error
```
Received disconnect from 34.83.48.182 port 22:2: Too many authentication failures
```
#### Summary of Changes
Set MaxAuthTries 

Fixes #
