### PR TITLE
Implement listener for serving repairs through Repairman protocol

### DIFF
--- a/core/src/blocktree.rs
+++ b/core/src/blocktree.rs
@@ -203,7 +203,7 @@ impl Blocktree {
     pub fn slot_data_iterator(
         &self,
         slot: u64,
-    ) -> Result<impl Iterator<Item = ((u64, u64), Vec<u8>)>> {
+    ) -> Result<impl Iterator<Item = ((u64, u64), Box<[u8]>)>> {
         let slot_iterator = self.db.iter::<cf::Data>(Some((slot, 0)))?;
         Ok(slot_iterator.take_while(move |((blob_slot, _), _)| *blob_slot == slot))
     }

--- a/core/src/blocktree/db.rs
+++ b/core/src/blocktree/db.rs
@@ -244,7 +244,7 @@ where
     pub fn iter<C>(
         &self,
         start_from: Option<C::Index>,
-    ) -> Result<impl Iterator<Item = (C::Index, Vec<u8>)>>
+    ) -> Result<impl Iterator<Item = (C::Index, Box<[u8]>)>>
     where
         C: Column<B>,
     {
@@ -258,7 +258,7 @@ where
             }
         };
 
-        Ok(iter.map(|(key, value)| (C::index(&key), value.into())))
+        Ok(iter.map(|(key, value)| (C::index(&key), value)))
     }
 
     #[inline]
@@ -387,7 +387,7 @@ where
     pub fn iter(
         &self,
         start_from: Option<C::Index>,
-    ) -> Result<impl Iterator<Item = (C::Index, Vec<u8>)>> {
+    ) -> Result<impl Iterator<Item = (C::Index, Box<[u8]>)>> {
         let iter = {
             if let Some(index) = start_from {
                 let key = C::key(index);
@@ -398,7 +398,7 @@ where
             }
         };
 
-        Ok(iter.map(|(key, value)| (C::index(&key), value.into())))
+        Ok(iter.map(|(key, value)| (C::index(&key), value)))
     }
 
     #[inline]

--- a/core/src/blocktree/db.rs
+++ b/core/src/blocktree/db.rs
@@ -282,7 +282,7 @@ where
     // Note this returns an object that can be used to directly write to multiple column families.
     // This circumvents the synchronization around APIs that in Blocktree that use
     // blocktree.batch_processor, so this API should only be used if the caller is sure they
-    // are writing to data iin columns that will not be corrupted by any simultaneous blocktree
+    // are writing to data in columns that will not be corrupted by any simultaneous blocktree
     // operations.
     pub unsafe fn batch_processor(&self) -> BatchProcessor<B> {
         BatchProcessor {

--- a/core/src/cluster_info.rs
+++ b/core/src/cluster_info.rs
@@ -344,6 +344,44 @@ impl ClusterInfo {
         (txs, max_ts)
     }
 
+    pub fn get_epoch_state_for_node(
+        &self,
+        pubkey: &Pubkey,
+        since: Option<u64>,
+    ) -> Option<(&EpochSlots, u64)> {
+        self.gossip
+            .crds
+            .table
+            .get(&CrdsValueLabel::EpochSlots(*pubkey))
+            .filter(|x| {
+                since
+                    .map(|since| x.insert_timestamp > since)
+                    .unwrap_or(true)
+            })
+            .map(|x| (x.value.epoch_slots().unwrap(), x.insert_timestamp))
+    }
+
+    pub fn get_gossiped_root_for_node(&self, pubkey: &Pubkey, since: Option<u64>) -> Option<u64> {
+        self.gossip
+            .crds
+            .table
+            .get(&CrdsValueLabel::EpochSlots(*pubkey))
+            .filter(|x| {
+                since
+                    .map(|since| x.insert_timestamp > since)
+                    .unwrap_or(true)
+            })
+            .map(|x| x.value.epoch_slots().unwrap().root)
+    }
+
+    pub fn get_contact_info_for_node(&self, pubkey: &Pubkey) -> Option<&ContactInfo> {
+        self.gossip
+            .crds
+            .table
+            .get(&CrdsValueLabel::ContactInfo(*pubkey))
+            .map(|x| x.value.contact_info().unwrap())
+    }
+
     pub fn purge(&mut self, now: u64) {
         self.gossip.purge(now);
     }

--- a/core/src/cluster_info_repair_listener.rs
+++ b/core/src/cluster_info_repair_listener.rs
@@ -92,8 +92,12 @@ impl ClusterInfoRepairListener {
                         // Following logic needs to be fast because it holds the lock
                         // preventing updates on gossip
                         peer_roots.insert(peer.id, (ts, peer_epoch_slots.root));
-                        if Self::should_repair_peer(my_root, peer_epoch_slots.root, epoch_schedule)
-                        {
+                        if Self::should_repair_peer(
+                            my_root,
+                            peer_epoch_slots.root,
+                            &epoch_schedule,
+                            NUM_BUFFER_SLOTS,
+                        ) {
                             // Clone out EpochSlots structure to avoid holding lock on gossip
                             peers_needing_repairs.insert(peer.id, peer_epoch_slots.clone());
                         }
@@ -138,8 +142,14 @@ impl ClusterInfoRepairListener {
 
             if let Some(repairee_tvu) = repairee_tvu {
                 // For every repairee, get the set of repairmen who are responsible for
-                let mut eligible_repairmen =
-                    Self::find_eligible_repairmen(my_id, repairee_root, peer_roots, epoch_schedule);
+                let mut eligible_repairmen = Self::find_eligible_repairmen(
+                    repairee_root,
+                    peer_roots,
+                    epoch_schedule,
+                    NUM_BUFFER_SLOTS,
+                );
+
+                eligible_repairmen.push(my_id);
 
                 Self::shuffle_repairmen(
                     &mut eligible_repairmen,
@@ -169,7 +179,7 @@ impl ClusterInfoRepairListener {
         my_root: u64,
         blocktree: &Blocktree,
         repairee_epoch_slots: &EpochSlots,
-        eligible_repairmen: &Vec<&Pubkey>,
+        eligible_repairmen: &[&Pubkey],
         socket: &UdpSocket,
         repairee_tvu: &SocketAddr,
     ) -> Result<()> {
@@ -179,21 +189,24 @@ impl ClusterInfoRepairListener {
         let mut total_data_blobs_sent = 0;
         let mut total_coding_blobs_sent = 0;
 
-        while slot_iter.valid() && slot_iter.key().unwrap() <= my_root {
-            let slot = slot_iter.key().unwrap();
-            let highest_index = slot_iter.value().unwrap().received;
+        for (slot, slot_meta) in slot_iter {
+            if slot > my_root {
+                break;
+            }
+            let highest_index = slot_meta.received;
             if !repairee_epoch_slots.slots.contains(&slot) {
                 // Calculate the blob indexes this node is responsible for repairing. Note that because we
                 // are only repairing slots that are before our root, the slot.received should be equal to
                 // the actual total number of blobs in the slot. Optimistically this means that most repairmen should
                 // observe the same "total" number of blobs for a particular slot, and thus the calculation in
                 // calculate_my_repairman_index_for_slot() will divide responsibility evenly across the cluster
-                let num_blobs_in_slot = slot_iter.value().unwrap().received as usize;
+                let num_blobs_in_slot = slot_meta.received as usize;
                 if let Some((my_repairman_index, repairman_step)) =
                     Self::calculate_my_repairman_index_for_slot(
                         my_id,
                         &eligible_repairmen,
                         num_blobs_in_slot,
+                        REPAIR_REDUNDANCY,
                     )
                 {
                     // Repairee is missing this slot, send them the blobs for this slot
@@ -265,24 +278,24 @@ impl ClusterInfoRepairListener {
 
     fn calculate_my_repairman_index_for_slot(
         my_id: &Pubkey,
-        eligible_repairmen: &Vec<&Pubkey>,
+        eligible_repairmen: &[&Pubkey],
         num_blobs_in_slot: usize,
+        repair_redundancy: usize,
     ) -> Option<(usize, usize)> {
-        let total_blobs = num_blobs_in_slot * REPAIR_REDUNDANCY;
+        let total_blobs = num_blobs_in_slot * repair_redundancy;
         let total_repairmen = min(total_blobs, eligible_repairmen.len());
-        let repairmen = &eligible_repairmen[..total_repairmen];
-
-        // The total number of blobs sent by each repairman
-        let blobs_per_repairman = total_blobs / total_repairmen;
 
         // Partitions the repairmen into `num_repairman_buckets` different groups.
         // Each repairman within the same group will be responsible for repairing,
         // for some `n`, all the blobs with index equal to `n % num_repairman_buckets`
         // All repairmen within the same group will be sending the same blobs.
-        let num_repairman_buckets = total_blobs / blobs_per_repairman;
+        let num_repairman_buckets = total_repairmen / repair_redundancy;
 
         // Calculate the indexes this node is responsible for
-        if let Some(my_position) = repairmen.iter().position(|id| *id == my_id) {
+        if let Some(my_position) = eligible_repairmen[..total_repairmen]
+            .iter()
+            .position(|id| *id == my_id)
+        {
             Some((my_position % num_repairman_buckets, num_repairman_buckets))
         } else {
             // If there are more repairmen than `total_blobs`, then some repairmen
@@ -292,15 +305,20 @@ impl ClusterInfoRepairListener {
     }
 
     fn find_eligible_repairmen<'a>(
-        my_id: &'a Pubkey,
         repairee_root: u64,
         repairman_roots: &'a HashMap<Pubkey, (u64, u64)>,
         epoch_schedule: &EpochSchedule,
+        num_buffer_slots: usize,
     ) -> Vec<&'a Pubkey> {
-        let mut repairmen: Vec<_> = repairman_roots
+        let repairmen: Vec<_> = repairman_roots
             .iter()
             .filter_map(|(repairman_id, (_, repairman_root))| {
-                if Self::should_repair_peer(*repairman_root, repairee_root, *epoch_schedule) {
+                if Self::should_repair_peer(
+                    *repairman_root,
+                    repairee_root,
+                    epoch_schedule,
+                    num_buffer_slots,
+                ) {
                     Some(repairman_id)
                 } else {
                     None
@@ -308,7 +326,6 @@ impl ClusterInfoRepairListener {
             })
             .collect();
 
-        repairmen.push(my_id);
         repairmen
     }
 
@@ -335,13 +352,15 @@ impl ClusterInfoRepairListener {
     fn should_repair_peer(
         repairman_root: u64,
         repairee_root: u64,
-        epoch_schedule: EpochSchedule,
+        epoch_schedule: &EpochSchedule,
+        num_buffer_slots: usize,
     ) -> bool {
         // Check if this potential repairman's confirmed leader schedule is greater
         // than an epoch ahead of the repairee's known schedule
         let repairman_epoch = epoch_schedule.get_stakers_epoch(repairman_root);
         let repairee_epoch =
-            epoch_schedule.get_stakers_epoch(repairee_root + NUM_BUFFER_SLOTS as u64);
+            epoch_schedule.get_stakers_epoch(repairee_root + num_buffer_slots as u64);
+
         repairman_epoch > repairee_epoch
     }
 
@@ -368,22 +387,256 @@ impl Service for ClusterInfoRepairListener {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::blocktree::get_tmp_ledger_path;
+    use crate::blocktree::tests::make_many_slot_entries;
+    use crate::streamer;
+    use std::collections::HashSet;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::mpsc::channel;
+    use std::sync::Arc;
+    use std::thread::sleep;
+    use std::time::Duration;
 
     #[test]
-    fn test_serve_repairs() {}
+    fn test_serve_repairs_to_repairee() {
+        let blocktree_path = get_tmp_ledger_path!();
+        let blocktree = Blocktree::open(&blocktree_path).unwrap();
+        let blobs_per_slot = 5;
+        let num_slots = 10;
+        assert_eq!(num_slots % 2, 0);
+        let (blobs, _) = make_many_slot_entries(0, num_slots, blobs_per_slot);
+
+        // Write slots in the range [0, num_slots] to blocktree
+        blocktree.insert_data_blobs(&blobs).unwrap();
+
+        // Set up my information
+        let my_id = Pubkey::new_rand();
+        let my_socket = UdpSocket::bind("0.0.0.0:0").unwrap();
+
+        // Set up the repairee's EpochSlots, such that they are missing every odd indexed slot
+        // in the range (repairee_root, num_slots]
+        let repairee_id = Pubkey::new_rand();
+        let repairee_root = 0;
+        let repairee_slots: HashSet<_> = (0..=num_slots).step_by(2).collect();
+        let repairee_epoch_slots = EpochSlots::new(repairee_id, repairee_root, repairee_slots, 1);
+
+        // Mock out some other repairmen such that each repairman is responsible for 1 blob in a slot
+        let num_repairmen = blobs_per_slot - 1;
+        let mut eligible_repairmen: Vec<_> =
+            (0..num_repairmen).map(|_| Pubkey::new_rand()).collect();
+        eligible_repairmen.push(my_id);
+        let eligible_repairmen_refs: Vec<_> = eligible_repairmen.iter().collect();
+
+        // Set up a blob reciever for the repairee
+        let (repairee_sender, repairee_receiver) = channel();
+        let repairee_socket = Arc::new(UdpSocket::bind("0.0.0.0:0").unwrap());
+        let repairee_tvu = repairee_socket.local_addr().unwrap();
+        let repairee_exit = Arc::new(AtomicBool::new(false));
+        let repairee_receiver_thread_hdl =
+            streamer::blob_receiver(repairee_socket, &repairee_exit, repairee_sender);
+
+        // Have all the repairman send the repairs
+        for repairman_id in &eligible_repairmen {
+            ClusterInfoRepairListener::serve_repairs_to_repairee(
+                &repairman_id,
+                num_slots - 1,
+                &blocktree,
+                &repairee_epoch_slots,
+                &eligible_repairmen_refs,
+                &my_socket,
+                &repairee_tvu,
+            )
+            .unwrap();
+        }
+
+        let mut received_blobs = vec![];
+
+        // This repairee was missing exactly `num_slots / 2` slots, so we expect to get
+        // `(num_slots / 2) * blobs_per_slot` blobs.
+        let num_expected_blobs = (num_slots / 2) * blobs_per_slot;
+        while (received_blobs.len() as u64) < num_expected_blobs {
+            received_blobs.extend(repairee_receiver.recv());
+        }
+
+        // Make sure no extra blobs get sent
+        sleep(Duration::from_millis(1000));
+        assert!(repairee_receiver.try_recv().is_err());
+        assert_eq!(received_blobs.len() as u64, num_expected_blobs);
+
+        // Shutdown
+        repairee_exit.store(true, Ordering::Relaxed);
+        repairee_receiver_thread_hdl.join().unwrap();
+        drop(blocktree);
+        Blocktree::destroy(&blocktree_path).expect("Expected successful database destruction");
+    }
 
     #[test]
-    fn test_shuffle_repairmen() {}
+    fn test_shuffle_repairmen() {
+        let num_repairmen = 10;
+        let eligible_repairmen: Vec<_> = (0..num_repairmen).map(|_| Pubkey::new_rand()).collect();
+
+        let unshuffled_refs: Vec<_> = eligible_repairmen.iter().collect();
+        let mut expected_order = unshuffled_refs.clone();
+
+        // Find the expected shuffled order based on a fixed seed
+        ClusterInfoRepairListener::shuffle_repairmen(&mut expected_order, unshuffled_refs[0], 0);
+        for _ in 0..10 {
+            let mut copied = unshuffled_refs.clone();
+            ClusterInfoRepairListener::shuffle_repairmen(&mut copied, unshuffled_refs[0], 0);
+
+            // Make sure shuffling repairmen is deterministic every time
+            assert_eq!(copied, expected_order);
+
+            // Make sure shuffling actually changes the order of the keys
+            assert_ne!(copied, unshuffled_refs);
+        }
+    }
 
     #[test]
-    fn calculate_my_repairman_index_for_slot() {}
+    fn test_calculate_my_repairman_index_for_slot() {
+        // Test when the number of blobs in the slot > number of repairmen
+        let num_repairmen = 10;
+        let num_blobs_in_slot = 42;
+        let repair_redundancy = 3;
+        run_calculate_my_repairman_index_for_slot(
+            num_repairmen,
+            num_blobs_in_slot,
+            repair_redundancy,
+        );
+
+        // Test when the number of blobs in the slot <= number of repairmen
+        let num_repairmen = 10;
+        let num_blobs_in_slot = 10;
+        let repair_redundancy = 3;
+        run_calculate_my_repairman_index_for_slot(
+            num_repairmen,
+            num_blobs_in_slot,
+            repair_redundancy,
+        );
+
+        // Test when there are more validators than repair_redundancy * num_blobs_in_slot
+        let num_repairmen = 42;
+        let num_blobs_in_slot = 10;
+        let repair_redundancy = 3;
+        run_calculate_my_repairman_index_for_slot(
+            num_repairmen,
+            num_blobs_in_slot,
+            repair_redundancy,
+        );
+    }
 
     #[test]
-    fn test_find_eligible_repairmen() {}
+    fn test_should_repair_peer() {
+        let epoch_schedule = EpochSchedule::new(32, 16, false);
 
-    #[test]
-    fn test_update_my_gossiped_root() {}
+        // If repairee is ahead of us, we don't repair
+        let repairman_root = 0;
+        let repairee_root = 5;
+        assert!(!ClusterInfoRepairListener::should_repair_peer(
+            repairman_root,
+            repairee_root,
+            &epoch_schedule,
+            0,
+        ));
 
-    #[test]
-    fn test_should_repair_peer() {}
+        // If repairee is at the same place as us, we don't repair
+        let repairman_root = 5;
+        let repairee_root = 5;
+        assert!(!ClusterInfoRepairListener::should_repair_peer(
+            repairman_root,
+            repairee_root,
+            &epoch_schedule,
+            0,
+        ));
+
+        // If repairee is behind but in the same confirmed epoch, we don't repair
+        let repairman_root = 15;
+        let repairee_root = 5;
+        assert!(!ClusterInfoRepairListener::should_repair_peer(
+            repairman_root,
+            repairee_root,
+            &epoch_schedule,
+            0,
+        ));
+
+        // If we have confirmed the next epoch, but the repairee is within the buffer
+        // range, we don't repair
+        let repairman_root = 16;
+        let repairee_root = 5;
+        assert!(!ClusterInfoRepairListener::should_repair_peer(
+            repairman_root,
+            repairee_root,
+            &epoch_schedule,
+            11,
+        ));
+
+        // If we have confirmed the next epoch, but the repairee is behind a confirmed epoch
+        // even with the buffer, then we should repair
+        let repairman_root = 16;
+        let repairee_root = 5;
+        assert!(ClusterInfoRepairListener::should_repair_peer(
+            repairman_root,
+            repairee_root,
+            &epoch_schedule,
+            10,
+        ));
+    }
+
+    fn run_calculate_my_repairman_index_for_slot(
+        num_repairmen: usize,
+        num_blobs_in_slot: usize,
+        repair_redundancy: usize,
+    ) {
+        let eligible_repairmen: Vec<_> = (0..num_repairmen).map(|_| Pubkey::new_rand()).collect();
+        let eligible_repairmen_ref: Vec<_> = eligible_repairmen.iter().collect();
+        let mut results = HashMap::new();
+        let mut none_results = 0;
+        let mut step = None;
+        for pk in &eligible_repairmen {
+            if let Some((repairman_index, repairman_step)) =
+                ClusterInfoRepairListener::calculate_my_repairman_index_for_slot(
+                    pk,
+                    &eligible_repairmen_ref[..],
+                    num_blobs_in_slot,
+                    repair_redundancy,
+                )
+            {
+                if let Some(step) = step {
+                    assert_eq!(step, repairman_step);
+                } else {
+                    step = Some(repairman_step);
+                }
+
+                results
+                    .entry(repairman_index)
+                    .and_modify(|e| *e += 1)
+                    .or_insert(1);
+            } else {
+                // This repairman isn't responsible for repairing this slot
+                none_results += 1;
+            }
+        }
+
+        // Analyze the results:
+
+        // 1) Each bucket should have at least min(repair_redundancy, num_repairmen)
+        // peers responsible for that bucket
+        for b in results.keys() {
+            assert!(results[b] >= min(num_repairmen, repair_redundancy));
+        }
+
+        // 2) Buckets should be as evenly divided as possible among the repairmen
+        let min_repairmen = results.values().min_by(|x, y| x.cmp(y)).unwrap();
+        let max_repairmen = results.values().max_by(|x, y| x.cmp(y)).unwrap();
+        assert!(*max_repairmen <= *min_repairmen + 1);
+
+        // 3) There should only be repairmen who are not responsible for repairing this slot
+        // if we have more repairman than `num_blobs_in_slot * repair_redundancy`. In this case the
+        // first `num_blobs_in_slot * repair_redundancy` repairmen woudl send one blob, and the rest
+        // would noe be responsible for sending any repairs
+        assert_eq!(
+            none_results,
+            num_repairmen.saturating_sub(num_blobs_in_slot * repair_redundancy)
+        );
+    }
 }

--- a/core/src/cluster_info_repair_listener.rs
+++ b/core/src/cluster_info_repair_listener.rs
@@ -20,7 +20,7 @@ use std::sync::{Arc, RwLock};
 use std::thread::{self, sleep, Builder, JoinHandle};
 use std::time::Duration;
 
-pub const REPAIRMEN_SLEEP_MILLIS: usize = 1000;
+pub const REPAIRMEN_SLEEP_MILLIS: usize = 100;
 pub const REPAIR_REDUNDANCY: usize = 3;
 pub const NUM_BUFFER_SLOTS: usize = 50;
 pub const GOSSIP_DELAY_SLOTS: usize = 2;
@@ -137,12 +137,15 @@ impl ClusterInfoRepairListener {
                     {
                         // Following logic needs to be fast because it holds the lock
                         // preventing updates on gossip
-                        peer_roots.insert(peer.id, (ts, peer_epoch_slots.root));
                         if Self::should_repair_peer(
                             my_root,
                             peer_epoch_slots.root,
                             NUM_BUFFER_SLOTS,
                         ) {
+                            // Only update our local timestamp for this peer if we are going to
+                            // repair them
+                            peer_roots.insert(peer.id, (ts, peer_epoch_slots.root));
+
                             // Clone out EpochSlots structure to avoid holding lock on gossip
                             peers_needing_repairs.insert(peer.id, peer_epoch_slots.clone());
                         }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -13,7 +13,6 @@ pub mod broadcast_stage;
 pub mod chacha;
 #[cfg(all(feature = "chacha", feature = "cuda"))]
 pub mod chacha_cuda;
-pub mod cluster_info_repair_listener;
 pub mod cluster_info_vote_listener;
 #[macro_use]
 pub mod contact_info;
@@ -30,6 +29,7 @@ pub mod blockstream_service;
 pub mod blocktree_processor;
 pub mod cluster;
 pub mod cluster_info;
+pub mod cluster_info_repair_listener;
 pub mod cluster_tests;
 pub mod entry;
 pub mod erasure;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -13,6 +13,7 @@ pub mod broadcast_stage;
 pub mod chacha;
 #[cfg(all(feature = "chacha", feature = "cuda"))]
 pub mod chacha_cuda;
+pub mod cluster_info_repair_listener;
 pub mod cluster_info_vote_listener;
 #[macro_use]
 pub mod contact_info;


### PR DESCRIPTION
#### Problem
Repairmen do not currently respond to repairees that need repair based on gossip

#### Summary of Changes
1) Implement a repair listener that polls gossip and detects which nodes need to be repaired
2) Evenly divide up responsibility of repairing blobs in slots among the repairmen

Note: This does not yet start up the repair listener in a fullnode, it's just the implementation.

Fixes #
