### PR TITLE
Pass credit-only accounts separately into programs

### DIFF
--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -9,6 +9,7 @@ use libc::c_char;
 use log::*;
 use solana_rbpf::{EbpfVmRaw, MemoryRegion};
 use solana_sdk::account::KeyedAccount;
+use solana_sdk::credit_only_account::KeyedCreditOnlyAccount;
 use solana_sdk::instruction::InstructionError;
 use solana_sdk::loader_instruction::LoaderInstruction;
 use solana_sdk::pubkey::Pubkey;
@@ -280,6 +281,7 @@ solana_entrypoint!(entrypoint);
 fn entrypoint(
     program_id: &Pubkey,
     keyed_accounts: &mut [KeyedAccount],
+    _keyed_credit_only_accounts: &mut [KeyedCreditOnlyAccount],
     tx_data: &[u8],
     tick_height: u64,
 ) -> Result<(), InstructionError> {

--- a/programs/budget_api/src/budget_processor.rs
+++ b/programs/budget_api/src/budget_processor.rs
@@ -6,6 +6,7 @@ use bincode::deserialize;
 use chrono::prelude::{DateTime, Utc};
 use log::*;
 use solana_sdk::account::KeyedAccount;
+use solana_sdk::credit_only_account::KeyedCreditOnlyAccount;
 use solana_sdk::instruction::InstructionError;
 use solana_sdk::pubkey::Pubkey;
 
@@ -73,6 +74,7 @@ fn apply_timestamp(
 pub fn process_instruction(
     _program_id: &Pubkey,
     keyed_accounts: &mut [KeyedAccount],
+    _keyed_credit_only_accounts: &mut [KeyedCreditOnlyAccount],
     data: &[u8],
     _tick_height: u64,
 ) -> Result<(), InstructionError> {

--- a/programs/config_api/src/config_processor.rs
+++ b/programs/config_api/src/config_processor.rs
@@ -2,12 +2,14 @@
 
 use log::*;
 use solana_sdk::account::KeyedAccount;
+use solana_sdk::credit_only_account::KeyedCreditOnlyAccount;
 use solana_sdk::instruction::InstructionError;
 use solana_sdk::pubkey::Pubkey;
 
 pub fn process_instruction(
     _program_id: &Pubkey,
     keyed_accounts: &mut [KeyedAccount],
+    _keyed_credit_only_accounts: &mut [KeyedCreditOnlyAccount],
     data: &[u8],
     _tick_height: u64,
 ) -> Result<(), InstructionError> {

--- a/programs/exchange_api/src/exchange_processor.rs
+++ b/programs/exchange_api/src/exchange_processor.rs
@@ -6,6 +6,7 @@ use crate::faucet_id;
 use log::*;
 use solana_metrics::inc_new_counter_info;
 use solana_sdk::account::KeyedAccount;
+use solana_sdk::credit_only_account::KeyedCreditOnlyAccount;
 use solana_sdk::instruction::InstructionError;
 use solana_sdk::pubkey::Pubkey;
 use std::cmp;
@@ -428,6 +429,7 @@ impl ExchangeProcessor {
 pub fn process_instruction(
     _program_id: &Pubkey,
     keyed_accounts: &mut [KeyedAccount],
+    _keyed_credit_only_accounts: &mut [KeyedCreditOnlyAccount],
     data: &[u8],
     _tick_height: u64,
 ) -> Result<(), InstructionError> {

--- a/programs/failure_program/src/lib.rs
+++ b/programs/failure_program/src/lib.rs
@@ -1,4 +1,5 @@
 use solana_sdk::account::KeyedAccount;
+use solana_sdk::credit_only_account::KeyedCreditOnlyAccount;
 use solana_sdk::instruction::InstructionError;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::solana_entrypoint;
@@ -7,6 +8,7 @@ solana_entrypoint!(entrypoint);
 fn entrypoint(
     _program_id: &Pubkey,
     _keyed_accounts: &mut [KeyedAccount],
+    _keyed_credit_only_accounts: &mut [KeyedCreditOnlyAccount],
     _data: &[u8],
     _tick_height: u64,
 ) -> Result<(), InstructionError> {

--- a/programs/noop_program/src/lib.rs
+++ b/programs/noop_program/src/lib.rs
@@ -1,5 +1,6 @@
 use log::*;
 use solana_sdk::account::KeyedAccount;
+use solana_sdk::credit_only_account::KeyedCreditOnlyAccount;
 use solana_sdk::instruction::InstructionError;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::solana_entrypoint;
@@ -8,12 +9,17 @@ solana_entrypoint!(entrypoint);
 fn entrypoint(
     program_id: &Pubkey,
     keyed_accounts: &mut [KeyedAccount],
+    keyed_credit_only_accounts: &mut [KeyedCreditOnlyAccount],
     data: &[u8],
     tick_height: u64,
 ) -> Result<(), InstructionError> {
     solana_logger::setup();
     trace!("noop: program_id: {:?}", program_id);
     trace!("noop: keyed_accounts: {:#?}", keyed_accounts);
+    trace!(
+        "noop: keyed_credit_only_accounts: {:#?}",
+        keyed_credit_only_accounts
+    );
     trace!("noop: data: {:?}", data);
     trace!("noop: tick_height: {:?}", tick_height);
     Ok(())

--- a/programs/stake_api/src/stake_instruction.rs
+++ b/programs/stake_api/src/stake_instruction.rs
@@ -4,6 +4,7 @@ use bincode::deserialize;
 use log::*;
 use serde_derive::{Deserialize, Serialize};
 use solana_sdk::account::KeyedAccount;
+use solana_sdk::credit_only_account::KeyedCreditOnlyAccount;
 use solana_sdk::instruction::{AccountMeta, Instruction, InstructionError};
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::system_instruction;
@@ -121,6 +122,7 @@ pub fn delegate_stake(
 pub fn process_instruction(
     _program_id: &Pubkey,
     keyed_accounts: &mut [KeyedAccount],
+    _keyed_credit_only_accounts: &mut [KeyedCreditOnlyAccount],
     data: &[u8],
     _tick_height: u64,
 ) -> Result<(), InstructionError> {
@@ -193,6 +195,7 @@ mod tests {
             super::process_instruction(
                 &Pubkey::default(),
                 &mut keyed_accounts,
+                &mut [],
                 &instruction.data,
                 0,
             )
@@ -233,6 +236,7 @@ mod tests {
                     false,
                     &mut Account::default(),
                 )],
+                &mut [],
                 &serialize(&StakeInstruction::DelegateStake).unwrap(),
                 0,
             ),
@@ -247,6 +251,7 @@ mod tests {
                     KeyedAccount::new(&Pubkey::default(), true, &mut Account::default()),
                     KeyedAccount::new(&Pubkey::default(), false, &mut Account::default()),
                 ],
+                &mut [],
                 &serialize(&StakeInstruction::DelegateStake).unwrap(),
                 0,
             ),
@@ -261,6 +266,7 @@ mod tests {
                     KeyedAccount::new(&Pubkey::default(), false, &mut Account::default()),
                     KeyedAccount::new(&Pubkey::default(), false, &mut Account::default()),
                 ],
+                &mut [],
                 &serialize(&StakeInstruction::RedeemVoteCredits).unwrap(),
                 0,
             ),
@@ -276,6 +282,7 @@ mod tests {
                     KeyedAccount::new(&Pubkey::default(), true, &mut Account::default()),
                     KeyedAccount::new(&Pubkey::default(), false, &mut Account::default()),
                 ],
+                &mut [],
                 &serialize(&StakeInstruction::DelegateStake).unwrap(),
                 0,
             ),
@@ -292,6 +299,7 @@ mod tests {
                     KeyedAccount::new(&Pubkey::default(), false, &mut Account::default()),
                     KeyedAccount::new(&Pubkey::default(), false, &mut Account::default()),
                 ],
+                &mut [],
                 &serialize(&StakeInstruction::RedeemVoteCredits).unwrap(),
                 0,
             ),

--- a/programs/storage_api/src/storage_processor.rs
+++ b/programs/storage_api/src/storage_processor.rs
@@ -4,6 +4,7 @@
 use crate::storage_contract::StorageAccount;
 use crate::storage_instruction::StorageInstruction;
 use solana_sdk::account::KeyedAccount;
+use solana_sdk::credit_only_account::KeyedCreditOnlyAccount;
 use solana_sdk::instruction::InstructionError;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::timing::DEFAULT_TICKS_PER_SLOT;
@@ -11,6 +12,7 @@ use solana_sdk::timing::DEFAULT_TICKS_PER_SLOT;
 pub fn process_instruction(
     _program_id: &Pubkey,
     keyed_accounts: &mut [KeyedAccount],
+    _keyed_credit_only_accounts: &mut [KeyedCreditOnlyAccount],
     data: &[u8],
     tick_height: u64,
 ) -> Result<(), InstructionError> {
@@ -133,7 +135,7 @@ mod tests {
             })
             .collect();
 
-        let ret = process_instruction(&id(), &mut keyed_accounts, &ix.data, tick_height);
+        let ret = process_instruction(&id(), &mut keyed_accounts, &mut [], &ix.data, tick_height);
         info!("ret: {:?}", ret);
         ret
     }
@@ -171,7 +173,7 @@ mod tests {
         let pubkey = Pubkey::new_rand();
         let mut accounts = [(pubkey, Account::default())];
         let mut keyed_accounts = create_keyed_accounts(&mut accounts);
-        assert!(process_instruction(&id(), &mut keyed_accounts, &[], 42).is_err());
+        assert!(process_instruction(&id(), &mut keyed_accounts, &mut [], &[], 42).is_err());
     }
 
     #[test]
@@ -188,7 +190,7 @@ mod tests {
         );
 
         assert_eq!(
-            process_instruction(&id(), &mut keyed_accounts, &ix.data, 42),
+            process_instruction(&id(), &mut keyed_accounts, &mut [], &ix.data, 42),
             Err(InstructionError::InvalidAccountData)
         );
     }

--- a/programs/token_api/src/token_processor.rs
+++ b/programs/token_api/src/token_processor.rs
@@ -1,18 +1,20 @@
 use crate::token_state::TokenState;
 use log::*;
 use solana_sdk::account::KeyedAccount;
+use solana_sdk::credit_only_account::KeyedCreditOnlyAccount;
 use solana_sdk::instruction::InstructionError;
 use solana_sdk::pubkey::Pubkey;
 
 pub fn process_instruction(
     program_id: &Pubkey,
-    info: &mut [KeyedAccount],
+    keyed_accounts: &mut [KeyedAccount],
+    _keyed_credit_only_accounts: &mut [KeyedCreditOnlyAccount],
     input: &[u8],
     _tick_height: u64,
 ) -> Result<(), InstructionError> {
     solana_logger::setup();
 
-    TokenState::process(program_id, info, input).map_err(|e| {
+    TokenState::process(program_id, keyed_accounts, input).map_err(|e| {
         error!("error: {:?}", e);
         InstructionError::CustomError(e as u32)
     })

--- a/programs/vote_api/src/vote_instruction.rs
+++ b/programs/vote_api/src/vote_instruction.rs
@@ -8,6 +8,7 @@ use log::*;
 use serde_derive::{Deserialize, Serialize};
 use solana_metrics::datapoint_warn;
 use solana_sdk::account::KeyedAccount;
+use solana_sdk::credit_only_account::KeyedCreditOnlyAccount;
 use solana_sdk::instruction::{AccountMeta, Instruction, InstructionError};
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::syscall::slot_hashes;
@@ -108,6 +109,7 @@ pub fn vote(
 pub fn process_instruction(
     _program_id: &Pubkey,
     keyed_accounts: &mut [KeyedAccount],
+    _keyed_credit_only_accounts: &mut [KeyedCreditOnlyAccount],
     data: &[u8],
     _tick_height: u64,
 ) -> Result<(), InstructionError> {
@@ -150,7 +152,7 @@ mod tests {
     #[test]
     fn test_vote_process_instruction_decode_bail() {
         assert_eq!(
-            super::process_instruction(&Pubkey::default(), &mut [], &[], 0,),
+            super::process_instruction(&Pubkey::default(), &mut [], &mut [], &[], 0,),
             Err(InstructionError::InvalidInstructionData),
         );
     }
@@ -170,6 +172,7 @@ mod tests {
             super::process_instruction(
                 &Pubkey::default(),
                 &mut keyed_accounts,
+                &mut [],
                 &instruction.data,
                 0,
             )

--- a/runtime/benches/bank.rs
+++ b/runtime/benches/bank.rs
@@ -9,6 +9,7 @@ use solana_runtime::loader_utils::{create_invoke_instruction, load_program};
 use solana_sdk::account::KeyedAccount;
 use solana_sdk::client::AsyncClient;
 use solana_sdk::client::SyncClient;
+use solana_sdk::credit_only_account::KeyedCreditOnlyAccount;
 use solana_sdk::genesis_block::create_genesis_block;
 use solana_sdk::instruction::InstructionError;
 use solana_sdk::native_loader;
@@ -28,6 +29,7 @@ const BUILTIN_PROGRAM_ID: [u8; 32] = [
 fn process_instruction(
     _program_id: &Pubkey,
     _keyed_accounts: &mut [KeyedAccount],
+    _keyed_credit_only_accounts: &mut [KeyedCreditOnlyAccount],
     _data: &[u8],
     _tick_height: u64,
 ) -> Result<(), InstructionError> {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -664,7 +664,7 @@ impl Bank {
                     Err(e) => Err(e.clone()),
                     Ok((ref mut accounts, ref mut loaders)) => self
                         .message_processor
-                        .process_message(tx.message(), loaders, accounts, tick_height),
+                        .process_message(tx.message(), loaders, accounts, &mut [], tick_height),
                 })
                 .collect();
 

--- a/runtime/src/system_instruction_processor.rs
+++ b/runtime/src/system_instruction_processor.rs
@@ -1,5 +1,6 @@
 use log::*;
 use solana_sdk::account::KeyedAccount;
+use solana_sdk::credit_only_account::KeyedCreditOnlyAccount;
 use solana_sdk::instruction::InstructionError;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::system_instruction::{SystemError, SystemInstruction};
@@ -69,6 +70,7 @@ fn transfer_lamports(
 pub fn process_instruction(
     _program_id: &Pubkey,
     keyed_accounts: &mut [KeyedAccount],
+    _keyed_credit_only_accounts: &mut [KeyedCreditOnlyAccount],
     data: &[u8],
     _tick_height: u64,
 ) -> Result<(), InstructionError> {
@@ -246,7 +248,13 @@ mod tests {
             program_id: another_program_owner,
         };
         let data = serialize(&instruction).unwrap();
-        let result = process_instruction(&system_program::id(), &mut keyed_accounts, &data, 0);
+        let result = process_instruction(
+            &system_program::id(),
+            &mut keyed_accounts,
+            &mut [],
+            &data,
+            0,
+        );
         assert_eq!(result, Err(InstructionError::IncorrectProgramId));
         assert_eq!(from_account.owner, new_program_owner);
     }

--- a/sdk/src/credit_only_account.rs
+++ b/sdk/src/credit_only_account.rs
@@ -1,0 +1,99 @@
+use crate::account::Account;
+use crate::pubkey::Pubkey;
+use std::sync::atomic::AtomicU64;
+use std::sync::Arc;
+use std::{cmp, fmt};
+
+/// A credit-only account struct, allowing atomic adds to lamports, but no other changes
+pub struct CreditOnlyAccount {
+    /// lamports in the account
+    pub lamports: AtomicU64,
+    /// data held in this account
+    pub data: Vec<u8>,
+    /// the program that owns this account. If executable, the program that loads this account.
+    pub owner: Pubkey,
+    /// this account's data contains a loaded program (and is now read-only)
+    pub executable: bool,
+}
+
+impl fmt::Debug for CreditOnlyAccount {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let data_len = cmp::min(64, self.data.len());
+        let data_str = if data_len > 0 {
+            format!(" data: {}", hex::encode(self.data[..data_len].to_vec()))
+        } else {
+            "".to_string()
+        };
+        write!(
+            f,
+            "CreditOnlyAccount {{ lamports: {:?} data.len: {} owner: {} executable: {}{} }}",
+            self.lamports,
+            self.data.len(),
+            self.owner,
+            self.executable,
+            data_str,
+        )
+    }
+}
+
+impl From<Account> for CreditOnlyAccount {
+    fn from(account: Account) -> Self {
+        CreditOnlyAccount {
+            lamports: AtomicU64::from(account.lamports),
+            data: account.data,
+            owner: account.owner,
+            executable: account.executable,
+        }
+    }
+}
+
+#[repr(C)]
+#[derive(Debug)]
+pub struct KeyedCreditOnlyAccount<'a> {
+    is_signer: bool, // Transaction was signed by this account's key
+    key: &'a Pubkey,
+    pub credits: u64,
+    pub account: &'a Arc<CreditOnlyAccount>,
+}
+
+impl<'a> KeyedCreditOnlyAccount<'a> {
+    pub fn signer_key(&self) -> Option<&Pubkey> {
+        if self.is_signer {
+            Some(self.key)
+        } else {
+            None
+        }
+    }
+
+    pub fn unsigned_key(&self) -> &Pubkey {
+        self.key
+    }
+
+    pub fn new(
+        key: &'a Pubkey,
+        is_signer: bool,
+        account: &'a Arc<CreditOnlyAccount>,
+    ) -> KeyedCreditOnlyAccount<'a> {
+        KeyedCreditOnlyAccount {
+            key,
+            is_signer,
+            credits: 0,
+            account,
+        }
+    }
+
+    pub fn credit(&mut self, lamports: u64) {
+        self.credits += lamports;
+    }
+}
+
+impl<'a> From<(&'a Pubkey, &'a Arc<CreditOnlyAccount>)> for KeyedCreditOnlyAccount<'a> {
+    fn from((key, account): (&'a Pubkey, &'a Arc<CreditOnlyAccount>)) -> Self {
+        KeyedCreditOnlyAccount {
+            is_signer: false,
+            key,
+            credits: 0,
+            account,
+        }
+    }
+}

--- a/sdk/src/instruction_processor_utils.rs
+++ b/sdk/src/instruction_processor_utils.rs
@@ -1,4 +1,5 @@
 use crate::account::KeyedAccount;
+use crate::credit_only_account::KeyedCreditOnlyAccount;
 use crate::instruction::InstructionError;
 use crate::pubkey::Pubkey;
 use num_traits::FromPrimitive;
@@ -10,6 +11,7 @@ pub const ENTRYPOINT: &str = "process";
 pub type Entrypoint = unsafe extern "C" fn(
     program_id: &Pubkey,
     keyed_accounts: &mut [KeyedAccount],
+    keyed_credit_only_accounts: &mut [KeyedCreditOnlyAccount],
     data: &[u8],
     tick_height: u64,
 ) -> Result<(), InstructionError>;
@@ -23,10 +25,11 @@ macro_rules! solana_entrypoint(
         pub extern "C" fn process(
             program_id: &solana_sdk::pubkey::Pubkey,
             keyed_accounts: &mut [solana_sdk::account::KeyedAccount],
+            keyed_credit_only_accounts: &mut [solana_sdk::credit_only_account::KeyedCreditOnlyAccount],
             data: &[u8],
             tick_height: u64
         ) -> Result<(), solana_sdk::instruction::InstructionError> {
-            $entrypoint(program_id, keyed_accounts, data, tick_height)
+            $entrypoint(program_id, keyed_accounts, keyed_credit_only_accounts, data, tick_height)
         }
     )
 );

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -2,6 +2,7 @@ pub mod account;
 pub mod account_utils;
 pub mod bpf_loader;
 pub mod client;
+pub mod credit_only_account;
 pub mod fee_calculator;
 pub mod genesis_block;
 pub mod hash;


### PR DESCRIPTION
#### Problem
Currently, all accounts are locked for a particular transaction and then passed into programs as mutable objects, preventing concurrent handling of credit-only (CO) accounts.

#### Summary of Changes
Pass CO accounts into programs separate from credit-debit accounts, using a thread-safe object with an AtomicU64 lamport field to allow atomic adds.
The meat of this pr is in runtime/src/message_processor.rs and the new CreditOnlyAccount module:
- From a set of loaded CO accounts, pull out each instruction's CO accounts by index
- Create KeyedCreditOnlyAccounts, including a field to track instruction credits for balanced instruction check
- Atomic add to CreditOnlyAccounts after each instruction has succeeded

Toward #4432 , items: 2, 5, 6
While this pr does pass `keyed_credit_only_accounts` into all our instruction processors, it does not change account handling in any of these programs. That work depends on implementing the CO cache and plumbing CO-account loading through `bank.rs` and `accounts.rs`
