### PR TITLE
Add bootstrap storage account to genesis

### DIFF
--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -215,7 +215,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
             // storage account
             (
                 bootstrap_storage_keypair.pubkey(),
-                Account::new(1, 1024 * 4, &system_program::id()),
+                Account::new(1, 1024 * 4, &solana_storage_api::id()),
             ),
         ],
         &[

--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -99,7 +99,6 @@ fn main() -> Result<(), Box<dyn error::Error>> {
         )
         .arg(
             Arg::with_name("bootstrap_storage_keypair_file")
-                .short("r")
                 .long("bootstrap-storage-keypair")
                 .value_name("BOOTSTRAP STORAGE KEYPAIR")
                 .takes_value(true)

--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -98,6 +98,15 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                 .help("Path to file containing the bootstrap leader's staking keypair"),
         )
         .arg(
+            Arg::with_name("bootstrap_storage_keypair_file")
+                .short("r")
+                .long("bootstrap-storage-keypair")
+                .value_name("BOOTSTRAP STORAGE KEYPAIR")
+                .takes_value(true)
+                .required(true)
+                .help("Path to file containing the bootstrap leader's storage keypair"),
+        )
+        .arg(
             Arg::with_name("bootstrap_leader_lamports")
                 .long("bootstrap-leader-lamports")
                 .value_name("LAMPORTS")
@@ -156,6 +165,8 @@ fn main() -> Result<(), Box<dyn error::Error>> {
     let bootstrap_leader_keypair_file = matches.value_of("bootstrap_leader_keypair_file").unwrap();
     let bootstrap_vote_keypair_file = matches.value_of("bootstrap_vote_keypair_file").unwrap();
     let bootstrap_stake_keypair_file = matches.value_of("bootstrap_stake_keypair_file").unwrap();
+    let bootstrap_storage_keypair_file =
+        matches.value_of("bootstrap_storage_keypair_file").unwrap();
     let mint_keypair_file = matches.value_of("mint_keypair_file").unwrap();
     let ledger_path = matches.value_of("ledger_path").unwrap();
     let lamports = value_t_or_exit!(matches, "lamports", u64);
@@ -165,6 +176,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
     let bootstrap_leader_keypair = read_keypair(bootstrap_leader_keypair_file)?;
     let bootstrap_vote_keypair = read_keypair(bootstrap_vote_keypair_file)?;
     let bootstrap_stake_keypair = read_keypair(bootstrap_stake_keypair_file)?;
+    let bootstrap_storage_keypair = read_keypair(bootstrap_storage_keypair_file)?;
     let mint_keypair = read_keypair(mint_keypair_file)?;
 
     // TODO: de-duplicate the stake once passive staking
@@ -200,6 +212,11 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                     &vote_state,
                     bootstrap_leader_stake_lamports,
                 ),
+            ),
+            // storage account
+            (
+                bootstrap_storage_keypair.pubkey(),
+                Account::new(1, 1024 * 4, &system_program::id()),
             ),
         ],
         &[

--- a/multinode-demo/fullnode.sh
+++ b/multinode-demo/fullnode.sh
@@ -92,7 +92,8 @@ setup_vote_and_stake_accounts() {
   if [[ -f "$node_keypair_path".configured ]]; then
     echo "Vote and stake accounts have already been configured"
   else
-    $solana_wallet --keypair "$node_keypair_path" --url "http://$entrypoint_ip:8899" airdrop $((stake*2+1)) || return $?
+    # Fund the node with enough tokens to fund its Vote, Staking, and Storage accounts
+    $solana_wallet --keypair "$node_keypair_path" --url "http://$entrypoint_ip:8899" airdrop $((stake*2+2)) || return $?
 
     # Fund the vote account from the node, with the node as the node_pubkey
     $solana_wallet --keypair "$node_keypair_path" --url "http://$entrypoint_ip:8899" \

--- a/multinode-demo/setup.sh
+++ b/multinode-demo/setup.sh
@@ -18,6 +18,7 @@ args=("$@")
 default_arg --bootstrap-leader-keypair "$SOLANA_CONFIG_DIR"/bootstrap-leader-keypair.json
 default_arg --bootstrap-vote-keypair "$SOLANA_CONFIG_DIR"/bootstrap-leader-vote-keypair.json
 default_arg --bootstrap-stake-keypair "$SOLANA_CONFIG_DIR"/bootstrap-leader-stake-keypair.json
+default_arg --bootstrap-storage-keypair "$SOLANA_CONFIG_DIR"/bootstrap-leader-storage-keypair.json
 default_arg --ledger "$SOLANA_RSYNC_CONFIG_DIR"/ledger
 default_arg --mint "$SOLANA_CONFIG_DIR"/mint-keypair.json
 default_arg --lamports 100000000000000

--- a/run.sh
+++ b/run.sh
@@ -44,7 +44,7 @@ solana-keygen -o "$dataDir"/config/leader-keypair.json
 solana-keygen -o "$dataDir"/config/leader-vote-account-keypair.json
 solana-keygen -o "$dataDir"/config/leader-stake-account-keypair.json
 solana-keygen -o "$dataDir"/config/drone-keypair.json
-solana-keygen -o "$dataDir"/config/storage-keypair.json
+solana-keygen -o "$dataDir"/config/leader-storage-account-keypair.json
 
 leaderVoteAccountPubkey=$(\
   solana-wallet \
@@ -61,6 +61,7 @@ solana-genesis \
   --bootstrap-leader-keypair "$dataDir"/config/leader-keypair.json \
   --bootstrap-vote-keypair "$dataDir"/config/leader-vote-account-keypair.json \
   --bootstrap-stake-keypair "$dataDir"/config/leader-stake-account-keypair.json \
+  --bootstrap-storage-keypair "$dataDir"/config/leader-storage-account-keypair.json \
   --ledger "$dataDir"/ledger
 
 solana-drone --keypair "$dataDir"/config/drone-keypair.json &


### PR DESCRIPTION
#### Problem

Storage account creation consumed the last remaining token in the bootstrap leader's account. This resulted in the node being removed from leader_rotation/stake holders. 

#### Summary of Changes

Add passive staking for storage accounts

