### PR TITLE
Performance tweaks

### DIFF
--- a/bench-streamer/src/main.rs
+++ b/bench-streamer/src/main.rs
@@ -20,13 +20,13 @@ fn producer(addr: &SocketAddr, exit: Arc<AtomicBool>) -> JoinHandle<()> {
         w.meta.size = PACKET_DATA_SIZE;
         w.meta.set_addr(&addr);
     }
-    let msgs_ = msgs.clone();
+    let msgs = Arc::new(msgs);
     spawn(move || loop {
         if exit.load(Ordering::Relaxed) {
             return;
         }
         let mut num = 0;
-        for p in &msgs_.packets {
+        for p in &msgs.packets {
             let a = p.meta.addr();
             assert!(p.meta.size < BLOB_SIZE);
             send.send_to(&p.data[..p.meta.size], &a).unwrap();

--- a/core/src/packet.rs
+++ b/core/src/packet.rs
@@ -119,7 +119,7 @@ impl Meta {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct Packets {
     pub packets: Vec<Packet>,
 }

--- a/core/src/packet.rs
+++ b/core/src/packet.rs
@@ -18,6 +18,7 @@ use std::mem::size_of;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, UdpSocket};
 use std::ops::{Deref, DerefMut};
 use std::sync::{Arc, RwLock};
+use std::time::Instant;
 
 pub type SharedBlob = Arc<RwLock<Blob>>;
 pub type SharedBlobs = Vec<SharedBlob>;
@@ -119,7 +120,7 @@ impl Meta {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Packets {
     pub packets: Vec<Packet>,
 }
@@ -213,6 +214,9 @@ pub enum BlobError {
 
 impl Packets {
     pub fn recv_from(&mut self, socket: &UdpSocket) -> Result<usize> {
+        const MAX_PACKETS_PER_VEC: usize = 1024;
+        const MAX_MILLIS_PER_BATCH: u128 = 2;
+
         let mut i = 0;
         //DOCUMENTED SIDE-EFFECT
         //Performance out of the IO without poll
@@ -222,11 +226,16 @@ impl Packets {
         //  * set it back to blocking before returning
         socket.set_nonblocking(false)?;
         trace!("receiving on {}", socket.local_addr().unwrap());
+        let start = Instant::now();
         loop {
             self.packets.resize(i + NUM_RCVMMSGS, Packet::default());
             match recv_mmsg(socket, &mut self.packets[i..]) {
                 Err(_) if i > 0 => {
-                    break;
+                    if i >= MAX_PACKETS_PER_VEC
+                        || start.elapsed().as_millis() > MAX_MILLIS_PER_BATCH
+                    {
+                        break;
+                    }
                 }
                 Err(e) => {
                     trace!("recv_from err {:?}", e);
@@ -238,7 +247,9 @@ impl Packets {
                     }
                     trace!("got {} packets", npkts);
                     i += npkts;
-                    if npkts != NUM_RCVMMSGS || i >= 1024 {
+                    if i >= MAX_PACKETS_PER_VEC
+                        || start.elapsed().as_millis() > MAX_MILLIS_PER_BATCH
+                    {
                         break;
                     }
                 }

--- a/core/src/sigverify_stage.rs
+++ b/core/src/sigverify_stage.rs
@@ -75,8 +75,12 @@ impl SigVerifyStage {
         let verified_batch = Self::verify_batch(batch, sigverify_disabled);
         inc_new_counter_info!("sigverify_stage-verified_packets_send", len);
 
-        if sendr.send(verified_batch).is_err() {
-            return Err(Error::SendError);
+        // Batch may be very large. Break it up so banking_stage can have maximum
+        // parallelism.
+        for item in verified_batch {
+            if sendr.send(vec![item]).is_err() {
+                return Err(Error::SendError);
+            }
         }
 
         let total_time_ms = timing::duration_as_ms(&now.elapsed());


### PR DESCRIPTION
#### Problem

* Packets getting cloned in banking_stage is bad for perf.
* Packets getting received into a single buffer causes many packets buffers to be created and those buffers propagate poorly through the backend because of how they are batched.
* Sigverify coalescing of huge batches causes poor banking_stage parallelism.

#### Summary of Changes

* Use Rc to take references to Packets buffers to prevent copies.
* Coalesce incoming packets better to create larger batches for sigverify/banking and reduce allocator work and memory usage.
* Split up batches going into banking from sigverify to help banking_stage parallelism.

Fixes #
