### PR TITLE
Various Snapshot generation improvements

### DIFF
--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -194,6 +194,7 @@ local|tar)
         --blockstream /tmp/solana-blockstream.sock
         --no-voting
         --stake 0
+        --generate-snapshots
       )
     else
       args+=(--stake "$stake")


### PR DESCRIPTION
* Only a single snapshot is maintained to avoid unbounded disk growth
* Snapshot is stored as a compressed tar archive for faster rsyncing
* Any validator node may now generate snapshots
* Updated testnet scripts to generate snapshots on the blockstreamer node
