### PR TITLE
Revert "Enable non-zero fees for all testnets (#4513)"

### DIFF
--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -80,7 +80,6 @@ local|tar)
       args=(
         --bootstrap-leader-lamports "$stake"
         --bootstrap-leader-stake-lamports "$stake"
-        --lamports-per-signature 1
       )
       # shellcheck disable=SC2206 # Do not want to quote $genesisOptions
       args+=($genesisOptions)


### PR DESCRIPTION
This reverts commit e15246746d8a446105d56b970caf2a3564d8f87d.

#### Problem
The testnet is unable to fund initial accounts.

#### Summary of Changes
The bench TPS client is not able to fund the initial accounts due to transaction fees. Reverting the patch for now.

Fixes #
