### PR TITLE
add bank hash to votes

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -302,7 +302,7 @@ impl ReplayStage {
     where
         T: 'static + KeypairUtil + Send + Sync,
     {
-        if let Some(new_root) = locktower.record_vote(bank.slot()) {
+        if let Some(new_root) = locktower.record_vote(bank.slot(), bank.hash()) {
             // get the root bank before squash
             let root_bank = bank_forks
                 .read()

--- a/programs/stake_api/src/stake_state.rs
+++ b/programs/stake_api/src/stake_state.rs
@@ -206,14 +206,14 @@ mod tests {
     use solana_sdk::account::Account;
     use solana_sdk::pubkey::Pubkey;
     use solana_sdk::signature::{Keypair, KeypairUtil};
-    use solana_vote_api::vote_state::{self, Vote};
+    use solana_vote_api::vote_state;
 
     #[test]
     fn test_stake_delegate_stake() {
         let vote_keypair = Keypair::new();
         let mut vote_state = VoteState::default();
         for i in 0..1000 {
-            vote_state.process_vote(&Vote::new(i));
+            vote_state.process_slot_vote_unchecked(i);
         }
 
         let vote_pubkey = vote_keypair.pubkey();
@@ -272,7 +272,7 @@ mod tests {
 
         // put a credit in the vote_state
         while vote_state.credits() == 0 {
-            vote_state.process_vote(&Vote::new(vote_i));
+            vote_state.process_slot_vote_unchecked(vote_i);
             vote_i += 1;
         }
         // this guy can't collect now, not enough stake to get paid on 1 credit
@@ -291,7 +291,7 @@ mod tests {
 
         // put more credit in the vote_state
         while vote_state.credits() < 10 {
-            vote_state.process_vote(&Vote::new(vote_i));
+            vote_state.process_slot_vote_unchecked(vote_i);
             vote_i += 1;
         }
         vote_state.commission = 0;
@@ -318,7 +318,7 @@ mod tests {
         let vote_keypair = Keypair::new();
         let mut vote_state = VoteState::default();
         for i in 0..1000 {
-            vote_state.process_vote(&Vote::new(i));
+            vote_state.process_slot_vote_unchecked(i);
         }
 
         let vote_pubkey = vote_keypair.pubkey();
@@ -364,7 +364,7 @@ mod tests {
         );
 
         // move the vote account forward
-        vote_state.process_vote(&Vote::new(1000));
+        vote_state.process_slot_vote_unchecked(1000);
         vote_keyed_account.set_state(&vote_state).unwrap();
 
         // now, no lamports in the pool!
@@ -392,7 +392,7 @@ mod tests {
         let vote_keypair = Keypair::new();
         let mut vote_state = VoteState::default();
         for i in 0..1000 {
-            vote_state.process_vote(&Vote::new(i));
+            vote_state.process_slot_vote_unchecked(i);
         }
 
         let vote_pubkey = vote_keypair.pubkey();
@@ -421,7 +421,7 @@ mod tests {
         let mut vote_state = VoteState::default();
         for i in 0..100 {
             // go back in time, previous state had 1000 votes
-            vote_state.process_vote(&Vote::new(i));
+            vote_state.process_slot_vote_unchecked(i);
         }
         vote_keyed_account.set_state(&vote_state).unwrap();
         // voter credits lower than stake_delegate credits...  TODO: is this an error?

--- a/sdk/src/packet.rs
+++ b/sdk/src/packet.rs
@@ -1,2 +1,5 @@
 /// Maximum over-the-wire size of a Transaction
-pub const PACKET_DATA_SIZE: usize = 512;
+///   1280 is IPv6 minimum MTU
+///   40 bytes is the size of the IPv6 header
+///   8 bytes is the size of the fragment header
+pub const PACKET_DATA_SIZE: usize = 1280 - 40 - 8;

--- a/sdk/src/syscall/mod.rs
+++ b/sdk/src/syscall/mod.rs
@@ -2,7 +2,7 @@
 //!
 use crate::pubkey::Pubkey;
 
-pub mod slothashes;
+pub mod slot_hashes;
 
 /// "Sysca11111111111111111111111111111111111111"
 ///   owner pubkey for syscall accounts

--- a/sdk/src/syscall/slot_hashes.rs
+++ b/sdk/src/syscall/slot_hashes.rs
@@ -17,6 +17,10 @@ pub fn id() -> Pubkey {
     Pubkey::new(&SYSCALL_SLOT_HASHES_ID)
 }
 
+pub fn check_id(pubkey: &Pubkey) -> bool {
+    pubkey.as_ref() == SYSCALL_SLOT_HASHES_ID
+}
+
 use crate::account_utils::State;
 use std::ops::{Deref, DerefMut};
 #[derive(Serialize, Deserialize)]


### PR DESCRIPTION
#### Problem
 votes don't contain a hash of the bank, can't be verified as correct

 #### Summary of Changes
 * add bank.hash() to votes that validators submit
 * add support for slot_hashes syscall account to vote_api, stubbed out dummy until bank supports it
 * grow packet to an IPv6-defined big, single-packet size, to be able to carry a max-size vote (currently 919 bytes)
 * modified locktower to keep a list of slot+hash for recent_votes instead of rebuilding from simulated vote_state
 * minor grooming of vote_state utility and testing functions

still to go: have vote_instruction request and bank actually supply the account that's supposed to be at syscall::slot_hashes::id()

CC #4245