### PR TITLE
Pull in support for Rust-BPF stack argument passing

### DIFF
--- a/programs/bpf/rust/many_args/src/lib.rs
+++ b/programs/bpf/rust/many_args/src/lib.rs
@@ -15,10 +15,19 @@ use solana_sdk_bpf_utils::info;
 pub extern "C" fn entrypoint(_input: *mut u8) -> bool {
     info!("Call same package");
     assert_eq!(crate::helper::many_args(1, 2, 3, 4, 5, 6, 7, 8, 9), 45);
+
     info!("Call another package");
     assert_eq!(
         solana_bpf_rust_many_args_dep::many_args(1, 2, 3, 4, 5, 6, 7, 8, 9),
         45
+    );
+    assert_eq!(
+        solana_bpf_rust_many_args_dep::many_args_sret(1, 2, 3, 4, 5, 6, 7, 8, 9),
+        solana_bpf_rust_many_args_dep::Ret {
+            group1: 6,
+            group2: 15,
+            group3: 24
+        }
     );
 
     info!("Success");

--- a/programs/bpf/rust/many_args_dep/src/lib.rs
+++ b/programs/bpf/rust/many_args_dep/src/lib.rs
@@ -23,6 +23,34 @@ pub fn many_args(
     arg1 + arg2 + arg3 + arg4 + arg5 + arg6 + arg7 + arg8 + arg9
 }
 
+#[derive(Debug, PartialEq)]
+pub struct Ret {
+    pub group1: u128,
+    pub group2: u128,
+    pub group3: u128,
+}
+
+pub fn many_args_sret(
+    arg1: u64,
+    arg2: u64,
+    arg3: u64,
+    arg4: u64,
+    arg5: u64,
+    arg6: u64,
+    arg7: u64,
+    arg8: u64,
+    arg9: u64,
+) -> Ret {
+    info!("Another package");
+    info!(arg1, arg2, arg3, arg4, arg5);
+    info!(arg6, arg7, arg8, arg9, 0);
+    Ret {
+        group1: u128::from(arg1) + u128::from(arg2) + u128::from(arg3),
+        group2: u128::from(arg4) + u128::from(arg5) + u128::from(arg6),
+        group3: u128::from(arg7) + u128::from(arg8) + u128::from(arg9),
+    }
+}
+
 #[cfg(test)]
 mod test {
     extern crate std;

--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -93,7 +93,7 @@ mod bpf {
                 ("solana_bpf_rust_alloc", true),
                 ("solana_bpf_rust_dep_crate", true),
                 ("solana_bpf_rust_iter", true),
-                // ("solana_bpf_rust_many_args", true),  // Issue #3099
+                ("solana_bpf_rust_many_args", true),
                 ("solana_bpf_rust_external_spend", false),
                 ("solana_bpf_rust_noop", true),
                 ("solana_bpf_rust_panic", false),

--- a/sdk/bpf/scripts/install.sh
+++ b/sdk/bpf/scripts/install.sh
@@ -54,7 +54,7 @@ if [[ ! -r criterion-$machine-$version.md ]]; then
 fi
 
 # Install LLVM
-version=v0.0.11
+version=v0.0.12
 if [[ ! -f llvm-native-$machine-$version.md ]]; then
   (
     filename=solana-llvm-$machine.tar.bz2
@@ -80,7 +80,7 @@ if [[ ! -f llvm-native-$machine-$version.md ]]; then
 fi
 
 # Install Rust-BPF
-version=v0.1.2
+version=v0.1.3
 if [[ ! -f rust-bpf-$machine-$version.md ]]; then
   (
     filename=solana-rust-bpf-$machine.tar.bz2


### PR DESCRIPTION
#### Problem

LLVM's BPF backend only supports passing arguments via registers of which BPF defines 5.  

#### Summary of Changes

Added support for passing additional arguments via the stack frame

Fixes #3099
