### PR TITLE
Rework Storage Program to accept multiple proofs per segment

### DIFF
--- a/core/src/fullnode.rs
+++ b/core/src/fullnode.rs
@@ -23,6 +23,7 @@ use solana_sdk::genesis_block::GenesisBlock;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::{Keypair, KeypairUtil};
 use solana_sdk::timing::timestamp;
+use solana_storage_api::SLOTS_PER_SEGMENT;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::Receiver;
@@ -44,7 +45,7 @@ impl Default for FullnodeConfig {
         // TODO: remove this, temporary parameter to configure
         // storage amount differently for test configurations
         // so tests don't take forever to run.
-        const NUM_HASHES_FOR_STORAGE_ROTATE: u64 = 128;
+        const NUM_HASHES_FOR_STORAGE_ROTATE: u64 = SLOTS_PER_SEGMENT;
         Self {
             sigverify_disabled: false,
             voting_disabled: false,

--- a/core/src/storage_stage.rs
+++ b/core/src/storage_stage.rs
@@ -401,8 +401,6 @@ impl StorageStage {
         let timeout = Duration::new(1, 0);
         let slot: u64 = slot_receiver.recv_timeout(timeout)?;
         *slot_count = slot;
-        // root slots have to be full
-        assert!(blocktree.meta(slot).unwrap().unwrap().is_full());
         if let Ok(entries) = blocktree.get_slot_entries(slot, 0, None) {
             for entry in &entries {
                 // Go through the transactions, find proofs, and use them to update
@@ -422,7 +420,11 @@ impl StorageStage {
                 }
             }
             if *slot_count % storage_rotate_count == 0 {
-                debug!("crosses sending at root slot: {}!", slot_count);
+                let entry_hash = entries.last().unwrap().hash;
+                debug!(
+                    "crosses sending at root slot: {}! with last entry's hash {}",
+                    slot_count, entry_hash
+                );
                 Self::process_entry_crossing(
                     &storage_keypair,
                     &storage_state,

--- a/core/src/storage_stage.rs
+++ b/core/src/storage_stage.rs
@@ -400,8 +400,7 @@ impl StorageStage {
     ) -> Result<()> {
         let timeout = Duration::new(1, 0);
         let slot: u64 = slot_receiver.recv_timeout(timeout)?;
-        storage_state.write().unwrap().slot = slot;
-        *slot_count += 1;
+        *slot_count = slot;
         if let Ok(entries) = blocktree.get_slot_entries(slot, 0, None) {
             for entry in entries {
                 // Go through the transactions, find proofs, and use them to update
@@ -419,20 +418,20 @@ impl StorageStage {
                         }
                     }
                 }
-                if *slot_count % storage_rotate_count == 0 {
-                    debug!(
-                        "crosses sending at slot: {}! hashes: {}",
-                        slot, entry.num_hashes
-                    );
-                    Self::process_entry_crossing(
-                        &storage_keypair,
-                        &storage_state,
-                        &blocktree,
-                        entry.hash,
-                        slot,
-                        instruction_sender,
-                    )?;
-                }
+            }
+            if *slot_count % storage_rotate_count == 0 {
+                debug!(
+                    "crosses sending at slot: {}! hashes: {}",
+                    slot, entry.num_hashes
+                );
+                Self::process_entry_crossing(
+                    &storage_keypair,
+                    &storage_state,
+                    &blocktree,
+                    entry.hash,
+                    slot,
+                    instruction_sender,
+                )?;
             }
         }
         Ok(())

--- a/core/src/storage_stage.rs
+++ b/core/src/storage_stage.rs
@@ -400,7 +400,10 @@ impl StorageStage {
     ) -> Result<()> {
         let timeout = Duration::new(1, 0);
         let slot: u64 = slot_receiver.recv_timeout(timeout)?;
-        *slot_count = slot;
+        *slot_count += 1;
+        // Todo check if any rooted slots were missed leading up to this one and bump slot count and process proofs for each missed root
+        // Update the advertised blockhash to the latest root directly.
+
         if let Ok(entries) = blocktree.get_slot_entries(slot, 0, None) {
             for entry in &entries {
                 // Go through the transactions, find proofs, and use them to update
@@ -420,6 +423,7 @@ impl StorageStage {
                 }
             }
             if *slot_count % storage_rotate_count == 0 {
+                // assume the last entry in the slot is the blockhash for that slot
                 let entry_hash = entries.last().unwrap().hash;
                 debug!(
                     "crosses sending at root slot: {}! with last entry's hash {}",

--- a/programs/storage_api/src/storage_contract.rs
+++ b/programs/storage_api/src/storage_contract.rs
@@ -277,7 +277,7 @@ impl<'a> StorageAccount<'a> {
                 &reward_validations
                     .get_mut(&claim_segment)
                     .map(|proofs| proofs.drain().map(|(_, proof)| proof).collect::<Vec<_>>())
-                    .unwrap_or(vec![]),
+                    .unwrap_or_default(),
             );
             // TODO can't just create lamports out of thin air
             // self.account.lamports += TOTAL_VALIDATOR_REWARDS * num_validations;


### PR DESCRIPTION
#### Problems

- Storage program doesn't support multiple samples per segment per replicator
- Storage program spams for a new account 
- Storage program incorrectly updates its slot for rpc

#### Summary of Changes

- Reworked storage program to carry multiple proofs per replicator. Updated to use Hashmaps where possible to avoid repeated searching and because validators will only have a few segments at a time, we dont need vec sizes to grow as the segment count increases.

- Fixed updating slot for rpc
- Fixed spamming for new acount 
- Added tick height protections in most instructions
- Updated tests to actually consider tick height
