### PR TITLE
Remove deprecated solana-wallet arg

### DIFF
--- a/wallet/src/wallet.rs
+++ b/wallet/src/wallet.rs
@@ -1603,17 +1603,8 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
             SubCommand::with_name("redeem-vote-credits")
                 .about("Redeem credits in the stake account")
                 .arg(
-                    Arg::with_name("mining_pool_account_pubkey")
-                        .index(1)
-                        .value_name("MINING POOL PUBKEY")
-                        .takes_value(true)
-                        .required(true)
-                        .validator(is_pubkey_or_keypair)
-                        .help("Mining pool account to redeem credits from"),
-                )
-                .arg(
                     Arg::with_name("stake_account_pubkey")
-                        .index(2)
+                        .index(1)
                         .value_name("STAKING ACCOUNT PUBKEY")
                         .takes_value(true)
                         .required(true)
@@ -1622,7 +1613,7 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                 )
                 .arg(
                     Arg::with_name("vote_account_pubkey")
-                        .index(3)
+                        .index(2)
                         .value_name("VOTE ACCOUNT PUBKEY")
                         .takes_value(true)
                         .required(true)


### PR DESCRIPTION
#### Problem
Mining pool pubkey was removed here: https://github.com/solana-labs/solana/commit/a49f5378e2314000bdca619029143e63ad5b0bfb#diff-bee466fb9fec4687d38fad4961b10c0aR251
But CLI arg persists, breaking the subcommand

#### Summary of Changes
Remove it
