### PR TITLE
Keybase pubkey file instructions and verification for validators

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2939,6 +2939,7 @@ dependencies = [
  "bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "dirs 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "reqwest 0.9.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.94 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.94 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/book/src/testnet-participation.md
+++ b/book/src/testnet-participation.md
@@ -255,3 +255,20 @@ Available fields for VALIDATOR_INFO_ARGS:
 * Website
 * Keybase ID
 * Details
+
+##### Keybase
+
+Including a Keybase ID allows client applications (like the Solana Network
+Explorer) to automatically pull in your validator public profile, including
+cryptographic proofs, brand identity, etc. To connect your validator pubkey with
+Keybase:
+
+1. Join https://keybase.io/ and complete the profile for your validator
+2. Add your validator **identity pubkey** to Keybase:
+  * Create an empty file on your local computer called `solana_pubkey_<PUBKEY>`
+  * In Keybase, navigate to the Files section, and upload your pubkey file to
+  your public folder: `/keybase/public/<KEYBASE_ID>`
+  * To check your pubkey, ensure you can successfully browse to
+  `https://keybase.pub/<KEYBASE_ID>/solana_pubkey_<PUBKEY>`
+3. Add or update your `solana-validator-info` with your Keybase ID. The CLI will
+verify the `solana_pubkey_<PUBKEY>` file

--- a/validator-info/Cargo.toml
+++ b/validator-info/Cargo.toml
@@ -16,6 +16,7 @@ cuda = []
 bincode = "1.1.4"
 clap = "2.33"
 dirs = "2.0.1"
+reqwest = "0.9.18"
 serde = "1.0.94"
 serde_derive = "1.0.94"
 serde_json = "1.0.40"


### PR DESCRIPTION
#### Problem
We're planning on using keybase as the source of validator's public profile, esp for Tour de SOL, but haven't established a method validators should use to add their pubkey. 

#### Summary of Changes
- Add instructions for adding a pubkey file to Keybase to connect to a validator identity; pubkey files should be empty, stored in a keybase user's public folder, with the filename: `solana_pubkey_<PUBKEY>`
- Add Keybase verification to `solana-validator-info`; this is currently a very simple HEAD check of a prescribed file location. (This could be expanded to allow validators to store their pubkey file in whatever Keybase file location.)

Toward #5011 
