### PR TITLE
Include perf-libs in release tarball

### DIFF
--- a/build-perf-libs.sh
+++ b/build-perf-libs.sh
@@ -12,8 +12,12 @@ if [[ -d target/perf-libs ]]; then
   exit 1
 fi
 
-set -x
-git clone git@github.com:solana-labs/solana-perf-libs.git target/perf-libs
-cd target/perf-libs
-make -j"$(nproc)"
-make DESTDIR=. install
+(
+  set -x
+  git clone git@github.com:solana-labs/solana-perf-libs.git target/perf-libs
+  cd target/perf-libs
+  make -j"$(nproc)"
+  make DESTDIR=. install
+)
+
+./fetch-perf-libs.sh

--- a/ci/publish-tarball.sh
+++ b/ci/publish-tarball.sh
@@ -48,7 +48,7 @@ echo --- Creating tarball
   COMMIT="$(git rev-parse HEAD)"
 
   (
-    echo "channel: $CHANNEL"
+    echo "channel: $CHANNEL_OR_TAG"
     echo "commit: $COMMIT"
     echo "target: $TARGET"
   ) > solana-release/version.yml
@@ -57,6 +57,9 @@ echo --- Creating tarball
   scripts/cargo-install-all.sh +"$rust_stable" solana-release
 
   ./fetch-perf-libs.sh
+  mkdir solana-release/target
+  cp -a target/perf-libs solana-release/target/
+
   # shellcheck source=/dev/null
   source ./target/perf-libs/env.sh
   (

--- a/fetch-perf-libs.sh
+++ b/fetch-perf-libs.sh
@@ -1,55 +1,63 @@
 #!/usr/bin/env bash
 set -e
+cd "$(dirname "$0")"
 
-if [[ $(uname) != Linux ]]; then
-  echo Performance libraries are only available for Linux
-  exit 1
-fi
+if [[ ! -d target/perf-libs ]]; then
+  if [[ $(uname) != Linux ]]; then
+    echo Performance libraries are only available for Linux
+    exit 1
+  fi
 
-if [[ $(uname -m) != x86_64 ]]; then
-  echo Performance libraries are only available for x86_64 architecture
-  exit 1
-fi
+  if [[ $(uname -m) != x86_64 ]]; then
+    echo Performance libraries are only available for x86_64 architecture
+    exit 1
+  fi
 
-mkdir -p target/perf-libs
-(
+  mkdir -p target/perf-libs
   cd target/perf-libs
   (
     set -x
     curl https://solana-perf.s3.amazonaws.com/v0.12.1/x86_64-unknown-linux-gnu/solana-perf.tgz | tar zxvf -
   )
 
-  if [[ -r solana-perf-CUDA_HOME.txt ]]; then
-    CUDA_HOME=$(cat solana-perf-CUDA_HOME.txt)
-  else
-    CUDA_HOME=/usr/local/cuda
-  fi
+  echo "Downloaded solana-perf version: $(cat solana-perf-HEAD.txt)"
+fi
 
-  echo CUDA_HOME="$CUDA_HOME"
-  if [[ -r "$CUDA_HOME"/version.txt && -r cuda-version.txt ]]; then
-    if ! diff "$CUDA_HOME"/version.txt cuda-version.txt > /dev/null; then
-        echo ==============================================
-        echo "Warning: possible CUDA version mismatch with $CUDA_HOME"
-        echo
-        echo "Expected version: $(cat cuda-version.txt)"
-        echo "Detected version: $(cat "$CUDA_HOME"/version.txt)"
-        echo ==============================================
-    fi
-  else
-    echo ==============================================
-    echo Warning: unable to validate CUDA version
-    echo ==============================================
-  fi
+cat > env.sh <<'EOF'
+SOLANA_PERF_LIBS="$(dirname "${BASH_SOURCE[0]}")"
 
-  cat > env.sh <<EOF
-export CUDA_HOME=$CUDA_HOME
-export LD_LIBRARY_PATH="$PWD:$CUDA_HOME/lib64:$LD_LIBRARY_PATH"
-export PATH="$PATH:$CUDA_HOME/bin"
+if [[ -r "$SOLANA_PERF_LIBS"/solana-perf-CUDA_HOME.txt ]]; then
+  CUDA_HOME=$(cat "$SOLANA_PERF_LIBS"/solana-perf-CUDA_HOME.txt)
+else
+  CUDA_HOME=/usr/local/cuda
+fi
+
+echo CUDA_HOME="$CUDA_HOME"
+export CUDA_HOME="$CUDA_HOME"
+
+echo LD_LIBRARY_PATH="$SOLANA_PERF_LIBS:$CUDA_HOME/lib64:$LD_LIBRARY_PATH"
+export LD_LIBRARY_PATH="$SOLANA_PERF_LIBS:$CUDA_HOME/lib64:$LD_LIBRARY_PATH"
+
+echo PATH="$SOLANA_PERF_LIBS:$CUDA_HOME/bin:$PATH"
+export PATH="$SOLANA_PERF_LIBS:$CUDA_HOME/bin:$PATH"
+
+if [[ -r "$CUDA_HOME"/version.txt && -r $SOLANA_PERF_LIBS/cuda-version.txt ]]; then
+  if ! diff "$CUDA_HOME"/version.txt "$SOLANA_PERF_LIBS"/cuda-version.txt > /dev/null; then
+      echo ==============================================
+      echo "Warning: possible CUDA version mismatch with $CUDA_HOME"
+      echo
+      echo "Expected version: $(cat "$SOLANA_PERF_LIBS"/cuda-version.txt)"
+      echo "Detected version: $(cat "$CUDA_HOME"/version.txt)"
+      echo ==============================================
+  fi
+else
+  echo ==============================================
+  echo Warning: unable to validate CUDA version
+  echo ==============================================
+fi
+
 EOF
 
-  echo "Downloaded solana-perf version: $(cat solana-perf-HEAD.txt)"
-  echo
-  echo "source ./target/perf-libs/env.sh to setup compatible build environment"
-)
-
+echo
+echo "source ./target/perf-libs/env.sh to setup environment"
 exit 0

--- a/multinode-demo/common.sh
+++ b/multinode-demo/common.sh
@@ -20,6 +20,11 @@ if [[ $(uname) != Linux ]]; then
   fi
 fi
 
+if [[ -f "$SOLANA_ROOT"/target/perf-libs/env.sh ]]; then
+  # shellcheck source=/dev/null
+  source "$SOLANA_ROOT"/target/perf-libs/env.sh
+fi
+
 if [[ -n $USE_INSTALL || ! -f "$SOLANA_ROOT"/Cargo.toml ]]; then
   solana_program() {
     declare program="$1"
@@ -46,9 +51,6 @@ else
     declare manifest_path="--manifest-path=$SOLANA_ROOT/$program/Cargo.toml"
     printf "cargo run $manifest_path $maybe_release $maybe_package --bin solana-%s %s -- " "$program" "$features"
   }
-  # shellcheck disable=2154 # 'here' is referenced but not assigned
-  LD_LIBRARY_PATH=$(cd "$SOLANA_ROOT/target/perf-libs" && pwd):$LD_LIBRARY_PATH
-  export LD_LIBRARY_PATH
 fi
 
 solana_bench_tps=$(solana_program bench-tps)


### PR DESCRIPTION
Ship perf-libs directly in the release tarball so `SOLANA_CUDA=1` works out of the box
