### PR TITLE
Set proper count value for account stores

### DIFF
--- a/core/src/bank_forks.rs
+++ b/core/src/bank_forks.rs
@@ -329,8 +329,9 @@ impl BankForks {
         names.sort();
         let mut bank_maps = vec![];
         let status_cache_rc = StatusCacheRc::default();
+        let id = (names[names.len() - 1] + 1) as usize;
         let mut bank0 =
-            Bank::create_with_genesis(&genesis_block, account_paths.clone(), &status_cache_rc);
+            Bank::create_with_genesis(&genesis_block, account_paths.clone(), &status_cache_rc, id);
         bank0.freeze();
         let bank_root = BankForks::load_snapshots(
             &names,

--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -1,21 +1,18 @@
 use hashbrown::HashMap;
 use log::*;
-use serde::{Deserialize, Serialize};
 use solana_sdk::pubkey::Pubkey;
 use std::collections;
 use std::collections::HashSet;
 
 pub type Fork = u64;
 
-#[derive(Debug, Default, Deserialize, Serialize)]
+#[derive(Debug, Default)]
 pub struct AccountsIndex<T> {
-    #[serde(skip)]
     pub account_maps: HashMap<Pubkey, Vec<(Fork, T)>>,
 
     pub roots: HashSet<Fork>,
 
     //This value that needs to be stored to recover the index from AppendVec
-    #[serde(skip)]
     pub last_root: Fork,
 }
 

--- a/runtime/src/append_vec.rs
+++ b/runtime/src/append_vec.rs
@@ -325,6 +325,7 @@ impl Serialize for AppendVec {
             + std::mem::size_of::<usize>() as u64;
         let mut buf = vec![0u8; len as usize];
         let mut wr = Cursor::new(&mut buf[..]);
+        self.map.flush().map_err(Error::custom)?;
         serialize_into(&mut wr, &self.path).map_err(Error::custom)?;
         serialize_into(&mut wr, &(self.current_len.load(Ordering::Relaxed) as u64))
             .map_err(Error::custom)?;

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4,7 +4,7 @@
 //! already been signed and verified.
 use crate::accounts::Accounts;
 use crate::accounts_db::{
-    ErrorCounters, InstructionAccounts, InstructionCredits, InstructionLoaders,
+    AppendVecId, ErrorCounters, InstructionAccounts, InstructionCredits, InstructionLoaders,
 };
 use crate::accounts_index::Fork;
 use crate::blockhash_queue::BlockhashQueue;
@@ -62,9 +62,12 @@ pub struct BankRc {
 }
 
 impl BankRc {
-    pub fn new(account_paths: Option<String>, id: usize) -> Self {
+    pub fn new(account_paths: Option<String>, id: AppendVecId) -> Self {
         let accounts = Accounts::new(account_paths);
-        accounts.accounts_db.next_id.store(id, Ordering::Relaxed);
+        accounts
+            .accounts_db
+            .next_id
+            .store(id as usize, Ordering::Relaxed);
         BankRc {
             accounts: Arc::new(accounts),
             parent: RwLock::new(None),
@@ -375,7 +378,7 @@ impl Bank {
         genesis_block: &GenesisBlock,
         account_paths: Option<String>,
         status_cache_rc: &StatusCacheRc,
-        id: usize,
+        id: AppendVecId,
     ) -> Self {
         let mut bank = Self::default();
         bank.set_bank_rc(&BankRc::new(account_paths, id), &status_cache_rc);


### PR DESCRIPTION
#### Problem
When a validator is started from a snapshot, after processing X number of post-snapshot shots (where X is < ~100), the validator dies with an error that looks like:
solana::blocktree_processor] Unexpected validator error: ProgramAccountNotFound

#### Summary of Changes
The count value for the account store 0 gets improperly reset when the accounts are merged from the snapshots. This results in the store being removed from the roots causing the account to be not found. Make sure that the accounts are merged properly preserving the account store 0 values.


Fixes #4735 
