### PR TITLE
net/: Switch to instances with AVX-512 if possible for better interop with dev machines

### DIFF
--- a/ci/testnet-deploy.sh
+++ b/ci/testnet-deploy.sh
@@ -49,7 +49,7 @@ Deploys a CD testnet
    -c [number]          - Number of client bencher nodes (default: $clientNodeCount)
    -u                   - Include a Blockstreamer (default: $blockstreamer)
    -P                   - Use public network IP addresses (default: $publicNetwork)
-   -G                   - Enable GPU, and set count/type of GPUs to use (e.g n1-standard-16 --accelerator count=4,type=nvidia-tesla-k80)
+   -G                   - Enable GPU, and set count/type of GPUs to use (e.g n1-standard-16 --accelerator count=2,type=nvidia-tesla-v100)
    -g                   - Enable GPU (default: $enableGpu)
    -a [address]         - Set the bootstrap fullnode's external IP address to this GCE address
    -d [disk-type]       - Specify a boot disk type (default None) Use pd-ssd to get ssd on GCE.

--- a/net/scripts/gce-provider.sh
+++ b/net/scripts/gce-provider.sh
@@ -163,7 +163,11 @@ cloud_CreateInstances() {
   args+=(--image $imageName)
 
   # shellcheck disable=SC2206 # Do not want to quote $machineType as it may contain extra args
-  args+=($machineType)
+  for word in $machineType; do
+    # Special handling for the "--min-cpu-platform" argument which may contain a
+    # space (escaped as '%20')...
+    args+=("${word//%20/ }")
+  done
   if [[ -n $optionalBootDiskSize ]]; then
     args+=(
       --boot-disk-size "${optionalBootDiskSize}GB"


### PR DESCRIPTION
Some of the dev machines folks are using support AVX-512, and building `solana-fullnode` (erasure) on those machines will generate AVX-512 instructions, that core dump when deployed to a machine without AVX-512.

AVX-512 is not yet ubiquitous so we can't enforce it as a minimum requirement (ie, switch CI over and build release binaries with it), so this PR really just tries to reduce some dev friction.