### PR TITLE
Boot remote native loads, take 2

### DIFF
--- a/programs/failure_program/tests/failure.rs
+++ b/programs/failure_program/tests/failure.rs
@@ -1,24 +1,23 @@
 use solana_runtime::bank::Bank;
 use solana_runtime::bank_client::BankClient;
-use solana_runtime::loader_utils::{create_invoke_instruction, load_program};
+use solana_runtime::loader_utils::create_invoke_instruction;
 use solana_sdk::client::SyncClient;
 use solana_sdk::genesis_block::create_genesis_block;
 use solana_sdk::instruction::InstructionError;
-use solana_sdk::native_loader;
+use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::KeypairUtil;
 use solana_sdk::transaction::TransactionError;
 
 #[test]
 fn test_program_native_failure() {
     let (genesis_block, alice_keypair) = create_genesis_block(50);
+    let program_id = Pubkey::new_rand();
     let bank = Bank::new(&genesis_block);
-    let bank_client = BankClient::new(bank);
-
-    let program = "solana_failure_program".as_bytes().to_vec();
-    let program_id = load_program(&bank_client, &alice_keypair, &native_loader::id(), program);
+    bank.register_native_instruction_processor("solana_failure_program", &program_id);
 
     // Call user program
     let instruction = create_invoke_instruction(alice_keypair.pubkey(), program_id, &1u8);
+    let bank_client = BankClient::new(bank);
     assert_eq!(
         bank_client
             .send_instruction(&alice_keypair, instruction)

--- a/runtime/tests/noop.rs
+++ b/runtime/tests/noop.rs
@@ -1,9 +1,9 @@
 use solana_runtime::bank::Bank;
 use solana_runtime::bank_client::BankClient;
-use solana_runtime::loader_utils::{create_invoke_instruction, load_program};
+use solana_runtime::loader_utils::create_invoke_instruction;
 use solana_sdk::client::SyncClient;
 use solana_sdk::genesis_block::create_genesis_block;
-use solana_sdk::native_loader;
+use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::KeypairUtil;
 
 #[test]
@@ -11,14 +11,13 @@ fn test_program_native_noop() {
     solana_logger::setup();
 
     let (genesis_block, alice_keypair) = create_genesis_block(50);
+    let program_id = Pubkey::new_rand();
     let bank = Bank::new(&genesis_block);
-    let bank_client = BankClient::new(bank);
-
-    let program = "solana_noop_program".as_bytes().to_vec();
-    let program_id = load_program(&bank_client, &alice_keypair, &native_loader::id(), program);
+    bank.register_native_instruction_processor("solana_noop_program", &program_id);
 
     // Call user program
     let instruction = create_invoke_instruction(alice_keypair.pubkey(), program_id, &1u8);
+    let bank_client = BankClient::new(bank);
     bank_client
         .send_instruction(&alice_keypair, instruction)
         .unwrap();


### PR DESCRIPTION
#### Problem

The native loader supports loading the name of native programs using transactions, which might be able to point to arbitrary file paths.

#### Summary of Changes

Drop support for that. Either register native programs with the Bank or use the BPF loader.