### PR TITLE
Add |wallet fees| subcommand for easy viewing of the current cluster fees

### DIFF
--- a/book/src/wallet.md
+++ b/book/src/wallet.md
@@ -285,6 +285,18 @@ ARGS:
 ```
 
 ```manpage
+solana-wallet-fees
+Display current cluster fees
+
+USAGE:
+    solana-wallet fees
+
+FLAGS:
+    -h, --help       Prints help information
+    -V, --version    Prints version information
+```
+
+```manpage
 solana-wallet-get-transaction-count
 Get current transaction count
 

--- a/wallet/wallet-help.sh
+++ b/wallet/wallet-help.sh
@@ -11,7 +11,7 @@ solana-wallet --help
 echo "\`\`\`"
 echo ""
 
-commands=(address airdrop balance cancel confirm deploy get-transaction-count pay send-signature send-timestamp)
+commands=(address airdrop balance cancel confirm deploy fees get-transaction-count pay send-signature send-timestamp)
 
 for x in "${commands[@]}"; do
     echo "\`\`\`manpage"


### PR DESCRIPTION
Example:
```bash
$ solana-wallet --url http://edge.testnet.solana.com:8899 fees
blockhash: GxumqaKcY3PTvjBL5BXtET8MmiNbacoKGtH148TGpd9u
lamports per signature: 1
```
