### PR TITLE
Unignore test_repairman_catchup 

### DIFF
--- a/core/tests/local_cluster.rs
+++ b/core/tests/local_cluster.rs
@@ -214,7 +214,7 @@ fn test_listener_startup() {
 #[test]
 #[ignore]
 fn test_repairman_catchup() {
-    run_repairman_catchup(5);
+    run_repairman_catchup(3);
 }
 
 fn run_repairman_catchup(num_repairmen: u64) {


### PR DESCRIPTION
#### Problem
Test is flaky due to gossip being slow when simulating too many nodes in local cluster.

#### Summary of Changes
Unignore test, lower number of simulated nodes

Fixes #
