### PR TITLE
Decrease instruction count in BPF Rust SDK entrypoint helper

### DIFF
--- a/sdk/bpf/rust/rust-utils/src/entrypoint.rs
+++ b/sdk/bpf/rust/rust-utils/src/entrypoint.rs
@@ -66,7 +66,7 @@ pub unsafe fn deserialize<'a>(
 
     // KeyedAccounts
 
-    let mut kas = Vec::new();
+    let mut kas = Vec::with_capacity(num_ka);
     for _ in 0..num_ka {
         let is_signer = {
             #[allow(clippy::cast_ptr_alignment)]


### PR DESCRIPTION
#### Problem
The account vec was not pre-allocated when deserializing keyed accounts. Each subsequent keyed account presumably required a new allocation when pushed, resulting in hundreds of unnecessary BPF instructions.

#### Summary of Changes
Initialize keyed account vec with a capacity

#### Details
This resulted in a 700-800 instruction decrease *per* keyed account.