### PR TITLE
Change EpochSlots to use BtreeSet

### DIFF
--- a/core/src/cluster_info.rs
+++ b/core/src/cluster_info.rs
@@ -40,7 +40,7 @@ use solana_sdk::signature::{Keypair, KeypairUtil, Signable, Signature};
 use solana_sdk::timing::{duration_as_ms, timestamp};
 use solana_sdk::transaction::Transaction;
 use std::cmp::min;
-use std::collections::HashSet;
+use std::collections::BTreeSet;
 use std::fmt;
 use std::io;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr, UdpSocket};
@@ -306,7 +306,7 @@ impl ClusterInfo {
         }
     }
 
-    pub fn push_epoch_slots(&mut self, id: Pubkey, root: u64, slots: HashSet<u64>) {
+    pub fn push_epoch_slots(&mut self, id: Pubkey, root: u64, slots: BTreeSet<u64>) {
         let now = timestamp();
         let mut entry = CrdsValue::EpochSlots(EpochSlots::new(id, root, slots, now));
         entry.sign(&self.keypair);
@@ -1205,11 +1205,13 @@ impl ClusterInfo {
     ) -> Vec<SharedBlob> {
         let self_id = me.read().unwrap().gossip.id;
         inc_new_counter_debug!("cluster_info-push_message", 1, 0, 1000);
+
         let prunes: Vec<_> = me
             .write()
             .unwrap()
             .gossip
             .process_push_message(data, timestamp());
+
         if !prunes.is_empty() {
             inc_new_counter_debug!("cluster_info-push_message-prunes", prunes.len());
             let ci = me.read().unwrap().lookup(from).cloned();

--- a/core/src/cluster_info_repair_listener.rs
+++ b/core/src/cluster_info_repair_listener.rs
@@ -444,7 +444,7 @@ mod tests {
     use crate::blocktree::tests::make_many_slot_entries;
     use crate::packet::{Blob, SharedBlob};
     use crate::streamer;
-    use std::collections::HashSet;
+    use std::collections::BTreeSet;
     use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::mpsc::channel;
     use std::sync::mpsc::Receiver;
@@ -528,7 +528,7 @@ mod tests {
         // Set up the repairee's EpochSlots, such that they are missing every odd indexed slot
         // in the range (repairee_root, num_slots]
         let repairee_root = 0;
-        let repairee_slots: HashSet<_> = (0..=num_slots).step_by(2).collect();
+        let repairee_slots: BTreeSet<_> = (0..=num_slots).step_by(2).collect();
         let repairee_epoch_slots =
             EpochSlots::new(mock_repairee.id, repairee_root, repairee_slots, 1);
 
@@ -608,7 +608,7 @@ mod tests {
         // Thus, no repairmen should send any blobs to this repairee b/c this repairee
         // already has all the slots for which they have a confirmed leader schedule
         let repairee_root = 0;
-        let repairee_slots: HashSet<_> = (0..=slots_per_epoch).collect();
+        let repairee_slots: BTreeSet<_> = (0..=slots_per_epoch).collect();
         let repairee_epoch_slots =
             EpochSlots::new(mock_repairee.id, repairee_root, repairee_slots.clone(), 1);
 


### PR DESCRIPTION
#### Problem
Serializing then deserializing then reserializing HashSet can change its serialized representation, since element ordering is not guaranteed. This can cause signature verification to fail in gossip for any objects containing HashSets

#### Summary of Changes
Change EpochSlots to use BtreeSets, which have fixed iteration order

Fixes #
