### PR TITLE
Add info logging around snapshot tarball generation

### DIFF
--- a/core/src/snapshot_utils.rs
+++ b/core/src/snapshot_utils.rs
@@ -84,6 +84,7 @@ pub fn package_snapshot<P: AsRef<Path>, Q: AsRef<Path>>(
     }
 
     let package = SnapshotPackage::new(
+        bank.slot(),
         snapshot_hard_links_dir,
         account_storage_entries,
         snapshot_package_output_file.as_ref().to_path_buf(),


### PR DESCRIPTION
#### Problem
No info is currently available about when snapshots were generated and the time it takes

#### Summary of Changes
Add info logging around snapshot tarball generation

Fixes #
