### PR TITLE
Add --expected-genesis-blockhash validator argument

### DIFF
--- a/cli/src/wallet.rs
+++ b/cli/src/wallet.rs
@@ -96,6 +96,7 @@ pub enum WalletCommand {
     ClaimStorageReward(Pubkey, Pubkey),
     ShowStorageAccount(Pubkey),
     Deploy(String),
+    GetGenesisBlockhash,
     GetSlot,
     GetEpochInfo,
     GetTransactionCount,
@@ -343,6 +344,7 @@ pub fn parse_command(
                 .unwrap()
                 .to_string(),
         )),
+        ("get-genesis-blockhash", Some(_matches)) => Ok(WalletCommand::GetGenesisBlockhash),
         ("get-slot", Some(_matches)) => Ok(WalletCommand::GetSlot),
         ("get-epoch-info", Some(_matches)) => Ok(WalletCommand::GetEpochInfo),
         ("get-transaction-count", Some(_matches)) => Ok(WalletCommand::GetTransactionCount),
@@ -1086,6 +1088,11 @@ fn process_cancel(rpc_client: &RpcClient, config: &WalletConfig, pubkey: &Pubkey
     log_instruction_custom_error::<BudgetError>(result)
 }
 
+fn process_get_genesis_blockhash(rpc_client: &RpcClient) -> ProcessResult {
+    let genesis_blockhash = rpc_client.get_genesis_blockhash()?;
+    Ok(genesis_blockhash.to_string())
+}
+
 fn process_get_slot(rpc_client: &RpcClient) -> ProcessResult {
     let slot = rpc_client.get_slot()?;
     Ok(slot.to_string())
@@ -1501,6 +1508,7 @@ pub fn process_command(config: &WalletConfig) -> ProcessResult {
             process_deploy(&rpc_client, config, program_location)
         }
 
+        WalletCommand::GetGenesisBlockhash => process_get_genesis_blockhash(&rpc_client),
         WalletCommand::GetSlot => process_get_slot(&rpc_client),
         WalletCommand::GetEpochInfo => process_get_epoch_info(&rpc_client),
         WalletCommand::GetTransactionCount => process_get_transaction_count(&rpc_client),
@@ -2195,6 +2203,10 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                         .required(true)
                         .help("/path/to/program.o"),
                 ), // TODO: Add "loader" argument; current default is bpf_loader
+        )
+        .subcommand(
+            SubCommand::with_name("get-genesis-blockhash")
+                .about("Get the genesis blockhash"),
         )
         .subcommand(
             SubCommand::with_name("get-slot")

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -497,12 +497,13 @@ pub fn new_banks_from_blocktree(
 ) {
     let genesis_block = GenesisBlock::load(blocktree_path).expect("Failed to load genesis block");
     let genesis_blockhash = genesis_block.hash();
+    info!("genesis blockhash: {}", genesis_blockhash);
 
     if let Some(expected_genesis_blockhash) = expected_genesis_blockhash {
         if genesis_blockhash != expected_genesis_blockhash {
             error!(
-                "Genesis blockhash mismatch: expected {} but local genesis blockhash is {}",
-                expected_genesis_blockhash, genesis_blockhash,
+                "genesis blockhash mismatch: expected {}",
+                expected_genesis_blockhash
             );
             error!(
                 "Delete the ledger directory to continue: {:?}",

--- a/multinode-demo/validator.sh
+++ b/multinode-demo/validator.sh
@@ -67,6 +67,9 @@ while [[ -n $1 ]]; do
     elif [[ $1 = --blockstream ]]; then
       args+=("$1" "$2")
       shift 2
+    elif [[ $1 = --expected-genesis-blockhash ]]; then
+      args+=("$1" "$2")
+      shift 2
     elif [[ $1 = --identity ]]; then
       identity_keypair_path=$2
       args+=("$1" "$2")


### PR DESCRIPTION
#### Problem
When a validator is started, there's no way for it to abort if the genesis blockhash is not what it requires.

#### Summary of Changes
1. `solana-validator --expected-genesis-blockhash xyz` to require a specific blockhash
2. `solana get-genesis-blockhash` to easily query nodes for their genesis blockhash (RPC API already existed and was being used during snapshot loading)
3. Plumb 1 and 2 through `ci/localnet-sanity.sh`

Fixes #6155
