### PR TITLE
Set maintenance policy to terminate and restart for GCE

### DIFF
--- a/net/scripts/gce-provider.sh
+++ b/net/scripts/gce-provider.sh
@@ -167,6 +167,8 @@ cloud_CreateInstances() {
     --tags testnet
     --metadata "testnet=$networkName"
     --image "$imageName"
+    --maintenance-policy TERMINATE
+    --restart-on-failure
   )
 
   # shellcheck disable=SC2206 # Do not want to quote $imageName as it may contain extra args


### PR DESCRIPTION
#### Problem

We recently removed the TERMINATE maintenance policy from GCE.  This breaks the creation of any GPU-enabled instances, which do not support live migration.

#### Summary of Changes

Set termination maintenance policy, but allow the instances to reboot after such a shutdown.