### PR TITLE
ThinClient internal name grooming

### DIFF
--- a/bench-tps/src/bench.rs
+++ b/bench-tps/src/bench.rs
@@ -404,7 +404,7 @@ fn do_tx_transfers<T: Client>(
             println!(
                 "Transferring 1 unit {} times... to {}",
                 txs0.len(),
-                client.as_ref().transactions_addr(),
+                client.as_ref().tpu_addr(),
             );
             let tx_len = txs0.len();
             let transfer_start = Instant::now();

--- a/client/src/perf_utils.rs
+++ b/client/src/perf_utils.rs
@@ -79,7 +79,7 @@ pub fn sample_txs<T>(
             sample_stats
                 .write()
                 .unwrap()
-                .push((client.transactions_addr(), stats));
+                .push((client.tpu_addr(), stats));
             return;
         }
         sleep(Duration::from_secs(sample_period));

--- a/core/src/gossip_service.rs
+++ b/core/src/gossip_service.rs
@@ -139,12 +139,12 @@ pub fn get_multi_client(nodes: &[ContactInfo]) -> (ThinClient, usize) {
         .filter_map(ContactInfo::valid_client_facing_addr)
         .map(|addrs| addrs)
         .collect();
-    let rpcs: Vec<_> = addrs.iter().map(|addr| addr.0).collect();
-    let tpus: Vec<_> = addrs.iter().map(|addr| addr.1).collect();
+    let rpc_addrs: Vec<_> = addrs.iter().map(|addr| addr.0).collect();
+    let tpu_addrs: Vec<_> = addrs.iter().map(|addr| addr.1).collect();
     let (_, transactions_socket) = solana_netutil::bind_in_range(FULLNODE_PORT_RANGE).unwrap();
-    let num_nodes = tpus.len();
+    let num_nodes = tpu_addrs.len();
     (
-        ThinClient::new_from_addrs(tpus, transactions_socket, rpcs),
+        ThinClient::new_from_addrs(rpc_addrs, tpu_addrs, transactions_socket),
         num_nodes,
     )
 }

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -585,9 +585,9 @@ impl RpcSol for RpcSolImpl {
         })?;
 
         let transactions_socket = UdpSocket::bind("0.0.0.0:0").unwrap();
-        let transactions_addr = get_tpu_addr(&meta.cluster_info)?;
+        let tpu_addr = get_tpu_addr(&meta.cluster_info)?;
         transactions_socket
-            .send_to(&data, transactions_addr)
+            .send_to(&data, tpu_addr)
             .map_err(|err| {
                 info!("request_airdrop: send_to error: {:?}", err);
                 Error::internal_error()
@@ -628,10 +628,10 @@ impl RpcSol for RpcSolImpl {
             return Err(Error::invalid_request());
         }
         let transactions_socket = UdpSocket::bind("0.0.0.0:0").unwrap();
-        let transactions_addr = get_tpu_addr(&meta.cluster_info)?;
-        trace!("send_transaction: leader is {:?}", &transactions_addr);
+        let tpu_addr = get_tpu_addr(&meta.cluster_info)?;
+        trace!("send_transaction: leader is {:?}", &tpu_addr);
         transactions_socket
-            .send_to(&data, transactions_addr)
+            .send_to(&data, tpu_addr)
             .map_err(|err| {
                 info!("send_transaction: send_to error: {:?}", err);
                 Error::internal_error()

--- a/runtime/src/bank_client.rs
+++ b/runtime/src/bank_client.rs
@@ -24,7 +24,7 @@ pub struct BankClient {
 }
 
 impl Client for BankClient {
-    fn transactions_addr(&self) -> String {
+    fn tpu_addr(&self) -> String {
         "Local BankClient".to_string()
     }
 }

--- a/sdk/src/client.rs
+++ b/sdk/src/client.rs
@@ -19,7 +19,7 @@ use crate::transport::Result;
 use std::io;
 
 pub trait Client: SyncClient + AsyncClient {
-    fn transactions_addr(&self) -> String;
+    fn tpu_addr(&self) -> String;
 }
 
 pub trait SyncClient {


### PR DESCRIPTION
Nodes can advertise a RPC port that they don't actually respond on (bad router config?).  This causes bench-tps to fail in confusing ways as it randomly distributes its load across all the nodes it knows about.

Filtering out those bad nodes should help with this somewhat


Fixes #5719
