### PR TITLE
Bump solana_libra packages to v0.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,6 +80,14 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "ascii-canvas"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "term 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "assert_cmd"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -611,13 +619,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "crossbeam"
-version = "0.4.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "crossbeam-channel 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossbeam-deque 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossbeam-epoch 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossbeam-utils 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-channel 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-deque 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-epoch 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -635,31 +647,10 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "crossbeam-epoch 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossbeam-utils 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "crossbeam-channel"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "crossbeam-deque"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "crossbeam-epoch 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossbeam-utils 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -682,32 +673,6 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "arrayvec 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossbeam-utils 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "arrayvec 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "crossbeam-epoch"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -726,11 +691,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "crossbeam-utils"
@@ -792,6 +752,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "diff"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "difference"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -851,6 +816,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "docopt"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
+ "strsim 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "dtoa"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -905,6 +881,14 @@ dependencies = [
  "rayon 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "ena"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1595,6 +1579,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "lalrpop"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ascii-canvas 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bit-set 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "diff 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "docopt 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ena 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lalrpop-util 0.16.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "petgraph 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "term 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "lalrpop-util"
 version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1730,11 +1738,6 @@ dependencies = [
  "libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "memoffset"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "memoffset"
@@ -1890,6 +1893,11 @@ dependencies = [
  "libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "new_debug_unreachable"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "nibble_vec"
@@ -2079,15 +2087,6 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "lock_api 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "parking_lot_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "parking_lot"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -2112,18 +2111,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2221,6 +2208,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "ppv-lite86"
 version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "precomputed-hash"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -2385,18 +2377,6 @@ dependencies = [
  "libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "rand"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3478,8 +3458,8 @@ dependencies = [
  "solana-move-loader-api 0.18.0-pre1",
  "solana-runtime 0.18.0-pre1",
  "solana-sdk 0.18.0-pre1",
- "solana_libra_language_e2e_tests 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana_libra_types 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_libra_language_e2e_tests 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_libra_types 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3534,16 +3514,16 @@ dependencies = [
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-logger 0.18.0-pre1",
  "solana-sdk 0.18.0-pre1",
- "solana_libra_bytecode_verifier 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana_libra_compiler 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana_libra_failure_ext 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana_libra_language_e2e_tests 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana_libra_state_view 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana_libra_stdlib 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana_libra_types 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana_libra_vm 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana_libra_vm_cache_map 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana_libra_vm_runtime 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_libra_bytecode_verifier 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_libra_compiler 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_libra_failure_ext 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_libra_language_e2e_tests 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_libra_state_view 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_libra_stdlib 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_libra_types 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_libra_vm 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_libra_vm_cache_map 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_libra_vm_runtime 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3863,44 +3843,44 @@ dependencies = [
 
 [[package]]
 name = "solana_libra_bytecode_verifier"
-version = "0.0.0-sol15"
+version = "0.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "mirai-annotations 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "petgraph 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana_libra_failure_ext 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana_libra_types 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana_libra_vm 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_libra_failure_ext 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_libra_types 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_libra_vm 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "solana_libra_canonical_serialization"
-version = "0.0.0-sol15"
+version = "0.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana_libra_failure_ext 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_libra_failure_ext 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "solana_libra_compiler"
-version = "0.0.0-sol15"
+version = "0.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana_libra_bytecode_verifier 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana_libra_failure_ext 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana_libra_ir_to_bytecode 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana_libra_stdlib 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana_libra_types 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana_libra_vm 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_libra_bytecode_verifier 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_libra_failure_ext 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_libra_ir_to_bytecode 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_libra_stdlib 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_libra_types 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_libra_vm 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "solana_libra_config"
-version = "0.0.0-sol15"
+version = "0.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3909,18 +3889,18 @@ dependencies = [
  "parity-multiaddr 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana_libra_crypto 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana_libra_failure_ext 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana_libra_logger 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana_libra_proto_conv 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana_libra_types 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_libra_crypto 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_libra_failure_ext 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_libra_logger 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_libra_proto_conv 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_libra_types 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "solana_libra_crypto"
-version = "0.0.0-sol15"
+version = "0.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3939,9 +3919,9 @@ dependencies = [
  "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha3 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana_libra_crypto-derive 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana_libra_failure_ext 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana_libra_proto_conv 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_libra_crypto-derive 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_libra_failure_ext 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_libra_proto_conv 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "threshold_crypto 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-keccak 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "x25519-dalek 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3949,7 +3929,7 @@ dependencies = [
 
 [[package]]
 name = "solana_libra_crypto-derive"
-version = "0.0.0-sol15"
+version = "0.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3958,21 +3938,21 @@ dependencies = [
 
 [[package]]
 name = "solana_libra_failure_ext"
-version = "0.0.0-sol15"
+version = "0.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana_libra_failure_macros 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_libra_failure_macros 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "solana_libra_failure_macros"
-version = "0.0.0-sol15"
+version = "0.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "solana_libra_ir_to_bytecode"
-version = "0.0.0-sol15"
+version = "0.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "codespan 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3980,28 +3960,29 @@ dependencies = [
  "lalrpop-util 0.16.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana_libra_failure_ext 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana_libra_ir_to_bytecode_syntax 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana_libra_types 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana_libra_vm 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_libra_failure_ext 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_libra_ir_to_bytecode_syntax 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_libra_types 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_libra_vm 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "solana_libra_ir_to_bytecode_syntax"
-version = "0.0.0-sol15"
+version = "0.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "codespan 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "codespan-reporting 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lalrpop 0.16.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "lalrpop-util 0.16.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana_libra_types 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_libra_types 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "solana_libra_language_e2e_tests"
-version = "0.0.0-sol15"
+version = "0.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "assert_matches 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4009,33 +3990,33 @@ dependencies = [
  "proptest 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest-derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana_libra_bytecode_verifier 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana_libra_canonical_serialization 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana_libra_compiler 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana_libra_config 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana_libra_crypto 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana_libra_failure_ext 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana_libra_ir_to_bytecode 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana_libra_logger 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana_libra_proptest_helpers 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana_libra_proto_conv 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana_libra_state_view 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana_libra_stdlib 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana_libra_types 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana_libra_vm 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana_libra_vm_genesis 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana_libra_vm_runtime 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_libra_bytecode_verifier 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_libra_canonical_serialization 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_libra_compiler 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_libra_config 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_libra_crypto 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_libra_failure_ext 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_libra_ir_to_bytecode 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_libra_logger 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_libra_proptest_helpers 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_libra_proto_conv 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_libra_state_view 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_libra_stdlib 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_libra_types 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_libra_vm 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_libra_vm_genesis 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_libra_vm_runtime 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-keccak 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "solana_libra_logger"
-version = "0.0.0-sol15"
+version = "0.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "backtrace 0.3.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossbeam 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.12.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4049,14 +4030,14 @@ dependencies = [
  "slog-envlogger 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog-scope 4.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog-term 2.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana_libra_failure_ext 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_libra_failure_ext 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "thread-id 3.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "solana_libra_metrics"
-version = "0.0.0-sol15"
+version = "0.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4066,26 +4047,26 @@ dependencies = [
  "prometheus 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana_libra_failure_ext 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana_libra_logger 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_libra_failure_ext 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_libra_logger 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "solana_libra_move_ir_natives"
-version = "0.0.0-sol15"
+version = "0.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitcoin_hashes 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana_libra_failure_ext 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana_libra_nextgen_crypto 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana_libra_types 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_libra_failure_ext 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_libra_nextgen_crypto 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_libra_types 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-keccak 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "solana_libra_nextgen_crypto"
-version = "0.0.0-sol15"
+version = "0.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4105,10 +4086,10 @@ dependencies = [
  "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha3 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana_libra_crypto 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana_libra_crypto-derive 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana_libra_failure_ext 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana_libra_proto_conv 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_libra_crypto 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_libra_crypto-derive 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_libra_failure_ext 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_libra_proto_conv 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "threshold_crypto 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-keccak 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "x25519-dalek 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4116,7 +4097,7 @@ dependencies = [
 
 [[package]]
 name = "solana_libra_proptest_helpers"
-version = "0.0.0-sol15"
+version = "0.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "crossbeam 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4126,17 +4107,17 @@ dependencies = [
 
 [[package]]
 name = "solana_libra_proto_conv"
-version = "0.0.0-sol15"
+version = "0.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "protobuf 2.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana_libra_failure_ext 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana_libra_proto_conv_derive 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_libra_failure_ext 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_libra_proto_conv_derive 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "solana_libra_proto_conv_derive"
-version = "0.0.0-sol15"
+version = "0.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4146,27 +4127,27 @@ dependencies = [
 
 [[package]]
 name = "solana_libra_state_view"
-version = "0.0.0-sol15"
+version = "0.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "solana_libra_failure_ext 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana_libra_types 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_libra_failure_ext 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_libra_types 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "solana_libra_stdlib"
-version = "0.0.0-sol15"
+version = "0.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana_libra_bytecode_verifier 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana_libra_ir_to_bytecode 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana_libra_types 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_libra_bytecode_verifier 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_libra_ir_to_bytecode 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_libra_types 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "solana_libra_types"
-version = "0.0.0-sol15"
+version = "0.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bech32 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4183,19 +4164,19 @@ dependencies = [
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana_libra_canonical_serialization 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana_libra_crypto 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana_libra_failure_ext 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana_libra_logger 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana_libra_nextgen_crypto 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana_libra_proptest_helpers 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana_libra_proto_conv 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_libra_canonical_serialization 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_libra_crypto 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_libra_failure_ext 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_libra_logger 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_libra_nextgen_crypto 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_libra_proptest_helpers 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_libra_proto_conv 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-keccak 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "solana_libra_vm"
-version = "0.0.0-sol15"
+version = "0.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4204,15 +4185,15 @@ dependencies = [
  "mirai-annotations 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest-derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana_libra_crypto 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana_libra_failure_ext 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana_libra_proptest_helpers 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana_libra_types 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_libra_crypto 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_libra_failure_ext 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_libra_proptest_helpers 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_libra_types 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "solana_libra_vm_cache_map"
-version = "0.0.0-sol15"
+version = "0.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "chashmap 2.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4221,30 +4202,30 @@ dependencies = [
 
 [[package]]
 name = "solana_libra_vm_genesis"
-version = "0.0.0-sol15"
+version = "0.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana_libra_config 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana_libra_crypto 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana_libra_failure_ext 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana_libra_ir_to_bytecode 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana_libra_proto_conv 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana_libra_state_view 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana_libra_stdlib 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana_libra_types 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana_libra_vm 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana_libra_vm_cache_map 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana_libra_vm_runtime 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_libra_config 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_libra_crypto 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_libra_failure_ext 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_libra_ir_to_bytecode 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_libra_proto_conv 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_libra_state_view 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_libra_stdlib 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_libra_types 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_libra_vm 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_libra_vm_cache_map 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_libra_vm_runtime 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-keccak 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "solana_libra_vm_runtime"
-version = "0.0.0-sol15"
+version = "0.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4253,18 +4234,18 @@ dependencies = [
  "proptest 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rental 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana_libra_bytecode_verifier 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana_libra_canonical_serialization 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana_libra_config 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana_libra_crypto 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana_libra_failure_ext 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana_libra_logger 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana_libra_metrics 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana_libra_move_ir_natives 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana_libra_state_view 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana_libra_types 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana_libra_vm 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana_libra_vm_cache_map 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_libra_bytecode_verifier 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_libra_canonical_serialization 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_libra_config 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_libra_crypto 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_libra_failure_ext 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_libra_logger 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_libra_metrics 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_libra_move_ir_natives 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_libra_state_view 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_libra_types 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_libra_vm 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_libra_vm_cache_map 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-keccak 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -4316,8 +4297,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "string_cache"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "new_debug_unreachable 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "phf_shared 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "precomputed-hash 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache_codegen 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache_shared 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "string_cache_codegen"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "phf_generator 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "phf_shared 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache_shared 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "string_cache_shared"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "strsim"
 version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "strsim"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -4439,6 +4456,15 @@ dependencies = [
  "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
  "remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "term"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -5110,6 +5136,7 @@ dependencies = [
 "checksum arrayref 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0d382e583f07208808f6b1249e60848879ba3543f57c32277bf52d69c2f0f0ee"
 "checksum arrayvec 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)" = "b8d73f9beda665eaa98ab9e4f7442bd4e7de6652587de55b2525e52e29c1b0ba"
 "checksum ascii 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3ae7d751998c189c1d4468cf0a39bb2eae052a9c58d50ebb3b9591ee3813ad50"
+"checksum ascii-canvas 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b385d69402821a1c254533a011a312531cbcc0e3e24f19bbb4747a5a2daf37e2"
 "checksum assert_cmd 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2dc477793bd82ec39799b6f6b3df64938532fdf2ab0d49ef817eac65856a5a1e"
 "checksum assert_matches 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7deb0a829ca7bcfaf5da70b073a8d128619259a7be8216a355e23f00763059e5"
 "checksum atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)" = "1803c647a3ec87095e7ae7acfca019e98de5ec9a7d01343f611cf3152ed71a90"
@@ -5172,18 +5199,13 @@ dependencies = [
 "checksum crc 1.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d663548de7f5cca343f1e0a48d14dcfb0e9eb4e079ec58883b7251539fa10aeb"
 "checksum crc32fast 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ba125de2af0df55319f41944744ad91c71113bf74a4646efff39afe1f6842db1"
 "checksum crossbeam 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)" = "bd66663db5a988098a89599d4857919b3acf7f61402e61365acfd3919857b9be"
-"checksum crossbeam 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d7408247b1b87f480890f28b670c5f8d9a8a4274833433fe74dc0dfd46d33650"
+"checksum crossbeam 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ad4c7ea749d9fb09e23c5cb17e3b70650860553a0e2744e38446b1803bf7db94"
 "checksum crossbeam 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2d818a4990769aac0c7ff1360e233ef3a41adcb009ebb2036bf6915eb0f6b23c"
-"checksum crossbeam-channel 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7b85741761b7f160bc5e7e0c14986ef685b7f8bf9b7ad081c60c604bb4649827"
 "checksum crossbeam-channel 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "c8ec7fcd21571dc78f96cc96243cab8d8f035247c3efd16c687be154c3fa9efa"
-"checksum crossbeam-deque 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7792c4a9b5a4222f654e3728a3dd945aacc24d2c3a1a096ed265d80e4929cb9a"
 "checksum crossbeam-deque 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "05e44b8cf3e1a625844d1750e1f7820da46044ff6d28f4d43e455ba3e5bb2c13"
 "checksum crossbeam-deque 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b18cd2e169ad86297e6bc0ad9aa679aee9daa4f19e8163860faf7c164e4f5a71"
-"checksum crossbeam-epoch 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "30fecfcac6abfef8771151f8be4abc9e4edc112c2bcb233314cafde2680536e9"
-"checksum crossbeam-epoch 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2449aaa4ec7ef96e5fb24db16024b935df718e9ae1cec0a1e68feeca2efca7b8"
 "checksum crossbeam-epoch 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "fedcd6772e37f3da2a9af9bf12ebe046c0dfe657992377b4df982a2b54cd37a9"
 "checksum crossbeam-queue 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7c979cd6cfe72335896575c6b5688da489e420d36a27a0b9eb0c73db574b4a4b"
-"checksum crossbeam-utils 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "677d453a17e8bd2b913fa38e8b9cf04bcdbb5be790aa294f2389661d72036015"
 "checksum crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)" = "04973fa96e96579258a5091af6003abde64af786b860f18622b82e026cca60e6"
 "checksum crunchy 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 "checksum crypto-mac 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4434400df11d95d556bac068ddfedd482915eb18fe8bea89bc80b6e4b1c179e5"
@@ -5191,6 +5213,7 @@ dependencies = [
 "checksum curve25519-dalek 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5d4b820e8711c211745880150f5fac78ab07d6e3851d8ce9f5a02cedc199174c"
 "checksum data-encoding 2.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f4f47ca1860a761136924ddd2422ba77b2ea54fe8cc75b9040804a0d9d32ad97"
 "checksum derive_deref 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "11554fdb0aa42363a442e0c4278f51c9621e20c1ce3bac51d79e60646f3b8b8f"
+"checksum diff 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "3c2b69f912779fbb121ceb775d74d51e915af17aaebc38d28a592843a2dd0a3a"
 "checksum difference 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
 "checksum digest 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "03b072242a8cbaf9c145665af9d250c59af3b958f83ed6824e13533cf76d5b90"
 "checksum digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
@@ -5198,11 +5221,13 @@ dependencies = [
 "checksum dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3fd78930633bd1c6e35c4b42b1df7b0cbc6bc191146e512bb3bedf243fcc3901"
 "checksum dirs 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "13aea89a5c93364a98e9b37b2fa237effbb694d5cfe01c5b70941f7eb087d5e3"
 "checksum dirs-sys 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "afa0b23de8fd801745c471deffa6e12d248f962c9fd4b4c33787b055599bde7b"
+"checksum docopt 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7f525a586d310c87df72ebcd98009e57f1cc030c8c268305287a476beb653969"
 "checksum dtoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "ea57b42383d091c85abcc2706240b94ab2a8fa1fc81c10ff23c4de06e2a90b5e"
 "checksum ed25519-dalek 1.0.0-pre.1 (registry+https://github.com/rust-lang/crates.io-index)" = "81956bcf7ef761fb4e1d88de3fa181358a0d26cbcb9755b587a08f9119824b86"
 "checksum either 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5527cfe0d098f36e3f8839852688e63c8fff1c90b2b405aef730615f9a7bcf7b"
 "checksum elf 0.0.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4841de15dbe0e49b9b62a417589299e3be0d557e0900d36acb87e6dae47197f5"
 "checksum elfkit 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "02f182eda16a7360c80a2f8638d0726e9d5478173058f1505c42536ca666ecd2"
+"checksum ena 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f56c93cc076508c549d9bb747f79aa9b4eb098be7b8cad8830c3137ef52d1e00"
 "checksum encode_unicode 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "90b2c9496c001e8cb61827acdefad780795c42264c137744cae6f7d9e3450abd"
 "checksum encoding_rs 0.8.17 (registry+https://github.com/rust-lang/crates.io-index)" = "4155785c79f2f6701f185eb2e6b4caf0555ec03477cb4c70db67b465311620ed"
 "checksum endian-type 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
@@ -5277,6 +5302,7 @@ dependencies = [
 "checksum jsonrpc-ws-server 13.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aee1265de937bd53ad0fc95ff5817314922ce009fa99a04a09fdf449b140ddf6"
 "checksum keccak 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
+"checksum lalrpop 0.16.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4e2e80bee40b22bca46665b4ef1f3cd88ed0fb043c971407eac17a0712c02572"
 "checksum lalrpop-util 0.16.3 (registry+https://github.com/rust-lang/crates.io-index)" = "33b27d8490dbe1f9704b0088d61e8d46edc10d5673a8829836c6ded26a9912c7"
 "checksum language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
 "checksum lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
@@ -5297,7 +5323,6 @@ dependencies = [
 "checksum memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e"
 "checksum memmap 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e2ffa2c986de11a9df78620c01eeaaf27d94d3ff02bf81bfcca953102dd0c6ff"
 "checksum memmap 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6585fd95e7bb50d6cc31e20d4cf9afb4e2ba16c5846fc76793f11218da9c475b"
-"checksum memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0f9dc261e2b62d7a622bf416ea3c5245cdd5d9a7fcc428c0d06804dfce1775b3"
 "checksum memoffset 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ce6075db033bbbb7ee5a0bbd3a3186bbae616f57fb001c485c7ff77955f8177f"
 "checksum memsec 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ccabb92f665f997bcb4f3ade019a8e07315148d8bcef3e65fbc5dbd65a22eb04"
 "checksum mime 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ba626b8a6de5da682e1caa06bdb42a335aee5a84db8e5046a3e8ab17ba0a3ae0"
@@ -5313,6 +5338,7 @@ dependencies = [
 "checksum mirai-annotations 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d15444fc4fbe11acaf6683f49e1d4be94bfd6d96799673e9b8417dd7ba9b6ea9"
 "checksum native-tls 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4b2df1a4c22fd44a62147fd8f13dd0f95c9d8ca7b2610299b2a2f9cf8964274e"
 "checksum net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88"
+"checksum new_debug_unreachable 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "f40f005c60db6e03bae699e414c58bf9aa7ea02a2d0b9bfbcf19286cc4c82b30"
 "checksum nibble_vec 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "c8d77f3db4bce033f4d04db08079b2ef1c3d02b44e86f25d08886fafa7756ffa"
 "checksum nix 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6c722bee1037d430d0f8e687bbdbf222f27cc6e4e68d5caf630857bb2b6dbdce"
 "checksum nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9667ddcc6cc8a43afc9b7917599d7216aa09c463919ea32c59ed6cac8bc945"
@@ -5334,11 +5360,9 @@ dependencies = [
 "checksum parity-multiaddr 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b574ca9f0c0235c04de4c5110542959f64c9b8882f638b70f6c6be52c75bdc46"
 "checksum parity-multihash 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "df3a17dc27848fd99e4f87eb0f8c9baba6ede0a6d555400c850ca45254ef4ce3"
 "checksum parking_lot 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "149d8f5b97f3c1133e3cfcd8886449959e856b557ff281e292b733d7c69e005e"
-"checksum parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "f0802bff09003b291ba756dc7e79313e51cc31667e94afbe847def490424cde5"
 "checksum parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ab41b4aed082705d1056416ae4468b6ea99d52599ecf3169b00088d43113e337"
 "checksum parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f842b1982eb6c2fe34036a4fbfb06dd185a3f5c8edfaacdf7d1ea10b07de6252"
 "checksum parking_lot_core 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "4db1a8ccf734a7bce794cc19b3df06ed87ab2f3907036b693c68f56b4d4537fa"
-"checksum parking_lot_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ad7f7e6ebdc79edff6fdcb87a55b620174f7a989e3eb31b65231f4af57f00b8c"
 "checksum parking_lot_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "94c8c7923936b28d546dfd14d4472eaf34c99b14e1c973a32b3e6d4eb04298c9"
 "checksum parking_lot_core 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b876b1b9e7ac6e1a74a6da34d25c42e17e8862aa409cbbbdcfc8d86c6f3bc62b"
 "checksum peeking_take_while 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
@@ -5351,6 +5375,7 @@ dependencies = [
 "checksum phf_shared 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)" = "234f71a15de2288bcb7e3b6515828d22af7ec8598ee6d24c3b526fa0a80b67a0"
 "checksum pkg-config 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "a7c1d2cfa5a714db3b5f24f0915e74fcdf91d09d496ba61329705dda7774d2af"
 "checksum ppv-lite86 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e3cbf9f658cdb5000fcf6f362b8ea2ba154b9f146a61c7a20d647034c6b6561b"
+"checksum precomputed-hash 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 "checksum predicates 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "53e09015b0d3f5a0ec2d4428f7559bb7b3fff341b4e159fedd1d57fac8b939ff"
 "checksum predicates-core 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "06075c3a3e92559ff8929e7a280684489ea27fe44805174c3ebd9328dcb37178"
 "checksum predicates-tree 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8e63c4859013b38a76eca2414c64911fba30def9e3202ac461a2d22831220124"
@@ -5369,7 +5394,6 @@ dependencies = [
 "checksum quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
 "checksum radix_trie 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "ebcf72e767017c1aa4b63d4dd0b0b836a243b648fd81d41c6bf6e850ef7a95c7"
 "checksum rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
-"checksum rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c618c47cd3ebd209790115ab837de41425723956ad3ce2e6a7f09890947cacb9"
 "checksum rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
 "checksum rand 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d47eab0e83d9693d40f825f86948aa16eff6750ead4bdffc4ab95b8b3a7f052c"
 "checksum rand04 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "58595cc8bb12add45412667f9b422d5a9842d61d36e8607bc7c84ff738bf9263"
@@ -5439,38 +5463,42 @@ dependencies = [
 "checksum smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "ab606a9c5e214920bb66c458cd7be8ef094f813f20fe77a54cc7dbfff220d4b7"
 "checksum socket2 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)" = "e8b74de517221a2cb01a53349cf54182acdc31a074727d3079068448c0676d85"
 "checksum solana-ed25519-dalek 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1c21f9d5aa62959872194dfd086feb4e8efec1c2589d27e6a0339904759e99fc"
-"checksum solana_libra_bytecode_verifier 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)" = "cdbd247ba148f48626f84f6c902270974b871ada749bd0c8a8df8325c2f443f7"
-"checksum solana_libra_canonical_serialization 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)" = "6e048a56ee25eb44fa3c10ffa32ef970b1ed235d0cf297c9b982bc1370a91915"
-"checksum solana_libra_compiler 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)" = "122680634c26d48b47e8fd84710f18c5d06fb263f6cbfd2429e508e9263b5b94"
-"checksum solana_libra_config 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)" = "f3e1f1e36b86eba9b3eee921d5f5a35ed000932bd135889f75baf7012b9b072c"
-"checksum solana_libra_crypto 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)" = "e034f00e11e54683ccd2b35cf70b21b42f49f6d6e7ffb742ed317a1d7a6a747d"
-"checksum solana_libra_crypto-derive 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)" = "8a73e01f1b8003fe23b541444ea6c4666edfdbd585bfc5834776c38f934c9261"
-"checksum solana_libra_failure_ext 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)" = "f746f50c7fc974eb154ff2a0016ca142f5cd9298af74cdd875b07e15235c0b0a"
-"checksum solana_libra_failure_macros 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)" = "3080ec410a120187c5184e85713ec6796bdff9297d23317d84d7d75b068d7d8d"
-"checksum solana_libra_ir_to_bytecode 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)" = "683468c3e738bf4f7775b04107121297e4a0da5708dd2262db02b4a5f5c58477"
-"checksum solana_libra_ir_to_bytecode_syntax 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)" = "2fced1204a50746ffca2ebf7716c2d0e69b11e2a65781dffad96c2f56366a2fa"
-"checksum solana_libra_language_e2e_tests 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)" = "5419058e181091b82ea4fe8bed5407ee718bfc61d87fccb8afc821d477bc66f9"
-"checksum solana_libra_logger 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)" = "ca510fe50f83785013bf4101b43833f3748b5e5b57d625bfa066301067405d1e"
-"checksum solana_libra_metrics 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)" = "8b308d761ff5a4aeadb9b3a4bb9633fad1697be64bbec00d80f477b4a3981e5e"
-"checksum solana_libra_move_ir_natives 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)" = "c4dc75fd4eccb74fb5b0617817b5b8d9db560625440f83f0ad42c01714f2eac6"
-"checksum solana_libra_nextgen_crypto 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)" = "2d08c6e256b8774b620d9b3d31b96c507f3585786a5f631acb329635e47ecba1"
-"checksum solana_libra_proptest_helpers 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)" = "e6ca5297a53d9f0778ab95303eb795e1d625a557626e3ce91661cbcfe3e20ecf"
-"checksum solana_libra_proto_conv 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)" = "9486271bc6a8f89a56b503a4c73085fd20958b8d9d0bcac9294299478039ac5f"
-"checksum solana_libra_proto_conv_derive 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)" = "d93691537cc87685e3d0e0c6da5b0972454bf0f9e6fcec544e59d3071c396281"
-"checksum solana_libra_state_view 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)" = "2817ffe86d237a656e243b0e8db2450a0cfe9988633a6d3d11b46aa1e41ecfaa"
-"checksum solana_libra_stdlib 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)" = "e723bac501b04923b2e2748757ab25b97fb5cca8a225ba2110fc37de1aa9fc3c"
-"checksum solana_libra_types 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a0da726df0dd4c9772e4a8cb2cba806ec4b1cf6154af0172a6b6292992fe9da"
-"checksum solana_libra_vm 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)" = "f77b064a6512b9962755208f90b2a750e44f6ee3a9f709746640fe1af9d465db"
-"checksum solana_libra_vm_cache_map 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)" = "7f8ad9ba68164d231a5057632cf48a1bc2bd35af296d797bdfc7606ae5f85d2b"
-"checksum solana_libra_vm_genesis 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)" = "a195626ecac8cf32fc83df08950c1c5ce7a99ef94a531306ad3adfd1f09303f8"
-"checksum solana_libra_vm_runtime 0.0.0-sol15 (registry+https://github.com/rust-lang/crates.io-index)" = "62401cabf7d9208bd7c9edc08a6f571401a7a1d0c94fde44dc60edbd4300e442"
+"checksum solana_libra_bytecode_verifier 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7db48f7a723c39b9acfc52e7e0778bb5dbe55d14025fd80e17e8ea48b246415c"
+"checksum solana_libra_canonical_serialization 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d6ef5769b20ca8acd70cc0482fa0cade3c512de9f7e0e35e91b65593b9491205"
+"checksum solana_libra_compiler 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8bccb768b90dd07df05810225db6f09f74e6ba91f2edb0951ce758b2c8c17fb6"
+"checksum solana_libra_config 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6940147c9a9bba5c71db04d34c15b244d05455321f9714e711cf15b96c833502"
+"checksum solana_libra_crypto 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ea74247fa8fb741ebaa220da301f4727b007c15038b340cbb0538aa84f440af4"
+"checksum solana_libra_crypto-derive 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7214e804d54b5065a7c5bce14572c556694eb07c2e78132175e6a77bd8298b67"
+"checksum solana_libra_failure_ext 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7c67432e0a9456e9afe048b8e6c71df73989a87121619e76f585ffb78a32a9d5"
+"checksum solana_libra_failure_macros 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "061aeeee7558e8bbede14617000982b297b4fad41bf75e5c8e17a9bb39e39983"
+"checksum solana_libra_ir_to_bytecode 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b60e655d870b9828045c92855ae4a66c3fa862518b6ea03ae4d130343cc0ed75"
+"checksum solana_libra_ir_to_bytecode_syntax 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1ad60eddc0744f12d339a6107634c881ab2811bc985606d3b55ab642baf62168"
+"checksum solana_libra_language_e2e_tests 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "22c672727431fb229e3340caccd3ae89fbf86a8076cac321bb29074c4e94b985"
+"checksum solana_libra_logger 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "94753c71c40b986a2090f454b4ef5005113ce6edf5e599cb1658b89a6bd2de27"
+"checksum solana_libra_metrics 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "46e3fea9d4f7e2f4db5561214eb9e1241ca2922c996adf769bd9bb16d935bb85"
+"checksum solana_libra_move_ir_natives 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9a98f71945c6e41a9832e7011c12c92494e2ab89472b61606b10e234e3203eef"
+"checksum solana_libra_nextgen_crypto 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5a851c731b996063760397156d974b57c733c9c89f857df5dae0cf4fa2741d71"
+"checksum solana_libra_proptest_helpers 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2cfe5875b5d0e7bc560fc04baed0ea12d83d0e0e626e689e89e59cff6c205e1d"
+"checksum solana_libra_proto_conv 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d37f626e6ed1a19be506e0993ea4666cd68912105dd8884efc0cea8ea4bb5bc7"
+"checksum solana_libra_proto_conv_derive 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ab2026a15e540fea668fb37ba937c7dbdd0ac5956f4fad1b90137e4789e07ae1"
+"checksum solana_libra_state_view 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b81d30ce8bc8834481b1d4a59535942bef6f86a27294845818df137b5ceb5d01"
+"checksum solana_libra_stdlib 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e11a856d7bddadeb1348cc015ef72901678c054408bccf3e8a681362ec5dda20"
+"checksum solana_libra_types 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0edf1027655faf0c8f4fb716f5dda255060b270f00483b1b32f76a233d0e77e7"
+"checksum solana_libra_vm 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4ed0934cd3c712c863c585eb19fb81c85af31d8110dd09441812564bdef2ba2f"
+"checksum solana_libra_vm_cache_map 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9f0abd2cc72c7d76ca9e0764e3f1fa01a01f49b9014a193f2a3fe735a034bf96"
+"checksum solana_libra_vm_genesis 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4dadfcf5fabfd28d09770d698c618a48d75819f6915bd8bdfa04b93b6e492530"
+"checksum solana_libra_vm_runtime 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "055a5de29d1b8a2b9f9e20293e07998b8e188164bbe6ac8a09260043f99379aa"
 "checksum solana_rbpf 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "b6145a3a0104925b0be63e817f7b5814fac6aa29a328bbc1d637ffd33022d748"
 "checksum solicit 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "172382bac9424588d7840732b250faeeef88942e37b6e35317dce98cafdd75b2"
 "checksum spin 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "ceac490aa12c567115b40b7b7fceca03a6c9d53d5defea066123debc83c5dc1f"
 "checksum spin 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "44363f6f51401c34e7be73db0db371c04705d35efbe9f7d6082e03a921a32c55"
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 "checksum string 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d24114bfcceb867ca7f71a0d3fe45d45619ec47a6fbfa98cb14e14250bfa5d6d"
+"checksum string_cache 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "25d70109977172b127fe834e5449e5ab1740b9ba49fa18a2020f509174f25423"
+"checksum string_cache_codegen 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1eea1eee654ef80933142157fdad9dd8bc43cf7c74e999e369263496f04ff4da"
+"checksum string_cache_shared 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b1884d1bc09741d466d9b14e6d37ac89d6909cbcac41dd9ae982d4d063bbedfc"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+"checksum strsim 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "032c03039aae92b350aad2e3779c352e104d919cb192ba2fabbd7b831ce4f0f6"
 "checksum structopt 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "16c2cdbf9cc375f15d1b4141bc48aeef444806655cd0e904207edc8d68d86ed7"
 "checksum structopt-derive 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "53010261a84b37689f9ed7d395165029f9cc7abb9f56bbfe86bee2597ed25107"
 "checksum subtle 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
@@ -5485,6 +5513,7 @@ dependencies = [
 "checksum tar 0.4.26 (registry+https://github.com/rust-lang/crates.io-index)" = "b3196bfbffbba3e57481b6ea32249fbaf590396a52505a2615adbb79d9d826d3"
 "checksum tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
 "checksum tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
+"checksum term 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "fa63644f74ce96fbeb9b794f66aff2a52d601cbd5e80f4b97123e3899f4570f1"
 "checksum term 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "edd106a334b7657c10b7c540a0106114feadeb4dc314513e97df481d5d966f42"
 "checksum termcolor 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "adc4587ead41bf016f11af03e55a624c06568b5a19db4e90fde573d805074f83"
 "checksum termcolor 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "96d6098003bde162e4277c70665bd87c326f5a0c3f3fbfb285787fa482d54e6e"

--- a/programs/librapay_api/Cargo.toml
+++ b/programs/librapay_api/Cargo.toml
@@ -14,8 +14,8 @@ log = "0.4.8"
 solana-logger = { path = "../../logger", version = "0.18.0-pre1" }
 solana-sdk = { path = "../../sdk", version = "0.18.0-pre1" }
 solana-runtime = { path = "../../runtime", version = "0.18.0-pre1" }
-types = { version = "0.0.0-sol15", package = "solana_libra_types" }
-language_e2e_tests = { version = "0.0.0-sol15", package = "solana_libra_language_e2e_tests" }
+types = { version = "0.0.0", package = "solana_libra_types" }
+language_e2e_tests = { version = "0.0.0", package = "solana_libra_language_e2e_tests" }
 solana-move-loader-api = { path = "../move_loader_api", version = "0.18.0-pre1" }
 
 [lib]

--- a/programs/move_loader_api/Cargo.toml
+++ b/programs/move_loader_api/Cargo.toml
@@ -20,16 +20,16 @@ serde_json = "1.0.40"
 solana-logger = { path = "../../logger", version = "0.18.0-pre1" }
 solana-sdk = { path = "../../sdk", version = "0.18.0-pre1" }
 
-bytecode_verifier = { version = "0.0.0-sol15", package = "solana_libra_bytecode_verifier" }
-compiler = { version = "0.0.0-sol15", package = "solana_libra_compiler" }
-failure = { version = "0.0.0-sol15", package = "solana_libra_failure_ext" }
-language_e2e_tests = { version = "0.0.0-sol15", package = "solana_libra_language_e2e_tests" }
-state_view = { version = "0.0.0-sol15", package = "solana_libra_state_view" }
-stdlib = { version = "0.0.0-sol15", package = "solana_libra_stdlib" }
-types = { version = "0.0.0-sol15", package = "solana_libra_types" }
-vm = { version = "0.0.0-sol15", package = "solana_libra_vm" }
-vm_cache_map = { version = "0.0.0-sol15", package = "solana_libra_vm_cache_map" }
-vm_runtime = { version = "0.0.0-sol15", package = "solana_libra_vm_runtime" }
+bytecode_verifier = { version = "0.0.0", package = "solana_libra_bytecode_verifier" }
+compiler = { version = "0.0.0", package = "solana_libra_compiler" }
+failure = { version = "0.0.0", package = "solana_libra_failure_ext" }
+language_e2e_tests = { version = "0.0.0", package = "solana_libra_language_e2e_tests" }
+state_view = { version = "0.0.0", package = "solana_libra_state_view" }
+stdlib = { version = "0.0.0", package = "solana_libra_stdlib" }
+types = { version = "0.0.0", package = "solana_libra_types" }
+vm = { version = "0.0.0", package = "solana_libra_vm" }
+vm_cache_map = { version = "0.0.0", package = "solana_libra_vm_cache_map" }
+vm_runtime = { version = "0.0.0", package = "solana_libra_vm_runtime" }
 
 [lib]
 crate-type = ["lib"]


### PR DESCRIPTION
#### Problem

We have a new version of the libra fork.

#### Summary of Changes

Start using it! This should allow #5365 to pass CI.
