### PR TITLE
Ignore retransmit channel error

### DIFF
--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -106,10 +106,8 @@ where
     );
 
     if !packets.packets.is_empty() {
-        match retransmit.send(packets) {
-            Ok(_) => Ok(()),
-            Err(e) => Err(e),
-        }?;
+        // Ignore the send error, as the retransmit is optional (e.g. replicators don't retransmit)
+        let _ = retransmit.send(packets);
     }
 
     blocktree.insert_shreds(shreds)?;


### PR DESCRIPTION
#### Problem
The retransmit in window_service is optional (e.g. replicators don't retransmit). So the retransmit channel may not exist. The sender should ignore the send errors

#### Summary of Changes
Ignore the send error.

#5294 