### PR TITLE
Accounts index opt

### DIFF
--- a/runtime/benches/accounts_index.rs
+++ b/runtime/benches/accounts_index.rs
@@ -18,10 +18,11 @@ fn bench_accounts_index(bencher: &mut Bencher) {
 
     const NUM_FORKS: u64 = 16;
 
+    let mut reclaims = vec![];
     let mut index = AccountsIndex::<AccountInfo>::default();
     for f in 0..NUM_FORKS {
         for _p in 0..NUM_PUBKEYS {
-            index.insert(f, &pubkeys[_p], AccountInfo::default());
+            index.insert(f, &pubkeys[_p], AccountInfo::default(), &mut reclaims);
         }
     }
 
@@ -30,7 +31,13 @@ fn bench_accounts_index(bencher: &mut Bencher) {
     bencher.iter(|| {
         for _p in 0..NUM_PUBKEYS {
             let pubkey = thread_rng().gen_range(0, NUM_PUBKEYS);
-            index.insert(fork, &pubkeys[pubkey], AccountInfo::default());
+            index.insert(
+                fork,
+                &pubkeys[pubkey],
+                AccountInfo::default(),
+                &mut reclaims,
+            );
+            reclaims.clear();
         }
         index.add_root(root);
         root += 1;

--- a/runtime/benches/accounts_index.rs
+++ b/runtime/benches/accounts_index.rs
@@ -1,0 +1,39 @@
+#![feature(test)]
+
+extern crate test;
+
+use rand::{thread_rng, Rng};
+use solana_runtime::accounts_db::AccountInfo;
+use solana_runtime::accounts_index::AccountsIndex;
+use solana_sdk::pubkey::Pubkey;
+use test::Bencher;
+
+#[bench]
+fn bench_accounts_index(bencher: &mut Bencher) {
+    const NUM_PUBKEYS: usize = 10_000;
+    let pubkeys: Vec<_> = (0..NUM_PUBKEYS)
+        .into_iter()
+        .map(|_| Pubkey::new_rand())
+        .collect();
+
+    const NUM_FORKS: u64 = 16;
+
+    let mut index = AccountsIndex::<AccountInfo>::default();
+    for f in 0..NUM_FORKS {
+        for _p in 0..NUM_PUBKEYS {
+            index.insert(f, &pubkeys[_p], AccountInfo::default());
+        }
+    }
+
+    let mut fork = NUM_FORKS;
+    let mut root = 0;
+    bencher.iter(|| {
+        for _p in 0..NUM_PUBKEYS {
+            let pubkey = thread_rng().gen_range(0, NUM_PUBKEYS);
+            index.insert(fork, &pubkeys[pubkey], AccountInfo::default());
+        }
+        index.add_root(root);
+        root += 1;
+        fork += 1;
+    });
+}

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -474,14 +474,14 @@ impl AccountsDB {
         fork_id: Fork,
         infos: Vec<AccountInfo>,
         accounts: &[(&Pubkey, &Account)],
-    ) -> Vec<(Fork, AccountInfo)> {
+    ) -> (Vec<(Fork, AccountInfo)>, u64) {
         let mut index = self.accounts_index.write().unwrap();
         let mut reclaims = vec![];
         for (i, info) in infos.into_iter().enumerate() {
             let key = &accounts[i].0;
             reclaims.extend(index.insert(fork_id, key, info).into_iter())
         }
-        reclaims
+        (reclaims, index.last_root)
     }
 
     fn remove_dead_accounts(&self, reclaims: Vec<(Fork, AccountInfo)>) -> HashSet<Fork> {
@@ -516,24 +516,30 @@ impl AccountsDB {
         dead_forks
     }
 
-    fn cleanup_dead_forks(&self, dead_forks: &mut HashSet<Fork>) {
-        let mut index = self.accounts_index.write().unwrap();
+    fn cleanup_dead_forks(&self, dead_forks: &mut HashSet<Fork>, last_root: u64) {
         // a fork is not totally dead until it is older than the root
-        dead_forks.retain(|fork| *fork < index.last_root);
-        for fork in dead_forks.iter() {
-            index.cleanup_dead_fork(*fork);
+        dead_forks.retain(|fork| *fork < last_root);
+        if !dead_forks.is_empty() {
+            let mut index = self.accounts_index.write().unwrap();
+            for fork in dead_forks.iter() {
+                index.cleanup_dead_fork(*fork);
+            }
         }
     }
 
     /// Store the account update.
     pub fn store(&self, fork_id: Fork, accounts: &[(&Pubkey, &Account)]) {
         let infos = self.store_accounts(fork_id, accounts);
-        let reclaims = self.update_index(fork_id, infos, accounts);
+
+        let (reclaims, last_root) = self.update_index(fork_id, infos, accounts);
         trace!("reclaim: {}", reclaims.len());
+
         let mut dead_forks = self.remove_dead_accounts(reclaims);
         trace!("dead_forks: {}", dead_forks.len());
-        self.cleanup_dead_forks(&mut dead_forks);
+
+        self.cleanup_dead_forks(&mut dead_forks, last_root);
         trace!("purge_forks: {}", dead_forks.len());
+
         for fork in dead_forks {
             self.purge_fork(fork);
         }

--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -1,7 +1,9 @@
+use hashbrown::HashMap;
 use log::*;
 use serde::{Deserialize, Serialize};
 use solana_sdk::pubkey::Pubkey;
-use std::collections::{HashMap, HashSet};
+use std::collections;
+use std::collections::HashSet;
 
 pub type Fork = u64;
 
@@ -19,7 +21,11 @@ pub struct AccountsIndex<T> {
 impl<T: Clone> AccountsIndex<T> {
     /// Get an account
     /// The latest account that appears in `ancestors` or `roots` is returned.
-    pub fn get(&self, pubkey: &Pubkey, ancestors: &HashMap<Fork, usize>) -> Option<(&T, Fork)> {
+    pub fn get(
+        &self,
+        pubkey: &Pubkey,
+        ancestors: &collections::HashMap<Fork, usize>,
+    ) -> Option<(&T, Fork)> {
         let list = self.account_maps.get(pubkey)?;
         let mut max = 0;
         let mut rv = None;
@@ -100,7 +106,7 @@ mod tests {
     fn test_get_empty() {
         let key = Keypair::new();
         let index = AccountsIndex::<bool>::default();
-        let ancestors = HashMap::new();
+        let ancestors = collections::HashMap::new();
         assert_eq!(index.get(&key.pubkey(), &ancestors), None);
     }
 
@@ -112,7 +118,7 @@ mod tests {
         index.insert(0, &key.pubkey(), true, &mut gc);
         assert!(gc.is_empty());
 
-        let ancestors = HashMap::new();
+        let ancestors = collections::HashMap::new();
         assert_eq!(index.get(&key.pubkey(), &ancestors), None);
     }
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1,6 +1,6 @@
 mod accounts;
 pub mod accounts_db;
-mod accounts_index;
+pub mod accounts_index;
 pub mod append_vec;
 pub mod bank;
 pub mod bank_client;


### PR DESCRIPTION
#### Problem

`accounts_index::insert` happens in a write lock and should be as fast as possible.

#### Summary of Changes

Optimize:
* Avoid taking the lock in cleanup_dead_forks in the majority of cases since we can save the last_root when it has the lock from update_index.
* Pass in an already-allocated vector to avoid malloc in the lock critical section
* Change `is_purged` to take the root to avoid looking up the account twice and doing the swap.

Fixes #
