### PR TITLE
Inline BPF log functions

### DIFF
--- a/sdk/src/log.rs
+++ b/sdk/src/log.rs
@@ -28,6 +28,7 @@ macro_rules! info {
 ///
 /// @param message - Message to print
 #[cfg(feature = "program")]
+#[inline]
 pub fn sol_log(message: &str) {
     unsafe {
         sol_log_(message.as_ptr(), message.len() as u64);
@@ -45,6 +46,7 @@ pub fn sol_log(_message: &str) {}
 /// @param argx - integer arguments to print
 
 #[cfg(feature = "program")]
+#[inline]
 pub fn sol_log_64(arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64) {
     unsafe {
         sol_log_64_(arg1, arg2, arg3, arg4, arg5);


### PR DESCRIPTION
#### Problem

Space wasted

#### Summary of Changes

Inline the log functions to reduce the BPF shared object size by a little and reduces the call depth needed

Fixes #
