### PR TITLE
Add AccountWrapper to pass accounts into programs

### DIFF
--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -6,7 +6,7 @@ use crate::rpc_request::RpcRequest;
 use bincode::serialize;
 use log::*;
 use serde_json::{json, Value};
-use solana_sdk::account::Account;
+use solana_sdk::credit_debit_account::CreditDebitAccount;
 use solana_sdk::fee_calculator::FeeCalculator;
 use solana_sdk::hash::Hash;
 use solana_sdk::pubkey::Pubkey;
@@ -223,7 +223,7 @@ impl RpcClient {
         Ok(res)
     }
 
-    pub fn get_account(&self, pubkey: &Pubkey) -> io::Result<Account> {
+    pub fn get_account(&self, pubkey: &Pubkey) -> io::Result<CreditDebitAccount> {
         let params = json!([format!("{}", pubkey)]);
         let response = self
             .client
@@ -231,7 +231,7 @@ impl RpcClient {
 
         response
             .and_then(|account_json| {
-                let account: Account =
+                let account: CreditDebitAccount =
                     serde_json::from_value(account_json).expect("deserialize account");
                 trace!("Response account {:?} {:?}", pubkey, account);
                 Ok(account)

--- a/core/src/locktower.rs
+++ b/core/src/locktower.rs
@@ -2,7 +2,7 @@ use crate::bank_forks::BankForks;
 use crate::staking_utils;
 use solana_metrics::datapoint_info;
 use solana_runtime::bank::Bank;
-use solana_sdk::account::Account;
+use solana_sdk::credit_debit_account::CreditDebitAccount;
 use solana_sdk::hash::Hash;
 use solana_sdk::pubkey::Pubkey;
 use solana_vote_api::vote_state::{Lockout, Vote, VoteState, MAX_LOCKOUT_HISTORY};
@@ -56,7 +56,7 @@ impl EpochStakes {
             &Pubkey::default(),
         )
     }
-    pub fn new_from_stakes(epoch: u64, accounts: &[(Pubkey, (u64, Account))]) -> Self {
+    pub fn new_from_stakes(epoch: u64, accounts: &[(Pubkey, (u64, CreditDebitAccount))]) -> Self {
         let stakes = accounts.iter().map(|(k, (v, _))| (*k, *v)).collect();
         Self::new(epoch, stakes, &accounts[0].0)
     }
@@ -109,7 +109,7 @@ impl Locktower {
         ancestors: &HashMap<u64, HashSet<u64>>,
     ) -> HashMap<u64, StakeLockout>
     where
-        F: Iterator<Item = (Pubkey, (u64, Account))>,
+        F: Iterator<Item = (Pubkey, (u64, CreditDebitAccount))>,
     {
         let mut stake_lockouts = HashMap::new();
         for (key, (_, account)) in vote_accounts {
@@ -407,10 +407,10 @@ impl Locktower {
 mod test {
     use super::*;
 
-    fn gen_stakes(stake_votes: &[(u64, &[u64])]) -> Vec<(Pubkey, (u64, Account))> {
+    fn gen_stakes(stake_votes: &[(u64, &[u64])]) -> Vec<(Pubkey, (u64, CreditDebitAccount))> {
         let mut stakes = vec![];
         for (lamports, votes) in stake_votes {
-            let mut account = Account::default();
+            let mut account = CreditDebitAccount::default();
             account.data = vec![0; 1024];
             account.lamports = *lamports;
             let mut vote_state = VoteState::default();
@@ -756,7 +756,7 @@ mod test {
     #[test]
     fn test_stake_is_updated_for_entire_branch() {
         let mut stake_lockouts = HashMap::new();
-        let mut account = Account::default();
+        let mut account = CreditDebitAccount::default();
         account.lamports = 1;
         let set: HashSet<u64> = vec![0u64, 1u64].into_iter().collect();
         let ancestors: HashMap<u64, HashSet<u64>> = [(2u64, set)].into_iter().cloned().collect();

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -10,7 +10,7 @@ use jsonrpc_core::{Error, Metadata, Result};
 use jsonrpc_derive::rpc;
 use solana_drone::drone::request_airdrop_transaction;
 use solana_runtime::bank::Bank;
-use solana_sdk::account::Account;
+use solana_sdk::credit_debit_account::CreditDebitAccount;
 use solana_sdk::fee_calculator::FeeCalculator;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::Signature;
@@ -64,7 +64,7 @@ impl JsonRpcRequestProcessor {
         }
     }
 
-    pub fn get_account_info(&self, pubkey: &Pubkey) -> Result<Account> {
+    pub fn get_account_info(&self, pubkey: &Pubkey) -> Result<CreditDebitAccount> {
         self.bank()
             .get_account(&pubkey)
             .ok_or_else(Error::invalid_request)
@@ -176,7 +176,7 @@ pub trait RpcSol {
     fn confirm_transaction(&self, _: Self::Metadata, _: String) -> Result<bool>;
 
     #[rpc(meta, name = "getAccountInfo")]
-    fn get_account_info(&self, _: Self::Metadata, _: String) -> Result<Account>;
+    fn get_account_info(&self, _: Self::Metadata, _: String) -> Result<CreditDebitAccount>;
 
     #[rpc(meta, name = "getBalance")]
     fn get_balance(&self, _: Self::Metadata, _: String) -> Result<u64>;
@@ -250,7 +250,7 @@ impl RpcSol for RpcSolImpl {
         })
     }
 
-    fn get_account_info(&self, meta: Self::Metadata, id: String) -> Result<Account> {
+    fn get_account_info(&self, meta: Self::Metadata, id: String) -> Result<CreditDebitAccount> {
         debug!("get_account_info rpc request received: {:?}", id);
         let pubkey = verify_pubkey(id)?;
         meta.request_processor

--- a/core/src/rpc_pubsub.rs
+++ b/core/src/rpc_pubsub.rs
@@ -5,7 +5,7 @@ use jsonrpc_core::{Error, ErrorCode, Result};
 use jsonrpc_derive::rpc;
 use jsonrpc_pubsub::typed::Subscriber;
 use jsonrpc_pubsub::{Session, SubscriptionId};
-use solana_sdk::account::Account;
+use solana_sdk::credit_debit_account::CreditDebitAccount;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::Signature;
 use solana_sdk::transaction;
@@ -25,7 +25,7 @@ pub trait RpcSolPubSub {
     fn account_subscribe(
         &self,
         _: Self::Metadata,
-        _: Subscriber<Account>,
+        _: Subscriber<CreditDebitAccount>,
         _: String,
         _: Option<Confirmations>,
     );
@@ -48,7 +48,7 @@ pub trait RpcSolPubSub {
     fn program_subscribe(
         &self,
         _: Self::Metadata,
-        _: Subscriber<(String, Account)>,
+        _: Subscriber<(String, CreditDebitAccount)>,
         _: String,
         _: Option<Confirmations>,
     );
@@ -114,7 +114,7 @@ impl RpcSolPubSub for RpcSolPubSubImpl {
     fn account_subscribe(
         &self,
         _meta: Self::Metadata,
-        subscriber: Subscriber<Account>,
+        subscriber: Subscriber<CreditDebitAccount>,
         pubkey_str: String,
         confirmations: Option<Confirmations>,
     ) {
@@ -152,7 +152,7 @@ impl RpcSolPubSub for RpcSolPubSubImpl {
     fn program_subscribe(
         &self,
         _meta: Self::Metadata,
-        subscriber: Subscriber<(String, Account)>,
+        subscriber: Subscriber<(String, CreditDebitAccount)>,
         pubkey_str: String,
         confirmations: Option<Confirmations>,
     ) {

--- a/core/src/rpc_subscriptions.rs
+++ b/core/src/rpc_subscriptions.rs
@@ -7,7 +7,7 @@ use jsonrpc_pubsub::typed::Sink;
 use jsonrpc_pubsub::SubscriptionId;
 use serde::Serialize;
 use solana_runtime::bank::Bank;
-use solana_sdk::account::Account;
+use solana_sdk::credit_debit_account::CreditDebitAccount;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::Signature;
 use solana_sdk::transaction;
@@ -18,9 +18,10 @@ use std::sync::{Arc, RwLock};
 pub type Confirmations = usize;
 
 type RpcAccountSubscriptions =
-    RwLock<HashMap<Pubkey, HashMap<SubscriptionId, (Sink<Account>, Confirmations)>>>;
-type RpcProgramSubscriptions =
-    RwLock<HashMap<Pubkey, HashMap<SubscriptionId, (Sink<(String, Account)>, Confirmations)>>>;
+    RwLock<HashMap<Pubkey, HashMap<SubscriptionId, (Sink<CreditDebitAccount>, Confirmations)>>>;
+type RpcProgramSubscriptions = RwLock<
+    HashMap<Pubkey, HashMap<SubscriptionId, (Sink<(String, CreditDebitAccount)>, Confirmations)>>,
+>;
 type RpcSignatureSubscriptions = RwLock<
     HashMap<Signature, HashMap<SubscriptionId, (Sink<transaction::Result<()>>, Confirmations)>>,
 >;
@@ -141,7 +142,11 @@ where
     }
 }
 
-fn notify_program(accounts: Vec<(Pubkey, Account)>, sink: &Sink<(String, Account)>, _root: u64) {
+fn notify_program(
+    accounts: Vec<(Pubkey, CreditDebitAccount)>,
+    sink: &Sink<(String, CreditDebitAccount)>,
+    _root: u64,
+) {
     for (pubkey, account) in accounts.iter() {
         sink.notify(Ok((pubkey.to_string(), account.clone())))
             .wait()
@@ -223,7 +228,7 @@ impl RpcSubscriptions {
         pubkey: &Pubkey,
         confirmations: Option<Confirmations>,
         sub_id: &SubscriptionId,
-        sink: &Sink<Account>,
+        sink: &Sink<CreditDebitAccount>,
     ) {
         let mut subscriptions = self.account_subscriptions.write().unwrap();
         add_subscription(&mut subscriptions, pubkey, confirmations, sub_id, sink);
@@ -239,7 +244,7 @@ impl RpcSubscriptions {
         program_id: &Pubkey,
         confirmations: Option<Confirmations>,
         sub_id: &SubscriptionId,
-        sink: &Sink<(String, Account)>,
+        sink: &Sink<(String, CreditDebitAccount)>,
     ) {
         let mut subscriptions = self.program_subscriptions.write().unwrap();
         add_subscription(&mut subscriptions, program_id, confirmations, sub_id, sink);

--- a/core/src/staking_utils.rs
+++ b/core/src/staking_utils.rs
@@ -1,5 +1,5 @@
 use solana_runtime::bank::Bank;
-use solana_sdk::account::Account;
+use solana_sdk::credit_debit_account::CreditDebitAccount;
 use solana_sdk::pubkey::Pubkey;
 use solana_vote_api::vote_state::VoteState;
 use std::borrow::Borrow;
@@ -52,7 +52,9 @@ pub fn staked_nodes_at_epoch(bank: &Bank, epoch_height: u64) -> Option<HashMap<P
 
 // input (vote_pubkey, (stake, vote_account)) => (stake, vote_state)
 fn to_vote_states(
-    node_staked_accounts: impl Iterator<Item = (impl Borrow<Pubkey>, impl Borrow<(u64, Account)>)>,
+    node_staked_accounts: impl Iterator<
+        Item = (impl Borrow<Pubkey>, impl Borrow<(u64, CreditDebitAccount)>),
+    >,
 ) -> impl Iterator<Item = (u64, VoteState)> {
     node_staked_accounts.filter_map(|(_, stake_account)| {
         VoteState::deserialize(&stake_account.borrow().1.data)

--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -14,7 +14,7 @@ extern crate solana_exchange_program;
 
 use clap::{crate_description, crate_name, crate_version, value_t_or_exit, App, Arg};
 use solana::blocktree::create_new_ledger;
-use solana_sdk::account::Account;
+use solana_sdk::credit_debit_account::CreditDebitAccount;
 use solana_sdk::fee_calculator::FeeCalculator;
 use solana_sdk::genesis_block::GenesisBlock;
 use solana_sdk::hash::{hash, Hash};
@@ -200,12 +200,12 @@ fn main() -> Result<(), Box<dyn error::Error>> {
             // the mint
             (
                 mint_keypair.pubkey(),
-                Account::new(lamports, 0, &system_program::id()),
+                CreditDebitAccount::new(lamports, 0, &system_program::id()),
             ),
             // node needs an account to issue votes from
             (
                 bootstrap_leader_keypair.pubkey(),
-                Account::new(bootstrap_leader_lamports, 0, &system_program::id()),
+                CreditDebitAccount::new(bootstrap_leader_lamports, 0, &system_program::id()),
             ),
             // where votes go to
             (bootstrap_vote_keypair.pubkey(), vote_account),

--- a/programs/budget_api/src/budget_processor.rs
+++ b/programs/budget_api/src/budget_processor.rs
@@ -5,7 +5,7 @@ use crate::budget_state::{BudgetError, BudgetState};
 use bincode::deserialize;
 use chrono::prelude::{DateTime, Utc};
 use log::*;
-use solana_sdk::account_api::AccountApi;
+use solana_sdk::account_api::{AccountApi, AccountWrapper};
 use solana_sdk::instruction::InstructionError;
 use solana_sdk::pubkey::Pubkey;
 
@@ -13,7 +13,7 @@ use solana_sdk::pubkey::Pubkey;
 /// will progress one step.
 fn apply_signature(
     budget_state: &mut BudgetState,
-    keyed_accounts: &mut [&mut AccountApi],
+    keyed_accounts: &mut [AccountWrapper],
 ) -> Result<(), BudgetError> {
     let mut final_payment = None;
     if let Some(ref mut expr) = budget_state.pending_budget {
@@ -54,7 +54,7 @@ fn apply_signature(
 /// will progress one step.
 fn apply_timestamp(
     budget_state: &mut BudgetState,
-    keyed_accounts: &mut [&mut AccountApi],
+    keyed_accounts: &mut [AccountWrapper],
     dt: DateTime<Utc>,
 ) -> Result<(), BudgetError> {
     // Check to see if any timelocked transactions can be completed.
@@ -84,7 +84,7 @@ fn apply_timestamp(
 
 pub fn process_instruction(
     _program_id: &Pubkey,
-    keyed_accounts: &mut [&mut AccountApi],
+    keyed_accounts: &mut [AccountWrapper],
     data: &[u8],
 ) -> Result<(), InstructionError> {
     let instruction = deserialize(data).map_err(|err| {

--- a/programs/budget_api/src/budget_state.rs
+++ b/programs/budget_api/src/budget_state.rs
@@ -8,6 +8,8 @@ use solana_sdk::instruction_processor_utils::DecodeError;
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, FromPrimitive)]
 pub enum BudgetError {
+    AccountCreditFailure,
+    AccountDebitFailure,
     DestinationMissing,
 }
 

--- a/programs/budget_api/src/budget_state.rs
+++ b/programs/budget_api/src/budget_state.rs
@@ -57,11 +57,11 @@ impl BudgetState {
 mod test {
     use super::*;
     use crate::id;
-    use solana_sdk::account::Account;
+    use solana_sdk::credit_debit_account::CreditDebitAccount;
 
     #[test]
     fn test_serializer() {
-        let mut a = Account::new(0, 512, &id());
+        let mut a = CreditDebitAccount::new(0, 512, &id());
         let b = BudgetState::default();
         b.serialize(&mut a.data).unwrap();
         let c = BudgetState::deserialize(&a.data).unwrap();
@@ -70,7 +70,7 @@ mod test {
 
     #[test]
     fn test_serializer_data_too_small() {
-        let mut a = Account::new(0, 1, &id());
+        let mut a = CreditDebitAccount::new(0, 1, &id());
         let b = BudgetState::default();
         assert_eq!(
             b.serialize(&mut a.data),

--- a/programs/config_api/src/config_processor.rs
+++ b/programs/config_api/src/config_processor.rs
@@ -1,13 +1,13 @@
 //! Config program
 
 use log::*;
-use solana_sdk::account::KeyedAccount;
+use solana_sdk::account_api::{AccountApi, AccountWrapper};
 use solana_sdk::instruction::InstructionError;
 use solana_sdk::pubkey::Pubkey;
 
 pub fn process_instruction(
     _program_id: &Pubkey,
-    keyed_accounts: &mut [KeyedAccount],
+    keyed_accounts: &mut [AccountWrapper],
     data: &[u8],
 ) -> Result<(), InstructionError> {
     if keyed_accounts[0].signer_key().is_none() {
@@ -15,12 +15,12 @@ pub fn process_instruction(
         Err(InstructionError::MissingRequiredSignature)?;
     }
 
-    if keyed_accounts[0].account.data.len() < data.len() {
+    if keyed_accounts[0].get_data().len() < data.len() {
         error!("instruction data too large");
         Err(InstructionError::InvalidInstructionData)?;
     }
 
-    keyed_accounts[0].account.data[0..data.len()].copy_from_slice(data);
+    keyed_accounts[0].account_writer()?.copy_from_slice(data);
     Ok(())
 }
 

--- a/programs/failure_program/src/lib.rs
+++ b/programs/failure_program/src/lib.rs
@@ -1,4 +1,4 @@
-use solana_sdk::account::KeyedAccount;
+use solana_sdk::account_api::AccountWrapper;
 use solana_sdk::instruction::InstructionError;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::solana_entrypoint;
@@ -6,7 +6,7 @@ use solana_sdk::solana_entrypoint;
 solana_entrypoint!(entrypoint);
 fn entrypoint(
     _program_id: &Pubkey,
-    _keyed_accounts: &mut [KeyedAccount],
+    _keyed_accounts: &mut [AccountWrapper],
     _data: &[u8],
 ) -> Result<(), InstructionError> {
     Err(InstructionError::GenericError)

--- a/programs/noop_program/src/lib.rs
+++ b/programs/noop_program/src/lib.rs
@@ -1,5 +1,5 @@
 use log::*;
-use solana_sdk::account::KeyedAccount;
+use solana_sdk::account_api::AccountWrapper;
 use solana_sdk::instruction::InstructionError;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::solana_entrypoint;
@@ -7,7 +7,7 @@ use solana_sdk::solana_entrypoint;
 solana_entrypoint!(entrypoint);
 fn entrypoint(
     program_id: &Pubkey,
-    keyed_accounts: &mut [KeyedAccount],
+    keyed_accounts: &mut [AccountWrapper],
     data: &[u8],
 ) -> Result<(), InstructionError> {
     solana_logger::setup();

--- a/programs/stake_api/src/stake_instruction.rs
+++ b/programs/stake_api/src/stake_instruction.rs
@@ -160,12 +160,12 @@ pub fn process_instruction(
 mod tests {
     use super::*;
     use bincode::serialize;
-    use solana_sdk::account::{Account, KeyedAccount};
+    use solana_sdk::credit_debit_account::{CreditDebitAccount, KeyedCreditDebitAccount};
 
     fn process_instruction(instruction: &Instruction) -> Result<(), InstructionError> {
         let mut accounts = vec![];
         for _ in 0..instruction.accounts.len() {
-            accounts.push(Account::default());
+            accounts.push(CreditDebitAccount::default());
         }
         {
             let mut keyed_accounts: Vec<_> = instruction
@@ -173,7 +173,7 @@ mod tests {
                 .iter()
                 .zip(accounts.iter_mut())
                 .map(|(meta, account)| {
-                    AccountWrapper::CreditDebit(KeyedAccount::new(
+                    AccountWrapper::CreditDebit(KeyedCreditDebitAccount::new(
                         &meta.pubkey,
                         meta.is_signer,
                         account,
@@ -208,10 +208,10 @@ mod tests {
         assert_eq!(
             super::process_instruction(
                 &Pubkey::default(),
-                &mut [AccountWrapper::CreditDebit(KeyedAccount::new(
+                &mut [AccountWrapper::CreditDebit(KeyedCreditDebitAccount::new(
                     &Pubkey::default(),
                     false,
-                    &mut Account::default(),
+                    &mut CreditDebitAccount::default(),
                 ))],
                 &serialize(&StakeInstruction::DelegateStake).unwrap(),
             ),
@@ -222,10 +222,10 @@ mod tests {
         assert_eq!(
             super::process_instruction(
                 &Pubkey::default(),
-                &mut [AccountWrapper::CreditDebit(KeyedAccount::new(
+                &mut [AccountWrapper::CreditDebit(KeyedCreditDebitAccount::new(
                     &Pubkey::default(),
                     false,
-                    &mut Account::default()
+                    &mut CreditDebitAccount::default()
                 ))],
                 &serialize(&StakeInstruction::DelegateStake).unwrap(),
             ),
@@ -236,15 +236,15 @@ mod tests {
             super::process_instruction(
                 &Pubkey::default(),
                 &mut [
-                    AccountWrapper::CreditDebit(KeyedAccount::new(
+                    AccountWrapper::CreditDebit(KeyedCreditDebitAccount::new(
                         &Pubkey::default(),
                         false,
-                        &mut Account::default()
+                        &mut CreditDebitAccount::default()
                     )),
-                    AccountWrapper::CreditDebit(KeyedAccount::new(
+                    AccountWrapper::CreditDebit(KeyedCreditDebitAccount::new(
                         &Pubkey::default(),
                         false,
-                        &mut Account::default()
+                        &mut CreditDebitAccount::default()
                     )),
                 ],
                 &serialize(&StakeInstruction::RedeemVoteCredits).unwrap(),
@@ -257,15 +257,15 @@ mod tests {
             super::process_instruction(
                 &Pubkey::default(),
                 &mut [
-                    AccountWrapper::CreditDebit(KeyedAccount::new(
+                    AccountWrapper::CreditDebit(KeyedCreditDebitAccount::new(
                         &Pubkey::default(),
                         true,
-                        &mut Account::default()
+                        &mut CreditDebitAccount::default()
                     )),
-                    AccountWrapper::CreditDebit(KeyedAccount::new(
+                    AccountWrapper::CreditDebit(KeyedCreditDebitAccount::new(
                         &Pubkey::default(),
                         false,
-                        &mut Account::default()
+                        &mut CreditDebitAccount::default()
                     )),
                 ],
                 &serialize(&StakeInstruction::DelegateStake).unwrap(),
@@ -278,20 +278,20 @@ mod tests {
             super::process_instruction(
                 &Pubkey::default(),
                 &mut [
-                    AccountWrapper::CreditDebit(KeyedAccount::new(
+                    AccountWrapper::CreditDebit(KeyedCreditDebitAccount::new(
                         &Pubkey::default(),
                         false,
-                        &mut Account::default()
+                        &mut CreditDebitAccount::default()
                     )),
-                    AccountWrapper::CreditDebit(KeyedAccount::new(
+                    AccountWrapper::CreditDebit(KeyedCreditDebitAccount::new(
                         &Pubkey::default(),
                         false,
-                        &mut Account::default()
+                        &mut CreditDebitAccount::default()
                     )),
-                    AccountWrapper::CreditDebit(KeyedAccount::new(
+                    AccountWrapper::CreditDebit(KeyedCreditDebitAccount::new(
                         &Pubkey::default(),
                         false,
-                        &mut Account::default()
+                        &mut CreditDebitAccount::default()
                     )),
                 ],
                 &serialize(&StakeInstruction::RedeemVoteCredits).unwrap(),

--- a/programs/token_api/src/token_processor.rs
+++ b/programs/token_api/src/token_processor.rs
@@ -1,12 +1,12 @@
 use crate::token_state::TokenState;
 use log::*;
-use solana_sdk::account::KeyedAccount;
+use solana_sdk::account_api::AccountWrapper;
 use solana_sdk::instruction::InstructionError;
 use solana_sdk::pubkey::Pubkey;
 
 pub fn process_instruction(
     program_id: &Pubkey,
-    info: &mut [KeyedAccount],
+    info: &mut [AccountWrapper],
     input: &[u8],
 ) -> Result<(), InstructionError> {
     solana_logger::setup();

--- a/programs/vote_api/src/vote_instruction.rs
+++ b/programs/vote_api/src/vote_instruction.rs
@@ -129,7 +129,7 @@ pub fn process_instruction(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use solana_sdk::account::{Account, KeyedAccount};
+    use solana_sdk::credit_debit_account::{CreditDebitAccount, KeyedCreditDebitAccount};
 
     // these are for 100% coverage in this file
     #[test]
@@ -143,7 +143,7 @@ mod tests {
     fn process_instruction(instruction: &Instruction) -> Result<(), InstructionError> {
         let mut accounts = vec![];
         for _ in 0..instruction.accounts.len() {
-            accounts.push(Account::default());
+            accounts.push(CreditDebitAccount::default());
         }
         {
             let mut keyed_accounts: Vec<_> = instruction
@@ -151,7 +151,7 @@ mod tests {
                 .iter()
                 .zip(accounts.iter_mut())
                 .map(|(meta, account)| {
-                    AccountWrapper::CreditDebit(KeyedAccount::new(
+                    AccountWrapper::CreditDebit(KeyedCreditDebitAccount::new(
                         &meta.pubkey,
                         meta.is_signer,
                         account,

--- a/runtime/benches/accounts.rs
+++ b/runtime/benches/accounts.rs
@@ -3,7 +3,7 @@
 extern crate test;
 
 use solana_runtime::bank::*;
-use solana_sdk::account::Account;
+use solana_sdk::credit_debit_account::CreditDebitAccount;
 use solana_sdk::genesis_block::create_genesis_block;
 use solana_sdk::pubkey::Pubkey;
 use std::sync::Arc;
@@ -12,7 +12,8 @@ use test::Bencher;
 fn deposit_many(bank: &Bank, pubkeys: &mut Vec<Pubkey>, num: usize) {
     for t in 0..num {
         let pubkey = Pubkey::new_rand();
-        let account = Account::new((t + 1) as u64, 0, &Account::default().owner);
+        let account =
+            CreditDebitAccount::new((t + 1) as u64, 0, &CreditDebitAccount::default().owner);
         pubkeys.push(pubkey.clone());
         assert!(bank.get_account(&pubkey).is_none());
         bank.deposit(&pubkey, (t + 1) as u64);

--- a/runtime/benches/bank.rs
+++ b/runtime/benches/bank.rs
@@ -6,7 +6,7 @@ use log::*;
 use solana_runtime::bank::*;
 use solana_runtime::bank_client::BankClient;
 use solana_runtime::loader_utils::{create_invoke_instruction, load_program};
-use solana_sdk::account::KeyedAccount;
+use solana_sdk::account_api::AccountWrapper;
 use solana_sdk::client::AsyncClient;
 use solana_sdk::client::SyncClient;
 use solana_sdk::genesis_block::create_genesis_block;
@@ -27,7 +27,7 @@ const BUILTIN_PROGRAM_ID: [u8; 32] = [
 
 fn process_instruction(
     _program_id: &Pubkey,
-    _keyed_accounts: &mut [KeyedAccount],
+    _keyed_accounts: &mut [AccountWrapper],
     _data: &[u8],
 ) -> Result<(), InstructionError> {
     Ok(())

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -9,7 +9,7 @@ use bincode::serialize;
 use log::*;
 use serde::{Deserialize, Serialize};
 use solana_metrics::inc_new_counter_error;
-use solana_sdk::account::Account;
+use solana_sdk::credit_debit_account::CreditDebitAccount;
 use solana_sdk::fee_calculator::FeeCalculator;
 use solana_sdk::hash::{Hash, Hasher};
 use solana_sdk::native_loader;
@@ -170,7 +170,7 @@ impl Accounts {
         tx: &Transaction,
         fee: u64,
         error_counters: &mut ErrorCounters,
-    ) -> Result<Vec<Account>> {
+    ) -> Result<Vec<CreditDebitAccount>> {
         // Copy all the accounts
         let message = tx.message();
         if tx.signatures.is_empty() && fee != 0 {
@@ -184,7 +184,7 @@ impl Accounts {
 
             // There is no way to predict what program will execute without an error
             // If a fee can pay for execution then the program will be scheduled
-            let mut called_accounts: Vec<Account> = vec![];
+            let mut called_accounts: Vec<CreditDebitAccount> = vec![];
             for key in &message.account_keys {
                 if !message.program_ids().contains(&key) {
                     called_accounts.push(
@@ -216,7 +216,7 @@ impl Accounts {
         accounts_index: &AccountsIndex<AccountInfo>,
         program_id: &Pubkey,
         error_counters: &mut ErrorCounters,
-    ) -> Result<Vec<(Pubkey, Account)>> {
+    ) -> Result<Vec<(Pubkey, CreditDebitAccount)>> {
         let mut accounts = Vec::new();
         let mut depth = 0;
         let mut program_id = *program_id;
@@ -260,7 +260,7 @@ impl Accounts {
         accounts_index: &AccountsIndex<AccountInfo>,
         tx: &Transaction,
         error_counters: &mut ErrorCounters,
-    ) -> Result<Vec<Vec<(Pubkey, Account)>>> {
+    ) -> Result<Vec<Vec<(Pubkey, CreditDebitAccount)>>> {
         let message = tx.message();
         message
             .instructions
@@ -326,29 +326,34 @@ impl Accounts {
         &self,
         ancestors: &HashMap<Fork, usize>,
         pubkey: &Pubkey,
-    ) -> Option<(Account, Fork)> {
+    ) -> Option<(CreditDebitAccount, Fork)> {
         self.accounts_db
             .load_slow(ancestors, pubkey)
             .filter(|(acc, _)| acc.lamports != 0)
     }
 
-    pub fn load_by_program(&self, fork: Fork, program_id: &Pubkey) -> Vec<(Pubkey, Account)> {
-        let accumulator: Vec<Vec<(Pubkey, u64, Account)>> = self.accounts_db.scan_account_storage(
-            fork,
-            |stored_account: &StoredAccount,
-             _id: AppendVecId,
-             accum: &mut Vec<(Pubkey, u64, Account)>| {
-                if stored_account.balance.owner == *program_id {
-                    let val = (
-                        stored_account.meta.pubkey,
-                        stored_account.meta.write_version,
-                        stored_account.clone_account(),
-                    );
-                    accum.push(val)
-                }
-            },
-        );
-        let mut versions: Vec<(Pubkey, u64, Account)> =
+    pub fn load_by_program(
+        &self,
+        fork: Fork,
+        program_id: &Pubkey,
+    ) -> Vec<(Pubkey, CreditDebitAccount)> {
+        let accumulator: Vec<Vec<(Pubkey, u64, CreditDebitAccount)>> =
+            self.accounts_db.scan_account_storage(
+                fork,
+                |stored_account: &StoredAccount,
+                 _id: AppendVecId,
+                 accum: &mut Vec<(Pubkey, u64, CreditDebitAccount)>| {
+                    if stored_account.balance.owner == *program_id {
+                        let val = (
+                            stored_account.meta.pubkey,
+                            stored_account.meta.write_version,
+                            stored_account.clone_account(),
+                        );
+                        accum.push(val)
+                    }
+                },
+            );
+        let mut versions: Vec<(Pubkey, u64, CreditDebitAccount)> =
             accumulator.into_iter().flat_map(|x| x).collect();
         versions.sort_by_key(|s| (s.0, (s.1 as i64).neg()));
         versions.dedup_by_key(|s| s.0);
@@ -356,7 +361,7 @@ impl Accounts {
     }
 
     /// Slow because lock is held for 1 operation instead of many
-    pub fn store_slow(&self, fork: Fork, pubkey: &Pubkey, account: &Account) {
+    pub fn store_slow(&self, fork: Fork, pubkey: &Pubkey, account: &CreditDebitAccount) {
         self.accounts_db.store(fork, &[(pubkey, account)]);
     }
 
@@ -555,7 +560,7 @@ impl Accounts {
         res: &[Result<()>],
         loaded: &[Result<(InstructionAccounts, InstructionLoaders)>],
     ) {
-        let mut accounts: Vec<(&Pubkey, &Account)> = vec![];
+        let mut accounts: Vec<(&Pubkey, &CreditDebitAccount)> = vec![];
         for (i, raccs) in loaded.iter().enumerate() {
             if res[i].is_err() || raccs.is_err() {
                 continue;
@@ -588,7 +593,6 @@ mod tests {
     use super::*;
     use bincode::{deserialize_from, serialize_into, serialized_size};
     use rand::{thread_rng, Rng};
-    use solana_sdk::account::Account;
     use solana_sdk::hash::Hash;
     use solana_sdk::instruction::CompiledInstruction;
     use solana_sdk::signature::{Keypair, KeypairUtil};
@@ -600,7 +604,7 @@ mod tests {
 
     fn load_accounts_with_fee(
         tx: Transaction,
-        ka: &Vec<(Pubkey, Account)>,
+        ka: &Vec<(Pubkey, CreditDebitAccount)>,
         fee_calculator: &FeeCalculator,
         error_counters: &mut ErrorCounters,
     ) -> Vec<Result<(InstructionAccounts, InstructionLoaders)>> {
@@ -622,7 +626,7 @@ mod tests {
 
     fn load_accounts(
         tx: Transaction,
-        ka: &Vec<(Pubkey, Account)>,
+        ka: &Vec<(Pubkey, CreditDebitAccount)>,
         error_counters: &mut ErrorCounters,
     ) -> Vec<Result<(InstructionAccounts, InstructionLoaders)>> {
         let fee_calculator = FeeCalculator::default();
@@ -631,7 +635,7 @@ mod tests {
 
     #[test]
     fn test_load_accounts_no_key() {
-        let accounts: Vec<(Pubkey, Account)> = Vec::new();
+        let accounts: Vec<(Pubkey, CreditDebitAccount)> = Vec::new();
         let mut error_counters = ErrorCounters::default();
 
         let instructions = vec![CompiledInstruction::new(0, &(), vec![0])];
@@ -652,7 +656,7 @@ mod tests {
 
     #[test]
     fn test_load_accounts_no_account_0_exists() {
-        let accounts: Vec<(Pubkey, Account)> = Vec::new();
+        let accounts: Vec<(Pubkey, CreditDebitAccount)> = Vec::new();
         let mut error_counters = ErrorCounters::default();
 
         let keypair = Keypair::new();
@@ -675,17 +679,17 @@ mod tests {
 
     #[test]
     fn test_load_accounts_unknown_program_id() {
-        let mut accounts: Vec<(Pubkey, Account)> = Vec::new();
+        let mut accounts: Vec<(Pubkey, CreditDebitAccount)> = Vec::new();
         let mut error_counters = ErrorCounters::default();
 
         let keypair = Keypair::new();
         let key0 = keypair.pubkey();
         let key1 = Pubkey::new(&[5u8; 32]);
 
-        let account = Account::new(1, 1, &Pubkey::default());
+        let account = CreditDebitAccount::new(1, 1, &Pubkey::default());
         accounts.push((key0, account));
 
-        let account = Account::new(2, 1, &Pubkey::default());
+        let account = CreditDebitAccount::new(2, 1, &Pubkey::default());
         accounts.push((key1, account));
 
         let instructions = vec![CompiledInstruction::new(1, &(), vec![0])];
@@ -709,13 +713,13 @@ mod tests {
 
     #[test]
     fn test_load_accounts_insufficient_funds() {
-        let mut accounts: Vec<(Pubkey, Account)> = Vec::new();
+        let mut accounts: Vec<(Pubkey, CreditDebitAccount)> = Vec::new();
         let mut error_counters = ErrorCounters::default();
 
         let keypair = Keypair::new();
         let key0 = keypair.pubkey();
 
-        let account = Account::new(1, 1, &Pubkey::default());
+        let account = CreditDebitAccount::new(1, 1, &Pubkey::default());
         accounts.push((key0, account));
 
         let instructions = vec![CompiledInstruction::new(1, &(), vec![0])];
@@ -743,13 +747,13 @@ mod tests {
 
     #[test]
     fn test_load_accounts_invalid_account_for_fee() {
-        let mut accounts: Vec<(Pubkey, Account)> = Vec::new();
+        let mut accounts: Vec<(Pubkey, CreditDebitAccount)> = Vec::new();
         let mut error_counters = ErrorCounters::default();
 
         let keypair = Keypair::new();
         let key0 = keypair.pubkey();
 
-        let account = Account::new(1, 1, &Pubkey::new_rand()); // <-- owner is not the system program
+        let account = CreditDebitAccount::new(1, 1, &Pubkey::new_rand()); // <-- owner is not the system program
         accounts.push((key0, account));
 
         let instructions = vec![CompiledInstruction::new(1, &(), vec![0])];
@@ -773,17 +777,17 @@ mod tests {
 
     #[test]
     fn test_load_accounts_no_loaders() {
-        let mut accounts: Vec<(Pubkey, Account)> = Vec::new();
+        let mut accounts: Vec<(Pubkey, CreditDebitAccount)> = Vec::new();
         let mut error_counters = ErrorCounters::default();
 
         let keypair = Keypair::new();
         let key0 = keypair.pubkey();
         let key1 = Pubkey::new(&[5u8; 32]);
 
-        let account = Account::new(1, 1, &Pubkey::default());
+        let account = CreditDebitAccount::new(1, 1, &Pubkey::default());
         accounts.push((key0, account));
 
-        let account = Account::new(2, 1, &Pubkey::default());
+        let account = CreditDebitAccount::new(2, 1, &Pubkey::default());
         accounts.push((key1, account));
 
         let instructions = vec![CompiledInstruction::new(2, &(), vec![0, 1])];
@@ -812,7 +816,7 @@ mod tests {
 
     #[test]
     fn test_load_accounts_max_call_depth() {
-        let mut accounts: Vec<(Pubkey, Account)> = Vec::new();
+        let mut accounts: Vec<(Pubkey, CreditDebitAccount)> = Vec::new();
         let mut error_counters = ErrorCounters::default();
 
         let keypair = Keypair::new();
@@ -824,35 +828,35 @@ mod tests {
         let key5 = Pubkey::new(&[9u8; 32]);
         let key6 = Pubkey::new(&[10u8; 32]);
 
-        let account = Account::new(1, 1, &Pubkey::default());
+        let account = CreditDebitAccount::new(1, 1, &Pubkey::default());
         accounts.push((key0, account));
 
-        let mut account = Account::new(40, 1, &Pubkey::default());
+        let mut account = CreditDebitAccount::new(40, 1, &Pubkey::default());
         account.executable = true;
         account.owner = native_loader::id();
         accounts.push((key1, account));
 
-        let mut account = Account::new(41, 1, &Pubkey::default());
+        let mut account = CreditDebitAccount::new(41, 1, &Pubkey::default());
         account.executable = true;
         account.owner = key1;
         accounts.push((key2, account));
 
-        let mut account = Account::new(42, 1, &Pubkey::default());
+        let mut account = CreditDebitAccount::new(42, 1, &Pubkey::default());
         account.executable = true;
         account.owner = key2;
         accounts.push((key3, account));
 
-        let mut account = Account::new(43, 1, &Pubkey::default());
+        let mut account = CreditDebitAccount::new(43, 1, &Pubkey::default());
         account.executable = true;
         account.owner = key3;
         accounts.push((key4, account));
 
-        let mut account = Account::new(44, 1, &Pubkey::default());
+        let mut account = CreditDebitAccount::new(44, 1, &Pubkey::default());
         account.executable = true;
         account.owner = key4;
         accounts.push((key5, account));
 
-        let mut account = Account::new(45, 1, &Pubkey::default());
+        let mut account = CreditDebitAccount::new(45, 1, &Pubkey::default());
         account.executable = true;
         account.owner = key5;
         accounts.push((key6, account));
@@ -875,17 +879,17 @@ mod tests {
 
     #[test]
     fn test_load_accounts_bad_program_id() {
-        let mut accounts: Vec<(Pubkey, Account)> = Vec::new();
+        let mut accounts: Vec<(Pubkey, CreditDebitAccount)> = Vec::new();
         let mut error_counters = ErrorCounters::default();
 
         let keypair = Keypair::new();
         let key0 = keypair.pubkey();
         let key1 = Pubkey::new(&[5u8; 32]);
 
-        let account = Account::new(1, 1, &Pubkey::default());
+        let account = CreditDebitAccount::new(1, 1, &Pubkey::default());
         accounts.push((key0, account));
 
-        let mut account = Account::new(40, 1, &Pubkey::default());
+        let mut account = CreditDebitAccount::new(40, 1, &Pubkey::default());
         account.executable = true;
         account.owner = Pubkey::default();
         accounts.push((key1, account));
@@ -908,17 +912,17 @@ mod tests {
 
     #[test]
     fn test_load_accounts_not_executable() {
-        let mut accounts: Vec<(Pubkey, Account)> = Vec::new();
+        let mut accounts: Vec<(Pubkey, CreditDebitAccount)> = Vec::new();
         let mut error_counters = ErrorCounters::default();
 
         let keypair = Keypair::new();
         let key0 = keypair.pubkey();
         let key1 = Pubkey::new(&[5u8; 32]);
 
-        let account = Account::new(1, 1, &Pubkey::default());
+        let account = CreditDebitAccount::new(1, 1, &Pubkey::default());
         accounts.push((key0, account));
 
-        let mut account = Account::new(40, 1, &Pubkey::default());
+        let mut account = CreditDebitAccount::new(40, 1, &Pubkey::default());
         account.owner = native_loader::id();
         accounts.push((key1, account));
 
@@ -940,7 +944,7 @@ mod tests {
 
     #[test]
     fn test_load_accounts_multiple_loaders() {
-        let mut accounts: Vec<(Pubkey, Account)> = Vec::new();
+        let mut accounts: Vec<(Pubkey, CreditDebitAccount)> = Vec::new();
         let mut error_counters = ErrorCounters::default();
 
         let keypair = Keypair::new();
@@ -949,20 +953,20 @@ mod tests {
         let key2 = Pubkey::new(&[6u8; 32]);
         let key3 = Pubkey::new(&[7u8; 32]);
 
-        let account = Account::new(1, 1, &Pubkey::default());
+        let account = CreditDebitAccount::new(1, 1, &Pubkey::default());
         accounts.push((key0, account));
 
-        let mut account = Account::new(40, 1, &Pubkey::default());
+        let mut account = CreditDebitAccount::new(40, 1, &Pubkey::default());
         account.executable = true;
         account.owner = native_loader::id();
         accounts.push((key1, account));
 
-        let mut account = Account::new(41, 1, &Pubkey::default());
+        let mut account = CreditDebitAccount::new(41, 1, &Pubkey::default());
         account.executable = true;
         account.owner = key1;
         accounts.push((key2, account));
 
-        let mut account = Account::new(42, 1, &Pubkey::default());
+        let mut account = CreditDebitAccount::new(42, 1, &Pubkey::default());
         account.executable = true;
         account.owner = key2;
         accounts.push((key3, account));
@@ -1003,13 +1007,13 @@ mod tests {
 
     #[test]
     fn test_load_account_pay_to_self() {
-        let mut accounts: Vec<(Pubkey, Account)> = Vec::new();
+        let mut accounts: Vec<(Pubkey, CreditDebitAccount)> = Vec::new();
         let mut error_counters = ErrorCounters::default();
 
         let keypair = Keypair::new();
         let pubkey = keypair.pubkey();
 
-        let account = Account::new(10, 1, &Pubkey::default());
+        let account = CreditDebitAccount::new(10, 1, &Pubkey::default());
         accounts.push((pubkey, account));
 
         let instructions = vec![CompiledInstruction::new(0, &(), vec![0, 1])];
@@ -1038,13 +1042,13 @@ mod tests {
 
         // Load accounts owned by various programs into AccountsDB
         let pubkey0 = Pubkey::new_rand();
-        let account0 = Account::new(1, 0, &Pubkey::new(&[2; 32]));
+        let account0 = CreditDebitAccount::new(1, 0, &Pubkey::new(&[2; 32]));
         accounts.store_slow(0, &pubkey0, &account0);
         let pubkey1 = Pubkey::new_rand();
-        let account1 = Account::new(1, 0, &Pubkey::new(&[2; 32]));
+        let account1 = CreditDebitAccount::new(1, 0, &Pubkey::new(&[2; 32]));
         accounts.store_slow(0, &pubkey1, &account1);
         let pubkey2 = Pubkey::new_rand();
-        let account2 = Account::new(1, 0, &Pubkey::new(&[3; 32]));
+        let account2 = CreditDebitAccount::new(1, 0, &Pubkey::new(&[3; 32]));
         accounts.store_slow(0, &pubkey2, &account2);
 
         let loaded = accounts.load_by_program(0, &Pubkey::new(&[2; 32]));
@@ -1080,7 +1084,11 @@ mod tests {
     fn test_accounts_empty_hash_internal_state() {
         let accounts = Accounts::new(None);
         assert_eq!(accounts.hash_internal_state(0), None);
-        accounts.store_slow(0, &Pubkey::default(), &Account::new(1, 0, &syscall::id()));
+        accounts.store_slow(
+            0,
+            &Pubkey::default(),
+            &CreditDebitAccount::new(1, 0, &syscall::id()),
+        );
         assert_eq!(accounts.hash_internal_state(0), None);
     }
 
@@ -1166,7 +1174,8 @@ mod tests {
     fn create_accounts(accounts: &Accounts, pubkeys: &mut Vec<Pubkey>, num: usize) {
         for t in 0..num {
             let pubkey = Pubkey::new_rand();
-            let account = Account::new((t + 1) as u64, 0, &Account::default().owner);
+            let account =
+                CreditDebitAccount::new((t + 1) as u64, 0, &CreditDebitAccount::default().owner);
             accounts.store_slow(0, &pubkey, &account);
             pubkeys.push(pubkey.clone());
         }
@@ -1177,7 +1186,8 @@ mod tests {
             let idx = thread_rng().gen_range(0, num - 1);
             let ancestors = vec![(0, 0)].into_iter().collect();
             let account = accounts.load_slow(&ancestors, &pubkeys[idx]).unwrap();
-            let account1 = Account::new((idx + 1) as u64, 0, &Account::default().owner);
+            let account1 =
+                CreditDebitAccount::new((idx + 1) as u64, 0, &CreditDebitAccount::default().owner);
             assert_eq!(account, (account1, 0));
         }
     }

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -28,7 +28,7 @@ use rayon::ThreadPool;
 use serde::de::{MapAccess, Visitor};
 use serde::ser::{SerializeMap, Serializer};
 use serde::{Deserialize, Serialize};
-use solana_sdk::account::Account;
+use solana_sdk::credit_debit_account::CreditDebitAccount;
 use solana_sdk::pubkey::Pubkey;
 use std::collections::{HashMap, HashSet};
 use std::fmt;
@@ -73,8 +73,8 @@ pub struct AccountInfo {
 }
 /// An offset into the AccountsDB::storage vector
 pub type AppendVecId = usize;
-pub type InstructionAccounts = Vec<Account>;
-pub type InstructionLoaders = Vec<Vec<(Pubkey, Account)>>;
+pub type InstructionAccounts = Vec<CreditDebitAccount>;
+pub type InstructionLoaders = Vec<Vec<(Pubkey, CreditDebitAccount)>>;
 
 #[derive(Default, Debug)]
 pub struct AccountStorage(HashMap<Fork, HashMap<usize, Arc<AccountStorageEntry>>>);
@@ -368,7 +368,7 @@ impl AccountsDB {
         ancestors: &HashMap<Fork, usize>,
         accounts_index: &AccountsIndex<AccountInfo>,
         pubkey: &Pubkey,
-    ) -> Option<(Account, Fork)> {
+    ) -> Option<(CreditDebitAccount, Fork)> {
         let (info, fork) = accounts_index.get(pubkey, ancestors)?;
         //TODO: thread this as a ref
         if let Some(fork_storage) = storage.0.get(&fork) {
@@ -385,7 +385,7 @@ impl AccountsDB {
         &self,
         ancestors: &HashMap<Fork, usize>,
         pubkey: &Pubkey,
-    ) -> Option<(Account, Fork)> {
+    ) -> Option<(CreditDebitAccount, Fork)> {
         let accounts_index = self.accounts_index.read().unwrap();
         let storage = self.storage.read().unwrap();
         Self::load(&storage, ancestors, &accounts_index, pubkey)
@@ -429,8 +429,12 @@ impl AccountsDB {
         }
     }
 
-    fn store_accounts(&self, fork_id: Fork, accounts: &[(&Pubkey, &Account)]) -> Vec<AccountInfo> {
-        let with_meta: Vec<(StorageMeta, &Account)> = accounts
+    fn store_accounts(
+        &self,
+        fork_id: Fork,
+        accounts: &[(&Pubkey, &CreditDebitAccount)],
+    ) -> Vec<AccountInfo> {
+        let with_meta: Vec<(StorageMeta, &CreditDebitAccount)> = accounts
             .iter()
             .map(|(pubkey, account)| {
                 let write_version = self.write_version.fetch_add(1, Ordering::Relaxed) as u64;
@@ -473,7 +477,7 @@ impl AccountsDB {
         &self,
         fork_id: Fork,
         infos: Vec<AccountInfo>,
-        accounts: &[(&Pubkey, &Account)],
+        accounts: &[(&Pubkey, &CreditDebitAccount)],
     ) -> Vec<(Fork, AccountInfo)> {
         let mut index = self.accounts_index.write().unwrap();
         let mut reclaims = vec![];
@@ -526,7 +530,7 @@ impl AccountsDB {
     }
 
     /// Store the account update.
-    pub fn store(&self, fork_id: Fork, accounts: &[(&Pubkey, &Account)]) {
+    pub fn store(&self, fork_id: Fork, accounts: &[(&Pubkey, &CreditDebitAccount)]) {
         let infos = self.store_accounts(fork_id, accounts);
         let reclaims = self.update_index(fork_id, infos, accounts);
         trace!("reclaim: {}", reclaims.len());
@@ -684,7 +688,6 @@ mod tests {
     use super::*;
     use bincode::{deserialize_from, serialize_into, serialized_size};
     use rand::{thread_rng, Rng};
-    use solana_sdk::account::Account;
 
     fn cleanup_paths(paths: &str) {
         let paths = get_paths_vec(&paths);
@@ -735,7 +738,7 @@ mod tests {
         let paths = get_tmp_accounts_path!();
         let db = AccountsDB::new(&paths.paths);
         let key = Pubkey::default();
-        let account0 = Account::new(1, 0, &key);
+        let account0 = CreditDebitAccount::new(1, 0, &key);
 
         db.store(0, &[(&key, &account0)]);
         db.add_root(0);
@@ -749,11 +752,11 @@ mod tests {
         let paths = get_tmp_accounts_path!();
         let db = AccountsDB::new(&paths.paths);
         let key = Pubkey::default();
-        let account0 = Account::new(1, 0, &key);
+        let account0 = CreditDebitAccount::new(1, 0, &key);
 
         db.store(0, &[(&key, &account0)]);
 
-        let account1 = Account::new(0, 0, &key);
+        let account1 = CreditDebitAccount::new(0, 0, &key);
         db.store(1, &[(&key, &account1)]);
 
         let ancestors = vec![(1, 1)].into_iter().collect();
@@ -769,11 +772,11 @@ mod tests {
         let paths = get_tmp_accounts_path!();
         let db = AccountsDB::new(&paths.paths);
         let key = Pubkey::default();
-        let account0 = Account::new(1, 0, &key);
+        let account0 = CreditDebitAccount::new(1, 0, &key);
 
         db.store(0, &[(&key, &account0)]);
 
-        let account1 = Account::new(0, 0, &key);
+        let account1 = CreditDebitAccount::new(0, 0, &key);
         db.store(1, &[(&key, &account1)]);
         db.add_root(0);
 
@@ -790,7 +793,7 @@ mod tests {
         let paths = get_tmp_accounts_path!();
         let db = AccountsDB::new(&paths.paths);
         let key = Pubkey::default();
-        let account0 = Account::new(1, 0, &key);
+        let account0 = CreditDebitAccount::new(1, 0, &key);
 
         // store value 1 in the "root", i.e. db zero
         db.store(0, &[(&key, &account0)]);
@@ -805,7 +808,7 @@ mod tests {
         //                                       (via root0)
 
         // store value 0 in one child
-        let account1 = Account::new(0, 0, &key);
+        let account1 = CreditDebitAccount::new(0, 0, &key);
         db.store(1, &[(&key, &account1)]);
 
         // masking accounts is done at the Accounts level, at accountsDB we see
@@ -837,7 +840,7 @@ mod tests {
             let idx = thread_rng().gen_range(0, 99);
             let ancestors = vec![(0, 0)].into_iter().collect();
             let account = db.load_slow(&ancestors, &pubkeys[idx]).unwrap();
-            let mut default_account = Account::default();
+            let mut default_account = CreditDebitAccount::default();
             default_account.lamports = (idx + 1) as u64;
             assert_eq!((default_account, 0), account);
         }
@@ -851,7 +854,7 @@ mod tests {
             let account0 = db.load_slow(&ancestors, &pubkeys[idx]).unwrap();
             let ancestors = vec![(1, 1)].into_iter().collect();
             let account1 = db.load_slow(&ancestors, &pubkeys[idx]).unwrap();
-            let mut default_account = Account::default();
+            let mut default_account = CreditDebitAccount::default();
             default_account.lamports = (idx + 1) as u64;
             assert_eq!(&default_account, &account0.0);
             assert_eq!(&default_account, &account1.0);
@@ -876,7 +879,7 @@ mod tests {
         assert!(check_storage(&db, 2));
 
         let pubkey = Pubkey::new_rand();
-        let account = Account::new(1, ACCOUNT_DATA_FILE_SIZE as usize / 3, &pubkey);
+        let account = CreditDebitAccount::new(1, ACCOUNT_DATA_FILE_SIZE as usize / 3, &pubkey);
         db.store(1, &[(&pubkey, &account)]);
         db.store(1, &[(&pubkeys[0], &account)]);
         {
@@ -907,11 +910,11 @@ mod tests {
         // 1 token in the "root", i.e. db zero
         let paths = get_tmp_accounts_path!();
         let db0 = AccountsDB::new(&paths.paths);
-        let account0 = Account::new(1, 0, &key);
+        let account0 = CreditDebitAccount::new(1, 0, &key);
         db0.store(0, &[(&key, &account0)]);
 
         // 0 lamports in the child
-        let account1 = Account::new(0, 0, &key);
+        let account1 = CreditDebitAccount::new(0, 0, &key);
         db0.store(1, &[(&key, &account1)]);
 
         // masking accounts is done at the Accounts level, at accountsDB we see
@@ -932,7 +935,11 @@ mod tests {
     ) {
         for t in 0..num {
             let pubkey = Pubkey::new_rand();
-            let account = Account::new((t + 1) as u64, space, &Account::default().owner);
+            let account = CreditDebitAccount::new(
+                (t + 1) as u64,
+                space,
+                &CreditDebitAccount::default().owner,
+            );
             pubkeys.push(pubkey.clone());
             let ancestors = vec![(fork, 0)].into_iter().collect();
             assert!(accounts.load_slow(&ancestors, &pubkey).is_none());
@@ -940,7 +947,8 @@ mod tests {
         }
         for t in 0..num_vote {
             let pubkey = Pubkey::new_rand();
-            let account = Account::new((num + t + 1) as u64, space, &solana_vote_api::id());
+            let account =
+                CreditDebitAccount::new((num + t + 1) as u64, space, &solana_vote_api::id());
             pubkeys.push(pubkey.clone());
             let ancestors = vec![(fork, 0)].into_iter().collect();
             assert!(accounts.load_slow(&ancestors, &pubkey).is_none());
@@ -959,7 +967,7 @@ mod tests {
                     let ancestors = vec![(fork, 0)].into_iter().collect();
                     assert!(accounts.load_slow(&ancestors, &pubkeys[idx]).is_none());
                 } else {
-                    let mut default_account = Account::default();
+                    let mut default_account = CreditDebitAccount::default();
                     default_account.lamports = account.lamports;
                     assert_eq!(default_account, account);
                 }
@@ -985,7 +993,11 @@ mod tests {
             let idx = thread_rng().gen_range(0, num - 1);
             let ancestors = vec![(fork, 0)].into_iter().collect();
             let account = accounts.load_slow(&ancestors, &pubkeys[idx]).unwrap();
-            let account1 = Account::new((idx + count) as u64, 0, &Account::default().owner);
+            let account1 = CreditDebitAccount::new(
+                (idx + count) as u64,
+                0,
+                &CreditDebitAccount::default().owner,
+            );
             assert_eq!(account, (account1, fork));
         }
     }
@@ -998,7 +1010,11 @@ mod tests {
         count: usize,
     ) {
         for idx in 0..num {
-            let account = Account::new((idx + count) as u64, 0, &Account::default().owner);
+            let account = CreditDebitAccount::new(
+                (idx + count) as u64,
+                0,
+                &CreditDebitAccount::default().owner,
+            );
             accounts.store(fork, &[(&pubkeys[idx], &account)]);
         }
     }
@@ -1011,7 +1027,7 @@ mod tests {
         create_account(&accounts, &mut pubkeys, 0, 1, 0, 0);
         let ancestors = vec![(0, 0)].into_iter().collect();
         let account = accounts.load_slow(&ancestors, &pubkeys[0]).unwrap();
-        let mut default_account = Account::default();
+        let mut default_account = CreditDebitAccount::default();
         default_account.lamports = 1;
         assert_eq!((default_account, 0), account);
     }
@@ -1043,7 +1059,7 @@ mod tests {
         let mut keys = vec![];
         for i in 0..9 {
             let key = Pubkey::new_rand();
-            let account = Account::new(i + 1, size as usize / 4, &key);
+            let account = CreditDebitAccount::new(i + 1, size as usize / 4, &key);
             accounts.store(0, &[(&key, &account)]);
             keys.push(key);
         }
@@ -1078,7 +1094,7 @@ mod tests {
         let count = [0, 1];
         let status = [AccountStorageStatus::Available, AccountStorageStatus::Full];
         let pubkey1 = Pubkey::new_rand();
-        let account1 = Account::new(1, ACCOUNT_DATA_FILE_SIZE as usize / 2, &pubkey1);
+        let account1 = CreditDebitAccount::new(1, ACCOUNT_DATA_FILE_SIZE as usize / 2, &pubkey1);
         accounts.store(0, &[(&pubkey1, &account1)]);
         {
             let stores = accounts.storage.read().unwrap();
@@ -1088,7 +1104,7 @@ mod tests {
         }
 
         let pubkey2 = Pubkey::new_rand();
-        let account2 = Account::new(1, ACCOUNT_DATA_FILE_SIZE as usize / 2, &pubkey2);
+        let account2 = CreditDebitAccount::new(1, ACCOUNT_DATA_FILE_SIZE as usize / 2, &pubkey2);
         accounts.store(0, &[(&pubkey2, &account2)]);
         {
             let stores = accounts.storage.read().unwrap();
@@ -1168,7 +1184,7 @@ mod tests {
         let paths = get_tmp_accounts_path!();
         let accounts = AccountsDB::new(&paths.paths);
         let pubkey = Pubkey::new_rand();
-        let account = Account::new(1, 0, &Account::default().owner);
+        let account = CreditDebitAccount::new(1, 0, &CreditDebitAccount::default().owner);
         //store an account
         accounts.store(0, &[(&pubkey, &account)]);
         let ancestors = vec![(0, 0)].into_iter().collect();
@@ -1250,7 +1266,7 @@ mod tests {
                     .name("account-writers".to_string())
                     .spawn(move || {
                         let pubkey = Pubkey::new_rand();
-                        let mut account = Account::new(1, 0, &pubkey);
+                        let mut account = CreditDebitAccount::new(1, 0, &pubkey);
                         let mut i = 0;
                         loop {
                             let account_bal = thread_rng().gen_range(1, 99);

--- a/runtime/src/append_vec.rs
+++ b/runtime/src/append_vec.rs
@@ -1,7 +1,7 @@
 use bincode::{deserialize_from, serialize_into, serialized_size};
 use memmap::MmapMut;
 use serde::{Deserialize, Serialize};
-use solana_sdk::account::Account;
+use solana_sdk::credit_debit_account::CreditDebitAccount;
 use solana_sdk::pubkey::Pubkey;
 use std::fmt;
 use std::fs::OpenOptions;
@@ -51,8 +51,8 @@ pub struct StoredAccount<'a> {
 }
 
 impl<'a> StoredAccount<'a> {
-    pub fn clone_account(&self) -> Account {
-        Account {
+    pub fn clone_account(&self) -> CreditDebitAccount {
+        CreditDebitAccount {
             lamports: self.balance.lamports,
             owner: self.balance.owner,
             executable: self.balance.executable,
@@ -204,7 +204,7 @@ impl AppendVec {
             next,
         ))
     }
-    pub fn get_account_test(&self, offset: usize) -> Option<(StorageMeta, Account)> {
+    pub fn get_account_test(&self, offset: usize) -> Option<(StorageMeta, CreditDebitAccount)> {
         let stored = self.get_account(offset)?;
         let meta = stored.0.meta.clone();
         Some((meta, stored.0.clone_account()))
@@ -220,7 +220,7 @@ impl AppendVec {
     }
 
     #[allow(clippy::mutex_atomic)]
-    pub fn append_accounts(&self, accounts: &[(StorageMeta, &Account)]) -> Vec<usize> {
+    pub fn append_accounts(&self, accounts: &[(StorageMeta, &CreditDebitAccount)]) -> Vec<usize> {
         let mut offset = self.append_offset.lock().unwrap();
         let mut rv = vec![];
         for (storage_meta, account) in accounts {
@@ -247,13 +247,17 @@ impl AppendVec {
         rv
     }
 
-    pub fn append_account(&self, storage_meta: StorageMeta, account: &Account) -> Option<usize> {
+    pub fn append_account(
+        &self,
+        storage_meta: StorageMeta,
+        account: &CreditDebitAccount,
+    ) -> Option<usize> {
         self.append_accounts(&[(storage_meta, account)])
             .first()
             .cloned()
     }
 
-    pub fn append_account_test(&self, data: &(StorageMeta, Account)) -> Option<usize> {
+    pub fn append_account_test(&self, data: &(StorageMeta, CreditDebitAccount)) -> Option<usize> {
         self.append_account(data.0.clone(), &data.1)
     }
 }
@@ -262,7 +266,7 @@ pub mod test_utils {
     use super::StorageMeta;
     use rand::distributions::Alphanumeric;
     use rand::{thread_rng, Rng};
-    use solana_sdk::account::Account;
+    use solana_sdk::credit_debit_account::CreditDebitAccount;
     use solana_sdk::pubkey::Pubkey;
     use std::fs::create_dir_all;
     use std::path::PathBuf;
@@ -289,9 +293,9 @@ pub mod test_utils {
         TempFile { path: buf }
     }
 
-    pub fn create_test_account(sample: usize) -> (StorageMeta, Account) {
+    pub fn create_test_account(sample: usize) -> (StorageMeta, CreditDebitAccount) {
         let data_len = sample % 256;
-        let mut account = Account::new(sample as u64, 0, &Pubkey::default());
+        let mut account = CreditDebitAccount::new(sample as u64, 0, &Pubkey::default());
         account.data = (0..data_len).map(|_| data_len as u8).collect();
         let storage_meta = StorageMeta {
             write_version: 0,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -20,7 +20,7 @@ use serde::{Deserialize, Serialize};
 use solana_metrics::{
     datapoint_info, inc_new_counter_debug, inc_new_counter_error, inc_new_counter_info,
 };
-use solana_sdk::account::Account;
+use solana_sdk::credit_debit_account::CreditDebitAccount;
 use solana_sdk::fee_calculator::FeeCalculator;
 use solana_sdk::genesis_block::GenesisBlock;
 use solana_sdk::hash::{extend_and_hash, Hash};
@@ -978,7 +978,7 @@ impl Bank {
         self.process_transaction(&tx).map(|_| signature)
     }
 
-    pub fn read_balance(account: &Account) -> u64 {
+    pub fn read_balance(account: &CreditDebitAccount) -> u64 {
         account.lamports
     }
     /// Each program would need to be able to introspect its own state
@@ -1000,7 +1000,7 @@ impl Bank {
         parents
     }
 
-    fn store(&self, pubkey: &Pubkey, account: &Account) {
+    fn store(&self, pubkey: &Pubkey, account: &CreditDebitAccount) {
         self.rc.accounts.store_slow(self.slot(), pubkey, account);
 
         if Stakes::is_stake(account) {
@@ -1043,7 +1043,7 @@ impl Bank {
         self.rc.parent = RwLock::new(Some(parent.clone()));
     }
 
-    pub fn get_account(&self, pubkey: &Pubkey) -> Option<Account> {
+    pub fn get_account(&self, pubkey: &Pubkey) -> Option<CreditDebitAccount> {
         self.rc
             .accounts
             .load_slow(&self.ancestors, pubkey)
@@ -1053,11 +1053,14 @@ impl Bank {
     pub fn get_program_accounts_modified_since_parent(
         &self,
         program_id: &Pubkey,
-    ) -> Vec<(Pubkey, Account)> {
+    ) -> Vec<(Pubkey, CreditDebitAccount)> {
         self.rc.accounts.load_by_program(self.slot(), program_id)
     }
 
-    pub fn get_account_modified_since_parent(&self, pubkey: &Pubkey) -> Option<(Account, Fork)> {
+    pub fn get_account_modified_since_parent(
+        &self,
+        pubkey: &Pubkey,
+    ) -> Option<(CreditDebitAccount, Fork)> {
         let just_self: HashMap<u64, usize> = vec![(self.slot(), 0)].into_iter().collect();
         self.rc.accounts.load_slow(&just_self, pubkey)
     }
@@ -1156,13 +1159,16 @@ impl Bank {
 
     /// current vote accounts for this bank along with the stake
     ///   attributed to each account
-    pub fn vote_accounts(&self) -> HashMap<Pubkey, (u64, Account)> {
+    pub fn vote_accounts(&self) -> HashMap<Pubkey, (u64, CreditDebitAccount)> {
         self.stakes.read().unwrap().vote_accounts().clone()
     }
 
     /// vote accounts for the specific epoch along with the stake
     ///   attributed to each account
-    pub fn epoch_vote_accounts(&self, epoch: u64) -> Option<&HashMap<Pubkey, (u64, Account)>> {
+    pub fn epoch_vote_accounts(
+        &self,
+        epoch: u64,
+    ) -> Option<&HashMap<Pubkey, (u64, CreditDebitAccount)>> {
         self.epoch_stakes.get(&epoch).map(Stakes::vote_accounts)
     }
 

--- a/runtime/src/genesis_utils.rs
+++ b/runtime/src/genesis_utils.rs
@@ -1,4 +1,4 @@
-use solana_sdk::account::Account;
+use solana_sdk::credit_debit_account::CreditDebitAccount;
 use solana_sdk::genesis_block::GenesisBlock;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::{Keypair, KeypairUtil};
@@ -40,13 +40,13 @@ pub fn create_genesis_block_with_leader(
             // the mint
             (
                 mint_keypair.pubkey(),
-                Account::new(mint_lamports, 0, &system_program::id()),
+                CreditDebitAccount::new(mint_lamports, 0, &system_program::id()),
             ),
             // node needs an account to issue votes and storage proofs from, this will require
             //  airdrops at some point to cover fees...
             (
                 *bootstrap_leader_pubkey,
-                Account::new(bootstrap_leader_lamports, 0, &system_program::id()),
+                CreditDebitAccount::new(bootstrap_leader_lamports, 0, &system_program::id()),
             ),
             // where votes go to
             (voting_keypair.pubkey(), vote_account),

--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -147,7 +147,7 @@ impl MessageProcessor {
 
         let mut keyed_accounts: Vec<AccountWrapper> = keyed_accounts
             .into_iter()
-            .map(|keyed_account| AccountWrapper::CreditDebit(keyed_account))
+            .map(AccountWrapper::CreditDebit)
             .collect();
 
         for (id, process_instruction) in &self.instruction_processors {

--- a/runtime/src/system_instruction_processor.rs
+++ b/runtime/src/system_instruction_processor.rs
@@ -14,11 +14,12 @@ fn create_system_account(
     space: u64,
     program_id: &Pubkey,
 ) -> Result<(), InstructionError> {
-    let mut e = None;
-    if !system_program::check_id(&keyed_accounts[FROM_ACCOUNT_INDEX].owner()) {
+    let mut e = if !system_program::check_id(&keyed_accounts[FROM_ACCOUNT_INDEX].owner()) {
         debug!("CreateAccount: invalid account[from] owner");
-        e = Some(SystemError::SourceNotSystemAccount);
-    }
+        Some(SystemError::SourceNotSystemAccount)
+    } else {
+        None
+    };
 
     if !keyed_accounts[TO_ACCOUNT_INDEX].get_data().is_empty()
         || !system_program::check_id(&keyed_accounts[TO_ACCOUNT_INDEX].owner())

--- a/runtime/src/system_instruction_processor.rs
+++ b/runtime/src/system_instruction_processor.rs
@@ -112,8 +112,8 @@ mod tests {
     use crate::bank::Bank;
     use crate::bank_client::BankClient;
     use bincode::serialize;
-    use solana_sdk::account::{Account, KeyedAccount};
     use solana_sdk::client::SyncClient;
+    use solana_sdk::credit_debit_account::{CreditDebitAccount, KeyedCreditDebitAccount};
     use solana_sdk::genesis_block::create_genesis_block;
     use solana_sdk::instruction::{AccountMeta, Instruction, InstructionError};
     use solana_sdk::signature::{Keypair, KeypairUtil};
@@ -124,14 +124,18 @@ mod tests {
     fn test_create_system_account() {
         let new_program_owner = Pubkey::new(&[9; 32]);
         let from = Pubkey::new_rand();
-        let mut from_account = Account::new(100, 0, &system_program::id());
+        let mut from_account = CreditDebitAccount::new(100, 0, &system_program::id());
 
         let to = Pubkey::new_rand();
-        let mut to_account = Account::new(0, 0, &Pubkey::default());
+        let mut to_account = CreditDebitAccount::new(0, 0, &Pubkey::default());
 
         let mut keyed_accounts = [
-            AccountWrapper::CreditDebit(KeyedAccount::new(&from, true, &mut from_account)),
-            AccountWrapper::CreditDebit(KeyedAccount::new(&to, false, &mut to_account)),
+            AccountWrapper::CreditDebit(KeyedCreditDebitAccount::new(
+                &from,
+                true,
+                &mut from_account,
+            )),
+            AccountWrapper::CreditDebit(KeyedCreditDebitAccount::new(&to, false, &mut to_account)),
         ];
         create_system_account(&mut keyed_accounts, 50, 2, &new_program_owner).unwrap();
         let from_lamports = from_account.lamports;
@@ -149,15 +153,19 @@ mod tests {
         // Attempt to create account with more lamports than remaining in from_account
         let new_program_owner = Pubkey::new(&[9; 32]);
         let from = Pubkey::new_rand();
-        let mut from_account = Account::new(100, 0, &system_program::id());
+        let mut from_account = CreditDebitAccount::new(100, 0, &system_program::id());
 
         let to = Pubkey::new_rand();
-        let mut to_account = Account::new(0, 0, &Pubkey::default());
+        let mut to_account = CreditDebitAccount::new(0, 0, &Pubkey::default());
         let unchanged_account = to_account.clone();
 
         let mut keyed_accounts = [
-            AccountWrapper::CreditDebit(KeyedAccount::new(&from, true, &mut from_account)),
-            AccountWrapper::CreditDebit(KeyedAccount::new(&to, false, &mut to_account)),
+            AccountWrapper::CreditDebit(KeyedCreditDebitAccount::new(
+                &from,
+                true,
+                &mut from_account,
+            )),
+            AccountWrapper::CreditDebit(KeyedCreditDebitAccount::new(&to, false, &mut to_account)),
         ];
         let result = create_system_account(&mut keyed_accounts, 150, 2, &new_program_owner);
         assert_eq!(
@@ -176,16 +184,24 @@ mod tests {
         // Attempt to create system account in account already owned by another program
         let new_program_owner = Pubkey::new(&[9; 32]);
         let from = Pubkey::new_rand();
-        let mut from_account = Account::new(100, 0, &system_program::id());
+        let mut from_account = CreditDebitAccount::new(100, 0, &system_program::id());
 
         let original_program_owner = Pubkey::new(&[5; 32]);
         let owned_key = Pubkey::new_rand();
-        let mut owned_account = Account::new(0, 0, &original_program_owner);
+        let mut owned_account = CreditDebitAccount::new(0, 0, &original_program_owner);
         let unchanged_account = owned_account.clone();
 
         let mut keyed_accounts = [
-            AccountWrapper::CreditDebit(KeyedAccount::new(&from, true, &mut from_account)),
-            AccountWrapper::CreditDebit(KeyedAccount::new(&owned_key, false, &mut owned_account)),
+            AccountWrapper::CreditDebit(KeyedCreditDebitAccount::new(
+                &from,
+                true,
+                &mut from_account,
+            )),
+            AccountWrapper::CreditDebit(KeyedCreditDebitAccount::new(
+                &owned_key,
+                false,
+                &mut owned_account,
+            )),
         ];
         let result = create_system_account(&mut keyed_accounts, 50, 2, &new_program_owner);
         assert_eq!(
@@ -204,10 +220,10 @@ mod tests {
         // Attempt to create system account in account with populated data
         let new_program_owner = Pubkey::new(&[9; 32]);
         let from = Pubkey::new_rand();
-        let mut from_account = Account::new(100, 0, &system_program::id());
+        let mut from_account = CreditDebitAccount::new(100, 0, &system_program::id());
 
         let populated_key = Pubkey::new_rand();
-        let mut populated_account = Account {
+        let mut populated_account = CreditDebitAccount {
             lamports: 0,
             data: vec![0, 1, 2, 3],
             owner: Pubkey::default(),
@@ -216,8 +232,12 @@ mod tests {
         let unchanged_account = populated_account.clone();
 
         let mut keyed_accounts = [
-            AccountWrapper::CreditDebit(KeyedAccount::new(&from, true, &mut from_account)),
-            AccountWrapper::CreditDebit(KeyedAccount::new(
+            AccountWrapper::CreditDebit(KeyedCreditDebitAccount::new(
+                &from,
+                true,
+                &mut from_account,
+            )),
+            AccountWrapper::CreditDebit(KeyedCreditDebitAccount::new(
                 &populated_key,
                 false,
                 &mut populated_account,
@@ -239,12 +259,16 @@ mod tests {
         let other_program = Pubkey::new(&[9; 32]);
 
         let from = Pubkey::new_rand();
-        let mut from_account = Account::new(100, 0, &other_program);
+        let mut from_account = CreditDebitAccount::new(100, 0, &other_program);
         let to = Pubkey::new_rand();
-        let mut to_account = Account::new(0, 0, &Pubkey::default());
+        let mut to_account = CreditDebitAccount::new(0, 0, &Pubkey::default());
         let mut keyed_accounts = [
-            AccountWrapper::CreditDebit(KeyedAccount::new(&from, true, &mut from_account)),
-            AccountWrapper::CreditDebit(KeyedAccount::new(&to, false, &mut to_account)),
+            AccountWrapper::CreditDebit(KeyedCreditDebitAccount::new(
+                &from,
+                true,
+                &mut from_account,
+            )),
+            AccountWrapper::CreditDebit(KeyedCreditDebitAccount::new(&to, false, &mut to_account)),
         ];
         let result = create_system_account(&mut keyed_accounts, 50, 2, &other_program);
         assert_eq!(
@@ -260,8 +284,8 @@ mod tests {
         let new_program_owner = Pubkey::new(&[9; 32]);
 
         let from = Pubkey::new_rand();
-        let mut from_account = Account::new(100, 0, &system_program::id());
-        let mut keyed_accounts = [AccountWrapper::CreditDebit(KeyedAccount::new(
+        let mut from_account = CreditDebitAccount::new(100, 0, &system_program::id());
+        let mut keyed_accounts = [AccountWrapper::CreditDebit(KeyedCreditDebitAccount::new(
             &from,
             true,
             &mut from_account,
@@ -272,7 +296,7 @@ mod tests {
 
         // Attempt to assign account not owned by system program
         let another_program_owner = Pubkey::new(&[8; 32]);
-        keyed_accounts = [AccountWrapper::CreditDebit(KeyedAccount::new(
+        keyed_accounts = [AccountWrapper::CreditDebit(KeyedCreditDebitAccount::new(
             &from,
             true,
             &mut from_account,
@@ -289,12 +313,16 @@ mod tests {
     #[test]
     fn test_transfer_lamports() {
         let from = Pubkey::new_rand();
-        let mut from_account = Account::new(100, 0, &Pubkey::new(&[2; 32])); // account owner should not matter
+        let mut from_account = CreditDebitAccount::new(100, 0, &Pubkey::new(&[2; 32])); // account owner should not matter
         let to = Pubkey::new_rand();
-        let mut to_account = Account::new(1, 0, &Pubkey::new(&[3; 32])); // account owner should not matter
+        let mut to_account = CreditDebitAccount::new(1, 0, &Pubkey::new(&[3; 32])); // account owner should not matter
         let mut keyed_accounts = [
-            AccountWrapper::CreditDebit(KeyedAccount::new(&from, true, &mut from_account)),
-            AccountWrapper::CreditDebit(KeyedAccount::new(&to, false, &mut to_account)),
+            AccountWrapper::CreditDebit(KeyedCreditDebitAccount::new(
+                &from,
+                true,
+                &mut from_account,
+            )),
+            AccountWrapper::CreditDebit(KeyedCreditDebitAccount::new(&to, false, &mut to_account)),
         ];
         transfer_lamports(&mut keyed_accounts, 50).unwrap();
         let from_lamports = from_account.lamports;
@@ -304,8 +332,12 @@ mod tests {
 
         // Attempt to move more lamports than remaining in from_account
         keyed_accounts = [
-            AccountWrapper::CreditDebit(KeyedAccount::new(&from, true, &mut from_account)),
-            AccountWrapper::CreditDebit(KeyedAccount::new(&to, false, &mut to_account)),
+            AccountWrapper::CreditDebit(KeyedCreditDebitAccount::new(
+                &from,
+                true,
+                &mut from_account,
+            )),
+            AccountWrapper::CreditDebit(KeyedCreditDebitAccount::new(&to, false, &mut to_account)),
         ];
         let result = transfer_lamports(&mut keyed_accounts, 100);
         assert_eq!(

--- a/sdk/src/account_api.rs
+++ b/sdk/src/account_api.rs
@@ -1,6 +1,6 @@
 //! Defines account apis for use in Solana programs.
 
-use crate::account::KeyedAccount;
+use crate::credit_debit_account::KeyedCreditDebitAccount;
 use crate::credit_only_account::KeyedCreditOnlyAccount;
 use crate::instruction::InstructionError;
 use crate::pubkey::Pubkey;
@@ -9,7 +9,7 @@ use std::sync::atomic::Ordering;
 
 #[derive(Debug)]
 pub enum AccountWrapper<'a> {
-    CreditDebit(KeyedAccount<'a>),
+    CreditDebit(KeyedCreditDebitAccount<'a>),
     CreditOnly(KeyedCreditOnlyAccount<'a>),
 }
 
@@ -110,7 +110,7 @@ impl<'a> AccountApi for AccountWrapper<'a> {
     }
 }
 
-impl<'a> AccountApi for KeyedAccount<'a> {
+impl<'a> AccountApi for KeyedCreditDebitAccount<'a> {
     fn signer_key(&self) -> Option<&Pubkey> {
         self.signer_key()
     }
@@ -215,7 +215,7 @@ impl<'a> AccountApi for KeyedCreditOnlyAccount<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::account::Account;
+    use crate::credit_debit_account::CreditDebitAccount;
     use crate::credit_only_account::CreditOnlyAccount;
     use bincode::serialize_into;
     use std::sync::Arc;
@@ -223,11 +223,11 @@ mod tests {
     #[test]
     fn test_account_api() {
         let pubkey0 = Pubkey::new_rand();
-        let mut account0 = Account::new(1, 0, &Pubkey::default());
-        let keyed_account = KeyedAccount::new(&pubkey0, false, &mut account0);
+        let mut account0 = CreditDebitAccount::new(1, 0, &Pubkey::default());
+        let keyed_account = KeyedCreditDebitAccount::new(&pubkey0, false, &mut account0);
 
         let pubkey1 = Pubkey::new_rand();
-        let account1 = Account::new(2, std::mem::size_of::<u32>(), &Pubkey::default());
+        let account1 = CreditDebitAccount::new(2, std::mem::size_of::<u32>(), &Pubkey::default());
         let credit_account = Arc::new(CreditOnlyAccount::from(account1));
         let keyed_credit_account = KeyedCreditOnlyAccount::new(&pubkey1, true, &credit_account);
 
@@ -284,7 +284,7 @@ mod tests {
 
         assert_eq!(
             account0,
-            Account {
+            CreditDebitAccount {
                 lamports: 10,
                 data: vec![42, 0, 0, 0],
                 owner: new_pubkey,

--- a/sdk/src/account_api.rs
+++ b/sdk/src/account_api.rs
@@ -1,0 +1,295 @@
+//! Defines account apis for use in Solana programs.
+
+use crate::account::KeyedAccount;
+use crate::credit_only_account::KeyedCreditOnlyAccount;
+use crate::instruction::InstructionError;
+use crate::pubkey::Pubkey;
+use std::fmt::Debug;
+use std::sync::atomic::Ordering;
+
+#[derive(Debug)]
+pub enum AccountWrapper<'a> {
+    CreditDebit(KeyedAccount<'a>),
+    CreditOnly(KeyedCreditOnlyAccount<'a>),
+}
+
+pub trait AccountApi: Debug {
+    fn signer_key(&self) -> Option<&Pubkey>;
+    fn unsigned_key(&self) -> &Pubkey;
+    fn lamports(&self) -> u64;
+    fn set_lamports(&mut self, lamports: u64) -> Result<(), InstructionError>;
+    fn credit(&mut self, lamports: u64) -> Result<(), InstructionError>;
+    fn debit(&mut self, lamports: u64) -> Result<(), InstructionError>;
+    fn get_data(&self) -> &[u8];
+    fn account_writer(&mut self) -> Result<&mut [u8], InstructionError>;
+    fn initialize_data(&mut self, space: u64) -> Result<(), InstructionError>;
+    fn owner(&self) -> &Pubkey;
+    fn set_owner(&mut self, owner: &Pubkey) -> Result<(), InstructionError>;
+    fn is_executable(&self) -> bool;
+    fn set_executable(&mut self, value: bool) -> Result<(), InstructionError>;
+}
+
+impl<'a> AccountApi for AccountWrapper<'a> {
+    fn signer_key(&self) -> Option<&Pubkey> {
+        match self {
+            AccountWrapper::CreditDebit(account) => account.signer_key(),
+            AccountWrapper::CreditOnly(account) => account.signer_key(),
+        }
+    }
+    fn unsigned_key(&self) -> &Pubkey {
+        match self {
+            AccountWrapper::CreditDebit(account) => account.unsigned_key(),
+            AccountWrapper::CreditOnly(account) => account.unsigned_key(),
+        }
+    }
+    fn lamports(&self) -> u64 {
+        match self {
+            AccountWrapper::CreditDebit(account) => account.lamports(),
+            AccountWrapper::CreditOnly(account) => account.lamports(),
+        }
+    }
+    fn set_lamports(&mut self, lamports: u64) -> Result<(), InstructionError> {
+        match self {
+            AccountWrapper::CreditDebit(account) => account.set_lamports(lamports),
+            AccountWrapper::CreditOnly(account) => account.set_lamports(lamports),
+        }
+    }
+    fn credit(&mut self, lamports: u64) -> Result<(), InstructionError> {
+        match self {
+            AccountWrapper::CreditDebit(account) => account.credit(lamports),
+            AccountWrapper::CreditOnly(account) => account.credit(lamports),
+        }
+    }
+    fn debit(&mut self, lamports: u64) -> Result<(), InstructionError> {
+        match self {
+            AccountWrapper::CreditDebit(account) => account.debit(lamports),
+            AccountWrapper::CreditOnly(account) => account.debit(lamports),
+        }
+    }
+    fn get_data(&self) -> &[u8] {
+        match self {
+            AccountWrapper::CreditDebit(account) => account.get_data(),
+            AccountWrapper::CreditOnly(account) => account.get_data(),
+        }
+    }
+    fn account_writer(&mut self) -> Result<&mut [u8], InstructionError> {
+        match self {
+            AccountWrapper::CreditDebit(account) => account.account_writer(),
+            AccountWrapper::CreditOnly(account) => account.account_writer(),
+        }
+    }
+    fn initialize_data(&mut self, space: u64) -> Result<(), InstructionError> {
+        match self {
+            AccountWrapper::CreditDebit(account) => account.initialize_data(space),
+            AccountWrapper::CreditOnly(account) => account.initialize_data(space),
+        }
+    }
+    fn owner(&self) -> &Pubkey {
+        match self {
+            AccountWrapper::CreditDebit(account) => account.owner(),
+            AccountWrapper::CreditOnly(account) => account.owner(),
+        }
+    }
+    fn set_owner(&mut self, owner: &Pubkey) -> Result<(), InstructionError> {
+        match self {
+            AccountWrapper::CreditDebit(account) => account.set_owner(owner),
+            AccountWrapper::CreditOnly(account) => account.set_owner(owner),
+        }
+    }
+    fn is_executable(&self) -> bool {
+        match self {
+            AccountWrapper::CreditDebit(account) => account.is_executable(),
+            AccountWrapper::CreditOnly(account) => account.is_executable(),
+        }
+    }
+    fn set_executable(&mut self, value: bool) -> Result<(), InstructionError> {
+        match self {
+            AccountWrapper::CreditDebit(account) => account.set_executable(value),
+            AccountWrapper::CreditOnly(account) => account.set_executable(value),
+        }
+    }
+}
+
+impl<'a> AccountApi for KeyedAccount<'a> {
+    fn signer_key(&self) -> Option<&Pubkey> {
+        self.signer_key()
+    }
+    fn unsigned_key(&self) -> &Pubkey {
+        self.unsigned_key()
+    }
+    fn lamports(&self) -> u64 {
+        self.account.lamports
+    }
+    fn set_lamports(&mut self, lamports: u64) -> Result<(), InstructionError> {
+        self.account.lamports = lamports;
+        Ok(())
+    }
+    fn credit(&mut self, lamports: u64) -> Result<(), InstructionError> {
+        self.account.lamports += lamports;
+        Ok(())
+    }
+    fn debit(&mut self, lamports: u64) -> Result<(), InstructionError> {
+        if self.account.lamports < lamports {
+            Err(InstructionError::new_result_with_negative_lamports())
+        } else {
+            self.account.lamports -= lamports;
+            Ok(())
+        }
+    }
+    fn get_data(&self) -> &[u8] {
+        &self.account.data
+    }
+    fn account_writer(&mut self) -> Result<&mut [u8], InstructionError> {
+        Ok(&mut self.account.data)
+    }
+    fn initialize_data(&mut self, space: u64) -> Result<(), InstructionError> {
+        self.account.data = vec![0; space as usize];
+        Ok(())
+    }
+    fn owner(&self) -> &Pubkey {
+        &self.account.owner
+    }
+    fn set_owner(&mut self, owner: &Pubkey) -> Result<(), InstructionError> {
+        self.account.owner = *owner;
+        Ok(())
+    }
+    fn is_executable(&self) -> bool {
+        self.account.executable
+    }
+    fn set_executable(&mut self, value: bool) -> Result<(), InstructionError> {
+        self.account.executable = value;
+        Ok(())
+    }
+}
+
+impl<'a> AccountApi for KeyedCreditOnlyAccount<'a> {
+    fn signer_key(&self) -> Option<&Pubkey> {
+        self.signer_key()
+    }
+    fn unsigned_key(&self) -> &Pubkey {
+        self.unsigned_key()
+    }
+    fn lamports(&self) -> u64 {
+        self.account.lamports.load(Ordering::Relaxed) + self.credits
+    }
+    fn set_lamports(&mut self, lamports: u64) -> Result<(), InstructionError> {
+        let current_lamports = self.account.lamports.load(Ordering::Relaxed);
+        if lamports >= current_lamports {
+            let credit = lamports - current_lamports;
+            self.credits += credit;
+            Ok(())
+        } else {
+            Err(InstructionError::CreditOnlyDebit)
+        }
+    }
+    fn credit(&mut self, lamports: u64) -> Result<(), InstructionError> {
+        self.credits += lamports;
+        Ok(())
+    }
+    fn debit(&mut self, _lamports: u64) -> Result<(), InstructionError> {
+        Err(InstructionError::CreditOnlyDebit)
+    }
+    fn get_data(&self) -> &[u8] {
+        &self.account.data
+    }
+    fn account_writer(&mut self) -> Result<&mut [u8], InstructionError> {
+        Err(InstructionError::CreditOnlyDataModification)
+    }
+    fn initialize_data(&mut self, _space: u64) -> Result<(), InstructionError> {
+        Err(InstructionError::CreditOnlyDataModification)
+    }
+    fn owner(&self) -> &Pubkey {
+        &self.account.owner
+    }
+    fn set_owner(&mut self, _owner: &Pubkey) -> Result<(), InstructionError> {
+        Err(InstructionError::CreditOnlyOwnerModification)
+    }
+    fn is_executable(&self) -> bool {
+        self.account.executable
+    }
+    fn set_executable(&mut self, _value: bool) -> Result<(), InstructionError> {
+        Err(InstructionError::CreditOnlyDataModification)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::account::Account;
+    use crate::credit_only_account::CreditOnlyAccount;
+    use bincode::serialize_into;
+    use std::sync::Arc;
+
+    #[test]
+    fn test_account_api() {
+        let pubkey0 = Pubkey::new_rand();
+        let mut account0 = Account::new(1, 0, &Pubkey::default());
+        let keyed_account = KeyedAccount::new(&pubkey0, false, &mut account0);
+
+        let pubkey1 = Pubkey::new_rand();
+        let account1 = Account::new(2, std::mem::size_of::<u32>(), &Pubkey::default());
+        let credit_account = Arc::new(CreditOnlyAccount::from(account1));
+        let keyed_credit_account = KeyedCreditOnlyAccount::new(&pubkey1, true, &credit_account);
+
+        let mut collection: Vec<AccountWrapper> = vec![
+            AccountWrapper::CreditDebit(keyed_account),
+            AccountWrapper::CreditOnly(keyed_credit_account),
+        ];
+
+        assert_eq!(collection[0].signer_key(), None);
+        assert_eq!(collection[1].signer_key(), Some(&pubkey1));
+
+        assert_eq!(collection[0].unsigned_key(), &pubkey0);
+        assert_eq!(collection[1].unsigned_key(), &pubkey1);
+
+        assert_eq!(collection[0].lamports(), 1);
+        assert_eq!(collection[1].lamports(), 2);
+
+        assert!(collection[0].set_lamports(10).is_ok());
+        assert_eq!(collection[0].lamports(), 10);
+        assert!(collection[1].set_lamports(11).is_ok());
+        assert_eq!(collection[1].lamports(), 11);
+        assert!(collection[1].set_lamports(0).is_err());
+        assert_eq!(collection[1].lamports(), 11);
+
+        assert!(collection[0].credit(10).is_ok());
+        assert_eq!(collection[0].lamports(), 20);
+        assert!(collection[1].credit(10).is_ok());
+        assert_eq!(collection[1].lamports(), 21);
+
+        assert!(collection[0].debit(10).is_ok());
+        assert_eq!(collection[0].lamports(), 10);
+        assert!(collection[1].debit(10).is_err());
+        assert_eq!(collection[1].lamports(), 21);
+
+        assert!(collection[0].initialize_data(4).is_ok());
+        assert_eq!(collection[0].get_data(), &[0; 4]);
+        assert!(collection[1].initialize_data(8).is_err());
+        assert_eq!(collection[1].get_data(), &[0; 4]);
+
+        assert!(serialize_into(collection[0].account_writer().unwrap(), &42u32).is_ok());
+        assert_eq!(collection[0].get_data(), &[42, 0, 0, 0]);
+        assert!(collection[1].account_writer().is_err());
+
+        let new_pubkey = Pubkey::new_rand();
+        assert!(collection[0].set_owner(&new_pubkey).is_ok());
+        assert_eq!(collection[0].owner(), &new_pubkey);
+        assert!(collection[1].set_owner(&new_pubkey).is_err());
+        assert_eq!(collection[1].owner(), &Pubkey::default());
+
+        assert!(collection[0].set_executable(true).is_ok());
+        assert_eq!(collection[0].is_executable(), true);
+        assert!(collection[1].set_executable(true).is_err());
+        assert_eq!(collection[1].is_executable(), false);
+
+        assert_eq!(
+            account0,
+            Account {
+                lamports: 10,
+                data: vec![42, 0, 0, 0],
+                owner: new_pubkey,
+                executable: true,
+            }
+        );
+    }
+}

--- a/sdk/src/account_utils.rs
+++ b/sdk/src/account_utils.rs
@@ -1,7 +1,8 @@
 //! useful extras for Account state
 use crate::account::{Account, KeyedAccount};
+use crate::account_api::{AccountApi, AccountWrapper};
 use crate::instruction::InstructionError;
-use bincode::ErrorKind;
+use bincode::{deserialize, serialize_into, ErrorKind};
 
 /// Convenience trait to covert bincode errors to instruction errors.
 pub trait State<T> {
@@ -37,11 +38,44 @@ where
     }
 }
 
+impl<'a, T> State<T> for AccountWrapper<'a>
+where
+    T: serde::Serialize + serde::de::DeserializeOwned,
+{
+    fn state(&self) -> Result<T, InstructionError> {
+        match self {
+            AccountWrapper::CreditDebit(account) => {
+                deserialize(account.get_data()).map_err(|_| InstructionError::InvalidAccountData)
+            }
+            AccountWrapper::CreditOnly(account) => {
+                deserialize(account.get_data()).map_err(|_| InstructionError::InvalidAccountData)
+            }
+        }
+    }
+    fn set_state(&mut self, state: &T) -> Result<(), InstructionError> {
+        match self {
+            AccountWrapper::CreditDebit(_) => serialize_into(self.account_writer()?, state)
+                .map_err(|err| match *err {
+                    ErrorKind::SizeLimit => InstructionError::AccountDataTooSmall,
+                    _ => InstructionError::GenericError,
+                }),
+            AccountWrapper::CreditOnly(_) => {
+                serialize_into(self.account_writer()?, state).map_err(|err| match *err {
+                    ErrorKind::SizeLimit => InstructionError::AccountDataTooSmall,
+                    _ => InstructionError::GenericError,
+                })
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::account::Account;
+    use crate::credit_only_account::{CreditOnlyAccount, KeyedCreditOnlyAccount};
     use crate::pubkey::Pubkey;
+    use std::sync::Arc;
 
     #[test]
     fn test_account_state() {
@@ -56,6 +90,56 @@ mod tests {
         assert!(account.set_state(&state).is_ok());
         let stored_state: u64 = account.state().unwrap();
         assert_eq!(stored_state, state);
+    }
+
+    #[test]
+    fn test_keyed_account_state() {
+        let state = 42u64;
+        let key0 = Pubkey::new_rand();
+
+        let mut account = Account::new(0, std::mem::size_of::<u64>(), &Pubkey::default());
+        let mut keyed_account = KeyedAccount::new(&key0, false, &mut account);
+
+        assert!(keyed_account.set_state(&state).is_ok());
+        let stored_state: u64 = keyed_account.state().unwrap();
+        assert_eq!(stored_state, state);
+    }
+
+    #[test]
+    fn test_account_wrapper_state() {
+        let uninitialized_state = 0u64;
+        let state0 = 42u64;
+        let state1 = 84u64;
+        let key0 = Pubkey::new_rand();
+        let key1 = Pubkey::new_rand();
+
+        let mut account = Account::new(0, std::mem::size_of::<u64>(), &Pubkey::default());
+        let keyed_account = KeyedAccount::new(&key0, false, &mut account);
+
+        let account = Account::new(1, std::mem::size_of::<u64>(), &Pubkey::default());
+        let credit_account = Arc::new(CreditOnlyAccount::from(account));
+        let keyed_credit_account = KeyedCreditOnlyAccount::new(&key1, false, &credit_account);
+
+        let mut collection: Vec<AccountWrapper> = vec![
+            AccountWrapper::CreditDebit(keyed_account),
+            AccountWrapper::CreditOnly(keyed_credit_account),
+        ];
+
+        assert!(collection[0].set_state(&state0).is_ok());
+        let stored_state: u64 = collection[0].state().unwrap();
+        assert_eq!(stored_state, state0);
+
+        assert!(collection[1].set_state(&state0).is_err());
+        let stored_state: u64 = collection[1].state().unwrap();
+        assert_eq!(stored_state, uninitialized_state);
+
+        // Test accessing accounts through variable assignment
+        let (credit_debit, _credit_only) = collection.split_at_mut(1);
+        let credit_debit = &mut credit_debit[0];
+
+        assert!(credit_debit.set_state(&state1).is_ok());
+        let stored_state: u64 = collection[0].state().unwrap();
+        assert_eq!(stored_state, state1);
     }
 
 }

--- a/sdk/src/credit_debit_account.rs
+++ b/sdk/src/credit_debit_account.rs
@@ -1,10 +1,10 @@
 use crate::pubkey::Pubkey;
 use std::{cmp, fmt};
 
-/// An Account with data that is stored on chain
+/// An credit-debit account with data that is stored on chain, the default account type
 #[repr(C)]
 #[derive(Serialize, Deserialize, Clone, Default, Eq, PartialEq)]
-pub struct Account {
+pub struct CreditDebitAccount {
     /// lamports in the account
     pub lamports: u64,
     /// data held in this account
@@ -15,7 +15,7 @@ pub struct Account {
     pub executable: bool,
 }
 
-impl fmt::Debug for Account {
+impl fmt::Debug for CreditDebitAccount {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let data_len = cmp::min(64, self.data.len());
         let data_str = if data_len > 0 {
@@ -25,7 +25,7 @@ impl fmt::Debug for Account {
         };
         write!(
             f,
-            "Account {{ lamports: {} data.len: {} owner: {} executable: {}{} }}",
+            "CreditDebitAccount {{ lamports: {} data.len: {} owner: {} executable: {}{} }}",
             self.lamports,
             self.data.len(),
             self.owner,
@@ -35,10 +35,10 @@ impl fmt::Debug for Account {
     }
 }
 
-impl Account {
+impl CreditDebitAccount {
     // TODO do we want to add executable and leader_owner even though they should always be false/default?
-    pub fn new(lamports: u64, space: usize, owner: &Pubkey) -> Account {
-        Account {
+    pub fn new(lamports: u64, space: usize, owner: &Pubkey) -> CreditDebitAccount {
+        CreditDebitAccount {
             lamports,
             data: vec![0u8; space],
             owner: *owner,
@@ -57,13 +57,13 @@ impl Account {
 
 #[repr(C)]
 #[derive(Debug)]
-pub struct KeyedAccount<'a> {
+pub struct KeyedCreditDebitAccount<'a> {
     is_signer: bool, // Transaction was signed by this account's key
     key: &'a Pubkey,
-    pub account: &'a mut Account,
+    pub account: &'a mut CreditDebitAccount,
 }
 
-impl<'a> KeyedAccount<'a> {
+impl<'a> KeyedCreditDebitAccount<'a> {
     pub fn signer_key(&self) -> Option<&Pubkey> {
         if self.is_signer {
             Some(self.key)
@@ -76,8 +76,12 @@ impl<'a> KeyedAccount<'a> {
         self.key
     }
 
-    pub fn new(key: &'a Pubkey, is_signer: bool, account: &'a mut Account) -> KeyedAccount<'a> {
-        KeyedAccount {
+    pub fn new(
+        key: &'a Pubkey,
+        is_signer: bool,
+        account: &'a mut CreditDebitAccount,
+    ) -> KeyedCreditDebitAccount<'a> {
+        KeyedCreditDebitAccount {
             key,
             is_signer,
             account,
@@ -85,9 +89,9 @@ impl<'a> KeyedAccount<'a> {
     }
 }
 
-impl<'a> From<(&'a Pubkey, &'a mut Account)> for KeyedAccount<'a> {
-    fn from((key, account): (&'a Pubkey, &'a mut Account)) -> Self {
-        KeyedAccount {
+impl<'a> From<(&'a Pubkey, &'a mut CreditDebitAccount)> for KeyedCreditDebitAccount<'a> {
+    fn from((key, account): (&'a Pubkey, &'a mut CreditDebitAccount)) -> Self {
+        KeyedCreditDebitAccount {
             is_signer: false,
             key,
             account,
@@ -95,9 +99,9 @@ impl<'a> From<(&'a Pubkey, &'a mut Account)> for KeyedAccount<'a> {
     }
 }
 
-impl<'a> From<&'a mut (Pubkey, Account)> for KeyedAccount<'a> {
-    fn from((key, account): &'a mut (Pubkey, Account)) -> Self {
-        KeyedAccount {
+impl<'a> From<&'a mut (Pubkey, CreditDebitAccount)> for KeyedCreditDebitAccount<'a> {
+    fn from((key, account): &'a mut (Pubkey, CreditDebitAccount)) -> Self {
+        KeyedCreditDebitAccount {
             is_signer: false,
             key,
             account,
@@ -105,6 +109,8 @@ impl<'a> From<&'a mut (Pubkey, Account)> for KeyedAccount<'a> {
     }
 }
 
-pub fn create_keyed_accounts(accounts: &mut [(Pubkey, Account)]) -> Vec<KeyedAccount> {
+pub fn create_keyed_accounts(
+    accounts: &mut [(Pubkey, CreditDebitAccount)],
+) -> Vec<KeyedCreditDebitAccount> {
     accounts.iter_mut().map(Into::into).collect()
 }

--- a/sdk/src/credit_only_account.rs
+++ b/sdk/src/credit_only_account.rs
@@ -1,0 +1,95 @@
+use crate::account::Account;
+use crate::pubkey::Pubkey;
+use std::sync::atomic::AtomicU64;
+use std::sync::Arc;
+use std::{cmp, fmt};
+
+/// A credit-only account struct, allowing atomic adds to lamports, but no other changes
+pub struct CreditOnlyAccount {
+    /// lamports in the account
+    pub lamports: AtomicU64,
+    /// data held in this account
+    pub data: Vec<u8>,
+    /// the program that owns this account. If executable, the program that loads this account.
+    pub owner: Pubkey,
+    /// this account's data contains a loaded program (and is now read-only)
+    pub executable: bool,
+}
+
+impl fmt::Debug for CreditOnlyAccount {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let data_len = cmp::min(64, self.data.len());
+        let data_str = if data_len > 0 {
+            format!(" data: {}", hex::encode(self.data[..data_len].to_vec()))
+        } else {
+            "".to_string()
+        };
+        write!(
+            f,
+            "CreditOnlyAccount {{ lamports: {:?} data.len: {} owner: {} executable: {}{} }}",
+            self.lamports,
+            self.data.len(),
+            self.owner,
+            self.executable,
+            data_str,
+        )
+    }
+}
+
+impl From<Account> for CreditOnlyAccount {
+    fn from(account: Account) -> Self {
+        CreditOnlyAccount {
+            lamports: AtomicU64::from(account.lamports),
+            data: account.data,
+            owner: account.owner,
+            executable: account.executable,
+        }
+    }
+}
+
+#[repr(C)]
+#[derive(Debug)]
+pub struct KeyedCreditOnlyAccount<'a> {
+    is_signer: bool, // Transaction was signed by this account's key
+    key: &'a Pubkey,
+    pub credits: u64,
+    pub account: &'a Arc<CreditOnlyAccount>,
+}
+
+impl<'a> KeyedCreditOnlyAccount<'a> {
+    pub fn signer_key(&self) -> Option<&Pubkey> {
+        if self.is_signer {
+            Some(self.key)
+        } else {
+            None
+        }
+    }
+
+    pub fn unsigned_key(&self) -> &Pubkey {
+        self.key
+    }
+
+    pub fn new(
+        key: &'a Pubkey,
+        is_signer: bool,
+        account: &'a Arc<CreditOnlyAccount>,
+    ) -> KeyedCreditOnlyAccount<'a> {
+        KeyedCreditOnlyAccount {
+            key,
+            is_signer,
+            credits: 0,
+            account,
+        }
+    }
+}
+
+impl<'a> From<(&'a Pubkey, &'a Arc<CreditOnlyAccount>)> for KeyedCreditOnlyAccount<'a> {
+    fn from((key, account): (&'a Pubkey, &'a Arc<CreditOnlyAccount>)) -> Self {
+        KeyedCreditOnlyAccount {
+            is_signer: false,
+            key,
+            credits: 0,
+            account,
+        }
+    }
+}

--- a/sdk/src/credit_only_account.rs
+++ b/sdk/src/credit_only_account.rs
@@ -1,4 +1,4 @@
-use crate::account::Account;
+use crate::credit_debit_account::CreditDebitAccount;
 use crate::pubkey::Pubkey;
 use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
@@ -36,8 +36,8 @@ impl fmt::Debug for CreditOnlyAccount {
     }
 }
 
-impl From<Account> for CreditOnlyAccount {
-    fn from(account: Account) -> Self {
+impl From<CreditDebitAccount> for CreditOnlyAccount {
+    fn from(account: CreditDebitAccount) -> Self {
         CreditOnlyAccount {
             lamports: AtomicU64::from(account.lamports),
             data: account.data,

--- a/sdk/src/genesis_block.rs
+++ b/sdk/src/genesis_block.rs
@@ -1,6 +1,6 @@
 //! The `genesis_block` module is a library for generating the chain's genesis block.
 
-use crate::account::Account;
+use crate::credit_debit_account::CreditDebitAccount;
 use crate::fee_calculator::FeeCalculator;
 use crate::hash::{hash, Hash};
 use crate::poh_config::PohConfig;
@@ -14,7 +14,7 @@ use std::path::Path;
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct GenesisBlock {
-    pub accounts: Vec<(Pubkey, Account)>,
+    pub accounts: Vec<(Pubkey, CreditDebitAccount)>,
     pub bootstrap_leader_pubkey: Pubkey,
     pub epoch_warmup: bool,
     pub fee_calculator: FeeCalculator,
@@ -33,7 +33,7 @@ pub fn create_genesis_block(lamports: u64) -> (GenesisBlock, Keypair) {
             &Pubkey::default(),
             &[(
                 mint_keypair.pubkey(),
-                Account::new(lamports, 0, &system_program::id()),
+                CreditDebitAccount::new(lamports, 0, &system_program::id()),
             )],
             &[],
         ),
@@ -44,7 +44,7 @@ pub fn create_genesis_block(lamports: u64) -> (GenesisBlock, Keypair) {
 impl GenesisBlock {
     pub fn new(
         bootstrap_leader_pubkey: &Pubkey,
-        accounts: &[(Pubkey, Account)],
+        accounts: &[(Pubkey, CreditDebitAccount)],
         native_instruction_processors: &[(String, Pubkey)],
     ) -> Self {
         Self {
@@ -109,9 +109,12 @@ mod tests {
             &[
                 (
                     mint_keypair.pubkey(),
-                    Account::new(10_000, 0, &Pubkey::default()),
+                    CreditDebitAccount::new(10_000, 0, &Pubkey::default()),
                 ),
-                (Pubkey::new_rand(), Account::new(1, 0, &Pubkey::default())),
+                (
+                    Pubkey::new_rand(),
+                    CreditDebitAccount::new(1, 0, &Pubkey::default()),
+                ),
             ],
             &[("hi".to_string(), Pubkey::new_rand())],
         );

--- a/sdk/src/instruction.rs
+++ b/sdk/src/instruction.rs
@@ -55,8 +55,11 @@ pub enum InstructionError {
     /// Instruction attempted to debit lamports
     CreditOnlyDebit,
 
-    /// Instruction attempted to debit lamports
+    /// Instruction attempted to modify data
     CreditOnlyDataModification,
+
+    /// Instruction attempted to modify the account owner
+    CreditOnlyOwnerModification,
 
     /// CustomError allows on-chain programs to implement program-specific error types and see
     /// them returned by the Solana runtime. A CustomError may be any type that is represented

--- a/sdk/src/instruction.rs
+++ b/sdk/src/instruction.rs
@@ -52,6 +52,12 @@ pub enum InstructionError {
     /// An account was referenced more than once in a single instruction
     DuplicateAccountIndex,
 
+    /// Instruction attempted to debit lamports
+    CreditOnlyDebit,
+
+    /// Instruction attempted to debit lamports
+    CreditOnlyDataModification,
+
     /// CustomError allows on-chain programs to implement program-specific error types and see
     /// them returned by the Solana runtime. A CustomError may be any type that is represented
     /// as or serialized to a u32 integer.

--- a/sdk/src/instruction_processor_utils.rs
+++ b/sdk/src/instruction_processor_utils.rs
@@ -1,4 +1,4 @@
-use crate::account::KeyedAccount;
+use crate::account_api::AccountWrapper;
 use crate::instruction::InstructionError;
 use crate::pubkey::Pubkey;
 use num_traits::FromPrimitive;
@@ -9,7 +9,7 @@ pub const ENTRYPOINT: &str = "process";
 // Native program ENTRYPOINT prototype
 pub type Entrypoint = unsafe extern "C" fn(
     program_id: &Pubkey,
-    keyed_accounts: &mut [KeyedAccount],
+    keyed_accounts: &mut [AccountWrapper],
     data: &[u8],
 ) -> Result<(), InstructionError>;
 
@@ -21,7 +21,7 @@ macro_rules! solana_entrypoint(
         #[no_mangle]
         pub extern "C" fn process(
             program_id: &solana_sdk::pubkey::Pubkey,
-            keyed_accounts: &mut [solana_sdk::account::KeyedAccount],
+            keyed_accounts: &mut [solana_sdk::account_api::AccountWrapper],
             data: &[u8],
         ) -> Result<(), solana_sdk::instruction::InstructionError> {
             $entrypoint(program_id, keyed_accounts, data)

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -1,8 +1,8 @@
-pub mod account;
 pub mod account_api;
 pub mod account_utils;
 pub mod bpf_loader;
 pub mod client;
+pub mod credit_debit_account;
 pub mod credit_only_account;
 pub mod fee_calculator;
 pub mod genesis_block;

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -1,7 +1,9 @@
 pub mod account;
+pub mod account_api;
 pub mod account_utils;
 pub mod bpf_loader;
 pub mod client;
+pub mod credit_only_account;
 pub mod fee_calculator;
 pub mod genesis_block;
 pub mod hash;

--- a/sdk/src/native_loader.rs
+++ b/sdk/src/native_loader.rs
@@ -1,4 +1,4 @@
-use crate::account::Account;
+use crate::credit_debit_account::CreditDebitAccount;
 use crate::pubkey::Pubkey;
 
 const NATIVE_LOADER_PROGRAM_ID: [u8; 32] = [
@@ -15,8 +15,8 @@ pub fn check_id(program_id: &Pubkey) -> bool {
 }
 
 /// Create an executable account with the given shared object name.
-pub fn create_loadable_account(name: &str) -> Account {
-    Account {
+pub fn create_loadable_account(name: &str) -> CreditDebitAccount {
+    CreditDebitAccount {
         lamports: 1,
         owner: id(),
         data: name.as_bytes().to_vec(),

--- a/sdk/src/syscall/fees.rs
+++ b/sdk/src/syscall/fees.rs
@@ -1,7 +1,7 @@
 //! This account contains the current cluster fees
 //!
-use crate::account::Account;
 use crate::account_utils::State;
+use crate::credit_debit_account::CreditDebitAccount;
 use crate::fee_calculator::FeeCalculator;
 use crate::pubkey::Pubkey;
 use crate::syscall;
@@ -29,10 +29,10 @@ pub struct Fees {
 }
 
 impl Fees {
-    pub fn from(account: &Account) -> Option<Self> {
+    pub fn from(account: &CreditDebitAccount) -> Option<Self> {
         account.state().ok()
     }
-    pub fn to(&self, account: &mut Account) -> Option<()> {
+    pub fn to(&self, account: &mut CreditDebitAccount) -> Option<()> {
         account.set_state(self).ok()
     }
 
@@ -41,8 +41,8 @@ impl Fees {
     }
 }
 
-pub fn create_account(lamports: u64) -> Account {
-    Account::new(lamports, Fees::size_of(), &syscall::id())
+pub fn create_account(lamports: u64) -> CreditDebitAccount {
+    CreditDebitAccount::new(lamports, Fees::size_of(), &syscall::id())
 }
 
 #[cfg(test)]

--- a/sdk/src/syscall/slot_hashes.rs
+++ b/sdk/src/syscall/slot_hashes.rs
@@ -2,8 +2,8 @@
 //!
 //! this account carries the Bank's most recent blockhashes for some N parents
 //!
-use crate::account::Account;
 use crate::account_utils::State;
+use crate::credit_debit_account::CreditDebitAccount;
 use crate::hash::Hash;
 use crate::pubkey::Pubkey;
 use crate::syscall;
@@ -34,10 +34,10 @@ pub struct SlotHashes {
 }
 
 impl SlotHashes {
-    pub fn from(account: &Account) -> Option<Self> {
+    pub fn from(account: &CreditDebitAccount) -> Option<Self> {
         account.state().ok()
     }
-    pub fn to(&self, account: &mut Account) -> Option<()> {
+    pub fn to(&self, account: &mut CreditDebitAccount) -> Option<()> {
         account.set_state(self).ok()
     }
 
@@ -60,8 +60,8 @@ impl Deref for SlotHashes {
     }
 }
 
-pub fn create_account(lamports: u64) -> Account {
-    Account::new(lamports, SlotHashes::size_of(), &syscall::id())
+pub fn create_account(lamports: u64) -> CreditDebitAccount {
+    CreditDebitAccount::new(lamports, SlotHashes::size_of(), &syscall::id())
 }
 
 #[cfg(test)]

--- a/sdk/src/syscall/tick_height.rs
+++ b/sdk/src/syscall/tick_height.rs
@@ -1,8 +1,8 @@
 //! This account contains the current cluster tick height
 //!
-use crate::account::Account;
 use crate::account_api::AccountWrapper;
 use crate::account_utils::State;
+use crate::credit_debit_account::CreditDebitAccount;
 use crate::pubkey::Pubkey;
 use crate::syscall;
 use bincode::serialized_size;
@@ -27,13 +27,13 @@ pub fn check_id(pubkey: &Pubkey) -> bool {
 pub struct TickHeight(u64);
 
 impl TickHeight {
-    pub fn from(account: &Account) -> Option<u64> {
+    pub fn from(account: &CreditDebitAccount) -> Option<u64> {
         account.state().ok().map(|res: Self| res.0)
     }
     pub fn from_wrapped(account: &AccountWrapper) -> Option<u64> {
         account.state().ok().map(|res: Self| res.0)
     }
-    pub fn to(tick_height: u64, account: &mut Account) -> Option<()> {
+    pub fn to(tick_height: u64, account: &mut CreditDebitAccount) -> Option<()> {
         account.set_state(&TickHeight(tick_height)).ok()
     }
 
@@ -42,8 +42,8 @@ impl TickHeight {
     }
 }
 
-pub fn create_account(lamports: u64) -> Account {
-    Account::new(lamports, TickHeight::size_of(), &syscall::id())
+pub fn create_account(lamports: u64) -> CreditDebitAccount {
+    CreditDebitAccount::new(lamports, TickHeight::size_of(), &syscall::id())
 }
 
 #[cfg(test)]

--- a/sdk/src/syscall/tick_height.rs
+++ b/sdk/src/syscall/tick_height.rs
@@ -1,6 +1,7 @@
 //! This account contains the current cluster tick height
 //!
 use crate::account::Account;
+use crate::account_api::AccountWrapper;
 use crate::account_utils::State;
 use crate::pubkey::Pubkey;
 use crate::syscall;
@@ -27,6 +28,9 @@ pub struct TickHeight(u64);
 
 impl TickHeight {
     pub fn from(account: &Account) -> Option<u64> {
+        account.state().ok().map(|res: Self| res.0)
+    }
+    pub fn from_wrapped(account: &AccountWrapper) -> Option<u64> {
         account.state().ok().map(|res: Self| res.0)
     }
     pub fn to(tick_height: u64, account: &mut Account) -> Option<()> {


### PR DESCRIPTION
@garious , @mvines , @jackcmay : comments appreciated

#### Problem
Currently, the program model prevents concurrent handling of credit-only (CO) accounts. Passing CO accounts in alongside credit-debit (CD) accounts is do-able, but provides a disjointed experience for users/developers.

#### Summary of Changes
- Introduce an AccountWrapper enum that allows CO and CD accounts to be passed into programs in the same collection
- Introduce an AccountApi trait to provide parallel methods for CO and CD accounts in programs. This trait also enforces credit-only rules on CO accounts.

#### Remaining Work for this PR
- [x] Fix up storage program
- [ ] Cherry-pick message-processing from #4479 
- [ ] Flesh out tests
- [x] Write macro to clean up boiler-plate `impl AccountApi for AccountWrapper`?
- [x] Rename KeyedAccount & Account, KeyedCreditOnlyAccount & CreditOnlyAccount -- @garious curious about your take on this. Please see this comment: https://github.com/solana-labs/solana/pull/4479/#discussion_r289173497

Toward #4432 , items: 2, 5, 6; and comment items 1-3
