### PR TITLE
Fix getProgramAccounts RPC

### DIFF
--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -73,7 +73,7 @@ impl JsonRpcRequestProcessor {
     pub fn get_program_accounts(&self, program_id: &Pubkey) -> Result<Vec<(String, Account)>> {
         Ok(self
             .bank()
-            .get_program_accounts_modified_since_parent(&program_id)
+            .get_program_accounts(&program_id)
             .into_iter()
             .map(|(pubkey, account)| (pubkey.to_string(), account))
             .collect())

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2739,4 +2739,51 @@ mod tests {
             (1.0, 1.0)
         );
     }
+
+    #[test]
+    fn test_bank_get_program_accounts() {
+        let (genesis_block, _mint_keypair) = create_genesis_block(500);
+        let parent = Arc::new(Bank::new(&genesis_block));
+
+        let bank0 = Arc::new(new_from_parent(&parent));
+
+        let pubkey0 = Pubkey::new_rand();
+        let program_id = Pubkey::new(&[2; 32]);
+        let account0 = Account::new(1, 0, &program_id);
+        bank0.store_account(&pubkey0, &account0);
+
+        assert_eq!(
+            bank0.get_program_accounts_modified_since_parent(&program_id),
+            vec![(pubkey0, account0.clone())]
+        );
+
+        let bank1 = Arc::new(new_from_parent(&bank0));
+        bank1.squash();
+        assert_eq!(
+            bank0.get_program_accounts(&program_id),
+            vec![(pubkey0, account0.clone())]
+        );
+        assert_eq!(
+            bank1.get_program_accounts(&program_id),
+            vec![(pubkey0, account0.clone())]
+        );
+        assert_eq!(
+            bank1.get_program_accounts_modified_since_parent(&program_id),
+            vec![]
+        );
+
+        let bank2 = Arc::new(new_from_parent(&bank1));
+        let pubkey1 = Pubkey::new_rand();
+        let account1 = Account::new(3, 0, &program_id);
+        bank2.store_account(&pubkey1, &account1);
+        // Accounts with 0 lamports should be filtered out by Accounts::load_by_program()
+        let pubkey2 = Pubkey::new_rand();
+        let account2 = Account::new(0, 0, &program_id);
+        bank2.store_account(&pubkey2, &account2);
+
+        let bank3 = Arc::new(new_from_parent(&bank2));
+        bank3.squash();
+        assert_eq!(bank1.get_program_accounts(&program_id).len(), 2);
+        assert_eq!(bank3.get_program_accounts(&program_id).len(), 2);
+    }
 }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1206,11 +1206,19 @@ impl Bank {
             .map(|(account, _)| account)
     }
 
+    pub fn get_program_accounts(&self, program_id: &Pubkey) -> Vec<(Pubkey, Account)> {
+        self.rc
+            .accounts
+            .load_by_program(&self.ancestors, program_id)
+    }
+
     pub fn get_program_accounts_modified_since_parent(
         &self,
         program_id: &Pubkey,
     ) -> Vec<(Pubkey, Account)> {
-        self.rc.accounts.load_by_program(self.slot(), program_id)
+        self.rc
+            .accounts
+            .load_by_program_fork(self.slot(), program_id)
     }
 
     pub fn get_account_modified_since_parent(&self, pubkey: &Pubkey) -> Option<(Account, Fork)> {


### PR DESCRIPTION
#### Problem
getProgramAccounts RPC only returns program accounts modified within the last slot, due to bank api limitations.

#### Summary of Changes
Use new scan_accounts methods to load all non-zero program accounts that exists in a bank's fork ancestor chain
Tap this method in getProgramAccounts RPC
