### PR TITLE
add stake and vote errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3867,6 +3867,8 @@ version = "0.19.0-pre0"
 dependencies = [
  "bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-derive 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-logger 0.19.0-pre0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3738,6 +3738,8 @@ version = "0.19.0-pre0"
 dependencies = [
  "bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-derive 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/cli/src/wallet.rs
+++ b/cli/src/wallet.rs
@@ -733,8 +733,9 @@ fn process_deactivate_stake_account(
         recent_blockhash,
     );
     check_account_for_fee(rpc_client, config, &fee_calculator, &tx.message)?;
-    let signature_str = rpc_client
+    let result = rpc_client
         .send_and_confirm_transaction(&mut tx, &[&config.keypair, &stake_account_keypair])?;
+    let signature_str = log_instruction_custom_error::<StakeError>(result)?;
     Ok(signature_str.to_string())
 }
 
@@ -812,7 +813,7 @@ fn process_delegate_stake(
 
     let result = rpc_client
         .send_and_confirm_transaction(&mut tx, &[&config.keypair, &stake_account_keypair]);
-    let signature_str = log_instruction_custom_error::<SystemError>(result)?;
+    let signature_str = log_instruction_custom_error::<StakeError>(result)?;
     Ok(signature_str.to_string())
 }
 
@@ -838,8 +839,9 @@ fn process_withdraw_stake(
     );
     check_account_for_fee(rpc_client, config, &fee_calculator, &tx.message)?;
 
-    let signature_str = rpc_client
+    let result = rpc_client
         .send_and_confirm_transaction(&mut tx, &[&config.keypair, &stake_account_keypair])?;
+    let signature_str = log_instruction_custom_error::<StakeError>(result)?;
     Ok(signature_str.to_string())
 }
 
@@ -861,7 +863,8 @@ fn process_redeem_vote_credits(
         recent_blockhash,
     );
     check_account_for_fee(rpc_client, config, &fee_calculator, &tx.message)?;
-    let signature_str = rpc_client.send_and_confirm_transaction(&mut tx, &[&config.keypair])?;
+    let result = rpc_client.send_and_confirm_transaction(&mut tx, &[&config.keypair])?;
+    let signature_str = log_instruction_custom_error::<StakeError>(result)?;
     Ok(signature_str.to_string())
 }
 

--- a/cli/src/wallet.rs
+++ b/cli/src/wallet.rs
@@ -28,7 +28,7 @@ use solana_sdk::signature::{read_keypair, Keypair, KeypairUtil, Signature};
 use solana_sdk::system_instruction::SystemError;
 use solana_sdk::system_transaction;
 use solana_sdk::transaction::{Transaction, TransactionError};
-use solana_stake_api::stake_instruction;
+use solana_stake_api::{stake_instruction, stake_state::StakeError};
 use solana_storage_api::storage_instruction;
 use solana_vote_api::vote_instruction;
 use solana_vote_api::vote_state::VoteState;
@@ -586,8 +586,7 @@ fn process_create_vote_account(
     let mut tx = Transaction::new_signed_instructions(&[&config.keypair], ixs, recent_blockhash);
     check_account_for_fee(rpc_client, config, &fee_calculator, &tx.message)?;
     let result = rpc_client.send_and_confirm_transaction(&mut tx, &[&config.keypair]);
-    let signature_str = log_instruction_custom_error::<SystemError>(result)?;
-    Ok(signature_str.to_string())
+    log_instruction_custom_error::<SystemError>(result)
 }
 
 fn process_authorize_voter(
@@ -734,9 +733,8 @@ fn process_deactivate_stake_account(
     );
     check_account_for_fee(rpc_client, config, &fee_calculator, &tx.message)?;
     let result = rpc_client
-        .send_and_confirm_transaction(&mut tx, &[&config.keypair, &stake_account_keypair])?;
-    let signature_str = log_instruction_custom_error::<StakeError>(result)?;
-    Ok(signature_str.to_string())
+        .send_and_confirm_transaction(&mut tx, &[&config.keypair, &stake_account_keypair]);
+    log_instruction_custom_error::<StakeError>(result)
 }
 
 fn process_delegate_stake(
@@ -813,8 +811,7 @@ fn process_delegate_stake(
 
     let result = rpc_client
         .send_and_confirm_transaction(&mut tx, &[&config.keypair, &stake_account_keypair]);
-    let signature_str = log_instruction_custom_error::<StakeError>(result)?;
-    Ok(signature_str.to_string())
+    log_instruction_custom_error::<StakeError>(result)
 }
 
 fn process_withdraw_stake(
@@ -840,9 +837,8 @@ fn process_withdraw_stake(
     check_account_for_fee(rpc_client, config, &fee_calculator, &tx.message)?;
 
     let result = rpc_client
-        .send_and_confirm_transaction(&mut tx, &[&config.keypair, &stake_account_keypair])?;
-    let signature_str = log_instruction_custom_error::<StakeError>(result)?;
-    Ok(signature_str.to_string())
+        .send_and_confirm_transaction(&mut tx, &[&config.keypair, &stake_account_keypair]);
+    log_instruction_custom_error::<StakeError>(result)
 }
 
 fn process_redeem_vote_credits(
@@ -863,9 +859,8 @@ fn process_redeem_vote_credits(
         recent_blockhash,
     );
     check_account_for_fee(rpc_client, config, &fee_calculator, &tx.message)?;
-    let result = rpc_client.send_and_confirm_transaction(&mut tx, &[&config.keypair])?;
-    let signature_str = log_instruction_custom_error::<StakeError>(result)?;
-    Ok(signature_str.to_string())
+    let result = rpc_client.send_and_confirm_transaction(&mut tx, &[&config.keypair]);
+    log_instruction_custom_error::<StakeError>(result)
 }
 
 fn process_show_stake_account(
@@ -934,8 +929,7 @@ fn process_create_replicator_storage_account(
     let mut tx = Transaction::new_signed_instructions(&[&config.keypair], ixs, recent_blockhash);
     check_account_for_fee(rpc_client, config, &fee_calculator, &tx.message)?;
     let result = rpc_client.send_and_confirm_transaction(&mut tx, &[&config.keypair]);
-    let signature_str = log_instruction_custom_error::<SystemError>(result)?;
-    Ok(signature_str.to_string())
+    log_instruction_custom_error::<SystemError>(result)
 }
 
 fn process_create_validator_storage_account(
@@ -961,8 +955,7 @@ fn process_create_validator_storage_account(
     let mut tx = Transaction::new_signed_instructions(&[&config.keypair], ixs, recent_blockhash);
     check_account_for_fee(rpc_client, config, &fee_calculator, &tx.message)?;
     let result = rpc_client.send_and_confirm_transaction(&mut tx, &[&config.keypair]);
-    let signature_str = log_instruction_custom_error::<SystemError>(result)?;
-    Ok(signature_str.to_string())
+    log_instruction_custom_error::<SystemError>(result)
 }
 
 fn process_claim_storage_reward(
@@ -1107,8 +1100,7 @@ fn process_pay(
         let mut tx = system_transaction::transfer(&config.keypair, to, lamports, blockhash);
         check_account_for_fee(rpc_client, config, &fee_calculator, &tx.message)?;
         let result = rpc_client.send_and_confirm_transaction(&mut tx, &[&config.keypair]);
-        let signature_str = log_instruction_custom_error::<SystemError>(result)?;
-        Ok(signature_str.to_string())
+        log_instruction_custom_error::<SystemError>(result)
     } else if *witnesses == None {
         let dt = timestamp.unwrap();
         let dt_pubkey = match timestamp_pubkey {
@@ -1185,8 +1177,7 @@ fn process_cancel(rpc_client: &RpcClient, config: &WalletConfig, pubkey: &Pubkey
     let mut tx = Transaction::new_signed_instructions(&[&config.keypair], vec![ix], blockhash);
     check_account_for_fee(rpc_client, config, &fee_calculator, &tx.message)?;
     let result = rpc_client.send_and_confirm_transaction(&mut tx, &[&config.keypair]);
-    let signature_str = log_instruction_custom_error::<BudgetError>(result)?;
-    Ok(signature_str.to_string())
+    log_instruction_custom_error::<BudgetError>(result)
 }
 
 fn process_get_slot(rpc_client: &RpcClient) -> ProcessResult {
@@ -1212,9 +1203,7 @@ fn process_time_elapsed(
     let mut tx = Transaction::new_signed_instructions(&[&config.keypair], vec![ix], blockhash);
     check_account_for_fee(rpc_client, config, &fee_calculator, &tx.message)?;
     let result = rpc_client.send_and_confirm_transaction(&mut tx, &[&config.keypair]);
-    let signature_str = log_instruction_custom_error::<BudgetError>(result)?;
-
-    Ok(signature_str.to_string())
+    log_instruction_custom_error::<BudgetError>(result)
 }
 
 fn process_witness(
@@ -1229,9 +1218,7 @@ fn process_witness(
     let mut tx = Transaction::new_signed_instructions(&[&config.keypair], vec![ix], blockhash);
     check_account_for_fee(rpc_client, config, &fee_calculator, &tx.message)?;
     let result = rpc_client.send_and_confirm_transaction(&mut tx, &[&config.keypair]);
-    let signature_str = log_instruction_custom_error::<BudgetError>(result)?;
-
-    Ok(signature_str.to_string())
+    log_instruction_custom_error::<BudgetError>(result)
 }
 
 fn process_get_version(rpc_client: &RpcClient, config: &WalletConfig) -> ProcessResult {
@@ -1637,7 +1624,7 @@ pub fn request_and_confirm_airdrop(
     drone_addr: &SocketAddr,
     to_pubkey: &Pubkey,
     lamports: u64,
-) -> Result<(), Box<dyn error::Error>> {
+) -> ProcessResult {
     let (blockhash, _fee_calculator) = rpc_client.get_recent_blockhash()?;
     let keypair = {
         let mut retries = 5;
@@ -1652,8 +1639,7 @@ pub fn request_and_confirm_airdrop(
     }?;
     let mut tx = keypair.airdrop_transaction();
     let result = rpc_client.send_and_confirm_transaction(&mut tx, &[&keypair]);
-    log_instruction_custom_error::<SystemError>(result)?;
-    Ok(())
+    log_instruction_custom_error::<SystemError>(result)
 }
 
 fn log_instruction_custom_error<E>(result: Result<String, ClientError>) -> ProcessResult

--- a/cli/src/wallet.rs
+++ b/cli/src/wallet.rs
@@ -1665,12 +1665,7 @@ where
         )) = err
         {
             if let Some(specific_error) = E::decode_custom_error_to_enum(code) {
-                error!(
-                    "{:?}: {}::{:?}",
-                    err,
-                    specific_error.type_of(),
-                    specific_error
-                );
+                error!("{}::{:?}", E::type_of(), specific_error);
                 Err(specific_error)?
             }
         }

--- a/programs/budget_api/src/budget_state.rs
+++ b/programs/budget_api/src/budget_state.rs
@@ -12,7 +12,7 @@ pub enum BudgetError {
 }
 
 impl<T> DecodeError<T> for BudgetError {
-    fn type_of(&self) -> &'static str {
+    fn type_of() -> &'static str {
         "BudgetError"
     }
 }

--- a/programs/stake_api/Cargo.toml
+++ b/programs/stake_api/Cargo.toml
@@ -11,6 +11,8 @@ edition = "2018"
 [dependencies]
 bincode = "1.1.4"
 log = "0.4.8"
+num-derive = "0.2"
+num-traits = "0.2"
 rand = "0.6.5"
 serde = "1.0.99"
 serde_derive = "1.0.99"

--- a/programs/stake_api/src/stake_state.rs
+++ b/programs/stake_api/src/stake_state.rs
@@ -1412,11 +1412,18 @@ mod tests {
             Err(StakeError::NoCreditsToRedeem.into())
         );
 
-        let err: InstructionError = StakeError::NoCreditsToRedeem.into();
-        if let InstructionError::CustomError(code) = err {
-            let specific_error: StakeError = StakeError::decode_custom_error_to_enum(code).unwrap();
-            eprintln!("{:?}: {}::{:?}", err, StakeError::type_of(), specific_error);
+        use num_traits::FromPrimitive;
+        fn foo<T>(err: InstructionError)
+        where
+            T: 'static + std::error::Error + DecodeError<T> + FromPrimitive,
+        {
+            if let InstructionError::CustomError(code) = err {
+                let specific_error: T = T::decode_custom_error_to_enum(code).unwrap();
+                eprintln!("{:?}: {}::{:?}", err, T::type_of(), specific_error);
+            }
         }
+        let err: InstructionError = StakeError::NoCreditsToRedeem.into();
+        foo::<StakeError>(err);
 
         // in this call, we've swapped rewards and vote, deserialization of rewards_pool fails
         assert_eq!(

--- a/programs/stake_api/src/stake_state.rs
+++ b/programs/stake_api/src/stake_state.rs
@@ -58,11 +58,12 @@ pub enum StakeError {
     NoCreditsToRedeem,
 }
 
-impl<T> DecodeError<T> for StakeError {
-    fn type_of(&self) -> &'static str {
+impl<E> DecodeError<E> for StakeError {
+    fn type_of() -> &'static str {
         "StakeError"
     }
 }
+
 impl Into<InstructionError> for StakeError {
     fn into(self) -> InstructionError {
         InstructionError::CustomError(self as u32)
@@ -72,10 +73,7 @@ impl Into<InstructionError> for StakeError {
 impl std::fmt::Display for StakeError {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
-            StakeError::NoCreditsToRedeem => write!(
-                f,
-                "StakeError::NoCreditsToRedeem not enough credits to redeem"
-            ),
+            StakeError::NoCreditsToRedeem => write!(f, "not enough credits to redeem"),
         }
     }
 }
@@ -1416,15 +1414,8 @@ mod tests {
 
         let err: InstructionError = StakeError::NoCreditsToRedeem.into();
         if let InstructionError::CustomError(code) = err {
-            let specific_error: Option<StakeError> = StakeError::decode_custom_error_to_enum(code);
-            if let Some(specific_error) = specific_error {
-                eprintln!(
-                    "{:?}: {}::{:?}",
-                    err,
-                    specific_error.type_of(),
-                    specific_error
-                );
-            }
+            let specific_error: StakeError = StakeError::decode_custom_error_to_enum(code).unwrap();
+            eprintln!("{:?}: {}::{:?}", err, StakeError::type_of(), specific_error);
         }
 
         // in this call, we've swapped rewards and vote, deserialization of rewards_pool fails

--- a/programs/stake_api/src/stake_state.rs
+++ b/programs/stake_api/src/stake_state.rs
@@ -1419,7 +1419,13 @@ mod tests {
         {
             if let InstructionError::CustomError(code) = err {
                 let specific_error: T = T::decode_custom_error_to_enum(code).unwrap();
-                eprintln!("{:?}: {}::{:?}", err, T::type_of(), specific_error);
+                eprintln!(
+                    "{:?}: {}::{:?} - {}",
+                    err,
+                    T::type_of(),
+                    specific_error,
+                    specific_error
+                );
             }
         }
         let err: InstructionError = StakeError::NoCreditsToRedeem.into();

--- a/programs/stake_api/src/stake_state.rs
+++ b/programs/stake_api/src/stake_state.rs
@@ -4,11 +4,13 @@
 //! * own mining pools
 
 use crate::{config::Config, id};
+use num_derive::FromPrimitive;
 use serde_derive::{Deserialize, Serialize};
 use solana_sdk::{
     account::{Account, KeyedAccount},
     account_utils::State,
     instruction::InstructionError,
+    instruction_processor_utils::DecodeError,
     pubkey::Pubkey,
     sysvar::{
         self,
@@ -49,6 +51,36 @@ impl StakeState {
         }
     }
 }
+
+/// Reasons the stake might have had an error
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, FromPrimitive)]
+pub enum StakeError {
+    NoCreditsToRedeem,
+}
+
+impl<T> DecodeError<T> for StakeError {
+    fn type_of(&self) -> &'static str {
+        "StakeError"
+    }
+}
+impl Into<InstructionError> for StakeError {
+    fn into(self) -> InstructionError {
+        InstructionError::CustomError(self as u32)
+    }
+}
+
+impl std::fmt::Display for StakeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            StakeError::NoCreditsToRedeem => write!(
+                f,
+                "StakeError::NoCreditsToRedeem not enough credits to redeem"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for StakeError {}
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 pub struct Stake {
@@ -408,7 +440,7 @@ impl<'a> StakeAccount for KeyedAccount<'a> {
                 self.set_state(&StakeState::Stake(stake))
             } else {
                 // not worth collecting
-                Err(InstructionError::CustomError(1))
+                Err(StakeError::NoCreditsToRedeem.into())
             }
         } else {
             Err(InstructionError::InvalidAccountData)
@@ -1379,8 +1411,21 @@ mod tests {
                 &rewards,
                 &stake_history,
             ),
-            Err(InstructionError::CustomError(1))
+            Err(StakeError::NoCreditsToRedeem.into())
         );
+
+        let err: InstructionError = StakeError::NoCreditsToRedeem.into();
+        if let InstructionError::CustomError(code) = err {
+            let specific_error: Option<StakeError> = StakeError::decode_custom_error_to_enum(code);
+            if let Some(specific_error) = specific_error {
+                eprintln!(
+                    "{:?}: {}::{:?}",
+                    err,
+                    specific_error.type_of(),
+                    specific_error
+                );
+            }
+        }
 
         // in this call, we've swapped rewards and vote, deserialization of rewards_pool fails
         assert_eq!(

--- a/programs/token_api/src/token_state.rs
+++ b/programs/token_api/src/token_state.rs
@@ -13,7 +13,7 @@ pub enum TokenError {
 }
 
 impl<T> DecodeError<T> for TokenError {
-    fn type_of(&self) -> &'static str {
+    fn type_of() -> &'static str {
         "TokenError"
     }
 }

--- a/programs/vote_api/Cargo.toml
+++ b/programs/vote_api/Cargo.toml
@@ -11,6 +11,8 @@ edition = "2018"
 [dependencies]
 bincode = "1.1.4"
 log = "0.4.8"
+num-derive = "0.2"
+num-traits = "0.2"
 serde = "1.0.99"
 serde_derive = "1.0.99"
 solana-logger = { path = "../../logger", version = "0.19.0-pre0" }

--- a/sdk/src/instruction_processor_utils.rs
+++ b/sdk/src/instruction_processor_utils.rs
@@ -36,7 +36,7 @@ pub trait DecodeError<E> {
     {
         E::from_u32(int)
     }
-    fn type_of(&self) -> &'static str;
+    fn type_of() -> &'static str;
 }
 
 #[cfg(test)]

--- a/sdk/src/instruction_processor_utils.rs
+++ b/sdk/src/instruction_processor_utils.rs
@@ -1,7 +1,7 @@
 use crate::account::KeyedAccount;
 use crate::instruction::InstructionError;
 use crate::pubkey::Pubkey;
-use num_traits::FromPrimitive;
+use num_traits::{FromPrimitive, ToPrimitive};
 
 // All native programs export a symbol named process()
 pub const ENTRYPOINT: &str = "process";
@@ -29,12 +29,21 @@ macro_rules! solana_entrypoint(
     )
 );
 
+impl<T> From<T> for InstructionError
+where
+    T: ToPrimitive,
+{
+    fn from(error: T) -> Self {
+        InstructionError::CustomError(error.to_u32().unwrap_or(0xbad_c0de))
+    }
+}
+
 pub trait DecodeError<E> {
-    fn decode_custom_error_to_enum(int: u32) -> Option<E>
+    fn decode_custom_error_to_enum(custom: u32) -> Option<E>
     where
         E: FromPrimitive,
     {
-        E::from_u32(int)
+        E::from_u32(custom)
     }
     fn type_of() -> &'static str;
 }
@@ -53,7 +62,7 @@ mod tests {
             C,
         }
         impl<T> DecodeError<T> for TestEnum {
-            fn type_of(&self) -> &'static str {
+            fn type_of() -> &'static str {
                 "TestEnum"
             }
         }

--- a/sdk/src/system_instruction.rs
+++ b/sdk/src/system_instruction.rs
@@ -14,7 +14,7 @@ pub enum SystemError {
 }
 
 impl<T> DecodeError<T> for SystemError {
-    fn type_of(&self) -> &'static str {
+    fn type_of() -> &'static str {
         "SystemError"
     }
 }


### PR DESCRIPTION
#### Problem
 vote and stake errors are either absent (as in vote()) or inscrutable (as in redeem_vote_credits())

 #### Summary of Changes
 * update vote and stake to support custom error ins and outs
 * simplify(?) the DecodeError trait, no need for &self
 * add support for into() InstructionError for error types that conform to the To/FromPrimitive model
     for these errors

Fixes #5572