### PR TITLE
Make config_api more robust

### DIFF
--- a/install/src/command.rs
+++ b/install/src/command.rs
@@ -226,6 +226,7 @@ fn store_update_manifest(
     let signers = [from_keypair, update_manifest_keypair];
     let instruction = config_instruction::store::<SignedUpdateManifest>(
         &update_manifest_keypair.pubkey(),
+        true,   // update_manifest_keypair is signer
         vec![], // additional keys
         update_manifest,
     );

--- a/programs/config_api/src/config_instruction.rs
+++ b/programs/config_api/src/config_instruction.rs
@@ -44,10 +44,11 @@ pub fn create_account<T: ConfigState>(
 /// Store new data in a configuration account
 pub fn store<T: ConfigState>(
     config_account_pubkey: &Pubkey,
+    is_config_signer: bool,
     keys: Vec<(Pubkey, bool)>,
     data: &T,
 ) -> Instruction {
-    let mut account_metas = vec![AccountMeta::new(*config_account_pubkey, true)];
+    let mut account_metas = vec![AccountMeta::new(*config_account_pubkey, is_config_signer)];
     for (signer_pubkey, _) in keys.iter().filter(|(_, is_signer)| *is_signer) {
         account_metas.push(AccountMeta::new(*signer_pubkey, true));
     }


### PR DESCRIPTION
#### Problem
Config_api brittle in several ways

#### Summary of Changes
- Maps ConfigKeys deserialize() error to appropriate InstructionError
- Uses Vec::get() instead of index to prevent panic
- Makes `keyed_accounts[0].signer_key()` check contingent on no signer keys specified in account data

Fixes #4973 
