### PR TITLE
Check for non zero count value

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -243,7 +243,9 @@ impl AccountStorageEntry {
             status = AccountStorageStatus::Available;
         }
 
-        *count_and_status = (count - 1, status);
+        if count > 0 {
+            *count_and_status = (count - 1, status);
+        }
         count_and_status.0
     }
 }


### PR DESCRIPTION
#### Problem
solana-replay-stage panics when starting a validator from a snapshot with overflow error

#### Summary of Changes
When accounts are restored from the storage, the accounts index is reconstructed and count status of indexes that were removed are no longer restored back. Add a check to prevent overflow in these scenarios.

Fixes #4725 
