### PR TITLE
Fix issues in ClusterInfoRepairListener

### DIFF
--- a/core/src/cluster_info_repair_listener.rs
+++ b/core/src/cluster_info_repair_listener.rs
@@ -21,7 +21,7 @@ use std::thread::{self, sleep, Builder, JoinHandle};
 use std::time::Duration;
 
 pub const REPAIRMEN_SLEEP_MILLIS: usize = 100;
-pub const REPAIR_REDUNDANCY: usize = 3;
+pub const REPAIR_REDUNDANCY: usize = 1;
 pub const NUM_BUFFER_SLOTS: usize = 50;
 pub const GOSSIP_DELAY_SLOTS: usize = 2;
 pub const NUM_SLOTS_PER_UPDATE: usize = 2;

--- a/core/src/cluster_info_repair_listener.rs
+++ b/core/src/cluster_info_repair_listener.rs
@@ -389,6 +389,7 @@ impl ClusterInfoRepairListener {
             .collect();
 
         repairmen.push(my_pubkey);
+        repairmen.sort();
         repairmen
     }
 


### PR DESCRIPTION
#### Problem
1) HashMap iteration order is not guaranteed, so repairmen don't all order their peers the same way before shuffling. This leads to nondeterministic repairmen ordering.
2) Repair redundancy can be 1 for now, erasure should already add the needed redundancy
3) The local peer_roots structure doesn't get updated when we don't send a repair to a peer. This means other information about other peers' roots is lost if we don't need to update them, but we need this information to calculate who are eligible repairmen/how to divide up the repairing work.

#### Summary of Changes
Fix 1) in first commit
Fix 2) in second commit
Fix 3) in commits 3 + 4. We now only update the local timestamp if we actually send a repair to a repairee, but we always update the root.

Fixes #
