### PR TITLE
remove set_leader from cluster_info

### DIFF
--- a/core/src/bank_forks.rs
+++ b/core/src/bank_forks.rs
@@ -107,12 +107,13 @@ impl BankForks {
         }
     }
 
-    pub fn insert(&mut self, bank: Bank) {
+    pub fn insert(&mut self, bank: Bank) -> Arc<Bank> {
         let bank = Arc::new(bank);
         let prev = self.banks.insert(bank.slot(), bank.clone());
         assert!(prev.is_none());
 
         self.working_bank = bank.clone();
+        bank
     }
 
     // TODO: really want to kill this...

--- a/core/src/contact_info.rs
+++ b/core/src/contact_info.rs
@@ -147,7 +147,7 @@ impl ContactInfo {
     }
 
     #[cfg(test)]
-    fn new_with_pubkey_socketaddr(pubkey: &Pubkey, bind_addr: &SocketAddr) -> Self {
+    pub(crate) fn new_with_pubkey_socketaddr(pubkey: &Pubkey, bind_addr: &SocketAddr) -> Self {
         fn next_port(addr: &SocketAddr, nxt: u16) -> SocketAddr {
             let mut nxt_addr = *addr;
             nxt_addr.set_port(addr.port() + nxt);

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -109,6 +109,10 @@ impl JsonRpcRequestProcessor {
         Ok(self.bank().slot())
     }
 
+    fn get_slot_leader(&self) -> Result<String> {
+        Ok(self.bank().collector_id().to_string())
+    }
+
     fn get_transaction_count(&self) -> Result<u64> {
         Ok(self.bank().transaction_count() as u64)
     }
@@ -505,12 +509,7 @@ impl RpcSol for RpcSolImpl {
     }
 
     fn get_slot_leader(&self, meta: Self::Metadata) -> Result<String> {
-        let cluster_info = meta.cluster_info.read().unwrap();
-        let leader_data_option = cluster_info.leader_data();
-        Ok(leader_data_option
-            .and_then(|leader_data| Some(leader_data.id))
-            .unwrap_or_default()
-            .to_string())
+        meta.request_processor.read().unwrap().get_slot_leader()
     }
 
     fn get_epoch_vote_accounts(&self, meta: Self::Metadata) -> Result<Vec<RpcVoteAccountInfo>> {
@@ -563,6 +562,7 @@ mod tests {
     ) -> (MetaIoHandler<Meta>, Meta, Arc<Bank>, Hash, Keypair, Pubkey) {
         let (bank_forks, alice) = new_bank_forks();
         let bank = bank_forks.read().unwrap().working_bank();
+        let leader_pubkey = *bank.collector_id();
         let exit = Arc::new(AtomicBool::new(false));
 
         let blockhash = bank.confirmed_last_blockhash().0;
@@ -581,9 +581,14 @@ mod tests {
         let cluster_info = Arc::new(RwLock::new(ClusterInfo::new_with_invalid_keypair(
             ContactInfo::default(),
         )));
-        let leader = ContactInfo::new_with_socketaddr(&socketaddr!("127.0.0.1:1234"));
 
-        cluster_info.write().unwrap().insert_info(leader.clone());
+        cluster_info
+            .write()
+            .unwrap()
+            .insert_info(ContactInfo::new_with_pubkey_socketaddr(
+                &leader_pubkey,
+                &socketaddr!("127.0.0.1:1234"),
+            ));
 
         let mut io = MetaIoHandler::default();
         let rpc = RpcSolImpl;
@@ -592,7 +597,7 @@ mod tests {
             request_processor,
             cluster_info,
         };
-        (io, meta, bank, blockhash, alice, leader.id)
+        (io, meta, bank, blockhash, alice, leader_pubkey)
     }
 
     #[test]
@@ -660,13 +665,12 @@ mod tests {
     #[test]
     fn test_rpc_get_slot_leader() {
         let bob_pubkey = Pubkey::new_rand();
-        let (io, meta, _bank, _blockhash, _alice, _leader_pubkey) =
+        let (io, meta, _bank, _blockhash, _alice, leader_pubkey) =
             start_rpc_handler_with_tx(&bob_pubkey);
 
         let req = format!(r#"{{"jsonrpc":"2.0","id":1,"method":"getSlotLeader"}}"#);
         let res = io.handle_request_sync(&req, meta);
-        let expected =
-            format!(r#"{{"jsonrpc":"2.0","result":"11111111111111111111111111111111","id":1}}"#);
+        let expected = format!(r#"{{"jsonrpc":"2.0","result":"{}","id":1}}"#, leader_pubkey);
         let expected: Response =
             serde_json::from_str(&expected).expect("expected response deserialization");
         let result: Response = serde_json::from_str(&res.expect("actual response"))

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -11,7 +11,6 @@ use crate::poh_recorder::{PohRecorder, WorkingBankEntries};
 use crate::service::Service;
 use crate::sigverify_stage::SigVerifyStage;
 use crossbeam_channel::unbounded;
-use solana_sdk::pubkey::Pubkey;
 use std::net::UdpSocket;
 use std::sync::atomic::AtomicBool;
 use std::sync::mpsc::{channel, Receiver};
@@ -29,7 +28,6 @@ pub struct Tpu {
 impl Tpu {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
-        id: &Pubkey,
         cluster_info: &Arc<RwLock<ClusterInfo>>,
         poh_recorder: &Arc<Mutex<PohRecorder>>,
         entry_receiver: Receiver<WorkingBankEntries>,
@@ -41,8 +39,6 @@ impl Tpu {
         broadcast_type: &BroadcastStageType,
         exit: &Arc<AtomicBool>,
     ) -> Self {
-        cluster_info.write().unwrap().set_leader(id);
-
         let (packet_sender, packet_receiver) = channel();
         let fetch_stage = FetchStage::new_with_sender(
             transactions_sockets,

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -257,7 +257,6 @@ impl Validator {
         }
 
         let tpu = Tpu::new(
-            &id,
             &cluster_info,
             &poh_recorder,
             entry_receiver,


### PR DESCRIPTION
#### Problem
 replay_stage is still hard to read, partly because of deprecated cluster_info.leader_data()

 #### Summary of Changes
 * remove deprecated API
 * move RPC to bank APIs for current leader (which matches rpc.get_slot())
 * clean up replay_stage some more


Fixes #