### PR TITLE
Cleanup num_threads() and batch_limit numbers

### DIFF
--- a/core/benches/banking_stage.rs
+++ b/core/benches/banking_stage.rs
@@ -77,8 +77,12 @@ fn bench_consume_buffered(bencher: &mut Bencher) {
         // This tests the performance of buffering packets.
         // If the packet buffers are copied, performance will be poor.
         bencher.iter(move || {
-            let _ignored =
-                BankingStage::consume_buffered_packets(&my_pubkey, &poh_recorder, &mut packets);
+            let _ignored = BankingStage::consume_buffered_packets(
+                &my_pubkey,
+                &poh_recorder,
+                &mut packets,
+                10_000,
+            );
         });
 
         exit.store(true, Ordering::Relaxed);

--- a/core/src/packet.rs
+++ b/core/src/packet.rs
@@ -33,6 +33,7 @@ pub const BLOB_SIZE: usize = (64 * 1024 - 128); // wikipedia says there should b
 pub const BLOB_DATA_SIZE: usize = BLOB_SIZE - (BLOB_HEADER_SIZE * 2);
 pub const BLOB_DATA_ALIGN: usize = 16; // safe for erasure input pointers, gf.c needs 16byte-aligned buffers
 pub const NUM_BLOBS: usize = (NUM_PACKETS * PACKET_DATA_SIZE) / BLOB_SIZE;
+pub const PACKETS_PER_BLOB: usize = 256; // reasonable estimate for payment packets per blob based on ~200b transaction size
 
 #[derive(Clone, Default, Debug, PartialEq, Serialize, Deserialize)]
 #[repr(C)]


### PR DESCRIPTION
#### Problem

banking_stage::num_threads() and NUM_THREADS are not used, but still in the code. Batch limit did not have good constants defined and no metrics for dropped batches.

#### Summary of Changes

Re-install thread numbers into num_threads(), add batch_limit based on total number of packets we want to batch and add metrics for dropped batches.

Fixes #

