### PR TITLE
localnet-sanity.sh: Give a unique port range for each validator node

### DIFF
--- a/ci/localnet-sanity.sh
+++ b/ci/localnet-sanity.sh
@@ -74,18 +74,23 @@ source scripts/configure-metrics.sh
 nodes=(
   "multinode-demo/drone.sh"
   "multinode-demo/bootstrap-leader.sh \
-    --init-complete-file init-complete-node1.log"
+    --init-complete-file init-complete-node1.log \
+    --dynamic-port-range 8000-8019"
   "multinode-demo/validator.sh \
     --enable-rpc-exit \
     --no-restart \
+    --dynamic-port-range 8020-8039
     --init-complete-file init-complete-node2.log \
     --rpc-port 18899"
 )
 
 for i in $(seq 1 $extraNodes); do
+  portStart=$((8040 + i * 20))
+  portEnd=$((portStart + 19))
   nodes+=(
     "multinode-demo/validator.sh \
       --no-restart \
+      --dynamic-port-range $portStart-$portEnd
       --label dyn$i \
       --init-complete-file init-complete-node$((2 + i)).log"
   )

--- a/multinode-demo/bootstrap-leader.sh
+++ b/multinode-demo/bootstrap-leader.sh
@@ -23,6 +23,9 @@ while [[ -n $1 ]]; do
     elif [[ $1 = --gossip-port ]]; then
       args+=("$1" "$2")
       shift 2
+    elif [[ $1 = --dynamic-port-range ]]; then
+      args+=("$1" "$2")
+      shift 2
     else
       echo "Unknown argument: $1"
       $program --help


### PR DESCRIPTION
This should fix the CI failure that occurred here:
https://buildkite.com/solana-labs/solana/builds/9984#7fbf4fc1-a284-4b1f-b236-256297da2de3