### PR TITLE
Refactor status cache and remove complex serialize/deserialize

### DIFF
--- a/core/src/bank_forks.rs
+++ b/core/src/bank_forks.rs
@@ -565,7 +565,7 @@ mod tests {
             mint_keypair,
             ..
         } = create_genesis_block(10_000);
-        let last_slot = 256;
+        let last_slot = 4;
         let bank0 = Bank::new_with_paths(
             &genesis_block,
             Some(accounts_dir.path().to_str().unwrap().to_string()),
@@ -641,7 +641,7 @@ mod tests {
             mint_keypair,
             ..
         } = create_genesis_block(10_000);
-        let last_slot = 64;
+        let last_slot = 256;
         let bank0 = Bank::new_with_paths(
             &genesis_block,
             Some(accounts_dir.path().to_str().unwrap().to_string()),

--- a/core/src/bank_forks.rs
+++ b/core/src/bank_forks.rs
@@ -212,7 +212,7 @@ impl BankForks {
 
         // Generate a snapshot if snapshots are configured and it's been an appropriate number
         // of banks since the last snapshot
-        if self.snapshot_config.is_some() {
+        if self.snapshot_config.is_some() && snapshot_package_sender.is_some() {
             let config = self
                 .snapshot_config
                 .as_ref()
@@ -410,7 +410,7 @@ mod tests {
     use crate::snapshot_package::SnapshotPackagerService;
     use fs_extra::dir::CopyOptions;
     use itertools::Itertools;
-    use solana_sdk::hash::Hash;
+    use solana_sdk::hash::{hashv, Hash};
     use solana_sdk::pubkey::Pubkey;
     use solana_sdk::signature::{Keypair, KeypairUtil};
     use solana_sdk::system_transaction;
@@ -565,60 +565,144 @@ mod tests {
             mint_keypair,
             ..
         } = create_genesis_block(10_000);
-        for index in 0..4 {
-            let bank0 = Bank::new_with_paths(
-                &genesis_block,
-                Some(accounts_dir.path().to_str().unwrap().to_string()),
+        let last_slot = 256;
+        let bank0 = Bank::new_with_paths(
+            &genesis_block,
+            Some(accounts_dir.path().to_str().unwrap().to_string()),
+        );
+        bank0.freeze();
+        let mut bank_forks = BankForks::new(0, bank0);
+        let snapshot_config = SnapshotConfig::new(
+            PathBuf::from(snapshot_dir.path()),
+            PathBuf::from(snapshot_output_path.path()),
+            100,
+        );
+        bank_forks.set_snapshot_config(snapshot_config.clone());
+        let bank0 = bank_forks.get(0).unwrap();
+        snapshot_utils::add_snapshot(&snapshot_config.snapshot_path, bank0, &vec![]).unwrap();
+        for forks in 0..last_slot {
+            let bank = Bank::new_from_parent(&bank_forks[forks], &Pubkey::default(), forks + 1);
+            let key1 = Keypair::new().pubkey();
+            let tx = system_transaction::create_user_account(
+                &mint_keypair,
+                &key1,
+                1,
+                genesis_block.hash(),
             );
-            bank0.freeze();
-            let mut bank_forks = BankForks::new(0, bank0);
-            let snapshot_config = SnapshotConfig::new(
-                PathBuf::from(snapshot_dir.path()),
-                PathBuf::from(snapshot_output_path.path()),
-                100,
-            );
-            bank_forks.set_snapshot_config(snapshot_config.clone());
-            let bank0 = bank_forks.get(0).unwrap();
-            snapshot_utils::add_snapshot(&snapshot_config.snapshot_path, bank0, &vec![]).unwrap();
-            for forks in 0..index {
-                let bank = Bank::new_from_parent(&bank_forks[forks], &Pubkey::default(), forks + 1);
-                let key1 = Keypair::new().pubkey();
-                let tx = system_transaction::create_user_account(
-                    &mint_keypair,
-                    &key1,
-                    1,
-                    genesis_block.hash(),
-                );
-                assert_eq!(bank.process_transaction(&tx), Ok(()));
-                bank.freeze();
-                snapshot_utils::add_snapshot(
-                    &snapshot_config.snapshot_path,
-                    &bank,
-                    &(0..=bank.slot()).collect::<Vec<_>>(),
-                )
-                .unwrap();
-                bank_forks.insert(bank);
-            }
-            // Generate a snapshot package for last bank
-            let last_bank = bank_forks.get(index.saturating_sub(1)).unwrap();
-            let slot_snapshot_paths =
-                snapshot_utils::get_snapshot_paths(&snapshot_config.snapshot_path);
-            let snapshot_package = snapshot_utils::package_snapshot(
-                last_bank,
-                &slot_snapshot_paths,
-                snapshot_utils::get_snapshot_tar_path(
-                    &snapshot_config.snapshot_package_output_path,
-                ),
+            assert_eq!(bank.process_transaction(&tx), Ok(()));
+            bank.freeze();
+            snapshot_utils::add_snapshot(
+                &snapshot_config.snapshot_path,
+                &bank,
+                &(vec![bank.slot()]),
             )
             .unwrap();
-            SnapshotPackagerService::package_snapshots(&snapshot_package).unwrap();
-
-            restore_from_snapshot(
-                bank_forks,
-                accounts_dir.path().to_str().unwrap().to_string(),
-                index,
-            );
+            bank_forks.insert(bank);
         }
+        // Generate a snapshot package for last bank
+        let last_bank = bank_forks.get(last_slot).unwrap();
+        let slot_snapshot_paths =
+            snapshot_utils::get_snapshot_paths(&snapshot_config.snapshot_path);
+        let snapshot_package = snapshot_utils::package_snapshot(
+            last_bank,
+            &slot_snapshot_paths,
+            snapshot_utils::get_snapshot_tar_path(&snapshot_config.snapshot_package_output_path),
+        )
+        .unwrap();
+        SnapshotPackagerService::package_snapshots(&snapshot_package).unwrap();
+
+        restore_from_snapshot(
+            bank_forks,
+            accounts_dir.path().to_str().unwrap().to_string(),
+            last_slot,
+        );
+    }
+
+    fn goto_end_of_slot(bank: &mut Bank) {
+        let mut tick_hash = bank.last_blockhash();
+        loop {
+            tick_hash = hashv(&[&tick_hash.as_ref(), &[42]]);
+            bank.register_tick(&tick_hash);
+            if tick_hash == bank.last_blockhash() {
+                bank.freeze();
+                return;
+            }
+        }
+    }
+
+    #[test]
+    fn test_bank_forks_status_cache_snapshot_n() {
+        solana_logger::setup();
+        let accounts_dir = TempDir::new().unwrap();
+        let snapshot_dir = TempDir::new().unwrap();
+        let snapshot_output_path = TempDir::new().unwrap();
+        let GenesisBlockInfo {
+            genesis_block,
+            mint_keypair,
+            ..
+        } = create_genesis_block(10_000);
+        let last_slot = 64;
+        let bank0 = Bank::new_with_paths(
+            &genesis_block,
+            Some(accounts_dir.path().to_str().unwrap().to_string()),
+        );
+        bank0.freeze();
+        let mut bank_forks = BankForks::new(0, bank0);
+        let snapshot_config = SnapshotConfig::new(
+            PathBuf::from(snapshot_dir.path()),
+            PathBuf::from(snapshot_output_path.path()),
+            100,
+        );
+        bank_forks.set_snapshot_config(snapshot_config.clone());
+        let bank0 = bank_forks.get(0).unwrap();
+        snapshot_utils::add_snapshot(&snapshot_config.snapshot_path, bank0, &vec![]).unwrap();
+        let key1 = Keypair::new().pubkey();
+        let key2 = Keypair::new().pubkey();
+        for slot in 0..last_slot {
+            let mut bank = Bank::new_from_parent(&bank_forks[slot], &Pubkey::default(), slot + 1);
+            let tx = system_transaction::transfer(
+                &mint_keypair,
+                &key1,
+                1,
+                bank_forks[slot].last_blockhash(),
+            );
+            assert_eq!(bank.process_transaction(&tx), Ok(()));
+            let tx = system_transaction::transfer(
+                &mint_keypair,
+                &key2,
+                1,
+                bank_forks[slot].last_blockhash(),
+            );
+            assert_eq!(bank.process_transaction(&tx), Ok(()));
+            goto_end_of_slot(&mut bank);
+            let bank = bank_forks.insert(bank);
+            // set root to make sure we don't end up with too many account storage entries
+            // and to allow purging logic on status_cache to kick in
+            bank_forks.set_root(bank.slot(), &None);
+            snapshot_utils::add_snapshot(
+                &snapshot_config.snapshot_path,
+                &bank,
+                &(vec![bank.slot()]),
+            )
+            .unwrap();
+        }
+        // Generate a snapshot package for last bank
+        let last_bank = bank_forks.get(last_slot).unwrap();
+        let slot_snapshot_paths =
+            snapshot_utils::get_snapshot_paths(&snapshot_config.snapshot_path);
+        let snapshot_package = snapshot_utils::package_snapshot(
+            last_bank,
+            &slot_snapshot_paths,
+            snapshot_utils::get_snapshot_tar_path(&snapshot_config.snapshot_package_output_path),
+        )
+        .unwrap();
+        SnapshotPackagerService::package_snapshots(&snapshot_package).unwrap();
+
+        restore_from_snapshot(
+            bank_forks,
+            accounts_dir.path().to_str().unwrap().to_string(),
+            last_slot,
+        );
     }
 
     #[test]

--- a/core/src/bank_forks.rs
+++ b/core/src/bank_forks.rs
@@ -554,6 +554,10 @@ mod tests {
         }
     }
 
+    // creates banks upto "last_slot" and runs the input function `f` on each bank created
+    // also marks each bank as root and generates snapshots
+    // finally tries to restore from the last bank's snapshot and compares the restored bank to the
+    // `last_slot` bank
     fn run_bank_forks_snapshot_n<F>(last_slot: u64, f: F)
     where
         F: Fn(&mut Bank, &Keypair),
@@ -616,6 +620,8 @@ mod tests {
 
     #[test]
     fn test_bank_forks_snapshot_n() {
+        // create banks upto slot 4 and create 1 new account in each bank. test that bank 4 snapshots
+        // and restores correctly
         run_bank_forks_snapshot_n(4, |bank, mint_keypair| {
             let key1 = Keypair::new().pubkey();
             let tx = system_transaction::create_user_account(
@@ -643,6 +649,10 @@ mod tests {
 
     #[test]
     fn test_bank_forks_status_cache_snapshot_n() {
+        // create banks upto slot 256 while transferring 1 lamport into 2 different accounts each time
+        // this is done to ensure the AccountStorageEntries keep getting cleaned up as the root moves
+        // ahead. Also tests the status_cache purge and status cache snapshotting.
+        // Makes sure that the last bank is restored correctly
         let key1 = Keypair::new().pubkey();
         let key2 = Keypair::new().pubkey();
         run_bank_forks_snapshot_n(256, |bank, mint_keypair| {

--- a/core/src/snapshot_utils.rs
+++ b/core/src/snapshot_utils.rs
@@ -3,16 +3,54 @@ use crate::snapshot_package::SnapshotPackage;
 use bincode::{deserialize_from, serialize_into};
 use flate2::read::GzDecoder;
 use solana_runtime::bank::Bank;
+use solana_runtime::status_cache::SlotDelta;
+use solana_sdk::transaction;
+use std::cmp::Ordering;
 use std::fs;
 use std::fs::File;
 use std::io::{BufReader, BufWriter, Error as IOError, ErrorKind};
 use std::path::{Path, PathBuf};
 use tar::Archive;
 
-pub fn package_snapshot<P: AsRef<Path>, Q: AsRef<Path>>(
+const SNAPSHOT_STATUS_CACHE_FILE_NAME: &str = "status_cache";
+
+#[derive(PartialEq, Ord, Eq, Debug)]
+pub struct SlotSnapshotPaths {
+    pub slot: u64,
+    pub snapshot_file_path: PathBuf,
+    pub snapshot_status_cache_path: PathBuf,
+}
+
+impl PartialOrd for SlotSnapshotPaths {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.slot.cmp(&other.slot))
+    }
+}
+
+impl SlotSnapshotPaths {
+    fn hardlink_snapshot_directory<P: AsRef<Path>>(&self, snapshot_hardlink_dir: P) -> Result<()> {
+        // Create a new directory in snapshot_hardlink_dir
+        let new_slot_hardlink_dir = snapshot_hardlink_dir.as_ref().join(self.slot.to_string());
+        let _ = fs::remove_dir_all(&new_slot_hardlink_dir);
+        fs::create_dir_all(&new_slot_hardlink_dir)?;
+
+        // Hardlink the snapshot
+        fs::hard_link(
+            &self.snapshot_file_path,
+            &new_slot_hardlink_dir.join(self.slot.to_string()),
+        )?;
+        // Hardlink the status cache
+        fs::hard_link(
+            &self.snapshot_status_cache_path,
+            &new_slot_hardlink_dir.join(SNAPSHOT_STATUS_CACHE_FILE_NAME),
+        )?;
+        Ok(())
+    }
+}
+
+pub fn package_snapshot<Q: AsRef<Path>>(
     bank: &Bank,
-    snapshot_names: &[u64],
-    snapshot_dir: P,
+    snapshot_files: &[SlotSnapshotPaths],
     snapshot_package_output_file: Q,
 ) -> Result<SnapshotPackage> {
     let slot = bank.slot();
@@ -46,15 +84,15 @@ pub fn package_snapshot<P: AsRef<Path>, Q: AsRef<Path>>(
 
     // Any errors from this point on will cause the above SnapshotPackage to drop, clearing
     // any temporary state created for the SnapshotPackage (like the snapshot_hard_links_dir)
-    for name in snapshot_names {
-        hardlink_snapshot_directory(&snapshot_dir, &snapshot_hard_links_dir, *name)?;
+    for files in snapshot_files {
+        files.hardlink_snapshot_directory(&snapshot_hard_links_dir)?;
     }
 
     Ok(package)
 }
 
-pub fn get_snapshot_names<P: AsRef<Path>>(snapshot_path: P) -> Vec<u64> {
-    let paths = fs::read_dir(snapshot_path).expect("Invalid snapshot path");
+pub fn get_snapshot_paths<P: AsRef<Path>>(snapshot_path: P) -> Vec<SlotSnapshotPaths> {
+    let paths = fs::read_dir(&snapshot_path).expect("Invalid snapshot path");
     let mut names = paths
         .filter_map(|entry| {
             entry.ok().and_then(|e| {
@@ -64,37 +102,64 @@ pub fn get_snapshot_names<P: AsRef<Path>>(snapshot_path: P) -> Vec<u64> {
                     .unwrap_or(None)
             })
         })
-        .collect::<Vec<u64>>();
+        .map(|slot| {
+            let snapshot_path = snapshot_path.as_ref().join(slot.to_string());
+            SlotSnapshotPaths {
+                slot,
+                snapshot_file_path: snapshot_path.join(get_snapshot_file_name(slot)),
+                snapshot_status_cache_path: snapshot_path.join(SNAPSHOT_STATUS_CACHE_FILE_NAME),
+            }
+        })
+        .collect::<Vec<SlotSnapshotPaths>>();
 
     names.sort();
     names
 }
 
-pub fn add_snapshot<P: AsRef<Path>>(snapshot_path: P, bank: &Bank) -> Result<()> {
+pub fn add_snapshot<P: AsRef<Path>>(
+    snapshot_path: P,
+    bank: &Bank,
+    slots_since_snapshot: &[u64],
+) -> Result<()> {
     let slot = bank.slot();
+    // snapshot_path/slot
     let slot_snapshot_dir = get_bank_snapshot_dir(snapshot_path, slot);
     fs::create_dir_all(slot_snapshot_dir.clone()).map_err(Error::from)?;
 
+    // the snapshot is stored as snapshot_path/slot/slot
     let snapshot_file_path = slot_snapshot_dir.join(get_snapshot_file_name(slot));
+    // the status cache is stored as snapshot_path/slot/slot_satus_cache
+    let snapshot_status_cache_file_path = slot_snapshot_dir.join(SNAPSHOT_STATUS_CACHE_FILE_NAME);
     info!(
-        "creating snapshot {}, path: {:?}",
+        "creating snapshot {}, path: {:?} status_cache: {:?}",
         bank.slot(),
-        snapshot_file_path
+        snapshot_file_path,
+        snapshot_status_cache_file_path
     );
-    let file = File::create(&snapshot_file_path)?;
-    let mut stream = BufWriter::new(file);
+    let snapshot_file = File::create(&snapshot_file_path)?;
+    // snapshot writer
+    let mut snapshot_stream = BufWriter::new(snapshot_file);
+    let status_cache = File::create(&snapshot_status_cache_file_path)?;
+    // status cache writer
+    let mut status_cache_stream = BufWriter::new(status_cache);
 
     // Create the snapshot
-    serialize_into(&mut stream, &*bank).map_err(|e| get_io_error(&e.to_string()))?;
-    serialize_into(&mut stream, &bank.rc).map_err(|e| get_io_error(&e.to_string()))?;
-    // TODO: Add status cache serialization code
-    /*serialize_into(&mut stream, &bank.src).map_err(|e| get_io_error(&e.to_string()))?;*/
+    serialize_into(&mut snapshot_stream, &*bank).map_err(|e| get_io_error(&e.to_string()))?;
+    serialize_into(&mut snapshot_stream, &bank.rc).map_err(|e| get_io_error(&e.to_string()))?;
+    // write the status cache
+    serialize_into(
+        &mut status_cache_stream,
+        &bank.src.slot_deltas(slots_since_snapshot),
+    )
+    .map_err(|_| get_io_error("serialize bank status cache error"))?;
 
     info!(
-        "successfully created snapshot {}, path: {:?}",
+        "successfully created snapshot {}, path: {:?} status_cache: {:?}",
         bank.slot(),
-        snapshot_file_path
+        snapshot_file_path,
+        snapshot_status_cache_file_path
     );
+
     Ok(())
 }
 
@@ -105,25 +170,20 @@ pub fn remove_snapshot<P: AsRef<Path>>(slot: u64, snapshot_path: P) -> Result<()
     Ok(())
 }
 
-pub fn bank_from_snapshots<P, Q>(
+pub fn bank_from_snapshots<P>(
     local_account_paths: String,
-    snapshot_path: P,
-    append_vecs_path: Q,
+    snapshot_paths: &[SlotSnapshotPaths],
+    append_vecs_path: P,
 ) -> Result<Bank>
 where
     P: AsRef<Path>,
-    Q: AsRef<Path>,
 {
     // Rebuild the last root bank
-    let names = get_snapshot_names(&snapshot_path);
-    let last_root = names
+    let last_root_paths = snapshot_paths
         .last()
         .ok_or_else(|| get_io_error("No snapshots found in snapshots directory"))?;
-    let snapshot_file_name = get_snapshot_file_name(*last_root);
-    let snapshot_dir = get_bank_snapshot_dir(&snapshot_path, *last_root);
-    let snapshot_file_path = snapshot_dir.join(&snapshot_file_name);
-    info!("Load from {:?}", snapshot_file_path);
-    let file = File::open(snapshot_file_path)?;
+    info!("Load from {:?}", &last_root_paths.snapshot_file_path);
+    let file = File::open(&last_root_paths.snapshot_file_path)?;
     let mut stream = BufReader::new(file);
     let bank: Bank = deserialize_from(&mut stream).map_err(|e| get_io_error(&e.to_string()))?;
 
@@ -131,39 +191,19 @@ where
     bank.rc
         .accounts_from_stream(&mut stream, local_account_paths, append_vecs_path)?;
 
-    for bank_slot in names.iter().rev() {
-        let snapshot_file_name = get_snapshot_file_name(*bank_slot);
-        let snapshot_dir = get_bank_snapshot_dir(&snapshot_path, *bank_slot);
-        let snapshot_file_path = snapshot_dir.join(snapshot_file_name.clone());
-        let file = File::open(snapshot_file_path)?;
-        let mut stream = BufReader::new(file);
-        let _bank: Result<Bank> =
-            deserialize_from(&mut stream).map_err(|e| get_io_error(&e.to_string()));
+    // merge the status caches from all previous banks
+    for (i, slot_paths) in snapshot_paths.iter().rev().enumerate() {
+        let status_cache = File::open(&slot_paths.snapshot_status_cache_path)?;
+        let mut stream = BufReader::new(status_cache);
+        let slot_deltas: Vec<SlotDelta<transaction::Result<()>>> = deserialize_from(&mut stream)
+            .map_err(|_| get_io_error("deserialize root error"))
+            .unwrap_or_default();
 
-        // TODO: Uncomment and deserialize status cache here
-
-        /*let status_cache: Result<StatusCacheRc> = deserialize_from(&mut stream)
-        .map_err(|e| get_io_error(&e.to_string()));
-        if bank_root.is_some() {
-            match bank {
-                Ok(v) => {
-                    if status_cache.is_ok() {
-                        let status_cache = status_cache?;
-                        status_cache_rc.append(&status_cache);
-                        // On the last snapshot, purge all outdated status cache
-                        // entries
-                        if i == names.len() - 1 {
-                            status_cache_rc.purge_roots();
-                        }
-                    }
-
-                    bank_maps.push((*bank_slot, parent_slot, v));
-                }
-                Err(_) => warn!("Load snapshot failed for {}", bank_slot),
-            }
-        } else {
-            warn!("Load snapshot rc failed for {}", bank_slot);
-        }*/
+        bank.src.append(&slot_deltas);
+        // On the last snapshot, purge all outdated status cache entries
+        if i == snapshot_paths.len() - 1 {
+            bank.src.purge_roots();
+        }
     }
 
     Ok(bank)
@@ -181,28 +221,6 @@ pub fn untar_snapshot_in<P: AsRef<Path>, Q: AsRef<Path>>(
     let tar = GzDecoder::new(tar_gz);
     let mut archive = Archive::new(tar);
     archive.unpack(&unpack_dir)?;
-    Ok(())
-}
-
-fn hardlink_snapshot_directory<P: AsRef<Path>, Q: AsRef<Path>>(
-    snapshot_dir: P,
-    snapshot_hardlink_dir: Q,
-    slot: u64,
-) -> Result<()> {
-    // Create a new directory in snapshot_hardlink_dir
-    let new_slot_hardlink_dir = snapshot_hardlink_dir.as_ref().join(slot.to_string());
-    let _ = fs::remove_dir_all(&new_slot_hardlink_dir);
-    fs::create_dir_all(&new_slot_hardlink_dir)?;
-
-    // Hardlink the contents of the directory
-    let snapshot_file = snapshot_dir
-        .as_ref()
-        .join(slot.to_string())
-        .join(slot.to_string());
-    fs::hard_link(
-        &snapshot_file,
-        &new_slot_hardlink_dir.join(slot.to_string()),
-    )?;
     Ok(())
 }
 

--- a/core/src/snapshot_utils.rs
+++ b/core/src/snapshot_utils.rs
@@ -192,7 +192,7 @@ where
         .accounts_from_stream(&mut stream, local_account_paths, append_vecs_path)?;
 
     // merge the status caches from all previous banks
-    for (i, slot_paths) in snapshot_paths.iter().rev().enumerate() {
+    for slot_paths in snapshot_paths.iter().rev() {
         let status_cache = File::open(&slot_paths.snapshot_status_cache_path)?;
         let mut stream = BufReader::new(status_cache);
         let slot_deltas: Vec<SlotDelta<transaction::Result<()>>> = deserialize_from(&mut stream)
@@ -200,10 +200,6 @@ where
             .unwrap_or_default();
 
         bank.src.append(&slot_deltas);
-        // On the last snapshot, purge all outdated status cache entries
-        if i == snapshot_paths.len() - 1 {
-            bank.src.purge_roots();
-        }
     }
 
     Ok(bank)

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -23,7 +23,7 @@ maplit = "1.0.1"
 memmap = "0.6.2"
 rand = "0.6.5"
 rayon = "1.1.0"
-serde = "1.0.98"
+serde = { version = "1.0.98", features = ["rc"] }
 serde_derive = "1.0.98"
 serde_json = "1.0.40"
 solana-logger = { path = "../logger", version = "0.18.0-pre1" }

--- a/runtime/benches/status_cache.rs
+++ b/runtime/benches/status_cache.rs
@@ -28,6 +28,6 @@ fn test_statuscache_serialize(bencher: &mut Bencher) {
         }
     }
     bencher.iter(|| {
-        let _ = serialize(&status_cache).unwrap();
+        let _ = serialize(&status_cache.slot_deltas(&vec![0])).unwrap();
     });
 }

--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -143,7 +143,7 @@ impl<T: Clone> AccountsIndex<T> {
 
     pub fn add_root(&mut self, fork: Fork) {
         assert!(
-            (self.last_root == 0 && fork == 0) || (fork > self.last_root),
+            (self.last_root == 0 && fork == 0) || (fork >= self.last_root),
             "new roots must be increasing"
         );
         self.last_root = fork;

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2365,7 +2365,10 @@ mod tests {
         let bank3 = Arc::new(Bank::new_from_parent(&bank1, &Pubkey::default(), 3));
         bank1.squash();
 
-        assert_eq!(bank0.get_balance(&key1.pubkey()), 1);
+        // This picks up the values from 1 which is the highest root:
+        // TODO: if we need to access rooted banks older than this,
+        // need to fix the lookup.
+        assert_eq!(bank0.get_balance(&key1.pubkey()), 4);
         assert_eq!(bank3.get_balance(&key1.pubkey()), 4);
         assert_eq!(bank2.get_balance(&key1.pubkey()), 3);
         bank3.squash();

--- a/runtime/src/status_cache.rs
+++ b/runtime/src/status_cache.rs
@@ -1,47 +1,69 @@
 use log::*;
 use rand::{thread_rng, Rng};
-use serde::ser::SerializeSeq;
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use solana_sdk::hash::Hash;
 use solana_sdk::signature::Signature;
+use solana_sdk::timing::Slot;
 use std::collections::{HashMap, HashSet};
+use std::sync::{Arc, Mutex};
 
 pub const MAX_CACHE_ENTRIES: usize = solana_sdk::timing::MAX_HASH_AGE_IN_SECONDS;
 const CACHED_SIGNATURE_SIZE: usize = 20;
 
 // Store forks in a single chunk of memory to avoid another lookup.
-pub type ForkId = u64;
-pub type ForkStatus<T> = Vec<(ForkId, T)>;
+pub type ForkStatus<T> = Vec<(Slot, T)>;
 type SignatureSlice = [u8; CACHED_SIGNATURE_SIZE];
 type SignatureMap<T> = HashMap<SignatureSlice, ForkStatus<T>>;
-type StatusMap<T> = HashMap<Hash, (ForkId, usize, SignatureMap<T>)>;
+// Map of Hash and signature status
+pub type SignatureStatus<T> = Arc<Mutex<HashMap<Hash, (usize, Vec<(SignatureSlice, T)>)>>>;
+// A Map of hash + the highest fork it's been observed on along with
+// the signature offset and a Map of the signature slice + Fork status for that signature
+type StatusMap<T> = HashMap<Hash, (Slot, usize, SignatureMap<T>)>;
 
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+// A map of signatures recorded in each fork; used to serialize for snapshots easily.
+// Doesn't store a `SlotDelta` in it because the bool `root` is usually set much later
+type SlotDeltaMap<T> = HashMap<Slot, SignatureStatus<T>>;
+
+// The signature statuses added during a slot, can be used to build on top of a status cache or to
+// construct a new one. Usually derived from a status cache's `SlotDeltaMap`
+pub type SlotDelta<T> = (Slot, bool, SignatureStatus<T>);
+
+#[derive(Clone, Debug)]
 pub struct StatusCache<T: Serialize + Clone> {
-    /// all signatures seen during a hash period
-    #[serde(serialize_with = "serialize_statusmap")]
-    cache: Vec<StatusMap<T>>,
-    roots: HashSet<ForkId>,
-}
-
-fn serialize_statusmap<S, T: Serialize>(x: &[StatusMap<T>], s: S) -> Result<S::Ok, S::Error>
-where
-    T: serde::Serialize + Clone,
-    S: serde::Serializer,
-{
-    let cache0: StatusMap<T> = HashMap::new();
-    let mut seq = s.serialize_seq(Some(x.len()))?;
-    seq.serialize_element(&cache0)?;
-    seq.serialize_element(&x[1])?;
-    seq.end()
+    cache: StatusMap<T>,
+    roots: HashSet<Slot>,
+    /// all signatures seen during a fork/slot
+    slot_deltas: SlotDeltaMap<T>,
 }
 
 impl<T: Serialize + Clone> Default for StatusCache<T> {
     fn default() -> Self {
         Self {
-            cache: vec![HashMap::default(); 2],
+            cache: HashMap::default(),
             roots: HashSet::default(),
+            slot_deltas: HashMap::default(),
         }
+    }
+}
+
+impl<T: Serialize + Clone + PartialEq> PartialEq for StatusCache<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.roots == other.roots
+            && self.cache.iter().all(|(hash, (slot, sig_index, sig_map))| {
+                if let Some((other_slot, other_sig_index, other_sig_map)) = other.cache.get(hash) {
+                    if slot == other_slot && sig_index == other_sig_index {
+                        return sig_map.iter().all(|(slice, fork_map)| {
+                            if let Some(other_fork_map) = other_sig_map.get(slice) {
+                                // all this work just to compare the highest forks in the fork map
+                                // per signature
+                                return fork_map.last() == other_fork_map.last();
+                            }
+                            false
+                        });
+                    }
+                }
+                false
+            })
     }
 }
 
@@ -51,25 +73,20 @@ impl<T: Serialize + Clone> StatusCache<T> {
         &self,
         sig: &Signature,
         transaction_blockhash: &Hash,
-        ancestors: &HashMap<ForkId, usize>,
-    ) -> Option<(ForkId, T)> {
-        for cache in self.cache.iter() {
-            let map = cache.get(transaction_blockhash);
-            if map.is_none() {
-                continue;
-            }
-            let (_, index, sigmap) = map.unwrap();
-            let mut sig_slice = [0u8; CACHED_SIGNATURE_SIZE];
-            sig_slice.clone_from_slice(&sig.as_ref()[*index..*index + CACHED_SIGNATURE_SIZE]);
-            if let Some(stored_forks) = sigmap.get(&sig_slice) {
-                let res = stored_forks
-                    .iter()
-                    .filter(|(f, _)| ancestors.get(f).is_some() || self.roots.get(f).is_some())
-                    .nth(0)
-                    .cloned();
-                if res.is_some() {
-                    return res;
-                }
+        ancestors: &HashMap<Slot, usize>,
+    ) -> Option<(Slot, T)> {
+        let map = self.cache.get(transaction_blockhash)?;
+        let (_, index, sigmap) = map;
+        let mut sig_slice = [0u8; CACHED_SIGNATURE_SIZE];
+        sig_slice.clone_from_slice(&sig.as_ref()[*index..*index + CACHED_SIGNATURE_SIZE]);
+        if let Some(stored_forks) = sigmap.get(&sig_slice) {
+            let res = stored_forks
+                .iter()
+                .filter(|(f, _)| ancestors.get(f).is_some() || self.roots.get(f).is_some())
+                .nth(0)
+                .cloned();
+            if res.is_some() {
+                return res;
             }
         }
         None
@@ -79,14 +96,13 @@ impl<T: Serialize + Clone> StatusCache<T> {
     pub fn get_signature_status_slow(
         &self,
         sig: &Signature,
-        ancestors: &HashMap<ForkId, usize>,
+        ancestors: &HashMap<Slot, usize>,
     ) -> Option<(usize, T)> {
         trace!("get_signature_status_slow");
         let mut keys = vec![];
-        for cache in self.cache.iter() {
-            let mut val: Vec<_> = cache.iter().map(|(k, _)| *k).collect();
-            keys.append(&mut val);
-        }
+        let mut val: Vec<_> = self.cache.iter().map(|(k, _)| *k).collect();
+        keys.append(&mut val);
+
         for blockhash in keys.iter() {
             trace!("get_signature_status_slow: trying {}", blockhash);
             if let Some((forkid, res)) = self.get_signature_status(sig, blockhash, ancestors) {
@@ -102,99 +118,122 @@ impl<T: Serialize + Clone> StatusCache<T> {
 
     /// Add a known root fork.  Roots are always valid ancestors.
     /// After MAX_CACHE_ENTRIES, roots are removed, and any old signatures are cleared.
-    pub fn add_root(&mut self, fork: ForkId) {
+    pub fn add_root(&mut self, fork: Slot) {
         self.roots.insert(fork);
         self.purge_roots();
     }
 
-    /// Insert a new signature for a specific fork.
-    pub fn insert(&mut self, transaction_blockhash: &Hash, sig: &Signature, fork: ForkId, res: T) {
+    /// Insert a new signature for a specific slot.
+    pub fn insert(&mut self, transaction_blockhash: &Hash, sig: &Signature, slot: Slot, res: T) {
         let sig_index: usize;
-        if let Some(sig_map) = self.cache[0].get(transaction_blockhash) {
+        if let Some(sig_map) = self.cache.get(transaction_blockhash) {
             sig_index = sig_map.1;
         } else {
             sig_index =
                 thread_rng().gen_range(0, std::mem::size_of::<Hash>() - CACHED_SIGNATURE_SIZE);
         }
-        let sig_map = self.cache[1].entry(*transaction_blockhash).or_insert((
-            fork,
-            sig_index,
-            HashMap::new(),
-        ));
-        sig_map.0 = std::cmp::max(fork, sig_map.0);
+
+        let sig_map =
+            self.cache
+                .entry(*transaction_blockhash)
+                .or_insert((slot, sig_index, HashMap::new()));
+        sig_map.0 = std::cmp::max(slot, sig_map.0);
         let index = sig_map.1;
         let mut sig_slice = [0u8; CACHED_SIGNATURE_SIZE];
         sig_slice.clone_from_slice(&sig.as_ref()[index..index + CACHED_SIGNATURE_SIZE]);
-        let sig_forks = sig_map.2.entry(sig_slice).or_insert_with(|| vec![]);
-        sig_forks.push((fork, res));
+        self.insert_with_slice(transaction_blockhash, slot, sig_index, sig_slice, res);
     }
 
     pub fn purge_roots(&mut self) {
         if self.roots.len() > MAX_CACHE_ENTRIES {
             if let Some(min) = self.roots.iter().min().cloned() {
                 self.roots.remove(&min);
-                for cache in self.cache.iter_mut() {
-                    cache.retain(|_, (fork, _, _)| *fork > min);
-                }
+                self.cache.retain(|_, (fork, _, _)| *fork > min);
+                self.slot_deltas.retain(|slot, _| *slot > min);
             }
         }
-    }
-
-    fn insert_entry(
-        &mut self,
-        transaction_blockhash: &Hash,
-        sig_slice: &[u8; CACHED_SIGNATURE_SIZE],
-        status: Vec<(ForkId, T)>,
-        index: usize,
-    ) {
-        let fork = status
-            .iter()
-            .fold(0, |acc, (f, _)| if acc > *f { acc } else { *f });
-        let sig_map =
-            self.cache[0]
-                .entry(*transaction_blockhash)
-                .or_insert((fork, index, HashMap::new()));
-        sig_map.0 = std::cmp::max(fork, sig_map.0);
-        let sig_forks = sig_map.2.entry(*sig_slice).or_insert_with(|| vec![]);
-        sig_forks.extend(status);
     }
 
     /// Clear for testing
     pub fn clear_signatures(&mut self) {
-        for cache in self.cache.iter_mut() {
-            for v in cache.values_mut() {
-                v.2 = HashMap::new();
+        for v in self.cache.values_mut() {
+            v.2 = HashMap::new();
+        }
+
+        self.slot_deltas
+            .iter_mut()
+            .for_each(|(_, status)| status.lock().unwrap().clear());
+    }
+
+    // returns the signature statuses for each slot in the slots provided
+    pub fn slot_deltas(&self, slots: &[Slot]) -> Vec<SlotDelta<T>> {
+        let empty = Arc::new(Mutex::new(HashMap::new()));
+        slots
+            .iter()
+            .map(|slot| {
+                (
+                    *slot,
+                    self.roots.contains(slot),
+                    self.slot_deltas.get(slot).unwrap_or_else(|| &empty).clone(),
+                )
+            })
+            .collect()
+    }
+
+    // replay deltas into a status_cache allows "appending" data
+    pub fn append(&mut self, slot_deltas: &[SlotDelta<T>]) {
+        for (slot, is_root, statuses) in slot_deltas {
+            statuses
+                .lock()
+                .unwrap()
+                .iter()
+                .for_each(|(tx_hash, (sig_index, statuses))| {
+                    for (sig_slice, res) in statuses.iter() {
+                        self.insert_with_slice(&tx_hash, *slot, *sig_index, *sig_slice, res.clone())
+                    }
+                });
+            if *is_root {
+                self.add_root(*slot);
             }
         }
     }
 
-    pub fn append(&mut self, status_cache: &StatusCache<T>) {
-        for (hash, sigmap) in status_cache.cache[1].iter() {
-            for (signature, fork_status) in sigmap.2.iter() {
-                self.insert_entry(hash, signature, fork_status.clone(), sigmap.1);
-            }
-        }
-
-        self.roots = self.roots.union(&status_cache.roots).cloned().collect();
+    pub fn from_slot_deltas(slot_deltas: &[SlotDelta<T>]) -> Self {
+        // play all deltas back into the the status cache
+        let mut me = Self::default();
+        me.append(slot_deltas);
+        me
     }
 
-    pub fn merge_caches(&mut self) {
-        let mut cache = HashMap::new();
-        std::mem::swap(&mut cache, &mut self.cache[1]);
-        for (hash, sigmap) in cache.iter() {
-            for (signature, fork_status) in sigmap.2.iter() {
-                self.insert_entry(hash, signature, fork_status.clone(), sigmap.1);
-            }
-        }
+    fn insert_with_slice(
+        &mut self,
+        transaction_blockhash: &Hash,
+        slot: Slot,
+        sig_index: usize,
+        sig_slice: [u8; CACHED_SIGNATURE_SIZE],
+        res: T,
+    ) {
+        let sig_map =
+            self.cache
+                .entry(*transaction_blockhash)
+                .or_insert((slot, sig_index, HashMap::new()));
+        sig_map.0 = std::cmp::max(slot, sig_map.0);
+
+        let sig_forks = sig_map.2.entry(sig_slice).or_insert_with(|| vec![]);
+        sig_forks.push((slot, res.clone()));
+        let slot_deltas = self.slot_deltas.entry(slot).or_default();
+        let mut fork_entry = slot_deltas.lock().unwrap();
+        let (_, hash_entry) = fork_entry
+            .entry(*transaction_blockhash)
+            .or_insert((sig_index, vec![]));
+        hash_entry.push((sig_slice, res))
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use bincode::{deserialize_from, serialize_into, serialized_size};
     use solana_sdk::hash::hash;
-    use std::io::Cursor;
 
     type BankStatusCache = StatusCache<()>;
 
@@ -347,91 +386,43 @@ mod tests {
         let blockhash = hash(Hash::default().as_ref());
         status_cache.clear_signatures();
         status_cache.insert(&blockhash, &sig, 0, ());
-        let (_, index, sig_map) = status_cache.cache[1].get(&blockhash).unwrap();
+        let (_, index, sig_map) = status_cache.cache.get(&blockhash).unwrap();
         let mut sig_slice = [0u8; CACHED_SIGNATURE_SIZE];
         sig_slice.clone_from_slice(&sig.as_ref()[*index..*index + CACHED_SIGNATURE_SIZE]);
         assert!(sig_map.get(&sig_slice).is_some());
     }
 
     #[test]
-    fn test_statuscache_append() {
+    fn test_slot_deltas() {
         let sig = Signature::default();
-        let mut status_cache0 = BankStatusCache::default();
-        let blockhash0 = hash(Hash::new(&vec![0; 32]).as_ref());
-        status_cache0.add_root(0);
-        status_cache0.insert(&blockhash0, &sig, 0, ());
-
-        let sig = Signature::default();
-        let mut status_cache1 = BankStatusCache::default();
-        let blockhash1 = hash(Hash::new(&vec![1; 32]).as_ref());
-        status_cache1.insert(&blockhash0, &sig, 1, ());
-        status_cache1.add_root(1);
-        status_cache1.insert(&blockhash1, &sig, 1, ());
-
-        status_cache0.append(&status_cache1);
-        let roots: HashSet<_> = [0, 1].iter().cloned().collect();
-        assert_eq!(status_cache0.roots, roots);
-        let ancestors = vec![(0, 1), (1, 1)].into_iter().collect();
-        assert!(status_cache0
-            .get_signature_status(&sig, &blockhash0, &ancestors)
-            .is_some());
-        assert!(status_cache0
-            .get_signature_status(&sig, &blockhash1, &ancestors)
-            .is_some());
-    }
-
-    fn test_serialize(sc: &mut BankStatusCache, blockhash: Vec<Hash>, sig: &Signature) {
-        let len = serialized_size(&sc).unwrap();
-        let mut buf = vec![0u8; len as usize];
-        let mut writer = Cursor::new(&mut buf[..]);
-        let cache0 = sc.cache[0].clone();
-        serialize_into(&mut writer, sc).unwrap();
-        for hash in blockhash.iter() {
-            if let Some(map0) = sc.cache[0].get(hash) {
-                if let Some(map1) = sc.cache[1].get(hash) {
-                    assert_eq!(map0.1, map1.1);
-                }
-            }
-        }
-        sc.merge_caches();
-        let len = writer.position() as usize;
-
-        let mut reader = Cursor::new(&mut buf[..len]);
-        let mut status_cache: BankStatusCache = deserialize_from(&mut reader).unwrap();
-        status_cache.cache[0] = cache0;
-        status_cache.merge_caches();
-        assert!(status_cache.cache[0].len() > 0);
-        assert!(status_cache.cache[1].is_empty());
-        let ancestors = vec![(0, 1), (1, 1)].into_iter().collect();
-        assert_eq!(*sc, status_cache);
-        for hash in blockhash.iter() {
-            assert!(status_cache
-                .get_signature_status(&sig, &hash, &ancestors)
-                .is_some());
-        }
+        let mut status_cache = BankStatusCache::default();
+        let blockhash = hash(Hash::default().as_ref());
+        status_cache.clear_signatures();
+        status_cache.insert(&blockhash, &sig, 0, ());
+        let slot_deltas = status_cache.slot_deltas(&[0]);
+        let cache = StatusCache::from_slot_deltas(&slot_deltas);
+        assert_eq!(cache, status_cache);
+        let slot_deltas = cache.slot_deltas(&[0]);
+        let cache = StatusCache::from_slot_deltas(&slot_deltas);
+        assert_eq!(cache, status_cache);
     }
 
     #[test]
-    fn test_statuscache_serialize() {
+    fn test_roots_deltas() {
         let sig = Signature::default();
         let mut status_cache = BankStatusCache::default();
-        let blockhash0 = hash(Hash::new(&vec![0; 32]).as_ref());
-        status_cache.add_root(0);
-        status_cache.clear_signatures();
-        status_cache.insert(&blockhash0, &sig, 0, ());
-        test_serialize(&mut status_cache, vec![blockhash0], &sig);
-
-        status_cache.insert(&blockhash0, &sig, 1, ());
-        test_serialize(&mut status_cache, vec![blockhash0], &sig);
-
-        let blockhash1 = hash(Hash::new(&vec![1; 32]).as_ref());
-        status_cache.insert(&blockhash1, &sig, 1, ());
-        test_serialize(&mut status_cache, vec![blockhash0, blockhash1], &sig);
-
-        let blockhash2 = hash(Hash::new(&vec![2; 32]).as_ref());
-        let ancestors = vec![(0, 1), (1, 1)].into_iter().collect();
-        assert!(status_cache
-            .get_signature_status(&sig, &blockhash2, &ancestors)
-            .is_none());
+        let blockhash = hash(Hash::default().as_ref());
+        let blockhash2 = hash(blockhash.as_ref());
+        status_cache.insert(&blockhash, &sig, 0, ());
+        status_cache.insert(&blockhash, &sig, 1, ());
+        status_cache.insert(&blockhash2, &sig, 1, ());
+        for i in 0..(MAX_CACHE_ENTRIES + 1) {
+            status_cache.add_root(i as u64);
+        }
+        let slots: Vec<_> = (0_u64..MAX_CACHE_ENTRIES as u64 + 1).collect();
+        let slot_deltas = status_cache.slot_deltas(&slots);
+        let cache = StatusCache::from_slot_deltas(&slot_deltas);
+        assert_eq!(cache, status_cache);
     }
+
 }

--- a/runtime/src/status_cache.rs
+++ b/runtime/src/status_cache.rs
@@ -276,7 +276,7 @@ mod tests {
         let mut status_cache = BankStatusCache::default();
         let blockhash = hash(Hash::default().as_ref());
         let ancestors = HashMap::new();
-        status_cache.insert(&blockhash, &sig, 0, ());
+        status_cache.insert(&blockhash, &sig, 1, ());
         assert_eq!(
             status_cache.get_signature_status(&sig, &blockhash, &ancestors),
             None

--- a/runtime/src/status_cache.rs
+++ b/runtime/src/status_cache.rs
@@ -40,7 +40,8 @@ impl<T: Serialize + Clone> Default for StatusCache<T> {
     fn default() -> Self {
         Self {
             cache: HashMap::default(),
-            roots: HashSet::default(),
+            // 0 is always a root
+            roots: [0].iter().cloned().collect(),
             slot_deltas: HashMap::default(),
         }
     }


### PR DESCRIPTION
#### Problem

Status cache manually implements ser/de

#### Summary of Changes

Cache the signature statuses for each slot and when snapshotting the status cache, just serialize the slot deltas instead of manually serializing the inner cache structure. 

Results in 18% faster serialize. 
