### PR TITLE
Increase parallelism in shredding

### DIFF
--- a/core/src/blockstream_service.rs
+++ b/core/src/blockstream_service.rs
@@ -169,7 +169,7 @@ mod test {
                 None,
                 true,
                 &Arc::new(Keypair::new()),
-                &entries,
+                entries,
             )
             .unwrap();
 

--- a/core/src/blocktree.rs
+++ b/core/src/blocktree.rs
@@ -806,7 +806,7 @@ impl Blocktree {
         self.code_shred_cf.get_bytes((slot, index))
     }
 
-    pub fn write_entries<I>(
+    /*pub fn write_entries<I>(
         &self,
         start_slot: u64,
         num_ticks_in_start_slot: u64,
@@ -833,9 +833,8 @@ impl Blocktree {
             },
             |v| v,
         );
-        let mut shredder =
-            Shredder::new(current_slot, parent_slot, 0.0, keypair, start_index as u32)
-                .expect("Failed to create entry shredder");
+        let mut shredder = Shredder::new(current_slot, parent_slot, 0.0, keypair)
+            .expect("Failed to create entry shredder");
         let mut all_shreds = vec![];
         // Find all the entries for start_slot
         for entry in entries {
@@ -871,7 +870,7 @@ impl Blocktree {
         let num_shreds = all_shreds.len();
         self.insert_shreds(all_shreds, None)?;
         Ok(num_shreds)
-    }
+    }*/
 
     pub fn get_index(&self, slot: u64) -> Result<Option<Index>> {
         self.index_cf.get(slot)
@@ -1553,13 +1552,12 @@ pub fn create_new_ledger(ledger_path: &Path, genesis_block: &GenesisBlock) -> Re
     let blocktree = Blocktree::open(ledger_path)?;
     let entries = crate::entry::create_ticks(ticks_per_slot, genesis_block.hash());
 
-    let mut shredder = Shredder::new(0, 0, 0.0, &Arc::new(Keypair::new()), 0)
+    let shredder = Shredder::new(0, 0, 0.0, Arc::new(Keypair::new()))
         .expect("Failed to create entry shredder");
     let last_hash = entries.last().unwrap().hash;
-    bincode::serialize_into(&mut shredder, &entries)
-        .expect("Expect to write all entries to shreds");
-    shredder.finalize_slot();
-    let shreds: Vec<Shred> = shredder.shreds.drain(..).collect();
+
+    let last_tick = ticks_per_slot - 1;
+    let shreds = shredder.entries_to_shreds(entries, true, 0).0;
 
     blocktree.insert_shreds(shreds, None)?;
     blocktree.set_roots(&[0])?;
@@ -1635,7 +1633,7 @@ pub fn create_new_tmp_ledger(name: &str, genesis_block: &GenesisBlock) -> (PathB
     (ledger_path, blockhash)
 }
 
-pub fn entries_to_test_shreds(
+/*pub fn entries_to_test_shreds(
     entries: Vec<Entry>,
     slot: u64,
     parent_slot: u64,
@@ -1653,7 +1651,7 @@ pub fn entries_to_test_shreds(
     }
 
     shredder.shreds.drain(..).collect()
-}
+}*/
 
 #[cfg(test)]
 pub mod tests {

--- a/core/src/blocktree_processor.rs
+++ b/core/src/blocktree_processor.rs
@@ -456,7 +456,7 @@ pub mod tests {
                 Some(parent_slot),
                 true,
                 &Arc::new(Keypair::new()),
-                &entries,
+                entries,
             )
             .unwrap();
 
@@ -849,7 +849,7 @@ pub mod tests {
 
         // Fill up the rest of slot 1 with ticks
         entries.extend(create_ticks(genesis_block.ticks_per_slot, last_entry_hash));
-
+        let last_blockhash = entries.last().unwrap().hash;
         let blocktree =
             Blocktree::open(&ledger_path).expect("Expected to successfully open database ledger");
         blocktree
@@ -861,7 +861,7 @@ pub mod tests {
                 None,
                 true,
                 &Arc::new(Keypair::new()),
-                &entries,
+                entries,
             )
             .unwrap();
         let (bank_forks, bank_forks_info, _) =
@@ -877,7 +877,7 @@ pub mod tests {
             mint - deducted_from_mint
         );
         assert_eq!(bank.tick_height(), 2 * genesis_block.ticks_per_slot - 1);
-        assert_eq!(bank.last_blockhash(), entries.last().unwrap().hash);
+        assert_eq!(bank.last_blockhash(), last_blockhash);
     }
 
     #[test]

--- a/core/src/broadcast_stage/broadcast_utils.rs
+++ b/core/src/broadcast_stage/broadcast_utils.rs
@@ -68,7 +68,6 @@ mod tests {
     use crate::genesis_utils::{create_genesis_block, GenesisBlockInfo};
     use solana_sdk::genesis_block::GenesisBlock;
     use solana_sdk::pubkey::Pubkey;
-    use solana_sdk::signature::Keypair;
     use solana_sdk::system_transaction;
     use solana_sdk::transaction::Transaction;
     use std::sync::mpsc::channel;

--- a/core/src/chacha.rs
+++ b/core/src/chacha.rs
@@ -136,7 +136,7 @@ mod tests {
                 None,
                 true,
                 &Arc::new(keypair),
-                &entries,
+                entries,
             )
             .unwrap();
 

--- a/core/src/chacha_cuda.rs
+++ b/core/src/chacha_cuda.rs
@@ -146,7 +146,7 @@ mod tests {
                 Some(0),
                 true,
                 &Arc::new(Keypair::new()),
-                &entries,
+                entries,
             )
             .unwrap();
 
@@ -207,7 +207,7 @@ mod tests {
                 Some(0),
                 true,
                 &Arc::new(Keypair::new()),
-                &entries,
+                entries,
             )
             .unwrap();
 

--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -317,12 +317,9 @@ mod test {
         parent: u64,
         keypair: &Arc<Keypair>,
     ) -> Vec<Shred> {
-        let mut shredder =
-            Shredder::new(slot, parent, 0.0, keypair, 0).expect("Failed to create entry shredder");
-        bincode::serialize_into(&mut shredder, &entries)
-            .expect("Expect to write all entries to shreds");
-        shredder.finalize_slot();
-        shredder.shreds.drain(..).collect()
+        let shredder = Shredder::new(slot, parent, 0.0, keypair.clone())
+            .expect("Failed to create entry shredder");
+        shredder.entries_to_shreds(entries, true, 0).0
     }
 
     #[test]


### PR DESCRIPTION
#### Problem
Work done across FEC sets for shredding can be parallelized

#### Summary of Changes
1) Serialize all entries
2) Break them into shred sized chunks, generate shreds
3) Organize shreds into FEC sets
4) Generate coding

TODO: 
1) Test for correctness, probably lots of broken things.
2) As part of 1) fix the tests in shred.rs


Fixes #
