### PR TITLE
Rpc to return software version

### DIFF
--- a/book/src/jsonrpc-api.md
+++ b/book/src/jsonrpc-api.md
@@ -39,7 +39,7 @@ Methods
 * [getNumBlocksSinceSignatureConfirmation](#getnumblockssincesignatureconfirmation)
 * [getTransactionCount](#gettransactioncount)
 * [getTotalSupply](#gettotalsupply)
-* [getVersion](#getsoftwareversion)
+* [getVersion](#getversion)
 * [requestAirdrop](#requestairdrop)
 * [sendTransaction](#sendtransaction)
 * [startSubscriptionChannel](#startsubscriptionchannel)

--- a/book/src/jsonrpc-api.md
+++ b/book/src/jsonrpc-api.md
@@ -33,6 +33,7 @@ Methods
 * [getSlot](#getslot)
 * [getSlotLeader](#getslotleader)
 * [getSlotsPerSegment](#getslotspersegment)
+* [getSoftwareVersion](#getsoftwareversion)
 * [getStorageTurn](#getstorageturn)
 * [getStorageTurnRate](#getstorageturnrate)
 * [getNumBlocksSinceSignatureConfirmation](#getnumblockssincesignatureconfirmation)
@@ -348,6 +349,23 @@ None
 curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1, "method":"getSlotsPerSegment"}' http://localhost:8899
 // Result
 {"jsonrpc":"2.0","result":"1024","id":1}
+```
+
+### getSoftwareVersion
+Returns the current solana software version running on the node
+
+##### Parameters:
+None
+
+##### Results:
+* `string` - software version
+
+##### Example:
+```bash
+// Request
+curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1, "method":"getSoftwareVersion"}' http://localhost:8899
+// Result
+{"jsonrpc":"2.0","result":"0.17.2","id":1}
 ```
 
 ----

--- a/book/src/jsonrpc-api.md
+++ b/book/src/jsonrpc-api.md
@@ -26,6 +26,7 @@ Methods
 * [getBalance](#getbalance)
 * [getClusterNodes](#getclusternodes)
 * [getEpochInfo](#getepochinfo)
+* [getEpochVoteAccounts](#getepochvoteaccounts)
 * [getLeaderSchedule](#getleaderschedule)
 * [getProgramAccounts](#getprogramaccounts)
 * [getRecentBlockhash](#getrecentblockhash)
@@ -33,13 +34,12 @@ Methods
 * [getSlot](#getslot)
 * [getSlotLeader](#getslotleader)
 * [getSlotsPerSegment](#getslotspersegment)
-* [getSoftwareVersion](#getsoftwareversion)
 * [getStorageTurn](#getstorageturn)
 * [getStorageTurnRate](#getstorageturnrate)
 * [getNumBlocksSinceSignatureConfirmation](#getnumblockssincesignatureconfirmation)
 * [getTransactionCount](#gettransactioncount)
 * [getTotalSupply](#gettotalsupply)
-* [getEpochVoteAccounts](#getepochvoteaccounts)
+* [getVersion](#getsoftwareversion)
 * [requestAirdrop](#requestairdrop)
 * [sendTransaction](#sendtransaction)
 * [startSubscriptionChannel](#startsubscriptionchannel)
@@ -199,6 +199,30 @@ curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1, "m
 
 ---
 
+### getEpochVoteAccounts
+Returns the account info and associated stake for all the voting accounts in the current epoch.
+
+##### Parameters:
+None
+
+##### Results:
+The result field will be an array of JSON objects, each with the following sub fields:
+* `votePubkey` - Vote account public key, as base-58 encoded string
+* `nodePubkey` - Node public key, as base-58 encoded string
+* `stake` - the stake, in lamports, delegated to this vote account
+* `commission`, a 32-bit integer used as a fraction (commission/MAX_U32) for rewards payout
+
+##### Example:
+```bash
+// Request
+curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1, "method":"getEpochVoteAccounts"}' http://localhost:8899
+
+// Result
+{"jsonrpc":"2.0","result":[{"commission":0,"nodePubkey":"Et2RaZJdJRTzTkodUwiHr4H6sLkVmijBFv8tkd7oSSFY","stake":42,"votePubkey":"B4CdWq3NBSoH2wYsVE1CaZSWPo2ZtopE4SJipQhZ3srF"}],"id":1}
+```
+
+---
+
 ### getLeaderSchedule
 Returns the leader schedule for the current epoch
 
@@ -351,23 +375,6 @@ curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1, "m
 {"jsonrpc":"2.0","result":"1024","id":1}
 ```
 
-### getSoftwareVersion
-Returns the current solana software version running on the node
-
-##### Parameters:
-None
-
-##### Results:
-* `string` - software version
-
-##### Example:
-```bash
-// Request
-curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1, "method":"getSoftwareVersion"}' http://localhost:8899
-// Result
-{"jsonrpc":"2.0","result":"0.17.2","id":1}
-```
-
 ----
 
 ### getStorageTurn
@@ -471,30 +478,25 @@ curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1, "m
 
 ---
 
-### getEpochVoteAccounts
-Returns the account info and associated stake for all the voting accounts in the current epoch.
+### getVersion
+Returns the current solana versions running on the node
 
 ##### Parameters:
 None
 
 ##### Results:
-The result field will be an array of JSON objects, each with the following sub fields:
-* `votePubkey` - Vote account public key, as base-58 encoded string
-* `nodePubkey` - Node public key, as base-58 encoded string
-* `stake` - the stake, in lamports, delegated to this vote account
-* `commission`, a 32-bit integer used as a fraction (commission/MAX_U32) for rewards payout
+The result field will be a JSON object with the following sub fields:
+* `solana-core`, software version of solana-core
 
 ##### Example:
 ```bash
 // Request
-curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1, "method":"getEpochVoteAccounts"}' http://localhost:8899
-
+curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1, "method":"getVersion"}' http://localhost:8899
 // Result
-{"jsonrpc":"2.0","result":[{"commission":0,"nodePubkey":"Et2RaZJdJRTzTkodUwiHr4H6sLkVmijBFv8tkd7oSSFY","stake":42,"votePubkey":"B4CdWq3NBSoH2wYsVE1CaZSWPo2ZtopE4SJipQhZ3srF"}],"id":1}
+{"jsonrpc":"2.0","result":{"solana-core": "0.17.2"},"id":1}
 ```
 
 ---
-
 
 ### requestAirdrop
 Requests an airdrop of lamports to a Pubkey

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -73,6 +73,7 @@ pub mod test_tx;
 pub mod tpu;
 pub mod tvu;
 pub mod validator;
+pub(crate) mod version;
 pub mod weighted_shuffle;
 pub mod window_service;
 

--- a/core/src/version.rs
+++ b/core/src/version.rs
@@ -1,0 +1,1 @@
+pub(crate) const VERSION: &str = env!("CARGO_PKG_VERSION");


### PR DESCRIPTION
#### Problem
No easy way to figure out what software version a testnet is running.
Versions may feature breaking changes, so a mismatch with an entrypoint node can cause unexpected errors for validators.

#### Summary of Changes
Adds getSoftwareVersion rpc that reports the solana-core version number of the compiled crate. I put the VERSION const in its own module because it didn't seem to sort anywhere else, but it could easily go in rpc.rs and be accessed locally if it seems like too much muss as is.

Toward #5435 
