### PR TITLE
Ignore test_snapshots_restart_validity as it times out in test-stable.sh

### DIFF
--- a/local_cluster/tests/local_cluster.rs
+++ b/local_cluster/tests/local_cluster.rs
@@ -299,6 +299,8 @@ fn test_listener_startup() {
 
 #[test]
 #[serial]
+#[allow(unused_attributes)]
+#[ignore]
 fn test_snapshots_restart_validity() {
     let temp_dir = TempDir::new().unwrap();
     let snapshot_path = temp_dir.path().join("bank_states");


### PR DESCRIPTION
test_snapshots_restart_validity times out in CI even though it passes locally.  Until this can be further debugged, disable the test to unclog CI