### PR TITLE
Bump BPF instruction cap

### DIFF
--- a/programs/bpf_loader_api/src/lib.rs
+++ b/programs/bpf_loader_api/src/lib.rs
@@ -28,7 +28,7 @@ use std::mem;
 pub fn create_vm(prog: &[u8]) -> Result<(EbpfVm, MemoryRegion), Error> {
     let mut vm = EbpfVm::new(None)?;
     vm.set_verifier(bpf_verifier::check)?;
-    vm.set_max_instruction_count(36000)?;
+    vm.set_max_instruction_count(100_000)?;
     vm.set_elf(&prog)?;
 
     let heap_region = helpers::register_helpers(&mut vm)?;


### PR DESCRIPTION
#### Problem

BPF Loader's initial cap on the number of instructions that may be executed was a wag. 

#### Summary of Changes

Some developers may use bincode or do other expensive operations and these can lead to higher instruction counts than the current cap.  Bump up the cap so we don't limit developers unnecessarily.. 

Fixes #
