### PR TITLE
simplify poh recorder => broadcast channel

### DIFF
--- a/core/src/broadcast_stage/broadcast_fake_blobs_run.rs
+++ b/core/src/broadcast_stage/broadcast_fake_blobs_run.rs
@@ -20,12 +20,12 @@ impl BroadcastRun for BroadcastFakeBlobsRun {
     fn run(
         &mut self,
         cluster_info: &Arc<RwLock<ClusterInfo>>,
-        receiver: &Receiver<WorkingBankEntries>,
+        receiver: &Receiver<WorkingBankEntry>,
         sock: &UdpSocket,
         blocktree: &Arc<Blocktree>,
     ) -> Result<()> {
         // 1) Pull entries from banking stage
-        let receive_results = broadcast_utils::recv_slot_shreds(receiver)?;
+        let receive_results = broadcast_utils::recv_slot_entries(receiver)?;
         let bank = receive_results.bank.clone();
         let last_tick = receive_results.last_tick;
 
@@ -37,7 +37,7 @@ impl BroadcastRun for BroadcastFakeBlobsRun {
             .unwrap_or(0);
 
         let (_, shred_bufs, _) = broadcast_utils::entries_to_shreds(
-            receive_results.ventries,
+            receive_results.entries,
             bank.slot(),
             receive_results.last_tick,
             bank.max_tick_height(),
@@ -52,12 +52,12 @@ impl BroadcastRun for BroadcastFakeBlobsRun {
             self.last_blockhash = bank.parent().unwrap().last_blockhash();
         }
 
-        let fake_ventries: Vec<_> = (0..receive_results.num_entries)
-            .map(|_| vec![(Entry::new(&self.last_blockhash, 0, vec![]), 0)])
+        let fake_entries: Vec<_> = (0..num_entries)
+            .map(|_| Entry::new(&self.last_blockhash, 0, vec![]))
             .collect();
 
         let (_fake_shreds, fake_shred_bufs, _) = broadcast_utils::entries_to_shreds(
-            fake_ventries,
+            fake_entries,
             bank.slot(),
             receive_results.last_tick,
             bank.max_tick_height(),

--- a/core/src/broadcast_stage/broadcast_fake_blobs_run.rs
+++ b/core/src/broadcast_stage/broadcast_fake_blobs_run.rs
@@ -36,6 +36,7 @@ impl BroadcastRun for BroadcastFakeBlobsRun {
             .map(|meta| meta.consumed)
             .unwrap_or(0);
 
+        let num_entries = receive_results.entries.len();
         let (_, shred_bufs, _) = broadcast_utils::entries_to_shreds(
             receive_results.entries,
             bank.slot(),

--- a/core/src/broadcast_stage/standard_broadcast_run.rs
+++ b/core/src/broadcast_stage/standard_broadcast_run.rs
@@ -52,14 +52,14 @@ impl BroadcastRun for StandardBroadcastRun {
     fn run(
         &mut self,
         cluster_info: &Arc<RwLock<ClusterInfo>>,
-        receiver: &Receiver<WorkingBankEntries>,
+        receiver: &Receiver<WorkingBankEntry>,
         sock: &UdpSocket,
         blocktree: &Arc<Blocktree>,
     ) -> Result<()> {
         // 1) Pull entries from banking stage
-        let receive_results = broadcast_utils::recv_slot_shreds(receiver)?;
+        let receive_results = broadcast_utils::recv_slot_entries(receiver)?;
         let receive_elapsed = receive_results.time_elapsed;
-        let num_entries = receive_results.num_entries;
+        let num_entries = receive_results.entries.len();
         let bank = receive_results.bank.clone();
         let last_tick = receive_results.last_tick;
         inc_new_counter_info!("broadcast_service-entries_received", num_entries);
@@ -80,9 +80,9 @@ impl BroadcastRun for StandardBroadcastRun {
         };
 
         let (all_shreds, shred_infos, latest_shred_index) = entries_to_shreds(
-            receive_results.ventries,
-            bank.slot(),
+            receive_results.entries,
             last_tick,
+            bank.slot(),
             bank.max_tick_height(),
             keypair,
             latest_shred_index,

--- a/core/src/poh_service.rs
+++ b/core/src/poh_service.rs
@@ -162,8 +162,7 @@ mod tests {
             let mut need_partial = true;
 
             while need_tick || need_entry || need_partial {
-                for entry in entry_receiver.recv().unwrap().1 {
-                    let entry = &entry.0;
+                for (_bank, (entry, _tick_height)) in entry_receiver.iter() {
                     if entry.is_tick() {
                         assert!(
                             entry.num_hashes <= poh_config.hashes_per_tick.unwrap(),

--- a/core/src/poh_service.rs
+++ b/core/src/poh_service.rs
@@ -162,33 +162,33 @@ mod tests {
             let mut need_partial = true;
 
             while need_tick || need_entry || need_partial {
-                for (_bank, (entry, _tick_height)) in entry_receiver.iter() {
-                    if entry.is_tick() {
-                        assert!(
-                            entry.num_hashes <= poh_config.hashes_per_tick.unwrap(),
-                            format!(
-                                "{} <= {}",
-                                entry.num_hashes,
-                                poh_config.hashes_per_tick.unwrap()
-                            )
-                        );
+                let (_bank, (entry, _tick_height)) = entry_receiver.recv().unwrap();
 
-                        if entry.num_hashes == poh_config.hashes_per_tick.unwrap() {
-                            need_tick = false;
-                        } else {
-                            need_partial = false;
-                        }
+                if entry.is_tick() {
+                    assert!(
+                        entry.num_hashes <= poh_config.hashes_per_tick.unwrap(),
+                        format!(
+                            "{} <= {}",
+                            entry.num_hashes,
+                            poh_config.hashes_per_tick.unwrap()
+                        )
+                    );
 
-                        hashes += entry.num_hashes;
-
-                        assert_eq!(hashes, poh_config.hashes_per_tick.unwrap());
-
-                        hashes = 0;
+                    if entry.num_hashes == poh_config.hashes_per_tick.unwrap() {
+                        need_tick = false;
                     } else {
-                        assert!(entry.num_hashes >= 1);
-                        need_entry = false;
-                        hashes += entry.num_hashes;
+                        need_partial = false;
                     }
+
+                    hashes += entry.num_hashes;
+
+                    assert_eq!(hashes, poh_config.hashes_per_tick.unwrap());
+
+                    hashes = 0;
+                } else {
+                    assert!(entry.num_hashes >= 1);
+                    need_entry = false;
+                    hashes += entry.num_hashes;
                 }
             }
             exit.store(true, Ordering::Relaxed);

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -7,7 +7,7 @@ use crate::broadcast_stage::{BroadcastStage, BroadcastStageType};
 use crate::cluster_info::ClusterInfo;
 use crate::cluster_info_vote_listener::ClusterInfoVoteListener;
 use crate::fetch_stage::FetchStage;
-use crate::poh_recorder::{PohRecorder, WorkingBankEntries};
+use crate::poh_recorder::{PohRecorder, WorkingBankEntry};
 use crate::service::Service;
 use crate::sigverify_stage::SigVerifyStage;
 use crossbeam_channel::unbounded;
@@ -30,7 +30,7 @@ impl Tpu {
     pub fn new(
         cluster_info: &Arc<RwLock<ClusterInfo>>,
         poh_recorder: &Arc<Mutex<PohRecorder>>,
-        entry_receiver: Receiver<WorkingBankEntries>,
+        entry_receiver: Receiver<WorkingBankEntry>,
         transactions_sockets: Vec<UdpSocket>,
         tpu_forwards_sockets: Vec<UdpSocket>,
         broadcast_socket: UdpSocket,

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -560,7 +560,7 @@ dependencies = [
 
 [[package]]
 name = "hex"
-version = "0.3.2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1442,7 +1442,7 @@ dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "generic-array 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "memmap 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2006,7 +2006,7 @@ dependencies = [
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
 "checksum hash32 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "12d790435639c06a7b798af9e1e331ae245b7ef915b92f70a39b4cf8c00686af"
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
-"checksum hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"
+"checksum hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "023b39be39e3a2da62a94feb433e91e8bcd37676fbc8bea371daf52b7a769a3e"
 "checksum humantime 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
 "checksum idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
 "checksum idna 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9"


### PR DESCRIPTION
#### Problem
 normal flow is for a single entry to come out of poh at every record, but
 the channel is a vector of vectors, so we're always sending a vector with
 exactly one entry

 #### Summary of Changes
 * re-jigger the channel to be the normal case (just one entry at a time)
 * shred an actual vector of entries, instead of a vector with a single entry
 * fix tests

Fixes #