### PR TITLE
runtime: Add bench for accounts::hash_internal_state

### DIFF
--- a/runtime/benches/accounts.rs
+++ b/runtime/benches/accounts.rs
@@ -2,6 +2,7 @@
 
 extern crate test;
 
+use solana_runtime::accounts::{Accounts, create_accounts};
 use solana_runtime::bank::*;
 use solana_sdk::account::Account;
 use solana_sdk::genesis_block::create_genesis_block;
@@ -56,3 +57,14 @@ fn test_accounts_squash(bencher: &mut Bencher) {
         banks[1].squash();
     });
 }
+
+#[bench]
+fn test_accounts_hash_internal_state(bencher: &mut Bencher) {
+    let accounts = Accounts::new(Some("bench_accounts_hash_internal".to_string()));
+    let mut pubkeys: Vec<Pubkey> = vec![];
+    create_accounts(&accounts, &mut pubkeys, 100);
+    bencher.iter(|| {
+        accounts.hash_internal_state(0);
+    });
+}
+

--- a/runtime/benches/accounts.rs
+++ b/runtime/benches/accounts.rs
@@ -62,7 +62,7 @@ fn test_accounts_squash(bencher: &mut Bencher) {
 fn test_accounts_hash_internal_state(bencher: &mut Bencher) {
     let accounts = Accounts::new(Some("bench_accounts_hash_internal".to_string()));
     let mut pubkeys: Vec<Pubkey> = vec![];
-    create_accounts(&accounts, &mut pubkeys, 100);
+    create_accounts(&accounts, &mut pubkeys, 60000);
     bencher.iter(|| {
         accounts.hash_internal_state(0);
     });

--- a/runtime/benches/accounts.rs
+++ b/runtime/benches/accounts.rs
@@ -2,7 +2,7 @@
 
 extern crate test;
 
-use solana_runtime::accounts::{create_accounts, Accounts};
+use solana_runtime::accounts::{create_test_accounts, Accounts};
 use solana_runtime::bank::*;
 use solana_sdk::account::Account;
 use solana_sdk::genesis_block::create_genesis_block;
@@ -62,7 +62,7 @@ fn test_accounts_squash(bencher: &mut Bencher) {
 fn test_accounts_hash_internal_state(bencher: &mut Bencher) {
     let accounts = Accounts::new(Some("bench_accounts_hash_internal".to_string()));
     let mut pubkeys: Vec<Pubkey> = vec![];
-    create_accounts(&accounts, &mut pubkeys, 60000);
+    create_test_accounts(&accounts, &mut pubkeys, 60000);
     bencher.iter(|| {
         accounts.hash_internal_state(0);
     });

--- a/runtime/benches/accounts.rs
+++ b/runtime/benches/accounts.rs
@@ -2,7 +2,7 @@
 
 extern crate test;
 
-use solana_runtime::accounts::{Accounts, create_accounts};
+use solana_runtime::accounts::{create_accounts, Accounts};
 use solana_runtime::bank::*;
 use solana_sdk::account::Account;
 use solana_sdk::genesis_block::create_genesis_block;
@@ -67,4 +67,3 @@ fn test_accounts_hash_internal_state(bencher: &mut Bencher) {
         accounts.hash_internal_state(0);
     });
 }
-

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -695,7 +695,7 @@ pub fn create_accounts(accounts: &Accounts, pubkeys: &mut Vec<Pubkey>, num: usiz
         let pubkey = Pubkey::new_rand();
         let account = Account::new((t + 1) as u64, 0, &Account::default().owner);
         accounts.store_slow(0, &pubkey, &account);
-        pubkeys.push(pubkey.clone());
+        pubkeys.push(pubkey);
     }
 }
 

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -690,6 +690,15 @@ impl Accounts {
     }
 }
 
+pub fn create_accounts(accounts: &Accounts, pubkeys: &mut Vec<Pubkey>, num: usize) {
+    for t in 0..num {
+        let pubkey = Pubkey::new_rand();
+        let account = Account::new((t + 1) as u64, 0, &Account::default().owner);
+        accounts.store_slow(0, &pubkey, &account);
+        pubkeys.push(pubkey.clone());
+    }
+}
+
 #[cfg(test)]
 mod tests {
     // TODO: all the bank tests are bank specific, issue: 2194
@@ -1192,15 +1201,6 @@ mod tests {
         assert_eq!(accounts.hash_internal_state(0), None);
         accounts.store_slow(0, &Pubkey::default(), &Account::new(1, 0, &sysvar::id()));
         assert_eq!(accounts.hash_internal_state(0), None);
-    }
-
-    fn create_accounts(accounts: &Accounts, pubkeys: &mut Vec<Pubkey>, num: usize) {
-        for t in 0..num {
-            let pubkey = Pubkey::new_rand();
-            let account = Account::new((t + 1) as u64, 0, &Account::default().owner);
-            accounts.store_slow(0, &pubkey, &account);
-            pubkeys.push(pubkey.clone());
-        }
     }
 
     fn check_accounts(accounts: &Accounts, pubkeys: &Vec<Pubkey>, num: usize) {

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -690,7 +690,7 @@ impl Accounts {
     }
 }
 
-pub fn create_accounts(accounts: &Accounts, pubkeys: &mut Vec<Pubkey>, num: usize) {
+pub fn create_test_accounts(accounts: &Accounts, pubkeys: &mut Vec<Pubkey>, num: usize) {
     for t in 0..num {
         let pubkey = Pubkey::new_rand();
         let account = Account::new((t + 1) as u64, 0, &Account::default().owner);
@@ -1219,7 +1219,7 @@ mod tests {
         let accounts = Accounts::new(Some("serialize_accounts".to_string()));
 
         let mut pubkeys: Vec<Pubkey> = vec![];
-        create_accounts(&accounts, &mut pubkeys, 100);
+        create_test_accounts(&accounts, &mut pubkeys, 100);
         check_accounts(&accounts, &pubkeys, 100);
         accounts.add_root(0);
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1,4 +1,4 @@
-mod accounts;
+pub mod accounts;
 pub mod accounts_db;
 pub mod accounts_index;
 pub mod append_vec;


### PR DESCRIPTION
#### Problem
There's no bench for hashing `Accounts` internal state

#### Summary of Changes
Write one