### PR TITLE
Add rent estimation rpc

### DIFF
--- a/book/src/api-reference/jsonrpc-api.md
+++ b/book/src/api-reference/jsonrpc-api.md
@@ -30,6 +30,7 @@ To interact with a Solana node inside a JavaScript application, use the [solana-
 * [getStorageTurn](jsonrpc-api.md#getstorageturn)
 * [getStorageTurnRate](jsonrpc-api.md#getstorageturnrate)
 * [getNumBlocksSinceSignatureConfirmation](jsonrpc-api.md#getnumblockssincesignatureconfirmation)
+* [getMinimumBalanceForRentExemption](jsonrpc-api.md#getminimumbalanceforrentexemption)
 * [getTransactionCount](jsonrpc-api.md#gettransactioncount)
 * [getTotalSupply](jsonrpc-api.md#gettotalsupply)
 * [getVersion](jsonrpc-api.md#getversion)
@@ -453,6 +454,28 @@ curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0", "id":1, "
 
 // Result
 {"jsonrpc":"2.0","result":8,"id":1}
+```
+
+### getMinimumBalanceForRentExemption
+
+Returns minimum balance required to make account rent exempt.
+
+#### Parameters:
+
+* `integer` - account data length, as unsigned integer
+
+#### Results:
+
+* `integer` - minimum lamports required in account, as unsigned 64-bit integer
+
+#### Example:
+
+```bash
+// Request
+curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0", "id":1, "method":"getMinimumBalanceForRentExemption", "params":[50]}' http://localhost:8899
+
+// Result
+{"jsonrpc":"2.0","result":500,"id":1}
 ```
 
 ### getTransactionCount

--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -306,6 +306,35 @@ impl RpcClient {
         self.get_account(pubkey).map(|account| account.data)
     }
 
+    pub fn get_minimum_balance_for_rent_exemption(&self, data_len: usize) -> io::Result<u64> {
+        let params = json!([format!("{}", data_len)]);
+        let minimum_balance_json = self
+            .client
+            .send(
+                &RpcRequest::GetMinimumBalanceForRentExemption,
+                Some(params),
+                0,
+            )
+            .map_err(|err| {
+                io::Error::new(
+                    io::ErrorKind::Other,
+                    format!(
+                        "GetMinimumBalanceForRentExemption request failure: {:?}",
+                        err
+                    ),
+                )
+            })?;
+
+        let minimum_balance: u64 =
+            serde_json::from_value(minimum_balance_json).expect("deserialize minimum_balance");
+        trace!(
+            "Response minimum balance {:?} {:?}",
+            data_len,
+            minimum_balance
+        );
+        Ok(minimum_balance)
+    }
+
     /// Request the balance of the user holding `pubkey`. This method blocks
     /// until the server sends a response. If the response packet is dropped
     /// by the network, this method will hang indefinitely.

--- a/client/src/rpc_request.rs
+++ b/client/src/rpc_request.rs
@@ -28,6 +28,7 @@ pub enum RpcRequest {
     RequestAirdrop,
     SendTransaction,
     SignVote,
+    GetMinimumBalanceForRentExemption,
 }
 
 impl RpcRequest {
@@ -61,6 +62,7 @@ impl RpcRequest {
             RpcRequest::RequestAirdrop => "requestAirdrop",
             RpcRequest::SendTransaction => "sendTransaction",
             RpcRequest::SignVote => "signVote",
+            RpcRequest::GetMinimumBalanceForRentExemption => "getMinimumBalanceForRentExemption",
         };
         let mut request = json!({
            "jsonrpc": jsonrpc,

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -73,6 +73,10 @@ impl JsonRpcRequestProcessor {
             .ok_or_else(Error::invalid_request)
     }
 
+    pub fn get_minimum_balance_for_rent_exemption(&self, data_len: usize) -> Result<u64> {
+        Ok(self.bank().get_minimum_balance_for_rent_exemption(data_len))
+    }
+
     pub fn get_program_accounts(&self, program_id: &Pubkey) -> Result<Vec<(String, Account)>> {
         Ok(self
             .bank()
@@ -299,6 +303,9 @@ pub trait RpcSol {
     #[rpc(meta, name = "getProgramAccounts")]
     fn get_program_accounts(&self, _: Self::Metadata, _: String) -> Result<Vec<(String, Account)>>;
 
+    #[rpc(meta, name = "getMinimumBalanceForRentExemption")]
+    fn get_minimum_balance_for_rent_exemption(&self, _: Self::Metadata, _: usize) -> Result<u64>;
+
     #[rpc(meta, name = "getInflation")]
     fn get_inflation(&self, _: Self::Metadata) -> Result<Inflation>;
 
@@ -405,6 +412,21 @@ impl RpcSol for RpcSolImpl {
             .read()
             .unwrap()
             .get_account_info(&pubkey)
+    }
+
+    fn get_minimum_balance_for_rent_exemption(
+        &self,
+        meta: Self::Metadata,
+        data_len: usize,
+    ) -> Result<u64> {
+        debug!(
+            "get_minimum_balance_for_rent_exemption rpc request received: {:?}",
+            data_len
+        );
+        meta.request_processor
+            .read()
+            .unwrap()
+            .get_minimum_balance_for_rent_exemption(data_len)
     }
 
     fn get_program_accounts(

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -926,7 +926,10 @@ pub mod tests {
         } else {
             panic!("Expected single response");
         };
-        assert_eq!(minimum_balance, bank.get_minimum_balance_for_rent_exemption(data_len));
+        assert_eq!(
+            minimum_balance,
+            bank.get_minimum_balance_for_rent_exemption(data_len)
+        );
     }
 
     #[test]
@@ -1227,7 +1230,7 @@ pub mod tests {
             mint_keypair,
             ..
         } = create_genesis_block(TEST_MINT_LAMPORTS);
-        
+
         genesis_block.rent_calculator.lamports_per_byte_year = 50;
         genesis_block.rent_calculator.exemption_threshold = 2.0;
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -680,7 +680,9 @@ impl Bank {
     }
 
     pub fn get_minimum_balance_for_rent_exemption(&self, data_len: usize) -> u64 {
-        self.rent_collector.rent_calculator.minimum_balance(data_len)
+        self.rent_collector
+            .rent_calculator
+            .minimum_balance(data_len)
     }
 
     pub fn last_blockhash_with_fee_calculator(&self) -> (Hash, FeeCalculator) {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -679,6 +679,10 @@ impl Bank {
         self.blockhash_queue.read().unwrap().last_hash()
     }
 
+    pub fn get_minimum_balance_for_rent_exemption(&self, data_len: usize) -> u64 {
+        self.rent_collector.rent_calculator.minimum_balance(data_len)
+    }
+
     pub fn last_blockhash_with_fee_calculator(&self) -> (Hash, FeeCalculator) {
         let blockhash_queue = self.blockhash_queue.read().unwrap();
         let last_hash = blockhash_queue.last_hash();


### PR DESCRIPTION
#### Problem
To enable smooth transition to #6017 we need to add rpc endpoint, which will be used by client to get rent estimation

#### Summary of Changes
Add a new rpc endpoint named `getMinimumBalanceForRentExemption`, which will give minimum balance for an account to be rent exempt. 

#### Rationale behind adding new rpc method:
Reason behind adding new rpc method instead of not using `getAccounts` existing rpc method is, client need not to be concerned about how/where we are getting the minimum rent, otherwise if the implementation details change in future, we have to keep updating clients to match it. 
