### PR TITLE
Nit: Remove extra semi-colons

### DIFF
--- a/metrics/src/datapoint.rs
+++ b/metrics/src/datapoint.rs
@@ -176,7 +176,7 @@ mod test {
             ("bool", true, bool)
         );
         assert_eq!(point.name, "name");
-        assert_eq!(point.fields[0], ("i64", "1i".to_string()));;
+        assert_eq!(point.fields[0], ("i64", "1i".to_string()));
         assert_eq!(
             point.fields[1],
             ("String", "\"string space string\"".to_string())

--- a/programs/stake_api/src/stake_state.rs
+++ b/programs/stake_api/src/stake_state.rs
@@ -1418,7 +1418,7 @@ mod tests {
             std::mem::size_of::<StakeState>(),
             &id(),
         )
-        .expect("stake_account");;
+        .expect("stake_account");
 
         let to = Pubkey::new_rand();
         let mut to_account = Account::new(1, 0, &system_program::id());


### PR DESCRIPTION
#### Problem
Extra semicolons cause warnings in coverage CI build

#### Summary of Changes
Remove them
