### PR TITLE
Fix Rust 1.37.0 compiler warnings

### DIFF
--- a/bench-exchange/src/bench.rs
+++ b/bench-exchange/src/bench.rs
@@ -660,7 +660,7 @@ fn verify_funding_transfer<T: SyncClient + ?Sized>(
     false
 }
 
-pub fn fund_keys(client: &Client, source: &Keypair, dests: &[Arc<Keypair>], lamports: u64) {
+pub fn fund_keys(client: &dyn Client, source: &Keypair, dests: &[Arc<Keypair>], lamports: u64) {
     let total = lamports * (dests.len() as u64 + 1);
     let mut funded: Vec<(&Keypair, u64)> = vec![(source, total)];
     let mut notfunded: Vec<&Arc<Keypair>> = dests.iter().collect();
@@ -778,7 +778,7 @@ pub fn fund_keys(client: &Client, source: &Keypair, dests: &[Arc<Keypair>], lamp
     }
 }
 
-pub fn create_token_accounts(client: &Client, signers: &[Arc<Keypair>], accounts: &[Pubkey]) {
+pub fn create_token_accounts(client: &dyn Client, signers: &[Arc<Keypair>], accounts: &[Pubkey]) {
     let mut notfunded: Vec<(&Arc<Keypair>, &Pubkey)> = signers.iter().zip(accounts).collect();
 
     while !notfunded.is_empty() {
@@ -908,7 +908,7 @@ fn generate_keypairs(num: u64) -> Vec<Keypair> {
     rnd.gen_n_keypairs(num)
 }
 
-pub fn airdrop_lamports(client: &Client, drone_addr: &SocketAddr, id: &Keypair, amount: u64) {
+pub fn airdrop_lamports(client: &dyn Client, drone_addr: &SocketAddr, id: &Keypair, amount: u64) {
     let balance = client.get_balance(&id.pubkey());
     let balance = balance.unwrap_or(0);
     if balance >= amount {

--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -20,7 +20,7 @@ use std::thread::sleep;
 use std::time::{Duration, Instant};
 
 pub struct RpcClient {
-    client: Box<GenericRpcClientRequest + Send + Sync>,
+    client: Box<dyn GenericRpcClientRequest + Send + Sync>,
 }
 
 impl RpcClient {

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -1294,7 +1294,12 @@ mod tests {
             ];
 
             let mut results = vec![Ok(()), Ok(())];
-            BankingStage::record_transactions(bank.slot(), &transactions, &results, &poh_recorder);
+            let _ = BankingStage::record_transactions(
+                bank.slot(),
+                &transactions,
+                &results,
+                &poh_recorder,
+            );
             let (_, entries) = entry_receiver.recv().unwrap();
             assert_eq!(entries[0].0.transactions.len(), transactions.len());
 

--- a/drone/src/bin/drone.rs
+++ b/drone/src/bin/drone.rs
@@ -7,7 +7,7 @@ use std::net::{Ipv4Addr, SocketAddr};
 use std::sync::{Arc, Mutex};
 use std::thread;
 
-fn main() -> Result<(), Box<error::Error>> {
+fn main() -> Result<(), Box<dyn error::Error>> {
     solana_logger::setup_with_filter("solana=info");
     solana_metrics::set_panic_hook("drone");
     let matches = App::new(crate_name!())

--- a/install/src/update_manifest.rs
+++ b/install/src/update_manifest.rs
@@ -40,7 +40,10 @@ impl Signable for SignedUpdateManifest {
 }
 
 impl SignedUpdateManifest {
-    pub fn deserialize(account_pubkey: &Pubkey, input: &[u8]) -> Result<Self, Box<error::Error>> {
+    pub fn deserialize(
+        account_pubkey: &Pubkey,
+        input: &[u8],
+    ) -> Result<Self, Box<dyn error::Error>> {
         let mut manifest: SignedUpdateManifest = bincode::deserialize(input)?;
         manifest.account_pubkey = *account_pubkey;
         if !manifest.verify() {

--- a/kvstore/src/lib.rs
+++ b/kvstore/src/lib.rs
@@ -332,7 +332,7 @@ fn load_tables(root: &Path, mapper: &dyn Mapper) -> Result<Vec<BTreeMap<Key, SST
     Ok(tables)
 }
 
-fn dump_tables(root: &Path, mapper: &Mapper) -> Result<()> {
+fn dump_tables(root: &Path, mapper: &dyn Mapper) -> Result<()> {
     mapper.serialize_state_to(&root.join(TABLES_FILE))?;
     Ok(())
 }

--- a/kvstore/src/mapper.rs
+++ b/kvstore/src/mapper.rs
@@ -12,7 +12,7 @@ pub use self::disk::Disk;
 pub use self::memory::Memory;
 
 pub trait Mapper: std::fmt::Debug + Send + Sync {
-    fn make_table(&self, kind: Kind, func: &mut FnMut(Writer, Writer)) -> Result<SSTable>;
+    fn make_table(&self, kind: Kind, func: &mut dyn FnMut(Writer, Writer)) -> Result<SSTable>;
     fn rotate_tables(&self) -> Result<()>;
     fn empty_trash(&self) -> Result<()>;
     fn active_set(&self) -> Result<Vec<SSTable>>;

--- a/kvstore/src/mapper/disk.rs
+++ b/kvstore/src/mapper/disk.rs
@@ -78,7 +78,7 @@ impl Disk {
 }
 
 impl Mapper for Disk {
-    fn make_table(&self, kind: Kind, func: &mut FnMut(Writer, Writer)) -> Result<SSTable> {
+    fn make_table(&self, kind: Kind, func: &mut dyn FnMut(Writer, Writer)) -> Result<SSTable> {
         let storage = self.choose_storage();
 
         let id = next_id(kind);

--- a/kvstore/src/mapper/memory.rs
+++ b/kvstore/src/mapper/memory.rs
@@ -51,7 +51,7 @@ impl Memory {
 }
 
 impl Mapper for Memory {
-    fn make_table(&self, kind: Kind, func: &mut FnMut(Writer, Writer)) -> Result<SSTable> {
+    fn make_table(&self, kind: Kind, func: &mut dyn FnMut(Writer, Writer)) -> Result<SSTable> {
         let backing = self.get_backing(kind);
         let id = next_id();
 

--- a/kvstore/src/writelog.rs
+++ b/kvstore/src/writelog.rs
@@ -109,7 +109,7 @@ trait LogWriter: std::fmt::Debug + Write + Send + Sync {
 /// Holds actual logging related state
 #[derive(Debug)]
 struct Logger {
-    writer: Box<LogWriter>,
+    writer: Box<dyn LogWriter>,
 }
 
 impl Logger {

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -247,15 +247,15 @@ fn main() {
                 })
                 .collect();
 
-            let mut output_file: Box<Write> = if let Some(path) = args_matches.value_of("slot_list")
-            {
-                match File::create(path) {
-                    Ok(file) => Box::new(file),
-                    _ => Box::new(stdout()),
-                }
-            } else {
-                Box::new(stdout())
-            };
+            let mut output_file: Box<dyn Write> =
+                if let Some(path) = args_matches.value_of("slot_list") {
+                    match File::create(path) {
+                        Ok(file) => Box::new(file),
+                        _ => Box::new(stdout()),
+                    }
+                } else {
+                    Box::new(stdout())
+                };
 
             slot_hash
                 .into_iter()

--- a/metrics/src/metrics.rs
+++ b/metrics/src/metrics.rs
@@ -236,7 +236,7 @@ impl Default for MetricsAgent {
 
 impl MetricsAgent {
     fn new(
-        writer: Arc<MetricsWriter + Send + Sync>,
+        writer: Arc<dyn MetricsWriter + Send + Sync>,
         write_frequency_secs: Duration,
         max_points_per_sec: usize,
     ) -> Self {
@@ -251,7 +251,7 @@ impl MetricsAgent {
         points: &[Point],
         last_write_time: Instant,
         max_points: usize,
-        writer: &Arc<MetricsWriter + Send + Sync>,
+        writer: &Arc<dyn MetricsWriter + Send + Sync>,
         max_points_per_sec: usize,
     ) -> usize {
         if points.is_empty() {
@@ -296,7 +296,7 @@ impl MetricsAgent {
 
     fn run(
         receiver: &Receiver<MetricsCommand>,
-        writer: &Arc<MetricsWriter + Send + Sync>,
+        writer: &Arc<dyn MetricsWriter + Send + Sync>,
         write_frequency_secs: Duration,
         max_points_per_sec: usize,
     ) {

--- a/vote-signer/src/bin/main.rs
+++ b/vote-signer/src/bin/main.rs
@@ -6,7 +6,7 @@ use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 pub const RPC_PORT: u16 = 8989;
 
-fn main() -> Result<(), Box<error::Error>> {
+fn main() -> Result<(), Box<dyn error::Error>> {
     solana_metrics::set_panic_hook("vote-signer");
 
     let matches = App::new(crate_name!())


### PR DESCRIPTION
#### Problem

The latest Rust compiler emits warnings when you don't explicitly declare you want to introduce the overhead of dynamic dispatch.

#### Summary of Changes

Add `dyn` everyone Rustc recommends.