### PR TITLE
Add Storage accounts for all nodes

### DIFF
--- a/core/src/fullnode.rs
+++ b/core/src/fullnode.rs
@@ -76,7 +76,8 @@ impl Fullnode {
         keypair: &Arc<Keypair>,
         ledger_path: &str,
         vote_account: &Pubkey,
-        voting_keypair: T,
+        voting_keypair: &Arc<T>,
+        storage_keypair: &Arc<Keypair>,
         entrypoint_info_option: Option<&ContactInfo>,
         config: &FullnodeConfig,
     ) -> Self
@@ -219,12 +220,13 @@ impl Fullnode {
         let voting_keypair = if config.voting_disabled {
             None
         } else {
-            Some(Arc::new(voting_keypair))
+            Some(voting_keypair)
         };
 
         let tvu = Tvu::new(
             vote_account,
             voting_keypair,
+            storage_keypair,
             &bank_forks,
             &cluster_info,
             sockets,
@@ -355,13 +357,15 @@ pub fn new_fullnode_for_tests() -> (Fullnode, ContactInfo, Keypair, String) {
 
     let (ledger_path, _blockhash) = create_new_tmp_ledger!(&genesis_block);
 
-    let voting_keypair = Keypair::new();
+    let voting_keypair = Arc::new(Keypair::new());
+    let storage_keypair = Arc::new(Keypair::new());
     let node = Fullnode::new(
         node,
         &node_keypair,
         &ledger_path,
         &voting_keypair.pubkey(),
-        voting_keypair,
+        &voting_keypair,
+        &storage_keypair,
         None,
         &FullnodeConfig::default(),
     );
@@ -387,13 +391,15 @@ mod tests {
             create_genesis_block_with_leader(10_000, &leader_keypair.pubkey(), 1000).0;
         let (validator_ledger_path, _blockhash) = create_new_tmp_ledger!(&genesis_block);
 
-        let voting_keypair = Keypair::new();
+        let voting_keypair = Arc::new(Keypair::new());
+        let storage_keypair = Arc::new(Keypair::new());
         let validator = Fullnode::new(
             validator_node,
             &Arc::new(validator_keypair),
             &validator_ledger_path,
             &voting_keypair.pubkey(),
-            voting_keypair,
+            &voting_keypair,
+            &storage_keypair,
             Some(&leader_node.info),
             &FullnodeConfig::default(),
         );
@@ -415,13 +421,15 @@ mod tests {
                     create_genesis_block_with_leader(10_000, &leader_keypair.pubkey(), 1000);
                 let (validator_ledger_path, _blockhash) = create_new_tmp_ledger!(&genesis_block);
                 ledger_paths.push(validator_ledger_path.clone());
-                let voting_keypair = Keypair::new();
+                let voting_keypair = Arc::new(Keypair::new());
+                let storage_keypair = Arc::new(Keypair::new());
                 Fullnode::new(
                     validator_node,
                     &Arc::new(validator_keypair),
                     &validator_ledger_path,
                     &voting_keypair.pubkey(),
-                    voting_keypair,
+                    &voting_keypair,
+                    &storage_keypair,
                     Some(&leader_node.info),
                     &FullnodeConfig::default(),
                 )

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -105,7 +105,7 @@ impl ReplayStage {
         }
         // Start the replay stage loop
         let leader_schedule_cache = leader_schedule_cache.clone();
-        let voting_keypair = voting_keypair.map(|kp| kp.clone());
+        let voting_keypair = voting_keypair.cloned();
         let t_replay = Builder::new()
             .name("solana-replay-stage".to_string())
             .spawn(move || {

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -74,7 +74,7 @@ impl ReplayStage {
     pub fn new<T>(
         my_id: &Pubkey,
         vote_account: &Pubkey,
-        voting_keypair: Option<Arc<T>>,
+        voting_keypair: Option<&Arc<T>>,
         blocktree: Arc<Blocktree>,
         bank_forks: &Arc<RwLock<BankForks>>,
         cluster_info: Arc<RwLock<ClusterInfo>>,
@@ -105,6 +105,7 @@ impl ReplayStage {
         }
         // Start the replay stage loop
         let leader_schedule_cache = leader_schedule_cache.clone();
+        let voting_keypair = voting_keypair.map(|kp| kp.clone());
         let t_replay = Builder::new()
             .name("solana-replay-stage".to_string())
             .spawn(move || {

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -57,7 +57,8 @@ impl Tvu {
     #[allow(clippy::new_ret_no_self, clippy::too_many_arguments)]
     pub fn new<T>(
         vote_account: &Pubkey,
-        voting_keypair: Option<Arc<T>>,
+        voting_keypair: Option<&Arc<T>>,
+        storage_keypair: &Arc<Keypair>,
         bank_forks: &Arc<RwLock<BankForks>>,
         cluster_info: &Arc<RwLock<ClusterInfo>>,
         sockets: Sockets,
@@ -139,13 +140,12 @@ impl Tvu {
             None
         };
 
-        let storage_keypair = Arc::new(Keypair::new());
         let storage_stage = StorageStage::new(
             storage_state,
             root_slot_receiver,
             Some(blocktree),
             &keypair,
-            &storage_keypair,
+            storage_keypair,
             &exit,
             &bank_forks,
             storage_rotate_count,
@@ -214,10 +214,12 @@ pub mod tests {
         let (exit, poh_recorder, poh_service, _entry_receiver) =
             create_test_recorder(&bank, &blocktree);
         let voting_keypair = Keypair::new();
+        let storage_keypair = Arc::new(Keypair::new());
         let leader_schedule_cache = Arc::new(LeaderScheduleCache::new_from_bank(&bank));
         let tvu = Tvu::new(
             &voting_keypair.pubkey(),
-            Some(Arc::new(voting_keypair)),
+            Some(&Arc::new(voting_keypair)),
+            &storage_keypair,
             &Arc::new(RwLock::new(bank_forks)),
             &cref1,
             {

--- a/core/tests/tvu.rs
+++ b/core/tests/tvu.rs
@@ -106,13 +106,15 @@ fn test_replay() {
     let dr_1 = new_gossip(cref1.clone(), target1.sockets.gossip, &exit);
 
     let voting_keypair = Keypair::new();
+    let storage_keypair = Arc::new(Keypair::new());
     let blocktree = Arc::new(blocktree);
     {
         let (poh_service_exit, poh_recorder, poh_service, _entry_receiver) =
             create_test_recorder(&working_bank, &blocktree);
         let tvu = Tvu::new(
             &voting_keypair.pubkey(),
-            Some(Arc::new(voting_keypair)),
+            Some(&Arc::new(voting_keypair)),
+            &storage_keypair,
             &bank_forks,
             &cref1,
             {

--- a/fullnode/src/main.rs
+++ b/fullnode/src/main.rs
@@ -60,6 +60,14 @@ fn main() {
                 .help("File containing the authorized voting keypair"),
         )
         .arg(
+            Arg::with_name("storage_keypair")
+                .long("storage_id")
+                .value_name("DIR")
+                .takes_value(true)
+                .required(true)
+                .help("File containing the storage account keypair"),
+        )
+        .arg(
             Arg::with_name("init_complete_file")
                 .long("init-complete-file")
                 .value_name("FILE")
@@ -167,6 +175,14 @@ fn main() {
     } else {
         Keypair::new()
     };
+    let storage_keypair = if let Some(storage_keypair) = matches.value_of("storage_keypair") {
+        read_keypair(storage_keypair).unwrap_or_else(|err| {
+            eprintln!("{}: Unable to open keypair file: {}", err, storage_keypair);
+            exit(1);
+        })
+    } else {
+        Keypair::new()
+    };
 
     let staking_account = matches
         .value_of("staking_account")
@@ -241,7 +257,8 @@ fn main() {
         &keypair,
         ledger_path,
         &staking_account,
-        voting_keypair,
+        &Arc::new(voting_keypair),
+        &Arc::new(storage_keypair),
         cluster_entrypoint.as_ref(),
         &fullnode_config,
     );

--- a/fullnode/src/main.rs
+++ b/fullnode/src/main.rs
@@ -62,7 +62,7 @@ fn main() {
         .arg(
             Arg::with_name("storage_keypair")
                 .long("storage-keypair")
-                .value_name("DIR")
+                .value_name("PATH")
                 .takes_value(true)
                 .required(true)
                 .help("File containing the storage account keypair"),

--- a/fullnode/src/main.rs
+++ b/fullnode/src/main.rs
@@ -61,7 +61,7 @@ fn main() {
         )
         .arg(
             Arg::with_name("storage_keypair")
-                .long("storage_id")
+                .long("storage-keypair")
                 .value_name("DIR")
                 .takes_value(true)
                 .required(true)

--- a/multinode-demo/fullnode.sh
+++ b/multinode-demo/fullnode.sh
@@ -225,6 +225,8 @@ if [[ $node_type = bootstrap_leader ]]; then
   fullnode_vote_keypair_path="$SOLANA_CONFIG_DIR"/bootstrap-leader-vote-keypair.json
   ledger_config_dir="$SOLANA_CONFIG_DIR"/bootstrap-leader-ledger
   accounts_config_dir="$SOLANA_CONFIG_DIR"/bootstrap-leader-accounts
+  fullnode_storage_keypair_path=$SOLANA_CONFIG_DIR/bootstrap-leader-storage-keypair.json
+
 
   default_arg --rpc-port 8899
   default_arg --rpc-drone-address 127.0.0.1:9900
@@ -240,7 +242,7 @@ elif [[ $node_type = replicator ]]; then
   shift "$shift"
 
   replicator_keypair_path=$SOLANA_CONFIG_DIR/replicator-id.json
-  replicator_storage_keypair_path="$SOLANA_CONFIG_DIR"/replicator-vote-id.json
+  replicator_storage_keypair_path="$SOLANA_CONFIG_DIR"/replicator-storage-id.json
   ledger_config_dir=$SOLANA_CONFIG_DIR/replicator-ledger
 
   mkdir -p "$SOLANA_CONFIG_DIR"
@@ -266,6 +268,7 @@ else
   : "${fullnode_keypair_path:=$SOLANA_CONFIG_DIR/fullnode-keypair$label.json}"
   fullnode_vote_keypair_path=$SOLANA_CONFIG_DIR/fullnode-vote-keypair$label.json
   fullnode_stake_keypair_path=$SOLANA_CONFIG_DIR/fullnode-stake-keypair$label.json
+  fullnode_storage_keypair_path=$SOLANA_CONFIG_DIR/fullnode-storage-keypair$label.json
   ledger_config_dir=$SOLANA_CONFIG_DIR/fullnode-ledger$label
   accounts_config_dir=$SOLANA_CONFIG_DIR/fullnode-accounts$label
 
@@ -273,6 +276,7 @@ else
   [[ -r "$fullnode_keypair_path" ]] || $solana_keygen -o "$fullnode_keypair_path"
   [[ -r "$fullnode_vote_keypair_path" ]] || $solana_keygen -o "$fullnode_vote_keypair_path"
   [[ -r "$fullnode_stake_keypair_path" ]] || $solana_keygen -o "$fullnode_stake_keypair_path"
+  [[ -r "$fullnode_storage_keypair_path" ]] || $solana_keygen -o "$fullnode_storage_keypair_path"
 
   default_arg --entrypoint "$entrypoint_address"
   default_arg --rpc-drone-address "${entrypoint_address%:*}:9900"
@@ -308,6 +312,7 @@ EOF
   default_arg --identity "$fullnode_keypair_path"
   default_arg --voting-keypair "$fullnode_vote_keypair_path"
   default_arg --vote-account "$fullnode_vote_pubkey"
+  default_arg --storage-keypair "$fullnode_storage_keypair_path"
   default_arg --ledger "$ledger_config_dir"
   default_arg --accounts "$accounts_config_dir"
 

--- a/multinode-demo/fullnode.sh
+++ b/multinode-demo/fullnode.sh
@@ -254,7 +254,7 @@ elif [[ $node_type = replicator ]]; then
 
   default_arg --entrypoint "$entrypoint_address"
   default_arg --identity "$replicator_keypair_path"
-  default_arg --storage_id "$replicator_storage_keypair_path"
+  default_arg --storage-keypair "$replicator_storage_keypair_path"
   default_arg --ledger "$ledger_config_dir"
 
 else

--- a/multinode-demo/setup.sh
+++ b/multinode-demo/setup.sh
@@ -12,6 +12,7 @@ $solana_keygen -o "$SOLANA_CONFIG_DIR"/mint-keypair.json
 $solana_keygen -o "$SOLANA_CONFIG_DIR"/bootstrap-leader-keypair.json
 $solana_keygen -o "$SOLANA_CONFIG_DIR"/bootstrap-leader-vote-keypair.json
 $solana_keygen -o "$SOLANA_CONFIG_DIR"/bootstrap-leader-stake-keypair.json
+$solana_keygen -o "$SOLANA_CONFIG_DIR"/bootstrap-leader-storage-keypair.json
 
 args=("$@")
 default_arg --bootstrap-leader-keypair "$SOLANA_CONFIG_DIR"/bootstrap-leader-keypair.json

--- a/replicator/src/main.rs
+++ b/replicator/src/main.rs
@@ -42,7 +42,7 @@ fn main() {
         .arg(
             Arg::with_name("storage_keypair")
                 .short("s")
-                .long("storage_id")
+                .long("storage-keypair")
                 .value_name("DIR")
                 .takes_value(true)
                 .required(true)

--- a/replicator/src/main.rs
+++ b/replicator/src/main.rs
@@ -43,7 +43,7 @@ fn main() {
             Arg::with_name("storage_keypair")
                 .short("s")
                 .long("storage-keypair")
-                .value_name("DIR")
+                .value_name("PATH")
                 .takes_value(true)
                 .required(true)
                 .help("File containing the storage account keypair"),


### PR DESCRIPTION
#### Problem

Fullnodes generate a random keypair for their storage accounts every time they are started. This means restarting a node will break its storage stage (Account not found/not enough funds to create a new storage account).

#### Summary of Changes

Added storage accounts to fullnodes and made voting keypairs and storage keyparis Arcs so that node restarts are performed correctly in local_cluster.
