### PR TITLE
More shred related cleanup

### DIFF
--- a/core/src/chacha.rs
+++ b/core/src/chacha.rs
@@ -153,7 +153,7 @@ mod tests {
         hasher.hash(&buf[..size]);
 
         //  golden needs to be updated if blob stuff changes....
-        let golden: Hash = "2rAoJANqvtAVcPDcKjBficfUN3NA1fRbCjd3Y7YYGqnu"
+        let golden: Hash = "9aHjDwufwfZgbmSdug5g58KSGqTsFx9faXuwoikDe4e4"
             .parse()
             .unwrap();
 

--- a/core/src/cluster_info.rs
+++ b/core/src/cluster_info.rs
@@ -1927,7 +1927,7 @@ mod tests {
                 0,
             );
             assert!(rv.is_empty());
-            let mut shred = Shred::FirstInSlot(DataShred::default());
+            let mut shred = Shred::Data(DataShred::default());
             shred.set_slot(2);
             shred.set_index(1);
 


### PR DESCRIPTION
#### Problem
Some of the data shred types can be removed, as the same can be inferred from the data shred flags. This will also pave way for reducing serialization/deserialization of shreds.

#### Summary of Changes
Removed the extra types. Added accessor functions to detect the types.

