### PR TITLE
Ensure cuda flag gets set correctly in core/

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -82,11 +82,12 @@ impl Validator {
         entrypoint_info_option: Option<&ContactInfo>,
         config: &ValidatorConfig,
     ) -> Self {
-        info!("creating bank...");
+        warn!("CUDA is {}abled", if cfg!(cuda) { "en" } else { "dis" });
 
         let id = keypair.pubkey();
         assert_eq!(id, node.info.id);
 
+        info!("creating bank...");
         let (
             bank_forks,
             bank_forks_info,

--- a/multinode-demo/common.sh
+++ b/multinode-demo/common.sh
@@ -36,7 +36,7 @@ else
     declare features="--features="
     if [[ "$program" =~ ^(.*)-cuda$ ]]; then
       program=${BASH_REMATCH[1]}
-      features+="cuda,"
+      features+="cuda"
     fi
     if [[ -r "$SOLANA_ROOT/$program"/Cargo.toml ]]; then
       maybe_package="--package solana-$program"

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -23,4 +23,4 @@ solana-vote-api = { path = "../programs/vote_api", version = "0.16.0" }
 solana-vote-signer = { path = "../vote-signer", version = "0.16.0" }
 
 [features]
-cuda = []
+cuda = ["solana/cuda"]


### PR DESCRIPTION
#### Problem
Cargo is weird, see #4693

#### Summary of Changes
* Explicitly set cuda rustc feature in core/build.rs because it seems that Cargo doesn't do it even though it set the CARGO_FEATURE_CUDA env variable.  😕 
* Add runtime log message at the top of Validator::new() to indicate if CUDA is enabled or not
* 🙏 a little to the cargo gods

Fixes #4693
