### PR TITLE
make gen_keypair_file() take &str

### DIFF
--- a/keygen/src/keygen.rs
+++ b/keygen/src/keygen.rs
@@ -81,7 +81,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                 path.to_str().unwrap()
             };
 
-            let serialized_keypair = gen_keypair_file(outfile.to_string())?;
+            let serialized_keypair = gen_keypair_file(outfile)?;
             if outfile == "-" {
                 println!("{}", serialized_keypair);
             }

--- a/sdk/src/signature.rs
+++ b/sdk/src/signature.rs
@@ -100,12 +100,12 @@ pub fn read_keypair(path: &str) -> Result<Keypair, Box<error::Error>> {
     Ok(keypair)
 }
 
-pub fn gen_keypair_file(outfile: String) -> Result<String, Box<error::Error>> {
+pub fn gen_keypair_file(outfile: &str) -> Result<String, Box<error::Error>> {
     let keypair_bytes = Keypair::new().to_bytes();
     let serialized = serde_json::to_string(&keypair_bytes.to_vec())?;
 
     if outfile != "-" {
-        if let Some(outdir) = Path::new(&outfile).parent() {
+        if let Some(outdir) = Path::new(outfile).parent() {
             fs::create_dir_all(outdir)?;
         }
         let mut f = File::create(outfile)?;
@@ -130,7 +130,7 @@ mod tests {
     #[test]
     fn test_gen_keypair_file() {
         let outfile = tmp_file_path("test_gen_keypair_file.json");
-        let serialized_keypair = gen_keypair_file(outfile.to_string()).unwrap();
+        let serialized_keypair = gen_keypair_file(&outfile).unwrap();
         let keypair_vec: Vec<u8> = serde_json::from_str(&serialized_keypair).unwrap();
         assert!(Path::new(&outfile).exists());
         assert_eq!(

--- a/wallet/src/main.rs
+++ b/wallet/src/main.rs
@@ -37,7 +37,7 @@ pub fn parse_args(matches: &ArgMatches<'_>) -> Result<WalletConfig, Box<dyn erro
     } else {
         path.extend(&[".config", "solana", "id.json"]);
         if !path.exists() {
-            gen_keypair_file(path.to_str().unwrap().to_string())?;
+            gen_keypair_file(path.to_str().unwrap())?;
             println!("New keypair generated at: {:?}", path.to_str().unwrap());
         }
 


### PR DESCRIPTION
#### Problem
 gen_keypair_file() asks for a moved String, tedious for customers

 #### Summary of Changes
 make it take &str
 fix customers