### PR TITLE
multinode-demo/validator.sh: Correct `new_genesis_block()` logic

### DIFF
--- a/multinode-demo/validator.sh
+++ b/multinode-demo/validator.sh
@@ -210,7 +210,7 @@ new_genesis_block() {
     rm -f "$ledger_dir"/new-genesis.tar.bz2
   }
   if [[ -f "$ledger_dir"/new-genesis.tar.bz2 ]]; then
-    ! diff -q "$ledger_dir"/new-genesis.tar.bz2 "$ledger_dir"/genesis.tar.bz2 >/dev/null 2>&1
+    diff -q "$ledger_dir"/new-genesis.tar.bz2 "$ledger_dir"/genesis.tar.bz2 >/dev/null 2>&1 && false
   else
     false
   fi

--- a/multinode-demo/validator.sh
+++ b/multinode-demo/validator.sh
@@ -207,8 +207,13 @@ new_genesis_block() {
     curl -f "$rpc_url"/genesis.tar.bz2 -o "$ledger_dir"/new-genesis.tar.bz2
   ) || {
     echo "Error: failed to fetch new genesis ledger"
+    rm -f "$ledger_dir"/new-genesis.tar.bz2
   }
-  ! diff -q "$ledger_dir"/new-genesis.tar.bz2 "$ledger_dir"/genesis.tar.bz2 >/dev/null 2>&1
+  if [[ -f "$ledger_dir"/new-genesis.tar.bz2 ]]; then
+    ! diff -q "$ledger_dir"/new-genesis.tar.bz2 "$ledger_dir"/genesis.tar.bz2 >/dev/null 2>&1
+  else
+    false
+  fi
 }
 
 set -e


### PR DESCRIPTION
#### Problem

`new_genesis_block()` returns `true` when the attempt to retrieve a new tarball fails, unnecessarily killing the node.

#### Summary of Changes

Change logic to only attempt to `diff` the new and old tarballs if `curl` exits success, return `false` otherwise