### PR TITLE
Clean up bench-tps fund keys error handling

### DIFF
--- a/bench-tps/src/main.rs
+++ b/bench-tps/src/main.rs
@@ -90,6 +90,10 @@ fn main() {
             tx_count,
             NUM_LAMPORTS_PER_ACCOUNT,
         )
+        .unwrap_or_else(|e| {
+            eprintln!("Error could not fund keys: {:?}", e);
+            exit(1);
+        })
     };
 
     let config = Config {


### PR DESCRIPTION
#### Problem

Shouldn't call exit from a library function.

#### Summary of Changes

Use an error return type and call exit in `main()`.

Fixes #
