### PR TITLE
net/config/ is now shellcheck compliant

### DIFF
--- a/net/gce.sh
+++ b/net/gce.sh
@@ -620,7 +620,7 @@ EOM
 
 # Place the generated private key at /solana-scratch/id_ecdsa so it's retrievable by anybody
 # who is able to log into this machine
-mkdir -p -m 0777 "/solana-scratch"
+mkdir -m 0777 /solana-scratch
 cat > /solana-scratch/id_ecdsa <<EOK
 $(cat "$sshPrivateKey")
 EOK

--- a/net/scripts/add-testnet-solana-user-authorized_keys.sh
+++ b/net/scripts/add-testnet-solana-user-authorized_keys.sh
@@ -6,7 +6,7 @@ set -ex
 
 [[ -d /home/solana/.ssh ]] || exit 1
 
-if [[ -z $SOLANA_PUBKEYS ]]; then
+if [[ ${#SOLANA_PUBKEYS[@]} -eq 0 ]]; then
   echo "Warning: source solana-user-authorized_keys.sh first"
 fi
 


### PR DESCRIPTION
shellcheck was getting angry at the generated net config files, which is annoying
