### PR TITLE
Store Move account data in a deterministic order

### DIFF
--- a/programs/move_loader_api/.gitignore
+++ b/programs/move_loader_api/.gitignore
@@ -1,2 +1,3 @@
 /farf/
 /target/
+Cargo.lock

--- a/programs/move_loader_api/Cargo.toml
+++ b/programs/move_loader_api/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2018"
 [dependencies]
 bincode = "1.1.4"
 byteorder = "1.3.2"
+indexmap = "1.0.2"
 libc = "0.2.58"
 log = "0.4.2"
 serde = "1.0.94"


### PR DESCRIPTION
#### Problem

Libra account data is not being stored in a deterministic way and therefore those accounts cannot be used a credit-only accounts

#### Summary of Changes

Store the data deterministiically

Fixes #
