### PR TITLE
Add solana-install-init binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,25 +41,25 @@ official release.
 ### Edge channel
 #### Linux (x86_64-unknown-linux-gnu)
 * [solana.tar.bz2](http://release.solana.com/edge/solana-release-x86_64-unknown-linux-gnu.tar.bz2)
-* [solana-install](http://release.solana.com/edge/solana-install-x86_64-unknown-linux-gnu) as a stand-alone executable
+* [solana-install-init](http://release.solana.com/edge/solana-install-init-x86_64-unknown-linux-gnu) as a stand-alone executable
 #### mac OS (x86_64-apple-darwin)
 * [solana.tar.bz2](http://release.solana.com/edge/solana-release-x86_64-apple-darwin.tar.bz2)
-* [solana-install](http://release.solana.com/edge/solana-install-x86_64-apple-darwin) as a stand-alone executable
+* [solana-install-init](http://release.solana.com/edge/solana-install-init-x86_64-apple-darwin) as a stand-alone executable
 #### Windows (x86_64-pc-windows-msvc)
 * [solana.tar.bz2](http://release.solana.com/edge/solana-release-x86_64-pc-windows-msvc.tar.bz2)
-* [solana-install.exe](http://release.solana.com/edge/solana-install-x86_64-pc-windows-msvc.exe) as a stand-alone executable
+* [solana-install-init.exe](http://release.solana.com/edge/solana-install-init-x86_64-pc-windows-msvc.exe) as a stand-alone executable
 
 
 ### Beta channel
 #### Linux (x86_64-unknown-linux-gnu)
 * [solana.tar.bz2](http://release.solana.com/beta/solana-release-x86_64-unknown-linux-gnu.tar.bz2)
-* [solana-install](http://release.solana.com/beta/solana-install-x86_64-unknown-linux-gnu) as a stand-alone executable
+* [solana-install-init](http://release.solana.com/beta/solana-install-init-x86_64-unknown-linux-gnu) as a stand-alone executable
 #### mac OS (x86_64-apple-darwin)
 * [solana.tar.bz2](http://release.solana.com/beta/solana-release-x86_64-apple-darwin.tar.bz2)
-* [solana-install](http://release.solana.com/beta/solana-install-x86_64-apple-darwin) as a stand-alone executable
+* [solana-install-init](http://release.solana.com/beta/solana-install-init-x86_64-apple-darwin) as a stand-alone executable
 #### Windows (x86_64-pc-windows-msvc)
 * [solana.tar.bz2](http://release.solana.com/beta/solana-release-x86_64-pc-windows-msvc.tar.bz2)
-* [solana-install.exe](http://release.solana.com/beta/solana-install-x86_64-pc-windows-msvc.exe) as a stand-alone executable
+* [solana-install-init.exe](http://release.solana.com/beta/solana-install-init-x86_64-pc-windows-msvc.exe) as a stand-alone executable
 
 Developing
 ===

--- a/book/src/installer.md
+++ b/book/src/installer.md
@@ -12,18 +12,18 @@ updates is managed using an on-chain update manifest program.
 #### Fetch and run a pre-built installer using a bootstrap curl/shell script
 The easiest install method for supported platforms:
 ```bash
-$ curl -sSf https://raw.githubusercontent.com/solana-labs/solana/v0.13.0/install/solana-install-init.sh | sh
+$ curl -sSf https://raw.githubusercontent.com/solana-labs/solana/v0.16.0/install/solana-install-init.sh | sh
 ```
 
 This script will check github for the latest tagged release and download and run the
-`solana-install` binary from there.
+`solana-install-init` binary from there.
 
 
 If additional arguments need to be specified during the installation, the
 following shell syntax is used:
 ```bash
-$ init_args=.... # arguments for `solana-installer init ...`
-$ curl -sSf https://raw.githubusercontent.com/solana-labs/solana/v0.13.0/install/solana-install-init.sh | sh -s - ${init_args}
+$ init_args=.... # arguments for `solana-install-init ...`
+$ curl -sSf https://raw.githubusercontent.com/solana-labs/solana/v0.16.0/install/solana-install-init.sh | sh -s - ${init_args}
 ```
 
 #### Fetch and run a pre-built installer from a Github release
@@ -31,9 +31,9 @@ With a well-known release URL, a pre-built binary can be obtained for supported
 platforms:
 
 ```bash
-$ curl -o solana-install https://github.com/solana-labs/solana/releases/download/v0.13.0/solana-install-x86_64-apple-darwin
-$ chmod +x ./solana-install
-$ ./solana-install --help
+$ curl -o solana-install-init https://github.com/solana-labs/solana/releases/download/v0.16.0/solana-install-init-x86_64-apple-darwin
+$ chmod +x ./solana-install-init
+$ ./solana-install-init --help
 ```
 
 #### Build and run the installer from source
@@ -119,7 +119,7 @@ It manages the following files and directories in the user's home directory:
 
 #### Command-line Interface
 ```manpage
-solana-install 0.13.0
+solana-install 0.16.0
 The solana cluster software installer
 
 USAGE:

--- a/install/Cargo.toml
+++ b/install/Cargo.toml
@@ -35,3 +35,11 @@ solana-sdk = { path = "../sdk", version = "0.16.0" }
 tar = "0.4.26"
 tempdir = "0.3.7"
 url = "1.7.2"
+
+[[bin]]
+name = "solana-install"
+path = "src/main-install.rs"
+
+[[bin]]
+name = "solana-install-init"
+path = "src/main-install-init.rs"

--- a/install/solana-install-init.sh
+++ b/install/solana-install-init.sh
@@ -74,7 +74,7 @@ main() {
       ;;
     esac
 
-    temp_dir="$(mktemp -d 2>/dev/null || ensure mktemp -d -t solana-install)"
+    temp_dir="$(mktemp -d 2>/dev/null || ensure mktemp -d -t solana-install-init)"
     ensure mkdir -p "$temp_dir"
 
     # Check for SOLANA_RELEASE environment variable override.  Otherwise fetch
@@ -94,24 +94,24 @@ main() {
       fi
     fi
 
-    download_url="$SOLANA_DOWNLOAD_ROOT/$release/solana-install-$TARGET"
-    solana_install="$temp_dir/solana-install-init"
+    download_url="$SOLANA_DOWNLOAD_ROOT/$release/solana-install-init-$TARGET"
+    solana_install_init="$temp_dir/solana-install-init"
 
     printf 'downloading %s installer\n' "$release" 1>&2
 
     ensure mkdir -p "$temp_dir"
-    ensure downloader "$download_url" "$solana_install"
-    ensure chmod u+x "$solana_install"
-    if [ ! -x "$solana_install" ]; then
-        printf '%s\n' "Cannot execute $solana_install (likely because of mounting /tmp as noexec)." 1>&2
+    ensure downloader "$download_url" "$solana_install_init"
+    ensure chmod u+x "$solana_install_init"
+    if [ ! -x "$solana_install_init" ]; then
+        printf '%s\n' "Cannot execute $solana_install_init (likely because of mounting /tmp as noexec)." 1>&2
         printf '%s\n' "Please copy the file to a location where you can execute binaries and run ./solana-install-init." 1>&2
         exit 1
     fi
 
-    ignore "$solana_install" init "$@"
+    ignore "$solana_install_init" "$@"
     retval=$?
 
-    ignore rm "$solana_install"
+    ignore rm "$solana_install_init"
     ignore rm -rf "$temp_dir"
 
     return "$retval"

--- a/install/src/lib.rs
+++ b/install/src/lib.rs
@@ -32,7 +32,7 @@ fn is_pubkey(string: String) -> Result<(), String> {
     }
 }
 
-fn main() -> Result<(), String> {
+pub fn main() -> Result<(), String> {
     solana_logger::setup();
 
     let matches = App::new(crate_name!())
@@ -228,4 +228,88 @@ fn main() -> Result<(), String> {
         }
         _ => unreachable!(),
     }
+}
+
+pub fn main_init() -> Result<(), String> {
+    solana_logger::setup();
+
+    let matches = App::new("solana-install-init")
+        .about("initializes a new installation")
+        .version(crate_version!())
+        .setting(AppSettings::SubcommandRequiredElseHelp)
+        .arg({
+            let arg = Arg::with_name("config_file")
+                .short("c")
+                .long("config")
+                .value_name("PATH")
+                .takes_value(true)
+                .help("Configuration file to use");
+            match *defaults::CONFIG_FILE {
+                Some(ref config_file) => arg.default_value(&config_file),
+                None => arg.required(true),
+            }
+        })
+        .arg({
+            let arg = Arg::with_name("data_dir")
+                .short("d")
+                .long("data-dir")
+                .value_name("PATH")
+                .takes_value(true)
+                .required(true)
+                .help("Directory to store install data");
+            match *defaults::DATA_DIR {
+                Some(ref data_dir) => arg.default_value(&data_dir),
+                None => arg,
+            }
+        })
+        .arg(
+            Arg::with_name("json_rpc_url")
+                .short("u")
+                .long("url")
+                .value_name("URL")
+                .takes_value(true)
+                .default_value(defaults::JSON_RPC_URL)
+                .validator(is_url)
+                .help("JSON RPC URL for the solana cluster"),
+        )
+        .arg(
+            Arg::with_name("no_modify_path")
+                .long("no-modify-path")
+                .help("Don't configure the PATH environment variable"),
+        )
+        .arg({
+            let arg = Arg::with_name("update_manifest_pubkey")
+                .short("p")
+                .long("pubkey")
+                .value_name("PUBKEY")
+                .takes_value(true)
+                .required(true)
+                .validator(is_pubkey)
+                .help("Public key of the update manifest");
+
+            match defaults::update_manifest_pubkey(build_env::TARGET) {
+                Some(default_value) => arg.default_value(default_value),
+                None => arg,
+            }
+        })
+        .get_matches();
+
+    let config_file = matches.value_of("config_file").unwrap();
+
+    let json_rpc_url = matches.value_of("json_rpc_url").unwrap();
+    let update_manifest_pubkey = matches
+        .value_of("update_manifest_pubkey")
+        .unwrap()
+        .parse::<Pubkey>()
+        .unwrap();
+    let data_dir = matches.value_of("data_dir").unwrap();
+    let no_modify_path = matches.is_present("no_modify_path");
+
+    command::init(
+        config_file,
+        data_dir,
+        json_rpc_url,
+        &update_manifest_pubkey,
+        no_modify_path,
+    )
 }

--- a/install/src/lib.rs
+++ b/install/src/lib.rs
@@ -236,7 +236,6 @@ pub fn main_init() -> Result<(), String> {
     let matches = App::new("solana-install-init")
         .about("initializes a new installation")
         .version(crate_version!())
-        .setting(AppSettings::SubcommandRequiredElseHelp)
         .arg({
             let arg = Arg::with_name("config_file")
                 .short("c")

--- a/install/src/main-install-init.rs
+++ b/install/src/main-install-init.rs
@@ -1,0 +1,3 @@
+fn main() -> Result<(), String> {
+    solana_install::main_init()
+}

--- a/install/src/main-install-init.rs
+++ b/install/src/main-install-init.rs
@@ -1,3 +1,27 @@
-fn main() -> Result<(), String> {
-    solana_install::main_init()
+use std::process::exit;
+
+#[cfg(windows)]
+fn press_enter() {
+    // On windows, where installation happens in a console that may have opened just for this
+    // purpose, give the user an opportunity to see the error before the window closes.
+    println!();
+    println!("Press the Enter key to continue.");
+
+    use std::io::BufRead;
+    let stdin = std::io::stdin();
+    let stdin = stdin.lock();
+    let mut lines = stdin.lines();
+    lines.next();
+}
+
+#[cfg(not(windows))]
+fn press_enter() {}
+
+fn main() {
+    solana_install::main_init().unwrap_or_else(|err| {
+        println!("Error: {}", err);
+        press_enter();
+        exit(1);
+    });
+    press_enter();
 }

--- a/install/src/main-install.rs
+++ b/install/src/main-install.rs
@@ -1,0 +1,3 @@
+fn main() -> Result<(), String> {
+    solana_install::main()
+}

--- a/scripts/cargo-install-all.sh
+++ b/scripts/cargo-install-all.sh
@@ -34,6 +34,7 @@ PROGRAMS=(
   solana-genesis
   solana-gossip
   solana-install
+  solana-install-init
   solana-keygen
   solana-ledger-tool
   solana-replicator


### PR DESCRIPTION
It's more convenient for users to have a `solana-install-init.exe` binary that can be executed immediately on download, than fumbling around with trying to find a console to run `solana-install.exe init` in.  

The name `solana-install-init.exe` is also clearly disposable once the installation is complete, whereas it was unclear if `solana-install.exe` needed to be kept around (it didn't!) since that program provides other functionality as well.