### PR TITLE
Temporarily revert: Convert System Transfer accounts to credit-only

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1724,7 +1724,7 @@ mod tests {
     }
 
     #[test]
-    fn test_credit_only_accounts() {
+    fn test_need_credit_only_accounts() {
         let (genesis_block, mint_keypair) = create_genesis_block(10);
         let bank = Bank::new(&genesis_block);
         let payer0 = Keypair::new();
@@ -1739,13 +1739,18 @@ mod tests {
         let txs = vec![tx0, tx1, tx2];
         let results = bank.process_transactions(&txs);
 
-        // If multiple transactions attempt to deposit into the same account, they should succeed,
-        // since System Transfer `To` accounts are given credit-only handling
+        // If multiple transactions attempt to deposit into the same account, only the first will
+        // succeed, even though such atomic adds are safe. A System Transfer `To` account should be
+        // given credit-only handling
 
         assert_eq!(results[0], Ok(()));
-        assert_eq!(results[1], Ok(()));
-        assert_eq!(results[2], Ok(()));
-        assert_eq!(bank.get_balance(&recipient), 3);
+        assert_eq!(results[1], Err(TransactionError::AccountInUse));
+        assert_eq!(results[2], Err(TransactionError::AccountInUse));
+
+        // After credit-only account handling is implemented, the following checks should pass instead:
+        // assert_eq!(results[0], Ok(()));
+        // assert_eq!(results[1], Ok(()));
+        // assert_eq!(results[2], Ok(()));
     }
 
     #[test]

--- a/sdk/src/system_instruction.rs
+++ b/sdk/src/system_instruction.rs
@@ -90,7 +90,7 @@ pub fn assign(from_pubkey: &Pubkey, program_id: &Pubkey) -> Instruction {
 pub fn transfer(from_pubkey: &Pubkey, to_pubkey: &Pubkey, lamports: u64) -> Instruction {
     let account_metas = vec![
         AccountMeta::new(*from_pubkey, true),
-        AccountMeta::new_credit_only(*to_pubkey, false),
+        AccountMeta::new(*to_pubkey, false),
     ];
     Instruction::new(
         system_program::id(),


### PR DESCRIPTION
#### Problem
Credit-only account handling isn't quite ready for action. Specifying System Transfer recipients as credit-only causes AccountNotFound errors in testnet validators

#### Summary of Changes
Revert System Transfer change converting `To` to CO

fyi @sakridge 
