### PR TITLE
Optimize BPF logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3098,7 +3098,7 @@ dependencies = [
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-logger 0.20.0",
  "solana-sdk 0.20.0",
- "solana_rbpf 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_rbpf 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -4364,7 +4364,7 @@ dependencies = [
 
 [[package]]
 name = "solana_rbpf"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5714,7 +5714,7 @@ dependencies = [
 "checksum solana_libra_vm_cache_map 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9f0abd2cc72c7d76ca9e0764e3f1fa01a01f49b9014a193f2a3fe735a034bf96"
 "checksum solana_libra_vm_genesis 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4dadfcf5fabfd28d09770d698c618a48d75819f6915bd8bdfa04b93b6e492530"
 "checksum solana_libra_vm_runtime 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "055a5de29d1b8a2b9f9e20293e07998b8e188164bbe6ac8a09260043f99379aa"
-"checksum solana_rbpf 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)" = "c7a69e553372557cfb6cf35396b8ddb65d3ccb7a0bb3fee3fba690b6ebd9c9d9"
+"checksum solana_rbpf 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)" = "cb45776e861c7a71ed3ccb629c076889dc91a9ba7c1e58e44f8c7b9f916f07c9"
 "checksum solicit 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "172382bac9424588d7840732b250faeeef88942e37b6e35317dce98cafdd75b2"
 "checksum sourcefile 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4bf77cb82ba8453b42b6ae1d692e4cdc92f9a47beaf89a847c8be83f4e328ad3"
 "checksum spin 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "ceac490aa12c567115b40b7b7fceca03a6c9d53d5defea066123debc83c5dc1f"

--- a/core/src/entry.rs
+++ b/core/src/entry.rs
@@ -555,5 +555,4 @@ mod tests {
         bad_ticks[1].hash = one;
         assert!(!bad_ticks.verify(&one)); // inductive step, bad
     }
-
 }

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -971,12 +971,12 @@ dependencies = [
 
 [[package]]
 name = "num-derive"
-version = "0.2.5"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1536,7 +1536,7 @@ dependencies = [
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-logger 0.20.0",
  "solana-sdk 0.20.0",
- "solana_rbpf 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_rbpf 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1560,7 +1560,7 @@ dependencies = [
  "solana-logger 0.20.0",
  "solana-runtime 0.20.0",
  "solana-sdk 0.20.0",
- "solana_rbpf 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_rbpf 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 2.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1803,7 +1803,7 @@ dependencies = [
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "memmap 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-derive 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1828,7 +1828,7 @@ version = "0.20.0"
 dependencies = [
  "bincode 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-derive 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1857,7 +1857,7 @@ dependencies = [
  "assert_matches 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bincode 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-derive 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1872,7 +1872,7 @@ version = "0.20.0"
 dependencies = [
  "bincode 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-derive 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1893,7 +1893,7 @@ dependencies = [
 
 [[package]]
 name = "solana_rbpf"
-version = "0.1.17"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2605,7 +2605,7 @@ dependencies = [
 "checksum net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88"
 "checksum nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9667ddcc6cc8a43afc9b7917599d7216aa09c463919ea32c59ed6cac8bc945"
 "checksum nom 4.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2ad2a91a8e869eeb30b9cb3119ae87773a8f4ae617f41b1eb9c154b2905f7bd6"
-"checksum num-derive 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "eafd0b45c5537c3ba526f79d3e75120036502bebacbb3f3220914067ce39dbf2"
+"checksum num-derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0c8b15b261814f992e33760b1fca9fe8b693d8a65299f20c9901688636cfb746"
 "checksum num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)" = "b85e541ef8255f6cf42bbfe4ef361305c6c135d10919ecc26126c4e5ae94bc09"
 "checksum num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "92e5113e9fd4cc14ded8e499429f396a20f98c772a47cc8622a736e1ec843c31"
 "checksum num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "6ba9a427cfca2be13aa6f6403b0b7e7368fe982bfa16fccc450ce74c46cd9b32"
@@ -2669,7 +2669,7 @@ dependencies = [
 "checksum slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 "checksum smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "ab606a9c5e214920bb66c458cd7be8ef094f813f20fe77a54cc7dbfff220d4b7"
 "checksum solana-ed25519-dalek 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1c21f9d5aa62959872194dfd086feb4e8efec1c2589d27e6a0339904759e99fc"
-"checksum solana_rbpf 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)" = "c5a7a30cf5e51a48137e572c44bc818b9f8f38cdf1dab73a76dd082410175073"
+"checksum solana_rbpf 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)" = "cb45776e861c7a71ed3ccb629c076889dc91a9ba7c1e58e44f8c7b9f916f07c9"
 "checksum sourcefile 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4bf77cb82ba8453b42b6ae1d692e4cdc92f9a47beaf89a847c8be83f4e328ad3"
 "checksum spin 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"

--- a/programs/bpf/Cargo.toml
+++ b/programs/bpf/Cargo.toml
@@ -26,7 +26,7 @@ solana-bpf-loader-api = { path = "../bpf_loader_api", version = "0.20.0" }
 solana-logger = { path = "../../logger", version = "0.20.0" }
 solana-runtime = { path = "../../runtime", version = "0.20.0" }
 solana-sdk = { path = "../../sdk", version = "0.20.0" }
-solana_rbpf = "=0.1.18"
+solana_rbpf = "=0.1.19"
 
 [[bench]]
 name = "bpf_loader"

--- a/programs/bpf_loader_api/Cargo.toml
+++ b/programs/bpf_loader_api/Cargo.toml
@@ -16,7 +16,7 @@ log = "0.4.8"
 serde = "1.0.101"
 solana-logger = { path = "../../logger", version = "0.20.0" }
 solana-sdk = { path = "../../sdk", version = "0.20.0" }
-solana_rbpf = "=0.1.18"
+solana_rbpf = "=0.1.19"
 
 [lib]
 crate-type = ["lib"]

--- a/programs/bpf_loader_api/src/helpers.rs
+++ b/programs/bpf_loader_api/src/helpers.rs
@@ -113,7 +113,6 @@ pub fn helper_sol_log(
                     info!("info!: {}", message);
                     return Ok(0);
                 }
-         
             }
         }
         Err(Error::new(

--- a/programs/bpf_loader_api/src/helpers.rs
+++ b/programs/bpf_loader_api/src/helpers.rs
@@ -101,23 +101,28 @@ pub fn helper_sol_log(
     ro_regions: &[MemoryRegion],
     _rw_regions: &[MemoryRegion],
 ) -> Result<(u64), Error> {
-    let host_addr = translate_addr(addr, len as usize, "Load", 0, ro_regions)?;
-    let c_buf: *const c_char = host_addr as *const c_char;
-    unsafe {
-        for i in 0..len {
-            let c = std::ptr::read(c_buf.offset(i as isize));
-            if i == len - 1 || c == 0 {
-                let message =
-                    from_utf8(from_raw_parts(host_addr as *const u8, len as usize)).unwrap();
-                info!("info!: {}", message);
-                return Ok(0);
+    if log_enabled!(log::Level::Info) {
+        let host_addr = translate_addr(addr, len as usize, "Load", 0, ro_regions)?;
+        let c_buf: *const c_char = host_addr as *const c_char;
+        unsafe {
+            for i in 0..len {
+                let c = std::ptr::read(c_buf.offset(i as isize));
+                if i == len - 1 || c == 0 {
+                    let message =
+                        from_utf8(from_raw_parts(host_addr as *const u8, len as usize)).unwrap();
+                    info!("info!: {}", message);
+                    return Ok(0);
+                }
+         
             }
         }
+        Err(Error::new(
+            ErrorKind::Other,
+            "Error: Unterminated string logged",
+        ))
+    } else {
+        Ok(0)
     }
-    Err(Error::new(
-        ErrorKind::Other,
-        "Error: Unterminated string logged",
-    ))
 }
 
 pub fn helper_sol_log_u64(
@@ -130,10 +135,12 @@ pub fn helper_sol_log_u64(
     _ro_regions: &[MemoryRegion],
     _rw_regions: &[MemoryRegion],
 ) -> Result<(u64), Error> {
-    info!(
-        "info!: {:#x}, {:#x}, {:#x}, {:#x}, {:#x}",
-        arg1, arg2, arg3, arg4, arg5
-    );
+    if log_enabled!(log::Level::Info) {
+        info!(
+            "info!: {:#x}, {:#x}, {:#x}, {:#x}, {:#x}",
+            arg1, arg2, arg3, arg4, arg5
+        );
+    }
     Ok(0)
 }
 

--- a/programs/exchange_api/src/lib.rs
+++ b/programs/exchange_api/src/lib.rs
@@ -25,5 +25,4 @@ pub mod faucet {
         EXCHANGE_FAUCET_ID,
         "ExchangeFaucet11111111111111111111111111111"
     );
-
 }

--- a/programs/stake_api/src/stake_instruction.rs
+++ b/programs/stake_api/src/stake_instruction.rs
@@ -178,7 +178,8 @@ fn metas_for_authorized_signer(
 
     // append signer at the end
     if !is_own_signer {
-        account_metas.push(AccountMeta::new_credit_only(*authorized_signer, true)) // signer
+        account_metas.push(AccountMeta::new_credit_only(*authorized_signer, true))
+        // signer
     }
 
     account_metas
@@ -641,5 +642,4 @@ mod tests {
             pretty_err::<StakeError>(StakeError::NoCreditsToRedeem.into())
         )
     }
-
 }

--- a/programs/vote_api/src/vote_instruction.rs
+++ b/programs/vote_api/src/vote_instruction.rs
@@ -103,7 +103,8 @@ fn metas_for_authorized_signer(
 
     // append signer at the end
     if !is_own_signer {
-        account_metas.push(AccountMeta::new_credit_only(*authorized_signer, true)) // signer
+        account_metas.push(AccountMeta::new_credit_only(*authorized_signer, true))
+        // signer
     }
 
     account_metas
@@ -337,5 +338,4 @@ mod tests {
             pretty_err::<VoteError>(VoteError::VoteTooOld.into())
         )
     }
-
 }

--- a/runtime/src/stakes.rs
+++ b/runtime/src/stakes.rs
@@ -509,5 +509,4 @@ pub mod tests {
             assert_eq!(vote_accounts.get(&vote_pubkey).unwrap().0, 0);
         }
     }
-
 }

--- a/runtime/src/status_cache.rs
+++ b/runtime/src/status_cache.rs
@@ -434,5 +434,4 @@ mod tests {
     fn test_age_sanity() {
         assert!(MAX_CACHE_ENTRIES <= MAX_RECENT_BLOCKHASHES);
     }
-
 }

--- a/sdk/src/account_utils.rs
+++ b/sdk/src/account_utils.rs
@@ -57,5 +57,4 @@ mod tests {
         let stored_state: u64 = account.state().unwrap();
         assert_eq!(stored_state, state);
     }
-
 }

--- a/sdk/src/genesis_block.rs
+++ b/sdk/src/genesis_block.rs
@@ -243,5 +243,4 @@ mod tests {
         assert_eq!(block.hash(), loaded_block.hash());
         let _ignored = std::fs::remove_file(&path);
     }
-
 }

--- a/sdk/src/hash.rs
+++ b/sdk/src/hash.rs
@@ -134,5 +134,4 @@ mod tests {
             Err(ParseHashError::Invalid)
         );
     }
-
 }

--- a/sdk/src/signature.rs
+++ b/sdk/src/signature.rs
@@ -235,5 +235,4 @@ mod tests {
             Err(ParseSignatureError::Invalid)
         );
     }
-
 }


### PR DESCRIPTION
#### Problem

Whether or not `info` is enabled for the bpf_loader_api module the BPF log messages are still formatted even if they are not sent.

#### Summary of Changes

Check if the message is actually enabled before incurring the formatting overhead.  When running a program that prints 1000 messages this optimization cuts the time program execution time in half.

Fixes #
