### PR TITLE
Confirm validator ports are reachable by the entrypoint at startup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3621,13 +3621,17 @@ name = "solana-netutil"
 version = "0.19.0-pre0"
 dependencies = [
  "bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "nix 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
  "socket2 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-logger 0.19.0-pre0",
  "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/netutil/Cargo.toml
+++ b/netutil/Cargo.toml
@@ -10,13 +10,17 @@ edition = "2018"
 
 [dependencies]
 bincode = "1.1.4"
+bytes = "0.4"
 clap = "2.33.0"
 log = "0.4.8"
 nix = "0.15.0"
 rand = "0.6.1"
+serde = "1.0.99"
+serde_derive = "1.0.99"
 socket2 = "0.3.11"
 solana-logger = { path = "../logger", version = "0.19.0-pre0" }
 tokio = "0.1"
+tokio-codec = "0.1"
 
 [lib]
 name = "solana_netutil"

--- a/netutil/src/ip_echo_server.rs
+++ b/netutil/src/ip_echo_server.rs
@@ -1,11 +1,34 @@
+use bytes::Bytes;
 use log::*;
+use serde_derive::{Deserialize, Serialize};
+use std::io;
 use std::net::SocketAddr;
+use std::time::Duration;
 use tokio;
 use tokio::net::TcpListener;
-use tokio::prelude::{Future, Stream};
+use tokio::prelude::*;
 use tokio::runtime::Runtime;
+use tokio_codec::{BytesCodec, Decoder};
 
 pub type IpEchoServer = Runtime;
+
+#[derive(Serialize, Deserialize, Default)]
+pub(crate) struct IpEchoServerMessage {
+    tcp_ports: [u16; 4], // Fixed size list of ports to avoid vec serde
+    udp_ports: [u16; 4], // Fixed size list of ports to avoid vec serde
+}
+
+impl IpEchoServerMessage {
+    pub fn new(tcp_ports: &[u16], udp_ports: &[u16]) -> Self {
+        let mut msg = Self::default();
+        assert!(tcp_ports.len() <= msg.tcp_ports.len());
+        assert!(udp_ports.len() <= msg.udp_ports.len());
+
+        msg.tcp_ports[..tcp_ports.len()].copy_from_slice(tcp_ports);
+        msg.udp_ports[..udp_ports.len()].copy_from_slice(udp_ports);
+        msg
+    }
+}
 
 /// Starts a simple TCP server on the given port that echos the IP address of any peer that
 /// connects.  Used by |get_public_ip_addr|
@@ -19,23 +42,96 @@ pub fn ip_echo_server(port: u16) -> IpEchoServer {
         .incoming()
         .map_err(|err| warn!("accept failed: {:?}", err))
         .for_each(move |socket| {
-            let ip = socket
-                .peer_addr()
-                .and_then(|peer_addr| {
-                    bincode::serialize(&peer_addr.ip()).map_err(|err| {
-                        std::io::Error::new(
-                            std::io::ErrorKind::Other,
-                            format!("Failed to serialize: {:?}", err),
-                        )
+            let ip = socket.peer_addr().expect("Expect peer_addr()").ip();
+            info!("connection from {:?}", ip);
+
+            let framed = BytesCodec::new().framed(socket);
+            let (writer, reader) = framed.split();
+
+            let processor = reader
+                .and_then(move |bytes| {
+                    bincode::deserialize::<IpEchoServerMessage>(&bytes).or_else(|err| {
+                        Err(io::Error::new(
+                            io::ErrorKind::Other,
+                            format!("Failed to deserialize IpEchoServerMessage: {:?}", err),
+                        ))
                     })
                 })
-                .unwrap_or_else(|_| vec![]);
+                .and_then(move |msg| {
+                    // Fire a datagram at each non-zero UDP port
+                    if !msg.udp_ports.is_empty() {
+                        match std::net::UdpSocket::bind("0.0.0.0:0") {
+                            Ok(udp_socket) => {
+                                for udp_port in &msg.udp_ports {
+                                    if *udp_port != 0 {
+                                        match udp_socket
+                                            .send_to(&[0], SocketAddr::from((ip, *udp_port)))
+                                        {
+                                            Ok(_) => debug!("Successful send_to udp/{}", udp_port),
+                                            Err(err) => {
+                                                info!("Failed to send_to udp/{}: {}", udp_port, err)
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                            Err(err) => {
+                                warn!("Failed to bind local udp socket: {}", err);
+                            }
+                        }
+                    }
 
-            let write_future = tokio::io::write_all(socket, ip)
-                .map_err(|err| warn!("write error: {:?}", err))
-                .map(|_| ());
+                    // Try to connect to each non-zero TCP port
+                    let tcp_futures: Vec<_> = msg
+                        .tcp_ports
+                        .iter()
+                        .filter_map(|tcp_port| {
+                            let tcp_port = *tcp_port;
+                            if tcp_port == 0 {
+                                None
+                            } else {
+                                Some(
+                                    tokio::net::TcpStream::connect(&SocketAddr::new(ip, tcp_port))
+                                        .and_then(move |tcp_stream| {
+                                            debug!("Connection established to tcp/{}", tcp_port);
+                                            let _ = tcp_stream.shutdown(std::net::Shutdown::Both);
+                                            Ok(())
+                                        })
+                                        .timeout(Duration::from_secs(5))
+                                        .or_else(move |err| {
+                                            Err(io::Error::new(
+                                                io::ErrorKind::Other,
+                                                format!(
+                                                    "Connection timeout to {}: {:?}",
+                                                    tcp_port, err
+                                                ),
+                                            ))
+                                        }),
+                                )
+                            }
+                        })
+                        .collect();
+                    future::join_all(tcp_futures)
+                })
+                .and_then(move |_| {
+                    let ip = bincode::serialize(&ip).unwrap_or_else(|err| {
+                        warn!("Failed to serialize: {:?}", err);
+                        vec![]
+                    });
+                    Ok(Bytes::from(ip))
+                });
 
-            tokio::spawn(write_future)
+            let connection = writer
+                .send_all(processor)
+                .timeout(Duration::from_secs(5))
+                .then(|result| {
+                    if let Err(err) = result {
+                        info!("Session failed: {:?}", err);
+                    }
+                    Ok(())
+                });
+
+            tokio::spawn(connection)
         });
 
     let mut rt = Runtime::new().expect("Failed to create Runtime");


### PR DESCRIPTION
#### Problem
Misconfigured routers/NATs produce misleading and hard to debug errors

#### Summary of Changes
Upon first connecting to the cluster entrypoint, ask it to connect back on a small set of TCP and UDP ports to confirm the validator is actually reachable

Fixes #5223
Fixes #3915
