### PR TITLE
Improve signature checks in config_api

### DIFF
--- a/install/src/command.rs
+++ b/install/src/command.rs
@@ -227,7 +227,6 @@ fn store_update_manifest(
     let instruction = config_instruction::store::<SignedUpdateManifest>(
         &update_manifest_keypair.pubkey(),
         true,   // update_manifest_keypair is signer
-        true,   // update_manifest_keypair is required to update account
         vec![], // additional keys
         update_manifest,
     );

--- a/install/src/command.rs
+++ b/install/src/command.rs
@@ -227,6 +227,7 @@ fn store_update_manifest(
     let instruction = config_instruction::store::<SignedUpdateManifest>(
         &update_manifest_keypair.pubkey(),
         true,   // update_manifest_keypair is signer
+        true,   // update_manifest_keypair is required to update account
         vec![], // additional keys
         update_manifest,
     );

--- a/programs/config_api/src/config_instruction.rs
+++ b/programs/config_api/src/config_instruction.rs
@@ -10,6 +10,8 @@ use solana_sdk::system_instruction;
 /// A collection of keys to be stored in Config account data.
 #[derive(Debug, Default, Deserialize, Serialize)]
 pub struct ConfigKeys {
+    // Whether the Config account keypair must sign any updates
+    pub require_config_signature: bool,
     // Each key tuple comprises a unique `Pubkey` identifier,
     // and `bool` whether that key is a signer of the data
     #[serde(with = "short_vec")]
@@ -18,9 +20,12 @@ pub struct ConfigKeys {
 
 impl ConfigKeys {
     pub fn serialized_size(keys: Vec<(Pubkey, bool)>) -> usize {
-        serialize(&ConfigKeys { keys })
-            .unwrap_or_else(|_| vec![])
-            .len()
+        serialize(&ConfigKeys {
+            require_config_signature: true,
+            keys,
+        })
+        .unwrap_or_else(|_| vec![])
+        .len()
     }
 }
 
@@ -45,6 +50,7 @@ pub fn create_account<T: ConfigState>(
 pub fn store<T: ConfigState>(
     config_account_pubkey: &Pubkey,
     is_config_signer: bool,
+    require_config_signature: bool,
     keys: Vec<(Pubkey, bool)>,
     data: &T,
 ) -> Instruction {
@@ -52,6 +58,12 @@ pub fn store<T: ConfigState>(
     for (signer_pubkey, _) in keys.iter().filter(|(_, is_signer)| *is_signer) {
         account_metas.push(AccountMeta::new(*signer_pubkey, true));
     }
-    let account_data = (ConfigKeys { keys }, data);
+    let account_data = (
+        ConfigKeys {
+            require_config_signature,
+            keys,
+        },
+        data,
+    );
     Instruction::new(id(), &account_data, account_metas)
 }


### PR DESCRIPTION
#### Problem
The intended purpose of storing signer Pubkeys in Config data is to transfer ownership from the Config account keypair to another keypair(s). However, if the stored keypairs are not checked on an account update, any signing keypairs can overwrite data with properly constructed instruction data.

#### Summary of Changes
- On initialization, the Config account keypair is required to be a signer
- On updates, the Config account keypair is only required to be a signer if specified in Config account data
- For a successful update, either the Config account keypair must be a signer, or the set of signers must equal the set of required signers previously specified in Config account data

@rob-solana , I think this addresses your question on #4980 , but I am not totally sure I've understood the question properly.
