### PR TITLE
Remove serialization of future AppendVecs

### DIFF
--- a/core/src/snapshot_utils.rs
+++ b/core/src/snapshot_utils.rs
@@ -60,7 +60,12 @@ pub fn package_snapshot<P: AsRef<Path>, Q: AsRef<Path>>(
     let snapshot_hard_links_dir = tempfile::tempdir_in(snapshot_path)?;
 
     // Get a reference to all the relevant AccountStorageEntries
-    let account_storage_entries = bank.rc.get_storage_entries();
+    let account_storage_entries: Vec<_> = bank
+        .rc
+        .get_storage_entries()
+        .into_iter()
+        .filter(|x| x.fork_id() <= bank.slot())
+        .collect();
 
     // Create a snapshot package
     info!(

--- a/runtime/benches/accounts.rs
+++ b/runtime/benches/accounts.rs
@@ -62,7 +62,7 @@ fn test_accounts_squash(bencher: &mut Bencher) {
 fn test_accounts_hash_internal_state(bencher: &mut Bencher) {
     let accounts = Accounts::new(Some("bench_accounts_hash_internal".to_string()));
     let mut pubkeys: Vec<Pubkey> = vec![];
-    create_test_accounts(&accounts, &mut pubkeys, 60000);
+    create_test_accounts(&accounts, &mut pubkeys, 60000, 0);
     bencher.iter(|| {
         accounts.hash_internal_state(0);
     });


### PR DESCRIPTION
#### Problem
Example: At bank slot 81, a root of 50 is set, and a snapshot of AccountsDb is taken. However, AccountsDb contains AccountStorageEntries for banks 51-81 which should not be included in the snapshot.

#### Summary of Changes
Filter out future AppendVecs and AccountStorageEntries when taking snapshots

Fixes #
