### PR TITLE
Create aligned number of keypairs in bench-tps so they all get funded

### DIFF
--- a/bench-tps/src/bench.rs
+++ b/bench-tps/src/bench.rs
@@ -587,12 +587,9 @@ pub fn generate_keypairs(seed_keypair: &Keypair, count: u64) -> Vec<Keypair> {
     seed.copy_from_slice(&seed_keypair.to_bytes()[..32]);
     let mut rnd = GenKeys::new(seed);
 
-    let mut total_keys = 0;
-    let mut target = count;
-    while target > 1 {
-        total_keys += target;
-        // Use the upper bound for this division otherwise it may not generate enough keys
-        target = (target + MAX_SPENDS_PER_TX - 1) / MAX_SPENDS_PER_TX;
+    let mut total_keys = 1;
+    while total_keys < count {
+        total_keys *= MAX_SPENDS_PER_TX;
     }
     rnd.gen_n_keypairs(total_keys)
 }
@@ -739,8 +736,7 @@ mod tests {
             generate_and_fund_keypairs(&client, None, &id, tx_count, lamports).unwrap();
 
         for kp in &keypairs {
-            // TODO: This should be >= lamports, but fails at the moment
-            assert_ne!(client.get_balance(&kp.pubkey()).unwrap(), 0);
+            assert!(client.get_balance(&kp.pubkey()).unwrap() >= lamports);
         }
     }
 }


### PR DESCRIPTION
#### Problem

bench-tps doesn't create enough keys in all cases so that it could fund them with enough tokens. This can cause AccountNotFound since the accounts do not have enough tokens and the switching logic will run the accounts out of tokens.

#### Summary of Changes

Create a `MAX_SPENDS_PER_TX` aligned number of accounts.

Fixes #
