### PR TITLE
Clone bpf-sdk repo with https for Travis

### DIFF
--- a/sdk/bpf/scripts/install.sh
+++ b/sdk/bpf/scripts/install.sh
@@ -95,9 +95,9 @@ if [[ ! -f rust-bpf-sysroot-$version.md ]]; then
 
     set -ex
     rm -rf rust-bpf-sysroot*
-    git clone --recursive --single-branch --branch $version git@github.com:solana-labs/rust-bpf-sysroot.git
+    git clone --recursive --single-branch --branch $version https://github.com/solana-labs/rust-bpf-sysroot.git
 
-    echo "git clone --recursive --single-branch --branch $version git@github.com:solana-labs/rust-bpf-sysroot.git" > rust-bpf-sysroot-$version.md
+    echo "git clone --recursive --single-branch --branch $version https://github.com/solana-labs/rust-bpf-sysroot.git" > rust-bpf-sysroot-$version.md
   )
   exitcode=$?
   if [[ $exitcode -ne 0 ]]; then


### PR DESCRIPTION
#### Problem
solana-web3.js fails in CI with `git clone` Permission denied (publickey) error in bpf-sdk
Travis CI requires use of https instead of ssh to clone repos with submodules: https://docs.travis-ci.com/user/common-build-problems/#git-cannot-clone-my-submodules

#### Summary of Changes
Change from ssh to https
