### PR TITLE
Add GPU based PoH verification

### DIFF
--- a/core/benches/poh_verify.rs
+++ b/core/benches/poh_verify.rs
@@ -1,0 +1,48 @@
+#![feature(test)]
+extern crate test;
+
+use solana::entry::EntrySlice;
+use solana::entry::{next_entry_mut, Entry};
+use solana_sdk::hash::{hash, Hash};
+use solana_sdk::signature::{Keypair, KeypairUtil};
+use solana_sdk::system_transaction;
+use test::Bencher;
+
+const NUM_HASHES: u64 = 400;
+const NUM_ENTRIES: usize = 800;
+
+#[bench]
+fn bench_poh_verify_ticks(bencher: &mut Bencher) {
+    let zero = Hash::default();
+    let mut cur_hash = hash(&zero.as_ref());
+    let start = *&cur_hash;
+
+    let mut ticks: Vec<Entry> = Vec::with_capacity(NUM_ENTRIES);
+    for _ in 0..NUM_ENTRIES {
+        ticks.push(next_entry_mut(&mut cur_hash, NUM_HASHES, vec![]));
+    }
+
+    bencher.iter(|| {
+        ticks.verify(&start);
+    })
+}
+
+#[bench]
+fn bench_poh_verify_transaction_entries(bencher: &mut Bencher) {
+    let zero = Hash::default();
+    let mut cur_hash = hash(&zero.as_ref());
+    let start = *&cur_hash;
+
+    let keypair1 = Keypair::new();
+    let pubkey1 = keypair1.pubkey();
+
+    let mut ticks: Vec<Entry> = Vec::with_capacity(NUM_ENTRIES);
+    for _ in 0..NUM_ENTRIES {
+        let tx = system_transaction::create_user_account(&keypair1, &pubkey1, 42, cur_hash);
+        ticks.push(next_entry_mut(&mut cur_hash, NUM_HASHES, vec![tx]));
+    }
+
+    bencher.iter(|| {
+        ticks.verify(&start);
+    })
+}

--- a/core/src/sigverify.rs
+++ b/core/src/sigverify.rs
@@ -17,6 +17,9 @@ use solana_sdk::signature::Signature;
 use solana_sdk::transaction::Transaction;
 use std::mem::size_of;
 
+#[cfg(feature = "cuda")]
+use std::os::raw::c_int;
+
 pub const NUM_THREADS: u32 = 10;
 use std::cell::RefCell;
 
@@ -68,6 +71,13 @@ extern "C" {
 
     pub fn chacha_init_sha_state(sha_state: *mut u8, num_keys: u32);
     pub fn chacha_end_sha_state(sha_state_in: *const u8, out: *mut u8, num_keys: u32);
+
+    pub fn poh_verify_many(
+        hashes: *const u8,
+        num_hashes_arr: *const u64,
+        num_elems: usize,
+        use_non_default_stream: u8,
+    ) -> c_int;
 }
 
 #[cfg(not(feature = "cuda"))]

--- a/core/src/sigverify.rs
+++ b/core/src/sigverify.rs
@@ -73,7 +73,7 @@ extern "C" {
     pub fn chacha_end_sha_state(sha_state_in: *const u8, out: *mut u8, num_keys: u32);
 
     pub fn poh_verify_many(
-        hashes: *const u8,
+        hashes: *mut u8,
         num_hashes_arr: *const u64,
         num_elems: usize,
         use_non_default_stream: u8,

--- a/fetch-perf-libs.sh
+++ b/fetch-perf-libs.sh
@@ -17,7 +17,7 @@ if [[ ! -d target/perf-libs ]]; then
   (
     set -x
     cd target/perf-libs
-    curl https://solana-perf.s3.amazonaws.com/v0.13.0/x86_64-unknown-linux-gnu/solana-perf.tgz | tar zxvf -
+    curl https://solana-perf.s3.amazonaws.com/v0.13.2/x86_64-unknown-linux-gnu/solana-perf.tgz | tar zxvf -
   )
 fi
 

--- a/fetch-perf-libs.sh
+++ b/fetch-perf-libs.sh
@@ -17,7 +17,7 @@ if [[ ! -d target/perf-libs ]]; then
   (
     set -x
     cd target/perf-libs
-    curl https://solana-perf.s3.amazonaws.com/v0.12.1/x86_64-unknown-linux-gnu/solana-perf.tgz | tar zxvf -
+    curl https://solana-perf.s3.amazonaws.com/v0.13.0/x86_64-unknown-linux-gnu/solana-perf.tgz | tar zxvf -
   )
 fi
 

--- a/sdk/src/hash.rs
+++ b/sdk/src/hash.rs
@@ -2,10 +2,10 @@
 
 use bs58;
 use sha2::{Digest, Sha256};
+use std::convert::TryFrom;
 use std::fmt;
 use std::mem;
 use std::str::FromStr;
-use std::convert::TryFrom;
 
 #[derive(Serialize, Deserialize, Clone, Copy, Default, Eq, PartialEq, Ord, PartialOrd, Hash)]
 #[repr(transparent)]
@@ -28,9 +28,7 @@ impl Hasher {
     pub fn result(self) -> Hash {
         // At the time of this writing, the sha2 library is stuck on an old version
         // of generic_array (0.9.0). Decouple ourselves with a clone to our version.
-        Hash(
-            <[u8; 32]>::try_from(self.hasher.result().as_slice()).unwrap(),
-        )
+        Hash(<[u8; 32]>::try_from(self.hasher.result().as_slice()).unwrap())
     }
 }
 

--- a/sdk/src/hash.rs
+++ b/sdk/src/hash.rs
@@ -1,15 +1,15 @@
 //! The `hash` module provides functions for creating SHA-256 hashes.
 
 use bs58;
-use generic_array::typenum::U32;
-use generic_array::GenericArray;
 use sha2::{Digest, Sha256};
 use std::fmt;
 use std::mem;
 use std::str::FromStr;
+use std::convert::TryFrom;
 
 #[derive(Serialize, Deserialize, Clone, Copy, Default, Eq, PartialEq, Ord, PartialOrd, Hash)]
-pub struct Hash(GenericArray<u8, U32>);
+#[repr(transparent)]
+pub struct Hash([u8; 32]);
 
 #[derive(Clone, Default)]
 pub struct Hasher {
@@ -28,9 +28,9 @@ impl Hasher {
     pub fn result(self) -> Hash {
         // At the time of this writing, the sha2 library is stuck on an old version
         // of generic_array (0.9.0). Decouple ourselves with a clone to our version.
-        Hash(GenericArray::clone_from_slice(
-            self.hasher.result().as_slice(),
-        ))
+        Hash(
+            <[u8; 32]>::try_from(self.hasher.result().as_slice()).unwrap(),
+        )
     }
 }
 
@@ -75,7 +75,7 @@ impl FromStr for Hash {
 
 impl Hash {
     pub fn new(hash_slice: &[u8]) -> Self {
-        Hash(GenericArray::clone_from_slice(&hash_slice))
+        Hash(<[u8; 32]>::try_from(hash_slice).unwrap())
     }
 }
 


### PR DESCRIPTION
#### Problem
PoH verify is done entirely on the CPU

#### Summary of Changes
Interface with new CUDA based PoH verification functions in solana-perf-libs. When the `cuda` feature is enabled, PoH verify will be offloaded to the GPU. The mixins due to transactions in a Transaction Entry are still calculated on CPU, due to the high ratio of data transferred to computation. 

Benchmarking demonstrates that the GPU offloading can have speed benefits, though large `num_hashes` per entry and small `[Entry].len()` values can result in CPU only computation still being faster. With `num_hashes=80`, I observed the cutoff to be around 600 Entries per slice. With `num_hashes=400`, I observed the cutoff to be between 300 and 400 Entries per slice. With other loads on the CPU, it is likely that larger `num_hashes` values and smaller `[Entry].len()` will still show a speed benefit.

Fixes #4161 

