### PR TITLE
Rate limit metrics per log level

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2734,6 +2734,7 @@ dependencies = [
 name = "solana-upload-perf"
 version = "0.15.0"
 dependencies = [
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-metrics 0.15.0",
 ]

--- a/core/src/blocktree.rs
+++ b/core/src/blocktree.rs
@@ -408,6 +408,7 @@ impl Blocktree {
                                 ),
                             )
                             .to_owned(),
+                        log::Level::Error,
                     );
                 }
             }

--- a/metrics/src/counter.rs
+++ b/metrics/src/counter.rs
@@ -134,7 +134,7 @@ impl Counter {
                         .or_insert(influxdb::Value::Integer(0));
                 }
                 if let Some(ref mut point) = self.point {
-                    submit(point.to_owned());
+                    submit(point.to_owned(), level);
                 }
             }
         }

--- a/upload-perf/Cargo.toml
+++ b/upload-perf/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2018"
 homepage = "https://solana.com/"
 
 [dependencies]
+log = "0.4.2"
 serde_json = "1.0.39"
 solana-metrics = { path = "../metrics", version = "0.15.0"  }
 

--- a/upload-perf/src/upload-perf.rs
+++ b/upload-perf/src/upload-perf.rs
@@ -77,6 +77,7 @@ fn main() {
                                 influxdb::Value::String(git_commit_hash.trim().to_string()),
                             )
                             .to_owned(),
+                        log::Level::Info,
                     );
                 }
                 let last_median = get_last_metrics(&"median".to_string(), &db, &name, &branch)


### PR DESCRIPTION
#### Problem
The rate limiting does not distinguish between different priorities of data points, and ends up dropping important metrics.

#### Summary of Changes
Adding facility to rate limit per log level. More changes are needed to identify what datapoint fits in which log level.