### PR TITLE
Make book build a little less annoying

### DIFF
--- a/book/build.sh
+++ b/book/build.sh
@@ -3,4 +3,4 @@ set -e
 
 cd "$(dirname "$0")"
 
-make -j"$(nproc)"
+make -j"$(nproc)" test

--- a/book/makefile
+++ b/book/makefile
@@ -4,11 +4,14 @@ MD_SRCS=$(wildcard src/*.md)
 
 SVG_IMGS=$(BOB_SRCS:art/%.bob=src/img/%.svg) $(MSC_SRCS:art/%.msc=src/img/%.svg)
 
-all: html/index.html
+TARGET=html/index.html
+TEST_STAMP=src/tests.ok
 
-test: src/tests.ok
+all: $(TARGET)
 
-open: all
+test: $(TEST_STAMP)
+
+open: $(TEST_STAMP)
 	mdbook build --open
 
 watch: $(SVG_IMGS)
@@ -26,11 +29,11 @@ src/%.md: %.md
 	@mkdir -p $(@D)
 	@cp $< $@
 
-src/tests.ok: $(SVG_IMGS) $(MD_SRCS)
+$(TEST_STAMP): $(TARGET)
 	mdbook test
 	touch $@
 
-html/index.html: src/tests.ok
+$(TARGET): $(SVG_IMGS) $(MD_SRCS)
 	mdbook build
 
 clean:


### PR DESCRIPTION
### Problem
Building the book reruns all tests every time.  This is annoying when you've changed an out of test resource or are making a bunch of little cosmetic tweaks.

#### Summary of Changes
This swaps dependencies on the book and test build targets such that
the book can be built w/o testing, but tests cannot be run w/o building