### PR TITLE
Clear C dependency files from cache

### DIFF
--- a/ci/test-bench.sh
+++ b/ci/test-bench.sh
@@ -41,8 +41,8 @@ BENCH_FILE=bench_output.log
 BENCH_ARTIFACT=current_bench_results.log
 
 # Clear the C dependency files, if dependeny moves these files are not regenerated
-find target/debug/bpf -name '*.d' -delete
-find target/release/bpf -name '*.d' -delete
+test -d target/debug/bpf find target/debug/bpf -name '*.d' -delete
+test -d target/release/bpf find target/release/bpf -name '*.d' -delete
 
 # Ensure all dependencies are built
 _ cargo +$rust_nightly build --all --release

--- a/ci/test-bench.sh
+++ b/ci/test-bench.sh
@@ -40,6 +40,10 @@ fi
 BENCH_FILE=bench_output.log
 BENCH_ARTIFACT=current_bench_results.log
 
+# Clear the C dependency files, if dependeny moves these files are not regenerated
+find target/debug/bpf -name '*.d' -delete
+find target/release/bpf -name '*.d' -delete
+
 # Ensure all dependencies are built
 _ cargo +$rust_nightly build --all --release
 

--- a/ci/test-bench.sh
+++ b/ci/test-bench.sh
@@ -41,8 +41,8 @@ BENCH_FILE=bench_output.log
 BENCH_ARTIFACT=current_bench_results.log
 
 # Clear the C dependency files, if dependeny moves these files are not regenerated
-test -d target/debug/bpf find target/debug/bpf -name '*.d' -delete
-test -d target/release/bpf find target/release/bpf -name '*.d' -delete
+test -d target/debug/bpf && find target/debug/bpf -name '*.d' -delete
+test -d target/release/bpf && find target/release/bpf -name '*.d' -delete
 
 # Ensure all dependencies are built
 _ cargo +$rust_nightly build --all --release

--- a/ci/test-stable.sh
+++ b/ci/test-stable.sh
@@ -20,8 +20,8 @@ source scripts/ulimit-n.sh
 rm -rf "$HOME/.config/solana"
 
 # Clear the C dependency files, if dependeny moves these files are not regenerated
-test -d target/debug/bpf find target/debug/bpf -name '*.d' -delete
-test -d target/release/bpf find target/release/bpf -name '*.d' -delete
+test -d target/debug/bpf && find target/debug/bpf -name '*.d' -delete
+test -d target/release/bpf && find target/release/bpf -name '*.d' -delete
 
 # Clear the BPF sysroot files, they are not automatically rebuilt
 rm -rf target/xargo # Issue #3105

--- a/ci/test-stable.sh
+++ b/ci/test-stable.sh
@@ -19,6 +19,10 @@ source scripts/ulimit-n.sh
 # Clear cached json keypair files
 rm -rf "$HOME/.config/solana"
 
+# Clear the C dependency files, if dependeny moves these files are not regenerated
+find target/debug/bpf -name '*.d' -delete
+find target/release/bpf -name '*.d' -delete
+
 # Clear the BPF sysroot files, they are not automatically rebuilt
 rm -rf target/xargo # Issue #3105
 

--- a/ci/test-stable.sh
+++ b/ci/test-stable.sh
@@ -20,8 +20,8 @@ source scripts/ulimit-n.sh
 rm -rf "$HOME/.config/solana"
 
 # Clear the C dependency files, if dependeny moves these files are not regenerated
-find target/debug/bpf -name '*.d' -delete
-find target/release/bpf -name '*.d' -delete
+test -d target/debug/bpf find target/debug/bpf -name '*.d' -delete
+test -d target/release/bpf find target/release/bpf -name '*.d' -delete
 
 # Clear the BPF sysroot files, they are not automatically rebuilt
 rm -rf target/xargo # Issue #3105


### PR DESCRIPTION
#### Problem

The C dependency files generated as part of the build process are not themselves dependent on the files the cover.  If a dependent file location is moved the dependency files are not updated and therefore cause an incorrect dependency to be expressed.  

In this case `solana_sdk.h` moved location but the .d files in the cache are enforcing it at its old location.

#### Summary of Changes

Clear the .d files from the cache

Fixes #
