### PR TITLE
Support for custom BroadcastStage in local cluster tests

### DIFF
--- a/bench-exchange/src/bench.rs
+++ b/bench-exchange/src/bench.rs
@@ -963,7 +963,6 @@ mod tests {
         solana_logger::setup();
 
         const NUM_NODES: usize = 1;
-        let validator_config = ValidatorConfig::default();
 
         let mut config = Config::default();
         config.identity = Keypair::new();
@@ -985,7 +984,7 @@ mod tests {
         let cluster = LocalCluster::new(&ClusterConfig {
             node_stakes: vec![100_000; NUM_NODES],
             cluster_lamports: 100_000_000_000_000,
-            validator_config,
+            validator_configs: vec![ValidatorConfig::default(); NUM_NODES],
             native_instruction_processors: [solana_exchange_program!()].to_vec(),
             ..ClusterConfig::default()
         });

--- a/bench-tps/src/bench.rs
+++ b/bench-tps/src/bench.rs
@@ -668,12 +668,11 @@ mod tests {
     #[test]
     fn test_bench_tps_local_cluster() {
         solana_logger::setup();
-        let validator_config = ValidatorConfig::default();
         const NUM_NODES: usize = 1;
         let cluster = LocalCluster::new(&ClusterConfig {
             node_stakes: vec![999_990; NUM_NODES],
             cluster_lamports: 2_000_000,
-            validator_config,
+            validator_configs: vec![ValidatorConfig::default(); NUM_NODES],
             ..ClusterConfig::default()
         });
 

--- a/core/src/broadcast_stage.rs
+++ b/core/src/broadcast_stage.rs
@@ -1,28 +1,30 @@
 //! A stage to broadcast data from a leader node to validators
-//!
+use self::fail_entry_verification_broadcast_run::FailEntryVerificationBroadcastRun;
+use self::standard_broadcast_run::StandardBroadcastRun;
 use crate::blocktree::Blocktree;
 use crate::cluster_info::{ClusterInfo, ClusterInfoError};
-use crate::entry::EntrySlice;
 use crate::erasure::CodingGenerator;
 use crate::packet::index_blobs;
 use crate::poh_recorder::WorkingBankEntries;
 use crate::result::{Error, Result};
 use crate::service::Service;
 use crate::staking_utils;
-use rayon::prelude::*;
 use rayon::ThreadPool;
 use solana_metrics::{
     datapoint, inc_new_counter_debug, inc_new_counter_error, inc_new_counter_info,
 };
 use solana_sdk::pubkey::Pubkey;
-use solana_sdk::signature::Signable;
 use solana_sdk::timing::duration_as_ms;
 use std::net::UdpSocket;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::{Receiver, RecvTimeoutError};
 use std::sync::{Arc, RwLock};
 use std::thread::{self, Builder, JoinHandle};
-use std::time::{Duration, Instant};
+use std::time::Instant;
+
+mod broadcast_utils;
+mod fail_entry_verification_broadcast_run;
+mod standard_broadcast_run;
 
 pub const NUM_THREADS: u32 = 10;
 
@@ -31,170 +33,58 @@ pub enum BroadcastStageReturnType {
     ChannelDisconnected,
 }
 
-#[derive(Default)]
-struct BroadcastStats {
-    num_entries: Vec<usize>,
-    run_elapsed: Vec<u64>,
-    to_blobs_elapsed: Vec<u64>,
+#[derive(PartialEq, Clone, Debug)]
+pub enum BroadcastStageType {
+    Standard,
+    FailEntryVerification,
+}
+
+impl BroadcastStageType {
+    pub fn new_broadcast_stage(
+        &self,
+        sock: UdpSocket,
+        cluster_info: Arc<RwLock<ClusterInfo>>,
+        receiver: Receiver<WorkingBankEntries>,
+        exit_sender: &Arc<AtomicBool>,
+        blocktree: &Arc<Blocktree>,
+    ) -> BroadcastStage {
+        match self {
+            BroadcastStageType::Standard => BroadcastStage::new(
+                sock,
+                cluster_info,
+                receiver,
+                exit_sender,
+                blocktree,
+                StandardBroadcastRun::new(),
+            ),
+
+            BroadcastStageType::FailEntryVerification => BroadcastStage::new(
+                sock,
+                cluster_info,
+                receiver,
+                exit_sender,
+                blocktree,
+                FailEntryVerificationBroadcastRun::new(),
+            ),
+        }
+    }
+}
+
+trait BroadcastRun {
+    fn run(
+        &mut self,
+        broadcast: &mut Broadcast,
+        cluster_info: &Arc<RwLock<ClusterInfo>>,
+        receiver: &Receiver<WorkingBankEntries>,
+        sock: &UdpSocket,
+        blocktree: &Arc<Blocktree>,
+    ) -> Result<()>;
 }
 
 struct Broadcast {
     id: Pubkey,
     coding_generator: CodingGenerator,
-    stats: BroadcastStats,
     thread_pool: ThreadPool,
-}
-
-impl Broadcast {
-    fn run(
-        &mut self,
-        cluster_info: &Arc<RwLock<ClusterInfo>>,
-        receiver: &Receiver<WorkingBankEntries>,
-        sock: &UdpSocket,
-        blocktree: &Arc<Blocktree>,
-    ) -> Result<()> {
-        let timer = Duration::new(1, 0);
-        let (mut bank, entries) = receiver.recv_timeout(timer)?;
-        let mut max_tick_height = bank.max_tick_height();
-
-        let run_start = Instant::now();
-        let mut num_entries = entries.len();
-        let mut ventries = Vec::new();
-        let mut last_tick = entries.last().map(|v| v.1).unwrap_or(0);
-        ventries.push(entries);
-
-        assert!(last_tick <= max_tick_height);
-        if last_tick != max_tick_height {
-            while let Ok((same_bank, entries)) = receiver.try_recv() {
-                // If the bank changed, that implies the previous slot was interrupted and we do not have to
-                // broadcast its entries.
-                if same_bank.slot() != bank.slot() {
-                    num_entries = 0;
-                    ventries.clear();
-                    bank = same_bank.clone();
-                    max_tick_height = bank.max_tick_height();
-                }
-                num_entries += entries.len();
-                last_tick = entries.last().map(|v| v.1).unwrap_or(0);
-                ventries.push(entries);
-                assert!(last_tick <= max_tick_height,);
-                if last_tick == max_tick_height {
-                    break;
-                }
-            }
-        }
-
-        inc_new_counter_info!("broadcast_service-entries_received", num_entries);
-
-        let to_blobs_start = Instant::now();
-
-        let blobs: Vec<_> = self.thread_pool.install(|| {
-            ventries
-                .into_par_iter()
-                .map(|p| {
-                    let entries: Vec<_> = p.into_iter().map(|e| e.0).collect();
-                    entries.to_shared_blobs()
-                })
-                .flatten()
-                .collect()
-        });
-
-        let blob_index = blocktree
-            .meta(bank.slot())
-            .expect("Database error")
-            .map(|meta| meta.consumed)
-            .unwrap_or(0);
-
-        index_blobs(
-            &blobs,
-            &self.id,
-            blob_index,
-            bank.slot(),
-            bank.parent().map_or(0, |parent| parent.slot()),
-        );
-
-        if last_tick == max_tick_height {
-            blobs.last().unwrap().write().unwrap().set_is_last_in_slot();
-        }
-
-        // Make sure not to modify the blob header or data after signing it here
-        self.thread_pool.install(|| {
-            blobs.par_iter().for_each(|b| {
-                b.write()
-                    .unwrap()
-                    .sign(&cluster_info.read().unwrap().keypair);
-            })
-        });
-
-        blocktree.write_shared_blobs(&blobs)?;
-
-        let coding = self.coding_generator.next(&blobs);
-
-        self.thread_pool.install(|| {
-            coding.par_iter().for_each(|c| {
-                c.write()
-                    .unwrap()
-                    .sign(&cluster_info.read().unwrap().keypair);
-            })
-        });
-
-        let to_blobs_elapsed = duration_as_ms(&to_blobs_start.elapsed());
-
-        let broadcast_start = Instant::now();
-
-        let bank_epoch = bank.get_stakers_epoch(bank.slot());
-        let stakes = staking_utils::staked_nodes_at_epoch(&bank, bank_epoch);
-
-        // Send out data
-        cluster_info
-            .read()
-            .unwrap()
-            .broadcast(sock, &blobs, stakes.as_ref())?;
-
-        inc_new_counter_debug!("streamer-broadcast-sent", blobs.len());
-
-        // send out erasures
-        cluster_info
-            .read()
-            .unwrap()
-            .broadcast(sock, &coding, stakes.as_ref())?;
-
-        self.update_broadcast_stats(
-            duration_as_ms(&broadcast_start.elapsed()),
-            duration_as_ms(&run_start.elapsed()),
-            num_entries,
-            to_blobs_elapsed,
-            blob_index,
-        );
-
-        Ok(())
-    }
-
-    fn update_broadcast_stats(
-        &mut self,
-        broadcast_elapsed: u64,
-        run_elapsed: u64,
-        num_entries: usize,
-        to_blobs_elapsed: u64,
-        blob_index: u64,
-    ) {
-        inc_new_counter_info!("broadcast_service-time_ms", broadcast_elapsed as usize);
-
-        self.stats.num_entries.push(num_entries);
-        self.stats.to_blobs_elapsed.push(to_blobs_elapsed);
-        self.stats.run_elapsed.push(run_elapsed);
-        if self.stats.num_entries.len() >= 16 {
-            info!(
-                "broadcast: entries: {:?} blob times ms: {:?} broadcast times ms: {:?}",
-                self.stats.num_entries, self.stats.to_blobs_elapsed, self.stats.run_elapsed
-            );
-            self.stats.num_entries.clear();
-            self.stats.to_blobs_elapsed.clear();
-            self.stats.run_elapsed.clear();
-        }
-
-        datapoint!("broadcast-service", ("transmit-index", blob_index, i64));
-    }
 }
 
 // Implement a destructor for the BroadcastStage thread to signal it exited
@@ -226,6 +116,7 @@ impl BroadcastStage {
         cluster_info: &Arc<RwLock<ClusterInfo>>,
         receiver: &Receiver<WorkingBankEntries>,
         blocktree: &Arc<Blocktree>,
+        mut broadcast_stage_run: impl BroadcastRun,
     ) -> BroadcastStageReturnType {
         let me = cluster_info.read().unwrap().my_data().clone();
         let coding_generator = CodingGenerator::default();
@@ -233,7 +124,6 @@ impl BroadcastStage {
         let mut broadcast = Broadcast {
             id: me.id,
             coding_generator,
-            stats: BroadcastStats::default(),
             thread_pool: rayon::ThreadPoolBuilder::new()
                 .num_threads(sys_info::cpu_num().unwrap_or(NUM_THREADS) as usize)
                 .build()
@@ -241,7 +131,9 @@ impl BroadcastStage {
         };
 
         loop {
-            if let Err(e) = broadcast.run(&cluster_info, receiver, sock, blocktree) {
+            if let Err(e) =
+                broadcast_stage_run.run(&mut broadcast, &cluster_info, receiver, sock, blocktree)
+            {
                 match e {
                     Error::RecvTimeoutError(RecvTimeoutError::Disconnected) | Error::SendError => {
                         return BroadcastStageReturnType::ChannelDisconnected;
@@ -273,12 +165,13 @@ impl BroadcastStage {
     /// which will then close FetchStage in the Tpu, and then the rest of the Tpu,
     /// completing the cycle.
     #[allow(clippy::too_many_arguments)]
-    pub fn new(
+    fn new(
         sock: UdpSocket,
         cluster_info: Arc<RwLock<ClusterInfo>>,
         receiver: Receiver<WorkingBankEntries>,
         exit_sender: &Arc<AtomicBool>,
         blocktree: &Arc<Blocktree>,
+        broadcast_stage_run: impl BroadcastRun + Send + 'static,
     ) -> Self {
         let blocktree = blocktree.clone();
         let exit_sender = exit_sender.clone();
@@ -286,7 +179,13 @@ impl BroadcastStage {
             .name("solana-broadcaster".to_string())
             .spawn(move || {
                 let _finalizer = Finalizer::new(exit_sender);
-                Self::run(&sock, &cluster_info, &receiver, &blocktree)
+                Self::run(
+                    &sock,
+                    &cluster_info,
+                    &receiver,
+                    &blocktree,
+                    broadcast_stage_run,
+                )
             })
             .unwrap();
 
@@ -357,6 +256,7 @@ mod test {
             entry_receiver,
             &exit_sender,
             &blocktree,
+            StandardBroadcastRun::new(),
         );
 
         MockBroadcastStage {

--- a/core/src/broadcast_stage/broadcast_utils.rs
+++ b/core/src/broadcast_stage/broadcast_utils.rs
@@ -1,7 +1,13 @@
 use crate::entry::Entry;
+use crate::entry::EntrySlice;
+use crate::erasure::CodingGenerator;
+use crate::packet::{self, SharedBlob};
 use crate::poh_recorder::WorkingBankEntries;
 use crate::result::Result;
+use rayon::prelude::*;
+use rayon::ThreadPool;
 use solana_runtime::bank::Bank;
+use solana_sdk::signature::{Keypair, KeypairUtil, Signable};
 use std::sync::mpsc::Receiver;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -66,4 +72,85 @@ pub(super) fn recv_slot_blobs(receiver: &Receiver<WorkingBankEntries>) -> Result
     let recv_end = recv_start.elapsed();
     let receive_results = ReceiveResults::new(ventries, num_entries, recv_end, bank, last_tick);
     Ok(receive_results)
+}
+
+pub(super) fn entries_to_blobs(
+    ventries: Vec<Vec<(Entry, u64)>>,
+    thread_pool: &ThreadPool,
+    latest_blob_index: u64,
+    last_tick: u64,
+    bank: &Bank,
+    keypair: &Keypair,
+    coding_generator: &mut CodingGenerator,
+) -> (Vec<SharedBlob>, Vec<SharedBlob>) {
+    let blobs = generate_data_blobs(
+        ventries,
+        thread_pool,
+        latest_blob_index,
+        last_tick,
+        &bank,
+        &keypair,
+    );
+
+    let coding = generate_coding_blobs(&blobs, &thread_pool, coding_generator, &keypair);
+
+    (blobs, coding)
+}
+
+pub(super) fn generate_data_blobs(
+    ventries: Vec<Vec<(Entry, u64)>>,
+    thread_pool: &ThreadPool,
+    latest_blob_index: u64,
+    last_tick: u64,
+    bank: &Bank,
+    keypair: &Keypair,
+) -> Vec<SharedBlob> {
+    let blobs: Vec<SharedBlob> = thread_pool.install(|| {
+        ventries
+            .into_par_iter()
+            .map(|p| {
+                let entries: Vec<_> = p.into_iter().map(|e| e.0).collect();
+                entries.to_shared_blobs()
+            })
+            .flatten()
+            .collect()
+    });
+
+    packet::index_blobs(
+        &blobs,
+        &keypair.pubkey(),
+        latest_blob_index,
+        bank.slot(),
+        bank.parent().map_or(0, |parent| parent.slot()),
+    );
+
+    if last_tick == bank.max_tick_height() {
+        blobs.last().unwrap().write().unwrap().set_is_last_in_slot();
+    }
+
+    // Make sure not to modify the blob header or data after signing it here
+    thread_pool.install(|| {
+        blobs.par_iter().for_each(|b| {
+            b.write().unwrap().sign(keypair);
+        })
+    });
+
+    blobs
+}
+
+pub(super) fn generate_coding_blobs(
+    blobs: &[SharedBlob],
+    thread_pool: &ThreadPool,
+    coding_generator: &mut CodingGenerator,
+    keypair: &Keypair,
+) -> Vec<SharedBlob> {
+    let coding = coding_generator.next(&blobs);
+
+    thread_pool.install(|| {
+        coding.par_iter().for_each(|c| {
+            c.write().unwrap().sign(keypair);
+        })
+    });
+
+    coding
 }

--- a/core/src/broadcast_stage/broadcast_utils.rs
+++ b/core/src/broadcast_stage/broadcast_utils.rs
@@ -1,0 +1,69 @@
+use crate::entry::Entry;
+use crate::poh_recorder::WorkingBankEntries;
+use crate::result::Result;
+use solana_runtime::bank::Bank;
+use std::sync::mpsc::Receiver;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+pub(super) struct ReceiveResults {
+    pub ventries: Vec<Vec<(Entry, u64)>>,
+    pub num_entries: usize,
+    pub time_elapsed: Duration,
+    pub bank: Arc<Bank>,
+    pub last_tick: u64,
+}
+
+impl ReceiveResults {
+    pub fn new(
+        ventries: Vec<Vec<(Entry, u64)>>,
+        num_entries: usize,
+        time_elapsed: Duration,
+        bank: Arc<Bank>,
+        last_tick: u64,
+    ) -> Self {
+        Self {
+            ventries,
+            num_entries,
+            time_elapsed,
+            bank,
+            last_tick,
+        }
+    }
+}
+
+pub(super) fn recv_slot_blobs(receiver: &Receiver<WorkingBankEntries>) -> Result<ReceiveResults> {
+    let timer = Duration::new(1, 0);
+    let (mut bank, entries) = receiver.recv_timeout(timer)?;
+    let recv_start = Instant::now();
+    let mut max_tick_height = bank.max_tick_height();
+    let mut num_entries = entries.len();
+    let mut ventries = Vec::new();
+    let mut last_tick = entries.last().map(|v| v.1).unwrap_or(0);
+    ventries.push(entries);
+
+    assert!(last_tick <= max_tick_height);
+    if last_tick != max_tick_height {
+        while let Ok((same_bank, entries)) = receiver.try_recv() {
+            // If the bank changed, that implies the previous slot was interrupted and we do not have to
+            // broadcast its entries.
+            if same_bank.slot() != bank.slot() {
+                num_entries = 0;
+                ventries.clear();
+                bank = same_bank.clone();
+                max_tick_height = bank.max_tick_height();
+            }
+            num_entries += entries.len();
+            last_tick = entries.last().map(|v| v.1).unwrap_or(0);
+            ventries.push(entries);
+            assert!(last_tick <= max_tick_height,);
+            if last_tick == max_tick_height {
+                break;
+            }
+        }
+    }
+
+    let recv_end = recv_start.elapsed();
+    let receive_results = ReceiveResults::new(ventries, num_entries, recv_end, bank, last_tick);
+    Ok(receive_results)
+}

--- a/core/src/broadcast_stage/fail_entry_verification_broadcast_run.rs
+++ b/core/src/broadcast_stage/fail_entry_verification_broadcast_run.rs
@@ -1,0 +1,110 @@
+use super::*;
+use crate::entry::EntrySlice;
+use rayon::prelude::*;
+use solana_sdk::hash::Hash;
+use solana_sdk::signature::Signable;
+
+pub(super) struct FailEntryVerificationBroadcastRun {}
+
+impl FailEntryVerificationBroadcastRun {
+    pub(super) fn new() -> Self {
+        Self {}
+    }
+}
+
+impl BroadcastRun for FailEntryVerificationBroadcastRun {
+    fn run(
+        &mut self,
+        broadcast: &mut Broadcast,
+        cluster_info: &Arc<RwLock<ClusterInfo>>,
+        receiver: &Receiver<WorkingBankEntries>,
+        sock: &UdpSocket,
+        blocktree: &Arc<Blocktree>,
+    ) -> Result<()> {
+        // 1) Pull entries from banking stage
+        let mut receive_results = broadcast_utils::recv_slot_blobs(receiver)?;
+        let bank = receive_results.bank.clone();
+        let last_tick = receive_results.last_tick;
+
+        // 2) Convert entries to blobs + generate coding blobs. Set a garbage PoH on the last entry
+        // in the slot to make verification fail on validators
+        if last_tick == bank.max_tick_height() {
+            let mut last_entry = receive_results
+                .ventries
+                .last_mut()
+                .unwrap()
+                .last_mut()
+                .unwrap();
+            last_entry.0.hash = Hash::default();
+        }
+
+        let blobs: Vec<_> = broadcast.thread_pool.install(|| {
+            receive_results
+                .ventries
+                .into_par_iter()
+                .map(|p| {
+                    let entries: Vec<_> = p.into_iter().map(|e| e.0).collect();
+                    entries.to_shared_blobs()
+                })
+                .flatten()
+                .collect()
+        });
+
+        let blob_index = blocktree
+            .meta(bank.slot())
+            .expect("Database error")
+            .map(|meta| meta.consumed)
+            .unwrap_or(0);
+
+        index_blobs(
+            &blobs,
+            &broadcast.id,
+            blob_index,
+            bank.slot(),
+            bank.parent().map_or(0, |parent| parent.slot()),
+        );
+
+        if last_tick == bank.max_tick_height() {
+            blobs.last().unwrap().write().unwrap().set_is_last_in_slot();
+        }
+
+        // Make sure not to modify the blob header or data after signing it here
+        broadcast.thread_pool.install(|| {
+            blobs.par_iter().for_each(|b| {
+                b.write()
+                    .unwrap()
+                    .sign(&cluster_info.read().unwrap().keypair);
+            })
+        });
+
+        blocktree.write_shared_blobs(&blobs)?;
+
+        let coding = broadcast.coding_generator.next(&blobs);
+
+        broadcast.thread_pool.install(|| {
+            coding.par_iter().for_each(|c| {
+                c.write()
+                    .unwrap()
+                    .sign(&cluster_info.read().unwrap().keypair);
+            })
+        });
+
+        // 3) Start broadcast step
+        let bank_epoch = bank.get_stakers_epoch(bank.slot());
+        let stakes = staking_utils::staked_nodes_at_epoch(&bank, bank_epoch);
+
+        // Broadcast data
+        cluster_info
+            .read()
+            .unwrap()
+            .broadcast(sock, &blobs, stakes.as_ref())?;
+
+        // Broadcast erasures
+        cluster_info
+            .read()
+            .unwrap()
+            .broadcast(sock, &coding, stakes.as_ref())?;
+
+        Ok(())
+    }
+}

--- a/core/src/broadcast_stage/standard_broadcast_run.rs
+++ b/core/src/broadcast_stage/standard_broadcast_run.rs
@@ -1,0 +1,154 @@
+use super::broadcast_utils;
+use super::*;
+use crate::entry::EntrySlice;
+use rayon::prelude::*;
+use solana_sdk::signature::Signable;
+
+#[derive(Default)]
+struct BroadcastStats {
+    num_entries: Vec<usize>,
+    run_elapsed: Vec<u64>,
+    to_blobs_elapsed: Vec<u64>,
+}
+
+pub(super) struct StandardBroadcastRun {
+    stats: BroadcastStats,
+}
+
+impl StandardBroadcastRun {
+    pub(super) fn new() -> Self {
+        Self {
+            stats: BroadcastStats::default(),
+        }
+    }
+
+    fn update_broadcast_stats(
+        &mut self,
+        broadcast_elapsed: u64,
+        run_elapsed: u64,
+        num_entries: usize,
+        to_blobs_elapsed: u64,
+        blob_index: u64,
+    ) {
+        inc_new_counter_info!("broadcast_service-time_ms", broadcast_elapsed as usize);
+
+        self.stats.num_entries.push(num_entries);
+        self.stats.to_blobs_elapsed.push(to_blobs_elapsed);
+        self.stats.run_elapsed.push(run_elapsed);
+        if self.stats.num_entries.len() >= 16 {
+            info!(
+                "broadcast: entries: {:?} blob times ms: {:?} broadcast times ms: {:?}",
+                self.stats.num_entries, self.stats.to_blobs_elapsed, self.stats.run_elapsed
+            );
+            self.stats.num_entries.clear();
+            self.stats.to_blobs_elapsed.clear();
+            self.stats.run_elapsed.clear();
+        }
+
+        datapoint!("broadcast-service", ("transmit-index", blob_index, i64));
+    }
+}
+
+impl BroadcastRun for StandardBroadcastRun {
+    fn run(
+        &mut self,
+        broadcast: &mut Broadcast,
+        cluster_info: &Arc<RwLock<ClusterInfo>>,
+        receiver: &Receiver<WorkingBankEntries>,
+        sock: &UdpSocket,
+        blocktree: &Arc<Blocktree>,
+    ) -> Result<()> {
+        // 1) Pull entries from banking stage
+        let receive_results = broadcast_utils::recv_slot_blobs(receiver)?;
+        let receive_elapsed = receive_results.time_elapsed;
+        let num_entries = receive_results.num_entries;
+        let bank = receive_results.bank.clone();
+        let last_tick = receive_results.last_tick;
+        inc_new_counter_info!("broadcast_service-entries_received", num_entries);
+
+        // 2) Convert entries to blobs + generate coding blobs
+        let to_blobs_start = Instant::now();
+        let blobs: Vec<_> = broadcast.thread_pool.install(|| {
+            receive_results
+                .ventries
+                .into_par_iter()
+                .map(|p| {
+                    let entries: Vec<_> = p.into_iter().map(|e| e.0).collect();
+                    entries.to_shared_blobs()
+                })
+                .flatten()
+                .collect()
+        });
+
+        let blob_index = blocktree
+            .meta(bank.slot())
+            .expect("Database error")
+            .map(|meta| meta.consumed)
+            .unwrap_or(0);
+
+        index_blobs(
+            &blobs,
+            &broadcast.id,
+            blob_index,
+            bank.slot(),
+            bank.parent().map_or(0, |parent| parent.slot()),
+        );
+
+        if last_tick == bank.max_tick_height() {
+            blobs.last().unwrap().write().unwrap().set_is_last_in_slot();
+        }
+
+        // Make sure not to modify the blob header or data after signing it here
+        broadcast.thread_pool.install(|| {
+            blobs.par_iter().for_each(|b| {
+                b.write()
+                    .unwrap()
+                    .sign(&cluster_info.read().unwrap().keypair);
+            })
+        });
+
+        blocktree.write_shared_blobs(&blobs)?;
+
+        let coding = broadcast.coding_generator.next(&blobs);
+
+        broadcast.thread_pool.install(|| {
+            coding.par_iter().for_each(|c| {
+                c.write()
+                    .unwrap()
+                    .sign(&cluster_info.read().unwrap().keypair);
+            })
+        });
+
+        let to_blobs_elapsed = to_blobs_start.elapsed();
+
+        // 3) Start broadcast step
+        let broadcast_start = Instant::now();
+        let bank_epoch = bank.get_stakers_epoch(bank.slot());
+        let stakes = staking_utils::staked_nodes_at_epoch(&bank, bank_epoch);
+
+        // Broadcast data
+        cluster_info
+            .read()
+            .unwrap()
+            .broadcast(sock, &blobs, stakes.as_ref())?;
+
+        inc_new_counter_debug!("streamer-broadcast-sent", blobs.len());
+
+        // Broadcast erasures
+        cluster_info
+            .read()
+            .unwrap()
+            .broadcast(sock, &coding, stakes.as_ref())?;
+
+        let broadcast_elapsed = broadcast_start.elapsed();
+        self.update_broadcast_stats(
+            duration_as_ms(&broadcast_elapsed),
+            duration_as_ms(&(receive_elapsed + to_blobs_elapsed + broadcast_elapsed)),
+            num_entries,
+            duration_as_ms(&to_blobs_elapsed),
+            blob_index,
+        );
+
+        Ok(())
+    }
+}

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -3,7 +3,7 @@
 
 use crate::banking_stage::BankingStage;
 use crate::blocktree::Blocktree;
-use crate::broadcast_stage::BroadcastStage;
+use crate::broadcast_stage::{BroadcastStage, BroadcastStageType};
 use crate::cluster_info::ClusterInfo;
 use crate::cluster_info_vote_listener::ClusterInfoVoteListener;
 use crate::fetch_stage::FetchStage;
@@ -70,7 +70,7 @@ impl Tpu {
             verified_vote_receiver,
         );
 
-        let broadcast_stage = BroadcastStage::new(
+        let broadcast_stage = BroadcastStageType::Standard.new_broadcast_stage(
             broadcast_socket,
             cluster_info.clone(),
             entry_receiver,

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -37,6 +37,7 @@ impl Tpu {
         broadcast_socket: UdpSocket,
         sigverify_disabled: bool,
         blocktree: &Arc<Blocktree>,
+        broadcast_type: &BroadcastStageType,
         exit: &Arc<AtomicBool>,
     ) -> Self {
         cluster_info.write().unwrap().set_leader(id);
@@ -70,7 +71,7 @@ impl Tpu {
             verified_vote_receiver,
         );
 
-        let broadcast_stage = BroadcastStageType::Standard.new_broadcast_stage(
+        let broadcast_stage = broadcast_type.new_broadcast_stage(
             broadcast_socket,
             cluster_info.clone(),
             entry_receiver,

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -3,6 +3,7 @@
 use crate::bank_forks::BankForks;
 use crate::blocktree::{Blocktree, CompletedSlotsReceiver};
 use crate::blocktree_processor::{self, BankForksInfo};
+use crate::broadcast_stage::BroadcastStageType;
 use crate::cluster_info::{ClusterInfo, Node};
 use crate::contact_info::ContactInfo;
 use crate::gossip_service::{discover_cluster, GossipService};
@@ -39,7 +40,9 @@ pub struct ValidatorConfig {
     pub account_paths: Option<String>,
     pub rpc_config: JsonRpcConfig,
     pub snapshot_path: Option<String>,
+    pub broadcast_stage_type: BroadcastStageType,
 }
+
 impl Default for ValidatorConfig {
     fn default() -> Self {
         // TODO: remove this, temporary parameter to configure
@@ -54,6 +57,7 @@ impl Default for ValidatorConfig {
             account_paths: None,
             rpc_config: JsonRpcConfig::default(),
             snapshot_path: None,
+            broadcast_stage_type: BroadcastStageType::Standard,
         }
     }
 }
@@ -262,6 +266,7 @@ impl Validator {
             node.sockets.broadcast,
             config.sigverify_disabled,
             &blocktree,
+            &config.broadcast_stage_type,
             &exit,
         );
 

--- a/core/tests/local_cluster.rs
+++ b/core/tests/local_cluster.rs
@@ -2,6 +2,7 @@ extern crate solana;
 
 use hashbrown::HashSet;
 use log::*;
+use solana::broadcast_stage::BroadcastStageType;
 use solana::cluster::Cluster;
 use solana::cluster_tests;
 use solana::gossip_service::discover_cluster;
@@ -23,6 +24,7 @@ fn test_spend_and_verify_all_nodes_1() {
         &local.entry_point_info,
         &local.funding_keypair,
         num_nodes,
+        HashSet::new(),
     );
 }
 
@@ -35,6 +37,7 @@ fn test_spend_and_verify_all_nodes_2() {
         &local.entry_point_info,
         &local.funding_keypair,
         num_nodes,
+        HashSet::new(),
     );
 }
 
@@ -47,6 +50,7 @@ fn test_spend_and_verify_all_nodes_3() {
         &local.entry_point_info,
         &local.funding_keypair,
         num_nodes,
+        HashSet::new(),
     );
 }
 
@@ -63,6 +67,7 @@ fn test_spend_and_verify_all_nodes_env_num_nodes() {
         &local.entry_point_info,
         &local.funding_keypair,
         num_nodes,
+        HashSet::new(),
     );
 }
 
@@ -83,8 +88,8 @@ fn test_fullnode_exit_2() {
     validator_config.rpc_config.enable_fullnode_exit = true;
     let config = ClusterConfig {
         cluster_lamports: 10_000,
-        node_stakes: vec![100; 2],
-        validator_config,
+        node_stakes: vec![100; num_nodes],
+        validator_configs: vec![ValidatorConfig::default(); num_nodes],
         ..ClusterConfig::default()
     };
     let local = LocalCluster::new(&config);
@@ -101,7 +106,7 @@ fn test_leader_failure_4() {
     let config = ClusterConfig {
         cluster_lamports: 10_000,
         node_stakes: vec![100; 4],
-        validator_config: validator_config.clone(),
+        validator_configs: vec![ValidatorConfig::default(); num_nodes],
         ..ClusterConfig::default()
     };
     let local = LocalCluster::new(&config);
@@ -124,7 +129,7 @@ fn test_two_unbalanced_stakes() {
     let mut cluster = LocalCluster::new(&ClusterConfig {
         node_stakes: vec![999_990, 3],
         cluster_lamports: 1_000_000,
-        validator_config: validator_config.clone(),
+        validator_configs: vec![ValidatorConfig::default(); 3],
         ticks_per_slot: num_ticks_per_slot,
         slots_per_epoch: num_slots_per_epoch,
         poh_config: PohConfig::new_sleep(Duration::from_millis(1000 / num_ticks_per_second)),
@@ -139,7 +144,10 @@ fn test_two_unbalanced_stakes() {
     );
     cluster.close_preserve_ledgers();
     let leader_pubkey = cluster.entry_point_info.id;
-    let leader_ledger = cluster.fullnode_infos[&leader_pubkey].ledger_path.clone();
+    let leader_ledger = cluster.fullnode_infos[&leader_pubkey]
+        .info
+        .ledger_path
+        .clone();
     cluster_tests::verify_ledger_ticks(&leader_ledger, num_ticks_per_slot as usize);
 }
 
@@ -151,6 +159,7 @@ fn test_forwarding() {
     let config = ClusterConfig {
         node_stakes: vec![999_990, 3],
         cluster_lamports: 2_000_000,
+        validator_configs: vec![ValidatorConfig::default(); 3],
         ..ClusterConfig::default()
     };
     let cluster = LocalCluster::new(&config);
@@ -171,13 +180,12 @@ fn test_forwarding() {
 
 #[test]
 fn test_restart_node() {
-    let validator_config = ValidatorConfig::default();
     let slots_per_epoch = MINIMUM_SLOTS_PER_EPOCH as u64;
     let ticks_per_slot = 16;
     let mut cluster = LocalCluster::new(&ClusterConfig {
         node_stakes: vec![3],
         cluster_lamports: 100,
-        validator_config: validator_config.clone(),
+        validator_configs: vec![ValidatorConfig::default(); 3],
         ticks_per_slot,
         slots_per_epoch,
         ..ClusterConfig::default()
@@ -205,11 +213,66 @@ fn test_listener_startup() {
         node_stakes: vec![100; 1],
         cluster_lamports: 1_000,
         num_listeners: 3,
+        validator_configs: vec![ValidatorConfig::default(); 1],
         ..ClusterConfig::default()
     };
     let cluster = LocalCluster::new(&config);
     let (cluster_nodes, _) = discover_cluster(&cluster.entry_point_info.gossip, 4).unwrap();
     assert_eq!(cluster_nodes.len(), 4);
+}
+
+#[test]
+#[ignore]
+fn test_fail_entry_verification_leader() {
+    solana_logger::setup();
+    let num_nodes = 4;
+    let validator_config = ValidatorConfig::default();
+    let mut error_validator_config = ValidatorConfig::default();
+    error_validator_config.broadcast_stage_type = BroadcastStageType::FailEntryVerification;
+    let mut validator_configs = vec![validator_config; num_nodes - 1];
+    validator_configs.push(error_validator_config);
+
+    let cluster_config = ClusterConfig {
+        cluster_lamports: 10_000,
+        node_stakes: vec![100; 4],
+        validator_configs: validator_configs,
+        slots_per_epoch: MINIMUM_SLOTS_PER_EPOCH * 2 as u64,
+        stakers_slot_offset: MINIMUM_SLOTS_PER_EPOCH * 2 as u64,
+        ..ClusterConfig::default()
+    };
+
+    let cluster = LocalCluster::new(&cluster_config);
+    let epoch_schedule = EpochSchedule::new(
+        cluster_config.slots_per_epoch,
+        cluster_config.stakers_slot_offset,
+        true,
+    );
+    let num_warmup_epochs = epoch_schedule.get_stakers_epoch(0) + 1;
+
+    // Wait for the corrupted leader to be scheduled afer the warmup epochs expire
+    cluster_tests::sleep_n_epochs(
+        (num_warmup_epochs + 1) as f64,
+        &cluster.genesis_block.poh_config,
+        cluster_config.ticks_per_slot,
+        cluster_config.slots_per_epoch,
+    );
+
+    let corrupt_node = cluster
+        .fullnode_infos
+        .iter()
+        .find(|(_, v)| v.config.broadcast_stage_type == BroadcastStageType::FailEntryVerification)
+        .unwrap()
+        .0;
+    let mut ignore = HashSet::new();
+    ignore.insert(*corrupt_node);
+
+    // Verify that we can still spend and verify even in the presence of corrupt nodes
+    cluster_tests::spend_and_verify_all_nodes(
+        &cluster.entry_point_info,
+        &cluster.funding_keypair,
+        num_nodes,
+        ignore,
+    );
 }
 
 #[test]
@@ -223,7 +286,7 @@ fn run_repairman_catchup(num_repairmen: u64) {
     let num_ticks_per_slot = 40;
     let num_slots_per_epoch = MINIMUM_SLOTS_PER_EPOCH as u64;
     let num_root_buffer_slots = 10;
-    // Calculate the leader schedule num_root_buffer slots ahead. Otherwise, if stakers_slot_offset ==
+    // Calculate the leader schedule num_root_buffer_slots ahead. Otherwise, if stakers_slot_offset ==
     // num_slots_per_epoch, and num_slots_per_epoch == MINIMUM_SLOTS_PER_EPOCH, then repairmen
     // will stop sending repairs after the last slot in epoch 1 (0-indexed), because the root
     // is at most in the first epoch.
@@ -256,7 +319,7 @@ fn run_repairman_catchup(num_repairmen: u64) {
     let mut cluster = LocalCluster::new(&ClusterConfig {
         node_stakes,
         cluster_lamports,
-        validator_config: validator_config.clone(),
+        validator_configs: vec![validator_config.clone(); num_repairmen as usize],
         ticks_per_slot: num_ticks_per_slot,
         slots_per_epoch: num_slots_per_epoch,
         stakers_slot_offset,

--- a/core/tests/local_cluster.rs
+++ b/core/tests/local_cluster.rs
@@ -89,7 +89,7 @@ fn test_fullnode_exit_2() {
     let config = ClusterConfig {
         cluster_lamports: 10_000,
         node_stakes: vec![100; num_nodes],
-        validator_configs: vec![ValidatorConfig::default(); num_nodes],
+        validator_configs: vec![validator_config.clone(); num_nodes],
         ..ClusterConfig::default()
     };
     let local = LocalCluster::new(&config);
@@ -106,7 +106,7 @@ fn test_leader_failure_4() {
     let config = ClusterConfig {
         cluster_lamports: 10_000,
         node_stakes: vec![100; 4],
-        validator_configs: vec![ValidatorConfig::default(); num_nodes],
+        validator_configs: vec![validator_config.clone(); num_nodes],
         ..ClusterConfig::default()
     };
     let local = LocalCluster::new(&config);
@@ -129,7 +129,7 @@ fn test_two_unbalanced_stakes() {
     let mut cluster = LocalCluster::new(&ClusterConfig {
         node_stakes: vec![999_990, 3],
         cluster_lamports: 1_000_000,
-        validator_configs: vec![ValidatorConfig::default(); 3],
+        validator_configs: vec![validator_config.clone(); 2],
         ticks_per_slot: num_ticks_per_slot,
         slots_per_epoch: num_slots_per_epoch,
         poh_config: PohConfig::new_sleep(Duration::from_millis(1000 / num_ticks_per_second)),
@@ -185,7 +185,7 @@ fn test_restart_node() {
     let mut cluster = LocalCluster::new(&ClusterConfig {
         node_stakes: vec![3],
         cluster_lamports: 100,
-        validator_configs: vec![ValidatorConfig::default(); 3],
+        validator_configs: vec![ValidatorConfig::default()],
         ticks_per_slot,
         slots_per_epoch,
         ..ClusterConfig::default()

--- a/core/tests/replicator.rs
+++ b/core/tests/replicator.rs
@@ -27,7 +27,7 @@ fn run_replicator_startup_basic(num_nodes: usize, num_replicators: usize) {
     let mut validator_config = ValidatorConfig::default();
     validator_config.storage_rotate_count = STORAGE_ROTATE_TEST_COUNT;
     let config = ClusterConfig {
-        validator_config,
+        validator_configs: vec![ValidatorConfig::default(); num_nodes],
         num_replicators,
         node_stakes: vec![100; num_nodes],
         cluster_lamports: 10_000,
@@ -149,7 +149,7 @@ fn test_account_setup() {
     let mut validator_config = ValidatorConfig::default();
     validator_config.storage_rotate_count = STORAGE_ROTATE_TEST_COUNT;
     let config = ClusterConfig {
-        validator_config,
+        validator_configs: vec![ValidatorConfig::default(); num_nodes],
         num_replicators,
         node_stakes: vec![100; num_nodes],
         cluster_lamports: 10_000,


### PR DESCRIPTION
#### Problem
No convenient way to test for malicious/erroneous behavior in validators (broadcasting different blobs to different validators, broadcasting error-causing blobs, etc.).

#### Summary of Changes
1) Refactor broadcast stage to allow for custom broadcast implementations.
2) Implement a version of broadcast, `FailEntryVerificationBroadcastRun` that produces an entry that doesn't PoH verify at the end of each slot.
3) Add parameter to ValidatorConfig to allow toggling of broadcast stage implementations.
4) Consume changes in local cluster, introduce a test `test_fail_entry_verification_leader` that uses the malfunctioning validator (test ignored until https://github.com/solana-labs/solana/pull/4715/files is checked in).

Fixes #
