### PR TITLE
Prevent run.sh from running beyond the first epoch under normal use

### DIFF
--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -158,6 +158,11 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                 .default_value(default_slots_per_epoch)
                 .help("The number of slots in an epoch"),
         )
+        .arg(
+            Arg::with_name("disable_epoch_warmup")
+                .long("--disable-epoch-warmup")
+                .hidden(true),
+        )
         .get_matches();
 
     let bootstrap_leader_keypair_file = matches.value_of("bootstrap_leader_keypair_file").unwrap();
@@ -227,6 +232,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
         value_t_or_exit!(matches, "lamports_per_signature", u64);
     genesis_block.ticks_per_slot = value_t_or_exit!(matches, "ticks_per_slot", u64);
     genesis_block.slots_per_epoch = value_t_or_exit!(matches, "slots_per_epoch", u64);
+    genesis_block.epoch_warmup = !matches.is_present("disable_epoch_warmup");
     genesis_block.poh_config.target_tick_duration =
         Duration::from_millis(value_t_or_exit!(matches, "target_tick_duration", u64));
 

--- a/run.sh
+++ b/run.sh
@@ -72,6 +72,8 @@ solana-genesis \
   --bootstrap-leader-lamports 10000000 \
   --lamports-per-signature 1 \
   --hashes-per-tick sleep \
+  --disable-epoch-warmup \
+  --slots-per-epoch 1000000 \
   --mint "$dataDir"/config/drone-keypair.json \
   --bootstrap-leader-keypair "$dataDir"/config/leader-keypair.json \
   --bootstrap-vote-keypair "$dataDir"/config/leader-vote-account-keypair.json \


### PR DESCRIPTION
The local cluster that run.sh starts will typically only have a single
node, the bootstrap leader.  With epoch warmup enabled, run.sh will fail
after ~90 seconds once the warmup period has been exceeded due to lack
of votes from other validators.

As a workaround, disable epoch warmup and set slots-per-epoch to 1
million to keep run.sh alive for more than a fortnight.
