### PR TITLE
add syscall::current to sdk

### DIFF
--- a/runtime/src/epoch_schedule.rs
+++ b/runtime/src/epoch_schedule.rs
@@ -62,6 +62,11 @@ impl EpochSchedule {
         }
     }
 
+    /// get epoch for the given slot
+    pub fn get_epoch(&self, slot: u64) -> u64 {
+        self.get_epoch_and_slot_index(slot).0
+    }
+
     /// get epoch and offset into the epoch for the given slot
     pub fn get_epoch_and_slot_index(&self, slot: u64) -> (u64, u64) {
         if slot < self.first_normal_slot {

--- a/sdk/src/syscall/current.rs
+++ b/sdk/src/syscall/current.rs
@@ -14,10 +14,9 @@ const ID: [u8; 32] = [
 #[repr(C)]
 #[derive(Serialize, Deserialize, Debug, Default, PartialEq)]
 pub struct Current {
-    slot: u64,
-    block: u64,
-    epoch: u64,
-    stakers_epoch: u64,
+    pub slot: u64,
+    pub epoch: u64,
+    pub stakers_epoch: u64,
 }
 
 impl Current {


### PR DESCRIPTION
#### Problem
 need current.slot and current.epoch in programs

 #### Summary of Changes
 add support for `current` to bank