### PR TITLE
Add getInflation JSON RPC endpoint

### DIFF
--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -9,6 +9,7 @@ use serde_json::{json, Value};
 use solana_sdk::account::Account;
 use solana_sdk::fee_calculator::FeeCalculator;
 use solana_sdk::hash::Hash;
+use solana_sdk::inflation::Inflation;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::{KeypairUtil, Signature};
 use solana_sdk::timing::{DEFAULT_TICKS_PER_SECOND, DEFAULT_TICKS_PER_SLOT};
@@ -90,6 +91,25 @@ impl RpcClient {
             io::Error::new(
                 io::ErrorKind::Other,
                 format!("GetSlot parse failure: {}", err),
+            )
+        })
+    }
+
+    pub fn get_inflation(&self) -> io::Result<Inflation> {
+        let response = self
+            .client
+            .send(&RpcRequest::GetInflation, None, 0)
+            .map_err(|err| {
+                io::Error::new(
+                    io::ErrorKind::Other,
+                    format!("GetInflation request failure: {:?}", err),
+                )
+            })?;
+
+        serde_json::from_value(response).map_err(|err| {
+            io::Error::new(
+                io::ErrorKind::Other,
+                format!("GetInflation parse failure: {}", err),
             )
         })
     }

--- a/client/src/rpc_request.rs
+++ b/client/src/rpc_request.rs
@@ -10,6 +10,7 @@ pub enum RpcRequest {
     GetBalance,
     GetClusterNodes,
     GetGenesisBlockhash,
+    GetInflation,
     GetNumBlocksSinceSignatureConfirmation,
     GetProgramAccounts,
     GetRecentBlockhash,
@@ -40,6 +41,7 @@ impl RpcRequest {
             RpcRequest::GetBalance => "getBalance",
             RpcRequest::GetClusterNodes => "getClusterNodes",
             RpcRequest::GetGenesisBlockhash => "getGenesisBlockhash",
+            RpcRequest::GetInflation => "getInflation",
             RpcRequest::GetNumBlocksSinceSignatureConfirmation => {
                 "getNumBlocksSinceSignatureConfirmation"
             }
@@ -109,6 +111,10 @@ mod tests {
         let test_request = RpcRequest::GetBalance;
         let request = test_request.build_request_json(1, Some(addr));
         assert_eq!(request["method"], "getBalance");
+
+        let test_request = RpcRequest::GetInflation;
+        let request = test_request.build_request_json(1, None);
+        assert_eq!(request["method"], "getInflation");
 
         let test_request = RpcRequest::GetRecentBlockhash;
         let request = test_request.build_request_json(1, None);

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1326,6 +1326,11 @@ impl Bank {
         self.tick_height.load(Ordering::Relaxed) as u64
     }
 
+    /// Return the inflation parameters of the Bank
+    pub fn inflation(&self) -> Inflation {
+        self.inflation
+    }
+
     /// Return the total capititalization of the Bank
     pub fn capitalization(&self) -> u64 {
         // capitalization is using an AtomicUSize because AtomicU64 is not yet a stable API.


### PR DESCRIPTION
#### Problem

* Network Explorer currently has hardcoded JS constants for network inflation rate
* A proper implementation retrieves these from the fullnode/bank/genesis block

#### Summary of Changes

* We plumb the Inflation parameters via a new RPC method `getInflation()`
