### PR TITLE
Broadcast blobs even if the peers have no stake

### DIFF
--- a/core/src/broadcast_stage.rs
+++ b/core/src/broadcast_stage.rs
@@ -127,23 +127,19 @@ impl Broadcast {
         let bank_epoch = bank.get_stakers_epoch(bank.slot());
         let stakes = staking_utils::staked_nodes_at_epoch(&bank, bank_epoch);
 
-        if let Some(nodes) = stakes.as_ref() {
-            if nodes.len() > 1 {
-                // Send out data
-                cluster_info
-                    .read()
-                    .unwrap()
-                    .broadcast(sock, &blobs, stakes.as_ref())?;
+        // Send out data
+        cluster_info
+            .read()
+            .unwrap()
+            .broadcast(sock, &blobs, stakes.as_ref())?;
 
-                inc_new_counter_debug!("streamer-broadcast-sent", blobs.len());
+        inc_new_counter_debug!("streamer-broadcast-sent", blobs.len());
 
-                // send out erasures
-                cluster_info
-                    .read()
-                    .unwrap()
-                    .broadcast(sock, &coding, stakes.as_ref())?;
-            }
-        }
+        // send out erasures
+        cluster_info
+            .read()
+            .unwrap()
+            .broadcast(sock, &coding, stakes.as_ref())?;
 
         self.update_broadcast_stats(
             duration_as_ms(&broadcast_start.elapsed()),


### PR DESCRIPTION
#### Problem
The blobs are not being broadcasted if peers have no stake. This is typically true during warmup epoch.

#### Summary of Changes
Remove the check for nodes with stake in broadcast stage.
