### PR TITLE
Halve stake of malicious validator

### DIFF
--- a/core/tests/local_cluster.rs
+++ b/core/tests/local_cluster.rs
@@ -244,10 +244,11 @@ fn test_fail_entry_verification_leader() {
     error_validator_config.broadcast_stage_type = BroadcastStageType::FailEntryVerification;
     let mut validator_configs = vec![validator_config; num_nodes - 1];
     validator_configs.push(error_validator_config);
-
+    let mut node_stakes = vec![100; num_nodes - 1];
+    node_stakes.push(50);
     let cluster_config = ClusterConfig {
         cluster_lamports: 10_000,
-        node_stakes: vec![100; 4],
+        node_stakes,
         validator_configs: validator_configs,
         slots_per_epoch: MINIMUM_SLOTS_PER_EPOCH * 2 as u64,
         stakers_slot_offset: MINIMUM_SLOTS_PER_EPOCH * 2 as u64,


### PR DESCRIPTION
#### Problem
The test `test_fail_entry_verification_leader` occasionally fails if the malicious leader is scheduled for a sufficient number of slots. Halving the malicious leader's stake/scheduled slots lowers this probability significantly
#### Summary of Changes
Halve the malicious leader's stake in the test `test_entry_verification_leader`
Fixes #
