### PR TITLE
Interpret Solana-CLI amount requests in SOL by default

### DIFF
--- a/book/src/cli.md
+++ b/book/src/cli.md
@@ -14,14 +14,20 @@ $ solana address
 <PUBKEY>
 ```
 
-#### Airdrop Lamports
+#### Airdrop SOL/Lamports
 
 ```sh
 // Command
-$ solana airdrop 123
+$ solana airdrop 2
 
 // Return
-"Your balance is: 123"
+"2.00000000 SOL"
+
+// Command
+$ solana airdrop 123 --lamports
+
+// Return
+"123 lamports"
 ```
 
 #### Get Balance
@@ -31,7 +37,7 @@ $ solana airdrop 123
 $ solana balance
 
 // Return
-"Your balance is: 123"
+"3.00050001 SOL"
 ```
 
 #### Confirm Transaction
@@ -175,29 +181,46 @@ USAGE:
 
 FLAGS:
     -h, --help       Prints help information
-        --rpc-tls    Enable TLS for the RPC endpoint
     -V, --version    Prints version information
 
 OPTIONS:
-        --drone-host <IP ADDRESS>    Drone host to use [default: same as --host]
-        --drone-port <PORT>          Drone port to use [default: 9900]
-    -n, --host <IP ADDRESS>          Host to use for both RPC and drone [default: 127.0.0.1]
-    -k, --keypair <PATH>             /path/to/id.json
-        --rpc-host <IP ADDRESS>      RPC host to use [default: same as --host]
-        --rpc-port <PORT>            RPC port to use [default: 8899]
+    -C, --config <PATH>     Configuration file to use [default: ~/.config/solana/wallet/config.yml]
+    -u, --url <URL>         JSON RPC URL for the solana cluster
+    -k, --keypair <PATH>    /path/to/id.json
 
 SUBCOMMANDS:
-    address                  Get your public key
-    airdrop                  Request a batch of lamports
-    balance                  Get your balance
-    cancel                   Cancel a transfer
-    confirm                  Confirm transaction by signature
-    deploy                   Deploy a program
-    get-transaction-count    Get current transaction count
-    help                     Prints this message or the help of the given subcommand(s)
-    pay                      Send a payment
-    send-signature           Send a signature to authorize a transfer
-    send-timestamp           Send a timestamp to unlock a transfer
+    address                               Get your public key
+    airdrop                               Request lamports
+    authorize-voter                       Authorize a new vote signing keypair for the given vote account
+    balance                               Get your balance
+    cancel                                Cancel a transfer
+    claim-storage-reward                  Redeem storage reward credits
+    cluster-version                       Get the version of the cluster entrypoint
+    confirm                               Confirm transaction by signature
+    create-replicator-storage-account     Create a replicator storage account
+    create-storage-mining-pool-account    Create mining pool account
+    create-validator-storage-account      Create a validator storage account
+    create-vote-account                   Create a vote account
+    deactivate-stake                      Deactivate the delegated stake from the stake account
+    delegate-stake                        Delegate stake to a vote account
+    deploy                                Deploy a program
+    fees                                  Display current cluster fees
+    get                                   Get wallet config settings
+    get-slot                              Get current slot
+    get-transaction-count                 Get current transaction count
+    help                                  Prints this message or the help of the given subcommand(s)
+    pay                                   Send a payment
+    ping                                  Submit transactions sequentially
+    redeem-vote-credits                   Redeem credits in the stake account
+    send-signature                        Send a signature to authorize a transfer
+    send-timestamp                        Send a timestamp to unlock a transfer
+    set                                   Set a wallet config setting
+    show-account                          Show the contents of an account
+    show-stake-account                    Show the contents of a stake account
+    show-storage-account                  Show the contents of a storage account
+    show-vote-account                     Show the contents of a vote account
+    validator-info                        Publish/get Validator info on Solana
+    withdraw-stake                        Withdraw the unstaked lamports from the stake account
 ```
 
 ```manpage
@@ -205,11 +228,16 @@ solana-address
 Get your public key
 
 USAGE:
-    solana address
+    solana address [OPTIONS]
 
 FLAGS:
     -h, --help       Prints help information
     -V, --version    Prints version information
+
+OPTIONS:
+    -C, --config <PATH>     Configuration file to use [default: ~/.config/solana/wallet/config.yml]
+    -u, --url <URL>         JSON RPC URL for the solana cluster
+    -k, --keypair <PATH>    /path/to/id.json
 ```
 
 ```manpage
@@ -217,14 +245,46 @@ solana-airdrop
 Request a batch of lamports
 
 USAGE:
-    solana airdrop <NUM>
+    solana airdrop [OPTIONS] <AMOUNT> [unit]
 
 FLAGS:
     -h, --help       Prints help information
     -V, --version    Prints version information
 
+OPTIONS:
+    -C, --config <PATH>        Configuration file to use [default: /Users/tyeraeulberg/.config/solana/wallet/config.yml]
+        --drone-host <HOST>    Drone host to use [default: the --url host]
+        --drone-port <PORT>    Drone port to use [default: 9900]
+    -u, --url <URL>            JSON RPC URL for the solana cluster
+    -k, --keypair <PATH>       /path/to/id.json
+
 ARGS:
-    <NUM>    The number of lamports to request
+    <AMOUNT>    The airdrop amount to request (default unit SOL)
+    <unit>      Specify unit to use for request and balance display [possible values: SOL, lamports]
+
+```
+
+```manpage
+solana-authorize-voter
+Authorize a new vote signing keypair for the given vote account
+
+USAGE:
+    solana authorize-voter [OPTIONS] <VOTE ACCOUNT PUBKEY> <CURRENT VOTER KEYPAIR FILE> <NEW VOTER PUBKEY>
+
+FLAGS:
+    -h, --help       Prints help information
+    -V, --version    Prints version information
+
+OPTIONS:
+    -C, --config <PATH>     Configuration file to use [default: ~/.config/solana/wallet/config.yml]
+    -u, --url <URL>         JSON RPC URL for the solana cluster
+    -k, --keypair <PATH>    /path/to/id.json
+
+ARGS:
+    <VOTE ACCOUNT PUBKEY>           Vote account in which to set the authorized voter
+    <CURRENT VOTER KEYPAIR FILE>    Keypair file for the currently authorized vote signer
+    <NEW VOTER PUBKEY>              New vote signer to authorize
+
 ```
 
 ```manpage
@@ -232,11 +292,20 @@ solana-balance
 Get your balance
 
 USAGE:
-    solana balance
+    solana balance [FLAGS] [OPTIONS] [PUBKEY]
 
 FLAGS:
-    -h, --help       Prints help information
-    -V, --version    Prints version information
+    -h, --help        Prints help information
+        --lamports    Display balance in lamports instead of SOL
+    -V, --version     Prints version information
+
+OPTIONS:
+    -C, --config <PATH>     Configuration file to use [default: ~/.config/solana/wallet/config.yml]
+    -u, --url <URL>         JSON RPC URL for the solana cluster
+    -k, --keypair <PATH>    /path/to/id.json
+
+ARGS:
+    <PUBKEY>    The public key of the balance to check
 ```
 
 ```manpage
@@ -244,14 +313,57 @@ solana-cancel
 Cancel a transfer
 
 USAGE:
-    solana cancel <PROCESS_ID>
+    solana cancel [OPTIONS] <PROCESS ID>
 
 FLAGS:
     -h, --help       Prints help information
     -V, --version    Prints version information
 
+OPTIONS:
+    -C, --config <PATH>     Configuration file to use [default: ~/.config/solana/wallet/config.yml]
+    -u, --url <URL>         JSON RPC URL for the solana cluster
+    -k, --keypair <PATH>    /path/to/id.json
+
 ARGS:
-    <PROCESS_ID>    The process id of the transfer to cancel
+    <PROCESS ID>    The process id of the transfer to cancel
+```
+
+```manpage
+solana-claim-storage-reward
+Redeem storage reward credits
+
+USAGE:
+    solana claim-storage-reward [OPTIONS] <NODE PUBKEY> <STORAGE ACCOUNT PUBKEY>
+
+FLAGS:
+    -h, --help       Prints help information
+    -V, --version    Prints version information
+
+OPTIONS:
+    -C, --config <PATH>     Configuration file to use [default: ~/.config/solana/wallet/config.yml]
+    -u, --url <URL>         JSON RPC URL for the solana cluster
+    -k, --keypair <PATH>    /path/to/id.json
+
+ARGS:
+    <NODE PUBKEY>               The node account to credit the rewards to
+    <STORAGE ACCOUNT PUBKEY>    Storage account address to redeem credits for
+```
+
+```manpage
+solana-cluster-version
+Get the version of the cluster entrypoint
+
+USAGE:
+    solana cluster-version [OPTIONS]
+
+FLAGS:
+    -h, --help       Prints help information
+    -V, --version    Prints version information
+
+OPTIONS:
+    -C, --config <PATH>     Configuration file to use [default: ~/.config/solana/wallet/config.yml]
+    -u, --url <URL>         JSON RPC URL for the solana cluster
+    -k, --keypair <PATH>    /path/to/id.json
 ```
 
 ```manpage
@@ -259,14 +371,150 @@ solana-confirm
 Confirm transaction by signature
 
 USAGE:
-    solana confirm <SIGNATURE>
+    solana confirm [OPTIONS] <SIGNATURE>
 
 FLAGS:
     -h, --help       Prints help information
     -V, --version    Prints version information
 
+OPTIONS:
+    -C, --config <PATH>     Configuration file to use [default: ~/.config/solana/wallet/config.yml]
+    -u, --url <URL>         JSON RPC URL for the solana cluster
+    -k, --keypair <PATH>    /path/to/id.json
+
 ARGS:
     <SIGNATURE>    The transaction signature to confirm
+```
+
+```manpage
+solana-create-replicator-storage-account
+Create a replicator storage account
+
+USAGE:
+    solana create-replicator-storage-account [OPTIONS] <STORAGE ACCOUNT OWNER PUBKEY> <STORAGE ACCOUNT PUBKEY>
+
+FLAGS:
+    -h, --help       Prints help information
+    -V, --version    Prints version information
+
+OPTIONS:
+    -C, --config <PATH>     Configuration file to use [default: ~/.config/solana/wallet/config.yml]
+    -u, --url <URL>         JSON RPC URL for the solana cluster
+    -k, --keypair <PATH>    /path/to/id.json
+
+ARGS:
+    <STORAGE ACCOUNT OWNER PUBKEY>
+    <STORAGE ACCOUNT PUBKEY>
+```
+
+```manpage
+solana-create-storage-mining-pool-account
+Create mining pool account
+
+USAGE:
+    solana create-storage-mining-pool-account [OPTIONS] <STORAGE ACCOUNT PUBKEY> <AMOUNT> [unit]
+
+FLAGS:
+    -h, --help       Prints help information
+    -V, --version    Prints version information
+
+OPTIONS:
+    -C, --config <PATH>     Configuration file to use [default: /Users/tyeraeulberg/.config/solana/wallet/config.yml]
+    -u, --url <URL>         JSON RPC URL for the solana cluster
+    -k, --keypair <PATH>    /path/to/id.json
+
+ARGS:
+    <STORAGE ACCOUNT PUBKEY>    Storage mining pool account address to fund
+    <AMOUNT>                    The amount to assign to the storage mining pool account (default unit SOL)
+    <unit>                      Specify unit to use for request [possible values: SOL, lamports]
+```
+
+```manpage
+solana-create-validator-storage-account
+Create a validator storage account
+
+USAGE:
+    solana create-validator-storage-account [OPTIONS] <STORAGE ACCOUNT OWNER PUBKEY> <STORAGE ACCOUNT PUBKEY>
+
+FLAGS:
+    -h, --help       Prints help information
+    -V, --version    Prints version information
+
+OPTIONS:
+    -C, --config <PATH>     Configuration file to use [default: ~/.config/solana/wallet/config.yml]
+    -u, --url <URL>         JSON RPC URL for the solana cluster
+    -k, --keypair <PATH>    /path/to/id.json
+
+ARGS:
+    <STORAGE ACCOUNT OWNER PUBKEY>
+    <STORAGE ACCOUNT PUBKEY>
+```
+
+```manpage
+solana-create-vote-account
+Create a vote account
+
+USAGE:
+    solana create-vote-account [OPTIONS] <VOTE ACCOUNT PUBKEY> <VALIDATOR PUBKEY> <LAMPORTS>
+
+FLAGS:
+    -h, --help       Prints help information
+    -V, --version    Prints version information
+
+OPTIONS:
+        --commission <NUM>    The commission taken on reward redemption (0-255), default: 0
+    -C, --config <PATH>       Configuration file to use [default: ~/.config/solana/wallet/config.yml]
+    -u, --url <URL>           JSON RPC URL for the solana cluster
+    -k, --keypair <PATH>      /path/to/id.json
+
+ARGS:
+    <VOTE ACCOUNT PUBKEY>    Vote account address to fund
+    <VALIDATOR PUBKEY>       Validator that will vote with this account
+    <LAMPORTS>               The amount of lamports to send to the vote account
+```
+
+```manpage
+solana-deactivate-stake
+Deactivate the delegated stake from the stake account
+
+USAGE:
+    solana deactivate-stake [OPTIONS] <STAKE ACCOUNT KEYPAIR FILE> <PUBKEY>
+
+FLAGS:
+    -h, --help       Prints help information
+    -V, --version    Prints version information
+
+OPTIONS:
+    -C, --config <PATH>     Configuration file to use [default: ~/.config/solana/wallet/config.yml]
+    -u, --url <URL>         JSON RPC URL for the solana cluster
+    -k, --keypair <PATH>    /path/to/id.json
+
+ARGS:
+    <STAKE ACCOUNT KEYPAIR FILE>    Keypair file for the stake account, for signing the delegate transaction.
+    <PUBKEY>                        The vote account to which the stake is currently delegated
+```
+
+```manpage
+solana-delegate-stake
+Delegate stake to a vote account
+
+USAGE:
+    solana delegate-stake [OPTIONS] <STAKE ACCOUNT KEYPAIR FILE> <VOTE ACCOUNT PUBKEY> <AMOUNT> [unit]
+
+FLAGS:
+    -h, --help       Prints help information
+    -V, --version    Prints version information
+
+OPTIONS:
+    -C, --config <PATH>     Configuration file to use [default: /Users/tyeraeulberg/.config/solana/wallet/config.yml]
+    -u, --url <URL>         JSON RPC URL for the solana cluster
+    -k, --keypair <PATH>    /path/to/id.json
+
+ARGS:
+    <STAKE ACCOUNT KEYPAIR FILE>    Keypair file for the new stake account
+    <VOTE ACCOUNT PUBKEY>           The vote account to which the stake will be delegated
+    <AMOUNT>                        The amount to delegate (default unit SOL)
+    <unit>                          Specify unit to use for request [possible values: SOL, lamports]
 ```
 
 ```manpage
@@ -274,14 +522,19 @@ solana-deploy
 Deploy a program
 
 USAGE:
-    solana deploy <PATH>
+    solana deploy [OPTIONS] <PATH TO PROGRAM>
 
 FLAGS:
     -h, --help       Prints help information
     -V, --version    Prints version information
 
+OPTIONS:
+    -C, --config <PATH>     Configuration file to use [default: ~/.config/solana/wallet/config.yml]
+    -u, --url <URL>         JSON RPC URL for the solana cluster
+    -k, --keypair <PATH>    /path/to/id.json
+
 ARGS:
-    <PATH>    /path/to/program.o
+    <PATH TO PROGRAM>    /path/to/program.o
 ```
 
 ```manpage
@@ -289,11 +542,53 @@ solana-fees
 Display current cluster fees
 
 USAGE:
-    solana fees
+    solana fees [OPTIONS]
 
 FLAGS:
     -h, --help       Prints help information
     -V, --version    Prints version information
+
+OPTIONS:
+    -C, --config <PATH>     Configuration file to use [default: ~/.config/solana/wallet/config.yml]
+    -u, --url <URL>         JSON RPC URL for the solana cluster
+    -k, --keypair <PATH>    /path/to/id.json
+```
+
+```manpage
+solana-get
+Get wallet config settings
+
+USAGE:
+    solana get [OPTIONS] [CONFIG_FIELD]
+
+FLAGS:
+    -h, --help       Prints help information
+    -V, --version    Prints version information
+
+OPTIONS:
+    -C, --config <PATH>     Configuration file to use [default: ~/.config/solana/wallet/config.yml]
+    -u, --url <URL>         JSON RPC URL for the solana cluster
+    -k, --keypair <PATH>    /path/to/id.json
+
+ARGS:
+    <CONFIG_FIELD>    Return a specific config setting [possible values: url, keypair]
+```
+
+```manpage
+solana-get-slot
+Get current slot
+
+USAGE:
+    solana get-slot [OPTIONS]
+
+FLAGS:
+    -h, --help       Prints help information
+    -V, --version    Prints version information
+
+OPTIONS:
+    -C, --config <PATH>     Configuration file to use [default: ~/.config/solana/wallet/config.yml]
+    -u, --url <URL>         JSON RPC URL for the solana cluster
+    -k, --keypair <PATH>    /path/to/id.json
 ```
 
 ```manpage
@@ -301,11 +596,16 @@ solana-get-transaction-count
 Get current transaction count
 
 USAGE:
-    solana get-transaction-count
+    solana get-transaction-count [OPTIONS]
 
 FLAGS:
     -h, --help       Prints help information
     -V, --version    Prints version information
+
+OPTIONS:
+    -C, --config <PATH>     Configuration file to use [default: ~/.config/solana/wallet/config.yml]
+    -u, --url <URL>         JSON RPC URL for the solana cluster
+    -k, --keypair <PATH>    /path/to/id.json
 ```
 
 ```manpage
@@ -313,7 +613,7 @@ solana-pay
 Send a payment
 
 USAGE:
-    solana pay [FLAGS] [OPTIONS] <PUBKEY> <NUM>
+    solana pay [FLAGS] [OPTIONS] <PUBKEY> <AMOUNT> [--] [unit]
 
 FLAGS:
         --cancelable
@@ -321,13 +621,60 @@ FLAGS:
     -V, --version       Prints version information
 
 OPTIONS:
+    -C, --config <PATH>                         Configuration file to use [default:
+                                                /Users/tyeraeulberg/.config/solana/wallet/config.yml]
+    -u, --url <URL>                             JSON RPC URL for the solana cluster
+    -k, --keypair <PATH>                        /path/to/id.json
         --after <DATETIME>                      A timestamp after which transaction will execute
         --require-timestamp-from <PUBKEY>       Require timestamp from this third party
         --require-signature-from <PUBKEY>...    Any third party signatures required to unlock the lamports
 
 ARGS:
     <PUBKEY>    The pubkey of recipient
-    <NUM>       The number of lamports to send
+    <AMOUNT>    The amount to send (default unit SOL)
+    <unit>      Specify unit to use for request [possible values: SOL, lamports]
+```
+
+```manpage
+solana-ping
+Submit transactions sequentially
+
+USAGE:
+    solana ping [OPTIONS]
+
+FLAGS:
+    -h, --help       Prints help information
+    -V, --version    Prints version information
+
+OPTIONS:
+    -C, --config <PATH>         Configuration file to use [default:
+                                ~/.config/solana/wallet/config.yml]
+    -c, --count <NUMBER>        Stop after submitting count transactions
+    -i, --interval <SECONDS>    Wait interval seconds between submitting the next transaction [default: 2]
+    -u, --url <URL>             JSON RPC URL for the solana cluster
+    -k, --keypair <PATH>        /path/to/id.json
+    -t, --timeout <SECONDS>     Wait up to timeout seconds for transaction confirmation [default: 10]
+```
+
+```manpage
+solana-redeem-vote-credits
+Redeem credits in the stake account
+
+USAGE:
+    solana redeem-vote-credits [OPTIONS] <STAKING ACCOUNT PUBKEY> <VOTE ACCOUNT PUBKEY>
+
+FLAGS:
+    -h, --help       Prints help information
+    -V, --version    Prints version information
+
+OPTIONS:
+    -C, --config <PATH>     Configuration file to use [default: ~/.config/solana/wallet/config.yml]
+    -u, --url <URL>         JSON RPC URL for the solana cluster
+    -k, --keypair <PATH>    /path/to/id.json
+
+ARGS:
+    <STAKING ACCOUNT PUBKEY>    Staking account address to redeem credits for
+    <VOTE ACCOUNT PUBKEY>       The vote account to which the stake was previously delegated.
 ```
 
 ```manpage
@@ -335,15 +682,20 @@ solana-send-signature
 Send a signature to authorize a transfer
 
 USAGE:
-    solana send-signature <PUBKEY> <PROCESS_ID>
+    solana send-signature [OPTIONS] <PUBKEY> <PROCESS ID>
 
 FLAGS:
     -h, --help       Prints help information
     -V, --version    Prints version information
 
+OPTIONS:
+    -C, --config <PATH>     Configuration file to use [default: ~/.config/solana/wallet/config.yml]
+    -u, --url <URL>         JSON RPC URL for the solana cluster
+    -k, --keypair <PATH>    /path/to/id.json
+
 ARGS:
     <PUBKEY>        The pubkey of recipient
-    <PROCESS_ID>    The process id of the transfer to authorize
+    <PROCESS ID>    The process id of the transfer to authorize
 ```
 
 ```manpage
@@ -351,16 +703,163 @@ solana-send-timestamp
 Send a timestamp to unlock a transfer
 
 USAGE:
-    solana send-timestamp [OPTIONS] <PUBKEY> <PROCESS_ID>
+    solana send-timestamp [OPTIONS] <PUBKEY> <PROCESS ID>
 
 FLAGS:
     -h, --help       Prints help information
     -V, --version    Prints version information
 
 OPTIONS:
+    -C, --config <PATH>      Configuration file to use [default: ~/.config/solana/wallet/config.yml]
         --date <DATETIME>    Optional arbitrary timestamp to apply
+    -u, --url <URL>          JSON RPC URL for the solana cluster
+    -k, --keypair <PATH>     /path/to/id.json
 
 ARGS:
     <PUBKEY>        The pubkey of recipient
-    <PROCESS_ID>    The process id of the transfer to unlock
+    <PROCESS ID>    The process id of the transfer to unlock
+```
+
+```manpage
+solana-set
+Set a wallet config setting
+
+USAGE:
+    solana set [OPTIONS] <--url <URL>|--keypair <PATH>>
+
+FLAGS:
+    -h, --help       Prints help information
+    -V, --version    Prints version information
+
+OPTIONS:
+    -C, --config <PATH>     Configuration file to use [default: ~/.config/solana/wallet/config.yml]
+    -u, --url <URL>         JSON RPC URL for the solana cluster
+    -k, --keypair <PATH>    /path/to/id.json
+```
+
+```manpage
+solana-show-account
+Show the contents of an account
+
+USAGE:
+    solana show-account [FLAGS] [OPTIONS] <ACCOUNT PUBKEY>
+
+FLAGS:
+    -h, --help        Prints help information
+        --lamports    Display balance in lamports instead of SOL
+    -V, --version     Prints version information
+
+OPTIONS:
+    -C, --config <PATH>     Configuration file to use [default: ~/.config/solana/wallet/config.yml]
+    -u, --url <URL>         JSON RPC URL for the solana cluster
+    -k, --keypair <PATH>    /path/to/id.json
+    -o, --output <FILE>     Write the account data to this file
+
+ARGS:
+    <ACCOUNT PUBKEY>    Account pubkey
+```
+
+```manpage
+solana-show-stake-account
+Show the contents of a stake account
+
+USAGE:
+    solana show-stake-account [OPTIONS] <STAKE ACCOUNT PUBKEY>
+
+FLAGS:
+    -h, --help       Prints help information
+    -V, --version    Prints version information
+
+OPTIONS:
+    -C, --config <PATH>     Configuration file to use [default: ~/.config/solana/wallet/config.yml]
+    -u, --url <URL>         JSON RPC URL for the solana cluster
+    -k, --keypair <PATH>    /path/to/id.json
+
+ARGS:
+    <STAKE ACCOUNT PUBKEY>    Stake account pubkey
+```
+
+```manpage
+solana-show-storage-account
+Show the contents of a storage account
+
+USAGE:
+    solana show-storage-account [OPTIONS] <STORAGE ACCOUNT PUBKEY>
+
+FLAGS:
+    -h, --help       Prints help information
+    -V, --version    Prints version information
+
+OPTIONS:
+    -C, --config <PATH>     Configuration file to use [default: ~/.config/solana/wallet/config.yml]
+    -u, --url <URL>         JSON RPC URL for the solana cluster
+    -k, --keypair <PATH>    /path/to/id.json
+
+ARGS:
+    <STORAGE ACCOUNT PUBKEY>    Storage account pubkey
+```
+
+```manpage
+solana-show-vote-account
+Show the contents of a vote account
+
+USAGE:
+    solana show-vote-account [OPTIONS] <VOTE ACCOUNT PUBKEY>
+
+FLAGS:
+    -h, --help       Prints help information
+    -V, --version    Prints version information
+
+OPTIONS:
+    -C, --config <PATH>     Configuration file to use [default: ~/.config/solana/wallet/config.yml]
+    -u, --url <URL>         JSON RPC URL for the solana cluster
+    -k, --keypair <PATH>    /path/to/id.json
+
+ARGS:
+    <VOTE ACCOUNT PUBKEY>    Vote account pubkey
+```
+
+```manpage
+solana-validator-info
+Publish/get Validator info on Solana
+
+USAGE:
+    solana validator-info [OPTIONS] [SUBCOMMAND]
+
+FLAGS:
+    -h, --help       Prints help information
+    -V, --version    Prints version information
+
+OPTIONS:
+    -C, --config <PATH>     Configuration file to use [default: ~/.config/solana/wallet/config.yml]
+    -u, --url <URL>         JSON RPC URL for the solana cluster
+    -k, --keypair <PATH>    /path/to/id.json
+
+SUBCOMMANDS:
+    get        Get and parse Solana Validator info
+    help       Prints this message or the help of the given subcommand(s)
+    publish    Publish Validator info on Solana
+```
+
+```manpage
+solana-withdraw-stake
+Withdraw the unstaked lamports from the stake account
+
+USAGE:
+    solana withdraw-stake [OPTIONS] <STAKE ACCOUNT KEYPAIR FILE> <DESTINATION PUBKEY> <AMOUNT> [unit]
+
+FLAGS:
+    -h, --help       Prints help information
+    -V, --version    Prints version information
+
+OPTIONS:
+    -C, --config <PATH>     Configuration file to use [default: /Users/tyeraeulberg/.config/solana/wallet/config.yml]
+    -u, --url <URL>         JSON RPC URL for the solana cluster
+    -k, --keypair <PATH>    /path/to/id.json
+
+ARGS:
+    <STAKE ACCOUNT KEYPAIR FILE>    Keypair file for the stake account, for signing the withdraw transaction.
+    <DESTINATION PUBKEY>            The account where the lamports should be transfered
+    <AMOUNT>                        The amount to withdraw from the stake account (default unit SOL)
+    <unit>                          Specify unit to use for request [possible values: SOL, lamports]
 ```

--- a/book/src/running-replicator.md
+++ b/book/src/running-replicator.md
@@ -129,7 +129,7 @@ $ export STORAGE_IDENTITY=$(solana-keygen pubkey storage-keypair.json)
 ```
 Then set up the storage accounts for your replicator by running:
 ```bash
-$ solana --keypair replicator-keypair.json airdrop 100000
+$ solana --keypair replicator-keypair.json airdrop 100000 lamports
 $ solana --keypair replicator-keypair.json create-replicator-storage-account $REPLICATOR_IDENTITY $STORAGE_IDENTITY
 ```
 Note: Every time the testnet restarts, run the steps to setup the replicator accounts again.

--- a/book/src/validator-monitor.md
+++ b/book/src/validator-monitor.md
@@ -25,10 +25,11 @@ $ solana show-vote-account 2ozWvfaXQd1X6uKh8jERoRGApDqSqcEy6fF1oN13LL2G
 ```
 
 ## Check Your Balance
-Your lamport balance should decrease by the transaction fee amount as your
-validator submits votes, and increase after serving as the leader:
+Your account balance should decrease by the transaction fee amount as your
+validator submits votes, and increase after serving as the leader. Pass the
+`--lamports` are to observe in finer detail:
 ```bash
-$ solana balance
+$ solana balance --lamports
 ```
 
 ## Check Slot Number

--- a/book/src/validator-stake.md
+++ b/book/src/validator-stake.md
@@ -10,7 +10,7 @@ $ solana-keygen new -o ~/validator-config/stake-keypair.json
 ```
 and use the cli's `delegate-stake` command to stake your validator with 42 lamports:
 ```bash
-$ solana delegate-stake ~/validator-config/stake-keypair.json ~/validator-vote-keypair.json 42
+$ solana delegate-stake ~/validator-config/stake-keypair.json ~/validator-vote-keypair.json 42 lamports
 ```
 
 Note that stakes need to warm up, and warmup increments are applied at Epoch boundaries, so it can take an hour
@@ -20,7 +20,7 @@ Assuming your node is voting, now you're up and running and generating validator
 to periodically redeem/claim your rewards:
 
 ```bash
-$ solana-wallet redeem-vote-credits ~/validator-config/stake-keypair.json ~/validator-vote-keypair.json
+$ solana redeem-vote-credits ~/validator-config/stake-keypair.json ~/validator-vote-keypair.json
 ```
 
 The rewards lamports earned are split between your stake account and the vote account according to the

--- a/book/src/validator-start.md
+++ b/book/src/validator-start.md
@@ -24,8 +24,8 @@ airdrop of lamports from the testnet drone:
 ```bash
 $ solana set --url http://testnet.solana.com:8899
 $ solana get
-$ solana airdrop 123
-$ solana balance
+$ solana airdrop 123 lamports
+$ solana balance --lamports
 ```
 
 Also try running following command to join the gossip network and view all the
@@ -52,7 +52,7 @@ $ solana set --keypair ~/validator-keypair.json
 **your validator identity keypair.**
 If you haven't, you will need to add the `--keypair` argument to each command, like:
 ```bash
-$ solana --keypair ~/validator-keypair.json airdrop 1000
+$ solana --keypair ~/validator-keypair.json airdrop 1000 lamports
 ```
 (You can always override the set configuration by explicitly passing the
 `--keypair` argument with a command.)
@@ -60,7 +60,7 @@ $ solana --keypair ~/validator-keypair.json airdrop 1000
 ### Validator Start
 Airdrop yourself some lamports to get started:
 ```bash
-$ solana airdrop 1000
+$ solana airdrop 1000 lamports
 ```
 
 Your validator will need a vote account.  Create it now with the following

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -10,3 +10,7 @@ pub mod wallet;
 pub(crate) fn lamports_to_sol(lamports: u64) -> f64 {
     lamports as f64 / 2u64.pow(34) as f64
 }
+
+pub(crate) fn sol_to_lamports(sol: f64) -> u64 {
+    (sol * 2u64.pow(34) as f64) as u64
+}

--- a/cli/tests/deploy.rs
+++ b/cli/tests/deploy.rs
@@ -34,6 +34,7 @@ fn test_wallet_deploy_program() {
         drone_host: None,
         drone_port: drone_addr.port(),
         lamports: 50,
+        use_lamports_unit: true,
     };
     process_command(&config).unwrap();
 

--- a/cli/tests/pay.rs
+++ b/cli/tests/pay.rs
@@ -66,14 +66,14 @@ fn test_wallet_timestamp_tx() {
     // Make transaction (from config_payer to bob_pubkey) requiring timestamp from config_witness
     let date_string = "\"2018-09-19T17:30:59Z\"";
     let dt: DateTime<Utc> = serde_json::from_str(&date_string).unwrap();
-    config_payer.command = WalletCommand::Pay(
-        10,
-        bob_pubkey,
-        Some(dt),
-        Some(config_witness.keypair.pubkey()),
-        None,
-        None,
-    );
+    config_payer.command = WalletCommand::Pay {
+        lamports: 10,
+        to: bob_pubkey,
+        timestamp: Some(dt),
+        timestamp_pubkey: Some(config_witness.keypair.pubkey()),
+        witnesses: None,
+        cancelable: None,
+    };
     let sig_response = process_command(&config_payer);
 
     let object: Value = serde_json::from_str(&sig_response.unwrap()).unwrap();
@@ -133,14 +133,14 @@ fn test_wallet_witness_tx() {
     .unwrap();
 
     // Make transaction (from config_payer to bob_pubkey) requiring witness signature from config_witness
-    config_payer.command = WalletCommand::Pay(
-        10,
-        bob_pubkey,
-        None,
-        None,
-        Some(vec![config_witness.keypair.pubkey()]),
-        None,
-    );
+    config_payer.command = WalletCommand::Pay {
+        lamports: 10,
+        to: bob_pubkey,
+        timestamp: None,
+        timestamp_pubkey: None,
+        witnesses: Some(vec![config_witness.keypair.pubkey()]),
+        cancelable: None,
+    };
     let sig_response = process_command(&config_payer);
 
     let object: Value = serde_json::from_str(&sig_response.unwrap()).unwrap();
@@ -193,14 +193,14 @@ fn test_wallet_cancel_tx() {
         .unwrap();
 
     // Make transaction (from config_payer to bob_pubkey) requiring witness signature from config_witness
-    config_payer.command = WalletCommand::Pay(
-        10,
-        bob_pubkey,
-        None,
-        None,
-        Some(vec![config_witness.keypair.pubkey()]),
-        Some(config_payer.keypair.pubkey()),
-    );
+    config_payer.command = WalletCommand::Pay {
+        lamports: 10,
+        to: bob_pubkey,
+        timestamp: None,
+        timestamp_pubkey: None,
+        witnesses: Some(vec![config_witness.keypair.pubkey()]),
+        cancelable: Some(config_payer.keypair.pubkey()),
+    };
     let sig_response = process_command(&config_payer).unwrap();
 
     let object: Value = serde_json::from_str(&sig_response).unwrap();

--- a/cli/tests/request_airdrop.rs
+++ b/cli/tests/request_airdrop.rs
@@ -19,6 +19,7 @@ fn test_wallet_request_airdrop() {
         drone_host: None,
         drone_port: drone_addr.port(),
         lamports: 50,
+        use_lamports_unit: true,
     };
 
     let sig_response = process_command(&bob_config);

--- a/multinode-demo/delegate-stake.sh
+++ b/multinode-demo/delegate-stake.sh
@@ -95,7 +95,7 @@ fi
 
 if ((airdrops_enabled)); then
   declare fees=100 # TODO: No hardcoded transaction fees, fetch the current cluster fees
-  $solana_cli "${common_args[@]}" airdrop $((stake_lamports+fees))
+  $solana_cli "${common_args[@]}" airdrop $((stake_lamports+fees)) lamports
 fi
 
 $solana_keygen new -o "$stake_keypair_path"
@@ -104,6 +104,5 @@ set -x
 $solana_cli "${common_args[@]}" \
   show-vote-account "$vote_keypair_path"
 $solana_cli "${common_args[@]}" \
-  delegate-stake $maybe_force "$stake_keypair_path" "$vote_keypair_path" "$stake_lamports"
+  delegate-stake $maybe_force "$stake_keypair_path" "$vote_keypair_path" "$stake_lamports" lamports
 $solana_cli "${common_args[@]}" show-stake-account "$stake_keypair_path"
-

--- a/multinode-demo/replicator.sh
+++ b/multinode-demo/replicator.sh
@@ -63,7 +63,7 @@ if [[ ! -r $identity_keypair ]]; then
 
   # TODO: https://github.com/solana-labs/solminer/blob/9cd2289/src/replicator.js#L17-L18
   $solana_cli --keypair "$identity_keypair" --url "$rpc_url" \
-      airdrop 100000
+      airdrop 100000 lamports
 fi
 identity_pubkey=$($solana_keygen pubkey "$identity_keypair")
 

--- a/multinode-demo/validator.sh
+++ b/multinode-demo/validator.sh
@@ -273,11 +273,11 @@ setup_validator_accounts() {
     echo "Adding $node_lamports to validator identity account:"
     (
       declare fees=100 # TODO: No hardcoded transaction fees, fetch the current cluster fees
-      wallet airdrop $((node_lamports+fees))
+      wallet airdrop $((node_lamports+fees)) lamports
     ) || return $?
   else
     echo "Validator identity account balance:"
-    wallet balance || return $?
+    wallet balance --lamports || return $?
   fi
 
   if ! wallet show-vote-account "$voting_keypair_path"; then

--- a/scripts/solana-install-deploy.sh
+++ b/scripts/solana-install-deploy.sh
@@ -72,10 +72,10 @@ PATH="$SOLANA_ROOT"/target/debug:$PATH
 
 set -x
 # shellcheck disable=SC2086 # Don't want to double quote $maybeKeypair
-balance=$(solana $maybeKeypair --url "$URL" balance)
+balance=$(solana $maybeKeypair --url "$URL" balance --lamports)
 if [[ $balance = "0 lamports" ]]; then
   # shellcheck disable=SC2086 # Don't want to double quote $maybeKeypair
-  solana $maybeKeypair --url "$URL" airdrop 42
+  solana $maybeKeypair --url "$URL" airdrop 42 lamports
 fi
 
 # shellcheck disable=SC2086 # Don't want to double quote $maybeKeypair

--- a/scripts/wallet-sanity.sh
+++ b/scripts/wallet-sanity.sh
@@ -63,11 +63,11 @@ fi
 
 $solana_cli "${entrypoint[@]}" address
 check_balance_output "0 lamports"
-$solana_cli "${entrypoint[@]}" airdrop 600
+$solana_cli "${entrypoint[@]}" airdrop 600 lamports
 check_balance_output "600 lamports"
-$solana_cli "${entrypoint[@]}" airdrop 400
+$solana_cli "${entrypoint[@]}" airdrop 400 lamports
 check_balance_output "1000 lamports"
-pay_and_confirm $garbage_address 50
+pay_and_confirm $garbage_address 50 lamports
 check_balance_output "lamports" # <-- exact number of lamports here depends on the current cluster fees
 
 echo PASS


### PR DESCRIPTION
#### Problem
Solana-cli commands only accept amounts in lamports, but SOL will be the unit most use.

#### Summary of Changes
Updates cli to accept amount inputs in SOL by default, with optional `--lamports`
In the case of airdrops, cli reports balance in whichever unit the request was made

Needs rebase on #5857

To come: update to https://github.com/solana-labs/tour-de-sol README
