### PR TITLE
v0.15: Disable |solana-install| check for edge/beta testnets

### DIFF
--- a/ci/testnet-deploy.sh
+++ b/ci/testnet-deploy.sh
@@ -311,6 +311,9 @@ if ! $skipStart; then
     if [[ -n $NO_LEDGER_VERIFY ]]; then
       args+=(-o noLedgerVerify)
     fi
+    if [[ -n $NO_INSTALL_CHECK ]]; then
+      args+=(-o noInstallCheck)
+    fi
     if [[ -n $maybeHashesPerTick ]]; then
       # shellcheck disable=SC2206 # Do not want to quote $maybeHashesPerTick
       args+=($maybeHashesPerTick)

--- a/ci/testnet-manager.sh
+++ b/ci/testnet-manager.sh
@@ -212,6 +212,7 @@ sanity() {
   testnet-edge)
     (
       set -x
+      NO_INSTALL_CHECK=1 \
       NO_LEDGER_VERIFY=1 \
         ci/testnet-sanity.sh edge-testnet-solana-com ec2 us-west-1a
     )
@@ -228,6 +229,7 @@ sanity() {
   testnet-beta)
     (
       set -x
+      NO_INSTALL_CHECK=1 \
       NO_LEDGER_VERIFY=1 \
         ci/testnet-sanity.sh beta-testnet-solana-com ec2 us-west-1a
     )

--- a/ci/testnet-sanity.sh
+++ b/ci/testnet-sanity.sh
@@ -64,6 +64,7 @@ for zone in "$@"; do
     ${NO_LEDGER_VERIFY:+-o noLedgerVerify} \
     ${NO_VALIDATOR_SANITY:+-o noValidatorSanity} \
     ${REJECT_EXTRA_NODES:+-o rejectExtraNodes} \
+    ${NO_INSTALL_CHECK:+-o noInstallCheck} \
     $zone || ok=false
 
   net/net.sh logs

--- a/net/net.sh
+++ b/net/net.sh
@@ -58,6 +58,7 @@ Operate a configured testnet
    -F                   - Discard validator nodes that didn't bootup successfully
    -o noLedgerVerify    - Skip ledger verification
    -o noValidatorSanity - Skip fullnode sanity
+   -o noInstallCheck    - Skip solana-install sanity
    -o rejectExtraNodes  - Require the exact number of nodes
 
  stop-specific options:
@@ -150,7 +151,7 @@ while getopts "h?T:t:o:f:rD:i:c:Fn:" opt "${shortArgs[@]}"; do
     ;;
   o)
     case $OPTARG in
-    noLedgerVerify|noValidatorSanity|rejectExtraNodes)
+    noLedgerVerify|noValidatorSanity|rejectExtraNodes|noInstallCheck)
       sanityExtraArgs="$sanityExtraArgs -o $OPTARG"
       ;;
     *)

--- a/net/remote/remote-sanity.sh
+++ b/net/remote/remote-sanity.sh
@@ -34,6 +34,7 @@ missing() {
 
 ledgerVerify=true
 validatorSanity=true
+installCheck=true
 rejectExtraNodes=false
 while [[ $1 = -o ]]; do
   opt="$2"
@@ -44,6 +45,9 @@ while [[ $1 = -o ]]; do
     ;;
   noValidatorSanity)
     validatorSanity=false
+    ;;
+  noInstallCheck)
+    installCheck=false
     ;;
   rejectExtraNodes)
     rejectExtraNodes=true
@@ -168,7 +172,7 @@ else
   echo "Note: validator sanity disabled"
 fi
 
-if [[ -r update_manifest_keypair.json ]]; then
+if $installCheck && [[ -r update_manifest_keypair.json ]]; then
   echo "--- $sanityTargetIp: solana-install test"
 
   (


### PR DESCRIPTION
The release tarball URL changes for these testnets, which causes the
normal |solana-install| check to fail and the testnet is unnecessarily
rebooted.
