### PR TITLE
Expand blocktree processor options

### DIFF
--- a/core/benches/banking_stage.rs
+++ b/core/benches/banking_stage.rs
@@ -275,7 +275,7 @@ fn simulate_process_entries(
     initial_lamports: u64,
     num_accounts: usize,
 ) {
-    let bank = Bank::new(genesis_block);
+    let bank = Arc::new(Bank::new(genesis_block));
 
     for i in 0..(num_accounts / 2) {
         bank.transfer(initial_lamports, mint_keypair, &keypairs[i * 2].pubkey())

--- a/core/src/blocktree_processor.rs
+++ b/core/src/blocktree_processor.rs
@@ -993,15 +993,17 @@ pub mod tests {
     }
 
     #[test]
-    fn test_process_entries_with_callback() {
+    fn test_process_ledger_options_entry_callback() {
         let GenesisBlockInfo {
             genesis_block,
             mint_keypair,
             ..
         } = create_genesis_block(100);
-        let bank = Arc::new(Bank::new(&genesis_block));
+        let (ledger_path, last_entry_hash) = create_new_tmp_ledger!(&genesis_block);
+        let blocktree =
+            Blocktree::open(&ledger_path).expect("Expected to successfully open database ledger");
+        let blockhash = genesis_block.hash();
         let keypairs = [Keypair::new(), Keypair::new(), Keypair::new()];
-        let blockhash = bank.last_blockhash();
 
         let tx = system_transaction::create_user_account(
             &mint_keypair,
@@ -1009,7 +1011,7 @@ pub mod tests {
             1,
             blockhash,
         );
-        let entry_1 = next_entry(&blockhash, 1, vec![tx]);
+        let entry_1 = next_entry(&last_entry_hash, 1, vec![tx]);
 
         let tx = system_transaction::create_user_account(
             &mint_keypair,
@@ -1018,6 +1020,21 @@ pub mod tests {
             blockhash,
         );
         let entry_2 = next_entry(&entry_1.hash, 1, vec![tx]);
+
+        let mut entries = vec![entry_1, entry_2];
+        entries.extend(create_ticks(genesis_block.ticks_per_slot, last_entry_hash));
+        blocktree
+            .write_entries(
+                1,
+                0,
+                0,
+                genesis_block.ticks_per_slot,
+                None,
+                true,
+                &Arc::new(Keypair::new()),
+                &entries,
+            )
+            .unwrap();
 
         let callback_counter: Arc<RwLock<usize>> = Arc::default();
         let entry_callback = {
@@ -1031,12 +1048,13 @@ pub mod tests {
             })
         };
 
-        assert_eq!(
-            process_entries_with_callback(&bank, &[entry_1, entry_2], true, &Some(entry_callback)),
-            Ok(())
-        );
+        let opts = ProcessOptions {
+            override_num_threads: Some(1),
+            entry_callback: Some(entry_callback),
+            ..ProcessOptions::default()
+        };
+        process_blocktree(&genesis_block, &blocktree, None, opts).unwrap();
         assert_eq!(*callback_counter.write().unwrap(), 2);
-        assert_eq!(bank.last_blockhash(), blockhash);
     }
 
     #[test]

--- a/core/src/blocktree_processor.rs
+++ b/core/src/blocktree_processor.rs
@@ -231,11 +231,10 @@ pub fn process_blocktree_from_root(
     let (bank_forks, bank_forks_info, leader_schedule_cache) = {
         if let Some(meta) = meta {
             let epoch_schedule = bank.epoch_schedule();
-            let mut leader_schedule_cache = if opts.full_leader_cache {
-                LeaderScheduleCache::new_with_capacity(*epoch_schedule, &bank, std::usize::MAX)
-            } else {
-                LeaderScheduleCache::new(*epoch_schedule, &bank)
-            };
+            let mut leader_schedule_cache = LeaderScheduleCache::new(*epoch_schedule, &bank);
+            if opts.full_leader_cache {
+                leader_schedule_cache.set_max_schedules(std::usize::MAX);
+            }
             let fork_info = process_pending_slots(
                 &bank,
                 &meta,

--- a/core/src/blocktree_processor.rs
+++ b/core/src/blocktree_processor.rs
@@ -183,7 +183,7 @@ pub struct ProcessOptions {
     pub full_leader_cache: bool,
     pub dev_halt_at_slot: Option<Slot>,
     pub entry_callback: Option<ProcessCallback>,
-    pub num_threads: Option<usize>,
+    pub override_num_threads: Option<usize>,
 }
 
 pub fn process_blocktree(
@@ -192,9 +192,7 @@ pub fn process_blocktree(
     account_paths: Option<String>,
     opts: ProcessOptions,
 ) -> result::Result<(BankForks, Vec<BankForksInfo>, LeaderScheduleCache), BlocktreeProcessorError> {
-    info!("processing ledger from bank 0...");
-
-    if let Some(num_threads) = opts.num_threads {
+    if let Some(num_threads) = opts.override_num_threads {
         PAR_THREAD_POOL.with(|pool| {
             *pool.borrow_mut() = rayon::ThreadPoolBuilder::new()
                 .num_threads(num_threads)
@@ -205,6 +203,7 @@ pub fn process_blocktree(
 
     // Setup bank for slot 0
     let bank0 = Arc::new(Bank::new_with_paths(&genesis_block, account_paths));
+    info!("processing ledger from bank 0...");
     process_bank_0(&bank0, blocktree, &opts)?;
     process_blocktree_from_root(blocktree, bank0, &opts)
 }

--- a/core/src/leader_schedule_cache.rs
+++ b/core/src/leader_schedule_cache.rs
@@ -58,6 +58,10 @@ impl LeaderScheduleCache {
         }
     }
 
+    pub fn max_schedules(&self) -> usize {
+        self.max_schedules.0
+    }
+
     pub fn set_root(&self, root_bank: &Bank) {
         let new_max_epoch = self.epoch_schedule.get_stakers_epoch(root_bank.slot());
         let old_max_epoch = {
@@ -204,7 +208,7 @@ impl LeaderScheduleCache {
             if let Entry::Vacant(v) = entry {
                 v.insert(leader_schedule.clone());
                 order.push_back(epoch);
-                Self::retain_latest(cached_schedules, order, self.max_schedules.0);
+                Self::retain_latest(cached_schedules, order, self.max_schedules());
             }
             leader_schedule
         })
@@ -245,7 +249,7 @@ mod tests {
         let bank = Bank::new(&genesis_block);
         let cache = LeaderScheduleCache::new_from_bank(&bank);
         assert_eq!(bank.slot(), 0);
-        assert_eq!(cache.max_schedules.0, MAX_SCHEDULES);
+        assert_eq!(cache.max_schedules(), MAX_SCHEDULES);
 
         // Epoch schedule for all epochs in the range:
         // [0, stakers_epoch(bank.slot())] should
@@ -568,9 +572,9 @@ mod tests {
 
         // Max schedules must be greater than 0
         cache.set_max_schedules(0);
-        assert_eq!(cache.max_schedules.0, MAX_SCHEDULES);
+        assert_eq!(cache.max_schedules(), MAX_SCHEDULES);
 
         cache.set_max_schedules(std::usize::MAX);
-        assert_eq!(cache.max_schedules.0, std::usize::MAX);
+        assert_eq!(cache.max_schedules(), std::usize::MAX);
     }
 }

--- a/core/src/leader_schedule_cache.rs
+++ b/core/src/leader_schedule_cache.rs
@@ -287,7 +287,7 @@ mod tests {
             cached_schedules.insert(i as u64, Arc::new(LeaderSchedule::default()));
             order.push_back(i as u64);
         }
-        LeaderScheduleCache::retain_latest(&mut cached_schedules, &mut order);
+        LeaderScheduleCache::retain_latest(&mut cached_schedules, &mut order, MAX_SCHEDULES);
         assert_eq!(cached_schedules.len(), MAX_SCHEDULES);
         let mut keys: Vec<_> = cached_schedules.keys().cloned().collect();
         keys.sort();

--- a/core/src/leader_schedule_cache.rs
+++ b/core/src/leader_schedule_cache.rs
@@ -250,6 +250,7 @@ mod tests {
         let bank = Bank::new(&genesis_block);
         let cache = LeaderScheduleCache::new_from_bank(&bank);
         assert_eq!(bank.slot(), 0);
+        assert_eq!(cache.capacity, MAX_SCHEDULES);
 
         // Epoch schedule for all epochs in the range:
         // [0, stakers_epoch(bank.slot())] should

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -364,7 +364,7 @@ impl ReplayStage {
 
     // Returns the replay result and the number of replayed transactions
     fn replay_blocktree_into_bank(
-        bank: &Bank,
+        bank: &Arc<Bank>,
         blocktree: &Blocktree,
         progress: &mut HashMap<u64, ForkProgress>,
     ) -> (Result<()>, usize) {
@@ -675,7 +675,7 @@ impl ReplayStage {
     }
 
     fn replay_entries_into_bank(
-        bank: &Bank,
+        bank: &Arc<Bank>,
         entries: Vec<Entry>,
         progress: &mut HashMap<u64, ForkProgress>,
         num: usize,
@@ -698,7 +698,7 @@ impl ReplayStage {
     }
 
     pub fn verify_and_process_entries(
-        bank: &Bank,
+        bank: &Arc<Bank>,
         entries: &[Entry],
         last_entry: &Hash,
         shred_index: usize,

--- a/core/src/storage_stage.rs
+++ b/core/src/storage_stage.rs
@@ -736,14 +736,14 @@ mod tests {
         let mut last_bank = bank;
         let rooted_banks = (slot..slot + last_bank.slots_per_segment() + 1)
             .map(|i| {
-                let bank = Bank::new_from_parent(&last_bank, &keypair.pubkey(), i);
+                let bank = Arc::new(Bank::new_from_parent(&last_bank, &keypair.pubkey(), i));
                 blocktree_processor::process_entries(
                     &bank,
                     &entry::create_ticks(64, bank.last_blockhash()),
                     true,
                 )
                 .expect("failed process entries");
-                last_bank = Arc::new(bank);
+                last_bank = bank;
                 last_bank.clone()
             })
             .collect::<Vec<_>>();

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -417,8 +417,11 @@ fn get_bank_forks(
             return blocktree_processor::process_blocktree_from_root(
                 blocktree,
                 Arc::new(deserialized_bank),
-                verify_ledger,
-                dev_halt_at_slot,
+                blocktree_processor::ProcessOptions {
+                    verify_ledger,
+                    dev_halt_at_slot,
+                    ..blocktree_processor::ProcessOptions::default()
+                },
             )
             .expect("processing blocktree after loading snapshot failed");
         } else {
@@ -433,8 +436,11 @@ fn get_bank_forks(
         &genesis_block,
         &blocktree,
         account_paths,
-        verify_ledger,
-        dev_halt_at_slot,
+        blocktree_processor::ProcessOptions {
+            verify_ledger,
+            dev_halt_at_slot,
+            ..blocktree_processor::ProcessOptions::default()
+        },
     )
     .expect("process_blocktree failed")
 }

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -417,7 +417,7 @@ fn get_bank_forks(
             return blocktree_processor::process_blocktree_from_root(
                 blocktree,
                 Arc::new(deserialized_bank),
-                blocktree_processor::ProcessOptions {
+                &blocktree_processor::ProcessOptions {
                     verify_ledger,
                     dev_halt_at_slot,
                     ..blocktree_processor::ProcessOptions::default()

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -1,6 +1,6 @@
 use clap::{crate_description, crate_name, crate_version, value_t_or_exit, App, Arg, SubCommand};
 use solana_core::blocktree::Blocktree;
-use solana_core::blocktree_processor::process_blocktree;
+use solana_core::blocktree_processor::{process_blocktree, ProcessOptions};
 use solana_sdk::clock::Slot;
 use solana_sdk::genesis_block::GenesisBlock;
 use std::collections::BTreeMap;
@@ -168,7 +168,11 @@ fn main() {
         }
         ("verify", _) => {
             println!("Verifying ledger...");
-            match process_blocktree(&genesis_block, &blocktree, None, true, None) {
+            let options = ProcessOptions {
+                verify_ledger: true,
+                ..ProcessOptions::default()
+            };
+            match process_blocktree(&genesis_block, &blocktree, None, options) {
                 Ok((_bank_forks, bank_forks_info, _)) => {
                     println!("{:?}", bank_forks_info);
                 }


### PR DESCRIPTION
#### Problem
Calculating the top performers for Tour de SOL will be done by post-processing the ledger and some changes need to be made to get the information needed:
* Need a way to run a callback after each processed entry
* Want to retain the full leader cache for post processing
* Want to optionally process the blocktree without parallelization

Related: https://github.com/solana-labs/tour-de-sol/pull/12