### PR TITLE
fix epoch_stakes

### DIFF
--- a/programs/stake_api/src/stake_state.rs
+++ b/programs/stake_api/src/stake_state.rs
@@ -53,7 +53,7 @@ pub struct Stake {
     pub activated: Epoch,   // epoch the stake was activated
     pub deactivated: Epoch, // epoch the stake was deactivated, std::Epoch::MAX if not deactivated
 }
-pub const STAKE_WARMUP_EPOCHS: u64 = 3;
+pub const STAKE_WARMUP_EPOCHS: Epoch = 3;
 
 impl Default for Stake {
     fn default() -> Self {
@@ -68,7 +68,7 @@ impl Default for Stake {
 }
 
 impl Stake {
-    pub fn stake(&self, epoch: u64) -> u64 {
+    pub fn stake(&self, epoch: Epoch) -> u64 {
         // before "activated" or after deactivated?
         if epoch < self.activated || epoch >= self.deactivated {
             return 0;
@@ -217,7 +217,7 @@ impl<'a> StakeAccount for KeyedAccount<'a> {
                 new_stake,
                 vote_account.unsigned_key(),
                 &vote_account.state()?,
-                clock.epoch,
+                clock.stakers_epoch,
             );
 
             self.set_state(&StakeState::Stake(stake))
@@ -231,7 +231,7 @@ impl<'a> StakeAccount for KeyedAccount<'a> {
         }
 
         if let StakeState::Stake(mut stake) = self.state()? {
-            stake.deactivate(clock.epoch);
+            stake.deactivate(clock.stakers_epoch);
 
             self.set_state(&StakeState::Stake(stake))
         } else {
@@ -287,7 +287,7 @@ impl<'a> StakeAccount for KeyedAccount<'a> {
 
         match self.state()? {
             StakeState::Stake(mut stake) => {
-                let staked = if stake.stake(clock.epoch) == 0 {
+                let staked = if stake.stake(clock.stakers_epoch) == 0 {
                     0
                 } else {
                     // Assume full stake if the stake is under warmup/cooldown
@@ -353,7 +353,10 @@ mod tests {
 
     #[test]
     fn test_stake_delegate_stake() {
-        let clock = sysvar::clock::Clock::default();
+        let clock = sysvar::clock::Clock {
+            stakers_epoch: 1,
+            ..sysvar::clock::Clock::default()
+        };
 
         let vote_keypair = Keypair::new();
         let mut vote_state = VoteState::default();
@@ -399,7 +402,7 @@ mod tests {
                 voter_pubkey: vote_keypair.pubkey(),
                 credits_observed: vote_state.credits(),
                 stake: stake_lamports,
-                activated: 0,
+                activated: clock.stakers_epoch,
                 deactivated: std::u64::MAX,
             })
         );
@@ -456,7 +459,10 @@ mod tests {
         let mut stake_account =
             Account::new(stake_lamports, std::mem::size_of::<StakeState>(), &id());
 
-        let clock = sysvar::clock::Clock::default();
+        let clock = sysvar::clock::Clock {
+            stakers_epoch: 1,
+            ..sysvar::clock::Clock::default()
+        };
 
         // unsigned keyed account
         let mut stake_keyed_account = KeyedAccount::new(&stake_pubkey, false, &mut stake_account);

--- a/runtime/src/stakes.rs
+++ b/runtime/src/stakes.rs
@@ -62,7 +62,9 @@ impl Stakes {
     }
 
     pub fn is_stake(account: &Account) -> bool {
-        solana_vote_api::check_id(&account.owner) || solana_stake_api::check_id(&account.owner)
+        solana_vote_api::check_id(&account.owner)
+            || solana_stake_api::check_id(&account.owner)
+                && account.data.len() >= std::mem::size_of::<StakeState>()
     }
 
     pub fn store(&mut self, pubkey: &Pubkey, account: &Account) {

--- a/runtime/src/stakes.rs
+++ b/runtime/src/stakes.rs
@@ -2,6 +2,7 @@
 //! node stakes
 use solana_sdk::account::Account;
 use solana_sdk::pubkey::Pubkey;
+use solana_sdk::timing::Epoch;
 use solana_stake_api::stake_state::StakeState;
 use solana_vote_api::vote_state::VoteState;
 use std::collections::HashMap;
@@ -19,11 +20,11 @@ pub struct Stakes {
     points: u64,
 
     /// current epoch, used to calculate current stake
-    epoch: u64,
+    epoch: Epoch,
 }
 
 impl Stakes {
-    pub fn clone_with_epoch(&self, epoch: u64) -> Self {
+    pub fn clone_with_epoch(&self, epoch: Epoch) -> Self {
         if self.epoch == epoch {
             self.clone()
         } else {
@@ -46,7 +47,7 @@ impl Stakes {
     }
 
     // sum the stakes that point to the given voter_pubkey
-    fn calculate_stake(&self, voter_pubkey: &Pubkey, epoch: u64) -> u64 {
+    fn calculate_stake(&self, voter_pubkey: &Pubkey, epoch: Epoch) -> u64 {
         self.stake_accounts
             .iter()
             .map(|(_, stake_account)| {


### PR DESCRIPTION
#### Problem
 bank's epoch_stakes were being populated with the current "first bank in the epoch"'s epoch, not
 the epoch to which those epoch stakes would apply to

 #### Summary of Changes
 use clone_with_epoch(stakers_epoch) for all calls that populate epoch_stakes

Fixes #