### PR TITLE
Rename sdk create_genesis_block to avoid confusion

### DIFF
--- a/bench-tps/src/bench.rs
+++ b/bench-tps/src/bench.rs
@@ -936,7 +936,7 @@ mod tests {
     use solana_runtime::bank_client::BankClient;
     use solana_sdk::client::SyncClient;
     use solana_sdk::fee_calculator::FeeCalculator;
-    use solana_sdk::genesis_block::create_genesis_block;
+    use solana_sdk::genesis_block::create_basic_genesis_block;
 
     #[test]
     fn test_switch_directions() {
@@ -955,7 +955,7 @@ mod tests {
 
     #[test]
     fn test_bench_tps_bank_client() {
-        let (genesis_block, id) = create_genesis_block(10_000);
+        let (genesis_block, id) = create_basic_genesis_block(10_000);
         let bank = Bank::new(&genesis_block);
         let clients = vec![BankClient::new(bank)];
 
@@ -973,7 +973,7 @@ mod tests {
 
     #[test]
     fn test_bench_tps_fund_keys() {
-        let (genesis_block, id) = create_genesis_block(10_000);
+        let (genesis_block, id) = create_basic_genesis_block(10_000);
         let bank = Bank::new(&genesis_block);
         let client = BankClient::new(bank);
         let tx_count = 10;
@@ -989,7 +989,7 @@ mod tests {
 
     #[test]
     fn test_bench_tps_fund_keys_with_fees() {
-        let (mut genesis_block, id) = create_genesis_block(10_000);
+        let (mut genesis_block, id) = create_basic_genesis_block(10_000);
         let fee_calculator = FeeCalculator::new(11);
         genesis_block.fee_calculator = fee_calculator;
         let bank = Bank::new(&genesis_block);

--- a/core/src/genesis_utils.rs
+++ b/core/src/genesis_utils.rs
@@ -3,7 +3,7 @@ pub use solana_runtime::genesis_utils::{
 };
 use solana_sdk::pubkey::Pubkey;
 
-// same as genesis_block::create_genesis_block, but with bootstrap_leader staking logic
+// same as genesis_utils::create_genesis_block, but with bootstrap_leader staking logic
 //  for the core crate tests
 pub fn create_genesis_block(mint_lamports: u64) -> GenesisBlockInfo {
     create_genesis_block_with_leader(

--- a/local_cluster/src/tests/bench_exchange.rs
+++ b/local_cluster/src/tests/bench_exchange.rs
@@ -7,7 +7,7 @@ use solana_exchange_api::exchange_processor::process_instruction;
 use solana_exchange_api::id;
 use solana_runtime::bank::Bank;
 use solana_runtime::bank_client::BankClient;
-use solana_sdk::genesis_block::create_genesis_block;
+use solana_sdk::genesis_block::create_basic_genesis_block;
 use solana_sdk::signature::{Keypair, KeypairUtil};
 use std::process::exit;
 use std::sync::mpsc::channel;
@@ -81,7 +81,7 @@ fn test_exchange_local_cluster() {
 #[test]
 fn test_exchange_bank_client() {
     solana_logger::setup();
-    let (genesis_block, identity) = create_genesis_block(100_000_000_000_000);
+    let (genesis_block, identity) = create_basic_genesis_block(100_000_000_000_000);
     let mut bank = Bank::new(&genesis_block);
     bank.add_instruction_processor(id(), process_instruction);
     let clients = vec![BankClient::new(bank)];

--- a/local_cluster/src/tests/replicator.rs
+++ b/local_cluster/src/tests/replicator.rs
@@ -8,7 +8,7 @@ use solana_core::gossip_service::discover_cluster;
 use solana_core::replicator::Replicator;
 use solana_core::storage_stage::SLOTS_PER_TURN_TEST;
 use solana_core::validator::ValidatorConfig;
-use solana_sdk::genesis_block::create_genesis_block;
+use solana_sdk::genesis_block::create_basic_genesis_block;
 use solana_sdk::signature::{Keypair, KeypairUtil};
 use std::fs::remove_dir_all;
 use std::sync::{Arc, RwLock};
@@ -88,7 +88,7 @@ fn test_replicator_startup_leader_hang() {
     info!("starting replicator test");
 
     let leader_ledger_path = std::path::PathBuf::from("replicator_test_leader_ledger");
-    let (genesis_block, _mint_keypair) = create_genesis_block(10_000);
+    let (genesis_block, _mint_keypair) = create_basic_genesis_block(10_000);
     let (replicator_ledger_path, _blockhash) = create_new_tmp_ledger!(&genesis_block);
 
     {

--- a/programs/budget_api/src/budget_processor.rs
+++ b/programs/budget_api/src/budget_processor.rs
@@ -193,7 +193,7 @@ mod tests {
     use solana_runtime::bank_client::BankClient;
     use solana_sdk::account::Account;
     use solana_sdk::client::SyncClient;
-    use solana_sdk::genesis_block::create_genesis_block;
+    use solana_sdk::genesis_block::create_basic_genesis_block;
     use solana_sdk::hash::hash;
     use solana_sdk::instruction::InstructionError;
     use solana_sdk::message::Message;
@@ -201,7 +201,7 @@ mod tests {
     use solana_sdk::transaction::TransactionError;
 
     fn create_bank(lamports: u64) -> (Bank, Keypair) {
-        let (genesis_block, mint_keypair) = create_genesis_block(lamports);
+        let (genesis_block, mint_keypair) = create_basic_genesis_block(lamports);
         let mut bank = Bank::new(&genesis_block);
         bank.add_instruction_processor(id(), process_instruction);
         (bank, mint_keypair)

--- a/programs/config_tests/tests/config_processor.rs
+++ b/programs/config_tests/tests/config_processor.rs
@@ -9,7 +9,7 @@ use solana_config_api::{
 use solana_runtime::{bank::Bank, bank_client::BankClient};
 use solana_sdk::{
     client::SyncClient,
-    genesis_block::create_genesis_block,
+    genesis_block::create_basic_genesis_block,
     message::Message,
     pubkey::Pubkey,
     signature::{Keypair, KeypairUtil},
@@ -41,7 +41,7 @@ impl ConfigState for MyConfig {
 }
 
 fn create_bank(lamports: u64) -> (Bank, Keypair) {
-    let (genesis_block, mint_keypair) = create_genesis_block(lamports);
+    let (genesis_block, mint_keypair) = create_basic_genesis_block(lamports);
     let mut bank = Bank::new(&genesis_block);
     bank.add_instruction_processor(id(), process_instruction);
     (bank, mint_keypair)

--- a/programs/exchange_api/src/exchange_processor.rs
+++ b/programs/exchange_api/src/exchange_processor.rs
@@ -463,7 +463,7 @@ mod test {
     use solana_runtime::bank::Bank;
     use solana_runtime::bank_client::BankClient;
     use solana_sdk::client::SyncClient;
-    use solana_sdk::genesis_block::create_genesis_block;
+    use solana_sdk::genesis_block::create_basic_genesis_block;
     use solana_sdk::signature::{Keypair, KeypairUtil};
     use solana_sdk::system_instruction;
     use std::mem;
@@ -546,7 +546,7 @@ mod test {
     }
 
     fn create_bank(lamports: u64) -> (Bank, Keypair) {
-        let (genesis_block, mint_keypair) = create_genesis_block(lamports);
+        let (genesis_block, mint_keypair) = create_basic_genesis_block(lamports);
         let mut bank = Bank::new(&genesis_block);
         bank.add_instruction_processor(id(), process_instruction);
         (bank, mint_keypair)

--- a/programs/failure_program/tests/failure.rs
+++ b/programs/failure_program/tests/failure.rs
@@ -2,7 +2,7 @@ use solana_runtime::bank::Bank;
 use solana_runtime::bank_client::BankClient;
 use solana_runtime::loader_utils::create_invoke_instruction;
 use solana_sdk::client::SyncClient;
-use solana_sdk::genesis_block::create_genesis_block;
+use solana_sdk::genesis_block::create_basic_genesis_block;
 use solana_sdk::instruction::InstructionError;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::KeypairUtil;
@@ -10,7 +10,7 @@ use solana_sdk::transaction::TransactionError;
 
 #[test]
 fn test_program_native_failure() {
-    let (genesis_block, alice_keypair) = create_genesis_block(50);
+    let (genesis_block, alice_keypair) = create_basic_genesis_block(50);
     let program_id = Pubkey::new_rand();
     let bank = Bank::new(&genesis_block);
     bank.register_native_instruction_processor("solana_failure_program", &program_id);

--- a/programs/librapay_api/src/librapay_transaction.rs
+++ b/programs/librapay_api/src/librapay_transaction.rs
@@ -141,12 +141,12 @@ mod tests {
     use crate::{create_genesis, upload_mint_program, upload_payment_program};
     use solana_runtime::bank::Bank;
     use solana_runtime::bank_client::BankClient;
-    use solana_sdk::genesis_block::create_genesis_block;
+    use solana_sdk::genesis_block::create_basic_genesis_block;
     use solana_sdk::signature::{Keypair, KeypairUtil};
     use std::sync::Arc;
 
     fn create_bank(lamports: u64) -> (Arc<Bank>, Keypair, Keypair, Pubkey, Pubkey) {
-        let (genesis_block, mint_keypair) = create_genesis_block(lamports);
+        let (genesis_block, mint_keypair) = create_basic_genesis_block(lamports);
         let mut bank = Bank::new(&genesis_block);
         bank.add_instruction_processor(
             solana_move_loader_api::id(),

--- a/runtime/benches/accounts.rs
+++ b/runtime/benches/accounts.rs
@@ -5,7 +5,7 @@ extern crate test;
 use solana_runtime::accounts::{create_test_accounts, Accounts};
 use solana_runtime::bank::*;
 use solana_sdk::account::Account;
-use solana_sdk::genesis_block::create_genesis_block;
+use solana_sdk::genesis_block::create_basic_genesis_block;
 use solana_sdk::pubkey::Pubkey;
 use std::sync::Arc;
 use test::Bencher;
@@ -23,7 +23,7 @@ fn deposit_many(bank: &Bank, pubkeys: &mut Vec<Pubkey>, num: usize) {
 
 #[bench]
 fn test_accounts_create(bencher: &mut Bencher) {
-    let (genesis_block, _) = create_genesis_block(10_000);
+    let (genesis_block, _) = create_basic_genesis_block(10_000);
     let bank0 = Bank::new_with_paths(&genesis_block, Some("bench_a0".to_string()));
     bencher.iter(|| {
         let mut pubkeys: Vec<Pubkey> = vec![];
@@ -33,7 +33,7 @@ fn test_accounts_create(bencher: &mut Bencher) {
 
 #[bench]
 fn test_accounts_squash(bencher: &mut Bencher) {
-    let (genesis_block, _) = create_genesis_block(100_000);
+    let (genesis_block, _) = create_basic_genesis_block(100_000);
     let mut banks: Vec<Arc<Bank>> = Vec::with_capacity(10);
     banks.push(Arc::new(Bank::new_with_paths(
         &genesis_block,

--- a/runtime/benches/bank.rs
+++ b/runtime/benches/bank.rs
@@ -9,7 +9,7 @@ use solana_runtime::loader_utils::create_invoke_instruction;
 use solana_sdk::account::KeyedAccount;
 use solana_sdk::client::AsyncClient;
 use solana_sdk::client::SyncClient;
-use solana_sdk::genesis_block::create_genesis_block;
+use solana_sdk::genesis_block::create_basic_genesis_block;
 use solana_sdk::instruction::InstructionError;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::{Keypair, KeypairUtil};
@@ -120,7 +120,7 @@ fn do_bench_transactions(
 ) {
     solana_logger::setup();
     let ns_per_s = 1_000_000_000;
-    let (mut genesis_block, mint_keypair) = create_genesis_block(100_000_000);
+    let (mut genesis_block, mint_keypair) = create_basic_genesis_block(100_000_000);
     genesis_block.ticks_per_slot = 100;
     let mut bank = Bank::new(&genesis_block);
     bank.add_instruction_processor(Pubkey::new(&BUILTIN_PROGRAM_ID), process_instruction);

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1535,7 +1535,7 @@ mod tests {
     };
     use bincode::{deserialize_from, serialize_into, serialized_size};
     use solana_sdk::clock::DEFAULT_TICKS_PER_SLOT;
-    use solana_sdk::genesis_block::create_genesis_block;
+    use solana_sdk::genesis_block::create_basic_genesis_block;
     use solana_sdk::hash;
     use solana_sdk::instruction::InstructionError;
     use solana_sdk::poh_config::PohConfig;
@@ -1660,7 +1660,7 @@ mod tests {
 
     #[test]
     fn test_two_payments_to_one_party() {
-        let (genesis_block, mint_keypair) = create_genesis_block(10_000);
+        let (genesis_block, mint_keypair) = create_basic_genesis_block(10_000);
         let pubkey = Pubkey::new_rand();
         let bank = Bank::new(&genesis_block);
         assert_eq!(bank.last_blockhash(), genesis_block.hash());
@@ -1675,7 +1675,7 @@ mod tests {
 
     #[test]
     fn test_one_source_two_tx_one_batch() {
-        let (genesis_block, mint_keypair) = create_genesis_block(1);
+        let (genesis_block, mint_keypair) = create_basic_genesis_block(1);
         let key1 = Pubkey::new_rand();
         let key2 = Pubkey::new_rand();
         let bank = Bank::new(&genesis_block);
@@ -1700,7 +1700,7 @@ mod tests {
 
     #[test]
     fn test_one_tx_two_out_atomic_fail() {
-        let (genesis_block, mint_keypair) = create_genesis_block(1);
+        let (genesis_block, mint_keypair) = create_basic_genesis_block(1);
         let key1 = Pubkey::new_rand();
         let key2 = Pubkey::new_rand();
         let bank = Bank::new(&genesis_block);
@@ -1725,7 +1725,7 @@ mod tests {
 
     #[test]
     fn test_one_tx_two_out_atomic_pass() {
-        let (genesis_block, mint_keypair) = create_genesis_block(2);
+        let (genesis_block, mint_keypair) = create_basic_genesis_block(2);
         let key1 = Pubkey::new_rand();
         let key2 = Pubkey::new_rand();
         let bank = Bank::new(&genesis_block);
@@ -1745,7 +1745,7 @@ mod tests {
     // This test demonstrates that fees are paid even when a program fails.
     #[test]
     fn test_detect_failed_duplicate_transactions() {
-        let (mut genesis_block, mint_keypair) = create_genesis_block(2);
+        let (mut genesis_block, mint_keypair) = create_basic_genesis_block(2);
         genesis_block.fee_calculator.lamports_per_signature = 1;
         let bank = Bank::new(&genesis_block);
 
@@ -1778,7 +1778,7 @@ mod tests {
 
     #[test]
     fn test_account_not_found() {
-        let (genesis_block, mint_keypair) = create_genesis_block(0);
+        let (genesis_block, mint_keypair) = create_basic_genesis_block(0);
         let bank = Bank::new(&genesis_block);
         let keypair = Keypair::new();
         assert_eq!(
@@ -1790,7 +1790,7 @@ mod tests {
 
     #[test]
     fn test_insufficient_funds() {
-        let (genesis_block, mint_keypair) = create_genesis_block(11_000);
+        let (genesis_block, mint_keypair) = create_basic_genesis_block(11_000);
         let bank = Bank::new(&genesis_block);
         let pubkey = Pubkey::new_rand();
         bank.transfer(1_000, &mint_keypair, &pubkey).unwrap();
@@ -1812,7 +1812,7 @@ mod tests {
 
     #[test]
     fn test_transfer_to_newb() {
-        let (genesis_block, mint_keypair) = create_genesis_block(10_000);
+        let (genesis_block, mint_keypair) = create_basic_genesis_block(10_000);
         let bank = Bank::new(&genesis_block);
         let pubkey = Pubkey::new_rand();
         bank.transfer(500, &mint_keypair, &pubkey).unwrap();
@@ -1821,7 +1821,7 @@ mod tests {
 
     #[test]
     fn test_bank_deposit() {
-        let (genesis_block, _mint_keypair) = create_genesis_block(100);
+        let (genesis_block, _mint_keypair) = create_basic_genesis_block(100);
         let bank = Bank::new(&genesis_block);
 
         // Test new account
@@ -1836,7 +1836,7 @@ mod tests {
 
     #[test]
     fn test_bank_withdraw() {
-        let (genesis_block, _mint_keypair) = create_genesis_block(100);
+        let (genesis_block, _mint_keypair) = create_basic_genesis_block(100);
         let bank = Bank::new(&genesis_block);
 
         // Test no account
@@ -2037,7 +2037,7 @@ mod tests {
 
     #[test]
     fn test_debits_before_credits() {
-        let (genesis_block, mint_keypair) = create_genesis_block(2);
+        let (genesis_block, mint_keypair) = create_basic_genesis_block(2);
         let bank = Bank::new(&genesis_block);
         let keypair = Keypair::new();
         let tx0 = system_transaction::create_user_account(
@@ -2062,7 +2062,7 @@ mod tests {
 
     #[test]
     fn test_credit_only_accounts() {
-        let (genesis_block, mint_keypair) = create_genesis_block(100);
+        let (genesis_block, mint_keypair) = create_basic_genesis_block(100);
         let bank = Bank::new(&genesis_block);
         let payer0 = Keypair::new();
         let payer1 = Keypair::new();
@@ -2113,7 +2113,7 @@ mod tests {
 
     #[test]
     fn test_interleaving_locks() {
-        let (genesis_block, mint_keypair) = create_genesis_block(3);
+        let (genesis_block, mint_keypair) = create_basic_genesis_block(3);
         let bank = Bank::new(&genesis_block);
         let alice = Keypair::new();
         let bob = Keypair::new();
@@ -2152,7 +2152,7 @@ mod tests {
     fn test_credit_only_relaxed_locks() {
         use solana_sdk::message::{Message, MessageHeader};
 
-        let (genesis_block, _) = create_genesis_block(3);
+        let (genesis_block, _) = create_basic_genesis_block(3);
         let bank = Bank::new(&genesis_block);
         let key0 = Keypair::new();
         let key1 = Keypair::new();
@@ -2213,7 +2213,7 @@ mod tests {
 
     #[test]
     fn test_bank_invalid_account_index() {
-        let (genesis_block, mint_keypair) = create_genesis_block(1);
+        let (genesis_block, mint_keypair) = create_basic_genesis_block(1);
         let keypair = Keypair::new();
         let bank = Bank::new(&genesis_block);
 
@@ -2237,7 +2237,7 @@ mod tests {
 
     #[test]
     fn test_bank_pay_to_self() {
-        let (genesis_block, mint_keypair) = create_genesis_block(1);
+        let (genesis_block, mint_keypair) = create_basic_genesis_block(1);
         let key1 = Keypair::new();
         let bank = Bank::new(&genesis_block);
 
@@ -2263,7 +2263,7 @@ mod tests {
     /// Verify that the parent's vector is computed correctly
     #[test]
     fn test_bank_parents() {
-        let (genesis_block, _) = create_genesis_block(1);
+        let (genesis_block, _) = create_basic_genesis_block(1);
         let parent = Arc::new(Bank::new(&genesis_block));
 
         let bank = new_from_parent(&parent);
@@ -2273,7 +2273,7 @@ mod tests {
     /// Verifies that last ids and status cache are correctly referenced from parent
     #[test]
     fn test_bank_parent_duplicate_signature() {
-        let (genesis_block, mint_keypair) = create_genesis_block(2);
+        let (genesis_block, mint_keypair) = create_basic_genesis_block(2);
         let key1 = Keypair::new();
         let parent = Arc::new(Bank::new(&genesis_block));
 
@@ -2290,7 +2290,7 @@ mod tests {
     /// Verifies that last ids and accounts are correctly referenced from parent
     #[test]
     fn test_bank_parent_account_spend() {
-        let (genesis_block, mint_keypair) = create_genesis_block(2);
+        let (genesis_block, mint_keypair) = create_basic_genesis_block(2);
         let key1 = Keypair::new();
         let key2 = Keypair::new();
         let parent = Arc::new(Bank::new(&genesis_block));
@@ -2306,7 +2306,7 @@ mod tests {
 
     #[test]
     fn test_bank_hash_internal_state() {
-        let (genesis_block, mint_keypair) = create_genesis_block(2_000);
+        let (genesis_block, mint_keypair) = create_basic_genesis_block(2_000);
         let bank0 = Bank::new(&genesis_block);
         let bank1 = Bank::new(&genesis_block);
         let initial_state = bank0.hash_internal_state();
@@ -2325,15 +2325,15 @@ mod tests {
 
     #[test]
     fn test_hash_internal_state_genesis() {
-        let bank0 = Bank::new(&create_genesis_block(10).0);
-        let bank1 = Bank::new(&create_genesis_block(20).0);
+        let bank0 = Bank::new(&create_basic_genesis_block(10).0);
+        let bank1 = Bank::new(&create_basic_genesis_block(20).0);
         assert_ne!(bank0.hash_internal_state(), bank1.hash_internal_state());
     }
 
     #[test]
     fn test_bank_hash_internal_state_squash() {
         let collector_id = Pubkey::default();
-        let bank0 = Arc::new(Bank::new(&create_genesis_block(10).0));
+        let bank0 = Arc::new(Bank::new(&create_basic_genesis_block(10).0));
         let hash0 = bank0.hash_internal_state();
         // save hash0 because new_from_parent
         // updates sysvar entries
@@ -2356,7 +2356,7 @@ mod tests {
     #[test]
     fn test_bank_squash() {
         solana_logger::setup();
-        let (genesis_block, mint_keypair) = create_genesis_block(2);
+        let (genesis_block, mint_keypair) = create_basic_genesis_block(2);
         let key1 = Keypair::new();
         let key2 = Keypair::new();
         let parent = Arc::new(Bank::new(&genesis_block));
@@ -2417,7 +2417,7 @@ mod tests {
 
     #[test]
     fn test_bank_get_account_in_parent_after_squash() {
-        let (genesis_block, mint_keypair) = create_genesis_block(500);
+        let (genesis_block, mint_keypair) = create_basic_genesis_block(500);
         let parent = Arc::new(Bank::new(&genesis_block));
 
         let key1 = Keypair::new();
@@ -2432,7 +2432,7 @@ mod tests {
     #[test]
     fn test_bank_get_account_in_parent_after_squash2() {
         solana_logger::setup();
-        let (genesis_block, mint_keypair) = create_genesis_block(500);
+        let (genesis_block, mint_keypair) = create_basic_genesis_block(500);
         let bank0 = Arc::new(Bank::new(&genesis_block));
 
         let key1 = Keypair::new();
@@ -2578,7 +2578,7 @@ mod tests {
     #[test]
     fn test_zero_signatures() {
         solana_logger::setup();
-        let (genesis_block, mint_keypair) = create_genesis_block(500);
+        let (genesis_block, mint_keypair) = create_basic_genesis_block(500);
         let mut bank = Bank::new(&genesis_block);
         bank.fee_calculator.lamports_per_signature = 2;
         let key = Keypair::new();
@@ -2599,7 +2599,7 @@ mod tests {
 
     #[test]
     fn test_bank_get_slots_in_epoch() {
-        let (genesis_block, _) = create_genesis_block(500);
+        let (genesis_block, _) = create_basic_genesis_block(500);
 
         let bank = Bank::new(&genesis_block);
 
@@ -2613,7 +2613,7 @@ mod tests {
 
     #[test]
     fn test_is_delta_true() {
-        let (genesis_block, mint_keypair) = create_genesis_block(500);
+        let (genesis_block, mint_keypair) = create_basic_genesis_block(500);
         let bank = Arc::new(Bank::new(&genesis_block));
         let key1 = Keypair::new();
         let tx_transfer_mint_to_1 =
@@ -2633,7 +2633,7 @@ mod tests {
     #[test]
     fn test_is_votable() {
         // test normal case
-        let (genesis_block, mint_keypair) = create_genesis_block(500);
+        let (genesis_block, mint_keypair) = create_basic_genesis_block(500);
         let bank = Arc::new(Bank::new(&genesis_block));
         let key1 = Keypair::new();
         assert_eq!(bank.is_votable(), false);
@@ -2652,7 +2652,7 @@ mod tests {
         assert_eq!(bank.is_votable(), true);
 
         // test empty bank with ticks
-        let (genesis_block, _mint_keypair) = create_genesis_block(500);
+        let (genesis_block, _mint_keypair) = create_basic_genesis_block(500);
         // make an empty bank at slot 1
         let bank = new_from_parent(&Arc::new(Bank::new(&genesis_block)));
         assert_eq!(bank.is_votable(), false);
@@ -2667,7 +2667,7 @@ mod tests {
 
     #[test]
     fn test_bank_inherit_tx_count() {
-        let (genesis_block, mint_keypair) = create_genesis_block(500);
+        let (genesis_block, mint_keypair) = create_basic_genesis_block(500);
         let bank0 = Arc::new(Bank::new(&genesis_block));
 
         // Bank 1
@@ -2706,7 +2706,7 @@ mod tests {
 
     #[test]
     fn test_bank_inherit_fee_calculator() {
-        let (mut genesis_block, _mint_keypair) = create_genesis_block(500);
+        let (mut genesis_block, _mint_keypair) = create_basic_genesis_block(500);
         genesis_block.fee_calculator.target_lamports_per_signature = 123;
 
         let bank0 = Arc::new(Bank::new(&genesis_block));
@@ -2762,7 +2762,7 @@ mod tests {
 
     #[test]
     fn test_bank_0_votable() {
-        let (genesis_block, _) = create_genesis_block(500);
+        let (genesis_block, _) = create_basic_genesis_block(500);
         let bank = Arc::new(Bank::new(&genesis_block));
         //set tick height to max
         let max_tick_height = ((bank.slot + 1) * bank.ticks_per_slot - 1) as usize;
@@ -2772,7 +2772,7 @@ mod tests {
 
     #[test]
     fn test_bank_fees_account() {
-        let (mut genesis_block, _) = create_genesis_block(500);
+        let (mut genesis_block, _) = create_basic_genesis_block(500);
         genesis_block.fee_calculator.lamports_per_signature = 12345;
         let bank = Arc::new(Bank::new(&genesis_block));
 
@@ -2787,7 +2787,7 @@ mod tests {
 
     #[test]
     fn test_is_delta_with_no_committables() {
-        let (genesis_block, mint_keypair) = create_genesis_block(8000);
+        let (genesis_block, mint_keypair) = create_basic_genesis_block(8000);
         let bank = Bank::new(&genesis_block);
         bank.is_delta.store(false, Ordering::Relaxed);
 
@@ -2826,7 +2826,7 @@ mod tests {
 
     #[test]
     fn test_bank_serialize() {
-        let (genesis_block, _) = create_genesis_block(500);
+        let (genesis_block, _) = create_basic_genesis_block(500);
         let bank0 = Arc::new(Bank::new(&genesis_block));
         let bank = new_from_parent(&bank0);
 
@@ -2864,7 +2864,7 @@ mod tests {
 
     #[test]
     fn test_check_point_values() {
-        let (genesis_block, _) = create_genesis_block(500);
+        let (genesis_block, _) = create_basic_genesis_block(500);
         let bank = Arc::new(Bank::new(&genesis_block));
 
         // check that point values are 0 if no previous value was known and current values are not normal
@@ -2883,7 +2883,7 @@ mod tests {
 
     #[test]
     fn test_bank_get_program_accounts() {
-        let (genesis_block, _mint_keypair) = create_genesis_block(500);
+        let (genesis_block, _mint_keypair) = create_basic_genesis_block(500);
         let parent = Arc::new(Bank::new(&genesis_block));
 
         let bank0 = Arc::new(new_from_parent(&parent));

--- a/runtime/src/bank_client.rs
+++ b/runtime/src/bank_client.rs
@@ -219,12 +219,12 @@ impl BankClient {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use solana_sdk::genesis_block::create_genesis_block;
+    use solana_sdk::genesis_block::create_basic_genesis_block;
     use solana_sdk::instruction::AccountMeta;
 
     #[test]
     fn test_bank_client_new_with_keypairs() {
-        let (genesis_block, john_doe_keypair) = create_genesis_block(10_000);
+        let (genesis_block, john_doe_keypair) = create_basic_genesis_block(10_000);
         let john_pubkey = john_doe_keypair.pubkey();
         let jane_doe_keypair = Keypair::new();
         let jane_pubkey = jane_doe_keypair.pubkey();

--- a/runtime/src/storage_utils.rs
+++ b/runtime/src/storage_utils.rs
@@ -83,7 +83,7 @@ pub(crate) mod tests {
     use super::*;
     use crate::bank_client::BankClient;
     use solana_sdk::client::SyncClient;
-    use solana_sdk::genesis_block::create_genesis_block;
+    use solana_sdk::genesis_block::create_basic_genesis_block;
     use solana_sdk::message::Message;
     use solana_sdk::signature::{Keypair, KeypairUtil};
     use solana_storage_api::storage_contract::{StorageAccount, STORAGE_ACCOUNT_SPACE};
@@ -92,7 +92,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_store_and_recover() {
-        let (genesis_block, mint_keypair) = create_genesis_block(1000);
+        let (genesis_block, mint_keypair) = create_basic_genesis_block(1000);
         let mint_pubkey = mint_keypair.pubkey();
         let replicator_keypair = Keypair::new();
         let replicator_pubkey = replicator_keypair.pubkey();

--- a/runtime/src/system_instruction_processor.rs
+++ b/runtime/src/system_instruction_processor.rs
@@ -131,7 +131,7 @@ mod tests {
     use bincode::serialize;
     use solana_sdk::account::Account;
     use solana_sdk::client::SyncClient;
-    use solana_sdk::genesis_block::create_genesis_block;
+    use solana_sdk::genesis_block::create_basic_genesis_block;
     use solana_sdk::instruction::{AccountMeta, Instruction, InstructionError};
     use solana_sdk::signature::{Keypair, KeypairUtil};
     use solana_sdk::system_program;
@@ -330,7 +330,7 @@ mod tests {
 
     #[test]
     fn test_system_unsigned_transaction() {
-        let (genesis_block, alice_keypair) = create_genesis_block(100);
+        let (genesis_block, alice_keypair) = create_basic_genesis_block(100);
         let alice_pubkey = alice_keypair.pubkey();
         let mallory_keypair = Keypair::new();
         let mallory_pubkey = mallory_keypair.pubkey();

--- a/runtime/tests/noop.rs
+++ b/runtime/tests/noop.rs
@@ -2,7 +2,7 @@ use solana_runtime::bank::Bank;
 use solana_runtime::bank_client::BankClient;
 use solana_runtime::loader_utils::create_invoke_instruction;
 use solana_sdk::client::SyncClient;
-use solana_sdk::genesis_block::create_genesis_block;
+use solana_sdk::genesis_block::create_basic_genesis_block;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::KeypairUtil;
 
@@ -10,7 +10,7 @@ use solana_sdk::signature::KeypairUtil;
 fn test_program_native_noop() {
     solana_logger::setup();
 
-    let (genesis_block, alice_keypair) = create_genesis_block(50);
+    let (genesis_block, alice_keypair) = create_basic_genesis_block(50);
     let program_id = Pubkey::new_rand();
     let bank = Bank::new(&genesis_block);
     bank.register_native_instruction_processor("solana_noop_program", &program_id);

--- a/sdk/src/genesis_block.rs
+++ b/sdk/src/genesis_block.rs
@@ -33,7 +33,7 @@ pub struct GenesisBlock {
 }
 
 // useful for basic tests
-pub fn create_genesis_block(lamports: u64) -> (GenesisBlock, Keypair) {
+pub fn create_basic_genesis_block(lamports: u64) -> (GenesisBlock, Keypair) {
     let mint_keypair = Keypair::new();
     (
         GenesisBlock::new(


### PR DESCRIPTION
#### Problem
There are two methods named `create_genesis_block` in our codebase. One in sdk used to generate a basic genesis block for testing and one in core which includes some a small set of native programs. It's easy to mix up the two and they have different behavior.

#### Summary of Changes
To avoid potential confusion in the two methods, `create_genesis_block` in solana-sdk has been renamed to `create_basic_genesis_block`. Open to other names!

