### PR TITLE
Add client options env var to testnet-automation

### DIFF
--- a/ci/testnet-automation.sh
+++ b/ci/testnet-automation.sh
@@ -28,6 +28,8 @@ launchTestnet() {
   declare nodeCount=$1
   echo --- setup "$nodeCount" node test
 
+  set -x
+
   # shellcheck disable=SC2068
   net/gce.sh create \
     -d pd-ssd \
@@ -47,8 +49,6 @@ launchTestnet() {
 
   echo --- wait "$ITERATION_WAIT" seconds to complete test
   sleep "$ITERATION_WAIT"
-
-  set -x
 
   declare q_mean_tps='
     SELECT round(mean("sum_count")) AS "mean_tps" FROM (

--- a/ci/testnet-automation.sh
+++ b/ci/testnet-automation.sh
@@ -16,6 +16,7 @@ source ci/upload-ci-artifact.sh
 [[ -n $LEADER_CPU_MACHINE_TYPE ]] ||
   LEADER_CPU_MACHINE_TYPE="--machine-type n1-standard-16 --accelerator count=2,type=nvidia-tesla-v100"
 [[ -n $CLIENT_COUNT ]] || CLIENT_COUNT=2
+[[ -n $CLIENT_OPTIONS ]] || CLIENT_OPTIONS=""
 [[ -n $TESTNET_TAG ]] || TESTNET_TAG=testnet-automation
 [[ -n $TESTNET_ZONES ]] || TESTNET_ZONES="us-west1-b"
 [[ -n $CHANNEL ]] || CHANNEL=beta
@@ -39,9 +40,9 @@ launchTestnet() {
 
   echo --- start "$nodeCount" node test
   if [[ -n $USE_PREBUILT_CHANNEL_TARBALL ]]; then
-    net/net.sh start -f "cuda" -o noValidatorSanity -t "$CHANNEL"
+    net/net.sh start -f "cuda" -o noValidatorSanity -t "$CHANNEL" "$CLIENT_OPTIONS"
   else
-    net/net.sh start -f "cuda" -o noValidatorSanity -T solana-release*.tar.bz2
+    net/net.sh start -f "cuda" -o noValidatorSanity -T solana-release*.tar.bz2 "$CLIENT_OPTIONS"
   fi
 
   echo --- wait "$ITERATION_WAIT" seconds to complete test

--- a/ci/testnet-automation.sh
+++ b/ci/testnet-automation.sh
@@ -24,6 +24,11 @@ source ci/upload-ci-artifact.sh
 
 TESTNET_CLOUD_ZONES=(); while read -r -d, ; do TESTNET_CLOUD_ZONES+=( "$REPLY" ); done <<< "${TESTNET_ZONES},"
 
+maybeClientOptions=
+if [[ -n $CLIENT_OPTIONS ]] ; then
+  maybeClientOptions="-c"
+fi
+
 launchTestnet() {
   declare nodeCount=$1
   echo --- setup "$nodeCount" node test
@@ -42,9 +47,9 @@ launchTestnet() {
 
   echo --- start "$nodeCount" node test
   if [[ -n $USE_PREBUILT_CHANNEL_TARBALL ]]; then
-    net/net.sh start -f "cuda" -o noValidatorSanity -t "$CHANNEL" $CLIENT_OPTIONS
+    net/net.sh start -f "cuda" -o noValidatorSanity -t "$CHANNEL" -c bench-tps=1="--tx_count 50000 --thread-batch-sleep-ms 1000"
   else
-    net/net.sh start -f "cuda" -o noValidatorSanity -T solana-release*.tar.bz2 $CLIENT_OPTIONS
+    net/net.sh start -f "cuda" -o noValidatorSanity -T solana-release*.tar.bz2 -c bench-tps=1="--tx_count 50000 --thread-batch-sleep-ms 1000"
   fi
 
   echo --- wait "$ITERATION_WAIT" seconds to complete test

--- a/ci/testnet-automation.sh
+++ b/ci/testnet-automation.sh
@@ -42,9 +42,9 @@ launchTestnet() {
 
   echo --- start "$nodeCount" node test
   if [[ -n $USE_PREBUILT_CHANNEL_TARBALL ]]; then
-    net/net.sh start -f "cuda" -o noValidatorSanity -t "$CHANNEL" "$CLIENT_OPTIONS"
+    net/net.sh start -f "cuda" -o noValidatorSanity -t "$CHANNEL" $CLIENT_OPTIONS
   else
-    net/net.sh start -f "cuda" -o noValidatorSanity -T solana-release*.tar.bz2 "$CLIENT_OPTIONS"
+    net/net.sh start -f "cuda" -o noValidatorSanity -T solana-release*.tar.bz2 $CLIENT_OPTIONS
   fi
 
   echo --- wait "$ITERATION_WAIT" seconds to complete test


### PR DESCRIPTION
#### Problem

We need a way to set client options from the testnet-automation pipeline

#### Summary of Changes

Add it.  Also, set the default options in the pipeline: https://buildkite.com/solana-labs/solana-testnet/settings

Fixes #
