### PR TITLE
Fix bind errors

### DIFF
--- a/ci/localnet-sanity.sh
+++ b/ci/localnet-sanity.sh
@@ -75,18 +75,18 @@ nodes=(
   "multinode-demo/drone.sh"
   "multinode-demo/bootstrap-leader.sh \
     --init-complete-file init-complete-node1.log \
-    --dynamic-port-range 8000-8019"
+    --dynamic-port-range 8000-8050"
   "multinode-demo/validator.sh \
     --enable-rpc-exit \
     --no-restart \
-    --dynamic-port-range 8020-8039
+    --dynamic-port-range 8050-8100
     --init-complete-file init-complete-node2.log \
     --rpc-port 18899"
 )
 
 for i in $(seq 1 $extraNodes); do
-  portStart=$((8040 + i * 20))
-  portEnd=$((portStart + 19))
+  portStart=$((8100 + i * 50))
+  portEnd=$((portStart + 49))
   nodes+=(
     "multinode-demo/validator.sh \
       --no-restart \

--- a/core/src/cluster_info.rs
+++ b/core/src/cluster_info.rs
@@ -47,12 +47,11 @@ use std::borrow::Cow;
 use std::cmp::min;
 use std::collections::{BTreeSet, HashMap, HashSet};
 use std::fmt;
-use std::net::{IpAddr, Ipv4Addr, SocketAddr, UdpSocket};
+use std::net::{IpAddr, Ipv4Addr, SocketAddr, TcpListener, UdpSocket};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, RwLock};
 use std::thread::{sleep, Builder, JoinHandle};
 use std::time::{Duration, Instant};
-use tokio::net::TcpListener;
 
 pub const FULLNODE_PORT_RANGE: PortRange = (8000, 10_000);
 

--- a/core/src/cluster_info.rs
+++ b/core/src/cluster_info.rs
@@ -34,7 +34,8 @@ use rand_chacha::ChaChaRng;
 use rayon::prelude::*;
 use solana_metrics::{datapoint_debug, inc_new_counter_debug, inc_new_counter_error};
 use solana_netutil::{
-    bind_in_range, bind_to, find_available_port_in_range, multi_bind_in_range, PortRange,
+    bind_common, bind_common_in_range, bind_in_range, find_available_port_in_range,
+    multi_bind_in_range, PortRange,
 };
 use solana_sdk::packet::PACKET_DATA_SIZE;
 use solana_sdk::pubkey::Pubkey;
@@ -51,6 +52,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, RwLock};
 use std::thread::{sleep, Builder, JoinHandle};
 use std::time::{Duration, Instant};
+use tokio::net::TcpListener;
 
 pub const FULLNODE_PORT_RANGE: PortRange = (8000, 10_000);
 
@@ -1485,7 +1487,7 @@ impl ClusterInfo {
 
     /// An alternative to Spy Node that has a valid gossip address and fully participate in Gossip.
     pub fn gossip_node(id: &Pubkey, gossip_addr: &SocketAddr) -> (ContactInfo, UdpSocket) {
-        let (port, gossip_socket) = Node::get_gossip_port(gossip_addr, FULLNODE_PORT_RANGE);
+        let (port, (gossip_socket, _)) = Node::get_gossip_port(gossip_addr, FULLNODE_PORT_RANGE);
         let daddr = socketaddr_any!();
 
         let node = ContactInfo::new(
@@ -1563,6 +1565,7 @@ pub fn compute_retransmit_peers(
 #[derive(Debug)]
 pub struct Sockets {
     pub gossip: UdpSocket,
+    pub ip_echo: Option<TcpListener>,
     pub tvu: Vec<UdpSocket>,
     pub tvu_forwards: Vec<UdpSocket>,
     pub tpu: Vec<UdpSocket>,
@@ -1619,12 +1622,14 @@ impl Node {
                 repair,
                 retransmit,
                 storage: Some(storage),
+                ip_echo: None,
             },
         }
     }
     pub fn new_localhost_with_pubkey(pubkey: &Pubkey) -> Self {
         let tpu = UdpSocket::bind("127.0.0.1:0").unwrap();
-        let gossip = UdpSocket::bind("127.0.0.1:0").unwrap();
+        let (gossip_port, (gossip, ip_echo)) = bind_common_in_range((1024, 65535)).unwrap();
+        let gossip_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), gossip_port);
         let tvu = UdpSocket::bind("127.0.0.1:0").unwrap();
         let tvu_forwards = UdpSocket::bind("127.0.0.1:0").unwrap();
         let tpu_forwards = UdpSocket::bind("127.0.0.1:0").unwrap();
@@ -1640,7 +1645,7 @@ impl Node {
         let storage = UdpSocket::bind("0.0.0.0:0").unwrap();
         let info = ContactInfo::new(
             pubkey,
-            gossip.local_addr().unwrap(),
+            gossip_addr,
             tvu.local_addr().unwrap(),
             tvu_forwards.local_addr().unwrap(),
             tpu.local_addr().unwrap(),
@@ -1654,6 +1659,7 @@ impl Node {
             info,
             sockets: Sockets {
                 gossip,
+                ip_echo: Some(ip_echo),
                 tvu: vec![tvu],
                 tvu_forwards: vec![tvu_forwards],
                 tpu: vec![tpu],
@@ -1665,16 +1671,19 @@ impl Node {
             },
         }
     }
-    fn get_gossip_port(gossip_addr: &SocketAddr, port_range: PortRange) -> (u16, UdpSocket) {
+    fn get_gossip_port(
+        gossip_addr: &SocketAddr,
+        port_range: PortRange,
+    ) -> (u16, (UdpSocket, TcpListener)) {
         if gossip_addr.port() != 0 {
             (
                 gossip_addr.port(),
-                bind_to(gossip_addr.port(), false).unwrap_or_else(|e| {
+                bind_common(gossip_addr.port(), false).unwrap_or_else(|e| {
                     panic!("gossip_addr bind_to port {}: {}", gossip_addr.port(), e)
                 }),
             )
         } else {
-            Self::bind(port_range)
+            bind_common_in_range(port_range).expect("Failed to bind")
         }
     }
     fn bind(port_range: PortRange) -> (u16, UdpSocket) {
@@ -1685,7 +1694,7 @@ impl Node {
         gossip_addr: &SocketAddr,
         port_range: PortRange,
     ) -> Node {
-        let (gossip_port, gossip) = Self::get_gossip_port(gossip_addr, port_range);
+        let (gossip_port, (gossip, ip_echo)) = Self::get_gossip_port(gossip_addr, port_range);
 
         let (tvu_port, tvu_sockets) = multi_bind_in_range(port_range, 8).expect("tvu multi_bind");
 
@@ -1727,6 +1736,7 @@ impl Node {
                 repair,
                 retransmit,
                 storage: None,
+                ip_echo: Some(ip_echo),
             },
         }
     }

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -240,8 +240,7 @@ impl Validator {
             "New blob signal for the TVU should be the same as the clear bank signal."
         );
 
-        let ip_echo_server =
-            solana_netutil::ip_echo_server(node.sockets.gossip.local_addr().unwrap().port());
+        let ip_echo_server = solana_netutil::ip_echo_server(node.sockets.ip_echo.unwrap());
 
         let gossip_service = GossipService::new(
             &cluster_info,

--- a/local_cluster/src/tests/replicator.rs
+++ b/local_cluster/src/tests/replicator.rs
@@ -74,7 +74,7 @@ fn test_replicator_startup_1_node() {
 }
 
 #[test]
-#[ignore]
+#[serial]
 fn test_replicator_startup_2_nodes() {
     run_replicator_startup_basic(2, 1);
 }
@@ -119,7 +119,7 @@ fn test_replicator_startup_leader_hang() {
 }
 
 #[test]
-#[ignore]
+#[serial]
 fn test_replicator_startup_ledger_hang() {
     solana_logger::setup();
     info!("starting replicator test");

--- a/netutil/src/bin/ip_address_server.rs
+++ b/netutil/src/bin/ip_address_server.rs
@@ -1,5 +1,5 @@
 use clap::{crate_version, App, Arg};
-use tokio::net::TcpListener;
+use std::net::{SocketAddr, TcpListener};
 
 fn main() {
     solana_logger::setup();
@@ -17,7 +17,8 @@ fn main() {
     let port = port
         .parse()
         .unwrap_or_else(|_| panic!("Unable to parse {}", port));
-    let tcp_listener = TcpListener::bind(&port).expect("unable to start tcp listener");
+    let bind_addr = SocketAddr::from(([0, 0, 0, 0], port));
+    let tcp_listener = TcpListener::bind(bind_addr).expect("unable to start tcp listener");
     let _runtime = solana_netutil::ip_echo_server(tcp_listener);
     loop {
         std::thread::park();

--- a/netutil/src/bin/ip_address_server.rs
+++ b/netutil/src/bin/ip_address_server.rs
@@ -1,4 +1,5 @@
 use clap::{crate_version, App, Arg};
+use tokio::net::TcpListener;
 
 fn main() {
     solana_logger::setup();
@@ -16,7 +17,8 @@ fn main() {
     let port = port
         .parse()
         .unwrap_or_else(|_| panic!("Unable to parse {}", port));
-    let _runtime = solana_netutil::ip_echo_server(port);
+    let tcp_listener = TcpListener::bind(&port).expect("unable to start tcp listener");
+    let _runtime = solana_netutil::ip_echo_server(tcp_listener);
     loop {
         std::thread::park();
     }

--- a/netutil/src/ip_echo_server.rs
+++ b/netutil/src/ip_echo_server.rs
@@ -32,11 +32,8 @@ impl IpEchoServerMessage {
 
 /// Starts a simple TCP server on the given port that echos the IP address of any peer that
 /// connects.  Used by |get_public_ip_addr|
-pub fn ip_echo_server(port: u16) -> IpEchoServer {
-    let bind_addr = SocketAddr::from(([0, 0, 0, 0], port));
-    let tcp = TcpListener::bind(&bind_addr)
-        .unwrap_or_else(|err| panic!("Unable to bind to {}: {}", bind_addr, err));
-    info!("bound to {:?}", bind_addr);
+pub fn ip_echo_server(tcp: TcpListener) -> IpEchoServer {
+    info!("bound to {:?}", tcp.local_addr());
 
     let server = tcp
         .incoming()

--- a/netutil/src/ip_echo_server.rs
+++ b/netutil/src/ip_echo_server.rs
@@ -7,6 +7,7 @@ use std::time::Duration;
 use tokio;
 use tokio::net::TcpListener;
 use tokio::prelude::*;
+use tokio::reactor::Handle;
 use tokio::runtime::Runtime;
 use tokio_codec::{BytesCodec, Decoder};
 
@@ -32,8 +33,10 @@ impl IpEchoServerMessage {
 
 /// Starts a simple TCP server on the given port that echos the IP address of any peer that
 /// connects.  Used by |get_public_ip_addr|
-pub fn ip_echo_server(tcp: TcpListener) -> IpEchoServer {
+pub fn ip_echo_server(tcp: std::net::TcpListener) -> IpEchoServer {
     info!("bound to {:?}", tcp.local_addr());
+    let tcp =
+        TcpListener::from_std(tcp, &Handle::default()).expect("Failed to convert std::TcpListener");
 
     let server = tcp
         .incoming()

--- a/netutil/src/lib.rs
+++ b/netutil/src/lib.rs
@@ -231,9 +231,7 @@ fn udp_socket(reuseaddr: bool) -> io::Result<Socket> {
 }
 
 // Find a port in the given range that is available for both TCP and UDP
-pub fn bind_common_in_range(
-    range: PortRange,
-) -> io::Result<(u16, (UdpSocket, tokio::net::TcpListener))> {
+pub fn bind_common_in_range(range: PortRange) -> io::Result<(u16, (UdpSocket, TcpListener))> {
     let (start, end) = range;
     let mut tries_left = end - start;
     let mut rand_port = thread_rng().gen_range(start, end);
@@ -319,13 +317,13 @@ pub fn bind_to(port: u16, reuseaddr: bool) -> io::Result<UdpSocket> {
 }
 
 // binds both a UdpSocket and a TcpListener
-pub fn bind_common(port: u16, reuseaddr: bool) -> io::Result<(UdpSocket, tokio::net::TcpListener)> {
+pub fn bind_common(port: u16, reuseaddr: bool) -> io::Result<(UdpSocket, TcpListener)> {
     let sock = udp_socket(reuseaddr)?;
 
     let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), port);
     let sock_addr = SockAddr::from(addr);
     match sock.bind(&sock_addr) {
-        Ok(_) => match tokio::net::TcpListener::bind(&addr) {
+        Ok(_) => match TcpListener::bind(&addr) {
             Ok(listener) => Result::Ok((sock.into_udp_socket(), listener)),
             Err(err) => Err(err),
         },

--- a/netutil/src/lib.rs
+++ b/netutil/src/lib.rs
@@ -230,6 +230,44 @@ fn udp_socket(reuseaddr: bool) -> io::Result<Socket> {
     Ok(sock)
 }
 
+// Find a port in the given range that is available for both TCP and UDP
+pub fn bind_common_in_range(
+    range: PortRange,
+) -> io::Result<(u16, (UdpSocket, tokio::net::TcpListener))> {
+    let sock = udp_socket(false)?;
+
+    let (start, end) = range;
+    let mut tries_left = end - start;
+    let mut rand_port = thread_rng().gen_range(start, end);
+    loop {
+        let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), rand_port);
+        let sock_addr = SockAddr::from(addr.clone());
+        match sock.bind(&sock_addr) {
+            Ok(_) => match tokio::net::TcpListener::bind(&addr) {
+                Ok(listener) => {
+                    let sock = sock.into_udp_socket();
+                    break Result::Ok((sock.local_addr().unwrap().port(), (sock, listener)));
+                }
+                Err(err) => {
+                    if tries_left == 0 {
+                        return Err(err);
+                    }
+                }
+            },
+            Err(err) => {
+                if tries_left == 0 {
+                    return Err(err);
+                }
+            }
+        }
+        rand_port += 1;
+        if rand_port == end {
+            rand_port = start;
+        }
+        tries_left -= 1;
+    }
+}
+
 pub fn bind_in_range(range: PortRange) -> io::Result<(u16, UdpSocket)> {
     let sock = udp_socket(false)?;
 
@@ -288,6 +326,20 @@ pub fn bind_to(port: u16, reuseaddr: bool) -> io::Result<UdpSocket> {
 
     match sock.bind(&SockAddr::from(addr)) {
         Ok(_) => Result::Ok(sock.into_udp_socket()),
+        Err(err) => Err(err),
+    }
+}
+
+pub fn bind_common(port: u16, reuseaddr: bool) -> io::Result<(UdpSocket, tokio::net::TcpListener)> {
+    let sock = udp_socket(reuseaddr)?;
+
+    let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), port);
+    let sock_addr = SockAddr::from(addr.clone());
+    match sock.bind(&sock_addr) {
+        Ok(_) => match tokio::net::TcpListener::bind(&addr) {
+            Ok(listener) => Result::Ok((sock.into_udp_socket(), listener)),
+            Err(err) => Err(err),
+        },
         Err(err) => Err(err),
     }
 }
@@ -384,6 +436,13 @@ mod tests {
     fn test_find_available_port_in_range() {
         assert_eq!(find_available_port_in_range((3000, 3001)).unwrap(), 3000);
         let port = find_available_port_in_range((3000, 3050)).unwrap();
+        assert!(3000 <= port && port < 3050);
+    }
+
+    #[test]
+    fn test_bind_common_in_range() {
+        assert_eq!(bind_common_in_range((3000, 3001)).unwrap().0, 3000);
+        let (port, _) = bind_common_in_range((3000, 3050)).unwrap();
         assert!(3000 <= port && port < 3050);
     }
 }

--- a/netutil/src/lib.rs
+++ b/netutil/src/lib.rs
@@ -323,7 +323,7 @@ pub fn bind_common(port: u16, reuseaddr: bool) -> io::Result<(UdpSocket, tokio::
     let sock = udp_socket(reuseaddr)?;
 
     let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), port);
-    let sock_addr = SockAddr::from(addr.clone());
+    let sock_addr = SockAddr::from(addr);
     match sock.bind(&sock_addr) {
         Ok(_) => match tokio::net::TcpListener::bind(&addr) {
             Ok(listener) => Result::Ok((sock.into_udp_socket(), listener)),


### PR DESCRIPTION
#### Problem

The `ip_echo_server` fails to bind when a node's gossip socket binds to a port that is free for UDP but in use for TCP. 

#### Summary of Changes

Add a fn that allows binding to an open port on both TCP and UDP. Fixes flakiness of local_cluster tests.
