### PR TITLE
tmp dirs target to farf

### DIFF
--- a/bench-exchange/.gitignore
+++ b/bench-exchange/.gitignore
@@ -1,3 +1,4 @@
 /target/
 /config/
 /config-local/
+/farf/

--- a/bench-streamer/.gitignore
+++ b/bench-streamer/.gitignore
@@ -1,1 +1,2 @@
 /target/
+/farf/

--- a/bench-tps/.gitignore
+++ b/bench-tps/.gitignore
@@ -1,3 +1,4 @@
 /target/
 /config/
 /config-local/
+/farf/

--- a/chacha-sys/.gitignore
+++ b/chacha-sys/.gitignore
@@ -1,1 +1,2 @@
 /target/
+/farf/

--- a/ci/nits.sh
+++ b/ci/nits.sh
@@ -46,16 +46,22 @@ if _ git --no-pager grep -n 'Default::default()' -- '*.rs'; then
 fi
 
 # Let's keep a .gitignore for every crate, ensure it's got
-#  /target/ in it
+#  /target/ and /farf/ in it
 declare gitignores_ok=true
 for i in $(git --no-pager ls-files \*/Cargo.toml ); do
   dir=$(dirname "$i")
   if [[ ! -f $dir/.gitignore ]]; then
       echo 'error: nits.sh .gitnore missing for crate '"$dir" >&2
       gitignores_ok=false
-  elif ! grep -q -e '^/target/$' "$dir"/.gitignore; then
+  else
+    if ! grep -q -e '^/target/$' "$dir"/.gitignore; then
       echo 'error: nits.sh "/target/" apparently missing from '"$dir"'/.gitignore' >&2
       gitignores_ok=false
+    fi
+    if ! grep -q -e '^/farf/$' "$dir"/.gitignore ; then
+      echo 'error: nits.sh "/farf/" apparently missing from '"$dir"'/.gitignore' >&2
+      gitignores_ok=false
+    fi
   fi
 done
 "$gitignores_ok"

--- a/client/.gitignore
+++ b/client/.gitignore
@@ -1,1 +1,2 @@
 /target/
+/farf/

--- a/core/.gitignore
+++ b/core/.gitignore
@@ -1,1 +1,2 @@
 /target/
+/farf/

--- a/core/src/bank_forks.rs
+++ b/core/src/bank_forks.rs
@@ -477,7 +477,7 @@ mod tests {
     }
 
     fn get_tmp_snapshots_path() -> TempPaths {
-        let out_dir = env::var("OUT_DIR").unwrap_or_else(|_| "target".to_string());
+        let out_dir = env::var("OUT_DIR").unwrap_or_else(|_| "farf".to_string());
         let path = format!("{}/snapshots", out_dir);
         TempPaths {
             paths: path.to_string(),
@@ -486,7 +486,7 @@ mod tests {
 
     fn get_tmp_bank_accounts_path(paths: &str) -> TempPaths {
         let vpaths = get_paths_vec(paths);
-        let out_dir = env::var("OUT_DIR").unwrap_or_else(|_| "target".to_string());
+        let out_dir = env::var("OUT_DIR").unwrap_or_else(|_| "farf".to_string());
         let vpaths: Vec<_> = vpaths
             .iter()
             .map(|path| format!("{}/{}", out_dir, path))

--- a/core/src/blocktree.rs
+++ b/core/src/blocktree.rs
@@ -1820,10 +1820,10 @@ macro_rules! get_tmp_ledger_path {
 
 pub fn get_tmp_ledger_path(name: &str) -> String {
     use std::env;
-    let out_dir = env::var("OUT_DIR").unwrap_or_else(|_| "target".to_string());
+    let out_dir = env::var("OUT_DIR").unwrap_or_else(|_| "farf".to_string());
     let keypair = Keypair::new();
 
-    let path = format!("{}/tmp/ledger/{}-{}", out_dir, name, keypair.pubkey());
+    let path = format!("{}/ledger/{}-{}", out_dir, name, keypair.pubkey());
 
     // whack any possible collision
     let _ignored = fs::remove_dir_all(&path);

--- a/core/src/replicator.rs
+++ b/core/src/replicator.rs
@@ -910,7 +910,7 @@ mod tests {
 
     fn tmp_file_path(name: &str) -> PathBuf {
         use std::env;
-        let out_dir = env::var("OUT_DIR").unwrap_or_else(|_| "target".to_string());
+        let out_dir = env::var("OUT_DIR").unwrap_or_else(|_| "farf".to_string());
         let keypair = Keypair::new();
 
         let mut path = PathBuf::new();

--- a/drone/.gitignore
+++ b/drone/.gitignore
@@ -1,1 +1,2 @@
 /target/
+/farf/

--- a/genesis/.gitignore
+++ b/genesis/.gitignore
@@ -1,1 +1,2 @@
 /target/
+/farf/

--- a/gossip/.gitignore
+++ b/gossip/.gitignore
@@ -1,1 +1,2 @@
 /target/
+/farf/

--- a/install/.gitignore
+++ b/install/.gitignore
@@ -1,1 +1,2 @@
 /target/
+/farf/

--- a/keygen/.gitignore
+++ b/keygen/.gitignore
@@ -1,1 +1,2 @@
 /target/
+/farf/

--- a/kvstore/.gitignore
+++ b/kvstore/.gitignore
@@ -1,1 +1,2 @@
 /target/
+/farf/

--- a/ledger-tool/.gitignore
+++ b/ledger-tool/.gitignore
@@ -1,1 +1,2 @@
 /target/
+/farf/

--- a/logger/.gitignore
+++ b/logger/.gitignore
@@ -1,1 +1,2 @@
 /target/
+/farf/

--- a/measure/.gitignore
+++ b/measure/.gitignore
@@ -1,1 +1,2 @@
 /target/
+/farf/

--- a/merkle-tree/.gitignore
+++ b/merkle-tree/.gitignore
@@ -1,1 +1,2 @@
 /target/
+/farf/

--- a/metrics/.gitignore
+++ b/metrics/.gitignore
@@ -1,1 +1,2 @@
 /target/
+/farf/

--- a/netutil/.gitignore
+++ b/netutil/.gitignore
@@ -1,1 +1,2 @@
 /target/
+/farf/

--- a/programs/bpf/.gitignore
+++ b/programs/bpf/.gitignore
@@ -1,1 +1,2 @@
 /target/
+/farf/

--- a/programs/bpf/rust/128bit/.gitignore
+++ b/programs/bpf/rust/128bit/.gitignore
@@ -1,3 +1,4 @@
 /target/
 
 Cargo.lock
+/farf/

--- a/programs/bpf/rust/128bit_dep/.gitignore
+++ b/programs/bpf/rust/128bit_dep/.gitignore
@@ -1,3 +1,4 @@
 /target/
 
 Cargo.lock
+/farf/

--- a/programs/bpf/rust/alloc/.gitignore
+++ b/programs/bpf/rust/alloc/.gitignore
@@ -1,3 +1,4 @@
 /target/
 
 Cargo.lock
+/farf/

--- a/programs/bpf/rust/dep_crate/.gitignore
+++ b/programs/bpf/rust/dep_crate/.gitignore
@@ -1,3 +1,4 @@
 /target/
 
 Cargo.lock
+/farf/

--- a/programs/bpf/rust/external_spend/.gitignore
+++ b/programs/bpf/rust/external_spend/.gitignore
@@ -1,3 +1,4 @@
 /target/
 
 Cargo.lock
+/farf/

--- a/programs/bpf/rust/iter/.gitignore
+++ b/programs/bpf/rust/iter/.gitignore
@@ -1,3 +1,4 @@
 /target/
 
 Cargo.lock
+/farf/

--- a/programs/bpf/rust/many_args/.gitignore
+++ b/programs/bpf/rust/many_args/.gitignore
@@ -1,3 +1,4 @@
 /target/
 
 Cargo.lock
+/farf/

--- a/programs/bpf/rust/many_args_dep/.gitignore
+++ b/programs/bpf/rust/many_args_dep/.gitignore
@@ -1,3 +1,4 @@
 /target/
 
 Cargo.lock
+/farf/

--- a/programs/bpf/rust/noop/.gitignore
+++ b/programs/bpf/rust/noop/.gitignore
@@ -1,3 +1,4 @@
 /target/
 
 Cargo.lock
+/farf/

--- a/programs/bpf/rust/panic/.gitignore
+++ b/programs/bpf/rust/panic/.gitignore
@@ -1,3 +1,4 @@
 /target/
 
 Cargo.lock
+/farf/

--- a/programs/bpf/rust/tick_height/.gitignore
+++ b/programs/bpf/rust/tick_height/.gitignore
@@ -1,3 +1,4 @@
 /target/
 
 Cargo.lock
+/farf/

--- a/programs/bpf_loader_api/.gitignore
+++ b/programs/bpf_loader_api/.gitignore
@@ -1,1 +1,2 @@
 /target/
+/farf/

--- a/programs/bpf_loader_program/.gitignore
+++ b/programs/bpf_loader_program/.gitignore
@@ -1,1 +1,2 @@
 /target/
+/farf/

--- a/programs/budget_api/.gitignore
+++ b/programs/budget_api/.gitignore
@@ -1,1 +1,2 @@
 /target/
+/farf/

--- a/programs/budget_program/.gitignore
+++ b/programs/budget_program/.gitignore
@@ -1,1 +1,2 @@
 /target/
+/farf/

--- a/programs/config_api/.gitignore
+++ b/programs/config_api/.gitignore
@@ -1,1 +1,2 @@
 /target/
+/farf/

--- a/programs/config_program/.gitignore
+++ b/programs/config_program/.gitignore
@@ -1,1 +1,2 @@
 /target/
+/farf/

--- a/programs/exchange_api/.gitignore
+++ b/programs/exchange_api/.gitignore
@@ -1,1 +1,2 @@
 /target/
+/farf/

--- a/programs/exchange_program/.gitignore
+++ b/programs/exchange_program/.gitignore
@@ -1,1 +1,2 @@
 /target/
+/farf/

--- a/programs/failure_program/.gitignore
+++ b/programs/failure_program/.gitignore
@@ -1,1 +1,2 @@
 /target/
+/farf/

--- a/programs/noop_program/.gitignore
+++ b/programs/noop_program/.gitignore
@@ -1,1 +1,2 @@
 /target/
+/farf/

--- a/programs/stake_api/.gitignore
+++ b/programs/stake_api/.gitignore
@@ -1,1 +1,2 @@
 /target/
+/farf/

--- a/programs/stake_program/.gitignore
+++ b/programs/stake_program/.gitignore
@@ -1,1 +1,2 @@
 /target/
+/farf/

--- a/programs/stake_tests/.gitignore
+++ b/programs/stake_tests/.gitignore
@@ -1,1 +1,2 @@
 /target/
+/farf/

--- a/programs/storage_api/.gitignore
+++ b/programs/storage_api/.gitignore
@@ -1,1 +1,2 @@
 /target/
+/farf/

--- a/programs/storage_program/.gitignore
+++ b/programs/storage_program/.gitignore
@@ -1,1 +1,2 @@
 /target/
+/farf/

--- a/programs/token_api/.gitignore
+++ b/programs/token_api/.gitignore
@@ -1,1 +1,2 @@
 /target/
+/farf/

--- a/programs/token_program/.gitignore
+++ b/programs/token_program/.gitignore
@@ -1,1 +1,2 @@
 /target/
+/farf/

--- a/programs/vote_api/.gitignore
+++ b/programs/vote_api/.gitignore
@@ -1,1 +1,2 @@
 /target/
+/farf/

--- a/programs/vote_program/.gitignore
+++ b/programs/vote_program/.gitignore
@@ -1,1 +1,2 @@
 /target/
+/farf/

--- a/replicator/.gitignore
+++ b/replicator/.gitignore
@@ -1,1 +1,2 @@
 /target/
+/farf/

--- a/runtime/.gitignore
+++ b/runtime/.gitignore
@@ -1,1 +1,2 @@
 /target/
+/farf/

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -77,7 +77,7 @@ impl Accounts {
     fn make_new_dir() -> String {
         static ACCOUNT_DIR: AtomicUsize = AtomicUsize::new(0);
         let dir = ACCOUNT_DIR.fetch_add(1, Ordering::Relaxed);
-        let out_dir = env::var("OUT_DIR").unwrap_or_else(|_| "target".to_string());
+        let out_dir = env::var("OUT_DIR").unwrap_or_else(|_| "farf".to_string());
         let keypair = Keypair::new();
         format!(
             "{}/{}/{}/{}",

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -750,7 +750,7 @@ mod tests {
 
     fn get_tmp_accounts_path(paths: &str) -> TempPaths {
         let vpaths = get_paths_vec(paths);
-        let out_dir = std::env::var("OUT_DIR").unwrap_or_else(|_| "target".to_string());
+        let out_dir = std::env::var("OUT_DIR").unwrap_or_else(|_| "farf".to_string());
         let vpaths: Vec<_> = vpaths
             .iter()
             .map(|path| format!("{}/{}", out_dir, path))

--- a/runtime/src/append_vec.rs
+++ b/runtime/src/append_vec.rs
@@ -298,7 +298,7 @@ pub mod test_utils {
     }
 
     pub fn get_append_vec_dir() -> String {
-        std::env::var("OUT_DIR").unwrap_or_else(|_| "target/append_vec_tests".to_string())
+        std::env::var("OUT_DIR").unwrap_or_else(|_| "farf/append_vec_tests".to_string())
     }
 
     pub fn get_append_vec_path(path: &str) -> TempFile {

--- a/sdk/.gitignore
+++ b/sdk/.gitignore
@@ -1,1 +1,2 @@
 /target/
+/farf/

--- a/sdk/bpf/rust/rust-no-std/.gitignore
+++ b/sdk/bpf/rust/rust-no-std/.gitignore
@@ -1,3 +1,4 @@
 /target/
 
 Cargo.lock
+/farf/

--- a/sdk/bpf/rust/rust-test/.gitignore
+++ b/sdk/bpf/rust/rust-test/.gitignore
@@ -1,3 +1,4 @@
 /target/
 
 Cargo.lock
+/farf/

--- a/sdk/bpf/rust/rust-utils/.gitignore
+++ b/sdk/bpf/rust/rust-utils/.gitignore
@@ -1,3 +1,4 @@
 /target/
 
 Cargo.lock
+/farf/

--- a/sdk/src/genesis_block.rs
+++ b/sdk/src/genesis_block.rs
@@ -194,7 +194,7 @@ mod tests {
     use crate::signature::{Keypair, KeypairUtil};
 
     fn make_tmp_path(name: &str) -> String {
-        let out_dir = std::env::var("OUT_DIR").unwrap_or_else(|_| "target".to_string());
+        let out_dir = std::env::var("OUT_DIR").unwrap_or_else(|_| "farf".to_string());
         let keypair = Keypair::new();
 
         let path = format!("{}/tmp/{}-{}", out_dir, name, keypair.pubkey());

--- a/sdk/src/signature.rs
+++ b/sdk/src/signature.rs
@@ -147,7 +147,7 @@ mod tests {
 
     fn tmp_file_path(name: &str) -> String {
         use std::env;
-        let out_dir = env::var("OUT_DIR").unwrap_or_else(|_| "target".to_string());
+        let out_dir = env::var("OUT_DIR").unwrap_or_else(|_| "farf".to_string());
         let keypair = Keypair::new();
 
         format!("{}/tmp/{}-{}", out_dir, name, keypair.pubkey()).to_string()

--- a/upload-perf/.gitignore
+++ b/upload-perf/.gitignore
@@ -1,1 +1,2 @@
 /target/
+/farf/

--- a/validator-info/.gitignore
+++ b/validator-info/.gitignore
@@ -1,1 +1,2 @@
 /target/
+/farf/

--- a/validator/.gitignore
+++ b/validator/.gitignore
@@ -1,1 +1,2 @@
 /target/
+/farf/

--- a/vote-signer/.gitignore
+++ b/vote-signer/.gitignore
@@ -1,1 +1,2 @@
 /target/
+/farf/

--- a/wallet/.gitignore
+++ b/wallet/.gitignore
@@ -1,1 +1,2 @@
 /target/
+/farf/

--- a/wallet/src/wallet.rs
+++ b/wallet/src/wallet.rs
@@ -1883,7 +1883,7 @@ mod tests {
         );
 
         fn make_tmp_path(name: &str) -> String {
-            let out_dir = std::env::var("OUT_DIR").unwrap_or_else(|_| "target".to_string());
+            let out_dir = std::env::var("OUT_DIR").unwrap_or_else(|_| "farf".to_string());
             let keypair = Keypair::new();
 
             let path = format!("{}/tmp/{}-{}", out_dir, name, keypair.pubkey());


### PR DESCRIPTION
#### Problem
 target is useful to keep around in CI, farf is not, we want to blow away
  tmp output files easily

 #### Summary of Changes
 move tmpdir stuff from target to farf
 .gitignore farf

Fixes #