### PR TITLE
solana-keygen no longer blindly overwrites a keypair, or assumes "new"

### DIFF
--- a/book/src/installer.md
+++ b/book/src/installer.md
@@ -49,7 +49,7 @@ $ cargo run -- --help
 Given a solana release tarball (as created by `ci/publish-tarball.sh`) that has already been uploaded to a publicly accessible URL,
 the following commands will deploy the update:
 ```bash
-$ solana-keygen -o update-manifest.json  # <-- only generated once, the public key is shared with users
+$ solana-keygen new -o update-manifest.json  # <-- only generated once, the public key is shared with users
 $ solana-install deploy http://example.com/path/to/solana-release.tar.bz2 update-manifest.json
 ```
 

--- a/book/src/testnet-participation.md
+++ b/book/src/testnet-participation.md
@@ -131,7 +131,7 @@ $ solana-gossip --entrypoint testnet.solana.com:8001 spy
 
 Now configure a key pair for your validator by running:
 ```bash
-$ solana-keygen -o ~/validator-keypair.json
+$ solana-keygen new -o ~/validator-keypair.json
 $ solana-keygen pubkey ~/validator-keypair.json
 ```
 

--- a/ci/localnet-sanity.sh
+++ b/ci/localnet-sanity.sh
@@ -307,7 +307,7 @@ while [[ $iteration -le $iterations ]]; do
     source multinode-demo/common.sh
     set -x
     client_keypair=/tmp/client-id.json-$$
-    $solana_keygen -o $client_keypair || exit $?
+    $solana_keygen new -o $client_keypair || exit $?
     $solana_gossip spy --num-nodes-exactly $numNodes || exit $?
     rm -rf $client_keypair
   ) || flag_error

--- a/keygen/src/keygen.rs
+++ b/keygen/src/keygen.rs
@@ -1,23 +1,29 @@
-use clap::{crate_description, crate_name, crate_version, App, Arg, SubCommand};
+use clap::{
+    crate_description, crate_name, crate_version, App, AppSettings, Arg, ArgMatches, SubCommand,
+};
 use solana_sdk::pubkey::write_pubkey;
 use solana_sdk::signature::{gen_keypair_file, read_keypair, KeypairUtil};
 use std::error;
+use std::path::Path;
+use std::process::exit;
+
+fn check_for_overwrite(outfile: &str, matches: &ArgMatches) {
+    let force = matches.is_present("force");
+    if !force && Path::new(outfile).exists() {
+        eprintln!("Refusing to overwrite {} without --force flag", outfile);
+        exit(1);
+    }
+}
 
 fn main() -> Result<(), Box<dyn error::Error>> {
     let matches = App::new(crate_name!())
         .about(crate_description!())
         .version(crate_version!())
-        .arg(
-            Arg::with_name("outfile")
-                .short("o")
-                .long("outfile")
-                .value_name("PATH")
-                .takes_value(true)
-                .help("Path to generated file"),
-        )
+        .setting(AppSettings::SubcommandRequiredElseHelp)
         .subcommand(
             SubCommand::with_name("new")
                 .about("Generate new keypair file")
+                .setting(AppSettings::DisableVersion)
                 .arg(
                     Arg::with_name("outfile")
                         .short("o")
@@ -25,11 +31,18 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                         .value_name("PATH")
                         .takes_value(true)
                         .help("Path to generated file"),
+                )
+                .arg(
+                    Arg::with_name("force")
+                        .short("f")
+                        .long("force")
+                        .help("Overwrite the output file if it exists"),
                 ),
         )
         .subcommand(
             SubCommand::with_name("pubkey")
                 .about("Display the pubkey from a keypair file")
+                .setting(AppSettings::DisableVersion)
                 .arg(
                     Arg::with_name("infile")
                         .index(1)
@@ -44,48 +57,55 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                         .value_name("PATH")
                         .takes_value(true)
                         .help("Path to generated file"),
+                )
+                .arg(
+                    Arg::with_name("force")
+                        .short("f")
+                        .long("force")
+                        .help("Overwrite the output file if it exists"),
                 ),
         )
         .get_matches();
 
     match matches.subcommand() {
-        ("pubkey", Some(pubkey_matches)) => {
+        ("pubkey", Some(matches)) => {
             let mut path = dirs::home_dir().expect("home directory");
-            let infile = if pubkey_matches.is_present("infile") {
-                pubkey_matches.value_of("infile").unwrap()
+            let infile = if matches.is_present("infile") {
+                matches.value_of("infile").unwrap()
             } else {
                 path.extend(&[".config", "solana", "id.json"]);
                 path.to_str().unwrap()
             };
             let keypair = read_keypair(infile)?;
 
-            if pubkey_matches.is_present("outfile") {
-                let outfile = pubkey_matches.value_of("outfile").unwrap();
+            if matches.is_present("outfile") {
+                let outfile = matches.value_of("outfile").unwrap();
+                check_for_overwrite(&outfile, &matches);
                 write_pubkey(outfile, keypair.pubkey())?;
             } else {
                 println!("{}", keypair.pubkey());
             }
         }
-        match_tuple => {
-            let working_matches = if let (_, Some(new_matches)) = match_tuple {
-                new_matches
-            } else {
-                &matches
-            };
-
+        ("new", Some(matches)) => {
             let mut path = dirs::home_dir().expect("home directory");
-            let outfile = if working_matches.is_present("outfile") {
-                working_matches.value_of("outfile").unwrap()
+            let outfile = if matches.is_present("outfile") {
+                matches.value_of("outfile").unwrap()
             } else {
                 path.extend(&[".config", "solana", "id.json"]);
                 path.to_str().unwrap()
             };
 
+            if outfile != "-" {
+                check_for_overwrite(&outfile, &matches);
+            }
             let serialized_keypair = gen_keypair_file(outfile)?;
             if outfile == "-" {
                 println!("{}", serialized_keypair);
+            } else {
+                println!("Wrote {}", outfile);
             }
         }
+        _ => unreachable!(),
     }
 
     Ok(())

--- a/multinode-demo/fullnode.sh
+++ b/multinode-demo/fullnode.sh
@@ -260,8 +260,8 @@ if [[ $node_type = replicator ]]; then
   configured_flag=$SOLANA_CONFIG_DIR/replicator$label.configured
 
   mkdir -p "$SOLANA_CONFIG_DIR"
-  [[ -r "$identity_keypair_path" ]] || $solana_keygen -o "$identity_keypair_path"
-  [[ -r "$storage_keypair_path" ]] || $solana_keygen -o "$storage_keypair_path"
+  [[ -r "$identity_keypair_path" ]] || $solana_keygen new -o "$identity_keypair_path"
+  [[ -r "$storage_keypair_path" ]] || $solana_keygen new -o "$storage_keypair_path"
 
   identity_pubkey=$($solana_keygen pubkey "$identity_keypair_path")
   storage_pubkey=$($solana_keygen pubkey "$storage_keypair_path")
@@ -318,10 +318,10 @@ elif [[ $node_type = validator ]]; then
   configured_flag=$SOLANA_CONFIG_DIR/validator$label.configured
 
   mkdir -p "$SOLANA_CONFIG_DIR"
-  [[ -r "$identity_keypair_path" ]] || $solana_keygen -o "$identity_keypair_path"
-  [[ -r "$vote_keypair_path" ]] || $solana_keygen -o "$vote_keypair_path"
-  [[ -r "$stake_keypair_path" ]] || $solana_keygen -o "$stake_keypair_path"
-  [[ -r "$storage_keypair_path" ]] || $solana_keygen -o "$storage_keypair_path"
+  [[ -r "$identity_keypair_path" ]] || $solana_keygen new -o "$identity_keypair_path"
+  [[ -r "$vote_keypair_path" ]] || $solana_keygen new -o "$vote_keypair_path"
+  [[ -r "$stake_keypair_path" ]] || $solana_keygen new -o "$stake_keypair_path"
+  [[ -r "$storage_keypair_path" ]] || $solana_keygen new -o "$storage_keypair_path"
 
   default_arg --entrypoint "$entrypoint_address"
   default_arg --rpc-drone-address "${entrypoint_address%:*}:9900"

--- a/multinode-demo/setup.sh
+++ b/multinode-demo/setup.sh
@@ -8,11 +8,11 @@ set -e
 "$here"/clear-config.sh
 
 # Create genesis ledger
-$solana_keygen -o "$SOLANA_CONFIG_DIR"/mint-keypair.json
-$solana_keygen -o "$SOLANA_CONFIG_DIR"/bootstrap-leader-keypair.json
-$solana_keygen -o "$SOLANA_CONFIG_DIR"/bootstrap-leader-vote-keypair.json
-$solana_keygen -o "$SOLANA_CONFIG_DIR"/bootstrap-leader-stake-keypair.json
-$solana_keygen -o "$SOLANA_CONFIG_DIR"/bootstrap-leader-storage-keypair.json
+$solana_keygen new -o "$SOLANA_CONFIG_DIR"/mint-keypair.json
+$solana_keygen new -o "$SOLANA_CONFIG_DIR"/bootstrap-leader-keypair.json
+$solana_keygen new -o "$SOLANA_CONFIG_DIR"/bootstrap-leader-vote-keypair.json
+$solana_keygen new -o "$SOLANA_CONFIG_DIR"/bootstrap-leader-stake-keypair.json
+$solana_keygen new -o "$SOLANA_CONFIG_DIR"/bootstrap-leader-storage-keypair.json
 
 args=("$@")
 default_arg --bootstrap-leader-keypair "$SOLANA_CONFIG_DIR"/bootstrap-leader-keypair.json

--- a/net/remote/remote-client.sh
+++ b/net/remote/remote-client.sh
@@ -65,7 +65,7 @@ solana-bench-tps)
   "
   ;;
 solana-bench-exchange)
-  solana-keygen -o bench.keypair
+  solana-keygen new -o bench.keypair
   clientCommand="\
     solana-bench-exchange \
       --entrypoint $entrypointIp:8001 \

--- a/net/remote/remote-sanity.sh
+++ b/net/remote/remote-sanity.sh
@@ -102,7 +102,7 @@ fi
 echo "+++ $sanityTargetIp: node count ($numSanityNodes expected)"
 (
   set -x
-  $solana_keygen -o "$client_id"
+  $solana_keygen new -o "$client_id"
 
   nodeArg="num-nodes"
   if $rejectExtraNodes; then

--- a/run.sh
+++ b/run.sh
@@ -45,22 +45,22 @@ leader_keypair="$dataDir/leader-keypair.json"
 if [[ -e $leader_keypair ]]; then
   echo "Use existing leader keypair"
 else
-  solana-keygen -o "$leader_keypair"
+  solana-keygen new -o "$leader_keypair"
 fi
 leader_vote_account_keypair="$dataDir/leader-vote-account-keypair.json"
 if [[ -e $leader_vote_account_keypair ]]; then
   echo "Use existing leader vote account keypair"
 else
-  solana-keygen -o "$leader_vote_account_keypair"
+  solana-keygen new -o "$leader_vote_account_keypair"
 fi
 leader_stake_account_keypair="$dataDir/leader-stake-account-keypair.json"
 if [[ -e $leader_stake_account_keypair ]]; then
   echo "Use existing leader stake account keypair"
 else
-  solana-keygen -o "$leader_stake_account_keypair"
+  solana-keygen new -o "$leader_stake_account_keypair"
 fi
-solana-keygen -o "$dataDir"/drone-keypair.json
-solana-keygen -o "$dataDir"/leader-storage-account-keypair.json
+solana-keygen new -o "$dataDir"/drone-keypair.json
+solana-keygen new -o "$dataDir"/leader-storage-account-keypair.json
 
 leaderVoteAccountPubkey=$(\
   solana-wallet \

--- a/scripts/wallet-sanity.sh
+++ b/scripts/wallet-sanity.sh
@@ -43,7 +43,7 @@ pay_and_confirm() {
   $solana_wallet "${entrypoint[@]}" confirm "$signature"
 }
 
-$solana_keygen
+$solana_keygen new
 
 node_readiness=false
 timeout=60


### PR DESCRIPTION
#### Problem
`solana-keygen` *really* wants to overwrite your keypair

#### Summary of Changes
* Use -f to overwrite, otherwise don't
* `solana-keygen new` is now required, `solana-keygen` without any
  arguments now presents --help instead of stomping on your default
  keypair
