### PR TITLE
Add newly completed slots signal to Blocktree

### DIFF
--- a/core/src/blocktree.rs
+++ b/core/src/blocktree.rs
@@ -2233,7 +2233,6 @@ pub mod tests {
         Blocktree::destroy(&ledger_path).expect("Expected successful database destruction");
     }
 
-
     #[test]
     pub fn test_completed_blobs_signal() {
         // Initialize ledger
@@ -2246,7 +2245,9 @@ pub mod tests {
         let (blobs, _) = make_slot_entries(0, 0, entries_per_slot);
 
         // Insert all but the first blob in the slot, should not be considered complete
-        ledger.insert_data_blobs(&blobs[1..entries_per_slot as usize]).unwrap();
+        ledger
+            .insert_data_blobs(&blobs[1..entries_per_slot as usize])
+            .unwrap();
         assert!(recvr.try_recv().is_err());
 
         //Insert first blob, slot should now be considered complete
@@ -2269,10 +2270,12 @@ pub mod tests {
         let (blobs, _) = make_slot_entries(slot, orphan_slot, entries_per_slot);
 
         // Create blobs for slot 5 chaining to slot 2
-        let (orphan_blobs, _) = make_slot_entries(orphan_slot,orphan_slot2 , entries_per_slot);
+        let (orphan_blobs, _) = make_slot_entries(orphan_slot, orphan_slot2, entries_per_slot);
 
         // Insert all but the first blob in the slot, should not be considered complete
-        ledger.insert_data_blobs(&blobs[1..entries_per_slot as usize]).unwrap();
+        ledger
+            .insert_data_blobs(&blobs[1..entries_per_slot as usize])
+            .unwrap();
         assert!(recvr.try_recv().is_err());
 
         //Insert first blob, slot should now be considered complete
@@ -2280,7 +2283,9 @@ pub mod tests {
         assert_eq!(recvr.try_recv().unwrap(), vec![slot]);
 
         // Insert the blobs for the orphan_slot
-        ledger.insert_data_blobs(&orphan_blobs[1..entries_per_slot as usize]).unwrap();
+        ledger
+            .insert_data_blobs(&orphan_blobs[1..entries_per_slot as usize])
+            .unwrap();
         assert!(recvr.try_recv().is_err());
 
         //Insert first blob, slot should now be considered complete
@@ -2307,11 +2312,14 @@ pub mod tests {
         let (blobs3, _) = make_slot_entries(slot3, 0, entries_per_slot);
         let (blobs4, _) = make_slot_entries(disconnected_slot, 1, entries_per_slot);
 
-        let mut all_blobs: Vec<_> = vec![blobs, blobs2, blobs3, blobs4].into_iter().flatten().collect();
+        let mut all_blobs: Vec<_> = vec![blobs, blobs2, blobs3, blobs4]
+            .into_iter()
+            .flatten()
+            .collect();
 
         all_blobs.shuffle(&mut thread_rng());
         ledger.insert_data_blobs(all_blobs).unwrap();
-        let mut result =  recvr.try_recv().unwrap();
+        let mut result = recvr.try_recv().unwrap();
         result.sort();
         assert_eq!(result, vec![slot3, disconnected_slot, slot2, slot]);
     }
@@ -2379,7 +2387,7 @@ pub mod tests {
         }
         Blocktree::destroy(&blocktree_path).expect("Expected successful database destruction");
     }
-    
+
     #[test]
     pub fn test_handle_chaining_missing_slots() {
         let blocktree_path = get_tmp_ledger_path("test_handle_chaining_missing_slots");

--- a/core/src/blocktree.rs
+++ b/core/src/blocktree.rs
@@ -28,7 +28,7 @@ use std::cmp;
 use std::fs;
 use std::io;
 use std::rc::Rc;
-use std::sync::mpsc::{sync_channel, Receiver, SyncSender};
+use std::sync::mpsc::{sync_channel, Receiver, SyncSender, TrySendError};
 use std::sync::{Arc, RwLock};
 
 pub use self::meta::*;
@@ -63,6 +63,10 @@ db_imports! {rocks, Rocks, "rocksdb"}
 #[cfg(feature = "kvstore")]
 db_imports! {kvs, Kvs, "kvstore"}
 
+pub const MAX_COMPLETED_SLOTS_IN_CHANNEL: usize = 100_000;
+
+pub type CompletedSlotsReceiver = Receiver<Vec<u64>>;
+
 #[derive(Debug)]
 pub enum BlocktreeError {
     BlobForIndexExists,
@@ -83,6 +87,7 @@ pub struct Blocktree {
     batch_processor: Arc<RwLock<BatchProcessor>>,
     session: Arc<erasure::Session>,
     pub new_blobs_signals: Vec<SyncSender<bool>>,
+    pub completed_slots: Vec<SyncSender<Vec<u64>>>,
 }
 
 // Column family for metadata about a leader slot
@@ -141,15 +146,21 @@ impl Blocktree {
             session,
             new_blobs_signals: vec![],
             batch_processor,
+            completed_slots: vec![],
         })
     }
 
-    pub fn open_with_signal(ledger_path: &str) -> Result<(Self, Receiver<bool>)> {
+    pub fn open_with_signal(
+        ledger_path: &str,
+    ) -> Result<(Self, Receiver<bool>, CompletedSlotsReceiver)> {
         let mut blocktree = Self::open(ledger_path)?;
         let (signal_sender, signal_receiver) = sync_channel(1);
+        let (completed_slots_sender, completed_slots_receiver) =
+            sync_channel(MAX_COMPLETED_SLOTS_IN_CHANNEL);
         blocktree.new_blobs_signals = vec![signal_sender];
+        blocktree.completed_slots = vec![completed_slots_sender];
 
-        Ok((blocktree, signal_receiver))
+        Ok((blocktree, signal_receiver, completed_slots_receiver))
     }
 
     pub fn destroy(ledger_path: &str) -> Result<()> {
@@ -340,11 +351,15 @@ impl Blocktree {
         // Handle chaining for the working set
         handle_chaining(&db, &mut write_batch, &slot_meta_working_set)?;
         let mut should_signal = false;
+        let mut newly_completed_slots = vec![];
 
         // Check if any metadata was changed, if so, insert the new version of the
         // metadata into the write batch
         for (slot, (meta, meta_backup)) in slot_meta_working_set.iter() {
             let meta: &SlotMeta = &RefCell::borrow(&*meta);
+            if self.completed_slots.len() > 0 && is_newly_completed_slot(meta, meta_backup) {
+                newly_completed_slots.push(*slot);
+            }
             // Check if the working copy of the metadata has changed
             if Some(meta) != meta_backup.as_ref() {
                 should_signal = should_signal || slot_has_updates(meta, &meta_backup);
@@ -356,13 +371,40 @@ impl Blocktree {
             write_batch.put::<cf::ErasureMeta>((slot, set_index), &erasure_meta)?;
         }
 
+        batch_processor.write(write_batch)?;
+
         if should_signal {
-            for signal in self.new_blobs_signals.iter() {
+            for signal in &self.new_blobs_signals {
                 let _ = signal.try_send(true);
             }
         }
 
-        batch_processor.write(write_batch)?;
+        if self.completed_slots.len() > 0 && !newly_completed_slots.is_empty() {
+            let mut slots: Vec<_> = (0..self.completed_slots.len() - 1)
+                .map(|_| newly_completed_slots.clone())
+                .collect();
+
+            slots.push(newly_completed_slots);
+
+            for (signal, slots) in self.completed_slots.iter().zip(slots.into_iter()) {
+                let res = signal.try_send(slots);
+                match res {
+                    Err(TrySendError::Full(_)) => {
+                        solana_metrics::submit(
+                            solana_metrics::influxdb::Point::new("blocktree_error")
+                                .add_field(
+                                    "error",
+                                    solana_metrics::influxdb::Value::String(
+                                        "Unable to send newly completed slot because channel is full".to_string(),
+                                    ),
+                                )
+                                .to_owned(),
+                        );
+                    }
+                    _ => (),
+                }
+            }
+        }
 
         Ok(())
     }
@@ -880,7 +922,7 @@ fn insert_data_blob<'a>(
     slot_meta.received = cmp::max(blob_index + 1, slot_meta.received);
     slot_meta.consumed = new_consumed;
     slot_meta.last_index = {
-        // If the last slot hasn't been set before, then
+        // If the last index in the slot hasn't been set before, then
         // set it to this blob index
         if slot_meta.last_index == std::u64::MAX {
             if blob_to_insert.is_last_in_slot() {
@@ -1123,9 +1165,8 @@ fn handle_chaining_for_slot(
         .expect("Slot must exist in the working_set hashmap");
 
     {
-        let is_orphaned = meta_backup.is_some() && is_orphan(meta_backup.as_ref().unwrap());
-
         let mut meta_mut = meta.borrow_mut();
+        let was_orphan_slot = meta_backup.is_some() && is_orphan(meta_backup.as_ref().unwrap());
 
         // If:
         // 1) This is a new slot
@@ -1137,27 +1178,32 @@ fn handle_chaining_for_slot(
             // Check if the slot represented by meta_mut is either a new slot or a orphan.
             // In both cases we need to run the chaining logic b/c the parent on the slot was
             // previously unknown.
-            if meta_backup.is_none() || is_orphaned {
+            if meta_backup.is_none() || was_orphan_slot {
                 let prev_slot_meta =
                     find_slot_meta_else_create(db, working_set, new_chained_slots, prev_slot)?;
 
-                // This is a newly inserted slot so run the chaining logic
+                // This is a newly inserted slot/orphan so run the chaining logic to link it to a
+                // newly discovered parent
                 chain_new_slot_to_prev_slot(&mut prev_slot_meta.borrow_mut(), slot, &mut meta_mut);
 
+                // If the parent of `slot` is a newly inserted orphan, insert it into the orphans
+                // column family
                 if is_orphan(&RefCell::borrow(&*prev_slot_meta)) {
                     write_batch.put::<cf::Orphans>(prev_slot, &true)?;
                 }
             }
         }
 
-        // At this point this slot has received a parent, so no longer a orphan
-        if is_orphaned {
+        // At this point this slot has received a parent, so it's no longer an orphan
+        if was_orphan_slot {
             write_batch.delete::<cf::Orphans>(slot)?;
         }
     }
 
-    // This is a newly inserted slot and slot.is_connected is true, so update all
-    // child slots so that their `is_connected` = true
+    // If this is a newly inserted slot, then we know the children of this slot were not previously
+    // connected to the trunk of the ledger. Thus if slot.is_connected is now true, we need to
+    // update all child slots with `is_connected` = true because these children are also now newly
+    // connected to to trunk of the the ledger
     let should_propagate_is_connected =
         is_newly_completed_slot(&RefCell::borrow(&*meta), meta_backup)
             && RefCell::borrow(&*meta).is_connected;
@@ -1238,7 +1284,6 @@ fn chain_new_slot_to_prev_slot(
 fn is_newly_completed_slot(slot_meta: &SlotMeta, backup_slot_meta: &Option<SlotMeta>) -> bool {
     slot_meta.is_full()
         && (backup_slot_meta.is_none()
-            || is_orphan(&backup_slot_meta.as_ref().unwrap())
             || slot_meta.consumed != backup_slot_meta.as_ref().unwrap().consumed)
 }
 
@@ -2112,7 +2157,7 @@ pub mod tests {
     pub fn test_new_blobs_signal() {
         // Initialize ledger
         let ledger_path = get_tmp_ledger_path("test_new_blobs_signal");
-        let (ledger, recvr) = Blocktree::open_with_signal(&ledger_path).unwrap();
+        let (ledger, recvr, _) = Blocktree::open_with_signal(&ledger_path).unwrap();
         let ledger = Arc::new(ledger);
 
         let entries_per_slot = 10;
@@ -2188,6 +2233,89 @@ pub mod tests {
         Blocktree::destroy(&ledger_path).expect("Expected successful database destruction");
     }
 
+
+    #[test]
+    pub fn test_completed_blobs_signal() {
+        // Initialize ledger
+        let ledger_path = get_tmp_ledger_path("test_completed_blobs_signal");
+        let (ledger, _, recvr) = Blocktree::open_with_signal(&ledger_path).unwrap();
+        let ledger = Arc::new(ledger);
+
+        let entries_per_slot = 10;
+        // Create blobs for slot 0
+        let (blobs, _) = make_slot_entries(0, 0, entries_per_slot);
+
+        // Insert all but the first blob in the slot, should not be considered complete
+        ledger.insert_data_blobs(&blobs[1..entries_per_slot as usize]).unwrap();
+        assert!(recvr.try_recv().is_err());
+
+        //Insert first blob, slot should now be considered complete
+        ledger.insert_data_blobs(once(&blobs[0])).unwrap();
+        assert_eq!(recvr.try_recv().unwrap(), vec![0]);
+    }
+
+    #[test]
+    pub fn test_completed_blobs_signal_orphans() {
+        // Initialize ledger
+        let ledger_path = get_tmp_ledger_path("test_completed_blobs_signal_orphans");
+        let (ledger, _, recvr) = Blocktree::open_with_signal(&ledger_path).unwrap();
+        let ledger = Arc::new(ledger);
+
+        let entries_per_slot = 10;
+        let slot = 10;
+        let orphan_slot = 5;
+        let orphan_slot2 = 2;
+        // Create blobs for slot 10, chaining to slot 5
+        let (blobs, _) = make_slot_entries(slot, orphan_slot, entries_per_slot);
+
+        // Create blobs for slot 5 chaining to slot 2
+        let (orphan_blobs, _) = make_slot_entries(orphan_slot,orphan_slot2 , entries_per_slot);
+
+        // Insert all but the first blob in the slot, should not be considered complete
+        ledger.insert_data_blobs(&blobs[1..entries_per_slot as usize]).unwrap();
+        assert!(recvr.try_recv().is_err());
+
+        //Insert first blob, slot should now be considered complete
+        ledger.insert_data_blobs(once(&blobs[0])).unwrap();
+        assert_eq!(recvr.try_recv().unwrap(), vec![slot]);
+
+        // Insert the blobs for the orphan_slot
+        ledger.insert_data_blobs(&orphan_blobs[1..entries_per_slot as usize]).unwrap();
+        assert!(recvr.try_recv().is_err());
+
+        //Insert first blob, slot should now be considered complete
+        ledger.insert_data_blobs(once(&orphan_blobs[0])).unwrap();
+        assert_eq!(recvr.try_recv().unwrap(), vec![orphan_slot]);
+    }
+
+    #[test]
+    pub fn test_completed_blobs_signal_many() {
+        // Initialize ledger
+        let ledger_path = get_tmp_ledger_path("test_completed_blobs_signal_many");
+        let (ledger, _, recvr) = Blocktree::open_with_signal(&ledger_path).unwrap();
+        let ledger = Arc::new(ledger);
+
+        let entries_per_slot = 10;
+        let slot = 10;
+        let slot2 = 5;
+        let slot3 = 2;
+        let disconnected_slot = 4;
+
+        // Create blobs for slot 10, chaining to slot 5
+        let (blobs, _) = make_slot_entries(slot, slot2, entries_per_slot);
+        let (blobs2, _) = make_slot_entries(slot2, slot3, entries_per_slot);
+        let (blobs3, _) = make_slot_entries(slot3, 0, entries_per_slot);
+        let (blobs4, _) = make_slot_entries(disconnected_slot, 1, entries_per_slot);
+
+        let mut all_blobs: Vec<_> = vec![blobs, blobs2, blobs3, blobs4].into_iter().flatten().collect();
+
+        all_blobs.shuffle(&mut thread_rng());
+        ledger.insert_data_blobs(all_blobs).unwrap();
+        let mut result =  recvr.try_recv().unwrap();
+        result.sort();
+        assert_eq!(result, vec![slot3, disconnected_slot, slot2, slot]);
+    }
+
     #[test]
     pub fn test_handle_chaining_basic() {
         let blocktree_path = get_tmp_ledger_path("test_handle_chaining_basic");
@@ -2251,7 +2379,7 @@ pub mod tests {
         }
         Blocktree::destroy(&blocktree_path).expect("Expected successful database destruction");
     }
-
+    
     #[test]
     pub fn test_handle_chaining_missing_slots() {
         let blocktree_path = get_tmp_ledger_path("test_handle_chaining_missing_slots");

--- a/core/src/repair_service.rs
+++ b/core/src/repair_service.rs
@@ -2,7 +2,7 @@
 //! regularly finds missing blobs in the ledger and sends repair requests for those blobs
 
 use crate::bank_forks::BankForks;
-use crate::blocktree::{Blocktree, SlotMeta};
+use crate::blocktree::{Blocktree, CompletedSlotsReceiver, SlotMeta};
 use crate::cluster_info::ClusterInfo;
 use crate::result::Result;
 use crate::service::Service;
@@ -69,6 +69,7 @@ impl RepairService {
         repair_socket: Arc<UdpSocket>,
         cluster_info: Arc<RwLock<ClusterInfo>>,
         bank_forks: Option<Arc<RwLock<BankForks>>>,
+        _new_slots_receiver: Option<CompletedSlotsReceiver>,
         repair_slot_range: Option<RepairSlotRange>,
     ) -> Self {
         let exit = exit.clone();

--- a/core/src/repair_service.rs
+++ b/core/src/repair_service.rs
@@ -24,7 +24,7 @@ pub const MAX_ORPHANS: usize = 5;
 
 pub enum RepairStrategy {
     RepairRange(RepairSlotRange),
-    Repair {
+    RepairAll {
         bank_forks: Arc<RwLock<BankForks>>,
         completed_slots_receiver: CompletedSlotsReceiver,
     },
@@ -122,11 +122,11 @@ impl RepairService {
                         )
                     }
 
-                    RepairStrategy::Repair {
+                    RepairStrategy::RepairAll {
                         ref bank_forks,
                         ref completed_slots_receiver,
                     } => {
-                        Self::update_fast_repair(
+                        Self::update_epoch_slots(
                             id,
                             &epoch_slots,
                             &cluster_info,
@@ -293,7 +293,9 @@ impl RepairService {
         }
     }
 
-    fn update_fast_repair(
+    // Update the gossiped structure used for the "Repairmen" repair protocol. See book
+    // for details.
+    fn update_epoch_slots(
         id: Pubkey,
         slots: &HashSet<u64>,
         cluster_info: &RwLock<ClusterInfo>,

--- a/core/src/replicator.rs
+++ b/core/src/replicator.rs
@@ -239,6 +239,7 @@ impl Replicator {
             repair_socket,
             &exit,
             Some(repair_slot_range),
+            None,
             &Hash::default(),
         );
 

--- a/core/src/replicator.rs
+++ b/core/src/replicator.rs
@@ -6,7 +6,7 @@ use crate::cluster_info::{ClusterInfo, Node, FULLNODE_PORT_RANGE};
 use crate::contact_info::ContactInfo;
 use crate::gossip_service::GossipService;
 use crate::packet::to_shared_blob;
-use crate::repair_service::RepairSlotRange;
+use crate::repair_service::{RepairSlotRange, RepairStrategy};
 use crate::result::Result;
 use crate::service::Service;
 use crate::storage_stage::SLOTS_PER_SEGMENT;
@@ -231,15 +231,13 @@ impl Replicator {
 
         let window_service = WindowService::new(
             None, //TODO: need a way to validate blobs... https://github.com/solana-labs/solana/issues/3924
-            None, //TODO: see above ^
             blocktree.clone(),
             cluster_info.clone(),
             blob_fetch_receiver,
             retransmit_sender,
             repair_socket,
             &exit,
-            Some(repair_slot_range),
-            None,
+            RepairStrategy::RepairRange(repair_slot_range),
             &Hash::default(),
         );
 

--- a/core/src/retransmit_stage.rs
+++ b/core/src/retransmit_stage.rs
@@ -1,7 +1,7 @@
 //! The `retransmit_stage` retransmits blobs between validators
 
 use crate::bank_forks::BankForks;
-use crate::blocktree::Blocktree;
+use crate::blocktree::{Blocktree, CompletedSlotsReceiver};
 use crate::cluster_info::{compute_retransmit_peers, ClusterInfo, DATA_PLANE_FANOUT};
 use crate::leader_schedule_cache::LeaderScheduleCache;
 use crate::result::{Error, Result};
@@ -118,6 +118,7 @@ impl RetransmitStage {
         fetch_stage_receiver: BlobReceiver,
         exit: &Arc<AtomicBool>,
         genesis_blockhash: &Hash,
+        completed_slots_receiver: CompletedSlotsReceiver,
     ) -> Self {
         let (retransmit_sender, retransmit_receiver) = channel();
 
@@ -138,6 +139,7 @@ impl RetransmitStage {
             repair_socket,
             exit,
             None,
+            Some(completed_slots_receiver),
             genesis_blockhash,
         );
 

--- a/core/src/retransmit_stage.rs
+++ b/core/src/retransmit_stage.rs
@@ -109,6 +109,7 @@ pub struct RetransmitStage {
 
 impl RetransmitStage {
     #[allow(clippy::new_ret_no_self)]
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         bank_forks: Arc<RwLock<BankForks>>,
         leader_schedule_cache: &Arc<LeaderScheduleCache>,

--- a/core/src/retransmit_stage.rs
+++ b/core/src/retransmit_stage.rs
@@ -4,6 +4,7 @@ use crate::bank_forks::BankForks;
 use crate::blocktree::{Blocktree, CompletedSlotsReceiver};
 use crate::cluster_info::{compute_retransmit_peers, ClusterInfo, DATA_PLANE_FANOUT};
 use crate::leader_schedule_cache::LeaderScheduleCache;
+use crate::repair_service::RepairStrategy;
 use crate::result::{Error, Result};
 use crate::service::Service;
 use crate::staking_utils;
@@ -129,8 +130,12 @@ impl RetransmitStage {
             cluster_info.clone(),
             retransmit_receiver,
         );
+
+        let repair_strategy = RepairStrategy::Repair {
+            bank_forks,
+            completed_slots_receiver,
+        };
         let window_service = WindowService::new(
-            Some(bank_forks),
             Some(leader_schedule_cache.clone()),
             blocktree,
             cluster_info.clone(),
@@ -138,8 +143,7 @@ impl RetransmitStage {
             retransmit_sender,
             repair_socket,
             exit,
-            None,
-            Some(completed_slots_receiver),
+            repair_strategy,
             genesis_blockhash,
         );
 

--- a/core/src/retransmit_stage.rs
+++ b/core/src/retransmit_stage.rs
@@ -132,7 +132,7 @@ impl RetransmitStage {
             retransmit_receiver,
         );
 
-        let repair_strategy = RepairStrategy::Repair {
+        let repair_strategy = RepairStrategy::RepairAll {
             bank_forks,
             completed_slots_receiver,
         };

--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -188,7 +188,7 @@ impl WindowService {
         let bank_forks = match repair_strategy {
             RepairStrategy::RepairRange(_) => None,
 
-            RepairStrategy::Repair { ref bank_forks, .. } => Some(bank_forks.clone()),
+            RepairStrategy::RepairAll { ref bank_forks, .. } => Some(bank_forks.clone()),
         };
 
         let repair_service = RepairService::new(
@@ -363,7 +363,7 @@ mod test {
         let bank = Bank::new(&create_genesis_block_with_leader(100, &me_id, 10).0);
         let leader_schedule_cache = Arc::new(LeaderScheduleCache::new_from_bank(&bank));
         let bank_forks = Arc::new(RwLock::new(BankForks::new(0, bank)));
-        let repair_strategy = RepairStrategy::Repair {
+        let repair_strategy = RepairStrategy::RepairAll {
             bank_forks,
             completed_slots_receiver,
         };
@@ -445,7 +445,7 @@ mod test {
         let bank = Bank::new(&create_genesis_block_with_leader(100, &me_id, 10).0);
         let leader_schedule_cache = Arc::new(LeaderScheduleCache::new_from_bank(&bank));
         let bank_forks = Arc::new(RwLock::new(BankForks::new(0, bank)));
-        let repair_strategy = RepairStrategy::Repair {
+        let repair_strategy = RepairStrategy::RepairAll {
             bank_forks,
             completed_slots_receiver,
         };

--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -188,10 +188,7 @@ impl WindowService {
         let bank_forks = match repair_strategy {
             RepairStrategy::RepairRange(_) => None,
 
-            RepairStrategy::Repair {
-                ref bank_forks,
-                completed_slots_receiver: _,
-            } => Some(bank_forks.clone()),
+            RepairStrategy::Repair { ref bank_forks, .. } => Some(bank_forks.clone()),
         };
 
         let repair_service = RepairService::new(

--- a/core/tests/tvu.rs
+++ b/core/tests/tvu.rs
@@ -83,8 +83,14 @@ fn test_replay() {
 
     let tvu_addr = target1.info.tvu;
 
-    let (bank_forks, _bank_forks_info, blocktree, ledger_signal_receiver, leader_schedule_cache) =
-        fullnode::new_banks_from_blocktree(&blocktree_path, None);
+    let (
+        bank_forks,
+        _bank_forks_info,
+        blocktree,
+        ledger_signal_receiver,
+        completed_slots_receiver,
+        leader_schedule_cache,
+    ) = fullnode::new_banks_from_blocktree(&blocktree_path, None);
     let working_bank = bank_forks.working_bank();
     assert_eq!(
         working_bank.get_balance(&mint_keypair.pubkey()),
@@ -126,6 +132,7 @@ fn test_replay() {
             &leader_schedule_cache,
             &exit,
             &solana_sdk::hash::Hash::default(),
+            completed_slots_receiver,
         );
 
         let mut mint_ref_balance = mint_balance;


### PR DESCRIPTION
#### Problem
Blocktree is missing a way to signal to RepairService when a slot is finished so that RepairService can update its EpochSlots structure in gossip

#### Summary of Changes
1) Introduce a channel to notify RepairService of newly completed slots
2) Refactor RepairService to use RepairStrategy

Fixes #
