### PR TITLE
Fix race condition in AccountsDb

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -21,6 +21,7 @@ use solana_runtime::bank::Bank;
 use solana_runtime::locked_accounts_results::LockedAccountsResults;
 use solana_sdk::poh_config::PohConfig;
 use solana_sdk::pubkey::Pubkey;
+use solana_sdk::system_config::NUM_BANKING_THREADS;
 use solana_sdk::timing::{
     self, duration_as_us, DEFAULT_TICKS_PER_SLOT, MAX_RECENT_BLOCKHASHES,
     MAX_TRANSACTION_FORWARDING_DELAY,
@@ -37,9 +38,6 @@ use sys_info;
 
 type PacketsAndOffsets = (Packets, Vec<usize>);
 pub type UnprocessedPackets = Vec<PacketsAndOffsets>;
-
-// number of threads is 1 until mt bank is ready
-pub const NUM_THREADS: u32 = 10;
 
 /// Stores the stage's thread handle and output receiver.
 pub struct BankingStage {
@@ -359,7 +357,7 @@ impl BankingStage {
     }
 
     pub fn num_threads() -> u32 {
-        sys_info::cpu_num().unwrap_or(NUM_THREADS)
+        sys_info::cpu_num().unwrap_or(NUM_BANKING_THREADS)
     }
 
     /// Convert the transactions from a blob of binary data to a vector of transactions

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -178,15 +178,8 @@ impl AccountStorageEntry {
     ) {
         let count = count_and_status.0;
 
-        if status == AccountStorageStatus::StorageFull && count == 0 {
-            // this case arises when the append_vec is full (store_ptrs fails),
-            //  but all accounts have already been removed from the storage
-            //
-            // the only time it's safe to call reset() on an append_vec is when
-            //  every account has been removed
-            //          **and**
-            //  the append_vec has previously been completely full
-            //
+        if count == 0 {
+            // This case arises when all accounts have already been removed from the storage
             self.accounts.reset();
             status = AccountStorageStatus::StorageAvailable;
         }
@@ -210,18 +203,8 @@ impl AccountStorageEntry {
         let mut count_and_status = self.count_and_status.write().unwrap();
         let (count, mut status) = *count_and_status;
 
-        if count == 1 && status == AccountStorageStatus::StorageFull {
-            // this case arises when we remove the last account from the
-            //  storage, but we've learned from previous write attempts that
-            //  the storage is full
-            //
-            // the only time it's safe to call reset() on an append_vec is when
-            //  every account has been removed
-            //          **and**
-            //  the append_vec has previously been completely full
-            //
-            // otherwise, the storage may be in flight with a store()
-            //   call
+        if count == 1 {
+            // This case arises when when every account has been removed
             self.accounts.reset();
             status = AccountStorageStatus::StorageAvailable;
         }

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -199,8 +199,7 @@ impl AccountStorageEntry {
         *count_and_status = (count_and_status.0 + 1, count_and_status.1);
     }
 
-    fn remove_account(&self) -> usize {
-        let mut count_and_status = self.count_and_status.write().unwrap();
+    fn remove_account(&self, count_and_status: &mut (usize, AccountStorageStatus)) -> usize {
         let (count, mut status) = *count_and_status;
 
         if count == 1 {
@@ -464,7 +463,8 @@ impl AccountsDB {
                         fork_id, store.fork_id,
                         "AccountDB::accounts_index corrupted. Storage should only point to one fork"
                     );
-                    let count = store.remove_account();
+                    let mut count_and_status = store.count_and_status.write().unwrap();
+                    let count = store.remove_account(&mut count_and_status);
                     if count == 0 {
                         dead_forks.insert(fork_id);
                     }

--- a/runtime/src/append_vec.rs
+++ b/runtime/src/append_vec.rs
@@ -130,6 +130,10 @@ impl AppendVec {
     fn get_slice(&self, offset: usize, size: usize) -> Option<(&[u8], usize)> {
         let len = self.len();
         if len < offset + size {
+            println!(
+                "Get slice is none, len: {}, offset: {}, size: {}",
+                len, offset, size
+            );
             return None;
         }
         let data = &self.map[offset..offset + size];
@@ -191,8 +195,16 @@ impl AppendVec {
     }
 
     pub fn get_account<'a>(&'a self, offset: usize) -> Option<(StoredAccount<'a>, usize)> {
-        let (meta, next): (&'a StorageMeta, _) = self.get_type(offset)?;
-        let (balance, next): (&'a AccountBalance, _) = self.get_type(next)?;
+        let res = self.get_type(offset);
+        if res.is_none() {
+            println!("Couldn't get offset");
+        }
+        let (meta, next): (&'a StorageMeta, _) = res?;
+        let res = self.get_type(next);
+        if res.is_none() {
+            println!("Couldn't get next");
+        }
+        let (balance, next): (&'a AccountBalance, _) = res?;
         let (data, next) = self.get_slice(next, meta.data_len as usize)?;
         Some((
             StoredAccount {

--- a/runtime/src/append_vec.rs
+++ b/runtime/src/append_vec.rs
@@ -130,10 +130,6 @@ impl AppendVec {
     fn get_slice(&self, offset: usize, size: usize) -> Option<(&[u8], usize)> {
         let len = self.len();
         if len < offset + size {
-            println!(
-                "Get slice is none, len: {}, offset: {}, size: {}",
-                len, offset, size
-            );
             return None;
         }
         let data = &self.map[offset..offset + size];
@@ -195,16 +191,8 @@ impl AppendVec {
     }
 
     pub fn get_account<'a>(&'a self, offset: usize) -> Option<(StoredAccount<'a>, usize)> {
-        let res = self.get_type(offset);
-        if res.is_none() {
-            println!("Couldn't get offset");
-        }
-        let (meta, next): (&'a StorageMeta, _) = res?;
-        let res = self.get_type(next);
-        if res.is_none() {
-            println!("Couldn't get next");
-        }
-        let (balance, next): (&'a AccountBalance, _) = res?;
+        let (meta, next): (&'a StorageMeta, _) = self.get_type(offset)?;
+        let (balance, next): (&'a AccountBalance, _) = self.get_type(next)?;
         let (data, next) = self.get_slice(next, meta.data_len as usize)?;
         Some((
             StoredAccount {

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -17,12 +17,12 @@ pub mod rpc_port;
 pub mod short_vec;
 pub mod signature;
 pub mod syscall;
+pub mod system_config;
 pub mod system_instruction;
 pub mod system_program;
 pub mod system_transaction;
 pub mod timing;
 pub mod transaction;
 pub mod transport;
-
 #[macro_use]
 extern crate serde_derive;

--- a/sdk/src/system_config.rs
+++ b/sdk/src/system_config.rs
@@ -1,0 +1,1 @@
+pub const NUM_BANKING_THREADS: u32 = 10;


### PR DESCRIPTION
#### Problem
There is a gap between append_accounts(): https://github.com/solana-labs/solana/blob/master/runtime/src/accounts_db.rs#L369 and add_account() here: https://github.com/solana-labs/solana/blob/master/runtime/src/accounts_db.rs#L374, which actually increments the counter. This exposes the possibility that reset() on the AccountStorageEntry could be called in between those two above, after the storage is marked as full here: https://github.com/solana-labs/solana/blob/master/runtime/src/accounts_db.rs#L371.

#### Summary of Changes
1) Add a stress test to reproduce the bug

2) Hold the count_and_status() lock before grabbing the offset() lock in the AppendVec and doing any append work. This prevents the reset logic in remove_accounts() and set_status() from happening in between appending to the vector and incrementing the count.

3) Remove the necessity to check for AccountStorageStatus::StorageFull before resetting AppendVecs. @rob-solana 

Fixes #
