### PR TITLE
Respect randomized transaction order when unlocking accounts

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -490,7 +490,7 @@ impl BankingStage {
         // TODO: Banking stage threads should be prioritized to complete faster then this queue
         // expires.
         let (mut loaded_accounts, results, mut retryable_txs, tx_count, signature_count) =
-            bank.load_and_execute_transactions(txs, None, lock_results, MAX_PROCESSING_AGE);
+            bank.load_and_execute_transactions(txs, lock_results, MAX_PROCESSING_AGE);
         load_execute_time.stop();
 
         let freeze_lock = bank.freeze_lock();

--- a/runtime/src/locked_accounts_results.rs
+++ b/runtime/src/locked_accounts_results.rs
@@ -6,6 +6,7 @@ pub struct LockedAccountsResults<'a, 'b> {
     locked_accounts_results: Vec<Result<()>>,
     bank: &'a Bank,
     transactions: &'b [Transaction],
+    txs_iteration_order: Option<Vec<usize>>,
     pub(crate) needs_unlock: bool,
 }
 
@@ -14,11 +15,13 @@ impl<'a, 'b> LockedAccountsResults<'a, 'b> {
         locked_accounts_results: Vec<Result<()>>,
         bank: &'a Bank,
         transactions: &'b [Transaction],
+        txs_iteration_order: Option<Vec<usize>>,
     ) -> Self {
         Self {
             locked_accounts_results,
             bank,
             transactions,
+            txs_iteration_order,
             needs_unlock: true,
         }
     }
@@ -29,6 +32,10 @@ impl<'a, 'b> LockedAccountsResults<'a, 'b> {
 
     pub fn transactions(&self) -> &[Transaction] {
         self.transactions
+    }
+
+    pub fn txs_iteration_order(&self) -> Option<&[usize]> {
+        self.txs_iteration_order.as_ref().map(|v| v.as_slice())
     }
 }
 


### PR DESCRIPTION
The randomized transaction order used to lock accounts was not applied when unlocking accounts, causing the wrong accounts to be unlocked at times.

Fixes #5895
