### PR TITLE
Forward transactions to the leader for next Nth slot

### DIFF
--- a/core/src/fetch_stage.rs
+++ b/core/src/fetch_stage.rs
@@ -1,6 +1,6 @@
 //! The `fetch_stage` batches input from a UDP socket and sends it to a channel.
 
-use crate::banking_stage::TRANSACTION_FORWARD_SLOT_TARGET;
+use crate::banking_stage::FORWARD_TRANSACTIONS_TO_LEADER_AT_SLOT_OFFSET;
 use crate::poh_recorder::PohRecorder;
 use crate::result::{Error, Result};
 use crate::service::Service;
@@ -63,7 +63,7 @@ impl FetchStage {
         }
 
         if poh_recorder.lock().unwrap().would_be_leader(
-            TRANSACTION_FORWARD_SLOT_TARGET
+            FORWARD_TRANSACTIONS_TO_LEADER_AT_SLOT_OFFSET
                 .saturating_add(1)
                 .saturating_mul(DEFAULT_TICKS_PER_SLOT),
         ) {

--- a/core/src/poh_recorder.rs
+++ b/core/src/poh_recorder.rs
@@ -105,6 +105,13 @@ impl PohRecorder {
         self.leader_schedule_cache.slot_leader_at(slot + 1, None)
     }
 
+    pub fn leader_after_slots(&self, slots: u64) -> Option<Pubkey> {
+        let slot =
+            leader_schedule_utils::tick_height_to_slot(self.ticks_per_slot, self.tick_height());
+        self.leader_schedule_cache
+            .slot_leader_at(slot + slots, None)
+    }
+
     pub fn start_slot(&self) -> u64 {
         self.start_slot
     }

--- a/sdk/src/timing.rs
+++ b/sdk/src/timing.rs
@@ -6,14 +6,14 @@ use std::time::{SystemTime, UNIX_EPOCH};
 // rate at any given time should be expected to drift
 pub const DEFAULT_NUM_TICKS_PER_SECOND: u64 = 10;
 
-// At 10 ticks/s, 4 ticks per slot implies that leader rotation and voting will happen
-// every 400 ms. A fast voting cadence ensures faster finality and convergence
-pub const DEFAULT_TICKS_PER_SLOT: u64 = 4;
+// At 10 ticks/s, 8 ticks per slot implies that leader rotation and voting will happen
+// every 800 ms. A fast voting cadence ensures faster finality and convergence
+pub const DEFAULT_TICKS_PER_SLOT: u64 = 8;
 
-// 1 Epoch = 400 * 8192 ms ~= 55 minutes
-pub const DEFAULT_SLOTS_PER_EPOCH: u64 = 8192;
+// 1 Epoch = 800 * 4096 ms ~= 55 minutes
+pub const DEFAULT_SLOTS_PER_EPOCH: u64 = 4096;
 
-pub const NUM_CONSECUTIVE_LEADER_SLOTS: u64 = 1;
+pub const NUM_CONSECUTIVE_LEADER_SLOTS: u64 = 8;
 
 /// The time window of recent block hash values that the bank will track the signatures
 /// of over. Once the bank discards a block hash, it will reject any transactions that use
@@ -29,11 +29,11 @@ pub const MAX_RECENT_BLOCKHASHES: usize = MAX_HASH_AGE_IN_SECONDS;
 /// This is maximum time consumed in forwarding a transaction from one node to next, before
 /// it can be processed in the target node
 #[cfg(feature = "cuda")]
-pub const MAX_TRANSACTION_FORWARDING_DELAY: usize = 2;
+pub const MAX_TRANSACTION_FORWARDING_DELAY: usize = 4;
 
 /// More delay is expected if CUDA is not enabled (as signature verification takes longer)
 #[cfg(not(feature = "cuda"))]
-pub const MAX_TRANSACTION_FORWARDING_DELAY: usize = 6;
+pub const MAX_TRANSACTION_FORWARDING_DELAY: usize = 12;
 
 pub fn duration_as_ns(d: &Duration) -> u64 {
     d.as_secs() * 1_000_000_000 + u64::from(d.subsec_nanos())

--- a/sdk/src/timing.rs
+++ b/sdk/src/timing.rs
@@ -6,14 +6,14 @@ use std::time::{SystemTime, UNIX_EPOCH};
 // rate at any given time should be expected to drift
 pub const DEFAULT_NUM_TICKS_PER_SECOND: u64 = 10;
 
-// At 10 ticks/s, 8 ticks per slot implies that leader rotation and voting will happen
-// every 800 ms. A fast voting cadence ensures faster finality and convergence
-pub const DEFAULT_TICKS_PER_SLOT: u64 = 8;
+// At 10 ticks/s, 4 ticks per slot implies that leader rotation and voting will happen
+// every 400 ms. A fast voting cadence ensures faster finality and convergence
+pub const DEFAULT_TICKS_PER_SLOT: u64 = 4;
 
-// 1 Epoch = 800 * 4096 ms ~= 55 minutes
-pub const DEFAULT_SLOTS_PER_EPOCH: u64 = 4096;
+// 1 Epoch = 400 * 8192 ms ~= 55 minutes
+pub const DEFAULT_SLOTS_PER_EPOCH: u64 = 8192;
 
-pub const NUM_CONSECUTIVE_LEADER_SLOTS: u64 = 8;
+pub const NUM_CONSECUTIVE_LEADER_SLOTS: u64 = 1;
 
 /// The time window of recent block hash values that the bank will track the signatures
 /// of over. Once the bank discards a block hash, it will reject any transactions that use
@@ -29,11 +29,11 @@ pub const MAX_RECENT_BLOCKHASHES: usize = MAX_HASH_AGE_IN_SECONDS;
 /// This is maximum time consumed in forwarding a transaction from one node to next, before
 /// it can be processed in the target node
 #[cfg(feature = "cuda")]
-pub const MAX_TRANSACTION_FORWARDING_DELAY: usize = 4;
+pub const MAX_TRANSACTION_FORWARDING_DELAY: usize = 2;
 
 /// More delay is expected if CUDA is not enabled (as signature verification takes longer)
 #[cfg(not(feature = "cuda"))]
-pub const MAX_TRANSACTION_FORWARDING_DELAY: usize = 12;
+pub const MAX_TRANSACTION_FORWARDING_DELAY: usize = 6;
 
 pub fn duration_as_ns(d: &Duration) -> u64 {
     d.as_secs() * 1_000_000_000 + u64::from(d.subsec_nanos())


### PR DESCRIPTION
#### Problem
Currently the transactions are forwarded to the leader for the next slot. This scheme breaks if we reduce the slot duration, and the nodes are scheduled to be a leader for 1 slot. Enough time may have passed (network delay and sig verification delay) by the time the forwarded transaction reaches the next slot leader. The receiving node will either re-forward the transaction, or drop it if it's too old. This impacts performance of the network, while nodes are doing wasteful work.

#### Summary of Changes
Check if the current node will be leader in next N-1 slots. If so, hold the transaction. If not, forward the transaction to the leader for the next Nth slot.

Fixes #4610  