### PR TITLE
Cleanup shreds to remove FirstShred data structure

### DIFF
--- a/core/src/blocktree.rs
+++ b/core/src/blocktree.rs
@@ -895,14 +895,9 @@ impl Blocktree {
             },
             |v| v,
         );
-        let mut shredder = Shredder::new(
-            current_slot,
-            Some(parent_slot),
-            0.0,
-            keypair,
-            start_index as u32,
-        )
-        .expect("Failed to create entry shredder");
+        let mut shredder =
+            Shredder::new(current_slot, parent_slot, 0.0, keypair, start_index as u32)
+                .expect("Failed to create entry shredder");
         let mut all_shreds = vec![];
         // Find all the entries for start_slot
         for entry in entries {
@@ -917,14 +912,9 @@ impl Blocktree {
                     .map(|s| bincode::deserialize(s).unwrap())
                     .collect();
                 all_shreds.extend(shreds);
-                shredder = Shredder::new(
-                    current_slot,
-                    Some(parent_slot),
-                    0.0,
-                    &Arc::new(Keypair::new()),
-                    0,
-                )
-                .expect("Failed to create entry shredder");
+                shredder =
+                    Shredder::new(current_slot, parent_slot, 0.0, &Arc::new(Keypair::new()), 0)
+                        .expect("Failed to create entry shredder");
             }
 
             if entry.borrow().is_tick() {
@@ -1654,7 +1644,7 @@ pub fn create_new_ledger(ledger_path: &Path, genesis_block: &GenesisBlock) -> Re
     let blocktree = Blocktree::open(ledger_path)?;
     let entries = crate::entry::create_ticks(ticks_per_slot, genesis_block.hash());
 
-    let mut shredder = Shredder::new(0, Some(0), 0.0, &Arc::new(Keypair::new()), 0)
+    let mut shredder = Shredder::new(0, 0, 0.0, &Arc::new(Keypair::new()), 0)
         .expect("Failed to create entry shredder");
     let last_hash = entries.last().unwrap().hash;
     bincode::serialize_into(&mut shredder, &entries)
@@ -1728,14 +1718,8 @@ pub fn entries_to_test_shreds(
     parent_slot: u64,
     is_full_slot: bool,
 ) -> Vec<Shred> {
-    let mut shredder = Shredder::new(
-        slot,
-        Some(parent_slot),
-        0.0,
-        &Arc::new(Keypair::new()),
-        0 as u32,
-    )
-    .expect("Failed to create entry shredder");
+    let mut shredder = Shredder::new(slot, parent_slot, 0.0, &Arc::new(Keypair::new()), 0 as u32)
+        .expect("Failed to create entry shredder");
 
     bincode::serialize_into(&mut shredder, &entries)
         .expect("Expect to write all entries to shreds");

--- a/core/src/broadcast_stage/broadcast_utils.rs
+++ b/core/src/broadcast_stage/broadcast_utils.rs
@@ -88,14 +88,9 @@ pub(super) fn entries_to_shreds(
         .for_each(|(i, entries_tuple)| {
             let (entries, _): (Vec<_>, Vec<_>) = entries_tuple.into_iter().unzip();
             //entries
-            let mut shredder = Shredder::new(
-                slot,
-                Some(parent_slot),
-                1.0,
-                keypair,
-                latest_shred_index as u32,
-            )
-            .expect("Expected to create a new shredder");
+            let mut shredder =
+                Shredder::new(slot, parent_slot, 1.0, keypair, latest_shred_index as u32)
+                    .expect("Expected to create a new shredder");
 
             bincode::serialize_into(&mut shredder, &entries)
                 .expect("Expect to write all entries to shreds");

--- a/core/src/chacha.rs
+++ b/core/src/chacha.rs
@@ -153,7 +153,7 @@ mod tests {
         hasher.hash(&buf[..size]);
 
         //  golden needs to be updated if blob stuff changes....
-        let golden: Hash = "EdYYuAuDPVY7DLNeCtPWAKipicx2KjsxqD2PZ7oxVmHE"
+        let golden: Hash = "HVUt3uy4it4NgbGgYiG9C3gnvxDCzkgqwzzSCM9N4sSt"
             .parse()
             .unwrap();
 

--- a/core/src/cluster_info.rs
+++ b/core/src/cluster_info.rs
@@ -1767,7 +1767,7 @@ mod tests {
     use crate::crds_value::CrdsValueLabel;
     use crate::repair_service::RepairType;
     use crate::result::Error;
-    use crate::shred::{FirstDataShred, Shred};
+    use crate::shred::{DataShred, Shred};
     use crate::test_tx::test_tx;
     use solana_sdk::hash::Hash;
     use solana_sdk::signature::{Keypair, KeypairUtil};
@@ -1927,7 +1927,7 @@ mod tests {
                 0,
             );
             assert!(rv.is_empty());
-            let mut shred = Shred::FirstInSlot(FirstDataShred::default());
+            let mut shred = Shred::FirstInSlot(DataShred::default());
             shred.set_slot(2);
             shred.set_index(1);
 

--- a/core/src/shred.rs
+++ b/core/src/shred.rs
@@ -40,7 +40,9 @@ impl Shred {
             | Shred::FirstInFECSet(s)
             | Shred::Data(s)
             | Shred::LastInFECSet(s)
-            | Shred::LastInSlot(s) => s.header.parent_offset as u64 + s.header.common_header.slot,
+            | Shred::LastInSlot(s) => {
+                u64::from(s.header.parent_offset) + s.header.common_header.slot
+            }
             Shred::Coding(_) => std::u64::MAX,
         }
     }
@@ -340,7 +342,7 @@ impl Shredder {
                     fec_rate
                 ),
             )))
-        } else if slot < parent || slot - parent > std::u16::MAX as u64 {
+        } else if slot < parent || slot - parent > u64::from(std::u16::MAX) {
             Err(Error::IO(IOError::new(
                 ErrorKind::Other,
                 format!(

--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -279,7 +279,7 @@ mod test {
 
     fn local_entries_to_shred(entries: Vec<Entry>, keypair: &Arc<Keypair>) -> Vec<Shred> {
         let mut shredder =
-            Shredder::new(0, Some(0), 0.0, keypair, 0).expect("Failed to create entry shredder");
+            Shredder::new(0, 0, 0.0, keypair, 0).expect("Failed to create entry shredder");
         bincode::serialize_into(&mut shredder, &entries)
             .expect("Expect to write all entries to shreds");
         shredder.finalize_slot();


### PR DESCRIPTION
#### Problem
FirstDataShred data structure is no longer required. Also parent slot information can be compressed to u16.

#### Summary of Changes
Cleaned up the code and changed parent slot to parent slot offset

Fixes #5605 
