### PR TITLE
Add support for additional disks for config-local

### DIFF
--- a/ci/testnet-deploy.sh
+++ b/ci/testnet-deploy.sh
@@ -298,6 +298,11 @@ if ! $skipCreate; then
     create_args+=(-f)
   fi
 
+  if [[ -n $maybeFullnodeAdditionalDiskSize ]]; then
+    # shellcheck disable=SC2206 # Do not want to quote
+    create_args+=($maybeFullnodeAdditionalDiskSize)
+  fi
+
   time net/"$cloudProvider".sh create "${create_args[@]}"
 else
   echo "--- $cloudProvider.sh config"
@@ -316,11 +321,6 @@ else
 
   if ! $failOnValidatorBootupFailure; then
     config_args+=(-f)
-  fi
-
-  if [[ -n $maybeFullnodeAdditionalDiskSize ]]; then
-    # shellcheck disable=SC2206 # Do not want to quote
-    create_args+=($maybeFullnodeAdditionalDiskSize)
   fi
 
   time net/"$cloudProvider".sh config "${config_args[@]}"

--- a/ci/testnet-deploy.sh
+++ b/ci/testnet-deploy.sh
@@ -28,6 +28,7 @@ maybeStakeNodesInGenesisBlock=
 maybeExternalPrimordialAccountsFile=
 maybeLamports=
 maybeLetsEncrypt=
+maybeFullnodeAdditionalDiskSize=
 
 usage() {
   exitcode=0
@@ -80,6 +81,8 @@ Deploys a CD testnet
                         - If set, will not fetch logs from remote nodes
    --letsencrypt [dns name]
                         - Attempt to generate a TLS certificate using this DNS name
+   --fullnode-additional-disk-size-gb [number]
+                    - Size of additional disk in GB for all fullnodes
 
    Note: the SOLANA_METRICS_CONFIG environment variable is used to configure
          metrics
@@ -112,6 +115,9 @@ while [[ -n $1 ]]; do
       shift 1
     elif [[ $1 = --letsencrypt ]]; then
       maybeLetsEncrypt="$1 $2"
+      shift 2
+    elif [[ $1 = --fullnode-additional-disk-size-gb ]]; then
+      maybeFullnodeAdditionalDiskSize="$1 $2"
       shift 2
     else
       usage "Unknown long option: $1"
@@ -310,6 +316,11 @@ else
 
   if ! $failOnValidatorBootupFailure; then
     config_args+=(-f)
+  fi
+
+  if [[ -n $maybeFullnodeAdditionalDiskSize ]]; then
+    # shellcheck disable=SC2206 # Do not want to quote
+    create_args+=($maybeFullnodeAdditionalDiskSize)
   fi
 
   time net/"$cloudProvider".sh config "${config_args[@]}"

--- a/multinode-demo/common.sh
+++ b/multinode-demo/common.sh
@@ -70,9 +70,9 @@ source "$SOLANA_ROOT"/scripts/configure-metrics.sh
 SOLANA_RSYNC_CONFIG_DIR=$SOLANA_ROOT/config
 
 # Configuration that remains local
-secondary_disk_mount_point=$(df | grep sdb | awk '{print $6}')
-if [[ -n $secondary_disk_mount_point ]]; then
-  SOLANA_CONFIG_DIR=$secondary_disk_mount_point/config-local
+SECONDARY_DISK_MOUNT_POINT=/mnt/extra-disk
+if [ -d $SECONDARY_DISK_MOUNT_POINT ]; then
+  SOLANA_CONFIG_DIR=$SECONDARY_DISK_MOUNT_POINT/config-local
 else
   SOLANA_CONFIG_DIR=$SOLANA_ROOT/config-local
 fi

--- a/multinode-demo/common.sh
+++ b/multinode-demo/common.sh
@@ -71,7 +71,7 @@ SOLANA_RSYNC_CONFIG_DIR=$SOLANA_ROOT/config
 
 # Configuration that remains local
 SECONDARY_DISK_MOUNT_POINT=/mnt/extra-disk
-if [ -d $SECONDARY_DISK_MOUNT_POINT ]; then
+if [[ -d $SECONDARY_DISK_MOUNT_POINT ]]; then
   SOLANA_CONFIG_DIR=$SECONDARY_DISK_MOUNT_POINT/config-local
 else
   SOLANA_CONFIG_DIR=$SOLANA_ROOT/config-local

--- a/multinode-demo/common.sh
+++ b/multinode-demo/common.sh
@@ -70,7 +70,12 @@ source "$SOLANA_ROOT"/scripts/configure-metrics.sh
 SOLANA_RSYNC_CONFIG_DIR=$SOLANA_ROOT/config
 
 # Configuration that remains local
-SOLANA_CONFIG_DIR=$SOLANA_ROOT/config-local
+secondary_disk_mount_point=$(df | grep sdb | awk '{print $6}')
+if [[ -n $secondary_disk_mount_point ]]; then
+  SOLANA_CONFIG_DIR=$secondary_disk_mount_point/config-local
+else
+  SOLANA_CONFIG_DIR=$SOLANA_ROOT/config-local
+fi
 
 default_arg() {
   declare name=$1

--- a/net/gce.sh
+++ b/net/gce.sh
@@ -644,7 +644,7 @@ $(
     fi
 
     if [[ -n $fullNodeAdditionalDiskSizeInGb ]]; then
-      cat mount_additional_disk.sh
+      cat mount-additional-disk.sh
     fi
 
 )

--- a/net/gce.sh
+++ b/net/gce.sh
@@ -60,6 +60,9 @@ additionalFullNodeCount=2
 clientNodeCount=1
 replicatorNodeCount=0
 blockstreamer=false
+fullNodeBootDiskSizeInGb=1000
+clientBootDiskSizeInGb=75
+replicatorBootDiskSizeInGb=1000
 fullNodeAdditionalDiskSizeInGb=
 externalNodes=false
 failOnValidatorBootupFailure=true
@@ -641,7 +644,7 @@ $(
     fi
 
     if [[ -n $fullNodeAdditionalDiskSizeInGb ]]; then
-      cat mount_Additional_disk.sh
+      cat mount_additional_disk.sh
     fi
 
 )

--- a/net/scripts/azure-provider.sh
+++ b/net/scripts/azure-provider.sh
@@ -309,3 +309,12 @@ cloud_FetchFile() {
   cloud_GetConfigValueFromInstanceName "$instanceName" osProfile.adminUsername
   scp "${config_value}@${publicIp}:${remoteFile}" "$localFile"
 }
+
+#
+# cloud_CreateAndAttachPersistentDisk
+#
+# Not yet implemented for this cloud provider
+cloud_CreateAndAttachPersistentDisk() {
+  echo "ERROR: cloud_CreateAndAttachPersistentDisk is not yet implemented for azure"
+  exit 1
+}

--- a/net/scripts/ec2-provider.sh
+++ b/net/scripts/ec2-provider.sh
@@ -381,3 +381,12 @@ cloud_FetchFile() {
       "solana@$publicIp:$remoteFile" "$localFile"
   )
 }
+
+#
+# cloud_CreateAndAttachPersistentDisk
+#
+# Not yet implemented for this cloud provider
+cloud_CreateAndAttachPersistentDisk() {
+  echo "ERROR: cloud_CreateAndAttachPersistentDisk is not yet implemented for ec2"
+  exit 1
+}

--- a/net/scripts/mount-additional-disk.sh
+++ b/net/scripts/mount-additional-disk.sh
@@ -10,10 +10,10 @@ else
     echo "${disk} is already mounted"
   else
     sudo mkfs.ext4 -F /dev/"$disk"
-    sudo mkdir -p /mnt/disks/"$disk"
+    sudo mkdir -p "$mount_point"
     sudo mount /dev/"$disk" "$mount_point"
-    sudo chmod a+w /mnt/disks/"$disk"
-    if ! mount | grep -q ${disk} ; then
+    sudo chmod a+w "$mount_point"
+    if ! mount | grep -q ${mount_point} ; then
       echo "${disk} failed to mount!"
       exit 1
     fi

--- a/net/scripts/mount-additional-disk.sh
+++ b/net/scripts/mount-additional-disk.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -x
 
+mount_point=/mnt/extra-disk
 disk=sdb
 if ! lsblk | grep -q ${disk} ; then
   echo "${disk} does not exist"
@@ -10,7 +11,7 @@ else
   else
     sudo mkfs.ext4 -F /dev/"$disk"
     sudo mkdir -p /mnt/disks/"$disk"
-    sudo mount /dev/"$disk" /mnt/disks/"$disk"
+    sudo mount /dev/"$disk" "$mount_point"
     sudo chmod a+w /mnt/disks/"$disk"
     if ! mount | grep -q ${disk} ; then
       echo "${disk} failed to mount!"

--- a/net/scripts/mount_additional_disk.sh
+++ b/net/scripts/mount_additional_disk.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -x
+
+disk=sdb
+if [[ -z $(lsblk | grep ${disk}) ]]; then
+  echo "${disk} does not exist"
+else
+  if [[ -n $(mount | grep ${disk}) ]]; then
+    echo "${disk} is already mounted"
+  else
+    sudo mkfs.ext4 -F /dev/"$disk"
+    sudo mkdir -p /mnt/disks/"$disk"
+    sudo mount /dev/"$disk" /mnt/disks/"$disk"
+    sudo chmod a+w /mnt/disks/"$disk"
+    if [[ -z $(mount | grep ${disk}) ]]; then
+      echo "${disk} failed to mount!"
+      exit 1
+    fi
+  fi
+fi

--- a/net/scripts/mount_additional_disk.sh
+++ b/net/scripts/mount_additional_disk.sh
@@ -2,17 +2,17 @@
 set -x
 
 disk=sdb
-if [[ -z $(lsblk | grep ${disk}) ]]; then
+if ! lsblk | grep -q ${disk} ; then
   echo "${disk} does not exist"
 else
-  if [[ -n $(mount | grep ${disk}) ]]; then
+  if mount | grep -q ${disk} ; then
     echo "${disk} is already mounted"
   else
     sudo mkfs.ext4 -F /dev/"$disk"
     sudo mkdir -p /mnt/disks/"$disk"
     sudo mount /dev/"$disk" /mnt/disks/"$disk"
     sudo chmod a+w /mnt/disks/"$disk"
-    if [[ -z $(mount | grep ${disk}) ]]; then
+    if ! mount | grep -q ${disk} ; then
       echo "${disk} failed to mount!"
       exit 1
     fi


### PR DESCRIPTION
#### Problem
Ledger gets big, fast.  At 24k TPS we are filling about 80GB of disk space per hour, or about 2TB per day.  We need more disk space on our VMs to support a long running cluster.

#### Summary of Changes
GCP allows up to 64TB of additional persistent storage per instance.  Add support to the gce API to add these disks, and mount them during start up.  Point the config-local dir to write to the additional disk.  Added flag to support this setting from ci automation.

Fixes #
