### PR TITLE
Rate limit transaction counters

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -228,10 +228,13 @@ impl BankingStage {
             (new_tx_count as f32) / (proc_start.as_s())
         );
 
-        inc_new_counter_info!("banking_stage-rebuffered_packets", rebuffered_packets);
-        inc_new_counter_info!("banking_stage-consumed_buffered_packets", new_tx_count);
-        inc_new_counter_debug!("banking_stage-process_transactions", new_tx_count);
-        inc_new_counter_debug!("banking_stage-dropped_batches_count", dropped_batches_count);
+        inc_new_high_rate_counter_info!("banking_stage-rebuffered_packets", rebuffered_packets);
+        inc_new_high_rate_counter_info!("banking_stage-consumed_buffered_packets", new_tx_count);
+        inc_new_high_rate_counter_debug!("banking_stage-process_transactions", new_tx_count);
+        inc_new_high_rate_counter_debug!(
+            "banking_stage-dropped_batches_count",
+            dropped_batches_count
+        );
 
         Ok(unprocessed_packets)
     }
@@ -810,7 +813,7 @@ impl BankingStage {
             count,
             id,
         );
-        inc_new_counter_debug!("banking_stage-transactions_received", count);
+        inc_new_high_rate_counter_debug!("banking_stage-transactions_received", count);
         let mut proc_start = Measure::start("process_received_packets_process");
         let mut new_tx_count = 0;
 
@@ -882,9 +885,12 @@ impl BankingStage {
             count,
             id,
         );
-        inc_new_counter_debug!("banking_stage-process_packets", count);
-        inc_new_counter_debug!("banking_stage-process_transactions", new_tx_count);
-        inc_new_counter_debug!("banking_stage-dropped_batches_count", dropped_batches_count);
+        inc_new_high_rate_counter_debug!("banking_stage-process_packets", count);
+        inc_new_high_rate_counter_debug!("banking_stage-process_transactions", new_tx_count);
+        inc_new_high_rate_counter_debug!(
+            "banking_stage-dropped_batches_count",
+            dropped_batches_count
+        );
 
         *recv_start = Instant::now();
 

--- a/core/src/cluster_info.rs
+++ b/core/src/cluster_info.rs
@@ -1155,7 +1155,7 @@ impl ClusterInfo {
         stakes: &HashMap<Pubkey, u64>,
     ) -> Vec<SharedBlob> {
         let self_id = me.read().unwrap().gossip.id;
-        inc_new_counter_debug!("cluster_info-push_message", 1, 0, 1000);
+        inc_new_high_rate_counter_debug!("cluster_info-push_message", 1);
 
         let updated: Vec<_> =
             me.write()

--- a/core/src/poh_recorder.rs
+++ b/core/src/poh_recorder.rs
@@ -296,11 +296,9 @@ impl PohRecorder {
     pub fn tick(&mut self) {
         let now = Instant::now();
         let poh_entry = self.poh.lock().unwrap().tick();
-        inc_new_counter_warn!(
+        inc_new_high_rate_counter_warn!(
             "poh_recorder-tick_lock_contention",
-            timing::duration_as_ms(&now.elapsed()) as usize,
-            0,
-            1000
+            timing::duration_as_ms(&now.elapsed()) as usize
         );
         let now = Instant::now();
         if let Some(poh_entry) = poh_entry {
@@ -308,11 +306,9 @@ impl PohRecorder {
             trace!("tick {}", self.tick_height);
 
             if self.start_leader_at_tick.is_none() {
-                inc_new_counter_warn!(
+                inc_new_high_rate_counter_warn!(
                     "poh_recorder-tick_overhead",
-                    timing::duration_as_ms(&now.elapsed()) as usize,
-                    0,
-                    1000
+                    timing::duration_as_ms(&now.elapsed()) as usize
                 );
                 return;
             }
@@ -326,11 +322,9 @@ impl PohRecorder {
             self.tick_cache.push((entry, self.tick_height));
             let _ = self.flush_cache(true);
         }
-        inc_new_counter_warn!(
+        inc_new_high_rate_counter_warn!(
             "poh_recorder-tick_overhead",
-            timing::duration_as_ms(&now.elapsed()) as usize,
-            0,
-            1000
+            timing::duration_as_ms(&now.elapsed()) as usize
         );
     }
 
@@ -356,11 +350,9 @@ impl PohRecorder {
 
             let now = Instant::now();
             if let Some(poh_entry) = self.poh.lock().unwrap().record(mixin) {
-                inc_new_counter_warn!(
+                inc_new_high_rate_counter_warn!(
                     "poh_recorder-record_lock_contention",
-                    timing::duration_as_ms(&now.elapsed()) as usize,
-                    0,
-                    1000
+                    timing::duration_as_ms(&now.elapsed()) as usize
                 );
                 let entry = Entry {
                     num_hashes: poh_entry.num_hashes,

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -556,7 +556,7 @@ impl ReplayStage {
                 );
             }
         }
-        inc_new_counter_info!("replay_stage-replay_transactions", tx_count);
+        inc_new_high_rate_counter_info!("replay_stage-replay_transactions", tx_count);
         did_complete_bank
     }
 

--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -39,12 +39,7 @@ fn retransmit_blobs(blobs: &[SharedBlob], retransmit: &BlobSender, id: &Pubkey) 
     }
 
     if !retransmit_queue.is_empty() {
-        inc_new_counter_debug!(
-            "streamer-recv_window-retransmit",
-            retransmit_queue.len(),
-            0,
-            1000
-        );
+        inc_new_high_rate_counter_debug!("streamer-recv_window-retransmit", retransmit_queue.len());
         retransmit.send(retransmit_queue)?;
     }
     Ok(())
@@ -118,7 +113,7 @@ where
         blobs.append(&mut blob)
     }
     let now = Instant::now();
-    inc_new_counter_debug!("streamer-recv_window-recv", blobs.len(), 0, 1000);
+    inc_new_high_rate_counter_debug!("streamer-recv_window-recv", blobs.len());
 
     let blobs: Vec<_> = thread_pool.install(|| {
         blobs

--- a/metrics/src/counter.rs
+++ b/metrics/src/counter.rs
@@ -6,7 +6,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 
 const DEFAULT_LOG_RATE: usize = 1000;
 const DEFAULT_METRICS_RATE: usize = 1;
-const DEFAULT_METRICS_HIGH_RATE: usize = 1000;
+const DEFAULT_METRICS_HIGH_RATE: usize = 10;
 
 /// Use default metrics high rate
 pub const HIGH_RATE: usize = 999_999;
@@ -319,6 +319,7 @@ mod tests {
             .ok();
         let _readlock = get_env_lock().read();
         static mut COUNTER: Counter = create_counter!("test", 1000, HIGH_RATE);
+        env::remove_var("SOLANA_METRICS_HIGH_RATE");
         unsafe {
             COUNTER.init();
             assert_eq!(
@@ -334,7 +335,7 @@ mod tests {
         env_logger::Builder::from_env(env_logger::Env::new().default_filter_or("solana=info"))
             .try_init()
             .ok();
-        let _readlock = get_env_lock().read();
+        let _writelock = get_env_lock().write();
         static mut COUNTER: Counter = create_counter!("test", 1000, HIGH_RATE);
         env::set_var("SOLANA_METRICS_HIGH_RATE", "50");
         unsafe {

--- a/multinode-demo/common.sh
+++ b/multinode-demo/common.sh
@@ -59,7 +59,10 @@ solana_wallet=$(solana_program wallet)
 solana_replicator=$(solana_program replicator)
 
 export RUST_BACKTRACE=1
-export SOLANA_METRICS_HIGH_RATE=1000
+
+if [[ -z $SOLANA_METRICS_HIGH_RATE ]]; then
+  export SOLANA_METRICS_HIGH_RATE=1000
+fi
 
 # shellcheck source=scripts/configure-metrics.sh
 source "$SOLANA_ROOT"/scripts/configure-metrics.sh

--- a/multinode-demo/common.sh
+++ b/multinode-demo/common.sh
@@ -59,6 +59,7 @@ solana_wallet=$(solana_program wallet)
 solana_replicator=$(solana_program replicator)
 
 export RUST_BACKTRACE=1
+export SOLANA_METRICS_HIGH_RATE=10
 
 # shellcheck source=scripts/configure-metrics.sh
 source "$SOLANA_ROOT"/scripts/configure-metrics.sh

--- a/multinode-demo/common.sh
+++ b/multinode-demo/common.sh
@@ -59,7 +59,7 @@ solana_wallet=$(solana_program wallet)
 solana_replicator=$(solana_program replicator)
 
 export RUST_BACKTRACE=1
-export SOLANA_METRICS_HIGH_RATE=10
+export SOLANA_METRICS_HIGH_RATE=1000
 
 # shellcheck source=scripts/configure-metrics.sh
 source "$SOLANA_ROOT"/scripts/configure-metrics.sh

--- a/programs/exchange_api/src/exchange_processor.rs
+++ b/programs/exchange_api/src/exchange_processor.rs
@@ -4,7 +4,7 @@ use crate::exchange_instruction::*;
 use crate::exchange_state::*;
 use crate::faucet;
 use log::*;
-use solana_metrics::inc_new_counter_info;
+use solana_metrics::inc_new_high_rate_counter_info;
 use solana_sdk::account::KeyedAccount;
 use solana_sdk::instruction::InstructionError;
 use solana_sdk::pubkey::Pubkey;
@@ -296,7 +296,7 @@ impl ExchangeProcessor {
         // Trade holds the tokens in escrow
         account.tokens[from_token] -= info.tokens;
 
-        inc_new_counter_info!("exchange_processor-trades", 1, 1000, 1000);
+        inc_new_high_rate_counter_info!("exchange_processor-trades", 1);
 
         Self::serialize(
             &ExchangeState::Trade(OrderInfo {
@@ -390,7 +390,7 @@ impl ExchangeProcessor {
             Err(e)?
         }
 
-        inc_new_counter_info!("exchange_processor-swaps", 1, 1000, 1000);
+        inc_new_high_rate_counter_info!("exchange_processor-swaps", 1);
 
         if to_order.tokens == 0 {
             // Turn into token account

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1043,7 +1043,7 @@ impl Bank {
                 0,
                 1000
             );
-            inc_new_counter_error!("bank-process_transactions-error_count", err_count, 0, 1000);
+            inc_new_counter_error!("bank-process_transactions-error_count", err_count);
         }
 
         Self::update_error_counters(&error_counters);
@@ -1115,8 +1115,8 @@ impl Bank {
         self.increment_transaction_count(tx_count);
         self.increment_signature_count(signature_count);
 
-        inc_new_counter_info!("bank-process_transactions-txs", tx_count, 0, 1000);
-        inc_new_counter_info!("bank-process_transactions-sigs", signature_count, 0, 1000);
+        inc_new_counter_info!("bank-process_transactions-txs", tx_count);
+        inc_new_counter_info!("bank-process_transactions-sigs", signature_count);
 
         if executed.iter().any(|res| Self::can_commit(res)) {
             self.is_delta.store(true, Ordering::Relaxed);

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -25,7 +25,7 @@ use log::*;
 use serde::{Deserialize, Serialize};
 use solana_measure::measure::Measure;
 use solana_metrics::{
-    datapoint_info, inc_new_counter_debug, inc_new_counter_error, inc_new_counter_info,
+    datapoint_info, inc_new_counter_debug, inc_new_counter_error, inc_new_high_rate_counter_info,
 };
 use solana_sdk::account::Account;
 use solana_sdk::fee_calculator::FeeCalculator;
@@ -905,59 +905,45 @@ impl Bank {
 
     fn update_error_counters(error_counters: &ErrorCounters) {
         if 0 != error_counters.blockhash_not_found {
-            inc_new_counter_error!(
+            inc_new_high_rate_counter_error!(
                 "bank-process_transactions-error-blockhash_not_found",
-                error_counters.blockhash_not_found,
-                0,
-                1000
+                error_counters.blockhash_not_found
             );
         }
         if 0 != error_counters.invalid_account_index {
-            inc_new_counter_error!(
+            inc_new_high_rate_counter_error!(
                 "bank-process_transactions-error-invalid_account_index",
-                error_counters.invalid_account_index,
-                0,
-                1000
+                error_counters.invalid_account_index
             );
         }
         if 0 != error_counters.reserve_blockhash {
-            inc_new_counter_error!(
+            inc_new_high_rate_counter_error!(
                 "bank-process_transactions-error-reserve_blockhash",
-                error_counters.reserve_blockhash,
-                0,
-                1000
+                error_counters.reserve_blockhash
             );
         }
         if 0 != error_counters.duplicate_signature {
-            inc_new_counter_error!(
+            inc_new_high_rate_counter_error!(
                 "bank-process_transactions-error-duplicate_signature",
-                error_counters.duplicate_signature,
-                0,
-                1000
+                error_counters.duplicate_signature
             );
         }
         if 0 != error_counters.invalid_account_for_fee {
-            inc_new_counter_error!(
+            inc_new_high_rate_counter_error!(
                 "bank-process_transactions-error-invalid_account_for_fee",
-                error_counters.invalid_account_for_fee,
-                0,
-                1000
+                error_counters.invalid_account_for_fee
             );
         }
         if 0 != error_counters.insufficient_funds {
-            inc_new_counter_error!(
+            inc_new_high_rate_counter_error!(
                 "bank-process_transactions-error-insufficient_funds",
-                error_counters.insufficient_funds,
-                0,
-                1000
+                error_counters.insufficient_funds
             );
         }
         if 0 != error_counters.account_loaded_twice {
-            inc_new_counter_error!(
+            inc_new_high_rate_counter_error!(
                 "bank-process_transactions-account_loaded_twice",
-                error_counters.account_loaded_twice,
-                0,
-                1000
+                error_counters.account_loaded_twice
             );
         }
     }
@@ -976,7 +962,7 @@ impl Bank {
         usize,
     ) {
         debug!("processing transactions: {}", txs.len());
-        inc_new_counter_info!("bank-process_transactions", txs.len());
+        inc_new_high_rate_counter_info!("bank-process_transactions", txs.len());
         let mut error_counters = ErrorCounters::default();
         let mut load_time = Measure::start("accounts_load");
 
@@ -1037,11 +1023,9 @@ impl Bank {
         }
         if err_count > 0 {
             debug!("{} errors of {} txs", err_count, err_count + tx_count);
-            inc_new_counter_error!(
+            inc_new_high_rate_counter_error!(
                 "bank-process_transactions-account_not_found",
-                error_counters.account_not_found,
-                0,
-                1000
+                error_counters.account_not_found
             );
             inc_new_counter_error!("bank-process_transactions-error_count", err_count);
         }
@@ -1115,8 +1099,8 @@ impl Bank {
         self.increment_transaction_count(tx_count);
         self.increment_signature_count(signature_count);
 
-        inc_new_counter_info!("bank-process_transactions-txs", tx_count);
-        inc_new_counter_info!("bank-process_transactions-sigs", signature_count);
+        inc_new_high_rate_counter_info!("bank-process_transactions-txs", tx_count);
+        inc_new_high_rate_counter_info!("bank-process_transactions-sigs", signature_count);
 
         if executed.iter().any(|res| Self::can_commit(res)) {
             self.is_delta.store(true, Ordering::Relaxed);


### PR DESCRIPTION
#### Problem
Metric counters are getting dropped during tps benchmarks

#### Summary of Changes
* allow setting a high metrics rate via env var
* default high metrics rate to 1000
* introduce new macros for high rate counters

Fixes https://github.com/solana-labs/solana/issues/5422
