### PR TITLE
validator.sh: Ensure validator process is kill when stdout/stderr are redirected

### DIFF
--- a/multinode-demo/fullnode.sh
+++ b/multinode-demo/fullnode.sh
@@ -371,13 +371,14 @@ PS4="$(basename "$0"): "
 
 pid=
 kill_fullnode() {
+  # Note: do not echo anything from this function to ensure $pid is actually
+  # killed when stdout/stderr are redirected
+  set +ex
   if [[ -n $pid ]]; then
     declare _pid=$pid
     pid=
-    echo "killing pid $_pid"
     kill "$_pid" || true
     wait "$_pid" || true
-    echo "$_pid killed"
   fi
 }
 trap 'kill_fullnode' INT TERM ERR


### PR DESCRIPTION
The solana-validator process remained in the background after a ^C on the following command
```
$ validator.sh --identity ~/validator-keypair.json --no-airdrop --stake 17179444942 --rpc-port 8899  tds.solana.com 2>&1 | tee ~/tds
```
