### PR TITLE
Update config program to accommodate multiple signers

### DIFF
--- a/install/src/command.rs
+++ b/install/src/command.rs
@@ -6,13 +6,14 @@ use console::{style, Emoji};
 use indicatif::{ProgressBar, ProgressStyle};
 use ring::digest::{Context, Digest, SHA256};
 use solana_client::rpc_client::RpcClient;
-use solana_config_api::config_instruction;
+use solana_config_api::config_instruction::{self, ConfigSigners};
 use solana_sdk::message::Message;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::{read_keypair, Keypair, KeypairUtil, Signable};
 use solana_sdk::transaction::Transaction;
 use std::fs::{self, File};
 use std::io::{self, BufReader, Read};
+use std::mem;
 use std::path::{Path, PathBuf};
 use std::sync::mpsc;
 use std::time::SystemTime;
@@ -203,7 +204,8 @@ fn new_update_manifest(
         let new_account = config_instruction::create_account::<SignedUpdateManifest>(
             &from_keypair.pubkey(),
             &update_manifest_keypair.pubkey(),
-            1, // lamports
+            1,      // lamports
+            vec![], // additional_signers
         );
         let mut transaction = Transaction::new_unsigned_instructions(vec![new_account]);
         transaction.sign(&[from_keypair], recent_blockhash);
@@ -225,6 +227,8 @@ fn store_update_manifest(
     let signers = [from_keypair, update_manifest_keypair];
     let instruction = config_instruction::store::<SignedUpdateManifest>(
         &update_manifest_keypair.pubkey(),
+        0,      // account_type default
+        vec![], // additional_signers
         update_manifest,
     );
 
@@ -239,9 +243,10 @@ fn get_update_manifest(
     rpc_client: &RpcClient,
     update_manifest_pubkey: &Pubkey,
 ) -> Result<UpdateManifest, String> {
-    let data = rpc_client
+    let mut data = rpc_client
         .get_account_data(update_manifest_pubkey)
         .map_err(|err| format!("Unable to fetch update manifest: {}", err))?;
+    data.split_off(mem::size_of::<u32>() + ConfigSigners::serialized_size(vec![]));
 
     let signed_update_manifest =
         SignedUpdateManifest::deserialize(update_manifest_pubkey, &data)

--- a/programs/config_api/Cargo.toml
+++ b/programs/config_api/Cargo.toml
@@ -22,4 +22,3 @@ solana-runtime = { path = "../../runtime", version = "0.17.0" }
 [lib]
 crate-type = ["lib"]
 name = "solana_config_api"
-

--- a/programs/config_api/src/config_instruction.rs
+++ b/programs/config_api/src/config_instruction.rs
@@ -7,8 +7,11 @@ use solana_sdk::pubkey::Pubkey;
 use solana_sdk::short_vec;
 use solana_sdk::system_instruction;
 
+/// A collection of keys to be stored in Config account data.
 #[derive(Debug, Default, Deserialize, Serialize)]
 pub struct ConfigKeys {
+    // Each key tuple comprises a unique `Pubkey` identifier,
+    // and `bool` whether that key is a signer of the data
     #[serde(with = "short_vec")]
     pub keys: Vec<(Pubkey, bool)>,
 }

--- a/programs/config_api/src/config_instruction.rs
+++ b/programs/config_api/src/config_instruction.rs
@@ -1,26 +1,57 @@
 use crate::id;
 use crate::ConfigState;
+use bincode::serialize;
+use serde_derive::{Deserialize, Serialize};
 use solana_sdk::instruction::{AccountMeta, Instruction};
 use solana_sdk::pubkey::Pubkey;
+use solana_sdk::short_vec;
 use solana_sdk::system_instruction;
+use std::mem;
+
+#[derive(Debug, Default, Deserialize, Serialize)]
+pub struct ConfigSigners {
+    #[serde(with = "short_vec")]
+    pub additional_signers: Vec<Pubkey>,
+}
+
+impl ConfigSigners {
+    pub fn serialized_size(additional_signers: Vec<Pubkey>) -> usize {
+        serialize(&ConfigSigners { additional_signers })
+            .unwrap_or_else(|_| vec![])
+            .len()
+    }
+}
 
 /// Create a new, empty configuration account
 pub fn create_account<T: ConfigState>(
     from_account_pubkey: &Pubkey,
     config_account_pubkey: &Pubkey,
     lamports: u64,
+    additional_signers: Vec<Pubkey>,
 ) -> Instruction {
+    let space = T::max_space()
+        + mem::size_of::<u32>() as u64
+        + ConfigSigners::serialized_size(additional_signers) as u64;
     system_instruction::create_account(
         from_account_pubkey,
         config_account_pubkey,
         lamports,
-        T::max_space(),
+        space,
         &id(),
     )
 }
 
 /// Store new data in a configuration account
-pub fn store<T: ConfigState>(config_account_pubkey: &Pubkey, data: &T) -> Instruction {
-    let account_metas = vec![AccountMeta::new(*config_account_pubkey, true)];
-    Instruction::new(id(), data, account_metas)
+pub fn store<T: ConfigState>(
+    config_account_pubkey: &Pubkey,
+    account_type: u32,
+    additional_signers: Vec<Pubkey>,
+    data: &T,
+) -> Instruction {
+    let mut account_metas = vec![AccountMeta::new(*config_account_pubkey, true)];
+    for signer_pubkey in additional_signers.iter() {
+        account_metas.push(AccountMeta::new(*signer_pubkey, true));
+    }
+    let account_data = (account_type, ConfigSigners { additional_signers }, data);
+    Instruction::new(id(), &account_data, account_metas)
 }

--- a/programs/config_api/src/config_processor.rs
+++ b/programs/config_api/src/config_processor.rs
@@ -1,5 +1,7 @@
 //! Config program
 
+use crate::config_instruction::ConfigSigners;
+use bincode::deserialize;
 use log::*;
 use solana_sdk::account::KeyedAccount;
 use solana_sdk::instruction::InstructionError;
@@ -15,12 +17,29 @@ pub fn process_instruction(
         Err(InstructionError::MissingRequiredSignature)?;
     }
 
+    let (_account_type, signers): (u32, ConfigSigners) = deserialize(data).unwrap();
+    for (i, signer) in signers.additional_signers.iter().enumerate() {
+        let account_index = i + 1;
+        let signer_account = keyed_accounts[account_index].signer_key();
+        if signer_account.is_none() {
+            error!("account[{:?}].signer_key().is_none()", account_index);
+            Err(InstructionError::MissingRequiredSignature)?;
+        }
+        if signer_account.unwrap() != signer {
+            error!(
+                "account[{:?}].signer_key() does not match Config data)",
+                account_index
+            );
+            Err(InstructionError::MissingRequiredSignature)?;
+        }
+    }
+
     if keyed_accounts[0].account.data.len() < data.len() {
         error!("instruction data too large");
         Err(InstructionError::InvalidInstructionData)?;
     }
 
-    keyed_accounts[0].account.data[0..data.len()].copy_from_slice(data);
+    keyed_accounts[0].account.data[0..data.len()].copy_from_slice(&data);
     Ok(())
 }
 
@@ -37,6 +56,7 @@ mod tests {
     use solana_sdk::message::Message;
     use solana_sdk::signature::{Keypair, KeypairUtil};
     use solana_sdk::system_instruction;
+    use std::mem;
 
     #[derive(Serialize, Deserialize, Default, Debug, PartialEq)]
     struct MyConfig {
@@ -64,7 +84,11 @@ mod tests {
         (bank, mint_keypair)
     }
 
-    fn create_config_account(bank: Bank, mint_keypair: &Keypair) -> (BankClient, Keypair) {
+    fn create_config_account(
+        bank: Bank,
+        mint_keypair: &Keypair,
+        signers: Vec<Pubkey>,
+    ) -> (BankClient, Keypair) {
         let config_keypair = Keypair::new();
         let config_pubkey = config_keypair.pubkey();
 
@@ -76,6 +100,7 @@ mod tests {
                     &mint_keypair.pubkey(),
                     &config_pubkey,
                     1,
+                    signers,
                 ),
             )
             .expect("new_account");
@@ -87,7 +112,7 @@ mod tests {
     fn test_process_create_ok() {
         solana_logger::setup();
         let (bank, mint_keypair) = create_bank(10_000);
-        let (bank_client, config_keypair) = create_config_account(bank, &mint_keypair);
+        let (bank_client, config_keypair) = create_config_account(bank, &mint_keypair, vec![]);
         let config_account_data = bank_client
             .get_account_data(&config_keypair.pubkey())
             .unwrap()
@@ -102,13 +127,17 @@ mod tests {
     fn test_process_store_ok() {
         solana_logger::setup();
         let (bank, mint_keypair) = create_bank(10_000);
-        let (bank_client, config_keypair) = create_config_account(bank, &mint_keypair);
+        let additional_signers = vec![];
+        let (bank_client, config_keypair) =
+            create_config_account(bank, &mint_keypair, additional_signers.clone());
         let config_pubkey = config_keypair.pubkey();
 
         let my_config = MyConfig::new(42);
 
-        let instruction = config_instruction::store(&config_pubkey, &my_config);
+        let instruction =
+            config_instruction::store(&config_pubkey, 0, additional_signers.clone(), &my_config);
         let message = Message::new_with_payer(vec![instruction], Some(&mint_keypair.pubkey()));
+
         bank_client
             .send_message(&[&mint_keypair, &config_keypair], message)
             .unwrap();
@@ -117,6 +146,9 @@ mod tests {
             .get_account_data(&config_pubkey)
             .unwrap()
             .unwrap();
+        let meta_length =
+            mem::size_of::<u32>() + ConfigSigners::serialized_size(additional_signers);
+        let config_account_data = &config_account_data[meta_length..config_account_data.len()];
         assert_eq!(
             my_config,
             MyConfig::deserialize(&config_account_data).unwrap()
@@ -127,12 +159,12 @@ mod tests {
     fn test_process_store_fail_instruction_data_too_large() {
         solana_logger::setup();
         let (bank, mint_keypair) = create_bank(10_000);
-        let (bank_client, config_keypair) = create_config_account(bank, &mint_keypair);
+        let (bank_client, config_keypair) = create_config_account(bank, &mint_keypair, vec![]);
         let config_pubkey = config_keypair.pubkey();
 
         let my_config = MyConfig::new(42);
 
-        let mut instruction = config_instruction::store(&config_pubkey, &my_config);
+        let mut instruction = config_instruction::store(&config_pubkey, 0, vec![], &my_config);
         instruction.data = vec![0; 123]; // <-- Replace data with a vector that's too large
         let message = Message::new(vec![instruction]);
         bank_client
@@ -148,18 +180,87 @@ mod tests {
         let system_pubkey = system_keypair.pubkey();
 
         bank.transfer(42, &mint_keypair, &system_pubkey).unwrap();
-        let (bank_client, config_keypair) = create_config_account(bank, &mint_keypair);
+        let (bank_client, config_keypair) = create_config_account(bank, &mint_keypair, vec![]);
         let config_pubkey = config_keypair.pubkey();
 
         let transfer_instruction =
             system_instruction::transfer(&system_pubkey, &Pubkey::new_rand(), 42);
         let my_config = MyConfig::new(42);
-        let mut store_instruction = config_instruction::store(&config_pubkey, &my_config);
+        let mut store_instruction =
+            config_instruction::store(&config_pubkey, 0, vec![], &my_config);
         store_instruction.accounts[0].is_signer = false; // <----- not a signer
 
         let message = Message::new(vec![transfer_instruction, store_instruction]);
         bank_client
             .send_message(&[&system_keypair], message)
+            .unwrap_err();
+    }
+
+    #[test]
+    fn test_process_store_with_additional_signers() {
+        solana_logger::setup();
+        let (bank, mint_keypair) = create_bank(10_000);
+        let signer0 = Keypair::new();
+        let signer1 = Keypair::new();
+        let additional_signers = vec![signer0.pubkey(), signer1.pubkey()];
+        let (bank_client, config_keypair) =
+            create_config_account(bank, &mint_keypair, additional_signers.clone());
+        let config_pubkey = config_keypair.pubkey();
+
+        let my_config = MyConfig::new(42);
+
+        let instruction =
+            config_instruction::store(&config_pubkey, 0, additional_signers.clone(), &my_config);
+        let message = Message::new_with_payer(vec![instruction], Some(&mint_keypair.pubkey()));
+
+        bank_client
+            .send_message(
+                &[&mint_keypair, &config_keypair, &signer0, &signer1],
+                message,
+            )
+            .unwrap();
+
+        let config_account_data = bank_client
+            .get_account_data(&config_pubkey)
+            .unwrap()
+            .unwrap();
+        let meta_length =
+            mem::size_of::<u32>() + ConfigSigners::serialized_size(additional_signers);
+        let config_account_data = &config_account_data[meta_length..config_account_data.len()];
+        assert_eq!(
+            my_config,
+            MyConfig::deserialize(&config_account_data).unwrap()
+        );
+    }
+
+    #[test]
+    fn test_process_store_with_bad_additional_signer() {
+        solana_logger::setup();
+        let (bank, mint_keypair) = create_bank(10_000);
+        let signer0 = Keypair::new();
+        let signer1 = Keypair::new();
+        let additional_signers = vec![signer0.pubkey()];
+        let (bank_client, config_keypair) =
+            create_config_account(bank, &mint_keypair, additional_signers.clone());
+        let config_pubkey = config_keypair.pubkey();
+
+        let my_config = MyConfig::new(42);
+
+        // Config-data pubkey doesn't match signer
+        let instruction =
+            config_instruction::store(&config_pubkey, 0, additional_signers.clone(), &my_config);
+        let mut message =
+            Message::new_with_payer(vec![instruction.clone()], Some(&mint_keypair.pubkey()));
+        message.account_keys[2] = signer1.pubkey();
+        bank_client
+            .send_message(&[&mint_keypair, &config_keypair, &signer1], message)
+            .unwrap_err();
+
+        // Config-data pubkey not a signer
+        let mut message = Message::new_with_payer(vec![instruction], Some(&mint_keypair.pubkey()));
+        message.header.num_required_signatures = 2;
+        bank_client
+            .send_message(&[&mint_keypair, &config_keypair], message)
             .unwrap_err();
     }
 }


### PR DESCRIPTION
#### Problem
Currently, the Config program is only used in the install module. However, it could have broader utility (for validator registration, eg) if data stored in config accounts could be authorized by additional signers.

#### Summary of Changes
Adds multi-signature functionality, storing additional signer keys in Config account data
~~Also adds an `account_type` u32 to Config account data, making it easier to filter relevant Config accounts~~
Keys are stored as `(key, is_signer): (Pubkey, bool)` tuples, enabling their use as unique account_type identifiers as well

