### PR TITLE
Limit threadpool threads and remove serial_test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2629,23 +2629,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serial_test"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "serial_test_derive"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.42 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "sha-1"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2849,8 +2832,6 @@ dependencies = [
  "serde_derive 1.0.100 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_yaml 0.8.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "serial_test 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serial_test_derive 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-client 0.19.0-pre0",
  "solana-core 0.19.0-pre0",
  "solana-drone 0.19.0-pre0",
@@ -3084,6 +3065,7 @@ dependencies = [
  "jsonrpc-http-server 13.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-pubsub 13.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-ws-server 13.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3098,8 +3080,6 @@ dependencies = [
  "serde 1.0.100 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.100 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "serial_test 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serial_test_derive 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-budget-api 0.19.0-pre0",
  "solana-budget-program 0.19.0-pre0",
  "solana-chacha-sys 0.19.0-pre0",
@@ -3112,6 +3092,7 @@ dependencies = [
  "solana-merkle-tree 0.19.0-pre0",
  "solana-metrics 0.19.0-pre0",
  "solana-netutil 0.19.0-pre0",
+ "solana-rayon-threadlimit 0.19.0-pre0",
  "solana-runtime 0.19.0-pre0",
  "solana-sdk 0.19.0-pre0",
  "solana-stake-api 0.19.0-pre0",
@@ -3355,11 +3336,10 @@ version = "0.19.0-pre0"
 dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "serial_test 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serial_test_derive 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-client 0.19.0-pre0",
  "solana-core 0.19.0-pre0",
  "solana-logger 0.19.0-pre0",
+ "solana-rayon-threadlimit 0.19.0-pre0",
  "solana-runtime 0.19.0-pre0",
  "solana-sdk 0.19.0-pre0",
  "solana-stake-api 0.19.0-pre0",
@@ -3402,8 +3382,6 @@ dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "serial_test 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serial_test_derive 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-sdk 0.19.0-pre0",
  "sys-info 0.5.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "ureq 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3473,6 +3451,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-rayon-threadlimit"
+version = "0.19.0-pre0"
+dependencies = [
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sys-info 0.5.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "solana-replicator"
 version = "0.19.0-pre0"
 dependencies = [
@@ -3510,6 +3496,7 @@ dependencies = [
  "solana-measure 0.19.0-pre0",
  "solana-metrics 0.19.0-pre0",
  "solana-noop-program 0.19.0-pre0",
+ "solana-rayon-threadlimit 0.19.0-pre0",
  "solana-sdk 0.19.0-pre0",
  "solana-stake-api 0.19.0-pre0",
  "solana-stake-program 0.19.0-pre0",
@@ -5323,8 +5310,6 @@ dependencies = [
 "checksum serde_derive 1.0.100 (registry+https://github.com/rust-lang/crates.io-index)" = "11e410fde43e157d789fc290d26bc940778ad0fdd47836426fbac36573710dbb"
 "checksum serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)" = "051c49229f282f7c6f3813f8286cc1e3323e8051823fce42c7ea80fe13521704"
 "checksum serde_yaml 0.8.9 (registry+https://github.com/rust-lang/crates.io-index)" = "38b08a9a90e5260fe01c6480ec7c811606df6d3a660415808c3c3fa8ed95b582"
-"checksum serial_test 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "50bfbc39343545618d97869d77f38ed43e48dd77432717dbc7ed39d797f3ecbe"
-"checksum serial_test_derive 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "89dd85be2e2ad75b041c9df2892ac078fa6e0b90024028b2b9fb4125b7530f01"
 "checksum sha-1 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "23962131a91661d643c98940b20fcaffe62d776a823247be80a48fcb8b6fce68"
 "checksum sha2 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9eb6be24e4c23a84d7184280d2722f7f2731fcdd4a9d886efbfe4413e4847ea0"
 "checksum sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7b4d8bfd0e469f417657573d8451fb33d16cfe0989359b93baf3a1ffc639543d"

--- a/bench-tps/Cargo.toml
+++ b/bench-tps/Cargo.toml
@@ -31,10 +31,6 @@ solana-sdk = { path = "../sdk", version = "0.19.0-pre0" }
 solana-move-loader-program = { path = "../programs/move_loader_program", version = "0.19.0-pre0" }
 solana-move-loader-api = { path = "../programs/move_loader_api", version = "0.19.0-pre0" }
 
-[dev-dependencies]
-serial_test = "0.2.0"
-serial_test_derive = "0.2.0"
-
 [features]
 cuda = ["solana-core/cuda"]
 

--- a/bench-tps/src/bench.rs
+++ b/bench-tps/src/bench.rs
@@ -1028,7 +1028,6 @@ mod tests {
     }
 
     #[test]
-    #[serial]
     fn test_bench_tps_local_cluster_solana() {
         let mut config = Config::default();
         config.tx_count = 100;
@@ -1038,7 +1037,6 @@ mod tests {
     }
 
     #[test]
-    #[serial]
     fn test_bench_tps_local_cluster_move() {
         let mut config = Config::default();
         config.tx_count = 100;

--- a/ci/test-stable.sh
+++ b/ci/test-stable.sh
@@ -77,7 +77,7 @@ test-stable-perf)
 
   # Run root package library tests
   _ cargo +"$rust_stable" build --all --tests --bins ${V:+--verbose} --features="$ROOT_FEATURES"
-  _ cargo +"$rust_stable" test --manifest-path=core/Cargo.toml ${V:+--verbose} --features="$ROOT_FEATURES" -- --nocapture
+  _ cargo +"$rust_stable" test --manifest-path=core/Cargo.toml ${V:+--verbose} --features="$ROOT_FEATURES" -- --nocapture --test-threads=1
   ;;
 *)
   echo "Error: Unknown test: $testName"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -75,6 +75,8 @@ tokio-codec = "0.1"
 tokio-fs = "0.1"
 tokio-io = "0.1"
 untrusted = "0.7.0"
+lazy_static = "1.4.0"
+solana-rayon-threadlimit = { path = "../rayon-threadlimit", version = "0.19.0-pre0" }
 
 # reed-solomon-erasure's simd_c feature fails to build for x86_64-pc-windows-msvc, use pure-rust
 [target.'cfg(windows)'.dependencies]
@@ -92,8 +94,6 @@ features = ["lz4"]
 [dev-dependencies]
 hex-literal = "0.2.1"
 matches = "0.1.6"
-serial_test = "0.2.0"
-serial_test_derive = "0.2.0"
 ureq = { version = "0.11.0", default-features = false, features = ["json"] }
 
 [[bench]]

--- a/core/src/blocktree_processor.rs
+++ b/core/src/blocktree_processor.rs
@@ -2,6 +2,8 @@ use crate::bank_forks::BankForks;
 use crate::blocktree::{Blocktree, SlotMeta};
 use crate::entry::{Entry, EntrySlice};
 use crate::leader_schedule_cache::LeaderScheduleCache;
+use rand::seq::SliceRandom;
+use rand::thread_rng;
 use rayon::prelude::*;
 use rayon::ThreadPool;
 use solana_metrics::{datapoint, datapoint_error, inc_new_counter_debug};
@@ -16,16 +18,15 @@ use std::result;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use rand::seq::SliceRandom;
-use rand::thread_rng;
-
 pub const NUM_THREADS: u32 = 10;
+use solana_rayon_threadlimit::thread_count::get_thread_count;
 use std::cell::RefCell;
 
 thread_local!(static PAR_THREAD_POOL: RefCell<ThreadPool> = RefCell::new(rayon::ThreadPoolBuilder::new()
-                    .num_threads(sys_info::cpu_num().unwrap_or(NUM_THREADS) as usize)
+                    .num_threads(get_thread_count())
                     .build()
-                    .unwrap()));
+                    .unwrap())
+);
 
 fn first_err(results: &[Result<()>]) -> Result<()> {
     for r in results {

--- a/core/src/entry.rs
+++ b/core/src/entry.rs
@@ -14,6 +14,7 @@ use solana_merkle_tree::MerkleTree;
 use solana_metrics::inc_new_counter_warn;
 use solana_sdk::hash::Hash;
 use solana_sdk::signature::{Keypair, KeypairUtil};
+use solana_sdk::timing;
 use solana_sdk::transaction::Transaction;
 use std::borrow::Borrow;
 use std::cell::RefCell;
@@ -22,7 +23,7 @@ use std::sync::{Arc, RwLock};
 
 #[cfg(feature = "cuda")]
 use crate::sigverify::poh_verify_many;
-use solana_sdk::timing;
+use solana_rayon_threadlimit::thread_count::get_thread_count;
 #[cfg(feature = "cuda")]
 use std::sync::Mutex;
 #[cfg(feature = "cuda")]
@@ -32,7 +33,7 @@ use std::time::Instant;
 pub const NUM_THREADS: u32 = 10;
 
 thread_local!(static PAR_THREAD_POOL: RefCell<ThreadPool> = RefCell::new(rayon::ThreadPoolBuilder::new()
-                    .num_threads(sys_info::cpu_num().unwrap_or(NUM_THREADS) as usize)
+                    .num_threads(get_thread_count())
                     .build()
                     .unwrap()));
 

--- a/core/src/sigverify.rs
+++ b/core/src/sigverify.rs
@@ -20,16 +20,15 @@ use solana_sdk::transaction::Transaction;
 use std::mem::size_of;
 
 #[cfg(feature = "cuda")]
-use std::os::raw::{c_int, c_uint};
-
-#[cfg(feature = "cuda")]
 use core::ffi::c_void;
-
+use solana_rayon_threadlimit::thread_count::get_thread_count;
+#[cfg(feature = "cuda")]
+use std::os::raw::{c_int, c_uint};
 pub const NUM_THREADS: u32 = 10;
 use std::cell::RefCell;
 
 thread_local!(static PAR_THREAD_POOL: RefCell<ThreadPool> = RefCell::new(rayon::ThreadPoolBuilder::new()
-                    .num_threads(sys_info::cpu_num().unwrap_or(NUM_THREADS) as usize)
+                    .num_threads(get_thread_count())
                     .build()
                     .unwrap()));
 

--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -12,6 +12,7 @@ use crate::streamer::{PacketReceiver, PacketSender};
 use rayon::iter::{IndexedParallelIterator, IntoParallelRefMutIterator, ParallelIterator};
 use rayon::ThreadPool;
 use solana_metrics::{inc_new_counter_debug, inc_new_counter_error};
+use solana_rayon_threadlimit::thread_count::get_thread_count;
 use solana_runtime::bank::Bank;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::timing::duration_as_ms;
@@ -205,7 +206,7 @@ impl WindowService {
                 trace!("{}: RECV_WINDOW started", id);
                 let mut now = Instant::now();
                 let thread_pool = rayon::ThreadPoolBuilder::new()
-                    .num_threads(sys_info::cpu_num().unwrap_or(NUM_THREADS) as usize)
+                    .num_threads(get_thread_count())
                     .build()
                     .unwrap();
                 loop {

--- a/core/tests/cluster_info.rs
+++ b/core/tests/cluster_info.rs
@@ -191,7 +191,6 @@ fn run_simulation(stakes: &[u64], fanout: usize) {
 
 // Run with a single layer
 #[test]
-#[serial]
 fn test_retransmit_small() {
     let stakes: Vec<_> = (0..200).map(|i| i).collect();
     run_simulation(&stakes, 200);
@@ -199,7 +198,6 @@ fn test_retransmit_small() {
 
 // Make sure at least 2 layers are used
 #[test]
-#[serial]
 fn test_retransmit_medium() {
     let num_nodes = 2000;
     let stakes: Vec<_> = (0..num_nodes).map(|i| i).collect();
@@ -208,7 +206,6 @@ fn test_retransmit_medium() {
 
 // Make sure at least 2 layers are used but with equal stakes
 #[test]
-#[serial]
 fn test_retransmit_medium_equal_stakes() {
     let num_nodes = 2000;
     let stakes: Vec<_> = (0..num_nodes).map(|_| 10).collect();
@@ -217,7 +214,6 @@ fn test_retransmit_medium_equal_stakes() {
 
 // Scale down the network and make sure many layers are used
 #[test]
-#[serial]
 fn test_retransmit_large() {
     let num_nodes = 4000;
     let stakes: Vec<_> = (0..num_nodes).map(|i| i).collect();

--- a/local_cluster/Cargo.toml
+++ b/local_cluster/Cargo.toml
@@ -22,10 +22,7 @@ solana-storage-program = { path = "../programs/storage_program", version = "0.19
 solana-vote-api = { path = "../programs/vote_api", version = "0.19.0-pre0" }
 symlink = "0.1.0"
 tempfile = "3.1.0"
-
-[dev-dependencies]
-serial_test = "0.2.0"
-serial_test_derive = "0.2.0"
+solana-rayon-threadlimit = { path = "../rayon-threadlimit", version = "0.19.0-pre0" }
 
 [features]
 cuda = ["solana-core/cuda"]

--- a/local_cluster/src/local_cluster.rs
+++ b/local_cluster/src/local_cluster.rs
@@ -10,6 +10,7 @@ use solana_core::{
     service::Service,
     validator::{Validator, ValidatorConfig},
 };
+use solana_rayon_threadlimit::thread_count::init_test_thread_count;
 use solana_sdk::{
     client::SyncClient,
     clock::DEFAULT_TICKS_PER_SLOT,
@@ -116,6 +117,8 @@ impl LocalCluster {
     }
 
     pub fn new(config: &ClusterConfig) -> Self {
+        init_test_thread_count();
+
         assert_eq!(config.validator_configs.len(), config.node_stakes.len());
         let leader_keypair = Arc::new(Keypair::new());
         let leader_pubkey = leader_keypair.pubkey();

--- a/local_cluster/tests/local_cluster.rs
+++ b/local_cluster/tests/local_cluster.rs
@@ -26,9 +26,6 @@ use std::{
 use tempfile::TempDir;
 
 #[test]
-#[serial]
-#[allow(unused_attributes)]
-#[ignore]
 fn test_ledger_cleanup_service() {
     solana_logger::setup();
     error!("test_ledger_cleanup_service");
@@ -67,7 +64,6 @@ fn test_ledger_cleanup_service() {
 }
 
 #[test]
-#[serial]
 fn test_spend_and_verify_all_nodes_1() {
     solana_logger::setup();
     error!("test_spend_and_verify_all_nodes_1");
@@ -82,7 +78,6 @@ fn test_spend_and_verify_all_nodes_1() {
 }
 
 #[test]
-#[serial]
 fn test_spend_and_verify_all_nodes_2() {
     solana_logger::setup();
     error!("test_spend_and_verify_all_nodes_2");
@@ -97,7 +92,6 @@ fn test_spend_and_verify_all_nodes_2() {
 }
 
 #[test]
-#[serial]
 fn test_spend_and_verify_all_nodes_3() {
     solana_logger::setup();
     error!("test_spend_and_verify_all_nodes_3");
@@ -111,9 +105,8 @@ fn test_spend_and_verify_all_nodes_3() {
     );
 }
 
-#[allow(unused_attributes)]
 #[test]
-#[serial]
+#[allow(unused_attributes)]
 #[ignore]
 fn test_spend_and_verify_all_nodes_env_num_nodes() {
     solana_logger::setup();
@@ -132,7 +125,6 @@ fn test_spend_and_verify_all_nodes_env_num_nodes() {
 
 #[allow(unused_attributes)]
 #[test]
-#[serial]
 #[should_panic]
 fn test_fullnode_exit_default_config_should_panic() {
     solana_logger::setup();
@@ -143,7 +135,6 @@ fn test_fullnode_exit_default_config_should_panic() {
 }
 
 #[test]
-#[serial]
 fn test_fullnode_exit_2() {
     solana_logger::setup();
     error!("test_fullnode_exit_2");
@@ -161,10 +152,7 @@ fn test_fullnode_exit_2() {
 }
 
 // Cluster needs a supermajority to remain, so the minimum size for this test is 4
-#[allow(unused_attributes)]
 #[test]
-#[serial]
-#[ignore]
 fn test_leader_failure_4() {
     solana_logger::setup();
     error!("test_leader_failure_4");
@@ -186,7 +174,6 @@ fn test_leader_failure_4() {
     );
 }
 #[test]
-#[serial]
 fn test_two_unbalanced_stakes() {
     solana_logger::setup();
     error!("test_two_unbalanced_stakes");
@@ -222,14 +209,13 @@ fn test_two_unbalanced_stakes() {
 }
 
 #[test]
-#[ignore]
 fn test_forwarding() {
     // Set up a cluster where one node is never the leader, so all txs sent to this node
     // will be have to be forwarded in order to be confirmed
     let config = ClusterConfig {
         node_stakes: vec![999_990, 3],
         cluster_lamports: 2_000_000,
-        validator_configs: vec![ValidatorConfig::default(); 3],
+        validator_configs: vec![ValidatorConfig::default(); 2],
         ..ClusterConfig::default()
     };
     let cluster = LocalCluster::new(&config);
@@ -249,7 +235,6 @@ fn test_forwarding() {
 }
 
 #[test]
-#[serial]
 fn test_restart_node() {
     solana_logger::setup();
     error!("test_restart_node");
@@ -287,7 +272,6 @@ fn test_restart_node() {
 }
 
 #[test]
-#[serial]
 fn test_listener_startup() {
     let config = ClusterConfig {
         node_stakes: vec![100; 1],
@@ -303,7 +287,6 @@ fn test_listener_startup() {
 
 #[allow(unused_attributes)]
 #[test]
-#[serial]
 fn test_snapshot_restart_locktower() {
     // First set up the cluster with 2 nodes
     let snapshot_interval_slots = 10;
@@ -363,9 +346,7 @@ fn test_snapshot_restart_locktower() {
     );
 }
 
-#[allow(unused_attributes)]
 #[test]
-#[serial]
 fn test_snapshots_blocktree_floor() {
     // First set up the cluster with 1 snapshotting leader
     let snapshot_interval_slots = 10;
@@ -447,7 +428,6 @@ fn test_snapshots_blocktree_floor() {
 }
 
 #[test]
-#[serial]
 fn test_snapshots_restart_validity() {
     solana_logger::setup();
     let snapshot_interval_slots = 10;
@@ -524,15 +504,13 @@ fn test_snapshots_restart_validity() {
     }
 }
 
-#[allow(unused_attributes)]
 #[test]
-#[serial]
-#[ignore]
 fn test_fail_entry_verification_leader() {
     test_faulty_node(BroadcastStageType::FailEntryVerification);
 }
 
 #[test]
+#[allow(unused_attributes)]
 #[ignore]
 fn test_fake_blobs_broadcast_leader() {
     test_faulty_node(BroadcastStageType::BroadcastFakeBlobs);
@@ -591,10 +569,7 @@ fn test_faulty_node(faulty_node_type: BroadcastStageType) {
     );
 }
 
-#[allow(unused_attributes)]
 #[test]
-#[serial]
-#[ignore]
 fn test_repairman_catchup() {
     solana_logger::setup();
     error!("test_repairman_catchup");

--- a/local_cluster/tests/replicator.rs
+++ b/local_cluster/tests/replicator.rs
@@ -74,19 +74,16 @@ fn run_replicator_startup_basic(num_nodes: usize, num_replicators: usize) {
 }
 
 #[test]
-#[serial]
 fn test_replicator_startup_1_node() {
     run_replicator_startup_basic(1, 1);
 }
 
 #[test]
-#[serial]
 fn test_replicator_startup_2_nodes() {
     run_replicator_startup_basic(2, 1);
 }
 
 #[test]
-#[serial]
 fn test_replicator_startup_leader_hang() {
     use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
@@ -125,7 +122,6 @@ fn test_replicator_startup_leader_hang() {
 }
 
 #[test]
-#[serial]
 fn test_replicator_startup_ledger_hang() {
     solana_logger::setup();
     info!("starting replicator test");
@@ -154,7 +150,6 @@ fn test_replicator_startup_ledger_hang() {
 }
 
 #[test]
-#[serial]
 fn test_account_setup() {
     let num_nodes = 1;
     let num_replicators = 1;

--- a/metrics/Cargo.toml
+++ b/metrics/Cargo.toml
@@ -18,8 +18,6 @@ ureq = "0.11.0"
 
 [dev-dependencies]
 rand = "0.6.5"
-serial_test = "0.2.0"
-serial_test_derive = "0.2.0"
 
 [lib]
 name = "solana_metrics"

--- a/metrics/src/counter.rs
+++ b/metrics/src/counter.rs
@@ -225,7 +225,6 @@ mod tests {
     }
 
     #[test]
-    #[serial]
     fn test_counter() {
         env_logger::Builder::from_env(env_logger::Env::new().default_filter_or("solana=info"))
             .try_init()
@@ -257,7 +256,6 @@ mod tests {
     }
 
     #[test]
-    #[serial]
     fn test_metricsrate() {
         env_logger::Builder::from_env(env_logger::Env::new().default_filter_or("solana=info"))
             .try_init()
@@ -275,7 +273,6 @@ mod tests {
     }
 
     #[test]
-    #[serial]
     fn test_metricsrate_env() {
         env_logger::Builder::from_env(env_logger::Env::new().default_filter_or("solana=info"))
             .try_init()
@@ -290,7 +287,6 @@ mod tests {
     }
 
     #[test]
-    #[serial]
     fn test_inc_new_counter() {
         let _readlock = get_env_lock().read();
         //make sure that macros are syntactically correct
@@ -301,7 +297,6 @@ mod tests {
     }
 
     #[test]
-    #[serial]
     fn test_lograte() {
         env_logger::Builder::from_env(env_logger::Env::new().default_filter_or("solana=info"))
             .try_init()
@@ -322,7 +317,6 @@ mod tests {
     }
 
     #[test]
-    #[serial]
     fn test_lograte_env() {
         env_logger::Builder::from_env(env_logger::Env::new().default_filter_or("solana=info"))
             .try_init()

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -37,6 +37,7 @@ solana-vote-api = { path = "../programs/vote_api", version = "0.19.0-pre0" }
 solana-vote-program = { path = "../programs/vote_program", version = "0.19.0-pre0" }
 sys-info = "0.5.7"
 tempfile = "3.1.0"
+solana-rayon-threadlimit = { path = "../rayon-threadlimit", version = "0.19.0-pre0" }
 
 [lib]
 crate-type = ["lib"]

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -30,6 +30,7 @@ use serde::de::{MapAccess, Visitor};
 use serde::ser::{SerializeMap, Serializer};
 use serde::{Deserialize, Serialize};
 use solana_measure::measure::Measure;
+use solana_rayon_threadlimit::thread_count::get_thread_count;
 use solana_sdk::account::Account;
 use solana_sdk::pubkey::Pubkey;
 use std::collections::{HashMap, HashSet};
@@ -39,7 +40,6 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, RwLock};
-use sys_info;
 use tempfile::TempDir;
 
 pub const DEFAULT_FILE_SIZE: u64 = 4 * 1024 * 1024;
@@ -370,7 +370,7 @@ pub struct AccountsDB {
 
 impl Default for AccountsDB {
     fn default() -> Self {
-        let num_threads = sys_info::cpu_num().unwrap_or(DEFAULT_NUM_THREADS) as usize;
+        let num_threads = get_thread_count();
 
         AccountsDB {
             accounts_index: RwLock::new(AccountsIndex::default()),


### PR DESCRIPTION
#### Problem

- Rayon has high CPU usage when load is low. see https://github.com/rayon-rs/rayon/issues/642
- `#[serial]` seems to cause high cpu usage when local_cluster tests are running

Together these issues seem to cause local cluster tests to flake due to a lack of cpu compute

#### Summary of Changes

Removed the `serial_test` crate. 
Put together a hack that limits the local_cluster threadpools to 1 thread each. Keeping cpu usage in check.

Fixes #5350
