### PR TITLE
Serialize genesis block using bincode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2690,6 +2690,7 @@ dependencies = [
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memmap 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-derive 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/multinode-demo/fullnode.sh
+++ b/multinode-demo/fullnode.sh
@@ -386,7 +386,7 @@ if [[ -z $CI ]]; then # Skip in CI
 fi
 
 new_gensis_block() {
-  ! diff -q "$SOLANA_RSYNC_CONFIG_DIR"/ledger/genesis.json "$ledger_config_dir"/genesis.json >/dev/null 2>&1
+  ! diff -q "$SOLANA_RSYNC_CONFIG_DIR"/ledger/genesis.bin "$ledger_config_dir"/genesis.bin >/dev/null 2>&1
 }
 
 set -e

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -18,6 +18,7 @@ generic-array = { version = "0.13.0", default-features = false, features = ["ser
 hex = "0.3.2"
 itertools = "0.8.0"
 log = "0.4.2"
+memmap = "0.6.2"
 num-derive = "0.2"
 num-traits = "0.2"
 rand = "0.6.5"


### PR DESCRIPTION
#### Problem
The genesis block JSON file is getting very large (~300MB) since we started adding bench client accounts to it. This is delaying testnet startup. `rsync` of genesis block is one of the reasons for delay.

#### Summary of Changes
Use bincode instead of json serialize. This will reduce the file size.

Fixes #
