### PR TITLE
Separate bootstrap leader's stake lamports from its identity lamports

### DIFF
--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -158,11 +158,6 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                 .default_value(default_slots_per_epoch)
                 .help("The number of slots in an epoch"),
         )
-        .arg(
-            Arg::with_name("disable_epoch_warmup")
-                .long("--disable-epoch-warmup")
-                .hidden(true),
-        )
         .get_matches();
 
     let bootstrap_leader_keypair_file = matches.value_of("bootstrap_leader_keypair_file").unwrap();
@@ -232,7 +227,6 @@ fn main() -> Result<(), Box<dyn error::Error>> {
         value_t_or_exit!(matches, "lamports_per_signature", u64);
     genesis_block.ticks_per_slot = value_t_or_exit!(matches, "ticks_per_slot", u64);
     genesis_block.slots_per_epoch = value_t_or_exit!(matches, "slots_per_epoch", u64);
-    genesis_block.epoch_warmup = !matches.is_present("disable_epoch_warmup");
     genesis_block.poh_config.target_tick_duration =
         Duration::from_millis(value_t_or_exit!(matches, "target_tick_duration", u64));
 

--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -114,6 +114,15 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                 .help("Number of lamports to assign to the bootstrap leader"),
         )
         .arg(
+            Arg::with_name("bootstrap_leader_stake_lamports")
+                .long("bootstrap-leader-stake-lamports")
+                .value_name("LAMPORTS")
+                .takes_value(true)
+                .default_value(default_bootstrap_leader_lamports)
+                .required(true)
+                .help("Number of lamports to assign to the bootstrap leader's stake account"),
+        )
+        .arg(
             Arg::with_name("lamports_per_signature")
                 .long("lamports-per-signature")
                 .value_name("LAMPORTS")
@@ -168,8 +177,9 @@ fn main() -> Result<(), Box<dyn error::Error>> {
     let mint_keypair_file = matches.value_of("mint_keypair_file").unwrap();
     let ledger_path = matches.value_of("ledger_path").unwrap();
     let lamports = value_t_or_exit!(matches, "lamports", u64);
+    let bootstrap_leader_lamports = value_t_or_exit!(matches, "bootstrap_leader_lamports", u64);
     let bootstrap_leader_stake_lamports =
-        value_t_or_exit!(matches, "bootstrap_leader_lamports", u64);
+        value_t_or_exit!(matches, "bootstrap_leader_stake_lamports", u64);
 
     let bootstrap_leader_keypair = read_keypair(bootstrap_leader_keypair_file)?;
     let bootstrap_vote_keypair = read_keypair(bootstrap_vote_keypair_file)?;
@@ -198,7 +208,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
             // node needs an account to issue votes from
             (
                 bootstrap_leader_keypair.pubkey(),
-                Account::new(1, 0, &system_program::id()),
+                Account::new(bootstrap_leader_lamports, 0, &system_program::id()),
             ),
             // where votes go to
             (bootstrap_vote_keypair.pubkey(), vote_account),

--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -77,7 +77,10 @@ local|tar)
     fi
     set -x
     if [[ $skipSetup != true ]]; then
-      args=(--bootstrap-leader-lamports "$stake")
+      args=(
+        --bootstrap-leader-lamports "$stake"
+        --bootstrap-leader-stake-lamports "$stake"
+      )
       # shellcheck disable=SC2206 # Do not want to quote $genesisOptions
       args+=($genesisOptions)
       ./multinode-demo/setup.sh "${args[@]}"

--- a/programs/vote_api/src/vote_state.rs
+++ b/programs/vote_api/src/vote_state.rs
@@ -323,11 +323,11 @@ pub fn create_bootstrap_leader_account(
     vote_pubkey: &Pubkey,
     node_pubkey: &Pubkey,
     commission: u32,
-    lamports: u64,
+    vote_lamports: u64,
 ) -> (Account, VoteState) {
     // Construct a vote account for the bootstrap_leader such that the leader_scheduler
     // will be forced to select it as the leader for height 0
-    let mut vote_account = create_account(&vote_pubkey, &node_pubkey, commission, lamports);
+    let mut vote_account = create_account(&vote_pubkey, &node_pubkey, commission, vote_lamports);
 
     let mut vote_state: VoteState = vote_account.state().unwrap();
     // TODO: get a hash for slot 0?

--- a/run.sh
+++ b/run.sh
@@ -73,8 +73,6 @@ solana-genesis \
   --bootstrap-leader-lamports 10000000 \
   --lamports-per-signature 1 \
   --hashes-per-tick sleep \
-  --disable-epoch-warmup \
-  --slots-per-epoch 1000000 \
   --mint "$dataDir"/drone-keypair.json \
   --bootstrap-leader-keypair "$dataDir"/leader-keypair.json \
   --bootstrap-vote-keypair "$dataDir"/leader-vote-account-keypair.json \

--- a/runtime/src/genesis_utils.rs
+++ b/runtime/src/genesis_utils.rs
@@ -20,6 +20,7 @@ pub fn create_genesis_block_with_leader(
     bootstrap_leader_pubkey: &Pubkey,
     bootstrap_leader_stake_lamports: u64,
 ) -> GenesisBlockInfo {
+    let bootstrap_leader_lamports = 42; // TODO: pass this in as an argument?
     let mint_keypair = Keypair::new();
     let voting_keypair = Keypair::new();
     let staking_keypair = Keypair::new();
@@ -45,7 +46,7 @@ pub fn create_genesis_block_with_leader(
             //  airdrops at some point to cover fees...
             (
                 *bootstrap_leader_pubkey,
-                Account::new(42, 0, &system_program::id()),
+                Account::new(bootstrap_leader_lamports, 0, &system_program::id()),
             ),
             // where votes go to
             (voting_keypair.pubkey(), vote_account),


### PR DESCRIPTION
Revert #4498 and fix it properly by funding the bootstrap leader's identity keypair (which is used to pay for votes)