### PR TITLE
Merklize PoH TX mixin hash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2201,6 +2201,7 @@ dependencies = [
  "solana-exchange-program 0.17.0",
  "solana-kvstore 0.17.0",
  "solana-logger 0.17.0",
+ "solana-merkle-tree 0.17.0",
  "solana-metrics 0.17.0",
  "solana-netutil 0.17.0",
  "solana-runtime 0.17.0",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -55,6 +55,7 @@ solana-ed25519-dalek = "0.2.0"
 solana-exchange-program = { path = "../programs/exchange_program", version = "0.17.0" }
 solana-kvstore = { path = "../kvstore", version = "0.17.0", optional = true }
 solana-logger = { path = "../logger", version = "0.17.0" }
+solana-merkle-tree = { path = "../merkle-tree", version = "0.17.0" }
 solana-metrics = { path = "../metrics", version = "0.17.0" }
 solana-netutil = { path = "../netutil", version = "0.17.0" }
 solana-runtime = { path = "../runtime", version = "0.17.0" }

--- a/core/src/entry.rs
+++ b/core/src/entry.rs
@@ -10,8 +10,9 @@ use chrono::prelude::Utc;
 use rayon::prelude::*;
 use rayon::ThreadPool;
 use solana_budget_api::budget_instruction;
+use solana_merkle_tree::MerkleTree;
 use solana_metrics::inc_new_counter_warn;
-use solana_sdk::hash::{Hash, Hasher};
+use solana_sdk::hash::Hash;
 use solana_sdk::signature::{Keypair, KeypairUtil};
 use solana_sdk::transaction::Transaction;
 use std::borrow::Borrow;
@@ -172,13 +173,16 @@ impl Entry {
 
 pub fn hash_transactions(transactions: &[Transaction]) -> Hash {
     // a hash of a slice of transactions only needs to hash the signatures
-    let mut hasher = Hasher::default();
-    transactions.iter().for_each(|tx| {
-        if !tx.signatures.is_empty() {
-            hasher.hash(&tx.signatures[0].as_ref());
-        }
-    });
-    hasher.result()
+    let signatures: Vec<_> = transactions
+        .iter()
+        .map(|tx| tx.signatures[0].as_ref())
+        .collect();
+    let merkle_tree = MerkleTree::new(&signatures);
+    if let Some(root_hash) = merkle_tree.get_root() {
+        *root_hash
+    } else {
+        Hash::default()
+    }
 }
 
 /// Creates the hash `num_hashes` after `start_hash`. If the transaction contains

--- a/core/src/entry.rs
+++ b/core/src/entry.rs
@@ -175,7 +175,7 @@ pub fn hash_transactions(transactions: &[Transaction]) -> Hash {
     // a hash of a slice of transactions only needs to hash the signatures
     let signatures: Vec<_> = transactions
         .iter()
-        .map(|tx| tx.signatures[0].as_ref())
+        .flat_map(|tx| tx.signatures.iter().map(|sig| sig.as_ref()))
         .collect();
     let merkle_tree = MerkleTree::new(&signatures);
     if let Some(root_hash) = merkle_tree.get_root() {


### PR DESCRIPTION
Requires https://github.com/solana-labs/solana/pull/4749

#### Problem
This is a first step towards SPV. We will need a way to generate short proofs that a transaction has been included in a specific block. A Merkle Tree is typically used to achieve this.  Use the Merkle root to replace the PoH mixin hash for now and have it available for implementing light entries later

#### Summary of Changes
Replace PoH TX mixin hash with Merkle root

