### PR TITLE
Plumb ClusterInfoRepairListener

### DIFF
--- a/core/src/cluster_info_repair_listener.rs
+++ b/core/src/cluster_info_repair_listener.rs
@@ -958,8 +958,8 @@ mod tests {
 
         // 3) There should only be repairmen who are not responsible for repairing this slot
         // if we have more repairman than `num_blobs_in_slot * repair_redundancy`. In this case the
-        // first `num_blobs_in_slot * repair_redundancy` repairmen woudl send one blob, and the rest
-        // would noe be responsible for sending any repairs
+        // first `num_blobs_in_slot * repair_redundancy` repairmen would send one blob, and the rest
+        // would not be responsible for sending any repairs
         assert_eq!(
             none_results,
             num_repairmen.saturating_sub(num_blobs_in_slot * repair_redundancy)

--- a/core/src/cluster_tests.rs
+++ b/core/src/cluster_tests.rs
@@ -20,6 +20,7 @@ use solana_sdk::timing::{
     NUM_CONSECUTIVE_LEADER_SLOTS,
 };
 use solana_sdk::transport::TransportError;
+use std::cmp::max;
 use std::thread::sleep;
 use std::time::Duration;
 
@@ -85,14 +86,18 @@ pub fn fullnode_exit(entry_point_info: &ContactInfo, nodes: usize) {
     }
 }
 
-pub fn verify_ledger_ticks(ledger_path: &str, ticks_per_slot: usize) {
+pub fn verify_ledger_ticks(ledger_path: &str, ticks_per_slot: usize) -> u64 {
     let ledger = Blocktree::open(ledger_path).unwrap();
+    let mut greatest_slot = 0;
     let zeroth_slot = ledger.get_slot_entries(0, 0, None).unwrap();
     let last_id = zeroth_slot.last().unwrap().hash;
     let next_slots = ledger.get_slots_since(&[0]).unwrap().remove(&0).unwrap();
     let mut pending_slots: Vec<_> = next_slots
         .into_iter()
-        .map(|slot| (slot, 0, last_id))
+        .map(|slot| {
+            greatest_slot = max(slot, greatest_slot);
+            (slot, 0, last_id)
+        })
         .collect();
     while !pending_slots.is_empty() {
         let (slot, parent_slot, last_id) = pending_slots.pop().unwrap();
@@ -116,6 +121,8 @@ pub fn verify_ledger_ticks(ledger_path: &str, ticks_per_slot: usize) {
                 .map(|child_slot| (child_slot, slot, last_id)),
         );
     }
+
+    greatest_slot
 }
 
 pub fn sleep_n_epochs(

--- a/core/src/leader_schedule_cache.rs
+++ b/core/src/leader_schedule_cache.rs
@@ -103,7 +103,7 @@ impl LeaderScheduleCache {
         // Forbid asking for slots in an unconfirmed epoch
         let bank_epoch = self.epoch_schedule.get_epoch_and_slot_index(slot).0;
         if bank_epoch > *self.max_epoch.read().unwrap() {
-            error!(
+            debug!(
                 "Requested leader in slot: {} of unconfirmed epoch: {}",
                 slot, bank_epoch
             );

--- a/core/src/local_cluster.rs
+++ b/core/src/local_cluster.rs
@@ -64,6 +64,7 @@ pub struct ClusterConfig {
     pub cluster_lamports: u64,
     pub ticks_per_slot: u64,
     pub slots_per_epoch: u64,
+    pub stakers_slot_offset: u64,
     pub native_instruction_processors: Vec<(String, Pubkey)>,
     pub poh_config: PohConfig,
 }
@@ -78,6 +79,7 @@ impl Default for ClusterConfig {
             cluster_lamports: 0,
             ticks_per_slot: DEFAULT_TICKS_PER_SLOT,
             slots_per_epoch: DEFAULT_SLOTS_PER_EPOCH,
+            stakers_slot_offset: DEFAULT_SLOTS_PER_EPOCH,
             native_instruction_processors: vec![],
             poh_config: PohConfig::default(),
         }
@@ -130,6 +132,7 @@ impl LocalCluster {
         );
         genesis_block.ticks_per_slot = config.ticks_per_slot;
         genesis_block.slots_per_epoch = config.slots_per_epoch;
+        genesis_block.stakers_slot_offset = config.stakers_slot_offset;
         genesis_block.poh_config = config.poh_config.clone();
         genesis_block
             .native_instruction_processors

--- a/core/src/local_cluster.rs
+++ b/core/src/local_cluster.rs
@@ -223,7 +223,7 @@ impl LocalCluster {
         }
     }
 
-    fn add_validator(&mut self, validator_config: &ValidatorConfig, stake: u64) {
+    pub fn add_validator(&mut self, validator_config: &ValidatorConfig, stake: u64) {
         let client = create_client(
             self.entry_point_info.client_facing_addr(),
             FULLNODE_PORT_RANGE,

--- a/core/src/repair_service.rs
+++ b/core/src/repair_service.rs
@@ -4,6 +4,7 @@
 use crate::bank_forks::BankForks;
 use crate::blocktree::{Blocktree, CompletedSlotsReceiver, SlotMeta};
 use crate::cluster_info::ClusterInfo;
+use crate::cluster_info_repair_listener::ClusterInfoRepairListener;
 use crate::result::Result;
 use crate::service::Service;
 use solana_metrics::datapoint_info;
@@ -56,23 +57,36 @@ impl Default for RepairSlotRange {
 
 pub struct RepairService {
     t_repair: JoinHandle<()>,
+    cluster_info_repair_listener: Option<ClusterInfoRepairListener>,
 }
 
 impl RepairService {
     pub fn new(
         blocktree: Arc<Blocktree>,
-        exit: &Arc<AtomicBool>,
+        exit: Arc<AtomicBool>,
         repair_socket: Arc<UdpSocket>,
         cluster_info: Arc<RwLock<ClusterInfo>>,
         repair_strategy: RepairStrategy,
     ) -> Self {
-        let exit = exit.clone();
+        let cluster_info_repair_listener = match repair_strategy {
+            RepairStrategy::RepairAll {
+                ref epoch_schedule, ..
+            } => Some(ClusterInfoRepairListener::new(
+                &blocktree,
+                &exit,
+                cluster_info.clone(),
+                epoch_schedule.clone(),
+            )),
+
+            _ => None,
+        };
+
         let t_repair = Builder::new()
             .name("solana-repair-service".to_string())
             .spawn(move || {
                 Self::run(
                     &blocktree,
-                    exit,
+                    &exit,
                     &repair_socket,
                     &cluster_info,
                     repair_strategy,
@@ -80,12 +94,15 @@ impl RepairService {
             })
             .unwrap();
 
-        RepairService { t_repair }
+        RepairService {
+            t_repair,
+            cluster_info_repair_listener,
+        }
     }
 
     fn run(
         blocktree: &Arc<Blocktree>,
-        exit: Arc<AtomicBool>,
+        exit: &Arc<AtomicBool>,
         repair_socket: &Arc<UdpSocket>,
         cluster_info: &Arc<RwLock<ClusterInfo>>,
         repair_strategy: RepairStrategy,
@@ -373,7 +390,14 @@ impl Service for RepairService {
     type JoinReturnType = ();
 
     fn join(self) -> thread::Result<()> {
-        self.t_repair.join()
+        let mut results = vec![self.t_repair.join()];
+        if let Some(cluster_info_repair_listener) = self.cluster_info_repair_listener {
+            results.push(cluster_info_repair_listener.join());
+        }
+        for r in results {
+            r?;
+        }
+        Ok(())
     }
 }
 

--- a/core/src/repair_service.rs
+++ b/core/src/repair_service.rs
@@ -75,7 +75,7 @@ impl RepairService {
                 &blocktree,
                 &exit,
                 cluster_info.clone(),
-                epoch_schedule.clone(),
+                *epoch_schedule,
             )),
 
             _ => None,

--- a/core/tests/local_cluster.rs
+++ b/core/tests/local_cluster.rs
@@ -212,7 +212,7 @@ fn test_listener_startup() {
 fn test_repairman_catchup() {
     let mut validator_config = ValidatorConfig::default();
     let num_ticks_per_second = 100;
-    let num_ticks_per_slot = 10;
+    let num_ticks_per_slot = 40;
     let num_slots_per_epoch = MINIMUM_SLOT_LENGTH as u64;
 
     validator_config.rpc_config.enable_fullnode_exit = true;
@@ -230,7 +230,7 @@ fn test_repairman_catchup() {
     cluster_tests::sleep_n_epochs(
         5.0,
         &cluster.genesis_block.poh_config,
-        timing::DEFAULT_TICKS_PER_SLOT,
+        num_ticks_per_slot,
         num_slots_per_epoch,
     );
 
@@ -242,7 +242,7 @@ fn test_repairman_catchup() {
     cluster_tests::sleep_n_epochs(
         3.0,
         &cluster.genesis_block.poh_config,
-        timing::DEFAULT_TICKS_PER_SLOT,
+        num_ticks_per_slot,
         num_slots_per_epoch,
     );
 

--- a/core/tests/local_cluster.rs
+++ b/core/tests/local_cluster.rs
@@ -2,6 +2,7 @@ extern crate solana;
 
 use crate::solana::blocktree::Blocktree;
 use hashbrown::HashSet;
+use log::*;
 use solana::cluster::Cluster;
 use solana::cluster_tests;
 use solana::gossip_service::discover_cluster;
@@ -302,5 +303,13 @@ fn run_repairman_catchup(num_repairmen: u64) {
     let validator_ledger = Blocktree::open(&validator_ledger_path).unwrap();
     let validator_rooted_slots: Vec<_> =
         validator_ledger.rooted_slot_iterator(0).unwrap().collect();
+
+    if validator_rooted_slots.len() as u64 <= num_expected_slots {
+        error!(
+            "Num expected slots: {}, number of rooted slots: {}",
+            num_expected_slots,
+            validator_rooted_slots.len()
+        );
+    }
     assert!(validator_rooted_slots.len() as u64 > num_expected_slots);
 }


### PR DESCRIPTION
#### Problem
ClusterInfoRepairListener is not currently integrated into fullnode.

#### Summary of Changes
1) Start a ClusterInfoRepairListener in RepairService
2) Throw out blobs we don't have a leader schedule for in WindowService instead of retaining them
3) Add a LocalCluster test for testing catchup when the cluster is beyond the known leader schedule of a repairee

Fixes #
https://github.com/solana-labs/solana/issues/3230