### PR TITLE
Increase ticks_per_slot for banking benchmark

### DIFF
--- a/runtime/benches/bank.rs
+++ b/runtime/benches/bank.rs
@@ -120,7 +120,8 @@ fn do_bench_transactions(
 ) {
     solana_logger::setup();
     let ns_per_s = 1_000_000_000;
-    let (genesis_block, mint_keypair) = create_genesis_block(100_000_000);
+    let (mut genesis_block, mint_keypair) = create_genesis_block(100_000_000);
+    genesis_block.ticks_per_slot = 100;
     let mut bank = Bank::new(&genesis_block);
     bank.add_instruction_processor(Pubkey::new(&BUILTIN_PROGRAM_ID), process_instruction);
     bank.register_native_instruction_processor(


### PR DESCRIPTION
#### Problem

Benchmarks can run out of ticks and do not handle more than one slot.

#### Summary of Changes

Increase ticks_per_slot for banking benches.

Fixes #
