### PR TITLE
remove no-snapshot option from tds testnet

### DIFF
--- a/ci/testnet-manager.sh
+++ b/ci/testnet-manager.sh
@@ -580,8 +580,7 @@ deploy() {
           ${maybeExternalAccountsFile} \
           ${maybeLamports} \
           ${maybeAdditionalDisk} \
-          --skip-deploy-update \
-          --no-snapshot
+          --skip-deploy-update
     )
     ;;
   *)


### PR DESCRIPTION
#### Problem
Option `no-snapshot` is not required to disable snapshot

#### Summary of Changes
Removed it

Fixes #
