### PR TITLE
cp -a includes -r

### DIFF
--- a/sdk/bpf/scripts/package.sh
+++ b/sdk/bpf/scripts/package.sh
@@ -12,6 +12,6 @@ cp LICENSE bpf-sdk/
   git rev-parse HEAD
 ) > bpf-sdk/version.txt
 
-cp -ra sdk/bpf/* bpf-sdk/
+cp -a sdk/bpf/* bpf-sdk/
 
 tar jvcf bpf-sdk.tar.bz2 bpf-sdk/


### PR DESCRIPTION
#### Problem

`cp -a` is the same as `cp -r -a` except macos does not complain of duplicate options

#### Summary of Changes

Fixes #
