### PR TITLE
Revert "require stake, vote and executable accounts to be rent exempt"

### DIFF
--- a/cli/src/wallet.rs
+++ b/cli/src/wallet.rs
@@ -871,7 +871,7 @@ fn process_deploy(
     // Build transactions to calculate fees
     let mut messages: Vec<&Message> = Vec::new();
     let (blockhash, fee_calculator) = rpc_client.get_recent_blockhash()?;
-    let mut create_account_tx = system_transaction::create_rent_exempted_account(
+    let mut create_account_tx = system_transaction::create_account(
         &config.keypair,
         &program_id.pubkey(),
         blockhash,

--- a/core/src/chacha.rs
+++ b/core/src/chacha.rs
@@ -153,7 +153,7 @@ mod tests {
         hasher.hash(&buf[..size]);
 
         //  golden needs to be updated if blob stuff changes....
-        let golden: Hash = "7P2RmguCZaaBDzjvAej6RnqiA3v82s3PyaCX3uNzsjfc"
+        let golden: Hash = "CLGvEayebjdgnLdttFAweZE9rqVkehXqEStUifG9kiU9"
             .parse()
             .unwrap();
 

--- a/drone/src/drone.rs
+++ b/drone/src/drone.rs
@@ -396,8 +396,7 @@ mod tests {
             SystemInstruction::CreateAccount {
                 lamports: 2,
                 space: 0,
-                program_id: Pubkey::default(),
-                require_rent_exemption: false
+                program_id: Pubkey::default()
             }
         );
 

--- a/programs/stake_api/src/stake_instruction.rs
+++ b/programs/stake_api/src/stake_instruction.rs
@@ -110,7 +110,7 @@ pub fn create_stake_account_with_lockup(
     custodian: &Pubkey,
 ) -> Vec<Instruction> {
     vec![
-        system_instruction::create_rent_exempted_account(
+        system_instruction::create_account(
             from_pubkey,
             stake_pubkey,
             lamports,

--- a/programs/vote_api/src/vote_instruction.rs
+++ b/programs/vote_api/src/vote_instruction.rs
@@ -87,13 +87,8 @@ pub fn create_account(
     lamports: u64,
 ) -> Vec<Instruction> {
     let space = VoteState::size_of() as u64;
-    let create_ix = system_instruction::create_rent_exempted_account(
-        from_pubkey,
-        vote_pubkey,
-        lamports,
-        space,
-        &id(),
-    );
+    let create_ix =
+        system_instruction::create_account(from_pubkey, vote_pubkey, lamports, space, &id());
     let init_ix = initialize_account(vote_pubkey, node_pubkey, commission);
     vec![create_ix, init_ix]
 }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -275,7 +275,6 @@ impl Bank {
             bank.update_stake_history(None);
         }
         bank.update_clock();
-        bank.update_rent();
         bank
     }
 

--- a/runtime/src/loader_utils.rs
+++ b/runtime/src/loader_utils.rs
@@ -16,7 +16,7 @@ pub fn load_program<T: Client>(
     let program_keypair = Keypair::new();
     let program_pubkey = program_keypair.pubkey();
 
-    let instruction = system_instruction::create_rent_exempted_account(
+    let instruction = system_instruction::create_account(
         &from_keypair.pubkey(),
         &program_pubkey,
         1,

--- a/sdk/src/system_transaction.rs
+++ b/sdk/src/system_transaction.rs
@@ -16,54 +16,9 @@ pub fn create_account(
     space: u64,
     program_id: &Pubkey,
 ) -> Transaction {
-    generate_create_account_tx(
-        from_keypair,
-        to,
-        recent_blockhash,
-        lamports,
-        space,
-        program_id,
-        false,
-    )
-}
-
-pub fn create_rent_exempted_account(
-    from_keypair: &Keypair,
-    to: &Pubkey,
-    recent_blockhash: Hash,
-    lamports: u64,
-    space: u64,
-    program_id: &Pubkey,
-) -> Transaction {
-    generate_create_account_tx(
-        from_keypair,
-        to,
-        recent_blockhash,
-        lamports,
-        space,
-        program_id,
-        true,
-    )
-}
-
-fn generate_create_account_tx(
-    from_keypair: &Keypair,
-    to: &Pubkey,
-    recent_blockhash: Hash,
-    lamports: u64,
-    space: u64,
-    program_id: &Pubkey,
-    require_rent_exemption: bool,
-) -> Transaction {
     let from_pubkey = from_keypair.pubkey();
-    let create_instruction = system_instruction::generate_create_account_instruction(
-        &from_pubkey,
-        to,
-        lamports,
-        space,
-        program_id,
-        require_rent_exemption,
-    );
+    let create_instruction =
+        system_instruction::create_account(&from_pubkey, to, lamports, space, program_id);
     let instructions = vec![create_instruction];
     Transaction::new_signed_instructions(&[from_keypair], instructions, recent_blockhash)
 }

--- a/sdk/src/sysvar/rent.rs
+++ b/sdk/src/sysvar/rent.rs
@@ -49,16 +49,6 @@ pub fn create_account(lamports: u64, rent_calculator: &RentCalculator) -> Accoun
     .unwrap()
 }
 
-use crate::account::KeyedAccount;
-use crate::instruction::InstructionError;
-
-pub fn from_keyed_account(account: &KeyedAccount) -> Result<Rent, InstructionError> {
-    if !check_id(account.unsigned_key()) {
-        return Err(InstructionError::InvalidArgument);
-    }
-    Rent::from_account(account.account).ok_or(InstructionError::InvalidArgument)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
Reverts solana-labs/solana#5928

Let's find a way to do this without adding the `require_rent_exemptio` parameter to SystemProgram:: CreateAccount() please