### PR TITLE
Broadcast stage tuning

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -52,7 +52,7 @@ pub const NUM_THREADS: u32 = 4;
 
 const TOTAL_BUFFERED_PACKETS: usize = 500_000;
 
-const MAX_NUM_TRANSACTIONS_PER_BATCH: usize = 512;
+const MAX_NUM_TRANSACTIONS_PER_BATCH: usize = 128;
 
 /// Stores the stage's thread handle and output receiver.
 pub struct BankingStage {

--- a/core/src/broadcast_stage.rs
+++ b/core/src/broadcast_stage.rs
@@ -8,7 +8,7 @@ use crate::poh_recorder::WorkingBankEntry;
 use crate::result::{Error, Result};
 use crate::service::Service;
 use crate::staking_utils;
-use solana_metrics::{datapoint, inc_new_counter_error, inc_new_counter_info};
+use solana_metrics::{datapoint_info, inc_new_counter_error, inc_new_counter_info};
 use std::net::UdpSocket;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::{Receiver, RecvTimeoutError};


### PR DESCRIPTION
#### Problem
The testnet under high TPS load is not able to maintain consensus 

#### Summary of Changes
The broadcast stage was shredding all entries that it received in one iteration. That was leading to longer delays in broadcasting of shreds to peer validators. Additionally, the validators had to receive all the shreds before entries could be created out of them. This was causing poor CPU utilization on validator nodes.

This change creates smaller batches of entries for shredding. This results in frequent shredding and broadcasting.

Fixes #
