### PR TITLE
Window service is filtering out coding shreds

### DIFF
--- a/core/src/blocktree.rs
+++ b/core/src/blocktree.rs
@@ -396,7 +396,7 @@ impl Blocktree {
                         set_index as usize,
                         slot,
                     ) {
-                        submit_metrics(true, "complete".into());
+                        submit_metrics(true, format!("complete. recovered: {}", result.len()));
                         recovered_data_shreds.append(&mut result);
                     } else {
                         submit_metrics(true, "incomplete".into());

--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -42,7 +42,9 @@ pub fn should_retransmit_and_persist(
         if leader_id == *my_pubkey {
             inc_new_counter_debug!("streamer-recv_window-circular_transmission", 1);
             false
-        } else if !blocktree::verify_shred_slots(shred.slot(), shred.parent(), root) {
+        } else if shred.is_data() // Only data shreds have parent information
+            && !blocktree::verify_shred_slots(shred.slot(), shred.parent(), root)
+        {
             inc_new_counter_debug!("streamer-recv_window-outdated_transmission", 1);
             false
         } else if !shred.verify(&leader_id) {

--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -47,6 +47,10 @@ pub fn should_retransmit_and_persist(
         {
             inc_new_counter_debug!("streamer-recv_window-outdated_transmission", 1);
             false
+        } else if shred.slot() < root {
+            // Filter out outdated coding shreds
+            inc_new_counter_debug!("streamer-recv_window-outdated_transmission", 1);
+            false
         } else if !shred.verify(&leader_id) {
             inc_new_counter_debug!("streamer-recv_window-invalid_signature", 1);
             false

--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -25,6 +25,16 @@ use std::time::{Duration, Instant};
 
 pub const NUM_THREADS: u32 = 10;
 
+fn verify_shred_slot(shred: &Shred, root: u64) -> bool {
+    if shred.is_data() {
+        // Only data shreds have parent information
+        blocktree::verify_shred_slots(shred.slot(), shred.parent(), root)
+    } else {
+        // Filter out outdated coding shreds
+        shred.slot() >= root
+    }
+}
+
 /// drop blobs that are from myself or not from the correct leader for the
 /// blob's slot
 pub fn should_retransmit_and_persist(
@@ -42,13 +52,7 @@ pub fn should_retransmit_and_persist(
         if leader_id == *my_pubkey {
             inc_new_counter_debug!("streamer-recv_window-circular_transmission", 1);
             false
-        } else if shred.is_data() // Only data shreds have parent information
-            && !blocktree::verify_shred_slots(shred.slot(), shred.parent(), root)
-        {
-            inc_new_counter_debug!("streamer-recv_window-outdated_transmission", 1);
-            false
-        } else if shred.slot() < root {
-            // Filter out outdated coding shreds
+        } else if !verify_shred_slot(shred, root) {
             inc_new_counter_debug!("streamer-recv_window-outdated_transmission", 1);
             false
         } else if !shred.verify(&leader_id) {


### PR DESCRIPTION
#### Problem
Coding shreds don't have parent field. The window service filter is checking for parent information, and filtering out the coding shreds.

#### Summary of Changes
Check for parent information only for data shreds.

Fixes #
