### PR TITLE
Check that Rust project exists

### DIFF
--- a/sdk/bpf/rust-utils/build.sh
+++ b/sdk/bpf/rust-utils/build.sh
@@ -4,7 +4,7 @@ if [ "$#" -ne 1 ]; then
     echo "Error: Must provide the full path to the project to build"
     exit 1
 fi
-if [ ! -d "$1" ]; then
+if [ ! -f "$1/Cargo.toml" ]; then
       echo "Error: Cannot find project: $1"
     exit 1
 fi

--- a/sdk/bpf/rust-utils/clean.sh
+++ b/sdk/bpf/rust-utils/clean.sh
@@ -4,7 +4,7 @@ if [ "$#" -ne 1 ]; then
     echo "Error: Must provide the full path to the project to build"
     exit 1
 fi
-if [ ! -d "$1" ]; then
+if [ ! -f "$1/Cargo.toml" ]; then
       echo "Error: Cannot find project: $1"
     exit 1
 fi


### PR DESCRIPTION
#### Problem

Calling `build.sh` or `clean.sh` on directory without project results in an attempt to build the rust bpfr sysroot with improper parameters and fails.  Its confusing and annoying.

#### Summary of Changes

Check that it there is at least a `Cargo.toml` file there.

Fixes #
