### PR TITLE
Wait for crate to be locatable on crates.io after uploading

### DIFF
--- a/ci/publish-crate.sh
+++ b/ci/publish-crate.sh
@@ -3,6 +3,14 @@ set -e
 cd "$(dirname "$0")/.."
 source ci/semver_bash/semver.sh
 
+is_crate_version_uploaded() {
+  name=$1
+  version=$2
+  curl https://crates.io/api/v1/crates/${name}/${version} | \
+  python3 -c "import sys,json; print('version' in json.load(sys.stdin));"
+
+}
+
 # Only package/publish if this is a tagged release
 [[ -n $TRIGGERED_BUILDKITE_TAG ]] || {
   echo TRIGGERED_BUILDKITE_TAG unset, skipped
@@ -35,8 +43,22 @@ for Cargo_toml in $Cargo_tomls; do
     # so use the solana rust docker image until this is resolved upstream
     source ci/rust-version.sh
     ci/docker-run.sh "$rust_stable_docker_image" bash -exc "cd $crate; $cargoCommand"
-    #ci/docker-run.sh rust bash -exc "cd $crate; $cargoCommand"
   ) || true # <-- Don't fail.  We want to be able to retry the job in cases when a publish fails halfway due to network/cloud issues
+
+  crate_name=$(grep -m 1 '^name = ' $Cargo_toml | cut -f 3 -d ' ' | tr -d \")
+  numRetries=30
+  sleepTime=2
+  for ((i = 1 ; i <= $numRetries ; i++)); do
+    echo "Attempt ${i} of ${numRetries}"
+    if $(is_crate_version_uploaded $crate_name $expectedCrateVersion) = "True"
+    then
+      echo "Found ${crate_name} version ${expectedCrateVersion} on crates.io"
+      break
+    else
+      echo "Did not find ${crate_name} version ${expectedCrateVersion} on crates.io.  Sleeping for ${sleepTime}."
+      sleep ${sleepTime}
+    fi
+  done
 done
 
 exit 0

--- a/ci/publish-crate.sh
+++ b/ci/publish-crate.sh
@@ -3,12 +3,12 @@ set -e
 cd "$(dirname "$0")/.."
 source ci/semver_bash/semver.sh
 
+# shellcheck disable=SC2086
 is_crate_version_uploaded() {
   name=$1
   version=$2
   curl https://crates.io/api/v1/crates/${name}/${version} | \
   python3 -c "import sys,json; print('version' in json.load(sys.stdin));"
-
 }
 
 # Only package/publish if this is a tagged release
@@ -47,17 +47,14 @@ for Cargo_toml in $Cargo_tomls; do
 
   crate_name=$(grep -m 1 '^name = ' $Cargo_toml | cut -f 3 -d ' ' | tr -d \")
   numRetries=30
-  sleepTime=2
-  for ((i = 1 ; i <= $numRetries ; i++)); do
+  for ((i = 1 ; i <= numRetries ; i++)); do
     echo "Attempt ${i} of ${numRetries}"
-    if $(is_crate_version_uploaded $crate_name $expectedCrateVersion) = "True"
-    then
+    if [[ $(is_crate_version_uploaded $crate_name $expectedCrateVersion) = True ]] ; then
       echo "Found ${crate_name} version ${expectedCrateVersion} on crates.io"
       break
-    else
-      echo "Did not find ${crate_name} version ${expectedCrateVersion} on crates.io.  Sleeping for ${sleepTime}."
-      sleep ${sleepTime}
     fi
+    echo "Did not find ${crate_name} version ${expectedCrateVersion} on crates.io.  Sleeping for 2 seconds."
+    sleep 2
   done
 done
 

--- a/ci/publish-crate.sh
+++ b/ci/publish-crate.sh
@@ -45,10 +45,12 @@ for Cargo_toml in $Cargo_tomls; do
     ci/docker-run.sh "$rust_stable_docker_image" bash -exc "cd $crate; $cargoCommand"
   ) || true # <-- Don't fail.  We want to be able to retry the job in cases when a publish fails halfway due to network/cloud issues
 
+  # shellcheck disable=SC2086
   crate_name=$(grep -m 1 '^name = ' $Cargo_toml | cut -f 3 -d ' ' | tr -d \")
   numRetries=30
   for ((i = 1 ; i <= numRetries ; i++)); do
     echo "Attempt ${i} of ${numRetries}"
+    # shellcheck disable=SC2086
     if [[ $(is_crate_version_uploaded $crate_name $expectedCrateVersion) = True ]] ; then
       echo "Found ${crate_name} version ${expectedCrateVersion} on crates.io"
       break


### PR DESCRIPTION
#### Problem

Crates are now published in dynamic order according to the dependency tree, but we move on to subsequent crate publishing before the previous crate might be finished uploading, resulting in a publish failure due to missing dependency.

#### Summary of Changes

After running cargo publish for a given crate, make sure the new version can be retrieved from crates.io before moving on to the next publish.

Fixes #4501 
