### PR TITLE
Refactor Blocktree for clarity and correctness

### DIFF
--- a/core/src/blocktree.rs
+++ b/core/src/blocktree.rs
@@ -646,7 +646,13 @@ impl Blocktree {
 
         // Assert guaranteed by integrity checks on the shred that happen before
         // `insert_coding_shred` is called
-        assert!(shred_index >= pos);
+        if shred_index < pos {
+            error!("Due to earlier validation, shred index must be >= pos");
+            return Err(Error::BlocktreeError(BlocktreeError::InvalidShredData(
+                Box::new(ErrorKind::Custom("shred index < pos")),
+            )));
+        }
+
         let set_index = shred_index - pos;
         let erasure_config = ErasureConfig::new(num_data, num_coding);
 

--- a/core/src/shred.rs
+++ b/core/src/shred.rs
@@ -12,7 +12,7 @@ use std::io::{Error as IOError, ErrorKind, Write};
 use std::sync::Arc;
 use std::{cmp, io};
 
-#[derive(Serialize, Deserialize, PartialEq, Debug)]
+#[derive(Serialize, Clone, Deserialize, PartialEq, Debug)]
 pub enum Shred {
     FirstInSlot(FirstDataShred),
     FirstInFECSet(DataShred),
@@ -130,7 +130,7 @@ impl Shred {
 }
 
 /// A common header that is present at start of every shred
-#[derive(Serialize, Deserialize, Default, PartialEq, Debug)]
+#[derive(Serialize, Clone, Deserialize, Default, PartialEq, Debug)]
 pub struct ShredCommonHeader {
     pub signature: Signature,
     pub slot: u64,
@@ -138,7 +138,7 @@ pub struct ShredCommonHeader {
 }
 
 /// A common header that is present at start of every data shred
-#[derive(Serialize, Deserialize, Default, PartialEq, Debug)]
+#[derive(Serialize, Clone, Deserialize, Default, PartialEq, Debug)]
 pub struct DataShredHeader {
     _reserved: CodingShredHeader,
     pub common_header: ShredCommonHeader,
@@ -147,14 +147,14 @@ pub struct DataShredHeader {
 }
 
 /// The first data shred also has parent slot value in it
-#[derive(Serialize, Deserialize, Default, PartialEq, Debug)]
+#[derive(Serialize, Clone, Deserialize, Default, PartialEq, Debug)]
 pub struct FirstDataShredHeader {
     pub data_header: DataShredHeader,
     pub parent: u64,
 }
 
 /// The coding shred header has FEC information
-#[derive(Serialize, Deserialize, Default, PartialEq, Debug)]
+#[derive(Serialize, Clone, Deserialize, Default, PartialEq, Debug)]
 pub struct CodingShredHeader {
     pub common_header: ShredCommonHeader,
     pub num_data_shreds: u16,
@@ -163,19 +163,19 @@ pub struct CodingShredHeader {
     pub payload: Vec<u8>,
 }
 
-#[derive(Serialize, Deserialize, PartialEq, Debug)]
+#[derive(Serialize, Clone, Deserialize, PartialEq, Debug)]
 pub struct FirstDataShred {
     pub header: FirstDataShredHeader,
     pub payload: Vec<u8>,
 }
 
-#[derive(Serialize, Deserialize, PartialEq, Debug)]
+#[derive(Serialize, Clone, Deserialize, PartialEq, Debug)]
 pub struct DataShred {
     pub header: DataShredHeader,
     pub payload: Vec<u8>,
 }
 
-#[derive(Serialize, Deserialize, PartialEq, Debug)]
+#[derive(Serialize, Clone, Deserialize, PartialEq, Debug)]
 pub struct CodingShred {
     pub header: CodingShredHeader,
 }
@@ -454,7 +454,7 @@ impl Shredder {
         first_shred
     }
 
-    fn new_coding_shred(
+    pub fn new_coding_shred(
         slot: u64,
         index: u32,
         num_data: usize,

--- a/local_cluster/tests/local_cluster.rs
+++ b/local_cluster/tests/local_cluster.rs
@@ -346,7 +346,7 @@ fn test_snapshots_blocktree_floor() {
     fs::hard_link(tar, &validator_tar_path).unwrap();
     let slot_floor = snapshot_utils::bank_slot_from_archive(&validator_tar_path).unwrap();
 
-    // Start up a new node from a snapshot, wait for it to catchup with the leader
+    // Start up a new node from a snapshot
     let validator_stake = 5;
     cluster.add_validator(
         &validator_snapshot_test_config.validator_config,
@@ -360,7 +360,7 @@ fn test_snapshots_blocktree_floor() {
     let validator_client = cluster.get_validator_client(&validator_id).unwrap();
     let mut current_slot = 0;
 
-    // Make sure this validator can get repaired past the first few warmup epochs
+    // Let this validator run a while with repair
     let target_slot = slot_floor + 40;
     while current_slot <= target_slot {
         trace!("current_slot: {}", current_slot);
@@ -379,6 +379,7 @@ fn test_snapshots_blocktree_floor() {
 
     // Skip the zeroth slot in blocktree that the ledger is initialized with
     let (first_slot, _) = blocktree.slot_meta_iterator(1).unwrap().next().unwrap();
+
     assert_eq!(first_slot, slot_floor);
 }
 

--- a/local_cluster/tests/local_cluster.rs
+++ b/local_cluster/tests/local_cluster.rs
@@ -303,7 +303,6 @@ fn test_listener_startup() {
 #[allow(unused_attributes)]
 #[test]
 #[serial]
-#[ignore]
 fn test_snapshots_blocktree_floor() {
     // First set up the cluster with 1 snapshotting leader
     let snapshot_interval_slots = 10;


### PR DESCRIPTION
#### Problem
1) Coding blobs do not go through integrity checks before being inserted
2) Corrupt coding and data blobs still lead to metadata being stored in blocktree

#### Summary of Changes
Refactor and add checks to fix the above

TODO: Add tests
Fixes #
