### PR TITLE
fix Instruction and CompiledInstruction field names

### DIFF
--- a/programs/budget_api/src/budget_processor.rs
+++ b/programs/budget_api/src/budget_processor.rs
@@ -256,7 +256,7 @@ mod tests {
         // Attack! Part 2: Point the instruction to the expected, but unsigned, key.
         message.account_keys.insert(3, alice_pubkey);
         message.instructions[0].accounts[0] = 3;
-        message.instructions[0].program_ids_index = 4;
+        message.instructions[0].program_id_index = 4;
 
         // Ensure the transaction fails because of the unsigned key.
         assert_eq!(
@@ -305,7 +305,7 @@ mod tests {
         // Attack! Part 2: Point the instruction to the expected, but unsigned, key.
         message.account_keys.insert(3, alice_pubkey);
         message.instructions[0].accounts[0] = 3;
-        message.instructions[0].program_ids_index = 4;
+        message.instructions[0].program_id_index = 4;
 
         // Ensure the transaction fails because of the unsigned key.
         assert_eq!(

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -236,11 +236,11 @@ impl Accounts {
             .instructions
             .iter()
             .map(|ix| {
-                if message.account_keys.len() <= ix.program_ids_index as usize {
+                if message.account_keys.len() <= ix.program_id_index as usize {
                     error_counters.account_not_found += 1;
                     return Err(TransactionError::AccountNotFound);
                 }
-                let program_id = message.account_keys[ix.program_ids_index as usize];
+                let program_id = message.account_keys[ix.program_id_index as usize];
                 Self::load_executable_accounts(
                     storage,
                     ancestors,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2116,7 +2116,7 @@ mod tests {
             system_transaction::transfer(&mint_keypair, &keypair.pubkey(), 1, genesis_block.hash());
 
         let mut tx_invalid_program_index = tx.clone();
-        tx_invalid_program_index.message.instructions[0].program_ids_index = 42;
+        tx_invalid_program_index.message.instructions[0].program_id_index = 42;
         assert_eq!(
             bank.process_transaction(&tx_invalid_program_index),
             Err(TransactionError::InvalidAccountIndex)

--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -260,7 +260,7 @@ impl MessageProcessor {
     ) -> Result<(), TransactionError> {
         for (instruction_index, instruction) in message.instructions.iter().enumerate() {
             let executable_index = message
-                .program_position(instruction.program_ids_index as usize)
+                .program_position(instruction.program_id_index as usize)
                 .ok_or(TransactionError::InvalidAccountIndex)?;
             let executable_accounts = &mut loaders[executable_index];
             let mut program_accounts = get_subset_unchecked_mut(accounts, &instruction.accounts)

--- a/sdk/src/instruction.rs
+++ b/sdk/src/instruction.rs
@@ -76,7 +76,7 @@ impl InstructionError {
 #[derive(Debug, PartialEq, Clone)]
 pub struct Instruction {
     /// Pubkey of the instruction processor that executes this instruction
-    pub program_ids_index: Pubkey,
+    pub program_id: Pubkey,
     /// Metadata for what accounts should be passed to the instruction processor
     pub accounts: Vec<AccountMeta>,
     /// Opaque data passed to the instruction processor
@@ -84,14 +84,10 @@ pub struct Instruction {
 }
 
 impl Instruction {
-    pub fn new<T: Serialize>(
-        program_ids_index: Pubkey,
-        data: &T,
-        accounts: Vec<AccountMeta>,
-    ) -> Self {
+    pub fn new<T: Serialize>(program_id: Pubkey, data: &T, accounts: Vec<AccountMeta>) -> Self {
         let data = serialize(data).unwrap();
         Self {
-            program_ids_index,
+            program_id,
             data,
             accounts,
         }

--- a/sdk/src/instruction.rs
+++ b/sdk/src/instruction.rs
@@ -127,7 +127,7 @@ impl AccountMeta {
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub struct CompiledInstruction {
     /// Index into the transaction keys array indicating the program account that executes this instruction
-    pub program_ids_index: u8,
+    pub program_id_index: u8,
     /// Ordered indices into the transaction keys array indicating which accounts to pass to the program
     #[serde(with = "short_vec")]
     pub accounts: Vec<u8>,
@@ -140,13 +140,13 @@ impl CompiledInstruction {
     pub fn new<T: Serialize>(program_ids_index: u8, data: &T, accounts: Vec<u8>) -> Self {
         let data = serialize(data).unwrap();
         Self {
-            program_ids_index,
+            program_id_index: program_ids_index,
             data,
             accounts,
         }
     }
 
     pub fn program_id<'a>(&self, program_ids: &'a [Pubkey]) -> &'a Pubkey {
-        &program_ids[self.program_ids_index as usize]
+        &program_ids[self.program_id_index as usize]
     }
 }

--- a/sdk/src/message.rs
+++ b/sdk/src/message.rs
@@ -18,7 +18,7 @@ fn compile_instruction(ix: Instruction, keys: &[Pubkey]) -> CompiledInstruction 
         .collect();
 
     CompiledInstruction {
-        program_ids_index: position(keys, &ix.program_id),
+        program_id_index: position(keys, &ix.program_id),
         data: ix.data.clone(),
         accounts,
     }
@@ -205,7 +205,7 @@ impl Message {
     pub fn program_ids(&self) -> Vec<&Pubkey> {
         self.instructions
             .iter()
-            .map(|ix| &self.account_keys[ix.program_ids_index as usize])
+            .map(|ix| &self.account_keys[ix.program_id_index as usize])
             .collect()
     }
 

--- a/sdk/src/message.rs
+++ b/sdk/src/message.rs
@@ -18,7 +18,7 @@ fn compile_instruction(ix: Instruction, keys: &[Pubkey]) -> CompiledInstruction 
         .collect();
 
     CompiledInstruction {
-        program_ids_index: position(keys, &ix.program_ids_index),
+        program_ids_index: position(keys, &ix.program_id),
         data: ix.data.clone(),
         accounts,
     }
@@ -118,7 +118,7 @@ fn get_keys(instructions: &[Instruction], payer: Option<&Pubkey>) -> Instruction
 fn get_program_ids(instructions: &[Instruction]) -> Vec<Pubkey> {
     instructions
         .iter()
-        .map(|ix| ix.program_ids_index)
+        .map(|ix| ix.program_id)
         .unique()
         .collect()
 }

--- a/sdk/src/transaction.rs
+++ b/sdk/src/transaction.rs
@@ -224,7 +224,7 @@ impl Transaction {
     pub fn verify_refs(&self) -> bool {
         let message = self.message();
         for instruction in &message.instructions {
-            if (instruction.program_ids_index as usize) >= message.account_keys.len() {
+            if (instruction.program_id_index as usize) >= message.account_keys.len() {
                 return false;
             }
             for account_index in &instruction.accounts {


### PR DESCRIPTION
#### Problem

Instruction and CompiledInstruction had the field `program_ids_index`, describing what was actually the Pubkey of the program, and a single index, respectively.

#### Summary of Changes

Change the field names to `program_id` and `program_id_index`
