### PR TITLE
Remove unnecessary erasure config references

### DIFF
--- a/core/src/broadcast_stage.rs
+++ b/core/src/broadcast_stage.rs
@@ -4,7 +4,6 @@ use self::fail_entry_verification_broadcast_run::FailEntryVerificationBroadcastR
 use self::standard_broadcast_run::StandardBroadcastRun;
 use crate::blocktree::Blocktree;
 use crate::cluster_info::{ClusterInfo, ClusterInfoError};
-use crate::erasure::ErasureConfig;
 use crate::poh_recorder::WorkingBankEntries;
 use crate::result::{Error, Result};
 use crate::service::Service;
@@ -44,7 +43,6 @@ impl BroadcastStageType {
         receiver: Receiver<WorkingBankEntries>,
         exit_sender: &Arc<AtomicBool>,
         blocktree: &Arc<Blocktree>,
-        erasure_config: &ErasureConfig,
     ) -> BroadcastStage {
         match self {
             BroadcastStageType::Standard => BroadcastStage::new(
@@ -54,7 +52,6 @@ impl BroadcastStageType {
                 exit_sender,
                 blocktree,
                 StandardBroadcastRun::new(),
-                erasure_config,
             ),
 
             BroadcastStageType::FailEntryVerification => BroadcastStage::new(
@@ -64,7 +61,6 @@ impl BroadcastStageType {
                 exit_sender,
                 blocktree,
                 FailEntryVerificationBroadcastRun::new(),
-                erasure_config,
             ),
 
             BroadcastStageType::BroadcastFakeBlobs => BroadcastStage::new(
@@ -74,7 +70,6 @@ impl BroadcastStageType {
                 exit_sender,
                 blocktree,
                 BroadcastFakeBlobsRun::new(0),
-                erasure_config,
             ),
         }
     }
@@ -161,7 +156,6 @@ impl BroadcastStage {
         exit_sender: &Arc<AtomicBool>,
         blocktree: &Arc<Blocktree>,
         broadcast_stage_run: impl BroadcastRun + Send + 'static,
-        _erasure_config: &ErasureConfig,
     ) -> Self {
         let blocktree = blocktree.clone();
         let exit_sender = exit_sender.clone();
@@ -249,7 +243,6 @@ mod test {
             &exit_sender,
             &blocktree,
             StandardBroadcastRun::new(),
-            &ErasureConfig::default(),
         );
 
         MockBroadcastStage {

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -6,7 +6,6 @@ use crate::blocktree::Blocktree;
 use crate::broadcast_stage::{BroadcastStage, BroadcastStageType};
 use crate::cluster_info::ClusterInfo;
 use crate::cluster_info_vote_listener::ClusterInfoVoteListener;
-use crate::erasure::ErasureConfig;
 use crate::fetch_stage::FetchStage;
 use crate::poh_recorder::{PohRecorder, WorkingBankEntries};
 use crate::service::Service;
@@ -38,7 +37,6 @@ impl Tpu {
         sigverify_disabled: bool,
         blocktree: &Arc<Blocktree>,
         broadcast_type: &BroadcastStageType,
-        erasure_config: &ErasureConfig,
         exit: &Arc<AtomicBool>,
     ) -> Self {
         let (packet_sender, packet_receiver) = channel();
@@ -76,7 +74,6 @@ impl Tpu {
             entry_receiver,
             &exit,
             blocktree,
-            erasure_config,
         );
 
         Self {

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -7,7 +7,6 @@ use crate::broadcast_stage::BroadcastStageType;
 use crate::cluster_info::{ClusterInfo, Node};
 use crate::confidence::ForkConfidenceCache;
 use crate::contact_info::ContactInfo;
-use crate::erasure::ErasureConfig;
 use crate::gossip_service::{discover_cluster, GossipService};
 use crate::leader_schedule_cache::LeaderScheduleCache;
 use crate::poh_recorder::PohRecorder;
@@ -49,7 +48,6 @@ pub struct ValidatorConfig {
     pub snapshot_config: Option<SnapshotConfig>,
     pub max_ledger_slots: Option<u64>,
     pub broadcast_stage_type: BroadcastStageType,
-    pub erasure_config: ErasureConfig,
 }
 
 impl Default for ValidatorConfig {
@@ -66,7 +64,6 @@ impl Default for ValidatorConfig {
             rpc_config: JsonRpcConfig::default(),
             snapshot_config: None,
             broadcast_stage_type: BroadcastStageType::Standard,
-            erasure_config: ErasureConfig::default(),
         }
     }
 }
@@ -337,7 +334,6 @@ impl Validator {
             config.dev_sigverify_disabled,
             &blocktree,
             &config.broadcast_stage_type,
-            &config.erasure_config,
             &exit,
         );
 


### PR DESCRIPTION
#### Problem
Erasure config is being constructed in validator.rs and passed around. It's not required anymore

#### Summary of Changes
Remove the references.

