### PR TITLE
Add Vest program

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1921,6 +1921,16 @@ dependencies = [
 
 [[package]]
 name = "num-derive"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.42 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-derive"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -3888,6 +3898,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-vest-api"
+version = "0.20.0-pre0"
+dependencies = [
+ "bincode 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-derive 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-config-api 0.20.0",
+ "solana-runtime 0.20.0",
+ "solana-sdk 0.20.0",
+]
+
+[[package]]
 name = "solana-vote-api"
 version = "0.20.0"
 dependencies = [
@@ -5543,6 +5569,7 @@ dependencies = [
 "checksum nix 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3b2e0b4f3320ed72aaedb9a5ac838690a8047c7b275da22711fddff4f8a14229"
 "checksum nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9667ddcc6cc8a43afc9b7917599d7216aa09c463919ea32c59ed6cac8bc945"
 "checksum nom 4.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2ad2a91a8e869eeb30b9cb3119ae87773a8f4ae617f41b1eb9c154b2905f7bd6"
+"checksum num-derive 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "eafd0b45c5537c3ba526f79d3e75120036502bebacbb3f3220914067ce39dbf2"
 "checksum num-derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0c8b15b261814f992e33760b1fca9fe8b693d8a65299f20c9901688636cfb746"
 "checksum num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)" = "b85e541ef8255f6cf42bbfe4ef361305c6c135d10919ecc26126c4e5ae94bc09"
 "checksum num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "92e5113e9fd4cc14ded8e499429f396a20f98c772a47cc8622a736e1ec843c31"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ members = [
     "programs/stake_tests",
     "programs/storage_api",
     "programs/storage_program",
+    "programs/vest_api",
     "programs/vote_api",
     "programs/vote_program",
     "replicator",

--- a/programs/vest_api/Cargo.toml
+++ b/programs/vest_api/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "solana-vest-api"
+version = "0.20.0-pre0"
+description = "Solana Vest program API"
+authors = ["Solana Maintainers <maintainers@solana.com>"]
+repository = "https://github.com/solana-labs/solana"
+license = "Apache-2.0"
+homepage = "https://solana.com/"
+edition = "2018"
+
+[dependencies]
+bincode = "1.1.4"
+chrono = { version = "0.4.9", features = ["serde"] }
+log = "0.4.8"
+num-derive = "0.2"
+num-traits = "0.2"
+serde = "1.0.100"
+serde_derive = "1.0.100"
+solana-sdk = { path = "../../sdk", version = "0.20.0-pre0" }
+solana-config-api = { path = "../config_api", version = "0.20.0-pre0" }
+
+[dev-dependencies]
+solana-runtime = { path = "../../runtime", version = "0.20.0-pre0" }
+
+[lib]
+crate-type = ["lib"]
+name = "solana_budget_api"

--- a/programs/vest_api/src/date_instruction.rs
+++ b/programs/vest_api/src/date_instruction.rs
@@ -1,0 +1,61 @@
+///
+/// A library for creating a trusted date oracle.
+///
+use bincode::{deserialize, serialized_size};
+use chrono::{
+    prelude::{DateTime, TimeZone, Utc},
+    serde::ts_seconds,
+};
+use serde_derive::{Deserialize, Serialize};
+use solana_config_api::{config_instruction, ConfigState};
+use solana_sdk::{instruction::Instruction, pubkey::Pubkey};
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
+pub struct DateConfig {
+    #[serde(with = "ts_seconds")]
+    pub dt: DateTime<Utc>,
+}
+
+impl Default for DateConfig {
+    fn default() -> Self {
+        Self {
+            dt: Utc.timestamp(0, 0),
+        }
+    }
+}
+impl DateConfig {
+    pub fn new(dt: DateTime<Utc>) -> Self {
+        Self { dt }
+    }
+
+    pub fn deserialize(input: &[u8]) -> Option<Self> {
+        deserialize(input).ok()
+    }
+}
+
+impl ConfigState for DateConfig {
+    fn max_space() -> u64 {
+        serialized_size(&Self::default()).unwrap()
+    }
+}
+
+/// Create a date account. The date is set to the Unix epoch.
+pub fn create_account(
+    from_account_pubkey: &Pubkey,
+    date_account_pubkey: &Pubkey,
+    lamports: u64,
+) -> Vec<Instruction> {
+    config_instruction::create_account::<DateConfig>(
+        from_account_pubkey,
+        date_account_pubkey,
+        lamports,
+        vec![],
+    )
+}
+
+/// Set the date in the date account. The account pubkey must be signed in the
+/// transaction containing this instruction.
+pub fn store(date_account_pubkey: &Pubkey, dt: DateTime<Utc>) -> Instruction {
+    let date_config = DateConfig::new(dt);
+    config_instruction::store(&date_account_pubkey, true, vec![], &date_config)
+}

--- a/programs/vest_api/src/date_instruction.rs
+++ b/programs/vest_api/src/date_instruction.rs
@@ -43,21 +43,16 @@ impl ConfigState for DateConfig {
 
 /// Create a date account. The date is set to the Unix epoch.
 pub fn create_account(
-    from_account_pubkey: &Pubkey,
-    date_account_pubkey: &Pubkey,
+    payer_pubkey: &Pubkey,
+    date_pubkey: &Pubkey,
     lamports: u64,
 ) -> Vec<Instruction> {
-    config_instruction::create_account::<DateConfig>(
-        from_account_pubkey,
-        date_account_pubkey,
-        lamports,
-        vec![],
-    )
+    config_instruction::create_account::<DateConfig>(payer_pubkey, date_pubkey, lamports, vec![])
 }
 
 /// Set the date in the date account. The account pubkey must be signed in the
 /// transaction containing this instruction.
-pub fn store(date_account_pubkey: &Pubkey, dt: Date<Utc>) -> Instruction {
+pub fn store(date_pubkey: &Pubkey, dt: Date<Utc>) -> Instruction {
     let date_config = DateConfig::new(dt);
-    config_instruction::store(&date_account_pubkey, true, vec![], &date_config)
+    config_instruction::store(&date_pubkey, true, vec![], &date_config)
 }

--- a/programs/vest_api/src/date_instruction.rs
+++ b/programs/vest_api/src/date_instruction.rs
@@ -3,7 +3,7 @@
 ///
 use bincode::{deserialize, serialized_size};
 use chrono::{
-    prelude::{DateTime, TimeZone, Utc},
+    prelude::{Date, DateTime, TimeZone, Utc},
     serde::ts_seconds,
 };
 use serde_derive::{Deserialize, Serialize};
@@ -24,8 +24,10 @@ impl Default for DateConfig {
     }
 }
 impl DateConfig {
-    pub fn new(dt: DateTime<Utc>) -> Self {
-        Self { dt }
+    pub fn new(dt: Date<Utc>) -> Self {
+        Self {
+            dt: dt.and_hms(0, 0, 0),
+        }
     }
 
     pub fn deserialize(input: &[u8]) -> Option<Self> {
@@ -55,7 +57,7 @@ pub fn create_account(
 
 /// Set the date in the date account. The account pubkey must be signed in the
 /// transaction containing this instruction.
-pub fn store(date_account_pubkey: &Pubkey, dt: DateTime<Utc>) -> Instruction {
+pub fn store(date_account_pubkey: &Pubkey, dt: Date<Utc>) -> Instruction {
     let date_config = DateConfig::new(dt);
     config_instruction::store(&date_account_pubkey, true, vec![], &date_config)
 }

--- a/programs/vest_api/src/lib.rs
+++ b/programs/vest_api/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod date_instruction;
 pub mod vest_instruction;
 pub mod vest_processor;
+pub mod vest_schedule;
 pub mod vest_state;
 
 const VEST_PROGRAM_ID: [u8; 32] = [

--- a/programs/vest_api/src/lib.rs
+++ b/programs/vest_api/src/lib.rs
@@ -1,0 +1,14 @@
+pub mod date_instruction;
+pub mod vest_instruction;
+pub mod vest_processor;
+pub mod vest_state;
+
+const VEST_PROGRAM_ID: [u8; 32] = [
+    7, 87, 23, 47, 219, 236, 238, 33, 137, 188, 215, 141, 32, 229, 155, 195, 133, 124, 23, 232,
+    113, 153, 252, 252, 111, 5, 187, 128, 0, 0, 0, 0,
+];
+
+solana_sdk::solana_name_id!(
+    VEST_PROGRAM_ID,
+    "Vest111111111111111111111111111111111111111"
+);

--- a/programs/vest_api/src/vest_instruction.rs
+++ b/programs/vest_api/src/vest_instruction.rs
@@ -123,7 +123,6 @@ pub fn terminate(from: &Pubkey, contract: &Pubkey, to: &Pubkey) -> Instruction {
     Instruction::new(id(), &VestInstruction::Terminate, account_metas)
 }
 
-/// Apply account data to a contract waiting on an AccountData witness.
 pub fn redeem_tokens(date_pubkey: &Pubkey, contract: &Pubkey, to: &Pubkey) -> Instruction {
     let account_metas = vec![
         AccountMeta::new_credit_only(*date_pubkey, false),

--- a/programs/vest_api/src/vest_instruction.rs
+++ b/programs/vest_api/src/vest_instruction.rs
@@ -4,7 +4,7 @@ use chrono::prelude::{Date, DateTime, Utc};
 use num_derive::FromPrimitive;
 use serde_derive::{Deserialize, Serialize};
 use solana_sdk::{
-    instruction::{AccountMeta, Instruction},
+    instruction::{AccountMeta, Instruction, InstructionError},
     instruction_processor_utils::DecodeError,
     pubkey::Pubkey,
     system_instruction,
@@ -14,7 +14,12 @@ use solana_sdk::{
 pub enum VestError {
     DestinationMissing,
     Unauthorized,
-    UnexpectedProgramId,
+}
+
+impl From<VestError> for InstructionError {
+    fn from(e: VestError) -> Self {
+        InstructionError::CustomError(e as u32)
+    }
 }
 
 impl<T> DecodeError<T> for VestError {
@@ -31,7 +36,6 @@ impl std::fmt::Display for VestError {
             match self {
                 VestError::DestinationMissing => "destination missing",
                 VestError::Unauthorized => "unauthorized",
-                VestError::UnexpectedProgramId => "unexpected program id",
             }
         )
     }

--- a/programs/vest_api/src/vest_instruction.rs
+++ b/programs/vest_api/src/vest_instruction.rs
@@ -54,6 +54,9 @@ pub enum VestInstruction {
         total_lamports: u64, // The number of lamports to send the payee if the schedule completes
     },
 
+    /// Change the payee pubkey
+    SetPayee(Pubkey),
+
     /// Load an account and pass its data to the contract for inspection.
     RedeemTokens,
 
@@ -110,6 +113,14 @@ pub fn create_account(
             lamports,
         ),
     ]
+}
+
+pub fn set_payee(old_payee: &Pubkey, contract: &Pubkey, new_payee: &Pubkey) -> Instruction {
+    let account_metas = vec![
+        AccountMeta::new(*old_payee, true),
+        AccountMeta::new(*contract, false),
+    ];
+    Instruction::new(id(), &VestInstruction::SetPayee(*new_payee), account_metas)
 }
 
 pub fn terminate(from: &Pubkey, contract: &Pubkey, to: &Pubkey) -> Instruction {

--- a/programs/vest_api/src/vest_instruction.rs
+++ b/programs/vest_api/src/vest_instruction.rs
@@ -46,8 +46,8 @@ pub enum VestInstruction {
         terminator_pubkey: Pubkey, // The address authorized to terminate this contract with a signed Terminate instruction
         payee_pubkey: Pubkey,      // The address authorized to redeem vested tokens
         start_dt: DateTime<Utc>,   // The day from which the vesting contract begins
-        oracle_pubkey: Pubkey, // Address of an account containing a trusted date, used to drive the vesting schedule
-        lamports: u64,         // The number of lamports to send the payee if the schedule completes
+        date_pubkey: Pubkey, // Address of an account containing a trusted date, used to drive the vesting schedule
+        lamports: u64,       // The number of lamports to send the payee if the schedule completes
     },
 
     /// Load an account and pass its data to the contract for inspection.
@@ -63,7 +63,7 @@ fn initialize_account(
     payee_pubkey: &Pubkey,
     contract_pubkey: &Pubkey,
     start_dt: Date<Utc>,
-    oracle_pubkey: &Pubkey,
+    date_pubkey: &Pubkey,
     lamports: u64,
 ) -> Instruction {
     let keys = vec![AccountMeta::new(*contract_pubkey, false)];
@@ -73,7 +73,7 @@ fn initialize_account(
             terminator_pubkey: *terminator_pubkey,
             payee_pubkey: *payee_pubkey,
             start_dt: start_dt.and_hms(0, 0, 0),
-            oracle_pubkey: *oracle_pubkey,
+            date_pubkey: *date_pubkey,
             lamports,
         },
         keys,
@@ -85,7 +85,7 @@ pub fn create_account(
     payee_pubkey: &Pubkey,
     contract_pubkey: &Pubkey,
     start_dt: Date<Utc>,
-    oracle_pubkey: &Pubkey,
+    date_pubkey: &Pubkey,
     lamports: u64,
 ) -> Vec<Instruction> {
     let space = serialized_size(&VestState::default()).unwrap();
@@ -102,7 +102,7 @@ pub fn create_account(
             payee_pubkey,
             contract_pubkey,
             start_dt,
-            oracle_pubkey,
+            date_pubkey,
             lamports,
         ),
     ]
@@ -120,9 +120,9 @@ pub fn terminate(from: &Pubkey, contract: &Pubkey, to: &Pubkey) -> Instruction {
 }
 
 /// Apply account data to a contract waiting on an AccountData witness.
-pub fn redeem_tokens(oracle_pubkey: &Pubkey, contract: &Pubkey, to: &Pubkey) -> Instruction {
+pub fn redeem_tokens(date_pubkey: &Pubkey, contract: &Pubkey, to: &Pubkey) -> Instruction {
     let account_metas = vec![
-        AccountMeta::new_credit_only(*oracle_pubkey, false),
+        AccountMeta::new_credit_only(*date_pubkey, false),
         AccountMeta::new(*contract, false),
         AccountMeta::new_credit_only(*to, false),
     ];

--- a/programs/vest_api/src/vest_instruction.rs
+++ b/programs/vest_api/src/vest_instruction.rs
@@ -1,0 +1,130 @@
+use crate::{id, vest_state::VestState};
+use bincode::serialized_size;
+use chrono::prelude::{DateTime, Utc};
+use num_derive::FromPrimitive;
+use serde_derive::{Deserialize, Serialize};
+use solana_sdk::{
+    instruction::{AccountMeta, Instruction},
+    instruction_processor_utils::DecodeError,
+    pubkey::Pubkey,
+    system_instruction,
+};
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, FromPrimitive)]
+pub enum VestError {
+    DestinationMissing,
+    Unauthorized,
+    UnexpectedProgramId,
+}
+
+impl<T> DecodeError<T> for VestError {
+    fn type_of() -> &'static str {
+        "VestError"
+    }
+}
+
+impl std::fmt::Display for VestError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                VestError::DestinationMissing => "destination missing",
+                VestError::Unauthorized => "unauthorized",
+                VestError::UnexpectedProgramId => "unexpected program id",
+            }
+        )
+    }
+}
+impl std::error::Error for VestError {}
+
+/// An instruction to progress the smart contract.
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
+pub enum VestInstruction {
+    /// Declare and instantiate a vesting schedule
+    InitializeAccount {
+        terminator_pubkey: Pubkey, // The address authorized to terminate this contract with a signed Terminate instruction
+        payee_pubkey: Pubkey,      // The address authorized to redeem vested tokens
+        start_dt: DateTime<Utc>,   // The day from which the vesting contract begins
+        oracle_pubkey: Pubkey, // Address of an account containing a trusted date, used to drive the vesting schedule
+        lamports: u64,         // The number of lamports to send the payee if the schedule completes
+    },
+
+    /// Load an account and pass its data to the contract for inspection.
+    RedeemTokens,
+
+    /// Tell the contract that the `InitializeAccount` with `Signature` has been
+    /// signed by the containing transaction's `Pubkey`.
+    Terminate,
+}
+
+fn initialize_account(
+    terminator_pubkey: &Pubkey,
+    payee_pubkey: &Pubkey,
+    contract_pubkey: &Pubkey,
+    start_dt: DateTime<Utc>,
+    oracle_pubkey: &Pubkey,
+    lamports: u64,
+) -> Instruction {
+    let keys = vec![AccountMeta::new(*contract_pubkey, false)];
+    Instruction::new(
+        id(),
+        &VestInstruction::InitializeAccount {
+            terminator_pubkey: *terminator_pubkey,
+            payee_pubkey: *payee_pubkey,
+            start_dt,
+            oracle_pubkey: *oracle_pubkey,
+            lamports,
+        },
+        keys,
+    )
+}
+
+pub fn create_account(
+    terminator_pubkey: &Pubkey,
+    payee_pubkey: &Pubkey,
+    contract_pubkey: &Pubkey,
+    start_dt: DateTime<Utc>,
+    oracle_pubkey: &Pubkey,
+    lamports: u64,
+) -> Vec<Instruction> {
+    let space = serialized_size(&VestState::default()).unwrap();
+    vec![
+        system_instruction::create_account(
+            &terminator_pubkey,
+            contract_pubkey,
+            lamports,
+            space,
+            &id(),
+        ),
+        initialize_account(
+            terminator_pubkey,
+            payee_pubkey,
+            contract_pubkey,
+            start_dt,
+            oracle_pubkey,
+            lamports,
+        ),
+    ]
+}
+
+pub fn terminate(from: &Pubkey, contract: &Pubkey, to: &Pubkey) -> Instruction {
+    let mut account_metas = vec![
+        AccountMeta::new(*from, true),
+        AccountMeta::new(*contract, false),
+    ];
+    if from != to {
+        account_metas.push(AccountMeta::new_credit_only(*to, false));
+    }
+    Instruction::new(id(), &VestInstruction::Terminate, account_metas)
+}
+
+/// Apply account data to a contract waiting on an AccountData witness.
+pub fn redeem_tokens(witness_pubkey: &Pubkey, contract: &Pubkey, to: &Pubkey) -> Instruction {
+    let account_metas = vec![
+        AccountMeta::new_credit_only(*witness_pubkey, false),
+        AccountMeta::new(*contract, false),
+        AccountMeta::new_credit_only(*to, false),
+    ];
+    Instruction::new(id(), &VestInstruction::RedeemTokens, account_metas)
+}

--- a/programs/vest_api/src/vest_instruction.rs
+++ b/programs/vest_api/src/vest_instruction.rs
@@ -1,6 +1,6 @@
 use crate::{id, vest_state::VestState};
 use bincode::serialized_size;
-use chrono::prelude::{DateTime, Utc};
+use chrono::prelude::{Date, DateTime, Utc};
 use num_derive::FromPrimitive;
 use serde_derive::{Deserialize, Serialize};
 use solana_sdk::{
@@ -62,7 +62,7 @@ fn initialize_account(
     terminator_pubkey: &Pubkey,
     payee_pubkey: &Pubkey,
     contract_pubkey: &Pubkey,
-    start_dt: DateTime<Utc>,
+    start_dt: Date<Utc>,
     oracle_pubkey: &Pubkey,
     lamports: u64,
 ) -> Instruction {
@@ -72,7 +72,7 @@ fn initialize_account(
         &VestInstruction::InitializeAccount {
             terminator_pubkey: *terminator_pubkey,
             payee_pubkey: *payee_pubkey,
-            start_dt,
+            start_dt: start_dt.and_hms(0, 0, 0),
             oracle_pubkey: *oracle_pubkey,
             lamports,
         },
@@ -84,7 +84,7 @@ pub fn create_account(
     terminator_pubkey: &Pubkey,
     payee_pubkey: &Pubkey,
     contract_pubkey: &Pubkey,
-    start_dt: DateTime<Utc>,
+    start_dt: Date<Utc>,
     oracle_pubkey: &Pubkey,
     lamports: u64,
 ) -> Vec<Instruction> {

--- a/programs/vest_api/src/vest_instruction.rs
+++ b/programs/vest_api/src/vest_instruction.rs
@@ -49,9 +49,9 @@ pub enum VestInstruction {
     InitializeAccount {
         terminator_pubkey: Pubkey, // The address authorized to terminate this contract with a signed Terminate instruction
         payee_pubkey: Pubkey,      // The address authorized to redeem vested tokens
-        start_dt: DateTime<Utc>,   // The day from which the vesting contract begins
+        start_date_time: DateTime<Utc>, // The day from which the vesting contract begins
         date_pubkey: Pubkey, // Address of an account containing a trusted date, used to drive the vesting schedule
-        lamports: u64,       // The number of lamports to send the payee if the schedule completes
+        total_lamports: u64, // The number of lamports to send the payee if the schedule completes
     },
 
     /// Load an account and pass its data to the contract for inspection.
@@ -66,9 +66,9 @@ fn initialize_account(
     terminator_pubkey: &Pubkey,
     payee_pubkey: &Pubkey,
     contract_pubkey: &Pubkey,
-    start_dt: Date<Utc>,
+    start_date: Date<Utc>,
     date_pubkey: &Pubkey,
-    lamports: u64,
+    total_lamports: u64,
 ) -> Instruction {
     let keys = vec![AccountMeta::new(*contract_pubkey, false)];
     Instruction::new(
@@ -76,9 +76,9 @@ fn initialize_account(
         &VestInstruction::InitializeAccount {
             terminator_pubkey: *terminator_pubkey,
             payee_pubkey: *payee_pubkey,
-            start_dt: start_dt.and_hms(0, 0, 0),
+            start_date_time: start_date.and_hms(0, 0, 0),
             date_pubkey: *date_pubkey,
-            lamports,
+            total_lamports,
         },
         keys,
     )
@@ -88,7 +88,7 @@ pub fn create_account(
     terminator_pubkey: &Pubkey,
     payee_pubkey: &Pubkey,
     contract_pubkey: &Pubkey,
-    start_dt: Date<Utc>,
+    start_date: Date<Utc>,
     date_pubkey: &Pubkey,
     lamports: u64,
 ) -> Vec<Instruction> {
@@ -105,7 +105,7 @@ pub fn create_account(
             terminator_pubkey,
             payee_pubkey,
             contract_pubkey,
-            start_dt,
+            start_date,
             date_pubkey,
             lamports,
         ),

--- a/programs/vest_api/src/vest_instruction.rs
+++ b/programs/vest_api/src/vest_instruction.rs
@@ -120,9 +120,9 @@ pub fn terminate(from: &Pubkey, contract: &Pubkey, to: &Pubkey) -> Instruction {
 }
 
 /// Apply account data to a contract waiting on an AccountData witness.
-pub fn redeem_tokens(witness_pubkey: &Pubkey, contract: &Pubkey, to: &Pubkey) -> Instruction {
+pub fn redeem_tokens(oracle_pubkey: &Pubkey, contract: &Pubkey, to: &Pubkey) -> Instruction {
     let account_metas = vec![
-        AccountMeta::new_credit_only(*witness_pubkey, false),
+        AccountMeta::new_credit_only(*oracle_pubkey, false),
         AccountMeta::new(*contract, false),
         AccountMeta::new_credit_only(*to, false),
     ];

--- a/programs/vest_api/src/vest_processor.rs
+++ b/programs/vest_api/src/vest_processor.rs
@@ -64,17 +64,17 @@ pub fn process_instruction(
         VestInstruction::InitializeAccount {
             terminator_pubkey,
             payee_pubkey,
-            start_dt,
+            start_date_time,
             date_pubkey,
-            lamports,
+            total_lamports,
         } => {
             let contract_account = &mut keyed_accounts[0].account;
             let vest_state = VestState {
                 terminator_pubkey,
                 payee_pubkey,
-                start_dt,
+                start_date_time,
                 date_pubkey,
-                lamports,
+                total_lamports,
                 redeemed_lamports: 0,
             };
             vest_state.serialize(&mut contract_account.data)
@@ -86,11 +86,11 @@ pub fn process_instruction(
                     _ => return Err(InstructionError::InvalidArgument),
                 };
             let mut vest_state = VestState::deserialize(&contract_keyed_account.account.data)?;
-            let current_dt = parse_date_account(date_keyed_account, &vest_state.date_pubkey)?;
+            let current_date = parse_date_account(date_keyed_account, &vest_state.date_pubkey)?;
             let contract_account = &mut contract_keyed_account.account;
             let payee_account = parse_account(payee_keyed_account, &vest_state.payee_pubkey)?;
 
-            vest_state.redeem_tokens(current_dt, contract_account, payee_account);
+            vest_state.redeem_tokens(current_date, contract_account, payee_account);
             vest_state.serialize(&mut contract_account.data)
         }
         VestInstruction::Terminate => {
@@ -181,7 +181,7 @@ mod tests {
         payer_keypair: &Keypair,
         payee_pubkey: &Pubkey,
         contract_pubkey: &Pubkey,
-        start_dt: Date<Utc>,
+        start_date: Date<Utc>,
         date_pubkey: &Pubkey,
         lamports: u64,
     ) -> Result<Signature, TransportError> {
@@ -189,7 +189,7 @@ mod tests {
             &payer_keypair.pubkey(),
             &payee_pubkey,
             &contract_pubkey,
-            start_dt,
+            start_date,
             &date_pubkey,
             lamports,
         );
@@ -295,19 +295,19 @@ mod tests {
         let date_keypair = Keypair::new();
         let date_pubkey = date_keypair.pubkey();
 
-        let current_dt = Utc.ymd(2019, 1, 1);
-        create_date_account(&bank_client, &alice_keypair, &date_keypair, current_dt).unwrap();
+        let current_date = Utc.ymd(2019, 1, 1);
+        create_date_account(&bank_client, &alice_keypair, &date_keypair, current_date).unwrap();
 
         let contract_pubkey = Pubkey::new_rand();
         let bob_pubkey = Pubkey::new_rand();
-        let start_dt = Utc.ymd(2018, 1, 1);
+        let start_date = Utc.ymd(2018, 1, 1);
 
         create_vest_account(
             &bank_client,
             &alice_keypair,
             &bob_pubkey,
             &contract_pubkey,
-            start_dt,
+            start_date,
             &date_pubkey,
             36,
         )
@@ -360,20 +360,20 @@ mod tests {
         let alice_pubkey = alice_keypair.pubkey();
         let contract_pubkey = Pubkey::new_rand();
         let bob_pubkey = Pubkey::new_rand();
-        let start_dt = Utc::now().date();
+        let start_date = Utc::now().date();
 
         let date_keypair = Keypair::new();
         let date_pubkey = date_keypair.pubkey();
 
-        let current_dt = Utc.ymd(2019, 1, 1);
-        create_date_account(&bank_client, &alice_keypair, &date_keypair, current_dt).unwrap();
+        let current_date = Utc.ymd(2019, 1, 1);
+        create_date_account(&bank_client, &alice_keypair, &date_keypair, current_date).unwrap();
 
         create_vest_account(
             &bank_client,
             &alice_keypair,
             &bob_pubkey,
             &contract_pubkey,
-            start_dt,
+            start_date,
             &date_pubkey,
             1,
         )

--- a/programs/vest_api/src/vest_processor.rs
+++ b/programs/vest_api/src/vest_processor.rs
@@ -2,64 +2,12 @@
 use crate::date_instruction::DateConfig;
 use crate::{
     vest_instruction::{VestError, VestInstruction},
+    vest_schedule::create_vesting_schedule,
     vest_state::VestState,
 };
 use bincode::deserialize;
-use chrono::prelude::*;
 use solana_config_api::get_config_data;
 use solana_sdk::{account::KeyedAccount, instruction::InstructionError, pubkey::Pubkey};
-
-/// Return the date that is 'n' months from 'start'.
-fn get_month(start: Date<Utc>, n: u32) -> Date<Utc> {
-    let year = start.year() + (start.month0() + n) as i32 / 12;
-    let month0 = (start.month0() + n) % 12;
-
-    // For those that started on the 31st, pay out on the latest day of the month.
-    let mut dt = None;
-    let mut days_back = 0;
-    while dt.is_none() {
-        dt = Utc
-            .ymd_opt(year, month0 + 1, start.day() - days_back)
-            .single();
-        days_back += 1;
-    }
-    dt.unwrap()
-}
-
-/// Integer division that also returns the remainer.
-fn div(dividend: u64, divisor: u64) -> (u64, u64) {
-    (dividend / divisor, dividend % divisor)
-}
-
-/// Return a list of contract messages and a list of vesting-date/lamports pairs.
-pub fn create_vesting_schedule(start_date: Date<Utc>, mut lamports: u64) -> Vec<(Date<Utc>, u64)> {
-    let mut schedule = vec![];
-
-    // 1/3 vest after one year from start date.
-    let (mut stipend, remainder) = div(lamports, 3);
-    stipend += remainder;
-
-    let dt = get_month(start_date, 12);
-    schedule.push((dt, stipend));
-
-    lamports -= stipend;
-
-    // Remaining 66% vest monthly after one year.
-    let payments = 24u32;
-    let (stipend, remainder) = div(lamports, u64::from(payments));
-    for n in 0..payments {
-        let mut stipend = stipend;
-        if u64::from(n) < remainder {
-            stipend += 1;
-        }
-        let dt = get_month(start_date, n + 13);
-        schedule.push((dt, stipend));
-        lamports -= stipend;
-    }
-    assert_eq!(lamports, 0);
-
-    schedule
-}
 
 /// Redeem vested tokens.
 fn redeem_tokens(
@@ -165,6 +113,7 @@ mod tests {
     use crate::date_instruction;
     use crate::id;
     use crate::vest_instruction;
+    use chrono::prelude::*;
     use solana_runtime::bank::Bank;
     use solana_runtime::bank_client::BankClient;
     use solana_sdk::client::SyncClient;
@@ -174,112 +123,6 @@ mod tests {
     use solana_sdk::signature::{Keypair, KeypairUtil, Signature};
     use solana_sdk::transport::TransportError;
     use std::sync::Arc;
-
-    #[test]
-    fn test_get_month() {
-        let start = Utc.ymd(2018, 1, 31);
-        assert_eq!(get_month(start, 0), Utc.ymd(2018, 1, 31));
-        assert_eq!(get_month(start, 1), Utc.ymd(2018, 2, 28));
-        assert_eq!(get_month(start, 2), Utc.ymd(2018, 3, 31));
-    }
-
-    #[test]
-    fn test_create_vesting_schedule() {
-        assert_eq!(
-            create_vesting_schedule(Utc.ymd(2018, 1, 1), 36_000),
-            vec![
-                (Utc.ymd(2019, 1, 1), 12000),
-                (Utc.ymd(2019, 2, 1), 1000),
-                (Utc.ymd(2019, 3, 1), 1000),
-                (Utc.ymd(2019, 4, 1), 1000),
-                (Utc.ymd(2019, 5, 1), 1000),
-                (Utc.ymd(2019, 6, 1), 1000),
-                (Utc.ymd(2019, 7, 1), 1000),
-                (Utc.ymd(2019, 8, 1), 1000),
-                (Utc.ymd(2019, 9, 1), 1000),
-                (Utc.ymd(2019, 10, 1), 1000),
-                (Utc.ymd(2019, 11, 1), 1000),
-                (Utc.ymd(2019, 12, 1), 1000),
-                (Utc.ymd(2020, 1, 1), 1000),
-                (Utc.ymd(2020, 2, 1), 1000),
-                (Utc.ymd(2020, 3, 1), 1000),
-                (Utc.ymd(2020, 4, 1), 1000),
-                (Utc.ymd(2020, 5, 1), 1000),
-                (Utc.ymd(2020, 6, 1), 1000),
-                (Utc.ymd(2020, 7, 1), 1000),
-                (Utc.ymd(2020, 8, 1), 1000),
-                (Utc.ymd(2020, 9, 1), 1000),
-                (Utc.ymd(2020, 10, 1), 1000),
-                (Utc.ymd(2020, 11, 1), 1000),
-                (Utc.ymd(2020, 12, 1), 1000),
-                (Utc.ymd(2021, 1, 1), 1000),
-            ]
-        );
-
-        // Ensure vesting date is sensible if start date was at the end of the month.
-        assert_eq!(
-            create_vesting_schedule(Utc.ymd(2018, 1, 31), 36_000),
-            vec![
-                (Utc.ymd(2019, 1, 31), 12000),
-                (Utc.ymd(2019, 2, 28), 1000),
-                (Utc.ymd(2019, 3, 31), 1000),
-                (Utc.ymd(2019, 4, 30), 1000),
-                (Utc.ymd(2019, 5, 31), 1000),
-                (Utc.ymd(2019, 6, 30), 1000),
-                (Utc.ymd(2019, 7, 31), 1000),
-                (Utc.ymd(2019, 8, 31), 1000),
-                (Utc.ymd(2019, 9, 30), 1000),
-                (Utc.ymd(2019, 10, 31), 1000),
-                (Utc.ymd(2019, 11, 30), 1000),
-                (Utc.ymd(2019, 12, 31), 1000),
-                (Utc.ymd(2020, 1, 31), 1000),
-                (Utc.ymd(2020, 2, 29), 1000), // Leap year
-                (Utc.ymd(2020, 3, 31), 1000),
-                (Utc.ymd(2020, 4, 30), 1000),
-                (Utc.ymd(2020, 5, 31), 1000),
-                (Utc.ymd(2020, 6, 30), 1000),
-                (Utc.ymd(2020, 7, 31), 1000),
-                (Utc.ymd(2020, 8, 31), 1000),
-                (Utc.ymd(2020, 9, 30), 1000),
-                (Utc.ymd(2020, 10, 31), 1000),
-                (Utc.ymd(2020, 11, 30), 1000),
-                (Utc.ymd(2020, 12, 31), 1000),
-                (Utc.ymd(2021, 1, 31), 1000),
-            ]
-        );
-
-        // Awkward numbers
-        assert_eq!(
-            create_vesting_schedule(Utc.ymd(2018, 1, 1), 123_123),
-            vec![
-                (Utc.ymd(2019, 1, 1), 41041), // floor(123_123 / 3) + 123_123 % 3
-                (Utc.ymd(2019, 2, 1), 3421),  // ceil(82_082 / 24)
-                (Utc.ymd(2019, 3, 1), 3421),  // ceil(82_082 / 24)
-                (Utc.ymd(2019, 4, 1), 3420),  // floor(82_082 / 24)
-                (Utc.ymd(2019, 5, 1), 3420),
-                (Utc.ymd(2019, 6, 1), 3420),
-                (Utc.ymd(2019, 7, 1), 3420),
-                (Utc.ymd(2019, 8, 1), 3420),
-                (Utc.ymd(2019, 9, 1), 3420),
-                (Utc.ymd(2019, 10, 1), 3420),
-                (Utc.ymd(2019, 11, 1), 3420),
-                (Utc.ymd(2019, 12, 1), 3420),
-                (Utc.ymd(2020, 1, 1), 3420),
-                (Utc.ymd(2020, 2, 1), 3420),
-                (Utc.ymd(2020, 3, 1), 3420),
-                (Utc.ymd(2020, 4, 1), 3420),
-                (Utc.ymd(2020, 5, 1), 3420),
-                (Utc.ymd(2020, 6, 1), 3420),
-                (Utc.ymd(2020, 7, 1), 3420),
-                (Utc.ymd(2020, 8, 1), 3420),
-                (Utc.ymd(2020, 9, 1), 3420),
-                (Utc.ymd(2020, 10, 1), 3420),
-                (Utc.ymd(2020, 11, 1), 3420),
-                (Utc.ymd(2020, 12, 1), 3420),
-                (Utc.ymd(2021, 1, 1), 3420),
-            ]
-        );
-    }
 
     fn create_bank(lamports: u64) -> (Bank, Keypair) {
         let (genesis_block, mint_keypair) = create_genesis_block(lamports);

--- a/programs/vest_api/src/vest_processor.rs
+++ b/programs/vest_api/src/vest_processor.rs
@@ -299,7 +299,7 @@ mod tests {
         let oracle_keypair = Keypair::new();
         let oracle_pubkey = oracle_keypair.pubkey();
 
-        let future_dt = Utc.ymd(2019, 1, 1).and_hms(0, 0, 0);
+        let future_dt = Utc.ymd(2019, 1, 1);
         let mut instructions = date_instruction::create_account(&alice_pubkey, &oracle_pubkey, 1);
         instructions.push(date_instruction::store(&oracle_pubkey, future_dt));
 
@@ -310,7 +310,7 @@ mod tests {
 
         let vest_pubkey = Pubkey::new_rand();
         let bob_pubkey = Pubkey::new_rand();
-        let dt = Utc.ymd(2018, 1, 1).and_hms(0, 0, 0);
+        let dt = Utc.ymd(2018, 1, 1);
 
         let instructions = vest_instruction::create_account(
             &alice_pubkey,
@@ -345,7 +345,7 @@ mod tests {
         let alice_pubkey = alice_keypair.pubkey();
         let vest_pubkey = Pubkey::new_rand();
         let bob_pubkey = Pubkey::new_rand();
-        let dt = Utc::now();
+        let dt = Utc::now().date();
 
         let instructions = vest_instruction::create_account(
             &alice_pubkey,

--- a/programs/vest_api/src/vest_processor.rs
+++ b/programs/vest_api/src/vest_processor.rs
@@ -1,0 +1,334 @@
+//! vest program
+use crate::date_instruction::DateConfig;
+use crate::{
+    vest_instruction::{VestError, VestInstruction},
+    vest_state::VestState,
+};
+use bincode::deserialize;
+use chrono::prelude::*;
+use log::*;
+use solana_config_api::get_config_data;
+use solana_sdk::{account::KeyedAccount, instruction::InstructionError, pubkey::Pubkey};
+
+/// Return the date that is 'n' months from 'start'.
+fn get_month(start: Date<Utc>, n: u32) -> Date<Utc> {
+    let year = start.year() + (start.month0() + n) as i32 / 12;
+    let month0 = (start.month0() + n) % 12;
+
+    // For those that started on the 31st, pay out on the latest day of the month.
+    let mut dt = None;
+    let mut days_back = 0;
+    while dt.is_none() {
+        dt = Utc
+            .ymd_opt(year, month0 + 1, start.day() - days_back)
+            .single();
+        days_back += 1;
+    }
+    dt.unwrap()
+}
+
+/// Integer division that also returns the remainer.
+fn div(dividend: u64, divisor: u64) -> (u64, u64) {
+    (dividend / divisor, dividend % divisor)
+}
+
+// Return a list of contract messages and a list of contract_id/to_id pairs.
+pub fn create_vesting_schedule(start_date: Date<Utc>, mut lamports: u64) -> Vec<(Date<Utc>, u64)> {
+    let mut schedule = vec![];
+
+    // 1/3 vest after one year from start date.
+    let (mut stipend, remainder) = div(lamports, 3);
+    stipend += remainder;
+
+    let dt = get_month(start_date, 12);
+    schedule.push((dt, stipend));
+
+    lamports -= stipend;
+
+    // Remaining 66% vest monthly after one year.
+    let payments = 24u32;
+    let (stipend, remainder) = div(lamports, u64::from(payments));
+    for n in 0..payments {
+        let mut stipend = stipend;
+        if u64::from(n) < remainder {
+            stipend += 1;
+        }
+        let dt = get_month(start_date, n + 13);
+        schedule.push((dt, stipend));
+        lamports -= stipend;
+    }
+    assert_eq!(lamports, 0);
+
+    schedule
+}
+
+/// Process an AccountData Witness and any payment waiting on it.
+fn redeem_tokens(
+    vest_state: &mut VestState,
+    keyed_accounts: &mut [KeyedAccount],
+) -> Result<(), VestError> {
+    let date_keyed_account = &keyed_accounts[0];
+    if date_keyed_account.account.owner != solana_config_api::id() {
+        return Err(VestError::UnexpectedProgramId);
+    }
+
+    if *date_keyed_account.unsigned_key() != vest_state.oracle_pubkey {
+        return Err(VestError::Unauthorized);
+    }
+
+    if &vest_state.payee_pubkey != keyed_accounts[2].unsigned_key() {
+        trace!("destination missing");
+        return Err(VestError::DestinationMissing);
+    }
+
+    let date_config: DateConfig =
+        deserialize(get_config_data(&date_keyed_account.account.data).unwrap()).unwrap();
+
+    let schedule = create_vesting_schedule(vest_state.start_dt.date(), vest_state.lamports);
+
+    let vested_lamports = schedule
+        .into_iter()
+        .take_while(|(dt, _)| *dt <= date_config.dt.date())
+        .map(|(_, lamports)| lamports)
+        .sum::<u64>();
+
+    let redeemable_lamports = vested_lamports.saturating_sub(vest_state.redeemed_lamports);
+
+    keyed_accounts[1].account.lamports -= redeemable_lamports;
+    keyed_accounts[2].account.lamports += redeemable_lamports;
+
+    vest_state.redeemed_lamports += redeemable_lamports;
+
+    Ok(())
+}
+
+/// Terminate the contract and return all tokens to the given pubkey.
+fn terminate(
+    vest_state: &mut VestState,
+    keyed_accounts: &mut [KeyedAccount],
+) -> Result<(), VestError> {
+    let signer_key = keyed_accounts[0].signer_key().unwrap();
+    if &vest_state.terminator_pubkey != signer_key {
+        return Err(VestError::Unauthorized);
+    }
+
+    // If only 2 accounts provided, send tokens to the signer.
+    let i = if keyed_accounts.len() < 3 { 0 } else { 2 };
+    keyed_accounts[i].account.lamports += keyed_accounts[1].account.lamports;
+    keyed_accounts[1].account.lamports = 0;
+    Ok(())
+}
+
+pub fn process_instruction(
+    _program_id: &Pubkey,
+    keyed_accounts: &mut [KeyedAccount],
+    data: &[u8],
+) -> Result<(), InstructionError> {
+    let instruction = deserialize(data).map_err(|err| {
+        info!("Invalid transaction data: {:?} {:?}", data, err);
+        InstructionError::InvalidInstructionData
+    })?;
+
+    trace!("process_instruction: {:?}", instruction);
+
+    match instruction {
+        VestInstruction::InitializeAccount {
+            terminator_pubkey,
+            payee_pubkey,
+            start_dt,
+            oracle_pubkey,
+            lamports,
+        } => {
+            let vest_state = VestState {
+                terminator_pubkey,
+                payee_pubkey,
+                start_dt,
+                oracle_pubkey,
+                lamports,
+                redeemed_lamports: 0,
+            };
+            vest_state.serialize(&mut keyed_accounts[0].account.data)
+        }
+        VestInstruction::RedeemTokens => {
+            let mut vest_state = VestState::deserialize(&keyed_accounts[1].account.data)?;
+            redeem_tokens(&mut vest_state, keyed_accounts)
+                .map_err(|e| InstructionError::CustomError(e as u32))?;
+            trace!("apply account data committed");
+            vest_state.serialize(&mut keyed_accounts[1].account.data)
+        }
+        VestInstruction::Terminate => {
+            let mut vest_state = VestState::deserialize(&keyed_accounts[1].account.data)?;
+            if keyed_accounts[0].signer_key().is_none() {
+                return Err(InstructionError::MissingRequiredSignature);
+            }
+            trace!("apply signature");
+            terminate(&mut vest_state, keyed_accounts)
+                .map_err(|e| InstructionError::CustomError(e as u32))?;
+            trace!("apply signature committed");
+            vest_state.serialize(&mut keyed_accounts[1].account.data)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::id;
+    use crate::vest_instruction;
+    use solana_runtime::bank::Bank;
+    use solana_runtime::bank_client::BankClient;
+    //use solana_sdk::account::Account;
+    use solana_sdk::client::SyncClient;
+    use solana_sdk::genesis_block::create_genesis_block;
+    //use solana_sdk::instruction::InstructionError;
+    use solana_sdk::message::Message;
+    use solana_sdk::signature::{Keypair, KeypairUtil};
+    //use solana_sdk::transaction::TransactionError;
+
+    #[test]
+    fn test_get_month() {
+        let start = Utc.ymd(2018, 1, 31);
+        assert_eq!(get_month(start, 0), Utc.ymd(2018, 1, 31));
+        assert_eq!(get_month(start, 1), Utc.ymd(2018, 2, 28));
+        assert_eq!(get_month(start, 2), Utc.ymd(2018, 3, 31));
+    }
+
+    #[test]
+    fn test_create_vesting_schedule() {
+        assert_eq!(
+            create_vesting_schedule(Utc.ymd(2018, 1, 1), 36_000),
+            vec![
+                (Utc.ymd(2019, 1, 1), 12000),
+                (Utc.ymd(2019, 2, 1), 1000),
+                (Utc.ymd(2019, 3, 1), 1000),
+                (Utc.ymd(2019, 4, 1), 1000),
+                (Utc.ymd(2019, 5, 1), 1000),
+                (Utc.ymd(2019, 6, 1), 1000),
+                (Utc.ymd(2019, 7, 1), 1000),
+                (Utc.ymd(2019, 8, 1), 1000),
+                (Utc.ymd(2019, 9, 1), 1000),
+                (Utc.ymd(2019, 10, 1), 1000),
+                (Utc.ymd(2019, 11, 1), 1000),
+                (Utc.ymd(2019, 12, 1), 1000),
+                (Utc.ymd(2020, 1, 1), 1000),
+                (Utc.ymd(2020, 2, 1), 1000),
+                (Utc.ymd(2020, 3, 1), 1000),
+                (Utc.ymd(2020, 4, 1), 1000),
+                (Utc.ymd(2020, 5, 1), 1000),
+                (Utc.ymd(2020, 6, 1), 1000),
+                (Utc.ymd(2020, 7, 1), 1000),
+                (Utc.ymd(2020, 8, 1), 1000),
+                (Utc.ymd(2020, 9, 1), 1000),
+                (Utc.ymd(2020, 10, 1), 1000),
+                (Utc.ymd(2020, 11, 1), 1000),
+                (Utc.ymd(2020, 12, 1), 1000),
+                (Utc.ymd(2021, 1, 1), 1000),
+            ]
+        );
+
+        // Ensure vesting date is sensible if start date was at the end of the month.
+        assert_eq!(
+            create_vesting_schedule(Utc.ymd(2018, 1, 31), 36_000),
+            vec![
+                (Utc.ymd(2019, 1, 31), 12000),
+                (Utc.ymd(2019, 2, 28), 1000),
+                (Utc.ymd(2019, 3, 31), 1000),
+                (Utc.ymd(2019, 4, 30), 1000),
+                (Utc.ymd(2019, 5, 31), 1000),
+                (Utc.ymd(2019, 6, 30), 1000),
+                (Utc.ymd(2019, 7, 31), 1000),
+                (Utc.ymd(2019, 8, 31), 1000),
+                (Utc.ymd(2019, 9, 30), 1000),
+                (Utc.ymd(2019, 10, 31), 1000),
+                (Utc.ymd(2019, 11, 30), 1000),
+                (Utc.ymd(2019, 12, 31), 1000),
+                (Utc.ymd(2020, 1, 31), 1000),
+                (Utc.ymd(2020, 2, 29), 1000), // Leap year
+                (Utc.ymd(2020, 3, 31), 1000),
+                (Utc.ymd(2020, 4, 30), 1000),
+                (Utc.ymd(2020, 5, 31), 1000),
+                (Utc.ymd(2020, 6, 30), 1000),
+                (Utc.ymd(2020, 7, 31), 1000),
+                (Utc.ymd(2020, 8, 31), 1000),
+                (Utc.ymd(2020, 9, 30), 1000),
+                (Utc.ymd(2020, 10, 31), 1000),
+                (Utc.ymd(2020, 11, 30), 1000),
+                (Utc.ymd(2020, 12, 31), 1000),
+                (Utc.ymd(2021, 1, 31), 1000),
+            ]
+        );
+
+        // Awkward numbers
+        assert_eq!(
+            create_vesting_schedule(Utc.ymd(2018, 1, 1), 123_123),
+            vec![
+                (Utc.ymd(2019, 1, 1), 41041), // floor(123_123 / 3) + 123_123 % 3
+                (Utc.ymd(2019, 2, 1), 3421),  // ceil(82_082 / 24)
+                (Utc.ymd(2019, 3, 1), 3421),  // ceil(82_082 / 24)
+                (Utc.ymd(2019, 4, 1), 3420),  // floor(82_082 / 24)
+                (Utc.ymd(2019, 5, 1), 3420),
+                (Utc.ymd(2019, 6, 1), 3420),
+                (Utc.ymd(2019, 7, 1), 3420),
+                (Utc.ymd(2019, 8, 1), 3420),
+                (Utc.ymd(2019, 9, 1), 3420),
+                (Utc.ymd(2019, 10, 1), 3420),
+                (Utc.ymd(2019, 11, 1), 3420),
+                (Utc.ymd(2019, 12, 1), 3420),
+                (Utc.ymd(2020, 1, 1), 3420),
+                (Utc.ymd(2020, 2, 1), 3420),
+                (Utc.ymd(2020, 3, 1), 3420),
+                (Utc.ymd(2020, 4, 1), 3420),
+                (Utc.ymd(2020, 5, 1), 3420),
+                (Utc.ymd(2020, 6, 1), 3420),
+                (Utc.ymd(2020, 7, 1), 3420),
+                (Utc.ymd(2020, 8, 1), 3420),
+                (Utc.ymd(2020, 9, 1), 3420),
+                (Utc.ymd(2020, 10, 1), 3420),
+                (Utc.ymd(2020, 11, 1), 3420),
+                (Utc.ymd(2020, 12, 1), 3420),
+                (Utc.ymd(2021, 1, 1), 3420),
+            ]
+        );
+    }
+
+    fn create_bank(lamports: u64) -> (Bank, Keypair) {
+        let (genesis_block, mint_keypair) = create_genesis_block(lamports);
+        let mut bank = Bank::new(&genesis_block);
+        bank.add_instruction_processor(id(), process_instruction);
+        (bank, mint_keypair)
+    }
+
+    #[test]
+    fn test_cancel_payment() {
+        let (bank, alice_keypair) = create_bank(3);
+        let bank_client = BankClient::new(bank);
+        let alice_pubkey = alice_keypair.pubkey();
+        let vest_pubkey = Pubkey::new_rand();
+        let bob_pubkey = Pubkey::new_rand();
+        let dt = Utc::now();
+
+        let instructions = vest_instruction::create_account(
+            &alice_pubkey,
+            &bob_pubkey,
+            &vest_pubkey,
+            dt,
+            &alice_pubkey,
+            1,
+        );
+        let message = Message::new(instructions);
+        bank_client
+            .send_message(&[&alice_keypair], message)
+            .unwrap();
+        assert_eq!(bank_client.get_balance(&alice_pubkey).unwrap(), 2);
+        assert_eq!(bank_client.get_balance(&vest_pubkey).unwrap(), 1);
+
+        // Now, terminate the transaction. alice gets her funds back
+        let instruction = vest_instruction::terminate(&alice_pubkey, &vest_pubkey, &alice_pubkey);
+        bank_client
+            .send_instruction(&alice_keypair, instruction)
+            .unwrap();
+        assert_eq!(bank_client.get_balance(&alice_pubkey).unwrap(), 3);
+        assert_eq!(bank_client.get_account_data(&vest_pubkey).unwrap(), None);
+        assert_eq!(bank_client.get_account_data(&bob_pubkey).unwrap(), None);
+    }
+}

--- a/programs/vest_api/src/vest_schedule.rs
+++ b/programs/vest_api/src/vest_schedule.rs
@@ -1,0 +1,166 @@
+//! A library for creating vesting schedules
+
+use chrono::prelude::*;
+
+/// Return the date that is 'n' months from 'start'.
+fn get_month(start: Date<Utc>, n: u32) -> Date<Utc> {
+    let year = start.year() + (start.month0() + n) as i32 / 12;
+    let month0 = (start.month0() + n) % 12;
+
+    // For those that started on the 31st, pay out on the latest day of the month.
+    let mut dt = None;
+    let mut days_back = 0;
+    while dt.is_none() {
+        dt = Utc
+            .ymd_opt(year, month0 + 1, start.day() - days_back)
+            .single();
+        days_back += 1;
+    }
+    dt.unwrap()
+}
+
+/// Integer division that also returns the remainer.
+fn div(dividend: u64, divisor: u64) -> (u64, u64) {
+    (dividend / divisor, dividend % divisor)
+}
+
+/// Return a list of contract messages and a list of vesting-date/lamports pairs.
+pub fn create_vesting_schedule(start_date: Date<Utc>, mut lamports: u64) -> Vec<(Date<Utc>, u64)> {
+    let mut schedule = vec![];
+
+    // 1/3 vest after one year from start date.
+    let (mut stipend, remainder) = div(lamports, 3);
+    stipend += remainder;
+
+    let dt = get_month(start_date, 12);
+    schedule.push((dt, stipend));
+
+    lamports -= stipend;
+
+    // Remaining 66% vest monthly after one year.
+    let payments = 24u32;
+    let (stipend, remainder) = div(lamports, u64::from(payments));
+    for n in 0..payments {
+        let mut stipend = stipend;
+        if u64::from(n) < remainder {
+            stipend += 1;
+        }
+        let dt = get_month(start_date, n + 13);
+        schedule.push((dt, stipend));
+        lamports -= stipend;
+    }
+    assert_eq!(lamports, 0);
+
+    schedule
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_get_month() {
+        let start = Utc.ymd(2018, 1, 31);
+        assert_eq!(get_month(start, 0), Utc.ymd(2018, 1, 31));
+        assert_eq!(get_month(start, 1), Utc.ymd(2018, 2, 28));
+        assert_eq!(get_month(start, 2), Utc.ymd(2018, 3, 31));
+    }
+
+    #[test]
+    fn test_create_vesting_schedule() {
+        assert_eq!(
+            create_vesting_schedule(Utc.ymd(2018, 1, 1), 36_000),
+            vec![
+                (Utc.ymd(2019, 1, 1), 12000),
+                (Utc.ymd(2019, 2, 1), 1000),
+                (Utc.ymd(2019, 3, 1), 1000),
+                (Utc.ymd(2019, 4, 1), 1000),
+                (Utc.ymd(2019, 5, 1), 1000),
+                (Utc.ymd(2019, 6, 1), 1000),
+                (Utc.ymd(2019, 7, 1), 1000),
+                (Utc.ymd(2019, 8, 1), 1000),
+                (Utc.ymd(2019, 9, 1), 1000),
+                (Utc.ymd(2019, 10, 1), 1000),
+                (Utc.ymd(2019, 11, 1), 1000),
+                (Utc.ymd(2019, 12, 1), 1000),
+                (Utc.ymd(2020, 1, 1), 1000),
+                (Utc.ymd(2020, 2, 1), 1000),
+                (Utc.ymd(2020, 3, 1), 1000),
+                (Utc.ymd(2020, 4, 1), 1000),
+                (Utc.ymd(2020, 5, 1), 1000),
+                (Utc.ymd(2020, 6, 1), 1000),
+                (Utc.ymd(2020, 7, 1), 1000),
+                (Utc.ymd(2020, 8, 1), 1000),
+                (Utc.ymd(2020, 9, 1), 1000),
+                (Utc.ymd(2020, 10, 1), 1000),
+                (Utc.ymd(2020, 11, 1), 1000),
+                (Utc.ymd(2020, 12, 1), 1000),
+                (Utc.ymd(2021, 1, 1), 1000),
+            ]
+        );
+
+        // Ensure vesting date is sensible if start date was at the end of the month.
+        assert_eq!(
+            create_vesting_schedule(Utc.ymd(2018, 1, 31), 36_000),
+            vec![
+                (Utc.ymd(2019, 1, 31), 12000),
+                (Utc.ymd(2019, 2, 28), 1000),
+                (Utc.ymd(2019, 3, 31), 1000),
+                (Utc.ymd(2019, 4, 30), 1000),
+                (Utc.ymd(2019, 5, 31), 1000),
+                (Utc.ymd(2019, 6, 30), 1000),
+                (Utc.ymd(2019, 7, 31), 1000),
+                (Utc.ymd(2019, 8, 31), 1000),
+                (Utc.ymd(2019, 9, 30), 1000),
+                (Utc.ymd(2019, 10, 31), 1000),
+                (Utc.ymd(2019, 11, 30), 1000),
+                (Utc.ymd(2019, 12, 31), 1000),
+                (Utc.ymd(2020, 1, 31), 1000),
+                (Utc.ymd(2020, 2, 29), 1000), // Leap year
+                (Utc.ymd(2020, 3, 31), 1000),
+                (Utc.ymd(2020, 4, 30), 1000),
+                (Utc.ymd(2020, 5, 31), 1000),
+                (Utc.ymd(2020, 6, 30), 1000),
+                (Utc.ymd(2020, 7, 31), 1000),
+                (Utc.ymd(2020, 8, 31), 1000),
+                (Utc.ymd(2020, 9, 30), 1000),
+                (Utc.ymd(2020, 10, 31), 1000),
+                (Utc.ymd(2020, 11, 30), 1000),
+                (Utc.ymd(2020, 12, 31), 1000),
+                (Utc.ymd(2021, 1, 31), 1000),
+            ]
+        );
+
+        // Awkward numbers
+        assert_eq!(
+            create_vesting_schedule(Utc.ymd(2018, 1, 1), 123_123),
+            vec![
+                (Utc.ymd(2019, 1, 1), 41041), // floor(123_123 / 3) + 123_123 % 3
+                (Utc.ymd(2019, 2, 1), 3421),  // ceil(82_082 / 24)
+                (Utc.ymd(2019, 3, 1), 3421),  // ceil(82_082 / 24)
+                (Utc.ymd(2019, 4, 1), 3420),  // floor(82_082 / 24)
+                (Utc.ymd(2019, 5, 1), 3420),
+                (Utc.ymd(2019, 6, 1), 3420),
+                (Utc.ymd(2019, 7, 1), 3420),
+                (Utc.ymd(2019, 8, 1), 3420),
+                (Utc.ymd(2019, 9, 1), 3420),
+                (Utc.ymd(2019, 10, 1), 3420),
+                (Utc.ymd(2019, 11, 1), 3420),
+                (Utc.ymd(2019, 12, 1), 3420),
+                (Utc.ymd(2020, 1, 1), 3420),
+                (Utc.ymd(2020, 2, 1), 3420),
+                (Utc.ymd(2020, 3, 1), 3420),
+                (Utc.ymd(2020, 4, 1), 3420),
+                (Utc.ymd(2020, 5, 1), 3420),
+                (Utc.ymd(2020, 6, 1), 3420),
+                (Utc.ymd(2020, 7, 1), 3420),
+                (Utc.ymd(2020, 8, 1), 3420),
+                (Utc.ymd(2020, 9, 1), 3420),
+                (Utc.ymd(2020, 10, 1), 3420),
+                (Utc.ymd(2020, 11, 1), 3420),
+                (Utc.ymd(2020, 12, 1), 3420),
+                (Utc.ymd(2021, 1, 1), 3420),
+            ]
+        );
+    }
+}

--- a/programs/vest_api/src/vest_schedule.rs
+++ b/programs/vest_api/src/vest_schedule.rs
@@ -19,7 +19,7 @@ fn get_month(start: Date<Utc>, n: u32) -> Date<Utc> {
     dt.unwrap()
 }
 
-/// Integer division that also returns the remainer.
+/// Integer division that also returns the remainder.
 fn div(dividend: u64, divisor: u64) -> (u64, u64) {
     (dividend / divisor, dividend % divisor)
 }

--- a/programs/vest_api/src/vest_state.rs
+++ b/programs/vest_api/src/vest_state.rs
@@ -19,13 +19,13 @@ pub struct VestState {
 
     /// The day from which the vesting contract begins
     #[serde(with = "ts_seconds")]
-    pub start_dt: DateTime<Utc>,
+    pub start_date_time: DateTime<Utc>,
 
     /// Address of an account containing a trusted date, used to drive the vesting schedule
     pub date_pubkey: Pubkey,
 
     /// The number of lamports to send the payee if the schedule completes
-    pub lamports: u64,
+    pub total_lamports: u64,
 
     /// The number of lamports the payee has already redeemed
     pub redeemed_lamports: u64,
@@ -36,9 +36,9 @@ impl Default for VestState {
         Self {
             terminator_pubkey: Pubkey::default(),
             payee_pubkey: Pubkey::default(),
-            start_dt: Utc.timestamp(0, 0),
+            start_date_time: Utc.timestamp(0, 0),
             date_pubkey: Pubkey::default(),
-            lamports: 0,
+            total_lamports: 0,
             redeemed_lamports: 0,
         }
     }
@@ -56,15 +56,15 @@ impl VestState {
     /// Redeem vested tokens.
     pub fn redeem_tokens(
         &mut self,
-        current_dt: Date<Utc>,
+        current_date: Date<Utc>,
         contract_account: &mut Account,
         payee_account: &mut Account,
     ) {
-        let schedule = create_vesting_schedule(self.start_dt.date(), self.lamports);
+        let schedule = create_vesting_schedule(self.start_date_time.date(), self.total_lamports);
 
         let vested_lamports = schedule
             .into_iter()
-            .take_while(|(dt, _)| *dt <= current_dt)
+            .take_while(|(dt, _)| *dt <= current_date)
             .map(|(_, lamports)| lamports)
             .sum::<u64>();
 

--- a/programs/vest_api/src/vest_state.rs
+++ b/programs/vest_api/src/vest_state.rs
@@ -1,0 +1,80 @@
+//! vest state
+use bincode::{self, deserialize, serialize_into};
+use chrono::{
+    prelude::{DateTime, TimeZone, Utc},
+    serde::ts_seconds,
+};
+use serde_derive::{Deserialize, Serialize};
+use solana_sdk::instruction::InstructionError;
+use solana_sdk::pubkey::Pubkey;
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct VestState {
+    /// The address authorized to terminate this contract with a signed Terminate instruction
+    pub terminator_pubkey: Pubkey,
+
+    /// The address authorized to redeem vested tokens
+    pub payee_pubkey: Pubkey,
+
+    /// The day from which the vesting contract begins
+    #[serde(with = "ts_seconds")]
+    pub start_dt: DateTime<Utc>,
+
+    /// Address of an account containing a trusted date, used to drive the vesting schedule
+    pub oracle_pubkey: Pubkey,
+
+    /// The number of lamports to send the payee if the schedule completes
+    pub lamports: u64,
+
+    /// The number of lamports the payee has already redeemed
+    pub redeemed_lamports: u64,
+}
+
+impl Default for VestState {
+    fn default() -> Self {
+        Self {
+            terminator_pubkey: Pubkey::default(),
+            payee_pubkey: Pubkey::default(),
+            start_dt: Utc.timestamp(0, 0),
+            oracle_pubkey: Pubkey::default(),
+            lamports: 0,
+            redeemed_lamports: 0,
+        }
+    }
+}
+
+impl VestState {
+    pub fn serialize(&self, output: &mut [u8]) -> Result<(), InstructionError> {
+        serialize_into(output, self).map_err(|_| InstructionError::AccountDataTooSmall)
+    }
+
+    pub fn deserialize(input: &[u8]) -> Result<Self, InstructionError> {
+        deserialize(input).map_err(|_| InstructionError::InvalidAccountData)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::id;
+    use solana_sdk::account::Account;
+
+    #[test]
+    fn test_serializer() {
+        let mut a = Account::new(0, 512, &id());
+        let b = VestState::default();
+        b.serialize(&mut a.data).unwrap();
+        let c = VestState::deserialize(&a.data).unwrap();
+        assert_eq!(b, c);
+    }
+
+    #[test]
+    fn test_serializer_data_too_small() {
+        let mut a = Account::new(0, 1, &id());
+        let b = VestState::default();
+        assert_eq!(
+            b.serialize(&mut a.data),
+            Err(InstructionError::AccountDataTooSmall)
+        );
+    }
+}

--- a/programs/vest_api/src/vest_state.rs
+++ b/programs/vest_api/src/vest_state.rs
@@ -21,7 +21,7 @@ pub struct VestState {
     pub start_dt: DateTime<Utc>,
 
     /// Address of an account containing a trusted date, used to drive the vesting schedule
-    pub oracle_pubkey: Pubkey,
+    pub date_pubkey: Pubkey,
 
     /// The number of lamports to send the payee if the schedule completes
     pub lamports: u64,
@@ -36,7 +36,7 @@ impl Default for VestState {
             terminator_pubkey: Pubkey::default(),
             payee_pubkey: Pubkey::default(),
             start_dt: Utc.timestamp(0, 0),
-            oracle_pubkey: Pubkey::default(),
+            date_pubkey: Pubkey::default(),
             lamports: 0,
             redeemed_lamports: 0,
         }


### PR DESCRIPTION
#### Problem

Using Budget to manage vesting schedules is a pain. We need to create 25 Budget contracts per vesting schedule (which there may be multiple per person) and then have the maintainer to send ApplyTimestamp to each of those contracts to get them to distribute tokens.

#### Summary of Changes

Add a new program Vest that manages a full vesting schedule. After creation, the creator should only interact with a specific contract in order to terminate it. Otherwise, it should simply publish dates to a single trusted account, an oracle account. To redeem tokens, the payee should send a RedeemTokens instruction to the vesting account, which would include the address of the oracle account.

- [x] Finish Vest program
- [x] Debate adding a DateTime program or tossing a DateTime account type into Vest
- [x] More branch coverage
- [x] Upload fun image

![image](https://user-images.githubusercontent.com/55449/66086347-06b20900-e531-11e9-8f89-86f29bad7a27.png)

Fixes #5978

