### PR TITLE
Bump perf libs version to fix out buffer sizing

### DIFF
--- a/core/benches/sigverify_stage.rs
+++ b/core/benches/sigverify_stage.rs
@@ -65,7 +65,7 @@ fn bench_sigverify_stage(bencher: &mut Bencher) {
             }
         }
         let mut received = 0;
-        //trace!("sent: {}", sent_len);
+        trace!("sent: {}", sent_len);
         loop {
             if let Ok(mut verifieds) = verified_r.recv_timeout(Duration::from_millis(10)) {
                 while let Some(v) = verifieds.pop() {
@@ -77,7 +77,7 @@ fn bench_sigverify_stage(bencher: &mut Bencher) {
                 }
             }
         }
-        //trace!("received: {}", received);
+        trace!("received: {}", received);
     });
     stage.join().unwrap();
 }

--- a/fetch-perf-libs.sh
+++ b/fetch-perf-libs.sh
@@ -16,7 +16,7 @@ mkdir -p target/perf-libs
   cd target/perf-libs
   (
     set -x
-    curl https://solana-perf.s3.amazonaws.com/v0.12.0/x86_64-unknown-linux-gnu/solana-perf.tgz | tar zxvf -
+    curl https://solana-perf.s3.amazonaws.com/v0.12.1/x86_64-unknown-linux-gnu/solana-perf.tgz | tar zxvf -
   )
 
   if [[ -r solana-perf-CUDA_HOME.txt ]]; then


### PR DESCRIPTION
#### Problem

v0.12.0 has a bug in the sigverify out buffer sizing for packets with multiple signatures.

#### Summary of Changes

Bump version to pick up the fix.

Fixes #
