### PR TITLE
Lower warn to info, fetch from validator root instead of root + 1

### DIFF
--- a/core/src/cluster_info_repair_listener.rs
+++ b/core/src/cluster_info_repair_listener.rs
@@ -260,14 +260,16 @@ impl ClusterInfoRepairListener {
         num_slots_to_repair: usize,
         epoch_schedule: &EpochSchedule,
     ) -> Result<()> {
-        let slot_iter = blocktree.rooted_slot_iterator(repairee_epoch_slots.root + 1);
-
+        let slot_iter = blocktree.rooted_slot_iterator(repairee_epoch_slots.root);
         if slot_iter.is_err() {
-            warn!("Root for repairee is on different fork OR replay_stage hasn't marked this slot as root yet");
+            info!(
+                "Root for repairee is on different fork. My root: {}, repairee_root: {}",
+                my_root, repairee_epoch_slots.root
+            );
             return Ok(());
         }
 
-        let slot_iter = slot_iter?;
+        let mut slot_iter = slot_iter?;
 
         let mut total_data_blobs_sent = 0;
         let mut total_coding_blobs_sent = 0;
@@ -276,6 +278,10 @@ impl ClusterInfoRepairListener {
             epoch_schedule.get_stakers_epoch(repairee_epoch_slots.root);
         let max_confirmed_repairee_slot =
             epoch_schedule.get_last_slot_in_epoch(max_confirmed_repairee_epoch);
+
+        // Skip the first slot in the iterator b/c we know it's the root slot which the repairee already
+        // has
+        slot_iter.next();
         for (slot, slot_meta) in slot_iter {
             if slot > my_root
                 || num_slots_repaired >= num_slots_to_repair

--- a/core/src/cluster_info_repair_listener.rs
+++ b/core/src/cluster_info_repair_listener.rs
@@ -279,8 +279,8 @@ impl ClusterInfoRepairListener {
         let max_confirmed_repairee_slot =
             epoch_schedule.get_last_slot_in_epoch(max_confirmed_repairee_epoch);
 
-        // Skip the first slot in the iterator b/c we know it's the root slot which the repairee already
-        // has
+        // Skip the first slot in the iterator because we know it's the root slot which the repairee
+        // already has
         slot_iter.next();
         for (slot, slot_meta) in slot_iter {
             if slot > my_root


### PR DESCRIPTION
#### Problem
1) Warn is too severe for just observing another fork
2) Searching for rooted slots to repair starting at `repairee_epoch_slots.root + 1` is invalid b/c it might not be on the same fork as `repairee_epoch_slots.root`

#### Summary of Changes
1) Lower warn to info
2) Start searching for rooted slots to repair starting at `repairee_epoch_slots.root` and simply skip the first slot in the iterator b/c it's the root slot.

Fixes #
