### PR TITLE
cli: Move drone arguments under the airdrop command

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -66,28 +66,6 @@ pub fn parse_args(matches: &ArgMatches<'_>) -> Result<WalletConfig, Box<dyn erro
         default.json_rpc_url
     };
 
-    let drone_host = if let Some(drone_host) = matches.value_of("drone_host") {
-        Some(solana_netutil::parse_host(drone_host).or_else(|err| {
-            Err(WalletError::BadParameter(format!(
-                "Invalid drone host: {:?}",
-                err
-            )))
-        })?)
-    } else {
-        None
-    };
-
-    let drone_port = matches
-        .value_of("drone_port")
-        .unwrap()
-        .parse()
-        .or_else(|err| {
-            Err(WalletError::BadParameter(format!(
-                "Invalid drone port: {:?}",
-                err
-            )))
-        })?;
-
     let mut path = dirs::home_dir().expect("home directory");
     let id_path = if matches.is_present("keypair") {
         matches.value_of("keypair").unwrap()
@@ -113,8 +91,6 @@ pub fn parse_args(matches: &ArgMatches<'_>) -> Result<WalletConfig, Box<dyn erro
 
     Ok(WalletConfig {
         command,
-        drone_host,
-        drone_port,
         json_rpc_url,
         keypair,
         rpc_client: None,
@@ -137,10 +113,6 @@ fn is_url(string: String) -> Result<(), String> {
 
 fn main() -> Result<(), Box<dyn error::Error>> {
     solana_logger::setup();
-
-    let default = WalletConfig::default();
-    let default_drone_port = format!("{}", default.drone_port);
-
     let matches = app(crate_name!(), crate_description!(), crate_version!())
         .arg({
             let arg = Arg::with_name("config_file")
@@ -163,21 +135,6 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                 .takes_value(true)
                 .validator(is_url)
                 .help("JSON RPC URL for the solana cluster"),
-        )
-        .arg(
-            Arg::with_name("drone_host")
-                .long("drone-host")
-                .value_name("HOST")
-                .takes_value(true)
-                .help("Drone host to use [default: same as the --url host]"),
-        )
-        .arg(
-            Arg::with_name("drone_port")
-                .long("drone-port")
-                .value_name("PORT")
-                .takes_value(true)
-                .default_value(&default_drone_port)
-                .help("Drone port to use"),
         )
         .arg(
             Arg::with_name("keypair")

--- a/cli/tests/deploy.rs
+++ b/cli/tests/deploy.rs
@@ -29,9 +29,12 @@ fn test_wallet_deploy_program() {
     let rpc_client = RpcClient::new_socket(leader_data.rpc);
 
     let mut config = WalletConfig::default();
-    config.drone_port = drone_addr.port();
     config.json_rpc_url = format!("http://{}:{}", leader_data.rpc.ip(), leader_data.rpc.port());
-    config.command = WalletCommand::Airdrop(50);
+    config.command = WalletCommand::Airdrop {
+        drone_host: None,
+        drone_port: drone_addr.port(),
+        lamports: 50,
+    };
     process_command(&config).unwrap();
 
     config.command = WalletCommand::Deploy(pathbuf.to_str().unwrap().to_string());

--- a/cli/tests/pay.rs
+++ b/cli/tests/pay.rs
@@ -40,12 +40,10 @@ fn test_wallet_timestamp_tx() {
     let rpc_client = RpcClient::new_socket(leader_data.rpc);
 
     let mut config_payer = WalletConfig::default();
-    config_payer.drone_port = drone_addr.port();
     config_payer.json_rpc_url =
         format!("http://{}:{}", leader_data.rpc.ip(), leader_data.rpc.port());
 
     let mut config_witness = WalletConfig::default();
-    config_witness.drone_port = config_payer.drone_port;
     config_witness.json_rpc_url = config_payer.json_rpc_url.clone();
 
     assert_ne!(
@@ -113,12 +111,10 @@ fn test_wallet_witness_tx() {
     let rpc_client = RpcClient::new_socket(leader_data.rpc);
 
     let mut config_payer = WalletConfig::default();
-    config_payer.drone_port = drone_addr.port();
     config_payer.json_rpc_url =
         format!("http://{}:{}", leader_data.rpc.ip(), leader_data.rpc.port());
 
     let mut config_witness = WalletConfig::default();
-    config_witness.drone_port = config_payer.drone_port;
     config_witness.json_rpc_url = config_payer.json_rpc_url.clone();
 
     assert_ne!(
@@ -182,12 +178,10 @@ fn test_wallet_cancel_tx() {
     let rpc_client = RpcClient::new_socket(leader_data.rpc);
 
     let mut config_payer = WalletConfig::default();
-    config_payer.drone_port = drone_addr.port();
     config_payer.json_rpc_url =
         format!("http://{}:{}", leader_data.rpc.ip(), leader_data.rpc.port());
 
     let mut config_witness = WalletConfig::default();
-    config_witness.drone_port = config_payer.drone_port;
     config_witness.json_rpc_url = config_payer.json_rpc_url.clone();
 
     assert_ne!(

--- a/cli/tests/request_airdrop.rs
+++ b/cli/tests/request_airdrop.rs
@@ -14,10 +14,12 @@ fn test_wallet_request_airdrop() {
     let drone_addr = receiver.recv().unwrap();
 
     let mut bob_config = WalletConfig::default();
-    bob_config.drone_port = drone_addr.port();
     bob_config.json_rpc_url = format!("http://{}:{}", leader_data.rpc.ip(), leader_data.rpc.port());
-
-    bob_config.command = WalletCommand::Airdrop(50);
+    bob_config.command = WalletCommand::Airdrop {
+        drone_host: None,
+        drone_port: drone_addr.port(),
+        lamports: 50,
+    };
 
     let sig_response = process_command(&bob_config);
     sig_response.unwrap();

--- a/drone/src/drone.rs
+++ b/drone/src/drone.rs
@@ -43,6 +43,7 @@ macro_rules! socketaddr {
 pub const TIME_SLICE: u64 = 60;
 pub const REQUEST_CAP: u64 = 100_000_000_000_000;
 pub const DRONE_PORT: u16 = 9900;
+pub const DRONE_PORT_STR: &str = "9900";
 
 #[derive(Serialize, Deserialize, Debug, Clone, Copy)]
 pub enum DroneRequest {


### PR DESCRIPTION
`--drone-host`/`--drone-url` are only applicable to the `airdrop` command, they don't deserve top-level standing.

🐃 