### PR TITLE
Bump sys-info from 0.5.7 to 0.5.8 for rayon-threadlimit

### DIFF
--- a/rayon-threadlimit/Cargo.toml
+++ b/rayon-threadlimit/Cargo.toml
@@ -10,4 +10,4 @@ edition = "2018"
 
 [dependencies]
 lazy_static = "1.4.0"
-sys-info = "0.5.7"
+sys-info = "0.5.8"


### PR DESCRIPTION
#### Problem
Version conflict for sys-info dependency. The other usages of sys-info were recently bumped to 0.5.8 (https://github.com/solana-labs/solana/pull/5877) but rayon-threadlimit must have been missed
