### PR TITLE
Set epoch schedule in set_root in leader schedule cache

### DIFF
--- a/core/src/blocktree_processor.rs
+++ b/core/src/blocktree_processor.rs
@@ -166,7 +166,8 @@ pub fn process_blocktree(
 
     blocktree.set_roots(&[0]).expect("Couldn't set first root");
 
-    let leader_schedule_cache = LeaderScheduleCache::new(*pending_slots[0].2.epoch_schedule(), 0);
+    let leader_schedule_cache =
+        LeaderScheduleCache::new(*pending_slots[0].2.epoch_schedule(), &pending_slots[0].2);
 
     let mut fork_info = vec![];
     let mut last_status_report = Instant::now();
@@ -225,7 +226,7 @@ pub fn process_blocktree(
 
         if blocktree.is_root(slot) {
             root = slot;
-            leader_schedule_cache.set_root(slot);
+            leader_schedule_cache.set_root(&bank);
             bank.squash();
             pending_slots.clear();
             fork_info.clear();

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -346,7 +346,7 @@ impl ReplayStage {
             // Set root first in leader schedule_cache before bank_forks because bank_forks.root
             // is consumed by repair_service to update gossip, so we don't want to get blobs for
             // repair on gossip before we update leader schedule, otherwise they may get dropped.
-            leader_schedule_cache.set_root(new_root);
+            leader_schedule_cache.set_root(rooted_banks.last().unwrap());
             bank_forks.write().unwrap().set_root(new_root);
             Self::handle_new_root(&bank_forks, progress);
             root_bank_sender.send(rooted_banks)?;

--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -328,12 +328,6 @@ mod test {
         blob.set_id(&leader_pubkey);
         blob.sign(&leader_keypair);
 
-        // without a Bank and blobs not from me, blob gets thrown out
-        assert_eq!(
-            should_retransmit_and_persist(&blob, None, &cache, &me_id),
-            false
-        );
-
         // with a Bank for slot 0, blob continues
         assert_eq!(
             should_retransmit_and_persist(&blob, Some(bank.clone()), &cache, &me_id),


### PR DESCRIPTION
#### Problem
On epoch boundaries, the next epoch of the leader schedule may not have been calculated yet. This is a problem for certain components like the BankingStage that wants to know who the leader is "N" slots in advance

#### Summary of Changes
1) Calculate leader schedule for all known epochs at cache creation
2) Greedily calculate schedules for new epochs in set_root()


Fixes #
