### PR TITLE
Fixes for Blocktree space amplification and slot deletion

### DIFF
--- a/core/src/blocktree.rs
+++ b/core/src/blocktree.rs
@@ -216,8 +216,6 @@ impl Blocktree {
                         .unwrap_or(batch_end + PURGE_BATCH_SIZE)
                         .min(batch_end + PURGE_BATCH_SIZE);
                 }
-            } else {
-                continue;
             }
         }
     }

--- a/core/src/blocktree.rs
+++ b/core/src/blocktree.rs
@@ -195,61 +195,153 @@ impl Blocktree {
     }
 
     /// Silently deletes all blocktree column families starting at the given slot until the `to` slot
-    /// Use with care; does not check for integrity and does not update slot metas that
-    /// refer to deleted slots
-    pub fn purge_slots(&self, from_slot: Slot, to_slot: Option<Slot>) {
-        let to_index = to_slot.map(|slot| (slot + 1, 0));
-        if let Err(e) = self.meta_cf.force_delete(Some(from_slot), to_slot) {
-            error!(
-                "Error: {:?} while deleting meta_cf for slot {:?}",
-                e, from_slot
-            )
+    /// Dangerous; Use with care:
+    /// Does not check for integrity and does not update slot metas that refer to deleted slots
+    /// Modifies multiple column families simultaneously
+    pub fn purge_slots(&self, mut from_slot: Slot, to_slot: Option<Slot>) {
+        // split the purge request into batches of 1000 slots
+        const PURGE_BATCH_SIZE: u64 = 1000;
+        let mut batch_end = to_slot
+            .unwrap_or(from_slot + PURGE_BATCH_SIZE)
+            .min(from_slot + PURGE_BATCH_SIZE);
+        while from_slot < batch_end {
+            if let Ok(end) = self.run_purge_batch(from_slot, batch_end) {
+                // no more slots to iter or reached the upper bound
+                if end {
+                    break;
+                } else {
+                    // update the next batch bounds
+                    from_slot = batch_end;
+                    batch_end = to_slot
+                        .unwrap_or(batch_end + PURGE_BATCH_SIZE)
+                        .min(batch_end + PURGE_BATCH_SIZE);
+                }
+            } else {
+                continue;
+            }
         }
-        if let Err(e) = self.data_cf.force_delete(Some((from_slot, 0)), to_index) {
-            error!(
-                "Error: {:?} while deleting data_cf for slot {:?}",
-                e, from_slot
-            )
-        }
-        if let Err(e) = self
-            .erasure_meta_cf
-            .force_delete(Some((from_slot, 0)), to_index)
-        {
-            error!(
-                "Error: {:?} while deleting erasure_meta_cf for slot {:?}",
-                e, from_slot
-            )
-        }
-        if let Err(e) = self.erasure_cf.force_delete(Some((from_slot, 0)), to_index) {
-            error!(
-                "Error: {:?} while deleting erasure_cf for slot {:?}",
-                e, from_slot
-            )
-        }
-        if let Err(e) = self.orphans_cf.force_delete(Some(from_slot), to_slot) {
-            error!(
-                "Error: {:?} while deleting orphans_cf for slot {:?}",
-                e, from_slot
-            )
-        }
-        if let Err(e) = self.index_cf.force_delete(Some(from_slot), to_slot) {
-            error!(
-                "Error: {:?} while deleting index_cf for slot {:?}",
-                e, from_slot
-            )
-        }
-        if let Err(e) = self.dead_slots_cf.force_delete(Some(from_slot), to_slot) {
-            error!(
-                "Error: {:?} while deleting dead_slots_cf for slot {:?}",
-                e, from_slot
-            )
-        }
-        let roots_cf = self.db.column::<cf::Root>();
-        if let Err(e) = roots_cf.force_delete(Some(from_slot), to_slot) {
-            error!(
-                "Error: {:?} while deleting roots_cf for slot {:?}",
-                e, from_slot
-            )
+    }
+
+    // Returns whether or not all iterators have reached their end
+    fn run_purge_batch(&self, from_slot: Slot, batch_end: Slot) -> Result<bool> {
+        let mut end = true;
+        let from_slot = Some(from_slot);
+        let batch_end = Some(batch_end);
+        unsafe {
+            let mut batch_processor = self.db.batch_processor();
+            let mut write_batch = batch_processor
+                .batch()
+                .expect("Database Error: Failed to get write batch");
+            end &= match self
+                .meta_cf
+                .delete_slot(&mut write_batch, from_slot, batch_end)
+            {
+                Ok(finished) => finished,
+                Err(e) => {
+                    error!(
+                        "Error: {:?} while deleting meta_cf for slot {:?}",
+                        e, from_slot
+                    );
+                    false
+                }
+            };
+            end &= match self
+                .data_cf
+                .delete_slot(&mut write_batch, from_slot, batch_end)
+            {
+                Ok(finished) => finished,
+                Err(e) => {
+                    error!(
+                        "Error: {:?} while deleting meta_cf for slot {:?}",
+                        e, from_slot
+                    );
+                    false
+                }
+            };
+            end &= match self
+                .erasure_meta_cf
+                .delete_slot(&mut write_batch, from_slot, batch_end)
+            {
+                Ok(finished) => finished,
+                Err(e) => {
+                    error!(
+                        "Error: {:?} while deleting meta_cf for slot {:?}",
+                        e, from_slot
+                    );
+                    false
+                }
+            };
+            end &= match self
+                .erasure_cf
+                .delete_slot(&mut write_batch, from_slot, batch_end)
+            {
+                Ok(finished) => finished,
+                Err(e) => {
+                    error!(
+                        "Error: {:?} while deleting meta_cf for slot {:?}",
+                        e, from_slot
+                    );
+                    false
+                }
+            };
+            end &= match self
+                .orphans_cf
+                .delete_slot(&mut write_batch, from_slot, batch_end)
+            {
+                Ok(finished) => finished,
+                Err(e) => {
+                    error!(
+                        "Error: {:?} while deleting meta_cf for slot {:?}",
+                        e, from_slot
+                    );
+                    false
+                }
+            };
+            end &= match self
+                .index_cf
+                .delete_slot(&mut write_batch, from_slot, batch_end)
+            {
+                Ok(finished) => finished,
+                Err(e) => {
+                    error!(
+                        "Error: {:?} while deleting meta_cf for slot {:?}",
+                        e, from_slot
+                    );
+                    false
+                }
+            };
+            end &= match self
+                .dead_slots_cf
+                .delete_slot(&mut write_batch, from_slot, batch_end)
+            {
+                Ok(finished) => finished,
+                Err(e) => {
+                    error!(
+                        "Error: {:?} while deleting meta_cf for slot {:?}",
+                        e, from_slot
+                    );
+                    false
+                }
+            };
+            let roots_cf = self.db.column::<cf::Root>();
+            end &= match roots_cf.delete_slot(&mut write_batch, from_slot, batch_end) {
+                Ok(finished) => finished,
+                Err(e) => {
+                    error!(
+                        "Error: {:?} while deleting meta_cf for slot {:?}",
+                        e, from_slot
+                    );
+                    false
+                }
+            };
+            if let Err(e) = batch_processor.write(write_batch) {
+                error!(
+                    "Error: {:?} while submitting write batch for slot {:?} retrying...",
+                    e, from_slot
+                );
+                Err(e)?;
+            }
+            Ok(end)
         }
     }
 
@@ -3489,6 +3581,26 @@ pub mod tests {
         blocktree.slot_meta_iterator(0).unwrap().for_each(|(_, _)| {
             assert!(false);
         });
+
+        drop(blocktree);
+        Blocktree::destroy(&blocktree_path).expect("Expected successful database destruction");
+    }
+
+    #[test]
+    fn test_purge_huge() {
+        let blocktree_path = get_tmp_ledger_path!();
+        let blocktree = Blocktree::open(&blocktree_path).unwrap();
+        let (blobs, _) = make_many_slot_entries(0, 5000, 10);
+        blocktree.write_blobs(blobs).unwrap();
+
+        blocktree.purge_slots(0, Some(4999));
+
+        blocktree
+            .slot_meta_iterator(0)
+            .unwrap()
+            .for_each(|(slot, _)| {
+                assert_eq!(slot, 5000);
+            });
 
         drop(blocktree);
         Blocktree::destroy(&blocktree_path).expect("Expected successful database destruction");

--- a/core/src/blocktree/db.rs
+++ b/core/src/blocktree/db.rs
@@ -422,10 +422,10 @@ where
         C::Index: PartialOrd + Copy,
     {
         let mut end = true;
-        let iter = self.iter(from.map(|from| C::as_index(from)))?;
+        let iter = self.iter(from.map(C::as_index))?;
         for (index, _) in iter {
-            if let Some(ref to) = to {
-                if &C::slot(index) > to {
+            if let Some(to) = to {
+                if C::slot(index) > to {
                     end = false;
                     break;
                 }

--- a/core/src/blocktree/db.rs
+++ b/core/src/blocktree/db.rs
@@ -5,6 +5,7 @@ use bincode::{deserialize, serialize};
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 
+use solana_sdk::timing::Slot;
 use std::borrow::Borrow;
 use std::collections::HashMap;
 use std::marker::PhantomData;
@@ -86,6 +87,8 @@ where
 
     fn key(index: Self::Index) -> B::OwnedKey;
     fn index(key: &B::Key) -> Self::Index;
+    fn slot(index: Self::Index) -> Slot;
+    fn as_index(slot: Slot) -> Self::Index;
 }
 
 pub trait DbCursor<B>
@@ -409,22 +412,29 @@ where
         Ok(iter.map(|(key, value)| (C::index(&key), value)))
     }
 
-    pub fn force_delete(&self, from: Option<C::Index>, to: Option<C::Index>) -> Result<()>
+    pub fn delete_slot(
+        &self,
+        batch: &mut WriteBatch<B>,
+        from: Option<Slot>,
+        to: Option<Slot>,
+    ) -> Result<bool>
     where
-        C::Index: PartialOrd,
+        C::Index: PartialOrd + Copy,
     {
-        let iter = self.iter(from)?;
+        let mut end = true;
+        let iter = self.iter(from.map(|from| C::as_index(from)))?;
         for (index, _) in iter {
             if let Some(ref to) = to {
-                if &index > to {
+                if &C::slot(index) > to {
+                    end = false;
                     break;
                 }
-            }
-            if let Err(e) = self.delete(index) {
-                error!("Error: {:?} while deleting {:?}", e, C::NAME)
+            };
+            if let Err(e) = batch.delete::<C>(index) {
+                error!("Error: {:?} while adding delete to batch {:?}", e, C::NAME)
             }
         }
-        Ok(())
+        Ok(end)
     }
 
     #[inline]

--- a/core/src/ledger_cleanup_service.rs
+++ b/core/src/ledger_cleanup_service.rs
@@ -13,7 +13,7 @@ use std::thread;
 use std::thread::{Builder, JoinHandle};
 use std::time::Duration;
 
-pub const DEFAULT_MAX_LEDGER_SLOTS: u64 = DEFAULT_SLOTS_PER_EPOCH * 5;
+pub const DEFAULT_MAX_LEDGER_SLOTS: u64 = 3 * DEFAULT_SLOTS_PER_EPOCH;
 
 pub struct LedgerCleanupService {
     t_cleanup: JoinHandle<()>,
@@ -26,6 +26,10 @@ impl LedgerCleanupService {
         max_ledger_slots: u64,
         exit: &Arc<AtomicBool>,
     ) -> Self {
+        info!(
+            "LedgerCleanupService active. Max Ledger Slots {}",
+            max_ledger_slots
+        );
         let exit = exit.clone();
         let t_cleanup = Builder::new()
             .name("solana-ledger-cleanup".to_string())

--- a/multinode-demo/fullnode.sh
+++ b/multinode-demo/fullnode.sh
@@ -259,6 +259,9 @@ while [[ -n $1 ]]; do
     elif [[ $1 = --no-sigverify ]]; then
       args+=("$1")
       shift
+    elif [[ $1 = --limit-ledger-size ]]; then
+      args+=("$1")
+      shift
     elif [[ $1 = --rpc-port ]]; then
       args+=("$1" "$2")
       shift 2


### PR DESCRIPTION
#### Problems

- Current Column Family settings in rocks result in huge space amplification. We end up with tons of WAL logs sitting around that never get cleaned up. Based on the calculation here https://github.com/facebook/rocksdb/blob/808e429bd6d628d2bff94f064229bf6f4cabd732/include/rocksdb/options.h#L402 we would almost always end up with `[(512MB * 8) * 32] * 4 = 524.28 GB` of disk usage by just logs before a flush and compaction would kick in. This causes deletion of slots to have no real impact until the ledger's overall size crosses into the multiple TB range

- `purge_slots` is unsafe unless it purges multiple CFs simultaneously

#### Summary of Changes

Since we don't have `max_total_wal_size` in rust-rocksdb, the same behavior can be achieved by Column Family specific configuration for the less frequently used (and smaller) CFs.

- Reduced the overall write buffers for blocktree. Needs tuning with TPS, currently the less frequent CFs are setup with really small buffers to allow compaction to run more efficiently. Current WAL space usage should be `[(256MB * 2 + 64Kb * 6) * 8] * 4 = 16.39 GB`, i.e after total WAL size exceeds 16.4GB, the oldest CF that hasn't been flushed will be flushed. Allowing more efficient use of compaction. 

- Updated `purge_slots` to pruge in a write_batch. Function got a little bit messy but it is pretty straightforward

- Reduced MAX_LEDGER_SLOTS (when `--limit-ledger-size` is active) to 3 Epochs instead of 5.

- added `--limit-ledger-size` to fullnode.sh, still no documentation for this.

