### PR TITLE
Enforce that only the system account can change the size of the account data

### DIFF
--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -85,9 +85,7 @@ fn verify_instruction(
     }
 
     // Only system accounts can change the size of the data.
-    if !system_program::check_id(&program_id)
-        && pre_data.len() != account.data.len()
-    {
+    if !system_program::check_id(&program_id) && pre_data.len() != account.data.len() {
         return Err(InstructionError::AccountDataSizeChanged);
     }
     // For accounts unassigned to the program, the data may not change.

--- a/sdk/src/instruction.rs
+++ b/sdk/src/instruction.rs
@@ -64,6 +64,9 @@ pub enum InstructionError {
     /// Executable bit on account changed, but shouldn't have
     ExecutableModified,
 
+    /// A non-system program changed the size of the account data
+    AccountDataSizeChanged,
+
     /// CustomError allows on-chain programs to implement program-specific error types and see
     /// them returned by the Solana runtime. A CustomError may be any type that is represented
     /// as or serialized to a u32 integer.


### PR DESCRIPTION
#### Problem

A program could grow or shrink the size of an account's data, account data allocation should only be done by the system program

#### Summary of Changes

Enforce that only the system program can change account data size

Fixes #
