### PR TITLE
Allow process_blocktree() to start processing from any root

### DIFF
--- a/core/src/bank_forks.rs
+++ b/core/src/bank_forks.rs
@@ -159,11 +159,21 @@ impl BankForks {
         self.banks.get(&bank_slot)
     }
 
-    pub fn new_from_banks(initial_banks: &[Arc<Bank>], rooted_path: Vec<u64>) -> Self {
+    pub fn new_from_banks(initial_forks: &[Arc<Bank>], rooted_path: Vec<u64>) -> Self {
         let mut banks = HashMap::new();
-        let working_bank = initial_banks[0].clone();
-        for bank in initial_banks {
+        let working_bank = initial_forks[0].clone();
+
+        // Iterate through the heads of all the different forks
+        for bank in initial_forks {
             banks.insert(bank.slot(), bank.clone());
+            let parents = bank.parents();
+            for parent in parents {
+                if banks.contains_key(&parent.slot()) {
+                    // All ancestors have already been inserted by another fork
+                    break;
+                }
+                banks.insert(parent.slot(), parent.clone());
+            }
         }
 
         Self {

--- a/core/src/bank_forks.rs
+++ b/core/src/bank_forks.rs
@@ -159,18 +159,19 @@ impl BankForks {
         self.banks.get(&bank_slot)
     }
 
-    pub fn new_from_banks(initial_banks: &[Arc<Bank>], root: u64) -> Self {
+    pub fn new_from_banks(initial_banks: &[Arc<Bank>], rooted_path: Vec<u64>) -> Self {
         let mut banks = HashMap::new();
         let working_bank = initial_banks[0].clone();
         for bank in initial_banks {
             banks.insert(bank.slot(), bank.clone());
         }
+
         Self {
-            root,
+            root: *rooted_path.last().unwrap(),
             banks,
             working_bank,
             snapshot_config: None,
-            slots_since_snapshot: vec![root],
+            slots_since_snapshot: rooted_path,
             confidence: HashMap::new(),
         }
     }

--- a/core/src/bank_forks.rs
+++ b/core/src/bank_forks.rs
@@ -1,19 +1,14 @@
 //! The `bank_forks` module implments BankForks a DAG of checkpointed Banks
 
-use crate::result::{Error, Result};
+use crate::result::Result;
 use crate::snapshot_package::SnapshotPackageSender;
-use crate::snapshot_package::{TAR_ACCOUNTS_DIR, TAR_SNAPSHOTS_DIR};
 use crate::snapshot_utils;
-use crate::snapshot_utils::untar_snapshot_in;
-use fs_extra::dir::CopyOptions;
 use solana_measure::measure::Measure;
 use solana_metrics::inc_new_counter_info;
 use solana_runtime::bank::Bank;
 use solana_runtime::status_cache::MAX_CACHE_ENTRIES;
 use solana_sdk::timing;
 use std::collections::{HashMap, HashSet};
-use std::fs;
-use std::io::{Error as IOError, ErrorKind};
 use std::ops::Index;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -175,7 +170,7 @@ impl BankForks {
             banks,
             working_bank,
             snapshot_config: None,
-            slots_since_snapshot: vec![],
+            slots_since_snapshot: vec![root],
             confidence: HashMap::new(),
         }
     }
@@ -367,54 +362,6 @@ impl BankForks {
     pub fn snapshot_config(&self) -> &Option<SnapshotConfig> {
         &self.snapshot_config
     }
-
-    pub fn load_from_snapshot<P: AsRef<Path>>(
-        account_paths: String,
-        snapshot_config: &SnapshotConfig,
-        snapshot_tar: P,
-    ) -> Result<Self> {
-        // Untar the snapshot into a temp directory under `snapshot_config.snapshot_path()`
-        let unpack_dir = tempfile::tempdir_in(snapshot_config.snapshot_path())?;
-        untar_snapshot_in(&snapshot_tar, &unpack_dir)?;
-
-        let unpacked_accounts_dir = unpack_dir.as_ref().join(TAR_ACCOUNTS_DIR);
-        let unpacked_snapshots_dir = unpack_dir.as_ref().join(TAR_SNAPSHOTS_DIR);
-        let snapshot_paths = snapshot_utils::get_snapshot_paths(&unpacked_snapshots_dir);
-        let bank = snapshot_utils::bank_from_snapshots(
-            account_paths,
-            &snapshot_paths,
-            unpacked_accounts_dir,
-        )?;
-
-        let bank = Arc::new(bank);
-        // Move the unpacked snapshots into `snapshot_config.snapshot_path()`
-        let dir_files = fs::read_dir(unpacked_snapshots_dir).expect("Invalid snapshot path");
-        let paths: Vec<PathBuf> = dir_files
-            .filter_map(|entry| entry.ok().map(|e| e.path()))
-            .collect();
-        let mut copy_options = CopyOptions::new();
-        copy_options.overwrite = true;
-        fs_extra::move_items(&paths, snapshot_config.snapshot_path(), &copy_options)?;
-
-        let mut banks = HashMap::new();
-        banks.insert(bank.slot(), bank.clone());
-        let root = bank.slot();
-        let snapshot_paths = snapshot_utils::get_snapshot_paths(&snapshot_config.snapshot_path);
-        if snapshot_paths.is_empty() {
-            return Err(Error::IO(IOError::new(
-                ErrorKind::Other,
-                "no snapshots found",
-            )));
-        }
-        Ok(BankForks {
-            banks,
-            working_bank: bank,
-            root,
-            snapshot_config: None,
-            slots_since_snapshot: vec![snapshot_paths.last().unwrap().slot],
-            confidence: HashMap::new(),
-        })
-    }
 }
 
 #[cfg(test)]
@@ -429,6 +376,7 @@ mod tests {
     use solana_sdk::pubkey::Pubkey;
     use solana_sdk::signature::{Keypair, KeypairUtil};
     use solana_sdk::system_transaction;
+    use std::fs;
     use std::sync::atomic::AtomicBool;
     use std::sync::mpsc::channel;
     use tempfile::TempDir;
@@ -541,35 +489,35 @@ mod tests {
         );
     }
 
-    fn restore_from_snapshot(bank_forks: BankForks, account_paths: String, last_slot: u64) {
-        let (snapshot_path, snapshot_package_output_path) = bank_forks
+    fn restore_from_snapshot(old_bank_forks: BankForks, account_paths: String) {
+        let (snapshot_path, snapshot_package_output_path) = old_bank_forks
             .snapshot_config
             .as_ref()
             .map(|c| (&c.snapshot_path, &c.snapshot_package_output_path))
             .unwrap();
 
-        let new = BankForks::load_from_snapshot(
+        let deserialized_bank = snapshot_utils::bank_from_archive(
             account_paths,
-            bank_forks.snapshot_config.as_ref().unwrap(),
+            old_bank_forks.snapshot_config.as_ref().unwrap(),
             snapshot_utils::get_snapshot_tar_path(snapshot_package_output_path),
         )
         .unwrap();
 
-        for (slot, _) in new.banks.iter() {
-            if *slot > 0 {
-                let bank = bank_forks.banks.get(slot).unwrap().clone();
-                let new_bank = new.banks.get(slot).unwrap();
-                bank.compare_bank(&new_bank);
-            }
-        }
+        let bank = old_bank_forks
+            .banks
+            .get(&deserialized_bank.slot())
+            .unwrap()
+            .clone();
+        bank.compare_bank(&deserialized_bank);
 
-        assert_eq!(new.working_bank().slot(), last_slot);
-        for (slot, _) in new.banks.iter() {
-            snapshot_utils::remove_snapshot(*slot, snapshot_path).unwrap();
+        let slot_snapshot_paths = snapshot_utils::get_snapshot_paths(&snapshot_path);
+
+        for p in slot_snapshot_paths {
+            snapshot_utils::remove_snapshot(p.slot, &snapshot_path).unwrap();
         }
     }
 
-    // creates banks upto "last_slot" and runs the input function `f` on each bank created
+    // creates banks up to "last_slot" and runs the input function `f` on each bank created
     // also marks each bank as root and generates snapshots
     // finally tries to restore from the last bank's snapshot and compares the restored bank to the
     // `last_slot` bank
@@ -627,7 +575,6 @@ mod tests {
         restore_from_snapshot(
             bank_forks,
             accounts_dir.path().to_str().unwrap().to_string(),
-            last_slot,
         );
     }
 

--- a/core/src/blocktree_processor.rs
+++ b/core/src/blocktree_processor.rs
@@ -266,6 +266,8 @@ fn process_bank_0(
 
     if !entries.is_empty() {
         verify_and_process_entries(bank0, &entries, verify_ledger, entry0.hash)?;
+    } else {
+        bank0.register_tick(&entry0.hash);
     }
 
     bank0.freeze();
@@ -1374,7 +1376,7 @@ pub mod tests {
         let bank1 = Arc::new(Bank::new_from_parent(&bank0, &Pubkey::default(), 1));
         bank1.squash();
         let slot1_entries = blocktree.get_slot_entries(1, 0, None).unwrap();
-        verify_and_process_entries(&bank1, &slot1_entries, true, blockhash).unwrap();
+        verify_and_process_entries(&bank1, &slot1_entries, true, bank0.last_blockhash()).unwrap();
 
         // Test process_blocktree_from_root() from slot 1 onwards
         let (bank_forks, bank_forks_info, _) =

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -1059,7 +1059,7 @@ mod test {
         let arc_bank0 = Arc::new(bank0);
         let bank_forks = Arc::new(RwLock::new(BankForks::new_from_banks(
             &[arc_bank0.clone()],
-            0,
+            vec![0],
         )));
         let pubkey = Pubkey::new_rand();
         let mut tower = Tower::new_from_forks(&bank_forks.read().unwrap(), &pubkey);

--- a/core/src/storage_stage.rs
+++ b/core/src/storage_stage.rs
@@ -659,7 +659,10 @@ mod tests {
         let cluster_info = test_cluster_info(&keypair.pubkey());
         let GenesisBlockInfo { genesis_block, .. } = create_genesis_block(1000);
         let bank = Arc::new(Bank::new(&genesis_block));
-        let bank_forks = Arc::new(RwLock::new(BankForks::new_from_banks(&[bank.clone()], 0)));
+        let bank_forks = Arc::new(RwLock::new(BankForks::new_from_banks(
+            &[bank.clone()],
+            vec![0],
+        )));
         let (_slot_sender, slot_receiver) = channel();
         let storage_state = StorageState::new(
             &bank.last_blockhash(),
@@ -699,7 +702,10 @@ mod tests {
         let blocktree = Arc::new(Blocktree::open(&ledger_path).unwrap());
         let slot = 1;
         let bank = Arc::new(Bank::new(&genesis_block));
-        let bank_forks = Arc::new(RwLock::new(BankForks::new_from_banks(&[bank.clone()], 0)));
+        let bank_forks = Arc::new(RwLock::new(BankForks::new_from_banks(
+            &[bank.clone()],
+            vec![0],
+        )));
 
         let cluster_info = test_cluster_info(&keypair.pubkey());
         let (bank_sender, bank_receiver) = channel();
@@ -791,7 +797,10 @@ mod tests {
 
         let bank = Bank::new(&genesis_block);
         let bank = Arc::new(bank);
-        let bank_forks = Arc::new(RwLock::new(BankForks::new_from_banks(&[bank.clone()], 0)));
+        let bank_forks = Arc::new(RwLock::new(BankForks::new_from_banks(
+            &[bank.clone()],
+            vec![0],
+        )));
         let cluster_info = test_cluster_info(&keypair.pubkey());
 
         let (bank_sender, bank_receiver) = channel();

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -355,29 +355,28 @@ fn get_bank_forks(
             // Check that the snapshot tar exists, try to load the snapshot if it does
             if tar.exists() {
                 // Fail hard here if snapshot fails to load, don't silently continue
-                let bank_forks = BankForks::load_from_snapshot(
-                    //&genesis_block,
+                let deserialized_bank = snapshot_utils::bank_from_archive(
                     account_paths
                         .clone()
                         .expect("Account paths not present when booting from snapshot"),
                     snapshot_config,
-                    tar,
+                    &tar,
                 )
                 .expect("Load from snapshot failed");
 
-                let bank = &bank_forks.working_bank();
-                let fork_info = BankForksInfo {
-                    bank_slot: bank.slot(),
-                };
-                result = Some((
-                    bank_forks,
-                    vec![fork_info],
-                    LeaderScheduleCache::new_from_bank(bank),
-                ));
+                result = Some(
+                    blocktree_processor::process_blocktree_from_root(
+                        blocktree,
+                        Arc::new(deserialized_bank),
+                        verify_ledger,
+                        dev_halt_at_slot,
+                    )
+                    .expect("processing blocktree after loading snapshot failed"),
+                );
             }
         }
 
-        // If loading from a snapshot failed/snapshot didn't exist
+        // If a snapshot doesn't exist
         if result.is_none() {
             result = Some(
                 blocktree_processor::process_blocktree(

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -368,7 +368,6 @@ fn get_bank_forks(
                 let bank = &bank_forks.working_bank();
                 let fork_info = BankForksInfo {
                     bank_slot: bank.slot(),
-                    entry_height: bank.tick_height(),
                 };
                 result = Some((
                     bank_forks,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -724,12 +724,12 @@ impl Bank {
 
         // TODO: put this assert back in
         // assert!(!self.is_frozen());
-
-        let current_tick_height = {
+        if self.ticks_per_slot() != 1 || self.slot() != 0 {
             self.tick_height.fetch_add(1, Ordering::Relaxed);
-            self.tick_height.load(Ordering::Relaxed) as u64
-        };
-        inc_new_counter_debug!("bank-register_tick-registered", 1);
+            inc_new_counter_debug!("bank-register_tick-registered", 1);
+        }
+
+        let current_tick_height = self.tick_height.load(Ordering::Relaxed) as u64;
 
         // Register a new block hash if at the last tick in the slot
         if current_tick_height % self.ticks_per_slot == self.ticks_per_slot - 1 {


### PR DESCRIPTION
#### Problem
After starting from a snapshot, there's no supported way to replay existing blobs in blocktree that come after that chain to that snapshot

#### Summary of Changes
Refactor `process_blocktree()` to allow support for `process_blocktree_from_root()`

TODO: Tests

Fixes #
