### PR TITLE
{net,ci}/ Remove disable leader rotation option

### DIFF
--- a/ci/iterations-localnet.sh
+++ b/ci/iterations-localnet.sh
@@ -51,11 +51,11 @@ runTest() {
 
 build
 
-runTest "Leader rotation on" \
+runTest "basic" \
   "ci/localnet-sanity.sh -i 128"
 
-runTest "Leader rotation on, restart" \
+runTest "restart" \
   "ci/localnet-sanity.sh -i 128 -k 16"
 
-runTest "Leader rotation on, incremental restart, extra node" \
+runTest "incremental restart, extra node" \
   "ci/localnet-sanity.sh -i 128 -k 16 -R -x"

--- a/ci/testnet-deploy.sh
+++ b/ci/testnet-deploy.sh
@@ -20,7 +20,6 @@ tarChannelOrTag=edge
 delete=false
 enableGpu=false
 bootDiskType=""
-leaderRotation=true
 blockstreamer=false
 deployUpdateManifest=true
 fetchLogs=true
@@ -52,7 +51,6 @@ Deploys a CD testnet
    -P                   - Use public network IP addresses (default: $publicNetwork)
    -G                   - Enable GPU, and set count/type of GPUs to use (e.g n1-standard-16 --accelerator count=4,type=nvidia-tesla-k80)
    -g                   - Enable GPU (default: $enableGpu)
-   -b                   - Disable leader rotation
    -a [address]         - Set the bootstrap fullnode's external IP address to this GCE address
    -d [disk-type]       - Specify a boot disk type (default None) Use pd-ssd to get ssd on GCE.
    -D                   - Delete the network
@@ -74,7 +72,7 @@ EOF
 
 zone=()
 
-while getopts "h?p:Pn:c:t:gG:a:Dbd:rusxz:p:C:Sfew" opt; do
+while getopts "h?p:Pn:c:t:gG:a:Dd:rusxz:p:C:Sfew" opt; do
   case $opt in
   h | \?)
     usage
@@ -106,9 +104,6 @@ while getopts "h?p:Pn:c:t:gG:a:Dbd:rusxz:p:C:Sfew" opt; do
       usage "Invalid release channel: $OPTARG"
       ;;
     esac
-    ;;
-  b)
-    leaderRotation=false
     ;;
   g)
     enableGpu=true
@@ -228,10 +223,6 @@ if ! $skipCreate; then
     else
       create_args+=(-G "$bootstrapFullNodeMachineType")
     fi
-  fi
-
-  if ! $leaderRotation; then
-    create_args+=(-b)
   fi
 
   if $publicNetwork; then

--- a/ci/testnet-manager.sh
+++ b/ci/testnet-manager.sh
@@ -338,7 +338,6 @@ deploy() {
       RUST_LOG=solana=warn \
         ci/testnet-deploy.sh -p edge-perf-testnet-solana-com -C ec2 -z us-west-2b \
           -g -t "$CHANNEL_OR_TAG" -c 2 \
-          -b \
           ${skipCreate:+-e} \
           ${skipStart:+-s} \
           ${maybeStop:+-S} \
@@ -351,7 +350,6 @@ deploy() {
       NO_VALIDATOR_SANITY=1 \
         ci/testnet-deploy.sh -p beta-testnet-solana-com -C ec2 -z us-west-1a \
           -t "$CHANNEL_OR_TAG" -n 3 -c 0 -u -P -a eipalloc-0f286cf8a0771ce35 \
-          -b \
           ${skipCreate:+-e} \
           ${skipStart:+-s} \
           ${maybeStop:+-S} \
@@ -366,7 +364,6 @@ deploy() {
       RUST_LOG=solana=warn \
         ci/testnet-deploy.sh -p beta-perf-testnet-solana-com -C ec2 -z us-west-2b \
           -g -t "$CHANNEL_OR_TAG" -c 2 \
-          -b \
           ${skipCreate:+-e} \
           ${skipStart:+-s} \
           ${maybeStop:+-S} \
@@ -410,7 +407,6 @@ deploy() {
         ci/testnet-deploy.sh -p perf-testnet-solana-com -C gce -z us-west1-b \
           -G "--machine-type n1-standard-16 --accelerator count=2,type=nvidia-tesla-v100" \
           -t "$CHANNEL_OR_TAG" -c 2 \
-          -b \
           -d pd-ssd \
           ${skipCreate:+-e} \
           ${skipStart:+-s} \

--- a/net/common.sh
+++ b/net/common.sh
@@ -36,7 +36,6 @@ clientIpListZone=()
 blockstreamerIpList=()
 blockstreamerIpListPrivate=()
 blockstreamerIpListZone=()
-leaderRotation=
 
 buildSshOptions() {
   sshOptions=(
@@ -60,7 +59,6 @@ loadConfigFile() {
   [[ -n "$publicNetwork" ]] || usage "Config file invalid, publicNetwork unspecified: $configFile"
   [[ -n "$netBasename" ]] || usage "Config file invalid, netBasename unspecified: $configFile"
   [[ -n $sshPrivateKey ]] || usage "Config file invalid, sshPrivateKey unspecified: $configFile"
-  [[ -n $leaderRotation ]] || usage "Config file invalid, leaderRotation unspecified: $configFile"
   [[ ${#fullnodeIpList[@]} -gt 0 ]] || usage "Config file invalid, fullnodeIpList unspecified: $configFile"
   [[ ${#fullnodeIpListPrivate[@]} -gt 0 ]] || usage "Config file invalid, fullnodeIpListPrivate unspecified: $configFile"
   [[ ${#fullnodeIpList[@]} -eq ${#fullnodeIpListPrivate[@]} ]] || usage "Config file invalid, fullnodeIpList/fullnodeIpListPrivate length mismatch: $configFile"

--- a/net/net.sh
+++ b/net/net.sh
@@ -294,7 +294,6 @@ startBootstrapLeader() {
          $((${#fullnodeIpList[@]} + ${#blockstreamerIpList[@]})) \
          \"$RUST_LOG\" \
          $skipSetup \
-         $leaderRotation \
          $failOnValidatorBootupFailure \
       "
   ) >> "$logFile" 2>&1 || {
@@ -322,7 +321,6 @@ startNode() {
          $((${#fullnodeIpList[@]} + ${#blockstreamerIpList[@]})) \
          \"$RUST_LOG\" \
          $skipSetup \
-         $leaderRotation \
          $failOnValidatorBootupFailure \
       "
   ) >> "$logFile" 2>&1 &
@@ -615,10 +613,6 @@ start)
   start
   ;;
 update)
-  $leaderRotation || {
-    echo Warning: unable to update because leader rotation is disabled
-    exit 1
-  }
   skipSetup=true
   updateNodes=true
   start

--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -10,8 +10,7 @@ entrypointIp="$3"
 numNodes="$4"
 RUST_LOG="$5"
 skipSetup="$6"
-leaderRotation="$7"
-failOnValidatorBootupFailure="$8"
+failOnValidatorBootupFailure="$7"
 set +x
 export RUST_LOG
 
@@ -33,14 +32,12 @@ missing() {
 [[ -n $entrypointIp ]]  || missing entrypointIp
 [[ -n $numNodes ]]      || missing numNodes
 [[ -n $skipSetup ]]     || missing skipSetup
-[[ -n $leaderRotation ]] || missing leaderRotation
 [[ -n $failOnValidatorBootupFailure ]] || missing failOnValidatorBootupFailure
 
 cat > deployConfig <<EOF
 deployMethod="$deployMethod"
 entrypointIp="$entrypointIp"
 numNodes="$numNodes"
-leaderRotation=$leaderRotation
 failOnValidatorBootupFailure=$failOnValidatorBootupFailure
 EOF
 
@@ -109,11 +106,7 @@ local|tar)
         --stake 0
       )
     else
-      if $leaderRotation; then
-        args+=("--stake" "$stake")
-      else
-        args+=("--stake" 0)
-      fi
+      args+=(--stake "$stake")
       args+=(--enable-rpc-exit)
     fi
 

--- a/net/remote/remote-sanity.sh
+++ b/net/remote/remote-sanity.sh
@@ -26,7 +26,6 @@ missing() {
 [[ -n $deployMethod ]]   || missing deployMethod
 [[ -n $entrypointIp ]]   || missing entrypointIp
 [[ -n $numNodes ]]       || missing numNodes
-[[ -n $leaderRotation ]] || missing leaderRotation
 [[ -n $failOnValidatorBootupFailure ]] || missing failOnValidatorBootupFailure
 
 ledgerVerify=true


### PR DESCRIPTION
There's no need to deploy a testnet with leader rotation disabled anymore, remove the plumbing to do so.