### PR TITLE
Update replicators to use a blockhash to generate offsets

### DIFF
--- a/core/src/replicator.rs
+++ b/core/src/replicator.rs
@@ -437,7 +437,7 @@ impl Replicator {
             use rand_chacha::ChaChaRng;
 
             let mut rng_seed = [0u8; 32];
-            rng_seed.copy_from_slice(&self.signature.to_bytes()[0..32]);
+            rng_seed.copy_from_slice(&self.blockhash.as_ref());
             let mut rng = ChaChaRng::from_seed(rng_seed);
             for _ in 0..NUM_STORAGE_SAMPLES {
                 self.sampling_offsets


### PR DESCRIPTION
#### Problem

Replicators use their encryption keys to generate offsets. This results in the same offsets for every proof.

#### Summary of Changes

Rotate the offsets based on a recent blockhash.
Minor fn renaming

Fixes #
