### PR TITLE
Remove brace expansion in arg list

### DIFF
--- a/ci/testnet-manager.sh
+++ b/ci/testnet-manager.sh
@@ -396,7 +396,7 @@ deploy() {
     (
       echo "--- net.sh update"
       set -x
-      time net/net.sh update -t "$CHANNEL_OR_TAG" --platform\ {linux,osx,windows}
+      time net/net.sh update -t edge --platform linux --platform osx --platform windows
     )
     ;;
   testnet-perf)


### PR DESCRIPTION
#### Problem

Braces expansion with whitespace quotes the individual results  in the array, which breaks the arg parsing in the called script

#### Summary of Changes

Explicitly type out the args

Fixes #6090 

