### PR TITLE
Change formula used in erasure statistics graph

### DIFF
--- a/metrics/scripts/grafana-provisioning/dashboards/testnet-monitor.json
+++ b/metrics/scripts/grafana-provisioning/dashboards/testnet-monitor.json
@@ -7279,7 +7279,7 @@
           "measurement": "cluster_info-vote-count",
           "orderByTime": "ASC",
           "policy": "autogen",
-          "query": "SELECT mean(\"recovered\") AS \"recovered\" FROM \"$testnet\".\"autogen\".\"blocktree-erasure\" WHERE host_id::tag =~ /$hostid/ AND $timeFilter GROUP BY time($__interval) FILL(0)",
+          "query": "SELECT sum(\"recovered\") AS \"recovered\" FROM \"$testnet\".\"autogen\".\"blocktree-erasure\" WHERE host_id::tag =~ /$hostid/ AND $timeFilter GROUP BY time($__interval) FILL(0)",
           "rawQuery": true,
           "refId": "B",
           "resultFormat": "time_series",


### PR DESCRIPTION
#### Problem
The erasure recovery graph in dashboard is showing statistics in fractions, and sometimes < 1. It does not look correct.

#### Summary of Changes
The dashboard was showing `mean` number of recovered shreds. Changing it to `sum`.
