### PR TITLE
Add random distribution for avalanche peers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2199,6 +2199,7 @@ dependencies = [
  "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "memmap 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "nix 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -38,6 +38,7 @@ libc = "0.2.55"
 log = "0.4.2"
 memmap = { version = "0.7.0", optional = true }
 nix = "0.14.0"
+num-traits = "0.2"
 rand = "0.6.5"
 rand_chacha = "0.1.1"
 rayon = "1.0.0"

--- a/core/src/cluster_info.rs
+++ b/core/src/cluster_info.rs
@@ -502,15 +502,12 @@ impl ClusterInfo {
                 let stake = stakes.map_or(1, |stakes| *stakes.get(&c.id).unwrap_or(&1));
                 (stake, (stake, c.clone()))
             })
-            .into_iter()
             .unzip();
 
         let shuffle: WeightedShuffle<u64> = WeightedShuffle::new(stakes, rng);
 
-        let mut out: Vec<(u64, ContactInfo)> = shuffle
-            .into_iter()
-            .map(|x| peers_with_stakes[x].clone())
-            .collect();
+        let mut out: Vec<(u64, ContactInfo)> =
+            shuffle.map(|x| peers_with_stakes[x].clone()).collect();
 
         out.dedup();
         out

--- a/core/src/cluster_info.rs
+++ b/core/src/cluster_info.rs
@@ -24,9 +24,11 @@ use crate::repair_service::RepairType;
 use crate::result::Result;
 use crate::staking_utils;
 use crate::streamer::{BlobReceiver, BlobSender};
+use crate::weighted_shuffle::WeightedShuffle;
 use bincode::{deserialize, serialize};
 use core::cmp;
 use rand::{thread_rng, Rng};
+use rand_chacha::ChaChaRng;
 use rayon::prelude::*;
 use solana_metrics::{datapoint_debug, inc_new_counter_debug, inc_new_counter_error};
 use solana_netutil::{
@@ -489,38 +491,40 @@ impl ClusterInfo {
             && !ContactInfo::is_valid_address(&contact_info.tpu)
     }
 
-    fn sort_by_stake<S: std::hash::BuildHasher>(
+    fn stake_weighted_shuffle<S: std::hash::BuildHasher>(
         peers: &[ContactInfo],
         stakes: Option<&HashMap<Pubkey, u64, S>>,
+        rng: ChaChaRng,
     ) -> Vec<(u64, ContactInfo)> {
-        let mut peers_with_stakes: Vec<_> = peers
+        let (stakes, peers_with_stakes): (Vec<_>, Vec<_>) = peers
             .iter()
             .map(|c| {
-                (
-                    stakes.map_or(0, |stakes| *stakes.get(&c.id).unwrap_or(&0)),
-                    c.clone(),
-                )
+                let stake = stakes.map_or(1, |stakes| *stakes.get(&c.id).unwrap_or(&1));
+                (stake, (stake, c.clone()))
             })
+            .into_iter()
+            .unzip();
+
+        let shuffle: WeightedShuffle<u64> = WeightedShuffle::new(stakes, rng);
+
+        let mut out: Vec<(u64, ContactInfo)> = shuffle
+            .into_iter()
+            .map(|x| peers_with_stakes[x].clone())
             .collect();
-        peers_with_stakes.sort_unstable_by(|(l_stake, l_info), (r_stake, r_info)| {
-            if r_stake == l_stake {
-                r_info.id.cmp(&l_info.id)
-            } else {
-                r_stake.cmp(&l_stake)
-            }
-        });
-        peers_with_stakes.dedup();
-        peers_with_stakes
+
+        out.dedup();
+        out
     }
 
     /// Return sorted Retransmit peers and index of `Self.id()` as if it were in that list
-    fn sorted_peers_and_index<S: std::hash::BuildHasher>(
+    fn shuffle_peers_and_index<S: std::hash::BuildHasher>(
         &self,
         stakes: Option<&HashMap<Pubkey, u64, S>>,
+        rng: ChaChaRng,
     ) -> (usize, Vec<ContactInfo>) {
         let mut peers = self.retransmit_peers();
         peers.push(self.lookup(&self.id()).unwrap().clone());
-        let contacts_and_stakes: Vec<_> = ClusterInfo::sort_by_stake(&peers, stakes);
+        let contacts_and_stakes: Vec<_> = ClusterInfo::stake_weighted_shuffle(&peers, stakes, rng);
         let mut index = 0;
         let peers: Vec<_> = contacts_and_stakes
             .into_iter()
@@ -537,9 +541,13 @@ impl ClusterInfo {
         (index, peers)
     }
 
-    pub fn sorted_tvu_peers(&self, stakes: Option<&HashMap<Pubkey, u64>>) -> Vec<ContactInfo> {
+    pub fn sorted_tvu_peers(
+        &self,
+        stakes: Option<&HashMap<Pubkey, u64>>,
+        rng: ChaChaRng,
+    ) -> Vec<ContactInfo> {
         let peers = self.tvu_peers();
-        let peers_with_stakes: Vec<_> = ClusterInfo::sort_by_stake(&peers, stakes);
+        let peers_with_stakes: Vec<_> = ClusterInfo::stake_weighted_shuffle(&peers, stakes, rng);
         peers_with_stakes
             .iter()
             .map(|(_, peer)| (*peer).clone())
@@ -1498,8 +1506,12 @@ pub fn compute_retransmit_peers<S: std::hash::BuildHasher>(
     stakes: Option<&HashMap<Pubkey, u64, S>>,
     cluster_info: &Arc<RwLock<ClusterInfo>>,
     fanout: usize,
+    rng: ChaChaRng,
 ) -> (Vec<ContactInfo>, Vec<ContactInfo>) {
-    let (my_index, peers) = cluster_info.read().unwrap().sorted_peers_and_index(stakes);
+    let (my_index, peers) = cluster_info
+        .read()
+        .unwrap()
+        .shuffle_peers_and_index(stakes, rng);
     //calc num_layers and num_neighborhoods using the total number of nodes
     let (num_layers, layer_indices) = ClusterInfo::describe_data_plane(peers.len(), fanout);
 

--- a/core/src/cluster_info.rs
+++ b/core/src/cluster_info.rs
@@ -498,7 +498,7 @@ impl ClusterInfo {
         rng: ChaChaRng,
     ) -> Vec<(u64, ContactInfo)> {
         let (stake_weights, peers_with_stakes): (Vec<_>, Vec<_>) = peers
-            .into_iter()
+            .iter()
             .map(|c| {
                 let stake = stakes.map_or(0, |stakes| *stakes.get(&c.id).unwrap_or(&0));
                 // For stake weighted shuffle a valid weight is atleast 1. Weight 0 is
@@ -512,7 +512,6 @@ impl ClusterInfo {
                     r_stake.cmp(&l_stake)
                 }
             })
-            .into_iter()
             .unzip();
 
         let shuffle = weighted_shuffle(stake_weights, rng);

--- a/core/src/crds_gossip_push.rs
+++ b/core/src/crds_gossip_push.rs
@@ -179,11 +179,10 @@ impl CrdsGossipPush {
 
         let mut seed = [0; 32];
         seed[0..8].copy_from_slice(&thread_rng().next_u64().to_le_bytes());
-        let mut shuffle: WeightedShuffle<f32> = WeightedShuffle::new(
+        let mut shuffle = WeightedShuffle::new(
             options.iter().map(|weighted| weighted.0).collect_vec(),
             ChaChaRng::from_seed(seed),
-        )
-        .into_iter();
+        );
 
         while new_items.len() < need {
             match shuffle.next() {

--- a/core/src/crds_gossip_push.rs
+++ b/core/src/crds_gossip_push.rs
@@ -14,11 +14,14 @@ use crate::crds_gossip::{get_stake, get_weight, CRDS_GOSSIP_BLOOM_SIZE};
 use crate::crds_gossip_error::CrdsGossipError;
 use crate::crds_value::{CrdsValue, CrdsValueLabel};
 use crate::packet::BLOB_DATA_SIZE;
+use crate::weighted_shuffle::WeightedShuffle;
 use bincode::serialized_size;
 use indexmap::map::IndexMap;
+use itertools::Itertools;
 use rand;
-use rand::distributions::{Distribution, WeightedIndex};
 use rand::seq::SliceRandom;
+use rand::{thread_rng, RngCore, SeedableRng};
+use rand_chacha::ChaChaRng;
 use solana_runtime::bloom::Bloom;
 use solana_sdk::hash::Hash;
 use solana_sdk::pubkey::Pubkey;
@@ -169,29 +172,36 @@ impl CrdsGossipPush {
         let need = Self::compute_need(self.num_active, self.active_set.len(), ratio);
         let mut new_items = HashMap::new();
 
-        let mut options: Vec<_> = self.push_options(crds, &self_id, stakes);
+        let options: Vec<_> = self.push_options(crds, &self_id, stakes);
         if options.is_empty() {
             return;
         }
+
+        let mut seed = [0; 32];
+        seed[0..8].copy_from_slice(&thread_rng().next_u64().to_le_bytes());
+        let mut shuffle: WeightedShuffle<f32> = WeightedShuffle::new(
+            options.iter().map(|weighted| weighted.0).collect_vec(),
+            ChaChaRng::from_seed(seed),
+        )
+        .into_iter();
+
         while new_items.len() < need {
-            let index = WeightedIndex::new(options.iter().map(|weighted| weighted.0));
-            if index.is_err() {
-                break;
+            match shuffle.next() {
+                Some(index) => {
+                    let item = options[index].1;
+                    if self.active_set.get(&item.id).is_some() {
+                        continue;
+                    }
+                    if new_items.get(&item.id).is_some() {
+                        continue;
+                    }
+                    let size = cmp::max(CRDS_GOSSIP_BLOOM_SIZE, network_size);
+                    let mut bloom = Bloom::random(size, 0.1, 1024 * 8 * 4);
+                    bloom.add(&item.id);
+                    new_items.insert(item.id, bloom);
+                }
+                _ => break,
             }
-            let index = index.unwrap();
-            let index = index.sample(&mut rand::thread_rng());
-            let item = options[index].1;
-            options.remove(index);
-            if self.active_set.get(&item.id).is_some() {
-                continue;
-            }
-            if new_items.get(&item.id).is_some() {
-                continue;
-            }
-            let size = cmp::max(CRDS_GOSSIP_BLOOM_SIZE, network_size);
-            let mut bloom = Bloom::random(size, 0.1, 1024 * 8 * 4);
-            bloom.add(&item.id);
-            new_items.insert(item.id, bloom);
         }
         let mut keys: Vec<Pubkey> = self.active_set.keys().cloned().collect();
         keys.shuffle(&mut rand::thread_rng());

--- a/core/src/crds_gossip_push.rs
+++ b/core/src/crds_gossip_push.rs
@@ -14,7 +14,7 @@ use crate::crds_gossip::{get_stake, get_weight, CRDS_GOSSIP_BLOOM_SIZE};
 use crate::crds_gossip_error::CrdsGossipError;
 use crate::crds_value::{CrdsValue, CrdsValueLabel};
 use crate::packet::BLOB_DATA_SIZE;
-use crate::weighted_shuffle::WeightedShuffle;
+use crate::weighted_shuffle::weighted_shuffle;
 use bincode::serialized_size;
 use indexmap::map::IndexMap;
 use itertools::Itertools;
@@ -179,10 +179,11 @@ impl CrdsGossipPush {
 
         let mut seed = [0; 32];
         seed[0..8].copy_from_slice(&thread_rng().next_u64().to_le_bytes());
-        let mut shuffle = WeightedShuffle::new(
+        let mut shuffle = weighted_shuffle(
             options.iter().map(|weighted| weighted.0).collect_vec(),
             ChaChaRng::from_seed(seed),
-        );
+        )
+        .into_iter();
 
         while new_items.len() < need {
             match shuffle.next() {

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -68,6 +68,7 @@ pub mod test_tx;
 pub mod tpu;
 pub mod tvu;
 pub mod validator;
+pub mod weighted_shuffle;
 pub mod window_service;
 
 #[macro_use]

--- a/core/src/weighted_shuffle.rs
+++ b/core/src/weighted_shuffle.rs
@@ -20,9 +20,11 @@ where
             let x = (total_weight / v).to_u32().unwrap();
             (
                 i,
-                (&mut rng)
-                    .gen_range(1, u32::from(std::u16::MAX))
-                    .saturating_mul(x) as u64,
+                u64::from(
+                    (&mut rng)
+                        .gen_range(1, u32::from(std::u16::MAX))
+                        .saturating_mul(x),
+                ),
             )
         })
         .sorted_by(|(_, l_val), (_, r_val)| l_val.cmp(r_val))

--- a/core/src/weighted_shuffle.rs
+++ b/core/src/weighted_shuffle.rs
@@ -1,0 +1,57 @@
+//! The `weighted_shuffle` module provides an iterator over shuffled weights.
+
+use rand::distributions::uniform::SampleUniform;
+use rand::distributions::{Distribution, WeightedIndex};
+use rand_chacha::ChaChaRng;
+
+pub struct WeightedShuffle<
+    T: SampleUniform + PartialOrd + for<'a> ::core::ops::AddAssign<&'a T> + Clone + Default,
+> {
+    weights: Vec<T>,
+    rng: ChaChaRng,
+}
+
+impl<T: SampleUniform + PartialOrd + for<'a> ::core::ops::AddAssign<&'a T> + Clone + Default>
+    WeightedShuffle<T>
+{
+    pub fn new(weights: Vec<T>, rng: ChaChaRng) -> Self {
+        WeightedShuffle { weights, rng }
+    }
+}
+
+impl<T: SampleUniform + PartialOrd + for<'a> ::core::ops::AddAssign<&'a T> + Clone + Default>
+    Iterator for WeightedShuffle<T>
+{
+    type Item = usize;
+
+    fn next(&mut self) -> Option<usize> {
+        match WeightedIndex::new(&self.weights) {
+            Ok(dist) => {
+                let choice = dist.sample(&mut self.rng);
+                self.weights[choice] = <T as Default>::default();
+                Some(choice)
+            }
+            _ => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand::SeedableRng;
+
+    #[test]
+    fn test_weighted_shuffle_iterator() {
+        let mut test_set = [0; 6];
+        let mut count = 0;
+        let shuffle: WeightedShuffle<u64> =
+            WeightedShuffle::new(vec![50, 10, 2, 1, 1, 1], ChaChaRng::from_seed([0x5a; 32]));
+        shuffle.into_iter().for_each(|x| {
+            assert_eq!(test_set[x], 0);
+            test_set[x] = 1;
+            count += 1;
+        });
+        assert_eq!(count, 6);
+    }
+}

--- a/core/src/weighted_shuffle.rs
+++ b/core/src/weighted_shuffle.rs
@@ -1,39 +1,33 @@
 //! The `weighted_shuffle` module provides an iterator over shuffled weights.
 
-use rand::distributions::uniform::SampleUniform;
-use rand::distributions::{Distribution, WeightedIndex};
+use itertools::Itertools;
+use num_traits::{FromPrimitive, ToPrimitive};
+use rand::Rng;
 use rand_chacha::ChaChaRng;
+use std::iter;
+use std::ops::Div;
 
-pub struct WeightedShuffle<
-    T: SampleUniform + PartialOrd + for<'a> ::core::ops::AddAssign<&'a T> + Clone + Default,
-> {
-    weights: Vec<T>,
-    rng: ChaChaRng,
-}
-
-impl<T: SampleUniform + PartialOrd + for<'a> ::core::ops::AddAssign<&'a T> + Clone + Default>
-    WeightedShuffle<T>
+pub fn weighted_shuffle<T>(weights: Vec<T>, rng: ChaChaRng) -> Vec<usize>
+where
+    T: Copy + PartialOrd + iter::Sum + Div<T, Output = T> + FromPrimitive + ToPrimitive + Default,
 {
-    pub fn new(weights: Vec<T>, rng: ChaChaRng) -> Self {
-        WeightedShuffle { weights, rng }
-    }
-}
-
-impl<T: SampleUniform + PartialOrd + for<'a> ::core::ops::AddAssign<&'a T> + Clone + Default>
-    Iterator for WeightedShuffle<T>
-{
-    type Item = usize;
-
-    fn next(&mut self) -> Option<usize> {
-        match WeightedIndex::new(&self.weights) {
-            Ok(dist) => {
-                let choice = dist.sample(&mut self.rng);
-                self.weights[choice] = <T as Default>::default();
-                Some(choice)
-            }
-            _ => None,
-        }
-    }
+    let mut rng = rng;
+    let total_weight: T = weights.clone().into_iter().sum();
+    weights
+        .into_iter()
+        .enumerate()
+        .map(|(i, v)| {
+            let x = (total_weight / v).to_u32().unwrap();
+            (
+                i,
+                (&mut rng)
+                    .gen_range(1, std::u16::MAX as u32)
+                    .saturating_mul(x),
+            )
+        })
+        .sorted_by(|(_, l_val), (_, r_val)| l_val.cmp(r_val))
+        .map(|x| x.0)
+        .collect()
 }
 
 #[cfg(test)]
@@ -45,8 +39,7 @@ mod tests {
     fn test_weighted_shuffle_iterator() {
         let mut test_set = [0; 6];
         let mut count = 0;
-        let shuffle: WeightedShuffle<u64> =
-            WeightedShuffle::new(vec![50, 10, 2, 1, 1, 1], ChaChaRng::from_seed([0x5a; 32]));
+        let shuffle = weighted_shuffle(vec![50, 10, 2, 1, 1, 1], ChaChaRng::from_seed([0x5a; 32]));
         shuffle.into_iter().for_each(|x| {
             assert_eq!(test_set[x], 0);
             test_set[x] = 1;
@@ -56,12 +49,23 @@ mod tests {
     }
 
     #[test]
-    fn test_weighted_shuffle_compare() {
-        let shuffle: WeightedShuffle<u64> =
-            WeightedShuffle::new(vec![50, 10, 2, 1, 1, 1], ChaChaRng::from_seed([0x5a; 32]));
+    fn test_weighted_shuffle_iterator_large() {
+        let mut test_set = vec![0; 100];
+        (0..100).for_each(|i| test_set[i] = (i + 1) as u64);
+        let mut count = 0;
+        let shuffle = weighted_shuffle(test_set, ChaChaRng::from_seed([0xa5; 32]));
+        shuffle.into_iter().for_each(|x| {
+            println!("{}", x);
+            count += 1;
+        });
+        assert_eq!(count, 100);
+    }
 
-        let shuffle1: WeightedShuffle<u64> =
-            WeightedShuffle::new(vec![50, 10, 2, 1, 1, 1], ChaChaRng::from_seed([0x5a; 32]));
+    #[test]
+    fn test_weighted_shuffle_compare() {
+        let shuffle = weighted_shuffle(vec![50, 10, 2, 1, 1, 1], ChaChaRng::from_seed([0x5a; 32]));
+
+        let shuffle1 = weighted_shuffle(vec![50, 10, 2, 1, 1, 1], ChaChaRng::from_seed([0x5a; 32]));
         shuffle1
             .into_iter()
             .zip(shuffle.into_iter())

--- a/core/src/weighted_shuffle.rs
+++ b/core/src/weighted_shuffle.rs
@@ -20,11 +20,7 @@ where
             let x = (total_weight / v).to_u32().unwrap();
             (
                 i,
-                u64::from(
-                    (&mut rng)
-                        .gen_range(1, u32::from(std::u16::MAX))
-                        .saturating_mul(x),
-                ),
+                (&mut rng).gen_range(1, u64::from(std::u16::MAX)) * u64::from(x),
             )
         })
         .sorted_by(|(_, l_val), (_, r_val)| l_val.cmp(r_val))

--- a/core/src/weighted_shuffle.rs
+++ b/core/src/weighted_shuffle.rs
@@ -54,4 +54,19 @@ mod tests {
         });
         assert_eq!(count, 6);
     }
+
+    #[test]
+    fn test_weighted_shuffle_compare() {
+        let shuffle: WeightedShuffle<u64> =
+            WeightedShuffle::new(vec![50, 10, 2, 1, 1, 1], ChaChaRng::from_seed([0x5a; 32]));
+
+        let shuffle1: WeightedShuffle<u64> =
+            WeightedShuffle::new(vec![50, 10, 2, 1, 1, 1], ChaChaRng::from_seed([0x5a; 32]));
+        shuffle1
+            .into_iter()
+            .zip(shuffle.into_iter())
+            .for_each(|(x, y)| {
+                assert_eq!(x, y);
+            });
+    }
 }

--- a/core/src/weighted_shuffle.rs
+++ b/core/src/weighted_shuffle.rs
@@ -58,7 +58,6 @@ mod tests {
         let mut count = 0;
         let shuffle = weighted_shuffle(test_weights, ChaChaRng::from_seed([0xa5; 32]));
         shuffle.into_iter().for_each(|x| {
-            println!("{}", x);
             assert_eq!(test_set[x], 0);
             test_set[x] = 1;
             count += 1;


### PR DESCRIPTION
#### Problem
Avalanche peers are not randomized and are prone to eclipse style attacks.

#### Summary of Changes
Randomize peers every bank slot. Maintain a cache of random peers for last 5 slots in retransmit stage (to avoid re-computation). Also, added a new class for weighted shuffle. Updated gossip push to use weighted shuffle.
 
Fixes #
