### PR TITLE
Rewrite multinode-demo/replicator.sh to avoid fullnode.sh

### DIFF
--- a/multinode-demo/replicator.sh
+++ b/multinode-demo/replicator.sh
@@ -1,4 +1,85 @@
 #!/usr/bin/env bash
+#
+# A thin wrapper around `solana-replicator` that automatically provisions the
+# replicator's identity and/or storage keypair if not provided by the caller.
+#
+set -e
 
 here=$(dirname "$0")
-exec "$here"/fullnode.sh --replicator "$@"
+# shellcheck source=multinode-demo/common.sh
+source "$here"/common.sh
+
+entrypoint=127.0.0.0:8001
+label=
+
+while [[ -n $1 ]]; do
+  if [[ ${1:0:1} = - ]]; then
+    if [[ $1 = --entrypoint ]]; then
+      entrypoint=$2
+      args+=("$1" "$2")
+      shift 2
+    elif [[ $1 = --identity ]]; then
+      identity_keypair=$2
+      [[ -r $identity_keypair ]] || {
+        echo "$identity_keypair does not exist"
+        exit 1
+      }
+      args+=("$1" "$2")
+      shift 2
+    elif [[ $1 = --label ]]; then
+      label="-$2"
+      shift 2
+    elif [[ $1 = --ledger ]]; then
+      args+=("$1" "$2")
+      shift 2
+    elif [[ $1 = --storage-keypair ]]; then
+      storage_keypair=$2
+      [[ -r $storage_keypair ]] || {
+        echo "$storage_keypair does not exist"
+        exit 1
+      }
+      args+=("$1" "$2")
+      shift 2
+    else
+      echo "Unknown argument: $1"
+      $solana_replicator --help
+      exit 1
+    fi
+  else
+    echo "Unknown argument: $1"
+    $solana_replicator --help
+    exit 1
+  fi
+done
+
+: "${identity_keypair:="$SOLANA_ROOT"/farf/replicator-identity-keypair"$label".json}"
+: "${storage_keypair:="$SOLANA_ROOT"/farf/storage-keypair"$label".json}"
+ledger="$SOLANA_ROOT"/farf/replicator-ledger"$label"
+
+rpc_url=$("$here"/rpc-url.sh "$entrypoint")
+
+if [[ ! -r $identity_keypair ]]; then
+  $solana_keygen new -o "$identity_keypair"
+
+  # TODO: https://github.com/solana-labs/solminer/blob/9cd2289/src/replicator.js#L17-L18
+  $solana_wallet --keypair "$identity_keypair" --url "$rpc_url" \
+      airdrop 100000
+fi
+identity_pubkey=$($solana_keygen pubkey "$identity_keypair")
+
+if [[ ! -r $storage_keypair ]]; then
+  $solana_keygen new -o "$storage_keypair"
+  storage_pubkey=$($solana_keygen pubkey "$storage_keypair")
+
+  $solana_wallet --keypair "$identity_keypair" --url "$rpc_url" \
+    create-replicator-storage-account "$identity_pubkey" "$storage_pubkey"
+fi
+
+default_arg --entrypoint "$entrypoint"
+default_arg --identity "$identity_keypair"
+default_arg --storage-keypair "$storage_keypair"
+default_arg --ledger "$ledger"
+
+set -x
+# shellcheck disable=SC2086 # Don't want to double quote $solana_replicator
+exec $solana_replicator "${args[@]}"

--- a/multinode-demo/rpc-url.sh
+++ b/multinode-demo/rpc-url.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+#
+# Given a gossip entrypoint derive the entrypoint's RPC address
+#
+
+entrypoint_address=$1
+if [[ -z $entrypoint_address ]]; then
+  echo "Error: entrypoint address not specified" >&2
+  exit 1
+fi
+
+# TODO: Rather than hard coding, add a `solana-gossip rpc-address` command that
+#       actually asks the entrypoint itself for its RPC address
+echo "http://${entrypoint_address%:*}:8899"

--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -273,22 +273,16 @@ local|tar|skip)
     fi
 
     args=(
-      "$entrypointIp":~/solana "$entrypointIp:8001"
+      --entrypoint "$entrypointIp:8001"
     )
 
     if [[ $airdropsEnabled != true ]]; then
-      args+=(--no-airdrop)
+      echo "TODO: replicators not supported without airdrops"
+      # TODO: need to provide the `--identity` argument to an existing system
+      #       account with lamports in it
+      exit 1
     fi
 
-    if [[ -n $internalNodesLamports ]] ; then
-      args+=(--node-lamports "$internalNodesLamports")
-    fi
-
-    if [[ $skipSetup != true ]]; then
-      ./multinode-demo/clear-config.sh
-    fi
-    # shellcheck disable=SC2206 # Don't want to double quote $extraNodeArgs
-    args+=($extraNodeArgs)
     nohup ./multinode-demo/replicator.sh "${args[@]}" > fullnode.log 2>&1 &
     sleep 1
     ;;


### PR DESCRIPTION
`fullnode.sh` is unmaintainable and presents a different cli interface than the Rust programs it wraps.

This PR moves us in the right direction by removing replicator support from fullnode.sh, and modifying the cli interface of multinode-demo/replicator.sh to be a minor superset of what `solana-replicator` provides.   

`replicator.sh` will optionally setup keys and airdrop for you, useful for development, but otherwise aims to be identical in behavior to `solana-replicator`.
