### PR TITLE
v0.15: Upgrade to rust stable 1.35.0 (#4568)

### DIFF
--- a/ci/docker-rust/Dockerfile
+++ b/ci/docker-rust/Dockerfile
@@ -1,6 +1,6 @@
 # Note: when the rust version is changed also modify
-# ci/buildkite.yml to pick up the new image tag
-FROM rust:1.34.0
+# ci/rust-version.sh to pick up the new image tag
+FROM rust:1.35.0
 
 RUN set -x \
  && apt update \

--- a/ci/docker-rust/README.md
+++ b/ci/docker-rust/README.md
@@ -1,6 +1,7 @@
 Docker image containing rust and some preinstalled packages used in CI.
 
-This image may be manually updated by running `./build.sh` if you are a member
-of the [Solana Labs](https://hub.docker.com/u/solanalabs/) Docker Hub
-organization, but it is also automatically updated periodically by
-[this automation](https://buildkite.com/solana-labs/solana-ci-docker-rust).
+This image manually maintained:
+1. Edit `Dockerfile` to match the desired rust version
+2. Run `./build.sh` to publish the new image, if you are a member of the [Solana
+   Labs](https://hub.docker.com/u/solanalabs/) Docker Hub organization.
+

--- a/ci/rust-version.sh
+++ b/ci/rust-version.sh
@@ -13,8 +13,8 @@
 #   $ source ci/rust-version.sh
 #
 
-export rust_stable=1.34.0
-export rust_stable_docker_image=solanalabs/rust:1.34.0
+export rust_stable=1.35.0
+export rust_stable_docker_image=solanalabs/rust:1.35.0
 
 export rust_nightly=nightly-2019-05-01
 export rust_nightly_docker_image=solanalabs/rust-nightly:2019-05-01


### PR DESCRIPTION
Upgrading v0.15 to new rust as well to prevent the CI cargo cache from churning thrashing between rust 1.34 and 1.35