### PR TITLE
Fixes to repair and orphan logic for data shreds

### DIFF
--- a/core/src/broadcast_stage/standard_broadcast_run.rs
+++ b/core/src/broadcast_stage/standard_broadcast_run.rs
@@ -88,7 +88,13 @@ impl BroadcastRun for StandardBroadcastRun {
                 )
             } else {
                 trace!("Renew shredder with same parent slot {:?}", parent_slot);
-                Shredder::new(bank.slot(), None, 0.0, keypair, latest_blob_index as u32)
+                Shredder::new(
+                    bank.slot(),
+                    Some(parent_slot),
+                    0.0,
+                    keypair,
+                    latest_blob_index as u32,
+                )
             }
         } else {
             trace!("New shredder with parent slot {:?}", parent_slot);

--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -114,7 +114,7 @@ where
 
     blocktree.insert_shreds(&shreds)?;
 
-    info!(
+    trace!(
         "Elapsed processing time in recv_window(): {}",
         duration_as_ms(&now.elapsed())
     );

--- a/local_cluster/tests/local_cluster.rs
+++ b/local_cluster/tests/local_cluster.rs
@@ -15,7 +15,7 @@ use solana_sdk::{client::SyncClient, poh_config::PohConfig, timing};
 use std::{collections::HashSet, thread::sleep, time::Duration};
 
 #[test]
-#[ignore]
+#[serial]
 fn test_ledger_cleanup_service() {
     solana_logger::setup();
     error!("test_ledger_cleanup_service");
@@ -69,7 +69,7 @@ fn test_spend_and_verify_all_nodes_1() {
 }
 
 #[test]
-#[ignore]
+#[serial]
 fn test_spend_and_verify_all_nodes_2() {
     solana_logger::setup();
     error!("test_spend_and_verify_all_nodes_2");
@@ -84,7 +84,7 @@ fn test_spend_and_verify_all_nodes_2() {
 }
 
 #[test]
-#[ignore]
+#[serial]
 fn test_spend_and_verify_all_nodes_3() {
     solana_logger::setup();
     error!("test_spend_and_verify_all_nodes_3");


### PR DESCRIPTION
#### Problem
The repair is not working reliably since we introduced data shreds

#### Summary of Changes
The shreds don't include parent slot information in every shred. This caused blocktree to create orphans and do repairs using orphans. This resulted in slower repairs, and potentially other issues.

For now, changed shred code to include parent slot information in every shred.
This also helped with fixing the broken local cluster tests

Fixes #5578 
#5294 
