### PR TITLE
net: Avoid setting RUST_LOG to the empty string

### DIFF
--- a/net/remote/remote-client.sh
+++ b/net/remote/remote-client.sh
@@ -8,11 +8,12 @@ echo "$(date) | $0 $*" > client.log
 deployMethod="$1"
 entrypointIp="$2"
 clientToRun="$3"
-RUST_LOG="$4"
+if [[ -n $4 ]]; then
+  export RUST_LOG="$4"
+fi
 benchTpsExtraArgs="$5"
 benchExchangeExtraArgs="$6"
 clientIndex="$7"
-export RUST_LOG=${RUST_LOG:-solana=info} # if RUST_LOG is unset, default to info
 
 missing() {
   echo "Error: $1 not specified"

--- a/net/remote/remote-deploy-update.sh
+++ b/net/remote/remote-deploy-update.sh
@@ -25,8 +25,9 @@ missing() {
 [[ -n $updatePlatform ]] || missing updatePlatform
 [[ -f update_manifest_keypair.json ]] || missing update_manifest_keypair.json
 
-RUST_LOG="$2"
-export RUST_LOG=${RUST_LOG:-solana=info} # if RUST_LOG is unset, default to info
+if [[ -n $2 ]]; then
+  export RUST_LOG="$2"
+fi
 
 source net/common.sh
 loadConfigFile

--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -8,7 +8,9 @@ deployMethod="$1"
 nodeType="$2"
 entrypointIp="$3"
 numNodes="$4"
-RUST_LOG="$5"
+if [[ -n $5 ]]; then
+  export RUST_LOG="$5"
+fi
 skipSetup="$6"
 failOnValidatorBootupFailure="$7"
 externalPrimordialAccountsFile="$8"
@@ -23,7 +25,6 @@ benchExchangeExtraArgs="${16}"
 genesisOptions="${17}"
 extraNodeArgs="${18}"
 set +x
-export RUST_LOG
 
 # Use a very large stake (relative to the default multinode-demo/ stake of 42)
 # for the testnet validators setup by net/.  This make it less likely that

--- a/net/remote/remote-sanity.sh
+++ b/net/remote/remote-sanity.sh
@@ -60,8 +60,9 @@ while [[ $1 = -o ]]; do
   esac
 done
 
-RUST_LOG="$1"
-export RUST_LOG=${RUST_LOG:-solana=info} # if RUST_LOG is unset, default to info
+if [[ -n $1 ]]; then
+  export RUST_LOG="$1"
+fi
 
 source net/common.sh
 loadConfigFile


### PR DESCRIPTION
`export RUST_LOG=` (no logging at all!) is no longer the same as `unset RUST_LOG` (use default logging), update `net/` to conform