### PR TITLE
cli: Mark global arguments as such

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -24,14 +24,17 @@ fn parse_settings(matches: &ArgMatches<'_>) -> Result<bool, Box<dyn error::Error
                     println_name_value("* keypair:", &config.keypair);
                 }
             } else {
-                println!("{} Either provide the `--config` arg or ensure home directory exists to use the default config location", style("No config file found.").bold());
+                println!(
+                    "{} Either provide the `--config` arg or ensure home directory exists to use the default config location",
+                    style("No config file found.").bold()
+                );
             }
             false
         }
         ("set", Some(subcommand_matches)) => {
             if let Some(config_file) = matches.value_of("config_file") {
                 let mut config = Config::load(config_file).unwrap_or_default();
-                if let Some(url) = subcommand_matches.value_of("url") {
+                if let Some(url) = subcommand_matches.value_of("json_rpc_url") {
                     config.url = url.to_string();
                 }
                 if let Some(keypair) = subcommand_matches.value_of("keypair") {
@@ -42,7 +45,10 @@ fn parse_settings(matches: &ArgMatches<'_>) -> Result<bool, Box<dyn error::Error
                 println_name_value("* url:", &config.url);
                 println_name_value("* keypair:", &config.keypair);
             } else {
-                println!("{} Either provide the `--config` arg or ensure home directory exists to use the default config location", style("No config file found.").bold());
+                println!(
+                    "{} Either provide the `--config` arg or ensure home directory exists to use the default config location",
+                    style("No config file found.").bold()
+                );
             }
             false
         }
@@ -116,10 +122,11 @@ fn main() -> Result<(), Box<dyn error::Error>> {
     let matches = app(crate_name!(), crate_description!(), crate_version!())
         .arg({
             let arg = Arg::with_name("config_file")
-                .short("c")
+                .short("C")
                 .long("config")
                 .value_name("PATH")
                 .takes_value(true)
+                .global(true)
                 .help("Configuration file to use");
             if let Some(ref config_file) = *config::CONFIG_FILE {
                 arg.default_value(&config_file)
@@ -133,6 +140,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                 .long("url")
                 .value_name("URL")
                 .takes_value(true)
+                .global(true)
                 .validator(is_url)
                 .help("JSON RPC URL for the solana cluster"),
         )
@@ -141,6 +149,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                 .short("k")
                 .long("keypair")
                 .value_name("PATH")
+                .global(true)
                 .takes_value(true)
                 .help("/path/to/id.json"),
         )
@@ -159,26 +168,9 @@ fn main() -> Result<(), Box<dyn error::Error>> {
         .subcommand(
             SubCommand::with_name("set")
                 .about("Set a wallet config setting")
-                .arg(
-                    Arg::with_name("url")
-                        .short("u")
-                        .long("url")
-                        .value_name("URL")
-                        .takes_value(true)
-                        .validator(is_url)
-                        .help("Set default JSON RPC URL to query"),
-                )
-                .arg(
-                    Arg::with_name("keypair")
-                        .short("k")
-                        .long("keypair")
-                        .value_name("PATH")
-                        .takes_value(true)
-                        .help("/path/to/id.json"),
-                )
                 .group(
                     ArgGroup::with_name("config_settings")
-                        .args(&["url", "keypair"])
+                        .args(&["json_rpc_url", "keypair"])
                         .multiple(true)
                         .required(true),
                 ),

--- a/cli/src/wallet.rs
+++ b/cli/src/wallet.rs
@@ -1683,22 +1683,21 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
         .subcommand(
             SubCommand::with_name("airdrop")
                 .about("Request lamports")
-        .arg(
-            Arg::with_name("drone_host")
-                .long("drone-host")
-                .value_name("HOST")
-                .takes_value(true)
-                .help("Drone host to use [default: the --url host]"),
-        )
-        .arg(
-            Arg::with_name("drone_port")
-                .long("drone-port")
-                .value_name("PORT")
-                .takes_value(true)
-                .default_value(solana_drone::drone::DRONE_PORT_STR)
-                .help("Drone port to use"),
-        )
-
+                .arg(
+                    Arg::with_name("drone_host")
+                        .long("drone-host")
+                        .value_name("HOST")
+                        .takes_value(true)
+                        .help("Drone host to use [default: the --url host]"),
+                )
+                .arg(
+                    Arg::with_name("drone_port")
+                        .long("drone-port")
+                        .value_name("PORT")
+                        .takes_value(true)
+                        .default_value(solana_drone::drone::DRONE_PORT_STR)
+                        .help("Drone port to use"),
+                )
                 .arg(
                     Arg::with_name("lamports")
                         .index(1)
@@ -1832,7 +1831,7 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                         .value_name("FILE")
                         .takes_value(true)
                         .help("Write the account data to this file"),
-                )
+                ),
         )
         .subcommand(
             SubCommand::with_name("show-vote-account")
@@ -1845,7 +1844,7 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                         .required(true)
                         .validator(is_pubkey_or_keypair)
                         .help("Vote account pubkey"),
-                )
+                ),
         )
         .subcommand(
             SubCommand::with_name("delegate-stake")
@@ -2045,14 +2044,13 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                 )
                 .arg(
                     Arg::with_name("storage_account_pubkey")
-                        .index(3)
+                        .index(2)
                         .value_name("STORAGE ACCOUNT PUBKEY")
                         .takes_value(true)
                         .required(true)
                         .validator(is_pubkey_or_keypair)
                         .help("Storage account address to redeem credits for"),
                 ))
-
         .subcommand(
             SubCommand::with_name("show-storage-account")
                 .about("Show the contents of a storage account")
@@ -2166,7 +2164,7 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                         .takes_value(true)
                         .default_value("10")
                         .help("Wait up to timeout seconds for transaction confirmation"),
-                )
+                ),
         )
         .subcommand(
             SubCommand::with_name("send-signature")


### PR DESCRIPTION
Fixes #5736

Evidence of success:
```bash
$ solana deactivate-stake --help
solana-deactivate-stake 
Deactivate the delegated stake from the stake account

USAGE:
    solana deactivate-stake [OPTIONS] <STAKE ACCOUNT KEYPAIR FILE> <PUBKEY>

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information

OPTIONS:
    -C, --config <PATH>     Configuration file to use [default: /Users/mvines/.config/solana/wallet/config.yml]
    -u, --url <URL>         JSON RPC URL for the solana cluster
    -k, --keypair <PATH>    /path/to/id.json

ARGS:
    <STAKE ACCOUNT KEYPAIR FILE>    Keypair file for the stake account, for signing the delegate transaction.
    <PUBKEY>                        The vote account to which the stake is currently delegated
```