### PR TITLE
support issuing vote instructions from system account

### DIFF
--- a/core/src/entry.rs
+++ b/core/src/entry.rs
@@ -438,8 +438,6 @@ mod tests {
     use solana_sdk::pubkey::Pubkey;
     use solana_sdk::signature::{Keypair, KeypairUtil};
     use solana_sdk::system_transaction;
-    use solana_vote_api::vote_instruction;
-    use solana_vote_api::vote_state::Vote;
     use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
     fn create_sample_payment(keypair: &Keypair, hash: Hash) -> Transaction {
@@ -457,12 +455,6 @@ mod tests {
     fn create_sample_apply_signature(keypair: &Keypair, hash: Hash) -> Transaction {
         let pubkey = keypair.pubkey();
         let ix = budget_instruction::apply_signature(&pubkey, &pubkey, &pubkey);
-        Transaction::new_signed_instructions(&[keypair], vec![ix], hash)
-    }
-
-    fn create_sample_vote(keypair: &Keypair, hash: Hash) -> Transaction {
-        let pubkey = keypair.pubkey();
-        let ix = vote_instruction::vote(&pubkey, vec![Vote::new(1)]);
         Transaction::new_signed_instructions(&[keypair], vec![ix], hash)
     }
 
@@ -647,8 +639,7 @@ mod tests {
         let hash = Hash::default();
         let next_hash = solana_sdk::hash::hash(&hash.as_ref());
         let keypair = Keypair::new();
-        let vote_account = Keypair::new();
-        let tx_small = create_sample_vote(&vote_account, next_hash);
+        let tx_small = create_sample_timestamp(&keypair, next_hash);
         let tx_large = create_sample_payment(&keypair, next_hash);
 
         let tx_small_size = serialized_size(&tx_small).unwrap() as usize;

--- a/core/src/fullnode.rs
+++ b/core/src/fullnode.rs
@@ -71,19 +71,16 @@ pub struct Fullnode {
 }
 
 impl Fullnode {
-    pub fn new<T>(
+    pub fn new(
         mut node: Node,
         keypair: &Arc<Keypair>,
         ledger_path: &str,
         vote_account: &Pubkey,
-        voting_keypair: &Arc<T>,
+        voting_keypair: &Arc<Keypair>,
         storage_keypair: &Arc<Keypair>,
         entrypoint_info_option: Option<&ContactInfo>,
         config: &FullnodeConfig,
-    ) -> Self
-    where
-        T: 'static + KeypairUtil + Sync + Send,
-    {
+    ) -> Self {
         info!("creating bank...");
 
         let id = keypair.pubkey();

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -55,9 +55,9 @@ impl Tvu {
     /// * `sockets` - fetch, repair, and retransmit sockets
     /// * `blocktree` - the ledger itself
     #[allow(clippy::new_ret_no_self, clippy::too_many_arguments)]
-    pub fn new<T>(
+    pub fn new(
         vote_account: &Pubkey,
-        voting_keypair: Option<&Arc<T>>,
+        voting_keypair: Option<&Arc<Keypair>>,
         storage_keypair: &Arc<Keypair>,
         bank_forks: &Arc<RwLock<BankForks>>,
         cluster_info: &Arc<RwLock<ClusterInfo>>,
@@ -73,10 +73,7 @@ impl Tvu {
         exit: &Arc<AtomicBool>,
         genesis_blockhash: &Hash,
         completed_slots_receiver: CompletedSlotsReceiver,
-    ) -> Self
-    where
-        T: 'static + KeypairUtil + Sync + Send,
-    {
+    ) -> Self {
         let keypair: Arc<Keypair> = cluster_info
             .read()
             .expect("Unable to read from cluster_info during Tvu creation")

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -55,9 +55,9 @@ impl Tvu {
     /// * `sockets` - fetch, repair, and retransmit sockets
     /// * `blocktree` - the ledger itself
     #[allow(clippy::new_ret_no_self, clippy::too_many_arguments)]
-    pub fn new(
+    pub fn new<T>(
         vote_account: &Pubkey,
-        voting_keypair: Option<&Arc<Keypair>>,
+        voting_keypair: Option<&Arc<T>>,
         storage_keypair: &Arc<Keypair>,
         bank_forks: &Arc<RwLock<BankForks>>,
         cluster_info: &Arc<RwLock<ClusterInfo>>,
@@ -73,7 +73,10 @@ impl Tvu {
         exit: &Arc<AtomicBool>,
         genesis_blockhash: &Hash,
         completed_slots_receiver: CompletedSlotsReceiver,
-    ) -> Self {
+    ) -> Self
+    where
+        T: 'static + KeypairUtil + Sync + Send,
+    {
         let keypair: Arc<Keypair> = cluster_info
             .read()
             .expect("Unable to read from cluster_info during Tvu creation")

--- a/wallet/src/wallet.rs
+++ b/wallet/src/wallet.rs
@@ -44,7 +44,7 @@ pub enum WalletCommand {
     Balance(Pubkey),
     Cancel(Pubkey),
     Confirm(Signature),
-    AuthorizeVoter(Pubkey),
+    AuthorizeVoter(Pubkey, Keypair, Pubkey),
     CreateVoteAccount(Pubkey, Pubkey, u32, u64),
     ShowVoteAccount(Pubkey),
     CreateStakeAccount(Pubkey, u64),
@@ -193,8 +193,16 @@ pub fn parse_command(
             ))
         }
         ("authorize-voter", Some(matches)) => {
-            let authorized_voter_id = pubkey_of(matches, "authorized_voter_id").unwrap();
-            Ok(WalletCommand::AuthorizeVoter(authorized_voter_id))
+            let voting_account_id = pubkey_of(matches, "voting_account_id").unwrap();
+            let authorized_voter_keypair =
+                keypair_of(matches, "authorized_voter_keypair_file").unwrap();
+            let new_authorized_voter_id = pubkey_of(matches, "new_authorized_voter_id").unwrap();
+
+            Ok(WalletCommand::AuthorizeVoter(
+                voting_account_id,
+                authorized_voter_keypair,
+                new_authorized_voter_id,
+            ))
         }
         ("show-vote-account", Some(matches)) => {
             let voting_account_id = pubkey_of(matches, "voting_account_id").unwrap();
@@ -392,12 +400,16 @@ fn process_create_vote_account(
 fn process_authorize_voter(
     rpc_client: &RpcClient,
     config: &WalletConfig,
-    authorized_voter_id: &Pubkey,
+    voting_account_id: &Pubkey,
+    authorized_voter_keypair: &Keypair,
+    new_authorized_voter_id: &Pubkey,
 ) -> ProcessResult {
     let (recent_blockhash, _fee_calculator) = rpc_client.get_recent_blockhash()?;
     let ixs = vec![vote_instruction::authorize_voter(
-        &config.keypair.pubkey(),
-        authorized_voter_id,
+        &config.keypair.pubkey(),           // from
+        voting_account_id,                  // vote account to update
+        &authorized_voter_keypair.pubkey(), // current authorized voter (often the vote account itself)
+        new_authorized_voter_id,            // new vote signer
     )];
 
     let mut tx = Transaction::new_signed_instructions(&[&config.keypair], ixs, recent_blockhash);
@@ -776,9 +788,17 @@ pub fn process_command(config: &WalletConfig) -> ProcessResult {
             )
         }
         // Configure staking account already created
-        WalletCommand::AuthorizeVoter(authorized_voter_id) => {
-            process_authorize_voter(&rpc_client, config, &authorized_voter_id)
-        }
+        WalletCommand::AuthorizeVoter(
+            voting_account_id,
+            authorized_voter_keypair,
+            new_authorized_voter_id,
+        ) => process_authorize_voter(
+            &rpc_client,
+            config,
+            &voting_account_id,
+            &authorized_voter_keypair,
+            &new_authorized_voter_id,
+        ),
         // Show a vote account
         WalletCommand::ShowVoteAccount(voting_account_id) => {
             process_show_vote_account(&rpc_client, config, &voting_account_id)
@@ -996,15 +1016,32 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
         )
         .subcommand(
             SubCommand::with_name("authorize-voter")
-                .about("Authorize a different voter for this vote account")
+                .about("Authorize a new vote signing keypair for the given vote account")
                 .arg(
-                    Arg::with_name("authorized_voter_id")
+                    Arg::with_name("voting_account_id")
                         .index(1)
                         .value_name("PUBKEY")
                         .takes_value(true)
                         .required(true)
                         .validator(is_pubkey)
-                        .help("Vote signer to authorize"),
+                        .help("Vote account in which to set the authorized voter"),
+                )
+                .arg(
+                    Arg::with_name("authorized_voter_keypair_file")
+                        .index(2)
+                        .value_name("KEYPAIR_FILE")
+                        .takes_value(true)
+                        .required(true)
+                        .help("Keypair file for the currently authorized vote signer"),
+                )
+                .arg(
+                    Arg::with_name("new_authorized_voter_id")
+                        .index(3)
+                        .value_name("PUBKEY")
+                        .takes_value(true)
+                        .required(true)
+                        .validator(is_pubkey)
+                        .help("New vote signer to authorize"),
                 ),
         )
         .subcommand(
@@ -1313,13 +1350,20 @@ mod tests {
         assert!(parse_command(&pubkey, &test_bad_signature).is_err());
 
         // Test AuthorizeVoter Subcommand
-        let test_authorize_voter =
-            test_commands
-                .clone()
-                .get_matches_from(vec!["test", "authorize-voter", &pubkey_string]);
+        let keypair_file = make_tmp_path("keypair_file");
+        gen_keypair_file(&keypair_file).unwrap();
+        let keypair = read_keypair(&keypair_file).unwrap();
+
+        let test_authorize_voter = test_commands.clone().get_matches_from(vec![
+            "test",
+            "authorize-voter",
+            &pubkey_string,
+            &keypair_file,
+            &pubkey_string,
+        ]);
         assert_eq!(
             parse_command(&pubkey, &test_authorize_voter).unwrap(),
-            WalletCommand::AuthorizeVoter(pubkey)
+            WalletCommand::AuthorizeVoter(pubkey, keypair, pubkey)
         );
 
         // Test CreateVoteAccount SubCommand
@@ -1545,7 +1589,8 @@ mod tests {
         let signature = process_command(&config);
         assert_eq!(signature.unwrap(), SIGNATURE.to_string());
 
-        config.command = WalletCommand::AuthorizeVoter(bob_pubkey);
+        let bob_keypair = Keypair::new();
+        config.command = WalletCommand::AuthorizeVoter(bob_pubkey, bob_keypair, bob_pubkey);
         let signature = process_command(&config);
         assert_eq!(signature.unwrap(), SIGNATURE.to_string());
 
@@ -1663,7 +1708,7 @@ mod tests {
         config.command = WalletCommand::CreateVoteAccount(bob_pubkey, node_id, 0, 10);
         assert!(process_command(&config).is_err());
 
-        config.command = WalletCommand::AuthorizeVoter(bob_pubkey);
+        config.command = WalletCommand::AuthorizeVoter(bob_pubkey, Keypair::new(), bob_pubkey);
         assert!(process_command(&config).is_err());
 
         config.command = WalletCommand::GetTransactionCount;

--- a/wallet/src/wallet.rs
+++ b/wallet/src/wallet.rs
@@ -412,7 +412,11 @@ fn process_authorize_voter(
         new_authorized_voter_id,            // new vote signer
     )];
 
-    let mut tx = Transaction::new_signed_instructions(&[&config.keypair], ixs, recent_blockhash);
+    let mut tx = Transaction::new_signed_instructions(
+        &[&config.keypair, &authorized_voter_keypair],
+        ixs,
+        recent_blockhash,
+    );
     let signature_str = rpc_client.send_and_confirm_transaction(&mut tx, &[&config.keypair])?;
     Ok(signature_str.to_string())
 }


### PR DESCRIPTION
#### Problem
 vote instruction constructors need a "from" parameter that needs to be a system account to pay the transaction fees

 #### Summary of Changes
 update vote_instruction and customers to issue from a system account

Fixes #4173