### PR TITLE
Update thinclient to resend the same tx until its blockhash expires

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -22,8 +22,8 @@ use solana_runtime::locked_accounts_results::LockedAccountsResults;
 use solana_sdk::poh_config::PohConfig;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::timing::{
-    self, duration_as_us, DEFAULT_NUM_TICKS_PER_SECOND, DEFAULT_TICKS_PER_SLOT,
-    MAX_RECENT_BLOCKHASHES, MAX_TRANSACTION_FORWARDING_DELAY,
+    self, duration_as_us, DEFAULT_NUM_TICKS_PER_SECOND, DEFAULT_TICKS_PER_SLOT, MAX_PROCESSING_AGE,
+    MAX_TRANSACTION_FORWARDING_DELAY,
 };
 use solana_sdk::transaction::{self, Transaction, TransactionError};
 use std::net::UdpSocket;
@@ -423,7 +423,7 @@ impl BankingStage {
         // TODO: Banking stage threads should be prioritized to complete faster then this queue
         // expires.
         let (loaded_accounts, results) =
-            bank.load_and_execute_transactions(txs, lock_results, MAX_RECENT_BLOCKHASHES / 2);
+            bank.load_and_execute_transactions(txs, lock_results, MAX_PROCESSING_AGE);
         let load_execute_time = now.elapsed();
 
         let freeze_lock = bank.freeze_lock();
@@ -620,7 +620,7 @@ impl BankingStage {
         let result = bank.check_transactions(
             transactions,
             &filter,
-            (MAX_RECENT_BLOCKHASHES / 2)
+            (MAX_PROCESSING_AGE)
                 .saturating_sub(MAX_TRANSACTION_FORWARDING_DELAY)
                 .saturating_sub(
                     (FORWARD_TRANSACTIONS_TO_LEADER_AT_SLOT_OFFSET * bank.ticks_per_slot()

--- a/core/src/replicator.rs
+++ b/core/src/replicator.rs
@@ -500,7 +500,11 @@ impl Replicator {
                 > 0
         );
         // ...or no lamports for fees
-        assert!(client.poll_get_balance(&self.keypair.pubkey()).unwrap() > 0);
+        let balance = client.poll_get_balance(&self.keypair.pubkey()).unwrap();
+        if balance == 0 {
+            error!("Unable to submit mining proof, insufficient Replicator Account balance");
+            return;
+        }
 
         let (blockhash, _) = client.get_recent_blockhash().expect("No recent blockhash");
         let instruction = storage_instruction::mining_proof(

--- a/sdk/src/timing.rs
+++ b/sdk/src/timing.rs
@@ -26,6 +26,9 @@ pub const MAX_HASH_AGE_IN_SECONDS: usize = 120;
 // This must be <= MAX_HASH_AGE_IN_SECONDS, otherwise there's risk for DuplicateSignature errors
 pub const MAX_RECENT_BLOCKHASHES: usize = MAX_HASH_AGE_IN_SECONDS;
 
+// The maximum age of a blockhash that will be accepted by the leader
+pub const MAX_PROCESSING_AGE: usize = MAX_RECENT_BLOCKHASHES / 2;
+
 /// This is maximum time consumed in forwarding a transaction from one node to next, before
 /// it can be processed in the target node
 #[cfg(feature = "cuda")]


### PR DESCRIPTION
#### Problem

Thinclient can consume `N-tries * fee` for a single transaction. This behavior is undesirable and results in the same transaction executing multiple times.

#### Summary of Changes

Attempt to resend the same transaction until the blockhash is too old before re-signing and re-submitting it as a fresh transaction. 

At the cost taking a little longer the transaction apis in Thinclient are now far less likely to cause a transaction to execute multiple times per client request. 

Fixes #4803
