### PR TITLE
Witness account data in Budget

### DIFF
--- a/programs/budget_api/src/budget_instruction.rs
+++ b/programs/budget_api/src/budget_instruction.rs
@@ -140,11 +140,7 @@ pub fn apply_signature(from: &Pubkey, contract: &Pubkey, to: &Pubkey) -> Instruc
     Instruction::new(id(), &BudgetInstruction::ApplySignature, account_metas)
 }
 
-pub fn apply_account_data(
-    account: &Pubkey,
-    contract: &Pubkey,
-    to: &Pubkey,
-) -> Instruction {
+pub fn apply_account_data(account: &Pubkey, contract: &Pubkey, to: &Pubkey) -> Instruction {
     let account_metas = vec![
         AccountMeta::new(*account, false),
         AccountMeta::new(*contract, false),

--- a/programs/budget_api/src/budget_instruction.rs
+++ b/programs/budget_api/src/budget_instruction.rs
@@ -140,9 +140,10 @@ pub fn apply_signature(from: &Pubkey, contract: &Pubkey, to: &Pubkey) -> Instruc
     Instruction::new(id(), &BudgetInstruction::ApplySignature, account_metas)
 }
 
-pub fn apply_account_data(account: &Pubkey, contract: &Pubkey, to: &Pubkey) -> Instruction {
+/// Apply account data to a contract waiting on an AccountData witness.
+pub fn apply_account_data(witness_pubkey: &Pubkey, contract: &Pubkey, to: &Pubkey) -> Instruction {
     let account_metas = vec![
-        AccountMeta::new(*account, false),
+        AccountMeta::new(*witness_pubkey, false),
         AccountMeta::new(*contract, false),
         AccountMeta::new(*to, false),
     ];

--- a/programs/budget_api/src/budget_instruction.rs
+++ b/programs/budget_api/src/budget_instruction.rs
@@ -21,7 +21,7 @@ pub struct Contract {
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub enum BudgetInstruction {
     /// Declare and instantiate `BudgetExpr`.
-    InitializeAccount(BudgetExpr),
+    InitializeAccount(Box<BudgetExpr>),
 
     /// Tell a payment plan acknowledge the given `DateTime` has past.
     ApplyTimestamp(DateTime<Utc>),
@@ -40,7 +40,11 @@ fn initialize_account(contract: &Pubkey, expr: BudgetExpr) -> Instruction {
         keys.push(AccountMeta::new(payment.to, false));
     }
     keys.push(AccountMeta::new(*contract, false));
-    Instruction::new(id(), &BudgetInstruction::InitializeAccount(expr), keys)
+    Instruction::new(
+        id(),
+        &BudgetInstruction::InitializeAccount(Box::new(expr)),
+        keys,
+    )
 }
 
 pub fn create_account(

--- a/programs/budget_api/src/budget_instruction.rs
+++ b/programs/budget_api/src/budget_instruction.rs
@@ -141,19 +141,15 @@ pub fn apply_signature(from: &Pubkey, contract: &Pubkey, to: &Pubkey) -> Instruc
 }
 
 pub fn apply_account_data(
-    from: &Pubkey,
-    contract: &Pubkey,
     account: &Pubkey,
+    contract: &Pubkey,
     to: &Pubkey,
 ) -> Instruction {
-    let mut account_metas = vec![
-        AccountMeta::new(*from, true),
-        AccountMeta::new(*contract, false),
+    let account_metas = vec![
         AccountMeta::new(*account, false),
+        AccountMeta::new(*contract, false),
+        AccountMeta::new(*to, false),
     ];
-    if from != to {
-        account_metas.push(AccountMeta::new(*to, false));
-    }
     Instruction::new(id(), &BudgetInstruction::ApplyAccountData, account_metas)
 }
 

--- a/programs/budget_api/src/budget_instruction.rs
+++ b/programs/budget_api/src/budget_instruction.rs
@@ -99,11 +99,17 @@ pub fn when_account_data(
     to: &Pubkey,
     contract: &Pubkey,
     account_pubkey: &Pubkey,
+    account_program_id: &Pubkey,
     account_hash: Hash,
     lamports: u64,
 ) -> Vec<Instruction> {
-    let expr =
-        BudgetExpr::new_payment_when_account_data(account_pubkey, account_hash, lamports, to);
+    let expr = BudgetExpr::new_payment_when_account_data(
+        account_pubkey,
+        account_program_id,
+        account_hash,
+        lamports,
+        to,
+    );
     create_account(from, contract, lamports, expr)
 }
 

--- a/programs/budget_api/src/budget_processor.rs
+++ b/programs/budget_api/src/budget_processor.rs
@@ -80,9 +80,11 @@ fn apply_account_data(
     let mut final_payment = None;
 
     if let Some(ref mut expr) = budget_state.pending_budget {
-        let key = keyed_accounts[2].unsigned_key();
-        let actual_hash = hash(&keyed_accounts[2].account.data);
-        expr.apply_witness(&Witness::AccountData(actual_hash), key);
+        let witness_keyed_account = &keyed_accounts[2];
+        let key = witness_keyed_account.unsigned_key();
+        let program_id = witness_keyed_account.account.owner;
+        let actual_hash = hash(&witness_keyed_account.account.data);
+        expr.apply_witness(&Witness::AccountData(actual_hash, program_id), key);
         final_payment = expr.final_payment();
     }
 
@@ -468,6 +470,7 @@ mod tests {
             &bob_pubkey,
             &budget_pubkey,
             &game_pubkey,
+            &game_account.owner,
             game_hash,
             1,
         );

--- a/programs/budget_api/src/budget_processor.rs
+++ b/programs/budget_api/src/budget_processor.rs
@@ -456,7 +456,7 @@ mod tests {
             data: vec![1, 2, 3],
             ..Account::default()
         };
-        bank.store(&game_pubkey, &game_account);
+        bank.store_account(&game_pubkey, &game_account);
         assert_eq!(bank.get_account(&game_pubkey).unwrap().data, vec![1, 2, 3]);
 
         let bank_client = BankClient::new(bank);

--- a/programs/budget_api/src/budget_processor.rs
+++ b/programs/budget_api/src/budget_processor.rs
@@ -126,7 +126,7 @@ pub fn process_instruction(
                 return Err(InstructionError::AccountAlreadyInitialized);
             }
             let mut budget_state = BudgetState::default();
-            budget_state.pending_budget = Some(expr);
+            budget_state.pending_budget = Some(*expr);
             budget_state.initialized = true;
             budget_state.serialize(&mut keyed_accounts[0].account.data)
         }

--- a/programs/budget_api/src/budget_processor.rs
+++ b/programs/budget_api/src/budget_processor.rs
@@ -468,7 +468,9 @@ mod tests {
         let bob_pubkey = bob_keypair.pubkey();
 
         // Give Bob some lamports so he can sign the witness transaction.
-        bank_client.transfer(1, &alice_keypair, &bob_pubkey).unwrap();
+        bank_client
+            .transfer(1, &alice_keypair, &bob_pubkey)
+            .unwrap();
 
         let instructions = budget_instruction::when_account_data(
             &alice_pubkey,
@@ -494,18 +496,13 @@ mod tests {
         assert!(budget_state.is_pending());
 
         // Acknowledge the condition occurred and that Bob's funds are now available.
-        let instruction = budget_instruction::apply_account_data(
-            &game_pubkey,
-            &budget_pubkey,
-            &bob_pubkey,
-        );
+        let instruction =
+            budget_instruction::apply_account_data(&game_pubkey, &budget_pubkey, &bob_pubkey);
 
         // Anyone can sign the message, but presumably it's Bob, since he's the
         // one claiming the payout.
         let message = Message::new_with_payer(vec![instruction], Some(&bob_pubkey));
-        bank_client
-            .send_message(&[&bob_keypair], message)
-            .unwrap();
+        bank_client.send_message(&[&bob_keypair], message).unwrap();
 
         assert_eq!(bank_client.get_balance(&alice_pubkey).unwrap(), 0);
         assert_eq!(bank_client.get_balance(&budget_pubkey).unwrap(), 0);

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -379,7 +379,7 @@ impl Bank {
         };
         current.to(&mut account).unwrap();
 
-        self.store(&current::id(), &account);
+        self.store_account(&current::id(), &account);
     }
 
     fn update_slot_hashes(&self) {
@@ -391,7 +391,7 @@ impl Bank {
         slot_hashes.add(self.slot(), self.hash());
         slot_hashes.to(&mut account).unwrap();
 
-        self.store(&slot_hashes::id(), &account);
+        self.store_account(&slot_hashes::id(), &account);
     }
 
     fn update_fees(&self) {
@@ -403,7 +403,7 @@ impl Bank {
         fees.fee_calculator = self.fee_calculator.clone();
         fees.to(&mut account).unwrap();
 
-        self.store(&fees::id(), &account);
+        self.store_account(&fees::id(), &account);
     }
 
     fn update_tick_height(&self) {
@@ -413,7 +413,7 @@ impl Bank {
 
         TickHeight::to(self.tick_height(), &mut account).unwrap();
 
-        self.store(&tick_height::id(), &account);
+        self.store_account(&tick_height::id(), &account);
     }
 
     fn set_hash(&self) -> bool {
@@ -482,7 +482,7 @@ impl Bank {
         self.update_fees();
 
         for (pubkey, account) in genesis_block.accounts.iter() {
-            self.store(pubkey, account);
+            self.store_account(pubkey, account);
             self.capitalization
                 .fetch_add(account.lamports as usize, Ordering::Relaxed);
         }
@@ -526,7 +526,7 @@ impl Bank {
     pub fn register_native_instruction_processor(&self, name: &str, program_id: &Pubkey) {
         debug!("Adding native program {} under {:?}", name, program_id);
         let account = native_loader::create_loadable_account(name);
-        self.store(program_id, &account);
+        self.store_account(program_id, &account);
     }
 
     /// Return the last block hash registered.
@@ -930,7 +930,7 @@ impl Bank {
                     Err(TransactionError::InstructionError(_, _)) => {
                         // credit the transaction fee even in case of InstructionError
                         // necessary to withdraw from account[0] here because previous
-                        // work of doing so (in accounts.load()) is ignored by store()
+                        // work of doing so (in accounts.load()) is ignored by store_account()
                         self.withdraw(&message.account_keys[0], fee)?;
                         fees += fee;
                         Ok(())
@@ -1034,7 +1034,7 @@ impl Bank {
         parents
     }
 
-    pub fn store(&self, pubkey: &Pubkey, account: &Account) {
+    pub fn store_account(&self, pubkey: &Pubkey, account: &Account) {
         self.rc.accounts.store_slow(self.slot(), pubkey, account);
 
         if Stakes::is_stake(account) {
@@ -1055,7 +1055,7 @@ impl Bank {
                 }
 
                 account.lamports -= lamports;
-                self.store(pubkey, &account);
+                self.store_account(pubkey, &account);
 
                 Ok(())
             }
@@ -1066,7 +1066,7 @@ impl Bank {
     pub fn deposit(&self, pubkey: &Pubkey, lamports: u64) {
         let mut account = self.get_account(pubkey).unwrap_or_default();
         account.lamports += lamports;
-        self.store(pubkey, &account);
+        self.store_account(pubkey, &account);
     }
 
     pub fn accounts(&self) -> Arc<Accounts> {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1034,7 +1034,7 @@ impl Bank {
         parents
     }
 
-    fn store(&self, pubkey: &Pubkey, account: &Account) {
+    pub fn store(&self, pubkey: &Pubkey, account: &Account) {
         self.rc.accounts.store_slow(self.slot(), pubkey, account);
 
         if Stakes::is_stake(account) {


### PR DESCRIPTION
#### Problem

A Budget contract can move lamports in response to a signature or a timestamp. It can't move lamports in response to an account containing certain data.

For example, if someone wanted to move lamports to another account if some user Alice won a particular game of tic tac toe, they should be able to create a Budget contract that sends lamports if shown the account with tic tac toe state that represents a win.

#### Summary of Changes

* Added a `Condition::AccountData(AccountConditions)` contract and an `ApplyAccountData` witness. To process `ApplyAccountData`, the budget program checks that the pubkey of the provided account and the hash of its account data meet the constraints passed into `Condition::AccountData`.
* Make `Bank::store` pub (and rename it to `store_account()` since the bank may store other things)

- [x] Add `program_id: Pubkey` to `Condition::AccountData`. Otherwise it's too easy to repurpose the account to include whatever data an attacker needs it to be as soon as the original account's lamports falls to zero.
- [x] Add more tests, such as checking account 0 takes the fee

Fixes #4602
