### PR TITLE
Fix stable metrics dashboard for current channel use

### DIFF
--- a/ci/publish-metrics-dashboard.sh
+++ b/ci/publish-metrics-dashboard.sh
@@ -45,7 +45,9 @@ beta)
   CHANNEL_BRANCH=$BETA_CHANNEL
   ;;
 stable)
-  CHANNEL_BRANCH=$STABLE_CHANNEL
+  # Set to whatever branch 'testnet' is on.
+  # TODO: Revert to $STABLE_CHANNEL for TdS
+  CHANNEL_BRANCH=$BETA_CHANNEL
   ;;
 *)
   echo "Error: Invalid PUBLISH_CHANNEL=$PUBLISH_CHANNEL"


### PR DESCRIPTION
#### Problem

'testnet' is currently running on the beta channel, but the metrics dashboard for it is publishing from the stable channel, and these dashboard are incompatible.

#### Summary of Changes

Set the 'stable' dashboard publishing to the same channel as testnet software.  This will likely revert to the stable channel when we launch TdS.
