### PR TITLE
Log fork stake-percentage in metrics, and display

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -477,6 +477,10 @@ impl ReplayStage {
                 let percentage_stake: f64 =
                     stake_lockout.stake() as f64 / total_epoch_stakes as f64;
                 let fork_metrics = *fork as i64;
+                let parent = w_bank_forks
+                    .get(*fork)
+                    .map(|bank| bank.parent().map(|parent| parent.slot()).unwrap_or(0))
+                    .unwrap_or(0) as i64;
                 solana_metrics::submit(
                     solana_metrics::influxdb::Point::new("stake-percentage")
                         .add_tag(
@@ -491,6 +495,7 @@ impl ReplayStage {
                             "fork",
                             solana_metrics::influxdb::Value::Integer(fork_metrics),
                         )
+                        .add_field("parent", solana_metrics::influxdb::Value::Integer(parent))
                         .add_field(
                             "root",
                             solana_metrics::influxdb::Value::Integer(

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -474,6 +474,32 @@ impl ReplayStage {
                     total_epoch_stakes,
                     stake_lockout.lockout(),
                 );
+                let percentage_stake: f64 =
+                    stake_lockout.stake() as f64 / total_epoch_stakes as f64;
+                let fork_metrics = *fork as i64;
+                solana_metrics::submit(
+                    solana_metrics::influxdb::Point::new("stake-percentage")
+                        .add_tag(
+                            "fork_tag",
+                            solana_metrics::influxdb::Value::Integer(fork_metrics),
+                        )
+                        .add_field(
+                            "percentage_stake",
+                            solana_metrics::influxdb::Value::Float(percentage_stake),
+                        )
+                        .add_field(
+                            "fork",
+                            solana_metrics::influxdb::Value::Integer(fork_metrics),
+                        )
+                        .add_field(
+                            "root",
+                            solana_metrics::influxdb::Value::Integer(
+                                tower.root().unwrap_or(0) as i64
+                            ),
+                        )
+                        .to_owned(),
+                    log::Level::Info,
+                );
             }
         }
         drop(w_bank_forks);

--- a/metrics/scripts/grafana-provisioning/dashboards/testnet-monitor.json
+++ b/metrics/scripts/grafana-provisioning/dashboards/testnet-monitor.json
@@ -7964,6 +7964,167 @@
         "align": false,
         "alignLevel": null
       }
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 97
+      },
+      "id": 60,
+      "panels": [],
+      "title": "Fork Confidence",
+      "type": "row"
+    },
+    {
+      "columns": [],
+      "datasource": "$datasource",
+      "fontSize": "100%",
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 98
+      },
+      "id": 62,
+      "links": [],
+      "pageSize": null,
+      "scroll": true,
+      "showHeader": true,
+      "sort": {
+        "col": 2,
+        "desc": true
+      },
+      "styles": [
+        {
+          "alias": "Time",
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "pattern": "Time",
+          "type": "hidden"
+        },
+        {
+          "alias": "",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "mappingType": 1,
+          "pattern": "fork_tag",
+          "thresholds": [],
+          "type": "hidden",
+          "unit": "short"
+        },
+        {
+          "alias": "Fork",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 0,
+          "mappingType": 1,
+          "pattern": "fork",
+          "thresholds": [],
+          "type": "number",
+          "unit": "none"
+        },
+        {
+          "alias": "# Nodes Reporting",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 0,
+          "mappingType": 1,
+          "pattern": "nodes_reporting",
+          "thresholds": [],
+          "type": "number",
+          "unit": "none"
+        },
+        {
+          "alias": "Mean Percentage Stake",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "mappingType": 1,
+          "pattern": "percentage_stake",
+          "thresholds": [],
+          "type": "number",
+          "unit": "short"
+        },
+        {
+          "alias": "",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "decimals": 0,
+          "pattern": "/.*/",
+          "thresholds": [],
+          "type": "number",
+          "unit": "short"
+        }
+      ],
+      "targets": [
+        {
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT mean(fork) as fork, mean(last) as percentage_stake, count(host_id) as nodes_reporting from (SELECT fork, last, host_id from (SELECT fork, root, last(percentage_stake) FROM  \"$testnet\".\"autogen\".\"stake-percentage\" WHERE $timeFilter GROUP BY fork_tag, host_id) WHERE fork > root) GROUP BY fork_tag",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "table",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "title": "Fork Percentage Stake",
+      "transform": "table",
+      "type": "table"
     }
   ],
   "refresh": "60s",

--- a/metrics/scripts/grafana-provisioning/dashboards/testnet-monitor.json
+++ b/metrics/scripts/grafana-provisioning/dashboards/testnet-monitor.json
@@ -7979,6 +7979,19 @@
       "type": "row"
     },
     {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 97
+      },
+      "id": 61,
+      "panels": [],
+      "title": "Fork Confidence",
+      "type": "row"
+    },
+    {
       "columns": [],
       "datasource": "$datasource",
       "fontSize": "100%",
@@ -8061,12 +8074,28 @@
             "rgba(50, 172, 45, 0.97)"
           ],
           "dateFormat": "YYYY-MM-DD HH:mm:ss",
-          "decimals": 2,
+          "decimals": 0,
           "mappingType": 1,
           "pattern": "percentage_stake",
           "thresholds": [],
           "type": "number",
-          "unit": "short"
+          "unit": "percentunit"
+        },
+        {
+          "alias": "Parent",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 0,
+          "mappingType": 1,
+          "pattern": "parent",
+          "thresholds": [],
+          "type": "number",
+          "unit": "none"
         },
         {
           "alias": "",
@@ -8101,7 +8130,7 @@
           ],
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "SELECT mean(fork) as fork, mean(last) as percentage_stake, count(host_id) as nodes_reporting from (SELECT fork, last, host_id from (SELECT fork, root, last(percentage_stake) FROM  \"$testnet\".\"autogen\".\"stake-percentage\" WHERE $timeFilter GROUP BY fork_tag, host_id) WHERE fork > root) GROUP BY fork_tag",
+          "query": "SELECT mean(fork) as fork, mean(parent) as parent, mean(last) as percentage_stake, count(host_id) as nodes_reporting from (SELECT fork, parent, last, host_id from (SELECT fork, root, parent, last(percentage_stake) FROM  \"$testnet\".\"autogen\".\"stake-percentage\" WHERE $timeFilter GROUP BY fork_tag, host_id) WHERE fork > root AND root != 0) GROUP BY fork_tag",
           "rawQuery": true,
           "refId": "A",
           "resultFormat": "table",


### PR DESCRIPTION
First and foremost, this change emits fork stake percentage every time it is updated by a validator.
It also adds an initial display implementation to our grafana dashboard, displaying the mean stake-percentage and number of reporting nodes for each fork, limited to those forks that have not been squashed.
A better display might be a scatter plot, but I had a hard time making grafana do my bidding using fork (instead of time) as the x-axis.

@aeyakovenko , would love feedback on the kind of display you want here.

Closes #5007 
