### PR TITLE
fix single node testnet, remove bootstrap vote

### DIFF
--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -166,6 +166,7 @@ impl Tower {
     }
 
     pub fn record_vote(&mut self, slot: u64, hash: Hash) -> Option<u64> {
+        trace!("{} record_vote for {}", self.node_pubkey, slot);
         let root_slot = self.lockouts.root_slot;
         let vote = Vote { slot, hash };
         self.lockouts.process_vote_unchecked(&vote);
@@ -344,6 +345,12 @@ impl Tower {
             if let Some((_stake, vote_account)) = bank.vote_accounts().get(vote_account_pubkey) {
                 let vote_state = VoteState::deserialize(&vote_account.data)
                     .expect("vote_account isn't a VoteState?");
+                trace!(
+                    "{} lockouts initialized to {:?}",
+                    self.node_pubkey,
+                    vote_state
+                );
+
                 assert_eq!(
                     vote_state.node_pubkey, self.node_pubkey,
                     "vote account's node_pubkey doesn't match",

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -586,7 +586,7 @@ impl ReplayStage {
             })
             .filter(|b| {
                 let has_voted = tower.has_voted(b.slot());
-                trace!("bank is has_voted: {} {}", b.slot(), has_voted);
+                trace!("bank has_voted: {} {}", b.slot(), has_voted);
                 !has_voted
             })
             .filter(|b| {

--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -245,11 +245,16 @@ fn main() -> Result<(), Box<dyn error::Error>> {
     let bootstrap_storage_keypair = read_keypair(bootstrap_storage_keypair_file)?;
     let mint_keypair = read_keypair(mint_keypair_file)?;
 
-    let (vote_account, vote_state) = vote_state::create_bootstrap_leader_account(
+    let vote_account = vote_state::create_account(
         &bootstrap_vote_keypair.pubkey(),
         &bootstrap_leader_keypair.pubkey(),
         0,
         1,
+    );
+    let stake_account = stake_state::create_account(
+        &bootstrap_vote_keypair.pubkey(),
+        &vote_account,
+        bootstrap_leader_stake_lamports,
     );
 
     let mut builder = Builder::new()
@@ -267,14 +272,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
             // where votes go to
             (bootstrap_vote_keypair.pubkey(), vote_account),
             // passive bootstrap leader stake
-            (
-                bootstrap_stake_keypair.pubkey(),
-                stake_state::create_stake_account(
-                    &bootstrap_vote_keypair.pubkey(),
-                    &vote_state,
-                    bootstrap_leader_stake_lamports,
-                ),
-            ),
+            (bootstrap_stake_keypair.pubkey(), stake_account),
             (
                 bootstrap_storage_keypair.pubkey(),
                 storage_contract::create_validator_storage_account(

--- a/programs/stake_api/src/stake_state.rs
+++ b/programs/stake_api/src/stake_state.rs
@@ -411,18 +411,16 @@ where
 }
 
 // utility function, used by Bank, tests, genesis
-pub fn create_stake_account(
-    voter_pubkey: &Pubkey,
-    vote_state: &VoteState,
-    lamports: u64,
-) -> Account {
+pub fn create_account(voter_pubkey: &Pubkey, vote_account: &Account, lamports: u64) -> Account {
     let mut stake_account = Account::new(lamports, std::mem::size_of::<StakeState>(), &id());
+
+    let vote_state = VoteState::from(vote_account).expect("vote_state");
 
     stake_account
         .set_state(&StakeState::Stake(Stake::new_bootstrap(
             lamports,
             voter_pubkey,
-            vote_state,
+            &vote_state,
         )))
         .expect("set_state");
 

--- a/programs/vote_api/src/vote_state.rs
+++ b/programs/vote_api/src/vote_state.rs
@@ -380,25 +380,6 @@ pub fn create_account(
     vote_account
 }
 
-// utility function, used by solana-genesis, tests
-pub fn create_bootstrap_leader_account(
-    vote_pubkey: &Pubkey,
-    node_pubkey: &Pubkey,
-    commission: u8,
-    vote_lamports: u64,
-) -> (Account, VoteState) {
-    // Construct a vote account for the bootstrap_leader such that the leader_scheduler
-    // will be forced to select it as the leader for height 0
-    let mut vote_account = create_account(&vote_pubkey, &node_pubkey, commission, vote_lamports);
-
-    let mut vote_state: VoteState = vote_account.state().unwrap();
-    // TODO: get a hash for slot 0?
-    vote_state.process_slot_vote_unchecked(0);
-
-    vote_account.set_state(&vote_state).unwrap();
-    (vote_account, vote_state)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -467,16 +448,6 @@ mod tests {
             &[(vote.slot, vote.hash)],
             0,
         )
-    }
-
-    #[test]
-    fn test_vote_create_bootstrap_leader_account() {
-        let vote_pubkey = Pubkey::new_rand();
-        let (_vote_account, vote_state) =
-            vote_state::create_bootstrap_leader_account(&vote_pubkey, &Pubkey::new_rand(), 0, 100);
-
-        assert_eq!(vote_state.votes.len(), 1);
-        assert_eq!(vote_state.votes[0], Lockout::new(&Vote::default()));
     }
 
     #[test]

--- a/runtime/src/genesis_utils.rs
+++ b/runtime/src/genesis_utils.rs
@@ -6,7 +6,7 @@ use solana_sdk::{
     signature::{Keypair, KeypairUtil},
     system_program,
 };
-use solana_stake_api;
+use solana_stake_api::stake_state;
 use solana_vote_api::vote_state;
 
 // The default stake placed with the bootstrap leader
@@ -32,12 +32,17 @@ pub fn create_genesis_block_with_leader(
     let voting_keypair = Keypair::new();
     let staking_keypair = Keypair::new();
 
-    // TODO: de-duplicate the stake once passive staking
-    //  is fully implemented
-    let (vote_account, vote_state) = vote_state::create_bootstrap_leader_account(
+    // TODO: de-duplicate the stake... passive staking is fully implemented
+    let vote_account = vote_state::create_account(
         &voting_keypair.pubkey(),
         &bootstrap_leader_pubkey,
         0,
+        bootstrap_leader_stake_lamports,
+    );
+
+    let stake_account = stake_state::create_account(
+        &voting_keypair.pubkey(),
+        &vote_account,
         bootstrap_leader_stake_lamports,
     );
 
@@ -57,14 +62,7 @@ pub fn create_genesis_block_with_leader(
             // where votes go to
             (voting_keypair.pubkey(), vote_account),
             // passive bootstrap leader stake, duplicates above temporarily
-            (
-                staking_keypair.pubkey(),
-                solana_stake_api::stake_state::create_stake_account(
-                    &voting_keypair.pubkey(),
-                    &vote_state,
-                    bootstrap_leader_stake_lamports,
-                ),
-            ),
+            (staking_keypair.pubkey(), stake_account),
         ])
         // Bare minimum program set
         .native_instruction_processors(&[

--- a/runtime/src/stakes.rs
+++ b/runtime/src/stakes.rs
@@ -222,7 +222,11 @@ pub mod tests {
     pub fn create_stake_account(stake: u64, vote_pubkey: &Pubkey) -> (Pubkey, Account) {
         (
             Pubkey::new_rand(),
-            stake_state::create_stake_account(&vote_pubkey, &VoteState::default(), stake),
+            stake_state::create_account(
+                &vote_pubkey,
+                &vote_state::create_account(&vote_pubkey, &Pubkey::new_rand(), 0, 1),
+                stake,
+            ),
         )
     }
 


### PR DESCRIPTION
#### Problem
 bootstrap leader vote account includes a vote for slot 0, which means
  the bootstrap leader doesn't need to vote on 0, which means
  that no transactions end up in bank 1 unless there are other nodes, which means
  that single-node testnets fail after an epoch


 #### Summary of Changes
 remove the bootstrap leader vote for slot 0
 (introduced at c5a74ada05a6a8b602841792303c2a82dd762f53)
 clean up the functions that genesis* use to construct these bootstrap accounts

Fixes #