### PR TITLE
Exclude GitBook synchronization commits from CI

### DIFF
--- a/.buildkite/pipeline-upload.sh
+++ b/.buildkite/pipeline-upload.sh
@@ -15,12 +15,17 @@ if [[ -n $BUILDKITE_TAG ]]; then
     "https://github.com/solana-labs/solana/releases/$BUILDKITE_TAG"
   buildkite-agent pipeline upload ci/buildkite-release.yml
 else
+  if [[ $BUILDKITE_BRANCH =~ ^pull ]]; then
+    # Add helpful link back to the corresponding Github Pull Request
+    buildkite-agent annotate --style info --context pr-backlink \
+      "Github Pull Request: https://github.com/solana-labs/solana/$BUILDKITE_BRANCH"
+  fi
+
+  if [[ $BUILDKITE_MESSAGE =~ GitBook: ]]; then
+    buildkite-agent annotate --style info --context gitbook-ci-skip \
+      "GitBook commit detected, CI skipped"
+    exit
+  fi
+
   buildkite-agent pipeline upload ci/buildkite.yml
 fi
-
-if [[ $BUILDKITE_BRANCH =~ ^pull ]]; then
-  # Add helpful link back to the corresponding Github Pull Request
-  buildkite-agent annotate --style info --context pr-backlink \
-    "Github Pull Request: https://github.com/solana-labs/solana/$BUILDKITE_BRANCH"
-fi
-


### PR DESCRIPTION
We don't need to be clogging up CI with gitbook sync commits
