### PR TITLE
Remove ls which is innacurate since we never clean up the logs

### DIFF
--- a/net/net.sh
+++ b/net/net.sh
@@ -562,8 +562,7 @@ start() {
   echo "Bootstrap leader deployment took $bootstrapNodeDeployTime seconds"
   echo "Additional fullnode deployment (${#fullnodeIpList[@]} full nodes, ${#blockstreamerIpList[@]} blockstreamer nodes) took $additionalNodeDeployTime seconds"
   echo "Client deployment (${#clientIpList[@]} instances) took $clientDeployTime seconds"
-  echo "Network start logs in $netLogDir:"
-  ls -l "$netLogDir"
+  echo "Network start logs in $netLogDir"
 }
 
 


### PR DESCRIPTION
#### Problem

ls of logs directory takes up a lot of screen space and has a bunch of old entries because they are never cleaned up. Prevents user from seeing if the network start/restart operation is successful.

#### Summary of Changes

Remove ls.

Fixes #
