### PR TITLE
Skip check if --custom-cpu is used as well.

### DIFF
--- a/net/gce.sh
+++ b/net/gce.sh
@@ -172,7 +172,7 @@ while [[ -n $1 ]]; do
     elif [[ $1 = --fullnode-additional-disk-size-gb ]]; then
       fullNodeAdditionalDiskSizeInGb="$2"
       shift 2
-    elif [[ $1 == --machine-type* ]]; then # Bypass quoted long args for GPUs
+    elif [[ $1 == --machine-type* || $1 == --custom-cpu* ]]; then # Bypass quoted long args for GPUs
       shortArgs+=("$1")
       shift
     else


### PR DESCRIPTION
#### Problem

--custom-cpu flag to gce.sh is not working

#### Summary of Changes

Skip it in long args check.

Fixes #
