### PR TITLE
Add a version field to blobs

### DIFF
--- a/core/src/chacha.rs
+++ b/core/src/chacha.rs
@@ -135,7 +135,7 @@ mod tests {
         hasher.hash(&buf[..size]);
 
         //  golden needs to be updated if blob stuff changes....
-        let golden: Hash = "Dy2V98ybxnp1mDTqXrUbsLE5LyKVpQN5zDhrEKCDEFhH"
+        let golden: Hash = "7hgFLHveuv9zvHpp6qpco9AHAJKyczdgxiktEMkeghDQ"
             .parse()
             .unwrap();
 

--- a/core/src/erasure.rs
+++ b/core/src/erasure.rs
@@ -273,11 +273,13 @@ impl CodingGenerator {
                 let index = data_blob.index();
                 let slot = data_blob.slot();
                 let id = data_blob.id();
+                let version = data_blob.version();
 
                 let mut coding_blob = Blob::default();
                 coding_blob.set_index(index);
                 coding_blob.set_slot(slot);
                 coding_blob.set_id(&id);
+                coding_blob.set_version(version);
                 coding_blob.set_size(max_data_size);
                 coding_blob.set_coding();
                 coding_blob.set_erasure_config(&data_blob.erasure_config());

--- a/core/src/packet.rs
+++ b/core/src/packet.rs
@@ -386,7 +386,8 @@ macro_rules! range {
 const SIGNATURE_RANGE: std::ops::Range<usize> = range!(0, Signature);
 const FORWARDED_RANGE: std::ops::Range<usize> = range!(SIGNATURE_RANGE.end, bool);
 const PARENT_RANGE: std::ops::Range<usize> = range!(FORWARDED_RANGE.end, u64);
-const SLOT_RANGE: std::ops::Range<usize> = range!(PARENT_RANGE.end, u64);
+const VERSION_RANGE: std::ops::Range<usize> = range!(PARENT_RANGE.end, u64);
+const SLOT_RANGE: std::ops::Range<usize> = range!(VERSION_RANGE.end, u64);
 const INDEX_RANGE: std::ops::Range<usize> = range!(SLOT_RANGE.end, u64);
 const ID_RANGE: std::ops::Range<usize> = range!(INDEX_RANGE.end, Pubkey);
 const FLAGS_RANGE: std::ops::Range<usize> = range!(ID_RANGE.end, u32);
@@ -437,6 +438,12 @@ impl Blob {
     }
     pub fn set_parent(&mut self, ix: u64) {
         LittleEndian::write_u64(&mut self.data[PARENT_RANGE], ix);
+    }
+    pub fn version(&self) -> u64 {
+        LittleEndian::read_u64(&self.data[VERSION_RANGE])
+    }
+    pub fn set_version(&mut self, version: u64) {
+        LittleEndian::write_u64(&mut self.data[VERSION_RANGE], version);
     }
     pub fn slot(&self) -> u64 {
         LittleEndian::read_u64(&self.data[SLOT_RANGE])
@@ -937,5 +944,13 @@ mod tests {
         assert_eq!(packets.packets.len(), 10);
         packets.reset();
         assert_eq!(packets.packets.len(), 0);
+    }
+
+    #[test]
+    fn test_version() {
+        let mut b = Blob::default();
+        assert_eq!(b.version(), 0);
+        b.set_version(1);
+        assert_eq!(b.version(), 1);
     }
 }


### PR DESCRIPTION
#### Problem
Add a version field to blobs
#### Summary of Changes
Blobs need versions to support rollbacks. 

Without a version, it becomes impossible to distinguish a legitimate blob from a continuation of state vs a blob from the previous run. 


