### PR TITLE
Fix paths

### DIFF
--- a/sdk/bpf/rust/build.sh
+++ b/sdk/bpf/rust/build.sh
@@ -24,7 +24,7 @@ export CC="$bpf_sdk/dependencies/llvm-native/bin/clang"
 export AR="$bpf_sdk/dependencies/llvm-native/bin/llvm-ar"
 
 # Use the SDK's version of Rust to build for BPF
-export RUSTUP_TOOLCHAIN=bpf2
+export RUSTUP_TOOLCHAIN=bpf
 export RUSTFLAGS="
     -C lto=no \
     -C opt-level=2 \

--- a/sdk/bpf/rust/build.sh
+++ b/sdk/bpf/rust/build.sh
@@ -12,7 +12,9 @@ fi
 echo "Building $1"
 set -e
 
-cd "$(dirname "$0")" && bpf_sdk="$PWD/.."
+pushd "$(dirname "$0")"
+bpf_sdk="$PWD/.."
+popd
 
 # Ensure the sdk is installed
 "$bpf_sdk"/scripts/install.sh
@@ -22,7 +24,7 @@ export CC="$bpf_sdk/dependencies/llvm-native/bin/clang"
 export AR="$bpf_sdk/dependencies/llvm-native/bin/llvm-ar"
 
 # Use the SDK's version of Rust to build for BPF
-export RUSTUP_TOOLCHAIN=bpf
+export RUSTUP_TOOLCHAIN=bpf2
 export RUSTFLAGS="
     -C lto=no \
     -C opt-level=2 \


### PR DESCRIPTION
#### Problem

Current directory is changed to the location of the build script.  Its a lot more convenient if its run from the caller's current directory

#### Summary of Changes

change to and back from script directory just to set bpf-sdk directory

Fixes #
