### PR TITLE
Fix issue in polling for transaction signatures

### DIFF
--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -484,7 +484,7 @@ impl RpcClient {
                     return Err(io::Error::new(io::ErrorKind::Other, "signature not found"));
                 }
             }
-            sleep(Duration::from_millis(250));
+            sleep(Duration::from_secs(1));
         }
         Ok(confirmed_blocks)
     }

--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -443,10 +443,9 @@ impl RpcClient {
         &self,
         signature: &Signature,
         min_confirmed_blocks: usize,
-    ) -> io::Result<()> {
+    ) -> io::Result<usize> {
         let mut now = Instant::now();
         let mut confirmed_blocks = 0;
-        let mut wait_time = 15;
         loop {
             let response = self.get_num_blocks_since_signature_confirmation(signature);
             match response {
@@ -461,12 +460,6 @@ impl RpcClient {
                         );
                         now = Instant::now();
                         confirmed_blocks = count;
-                        // If the signature has been confirmed once, wait extra while reconfirming it
-                        // One confirmation means the transaction has been seen by the network, so
-                        // next confirmation (for a higher block count) should come through.
-                        // Returning an error prematurely will cause a valid transaction to be deemed
-                        // as failure.
-                        wait_time = 30;
                     }
                     if count >= min_confirmed_blocks {
                         break;
@@ -476,7 +469,7 @@ impl RpcClient {
                     debug!("check_confirmations request failed: {:?}", err);
                 }
             };
-            if now.elapsed().as_secs() > wait_time {
+            if now.elapsed().as_secs() > 15 {
                 info!(
                     "signature {} confirmed {} out of {} failed after {} ms",
                     signature,
@@ -484,12 +477,16 @@ impl RpcClient {
                     min_confirmed_blocks,
                     now.elapsed().as_millis()
                 );
-                // TODO: Return a better error.
-                return Err(io::Error::new(io::ErrorKind::Other, "signature not found"));
+                if confirmed_blocks > 0 {
+                    return Ok(confirmed_blocks);
+                } else {
+                    // TODO: Return a better error.
+                    return Err(io::Error::new(io::ErrorKind::Other, "signature not found"));
+                }
             }
-            sleep(Duration::from_secs(1));
+            sleep(Duration::from_millis(250));
         }
-        Ok(())
+        Ok(confirmed_blocks)
     }
 
     pub fn get_num_blocks_since_signature_confirmation(

--- a/client/src/thin_client.rs
+++ b/client/src/thin_client.rs
@@ -19,7 +19,6 @@ use solana_sdk::system_instruction;
 use solana_sdk::timing::{duration_as_ms, MAX_PROCESSING_AGE};
 use solana_sdk::transaction::{self, Transaction};
 use solana_sdk::transport::Result as TransportResult;
-use std::cmp;
 use std::io;
 use std::net::{SocketAddr, UdpSocket};
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
@@ -233,8 +232,7 @@ impl ThinClient {
                     // Since network has seen the transaction, wait longer to receive
                     // all pending confirmations. Resending the transaction could result into
                     // extra transaction fees
-                    wait_time = cmp::max(
-                        wait_time,
+                    wait_time = wait_time.max(
                         MAX_PROCESSING_AGE * pending_confirmations.saturating_sub(num_confirmed),
                     );
                 }

--- a/client/src/thin_client.rs
+++ b/client/src/thin_client.rs
@@ -19,6 +19,7 @@ use solana_sdk::system_instruction;
 use solana_sdk::timing::{duration_as_ms, MAX_PROCESSING_AGE};
 use solana_sdk::transaction::{self, Transaction};
 use solana_sdk::transport::Result as TransportResult;
+use std::cmp;
 use std::io;
 use std::net::{SocketAddr, UdpSocket};
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
@@ -233,7 +234,7 @@ impl ThinClient {
                     // all pending confirmations. Resending the transaction could result into
                     // extra transaction fees
                     pending_confirmations -= confirmed_blocks;
-                    wait_time = MAX_PROCESSING_AGE * pending_confirmations;
+                    wait_time = cmp::max(wait_time, MAX_PROCESSING_AGE * pending_confirmations);
                 }
             }
             info!(

--- a/runtime/src/bank_client.rs
+++ b/runtime/src/bank_client.rs
@@ -127,7 +127,7 @@ impl SyncClient for BankClient {
         &self,
         signature: &Signature,
         min_confirmed_blocks: usize,
-    ) -> Result<()> {
+    ) -> Result<usize> {
         let mut now = Instant::now();
         let mut confirmed_blocks = 0;
         loop {
@@ -152,7 +152,7 @@ impl SyncClient for BankClient {
             }
             sleep(Duration::from_millis(250));
         }
-        Ok(())
+        Ok(confirmed_blocks)
     }
 
     fn poll_for_signature(&self, signature: &Signature) -> Result<()> {

--- a/sdk/src/client.rs
+++ b/sdk/src/client.rs
@@ -64,7 +64,7 @@ pub trait SyncClient {
         &self,
         signature: &Signature,
         min_confirmed_blocks: usize,
-    ) -> Result<()>;
+    ) -> Result<usize>;
 
     /// Poll to confirm a transaction.
     fn poll_for_signature(&self, signature: &Signature) -> Result<()>;


### PR DESCRIPTION
#### Problem
The request to poll for transaction signature may fail when multiple confirmations are requested. The caller doesn't get information on whether the transaction was never confirmed, or failed after certain number of confirmation. This can result in multiple transactions (duplicate, as well with different signatures), and cause extra transaction fees.

#### Summary of Changes
The API returns how many confirmation were observed. The caller of the API can decide to poll for extra time to receive all the required confirmations.

Fixes #
