### PR TITLE
Don't start drone if primordial accounts are created for nodes

### DIFF
--- a/multinode-demo/fullnode.sh
+++ b/multinode-demo/fullnode.sh
@@ -316,7 +316,9 @@ elif [[ $node_type = bootstrap_leader ]]; then
   configured_flag=$SOLANA_CONFIG_DIR/bootstrap-leader.configured
 
   default_arg --rpc-port 8899
-  default_arg --rpc-drone-address 127.0.0.1:9900
+  if ((airdrops_enabled)); then
+    default_arg --rpc-drone-address 127.0.0.1:9900
+  fi
   default_arg --gossip-port 8001
 
 elif [[ $node_type = validator ]]; then
@@ -342,7 +344,9 @@ elif [[ $node_type = validator ]]; then
   [[ -r "$storage_keypair_path" ]] || $solana_keygen new -o "$storage_keypair_path"
 
   default_arg --entrypoint "$entrypoint_address"
-  default_arg --rpc-drone-address "${entrypoint_address%:*}:9900"
+  if ((airdrops_enabled)); then
+    default_arg --rpc-drone-address "${entrypoint_address%:*}:9900"
+  fi
 
   rsync_entrypoint_url=$(rsync_url "$entrypoint")
 else

--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -42,12 +42,17 @@ missing() {
 [[ -n $skipSetup ]]     || missing skipSetup
 [[ -n $failOnValidatorBootupFailure ]] || missing failOnValidatorBootupFailure
 
+airdropsEnabled=true
+if [[ -n $stakeNodesInGenesisBlock ]]; then
+  airdropsEnabled=false
+fi
 cat > deployConfig <<EOF
 deployMethod="$deployMethod"
 entrypointIp="$entrypointIp"
 numNodes="$numNodes"
 failOnValidatorBootupFailure=$failOnValidatorBootupFailure
 genesisOptions="$genesisOptions"
+airdropsEnabled="$airdropsEnabled"
 EOF
 
 source net/common.sh

--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -52,7 +52,7 @@ entrypointIp="$entrypointIp"
 numNodes="$numNodes"
 failOnValidatorBootupFailure=$failOnValidatorBootupFailure
 genesisOptions="$genesisOptions"
-airdropsEnabled="$airdropsEnabled"
+airdropsEnabled=$airdropsEnabled
 EOF
 
 source net/common.sh

--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -141,7 +141,7 @@ local|tar)
       args+=($genesisOptions)
       ./multinode-demo/setup.sh "${args[@]}"
     fi
-    ./multinode-demo/drone.sh > drone.log 2>&1 &
+    [[ -n $stakeNodesInGenesisBlock ]] || ./multinode-demo/drone.sh > drone.log 2>&1 &
 
     args=(
       --enable-rpc-exit
@@ -201,7 +201,7 @@ local|tar)
       # a static IP/DNS name for hosting the blockexplorer web app, and is
       # a location that somebody would expect to be able to airdrop from
       scp "$entrypointIp":~/solana/config-local/mint-keypair.json config-local/
-      ./multinode-demo/drone.sh > drone.log 2>&1 &
+      [[ -n $stakeNodesInGenesisBlock ]] || ./multinode-demo/drone.sh > drone.log 2>&1 &
 
       export BLOCKEXPLORER_GEOIP_WHITELIST=$PWD/net/config/geoip.yml
       npm install @solana/blockexplorer@1

--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -141,8 +141,9 @@ local|tar)
       args+=($genesisOptions)
       ./multinode-demo/setup.sh "${args[@]}"
     fi
-    [[ -n $stakeNodesInGenesisBlock ]] || ./multinode-demo/drone.sh > drone.log 2>&1 &
-
+    if [[ -z $stakeNodesInGenesisBlock ]]; then
+      ./multinode-demo/drone.sh > drone.log 2>&1 &
+    fi
     args=(
       --enable-rpc-exit
       --gossip-port "$entrypointIp":8001
@@ -201,8 +202,9 @@ local|tar)
       # a static IP/DNS name for hosting the blockexplorer web app, and is
       # a location that somebody would expect to be able to airdrop from
       scp "$entrypointIp":~/solana/config-local/mint-keypair.json config-local/
-      [[ -n $stakeNodesInGenesisBlock ]] || ./multinode-demo/drone.sh > drone.log 2>&1 &
-
+      if [[ -z $stakeNodesInGenesisBlock ]]; then
+        ./multinode-demo/drone.sh > drone.log 2>&1 &
+      fi
       export BLOCKEXPLORER_GEOIP_WHITELIST=$PWD/net/config/geoip.yml
       npm install @solana/blockexplorer@1
       npx solana-blockexplorer > blockexplorer.log 2>&1 &

--- a/net/remote/remote-sanity.sh
+++ b/net/remote/remote-sanity.sh
@@ -129,6 +129,9 @@ if [[ "$airdropsEnabled" = true ]]; then
     set -x
     scripts/wallet-sanity.sh --url http://"$sanityTargetIp":8899
   )
+else
+  echo "^^^ +++"
+  echo "Note: wallet sanity is disabled as airdrops are disabled"
 fi
 
 echo "--- $sanityTargetIp: verify ledger"

--- a/net/remote/remote-sanity.sh
+++ b/net/remote/remote-sanity.sh
@@ -13,6 +13,7 @@ deployMethod=
 entrypointIp=
 numNodes=
 failOnValidatorBootupFailure=
+airdropsEnabled=true
 
 [[ -r deployConfig ]] || {
   echo deployConfig missing
@@ -122,11 +123,13 @@ echo "--- $sanityTargetIp: RPC API: getTransactionCount"
     http://"$sanityTargetIp":8899
 )
 
-echo "--- $sanityTargetIp: wallet sanity"
-(
-  set -x
-  scripts/wallet-sanity.sh --url http://"$sanityTargetIp":8899
-)
+if [[ "$airdropsEnabled" = true ]]; then
+  echo "--- $sanityTargetIp: wallet sanity"
+  (
+    set -x
+    scripts/wallet-sanity.sh --url http://"$sanityTargetIp":8899
+  )
+fi
 
 echo "--- $sanityTargetIp: verify ledger"
 if $ledgerVerify; then


### PR DESCRIPTION
#### Problem
The drone can be misused in TdS testnet setup. The drone should not be started, as all nodes are staked via genesis block.

#### Summary of Changes
Don't start the drone if the nodes have primordial accounts in genesis block.

Fixes #4540 