### PR TITLE
add with_data and sample uses

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -208,9 +208,9 @@ impl Bank {
             .get_account(&slot_hashes::id())
             .unwrap_or_else(|| slot_hashes::create_account(1));
 
-        let mut slot_hashes = SlotHashes::from(&account).unwrap();
-        slot_hashes.add(self.slot(), self.hash());
-        slot_hashes.to(&mut account).unwrap();
+        account
+            .with_data(|slot_hashes: &mut SlotHashes| slot_hashes.add(self.slot(), self.hash()))
+            .unwrap();
 
         self.store(&slot_hashes::id(), &account);
     }

--- a/sdk/src/account_utils.rs
+++ b/sdk/src/account_utils.rs
@@ -16,11 +16,11 @@ where
     T: serde::Serialize + serde::de::DeserializeOwned,
 {
     fn state(&self) -> Result<T, InstructionError> {
-        self.deserialize_data().map_err(|e| e.into())
+        Ok(self.deserialize_data()?)
     }
 
     fn set_state(&mut self, state: &T) -> Result<(), InstructionError> {
-        self.serialize_data(state).map_err(|e| e.into())
+        Ok(self.serialize_data(state)?)
     }
 }
 

--- a/sdk/src/account_utils.rs
+++ b/sdk/src/account_utils.rs
@@ -1,11 +1,13 @@
 //! useful extras for Account state
 use crate::account::{Account, KeyedAccount};
 use crate::instruction::InstructionError;
-use bincode::ErrorKind;
 
 /// Convenience trait to covert bincode errors to instruction errors.
 pub trait State<T> {
     fn state(&self) -> Result<T, InstructionError>;
+    //    fn with_state<R, E, F>(&mut self, func: F) -> Result<Result<R, E>, InstructionError>
+    //    where
+    //        F: FnOnce(&mut T) -> Result<R, E>;
     fn set_state(&mut self, state: &T) -> Result<(), InstructionError>;
 }
 
@@ -14,14 +16,11 @@ where
     T: serde::Serialize + serde::de::DeserializeOwned,
 {
     fn state(&self) -> Result<T, InstructionError> {
-        self.deserialize_data()
-            .map_err(|_| InstructionError::InvalidAccountData)
+        self.deserialize_data().map_err(|e| e.into())
     }
+
     fn set_state(&mut self, state: &T) -> Result<(), InstructionError> {
-        self.serialize_data(state).map_err(|err| match *err {
-            ErrorKind::SizeLimit => InstructionError::AccountDataTooSmall,
-            _ => InstructionError::GenericError,
-        })
+        self.serialize_data(state).map_err(|e| e.into())
     }
 }
 
@@ -32,6 +31,7 @@ where
     fn state(&self) -> Result<T, InstructionError> {
         self.account.state()
     }
+
     fn set_state(&mut self, state: &T) -> Result<(), InstructionError> {
         self.account.set_state(state)
     }

--- a/sdk/src/instruction.rs
+++ b/sdk/src/instruction.rs
@@ -58,6 +58,27 @@ pub enum InstructionError {
     CustomError(u32),
 }
 
+impl std::error::Error for InstructionError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        None
+    }
+}
+
+impl std::fmt::Display for InstructionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+impl From<Box<bincode::ErrorKind>> for InstructionError {
+    fn from(e: Box<bincode::ErrorKind>) -> Self {
+        match *e {
+            bincode::ErrorKind::SizeLimit => InstructionError::AccountDataTooSmall,
+            _ => InstructionError::InvalidAccountData,
+        }
+    }
+}
+
 impl InstructionError {
     pub fn new_result_with_negative_lamports() -> Self {
         InstructionError::CustomError(SystemError::ResultWithNegativeLamports as u32)


### PR DESCRIPTION
#### Problem
state(), set_state() (and serialize/deserialize_data) end up copy-pasta across code trying to more natively interact with account objects

#### Summary of Changes
add with_data(), which takes a Result closure
added some example use cases

feedback appreciated on errors.  I tried a bunch of different ways to show plumb bincode::ErrorKind errors and E errors, and this seemed like the least painful.  Box<std::error::Error> was much prettier, but because Solana doesn't use Boxed errors, the compatibility broke right at process_instruction()