### PR TITLE
Use LLVM's C builtins for BPF

### DIFF
--- a/programs/bpf/rust/128bit/src/lib.rs
+++ b/programs/bpf/rust/128bit/src/lib.rs
@@ -24,16 +24,25 @@ pub extern "C" fn entrypoint(_input: *mut u8) -> bool {
     z -= 1;
     assert_eq!(z, 340_282_366_920_938_463_463_374_607_431_768_211_454);
 
-    // ISSUE: https://github.com/solana-labs/solana/issues/5600
-    // assert_eq!(u128::from(1u32.to_be()), 1);
+    assert_eq!(u128::from(1u32.to_le()), 1);
+    assert_eq!(u128::from(1u32.to_be()), 0x1000000);
 
-    // ISSUE: https://github.com/solana-labs/solana/issues/5619
-    // solana_bpf_rust_128bit_dep::two_thirds(10);
+    assert_eq!(solana_bpf_rust_128bit_dep::uadd(10, 20), 30u128);
+    assert_eq!(solana_bpf_rust_128bit_dep::usubtract(30, 20), 10u128);
+    assert_eq!(solana_bpf_rust_128bit_dep::umultiply(30, 20), 600u128);
+    assert_eq!(solana_bpf_rust_128bit_dep::udivide(20, 10), 2u128);
+    assert_eq!(solana_bpf_rust_128bit_dep::umodulo(20, 3), 2u128);
+
+    assert_eq!(solana_bpf_rust_128bit_dep::add(-10, -20), -30i128);
+    assert_eq!(solana_bpf_rust_128bit_dep::subtract(-30, -20), -10i128);
+    assert_eq!(solana_bpf_rust_128bit_dep::multiply(-30, -20), 600i128);
+    assert_eq!(solana_bpf_rust_128bit_dep::divide(-20, -10), 2i128);
+    assert_eq!(solana_bpf_rust_128bit_dep::modulo(-20, -3), -2i128);
 
     let x = u64::max_value();
     assert_eq!(u128::from(x) + u128::from(x), 36_893_488_147_419_103_230);
 
-    let x = solana_bpf_rust_128bit_dep::work(
+    let x = solana_bpf_rust_128bit_dep::uadd(
         u128::from(u64::max_value()),
         u128::from(u64::max_value()),
     );

--- a/programs/bpf/rust/128bit/src/lib.rs
+++ b/programs/bpf/rust/128bit/src/lib.rs
@@ -25,7 +25,7 @@ pub extern "C" fn entrypoint(_input: *mut u8) -> bool {
     assert_eq!(z, 340_282_366_920_938_463_463_374_607_431_768_211_454);
 
     assert_eq!(u128::from(1u32.to_le()), 1);
-    assert_eq!(u128::from(1u32.to_be()), 0x1000000);
+    assert_eq!(u128::from(1u32.to_be()), 0x1_000_000);
 
     assert_eq!(solana_bpf_rust_128bit_dep::uadd(10, 20), 30u128);
     assert_eq!(solana_bpf_rust_128bit_dep::usubtract(30, 20), 10u128);

--- a/programs/bpf/rust/128bit_dep/src/lib.rs
+++ b/programs/bpf/rust/128bit_dep/src/lib.rs
@@ -4,12 +4,36 @@
 
 extern crate solana_sdk_bpf_utils;
 
-pub fn work(x: u128, y: u128) -> u128 {
+pub fn uadd(x: u128, y: u128) -> u128 {
     x + y
 }
+pub fn usubtract(x: u128, y: u128) -> u128 {
+    x - y
+}
+pub fn umultiply(x: u128, y: u128) -> u128 {
+    x * y
+}
+pub fn udivide(n: u128, d: u128) -> u128 {
+    n / d
+}
+pub fn umodulo(n: u128, d: u128) -> u128 {
+    n % d
+}
 
-pub fn two_thirds(x: u128) -> u128 {
-    2 * x / 3
+pub fn add(x: i128, y: i128) -> i128 {
+    x + y
+}
+pub fn subtract(x: i128, y: i128) -> i128 {
+    x - y
+}
+pub fn multiply(x: i128, y: i128) -> i128 {
+    x * y
+}
+pub fn divide(n: i128, d: i128) -> i128 {
+    n / d
+}
+pub fn modulo(n: i128, d: i128) -> i128 {
+    n % d
 }
 
 #[cfg(test)]

--- a/programs/bpf/rust/128bit_dep/src/lib.rs
+++ b/programs/bpf/rust/128bit_dep/src/lib.rs
@@ -54,7 +54,7 @@ mod test {
     }
 
     #[test]
-    fn test_work() {
-        assert_eq!(3, work(1, 2));
+    fn test_add() {
+        assert_eq!(3, add(1, 2));
     }
 }

--- a/sdk/bpf/scripts/install.sh
+++ b/sdk/bpf/scripts/install.sh
@@ -116,7 +116,7 @@ if [[ ! -f rust-bpf-$machine-$version.md ]]; then
 fi
 
 # Install Rust-BPF Sysroot sources
-version=v0.7
+version=v0.8
 if [[ ! -f rust-bpf-sysroot-$version.md ]]; then
   (
     set -ex


### PR DESCRIPTION
#### Problem

Rust 128-bit builtins causing ABI incompatibilities

https://github.com/solana-labs/solana/issues/5716

#### Summary of Changes

Use LLVM's C versions of the builtins

Fixes #5619 

