### PR TITLE
Replace Shred usage with ShredInfo

### DIFF
--- a/core/src/broadcast_stage/broadcast_fake_blobs_run.rs
+++ b/core/src/broadcast_stage/broadcast_fake_blobs_run.rs
@@ -36,7 +36,7 @@ impl BroadcastRun for BroadcastFakeBlobsRun {
             .map(|meta| meta.consumed)
             .unwrap_or(0);
 
-        let (shreds, shred_bufs, _) = broadcast_utils::entries_to_shreds(
+        let (_, shred_bufs, _) = broadcast_utils::entries_to_shreds(
             receive_results.ventries,
             bank.slot(),
             receive_results.last_tick,
@@ -72,7 +72,7 @@ impl BroadcastRun for BroadcastFakeBlobsRun {
             self.last_blockhash = Hash::default();
         }
 
-        blocktree.insert_shreds(shreds, None)?;
+        blocktree.insert_shreds(shred_bufs.clone(), None)?;
         // 3) Start broadcast step
         let peers = cluster_info.read().unwrap().tvu_peers();
         peers.iter().enumerate().for_each(|(i, peer)| {

--- a/core/src/broadcast_stage/fail_entry_verification_broadcast_run.rs
+++ b/core/src/broadcast_stage/fail_entry_verification_broadcast_run.rs
@@ -53,7 +53,7 @@ impl BroadcastRun for FailEntryVerificationBroadcastRun {
 
         let seeds: Vec<[u8; 32]> = shreds.iter().map(|s| s.seed()).collect();
 
-        blocktree.insert_shreds(shreds, None)?;
+        blocktree.insert_shreds(shred_infos.clone(), None)?;
 
         // 3) Start broadcast step
         let bank_epoch = bank.get_stakers_epoch(bank.slot());

--- a/core/src/broadcast_stage/standard_broadcast_run.rs
+++ b/core/src/broadcast_stage/standard_broadcast_run.rs
@@ -92,7 +92,7 @@ impl BroadcastRun for StandardBroadcastRun {
         let all_seeds: Vec<[u8; 32]> = all_shreds.iter().map(|s| s.seed()).collect();
         let num_shreds = all_shreds.len();
         blocktree
-            .insert_shreds(all_shreds, None)
+            .insert_shreds(shred_infos.clone(), None)
             .expect("Failed to insert shreds in blocktree");
 
         let to_blobs_elapsed = to_blobs_start.elapsed();

--- a/core/src/cluster_info.rs
+++ b/core/src/cluster_info.rs
@@ -1768,7 +1768,7 @@ mod tests {
     use crate::crds_value::CrdsValueLabel;
     use crate::repair_service::RepairType;
     use crate::result::Error;
-    use crate::shred::{DataShred, Shred};
+    use crate::shred::{DataShred, Shred, ShredInfo};
     use crate::test_tx::test_tx;
     use solana_sdk::clock::DEFAULT_TICKS_PER_SLOT;
     use solana_sdk::hash::Hash;
@@ -1931,9 +1931,10 @@ mod tests {
             let mut shred = Shred::Data(DataShred::default());
             shred.set_slot(2);
             shred.set_index(1);
+            let shred_info = ShredInfo::new_from_shred(&shred);
 
             blocktree
-                .insert_shreds(vec![shred], None)
+                .insert_shreds(vec![shred_info], None)
                 .expect("Expect successful ledger write");
 
             let rv = ClusterInfo::run_window_request(
@@ -2008,10 +2009,10 @@ mod tests {
             assert!(rv.is_empty());
 
             // Create slots 1, 2, 3 with 5 blobs apiece
-            let (blobs, _) = make_many_slot_entries(1, 3, 5);
+            let (shreds, _) = make_many_slot_entries(1, 3, 5);
 
             blocktree
-                .insert_shreds(blobs, None)
+                .insert_shreds(shreds, None)
                 .expect("Expect successful ledger write");
 
             // We don't have slot 4, so we don't know how to service this requeset

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -872,7 +872,7 @@ mod test {
     use crate::entry;
     use crate::genesis_utils::{create_genesis_block, create_genesis_block_with_leader};
     use crate::replay_stage::ReplayStage;
-    use crate::shred::Shred;
+    use crate::shred::ShredInfo;
     use solana_runtime::genesis_utils::GenesisBlockInfo;
     use solana_sdk::hash::{hash, Hash};
     use solana_sdk::signature::{Keypair, KeypairUtil};
@@ -1022,7 +1022,7 @@ mod test {
     // marked as dead. Returns the error for caller to verify.
     fn check_dead_fork<F>(shred_to_insert: F) -> Result<()>
     where
-        F: Fn(&Hash, u64) -> Vec<Shred>,
+        F: Fn(&Hash, u64) -> Vec<ShredInfo>,
     {
         let ledger_path = get_tmp_ledger_path!();
         let res = {

--- a/core/src/replicator.rs
+++ b/core/src/replicator.rs
@@ -874,7 +874,7 @@ impl Replicator {
                 let shreds: Vec<ShredInfo> = packets
                     .packets
                     .into_iter()
-                    .map(|p| ShredInfo::new_from_serialized_shred(p.data.to_vec()))
+                    .filter_map(|p| ShredInfo::new_from_serialized_shred(p.data.to_vec()).ok())
                     .collect();
                 blocktree.insert_shreds(shreds, None)?;
             }

--- a/core/src/replicator.rs
+++ b/core/src/replicator.rs
@@ -11,7 +11,7 @@ use crate::repair_service;
 use crate::repair_service::{RepairService, RepairSlotRange, RepairStrategy};
 use crate::result::{Error, Result};
 use crate::service::Service;
-use crate::shred::Shred;
+use crate::shred::ShredInfo;
 use crate::storage_stage::NUM_STORAGE_SAMPLES;
 use crate::streamer::{receiver, responder, PacketReceiver};
 use crate::window_service::WindowService;
@@ -477,7 +477,7 @@ impl Replicator {
             &exit,
             RepairStrategy::RepairRange(repair_slot_range),
             &Arc::new(LeaderScheduleCache::default()),
-            |_, _, _, _, _| true,
+            |_, _, _, _| true,
         );
         info!("waiting for ledger download");
         Self::wait_for_segment_download(
@@ -871,10 +871,10 @@ impl Replicator {
                 while let Ok(mut more) = r_reader.try_recv() {
                     packets.packets.append(&mut more.packets);
                 }
-                let shreds: Vec<Shred> = packets
+                let shreds: Vec<ShredInfo> = packets
                     .packets
-                    .iter()
-                    .filter_map(|p| bincode::deserialize(&p.data).ok())
+                    .into_iter()
+                    .map(|p| ShredInfo::new_from_serialized_shred(p.data.to_vec()))
                     .collect();
                 blocktree.insert_shreds(shreds, None)?;
             }

--- a/core/src/retransmit_stage.rs
+++ b/core/src/retransmit_stage.rs
@@ -151,10 +151,9 @@ impl RetransmitStage {
             exit,
             repair_strategy,
             &leader_schedule_cache.clone(),
-            move |id, shred, shred_buf, working_bank, last_root| {
+            move |id, shred, working_bank, last_root| {
                 should_retransmit_and_persist(
                     shred,
-                    shred_buf,
                     working_bank,
                     &leader_schedule_cache,
                     id,

--- a/core/src/shred.rs
+++ b/core/src/shred.rs
@@ -930,8 +930,7 @@ impl Shredder {
                 Err(reed_solomon_erasure::Error::TooFewDataShards)?;
             }
 
-            let shred_bufs = shreds.iter().map(|shred| &shred.shred).collect();
-            shred_bufs
+            shreds.iter().map(|shred| &shred.shred).collect()
         };
 
         Ok(Self::reassemble_payload(num_data, data_shred_bufs))

--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -7,7 +7,7 @@ use crate::leader_schedule_cache::LeaderScheduleCache;
 use crate::repair_service::{RepairService, RepairStrategy};
 use crate::result::{Error, Result};
 use crate::service::Service;
-use crate::shred::Shred;
+use crate::shred::ShredInfo;
 use crate::streamer::{PacketReceiver, PacketSender};
 use rayon::iter::{IndexedParallelIterator, IntoParallelRefMutIterator, ParallelIterator};
 use rayon::ThreadPool;
@@ -28,8 +28,7 @@ pub const NUM_THREADS: u32 = 10;
 /// drop blobs that are from myself or not from the correct leader for the
 /// blob's slot
 pub fn should_retransmit_and_persist(
-    shred: &Shred,
-    shred_buf: &[u8],
+    shred: &ShredInfo,
     bank: Option<Arc<Bank>>,
     leader_schedule_cache: &Arc<LeaderScheduleCache>,
     my_pubkey: &Pubkey,
@@ -46,7 +45,7 @@ pub fn should_retransmit_and_persist(
         } else if !blocktree::verify_shred_slots(shred.slot(), shred.parent(), root) {
             inc_new_counter_debug!("streamer-recv_window-outdated_transmission", 1);
             false
-        } else if !shred.fast_verify(&shred_buf, &leader_id) {
+        } else if !shred.verify(&leader_id) {
             inc_new_counter_debug!("streamer-recv_window-invalid_signature", 1);
             false
         } else {
@@ -68,7 +67,7 @@ fn recv_window<F>(
     leader_schedule_cache: &Arc<LeaderScheduleCache>,
 ) -> Result<()>
 where
-    F: Fn(&Shred, &[u8], u64) -> bool,
+    F: Fn(&ShredInfo, u64) -> bool,
     F: Sync,
 {
     let timer = Duration::from_millis(200);
@@ -87,15 +86,11 @@ where
             .par_iter_mut()
             .enumerate()
             .filter_map(|(i, packet)| {
-                if let Ok(s) = bincode::deserialize(&packet.data) {
-                    let shred: Shred = s;
-                    if shred_filter(&shred, &packet.data, last_root) {
-                        packet.meta.slot = shred.slot();
-                        packet.meta.seed = shred.seed();
-                        Some((shred, i))
-                    } else {
-                        None
-                    }
+                let shred = ShredInfo::new_from_serialized_shred(packet.data.to_vec());
+                if shred_filter(&shred, last_root) {
+                    packet.meta.slot = shred.slot();
+                    packet.meta.seed = shred.seed();
+                    Some((shred, i))
                 } else {
                     None
                 }
@@ -179,7 +174,7 @@ impl WindowService {
     ) -> WindowService
     where
         F: 'static
-            + Fn(&Pubkey, &Shred, &[u8], Option<Arc<Bank>>, u64) -> bool
+            + Fn(&Pubkey, &ShredInfo, Option<Arc<Bank>>, u64) -> bool
             + std::marker::Send
             + std::marker::Sync,
     {
@@ -223,11 +218,10 @@ impl WindowService {
                         &id,
                         &r,
                         &retransmit,
-                        |shred, shred_buf, last_root| {
+                        |shred, last_root| {
                             shred_filter(
                                 &id,
                                 shred,
-                                shred_buf,
                                 bank_forks
                                     .as_ref()
                                     .map(|bank_forks| bank_forks.read().unwrap().working_bank()),
@@ -308,13 +302,13 @@ mod test {
         slot: u64,
         parent: u64,
         keypair: &Arc<Keypair>,
-    ) -> Vec<Shred> {
+    ) -> Vec<ShredInfo> {
         let mut shredder =
             Shredder::new(slot, parent, 0.0, keypair, 0).expect("Failed to create entry shredder");
         bincode::serialize_into(&mut shredder, &entries)
             .expect("Expect to write all entries to shreds");
         shredder.finalize_slot();
-        shredder.shred_tuples.into_iter().map(|(s, _)| s).collect()
+        shredder.shred_tuples.into_iter().map(|(_, s)| s).collect()
     }
 
     #[test]
@@ -350,21 +344,10 @@ mod test {
         let cache = Arc::new(LeaderScheduleCache::new_from_bank(&bank));
 
         let mut shreds = local_entries_to_shred(vec![Entry::default()], 0, 0, &leader_keypair);
-        let shred_bufs: Vec<_> = shreds
-            .iter()
-            .map(|s| bincode::serialize(s).unwrap())
-            .collect();
 
         // with a Bank for slot 0, blob continues
         assert_eq!(
-            should_retransmit_and_persist(
-                &shreds[0],
-                &shred_bufs[0],
-                Some(bank.clone()),
-                &cache,
-                &me_id,
-                0,
-            ),
+            should_retransmit_and_persist(&shreds[0], Some(bank.clone()), &cache, &me_id, 0,),
             true
         );
 
@@ -379,14 +362,7 @@ mod test {
         // with a Bank and no idea who leader is, blob gets thrown out
         shreds[0].set_slot(MINIMUM_SLOTS_PER_EPOCH as u64 * 3);
         assert_eq!(
-            should_retransmit_and_persist(
-                &shreds[0],
-                &shred_bufs[0],
-                Some(bank.clone()),
-                &cache,
-                &me_id,
-                0
-            ),
+            should_retransmit_and_persist(&shreds[0], Some(bank.clone()), &cache, &me_id, 0),
             false
         );
 
@@ -395,14 +371,7 @@ mod test {
         let shreds =
             local_entries_to_shred(vec![Entry::default()], slot, slot - 1, &leader_keypair);
         assert_eq!(
-            should_retransmit_and_persist(
-                &shreds[0],
-                &shred_bufs[0],
-                Some(bank.clone()),
-                &cache,
-                &me_id,
-                slot
-            ),
+            should_retransmit_and_persist(&shreds[0], Some(bank.clone()), &cache, &me_id, slot),
             false
         );
 
@@ -411,14 +380,7 @@ mod test {
         let shreds =
             local_entries_to_shred(vec![Entry::default()], slot + 1, slot - 1, &leader_keypair);
         assert_eq!(
-            should_retransmit_and_persist(
-                &shreds[0],
-                &shred_bufs[0],
-                Some(bank.clone()),
-                &cache,
-                &me_id,
-                slot
-            ),
+            should_retransmit_and_persist(&shreds[0], Some(bank.clone()), &cache, &me_id, slot),
             false
         );
 


### PR DESCRIPTION
#### Problem
Usage of Shred required additional serialization and deserialization. That caused performance degradation.

#### Summary of Changes
Use ShredInfo data structure that doesn't require deserialization to make sense of shred meta data.

Fixes #5704 
