### PR TITLE
Add datacenter node setup scripts

### DIFF
--- a/net/datacenter-node-install/README.md
+++ b/net/datacenter-node-install/README.md
@@ -1,0 +1,11 @@
+# Introduction
+
+These scripts are intended to facilitate the preparation of dedicated Solana
+nodes.  They have been tested as working from a clean installation of Ubuntu
+18.04 Server.  Use elsewhere is unsupported.
+
+# Installation
+
+1) `sudo ./setup-dc-node-1.sh`
+2) `sudo reboot`
+3) `sudo ./setup-dc-node-2.sh`

--- a/net/datacenter-node-install/disable-networkd-wait.sh
+++ b/net/datacenter-node-install/disable-networkd-wait.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+if [[ "$EUID" -ne 0 ]]; then
+  echo "Please run as root"
+  exit 1
+fi
+
+set -xe
+
+systemctl disable systemd-networkd-wait-online.service
+systemctl mask systemd-networkd-wait-online.service

--- a/net/datacenter-node-install/disable-networkd-wait.sh
+++ b/net/datacenter-node-install/disable-networkd-wait.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 
-if [[ "$EUID" -ne 0 ]]; then
-  echo "Please run as root"
-  exit 1
-fi
+HERE="$(dirname "$0")"
+
+source "$HERE"/utils.sh
+
+ensure_env || exit 1
 
 set -xe
 

--- a/net/datacenter-node-install/disable-networkd-wait.sh
+++ b/net/datacenter-node-install/disable-networkd-wait.sh
@@ -2,6 +2,7 @@
 
 HERE="$(dirname "$0")"
 
+# shellcheck source=utils.sh
 source "$HERE"/utils.sh
 
 ensure_env || exit 1

--- a/net/datacenter-node-install/disable-networkd-wait.sh
+++ b/net/datacenter-node-install/disable-networkd-wait.sh
@@ -2,7 +2,7 @@
 
 HERE="$(dirname "$0")"
 
-# shellcheck source=utils.sh
+# shellcheck source=net/datacenter-node-install/utils.sh
 source "$HERE"/utils.sh
 
 ensure_env || exit 1

--- a/net/datacenter-node-install/disable-nouveau.sh
+++ b/net/datacenter-node-install/disable-nouveau.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+cat <<EOF > /etc/modprobe.d/blacklist-nouveau.conf
+blacklist nouveau
+options nouveau modeset=0
+EOF
+
+update-initramfs -u

--- a/net/datacenter-node-install/disable-nouveau.sh
+++ b/net/datacenter-node-install/disable-nouveau.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+HERE="$(dirname "$0")"
+
+source "$HERE"/utils.sh
+
+ensure_env || exit 1
+
 cat <<EOF > /etc/modprobe.d/blacklist-nouveau.conf
 blacklist nouveau
 options nouveau modeset=0

--- a/net/datacenter-node-install/disable-nouveau.sh
+++ b/net/datacenter-node-install/disable-nouveau.sh
@@ -2,6 +2,7 @@
 
 HERE="$(dirname "$0")"
 
+# shellcheck source=utils.sh
 source "$HERE"/utils.sh
 
 ensure_env || exit 1

--- a/net/datacenter-node-install/disable-nouveau.sh
+++ b/net/datacenter-node-install/disable-nouveau.sh
@@ -2,7 +2,7 @@
 
 HERE="$(dirname "$0")"
 
-# shellcheck source=utils.sh
+# shellcheck source=net/datacenter-node-install/utils.sh
 source "$HERE"/utils.sh
 
 ensure_env || exit 1

--- a/net/datacenter-node-install/set-hostname.sh
+++ b/net/datacenter-node-install/set-hostname.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 
-if [[ "$EUID" -ne 0 ]]; then
-  echo "Please run as root"
-  exit 1
-fi
+HERE="$(dirname "$0")"
+
+source "$HERE"/utils.sh
+
+ensure_env || exit 1
 
 set -xe
 

--- a/net/datacenter-node-install/set-hostname.sh
+++ b/net/datacenter-node-install/set-hostname.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+if [[ "$EUID" -ne 0 ]]; then
+  echo "Please run as root"
+  exit 1
+fi
+
+set -xe
+
+echo "preserve_hostname: false" > /etc/cloud/cloud.cfg.d/99-disable-preserve-hostname.cfg
+systemctl restart cloud-init
+hostnamectl set-hostname "$1"

--- a/net/datacenter-node-install/set-hostname.sh
+++ b/net/datacenter-node-install/set-hostname.sh
@@ -2,6 +2,7 @@
 
 HERE="$(dirname "$0")"
 
+# shellcheck source=utils.sh
 source "$HERE"/utils.sh
 
 ensure_env || exit 1

--- a/net/datacenter-node-install/set-hostname.sh
+++ b/net/datacenter-node-install/set-hostname.sh
@@ -2,7 +2,7 @@
 
 HERE="$(dirname "$0")"
 
-# shellcheck source=utils.sh
+# shellcheck source=net/datacenter-node-install/utils.sh
 source "$HERE"/utils.sh
 
 ensure_env || exit 1

--- a/net/datacenter-node-install/setup-cuda.sh
+++ b/net/datacenter-node-install/setup-cuda.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 
-if [[ "$EUID" -ne 0 ]]; then
-  echo "Please run as root"
-  exit 1
-fi
+HERE="$(dirname "$0")"
+
+source "$HERE"/utils.sh
+
+ensure_env || exit 1
 
 set -xe
 

--- a/net/datacenter-node-install/setup-cuda.sh
+++ b/net/datacenter-node-install/setup-cuda.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+if [[ "$EUID" -ne 0 ]]; then
+  echo "Please run as root"
+  exit 1
+fi
+
+set -xe
+
+apt update
+apt install -y gcc make dkms
+
+sh cuda_10.0.130_410.48_linux.run --silent --driver --toolkit
+sh cuda_10.1.168_418.67_linux.run --silent --driver --toolkit

--- a/net/datacenter-node-install/setup-cuda.sh
+++ b/net/datacenter-node-install/setup-cuda.sh
@@ -2,6 +2,7 @@
 
 HERE="$(dirname "$0")"
 
+# shellcheck source=utils.sh
 source "$HERE"/utils.sh
 
 ensure_env || exit 1

--- a/net/datacenter-node-install/setup-cuda.sh
+++ b/net/datacenter-node-install/setup-cuda.sh
@@ -2,7 +2,7 @@
 
 HERE="$(dirname "$0")"
 
-# shellcheck source=utils.sh
+# shellcheck source=net/datacenter-node-install/utils.sh
 source "$HERE"/utils.sh
 
 ensure_env || exit 1

--- a/net/datacenter-node-install/setup-dc-node-1.sh
+++ b/net/datacenter-node-install/setup-dc-node-1.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+
+if [[ "$EUID" -ne 0 ]]; then
+  echo "Please run as root"
+  exit 1
+fi
+
+if [[ -n "$1" ]]; then
+  PUBKEY_FILE="$1"
+else
+  cat <<EOF
+Usage: $0 [pubkey_file]
+
+The pubkey_file should be the pubkey that will eb set up to allow the current user
+(assumed to be the machine admin) to log in via ssh
+EOF
+  exit 1
+fi
+
+USERNAME="$(whoami)"
+
+set -xe
+
+apt update
+apt upgrade -y
+apt install -y build-essential pkg-config clang
+
+../scripts/install-docker.sh
+
+usermod -aG docker USERNAME
+
+../scripts/install-certbot.sh
+
+./setup-sudoers.sh
+
+./setup-ssh.sh
+
+# Allow admin user to log in
+mkdir .ssh
+chown "$USERNAME:$USERNAME" .ssh
+cat "$PUBKEY_FILE" > .ssh/authorized_keys
+chown "$USERNAME:$USERNAME" .ssh/authorized_keys
+
+./disable-nouveau.sh
+
+./disable-networkd-wait.sh
+
+./setup-grub.sh
+
+../scripts/install-earlyoom.sh
+
+../scripts/install-nodeljs.sh
+
+../scripts/localtime.sh
+
+../scripts/install-redis.sh
+
+../scripts/install-rsync.sh
+
+../scripts/install-libssl-compatability.sh
+
+# Setup kernel constants
+cat > /etc/sysctl.d/20-solana-node.conf <<EOF
+
+# Solana networking requirements
+net.core.rmem_default=1610612736
+net.core.rmem_max=1610612736
+net.core.wmem_default=1610612736
+net.core.wmem_max=1610612736
+
+# Solana earlyoom setup
+kernel.sysrq=$(( $(cat /proc/sys/kernel/sysrq) | 64 ))
+EOF
+
+# Allow more files to be opened by a user
+sed -i 's/^\(# End of file\)/* soft nofile 65535\n\n\1/' /etc/security/limits.conf
+
+echo "Please reboot then run setup-dc-node-2.sh"

--- a/net/datacenter-node-install/setup-dc-node-1.sh
+++ b/net/datacenter-node-install/setup-dc-node-1.sh
@@ -28,7 +28,7 @@ apt install -y build-essential pkg-config clang
 
 "$HERE"/../scripts/install-docker.sh
 
-usermod -aG docker USERNAME
+usermod -aG docker "$USERNAME"
 
 "$HERE"/../scripts/install-certbot.sh
 

--- a/net/datacenter-node-install/setup-dc-node-1.sh
+++ b/net/datacenter-node-install/setup-dc-node-1.sh
@@ -11,7 +11,7 @@ else
   cat <<EOF
 Usage: $0 [pubkey_file]
 
-The pubkey_file should be the pubkey that will eb set up to allow the current user
+The pubkey_file should be the pubkey that will be set up to allow the current user
 (assumed to be the machine admin) to log in via ssh
 EOF
   exit 1

--- a/net/datacenter-node-install/setup-dc-node-1.sh
+++ b/net/datacenter-node-install/setup-dc-node-1.sh
@@ -1,9 +1,12 @@
 #!/usr/bin/env bash
 
-if [[ "$EUID" -ne 0 ]]; then
-  echo "Please run as root"
-  exit 1
-fi
+HERE="$(dirname "$0")"
+
+source "$HERE"/utils.sh
+
+ensure_env || exit 1
+
+exit
 
 if [[ -n "$1" ]]; then
   PUBKEY_FILE="$1"
@@ -17,9 +20,6 @@ EOF
   exit 1
 fi
 
-USERNAME="$(whoami)"
-HERE="$(dirname "$0")"
-
 set -xe
 
 apt update
@@ -27,17 +27,17 @@ apt upgrade -y
 apt install -y build-essential pkg-config clang
 
 "$HERE"/../scripts/install-docker.sh
-usermod -aG docker "$USERNAME"
+usermod -aG docker "$SETUP_USER"
 "$HERE"/../scripts/install-certbot.sh
 "$HERE"/setup-sudoers.sh
 "$HERE"/setup-ssh.sh
 
 # Allow admin user to log in
-BASE_SSH_DIR="${HOME}/.ssh"
+BASE_SSH_DIR="${SETUP_HOME}/.ssh"
 mkdir "$BASE_SSH_DIR"
-chown "$USERNAME:$USERNAME" "$BASE_SSH_DIR"
+chown "$SETUP_USER:$SETUP_USER" "$BASE_SSH_DIR"
 cat "$PUBKEY_FILE" > "${BASE_SSH_DIR}/authorized_keys"
-chown "$USERNAME:$USERNAME" "${BASE_SSH_DIR}/.ssh/authorized_keys"
+chown "$SETUP_USER:$SETUP_USER" "${BASE_SSH_DIR}/.ssh/authorized_keys"
 
 "$HERE"/disable-nouveau.sh
 "$HERE"/disable-networkd-wait.sh

--- a/net/datacenter-node-install/setup-dc-node-1.sh
+++ b/net/datacenter-node-install/setup-dc-node-1.sh
@@ -18,6 +18,7 @@ EOF
 fi
 
 USERNAME="$(whoami)"
+HERE="$(dirname "$0")"
 
 set -xe
 
@@ -25,39 +26,40 @@ apt update
 apt upgrade -y
 apt install -y build-essential pkg-config clang
 
-../scripts/install-docker.sh
+"$HERE"/../scripts/install-docker.sh
 
 usermod -aG docker USERNAME
 
-../scripts/install-certbot.sh
+"$HERE"/../scripts/install-certbot.sh
 
-./setup-sudoers.sh
+"$HERE"/setup-sudoers.sh
 
-./setup-ssh.sh
+"$HERE"/setup-ssh.sh
 
 # Allow admin user to log in
-mkdir .ssh
-chown "$USERNAME:$USERNAME" .ssh
-cat "$PUBKEY_FILE" > .ssh/authorized_keys
-chown "$USERNAME:$USERNAME" .ssh/authorized_keys
+BASE_SSH_DIR="${HOME}/.ssh"
+mkdir "$BASE_SSH_DIR"
+chown "$USERNAME:$USERNAME" "$BASE_SSH_DIR"
+cat "$PUBKEY_FILE" > "${BASE_SSH_DIR}/authorized_keys"
+chown "$USERNAME:$USERNAME" "${BASE_SSH_DIR}/.ssh/authorized_keys"
 
-./disable-nouveau.sh
+"$HERE"/disable-nouveau.sh
 
-./disable-networkd-wait.sh
+"$HERE"/disable-networkd-wait.sh
 
-./setup-grub.sh
+"$HERE"/setup-grub.sh
 
-../scripts/install-earlyoom.sh
+"$HERE"/../scripts/install-earlyoom.sh
 
-../scripts/install-nodeljs.sh
+"$HERE"/../scripts/install-nodeljs.sh
 
-../scripts/localtime.sh
+"$HERE"/../scripts/localtime.sh
 
-../scripts/install-redis.sh
+"$HERE"/../scripts/install-redis.sh
 
-../scripts/install-rsync.sh
+"$HERE"/../scripts/install-rsync.sh
 
-../scripts/install-libssl-compatability.sh
+"$HERE"/../scripts/install-libssl-compatability.sh
 
 # Setup kernel constants
 cat > /etc/sysctl.d/20-solana-node.conf <<EOF

--- a/net/datacenter-node-install/setup-dc-node-1.sh
+++ b/net/datacenter-node-install/setup-dc-node-1.sh
@@ -2,6 +2,7 @@
 
 HERE="$(dirname "$0")"
 
+# shellcheck source=utils.sh
 source "$HERE"/utils.sh
 
 ensure_env || exit 1

--- a/net/datacenter-node-install/setup-dc-node-1.sh
+++ b/net/datacenter-node-install/setup-dc-node-1.sh
@@ -2,7 +2,7 @@
 
 HERE="$(dirname "$0")"
 
-# shellcheck source=utils.sh
+# shellcheck source=net/datacenter-node-install/utils.sh
 source "$HERE"/utils.sh
 
 ensure_env || exit 1

--- a/net/datacenter-node-install/setup-dc-node-1.sh
+++ b/net/datacenter-node-install/setup-dc-node-1.sh
@@ -27,13 +27,9 @@ apt upgrade -y
 apt install -y build-essential pkg-config clang
 
 "$HERE"/../scripts/install-docker.sh
-
 usermod -aG docker "$USERNAME"
-
 "$HERE"/../scripts/install-certbot.sh
-
 "$HERE"/setup-sudoers.sh
-
 "$HERE"/setup-ssh.sh
 
 # Allow admin user to log in
@@ -44,21 +40,13 @@ cat "$PUBKEY_FILE" > "${BASE_SSH_DIR}/authorized_keys"
 chown "$USERNAME:$USERNAME" "${BASE_SSH_DIR}/.ssh/authorized_keys"
 
 "$HERE"/disable-nouveau.sh
-
 "$HERE"/disable-networkd-wait.sh
-
 "$HERE"/setup-grub.sh
-
 "$HERE"/../scripts/install-earlyoom.sh
-
 "$HERE"/../scripts/install-nodeljs.sh
-
 "$HERE"/../scripts/localtime.sh
-
 "$HERE"/../scripts/install-redis.sh
-
 "$HERE"/../scripts/install-rsync.sh
-
 "$HERE"/../scripts/install-libssl-compatability.sh
 
 # Setup kernel constants

--- a/net/datacenter-node-install/setup-dc-node-2.sh
+++ b/net/datacenter-node-install/setup-dc-node-2.sh
@@ -13,5 +13,5 @@ set -xe
 
 # setup persistence mode across reboots
 tar -xvf /usr/share/doc/NVIDIA_GLX-1.0/sample/nvidia-persistenced-init.tar.bz2
-sudo "$HERE"/nvidia-persistenced-init/install.sh systemd
+"$HERE"/nvidia-persistenced-init/install.sh systemd
 rm -r nvidia-persistenced-init

--- a/net/datacenter-node-install/setup-dc-node-2.sh
+++ b/net/datacenter-node-install/setup-dc-node-2.sh
@@ -5,11 +5,13 @@ if [[ "$EUID" -ne 0 ]]; then
   exit 1
 fi
 
+HERE="$(dirname "$0")"
+
 set -xe
 
-./setup-cuda.sh
+"$HERE"/setup-cuda.sh
 
 # setup persistence mode across reboots
 tar -xvf /usr/share/doc/NVIDIA_GLX-1.0/sample/nvidia-persistenced-init.tar.bz2
-sudo ./nvidia-persistenced-init/install.sh systemd
+sudo "$HERE"/nvidia-persistenced-init/install.sh systemd
 rm -r nvidia-persistenced-init

--- a/net/datacenter-node-install/setup-dc-node-2.sh
+++ b/net/datacenter-node-install/setup-dc-node-2.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+if [[ "$EUID" -ne 0 ]]; then
+  echo "Please run as root"
+  exit 1
+fi
+
+set -xe
+
+./setup-cuda.sh
+
+# setup persistence mode across reboots
+tar -xvf /usr/share/doc/NVIDIA_GLX-1.0/sample/nvidia-persistenced-init.tar.bz2
+sudo ./nvidia-persistenced-init/install.sh systemd
+rm -r nvidia-persistenced-init

--- a/net/datacenter-node-install/setup-dc-node-2.sh
+++ b/net/datacenter-node-install/setup-dc-node-2.sh
@@ -1,11 +1,10 @@
 #!/usr/bin/env bash
 
-if [[ "$EUID" -ne 0 ]]; then
-  echo "Please run as root"
-  exit 1
-fi
-
 HERE="$(dirname "$0")"
+
+source "$HERE"/utils.sh
+
+ensure_env || exit 1
 
 set -xe
 

--- a/net/datacenter-node-install/setup-dc-node-2.sh
+++ b/net/datacenter-node-install/setup-dc-node-2.sh
@@ -12,6 +12,11 @@ set -xe
 "$HERE"/setup-cuda.sh
 
 # setup persistence mode across reboots
-tar -xvf /usr/share/doc/NVIDIA_GLX-1.0/sample/nvidia-persistenced-init.tar.bz2
-"$HERE"/nvidia-persistenced-init/install.sh systemd
-rm -r nvidia-persistenced-init
+TMPDIR="$(mktemp)"
+mkdir -p "$TMPDIR"
+if pushd "$TMPDIR"; then
+  tar -xvf /usr/share/doc/NVIDIA_GLX-1.0/sample/nvidia-persistenced-init.tar.bz2
+  ./nvidia-persistenced-init/install.sh systemd
+  popd
+  rm -rf "$TMPDIR"
+fi

--- a/net/datacenter-node-install/setup-dc-node-2.sh
+++ b/net/datacenter-node-install/setup-dc-node-2.sh
@@ -2,6 +2,7 @@
 
 HERE="$(dirname "$0")"
 
+# shellcheck source=utils.sh
 source "$HERE"/utils.sh
 
 ensure_env || exit 1

--- a/net/datacenter-node-install/setup-dc-node-2.sh
+++ b/net/datacenter-node-install/setup-dc-node-2.sh
@@ -2,7 +2,7 @@
 
 HERE="$(dirname "$0")"
 
-# shellcheck source=utils.sh
+# shellcheck source=net/datacenter-node-install/utils.sh
 source "$HERE"/utils.sh
 
 ensure_env || exit 1

--- a/net/datacenter-node-install/setup-grub.sh
+++ b/net/datacenter-node-install/setup-grub.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 
-if [[ "$EUID" -ne 0 ]]; then
-  echo "Please run as root"
-  exit 1
-fi
+HERE="$(dirname "$0")"
+
+source "$HERE"/utils.sh
+
+ensure_env || exit 1
 
 set -xe
 

--- a/net/datacenter-node-install/setup-grub.sh
+++ b/net/datacenter-node-install/setup-grub.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+if [[ "$EUID" -ne 0 ]]; then
+  echo "Please run as root"
+  exit 1
+fi
+
+set -xe
+
+printf "GRUB_GFXPAYLOAD_LINUX=1280x1024x32\n\n" >> /etc/default/grub
+update-grub

--- a/net/datacenter-node-install/setup-grub.sh
+++ b/net/datacenter-node-install/setup-grub.sh
@@ -2,6 +2,7 @@
 
 HERE="$(dirname "$0")"
 
+# shellcheck source=utils.sh
 source "$HERE"/utils.sh
 
 ensure_env || exit 1

--- a/net/datacenter-node-install/setup-grub.sh
+++ b/net/datacenter-node-install/setup-grub.sh
@@ -2,7 +2,7 @@
 
 HERE="$(dirname "$0")"
 
-# shellcheck source=utils.sh
+# shellcheck source=net/datacenter-node-install/utils.sh
 source "$HERE"/utils.sh
 
 ensure_env || exit 1

--- a/net/datacenter-node-install/setup-ssh.sh
+++ b/net/datacenter-node-install/setup-ssh.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+if [[ "$EUID" -ne 0 ]]; then
+  echo "Please run as root"
+  exit 1
+fi
+
+set -xe
+# Setup sshd
+sed -i 's/^PasswordAuthentication yes//' /etc/ssh/sshd_config
+sed -i 's/^#\(PasswordAuthentication\) yes/\1 no/' /etc/ssh/sshd_config
+sed -i 's/^#\(PermitRootLogin\) .*/\1 no/' /etc/ssh/sshd_config
+systemctl restart sshd

--- a/net/datacenter-node-install/setup-ssh.sh
+++ b/net/datacenter-node-install/setup-ssh.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 
-if [[ "$EUID" -ne 0 ]]; then
-  echo "Please run as root"
-  exit 1
-fi
+HERE="$(dirname "$0")"
+
+source "$HERE"/utils.sh
+
+ensure_env || exit 1
 
 set -xe
 # Setup sshd

--- a/net/datacenter-node-install/setup-ssh.sh
+++ b/net/datacenter-node-install/setup-ssh.sh
@@ -2,6 +2,7 @@
 
 HERE="$(dirname "$0")"
 
+# shellcheck source=utils.sh
 source "$HERE"/utils.sh
 
 ensure_env || exit 1

--- a/net/datacenter-node-install/setup-ssh.sh
+++ b/net/datacenter-node-install/setup-ssh.sh
@@ -2,7 +2,7 @@
 
 HERE="$(dirname "$0")"
 
-# shellcheck source=utils.sh
+# shellcheck source=net/datacenter-node-install/utils.sh
 source "$HERE"/utils.sh
 
 ensure_env || exit 1

--- a/net/datacenter-node-install/setup-sudoers.sh
+++ b/net/datacenter-node-install/setup-sudoers.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+if [[ "$EUID" -ne 0 ]]; then
+  echo "Please run as root"
+  exit 1
+fi
+
+set -xe
+
+# Enable passwordless sudo
+EDITOR='tee' visudo <<EOF 
+#
+# This file MUST be edited with the 'visudo' command as root.
+#
+# Please consider adding local content in /etc/sudoers.d/ instead of
+# directly modifying this file.
+#
+# See the man page for details on how to write a sudoers file.
+#
+Defaults	env_reset
+Defaults	mail_badpass
+Defaults	secure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin"
+
+# Host alias specification
+
+# User alias specification
+
+# Cmnd alias specification
+
+# User privilege specification
+root	ALL=(ALL:ALL) ALL
+
+# Members of the admin group may gain root privileges
+%admin ALL=(ALL) ALL
+
+# Allow members of group sudo to execute any command
+%sudo	ALL=(ALL:ALL) ALL
+
+# Allow all members of sudo group to use passwordless sudo
+%sudo	ALL=(ALL) NOPASSWD:ALL
+
+# See sudoers(5) for more information on "#include" directives:
+
+#includedir /etc/sudoers.d
+EOF
+

--- a/net/datacenter-node-install/setup-sudoers.sh
+++ b/net/datacenter-node-install/setup-sudoers.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 
-if [[ "$EUID" -ne 0 ]]; then
-  echo "Please run as root"
-  exit 1
-fi
+HERE="$(dirname "$0")"
+
+source "$HERE"/utils.sh
+
+ensure_env || exit 1
 
 set -xe
 

--- a/net/datacenter-node-install/setup-sudoers.sh
+++ b/net/datacenter-node-install/setup-sudoers.sh
@@ -2,6 +2,7 @@
 
 HERE="$(dirname "$0")"
 
+# shellcheck source=utils.sh
 source "$HERE"/utils.sh
 
 ensure_env || exit 1

--- a/net/datacenter-node-install/setup-sudoers.sh
+++ b/net/datacenter-node-install/setup-sudoers.sh
@@ -2,7 +2,7 @@
 
 HERE="$(dirname "$0")"
 
-# shellcheck source=utils.sh
+# shellcheck source=net/datacenter-node-install/utils.sh
 source "$HERE"/utils.sh
 
 ensure_env || exit 1

--- a/net/datacenter-node-install/setup-validator.sh
+++ b/net/datacenter-node-install/setup-validator.sh
@@ -5,13 +5,15 @@ if [[ "$EUID" -ne 0 ]]; then
   exit 1
 fi
 
+HERE="$(dirname "$0")"
+
 set -xe
 
-./disable-networkd-wait.sh
+"$HERE"/disable-networkd-wait.sh
 
-./setup-grub.sh
+"$HERE"/setup-grub.sh
 
-./setup-cuda.sh
+"$HERE"/setup-cuda.sh
 
 PASSWORD="$(dd if=/dev/urandom bs=1 count=9 status=none | base64)"
 echo "$PASSWORD"

--- a/net/datacenter-node-install/setup-validator.sh
+++ b/net/datacenter-node-install/setup-validator.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+if [[ "$EUID" -ne 0 ]]; then
+  echo "Please run as root"
+  exit 1
+fi
+
+set -xe
+
+./disable-networkd-wait.sh
+
+./setup-grub.sh
+
+./setup-cuda.sh
+
+PASSWORD="$(dd if=/dev/urandom bs=1 count=9 status=none | base64)"
+echo "$PASSWORD"
+chpasswd <<< "solana:$PASSWORD"
+

--- a/net/datacenter-node-install/setup-validator.sh
+++ b/net/datacenter-node-install/setup-validator.sh
@@ -1,11 +1,10 @@
 #!/usr/bin/env bash
 
-if [[ "$EUID" -ne 0 ]]; then
-  echo "Please run as root"
-  exit 1
-fi
-
 HERE="$(dirname "$0")"
+
+source "$HERE"/utils.sh
+
+ensure_env || exit 1
 
 set -xe
 

--- a/net/datacenter-node-install/setup-validator.sh
+++ b/net/datacenter-node-install/setup-validator.sh
@@ -2,6 +2,7 @@
 
 HERE="$(dirname "$0")"
 
+# shellcheck source=utils.sh
 source "$HERE"/utils.sh
 
 ensure_env || exit 1

--- a/net/datacenter-node-install/setup-validator.sh
+++ b/net/datacenter-node-install/setup-validator.sh
@@ -2,7 +2,7 @@
 
 HERE="$(dirname "$0")"
 
-# shellcheck source=utils.sh
+# shellcheck source=net/datacenter-node-install/utils.sh
 source "$HERE"/utils.sh
 
 ensure_env || exit 1

--- a/net/datacenter-node-install/utils.sh
+++ b/net/datacenter-node-install/utils.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+# We need root access, but also appropriate envvar values. Require scripts to
+# run with sudo as a normal user
+ensure_env() {
+  RC=false
+  [ $EUID -eq 0 ] && [ -n "$SUDO_USER" ] && [ "$SUDO_USER" != "root" ] && RC=true
+  if $RC; then
+    SETUP_USER="$SUDO_USER"
+    SETUP_HOME="$HOME"
+  else
+    echo "Please run \"$0\" via sudo as a normal user"
+  fi
+  $RC
+}
+

--- a/net/datacenter-node-install/utils.sh
+++ b/net/datacenter-node-install/utils.sh
@@ -6,8 +6,8 @@ ensure_env() {
   RC=false
   [ $EUID -eq 0 ] && [ -n "$SUDO_USER" ] && [ "$SUDO_USER" != "root" ] && RC=true
   if $RC; then
-    SETUP_USER="$SUDO_USER"
-    SETUP_HOME="$HOME"
+    export SETUP_USER="$SUDO_USER"
+    export SETUP_HOME="$HOME"
   else
     echo "Please run \"$0\" via sudo as a normal user"
   fi


### PR DESCRIPTION
#### Problem

We need to consistently setup new nodes for the datacenter

#### Summary of Changes

Add bash scripts that do all the setup for us. Also add helper scripts that do parts of the setup if something breaks.
