### PR TITLE
Cherry-pick: Reduce poll sleep (#6068)

### DIFF
--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -588,7 +588,7 @@ impl RpcClient {
                     return Err(io::Error::new(io::ErrorKind::Other, "signature not found"));
                 }
             }
-            sleep(Duration::from_secs(1));
+            sleep(Duration::from_millis(250));
         }
         Ok(confirmed_blocks)
     }

--- a/local_cluster/src/tests/local_cluster.rs
+++ b/local_cluster/src/tests/local_cluster.rs
@@ -582,7 +582,6 @@ fn test_faulty_node(faulty_node_type: BroadcastStageType) {
 }
 
 #[test]
-#[ignore]
 fn test_repairman_catchup() {
     solana_logger::setup();
     error!("test_repairman_catchup");


### PR DESCRIPTION
#### Problem
test_repairman_catchup was ignored

#### Summary of Changes
Unignores test and decreases `poll_for_signature_confirmations()` loop sleep, which allows the local cluster to catch up more quickly

Fixes #6066 
