### PR TITLE
Facility to provision primordial accounts for fullnodes in genesis block

### DIFF
--- a/multinode-demo/fullnode.sh
+++ b/multinode-demo/fullnode.sh
@@ -29,6 +29,7 @@ Start a validator or a replicator
   --no-voting               - start node without vote signer
   --rpc-port port           - custom RPC port for this node
   --no-restart              - do not restart the node if it exits
+  --no-airdrops             - The genesis block has an account for the node. Airdrops are not required.
 
 EOF
   exit 1
@@ -97,9 +98,11 @@ setup_validator_accounts() {
   if [[ -f $configured_flag ]]; then
     echo "Vote and stake accounts have already been configured"
   else
-    # Fund the node with enough tokens to fund its Vote, Staking, and Storage accounts
-    declare fees=100 # TODO: No hardcoded transaction fees, fetch the current cluster fees
-    $solana_wallet --keypair "$node_keypair_path" --url "http://$entrypoint_ip:8899" airdrop $((node_lamports+stake_lamports+fees)) || return $?
+    if ((airdrops_enabled)); then
+      # Fund the node with enough tokens to fund its Vote, Staking, and Storage accounts
+      declare fees=100 # TODO: No hardcoded transaction fees, fetch the current cluster fees
+      $solana_wallet --keypair "$node_keypair_path" --url "http://$entrypoint_ip:8899" airdrop $((node_lamports+stake_lamports+fees)) || return $?
+    fi
 
     # Fund the vote account from the node, with the node as the node_pubkey
     $solana_wallet --keypair "$node_keypair_path" --url "http://$entrypoint_ip:8899" \
@@ -149,7 +152,9 @@ setup_replicator_account() {
   if [[ -f $configured_flag ]]; then
     echo "Replicator account has already been configured"
   else
-    $solana_wallet --keypair "$node_keypair_path" --url "http://$entrypoint_ip:8899" airdrop "$node_lamports" || return $?
+    if ((airdrops_enabled)); then
+      $solana_wallet --keypair "$node_keypair_path" --url "http://$entrypoint_ip:8899" airdrop "$node_lamports" || return $?
+    fi
 
     # Setup replicator storage account
     $solana_wallet --keypair "$node_keypair_path" --url "http://$entrypoint_ip:8899" \
@@ -179,6 +184,7 @@ poll_for_new_genesis_block=0
 label=
 identity_keypair_path=
 no_restart=0
+airdrops_enabled=1
 
 positional_args=()
 while [[ -n $1 ]]; do
@@ -233,6 +239,9 @@ while [[ -n $1 ]]; do
     elif [[ $1 = --gossip-port ]]; then
       args+=("$1" "$2")
       shift 2
+    elif [[ $1 = --no-airdrops ]]; then
+      airdrops_enabled=0
+      shift
     elif [[ $1 = -h ]]; then
       fullnode_usage "$@"
     else

--- a/multinode-demo/fullnode.sh
+++ b/multinode-demo/fullnode.sh
@@ -29,7 +29,7 @@ Start a validator or a replicator
   --no-voting               - start node without vote signer
   --rpc-port port           - custom RPC port for this node
   --no-restart              - do not restart the node if it exits
-  --no-airdrops             - The genesis block has an account for the node. Airdrops are not required.
+  --no-airdrop              - The genesis block has an account for the node. Airdrops are not required.
 
 EOF
   exit 1
@@ -102,6 +102,9 @@ setup_validator_accounts() {
       # Fund the node with enough tokens to fund its Vote, Staking, and Storage accounts
       declare fees=100 # TODO: No hardcoded transaction fees, fetch the current cluster fees
       $solana_wallet --keypair "$node_keypair_path" --url "http://$entrypoint_ip:8899" airdrop $((node_lamports+stake_lamports+fees)) || return $?
+    else
+      echo "current account balance is "
+      $solana_wallet --keypair "$node_keypair_path" --url "http://$entrypoint_ip:8899" balance || return $?
     fi
 
     # Fund the vote account from the node, with the node as the node_pubkey
@@ -154,6 +157,9 @@ setup_replicator_account() {
   else
     if ((airdrops_enabled)); then
       $solana_wallet --keypair "$node_keypair_path" --url "http://$entrypoint_ip:8899" airdrop "$node_lamports" || return $?
+    else
+      echo "current account balance is "
+      $solana_wallet --keypair "$node_keypair_path" --url "http://$entrypoint_ip:8899" balance || return $?
     fi
 
     # Setup replicator storage account
@@ -239,7 +245,7 @@ while [[ -n $1 ]]; do
     elif [[ $1 = --gossip-port ]]; then
       args+=("$1" "$2")
       shift 2
-    elif [[ $1 = --no-airdrops ]]; then
+    elif [[ $1 = --no-airdrop ]]; then
       airdrops_enabled=0
       shift
     elif [[ $1 = -h ]]; then

--- a/net/net.sh
+++ b/net/net.sh
@@ -55,6 +55,12 @@ Operate a configured testnet
                                       - Override the default --hashes-per-tick for the cluster
    -n NUM_FULL_NODES                  - Number of fullnodes to apply command to.
 
+   -x Accounts and Stakes for external nodes
+                                      - A YML file with a list of account pubkeys and corresponding stakes
+                                         for external nodes
+   -s Num lamports per node in genesis block
+                                      - Create account keypairs for internal nodes and assign these many lamports
+
  sanity/start/update-specific options:
    -F                   - Discard validator nodes that didn't bootup successfully
    -o noLedgerVerify    - Skip ledger verification

--- a/net/net.sh
+++ b/net/net.sh
@@ -333,7 +333,7 @@ startBootstrapLeader() {
          $deployMethod \
          bootstrap-leader \
          $entrypointIp \
-         $((${#fullnodeIpList[@]} + ${#blockstreamerIpList[@]})) \
+         $((${#fullnodeIpList[@]} + ${#blockstreamerIpList[@]} + ${#replicatorIpList[@]})) \
          \"$RUST_LOG\" \
          $skipSetup \
          $failOnValidatorBootupFailure \
@@ -365,7 +365,7 @@ startNode() {
          $deployMethod \
          $nodeType \
          $entrypointIp \
-         $((${#fullnodeIpList[@]} + ${#blockstreamerIpList[@]})) \
+         $((${#fullnodeIpList[@]} + ${#blockstreamerIpList[@]} + ${#replicatorIpList[@]})) \
          \"$RUST_LOG\" \
          $skipSetup \
          $failOnValidatorBootupFailure \

--- a/net/net.sh
+++ b/net/net.sh
@@ -87,7 +87,7 @@ numBenchExchangeClients=0
 benchTpsExtraArgs=
 benchExchangeExtraArgs=
 failOnValidatorBootupFailure=true
-genesisOptions="--primordial-accounts-file ~/solana/solana-node-stakes/fullnode-stakes.yml"
+genesisOptions=
 numFullnodesRequested=
 externalPrimordialAccountsFile=
 stakeNodesInGenesisBlock=
@@ -292,7 +292,7 @@ startCommon() {
   fi
   [[ -z "$externalNodeSshKey" ]] || ssh-copy-id -f -i "$externalNodeSshKey" "${sshOptions[@]}" "solana@$ipAddress"
   rsync -vPrc -e "ssh ${sshOptions[*]}" \
-    "$SOLANA_ROOT"/{fetch-perf-libs.sh,scripts,net,multinode-demo,solana-node-keys/"$ipAddress"} \
+    "$SOLANA_ROOT"/{fetch-perf-libs.sh,scripts,net,multinode-demo} \
     "$ipAddress":~/solana/
 }
 
@@ -455,7 +455,6 @@ deployUpdate() {
 }
 
 start() {
-  declare keygen=
   case $deployMethod in
   tar)
     if [[ -n $releaseChannel ]]; then
@@ -477,12 +476,10 @@ start() {
       rm -rf "$SOLANA_ROOT"/solana-release
       (cd "$SOLANA_ROOT"; tar jxv) < "$tarballFilename"
       cat "$SOLANA_ROOT"/solana-release/version.yml
-      keygen="$SOLANA_ROOT"/solana-release/bin/solana-keygen
     )
     ;;
   local)
     build
-    keygen="$SOLANA_ROOT"/target/release/solana-keygen
     ;;
   *)
     usage "Internal error: invalid deployMethod: $deployMethod"
@@ -495,16 +492,6 @@ start() {
   else
     $metricsWriteDatapoint "testnet-deploy net-start-begin=1"
   fi
-
-  set -x
-  rm -rf "$SOLANA_ROOT"/solana-node-keys
-  rm -rf "$SOLANA_ROOT"/solana-node-stakes
-  mkdir "$SOLANA_ROOT"/solana-node-stakes
-  for ipAddress in "${fullnodeIpList[@]}" "${blockstreamerIpList[@]}"; do
-    "$keygen" new -o "$SOLANA_ROOT"/solana-node-keys/"$ipAddress"
-    pubkey="$($keygen pubkey $SOLANA_ROOT/solana-node-keys/$ipAddress)"
-    echo "${pubkey}: 200" >> "$SOLANA_ROOT"/solana-node-stakes/fullnode-stakes.yml
-  done
 
   declare bootstrapLeader=true
   declare nodeType=validator

--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -84,7 +84,7 @@ local|tar)
     rm -rf ./solana-node-stakes
     mkdir ./solana-node-stakes
     if [[ -n $stakeNodesInGenesisBlock ]]; then
-      for i in $(seq 1 "$numNodes"); do
+      for i in $(seq 0 "$numNodes"); do
         solana-keygen new -o ./solana-node-keys/"$i"
         pubkey="$(solana-keygen pubkey ./solana-node-keys/"$i")"
         echo "${pubkey}: $stakeNodesInGenesisBlock" >> ./solana-node-stakes/fullnode-stakes.yml

--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -84,13 +84,13 @@ local|tar)
     rm -rf ./solana-node-stakes
     mkdir ./solana-node-stakes
     if [[ -n $stakeNodesInGenesisBlock ]]; then
-      for i in $(seq 1 $numNodes); do
+      for i in $(seq 1 "$numNodes"); do
         solana-keygen new -o ./solana-node-keys/"$i"
-        pubkey="$(solana-keygen pubkey ./solana-node-keys/$i)"
+        pubkey="$(solana-keygen pubkey ./solana-node-keys/"$i")"
         echo "${pubkey}: $stakeNodesInGenesisBlock" >> ./solana-node-stakes/fullnode-stakes.yml
       done
     fi
-    [[ -z $externalPrimordialAccountsFile ]] || cat $externalPrimordialAccountsFile >> ./solana-node-stakes/fullnode-stakes.yml
+    [[ -z $externalPrimordialAccountsFile ]] || cat "$externalPrimordialAccountsFile" >> ./solana-node-stakes/fullnode-stakes.yml
     if [ -f ./solana-node-stakes/fullnode-stakes.yml ]; then
       genesisOptions+=" --primordial-accounts-file ./solana-node-stakes/fullnode-stakes.yml"
     fi

--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -85,7 +85,7 @@ local|tar)
     mkdir ./solana-node-stakes
     if [[ -n $stakeNodesInGenesisBlock ]]; then
       for i in $(seq 1 "$numNodes"); do
-        solana-keygen new -f -o ./solana-node-keys/"$i"
+        solana-keygen new -o ./solana-node-keys/"$i"
         pubkey="$(solana-keygen pubkey ./solana-node-keys/"$i")"
         echo "${pubkey}: $stakeNodesInGenesisBlock" >> ./solana-node-stakes/fullnode-stakes.yml
       done

--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -85,7 +85,7 @@ local|tar)
     mkdir ./solana-node-stakes
     if [[ -n $stakeNodesInGenesisBlock ]]; then
       for i in $(seq 1 "$numNodes"); do
-        solana-keygen new -o ./solana-node-keys/"$i"
+        solana-keygen new -f -o ./solana-node-keys/"$i"
         pubkey="$(solana-keygen pubkey ./solana-node-keys/"$i")"
         echo "${pubkey}: $stakeNodesInGenesisBlock" >> ./solana-node-stakes/fullnode-stakes.yml
       done
@@ -110,7 +110,7 @@ local|tar)
     )
 
     if [[ -n $stakeNodesInGenesisBlock ]]; then
-      args+=(--no-airdrops)
+      args+=(--no-airdrop)
     fi
     nohup ./multinode-demo/validator.sh --bootstrap-leader "${args[@]}" > fullnode.log 2>&1 &
     sleep 1
@@ -142,12 +142,12 @@ local|tar)
       args+=(--enable-rpc-exit)
     fi
 
-    if [ -f ~/solana/fullnode-identity.json ]; then
+    if [[ -f ~/solana/fullnode-identity.json ]]; then
       args+=(--identity ~/solana/fullnode-identity.json)
     fi
 
     if [[ -n $stakeNodesInGenesisBlock ]]; then
-      args+=(--no-airdrops)
+      args+=(--no-airdrop)
     fi
 
     set -x
@@ -190,7 +190,7 @@ local|tar)
     )
 
     if [[ -n $stakeNodesInGenesisBlock ]]; then
-      args+=(--no-airdrops)
+      args+=(--no-airdrop)
     fi
 
     if [[ $skipSetup != true ]]; then

--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -11,7 +11,10 @@ numNodes="$4"
 RUST_LOG="$5"
 skipSetup="$6"
 failOnValidatorBootupFailure="$7"
-genesisOptions="$8"
+externalPrimordialAccountsFile="$8"
+stakeNodesInGenesisBlock="$9"
+nodeIndex="${10}"
+genesisOptions="${11}"
 set +x
 export RUST_LOG
 
@@ -77,6 +80,20 @@ local|tar)
       export SOLANA_CUDA=1
     fi
     set -x
+    rm -rf ./solana-node-keys
+    rm -rf ./solana-node-stakes
+    mkdir ./solana-node-stakes
+    if [[ -n $stakeNodesInGenesisBlock ]]; then
+      for i in $(seq 1 $nodeNodes); do
+        solana-keygen new -o ./solana-node-keys/"$i"
+        pubkey="$(solana-keygen pubkey ./solana-node-keys/$i)"
+        echo "${pubkey}: $stakeNodesInGenesisBlock" >> ./solana-node-stakes/fullnode-stakes.yml
+      done
+    fi
+    [[ -z $externalPrimordialAccountsFile ]] || cat $externalPrimordialAccountsFile >> ./solana-node-stakes/fullnode-stakes.yml
+    if [ -f ./solana-node-stakes/fullnode-stakes.yml ]; then
+      genesisOptions+=" --primordial-accounts-file ~/solana/solana-node-stakes/fullnode-stakes.yml"
+    fi
     if [[ $skipSetup != true ]]; then
       args=(
         --bootstrap-leader-stake-lamports "$stake"
@@ -97,6 +114,9 @@ local|tar)
     ;;
   validator|blockstreamer)
     net/scripts/rsync-retry.sh -vPrc "$entrypointIp":~/.cargo/bin/ ~/.cargo/bin/
+    rm -f ~/solana/fullnode-identity.json
+    [[ -z $stakeNodesInGenesisBlock ]] || net/scripts/rsync-retry.sh -vPrc \
+    "$entrypointIp":~/solana/solana-node-keys/"$nodeIndex" ~/solana/fullnode-identity.json
 
     if [[ -e /dev/nvidia0 && -x ~/.cargo/bin/solana-validator-cuda ]]; then
       echo Selecting solana-validator-cuda
@@ -117,6 +137,10 @@ local|tar)
     else
       args+=(--stake "$stake")
       args+=(--enable-rpc-exit)
+    fi
+
+    if [ -f ~/solana/fullnode-identity.json ]; then
+      args+=(--identity ~/solana/fullnode-identity.json)
     fi
 
     set -x

--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -109,6 +109,9 @@ local|tar)
       --gossip-port "$entrypointIp":8001
     )
 
+    if [[ -n $stakeNodesInGenesisBlock ]]; then
+      args+=(--no-airdrops)
+    fi
     nohup ./multinode-demo/validator.sh --bootstrap-leader "${args[@]}" > fullnode.log 2>&1 &
     sleep 1
     ;;
@@ -141,6 +144,10 @@ local|tar)
 
     if [ -f ~/solana/fullnode-identity.json ]; then
       args+=(--identity ~/solana/fullnode-identity.json)
+    fi
+
+    if [[ -n $stakeNodesInGenesisBlock ]]; then
+      args+=(--no-airdrops)
     fi
 
     set -x
@@ -181,6 +188,11 @@ local|tar)
     args=(
       "$entrypointIp":~/solana "$entrypointIp:8001"
     )
+
+    if [[ -n $stakeNodesInGenesisBlock ]]; then
+      args+=(--no-airdrops)
+    fi
+
     if [[ $skipSetup != true ]]; then
       ./multinode-demo/clear-config.sh
     fi

--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -92,7 +92,7 @@ local|tar)
     fi
     [[ -z $externalPrimordialAccountsFile ]] || cat $externalPrimordialAccountsFile >> ./solana-node-stakes/fullnode-stakes.yml
     if [ -f ./solana-node-stakes/fullnode-stakes.yml ]; then
-      genesisOptions+=" --primordial-accounts-file ~/solana/solana-node-stakes/fullnode-stakes.yml"
+      genesisOptions+=" --primordial-accounts-file ./solana-node-stakes/fullnode-stakes.yml"
     fi
     if [[ $skipSetup != true ]]; then
       args=(

--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -84,7 +84,7 @@ local|tar)
     rm -rf ./solana-node-stakes
     mkdir ./solana-node-stakes
     if [[ -n $stakeNodesInGenesisBlock ]]; then
-      for i in $(seq 1 $nodeNodes); do
+      for i in $(seq 1 $numNodes); do
         solana-keygen new -o ./solana-node-keys/"$i"
         pubkey="$(solana-keygen pubkey ./solana-node-keys/$i)"
         echo "${pubkey}: $stakeNodesInGenesisBlock" >> ./solana-node-stakes/fullnode-stakes.yml


### PR DESCRIPTION
#### Problem
The testnet scripts do not support creation and assignment of primordial account for nodes.

#### Summary of Changes
Updated testnet scripts for
1. Provide a YAML file with account pubkey and corresponding lamports for external nodes
2. Configure internal nodes with accounts and lamports provisioned in genesis block 
3. Fixed genesis block code to use simple strings for YAML parsing