### PR TITLE
net/:  Add solana-install test to sanity

### DIFF
--- a/net/gce.sh
+++ b/net/gce.sh
@@ -522,19 +522,26 @@ create)
 
   printNetworkInfo() {
     cat <<EOF
-========================================================================================
-
-Network composition:
+==[ Network composition ]===============================================================
   Bootstrap leader = $bootstrapLeaderMachineType (GPU=$enableGpu)
   Additional fullnodes = $additionalFullNodeCount x $fullNodeMachineType
   Client(s) = $clientNodeCount x $clientMachineType
   Blockstreamer = $blockstreamer
-
 ========================================================================================
 
 EOF
   }
   printNetworkInfo
+
+  creationDate=$(date)
+  creationInfo() {
+    cat <<EOF
+
+  Instance running since: $creationDate
+
+========================================================================================
+EOF
+  }
 
   declare startupScript="$netConfigDir"/instance-startup-script.sh
   cat > "$startupScript" <<EOF
@@ -554,6 +561,7 @@ cat > /etc/motd <<EOM
     $ until [[ -f /.instance-startup-complete ]]; do sleep 1; done
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+$(creationInfo)
 EOM
 
 # Place the generated private key at /solana-id_ecdsa so it's retrievable by anybody
@@ -590,6 +598,7 @@ $(
 
 cat > /etc/motd <<EOM
 $(printNetworkInfo)
+$(creationInfo)
 EOM
 
 touch /.instance-startup-complete

--- a/net/gce.sh
+++ b/net/gce.sh
@@ -587,6 +587,7 @@ $(
     install-nodejs.sh \
     install-redis.sh \
     install-rsync.sh \
+    localtime.sh \
     network-config.sh \
     remove-docker-interface.sh \
 

--- a/net/remote/remote-sanity.sh
+++ b/net/remote/remote-sanity.sh
@@ -69,8 +69,9 @@ local|tar)
   entrypointRsyncUrl="$entrypointIp:~/solana"
 
   solana_gossip=solana-gossip
-  solana_ledger_tool=solana-ledger-tool
+  solana_install=solana-install
   solana_keygen=solana-keygen
+  solana_ledger_tool=solana-ledger-tool
 
   ledger=config-local/bootstrap-leader-ledger
   client_id=config-local/client-id.json
@@ -161,6 +162,23 @@ if $validatorSanity; then
 else
   echo "^^^ +++"
   echo "Note: validator sanity disabled"
+fi
+
+if [[ -r update_manifest_keypair.json ]]; then
+  echo "--- $entrypointIp: solana-install test"
+
+  (
+    set -x
+    update_manifest_pubkey=$($solana_keygen pubkey update_manifest_keypair.json)
+    rm -rf install-data-dir
+    $solana_install init \
+      --no-modify-path \
+      --data-dir install-data-dir \
+      --url http://"$entrypointIp":8899 \
+      --pubkey "$update_manifest_pubkey"
+
+    $solana_install info
+  )
 fi
 
 echo --- Pass

--- a/net/scripts/install-rsync.sh
+++ b/net/scripts/install-rsync.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Rsync setup for Snap builds
+# Rsync setup
 #
 set -ex
 

--- a/net/scripts/localtime.sh
+++ b/net/scripts/localtime.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+#
+# Setup timezone
+#
+set -ex
+
+[[ $(uname) = Linux ]] || exit 1
+[[ $USER = root ]] || exit 1
+
+ln -sf /usr/share/zoneinfo/America/Los_Angeles /etc/localtime


### PR DESCRIPTION
This strengthens the testnet sanity suite to include a `solana-install` check.  We want to ensure `solana-install` works as it's one of the first user entrypoints into a public testnet