### PR TITLE
Solana-wallet: Use check_unique_pubkeys helper to prevent DuplicateAccountIndex

### DIFF
--- a/wallet/src/wallet.rs
+++ b/wallet/src/wallet.rs
@@ -563,6 +563,10 @@ fn process_create_vote_account(
         (vote_account_pubkey, "vote_account_pubkey".to_string()),
         (node_pubkey, "node_pubkey".to_string()),
     )?;
+    check_unique_pubkeys(
+        (&config.keypair.pubkey(), "wallet keypair".to_string()),
+        (vote_account_pubkey, "vote_account_pubkey".to_string()),
+    )?;
     let ixs = vote_instruction::create_account(
         &config.keypair.pubkey(),
         vote_account_pubkey,
@@ -734,6 +738,13 @@ fn process_delegate_stake(
     lamports: u64,
     force: bool,
 ) -> ProcessResult {
+    check_unique_pubkeys(
+        (&config.keypair.pubkey(), "wallet keypair".to_string()),
+        (
+            &stake_account_keypair.pubkey(),
+            "stake_account_keypair".to_string(),
+        ),
+    )?;
     let (recent_blockhash, fee_calculator) = rpc_client.get_recent_blockhash()?;
 
     let ixs = stake_instruction::create_stake_account_and_delegate_stake(
@@ -887,6 +898,13 @@ fn process_create_replicator_storage_account(
     account_owner: &Pubkey,
     storage_account_pubkey: &Pubkey,
 ) -> ProcessResult {
+    check_unique_pubkeys(
+        (&config.keypair.pubkey(), "wallet keypair".to_string()),
+        (
+            &storage_account_pubkey,
+            "storage_account_pubkey".to_string(),
+        ),
+    )?;
     let (recent_blockhash, fee_calculator) = rpc_client.get_recent_blockhash()?;
     let ixs = storage_instruction::create_replicator_storage_account(
         &config.keypair.pubkey(),
@@ -907,6 +925,13 @@ fn process_create_validator_storage_account(
     account_owner: &Pubkey,
     storage_account_pubkey: &Pubkey,
 ) -> ProcessResult {
+    check_unique_pubkeys(
+        (&config.keypair.pubkey(), "wallet keypair".to_string()),
+        (
+            &storage_account_pubkey,
+            "storage_account_pubkey".to_string(),
+        ),
+    )?;
     let (recent_blockhash, fee_calculator) = rpc_client.get_recent_blockhash()?;
     let ixs = storage_instruction::create_validator_storage_account(
         &config.keypair.pubkey(),
@@ -1053,6 +1078,10 @@ fn process_pay(
     witnesses: &Option<Vec<Pubkey>>,
     cancelable: Option<Pubkey>,
 ) -> ProcessResult {
+    check_unique_pubkeys(
+        (&config.keypair.pubkey(), "wallet keypair".to_string()),
+        (to, "to".to_string()),
+    )?;
     let (blockhash, fee_calculator) = rpc_client.get_recent_blockhash()?;
 
     if timestamp == None && *witnesses == None {


### PR DESCRIPTION
…errors earlier

#### Problem
The particular: if user flops the pubkeys in `solana-wallet create-vote-account`, they receive an unhelpful error, InstructionError::DuplicateAccountIndex

In general: this error will return anytime a user attempts to reuse the wallet signing keypair as a new account pubkey. The error message solana-wallet receives in not explicit about the keys in question or the instruction, and receiving the error at all requires waiting until the transaction is processed by the cluster.

#### Summary of Changes
Use `check_unique_pubkeys()` to check common mistake cases before submitting transactions to the cluster
This can't determine whether key arguments are flopped specifically, but the print message does indicate which argument is a duplicate

(A more comprehensive solution might be to provide more information to the user about what instructions/transactions are being constructed and systematically test them before submission.)

Fixes #5437 
