### PR TITLE
Bench tps: improve fund_keys

### DIFF
--- a/bench-tps/src/bench.rs
+++ b/bench-tps/src/bench.rs
@@ -560,9 +560,6 @@ pub fn fund_keys<T: Client>(
                 send_txs.stop();
                 debug!("send {} txs: {}us", to_fund_txs.len(), send_txs.as_us());
 
-                // retry anything that seems to have dropped through cracks
-                //  again since these txs are all or nothing, they're fine to
-                //  retry
                 let mut verify_txs = Measure::start("verify_txs");
                 let mut starting_txs = to_fund_txs.len();
                 let mut verified_txs = 0;
@@ -592,6 +589,9 @@ pub fn fund_keys<T: Client>(
                 verify_txs.stop();
                 debug!("verified {} txs: {}us", starting_txs, verify_txs.as_us());
 
+                // retry anything that seems to have dropped through cracks
+                //  again since these txs are all or nothing, they're fine to
+                //  retry
                 tries += 1;
             }
             println!("transferred");

--- a/bench-tps/src/bench.rs
+++ b/bench-tps/src/bench.rs
@@ -13,7 +13,7 @@ use solana_measure::measure::Measure;
 use solana_metrics::datapoint_info;
 use solana_sdk::{
     client::Client,
-    clock::{DEFAULT_TICKS_PER_SLOT, MAX_RECENT_BLOCKHASHES},
+    clock::{DEFAULT_TICKS_PER_SECOND, DEFAULT_TICKS_PER_SLOT, MAX_PROCESSING_AGE},
     fee_calculator::FeeCalculator,
     hash::Hash,
     pubkey::Pubkey,
@@ -34,10 +34,9 @@ use std::{
     time::{Duration, Instant},
 };
 
-// The point at which transactions become "too old", in seconds. The cluster keeps blockhashes for
-// approximately MAX_RECENT_BLOCKHASHES/DEFAULT_TICKS_PER_SLOT seconds. The adjustment of 5sec
-// seems about right to minimize BlockhashNotFound errors, based on empirical testing.
-const MAX_TX_QUEUE_AGE: u64 = MAX_RECENT_BLOCKHASHES as u64 / DEFAULT_TICKS_PER_SLOT - 5;
+// The point at which transactions become "too old", in seconds.
+const MAX_TX_QUEUE_AGE: u64 =
+    MAX_PROCESSING_AGE as u64 * DEFAULT_TICKS_PER_SECOND / DEFAULT_TICKS_PER_SLOT;
 
 #[cfg(feature = "move")]
 use solana_librapay_api::librapay_transaction;

--- a/bench-tps/src/cli.rs
+++ b/bench-tps/src/cli.rs
@@ -1,11 +1,8 @@
-use std::net::SocketAddr;
-use std::process::exit;
-use std::time::Duration;
-
 use clap::{crate_description, crate_name, crate_version, App, Arg, ArgMatches};
 use solana_drone::drone::DRONE_PORT;
 use solana_sdk::fee_calculator::FeeCalculator;
 use solana_sdk::signature::{read_keypair, Keypair, KeypairUtil};
+use std::{net::SocketAddr, process::exit, time::Duration};
 
 const NUM_LAMPORTS_PER_ACCOUNT_DEFAULT: u64 = 64 * 1024;
 

--- a/bench-tps/src/main.rs
+++ b/bench-tps/src/main.rs
@@ -1,3 +1,4 @@
+use log::*;
 use solana_bench_tps::bench::{do_bench_tps, generate_and_fund_keypairs, generate_keypairs};
 use solana_bench_tps::cli;
 use solana_core::gossip_service::{discover_cluster, get_multi_client};
@@ -5,11 +6,7 @@ use solana_genesis::PrimordialAccountDetails;
 use solana_sdk::fee_calculator::FeeCalculator;
 use solana_sdk::signature::{Keypair, KeypairUtil};
 use solana_sdk::system_program;
-use std::collections::HashMap;
-use std::fs::File;
-use std::io::prelude::*;
-use std::path::Path;
-use std::process::exit;
+use std::{collections::HashMap, fs::File, io::prelude::*, path::Path, process::exit};
 
 /// Number of signatures for all transactions in ~1 week at ~100K TPS
 pub const NUM_SIGNATURES_FOR_TXS: u64 = 100_000 * 60 * 60 * 24 * 7;
@@ -37,7 +34,7 @@ fn main() {
     } = &cli_config;
 
     if *write_to_client_file {
-        println!("Generating {} keypairs", *tx_count * 2);
+        info!("Generating {} keypairs", *tx_count * 2);
         let (keypairs, _) = generate_keypairs(&id, *tx_count as u64 * 2);
         let num_accounts = keypairs.len() as u64;
         let max_fee = FeeCalculator::new(*target_lamports_per_signature).max_lamports_per_signature;
@@ -57,7 +54,7 @@ fn main() {
             );
         });
 
-        println!("Writing {}", client_ids_and_stake_file);
+        info!("Writing {}", client_ids_and_stake_file);
         let serialized = serde_yaml::to_string(&accounts).unwrap();
         let path = Path::new(&client_ids_and_stake_file);
         let mut file = File::create(path).unwrap();
@@ -65,7 +62,7 @@ fn main() {
         return;
     }
 
-    println!("Connecting to the cluster");
+    info!("Connecting to the cluster");
     let (nodes, _replicators) =
         discover_cluster(&entrypoint_addr, *num_nodes).unwrap_or_else(|err| {
             eprintln!("Failed to discover {} nodes: {:?}", num_nodes, err);
@@ -86,7 +83,7 @@ fn main() {
         let path = Path::new(&client_ids_and_stake_file);
         let file = File::open(path).unwrap();
 
-        println!("Reading {}", client_ids_and_stake_file);
+        info!("Reading {}", client_ids_and_stake_file);
         let accounts: HashMap<String, PrimordialAccountDetails> =
             serde_yaml::from_reader(file).unwrap();
         let mut keypairs = vec![];


### PR DESCRIPTION
#### Problem
The `fund_keys()` step of bench-tps can take a really long time, and is completely silent about what is going on, leaving users wondering if the script is completely stalled, or what?

Analysis:
Funding transfer-verification loops in order to catch transactions that made it to the testnet node successfully, but weren't done processing by the time bench-tps client checked the account balance. But looping 10 times is excessive. In the case of dropped transactions, the client continues to re-check the same unchanged accounts 10 times, which can take an exceptionally long time for large transaction batches with slow communication with the testnet.
It is much faster to rebuild and resubmit the transactions.

I tested against a GCE testnet in us-west-1b, with GCE instance in the same region, a Mac laptop in Colorado, a GCE instance in asia-south1-b, and an Azure instance in West US.
(@sagar-solana , fwiw, I only saw significant dropped transactions on my laptop. Curious if that's what you're seeing, or just really slow communication with your testnet.)

#### Summary of Changes
- Loop funding verification fewer times: 3x for small transaction batches and only once for large batches
- Add print statements to update users on progress during large funding batches every 5sec
- Add debug logging for bench-tps users to optionally see timing info about funding steps and success/failure of funding transactions
- Also fixes old-blockhash math, which was empirically correct by accident

Toward #6163 
(Possibly "fixed enough for now"...?)
