### PR TITLE
Introduce delegate-stake.sh for adding stake to a validator.sh

### DIFF
--- a/book/src/testnet-participation.md
+++ b/book/src/testnet-participation.md
@@ -222,7 +222,6 @@ $ solana-keygen pubkey ~/.local/share/solana/install/active_release/config/valid
 $ solana-keygen pubkey ./config/validator-vote-keypair.json
 ```
 
-
 #### Validator Metrics
 Metrics are available for local monitoring of your validator.
 
@@ -282,3 +281,33 @@ Keybase:
   `https://keybase.pub/<KEYBASE_USERNAME>/solana/validator-<PUBKEY>`
 3. Add or update your `solana-validator-info` with your Keybase username. The
 CLI will verify the `validator-<PUBKEY>` file
+
+### Staking
+When your validator starts it will have no stake, which means it will ineligible to become leader.
+
+Adding stake can be accomplished by using the `solana-wallet` command.  First
+obtain the public key for your validator's vote account with:
+```bash
+$ solana-keygen pubkey ~/validator-config/vote-keypair.json
+```
+This will output a base58-encoded value that looks similar to
+`DhUYZR98qFLLrnHg2HWeGhBQJ9tru7nwdEfYm8L8HdR9`. Then create a stake account
+keypair with `solana-keygen`:
+```bash
+$ solana-keygen new -o ~/validator-config/stake-keypair.json
+```
+and use the wallet's `delegate-stake` command to stake your validator with 42 lamports:
+```bash
+$ solana-wallet delegate-stake ~/validator-config/stake-keypair.json [VOTE PUBKEY] 42
+```
+
+Note that stake changes are applied at Epoch boundaries so it can take an hour
+or more for the change to take effect.
+
+Stake can be deactivate by running:
+```bash
+$ solana-wallet deactivate-stake ~/validator-config/stake-keypair.json
+```
+Note that a stake account may only be used once, so after deactivation use the
+wallet's `withdraw-stake` command to recover the previously staked lamports.
+

--- a/multinode-demo/delegate-stake.sh
+++ b/multinode-demo/delegate-stake.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+#
+# Delegate stake to a validator
+#
+set -e
+
+here=$(dirname "$0")
+# shellcheck source=multinode-demo/common.sh
+source "$here"/common.sh
+
+stake_lamports=42           # default number of lamports to assign as stake
+url=http://127.0.0.1:8899   # default RPC url
+
+usage() {
+  if [[ -n $1 ]]; then
+    echo "$*"
+    echo
+  fi
+  cat <<EOF
+
+usage: $0 [OPTIONS] <lamports to stake ($stake_lamports)>
+
+Add stake to a validator
+
+OPTIONS:
+  --url   RPC_URL           - RPC URL to the cluster ($url)
+  --label LABEL             - Append the given label to the configuration files, useful when running
+                              multiple validators in the same workspace
+  --no-airdrop              - Do not attempt to airdrop the stake
+  --keypair FILE            - Keypair to fund the stake from
+
+EOF
+  exit 1
+}
+
+common_args=()
+label=
+airdrops_enabled=1
+
+positional_args=()
+while [[ -n $1 ]]; do
+  if [[ ${1:0:1} = - ]]; then
+    if [[ $1 = --label ]]; then
+      label="-$2"
+      shift 2
+    elif [[ $1 = --keypair || $1 = -k ]]; then
+      common_args+=("$1" "$2")
+      shift 2
+    elif [[ $1 = --url || $1 = -u ]]; then
+      url=$2
+      shift 2
+    elif [[ $1 = --no-airdrop ]]; then
+      airdrops_enabled=0
+      shift
+    elif [[ $1 = -h ]]; then
+      usage "$@"
+    else
+      echo "Unknown argument: $1"
+      exit 1
+    fi
+  else
+    positional_args+=("$1")
+    shift
+  fi
+done
+
+common_args+=(--url "$url")
+
+if [[ ${#positional_args[@]} -gt 1 ]]; then
+  usage "$@"
+fi
+if [[ -n ${positional_args[0]} ]]; then
+  stake_lamports=${positional_args[0]}
+fi
+
+config_dir="$SOLANA_CONFIG_DIR/validator$label"
+vote_keypair_path="$config_dir"/vote-keypair.json
+stake_keypair_path=$config_dir/stake-keypair.json
+
+if [[ ! -f $vote_keypair_path ]]; then
+  echo "Error: $vote_keypair_path not found"
+  exit 1
+fi
+
+if [[ -f $stake_keypair_path ]]; then
+  # TODO: Add ability to add multiple stakes with this script?
+  echo "Error: $stake_keypair_path already exists"
+  exit 1
+fi
+
+vote_pubkey=$($solana_keygen pubkey "$vote_keypair_path")
+
+if ((airdrops_enabled)); then
+  declare fees=100 # TODO: No hardcoded transaction fees, fetch the current cluster fees
+  $solana_wallet "${common_args[@]}" airdrop $((stake_lamports+fees))
+fi
+
+$solana_keygen new -o "$stake_keypair_path"
+stake_pubkey=$($solana_keygen pubkey "$stake_keypair_path")
+
+set -x
+$solana_wallet "${common_args[@]}" \
+  delegate-stake "$stake_keypair_path" "$vote_pubkey" "$stake_lamports"
+$solana_wallet "${common_args[@]}" show-stake-account "$stake_pubkey"
+

--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -199,10 +199,8 @@ local|tar|skip)
       args+=(
         --blockstream /tmp/solana-blockstream.sock
         --no-voting
-        --stake 0
       )
     else
-      args+=(--stake "$stake")
       args+=(--enable-rpc-exit)
       if [[ -n $internalNodesLamports ]]; then
         args+=(--node-lamports "$internalNodesLamports")
@@ -261,6 +259,10 @@ local|tar|skip)
     pid=$!
     oom_score_adj "$pid" 1000
     waitForNodeToInit
+
+    if [[ $skipSetup != true && $nodeType != blockstreamer ]]; then
+      ./multinode-demo/delegate-stake.sh $stake
+    fi
     ;;
   replicator)
     if [[ $deployMethod != skip ]]; then


### PR DESCRIPTION
#### Problem
`validator.sh` sets you up for failure by delegating stake before your validator even starts.

#### Summary of Changes
`validator.sh` boots your validator with no stake.   Use `delegate-stake.sh` to then apply some stake

TODO:
* [x] Update docs in the book for how to delegate stake from a release
* [x] Figure out how to deal with cluster restarts (going to punt on this, stake will not be automatically re-applied on a cluster restart)