### PR TITLE
Remove obsolete internal multinode-demo/ logging

### DIFF
--- a/multinode-demo/common.sh
+++ b/multinode-demo/common.sh
@@ -10,9 +10,6 @@
 SOLANA_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/.. || exit 1; pwd)"
 
 rsync=rsync
-bootstrap_leader_logger="tee bootstrap-leader.log"
-fullnode_logger="tee fullnode.log"
-drone_logger="tee drone.log"
 
 if [[ $(uname) != Linux ]]; then
   # Protect against unsupported configurations to prevent non-obvious errors

--- a/multinode-demo/drone.sh
+++ b/multinode-demo/drone.sh
@@ -14,12 +14,6 @@ source "$here"/common.sh
   exit 1
 }
 
-set -ex
-
-trap 'kill "$pid" && wait "$pid"' INT TERM ERR
-$solana_drone \
-  --keypair "$SOLANA_CONFIG_DIR"/mint-keypair.json \
-  "$@" \
-  > >($drone_logger) 2>&1 &
-pid=$!
-wait "$pid"
+set -x
+# shellcheck disable=SC2086 # Don't want to double quote $solana_drone
+exec $solana_drone --keypair "$SOLANA_CONFIG_DIR"/mint-keypair.json "$@"

--- a/multinode-demo/fullnode.sh
+++ b/multinode-demo/fullnode.sh
@@ -362,7 +362,7 @@ while true; do
   fi
 
   echo "$PS4$program ${args[*]}"
-  $program "${args[@]}" > >($fullnode_logger) 2>&1 &
+  $program "${args[@]}" &
   pid=$!
   oom_score_adj "$pid" 1000
 

--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -87,8 +87,7 @@ local|tar)
       --gossip-port "$entrypointIp":8001
     )
 
-    ./multinode-demo/bootstrap-leader.sh "${args[@]}" > bootstrap-leader.log 2>&1 &
-    ln -sTf bootstrap-leader.log fullnode.log
+    ./multinode-demo/fullnode.sh --bootstrap-leader "${args[@]}" > fullnode.log 2>&1 &
     ;;
   fullnode|blockstreamer)
     net/scripts/rsync-retry.sh -vPrc "$entrypointIp":~/.cargo/bin/ ~/.cargo/bin/


### PR DESCRIPTION
Looks like all current multinode-demo/ clients are already logging so no need to double log