### PR TITLE
Surface --voting-keypair to release users

### DIFF
--- a/book/src/testnet-participation.md
+++ b/book/src/testnet-participation.md
@@ -144,28 +144,42 @@ $ solana-gossip --entrypoint testnet.solana.com:8001 spy
 # Press ^C to exit
 ```
 
-Now configure a key pair for your validator by running:
+Now create an identity keypair for your validator by running:
 ```bash
 $ solana-keygen new -o ~/validator-keypair.json
 ```
+and airdrop yourself some lamports to get started:
+```bash
+$ solana-wallet --keypair ~/validator-keypair.json airdrop 1000
+```
+
+Your validator will need a vote account.  Create it now with the following
+commands:
+```bash
+$ solana-keygen new -o ~/validator-vote-keypair.json
+$ VOTE_PUBKEY=$(solana-keygen pubkey ~/validator-vote-keypair.json)
+$ IDENTITY_PUBKEY=$(solana-keygen pubkey ~/validator-keypair.json)
+$ solana-wallet create-vote-account "$VOTE_PUBKEY" "$IDENTITY_PUBKEY" 1
+```
+
 
 Then use one of the following commands, depending on your installation
 choice, to start the node:
 
 If this is a `solana-install`-installation:
 ```bash
-$ validator.sh --identity ~/validator-keypair.json --config-dir ~/validator-config --rpc-port 8899 --poll-for-new-genesis-block testnet.solana.com
+$ validator.sh --identity ~/validator-keypair.json --voting-keypair ~/validator-vote-keypair.json --config-dir ~/validator-config --rpc-port 8899 --poll-for-new-genesis-block testnet.solana.com
 ```
 
 Alternatively, the `solana-install run` command can be used to run the validator
 node while periodically checking for and applying software updates:
 ```bash
-$ solana-install run validator.sh -- --identity ~/validator-keypair.json --config-dir ~/validator-config --rpc-port 8899 --poll-for-new-genesis-block testnet.solana.com
+$ solana-install run validator.sh -- --identity ~/validator-keypair.json --voting-keypair ~/validator-vote-keypair.json --config-dir ~/validator-config --rpc-port 8899 --poll-for-new-genesis-block testnet.solana.com
 ```
 
 If you built from source:
 ```bash
-$ NDEBUG=1 USE_INSTALL=1 ./multinode-demo/validator.sh --identity ~/validator-keypair.json --rpc-port 8899 --poll-for-new-genesis-block testnet.solana.com
+$ NDEBUG=1 USE_INSTALL=1 ./multinode-demo/validator.sh --identity ~/validator-keypair.json --voting-keypair ~/validator-vote-keypair.json --rpc-port 8899 --poll-for-new-genesis-block testnet.solana.com
 ```
 
 #### Enabling CUDA
@@ -221,10 +235,7 @@ $ solana-wallet show-vote-account 2ozWvfaXQd1X6uKh8jERoRGApDqSqcEy6fF1oN13LL2G
 
 The vote pubkey for the validator can also be found by running:
 ```bash
-# If this is a `solana-install`-installation run:
-$ solana-keygen pubkey ~/.local/share/solana/install/active_release/config/validator-vote-keypair.json
-# Otherwise run:
-$ solana-keygen pubkey ./config/validator-vote-keypair.json
+$ solana-keygen pubkey ~/validator-vote-keypair.json
 ```
 
 #### Validator Metrics

--- a/ci/publish-tarball.sh
+++ b/ci/publish-tarball.sh
@@ -102,6 +102,7 @@ set -e
 cd "$(dirname "$0")"/..
 export USE_INSTALL=1
 export REQUIRE_CONFIG_DIR=1
+export REQUIRE_KEYPAIRS=1
 exec multinode-demo/validator.sh "$@"
 EOF
   chmod +x solana-release/bin/validator.sh

--- a/multinode-demo/validator.sh
+++ b/multinode-demo/validator.sh
@@ -76,6 +76,7 @@ node_lamports=424242  # number of lamports to airdrop the node for transaction f
 poll_for_new_genesis_block=0
 label=
 identity_keypair_path=
+voting_keypair_path=
 no_restart=0
 # TODO: Enable boot_from_snapshot when snapshots work
 #boot_from_snapshot=1
@@ -180,6 +181,15 @@ if [[ -n $REQUIRE_CONFIG_DIR ]]; then
   SOLANA_CONFIG_DIR="$config_dir"
 fi
 
+if [[ -n $REQUIRE_KEYPAIRS ]]; then
+  if [[ -z $identity_keypair_path ]]; then
+    usage "Error: --identity not specified"
+  fi
+  if [[ -z $voting_keypair_path ]]; then
+    usage "Error: --voting-keypair not specified"
+  fi
+fi
+
 if [[ -z "$config_dir" ]]; then
   config_dir="$SOLANA_CONFIG_DIR/validator$label"
 fi
@@ -216,7 +226,6 @@ drone_address="${gossip_entrypoint%:*}":9900
 
 ledger_config_dir=$config_dir/ledger
 state_dir="$config_dir"/state
-configured_flag=$config_dir/.configured
 
 default_arg --entrypoint "$gossip_entrypoint"
 if ((airdrops_enabled)); then
@@ -300,7 +309,7 @@ while true; do
     # over again
     (
       set -x
-      rm -rf "$ledger_config_dir" "$state_dir" "$configured_flag"
+      rm -rf "$ledger_config_dir" "$state_dir"
     )
   fi
 

--- a/multinode-demo/validator.sh
+++ b/multinode-demo/validator.sh
@@ -33,61 +33,50 @@ EOF
   exit 1
 }
 
+
+wallet() {
+  (
+    set -x
+    $solana_wallet --keypair "$identity_keypair_path" --url "$rpc_url" "$@"
+  )
+}
+
 setup_validator_accounts() {
   declare node_lamports=$1
 
-  if [[ -f $configured_flag ]]; then
-    echo "Vote and stake accounts have already been configured"
+  if ((airdrops_enabled)); then
+    echo "Adding $node_lamports to validator identity account:"
+    (
+      declare fees=100 # TODO: No hardcoded transaction fees, fetch the current cluster fees
+      wallet airdrop $((node_lamports+fees))
+    ) || return $?
   else
-    if ((airdrops_enabled)); then
-      echo "Fund the node with enough tokens to fund its Vote, Staking, and Storage accounts"
-      (
-        declare fees=100 # TODO: No hardcoded transaction fees, fetch the current cluster fees
-        set -x
-        $solana_wallet --keypair "$identity_keypair_path" --url "$rpc_url" \
-          airdrop $((node_lamports+fees))
-      ) || return $?
-    else
-      echo "current account balance is "
-      $solana_wallet --keypair "$identity_keypair_path" --url "$rpc_url" balance || return $?
-    fi
-
-    echo "Fund the vote account from the node's identity pubkey"
-    (
-      set -x
-      $solana_wallet --keypair "$identity_keypair_path" --url "$rpc_url" \
-      create-vote-account "$vote_pubkey" "$identity_pubkey" 1 --commission 127
-    ) || return $?
-
-    echo "Create validator storage account"
-    (
-      set -x
-      $solana_wallet --keypair "$identity_keypair_path" --url "$rpc_url" \
-        create-validator-storage-account "$identity_pubkey" "$storage_pubkey"
-    ) || return $?
-
-    touch "$configured_flag"
+    echo "Validator identity account balance:"
+    wallet balance || return $?
   fi
 
-  echo "Identity account balance:"
-  (
-    set -x
-    $solana_wallet --keypair "$identity_keypair_path" --url "$rpc_url" balance
-    $solana_wallet --keypair "$identity_keypair_path" --url "$rpc_url" \
-      show-vote-account "$vote_pubkey"
-    $solana_wallet --keypair "$identity_keypair_path" --url "$rpc_url" \
-      show-storage-account "$storage_pubkey"
-  )
+  if ! wallet show-vote-account "$vote_pubkey"; then
+    echo "Creating validator vote account"
+    wallet create-vote-account "$vote_pubkey" "$identity_pubkey" 1 --commission 127 || return $?
+  fi
+  echo "Validator vote account configured"
+
+  if ! wallet show-storage-account "$storage_pubkey"; then
+    echo "Creating validator storage account"
+    wallet create-validator-storage-account "$identity_pubkey" "$storage_pubkey" || return $?
+  fi
+  echo "Validator storage account configured"
+
   return 0
 }
 
 args=()
-node_lamports=424242  # number of lamports to assign the node for transaction fees
+airdrops_enabled=1
+node_lamports=424242  # number of lamports to airdrop the node for transaction fees (ignored if airdrops_enabled=0)
 poll_for_new_genesis_block=0
 label=
 identity_keypair_path=
 no_restart=0
-airdrops_enabled=1
 # TODO: Enable boot_from_snapshot when snapshots work
 #boot_from_snapshot=1
 boot_from_snapshot=0


### PR DESCRIPTION
Automatically creating the voting account in `validator.sh` for TdS users is harmful and can easily produce a validator with multiple vote accounts, which while is not an error can be quite confusing.  Instead require users create their vote account first