### PR TITLE
Plumb --skip-ledger-verify through net/

### DIFF
--- a/multinode-demo/fullnode.sh
+++ b/multinode-demo/fullnode.sh
@@ -220,6 +220,9 @@ while [[ -n $1 ]]; do
     elif [[ $1 = --no-voting ]]; then
       args+=("$1")
       shift
+    elif [[ $1 = --skip-ledger-verify ]]; then
+      args+=("$1")
+      shift
     elif [[ $1 = --no-sigverify ]]; then
       args+=("$1")
       shift

--- a/net/net.sh
+++ b/net/net.sh
@@ -62,6 +62,10 @@ Operate a configured testnet
                                       - A YML file with a list of account pubkeys and corresponding stakes for external nodes
    --no-snapshot
                                       - If set, disables booting validators from a snapshot
+   --skip-ledger-verify
+                                      - If set, validators will skip verifying
+                                        the ledger they already have saved to disk at
+                                        boot (results in a much faster boot)
  sanity/start/update-specific options:
    -F                   - Discard validator nodes that didn't bootup successfully
    -o noLedgerVerify    - Skip ledger verification
@@ -100,6 +104,7 @@ externalPrimordialAccountsFile=
 remoteExternalPrimordialAccountsFile=
 stakeNodesInGenesisBlock=
 maybeNoSnapshot=""
+maybeSkipLedgerVerify=""
 
 command=$1
 [[ -n $command ]] || usage
@@ -119,6 +124,9 @@ while [[ -n $1 ]]; do
       shift 2
     elif [[ $1 = --no-snapshot ]]; then
       maybeNoSnapshot="$1"
+      shift 1
+    elif [[ $1 = --skip-ledger-verify ]]; then
+      maybeSkipLedgerVerify="$1"
       shift 1
     elif [[ $1 = --deploy-update ]]; then
       updatePlatforms="$updatePlatforms $2"
@@ -359,7 +367,7 @@ startBootstrapLeader() {
          $numBenchTpsClients \"$benchTpsExtraArgs\" \
          $numBenchExchangeClients \"$benchExchangeExtraArgs\" \
          \"$genesisOptions\" \
-         $maybeNoSnapshot \
+         "$maybeNoSnapshot $maybeSkipLedgerVerify" \
       "
   ) >> "$logFile" 2>&1 || {
     cat "$logFile"
@@ -409,7 +417,7 @@ startNode() {
          \"$stakeNodesInGenesisBlock\" \
          $nodeIndex \
          \"$genesisOptions\" \
-         $maybeNoSnapshot \
+         \"$maybeNoSnapshot $maybeSkipLedgerVerify\" \
       "
   ) >> "$logFile" 2>&1 &
   declare pid=$!

--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -19,7 +19,7 @@ benchTpsExtraArgs="${12}"
 numBenchExchangeClients="${13}"
 benchExchangeExtraArgs="${14}"
 genesisOptions="${15}"
-noSnapshot="${16}"
+extraNodeArgs="${16}"
 set +x
 export RUST_LOG
 
@@ -171,7 +171,7 @@ local|tar)
       args+=(--no-airdrop)
     fi
     args+=(--init-complete-file "$initCompleteFile")
-    args+=("$noSnapshot")
+    args+=($extraNodeArgs)
     nohup ./multinode-demo/validator.sh --bootstrap-leader "${args[@]}" > fullnode.log 2>&1 &
     waitForNodeToInit
     ;;
@@ -249,7 +249,7 @@ local|tar)
     fi
 
     args+=(--init-complete-file "$initCompleteFile")
-    args+=("$noSnapshot")
+    args+=($extraNodeArgs)
     nohup ./multinode-demo/validator.sh "${args[@]}" > fullnode.log 2>&1 &
     waitForNodeToInit
     ;;
@@ -267,7 +267,7 @@ local|tar)
     if [[ $skipSetup != true ]]; then
       ./multinode-demo/clear-config.sh
     fi
-    args+=("$noSnapshot")
+    args+=($extraNodeArgs)
     nohup ./multinode-demo/replicator.sh "${args[@]}" > fullnode.log 2>&1 &
     sleep 1
     ;;


### PR DESCRIPTION
When performing a rollback, we'll want to restart the nodes affecting the rollback with `--skip-ledger-verify` so they can reach the rollback height as quickly as possible