### PR TITLE
Harden Merkle Tree against second pre-image attacks

### DIFF
--- a/core/src/chacha.rs
+++ b/core/src/chacha.rs
@@ -133,7 +133,7 @@ mod tests {
         hasher.hash(&buf[..size]);
 
         //  golden needs to be updated if blob stuff changes....
-        let golden: Hash = "E2HZjSC6VgH4nmEiTbMDATTeBcFjwSYz7QYvU7doGNhD"
+        let golden: Hash = "53P7UXH7JstJa994fZsfuyr7nrRDrDDpvS3WSPvMUs45"
             .parse()
             .unwrap();
 


### PR DESCRIPTION
#### Problem
Merkle Trees are vulnerable to trivial second pre-image attacks if the leaf and intermediate nodes receive the same hashing treatment

https://flawed.net.nz/2018/02/21/attacking-merkle-trees-with-a-second-preimage-attack/

#### Summary of Changes
Prefix the inputs data of leaf nodes with `0x00`, intermediate nodes with `0x01`