### PR TITLE
Replace TokenPair in exchange

### DIFF
--- a/bench-exchange/src/bench.rs
+++ b/bench-exchange/src/bench.rs
@@ -509,7 +509,7 @@ fn trader<T>(
     T: Client,
 {
     // TODO Hard coded for now
-    let pair = TokenPair::AB;
+    let pair = AssetPair::default();
     let tokens = 1;
     let price = 1000;
     let mut account_group: usize = 0;

--- a/programs/exchange_api/src/exchange_instruction.rs
+++ b/programs/exchange_api/src/exchange_instruction.rs
@@ -12,7 +12,7 @@ pub struct OrderRequestInfo {
     pub direction: Direction,
 
     /// Token pair to trade
-    pub pair: TokenPair,
+    pub pair: AssetPair,
 
     /// Number of tokens to exchange; refers to the primary or the secondary depending on the direction
     pub tokens: u64,
@@ -85,7 +85,7 @@ pub fn trade_request(
     owner: &Pubkey,
     trade: &Pubkey,
     direction: Direction,
-    pair: TokenPair,
+    pair: AssetPair,
     tokens: u64,
     price: u64,
     src_account: &Pubkey,

--- a/programs/exchange_api/src/exchange_processor.rs
+++ b/programs/exchange_api/src/exchange_processor.rs
@@ -64,8 +64,8 @@ impl ExchangeProcessor {
         // Turn trade order into token account
 
         let token = match trade.direction {
-            Direction::To => trade.pair.secondary(),
-            Direction::From => trade.pair.primary(),
+            Direction::To => trade.pair.Quote,
+            Direction::From => trade.pair.Base,
         };
 
         let mut account = TokenAccountInfo::default().owner(&trade.owner);
@@ -131,8 +131,8 @@ impl ExchangeProcessor {
 
         trace!("pp {} sp {}", primary_profit, secondary_profit);
 
-        let primary_token = to_trade.pair.primary();
-        let secondary_token = from_trade.pair.secondary();
+        let primary_token = to_trade.pair.Base;
+        let secondary_token = from_trade.pair.Quote;
 
         // Update tokens
 
@@ -225,8 +225,8 @@ impl ExchangeProcessor {
                     }
 
                     let from_token = match from_trade.direction {
-                        Direction::To => from_trade.pair.secondary(),
-                        Direction::From => from_trade.pair.primary(),
+                        Direction::To => from_trade.pair.Quote,
+                        Direction::From => from_trade.pair.Base,
                     };
                     if token != from_token {
                         error!("Trade to transfer from does not hold correct token");
@@ -281,8 +281,8 @@ impl ExchangeProcessor {
             Err(InstructionError::GenericError)?
         }
         let from_token = match info.direction {
-            Direction::To => info.pair.primary(),
-            Direction::From => info.pair.secondary(),
+            Direction::To => info.pair.Base,
+            Direction::From => info.pair.Quote,
         };
         if account.tokens[from_token] < info.tokens {
             error!("From token balance is too low");
@@ -332,8 +332,8 @@ impl ExchangeProcessor {
         }
 
         let token = match order.direction {
-            Direction::To => order.pair.primary(),
-            Direction::From => order.pair.secondary(),
+            Direction::To => order.pair.Base,
+            Direction::From => order.pair.Quote,
         };
 
         let mut account = TokenAccountInfo::default().owner(&order.owner);
@@ -603,7 +603,7 @@ mod test {
         client: &BankClient,
         owner: &Keypair,
         direction: Direction,
-        pair: TokenPair,
+        pair: AssetPair,
         from_token: Token,
         src_tokens: u64,
         trade_tokens: u64,
@@ -701,7 +701,7 @@ mod test {
             &client,
             &owner,
             Direction::To,
-            TokenPair::AB,
+            AssetPair::default(),
             Token::A,
             42,
             2,
@@ -717,7 +717,7 @@ mod test {
             OrderInfo {
                 owner: owner.pubkey(),
                 direction: Direction::To,
-                pair: TokenPair::AB,
+                pair: AssetPair::default(),
                 tokens: 2,
                 price: 1000,
                 tokens_settled: 0
@@ -743,7 +743,7 @@ mod test {
             &client,
             &owner,
             Direction::To,
-            TokenPair::AB,
+            AssetPair::default(),
             Token::A,
             2,
             2,
@@ -753,7 +753,7 @@ mod test {
             &client,
             &owner,
             Direction::From,
-            TokenPair::AB,
+            AssetPair::default(),
             Token::B,
             3,
             3,
@@ -776,7 +776,7 @@ mod test {
             OrderInfo {
                 owner: owner.pubkey(),
                 direction: Direction::To,
-                pair: TokenPair::AB,
+                pair: AssetPair::default(),
                 tokens: 1,
                 price: 2000,
                 tokens_settled: 2,
@@ -810,7 +810,7 @@ mod test {
             &client,
             &owner,
             Direction::To,
-            TokenPair::AB,
+            AssetPair::default(),
             Token::A,
             3,
             3,
@@ -820,7 +820,7 @@ mod test {
             &client,
             &owner,
             Direction::From,
-            TokenPair::AB,
+            AssetPair::default(),
             Token::B,
             3,
             3,

--- a/programs/exchange_api/src/exchange_state.rs
+++ b/programs/exchange_api/src/exchange_state.rs
@@ -76,32 +76,19 @@ impl std::ops::IndexMut<Token> for Tokens {
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[allow(non_snake_case)]
-pub enum TokenPair {
-    AB,
-    AC,
-    AD,
-    BC,
-    BD,
-    CD,
+pub struct AssetPair {
+    // represents a pair of two token enums that defines a market
+    pub Base: Token,
+    // "primary" token and numerator for pricing purposes
+    pub Quote: Token,
+    // "secondary" token and denominator for pricing purposes
 }
-impl Default for TokenPair {
-    fn default() -> Self {
-        TokenPair::AB
-    }
-}
-impl TokenPair {
-    pub fn primary(self) -> Token {
-        match self {
-            TokenPair::AB | TokenPair::AC | TokenPair::AD => Token::A,
-            TokenPair::BC | TokenPair::BD => Token::B,
-            TokenPair::CD => Token::C,
-        }
-    }
-    pub fn secondary(self) -> Token {
-        match self {
-            TokenPair::AB => Token::B,
-            TokenPair::AC | TokenPair::BC => Token::C,
-            TokenPair::AD | TokenPair::BD | TokenPair::CD => Token::D,
+
+impl Default for AssetPair {
+    fn default() -> AssetPair {
+        AssetPair {
+            Base: Token::A,
+            Quote: Token::B,
         }
     }
 }
@@ -114,6 +101,7 @@ pub struct TokenAccountInfo {
     /// Current number of tokens this account holds
     pub tokens: Tokens,
 }
+
 impl TokenAccountInfo {
     pub fn owner(mut self, owner: &Pubkey) -> Self {
         self.owner = *owner;
@@ -156,7 +144,7 @@ pub struct OrderInfo {
     /// Direction of the exchange
     pub direction: Direction,
     /// Token pair indicating two tokens to exchange, first is primary
-    pub pair: TokenPair,
+    pub pair: AssetPair,
     /// Number of tokens to exchange; primary or secondary depending on direction.  Once
     /// this number goes to zero this trade order will be converted into a regular token account
     pub tokens: u64,
@@ -171,7 +159,7 @@ impl Default for OrderInfo {
     fn default() -> Self {
         Self {
             owner: Pubkey::default(),
-            pair: TokenPair::AB,
+            pair: AssetPair::default(),
             direction: Direction::To,
             tokens: 0,
             price: 0,
@@ -180,7 +168,7 @@ impl Default for OrderInfo {
     }
 }
 impl OrderInfo {
-    pub fn pair(mut self, pair: TokenPair) -> Self {
+    pub fn pair(mut self, pair: AssetPair) -> Self {
         self.pair = pair;
         self
     }


### PR DESCRIPTION
#### Problem
Exchange Token Pair representation is sort of clunky and doesn't scale with number of tokens
Token is a somewhat overspecific asset class name

#### Summary of Changes
- Simplify the Token Pair representation:
  - make it a struct instead of an enum
  - rename fields
  - remove unnecessary accessors
- change use instances
- rename to AssetPair

