### PR TITLE
clippy

### DIFF
--- a/programs/vote_api/src/vote_instruction.rs
+++ b/programs/vote_api/src/vote_instruction.rs
@@ -181,7 +181,7 @@ pub fn process_instruction(
     match deserialize(data).map_err(|_| InstructionError::InvalidInstructionData)? {
         VoteInstruction::InitializeAccount(vote_init) => {
             if rest.is_empty() {
-                Err(InstructionError::InvalidInstructionData)?;
+                return Err(InstructionError::InvalidInstructionData);
             }
             rent::verify_rent_exemption(me, &rest[0])?;
             vote_state::initialize_account(me, &vote_init)


### PR DESCRIPTION
Fyi, @ParthDesai , clippy now requires this syntax.
I think your pr was not rebased on Rust v1.38, which is why CI didn't pick it up
