### PR TITLE
Deserialize buffered packets before we are leader

### DIFF
--- a/core/benches/banking_stage.rs
+++ b/core/benches/banking_stage.rs
@@ -71,13 +71,13 @@ fn bench_consume_buffered(bencher: &mut Bencher) {
         let mut packets = vec![];
         for batch in batches {
             let batch_len = batch.packets.len();
-            packets.push((batch, vec![0usize; batch_len]));
+            packets.push((batch, None, vec![0usize; batch_len]));
         }
         // This tests the performance of buffering packets.
         // If the packet buffers are copied, performance will be poor.
         bencher.iter(move || {
             let _ignored =
-                BankingStage::consume_buffered_packets(&my_pubkey, &poh_recorder, &mut packets);
+                BankingStage::consume_buffered_packets(&my_pubkey, &poh_recorder, &mut packets, 0);
         });
 
         exit.store(true, Ordering::Relaxed);


### PR DESCRIPTION
#### Problem

Deserialize is very expensive, if we can receive packets before our leader slot and deserialize them early then we can save a lot of work doing deserialize while the slot is active.

#### Summary of Changes

Deserialize when buffering packets.

Fixes #
