### PR TITLE
Surface validator pubkey in metrics

### DIFF
--- a/multinode-demo/fullnode.sh
+++ b/multinode-demo/fullnode.sh
@@ -361,6 +361,7 @@ else
 fi
 
 identity_pubkey=$($solana_keygen pubkey "$identity_keypair_path")
+export SOLANA_METRICS_HOST_ID="$identity_pubkey"
 
 if [[ $node_type != replicator ]]; then
   accounts_config_dir="$state_dir"/accounts

--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -81,7 +81,6 @@ case $deployMethod in
 local|tar)
   PATH="$HOME"/.cargo/bin:"$PATH"
   export USE_INSTALL=1
-  export SOLANA_METRICS_DISPLAY_HOSTNAME=1
 
   # Setup `/var/snap/solana/current` symlink so rsyncing the genesis
   # ledger works (reference: `net/scripts/install-rsync.sh`)


### PR DESCRIPTION
Instead of hashing a validator's hostname for the metrics host_id, it's much more helpful to use the validator's pubkey