### PR TITLE
Add ability to prune ledger

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2668,6 +2668,7 @@ name = "solana-ledger-tool"
 version = "0.17.0"
 dependencies = [
  "assert_cmd 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.94 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.94 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/core/src/blocktree.rs
+++ b/core/src/blocktree.rs
@@ -193,7 +193,7 @@ impl Blocktree {
         false
     }
 
-    // silently deletes all blocktree column families starting a the given slot
+    // silently deletes all blocktree column families starting at the given slot
     fn delete_all_columns(&self, starting_slot: u64) {
         match self.meta_cf.force_delete_all(Some(starting_slot)) {
             Ok(_) => (),
@@ -1005,7 +1005,7 @@ impl Blocktree {
             target_slot,
             &bincode::serialize(&meta).expect("couldn't get meta bytes"),
         )
-        .expect("unable to update meta for target  slot");
+        .expect("unable to update meta for target slot");
 
         self.delete_all_columns(target_slot + 1);
 
@@ -1014,15 +1014,15 @@ impl Blocktree {
             .slot_meta_iterator(0)
             .expect("unable to iterate over meta")
         {
+            if slot > target_slot {
+                break;
+            }
             meta.next_slots.retain(|slot| *slot <= target_slot);
             self.put_meta_bytes(
                 slot,
                 &bincode::serialize(&meta).expect("couldn't update meta"),
             )
             .expect("couldn't update meta");
-            if slot > target_slot {
-                break;
-            }
         }
     }
 }

--- a/core/src/blocktree.rs
+++ b/core/src/blocktree.rs
@@ -194,20 +194,21 @@ impl Blocktree {
     }
 
     // Helper that deletes columns that have `(Slot,Index)` as their Index
-    fn delete_indexed_column<C>(&self, column: &LedgerColumn<C>, slot: u64) -> Result<()>
+    fn delete_indexed_column<C>(&self, column: &LedgerColumn<C>, delete_slot: u64) -> Result<()>
     where
         C: Column<Index = (u64, u64)>,
     {
-        let mut iter = column.iter(Some((slot, 0)))?;
+        let iter = column.iter(Some((delete_slot, 0)))?;
         let mut max_index = 0;
-        while let Some(((slot, index), _)) = iter.next() {
-            if slot != slot {
+
+        for ((slot, index), _) in iter {
+            if slot != delete_slot {
                 break;
             }
             max_index = index;
         }
         for i in 0..max_index {
-            column.delete((slot, i))?;
+            column.delete((delete_slot, i))?;
         }
         Ok(())
     }

--- a/core/src/blocktree.rs
+++ b/core/src/blocktree.rs
@@ -207,7 +207,7 @@ impl Blocktree {
             }
             max_index = index;
         }
-        for i in 0..max_index {
+        for i in 0..=max_index {
             column.delete((delete_slot, i))?;
         }
         Ok(())
@@ -3436,6 +3436,13 @@ pub mod tests {
                 assert!(slot <= 5);
                 assert_eq!(meta.last_index, 5)
             });
+
+        let data_iter = blocktree.data_cf.iter(Some((0, 0))).unwrap();
+        for ((slot, _), _) in data_iter {
+            if slot > 5 {
+                assert!(false);
+            }
+        }
 
         drop(blocktree);
         Blocktree::destroy(&blocktree_path).expect("Expected successful database destruction");

--- a/core/src/blocktree/db.rs
+++ b/core/src/blocktree/db.rs
@@ -409,6 +409,16 @@ where
         Ok(iter.map(|(key, value)| (C::index(&key), value)))
     }
 
+    //TODO add a delete_until that goes the other way
+    pub fn force_delete_all(&self, start_from: Option<C::Index>) -> Result<()> {
+        let iter = self.iter(start_from)?;
+        iter.for_each(|(index, _)| match self.delete(index) {
+            Ok(_) => (),
+            Err(e) => error!("Error: {:?} while deleting {:?}", e, C::NAME),
+        });
+        Ok(())
+    }
+
     #[inline]
     pub fn handle(&self) -> B::ColumnFamily {
         self.backend.cf_handle(C::NAME).clone()

--- a/ledger-tool/Cargo.toml
+++ b/ledger-tool/Cargo.toml
@@ -9,6 +9,7 @@ license = "Apache-2.0"
 homepage = "https://solana.com/"
 
 [dependencies]
+bincode = "1.1.4"
 clap = "2.33.0"
 serde = "1.0.94"
 serde_derive = "1.0.94"

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -91,6 +91,7 @@ fn main() {
                 .long("slot-list")
                 .value_name("FILENAME")
                 .takes_value(true)
+                .required(true)
                 .help("The location of the YAML file with a list of rollback slot heights and hashes"),
         ))
         .subcommand(SubCommand::with_name("list-roots").about("Output upto last <num-roots> root hashes and their heights starting at the given block height").arg(
@@ -191,7 +192,7 @@ fn main() {
                     .last()
                     .expect("Failed to find a valid slot");
                 println!("Prune at slot {:?} hash {:?}", target_slot, target_hash);
-                // ToDo: Do the actual pruning of the database
+                blocktree.prune(*target_slot);
             }
         }
         ("list-roots", Some(args_matches)) => {


### PR DESCRIPTION
#### Problem

Ledger tool's `prune` does not actually prune the ledger

#### Summary of Changes

Add functions to prune the ledger. Add preliminary tests.

Remaining: 
- [x] Check that cluster reboots from a pruned ledger
- [x] Rollback procedure documentation (https://github.com/solana-labs/tour-de-sol/pull/3)

Fixes #5082
