### PR TITLE
validator: Add --dev-halt-at-slot option

### DIFF
--- a/core/tests/tvu.rs
+++ b/core/tests/tvu.rs
@@ -97,7 +97,7 @@ fn test_replay() {
         completed_slots_receiver,
         leader_schedule_cache,
         _,
-    ) = validator::new_banks_from_blocktree(&blocktree_path, None, None, true);
+    ) = validator::new_banks_from_blocktree(&blocktree_path, None, None, true, None);
     let working_bank = bank_forks.working_bank();
     assert_eq!(
         working_bank.get_balance(&mint_keypair.pubkey()),

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -149,7 +149,7 @@ fn main() {
         }
         ("verify", _) => {
             println!("Verifying ledger...");
-            match process_blocktree(&genesis_block, &blocktree, None, true) {
+            match process_blocktree(&genesis_block, &blocktree, None, true, None) {
                 Ok((_bank_forks, bank_forks_info, _)) => {
                     println!("{:?}", bank_forks_info);
                 }

--- a/multinode-demo/validator.sh
+++ b/multinode-demo/validator.sh
@@ -97,7 +97,7 @@ while [[ -n $1 ]]; do
     elif [[ $1 = --skip-ledger-verify ]]; then
       args+=("$1")
       shift
-    elif [[ $1 = --no-sigverify ]]; then
+    elif [[ $1 = --dev-no-sigverify ]]; then
       args+=("$1")
       shift
     elif [[ $1 = --limit-ledger-size ]]; then


### PR DESCRIPTION
Starting `solana-validator` with `--dev-halt-at-slot` allows you to boot the validator to any desired slot that it already has in it's ledger and then poke at it over RPC.

Fixes #5445
