### PR TITLE
Remove extra call to serialize in shred verify

### DIFF
--- a/core/src/replicator.rs
+++ b/core/src/replicator.rs
@@ -474,7 +474,7 @@ impl Replicator {
             repair_socket,
             &exit,
             RepairStrategy::RepairRange(repair_slot_range),
-            |_, _, _| true,
+            |_, _, _, _| true,
         );
         info!("waiting for ledger download");
         Self::wait_for_segment_download(

--- a/core/src/retransmit_stage.rs
+++ b/core/src/retransmit_stage.rs
@@ -150,8 +150,14 @@ impl RetransmitStage {
             repair_socket,
             exit,
             repair_strategy,
-            move |id, blob, working_bank| {
-                should_retransmit_and_persist(blob, working_bank, &leader_schedule_cache, id)
+            move |id, shred, shred_buf, working_bank| {
+                should_retransmit_and_persist(
+                    shred,
+                    shred_buf,
+                    working_bank,
+                    &leader_schedule_cache,
+                    id,
+                )
             },
         );
 

--- a/core/src/shred.rs
+++ b/core/src/shred.rs
@@ -107,6 +107,11 @@ impl Shred {
     }
 
     pub fn verify(&self, pubkey: &Pubkey) -> bool {
+        let shred = bincode::serialize(&self).unwrap();
+        self.fast_verify(&shred, pubkey)
+    }
+
+    pub fn fast_verify(&self, shred_buf: &[u8], pubkey: &Pubkey) -> bool {
         let signed_payload_offset = match self {
             Shred::FirstInSlot(_)
             | Shred::FirstInFECSet(_)
@@ -119,9 +124,8 @@ impl Shred {
             }
         } + bincode::serialized_size(&Signature::default()).unwrap()
             as usize;
-        let shred = bincode::serialize(&self).unwrap();
         self.signature()
-            .verify(pubkey.as_ref(), &shred[signed_payload_offset..])
+            .verify(pubkey.as_ref(), &shred_buf[signed_payload_offset..])
     }
 }
 


### PR DESCRIPTION
#### Problem
Window service already has serialized shred, but shred verify serializes it again.

#### Summary of Changes
Use serialized buffer from window service to perform shred verification.

#5294 