### PR TITLE
Ignore old shreds in WindowService

### DIFF
--- a/core/src/replicator.rs
+++ b/core/src/replicator.rs
@@ -477,7 +477,7 @@ impl Replicator {
             &exit,
             RepairStrategy::RepairRange(repair_slot_range),
             &Arc::new(LeaderScheduleCache::default()),
-            |_, _, _, _| true,
+            |_, _, _, _, _| true,
         );
         info!("waiting for ledger download");
         Self::wait_for_segment_download(

--- a/core/src/retransmit_stage.rs
+++ b/core/src/retransmit_stage.rs
@@ -151,13 +151,14 @@ impl RetransmitStage {
             exit,
             repair_strategy,
             &leader_schedule_cache.clone(),
-            move |id, shred, shred_buf, working_bank| {
+            move |id, shred, shred_buf, working_bank, last_root| {
                 should_retransmit_and_persist(
                     shred,
                     shred_buf,
                     working_bank,
                     &leader_schedule_cache,
                     id,
+                    last_root,
                 )
             },
         );


### PR DESCRIPTION
#### Problem
Retransmitted shreds that are far back in history waste cycles on signature verification

#### Summary of Changes
Ignore retransmitted shreds that are before the current root

Fixes #
