### PR TITLE
Fix credit only commit_credits race

### DIFF
--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -1393,34 +1393,34 @@ mod tests {
         accounts.store_slow(0, &pubkey0, &account0);
         accounts.store_slow(0, &pubkey1, &account1);
 
-        let mut credit_only_account_locks = accounts.credit_only_account_locks.write().unwrap();
-        let credit_only_account_locks = credit_only_account_locks.as_mut().unwrap();
-        credit_only_account_locks.insert(
-            pubkey0,
-            CreditOnlyLock {
-                credits: AtomicU64::new(0),
-                lock_count: Mutex::new(1),
-            },
-        );
-        credit_only_account_locks.insert(
-            pubkey1,
-            CreditOnlyLock {
-                credits: AtomicU64::new(5),
-                lock_count: Mutex::new(1),
-            },
-        );
-        credit_only_account_locks.insert(
-            pubkey2,
-            CreditOnlyLock {
-                credits: AtomicU64::new(10),
-                lock_count: Mutex::new(1),
-            },
-        );
-
-        drop(credit_only_account_locks);
+        {
+            let mut credit_only_account_locks = accounts.credit_only_account_locks.write().unwrap();
+            let credit_only_account_locks = credit_only_account_locks.as_mut().unwrap();
+            credit_only_account_locks.insert(
+                pubkey0,
+                CreditOnlyLock {
+                    credits: AtomicU64::new(0),
+                    lock_count: Mutex::new(1),
+                },
+            );
+            credit_only_account_locks.insert(
+                pubkey1,
+                CreditOnlyLock {
+                    credits: AtomicU64::new(5),
+                    lock_count: Mutex::new(1),
+                },
+            );
+            credit_only_account_locks.insert(
+                pubkey2,
+                CreditOnlyLock {
+                    credits: AtomicU64::new(10),
+                    lock_count: Mutex::new(1),
+                },
+            );
+        }
 
         let ancestors = vec![(0, 0)].into_iter().collect();
-        accounts.commit_credits(&ancestors, 0);
+        accounts.commit_credits_unsafe(&ancestors, 0);
 
         // No change when CreditOnlyLock credits are 0
         assert_eq!(
@@ -1506,16 +1506,17 @@ mod tests {
         let mut loaded = vec![loaded0, loaded1];
 
         let accounts = Accounts::new(None);
-        let mut credit_only_locks = accounts.credit_only_account_locks.write().unwrap();
-        let credit_only_locks = credit_only_locks.as_mut().unwrap();
-        credit_only_locks.insert(
-            pubkey,
-            CreditOnlyLock {
-                credits: AtomicU64::new(0),
-                lock_count: Mutex::new(1),
-            },
-        );
-        drop(credit_only_locks);
+        {
+            let mut credit_only_locks = accounts.credit_only_account_locks.write().unwrap();
+            let credit_only_locks = credit_only_locks.as_mut().unwrap();
+            credit_only_locks.insert(
+                pubkey,
+                CreditOnlyLock {
+                    credits: AtomicU64::new(0),
+                    lock_count: Mutex::new(1),
+                },
+            );
+        }
         let collected_accounts = accounts.collect_accounts(&txs, &loaders, &mut loaded);
         assert_eq!(collected_accounts.len(), 3);
         assert!(collected_accounts.contains_key(&keypair0.pubkey()));

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -556,8 +556,30 @@ impl Accounts {
 
     /// Commit remaining credit-only changes, regardless of reference count
     pub fn commit_credits(&self, ancestors: &HashMap<Fork, usize>, fork: Fork) {
+        // Clear the credit only hashmap so that no further transactions can modify it
         let credit_only_account_locks = Self::take_credit_only(&self.credit_only_account_locks)
             .expect("Credit only locks didn't exist in commit_credits");
+        self.store_credit_only_credits(credit_only_account_locks, ancestors, fork);
+    }
+
+    /// Used only for tests to store credit-only accounts after every transaction
+    pub fn commit_credits_unsafe(&self, ancestors: &HashMap<Fork, usize>, fork: Fork) {
+        // Clear the credit only hashmap so that no further transactions can modify it
+        let mut w_credit_only_account_locks = self.credit_only_account_locks.write().unwrap();
+        let w_credit_only_account_locks =
+            Self::get_write_access_credit_only(&mut w_credit_only_account_locks)
+                .expect("Credit only locks didn't exist in commit_credits");
+        self.store_credit_only_credits(w_credit_only_account_locks.drain(), ancestors, fork);
+    }
+
+    fn store_credit_only_credits<I>(
+        &self,
+        credit_only_account_locks: I,
+        ancestors: &HashMap<Fork, usize>,
+        fork: Fork,
+    ) where
+        I: IntoIterator<Item = (Pubkey, CreditOnlyLock)>,
+    {
         for (pubkey, lock) in credit_only_account_locks {
             let lock_count = *lock.lock_count.lock().unwrap();
             if lock_count != 0 {

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -631,7 +631,7 @@ impl Accounts {
                             .read()
                             .unwrap()
                             .as_ref()
-                            .expect("Credit only locks didn't exist during a store")
+                            .expect("Collect accounts should only be called before a commit, and credit only account locks should exist before a commit")
                             .get(key)
                             .unwrap()
                             .credits

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1991,7 +1991,7 @@ mod tests {
             system_transaction::transfer(&payer1, &recipient.pubkey(), 1, genesis_block.hash());
         let txs = vec![tx0, tx1, tx2];
         let results = bank.process_transactions(&txs);
-        bank.commit_credits();
+        bank.commit_credits_unsafe();
 
         // If multiple transactions attempt to deposit into the same account, they should succeed,
         // since System Transfer `To` accounts are given credit-only handling
@@ -2010,7 +2010,7 @@ mod tests {
             system_transaction::transfer(&recipient, &payer0.pubkey(), 1, genesis_block.hash());
         let txs = vec![tx0, tx1];
         let results = bank.process_transactions(&txs);
-        bank.commit_credits();
+        bank.commit_credits_unsafe();
         // However, an account may not be locked as credit-only and credit-debit at the same time.
         assert_eq!(results[0], Ok(()));
         assert_eq!(results[1], Err(TransactionError::AccountInUse));

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -751,7 +751,9 @@ impl Bank {
     pub fn process_transaction(&self, tx: &Transaction) -> Result<()> {
         let txs = vec![tx.clone()];
         self.process_transactions(&txs)[0].clone()?;
-        self.commit_credits();
+        // Call this instead of commit_credits(), so that the credit-only locks hashmap on this
+        // bank isn't deleted
+        self.commit_credits_unsafe();
         tx.signatures
             .get(0)
             .map_or(Ok(()), |sig| self.get_signature_status(sig).unwrap())
@@ -1426,6 +1428,12 @@ impl Bank {
         self.rc
             .accounts
             .commit_credits(&self.ancestors, self.slot());
+    }
+
+    fn commit_credits_unsafe(&self) {
+        self.rc
+            .accounts
+            .commit_credits_unsafe(&self.ancestors, self.slot());
     }
 }
 


### PR DESCRIPTION
#### Problem
A race in `commit_credits` if interleaved with `lock_accounts` can cause a subtraction overflow on the refcounted credit-only AtomicU64 as follows: 

1) a transaction grabs a credit only lock
2) `commit_credits()` drains the hashmap
3) a second transaction grabs the same credit only lock, reinserting the entry into the hashmap
Now the count in the hashmap is 1, and there are two threads trying to decrement on `unlock_accounts()`.

#### Summary of Changes
1) Convert the `credit_only_account_locks` to be a `Option<HashMap<Pubkey, CreditOnlyLock>>>` instead of just a `HashMap<Pubkey, CreditOnlyLock>>`

2) On `commit_credits()`, do a `take()` on the option so that the hashmap is no longer available to be written to. this prevents any transactions from reinserting into the hashmap. There are then only 2 cases for interleaving with `commit_credits` and `lock_accounts`. Either: 
     a) Any transactions that tries to lock after `commit_credits` will find the HashMap is `None` so will fail the lock
   b) Any transaction that grabs a lock and then `commit_credits` clears the HashMap will find the HashMap is `None` on `unlock_accounts`, and will perform a no-op.

3) Refactor calls to `commit_credits` in `process_transactions` which is only used in tests, because tests rely on being able to reuse the bank's credit-only locks, so we can't clear them on `commit_credits` - instead make a separate `commit_credits_unsafe` specifically for tests

Fixes #
