### PR TITLE
Print airdrop request in proper units

### DIFF
--- a/cli/src/wallet.rs
+++ b/cli/src/wallet.rs
@@ -1734,7 +1734,9 @@ fn build_balance_message(lamports: u64, use_lamports_unit: bool) -> String {
         format!("{:?} lamport{}", lamports, ess)
     } else {
         let sol = lamports_to_sol(lamports);
-        format!("{:.8} SOL", sol)
+        let sol_str = format!("{:.8}", sol);
+        let pretty_sol = sol_str.trim_end_matches('0').trim_end_matches('.');
+        format!("{} SOL", pretty_sol)
     }
 }
 
@@ -2815,7 +2817,7 @@ mod tests {
             pubkey: config.keypair.pubkey(),
             use_lamports_unit: false,
         };
-        assert_eq!(process_command(&config).unwrap(), "0.00000000 SOL");
+        assert_eq!(process_command(&config).unwrap(), "0 SOL");
 
         let process_id = Pubkey::new_rand();
         config.command = WalletCommand::Cancel(process_id);

--- a/cli/src/wallet.rs
+++ b/cli/src/wallet.rs
@@ -547,8 +547,9 @@ fn process_airdrop(
     use_lamports_unit: bool,
 ) -> ProcessResult {
     println!(
-        "Requesting airdrop of {:?} lamports from {}",
-        lamports, drone_addr
+        "Requesting airdrop of {} from {}",
+        build_balance_message(lamports, use_lamports_unit),
+        drone_addr
     );
     let previous_balance = match rpc_client.retry_get_balance(&config.keypair.pubkey(), 5)? {
         Some(lamports) => lamports,


### PR DESCRIPTION
#### Problem
This is goofy (the lamports print):
```
$ solana airdrop 1
Keypair: ~/validator-keypair.json
RPC Endpoint: http://edge.testnet.solana.com:8899
Requesting airdrop of 17179869184 lamports from 34.83.51.122:9900
1.00000000 SOL
```

#### Summary of Changes
```
$ solana airdrop 1
Keypair: ~/validator-keypair.json
RPC Endpoint: http://edge.testnet.solana.com:8899
Requesting airdrop of 1 SOL from 34.83.51.122:9900
1 SOL
```
Displays 8-decimal precision, with trailing zeros stripped
