### PR TITLE
Extend GetBlockHash RPC API to include the fee schedule for using the returned blockhash

### DIFF
--- a/bench-exchange/src/bench.rs
+++ b/bench-exchange/src/bench.rs
@@ -371,7 +371,7 @@ fn swapper<T>(
             }
             account_group = (account_group + 1) % account_groups as usize;
 
-            let blockhash = client
+            let (blockhash, _fee_calculator) = client
                 .get_recent_blockhash()
                 .expect("Failed to get blockhash");
             let to_swap_txs: Vec<_> = to_swap
@@ -499,7 +499,7 @@ fn trader<T>(
         }
         account_group = (account_group + 1) % account_groups as usize;
 
-        let blockhash = client
+        let (blockhash, _fee_calculator) = client
             .get_recent_blockhash()
             .expect("Failed to get blockhash");
 
@@ -663,7 +663,8 @@ pub fn fund_keys(client: &Client, source: &Keypair, dests: &[Arc<Keypair>], lamp
                     to_fund_txs.len(),
                 );
 
-                let blockhash = client.get_recent_blockhash().expect("blockhash");
+                let (blockhash, _fee_calculator) =
+                    client.get_recent_blockhash().expect("blockhash");
                 to_fund_txs.par_iter_mut().for_each(|(k, tx)| {
                     tx.sign(&[*k], blockhash);
                 });
@@ -738,7 +739,7 @@ pub fn create_token_accounts(client: &Client, signers: &[Arc<Keypair>], accounts
 
             let mut retries = 0;
             while !to_create_txs.is_empty() {
-                let blockhash = client
+                let (blockhash, _fee_calculator) = client
                     .get_recent_blockhash()
                     .expect("Failed to get blockhash");
                 to_create_txs.par_iter_mut().for_each(|(k, tx)| {
@@ -854,7 +855,7 @@ pub fn airdrop_lamports(client: &Client, drone_addr: &SocketAddr, id: &Keypair, 
 
     let mut tries = 0;
     loop {
-        let blockhash = client
+        let (blockhash, _fee_calculator) = client
             .get_recent_blockhash()
             .expect("Failed to get blockhash");
         match request_airdrop_transaction(&drone_addr, &id.pubkey(), amount_to_drop, blockhash) {

--- a/bench-tps/src/bench.rs
+++ b/bench-tps/src/bench.rs
@@ -140,7 +140,7 @@ where
         // this seems to be faster than trying to determine the balance of individual
         // accounts
         let len = tx_count as usize;
-        if let Ok(new_blockhash) = client.get_new_blockhash(&blockhash) {
+        if let Ok((new_blockhash, _fee_calculator)) = client.get_new_blockhash(&blockhash) {
             blockhash = new_blockhash;
         } else {
             if blockhash_time.elapsed().as_secs() > 30 {
@@ -404,7 +404,7 @@ pub fn fund_keys<T: Client>(client: &T, source: &Keypair, dests: &[Keypair], lam
                     to_fund_txs.len(),
                 );
 
-                let blockhash = client.get_recent_blockhash().unwrap();
+                let (blockhash, _fee_calculator) = client.get_recent_blockhash().unwrap();
 
                 // re-sign retained to_fund_txes with updated blockhash
                 to_fund_txs.par_iter_mut().for_each(|(k, tx)| {
@@ -454,7 +454,7 @@ pub fn airdrop_lamports<T: Client>(
             id.pubkey(),
         );
 
-        let blockhash = client.get_recent_blockhash().unwrap();
+        let (blockhash, _fee_calculator) = client.get_recent_blockhash().unwrap();
         match request_airdrop_transaction(&drone_addr, &id.pubkey(), airdrop_amount, blockhash) {
             Ok(transaction) => {
                 let signature = client.async_send_transaction(transaction).unwrap();

--- a/book/src/jsonrpc-api.md
+++ b/book/src/jsonrpc-api.md
@@ -167,13 +167,16 @@ curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0", "id":1, "
 ---
 
 ### getRecentBlockhash
-Returns a recent block hash from the ledger
+Returns a recent block hash from the ledger, and a fee schedule that can be used
+to compute the cost of submitting a transaction using it.
 
 ##### Parameters:
 None
 
 ##### Results:
+An array consisting of
 * `string` - a Hash as base-58 encoded string
+* `FeeCalculator object` - the fee schedule for this block hash
 
 ##### Example:
 ```bash
@@ -181,7 +184,7 @@ None
 curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1, "method":"getRecentBlockhash"}' http://localhost:8899
 
 // Result
-{"jsonrpc":"2.0","result":"GH7ome3EiwEr7tu9JuTh2dpYWBJK3z69Xm1ZE3MEE6JC","id":1}
+{"jsonrpc":"2.0","result":["GH7ome3EiwEr7tu9JuTh2dpYWBJK3z69Xm1ZE3MEE6JC",{"lamportsPerSignature": 0}],"id":1}
 ```
 
 ---

--- a/client/src/mock_rpc_client_request.rs
+++ b/client/src/mock_rpc_client_request.rs
@@ -2,6 +2,7 @@ use crate::client_error::ClientError;
 use crate::generic_rpc_client_request::GenericRpcClientRequest;
 use crate::rpc_request::RpcRequest;
 use serde_json::{Number, Value};
+use solana_sdk::fee_calculator::FeeCalculator;
 use solana_sdk::transaction::{self, TransactionError};
 
 pub const PUBKEY: &str = "7RoSF9fUmdphVCpabEoefH81WwrW7orsWonXWqTXkKV8";
@@ -44,7 +45,10 @@ impl GenericRpcClientRequest for MockRpcClientRequest {
                 let n = if self.url == "airdrop" { 0 } else { 50 };
                 Value::Number(Number::from(n))
             }
-            RpcRequest::GetRecentBlockhash => Value::String(PUBKEY.to_string()),
+            RpcRequest::GetRecentBlockhash => Value::Array(vec![
+                Value::String(PUBKEY.to_string()),
+                serde_json::to_value(FeeCalculator::default()).unwrap(),
+            ]),
             RpcRequest::GetSignatureStatus => {
                 let response: Option<transaction::Result<()>> = if self.url == "account_in_use" {
                     Some(Err(TransactionError::AccountInUse))

--- a/core/src/cluster_tests.rs
+++ b/core/src/cluster_tests.rs
@@ -39,11 +39,12 @@ pub fn spend_and_verify_all_nodes(
             .poll_get_balance(&funding_keypair.pubkey())
             .expect("balance in source");
         assert!(bal > 0);
+        let (blockhash, _fee_calculator) = client.get_recent_blockhash().unwrap();
         let mut transaction = system_transaction::transfer(
             &funding_keypair,
             &random_keypair.pubkey(),
             1,
-            client.get_recent_blockhash().unwrap(),
+            blockhash,
             0,
         );
         let confs = VOTE_THRESHOLD_DEPTH + 1;
@@ -65,11 +66,12 @@ pub fn send_many_transactions(node: &ContactInfo, funding_keypair: &Keypair, num
             .poll_get_balance(&funding_keypair.pubkey())
             .expect("balance in source");
         assert!(bal > 0);
+        let (blockhash, _fee_calculator) = client.get_recent_blockhash().unwrap();
         let mut transaction = system_transaction::transfer(
             &funding_keypair,
             &random_keypair.pubkey(),
             1,
-            client.get_recent_blockhash().unwrap(),
+            blockhash,
             0,
         );
         client
@@ -187,11 +189,12 @@ pub fn kill_entry_and_spend_and_verify_rest(
             }
 
             let random_keypair = Keypair::new();
+            let (blockhash, _fee_calculator) = client.get_recent_blockhash().unwrap();
             let mut transaction = system_transaction::transfer(
                 &funding_keypair,
                 &random_keypair.pubkey(),
                 1,
-                client.get_recent_blockhash().unwrap(),
+                blockhash,
                 0,
             );
 

--- a/core/src/local_cluster.rs
+++ b/core/src/local_cluster.rs
@@ -338,7 +338,7 @@ impl LocalCluster {
         lamports: u64,
     ) -> u64 {
         trace!("getting leader blockhash");
-        let blockhash = client.get_recent_blockhash().unwrap();
+        let (blockhash, _fee_calculator) = client.get_recent_blockhash().unwrap();
         let mut tx = system_transaction::create_user_account(
             &source_keypair,
             dest_pubkey,
@@ -378,10 +378,11 @@ impl LocalCluster {
                 0,
                 amount,
             );
+            let (blockhash, _fee_calculator) = client.get_recent_blockhash().unwrap();
             let mut transaction = Transaction::new_signed_instructions(
                 &[from_account.as_ref()],
                 instructions,
-                client.get_recent_blockhash().unwrap(),
+                blockhash,
             );
 
             client

--- a/core/src/replicator.rs
+++ b/core/src/replicator.rs
@@ -419,7 +419,7 @@ impl Replicator {
         // check if the account exists
         let bal = client.poll_get_balance(&storage_keypair.pubkey());
         if bal.is_err() || bal.unwrap() == 0 {
-            let blockhash = client.get_recent_blockhash().expect("blockhash");
+            let (blockhash, _fee_calculator) = client.get_recent_blockhash().expect("blockhash");
             //TODO the account space needs to be well defined somewhere
             let tx = system_transaction::create_account(
                 keypair,

--- a/core/tests/rpc.rs
+++ b/core/tests/rpc.rs
@@ -35,7 +35,7 @@ fn test_rpc_send_tx() {
         .send()
         .unwrap();
     let json: Value = serde_json::from_str(&response.text().unwrap()).unwrap();
-    let blockhash_vec = bs58::decode(json["result"].as_str().unwrap())
+    let blockhash_vec = bs58::decode(json["result"][0].as_str().unwrap())
         .into_vec()
         .unwrap();
     let blockhash = Hash::new(&blockhash_vec);

--- a/install/src/command.rs
+++ b/install/src/command.rs
@@ -197,7 +197,7 @@ fn new_update_manifest(
         .get_account_data(&update_manifest_keypair.pubkey())
         .is_err()
     {
-        let recect_blockhash = rpc_client.get_recent_blockhash()?;
+        let (recent_blockhash, _fee_calculator) = rpc_client.get_recent_blockhash()?;
 
         let new_account = config_instruction::create_account::<SignedUpdateManifest>(
             &from_keypair.pubkey(),
@@ -205,7 +205,7 @@ fn new_update_manifest(
             1, // lamports
         );
         let mut transaction = Transaction::new_unsigned_instructions(vec![new_account]);
-        transaction.sign(&[from_keypair], recect_blockhash);
+        transaction.sign(&[from_keypair], recent_blockhash);
 
         rpc_client.send_and_confirm_transaction(&mut transaction, &[from_keypair])?;
     }
@@ -219,7 +219,7 @@ fn store_update_manifest(
     update_manifest_keypair: &Keypair,
     update_manifest: &SignedUpdateManifest,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let recect_blockhash = rpc_client.get_recent_blockhash()?;
+    let (recent_blockhash, _fee_calculator) = rpc_client.get_recent_blockhash()?;
 
     let signers = [from_keypair, update_manifest_keypair];
     let instruction = config_instruction::store::<SignedUpdateManifest>(
@@ -228,7 +228,7 @@ fn store_update_manifest(
     );
 
     let message = Message::new_with_payer(vec![instruction], Some(&from_keypair.pubkey()));
-    let mut transaction = Transaction::new(&signers, message, recect_blockhash);
+    let mut transaction = Transaction::new(&signers, message, recent_blockhash);
     rpc_client.send_and_confirm_transaction(&mut transaction, &[from_keypair])?;
     Ok(())
 }

--- a/runtime/benches/bank.rs
+++ b/runtime/benches/bank.rs
@@ -50,11 +50,8 @@ pub fn create_builtin_transactions(
                 .expect(&format!("{}:{}", line!(), file!()));
 
             let instruction = create_invoke_instruction(rando0.pubkey(), program_id, &1u8);
-            Transaction::new_signed_instructions(
-                &[&rando0],
-                vec![instruction],
-                bank_client.get_recent_blockhash().unwrap(),
-            )
+            let (blockhash, _fee_calculator) = bank_client.get_recent_blockhash().unwrap();
+            Transaction::new_signed_instructions(&[&rando0], vec![instruction], blockhash)
         })
         .collect()
 }
@@ -76,11 +73,8 @@ pub fn create_native_loader_transactions(
                 .expect(&format!("{}:{}", line!(), file!()));
 
             let instruction = create_invoke_instruction(rando0.pubkey(), program_id, &1u8);
-            Transaction::new_signed_instructions(
-                &[&rando0],
-                vec![instruction],
-                bank_client.get_recent_blockhash().unwrap(),
-            )
+            let (blockhash, _fee_calculator) = bank_client.get_recent_blockhash().unwrap();
+            Transaction::new_signed_instructions(&[&rando0], vec![instruction], blockhash)
         })
         .collect()
 }

--- a/sdk/src/client.rs
+++ b/sdk/src/client.rs
@@ -7,6 +7,7 @@
 //! Asynchronous implementations are expected to create transactions, sign them, and send
 //! them but without waiting to see if the server accepted it.
 
+use crate::fee_calculator::FeeCalculator;
 use crate::hash::Hash;
 use crate::instruction::Instruction;
 use crate::message::Message;
@@ -46,7 +47,7 @@ pub trait SyncClient {
     ) -> Result<Option<transaction::Result<()>>>;
 
     /// Get recent blockhash
-    fn get_recent_blockhash(&self) -> Result<Hash>;
+    fn get_recent_blockhash(&self) -> Result<(Hash, FeeCalculator)>;
 
     /// Get transaction count
     fn get_transaction_count(&self) -> Result<u64>;
@@ -61,7 +62,7 @@ pub trait SyncClient {
     /// Poll to confirm a transaction.
     fn poll_for_signature(&self, signature: &Signature) -> Result<()>;
 
-    fn get_new_blockhash(&self, blockhash: &Hash) -> Result<Hash>;
+    fn get_new_blockhash(&self, blockhash: &Hash) -> Result<(Hash, FeeCalculator)>;
 }
 
 pub trait AsyncClient {

--- a/sdk/src/fee_calculator.rs
+++ b/sdk/src/fee_calculator.rs
@@ -1,6 +1,7 @@
 use crate::message::Message;
 
 #[derive(Serialize, Deserialize, Clone, Debug, Default)]
+#[serde(rename_all = "camelCase")]
 pub struct FeeCalculator {
     pub lamports_per_signature: u64,
 }

--- a/wallet/src/wallet.rs
+++ b/wallet/src/wallet.rs
@@ -388,7 +388,7 @@ fn process_create_vote_account(
         commission,
         lamports,
     );
-    let recent_blockhash = rpc_client.get_recent_blockhash()?;
+    let (recent_blockhash, _fee_calculator) = rpc_client.get_recent_blockhash()?;
     let mut tx = Transaction::new_signed_instructions(&[&config.keypair], ixs, recent_blockhash);
     let signature_str = rpc_client.send_and_confirm_transaction(&mut tx, &[&config.keypair])?;
     Ok(signature_str.to_string())
@@ -399,7 +399,7 @@ fn process_authorize_voter(
     config: &WalletConfig,
     authorized_voter_id: &Pubkey,
 ) -> ProcessResult {
-    let recent_blockhash = rpc_client.get_recent_blockhash()?;
+    let (recent_blockhash, _fee_calculator) = rpc_client.get_recent_blockhash()?;
     let ixs = vec![vote_instruction::authorize_voter(
         &config.keypair.pubkey(),
         authorized_voter_id,
@@ -457,7 +457,7 @@ fn process_create_stake_account(
     staking_account_id: &Pubkey,
     lamports: u64,
 ) -> ProcessResult {
-    let recent_blockhash = rpc_client.get_recent_blockhash()?;
+    let (recent_blockhash, _fee_calculator) = rpc_client.get_recent_blockhash()?;
     let ixs = vec![stake_instruction::create_account(
         &config.keypair.pubkey(),
         staking_account_id,
@@ -474,7 +474,7 @@ fn process_delegate_stake(
     staking_account_keypair: &Keypair,
     voting_account_id: &Pubkey,
 ) -> ProcessResult {
-    let recent_blockhash = rpc_client.get_recent_blockhash()?;
+    let (recent_blockhash, _fee_calculator) = rpc_client.get_recent_blockhash()?;
     let ixs = vec![stake_instruction::delegate_stake(
         &config.keypair.pubkey(),
         &staking_account_keypair.pubkey(),
@@ -527,7 +527,7 @@ fn process_deploy(
         }
     }
 
-    let blockhash = rpc_client.get_recent_blockhash()?;
+    let (blockhash, _fee_calculator) = rpc_client.get_recent_blockhash()?;
     let program_id = Keypair::new();
     let mut file = File::open(program_location).map_err(|err| {
         WalletError::DynamicProgramError(
@@ -600,7 +600,7 @@ fn process_pay(
     witnesses: &Option<Vec<Pubkey>>,
     cancelable: Option<Pubkey>,
 ) -> ProcessResult {
-    let blockhash = rpc_client.get_recent_blockhash()?;
+    let (blockhash, _fee_calculator) = rpc_client.get_recent_blockhash()?;
 
     if timestamp == None && *witnesses == None {
         let mut tx = system_transaction::transfer(&config.keypair, to, lamports, blockhash, 0);
@@ -636,7 +636,7 @@ fn process_pay(
         })
         .to_string())
     } else if timestamp == None {
-        let blockhash = rpc_client.get_recent_blockhash()?;
+        let (blockhash, _fee_calculator) = rpc_client.get_recent_blockhash()?;
 
         let witness = if let Some(ref witness_vec) = *witnesses {
             witness_vec[0]
@@ -672,7 +672,7 @@ fn process_pay(
 }
 
 fn process_cancel(rpc_client: &RpcClient, config: &WalletConfig, pubkey: &Pubkey) -> ProcessResult {
-    let blockhash = rpc_client.get_recent_blockhash()?;
+    let (blockhash, _fee_calculator) = rpc_client.get_recent_blockhash()?;
     let ix = budget_instruction::apply_signature(
         &config.keypair.pubkey(),
         pubkey,
@@ -703,7 +703,7 @@ fn process_time_elapsed(
         request_and_confirm_airdrop(&rpc_client, &drone_addr, &config.keypair.pubkey(), 1)?;
     }
 
-    let blockhash = rpc_client.get_recent_blockhash()?;
+    let (blockhash, _fee_calculator) = rpc_client.get_recent_blockhash()?;
 
     let ix = budget_instruction::apply_timestamp(&config.keypair.pubkey(), pubkey, to, dt);
     let mut tx = Transaction::new_signed_instructions(&[&config.keypair], vec![ix], blockhash);
@@ -726,7 +726,7 @@ fn process_witness(
         request_and_confirm_airdrop(&rpc_client, &drone_addr, &config.keypair.pubkey(), 1)?;
     }
 
-    let blockhash = rpc_client.get_recent_blockhash()?;
+    let (blockhash, _fee_calculator) = rpc_client.get_recent_blockhash()?;
     let ix = budget_instruction::apply_signature(&config.keypair.pubkey(), pubkey, to);
     let mut tx = Transaction::new_signed_instructions(&[&config.keypair], vec![ix], blockhash);
     let result = rpc_client.send_and_confirm_transaction(&mut tx, &[&config.keypair]);
@@ -891,7 +891,7 @@ pub fn request_and_confirm_airdrop(
     to_pubkey: &Pubkey,
     lamports: u64,
 ) -> Result<(), Box<dyn error::Error>> {
-    let blockhash = rpc_client.get_recent_blockhash()?;
+    let (blockhash, _fee_calculator) = rpc_client.get_recent_blockhash()?;
     let keypair = {
         let mut retries = 5;
         loop {


### PR DESCRIPTION
Clients have no idea what the current fee schedule for a cluster is, and once #4167 is fully implemented that schedule will be dynamic.