### PR TITLE
Fix date formatting to work on Mac OS

### DIFF
--- a/scripts/metrics-write-datapoint.sh
+++ b/scripts/metrics-write-datapoint.sh
@@ -9,7 +9,7 @@ if [[ -z $point ]]; then
   exit 1
 fi
 
-echo "[$(date --iso-8601=seconds)] Influx data point: $point"
+echo "[$(date -u +"%Y-%m-%dT%H:%M:%SZ")] Influx data point: $point"
 if [[ -z $INFLUX_DATABASE || -z $INFLUX_USERNAME || -z $INFLUX_PASSWORD ]]; then
   echo Influx user credentials not found
   exit 0


### PR DESCRIPTION
#### Problem

Recent timestamp formatting does not work on Mac OS.

#### Summary of Changes

Apply `date` options that work on GNU and OSX