### PR TITLE
Reorder parameters

### DIFF
--- a/programs/vest_api/src/date_instruction.rs
+++ b/programs/vest_api/src/date_instruction.rs
@@ -13,20 +13,20 @@ use solana_sdk::{instruction::Instruction, pubkey::Pubkey};
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub struct DateConfig {
     #[serde(with = "ts_seconds")]
-    pub dt: DateTime<Utc>,
+    pub date_time: DateTime<Utc>,
 }
 
 impl Default for DateConfig {
     fn default() -> Self {
         Self {
-            dt: Utc.timestamp(0, 0),
+            date_time: Utc.timestamp(0, 0),
         }
     }
 }
 impl DateConfig {
-    pub fn new(dt: Date<Utc>) -> Self {
+    pub fn new(date: Date<Utc>) -> Self {
         Self {
-            dt: dt.and_hms(0, 0, 0),
+            date_time: date.and_hms(0, 0, 0),
         }
     }
 
@@ -52,7 +52,7 @@ pub fn create_account(
 
 /// Set the date in the date account. The account pubkey must be signed in the
 /// transaction containing this instruction.
-pub fn store(date_pubkey: &Pubkey, dt: Date<Utc>) -> Instruction {
-    let date_config = DateConfig::new(dt);
+pub fn store(date_pubkey: &Pubkey, date: Date<Utc>) -> Instruction {
+    let date_config = DateConfig::new(date);
     config_instruction::store(&date_pubkey, true, vec![], &date_config)
 }

--- a/programs/vest_api/src/vest_instruction.rs
+++ b/programs/vest_api/src/vest_instruction.rs
@@ -89,8 +89,8 @@ fn initialize_account(
 
 pub fn create_account(
     terminator_pubkey: &Pubkey,
-    payee_pubkey: &Pubkey,
     contract_pubkey: &Pubkey,
+    payee_pubkey: &Pubkey,
     start_date: Date<Utc>,
     date_pubkey: &Pubkey,
     lamports: u64,
@@ -115,30 +115,30 @@ pub fn create_account(
     ]
 }
 
-pub fn set_payee(old_payee: &Pubkey, contract: &Pubkey, new_payee: &Pubkey) -> Instruction {
+pub fn set_payee(contract: &Pubkey, old_payee: &Pubkey, new_payee: &Pubkey) -> Instruction {
     let account_metas = vec![
-        AccountMeta::new(*old_payee, true),
         AccountMeta::new(*contract, false),
+        AccountMeta::new(*old_payee, true),
     ];
     Instruction::new(id(), &VestInstruction::SetPayee(*new_payee), account_metas)
 }
 
-pub fn terminate(from: &Pubkey, contract: &Pubkey, to: &Pubkey) -> Instruction {
-    let mut account_metas = vec![
-        AccountMeta::new(*from, true),
+pub fn redeem_tokens(contract: &Pubkey, date_pubkey: &Pubkey, to: &Pubkey) -> Instruction {
+    let account_metas = vec![
         AccountMeta::new(*contract, false),
+        AccountMeta::new_credit_only(*date_pubkey, false),
+        AccountMeta::new_credit_only(*to, false),
+    ];
+    Instruction::new(id(), &VestInstruction::RedeemTokens, account_metas)
+}
+
+pub fn terminate(contract: &Pubkey, from: &Pubkey, to: &Pubkey) -> Instruction {
+    let mut account_metas = vec![
+        AccountMeta::new(*contract, false),
+        AccountMeta::new(*from, true),
     ];
     if from != to {
         account_metas.push(AccountMeta::new_credit_only(*to, false));
     }
     Instruction::new(id(), &VestInstruction::Terminate, account_metas)
-}
-
-pub fn redeem_tokens(date_pubkey: &Pubkey, contract: &Pubkey, to: &Pubkey) -> Instruction {
-    let account_metas = vec![
-        AccountMeta::new_credit_only(*date_pubkey, false),
-        AccountMeta::new(*contract, false),
-        AccountMeta::new_credit_only(*to, false),
-    ];
-    Instruction::new(id(), &VestInstruction::RedeemTokens, account_metas)
 }

--- a/programs/vest_api/src/vest_state.rs
+++ b/programs/vest_api/src/vest_state.rs
@@ -56,8 +56,8 @@ impl VestState {
     /// Redeem vested tokens.
     pub fn redeem_tokens(
         &mut self,
-        current_date: Date<Utc>,
         contract_account: &mut Account,
+        current_date: Date<Utc>,
         payee_account: &mut Account,
     ) {
         let schedule = create_vesting_schedule(self.start_date_time.date(), self.total_lamports);


### PR DESCRIPTION
#### Problem

VestState has a nice OO interface, whereas using instructions to perform the same action from a transaction does not. The inconsistency obfuscates how mechanical (and potentially automatable) the shim layer is.

#### Summary of Changes

Switching to a parameter order that makes the vest_processor code more
consistent and mechanical.
