### PR TITLE
Snapshot optimizations

### DIFF
--- a/core/src/snapshot_package.rs
+++ b/core/src/snapshot_package.rs
@@ -119,7 +119,11 @@ impl SnapshotPackagerService {
     }
 
     fn run(snapshot_receiver: &SnapshotPackageReceiver) -> Result<()> {
-        let snapshot_package = snapshot_receiver.recv_timeout(Duration::from_secs(1))?;
+        let mut snapshot_package = snapshot_receiver.recv_timeout(Duration::from_secs(1))?;
+        // Only package the latest
+        while let Ok(new_snapshot_package) = snapshot_receiver.recv() {
+            snapshot_package = new_snapshot_package;
+        }
         Self::package_snapshots(&snapshot_package)?;
         Ok(())
     }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -45,7 +45,7 @@ use solana_sdk::{
     timing::{duration_as_ns, get_segment_from_slot, Epoch, Slot, MAX_RECENT_BLOCKHASHES},
     transaction::{Result, Transaction, TransactionError},
 };
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::io::{BufReader, Cursor, Error as IOError, Read};
 use std::path::Path;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
@@ -124,13 +124,17 @@ impl Serialize for BankRc {
 pub struct StatusCacheRc {
     /// where all the Accounts are stored
     /// A cache of signature statuses
-    status_cache: Arc<RwLock<BankStatusCache>>,
+    pub status_cache: Arc<RwLock<BankStatusCache>>,
 }
 
 impl StatusCacheRc {
     pub fn slot_deltas(&self, slots: &[Slot]) -> Vec<SlotDelta<Result<()>>> {
         let sc = self.status_cache.read().unwrap();
         sc.slot_deltas(slots)
+    }
+
+    pub fn roots(&self) -> HashSet<u64> {
+        self.status_cache.read().unwrap().roots().clone()
     }
 
     pub fn append(&self, slot_deltas: &[SlotDelta<Result<()>>]) {

--- a/runtime/src/status_cache.rs
+++ b/runtime/src/status_cache.rs
@@ -124,6 +124,10 @@ impl<T: Serialize + Clone> StatusCache<T> {
         self.purge_roots();
     }
 
+    pub fn roots(&self) -> &HashSet<u64> {
+        &self.roots
+    }
+
     /// Insert a new signature for a specific slot.
     pub fn insert(&mut self, transaction_blockhash: &Hash, sig: &Signature, slot: Slot, res: T) {
         let sig_index: usize;


### PR DESCRIPTION
#### Problem
1) SnapshotPackagerService attempts to package every SnapshotPackage it receives when it only needs to package the latest one

2) BankForks.slots_since_snapshots() only needs to track latest MAX_CACHE_ENTRIES rooted slots to be in sync with the status cache

#### Summary of Changes
1) Address above
2) Refactor tests

Fixes #
