### PR TITLE
Prevent subtract overflow panic when slot < max lockout history

### DIFF
--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -163,7 +163,11 @@ impl JsonRpcRequestProcessor {
                 }
             })
             .partition(|vote_account_info| {
-                vote_account_info.last_vote >= bank.slot() - MAX_LOCKOUT_HISTORY as u64
+                if bank.slot() >= MAX_LOCKOUT_HISTORY as u64 {
+                    vote_account_info.last_vote > bank.slot() - MAX_LOCKOUT_HISTORY as u64
+                } else {
+                    vote_account_info.last_vote > 0
+                }
             });
         Ok(RpcVoteAccountStatus {
             current: current_vote_accounts,


### PR DESCRIPTION
#### Problem
Receiving a getVoteAccounts rpc request before slot 32 causes a fullnode jsonrpc thread to panic.

#### Summary of Changes
Check slot height >= MAX_LOCKOUT_HISTORY, and partition vote accounts accordingly

Fixes #6133 
