### PR TITLE
multinode-demo/fullnode.sh: Avoid generating default keypair

### DIFF
--- a/multinode-demo/fullnode.sh
+++ b/multinode-demo/fullnode.sh
@@ -110,10 +110,10 @@ setup_vote_and_stake_accounts() {
     touch "$node_keypair_path".configured
   fi
 
-  $solana_wallet --url "http://$entrypoint_ip:8899" \
+  $solana_wallet --keypair "$node_keypair_path" --url "http://$entrypoint_ip:8899" \
           show-vote-account "$vote_pubkey"
 
-  $solana_wallet --url "http://$entrypoint_ip:8899" \
+  $solana_wallet --keypair "$node_keypair_path" --url "http://$entrypoint_ip:8899" \
           show-stake-account "$stake_pubkey"
 
 


### PR DESCRIPTION
Fixes some intermittent CI failures 

eg: https://buildkite.com/solana-labs/solana/builds/6594#5cdec00d-8254-4363-942c-39a33ecfc28e