### PR TITLE
get DLL names from programs that made the DLL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2461,9 +2461,11 @@ dependencies = [
  "solana-exchange-api 0.15.0",
  "solana-sdk 0.15.0",
  "solana-stake-api 0.15.0",
+ "solana-stake-program 0.15.0",
  "solana-storage-api 0.15.0",
  "solana-token-api 0.15.0",
  "solana-vote-api 0.15.0",
+ "solana-vote-program 0.15.0",
 ]
 
 [[package]]
@@ -2621,6 +2623,7 @@ dependencies = [
  "solana-sdk 0.15.0",
  "solana-stake-api 0.15.0",
  "solana-vote-api 0.15.0",
+ "solana-vote-program 0.15.0",
 ]
 
 [[package]]

--- a/genesis/Cargo.toml
+++ b/genesis/Cargo.toml
@@ -15,7 +15,9 @@ solana = { path = "../core", version = "0.15.0"  }
 solana-sdk = { path = "../sdk", version = "0.15.0"  }
 solana-budget-api = { path = "../programs/budget_api", version = "0.15.0"  }
 solana-vote-api = { path = "../programs/vote_api", version = "0.15.0"  }
+solana-vote-program = { path = "../programs/vote_program", version = "0.15.0"  }
 solana-stake-api = { path = "../programs/stake_api", version = "0.15.0"  }
+solana-stake-program = { path = "../programs/stake_program", version = "0.15.0"  }
 solana-storage-api = { path = "../programs/storage_api", version = "0.15.0"  }
 solana-token-api = { path = "../programs/token_api", version = "0.15.0"  }
 solana-config-api = { path = "../programs/config_api", version = "0.15.0"  }

--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -1,6 +1,7 @@
 //! A command-line executable for generating the chain's genesis block.
 #[macro_use]
 extern crate solana_vote_program;
+#[macro_use]
 extern crate solana_stake_program;
 
 use clap::{crate_description, crate_name, crate_version, value_t_or_exit, App, Arg};

--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -1,4 +1,7 @@
 //! A command-line executable for generating the chain's genesis block.
+#[macro_use]
+extern crate solana_vote_program;
+extern crate solana_stake_program;
 
 use clap::{crate_description, crate_name, crate_version, value_t_or_exit, App, Arg};
 use solana::blocktree::create_new_ledger;
@@ -144,8 +147,8 @@ fn main() -> Result<(), Box<dyn error::Error>> {
             ),
         ],
         &[
-            ("solana_vote_program".to_string(), solana_vote_api::id()),
-            ("solana_stake_program".to_string(), solana_stake_api::id()),
+            solana_vote_program!(),
+            solana_stake_program!(),
             ("solana_budget_program".to_string(), solana_budget_api::id()),
             (
                 "solana_storage_program".to_string(),

--- a/programs/stake_program/Cargo.toml
+++ b/programs/stake_program/Cargo.toml
@@ -16,5 +16,4 @@ solana-stake-api = { path = "../stake_api", version = "0.15.0"  }
 
 [lib]
 name = "solana_stake_program"
-crate-type = ["cdylib"]
-
+crate-type = ["lib", "cdylib"]

--- a/programs/stake_program/src/lib.rs
+++ b/programs/stake_program/src/lib.rs
@@ -1,3 +1,9 @@
-use solana_stake_api::stake_instruction::process_instruction;
+#[macro_export]
+macro_rules! solana_stake_program {
+    () => {
+        ("solana_stake_program".to_string(), solana_stake_api::id())
+    };
+}
 
+use solana_stake_api::stake_instruction::process_instruction;
 solana_sdk::solana_entrypoint!(process_instruction);

--- a/programs/vote_program/Cargo.toml
+++ b/programs/vote_program/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "solana-vote-program"
 version = "0.15.0"
-description = "Solana vote program"
+description = "Solana Vote program"
 authors = ["Solana Maintainers <maintainers@solana.com>"]
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
@@ -16,5 +16,4 @@ solana-vote-api = { path = "../vote_api", version = "0.15.0"  }
 
 [lib]
 name = "solana_vote_program"
-crate-type = ["cdylib"]
-
+crate-type = ["lib","cdylib"]

--- a/programs/vote_program/src/lib.rs
+++ b/programs/vote_program/src/lib.rs
@@ -1,3 +1,9 @@
-use solana_vote_api::vote_instruction::process_instruction;
+#[macro_export]
+macro_rules! solana_vote_program {
+    () => {
+        ("solana_vote_program".to_string(), solana_vote_api::id())
+    };
+}
 
+use solana_vote_api::vote_instruction::process_instruction;
 solana_sdk::solana_entrypoint!(process_instruction);

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -28,6 +28,7 @@ solana-metrics = { path = "../metrics", version = "0.15.0"  }
 solana-sdk = { path = "../sdk", version = "0.15.0"  }
 solana-stake-api = { path = "../programs/stake_api", version = "0.15.0"  }
 solana-vote-api = { path = "../programs/vote_api", version = "0.15.0"  }
+solana-vote-program = { path = "../programs/vote_program", version = "0.15.0"  }
 
 [lib]
 name = "solana_runtime"

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2,7 +2,6 @@
 //! programs. It offers a high-level API that signs transactions
 //! on behalf of the caller, and a low-level API for when they have
 //! already been signed and verified.
-
 use crate::accounts::{AccountLockType, Accounts};
 use crate::accounts_db::{ErrorCounters, InstructionAccounts, InstructionLoaders};
 use crate::accounts_index::Fork;
@@ -373,7 +372,10 @@ impl Bank {
             "solana_bpf_loader",
             &solana_sdk::bpf_loader::id(),
         );
-        self.register_native_instruction_processor("solana_vote_program", &solana_vote_api::id());
+        self.register_native_instruction_processor(
+            &solana_vote_program!().0,
+            &solana_vote_program!().1,
+        );
 
         // Add additional native programs specified in the genesis block
         for (name, program_id) in &genesis_block.native_instruction_processors {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -18,4 +18,7 @@ mod system_instruction_processor;
 extern crate solana_metrics;
 
 #[macro_use]
+extern crate solana_vote_program;
+
+#[macro_use]
 extern crate serde_derive;


### PR DESCRIPTION
#### Problem
 cdylib dependencies preclude rust linking, but rust linking would be a nice way to force a dependency on a cdylib native program

 #### Summary of Changes
 use macros in the program, no linkage, but listing the program crate in the manifest is required