### PR TITLE
System program is now registered like all other native programs

### DIFF
--- a/genesis_programs/src/lib.rs
+++ b/genesis_programs/src/lib.rs
@@ -1,4 +1,5 @@
 use solana_sdk::pubkey::Pubkey;
+use solana_sdk::system_program::solana_system_program;
 
 #[macro_use]
 extern crate solana_bpf_loader_program;
@@ -21,6 +22,7 @@ extern crate solana_vote_program;
 
 pub fn get() -> Vec<(String, Pubkey)> {
     vec![
+        solana_system_program(),
         solana_bpf_loader_program!(),
         solana_budget_program!(),
         solana_config_program!(),

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -613,12 +613,6 @@ impl Bank {
 
         self.inflation = genesis_block.inflation.clone();
 
-        // Add native programs mandatory for the MessageProcessor to function
-        self.register_native_instruction_processor(
-            "solana_system_program",
-            &solana_sdk::system_program::id(),
-        );
-
         // Add additional native programs specified in the genesis block
         for (name, program_id) in &genesis_block.native_instruction_processors {
             self.register_native_instruction_processor(name, program_id);

--- a/runtime/src/genesis_utils.rs
+++ b/runtime/src/genesis_utils.rs
@@ -4,7 +4,7 @@ use solana_sdk::{
     genesis_block::{Builder, GenesisBlock},
     pubkey::Pubkey,
     signature::{Keypair, KeypairUtil},
-    system_program,
+    system_program::{self, solana_system_program},
 };
 use solana_stake_api;
 use solana_vote_api::vote_state;
@@ -68,6 +68,7 @@ pub fn create_genesis_block_with_leader(
         ])
         // Bare minimum program set
         .native_instruction_processors(&[
+            solana_system_program(),
             solana_bpf_loader_program!(),
             solana_vote_program!(),
             solana_stake_program!(),

--- a/sdk/src/genesis_block.rs
+++ b/sdk/src/genesis_block.rs
@@ -8,7 +8,7 @@ use crate::poh_config::PohConfig;
 use crate::pubkey::Pubkey;
 use crate::rent::Rent;
 use crate::signature::{Keypair, KeypairUtil};
-use crate::system_program;
+use crate::system_program::{self, solana_system_program};
 use crate::timing::{DEFAULT_SLOTS_PER_EPOCH, DEFAULT_SLOTS_PER_SEGMENT, DEFAULT_TICKS_PER_SLOT};
 use bincode::{deserialize, serialize};
 use memmap::Mmap;
@@ -41,7 +41,7 @@ pub fn create_genesis_block(lamports: u64) -> (GenesisBlock, Keypair) {
                 mint_keypair.pubkey(),
                 Account::new(lamports, 0, &system_program::id()),
             )],
-            &[],
+            &[solana_system_program()],
         ),
         mint_keypair,
     )

--- a/sdk/src/system_program.rs
+++ b/sdk/src/system_program.rs
@@ -3,3 +3,7 @@ const ID: [u8; 32] = [
 ];
 
 crate::solana_name_id!(ID, "11111111111111111111111111111111");
+
+pub fn solana_system_program() -> (String, crate::pubkey::Pubkey) {
+    ("solana_system_program".to_string(), id())
+}


### PR DESCRIPTION
With the system program registration hard coded in the bank it's not possible to boot a cluster without the system program present.   Now `solana-genesis` controls the presence of the system program, like all other native programs, which opens the door to adding a new facility to disable the system program (for a later PR)