### PR TITLE
Forward transactions as packets instead of blobs

### DIFF
--- a/core/src/cluster_info.rs
+++ b/core/src/cluster_info.rs
@@ -1464,7 +1464,7 @@ pub struct Sockets {
     pub gossip: UdpSocket,
     pub tvu: Vec<UdpSocket>,
     pub tpu: Vec<UdpSocket>,
-    pub tpu_via_blobs: Vec<UdpSocket>,
+    pub tpu_forwards: Vec<UdpSocket>,
     pub broadcast: UdpSocket,
     pub repair: UdpSocket,
     pub retransmit: UdpSocket,
@@ -1509,7 +1509,7 @@ impl Node {
                 gossip,
                 tvu: vec![tvu],
                 tpu: vec![],
-                tpu_via_blobs: vec![],
+                tpu_forwards: vec![],
                 broadcast,
                 repair,
                 retransmit,
@@ -1521,7 +1521,7 @@ impl Node {
         let tpu = UdpSocket::bind("127.0.0.1:0").unwrap();
         let gossip = UdpSocket::bind("127.0.0.1:0").unwrap();
         let tvu = UdpSocket::bind("127.0.0.1:0").unwrap();
-        let tpu_via_blobs = UdpSocket::bind("127.0.0.1:0").unwrap();
+        let tpu_forwards = UdpSocket::bind("127.0.0.1:0").unwrap();
         let repair = UdpSocket::bind("127.0.0.1:0").unwrap();
         let rpc_port = find_available_port_in_range((1024, 65535)).unwrap();
         let rpc_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), rpc_port);
@@ -1537,7 +1537,7 @@ impl Node {
             gossip.local_addr().unwrap(),
             tvu.local_addr().unwrap(),
             tpu.local_addr().unwrap(),
-            tpu_via_blobs.local_addr().unwrap(),
+            tpu_forwards.local_addr().unwrap(),
             storage.local_addr().unwrap(),
             rpc_addr,
             rpc_pubsub_addr,
@@ -1549,7 +1549,7 @@ impl Node {
                 gossip,
                 tvu: vec![tvu],
                 tpu: vec![tpu],
-                tpu_via_blobs: vec![tpu_via_blobs],
+                tpu_forwards: vec![tpu_forwards],
                 broadcast,
                 repair,
                 retransmit,
@@ -1583,7 +1583,7 @@ impl Node {
 
         let (tpu_port, tpu_sockets) = multi_bind_in_range(port_range, 32).expect("tpu multi_bind");
 
-        let (tpu_via_blobs_port, tpu_via_blobs_sockets) =
+        let (tpu_forwards_port, tpu_forwards_sockets) =
             multi_bind_in_range(port_range, 8).expect("tpu multi_bind");
 
         let (_, repair) = Self::bind(port_range);
@@ -1595,7 +1595,7 @@ impl Node {
             SocketAddr::new(gossip_addr.ip(), gossip_port),
             SocketAddr::new(gossip_addr.ip(), tvu_port),
             SocketAddr::new(gossip_addr.ip(), tpu_port),
-            SocketAddr::new(gossip_addr.ip(), tpu_via_blobs_port),
+            SocketAddr::new(gossip_addr.ip(), tpu_forwards_port),
             socketaddr_any!(),
             socketaddr_any!(),
             socketaddr_any!(),
@@ -1609,7 +1609,7 @@ impl Node {
                 gossip,
                 tvu: tvu_sockets,
                 tpu: tpu_sockets,
-                tpu_via_blobs: tpu_via_blobs_sockets,
+                tpu_forwards: tpu_forwards_sockets,
                 broadcast,
                 repair,
                 retransmit,
@@ -1630,9 +1630,9 @@ impl Node {
 
         let empty = socketaddr_any!();
         new.info.tpu = empty;
-        new.info.tpu_via_blobs = empty;
+        new.info.tpu_forwards = empty;
         new.sockets.tpu = vec![];
-        new.sockets.tpu_via_blobs = vec![];
+        new.sockets.tpu_forwards = vec![];
 
         new
     }

--- a/core/src/contact_info.rs
+++ b/core/src/contact_info.rs
@@ -106,7 +106,7 @@ impl ContactInfo {
             gossip,
             tvu,
             tpu,
-            tpu_forwards: tpu_forwards,
+            tpu_forwards,
             storage_addr,
             rpc,
             rpc_pubsub,

--- a/core/src/contact_info.rs
+++ b/core/src/contact_info.rs
@@ -23,7 +23,7 @@ pub struct ContactInfo {
     /// transactions address
     pub tpu: SocketAddr,
     /// address to forward unprocessed transactions to
-    pub tpu_via_blobs: SocketAddr,
+    pub tpu_forwards: SocketAddr,
     /// storage data address
     pub storage_addr: SocketAddr,
     /// address to which to send JSON-RPC requests
@@ -78,7 +78,7 @@ impl Default for ContactInfo {
             gossip: socketaddr_any!(),
             tvu: socketaddr_any!(),
             tpu: socketaddr_any!(),
-            tpu_via_blobs: socketaddr_any!(),
+            tpu_forwards: socketaddr_any!(),
             storage_addr: socketaddr_any!(),
             rpc: socketaddr_any!(),
             rpc_pubsub: socketaddr_any!(),
@@ -94,7 +94,7 @@ impl ContactInfo {
         gossip: SocketAddr,
         tvu: SocketAddr,
         tpu: SocketAddr,
-        tpu_via_blobs: SocketAddr,
+        tpu_forwards: SocketAddr,
         storage_addr: SocketAddr,
         rpc: SocketAddr,
         rpc_pubsub: SocketAddr,
@@ -106,7 +106,7 @@ impl ContactInfo {
             gossip,
             tvu,
             tpu,
-            tpu_via_blobs,
+            tpu_forwards: tpu_forwards,
             storage_addr,
             rpc,
             rpc_pubsub,
@@ -157,7 +157,7 @@ impl ContactInfo {
         let tpu_addr = *bind_addr;
         let gossip_addr = next_port(&bind_addr, 1);
         let tvu_addr = next_port(&bind_addr, 2);
-        let tpu_via_blobs_addr = next_port(&bind_addr, 3);
+        let tpu_forwards_addr = next_port(&bind_addr, 3);
         let rpc_addr = SocketAddr::new(bind_addr.ip(), rpc_port::DEFAULT_RPC_PORT);
         let rpc_pubsub_addr = SocketAddr::new(bind_addr.ip(), rpc_port::DEFAULT_RPC_PUBSUB_PORT);
         Self::new(
@@ -165,7 +165,7 @@ impl ContactInfo {
             gossip_addr,
             tvu_addr,
             tpu_addr,
-            tpu_via_blobs_addr,
+            tpu_forwards_addr,
             "0.0.0.0:0".parse().unwrap(),
             rpc_addr,
             rpc_pubsub_addr,
@@ -233,7 +233,7 @@ impl Signable for ContactInfo {
             gossip: SocketAddr,
             tvu: SocketAddr,
             tpu: SocketAddr,
-            tpu_via_blobs: SocketAddr,
+            tpu_forwards: SocketAddr,
             storage_addr: SocketAddr,
             rpc: SocketAddr,
             rpc_pubsub: SocketAddr,
@@ -247,7 +247,7 @@ impl Signable for ContactInfo {
             tvu: me.tvu,
             tpu: me.tpu,
             storage_addr: me.storage_addr,
-            tpu_via_blobs: me.tpu_via_blobs,
+            tpu_forwards: me.tpu_forwards,
             rpc: me.rpc,
             rpc_pubsub: me.rpc_pubsub,
             wallclock: me.wallclock,
@@ -287,7 +287,7 @@ mod tests {
         let ci = ContactInfo::default();
         assert!(ci.gossip.ip().is_unspecified());
         assert!(ci.tvu.ip().is_unspecified());
-        assert!(ci.tpu_via_blobs.ip().is_unspecified());
+        assert!(ci.tpu_forwards.ip().is_unspecified());
         assert!(ci.rpc.ip().is_unspecified());
         assert!(ci.rpc_pubsub.ip().is_unspecified());
         assert!(ci.tpu.ip().is_unspecified());
@@ -298,7 +298,7 @@ mod tests {
         let ci = ContactInfo::new_multicast();
         assert!(ci.gossip.ip().is_multicast());
         assert!(ci.tvu.ip().is_multicast());
-        assert!(ci.tpu_via_blobs.ip().is_multicast());
+        assert!(ci.tpu_forwards.ip().is_multicast());
         assert!(ci.rpc.ip().is_multicast());
         assert!(ci.rpc_pubsub.ip().is_multicast());
         assert!(ci.tpu.ip().is_multicast());
@@ -310,7 +310,7 @@ mod tests {
         let ci = ContactInfo::new_gossip_entry_point(&addr);
         assert_eq!(ci.gossip, addr);
         assert!(ci.tvu.ip().is_unspecified());
-        assert!(ci.tpu_via_blobs.ip().is_unspecified());
+        assert!(ci.tpu_forwards.ip().is_unspecified());
         assert!(ci.rpc.ip().is_unspecified());
         assert!(ci.rpc_pubsub.ip().is_unspecified());
         assert!(ci.tpu.ip().is_unspecified());
@@ -323,7 +323,7 @@ mod tests {
         assert_eq!(ci.tpu, addr);
         assert_eq!(ci.gossip.port(), 11);
         assert_eq!(ci.tvu.port(), 12);
-        assert_eq!(ci.tpu_via_blobs.port(), 13);
+        assert_eq!(ci.tpu_forwards.port(), 13);
         assert_eq!(ci.rpc.port(), 8899);
         assert_eq!(ci.rpc_pubsub.port(), 8900);
         assert!(ci.storage_addr.ip().is_unspecified());
@@ -338,7 +338,7 @@ mod tests {
         assert_eq!(d1.id, keypair.pubkey());
         assert_eq!(d1.gossip, socketaddr!("127.0.0.1:1235"));
         assert_eq!(d1.tvu, socketaddr!("127.0.0.1:1236"));
-        assert_eq!(d1.tpu_via_blobs, socketaddr!("127.0.0.1:1237"));
+        assert_eq!(d1.tpu_forwards, socketaddr!("127.0.0.1:1237"));
         assert_eq!(d1.tpu, socketaddr!("127.0.0.1:1234"));
         assert_eq!(d1.rpc, socketaddr!("127.0.0.1:8899"));
         assert_eq!(d1.rpc_pubsub, socketaddr!("127.0.0.1:8900"));

--- a/core/src/streamer.rs
+++ b/core/src/streamer.rs
@@ -134,46 +134,6 @@ pub fn blob_receiver(
         .unwrap()
 }
 
-fn recv_blob_packets(sock: &UdpSocket, s: &PacketSender, recycler: &PacketsRecycler) -> Result<()> {
-    trace!(
-        "recv_blob_packets: receiving on {}",
-        sock.local_addr().unwrap()
-    );
-
-    let blobs = Blob::recv_from(sock)?;
-    for blob in blobs {
-        let mut packets =
-            Packets::new_with_recycler(recycler.clone(), PACKETS_PER_BLOB, "recv_blob_packets");
-        blob.read().unwrap().load_packets(&mut packets.packets);
-        s.send(packets)?;
-    }
-
-    Ok(())
-}
-
-pub fn blob_packet_receiver(
-    sock: Arc<UdpSocket>,
-    exit: &Arc<AtomicBool>,
-    s: PacketSender,
-) -> JoinHandle<()> {
-    //DOCUMENTED SIDE-EFFECT
-    //1 second timeout on socket read
-    let timer = Duration::new(1, 0);
-    sock.set_read_timeout(Some(timer))
-        .expect("set socket timeout");
-    let exit = exit.clone();
-    let recycler = PacketsRecycler::default();
-    Builder::new()
-        .name("solana-blob_packet_receiver".to_string())
-        .spawn(move || loop {
-            if exit.load(Ordering::Relaxed) {
-                break;
-            }
-            let _ = recv_blob_packets(&sock, &s, &recycler);
-        })
-        .unwrap()
-}
-
 #[cfg(test)]
 mod test {
     use super::*;

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -33,7 +33,7 @@ impl Tpu {
         poh_recorder: &Arc<Mutex<PohRecorder>>,
         entry_receiver: Receiver<WorkingBankEntries>,
         transactions_sockets: Vec<UdpSocket>,
-        tpu_via_blobs_sockets: Vec<UdpSocket>,
+        tpu_forwards_sockets: Vec<UdpSocket>,
         broadcast_socket: UdpSocket,
         sigverify_disabled: bool,
         blocktree: &Arc<Blocktree>,
@@ -44,7 +44,7 @@ impl Tpu {
         let (packet_sender, packet_receiver) = channel();
         let fetch_stage = FetchStage::new_with_sender(
             transactions_sockets,
-            tpu_via_blobs_sockets,
+            tpu_forwards_sockets,
             &exit,
             &packet_sender,
             &poh_recorder,

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -267,7 +267,7 @@ impl Validator {
             &poh_recorder,
             entry_receiver,
             node.sockets.tpu,
-            node.sockets.tpu_via_blobs,
+            node.sockets.tpu_forwards,
             node.sockets.broadcast,
             config.sigverify_disabled,
             &blocktree,


### PR DESCRIPTION
#### Problem
The transactions are forwarded as blobs. With a lot of forwarded transactions, the blob size can get larger than MTU. In high packet drop networks, the chances of dropping of a big UDP packet increases significantly. 

#### Summary of Changes
Forward transactions in packets, as originally sent by the client.

#5294 