### PR TITLE
Only take snapshots of roots

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -307,8 +307,11 @@ fn get_bank_forks(
     verify_ledger: bool,
 ) -> (BankForks, Vec<BankForksInfo>, LeaderScheduleCache) {
     if snapshot_path.is_some() {
-        let bank_forks =
-            BankForks::load_from_snapshot(&genesis_block, account_paths.clone(), &snapshot_path);
+        let bank_forks = BankForks::load_from_snapshot(
+            &genesis_block,
+            account_paths.clone(),
+            snapshot_path.as_ref().unwrap(),
+        );
         match bank_forks {
             Ok(v) => {
                 let bank = &v.working_bank();

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -173,6 +173,10 @@ impl StatusCacheRc {
         let sc = status_cache_rc.status_cache.write().unwrap();
         self.status_cache.write().unwrap().append(&sc);
     }
+
+    pub fn purge_roots(&self) {
+        self.status_cache.write().unwrap().purge_roots();
+    }
 }
 
 /// Manager for the state of all accounts and programs after processing its entries.

--- a/runtime/src/status_cache.rs
+++ b/runtime/src/status_cache.rs
@@ -6,7 +6,7 @@ use solana_sdk::hash::Hash;
 use solana_sdk::signature::Signature;
 use std::collections::{HashMap, HashSet};
 
-const MAX_CACHE_ENTRIES: usize = solana_sdk::timing::MAX_HASH_AGE_IN_SECONDS;
+pub const MAX_CACHE_ENTRIES: usize = solana_sdk::timing::MAX_HASH_AGE_IN_SECONDS;
 const CACHED_SIGNATURE_SIZE: usize = 20;
 
 // Store forks in a single chunk of memory to avoid another lookup.

--- a/runtime/src/status_cache.rs
+++ b/runtime/src/status_cache.rs
@@ -104,14 +104,7 @@ impl<T: Serialize + Clone> StatusCache<T> {
     /// After MAX_CACHE_ENTRIES, roots are removed, and any old signatures are cleared.
     pub fn add_root(&mut self, fork: ForkId) {
         self.roots.insert(fork);
-        if self.roots.len() > MAX_CACHE_ENTRIES {
-            if let Some(min) = self.roots.iter().min().cloned() {
-                self.roots.remove(&min);
-                for cache in self.cache.iter_mut() {
-                    cache.retain(|_, (fork, _, _)| *fork > min);
-                }
-            }
-        }
+        self.purge_roots();
     }
 
     /// Insert a new signature for a specific fork.
@@ -134,6 +127,17 @@ impl<T: Serialize + Clone> StatusCache<T> {
         sig_slice.clone_from_slice(&sig.as_ref()[index..index + CACHED_SIGNATURE_SIZE]);
         let sig_forks = sig_map.2.entry(sig_slice).or_insert_with(|| vec![]);
         sig_forks.push((fork, res));
+    }
+
+    pub fn purge_roots(&mut self) {
+        if self.roots.len() > MAX_CACHE_ENTRIES {
+            if let Some(min) = self.roots.iter().min().cloned() {
+                self.roots.remove(&min);
+                for cache in self.cache.iter_mut() {
+                    cache.retain(|_, (fork, _, _)| *fork > min);
+                }
+            }
+        }
     }
 
     fn insert_entry(
@@ -171,7 +175,7 @@ impl<T: Serialize + Clone> StatusCache<T> {
             }
         }
 
-        self.roots = self.roots.union(&status_cache.roots).cloned().collect();
+        self.roots = status_cache.roots.clone();
     }
 
     pub fn merge_caches(&mut self) {


### PR DESCRIPTION
#### Problem
We currently take snapshots of all frozen banks which can lead to unnecessary banks being snapshotted.

#### Summary of Changes
Only take snapshots of most recent rooted bank.

@sagar-solana, currently seeing DuplicateSignature errors when restarting with this PR. Mind towing this while I hack on the disappearing AppendVec + snapshot change?
Fixes #
