### PR TITLE
Reduce bench-tps 100ms sleep to 1ms.

### DIFF
--- a/bench-tps/src/bench.rs
+++ b/bench-tps/src/bench.rs
@@ -165,7 +165,7 @@ where
         // in tested environments.
         if !sustained {
             while shared_tx_active_thread_count.load(Ordering::Relaxed) > 0 {
-                sleep(Duration::from_millis(100));
+                sleep(Duration::from_millis(1));
             }
         }
 


### PR DESCRIPTION
#### Problem

100ms is really long.

#### Summary of Changes

Make the sleep 1ms.

Fixes #
