### PR TITLE
Plumb node funding from genesis

### DIFF
--- a/ci/testnet-deploy.sh
+++ b/ci/testnet-deploy.sh
@@ -25,8 +25,8 @@ deployUpdateManifest=true
 fetchLogs=true
 maybeHashesPerTick=
 maybeDisableAirdrops=
-maybeStakeNodesInGenesisBlock=
-maybeFundNodesInGenesisBlock=
+maybeInternalNodesStakeLamports=
+maybeInternalNodesLamports=
 maybeExternalPrimordialAccountsFile=
 maybeLamports=
 maybeLetsEncrypt=
@@ -72,9 +72,9 @@ Deploys a CD testnet
    -f                   - Discard validator nodes that didn't bootup successfully
    --no-airdrop
                         - If set, disables airdrops.  Nodes must be funded in genesis block when airdrops are disabled.
-   --stake-lamports-internal-nodes NUM_LAMPORTS
+   --internal-nodes-stake-lamports NUM_LAMPORTS
                         - Amount to stake internal nodes.
-   --lamports-internal-nodes NUM_LAMPORTS
+   --internal-nodes-lamports NUM_LAMPORTS
                         - Amount to fund internal nodes in genesis block
    --external-accounts-file FILE_PATH
                         - Path to external Primordial Accounts file, if it exists.
@@ -113,11 +113,11 @@ while [[ -n $1 ]]; do
     elif [[ $1 = --no-airdrop ]]; then
       maybeDisableAirdrops="$1"
       shift 1
-    elif [[ $1 = --stake-lamports-internal-nodes ]]; then
-      maybeStakeNodesInGenesisBlock="$1 $2"
+    elif [[ $1 = --internal-nodes-stake-lamports ]]; then
+      maybeInternalNodesStakeLamports="$1 $2"
       shift 2
-    elif [[ $1 = --lamports-internal-nodes ]]; then
-      maybeFundNodesInGenesisBlock="$1 $2"
+    elif [[ $1 = --internal-nodes-lamports ]]; then
+      maybeInternalNodesLamports="$1 $2"
       shift 2
     elif [[ $1 = --external-accounts-file ]]; then
       maybeExternalPrimordialAccountsFile="$1 $2"
@@ -405,13 +405,13 @@ if ! $skipStart; then
       # shellcheck disable=SC2206
       args+=($maybeDisableAirdrops)
     fi
-    if [[ -n $maybeStakeNodesInGenesisBlock ]]; then
-      # shellcheck disable=SC2206 # Do not want to quote $maybeStakeNodesInGenesisBlock
-      args+=($maybeStakeNodesInGenesisBlock)
+    if [[ -n $maybeInternalNodesStakeLamports ]]; then
+      # shellcheck disable=SC2206 # Do not want to quote $maybeInternalNodesStakeLamports
+      args+=($maybeInternalNodesStakeLamports)
     fi
-    if [[ -n $maybeFundNodesInGenesisBlock ]]; then
-      # shellcheck disable=SC2206 # Do not want to quote $maybeFundNodesInGenesisBlock
-      args+=($maybeFundNodesInGenesisBlock)
+    if [[ -n $maybeInternalNodesLamports ]]; then
+      # shellcheck disable=SC2206 # Do not want to quote $maybeInternalNodesLamports
+      args+=($maybeInternalNodesLamports)
     fi
     if [[ -n $maybeExternalPrimordialAccountsFile ]]; then
       # shellcheck disable=SC2206 # Do not want to quote $maybeExternalPrimordialAccountsFile

--- a/ci/testnet-deploy.sh
+++ b/ci/testnet-deploy.sh
@@ -24,7 +24,9 @@ blockstreamer=false
 deployUpdateManifest=true
 fetchLogs=true
 maybeHashesPerTick=
+maybeDisableAirdrops=
 maybeStakeNodesInGenesisBlock=
+maybeFundNodesInGenesisBlock=
 maybeExternalPrimordialAccountsFile=
 maybeLamports=
 maybeLetsEncrypt=
@@ -68,8 +70,12 @@ Deploys a CD testnet
    -s                   - Skip start.  Nodes will still be created or configured, but network software will not be started.
    -S                   - Stop network software without tearing down nodes.
    -f                   - Discard validator nodes that didn't bootup successfully
-   --stake-internal-nodes NUM_LAMPORTS
-                        - Amount to stake internal nodes.  If set, airdrops are disabled.
+   --no-airdrop
+                        - If set, disables airdrops.  Nodes must be funded in genesis block when airdrops are disabled.
+   --stake-lamports-internal-nodes NUM_LAMPORTS
+                        - Amount to stake internal nodes.
+   --lamports-internal-nodes NUM_LAMPORTS
+                        - Amount to fund internal nodes in genesis block
    --external-accounts-file FILE_PATH
                         - Path to external Primordial Accounts file, if it exists.
    --hashes-per-tick NUM_HASHES|sleep|auto
@@ -104,8 +110,14 @@ while [[ -n $1 ]]; do
     elif [[ $1 = --lamports ]]; then
       maybeLamports="$1 $2"
       shift 2
-    elif [[ $1 = --stake-internal-nodes ]]; then
+    elif [[ $1 = --no-airdrop ]]; then
+      maybeDisableAirdrops="$1"
+      shift 1
+    elif [[ $1 = --stake-lamports-internal-nodes ]]; then
       maybeStakeNodesInGenesisBlock="$1 $2"
+      shift 2
+    elif [[ $1 = --lamports-internal-nodes ]]; then
+      maybeFundNodesInGenesisBlock="$1 $2"
       shift 2
     elif [[ $1 = --external-accounts-file ]]; then
       maybeExternalPrimordialAccountsFile="$1 $2"
@@ -389,9 +401,17 @@ if ! $skipStart; then
       args+=(--deploy-update windows)
     fi
 
+    if [[ -n $maybeDisableAirdrops ]]; then
+      # shellcheck disable=SC2206
+      args+=($maybeDisableAirdrops)
+    fi
     if [[ -n $maybeStakeNodesInGenesisBlock ]]; then
       # shellcheck disable=SC2206 # Do not want to quote $maybeStakeNodesInGenesisBlock
       args+=($maybeStakeNodesInGenesisBlock)
+    fi
+    if [[ -n $maybeFundNodesInGenesisBlock ]]; then
+      # shellcheck disable=SC2206 # Do not want to quote $maybeFundNodesInGenesisBlock
+      args+=($maybeFundNodesInGenesisBlock)
     fi
     if [[ -n $maybeExternalPrimordialAccountsFile ]]; then
       # shellcheck disable=SC2206 # Do not want to quote $maybeExternalPrimordialAccountsFile

--- a/ci/testnet-manager.sh
+++ b/ci/testnet-manager.sh
@@ -500,12 +500,30 @@ deploy() {
         maybeHashesPerTick="--hashes-per-tick ${HASHES_PER_TICK}"
       fi
 
-      if [[ -z $STAKE_INTERNAL_NODES ]]; then
-        maybeStakeInternalNodes="--stake-internal-nodes 1000000000000"
-      elif [[ $STAKE_INTERNAL_NODES == skip ]]; then
-        maybeStakeInternalNodes=""
+      if [[ -z $DISABLE_AIRDROPS ]]; then
+        DISABLE_AIRDROPS="true"
+      fi
+
+      if [[ $DISABLE_AIRDROPS == true ]] ; then
+        maybeDisableAirdrops="--no-airdrop"
       else
-        maybeStakeInternalNodes="--stake-internal-nodes ${STAKE_INTERNAL_NODES}"
+        maybeDisableAirdrops=""
+      fi
+
+      if [[ -z $STAKE_LAMPORTS_INTERNAL_NODES ]]; then
+        maybeStakeLamportsInternalNodes="--stake-lamports-internal-nodes 1000000000000"
+      elif [[ $STAKE_LAMPORTS_INTERNAL_NODES == skip ]]; then
+        maybeStakeLamportsInternalNodes=""
+      else
+        maybeStakeLamportsInternalNodes="--stake-lamports-internal-nodes ${STAKE_LAMPORTS_INTERNAL_NODES}"
+      fi
+
+      if [[ -z $LAMPORTS_INTERNAL_NODES ]]; then
+        maybeLamportsInternalNodes="--lamports-internal-nodes 2000000000000"
+      elif [[ $LAMPORTS_INTERNAL_NODES == skip ]]; then
+        maybeLamportsInternalNodes=""
+      else
+        maybeLamportsInternalNodes="--lamports-internal-nodes ${LAMPORTS_INTERNAL_NODES}"
       fi
 
       EXTERNAL_ACCOUNTS_FILE=/tmp/validator.yml
@@ -557,7 +575,9 @@ deploy() {
           ${skipStart:+-s} \
           ${maybeStop:+-S} \
           ${maybeDelete:+-D} \
-          ${maybeStakeInternalNodes} \
+          ${maybeDisableAirdrops} \
+          ${maybeStakeLamportsInternalNodes} \
+          ${maybeLamportsInternalNodes} \
           ${maybeExternalAccountsFile} \
           ${maybeLamports} \
           ${maybeAdditionalDisk} \

--- a/ci/testnet-manager.sh
+++ b/ci/testnet-manager.sh
@@ -510,20 +510,20 @@ deploy() {
         maybeDisableAirdrops=""
       fi
 
-      if [[ -z $STAKE_LAMPORTS_INTERNAL_NODES ]]; then
-        maybeStakeLamportsInternalNodes="--stake-lamports-internal-nodes 1000000000000"
-      elif [[ $STAKE_LAMPORTS_INTERNAL_NODES == skip ]]; then
-        maybeStakeLamportsInternalNodes=""
+      if [[ -z $INTERNAL_NODES_STAKE_LAMPORTS ]]; then
+        maybeInternalNodesStakeLamports="--internal-nodes-stake-lamports 1000000000000"
+      elif [[ $INTERNAL_NODES_STAKE_LAMPORTS == skip ]]; then
+        maybeInternalNodesStakeLamports=""
       else
-        maybeStakeLamportsInternalNodes="--stake-lamports-internal-nodes ${STAKE_LAMPORTS_INTERNAL_NODES}"
+        maybeInternalNodesStakeLamports="--internal-nodes-stake-lamports ${INTERNAL_NODES_STAKE_LAMPORTS}"
       fi
 
-      if [[ -z $LAMPORTS_INTERNAL_NODES ]]; then
-        maybeLamportsInternalNodes="--lamports-internal-nodes 2000000000000"
-      elif [[ $LAMPORTS_INTERNAL_NODES == skip ]]; then
-        maybeLamportsInternalNodes=""
+      if [[ -z $INTERNAL_NODES_LAMPORTS ]]; then
+        maybeInternalNodesLamports="--internal-nodes-lamports 2000000000000"
+      elif [[ $INTERNAL_NODES_LAMPORTS == skip ]]; then
+        maybeInternalNodesLamports=""
       else
-        maybeLamportsInternalNodes="--lamports-internal-nodes ${LAMPORTS_INTERNAL_NODES}"
+        maybeInternalNodesLamports="--internal-nodes-lamports ${INTERNAL_NODES_LAMPORTS}"
       fi
 
       EXTERNAL_ACCOUNTS_FILE=/tmp/validator.yml
@@ -576,8 +576,8 @@ deploy() {
           ${maybeStop:+-S} \
           ${maybeDelete:+-D} \
           ${maybeDisableAirdrops} \
-          ${maybeStakeLamportsInternalNodes} \
-          ${maybeLamportsInternalNodes} \
+          ${maybeInternalNodesStakeLamports} \
+          ${maybeInternalNodesLamports} \
           ${maybeExternalAccountsFile} \
           ${maybeLamports} \
           ${maybeAdditionalDisk} \

--- a/multinode-demo/fullnode.sh
+++ b/multinode-demo/fullnode.sh
@@ -27,6 +27,7 @@ Start a validator or a replicator
   --label LABEL             - Append the given label to the configuration files, useful when running
                               multiple fullnodes in the same workspace
   --stake LAMPORTS          - Number of lamports to stake
+  --node-lamports LAMPORTS  - Number of lamports this node has been funded from the genesis block
   --no-voting               - start node without vote signer
   --rpc-port port           - custom RPC port for this node
   --no-restart              - do not restart the node if it exits
@@ -216,6 +217,9 @@ while [[ -n $1 ]]; do
       shift 2
     elif [[ $1 = --stake ]]; then
       stake_lamports="$2"
+      shift 2
+    elif [[ $1 = --node-lamports ]]; then
+      node_lamports="$2"
       shift 2
     elif [[ $1 = --no-voting ]]; then
       args+=("$1")

--- a/net/net.sh
+++ b/net/net.sh
@@ -60,12 +60,12 @@ Operate a configured testnet
                                       - If set, disables airdrops.  Nodes must be funded in genesis block when airdrops are disabled.
    --lamports NUM_LAMPORTS_TO_MINT
                                       - Override the default 100000000000000 lamports minted in genesis
-   --stake-lamports-internal-nodes NUM_LAMPORTS_PER_NODE
-                                      - Amount to stake internal nodes in genesis block.
-   --lamports-internal-nodes NUM_LAMPORTS_PER_NODE
+   --internal-nodes-stake-lamports NUM_LAMPORTS_PER_NODE
+                                      - Amount to stake internal nodes.
+   --internal-nodes-lamports NUM_LAMPORTS_PER_NODE
                                       - Amount to fund internal nodes in genesis block.
    --external-accounts-file FILE_PATH
-                                      - A YML file with a list of account pubkeys and corresponding stakes for external nodes
+                                      - A YML file with a list of account pubkeys and corresponding lamport balances in genesis block for external nodes
    --no-snapshot
                                       - If set, disables booting validators from a snapshot
    --skip-ledger-verify
@@ -112,8 +112,8 @@ genesisOptions=
 numFullnodesRequested=
 externalPrimordialAccountsFile=
 remoteExternalPrimordialAccountsFile=
-stakeNodesInGenesisBlock=
-fundNodesInGenesisBlock=
+internalNodesStakeLamports=
+internalNodesLamports=
 maybeNoSnapshot=""
 maybeSkipLedgerVerify=""
 maybeDisableAirdrops=""
@@ -143,11 +143,11 @@ while [[ -n $1 ]]; do
     elif [[ $1 = --deploy-update ]]; then
       updatePlatforms="$updatePlatforms $2"
       shift 2
-    elif [[ $1 = --stake-lamports-internal-nodes ]]; then
-      stakeNodesInGenesisBlock="$2"
+    elif [[ $1 = --internal-nodes-stake-lamports ]]; then
+      internalNodesStakeLamports="$2"
       shift 2
-    elif [[ $1 = --lamports-internal-nodes ]]; then
-      fundNodesInGenesisBlock="$2"
+    elif [[ $1 = --internal-nodes-lamports ]]; then
+      internalNodesLamports="$2"
       shift 2
     elif [[ $1 = --external-accounts-file ]]; then
       externalPrimordialAccountsFile="$2"
@@ -382,8 +382,8 @@ startBootstrapLeader() {
          $failOnValidatorBootupFailure \
          \"$remoteExternalPrimordialAccountsFile\" \
          \"$maybeDisableAirdrops\" \
-         \"$stakeNodesInGenesisBlock\" \
-         \"$fundNodesInGenesisBlock\" \
+         \"$internalNodesStakeLamports\" \
+         \"$internalNodesLamports\" \
          $nodeIndex \
          $numBenchTpsClients \"$benchTpsExtraArgs\" \
          $numBenchExchangeClients \"$benchExchangeExtraArgs\" \
@@ -446,8 +446,8 @@ startNode() {
          $failOnValidatorBootupFailure \
          \"$remoteExternalPrimordialAccountsFile\" \
          \"$maybeDisableAirdrops\" \
-         \"$stakeNodesInGenesisBlock\" \
-         \"$fundNodesInGenesisBlock\" \
+         \"$internalNodesStakeLamports\" \
+         \"$internalNodesLamports\" \
          $nodeIndex \
          $numBenchTpsClients \"$benchTpsExtraArgs\" \
          $numBenchExchangeClients \"$benchExchangeExtraArgs\" \

--- a/net/net.sh
+++ b/net/net.sh
@@ -56,10 +56,14 @@ Operate a configured testnet
 
    --hashes-per-tick NUM_HASHES|sleep|auto
                                       - Override the default --hashes-per-tick for the cluster
+   --no-airdrop
+                                      - If set, disables airdrops.  Nodes must be funded in genesis block when airdrops are disabled.
    --lamports NUM_LAMPORTS_TO_MINT
                                       - Override the default 100000000000000 lamports minted in genesis
-   --stake-internal-nodes NUM_LAMPORTS_PER_NODE
-                                      - Amount to stake internal nodes in genesis block.  If set, airdrops are disabled.
+   --stake-lamports-internal-nodes NUM_LAMPORTS_PER_NODE
+                                      - Amount to stake internal nodes in genesis block.
+   --lamports-internal-nodes NUM_LAMPORTS_PER_NODE
+                                      - Amount to fund internal nodes in genesis block.
    --external-accounts-file FILE_PATH
                                       - A YML file with a list of account pubkeys and corresponding stakes for external nodes
    --no-snapshot
@@ -109,8 +113,10 @@ numFullnodesRequested=
 externalPrimordialAccountsFile=
 remoteExternalPrimordialAccountsFile=
 stakeNodesInGenesisBlock=
+fundNodesInGenesisBlock=
 maybeNoSnapshot=""
 maybeSkipLedgerVerify=""
+maybeDisableAirdrops=""
 
 command=$1
 [[ -n $command ]] || usage
@@ -137,13 +143,19 @@ while [[ -n $1 ]]; do
     elif [[ $1 = --deploy-update ]]; then
       updatePlatforms="$updatePlatforms $2"
       shift 2
-    elif [[ $1 = --stake-internal-nodes ]]; then
+    elif [[ $1 = --stake-lamports-internal-nodes ]]; then
       stakeNodesInGenesisBlock="$2"
+      shift 2
+    elif [[ $1 = --lamports-internal-nodes ]]; then
+      fundNodesInGenesisBlock="$2"
       shift 2
     elif [[ $1 = --external-accounts-file ]]; then
       externalPrimordialAccountsFile="$2"
       remoteExternalPrimordialAccountsFile=/tmp/external-primordial-accounts.yml
       shift 2
+    elif [[ $1 = --no-airdrop ]]; then
+      maybeDisableAirdrops="$1"
+      shift 1
     else
       usage "Unknown long option: $1"
     fi
@@ -369,7 +381,9 @@ startBootstrapLeader() {
          $skipSetup \
          $failOnValidatorBootupFailure \
          \"$remoteExternalPrimordialAccountsFile\" \
+         \"$maybeDisableAirdrops\" \
          \"$stakeNodesInGenesisBlock\" \
+         \"$fundNodesInGenesisBlock\" \
          $nodeIndex \
          $numBenchTpsClients \"$benchTpsExtraArgs\" \
          $numBenchExchangeClients \"$benchExchangeExtraArgs\" \
@@ -431,7 +445,9 @@ startNode() {
          $skipSetup \
          $failOnValidatorBootupFailure \
          \"$remoteExternalPrimordialAccountsFile\" \
+         \"$maybeDisableAirdrops\" \
          \"$stakeNodesInGenesisBlock\" \
+         \"$fundNodesInGenesisBlock\" \
          $nodeIndex \
          $numBenchTpsClients \"$benchTpsExtraArgs\" \
          $numBenchExchangeClients \"$benchExchangeExtraArgs\" \

--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -109,13 +109,13 @@ local|tar)
     fi
     set -x
     rm -rf ./solana-node-keys
-    rm -rf ./solana-node-stakes
-    mkdir ./solana-node-stakes
-    if [[ -n $internalNodesStakeLamports ]]; then
+    rm -rf ./solana-node-balances
+    mkdir ./solana-node-balances
+    if [[ -n $internalNodesLamports ]]; then
       for i in $(seq 0 "$numNodes"); do
         solana-keygen new -o ./solana-node-keys/"$i"
         pubkey="$(solana-keygen pubkey ./solana-node-keys/"$i")"
-        echo "${pubkey}: $internalNodesStakeLamports" >> ./solana-node-stakes/fullnode-stakes.yml
+        echo "${pubkey}: $internalNodesLamports" >> ./solana-node-balances/fullnode-balances.yml
       done
     fi
 
@@ -146,9 +146,9 @@ local|tar)
       tail -n +2 -q ./solana-client-accounts/bench-exchange"$i".yml >> ./solana-client-accounts/client-accounts.yml
       echo "" >> ./solana-client-accounts/client-accounts.yml
     done
-    [[ -z $externalPrimordialAccountsFile ]] || cat "$externalPrimordialAccountsFile" >> ./solana-node-stakes/fullnode-stakes.yml
-    if [ -f ./solana-node-stakes/fullnode-stakes.yml ]; then
-      genesisOptions+=" --primordial-accounts-file ./solana-node-stakes/fullnode-stakes.yml"
+    [[ -z $externalPrimordialAccountsFile ]] || cat "$externalPrimordialAccountsFile" >> ./solana-node-balances/fullnode-balances.yml
+    if [ -f ./solana-node-balances/fullnode-balances.yml ]; then
+      genesisOptions+=" --primordial-accounts-file ./solana-node-balances/fullnode-balances.yml"
     fi
     if [ -f ./solana-client-accounts/client-accounts.yml ]; then
       genesisOptions+=" --primordial-keypairs-file ./solana-client-accounts/client-accounts.yml"
@@ -184,6 +184,7 @@ local|tar)
   validator|blockstreamer)
     net/scripts/rsync-retry.sh -vPrc "$entrypointIp":~/.cargo/bin/ ~/.cargo/bin/
     rm -f ~/solana/fullnode-identity.json
+    # TODO: Is this supposed to be Lamports or StakeLamports?
     [[ -z $internalNodesStakeLamports ]] || net/scripts/rsync-retry.sh -vPrc \
     "$entrypointIp":~/solana/solana-node-keys/"$nodeIndex" ~/solana/fullnode-identity.json
 

--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -184,8 +184,7 @@ local|tar)
   validator|blockstreamer)
     net/scripts/rsync-retry.sh -vPrc "$entrypointIp":~/.cargo/bin/ ~/.cargo/bin/
     rm -f ~/solana/fullnode-identity.json
-    # TODO: Is this supposed to be Lamports or StakeLamports?
-    [[ -z $internalNodesStakeLamports ]] || net/scripts/rsync-retry.sh -vPrc \
+    [[ -z $internalNodesLamports ]] || net/scripts/rsync-retry.sh -vPrc \
     "$entrypointIp":~/solana/solana-node-keys/"$nodeIndex" ~/solana/fullnode-identity.json
 
     if [[ -e /dev/nvidia0 && -x ~/.cargo/bin/solana-validator-cuda ]]; then


### PR DESCRIPTION
Existing scripts were not correctly propagating genesis node funding to fullnode.sh.  This should fix it!

Also, add explicit airdrop enable/disable option, rather than implying it by the presence of genesis node funding.  Explicitly setting node stake, node funds at genesis and airdrops on/off are now supported from top level CI scripts.
