### PR TITLE
Add bigger buffers for shred column families in rocks

### DIFF
--- a/core/src/blocktree/rocks.rs
+++ b/core/src/blocktree/rocks.rs
@@ -464,11 +464,11 @@ impl std::convert::From<rocksdb::Error> for Error {
 }
 
 fn get_cf_options(name: &'static str) -> Options {
-    use crate::blocktree::db::columns::{Coding, Data};
+    use crate::blocktree::db::columns::{Coding, Data, ShredCode, ShredData};
 
     let mut options = Options::default();
     match name {
-        Coding::NAME | Data::NAME => {
+        Coding::NAME | Data::NAME | ShredCode::NAME | ShredData::NAME => {
             // 512MB * 8 = 4GB. 2 of these columns should take no more than 8GB of RAM
             options.set_max_write_buffer_number(8);
             options.set_write_buffer_size(MAX_WRITE_BUFFER_SIZE as usize);


### PR DESCRIPTION
#### Problem
Blocktree was configured with the wrong configuration for big column families like ShredData and ShredCode

#### Summary of Changes
Change configuration for those column families to use appropriate values.

Fixes #
