### PR TITLE
Test ssh key check

### DIFF
--- a/ci/check-ssh-keys.sh
+++ b/ci/check-ssh-keys.sh
@@ -1,0 +1,4 @@
+if grep -q rsa net/scripts/solana-user-authorized_keys.sh; then
+   echo "No rsa keys allowed, small key sizes are insecure."
+   exit 1
+fi

--- a/ci/test-checks.sh
+++ b/ci/test-checks.sh
@@ -24,6 +24,7 @@ _ ci/nits.sh
 _ ci/order-crates-for-publishing.py
 _ book/build.sh
 _ book/build-svg.sh
+_ ci/check-ssh-keys.sh
 
 {
   cd programs/bpf


### PR DESCRIPTION
#### Problem

We disallow rsa keys, but there is nothing to check for that.

#### Summary of Changes

Add check for rsa keys in key file.

Fixes #
