### PR TITLE
Fix really old banks triggering log spam

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -575,6 +575,11 @@ impl ReplayStage {
                 is_votable
             })
             .filter(|b| {
+                let is_recent = tower.is_recent(b.slot());
+                trace!("tower is recent: {} {}", b.slot(), is_recent);
+                is_recent
+            })
+            .filter(|b| {
                 let has_voted = tower.has_voted(b.slot());
                 trace!("bank has_voted: {} {}", b.slot(), has_voted);
                 !has_voted


### PR DESCRIPTION
#### Problem

When bank_forks carries a bank for a slot older than the oldest slot in TowerBFT, that bank will trigger "Dropped Vote" log spam. 

#### Summary of Changes

Added another check in replay_stage that will skip processing banks for slots older than our oldest lockout vote. 

Fixes https://github.com/solana-labs/solana/issues/6006
