### PR TITLE
testnet-edge/testnet-beta now update while preserving the ledger

### DIFF
--- a/ci/testnet-deploy.sh
+++ b/ci/testnet-deploy.sh
@@ -21,7 +21,6 @@ delete=false
 enableGpu=false
 bootDiskType=""
 blockstreamer=false
-deployUpdateManifest=true
 fetchLogs=true
 maybeHashesPerTick=
 maybeDisableAirdrops=
@@ -123,9 +122,6 @@ while [[ -n $1 ]]; do
     elif [[ $1 = --external-accounts-file ]]; then
       maybeExternalPrimordialAccountsFile="$1 $2"
       shift 2
-    elif [[ $1 = --skip-deploy-update ]]; then
-      deployUpdateManifest=false
-      shift 1
     elif [[ $1 = --skip-remote-log-retrieval ]]; then
       fetchLogs=false
       shift 1
@@ -153,7 +149,7 @@ while [[ -n $1 ]]; do
   fi
 done
 
-while getopts "h?p:Pn:c:t:gG:a:Dd:rusxz:p:C:Sfew" opt "${shortArgs[@]}"; do
+while getopts "h?p:Pn:c:t:gG:a:Dd:rusxz:p:C:Sfe" opt "${shortArgs[@]}"; do
   case $opt in
   h | \?)
     usage
@@ -222,10 +218,6 @@ while getopts "h?p:Pn:c:t:gG:a:Dd:rusxz:p:C:Sfew" opt "${shortArgs[@]}"; do
     ;;
   S)
     stopNetwork=true
-    ;;
-  w)
-    fetchLogs=false
-    deployUpdateManifest=false
     ;;
   *)
     usage "Unknown option: $opt"
@@ -365,8 +357,6 @@ ok=true
 if ! $skipStart; then
   (
     if $skipCreate; then
-      # TODO: Enable rolling updates
-      #op=update
       op=restart
     else
       op=start
@@ -389,13 +379,6 @@ if ! $skipStart; then
 
     if ! $failOnValidatorBootupFailure; then
       args+=(-F)
-    fi
-
-    if $deployUpdateManifest; then
-      rm -f update_manifest_keypair.json
-      args+=(--deploy-update linux)
-      args+=(--deploy-update osx)
-      args+=(--deploy-update windows)
     fi
 
     # shellcheck disable=SC2206 # Do not want to quote

--- a/ci/testnet-manager.sh
+++ b/ci/testnet-manager.sh
@@ -219,6 +219,7 @@ sanity() {
       NO_INSTALL_CHECK=1 \
       NO_VALIDATOR_SANITY=1 \
         ci/testnet-sanity.sh edge-testnet-solana-com gce us-west1-b
+      time net/net.sh restart --skip-setup --deploy-if-newer -t "$CHANNEL_OR_TAG"
     )
     ;;
   testnet-edge-perf)
@@ -235,6 +236,7 @@ sanity() {
       NO_INSTALL_CHECK=1 \
       NO_VALIDATOR_SANITY=1 \
         ci/testnet-sanity.sh beta-testnet-solana-com gce us-west1-b
+      time net/net.sh restart --skip-setup --deploy-if-newer -t "$CHANNEL_OR_TAG"
     )
     ;;
   testnet-beta-perf)

--- a/ci/testnet-manager.sh
+++ b/ci/testnet-manager.sh
@@ -376,6 +376,7 @@ deploy() {
         ${skipStart:+-s} \
         ${maybeStop:+-S} \
         ${maybeDelete:+-D}
+      time net/net.sh update -t "$CHANNEL_OR_TAG" --platform\ {linux,osx,windows}
     )
     ;;
   testnet-perf)
@@ -405,7 +406,6 @@ deploy() {
       NO_VALIDATOR_SANITY=1 \
         ci/testnet-deploy.sh -p demo-testnet-solana-com -C gce ${GCE_ZONE_ARGS[@]} \
           -t "$CHANNEL_OR_TAG" -n "$GCE_NODE_COUNT" -c 0 -P -u -f \
-          --skip-deploy-update \
           --skip-remote-log-retrieval \
           -a demo-testnet-solana-com \
           ${skipCreate:+-e} \
@@ -418,7 +418,6 @@ deploy() {
         NO_VALIDATOR_SANITY=1 \
           ci/testnet-deploy.sh -p demo-testnet-solana-com2 -C gce ${GCE_LOW_QUOTA_ZONE_ARGS[@]} \
             -t "$CHANNEL_OR_TAG" -n "$GCE_LOW_QUOTA_NODE_COUNT" -c 0 -P -f -x \
-            --skip-deploy-update \
             --skip-remote-log-retrieval \
             ${skipCreate:+-e} \
             ${skipStart:+-s} \
@@ -540,8 +539,7 @@ deploy() {
           ${maybeInternalNodesLamports} \
           ${maybeExternalAccountsFile} \
           ${maybeLamports} \
-          ${maybeAdditionalDisk} \
-          --skip-deploy-update
+          ${maybeAdditionalDisk}
     )
     ;;
   *)

--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -216,6 +216,7 @@ EOF
   validator|blockstreamer)
     if [[ $deployMethod != skip ]]; then
       net/scripts/rsync-retry.sh -vPrc "$entrypointIp":~/.cargo/bin/ ~/.cargo/bin/
+      net/scripts/rsync-retry.sh -vPrc "$entrypointIp":~/version.yml version.yml
     fi
     if [[ $skipSetup != true ]]; then
       multinode-demo/clear-config.sh


### PR DESCRIPTION
#### Problem
Not really testing snapshots much in practice

#### Summary of Changes
Update the software on testnet-edge/testnet-beta while keeping the old ledger to ensure we can consistently bring the cluster back up from a snapshot.

TODO: Manual intervention is currently required when an incompatible change (such as to the genesis block) is made on master.   But that's ok for now, I'm already monitoring...

Fixes #3774