### PR TITLE
Update project to use new account serialization format

### DIFF
--- a/bench-exchange/Cargo.toml
+++ b/bench-exchange/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = "1.0.40"
 serde_yaml = "0.8.9"
 # solana-runtime = { path = "../solana/runtime"}
 solana-core = { path = "../core", version = "0.19.0-pre0" }
+solana-genesis = { path = "../genesis", version = "0.19.0-pre0" } 
 solana-local-cluster = { path = "../local_cluster", version = "0.19.0-pre0" }
 solana-client = { path = "../client", version = "0.19.0-pre0" }
 solana-drone = { path = "../drone", version = "0.19.0-pre0" }

--- a/bench-exchange/src/bench.rs
+++ b/bench-exchange/src/bench.rs
@@ -11,7 +11,7 @@ use solana_drone::drone::request_airdrop_transaction;
 use solana_exchange_api::exchange_instruction;
 use solana_exchange_api::exchange_state::*;
 use solana_exchange_api::id;
-use solana_genesis::account_details::PrimordialAccountDetails;
+use solana_genesis::PrimordialAccountDetails;
 use solana_metrics::datapoint_info;
 use solana_sdk::client::Client;
 use solana_sdk::client::SyncClient;

--- a/bench-exchange/src/bench.rs
+++ b/bench-exchange/src/bench.rs
@@ -11,14 +11,15 @@ use solana_drone::drone::request_airdrop_transaction;
 use solana_exchange_api::exchange_instruction;
 use solana_exchange_api::exchange_state::*;
 use solana_exchange_api::id;
+use solana_genesis::account_details::PrimordialAccountDetails;
 use solana_metrics::datapoint_info;
 use solana_sdk::client::Client;
 use solana_sdk::client::SyncClient;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::{Keypair, KeypairUtil};
-use solana_sdk::system_instruction;
 use solana_sdk::timing::{duration_as_ms, duration_as_s};
 use solana_sdk::transaction::Transaction;
+use solana_sdk::{system_instruction, system_program};
 use std::cmp;
 use std::collections::{HashMap, VecDeque};
 use std::fs::File;
@@ -88,7 +89,12 @@ pub fn create_client_accounts_file(
     keypairs.iter().for_each(|keypair| {
         accounts.insert(
             serde_json::to_string(&keypair.to_bytes().to_vec()).unwrap(),
-            fund_amount,
+            PrimordialAccountDetails {
+                balance: fund_amount,
+                executable: false,
+                owner: system_program::id().to_string(),
+                data: String::new(),
+            },
         );
     });
 

--- a/bench-tps/Cargo.toml
+++ b/bench-tps/Cargo.toml
@@ -17,6 +17,7 @@ serde_derive = "1.0.99"
 serde_json = "1.0.40"
 serde_yaml = "0.8.9"
 solana-core = { path = "../core", version = "0.19.0-pre0" }
+solana-genesis = { path = "../genesis", version = "0.19.0-pre0" } 
 solana-local-cluster = { path = "../local_cluster", version = "0.19.0-pre0" }
 solana-client = { path = "../client", version = "0.19.0-pre0" }
 solana-drone = { path = "../drone", version = "0.19.0-pre0" }

--- a/bench-tps/src/main.rs
+++ b/bench-tps/src/main.rs
@@ -9,8 +9,10 @@ use crate::bench::{
     do_bench_tps, generate_and_fund_keypairs, generate_keypairs, Config, NUM_LAMPORTS_PER_ACCOUNT,
 };
 use solana_core::gossip_service::{discover_cluster, get_multi_client};
+use solana_genesis::account_details::PrimordialAccountDetails;
 use solana_sdk::fee_calculator::FeeCalculator;
 use solana_sdk::signature::{Keypair, KeypairUtil};
+use solana_sdk::system_program;
 use std::collections::HashMap;
 use std::fs::File;
 use std::io::prelude::*;
@@ -55,7 +57,12 @@ fn main() {
         keypairs.iter().for_each(|keypair| {
             accounts.insert(
                 serde_json::to_string(&keypair.to_bytes().to_vec()).unwrap(),
-                num_lamports_per_account,
+                PrimordialAccountDetails {
+                    balance: num_lamports_per_account,
+                    executable: false,
+                    owner: system_program::id().to_string(),
+                    data: String::new(),
+                },
             );
         });
 

--- a/bench-tps/src/main.rs
+++ b/bench-tps/src/main.rs
@@ -9,7 +9,7 @@ use crate::bench::{
     do_bench_tps, generate_and_fund_keypairs, generate_keypairs, Config, NUM_LAMPORTS_PER_ACCOUNT,
 };
 use solana_core::gossip_service::{discover_cluster, get_multi_client};
-use solana_genesis::account_details::PrimordialAccountDetails;
+use solana_genesis::PrimordialAccountDetails;
 use solana_sdk::fee_calculator::FeeCalculator;
 use solana_sdk::signature::{Keypair, KeypairUtil};
 use solana_sdk::system_program;

--- a/genesis/src/account_details.rs
+++ b/genesis/src/account_details.rs
@@ -1,0 +1,9 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct PrimordialAccountDetails {
+    pub balance: u64,
+    pub owner: String,
+    pub data: String,
+    pub executable: bool,
+}

--- a/genesis/src/account_details.rs
+++ b/genesis/src/account_details.rs
@@ -1,9 +1,0 @@
-use serde::{Deserialize, Serialize};
-
-#[derive(Serialize, Deserialize, Debug)]
-pub struct PrimordialAccountDetails {
-    pub balance: u64,
-    pub owner: String,
-    pub data: String,
-    pub executable: bool,
-}

--- a/genesis/src/lib.rs
+++ b/genesis/src/lib.rs
@@ -1,1 +1,9 @@
-pub mod account_details;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct PrimordialAccountDetails {
+    pub balance: u64,
+    pub owner: String,
+    pub data: String,
+    pub executable: bool,
+}

--- a/genesis/src/lib.rs
+++ b/genesis/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod account_details;

--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -2,8 +2,8 @@
 
 use base64;
 use clap::{crate_description, crate_name, crate_version, value_t_or_exit, App, Arg};
-use serde::{Deserialize, Serialize};
 use solana_core::blocktree::create_new_ledger;
+use solana_genesis::account_details::PrimordialAccountDetails;
 use solana_sdk::account::Account;
 use solana_sdk::clock;
 use solana_sdk::fee_calculator::FeeCalculator;
@@ -31,14 +31,6 @@ pub const BOOTSTRAP_LEADER_LAMPORTS: u64 = 42;
 pub enum AccountFileFormat {
     Pubkey,
     Keypair,
-}
-
-#[derive(Serialize, Deserialize, Debug)]
-pub struct PrimordialAccountDetails {
-    balance: u64,
-    owner: String,
-    data: String,
-    executable: bool,
 }
 
 pub fn append_primordial_accounts(

--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -3,7 +3,7 @@
 use base64;
 use clap::{crate_description, crate_name, crate_version, value_t_or_exit, App, Arg};
 use solana_core::blocktree::create_new_ledger;
-use solana_genesis::account_details::PrimordialAccountDetails;
+use solana_genesis::PrimordialAccountDetails;
 use solana_sdk::account::Account;
 use solana_sdk::clock;
 use solana_sdk::fee_calculator::FeeCalculator;

--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -110,10 +110,11 @@ local|tar|skip)
       rm -rf ./solana-node-balances
       mkdir ./solana-node-balances
       if [[ -n $internalNodesLamports ]]; then
+        echo "---" >> ./solana-node-balances/fullnode-balances.yml
         for i in $(seq 0 "$numNodes"); do
           solana-keygen new -o ./solana-node-keys/"$i"
           pubkey="$(solana-keygen pubkey ./solana-node-keys/"$i")"
-          echo "${pubkey}: $internalNodesLamports" >> ./solana-node-balances/fullnode-balances.yml
+          echo -e "${pubkey}:\n  balance: $internalNodesLamports\n  owner: 11111111111111111111111111111111\n  data:\n  executable: false" >> ./solana-node-balances/fullnode-balances.yml
         done
       fi
 

--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -114,7 +114,13 @@ local|tar|skip)
         for i in $(seq 0 "$numNodes"); do
           solana-keygen new -o ./solana-node-keys/"$i"
           pubkey="$(solana-keygen pubkey ./solana-node-keys/"$i")"
-          echo -e "${pubkey}:\n  balance: $internalNodesLamports\n  owner: 11111111111111111111111111111111\n  data:\n  executable: false" >> ./solana-node-balances/fullnode-balances.yml
+          cat >> ./solana-node-balances/fullnode-balances.yml <<EOF
+$pubkey:
+  balance: $internalNodesLamports
+  owner: 11111111111111111111111111111111
+  data:
+  executable: false
+EOF
         done
       fi
 


### PR DESCRIPTION
#### Problem
I see this error while running net.sh start
```
Hashes per tick: 248756
Error: Custom { kind: Other, error: StringError("Message(\"invalid type: integer `116286523`, expected struct PrimordialAccountDetails\", Some(Pos { marker: Marker { i
ndex: 237, line: 1, col: 237 }, path: \"[213,15,120,234,113,155,77,37,232,44,112,221,246,17,218,95,142,182,96,218,180,117,255,113,216,199,47,104,145,216,80,114,223,223
,65,0,66,191,10,17,32,125,67,14,154,78,35,143,241,249,142,180,137,179,215,90,167,36,28,210,18,165,189,178]\" }))") }
^^^ +++
```

#### Summary of Changes
Update `bench-tps`, `bench-exchange` and `net/remote/remote-node.sh` to use new account serialization format.

Fixes #5836 
