### PR TITLE
Change JsonRpc exit to use wait->close

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -67,9 +67,26 @@ impl Default for ValidatorConfig {
     }
 }
 
+#[derive(Default)]
+pub struct ValidatorExit {
+    exits: Vec<Box<FnOnce() + Send + Sync>>,
+}
+
+impl ValidatorExit {
+    pub fn register_exit(&mut self, exit: Box<FnOnce() -> () + Send + Sync>) {
+        self.exits.push(exit);
+    }
+
+    pub fn exit(self) {
+        for exit in self.exits {
+            exit();
+        }
+    }
+}
+
 pub struct Validator {
     pub id: Pubkey,
-    exit: Arc<AtomicBool>,
+    validator_exit: Arc<RwLock<Option<ValidatorExit>>>,
     rpc_service: Option<JsonRpcService>,
     rpc_pubsub_service: Option<PubSubService>,
     gossip_service: GossipService,
@@ -140,6 +157,11 @@ impl Validator {
         let bank = bank_forks[bank_info.bank_slot].clone();
         let bank_forks = Arc::new(RwLock::new(bank_forks));
 
+        let mut validator_exit = ValidatorExit::default();
+        let exit_ = exit.clone();
+        validator_exit.register_exit(Box::new(move || exit_.store(true, Ordering::Relaxed)));
+        let validator_exit = Arc::new(RwLock::new(Some(validator_exit)));
+
         node.info.wallclock = timestamp();
         let cluster_info = Arc::new(RwLock::new(ClusterInfo::new(
             node.info.clone(),
@@ -162,7 +184,7 @@ impl Validator {
                 config.rpc_config.clone(),
                 bank_forks.clone(),
                 ledger_path,
-                &exit,
+                &validator_exit,
             ))
         };
 
@@ -312,17 +334,18 @@ impl Validator {
             rpc_pubsub_service,
             tpu,
             tvu,
-            exit,
             poh_service,
             poh_recorder,
             ip_echo_server,
+            validator_exit,
         }
     }
 
     // Used for notifying many nodes in parallel to exit
     pub fn exit(&mut self) {
-        self.exit.store(true, Ordering::Relaxed);
-        self.rpc_service.as_mut().map(|r| r.exit());
+        if let Some(x) = self.validator_exit.write().unwrap().take() {
+            x.exit()
+        }
     }
 
     pub fn close(mut self) -> Result<()> {

--- a/local_cluster/src/local_cluster.rs
+++ b/local_cluster/src/local_cluster.rs
@@ -257,8 +257,8 @@ impl LocalCluster {
         cluster
     }
 
-    pub fn exit(&self) {
-        for node in self.fullnodes.values() {
+    pub fn exit(&mut self) {
+        for node in self.fullnodes.values_mut() {
             node.exit();
         }
     }
@@ -587,7 +587,7 @@ impl Cluster for LocalCluster {
 
     fn restart_node(&mut self, pubkey: Pubkey) {
         // Shut down the fullnode
-        let node = self.fullnodes.remove(&pubkey).unwrap();
+        let mut node = self.fullnodes.remove(&pubkey).unwrap();
         node.exit();
         node.join().unwrap();
 


### PR DESCRIPTION
#### Problem
JsonRpcService exit does not currently guarantee threads have finished cleanup

#### Summary of Changes
1) Change to use `wait->close()` in jsonrpc exit
2) Change `fullnode_exit()` (invoked through RPC) to call the `exit()` method on a `validator_exit()` object which stores all the closures necessary to shutdown a validator

Fixes #
