### PR TITLE
Add tds-metrics host to grafcli config

### DIFF
--- a/metrics/grafcli.conf
+++ b/metrics/grafcli.conf
@@ -8,8 +8,14 @@ force = on
 
 [hosts]
 metrics = on
+tds-metrics = on
 
 [metrics]
 type = api
 url = https://metrics.solana.com:3000/api
+ssl = off
+
+[tds-metrics]
+type = api
+url = https://tds-metrics.solana.com:3000/api
 ssl = off


### PR DESCRIPTION
#### Problem
tds-metrics.solana.com influx server is not getting the dashboards updated like m.s.c does on the daily

#### Summary of Changes
Update grafcli.conf to include this new host.  Additional testnet-monitor.json work likely needed here.

Fixes #5428 
