### PR TITLE
Add credit-only info to AccountMetadata

### DIFF
--- a/programs/config_api/src/config_processor.rs
+++ b/programs/config_api/src/config_processor.rs
@@ -153,7 +153,7 @@ mod tests {
         let config_pubkey = config_keypair.pubkey();
 
         let transfer_instruction =
-            system_instruction::transfer(&system_pubkey, &Pubkey::default(), 42);
+            system_instruction::transfer(&system_pubkey, &Pubkey::new_rand(), 42);
         let my_config = MyConfig::new(42);
         let mut store_instruction = config_instruction::store(&config_pubkey, &my_config);
         store_instruction.accounts[0].is_signer = false; // <----- not a signer

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -626,7 +626,7 @@ mod tests {
         let accounts: Vec<(Pubkey, Account)> = Vec::new();
         let mut error_counters = ErrorCounters::default();
 
-        let instructions = vec![CompiledInstruction::new(1, &(), vec![0])];
+        let instructions = vec![CompiledInstruction::new(0, &(), vec![0])];
         let tx = Transaction::new_with_compiled_instructions::<Keypair>(
             &[],
             &[],

--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -227,9 +227,9 @@ impl MessageProcessor {
             let executable_accounts = &mut loaders[executable_index];
             let mut program_accounts = get_subset_unchecked_mut(accounts, &instruction.accounts)
                 .map_err(|err| TransactionError::InstructionError(instruction_index as u8, err))?;
-            // TODO: previous expression breaks if an executable account is also included as a
-            // regular account for an instruction, because the executable account is not passed in
-            // as part of the accounts slice
+            // TODO: `get_subset_unchecked_mut` panics on an index out of bounds if an executable
+            // account is also included as a regular account for an instruction, because the
+            // executable account is not passed in as part of the accounts slice
             self.execute_instruction(
                 message,
                 instruction,

--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -221,10 +221,15 @@ impl MessageProcessor {
         tick_height: u64,
     ) -> Result<(), TransactionError> {
         for (instruction_index, instruction) in message.instructions.iter().enumerate() {
-            let executable_accounts = &mut loaders
-                [message.program_index_in_program_ids(instruction.program_ids_index) as usize];
+            let executable_index = message
+                .program_index_in_program_ids(instruction.program_ids_index as usize)
+                .ok_or(TransactionError::InvalidAccountIndex)?;
+            let executable_accounts = &mut loaders[executable_index];
             let mut program_accounts = get_subset_unchecked_mut(accounts, &instruction.accounts)
                 .map_err(|err| TransactionError::InstructionError(instruction_index as u8, err))?;
+            // TODO: previous expression breaks if an executable account is also included as a
+            // regular account for an instruction, because the executable account is not passed in
+            // as part of the accounts slice
             self.execute_instruction(
                 message,
                 instruction,

--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -222,7 +222,7 @@ impl MessageProcessor {
     ) -> Result<(), TransactionError> {
         for (instruction_index, instruction) in message.instructions.iter().enumerate() {
             let executable_index = message
-                .program_index_in_program_ids(instruction.program_ids_index as usize)
+                .program_position(instruction.program_ids_index as usize)
                 .ok_or(TransactionError::InvalidAccountIndex)?;
             let executable_accounts = &mut loaders[executable_index];
             let mut program_accounts = get_subset_unchecked_mut(accounts, &instruction.accounts)

--- a/sdk/src/instruction.rs
+++ b/sdk/src/instruction.rs
@@ -96,8 +96,8 @@ pub struct AccountMeta {
     pub pubkey: Pubkey,
     /// True if an Instruciton requires a Transaction signature matching `pubkey`.
     pub is_signer: bool,
-    /// True if the `pubkey` can be loaded as a credit-only account.
-    pub is_credit_only: bool,
+    /// True if the `pubkey` can be loaded as a credit-debit account.
+    pub is_debitable: bool,
 }
 
 impl AccountMeta {
@@ -105,7 +105,7 @@ impl AccountMeta {
         Self {
             pubkey,
             is_signer,
-            is_credit_only: false,
+            is_debitable: true,
         }
     }
 
@@ -113,7 +113,7 @@ impl AccountMeta {
         Self {
             pubkey,
             is_signer,
-            is_credit_only: true,
+            is_debitable: false,
         }
     }
 }

--- a/sdk/src/instruction.rs
+++ b/sdk/src/instruction.rs
@@ -96,11 +96,25 @@ pub struct AccountMeta {
     pub pubkey: Pubkey,
     /// True if an Instruciton requires a Transaction signature matching `pubkey`.
     pub is_signer: bool,
+    /// True if the `pubkey` can be loaded as a credit-only account.
+    pub is_credit_only: bool,
 }
 
 impl AccountMeta {
     pub fn new(pubkey: Pubkey, is_signer: bool) -> Self {
-        Self { pubkey, is_signer }
+        Self {
+            pubkey,
+            is_signer,
+            is_credit_only: false,
+        }
+    }
+
+    pub fn new_credit_only(pubkey: Pubkey, is_signer: bool) -> Self {
+        Self {
+            pubkey,
+            is_signer,
+            is_credit_only: true,
+        }
     }
 }
 

--- a/sdk/src/message.rs
+++ b/sdk/src/message.rs
@@ -43,7 +43,7 @@ fn get_keys(
         .map(|program_id| AccountMeta {
             pubkey: *program_id,
             is_signer: false,
-            is_credit_only: true,
+            is_debitable: false,
         })
         .collect();
     let mut keys_and_signed: Vec<_> = instructions
@@ -54,7 +54,7 @@ fn get_keys(
     keys_and_signed.sort_by(|x, y| {
         y.is_signer
             .cmp(&x.is_signer)
-            .then(x.is_credit_only.cmp(&y.is_credit_only))
+            .then(y.is_debitable.cmp(&x.is_debitable))
     });
 
     let payer_account_meta;
@@ -62,7 +62,7 @@ fn get_keys(
         payer_account_meta = AccountMeta {
             pubkey: *payer,
             is_signer: true,
-            is_credit_only: false,
+            is_debitable: true,
         };
         keys_and_signed.insert(0, &payer_account_meta);
     }
@@ -74,12 +74,12 @@ fn get_keys(
     for account_meta in keys_and_signed.into_iter().unique_by(|x| x.pubkey) {
         if account_meta.is_signer {
             signed_keys.push(account_meta.pubkey);
-            if account_meta.is_credit_only {
+            if !account_meta.is_debitable {
                 num_credit_only_signed_accounts += 1;
             }
         } else {
             unsigned_keys.push(account_meta.pubkey);
-            if account_meta.is_credit_only {
+            if !account_meta.is_debitable {
                 num_credit_only_unsigned_accounts += 1;
             }
         }

--- a/sdk/src/transaction.rs
+++ b/sdk/src/transaction.rs
@@ -246,7 +246,7 @@ mod tests {
     fn get_program_id(tx: &Transaction, instruction_index: usize) -> &Pubkey {
         let message = tx.message();
         let instruction = &message.instructions[instruction_index];
-        instruction.program_id(message.program_ids())
+        instruction.program_id(&message.account_keys)
     }
 
     #[test]
@@ -257,8 +257,8 @@ mod tests {
         let prog1 = Pubkey::new_rand();
         let prog2 = Pubkey::new_rand();
         let instructions = vec![
-            CompiledInstruction::new(0, &(), vec![0, 1]),
-            CompiledInstruction::new(1, &(), vec![0, 2]),
+            CompiledInstruction::new(3, &(), vec![0, 1]),
+            CompiledInstruction::new(4, &(), vec![0, 2]),
         ];
         let tx = Transaction::new_with_compiled_instructions(
             &[&key],
@@ -306,7 +306,7 @@ mod tests {
     #[test]
     fn test_refs_invalid_account() {
         let key = Keypair::new();
-        let instructions = vec![CompiledInstruction::new(0, &(), vec![2])];
+        let instructions = vec![CompiledInstruction::new(1, &(), vec![2])];
         let tx = Transaction::new_with_compiled_instructions(
             &[&key],
             &[],


### PR DESCRIPTION
#### Problem
Currently, only programs are being classified as credit-only (CO) accounts because there is no way to identify other account keys as CO

#### Summary of Changes
- Adds `is_credit_only` field to AccountMeta; AccountMeta::new() defaults to credit-debit
- Includes all CO accounts in Message::get_keys to be sorted and deduped
- Adds `get_account_keys_by_lock_type` api, which will be needed to plumb CO account handling into runtime

Toward #4168 
