### PR TITLE
Update expected keybase-pubkey location

### DIFF
--- a/book/src/testnet-participation.md
+++ b/book/src/testnet-participation.md
@@ -265,10 +265,10 @@ Keybase:
 
 1. Join https://keybase.io/ and complete the profile for your validator
 2. Add your validator **identity pubkey** to Keybase:
-  * Create an empty file on your local computer called `solana_pubkey_<PUBKEY>`
+  * Create an empty file on your local computer called `validator-<PUBKEY>`
   * In Keybase, navigate to the Files section, and upload your pubkey file to
-  your public folder: `/keybase/public/<KEYBASE_ID>`
+  a `solana` subdirectory in your public folder: `/keybase/public/<KEYBASE_ID>/solana`
   * To check your pubkey, ensure you can successfully browse to
-  `https://keybase.pub/<KEYBASE_ID>/solana_pubkey_<PUBKEY>`
+  `https://keybase.pub/<KEYBASE_ID>/solana/validator-<PUBKEY>`
 3. Add or update your `solana-validator-info` with your Keybase ID. The CLI will
-verify the `solana_pubkey_<PUBKEY>` file
+verify the `validator-<PUBKEY>` file

--- a/validator-info/src/validator_info.rs
+++ b/validator-info/src/validator_info.rs
@@ -106,7 +106,7 @@ fn verify_keybase(
 ) -> Result<(), Box<dyn error::Error>> {
     if let Some(keybase_id) = keybase_id.as_str() {
         let url = format!(
-            "https://keybase.pub/{}/solana_pubkey_{:?}",
+            "https://keybase.pub/{}/solana/validator-{:?}",
             keybase_id, validator_pubkey
         );
         let client = Client::new();


### PR DESCRIPTION
#### Problem
We need a programmatic way to derive the TdS validator pubkeys from their keybase ids. That would be easier if validators stashed their pubkeys in a more-specific known location

#### Summary of Changes
Expect validator pubkey to be in `/<keybase_id>/public/solana` and called `validator-<PUBKEY>`

Toward #5011 
