### PR TITLE
Add confidence cache to BankForks

### DIFF
--- a/core/src/bank_forks.rs
+++ b/core/src/bank_forks.rs
@@ -223,6 +223,10 @@ impl BankForks {
             });
     }
 
+    pub fn get_fork_confidence(&self, fork: u64) -> Option<&Confidence> {
+        self.confidence.get(&fork)
+    }
+
     fn get_io_error(error: &str) -> Error {
         warn!("BankForks error: {:?}", error);
         Error::new(ErrorKind::Other, error)

--- a/core/src/bank_forks.rs
+++ b/core/src/bank_forks.rs
@@ -188,6 +188,7 @@ impl BankForks {
         let descendants = self.descendants();
         self.banks
             .retain(|slot, _| descendants[&root].contains(slot));
+        self.confidence.retain(|slot, _| slot == &root || descendants[&root].contains(slot));
         if self.snapshot_path.is_some() {
             let diff: HashSet<_> = slots.symmetric_difference(&self.slots).collect();
             trace!("prune non root {} - {:?}", root, diff);

--- a/core/src/bank_forks.rs
+++ b/core/src/bank_forks.rs
@@ -20,6 +20,24 @@ pub struct BankForks {
     root: u64,
     slots: HashSet<u64>,
     snapshot_path: Option<String>,
+    confidence: HashMap<u64, Confidence>,
+}
+
+#[derive(Debug, Default, PartialEq)]
+pub struct Confidence {
+    fork_stakes: u64,
+    epoch_stakes: u64,
+    lockouts: u64,
+}
+
+impl Confidence {
+    pub fn new(fork_stakes: u64, epoch_stakes: u64, lockouts: u64) -> Self {
+        Self {
+            fork_stakes,
+            epoch_stakes,
+            lockouts,
+        }
+    }
 }
 
 impl Index<u64> for BankForks {
@@ -40,6 +58,7 @@ impl BankForks {
             root: 0,
             slots: HashSet::new(),
             snapshot_path: None,
+            confidence: HashMap::new(),
         }
     }
 
@@ -104,6 +123,7 @@ impl BankForks {
             working_bank,
             slots: HashSet::new(),
             snapshot_path: None,
+            confidence: HashMap::new(),
         }
     }
 
@@ -173,6 +193,10 @@ impl BankForks {
             }
         }
         self.slots = slots.clone();
+    }
+
+    pub fn cache_fork_confidence(&mut self, fork: u64, confidence: Confidence) {
+        self.confidence.insert(fork, confidence);
     }
 
     fn get_io_error(error: &str) -> Error {
@@ -356,6 +380,7 @@ impl BankForks {
             root,
             slots,
             snapshot_path: snapshot_path.clone(),
+            confidence: HashMap::new(),
         })
     }
 }

--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -347,12 +347,11 @@ impl Tower {
     }
 
     pub fn aggregate_stake_lockouts(
-        &self,
+        root: Option<u64>,
         ancestors: &HashMap<u64, HashSet<u64>>,
-        stake_lockouts: &HashMap<u64, StakeLockout>,
+        stake_lockouts: HashMap<u64, StakeLockout>,
     ) -> HashMap<u64, u128> {
         let mut stake_weighted_lockouts: HashMap<u64, u128> = HashMap::new();
-        let root = self.root();
         for (fork, lockout) in stake_lockouts.iter() {
             if root.is_none() || *fork >= root.unwrap() {
                 let mut slot_with_ancestors = vec![*fork];
@@ -612,7 +611,8 @@ mod test {
         ]
         .into_iter()
         .collect();
-        let stake_weighted_lockouts = tower.aggregate_stake_lockouts(&ancestors, &stakes);
+        let stake_weighted_lockouts =
+            Tower::aggregate_stake_lockouts(tower.root(), &ancestors, stakes);
         assert!(stake_weighted_lockouts.get(&0).is_none());
         assert_eq!(*stake_weighted_lockouts.get(&1).unwrap(), 8 + 16 + 24);
         assert_eq!(*stake_weighted_lockouts.get(&2).unwrap(), 8 + 16);


### PR DESCRIPTION
#### Problem
Aside from the simple count of confirmed blocks, there is currently no way to understand the cluster confidence in a processed transaction.

#### Summary of Changes
Cache various confidence data in BankForks, allowing it to be exposed via RPC. Data includes fork stake and epoch stake (to calculate percentage stake vote), and fork lockout total

Toward #5007 
