### PR TITLE
solana-validator: Adjust |ulimit -n| automatically, no bash required

### DIFF
--- a/scripts/tune-system.sh
+++ b/scripts/tune-system.sh
@@ -3,9 +3,6 @@
 # Adjusts system settings for optimal fullnode performance
 #
 
-# shellcheck source=scripts/ulimit-n.sh
-source "$(dirname "${BASH_SOURCE[0]}")"/ulimit-n.sh
-
 sysctl_write() {
   declare name=$1
   declare new_value=$2


### PR DESCRIPTION
We used bash to adjust `limit -n` before running a validator, which doesn't exist when `solana-validator` is run stand-alone.  Instead adjust the rlimit directly from Rust