### PR TITLE
chore: bump blockexplorer version for testnet to include object expiration

### DIFF
--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -131,7 +131,7 @@ local|tar)
       ./multinode-demo/drone.sh > drone.log 2>&1 &
 
       export BLOCKEXPLORER_GEOIP_WHITELIST=$PWD/net/config/geoip.yml
-      npm install @solana/blockexplorer@1.8.12
+      npm install @solana/blockexplorer@1.9.0
       npx solana-blockexplorer > blockexplorer.log 2>&1 &
 
       # Confirm the blockexplorer is accessible


### PR DESCRIPTION
#### Problem

* testnet needs fix for object expiration

#### Summary of Changes

* use the new blockexplorer 1.9.0 build

Fixes #
