### PR TITLE
Set exit when replicator run bails

### DIFF
--- a/core/src/replicator.rs
+++ b/core/src/replicator.rs
@@ -367,6 +367,7 @@ impl Replicator {
             meta.blockhash = storage_blockhash;
             Self::redeem_rewards(&cluster_info, replicator_keypair, storage_keypair);
         }
+        exit.store(true, Ordering::Relaxed);
     }
 
     fn redeem_rewards(


### PR DESCRIPTION
#### Problem

Replicator goes silent and sleeps forever if `run` returns

#### Summary of Changes

Make `run` set the exit flag.
