### PR TITLE
Solana-wallet: enable keypair use for pubkey args

### DIFF
--- a/book/src/validator-start.md
+++ b/book/src/validator-start.md
@@ -49,7 +49,7 @@ commands:
 $ solana-keygen new -o ~/validator-vote-keypair.json
 $ VOTE_PUBKEY=$(solana-keygen pubkey ~/validator-vote-keypair.json)
 $ IDENTITY_PUBKEY=$(solana-keygen pubkey ~/validator-keypair.json)
-$ solana-wallet create-vote-account "$VOTE_PUBKEY" "$IDENTITY_PUBKEY" 1
+$ solana-wallet --keypair ~/validator-keypair.json create-vote-account "$VOTE_PUBKEY" "$IDENTITY_PUBKEY" 1
 ```
 
 Then use one of the following commands, depending on your installation

--- a/book/src/validator-start.md
+++ b/book/src/validator-start.md
@@ -47,9 +47,7 @@ Your validator will need a vote account.  Create it now with the following
 commands:
 ```bash
 $ solana-keygen new -o ~/validator-vote-keypair.json
-$ VOTE_PUBKEY=$(solana-keygen pubkey ~/validator-vote-keypair.json)
-$ IDENTITY_PUBKEY=$(solana-keygen pubkey ~/validator-keypair.json)
-$ solana-wallet --keypair ~/validator-keypair.json create-vote-account "$VOTE_PUBKEY" "$IDENTITY_PUBKEY" 1
+$ solana-wallet --keypair ~/validator-keypair.json create-vote-account ~/validator-vote-keypair.json ~/validator-keypair.json 1
 ```
 
 Then use one of the following commands, depending on your installation

--- a/wallet/src/wallet.rs
+++ b/wallet/src/wallet.rs
@@ -1358,7 +1358,7 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                 .arg(
                     Arg::with_name("lamports")
                         .index(1)
-                        .value_name("NUM")
+                        .value_name("LAMPORTS")
                         .takes_value(true)
                         .required(true)
                         .help("The number of lamports to request"),
@@ -1382,7 +1382,7 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                 .arg(
                     Arg::with_name("process_id")
                         .index(1)
-                        .value_name("PROCESS_ID")
+                        .value_name("PROCESS ID")
                         .takes_value(true)
                         .required(true)
                         .validator(is_pubkey)
@@ -1407,7 +1407,7 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                 .arg(
                     Arg::with_name("vote_account_pubkey")
                         .index(1)
-                        .value_name("PUBKEY")
+                        .value_name("VOTE ACCOUNT PUBKEY")
                         .takes_value(true)
                         .required(true)
                         .validator(is_pubkey)
@@ -1416,7 +1416,7 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                 .arg(
                     Arg::with_name("authorized_voter_keypair_file")
                         .index(2)
-                        .value_name("KEYPAIR_FILE")
+                        .value_name("CURRENT VOTER KEYPAIR FILE")
                         .takes_value(true)
                         .required(true)
                         .help("Keypair file for the currently authorized vote signer"),
@@ -1424,7 +1424,7 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                 .arg(
                     Arg::with_name("new_authorized_voter_pubkey")
                         .index(3)
-                        .value_name("PUBKEY")
+                        .value_name("NEW VOTER PUBKEY")
                         .takes_value(true)
                         .required(true)
                         .validator(is_pubkey)
@@ -1437,7 +1437,7 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                 .arg(
                     Arg::with_name("vote_account_pubkey")
                         .index(1)
-                        .value_name("PUBKEY")
+                        .value_name("VOTE ACCOUNT PUBKEY")
                         .takes_value(true)
                         .required(true)
                         .validator(is_pubkey)
@@ -1446,7 +1446,7 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                 .arg(
                     Arg::with_name("node_pubkey")
                         .index(2)
-                        .value_name("PUBKEY")
+                        .value_name("VALIDATOR PUBKEY")
                         .takes_value(true)
                         .required(true)
                         .validator(is_pubkey)
@@ -1455,7 +1455,7 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                 .arg(
                     Arg::with_name("lamports")
                         .index(3)
-                        .value_name("NUM")
+                        .value_name("LAMPORTS")
                         .takes_value(true)
                         .required(true)
                         .help("The number of lamports to send to the vote account"),
@@ -1474,7 +1474,7 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                 .arg(
                     Arg::with_name("vote_account_pubkey")
                         .index(1)
-                        .value_name("PUBKEY")
+                        .value_name("VOTE ACCOUNT PUBKEY")
                         .takes_value(true)
                         .required(true)
                         .validator(is_pubkey)
@@ -1494,7 +1494,7 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                 .arg(
                     Arg::with_name("stake_account_keypair_file")
                         .index(1)
-                        .value_name("KEYPAIR_FILE")
+                        .value_name("STAKE ACCOUNT KEYPAIR FILE")
                         .takes_value(true)
                         .required(true)
                         .help("Keypair file for the new stake account"),
@@ -1502,7 +1502,7 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                 .arg(
                     Arg::with_name("vote_account_pubkey")
                         .index(2)
-                        .value_name("PUBKEY")
+                        .value_name("VOTE ACCOUNT PUBKEY")
                         .takes_value(true)
                         .required(true)
                         .validator(is_pubkey)
@@ -1511,7 +1511,7 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                 .arg(
                     Arg::with_name("lamports_to_stake")
                         .index(3)
-                        .value_name("NUM")
+                        .value_name("LAMPORTS")
                         .takes_value(true)
                         .required(true)
                         .help("The number of lamports to stake"),
@@ -1523,7 +1523,7 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                 .arg(
                     Arg::with_name("stake_account_keypair_file")
                         .index(1)
-                        .value_name("KEYPAIR_FILE")
+                        .value_name("STAKE ACCOUNT KEYPAIR FILE")
                         .takes_value(true)
                         .required(true)
                         .help("Keypair file for the stake account, for signing the delegate transaction."),
@@ -1535,7 +1535,7 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                 .arg(
                     Arg::with_name("stake_account_keypair_file")
                         .index(1)
-                        .value_name("KEYPAIR_FILE")
+                        .value_name("STAKE ACCOUNT KEYPAIR FILE")
                         .takes_value(true)
                         .required(true)
                         .help("Keypair file for the stake account, for signing the withdraw transaction."),
@@ -1543,7 +1543,7 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                 .arg(
                     Arg::with_name("destination_account_pubkey")
                         .index(2)
-                        .value_name("PUBKEY")
+                        .value_name("DESTINATION PUBKEY")
                         .takes_value(true)
                         .required(true)
                         .validator(is_pubkey)
@@ -1552,7 +1552,7 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                 .arg(
                     Arg::with_name("lamports")
                         .index(3)
-                        .value_name("NUM")
+                        .value_name("LAMPORTS")
                         .takes_value(true)
                         .required(true)
                         .help("The number of lamports to to withdraw from the stake account."),
@@ -1582,7 +1582,7 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                 .arg(
                     Arg::with_name("vote_account_pubkey")
                         .index(3)
-                        .value_name("PUBKEY")
+                        .value_name("VOTE ACCOUNT PUBKEY")
                         .takes_value(true)
                         .required(true)
                         .validator(is_pubkey)
@@ -1595,7 +1595,7 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                 .arg(
                     Arg::with_name("stake_account_pubkey")
                         .index(1)
-                        .value_name("PUBKEY")
+                        .value_name("STAKE ACCOUNT PUBKEY")
                         .takes_value(true)
                         .required(true)
                         .validator(is_pubkey)
@@ -1608,7 +1608,7 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                 .arg(
                     Arg::with_name("storage_account_pubkey")
                         .index(1)
-                        .value_name("PUBKEY")
+                        .value_name("STORAGE ACCOUNT PUBKEY")
                         .takes_value(true)
                         .required(true)
                         .validator(is_pubkey)
@@ -1617,7 +1617,7 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                 .arg(
                     Arg::with_name("lamports")
                         .index(2)
-                        .value_name("NUM")
+                        .value_name("LAMPORTS")
                         .takes_value(true)
                         .required(true)
                         .help("The number of lamports to assign to the storage mining pool account"),
@@ -1629,7 +1629,7 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                 .arg(
                     Arg::with_name("storage_account_owner")
                         .index(1)
-                        .value_name("PUBKEY")
+                        .value_name("STORAGE ACCOUNT OWNER PUBKEY")
                         .takes_value(true)
                         .required(true)
                         .validator(is_pubkey)
@@ -1637,7 +1637,7 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                 .arg(
                     Arg::with_name("storage_account_pubkey")
                         .index(2)
-                        .value_name("PUBKEY")
+                        .value_name("STORAGE ACCOUNT PUBKEY")
                         .takes_value(true)
                         .required(true)
                         .validator(is_pubkey)
@@ -1649,7 +1649,7 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                 .arg(
                     Arg::with_name("storage_account_owner")
                         .index(1)
-                        .value_name("PUBKEY")
+                        .value_name("STORAGE ACCOUNT OWNER PUBKEY")
                         .takes_value(true)
                         .required(true)
                         .validator(is_pubkey)
@@ -1657,7 +1657,7 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                 .arg(
                     Arg::with_name("storage_account_pubkey")
                         .index(2)
-                        .value_name("PUBKEY")
+                        .value_name("STORAGE ACCOUNT PUBKEY")
                         .takes_value(true)
                         .required(true)
                         .validator(is_pubkey)
@@ -1691,7 +1691,7 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                 .arg(
                     Arg::with_name("storage_account_pubkey")
                         .index(1)
-                        .value_name("PUBKEY")
+                        .value_name("STORAGE ACCOUNT PUBKEY")
                         .takes_value(true)
                         .required(true)
                         .validator(is_pubkey)
@@ -1704,7 +1704,7 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                 .arg(
                     Arg::with_name("program_location")
                         .index(1)
-                        .value_name("PATH")
+                        .value_name("PATH TO PROGRAM")
                         .takes_value(true)
                         .required(true)
                         .help("/path/to/program.o"),
@@ -1733,7 +1733,7 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                 .arg(
                     Arg::with_name("lamports")
                         .index(2)
-                        .value_name("NUM")
+                        .value_name("LAMPORTS")
                         .takes_value(true)
                         .required(true)
                         .help("The number of lamports to send"),
@@ -1785,7 +1785,7 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                 .arg(
                     Arg::with_name("process_id")
                         .index(2)
-                        .value_name("PROCESS_ID")
+                        .value_name("PROCESS ID")
                         .takes_value(true)
                         .required(true)
                         .help("The process id of the transfer to authorize"),
@@ -1806,7 +1806,7 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                 .arg(
                     Arg::with_name("process_id")
                         .index(2)
-                        .value_name("PROCESS_ID")
+                        .value_name("PROCESS ID")
                         .takes_value(true)
                         .required(true)
                         .help("The process id of the transfer to unlock"),

--- a/wallet/src/wallet.rs
+++ b/wallet/src/wallet.rs
@@ -1901,6 +1901,28 @@ mod tests {
             .get_matches_from(vec!["test", "airdrop", "notint"]);
         assert!(parse_command(&pubkey, &test_bad_airdrop).is_err());
 
+        // Test Balance Subcommand, incl pubkey and keypair-file inputs
+        let keypair_file = make_tmp_path("keypair_file");
+        gen_keypair_file(&keypair_file).unwrap();
+        let keypair = read_keypair(&keypair_file).unwrap();
+        let test_balance = test_commands.clone().get_matches_from(vec![
+            "test",
+            "balance",
+            &keypair.pubkey().to_string(),
+        ]);
+        assert_eq!(
+            parse_command(&pubkey, &test_balance).unwrap(),
+            WalletCommand::Balance(keypair.pubkey())
+        );
+        let test_balance =
+            test_commands
+                .clone()
+                .get_matches_from(vec!["test", "balance", &keypair_file]);
+        assert_eq!(
+            parse_command(&pubkey, &test_balance).unwrap(),
+            WalletCommand::Balance(keypair.pubkey())
+        );
+
         // Test Cancel Subcommand
         let test_cancel =
             test_commands

--- a/wallet/src/wallet.rs
+++ b/wallet/src/wallet.rs
@@ -1345,6 +1345,15 @@ fn is_pubkey(string: String) -> Result<(), String> {
     }
 }
 
+// Return an error if string cannot be parsed as pubkey string or keypair file location
+fn is_pubkey_or_keypair(string: String) -> Result<(), String> {
+    is_pubkey(string.clone()).or_else(|_| {
+        read_keypair(&string)
+            .map(|_| ())
+            .map_err(|err| format!("{:?}", err))
+    })
+}
+
 pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, 'v> {
     App::new(name)
         .about(about)
@@ -1372,7 +1381,7 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                         .index(1)
                         .value_name("PUBKEY")
                         .takes_value(true)
-                        .validator(is_pubkey)
+                        .validator(is_pubkey_or_keypair)
                         .help("The public key of the balance to check"),
                 ),
         )
@@ -1410,7 +1419,7 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                         .value_name("VOTE ACCOUNT PUBKEY")
                         .takes_value(true)
                         .required(true)
-                        .validator(is_pubkey)
+                        .validator(is_pubkey_or_keypair)
                         .help("Vote account in which to set the authorized voter"),
                 )
                 .arg(
@@ -1427,7 +1436,7 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                         .value_name("NEW VOTER PUBKEY")
                         .takes_value(true)
                         .required(true)
-                        .validator(is_pubkey)
+                        .validator(is_pubkey_or_keypair)
                         .help("New vote signer to authorize"),
                 ),
         )
@@ -1440,7 +1449,7 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                         .value_name("VOTE ACCOUNT PUBKEY")
                         .takes_value(true)
                         .required(true)
-                        .validator(is_pubkey)
+                        .validator(is_pubkey_or_keypair)
                         .help("Vote account address to fund"),
                 )
                 .arg(
@@ -1449,7 +1458,7 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                         .value_name("VALIDATOR PUBKEY")
                         .takes_value(true)
                         .required(true)
-                        .validator(is_pubkey)
+                        .validator(is_pubkey_or_keypair)
                         .help("Validator that will vote with this account"),
                 )
                 .arg(
@@ -1477,7 +1486,7 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                         .value_name("VOTE ACCOUNT PUBKEY")
                         .takes_value(true)
                         .required(true)
-                        .validator(is_pubkey)
+                        .validator(is_pubkey_or_keypair)
                         .help("Vote account pubkey"),
                 )
         )
@@ -1505,7 +1514,7 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                         .value_name("VOTE ACCOUNT PUBKEY")
                         .takes_value(true)
                         .required(true)
-                        .validator(is_pubkey)
+                        .validator(is_pubkey_or_keypair)
                         .help("The vote account to which the stake will be delegated"),
                 )
                 .arg(
@@ -1546,7 +1555,7 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                         .value_name("DESTINATION PUBKEY")
                         .takes_value(true)
                         .required(true)
-                        .validator(is_pubkey)
+                        .validator(is_pubkey_or_keypair)
                         .help("The account where the lamports should be transfered"),
                 )
                 .arg(
@@ -1567,7 +1576,7 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                         .value_name("MINING POOL PUBKEY")
                         .takes_value(true)
                         .required(true)
-                        .validator(is_pubkey)
+                        .validator(is_pubkey_or_keypair)
                         .help("Mining pool account to redeem credits from"),
                 )
                 .arg(
@@ -1576,7 +1585,7 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                         .value_name("STAKING ACCOUNT PUBKEY")
                         .takes_value(true)
                         .required(true)
-                        .validator(is_pubkey)
+                        .validator(is_pubkey_or_keypair)
                         .help("Staking account address to redeem credits for"),
                 )
                 .arg(
@@ -1585,7 +1594,7 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                         .value_name("VOTE ACCOUNT PUBKEY")
                         .takes_value(true)
                         .required(true)
-                        .validator(is_pubkey)
+                        .validator(is_pubkey_or_keypair)
                         .help("The vote account to which the stake was previously delegated."),
                 ),
         )
@@ -1598,7 +1607,7 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                         .value_name("STAKE ACCOUNT PUBKEY")
                         .takes_value(true)
                         .required(true)
-                        .validator(is_pubkey)
+                        .validator(is_pubkey_or_keypair)
                         .help("Stake account pubkey"),
                 )
         )
@@ -1611,7 +1620,7 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                         .value_name("STORAGE ACCOUNT PUBKEY")
                         .takes_value(true)
                         .required(true)
-                        .validator(is_pubkey)
+                        .validator(is_pubkey_or_keypair)
                         .help("Storage mining pool account address to fund"),
                 )
                 .arg(
@@ -1632,7 +1641,7 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                         .value_name("STORAGE ACCOUNT OWNER PUBKEY")
                         .takes_value(true)
                         .required(true)
-                        .validator(is_pubkey)
+                        .validator(is_pubkey_or_keypair)
                 )
                 .arg(
                     Arg::with_name("storage_account_pubkey")
@@ -1640,7 +1649,7 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                         .value_name("STORAGE ACCOUNT PUBKEY")
                         .takes_value(true)
                         .required(true)
-                        .validator(is_pubkey)
+                        .validator(is_pubkey_or_keypair)
                 )
         )
         .subcommand(
@@ -1672,7 +1681,7 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                         .value_name("NODE PUBKEY")
                         .takes_value(true)
                         .required(true)
-                        .validator(is_pubkey)
+                        .validator(is_pubkey_or_keypair)
                         .help("The node account to credit the rewards to"),
                 )
                 .arg(
@@ -1681,7 +1690,7 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                         .value_name("STORAGE ACCOUNT PUBKEY")
                         .takes_value(true)
                         .required(true)
-                        .validator(is_pubkey)
+                        .validator(is_pubkey_or_keypair)
                         .help("Storage account address to redeem credits for"),
                 ))
 
@@ -1694,7 +1703,7 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                         .value_name("STORAGE ACCOUNT PUBKEY")
                         .takes_value(true)
                         .required(true)
-                        .validator(is_pubkey)
+                        .validator(is_pubkey_or_keypair)
                         .help("Storage account pubkey"),
                 )
         )


### PR DESCRIPTION
#### Problem
1. It is tedious to pull pubkey strings from keypair files for various wallet commands, especially repeatedly
2. When required positional args are not provided, it is difficult to understand from the clap response prints what value is expected

#### Summary of Changes
- Adds pubkey-or-keypair-file validation and parsing to solana-wallet as a convenience to users who don't mind giving the full keypair, even though only the public key is required.
- Makes clap value_names more verbose for positional arguments.
- Also, throws in a fix for a bug in the book that I came across in testing the new functionality.

Fixes #5439 
