### PR TITLE
Make Thin client fee aware 

### DIFF
--- a/client/src/thin_client.rs
+++ b/client/src/thin_client.rs
@@ -206,10 +206,8 @@ impl ThinClient {
         min_confirmed_blocks: usize,
         fee_limit: u64,
     ) -> io::Result<Signature> {
-        let mut signatures = vec![];
         let mut cost = 0;
         for x in 0..tries {
-            signatures.push(transaction.signatures[0]);
             if fee_limit > 0 && cost < fee_limit {
                 let (_blockhash, fee_calculator) = self.rpc_client().get_recent_blockhash()?;
                 cost += fee_calculator.calculate_fee(&transaction.message);
@@ -229,14 +227,11 @@ impl ThinClient {
                     fee_limit,
                 );
             }
-            for sig in signatures.iter() {
-                // break if any of the previous transactions have worked
-                if self
-                    .poll_for_signature_confirmation(sig, min_confirmed_blocks)
-                    .is_ok()
-                {
-                    return Ok(*sig);
-                }
+            if self
+                .poll_for_signature_confirmation(sig, min_confirmed_blocks)
+                .is_ok()
+            {
+                return Ok(*sig);
             }
             info!(
                 "{} tries failed transfer to {}",

--- a/client/src/thin_client.rs
+++ b/client/src/thin_client.rs
@@ -228,10 +228,10 @@ impl ThinClient {
                 );
             }
             if self
-                .poll_for_signature_confirmation(sig, min_confirmed_blocks)
+                .poll_for_signature_confirmation(&transaction.signatures[0], min_confirmed_blocks)
                 .is_ok()
             {
-                return Ok(*sig);
+                return Ok(transaction.signatures[0]);
             }
             info!(
                 "{} tries failed transfer to {}",

--- a/client/src/thin_client.rs
+++ b/client/src/thin_client.rs
@@ -235,7 +235,7 @@ impl ThinClient {
                     .poll_for_signature_confirmation(sig, min_confirmed_blocks)
                     .is_ok()
                 {
-                    return Ok(sig);
+                    return Ok(*sig);
                 }
             }
             info!(

--- a/client/src/thin_client.rs
+++ b/client/src/thin_client.rs
@@ -235,7 +235,7 @@ impl ThinClient {
                     .poll_for_signature_confirmation(sig, min_confirmed_blocks)
                     .is_ok()
                 {
-                    return Ok(sig.clone());
+                    return Ok(sig);
                 }
             }
             info!(

--- a/core/src/local_cluster.rs
+++ b/core/src/local_cluster.rs
@@ -469,6 +469,7 @@ impl LocalCluster {
                     &mut transaction,
                     5,
                     0,
+                    0,
                 )
                 .expect("delegate stake");
             client

--- a/core/src/replicator.rs
+++ b/core/src/replicator.rs
@@ -528,7 +528,7 @@ impl Replicator {
                 0,
                 balance,
             )
-            .map_err(|e| println!("Error {:?}, transfer didn't work!", e));
+            .expect("transfer didn't work!");
     }
 
     pub fn close(self) {


### PR DESCRIPTION
#### Problem

Thin Client is not intelligent about how it retries transactions.

- For every retry, it re-signs transactions and "forgets" previous transactions. This can consume N-tries * Fee in fees.

#### Summary of Changes

- Added a fee limit to send_transaction

Fixes #4803
