### PR TITLE
protect against corruption

### DIFF
--- a/sdk/src/account.rs
+++ b/sdk/src/account.rs
@@ -65,6 +65,9 @@ impl Account {
     }
 
     pub fn serialize_data<T: serde::Serialize>(&mut self, state: &T) -> Result<(), bincode::Error> {
+        if bincode::serialized_size(state)? > self.data.len() as u64 {
+            return Err(Box::new(bincode::ErrorKind::SizeLimit));
+        }
         bincode::serialize_into(&mut self.data[..], state)
     }
 }


### PR DESCRIPTION
#### Problem
 when serializing state into an account whose data is too small, the account is corrupted and thereafter unrecoverable

 #### Summary of Changes
 don't write unless it looks like it'll fit

Fixes #