### PR TITLE
Fix GCP VMs boot up failure

### DIFF
--- a/net/scripts/install-libssl-compatability.sh
+++ b/net/scripts/install-libssl-compatability.sh
@@ -6,7 +6,7 @@ set -ex
 
 # Install libssl-dev to be compatible with binaries built on an Ubuntu machine...
 apt-get update
-apt-get --assume-yes install libssl-dev
+DEBIAN_FRONTEND=noninteractive apt-get --assume-yes install libssl-dev
 
 # Install libssl1.1 to be compatible with binaries built in the
 # solanalabs/rust docker image


### PR DESCRIPTION
#### Problem
GCP VMs are failing to fully boot up as installation of libssl is interrupted for service restart prompt.

#### Summary of Changes
Add flag to make the prompt non interactive.

Fixes #
