### PR TITLE
Always send pull responses to the origin addr

### DIFF
--- a/core/src/cluster_info.rs
+++ b/core/src/cluster_info.rs
@@ -751,7 +751,7 @@ impl ClusterInfo {
 
     /// retransmit messages to a list of nodes
     /// # Remarks
-    /// We need to avoid having obj locked while doing any io, such as the `send_to`
+    /// We need to avoid having obj locked while doing a io, such as the `send_to`
     pub fn retransmit_to(
         obj: &Arc<RwLock<Self>>,
         peers: &[ContactInfo],
@@ -1096,7 +1096,7 @@ impl ClusterInfo {
         if caller.contact_info().is_none() {
             return vec![];
         }
-        let mut from = caller.contact_info().cloned().unwrap();
+        let from = caller.contact_info()unwrap();
         if from.id == self_id {
             warn!(
                 "PullRequest ignored, I'm talking to myself: me={} remoteme={}",
@@ -1114,15 +1114,10 @@ impl ClusterInfo {
         let len = data.len();
         trace!("get updates since response {}", len);
         let rsp = Protocol::PullResponse(self_id, data);
-        // The remote node may not know its public IP:PORT. Record what it looks like to us.
-        // This may or may not be correct for everybody, but it's better than leaving the remote with
-        // an unspecified address in our table
-        if from.gossip.ip().is_unspecified() {
-            inc_new_counter_debug!("cluster_info-window-request-updates-unspec-gossip", 1);
-            from.gossip = *from_addr;
-        }
+        // The remote node may not know its public IP:PORT. Instead of responding to the caller's
+        // gossip addr, respond to the origin addr.
         inc_new_counter_debug!("cluster_info-pull_request-rsp", len);
-        to_shared_blob(rsp, from.gossip).ok().into_iter().collect()
+        to_shared_blob(rsp, *from_addr).ok().into_iter().collect()
     }
 
     fn handle_pull_response(me: &Arc<RwLock<Self>>, from: &Pubkey, data: Vec<CrdsValue>) {

--- a/core/src/cluster_info.rs
+++ b/core/src/cluster_info.rs
@@ -1096,7 +1096,7 @@ impl ClusterInfo {
         if caller.contact_info().is_none() {
             return vec![];
         }
-        let from = caller.contact_info()unwrap();
+        let from = caller.contact_info().unwrap();
         if from.id == self_id {
             warn!(
                 "PullRequest ignored, I'm talking to myself: me={} remoteme={}",

--- a/gossip/src/main.rs
+++ b/gossip/src/main.rs
@@ -42,12 +42,6 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                 .about("Monitor the gossip entrypoint")
                 .setting(AppSettings::DisableVersion)
                 .arg(
-                    clap::Arg::with_name("pull_only")
-                        .long("pull-only")
-                        .takes_value(false)
-                        .help("Use a partial gossip node (Pulls only) to spy on the cluster. By default it will use a full fledged gossip node (Pushes and Pulls). Useful when behind a NAT"),
-                )
-                .arg(
                     Arg::with_name("num_nodes")
                         .short("N")
                         .long("num-nodes")
@@ -120,9 +114,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                 .value_of("node_pubkey")
                 .map(|pubkey_str| pubkey_str.parse::<Pubkey>().unwrap());
 
-            let gossip_addr = if matches.is_present("pull_only") {
-                None
-            } else {
+            let gossip_addr = {
                 let mut addr = socketaddr_any!();
                 addr.set_ip(
                     solana_netutil::get_public_ip_addr(&entrypoint_addr).unwrap_or_else(|err| {


### PR DESCRIPTION
#### Problem

It's not possible to gossip with our cluster if a node does not realize that it is behind a NAT/network with dynamic port mapping. Pull requests only send responses to the contact info of the node.

#### Summary of Changes

The main benefit of pull requests is that they allow just about anyone to gossip with our cluster (whether or not they're behind a NAT), because of this they should always respond to the origin of the request instead of where the node thinks it is.

