### PR TITLE
Change seed for retransmit to use blob signature

### DIFF
--- a/core/src/packet.rs
+++ b/core/src/packet.rs
@@ -406,8 +406,8 @@ impl Blob {
 
     pub fn seed(&self) -> [u8; 32] {
         let mut seed = [0; 32];
-        seed[0..8].copy_from_slice(&self.index().to_le_bytes());
-        seed[8..16].copy_from_slice(&self.slot().to_le_bytes());
+        let seed_len = seed.len();
+        seed[0..32].copy_from_slice(&self.get_signature_bytes()[..seed_len]);
         seed
     }
 
@@ -486,6 +486,10 @@ impl Blob {
         let new_size = size + BLOB_HEADER_SIZE;
         self.meta.size = new_size;
         self.set_data_size(new_size as u64);
+    }
+
+    pub fn get_signature_bytes(&self) -> &[u8] {
+        &self.data[SIGNATURE_RANGE]
     }
 
     pub fn store_packets<T: Borrow<Packet>>(&mut self, packets: &[T]) -> u64 {
@@ -609,7 +613,7 @@ impl Signable for Blob {
     }
 
     fn get_signature(&self) -> Signature {
-        Signature::new(&self.data[SIGNATURE_RANGE])
+        Signature::new(self.get_signature_bytes())
     }
 
     fn set_signature(&mut self, signature: Signature) {

--- a/core/src/packet.rs
+++ b/core/src/packet.rs
@@ -407,7 +407,7 @@ impl Blob {
     pub fn seed(&self) -> [u8; 32] {
         let mut seed = [0; 32];
         let seed_len = seed.len();
-        seed[0..32].copy_from_slice(&self.get_signature_bytes()[..seed_len]);
+        seed[0..seed_len].copy_from_slice(&self.get_signature_bytes()[..seed_len]);
         seed
     }
 

--- a/core/src/packet.rs
+++ b/core/src/packet.rs
@@ -407,7 +407,8 @@ impl Blob {
     pub fn seed(&self) -> [u8; 32] {
         let mut seed = [0; 32];
         let seed_len = seed.len();
-        seed[0..seed_len].copy_from_slice(&self.get_signature_bytes()[..seed_len]);
+        let signature_bytes = self.get_signature_bytes();
+        seed[0..seed_len].copy_from_slice(&signature_bytes[(signature_bytes.len() - seed_len)..]);
         seed
     }
 


### PR DESCRIPTION
#### Problem
Seed currently uses a predictable blob slot + index

#### Summary of Changes
Change seed to use the first 32 bytes of the blob signature (signature is 64 bytes)

Fixes #
