### PR TITLE
ci: Move coverage back to the default queue

### DIFF
--- a/ci/buildkite.yml
+++ b/ci/buildkite.yml
@@ -22,8 +22,6 @@ steps:
   - command: ". ci/rust-version.sh; ci/docker-run.sh $$rust_nightly_docker_image ci/test-coverage.sh"
     name: "coverage"
     timeout_in_minutes: 40
-    agents:
-        - "queue=cuda"
   # TODO: Fix and re-enable test-large-network.sh
   # - command: "ci/test-large-network.sh || true"
   #   name: "large-network [ignored]"


### PR DESCRIPTION
The CPU-only CI machines have been resized 2x.  (32GB RAM, 8 CPU cores)