### PR TITLE
Move genesis/snapshot archive download into Rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1068,7 +1068,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "crc32fast 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.61 (registry+https://github.com/rust-lang/crates.io-index)",
- "miniz-sys 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "miniz_oxide_c_api 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1811,15 +1810,6 @@ dependencies = [
  "phf 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "phf_codegen 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicase 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "miniz-sys"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "cc 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.61 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3053,12 +3043,12 @@ dependencies = [
  "bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "bs58 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bzip2 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "core_affinity 0.5.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "crc 1.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-channel 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "dir-diff 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "flate2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "fs_extra 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex-literal 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3830,8 +3820,10 @@ dependencies = [
 name = "solana-validator"
 version = "0.18.0-pre1"
 dependencies = [
+ "bzip2 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "reqwest 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana 0.18.0-pre1",
  "solana-drone 0.18.0-pre1",
@@ -3842,6 +3834,8 @@ dependencies = [
  "solana-sdk 0.18.0-pre1",
  "solana-vote-api 0.18.0-pre1",
  "solana-vote-signer 0.18.0-pre1",
+ "tar 0.4.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -5430,7 +5424,6 @@ dependencies = [
 "checksum mime 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ba626b8a6de5da682e1caa06bdb42a335aee5a84db8e5046a3e8ab17ba0a3ae0"
 "checksum mime 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)" = "3e27ca21f40a310bd06d9031785f4801710d566c184a6e15bad4f1d9b65f9425"
 "checksum mime_guess 2.0.0-alpha.6 (registry+https://github.com/rust-lang/crates.io-index)" = "30de2e4613efcba1ec63d8133f344076952090c122992a903359be5a4f99c3ed"
-"checksum miniz-sys 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "1e9e3ae51cea1576ceba0dde3d484d30e6e5b86dee0b2d412fe3a16a15c98202"
 "checksum miniz_oxide 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c061edee74a88eb35d876ce88b94d77a0448a201de111c244b70d047f5820516"
 "checksum miniz_oxide_c_api 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6c675792957b0d19933816c4e1d56663c341dd9bfa31cb2140ff2267c1d8ecf4"
 "checksum mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)" = "83f51996a3ed004ef184e16818edc51fadffe8e7ca68be67f9dee67d84d0ff23"

--- a/ci/testnet-deploy.sh
+++ b/ci/testnet-deploy.sh
@@ -90,7 +90,7 @@ Deploys a CD testnet
                         - Attempt to generate a TLS certificate using this DNS name
    --fullnode-additional-disk-size-gb [number]
                         - Size of additional disk in GB for all fullnodes
-   --no-snapshot
+   --no-snapshot-fetch
                         - If set, disables booting validators from a snapshot
 
    Note: the SOLANA_METRICS_CONFIG environment variable is used to configure
@@ -137,7 +137,7 @@ while [[ -n $1 ]]; do
     elif [[ $1 == --machine-type* ]]; then # Bypass quoted long args for GPUs
       shortArgs+=("$1")
       shift
-    elif [[ $1 = --no-snapshot ]]; then
+    elif [[ $1 = --no-snapshot-fetch ]]; then
       maybeNoSnapshot="$1"
       shift 1
     else

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -21,12 +21,12 @@ kvstore = ["solana-kvstore"]
 bincode = "1.1.4"
 bs58 = "0.2.0"
 byteorder = "1.3.2"
+bzip2 = "0.3.3"
 chrono = { version = "0.4.7", features = ["serde"] }
 core_affinity = "0.5.9"
 crc = { version = "1.8.1", optional = true }
 crossbeam-channel = "0.3"
 dir-diff = "0.3.1"
-flate2 = "1.0.9"
 fs_extra = "1.1.0"
 indexmap = "1.0"
 itertools = "0.8.0"

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -102,9 +102,9 @@ extern crate solana_metrics;
 #[macro_use]
 extern crate matches;
 
+extern crate bzip2;
 extern crate crossbeam_channel;
 extern crate dir_diff;
-extern crate flate2;
 extern crate fs_extra;
 extern crate tar;
 extern crate tempfile;

--- a/core/src/rpc_service.rs
+++ b/core/src/rpc_service.rs
@@ -70,8 +70,8 @@ impl RequestMiddleware for RpcRequestMiddleware {
     fn on_request(&self, request: hyper::Request<hyper::Body>) -> RequestMiddlewareAction {
         trace!("request uri: {}", request.uri());
         match request.uri().path() {
-            "/snapshot.tgz" => self.get("snapshot.tgz"),
-            "/genesis.tgz" => self.get("genesis.tgz"),
+            "/snapshot.tar.bz2" => self.get("snapshot.tar.bz2"),
+            "/genesis.tar.bz2" => self.get("genesis.tar.bz2"),
             _ => RequestMiddlewareAction::Proceed {
                 should_continue_on_invalid_cors: false,
                 request,

--- a/core/src/snapshot_package.rs
+++ b/core/src/snapshot_package.rs
@@ -1,7 +1,6 @@
 use crate::result::{Error, Result};
 use crate::service::Service;
-use flate2::write::GzEncoder;
-use flate2::Compression;
+use bzip2::write::BzEncoder;
 use solana_runtime::accounts_db::AccountStorageEntry;
 use std::fs;
 use std::path::Path;
@@ -77,11 +76,11 @@ impl SnapshotPackagerService {
         // Create the tar builder
         let tar_gz = tempfile::Builder::new()
             .prefix("new_state")
-            .suffix(".tgz")
+            .suffix(".tar.bz2")
             .tempfile_in(tar_dir)?;
 
         let temp_tar_path = tar_gz.path();
-        let enc = GzEncoder::new(&tar_gz, Compression::default());
+        let enc = BzEncoder::new(&tar_gz, bzip2::Compression::Default);
         let mut tar = tar::Builder::new(enc);
 
         // Create the list of paths to compress, starting with the snapshots

--- a/core/src/snapshot_utils.rs
+++ b/core/src/snapshot_utils.rs
@@ -3,7 +3,7 @@ use crate::result::{Error, Result};
 use crate::snapshot_package::SnapshotPackage;
 use crate::snapshot_package::{TAR_ACCOUNTS_DIR, TAR_SNAPSHOTS_DIR};
 use bincode::{deserialize_from, serialize_into};
-use flate2::read::GzDecoder;
+use bzip2::bufread::BzDecoder;
 use fs_extra::dir::CopyOptions;
 use solana_runtime::bank::Bank;
 use solana_runtime::status_cache::SlotDelta;
@@ -198,15 +198,15 @@ pub fn bank_from_archive<P: AsRef<Path>>(
 }
 
 pub fn get_snapshot_tar_path<P: AsRef<Path>>(snapshot_output_dir: P) -> PathBuf {
-    snapshot_output_dir.as_ref().join("snapshot.tgz")
+    snapshot_output_dir.as_ref().join("snapshot.tar.bz2")
 }
 
 pub fn untar_snapshot_in<P: AsRef<Path>, Q: AsRef<Path>>(
     snapshot_tar: P,
     unpack_dir: Q,
 ) -> Result<()> {
-    let tar_gz = File::open(snapshot_tar)?;
-    let tar = GzDecoder::new(tar_gz);
+    let tar_bz2 = File::open(snapshot_tar)?;
+    let tar = BzDecoder::new(BufReader::new(tar_bz2));
     let mut archive = Archive::new(tar);
     archive.unpack(&unpack_dir)?;
     Ok(())

--- a/multinode-demo/setup.sh
+++ b/multinode-demo/setup.sh
@@ -34,5 +34,5 @@ $solana_genesis "${args[@]}"
 (
   cd "$SOLANA_CONFIG_DIR"/bootstrap-leader
   set -x
-  tar zcvfS genesis.tgz genesis.bin rocksdb
+  tar jcvfS genesis.tar.bz2 genesis.bin rocksdb
 )

--- a/net/net.sh
+++ b/net/net.sh
@@ -66,7 +66,7 @@ Operate a configured testnet
                                       - Amount to fund internal nodes in genesis block.
    --external-accounts-file FILE_PATH
                                       - A YML file with a list of account pubkeys and corresponding lamport balances in genesis block for external nodes
-   --no-snapshot
+   --no-snapshot-fetch
                                       - If set, disables booting validators from a snapshot
    --skip-ledger-verify
                                       - If set, validators will skip verifying
@@ -139,7 +139,7 @@ while [[ -n $1 ]]; do
     elif [[ $1 = --lamports ]]; then
       genesisOptions="$genesisOptions $1 $2"
       shift 2
-    elif [[ $1 = --no-snapshot ]]; then
+    elif [[ $1 = --no-snapshot-fetch ]]; then
       maybeNoSnapshot="$1"
       shift 1
     elif [[ $1 = --no-deploy ]]; then

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -9,8 +9,10 @@ license = "Apache-2.0"
 homepage = "https://solana.com/"
 
 [dependencies]
+bzip2 = "0.3.3"
 clap = "2.33.0"
 log = "0.4.8"
+reqwest = "0.9.19"
 serde_json = "1.0.40"
 solana = { path = "../core", version = "0.18.0-pre1" }
 solana-drone = { path = "../drone", version = "0.18.0-pre1" }
@@ -21,6 +23,8 @@ solana-runtime = { path = "../runtime", version = "0.18.0-pre1" }
 solana-sdk = { path = "../sdk", version = "0.18.0-pre1" }
 solana-vote-api = { path = "../programs/vote_api", version = "0.18.0-pre1" }
 solana-vote-signer = { path = "../vote-signer", version = "0.18.0-pre1" }
+tempfile = "3.1.0"
+tar = "0.4.26"
 
 [features]
 cuda = ["solana/cuda"]


### PR DESCRIPTION
`solana-validator` is now fully usable stand-alone without the `validator.sh` crutch
