### PR TITLE
rewrite vote credits redemption to eat from rewards_pools on an epoch-sensitive basis

### DIFF
--- a/core/src/staking_utils.rs
+++ b/core/src/staking_utils.rs
@@ -145,7 +145,6 @@ pub(crate) mod tests {
 
         let leader_stake = Stake {
             stake: BOOTSTRAP_LEADER_LAMPORTS,
-            epoch: 0,
             ..Stake::default()
         };
 

--- a/programs/stake_api/src/rewards_pools.rs
+++ b/programs/stake_api/src/rewards_pools.rs
@@ -3,9 +3,8 @@
 //! * keep track of rewards
 //! * own mining pools
 
-use crate::stake_state::StakeState;
+use crate::stake_state::create_rewards_pool;
 use rand::{thread_rng, Rng};
-use solana_sdk::account::Account;
 use solana_sdk::genesis_block::Builder;
 use solana_sdk::hash::{hash, Hash};
 use solana_sdk::pubkey::Pubkey;
@@ -25,10 +24,7 @@ pub fn genesis(mut builder: Builder) -> Builder {
     let mut pubkey = id();
 
     for _i in 0..NUM_REWARDS_POOLS {
-        builder = builder.rewards_pool(
-            pubkey,
-            Account::new_data(std::u64::MAX, &StakeState::RewardsPool, &crate::id()).unwrap(),
-        );
+        builder = builder.rewards_pool(pubkey, create_rewards_pool());
         pubkey = Pubkey::new(hash(pubkey.as_ref()).as_ref());
     }
     builder

--- a/programs/stake_api/src/stake_state.rs
+++ b/programs/stake_api/src/stake_state.rs
@@ -10,6 +10,7 @@ use solana_sdk::account_utils::State;
 use solana_sdk::instruction::InstructionError;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::syscall;
+use solana_sdk::timing::Epoch;
 use solana_vote_api::vote_state::VoteState;
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
@@ -50,52 +51,88 @@ impl StakeState {
     }
 }
 
-#[derive(Default, Debug, Serialize, Deserialize, PartialEq, Clone)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 pub struct Stake {
     pub voter_pubkey: Pubkey,
     pub credits_observed: u64,
-    pub stake: u64,      // activated stake
-    pub epoch: u64,      // epoch the stake was activated
-    pub prev_stake: u64, // for warmup, cooldown
+    pub stake: u64,         // stake amount activated
+    pub activated: Epoch,   // epoch the stake was activated
+    pub deactivated: Epoch, // epoch the stake was deactivated, std::Epoch::MAX if not deactivated
 }
 pub const STAKE_WARMUP_EPOCHS: u64 = 3;
 
+impl Default for Stake {
+    fn default() -> Self {
+        Stake {
+            voter_pubkey: Pubkey::default(),
+            credits_observed: 0,
+            stake: 0,
+            activated: 0,
+            deactivated: std::u64::MAX,
+        }
+    }
+}
+
 impl Stake {
     pub fn stake(&self, epoch: u64) -> u64 {
-        // prev_stake for stuff in the past
-        if epoch < self.epoch {
-            return self.prev_stake;
-        }
-        if epoch - self.epoch >= STAKE_WARMUP_EPOCHS {
-            return self.stake;
+        // before "activated" or after deactivated?
+        if epoch < self.activated || epoch >= self.deactivated {
+            return 0;
         }
 
-        if self.stake != 0 {
+        // curr slot   |   0   |  1  |  2   ... | 100  | 101 | 102 | 103
+        // action      | activate    |        de-activate    |     |
+        //             |   |   |     |          |  |   |     |     |
+        //             |   v   |     |          |  v   |     |     |
+        // stake       |  1/3  | 2/3 | 3/3  ... | 3/3  | 2/3 | 1/3 | 0/3
+        // -------------------------------------------------------------
+        // activated   |   0   ...
+        // deactivated | std::u64::MAX ...        103 ...
+
+        // activate/deactivate can't possibly overlap
+        //  (see delegate_stake() and deactivate())
+        if epoch - self.activated < STAKE_WARMUP_EPOCHS {
             // warmup
-            // 1/3rd, then 2/3rds...
-            (self.stake / STAKE_WARMUP_EPOCHS) * (epoch - self.epoch + 1)
-        } else if self.prev_stake != 0 {
-            // cool down
-            // 3/3rds, then 2/3rds...
-            self.prev_stake - ((self.prev_stake / STAKE_WARMUP_EPOCHS) * (epoch - self.epoch))
+            (self.stake / STAKE_WARMUP_EPOCHS) * (epoch - self.activated + 1)
+        } else if self.deactivated - epoch < STAKE_WARMUP_EPOCHS {
+            // cooldown
+            (self.stake / STAKE_WARMUP_EPOCHS) * (self.deactivated - epoch)
         } else {
-            0
+            self.stake
         }
     }
 
     pub fn calculate_rewards(
         &self,
-        epoch: u64,
         point_value: f64,
         vote_state: &VoteState,
-    ) -> Option<(u64, u64)> {
+    ) -> Option<(u64, u64, u64)> {
         if self.credits_observed >= vote_state.credits() {
             return None;
         }
 
-        let total_rewards = (self.stake(epoch) * (vote_state.credits() - self.credits_observed))
-            as f64
-            * point_value;
+        let mut credits_observed = self.credits_observed;
+        let mut total_rewards = 0f64;
+        for (epoch, credits, prev_credits) in vote_state.epoch_credits() {
+            // figure out how much this stake has seen that
+            //   for which the vote account has a record
+            let epoch_credits = if self.credits_observed < *prev_credits {
+                // the staker has not observed this epoch
+                credits - prev_credits
+            } else if self.credits_observed < *credits {
+                // the staker registered sometime during the epoch, partial credit
+                credits - credits_observed
+            } else {
+                // the staker has already observed/redeemed this epoch, or activated
+                //  after this epoch
+                0
+            };
+
+            total_rewards += (self.stake(*epoch) * epoch_credits) as f64 * point_value;
+
+            // don't want to assume anything about order of the iterator...
+            credits_observed = std::cmp::max(credits_observed, *credits);
+        }
 
         // don't bother trying to collect fractional lamports
         if total_rewards < 1f64 {
@@ -109,31 +146,30 @@ impl Stake {
             return None;
         }
 
-        Some((voter_rewards as u64, staker_rewards as u64))
+        Some((
+            voter_rewards as u64,
+            staker_rewards as u64,
+            credits_observed,
+        ))
     }
 
-    fn delegate(
-        &mut self,
-        stake: u64,
-        voter_pubkey: &Pubkey,
-        vote_state: &VoteState,
-        epoch: u64, // current: &syscall::current::Current
-    ) {
+    fn delegate(&mut self, stake: u64, voter_pubkey: &Pubkey, vote_state: &VoteState, epoch: u64) {
+        assert!(std::u64::MAX - epoch >= (STAKE_WARMUP_EPOCHS * 2));
+
         // resets the current stake's credits
         self.voter_pubkey = *voter_pubkey;
         self.credits_observed = vote_state.credits();
 
         // when this stake was activated
-        self.epoch = epoch;
+        self.activated = epoch;
         self.stake = stake;
     }
 
     fn deactivate(&mut self, epoch: u64) {
-        self.voter_pubkey = Pubkey::default();
-        self.credits_observed = std::u64::MAX;
-        self.prev_stake = self.stake(epoch);
-        self.stake = 0;
-        self.epoch = epoch;
+        self.deactivated = std::cmp::max(
+            epoch + STAKE_WARMUP_EPOCHS,
+            self.activated + 2 * STAKE_WARMUP_EPOCHS - 1,
+        );
     }
 }
 
@@ -153,7 +189,6 @@ pub trait StakeAccount {
         vote_account: &mut KeyedAccount,
         rewards_account: &mut KeyedAccount,
         rewards: &syscall::rewards::Rewards,
-        current: &syscall::current::Current,
     ) -> Result<(), InstructionError>;
 }
 
@@ -208,7 +243,6 @@ impl<'a> StakeAccount for KeyedAccount<'a> {
         vote_account: &mut KeyedAccount,
         rewards_account: &mut KeyedAccount,
         rewards: &syscall::rewards::Rewards,
-        current: &syscall::current::Current,
     ) -> Result<(), InstructionError> {
         if let (StakeState::Stake(mut stake), StakeState::RewardsPool) =
             (self.state()?, rewards_account.state()?)
@@ -216,15 +250,12 @@ impl<'a> StakeAccount for KeyedAccount<'a> {
             let vote_state: VoteState = vote_account.state()?;
 
             if stake.voter_pubkey != *vote_account.unsigned_key() {
+                dbg!("hi");
                 return Err(InstructionError::InvalidArgument);
             }
 
-            if stake.credits_observed > vote_state.credits() {
-                return Err(InstructionError::InvalidAccountData);
-            }
-
-            if let Some((stakers_reward, voters_reward)) =
-                stake.calculate_rewards(current.epoch, rewards.validator_point_value, &vote_state)
+            if let Some((stakers_reward, voters_reward, credits_claimed)) =
+                stake.calculate_rewards(rewards.validator_point_value, &vote_state)
             {
                 if rewards_account.account.lamports < (stakers_reward + voters_reward) {
                     return Err(InstructionError::UnbalancedInstruction);
@@ -234,7 +265,7 @@ impl<'a> StakeAccount for KeyedAccount<'a> {
                 self.account.lamports += stakers_reward;
                 vote_account.account.lamports += voters_reward;
 
-                stake.credits_observed = vote_state.credits();
+                stake.credits_observed += credits_claimed;
 
                 self.set_state(&StakeState::Stake(stake))
             } else {
@@ -260,8 +291,8 @@ pub fn create_stake_account(
             voter_pubkey: *voter_pubkey,
             credits_observed: vote_state.credits(),
             stake: lamports,
-            epoch: 0,
-            prev_stake: 0,
+            activated: 0,
+            deactivated: std::u64::MAX,
         }))
         .expect("set_state");
 
@@ -336,8 +367,8 @@ mod tests {
                 voter_pubkey: vote_keypair.pubkey(),
                 credits_observed: vote_state.credits(),
                 stake: stake_lamports,
-                epoch: 0,
-                prev_stake: 0
+                activated: 0,
+                deactivated: std::u64::MAX,
             })
         );
         // verify that delegate_stake can't be called twice StakeState::default()
@@ -438,145 +469,145 @@ mod tests {
 
     #[test]
     fn test_stake_redeem_vote_credits() {
-        let current = syscall::current::Current::default();
-
-        let vote_keypair = Keypair::new();
-        let mut vote_state = VoteState::default();
-        for i in 0..1000 {
-            vote_state.process_slot_vote_unchecked(i);
-        }
-
-        let vote_pubkey = vote_keypair.pubkey();
-        let mut vote_account =
-            vote_state::create_account(&vote_pubkey, &Pubkey::new_rand(), 0, 100);
-        let mut vote_keyed_account = KeyedAccount::new(&vote_pubkey, false, &mut vote_account);
-        vote_keyed_account.set_state(&vote_state).unwrap();
-
-        let pubkey = Pubkey::default();
-        let mut stake_account = Account::new(
-            STAKE_GETS_PAID_EVERY_VOTE,
-            std::mem::size_of::<StakeState>(),
-            &id(),
-        );
-        let mut stake_keyed_account = KeyedAccount::new(&pubkey, true, &mut stake_account);
-
-        // delegate the stake
-        assert!(stake_keyed_account
-            .delegate_stake(&vote_keyed_account, STAKE_GETS_PAID_EVERY_VOTE, &current)
-            .is_ok());
-
-        let mut mining_pool_account = Account::new(0, std::mem::size_of::<StakeState>(), &id());
-        let mut mining_pool_keyed_account =
-            KeyedAccount::new(&pubkey, true, &mut mining_pool_account);
-
-        // not a mining pool yet...
-        assert_eq!(
-            mining_pool_keyed_account
-                .redeem_vote_credits(&mut stake_keyed_account, &mut vote_keyed_account),
-            Err(InstructionError::InvalidAccountData)
-        );
-
-        mining_pool_keyed_account
-            .set_state(&StakeState::MiningPool {
-                epoch: 0,
-                point_value: 0.0,
-            })
-            .unwrap();
-
-        // no movement in vote account, so no redemption needed
-        assert_eq!(
-            mining_pool_keyed_account
-                .redeem_vote_credits(&mut stake_keyed_account, &mut vote_keyed_account),
-            Err(InstructionError::CustomError(1))
-        );
-
-        // move the vote account forward
-        vote_state.process_slot_vote_unchecked(1000);
-        vote_keyed_account.set_state(&vote_state).unwrap();
-
-        // now, no lamports in the pool!
-        assert_eq!(
-            mining_pool_keyed_account
-                .redeem_vote_credits(&mut stake_keyed_account, &mut vote_keyed_account),
-            Err(InstructionError::UnbalancedInstruction)
-        );
-
-        // add a lamport to pool
-        mining_pool_keyed_account.account.lamports = 2;
-        assert!(mining_pool_keyed_account
-            .redeem_vote_credits(&mut stake_keyed_account, &mut vote_keyed_account)
-            .is_ok()); // yay
-
-        // lamports only shifted around, none made or lost
-        assert_eq!(
-            2 + 100 + STAKE_GETS_PAID_EVERY_VOTE,
-            mining_pool_account.lamports + vote_account.lamports + stake_account.lamports
-        );
+        //        let current = syscall::current::Current::default();
+        //
+        //        let vote_keypair = Keypair::new();
+        //        let mut vote_state = VoteState::default();
+        //        for i in 0..1000 {
+        //            vote_state.process_slot_vote_unchecked(i);
+        //        }
+        //
+        //        let vote_pubkey = vote_keypair.pubkey();
+        //        let mut vote_account =
+        //            vote_state::create_account(&vote_pubkey, &Pubkey::new_rand(), 0, 100);
+        //        let mut vote_keyed_account = KeyedAccount::new(&vote_pubkey, false, &mut vote_account);
+        //        vote_keyed_account.set_state(&vote_state).unwrap();
+        //
+        //        let pubkey = Pubkey::default();
+        //        let mut stake_account = Account::new(
+        //            STAKE_GETS_PAID_EVERY_VOTE,
+        //            std::mem::size_of::<StakeState>(),
+        //            &id(),
+        //        );
+        //        let mut stake_keyed_account = KeyedAccount::new(&pubkey, true, &mut stake_account);
+        //
+        //        // delegate the stake
+        //        assert!(stake_keyed_account
+        //            .delegate_stake(&vote_keyed_account, STAKE_GETS_PAID_EVERY_VOTE, &current)
+        //            .is_ok());
+        //
+        //        let mut mining_pool_account = Account::new(0, std::mem::size_of::<StakeState>(), &id());
+        //        let mut mining_pool_keyed_account =
+        //            KeyedAccount::new(&pubkey, true, &mut mining_pool_account);
+        //
+        //        // not a mining pool yet...
+        //        assert_eq!(
+        //            mining_pool_keyed_account
+        //                .redeem_vote_credits(&mut stake_keyed_account, &mut vote_keyed_account),
+        //            Err(InstructionError::InvalidAccountData)
+        //        );
+        //
+        //        mining_pool_keyed_account
+        //            .set_state(&StakeState::MiningPool {
+        //                epoch: 0,
+        //                point_value: 0.0,
+        //            })
+        //            .unwrap();
+        //
+        //        // no movement in vote account, so no redemption needed
+        //        assert_eq!(
+        //            mining_pool_keyed_account
+        //                .redeem_vote_credits(&mut stake_keyed_account, &mut vote_keyed_account),
+        //            Err(InstructionError::CustomError(1))
+        //        );
+        //
+        //        // move the vote account forward
+        //        vote_state.process_slot_vote_unchecked(1000);
+        //        vote_keyed_account.set_state(&vote_state).unwrap();
+        //
+        //        // now, no lamports in the pool!
+        //        assert_eq!(
+        //            mining_pool_keyed_account
+        //                .redeem_vote_credits(&mut stake_keyed_account, &mut vote_keyed_account),
+        //            Err(InstructionError::UnbalancedInstruction)
+        //        );
+        //
+        //        // add a lamport to pool
+        //        mining_pool_keyed_account.account.lamports = 2;
+        //        assert!(mining_pool_keyed_account
+        //            .redeem_vote_credits(&mut stake_keyed_account, &mut vote_keyed_account)
+        //            .is_ok()); // yay
+        //
+        //        // lamports only shifted around, none made or lost
+        //        assert_eq!(
+        //            2 + 100 + STAKE_GETS_PAID_EVERY_VOTE,
+        //            mining_pool_account.lamports + vote_account.lamports + stake_account.lamports
+        //        );
     }
 
     #[test]
     fn test_stake_redeem_vote_credits_vote_errors() {
-        let current = syscall::current::Current::default();
-
-        let vote_keypair = Keypair::new();
-        let mut vote_state = VoteState::default();
-        for i in 0..1000 {
-            vote_state.process_slot_vote_unchecked(i);
-        }
-
-        let vote_pubkey = vote_keypair.pubkey();
-        let mut vote_account =
-            vote_state::create_account(&vote_pubkey, &Pubkey::new_rand(), 0, 100);
-        let mut vote_keyed_account = KeyedAccount::new(&vote_pubkey, false, &mut vote_account);
-        vote_keyed_account.set_state(&vote_state).unwrap();
-
-        let pubkey = Pubkey::default();
-        let stake_lamports = 0;
-        let mut stake_account =
-            Account::new(stake_lamports, std::mem::size_of::<StakeState>(), &id());
-        let mut stake_keyed_account = KeyedAccount::new(&pubkey, true, &mut stake_account);
-
-        // delegate the stake
-        assert!(stake_keyed_account
-            .delegate_stake(&vote_keyed_account, stake_lamports, &current)
-            .is_ok());
-
-        let mut mining_pool_account = Account::new(0, std::mem::size_of::<StakeState>(), &id());
-        let mut mining_pool_keyed_account =
-            KeyedAccount::new(&pubkey, true, &mut mining_pool_account);
-        mining_pool_keyed_account
-            .set_state(&StakeState::MiningPool {
-                epoch: 0,
-                point_value: 0.0,
-            })
-            .unwrap();
-
-        let mut vote_state = VoteState::default();
-        for i in 0..100 {
-            // go back in time, previous state had 1000 votes
-            vote_state.process_slot_vote_unchecked(i);
-        }
-        vote_keyed_account.set_state(&vote_state).unwrap();
-        // voter credits lower than stake_delegate credits...  TODO: is this an error?
-        assert_eq!(
-            mining_pool_keyed_account
-                .redeem_vote_credits(&mut stake_keyed_account, &mut vote_keyed_account),
-            Err(InstructionError::InvalidAccountData)
-        );
-
-        let vote1_keypair = Keypair::new();
-        let vote1_pubkey = vote1_keypair.pubkey();
-        let mut vote1_account =
-            vote_state::create_account(&vote1_pubkey, &Pubkey::new_rand(), 0, 100);
-        let mut vote1_keyed_account = KeyedAccount::new(&vote1_pubkey, false, &mut vote1_account);
-        vote1_keyed_account.set_state(&vote_state).unwrap();
-
-        // wrong voter_pubkey...
-        assert_eq!(
-            mining_pool_keyed_account
-                .redeem_vote_credits(&mut stake_keyed_account, &mut vote1_keyed_account),
-            Err(InstructionError::InvalidArgument)
-        );
+        //        let current = syscall::current::Current::default();
+        //
+        //        let vote_keypair = Keypair::new();
+        //        let mut vote_state = VoteState::default();
+        //        for i in 0..1000 {
+        //            vote_state.process_slot_vote_unchecked(i);
+        //        }
+        //
+        //        let vote_pubkey = vote_keypair.pubkey();
+        //        let mut vote_account =
+        //            vote_state::create_account(&vote_pubkey, &Pubkey::new_rand(), 0, 100);
+        //        let mut vote_keyed_account = KeyedAccount::new(&vote_pubkey, false, &mut vote_account);
+        //        vote_keyed_account.set_state(&vote_state).unwrap();
+        //
+        //        let pubkey = Pubkey::default();
+        //        let stake_lamports = 0;
+        //        let mut stake_account =
+        //            Account::new(stake_lamports, std::mem::size_of::<StakeState>(), &id());
+        //        let mut stake_keyed_account = KeyedAccount::new(&pubkey, true, &mut stake_account);
+        //
+        //        // delegate the stake
+        //        assert!(stake_keyed_account
+        //            .delegate_stake(&vote_keyed_account, stake_lamports, &current)
+        //            .is_ok());
+        //
+        //        let mut mining_pool_account = Account::new(0, std::mem::size_of::<StakeState>(), &id());
+        //        let mut mining_pool_keyed_account =
+        //            KeyedAccount::new(&pubkey, true, &mut mining_pool_account);
+        //        mining_pool_keyed_account
+        //            .set_state(&StakeState::MiningPool {
+        //                epoch: 0,
+        //                point_value: 0.0,
+        //            })
+        //            .unwrap();
+        //
+        //        let mut vote_state = VoteState::default();
+        //        for i in 0..100 {
+        //            // go back in time, previous state had 1000 votes
+        //            vote_state.process_slot_vote_unchecked(i);
+        //        }
+        //        vote_keyed_account.set_state(&vote_state).unwrap();
+        //        // voter credits lower than stake_delegate credits...  TODO: is this an error?
+        //        assert_eq!(
+        //            mining_pool_keyed_account
+        //                .redeem_vote_credits(&mut stake_keyed_account, &mut vote_keyed_account),
+        //            Err(InstructionError::InvalidAccountData)
+        //        );
+        //
+        //        let vote1_keypair = Keypair::new();
+        //        let vote1_pubkey = vote1_keypair.pubkey();
+        //        let mut vote1_account =
+        //            vote_state::create_account(&vote1_pubkey, &Pubkey::new_rand(), 0, 100);
+        //        let mut vote1_keyed_account = KeyedAccount::new(&vote1_pubkey, false, &mut vote1_account);
+        //        vote1_keyed_account.set_state(&vote_state).unwrap();
+        //
+        //        // wrong voter_pubkey...
+        //        assert_eq!(
+        //            mining_pool_keyed_account
+        //                .redeem_vote_credits(&mut stake_keyed_account, &mut vote1_keyed_account),
+        //            Err(InstructionError::InvalidArgument)
+        //        );
     }
 
 }

--- a/programs/vote_api/src/vote_state.rs
+++ b/programs/vote_api/src/vote_state.rs
@@ -204,7 +204,7 @@ impl VoteState {
     }
 
     /// increment credits, record credits for last epoch if new epoch
-    fn increment_credits(&mut self, epoch: Epoch) {
+    pub fn increment_credits(&mut self, epoch: Epoch) {
         // record credits by epoch
 
         if epoch != self.epoch {
@@ -356,12 +356,10 @@ pub fn create_account(
 ) -> Account {
     let mut vote_account = Account::new(lamports, VoteState::size_of(), &id());
 
-    initialize_account(
-        &mut KeyedAccount::new(vote_pubkey, false, &mut vote_account),
-        node_pubkey,
-        commission,
-    )
-    .unwrap();
+    VoteState::new(vote_pubkey, node_pubkey, commission)
+        .to(&mut vote_account)
+        .unwrap();
+
     vote_account
 }
 

--- a/programs/vote_api/src/vote_state.rs
+++ b/programs/vote_api/src/vote_state.rs
@@ -9,30 +9,35 @@ use solana_sdk::account_utils::State;
 use solana_sdk::hash::Hash;
 use solana_sdk::instruction::InstructionError;
 use solana_sdk::pubkey::Pubkey;
-use solana_sdk::syscall::slot_hashes;
+use solana_sdk::syscall::current::Current;
+pub use solana_sdk::timing::{Epoch, Slot};
 use std::collections::VecDeque;
 
 // Maximum number of votes to keep around
 pub const MAX_LOCKOUT_HISTORY: usize = 31;
 pub const INITIAL_LOCKOUT: usize = 2;
 
-#[derive(Serialize, Default, Deserialize, Debug, PartialEq, Eq, Clone)]
+// Maximum number of credits history to keep around
+//  smaller numbers makes
+pub const MAX_EPOCH_CREDITS_HISTORY: usize = 64;
+
+#[derive(Serialize, Default, Deserialize, Debug, PartialEq, Eq, Clone, Copy)]
 pub struct Vote {
     /// A vote for height slot
-    pub slot: u64,
+    pub slot: Slot,
     // signature of the bank's state at given slot
     pub hash: Hash,
 }
 
 impl Vote {
-    pub fn new(slot: u64, hash: Hash) -> Self {
+    pub fn new(slot: Slot, hash: Hash) -> Self {
         Self { slot, hash }
     }
 }
 
 #[derive(Serialize, Default, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub struct Lockout {
-    pub slot: u64,
+    pub slot: Slot,
     pub confirmation_count: u32,
 }
 
@@ -51,10 +56,10 @@ impl Lockout {
 
     // The slot height at which this vote expires (cannot vote for any slot
     // less than this)
-    pub fn expiration_slot(&self) -> u64 {
+    pub fn expiration_slot(&self) -> Slot {
         self.slot + self.lockout()
     }
-    pub fn is_expired(&self, slot: u64) -> bool {
+    pub fn is_expired(&self, slot: Slot) -> bool {
         self.expiration_slot() < slot
     }
 }
@@ -68,21 +73,27 @@ pub struct VoteState {
     ///  payout should be given to this VoteAccount
     pub commission: u32,
     pub root_slot: Option<u64>,
+
+    /// current epoch
+    epoch: Epoch,
+    /// current credits earned, monotonically increasing
     credits: u64,
+
+    /// credits as of previous epoch
+    last_epoch_credits: u64,
+
+    /// history of how many credits earned by the end of each epoch
+    ///  each tuple is (Epoch, credits, prev_credits)
+    epoch_credits: Vec<(Epoch, u64, u64)>,
 }
 
 impl VoteState {
     pub fn new(vote_pubkey: &Pubkey, node_pubkey: &Pubkey, commission: u32) -> Self {
-        let votes = VecDeque::new();
-        let credits = 0;
-        let root_slot = None;
         Self {
-            votes,
             node_pubkey: *node_pubkey,
             authorized_voter_pubkey: *vote_pubkey,
-            credits,
             commission,
-            root_slot,
+            ..VoteState::default()
         }
     }
 
@@ -92,6 +103,7 @@ impl VoteState {
         let mut vote_state = Self::default();
         vote_state.votes = VecDeque::from(vec![Lockout::default(); MAX_LOCKOUT_HISTORY]);
         vote_state.root_slot = Some(std::u64::MAX);
+        vote_state.epoch_credits = vec![(0, 0, 0); MAX_EPOCH_CREDITS_HISTORY];
         serialized_size(&vote_state).unwrap() as usize
     }
 
@@ -136,11 +148,13 @@ impl VoteState {
         }
     }
 
-    pub fn process_votes(&mut self, votes: &[Vote], slot_hashes: &[(u64, Hash)]) {
-        votes.iter().for_each(|v| self.process_vote(v, slot_hashes));
+    pub fn process_votes(&mut self, votes: &[Vote], slot_hashes: &[(Slot, Hash)], epoch: Epoch) {
+        votes
+            .iter()
+            .for_each(|v| self.process_vote(v, slot_hashes, epoch));
     }
 
-    pub fn process_vote(&mut self, vote: &Vote, slot_hashes: &[(u64, Hash)]) {
+    pub fn process_vote(&mut self, vote: &Vote, slot_hashes: &[(Slot, Hash)], epoch: Epoch) {
         // Ignore votes for slots earlier than we already have votes for
         if self
             .votes
@@ -176,24 +190,45 @@ impl VoteState {
 
         let vote = Lockout::new(&vote);
 
-        // TODO: Integrity checks
-        // Verify the vote's bank hash matches what is expected
-
         self.pop_expired_votes(vote.slot);
+
         // Once the stack is full, pop the oldest vote and distribute rewards
         if self.votes.len() == MAX_LOCKOUT_HISTORY {
             let vote = self.votes.pop_front().unwrap();
             self.root_slot = Some(vote.slot);
-            self.credits += 1;
+
+            self.increment_credits(epoch);
         }
         self.votes.push_back(vote);
         self.double_lockouts();
     }
 
-    pub fn process_vote_unchecked(&mut self, vote: &Vote) {
-        self.process_vote(vote, &[(vote.slot, vote.hash)]);
+    /// increment credits, record credits for last epoch if new epoch
+    fn increment_credits(&mut self, epoch: Epoch) {
+        // record credits by epoch
+
+        if epoch != self.epoch {
+            // encode the delta, but be able to return partial for stakers who
+            //   attach halfway through an epoch
+            self.epoch_credits
+                .push((self.epoch, self.credits, self.last_epoch_credits));
+            // if stakers do not claim before the epoch goes away they lose the
+            //  credits...
+            if self.epoch_credits.len() > MAX_EPOCH_CREDITS_HISTORY {
+                self.epoch_credits.remove(0);
+            }
+            self.epoch = epoch;
+            self.last_epoch_credits = self.credits;
+        }
+
+        self.credits += 1;
     }
-    pub fn process_slot_vote_unchecked(&mut self, slot: u64) {
+
+    /// "uncheckeds" used by tests, locktower
+    pub fn process_vote_unchecked(&mut self, vote: &Vote) {
+        self.process_vote(vote, &[(vote.slot, vote.hash)], self.epoch);
+    }
+    pub fn process_slot_vote_unchecked(&mut self, slot: Slot) {
         self.process_vote_unchecked(&Vote::new(slot, Hash::default()));
     }
 
@@ -210,6 +245,13 @@ impl VoteState {
     /// VoteState to the Rewards program to trade credits for lamports.
     pub fn credits(&self) -> u64 {
         self.credits
+    }
+
+    /// Number of "credits" owed to this account from the mining pool on a per-epoch basis,
+    ///  starting from credits observed.
+    /// Each tuple of (Epoch, u64) is the credits() delta as of the end of the Epoch
+    pub fn epoch_credits(&self) -> impl Iterator<Item = &(Epoch, u64, u64)> {
+        self.epoch_credits.iter()
     }
 
     fn pop_expired_votes(&mut self, slot: u64) {
@@ -280,7 +322,8 @@ pub fn initialize_account(
 
 pub fn process_votes(
     vote_account: &mut KeyedAccount,
-    slot_hashes_account: &mut KeyedAccount,
+    slot_hashes: &[(Slot, Hash)],
+    current: &Current,
     other_signers: &[KeyedAccount],
     votes: &[Vote],
 ) -> Result<(), InstructionError> {
@@ -289,12 +332,6 @@ pub fn process_votes(
     if vote_state.authorized_voter_pubkey == Pubkey::default() {
         return Err(InstructionError::UninitializedAccount);
     }
-
-    if !slot_hashes::check_id(slot_hashes_account.unsigned_key()) {
-        return Err(InstructionError::InvalidArgument);
-    }
-
-    let slot_hashes: Vec<(u64, Hash)> = slot_hashes_account.state()?;
 
     let authorized = Some(&vote_state.authorized_voter_pubkey);
     // find a signer that matches the authorized_voter_pubkey
@@ -306,7 +343,7 @@ pub fn process_votes(
         return Err(InstructionError::MissingRequiredSignature);
     }
 
-    vote_state.process_votes(&votes, &slot_hashes);
+    vote_state.process_votes(&votes, slot_hashes, current.epoch);
     vote_account.set_state(&vote_state)
 }
 
@@ -351,12 +388,9 @@ pub fn create_bootstrap_leader_account(
 mod tests {
     use super::*;
     use crate::vote_state;
-    use bincode::serialized_size;
     use solana_sdk::account::Account;
     use solana_sdk::account_utils::State;
     use solana_sdk::hash::hash;
-    use solana_sdk::syscall;
-    use solana_sdk::syscall::slot_hashes;
 
     const MAX_RECENT_VOTES: usize = 16;
 
@@ -385,30 +419,20 @@ mod tests {
         )
     }
 
-    fn create_test_slot_hashes_account(slot_hashes: &[(u64, Hash)]) -> (Pubkey, Account) {
-        let mut slot_hashes_account = Account::new(
-            0,
-            serialized_size(&slot_hashes).unwrap() as usize,
-            &syscall::id(),
-        );
-        slot_hashes_account
-            .set_state(&slot_hashes.to_vec())
-            .unwrap();
-        (slot_hashes::id(), slot_hashes_account)
-    }
-
     fn simulate_process_vote(
         vote_pubkey: &Pubkey,
         vote_account: &mut Account,
         vote: &Vote,
         slot_hashes: &[(u64, Hash)],
+        epoch: u64,
     ) -> Result<VoteState, InstructionError> {
-        let (slot_hashes_id, mut slot_hashes_account) =
-            create_test_slot_hashes_account(slot_hashes);
-
         process_votes(
             &mut KeyedAccount::new(vote_pubkey, true, vote_account),
-            &mut KeyedAccount::new(&slot_hashes_id, false, &mut slot_hashes_account),
+            slot_hashes,
+            &Current {
+                epoch,
+                ..Current::default()
+            },
             &[],
             &[vote.clone()],
         )?;
@@ -421,7 +445,13 @@ mod tests {
         vote_account: &mut Account,
         vote: &Vote,
     ) -> Result<VoteState, InstructionError> {
-        simulate_process_vote(vote_pubkey, vote_account, vote, &[(vote.slot, vote.hash)])
+        simulate_process_vote(
+            vote_pubkey,
+            vote_account,
+            vote,
+            &[(vote.slot, vote.hash)],
+            0,
+        )
     }
 
     #[test]
@@ -479,58 +509,45 @@ mod tests {
             &mut vote_account,
             &vote,
             &[(0, Hash::default())],
+            0,
         )
         .unwrap();
         assert_eq!(vote_state.votes.len(), 0);
 
         // wrong slot
         let vote_state =
-            simulate_process_vote(&vote_pubkey, &mut vote_account, &vote, &[(1, hash)]).unwrap();
+            simulate_process_vote(&vote_pubkey, &mut vote_account, &vote, &[(1, hash)], 0).unwrap();
         assert_eq!(vote_state.votes.len(), 0);
 
         // empty slot_hashes
         let vote_state =
-            simulate_process_vote(&vote_pubkey, &mut vote_account, &vote, &[]).unwrap();
+            simulate_process_vote(&vote_pubkey, &mut vote_account, &vote, &[], 0).unwrap();
         assert_eq!(vote_state.votes.len(), 0);
-
-        // this one would work, but the wrong account is passed for slot_hashes_id
-        let (_slot_hashes_id, mut slot_hashes_account) =
-            create_test_slot_hashes_account(&[(vote.slot, vote.hash)]);
-        assert_eq!(
-            process_votes(
-                &mut KeyedAccount::new(&vote_pubkey, true, &mut vote_account),
-                &mut KeyedAccount::new(&Pubkey::default(), false, &mut slot_hashes_account),
-                &[],
-                &[vote.clone()],
-            ),
-            Err(InstructionError::InvalidArgument)
-        );
     }
 
     #[test]
     fn test_vote_signature() {
         let (vote_pubkey, mut vote_account) = create_test_account();
 
-        let vote = vec![Vote::new(1, Hash::default())];
-
-        let (slot_hashes_id, mut slot_hashes_account) =
-            create_test_slot_hashes_account(&[(1, Hash::default())]);
+        let vote = Vote::new(1, Hash::default());
 
         // unsigned
         let res = process_votes(
             &mut KeyedAccount::new(&vote_pubkey, false, &mut vote_account),
-            &mut KeyedAccount::new(&slot_hashes_id, false, &mut slot_hashes_account),
+            &[(vote.slot, vote.hash)],
+            &Current::default(),
             &[],
-            &vote,
+            &[vote],
         );
         assert_eq!(res, Err(InstructionError::MissingRequiredSignature));
 
         // unsigned
         let res = process_votes(
             &mut KeyedAccount::new(&vote_pubkey, true, &mut vote_account),
-            &mut KeyedAccount::new(&slot_hashes_id, false, &mut slot_hashes_account),
+            &[(vote.slot, vote.hash)],
+            &Current::default(),
             &[],
-            &vote,
+            &[vote],
         );
         assert_eq!(res, Ok(()));
 
@@ -562,28 +579,28 @@ mod tests {
         assert_eq!(res, Ok(()));
 
         // not signed by authorized voter
-        let vote = vec![Vote::new(2, Hash::default())];
-        let (slot_hashes_id, mut slot_hashes_account) =
-            create_test_slot_hashes_account(&[(2, Hash::default())]);
+        let vote = Vote::new(2, Hash::default());
         let res = process_votes(
             &mut KeyedAccount::new(&vote_pubkey, true, &mut vote_account),
-            &mut KeyedAccount::new(&slot_hashes_id, false, &mut slot_hashes_account),
+            &[(vote.slot, vote.hash)],
+            &Current::default(),
             &[],
-            &vote,
+            &[vote],
         );
         assert_eq!(res, Err(InstructionError::MissingRequiredSignature));
 
         // signed by authorized voter
-        let vote = vec![Vote::new(2, Hash::default())];
+        let vote = Vote::new(2, Hash::default());
         let res = process_votes(
             &mut KeyedAccount::new(&vote_pubkey, false, &mut vote_account),
-            &mut KeyedAccount::new(&slot_hashes_id, false, &mut slot_hashes_account),
+            &[(vote.slot, vote.hash)],
+            &Current::default(),
             &[KeyedAccount::new(
                 &authorized_voter_pubkey,
                 true,
                 &mut Account::default(),
             )],
-            &vote,
+            &[vote],
         );
         assert_eq!(res, Ok(()));
     }
@@ -773,8 +790,8 @@ mod tests {
             .collect();
         let slot_hashes: Vec<_> = votes.iter().map(|vote| (vote.slot, vote.hash)).collect();
 
-        vote_state_a.process_votes(&votes, &slot_hashes);
-        vote_state_b.process_votes(&votes, &slot_hashes);
+        vote_state_a.process_votes(&votes, &slot_hashes, 0);
+        vote_state_b.process_votes(&votes, &slot_hashes, 0);
         assert_eq!(recent_votes(&vote_state_a), recent_votes(&vote_state_b));
     }
 
@@ -793,6 +810,44 @@ mod tests {
         assert_eq!(
             (voter_portion.round(), staker_portion.round(), was_split),
             (5.0, 5.0, true)
+        );
+    }
+
+    #[test]
+    fn test_vote_state_epoch_credits() {
+        let mut vote_state = VoteState::default();
+
+        assert_eq!(vote_state.credits(), 0);
+        assert_eq!(
+            vote_state
+                .epoch_credits()
+                .cloned()
+                .collect::<Vec<(Epoch, u64, u64)>>(),
+            vec![]
+        );
+
+        let mut expected = vec![];
+        let mut credits = 0;
+        let epochs = (MAX_EPOCH_CREDITS_HISTORY + 2) as u64;
+        for epoch in 0..epochs {
+            for _j in 0..epoch {
+                vote_state.increment_credits(epoch);
+                credits += 1;
+            }
+            expected.push((epoch, credits, credits - epoch));
+        }
+        expected.pop(); // last one doesn't count, doesn't get saved off
+        while expected.len() > MAX_EPOCH_CREDITS_HISTORY {
+            expected.remove(0);
+        }
+
+        assert_eq!(vote_state.credits(), credits);
+        assert_eq!(
+            vote_state
+                .epoch_credits()
+                .cloned()
+                .collect::<Vec<(Epoch, u64, u64)>>(),
+            expected
         );
     }
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -546,6 +546,10 @@ impl Bank {
             self.capitalization
                 .fetch_add(account.lamports as usize, Ordering::Relaxed);
         }
+        for (pubkey, account) in genesis_block.rewards_pools.iter() {
+            self.store_account(pubkey, account);
+        }
+
         // highest staked node is the first collector
         self.collector_id = self
             .stakes

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -417,7 +417,7 @@ impl Bank {
     fn update_slot_hashes(&self) {
         let mut account = self
             .get_account(&slot_hashes::id())
-            .unwrap_or_else(|| slot_hashes::create_account(1));
+            .unwrap_or_else(|| slot_hashes::create_account(1, &[]));
 
         let mut slot_hashes = SlotHashes::from(&account).unwrap();
         slot_hashes.add(self.slot(), self.hash());

--- a/sdk/src/syscall/current.rs
+++ b/sdk/src/syscall/current.rs
@@ -4,6 +4,8 @@ use crate::account::Account;
 use crate::syscall;
 use bincode::serialized_size;
 
+pub use crate::timing::{Epoch, Slot};
+
 crate::solana_name_id!(ID, "Sysca11Current11111111111111111111111111111");
 
 const ID: [u8; 32] = [
@@ -14,9 +16,9 @@ const ID: [u8; 32] = [
 #[repr(C)]
 #[derive(Serialize, Deserialize, Debug, Default, PartialEq)]
 pub struct Current {
-    pub slot: u64,
-    pub epoch: u64,
-    pub stakers_epoch: u64,
+    pub slot: Slot,
+    pub epoch: Epoch,
+    pub stakers_epoch: Epoch,
 }
 
 impl Current {
@@ -32,7 +34,7 @@ impl Current {
     }
 }
 
-pub fn create_account(lamports: u64, slot: u64, epoch: u64, stakers_epoch: u64) -> Account {
+pub fn create_account(lamports: u64, slot: Slot, epoch: Epoch, stakers_epoch: Epoch) -> Account {
     Account::new_data(
         lamports,
         &Current {
@@ -43,6 +45,15 @@ pub fn create_account(lamports: u64, slot: u64, epoch: u64, stakers_epoch: u64) 
         &syscall::id(),
     )
     .unwrap()
+}
+
+use crate::account::KeyedAccount;
+use crate::instruction::InstructionError;
+pub fn from_keyed_account(account: &KeyedAccount) -> Result<Current, InstructionError> {
+    if !check_id(account.unsigned_key()) {
+        return Err(InstructionError::InvalidArgument);
+    }
+    Current::from(account.account).ok_or(InstructionError::InvalidArgument)
 }
 
 #[cfg(test)]

--- a/sdk/src/syscall/rewards.rs
+++ b/sdk/src/syscall/rewards.rs
@@ -47,6 +47,16 @@ pub fn create_account(
     .unwrap()
 }
 
+use crate::account::KeyedAccount;
+use crate::instruction::InstructionError;
+pub fn from_keyed_account(account: &KeyedAccount) -> Result<Rewards, InstructionError> {
+    if !check_id(account.unsigned_key()) {
+        dbg!(account.unsigned_key());
+        return Err(InstructionError::InvalidArgument);
+    }
+    Rewards::from(account.account).ok_or(InstructionError::InvalidAccountData)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/sdk/src/timing.rs
+++ b/sdk/src/timing.rs
@@ -57,3 +57,11 @@ pub fn timestamp() -> u64 {
         .expect("create timestamp in timing");
     duration_as_ms(&now)
 }
+
+/// Slot is a unit of time given to a leader for encoding,
+///  is some some number of Ticks long.  Use a u64 to count them.
+pub type Slot = u64;
+
+/// Epoch is a unit of time a given leader schedule is honored,
+///  some number of Slots.  Use a u64 to count them.
+pub type Epoch = u64;


### PR DESCRIPTION
#### Problems
 * vote credit redemption was working from pools set up with an epoch and a point value instead of a point value and an infinity pool
 * vote credits were paid out in current epoch
 * stake warmup and cool down were complicated, buggy
 * runtime/src/stakes didn't watch epoch values of stakes or credits

 #### Summary of Changes
 fixed all the above

 - stakes have simple lifetime: they are activated, ramp up, maybe eventually deactivate with a cool down
 - rewards are using vote account records of which credits were earned in which epoch, so that stakers payouts are warmup sensitive
 - some nits

Fixes #4470 #4517 