### PR TITLE
Drop older slots in the ledger

### DIFF
--- a/core/src/blocktree.rs
+++ b/core/src/blocktree.rs
@@ -193,8 +193,10 @@ impl Blocktree {
         false
     }
 
-    // silently deletes all blocktree column families starting at the given slot until the `to` slot
-    fn delete_all_columns(&self, from_slot: u64, to_slot: Option<u64>) {
+    /// Silently deletes all blocktree column families starting at the given slot until the `to` slot
+    /// Use with care; does not check for integrity and does not update slot metas that
+    /// refer to deleted slots
+    pub fn delete_all_columns(&self, from_slot: u64, to_slot: Option<u64>) {
         let to_index = to_slot.map(|slot| (slot + 1, 0));
         match self.meta_cf.force_delete(Some(from_slot), to_slot) {
             Ok(_) => (),
@@ -3474,7 +3476,7 @@ pub mod tests {
     }
 
     #[test]
-    fn test_delete() {
+    fn test_delete_all_columns() {
         let blocktree_path = get_tmp_ledger_path!();
         let blocktree = Blocktree::open(&blocktree_path).unwrap();
         let (blobs, _) = make_many_slot_entries(0, 50, 5);

--- a/core/src/blocktree.rs
+++ b/core/src/blocktree.rs
@@ -3469,13 +3469,13 @@ pub mod tests {
     }
 
     #[test]
-    fn test_delete_all_columns() {
+    fn test_purge_slots() {
         let blocktree_path = get_tmp_ledger_path!();
         let blocktree = Blocktree::open(&blocktree_path).unwrap();
         let (blobs, _) = make_many_slot_entries(0, 50, 5);
         blocktree.write_blobs(blobs).unwrap();
 
-        blocktree.delete_all_columns(0, Some(5));
+        blocktree.purge_slots(0, Some(5));
 
         blocktree
             .slot_meta_iterator(0)
@@ -3484,7 +3484,7 @@ pub mod tests {
                 assert!(slot > 5);
             });
 
-        blocktree.delete_all_columns(0, None);
+        blocktree.purge_slots(0, None);
 
         blocktree.slot_meta_iterator(0).unwrap().for_each(|(_, _)| {
             assert!(false);

--- a/core/src/blocktree/db.rs
+++ b/core/src/blocktree/db.rs
@@ -420,9 +420,8 @@ where
                     break;
                 }
             }
-            match self.delete(index) {
-                Ok(_) => (),
-                Err(e) => error!("Error: {:?} while deleting {:?}", e, C::NAME),
+            if let Err(e) = self.delete(index) {
+                error!("Error: {:?} while deleting {:?}", e, C::NAME)
             }
         }
         Ok(())

--- a/core/src/blocktree/db.rs
+++ b/core/src/blocktree/db.rs
@@ -409,13 +409,22 @@ where
         Ok(iter.map(|(key, value)| (C::index(&key), value)))
     }
 
-    //TODO add a delete_until that goes the other way
-    pub fn force_delete_all(&self, start_from: Option<C::Index>) -> Result<()> {
-        let iter = self.iter(start_from)?;
-        iter.for_each(|(index, _)| match self.delete(index) {
-            Ok(_) => (),
-            Err(e) => error!("Error: {:?} while deleting {:?}", e, C::NAME),
-        });
+    pub fn force_delete(&self, from: Option<C::Index>, to: Option<C::Index>) -> Result<()>
+    where
+        C::Index: PartialOrd,
+    {
+        let iter = self.iter(from)?;
+        for (index, _) in iter {
+            if let Some(ref to) = to {
+                if &index > to {
+                    break;
+                }
+            }
+            match self.delete(index) {
+                Ok(_) => (),
+                Err(e) => error!("Error: {:?} while deleting {:?}", e, C::NAME),
+            }
+        }
         Ok(())
     }
 

--- a/core/src/ledger_cleanup_service.rs
+++ b/core/src/ledger_cleanup_service.rs
@@ -40,7 +40,7 @@ impl LedgerCleanupService {
                     match e {
                         Error::RecvTimeoutError(RecvTimeoutError::Disconnected) => break,
                         Error::RecvTimeoutError(RecvTimeoutError::Timeout) => (),
-                        _ => info!("Error from process_entries: {:?}", e),
+                        _ => info!("Error from cleanup_ledger: {:?}", e),
                     }
                 }
             })

--- a/core/src/ledger_cleanup_service.rs
+++ b/core/src/ledger_cleanup_service.rs
@@ -20,7 +20,6 @@ pub struct LedgerCleanupService {
 }
 
 impl LedgerCleanupService {
-    #[allow(clippy::new_ret_no_self)]
     pub fn new(
         slot_full_receiver: Receiver<(u64, Pubkey)>,
         blocktree: Arc<Blocktree>,
@@ -56,7 +55,7 @@ impl LedgerCleanupService {
         let (slot, _) = slot_full_receiver.recv_timeout(Duration::from_secs(1))?;
         if slot > max_ledger_slots {
             //cleanup
-            blocktree.delete_all_columns(0, Some(slot - max_ledger_slots));
+            blocktree.purge_slots(0, Some(slot - max_ledger_slots));
         }
         Ok(())
     }

--- a/core/src/ledger_cleanup_service.rs
+++ b/core/src/ledger_cleanup_service.rs
@@ -1,0 +1,101 @@
+//! The `ledger_cleanup_service` drops older ledger data to limit disk space usage
+
+use crate::blocktree::Blocktree;
+use crate::result::{Error, Result};
+use crate::service::Service;
+use solana_sdk::pubkey::Pubkey;
+use solana_sdk::timing::DEFAULT_SLOTS_PER_EPOCH;
+use std::string::ToString;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc::{Receiver, RecvTimeoutError};
+use std::sync::Arc;
+use std::thread;
+use std::thread::{Builder, JoinHandle};
+use std::time::Duration;
+
+pub const DEFAULT_MAX_LEDGER_SLOTS: u64 = DEFAULT_SLOTS_PER_EPOCH * 5;
+
+pub struct LedgerCleanupService {
+    t_cleanup: JoinHandle<()>,
+}
+
+impl LedgerCleanupService {
+    #[allow(clippy::new_ret_no_self)]
+    pub fn new(
+        slot_full_receiver: Receiver<(u64, Pubkey)>,
+        blocktree: Arc<Blocktree>,
+        max_ledger_slots: u64,
+        exit: &Arc<AtomicBool>,
+    ) -> Self {
+        let exit = exit.clone();
+        let t_cleanup = Builder::new()
+            .name("solana-ledger-cleanup".to_string())
+            .spawn(move || loop {
+                if exit.load(Ordering::Relaxed) {
+                    break;
+                }
+                if let Err(e) =
+                    Self::cleanup_ledger(&slot_full_receiver, &blocktree, max_ledger_slots)
+                {
+                    match e {
+                        Error::RecvTimeoutError(RecvTimeoutError::Disconnected) => break,
+                        Error::RecvTimeoutError(RecvTimeoutError::Timeout) => (),
+                        _ => info!("Error from process_entries: {:?}", e),
+                    }
+                }
+            })
+            .unwrap();
+        Self { t_cleanup }
+    }
+
+    fn cleanup_ledger(
+        slot_full_receiver: &Receiver<(u64, Pubkey)>,
+        blocktree: &Arc<Blocktree>,
+        max_ledger_slots: u64,
+    ) -> Result<()> {
+        let (slot, _) = slot_full_receiver.recv_timeout(Duration::from_secs(1))?;
+        if slot > max_ledger_slots {
+            //cleanup
+            blocktree.delete_all_columns(0, Some(slot - max_ledger_slots));
+        }
+        Ok(())
+    }
+}
+
+impl Service for LedgerCleanupService {
+    type JoinReturnType = ();
+
+    fn join(self) -> thread::Result<()> {
+        self.t_cleanup.join()
+    }
+}
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::blocktree::get_tmp_ledger_path;
+    use crate::blocktree::tests::make_many_slot_entries;
+    use std::sync::mpsc::channel;
+
+    #[test]
+    fn test_cleanup() {
+        let blocktree_path = get_tmp_ledger_path!();
+        let blocktree = Blocktree::open(&blocktree_path).unwrap();
+        let (blobs, _) = make_many_slot_entries(0, 50, 5);
+        blocktree.write_blobs(blobs).unwrap();
+        let blocktree = Arc::new(blocktree);
+        let (sender, receiver) = channel();
+
+        //send a signal to kill slots 0-40
+        sender.send((50, Pubkey::default())).unwrap();
+        LedgerCleanupService::cleanup_ledger(&receiver, &blocktree, 10).unwrap();
+
+        //check that 0-40 don't exist
+        blocktree
+            .slot_meta_iterator(0)
+            .unwrap()
+            .for_each(|(slot, _)| assert!(slot > 40));
+
+        drop(blocktree);
+        Blocktree::destroy(&blocktree_path).expect("Expected successful database destruction");
+    }
+}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -42,6 +42,7 @@ pub mod gossip_service;
 pub mod leader_schedule;
 pub mod leader_schedule_cache;
 pub mod leader_schedule_utils;
+pub mod ledger_cleanup_service;
 pub mod local_cluster;
 pub mod local_vote_signer_service;
 pub mod packet;

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -435,7 +435,7 @@ impl ReplayStage {
             assert_eq!(*bank_slot, bank.slot());
             if bank.tick_height() == bank.max_tick_height() {
                 did_complete_bank = true;
-                Self::process_completed_bank(my_pubkey, bank, slot_full_sender);
+                Self::process_completed_bank(my_pubkey, bank, slot_full_senders);
             } else {
                 trace!(
                     "bank {} not completed tick_height: {}, max_tick_height: {}",

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -622,13 +622,11 @@ impl ReplayStage {
     ) {
         bank.freeze();
         info!("bank frozen {}", bank.slot());
-        if let Err(e) = slot_full_senders
-            .iter()
-            .map(|sender| sender.send((bank.slot(), *bank.collector_id())))
-            .collect::<std::result::Result<Vec<_>, _>>()
-        {
-            trace!("{} slot_full alert failed: {:?}", my_pubkey, e);
-        }
+        slot_full_senders.iter().for_each(|sender| {
+            if let Err(e) = sender.send((bank.slot(), *bank.collector_id())) {
+                trace!("{} slot_full alert failed: {:?}", my_pubkey, e);
+            }
+        });
     }
 
     fn generate_new_bank_forks(

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -88,12 +88,12 @@ impl ReplayStage {
         subscriptions: &Arc<RpcSubscriptions>,
         poh_recorder: &Arc<Mutex<PohRecorder>>,
         leader_schedule_cache: &Arc<LeaderScheduleCache>,
-    ) -> (Self, Receiver<(u64, Pubkey)>, Receiver<Vec<Arc<Bank>>>)
+        slot_full_senders: Vec<Sender<(u64, Pubkey)>>,
+    ) -> (Self, Receiver<Vec<Arc<Bank>>>)
     where
         T: 'static + KeypairUtil + Send + Sync,
     {
         let (root_bank_sender, root_bank_receiver) = channel();
-        let (slot_full_sender, slot_full_receiver) = channel();
         trace!("replay stage");
         let exit_ = exit.clone();
         let subscriptions = subscriptions.clone();
@@ -132,7 +132,7 @@ impl ReplayStage {
                         &bank_forks,
                         &my_pubkey,
                         &mut progress,
-                        &slot_full_sender,
+                        &slot_full_senders,
                     );
 
                     let votable = Self::generate_votable_banks(&bank_forks, &tower, &mut progress);
@@ -191,7 +191,7 @@ impl ReplayStage {
                 Ok(())
             })
             .unwrap();
-        (Self { t_replay }, slot_full_receiver, root_bank_receiver)
+        (Self { t_replay }, root_bank_receiver)
     }
 
     fn maybe_start_leader(
@@ -409,7 +409,7 @@ impl ReplayStage {
         bank_forks: &Arc<RwLock<BankForks>>,
         my_pubkey: &Pubkey,
         progress: &mut HashMap<u64, ForkProgress>,
-        slot_full_sender: &Sender<(u64, Pubkey)>,
+        slot_full_senders: &[Sender<(u64, Pubkey)>],
     ) -> bool {
         let mut did_complete_bank = false;
         let active_banks = bank_forks.read().unwrap().active_banks();
@@ -618,11 +618,15 @@ impl ReplayStage {
     fn process_completed_bank(
         my_pubkey: &Pubkey,
         bank: Arc<Bank>,
-        slot_full_sender: &Sender<(u64, Pubkey)>,
+        slot_full_senders: &[Sender<(u64, Pubkey)>],
     ) {
         bank.freeze();
         info!("bank frozen {}", bank.slot());
-        if let Err(e) = slot_full_sender.send((bank.slot(), *bank.collector_id())) {
+        if let Err(e) = slot_full_senders
+            .iter()
+            .map(|sender| sender.send((bank.slot(), *bank.collector_id())))
+            .collect::<std::result::Result<Vec<_>, _>>()
+        {
             trace!("{} slot_full alert failed: {:?}", my_pubkey, e);
         }
     }

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -40,6 +40,7 @@ pub struct ValidatorConfig {
     pub account_paths: Option<String>,
     pub rpc_config: JsonRpcConfig,
     pub snapshot_path: Option<String>,
+    pub max_ledger_slots: Option<u64>,
     pub broadcast_stage_type: BroadcastStageType,
     pub erasure_config: ErasureConfig,
 }
@@ -51,6 +52,7 @@ impl Default for ValidatorConfig {
             voting_disabled: false,
             blockstream: None,
             storage_slots_per_turn: DEFAULT_SLOTS_PER_TURN,
+            max_ledger_slots: None,
             account_paths: None,
             rpc_config: JsonRpcConfig::default(),
             snapshot_path: None,
@@ -247,6 +249,7 @@ impl Validator {
             blocktree.clone(),
             &storage_state,
             config.blockstream.as_ref(),
+            config.max_ledger_slots,
             ledger_signal_receiver,
             &subscriptions,
             &poh_recorder,

--- a/core/tests/local_cluster.rs
+++ b/core/tests/local_cluster.rs
@@ -49,9 +49,9 @@ fn test_ledger_cleanup_service() {
         blocktree
             .slot_meta_iterator(0)
             .unwrap()
-            .for_each(|_| slots += 3);
+            .for_each(|_| slots += 1);
         // with 3 nodes upto 3 slots can be in progress and not complete so max slots in blocktree should be upto 103
-        assert!(slots <= 101, "got {}", slots);
+        assert!(slots <= 103, "got {}", slots);
     }
 }
 

--- a/core/tests/local_cluster.rs
+++ b/core/tests/local_cluster.rs
@@ -49,9 +49,9 @@ fn test_ledger_cleanup_service() {
         blocktree
             .slot_meta_iterator(0)
             .unwrap()
-            .for_each(|_| slots += 1);
-        // 1 slot can be in progress and not complete so max slots in blocktree should be 101
-        assert!(slots <= 101);
+            .for_each(|_| slots += 3);
+        // with 3 nodes upto 3 slots can be in progress and not complete so max slots in blocktree should be upto 103
+        assert!(slots <= 101, "got {}", slots);
     }
 }
 

--- a/core/tests/local_cluster.rs
+++ b/core/tests/local_cluster.rs
@@ -3,6 +3,7 @@ extern crate solana;
 use hashbrown::HashSet;
 use log::*;
 use serial_test_derive::serial;
+use solana::blocktree::Blocktree;
 use solana::broadcast_stage::BroadcastStageType;
 use solana::cluster::Cluster;
 use solana::cluster_tests;
@@ -15,6 +16,44 @@ use solana_sdk::poh_config::PohConfig;
 use solana_sdk::timing;
 use std::thread::sleep;
 use std::time::Duration;
+
+#[test]
+#[serial]
+fn test_ledger_cleanup_service() {
+    solana_logger::setup();
+    let num_nodes = 3;
+    let mut validator_config = ValidatorConfig::default();
+    validator_config.max_ledger_slots = Some(100);
+    let config = ClusterConfig {
+        cluster_lamports: 10_000,
+        poh_config: PohConfig::new_sleep(Duration::from_millis(50)),
+        node_stakes: vec![100; num_nodes],
+        validator_configs: vec![validator_config.clone(); num_nodes],
+        ..ClusterConfig::default()
+    };
+    let mut cluster = LocalCluster::new(&config);
+    // 200ms/per * 100 = 20 seconds, so sleep a little longer than that.
+    sleep(Duration::from_secs(60));
+
+    cluster_tests::spend_and_verify_all_nodes(
+        &cluster.entry_point_info,
+        &cluster.funding_keypair,
+        num_nodes,
+        HashSet::new(),
+    );
+    cluster.close_preserve_ledgers();
+    //check everyone's ledgers and make sure only ~100 slots are stored
+    for (_, info) in &cluster.fullnode_infos {
+        let mut slots = 0;
+        let blocktree = Blocktree::open(&info.info.ledger_path).unwrap();
+        blocktree
+            .slot_meta_iterator(0)
+            .unwrap()
+            .for_each(|_| slots += 1);
+        // 1 slot can be in progress and not complete so max slots in blocktree should be 101
+        assert!(slots <= 101);
+    }
+}
 
 #[test]
 #[serial]

--- a/core/tests/tvu.rs
+++ b/core/tests/tvu.rs
@@ -134,6 +134,7 @@ fn test_replay() {
             blocktree,
             &StorageState::default(),
             None,
+            None,
             ledger_signal_receiver,
             &Arc::new(RpcSubscriptions::default()),
             &poh_recorder,


### PR DESCRIPTION
#### Problem

Need a way to limit ledger disk space usage 

#### Summary of Changes

Actively prune older slots out of blocktree.

- Added a ledger cleanup service that runs off of replay stage signals
- Added tests (local_cluster test that runs with max_ledger_slots == 100 works!)
- Feature is optional and not enabled by default _and_ requires snapshots to be enabled

Fixes #5051
