### PR TITLE
Cli refactor: vote and storage program functionalities

### DIFF
--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -6,6 +6,7 @@ pub mod display;
 pub mod input_parsers;
 pub mod input_validators;
 pub mod stake;
+pub mod storage;
 pub mod validator_info;
 pub mod vote;
 pub mod wallet;

--- a/cli/src/storage.rs
+++ b/cli/src/storage.rs
@@ -1,0 +1,271 @@
+use crate::{
+    input_parsers::*,
+    input_validators::*,
+    wallet::{
+        check_account_for_fee, check_unique_pubkeys, log_instruction_custom_error, ProcessResult,
+        WalletCommand, WalletConfig, WalletError,
+    },
+};
+use clap::{App, Arg, ArgMatches, SubCommand};
+use solana_client::rpc_client::RpcClient;
+use solana_sdk::{
+    account_utils::State, message::Message, pubkey::Pubkey, signature::KeypairUtil,
+    system_instruction::SystemError, transaction::Transaction,
+};
+use solana_storage_api::storage_instruction::{self, StorageAccountType};
+
+pub trait StorageSubCommands {
+    fn storage_subcommands(self) -> Self;
+}
+
+impl StorageSubCommands for App<'_, '_> {
+    fn storage_subcommands(self) -> Self {
+        self.subcommand(
+            SubCommand::with_name("create-replicator-storage-account")
+                .about("Create a replicator storage account")
+                .arg(
+                    Arg::with_name("storage_account_owner")
+                        .index(1)
+                        .value_name("STORAGE ACCOUNT OWNER PUBKEY")
+                        .takes_value(true)
+                        .required(true)
+                        .validator(is_pubkey_or_keypair),
+                )
+                .arg(
+                    Arg::with_name("storage_account_pubkey")
+                        .index(2)
+                        .value_name("STORAGE ACCOUNT PUBKEY")
+                        .takes_value(true)
+                        .required(true)
+                        .validator(is_pubkey_or_keypair),
+                ),
+        )
+        .subcommand(
+            SubCommand::with_name("create-validator-storage-account")
+                .about("Create a validator storage account")
+                .arg(
+                    Arg::with_name("storage_account_owner")
+                        .index(1)
+                        .value_name("STORAGE ACCOUNT OWNER PUBKEY")
+                        .takes_value(true)
+                        .required(true)
+                        .validator(is_pubkey_or_keypair),
+                )
+                .arg(
+                    Arg::with_name("storage_account_pubkey")
+                        .index(2)
+                        .value_name("STORAGE ACCOUNT PUBKEY")
+                        .takes_value(true)
+                        .required(true)
+                        .validator(is_pubkey_or_keypair),
+                ),
+        )
+        .subcommand(
+            SubCommand::with_name("claim-storage-reward")
+                .about("Redeem storage reward credits")
+                .arg(
+                    Arg::with_name("node_account_pubkey")
+                        .index(1)
+                        .value_name("NODE PUBKEY")
+                        .takes_value(true)
+                        .required(true)
+                        .validator(is_pubkey_or_keypair)
+                        .help("The node account to credit the rewards to"),
+                )
+                .arg(
+                    Arg::with_name("storage_account_pubkey")
+                        .index(2)
+                        .value_name("STORAGE ACCOUNT PUBKEY")
+                        .takes_value(true)
+                        .required(true)
+                        .validator(is_pubkey_or_keypair)
+                        .help("Storage account address to redeem credits for"),
+                ),
+        )
+        .subcommand(
+            SubCommand::with_name("show-storage-account")
+                .about("Show the contents of a storage account")
+                .arg(
+                    Arg::with_name("storage_account_pubkey")
+                        .index(1)
+                        .value_name("STORAGE ACCOUNT PUBKEY")
+                        .takes_value(true)
+                        .required(true)
+                        .validator(is_pubkey_or_keypair)
+                        .help("Storage account pubkey"),
+                ),
+        )
+    }
+}
+
+pub fn parse_storage_create_replicator_account(
+    matches: &ArgMatches<'_>,
+) -> Result<WalletCommand, WalletError> {
+    let account_owner = pubkey_of(matches, "storage_account_owner").unwrap();
+    let storage_account_pubkey = pubkey_of(matches, "storage_account_pubkey").unwrap();
+    Ok(WalletCommand::CreateStorageAccount {
+        account_owner,
+        storage_account_pubkey,
+        account_type: StorageAccountType::Replicator,
+    })
+}
+
+pub fn parse_storage_create_validator_account(
+    matches: &ArgMatches<'_>,
+) -> Result<WalletCommand, WalletError> {
+    let account_owner = pubkey_of(matches, "storage_account_owner").unwrap();
+    let storage_account_pubkey = pubkey_of(matches, "storage_account_pubkey").unwrap();
+    Ok(WalletCommand::CreateStorageAccount {
+        account_owner,
+        storage_account_pubkey,
+        account_type: StorageAccountType::Validator,
+    })
+}
+
+pub fn parse_storage_claim_reward(matches: &ArgMatches<'_>) -> Result<WalletCommand, WalletError> {
+    let node_account_pubkey = pubkey_of(matches, "node_account_pubkey").unwrap();
+    let storage_account_pubkey = pubkey_of(matches, "storage_account_pubkey").unwrap();
+    Ok(WalletCommand::ClaimStorageReward {
+        node_account_pubkey,
+        storage_account_pubkey,
+    })
+}
+
+pub fn parse_storage_get_account_command(
+    matches: &ArgMatches<'_>,
+) -> Result<WalletCommand, WalletError> {
+    let storage_account_pubkey = pubkey_of(matches, "storage_account_pubkey").unwrap();
+    Ok(WalletCommand::ShowStorageAccount(storage_account_pubkey))
+}
+
+pub fn process_create_storage_account(
+    rpc_client: &RpcClient,
+    config: &WalletConfig,
+    account_owner: &Pubkey,
+    storage_account_pubkey: &Pubkey,
+    account_type: StorageAccountType,
+) -> ProcessResult {
+    check_unique_pubkeys(
+        (&config.keypair.pubkey(), "wallet keypair".to_string()),
+        (
+            &storage_account_pubkey,
+            "storage_account_pubkey".to_string(),
+        ),
+    )?;
+    let (recent_blockhash, fee_calculator) = rpc_client.get_recent_blockhash()?;
+    let ixs = storage_instruction::create_storage_account(
+        &config.keypair.pubkey(),
+        &account_owner,
+        storage_account_pubkey,
+        1,
+        account_type,
+    );
+    let mut tx = Transaction::new_signed_instructions(&[&config.keypair], ixs, recent_blockhash);
+    check_account_for_fee(rpc_client, config, &fee_calculator, &tx.message)?;
+    let result = rpc_client.send_and_confirm_transaction(&mut tx, &[&config.keypair]);
+    log_instruction_custom_error::<SystemError>(result)
+}
+
+pub fn process_claim_storage_reward(
+    rpc_client: &RpcClient,
+    config: &WalletConfig,
+    node_account_pubkey: &Pubkey,
+    storage_account_pubkey: &Pubkey,
+) -> ProcessResult {
+    let (recent_blockhash, fee_calculator) = rpc_client.get_recent_blockhash()?;
+
+    let instruction =
+        storage_instruction::claim_reward(node_account_pubkey, storage_account_pubkey);
+    let signers = [&config.keypair];
+    let message = Message::new_with_payer(vec![instruction], Some(&signers[0].pubkey()));
+
+    let mut tx = Transaction::new(&signers, message, recent_blockhash);
+    check_account_for_fee(rpc_client, config, &fee_calculator, &tx.message)?;
+    let signature_str = rpc_client.send_and_confirm_transaction(&mut tx, &signers)?;
+    Ok(signature_str.to_string())
+}
+
+pub fn process_show_storage_account(
+    rpc_client: &RpcClient,
+    _config: &WalletConfig,
+    storage_account_pubkey: &Pubkey,
+) -> ProcessResult {
+    let account = rpc_client.get_account(storage_account_pubkey)?;
+
+    if account.owner != solana_storage_api::id() {
+        return Err(WalletError::RpcRequestError(
+            format!("{:?} is not a storage account", storage_account_pubkey).to_string(),
+        )
+        .into());
+    }
+
+    use solana_storage_api::storage_contract::StorageContract;
+    let storage_contract: StorageContract = account.state().map_err(|err| {
+        WalletError::RpcRequestError(
+            format!("Unable to deserialize storage account: {:?}", err).to_string(),
+        )
+    })?;
+    println!("{:#?}", storage_contract);
+    println!("account lamports: {}", account.lamports);
+    Ok("".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::wallet::{app, parse_command};
+
+    #[test]
+    fn test_parse_command() {
+        let test_commands = app("test", "desc", "version");
+        let pubkey = Pubkey::new_rand();
+        let pubkey_string = pubkey.to_string();
+        let storage_account_pubkey = Pubkey::new_rand();
+        let storage_account_string = storage_account_pubkey.to_string();
+
+        let test_create_replicator_storage_account = test_commands.clone().get_matches_from(vec![
+            "test",
+            "create-replicator-storage-account",
+            &pubkey_string,
+            &storage_account_string,
+        ]);
+        assert_eq!(
+            parse_command(&pubkey, &test_create_replicator_storage_account).unwrap(),
+            WalletCommand::CreateStorageAccount {
+                account_owner: pubkey,
+                storage_account_pubkey,
+                account_type: StorageAccountType::Replicator,
+            }
+        );
+
+        let test_create_validator_storage_account = test_commands.clone().get_matches_from(vec![
+            "test",
+            "create-validator-storage-account",
+            &pubkey_string,
+            &storage_account_string,
+        ]);
+        assert_eq!(
+            parse_command(&pubkey, &test_create_validator_storage_account).unwrap(),
+            WalletCommand::CreateStorageAccount {
+                account_owner: pubkey,
+                storage_account_pubkey,
+                account_type: StorageAccountType::Validator,
+            }
+        );
+
+        let test_claim_storage_reward = test_commands.clone().get_matches_from(vec![
+            "test",
+            "claim-storage-reward",
+            &pubkey_string,
+            &storage_account_string,
+        ]);
+        assert_eq!(
+            parse_command(&pubkey, &test_claim_storage_reward).unwrap(),
+            WalletCommand::ClaimStorageReward {
+                node_account_pubkey: pubkey,
+                storage_account_pubkey,
+            }
+        );
+    }
+    // TODO: Add process tests
+}

--- a/cli/src/wallet.rs
+++ b/cli/src/wallet.rs
@@ -1483,95 +1483,6 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                 ),
         )
         .subcommand(
-            SubCommand::with_name("vote-authorize-voter")
-                .about("Authorize a new vote signing keypair for the given vote account")
-                .arg(
-                    Arg::with_name("vote_account_pubkey")
-                        .index(1)
-                        .value_name("VOTE ACCOUNT PUBKEY")
-                        .takes_value(true)
-                        .required(true)
-                        .validator(is_pubkey_or_keypair)
-                        .help("Vote account in which to set the authorized voter"),
-                )
-                .arg(
-                    Arg::with_name("new_authorized_pubkey")
-                        .index(2)
-                        .value_name("NEW VOTER PUBKEY")
-                        .takes_value(true)
-                        .required(true)
-                        .validator(is_pubkey_or_keypair)
-                        .help("New vote signer to authorize"),
-                ),
-        )
-        .subcommand(
-            SubCommand::with_name("vote-authorize-withdrawer")
-                .about("Authorize a new withdraw signing keypair for the given vote account")
-                .arg(
-                    Arg::with_name("vote_account_pubkey")
-                        .index(1)
-                        .value_name("VOTE ACCOUNT PUBKEY")
-                        .takes_value(true)
-                        .required(true)
-                        .validator(is_pubkey_or_keypair)
-                        .help("Vote account in which to set the authorized withdrawer"),
-                )
-                .arg(
-                    Arg::with_name("new_authorized_pubkey")
-                        .index(2)
-                        .value_name("NEW WITHDRAWER PUBKEY")
-                        .takes_value(true)
-                        .required(true)
-                        .validator(is_pubkey_or_keypair)
-                        .help("New withdrawer to authorize"),
-                ),
-        )
-        .subcommand(
-            SubCommand::with_name("create-vote-account")
-                .about("Create a vote account")
-                .arg(
-                    Arg::with_name("vote_account_pubkey")
-                        .index(1)
-                        .value_name("VOTE ACCOUNT PUBKEY")
-                        .takes_value(true)
-                        .required(true)
-                        .validator(is_pubkey_or_keypair)
-                        .help("Vote account address to fund"),
-                )
-                .arg(
-                    Arg::with_name("node_pubkey")
-                        .index(2)
-                        .value_name("VALIDATOR PUBKEY")
-                        .takes_value(true)
-                        .required(true)
-                        .validator(is_pubkey_or_keypair)
-                        .help("Validator that will vote with this account"),
-                )
-                .arg(
-                    Arg::with_name("commission")
-                        .long("commission")
-                        .value_name("NUM")
-                        .takes_value(true)
-                        .help("The commission taken on reward redemption (0-255), default: 0"),
-                )
-                .arg(
-                    Arg::with_name("authorized_voter")
-                        .long("authorized-voter")
-                        .value_name("PUBKEY")
-                        .takes_value(true)
-                        .validator(is_pubkey_or_keypair)
-                        .help("Public key of the authorized voter (defaults to vote account)"),
-                )
-                .arg(
-                    Arg::with_name("authorized_withdrawer")
-                        .long("authorized-withdrawer")
-                        .value_name("PUBKEY")
-                        .takes_value(true)
-                        .validator(is_pubkey_or_keypair)
-                        .help("Public key of the authorized withdrawer (defaults to wallet)"),
-                ),
-        )
-        .subcommand(
             SubCommand::with_name("show-account")
                 .about("Show the contents of an account")
                 .arg(
@@ -1598,50 +1509,7 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                         .help("Display balance in lamports instead of SOL"),
                 ),
         )
-        .subcommand(
-            SubCommand::with_name("show-vote-account")
-                .about("Show the contents of a vote account")
-                .arg(
-                    Arg::with_name("vote_account_pubkey")
-                        .index(1)
-                        .value_name("VOTE ACCOUNT PUBKEY")
-                        .takes_value(true)
-                        .required(true)
-                        .validator(is_pubkey_or_keypair)
-                        .help("Vote account pubkey"),
-                )
-                .arg(
-                    Arg::with_name("lamports")
-                        .long("lamports")
-                        .takes_value(false)
-                        .help("Display balance in lamports instead of SOL"),
-                ),
-        )
-        .subcommand(
-            SubCommand::with_name("uptime")
-                .about("Show the uptime of a validator, based on epoch voting history")
-                .arg(
-                    Arg::with_name("vote_account_pubkey")
-                        .index(1)
-                        .value_name("VOTE ACCOUNT PUBKEY")
-                        .takes_value(true)
-                        .required(true)
-                        .validator(is_pubkey_or_keypair)
-                        .help("Vote account pubkey"),
-                )
-                .arg(
-                    Arg::with_name("span")
-                        .long("span")
-                        .value_name("NUM OF EPOCHS")
-                        .takes_value(true)
-                        .help("Number of recent epochs to examine")
-                )
-                .arg(
-                    Arg::with_name("aggregate")
-                        .long("aggregate")
-                        .help("Aggregate uptime data across span")
-                ),
-        )
+        .vote_subcommands()
         .stake_subcommands()
         .subcommand(
             SubCommand::with_name("create-storage-mining-pool-account")

--- a/cli/src/wallet.rs
+++ b/cli/src/wallet.rs
@@ -50,21 +50,46 @@ static CROSS_MARK: Emoji = Emoji("❌ ", "");
 #[derive(Debug, PartialEq)]
 #[allow(clippy::large_enum_variant)]
 pub enum WalletCommand {
-    Address,
+    // Cluster Info Commands
     Fees,
-    Airdrop {
-        drone_host: Option<IpAddr>,
-        drone_port: u16,
-        lamports: u64,
-        use_lamports_unit: bool,
+    GetGenesisBlockhash,
+    GetSlot,
+    GetEpochInfo,
+    GetTransactionCount,
+    GetVersion,
+    Ping {
+        interval: Duration,
+        count: Option<u64>,
+        timeout: Duration,
     },
-    Balance {
+    // Program Deployment
+    Deploy(String),
+    // Stake Commands
+    CreateStakeAccount(Pubkey, Authorized, Lockup, u64),
+    DelegateStake(Pubkey, Pubkey, bool),
+    DeactivateStake(Pubkey, Pubkey),
+    RedeemVoteCredits(Pubkey, Pubkey),
+    ShowStakeAccount {
         pubkey: Pubkey,
         use_lamports_unit: bool,
     },
-    Cancel(Pubkey),
-    Confirm(Signature),
-    VoteAuthorize(Pubkey, Pubkey, VoteAuthorize),
+    StakeAuthorize(Pubkey, Pubkey, StakeAuthorize),
+    WithdrawStake(Pubkey, Pubkey, u64),
+    // Storage Commands
+    CreateStorageAccount {
+        account_owner: Pubkey,
+        storage_account_pubkey: Pubkey,
+        account_type: StorageAccountType,
+    },
+    ClaimStorageReward {
+        node_account_pubkey: Pubkey,
+        storage_account_pubkey: Pubkey,
+    },
+    ShowStorageAccount(Pubkey),
+    // Validator Info Commands
+    GetValidatorInfo(Option<Pubkey>),
+    SetValidatorInfo(ValidatorInfo, Option<Pubkey>),
+    // Vote Commands
     CreateVoteAccount(Pubkey, VoteInit),
     ShowAccount {
         pubkey: Pubkey,
@@ -80,32 +105,21 @@ pub enum WalletCommand {
         aggregate: bool,
         span: Option<u64>,
     },
-    CreateStakeAccount(Pubkey, Authorized, Lockup, u64),
-    StakeAuthorize(Pubkey, Pubkey, StakeAuthorize),
-    DelegateStake(Pubkey, Pubkey, bool),
-    WithdrawStake(Pubkey, Pubkey, u64),
-    DeactivateStake(Pubkey, Pubkey),
-    RedeemVoteCredits(Pubkey, Pubkey),
-    ShowStakeAccount {
+    VoteAuthorize(Pubkey, Pubkey, VoteAuthorize),
+    // Wallet Commands
+    Address,
+    Airdrop {
+        drone_host: Option<IpAddr>,
+        drone_port: u16,
+        lamports: u64,
+        use_lamports_unit: bool,
+    },
+    Balance {
         pubkey: Pubkey,
         use_lamports_unit: bool,
     },
-    CreateStorageAccount {
-        account_owner: Pubkey,
-        storage_account_pubkey: Pubkey,
-        account_type: StorageAccountType,
-    },
-    ClaimStorageReward {
-        node_account_pubkey: Pubkey,
-        storage_account_pubkey: Pubkey,
-    },
-    ShowStorageAccount(Pubkey),
-    Deploy(String),
-    GetGenesisBlockhash,
-    GetSlot,
-    GetEpochInfo,
-    GetTransactionCount,
-    GetVersion,
+    Cancel(Pubkey),
+    Confirm(Signature),
     Pay {
         lamports: u64,
         to: Pubkey,
@@ -114,15 +128,8 @@ pub enum WalletCommand {
         witnesses: Option<Vec<Pubkey>>,
         cancelable: Option<Pubkey>,
     },
-    Ping {
-        interval: Duration,
-        count: Option<u64>,
-        timeout: Duration,
-    },
     TimeElapsed(Pubkey, Pubkey, DateTime<Utc>), // TimeElapsed(to, process_id, timestamp)
     Witness(Pubkey, Pubkey),                    // Witness(to, process_id)
-    GetValidatorInfo(Option<Pubkey>),
-    SetValidatorInfo(ValidatorInfo, Option<Pubkey>),
 }
 
 #[derive(Debug, Clone)]

--- a/core/src/replicator.rs
+++ b/core/src/replicator.rs
@@ -35,7 +35,7 @@ use solana_sdk::timing::timestamp;
 use solana_sdk::transaction::Transaction;
 use solana_sdk::transport::TransportError;
 use solana_storage_api::storage_contract::StorageContract;
-use solana_storage_api::storage_instruction;
+use solana_storage_api::storage_instruction::{self, StorageAccountType};
 use std::fs::File;
 use std::io::{self, BufReader, ErrorKind, Read, Seek, SeekFrom};
 use std::mem::size_of;
@@ -600,11 +600,12 @@ impl Replicator {
                 }
             };
 
-            let ix = storage_instruction::create_replicator_storage_account(
+            let ix = storage_instruction::create_storage_account(
                 &keypair.pubkey(),
                 &keypair.pubkey(),
                 &storage_keypair.pubkey(),
                 1,
+                StorageAccountType::Replicator,
             );
             let tx = Transaction::new_signed_instructions(&[keypair], ix, blockhash);
             let signature = client.async_send_transaction(tx)?;

--- a/core/src/storage_stage.rs
+++ b/core/src/storage_stage.rs
@@ -641,6 +641,7 @@ mod tests {
     use solana_sdk::hash::{Hash, Hasher};
     use solana_sdk::pubkey::Pubkey;
     use solana_sdk::signature::{Keypair, KeypairUtil};
+    use solana_storage_api::storage_instruction::StorageAccountType;
     use std::cmp::{max, min};
     use std::fs::remove_dir_all;
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
@@ -822,11 +823,12 @@ mod tests {
 
         // create accounts
         let bank = Arc::new(Bank::new_from_parent(&bank, &keypair.pubkey(), 1));
-        let account_ix = storage_instruction::create_replicator_storage_account(
+        let account_ix = storage_instruction::create_storage_account(
             &mint_keypair.pubkey(),
             &Pubkey::new_rand(),
             &replicator_keypair.pubkey(),
             1,
+            StorageAccountType::Replicator,
         );
         let account_tx = Transaction::new_signed_instructions(
             &[&mint_keypair],

--- a/programs/storage_api/src/storage_processor.rs
+++ b/programs/storage_api/src/storage_processor.rs
@@ -20,17 +20,14 @@ pub fn process_instruction(
     let mut storage_account = StorageAccount::new(*me[0].unsigned_key(), &mut me[0].account);
 
     match bincode::deserialize(data).map_err(|_| InstructionError::InvalidInstructionData)? {
-        StorageInstruction::InitializeReplicatorStorage { owner } => {
+        StorageInstruction::InitializeStorage {
+            owner,
+            account_type,
+        } => {
             if !rest.is_empty() {
                 return Err(InstructionError::InvalidArgument);
             }
-            storage_account.initialize_replicator_storage(owner)
-        }
-        StorageInstruction::InitializeValidatorStorage { owner } => {
-            if !rest.is_empty() {
-                return Err(InstructionError::InvalidArgument);
-            }
-            storage_account.initialize_validator_storage(owner)
+            storage_account.initialize_storage(owner, account_type)
         }
         StorageInstruction::SubmitMiningProof {
             sha_state,


### PR DESCRIPTION
#### Problem
The solana-cli crate is really hard to maintain, since it pulls in motley native programs and has historically collected everything in one mega `wallet.rs`. A reorganization and refactoring was begun, but has not been implemented everywhere.

#### Summary of Changes
- Follows the model of the Stake program to move Vote program subcommands out of the main `wallet.rs` file into `vote.rs` 
- Moves Storage program subcommands, parse methods, and process methods into separate module
- Rearranges the huge WalletCommand enum by related program, and adds comments 
