### PR TITLE
Add minor performance bump to shredding

### DIFF
--- a/core/benches/shredder.rs
+++ b/core/benches/shredder.rs
@@ -1,0 +1,34 @@
+#![feature(test)]
+
+extern crate test;
+
+use solana_core::shred::{Shredder, RECOMMENDED_FEC_RATE};
+use solana_sdk::signature::{Keypair, KeypairUtil};
+use std::sync::Arc;
+use test::Bencher;
+
+#[bench]
+fn bench_shredder(bencher: &mut Bencher) {
+    let kp = Arc::new(Keypair::new());
+    // 1Mb
+    let data = vec![0u8; 1000 * 1000];
+    bencher.iter(|| {
+        let mut shredder = Shredder::new(1, 0, RECOMMENDED_FEC_RATE, &kp, 0).unwrap();
+        bincode::serialize_into(&mut shredder, &data).unwrap();
+    })
+}
+
+#[bench]
+fn bench_deshredder(bencher: &mut Bencher) {
+    let kp = Arc::new(Keypair::new());
+    // 10MB
+    let data = vec![0u8; 10000 * 1000];
+    let mut shredded = Shredder::new(1, 0, 0.0, &kp, 0).unwrap();
+    let _ = bincode::serialize_into(&mut shredded, &data);
+    shredded.finalize_data();
+    let (_, shreds): (Vec<_>, Vec<_>) = shredded.shred_tuples.into_iter().unzip();
+    bencher.iter(|| {
+        let raw = &mut Shredder::deshred(&shreds).unwrap();
+        assert_ne!(raw.len(), 0);
+    })
+}

--- a/core/src/shred.rs
+++ b/core/src/shred.rs
@@ -648,9 +648,8 @@ impl Shredder {
 
     /// Finalize a data shred. Update the shred index for the next shred
     fn finalize_data_shred(&mut self) {
-        let mut data = vec![0; PACKET_DATA_SIZE];
-        let mut wr = io::Cursor::new(&mut data[..]);
-        bincode::serialize_into(&mut wr, &self.active_shred).expect("Failed to serialize shred");
+        let mut data = Vec::with_capacity(PACKET_DATA_SIZE);
+        bincode::serialize_into(&mut data, &self.active_shred).expect("Failed to serialize shred");
 
         self.active_offset = 0;
         self.index += 1;


### PR DESCRIPTION
#### Problem

When finalizing a data shred the shredder manually constructs a cursor over an empty shred buffer. This is slightly slower than just using Vec's write implementation.

#### Summary of Changes

Used Vec's write implementation that just calls `extend_from_slice` internally. 
Added benches for shredding and deshredding

```
New baseline on master without signing
1Mb (8 * 1000 * 1000)
test bench_shredder   ... bench:  17,840,548 ns/iter (+/- 785,096)
test bench_shredder   ... bench:  17,823,871 ns/iter (+/- 780,049)
test bench_shredder   ... bench:  17,715,145 ns/iter (+/- 732,939)

1Mb (8 * 1000 * 1000) this PR and without signing
test bench_shredder   ... bench:  16,590,388 ns/iter (+/- 690,641)
test bench_shredder   ... bench:  16,818,323 ns/iter (+/- 554,646)
test bench_shredder   ... bench:  16,868,505 ns/iter (+/- 575,900)
```

