### PR TITLE
Fix poh recorder not flushing virtual ticks immediately

### DIFF
--- a/core/src/poh_recorder.rs
+++ b/core/src/poh_recorder.rs
@@ -1219,6 +1219,8 @@ mod tests {
                 false
             );
 
+            // Move the bank up a slot (so that max_tick_height > slot 0's tick_height)
+            let bank = Arc::new(Bank::new_from_parent(&bank, &Pubkey::default(), 1));
             // If we set the working bank, the node should be leader within next 2 slots
             poh_recorder.set_bank(&bank);
             assert_eq!(

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -876,6 +876,13 @@ impl Bank {
             .collect()
     }
 
+    pub fn check_hash_age(&self, hash: &Hash, max_age: usize) -> bool {
+        self.blockhash_queue
+            .read()
+            .unwrap()
+            .check_hash_age(hash, max_age)
+    }
+
     pub fn check_transactions(
         &self,
         txs: &[Transaction],


### PR DESCRIPTION
#### Problem

The problem that likely took town the TDS cluster exposes it self like so,  
1. While timing out a no-show leader for more than 1 slot, poh recorder can build up enough virtual ticks such that a bug is exposed. virtual ticks can't flush since it has no bank. 
2. When the node becomes a leader, poh recorder is finally given a bank
3. A tx goes through banking stage and passes the age check (this is the bug; there can be a tx using a blockhash that will be purged by the virtual ticks). 
4. banking stage calls `record` and poh flushes all the virtual ticks before recording the new tx (this is fine). 
5. Rest of the cluster sees `BlockhashNotFound` on any transaction that passed since flushing virtual ticks moved the tx's blockhash out of age range and the tx failed the age check when they were replaying the tx. 
6. all ledgers(including the leader's) will fail verify with `BlockhashNotFound`.

#### Summary of Changes

Make sure all virtual ticks are flushed as soon as poh recorder is given a bank.
This will block `set_bank` until the virtual ticks are written to the newly set bank. 

