### PR TITLE
Improve validator-info CLI

### DIFF
--- a/book/src/testnet-participation.md
+++ b/book/src/testnet-participation.md
@@ -248,10 +248,9 @@ to other users.
 
 Run the solana-validator-info CLI to populate a validator-info account:
 ```bash
-$ solana-validator-info publish -k ~/validator-keypair.json <VALIDATOR_INFO_ARGS>
+$ solana-validator-info publish ~/validator-keypair.json <VALIDATOR_NAME> <VALIDATOR_INFO_ARGS>
 ```
-Available fields for VALIDATOR_INFO_ARGS:
-* Name (required)
+Optional fields for VALIDATOR_INFO_ARGS:
 * Website
 * Keybase ID
 * Details

--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -293,7 +293,6 @@ impl RpcClient {
                     format!("GetProgramAccounts parse failure: {:?}", err),
                 )
             })?;
-        println!("{:?}", accounts);
 
         let mut pubkey_accounts: Vec<(Pubkey, Account)> = Vec::new();
         for (string, account) in accounts.into_iter() {

--- a/validator-info/src/validator_info.rs
+++ b/validator-info/src/validator_info.rs
@@ -184,8 +184,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                 )
                 .arg(
                     Arg::with_name("validator_keypair")
-                        .short("v")
-                        .long("validator-keypair")
+                        .index(1)
                         .value_name("PATH")
                         .takes_value(true)
                         .required(true)
@@ -202,8 +201,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                 )
                 .arg(
                     Arg::with_name("name")
-                        .short("n")
-                        .long("name")
+                        .index(2)
                         .value_name("STRING")
                         .takes_value(true)
                         .required(true)

--- a/validator-info/src/validator_info.rs
+++ b/validator-info/src/validator_info.rs
@@ -261,7 +261,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                         .value_name("PUBKEY")
                         .takes_value(true)
                         .validator(is_pubkey)
-                        .help("The pubkey of the Validator info account"),
+                        .help("The pubkey of the Validator info account; without this argument, returns all"),
                 ),
         )
         .get_matches();


### PR DESCRIPTION
#### Problem
The solana-validator-info CLI's `get` subcommand is a bit fragile and counterintuitive.

#### Summary of Changes
- Fix empty result handling/parsing of non-validator-info Config accounts (resolves index out-of-bounds panic)
- `get` - Shift from named arguments to a single index specifying info-account pubkey. Default returns all validator-info accounts.

Fixes #5120
