### PR TITLE
Reduce log level for known issue

### DIFF
--- a/core/src/cluster_info.rs
+++ b/core/src/cluster_info.rs
@@ -873,7 +873,7 @@ impl ClusterInfo {
                     if msg_size < MAX_PROTOCOL_PAYLOAD_SIZE as u64 {
                         msgs.push(msg);
                     } else {
-                        warn!(
+                        debug!(
                             "dropping message larger than the maximum payload size {:?}",
                             msg
                         );


### PR DESCRIPTION
#### Problem

Error print for #5522 is unnecessarily scary. 

#### Summary of Changes

#5522 is a known issue and so the log level can be toned down until it's fixed and then raised again

