### PR TITLE
Sort bench-tps keypairs

### DIFF
--- a/bench-tps/src/main.rs
+++ b/bench-tps/src/main.rs
@@ -6,7 +6,7 @@ use crate::bench::{
 };
 use solana::gossip_service::{discover_cluster, get_multi_client};
 use solana_sdk::fee_calculator::FeeCalculator;
-use solana_sdk::signature::Keypair;
+use solana_sdk::signature::{Keypair, KeypairUtil};
 use std::collections::HashMap;
 use std::fs::File;
 use std::io::prelude::*;
@@ -91,6 +91,7 @@ fn main() {
             keypairs.push(Keypair::from_bytes(&bytes).unwrap());
             last_balance = balance;
         });
+        keypairs.sort_by(|x, y| x.pubkey().to_string().cmp(&y.pubkey().to_string()));
         (keypairs, last_balance)
     } else {
         generate_and_fund_keypairs(

--- a/bench-tps/src/main.rs
+++ b/bench-tps/src/main.rs
@@ -91,6 +91,9 @@ fn main() {
             keypairs.push(Keypair::from_bytes(&bytes).unwrap());
             last_balance = balance;
         });
+        // Sort keypairs so that do_bench_tps() uses the same subset of accounts for each run.
+        // This prevents the amount of storage needed for bench-tps accounts from creeping up
+        // across multiple runs.
         keypairs.sort_by(|x, y| x.pubkey().to_string().cmp(&y.pubkey().to_string()));
         (keypairs, last_balance)
     } else {


### PR DESCRIPTION
#### Problem
The accounts store, `state.tgz`, can get very large after multiple runs of bench-tps, especially with a high transaction rate. This is because bench-tps is using a somewhat different set of keypairs for each run, leaving a batch of dangling unused accounts in historical `accounts/<slot>/` directories.

Here is a grafana table that illustrates the issue. Squashing time correlates with state.tgz size.
![image](https://user-images.githubusercontent.com/3030561/61755146-82dee200-ad73-11e9-911d-3703979c8b95.png)
The steady stair step on the left is from a testnet running current bench-tps (3min duration), with each jump representing a bench-tps run. The flatter line on the right is a testnet running bench-tps with sorted keypairs (ie. the same set each run).

#### Summary of Changes
Sort bench-tps keypairs to use the same selection of keypairs each run

**Note:** I think there are still optimizations possible for the state.tgz accounts store around `AccountsDB::remove_dead_accounts` and `AccountsDB::cleanup_dead_forks`, but this should resolve the biggest source of bloat for TdS

Fixes #5132 
