### PR TITLE
Remove vote pubkey from deactivate_stake

### DIFF
--- a/book/src/api-reference/cli.md
+++ b/book/src/api-reference/cli.md
@@ -483,7 +483,7 @@ solana-deactivate-stake
 Deactivate the delegated stake from the stake account
 
 USAGE:
-    solana deactivate-stake [OPTIONS] <STAKE ACCOUNT> <VOTE ACCOUNT>
+    solana deactivate-stake [OPTIONS] <STAKE ACCOUNT>
 
 FLAGS:
     -h, --help       Prints help information
@@ -496,7 +496,6 @@ OPTIONS:
 
 ARGS:
     <STAKE ACCOUNT>    Stake account to be deactivated.
-    <VOTE ACCOUNT>     The vote account to which the stake is currently delegated
 ```
 
 #### solana-delegate-stake

--- a/book/src/cluster/stake-delegation-and-rewards.md
+++ b/book/src/cluster/stake-delegation-and-rewards.md
@@ -29,9 +29,9 @@ VoteState is the current state of all the votes the validator has submitted to t
 * Account::lamports - The accumulated lamports from the commission. These do not count as stakes.
 * `authorized_voter` - Only this identity is authorized to submit votes. This field can only modified by this identity.
 * `node_pubkey` - The Solana node that votes in this account.
-* `authorized_withdrawer` - the identity of the entity in charge of the lamports of this account, separate from the account's 
+* `authorized_withdrawer` - the identity of the entity in charge of the lamports of this account, separate from the account's
                            address and the authorized vote signer
-                             
+
 
 ### VoteInstruction::Initialize(VoteInit)
 
@@ -77,12 +77,12 @@ StakeState::Stake is the current delegation preference of the **staker** and con
 * `deactivated` - the epoch at which this stake was de-activated, some cool down epochs are required before the account
                   is fully deactivated, and the stake available for withdrawal    
 * `authorized_staker` - the pubkey of the entity that must sign delegation, activation, and deactivation transactions
-* `authorized_withdrawer` - the identity of the entity in charge of the lamports of this account, separate from the account's 
+* `authorized_withdrawer` - the identity of the entity in charge of the lamports of this account, separate from the account's
                            address, and the authorized staker
 
 ### StakeState::RewardsPool
 
-To avoid a single network wide lock or contention in redemption, 256 RewardsPools are part of genesis under pre-determined 
+To avoid a single network wide lock or contention in redemption, 256 RewardsPools are part of genesis under pre-determined
 keys, each with std::u64::MAX credits to be able to satisfy redemptions according to point value.
 
 The Stakes and the RewardsPool are accounts that are owned by the same `Stake` program.
@@ -99,8 +99,8 @@ stake is re-delegated  The transaction must be signed by the stake's `authorized
 
 ### StakeInstruction::Authorize\(Pubkey, StakeAuthorize\)
 
-Updates the account with a new authorized staker or withdrawer, according to 
-  the StakeAuthorize parameter (`Staker` or `Withdrawer`).  The transaction must be by signed by the 
+Updates the account with a new authorized staker or withdrawer, according to
+  the StakeAuthorize parameter (`Staker` or `Withdrawer`).  The transaction must be by signed by the
   Stakee account's current `authorized_staker` or `authorized_withdrawer`.
 
 * `account[0]` - RW - The StakeState
@@ -119,7 +119,7 @@ The Vote account and the Stake account pair maintain a lifetime counter of total
 * `account[3]` - R - sysvar::rewards account from the Bank that carries point value.
 * `account[4]` - R - sysvar::stake\_history account from the Bank that carries stake warmup/cooldown history
 
-Reward is paid out for the difference between `VoteState::credits` to `StakeState::Stake::credits_observed`, multiplied by `sysvar::rewards::Rewards::validator_point_value`. `StakeState::Stake::credits_observed` is updated to`VoteState::credits`. The commission is deposited into the Vote account token balance, and the reward is deposited to the Stake account token balance and 
+Reward is paid out for the difference between `VoteState::credits` to `StakeState::Stake::credits_observed`, multiplied by `sysvar::rewards::Rewards::validator_point_value`. `StakeState::Stake::credits_observed` is updated to`VoteState::credits`. The commission is deposited into the Vote account token balance, and the reward is deposited to the Stake account token balance and
 the stake account's `stake` is increased by the same amount (re-invested).
 
 ```text
@@ -135,8 +135,7 @@ A staker may wish to withdraw from the network. To do so he must first deactivat
 The transaction must be signed by the stake's `authorized_staker`.
 
 * `account[0]` - RW - The StakeState::Stake instance that is deactivating.
-* `account[1]` - R - The VoteState instance to which this stake is delegated, required in case of slashing
-* `account[2]` - R - sysvar::clock account from the Bank that carries current epoch
+* `account[1]` - R - sysvar::clock account from the Bank that carries current epoch
 
 StakeState::Stake::deactivated is set to the current epoch + cool down. The account's stake will ramp down to zero by that epoch, and Account::lamports will be available for withdrawal.
 
@@ -230,4 +229,3 @@ Only lamports in excess of effective+activating stake may be withdrawn at any ti
 ### Lock-up
 
 Stake accounts support the notion of lock-up, wherein the stake account balance is unavailable for withdrawal until a specified time. Lock-up is specified as a slot height, i.e. the minimum slot height that must be reached by the network before the stake account balance is available for withdrawal, except to a specified custodian.  This information is gathered when the stake account is created.
-

--- a/book/src/running-validator/validator-stake.md
+++ b/book/src/running-validator/validator-stake.md
@@ -36,7 +36,7 @@ The rewards lamports earned are split between your stake account and the vote ac
 Stake can be deactivated by running:
 
 ```bash
-$ solana deactivate-stake ~/validator-config/stake-keypair.json ~/validator-vote-keypair.json
+$ solana deactivate-stake ~/validator-config/stake-keypair.json
 ```
 
 The stake will cool down, deactivate over time. While cooling down, your stake will continue to earn rewards. Only after stake cooldown is it safe to turn off your validator or withdraw it from the network. Cooldown may take several epochs to complete, depending on active stake and the size of your stake.

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -61,7 +61,7 @@ pub enum CliCommand {
     Deploy(String),
     // Stake Commands
     CreateStakeAccount(Pubkey, Authorized, Lockup, u64),
-    DeactivateStake(Pubkey, Pubkey),
+    DeactivateStake(Pubkey),
     DelegateStake(Pubkey, Pubkey, bool),
     RedeemVoteCredits(Pubkey, Pubkey),
     ShowStakeAccount {
@@ -774,13 +774,8 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             )
         }
         // Deactivate stake account
-        CliCommand::DeactivateStake(stake_account_pubkey, vote_account_pubkey) => {
-            process_deactivate_stake_account(
-                &rpc_client,
-                config,
-                &stake_account_pubkey,
-                &vote_account_pubkey,
-            )
+        CliCommand::DeactivateStake(stake_account_pubkey) => {
+            process_deactivate_stake_account(&rpc_client, config, &stake_account_pubkey)
         }
         CliCommand::DelegateStake(stake_account_pubkey, vote_account_pubkey, force) => {
             process_delegate_stake(
@@ -1733,8 +1728,7 @@ mod tests {
         assert_eq!(signature.unwrap(), SIGNATURE.to_string());
 
         let stake_pubkey = Pubkey::new_rand();
-        let vote_pubkey = Pubkey::new_rand();
-        config.command = CliCommand::DeactivateStake(stake_pubkey, vote_pubkey);
+        config.command = CliCommand::DeactivateStake(stake_pubkey);
         let signature = process_command(&config);
         assert_eq!(signature.unwrap(), SIGNATURE.to_string());
 

--- a/programs/stake_api/src/stake_instruction.rs
+++ b/programs/stake_api/src/stake_instruction.rs
@@ -584,7 +584,6 @@ mod tests {
                 &Pubkey::default(),
                 &mut [
                     KeyedAccount::new(&Pubkey::default(), false, &mut Account::default()),
-                    KeyedAccount::new(&Pubkey::default(), false, &mut Account::default()),
                     KeyedAccount::new(
                         &sysvar::rewards::id(),
                         false,
@@ -600,14 +599,11 @@ mod tests {
         assert_eq!(
             super::process_instruction(
                 &Pubkey::default(),
-                &mut [
-                    KeyedAccount::new(&Pubkey::default(), false, &mut Account::default()),
-                    KeyedAccount::new(
-                        &sysvar::clock::id(),
-                        false,
-                        &mut sysvar::rewards::create_account(1, 0.0, 0.0)
-                    ),
-                ],
+                &mut [KeyedAccount::new(
+                    &sysvar::clock::id(),
+                    false,
+                    &mut sysvar::rewards::create_account(1, 0.0, 0.0)
+                ),],
                 &serialize(&StakeInstruction::Deactivate).unwrap(),
             ),
             Err(InstructionError::InvalidInstructionData),

--- a/programs/stake_api/src/stake_instruction.rs
+++ b/programs/stake_api/src/stake_instruction.rs
@@ -100,10 +100,9 @@ pub enum StakeInstruction {
     /// Deactivates the stake in the account
     ///    requires Authorized::staker signature
     ///
-    /// Expects 3 Accounts:
+    /// Expects 2 Accounts:
     ///    0 - Delegate StakeAccount
-    ///    1 - VoteAccount to which the Stake is delegated
-    ///    2 - Syscall Account that carries epoch
+    ///    1 - Syscall Account that carries epoch
     ///
     Deactivate,
 }

--- a/programs/stake_tests/tests/stake_instruction.rs
+++ b/programs/stake_tests/tests/stake_instruction.rs
@@ -190,7 +190,6 @@ fn test_stake_account_delegate() {
         vec![stake_instruction::deactivate_stake(
             &staker_pubkey,
             &staker_pubkey,
-            &vote_pubkey,
         )],
         Some(&mint_pubkey),
     );


### PR DESCRIPTION
#### Problem
With current stake account implementation and ideas about slashing, vote pubkey is no longer necessary in `deactivate_stake` methods. And it adds complication for wallets, that have to store both vote and stake pubkeys to manage delegated stakes.

#### Summary of Changes
Removes vote pubkey from `deactivate_stake` methods

