### PR TITLE
Start validator nodes from snapshot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2653,6 +2653,7 @@ dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "hashbrown 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
  "libloading 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/core/src/bank_forks.rs
+++ b/core/src/bank_forks.rs
@@ -166,7 +166,7 @@ impl BankForks {
             for slot in diff.iter() {
                 if **slot > root {
                     let _ = self.add_snapshot(**slot, root);
-                } else if **slot > 0 {
+                } else {
                     BankForks::remove_snapshot(**slot, &self.snapshot_path);
                 }
             }

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -297,7 +297,7 @@ fn get_bank_forks(
     snapshot_path: Option<String>,
 ) -> (BankForks, Vec<BankForksInfo>, LeaderScheduleCache) {
     if snapshot_path.is_some() {
-        let bank_forks = BankForks::load_from_snapshot(&snapshot_path);
+        let bank_forks = BankForks::load_from_snapshot(&genesis_block, &snapshot_path);
         match bank_forks {
             Ok(v) => {
                 let bank = &v.working_bank();

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -297,7 +297,8 @@ fn get_bank_forks(
     snapshot_path: Option<String>,
 ) -> (BankForks, Vec<BankForksInfo>, LeaderScheduleCache) {
     if snapshot_path.is_some() {
-        let bank_forks = BankForks::load_from_snapshot(&genesis_block, &snapshot_path);
+        let bank_forks =
+            BankForks::load_from_snapshot(&genesis_block, account_paths.clone(), &snapshot_path);
         match bank_forks {
             Ok(v) => {
                 let bank = &v.working_bank();

--- a/multinode-demo/fullnode.sh
+++ b/multinode-demo/fullnode.sh
@@ -312,12 +312,9 @@ elif [[ $node_type = bootstrap_leader ]]; then
   vote_keypair_path="$SOLANA_CONFIG_DIR"/bootstrap-leader-vote-keypair.json
   ledger_config_dir="$SOLANA_CONFIG_DIR"/bootstrap-leader-ledger
   accounts_config_dir="$SOLANA_CONFIG_DIR"/bootstrap-leader-accounts
-  storage_keypair_path=$SOLANA_CONFIG_DIR/bootstrap-leader-storage-keypair.json
-<<<<<<< HEAD
-  configured_flag=$SOLANA_CONFIG_DIR/bootstrap-leader.configured
-=======
   snapshot_config_dir="$SOLANA_CONFIG_DIR"/bootstrap-leader-snapshots
->>>>>>> validator restart
+  storage_keypair_path=$SOLANA_CONFIG_DIR/bootstrap-leader-storage-keypair.json
+  configured_flag=$SOLANA_CONFIG_DIR/bootstrap-leader.configured
 
   default_arg --rpc-port 8899
   default_arg --rpc-drone-address 127.0.0.1:9900
@@ -337,11 +334,8 @@ elif [[ $node_type = validator ]]; then
   storage_keypair_path=$SOLANA_CONFIG_DIR/validator-storage-keypair$label.json
   ledger_config_dir=$SOLANA_CONFIG_DIR/validator-ledger$label
   accounts_config_dir=$SOLANA_CONFIG_DIR/validator-accounts$label
-<<<<<<< HEAD
-  configured_flag=$SOLANA_CONFIG_DIR/validator$label.configured
-=======
   snapshot_config_dir="$SOLANA_CONFIG_DIR"/validator-snapshots$label
->>>>>>> validator restart
+  configured_flag=$SOLANA_CONFIG_DIR/validator$label.configured
 
   mkdir -p "$SOLANA_CONFIG_DIR"
   [[ -r "$identity_keypair_path" ]] || $solana_keygen new -o "$identity_keypair_path"
@@ -425,11 +419,13 @@ while true; do
 
   (
     set -x
-    if [[ -d "$SOLANA_RSYNC_CONFIG_DIR"/snapshots ]]; then
-      if [[ ! -d $snapshot_config_dir ]]; then
-        cp -a "$SOLANA_RSYNC_CONFIG_DIR"/snapshots/ "$snapshot_config_dir"
-        cp -a "$SOLANA_RSYNC_CONFIG_DIR"/accounts/ "$accounts_config_dir"
-      fi
+    if [[ $node_type = validator ]]; then
+	rm -rf "$ledger_config_dir"
+        if [[ -d "$SOLANA_RSYNC_CONFIG_DIR"/snapshots ]]; then
+          rm -rf "$snapshot_config_dir" "$accounts_config_dir"
+          cp -a "$SOLANA_RSYNC_CONFIG_DIR"/snapshots/ "$snapshot_config_dir"
+          cp -a "$SOLANA_RSYNC_CONFIG_DIR"/accounts/ "$accounts_config_dir"
+        fi
     fi
     if [[ ! -d "$ledger_config_dir" ]]; then
       cp -a "$SOLANA_RSYNC_CONFIG_DIR"/ledger/ "$ledger_config_dir"

--- a/multinode-demo/fullnode.sh
+++ b/multinode-demo/fullnode.sh
@@ -477,10 +477,9 @@ while true; do
         if [[ -d $snapshot_config_dir ]]; then
           $rsync -qrt --delete-after "$snapshot_config_dir"/ "$SOLANA_RSYNC_CONFIG_DIR"/snapshots
           $rsync -qrt --delete-after "$accounts_config_dir"/ "$SOLANA_RSYNC_CONFIG_DIR"/accounts
-#          $rsync -qrt --delete-after "$ledger_config_dir"/ "$SOLANA_RSYNC_CONFIG_DIR"/ledger
 	fi
       ) || true
-      secs_to_next_sync_poll=30
+      secs_to_next_sync_poll=60
     done
   else
     secs_to_next_genesis_poll=1

--- a/multinode-demo/fullnode.sh
+++ b/multinode-demo/fullnode.sh
@@ -313,7 +313,11 @@ elif [[ $node_type = bootstrap_leader ]]; then
   ledger_config_dir="$SOLANA_CONFIG_DIR"/bootstrap-leader-ledger
   accounts_config_dir="$SOLANA_CONFIG_DIR"/bootstrap-leader-accounts
   storage_keypair_path=$SOLANA_CONFIG_DIR/bootstrap-leader-storage-keypair.json
+<<<<<<< HEAD
   configured_flag=$SOLANA_CONFIG_DIR/bootstrap-leader.configured
+=======
+  snapshot_config_dir="$SOLANA_CONFIG_DIR"/bootstrap-leader-snapshots
+>>>>>>> validator restart
 
   default_arg --rpc-port 8899
   default_arg --rpc-drone-address 127.0.0.1:9900
@@ -333,7 +337,11 @@ elif [[ $node_type = validator ]]; then
   storage_keypair_path=$SOLANA_CONFIG_DIR/validator-storage-keypair$label.json
   ledger_config_dir=$SOLANA_CONFIG_DIR/validator-ledger$label
   accounts_config_dir=$SOLANA_CONFIG_DIR/validator-accounts$label
+<<<<<<< HEAD
   configured_flag=$SOLANA_CONFIG_DIR/validator$label.configured
+=======
+  snapshot_config_dir="$SOLANA_CONFIG_DIR"/validator-snapshots$label
+>>>>>>> validator restart
 
   mkdir -p "$SOLANA_CONFIG_DIR"
   [[ -r "$identity_keypair_path" ]] || $solana_keygen new -o "$identity_keypair_path"
@@ -363,6 +371,7 @@ vote pubkey: $vote_pubkey
 storage pubkey: $storage_pubkey
 ledger: $ledger_config_dir
 accounts: $accounts_config_dir
+snapshots: $snapshot_config_dir
 ========================================================================
 EOF
 
@@ -372,6 +381,7 @@ EOF
   default_arg --storage-keypair "$storage_keypair_path"
   default_arg --ledger "$ledger_config_dir"
   default_arg --accounts "$accounts_config_dir"
+  default_arg --snapshot-path "$snapshot_config_dir"
 
   if [[ -n $SOLANA_CUDA ]]; then
     program=$solana_validator_cuda
@@ -396,7 +406,12 @@ while true; do
     if [[ $node_type = bootstrap_leader ]]; then
       ledger_not_setup "$SOLANA_RSYNC_CONFIG_DIR/ledger does not exist"
     fi
-    $rsync -vPr "${rsync_entrypoint_url:?}"/config/ledger "$SOLANA_RSYNC_CONFIG_DIR"
+    (
+      set -x
+      $rsync -qvPr "${rsync_entrypoint_url:?}"/config/ledger "$SOLANA_RSYNC_CONFIG_DIR"
+      $rsync -vqPr "${rsync_entrypoint_url:?}"/config/snapshots "$SOLANA_RSYNC_CONFIG_DIR"
+      $rsync -vqPr "${rsync_entrypoint_url:?}"/config/accounts "$SOLANA_RSYNC_CONFIG_DIR"
+    ) || true
   fi
 
   if new_gensis_block; then
@@ -404,14 +419,23 @@ while true; do
     # keypair for the node and start all over again
     (
       set -x
-      rm -rf "$ledger_config_dir" "$accounts_config_dir" "$configured_flag"
+      rm -rf "$ledger_config_dir" "$accounts_config_dir" "$snapshot_config_dir" "$configured_flag"
     )
   fi
 
-  if [[ ! -d "$ledger_config_dir" ]]; then
-    cp -a "$SOLANA_RSYNC_CONFIG_DIR"/ledger/ "$ledger_config_dir"
-    $solana_ledger_tool --ledger "$ledger_config_dir" verify
-  fi
+  (
+    set -x
+    if [[ -d "$SOLANA_RSYNC_CONFIG_DIR"/snapshots ]]; then
+      if [[ ! -d $snapshot_config_dir ]]; then
+        cp -a "$SOLANA_RSYNC_CONFIG_DIR"/snapshots/ "$snapshot_config_dir"
+        cp -a "$SOLANA_RSYNC_CONFIG_DIR"/accounts/ "$accounts_config_dir"
+      fi
+    fi
+    if [[ ! -d "$ledger_config_dir" ]]; then
+      cp -a "$SOLANA_RSYNC_CONFIG_DIR"/ledger/ "$ledger_config_dir"
+      $solana_ledger_tool --ledger "$ledger_config_dir" verify
+    fi
+  )
 
   trap '[[ -n $pid ]] && kill "$pid" >/dev/null 2>&1 && wait "$pid"' INT TERM ERR
 
@@ -443,9 +467,25 @@ while true; do
   fi
 
   if [[ $node_type = bootstrap_leader ]]; then
-    wait "$pid" || true
-    echo "############## $node_type exited, restarting ##############"
-    sleep 1
+    secs_to_next_sync_poll=30
+    while true; do
+      if ! kill -0 "$pid"; then
+        wait "$pid"
+        exit 0
+      fi
+
+      sleep 1
+
+      ((secs_to_next_sync_poll--)) && continue
+      (
+        if [[ -d $snapshot_config_dir ]]; then
+          $rsync -qrt --delete-after "$snapshot_config_dir"/ "$SOLANA_RSYNC_CONFIG_DIR"/snapshots
+          $rsync -qrt --delete-after "$accounts_config_dir"/ "$SOLANA_RSYNC_CONFIG_DIR"/accounts
+#          $rsync -qrt --delete-after "$ledger_config_dir"/ "$SOLANA_RSYNC_CONFIG_DIR"/ledger
+	fi
+      ) || true
+      secs_to_next_sync_poll=30
+    done
   else
     secs_to_next_genesis_poll=1
     while true; do

--- a/multinode-demo/fullnode.sh
+++ b/multinode-demo/fullnode.sh
@@ -403,8 +403,10 @@ while true; do
     (
       set -x
       $rsync -qvPr "${rsync_entrypoint_url:?}"/config/ledger "$SOLANA_RSYNC_CONFIG_DIR"
-      $rsync -vqPr "${rsync_entrypoint_url:?}"/config/snapshots "$SOLANA_RSYNC_CONFIG_DIR"
-      $rsync -vqPr "${rsync_entrypoint_url:?}"/config/accounts "$SOLANA_RSYNC_CONFIG_DIR"
+      $rsync -qvPr "${rsync_entrypoint_url:?}"/config/snapshot_dir "$SOLANA_RSYNC_CONFIG_DIR"
+      current_snapshot_dir=$(cat "$SOLANA_RSYNC_CONFIG_DIR"/snapshot_dir)
+      $rsync -vqPr "${rsync_entrypoint_url:?}"/config/"$current_snapshot_dir"/snapshots "$SOLANA_RSYNC_CONFIG_DIR"
+      $rsync -vqPr "${rsync_entrypoint_url:?}"/config/"$current_snapshot_dir"/accounts "$SOLANA_RSYNC_CONFIG_DIR"
     ) || true
   fi
 
@@ -463,6 +465,7 @@ while true; do
   fi
 
   if [[ $node_type = bootstrap_leader ]]; then
+    snapshot_dir=0
     secs_to_next_sync_poll=30
     while true; do
       if ! kill -0 "$pid"; then
@@ -475,11 +478,15 @@ while true; do
       ((secs_to_next_sync_poll--)) && continue
       (
         if [[ -d $snapshot_config_dir ]]; then
-          $rsync -qrt --delete-after "$snapshot_config_dir"/ "$SOLANA_RSYNC_CONFIG_DIR"/snapshots
-          $rsync -qrt --delete-after "$accounts_config_dir"/ "$SOLANA_RSYNC_CONFIG_DIR"/accounts
+          current_config_dir="$SOLANA_RSYNC_CONFIG_DIR"/$snapshot_dir
+          mkdir -p "$current_config_dir"
+          cp -a "$snapshot_config_dir"/ "$current_config_dir"/snapshots
+          cp -a "$accounts_config_dir"/ "$current_config_dir"/accounts
+          echo $snapshot_dir > "$SOLANA_RSYNC_CONFIG_DIR"/snapshot_dir
 	fi
       ) || true
       secs_to_next_sync_poll=60
+      snapshot_dir=$((snapshot_dir+1))
     done
   else
     secs_to_next_genesis_poll=1

--- a/net/net.sh
+++ b/net/net.sh
@@ -120,7 +120,7 @@ while [[ -n $1 ]]; do
   fi
 done
 
-while getopts "h?T:t:o:f:rD:c:Fn:x:s:" opt "${shortArgs[@]}"; do
+while getopts "h?T:t:o:f:rD:c:Fn:i:x:s:" opt "${shortArgs[@]}"; do
   case $opt in
   h | \?)
     usage
@@ -204,6 +204,9 @@ while getopts "h?T:t:o:f:rD:c:Fn:x:s:" opt "${shortArgs[@]}"; do
     ;;
   s)
     stakeNodesInGenesisBlock=$OPTARG
+    ;;
+  i)
+    nodeAddress=$OPTARG
     ;;
   *)
     usage "Error: unhandled option: $opt"
@@ -683,6 +686,12 @@ sanity)
   ;;
 stop)
   stop
+  ;;
+stopnode)
+  stopNode "$nodeAddress" true
+  ;;
+startnode)
+  startNode "$nodeAddress" validator
   ;;
 logs)
   fetchRemoteLog() {

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -14,6 +14,7 @@ bv = { version = "0.11.0", features = ["serde"] }
 byteorder = "1.3.2"
 fnv = "1.0.6"
 hashbrown = "0.2.0"
+lazy_static = "1.3.0"
 libc = "0.2.58"
 libloading = "0.5.1"
 log = "0.4.2"

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -190,6 +190,7 @@ impl Accounts {
                 Some(program) => program,
                 None => {
                     error_counters.account_not_found += 1;
+                    info!("ancestors {:?}, accouts index {:?}, id {:?}", ancestors, accounts_index, program_id);
                     return Err(TransactionError::ProgramAccountNotFound);
                 }
             };

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -22,7 +22,6 @@ use std::collections::{HashMap, HashSet};
 use std::env;
 use std::fs::remove_dir_all;
 use std::io::{BufReader, Read};
-use std::iter::once;
 use std::ops::Neg;
 use std::path::Path;
 use std::sync::atomic::{AtomicUsize, Ordering};

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -39,7 +39,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, RwLock};
 use sys_info;
 
-const ACCOUNT_DATA_FILE_SIZE: u64 = 64 * 1024 * 1024;
+const ACCOUNT_DATA_FILE_SIZE: u64 = 16 * 1024 * 1024;
 const ACCOUNT_DATA_FILE: &str = "data";
 pub const NUM_THREADS: u32 = 10;
 
@@ -340,8 +340,9 @@ impl AccountsDB {
             let union = index.roots.union(&accounts_index.roots);
             index.roots = union.cloned().collect();
             index.last_root = accounts_index.last_root;
+            let mut stores = self.storage.write().unwrap();
+            stores.0.extend(storage.0);
         }
-        *self.storage.write().unwrap() = storage;
         self.next_id
             .store(ids[ids.len() - 1] + 1, Ordering::Relaxed);
         self.write_version.store(version, Ordering::Relaxed);

--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -15,6 +15,7 @@ pub struct AccountsIndex<T> {
     pub roots: HashSet<Fork>,
 
     //This value that needs to be stored to recover the index from AppendVec
+    #[serde(skip)]
     pub last_root: Fork,
 }
 

--- a/runtime/src/append_vec.rs
+++ b/runtime/src/append_vec.rs
@@ -360,12 +360,14 @@ impl<'a> serde::de::Visitor<'a> for AppendVecVisitor {
         let split_path: Vec<&str> = path.to_str().unwrap().rsplit('/').collect();
         let account_paths = ACCOUNT_PATHS.lock().unwrap().clone();
         let mut account_path = path.clone();
-        for dir_path in account_paths.iter() {
-            let fullpath = format!("{}/{}/{}", dir_path, split_path[1], split_path[0]);
-            let file_path = Path::new(&fullpath);
-            if file_path.exists() {
-                account_path = file_path.to_path_buf();
-                break;
+        if split_path.len() >= 2 {
+            for dir_path in account_paths.iter() {
+                let fullpath = format!("{}/{}/{}", dir_path, split_path[1], split_path[0]);
+                let file_path = Path::new(&fullpath);
+                if file_path.exists() {
+                    account_path = file_path.to_path_buf();
+                    break;
+                }
             }
         }
 
@@ -376,7 +378,7 @@ impl<'a> serde::de::Visitor<'a> for AppendVecVisitor {
             .open(account_path.as_path());
 
         if data.is_err() {
-            warn!("account open {:?} failed, create empty", account_path);
+            warn!("account open {:?} failed", account_path);
             std::fs::create_dir_all(&account_path.parent().unwrap())
                 .expect("Create directory failed");
             return Ok(AppendVec::new(&account_path, true, file_size as usize));

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4,7 +4,7 @@
 //! already been signed and verified.
 use crate::accounts::Accounts;
 use crate::accounts_db::{
-    AccountsDB, ErrorCounters, InstructionAccounts, InstructionCredits, InstructionLoaders,
+    ErrorCounters, InstructionAccounts, InstructionCredits, InstructionLoaders,
 };
 use crate::accounts_index::Fork;
 use crate::blockhash_queue::BlockhashQueue;


### PR DESCRIPTION
#### Problem
To speed up node restart, the bank state information is saved and restored from the snapshot rather than having to replay the transactions from the ledger. 

#### Summary of Changes
Restore the forking information and any additional information that may be needed to resume the validator node from the bank snapshots.

Fixes #4156 
