### PR TITLE
add solana_name_id, reassociate names with modules, modularize id tests

### DIFF
--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -275,57 +275,6 @@ mod tests {
     use hashbrown::HashSet;
 
     #[test]
-    fn test_program_ids() {
-        let ids = [
-            (
-                "11111111111111111111111111111111",
-                solana_sdk::system_program::id(),
-            ),
-            (
-                "NativeLoader1111111111111111111111111111111",
-                solana_sdk::native_loader::id(),
-            ),
-            (
-                "BPFLoader1111111111111111111111111111111111",
-                solana_sdk::bpf_loader::id(),
-            ),
-            (
-                "Budget1111111111111111111111111111111111111",
-                solana_budget_api::id(),
-            ),
-            (
-                "Stake11111111111111111111111111111111111111",
-                solana_stake_api::id(),
-            ),
-            (
-                "Storage111111111111111111111111111111111111",
-                solana_storage_api::id(),
-            ),
-            (
-                "Token11111111111111111111111111111111111111",
-                solana_token_api::id(),
-            ),
-            (
-                "Vote111111111111111111111111111111111111111",
-                solana_vote_api::id(),
-            ),
-            (
-                "Stake11111111111111111111111111111111111111",
-                solana_stake_api::id(),
-            ),
-            (
-                "Config1111111111111111111111111111111111111",
-                solana_config_api::id(),
-            ),
-            (
-                "Exchange11111111111111111111111111111111111",
-                solana_exchange_api::id(),
-            ),
-        ];
-        assert!(ids.iter().all(|(name, id)| *name == id.to_string()));
-    }
-
-    #[test]
     fn test_program_id_uniqueness() {
         let mut unique = HashSet::new();
         let ids = vec![

--- a/programs/budget_api/src/lib.rs
+++ b/programs/budget_api/src/lib.rs
@@ -8,4 +8,7 @@ const BUDGET_PROGRAM_ID: [u8; 32] = [
     198, 115, 123, 98, 188, 19, 160, 0, 0, 0, 0,
 ];
 
-solana_sdk::solana_program_id!(BUDGET_PROGRAM_ID);
+solana_sdk::solana_name_id!(
+    BUDGET_PROGRAM_ID,
+    "Budget1111111111111111111111111111111111111"
+);

--- a/programs/config_api/src/lib.rs
+++ b/programs/config_api/src/lib.rs
@@ -8,7 +8,10 @@ const CONFIG_PROGRAM_ID: [u8; 32] = [
     64, 25, 163, 35, 239, 160, 0, 0, 0, 0,
 ];
 
-solana_sdk::solana_program_id!(CONFIG_PROGRAM_ID);
+solana_sdk::solana_name_id!(
+    CONFIG_PROGRAM_ID,
+    "Config1111111111111111111111111111111111111"
+);
 
 pub trait ConfigState: Serialize {
     /// Maximum space that the serialized representation will require

--- a/programs/exchange_api/src/exchange_processor.rs
+++ b/programs/exchange_api/src/exchange_processor.rs
@@ -2,7 +2,7 @@
 
 use crate::exchange_instruction::*;
 use crate::exchange_state::*;
-use crate::faucet_id;
+use crate::faucet;
 use log::*;
 use solana_metrics::inc_new_counter_info;
 use solana_sdk::account::KeyedAccount;
@@ -192,7 +192,7 @@ impl ExchangeProcessor {
         let mut to_account =
             Self::deserialize_account(&keyed_accounts[TO_ACCOUNT_INDEX].account.data)?;
 
-        if &faucet_id() == keyed_accounts[FROM_ACCOUNT_INDEX].unsigned_key() {
+        if &faucet::id() == keyed_accounts[FROM_ACCOUNT_INDEX].unsigned_key() {
             to_account.tokens[token] += tokens;
         } else {
             let state: ExchangeState =
@@ -590,7 +590,7 @@ mod test {
         let instruction = exchange_instruction::transfer_request(
             &owner.pubkey(),
             to,
-            &faucet_id(),
+            &faucet::id(),
             token,
             tokens,
         );
@@ -671,7 +671,7 @@ mod test {
         let instruction = exchange_instruction::transfer_request(
             &owner.pubkey(),
             &new,
-            &faucet_id(),
+            &faucet::id(),
             Token::A,
             42,
         );

--- a/programs/exchange_api/src/lib.rs
+++ b/programs/exchange_api/src/lib.rs
@@ -10,23 +10,20 @@ pub const EXCHANGE_PROGRAM_ID: [u8; 32] = [
     33, 70, 185, 192, 42, 31, 141, 152, 0, 0, 0, 0,
 ];
 
-solana_sdk::solana_program_id!(EXCHANGE_PROGRAM_ID);
+solana_sdk::solana_name_id!(
+    EXCHANGE_PROGRAM_ID,
+    "Exchange11111111111111111111111111111111111"
+);
 
-pub const EXCHANGE_FAUCET_ID: [u8; 32] = [
-    3, 147, 111, 103, 210, 47, 23, 11, 176, 29, 147, 89, 237, 155, 21, 62, 107, 105, 157, 1, 98,
-    204, 206, 211, 54, 212, 79, 15, 160, 0, 0, 0,
-];
+pub mod faucet {
+    pub const EXCHANGE_FAUCET_ID: [u8; 32] = [
+        3, 147, 111, 103, 210, 47, 23, 11, 176, 29, 147, 89, 237, 155, 21, 62, 107, 105, 157, 1,
+        98, 204, 206, 211, 54, 212, 79, 15, 160, 0, 0, 0,
+    ];
 
-pub fn faucet_id() -> solana_sdk::pubkey::Pubkey {
-    solana_sdk::pubkey::Pubkey::new(&EXCHANGE_FAUCET_ID)
-}
+    solana_sdk::solana_name_id!(
+        EXCHANGE_FAUCET_ID,
+        "ExchangeFaucet11111111111111111111111111111"
+    );
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    #[test]
-    fn exchange_faucet_id() {
-        let ids = [("ExchangeFaucet11111111111111111111111111111", faucet_id())];
-        assert!(ids.iter().all(|(name, id)| *name == id.to_string()));
-    }
 }

--- a/programs/stake_api/src/lib.rs
+++ b/programs/stake_api/src/lib.rs
@@ -6,4 +6,7 @@ const STAKE_PROGRAM_ID: [u8; 32] = [
     120, 114, 43, 104, 164, 157, 192, 0, 0, 0, 0,
 ];
 
-solana_sdk::solana_program_id!(STAKE_PROGRAM_ID);
+solana_sdk::solana_name_id!(
+    STAKE_PROGRAM_ID,
+    "Stake11111111111111111111111111111111111111"
+);

--- a/programs/storage_api/src/lib.rs
+++ b/programs/storage_api/src/lib.rs
@@ -12,4 +12,7 @@ const STORAGE_PROGRAM_ID: [u8; 32] = [
     6, 162, 25, 123, 127, 68, 233, 59, 131, 151, 21, 152, 162, 120, 90, 37, 154, 88, 86, 5, 156,
     221, 182, 201, 142, 103, 151, 112, 0, 0, 0, 0,
 ];
-solana_sdk::solana_program_id!(STORAGE_PROGRAM_ID);
+solana_sdk::solana_name_id!(
+    STORAGE_PROGRAM_ID,
+    "Storage111111111111111111111111111111111111"
+);

--- a/programs/vote_api/src/lib.rs
+++ b/programs/vote_api/src/lib.rs
@@ -6,4 +6,7 @@ const VOTE_PROGRAM_ID: [u8; 32] = [
     16, 67, 252, 13, 163, 83, 128, 0, 0, 0, 0,
 ];
 
-solana_sdk::solana_program_id!(VOTE_PROGRAM_ID);
+solana_sdk::solana_name_id!(
+    VOTE_PROGRAM_ID,
+    "Vote111111111111111111111111111111111111111"
+);

--- a/sdk/src/bpf_loader.rs
+++ b/sdk/src/bpf_loader.rs
@@ -1,10 +1,6 @@
-use crate::pubkey::Pubkey;
-
-const BPF_LOADER_PROGRAM_ID: [u8; 32] = [
+const ID: [u8; 32] = [
     2, 168, 246, 145, 78, 136, 161, 107, 189, 35, 149, 133, 95, 100, 4, 217, 180, 244, 86, 183,
     130, 27, 176, 20, 87, 73, 66, 140, 0, 0, 0, 0,
 ];
 
-pub fn id() -> Pubkey {
-    Pubkey::new(&BPF_LOADER_PROGRAM_ID)
-}
+crate::solana_name_id!(ID, "BPFLoader1111111111111111111111111111111111");

--- a/sdk/src/instruction_processor_utils.rs
+++ b/sdk/src/instruction_processor_utils.rs
@@ -20,31 +20,11 @@ macro_rules! solana_entrypoint(
     ($entrypoint:ident) => (
         #[no_mangle]
         pub extern "C" fn process(
-            program_id: &solana_sdk::pubkey::Pubkey,
-            keyed_accounts: &mut [solana_sdk::account::KeyedAccount],
+            program_id: &$crate::pubkey::Pubkey,
+            keyed_accounts: &mut [$crate::account::KeyedAccount],
             data: &[u8],
-        ) -> Result<(), solana_sdk::instruction::InstructionError> {
+        ) -> Result<(), $crate::instruction::InstructionError> {
             $entrypoint(program_id, keyed_accounts, data)
-        }
-    )
-);
-
-#[macro_export]
-macro_rules! solana_program_id(
-    ($program_id:ident) => (
-
-        pub fn check_id(program_id: &solana_sdk::pubkey::Pubkey) -> bool {
-            program_id.as_ref() == $program_id
-        }
-
-        pub fn id() -> solana_sdk::pubkey::Pubkey {
-            solana_sdk::pubkey::Pubkey::new(&$program_id)
-        }
-
-        #[cfg(test)]
-        #[test]
-        fn test_program_id() {
-            assert!(check_id(&id()));
         }
     )
 );

--- a/sdk/src/native_loader.rs
+++ b/sdk/src/native_loader.rs
@@ -1,18 +1,11 @@
 use crate::account::Account;
-use crate::pubkey::Pubkey;
 
-const NATIVE_LOADER_PROGRAM_ID: [u8; 32] = [
+const ID: [u8; 32] = [
     5, 135, 132, 191, 20, 139, 164, 40, 47, 176, 18, 87, 72, 136, 169, 241, 83, 160, 125, 173, 247,
     101, 192, 69, 92, 154, 151, 3, 128, 0, 0, 0,
 ];
 
-pub fn id() -> Pubkey {
-    Pubkey::new(&NATIVE_LOADER_PROGRAM_ID)
-}
-
-pub fn check_id(program_id: &Pubkey) -> bool {
-    program_id.as_ref() == NATIVE_LOADER_PROGRAM_ID
-}
+crate::solana_name_id!(ID, "NativeLoader1111111111111111111111111111111");
 
 /// Create an executable account with the given shared object name.
 pub fn create_loadable_account(name: &str) -> Account {

--- a/sdk/src/pubkey.rs
+++ b/sdk/src/pubkey.rs
@@ -88,6 +88,41 @@ pub fn read_pubkey(infile: &str) -> Result<Pubkey, Box<error::Error>> {
     Ok(Pubkey::from_str(&printable)?)
 }
 
+#[macro_export]
+macro_rules! solana_id(
+    ($id:ident) => (
+
+        pub fn check_id(id: &$crate::pubkey::Pubkey) -> bool {
+            id.as_ref() == $id
+        }
+
+        pub fn id() -> $crate::pubkey::Pubkey {
+            $crate::pubkey::Pubkey::new(&$id)
+        }
+
+        #[cfg(test)]
+        #[test]
+        fn test_id() {
+            assert!(check_id(&id()));
+        }
+
+    )
+);
+
+#[macro_export]
+macro_rules! solana_name_id(
+    ($id:ident, $name:expr) => (
+
+        $crate::solana_id!($id);
+
+        #[cfg(test)]
+        #[test]
+        fn test_name_id() {
+            assert_eq!(id().to_string(), $name);
+        }
+    )
+);
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/sdk/src/syscall/current.rs
+++ b/sdk/src/syscall/current.rs
@@ -1,0 +1,50 @@
+//! This account contains the current slot, epoch, and stakers_epoch
+//!
+use crate::account::Account;
+use crate::syscall;
+use bincode::serialized_size;
+
+crate::solana_name_id!(ID, "Sysca11Current11111111111111111111111111111");
+
+const ID: [u8; 32] = [
+    6, 167, 211, 138, 69, 218, 14, 184, 34, 50, 188, 33, 201, 49, 63, 13, 15, 193, 33, 132, 208,
+    238, 129, 224, 101, 67, 14, 11, 160, 0, 0, 0,
+];
+
+#[repr(C)]
+#[derive(Serialize, Deserialize, Debug, Default, PartialEq)]
+pub struct Current {
+    slot: u64,
+    block: u64,
+    epoch: u64,
+    stakers_epoch: u64,
+}
+
+impl Current {
+    pub fn from(account: &Account) -> Option<Self> {
+        account.deserialize_data().ok()
+    }
+    pub fn to(&self, account: &mut Account) -> Option<()> {
+        account.serialize_data(self).ok()
+    }
+
+    pub fn size_of() -> usize {
+        serialized_size(&Self::default()).unwrap() as usize
+    }
+}
+
+pub fn create_account(lamports: u64) -> Account {
+    Account::new(lamports, Current::size_of(), &syscall::id())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_create_account() {
+        let account = create_account(1);
+        let current = Current::from(&account).unwrap();
+        assert_eq!(current, Current::default());
+    }
+}

--- a/sdk/src/syscall/fees.rs
+++ b/sdk/src/syscall/fees.rs
@@ -3,24 +3,16 @@
 use crate::account::Account;
 use crate::account_utils::State;
 use crate::fee_calculator::FeeCalculator;
-use crate::pubkey::Pubkey;
 use crate::syscall;
 use bincode::serialized_size;
 
-/// "Sysca11Fees11111111111111111111111111"
 ///  fees account pubkey
 const ID: [u8; 32] = [
     6, 167, 211, 138, 69, 218, 104, 33, 3, 92, 89, 173, 16, 89, 109, 253, 49, 97, 98, 165, 87, 222,
     119, 112, 253, 90, 76, 184, 0, 0, 0, 0,
 ];
 
-pub fn id() -> Pubkey {
-    Pubkey::new(&ID)
-}
-
-pub fn check_id(pubkey: &Pubkey) -> bool {
-    pubkey.as_ref() == ID
-}
+crate::solana_name_id!(ID, "Sysca11Fees11111111111111111111111111111111");
 
 #[repr(C)]
 #[derive(Serialize, Deserialize, Debug, Default)]
@@ -48,15 +40,6 @@ pub fn create_account(lamports: u64) -> Account {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_fees_id() {
-        let name = "Sysca11Fees11111111111111111111111111111111";
-        // To get the bytes above:
-        // dbg!((name, bs58::decode(name).into_vec().unwrap()));
-        assert_eq!(name, id().to_string());
-        assert!(check_id(&id()));
-    }
 
     #[test]
     fn test_fees_create_account() {

--- a/sdk/src/syscall/mod.rs
+++ b/sdk/src/syscall/mod.rs
@@ -2,9 +2,17 @@
 //!
 use crate::pubkey::Pubkey;
 
+pub mod current;
 pub mod fees;
 pub mod slot_hashes;
 pub mod tick_height;
+
+pub fn is_syscall_id(id: &Pubkey) -> bool {
+    current::check_id(id)
+        || fees::check_id(id)
+        || slot_hashes::check_id(id)
+        || tick_height::check_id(id)
+}
 
 /// "Sysca11111111111111111111111111111111111111"
 ///   owner pubkey for syscall accounts
@@ -13,25 +21,4 @@ const ID: [u8; 32] = [
     253, 202, 87, 144, 232, 16, 195, 192, 0, 0, 0, 0,
 ];
 
-pub fn id() -> Pubkey {
-    Pubkey::new(&ID)
-}
-
-pub fn check_id(id: &Pubkey) -> bool {
-    id.as_ref() == ID
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    #[test]
-    fn test_syscall_ids() {
-        let ids = [("Sysca11111111111111111111111111111111111111", id())];
-        // to get the bytes above:
-        //        ids.iter().for_each(|(name, _)| {
-        //            dbg!((name, bs58::decode(name).into_vec().unwrap()));
-        //        });
-        assert!(ids.iter().all(|(name, id)| *name == id.to_string()));
-        assert!(check_id(&id()));
-    }
-}
+crate::solana_name_id!(ID, "Sysca11111111111111111111111111111111111111");

--- a/sdk/src/syscall/slot_hashes.rs
+++ b/sdk/src/syscall/slot_hashes.rs
@@ -70,17 +70,6 @@ mod tests {
     use crate::hash::hash;
 
     #[test]
-    fn test_id() {
-        let ids = [("Sysca11S1otHashes11111111111111111111111111", id())];
-        // to get the bytes above:
-        //        ids.iter().for_each(|(name, _)| {
-        //            dbg!((name, bs58::decode(name).into_vec().unwrap()));
-        //        });
-        assert!(ids.iter().all(|(name, id)| *name == id.to_string()));
-        assert!(check_id(&id()));
-    }
-
-    #[test]
     fn test_create_account() {
         let lamports = 42;
         let account = create_account(lamports);

--- a/sdk/src/syscall/tick_height.rs
+++ b/sdk/src/syscall/tick_height.rs
@@ -2,7 +2,6 @@
 //!
 use crate::account::Account;
 use crate::account_utils::State;
-use crate::pubkey::Pubkey;
 use crate::syscall;
 use bincode::serialized_size;
 
@@ -13,13 +12,7 @@ const ID: [u8; 32] = [
     208, 229, 34, 163, 11, 168, 45, 109, 60, 0, 0, 0,
 ];
 
-pub fn id() -> Pubkey {
-    Pubkey::new(&ID)
-}
-
-pub fn check_id(pubkey: &Pubkey) -> bool {
-    pubkey.as_ref() == ID
-}
+crate::solana_name_id!(ID, "Sysca11TickHeight11111111111111111111111111");
 
 #[repr(C)]
 #[derive(Serialize, Deserialize, Debug, Default)]
@@ -45,15 +38,6 @@ pub fn create_account(lamports: u64) -> Account {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_tick_height_id() {
-        let name = "Sysca11TickHeight11111111111111111111111111";
-        // To get the bytes above:
-        // dbg!((name, bs58::decode(name).into_vec().unwrap()));
-        assert_eq!(name, id().to_string());
-        assert!(check_id(&id()));
-    }
 
     #[test]
     fn test_tick_height_create_account() {

--- a/sdk/src/system_instruction.rs
+++ b/sdk/src/system_instruction.rs
@@ -9,6 +9,8 @@ pub enum SystemError {
     AccountAlreadyInUse,
     ResultWithNegativeLamports,
     SourceNotSystemAccount,
+    InvalidProgramId,
+    InvalidAccountId,
 }
 
 impl<T> DecodeError<T> for SystemError {

--- a/sdk/src/system_program.rs
+++ b/sdk/src/system_program.rs
@@ -1,13 +1,5 @@
-use crate::pubkey::Pubkey;
-
-const SYSTEM_PROGRAM_ID: [u8; 32] = [
+const ID: [u8; 32] = [
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 ];
 
-pub fn id() -> Pubkey {
-    Pubkey::new(&SYSTEM_PROGRAM_ID)
-}
-
-pub fn check_id(program_id: &Pubkey) -> bool {
-    program_id.as_ref() == SYSTEM_PROGRAM_ID
-}
+crate::solana_name_id!(ID, "11111111111111111111111111111111");


### PR DESCRIPTION
#### Problem
 syscall ids shouldn't be create-able outside the system
 lots of name-based ids that have lost their strings and their tests

 #### Summary of Changes
 prevent creation of syscall owned or syscall-id'd accounts
 re-associate strings with ids, modularize tests

Fixes #