### PR TITLE
Delete terminated GCP instances

### DIFF
--- a/net/gce.sh
+++ b/net/gce.sh
@@ -412,7 +412,6 @@ EOF
     declare failOnFailure="$6"
     declare arrayName="$7"
 
-    # This check should eventually be moved to cloud provider specific script
     if [ "$publicIp" = "TERMINATED" ] || [ "$privateIp" = "TERMINATED" ]; then
       if $failOnFailure; then
         exit 1


### PR DESCRIPTION
GCP instances sometimes self-terminate and then get stuck.   Widen the filter so we can successfully locate and delete them.