### PR TITLE
Remove unnecessary construction of descendants

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -573,7 +573,6 @@ impl ReplayStage {
     ) -> Vec<(u128, Arc<Bank>, HashMap<u64, StakeLockout>, u64)> {
         let tower_start = Instant::now();
         // Tower voting
-        let descendants = bank_forks.read().unwrap().descendants();
         let ancestors = bank_forks.read().unwrap().ancestors();
         let frozen_banks = bank_forks.read().unwrap().frozen_banks();
 
@@ -591,7 +590,7 @@ impl ReplayStage {
                 !has_voted
             })
             .filter(|b| {
-                let is_locked_out = tower.is_locked_out(b.slot(), &descendants);
+                let is_locked_out = tower.is_locked_out(b.slot(), &ancestors);
                 trace!("bank is is_locked_out: {} {}", b.slot(), is_locked_out);
                 !is_locked_out
             })


### PR DESCRIPTION
#### Problem
Descendants calculation in replay stage is expensive and redundant
#### Summary of Changes
Replace descendants with ancestors
Fixes #
One step closer toward https://github.com/solana-labs/solana/issues/4924