### PR TITLE
Add design for out of order blocks.

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -57,6 +57,7 @@
   - [Credit-only Accounts](credit-only-credit-debit-accounts.md)
   - [Deterministic Transaction Fees](transaction-fees.md)
   - [Validator](validator.md)
+  - [Out Of Order Blocks](out-of-order-blocks.md)
 
 - [Implemented Design Proposals](implemented-proposals.md)
   - [Fork Selection](fork-selection.md)

--- a/book/src/out-of-order-blocks.md
+++ b/book/src/out-of-order-blocks.md
@@ -122,4 +122,4 @@ If it is possible to build hardware that is much faster than the expected time
 to find the golden ticket, then an attacker could grind the Block Hash value to
 ensure that they are the leader 50% of the time.  Since the network is still
 relying on staked lamports as the Sybil resistant mechanism, we could increase
-the difficulty for consequtive stakes.
+the difficulty for consecutive stakes.

--- a/book/src/out-of-order-blocks.md
+++ b/book/src/out-of-order-blocks.md
@@ -96,15 +96,12 @@ schedule completely randomly.
 
 1. Leader 2 finds the golden ticket in slot 1
 2. Leader 2 proposes block for slot 2
-3. Block contains up to two PoH paths:
-    * The golden ticket PoH.
-    * The PoH path to a previous block.
 
-The golden ticket PoH path must be at most 1 slot longer that the PoH path to
-the block, and this should only occur if the block is attached to the previous
-block.  The reason why the two paths could be different is because Leader 1 may
-complete the block for slot 1 and Leader 2 may decide to attach block 2 to block
-1.
+PoH path with the golden ticket should attack to the proposed block, except if
+the block attaches to the previous block directly. In this scenario, the PoH
+path for the golden ticket was generated concurrently with the previous leaders
+block, and the proposed block is directly attached to the previous block as
+well.
 
 ### Ahead of time Execution
 
@@ -123,3 +120,9 @@ to find the golden ticket, then an attacker could grind the Block Hash value to
 ensure that they are the leader 50% of the time.  Since the network is still
 relying on staked lamports as the Sybil resistant mechanism, we could increase
 the difficulty for consecutive stakes.
+
+## Ledger Interpretation
+
+The PoH with the golden ticket needs to be included in the ledger.  In the case
+where the blocks directly attach, it should be included as an entry in the
+block.

--- a/book/src/out-of-order-blocks.md
+++ b/book/src/out-of-order-blocks.md
@@ -19,17 +19,19 @@ censor — is not addressed in this design.
 
 ## Random Leaders
 
-Leaders can generate a *golden ticket* to propose a block.
+Leaders can generate a *golden ticket* to propose a subsequent block.
 
 * *N* number of bits of a leader's vote signature that must match a PoH hash.
 This hash can be in between ticks.
 
 The leader must find the golden ticket in the empty PoH entries leading up to
 the proposed block.  Once the golden ticket is found, the leader can propose the
-next slot.  The leader signs the BlockHash of the block that the entries are
-generated from with a Vote.  Since each validator is resetting its PoH every
-time it votes, each validator can search for a golden ticket from that starting
-point.
+block for the next slot.
+
+To find the golden ticket, the leader signs the BlockHash of the block that the
+entries are generated from with a Vote.  Since each validator is resetting its
+PoH every time it votes, each validator can search for a golden ticket from that
+starting point, and look for a PoH hash matching *N* bits of the Vote signature.
 
 The same proposed [fork selection]/fork-selection.md) rules apply.  Once a block
 is voted on, the validator would switch its PoH to reset on this new block, and

--- a/book/src/out-of-order-blocks.md
+++ b/book/src/out-of-order-blocks.md
@@ -56,12 +56,12 @@ Difficulty is the number of matching bits that the golden ticket needs to match
 the signature.
 
 The golden ticket connects via PoH entries to a known block with an immutable
-account balance.  So, a simple token balance can be used to set the difficulty.
-Hashing with 1 account has been delegated 100 tokens should generate as many
-tickets as 2 accounts with 50 delegated tokens.
+account state.  The stake size can be used to set the difficulty.  Hashing with
+1 account has been delegated 100 tokens should generate as many tickets as 2
+accounts with 50 delegated tokens.
 
-Given the total delegated state size for the epoch, the difficulty can be
-computed with the leader scheduler.
+Given the total delegated stake size for the epoch, and number of hashes per
+Tick, the difficulty can be computed with the leader scheduler.
 
 ### Generating VDFs for Multiple Forks
 
@@ -71,9 +71,9 @@ lockout distance for the rest of the cluster and also be the heaviest fork
 based on lockout.  Let’s say the difficulty was set to the cluster generating a
 golden ticket block every 3 slots.
 
-For example,
+For example:
 
-starting with ‘n - 3’ forks, the proposed block would only be valid if no one in
+Starting with ‘n - 3’ forks, the proposed block would only be valid if no one in
 the cluster voted.  If they did, the golden ticket would need to be in the ‘n +
 7’ slot and propose the n + 8 block.
 
@@ -101,9 +101,10 @@ schedule completely randomly.
     * The PoH path to a previous block.
 
 The golden ticket PoH path must be at most 1 slot longer that the PoH path to
-the block.  The reason why the two paths could be different is because Leader 1
-may complete the block for slot 1 and Leader 2 may decide to attach block 2 to
-block 1.
+the block, and this should only occur if the block is attached to the previous
+block.  The reason why the two paths could be different is because Leader 1 may
+complete the block for slot 1 and Leader 2 may decide to attach block 2 to block
+1.
 
 ### Grinding
 

--- a/book/src/out-of-order-blocks.md
+++ b/book/src/out-of-order-blocks.md
@@ -39,7 +39,7 @@ proposes a block.
 To make it easy to verify, the vote with the golden ticket must be present in
 the proposed block as the first transaction.
 
-#### Grinding
+### Grinding
 
 Because the golden ticket is biasable, the last leader has the most opportunity
 to influence the BlockHash to generate the golden ticket for itself.  This
@@ -50,7 +50,7 @@ to the leaders’ VoteState account.
 To reduce the ability to grind the value, the golden ticket must appear *X*
 ticks after the block, where *X* is half of the number of ticks per block.
 
-#### Difficulty
+### Difficulty
 
 Difficulty is the number of matching bits that the golden ticket needs to match
 the signature.
@@ -63,7 +63,7 @@ tickets as 2 accounts with 50 delegated tokens.
 Given the total delegated state size for the epoch, the difficulty can be
 computed with the leader scheduler.
 
-#### Generating VDFs for Multiple Forks
+### Generating VDFs for Multiple Forks
 
 The number of potential forks the attacker can choose from is limited by
 the fork selection algorithm.  The generated golden ticket needs to be past the
@@ -77,7 +77,7 @@ starting with ‘n - 3’ forks, the proposed block would only be valid if no on
 the cluster voted.  If they did, the golden ticket would need to be in the ‘n +
 7’ slot and propose the n + 8 block.
 
-#### Transaction Ingress Point
+### Transaction Ingress Point
 
 Because there is no deterministic ingress point, there is no place for
 validators to forward transactions.  This design will end up requiring a shared
@@ -88,3 +88,27 @@ The validators already transmit their votes through gossip, so the golden ticket
 block can pick up the validator votes and any additional transactions that have
 not been encoded into the ledger.  These transactions could come from rejected
 forks.
+
+## Only Random Leaders
+
+If the random source is considered secure, it is possible to generate a leader
+schedule completely randomly.
+
+1. Leader 2 finds the golden ticket in slot 1
+2. Leader 2 proposes block for slot 2
+3. Block contains up to two PoH paths:
+    * The golden ticket PoH.
+    * The PoH path to a previous block.
+
+The golden ticket PoH path must be at most 1 slot longer that the PoH path to
+the block.  The reason why the two paths could be different is because Leader 1
+may complete the block for slot 1 and Leader 2 may decide to attach block 2 to
+block 1.
+
+### Grinding
+
+If it is possible to build hardware that is much faster than the expected time
+to find the golden ticket, then an attacker could grind the Block Hash value to
+ensure that they are the leader 50% of the time.  Since the network is still
+relying on staked lamports as the Sybil resistant mechanism, we could increase
+the difficulty for consequtive stakes.

--- a/book/src/out-of-order-blocks.md
+++ b/book/src/out-of-order-blocks.md
@@ -79,17 +79,20 @@ Starting with ‘n - 3’ forks, the proposed block would only be valid if no on
 the cluster voted.  If they did, the golden ticket would need to be in the ‘n +
 7’ slot and propose the n + 8 block.
 
-### Transaction Ingress Point
+### Slot Acquisition
 
 Because there is no deterministic ingress point, there is no place for
-validators to forward transactions.  This design will end up requiring a shared
-*mempool* of transactions between all the nodes, just like traditional PoW
-systems.
+validators to forward transactions. 
 
 The validators already transmit their votes through gossip, so the golden ticket
 block can pick up the validator votes and any additional transactions that have
 not been encoded into the ledger.  These transactions could come from rejected
 forks.
+
+But to receive transactions a head of time, the leader can transmit the golden
+ticket to the rest of the network prior to transmitting the entire block.  The
+network can pick the earliest known golden ticket based on PoH hash counts and
+start forwarding transactions to that leader.
 
 ## Only Random Leaders
 

--- a/book/src/out-of-order-blocks.md
+++ b/book/src/out-of-order-blocks.md
@@ -19,23 +19,23 @@ censor — is not addressed in this design.
 
 ## Random Leaders
 
-Leaders can generate a *golden ticket* to propose a subsequent block.
+Validators can generate a *golden ticket* to propose a subsequent block.
 
-* *N* number of bits of a leader's vote signature that must match a PoH hash.
+* *N* number of bits of a validator's vote signature that must match a PoH hash.
 This hash can be in between ticks.
 
-The leader must find the golden ticket in the empty PoH entries leading up to
-the proposed block.  Once the golden ticket is found, the leader can propose the
+The validator must find the golden ticket in the empty PoH entries leading up to
+the proposed block.  Once the golden ticket is found, the validator can propose the
 block for the next slot.
 
-To find the golden ticket, the leader signs the BlockHash of the block that the
+To find the golden ticket, the validator signs the BlockHash of the block that the
 entries are generated from with a Vote.  Since each validator is resetting its
 PoH every time it votes, each validator can search for a golden ticket from that
 starting point, and look for a PoH hash matching *N* bits of the Vote signature.
 
 The same proposed [fork selection]/fork-selection.md) rules apply.  Once a block
 is voted on, the validator would switch its PoH to reset on this new block, and
-either a new golden ticket block is proposed, or the next scheduled leader
+either a new golden ticket block is proposed, or the next scheduled validator
 proposes a block.
 
 To make it easy to verify, the vote with the golden ticket must be present in
@@ -51,6 +51,14 @@ to the leaders’ VoteState account.
 
 To reduce the ability to grind the value, the golden ticket must appear *X*
 ticks after the block, where *X* is half of the number of ticks per block.
+
+It is possible to build hardware that is much faster than the expected time to
+find the golden ticket, Since the network is still relying on staked lamports as
+the Sybil resistant mechanism, it could increase the difficulty for recent
+stakes.  Regardless of hardware the goal should be a stake weighted distribution
+of validators scheduled over the epoch.  One approach would be to increase the
+difficulty by 1 bit whenever the validator has taken more than the stake
+weighted alloted number of slots.
 
 ### Difficulty
 
@@ -120,11 +128,6 @@ leader so it can start executing them ahead of its block.
 
 ### Grinding
 
-If it is possible to build hardware that is much faster than the expected time
-to find the golden ticket, then an attacker could grind the Block Hash value to
-ensure that they are the leader 50% of the time.  Since the network is still
-relying on staked lamports as the Sybil resistant mechanism, we could increase
-the difficulty for consecutive stakes.
 
 ## Ledger Interpretation
 

--- a/book/src/out-of-order-blocks.md
+++ b/book/src/out-of-order-blocks.md
@@ -1,4 +1,4 @@
-# Random Leader Scheduler
+# Out Of Order Blocks
 
 The [deterministic leader schedule](../tree/master/book/src/leader-rotation.md)
 creates a fixed schedule for block production.  The main problems with this

--- a/book/src/out-of-order-blocks.md
+++ b/book/src/out-of-order-blocks.md
@@ -106,6 +106,16 @@ block.  The reason why the two paths could be different is because Leader 1 may
 complete the block for slot 1 and Leader 2 may decide to attach block 2 to block
 1.
 
+### Ahead of time Execution
+
+Once the leader finds the golden ticket, it can transmit it to the network.  The
+network can choose from the earliest golden ticket as the next leader and start
+forwarding packets to that leader.
+
+It may be necessary to start the leader at the *N+X* block to allow for the
+golden ticket to propagate and for enough transactions to be forwarded to the
+leader so it can start executing them ahead of its block.
+
 ### Grinding
 
 If it is possible to build hardware that is much faster than the expected time

--- a/book/src/random-leader-scheduler.md
+++ b/book/src/random-leader-scheduler.md
@@ -1,0 +1,90 @@
+# Random Leader Scheduler
+
+The [deterministic leader schedule](../tree/master/book/src/leader-rotation.md)
+creates a fixed schedule for block production.  The main problems with this
+approach are as follows:
+
+* The leader schedule has to balance both performance and liveness requirements.
+The epoch needs to be long enough to guarantee liveness.
+
+* The cluster has to wait for unavailable nodes.
+
+* The cluster's liveness depends on the availability of scheduled nodes.
+
+* Attackers know in advance all of the leaders that propose a block.
+
+The general problems of DPOS — that a cluster requires an interactive protocol
+for account registration, delegation, and voting that a set of leaders can
+censor — is not addressed in this design.
+
+## Random Leaders
+
+Leaders can generate a *golden ticket* to propose a block.
+
+* *N* number of bits of a leader's vote signature that must match a PoH hash.
+This hash can be in between ticks.
+
+The leader must find the golden ticket in the empty PoH entries leading up to
+the proposed block.  Once the golden ticket is found, the leader can propose the
+next slot.  The leader signs the BlockHash of the block that the entries are
+generated from with a Vote.  Since each validator is resetting its PoH every
+time it votes, each validator can search for a golden ticket from that starting
+point.
+
+The same proposed [fork selection]/fork-selection.md) rules apply.  Once a block
+is voted on, the validator would switch its PoH to reset on this new block, and
+either a new golden ticket block is proposed, or the next scheduled leader
+proposes a block.
+
+To make it easy to verify, the vote with the golden ticket must be present in
+the proposed block as the first transaction.
+
+#### Grinding
+
+Because the golden ticket is biasable, the last leader has the most opportunity
+to influence the BlockHash to generate the golden ticket for itself.  This
+BlockHash could be a grinding attack with N cores.  Grinding should be a limited
+attack vector, since the difficulty is determined by the size of the delegates
+to the leaders’ VoteState account.
+
+To reduce the ability to grind the value, the golden ticket must appear *X*
+ticks after the block, where *X* is half of the number of ticks per block.
+
+#### Difficulty
+
+Difficulty is the number of matching bits that the golden ticket needs to match
+the signature.
+
+The golden ticket connects via PoH entries to a known block with an immutable
+account balance.  So, a simple token balance can be used to set the difficulty.
+Hashing with 1 account has been delegated 100 tokens should generate as many
+tickets as 2 accounts with 50 delegated tokens.
+
+Given the total delegated state size for the epoch, the difficulty can be
+computed with the leader scheduler.
+
+#### Generating VDFs for Multiple Forks
+
+The number of potential forks the attacker can choose from is limited by
+the fork selection algorithm.  The generated golden ticket needs to be past the
+lockout distance for the rest of the cluster and also be the heaviest fork
+based on lockout.  Let’s say the difficulty was set to the cluster generating a
+golden ticket block every 3 slots.
+
+For example,
+
+starting with ‘n - 3’ forks, the proposed block would only be valid if no one in
+the cluster voted.  If they did, the golden ticket would need to be in the ‘n +
+7’ slot and propose the n + 8 block.
+
+#### Transaction Ingress Point
+
+Because there is no deterministic ingress point, there is no place for
+validators to forward transactions.  This design will end up requiring a shared
+*mempool* of transactions between all the nodes, just like traditional PoW
+systems.
+
+The validators already transmit their votes through gossip, so the golden ticket
+block can pick up the validator votes and any additional transactions that have
+not been encoded into the ledger.  These transactions could come from rejected
+forks.


### PR DESCRIPTION
#### Problem

The [current implementation](../tree/master/book/src/leader-rotation.md) has a predetermined schedule for leaders to propose a block.  The main problems with this approach are:

* leader schedule has to balance both performance and liveness requirements
* cluster has to wait for unavailable nodes
* cluster liveness depends on availability of scheduled nodes
* attackers know in advance all the leaders that propose a block

#### Summary of Changes

Add a design that would allow leaders to generate out of order blocks.

Fixes #2318
