### PR TITLE
remove build --all

### DIFF
--- a/ci/test-stable.sh
+++ b/ci/test-stable.sh
@@ -73,7 +73,6 @@ test-stable-perf)
   fi
 
   # Run root package library tests
-  _ cargo +"$rust_stable" build --all ${V:+--verbose} --features="$ROOT_FEATURES"
   _ cargo +"$rust_stable" test --manifest-path=core/Cargo.toml ${V:+--verbose} --features="$ROOT_FEATURES" -- --nocapture --test-threads=1
   ;;
 *)

--- a/ci/test-stable.sh
+++ b/ci/test-stable.sh
@@ -31,8 +31,6 @@ testName=$(basename "$0" .sh)
 case $testName in
 test-stable)
   echo "Executing $testName"
-
-  _ cargo +"$rust_stable" build --all ${V:+--verbose}
   _ cargo +"$rust_stable" test --all ${V:+--verbose} -- --nocapture --test-threads=1
   ;;
 test-stable-perf)


### PR DESCRIPTION
#### Problem
 cargo build --all is unnecessary now that inter-project dependencies are correct

 #### Summary of Changes
 remove build --all

Fixes #