### PR TITLE
Fix vest_api output filename

### DIFF
--- a/programs/vest_api/Cargo.toml
+++ b/programs/vest_api/Cargo.toml
@@ -24,4 +24,4 @@ solana-runtime = { path = "../../runtime", version = "0.20.0-pre0" }
 
 [lib]
 crate-type = ["lib"]
-name = "solana_budget_api"
+name = "solana_vest_api"


### PR DESCRIPTION
#### Problem
Seeing this compilation error while building all targets
```
warning: output filename collision.
The lib target `solana_budget_api` in package `solana-vest-api v0.20.0-pre0 (./solana/programs/vest_api)` has the same output filename as the lib target `solana_budget_api` in package `solana-budget-api v0.20.0 (./solana/programs/budget_api)`.
```

#### Summary of Changes
Updated name of output lib for `vest_api`

Fixes #
