### PR TITLE
Add logs to indicate when the leader changes

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -140,7 +140,7 @@ impl ReplayStage {
 
                     if let Some((_, bank)) = votable.last() {
                         subscriptions.notify_subscribers(bank.slot(), &bank_forks);
-                        
+
                         if let Some(new_leader) =
                             leader_schedule_cache.slot_leader_at(bank.slot(), Some(&bank))
                         {

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -139,6 +139,8 @@ impl ReplayStage {
                     let votable = Self::generate_votable_banks(&bank_forks, &tower, &mut progress);
 
                     if let Some((_, bank)) = votable.last() {
+                        subscriptions.notify_subscribers(bank.slot(), &bank_forks);
+                        
                         if let Some(new_leader) =
                             leader_schedule_cache.slot_leader_at(bank.slot(), Some(&bank))
                         {

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -111,6 +111,7 @@ impl ReplayStage {
             .spawn(move || {
                 let _exit = Finalizer::new(exit_.clone());
                 let mut progress = HashMap::new();
+                let mut current_leader = None;
 
                 loop {
                     let now = Instant::now();
@@ -138,7 +139,16 @@ impl ReplayStage {
                     let votable = Self::generate_votable_banks(&bank_forks, &tower, &mut progress);
 
                     if let Some((_, bank)) = votable.last() {
-                        subscriptions.notify_subscribers(bank.slot(), &bank_forks);
+                        if let Some(new_leader) =
+                            leader_schedule_cache.slot_leader_at(bank.slot(), Some(&bank))
+                        {
+                            Self::log_leader_change(
+                                &my_pubkey,
+                                bank.slot(),
+                                &mut current_leader,
+                                &new_leader,
+                            );
+                        }
 
                         Self::handle_votable_bank(
                             &bank,
@@ -170,6 +180,15 @@ impl ReplayStage {
                             &poh_recorder,
                             &leader_schedule_cache,
                         );
+
+                        if let Some(bank) = poh_recorder.lock().unwrap().bank() {
+                            Self::log_leader_change(
+                                &my_pubkey,
+                                bank.slot(),
+                                &mut current_leader,
+                                &my_pubkey,
+                            );
+                        }
                     }
 
                     inc_new_counter_info!(
@@ -192,6 +211,30 @@ impl ReplayStage {
             })
             .unwrap();
         (Self { t_replay }, root_bank_receiver)
+    }
+
+    fn log_leader_change(
+        my_pubkey: &Pubkey,
+        bank_slot: u64,
+        current_leader: &mut Option<Pubkey>,
+        new_leader: &Pubkey,
+    ) {
+        if let Some(ref current_leader) = current_leader {
+            if current_leader != new_leader {
+                let msg = if current_leader == my_pubkey {
+                    "I am no longer the leader"
+                } else if new_leader == my_pubkey {
+                    "I am the new leader"
+                } else {
+                    ""
+                };
+                info!(
+                    "LEADER CHANGE at slot: {} leader: {}. {}",
+                    bank_slot, new_leader, msg
+                );
+            }
+        }
+        current_leader.replace(new_leader.to_owned());
     }
 
     fn maybe_start_leader(
@@ -258,12 +301,6 @@ impl ReplayStage {
                 .unwrap()
                 .insert(Bank::new_from_parent(&parent, my_pubkey, poh_slot));
 
-            info!(
-                "poh_recorder new working bank: me: {} next_slot: {} next_leader: {}",
-                my_pubkey,
-                tpu_bank.slot(),
-                next_leader
-            );
             poh_recorder.lock().unwrap().set_bank(&tpu_bank);
         } else {
             error!("{} No next leader found", my_pubkey);
@@ -396,11 +433,18 @@ impl ReplayStage {
             .lock()
             .unwrap()
             .reset(bank.last_blockhash(), bank.slot(), next_leader_slot);
-        debug!(
-            "{:?} voted and reset poh at {}. next leader slot {:?}",
+
+        let next_leader_msg = if let Some(next_leader_slot) = next_leader_slot {
+            format!("My next leader slot is #{}", next_leader_slot)
+        } else {
+            "I am not in the upcoming leader schedule yet".to_owned()
+        };
+
+        info!(
+            "{} voted and reset poh at {}. {}",
             my_pubkey,
             bank.tick_height(),
-            next_leader_slot
+            next_leader_msg,
         );
     }
 


### PR DESCRIPTION
#### Problem
Cannot tell when a validator becomes the leader from the info logs. It should be clear when the leader changes and what next slot they will be the leader for.

#### Summary of Changes
- Add a new `LEADER CHANGE` log entry that says who the new leader is
- Increase the log level of an entry that indicates when a validator can next expect to be the leader
- Remove a now redundant info log entry which stated who the next leader was

```
$ LEADER CHANGE at slot: 161 leader: 86adEr4LoGYS4R1RFggcGR8FRz6aPRYEJbDBcQkk6atd. I am the new leader
$ LEADER CHANGE at slot: 164 leader: 5YsY64d5o6PBaMQ2JGxPo8U8GJCo6xowKaemYDmtF29v. I am no longer the leader
$ 86adEr4LoGYS4R1RFggcGR8FRz6aPRYEJbDBcQkk6atd voted and reset poh at 663. My next leader slot is #172
```

Fixes #5213
