### PR TITLE
Update Rust program build script paths

### DIFF
--- a/sdk/bpf/.gitignore
+++ b/sdk/bpf/.gitignore
@@ -1,3 +1,4 @@
 /dependencies/criterion*
 /dependencies/llvm-native*
 /dependencies/rust-bpf*
+/dependencies/xargo*

--- a/sdk/bpf/rust/build.sh
+++ b/sdk/bpf/rust/build.sh
@@ -9,9 +9,10 @@ if [ ! -f "$1/Cargo.toml" ]; then
     exit 1
 fi
 
-cd "$(dirname "$0")"
+pushd "$(dirname "$0")"
 bpf_sdk="$PWD/.."
-export XARGO_HOME="$PWD/../../../target/xargo"
+export XARGO_HOME="$bpf_sdk/dependencies/xargo"
+popd
 
 cd "$1"
 

--- a/sdk/bpf/rust/build.sh
+++ b/sdk/bpf/rust/build.sh
@@ -11,7 +11,6 @@ fi
 
 pushd "$(dirname "$0")"
 bpf_sdk="$PWD/.."
-export XARGO_HOME="$bpf_sdk/dependencies/xargo"
 popd
 
 cd "$1"
@@ -38,6 +37,7 @@ export RUSTFLAGS="
     -C link-arg=-shared \
     -C link-arg=--entry=entrypoint \
     -C linker=$bpf_sdk/dependencies/llvm-native/bin/ld.lld"
+export XARGO_HOME="$bpf_sdk/dependencies/xargo"
 export XARGO_RUST_SRC="$bpf_sdk/dependencies/rust-bpf-sysroot/src"
 xargo build --target bpfel-unknown-unknown --release -v
 

--- a/sdk/bpf/scripts/install.sh
+++ b/sdk/bpf/scripts/install.sh
@@ -55,6 +55,7 @@ if [[ ! -f llvm-native-$machine-$version.md ]]; then
 
     set -ex
     rm -rf llvm-native*
+    rm -rf xargo
     mkdir -p llvm-native
     cd llvm-native
 
@@ -81,6 +82,7 @@ if [[ ! -f rust-bpf-$machine-$version.md ]]; then
     set -ex
     rm -rf rust-bpf
     rm -rf rust-bpf-$machine-*
+    rm -rf xargo
     mkdir -p rust-bpf
     pushd rust-bpf
 
@@ -113,6 +115,7 @@ if [[ ! -f rust-bpf-sysroot-$version.md ]]; then
   (
     set -ex
     rm -rf rust-bpf-sysroot*
+    rm -rf xargo
     cmd="git clone --recursive --single-branch --branch $version https://github.com/solana-labs/rust-bpf-sysroot.git"
     $cmd
 


### PR DESCRIPTION
#### Problem

Rust program build script puts the xargo dir into solana's target.  That is not compatible with non-solana repos.

#### Summary of Changes

Instead put it into the SDK's own dependency directory.

Fixes #