### PR TITLE
Fix vote metrics

### DIFF
--- a/programs/vote_api/src/vote_instruction.rs
+++ b/programs/vote_api/src/vote_instruction.rs
@@ -158,7 +158,7 @@ pub fn process_instruction(
     keyed_accounts: &mut [KeyedAccount],
     data: &[u8],
 ) -> Result<(), InstructionError> {
-    solana_logger::setup_with_filter("solana=warn");
+    solana_logger::setup_with_filter("solana=info");
 
     trace!("process_instruction: {:?}", data);
     trace!("keyed_accounts: {:?}", keyed_accounts);


### PR DESCRIPTION
#### Problem
Testnet dashboard is not showing vote count

#### Summary of Changes
The vote datapoint is changed to `info`, but the filter is set to `warn`. That's causing vote metrics to get dropped. Changing the filter to `info` as well.
