### PR TITLE
Teach solana-install about release channels

### DIFF
--- a/install/src/config.rs
+++ b/install/src/config.rs
@@ -5,13 +5,19 @@ use std::fs::{create_dir_all, File};
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+pub enum ExplicitRelease {
+    Semver(String),
+    Channel(String),
+}
+
 #[derive(Serialize, Deserialize, Default, Debug, PartialEq)]
 pub struct Config {
     pub json_rpc_url: String,
     pub update_manifest_pubkey: Pubkey,
     pub current_update_manifest: Option<UpdateManifest>,
     pub update_poll_secs: u64,
-    pub release_semver: Option<String>,
+    pub explicit_release: Option<ExplicitRelease>,
     releases_dir: PathBuf,
     active_release_dir: PathBuf,
 }
@@ -21,14 +27,14 @@ impl Config {
         data_dir: &str,
         json_rpc_url: &str,
         update_manifest_pubkey: &Pubkey,
-        release_semver: Option<&str>,
+        explicit_release: Option<ExplicitRelease>,
     ) -> Self {
         Self {
             json_rpc_url: json_rpc_url.to_string(),
             update_manifest_pubkey: *update_manifest_pubkey,
             current_update_manifest: None,
             update_poll_secs: 60, // check for updates once a minute
-            release_semver: release_semver.map(|s| s.to_string()),
+            explicit_release,
             releases_dir: PathBuf::from(data_dir).join("releases"),
             active_release_dir: PathBuf::from(data_dir).join("active_release"),
         }


### PR DESCRIPTION
```bash
$ solana-install init edge  # <-- setup an install using the edge channel
$ solana-install update     # <-- update to the latest edge channel release
```

This makes it so much easier to test drive the latest edge/beta binaries