### PR TITLE
Purge remaining uses of term Locktower

### DIFF
--- a/metrics/scripts/grafana-provisioning/dashboards/testnet-monitor.json
+++ b/metrics/scripts/grafana-provisioning/dashboards/testnet-monitor.json
@@ -7025,7 +7025,7 @@
       },
       "id": 51,
       "panels": [],
-      "title": "Locktower Consensus",
+      "title": "Tower Consensus",
       "type": "row"
     },
     {
@@ -7150,7 +7150,7 @@
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Locktower Distance in Latest and Root Slot ($hostid)",
+      "title": "Tower Distance in Latest and Root Slot ($hostid)",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -7310,7 +7310,7 @@
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Locktower Root Slot ($hostid)",
+      "title": "Tower Root Slot ($hostid)",
       "tooltip": {
         "shared": true,
         "sort": 0,

--- a/programs/vote_api/src/vote_state.rs
+++ b/programs/vote_api/src/vote_state.rs
@@ -224,7 +224,7 @@ impl VoteState {
         self.credits += 1;
     }
 
-    /// "uncheckeds" used by tests, locktower
+    /// "unchecked" functions used by tests and Tower
     pub fn process_vote_unchecked(&mut self, vote: &Vote) {
         self.process_vote(vote, &[(vote.slot, vote.hash)], self.epoch);
     }


### PR DESCRIPTION
#### Problem

Locktower was renamed to Tower BFT, but not all references were updated.

#### Summary of Changes

Rename the remaining uses of Locktower to Tower.
