### PR TITLE
Call book/build.sh from docker

### DIFF
--- a/ci/publish-book.sh
+++ b/ci/publish-book.sh
@@ -4,6 +4,7 @@ set -e
 cd "$(dirname "$0")/.."
 BOOK="book"
 
+source ci/rust-version.sh stable
 eval "$(ci/channel-info.sh)"
 
 if [[ -n $PUBLISH_BOOK_TAG ]]; then
@@ -44,7 +45,7 @@ else
   BOOK=$CHANNEL
 fi
 
-book/build.sh
+ci/docker-run.sh "$rust_stable_docker_image" bash -exc "book/build.sh"
 
 echo --- create book repo
 (

--- a/ci/publish-book.sh
+++ b/ci/publish-book.sh
@@ -38,8 +38,11 @@ else
     repo=git@github.com:solana-labs/book-beta.git
     ;;
   *)
-   echo "--- publish skipped"
-   exit 0
+#   echo "--- publish skipped"
+#   exit 0
+    echo "channel is ${CHANNEL}"
+    echo "writing to book-edge for debugging"
+    repo=git@github.com:solana-labs/book-edge.git
    ;;
   esac
   BOOK=$CHANNEL

--- a/ci/publish-book.sh
+++ b/ci/publish-book.sh
@@ -38,11 +38,8 @@ else
     repo=git@github.com:solana-labs/book-beta.git
     ;;
   *)
-#   echo "--- publish skipped"
-#   exit 0
-    echo "channel is ${CHANNEL}"
-    echo "writing to book-edge for debugging"
-    repo=git@github.com:solana-labs/book-edge.git
+   echo "--- publish skipped"
+   exit 0
    ;;
   esac
   BOOK=$CHANNEL


### PR DESCRIPTION
#### Problem
Publish book job are now failing as svgbob_cli was in our CARGO_HOME, which was removed with https://github.com/solana-labs/solana/pull/5219

#### Summary of Changes
Run book/build.sh from docker, which does contain svgbob_cli