### PR TITLE
Change recv to try_recv

### DIFF
--- a/core/src/snapshot_package.rs
+++ b/core/src/snapshot_package.rs
@@ -131,7 +131,7 @@ impl SnapshotPackagerService {
     fn run(snapshot_receiver: &SnapshotPackageReceiver) -> Result<()> {
         let mut snapshot_package = snapshot_receiver.recv_timeout(Duration::from_secs(1))?;
         // Only package the latest
-        while let Ok(new_snapshot_package) = snapshot_receiver.recv() {
+        while let Ok(new_snapshot_package) = snapshot_receiver.try_recv() {
             snapshot_package = new_snapshot_package;
         }
         Self::package_snapshots(&snapshot_package)?;


### PR DESCRIPTION
#### Problem
SnapshotPackagerService will block on recv instead of polling after receiving a snapshot, blocking snapshot creation

#### Summary of Changes
Change recv to try_recv

Fixes #
