### PR TITLE
Add parallel shred signing to shredder

### DIFF
--- a/rayon-threadlimit/src/lib.rs
+++ b/rayon-threadlimit/src/lib.rs
@@ -4,9 +4,12 @@ extern crate lazy_static;
 use std::sync::RwLock;
 
 //TODO remove this hack when rayon fixes itself
+
 lazy_static! {
+// reduce the number of threads each pool is allowed to half the cpu core count, to avoid rayon
+// hogging cpu
     static ref MAX_RAYON_THREADS: RwLock<usize> =
-        RwLock::new(sys_info::cpu_num().unwrap() as usize);
+        RwLock::new(sys_info::cpu_num().unwrap() as usize / 2);
 }
 
 pub fn get_thread_count() -> usize {


### PR DESCRIPTION
#### Problem

Shreds are signed serially on a single thread

#### Summary of Changes

Add a `thread_local!` threadpool to shredder. 
Limit the number of threads each rayon threadpool is allowed to ` cpu_num / 2 `. We might need to tune this later. But benches show an improvement when the pool is smaller. Likely due to the rayon cpu hogging bug. 

