### PR TITLE
Remove bloat due to test symbols

### DIFF
--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -1227,6 +1227,7 @@ version = "0.19.0-pre0"
 dependencies = [
  "solana-bpf-rust-128bit-dep 0.19.0-pre0",
  "solana-sdk 0.19.0-pre0",
+ "solana-sdk-bpf-test 0.19.0-pre0",
 ]
 
 [[package]]
@@ -1234,6 +1235,7 @@ name = "solana-bpf-rust-128bit-dep"
 version = "0.19.0-pre0"
 dependencies = [
  "solana-sdk 0.19.0-pre0",
+ "solana-sdk-bpf-test 0.19.0-pre0",
 ]
 
 [[package]]
@@ -1241,6 +1243,7 @@ name = "solana-bpf-rust-alloc"
 version = "0.19.0-pre0"
 dependencies = [
  "solana-sdk 0.19.0-pre0",
+ "solana-sdk-bpf-test 0.19.0-pre0",
 ]
 
 [[package]]
@@ -1249,6 +1252,7 @@ version = "0.19.0-pre0"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-sdk 0.19.0-pre0",
+ "solana-sdk-bpf-test 0.19.0-pre0",
 ]
 
 [[package]]
@@ -1256,6 +1260,7 @@ name = "solana-bpf-rust-external-spend"
 version = "0.19.0-pre0"
 dependencies = [
  "solana-sdk 0.19.0-pre0",
+ "solana-sdk-bpf-test 0.19.0-pre0",
 ]
 
 [[package]]
@@ -1263,6 +1268,7 @@ name = "solana-bpf-rust-iter"
 version = "0.19.0-pre0"
 dependencies = [
  "solana-sdk 0.19.0-pre0",
+ "solana-sdk-bpf-test 0.19.0-pre0",
 ]
 
 [[package]]
@@ -1271,6 +1277,7 @@ version = "0.19.0-pre0"
 dependencies = [
  "solana-bpf-rust-many-args-dep 0.19.0-pre0",
  "solana-sdk 0.19.0-pre0",
+ "solana-sdk-bpf-test 0.19.0-pre0",
 ]
 
 [[package]]
@@ -1278,6 +1285,7 @@ name = "solana-bpf-rust-many-args-dep"
 version = "0.19.0-pre0"
 dependencies = [
  "solana-sdk 0.19.0-pre0",
+ "solana-sdk-bpf-test 0.19.0-pre0",
 ]
 
 [[package]]
@@ -1285,6 +1293,7 @@ name = "solana-bpf-rust-noop"
 version = "0.19.0-pre0"
 dependencies = [
  "solana-sdk 0.19.0-pre0",
+ "solana-sdk-bpf-test 0.19.0-pre0",
 ]
 
 [[package]]
@@ -1292,6 +1301,7 @@ name = "solana-bpf-rust-panic"
 version = "0.19.0-pre0"
 dependencies = [
  "solana-sdk 0.19.0-pre0",
+ "solana-sdk-bpf-test 0.19.0-pre0",
 ]
 
 [[package]]
@@ -1300,6 +1310,7 @@ version = "0.19.0-pre0"
 dependencies = [
  "solana-bpf-rust-param-passing-dep 0.19.0-pre0",
  "solana-sdk 0.19.0-pre0",
+ "solana-sdk-bpf-test 0.19.0-pre0",
 ]
 
 [[package]]
@@ -1307,6 +1318,7 @@ name = "solana-bpf-rust-param-passing-dep"
 version = "0.19.0-pre0"
 dependencies = [
  "solana-sdk 0.19.0-pre0",
+ "solana-sdk-bpf-test 0.19.0-pre0",
 ]
 
 [[package]]
@@ -1314,6 +1326,7 @@ name = "solana-bpf-rust-sysval"
 version = "0.19.0-pre0"
 dependencies = [
  "solana-sdk 0.19.0-pre0",
+ "solana-sdk-bpf-test 0.19.0-pre0",
 ]
 
 [[package]]
@@ -1459,6 +1472,10 @@ dependencies = [
  "solana-logger 0.19.0-pre0",
  "untrusted 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "solana-sdk-bpf-test"
+version = "0.19.0-pre0"
 
 [[package]]
 name = "solana-stake-api"

--- a/programs/bpf/build.rs
+++ b/programs/bpf/build.rs
@@ -39,9 +39,8 @@ fn rerun_if_changed(files: &[&str], directories: &[&str], excludes: &[&str]) {
 fn main() {
     let bpf_c = !env::var("CARGO_FEATURE_BPF_C").is_err();
     if bpf_c {
-        let install_dir = "OUT_DIR=../target/".to_string()
-            + &env::var("PROFILE").unwrap()
-            + &"/bpf".to_string();
+        let install_dir =
+            "OUT_DIR=../target/".to_string() + &env::var("PROFILE").unwrap() + &"/bpf".to_string();
 
         println!("cargo:warning=(not a warning) Building C-based BPF programs");
         assert!(Command::new("make")

--- a/programs/bpf/rust/128bit/Cargo.toml
+++ b/programs/bpf/rust/128bit/Cargo.toml
@@ -15,6 +15,9 @@ edition = "2018"
 solana-sdk = { path = "../../../../sdk/", version = "0.19.0-pre0", default-features = false }
 solana-bpf-rust-128bit-dep = { path = "../128bit_dep", version = "0.19.0-pre0" }
 
+[dev_dependencies]
+solana-sdk-bpf-test = { path = "../../../../sdk/bpf/rust/test", version = "0.19.0-pre0" }
+
 [features]
 program = ["solana-sdk/program"]
 default = ["program"]

--- a/programs/bpf/rust/128bit/src/lib.rs
+++ b/programs/bpf/rust/128bit/src/lib.rs
@@ -49,3 +49,14 @@ pub extern "C" fn entrypoint(_input: *mut u8) -> u32 {
 
     SUCCESS
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    extern crate solana_sdk_bpf_test;
+
+    #[test]
+    fn test_entrypoint() {
+        assert_eq!(SUCCESS, entrypoint(std::ptr::null_mut()));
+    }
+}

--- a/programs/bpf/rust/128bit/src/lib.rs
+++ b/programs/bpf/rust/128bit/src/lib.rs
@@ -53,7 +53,8 @@ pub extern "C" fn entrypoint(_input: *mut u8) -> u32 {
 #[cfg(test)]
 mod test {
     use super::*;
-    extern crate solana_sdk_bpf_test;
+    // Pulls in the stubs requried for `info!()`
+    solana_sdk_bpf_test::stubs!();
 
     #[test]
     fn test_entrypoint() {

--- a/programs/bpf/rust/128bit_dep/Cargo.toml
+++ b/programs/bpf/rust/128bit_dep/Cargo.toml
@@ -14,6 +14,9 @@ edition = "2018"
 [dependencies]
 solana-sdk = { path = "../../../../sdk/", version = "0.19.0-pre0", default-features = false }
 
+[dev_dependencies]
+solana-sdk-bpf-test = { path = "../../../../sdk/bpf/rust/test", version = "0.19.0-pre0" }
+
 [features]
 program = ["solana-sdk/program"]
 default = ["program"]

--- a/programs/bpf/rust/alloc/Cargo.toml
+++ b/programs/bpf/rust/alloc/Cargo.toml
@@ -14,6 +14,9 @@ edition = "2018"
 [dependencies]
 solana-sdk = { path = "../../../../sdk/", version = "0.19.0-pre0", default-features = false }
 
+[dev_dependencies]
+solana-sdk-bpf-test = { path = "../../../../sdk/bpf/rust/test", version = "0.19.0-pre0" }
+
 [features]
 program = ["solana-sdk/program"]
 default = ["program"]

--- a/programs/bpf/rust/alloc/src/lib.rs
+++ b/programs/bpf/rust/alloc/src/lib.rs
@@ -106,19 +106,8 @@ pub extern "C" fn entrypoint(_input: *mut u8) -> u32 {
 #[cfg(test)]
 mod test {
     use super::*;
-    extern crate solana_sdk_bpf_test;
-
-    #[test]
-    fn pull_in_externs() {
-        // Rust on Linux excludes the solana_sdk_bpf_test library unless there is a
-        // direct dependency, use this test to force the pull in of the library.
-        // This is not necessary on macos and unfortunate on Linux
-        // Issue #4972
-        extern crate solana_sdk_bpf_test;
-        use solana_sdk_bpf_test::*;
-        unsafe { sol_log_("X".as_ptr(), 1) };
-        sol_log_64_(1, 2, 3, 4, 5);
-    }
+    // Pulls in the stubs requried for `info!()`
+    solana_sdk_bpf_test::stubs!();
 
     #[test]
     fn test_entrypoint() {

--- a/programs/bpf/rust/alloc/src/lib.rs
+++ b/programs/bpf/rust/alloc/src/lib.rs
@@ -102,3 +102,14 @@ pub extern "C" fn entrypoint(_input: *mut u8) -> u32 {
 
     SUCCESS
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    extern crate solana_sdk_bpf_test;
+
+    #[test]
+    fn test_entrypoint() {
+        assert_eq!(SUCCESS, entrypoint(std::ptr::null_mut()));
+    }
+}

--- a/programs/bpf/rust/alloc/src/lib.rs
+++ b/programs/bpf/rust/alloc/src/lib.rs
@@ -109,6 +109,18 @@ mod test {
     extern crate solana_sdk_bpf_test;
 
     #[test]
+    fn pull_in_externs() {
+        // Rust on Linux excludes the solana_sdk_bpf_test library unless there is a
+        // direct dependency, use this test to force the pull in of the library.
+        // This is not necessary on macos and unfortunate on Linux
+        // Issue #4972
+        extern crate solana_sdk_bpf_test;
+        use solana_sdk_bpf_test::*;
+        unsafe { sol_log_("X".as_ptr(), 1) };
+        sol_log_64_(1, 2, 3, 4, 5);
+    }
+
+    #[test]
     fn test_entrypoint() {
         assert_eq!(SUCCESS, entrypoint(std::ptr::null_mut()));
     }

--- a/programs/bpf/rust/dep_crate/Cargo.toml
+++ b/programs/bpf/rust/dep_crate/Cargo.toml
@@ -15,6 +15,9 @@ edition = "2018"
 byteorder = { version = "1", default-features = false }
 solana-sdk = { path = "../../../../sdk/", version = "0.19.0-pre0", default-features = false }
 
+[dev_dependencies]
+solana-sdk-bpf-test = { path = "../../../../sdk/bpf/rust/test", version = "0.19.0-pre0" }
+
 [features]
 program = ["solana-sdk/program"]
 default = ["program"]

--- a/programs/bpf/rust/dep_crate/src/lib.rs
+++ b/programs/bpf/rust/dep_crate/src/lib.rs
@@ -16,3 +16,14 @@ pub extern "C" fn entrypoint(_input: *mut u8) -> u32 {
 
     SUCCESS
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    extern crate solana_sdk_bpf_test;
+
+    #[test]
+    fn test_entrypoint() {
+        assert_eq!(SUCCESS, entrypoint(std::ptr::null_mut()));
+    }
+}

--- a/programs/bpf/rust/dep_crate/src/lib.rs
+++ b/programs/bpf/rust/dep_crate/src/lib.rs
@@ -20,7 +20,8 @@ pub extern "C" fn entrypoint(_input: *mut u8) -> u32 {
 #[cfg(test)]
 mod test {
     use super::*;
-    extern crate solana_sdk_bpf_test;
+    // Pulls in the stubs requried for `info!()`
+    solana_sdk_bpf_test::stubs!();
 
     #[test]
     fn test_entrypoint() {

--- a/programs/bpf/rust/do.sh
+++ b/programs/bpf/rust/do.sh
@@ -28,17 +28,17 @@ perform_action() {
     set -e
     case "$1" in
     build)
-         "$sdkDir"/bpf/rust/build.sh "$2"
+        "$sdkDir"/bpf/rust/build.sh "$2"
 
-         so_path="$targetDir/$profile/"
-         so_name="solana_bpf_rust_${3%/}"
-         if [ -f "$so_path/${so_name}.so" ]; then
-               cp "$so_path/${so_name}.so" "$so_path/${so_name}_debug.so"
-                "$sdkDir"/bpf/dependencies/llvm-native/bin/llvm-objcopy --strip-all "$so_path/${so_name}.so" "$so_path/$so_name.so"
+        so_path="$targetDir/$profile/"
+        so_name="solana_bpf_rust_${3%/}"
+        if [ -f "$so_path/${so_name}.so" ]; then
+            cp "$so_path/${so_name}.so" "$so_path/${so_name}_debug.so"
+            "$sdkDir"/bpf/dependencies/llvm-native/bin/llvm-objcopy --strip-all "$so_path/${so_name}.so" "$so_path/$so_name.so"
         fi
         ;;
     clean)
-         "$sdkDir"/bpf/rust/clean.sh "$2"
+        "$sdkDir"/bpf/rust/clean.sh "$2"
         ;;
     test)
         (
@@ -77,17 +77,17 @@ perform_action() {
                 ls \
                     -la \
                     "$so" \
-                    > "${dump}-mangled.txt"
+                    >"${dump}-mangled.txt"
                 greadelf \
                     -aW \
                     "$so" \
-                    >> "${dump}-mangled.txt"
+                    >>"${dump}-mangled.txt"
                 ../"$sdkDir"/bpf/dependencies/llvm-native/bin/llvm-objdump \
                     -print-imm-hex \
                     --source \
                     --disassemble \
                     "$so" \
-                    >> "${dump}-mangled.txt"
+                    >>"${dump}-mangled.txt"
                 sed \
                     s/://g \
                     < "${dump}-mangled.txt" \
@@ -114,7 +114,7 @@ set -e
 
 if [ "$#" -ne 2 ]; then
     # Build all projects
-    for project in */ ; do
+    for project in */; do
         perform_action "$1" "$PWD/$project" "$project"
     done
 else

--- a/programs/bpf/rust/external_spend/Cargo.toml
+++ b/programs/bpf/rust/external_spend/Cargo.toml
@@ -14,6 +14,9 @@ edition = "2018"
 [dependencies]
 solana-sdk = { path = "../../../../sdk/", version = "0.19.0-pre0", default-features = false }
 
+[dev_dependencies]
+solana-sdk-bpf-test = { path = "../../../../sdk/bpf/rust/test", version = "0.19.0-pre0" }
+
 [features]
 program = ["solana-sdk/program"]
 default = ["program"]

--- a/programs/bpf/rust/iter/Cargo.toml
+++ b/programs/bpf/rust/iter/Cargo.toml
@@ -14,6 +14,9 @@ edition = "2018"
 [dependencies]
 solana-sdk = { path = "../../../../sdk/", version = "0.19.0-pre0", default-features = false }
 
+[dev_dependencies]
+solana-sdk-bpf-test = { path = "../../../../sdk/bpf/rust/test", version = "0.19.0-pre0" }
+
 [features]
 program = ["solana-sdk/program"]
 default = ["program"]

--- a/programs/bpf/rust/iter/src/lib.rs
+++ b/programs/bpf/rust/iter/src/lib.rs
@@ -18,3 +18,14 @@ pub extern "C" fn entrypoint(_input: *mut u8) -> u32 {
 
     SUCCESS
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    extern crate solana_sdk_bpf_test;
+
+    #[test]
+    fn test_entrypoint() {
+        assert_eq!(SUCCESS, entrypoint(std::ptr::null_mut()));
+    }
+}

--- a/programs/bpf/rust/iter/src/lib.rs
+++ b/programs/bpf/rust/iter/src/lib.rs
@@ -22,7 +22,8 @@ pub extern "C" fn entrypoint(_input: *mut u8) -> u32 {
 #[cfg(test)]
 mod test {
     use super::*;
-    extern crate solana_sdk_bpf_test;
+    // Pulls in the stubs requried for `info!()`
+    solana_sdk_bpf_test::stubs!();
 
     #[test]
     fn test_entrypoint() {

--- a/programs/bpf/rust/many_args/Cargo.toml
+++ b/programs/bpf/rust/many_args/Cargo.toml
@@ -15,6 +15,9 @@ edition = "2018"
 solana-sdk = { path = "../../../../sdk/", version = "0.19.0-pre0", default-features = false }
 solana-bpf-rust-many-args-dep = { path = "../many_args_dep", version = "0.19.0-pre0" }
 
+[dev_dependencies]
+solana-sdk-bpf-test = { path = "../../../../sdk/bpf/rust/test", version = "0.19.0-pre0" }
+
 [features]
 program = ["solana-sdk/program"]
 default = ["program"]

--- a/programs/bpf/rust/many_args/src/lib.rs
+++ b/programs/bpf/rust/many_args/src/lib.rs
@@ -26,3 +26,14 @@ pub extern "C" fn entrypoint(_input: *mut u8) -> u32 {
 
     SUCCESS
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    extern crate solana_sdk_bpf_test;
+
+    #[test]
+    fn test_entrypoint() {
+        assert_eq!(SUCCESS, entrypoint(std::ptr::null_mut()));
+    }
+}

--- a/programs/bpf/rust/many_args/src/lib.rs
+++ b/programs/bpf/rust/many_args/src/lib.rs
@@ -30,7 +30,8 @@ pub extern "C" fn entrypoint(_input: *mut u8) -> u32 {
 #[cfg(test)]
 mod test {
     use super::*;
-    extern crate solana_sdk_bpf_test;
+    // Pulls in the stubs requried for `info!()`
+    solana_sdk_bpf_test::stubs!();
 
     #[test]
     fn test_entrypoint() {

--- a/programs/bpf/rust/many_args_dep/Cargo.toml
+++ b/programs/bpf/rust/many_args_dep/Cargo.toml
@@ -14,6 +14,9 @@ edition = "2018"
 [dependencies]
 solana-sdk = { path = "../../../../sdk/", version = "0.19.0-pre0", default-features = false }
 
+[dev_dependencies]
+solana-sdk-bpf-test = { path = "../../../../sdk/bpf/rust/test", version = "0.19.0-pre0" }
+
 [features]
 program = ["solana-sdk/program"]
 default = ["program"]

--- a/programs/bpf/rust/many_args_dep/src/lib.rs
+++ b/programs/bpf/rust/many_args_dep/src/lib.rs
@@ -50,8 +50,8 @@ pub fn many_args_sret(
 
 #[cfg(test)]
 mod test {
-    extern crate std;
     use super::*;
+    extern crate solana_sdk_bpf_test;
 
     #[test]
     fn test_many_args() {

--- a/programs/bpf/rust/many_args_dep/src/lib.rs
+++ b/programs/bpf/rust/many_args_dep/src/lib.rs
@@ -51,7 +51,8 @@ pub fn many_args_sret(
 #[cfg(test)]
 mod test {
     use super::*;
-    extern crate solana_sdk_bpf_test;
+    // Pulls in the stubs requried for `info!()`
+    solana_sdk_bpf_test::stubs!();
 
     #[test]
     fn test_many_args() {

--- a/programs/bpf/rust/noop/Cargo.toml
+++ b/programs/bpf/rust/noop/Cargo.toml
@@ -14,6 +14,9 @@ edition = "2018"
 [dependencies]
 solana-sdk = { path = "../../../../sdk/", version = "0.19.0-pre0", default-features = false }
 
+[dev_dependencies]
+solana-sdk-bpf-test = { path = "../../../../sdk/bpf/rust/test", version = "0.19.0-pre0" }
+
 [features]
 program = ["solana-sdk/program"]
 default = ["program"]

--- a/programs/bpf/rust/noop/src/lib.rs
+++ b/programs/bpf/rust/noop/src/lib.rs
@@ -60,6 +60,8 @@ fn process_instruction(program_id: &Pubkey, accounts: &mut [AccountInfo], data: 
 #[cfg(test)]
 mod test {
     use super::*;
+    // Pulls in the stubs requried for `info!()`
+    solana_sdk_bpf_test::stubs!();
 
     #[test]
     fn test_return_sstruct() {

--- a/programs/bpf/rust/panic/Cargo.toml
+++ b/programs/bpf/rust/panic/Cargo.toml
@@ -14,6 +14,9 @@ edition = "2018"
 [dependencies]
 solana-sdk = { path = "../../../../sdk/", version = "0.19.0-pre0", default-features = false }
 
+[dev_dependencies]
+solana-sdk-bpf-test = { path = "../../../../sdk/bpf/rust/test", version = "0.19.0-pre0" }
+
 [features]
 program = ["solana-sdk/program"]
 default = ["program"]

--- a/programs/bpf/rust/param_passing/Cargo.toml
+++ b/programs/bpf/rust/param_passing/Cargo.toml
@@ -15,6 +15,9 @@ edition = "2018"
 solana-sdk = { path = "../../../../sdk/", version = "0.19.0-pre0", default-features = false }
 solana-bpf-rust-param-passing-dep = { path = "../param_passing_dep", version = "0.19.0-pre0" }
 
+[dev_dependencies]
+solana-sdk-bpf-test = { path = "../../../../sdk/bpf/rust/test", version = "0.19.0-pre0" }
+
 [features]
 program = ["solana-sdk/program"]
 default = ["program"]

--- a/programs/bpf/rust/param_passing/src/lib.rs
+++ b/programs/bpf/rust/param_passing/src/lib.rs
@@ -23,3 +23,14 @@ pub extern "C" fn entrypoint(_input: *mut u8) -> u32 {
 
     SUCCESS
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    extern crate solana_sdk_bpf_test;
+
+    #[test]
+    fn test_entrypoint() {
+        assert_eq!(SUCCESS, entrypoint(std::ptr::null_mut()));
+    }
+}

--- a/programs/bpf/rust/param_passing/src/lib.rs
+++ b/programs/bpf/rust/param_passing/src/lib.rs
@@ -27,7 +27,8 @@ pub extern "C" fn entrypoint(_input: *mut u8) -> u32 {
 #[cfg(test)]
 mod test {
     use super::*;
-    extern crate solana_sdk_bpf_test;
+    // Pulls in the stubs requried for `info!()`
+    solana_sdk_bpf_test::stubs!();
 
     #[test]
     fn test_entrypoint() {

--- a/programs/bpf/rust/param_passing_dep/Cargo.toml
+++ b/programs/bpf/rust/param_passing_dep/Cargo.toml
@@ -14,6 +14,9 @@ edition = "2018"
 [dependencies]
 solana-sdk = { path = "../../../../sdk/", version = "0.19.0-pre0", default-features = false }
 
+[dev_dependencies]
+solana-sdk-bpf-test = { path = "../../../../sdk/bpf/rust/test", version = "0.19.0-pre0" }
+
 [features]
 program = ["solana-sdk/program"]
 default = ["program"]

--- a/programs/bpf/rust/param_passing_dep/src/lib.rs
+++ b/programs/bpf/rust/param_passing_dep/src/lib.rs
@@ -2,6 +2,7 @@
 
 extern crate solana_sdk;
 
+#[derive(Debug)]
 pub struct Data<'a> {
     pub twentyone: u64,
     pub twentytwo: u64,
@@ -11,6 +12,7 @@ pub struct Data<'a> {
     pub array: &'a [u8],
 }
 
+#[derive(PartialEq, Debug)]
 pub struct TestDep {
     pub thirty: u32,
 }
@@ -19,5 +21,25 @@ impl<'a> TestDep {
         Self {
             thirty: data.twentyfive + five as u32,
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    extern crate solana_sdk_bpf_test;
+
+    #[test]
+    fn test_dep() {
+        let array = [0xA, 0xB, 0xC, 0xD, 0xE, 0xF];
+        let data = Data {
+            twentyone: 21u64,
+            twentytwo: 22u64,
+            twentythree: 23u64,
+            twentyfour: 24u64,
+            twentyfive: 25u32,
+            array: &array,
+        };
+        assert_eq!(TestDep { thirty: 30 }, TestDep::new(&data, 1, 2, 3, 4, 5));
     }
 }

--- a/programs/bpf/rust/param_passing_dep/src/lib.rs
+++ b/programs/bpf/rust/param_passing_dep/src/lib.rs
@@ -27,7 +27,8 @@ impl<'a> TestDep {
 #[cfg(test)]
 mod test {
     use super::*;
-    extern crate solana_sdk_bpf_test;
+    // Pulls in the stubs requried for `info!()`
+    solana_sdk_bpf_test::stubs!();
 
     #[test]
     fn test_dep() {

--- a/programs/bpf/rust/sysval/Cargo.toml
+++ b/programs/bpf/rust/sysval/Cargo.toml
@@ -14,6 +14,9 @@ edition = "2018"
 [dependencies]
 solana-sdk = { path = "../../../../sdk/", version = "0.19.0-pre0", default-features = false }
 
+[dev_dependencies]
+solana-sdk-bpf-test = { path = "../../../../sdk/bpf/rust/test", version = "0.19.0-pre0" }
+
 [features]
 program = ["solana-sdk/program"]
 default = ["program"]

--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -83,7 +83,7 @@ mod bpf {
         use solana_sdk::instruction::{AccountMeta, Instruction};
         use solana_sdk::pubkey::Pubkey;
         use solana_sdk::signature::{Keypair, KeypairUtil};
-        use solana_sdk::sysvar::{clock, fees, rewards, slot_hashes, stake_history, rent};
+        use solana_sdk::sysvar::{clock, fees, rent, rewards, slot_hashes, stake_history};
         use std::io::Read;
         use std::sync::Arc;
 
@@ -132,7 +132,7 @@ mod bpf {
                     AccountMeta::new(rewards::id(), false),
                     AccountMeta::new(slot_hashes::id(), false),
                     AccountMeta::new(stake_history::id(), false),
-                    AccountMeta::new(rent::id(), false)
+                    AccountMeta::new(rent::id(), false),
                 ];
                 let instruction = Instruction::new(program_id, &1u8, account_metas);
                 let result = bank_client.send_instruction(&mint_keypair, instruction);

--- a/sdk/bpf/rust/test/.gitignore
+++ b/sdk/bpf/rust/test/.gitignore
@@ -1,0 +1,3 @@
+/target/
+/farf/
+Cargo.lock

--- a/sdk/bpf/rust/test/Cargo.toml
+++ b/sdk/bpf/rust/test/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "solana-sdk-bpf-test"
+version = "0.19.0-pre0"
+description = "Solana BPF SDK test utilities"
+authors = ["Solana Maintainers <maintainers@solana.com>"]
+repository = "https://github.com/solana-labs/solana"
+license = "Apache-2.0"
+homepage = "https://solana.com/"
+edition = "2018"
+
+[workspace]
+members = []

--- a/sdk/bpf/rust/test/src/lib.rs
+++ b/sdk/bpf/rust/test/src/lib.rs
@@ -1,4 +1,4 @@
-  //! @brief Solana Rust-based BPF program utility functions and types
+//! @brief Solana Rust-based BPF program utility functions and types
 
 #[no_mangle]
 pub unsafe fn sol_log_(message: *const u8, length: u64) {
@@ -10,4 +10,16 @@ pub unsafe fn sol_log_(message: *const u8, length: u64) {
 #[no_mangle]
 pub fn sol_log_64_(arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64) {
     std::println!("{} {} {} {} {}", arg1, arg2, arg3, arg4, arg5);
+}
+
+#[macro_export]
+macro_rules! stubs {
+    () => {
+        #[test]
+        fn pull_in_externs() {
+            use $crate::*;
+            unsafe { sol_log_("sol_log_".as_ptr(), 8) };
+            sol_log_64_(1, 2, 3, 4, 5);
+        }
+    };
 }

--- a/sdk/bpf/rust/test/src/lib.rs
+++ b/sdk/bpf/rust/test/src/lib.rs
@@ -1,15 +1,13 @@
   //! @brief Solana Rust-based BPF program utility functions and types
 
-#[allow(dead_code)]
 #[no_mangle]
-pub unsafe extern "C" fn sol_log_(message: *const u8, length: u64) {
+pub unsafe fn sol_log_(message: *const u8, length: u64) {
     let slice = std::slice::from_raw_parts(message, length as usize);
     let string = std::str::from_utf8(&slice).unwrap();
     std::println!("{}", string);
 }
 
-#[allow(dead_code)]
 #[no_mangle]
-pub extern "C" fn sol_log_64_(arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64) {
+pub fn sol_log_64_(arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64) {
     std::println!("{} {} {} {} {}", arg1, arg2, arg3, arg4, arg5);
 }

--- a/sdk/bpf/rust/test/src/lib.rs
+++ b/sdk/bpf/rust/test/src/lib.rs
@@ -1,4 +1,4 @@
-//! @brief Solana Rust-based BPF program utility functions and types
+  //! @brief Solana Rust-based BPF program utility functions and types
 
 #[no_mangle]
 pub unsafe fn sol_log_(message: *const u8, length: u64) {

--- a/sdk/bpf/rust/test/src/lib.rs
+++ b/sdk/bpf/rust/test/src/lib.rs
@@ -1,13 +1,15 @@
   //! @brief Solana Rust-based BPF program utility functions and types
 
+#[allow(dead_code)]
 #[no_mangle]
-pub unsafe fn sol_log_(message: *const u8, length: u64) {
+pub unsafe extern "C" fn sol_log_(message: *const u8, length: u64) {
     let slice = std::slice::from_raw_parts(message, length as usize);
     let string = std::str::from_utf8(&slice).unwrap();
     std::println!("{}", string);
 }
 
+#[allow(dead_code)]
 #[no_mangle]
-pub fn sol_log_64_(arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64) {
+pub extern "C" fn sol_log_64_(arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64) {
     std::println!("{} {} {} {} {}", arg1, arg2, arg3, arg4, arg5);
 }

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -25,7 +25,6 @@ pub mod timing;
 pub mod account_info;
 pub mod entrypoint;
 pub mod log;
-pub mod program_test;
 
 // Modules not usable by on-chain programs
 #[cfg(not(feature = "program"))]

--- a/sdk/src/log.rs
+++ b/sdk/src/log.rs
@@ -27,26 +27,35 @@ macro_rules! info {
 /// Prints a string to stdout
 ///
 /// @param message - Message to print
+#[cfg(feature = "program")]
 pub fn sol_log(message: &str) {
     unsafe {
         sol_log_(message.as_ptr(), message.len() as u64);
     }
 }
+#[cfg(feature = "program")]
 extern "C" {
     fn sol_log_(message: *const u8, length: u64);
 }
+#[cfg(not(feature = "program"))]
+pub fn sol_log(_message: &str) {}
 
 /// Prints 64 bit values represented as hexadecimal to stdout
 ///
 /// @param argx - integer arguments to print
+
+#[cfg(feature = "program")]
 pub fn sol_log_64(arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64) {
     unsafe {
         sol_log_64_(arg1, arg2, arg3, arg4, arg5);
     }
 }
+#[cfg(feature = "program")]
 extern "C" {
     fn sol_log_64_(arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64);
 }
+#[cfg(not(feature = "program"))]
+pub fn sol_log_64(_arg1: u64, _arg2: u64, _arg3: u64, _arg4: u64, _arg5: u64) {}
 
 /// Prints the hexadecimal representation of a slice
 ///
@@ -65,7 +74,7 @@ pub fn sol_log_slice(slice: &[u8]) {
 #[allow(dead_code)]
 pub fn sol_log_params(accounts: &[AccountInfo], data: &[u8]) {
     for (i, account) in accounts.iter().enumerate() {
-        sol_log("SolKeyedAccount");
+        sol_log("AccountInfo");
         sol_log_64(0, 0, 0, 0, i as u64);
         sol_log("- Is signer");
         sol_log_64(0, 0, 0, 0, account.is_signer as u64);


### PR DESCRIPTION
#### Problem

Putting the test stubs for the BPF log functions in the Solana SDK resulted in all BPF programs pulling in those stubs and the stubs dependencies.  This resulted in bloat of even the simplest BPF programs by ~60k even though those symbols were never called.  The simplest BPF programs are typically around 1-3k.

#### Summary of Changes

Moving those stubs out of the Solana SDK and into a test only crate removes the bloat and allows BPF programs to pull the imports for tests only.

This PR also adds tests for most of the test BPF programs.

Fixes #
