### PR TITLE
Add test to exercise more args then registers

### DIFF
--- a/programs/bpf/build.rs
+++ b/programs/bpf/build.rs
@@ -67,7 +67,7 @@ fn main() {
             .expect("Unable to create BPF install directory")
             .success());
 
-        let rust_programs = ["alloc", "dep_crate", "iter", "noop", "panic"];
+        let rust_programs = ["alloc", "dep_crate", "iter", "many_args", "noop", "panic"];
         for program in rust_programs.iter() {
             println!(
                 "cargo:warning=(not a warning) Building Rust-based BPF programs: solana_bpf_rust_{}",

--- a/programs/bpf/rust/many_args/.gitignore
+++ b/programs/bpf/rust/many_args/.gitignore
@@ -1,0 +1,3 @@
+/target/
+
+Cargo.lock

--- a/programs/bpf/rust/many_args/Cargo.toml
+++ b/programs/bpf/rust/many_args/Cargo.toml
@@ -1,0 +1,23 @@
+
+# Note: This crate must be built using build.sh
+
+[package]
+name = "solana-bpf-rust-many-args"
+version = "0.16.0"
+description = "Solana BPF many-args program written in Rust"
+authors = ["Solana Maintainers <maintainers@solana.com>"]
+repository = "https://github.com/solana-labs/solana"
+license = "Apache-2.0"
+homepage = "https://solana.com/"
+edition = "2018"
+
+[dependencies]
+solana-sdk-bpf-utils = { path = "../../../../sdk/bpf/rust-utils", version = "0.16.0" }
+solana-bpf-rust-many-args-dep = { path = "../many_args_dep", version = "0.16.0" }
+
+[workspace]
+members = []
+
+[lib]
+crate-type = ["cdylib"]
+name = "solana_bpf_rust_many_args"

--- a/programs/bpf/rust/many_args/Xargo.toml
+++ b/programs/bpf/rust/many_args/Xargo.toml
@@ -1,0 +1,6 @@
+[dependencies.compiler_builtins]
+path = "../../../../sdk/bpf/rust-bpf-sysroot/src/compiler-builtins"
+features = ["c", "mem"]
+
+[target.bpfel-unknown-unknown.dependencies]
+alloc = { path = "../../../../sdk/bpf/rust-bpf-sysroot/src/liballoc" }

--- a/programs/bpf/rust/many_args/src/helper.rs
+++ b/programs/bpf/rust/many_args/src/helper.rs
@@ -1,0 +1,22 @@
+//! @brief Example Rust-based BPF program tests loop iteration
+
+extern crate solana_sdk_bpf_utils;
+
+use solana_sdk_bpf_utils::log::*;
+
+pub fn many_args(
+    arg1: u64,
+    arg2: u64,
+    arg3: u64,
+    arg4: u64,
+    arg5: u64,
+    arg6: u64,
+    arg7: u64,
+    arg8: u64,
+    arg9: u64,
+) -> u64 {
+    sol_log("same package");
+    sol_log_64(arg1, arg2, arg3, arg4, arg5);
+    sol_log_64(arg6, arg7, arg8, arg9, 0);
+    arg1 + arg2 + arg3 + arg4 + arg5 + arg6 + arg7 + arg8 + arg9
+}

--- a/programs/bpf/rust/many_args/src/lib.rs
+++ b/programs/bpf/rust/many_args/src/lib.rs
@@ -1,0 +1,23 @@
+//! @brief Example Rust-based BPF program tests loop iteration
+
+#![no_std]
+
+mod helper;
+
+extern crate solana_sdk_bpf_utils;
+
+use solana_sdk_bpf_utils::log::*;
+
+#[no_mangle]
+pub extern "C" fn entrypoint(_input: *mut u8) -> bool {
+    sol_log("call same package");
+    assert_eq!(crate::helper::many_args(1, 2, 3, 4, 5, 6, 7, 8, 9), 45);
+    sol_log("call another package");
+    assert_eq!(
+        solana_bpf_rust_many_args_dep::many_args(1, 2, 3, 4, 5, 6, 7, 8, 9),
+        45
+    );
+
+    sol_log("Success");
+    true
+}

--- a/programs/bpf/rust/many_args_dep/.gitignore
+++ b/programs/bpf/rust/many_args_dep/.gitignore
@@ -1,0 +1,3 @@
+/target/
+
+Cargo.lock

--- a/programs/bpf/rust/many_args_dep/Cargo.toml
+++ b/programs/bpf/rust/many_args_dep/Cargo.toml
@@ -1,0 +1,19 @@
+
+# Note: This crate must be built using build.sh
+
+[package]
+name = "solana-bpf-rust-many-args-dep"
+version = "0.16.0"
+description = "Solana BPF many-args-dep program written in Rust"
+authors = ["Solana Maintainers <maintainers@solana.com>"]
+repository = "https://github.com/solana-labs/solana"
+license = "Apache-2.0"
+homepage = "https://solana.com/"
+edition = "2018"
+
+[dependencies]
+solana-sdk-bpf-utils = { path = "../../../../sdk/bpf/rust-utils", version = "0.16.0" }
+
+[workspace]
+members = []
+

--- a/programs/bpf/rust/many_args_dep/src/lib.rs
+++ b/programs/bpf/rust/many_args_dep/src/lib.rs
@@ -1,0 +1,24 @@
+//! @brief Solana Rust-based BPF program utility functions and types
+
+#![no_std]
+
+extern crate solana_sdk_bpf_utils;
+
+use solana_sdk_bpf_utils::log::*;
+
+pub fn many_args(
+    arg1: u64,
+    arg2: u64,
+    arg3: u64,
+    arg4: u64,
+    arg5: u64,
+    arg6: u64,
+    arg7: u64,
+    arg8: u64,
+    arg9: u64,
+) -> u64 {
+    sol_log("another package");
+    sol_log_64(arg1, arg2, arg3, arg4, arg5);
+    sol_log_64(arg6, arg7, arg8, arg9, 0);
+    arg1 + arg2 + arg3 + arg4 + arg5 + arg6 + arg7 + arg8 + arg9
+}

--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -115,11 +115,12 @@ mod bpf {
             solana_logger::setup();
 
             let programs = [
-                ("solana_bpf_rust_alloc", true),
-                ("solana_bpf_rust_iter", true),
-                ("solana_bpf_rust_noop", true),
-                ("solana_bpf_rust_dep_crate", true),
-                ("solana_bpf_rust_panic", false),
+                // ("solana_bpf_rust_alloc", true),
+                // ("solana_bpf_rust_iter", true),
+                ("solana_bpf_rust_many_args", true),
+                // ("solana_bpf_rust_noop", true),
+                // ("solana_bpf_rust_dep_crate", true),
+                // ("solana_bpf_rust_panic", false),
             ];
             for program in programs.iter() {
                 let filename = create_bpf_path(program.0);

--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -115,12 +115,12 @@ mod bpf {
             solana_logger::setup();
 
             let programs = [
-                // ("solana_bpf_rust_alloc", true),
-                // ("solana_bpf_rust_iter", true),
-                ("solana_bpf_rust_many_args", true),
-                // ("solana_bpf_rust_noop", true),
-                // ("solana_bpf_rust_dep_crate", true),
-                // ("solana_bpf_rust_panic", false),
+                ("solana_bpf_rust_alloc", true),
+                ("solana_bpf_rust_iter", true),
+                // ("solana_bpf_rust_many_args", true),  // Issue #3099
+                ("solana_bpf_rust_noop", true),
+                ("solana_bpf_rust_dep_crate", true),
+                ("solana_bpf_rust_panic", false),
             ];
             for program in programs.iter() {
                 let filename = create_bpf_path(program.0);


### PR DESCRIPTION
#### Problem

BPF has 5 registers available to pass arguments into a function.  LLVM backend currently warns and ignores any function arguments over 5.

#3099

#### Summary of Changes

Add a test to highlight this behavior that should be enabled when this issue is fixed.

Fixes #
