### PR TITLE
Coalesce gossip pull requests and serve them in batches

### DIFF
--- a/core/src/cluster_info.rs
+++ b/core/src/cluster_info.rs
@@ -19,7 +19,7 @@ use crate::crds_gossip::CrdsGossip;
 use crate::crds_gossip_error::CrdsGossipError;
 use crate::crds_gossip_pull::{CrdsFilter, CRDS_GOSSIP_PULL_CRDS_TIMEOUT_MS};
 use crate::crds_value::{CrdsValue, CrdsValueLabel, EpochSlots, Vote};
-use crate::packet::{to_shared_blob, Blob, SharedBlob, BLOB_SIZE};
+use crate::packet::{to_shared_blob, SharedBlob, BLOB_SIZE};
 use crate::repair_service::RepairType;
 use crate::result::Result;
 use crate::staking_utils;
@@ -149,6 +149,11 @@ impl Signable for PruneData {
     fn set_signature(&mut self, signature: Signature) {
         self.signature = signature
     }
+}
+
+struct PullData {
+    pub caller: CrdsValue,
+    pub filters: Vec<(SocketAddr, CrdsFilter)>,
 }
 
 // TODO These messages should go through the gpu pipeline for spam filtering
@@ -1098,60 +1103,141 @@ impl ClusterInfo {
         res
     }
 
-    //TODO we should first coalesce all the requests
-    fn handle_blob(
-        obj: &Arc<RwLock<Self>>,
+    fn handle_blobs(
+        me: &Arc<RwLock<Self>>,
         blocktree: Option<&Arc<Blocktree>>,
         stakes: &HashMap<Pubkey, u64>,
-        blob: &Blob,
+        blobs: &[SharedBlob],
     ) -> Vec<SharedBlob> {
-        deserialize(&blob.data[..blob.meta.size])
-            .into_iter()
-            .flat_map(|request| {
-                ClusterInfo::handle_protocol(obj, &blob.meta.addr(), blocktree, stakes, request)
-            })
-            .collect()
+        // iter over the blobs, collect pulls separately and process everything else
+        let mut gossip_pulls: HashMap<Pubkey, PullData> = HashMap::new();
+        let mut responses = Vec::new();
+        blobs.iter().for_each(|blob| {
+            let blob = blob.read().unwrap();
+            let from_addr = blob.meta.addr();
+            deserialize(&blob.data[..blob.meta.size])
+                .into_iter()
+                .for_each(|request| match request {
+                    Protocol::PullRequest(filter, caller) => {
+                        if !caller.verify() {
+                            inc_new_counter_error!(
+                                "cluster_info-gossip_pull_request_verify_fail",
+                                1
+                            );
+                        } else if caller.contact_info().is_some() {
+                            if caller.contact_info().unwrap().pubkey()
+                                == me.read().unwrap().gossip.id
+                            {
+                                warn!("PullRequest ignored, I'm talking to myself");
+                                inc_new_counter_debug!("cluster_info-window-request-loopback", 1);
+                            } else {
+                                gossip_pulls
+                                    .entry(caller.pubkey())
+                                    .or_insert(PullData {
+                                        caller,
+                                        filters: vec![],
+                                    })
+                                    .filters
+                                    .push((from_addr, filter));
+                            }
+                        }
+                    }
+                    Protocol::PullResponse(from, mut data) => {
+                        data.retain(|v| {
+                            let ret = v.verify();
+                            if !ret {
+                                inc_new_counter_error!(
+                                    "cluster_info-gossip_pull_response_verify_fail",
+                                    1
+                                );
+                            }
+                            ret
+                        });
+                        Self::handle_pull_response(me, &from, data);
+                    }
+                    Protocol::PushMessage(from, mut data) => {
+                        data.retain(|v| {
+                            let ret = v.verify();
+                            if !ret {
+                                inc_new_counter_error!(
+                                    "cluster_info-gossip_push_msg_verify_fail",
+                                    1
+                                );
+                            }
+                            ret
+                        });
+                        responses.append(&mut Self::handle_push_message(me, &from, data, stakes))
+                    }
+                    Protocol::PruneMessage(from, data) => {
+                        if data.verify() {
+                            inc_new_counter_debug!("cluster_info-prune_message", 1);
+                            inc_new_counter_debug!(
+                                "cluster_info-prune_message-size",
+                                data.prunes.len()
+                            );
+                            match me.write().unwrap().gossip.process_prune_msg(
+                                &from,
+                                &data.destination,
+                                &data.prunes,
+                                data.wallclock,
+                                timestamp(),
+                            ) {
+                                Err(CrdsGossipError::PruneMessageTimeout) => {
+                                    inc_new_counter_debug!("cluster_info-prune_message_timeout", 1)
+                                }
+                                Err(CrdsGossipError::BadPruneDestination) => {
+                                    inc_new_counter_debug!("cluster_info-bad_prune_destination", 1)
+                                }
+                                _ => (),
+                            }
+                        } else {
+                            inc_new_counter_debug!("cluster_info-gossip_prune_msg_verify_fail", 1);
+                        }
+                    }
+                    _ => responses
+                        .append(&mut Self::handle_repair(me, &from_addr, blocktree, request)),
+                })
+        });
+        // process the collected pulls together
+        responses.append(&mut Self::handle_pull_requests(me, &mut gossip_pulls));
+        responses
     }
 
-    fn handle_pull_request(
+    fn handle_pull_requests(
         me: &Arc<RwLock<Self>>,
-        filter: CrdsFilter,
-        caller: CrdsValue,
-        from_addr: &SocketAddr,
+        requests: &mut HashMap<Pubkey, PullData>,
     ) -> Vec<SharedBlob> {
-        let self_id = me.read().unwrap().gossip.id;
-        inc_new_counter_debug!("cluster_info-pull_request", 1);
-        if caller.contact_info().is_none() {
-            return vec![];
-        }
-        let from = caller.contact_info().unwrap();
-        if from.id == self_id {
-            warn!(
-                "PullRequest ignored, I'm talking to myself: me={} remoteme={}",
-                self_id, from.id
-            );
-            inc_new_counter_debug!("cluster_info-window-request-loopback", 1);
-            return vec![];
-        }
-        let now = timestamp();
-        let data = me
-            .write()
-            .unwrap()
-            .gossip
-            .process_pull_request(caller, filter, now);
-        let len = data.len();
-        trace!("get updates since response {}", len);
-        let responses: Vec<_> = Self::split_gossip_messages(data)
-            .into_iter()
-            .map(move |payload| Protocol::PullResponse(self_id, payload))
-            .collect();
-        // The remote node may not know its public IP:PORT. Instead of responding to the caller's
-        // gossip addr, respond to the origin addr.
-        inc_new_counter_debug!("cluster_info-pull_request-rsp", len);
-        responses
-            .into_iter()
-            .map(|rsp| to_shared_blob(rsp, *from_addr).ok().into_iter())
-            .flatten()
+        requests
+            .drain()
+            .flat_map(|(_, pull_data)| {
+                let self_id = me.read().unwrap().id();
+                let now = timestamp();
+                let from_addr = pull_data.filters.last().unwrap().0;
+                let pull_response = me.write().unwrap().gossip.process_pull_request(
+                    pull_data.caller,
+                    &pull_data
+                        .filters
+                        .into_iter()
+                        .map(|(_, filter)| filter)
+                        .collect::<Vec<_>>(),
+                    now,
+                );
+                let len = pull_response.len();
+                trace!("get updates since response {}", len);
+                let responses: Vec<_> = Self::split_gossip_messages(pull_response)
+                    .into_iter()
+                    .map(move |payload| Protocol::PullResponse(self_id, payload))
+                    .collect();
+                // The remote node may not know its public IP:PORT. Instead of responding to the caller's
+                // gossip addr, respond to the origin addr. The last origin addr is picked from the list of
+                // addrs.
+                inc_new_counter_debug!("cluster_info-pull_request-rsp", len);
+                responses
+                    .into_iter()
+                    .map(|rsp| to_shared_blob(rsp, from_addr).ok().into_iter())
+                    .flatten()
+                    .collect::<Vec<_>>()
+            })
             .collect()
     }
 
@@ -1312,73 +1398,6 @@ impl ClusterInfo {
         res
     }
 
-    fn handle_protocol(
-        me: &Arc<RwLock<Self>>,
-        from_addr: &SocketAddr,
-        blocktree: Option<&Arc<Blocktree>>,
-        stakes: &HashMap<Pubkey, u64>,
-        request: Protocol,
-    ) -> Vec<SharedBlob> {
-        match request {
-            // TODO verify messages faster
-            Protocol::PullRequest(filter, caller) => {
-                if !caller.verify() {
-                    inc_new_counter_error!("cluster_info-gossip_pull_request_verify_fail", 1);
-                    vec![]
-                } else {
-                    Self::handle_pull_request(me, filter, caller, from_addr)
-                }
-            }
-            Protocol::PullResponse(from, mut data) => {
-                data.retain(|v| {
-                    let ret = v.verify();
-                    if !ret {
-                        inc_new_counter_error!("cluster_info-gossip_pull_response_verify_fail", 1);
-                    }
-                    ret
-                });
-                Self::handle_pull_response(me, &from, data);
-                vec![]
-            }
-            Protocol::PushMessage(from, mut data) => {
-                data.retain(|v| {
-                    let ret = v.verify();
-                    if !ret {
-                        inc_new_counter_error!("cluster_info-gossip_push_msg_verify_fail", 1);
-                    }
-                    ret
-                });
-                Self::handle_push_message(me, &from, data, stakes)
-            }
-            Protocol::PruneMessage(from, data) => {
-                if data.verify() {
-                    inc_new_counter_debug!("cluster_info-prune_message", 1);
-                    inc_new_counter_debug!("cluster_info-prune_message-size", data.prunes.len());
-                    match me.write().unwrap().gossip.process_prune_msg(
-                        &from,
-                        &data.destination,
-                        &data.prunes,
-                        data.wallclock,
-                        timestamp(),
-                    ) {
-                        Err(CrdsGossipError::PruneMessageTimeout) => {
-                            inc_new_counter_debug!("cluster_info-prune_message_timeout", 1)
-                        }
-                        Err(CrdsGossipError::BadPruneDestination) => {
-                            inc_new_counter_debug!("cluster_info-bad_prune_destination", 1)
-                        }
-                        Err(_) => (),
-                        Ok(_) => (),
-                    }
-                } else {
-                    inc_new_counter_debug!("cluster_info-gossip_prune_msg_verify_fail", 1);
-                }
-                vec![]
-            }
-            _ => Self::handle_repair(me, from_addr, blocktree, request),
-        }
-    }
-
     /// Process messages from the network
     fn run_listen(
         obj: &Arc<RwLock<Self>>,
@@ -1393,7 +1412,6 @@ impl ClusterInfo {
         while let Ok(mut more) = requests_receiver.try_recv() {
             reqs.append(&mut more);
         }
-        let mut resps = Vec::new();
 
         let stakes: HashMap<_, _> = match bank_forks {
             Some(ref bank_forks) => {
@@ -1402,11 +1420,8 @@ impl ClusterInfo {
             None => HashMap::new(),
         };
 
-        for req in reqs {
-            let mut resp = Self::handle_blob(obj, blocktree, &stakes, &req.read().unwrap());
-            resps.append(&mut resp);
-        }
-        response_sender.send(resps)?;
+        let responses = Self::handle_blobs(obj, blocktree, &stakes, &reqs);
+        response_sender.send(responses)?;
         Ok(())
     }
     pub fn listen(
@@ -1712,7 +1727,7 @@ mod tests {
     use crate::blocktree::Blocktree;
     use crate::crds_value::CrdsValueLabel;
     use crate::erasure::ErasureConfig;
-    use crate::packet::BLOB_HEADER_SIZE;
+    use crate::packet::{Blob, BLOB_HEADER_SIZE};
     use crate::repair_service::RepairType;
     use crate::result::Error;
     use crate::test_tx::test_tx;

--- a/core/src/crds_gossip.rs
+++ b/core/src/crds_gossip.rs
@@ -145,14 +145,13 @@ impl CrdsGossip {
         self.pull.mark_pull_request_creation_time(from, now)
     }
     /// process a pull request and create a response
-    pub fn process_pull_request(
+    pub fn process_pull_requests(
         &mut self,
-        caller: CrdsValue,
-        filters: &[CrdsFilter],
+        filters: Vec<(CrdsValue, CrdsFilter)>,
         now: u64,
-    ) -> Vec<CrdsValue> {
+    ) -> Vec<Vec<CrdsValue>> {
         self.pull
-            .process_pull_request(&mut self.crds, caller, filters, now)
+            .process_pull_requests(&mut self.crds, filters, now)
     }
     /// process a pull response
     pub fn process_pull_response(

--- a/core/src/crds_gossip.rs
+++ b/core/src/crds_gossip.rs
@@ -148,11 +148,11 @@ impl CrdsGossip {
     pub fn process_pull_request(
         &mut self,
         caller: CrdsValue,
-        filter: CrdsFilter,
+        filters: &[CrdsFilter],
         now: u64,
     ) -> Vec<CrdsValue> {
         self.pull
-            .process_pull_request(&mut self.crds, caller, filter, now)
+            .process_pull_request(&mut self.crds, caller, filters, now)
     }
     /// process a pull response
     pub fn process_pull_response(

--- a/core/src/crds_gossip_pull.rs
+++ b/core/src/crds_gossip_pull.rs
@@ -191,21 +191,22 @@ impl CrdsGossipPull {
     }
 
     /// process a pull request and create a response
-    pub fn process_pull_request(
+    pub fn process_pull_requests(
         &mut self,
         crds: &mut Crds,
-        caller: CrdsValue,
-        filters: &[CrdsFilter],
+        requests: Vec<(CrdsValue, CrdsFilter)>,
         now: u64,
-    ) -> Vec<CrdsValue> {
-        let rv = self.filter_crds_values(crds, filters);
-        let key = caller.label().pubkey();
-        let old = crds.insert(caller, now);
-        if let Some(val) = old.ok().and_then(|opt| opt) {
-            self.purged_values
-                .push_back((val.value_hash, val.local_timestamp));
-        }
-        crds.update_record_timestamp(&key, now);
+    ) -> Vec<Vec<CrdsValue>> {
+        let rv = self.filter_crds_values(crds, &requests);
+        requests.into_iter().for_each(|(caller, _)| {
+            let key = caller.label().pubkey();
+            let old = crds.insert(caller, now);
+            if let Some(val) = old.ok().and_then(|opt| opt) {
+                self.purged_values
+                    .push_back((val.value_hash, val.local_timestamp));
+            }
+            crds.update_record_timestamp(&key, now);
+        });
         rv
     }
     /// process a pull response
@@ -251,12 +252,18 @@ impl CrdsGossipPull {
         filters
     }
     /// filter values that fail the bloom filter up to max_bytes
-    fn filter_crds_values(&self, crds: &Crds, filters: &[CrdsFilter]) -> Vec<CrdsValue> {
-        let mut ret = vec![];
+    fn filter_crds_values(
+        &self,
+        crds: &Crds,
+        filters: &[(CrdsValue, CrdsFilter)],
+    ) -> Vec<Vec<CrdsValue>> {
+        let mut ret = vec![vec![]; filters.len()];
         for v in crds.table.values() {
-            if filters.iter().any(|filter| !filter.contains(&v.value_hash)) {
-                ret.push(v.value.clone());
-            }
+            filters.iter().enumerate().for_each(|(i, (_, filter))| {
+                if !filter.contains(&v.value_hash) {
+                    ret[i].push(v.value.clone());
+                }
+            });
         }
         ret
     }
@@ -394,8 +401,9 @@ mod test {
         let mut dest_crds = Crds::default();
         let mut dest = CrdsGossipPull::default();
         let (_, filters, caller) = req.unwrap();
-        let rsp = dest.process_pull_request(&mut dest_crds, caller.clone(), &filters, 1);
-        assert!(rsp.is_empty());
+        let filters = filters.into_iter().map(|f| (caller.clone(), f)).collect();
+        let rsp = dest.process_pull_requests(&mut dest_crds, filters, 1);
+        assert!(rsp.iter().all(|rsp| rsp.is_empty()));
         assert!(dest_crds.lookup(&caller.label()).is_some());
         assert_eq!(
             dest_crds
@@ -452,8 +460,8 @@ mod test {
                 PACKET_DATA_SIZE,
             );
             let (_, filters, caller) = req.unwrap();
-            let rsp =
-                dest.process_pull_request(&mut dest_crds, caller.clone(), &filters.as_ref(), 0);
+            let filters = filters.into_iter().map(|f| (caller.clone(), f)).collect();
+            let mut rsp = dest.process_pull_requests(&mut dest_crds, filters, 0);
             // if there is a false positive this is empty
             // prob should be around 0.1 per iteration
             if rsp.is_empty() {
@@ -464,7 +472,8 @@ mod test {
                 continue;
             }
             assert_eq!(rsp.len(), 1);
-            let failed = node.process_pull_response(&mut node_crds, &node_pubkey, rsp, 1);
+            let failed =
+                node.process_pull_response(&mut node_crds, &node_pubkey, rsp.pop().unwrap(), 1);
             assert_eq!(failed, 0);
             assert_eq!(
                 node_crds

--- a/core/src/replicator.rs
+++ b/core/src/replicator.rs
@@ -846,7 +846,10 @@ impl Replicator {
                 }
             }
             let res = r_reader.recv_timeout(Duration::new(1, 0));
-            if let Ok(blobs) = res {
+            if let Ok(mut blobs) = res {
+                while let Ok(mut more) = r_reader.try_recv() {
+                    blobs.append(&mut more);
+                }
                 window_service::process_blobs(&blobs, blocktree)?;
             }
             // check if all the slots in the segment are complete

--- a/core/tests/crds_gossip.rs
+++ b/core/tests/crds_gossip.rs
@@ -399,15 +399,23 @@ fn network_run_pull(
                     .map(|f| f.filter.bits.len() as usize / 8)
                     .sum::<usize>();
                 bytes += serialized_size(&caller_info).unwrap() as usize;
+                let filters = filters
+                    .into_iter()
+                    .map(|f| (caller_info.clone(), f))
+                    .collect();
                 let rsp = network
                     .get(&to)
                     .map(|node| {
                         let mut rsp = vec![];
-                        rsp.append(&mut node.lock().unwrap().process_pull_requests(
-                            caller_info.clone(),
-                            &filters,
-                            now,
-                        ));
+                        rsp.append(
+                            &mut node
+                                .lock()
+                                .unwrap()
+                                .process_pull_requests(filters, now)
+                                .into_iter()
+                                .flatten()
+                                .collect(),
+                        );
                         rsp
                     })
                     .unwrap();

--- a/core/tests/crds_gossip.rs
+++ b/core/tests/crds_gossip.rs
@@ -403,13 +403,11 @@ fn network_run_pull(
                     .get(&to)
                     .map(|node| {
                         let mut rsp = vec![];
-                        for filter in filters {
-                            rsp.append(&mut node.lock().unwrap().process_pull_request(
-                                caller_info.clone(),
-                                filter,
-                                now,
-                            ));
-                        }
+                        rsp.append(&mut node.lock().unwrap().process_pull_request(
+                            caller_info.clone(),
+                            &filters,
+                            now,
+                        ));
                         rsp
                     })
                     .unwrap();

--- a/core/tests/crds_gossip.rs
+++ b/core/tests/crds_gossip.rs
@@ -403,7 +403,7 @@ fn network_run_pull(
                     .get(&to)
                     .map(|node| {
                         let mut rsp = vec![];
-                        rsp.append(&mut node.lock().unwrap().process_pull_request(
+                        rsp.append(&mut node.lock().unwrap().process_pull_requests(
                             caller_info.clone(),
                             &filters,
                             now,


### PR DESCRIPTION
#### Problem

With the smaller split gossip pull requests the server side can end up doing unnecessary iteration over its crdsvalue for each pull request it receives from a single peer

#### Summary of Changes

batch pull requests that originate form the same peer and process them together

