### PR TITLE
Switch erasure to  solana-reed-solomon-erasure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2404,17 +2404,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "reed-solomon-erasure"
-version = "3.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "cc 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
- "rayon 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "regex"
 version = "0.1.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3092,7 +3081,6 @@ dependencies = [
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "reed-solomon-erasure 3.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rocksdb 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.100 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.100 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3112,6 +3100,7 @@ dependencies = [
  "solana-metrics 0.19.0-pre0",
  "solana-netutil 0.19.0-pre0",
  "solana-rayon-threadlimit 0.19.0-pre0",
+ "solana-reed-solomon-erasure 3.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-runtime 0.19.0-pre0",
  "solana-sdk 0.19.0-pre0",
  "solana-stake-api 0.19.0-pre0",
@@ -3503,6 +3492,17 @@ version = "0.19.0-pre0"
 dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sys-info 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "solana-reed-solomon-erasure"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rayon 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -5344,7 +5344,6 @@ dependencies = [
 "checksum rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
 "checksum redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)" = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
 "checksum redox_users 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3fe5204c3a17e97dde73f285d49be585df59ed84b50a872baf416e73b62c3828"
-"checksum reed-solomon-erasure 3.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "77cbbd4c02f53e345fe49e74255a1b10080731ffb2a03475e11df7fc8a043c37"
 "checksum regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)" = "4fd4ace6a8cf7860714a2c2280d6c1f7e6a413486c13298bbc86fd3da019402f"
 "checksum regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dc220bd33bdce8f093101afe22a037b8eb0e5af33592e6a9caafff0d4cb81cbd"
 "checksum regex-syntax 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "f9ec002c35e86791825ed294b50008eea9ddfc8def4420124fbc6b08db834957"
@@ -5390,6 +5389,7 @@ dependencies = [
 "checksum smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "ab606a9c5e214920bb66c458cd7be8ef094f813f20fe77a54cc7dbfff220d4b7"
 "checksum socket2 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)" = "e8b74de517221a2cb01a53349cf54182acdc31a074727d3079068448c0676d85"
 "checksum solana-ed25519-dalek 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1c21f9d5aa62959872194dfd086feb4e8efec1c2589d27e6a0339904759e99fc"
+"checksum solana-reed-solomon-erasure 3.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7948662ae34889f594a1c63ea573db43b7500470325291f43ba8d30c8b9773d8"
 "checksum solana_libra_bytecode_verifier 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7db48f7a723c39b9acfc52e7e0778bb5dbe55d14025fd80e17e8ea48b246415c"
 "checksum solana_libra_canonical_serialization 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d6ef5769b20ca8acd70cc0482fa0cade3c512de9f7e0e35e91b65593b9491205"
 "checksum solana_libra_compiler 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8bccb768b90dd07df05810225db6f09f74e6ba91f2edb0951ce758b2c8c17fb6"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -80,9 +80,9 @@ solana-rayon-threadlimit = { path = "../rayon-threadlimit", version = "0.19.0-pr
 
 # reed-solomon-erasure's simd_c feature fails to build for x86_64-pc-windows-msvc, use pure-rust
 [target.'cfg(windows)'.dependencies]
-reed-solomon-erasure = { version = "3.1.1", features = ["pure-rust"] }
+reed-solomon-erasure = { package = "solana-reed-solomon-erasure", version = "3.1.1", features = ["pure-rust"] }
 [target.'cfg(not(windows))'.dependencies]
-reed-solomon-erasure = "3.1.1"
+reed-solomon-erasure = { package = "solana-reed-solomon-erasure", version = "3.1.1" }
 
 [dependencies.rocksdb]
 # Avoid the vendored bzip2 within rocksdb-sys that can cause linker conflicts

--- a/core/src/erasure.rs
+++ b/core/src/erasure.rs
@@ -41,7 +41,7 @@
 //!
 //!
 
-use reed_solomon_erasure::ReedSolomon;
+use reed_solomon_erasure::{ParallelParam, ReedSolomon};
 
 //TODO(sakridge) pick these values
 /// Number of data blobs
@@ -90,13 +90,14 @@ pub struct Session(ReedSolomon);
 
 impl Session {
     pub fn new(data_count: usize, coding_count: usize) -> Result<Session> {
-        let rs = ReedSolomon::new(data_count, coding_count)?;
+        let rs = ReedSolomon::with_pparam(data_count, coding_count, ParallelParam::Disabled)?;
 
         Ok(Session(rs))
     }
 
     pub fn new_from_config(config: &ErasureConfig) -> Result<Session> {
-        let rs = ReedSolomon::new(config.num_data, config.num_coding)?;
+        let rs =
+            ReedSolomon::with_pparam(config.num_data, config.num_coding, ParallelParam::Disabled)?;
 
         Ok(Session(rs))
     }


### PR DESCRIPTION
#### Problem

reed-solomon-erasure seems to perform terribly with our config of MTU sized shreds and rayon.

#### Summary of Changes

Forked the project and disabled rayon so that our usecase performs well. Also needs an erasure coding ratio update to make full use of this. 

