### PR TITLE
TdS prize tool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3856,6 +3856,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-tds-prize-tool"
+version = "0.20.0"
+dependencies = [
+ "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-core 0.20.0",
+ "solana-logger 0.20.0",
+ "solana-runtime 0.20.0",
+ "solana-sdk 0.20.0",
+ "solana-stake-api 0.20.0",
+ "solana-vote-api 0.20.0",
+]
+
+[[package]]
 name = "solana-token-api"
 version = "0.20.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ members = [
     "runtime",
     "sdk",
     "sdk-c",
+    "tds-prize-tool",
     "upload-perf",
     "netutil",
     "fixed-buf",

--- a/cli/src/input_parsers.rs
+++ b/cli/src/input_parsers.rs
@@ -1,6 +1,6 @@
-use crate::sol_to_lamports;
 use clap::ArgMatches;
 use solana_sdk::{
+    native_token::sol_to_lamports,
     pubkey::Pubkey,
     signature::{read_keypair, Keypair, KeypairUtil},
 };

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -9,11 +9,3 @@ pub mod stake;
 pub mod validator_info;
 pub mod vote;
 pub mod wallet;
-
-pub(crate) fn lamports_to_sol(lamports: u64) -> f64 {
-    lamports as f64 / 2u64.pow(34) as f64
-}
-
-pub(crate) fn sol_to_lamports(sol: f64) -> u64 {
-    (sol * 2u64.pow(34) as f64) as u64
-}

--- a/cli/src/wallet.rs
+++ b/cli/src/wallet.rs
@@ -1,5 +1,5 @@
 use crate::{
-    display::println_name_value, input_parsers::*, input_validators::*, lamports_to_sol, stake::*,
+    display::println_name_value, input_parsers::*, input_validators::*, stake::*,
     validator_info::*, vote::*,
 };
 use chrono::prelude::*;
@@ -23,6 +23,7 @@ use solana_sdk::{
     instruction_processor_utils::DecodeError,
     loader_instruction,
     message::Message,
+    native_token::lamports_to_sol,
     pubkey::Pubkey,
     signature::{Keypair, KeypairUtil, Signature},
     system_instruction::SystemError,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1485,6 +1485,11 @@ impl Bank {
         self.stakes.read().unwrap().vote_accounts().clone()
     }
 
+    /// current stake accounts for this bank
+    pub fn stake_accounts(&self) -> HashMap<Pubkey, Account> {
+        self.stakes.read().unwrap().stake_accounts().clone()
+    }
+
     /// vote accounts for the specific epoch along with the stake
     ///   attributed to each account
     pub fn epoch_vote_accounts(&self, epoch: Epoch) -> Option<&HashMap<Pubkey, (u64, Account)>> {

--- a/runtime/src/stakes.rs
+++ b/runtime/src/stakes.rs
@@ -167,8 +167,13 @@ impl Stakes {
             }
         }
     }
+
     pub fn vote_accounts(&self) -> &HashMap<Pubkey, (u64, Account)> {
         &self.vote_accounts
+    }
+
+    pub fn stake_accounts(&self) -> &HashMap<Pubkey, Account> {
+        &self.stake_accounts
     }
 
     pub fn rewards_pools(&self) -> impl Iterator<Item = (&Pubkey, &Account)> {

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -10,6 +10,7 @@ pub mod instruction_processor_utils;
 pub mod loader_instruction;
 pub mod message;
 pub mod native_loader;
+pub mod native_token;
 pub mod packet;
 pub mod poh_config;
 pub mod pubkey;

--- a/sdk/src/native_token.rs
+++ b/sdk/src/native_token.rs
@@ -1,0 +1,12 @@
+/// There are 2^34 lamports in one sol
+pub const SOL_LAMPORTS: u64 = 17_179_869_184;
+
+/// Approximately convert fractional native tokens (lamports) into native tokens (sol)
+pub fn lamports_to_sol(lamports: u64) -> f64 {
+    lamports as f64 / SOL_LAMPORTS as f64
+}
+
+/// Approximately convert native tokens (sol) into fractional native tokens (lamports)
+pub fn sol_to_lamports(sol: f64) -> u64 {
+    (sol * SOL_LAMPORTS as f64) as u64
+}

--- a/tds-prize-tool/Cargo.toml
+++ b/tds-prize-tool/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+authors = ["Solana Maintainers <maintainers@solana.com>"]
+edition = "2018"
+name = "solana-tds-prize-tool"
+description = "Solana Tour de Sol prize tool"
+version = "0.20.0"
+repository = "https://github.com/solana-labs/solana"
+license = "Apache-2.0"
+homepage = "https://solana.com/tds"
+
+[dependencies]
+clap = "2.33.0"
+solana-core = { path = "../core", version = "0.20.0" }
+solana-runtime = { path = "../runtime", version = "0.20.0" }
+solana-logger = { path = "../logger", version = "0.20.0" }
+solana-sdk = { path = "../sdk", version = "0.20.0" }
+solana-stake-api = { path = "../programs/stake_api", version = "0.20.0" }
+solana-vote-api = { path = "../programs/vote_api", version = "0.20.0" }

--- a/tds-prize-tool/src/main.rs
+++ b/tds-prize-tool/src/main.rs
@@ -1,11 +1,11 @@
 mod prize;
 mod rewards_earned;
-mod utils;
 
 use clap::{crate_description, crate_name, crate_version, value_t_or_exit, App, Arg};
 use solana_core::blocktree::Blocktree;
 use solana_core::blocktree_processor::process_blocktree;
 use solana_sdk::genesis_block::GenesisBlock;
+use solana_sdk::native_token::sol_to_lamports;
 use std::path::PathBuf;
 use std::process::exit;
 
@@ -54,10 +54,10 @@ fn main() {
     };
 
     println!("Verifying ledger...");
-    match process_blocktree(&genesis_block, &blocktree, None, true, None) {
+    match process_blocktree(&genesis_block, &blocktree, None, false, None) {
         Ok((bank_forks, _bank_forks_info, _leader_schedule_cache)) => {
             let bank = bank_forks.working_bank();
-            let starting_balance = utils::sol_to_lamports(starting_balance_sol);
+            let starting_balance = sol_to_lamports(starting_balance_sol);
             let rewards_earned_winners = rewards_earned::compute_winners(&bank, starting_balance);
             println!("{:#?}", rewards_earned_winners);
         }

--- a/tds-prize-tool/src/main.rs
+++ b/tds-prize-tool/src/main.rs
@@ -1,0 +1,59 @@
+mod prize;
+mod rewards_earned;
+
+use clap::{crate_description, crate_name, crate_version, value_t_or_exit, App, Arg, SubCommand};
+use solana_core::blocktree::Blocktree;
+use solana_core::blocktree_processor::process_blocktree;
+use solana_sdk::genesis_block::GenesisBlock;
+use std::path::PathBuf;
+use std::process::exit;
+
+fn main() {
+    solana_logger::setup();
+
+    let matches = App::new(crate_name!())
+        .about(crate_description!())
+        .version(crate_version!())
+        .arg(
+            Arg::with_name("ledger")
+                .short("l")
+                .long("ledger")
+                .value_name("DIR")
+                .takes_value(true)
+                .global(true)
+                .help("Use directory for ledger location"),
+        )
+        .subcommand(SubCommand::with_name("results").about("Print the results"))
+        .get_matches();
+
+    let ledger_path = PathBuf::from(value_t_or_exit!(matches, "ledger", String));
+
+    let genesis_block = GenesisBlock::load(&ledger_path).unwrap_or_else(|err| {
+        eprintln!(
+            "Failed to open ledger genesis_block at {:?}: {}",
+            ledger_path, err
+        );
+        exit(1);
+    });
+
+    let blocktree = match Blocktree::open(&ledger_path) {
+        Ok(blocktree) => blocktree,
+        Err(err) => {
+            eprintln!("Failed to open ledger at {:?}: {}", ledger_path, err);
+            exit(1);
+        }
+    };
+
+    println!("Verifying ledger...");
+    match process_blocktree(&genesis_block, &blocktree, None, true, None) {
+        Ok((bank_forks, _bank_forks_info, _leader_schedule_cache)) => {
+            let bank = bank_forks.working_bank();
+            let rewards_earned_winners = rewards_earned::compute_winners(&bank);
+            println!("{:#?}", rewards_earned_winners);
+        }
+        Err(err) => {
+            eprintln!("Ledger verification failed: {:?}", err);
+            exit(1);
+        }
+    }
+}

--- a/tds-prize-tool/src/prize.rs
+++ b/tds-prize-tool/src/prize.rs
@@ -1,0 +1,17 @@
+use solana_sdk::pubkey::Pubkey;
+
+#[derive(Debug)]
+pub enum Category {
+    // Availability,
+    // ConfirmationLatency,
+    RewardsEarned,
+}
+
+pub type Winner = (Pubkey, String);
+
+#[derive(Debug)]
+pub struct Winners {
+    pub category: Category,
+    pub top_winners: Vec<Winner>,
+    pub bucket_winners: Vec<(String, Vec<Winner>)>,
+}

--- a/tds-prize-tool/src/rewards_earned.rs
+++ b/tds-prize-tool/src/rewards_earned.rs
@@ -12,7 +12,7 @@ use crate::prize::{self, Winner, Winners};
 use solana_runtime::bank::Bank;
 use solana_sdk::account::Account;
 use solana_sdk::pubkey::Pubkey;
-use solana_stake_api::stake_state::{Authorized, Lockup, StakeState};
+use solana_stake_api::stake_state::StakeState;
 use solana_vote_api::vote_state::VoteState;
 use std::cmp::{max, min};
 use std::collections::HashMap;
@@ -135,7 +135,7 @@ pub fn compute_winners(bank: &Bank, starting_balance: u64) -> Winners {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use solana_stake_api::stake_state::Stake;
+    use solana_stake_api::stake_state::{Authorized, Lockup, Stake};
     use solana_vote_api::vote_state::VoteInit;
 
     #[test]

--- a/tds-prize-tool/src/rewards_earned.rs
+++ b/tds-prize-tool/src/rewards_earned.rs
@@ -1,0 +1,282 @@
+use crate::prize::{self, Winner, Winners};
+use solana_runtime::bank::Bank;
+use solana_sdk::account::Account;
+use solana_sdk::pubkey::Pubkey;
+use solana_stake_api::stake_state::StakeState;
+use solana_vote_api::vote_state::VoteState;
+use std::cmp::{max, min};
+use std::collections::HashMap;
+
+pub const STARTING_BALANCE_LAMPORTS: i64 = 0; // TODO
+
+const HIGH_BUCKET: &str = "Top 25% Bucket";
+const MID_BUCKET: &str = "Top 25-50% Bucket";
+const LOW_BUCKET: &str = "Top 50-90% Bucket";
+
+fn voter_stake_rewards(stake_accounts: HashMap<Pubkey, Account>) -> HashMap<Pubkey, u64> {
+    let mut voter_stake_sum: HashMap<Pubkey, u64> = HashMap::new();
+    for (_key, account) in stake_accounts {
+        if let Some(StakeState::Stake(_authorized, _lockup, stake)) = StakeState::from(&account) {
+            let stake_sum = voter_stake_sum
+                .get(&stake.voter_pubkey)
+                .cloned()
+                .unwrap_or_default();
+            voter_stake_sum.insert(stake.voter_pubkey, stake_sum + account.lamports);
+        }
+    }
+    voter_stake_sum
+}
+
+fn validator_results(validator_reward_map: HashMap<Pubkey, u64>) -> Vec<(Pubkey, i64)> {
+    let mut validator_rewards: Vec<(Pubkey, u64)> = validator_reward_map
+        .iter()
+        .map(|(key, balance)| (*key, *balance))
+        .collect();
+
+    // Sort descending and calculate results
+    validator_rewards.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap());
+    validator_rewards
+        .into_iter()
+        .map(|(key, earned)| (key, (earned as i64) - STARTING_BALANCE_LAMPORTS))
+        .collect()
+}
+
+fn validator_rewards(
+    mut voter_stake_rewards: HashMap<Pubkey, u64>,
+    vote_accounts: HashMap<Pubkey, (u64, Account)>,
+) -> HashMap<Pubkey, u64> {
+    // Sum validator earned reward totals (stake rewards + commission)
+    let mut validator_reward_map: HashMap<Pubkey, u64> = HashMap::new();
+    for (voter_key, (_stake, account)) in vote_accounts {
+        if let Some(vote_state) = VoteState::from(&account) {
+            let voter_commission = account.lamports;
+            let voter_stake_reward = voter_stake_rewards.remove(&voter_key).unwrap_or_default();
+
+            // TODO: check if it's possible to have multiple vote accounts in working bank
+            let validator_id = vote_state.node_pubkey;
+            if let Some(validator_reward) = validator_reward_map.get_mut(&validator_id) {
+                *validator_reward += voter_commission + voter_stake_reward;
+            } else {
+                validator_reward_map.insert(validator_id, voter_commission + voter_stake_reward);
+            }
+        }
+    }
+
+    validator_reward_map
+}
+
+// Bucket validators for reward distribution
+// - (1) Top 25% of reward earners
+// - (2) Top 25-50% of reward earners
+// - (3) Top 50-90% of reward earners
+fn bucket_winners(results: &[(Pubkey, i64)]) -> Vec<(String, Vec<Winner>)> {
+    let num_validators = results.len();
+    let mut bucket_winners = Vec::new();
+
+    // Tied winners should not end up in different buckets
+    let handle_ties = |mut index: usize| -> usize {
+        while (index + 1 < num_validators) && (results[index].1 == results[index + 1].1) {
+            index += 1;
+        }
+        index
+    };
+
+    // Top 25% of validators
+    let hi_bucket_index = handle_ties(max(1, num_validators / 4) - 1);
+    let hi = &results[..=hi_bucket_index];
+    bucket_winners.push((HIGH_BUCKET.to_string(), normalize_winners(hi)));
+
+    // Top 25-50% of validators
+    let md_bucket_index = handle_ties(max(1, num_validators / 2) - 1);
+    let md = &results[(hi_bucket_index + 1)..=md_bucket_index];
+    bucket_winners.push((MID_BUCKET.to_string(), normalize_winners(md)));
+
+    // Top 50-90% of validators
+    let lo_bucket_index = handle_ties(max(1, 9 * num_validators / 10) - 1);
+    let lo = &results[(md_bucket_index + 1)..=lo_bucket_index];
+    bucket_winners.push((LOW_BUCKET.to_string(), normalize_winners(lo)));
+
+    bucket_winners
+}
+
+fn normalize_winners(winners: &[(Pubkey, i64)]) -> Vec<(Pubkey, String)> {
+    winners
+        .iter()
+        .map(|(key, earned)| {
+            (
+                *key,
+                format!("Earned {} lamports in stake rewards and commission", earned),
+            )
+        })
+        .collect()
+}
+
+pub fn compute_winners(bank: &Bank) -> Winners {
+    let voter_stake_rewards = voter_stake_rewards(bank.stake_accounts());
+    let validator_reward_map = validator_rewards(voter_stake_rewards, bank.vote_accounts());
+    let results = validator_results(validator_reward_map);
+    let num_validators = results.len();
+    let num_winners = min(num_validators, 3);
+
+    Winners {
+        category: prize::Category::RewardsEarned,
+        top_winners: normalize_winners(&results[..num_winners]),
+        bucket_winners: bucket_winners(&results),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use solana_stake_api::stake_state::Stake;
+    use solana_vote_api::vote_state::VoteInit;
+
+    #[test]
+    fn test_validator_results() {
+        let mut rewards_map = HashMap::new();
+        let top_validator = Pubkey::new_rand();
+        let bottom_validator = Pubkey::new_rand();
+        rewards_map.insert(top_validator, 1000);
+        rewards_map.insert(bottom_validator, 10);
+
+        let results = validator_results(rewards_map);
+        assert_eq!(results[0], (top_validator, 1000));
+        assert_eq!(results[1], (bottom_validator, 10));
+    }
+
+    #[test]
+    fn test_validator_rewards() {
+        let new_vote_account = |lamports: u64, validator_id: &Pubkey| -> Account {
+            Account::new_data(
+                lamports,
+                &VoteState::new(&VoteInit {
+                    node_pubkey: validator_id.clone(),
+                    ..VoteInit::default()
+                }),
+                &Pubkey::new_rand(),
+            )
+            .unwrap()
+        };
+
+        let validator1 = Pubkey::new_rand();
+        let validator2 = Pubkey::new_rand();
+
+        let mut vote_accounts = HashMap::new();
+        let voter1 = Pubkey::new_rand();
+        vote_accounts.insert(voter1.clone(), (0, new_vote_account(100, &validator1)));
+        vote_accounts.insert(Pubkey::new_rand(), (0, new_vote_account(100, &validator2)));
+        vote_accounts.insert(Pubkey::new_rand(), (0, new_vote_account(100, &validator2)));
+
+        let voter_stake_rewards = {
+            let mut map = HashMap::new();
+            map.insert(voter1, 1000);
+            map
+        };
+
+        let expected_rewards = {
+            let mut map = HashMap::new();
+            map.insert(validator1, 1100);
+            map.insert(validator2, 200);
+            map
+        };
+
+        assert_eq!(
+            expected_rewards,
+            validator_rewards(voter_stake_rewards, vote_accounts)
+        );
+    }
+
+    #[test]
+    fn test_voter_stake_rewards() {
+        let new_stake_account = |lamports: u64, voter_pubkey: &Pubkey| -> Account {
+            Account::new_data(
+                lamports,
+                &StakeState::Stake(
+                    Default::default(),
+                    Default::default(),
+                    Stake {
+                        voter_pubkey: voter_pubkey.clone(),
+                        ..Stake::default()
+                    },
+                ),
+                &Pubkey::new_rand(),
+            )
+            .unwrap()
+        };
+
+        let voter_pubkey1 = Pubkey::new_rand();
+        let voter_pubkey2 = Pubkey::new_rand();
+
+        let mut stake_accounts = HashMap::new();
+        stake_accounts.insert(Pubkey::new_rand(), new_stake_account(100, &voter_pubkey1));
+        stake_accounts.insert(Pubkey::new_rand(), new_stake_account(100, &voter_pubkey2));
+        stake_accounts.insert(Pubkey::new_rand(), new_stake_account(100, &voter_pubkey2));
+
+        let expected = {
+            let mut map = HashMap::new();
+            map.insert(voter_pubkey1, 100);
+            map.insert(voter_pubkey2, 200);
+            map
+        };
+
+        assert_eq!(expected, voter_stake_rewards(stake_accounts));
+    }
+
+    #[test]
+    fn test_bucket_winners() {
+        let mut results = Vec::new();
+
+        let expected_hi_bucket = vec![(Pubkey::new_rand(), 8_000), (Pubkey::new_rand(), 7_000)];
+
+        let expected_md_bucket = vec![(Pubkey::new_rand(), 6_000), (Pubkey::new_rand(), 5_000)];
+
+        let expected_lo_bucket = vec![
+            (Pubkey::new_rand(), 4_000),
+            (Pubkey::new_rand(), 3_000),
+            (Pubkey::new_rand(), 2_000),
+        ];
+
+        results.extend(expected_hi_bucket.iter());
+        results.extend(expected_md_bucket.iter());
+        results.extend(expected_lo_bucket.iter());
+        results.push((Pubkey::new_rand(), 1_000));
+
+        let bucket_winners = bucket_winners(&results);
+
+        assert_eq!(bucket_winners[0].1, normalize_winners(&expected_hi_bucket));
+        assert_eq!(bucket_winners[1].1, normalize_winners(&expected_md_bucket));
+        assert_eq!(bucket_winners[2].1, normalize_winners(&expected_lo_bucket));
+    }
+
+    #[test]
+    fn test_bucket_winners_with_ties() {
+        let mut results = Vec::new();
+
+        // Ties should all get bucketed together
+        let expected_hi_bucket = vec![
+            (Pubkey::new_rand(), 8_000),
+            (Pubkey::new_rand(), 7_000),
+            (Pubkey::new_rand(), 7_000),
+            (Pubkey::new_rand(), 7_000),
+        ];
+
+        let expected_md_bucket = vec![];
+
+        let expected_lo_bucket = vec![
+            (Pubkey::new_rand(), 4_000),
+            (Pubkey::new_rand(), 3_000),
+            (Pubkey::new_rand(), 2_000),
+        ];
+
+        results.extend(expected_hi_bucket.iter());
+        results.extend(expected_md_bucket.iter());
+        results.extend(expected_lo_bucket.iter());
+        results.push((Pubkey::new_rand(), 1_000));
+
+        let bucket_winners = bucket_winners(&results);
+
+        assert_eq!(bucket_winners[0].1, normalize_winners(&expected_hi_bucket));
+        assert_eq!(bucket_winners[1].1, normalize_winners(&expected_md_bucket));
+        assert_eq!(bucket_winners[2].1, normalize_winners(&expected_lo_bucket));
+    }
+}

--- a/tds-prize-tool/src/rewards_earned.rs
+++ b/tds-prize-tool/src/rewards_earned.rs
@@ -1,3 +1,13 @@
+//! Calculates the winners of the "Most Rewards Earned" category in Tour de Sol by summing the
+//! balances of all stake and vote accounts attributed to a particular validator.
+//!
+//! The top 3 validators will receive the top prizes and validators will be awarded additional
+//! prizes if they place into the following buckets:
+//!
+//! `hi` - Top 25%
+//! `md` - Top 25-50%
+//! `lo` - Top 50-90%
+
 use crate::prize::{self, Winner, Winners};
 use solana_runtime::bank::Bank;
 use solana_sdk::account::Account;
@@ -66,9 +76,6 @@ fn validator_rewards(
 }
 
 // Bucket validators for reward distribution
-// - (1) Top 25% of reward earners
-// - (2) Top 25-50% of reward earners
-// - (3) Top 50-90% of reward earners
 fn bucket_winners(results: &[(Pubkey, i64)]) -> Vec<(String, Vec<Winner>)> {
     let num_validators = results.len();
     let mut bucket_winners = Vec::new();

--- a/tds-prize-tool/src/utils.rs
+++ b/tds-prize-tool/src/utils.rs
@@ -1,3 +1,0 @@
-pub(crate) fn sol_to_lamports(sol: f64) -> u64 {
-    (sol * 2u64.pow(34) as f64) as u64
-}

--- a/tds-prize-tool/src/utils.rs
+++ b/tds-prize-tool/src/utils.rs
@@ -1,0 +1,3 @@
+pub(crate) fn sol_to_lamports(sol: f64) -> u64 {
+    (sol * 2u64.pow(34) as f64) as u64
+}


### PR DESCRIPTION
#### Problem
Need transparent deterministic tooling for determining the winners of TdS

#### Summary of Changes
1. Create a new CLI tool which behaves similarly to `ledger-tool` for the purpose of computing the TdS prize winners. This new tool will be moved to https://github.com/solana-labs/tour-de-sol once required runtime changes are shipped to crates.io
2. Compute the winners for the "Most Rewards Earned" category ([TdS Compensation Design](https://forums.solana.com/t/tour-de-sol-stage-1-preliminary-compensation-design/79)) by summing the balances of the vote and stake accounts which are attributed to a particular validator.

Fixes #6077
Depends on #6184 
