### PR TITLE
Cleanup Rust BPF program building

### DIFF
--- a/ci/test-stable.sh
+++ b/ci/test-stable.sh
@@ -47,7 +47,6 @@ test-stable-perf)
 
   # BPF program tests
   _ make -C programs/bpf/c tests
-  _ programs/bpf/rust/noop/build.sh # Must be built out of band
   _ cargo +"$rust_stable" test \
     --manifest-path programs/bpf/Cargo.toml \
     --no-default-features --features=bpf_c,bpf_rust

--- a/programs/bpf/build.rs
+++ b/programs/bpf/build.rs
@@ -27,73 +27,63 @@ fn rerun_if_changed(files: &[&str], directories: &[&str]) {
 }
 
 fn main() {
-    println!("cargo:rerun-if-changed=build.rs");
-
     let bpf_c = !env::var("CARGO_FEATURE_BPF_C").is_err();
     if bpf_c {
-        let out_dir = "OUT_DIR=../../../target/".to_string()
+        let install_dir = "OUT_DIR=../../../target/".to_string()
             + &env::var("PROFILE").unwrap()
             + &"/bpf".to_string();
 
-        rerun_if_changed(
-            &["../../sdk/bpf/bpf.ld", "../../sdk/bpf/bpf.mk", "c/makefile"],
-            &["../../sdk/bpf/inc", "../../sdk/bpf/scripts", "c/src"],
-        );
-
-        println!("cargo:warning=(not a warning) Compiling C-based BPF programs");
-        let status = Command::new("make")
+        println!("cargo:warning=(not a warning) Building C-based BPF programs");
+        assert!(Command::new("make")
             .current_dir("c")
             .arg("programs")
-            .arg(&out_dir)
+            .arg(&install_dir)
             .status()
-            .expect("Failed to build C-based BPF programs");
-        assert!(status.success());
+            .expect("Failed to build C-based BPF programs")
+            .success());
+
+        rerun_if_changed(&["c/makefile"], &["c/src", "../../sdk"]);
     }
 
     let bpf_rust = !env::var("CARGO_FEATURE_BPF_RUST").is_err();
     if bpf_rust {
         let install_dir =
-            "../../../../target/".to_string() + &env::var("PROFILE").unwrap() + &"/bpf".to_string();
+            "../../target/".to_string() + &env::var("PROFILE").unwrap() + &"/bpf".to_string();
 
-        if !Path::new("rust/noop/target/bpfel-unknown-unknown/release/solana_bpf_rust_noop.so")
-            .is_file()
-        {
-            // Cannot build Rust BPF programs as part of main build because
-            // to build it requires calling Cargo with different parameters which
-            // would deadlock due to recursive cargo calls
-            panic!(
-                "solana_bpf_rust_noop.so not found, you must manually run \
-                 `programs/bpf/rust/noop/build.sh` to build it"
-            );
-        }
-
-        rerun_if_changed(
-            &[
-                "rust/noop/bpf.ld",
-                "rust/noop/build.sh",
-                "rust/noop/Cargo.toml",
-                "rust/noop/target/bpfel-unknown-unknown/release/solana_bpf_rust_noop.so",
-            ],
-            &["rust/noop/src"],
-        );
-
-        println!(
-            "cargo:warning=(not a warning) Installing Rust-based BPF program: solana_bpf_rust_noop"
-        );
-        let status = Command::new("mkdir")
-            .current_dir("rust/noop")
+        assert!(Command::new("mkdir")
             .arg("-p")
             .arg(&install_dir)
             .status()
-            .expect("Unable to create BPF install directory");
-        assert!(status.success());
+            .expect("Unable to create BPF install directory")
+            .success());
 
-        let status = Command::new("cp")
-            .current_dir("rust/noop")
-            .arg("target/bpfel-unknown-unknown/release/solana_bpf_rust_noop.so")
-            .arg(&install_dir)
-            .status()
-            .expect("Failed to copy solana_rust_bpf_noop.so to install directory");
-        assert!(status.success());
+        let rust_programs = ["demo", "noop"];
+        for program in rust_programs.iter() {
+            println!(
+                "cargo:warning=(not a warning) Building Rust-based BPF program: solana_bpf_rust_{}",
+                program
+            );
+            assert!(Command::new("./build.sh")
+                .current_dir(format!("rust/{}", program))
+                .env("RUSTUP_TOOLCHAIN", "bpf")
+                .status()
+                .expect(&format!(
+                    "Failed to call solana-bpf-rust-{}'s build.sh",
+                    program
+                ))
+                .success());
+            let src = format!(
+                "rust/{}/target/bpfel-unknown-unknown/release/solana_bpf_rust_{}.so",
+                program, program,
+            );
+            assert!(Command::new("cp")
+                .arg(&src)
+                .arg(&install_dir)
+                .status()
+                .expect(&format!("Failed to cp {} to {}", src, install_dir))
+                .success());
+        }
+
+        rerun_if_changed(&[], &["rust", "../../sdk"]);
     }
 }

--- a/programs/bpf/build.rs
+++ b/programs/bpf/build.rs
@@ -67,7 +67,7 @@ fn main() {
             .expect("Unable to create BPF install directory")
             .success());
 
-        let rust_programs = ["demo", "noop"];
+        let rust_programs = ["noop"];
         for program in rust_programs.iter() {
             println!(
                 "cargo:warning=(not a warning) Building Rust-based BPF program: solana_bpf_rust_{}",

--- a/programs/bpf/rust/noop/Cargo.toml
+++ b/programs/bpf/rust/noop/Cargo.toml
@@ -9,10 +9,8 @@ authors = ["Solana Maintainers <maintainers@solana.com>"]
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 homepage = "https://solana.com/"
-edition = "2018"
 
 [dependencies]
-solana-sdk-rust-utils = { path = "../../../../sdk/bpf/rust-utils", version = "0.15.0" }
 # byteorder = { version = "1.3.1", default-features = false }
 # heapless = { version = "0.4.0", default-features = false }
 # byte = { version = "0.2", default-features = false }

--- a/programs/bpf/rust/noop/Cargo.toml
+++ b/programs/bpf/rust/noop/Cargo.toml
@@ -9,8 +9,10 @@ authors = ["Solana Maintainers <maintainers@solana.com>"]
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 homepage = "https://solana.com/"
+edition = "2018"
 
 [dependencies]
+solana-sdk-rust-utils = { path = "../../../../sdk/bpf/rust-utils", version = "0.15.0" }
 # byteorder = { version = "1.3.1", default-features = false }
 # heapless = { version = "0.4.0", default-features = false }
 # byte = { version = "0.2", default-features = false }

--- a/programs/bpf/rust/noop/build.sh
+++ b/programs/bpf/rust/noop/build.sh
@@ -8,8 +8,8 @@ set -e
 
 # Ensure the sdk is installed
 ../../../../sdk/bpf/scripts/install.sh
-rustup override set bpf
 
+export RUSTUP_TOOLCHAIN=bpf
 export RUSTFLAGS="$RUSTFLAGS \
     -C lto=no \
     -C opt-level=2 \
@@ -21,7 +21,6 @@ export RUSTFLAGS="$RUSTFLAGS \
     -C linker=../../../../sdk/bpf/llvm-native/bin/ld.lld"
 export XARGO_HOME="$PWD/target/xargo"
 export XARGO_RUST_SRC="../../../../sdk/bpf/rust-bpf-sysroot/src"
-# export XARGO_RUST_SRC="../../../../../rust-bpf-sysroot/src"
 xargo build --target bpfel-unknown-unknown --release -v
 
 { { set +x; } 2>/dev/null; echo Success; }

--- a/programs/bpf/rust/noop/build.sh
+++ b/programs/bpf/rust/noop/build.sh
@@ -6,8 +6,10 @@ cargo install xargo
 
 set -e
 
+bpf_sdk=../../../../sdk/bpf
+
 # Ensure the sdk is installed
-../../../../sdk/bpf/scripts/install.sh
+"$bpf_sdk"/scripts/install.sh
 
 export RUSTUP_TOOLCHAIN=bpf
 export RUSTFLAGS="$RUSTFLAGS \
@@ -18,9 +20,9 @@ export RUSTFLAGS="$RUSTFLAGS \
     -C link-arg=--Bdynamic \
     -C link-arg=-shared \
     -C link-arg=--entry=entrypoint \
-    -C linker=../../../../sdk/bpf/llvm-native/bin/ld.lld"
+    -C linker=$bpf_sdk/llvm-native/bin/ld.lld"
 export XARGO_HOME="$PWD/target/xargo"
-export XARGO_RUST_SRC="../../../../sdk/bpf/rust-bpf-sysroot/src"
+export XARGO_RUST_SRC="$bpf_sdk/rust-bpf-sysroot/src"
 xargo build --target bpfel-unknown-unknown --release -v
 
 { { set +x; } 2>/dev/null; echo Success; }

--- a/programs/bpf/rust/noop/dump.sh
+++ b/programs/bpf/rust/noop/dump.sh
@@ -7,6 +7,6 @@ set -e
 
 ./clean.sh
 ./build.sh
-ls -la ./target/bpfel_unknown_unknown/release/solana_bpf_rust_noop.so > dump.txt
-greadelf -aW ./target/bpfel_unknown_unknown/release/solana_bpf_rust_noop.so | rustfilt >> dump.txt
-llvm-objdump -print-imm-hex --source --disassemble ./target/bpfel_unknown_unknown/release/solana_bpf_rust_noop.so >> dump.txt
+ls -la ./target/bpfel-unknown-unknownrelease/solana_bpf_rust_noop.so > dump.txt
+greadelf -aW ./target/bpfel-unknown-unknown/release/solana_bpf_rust_noop.so | rustfilt >> dump.txt
+llvm-objdump -print-imm-hex --source --disassemble ./target/bpfel-unknown-unknown/release/solana_bpf_rust_noop.so >> dump.txt

--- a/programs/bpf/rust/noop/dump.sh
+++ b/programs/bpf/rust/noop/dump.sh
@@ -7,6 +7,6 @@ set -e
 
 ./clean.sh
 ./build.sh
-ls -la ./target/bpfel-unknown-unknownrelease/solana_bpf_rust_noop.so > dump.txt
+ls -la ./target/bpfel-unknown-unknown/release/solana_bpf_rust_noop.so > dump.txt
 greadelf -aW ./target/bpfel-unknown-unknown/release/solana_bpf_rust_noop.so | rustfilt >> dump.txt
 llvm-objdump -print-imm-hex --source --disassemble ./target/bpfel-unknown-unknown/release/solana_bpf_rust_noop.so >> dump.txt


### PR DESCRIPTION
#### Problem


#### Summary of Changes

- Rust BPF program build script was using toolchain overrides, use RUSTUP_TOOLCHAIN environment  variable instead
- Now that the dependencies are independent Rust BPF programs are now build inline with the main build.
- More comprehensive list of re-run files in the build.rs script
- Ability to build more than one Rust BPF program
- Rerun for itself is redundant
- Fix dump script names

Fixes #
