### PR TITLE
Add LoaderInstruction::InvokeMain

### DIFF
--- a/programs/bpf_loader_api/src/lib.rs
+++ b/programs/bpf_loader_api/src/lib.rs
@@ -85,7 +85,7 @@ fn deserialize_parameters(keyed_accounts: &mut [KeyedAccount], buffer: &[u8]) {
 pub fn process_instruction(
     program_id: &Pubkey,
     keyed_accounts: &mut [KeyedAccount],
-    tx_data: &[u8],
+    ix_data: &[u8],
 ) -> Result<(), InstructionError> {
     solana_logger::setup();
 
@@ -100,7 +100,7 @@ pub fn process_instruction(
                 return Err(InstructionError::GenericError);
             }
         };
-        let mut v = serialize_parameters(program_id, params, &tx_data);
+        let mut v = serialize_parameters(program_id, params, &ix_data);
 
         match vm.execute_program(v.as_mut_slice(), &[], &[heap_region]) {
             Ok(status) => {
@@ -119,7 +119,7 @@ pub fn process_instruction(
             "BPF program executed {} instructions",
             vm.get_last_instruction_count()
         );
-    } else if let Ok(instruction) = bincode::deserialize(tx_data) {
+    } else if let Ok(instruction) = bincode::deserialize(ix_data) {
         if keyed_accounts[0].signer_key().is_none() {
             warn!("key[0] did not sign the transaction");
             return Err(InstructionError::GenericError);
@@ -148,7 +148,7 @@ pub fn process_instruction(
             }
         }
     } else {
-        warn!("Invalid program transaction: {:?}", tx_data);
+        warn!("Invalid instruction data: {:?}", ix_data);
         return Err(InstructionError::GenericError);
     }
     Ok(())

--- a/programs/bpf_loader_api/src/lib.rs
+++ b/programs/bpf_loader_api/src/lib.rs
@@ -89,43 +89,13 @@ pub fn process_instruction(
 ) -> Result<(), InstructionError> {
     solana_logger::setup();
 
-    if keyed_accounts[0].account.executable {
-        let (progs, params) = keyed_accounts.split_at_mut(1);
-        let prog = &progs[0].account.data;
-        info!("Call BPF program");
-        let (mut vm, heap_region) = match create_vm(prog) {
-            Ok(info) => info,
-            Err(e) => {
-                warn!("Failed to create BPF VM: {}", e);
-                return Err(InstructionError::GenericError);
-            }
-        };
-        let mut v = serialize_parameters(program_id, params, &ix_data);
-
-        match vm.execute_program(v.as_mut_slice(), &[], &[heap_region]) {
-            Ok(status) => {
-                if 0 == status {
-                    warn!("BPF program failed: {}", status);
-                    return Err(InstructionError::GenericError);
-                }
-            }
-            Err(e) => {
-                warn!("BPF VM failed to run program: {}", e);
-                return Err(InstructionError::GenericError);
-            }
-        }
-        deserialize_parameters(params, &v);
-        info!(
-            "BPF program executed {} instructions",
-            vm.get_last_instruction_count()
-        );
-    } else if let Ok(instruction) = bincode::deserialize(ix_data) {
-        if keyed_accounts[0].signer_key().is_none() {
-            warn!("key[0] did not sign the transaction");
-            return Err(InstructionError::GenericError);
-        }
+    if let Ok(instruction) = bincode::deserialize(ix_data) {
         match instruction {
             LoaderInstruction::Write { offset, bytes } => {
+                if keyed_accounts[0].signer_key().is_none() {
+                    warn!("key[0] did not sign the transaction");
+                    return Err(InstructionError::GenericError);
+                }
                 let offset = offset as usize;
                 let len = bytes.len();
                 debug!("Write: offset={} length={}", offset, len);
@@ -140,10 +110,49 @@ pub fn process_instruction(
                 keyed_accounts[0].account.data[offset..offset + len].copy_from_slice(&bytes);
             }
             LoaderInstruction::Finalize => {
+                if keyed_accounts[0].signer_key().is_none() {
+                    warn!("key[0] did not sign the transaction");
+                    return Err(InstructionError::GenericError);
+                }
                 keyed_accounts[0].account.executable = true;
                 info!(
                     "Finalize: account {:?}",
                     keyed_accounts[0].signer_key().unwrap()
+                );
+            }
+            LoaderInstruction::InvokeMain { data } => {
+                if !keyed_accounts[0].account.executable {
+                    warn!("BPF account not executable");
+                    return Err(InstructionError::GenericError);
+                }
+                let (progs, params) = keyed_accounts.split_at_mut(1);
+                let prog = &progs[0].account.data;
+                info!("Call BPF program");
+                let (mut vm, heap_region) = match create_vm(prog) {
+                    Ok(info) => info,
+                    Err(e) => {
+                        warn!("Failed to create BPF VM: {}", e);
+                        return Err(InstructionError::GenericError);
+                    }
+                };
+                let mut v = serialize_parameters(program_id, params, &data);
+
+                match vm.execute_program(v.as_mut_slice(), &[], &[heap_region]) {
+                    Ok(status) => {
+                        if 0 == status {
+                            warn!("BPF program failed: {}", status);
+                            return Err(InstructionError::GenericError);
+                        }
+                    }
+                    Err(e) => {
+                        warn!("BPF VM failed to run program: {}", e);
+                        return Err(InstructionError::GenericError);
+                    }
+                }
+                deserialize_parameters(params, &v);
+                info!(
+                    "BPF program executed {} instructions",
+                    vm.get_last_instruction_count()
                 );
             }
         }

--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -12,6 +12,7 @@ use solana_sdk::pubkey::Pubkey;
 use solana_sdk::system_program;
 use solana_sdk::transaction::TransactionError;
 use std::collections::HashMap;
+use std::io::Write;
 use std::sync::RwLock;
 
 #[cfg(unix)]
@@ -93,6 +94,27 @@ fn verify_instruction(
     Ok(())
 }
 
+/// Return instruction data to pass to process_instruction().
+/// When a loader is detected, the instruction data is wrapped with a LoaderInstruction
+/// to signal to the loader that the instruction data should be used as arguments when
+/// invoking a "main()" function.
+fn get_loader_instruction_data<'a>(
+    loaders: &[(Pubkey, Account)],
+    ix_data: &'a [u8],
+    loader_ix_data: &'a mut Vec<u8>,
+) -> &'a [u8] {
+    if loaders.len() > 1 {
+        let ix = LoaderInstruction::InvokeMain {
+            data: ix_data.to_vec(),
+        };
+        let ix_data = bincode::serialize(&ix).unwrap();
+        loader_ix_data.write(&ix_data).unwrap();
+        loader_ix_data
+    } else {
+        ix_data
+    }
+}
+
 pub type ProcessInstruction =
     fn(&Pubkey, &mut [KeyedAccount], &[u8]) -> Result<(), InstructionError>;
 
@@ -141,7 +163,13 @@ impl MessageProcessor {
         program_accounts: &mut [&mut Account],
     ) -> Result<(), InstructionError> {
         let program_id = instruction.program_id(&message.account_keys);
-        let is_loader = executable_accounts.len() > 1;
+
+        let mut loader_ix_data = vec![];
+        let ix_data = get_loader_instruction_data(
+            executable_accounts,
+            &instruction.data,
+            &mut loader_ix_data,
+        );
 
         let mut keyed_accounts = create_keyed_credit_only_accounts(executable_accounts);
         let mut keyed_accounts2: Vec<_> = instruction
@@ -170,11 +198,7 @@ impl MessageProcessor {
 
         for (id, process_instruction) in &self.instruction_processors {
             if id == program_id {
-                return process_instruction(
-                    &program_id,
-                    &mut keyed_accounts[1..],
-                    &instruction.data,
-                );
+                return process_instruction(&program_id, &mut keyed_accounts[1..], &ix_data);
             }
         }
 
@@ -183,25 +207,10 @@ impl MessageProcessor {
             "loader not executable"
         );
 
-        // If invoking indirectly via a loader, wrap the instruction data with an
-        // instruction that tells the loader to invoke "main()".
-        if is_loader {
-            let ix = LoaderInstruction::InvokeMain {
-                data: instruction.data.clone(),
-            };
-            let ix_data = bincode::serialize(&ix).unwrap();
-            return native_loader::invoke_entrypoint(
-                &program_id,
-                &mut keyed_accounts,
-                &ix_data,
-                &self.symbol_cache,
-            );
-        }
-
         native_loader::invoke_entrypoint(
             &program_id,
             &mut keyed_accounts,
-            &instruction.data,
+            ix_data,
             &self.symbol_cache,
         )
     }
@@ -544,5 +553,38 @@ mod tests {
                 InstructionError::UnbalancedInstruction
             ))
         );
+    }
+
+    #[test]
+    fn test_get_loader_instruction_data() {
+        // First ensure the ix_data is unaffected if not invoking via a loader.
+        let ix_data = [1];
+        let mut loader_ix_data = vec![];
+
+        let native_pubkey = Pubkey::new_rand();
+        let native_loader = (native_pubkey, Account::new(0, 0, &native_pubkey));
+        assert_eq!(
+            get_loader_instruction_data(&[native_loader.clone()], &ix_data, &mut loader_ix_data),
+            &ix_data
+        );
+
+        // Now ensure the ix_data is wrapped when there's a loader present.
+        let acme_pubkey = Pubkey::new_rand();
+        let acme_loader = (acme_pubkey, Account::new(0, 0, &native_pubkey));
+        let expected_ix = LoaderInstruction::InvokeMain {
+            data: ix_data.to_vec(),
+        };
+        let expected_ix_data = bincode::serialize(&expected_ix).unwrap();
+        assert_eq!(
+            get_loader_instruction_data(
+                &[native_loader.clone(), acme_loader.clone()],
+                &ix_data,
+                &mut loader_ix_data
+            ),
+            &expected_ix_data[..]
+        );
+
+        // Note there was an allocation in the input vector.
+        assert_eq!(loader_ix_data, expected_ix_data);
     }
 }

--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -176,7 +176,11 @@ impl MessageProcessor {
             }
         }
 
-        native_loader::entrypoint(
+        assert!(
+            keyed_accounts[0].account.executable,
+            "loader not executable"
+        );
+        native_loader::invoke_entrypoint(
             &program_id,
             &mut keyed_accounts,
             &instruction.data,

--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -108,7 +108,7 @@ fn get_loader_instruction_data<'a>(
             data: ix_data.to_vec(),
         };
         let ix_data = bincode::serialize(&ix).unwrap();
-        loader_ix_data.write(&ix_data).unwrap();
+        loader_ix_data.write_all(&ix_data).unwrap();
         loader_ix_data
     } else {
         ix_data

--- a/sdk/src/loader_instruction.rs
+++ b/sdk/src/loader_instruction.rs
@@ -18,6 +18,11 @@ pub enum LoaderInstruction {
     ///
     /// The transaction must be signed by key[0]
     Finalize,
+
+    /// Invoke the "main" entrypoint with the given data.
+    ///
+    /// * key[0] - an executable account
+    InvokeMain { data: Vec<u8> },
 }
 
 pub fn write(


### PR DESCRIPTION
#### Problem

A loader assumes its being invoked to run a program's entrypoint if it is called with an executable account. If the account isn't executable, it then parses the instruction data to see why it was actually invoked. The inflexible interface means we can't extend a loader to do other useful things with the underlying VM such as telling it to call some non-main function or to preprocess the instruction data (i.e. to compile a Move transaction script and invoke **its** main()).

#### Summary of Changes

Wrap instruction data with the new `LoaderInstruction::InvokeMain` if that's what we want the loader to do.  The new instruction can be used implicitly, as it is today, or explicitly by sending the instruction directly to the loader. While this variation will likely always be used implicitly, future variations such as `LoaderInstruction::InvokeFunction` or `LoaderInstruction::ExecuteScript` would be used directly.

TODO:
- [x] Add a test to ensure the explicit usage doesn't double-wrap the instruction data

tag: @jackcmay 
