### PR TITLE
Fix storage program space issues and limit storage transaction data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2734,6 +2734,8 @@ dependencies = [
  "assert_matches 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-derive 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-logger 0.16.0",

--- a/core/src/storage_stage.rs
+++ b/core/src/storage_stage.rs
@@ -647,9 +647,9 @@ mod tests {
         let cluster_info = test_cluster_info(&keypair.pubkey());
         let GenesisBlockInfo { genesis_block, .. } = create_genesis_block(1000);
         let bank = Arc::new(Bank::new(&genesis_block));
-        let bank_forks = Arc::new(RwLock::new(BankForks::new_from_banks(&[bank], 0)));
+        let bank_forks = Arc::new(RwLock::new(BankForks::new_from_banks(&[bank.clone()], 0)));
         let (_slot_sender, slot_receiver) = channel();
-        let storage_state = StorageState::new();
+        let storage_state = StorageState::new(&bank.last_blockhash());
         let storage_stage = StorageStage::new(
             &storage_state,
             slot_receiver,
@@ -688,7 +688,7 @@ mod tests {
 
         let cluster_info = test_cluster_info(&keypair.pubkey());
         let (bank_sender, bank_receiver) = channel();
-        let storage_state = StorageState::new();
+        let storage_state = StorageState::new(&bank.last_blockhash());
         let storage_stage = StorageStage::new(
             &storage_state,
             bank_receiver,
@@ -777,7 +777,7 @@ mod tests {
         let cluster_info = test_cluster_info(&keypair.pubkey());
 
         let (bank_sender, bank_receiver) = channel();
-        let storage_state = StorageState::new();
+        let storage_state = StorageState::new(&bank.last_blockhash());
         let storage_stage = StorageStage::new(
             &storage_state,
             bank_receiver,

--- a/core/src/storage_stage.rs
+++ b/core/src/storage_stage.rs
@@ -21,11 +21,10 @@ use solana_sdk::message::Message;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::{Keypair, KeypairUtil, Signature};
 use solana_sdk::transaction::Transaction;
-use solana_storage_api::storage_contract::{CheckedProof, Proof, ProofStatus, StorageContract};
+use solana_storage_api::storage_contract::{Proof, ProofStatus, StorageContract};
 use solana_storage_api::storage_instruction::proof_validation;
 use solana_storage_api::{get_segment_from_slot, storage_instruction};
 use std::collections::HashMap;
-use std::io;
 use std::mem::size_of;
 use std::net::UdpSocket;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -33,6 +32,7 @@ use std::sync::mpsc::{channel, Receiver, RecvTimeoutError, Sender};
 use std::sync::{Arc, RwLock};
 use std::thread::{self, sleep, Builder, JoinHandle};
 use std::time::{Duration, Instant};
+use std::{cmp, io};
 
 // Block of hash answers to validate against
 // Vec of [ledger blocks] x [keys]
@@ -86,7 +86,7 @@ fn get_identity_index_from_signature(key: &Signature) -> usize {
 }
 
 impl StorageState {
-    pub fn new() -> Self {
+    pub fn new(hash: &Hash) -> Self {
         let storage_keys = vec![0u8; KEY_SIZE * NUM_IDENTITIES];
         let storage_results = vec![Hash::default(); NUM_IDENTITIES];
         let replicator_map = vec![];
@@ -96,7 +96,7 @@ impl StorageState {
             storage_results,
             replicator_map,
             slot: 0,
-            storage_blockhash: Hash::default(),
+            storage_blockhash: *hash,
         };
 
         StorageState {
@@ -439,7 +439,7 @@ impl StorageStage {
             //convert slot to segment
             let segment = get_segment_from_slot(slot);
             if let Some(proofs) = proofs.get(&segment) {
-                for (_, proof) in proofs.iter() {
+                for proof in proofs.iter() {
                     {
                         debug!(
                             "generating storage_keys from storage txs current_key_idx: {}",
@@ -543,6 +543,8 @@ impl StorageStage {
         // bundle up mining submissions from replicators
         // and submit them in a tx to the leader to get rewarded.
         let mut w_state = storage_state.write().unwrap();
+        let mut max_proof_mask = 0;
+        let proof_mask_limit = storage_instruction::proof_mask_limit();
         let instructions: Vec<_> = w_state
             .replicator_map
             .iter_mut()
@@ -552,32 +554,44 @@ impl StorageStage {
                     .iter_mut()
                     .filter_map(|(id, proofs)| {
                         if !proofs.is_empty() {
-                            Some((
-                                *id,
-                                proofs
-                                    .drain(..)
-                                    .map(|proof| CheckedProof {
-                                        proof,
-                                        status: ProofStatus::Valid,
-                                    })
-                                    .collect::<Vec<_>>(),
-                            ))
+                            if (proofs.len() as u64) >= proof_mask_limit {
+                                proofs.clear();
+                                None
+                            } else {
+                                max_proof_mask = cmp::max(max_proof_mask, proofs.len());
+                                Some((
+                                    *id,
+                                    proofs
+                                        .drain(..)
+                                        .map(|_| ProofStatus::Valid)
+                                        .collect::<Vec<_>>(),
+                                ))
+                            }
                         } else {
                             None
                         }
                     })
-                    .collect::<HashMap<_, _>>();
+                    .collect::<Vec<(_, _)>>();
+
                 if !checked_proofs.is_empty() {
-                    let ix = proof_validation(
-                        &storage_keypair.pubkey(),
-                        current_segment as u64,
-                        checked_proofs,
-                    );
-                    Some(ix)
+                    let max_accounts_per_ix =
+                        storage_instruction::validation_account_limit(max_proof_mask);
+                    let ixs = checked_proofs
+                        .chunks(max_accounts_per_ix as usize)
+                        .map(|checked_proofs| {
+                            proof_validation(
+                                &storage_keypair.pubkey(),
+                                current_segment as u64,
+                                checked_proofs.to_vec(),
+                            )
+                        })
+                        .collect::<Vec<_>>();
+                    Some(ixs)
                 } else {
                     None
                 }
             })
+            .flatten()
             .collect();
         let res: std::result::Result<_, _> = instructions
             .into_iter()
@@ -808,6 +822,7 @@ mod tests {
             Hash::default(),
             0,
             keypair.sign_message(b"test"),
+            bank.last_blockhash(),
         );
 
         let next_bank = Arc::new(Bank::new_from_parent(&bank, &keypair.pubkey(), 2));

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -153,7 +153,7 @@ impl Validator {
             keypair.clone(),
         )));
 
-        let storage_state = StorageState::new();
+        let storage_state = StorageState::new(&bank.last_blockhash());
 
         let rpc_service = if node.info.rpc.port() == 0 {
             None

--- a/programs/storage_api/Cargo.toml
+++ b/programs/storage_api/Cargo.toml
@@ -12,6 +12,8 @@ edition = "2018"
 assert_matches = "1.3.0"
 bincode = "1.1.4"
 log = "0.4.2"
+num-derive = "0.2"
+num-traits = "0.2"
 serde = "1.0.92"
 serde_derive = "1.0.92"
 solana-logger = { path = "../../logger", version = "0.16.0" }

--- a/programs/storage_api/src/storage_contract.rs
+++ b/programs/storage_api/src/storage_contract.rs
@@ -1,5 +1,6 @@
 use crate::get_segment_from_slot;
 use log::*;
+use num_derive::FromPrimitive;
 use serde_derive::{Deserialize, Serialize};
 use solana_sdk::account::Account;
 use solana_sdk::account::KeyedAccount;
@@ -10,10 +11,22 @@ use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::Signature;
 use std::collections::HashMap;
 
-pub const TOTAL_VALIDATOR_REWARDS: u64 = 1;
-pub const TOTAL_REPLICATOR_REWARDS: u64 = 1;
+pub const VALIDATOR_REWARD: u64 = 25;
+pub const REPLICATOR_REWARD: u64 = 25;
 // Todo Tune this for actual use cases when replicators are feature complete
 pub const STORAGE_ACCOUNT_SPACE: u64 = 1024 * 8;
+pub const MAX_PROOFS_PER_SEGMENT: usize = 80;
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, FromPrimitive)]
+pub enum StorageError {
+    InvalidSegment,
+    InvalidBlockhash,
+    InvalidProofMask,
+    DuplicateProof,
+    RewardPoolDepleted,
+    InvalidOwner,
+    ProofLimitReached,
+}
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub enum ProofStatus {
@@ -30,16 +43,14 @@ impl Default for ProofStatus {
 
 #[derive(Default, Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct Proof {
+    /// The encryption key the replicator used (also used to generate offsets)
     pub signature: Signature,
+    /// A "recent" blockhash used to generate the seed
+    pub blockhash: Hash,
+    /// The resulting sampled state
     pub sha_state: Hash,
     /// The start index of the segment proof is for
     pub segment_index: usize,
-}
-
-#[derive(Default, Debug, Serialize, Deserialize, Clone)]
-pub struct CheckedProof {
-    pub proof: Proof,
-    pub status: ProofStatus,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -52,16 +63,20 @@ pub enum StorageContract {
         slot: u64,
         // Most recently advertised blockhash
         hash: Hash,
-        lockout_validations: HashMap<usize, HashMap<Hash, ProofStatus>>,
-        reward_validations: HashMap<usize, HashMap<Hash, ProofStatus>>,
+        // Lockouts and Rewards are per segment per replicator. It needs to remain this way until
+        // the challenge stage is added. Once challenges are in rewards can just be a number
+        lockout_validations: HashMap<usize, HashMap<Pubkey, Vec<ProofStatus>>>,
+        // lamports that are ready to be claimed
+        pending_lamports: u64,
     },
     ReplicatorStorage {
         owner: Pubkey,
-        /// Map of Proofs per segment, in a HashMap based on the sha_state
-        proofs: HashMap<usize, HashMap<Hash, Proof>>,
-        /// Map of Rewards per segment, in a HashMap based on the sha_state
-        /// Multiple validators can validate the same set of proofs so it needs a Vec
-        reward_validations: HashMap<usize, HashMap<Hash, Vec<ProofStatus>>>,
+        // TODO what to do about duplicate proofs across segments? - Check the blockhashes
+        // Map of Proofs per segment, in a Vec
+        proofs: HashMap<usize, Vec<Proof>>,
+        // Map of Rewards per segment, in a HashMap based on the validator account that verified
+        // the proof. This can be used for challenge stage when its added
+        reward_validations: HashMap<usize, HashMap<Pubkey, Vec<ProofStatus>>>,
     },
 
     MiningPool,
@@ -77,7 +92,7 @@ pub fn create_validator_storage_account(owner: Pubkey, lamports: u64) -> Account
             slot: 0,
             hash: Hash::default(),
             lockout_validations: HashMap::new(),
-            reward_validations: HashMap::new(),
+            pending_lamports: 0,
         })
         .expect("set_state");
 
@@ -85,12 +100,13 @@ pub fn create_validator_storage_account(owner: Pubkey, lamports: u64) -> Account
 }
 
 pub struct StorageAccount<'a> {
+    pub(crate) id: Pubkey,
     account: &'a mut Account,
 }
 
 impl<'a> StorageAccount<'a> {
-    pub fn new(account: &'a mut Account) -> Self {
-        Self { account }
+    pub fn new(id: Pubkey, account: &'a mut Account) -> Self {
+        Self { id, account }
     }
 
     pub fn initialize_mining_pool(&mut self) -> Result<(), InstructionError> {
@@ -125,7 +141,7 @@ impl<'a> StorageAccount<'a> {
                 slot: 0,
                 hash: Hash::default(),
                 lockout_validations: HashMap::new(),
-                reward_validations: HashMap::new(),
+                pending_lamports: 0,
             };
             self.account.set_state(storage_contract)
         } else {
@@ -138,15 +154,28 @@ impl<'a> StorageAccount<'a> {
         sha_state: Hash,
         segment_index: usize,
         signature: Signature,
+        blockhash: Hash,
         current_slot: u64,
     ) -> Result<(), InstructionError> {
         let mut storage_contract = &mut self.account.state()?;
-        if let StorageContract::ReplicatorStorage { proofs, .. } = &mut storage_contract {
+        if let StorageContract::ReplicatorStorage {
+            proofs,
+            reward_validations,
+            ..
+        } = &mut storage_contract
+        {
             let current_segment = get_segment_from_slot(current_slot);
+
+            // clean up the account
+            // TODO check for time correctness - storage seems to run at a delay of about 3
+            proofs.retain(|segment, _| *segment >= current_segment.saturating_sub(5));
+            reward_validations.retain(|segment, _| *segment >= current_segment.saturating_sub(10));
 
             if segment_index >= current_segment {
                 // attempt to submit proof for unconfirmed segment
-                return Err(InstructionError::InvalidArgument);
+                return Err(InstructionError::CustomError(
+                    StorageError::InvalidSegment as u32,
+                ));
             }
 
             debug!(
@@ -154,23 +183,33 @@ impl<'a> StorageAccount<'a> {
                 sha_state, segment_index
             );
 
+            // TODO check that this blockhash is valid and recent
+            //            if !is_valid(&blockhash) {
+            //                // proof isn't using a recent blockhash
+            //                return Err(InstructionError::CustomError(InvalidBlockhash as u32));
+            //            }
+
+            let proof = Proof {
+                sha_state,
+                signature,
+                blockhash,
+                segment_index,
+            };
             // store the proofs in the "current" segment's entry in the hash map.
             let segment_proofs = proofs.entry(current_segment).or_default();
-            if segment_proofs.contains_key(&sha_state) {
+            if segment_proofs.contains(&proof) {
                 // do not accept duplicate proofs
-                return Err(InstructionError::InvalidArgument);
+                return Err(InstructionError::CustomError(
+                    StorageError::DuplicateProof as u32,
+                ));
             }
-            segment_proofs.insert(
-                sha_state,
-                Proof {
-                    sha_state,
-                    signature,
-                    segment_index,
-                },
-            );
-            // TODO check for time correctness
-            proofs.retain(|segment, _| *segment >= current_segment.saturating_sub(5));
-
+            if segment_proofs.len() >= MAX_PROOFS_PER_SEGMENT {
+                // do not accept more than MAX_PROOFS_PER_SEGMENT
+                return Err(InstructionError::CustomError(
+                    StorageError::ProofLimitReached as u32,
+                ));
+            }
+            segment_proofs.push(proof);
             self.account.set_state(storage_contract)
         } else {
             Err(InstructionError::InvalidArgument)?
@@ -187,8 +226,8 @@ impl<'a> StorageAccount<'a> {
         if let StorageContract::ValidatorStorage {
             slot: state_slot,
             hash: state_hash,
-            reward_validations,
             lockout_validations,
+            pending_lamports,
             ..
         } = &mut storage_contract
         {
@@ -200,14 +239,27 @@ impl<'a> StorageAccount<'a> {
                 segment, current_segment
             );
             if segment < original_segment || segment >= current_segment {
-                return Err(InstructionError::InvalidArgument);
+                return Err(InstructionError::CustomError(
+                    StorageError::InvalidSegment as u32,
+                ));
             }
 
             *state_slot = slot;
             *state_hash = hash;
 
-            // move storage epoch updated, move the lockout_validations to reward_validations
-            reward_validations.extend(lockout_validations.drain());
+            // storage epoch updated, move the lockout_validations to pending_lamports
+            let num_validations = count_valid_proofs(
+                &lockout_validations
+                    .drain()
+                    .flat_map(|(_segment, mut proofs)| {
+                        proofs
+                            .drain()
+                            .flat_map(|(_, proof)| proof)
+                            .collect::<Vec<_>>()
+                    })
+                    .collect::<Vec<_>>(),
+            );
+            *pending_lamports += VALIDATOR_REWARD * num_validations;
             self.account.set_state(storage_contract)
         } else {
             Err(InstructionError::InvalidArgument)?
@@ -216,8 +268,9 @@ impl<'a> StorageAccount<'a> {
 
     pub fn proof_validation(
         &mut self,
+        me: &Pubkey,
         segment: u64,
-        proofs: Vec<(Pubkey, Vec<CheckedProof>)>,
+        proofs_per_account: Vec<Vec<ProofStatus>>,
         replicator_accounts: &mut [StorageAccount],
     ) -> Result<(), InstructionError> {
         let mut storage_contract = &mut self.account.state()?;
@@ -231,56 +284,72 @@ impl<'a> StorageAccount<'a> {
             let state_segment = get_segment_from_slot(*state_slot);
 
             if segment_index > state_segment {
-                return Err(InstructionError::InvalidArgument);
+                return Err(InstructionError::CustomError(
+                    StorageError::InvalidSegment as u32,
+                ));
             }
 
-            let accounts_and_proofs = replicator_accounts
+            let accounts = replicator_accounts
                 .iter_mut()
-                .filter_map(|account| {
-                    account
-                        .account
-                        .state()
-                        .ok()
-                        .map(move |contract| match contract {
-                            StorageContract::ReplicatorStorage { proofs, .. } => {
-                                if let Some(proofs) = proofs.get(&segment_index).cloned() {
-                                    Some((account, proofs))
+                .enumerate()
+                .filter_map(|(i, account)| {
+                    account.account.state().ok().map(|contract| match contract {
+                        StorageContract::ReplicatorStorage {
+                            proofs: account_proofs,
+                            ..
+                        } => {
+                            //TODO do this better
+                            if let Some(segment_proofs) =
+                                account_proofs.get(&segment_index).cloned()
+                            {
+                                if proofs_per_account
+                                    .get(i)
+                                    .filter(|proofs| proofs.len() == segment_proofs.len())
+                                    .is_some()
+                                {
+                                    Some(account)
                                 } else {
                                     None
                                 }
+                            } else {
+                                None
                             }
-                            _ => None,
-                        })
+                        }
+                        _ => None,
+                    })
                 })
                 .flatten()
                 .collect::<Vec<_>>();
 
-            if accounts_and_proofs.len() != proofs.len() {
-                // don't have all the accounts to validate the proofs against
-                return Err(InstructionError::InvalidArgument);
+            if accounts.len() != proofs_per_account.len() {
+                // don't have all the accounts to validate the proofs_per_account against
+                return Err(InstructionError::CustomError(
+                    StorageError::InvalidProofMask as u32,
+                ));
             }
 
-            let valid_proofs: Vec<_> = proofs
+            let stored_proofs: Vec<_> = proofs_per_account
                 .into_iter()
-                .zip(accounts_and_proofs.into_iter())
-                .flat_map(|((_id, checked_proofs), (account, proofs))| {
-                    checked_proofs.into_iter().filter_map(move |checked_proof| {
-                        proofs.get(&checked_proof.proof.sha_state).map(|proof| {
-                            process_validation(account, segment_index, &proof, &checked_proof)
-                                .map(|_| checked_proof)
-                        })
-                    })
+                .zip(accounts.into_iter())
+                .filter_map(|(checked_proofs, account)| {
+                    if store_validation_result(me, account, segment_index, &checked_proofs).is_ok()
+                    {
+                        Some((account.id, checked_proofs))
+                    } else {
+                        None
+                    }
                 })
-                .flatten()
                 .collect();
 
             // allow validators to store successful validations
-            valid_proofs.into_iter().for_each(|proof| {
-                lockout_validations
-                    .entry(segment_index)
-                    .or_default()
-                    .insert(proof.proof.sha_state, proof.status);
-            });
+            stored_proofs
+                .into_iter()
+                .for_each(|(replicator_account_id, proof_mask)| {
+                    lockout_validations
+                        .entry(segment_index)
+                        .or_default()
+                        .insert(replicator_account_id, proof_mask);
+                });
 
             self.account.set_state(storage_contract)
         } else {
@@ -291,59 +360,59 @@ impl<'a> StorageAccount<'a> {
     pub fn claim_storage_reward(
         &mut self,
         mining_pool: &mut KeyedAccount,
+        owner: &mut StorageAccount,
     ) -> Result<(), InstructionError> {
         let mut storage_contract = &mut self.account.state()?;
 
         if let StorageContract::ValidatorStorage {
-            reward_validations, ..
+            owner: account_owner,
+            pending_lamports,
+            ..
         } = &mut storage_contract
         {
-            let num_validations = count_valid_proofs(
-                &reward_validations
-                    .drain()
-                    .flat_map(|(_segment, mut proofs)| {
-                        proofs.drain().map(|(_, proof)| proof).collect::<Vec<_>>()
-                    })
-                    .collect::<Vec<_>>(),
-            );
-            let reward = TOTAL_VALIDATOR_REWARDS * num_validations;
-            mining_pool.account.lamports -= reward;
-            self.account.lamports += reward;
+            if owner.id != *account_owner {
+                Err(InstructionError::CustomError(
+                    StorageError::InvalidOwner as u32,
+                ))?
+            }
+
+            let pending = *pending_lamports;
+            if mining_pool.account.lamports < pending {
+                Err(InstructionError::CustomError(
+                    StorageError::RewardPoolDepleted as u32,
+                ))?
+            }
+            mining_pool.account.lamports -= pending;
+            owner.account.lamports += pending;
+            //clear pending_lamports
+            *pending_lamports = 0;
             self.account.set_state(storage_contract)
         } else if let StorageContract::ReplicatorStorage {
-            proofs,
+            owner: account_owner,
             reward_validations,
             ..
         } = &mut storage_contract
         {
-            // remove proofs for which rewards have already been collected
-            let segment_proofs = proofs;
+            if owner.id != *account_owner {
+                Err(InstructionError::CustomError(
+                    StorageError::InvalidOwner as u32,
+                ))?
+            }
+
             let checked_proofs = reward_validations
                 .drain()
-                .flat_map(|(segment, mut proofs)| {
+                .flat_map(|(_, mut proofs)| {
                     proofs
                         .drain()
-                        .map(|(sha_state, proof)| {
-                            proof
-                                .into_iter()
-                                .map(|proof| {
-                                    segment_proofs.get_mut(&segment).and_then(|segment_proofs| {
-                                        segment_proofs.remove(&sha_state)
-                                    });
-                                    proof
-                                })
-                                .collect::<Vec<_>>()
-                        })
-                        .flatten()
+                        .flat_map(|(_, proofs)| proofs)
                         .collect::<Vec<_>>()
                 })
                 .collect::<Vec<_>>();
             let total_proofs = checked_proofs.len() as u64;
             let num_validations = count_valid_proofs(&checked_proofs);
-            let reward =
-                num_validations * TOTAL_REPLICATOR_REWARDS * (num_validations / total_proofs);
+            let reward = num_validations * REPLICATOR_REWARD * (num_validations / total_proofs);
             mining_pool.account.lamports -= reward;
-            self.account.lamports += reward;
+            owner.account.lamports += reward;
             self.account.set_state(storage_contract)
         } else {
             Err(InstructionError::InvalidArgument)?
@@ -353,9 +422,10 @@ impl<'a> StorageAccount<'a> {
 
 /// Store the result of a proof validation into the replicator account
 fn store_validation_result(
+    me: &Pubkey,
     storage_account: &mut StorageAccount,
     segment: usize,
-    checked_proof: CheckedProof,
+    proof_mask: &Vec<ProofStatus>,
 ) -> Result<(), InstructionError> {
     let mut storage_contract = storage_account.account.state()?;
     match &mut storage_contract {
@@ -368,20 +438,14 @@ fn store_validation_result(
                 return Err(InstructionError::InvalidAccountData);
             }
 
-            if proofs
-                .get(&segment)
-                .unwrap()
-                .contains_key(&checked_proof.proof.sha_state)
-            {
-                reward_validations
-                    .entry(segment)
-                    .or_default()
-                    .entry(checked_proof.proof.sha_state)
-                    .or_default()
-                    .push(checked_proof.status);
-            } else {
+            if proofs.get(&segment).unwrap().len() != proof_mask.len() {
                 return Err(InstructionError::InvalidAccountData);
             }
+
+            reward_validations
+                .entry(segment)
+                .or_default()
+                .insert(*me, proof_mask.clone());
         }
         _ => return Err(InstructionError::InvalidAccountData),
     }
@@ -398,21 +462,6 @@ fn count_valid_proofs(proofs: &[ProofStatus]) -> u64 {
     num
 }
 
-fn process_validation(
-    account: &mut StorageAccount,
-    segment_index: usize,
-    proof: &Proof,
-    checked_proof: &CheckedProof,
-) -> Result<(), InstructionError> {
-    store_validation_result(account, segment_index, checked_proof.clone())?;
-    if proof.signature != checked_proof.proof.signature
-        || checked_proof.status != ProofStatus::Valid
-    {
-        return Err(InstructionError::GenericError);
-    }
-    Ok(())
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -423,7 +472,7 @@ mod tests {
         solana_logger::setup();
         let mut account = Account::default();
         account.data.resize(STORAGE_ACCOUNT_SPACE as usize, 0);
-        let storage_account = StorageAccount::new(&mut account);
+        let storage_account = StorageAccount::new(Pubkey::default(), &mut account);
         // pretend it's a validator op code
         let mut contract = storage_account.account.state().unwrap();
         if let StorageContract::ValidatorStorage { .. } = contract {
@@ -438,7 +487,7 @@ mod tests {
             slot: 0,
             hash: Hash::default(),
             lockout_validations: HashMap::new(),
-            reward_validations: HashMap::new(),
+            pending_lamports: 0,
         };
         storage_account.account.set_state(&contract).unwrap();
         if let StorageContract::ReplicatorStorage { .. } = contract {
@@ -458,6 +507,7 @@ mod tests {
     #[test]
     fn test_process_validation() {
         let mut account = StorageAccount {
+            id: Pubkey::default(),
             account: &mut Account {
                 lamports: 0,
                 data: vec![],
@@ -467,17 +517,18 @@ mod tests {
         };
         let segment_index = 0_usize;
         let proof = Proof {
-            signature: Signature::default(),
-            sha_state: Hash::default(),
             segment_index,
-        };
-        let mut checked_proof = CheckedProof {
-            proof: proof.clone(),
-            status: ProofStatus::Valid,
+            ..Proof::default()
         };
 
         // account has no space
-        process_validation(&mut account, segment_index, &proof, &checked_proof).unwrap_err();
+        store_validation_result(
+            &Pubkey::default(),
+            &mut account,
+            segment_index,
+            &vec![ProofStatus::default(); 1],
+        )
+        .unwrap_err();
 
         account
             .account
@@ -485,10 +536,8 @@ mod tests {
             .resize(STORAGE_ACCOUNT_SPACE as usize, 0);
         let storage_contract = &mut account.account.state().unwrap();
         if let StorageContract::Uninitialized = storage_contract {
-            let mut proof_map = HashMap::new();
-            proof_map.insert(proof.sha_state, proof.clone());
             let mut proofs = HashMap::new();
-            proofs.insert(0, proof_map);
+            proofs.insert(0, vec![proof.clone()]);
             *storage_contract = StorageContract::ReplicatorStorage {
                 owner: Pubkey::default(),
                 proofs,
@@ -498,11 +547,21 @@ mod tests {
         account.account.set_state(storage_contract).unwrap();
 
         // proof is valid
-        process_validation(&mut account, segment_index, &proof, &checked_proof).unwrap();
+        store_validation_result(
+            &Pubkey::default(),
+            &mut account,
+            segment_index,
+            &vec![ProofStatus::Valid],
+        )
+        .unwrap();
 
-        checked_proof.status = ProofStatus::NotValid;
-
-        // proof failed verification
-        process_validation(&mut account, segment_index, &proof, &checked_proof).unwrap_err();
+        // proof failed verification but we should still be able to store it
+        store_validation_result(
+            &Pubkey::default(),
+            &mut account,
+            segment_index,
+            &vec![ProofStatus::NotValid],
+        )
+        .unwrap();
     }
 }

--- a/programs/storage_api/src/storage_contract.rs
+++ b/programs/storage_api/src/storage_contract.rs
@@ -425,7 +425,7 @@ fn store_validation_result(
     me: &Pubkey,
     storage_account: &mut StorageAccount,
     segment: usize,
-    proof_mask: &Vec<ProofStatus>,
+    proof_mask: &[ProofStatus],
 ) -> Result<(), InstructionError> {
     let mut storage_contract = storage_account.account.state()?;
     match &mut storage_contract {
@@ -445,7 +445,7 @@ fn store_validation_result(
             reward_validations
                 .entry(segment)
                 .or_default()
-                .insert(*me, proof_mask.clone());
+                .insert(*me, proof_mask.to_vec());
         }
         _ => return Err(InstructionError::InvalidAccountData),
     }

--- a/programs/storage_api/src/storage_instruction.rs
+++ b/programs/storage_api/src/storage_instruction.rs
@@ -1,5 +1,5 @@
 use crate::id;
-use crate::storage_contract::{CheckedProof, STORAGE_ACCOUNT_SPACE};
+use crate::storage_contract::{ProofStatus, STORAGE_ACCOUNT_SPACE};
 use serde_derive::{Deserialize, Serialize};
 use solana_sdk::hash::Hash;
 use solana_sdk::instruction::{AccountMeta, Instruction};
@@ -7,7 +7,6 @@ use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::Signature;
 use solana_sdk::syscall::current;
 use solana_sdk::system_instruction;
-use std::collections::HashMap;
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum StorageInstruction {
@@ -27,6 +26,7 @@ pub enum StorageInstruction {
         sha_state: Hash,
         segment_index: usize,
         signature: Signature,
+        blockhash: Hash,
     },
     AdvertiseStorageRecentBlockhash {
         hash: Hash,
@@ -37,11 +37,44 @@ pub enum StorageInstruction {
     /// Expects 1 Account:
     ///    0 - Storage account with credits to redeem
     ///    1 - MiningPool account to redeem credits from
+    ///    2 - Replicator account to credit - this account *must* be the owner
     ClaimStorageReward,
     ProofValidation {
+        /// The segment during which this proof was generated
         segment: u64,
-        proofs: Vec<(Pubkey, Vec<CheckedProof>)>,
+        /// A Vec of proof masks per keyed replicator account loaded by the instruction
+        proofs: Vec<Vec<ProofStatus>>,
     },
+}
+
+fn get_ratios() -> (u64, u64) {
+    // max number bytes available for account metas and proofs
+    static MAX_BYTES: u64 = 900;
+    let account_meta_size: u64 =
+        bincode::serialized_size(&AccountMeta::new(Pubkey::new_rand(), false)).unwrap_or(0);
+    let proof_size: u64 = bincode::serialized_size(&ProofStatus::default()).unwrap_or(0);
+
+    // the ratio between account meta size and a single proof status
+    let ratio = (account_meta_size + proof_size - 1) / proof_size;
+    let bytes = (MAX_BYTES + ratio - 1) / ratio;
+    (ratio, bytes)
+}
+
+/// Returns how many accounts and their proofs will fit in a single proof validation tx
+///
+/// # Arguments
+///
+/// * `proof_mask_max` - The largest proof mask across all accounts intended for submission
+///
+pub fn validation_account_limit(proof_mask_max: usize) -> u64 {
+    let (ratio, bytes) = get_ratios();
+    // account_meta_count * (ratio + proof_mask_max) = bytes
+    bytes / (ratio + proof_mask_max as u64)
+}
+
+pub fn proof_mask_limit() -> u64 {
+    let (ratio, bytes) = get_ratios();
+    bytes - ratio
 }
 
 pub fn create_validator_storage_account(
@@ -118,11 +151,13 @@ pub fn mining_proof(
     sha_state: Hash,
     segment_index: usize,
     signature: Signature,
+    blockhash: Hash,
 ) -> Instruction {
     let storage_instruction = StorageInstruction::SubmitMiningProof {
         sha_state,
         segment_index,
         signature,
+        blockhash,
     };
     let account_metas = vec![
         AccountMeta::new(*storage_pubkey, true),
@@ -147,26 +182,45 @@ pub fn advertise_recent_blockhash(
     Instruction::new(id(), &storage_instruction, account_metas)
 }
 
-pub fn proof_validation<S: std::hash::BuildHasher>(
+pub fn proof_validation(
     storage_pubkey: &Pubkey,
     segment: u64,
-    checked_proofs: HashMap<Pubkey, Vec<CheckedProof>, S>,
+    checked_proofs: Vec<(Pubkey, Vec<ProofStatus>)>,
 ) -> Instruction {
     let mut account_metas = vec![AccountMeta::new(*storage_pubkey, true)];
     let mut proofs = vec![];
     checked_proofs.into_iter().for_each(|(id, p)| {
-        proofs.push((id, p));
+        proofs.push(p);
         account_metas.push(AccountMeta::new(id, false))
     });
     let storage_instruction = StorageInstruction::ProofValidation { segment, proofs };
     Instruction::new(id(), &storage_instruction, account_metas)
 }
 
-pub fn claim_reward(storage_pubkey: &Pubkey, mining_pool_pubkey: &Pubkey) -> Instruction {
+pub fn claim_reward(
+    owner_pubkey: &Pubkey,
+    storage_pubkey: &Pubkey,
+    mining_pool_pubkey: &Pubkey,
+) -> Instruction {
     let storage_instruction = StorageInstruction::ClaimStorageReward;
     let account_metas = vec![
         AccountMeta::new(*storage_pubkey, false),
         AccountMeta::new(*mining_pool_pubkey, false),
+        AccountMeta::new(*owner_pubkey, false),
     ];
     Instruction::new(id(), &storage_instruction, account_metas)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use solana_sdk::message::Message;
+    use solana_sdk::transaction::Transaction;
+
+    #[test]
+    fn check_size() {
+        // check that if there's 50 proof per account, only 1 account can fit in a single tx
+        assert_eq!(validation_account_limit(50), 1);
+        println!(" limit {:?}", proof_mask_limit());
+    }
 }

--- a/programs/storage_api/src/storage_instruction.rs
+++ b/programs/storage_api/src/storage_instruction.rs
@@ -217,8 +217,6 @@ pub fn claim_reward(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use solana_sdk::message::Message;
-    use solana_sdk::transaction::Transaction;
 
     #[test]
     fn check_size() {

--- a/programs/storage_api/src/storage_instruction.rs
+++ b/programs/storage_api/src/storage_instruction.rs
@@ -49,6 +49,9 @@ pub enum StorageInstruction {
 
 fn get_ratios() -> (u64, u64) {
     // max number bytes available for account metas and proofs
+    // The maximum transaction size is == `PACKET_DATA_SIZE` (1232 bytes)
+    // There are approx. 900 bytes lefter over after the storage instruction is wrapped into
+    // a signed transaction.
     static MAX_BYTES: u64 = 900;
     let account_meta_size: u64 =
         bincode::serialized_size(&AccountMeta::new(Pubkey::new_rand(), false)).unwrap_or(0);
@@ -221,6 +224,5 @@ mod tests {
     fn check_size() {
         // check that if there's 50 proof per account, only 1 account can fit in a single tx
         assert_eq!(validation_account_limit(50), 1);
-        println!(" limit {:?}", proof_mask_limit());
     }
 }

--- a/programs/storage_api/src/storage_instruction.rs
+++ b/programs/storage_api/src/storage_instruction.rs
@@ -50,7 +50,7 @@ pub enum StorageInstruction {
 fn get_ratios() -> (u64, u64) {
     // max number bytes available for account metas and proofs
     // The maximum transaction size is == `PACKET_DATA_SIZE` (1232 bytes)
-    // There are approx. 900 bytes lefter over after the storage instruction is wrapped into
+    // There are approx. 900 bytes left over after the storage instruction is wrapped into
     // a signed transaction.
     static MAX_BYTES: u64 = 900;
     let account_meta_size: u64 =

--- a/programs/storage_api/src/storage_processor.rs
+++ b/programs/storage_api/src/storage_processor.rs
@@ -17,7 +17,7 @@ pub fn process_instruction(
 
     let (me, rest) = keyed_accounts.split_at_mut(1);
     let me_unsigned = me[0].signer_key().is_none();
-    let mut storage_account = StorageAccount::new(&mut me[0].account);
+    let mut storage_account = StorageAccount::new(*me[0].unsigned_key(), &mut me[0].account);
 
     match bincode::deserialize(data).map_err(|_| InstructionError::InvalidInstructionData)? {
         StorageInstruction::InitializeMiningPool => {
@@ -42,13 +42,20 @@ pub fn process_instruction(
             sha_state,
             segment_index,
             signature,
+            blockhash,
         } => {
             if me_unsigned || rest.len() != 1 {
                 // This instruction must be signed by `me`
                 Err(InstructionError::InvalidArgument)?;
             }
             let current = Current::from(&rest[0].account).unwrap();
-            storage_account.submit_mining_proof(sha_state, segment_index, signature, current.slot)
+            storage_account.submit_mining_proof(
+                sha_state,
+                segment_index,
+                signature,
+                blockhash,
+                current.slot,
+            )
         }
         StorageInstruction::AdvertiseStorageRecentBlockhash { hash, slot } => {
             if me_unsigned || rest.len() != 1 {
@@ -59,21 +66,27 @@ pub fn process_instruction(
             storage_account.advertise_storage_recent_blockhash(hash, slot, current.slot)
         }
         StorageInstruction::ClaimStorageReward => {
-            if rest.len() != 1 {
+            if rest.len() != 2 {
                 Err(InstructionError::InvalidArgument)?;
             }
-            storage_account.claim_storage_reward(&mut rest[0])
+            let (mining_pool, owner) = rest.split_at_mut(1);
+            let mut owner = StorageAccount::new(*owner[0].unsigned_key(), &mut owner[0].account);
+
+            storage_account.claim_storage_reward(&mut mining_pool[0], &mut owner)
         }
         StorageInstruction::ProofValidation { segment, proofs } => {
             if me_unsigned || rest.is_empty() {
                 // This instruction must be signed by `me` and `rest` cannot be empty
                 Err(InstructionError::InvalidArgument)?;
             }
+            let me_id = storage_account.id.clone();
             let mut rest: Vec<_> = rest
                 .iter_mut()
-                .map(|keyed_account| StorageAccount::new(&mut keyed_account.account))
+                .map(|keyed_account| {
+                    StorageAccount::new(*keyed_account.unsigned_key(), &mut keyed_account.account)
+                })
                 .collect();
-            storage_account.proof_validation(segment, proofs, &mut rest)
+            storage_account.proof_validation(&me_id, segment, proofs, &mut rest)
         }
     }
 }

--- a/programs/storage_api/src/storage_processor.rs
+++ b/programs/storage_api/src/storage_processor.rs
@@ -79,7 +79,7 @@ pub fn process_instruction(
                 // This instruction must be signed by `me` and `rest` cannot be empty
                 Err(InstructionError::InvalidArgument)?;
             }
-            let me_id = storage_account.id.clone();
+            let me_id = storage_account.id;
             let mut rest: Vec<_> = rest
                 .iter_mut()
                 .map(|keyed_account| {

--- a/replicator/src/main.rs
+++ b/replicator/src/main.rs
@@ -2,8 +2,8 @@ use clap::{crate_description, crate_name, crate_version, App, Arg};
 use solana::cluster_info::{Node, FULLNODE_PORT_RANGE};
 use solana::contact_info::ContactInfo;
 use solana::replicator::Replicator;
-use solana::socketaddr;
 use solana_sdk::signature::{read_keypair, Keypair, KeypairUtil};
+use std::net::SocketAddr;
 use std::process::exit;
 use std::sync::Arc;
 
@@ -77,7 +77,8 @@ fn main() {
         .unwrap();
 
     let gossip_addr = {
-        let mut addr = socketaddr!([127, 0, 0, 1], 8700);
+        let ip = solana_netutil::get_public_ip_addr(&entrypoint_addr).unwrap();
+        let mut addr = SocketAddr::new(ip, 0);
         addr.set_ip(solana_netutil::get_public_ip_addr(&entrypoint_addr).unwrap());
         addr
     };


### PR DESCRIPTION
#### Problem

Storage accounts can fill up quite easily and it's possible for validators to be unable to submit some proof of validation transactions if there are too many replicators and proofs in a turn/segment

#### Summary of Changes

Numerous updates to storage accounts and storage program

- Re-introduced a proof mask for storage validations 
- Simplified validator rewards to just a number
- Added functionality to dynamically split validation transactions to avoid running up against the tx size limit
- Replicators will drop rewards that haven't been claimed for 10 turns/segments
- Added more sensible errors to storage program
- Replicators now submit proofs more correctly. i.e; they submit the encryption key as well as the blockhash used to generate the offsets (they don't use this blockhash for the offsets just yet)
- Updated storage reward claims to go into the account owner's balance instead of the storage account itself
- Fixed replicators using a hardcoded gossip port

Fixes #4536
