### PR TITLE
Limit short_vec length to u16, usize is overkill for our usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2645,6 +2645,7 @@ dependencies = [
 name = "solana-sdk"
 version = "0.16.0"
 dependencies = [
+ "assert_matches 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "bs58 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -9,6 +9,7 @@ license = "Apache-2.0"
 edition = "2018"
 
 [dependencies]
+assert_matches = "1.3.0"
 bincode = "1.1.4"
 bs58 = "0.2.0"
 byteorder = "1.2.1"


### PR DESCRIPTION
Work around the data validation error at #4586 by restricting short_vec length to u16.

Fixes #4586
