### PR TITLE
Update stakers_slot_offset if slots_per_epoch is adjusted

### DIFF
--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -330,6 +330,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
 
     genesis_block.ticks_per_slot = value_t_or_exit!(matches, "ticks_per_slot", u64);
     genesis_block.slots_per_epoch = value_t_or_exit!(matches, "slots_per_epoch", u64);
+    genesis_block.stakers_slot_offset = genesis_block.slots_per_epoch;
     genesis_block.poh_config.target_tick_duration =
         Duration::from_millis(value_t_or_exit!(matches, "target_tick_duration", u64));
 


### PR DESCRIPTION
#### Problem
Supplying the `--slots-per-epoch` arg to `solana-genesis` can cause the `stakers_slot_offset` value to go bad due to this coupling:
https://github.com/solana-labs/solana/blob/0dcdc37fec7e2c3db2df58bbea90eb1d18727cb4/sdk/src/genesis_block.rs#L51-L52

#### Summary of Changes
The `--slots-per-epoch` now sets both `slots_per_epoch` and `stakers_slot_offset`