### PR TITLE
Run sdk-c through clippy separately

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -368,6 +368,22 @@ version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "cbindgen"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3655,6 +3671,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-sdk-c"
+version = "0.18.0-pre1"
+dependencies = [
+ "bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bs58 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cbindgen 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-ed25519-dalek 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-sdk 0.18.0-pre1",
+]
+
+[[package]]
 name = "solana-stake-api"
 version = "0.18.0-pre1"
 dependencies = [
@@ -5193,6 +5223,7 @@ dependencies = [
 "checksum bzip2-sys 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "6584aa36f5ad4c9247f5323b0a42f37802b37a836f0ad87084d7a33961abe25f"
 "checksum c2-chacha 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7d64d04786e0f528460fc884753cf8dddcc466be308f6026f8e355c41a0e4101"
 "checksum c_linked_list 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4964518bd3b4a8190e832886cdc0da9794f12e8e6c1613a9e90ff331c4c8724b"
+"checksum cbindgen 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0e7e19db9a3892c88c74cbbdcd218196068a928f1b60e736c448b13a1e81f277"
 "checksum cc 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)" = "ce400c638d48ee0e9ab75aef7997609ec57367ccfe1463f21bf53c3eca67bf46"
 "checksum cexpr 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "a7fa24eb00d5ffab90eaeaf1092ac85c04c64aaf358ea6f84505b8116d24c6af"
 "checksum cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "b486ce3ccf7ffd79fdeb678eac06a9e6c09fc88d33836340becb8fffe87c5e33"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ members = [
     "replicator",
     "runtime",
     "sdk",
+    "sdk-c",
     "upload-perf",
     "validator-info",
     "vote-signer",

--- a/ci/test-checks.sh
+++ b/ci/test-checks.sh
@@ -11,8 +11,13 @@ export RUST_BACKTRACE=1
 export RUSTFLAGS="-D warnings"
 
 _ cargo +"$rust_stable" fmt --all -- --check
+
+# Clippy gets stuck for unknown reasons if sdk-c is included in the build, so check it separately.
+# See https://github.com/solana-labs/solana/issues/5503
 _ cargo +"$rust_stable" clippy --version
-_ cargo +"$rust_stable" clippy --all -- --deny=warnings
+_ cargo +"$rust_stable" clippy --all --exclude solana-sdk-c -- --deny=warnings
+_ cargo +"$rust_stable" clippy --manifest-path sdk-c/Cargo.toml -- --deny=warnings
+
 _ cargo +"$rust_stable" audit --version
 _ cargo +"$rust_stable" audit
 _ ci/nits.sh


### PR DESCRIPTION
#### Problem

`sdk-c` causes `clippy` to fail if `clippy` is run with the `--all` argument.

#### Summary of Changes

Add `sdk-c` back into the workspace. Exclude `sdk-c` from the `clippy --all` run, then run `clippy` on `sdk-c` on its own.
