### PR TITLE
Change default location of `solana.h` to `OUT_DIR`

### DIFF
--- a/sdk-c/README.md
+++ b/sdk-c/README.md
@@ -5,7 +5,7 @@ to generate a header file during the build. To generate both:
 
 ```shell
 $ cd <path/to/solana/repo>/sdk-c
-$ cargo build
+$ SOLANA_H_OUT_DIR="$(pwd)/include" cargo build
 ```
 
 This will generate the static library in `<path/to/solana/repo>/target/deps` and the header file in

--- a/sdk-c/build.rs
+++ b/sdk-c/build.rs
@@ -1,12 +1,17 @@
 use std::env;
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 fn main() {
     let crate_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
 
-    let out_path = Path::new(&crate_dir);
-    let out_path = out_path.join(Path::new("include"));
+    let out_path = if let Ok(path) = env::var("SOLANA_H_OUT_DIR") {
+        PathBuf::from(path)
+    } else {
+        let out_dir = env::var("OUT_DIR").unwrap();
+        let out_dir = Path::new(&out_dir);
+        out_dir.join(Path::new("include"))
+    };
 
     // Ensure `out_path` exists
     fs::create_dir_all(&out_path).unwrap_or_else(|err| {


### PR DESCRIPTION
#### Problem

`sdk-c/build.rs` generates the `solana.h` file in the source directory by default, preventing crate publishing.

#### Summary of Changes

Change the default location to the `OUT_DIR`, as required for publishing. Also allow the user to override by setting the `SOLANA_H_OUT_DIR` environment variable.

Fixes #5386
