### PR TITLE
Skip considering banks older than the latest vote slot

### DIFF
--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -253,10 +253,10 @@ impl Tower {
         sum
     }
 
-    // a slot is not recent if its older than the oldest lockout we have
+    // a slot is not recent if it's older than the newest vote we have
     pub fn is_recent(&self, slot: u64) -> bool {
-        if let Some(oldest_vote) = self.lockouts.votes.front() {
-            if slot < oldest_vote.slot {
+        if let Some(last_vote) = self.lockouts.votes.back() {
+            if slot <= last_vote.slot {
                 return false;
             }
         }
@@ -610,6 +610,7 @@ mod test {
         }
         assert!(!tower.is_recent(0));
         assert!(!tower.is_recent(32));
+        assert!(!tower.is_recent(63));
         assert!(tower.is_recent(65));
     }
 

--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -254,7 +254,7 @@ impl Tower {
     }
 
     // a slot is not recent if it's older than the newest vote we have
-    pub fn is_recent(&self, slot: u64) -> bool {
+    fn is_recent(&self, slot: u64) -> bool {
         if let Some(last_vote) = self.lockouts.votes.back() {
             if slot <= last_vote.slot {
                 return false;
@@ -274,6 +274,11 @@ impl Tower {
 
     pub fn is_locked_out(&self, slot: u64, ancestors: &HashMap<u64, HashSet<u64>>) -> bool {
         assert!(ancestors.contains_key(&slot));
+
+        if !self.is_recent(slot) {
+            trace!("slot is not recent: {} {}", slot, is_recent);
+            return false;
+        }
 
         let mut lockouts = self.lockouts.clone();
         lockouts.process_slot_vote_unchecked(slot);

--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -276,7 +276,7 @@ impl Tower {
         assert!(ancestors.contains_key(&slot));
 
         if !self.is_recent(slot) {
-            trace!("slot is not recent: {} {}", slot, is_recent);
+            trace!("slot is not recent: {}", slot);
             return false;
         }
 

--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -277,7 +277,7 @@ impl Tower {
 
         if !self.is_recent(slot) {
             trace!("slot is not recent: {}", slot);
-            return false;
+            return true;
         }
 
         let mut lockouts = self.lockouts.clone();

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -575,11 +575,6 @@ impl ReplayStage {
                 is_votable
             })
             .filter(|b| {
-                let is_recent = tower.is_recent(b.slot());
-                trace!("tower is recent: {} {}", b.slot(), is_recent);
-                is_recent
-            })
-            .filter(|b| {
                 let has_voted = tower.has_voted(b.slot());
                 trace!("bank has_voted: {} {}", b.slot(), has_voted);
                 !has_voted


### PR DESCRIPTION
#### Problem

The "dropped" vote message prints when we attempt to simulate votes for slots older than the latest vote observed

#### Summary of Changes

Moved the `is_recent` check to drop anything older than the latest vote. Fully suppresses the bogus dropped vote log from replay_stage.

