### PR TITLE
include vote account in deactivate

### DIFF
--- a/book/src/validator-stake.md
+++ b/book/src/validator-stake.md
@@ -23,7 +23,7 @@ or more for the change to take effect.
 
 Stake can be deactivate by running:
 ```bash
-$ solana-wallet deactivate-stake ~/validator-config/stake-keypair.json
+$ solana-wallet deactivate-stake ~/validator-config/stake-keypair.json [VOTE PUBKEY]
 ```
 Note that a stake account may only be used once, so after deactivation, use the
 wallet's `withdraw-stake` command to recover the previously staked lamports.

--- a/programs/stake_tests/tests/stake_instruction.rs
+++ b/programs/stake_tests/tests/stake_instruction.rs
@@ -175,7 +175,10 @@ fn test_stake_account_delegate() {
 
     // Deactivate the stake
     let message = Message::new_with_payer(
-        vec![stake_instruction::deactivate_stake(&staker_pubkey)],
+        vec![stake_instruction::deactivate_stake(
+            &staker_pubkey,
+            &vote_pubkey,
+        )],
         Some(&mint_pubkey),
     );
     assert!(bank_client


### PR DESCRIPTION
#### Problem
 deactivate is a potential hole for stake recovery in the case of a slashed stake if
 the vote account is not also presented during the instruction

 #### Summary of Changes
 require that the the vote account (which will carry "slashed" info) is also presented to deactivate

Fixes #4991