### PR TITLE
Convert syscall accounts to credit only accounts

### DIFF
--- a/programs/stake_api/src/stake_instruction.rs
+++ b/programs/stake_api/src/stake_instruction.rs
@@ -81,7 +81,7 @@ pub fn redeem_vote_credits(stake_pubkey: &Pubkey, vote_pubkey: &Pubkey) -> Instr
         AccountMeta::new(*stake_pubkey, false),
         AccountMeta::new(*vote_pubkey, false),
         AccountMeta::new(crate::rewards_pools::random_id(), false),
-        AccountMeta::new(syscall::rewards::id(), false),
+        AccountMeta::new_credit_only(syscall::rewards::id(), false),
     ];
     Instruction::new(id(), &StakeInstruction::RedeemVoteCredits, account_metas)
 }
@@ -90,7 +90,7 @@ pub fn delegate_stake(stake_pubkey: &Pubkey, vote_pubkey: &Pubkey, stake: u64) -
     let account_metas = vec![
         AccountMeta::new(*stake_pubkey, true),
         AccountMeta::new(*vote_pubkey, false),
-        AccountMeta::new(syscall::current::id(), false),
+        AccountMeta::new_credit_only(syscall::current::id(), false),
     ];
     Instruction::new(id(), &StakeInstruction::DelegateStake(stake), account_metas)
 }
@@ -99,7 +99,7 @@ pub fn withdraw(stake_pubkey: &Pubkey, to_pubkey: &Pubkey, lamports: u64) -> Ins
     let account_metas = vec![
         AccountMeta::new(*stake_pubkey, true),
         AccountMeta::new(*to_pubkey, false),
-        AccountMeta::new(syscall::current::id(), false),
+        AccountMeta::new_credit_only(syscall::current::id(), false),
     ];
     Instruction::new(id(), &StakeInstruction::Withdraw(lamports), account_metas)
 }
@@ -107,7 +107,7 @@ pub fn withdraw(stake_pubkey: &Pubkey, to_pubkey: &Pubkey, lamports: u64) -> Ins
 pub fn deactivate_stake(stake_pubkey: &Pubkey) -> Instruction {
     let account_metas = vec![
         AccountMeta::new(*stake_pubkey, true),
-        AccountMeta::new(syscall::current::id(), false),
+        AccountMeta::new_credit_only(syscall::current::id(), false),
     ];
     Instruction::new(id(), &StakeInstruction::Deactivate, account_metas)
 }

--- a/programs/vote_api/src/vote_instruction.rs
+++ b/programs/vote_api/src/vote_instruction.rs
@@ -95,9 +95,9 @@ pub fn vote(
         authorized_voter_pubkey,
         &[
             // request slot_hashes syscall account after vote_pubkey
-            AccountMeta::new(syscall::slot_hashes::id(), false),
+            AccountMeta::new_credit_only(syscall::slot_hashes::id(), false),
             // request current syscall account after that
-            AccountMeta::new(syscall::current::id(), false),
+            AccountMeta::new_credit_only(syscall::current::id(), false),
         ],
     );
 


### PR DESCRIPTION
#### Problem
Syscall accounts are used in parallel in transactions. These accounts are not used for credits/debits or fees. But the transactions may fail due to AccountInUse errors. This puts extra burden on packet buffering and forwarding.

#### Summary of Changes
Change these accounts to credit only accounts.

Fixes #
