### PR TITLE
add authorized parameters to vote api

### DIFF
--- a/cli/src/vote.rs
+++ b/cli/src/vote.rs
@@ -15,7 +15,7 @@ use solana_sdk::{
 };
 use solana_vote_api::{
     vote_instruction::{self, VoteError},
-    vote_state::VoteState,
+    vote_state::{VoteAuthorize, VoteInit, VoteState},
 };
 
 pub fn parse_vote_create_account(matches: &ArgMatches<'_>) -> Result<WalletCommand, WalletError> {
@@ -32,39 +32,29 @@ pub fn parse_vote_create_account(matches: &ArgMatches<'_>) -> Result<WalletComma
         .map_err(|err| WalletError::BadParameter(format!("Invalid lamports: {:?}", err)))?;
     Ok(WalletCommand::CreateVoteAccount(
         vote_account_pubkey,
-        node_pubkey,
-        authorized_voter,
-        authorized_withdrawer,
-        commission,
+        VoteInit {
+            node_pubkey,
+            authorized_voter,
+            authorized_withdrawer,
+            commission,
+        },
         lamports,
     ))
 }
 
-pub fn parse_vote_authorize_voter(matches: &ArgMatches<'_>) -> Result<WalletCommand, WalletError> {
-    let vote_account_pubkey = pubkey_of(matches, "vote_account_pubkey").unwrap();
-    let authorized_voter_keypair = keypair_of(matches, "authorized_voter_keypair_file").unwrap();
-    let new_authorized_voter_pubkey = pubkey_of(matches, "new_authorized_voter_pubkey").unwrap();
-
-    Ok(WalletCommand::AuthorizeVoter(
-        vote_account_pubkey,
-        authorized_voter_keypair,
-        new_authorized_voter_pubkey,
-    ))
-}
-
-pub fn parse_vote_authorize_withdrawer(
+pub fn parse_vote_authorize(
     matches: &ArgMatches<'_>,
+    vote_authorize: VoteAuthorize,
 ) -> Result<WalletCommand, WalletError> {
     let vote_account_pubkey = pubkey_of(matches, "vote_account_pubkey").unwrap();
-    let authorized_withdrawer_keypair =
-        keypair_of(matches, "authorized_withdrawer_keypair_file").unwrap();
-    let new_authorized_withdrawer_pubkey =
-        pubkey_of(matches, "new_authorized_withdrawer_pubkey").unwrap();
+    let authorized_keypair = keypair_of(matches, "authorized_keypair_file").unwrap();
+    let new_authorized_pubkey = pubkey_of(matches, "new_authorized_pubkey").unwrap();
 
-    Ok(WalletCommand::AuthorizeWithdrawer(
+    Ok(WalletCommand::VoteAuthorize(
         vote_account_pubkey,
-        authorized_withdrawer_keypair,
-        new_authorized_withdrawer_pubkey,
+        authorized_keypair,
+        new_authorized_pubkey,
+        vote_authorize,
     ))
 }
 
@@ -79,15 +69,12 @@ pub fn process_create_vote_account(
     rpc_client: &RpcClient,
     config: &WalletConfig,
     vote_account_pubkey: &Pubkey,
-    node_pubkey: &Pubkey,
-    authorized_voter: &Pubkey,
-    authorized_withdrawer: &Pubkey,
-    commission: u8,
+    vote_init: &VoteInit,
     lamports: u64,
 ) -> ProcessResult {
     check_unique_pubkeys(
         (vote_account_pubkey, "vote_account_pubkey".to_string()),
-        (node_pubkey, "node_pubkey".to_string()),
+        (&vote_init.node_pubkey, "node_pubkey".to_string()),
     )?;
     check_unique_pubkeys(
         (&config.keypair.pubkey(), "wallet keypair".to_string()),
@@ -96,10 +83,7 @@ pub fn process_create_vote_account(
     let ixs = vote_instruction::create_account(
         &config.keypair.pubkey(),
         vote_account_pubkey,
-        node_pubkey,
-        authorized_voter,
-        authorized_withdrawer,
-        commission,
+        vote_init,
         lamports,
     );
     let (recent_blockhash, fee_calculator) = rpc_client.get_recent_blockhash()?;
@@ -109,69 +93,35 @@ pub fn process_create_vote_account(
     log_instruction_custom_error::<SystemError>(result)
 }
 
-pub fn process_authorize_voter(
+pub fn process_vote_authorize(
     rpc_client: &RpcClient,
     config: &WalletConfig,
     vote_account_pubkey: &Pubkey,
-    authorized_voter_keypair: &Keypair,
-    new_authorized_voter_pubkey: &Pubkey,
+    authorized_keypair: &Keypair,
+    new_authorized_pubkey: &Pubkey,
+    vote_authorize: VoteAuthorize,
 ) -> ProcessResult {
     check_unique_pubkeys(
         (vote_account_pubkey, "vote_account_pubkey".to_string()),
-        (
-            new_authorized_voter_pubkey,
-            "new_authorized_voter_pubkey".to_string(),
-        ),
+        (new_authorized_pubkey, "new_authorized_pubkey".to_string()),
     )?;
     let (recent_blockhash, fee_calculator) = rpc_client.get_recent_blockhash()?;
-    let ixs = vec![vote_instruction::authorize_voter(
-        vote_account_pubkey,                // vote account to update
-        &authorized_voter_keypair.pubkey(), // current authorized voter (often the vote account itself)
-        new_authorized_voter_pubkey,        // new vote signer
+    let ixs = vec![vote_instruction::authorize(
+        vote_account_pubkey,          // vote account to update
+        &authorized_keypair.pubkey(), // current authorized voter (often the vote account itself)
+        new_authorized_pubkey,        // new vote signer
+        vote_authorize,               // vote or withdraw
     )];
 
     let mut tx = Transaction::new_signed_with_payer(
         ixs,
         Some(&config.keypair.pubkey()),
-        &[&config.keypair, &authorized_voter_keypair],
+        &[&config.keypair, &authorized_keypair],
         recent_blockhash,
     );
     check_account_for_fee(rpc_client, config, &fee_calculator, &tx.message)?;
-    let result = rpc_client
-        .send_and_confirm_transaction(&mut tx, &[&config.keypair, &authorized_voter_keypair]);
-    log_instruction_custom_error::<VoteError>(result)
-}
-
-pub fn process_authorize_withdrawer(
-    rpc_client: &RpcClient,
-    config: &WalletConfig,
-    vote_account_pubkey: &Pubkey,
-    authorized_withdrawer_keypair: &Keypair,
-    new_authorized_withdrawer_pubkey: &Pubkey,
-) -> ProcessResult {
-    check_unique_pubkeys(
-        (vote_account_pubkey, "vote_account_pubkey".to_string()),
-        (
-            new_authorized_withdrawer_pubkey,
-            "new_authorized_withdrawer_pubkey".to_string(),
-        ),
-    )?;
-    let (recent_blockhash, fee_calculator) = rpc_client.get_recent_blockhash()?;
-    let ixs = vec![vote_instruction::authorize_withdrawer(
-        vote_account_pubkey,                     // vote account to update
-        &authorized_withdrawer_keypair.pubkey(), // current authorized withdrawer (often the vote account itself)
-        new_authorized_withdrawer_pubkey,        // new vote signer
-    )];
-
-    let mut tx = Transaction::new_signed_with_payer(
-        ixs,
-        Some(&config.keypair.pubkey()),
-        &[&config.keypair, &authorized_withdrawer_keypair],
-        recent_blockhash,
-    );
-    check_account_for_fee(rpc_client, config, &fee_calculator, &tx.message)?;
-    let result = rpc_client
-        .send_and_confirm_transaction(&mut tx, &[&config.keypair, &authorized_withdrawer_keypair]);
+    let result =
+        rpc_client.send_and_confirm_transaction(&mut tx, &[&config.keypair, &authorized_keypair]);
     log_instruction_custom_error::<VoteError>(result)
 }
 
@@ -347,14 +297,14 @@ mod tests {
 
         let test_authorize_voter = test_commands.clone().get_matches_from(vec![
             "test",
-            "authorize-voter",
+            "vote-authorize-voter",
             &pubkey_string,
             &keypair_file,
             &pubkey_string,
         ]);
         assert_eq!(
             parse_command(&pubkey, &test_authorize_voter).unwrap(),
-            WalletCommand::AuthorizeVoter(pubkey, keypair, pubkey)
+            WalletCommand::VoteAuthorize(pubkey, keypair, pubkey, VoteAuthorize::Voter)
         );
         fs::remove_file(&keypair_file).unwrap();
 
@@ -372,7 +322,16 @@ mod tests {
         ]);
         assert_eq!(
             parse_command(&pubkey, &test_create_vote_account).unwrap(),
-            WalletCommand::CreateVoteAccount(pubkey, node_pubkey, pubkey, pubkey, 10, 50)
+            WalletCommand::CreateVoteAccount(
+                pubkey,
+                VoteInit {
+                    node_pubkey,
+                    authorized_voter: pubkey,
+                    authorized_withdrawer: pubkey,
+                    commission: 10
+                },
+                50
+            )
         );
         let test_create_vote_account2 = test_commands.clone().get_matches_from(vec![
             "test",
@@ -383,7 +342,16 @@ mod tests {
         ]);
         assert_eq!(
             parse_command(&pubkey, &test_create_vote_account2).unwrap(),
-            WalletCommand::CreateVoteAccount(pubkey, node_pubkey, pubkey, pubkey, 0, 50)
+            WalletCommand::CreateVoteAccount(
+                pubkey,
+                VoteInit {
+                    node_pubkey,
+                    authorized_voter: pubkey,
+                    authorized_withdrawer: pubkey,
+                    commission: 0
+                },
+                50
+            )
         );
         // test init with an authed voter
         let authed = Pubkey::new_rand();
@@ -398,7 +366,16 @@ mod tests {
         ]);
         assert_eq!(
             parse_command(&pubkey, &test_create_vote_account3).unwrap(),
-            WalletCommand::CreateVoteAccount(pubkey, node_pubkey, authed, pubkey, 0, 50)
+            WalletCommand::CreateVoteAccount(
+                pubkey,
+                VoteInit {
+                    node_pubkey,
+                    authorized_voter: authed,
+                    authorized_withdrawer: pubkey,
+                    commission: 0
+                },
+                50
+            )
         );
         // test init with an authed withdrawer
         let test_create_vote_account4 = test_commands.clone().get_matches_from(vec![
@@ -412,7 +389,16 @@ mod tests {
         ]);
         assert_eq!(
             parse_command(&pubkey, &test_create_vote_account4).unwrap(),
-            WalletCommand::CreateVoteAccount(pubkey, node_pubkey, pubkey, authed, 0, 50)
+            WalletCommand::CreateVoteAccount(
+                pubkey,
+                VoteInit {
+                    node_pubkey,
+                    authorized_voter: pubkey,
+                    authorized_withdrawer: authed,
+                    commission: 0
+                },
+                50
+            )
         );
 
         // Test Uptime Subcommand

--- a/core/src/confidence.rs
+++ b/core/src/confidence.rs
@@ -228,7 +228,7 @@ mod tests {
         let ancestors = vec![3, 4, 5, 7, 9, 11];
         let mut confidence = HashMap::new();
         let lamports = 5;
-        let mut vote_state = VoteState::new(&Pubkey::default(), &Pubkey::default(), 0);
+        let mut vote_state = VoteState::default();
 
         let root = ancestors.last().unwrap();
         vote_state.root_slot = Some(*root);
@@ -251,7 +251,7 @@ mod tests {
         let ancestors = vec![3, 4, 5, 7, 9, 11];
         let mut confidence = HashMap::new();
         let lamports = 5;
-        let mut vote_state = VoteState::new(&Pubkey::default(), &Pubkey::default(), 0);
+        let mut vote_state = VoteState::default();
 
         let root = ancestors[2];
         vote_state.root_slot = Some(root);
@@ -281,7 +281,7 @@ mod tests {
         let ancestors = vec![3, 4, 5, 7, 9, 10, 11];
         let mut confidence = HashMap::new();
         let lamports = 5;
-        let mut vote_state = VoteState::new(&Pubkey::default(), &Pubkey::default(), 0);
+        let mut vote_state = VoteState::default();
 
         let root = ancestors[2];
         vote_state.root_slot = Some(root);

--- a/core/src/staking_utils.rs
+++ b/core/src/staking_utils.rs
@@ -1,9 +1,7 @@
 use solana_runtime::bank::Bank;
-use solana_sdk::account::Account;
-use solana_sdk::pubkey::Pubkey;
+use solana_sdk::{account::Account, pubkey::Pubkey};
 use solana_vote_api::vote_state::VoteState;
-use std::borrow::Borrow;
-use std::collections::HashMap;
+use std::{borrow::Borrow, collections::HashMap};
 
 /// Looks through vote accounts, and finds the latest slot that has achieved
 /// supermajority lockout
@@ -99,14 +97,15 @@ where
 pub(crate) mod tests {
     use super::*;
     use crate::genesis_utils::{create_genesis_block, GenesisBlockInfo, BOOTSTRAP_LEADER_LAMPORTS};
-    use solana_sdk::instruction::Instruction;
-    use solana_sdk::pubkey::Pubkey;
-    use solana_sdk::signature::{Keypair, KeypairUtil};
-    use solana_sdk::sysvar::stake_history::{self, StakeHistory};
-    use solana_sdk::transaction::Transaction;
-    use solana_stake_api::stake_instruction;
-    use solana_stake_api::stake_state::Stake;
-    use solana_vote_api::vote_instruction;
+    use solana_sdk::{
+        instruction::Instruction,
+        pubkey::Pubkey,
+        signature::{Keypair, KeypairUtil},
+        sysvar::stake_history::{self, StakeHistory},
+        transaction::Transaction,
+    };
+    use solana_stake_api::{stake_instruction, stake_state::Stake};
+    use solana_vote_api::{vote_instruction, vote_state::VoteInit};
     use std::sync::Arc;
 
     fn new_from_parent(parent: &Arc<Bank>, slot: u64) -> Bank {
@@ -140,10 +139,12 @@ pub(crate) mod tests {
             vote_instruction::create_account(
                 &from_account.pubkey(),
                 vote_pubkey,
-                node_pubkey,
-                vote_pubkey,
-                vote_pubkey,
-                0,
+                &VoteInit {
+                    node_pubkey: *node_pubkey,
+                    authorized_voter: *vote_pubkey,
+                    authorized_withdrawer: *vote_pubkey,
+                    commission: 0,
+                },
                 amount,
             ),
         );
@@ -290,17 +291,28 @@ pub(crate) mod tests {
     fn test_to_staked_nodes() {
         let mut stakes = Vec::new();
         let node1 = Pubkey::new_rand();
-        let node2 = Pubkey::new_rand();
 
         // Node 1 has stake of 3
         for i in 0..3 {
-            let vote = Pubkey::new_rand();
-            stakes.push((i, VoteState::new(&node1, &vote, &vote, 0)));
+            stakes.push((
+                i,
+                VoteState::new(&VoteInit {
+                    node_pubkey: node1,
+                    ..VoteInit::default()
+                }),
+            ));
         }
 
         // Node 1 has stake of 5
-        let vote = Pubkey::new_rand();
-        stakes.push((5, VoteState::new(&node2, &vote, &vote, 0)));
+        let node2 = Pubkey::new_rand();
+
+        stakes.push((
+            5,
+            VoteState::new(&VoteInit {
+                node_pubkey: node2,
+                ..VoteInit::default()
+            }),
+        ));
 
         let result = to_staked_nodes(stakes.into_iter());
         assert_eq!(result.len(), 2);

--- a/core/src/staking_utils.rs
+++ b/core/src/staking_utils.rs
@@ -141,6 +141,8 @@ pub(crate) mod tests {
                 &from_account.pubkey(),
                 vote_pubkey,
                 node_pubkey,
+                vote_pubkey,
+                vote_pubkey,
                 0,
                 amount,
             ),
@@ -292,11 +294,13 @@ pub(crate) mod tests {
 
         // Node 1 has stake of 3
         for i in 0..3 {
-            stakes.push((i, VoteState::new(&Pubkey::new_rand(), &node1, 0)));
+            let vote = Pubkey::new_rand();
+            stakes.push((i, VoteState::new(&node1, &vote, &vote, 0)));
         }
 
         // Node 1 has stake of 5
-        stakes.push((5, VoteState::new(&Pubkey::new_rand(), &node2, 0)));
+        let vote = Pubkey::new_rand();
+        stakes.push((5, VoteState::new(&node2, &vote, &vote, 0)));
 
         let result = to_staked_nodes(stakes.into_iter());
         assert_eq!(result.len(), 2);

--- a/local_cluster/src/local_cluster.rs
+++ b/local_cluster/src/local_cluster.rs
@@ -12,8 +12,7 @@ use solana_core::{
 };
 use solana_sdk::{
     client::SyncClient,
-    clock::DEFAULT_TICKS_PER_SLOT,
-    clock::{DEFAULT_SLOTS_PER_EPOCH, DEFAULT_SLOTS_PER_SEGMENT},
+    clock::{DEFAULT_SLOTS_PER_EPOCH, DEFAULT_SLOTS_PER_SEGMENT, DEFAULT_TICKS_PER_SLOT},
     genesis_block::GenesisBlock,
     message::Message,
     poh_config::PohConfig,
@@ -24,7 +23,10 @@ use solana_sdk::{
 };
 use solana_stake_api::{config as stake_config, stake_instruction, stake_state::StakeState};
 use solana_storage_api::{storage_contract, storage_instruction};
-use solana_vote_api::{vote_instruction, vote_state::VoteState};
+use solana_vote_api::{
+    vote_instruction,
+    vote_state::{VoteInit, VoteState},
+};
 use std::{
     collections::HashMap,
     fs::remove_dir_all,
@@ -436,10 +438,12 @@ impl LocalCluster {
                 vote_instruction::create_account(
                     &from_account.pubkey(),
                     &vote_account_pubkey,
-                    &node_pubkey,
-                    &vote_account_pubkey,
-                    &vote_account_pubkey,
-                    0,
+                    &VoteInit {
+                        node_pubkey,
+                        authorized_voter: vote_account_pubkey,
+                        authorized_withdrawer: vote_account_pubkey,
+                        commission: 0,
+                    },
                     amount,
                 ),
                 client.get_recent_blockhash().unwrap().0,

--- a/local_cluster/src/local_cluster.rs
+++ b/local_cluster/src/local_cluster.rs
@@ -437,6 +437,8 @@ impl LocalCluster {
                     &from_account.pubkey(),
                     &vote_account_pubkey,
                     &node_pubkey,
+                    &vote_account_pubkey,
+                    &vote_account_pubkey,
                     0,
                     amount,
                 ),

--- a/programs/stake_tests/tests/stake_instruction.rs
+++ b/programs/stake_tests/tests/stake_instruction.rs
@@ -14,7 +14,7 @@ use solana_stake_api::stake_instruction;
 use solana_stake_api::stake_instruction::process_instruction;
 use solana_stake_api::stake_state::StakeState;
 use solana_vote_api::vote_instruction;
-use solana_vote_api::vote_state::{Vote, VoteState};
+use solana_vote_api::vote_state::{Vote, VoteInit, VoteState};
 use std::sync::Arc;
 
 fn fill_epoch_with_votes(
@@ -76,10 +76,12 @@ fn test_stake_account_delegate() {
     let message = Message::new(vote_instruction::create_account(
         &mint_pubkey,
         &vote_pubkey,
-        &node_pubkey,
-        &vote_pubkey,
-        &vote_pubkey,
-        std::u8::MAX / 2,
+        &VoteInit {
+            node_pubkey,
+            authorized_voter: vote_pubkey,
+            authorized_withdrawer: vote_pubkey,
+            commission: std::u8::MAX / 2,
+        },
         10,
     ));
     bank_client

--- a/programs/stake_tests/tests/stake_instruction.rs
+++ b/programs/stake_tests/tests/stake_instruction.rs
@@ -77,6 +77,8 @@ fn test_stake_account_delegate() {
         &mint_pubkey,
         &vote_pubkey,
         &node_pubkey,
+        &vote_pubkey,
+        &vote_pubkey,
         std::u8::MAX / 2,
         10,
     ));

--- a/programs/vote_api/src/vote_instruction.rs
+++ b/programs/vote_api/src/vote_instruction.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     id,
-    vote_state::{self, Vote, VoteState},
+    vote_state::{self, Vote, VoteAuthorize, VoteInit, VoteState},
 };
 use bincode::deserialize;
 use log::*;
@@ -51,14 +51,11 @@ impl std::error::Error for VoteError {}
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub enum VoteInstruction {
     /// Initialize the VoteState for this `vote account`
-    /// takes a node_pubkey and commission
-    InitializeAccount(Pubkey, Pubkey, Pubkey, u8),
+    InitializeAccount(VoteInit),
 
-    /// Authorize a voter to send signed votes.
-    AuthorizeVoter(Pubkey),
-
-    /// Authorize a withdrawer to be able to withdraw
-    AuthorizeWithdrawer(Pubkey),
+    /// Authorize a voter to send signed votes or a withdrawer
+    ///  to withdraw
+    Authorize(Pubkey, VoteAuthorize),
 
     /// A Vote instruction with recent votes
     Vote(Vote),
@@ -67,22 +64,11 @@ pub enum VoteInstruction {
     Withdraw(u64),
 }
 
-fn initialize_account(
-    vote_pubkey: &Pubkey,
-    node_pubkey: &Pubkey,
-    authorized_voter: &Pubkey,
-    authorized_withdrawer: &Pubkey,
-    commission: u8,
-) -> Instruction {
+fn initialize_account(vote_pubkey: &Pubkey, vote_init: &VoteInit) -> Instruction {
     let account_metas = vec![AccountMeta::new(*vote_pubkey, false)];
     Instruction::new(
         id(),
-        &VoteInstruction::InitializeAccount(
-            *node_pubkey,
-            *authorized_voter,
-            *authorized_withdrawer,
-            commission,
-        ),
+        &VoteInstruction::InitializeAccount(*vote_init),
         account_metas,
     )
 }
@@ -90,22 +76,13 @@ fn initialize_account(
 pub fn create_account(
     from_pubkey: &Pubkey,
     vote_pubkey: &Pubkey,
-    node_pubkey: &Pubkey,
-    authorized_voter: &Pubkey,
-    authorized_withdrawer: &Pubkey,
-    commission: u8,
+    vote_init: &VoteInit,
     lamports: u64,
 ) -> Vec<Instruction> {
     let space = VoteState::size_of() as u64;
     let create_ix =
         system_instruction::create_account(from_pubkey, vote_pubkey, lamports, space, &id());
-    let init_ix = initialize_account(
-        vote_pubkey,
-        node_pubkey,
-        authorized_voter,
-        authorized_withdrawer,
-        commission,
-    );
+    let init_ix = initialize_account(vote_pubkey, vote_init);
     vec![create_ix, init_ix]
 }
 
@@ -132,30 +109,17 @@ fn metas_for_authorized_signer(
     account_metas
 }
 
-pub fn authorize_voter(
+pub fn authorize(
     vote_pubkey: &Pubkey,
-    authorized_voter_pubkey: &Pubkey, // currently authorized
-    new_authorized_voter_pubkey: &Pubkey,
+    authorized_pubkey: &Pubkey, // currently authorized
+    new_authorized_pubkey: &Pubkey,
+    vote_authorize: VoteAuthorize,
 ) -> Instruction {
-    let account_metas = metas_for_authorized_signer(vote_pubkey, authorized_voter_pubkey, &[]);
+    let account_metas = metas_for_authorized_signer(vote_pubkey, authorized_pubkey, &[]);
 
     Instruction::new(
         id(),
-        &VoteInstruction::AuthorizeVoter(*new_authorized_voter_pubkey),
-        account_metas,
-    )
-}
-
-pub fn authorize_withdrawer(
-    vote_pubkey: &Pubkey,
-    authorized_withdrawer_pubkey: &Pubkey, // currently authorized
-    new_authorized_withdrawer_pubkey: &Pubkey,
-) -> Instruction {
-    let account_metas = metas_for_authorized_signer(vote_pubkey, authorized_withdrawer_pubkey, &[]);
-
-    Instruction::new(
-        id(),
-        &VoteInstruction::AuthorizeWithdrawer(*new_authorized_withdrawer_pubkey),
+        &VoteInstruction::Authorize(*new_authorized_pubkey, vote_authorize),
         account_metas,
     )
 }
@@ -210,23 +174,11 @@ pub fn process_instruction(
 
     // TODO: data-driven unpack and dispatch of KeyedAccounts
     match deserialize(data).map_err(|_| InstructionError::InvalidInstructionData)? {
-        VoteInstruction::InitializeAccount(
-            node_pubkey,
-            authorized_voter,
-            authorized_withdrawer,
-            commission,
-        ) => vote_state::initialize_account(
-            me,
-            &node_pubkey,
-            &authorized_voter,
-            &authorized_withdrawer,
-            commission,
-        ),
-        VoteInstruction::AuthorizeVoter(voter_pubkey) => {
-            vote_state::authorize_voter(me, rest, &voter_pubkey)
+        VoteInstruction::InitializeAccount(vote_init) => {
+            vote_state::initialize_account(me, &vote_init)
         }
-        VoteInstruction::AuthorizeWithdrawer(withdrawer_pubkey) => {
-            vote_state::authorize_withdrawer(me, rest, &withdrawer_pubkey)
+        VoteInstruction::Authorize(voter_pubkey, vote_authorize) => {
+            vote_state::authorize(me, rest, &voter_pubkey, vote_authorize)
         }
         VoteInstruction::Vote(vote) => {
             datapoint_info!("vote-native", ("count", 1, i64));
@@ -303,10 +255,7 @@ mod tests {
         let instructions = create_account(
             &Pubkey::default(),
             &Pubkey::default(),
-            &Pubkey::default(),
-            &Pubkey::default(),
-            &Pubkey::default(),
-            0,
+            &VoteInit::default(),
             100,
         );
         assert_eq!(
@@ -322,18 +271,11 @@ mod tests {
             Err(InstructionError::InvalidAccountData),
         );
         assert_eq!(
-            process_instruction(&authorize_voter(
+            process_instruction(&authorize(
                 &Pubkey::default(),
                 &Pubkey::default(),
                 &Pubkey::default(),
-            )),
-            Err(InstructionError::InvalidAccountData),
-        );
-        assert_eq!(
-            process_instruction(&authorize_withdrawer(
-                &Pubkey::default(),
-                &Pubkey::default(),
-                &Pubkey::default(),
+                VoteAuthorize::Voter,
             )),
             Err(InstructionError::InvalidAccountData),
         );

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2854,6 +2854,8 @@ mod tests {
             &mint_keypair.pubkey(),
             &vote_keypair.pubkey(),
             &mint_keypair.pubkey(),
+            &vote_keypair.pubkey(),
+            &vote_keypair.pubkey(),
             0,
             10,
         );

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1576,7 +1576,7 @@ mod tests {
     use solana_sdk::sysvar::{fees::Fees, rewards::Rewards};
     use solana_stake_api::stake_state::Stake;
     use solana_vote_api::vote_instruction;
-    use solana_vote_api::vote_state::{VoteState, MAX_LOCKOUT_HISTORY};
+    use solana_vote_api::vote_state::{VoteInit, VoteState, MAX_LOCKOUT_HISTORY};
     use std::io::Cursor;
     use std::time::Duration;
     use tempfile::TempDir;
@@ -2853,10 +2853,12 @@ mod tests {
         let instructions = vote_instruction::create_account(
             &mint_keypair.pubkey(),
             &vote_keypair.pubkey(),
-            &mint_keypair.pubkey(),
-            &vote_keypair.pubkey(),
-            &vote_keypair.pubkey(),
-            0,
+            &VoteInit {
+                node_pubkey: mint_keypair.pubkey(),
+                authorized_voter: vote_keypair.pubkey(),
+                authorized_withdrawer: vote_keypair.pubkey(),
+                commission: 0,
+            },
             10,
         );
 


### PR DESCRIPTION
#### Problems
* vote account withdrawals require vote account signatures on the transaction,
  which can't be done with a single-signature wallet
* authorized_voter can't be set without a vote account signature


#### Summary of Changes

* add authorized keys for votes and withdrawals to vote account initialization
* add support for re-keying withdrawal
* add support for such to wallet



Fixes #