### PR TITLE
Enable GPUs and secondary disks for TdS net, pull external account file

### DIFF
--- a/ci/testnet-deploy.sh
+++ b/ci/testnet-deploy.sh
@@ -119,6 +119,9 @@ while [[ -n $1 ]]; do
     elif [[ $1 = --fullnode-additional-disk-size-gb ]]; then
       maybeFullnodeAdditionalDiskSize="$1 $2"
       shift 2
+    elif [[ $1 == --machine-type* ]]; then # Bypass quoted long args for GPUs
+      shortArgs+=("$1")
+      shift
     else
       usage "Unknown long option: $1"
     fi

--- a/ci/testnet-manager.sh
+++ b/ci/testnet-manager.sh
@@ -469,6 +469,12 @@ deploy() {
   tds)
     (
       set -x
+
+      EXTERNAL_ACCOUNTS_FILE_URL=https://raw.githubusercontent.com/solana-labs/tour-de-sol/master/stage1/validator.yml
+      EXTERNAL_ACCOUNTS_FILE=/tmp/validator.yml
+
+      wget ${EXTERNAL_ACCOUNTS_FILE_URL} -o ${EXTERNAL_ACCOUNTS_FILE}
+
       # Multiple V100 GPUs are available in us-west1, us-central1 and europe-west4
       # shellcheck disable=SC2068
       # shellcheck disable=SC2086
@@ -488,7 +494,7 @@ deploy() {
           ${maybeStop:+-S} \
           ${maybeDelete:+-D} \
           --stake-internal-nodes 1000000000000 \
-          --external-accounts-file /tmp/stakes.yml \
+          --external-accounts-file "$EXTERNAL_ACCOUNTS_FILE" \
           --lamports 8589934592000000000 \
           --skip-deploy-update \
           --fullnode-additional-disk-size-gb 32000

--- a/ci/testnet-manager.sh
+++ b/ci/testnet-manager.sh
@@ -473,7 +473,7 @@ deploy() {
       EXTERNAL_ACCOUNTS_FILE_URL=https://raw.githubusercontent.com/solana-labs/tour-de-sol/master/stage1/validator.yml
       EXTERNAL_ACCOUNTS_FILE=/tmp/validator.yml
 
-      wget ${EXTERNAL_ACCOUNTS_FILE_URL} -o ${EXTERNAL_ACCOUNTS_FILE}
+      wget ${EXTERNAL_ACCOUNTS_FILE_URL} -O ${EXTERNAL_ACCOUNTS_FILE}
 
       # Multiple V100 GPUs are available in us-west1, us-central1 and europe-west4
       # shellcheck disable=SC2068

--- a/ci/testnet-manager.sh
+++ b/ci/testnet-manager.sh
@@ -490,7 +490,8 @@ deploy() {
           --stake-internal-nodes 1000000000000 \
           --external-accounts-file /tmp/stakes.yml \
           --lamports 8589934592000000000 \
-          --skip-deploy-update
+          --skip-deploy-update \
+          --fullnode-additional-disk-size-gb 32000
 
     )
     ;;

--- a/ci/testnet-manager.sh
+++ b/ci/testnet-manager.sh
@@ -469,12 +469,17 @@ deploy() {
   tds)
     (
       set -x
-      # TODO: Should we spread the few nodes around multiple zones?
+      # Multiple V100 GPUs are available in us-west1, us-central1 and europe-west4
       # shellcheck disable=SC2068
       # shellcheck disable=SC2086
       NO_LEDGER_VERIFY=1 \
       NO_VALIDATOR_SANITY=1 \
-        ci/testnet-deploy.sh -p tds-solana-com -C gce ${GCE_ZONE_ARGS[0]} \
+        ci/testnet-deploy.sh -p tds-solana-com -C gce \
+          -G "--machine-type n1-standard-16 --accelerator count=2,type=nvidia-tesla-v100" \
+          -d pd-ssd \
+          -z us-west1-a \
+          -z us-central1-a \
+          -z europe-west4-a \
           -t "$CHANNEL_OR_TAG" -n "$GCE_NODE_COUNT" -c 1 -P -u \
           -a tds-solana-com --letsencrypt tds.solana.com \
           --hashes-per-tick auto \

--- a/multinode-demo/common.sh
+++ b/multinode-demo/common.sh
@@ -70,11 +70,14 @@ source "$SOLANA_ROOT"/scripts/configure-metrics.sh
 SOLANA_RSYNC_CONFIG_DIR=$SOLANA_ROOT/config
 
 # Configuration that remains local
+SOLANA_CONFIG_DIR=$SOLANA_ROOT/config-local
+
+# If there is a secondary disk, symlink the config-local dir there
 SECONDARY_DISK_MOUNT_POINT=/mnt/extra-disk
 if [[ -d $SECONDARY_DISK_MOUNT_POINT ]]; then
-  SOLANA_CONFIG_DIR=$SECONDARY_DISK_MOUNT_POINT/config-local
-else
-  SOLANA_CONFIG_DIR=$SOLANA_ROOT/config-local
+  mkdir -p $SECONDARY_DISK_MOUNT_POINT/config-local
+  mkdir -p $SOLANA_ROOT
+  ln -s $SECONDARY_DISK_MOUNT_POINT/config-local $SOLANA_CONFIG_DIR
 fi
 
 default_arg() {

--- a/multinode-demo/common.sh
+++ b/multinode-demo/common.sh
@@ -76,8 +76,8 @@ SOLANA_CONFIG_DIR=$SOLANA_ROOT/config-local
 SECONDARY_DISK_MOUNT_POINT=/mnt/extra-disk
 if [[ -d $SECONDARY_DISK_MOUNT_POINT ]]; then
   mkdir -p $SECONDARY_DISK_MOUNT_POINT/config-local
-  mkdir -p $SOLANA_ROOT
-  ln -s $SECONDARY_DISK_MOUNT_POINT/config-local $SOLANA_CONFIG_DIR
+  mkdir -p "$SOLANA_ROOT"
+  ln -s $SECONDARY_DISK_MOUNT_POINT/config-local "$SOLANA_ROOT"
 fi
 
 default_arg() {

--- a/net/gce.sh
+++ b/net/gce.sh
@@ -159,6 +159,9 @@ while [[ -n $1 ]]; do
     elif [[ $1 = --fullnode-additional-disk-size-gb ]]; then
       fullNodeAdditionalDiskSizeInGb="$2"
       shift 2
+    elif [[ $1 == --machine-type* ]]; then # Bypass quoted long args for GPUs
+      shortArgs+=("$1")
+      shift
     else
       usage "Unknown long option: $1"
     fi


### PR DESCRIPTION
#### Problem
Turn up the settings on the TdS testnet.  Add V100 GPUs, spread out geographically and add big secondary disks to hold the ledger.
Fixes #4986 
Depends on https://github.com/solana-labs/solana/pull/5030
