### PR TITLE
fix blocktree_processor test_process_entries_stress

### DIFF
--- a/core/src/blocktree_processor.rs
+++ b/core/src/blocktree_processor.rs
@@ -1321,9 +1321,10 @@ pub mod tests {
             )
             .expect("process ticks failed");
 
-            i += 1;
-            bank = Bank::new_from_parent(&Arc::new(bank), &Pubkey::default(), i as u64);
             bank.squash();
+            i += 1;
+
+            bank = Bank::new_from_parent(&Arc::new(bank), &Pubkey::default(), i as u64);
         }
     }
 


### PR DESCRIPTION
#### Problem
 test was operating on a frozen bank, screwing up credit-only accounts

 #### Summary of Changes
 squash before parenting

Fixes #