### PR TITLE
Make Merkle Tree instantiation a little less painful

### DIFF
--- a/core/src/entry.rs
+++ b/core/src/entry.rs
@@ -175,7 +175,7 @@ pub fn hash_transactions(transactions: &[Transaction]) -> Hash {
     // a hash of a slice of transactions only needs to hash the signatures
     let signatures: Vec<_> = transactions
         .iter()
-        .flat_map(|tx| tx.signatures.iter().map(|sig| sig.as_ref()))
+        .flat_map(|tx| tx.signatures.iter())
         .collect();
     let merkle_tree = MerkleTree::new(&signatures);
     if let Some(root_hash) = merkle_tree.get_root() {

--- a/merkle-tree/src/merkle_tree.rs
+++ b/merkle-tree/src/merkle_tree.rs
@@ -84,7 +84,7 @@ impl MerkleTree {
         capacity
     }
 
-    pub fn new(items: &[&[u8]]) -> Self {
+    pub fn new<T: AsRef<[u8]>>(items: &[T]) -> Self {
         let cap = MerkleTree::calculate_vec_capacity(items.len());
         let mut mt = MerkleTree {
             leaf_count: items.len(),
@@ -92,6 +92,7 @@ impl MerkleTree {
         };
 
         for item in items {
+            let item = item.as_ref();
             let hash = hash_leaf!(item);
             mt.nodes.push(hash);
         }
@@ -178,7 +179,7 @@ mod tests {
 
     #[test]
     fn test_tree_from_empty() {
-        let mt = MerkleTree::new(&[]);
+        let mt = MerkleTree::new::<[u8; 0]>(&[]);
         assert_eq!(mt.get_root(), None);
     }
 


### PR DESCRIPTION
#### Problem
`MerkleTree::new()`'s requirement of `&[&[u8]]` leaf data makes instantiation annoying as it frequently requires the input being transformed first.

#### Summary of Changes
Instead, allow inputs to be `AsRef<[u8]>` and `.as_ref()` them while generating leaf hashes