### PR TITLE
Add rewards to is_syscall_id()

### DIFF
--- a/sdk/src/syscall/mod.rs
+++ b/sdk/src/syscall/mod.rs
@@ -8,7 +8,10 @@ pub mod rewards;
 pub mod slot_hashes;
 
 pub fn is_syscall_id(id: &Pubkey) -> bool {
-    current::check_id(id) || fees::check_id(id) || slot_hashes::check_id(id)
+    current::check_id(id)
+        || fees::check_id(id)
+        || rewards::check_id(id)
+        || slot_hashes::check_id(id)
 }
 
 /// "Sysca11111111111111111111111111111111111111"


### PR DESCRIPTION
#### Problem

Rewards is not part of the check if an id is a Syscall

#### Summary of Changes

Add it

Fixes #
