### PR TITLE
net: net.sh - Enable deploying testnets on debug binaries

### DIFF
--- a/net/net.sh
+++ b/net/net.sh
@@ -122,6 +122,8 @@ internalNodesLamports=
 maybeNoSnapshot=""
 maybeSkipLedgerVerify=""
 maybeDisableAirdrops=""
+buildProfile="--release"
+debugBuild=false
 
 command=$1
 [[ -n $command ]] || usage
@@ -164,6 +166,9 @@ while [[ -n $1 ]]; do
     elif [[ $1 = --no-airdrop ]]; then
       maybeDisableAirdrops="$1"
       shift 1
+    elif [[ $1 = --debug ]]; then
+      debugBuild=true
+      shift 1
     else
       usage "Unknown long option: $1"
     fi
@@ -173,7 +178,7 @@ while [[ -n $1 ]]; do
   fi
 done
 
-while getopts "h?T:t:o:f:rD:c:Fn:i:" opt "${shortArgs[@]}"; do
+while getopts "h?T:t:o:f:rD:c:Fn:i:d" opt "${shortArgs[@]}"; do
   case $opt in
   h | \?)
     usage
@@ -255,11 +260,16 @@ while getopts "h?T:t:o:f:rD:c:Fn:i:" opt "${shortArgs[@]}"; do
   i)
     nodeAddress=$OPTARG
     ;;
+  d)
+    debugBuild=true
+    ;;
   *)
     usage "Error: unhandled option: $opt"
     ;;
   esac
 done
+
+$debugBuild && buildProfile=""
 
 loadConfigFile
 
@@ -317,7 +327,7 @@ build() {
     fi
     $MAYBE_DOCKER bash -c "
       set -ex
-      scripts/cargo-install-all.sh farf \"$cargoFeatures\"
+      scripts/cargo-install-all.sh farf \"$cargoFeatures\" \"$buildProfile\"
       if [[ -n \"$customPrograms\" ]]; then
         scripts/cargo-install-custom-programs.sh farf $customPrograms
       fi

--- a/net/net.sh
+++ b/net/net.sh
@@ -39,6 +39,7 @@ Operate a configured testnet
                                         (ignored if -s or -S is specified)
    -r                                 - Reuse existing node/ledger configuration from a
                                         previous |start| (ie, don't run ./multinode-demo/setup.sh).
+   -d / --debug                       - Build/deploy the testnet with debug binaries
    -D /path/to/programs               - Deploy custom programs from this location
    -c clientType=numClients=extraArgs - Number of clientTypes to start.  This options can be specified
                                         more than once.  Defaults to bench-tps for all clients if not

--- a/scripts/cargo-install-all.sh
+++ b/scripts/cargo-install-all.sh
@@ -17,6 +17,9 @@ fi
 
 installDir="$(mkdir -p "$1"; cd "$1"; pwd)"
 cargoFeatures="$2"
+buildProfile="$3"
+[ -n "$buildProfile" ] && binTargetDir="release" || binTargetDir="debug"
+
 echo "Install location: $installDir"
 
 cd "$(dirname "$0")"/..
@@ -26,7 +29,7 @@ SECONDS=0
 (
   set -x
   # shellcheck disable=SC2086 # Don't want to double quote $rust_version
-  cargo $rust_version build --all --release --features="$cargoFeatures"
+  cargo $rust_version build --all $buildProfile --features="$cargoFeatures"
 )
 
 BIN_CRATES=(
@@ -53,7 +56,7 @@ for crate in "${BIN_CRATES[@]}"; do
 done
 
 for dir in programs/*; do
-  for program in echo target/release/deps/libsolana_"$(basename "$dir")".{so,dylib,dll}; do
+  for program in echo target/$binTargetDir/deps/libsolana_"$(basename "$dir")".{so,dylib,dll}; do
     if [[ -f $program ]]; then
       mkdir -p "$installDir/bin/deps"
       rm -f "$installDir/bin/deps/$(basename "$program")"

--- a/scripts/cargo-install-all.sh
+++ b/scripts/cargo-install-all.sh
@@ -17,8 +17,13 @@ fi
 
 installDir="$(mkdir -p "$1"; cd "$1"; pwd)"
 cargoFeatures="$2"
+
 buildProfile="$3"
-[ -n "$buildProfile" ] && binTargetDir="release" || binTargetDir="debug"
+if [[ -n "$buildProfile" ]]; then
+  binTargetDir="release"
+else
+  binTargetDir="debug"
+fi
 
 echo "Install location: $installDir"
 


### PR DESCRIPTION
#### Problem

`net.sh` can only build/deploy testnets on release binaries, which makes debugging some issues more complex than necessary

#### Summary of Changes

Add `-d`/`--debug` flags to enable build/deploy of testnets with debug binaries
