### PR TITLE
multinode-demo/validator.sh: Don't exit from `kill_node`

### DIFF
--- a/multinode-demo/validator.sh
+++ b/multinode-demo/validator.sh
@@ -250,12 +250,13 @@ kill_node() {
     kill "$_pid" || true
     wait "$_pid" || true
   fi
-  exit
 }
+
 kill_node_and_exit() {
   kill_node
   exit
 }
+
 trap 'kill_node_and_exit' INT TERM ERR
 
 wallet() {


### PR DESCRIPTION
#### Problem

`validator.sh` currently `exit`s the process at the end of `kill_node`.  `kill_node` is also used to restart the validator when a new genesis block is detected, which `exit` prevents

#### Summary of Changes

Don't call `exit` at the of `kill_node`, that's `kill_node_and_exit`'s job