### PR TITLE
clear-config.sh now works with a secondary disk

### DIFF
--- a/multinode-demo/clear-config.sh
+++ b/multinode-demo/clear-config.sh
@@ -11,7 +11,9 @@ set -e
 
 for i in "$SOLANA_RSYNC_CONFIG_DIR" "$SOLANA_CONFIG_DIR"; do
   echo "Cleaning $i"
+  rm -rvf "${i:?}/" # <-- $i might be a symlink, rm the other side of it first
   rm -rvf "$i"
   mkdir -p "$i"
 done
 
+setup_secondary_mount

--- a/multinode-demo/common.sh
+++ b/multinode-demo/common.sh
@@ -72,13 +72,16 @@ SOLANA_RSYNC_CONFIG_DIR=$SOLANA_ROOT/config
 # Configuration that remains local
 SOLANA_CONFIG_DIR=$SOLANA_ROOT/config-local
 
-# If there is a secondary disk, symlink the config-local dir there
 SECONDARY_DISK_MOUNT_POINT=/mnt/extra-disk
-if [[ -d $SECONDARY_DISK_MOUNT_POINT ]]; then
-  mkdir -p $SECONDARY_DISK_MOUNT_POINT/config-local
-  mkdir -p "$SOLANA_ROOT"
-  ln -s $SECONDARY_DISK_MOUNT_POINT/config-local "$SOLANA_ROOT"
-fi
+setup_secondary_mount() {
+  # If there is a secondary disk, symlink the config-local dir there
+  if [[ -d $SECONDARY_DISK_MOUNT_POINT ]]; then
+    mkdir -p $SECONDARY_DISK_MOUNT_POINT/config-local
+    rm -rf "$SOLANA_CONFIG_DIR"
+    ln -sfT $SECONDARY_DISK_MOUNT_POINT/config-local "$SOLANA_CONFIG_DIR"
+  fi
+}
+setup_secondary_mount
 
 default_arg() {
   declare name=$1


### PR DESCRIPTION
#### Problem
`./multinode-demo/clear-config.sh` kills the secondary disk symlink

#### Summary of Changes
Fix it