### PR TITLE
Page-pin packet memory for cuda

### DIFF
--- a/bench-streamer/src/main.rs
+++ b/bench-streamer/src/main.rs
@@ -1,4 +1,5 @@
 use clap::{crate_description, crate_name, crate_version, App, Arg};
+use solana::packet::PacketsRecycler;
 use solana::packet::{Packet, Packets, BLOB_SIZE, PACKET_DATA_SIZE};
 use solana::result::Result;
 use solana::streamer::{receiver, PacketReceiver};
@@ -74,6 +75,7 @@ fn main() -> Result<()> {
 
     let mut read_channels = Vec::new();
     let mut read_threads = Vec::new();
+    let recycler = PacketsRecycler::default();
     for _ in 0..num_sockets {
         let read = solana_netutil::bind_to(port, false).unwrap();
         read.set_read_timeout(Some(Duration::new(1, 0))).unwrap();
@@ -83,7 +85,13 @@ fn main() -> Result<()> {
 
         let (s_reader, r_reader) = channel();
         read_channels.push(r_reader);
-        read_threads.push(receiver(Arc::new(read), &exit, s_reader));
+        read_threads.push(receiver(
+            Arc::new(read),
+            &exit,
+            s_reader,
+            recycler.clone(),
+            "bench-streamer-test",
+        ));
     }
 
     let t_producer1 = producer(&addr, exit.clone());

--- a/bench-streamer/src/main.rs
+++ b/bench-streamer/src/main.rs
@@ -16,7 +16,7 @@ fn producer(addr: &SocketAddr, exit: Arc<AtomicBool>) -> JoinHandle<()> {
     let send = UdpSocket::bind("0.0.0.0:0").unwrap();
     let mut msgs = Packets::default();
     msgs.packets.resize(10, Packet::default());
-    for w in &mut msgs.packets {
+    for w in msgs.packets.iter_mut() {
         w.meta.size = PACKET_DATA_SIZE;
         w.meta.set_addr(&addr);
     }

--- a/core/benches/sigverify.rs
+++ b/core/benches/sigverify.rs
@@ -3,6 +3,7 @@
 extern crate test;
 
 use solana::packet::to_packets;
+use solana::recycler::Recycler;
 use solana::sigverify;
 use solana::test_tx::test_tx;
 use test::Bencher;
@@ -14,8 +15,10 @@ fn bench_sigverify(bencher: &mut Bencher) {
     // generate packet vector
     let batches = to_packets(&vec![tx; 128]);
 
+    let recycler = Recycler::default();
+    let recycler_out = Recycler::default();
     // verify packets
     bencher.iter(|| {
-        let _ans = sigverify::ed25519_verify(&batches);
+        let _ans = sigverify::ed25519_verify(&batches, &recycler, &recycler_out);
     })
 }

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -804,6 +804,9 @@ impl BankingStage {
         packet_indexes: Vec<usize>,
     ) {
         if !packet_indexes.is_empty() {
+            if unprocessed_packets.len() > 400 {
+                unprocessed_packets.remove(0);
+            }
             unprocessed_packets.push((packets, packet_indexes));
         }
     }

--- a/core/src/cuda_runtime.rs
+++ b/core/src/cuda_runtime.rs
@@ -1,0 +1,209 @@
+use crate::recycler::Reset;
+//use std::vec::IntoIter;
+use std::ops::{Deref, DerefMut};
+//use std::iter::IntoIterator;
+//use std::iter::Iterator;
+
+#[cfg(feature = "cuda")]
+use std::mem::size_of;
+
+#[cfg(feature = "cuda")]
+use core::ffi::c_void;
+
+#[cfg(feature = "cuda")]
+type CudaError = i32;
+
+#[cfg(feature = "cuda")]
+#[link(name = "cudart")]
+extern "C" {
+    fn cudaHostRegister(ptr: *mut c_void, size: usize, flags: u32) -> CudaError;
+    fn cudaHostUnregister(ptr: *mut c_void) -> CudaError;
+}
+
+#[cfg(feature = "cuda")]
+const CUDA_SUCCESS: CudaError = 0;
+
+pub fn pin<T>(_mem: &mut Vec<T>) {
+    #[cfg(feature = "cuda")]
+    unsafe {
+        trace!(
+            "pinning: {:?} bytes: {}",
+            _mem.as_ptr(),
+            _mem.capacity() * size_of::<T>()
+        );
+        let err = cudaHostRegister(
+            _mem.as_mut_ptr() as *mut c_void,
+            _mem.capacity() * size_of::<T>(),
+            0,
+        );
+        if err != CUDA_SUCCESS {
+            error!("cudaHostRegister error: {}", err);
+        }
+    }
+}
+
+pub fn unpin<T>(_mem: *mut T) {
+    #[cfg(feature = "cuda")]
+    unsafe {
+        let err = cudaHostUnregister(_mem as *mut c_void);
+        if err != CUDA_SUCCESS {
+            error!("cudaHostUnregister returned: {}", err);
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct PinnedVec<T> {
+    x: Vec<T>,
+    pinned: bool,
+}
+
+impl Reset for PinnedVec<u8> {
+    fn reset(&mut self) {
+        self.resize(0, 0u8);
+    }
+}
+
+impl Reset for PinnedVec<u32> {
+    fn reset(&mut self) {
+        self.resize(0, 0u32);
+    }
+}
+
+impl<T: Clone> Default for PinnedVec<T> {
+    fn default() -> Self {
+        Self {
+            x: Vec::new(),
+            pinned: false,
+        }
+    }
+}
+
+impl<T> Deref for PinnedVec<T> {
+    type Target = Vec<T>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.x
+    }
+}
+
+impl<T> DerefMut for PinnedVec<T> {
+    fn deref_mut(&mut self) -> &mut Vec<T> {
+        &mut self.x
+    }
+}
+
+pub struct PinnedIter<'a, T>(std::slice::Iter<'a, T>);
+
+pub struct PinnedIterMut<'a, T>(std::slice::IterMut<'a, T>);
+
+impl<'a, T> Iterator for PinnedIter<'a, T> {
+    type Item = &'a T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next()
+    }
+}
+
+impl<'a, T> Iterator for PinnedIterMut<'a, T> {
+    type Item = &'a mut T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next()
+    }
+}
+
+impl<'a, T> IntoIterator for &'a PinnedVec<T> {
+    type Item = &'a T;
+    type IntoIter = PinnedIter<'a, T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        PinnedIter(self.iter())
+    }
+}
+
+impl<T: Clone> PinnedVec<T> {
+    pub fn from_vec(mut source: Vec<T>) -> Self {
+        pin(&mut source);
+
+        Self {
+            x: source,
+            pinned: true,
+        }
+    }
+
+    pub fn with_capacity(capacity: usize) -> Self {
+        let x = Vec::with_capacity(capacity);
+        Self::from_vec(x)
+    }
+
+    pub fn iter(&self) -> PinnedIter<T> {
+        PinnedIter(self.x.iter())
+    }
+
+    pub fn iter_mut(&mut self) -> PinnedIterMut<T> {
+        PinnedIterMut(self.x.iter_mut())
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.x.is_empty()
+    }
+
+    pub fn len(&self) -> usize {
+        self.x.len()
+    }
+
+    #[cfg(feature = "cuda")]
+    pub fn as_ptr(&self) -> *const T {
+        self.x.as_ptr()
+    }
+
+    #[cfg(feature = "cuda")]
+    pub fn as_mut_ptr(&mut self) -> *mut T {
+        self.x.as_mut_ptr()
+    }
+
+    pub fn push(&mut self, x: T) {
+        let old_ptr = self.x.as_mut_ptr();
+        let old_capacity = self.x.capacity();
+        self.x.push(x);
+        self.check_ptr(old_ptr, old_capacity);
+    }
+
+    pub fn resize(&mut self, size: usize, elem: T) {
+        let old_ptr = self.x.as_mut_ptr();
+        let old_capacity = self.x.capacity();
+        self.x.resize(size, elem);
+        self.check_ptr(old_ptr, old_capacity);
+    }
+
+    fn check_ptr(&mut self, _old_ptr: *mut T, _old_capacity: usize) {
+        #[cfg(feature = "cuda")]
+        {
+            if self.x.as_ptr() != _old_ptr || self.x.capacity() != _old_capacity {
+                if self.pinned {
+                    unpin(_old_ptr);
+                }
+
+                pin(&mut self.x);
+                self.pinned = true;
+            }
+        }
+    }
+}
+
+impl<T: Clone> Clone for PinnedVec<T> {
+    fn clone(&self) -> Self {
+        let mut x = self.x.clone();
+        pin(&mut x);
+        Self { x, pinned: true }
+    }
+}
+
+impl<T> Drop for PinnedVec<T> {
+    fn drop(&mut self) {
+        if self.pinned {
+            unpin(self.x.as_mut_ptr());
+        }
+    }
+}

--- a/core/src/cuda_runtime.rs
+++ b/core/src/cuda_runtime.rs
@@ -191,6 +191,11 @@ impl<T: Clone> PinnedVec<T> {
     pub fn push(&mut self, x: T) {
         let old_ptr = self.x.as_mut_ptr();
         let old_capacity = self.x.capacity();
+        // Predict realloc and unpin
+        if self.pinned && self.x.capacity() == self.x.len() {
+            unpin(old_ptr);
+            self.pinned = false;
+        }
         self.x.push(x);
         self.check_ptr(old_ptr, old_capacity, "push");
     }
@@ -198,6 +203,11 @@ impl<T: Clone> PinnedVec<T> {
     pub fn resize(&mut self, size: usize, elem: T) {
         let old_ptr = self.x.as_mut_ptr();
         let old_capacity = self.x.capacity();
+        // Predict realloc and unpin.
+        if self.pinned && self.x.capacity() < size {
+            unpin(old_ptr);
+            self.pinned = false;
+        }
         self.x.resize(size, elem);
         self.check_ptr(old_ptr, old_capacity, "resize");
     }

--- a/core/src/cuda_runtime.rs
+++ b/core/src/cuda_runtime.rs
@@ -40,7 +40,7 @@ pub fn pin<T>(_mem: &mut Vec<T>) {
                 "cudaHostRegister error: {} ptr: {:?} bytes: {}",
                 err,
                 _mem.as_ptr(),
-                _mem.len() * size_of::<T>()
+                _mem.capacity() * size_of::<T>()
             );
         }
     }
@@ -141,6 +141,21 @@ impl<'a, T> IntoIterator for &'a PinnedVec<T> {
 }
 
 impl<T: Clone> PinnedVec<T> {
+    pub fn reserve_and_pin(&mut self, size: usize) {
+        if self.x.capacity() < size {
+            if self.pinned {
+                unpin(&mut self.x);
+                self.pinned = false;
+            }
+            self.x.reserve(size);
+        }
+        self.set_pinnable();
+        if !self.pinned {
+            pin(&mut self.x);
+            self.pinned = true;
+        }
+    }
+
     pub fn set_pinnable(&mut self) {
         self.pinnable = true;
     }

--- a/core/src/fetch_stage.rs
+++ b/core/src/fetch_stage.rs
@@ -2,6 +2,7 @@
 
 use crate::banking_stage::FORWARD_TRANSACTIONS_TO_LEADER_AT_SLOT_OFFSET;
 use crate::poh_recorder::PohRecorder;
+use crate::recycler::Recycler;
 use crate::result::{Error, Result};
 use crate::service::Service;
 use crate::streamer::{self, PacketReceiver, PacketSender};
@@ -87,9 +88,16 @@ impl FetchStage {
         sender: &PacketSender,
         poh_recorder: &Arc<Mutex<PohRecorder>>,
     ) -> Self {
-        let tpu_threads = sockets
-            .into_iter()
-            .map(|socket| streamer::receiver(socket, &exit, sender.clone()));
+        let recycler = Recycler::default();
+        let tpu_threads = sockets.into_iter().map(|socket| {
+            streamer::receiver(
+                socket,
+                &exit,
+                sender.clone(),
+                recycler.clone(),
+                "fetch_stage",
+            )
+        });
 
         let (forward_sender, forward_receiver) = channel();
         let tpu_via_blobs_threads = tpu_via_blobs_sockets

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -13,6 +13,7 @@ pub mod chacha;
 #[cfg(cuda)]
 pub mod chacha_cuda;
 pub mod cluster_info_vote_listener;
+pub mod recycler;
 #[macro_use]
 pub mod contact_info;
 pub mod crds;
@@ -31,6 +32,7 @@ pub mod cluster_info;
 pub mod cluster_info_repair_listener;
 pub mod cluster_tests;
 pub mod consensus;
+pub mod cuda_runtime;
 pub mod entry;
 pub mod erasure;
 pub mod fetch_stage;

--- a/core/src/packet.rs
+++ b/core/src/packet.rs
@@ -175,8 +175,8 @@ impl Packets {
         }
     }
 
-    pub fn new_with_recycler(recycler: PacketsRecycler) -> Self {
-        let mut packets = recycler.allocate();
+    pub fn new_with_recycler(recycler: PacketsRecycler, name: &'static str) -> Self {
+        let mut packets = recycler.allocate(name);
         packets.set_pinnable();
         Packets {
             packets,

--- a/core/src/packet.rs
+++ b/core/src/packet.rs
@@ -175,9 +175,9 @@ impl Packets {
         }
     }
 
-    pub fn new_with_recycler(recycler: PacketsRecycler, name: &'static str) -> Self {
+    pub fn new_with_recycler(recycler: PacketsRecycler, size: usize, name: &'static str) -> Self {
         let mut packets = recycler.allocate(name);
-        packets.set_pinnable();
+        packets.reserve_and_pin(size);
         Packets {
             packets,
             recycler: Some(recycler),

--- a/core/src/packet.rs
+++ b/core/src/packet.rs
@@ -905,4 +905,13 @@ mod tests {
         b.sign(&k);
         assert!(b.verify());
     }
+
+    #[test]
+    fn test_packets_reset() {
+        let mut packets = Packets::default();
+        packets.packets.resize(10, Packet::default());
+        assert_eq!(packets.packets.len(), 10);
+        packets.reset();
+        assert_eq!(packets.packets.len(), 0);
+    }
 }

--- a/core/src/recycler.rs
+++ b/core/src/recycler.rs
@@ -1,0 +1,42 @@
+use std::sync::{Arc, Mutex};
+
+pub struct Recycler<T> {
+    gc: Arc<Mutex<Vec<T>>>,
+}
+
+impl<T: Default> Default for Recycler<T> {
+    fn default() -> Recycler<T> {
+        Recycler {
+            gc: Arc::new(Mutex::new(vec![])),
+        }
+    }
+}
+
+impl<T: Default> Clone for Recycler<T> {
+    fn clone(&self) -> Recycler<T> {
+        Recycler {
+            gc: self.gc.clone(),
+        }
+    }
+}
+
+pub trait Reset {
+    fn reset(&mut self);
+}
+
+impl<T: Default + Reset> Recycler<T> {
+    pub fn allocate(&self) -> T {
+        let mut gc = self.gc.lock().expect("recycler lock in pb fn allocate");
+
+        if let Some(mut x) = gc.pop() {
+            x.reset();
+            return x;
+        } else {
+            return T::default();
+        }
+    }
+    pub fn recycle(&self, x: T) {
+        let mut gc = self.gc.lock().expect("recycler lock in pub fn recycle");
+        gc.push(x);
+    }
+}

--- a/core/src/recycler.rs
+++ b/core/src/recycler.rs
@@ -1,14 +1,29 @@
+use rand::{thread_rng, Rng};
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
+
+#[derive(Debug, Default)]
+struct RecyclerStats {
+    total: AtomicUsize,
+    reuse: AtomicUsize,
+    max_gc: AtomicUsize,
+}
 
 #[derive(Debug)]
 pub struct Recycler<T> {
     gc: Arc<Mutex<Vec<T>>>,
+    stats: Arc<RecyclerStats>,
+    id: usize,
 }
 
 impl<T: Default> Default for Recycler<T> {
     fn default() -> Recycler<T> {
+        let id = thread_rng().gen_range(0, 1000);
+        trace!("new recycler..{}", id);
         Recycler {
             gc: Arc::new(Mutex::new(vec![])),
+            stats: Arc::new(RecyclerStats::default()),
+            id,
         }
     }
 }
@@ -17,6 +32,8 @@ impl<T: Default> Clone for Recycler<T> {
     fn clone(&self) -> Recycler<T> {
         Recycler {
             gc: self.gc.clone(),
+            stats: self.stats.clone(),
+            id: self.id,
         }
     }
 }
@@ -26,7 +43,7 @@ pub trait Reset {
 }
 
 impl<T: Default + Reset> Recycler<T> {
-    pub fn allocate(&self) -> T {
+    pub fn allocate(&self, name: &'static str) -> T {
         let new = self
             .gc
             .lock()
@@ -34,15 +51,37 @@ impl<T: Default + Reset> Recycler<T> {
             .pop();
 
         if let Some(mut x) = new {
+            self.stats.reuse.fetch_add(1, Ordering::Relaxed);
             x.reset();
             return x;
-        } else {
-            return T::default();
         }
+
+        trace!(
+            "allocating new: total {} {:?} id: {} reuse: {} max_gc: {}",
+            self.stats.total.fetch_add(1, Ordering::Relaxed),
+            name,
+            self.id,
+            self.stats.reuse.load(Ordering::Relaxed),
+            self.stats.max_gc.load(Ordering::Relaxed),
+        );
+
+        T::default()
     }
+
     pub fn recycle(&self, x: T) {
-        let mut gc = self.gc.lock().expect("recycler lock in pub fn recycle");
-        gc.push(x);
+        let len = {
+            let mut gc = self.gc.lock().expect("recycler lock in pub fn recycle");
+            gc.push(x);
+            gc.len()
+        };
+
+        let max_gc = self.stats.max_gc.load(Ordering::Relaxed);
+        if len > max_gc {
+            // this is not completely accurate, but for most cases should be fine.
+            self.stats
+                .max_gc
+                .compare_and_swap(max_gc, len, Ordering::Relaxed);
+        }
     }
 }
 
@@ -59,13 +98,13 @@ mod tests {
     #[test]
     fn test_recycler() {
         let recycler = Recycler::default();
-        let mut y: u64 = recycler.allocate();
+        let mut y: u64 = recycler.allocate("test_recycler1");
         assert_eq!(y, 0);
         y = 20;
         let recycler2 = recycler.clone();
         recycler2.recycle(y);
         assert_eq!(recycler.gc.lock().unwrap().len(), 1);
-        let z = recycler.allocate();
+        let z = recycler.allocate("test_recycler2");
         assert_eq!(z, 10);
         assert_eq!(recycler.gc.lock().unwrap().len(), 0);
     }

--- a/core/src/recycler.rs
+++ b/core/src/recycler.rs
@@ -27,9 +27,13 @@ pub trait Reset {
 
 impl<T: Default + Reset> Recycler<T> {
     pub fn allocate(&self) -> T {
-        let mut gc = self.gc.lock().expect("recycler lock in pb fn allocate");
+        let new = self
+            .gc
+            .lock()
+            .expect("recycler lock in pb fn allocate")
+            .pop();
 
-        if let Some(mut x) = gc.pop() {
+        if let Some(mut x) = new {
             x.reset();
             return x;
         } else {
@@ -39,5 +43,30 @@ impl<T: Default + Reset> Recycler<T> {
     pub fn recycle(&self, x: T) {
         let mut gc = self.gc.lock().expect("recycler lock in pub fn recycle");
         gc.push(x);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    impl Reset for u64 {
+        fn reset(&mut self) {
+            *self = 10;
+        }
+    }
+
+    #[test]
+    fn test_recycler() {
+        let recycler = Recycler::default();
+        let mut y: u64 = recycler.allocate();
+        assert_eq!(y, 0);
+        y = 20;
+        let recycler2 = recycler.clone();
+        recycler2.recycle(y);
+        assert_eq!(recycler.gc.lock().unwrap().len(), 1);
+        let z = recycler.allocate();
+        assert_eq!(z, 10);
+        assert_eq!(recycler.gc.lock().unwrap().len(), 0);
     }
 }

--- a/core/src/recycler.rs
+++ b/core/src/recycler.rs
@@ -1,5 +1,6 @@
 use std::sync::{Arc, Mutex};
 
+#[derive(Debug)]
 pub struct Recycler<T> {
     gc: Arc<Mutex<Vec<T>>>,
 }

--- a/core/src/replicator.rs
+++ b/core/src/replicator.rs
@@ -5,6 +5,7 @@ use crate::cluster_info::{ClusterInfo, Node, FULLNODE_PORT_RANGE};
 use crate::contact_info::ContactInfo;
 use crate::gossip_service::GossipService;
 use crate::packet::to_shared_blob;
+use crate::recycler::Recycler;
 use crate::repair_service::{RepairService, RepairSlotRange, RepairStrategy};
 use crate::result::{Error, Result};
 use crate::service::Service;
@@ -121,7 +122,14 @@ fn create_request_processor(
     let (s_reader, r_reader) = channel();
     let (s_responder, r_responder) = channel();
     let storage_socket = Arc::new(socket);
-    let t_receiver = receiver(storage_socket.clone(), exit, s_reader);
+    let recycler = Recycler::default();
+    let t_receiver = receiver(
+        storage_socket.clone(),
+        exit,
+        s_reader,
+        recycler,
+        "replicator",
+    );
     thread_handles.push(t_receiver);
 
     let t_responder = responder("replicator-responder", storage_socket.clone(), r_responder);

--- a/core/src/sigverify.rs
+++ b/core/src/sigverify.rs
@@ -155,13 +155,13 @@ pub fn get_packet_offsets(packet: &Packet, current_offset: u32) -> (u32, u32, u3
 
 pub fn generate_offsets(batches: &[Packets], recycler: &Recycler<TxOffset>) -> Result<TxOffsets> {
     debug!("allocating..");
-    let mut signature_offsets: PinnedVec<_> = recycler.allocate();
+    let mut signature_offsets: PinnedVec<_> = recycler.allocate("sig_offsets");
     signature_offsets.set_pinnable();
-    let mut pubkey_offsets: PinnedVec<_> = recycler.allocate();
+    let mut pubkey_offsets: PinnedVec<_> = recycler.allocate("pubkey_offsets");
     pubkey_offsets.set_pinnable();
-    let mut msg_start_offsets: PinnedVec<_> = recycler.allocate();
+    let mut msg_start_offsets: PinnedVec<_> = recycler.allocate("msg_start_offsets");
     msg_start_offsets.set_pinnable();
-    let mut msg_sizes: PinnedVec<_> = recycler.allocate();
+    let mut msg_sizes: PinnedVec<_> = recycler.allocate("msg_size_offsets");
     msg_sizes.set_pinnable();
     let mut current_packet = 0;
     let mut v_sig_lens = Vec::new();
@@ -264,7 +264,7 @@ pub fn ed25519_verify(
 
     debug!("CUDA ECDSA for {}", batch_size(batches));
     debug!("allocating out..");
-    let mut out = recycler_out.allocate();
+    let mut out = recycler_out.allocate("out_buffer");
     out.set_pinnable();
     let mut elems = Vec::new();
     let mut rvs = Vec::new();

--- a/core/src/sigverify.rs
+++ b/core/src/sigverify.rs
@@ -156,9 +156,13 @@ pub fn get_packet_offsets(packet: &Packet, current_offset: u32) -> (u32, u32, u3
 pub fn generate_offsets(batches: &[Packets], recycler: &Recycler<TxOffset>) -> Result<TxOffsets> {
     debug!("allocating..");
     let mut signature_offsets: PinnedVec<_> = recycler.allocate();
+    signature_offsets.set_pinnable();
     let mut pubkey_offsets: PinnedVec<_> = recycler.allocate();
+    pubkey_offsets.set_pinnable();
     let mut msg_start_offsets: PinnedVec<_> = recycler.allocate();
+    msg_start_offsets.set_pinnable();
     let mut msg_sizes: PinnedVec<_> = recycler.allocate();
+    msg_sizes.set_pinnable();
     let mut current_packet = 0;
     let mut v_sig_lens = Vec::new();
     batches.iter().for_each(|p| {
@@ -261,6 +265,7 @@ pub fn ed25519_verify(
     debug!("CUDA ECDSA for {}", batch_size(batches));
     debug!("allocating out..");
     let mut out = recycler_out.allocate();
+    out.set_pinnable();
     let mut elems = Vec::new();
     let mut rvs = Vec::new();
 

--- a/core/src/sigverify.rs
+++ b/core/src/sigverify.rs
@@ -20,7 +20,10 @@ use solana_sdk::transaction::Transaction;
 use std::mem::size_of;
 
 #[cfg(feature = "cuda")]
-use std::os::raw::c_int;
+use std::os::raw::{c_int, c_uint};
+
+#[cfg(feature = "cuda")]
+use core::ffi::c_void;
 
 pub const NUM_THREADS: u32 = 10;
 use std::cell::RefCell;
@@ -82,6 +85,9 @@ extern "C" {
         num_elems: usize,
         use_non_default_stream: u8,
     ) -> c_int;
+
+    pub fn cuda_host_register(ptr: *mut c_void, size: usize, flags: c_uint) -> c_int;
+    pub fn cuda_host_unregister(ptr: *mut c_void) -> c_int;
 }
 
 #[cfg(not(feature = "cuda"))]

--- a/core/src/sigverify_stage.rs
+++ b/core/src/sigverify_stage.rs
@@ -5,10 +5,13 @@
 //! transaction. All processing is done on the CPU by default and on a GPU
 //! if the `cuda` feature is enabled with `--features=cuda`.
 
+use crate::cuda_runtime::PinnedVec;
 use crate::packet::Packets;
+use crate::recycler::Recycler;
 use crate::result::{Error, Result};
 use crate::service::Service;
 use crate::sigverify;
+use crate::sigverify::TxOffset;
 use crate::streamer::{self, PacketReceiver};
 use solana_metrics::{datapoint_info, inc_new_counter_info};
 use solana_sdk::timing;
@@ -18,7 +21,7 @@ use std::thread::{self, Builder, JoinHandle};
 use std::time::Instant;
 
 #[cfg(feature = "cuda")]
-const RECV_BATCH_MAX: usize = 60_000;
+const RECV_BATCH_MAX: usize = 5_000;
 
 #[cfg(not(feature = "cuda"))]
 const RECV_BATCH_MAX: usize = 1000;
@@ -42,11 +45,16 @@ impl SigVerifyStage {
         Self { thread_hdls }
     }
 
-    fn verify_batch(batch: Vec<Packets>, sigverify_disabled: bool) -> VerifiedPackets {
+    fn verify_batch(
+        batch: Vec<Packets>,
+        sigverify_disabled: bool,
+        recycler: &Recycler<TxOffset>,
+        recycler_out: &Recycler<PinnedVec<u8>>,
+    ) -> VerifiedPackets {
         let r = if sigverify_disabled {
             sigverify::ed25519_verify_disabled(&batch)
         } else {
-            sigverify::ed25519_verify(&batch)
+            sigverify::ed25519_verify(&batch, recycler, recycler_out)
         };
         batch.into_iter().zip(r).collect()
     }
@@ -56,6 +64,8 @@ impl SigVerifyStage {
         sendr: &Sender<VerifiedPackets>,
         sigverify_disabled: bool,
         id: usize,
+        recycler: &Recycler<TxOffset>,
+        recycler_out: &Recycler<PinnedVec<u8>>,
     ) -> Result<()> {
         let (batch, len, recv_time) = streamer::recv_batch(
             &recvr.lock().expect("'recvr' lock in fn verifier"),
@@ -68,11 +78,11 @@ impl SigVerifyStage {
         debug!(
             "@{:?} verifier: verifying: {} id: {}",
             timing::timestamp(),
-            batch.len(),
+            len,
             id
         );
 
-        let verified_batch = Self::verify_batch(batch, sigverify_disabled);
+        let verified_batch = Self::verify_batch(batch, sigverify_disabled, recycler, recycler_out);
         inc_new_counter_info!("sigverify_stage-verified_packets_send", len);
 
         if sendr.send(verified_batch).is_err() {
@@ -113,17 +123,26 @@ impl SigVerifyStage {
     ) -> JoinHandle<()> {
         Builder::new()
             .name(format!("solana-verifier-{}", id))
-            .spawn(move || loop {
-                if let Err(e) =
-                    Self::verifier(&packet_receiver, &verified_sender, sigverify_disabled, id)
-                {
-                    match e {
-                        Error::RecvTimeoutError(RecvTimeoutError::Disconnected) => break,
-                        Error::RecvTimeoutError(RecvTimeoutError::Timeout) => (),
-                        Error::SendError => {
-                            break;
+            .spawn(move || {
+                let recycler = Recycler::default();
+                let recycler_out = Recycler::default();
+                loop {
+                    if let Err(e) = Self::verifier(
+                        &packet_receiver,
+                        &verified_sender,
+                        sigverify_disabled,
+                        id,
+                        &recycler,
+                        &recycler_out,
+                    ) {
+                        match e {
+                            Error::RecvTimeoutError(RecvTimeoutError::Disconnected) => break,
+                            Error::RecvTimeoutError(RecvTimeoutError::Timeout) => (),
+                            Error::SendError => {
+                                break;
+                            }
+                            _ => error!("{:?}", e),
                         }
-                        _ => error!("{:?}", e),
                     }
                 }
             })

--- a/core/src/streamer.rs
+++ b/core/src/streamer.rs
@@ -24,7 +24,7 @@ fn recv_loop(
     name: &'static str,
 ) -> Result<()> {
     loop {
-        let mut msgs = Packets::new_with_recycler(recycler.clone(), name);
+        let mut msgs = Packets::new_with_recycler(recycler.clone(), 256, name);
         loop {
             // Check for exit signal, even if socket is busy
             // (for instance the leader trasaction socket)
@@ -142,7 +142,7 @@ fn recv_blob_packets(sock: &UdpSocket, s: &PacketSender, recycler: &PacketsRecyc
 
     let blobs = Blob::recv_from(sock)?;
     for blob in blobs {
-        let mut packets = Packets::new_with_recycler(recycler.clone(), "recv_blob_packets");
+        let mut packets = Packets::new_with_recycler(recycler.clone(), 256, "recv_blob_packets");
         blob.read().unwrap().load_packets(&mut packets.packets);
         s.send(packets)?;
     }

--- a/fetch-perf-libs.sh
+++ b/fetch-perf-libs.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-PERF_LIBS_VERSION=v0.14.1
+PERF_LIBS_VERSION=v0.15.0
 
 set -e
 cd "$(dirname "$0")"


### PR DESCRIPTION
#### Problem

cuda cannot overlap memory transfers and kernels if memory is not page-pinned.

#### Summary of Changes

use cudaHostRegister and cudaHostUnregister to page-pin memory.

Introduce `PinnedVec` wrapper class which has its memory pinned by the above cuda functions. It registers on creation, unregister on drop, also on `push` and `resize` it checks the pointer and the capacity of the vec for any change and then does the unregister/register if changed.

Add back the Recycler so that these `PinnedVec`'s are re-used since we cannot call cudaHostRegister/cudHostUnregister in the middle of computation since it will cause a GPU sync.

Fixes #4235 
