### PR TITLE
Un-finalized Move program account format is now same as mvir compiler outputs

### DIFF
--- a/programs/move_loader_api/src/account_state.rs
+++ b/programs/move_loader_api/src/account_state.rs
@@ -9,6 +9,7 @@ use stdlib::stdlib_modules;
 use types::{
     account_address::AccountAddress,
     byte_array::ByteArray,
+    transaction::Program,
     write_set::{WriteOp, WriteSet},
 };
 use vm::{
@@ -38,11 +39,8 @@ fn to_array_32(array: &[u8]) -> &[u8; 32] {
 pub enum LibraAccountState {
     /// No data for this account yet
     Unallocated,
-    /// Serialized compiled program bytes
-    CompiledProgram {
-        script_bytes: Vec<u8>,
-        modules_bytes: Vec<Vec<u8>>,
-    },
+    /// Json string representation of types::transaction::Program
+    CompiledProgram(String),
     /// Serialized verified program bytes
     VerifiedProgram {
         script_bytes: Vec<u8>,
@@ -101,10 +99,9 @@ impl LibraAccountState {
                 .expect("Unable to serialize module");
             modules_bytes.push(buf);
         }
-        LibraAccountState::CompiledProgram {
-            script_bytes,
-            modules_bytes,
-        }
+        LibraAccountState::CompiledProgram(
+            serde_json::to_string(&Program::new(script_bytes, modules_bytes, vec![])).unwrap(),
+        )
     }
 
     pub fn create_user(owner: &Pubkey, write_set: WriteSet) -> Self {

--- a/programs/move_loader_api/src/error_mappers.rs
+++ b/programs/move_loader_api/src/error_mappers.rs
@@ -25,6 +25,11 @@ pub fn map_data_error(err: std::boxed::Box<bincode::ErrorKind>) -> InstructionEr
     debug!("Error: Account data: {:?}", err);
     InstructionError::InvalidAccountData
 }
+#[allow(clippy::needless_pass_by_value)]
+pub fn map_json_error(err: serde_json::error::Error) -> InstructionError {
+    debug!("Error: serde_json: {:?}", err);
+    InstructionError::InvalidAccountData
+}
 pub fn map_vm_verification_error(
     err: (CompiledModule, Vec<vm::errors::VerificationError>),
 ) -> InstructionError {


### PR DESCRIPTION
#### Problem

Un-finalized Move program accounts don't match what Libra's Move IR compiler outputs which results in multiple unnecessary conversions end-to-end when loading a Move program.

#### Summary of Changes

Un-finalized program account now holds the same output as the Move IR compiler generates (besides being wrapped in a `LibraAccountState` enum).

Fixes #
