### PR TITLE
Offload remaining confidence cache computation to separate thread

### DIFF
--- a/core/src/confidence.rs
+++ b/core/src/confidence.rs
@@ -1,0 +1,119 @@
+use std::collections::{HashMap, HashSet};
+
+#[derive(Debug, Default, PartialEq)]
+pub struct Confidence {
+    fork_stakes: u64,
+    total_stake: u64,
+    lockouts: u64,
+    stake_weighted_lockouts: u128,
+}
+
+impl Confidence {
+    pub fn new(fork_stakes: u64, total_stake: u64, lockouts: u64) -> Self {
+        Self {
+            fork_stakes,
+            total_stake,
+            lockouts,
+            stake_weighted_lockouts: 0,
+        }
+    }
+    pub fn new_with_stake_weighted(
+        fork_stakes: u64,
+        total_stake: u64,
+        lockouts: u64,
+        stake_weighted_lockouts: u128,
+    ) -> Self {
+        Self {
+            fork_stakes,
+            total_stake,
+            lockouts,
+            stake_weighted_lockouts,
+        }
+    }
+}
+
+#[derive(Default, PartialEq)]
+pub struct ForkConfidenceCache {
+    confidence: HashMap<u64, Confidence>,
+}
+
+impl ForkConfidenceCache {
+    pub fn cache_fork_confidence(
+        &mut self,
+        fork: u64,
+        fork_stakes: u64,
+        total_stake: u64,
+        lockouts: u64,
+    ) {
+        self.confidence
+            .entry(fork)
+            .and_modify(|entry| {
+                entry.fork_stakes = fork_stakes;
+                entry.total_stake = total_stake;
+                entry.lockouts = lockouts;
+            })
+            .or_insert_with(|| Confidence::new(fork_stakes, total_stake, lockouts));
+    }
+
+    pub fn cache_stake_weighted_lockouts(&mut self, fork: u64, stake_weighted_lockouts: u128) {
+        self.confidence
+            .entry(fork)
+            .and_modify(|entry| {
+                entry.stake_weighted_lockouts = stake_weighted_lockouts;
+            })
+            .or_insert(Confidence {
+                fork_stakes: 0,
+                total_stake: 0,
+                lockouts: 0,
+                stake_weighted_lockouts,
+            });
+    }
+
+    pub fn get_fork_confidence(&self, fork: u64) -> Option<&Confidence> {
+        self.confidence.get(&fork)
+    }
+
+    pub fn prune_confidence_cache(&mut self, ancestors: &HashMap<u64, HashSet<u64>>, root: u64) {
+        self.confidence
+            .retain(|slot, _| slot == &root || ancestors[&slot].contains(&root));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_fork_confidence_cache() {
+        let mut cache = ForkConfidenceCache::default();
+        let fork = 0;
+        assert!(cache.confidence.get(&fork).is_none());
+        cache.cache_fork_confidence(fork, 11, 12, 13);
+        assert_eq!(
+            cache.confidence.get(&fork).unwrap(),
+            &Confidence {
+                fork_stakes: 11,
+                total_stake: 12,
+                lockouts: 13,
+                stake_weighted_lockouts: 0,
+            }
+        );
+        // Ensure that {fork_stakes, total_stake, lockouts} and stake_weighted_lockouts
+        // can be updated separately
+        cache.cache_stake_weighted_lockouts(fork, 20);
+        assert_eq!(
+            cache.confidence.get(&fork).unwrap(),
+            &Confidence {
+                fork_stakes: 11,
+                total_stake: 12,
+                lockouts: 13,
+                stake_weighted_lockouts: 20,
+            }
+        );
+        cache.cache_fork_confidence(fork, 21, 22, 23);
+        assert_eq!(
+            cache.confidence.get(&fork).unwrap().stake_weighted_lockouts,
+            20,
+        );
+    }
+}

--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -304,7 +304,7 @@ impl Tower {
     pub fn aggregate_stake_lockouts(
         root: Option<u64>,
         ancestors: &HashMap<u64, HashSet<u64>>,
-        stake_lockouts: HashMap<u64, StakeLockout>,
+        stake_lockouts: &HashMap<u64, StakeLockout>,
     ) -> HashMap<u64, u128> {
         let mut stake_weighted_lockouts: HashMap<u64, u128> = HashMap::new();
         for (fork, lockout) in stake_lockouts.iter() {
@@ -562,7 +562,7 @@ mod test {
         .into_iter()
         .collect();
         let stake_weighted_lockouts =
-            Tower::aggregate_stake_lockouts(tower.root(), &ancestors, stakes);
+            Tower::aggregate_stake_lockouts(tower.root(), &ancestors, &stakes);
         assert!(stake_weighted_lockouts.get(&0).is_none());
         assert_eq!(*stake_weighted_lockouts.get(&1).unwrap(), 8 + 16 + 24);
         assert_eq!(*stake_weighted_lockouts.get(&2).unwrap(), 8 + 16);

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -13,6 +13,7 @@ pub mod chacha;
 #[cfg(cuda)]
 pub mod chacha_cuda;
 pub mod cluster_info_vote_listener;
+pub mod confidence;
 pub mod recycler;
 #[macro_use]
 pub mod contact_info;

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -5,6 +5,7 @@ use crate::blocktree::{Blocktree, CompletedSlotsReceiver};
 use crate::blocktree_processor::{self, BankForksInfo};
 use crate::broadcast_stage::BroadcastStageType;
 use crate::cluster_info::{ClusterInfo, Node};
+use crate::confidence::ForkConfidenceCache;
 use crate::contact_info::ContactInfo;
 use crate::erasure::ErasureConfig;
 use crate::gossip_service::{discover_cluster, GossipService};
@@ -301,6 +302,7 @@ impl Validator {
             Some(voting_keypair)
         };
 
+        let fork_confidence_cache = Arc::new(RwLock::new(ForkConfidenceCache::default()));
         let tvu = Tvu::new(
             vote_account,
             voting_keypair,
@@ -318,6 +320,7 @@ impl Validator {
             &leader_schedule_cache,
             &exit,
             completed_slots_receiver,
+            fork_confidence_cache,
         );
 
         if config.dev_sigverify_disabled {

--- a/core/tests/tvu.rs
+++ b/core/tests/tvu.rs
@@ -5,6 +5,7 @@ use log::*;
 use solana_core::banking_stage::create_test_recorder;
 use solana_core::blocktree::{create_new_tmp_ledger, Blocktree};
 use solana_core::cluster_info::{ClusterInfo, Node};
+use solana_core::confidence::ForkConfidenceCache;
 use solana_core::entry::next_entry_mut;
 use solana_core::entry::EntrySlice;
 use solana_core::genesis_utils::{create_genesis_block_with_leader, GenesisBlockInfo};
@@ -120,6 +121,7 @@ fn test_replay() {
     {
         let (poh_service_exit, poh_recorder, poh_service, _entry_receiver) =
             create_test_recorder(&working_bank, &blocktree);
+        let fork_confidence_cache = Arc::new(RwLock::new(ForkConfidenceCache::default()));
         let tvu = Tvu::new(
             &voting_keypair.pubkey(),
             Some(&Arc::new(voting_keypair)),
@@ -144,6 +146,7 @@ fn test_replay() {
             &leader_schedule_cache,
             &exit,
             completed_slots_receiver,
+            fork_confidence_cache,
         );
 
         let mut mint_ref_balance = mint_balance;


### PR DESCRIPTION
#### Problem
1) Some remaining confidence cache work can potentially cause replay_stage to slow down as number of banks in history grows large

2) Ancestors, an expensive computation, is recalculated for confidence metrics.

3) Accessing confidence cache locks bank forks
#### Summary of Changes
Offload work to separate aggregation thread, reuse ancestors from earlier in replay_stage, move confidence cache out of bank forks

Fixes #
