### PR TITLE
Stabilize some banking stage tests

### DIFF
--- a/banking_bench/src/main.rs
+++ b/banking_bench/src/main.rs
@@ -155,7 +155,7 @@ fn main() {
             Blocktree::open(&ledger_path).expect("Expected to be able to open database ledger"),
         );
         let (exit, poh_recorder, poh_service, signal_receiver) =
-            create_test_recorder(&bank, &blocktree);
+            create_test_recorder(&bank, &blocktree, None);
         let cluster_info = ClusterInfo::new_with_invalid_keypair(Node::new_localhost().info);
         let cluster_info = Arc::new(RwLock::new(cluster_info));
         let _banking_stage = BankingStage::new(

--- a/core/benches/banking_stage.rs
+++ b/core/benches/banking_stage.rs
@@ -66,7 +66,7 @@ fn bench_consume_buffered(bencher: &mut Bencher) {
             Blocktree::open(&ledger_path).expect("Expected to be able to open database ledger"),
         );
         let (exit, poh_recorder, poh_service, _signal_receiver) =
-            create_test_recorder(&bank, &blocktree);
+            create_test_recorder(&bank, &blocktree, None);
 
         let tx = test_tx();
         let len = 4096;
@@ -198,7 +198,7 @@ fn bench_banking(bencher: &mut Bencher, tx_type: TransactionType) {
             Blocktree::open(&ledger_path).expect("Expected to be able to open database ledger"),
         );
         let (exit, poh_recorder, poh_service, signal_receiver) =
-            create_test_recorder(&bank, &blocktree);
+            create_test_recorder(&bank, &blocktree, None);
         let cluster_info = ClusterInfo::new_with_invalid_keypair(Node::new_localhost().info);
         let cluster_info = Arc::new(RwLock::new(cluster_info));
         let _banking_stage = BankingStage::new(

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -1012,6 +1012,7 @@ mod tests {
             mut genesis_block, ..
         } = create_genesis_block(2);
         genesis_block.ticks_per_slot = 4;
+        let num_extra_ticks = 2;
         let bank = Arc::new(Bank::new(&genesis_block));
         let start_hash = bank.last_blockhash();
         let (verified_sender, verified_receiver) = unbounded();
@@ -1022,7 +1023,7 @@ mod tests {
                 Blocktree::open(&ledger_path).expect("Expected to be able to open database ledger"),
             );
             let mut poh_config = PohConfig::default();
-            poh_config.target_tick_count = Some(6);
+            poh_config.target_tick_count = Some(genesis_block.ticks_per_slot + num_extra_ticks);
             let (exit, poh_recorder, poh_service, entry_receiver) =
                 create_test_recorder(&bank, &blocktree, Some(poh_config));
             let cluster_info = ClusterInfo::new_with_invalid_keypair(Node::new_localhost().info);
@@ -1072,8 +1073,8 @@ mod tests {
                 Blocktree::open(&ledger_path).expect("Expected to be able to open database ledger"),
             );
             let mut poh_config = PohConfig::default();
-            // limit the tick to 1 to prevent clearing working_bank at PohRecord then PohRecorderError(MaxHeightReached) at BankingStage
-            poh_config.target_tick_count = Some(1);
+            // limit tick count to avoid clearing working_bank at PohRecord then PohRecorderError(MaxHeightReached) at BankingStage
+            poh_config.target_tick_count = Some(genesis_block.ticks_per_slot - 1);
             let (exit, poh_recorder, poh_service, entry_receiver) =
                 create_test_recorder(&bank, &blocktree, Some(poh_config));
             let cluster_info = ClusterInfo::new_with_invalid_keypair(Node::new_localhost().info);
@@ -1221,8 +1222,8 @@ mod tests {
                         .expect("Expected to be able to open database ledger"),
                 );
                 let mut poh_config = PohConfig::default();
-                // limit the tick to 1 to prevent clearing working_bank at PohRecord then PohRecorderError(MaxHeightReached) at BankingStage
-                poh_config.target_tick_count = Some(1);
+                // limit tick count to avoid clearing working_bank at PohRecord then PohRecorderError(MaxHeightReached) at BankingStage
+                poh_config.target_tick_count = Some(genesis_block.ticks_per_slot - 1);
                 let (exit, poh_recorder, poh_service, entry_receiver) =
                     create_test_recorder(&bank, &blocktree, Some(poh_config));
                 let cluster_info =

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -936,10 +936,10 @@ pub fn create_test_recorder(
     Receiver<WorkingBankEntry>,
 ) {
     let exit = Arc::new(AtomicBool::new(false));
-    let poh_config = if poh_config.is_none() {
-        Arc::new(PohConfig::default())
+    let poh_config = if let Some(poh_config) = poh_config {
+        Arc::new(poh_config)
     } else {
-        Arc::new(poh_config.unwrap())
+        Arc::new(PohConfig::default())
     };
     let (mut poh_recorder, entry_receiver) = PohRecorder::new(
         bank.tick_height(),

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -1023,7 +1023,7 @@ mod tests {
                 Blocktree::open(&ledger_path).expect("Expected to be able to open database ledger"),
             );
             let mut poh_config = PohConfig::default();
-            poh_config.target_tick_count = Some(genesis_block.ticks_per_slot + num_extra_ticks);
+            poh_config.target_tick_count = Some(bank.max_tick_height() + num_extra_ticks);
             let (exit, poh_recorder, poh_service, entry_receiver) =
                 create_test_recorder(&bank, &blocktree, Some(poh_config));
             let cluster_info = ClusterInfo::new_with_invalid_keypair(Node::new_localhost().info);

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -936,11 +936,7 @@ pub fn create_test_recorder(
     Receiver<WorkingBankEntry>,
 ) {
     let exit = Arc::new(AtomicBool::new(false));
-    let poh_config = if let Some(poh_config) = poh_config {
-        Arc::new(poh_config)
-    } else {
-        Arc::new(PohConfig::default())
-    };
+    let poh_config = Arc::new(poh_config.unwrap_or_default());
     let (mut poh_recorder, entry_receiver) = PohRecorder::new(
         bank.tick_height(),
         bank.last_blockhash(),

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -1074,7 +1074,7 @@ mod tests {
             );
             let mut poh_config = PohConfig::default();
             // limit tick count to avoid clearing working_bank at PohRecord then PohRecorderError(MaxHeightReached) at BankingStage
-            poh_config.target_tick_count = Some(genesis_block.ticks_per_slot - 1);
+            poh_config.target_tick_count = Some(bank.max_tick_height() - 1);
             let (exit, poh_recorder, poh_service, entry_receiver) =
                 create_test_recorder(&bank, &blocktree, Some(poh_config));
             let cluster_info = ClusterInfo::new_with_invalid_keypair(Node::new_localhost().info);
@@ -1223,7 +1223,7 @@ mod tests {
                 );
                 let mut poh_config = PohConfig::default();
                 // limit tick count to avoid clearing working_bank at PohRecord then PohRecorderError(MaxHeightReached) at BankingStage
-                poh_config.target_tick_count = Some(genesis_block.ticks_per_slot - 1);
+                poh_config.target_tick_count = Some(bank.max_tick_height() - 1);
                 let (exit, poh_recorder, poh_service, entry_receiver) =
                     create_test_recorder(&bank, &blocktree, Some(poh_config));
                 let cluster_info =

--- a/core/src/poh_service.rs
+++ b/core/src/poh_service.rs
@@ -35,7 +35,11 @@ impl PohService {
                     if poh_config.target_tick_count.is_none() {
                         Self::sleepy_tick_producer(poh_recorder, &poh_config, &poh_exit_);
                     } else {
-                        Self::short_lived_tick_producer(poh_recorder, &poh_config, &poh_exit_);
+                        Self::short_lived_sleepy_tick_producer(
+                            poh_recorder,
+                            &poh_config,
+                            &poh_exit_,
+                        );
                     }
                 } else {
                     // PoH service runs in a tight loop, generating hashes as fast as possible.
@@ -64,7 +68,7 @@ impl PohService {
         }
     }
 
-    fn short_lived_tick_producer(
+    fn short_lived_sleepy_tick_producer(
         poh_recorder: Arc<Mutex<PohRecorder>>,
         poh_config: &PohConfig,
         poh_exit: &AtomicBool,

--- a/core/src/poh_service.rs
+++ b/core/src/poh_service.rs
@@ -32,7 +32,11 @@ impl PohService {
             .name("solana-poh-service-tick_producer".to_string())
             .spawn(move || {
                 if poh_config.hashes_per_tick.is_none() {
-                    Self::sleepy_tick_producer(poh_recorder, &poh_config, &poh_exit_);
+                    if poh_config.target_tick_count.is_none() {
+                        Self::sleepy_tick_producer(poh_recorder, &poh_config, &poh_exit_);
+                    } else {
+                        Self::short_lived_tick_producer(poh_recorder, &poh_config, &poh_exit_);
+                    }
                 } else {
                     // PoH service runs in a tight loop, generating hashes as fast as possible.
                     // Let's dedicate one of the CPU cores to this thread so that it can gain
@@ -57,6 +61,22 @@ impl PohService {
         while !poh_exit.load(Ordering::Relaxed) {
             sleep(poh_config.target_tick_duration);
             poh_recorder.lock().unwrap().tick();
+        }
+    }
+
+    fn short_lived_tick_producer(
+        poh_recorder: Arc<Mutex<PohRecorder>>,
+        poh_config: &PohConfig,
+        poh_exit: &AtomicBool,
+    ) {
+        let mut warned = false;
+        for _ in 0..poh_config.target_tick_count.unwrap() {
+            sleep(poh_config.target_tick_duration);
+            poh_recorder.lock().unwrap().tick();
+            if poh_exit.load(Ordering::Relaxed) && !warned {
+                warned = true;
+                warn!("exit signal is ignored because PohService is scheduled to exit soon");
+            }
         }
     }
 
@@ -108,6 +128,7 @@ mod tests {
             let poh_config = Arc::new(PohConfig {
                 hashes_per_tick: Some(2),
                 target_tick_duration: Duration::from_millis(42),
+                target_tick_count: None,
             });
             let (poh_recorder, entry_receiver) = PohRecorder::new(
                 bank.tick_height(),

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -257,7 +257,7 @@ pub mod tests {
         let blocktree = Arc::new(blocktree);
         let bank = bank_forks.working_bank();
         let (exit, poh_recorder, poh_service, _entry_receiver) =
-            create_test_recorder(&bank, &blocktree);
+            create_test_recorder(&bank, &blocktree, None);
         let voting_keypair = Keypair::new();
         let storage_keypair = Arc::new(Keypair::new());
         let leader_schedule_cache = Arc::new(LeaderScheduleCache::new_from_bank(&bank));

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1675,6 +1675,7 @@ mod tests {
                         / DEFAULT_TICKS_PER_SLOT,
                 ),
                 hashes_per_tick: None,
+                target_tick_count: None,
             },
 
             ..GenesisBlock::default()

--- a/sdk/src/poh_config.rs
+++ b/sdk/src/poh_config.rs
@@ -6,6 +6,9 @@ pub struct PohConfig {
     /// The target tick rate of the cluster.
     pub target_tick_duration: Duration,
 
+    /// The target total tick count to be produced; used for testing only
+    pub target_tick_count: Option<u64>,
+
     /// How many hashes to roll before emitting the next tick entry.
     /// None enables "Low power mode", which implies:
     /// * sleep for `target_tick_duration` instead of hashing
@@ -18,6 +21,7 @@ impl PohConfig {
         Self {
             target_tick_duration,
             hashes_per_tick: None,
+            target_tick_count: None,
         }
     }
 }


### PR DESCRIPTION
#### Problem

Various banking stage tests are fragile.

#### Summary of Changes

Fixed several race conditions in tests.

This fixes 3 unstable unit tests. For all of them, the root cause of unstability is a race condition between solana-poh-service-tick_producer thread and solana-banking-stage-tx thread. So, to precisely control the timings of solana-poh-service-tick_producer thread, I introduced new PohConfig field just for testing purpose.

The requested explanations for each tests follow (in simpler-hardest order):

- `test_banking_stage_tick`
  - Problem: Even if we waited for 600ms, it's possible for ticks not to be produced enough when the ticker thread is stalled under heavy system load.
  - Solution: Always ensure enough ticks are produced (in this pull request, produce 6 ticks)
- `test_banking_stage_entryfication` (originally mentioned by the issue)
  - Problem: Right in the middle of solana-banking-stage-tx's processing of received packets, the thread may be paused and the solana-poh-service-tick_producer thread starts kicking in. If that is the case and new tick entry unfortunately knocks the maximum tick height, it interrupts the in-flight processing of the packets. Depending on the exact timing, the banking stage interrupt results in MaxHeightReached error from PohRecorder when banking stage tries to record a transaction entry or simply enqueuing code path of (unprocessed_packets=>buffered_packets). Then, at test code, this results in an infinite loop at HERE (btw, this loop is itself a bit off..., should fix it too?), and eventual timeout on the CI, vomitting an odd RocksDB error.
  - Solution: Prevent slots from becoming full merely with tick PoH entries.
- `test_banking_stage_entries_only`
  - Problem: In addition to the problem and solution of `test_banking_stage_entryfication`. There are additional issues. First, assertion may be run before banking stage finishes. Second, the wall time resulted from `for _ in 0..10` + `sleep(Duration::from_millis(200));` may not be enough. 
  - For the two additional issue, do simple fix: reorder `banking_stage.join().unwrap();` up in the test code and replace the 10-time repetition with unbounded looping also with guard for empty entries from `entry_receiver`

(First starting from #5660, I ended up with spotting other similar race conditions in neighbor tests, so fixed them as well.)

Fixes #5660