### PR TITLE
Avoid linking with CUDA directly

### DIFF
--- a/ci/test-stable.sh
+++ b/ci/test-stable.sh
@@ -42,8 +42,9 @@ test-stable-perf)
     .rs$ \
     Cargo.lock$ \
     Cargo.toml$ \
-    ci/test-stable-perf.sh \
-    ci/test-stable.sh \
+    ^ci/test-stable-perf.sh \
+    ^ci/test-stable.sh \
+    ^core/build.rs \
     ^fetch-perf-libs.sh \
     ^programs/ \
     ^sdk/ \

--- a/core/build.rs
+++ b/core/build.rs
@@ -41,14 +41,5 @@ fn main() {
         } else {
             println!("cargo:rerun-if-changed={}/libcuda-crypt.so", perf_libs_dir);
         }
-
-        let cuda_home = match env::var("CUDA_HOME") {
-            Ok(cuda_home) => cuda_home,
-            Err(_) => String::from("/usr/local/cuda"),
-        };
-        println!("cargo:rustc-link-search=native={}/lib64", cuda_home);
-        println!("cargo:rustc-link-lib=dylib=cudart");
-        println!("cargo:rustc-link-lib=dylib=cuda");
-        println!("cargo:rustc-link-lib=dylib=cudadevrt");
     }
 }

--- a/fetch-perf-libs.sh
+++ b/fetch-perf-libs.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-PERF_LIBS_VERSION=v0.14.0
+PERF_LIBS_VERSION=v0.14.1
 
 set -e
 cd "$(dirname "$0")"


### PR DESCRIPTION
By not linking directly with CUDA libraries and only linking with libcuda-crypt.so, the build host and final user machine do not require the same CUDA version