### PR TITLE
Don't print leader update message unless leader actually updates

### DIFF
--- a/core/src/cluster_info.rs
+++ b/core/src/cluster_info.rs
@@ -297,11 +297,13 @@ impl ClusterInfo {
 
     /// Record the id of the current leader for use by `leader_tpu_via_blobs()`
     pub fn set_leader(&mut self, leader_id: &Pubkey) {
-        warn!(
-            "{}: LEADER_UPDATE TO {} from {}",
-            self.gossip.id, leader_id, self.gossip_leader_id,
-        );
-        self.gossip_leader_id = *leader_id;
+        if *leader_id != self.gossip_leader_id {
+            warn!(
+                "{}: LEADER_UPDATE TO {} from {}",
+                self.gossip.id, leader_id, self.gossip_leader_id,
+            );
+            self.gossip_leader_id = *leader_id;
+        }
     }
 
     pub fn push_epoch_slots(&mut self, id: Pubkey, root: u64, slots: HashSet<u64>) {


### PR DESCRIPTION
#### Problem

LEADER_UPDATE message prints way too much and only really needed when the leader actually updates.

#### Summary of Changes

Check for this case and do the print then.

Fixes #
