### PR TITLE
wallet: Refuse to delegate stake to a vote account with a stale root slot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -360,22 +360,6 @@ version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "cbindgen"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.42 (registry+https://github.com/rust-lang/crates.io-index)",
- "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "toml 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "cc"
 version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3673,20 +3657,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-sdk-c"
-version = "0.18.0-pre0"
-dependencies = [
- "bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "bs58 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "cbindgen 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-ed25519-dalek 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-sdk 0.18.0-pre0",
-]
-
-[[package]]
 name = "solana-stake-api"
 version = "0.18.0-pre0"
 dependencies = [
@@ -5173,7 +5143,6 @@ dependencies = [
 "checksum bzip2-sys 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "6584aa36f5ad4c9247f5323b0a42f37802b37a836f0ad87084d7a33961abe25f"
 "checksum c2-chacha 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7d64d04786e0f528460fc884753cf8dddcc466be308f6026f8e355c41a0e4101"
 "checksum c_linked_list 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4964518bd3b4a8190e832886cdc0da9794f12e8e6c1613a9e90ff331c4c8724b"
-"checksum cbindgen 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0e7e19db9a3892c88c74cbbdcd218196068a928f1b60e736c448b13a1e81f277"
 "checksum cc 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)" = "ce400c638d48ee0e9ab75aef7997609ec57367ccfe1463f21bf53c3eca67bf46"
 "checksum cexpr 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "a7fa24eb00d5ffab90eaeaf1092ac85c04c64aaf358ea6f84505b8116d24c6af"
 "checksum cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "b486ce3ccf7ffd79fdeb678eac06a9e6c09fc88d33836340becb8fffe87c5e33"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,6 @@ members = [
     "bench-exchange",
     "bench-streamer",
     "bench-tps",
-    "sdk-c",
     "chacha-sys",
     "client",
     "core",

--- a/multinode-demo/delegate-stake.sh
+++ b/multinode-demo/delegate-stake.sh
@@ -28,6 +28,7 @@ OPTIONS:
                               multiple validators in the same workspace
   --no-airdrop              - Do not attempt to airdrop the stake
   --keypair FILE            - Keypair to fund the stake from
+  --force                   - Override delegate-stake sanity checks
 
 EOF
   exit 1
@@ -36,6 +37,7 @@ EOF
 common_args=()
 label=
 airdrops_enabled=1
+maybe_force=
 
 positional_args=()
 while [[ -n $1 ]]; do
@@ -45,6 +47,9 @@ while [[ -n $1 ]]; do
       shift 2
     elif [[ $1 = --keypair || $1 = -k ]]; then
       common_args+=("$1" "$2")
+      shift 2
+    elif [[ $1 = --force ]]; then
+      maybe_force=--force
       shift 2
     elif [[ $1 = --url || $1 = -u ]]; then
       url=$2
@@ -100,6 +105,6 @@ stake_pubkey=$($solana_keygen pubkey "$stake_keypair_path")
 
 set -x
 $solana_wallet "${common_args[@]}" \
-  delegate-stake "$stake_keypair_path" "$vote_pubkey" "$stake_lamports"
+  delegate-stake $maybe_force "$stake_keypair_path" "$vote_pubkey" "$stake_lamports"
 $solana_wallet "${common_args[@]}" show-stake-account "$stake_pubkey"
 

--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -261,7 +261,7 @@ local|tar|skip)
     waitForNodeToInit
 
     if [[ $skipSetup != true && $nodeType != blockstreamer ]]; then
-      ./multinode-demo/delegate-stake.sh $stake
+      ./multinode-demo/delegate-stake.sh --force $stake
     fi
     ;;
   replicator)


### PR DESCRIPTION
Delegating your stake to a vote account that is behind the tip of the cluster is a really bad idea.  Let's make wallet protect the user from this footgun.

TODO:
* [x] Fix multinode-demo/ scripts to not stake a validator before it boots
* [x] Maybe same ^^^ for net/remote/ scripts
* [x] Update testnet participation guide with details on how to properly stake