### PR TITLE
remove payer from vote instructions

### DIFF
--- a/core/src/cluster_info_vote_listener.rs
+++ b/core/src/cluster_info_vote_listener.rs
@@ -101,14 +101,10 @@ mod tests {
         let votes = (0..MAX_RECENT_VOTES)
             .map(|i| Vote::new(i as u64, Hash::default()))
             .collect::<Vec<_>>();
-        let vote_ix = vote_instruction::vote(
-            &node_keypair.pubkey(),
-            &vote_keypair.pubkey(),
-            &vote_keypair.pubkey(),
-            votes,
-        );
+        let vote_ix = vote_instruction::vote(&vote_keypair.pubkey(), &vote_keypair.pubkey(), votes);
 
-        let mut vote_tx = Transaction::new_unsigned_instructions(vec![vote_ix]);
+        let mut vote_tx = Transaction::new_with_payer(vec![vote_ix], Some(&node_keypair.pubkey()));
+
         vote_tx.partial_sign(&[&node_keypair], Hash::default());
         vote_tx.partial_sign(&[&vote_keypair], Hash::default());
 

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -333,13 +333,14 @@ impl ReplayStage {
 
             // Send our last few votes along with the new one
             let vote_ix = vote_instruction::vote(
-                &node_keypair.pubkey(),
                 &vote_account,
                 &voting_keypair.pubkey(),
                 locktower.recent_votes(),
             );
 
-            let mut vote_tx = Transaction::new_unsigned_instructions(vec![vote_ix]);
+            let mut vote_tx =
+                Transaction::new_with_payer(vec![vote_ix], Some(&node_keypair.pubkey()));;
+
             let blockhash = bank.last_blockhash();
             vote_tx.partial_sign(&[node_keypair.as_ref()], blockhash);
             vote_tx.partial_sign(&[voting_keypair.as_ref()], blockhash);

--- a/wallet/src/wallet.rs
+++ b/wallet/src/wallet.rs
@@ -472,18 +472,19 @@ fn process_authorize_voter(
 ) -> ProcessResult {
     let (recent_blockhash, _fee_calculator) = rpc_client.get_recent_blockhash()?;
     let ixs = vec![vote_instruction::authorize_voter(
-        &config.keypair.pubkey(),           // from
         voting_account_pubkey,              // vote account to update
         &authorized_voter_keypair.pubkey(), // current authorized voter (often the vote account itself)
         new_authorized_voter_pubkey,        // new vote signer
     )];
 
-    let mut tx = Transaction::new_signed_instructions(
-        &[&config.keypair, &authorized_voter_keypair],
+    let mut tx = Transaction::new_signed_with_payer(
         ixs,
+        Some(&config.keypair.pubkey()),
+        &[&config.keypair, &authorized_voter_keypair],
         recent_blockhash,
     );
-    let signature_str = rpc_client.send_and_confirm_transaction(&mut tx, &[&config.keypair])?;
+    let signature_str = rpc_client
+        .send_and_confirm_transaction(&mut tx, &[&config.keypair, &authorized_voter_keypair])?;
     Ok(signature_str.to_string())
 }
 


### PR DESCRIPTION
#### Problem
 vote instruction vectors and vote_api instruction processor have payer information that they'd otherwise ignore

 #### Summary of Changes
 add Transaction::new_with_payer, to facilitate
 move vote instruction to new Transaction APIs
 update the unnecessarily rigid Transaction::sign() to use partial_sign()

Fixes #