### PR TITLE
get_new_blockhash() now retries longer (5s instead of 2s)

### DIFF
--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -425,9 +425,9 @@ impl RpcClient {
     }
 
     pub fn get_new_blockhash(&self, blockhash: &Hash) -> io::Result<(Hash, FeeCalculator)> {
-        let mut num_retries = 10;
+        let mut num_retries = 0;
         let start = Instant::now();
-        while num_retries > 0 {
+        while start.elapsed().as_secs() < 5 {
             if let Ok((new_blockhash, fee_calculator)) = self.get_recent_blockhash() {
                 if new_blockhash != *blockhash {
                     return Ok((new_blockhash, fee_calculator));
@@ -439,13 +439,14 @@ impl RpcClient {
             sleep(Duration::from_millis(
                 500 * DEFAULT_TICKS_PER_SLOT / DEFAULT_TICKS_PER_SECOND,
             ));
-            num_retries -= 1;
+            num_retries += 1;
         }
         Err(io::Error::new(
             io::ErrorKind::Other,
             format!(
-                "Unable to get new blockhash after {}ms, stuck at {}",
+                "Unable to get new blockhash after {}ms (retried {} times), stuck at {}",
                 start.elapsed().as_millis(),
+                num_retries,
                 blockhash
             ),
         ))


### PR DESCRIPTION
This'll hopefully help with the occasional `solana ping` failures in testnet sanity, and cleans up how we do the retries
