### PR TITLE
Look for dynamic lib filenames with hashes in native loader

### DIFF
--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -45,3 +45,4 @@ name = "solana_runtime"
 
 [dev-dependencies]
 solana-noop-program = { path = "../programs/noop_program", version = "0.19.0-pre0" }
+tempfile = "3"

--- a/runtime/src/native_loader.rs
+++ b/runtime/src/native_loader.rs
@@ -32,16 +32,17 @@ const PLATFORM_FILE_EXTENSION_NATIVE: &str = "dll";
 // Cargo adds a hash in the filename of git and crates.io dependencies so we cannot
 // deterministically build a path, we have to search for it.
 fn find_library(root: PathBuf, library_name: &str) -> Option<PathBuf> {
-    let files = root.read_dir().expect("Failed to read library files");
-    for file in files.filter_map(Result::ok) {
-        let file_path = file.path();
-        if let Some(file_name) = file_path.file_name() {
-            if let Some(file_name) = file_name.to_str() {
-                if file_name.ends_with(PLATFORM_FILE_EXTENSION_NATIVE)
-                    && file_name.starts_with(&library_name)
-                    && file_name.split(&['-', '.'][..]).next() == Some(library_name)
-                {
-                    return Some(file_path);
+    if let Ok(files) = root.read_dir() {
+        for file in files.filter_map(Result::ok) {
+            let file_path = file.path();
+            if let Some(file_name) = file_path.file_name() {
+                if let Some(file_name) = file_name.to_str() {
+                    if file_name.ends_with(PLATFORM_FILE_EXTENSION_NATIVE)
+                        && file_name.starts_with(&library_name)
+                        && file_name.split(&['-', '.'][..]).next() == Some(library_name)
+                    {
+                        return Some(file_path);
+                    }
                 }
             }
         }

--- a/runtime/src/native_loader.rs
+++ b/runtime/src/native_loader.rs
@@ -143,6 +143,12 @@ mod tests {
     use tempfile::tempdir;
 
     #[test]
+    fn test_create_library_path() {
+        assert!(create_library_path("solana_bpf_loader_program").is_some());
+        assert!(create_library_path("solana_bpf_loader").is_none());
+    }
+
+    #[test]
     fn test_find_library() {
         let root = tempdir().unwrap();
         let prefix = "libsolana_bpf_loader_program";


### PR DESCRIPTION
#### Problem
Cargo adds an extra hash in the file name for dependencies from git and crates.io so native loader cannot deterministically find the file path of a native program dynamic library.

#### Summary of Changes
Search exe directory for dynamic libraries ignoring hashes in the file names

Fixes https://github.com/solana-labs/solana/issues/5966
