### PR TITLE
scripts/cargo-install-all.sh: Ensure `solana-genesis` is built last

### DIFF
--- a/scripts/cargo-install-all.sh
+++ b/scripts/cargo-install-all.sh
@@ -48,8 +48,11 @@ BIN_CRATES=(
   cli
   bench-exchange
   bench-tps
-  genesis
 )
+
+#XXX: Ensure `solana-genesis` is built LAST!
+# See https://github.com/solana-labs/solana/issues/5826
+BIN_CRATES+=( "genesis" )
 
 for crate in "${BIN_CRATES[@]}"; do
   (

--- a/scripts/cargo-install-all.sh
+++ b/scripts/cargo-install-all.sh
@@ -39,7 +39,6 @@ SECONDS=0
 
 BIN_CRATES=(
   drone
-  genesis
   gossip
   install
   keygen
@@ -49,6 +48,7 @@ BIN_CRATES=(
   cli
   bench-exchange
   bench-tps
+  genesis
 )
 
 for crate in "${BIN_CRATES[@]}"; do


### PR DESCRIPTION
#### Problem

`solana-genesis` build hangs from `cargo install`.  See #5826 

#### Summary of Changes

Ensure `solana-genesis` build is last

Works around #5826