### PR TITLE
Add Bankless Leader design

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -54,6 +54,7 @@
   * [Rent](proposals/rent.md)
   * [Inter-chain Transaction Verification](proposals/interchain-transaction-verification.md)
   * [Snapshot Verification](proposals/snapshot-verification.md)
+  * [Bankless Leader](proposals/bankless-leader.md)
 * [Implemented Design Proposals](implemented-proposals/README.md)
   * [Blocktree](implemented-proposals/blocktree.md)
   * [Cluster Software Installation and Updates](implemented-proposals/installer.md)

--- a/book/src/proposals/bankless-leader.md
+++ b/book/src/proposals/bankless-leader.md
@@ -29,6 +29,7 @@ entire duration of the cache.  At the block boundary, the cache can
 be reset along with the base fork after replay stage finishes
 verifying the previous block.
 
+
 ## Balance Check
 
 Prior to the balance check, the leader validates all the signatures
@@ -64,6 +65,19 @@ while the replay stage for the first block is playing.
 When the leader finishes the replay stage it can reset the balance
 cache by clearing it, and set a new fork as the base for the
 cache which can become active on the next block.
+
+## Reseting the Balance Cache
+
+1. At the start of the block, if the balance cache is uninitialized,
+set the base fork for the balance cache to be the parent of the
+block and create an empty cache.
+
+2. if the cache is initialized, check if block's parents has a new
+finalized bank that is newer than the current base fork for the
+balance cache.
+
+3. if a parent newer than the cache's base fork exist, reset the
+cache to the parent.
 
 ## Impact on Clients
 

--- a/book/src/proposals/bankless-leader.md
+++ b/book/src/proposals/bankless-leader.md
@@ -89,4 +89,4 @@ should use a dedicated fee account that is not used as Credit-Debit
 in any instruction.
 
 Once an account fee is used as Credit-Debit, it will fail the
-balance check for the remainder of the block.
+balance check until the balance cache is reset.

--- a/book/src/proposals/bankless-leader.md
+++ b/book/src/proposals/bankless-leader.md
@@ -10,17 +10,17 @@ execution of well formed entries.  For transactions that have
 low execution costs, the leader does 3x more memory operations
 before any bank execution than the validator.
 
-## Execution Key
+## Fee Account
 
-The [execution key](terminology.md#execution_key) pays for the
+The [fee account](terminology.md#fee_account) pays for the
 transaction to be included in the block.  The leader only needs to
-validate that the execution key has the balance to pay for the
+validate that the fee account has the balance to pay for the
 fee.
 
 ## Balance Cache
 
 For the duration of the block, the leader maintains a temporary
-balance cache for all the processed execution keys.  The cache is
+balance cache for all the processed fee accounts.  The cache is
 a map of pubkeys to lamports.
 
 At the start of the block the balance cache is empty.  At the end
@@ -33,8 +33,8 @@ in the transaction.
 
 1. Verify the accounts are not in use and BlockHash is valid.
 
-2. Check if the key is present in the cache, or load the key from
-accounts\_db and store the key and the last lamport balance in the
+2. Check if the fee account is present in the cache, or load the
+account from accounts\_db and store the lamport balance in the
 cache.
 
 3. If the balance is less than the fee, drop the transaction.
@@ -43,7 +43,7 @@ cache.
 
 5. For all the keys in the transaction that are Credit-Debit and
 are referenced by an instruction, reduce their balance to 0 in the
-cache.  The execution key is declared as Credit-Debit, but as long
+cache.  The account fee is declared as Credit-Debit, but as long
 as it is not used in any instruction its balance will not be reduced
 to 0.
 
@@ -54,12 +54,12 @@ replay stage operation.
 
 ## Impact on Clients
 
-The same execution key can be reused many times in the same block
-until it is used once as a Credit-Debit key by an instruction.
+The same fee account can be reused many times in the same block
+until it is used once as Credit-Debit by an instruction.
 
 Clients that transmit a large number of transactions per second
-should use a dedicated execution key that is not used as Credit-Debit
+should use a dedicated fee account that is not used as Credit-Debit
 in any instruction.
 
-Once a execution key is used as Credit-Debit, it will fail the
+Once an account fee is used as Credit-Debit, it will fail the
 balance check for the remainder of the block.

--- a/book/src/proposals/bankless-leader.md
+++ b/book/src/proposals/bankless-leader.md
@@ -8,6 +8,19 @@ needs to reassemble the block and replay execution of well formed
 entries.  The leader does 3x more memory operations before any bank
 execution than the validator per processed transaction.
 
+## Rationale
+
+Normal bank operation for a spend needs to do 2 loads and 2 stores.
+With this design leader just does 1 load. so 4x less account\_db
+work before generating the block. The store operations are likely
+to be more expensive than reads.
+
+When replay stage starts processing the same transactions, it can
+assume that PoH is valid, and that all the entries are safe for
+parallel execution.  The fee accounts that have been loaded to
+produce the block are likely to still be in memory, so the additional
+load should be warm and the cost is likely to be amortized.
+
 ## Fee Account
 
 The [fee account](terminology.md#fee_account) pays for the

--- a/book/src/proposals/bankless-leader.md
+++ b/book/src/proposals/bankless-leader.md
@@ -7,8 +7,8 @@ the entries and broadcasting the shreds.
 
 While a validator only needs to reassemble the block and replay
 execution of well formed entries.  For transactions that have
-low execution costs, the leader does 3x more memory operations than
-the validator.
+low execution costs, the leader does 3x more memory operations
+before any bank execution than the validator.
 
 ## Execution Key
 
@@ -28,6 +28,9 @@ of the block the cache is destroyed.
 
 ## Balance Check
 
+Prior to the balance check, the leader validates all the signatures
+in the transaction.
+
 1. Verify the accounts are not in use and BlockHash is valid.
 
 2. Check if the key is present in the cache, or load the key from
@@ -38,8 +41,10 @@ cache.
 
 4. Subtract the fee from the balance.
 
-5. For all the keys in the transaction that are used as Credit-Debit,
-mark their balance as 0 by storing the balance in the cache.
+5. For all the keys in the transaction that are Credit-Debit and
+are referenced by an instruction, mark their balance as 0 in the
+cache.  The execution key can be declared as Credit-Debit as long
+as it is not used in any instruction.
 
 ## Leader Replay
 
@@ -53,7 +58,7 @@ until it is used once as a Credit-Debit key.
 
 Clients that transmit a large number of transactions per second
 should use a dedicated execution key that is not used as Credit-Debit
-in any transactions.
+in any instruction.
 
 Once a execution key is used as Credit-Debit, it will fail the
 balance check for the remainder of the block.

--- a/book/src/proposals/bankless-leader.md
+++ b/book/src/proposals/bankless-leader.md
@@ -73,7 +73,7 @@ set the base fork for the balance cache to be the parent of the
 block and create an empty cache.
 
 2. if the cache is initialized, check if block's parents has a new
-finalized bank that is newer than the current base fork for the
+frozen bank that is newer than the current base fork for the
 balance cache.
 
 3. if a parent newer than the cache's base fork exist, reset the

--- a/book/src/proposals/bankless-leader.md
+++ b/book/src/proposals/bankless-leader.md
@@ -3,12 +3,10 @@
 A bankless leader does the minimum amount of work to produce a valid
 block.  The leader is tasked with ingress transactions, sorting and
 filtering valid transactions, arranging them into entries, shredding
-the entries and broadcasting the shreds.
-
-While a validator only needs to reassemble the block and replay
-execution of well formed entries.  For transactions that have
-low execution costs, the leader does 3x more memory operations
-before any bank execution than the validator.
+the entries and broadcasting the shreds.  While a validator only
+needs to reassemble the block and replay execution of well formed
+entries.  The leader does 3x more memory operations before any bank
+execution than the validator per processed transaction.
 
 ## Fee Account
 

--- a/book/src/proposals/bankless-leader.md
+++ b/book/src/proposals/bankless-leader.md
@@ -17,12 +17,17 @@ fee.
 
 ## Balance Cache
 
-For the duration of the block, the leader maintains a temporary
-balance cache for all the processed fee accounts.  The cache is
-a map of pubkeys to lamports.
+For the duration of the leaders consecutive blocks, the leader
+maintains a temporary balance cache for all the processed fee
+accounts.  The cache is a map of pubkeys to lamports.
 
-At the start of the block the balance cache is empty.  At the end
-of the block the cache is destroyed.
+At the start of the first block the balance cache is empty.  At the
+end of the last block the cache is destroyed.
+
+The balance cache lookups must reference the same base fork for the
+entire duration of the cache.  At the block boundary, the cache can
+be reset along with the base fork after replay stage finishes
+verifying the previous block.
 
 ## Balance Check
 
@@ -47,8 +52,18 @@ to 0.
 
 ## Leader Replay
 
-Leaders will need to replay their block as part of the standard
+Leaders will need to replay their blocks as part of the standard
 replay stage operation.
+
+## Leader Replay With Consecutive Blocks
+
+A leader can be scheduled to produce multiple blocks in a row.  In
+that scenario the leader is likely to be producing the next block
+while the replay stage for the first block is playing.
+
+When the leader finishes the replay stage it can reset the balance
+cache by clearing it, and set a new fork as the base for the
+cache which can become active on the next block.
 
 ## Impact on Clients
 

--- a/book/src/proposals/bankless-leader.md
+++ b/book/src/proposals/bankless-leader.md
@@ -1,0 +1,42 @@
+# Bankless Leader
+
+A bankless leader does the minimum amount of work to produce a valid
+block.  The leader is tasked with ingress transactions, sorting and
+filtering valid transactions, arranging them into entries, shreding
+the entries and broadcasting the shreds.  While a validator only
+needs to reassemble the block and replay it.
+
+
+## Execution Key Balance Check
+
+The [execution key](terminology.md#execution_key) pays for the
+transaction to be included in the block.  The leader only needs to
+validate that the execution key has the balance to pay for the
+transaction fee.
+
+1. Verify the accounts are not in use and BankHash is valid.
+
+2. check if the key is present in the cache, or load the key from
+accounts\_db and store the key and the last lamport balance in the
+cache.
+
+3. if the balance is less than the fee, drop the transaction.
+
+4. subtract the fee from the balance
+
+5. for all the keys in the transaction that are used as Credit-Debit,
+mark their balance as 0 by storing the balance in the cache.
+
+## Leader Replay
+
+Leaders will need to replay their block as part of the standard
+replay stage operation.
+
+## Impact on Clients
+
+The same execution key can be reused many times in the same block
+until it is used once as a Credit-Debit key.
+
+Clients that transmit a large number of transactions per second
+should use a dedicated execution key that is not used as Credit-Debit
+in any transactions.

--- a/book/src/proposals/bankless-leader.md
+++ b/book/src/proposals/bankless-leader.md
@@ -42,9 +42,10 @@ cache.
 4. Subtract the fee from the balance.
 
 5. For all the keys in the transaction that are Credit-Debit and
-are referenced by an instruction, mark their balance as 0 in the
-cache.  The execution key can be declared as Credit-Debit as long
-as it is not used in any instruction.
+are referenced by an instruction, reduce their balance to 0 in the
+cache.  The execution key is declared as Credit-Debit, but as long
+as it is not used in any instruction its balance will not be reduced
+to 0.
 
 ## Leader Replay
 
@@ -54,7 +55,7 @@ replay stage operation.
 ## Impact on Clients
 
 The same execution key can be reused many times in the same block
-until it is used once as a Credit-Debit key.
+until it is used once as a Credit-Debit key by an instruction.
 
 Clients that transmit a large number of transactions per second
 should use a dedicated execution key that is not used as Credit-Debit

--- a/book/src/proposals/bankless-leader.md
+++ b/book/src/proposals/bankless-leader.md
@@ -2,29 +2,43 @@
 
 A bankless leader does the minimum amount of work to produce a valid
 block.  The leader is tasked with ingress transactions, sorting and
-filtering valid transactions, arranging them into entries, shreding
-the entries and broadcasting the shreds.  While a validator only
-needs to reassemble the block and replay it.
+filtering valid transactions, arranging them into entries, shredding
+the entries and broadcasting the shreds.
 
+While a validator only needs to reassemble the block and replay
+execution of well formed entries.  For transactions that have
+low execution costs, the leader does 3x more memory operations than
+the validator.
 
-## Execution Key Balance Check
+## Execution Key
 
 The [execution key](terminology.md#execution_key) pays for the
 transaction to be included in the block.  The leader only needs to
 validate that the execution key has the balance to pay for the
-transaction fee.
+fee.
 
-1. Verify the accounts are not in use and BankHash is valid.
+## Balance Cache
 
-2. check if the key is present in the cache, or load the key from
+For the duration of the block, the leader maintains a temporary
+balance cache for all the processed execution keys.  The cache is
+a map of pubkeys to lamports.
+
+At the start of the block the balance cache is empty.  At the end
+of the block the cache is destroyed.
+
+## Balance Check
+
+1. Verify the accounts are not in use and BlockHash is valid.
+
+2. Check if the key is present in the cache, or load the key from
 accounts\_db and store the key and the last lamport balance in the
 cache.
 
-3. if the balance is less than the fee, drop the transaction.
+3. If the balance is less than the fee, drop the transaction.
 
-4. subtract the fee from the balance
+4. Subtract the fee from the balance.
 
-5. for all the keys in the transaction that are used as Credit-Debit,
+5. For all the keys in the transaction that are used as Credit-Debit,
 mark their balance as 0 by storing the balance in the cache.
 
 ## Leader Replay
@@ -40,3 +54,6 @@ until it is used once as a Credit-Debit key.
 Clients that transmit a large number of transactions per second
 should use a dedicated execution key that is not used as Credit-Debit
 in any transactions.
+
+Once a execution key is used as Credit-Debit, it will fail the
+balance check for the remainder of the block.

--- a/book/src/terminology.md
+++ b/book/src/terminology.md
@@ -74,13 +74,13 @@ A globally unique identifier that is also a proof that the [entry](terminology.m
 
 The time, i.e. number of [slots](terminology.md#slot), for which a [leader schedule](terminology.md#leader-schedule) is valid.
 
-## execution key
-
-The key in the transaction that pays for the cost of including the transaction in the ledger.  This is the first key in the transaction.  This key must be declared as Credit-Debit since paying for the transaction reduces the account balance.
-
 ## fake storage proof
 
 A proof which has the same format as a storage proof, but the sha state is actually from hashing a known ledger value which the storage client can reveal and is also easily verifiable by the network on-chain.
+
+## fee account
+
+The fee account in the transaction is the account pays for the cost of including the transaction in the ledger.  This is the first account in the transaction.  This account must be declared as Credit-Debit in the transaction since paying for the transaction reduces the account balance.
 
 ## finality
 

--- a/book/src/terminology.md
+++ b/book/src/terminology.md
@@ -74,6 +74,10 @@ A globally unique identifier that is also a proof that the [entry](terminology.m
 
 The time, i.e. number of [slots](terminology.md#slot), for which a [leader schedule](terminology.md#leader-schedule) is valid.
 
+## execution key
+
+The key in the transaction that pays for the cost of including the transaction in the ledger.  This is the first key in the transaction.
+
 ## fake storage proof
 
 A proof which has the same format as a storage proof, but the sha state is actually from hashing a known ledger value which the storage client can reveal and is also easily verifiable by the network on-chain.

--- a/book/src/terminology.md
+++ b/book/src/terminology.md
@@ -76,7 +76,7 @@ The time, i.e. number of [slots](terminology.md#slot), for which a [leader sched
 
 ## execution key
 
-The key in the transaction that pays for the cost of including the transaction in the ledger.  This is the first key in the transaction.
+The key in the transaction that pays for the cost of including the transaction in the ledger.  This is the first key in the transaction.  This key must be declared as Credit-Debit since paying for the transaction reduces the account balance.
 
 ## fake storage proof
 


### PR DESCRIPTION
#### Problem

Leaders are a bottleneck on performance, since they have to do a lot of work of arranging transactions into well formed entries and shredding and broadcasting the entries to the rest of the network.  This CPU intensive work is competing for resources with the Bank.

#### Summary of Changes

Propose a design in which leaders skip execution of transactions and produce valid entries by only verifying that the transaction can afford to be included in the block.

Fixes #
