### PR TITLE
Vote Transactions carry the last N votes, which blows up their size.

### DIFF
--- a/core/src/cluster_info_vote_listener.rs
+++ b/core/src/cluster_info_vote_listener.rs
@@ -85,7 +85,6 @@ impl Service for ClusterInfoVoteListener {
 
 #[cfg(test)]
 mod tests {
-    use crate::consensus::MAX_RECENT_VOTES;
     use crate::packet;
     use solana_sdk::hash::Hash;
     use solana_sdk::signature::{Keypair, KeypairUtil};
@@ -98,9 +97,8 @@ mod tests {
         solana_logger::setup();
         let node_keypair = Keypair::new();
         let vote_keypair = Keypair::new();
-        let votes = (0..MAX_RECENT_VOTES)
-            .map(|i| Vote::new(i as u64, Hash::default()))
-            .collect::<Vec<_>>();
+        let slots: Vec<_> = (0..31).into_iter().collect();
+        let votes = Vote::new(slots, Hash::default());
         let vote_ix = vote_instruction::vote(&vote_keypair.pubkey(), &vote_keypair.pubkey(), votes);
 
         let mut vote_tx = Transaction::new_with_payer(vec![vote_ix], Some(&node_keypair.pubkey()));

--- a/programs/stake_tests/tests/stake_instruction.rs
+++ b/programs/stake_tests/tests/stake_instruction.rs
@@ -40,7 +40,7 @@ fn fill_epoch_with_votes(
             vec![vote_instruction::vote(
                 &vote_pubkey,
                 &vote_pubkey,
-                vec![Vote::new(parent.slot() as u64, parent.hash())],
+                Vote::new(vec![parent.slot() as u64], parent.hash()),
             )],
             Some(&mint_pubkey),
         );


### PR DESCRIPTION
#### Problem

Vote transactions are large.

#### Summary of Changes

The vote should just carry the last bank hash, and its Tower stack of slots.

Fixes #

tag: @carllin @sagar-solana @rob-solana 