### PR TITLE
no more OUT_DIR

### DIFF
--- a/core/src/bank_forks.rs
+++ b/core/src/bank_forks.rs
@@ -477,7 +477,7 @@ mod tests {
     }
 
     fn get_tmp_snapshots_path() -> TempPaths {
-        let out_dir = env::var("OUT_DIR").unwrap_or_else(|_| "farf".to_string());
+        let out_dir = env::var("FARF_DIR").unwrap_or_else(|_| "farf".to_string());
         let path = format!("{}/snapshots", out_dir);
         TempPaths {
             paths: path.to_string(),
@@ -486,7 +486,7 @@ mod tests {
 
     fn get_tmp_bank_accounts_path(paths: &str) -> TempPaths {
         let vpaths = get_paths_vec(paths);
-        let out_dir = env::var("OUT_DIR").unwrap_or_else(|_| "farf".to_string());
+        let out_dir = env::var("FARF_DIR").unwrap_or_else(|_| "farf".to_string());
         let vpaths: Vec<_> = vpaths
             .iter()
             .map(|path| format!("{}/{}", out_dir, path))

--- a/core/src/blocktree.rs
+++ b/core/src/blocktree.rs
@@ -1820,7 +1820,7 @@ macro_rules! get_tmp_ledger_path {
 
 pub fn get_tmp_ledger_path(name: &str) -> String {
     use std::env;
-    let out_dir = env::var("OUT_DIR").unwrap_or_else(|_| "farf".to_string());
+    let out_dir = env::var("FARF_DIR").unwrap_or_else(|_| "farf".to_string());
     let keypair = Keypair::new();
 
     let path = format!("{}/ledger/{}-{}", out_dir, name, keypair.pubkey());

--- a/core/src/replicator.rs
+++ b/core/src/replicator.rs
@@ -910,7 +910,7 @@ mod tests {
 
     fn tmp_file_path(name: &str) -> PathBuf {
         use std::env;
-        let out_dir = env::var("OUT_DIR").unwrap_or_else(|_| "farf".to_string());
+        let out_dir = env::var("FARF_DIR").unwrap_or_else(|_| "farf".to_string());
         let keypair = Keypair::new();
 
         let mut path = PathBuf::new();

--- a/multinode-demo/fullnode.sh
+++ b/multinode-demo/fullnode.sh
@@ -112,15 +112,17 @@ setup_validator_accounts() {
     touch "$configured_flag"
   fi
 
-  $solana_wallet --keypair "$identity_keypair_path" --url "http://$entrypoint_ip:8899" \
-    show-vote-account "$vote_pubkey"
-  $solana_wallet --keypair "$identity_keypair_path" --url "http://$entrypoint_ip:8899" \
-    show-stake-account "$stake_pubkey"
-  $solana_wallet --keypair "$identity_keypair_path" --url "http://$entrypoint_ip:8899" \
-    show-storage-account "$storage_pubkey"
-
   echo "Identity account balance:"
-  $solana_wallet --keypair "$identity_keypair_path" --url "http://$entrypoint_ip:8899" balance
+  (
+    set -x
+    $solana_wallet --keypair "$identity_keypair_path" --url "http://$entrypoint_ip:8899" balance
+    $solana_wallet --keypair "$identity_keypair_path" --url "http://$entrypoint_ip:8899" \
+      show-vote-account "$vote_pubkey"
+    $solana_wallet --keypair "$identity_keypair_path" --url "http://$entrypoint_ip:8899" \
+      show-stake-account "$stake_pubkey"
+    $solana_wallet --keypair "$identity_keypair_path" --url "http://$entrypoint_ip:8899" \
+      show-storage-account "$storage_pubkey"
+  )
   return 0
 }
 
@@ -468,6 +470,7 @@ EOF
 ======================[ $node_type configuration ]======================
 identity pubkey: $identity_pubkey
 vote pubkey: $vote_pubkey
+stake pubkey: $stake_pubkey
 storage pubkey: $storage_pubkey
 ledger: $ledger_config_dir
 accounts: $accounts_config_dir

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -78,7 +78,7 @@ impl Accounts {
     fn make_new_dir() -> String {
         static ACCOUNT_DIR: AtomicUsize = AtomicUsize::new(0);
         let dir = ACCOUNT_DIR.fetch_add(1, Ordering::Relaxed);
-        let out_dir = env::var("OUT_DIR").unwrap_or_else(|_| "farf".to_string());
+        let out_dir = env::var("FARF_DIR").unwrap_or_else(|_| "farf".to_string());
         let keypair = Keypair::new();
         format!(
             "{}/{}/{}/{}",

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -789,7 +789,7 @@ mod tests {
 
     fn get_tmp_accounts_path(paths: &str) -> TempPaths {
         let vpaths = get_paths_vec(paths);
-        let out_dir = std::env::var("OUT_DIR").unwrap_or_else(|_| "farf".to_string());
+        let out_dir = std::env::var("FARF_DIR").unwrap_or_else(|_| "farf".to_string());
         let vpaths: Vec<_> = vpaths
             .iter()
             .map(|path| format!("{}/{}", out_dir, path))

--- a/runtime/src/append_vec.rs
+++ b/runtime/src/append_vec.rs
@@ -93,6 +93,10 @@ impl AppendVec {
             .create(create)
             .open(file)
             .map_err(|e| {
+                warn!("in current dir {:?}", std::env::current_dir());
+                for ancestor in file.ancestors() {
+                    warn!("{:?} is {:?}", ancestor, std::fs::metadata(ancestor));
+                }
                 panic!(
                     "Unable to {} data file {}, err {:?}",
                     if create { "create" } else { "open" },

--- a/runtime/src/append_vec.rs
+++ b/runtime/src/append_vec.rs
@@ -298,7 +298,7 @@ pub mod test_utils {
     }
 
     pub fn get_append_vec_dir() -> String {
-        std::env::var("OUT_DIR").unwrap_or_else(|_| "farf/append_vec_tests".to_string())
+        std::env::var("FARF_DIR").unwrap_or_else(|_| "farf/append_vec_tests".to_string())
     }
 
     pub fn get_append_vec_path(path: &str) -> TempFile {

--- a/sdk/src/genesis_block.rs
+++ b/sdk/src/genesis_block.rs
@@ -194,7 +194,7 @@ mod tests {
     use crate::signature::{Keypair, KeypairUtil};
 
     fn make_tmp_path(name: &str) -> String {
-        let out_dir = std::env::var("OUT_DIR").unwrap_or_else(|_| "farf".to_string());
+        let out_dir = std::env::var("FARF_DIR").unwrap_or_else(|_| "farf".to_string());
         let keypair = Keypair::new();
 
         let path = format!("{}/tmp/{}-{}", out_dir, name, keypair.pubkey());

--- a/sdk/src/signature.rs
+++ b/sdk/src/signature.rs
@@ -154,7 +154,7 @@ mod tests {
 
     fn tmp_file_path(name: &str) -> String {
         use std::env;
-        let out_dir = env::var("OUT_DIR").unwrap_or_else(|_| "farf".to_string());
+        let out_dir = env::var("FARF_DIR").unwrap_or_else(|_| "farf".to_string());
         let keypair = Keypair::new();
 
         format!("{}/tmp/{}-{}", out_dir, name, keypair.pubkey()).to_string()

--- a/wallet/src/wallet.rs
+++ b/wallet/src/wallet.rs
@@ -1901,7 +1901,7 @@ mod tests {
         );
 
         fn make_tmp_path(name: &str) -> String {
-            let out_dir = std::env::var("OUT_DIR").unwrap_or_else(|_| "farf".to_string());
+            let out_dir = std::env::var("FARF_DIR").unwrap_or_else(|_| "farf".to_string());
             let keypair = Keypair::new();
 
             let path = format!("{}/tmp/{}-{}", out_dir, name, keypair.pubkey());


### PR DESCRIPTION
#### Problem
 we don't want to put temp files in the build directory anymore, and OUT_DIR is actually set for some crates, resulting in FARFs ending up in target/, making it harder to clean up test file runs without also whacking usefully cached build results


 #### Summary of Changes
 OUT_DIR->FARF_DIR for tmp stuff

Fixes #