### PR TITLE
Fix always passing in remote filename, even if no accounts file

### DIFF
--- a/net/net.sh
+++ b/net/net.sh
@@ -122,7 +122,7 @@ while [[ -n $1 ]]; do
       shift 2
     elif [[ $1 = --external-accounts-file ]]; then
       externalPrimordialAccountsFile="$2"
-      remoteExternalPrimordialAccountsFile=/tmp/external-primodial-accounts.yml
+      remoteExternalPrimordialAccountsFile=/tmp/external-primordial-accounts.yml
       shift 2
     else
       usage "Unknown long option: $1"

--- a/net/net.sh
+++ b/net/net.sh
@@ -95,7 +95,7 @@ failOnValidatorBootupFailure=true
 genesisOptions=
 numFullnodesRequested=
 externalPrimordialAccountsFile=
-remoteExternalPrimordialAccountsFile=/tmp/external-primodial-accounts.yml
+remoteExternalPrimordialAccountsFile=
 stakeNodesInGenesisBlock=
 
 command=$1
@@ -122,6 +122,7 @@ while [[ -n $1 ]]; do
       shift 2
     elif [[ $1 = --external-accounts-file ]]; then
       externalPrimordialAccountsFile="$2"
+      remoteExternalPrimordialAccountsFile=/tmp/external-primodial-accounts.yml
       shift 2
     else
       usage "Unknown long option: $1"


### PR DESCRIPTION
#### Problem
We were setting remote accounts file path even if we were not writing to such a file, causing the scripts later to look for a non existent file.
