### PR TITLE
Default to solana=info log level for drone & bench-tps

### DIFF
--- a/bench-tps/src/main.rs
+++ b/bench-tps/src/main.rs
@@ -21,7 +21,7 @@ use std::process::exit;
 pub const NUM_SIGNATURES_FOR_TXS: u64 = 100_000 * 60 * 60 * 24 * 7;
 
 fn main() {
-    solana_logger::setup();
+    solana_logger::setup_with_filter("solana=info");
     solana_metrics::set_panic_hook("bench-tps");
 
     let matches = cli::build_args().get_matches();

--- a/drone/src/bin/drone.rs
+++ b/drone/src/bin/drone.rs
@@ -8,7 +8,7 @@ use std::sync::{Arc, Mutex};
 use std::thread;
 
 fn main() -> Result<(), Box<error::Error>> {
-    solana_logger::setup();
+    solana_logger::setup_with_filter("solana=info");
     solana_metrics::set_panic_hook("drone");
     let matches = App::new(crate_name!())
         .about(crate_description!())


### PR DESCRIPTION
#### Problem

bench-tps and drone don't print much

#### Summary of Changes

default to info level for them.

Fixes #
