### PR TITLE
Solana-wallet: prevent duplicate pubkeys 

### DIFF
--- a/wallet/src/wallet.rs
+++ b/wallet/src/wallet.rs
@@ -2355,7 +2355,9 @@ mod tests {
         assert_eq!(signature.unwrap(), SIGNATURE.to_string());
 
         let bob_keypair = Keypair::new();
-        config.command = WalletCommand::AuthorizeVoter(bob_pubkey, bob_keypair, bob_pubkey);
+        let new_authorized_voter_pubkey = Pubkey::new_rand();
+        config.command =
+            WalletCommand::AuthorizeVoter(bob_pubkey, bob_keypair, new_authorized_voter_pubkey);
         let signature = process_command(&config);
         assert_eq!(signature.unwrap(), SIGNATURE.to_string());
 


### PR DESCRIPTION
#### Problem
In some cases, duplicate pubkeys can indicate that a program instruction is incorrect (even if the program would process it successfully).

#### Summary of Changes
Check for pubkey duplicates in these cases and return a WalletError

Toward #5437 
Fixes Bullet 5
