### PR TITLE
Save snapshots followed by accounts to avoid stale account data

### DIFF
--- a/multinode-demo/fullnode.sh
+++ b/multinode-demo/fullnode.sh
@@ -489,6 +489,10 @@ while true; do
         (
           rm -rf "$new_state_dir" "$new_state_archive"
           mkdir -p "$new_state_dir"
+          # When saving the state, its necessary to have the snapshots be saved first
+          # followed by the accounts folder. This would avoid conditions where incomplete
+          # accounts gets picked while its still in the process of being updated and are
+          # not frozen yet.
           cp -a "$state_dir"/snapshots "$new_state_dir"
           cp -a "$state_dir"/accounts "$new_state_dir"
           cd "$new_state_dir"

--- a/multinode-demo/fullnode.sh
+++ b/multinode-demo/fullnode.sh
@@ -488,7 +488,9 @@ while true; do
         new_state_archive="$SOLANA_RSYNC_CONFIG_DIR"/new_state.tgz
         (
           rm -rf "$new_state_dir" "$new_state_archive"
-          cp -a "$state_dir" "$new_state_dir"
+          mkdir -p "$new_state_dir"
+          cp -a "$state_dir"/snapshots "$new_state_dir"
+          cp -a "$state_dir"/accounts "$new_state_dir"
           cd "$new_state_dir"
           tar zcfS "$new_state_archive" ./*
         )


### PR DESCRIPTION
#### Problem
Once the validator starts and catches up to the latest block, observe messages like:

[2019-06-25T19:42:22.269520708Z WARN  solana_vote_api::vote_state] dropped vote Vote { slot: 939, hash: 9uFh7iTJ3J9PwavjeTu3prLFA4kptGSjPDEHTfmiazcT  } matched slot 939, but not hash 8sc4miN9jEGRkBaVtJn8apA3LbkQrNNnA3aD3DQuW7fg

#### Summary of Changes
When the state (containing snapshots and accounts) is copied, if the accounts are stored first followed by snapshots, an older version of account not reflective of the snapshot state would end up being copied over causing issues when restoring it back. Make sure that the snapshots are copied followed by accounts to avoid this condition,

Fixes #4817
