### PR TITLE
Add full spend recent blockhash sentinel

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -20,7 +20,10 @@ use solana_ledger::{
 };
 use solana_measure::measure::Measure;
 use solana_metrics::{inc_new_counter_debug, inc_new_counter_info, inc_new_counter_warn};
-use solana_runtime::{accounts_db::ErrorCounters, bank::Bank, transaction_batch::TransactionBatch};
+use solana_runtime::{
+    accounts_db::ErrorCounters, bank::Bank, blockhash_queue::HashAgeKind,
+    transaction_batch::TransactionBatch,
+};
 use solana_sdk::clock::MAX_TRANSACTION_FORWARDING_DELAY_GPU;
 use solana_sdk::{
     clock::{
@@ -648,7 +651,7 @@ impl BankingStage {
     // This function returns a vector containing index of all valid transactions. A valid
     // transaction has result Ok() as the value
     fn filter_valid_transaction_indexes(
-        valid_txs: &[transaction::Result<()>],
+        valid_txs: &[transaction::Result<HashAgeKind>],
         transaction_indexes: &[usize],
     ) -> Vec<usize> {
         let valid_transactions = valid_txs
@@ -1497,10 +1500,10 @@ mod tests {
                 &vec![
                     Err(TransactionError::BlockhashNotFound),
                     Err(TransactionError::BlockhashNotFound),
-                    Ok(()),
+                    Ok(HashAgeKind::Extant),
                     Err(TransactionError::BlockhashNotFound),
-                    Ok(()),
-                    Ok(())
+                    Ok(HashAgeKind::Extant),
+                    Ok(HashAgeKind::Extant),
                 ],
                 &vec![2, 4, 5, 9, 11, 13]
             ),
@@ -1510,12 +1513,12 @@ mod tests {
         assert_eq!(
             BankingStage::filter_valid_transaction_indexes(
                 &vec![
-                    Ok(()),
+                    Ok(HashAgeKind::Extant),
                     Err(TransactionError::BlockhashNotFound),
                     Err(TransactionError::BlockhashNotFound),
-                    Ok(()),
-                    Ok(()),
-                    Ok(())
+                    Ok(HashAgeKind::Extant),
+                    Ok(HashAgeKind::Extant),
+                    Ok(HashAgeKind::Extant),
                 ],
                 &vec![1, 6, 7, 9, 31, 43]
             ),

--- a/core/src/poh_recorder.rs
+++ b/core/src/poh_recorder.rs
@@ -1296,7 +1296,7 @@ mod tests {
                 poh_recorder.tick();
             }
             poh_recorder.set_bank(&bank.clone());
-            assert!(!bank.check_hash_age(&genesis_blockhash, 1));
+            assert!(bank.check_hash_age(&genesis_blockhash, 1).is_err());
         }
     }
 

--- a/runtime/src/blockhash_queue.rs
+++ b/runtime/src/blockhash_queue.rs
@@ -54,7 +54,7 @@ impl BlockhashQueue {
     pub fn check_hash_age(&self, hash: &Hash, max_age: usize) -> bool {
         let hash_age = self.ages.get(hash);
         match hash_age {
-            Some(age) => self.hash_height - age.hash_height <= max_age as u64,
+            Some(age) => Self::check_age(self.hash_height, max_age, age),
             _ => false,
         }
     }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -4,7 +4,7 @@ pub mod accounts_index;
 pub mod append_vec;
 pub mod bank;
 pub mod bank_client;
-mod blockhash_queue;
+pub mod blockhash_queue;
 pub mod bloom;
 pub mod genesis_utils;
 pub mod loader_utils;

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -4,6 +4,7 @@ pub mod bpf_loader;
 pub mod clock;
 pub mod epoch_schedule;
 pub mod fee_calculator;
+#[macro_use]
 pub mod hash;
 pub mod inflation;
 pub mod instruction;

--- a/sdk/src/transaction.rs
+++ b/sdk/src/transaction.rs
@@ -64,6 +64,9 @@ pub enum TransactionError {
 
     /// Transaction contains an invalid account reference
     InvalidAccountIndex,
+
+    /// Fee account fo transaction marked "full spend" would still carry a balance
+    ExcessBalance,
 }
 
 pub type Result<T> = result::Result<T, TransactionError>;

--- a/sdk/src/transaction.rs
+++ b/sdk/src/transaction.rs
@@ -9,6 +9,19 @@ use crate::signature::{KeypairUtil, Signature};
 use bincode::serialize;
 use std::result;
 
+pub mod full_spend_blockhash {
+    const FULL_SPEND_BLOCKHASH: [u8; 32] = [
+        0x03, 0xd0, 0xed, 0x95, 0x9c, 0x7d, 0x80, 0xeb, 0x88, 0xd0, 0xed, 0x4d, 0x07, 0x5b, 0x5f,
+        0x30, 0xfb, 0x6d, 0x16, 0xca, 0xb8, 0xa2, 0x89, 0x45, 0x40, 0x9c, 0xbe, 0x08, 0x00, 0x00,
+        0x00, 0x00,
+    ];
+
+    cardinal_name_hash!(
+        FULL_SPEND_BLOCKHASH,
+        "Fu11Spend1111111111111111111111111111111111"
+    );
+}
+
 /// Reasons a transaction might be rejected.
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub enum TransactionError {


### PR DESCRIPTION
#### Problem

Custodial services need much longer to sign a transaction than our current replay protection allows.

#### Summary of Changes

Remove dupe code
Preparatory return type adjustment
Introduce full spend recent blockhash sentinel value

Fixes #1982

This is a first pass.  I couldn't find where we ever came to a conclusion as to whether or not consensus should validate that the transaction indeed fully spends the account balance, so I didn't implement that here.