### PR TITLE
feat: use redis version 5+ via ppa:chris-lea

### DIFF
--- a/net/scripts/install-redis.sh
+++ b/net/scripts/install-redis.sh
@@ -4,4 +4,5 @@ set -ex
 [[ $(uname) = Linux ]] || exit 1
 [[ $USER = root ]] || exit 1
 
+add-apt-repository -y ppa:chris-lea/redis-server
 apt-get --assume-yes install redis


### PR DESCRIPTION
#### Problem

* Network Explorer requires redis 5+ for STREAM api (block/transaction timelines etc)
* Ubuntu 18.04 is stuck on redis 4

#### Summary of Changes

* update provisioning script to use ppa:chris-lea/redis-server

