### PR TITLE
Check for bank slot below the tower root slot

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -591,6 +591,13 @@ impl ReplayStage {
                 !has_voted
             })
             .filter(|b| {
+                if let Some(root_slot) = tower.root() {
+                    b.slot() > root_slot
+                } else {
+                    true
+                }
+            })
+            .filter(|b| {
                 let is_locked_out = tower.is_locked_out(b.slot(), &ancestors);
                 trace!("bank is is_locked_out: {} {}", b.slot(), is_locked_out);
                 !is_locked_out


### PR DESCRIPTION
#### Problem

Banks which are too old to be in tower consensus will
return has_voted == false, and thus produce warnings when
trying to process the vote slot later on in `tower.is_locked_out()`.

#### Summary of Changes

Filter these older banks earlier to prevent this message.

Fixes #
