### PR TITLE
solana-validator now verifies its genesis blockhash against the cluster entrypoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3846,6 +3846,7 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-client 0.18.0-pre2",
  "solana-core 0.18.0-pre2",
  "solana-drone 0.18.0-pre2",
  "solana-logger 0.18.0-pre2",

--- a/book/src/jsonrpc-api.md
+++ b/book/src/jsonrpc-api.md
@@ -26,6 +26,7 @@ Methods
 * [getBalance](#getbalance)
 * [getClusterNodes](#getclusternodes)
 * [getEpochInfo](#getepochinfo)
+* [getGenesisBlockhash](#getgenesisblockhash)
 * [getLeaderSchedule](#getleaderschedule)
 * [getProgramAccounts](#getprogramaccounts)
 * [getRecentBlockhash](#getrecentblockhash)
@@ -195,6 +196,25 @@ curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1, "m
 
 // Result
 {"jsonrpc":"2.0","result":{"epoch":3,"slotIndex":126,"slotsInEpoch":256},"id":1}
+```
+
+---
+### getGenesisBlockhash
+Returns the genesis block hash
+
+##### Parameters:
+None
+
+##### Results:
+* `string` - a Hash as base-58 encoded string
+
+##### Example:
+```bash
+// Request
+curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1, "method":"getGenesisBlockhash"}' http://localhost:8899
+
+// Result
+{"jsonrpc":"2.0","result":"GH7ome3EiwEr7tu9JuTh2dpYWBJK3z69Xm1ZE3MEE6JC","id":1}
 ```
 
 ---

--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -369,7 +369,7 @@ impl RpcClient {
         let blockhash = blockhash.parse().map_err(|err| {
             io::Error::new(
                 io::ErrorKind::Other,
-                format!("GetRecentBlockhash parse failure: {:?}", err),
+                format!("GetRecentBlockhash hash parse failure: {:?}", err),
             )
         })?;
         Ok((blockhash, fee_calculator))
@@ -395,6 +395,33 @@ impl RpcClient {
             io::ErrorKind::Other,
             "Unable to get new blockhash, too many retries",
         ))
+    }
+
+    pub fn get_genesis_blockhash(&self) -> io::Result<Hash> {
+        let response = self
+            .client
+            .send(&RpcRequest::GetGenesisBlockhash, None, 0)
+            .map_err(|err| {
+                io::Error::new(
+                    io::ErrorKind::Other,
+                    format!("GetGenesisBlockhash request failure: {:?}", err),
+                )
+            })?;
+
+        let blockhash = serde_json::from_value::<String>(response).map_err(|err| {
+            io::Error::new(
+                io::ErrorKind::Other,
+                format!("GetGenesisBlockhash parse failure: {:?}", err),
+            )
+        })?;
+
+        let blockhash = blockhash.parse().map_err(|err| {
+            io::Error::new(
+                io::ErrorKind::Other,
+                format!("GetGenesisBlockhash hash parse failure: {:?}", err),
+            )
+        })?;
+        Ok(blockhash)
     }
 
     pub fn poll_balance_with_timeout(

--- a/client/src/rpc_request.rs
+++ b/client/src/rpc_request.rs
@@ -9,6 +9,7 @@ pub enum RpcRequest {
     GetAccountInfo,
     GetBalance,
     GetClusterNodes,
+    GetGenesisBlockhash,
     GetNumBlocksSinceSignatureConfirmation,
     GetProgramAccounts,
     GetRecentBlockhash,
@@ -38,6 +39,7 @@ impl RpcRequest {
             RpcRequest::GetAccountInfo => "getAccountInfo",
             RpcRequest::GetBalance => "getBalance",
             RpcRequest::GetClusterNodes => "getClusterNodes",
+            RpcRequest::GetGenesisBlockhash => "getGenesisBlockhash",
             RpcRequest::GetNumBlocksSinceSignatureConfirmation => {
                 "getNumBlocksSinceSignatureConfirmation"
             }

--- a/core/src/rpc_service.rs
+++ b/core/src/rpc_service.rs
@@ -12,6 +12,7 @@ use jsonrpc_http_server::{
     hyper, AccessControlAllowOrigin, DomainsValidation, RequestMiddleware, RequestMiddlewareAction,
     ServerBuilder,
 };
+use solana_sdk::hash::Hash;
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
 use std::sync::mpsc::channel;
@@ -91,6 +92,7 @@ impl JsonRpcService {
         config: JsonRpcConfig,
         bank_forks: Arc<RwLock<BankForks>>,
         ledger_path: &Path,
+        genesis_blockhash: Hash,
         validator_exit: &Arc<RwLock<Option<ValidatorExit>>>,
     ) -> Self {
         info!("rpc bound to {:?}", rpc_addr);
@@ -118,6 +120,7 @@ impl JsonRpcService {
                     ServerBuilder::with_meta_extractor(io, move |_req: &hyper::Request<hyper::Body>| Meta {
                         request_processor: request_processor_.clone(),
                         cluster_info: cluster_info.clone(),
+                        genesis_blockhash
                     }).threads(4)
                         .cors(DomainsValidation::AllowOnly(vec![
                             AccessControlAllowOrigin::Any,
@@ -201,6 +204,7 @@ mod tests {
             JsonRpcConfig::default(),
             bank_forks,
             &PathBuf::from("farf"),
+            Hash::default(),
             &validator_exit,
         );
         let thread = rpc_service.thread_hdl.thread();

--- a/core/tests/tvu.rs
+++ b/core/tests/tvu.rs
@@ -91,6 +91,7 @@ fn test_replay() {
     let tvu_addr = target1.info.tvu;
 
     let (
+        _genesis_blockhash,
         bank_forks,
         _bank_forks_info,
         blocktree,
@@ -98,7 +99,7 @@ fn test_replay() {
         completed_slots_receiver,
         leader_schedule_cache,
         _,
-    ) = validator::new_banks_from_blocktree(&blocktree_path, None, None, true, None);
+    ) = validator::new_banks_from_blocktree(None, &blocktree_path, None, None, true, None);
     let working_bank = bank_forks.working_bank();
     assert_eq!(
         working_bank.get_balance(&mint_keypair.pubkey()),

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -14,6 +14,7 @@ clap = "2.33.0"
 log = "0.4.8"
 reqwest = "0.9.19"
 serde_json = "1.0.40"
+solana-client = { path = "../client", version = "0.18.0-pre2" }
 solana-core = { path = "../core", version = "0.18.0-pre2" }
 solana-drone = { path = "../drone", version = "0.18.0-pre2" }
 solana-logger = { path = "../logger", version = "0.18.0-pre2" }


### PR DESCRIPTION
The genesis blockhash sanity check lived in `validator.sh`, but in a bashless world `solana-validator` itself should to confirm that the genesis block it has locally still matches the cluster entrypoint's genesis block.   

This helps remove the footgun of accidentally using a stale ledger, like from the previous TdS dry run. 