### PR TITLE
Introduce API to access SlotMeta iterators

### DIFF
--- a/core/src/blocktree.rs
+++ b/core/src/blocktree.rs
@@ -182,16 +182,10 @@ impl Blocktree {
         self.orphans_cf.get(slot)
     }
 
-    pub fn get_next_slot(&self, slot: u64) -> Result<Option<u64>> {
+    pub fn slot_meta_iterator(&self, slot: u64) -> Result<Cursor<cf::SlotMeta>> {
         let mut db_iterator = self.db.cursor::<cf::SlotMeta>()?;
-
-        db_iterator.seek(slot + 1);
-        if !db_iterator.valid() {
-            Ok(None)
-        } else {
-            let next_slot = db_iterator.key().expect("Expected valid key");
-            Ok(Some(next_slot))
-        }
+        db_iterator.seek(slot);
+        Ok(db_iterator)
     }
 
     pub fn write_shared_blobs<I>(&self, shared_blobs: I) -> Result<()>


### PR DESCRIPTION
#### Problem
No current way to access the SlotMeta column family with an iterator

#### Summary of Changes
1. Introduce API to access SlotMeta iterators, `slot_meta_iterator()`
2. Remove the outdated `get_next_slot()` API
3. Rewrite users of `get_next_slot()` to directly use new the `slot_meta_iterator()` API

Fixes #
