### PR TITLE
Install bzip2 in solana docker file

### DIFF
--- a/sdk/docker-solana/Dockerfile
+++ b/sdk/docker-solana/Dockerfile
@@ -3,9 +3,8 @@ FROM debian:buster
 # JSON RPC port
 EXPOSE 8899/tcp
 
-# Install libssl
 RUN apt update && \
-    apt-get install -y libssl-dev && \
+    apt-get install -y bzip2 libssl-dev && \
     rm -rf /var/lib/apt/lists/*
 
 COPY usr/bin /usr/bin/


### PR DESCRIPTION
#### Problem
Solana docker image is throwing this error:
```
/bin/sh: 1: bzip2: not found
tar: /usr/bin/config/ledger/new_stateaQTCHO.tar.bz2: Cannot write: Broken pipe
tar: Child returned status 127
tar: Error is not recoverable: exiting now
```

#### Summary of Changes
Add `apt-get install bzip2` to Dockerfile

Fixes #
