### PR TITLE
Fix bench clients reading primordial account files

### DIFF
--- a/bench-exchange/src/bench.rs
+++ b/bench-exchange/src/bench.rs
@@ -140,7 +140,8 @@ where
         let path = Path::new(&client_ids_and_stake_file);
         let file = File::open(path).unwrap();
 
-        let accounts: HashMap<String, u64> = serde_yaml::from_reader(file).unwrap();
+        let accounts: HashMap<String, PrimordialAccountDetails> =
+            serde_yaml::from_reader(file).unwrap();
         accounts
             .into_iter()
             .map(|(keypair, _)| {

--- a/bench-tps/src/main.rs
+++ b/bench-tps/src/main.rs
@@ -94,15 +94,18 @@ fn main() {
         let path = Path::new(&client_ids_and_stake_file);
         let file = File::open(path).unwrap();
 
-        let accounts: HashMap<String, u64> = serde_yaml::from_reader(file).unwrap();
+        let accounts: HashMap<String, PrimordialAccountDetails> =
+            serde_yaml::from_reader(file).unwrap();
         let mut keypairs = vec![];
         let mut last_balance = 0;
 
-        accounts.into_iter().for_each(|(keypair, balance)| {
-            let bytes: Vec<u8> = serde_json::from_str(keypair.as_str()).unwrap();
-            keypairs.push(Keypair::from_bytes(&bytes).unwrap());
-            last_balance = balance;
-        });
+        accounts
+            .into_iter()
+            .for_each(|(keypair, primordial_account)| {
+                let bytes: Vec<u8> = serde_json::from_str(keypair.as_str()).unwrap();
+                keypairs.push(Keypair::from_bytes(&bytes).unwrap());
+                last_balance = primordial_account.balance;
+            });
         // Sort keypairs so that do_bench_tps() uses the same subset of accounts for each run.
         // This prevents the amount of storage needed for bench-tps accounts from creeping up
         // across multiple runs.


### PR DESCRIPTION
#### Problem

Bench-tps is unable to lookup its primordial account balances since it's using the wrong format

#### Summary of Changes

Updated to use the correct `PrimordialAccountDetails` format. 
