### PR TITLE
Solana-wallet: print JSON RPC endpoint

### DIFF
--- a/scripts/wallet-sanity.sh
+++ b/scripts/wallet-sanity.sh
@@ -39,7 +39,7 @@ check_balance_output() {
 
 pay_and_confirm() {
   exec 42>&1
-  signature=$($solana_wallet "${entrypoint[@]}" pay "$@" | tee >(cat - >&42))
+  signature=$($solana_wallet "${entrypoint[@]}" pay "$@" | tail -c 88 | tee >(cat - >&42))
   $solana_wallet "${entrypoint[@]}" confirm "$signature"
 }
 

--- a/wallet/src/wallet.rs
+++ b/wallet/src/wallet.rs
@@ -1120,6 +1120,7 @@ pub fn process_command(config: &WalletConfig) -> ProcessResult {
         // Get address of this client
         return Ok(format!("{}", config.keypair.pubkey()));
     }
+    println_name_value("Using RPC Endpoint:", &config.json_rpc_url);
 
     let drone_addr = config.drone_addr();
 


### PR DESCRIPTION
#### Problem
It is easy to submit solana-wallet commands against the wrong testnet without realizing you are doing so

#### Summary of Changes
Print JSON RPC endpoint on every external command

Toward #5437 
