### PR TITLE
Check for valid pid before kill in node stop script

### DIFF
--- a/net/net.sh
+++ b/net/net.sh
@@ -659,7 +659,9 @@ stopNode() {
       ! tmux list-sessions || tmux kill-session
       for pid in solana/{net-stats,oom-monitor}.pid; do
         pgid=\$(ps opgid= \$(cat \$pid) | tr -d '[:space:]')
-        sudo kill -- -\$pgid
+        if [[ -n \$pgid ]]; then
+          sudo kill -- -\$pgid
+        fi
       done
       for pattern in node solana- remote-; do
         pkill -9 \$pattern


### PR DESCRIPTION
#### Problem

pid to kill can be empty string, so kill will error in that case.

#### Summary of Changes

guard kill with valid pid.

Fixes #
