### PR TITLE
Enable transaction fees for multinode-demo/ and net/

### DIFF
--- a/ci/localnet-sanity.sh
+++ b/ci/localnet-sanity.sh
@@ -294,10 +294,7 @@ flag_error() {
 }
 
 if ! $skipSetup; then
-  multinode-demo/setup.sh \
-    --hashes-per-tick auto \
-    --lamports-per-signature 1 \
-
+  multinode-demo/setup.sh --hashes-per-tick auto
 else
   verifyLedger
 fi

--- a/multinode-demo/setup.sh
+++ b/multinode-demo/setup.sh
@@ -22,8 +22,9 @@ default_arg --bootstrap-storage-keypair "$SOLANA_CONFIG_DIR"/bootstrap-leader-st
 default_arg --ledger "$SOLANA_RSYNC_CONFIG_DIR"/ledger
 default_arg --mint "$SOLANA_CONFIG_DIR"/mint-keypair.json
 default_arg --lamports 100000000000000
+default_arg --bootstrap-leader-lamports 424242
+default_arg --lamports-per-signature 1
 default_arg --hashes-per-tick sleep
-
 $solana_genesis "${args[@]}"
 
 test -d "$SOLANA_RSYNC_CONFIG_DIR"/ledger

--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -15,7 +15,7 @@ genesisOptions="$8"
 set +x
 export RUST_LOG
 
-# Use a very large stake (relative to the default multinode-demo/ stake of 43)
+# Use a very large stake (relative to the default multinode-demo/ stake of 42)
 # for the testnet validators setup by net/.  This make it less likely that
 # low-staked ephemeral validator a random user may attach to testnet will cause
 # trouble
@@ -78,7 +78,6 @@ local|tar)
     set -x
     if [[ $skipSetup != true ]]; then
       args=(
-        --bootstrap-leader-lamports "$stake"
         --bootstrap-leader-stake-lamports "$stake"
       )
       # shellcheck disable=SC2206 # Do not want to quote $genesisOptions


### PR DESCRIPTION
Attempt #2.   The first commit in here is from #4525.

multinode-demo/ now differentiates between the lamports used for staking and lamports used for funding transactions.   All nodes by default still get a stake of 42 but receive 424242 lamports in their identity account for funding transactions.