### PR TITLE
Panic filename

### DIFF
--- a/programs/bpf/build.rs
+++ b/programs/bpf/build.rs
@@ -67,7 +67,7 @@ fn main() {
             .expect("Unable to create BPF install directory")
             .success());
 
-        let rust_programs = ["alloc", "iter", "noop"];
+        let rust_programs = ["alloc", "iter", "noop", "panic"];
         for program in rust_programs.iter() {
             println!(
                 "cargo:warning=(not a warning) Building Rust-based BPF programs: solana_bpf_rust_{}",

--- a/programs/bpf/rust/alloc/Xargo.toml
+++ b/programs/bpf/rust/alloc/Xargo.toml
@@ -1,5 +1,3 @@
-
-
 [dependencies.compiler_builtins]
 path = "../../../../sdk/bpf/rust-bpf-sysroot/src/compiler-builtins"
 features = ["c", "mem"]

--- a/programs/bpf/rust/alloc/src/lib.rs
+++ b/programs/bpf/rust/alloc/src/lib.rs
@@ -1,5 +1,4 @@
-//! @brief Example Rust-based BPF program that prints out the parameters passed to it
-
+//! @brief Example Rust-based BPF program that test dynamic memory allocation
 #![no_std]
 
 #[macro_use]

--- a/programs/bpf/rust/iter/Xargo.toml
+++ b/programs/bpf/rust/iter/Xargo.toml
@@ -1,5 +1,3 @@
-
-
 [dependencies.compiler_builtins]
 path = "../../../../sdk/bpf/rust-bpf-sysroot/src/compiler-builtins"
 features = ["c", "mem"]

--- a/programs/bpf/rust/iter/src/lib.rs
+++ b/programs/bpf/rust/iter/src/lib.rs
@@ -1,4 +1,4 @@
-//! @brief Example Rust-based BPF program that prints out the parameters passed to it
+//! @brief Example Rust-based BPF program tests loop iteration
 
 #![no_std]
 

--- a/programs/bpf/rust/noop/Xargo.toml
+++ b/programs/bpf/rust/noop/Xargo.toml
@@ -1,5 +1,3 @@
-
-
 [dependencies.compiler_builtins]
 path = "../../../../sdk/bpf/rust-bpf-sysroot/src/compiler-builtins"
 features = ["c", "mem"]

--- a/programs/bpf/rust/panic/.gitignore
+++ b/programs/bpf/rust/panic/.gitignore
@@ -1,0 +1,3 @@
+/target/
+
+Cargo.lock

--- a/programs/bpf/rust/panic/Cargo.toml
+++ b/programs/bpf/rust/panic/Cargo.toml
@@ -12,7 +12,7 @@ homepage = "https://solana.com/"
 edition = "2018"
 
 [dependencies]
-solana-sdk-bpf-utils = { path = "../../../../sdk/bpf/rust-utils", version = "0.15.0" }
+solana-sdk-bpf-utils = { path = "../../../../sdk/bpf/rust-utils", version = "0.16.0" }
 
 [workspace]
 members = []

--- a/programs/bpf/rust/panic/Cargo.toml
+++ b/programs/bpf/rust/panic/Cargo.toml
@@ -1,0 +1,22 @@
+
+# Note: This crate must be built using build.sh
+
+[package]
+name = "solana-bpf-rust-panic"
+version = "0.15.0"
+description = "Solana BPF iter program written in Rust"
+authors = ["Solana Maintainers <maintainers@solana.com>"]
+repository = "https://github.com/solana-labs/solana"
+license = "Apache-2.0"
+homepage = "https://solana.com/"
+edition = "2018"
+
+[dependencies]
+solana-sdk-bpf-utils = { path = "../../../../sdk/bpf/rust-utils", version = "0.15.0" }
+
+[workspace]
+members = []
+
+[lib]
+name = "solana_bpf_rust_panic"
+crate-type = ["cdylib"]

--- a/programs/bpf/rust/panic/Xargo.toml
+++ b/programs/bpf/rust/panic/Xargo.toml
@@ -1,8 +1,6 @@
-
-
 [dependencies.compiler_builtins]
 path = "../../../../sdk/bpf/rust-bpf-sysroot/src/compiler-builtins"
-features = ["cc"]
+features = ["c", "mem"]
 
 [target.bpfel-unknown-unknown.dependencies]
 alloc = { path = "../../../../sdk/bpf/rust-bpf-sysroot/src/liballoc" }

--- a/programs/bpf/rust/panic/Xargo.toml
+++ b/programs/bpf/rust/panic/Xargo.toml
@@ -1,0 +1,8 @@
+
+
+[dependencies.compiler_builtins]
+path = "../../../../sdk/bpf/rust-bpf-sysroot/src/compiler-builtins"
+features = ["cc"]
+
+[target.bpfel-unknown-unknown.dependencies]
+alloc = { path = "../../../../sdk/bpf/rust-bpf-sysroot/src/liballoc" }

--- a/programs/bpf/rust/panic/src/lib.rs
+++ b/programs/bpf/rust/panic/src/lib.rs
@@ -1,4 +1,4 @@
-//! @brief Example Rust-based BPF program that prints out the parameters passed to it
+//! @brief Example Rust-based BPF program that panics
 
 #![no_std]
 

--- a/programs/bpf/rust/panic/src/lib.rs
+++ b/programs/bpf/rust/panic/src/lib.rs
@@ -1,0 +1,10 @@
+//! @brief Example Rust-based BPF program that prints out the parameters passed to it
+
+#![no_std]
+
+extern crate solana_sdk_bpf_utils;
+
+#[no_mangle]
+pub extern "C" fn entrypoint(_input: *mut u8) -> bool {
+    panic!();
+}

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -37,7 +37,31 @@ use allocator_bump::BPFAllocator;
 /// are expected to enforce this
 const DEFAULT_HEAP_SIZE: usize = 32 * 1024;
 
+/// Verifies a string passed out of the program
+fn verify_string(addr: u64, ro_regions: &[MemoryRegion]) -> Result<(()), Error> {
+    for region in ro_regions.iter() {
+        if region.addr <= addr && (addr as u64) < region.addr + region.len {
+            let c_buf: *const c_char = addr as *const c_char;
+            let max_size = region.addr + region.len - addr;
+            unsafe {
+                for i in 0..max_size {
+                    if std::ptr::read(c_buf.offset(i as isize)) == 0 {
+                        return Ok(());
+                    }
+                }
+            }
+            return Err(Error::new(ErrorKind::Other, "Error, Unterminated string"));
+        }
+    }
+    Err(Error::new(
+        ErrorKind::Other,
+        "Error: Load segfault, bad string pointer",
+    ))
+}
+
 /// Abort helper functions, called when the BPF program calls `abort()`
+/// The verify function returns an error which will cause the BPF program
+/// to be halted immediately
 pub fn helper_abort_verify(
     _arg1: u64,
     _arg2: u64,
@@ -69,16 +93,29 @@ pub fn helper_abort(
 /// The verify function returns an error which will cause the BPF program
 /// to be halted immediately
 pub fn helper_sol_panic_verify(
-    _arg1: u64,
-    _arg2: u64,
-    _arg3: u64,
+    file: u64,
+    line: u64,
+    column: u64,
     _arg4: u64,
     _arg5: u64,
     _context: &mut Option<Box<Any + 'static>>,
-    _ro_regions: &[MemoryRegion],
+    ro_regions: &[MemoryRegion],
     _rw_regions: &[MemoryRegion],
 ) -> Result<(()), Error> {
-    Err(Error::new(ErrorKind::Other, "Error: BPF program Panic!"))
+    if let Ok(_) = verify_string(file, ro_regions) {
+        let c_buf: *const c_char = file as *const c_char;
+        let c_str: &CStr = unsafe { CStr::from_ptr(c_buf) };
+        if let Ok(slice) = c_str.to_str() {
+            return Err(Error::new(
+                ErrorKind::Other,
+                format!(
+                    "Error: BPF program Panicked at {}, {}:{}",
+                    slice, line, column
+                ),
+            ));
+        }
+    }
+    Err(Error::new(ErrorKind::Other, "Error: BPF program Panicked"))
 }
 pub fn helper_sol_panic(
     _arg1: u64,
@@ -105,24 +142,7 @@ pub fn helper_sol_log_verify(
     ro_regions: &[MemoryRegion],
     _rw_regions: &[MemoryRegion],
 ) -> Result<(()), Error> {
-    for region in ro_regions.iter() {
-        if region.addr <= addr && (addr as u64) < region.addr + region.len {
-            let c_buf: *const c_char = addr as *const c_char;
-            let max_size = region.addr + region.len - addr;
-            unsafe {
-                for i in 0..max_size {
-                    if std::ptr::read(c_buf.offset(i as isize)) == 0 {
-                        return Ok(());
-                    }
-                }
-            }
-            return Err(Error::new(ErrorKind::Other, "Error, Unterminated string"));
-        }
-    }
-    Err(Error::new(
-        ErrorKind::Other,
-        "Error: Load segfault, bad string pointer",
-    ))
+    verify_string(addr, ro_regions)
 }
 pub fn helper_sol_log(
     addr: u64,

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -102,7 +102,7 @@ pub fn helper_sol_panic_verify(
     ro_regions: &[MemoryRegion],
     _rw_regions: &[MemoryRegion],
 ) -> Result<(()), Error> {
-    if let Ok(_) = verify_string(file, ro_regions) {
+    if verify_string(file, ro_regions).is_ok() {
         let c_buf: *const c_char = file as *const c_char;
         let c_str: &CStr = unsafe { CStr::from_ptr(c_buf) };
         if let Ok(slice) = c_str.to_str() {


### PR DESCRIPTION
#### Problem

- Use the filename where the panic occurred caused a crash
- Panic error reporting just reports that panic occurred

#### Summary of Changes

- No more crash due to BPF backend bug fix
- Report filename:line:column where the panic occurred.

Fixes #4387
