### PR TITLE
Add test case for u128 panic

### DIFF
--- a/programs/bpf/rust/128bit/src/lib.rs
+++ b/programs/bpf/rust/128bit/src/lib.rs
@@ -24,6 +24,9 @@ pub extern "C" fn entrypoint(_input: *mut u8) -> bool {
     z -= 1;
     assert_eq!(z, 340_282_366_920_938_463_463_374_607_431_768_211_454);
 
+    // ISSUE: https://github.com/solana-labs/solana/issues/5600
+    // assert_eq!(u128::from(1u32.to_be()), 1);
+
     let x = u64::max_value();
     assert_eq!(u128::from(x) + u128::from(x), 36_893_488_147_419_103_230);
 


### PR DESCRIPTION
#### Problem
`u128::from(1u32.to_be())` panics

#### Summary of Changes
Add commented out test case