### PR TITLE
Print account balances in SOL by default

### DIFF
--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -6,3 +6,7 @@ pub mod display;
 pub mod input_validators;
 pub mod validator_info;
 pub mod wallet;
+
+pub(crate) fn lamports_to_sol(lamports: u64) -> f64 {
+    lamports as f64 / 2u64.pow(34) as f64
+}

--- a/cli/src/wallet.rs
+++ b/cli/src/wallet.rs
@@ -55,12 +55,19 @@ pub enum WalletCommand {
         drone_port: u16,
         lamports: u64,
     },
-    Balance(Pubkey, bool),
+    Balance {
+        pubkey: Pubkey,
+        use_lamports_unit: bool,
+    },
     Cancel(Pubkey),
     Confirm(Signature),
     AuthorizeVoter(Pubkey, Keypair, Pubkey),
     CreateVoteAccount(Pubkey, Pubkey, u8, u64),
-    ShowAccount(Pubkey, Option<String>, bool),
+    ShowAccount {
+        pubkey: Pubkey,
+        output_file: Option<String>,
+        use_lamports_unit: bool,
+    },
     ShowVoteAccount(Pubkey),
     DelegateStake(Keypair, Pubkey, u64, bool),
     WithdrawStake(Keypair, Pubkey, u64),
@@ -134,7 +141,10 @@ impl Default for WalletConfig {
         keypair_path.extend(&[".config", "solana", "id.json"]);
 
         WalletConfig {
-            command: WalletCommand::Balance(Pubkey::default(), false),
+            command: WalletCommand::Balance {
+                pubkey: Pubkey::default(),
+                use_lamports_unit: false,
+            },
             json_rpc_url: "http://127.0.0.1:8899".to_string(),
             keypair: Keypair::new(),
             keypair_path: keypair_path.to_str().unwrap().to_string(),
@@ -221,7 +231,10 @@ pub fn parse_command(
         ("balance", Some(balance_matches)) => {
             let pubkey = pubkey_of(&balance_matches, "pubkey").unwrap_or(*pubkey);
             let use_lamports_unit = balance_matches.is_present("lamports");
-            Ok(WalletCommand::Balance(pubkey, use_lamports_unit))
+            Ok(WalletCommand::Balance {
+                pubkey,
+                use_lamports_unit,
+            })
         }
         ("cancel", Some(cancel_matches)) => {
             let process_id = value_of(cancel_matches, "process_id").unwrap();
@@ -269,11 +282,11 @@ pub fn parse_command(
             let account_pubkey = pubkey_of(matches, "account_pubkey").unwrap();
             let output_file = matches.value_of("output_file");
             let use_lamports_unit = matches.is_present("lamports");
-            Ok(WalletCommand::ShowAccount(
-                account_pubkey,
-                output_file.map(ToString::to_string),
+            Ok(WalletCommand::ShowAccount {
+                pubkey: account_pubkey,
+                output_file: output_file.map(ToString::to_string),
                 use_lamports_unit,
-            ))
+            })
         }
         ("show-vote-account", Some(matches)) => {
             let vote_account_pubkey = pubkey_of(matches, "vote_account_pubkey").unwrap();
@@ -537,20 +550,11 @@ fn process_airdrop(
 fn process_balance(
     pubkey: &Pubkey,
     rpc_client: &RpcClient,
-    use_lamports_unit: &bool,
+    use_lamports_unit: bool,
 ) -> ProcessResult {
     let balance = rpc_client.retry_get_balance(pubkey, 5)?;
     match balance {
-        Some(lamports) => {
-            let msg = if *use_lamports_unit {
-                let ess = if lamports == 1 { "" } else { "s" };
-                format!("{:?} lamport{}", lamports, ess)
-            } else {
-                let sol = lamports_to_sol(lamports);
-                format!("{:.8} SOL", sol)
-            };
-            Ok(msg)
-        }
+        Some(lamports) => Ok(build_balance_message(lamports, use_lamports_unit)),
         None => Err(WalletError::RpcRequestError(
             "Received result of an unexpected type".to_string(),
         ))?,
@@ -644,17 +648,16 @@ fn process_show_account(
     _config: &WalletConfig,
     account_pubkey: &Pubkey,
     output_file: &Option<String>,
-    use_lamports_unit: &bool,
+    use_lamports_unit: bool,
 ) -> ProcessResult {
     let account = rpc_client.get_account(account_pubkey)?;
 
     println!();
     println!("Public Key: {}", account_pubkey);
-    if *use_lamports_unit {
-        println!("Lamports: {}", account.lamports);
-    } else {
-        println!("SOL: {:.8}", lamports_to_sol(account.lamports));
-    }
+    println!(
+        "{:?}",
+        build_balance_message(account.lamports, use_lamports_unit)
+    );
     println!("Owner: {}", account.owner);
     println!("Executable: {}", account.executable);
 
@@ -1423,9 +1426,10 @@ pub fn process_command(config: &WalletConfig) -> ProcessResult {
         }
 
         // Check client balance
-        WalletCommand::Balance(pubkey, use_lamports_unit) => {
-            process_balance(&pubkey, &rpc_client, use_lamports_unit)
-        }
+        WalletCommand::Balance {
+            pubkey,
+            use_lamports_unit,
+        } => process_balance(&pubkey, &rpc_client, *use_lamports_unit),
 
         // Cancel a contract by contract Pubkey
         WalletCommand::Cancel(pubkey) => process_cancel(&rpc_client, config, &pubkey),
@@ -1460,15 +1464,17 @@ pub fn process_command(config: &WalletConfig) -> ProcessResult {
             &new_authorized_voter_pubkey,
         ),
 
-        WalletCommand::ShowAccount(account_pubkey, output_file, use_lamports_unit) => {
-            process_show_account(
-                &rpc_client,
-                config,
-                &account_pubkey,
-                &output_file,
-                use_lamports_unit,
-            )
-        }
+        WalletCommand::ShowAccount {
+            pubkey,
+            output_file,
+            use_lamports_unit,
+        } => process_show_account(
+            &rpc_client,
+            config,
+            &pubkey,
+            &output_file,
+            *use_lamports_unit,
+        ),
 
         WalletCommand::ShowVoteAccount(vote_account_pubkey) => {
             process_show_vote_account(&rpc_client, config, &vote_account_pubkey)
@@ -1695,6 +1701,16 @@ where
     }
 }
 
+fn build_balance_message(lamports: u64, use_lamports_unit: bool) -> String {
+    if use_lamports_unit {
+        let ess = if lamports == 1 { "" } else { "s" };
+        format!("{:?} lamport{}", lamports, ess)
+    } else {
+        let sol = lamports_to_sol(lamports);
+        format!("{:.8} SOL", sol)
+    }
+}
+
 pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, 'v> {
     App::new(name)
         .about(about)
@@ -1744,7 +1760,7 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                     Arg::with_name("lamports")
                         .long("lamports")
                         .takes_value(false)
-                        .help("Display balance in lamports"),
+                        .help("Display balance in lamports instead of SOL"),
                 ),
         )
         .subcommand(
@@ -1864,7 +1880,7 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                     Arg::with_name("lamports")
                         .long("lamports")
                         .takes_value(false)
-                        .help("Display balance in lamports"),
+                        .help("Display balance in lamports instead of SOL"),
                 ),
         )
         .subcommand(
@@ -2376,7 +2392,10 @@ mod tests {
         ]);
         assert_eq!(
             parse_command(&pubkey, &test_balance).unwrap(),
-            WalletCommand::Balance(keypair.pubkey(), false)
+            WalletCommand::Balance {
+                pubkey: keypair.pubkey(),
+                use_lamports_unit: false
+            }
         );
         let test_balance = test_commands.clone().get_matches_from(vec![
             "test",
@@ -2386,7 +2405,10 @@ mod tests {
         ]);
         assert_eq!(
             parse_command(&pubkey, &test_balance).unwrap(),
-            WalletCommand::Balance(keypair.pubkey(), true)
+            WalletCommand::Balance {
+                pubkey: keypair.pubkey(),
+                use_lamports_unit: true
+            }
         );
 
         // Test Cancel Subcommand
@@ -2671,10 +2693,16 @@ mod tests {
         config.command = WalletCommand::Address;
         assert_eq!(process_command(&config).unwrap(), pubkey);
 
-        config.command = WalletCommand::Balance(config.keypair.pubkey(), true);
+        config.command = WalletCommand::Balance {
+            pubkey: config.keypair.pubkey(),
+            use_lamports_unit: true,
+        };
         assert_eq!(process_command(&config).unwrap(), "50 lamports");
 
-        config.command = WalletCommand::Balance(config.keypair.pubkey(), false);
+        config.command = WalletCommand::Balance {
+            pubkey: config.keypair.pubkey(),
+            use_lamports_unit: false,
+        };
         assert_eq!(process_command(&config).unwrap(), "0.00000000 SOL");
 
         let process_id = Pubkey::new_rand();
@@ -2829,7 +2857,10 @@ mod tests {
         };
         assert!(process_command(&config).is_err());
 
-        config.command = WalletCommand::Balance(config.keypair.pubkey(), false);
+        config.command = WalletCommand::Balance {
+            pubkey: config.keypair.pubkey(),
+            use_lamports_unit: false,
+        };
         assert!(process_command(&config).is_err());
 
         config.command = WalletCommand::CreateVoteAccount(bob_pubkey, node_pubkey, 0, 10);

--- a/scripts/wallet-sanity.sh
+++ b/scripts/wallet-sanity.sh
@@ -23,7 +23,7 @@ check_balance_output() {
   exec 42>&1
   attempts=3
   while [[ $attempts -gt 0 ]]; do
-    output=$($solana_cli "${entrypoint[@]}" balance | tee >(cat - >&42))
+    output=$($solana_cli "${entrypoint[@]}" balance --lamports | tee >(cat - >&42))
     if [[ "$output" =~ $expected_output ]]; then
       break
     else


### PR DESCRIPTION
#### Problem
Solana-cli account balances currently feature super-long, unformatted numbers, using the lamport unit.

#### Summary of Changes
Updates solana-cli to print account balances in SOL by default; offers optional `--lamports` arg to use lamports instead

To come in a follow-up PR: add `--lamports` arg in Airdrop, DelegateStake, Pay, and WithdrawStake commands, using SOL by default for both amount inputs (and in the case of Airdrop, the balance print)

Fixes #5729 
