### PR TITLE
Default log level to to RUST_LOG=solana=info

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2605,9 +2605,9 @@ name = "solana-gossip"
 version = "0.17.0"
 dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana 0.17.0",
  "solana-client 0.17.0",
+ "solana-logger 0.17.0",
  "solana-netutil 0.17.0",
  "solana-sdk 0.17.0",
 ]

--- a/gossip/Cargo.toml
+++ b/gossip/Cargo.toml
@@ -10,9 +10,9 @@ homepage = "https://solana.com/"
 
 [dependencies]
 clap = "2.33.0"
-env_logger = "0.6.2"
 solana = { path = "../core", version = "0.17.0" }
 solana-client = { path = "../client", version = "0.17.0" }
+solana-logger = { path = "../logger", version = "0.17.0" }
 solana-netutil = { path = "../netutil", version = "0.17.0" }
 solana-sdk = { path = "../sdk", version = "0.17.0" }
 

--- a/gossip/src/main.rs
+++ b/gossip/src/main.rs
@@ -20,7 +20,7 @@ fn pubkey_validator(pubkey: String) -> Result<(), String> {
 }
 
 fn main() -> Result<(), Box<dyn error::Error>> {
-    env_logger::Builder::from_env(env_logger::Env::new().default_filter_or("solana=info")).init();
+    solana_logger::setup();
 
     let mut entrypoint_addr = SocketAddr::from(([127, 0, 0, 1], 8001));
     let entrypoint_string = entrypoint_addr.to_string();

--- a/logger/src/lib.rs
+++ b/logger/src/lib.rs
@@ -9,7 +9,7 @@ static INIT: Once = Once::new();
 /// Setup function that is only run once, even if called multiple times.
 pub fn setup() {
     INIT.call_once(|| {
-        env_logger::Builder::from_default_env()
+        env_logger::Builder::from_env(env_logger::Env::new().default_filter_or("solana=info"))
             .default_format_timestamp_nanos(true)
             .init();
     });

--- a/multinode-demo/common.sh
+++ b/multinode-demo/common.sh
@@ -60,7 +60,6 @@ solana_ledger_tool=$(solana_program ledger-tool)
 solana_wallet=$(solana_program wallet)
 solana_replicator=$(solana_program replicator)
 
-export RUST_LOG=${RUST_LOG:-solana=info} # if RUST_LOG is unset, default to info
 export RUST_BACKTRACE=1
 
 # shellcheck source=scripts/configure-metrics.sh


### PR DESCRIPTION
`solana-validator` outputs nothing by default.   The user needs to manually `export RUST_LOG=solana=info`, which is a pain.  

We don't see this internally because `multinode-demo/common.sh` previously setup a nice RUST_LOG default for us.

