### PR TITLE
Revert "Fix roots never being purged (#4134)"

### DIFF
--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -70,7 +70,7 @@ impl<T: Clone> AccountsIndex<T> {
     }
 
     pub fn is_purged(&self, fork: Fork) -> bool {
-        fork < self.last_root
+        !self.is_root(fork) && fork < self.last_root
     }
     pub fn is_root(&self, fork: Fork) -> bool {
         self.roots.contains(&fork)
@@ -162,8 +162,6 @@ mod tests {
         assert!(!index.is_purged(0));
         index.add_root(1);
         assert!(index.is_purged(0));
-        index.add_root(2);
-        assert!(index.is_purged(1));
     }
 
     #[test]


### PR DESCRIPTION
This reverts commit 5bb75a5894778c13006d7ad33a5a6c9a1e2fa56a.

#### Problem

Purging roots can result in some child banks having no references to accounts created in the purged root.

Flow: 
1 - Create account in some Bank N
2 - Bank N+M writes to the account causing Bank N to be purged
3 - Asking Bank N or any Bank in between about account created in N will not return anything

#### Summary of Changes

Reverted change that started purging roots.

