### PR TITLE
Add wallet get-slot command and document how to use it

### DIFF
--- a/book/src/testnet-participation.md
+++ b/book/src/testnet-participation.md
@@ -238,6 +238,26 @@ The vote pubkey for the validator can also be found by running:
 $ solana-keygen pubkey ~/validator-vote-keypair.json
 ```
 
+#### Has my validator caught up?
+After your validator boots it make take some time to catch up with the cluster.
+Use the `get-slot` wallet command to view the current slot that the cluster is
+processing:
+```bash
+$ solana-wallet get-slot
+```
+
+The current slot that your validator is processing can then been seen with:
+```bash
+$ solana-wallet --url http://127.0.0.1:8899 get-slot
+```
+
+Until your validator has caught up it will not be able to vote successfully and
+stake cannot be delegated to it.
+
+Also if you find the cluster's slot advancing faster than yours, you will likely
+never catch up.  This typically implies some kind of networking issue between
+your validator and the rest of the cluster.
+
 #### Validator Metrics
 Metrics are available for local monitoring of your validator.
 

--- a/book/src/testnet-participation.md
+++ b/book/src/testnet-participation.md
@@ -239,7 +239,7 @@ $ solana-keygen pubkey ~/validator-vote-keypair.json
 ```
 
 #### Has my validator caught up?
-After your validator boots it make take some time to catch up with the cluster.
+After your validator boots, it may take some time to catch up with the cluster.
 Use the `get-slot` wallet command to view the current slot that the cluster is
 processing:
 ```bash
@@ -251,7 +251,7 @@ The current slot that your validator is processing can then been seen with:
 $ solana-wallet --url http://127.0.0.1:8899 get-slot
 ```
 
-Until your validator has caught up it will not be able to vote successfully and
+Until your validator has caught up, it will not be able to vote successfully and
 stake cannot be delegated to it.
 
 Also if you find the cluster's slot advancing faster than yours, you will likely


### PR DESCRIPTION
#### Problem
So has my validator caught up to the cluster?

#### Summary of Changes
Comparing the output from:
```bash
$ solana-wallet get-slot
```
and
```bash
solana-wallet --url http://127.0.0.1:8899 get-slot
```
will tell you.