### PR TITLE
Remove genesis blockhash

### DIFF
--- a/core/src/broadcast_stage.rs
+++ b/core/src/broadcast_stage.rs
@@ -333,7 +333,6 @@ mod test {
             entry_receiver,
             &exit_sender,
             &blocktree,
-            &Hash::default(),
         );
 
         MockBroadcastStage {

--- a/core/src/broadcast_stage.rs
+++ b/core/src/broadcast_stage.rs
@@ -14,7 +14,6 @@ use solana_metrics::{
     datapoint, inc_new_counter_debug, inc_new_counter_error, inc_new_counter_info,
     inc_new_counter_warn,
 };
-use solana_sdk::hash::Hash;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::timing::duration_as_ms;
 use std::net::UdpSocket;
@@ -49,7 +48,6 @@ impl Broadcast {
         receiver: &Receiver<WorkingBankEntries>,
         sock: &UdpSocket,
         blocktree: &Arc<Blocktree>,
-        genesis_blockhash: &Hash,
     ) -> Result<()> {
         let timer = Duration::new(1, 0);
         let (mut bank, entries) = receiver.recv_timeout(timer)?;
@@ -114,7 +112,6 @@ impl Broadcast {
         index_blobs_with_genesis(
             &blobs,
             &self.id,
-            genesis_blockhash,
             blob_index,
             bank.slot(),
             bank.parent().map_or(0, |parent| parent.slot()),
@@ -209,7 +206,6 @@ impl BroadcastStage {
         cluster_info: &Arc<RwLock<ClusterInfo>>,
         receiver: &Receiver<WorkingBankEntries>,
         blocktree: &Arc<Blocktree>,
-        genesis_blockhash: &Hash,
     ) -> BroadcastStageReturnType {
         let me = cluster_info.read().unwrap().my_data().clone();
         let coding_generator = CodingGenerator::default();
@@ -221,9 +217,7 @@ impl BroadcastStage {
         };
 
         loop {
-            if let Err(e) =
-                broadcast.run(&cluster_info, receiver, sock, blocktree, genesis_blockhash)
-            {
+            if let Err(e) = broadcast.run(&cluster_info, receiver, sock, blocktree) {
                 match e {
                     Error::RecvTimeoutError(RecvTimeoutError::Disconnected) | Error::SendError => {
                         return BroadcastStageReturnType::ChannelDisconnected;
@@ -261,22 +255,14 @@ impl BroadcastStage {
         receiver: Receiver<WorkingBankEntries>,
         exit_sender: &Arc<AtomicBool>,
         blocktree: &Arc<Blocktree>,
-        genesis_blockhash: &Hash,
     ) -> Self {
         let blocktree = blocktree.clone();
         let exit_sender = exit_sender.clone();
-        let genesis_blockhash = *genesis_blockhash;
         let thread_hdl = Builder::new()
             .name("solana-broadcaster".to_string())
             .spawn(move || {
                 let _finalizer = Finalizer::new(exit_sender);
-                Self::run(
-                    &sock,
-                    &cluster_info,
-                    &receiver,
-                    &blocktree,
-                    &genesis_blockhash,
-                )
+                Self::run(&sock, &cluster_info, &receiver, &blocktree)
             })
             .unwrap();
 

--- a/core/src/chacha.rs
+++ b/core/src/chacha.rs
@@ -154,7 +154,7 @@ mod tests {
         hasher.hash(&buf[..size]);
 
         //  golden needs to be updated if blob stuff changes....
-        let golden: Hash = "9xb2Asf7UK5G8WqPwsvzo5xwLi4dixBSDiYKCtYRikA"
+        let golden: Hash = "HZJWPVZcLtdQg34ov1vq9fjeqbgagHyhn4weLcvFsFnY"
             .parse()
             .unwrap();
 

--- a/core/src/erasure.rs
+++ b/core/src/erasure.rs
@@ -226,10 +226,8 @@ impl CodingGenerator {
                 let index = data_blob.index();
                 let slot = data_blob.slot();
                 let id = data_blob.id();
-                let genesis_blockhash = data_blob.genesis_blockhash();
 
                 let mut coding_blob = Blob::default();
-                coding_blob.set_genesis_blockhash(&genesis_blockhash);
                 coding_blob.set_index(index);
                 coding_blob.set_slot(slot);
                 coding_blob.set_id(&id);

--- a/core/src/packet.rs
+++ b/core/src/packet.rs
@@ -5,7 +5,6 @@ use bincode;
 use byteorder::{ByteOrder, LittleEndian};
 use serde::Serialize;
 use solana_metrics::inc_new_counter_debug;
-use solana_sdk::hash::Hash;
 pub use solana_sdk::packet::PACKET_DATA_SIZE;
 use solana_sdk::pubkey::Pubkey;
 use std::borrow::Borrow;
@@ -333,8 +332,7 @@ const SLOT_RANGE: std::ops::Range<usize> = range!(PARENT_RANGE.end, u64);
 const INDEX_RANGE: std::ops::Range<usize> = range!(SLOT_RANGE.end, u64);
 const ID_RANGE: std::ops::Range<usize> = range!(INDEX_RANGE.end, Pubkey);
 const FORWARDED_RANGE: std::ops::Range<usize> = range!(ID_RANGE.end, bool);
-const GENESIS_RANGE: std::ops::Range<usize> = range!(FORWARDED_RANGE.end, Hash);
-const FLAGS_RANGE: std::ops::Range<usize> = range!(GENESIS_RANGE.end, u32);
+const FLAGS_RANGE: std::ops::Range<usize> = range!(FORWARDED_RANGE.end, u32);
 const SIZE_RANGE: std::ops::Range<usize> = range!(FLAGS_RANGE.end, u64);
 
 macro_rules! align {
@@ -413,14 +411,6 @@ impl Blob {
     /// Mark this blob's forwarded status
     pub fn set_forwarded(&mut self, forward: bool) {
         self.data[FORWARDED_RANGE][0] = u8::from(forward)
-    }
-
-    pub fn set_genesis_blockhash(&mut self, blockhash: &Hash) {
-        self.data[GENESIS_RANGE].copy_from_slice(blockhash.as_ref())
-    }
-
-    pub fn genesis_blockhash(&self) -> Hash {
-        Hash::new(&self.data[GENESIS_RANGE])
     }
 
     pub fn flags(&self) -> u32 {
@@ -589,13 +579,12 @@ impl Blob {
 }
 
 pub fn index_blobs(blobs: &[SharedBlob], id: &Pubkey, blob_index: u64, slot: u64, parent: u64) {
-    index_blobs_with_genesis(blobs, id, &Hash::default(), blob_index, slot, parent)
+    index_blobs_with_genesis(blobs, id, blob_index, slot, parent)
 }
 
 pub fn index_blobs_with_genesis(
     blobs: &[SharedBlob],
     id: &Pubkey,
-    genesis: &Hash,
     mut blob_index: u64,
     slot: u64,
     parent: u64,
@@ -605,7 +594,6 @@ pub fn index_blobs_with_genesis(
         let mut blob = blob.write().unwrap();
 
         blob.set_index(blob_index);
-        blob.set_genesis_blockhash(genesis);
         blob.set_slot(slot);
         blob.set_parent(parent);
         blob.set_id(id);
@@ -825,15 +813,4 @@ mod tests {
         p2.data[1] = 4;
         assert!(p1 != p2);
     }
-
-    #[test]
-    fn test_blob_genesis_blockhash() {
-        let mut blob = Blob::default();
-        assert_eq!(blob.genesis_blockhash(), Hash::default());
-
-        let hash = Hash::new(&Pubkey::new_rand().as_ref());
-        blob.set_genesis_blockhash(&hash);
-        assert_eq!(blob.genesis_blockhash(), hash);
-    }
-
 }

--- a/core/src/replicator.rs
+++ b/core/src/replicator.rs
@@ -22,9 +22,7 @@ use solana_client::rpc_client::RpcClient;
 use solana_client::rpc_request::RpcRequest;
 use solana_client::thin_client::ThinClient;
 use solana_ed25519_dalek as ed25519_dalek;
-use solana_runtime::bank::Bank;
 use solana_sdk::client::{AsyncClient, SyncClient};
-use solana_sdk::genesis_block::GenesisBlock;
 use solana_sdk::hash::{Hash, Hasher};
 use solana_sdk::message::Message;
 use solana_sdk::signature::{Keypair, KeypairUtil, Signature};
@@ -188,10 +186,6 @@ impl Replicator {
         // Note for now, this ledger will not contain any of the existing entries
         // in the ledger located at ledger_path, and will only append on newly received
         // entries after being passed to window_service
-        let genesis_block =
-            GenesisBlock::load(ledger_path).expect("Expected to successfully open genesis block");
-        let bank = Bank::new_with_paths(&genesis_block, None);
-        let genesis_blockhash = bank.last_blockhash();
         let blocktree = Arc::new(
             Blocktree::open(ledger_path).expect("Expected to be able to open database ledger"),
         );
@@ -235,7 +229,6 @@ impl Replicator {
             repair_socket,
             &exit,
             RepairStrategy::RepairRange(repair_slot_range),
-            &genesis_blockhash,
             |_, _, _| true,
         );
 

--- a/core/src/retransmit_stage.rs
+++ b/core/src/retransmit_stage.rs
@@ -12,7 +12,6 @@ use crate::streamer::BlobReceiver;
 use crate::window_service::{should_retransmit_and_persist, WindowService};
 use solana_metrics::{datapoint_info, inc_new_counter_error};
 use solana_runtime::epoch_schedule::EpochSchedule;
-use solana_sdk::hash::Hash;
 use std::net::UdpSocket;
 use std::sync::atomic::AtomicBool;
 use std::sync::mpsc::channel;
@@ -116,7 +115,6 @@ impl RetransmitStage {
         repair_socket: Arc<UdpSocket>,
         fetch_stage_receiver: BlobReceiver,
         exit: &Arc<AtomicBool>,
-        genesis_blockhash: &Hash,
         completed_slots_receiver: CompletedSlotsReceiver,
         epoch_schedule: EpochSchedule,
     ) -> Self {
@@ -144,7 +142,6 @@ impl RetransmitStage {
             repair_socket,
             exit,
             repair_strategy,
-            genesis_blockhash,
             move |id, blob, working_bank| {
                 should_retransmit_and_persist(blob, working_bank, &leader_schedule_cache, id)
             },

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -10,7 +10,6 @@ use crate::fetch_stage::FetchStage;
 use crate::poh_recorder::{PohRecorder, WorkingBankEntries};
 use crate::service::Service;
 use crate::sigverify_stage::SigVerifyStage;
-use solana_sdk::hash::Hash;
 use solana_sdk::pubkey::Pubkey;
 use std::net::UdpSocket;
 use std::sync::atomic::AtomicBool;
@@ -39,7 +38,6 @@ impl Tpu {
         sigverify_disabled: bool,
         blocktree: &Arc<Blocktree>,
         exit: &Arc<AtomicBool>,
-        genesis_blockhash: &Hash,
     ) -> Self {
         cluster_info.write().unwrap().set_leader(id);
 
@@ -78,7 +76,6 @@ impl Tpu {
             entry_receiver,
             &exit,
             blocktree,
-            genesis_blockhash,
         );
 
         Self {

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -24,7 +24,6 @@ use crate::retransmit_stage::RetransmitStage;
 use crate::rpc_subscriptions::RpcSubscriptions;
 use crate::service::Service;
 use crate::storage_stage::{StorageStage, StorageState};
-use solana_sdk::hash::Hash;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::{Keypair, KeypairUtil};
 use std::net::UdpSocket;
@@ -71,7 +70,6 @@ impl Tvu {
         poh_recorder: &Arc<Mutex<PohRecorder>>,
         leader_schedule_cache: &Arc<LeaderScheduleCache>,
         exit: &Arc<AtomicBool>,
-        genesis_blockhash: &Hash,
         completed_slots_receiver: CompletedSlotsReceiver,
     ) -> Self
     where
@@ -109,7 +107,6 @@ impl Tvu {
             repair_socket,
             blob_fetch_receiver,
             &exit,
-            genesis_blockhash,
             completed_slots_receiver,
             *bank_forks.read().unwrap().working_bank().epoch_schedule(),
         );

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -235,7 +235,6 @@ pub mod tests {
             &poh_recorder,
             &leader_schedule_cache,
             &exit,
-            &Hash::default(),
             completed_slots_receiver,
         );
         exit.store(true, Ordering::Relaxed);

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -18,7 +18,6 @@ use crate::storage_stage::StorageState;
 use crate::tpu::Tpu;
 use crate::tvu::{Sockets, Tvu};
 use solana_metrics::inc_new_counter_info;
-use solana_runtime::bank::Bank;
 use solana_sdk::genesis_block::GenesisBlock;
 use solana_sdk::poh_config::PohConfig;
 use solana_sdk::pubkey::Pubkey;
@@ -85,10 +84,6 @@ impl Validator {
 
         let id = keypair.pubkey();
         assert_eq!(id, node.info.id);
-        let genesis_block =
-            GenesisBlock::load(ledger_path).expect("Expected to successfully open genesis block");
-        let bank = Bank::new_with_paths(&genesis_block, None);
-        let genesis_blockhash = bank.last_blockhash();
 
         let (
             bank_forks,
@@ -239,7 +234,6 @@ impl Validator {
             &poh_recorder,
             &leader_schedule_cache,
             &exit,
-            &genesis_blockhash,
             completed_slots_receiver,
         );
 
@@ -258,7 +252,6 @@ impl Validator {
             config.sigverify_disabled,
             &blocktree,
             &exit,
-            &genesis_blockhash,
         );
 
         inc_new_counter_info!("fullnode-new", 1);

--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -11,7 +11,6 @@ use crate::service::Service;
 use crate::streamer::{BlobReceiver, BlobSender};
 use solana_metrics::{inc_new_counter_debug, inc_new_counter_error};
 use solana_runtime::bank::Bank;
-use solana_sdk::hash::Hash;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::timing::duration_as_ms;
 use std::net::UdpSocket;
@@ -108,7 +107,6 @@ fn recv_window<F>(
     my_pubkey: &Pubkey,
     r: &BlobReceiver,
     retransmit: &BlobSender,
-    genesis_blockhash: &Hash,
     blob_filter: F,
 ) -> Result<()>
 where
@@ -123,10 +121,7 @@ where
     let now = Instant::now();
     inc_new_counter_debug!("streamer-recv_window-recv", blobs.len(), 0, 1000);
 
-    blobs.retain(|blob| {
-        blob_filter(&blob.read().unwrap())
-            && blob.read().unwrap().genesis_blockhash() == *genesis_blockhash
-    });
+    blobs.retain(|blob| blob_filter(&blob.read().unwrap()));
 
     retransmit_blobs(&blobs, retransmit, my_pubkey)?;
 
@@ -175,7 +170,6 @@ impl WindowService {
         repair_socket: Arc<UdpSocket>,
         exit: &Arc<AtomicBool>,
         repair_strategy: RepairStrategy,
-        genesis_blockhash: &Hash,
         blob_filter: F,
     ) -> WindowService
     where
@@ -198,7 +192,6 @@ impl WindowService {
             repair_strategy,
         );
         let exit = exit.clone();
-        let hash = *genesis_blockhash;
         let blob_filter = Arc::new(blob_filter);
         let bank_forks = bank_forks.clone();
         let t_window = Builder::new()
@@ -212,7 +205,7 @@ impl WindowService {
                         break;
                     }
 
-                    if let Err(e) = recv_window(&blocktree, &id, &r, &retransmit, &hash, |blob| {
+                    if let Err(e) = recv_window(&blocktree, &id, &r, &retransmit, |blob| {
                         blob_filter(
                             &id,
                             blob,
@@ -379,7 +372,6 @@ mod test {
             Arc::new(leader_node.sockets.repair),
             &exit,
             repair_strategy,
-            &Hash::default(),
             |_, _, _| true,
         );
         let t_responder = {

--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -454,7 +454,6 @@ mod test {
             Arc::new(leader_node.sockets.repair),
             &exit,
             repair_strategy,
-            &Hash::default(),
             |_, _, _| true,
         );
         let t_responder = {

--- a/core/tests/tvu.rs
+++ b/core/tests/tvu.rs
@@ -137,7 +137,6 @@ fn test_replay() {
             &poh_recorder,
             &leader_schedule_cache,
             &exit,
-            &solana_sdk::hash::Hash::default(),
             completed_slots_receiver,
         );
 


### PR DESCRIPTION
#### Problem
Genesis blockhash was a temporary hack to prevent validators from inadvertently repairing blobs for other leader's slots between testnet runs before we added a check in window_service to enforce that blobs for slots must come from the leader for that slot.

Note: There still seems to be an edge case where if 
1) A validator keeps the same validator id between testnet restarts, 
2) They are the leader for the same slot in both runs,
3) They don't clear their ledger

Then this validator they can still inadvertently serve bogus repairs to validators and pollute the ledgers of some subset of validators on testnet. 

@mvines, @sagar-solana, @rob-solana 

### Summary of Changes
Remove genesis blockhash


Fixes #3953 