### PR TITLE
add authorities to stake init

### DIFF
--- a/cli/src/wallet.rs
+++ b/cli/src/wallet.rs
@@ -29,7 +29,10 @@ use solana_sdk::{
     system_transaction,
     transaction::{Transaction, TransactionError},
 };
-use solana_stake_api::stake_instruction::{self, StakeError};
+use solana_stake_api::{
+    stake_instruction::{self, StakeError},
+    stake_state::Authorized,
+};
 use solana_storage_api::storage_instruction;
 use solana_vote_api::vote_state::{VoteAuthorize, VoteInit, VoteState};
 use std::{
@@ -80,7 +83,7 @@ pub enum WalletCommand {
         aggregate: bool,
         span: Option<u64>,
     },
-    DelegateStake(Keypair, Pubkey, u64, bool),
+    DelegateStake(Keypair, Pubkey, u64, Authorized, bool),
     WithdrawStake(Keypair, Pubkey, u64),
     DeactivateStake(Keypair, Pubkey),
     RedeemVoteCredits(Pubkey, Pubkey),
@@ -257,11 +260,13 @@ pub fn parse_command(
                 matches.value_of("amount").unwrap(),
                 matches.value_of("unit"),
             )?;
+            let authorized = Authorized::auto(&stake_account_keypair.pubkey());
             let force = matches.is_present("force");
             Ok(WalletCommand::DelegateStake(
                 stake_account_keypair,
                 vote_account_pubkey,
                 lamports,
+                authorized,
                 force,
             ))
         }
@@ -607,6 +612,7 @@ fn process_delegate_stake(
     stake_account_keypair: &Keypair,
     vote_account_pubkey: &Pubkey,
     lamports: u64,
+    authorized: &Authorized,
     force: bool,
 ) -> ProcessResult {
     check_unique_pubkeys(
@@ -623,6 +629,7 @@ fn process_delegate_stake(
         &stake_account_keypair.pubkey(),
         vote_account_pubkey,
         lamports,
+        authorized,
     );
 
     // Sanity check the vote account to ensure it is attached to a validator that has recently
@@ -741,7 +748,7 @@ fn process_show_stake_account(
         ))?;
     }
     match stake_account.state() {
-        Ok(StakeState::Stake(stake)) => {
+        Ok(StakeState::Stake(_authorized, _lockup, stake)) => {
             println!(
                 "total stake: {}",
                 build_balance_message(stake_account.lamports, use_lamports_unit)
@@ -767,9 +774,8 @@ fn process_show_stake_account(
             Ok("".to_string())
         }
         Ok(StakeState::RewardsPool) => Ok("Stake account is a rewards pool".to_string()),
-        Ok(StakeState::Uninitialized) | Ok(StakeState::Lockup(_)) => {
-            Ok("Stake account is uninitialized".to_string())
-        }
+        Ok(StakeState::Uninitialized) => Ok("Stake account is unstaked".to_string()),
+        Ok(StakeState::Initialized(_, _)) => Ok("Stake account is not delegated".to_string()),
         Err(err) => Err(WalletError::RpcRequestError(format!(
             "Account data could not be deserialized to stake state: {:?}",
             err
@@ -1347,6 +1353,7 @@ pub fn process_command(config: &WalletConfig) -> ProcessResult {
             stake_account_keypair,
             vote_account_pubkey,
             lamports,
+            authorized,
             force,
         ) => process_delegate_stake(
             &rpc_client,
@@ -1354,6 +1361,7 @@ pub fn process_command(config: &WalletConfig) -> ProcessResult {
             &stake_account_keypair,
             &vote_account_pubkey,
             *lamports,
+            &authorized,
             *force,
         ),
 
@@ -2477,9 +2485,16 @@ mod tests {
             "42",
             "lamports",
         ]);
+        let stake_pubkey = keypair.pubkey();
         assert_eq!(
             parse_command(&pubkey, &test_delegate_stake).unwrap(),
-            WalletCommand::DelegateStake(keypair, pubkey, 42, false)
+            WalletCommand::DelegateStake(
+                keypair,
+                pubkey,
+                42,
+                Authorized::auto(&stake_pubkey),
+                false,
+            )
         );
 
         let keypair = read_keypair(&keypair_file).unwrap();
@@ -2492,9 +2507,16 @@ mod tests {
             "42",
             "lamports",
         ]);
+        let stake_pubkey = keypair.pubkey();
         assert_eq!(
             parse_command(&pubkey, &test_delegate_stake).unwrap(),
-            WalletCommand::DelegateStake(keypair, pubkey, 42, true)
+            WalletCommand::DelegateStake(
+                keypair,
+                pubkey,
+                42,
+                Authorized::auto(&stake_pubkey),
+                true
+            )
         );
 
         // Test WithdrawStake Subcommand

--- a/core/src/confidence.rs
+++ b/core/src/confidence.rs
@@ -319,18 +319,20 @@ mod tests {
             mut genesis_block, ..
         } = create_genesis_block(10_000);
 
+        let sk1 = Pubkey::new_rand();
         let pk1 = Pubkey::new_rand();
         let mut vote_account1 = vote_state::create_account(&pk1, &Pubkey::new_rand(), 0, 100);
-        let stake_account1 = stake_state::create_account(&pk1, &vote_account1, 100);
+        let stake_account1 = stake_state::create_account(&sk1, &pk1, &vote_account1, 100);
+        let sk2 = Pubkey::new_rand();
         let pk2 = Pubkey::new_rand();
         let mut vote_account2 = vote_state::create_account(&pk2, &Pubkey::new_rand(), 0, 50);
-        let stake_account2 = stake_state::create_account(&pk2, &vote_account2, 50);
+        let stake_account2 = stake_state::create_account(&sk2, &pk2, &vote_account2, 50);
 
         genesis_block.accounts.extend(vec![
             (pk1, vote_account1.clone()),
-            (Pubkey::new_rand(), stake_account1),
+            (sk1, stake_account1),
             (pk2, vote_account2.clone()),
-            (Pubkey::new_rand(), stake_account2),
+            (sk2, stake_account2),
         ]);
 
         // Create bank

--- a/core/src/staking_utils.rs
+++ b/core/src/staking_utils.rs
@@ -104,7 +104,10 @@ pub(crate) mod tests {
         sysvar::stake_history::{self, StakeHistory},
         transaction::Transaction,
     };
-    use solana_stake_api::{stake_instruction, stake_state::Stake};
+    use solana_stake_api::{
+        stake_instruction,
+        stake_state::{Authorized, Stake},
+    };
     use solana_vote_api::{vote_instruction, vote_state::VoteInit};
     use std::sync::Arc;
 
@@ -160,6 +163,7 @@ pub(crate) mod tests {
                 &stake_account_pubkey,
                 vote_pubkey,
                 amount,
+                &Authorized::auto(&stake_account_pubkey),
             ),
         );
     }

--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -315,6 +315,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
         1,
     );
     let stake_account = stake_state::create_account(
+        &bootstrap_stake_keypair.pubkey(),
         &bootstrap_vote_keypair.pubkey(),
         &vote_account,
         bootstrap_leader_stake_lamports,

--- a/local_cluster/src/local_cluster.rs
+++ b/local_cluster/src/local_cluster.rs
@@ -21,7 +21,10 @@ use solana_sdk::{
     system_transaction,
     transaction::Transaction,
 };
-use solana_stake_api::{config as stake_config, stake_instruction, stake_state::StakeState};
+use solana_stake_api::{
+    config as stake_config, stake_instruction,
+    stake_state::{Authorized as StakeAuthorized, StakeState},
+};
 use solana_storage_api::{storage_contract, storage_instruction};
 use solana_vote_api::{
     vote_instruction,
@@ -462,6 +465,7 @@ impl LocalCluster {
                     &stake_account_pubkey,
                     &vote_account_pubkey,
                     amount,
+                    &StakeAuthorized::auto(&stake_account_pubkey),
                 ),
                 client.get_recent_blockhash().unwrap().0,
             );

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -102,7 +102,7 @@ dependencies = [
 
 [[package]]
 name = "bincode"
-version = "1.1.4"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "autocfg 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1529,7 +1529,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "solana-bpf-loader-api"
 version = "0.20.0"
 dependencies = [
- "bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bincode 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1553,7 +1553,7 @@ dependencies = [
 name = "solana-bpf-programs"
 version = "0.20.0"
 dependencies = [
- "bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bincode 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "elf 0.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-bpf-loader-api 0.20.0",
@@ -1676,7 +1676,7 @@ dependencies = [
 name = "solana-config-api"
 version = "0.20.0"
 dependencies = [
- "bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bincode 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1757,11 +1757,12 @@ dependencies = [
 name = "solana-runtime"
 version = "0.20.0"
 dependencies = [
- "bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bincode 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bv 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "fs_extra 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
  "libloading 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1793,7 +1794,7 @@ name = "solana-sdk"
 version = "0.20.0"
 dependencies = [
  "assert_matches 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bincode 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bs58 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1825,7 +1826,7 @@ version = "0.20.0"
 name = "solana-stake-api"
 version = "0.20.0"
 dependencies = [
- "bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bincode 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-derive 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1854,7 +1855,7 @@ name = "solana-storage-api"
 version = "0.20.0"
 dependencies = [
  "assert_matches 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bincode 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-derive 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1869,7 +1870,7 @@ dependencies = [
 name = "solana-vote-api"
 version = "0.20.0"
 dependencies = [
- "bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bincode 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-derive 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2504,7 +2505,7 @@ dependencies = [
 "checksum backtrace 0.3.37 (registry+https://github.com/rust-lang/crates.io-index)" = "5180c5a20655b14a819b652fd2378fa5f1697b6c9ddad3e695c2f9cedf6df4e2"
 "checksum backtrace-sys 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)" = "82a830b4ef2d1124a711c71d263c5abdc710ef8e907bd508c88be475cebc422b"
 "checksum base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
-"checksum bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "9f04a5e50dc80b3d5d35320889053637d15011aed5e66b66b37ae798c65da6f7"
+"checksum bincode 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b8ab639324e3ee8774d296864fbc0dbbb256cf1a41c490b94cba90c082915f92"
 "checksum bit-vec 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "02b4ff8b16e6076c3e14220b39fbc1fabb6737522281a388998046859400895f"
 "checksum bit-vec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f59bbe95d4e52a6398ec21238d31577f2b28a9d86807f06ca59d191d8440d0bb"
 "checksum bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3d155346769a6855b86399e9bc3814ab343cd3d62c7e985113d46a0ec3c281fd"

--- a/programs/stake_api/src/stake_state.rs
+++ b/programs/stake_api/src/stake_state.rs
@@ -22,8 +22,8 @@ use solana_vote_api::vote_state::VoteState;
 #[allow(clippy::large_enum_variant)]
 pub enum StakeState {
     Uninitialized,
-    Lockup(Lockup),
-    Stake(Stake),
+    Initialized(Authorized, Lockup),
+    Stake(Authorized, Lockup, Stake),
     RewardsPool,
 }
 
@@ -43,12 +43,28 @@ impl StakeState {
         Self::from(account).and_then(|state: Self| state.stake())
     }
 
+    pub fn authorized_from(account: &Account) -> Option<Authorized> {
+        Self::from(account).and_then(|state: Self| state.authorized())
+    }
+
     pub fn stake(&self) -> Option<Stake> {
         match self {
-            StakeState::Stake(stake) => Some(stake.clone()),
+            StakeState::Stake(_authorized, _lockup, stake) => Some(stake.clone()),
             _ => None,
         }
     }
+    pub fn authorized(&self) -> Option<Authorized> {
+        match self {
+            StakeState::Stake(authorized, _lockup, _stake) => Some(authorized.clone()),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone, Copy)]
+pub enum StakeAuthorize {
+    Staker,
+    Withdrawer,
 }
 
 #[derive(Default, Debug, Serialize, Deserialize, PartialEq, Clone, Copy)]
@@ -58,8 +74,12 @@ pub struct Lockup {
     /// custodian account, the only account to which this stake will honor a
     /// withdrawal *before* lockup expires
     pub custodian: Pubkey,
-    /// alternate signer that is enabled to act on the Stake account
-    pub authority: Pubkey,
+}
+
+#[derive(Default, Debug, Serialize, Deserialize, PartialEq, Clone, Copy)]
+pub struct Authorized {
+    pub staker: Pubkey,
+    pub withdrawer: Pubkey,
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
@@ -78,8 +98,6 @@ pub struct Stake {
     pub deactivation_epoch: Epoch,
     /// stake config (warmup, etc.)
     pub config: Config,
-    /// the Lockup information, see above
-    pub lockup: Lockup,
     /// history of prior delegates and the epoch ranges for which
     ///  they were set, circular buffer
     pub prior_delegates: [(Pubkey, Epoch, Epoch); MAX_PRIOR_DELEGATES],
@@ -92,7 +110,6 @@ const MAX_PRIOR_DELEGATES: usize = 32; // this is how many epochs a stake is exp
 impl Default for Stake {
     fn default() -> Self {
         Self {
-            lockup: Lockup::default(),
             voter_pubkey: Pubkey::default(),
             voter_pubkey_epoch: 0,
             credits_observed: 0,
@@ -106,18 +123,52 @@ impl Default for Stake {
     }
 }
 
+impl Authorized {
+    pub fn auto(authorized: &Pubkey) -> Self {
+        Self {
+            staker: *authorized,
+            withdrawer: *authorized,
+        }
+    }
+    pub fn check(
+        &self,
+        stake_signer: Option<&Pubkey>,
+        other_signers: &[KeyedAccount],
+        stake_authorize: StakeAuthorize,
+    ) -> Result<(), InstructionError> {
+        let authorized = match stake_authorize {
+            StakeAuthorize::Staker => Some(&self.staker),
+            StakeAuthorize::Withdrawer => Some(&self.withdrawer),
+        };
+        if stake_signer != authorized
+            && other_signers
+                .iter()
+                .all(|account| account.signer_key() != authorized)
+        {
+            Err(InstructionError::MissingRequiredSignature)
+        } else {
+            Ok(())
+        }
+    }
+    pub fn authorize(
+        &mut self,
+        stake_signer: Option<&Pubkey>,
+        other_signers: &[KeyedAccount],
+        new_authorized: &Pubkey,
+        stake_authorize: StakeAuthorize,
+    ) -> Result<(), InstructionError> {
+        self.check(stake_signer, other_signers, stake_authorize)?;
+        match stake_authorize {
+            StakeAuthorize::Staker => self.staker = *new_authorized,
+            StakeAuthorize::Withdrawer => self.withdrawer = *new_authorized,
+        }
+        Ok(())
+    }
+}
+
 impl Stake {
     fn is_bootstrap(&self) -> bool {
         self.activation_epoch == std::u64::MAX
-    }
-
-    fn check_authorized(
-        &self,
-        stake_pubkey_signer: Option<&Pubkey>,
-        other_signers: &[KeyedAccount],
-    ) -> Result<(), InstructionError> {
-        self.lockup
-            .check_authorized(stake_pubkey_signer, other_signers)
     }
 
     pub fn stake(&self, epoch: Epoch, history: Option<&StakeHistory>) -> u64 {
@@ -310,7 +361,6 @@ impl Stake {
             vote_state,
             std::u64::MAX,
             &Config::default(),
-            &Lockup::default(),
         )
     }
 
@@ -340,7 +390,6 @@ impl Stake {
         vote_state: &VoteState,
         activation_epoch: Epoch,
         config: &Config,
-        lockup: &Lockup,
     ) -> Self {
         Self {
             stake,
@@ -349,7 +398,6 @@ impl Stake {
             voter_pubkey_epoch: activation_epoch,
             credits_observed: vote_state.credits(),
             config: *config,
-            lockup: *lockup,
             ..Stake::default()
         }
     }
@@ -359,29 +407,16 @@ impl Stake {
     }
 }
 
-impl Lockup {
-    fn check_authorized(
-        &self,
-        stake_pubkey_signer: Option<&Pubkey>,
-        other_signers: &[KeyedAccount],
-    ) -> Result<(), InstructionError> {
-        let authorized = Some(&self.authority);
-        if stake_pubkey_signer != authorized
-            && other_signers
-                .iter()
-                .all(|account| account.signer_key() != authorized)
-        {
-            return Err(InstructionError::MissingRequiredSignature);
-        }
-        Ok(())
-    }
-}
-
 pub trait StakeAccount {
-    fn lockup(&mut self, slot: Slot, custodian: &Pubkey) -> Result<(), InstructionError>;
+    fn initialize(
+        &mut self,
+        authorized: &Authorized,
+        lockup: &Lockup,
+    ) -> Result<(), InstructionError>;
     fn authorize(
         &mut self,
-        authorized_pubkey: &Pubkey,
+        authority: &Pubkey,
+        stake_authorize: StakeAuthorize,
         other_signers: &[KeyedAccount],
     ) -> Result<(), InstructionError>;
     fn delegate_stake(
@@ -415,13 +450,13 @@ pub trait StakeAccount {
 }
 
 impl<'a> StakeAccount for KeyedAccount<'a> {
-    fn lockup(&mut self, slot: Slot, custodian: &Pubkey) -> Result<(), InstructionError> {
+    fn initialize(
+        &mut self,
+        authorized: &Authorized,
+        lockup: &Lockup,
+    ) -> Result<(), InstructionError> {
         if let StakeState::Uninitialized = self.state()? {
-            self.set_state(&StakeState::Lockup(Lockup {
-                slot,
-                custodian: *custodian,
-                authority: *self.unsigned_key(),
-            }))
+            self.set_state(&StakeState::Initialized(*authorized, *lockup))
         } else {
             Err(InstructionError::InvalidAccountData)
         }
@@ -432,17 +467,17 @@ impl<'a> StakeAccount for KeyedAccount<'a> {
     fn authorize(
         &mut self,
         authority: &Pubkey,
+        stake_authorize: StakeAuthorize,
         other_signers: &[KeyedAccount],
     ) -> Result<(), InstructionError> {
         let stake_state = self.state()?;
-        if let StakeState::Stake(mut stake) = stake_state {
-            stake.check_authorized(self.signer_key(), other_signers)?;
-            stake.lockup.authority = *authority;
-            self.set_state(&StakeState::Stake(stake))
-        } else if let StakeState::Lockup(mut lockup) = stake_state {
-            lockup.check_authorized(self.signer_key(), other_signers)?;
-            lockup.authority = *authority;
-            self.set_state(&StakeState::Lockup(lockup))
+
+        if let StakeState::Stake(mut authorized, lockup, stake) = stake_state {
+            authorized.authorize(self.signer_key(), other_signers, authority, stake_authorize)?;
+            self.set_state(&StakeState::Stake(authorized, lockup, stake))
+        } else if let StakeState::Initialized(mut authorized, lockup) = stake_state {
+            authorized.authorize(self.signer_key(), other_signers, authority, stake_authorize)?;
+            self.set_state(&StakeState::Initialized(authorized, lockup))
         } else {
             Err(InstructionError::InvalidAccountData)
         }
@@ -454,26 +489,25 @@ impl<'a> StakeAccount for KeyedAccount<'a> {
         config: &Config,
         other_signers: &[KeyedAccount],
     ) -> Result<(), InstructionError> {
-        if let StakeState::Lockup(lockup) = self.state()? {
-            lockup.check_authorized(self.signer_key(), other_signers)?;
+        if let StakeState::Initialized(authorized, lockup) = self.state()? {
+            authorized.check(self.signer_key(), other_signers, StakeAuthorize::Staker)?;
             let stake = Stake::new(
                 self.account.lamports,
                 vote_account.unsigned_key(),
                 &vote_account.state()?,
                 clock.epoch,
                 config,
-                &lockup,
             );
 
-            self.set_state(&StakeState::Stake(stake))
-        } else if let StakeState::Stake(mut stake) = self.state()? {
-            stake.check_authorized(self.signer_key(), other_signers)?;
+            self.set_state(&StakeState::Stake(authorized, lockup, stake))
+        } else if let StakeState::Stake(authorized, lockup, mut stake) = self.state()? {
+            authorized.check(self.signer_key(), other_signers, StakeAuthorize::Staker)?;
             stake.redelegate(
                 vote_account.unsigned_key(),
                 &vote_account.state()?,
                 clock.epoch,
             )?;
-            self.set_state(&StakeState::Stake(stake))
+            self.set_state(&StakeState::Stake(authorized, lockup, stake))
         } else {
             Err(InstructionError::InvalidAccountData)
         }
@@ -484,11 +518,11 @@ impl<'a> StakeAccount for KeyedAccount<'a> {
         clock: &sysvar::clock::Clock,
         other_signers: &[KeyedAccount],
     ) -> Result<(), InstructionError> {
-        if let StakeState::Stake(mut stake) = self.state()? {
-            stake.check_authorized(self.signer_key(), other_signers)?;
+        if let StakeState::Stake(authorized, lockup, mut stake) = self.state()? {
+            authorized.check(self.signer_key(), other_signers, StakeAuthorize::Staker)?;
             stake.deactivate(clock.epoch);
 
-            self.set_state(&StakeState::Stake(stake))
+            self.set_state(&StakeState::Stake(authorized, lockup, stake))
         } else {
             Err(InstructionError::InvalidAccountData)
         }
@@ -500,7 +534,7 @@ impl<'a> StakeAccount for KeyedAccount<'a> {
         rewards: &sysvar::rewards::Rewards,
         stake_history: &sysvar::stake_history::StakeHistory,
     ) -> Result<(), InstructionError> {
-        if let (StakeState::Stake(mut stake), StakeState::RewardsPool) =
+        if let (StakeState::Stake(authorized, lockup, mut stake), StakeState::RewardsPool) =
             (self.state()?, rewards_account.state()?)
         {
             let vote_state: VoteState = vote_account.state()?;
@@ -528,7 +562,7 @@ impl<'a> StakeAccount for KeyedAccount<'a> {
 
                 stake.credits_observed = credits_observed;
 
-                self.set_state(&StakeState::Stake(stake))
+                self.set_state(&StakeState::Stake(authorized, lockup, stake))
             } else {
                 // not worth collecting
                 Err(StakeError::NoCreditsToRedeem.into())
@@ -546,8 +580,8 @@ impl<'a> StakeAccount for KeyedAccount<'a> {
         other_signers: &[KeyedAccount],
     ) -> Result<(), InstructionError> {
         let lockup = match self.state()? {
-            StakeState::Stake(stake) => {
-                stake.check_authorized(self.signer_key(), other_signers)?;
+            StakeState::Stake(authorized, lockup, stake) => {
+                authorized.check(self.signer_key(), other_signers, StakeAuthorize::Withdrawer)?;
                 // if we have a deactivation epoch and we're in cooldown
                 let staked = if clock.epoch >= stake.deactivation_epoch {
                     stake.stake(clock.epoch, Some(stake_history))
@@ -561,10 +595,10 @@ impl<'a> StakeAccount for KeyedAccount<'a> {
                 if lamports > self.account.lamports.saturating_sub(staked) {
                     return Err(InstructionError::InsufficientFunds);
                 }
-                stake.lockup
+                lockup
             }
-            StakeState::Lockup(lockup) => {
-                lockup.check_authorized(self.signer_key(), other_signers)?;
+            StakeState::Initialized(authorized, lockup) => {
+                authorized.check(self.signer_key(), other_signers, StakeAuthorize::Withdrawer)?;
                 lockup
             }
             StakeState::Uninitialized => {
@@ -615,17 +649,25 @@ where
 }
 
 // utility function, used by Bank, tests, genesis
-pub fn create_account(voter_pubkey: &Pubkey, vote_account: &Account, lamports: u64) -> Account {
+pub fn create_account(
+    authorized: &Pubkey,
+    voter_pubkey: &Pubkey,
+    vote_account: &Account,
+    lamports: u64,
+) -> Account {
     let mut stake_account = Account::new(lamports, std::mem::size_of::<StakeState>(), &id());
 
     let vote_state = VoteState::from(vote_account).expect("vote_state");
 
     stake_account
-        .set_state(&StakeState::Stake(Stake::new_bootstrap(
-            lamports,
-            voter_pubkey,
-            &vote_state,
-        )))
+        .set_state(&StakeState::Stake(
+            Authorized {
+                staker: *authorized,
+                withdrawer: *authorized,
+            },
+            Lockup::default(),
+            Stake::new_bootstrap(lamports, voter_pubkey, &vote_state),
+        ))
         .expect("set_state");
 
     stake_account
@@ -691,10 +733,13 @@ mod tests {
         let stake_lamports = 42;
         let mut stake_account = Account::new_data_with_space(
             stake_lamports,
-            &StakeState::Lockup(Lockup {
-                authority: stake_pubkey,
-                ..Lockup::default()
-            }),
+            &StakeState::Initialized(
+                Authorized {
+                    staker: stake_pubkey,
+                    withdrawer: stake_pubkey,
+                },
+                Lockup::default(),
+            ),
             std::mem::size_of::<StakeState>(),
             &id(),
         )
@@ -707,10 +752,13 @@ mod tests {
             let stake_state: StakeState = stake_keyed_account.state().unwrap();
             assert_eq!(
                 stake_state,
-                StakeState::Lockup(Lockup {
-                    authority: stake_pubkey,
-                    ..Lockup::default()
-                })
+                StakeState::Initialized(
+                    Authorized {
+                        staker: stake_pubkey,
+                        withdrawer: stake_pubkey,
+                    },
+                    Lockup::default(),
+                )
             );
         }
 
@@ -741,10 +789,6 @@ mod tests {
                 stake: stake_lamports,
                 activation_epoch: clock.epoch,
                 deactivation_epoch: std::u64::MAX,
-                lockup: Lockup {
-                    authority: stake_pubkey,
-                    ..Lockup::default()
-                },
                 ..Stake::default()
             }
         );
@@ -1062,21 +1106,32 @@ mod tests {
         // unsigned keyed account
         let mut stake_keyed_account = KeyedAccount::new(&stake_pubkey, false, &mut stake_account);
         let custodian = Pubkey::new_rand();
-        assert_eq!(stake_keyed_account.lockup(1, &custodian), Ok(()));
+        assert_eq!(
+            stake_keyed_account.initialize(
+                &Authorized {
+                    staker: stake_pubkey,
+                    withdrawer: stake_pubkey
+                },
+                &Lockup { slot: 1, custodian }
+            ),
+            Ok(())
+        );
 
         // first time works, as is uninit
         assert_eq!(
             StakeState::from(&stake_keyed_account.account).unwrap(),
-            StakeState::Lockup(Lockup {
-                slot: 1,
-                authority: stake_pubkey,
-                custodian
-            })
+            StakeState::Initialized(
+                Authorized {
+                    staker: stake_pubkey,
+                    withdrawer: stake_pubkey
+                },
+                Lockup { slot: 1, custodian }
+            )
         );
 
         // 2nd time fails, can't move it from anything other than uninit->lockup
         assert_eq!(
-            stake_keyed_account.lockup(1, &Pubkey::default()),
+            stake_keyed_account.initialize(&Authorized::default(), &Lockup::default()),
             Err(InstructionError::InvalidAccountData)
         );
     }
@@ -1087,10 +1142,7 @@ mod tests {
         let stake_lamports = 42;
         let mut stake_account = Account::new_data_with_space(
             stake_lamports,
-            &StakeState::Lockup(Lockup {
-                authority: stake_pubkey,
-                ..Lockup::default()
-            }),
+            &StakeState::Initialized(Authorized::auto(&stake_pubkey), Lockup::default()),
             std::mem::size_of::<StakeState>(),
             &id(),
         )
@@ -1195,7 +1247,12 @@ mod tests {
         // lockup
         let mut stake_keyed_account = KeyedAccount::new(&stake_pubkey, true, &mut stake_account);
         let custodian = Pubkey::new_rand();
-        stake_keyed_account.lockup(0, &custodian).unwrap();
+        stake_keyed_account
+            .initialize(
+                &Authorized::auto(&stake_pubkey),
+                &Lockup { slot: 0, custodian },
+            )
+            .unwrap();
 
         // signed keyed account and locked up, more than available should fail
         let mut stake_keyed_account = KeyedAccount::new(&stake_pubkey, true, &mut stake_account);
@@ -1297,10 +1354,7 @@ mod tests {
         let stake_lamports = 42;
         let mut stake_account = Account::new_data_with_space(
             total_lamports,
-            &StakeState::Lockup(Lockup {
-                authority: stake_pubkey,
-                ..Lockup::default()
-            }),
+            &StakeState::Initialized(Authorized::auto(&stake_pubkey), Lockup::default()),
             std::mem::size_of::<StakeState>(),
             &id(),
         )
@@ -1381,17 +1435,16 @@ mod tests {
     }
 
     #[test]
-    fn test_withdraw_lockout() {
+    fn test_withdraw_lockup() {
         let stake_pubkey = Pubkey::new_rand();
         let custodian = Pubkey::new_rand();
         let total_lamports = 100;
         let mut stake_account = Account::new_data_with_space(
             total_lamports,
-            &StakeState::Lockup(Lockup {
-                slot: 1,
-                authority: stake_pubkey,
-                custodian,
-            }),
+            &StakeState::Initialized(
+                Authorized::auto(&stake_pubkey),
+                Lockup { slot: 1, custodian },
+            ),
             std::mem::size_of::<StakeState>(),
             &id(),
         )
@@ -1542,10 +1595,7 @@ mod tests {
         let stake_lamports = 100;
         let mut stake_account = Account::new_data_with_space(
             stake_lamports,
-            &StakeState::Lockup(Lockup {
-                authority: stake_pubkey,
-                ..Lockup::default()
-            }),
+            &StakeState::Initialized(Authorized::auto(&stake_pubkey), Lockup::default()),
             std::mem::size_of::<StakeState>(),
             &id(),
         )
@@ -1673,10 +1723,7 @@ mod tests {
         let stake_lamports = 42;
         let mut stake_account = Account::new_data_with_space(
             stake_lamports,
-            &StakeState::Lockup(Lockup {
-                authority: stake_pubkey,
-                ..Lockup::default()
-            }),
+            &StakeState::Initialized(Authorized::auto(&stake_pubkey), Lockup::default()),
             std::mem::size_of::<StakeState>(),
             &id(),
         )
@@ -1690,16 +1737,27 @@ mod tests {
         let mut stake_keyed_account = KeyedAccount::new(&stake_pubkey, true, &mut stake_account);
 
         let stake_pubkey0 = Pubkey::new_rand();
-        assert_eq!(stake_keyed_account.authorize(&stake_pubkey0, &[]), Ok(()));
-        if let StakeState::Lockup(lockup) = StakeState::from(&stake_keyed_account.account).unwrap()
+        assert_eq!(
+            stake_keyed_account.authorize(&stake_pubkey0, StakeAuthorize::Staker, &[]),
+            Ok(())
+        );
+        assert_eq!(
+            stake_keyed_account.authorize(&stake_pubkey0, StakeAuthorize::Withdrawer, &[]),
+            Ok(())
+        );
+        if let StakeState::Initialized(authorized, _lockup) =
+            StakeState::from(&stake_keyed_account.account).unwrap()
         {
-            assert_eq!(lockup.authority, stake_pubkey0);
+            assert_eq!(authorized.staker, stake_pubkey0);
+            assert_eq!(authorized.withdrawer, stake_pubkey0);
+        } else {
+            assert!(false);
         }
 
         // A second authorization signed by the stake_keyed_account should fail
         let stake_pubkey1 = Pubkey::new_rand();
         assert_eq!(
-            stake_keyed_account.authorize(&stake_pubkey1, &[]),
+            stake_keyed_account.authorize(&stake_pubkey1, StakeAuthorize::Staker, &[]),
             Err(InstructionError::MissingRequiredSignature)
         );
 
@@ -1709,18 +1767,38 @@ mod tests {
         // Test a second authorization by the newly authorized pubkey
         let stake_pubkey2 = Pubkey::new_rand();
         assert_eq!(
-            stake_keyed_account.authorize(&stake_pubkey2, &[staker_keyed_account0]),
+            stake_keyed_account.authorize(
+                &stake_pubkey2,
+                StakeAuthorize::Staker,
+                &[staker_keyed_account0]
+            ),
             Ok(())
         );
-        if let StakeState::Lockup(lockup) = StakeState::from(&stake_keyed_account.account).unwrap()
+        if let StakeState::Initialized(authorized, _lockup) =
+            StakeState::from(&stake_keyed_account.account).unwrap()
         {
-            assert_eq!(lockup.authority, stake_pubkey2);
+            assert_eq!(authorized.staker, stake_pubkey2);
+        }
+
+        let staker_keyed_account0 = KeyedAccount::new(&stake_pubkey0, true, &mut staker_account0);
+        assert_eq!(
+            stake_keyed_account.authorize(
+                &stake_pubkey2,
+                StakeAuthorize::Withdrawer,
+                &[staker_keyed_account0]
+            ),
+            Ok(())
+        );
+        if let StakeState::Initialized(authorized, _lockup) =
+            StakeState::from(&stake_keyed_account.account).unwrap()
+        {
+            assert_eq!(authorized.staker, stake_pubkey2);
         }
 
         let mut staker_account2 = Account::new(1, 0, &system_program::id());
         let staker_keyed_account2 = KeyedAccount::new(&stake_pubkey2, true, &mut staker_account2);
 
-        // Test an action by the currently authorized pubkey
+        // Test an action by the currently authorized withdrawer
         assert_eq!(
             stake_keyed_account.withdraw(
                 stake_lamports,
@@ -1739,10 +1817,7 @@ mod tests {
         let stake_lamports = 42;
         let mut stake_account = Account::new_data_with_space(
             stake_lamports,
-            &StakeState::Lockup(Lockup {
-                authority: stake_pubkey,
-                ..Lockup::default()
-            }),
+            &StakeState::Initialized(Authorized::auto(&stake_pubkey), Lockup::default()),
             std::mem::size_of::<StakeState>(),
             &id(),
         )
@@ -1762,11 +1837,11 @@ mod tests {
 
         let new_staker_pubkey = Pubkey::new_rand();
         assert_eq!(
-            stake_keyed_account.authorize(&new_staker_pubkey, &[]),
+            stake_keyed_account.authorize(&new_staker_pubkey, StakeAuthorize::Staker, &[]),
             Ok(())
         );
-        let stake = StakeState::stake_from(&stake_keyed_account.account).unwrap();
-        assert_eq!(stake.lockup.authority, new_staker_pubkey);
+        let authorized = StakeState::authorized_from(&stake_keyed_account.account).unwrap();
+        assert_eq!(authorized.staker, new_staker_pubkey);
 
         let other_pubkey = Pubkey::new_rand();
         let mut other_account = Account::new(1, 0, &system_program::id());

--- a/programs/stake_api/src/stake_state.rs
+++ b/programs/stake_api/src/stake_state.rs
@@ -18,7 +18,7 @@ use solana_sdk::{
 };
 use solana_vote_api::vote_state::VoteState;
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone, Copy)]
 #[allow(clippy::large_enum_variant)]
 pub enum StakeState {
     Uninitialized,
@@ -49,13 +49,13 @@ impl StakeState {
 
     pub fn stake(&self) -> Option<Stake> {
         match self {
-            StakeState::Stake(_authorized, _lockup, stake) => Some(stake.clone()),
+            StakeState::Stake(_authorized, _lockup, stake) => Some(*stake),
             _ => None,
         }
     }
     pub fn authorized(&self) -> Option<Authorized> {
         match self {
-            StakeState::Stake(authorized, _lockup, _stake) => Some(authorized.clone()),
+            StakeState::Stake(authorized, _lockup, _stake) => Some(*authorized),
             _ => None,
         }
     }
@@ -82,7 +82,7 @@ pub struct Authorized {
     pub withdrawer: Pubkey,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone, Copy)]
 pub struct Stake {
     /// most recently delegated vote account pubkey
     pub voter_pubkey: Pubkey,

--- a/programs/stake_api/src/stake_state.rs
+++ b/programs/stake_api/src/stake_state.rs
@@ -69,10 +69,12 @@ pub enum StakeAuthorize {
 
 #[derive(Default, Debug, Serialize, Deserialize, PartialEq, Clone, Copy)]
 pub struct Lockup {
-    /// slot height at which this stake will allow withdrawal, unless to the custodian
+    /// slot height at which this stake will allow withdrawal, unless
+    ///  to the custodian
     pub slot: Slot,
     /// custodian account, the only account to which this stake will honor a
-    /// withdrawal *before* lockup expires
+    ///  withdrawal before lockup expires.  After lockup expires, custodian
+    ///  is irrelevant
     pub custodian: Pubkey,
 }
 

--- a/runtime/src/genesis_utils.rs
+++ b/runtime/src/genesis_utils.rs
@@ -41,6 +41,7 @@ pub fn create_genesis_block_with_leader(
     );
 
     let stake_account = stake_state::create_account(
+        &staking_keypair.pubkey(),
         &voting_keypair.pubkey(),
         &vote_account,
         bootstrap_leader_stake_lamports,

--- a/runtime/src/stakes.rs
+++ b/runtime/src/stakes.rs
@@ -220,9 +220,11 @@ pub mod tests {
 
     //   add stake to a vote_pubkey                               (   stake    )
     pub fn create_stake_account(stake: u64, vote_pubkey: &Pubkey) -> (Pubkey, Account) {
+        let stake_pubkey = Pubkey::new_rand();
         (
-            Pubkey::new_rand(),
+            stake_pubkey,
             stake_state::create_account(
+                &stake_pubkey,
                 &vote_pubkey,
                 &vote_state::create_account(&vote_pubkey, &Pubkey::new_rand(), 0, 1),
                 stake,


### PR DESCRIPTION
#### Problem
* stakes lack offline pubkeys for managing the lamports contained in the account,
 the authorized pubkey is exposed by staking operations
* stakes lack a way to set a system account as authorized staker without issuing a doubly-signed transaction

 #### Summary of Changes
* add an Authorized field to StakeState::Stake that carries authorized staker
 and withdrawer, a la vote_state
* update stake call flow to include an init step that sets authorized pubkeys that can differ from the stake pubkey

CC #5988