### PR TITLE
validator.sh: Introduce --config-dir to avoid shipping clear-config.sh

### DIFF
--- a/book/src/testnet-participation.md
+++ b/book/src/testnet-participation.md
@@ -155,20 +155,17 @@ choice, to start the node:
 
 If this is a `solana-install`-installation:
 ```bash
-$ clear-config.sh
-$ validator.sh --identity ~/validator-keypair.json --rpc-port 8899 --poll-for-new-genesis-block testnet.solana.com
+$ validator.sh --identity ~/validator-keypair.json --config-dir ~/validator-config --rpc-port 8899 --poll-for-new-genesis-block testnet.solana.com
 ```
 
 Alternatively, the `solana-install run` command can be used to run the validator
 node while periodically checking for and applying software updates:
 ```bash
-$ clear-config.sh
-$ solana-install run validator.sh -- --identity ~/validator-keypair.json --rpc-port 8899 --poll-for-new-genesis-block testnet.solana.com
+$ solana-install run validator.sh -- --identity ~/validator-keypair.json --config-dir ~/validator-config --rpc-port 8899 --poll-for-new-genesis-block testnet.solana.com
 ```
 
 If you built from source:
 ```bash
-$ USE_INSTALL=1 ./multinode-demo/clear-config.sh
 $ USE_INSTALL=1 ./multinode-demo/validator.sh --identity ~/validator-keypair.json --rpc-port 8899 --poll-for-new-genesis-block testnet.solana.com
 ```
 

--- a/ci/publish-tarball.sh
+++ b/ci/publish-tarball.sh
@@ -101,20 +101,10 @@ echo --- Creating tarball
 set -e
 cd "$(dirname "$0")"/..
 export USE_INSTALL=1
+export REQUIRE_CONFIG_DIR=1
 exec multinode-demo/validator.sh "$@"
 EOF
   chmod +x solana-release/bin/validator.sh
-
-  # Add a wrapper script for clear-config.sh
-  # TODO: Remove multinode/... from tarball
-  cat > solana-release/bin/clear-config.sh <<'EOF'
-#!/usr/bin/env bash
-set -e
-cd "$(dirname "$0")"/..
-export USE_INSTALL=1
-exec multinode-demo/clear-config.sh "$@"
-EOF
-  chmod +x solana-release/bin/clear-config.sh
 
   tar cvf solana-release-$TARGET.tar solana-release
   bzip2 solana-release-$TARGET.tar

--- a/multinode-demo/common.sh
+++ b/multinode-demo/common.sh
@@ -81,7 +81,6 @@ setup_secondary_mount() {
     ln -sfT $SECONDARY_DISK_MOUNT_POINT/config-local "$SOLANA_CONFIG_DIR"
   fi
 }
-setup_secondary_mount
 
 default_arg() {
   declare name=$1

--- a/multinode-demo/fullnode.sh
+++ b/multinode-demo/fullnode.sh
@@ -18,10 +18,11 @@ fullnode_usage() {
   cat <<EOF
 
 Fullnode Usage:
-usage: $0 [--blockstream PATH] [--init-complete-file FILE] [--label LABEL] [--stake LAMPORTS] [--no-voting] [--rpc-port port] [rsync network path to bootstrap leader configuration] [cluster entry point]
+usage: $0 [--config-dir PATH] [--blockstream PATH] [--init-complete-file FILE] [--label LABEL] [--stake LAMPORTS] [--no-voting] [--rpc-port port] [rsync network path to bootstrap leader configuration] [cluster entry point]
 
 Start a validator or a replicator
 
+  --config-dir PATH         - store configuration and data files under this PATH
   --blockstream PATH        - open blockstream at this unix domain socket location
   --init-complete-file FILE - create this file, if it doesn't already exist, once node initialization is complete
   --label LABEL             - Append the given label to the configuration files, useful when running
@@ -199,6 +200,7 @@ airdrops_enabled=1
 generate_snapshots=0
 boot_from_snapshot=1
 reset_ledger=0
+config_dir=
 
 positional_args=()
 while [[ -n $1 ]]; do
@@ -272,6 +274,9 @@ while [[ -n $1 ]]; do
     elif [[ $1 = --reset-ledger ]]; then
       reset_ledger=1
       shift
+    elif [[ $1 = --config-dir ]]; then
+      config_dir=$2
+      shift 2
     elif [[ $1 = -h ]]; then
       fullnode_usage "$@"
     else
@@ -284,6 +289,16 @@ while [[ -n $1 ]]; do
   fi
 done
 
+if [[ -n $REQUIRE_CONFIG_DIR ]]; then
+  if [[ -z $config_dir ]]; then
+    fullnode_usage "Error: --config-dir not specified"
+  fi
+
+  SOLANA_RSYNC_CONFIG_DIR="$config_dir"/config
+  SOLANA_CONFIG_DIR="$config_dir"/config-local
+fi
+
+setup_secondary_mount
 
 if [[ $node_type = replicator ]]; then
   if [[ ${#positional_args[@]} -gt 2 ]]; then

--- a/multinode-demo/setup.sh
+++ b/multinode-demo/setup.sh
@@ -3,6 +3,7 @@
 here=$(dirname "$0")
 # shellcheck source=multinode-demo/common.sh
 source "$here"/common.sh
+setup_secondary_mount
 
 set -e
 "$here"/clear-config.sh


### PR DESCRIPTION
#### Problem
1. Shipping `clear-config.sh` is gross
2. `solana-install`-based installs write the ledger and other config files in a _hidden_ location, the user should instead get to pick

#### Summary of Changes
`validator.sh --config-dir ~/wherever` makes the user specify where the ledger goes, and avoids the need for `clear-config.sh` since the user can just `rm -rf ~/wherever` themselves.
