### PR TITLE
.iter fixed, drop enumerate where not needed

### DIFF
--- a/programs/bpf/rust/alloc/src/lib.rs
+++ b/programs/bpf/rust/alloc/src/lib.rs
@@ -8,8 +8,8 @@ extern crate solana_sdk_bpf_utils;
 
 use solana_sdk_bpf_utils::log::*;
 
-use core::alloc::Layout;
 use alloc::vec::Vec;
+use core::alloc::Layout;
 use core::mem;
 
 #[no_mangle]

--- a/programs/bpf/rust/alloc/src/lib.rs
+++ b/programs/bpf/rust/alloc/src/lib.rs
@@ -9,7 +9,7 @@ extern crate solana_sdk_bpf_utils;
 use solana_sdk_bpf_utils::log::*;
 
 use core::alloc::Layout;
-// use alloc::vec::Vec;
+use alloc::vec::Vec;
 use core::mem;
 
 #[no_mangle]
@@ -40,18 +40,17 @@ pub extern "C" fn entrypoint(_input: *mut u8) -> bool {
     unsafe {
         // Test allocated memory read and write
 
+        const ITERS: usize = 100;
         let layout = Layout::from_size_align(100, mem::align_of::<u8>()).unwrap();
         let ptr = alloc::alloc::alloc(layout);
         if ptr.is_null() {
-            sol_log("Error: Alloc of 100 bytes failed");
+            sol_log("Error: Alloc failed");
             alloc::alloc::handle_alloc_error(layout);
         }
-        let iter = 0..100; // This weirdness due to #issue $#4271
-        for (i, _) in iter.enumerate() {
+        for i in 0..ITERS {
             *ptr.add(i) = i as u8;
         }
-        let iter = 0..100; // This weirdness due to #issue $#4271
-        for (i, _) in iter.enumerate() {
+        for i in 0..ITERS {
             assert_eq!(*ptr.add(i as usize), i as u8);
         }
         sol_log_64(0x3, 0, 0, 0, *ptr.add(42) as u64);
@@ -78,46 +77,32 @@ pub extern "C" fn entrypoint(_input: *mut u8) -> bool {
     //     alloc::alloc::dealloc(ptr, layout);
     // }
 
-    // {
-    //     // Test allocated vector
-
-    //     const ITERS: usize = 100;
-    //     let ones = vec![1_usize; ITERS];
-    //     let mut sum: usize = 0;
-
-    //     for v in ones.iter() {
-    //         sum += ones[*v];
-    //     }
-    //     sol_log_64(0x0, 0, 0, 0, sum as u64);
-    //     assert_eq!(sum, ITERS);
-    // }
-
-    // {
-    //     // TODO test Vec::new()
-
-    //     const ITERS: usize = 100;
-    //     let mut v = Vec::new();
-
-    //     for i in 0..ITERS {
-    //         sol_log_64(i as u64, 0, 0, 0, 0);
-    //         v.push(i);
-    //     }
-    //     sol_log_64(0x4, 0, 0, 0, v.len() as u64);
-    //     assert_eq!(v.len(), ITERS);
-    // }
-
     {
         // Test allocated vector
-        const ITERS: usize = 100;
-        let ones = vec![1_u64; ITERS];
-        let mut sum: u64 = 0;
 
-        for (i, _v) in ones.iter().enumerate() {
-            sol_log_64(i as u64, 0, 0, 0, 0);
-            sum += ones[i as usize];
+        const ITERS: usize = 100;
+        let ones = vec![1_usize; ITERS];
+        let mut sum: usize = 0;
+
+        for v in ones.iter() {
+            sum += ones[*v];
         }
-        sol_log_64(0x4, 0, 0, 0, sum);
-        assert_eq!(sum, ITERS as u64);
+        sol_log_64(0x0, 0, 0, 0, sum as u64);
+        assert_eq!(sum, ITERS);
+    }
+
+    {
+        // TODO test Vec::new()
+
+        const ITERS: usize = 100;
+        let mut v = Vec::new();
+
+        for i in 0..ITERS {
+            sol_log_64(i as u64, 0, 0, 0, 0);
+            v.push(i);
+        }
+        sol_log_64(0x4, 0, 0, 0, v.len() as u64);
+        assert_eq!(v.len(), ITERS);
     }
 
     sol_log("Success");

--- a/sdk/bpf/rust-utils/src/entrypoint.rs
+++ b/sdk/bpf/rust-utils/src/entrypoint.rs
@@ -88,8 +88,7 @@ pub unsafe fn deserialize<'a>(
 
     let mut ka: [Option<SolKeyedAccount>; MAX_ACCOUNTS] =
         [None, None, None, None, None, None, None, None, None, None];
-    let iter = 0..num_ka; // This weirdness due to #issue $#4271
-    for (i, _) in iter.enumerate() {
+    for i in 0..num_ka {
         let is_signer = {
             #[allow(clippy::cast_ptr_alignment)]
             let is_signer_val = *(input.add(offset) as *const u64);

--- a/sdk/bpf/rust-utils/src/entrypoint.rs
+++ b/sdk/bpf/rust-utils/src/entrypoint.rs
@@ -147,9 +147,7 @@ pub unsafe fn deserialize<'a>(
         }
     };
 
-    let info = SolClusterInfo {
-        program_id,
-    };
+    let info = SolClusterInfo { program_id };
 
     Ok((ka, info, data))
 }


### PR DESCRIPTION
#### Problem

.iter() does not iterate without adding .enumerate().

#### Summary of Changes

Underlying BPF backend lowering issue fixed where small structs were mishandled and only one of the members returned.

Fixes #4271 

