### PR TITLE
solana-validator: Refine error message when ledger can't be opened

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -446,12 +446,10 @@ pub fn new_banks_from_blocktree(
     LeaderScheduleCache,
     PohConfig,
 ) {
-    let genesis_block =
-        GenesisBlock::load(blocktree_path).expect("Expected to successfully open genesis block");
+    let genesis_block = GenesisBlock::load(blocktree_path).expect("Failed to load genesis block");
 
     let (blocktree, ledger_signal_receiver, completed_slots_receiver) =
-        Blocktree::open_with_signal(blocktree_path)
-            .expect("Expected to successfully open database ledger");
+        Blocktree::open_with_signal(blocktree_path).expect("Failed to open ledger database");
 
     let (bank_forks, bank_forks_info, leader_schedule_cache) = get_bank_forks(
         &genesis_block,


### PR DESCRIPTION
Fixes #5569
(Well sorta fixes #5569 by improving the error message.  The validator still panics instead of existing cleanly, but plumbing up a clean exit is looking like a pretty low RoI right now)
