### PR TITLE
v0.15: Limit short_vec length to u16, usize is overkill for our usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2630,6 +2630,7 @@ dependencies = [
 name = "solana-sdk"
 version = "0.15.3"
 dependencies = [
+ "assert_matches 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "bs58 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/core/src/replicator.rs
+++ b/core/src/replicator.rs
@@ -381,7 +381,7 @@ impl Replicator {
         #[cfg(feature = "chacha")]
         {
             use crate::storage_stage::NUM_STORAGE_SAMPLES;
-            use rand::{Rng, SeedableRng};
+            use rand::SeedableRng;
             use rand_chacha::ChaChaRng;
 
             let mut rng_seed = [0u8; 32];

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -9,6 +9,7 @@ license = "Apache-2.0"
 edition = "2018"
 
 [dependencies]
+assert_matches = "1.3.0"
 bincode = "1.1.4"
 bs58 = "0.2.0"
 hex = "0.3.2"


### PR DESCRIPTION
#4588 for v0.15