### PR TITLE
Rm metrics docker even if not running

### DIFF
--- a/metrics/scripts/stop.sh
+++ b/metrics/scripts/stop.sh
@@ -2,7 +2,9 @@
 #
 # Stops local metrics
 #
+
 cd "$(dirname "$0")"
+
 for container in influxdb grafana; do
   if [ "$(docker ps -q -a -f name=$container)" ]; then
   (
@@ -12,5 +14,6 @@ for container in influxdb grafana; do
   )
   fi
 done
+
 echo Local metrics stopped
 exit 0

--- a/metrics/scripts/stop.sh
+++ b/metrics/scripts/stop.sh
@@ -2,19 +2,15 @@
 #
 # Stops local metrics
 #
-
 cd "$(dirname "$0")"
-
 for container in influxdb grafana; do
-  if [ "$(docker ps -q -f name=$container)" ]; then
+  if [ "$(docker ps -q -a -f name=$container)" ]; then
   (
     set +e
-    docker kill $container
-    docker rm $container
+    docker rm -f $container
     exit 0
   )
   fi
- done
-
- echo Local metrics stopped
- exit 0
+done
+echo Local metrics stopped
+exit 0


### PR DESCRIPTION
#### Problem

If metrics `start.sh` fails to start a docker but the container exists then trying to call `start.sh` again fails due to an existing container being present.

#### Summary of Changes

Change `stop.sh` to both remove the container even if it's not running.

Fixes #
