### PR TITLE
Ensure all builds are triggered on a rust upgrade

### DIFF
--- a/ci/test-bench.sh
+++ b/ci/test-bench.sh
@@ -12,7 +12,8 @@ ci/affects-files.sh \
   .rs$ \
   Cargo.lock$ \
   Cargo.toml$ \
-  ci/test-bench.sh \
+  ^ci/rust-version.sh \
+  ^ci/test-bench.sh \
 || {
   annotate --style info --context test-bench \
     "Bench skipped as no .rs files were modified"

--- a/ci/test-coverage.sh
+++ b/ci/test-coverage.sh
@@ -12,8 +12,9 @@ ci/affects-files.sh \
   .rs$ \
   Cargo.lock$ \
   Cargo.toml$ \
-  ci/test-coverage.sh \
-  scripts/coverage.sh \
+  ^ci/rust-version.sh \
+  ^ci/test-coverage.sh \
+  ^scripts/coverage.sh \
 || {
   annotate --style info --context test-coverage \
     "Coverage skipped as no .rs files were modified"

--- a/ci/test-stable.sh
+++ b/ci/test-stable.sh
@@ -43,6 +43,7 @@ test-stable-perf)
     .rs$ \
     Cargo.lock$ \
     Cargo.toml$ \
+    ^ci/rust-version.sh \
     ^ci/test-stable-perf.sh \
     ^ci/test-stable.sh \
     ^ci/test-local-cluster.sh \


### PR DESCRIPTION
Rust 1.38 upgrade broke coverage and we didn't know until after it landed. 