### PR TITLE
Fix bench-tps funding math; make generate_keypairs() and fund_keys() algorithms consistent

### DIFF
--- a/bench-tps/src/main.rs
+++ b/bench-tps/src/main.rs
@@ -40,7 +40,7 @@ fn main() {
     } = cli_config;
 
     if write_to_client_file {
-        let keypairs = generate_keypairs(&id, tx_count as u64 * 2);
+        let (keypairs, _) = generate_keypairs(&id, tx_count as u64 * 2);
         let num_accounts = keypairs.len() as u64;
         let max_fee = FeeCalculator::new(target_lamports_per_signature).max_lamports_per_signature;
         let num_lamports_per_account = (num_accounts - 1 + NUM_SIGNATURES_FOR_TXS * max_fee)


### PR DESCRIPTION
#### Problem
Bench-tps panics when fees are enabled:
```
thread 'main' panicked at 'attempt to subtract with overflow', bench-tps/src/bench.rs:365:28
``` 

The source of the problem is: `let per_unit = (f.1 - max_units * lamports_per_signature) / max_units;`
I am not sure of the motivation for `max_units * lamports_per_signature` here, but it causes the algorithm to reserve too many lamports in funder accounts, and send `f.1 - max_units * lamports_per_signature` negative before all the accounts are funded.

#### Summary of Changes
Adjust `per_unit` calculation to reserve the actual desired number of lamports in funder accounts.
This PR also adjusts `generate_keypairs()` to match the funding algorithm, so that all accounts are funded with the same (full) amount. This isn't strictly necessary to resolve the panic, but seems like it will make bench-tps less brittle in the context of fees.