### PR TITLE
v0.16: install: Avoid signal-hook crate on windows

### DIFF
--- a/install/Cargo.toml
+++ b/install/Cargo.toml
@@ -39,6 +39,9 @@ tar = "0.4.26"
 tempdir = "0.3.7"
 url = "1.7.2"
 
+[target."cfg(not(windows))".dependencies]
+signal-hook = "0.1.9"
+
 [target."cfg(windows)".dependencies]
 winapi = "0.3.7"
 winreg = "0.6"

--- a/install/src/command.rs
+++ b/install/src/command.rs
@@ -760,14 +760,15 @@ pub fn run(
     let mut child_option: Option<std::process::Child> = None;
     let mut now = Instant::now();
 
-    let (signal_sender, signal_receiver) = mpsc::channel();
-    if !cfg!(windows) {
+    let (_signal_sender, signal_receiver) = mpsc::channel();
+    #[cfg(not(windows))]
+    {
         use signal_hook::{iterator::Signals, SIGTERM};
         let signals = Signals::new(&[SIGTERM]).unwrap();
         std::thread::spawn(move || {
             for sig in signals.forever() {
                 eprintln!("run: received signal {:?}", sig);
-                let _ = signal_sender.send(());
+                let _ = _signal_sender.send(());
             }
         });
     }


### PR DESCRIPTION
cc: https://github.com/solana-labs/solana/pull/4900