### PR TITLE
Insert data shreds in blocktree and database

### DIFF
--- a/core/src/blocktree.rs
+++ b/core/src/blocktree.rs
@@ -1429,7 +1429,7 @@ fn get_slot_meta_entry<'a>(
     let meta_cf = db.column::<cf::SlotMeta>();
 
     // Check if we've already inserted the slot metadata for this blob's slot
-    let entry = slot_meta_working_set.entry(slot).or_insert_with(|| {
+    slot_meta_working_set.entry(slot).or_insert_with(|| {
         // Store a 2-tuple of the metadata (working copy, backup copy)
         if let Some(mut meta) = meta_cf.get(slot).expect("Expect database get to succeed") {
             let backup = Some(meta.clone());
@@ -1448,9 +1448,7 @@ fn get_slot_meta_entry<'a>(
                 None,
             )
         }
-    });
-
-    entry
+    })
 }
 
 fn should_insert_blob(

--- a/core/src/blocktree.rs
+++ b/core/src/blocktree.rs
@@ -411,11 +411,11 @@ impl Blocktree {
 
         for shared_shred in shared_shreds {
             let slot = shared_shred.slot();
-            let index = shared_shred.index() as u64;
+            let index = u64::from(shared_shred.index());
 
             let inserted = Blocktree::insert_data_shred(
                 db,
-                &mut just_inserted_data_indexes,
+                &just_inserted_data_indexes,
                 &mut slot_meta_working_set,
                 &mut index_working_set,
                 shared_shred.borrow(),
@@ -467,7 +467,7 @@ impl Blocktree {
         write_batch: &mut WriteBatch,
     ) -> Result<bool> {
         let slot = shred.slot();
-        let index = shred.index() as u64;
+        let index = u64::from(shred.index());
         let parent = if let Shred::FirstInSlot(s) = shred {
             s.header.parent
         } else {


### PR DESCRIPTION
#### Problem
Missing implementation for inserting data shreds in blocktree

#### Summary of Changes
Added code to insert data shreds in database.
Refactored blob insertion code to reuse some existing functionality

#5294 