### PR TITLE
multinode-demo/ grooming

### DIFF
--- a/book/src/testnet-participation.md
+++ b/book/src/testnet-participation.md
@@ -114,25 +114,31 @@ $ solana-gossip --entrypoint testnet.solana.com:8001 spy
 # Press ^C to exit
 ```
 
-Then the following command will start a new validator node.
+Now configure a key pair for your validator by running:
+```bash
+$ solana-keygen -o fullnode-keypair.json
+```
+
+Then use one of the following commands, depending on your installation
+choice, to start the node:
 
 If this is a `solana-install`-installation:
 ```bash
 $ clear-fullnode-config.sh
-$ fullnode.sh --poll-for-new-genesis-block testnet.solana.com
+$ fullnode.sh --identity fullnode-keypair.json --poll-for-new-genesis-block testnet.solana.com
 ```
 
 Alternatively, the `solana-install run` command can be used to run the validator
 node while periodically checking for and applying software updates:
 ```bash
 $ clear-fullnode-config.sh
-$ solana-install run fullnode.sh -- --poll-for-new-genesis-block testnet.solana.com
+$ solana-install run fullnode.sh -- --identity fullnode-keypair.json --poll-for-new-genesis-block testnet.solana.com
 ```
 
 If you built from source:
 ```bash
 $ USE_INSTALL=1 ./multinode-demo/clear-fullnode-config.sh
-$ USE_INSTALL=1 ./multinode-demo/fullnode.sh --poll-for-new-genesis-block testnet.solana.com
+$ USE_INSTALL=1 ./multinode-demo/fullnode.sh --identity fullnode-keypair.json --poll-for-new-genesis-block testnet.solana.com
 ```
 
 #### Controlling local network port allocation
@@ -142,35 +148,40 @@ example, `fullnode.sh --dynamic-port-range 11000-11010 ...` will restrict the
 validator to ports 11000-11011.
 
 ### Validator Monitoring
-From another console, confirm the IP address of your validator is visible in the
-gossip network by running:
-```bash
-$ solana-gossip --entrypoint testnet.solana.com:8001 spy
-```
-
 When `fullnode.sh` starts, it will output a fullnode configuration that looks
 similar to:
 ```bash
 ======================[ Fullnode configuration ]======================
-node id: 4ceWXsL3UJvn7NYZiRkw7NsryMpviaKBDYr8GK7J61Dm
-vote id: 2ozWvfaXQd1X6uKh8jERoRGApDqSqcEy6fF1oN13LL2G
+node pubkey: 4ceWXsL3UJvn7NYZiRkw7NsryMpviaKBDYr8GK7J61Dm
+vote pubkey: 2ozWvfaXQd1X6uKh8jERoRGApDqSqcEy6fF1oN13LL2G
 ledger: ...
 accounts: ...
 ======================================================================
 ```
 
-Provide the **vote id** pubkey to the `solana-wallet show-vote-account` command to view
+The **node pubkey** for your validator can also be found by running:
+```bash
+$ solana-keygen pubkey fullnode-keypair.json
+```
+
+From another console, confirm the IP address and **node pubkey** of your validator is visible in the
+gossip network by running:
+```bash
+$ solana-gossip --entrypoint testnet.solana.com:8001 spy
+```
+
+Provide the **vote pubkey** to the `solana-wallet show-vote-account` command to view
 the recent voting activity from your validator:
 ```bash
 $ solana-wallet -n testnet.solana.com show-vote-account 2ozWvfaXQd1X6uKh8jERoRGApDqSqcEy6fF1oN13LL2G
 ```
 
-The vote id for the validator can also be found by running:
+The vote pubkey for the validator can also be found by running:
 ```bash
 # If this is a `solana-install`-installation run:
-$ solana-keygen pubkey ~/.local/share/solana/install/active_release/config-local/fullnode-vote-id.json
+$ solana-keygen pubkey ~/.local/share/solana/install/active_release/config-local/fullnode-vote-keypair.json
 # Otherwise run:
-$ solana-keygen pubkey ./config-local/fullnode-vote-id.json
+$ solana-keygen pubkey ./config-local/fullnode-vote-keypair.json
 ```
 
 ### Sharing Metrics From Your Validator

--- a/multinode-demo/drone.sh
+++ b/multinode-demo/drone.sh
@@ -7,8 +7,8 @@ here=$(dirname "$0")
 # shellcheck source=multinode-demo/common.sh
 source "$here"/common.sh
 
-[[ -f "$SOLANA_CONFIG_DIR"/mint-id.json ]] || {
-  echo "$SOLANA_CONFIG_DIR/mint-id.json not found, create it by running:"
+[[ -f "$SOLANA_CONFIG_DIR"/mint-keypair.json ]] || {
+  echo "$SOLANA_CONFIG_DIR/mint-keypair.json not found, create it by running:"
   echo
   echo "  ${here}/setup.sh"
   exit 1
@@ -18,7 +18,7 @@ set -ex
 
 trap 'kill "$pid" && wait "$pid"' INT TERM ERR
 $solana_drone \
-  --keypair "$SOLANA_CONFIG_DIR"/mint-id.json \
+  --keypair "$SOLANA_CONFIG_DIR"/mint-keypair.json \
   "$@" \
   > >($drone_logger) 2>&1 &
 pid=$!

--- a/multinode-demo/fullnode.sh
+++ b/multinode-demo/fullnode.sh
@@ -140,6 +140,7 @@ bootstrap_leader=false
 stake=42 # number of lamports to assign as stake by default
 poll_for_new_genesis_block=0
 label=
+fullnode_id_path=
 
 positional_args=()
 while [[ -n $1 ]]; do
@@ -155,6 +156,10 @@ while [[ -n $1 ]]; do
       shift
     elif [[ $1 = --blockstream ]]; then
       stake=0
+      args+=("$1" "$2")
+      shift 2
+    elif [[ $1 = --identity ]]; then
+      fullnode_id_path=$2
       args+=("$1" "$2")
       shift 2
     elif [[ $1 = --enable-rpc-exit ]]; then
@@ -203,7 +208,7 @@ if $bootstrap_leader; then
 
   $solana_ledger_tool --ledger "$SOLANA_CONFIG_DIR"/bootstrap-leader-ledger verify
 
-  fullnode_id_path="$SOLANA_CONFIG_DIR"/bootstrap-leader-id.json
+  : ${fullnode_id_path:="$SOLANA_CONFIG_DIR"/bootstrap-leader-id.json}
   fullnode_vote_id_path="$SOLANA_CONFIG_DIR"/bootstrap-leader-vote-id.json
   ledger_config_dir="$SOLANA_CONFIG_DIR"/bootstrap-leader-ledger
   accounts_config_dir="$SOLANA_CONFIG_DIR"/bootstrap-leader-accounts
@@ -219,7 +224,7 @@ else
   read -r entrypoint entrypoint_address shift < <(find_entrypoint "${positional_args[@]}")
   shift "$shift"
 
-  fullnode_id_path=$SOLANA_CONFIG_DIR/fullnode-id$label.json
+  : ${fullnode_id_path:=$SOLANA_CONFIG_DIR/fullnode-id$label.json}
   fullnode_vote_id_path=$SOLANA_CONFIG_DIR/fullnode-vote-id$label.json
   ledger_config_dir=$SOLANA_CONFIG_DIR/fullnode-ledger$label
   accounts_config_dir=$SOLANA_CONFIG_DIR/fullnode-accounts$label

--- a/multinode-demo/setup.sh
+++ b/multinode-demo/setup.sh
@@ -8,17 +8,17 @@ set -e
 "$here"/clear-fullnode-config.sh
 
 # Create genesis ledger
-$solana_keygen -o "$SOLANA_CONFIG_DIR"/mint-id.json
-$solana_keygen -o "$SOLANA_CONFIG_DIR"/bootstrap-leader-id.json
-$solana_keygen -o "$SOLANA_CONFIG_DIR"/bootstrap-leader-vote-id.json
-$solana_keygen -o "$SOLANA_CONFIG_DIR"/bootstrap-leader-stake-id.json
+$solana_keygen -o "$SOLANA_CONFIG_DIR"/mint-keypair.json
+$solana_keygen -o "$SOLANA_CONFIG_DIR"/bootstrap-leader-keypair.json
+$solana_keygen -o "$SOLANA_CONFIG_DIR"/bootstrap-leader-vote-keypair.json
+$solana_keygen -o "$SOLANA_CONFIG_DIR"/bootstrap-leader-stake-keypair.json
 
 args=("$@")
-default_arg --bootstrap-leader-keypair "$SOLANA_CONFIG_DIR"/bootstrap-leader-id.json
-default_arg --bootstrap-vote-keypair "$SOLANA_CONFIG_DIR"/bootstrap-leader-vote-id.json
-default_arg --bootstrap-stake-keypair "$SOLANA_CONFIG_DIR"/bootstrap-leader-stake-id.json
+default_arg --bootstrap-leader-keypair "$SOLANA_CONFIG_DIR"/bootstrap-leader-keypair.json
+default_arg --bootstrap-vote-keypair "$SOLANA_CONFIG_DIR"/bootstrap-leader-vote-keypair.json
+default_arg --bootstrap-stake-keypair "$SOLANA_CONFIG_DIR"/bootstrap-leader-stake-keypair.json
 default_arg --ledger "$SOLANA_RSYNC_CONFIG_DIR"/ledger
-default_arg --mint "$SOLANA_CONFIG_DIR"/mint-id.json
+default_arg --mint "$SOLANA_CONFIG_DIR"/mint-keypair.json
 default_arg --lamports 100000000000000
 
 $solana_genesis "${args[@]}"


### PR DESCRIPTION
* Rename leader variables to entrypoint
* The fullnode identity keypair can now be provided thusly: `./fullnode.sh --identity path/to/my/node-keypair.json`.  Document this new ability in the testnet participation doc to encourage validators to use constant keypairs across testnet cluster restarts.
* Rename "-id" files to "-keypair" and "_id" variables to "_keypair" to be more precise