### PR TITLE
Update solana_rbpf to v0.1.18

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3098,7 +3098,7 @@ dependencies = [
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-logger 0.20.0",
  "solana-sdk 0.20.0",
- "solana_rbpf 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_rbpf 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -4364,7 +4364,7 @@ dependencies = [
 
 [[package]]
 name = "solana_rbpf"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5714,7 +5714,7 @@ dependencies = [
 "checksum solana_libra_vm_cache_map 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9f0abd2cc72c7d76ca9e0764e3f1fa01a01f49b9014a193f2a3fe735a034bf96"
 "checksum solana_libra_vm_genesis 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4dadfcf5fabfd28d09770d698c618a48d75819f6915bd8bdfa04b93b6e492530"
 "checksum solana_libra_vm_runtime 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "055a5de29d1b8a2b9f9e20293e07998b8e188164bbe6ac8a09260043f99379aa"
-"checksum solana_rbpf 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)" = "c5a7a30cf5e51a48137e572c44bc818b9f8f38cdf1dab73a76dd082410175073"
+"checksum solana_rbpf 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)" = "c7a69e553372557cfb6cf35396b8ddb65d3ccb7a0bb3fee3fba690b6ebd9c9d9"
 "checksum solicit 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "172382bac9424588d7840732b250faeeef88942e37b6e35317dce98cafdd75b2"
 "checksum sourcefile 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4bf77cb82ba8453b42b6ae1d692e4cdc92f9a47beaf89a847c8be83f4e328ad3"
 "checksum spin 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "ceac490aa12c567115b40b7b7fceca03a6c9d53d5defea066123debc83c5dc1f"

--- a/programs/bpf/Cargo.toml
+++ b/programs/bpf/Cargo.toml
@@ -26,7 +26,7 @@ solana-bpf-loader-api = { path = "../bpf_loader_api", version = "0.20.0" }
 solana-logger = { path = "../../logger", version = "0.20.0" }
 solana-runtime = { path = "../../runtime", version = "0.20.0" }
 solana-sdk = { path = "../../sdk", version = "0.20.0" }
-solana_rbpf = "=0.1.17"
+solana_rbpf = "=0.1.18"
 
 [[bench]]
 name = "bpf_loader"

--- a/programs/bpf_loader_api/Cargo.toml
+++ b/programs/bpf_loader_api/Cargo.toml
@@ -16,7 +16,7 @@ log = "0.4.8"
 serde = "1.0.101"
 solana-logger = { path = "../../logger", version = "0.20.0" }
 solana-sdk = { path = "../../sdk", version = "0.20.0" }
-solana_rbpf = "=0.1.17"
+solana_rbpf = "=0.1.18"
 
 [lib]
 crate-type = ["lib"]


### PR DESCRIPTION
#### Problem

#### Summary of Changes

Pulls in a change to remove costly `trace!` call that was formating the message even when the message was not enabled for printing.

Fixes #
