### PR TITLE
net: init-metrics.sh - urlencode influx password

### DIFF
--- a/net/common.sh
+++ b/net/common.sh
@@ -79,10 +79,10 @@ loadConfigFile() {
 
 # https://gist.github.com/cdown/1163649
 urlencode() {
-  s="$1"
-  l=$((${#s} - 1))
+  declare s="$1"
+  declare l=$((${#s} - 1))
   for i in $(seq 0 $l); do
-    c="${s:$i:1}"
+    declare c="${s:$i:1}"
     case $c in
       [a-zA-Z0-9.~_-])
         echo -n "$c"

--- a/net/common.sh
+++ b/net/common.sh
@@ -76,3 +76,21 @@ loadConfigFile() {
   buildSshOptions
   configureMetrics
 }
+
+# https://gist.github.com/cdown/1163649
+urlencode() {
+  s="$1"
+  l=$((${#s} - 1))
+  for i in $(seq 0 $l); do
+    c="${s:$i:1}"
+    case $c in
+      [a-zA-Z0-9.~_-])
+        echo -n "$c"
+        ;;
+      *)
+        printf '%%%02X' "'$c"
+        ;;
+    esac
+  done
+}
+

--- a/net/init-metrics.sh
+++ b/net/init-metrics.sh
@@ -29,7 +29,7 @@ EOF
 urlencode() {
   s="$1"
   l=$((${#s} - 1))
-  for i in `seq 0 $l`; do
+  for i in $(seq 0 $l); do
     c="${s:$i:1}"
     case $c in
       [a-zA-Z0-9.~_-])
@@ -77,7 +77,7 @@ else
   [[ -n $password ]] || { echo "Password not specified"; exit 1; }
   echo
 
-  password=`urlencode "$password"`
+  password="$(urlencode "$password")"
 
   query() {
     echo "$*"

--- a/net/init-metrics.sh
+++ b/net/init-metrics.sh
@@ -25,23 +25,6 @@ EOF
   exit $exitcode
 }
 
-# https://gist.github.com/cdown/1163649
-urlencode() {
-  s="$1"
-  l=$((${#s} - 1))
-  for i in $(seq 0 $l); do
-    c="${s:$i:1}"
-    case $c in
-      [a-zA-Z0-9.~_-])
-        echo -n "$c"
-        ;;
-      *)
-        printf '%%%02X' "'$c"
-        ;;
-    esac
-  done
-}
-
 loadConfigFile
 
 useEnv=false

--- a/net/init-metrics.sh
+++ b/net/init-metrics.sh
@@ -25,6 +25,23 @@ EOF
   exit $exitcode
 }
 
+# https://gist.github.com/cdown/1163649
+urlencode() {
+  s="$1"
+  l=$((${#s} - 1))
+  for i in `seq 0 $l`; do
+    c="${s:$i:1}"
+    case $c in
+      [a-zA-Z0-9.~_-])
+        echo -n "$c"
+        ;;
+      *)
+        printf '%%%02X' "'$c"
+        ;;
+    esac
+  done
+}
+
 loadConfigFile
 
 useEnv=false
@@ -59,6 +76,8 @@ else
   read -rs -p "InfluxDB password for $username: " password
   [[ -n $password ]] || { echo "Password not specified"; exit 1; }
   echo
+
+  password=`urlencode "$password"`
 
   query() {
     echo "$*"


### PR DESCRIPTION
#### Problem

`init-metrics.sh` REST requests fail authorization if the user's InfluxDB password contains characters that need to be urlencoded

#### Summary of Changes

urlencode the InfluxDB password
