### PR TITLE
Enabling building for bpf stack bug test program

### DIFF
--- a/programs/bpf/build.rs
+++ b/programs/bpf/build.rs
@@ -76,8 +76,7 @@ fn main() {
             "external_spend",
             "noop",
             "panic",
-            // ISSUE: https://github.com/solana-labs/solana/issues/5602
-            // "stack_bug",
+            "stack_bug",
             "tick_height",
         ];
         for program in rust_programs.iter() {


### PR DESCRIPTION
The stack bug test program was recently added but should have been enabled for building. This fixes that.