### PR TITLE
Update cargo files for 0.15.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2167,7 +2167,7 @@ dependencies = [
 
 [[package]]
 name = "solana"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "bs58 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2198,26 +2198,26 @@ dependencies = [
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-budget-api 0.15.2",
- "solana-budget-program 0.15.2",
- "solana-client 0.15.2",
- "solana-config-program 0.15.2",
- "solana-drone 0.15.2",
+ "solana-budget-api 0.15.3",
+ "solana-budget-program 0.15.3",
+ "solana-client 0.15.3",
+ "solana-config-program 0.15.3",
+ "solana-drone 0.15.3",
  "solana-ed25519-dalek 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-exchange-program 0.15.2",
- "solana-kvstore 0.15.2",
- "solana-logger 0.15.2",
- "solana-metrics 0.15.2",
- "solana-netutil 0.15.2",
- "solana-runtime 0.15.2",
- "solana-sdk 0.15.2",
- "solana-stake-api 0.15.2",
- "solana-stake-program 0.15.2",
- "solana-storage-api 0.15.2",
- "solana-storage-program 0.15.2",
- "solana-vote-api 0.15.2",
- "solana-vote-program 0.15.2",
- "solana-vote-signer 0.15.2",
+ "solana-exchange-program 0.15.3",
+ "solana-kvstore 0.15.3",
+ "solana-logger 0.15.3",
+ "solana-metrics 0.15.3",
+ "solana-netutil 0.15.3",
+ "solana-runtime 0.15.3",
+ "solana-sdk 0.15.3",
+ "solana-stake-api 0.15.3",
+ "solana-stake-program 0.15.3",
+ "solana-storage-api 0.15.3",
+ "solana-storage-program 0.15.3",
+ "solana-vote-api 0.15.3",
+ "solana-vote-program 0.15.3",
+ "solana-vote-signer 0.15.3",
  "sys-info 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2226,7 +2226,7 @@ dependencies = [
 
 [[package]]
 name = "solana-bench-exchange"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "bs58 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2241,80 +2241,80 @@ dependencies = [
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana 0.15.2",
- "solana-client 0.15.2",
- "solana-drone 0.15.2",
- "solana-exchange-api 0.15.2",
- "solana-exchange-program 0.15.2",
- "solana-logger 0.15.2",
- "solana-metrics 0.15.2",
- "solana-netutil 0.15.2",
- "solana-runtime 0.15.2",
- "solana-sdk 0.15.2",
+ "solana 0.15.3",
+ "solana-client 0.15.3",
+ "solana-drone 0.15.3",
+ "solana-exchange-api 0.15.3",
+ "solana-exchange-program 0.15.3",
+ "solana-logger 0.15.3",
+ "solana-metrics 0.15.3",
+ "solana-netutil 0.15.3",
+ "solana-runtime 0.15.3",
+ "solana-sdk 0.15.3",
  "untrusted 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ws 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "solana-bench-streamer"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana 0.15.2",
- "solana-logger 0.15.2",
- "solana-netutil 0.15.2",
+ "solana 0.15.3",
+ "solana-logger 0.15.3",
+ "solana-netutil 0.15.3",
 ]
 
 [[package]]
 name = "solana-bench-tps"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana 0.15.2",
- "solana-client 0.15.2",
- "solana-drone 0.15.2",
- "solana-logger 0.15.2",
- "solana-metrics 0.15.2",
- "solana-netutil 0.15.2",
- "solana-runtime 0.15.2",
- "solana-sdk 0.15.2",
+ "solana 0.15.3",
+ "solana-client 0.15.3",
+ "solana-drone 0.15.3",
+ "solana-logger 0.15.3",
+ "solana-metrics 0.15.3",
+ "solana-netutil 0.15.3",
+ "solana-runtime 0.15.3",
+ "solana-sdk 0.15.3",
 ]
 
 [[package]]
 name = "solana-bpf-programs"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "elf 0.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-bpfloader 0.15.2",
- "solana-logger 0.15.2",
- "solana-runtime 0.15.2",
- "solana-sdk 0.15.2",
+ "solana-bpfloader 0.15.3",
+ "solana-logger 0.15.3",
+ "solana-runtime 0.15.3",
+ "solana-sdk 0.15.3",
  "solana_rbpf 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 2.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "solana-bpfloader"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-logger 0.15.2",
- "solana-sdk 0.15.2",
+ "solana-logger 0.15.3",
+ "solana-sdk 0.15.3",
  "solana_rbpf 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "solana-budget-api"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2323,23 +2323,23 @@ dependencies = [
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-runtime 0.15.2",
- "solana-sdk 0.15.2",
+ "solana-runtime 0.15.3",
+ "solana-sdk 0.15.3",
 ]
 
 [[package]]
 name = "solana-budget-program"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-budget-api 0.15.2",
- "solana-logger 0.15.2",
- "solana-sdk 0.15.2",
+ "solana-budget-api 0.15.3",
+ "solana-logger 0.15.3",
+ "solana-sdk 0.15.3",
 ]
 
 [[package]]
 name = "solana-client"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "bs58 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2350,37 +2350,37 @@ dependencies = [
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-logger 0.15.2",
- "solana-netutil 0.15.2",
- "solana-sdk 0.15.2",
+ "solana-logger 0.15.3",
+ "solana-netutil 0.15.3",
+ "solana-sdk 0.15.3",
 ]
 
 [[package]]
 name = "solana-config-api"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-logger 0.15.2",
- "solana-runtime 0.15.2",
- "solana-sdk 0.15.2",
+ "solana-logger 0.15.3",
+ "solana-runtime 0.15.3",
+ "solana-sdk 0.15.3",
 ]
 
 [[package]]
 name = "solana-config-program"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-config-api 0.15.2",
- "solana-logger 0.15.2",
- "solana-sdk 0.15.2",
+ "solana-config-api 0.15.3",
+ "solana-logger 0.15.3",
+ "solana-sdk 0.15.3",
 ]
 
 [[package]]
 name = "solana-drone"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2389,9 +2389,9 @@ dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-logger 0.15.2",
- "solana-metrics 0.15.2",
- "solana-sdk 0.15.2",
+ "solana-logger 0.15.3",
+ "solana-metrics 0.15.3",
+ "solana-sdk 0.15.3",
  "tokio 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2410,77 +2410,77 @@ dependencies = [
 
 [[package]]
 name = "solana-exchange-api"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-logger 0.15.2",
- "solana-metrics 0.15.2",
- "solana-runtime 0.15.2",
- "solana-sdk 0.15.2",
+ "solana-logger 0.15.3",
+ "solana-metrics 0.15.3",
+ "solana-runtime 0.15.3",
+ "solana-sdk 0.15.3",
 ]
 
 [[package]]
 name = "solana-exchange-program"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-exchange-api 0.15.2",
- "solana-logger 0.15.2",
- "solana-sdk 0.15.2",
+ "solana-exchange-api 0.15.3",
+ "solana-logger 0.15.3",
+ "solana-sdk 0.15.3",
 ]
 
 [[package]]
 name = "solana-failure-program"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-runtime 0.15.2",
- "solana-sdk 0.15.2",
+ "solana-runtime 0.15.3",
+ "solana-sdk 0.15.3",
 ]
 
 [[package]]
 name = "solana-genesis"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hashbrown 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana 0.15.2",
- "solana-budget-api 0.15.2",
- "solana-budget-program 0.15.2",
- "solana-config-api 0.15.2",
- "solana-config-program 0.15.2",
- "solana-exchange-api 0.15.2",
- "solana-exchange-program 0.15.2",
- "solana-sdk 0.15.2",
- "solana-stake-api 0.15.2",
- "solana-stake-program 0.15.2",
- "solana-storage-api 0.15.2",
- "solana-storage-program 0.15.2",
- "solana-token-api 0.15.2",
- "solana-token-program 0.15.2",
- "solana-vote-api 0.15.2",
- "solana-vote-program 0.15.2",
+ "solana 0.15.3",
+ "solana-budget-api 0.15.3",
+ "solana-budget-program 0.15.3",
+ "solana-config-api 0.15.3",
+ "solana-config-program 0.15.3",
+ "solana-exchange-api 0.15.3",
+ "solana-exchange-program 0.15.3",
+ "solana-sdk 0.15.3",
+ "solana-stake-api 0.15.3",
+ "solana-stake-program 0.15.3",
+ "solana-storage-api 0.15.3",
+ "solana-storage-program 0.15.3",
+ "solana-token-api 0.15.3",
+ "solana-token-program 0.15.3",
+ "solana-vote-api 0.15.3",
+ "solana-vote-program 0.15.3",
 ]
 
 [[package]]
 name = "solana-gossip"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana 0.15.2",
- "solana-client 0.15.2",
- "solana-netutil 0.15.2",
- "solana-sdk 0.15.2",
+ "solana 0.15.3",
+ "solana-client 0.15.3",
+ "solana-netutil 0.15.3",
+ "solana-sdk 0.15.3",
 ]
 
 [[package]]
 name = "solana-install"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "bs58 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2497,10 +2497,10 @@ dependencies = [
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_yaml 0.8.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-client 0.15.2",
- "solana-config-api 0.15.2",
- "solana-logger 0.15.2",
- "solana-sdk 0.15.2",
+ "solana-client 0.15.3",
+ "solana-config-api 0.15.3",
+ "solana-logger 0.15.3",
+ "solana-sdk 0.15.3",
  "tar 0.4.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2508,16 +2508,16 @@ dependencies = [
 
 [[package]]
 name = "solana-keygen"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-sdk 0.15.2",
+ "solana-sdk 0.15.3",
 ]
 
 [[package]]
 name = "solana-kvstore"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2532,27 +2532,27 @@ dependencies = [
 
 [[package]]
 name = "solana-ledger-tool"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "assert_cmd 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana 0.15.2",
- "solana-logger 0.15.2",
- "solana-runtime 0.15.2",
- "solana-sdk 0.15.2",
+ "solana 0.15.3",
+ "solana-logger 0.15.3",
+ "solana-runtime 0.15.3",
+ "solana-sdk 0.15.3",
 ]
 
 [[package]]
 name = "solana-logger"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "solana-metrics"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "influx_db_client 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2560,13 +2560,13 @@ dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.9.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-sdk 0.15.2",
+ "solana-sdk 0.15.3",
  "sys-info 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "solana-netutil"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2574,33 +2574,33 @@ dependencies = [
  "nix 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "socket2 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-logger 0.15.2",
+ "solana-logger 0.15.3",
  "tokio 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "solana-noop-program"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-logger 0.15.2",
- "solana-sdk 0.15.2",
+ "solana-logger 0.15.3",
+ "solana-sdk 0.15.3",
 ]
 
 [[package]]
 name = "solana-replicator"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana 0.15.2",
- "solana-logger 0.15.2",
- "solana-netutil 0.15.2",
- "solana-sdk 0.15.2",
+ "solana 0.15.3",
+ "solana-logger 0.15.3",
+ "solana-netutil 0.15.3",
+ "solana-sdk 0.15.3",
 ]
 
 [[package]]
 name = "solana-runtime"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "bv 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2616,19 +2616,19 @@ dependencies = [
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-logger 0.15.2",
- "solana-metrics 0.15.2",
- "solana-noop-program 0.15.2",
- "solana-sdk 0.15.2",
- "solana-stake-api 0.15.2",
- "solana-stake-program 0.15.2",
- "solana-vote-api 0.15.2",
- "solana-vote-program 0.15.2",
+ "solana-logger 0.15.3",
+ "solana-metrics 0.15.3",
+ "solana-noop-program 0.15.3",
+ "solana-sdk 0.15.3",
+ "solana-stake-api 0.15.3",
+ "solana-stake-program 0.15.3",
+ "solana-vote-api 0.15.3",
+ "solana-vote-program 0.15.3",
 ]
 
 [[package]]
 name = "solana-sdk"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "bs58 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2652,55 +2652,55 @@ dependencies = [
 
 [[package]]
 name = "solana-stake-api"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-logger 0.15.2",
- "solana-metrics 0.15.2",
- "solana-sdk 0.15.2",
- "solana-vote-api 0.15.2",
+ "solana-logger 0.15.3",
+ "solana-metrics 0.15.3",
+ "solana-sdk 0.15.3",
+ "solana-vote-api 0.15.3",
 ]
 
 [[package]]
 name = "solana-stake-program"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-logger 0.15.2",
- "solana-sdk 0.15.2",
- "solana-stake-api 0.15.2",
+ "solana-logger 0.15.3",
+ "solana-sdk 0.15.3",
+ "solana-stake-api 0.15.3",
 ]
 
 [[package]]
 name = "solana-storage-api"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "assert_matches 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-logger 0.15.2",
- "solana-runtime 0.15.2",
- "solana-sdk 0.15.2",
+ "solana-logger 0.15.3",
+ "solana-runtime 0.15.3",
+ "solana-sdk 0.15.3",
 ]
 
 [[package]]
 name = "solana-storage-program"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-logger 0.15.2",
- "solana-sdk 0.15.2",
- "solana-storage-api 0.15.2",
+ "solana-logger 0.15.3",
+ "solana-sdk 0.15.3",
+ "solana-storage-api 0.15.3",
 ]
 
 [[package]]
 name = "solana-token-api"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2708,73 +2708,73 @@ dependencies = [
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-logger 0.15.2",
- "solana-sdk 0.15.2",
+ "solana-logger 0.15.3",
+ "solana-sdk 0.15.3",
 ]
 
 [[package]]
 name = "solana-token-program"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-logger 0.15.2",
- "solana-sdk 0.15.2",
- "solana-token-api 0.15.2",
+ "solana-logger 0.15.3",
+ "solana-sdk 0.15.3",
+ "solana-token-api 0.15.3",
 ]
 
 [[package]]
 name = "solana-upload-perf"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-metrics 0.15.2",
+ "solana-metrics 0.15.3",
 ]
 
 [[package]]
 name = "solana-validator"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana 0.15.2",
- "solana-drone 0.15.2",
- "solana-logger 0.15.2",
- "solana-metrics 0.15.2",
- "solana-netutil 0.15.2",
- "solana-runtime 0.15.2",
- "solana-sdk 0.15.2",
- "solana-vote-api 0.15.2",
- "solana-vote-signer 0.15.2",
+ "solana 0.15.3",
+ "solana-drone 0.15.3",
+ "solana-logger 0.15.3",
+ "solana-metrics 0.15.3",
+ "solana-netutil 0.15.3",
+ "solana-runtime 0.15.3",
+ "solana-sdk 0.15.3",
+ "solana-vote-api 0.15.3",
+ "solana-vote-signer 0.15.3",
 ]
 
 [[package]]
 name = "solana-vote-api"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-logger 0.15.2",
- "solana-metrics 0.15.2",
- "solana-sdk 0.15.2",
+ "solana-logger 0.15.3",
+ "solana-metrics 0.15.3",
+ "solana-sdk 0.15.3",
 ]
 
 [[package]]
 name = "solana-vote-program"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-logger 0.15.2",
- "solana-sdk 0.15.2",
- "solana-vote-api 0.15.2",
+ "solana-logger 0.15.3",
+ "solana-sdk 0.15.3",
+ "solana-vote-api 0.15.3",
 ]
 
 [[package]]
 name = "solana-vote-signer"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "bs58 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2784,13 +2784,13 @@ dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-metrics 0.15.2",
- "solana-sdk 0.15.2",
+ "solana-metrics 0.15.3",
+ "solana-sdk 0.15.3",
 ]
 
 [[package]]
 name = "solana-wallet"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "bs58 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2800,18 +2800,18 @@ dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana 0.15.2",
- "solana-budget-api 0.15.2",
- "solana-budget-program 0.15.2",
- "solana-client 0.15.2",
- "solana-drone 0.15.2",
- "solana-logger 0.15.2",
- "solana-netutil 0.15.2",
- "solana-sdk 0.15.2",
- "solana-stake-api 0.15.2",
- "solana-storage-api 0.15.2",
- "solana-vote-api 0.15.2",
- "solana-vote-signer 0.15.2",
+ "solana 0.15.3",
+ "solana-budget-api 0.15.3",
+ "solana-budget-program 0.15.3",
+ "solana-client 0.15.3",
+ "solana-drone 0.15.3",
+ "solana-logger 0.15.3",
+ "solana-netutil 0.15.3",
+ "solana-sdk 0.15.3",
+ "solana-stake-api 0.15.3",
+ "solana-storage-api 0.15.3",
+ "solana-vote-api 0.15.3",
+ "solana-vote-signer 0.15.3",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/bench-exchange/Cargo.toml
+++ b/bench-exchange/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Solana Maintainers <maintainers@solana.com>"]
 edition = "2018"
 name = "solana-bench-exchange"
-version = "0.15.2"
+version = "0.15.3"
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 homepage = "https://solana.com/"
@@ -23,16 +23,16 @@ serde = "1.0.91"
 serde_derive = "1.0.91"
 serde_json = "1.0.38"
 # solana-runtime = { path = "../solana/runtime"}
-solana = { path = "../core", version = "0.15.2"    }
-solana-client = { path = "../client", version = "0.15.2"    }
-solana-drone = { path = "../drone", version = "0.15.2"    }
-solana-exchange-api = { path = "../programs/exchange_api", version = "0.15.2"    }
-solana-exchange-program = { path = "../programs/exchange_program", version = "0.15.2"    }
-solana-logger = { path = "../logger", version = "0.15.2"    }
-solana-metrics = { path = "../metrics", version = "0.15.2"    }
-solana-netutil = { path = "../netutil", version = "0.15.2"    }
-solana-runtime = { path = "../runtime", version = "0.15.2"    }
-solana-sdk = { path = "../sdk", version = "0.15.2"    }
+solana = { path = "../core", version = "0.15.3"     }
+solana-client = { path = "../client", version = "0.15.3"     }
+solana-drone = { path = "../drone", version = "0.15.3"     }
+solana-exchange-api = { path = "../programs/exchange_api", version = "0.15.3"     }
+solana-exchange-program = { path = "../programs/exchange_program", version = "0.15.3"     }
+solana-logger = { path = "../logger", version = "0.15.3"     }
+solana-metrics = { path = "../metrics", version = "0.15.3"     }
+solana-netutil = { path = "../netutil", version = "0.15.3"     }
+solana-runtime = { path = "../runtime", version = "0.15.3"     }
+solana-sdk = { path = "../sdk", version = "0.15.3"     }
 ws = "0.8.1"
 untrusted = "0.6.2"
 

--- a/bench-streamer/Cargo.toml
+++ b/bench-streamer/Cargo.toml
@@ -2,16 +2,16 @@
 authors = ["Solana Maintainers <maintainers@solana.com>"]
 edition = "2018"
 name = "solana-bench-streamer"
-version = "0.15.2"
+version = "0.15.3"
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 homepage = "https://solana.com/"
 
 [dependencies]
 clap = "2.33.0"
-solana = { path = "../core", version = "0.15.2"    }
-solana-logger = { path = "../logger", version = "0.15.2"    }
-solana-netutil = { path = "../netutil", version = "0.15.2"    }
+solana = { path = "../core", version = "0.15.3"     }
+solana-logger = { path = "../logger", version = "0.15.3"     }
+solana-netutil = { path = "../netutil", version = "0.15.3"     }
 
 [features]
 cuda = ["solana/cuda"]

--- a/bench-tps/Cargo.toml
+++ b/bench-tps/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Solana Maintainers <maintainers@solana.com>"]
 edition = "2018"
 name = "solana-bench-tps"
-version = "0.15.2"
+version = "0.15.3"
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 homepage = "https://solana.com/"
@@ -12,14 +12,14 @@ clap = "2.33.0"
 log = "0.4.6"
 rayon = "1.0.3"
 serde_json = "1.0.39"
-solana = { path = "../core", version = "0.15.2"    }
-solana-client = { path = "../client", version = "0.15.2"    }
-solana-drone = { path = "../drone", version = "0.15.2"    }
-solana-logger = { path = "../logger", version = "0.15.2"    }
-solana-metrics = { path = "../metrics", version = "0.15.2"    }
-solana-netutil = { path = "../netutil", version = "0.15.2"    }
-solana-runtime = { path = "../runtime", version = "0.15.2"    }
-solana-sdk = { path = "../sdk", version = "0.15.2"    }
+solana = { path = "../core", version = "0.15.3"     }
+solana-client = { path = "../client", version = "0.15.3"     }
+solana-drone = { path = "../drone", version = "0.15.3"     }
+solana-logger = { path = "../logger", version = "0.15.3"     }
+solana-metrics = { path = "../metrics", version = "0.15.3"     }
+solana-netutil = { path = "../netutil", version = "0.15.3"     }
+solana-runtime = { path = "../runtime", version = "0.15.3"     }
+solana-sdk = { path = "../sdk", version = "0.15.3"     }
 
 [features]
 cuda = ["solana/cuda"]

--- a/book/src/testnet-participation.md
+++ b/book/src/testnet-participation.md
@@ -67,8 +67,8 @@ The `solana-install` tool can be used to easily install and upgrade the cluster
 software on Linux x86_64 systems.
 
 ```bash
-$ export SOLANA_RELEASE=v0.15.0  # skip this line to install the latest release
-$ curl -sSf https://raw.githubusercontent.com/solana-labs/solana/v0.14.0/install/solana-install-init.sh | sh -s
+$ export SOLANA_RELEASE=v0.15.2  # skip this line to install the latest release
+$ curl -sSf https://raw.githubusercontent.com/solana-labs/solana/v0.15.2/install/solana-install-init.sh | sh -s
 ```
 
 Alternatively build the `solana-install` program from source and run the

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-client"
-version = "0.15.2"
+version = "0.15.3"
 description = "Solana Client"
 authors = ["Solana Maintainers <maintainers@solana.com>"]
 repository = "https://github.com/solana-labs/solana"
@@ -17,10 +17,10 @@ reqwest = "0.9.17"
 serde = "1.0.89"
 serde_derive = "1.0.91"
 serde_json = "1.0.39"
-solana-netutil = { path = "../netutil", version = "0.15.2"    }
-solana-sdk = { path = "../sdk", version = "0.15.2"    }
+solana-netutil = { path = "../netutil", version = "0.15.3"     }
+solana-sdk = { path = "../sdk", version = "0.15.3"     }
 
 [dev-dependencies]
 jsonrpc-core = "10.1.0"
 jsonrpc-http-server = "10.1.0"
-solana-logger = { path = "../logger", version = "0.15.2"    }
+solana-logger = { path = "../logger", version = "0.15.3"     }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "solana"
 description = "Blockchain, Rebuilt for Scale"
-version = "0.15.2"
+version = "0.15.3"
 documentation = "https://docs.rs/solana"
 homepage = "https://solana.com/"
 readme = "../README.md"
@@ -47,26 +47,26 @@ rocksdb = "0.11.0"
 serde = "1.0.89"
 serde_derive = "1.0.91"
 serde_json = "1.0.39"
-solana-budget-api = { path = "../programs/budget_api", version = "0.15.2"    }
-solana-budget-program = { path = "../programs/budget_program", version = "0.15.2"    }
-solana-client = { path = "../client", version = "0.15.2"    }
-solana-drone = { path = "../drone", version = "0.15.2"    }
+solana-budget-api = { path = "../programs/budget_api", version = "0.15.3"     }
+solana-budget-program = { path = "../programs/budget_program", version = "0.15.3"     }
+solana-client = { path = "../client", version = "0.15.3"     }
+solana-drone = { path = "../drone", version = "0.15.3"     }
 solana-ed25519-dalek = "0.2.0"
-solana-kvstore = { path = "../kvstore", version = "0.15.2" , optional = true    }
-solana-logger = { path = "../logger", version = "0.15.2"    }
-solana-metrics = { path = "../metrics", version = "0.15.2"    }
-solana-netutil = { path = "../netutil", version = "0.15.2"    }
-solana-runtime = { path = "../runtime", version = "0.15.2"    }
-solana-sdk = { path = "../sdk", version = "0.15.2"    }
-solana-stake-api = { path = "../programs/stake_api", version = "0.15.2"    }
-solana-stake-program = { path = "../programs/stake_program", version = "0.15.2"    }
-solana-storage-api = { path = "../programs/storage_api", version = "0.15.2"    }
-solana-storage-program = { path = "../programs/storage_program", version = "0.15.2"    }
-solana-vote-api = { path = "../programs/vote_api", version = "0.15.2"    }
-solana-vote-program = { path = "../programs/vote_program", version = "0.15.2"    }
-solana-exchange-program = { path = "../programs/exchange_program", version = "0.15.2"    }
-solana-config-program = { path = "../programs/config_program", version = "0.15.2"    }
-solana-vote-signer = { path = "../vote-signer", version = "0.15.2"    }
+solana-kvstore = { path = "../kvstore", version = "0.15.3" , optional = true     }
+solana-logger = { path = "../logger", version = "0.15.3"     }
+solana-metrics = { path = "../metrics", version = "0.15.3"     }
+solana-netutil = { path = "../netutil", version = "0.15.3"     }
+solana-runtime = { path = "../runtime", version = "0.15.3"     }
+solana-sdk = { path = "../sdk", version = "0.15.3"     }
+solana-stake-api = { path = "../programs/stake_api", version = "0.15.3"     }
+solana-stake-program = { path = "../programs/stake_program", version = "0.15.3"     }
+solana-storage-api = { path = "../programs/storage_api", version = "0.15.3"     }
+solana-storage-program = { path = "../programs/storage_program", version = "0.15.3"     }
+solana-vote-api = { path = "../programs/vote_api", version = "0.15.3"     }
+solana-vote-program = { path = "../programs/vote_program", version = "0.15.3"     }
+solana-exchange-program = { path = "../programs/exchange_program", version = "0.15.3"     }
+solana-config-program = { path = "../programs/config_program", version = "0.15.3"     }
+solana-vote-signer = { path = "../vote-signer", version = "0.15.3"     }
 sys-info = "0.5.6"
 tokio = "0.1"
 tokio-codec = "0.1"

--- a/drone/Cargo.toml
+++ b/drone/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-drone"
-version = "0.15.2"
+version = "0.15.3"
 description = "Solana Drone"
 authors = ["Solana Maintainers <maintainers@solana.com>"]
 repository = "https://github.com/solana-labs/solana"
@@ -20,9 +20,9 @@ clap = "2.33"
 log = "0.4.2"
 serde = "1.0.91"
 serde_derive = "1.0.91"
-solana-logger = { path = "../logger", version = "0.15.2"    }
-solana-sdk = { path = "../sdk", version = "0.15.2"    }
-solana-metrics = { path = "../metrics", version = "0.15.2"    }
+solana-logger = { path = "../logger", version = "0.15.3"     }
+solana-sdk = { path = "../sdk", version = "0.15.3"     }
+solana-metrics = { path = "../metrics", version = "0.15.3"     }
 tokio = "0.1"
 tokio-codec = "0.1"
 

--- a/genesis/Cargo.toml
+++ b/genesis/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Solana Maintainers <maintainers@solana.com>"]
 edition = "2018"
 name = "solana-genesis"
 description = "Blockchain, Rebuilt for Scale"
-version = "0.15.2"
+version = "0.15.3"
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 homepage = "https://solana.com/"
@@ -11,22 +11,22 @@ homepage = "https://solana.com/"
 [dependencies]
 clap = "2.33.0"
 serde_json = "1.0.39"
-solana = { path = "../core", version = "0.15.2"    }
-solana-sdk = { path = "../sdk", version = "0.15.2"    }
-solana-budget-api = { path = "../programs/budget_api", version = "0.15.2"    }
-solana-budget-program = { path = "../programs/budget_program", version = "0.15.2"    }
-solana-vote-api = { path = "../programs/vote_api", version = "0.15.2"    }
-solana-vote-program = { path = "../programs/vote_program", version = "0.15.2"    }
-solana-stake-api = { path = "../programs/stake_api", version = "0.15.2"    }
-solana-stake-program = { path = "../programs/stake_program", version = "0.15.2"    }
-solana-storage-api = { path = "../programs/storage_api", version = "0.15.2"    }
-solana-storage-program = { path = "../programs/storage_program", version = "0.15.2"    }
-solana-token-api = { path = "../programs/token_api", version = "0.15.2"    }
-solana-token-program = { path = "../programs/token_program", version = "0.15.2"    }
-solana-config-api = { path = "../programs/config_api", version = "0.15.2"    }
-solana-config-program = { path = "../programs/config_program", version = "0.15.2"    }
-solana-exchange-api = { path = "../programs/exchange_api", version = "0.15.2"    }
-solana-exchange-program = { path = "../programs/exchange_program", version = "0.15.2"    }
+solana = { path = "../core", version = "0.15.3"     }
+solana-sdk = { path = "../sdk", version = "0.15.3"     }
+solana-budget-api = { path = "../programs/budget_api", version = "0.15.3"     }
+solana-budget-program = { path = "../programs/budget_program", version = "0.15.3"     }
+solana-vote-api = { path = "../programs/vote_api", version = "0.15.3"     }
+solana-vote-program = { path = "../programs/vote_program", version = "0.15.3"     }
+solana-stake-api = { path = "../programs/stake_api", version = "0.15.3"     }
+solana-stake-program = { path = "../programs/stake_program", version = "0.15.3"     }
+solana-storage-api = { path = "../programs/storage_api", version = "0.15.3"     }
+solana-storage-program = { path = "../programs/storage_program", version = "0.15.3"     }
+solana-token-api = { path = "../programs/token_api", version = "0.15.3"     }
+solana-token-program = { path = "../programs/token_program", version = "0.15.3"     }
+solana-config-api = { path = "../programs/config_api", version = "0.15.3"     }
+solana-config-program = { path = "../programs/config_program", version = "0.15.3"     }
+solana-exchange-api = { path = "../programs/exchange_api", version = "0.15.3"     }
+solana-exchange-program = { path = "../programs/exchange_program", version = "0.15.3"     }
 
 [dev-dependencies]
 hashbrown = "0.3.0"

--- a/gossip/Cargo.toml
+++ b/gossip/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Solana Maintainers <maintainers@solana.com>"]
 edition = "2018"
 name = "solana-gossip"
 description = "Blockchain, Rebuilt for Scale"
-version = "0.15.2"
+version = "0.15.3"
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 homepage = "https://solana.com/"
@@ -11,10 +11,10 @@ homepage = "https://solana.com/"
 [dependencies]
 clap = "2.33.0"
 env_logger = "0.6.1"
-solana = { path = "../core", version = "0.15.2"    }
-solana-client = { path = "../client", version = "0.15.2"     }
-solana-netutil = { path = "../netutil", version = "0.15.2"    }
-solana-sdk = { path = "../sdk", version = "0.15.2"    }
+solana = { path = "../core", version = "0.15.3"     }
+solana-client = { path = "../client", version = "0.15.3"      }
+solana-netutil = { path = "../netutil", version = "0.15.3"     }
+solana-sdk = { path = "../sdk", version = "0.15.3"     }
 
 [features]
 chacha = []

--- a/install/Cargo.toml
+++ b/install/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Solana Maintainers <maintainers@solana.com>"]
 edition = "2018"
 name = "solana-install"
 description = "The solana cluster software installer"
-version = "0.15.2"
+version = "0.15.3"
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 homepage = "https://solana.com/"
@@ -28,10 +28,10 @@ ring = "0.13.2"
 serde = "1.0.91"
 serde_derive = "1.0.91"
 serde_yaml = "0.8.9"
-solana-client = { path = "../client", version = "0.15.2"    }
-solana-config-api = { path = "../programs/config_api", version = "0.15.2"    }
-solana-logger = { path = "../logger", version = "0.15.2"    }
-solana-sdk = { path = "../sdk", version = "0.15.2"    }
+solana-client = { path = "../client", version = "0.15.3"     }
+solana-config-api = { path = "../programs/config_api", version = "0.15.3"     }
+solana-logger = { path = "../logger", version = "0.15.3"     }
+solana-sdk = { path = "../sdk", version = "0.15.3"     }
 tar = "0.4.26"
 tempdir = "0.3.7"
 url = "1.7.2"

--- a/keygen/Cargo.toml
+++ b/keygen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-keygen"
-version = "0.15.2"
+version = "0.15.3"
 description = "Solana key generation utility"
 authors = ["Solana Maintainers <maintainers@solana.com>"]
 repository = "https://github.com/solana-labs/solana"
@@ -15,7 +15,7 @@ erasure = []
 [dependencies]
 dirs = "1.0.5"
 clap = "2.33"
-solana-sdk = { path = "../sdk", version = "0.15.2"    }
+solana-sdk = { path = "../sdk", version = "0.15.3"     }
 
 [[bin]]
 name = "solana-keygen"

--- a/kvstore/Cargo.toml
+++ b/kvstore/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "solana-kvstore"
 description = "Embedded Key-Value store for solana"
-version = "0.15.2"
+version = "0.15.3"
 homepage = "https://solana.com/"
 repository = "https://github.com/solana-labs/solana"
 authors = ["Solana Maintainers <maintainers@solana.com>"]

--- a/ledger-tool/Cargo.toml
+++ b/ledger-tool/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Solana Maintainers <maintainers@solana.com>"]
 edition = "2018"
 name = "solana-ledger-tool"
 description = "Blockchain, Rebuilt for Scale"
-version = "0.15.2"
+version = "0.15.3"
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 homepage = "https://solana.com/"
@@ -11,10 +11,10 @@ homepage = "https://solana.com/"
 [dependencies]
 clap = "2.33.0"
 serde_json = "1.0.39"
-solana = { path = "../core", version = "0.15.2"    }
-solana-sdk = { path = "../sdk", version = "0.15.2"    }
-solana-logger = { path = "../logger", version = "0.15.2"    }
-solana-runtime = { path = "../runtime", version = "0.15.2"    }
+solana = { path = "../core", version = "0.15.3"     }
+solana-sdk = { path = "../sdk", version = "0.15.3"     }
+solana-logger = { path = "../logger", version = "0.15.3"     }
+solana-runtime = { path = "../runtime", version = "0.15.3"     }
 
 [dev-dependencies]
 assert_cmd = "0.11"

--- a/logger/Cargo.toml
+++ b/logger/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-logger"
-version = "0.15.2"
+version = "0.15.3"
 description = "Solana Logger"
 authors = ["Solana Maintainers <maintainers@solana.com>"]
 repository = "https://github.com/solana-labs/solana"

--- a/metrics/Cargo.toml
+++ b/metrics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-metrics"
-version = "0.15.2"
+version = "0.15.3"
 description = "Solana Metrics"
 authors = ["Solana Maintainers <maintainers@solana.com>"]
 repository = "https://github.com/solana-labs/solana"
@@ -15,7 +15,7 @@ log = "0.4.2"
 reqwest = "0.9.17"
 lazy_static = "1.3.0"
 sys-info = "0.5.6"
-solana-sdk = { path = "../sdk", version = "0.15.2"    }
+solana-sdk = { path = "../sdk", version = "0.15.3"     }
 
 [dev-dependencies]
 rand = "0.6.5"

--- a/netutil/Cargo.toml
+++ b/netutil/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-netutil"
-version = "0.15.2"
+version = "0.15.3"
 description = "Solana Network Utilities"
 authors = ["Solana Maintainers <maintainers@solana.com>"]
 repository = "https://github.com/solana-labs/solana"
@@ -15,7 +15,7 @@ log = "0.4.2"
 nix = "0.14.0"
 rand = "0.6.1"
 socket2 = "0.3.9"
-solana-logger = { path = "../logger", version = "0.15.2"    }
+solana-logger = { path = "../logger", version = "0.15.3"     }
 tokio = "0.1"
 
 [lib]

--- a/programs/bpf/Cargo.toml
+++ b/programs/bpf/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "solana-bpf-programs"
 description = "Blockchain, Rebuilt for Scale"
-version = "0.15.2"
+version = "0.15.3"
 documentation = "https://docs.rs/solana"
 homepage = "https://solana.com/"
 readme = "README.md"
@@ -22,10 +22,10 @@ bincode = "1.1.4"
 byteorder = "1.3.1"
 elf = "0.0.10"
 solana_rbpf = "=0.1.12"
-solana-bpfloader = { path = "../bpf_loader", version = "0.15.2"    }
-solana-logger = { path = "../../logger", version = "0.15.2"    }
-solana-runtime = { path = "../../runtime", version = "0.15.2"    }
-solana-sdk = { path = "../../sdk", version = "0.15.2"    }
+solana-bpfloader = { path = "../bpf_loader", version = "0.15.3"     }
+solana-logger = { path = "../../logger", version = "0.15.3"     }
+solana-runtime = { path = "../../runtime", version = "0.15.3"     }
+solana-sdk = { path = "../../sdk", version = "0.15.3"     }
 
 [[bench]]
 name = "bpf_loader"

--- a/programs/bpf/rust/alloc/Cargo.toml
+++ b/programs/bpf/rust/alloc/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "solana-bpf-rust-alloc"
-version = "0.15.2"
+version = "0.15.3"
 description = "Solana BPF alloc program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.com>"]
 repository = "https://github.com/solana-labs/solana"
@@ -12,7 +12,7 @@ homepage = "https://solana.com/"
 edition = "2018"
 
 [dependencies]
-solana-sdk-bpf-utils = { path = "../../../../sdk/bpf/rust-utils", version = "0.15.2"   }
+solana-sdk-bpf-utils = { path = "../../../../sdk/bpf/rust-utils", version = "0.15.3"    }
 
 [workspace]
 members = []

--- a/programs/bpf/rust/iter/Cargo.toml
+++ b/programs/bpf/rust/iter/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "solana-bpf-rust-iter"
-version = "0.15.2"
+version = "0.15.3"
 description = "Solana BPF iter program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.com>"]
 repository = "https://github.com/solana-labs/solana"
@@ -12,7 +12,7 @@ homepage = "https://solana.com/"
 edition = "2018"
 
 [dependencies]
-solana-sdk-bpf-utils = { path = "../../../../sdk/bpf/rust-utils", version = "0.15.2"   }
+solana-sdk-bpf-utils = { path = "../../../../sdk/bpf/rust-utils", version = "0.15.3"    }
 
 [workspace]
 members = []

--- a/programs/bpf/rust/noop/Cargo.toml
+++ b/programs/bpf/rust/noop/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "solana-bpf-rust-noop"
-version = "0.15.2"
+version = "0.15.3"
 description = "Solana BPF noop program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.com>"]
 repository = "https://github.com/solana-labs/solana"
@@ -12,7 +12,7 @@ homepage = "https://solana.com/"
 edition = "2018"
 
 [dependencies]
-solana-sdk-bpf-utils = { path = "../../../../sdk/bpf/rust-utils", version = "0.15.2"   }
+solana-sdk-bpf-utils = { path = "../../../../sdk/bpf/rust-utils", version = "0.15.3"    }
 
 [workspace]
 members = []

--- a/programs/bpf_loader/Cargo.toml
+++ b/programs/bpf_loader/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpfloader"
-version = "0.15.2"
+version = "0.15.3"
 description = "Solana BPF Loader"
 authors = ["Solana Maintainers <maintainers@solana.com>"]
 repository = "https://github.com/solana-labs/solana"
@@ -15,8 +15,8 @@ libc = "0.2.55"
 log = "0.4.2"
 solana_rbpf = "=0.1.12"
 serde = "1.0.91"
-solana-logger = { path = "../../logger", version = "0.15.2"    }
-solana-sdk = { path = "../../sdk", version = "0.15.2"    }
+solana-logger = { path = "../../logger", version = "0.15.3"     }
+solana-sdk = { path = "../../sdk", version = "0.15.3"     }
 
 [lib]
 name = "solana_bpf_loader"

--- a/programs/budget_api/Cargo.toml
+++ b/programs/budget_api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-budget-api"
-version = "0.15.2"
+version = "0.15.3"
 description = "Solana Budget program API"
 authors = ["Solana Maintainers <maintainers@solana.com>"]
 repository = "https://github.com/solana-labs/solana"
@@ -16,10 +16,10 @@ num-derive = "0.2"
 num-traits = "0.2"
 serde = "1.0.91"
 serde_derive = "1.0.91"
-solana-sdk = { path = "../../sdk", version = "0.15.2"    }
+solana-sdk = { path = "../../sdk", version = "0.15.3"     }
 
 [dev-dependencies]
-solana-runtime = { path = "../../runtime", version = "0.15.2"    }
+solana-runtime = { path = "../../runtime", version = "0.15.3"     }
 
 [lib]
 name = "solana_budget_api"

--- a/programs/budget_program/Cargo.toml
+++ b/programs/budget_program/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-budget-program"
-version = "0.15.2"
+version = "0.15.3"
 description = "Solana budget program"
 authors = ["Solana Maintainers <maintainers@solana.com>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,9 +10,9 @@ edition = "2018"
 
 [dependencies]
 log = "0.4.2"
-solana-budget-api = { path = "../budget_api", version = "0.15.2"    }
-solana-logger = { path = "../../logger", version = "0.15.2"    }
-solana-sdk = { path = "../../sdk", version = "0.15.2"    }
+solana-budget-api = { path = "../budget_api", version = "0.15.3"     }
+solana-logger = { path = "../../logger", version = "0.15.3"     }
+solana-sdk = { path = "../../sdk", version = "0.15.3"     }
 
 [lib]
 name = "solana_budget_program"

--- a/programs/config_api/Cargo.toml
+++ b/programs/config_api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-config-api"
-version = "0.15.2"
+version = "0.15.3"
 description = "config program API"
 authors = ["Solana Maintainers <maintainers@solana.com>"]
 repository = "https://github.com/solana-labs/solana"
@@ -13,11 +13,11 @@ bincode = "1.1.4"
 log = "0.4.2"
 serde = "1.0.91"
 serde_derive = "1.0.91"
-solana-logger = { path = "../../logger", version = "0.15.2"    }
-solana-sdk = { path = "../../sdk", version = "0.15.2"    }
+solana-logger = { path = "../../logger", version = "0.15.3"     }
+solana-sdk = { path = "../../sdk", version = "0.15.3"     }
 
 [dev-dependencies]
-solana-runtime = { path = "../../runtime", version = "0.15.2"    }
+solana-runtime = { path = "../../runtime", version = "0.15.3"     }
 
 [lib]
 name = "solana_config_api"

--- a/programs/config_program/Cargo.toml
+++ b/programs/config_program/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-config-program"
-version = "0.15.2"
+version = "0.15.3"
 description = "config program"
 authors = ["Solana Maintainers <maintainers@solana.com>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,9 +10,9 @@ edition = "2018"
 
 [dependencies]
 log = "0.4.2"
-solana-config-api = { path = "../config_api", version = "0.15.2"    }
-solana-logger = { path = "../../logger", version = "0.15.2"    }
-solana-sdk = { path = "../../sdk", version = "0.15.2"    }
+solana-config-api = { path = "../config_api", version = "0.15.3"     }
+solana-logger = { path = "../../logger", version = "0.15.3"     }
+solana-sdk = { path = "../../sdk", version = "0.15.3"     }
 
 [lib]
 name = "solana_config_program"

--- a/programs/exchange_api/Cargo.toml
+++ b/programs/exchange_api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-exchange-api"
-version = "0.15.2"
+version = "0.15.3"
 description = "Solana Exchange program API"
 authors = ["Solana Maintainers <maintainers@solana.com>"]
 repository = "https://github.com/solana-labs/solana"
@@ -13,12 +13,12 @@ log = "0.4.2"
 bincode = "1.1.4"
 serde = "1.0.91"
 serde_derive = "1.0.91"
-solana-logger = { path = "../../logger", version = "0.15.2"    }
-solana-sdk = { path = "../../sdk", version = "0.15.2"    }
-solana-metrics = { path = "../../metrics", version = "0.15.2"    }
+solana-logger = { path = "../../logger", version = "0.15.3"     }
+solana-sdk = { path = "../../sdk", version = "0.15.3"     }
+solana-metrics = { path = "../../metrics", version = "0.15.3"     }
 
 [dev-dependencies]
-solana-runtime = { path = "../../runtime", version = "0.15.2"    }
+solana-runtime = { path = "../../runtime", version = "0.15.3"     }
 
 [lib]
 name = "solana_exchange_api"

--- a/programs/exchange_program/Cargo.toml
+++ b/programs/exchange_program/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-exchange-program"
-version = "0.15.2"
+version = "0.15.3"
 description = "Solana exchange program"
 authors = ["Solana Maintainers <maintainers@solana.com>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,9 +10,9 @@ edition = "2018"
 
 [dependencies]
 log = "0.4.2"
-solana-exchange-api = { path = "../exchange_api", version = "0.15.2"    }
-solana-logger = { path = "../../logger", version = "0.15.2"    }
-solana-sdk = { path = "../../sdk", version = "0.15.2"    }
+solana-exchange-api = { path = "../exchange_api", version = "0.15.3"     }
+solana-logger = { path = "../../logger", version = "0.15.3"     }
+solana-sdk = { path = "../../sdk", version = "0.15.3"     }
 
 [lib]
 name = "solana_exchange_program"

--- a/programs/failure_program/Cargo.toml
+++ b/programs/failure_program/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-failure-program"
-version = "0.15.2"
+version = "0.15.3"
 description = "Solana failure program"
 authors = ["Solana Maintainers <maintainers@solana.com>"]
 repository = "https://github.com/solana-labs/solana"
@@ -9,11 +9,11 @@ homepage = "https://solana.com/"
 edition = "2018"
 
 [dependencies]
-solana-sdk = { path = "../../sdk", version = "0.15.2"    }
+solana-sdk = { path = "../../sdk", version = "0.15.3"     }
 log = "0.4.2"
 
 [dev-dependencies]
-solana-runtime = { path = "../../runtime", version = "0.15.2"    }
+solana-runtime = { path = "../../runtime", version = "0.15.3"     }
 
 [lib]
 name = "solana_failure_program"

--- a/programs/noop_program/Cargo.toml
+++ b/programs/noop_program/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-noop-program"
-version = "0.15.2"
+version = "0.15.3"
 description = "Solana noop program"
 authors = ["Solana Maintainers <maintainers@solana.com>"]
 repository = "https://github.com/solana-labs/solana"
@@ -9,8 +9,8 @@ homepage = "https://solana.com/"
 edition = "2018"
 
 [dependencies]
-solana-sdk = { path = "../../sdk", version = "0.15.2"    }
-solana-logger = { path = "../../logger", version = "0.15.2"    }
+solana-sdk = { path = "../../sdk", version = "0.15.3"     }
+solana-logger = { path = "../../logger", version = "0.15.3"     }
 log = "0.4.2"
 
 [lib]

--- a/programs/stake_api/Cargo.toml
+++ b/programs/stake_api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-stake-api"
-version = "0.15.2"
+version = "0.15.3"
 description = "Solana Stake program API"
 authors = ["Solana Maintainers <maintainers@solana.com>"]
 repository = "https://github.com/solana-labs/solana"
@@ -13,10 +13,10 @@ bincode = "1.1.4"
 log = "0.4.2"
 serde = "1.0.91"
 serde_derive = "1.0.91"
-solana-logger = { path = "../../logger", version = "0.15.2"    }
-solana-metrics = { path = "../../metrics", version = "0.15.2"    }
-solana-sdk = { path = "../../sdk", version = "0.15.2"    }
-solana-vote-api = { path = "../vote_api", version = "0.15.2"    }
+solana-logger = { path = "../../logger", version = "0.15.3"     }
+solana-metrics = { path = "../../metrics", version = "0.15.3"     }
+solana-sdk = { path = "../../sdk", version = "0.15.3"     }
+solana-vote-api = { path = "../vote_api", version = "0.15.3"     }
 
 [lib]
 name = "solana_stake_api"

--- a/programs/stake_program/Cargo.toml
+++ b/programs/stake_program/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-stake-program"
-version = "0.15.2"
+version = "0.15.3"
 description = "Solana stake program"
 authors = ["Solana Maintainers <maintainers@solana.com>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,9 +10,9 @@ edition = "2018"
 
 [dependencies]
 log = "0.4.2"
-solana-logger = { path = "../../logger", version = "0.15.2"    }
-solana-sdk = { path = "../../sdk", version = "0.15.2"    }
-solana-stake-api = { path = "../stake_api", version = "0.15.2"    }
+solana-logger = { path = "../../logger", version = "0.15.3"     }
+solana-sdk = { path = "../../sdk", version = "0.15.3"     }
+solana-stake-api = { path = "../stake_api", version = "0.15.3"     }
 
 [lib]
 name = "solana_stake_program"

--- a/programs/storage_api/Cargo.toml
+++ b/programs/storage_api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-storage-api"
-version = "0.15.2"
+version = "0.15.3"
 description = "Solana Storage program API"
 authors = ["Solana Maintainers <maintainers@solana.com>"]
 repository = "https://github.com/solana-labs/solana"
@@ -13,12 +13,12 @@ bincode = "1.1.4"
 log = "0.4.2"
 serde = "1.0.91"
 serde_derive = "1.0.91"
-solana-logger = { path = "../../logger", version = "0.15.2"    }
-solana-sdk = { path = "../../sdk", version = "0.15.2"    }
+solana-logger = { path = "../../logger", version = "0.15.3"     }
+solana-sdk = { path = "../../sdk", version = "0.15.3"     }
 assert_matches = "1.3.0"
 
 [dev-dependencies]
-solana-runtime = { path = "../../runtime", version = "0.15.2"    }
+solana-runtime = { path = "../../runtime", version = "0.15.3"     }
 
 [lib]
 name = "solana_storage_api"

--- a/programs/storage_program/Cargo.toml
+++ b/programs/storage_program/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-storage-program"
-version = "0.15.2"
+version = "0.15.3"
 description = "Solana storage program"
 authors = ["Solana Maintainers <maintainers@solana.com>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,9 +10,9 @@ edition = "2018"
 
 [dependencies]
 log = "0.4.2"
-solana-logger = { path = "../../logger", version = "0.15.2"    }
-solana-sdk = { path = "../../sdk", version = "0.15.2"    }
-solana-storage-api = { path = "../storage_api", version = "0.15.2"    }
+solana-logger = { path = "../../logger", version = "0.15.3"     }
+solana-sdk = { path = "../../sdk", version = "0.15.3"     }
+solana-storage-api = { path = "../storage_api", version = "0.15.3"     }
 
 [lib]
 name = "solana_storage_program"

--- a/programs/token_api/Cargo.toml
+++ b/programs/token_api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-token-api"
-version = "0.15.2"
+version = "0.15.3"
 description = "Solana Token API"
 authors = ["Solana Maintainers <maintainers@solana.com>"]
 repository = "https://github.com/solana-labs/solana"
@@ -15,8 +15,8 @@ num-derive = "0.2"
 num-traits = "0.2"
 serde = "1.0.91"
 serde_derive = "1.0.91"
-solana-logger = { path = "../../logger", version = "0.15.2"    }
-solana-sdk = { path = "../../sdk", version = "0.15.2"    }
+solana-logger = { path = "../../logger", version = "0.15.3"     }
+solana-sdk = { path = "../../sdk", version = "0.15.3"     }
 
 [lib]
 name = "solana_token_api"

--- a/programs/token_program/Cargo.toml
+++ b/programs/token_program/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-token-program"
-version = "0.15.2"
+version = "0.15.3"
 description = "Solana token program"
 authors = ["Solana Maintainers <maintainers@solana.com>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,9 +10,9 @@ edition = "2018"
 
 [dependencies]
 log = "0.4.2"
-solana-logger = { path = "../../logger", version = "0.15.2"    }
-solana-sdk = { path = "../../sdk", version = "0.15.2"    }
-solana-token-api = { path = "../token_api", version = "0.15.2"    }
+solana-logger = { path = "../../logger", version = "0.15.3"     }
+solana-sdk = { path = "../../sdk", version = "0.15.3"     }
+solana-token-api = { path = "../token_api", version = "0.15.3"     }
 
 [lib]
 name = "solana_token_program"

--- a/programs/vote_api/Cargo.toml
+++ b/programs/vote_api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-vote-api"
-version = "0.15.2"
+version = "0.15.3"
 description = "Solana Vote program API"
 authors = ["Solana Maintainers <maintainers@solana.com>"]
 repository = "https://github.com/solana-labs/solana"
@@ -13,9 +13,9 @@ bincode = "1.1.4"
 log = "0.4.2"
 serde = "1.0.91"
 serde_derive = "1.0.91"
-solana-logger = { path = "../../logger", version = "0.15.2"    }
-solana-metrics = { path = "../../metrics", version = "0.15.2"    }
-solana-sdk = { path = "../../sdk", version = "0.15.2"    }
+solana-logger = { path = "../../logger", version = "0.15.3"     }
+solana-metrics = { path = "../../metrics", version = "0.15.3"     }
+solana-sdk = { path = "../../sdk", version = "0.15.3"     }
 
 [lib]
 name = "solana_vote_api"

--- a/programs/vote_program/Cargo.toml
+++ b/programs/vote_program/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-vote-program"
-version = "0.15.2"
+version = "0.15.3"
 description = "Solana Vote program"
 authors = ["Solana Maintainers <maintainers@solana.com>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,9 +10,9 @@ edition = "2018"
 
 [dependencies]
 log = "0.4.2"
-solana-logger = { path = "../../logger", version = "0.15.2"    }
-solana-sdk = { path = "../../sdk", version = "0.15.2"    }
-solana-vote-api = { path = "../vote_api", version = "0.15.2"    }
+solana-logger = { path = "../../logger", version = "0.15.3"     }
+solana-sdk = { path = "../../sdk", version = "0.15.3"     }
+solana-vote-api = { path = "../vote_api", version = "0.15.3"     }
 
 [lib]
 name = "solana_vote_program"

--- a/replicator/Cargo.toml
+++ b/replicator/Cargo.toml
@@ -2,17 +2,17 @@
 authors = ["Solana Maintainers <maintainers@solana.com>"]
 edition = "2018"
 name = "solana-replicator"
-version = "0.15.2"
+version = "0.15.3"
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 homepage = "https://solana.com/"
 
 [dependencies]
 clap = "2.33.0"
-solana = { path = "../core", version = "0.15.2"    }
-solana-logger = { path = "../logger", version = "0.15.2"    }
-solana-netutil = { path = "../netutil", version = "0.15.2"    }
-solana-sdk = { path = "../sdk", version = "0.15.2"    }
+solana = { path = "../core", version = "0.15.3"     }
+solana-logger = { path = "../logger", version = "0.15.3"     }
+solana-netutil = { path = "../netutil", version = "0.15.3"     }
+solana-sdk = { path = "../sdk", version = "0.15.3"     }
 
 [features]
 chacha = ["solana/chacha"]

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-runtime"
-version = "0.15.2"
+version = "0.15.3"
 description = "Solana runtime"
 authors = ["Solana Maintainers <maintainers@solana.com>"]
 repository = "https://github.com/solana-labs/solana"
@@ -23,14 +23,14 @@ rayon = "1.0.0"
 serde = "1.0.88"
 serde_derive = "1.0.91"
 serde_json = "1.0.38"
-solana-logger = { path = "../logger", version = "0.15.2"    }
-solana-metrics = { path = "../metrics", version = "0.15.2"    }
-solana-sdk = { path = "../sdk", version = "0.15.2"    }
-solana-stake-api = { path = "../programs/stake_api", version = "0.15.2"    }
-solana-vote-api = { path = "../programs/vote_api", version = "0.15.2"    }
-solana-vote-program = { path = "../programs/vote_program", version = "0.15.2"    }
-solana-stake-program = { path = "../programs/stake_program", version = "0.15.2"    }
-solana-noop-program = { path = "../programs/noop_program", version = "0.15.2"    }
+solana-logger = { path = "../logger", version = "0.15.3"     }
+solana-metrics = { path = "../metrics", version = "0.15.3"     }
+solana-sdk = { path = "../sdk", version = "0.15.3"     }
+solana-stake-api = { path = "../programs/stake_api", version = "0.15.3"     }
+solana-vote-api = { path = "../programs/vote_api", version = "0.15.3"     }
+solana-vote-program = { path = "../programs/vote_program", version = "0.15.3"     }
+solana-stake-program = { path = "../programs/stake_program", version = "0.15.3"     }
+solana-noop-program = { path = "../programs/noop_program", version = "0.15.3"     }
 
 [lib]
 name = "solana_runtime"

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-sdk"
-version = "0.15.2"
+version = "0.15.3"
 description = "Solana SDK"
 authors = ["Solana Maintainers <maintainers@solana.com>"]
 repository = "https://github.com/solana-labs/solana"

--- a/sdk/bpf/rust-utils/Cargo.toml
+++ b/sdk/bpf/rust-utils/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "solana-sdk-bpf-utils"
-version = "0.15.2"
+version = "0.15.3"
 description = "Solana BPF SDK Rust Utils"
 authors = ["Solana Maintainers <maintainers@solana.com>"]
 repository = "https://github.com/solana-labs/solana"

--- a/upload-perf/Cargo.toml
+++ b/upload-perf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-upload-perf"
-version = "0.15.2"
+version = "0.15.3"
 description = "Metrics Upload Utility"
 authors = ["Solana Maintainers <maintainers@solana.com>"]
 repository = "https://github.com/solana-labs/solana"
@@ -12,7 +12,7 @@ publish = false
 [dependencies]
 log = "0.4.2"
 serde_json = "1.0.39"
-solana-metrics = { path = "../metrics", version = "0.15.2"    }
+solana-metrics = { path = "../metrics", version = "0.15.3"     }
 
 [[bin]]
 name = "solana-upload-perf"

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Solana Maintainers <maintainers@solana.com>"]
 edition = "2018"
 name = "solana-validator"
 description = "Blockchain, Rebuilt for Scale"
-version = "0.15.2"
+version = "0.15.3"
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 homepage = "https://solana.com/"
@@ -12,15 +12,15 @@ homepage = "https://solana.com/"
 clap = "2.33.0"
 log = "0.4.2"
 serde_json = "1.0.39"
-solana = { path = "../core", version = "0.15.2"    }
-solana-drone = { path = "../drone", version = "0.15.2"    }
-solana-logger = { path = "../logger", version = "0.15.2"    }
-solana-netutil = { path = "../netutil", version = "0.15.2"    }
-solana-metrics = { path = "../metrics", version = "0.15.2"    }
-solana-runtime = { path = "../runtime", version = "0.15.2"    }
-solana-sdk = { path = "../sdk", version = "0.15.2"    }
-solana-vote-api = { path = "../programs/vote_api", version = "0.15.2"    }
-solana-vote-signer = { path = "../vote-signer", version = "0.15.2"    }
+solana = { path = "../core", version = "0.15.3"     }
+solana-drone = { path = "../drone", version = "0.15.3"     }
+solana-logger = { path = "../logger", version = "0.15.3"     }
+solana-netutil = { path = "../netutil", version = "0.15.3"     }
+solana-metrics = { path = "../metrics", version = "0.15.3"     }
+solana-runtime = { path = "../runtime", version = "0.15.3"     }
+solana-sdk = { path = "../sdk", version = "0.15.3"     }
+solana-vote-api = { path = "../programs/vote_api", version = "0.15.3"     }
+solana-vote-signer = { path = "../vote-signer", version = "0.15.3"     }
 
 [features]
 chacha = ["solana/chacha"]

--- a/vote-signer/Cargo.toml
+++ b/vote-signer/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Solana Maintainers <maintainers@solana.com>"]
 edition = "2018"
 name = "solana-vote-signer"
 description = "Solana Vote Signing Service"
-version = "0.15.2"
+version = "0.15.3"
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 homepage = "https://solana.com/"
@@ -17,8 +17,8 @@ jsonrpc-derive = "11.0.0"
 jsonrpc-http-server = "11.0.0"
 serde = "1.0.91"
 serde_json = "1.0.39"
-solana-sdk = { path = "../sdk", version = "0.15.2"    }
-solana-metrics = { path = "../metrics", version = "0.15.2"    }
+solana-sdk = { path = "../sdk", version = "0.15.3"     }
+solana-metrics = { path = "../metrics", version = "0.15.3"     }
 
 [lib]
 name = "solana_vote_signer"

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Solana Maintainers <maintainers@solana.com>"]
 edition = "2018"
 name = "solana-wallet"
 description = "Blockchain, Rebuilt for Scale"
-version = "0.15.2"
+version = "0.15.3"
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 homepage = "https://solana.com/"
@@ -17,21 +17,21 @@ dirs = "1.0.5"
 log = "0.4.2"
 num-traits = "0.2"
 serde_json = "1.0.39"
-solana-budget-api = { path = "../programs/budget_api", version = "0.15.2"    }
-solana-client = { path = "../client", version = "0.15.2"    }
-solana-drone = { path = "../drone", version = "0.15.2"    }
-solana-logger = { path = "../logger", version = "0.15.2"    }
-solana-netutil = { path = "../netutil", version = "0.15.2"    }
-solana-sdk = { path = "../sdk", version = "0.15.2"    }
-solana-stake-api = { path = "../programs/stake_api", version = "0.15.2"    }
-solana-storage-api = { path = "../programs/storage_api", version = "0.15.2"    }
-solana-vote-api = { path = "../programs/vote_api", version = "0.15.2"    }
-solana-vote-signer = { path = "../vote-signer", version = "0.15.2"    }
+solana-budget-api = { path = "../programs/budget_api", version = "0.15.3"     }
+solana-client = { path = "../client", version = "0.15.3"     }
+solana-drone = { path = "../drone", version = "0.15.3"     }
+solana-logger = { path = "../logger", version = "0.15.3"     }
+solana-netutil = { path = "../netutil", version = "0.15.3"     }
+solana-sdk = { path = "../sdk", version = "0.15.3"     }
+solana-stake-api = { path = "../programs/stake_api", version = "0.15.3"     }
+solana-storage-api = { path = "../programs/storage_api", version = "0.15.3"     }
+solana-vote-api = { path = "../programs/vote_api", version = "0.15.3"     }
+solana-vote-signer = { path = "../vote-signer", version = "0.15.3"     }
 url = "1.7.2"
 
 [dev-dependencies]
-solana-budget-program = { path = "../programs/budget_program", version = "0.15.2"    }
-solana = { path = "../core", version = "0.15.2"    }
+solana-budget-program = { path = "../programs/budget_program", version = "0.15.3"     }
+solana = { path = "../core", version = "0.15.3"     }
 
 [features]
 cuda = []


### PR DESCRIPTION
Update cargo.toml, cargo.lock and testnet-participation.md following the release of v0.15.2 tag.
