### PR TITLE
solana-keygen - Poor mans keypair encryption

### DIFF
--- a/bench-exchange/src/cli.rs
+++ b/bench-exchange/src/cli.rs
@@ -1,7 +1,7 @@
 use clap::{crate_description, crate_name, crate_version, value_t, App, Arg, ArgMatches};
 use solana_core::gen_keys::GenKeys;
 use solana_drone::drone::DRONE_PORT;
-use solana_sdk::signature::{read_keypair, Keypair, KeypairUtil};
+use solana_sdk::signature::{read_keypair_file, Keypair, KeypairUtil};
 use std::net::SocketAddr;
 use std::process::exit;
 use std::time::Duration;
@@ -179,7 +179,7 @@ pub fn extract_args<'a>(matches: &ArgMatches<'a>) -> Config {
         });
 
     if matches.is_present("identity") {
-        args.identity = read_keypair(matches.value_of("identity").unwrap())
+        args.identity = read_keypair_file(matches.value_of("identity").unwrap())
             .expect("can't read client identity");
     } else {
         args.identity = {

--- a/bench-tps/src/cli.rs
+++ b/bench-tps/src/cli.rs
@@ -1,7 +1,7 @@
 use clap::{crate_description, crate_name, crate_version, App, Arg, ArgMatches};
 use solana_drone::drone::DRONE_PORT;
 use solana_sdk::fee_calculator::FeeCalculator;
-use solana_sdk::signature::{read_keypair, Keypair, KeypairUtil};
+use solana_sdk::signature::{read_keypair_file, Keypair, KeypairUtil};
 use std::{net::SocketAddr, process::exit, time::Duration};
 
 const NUM_LAMPORTS_PER_ACCOUNT_DEFAULT: u64 = 64 * 1024;
@@ -181,7 +181,7 @@ pub fn extract_args<'a>(matches: &ArgMatches<'a>) -> Config {
     }
 
     if matches.is_present("identity") {
-        args.id = read_keypair(matches.value_of("identity").unwrap())
+        args.id = read_keypair_file(matches.value_of("identity").unwrap())
             .expect("can't read client identity");
     }
 

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -1385,7 +1385,7 @@ mod tests {
     use serde_json::Value;
     use solana_client::mock_rpc_client_request::SIGNATURE;
     use solana_sdk::{
-        signature::{gen_keypair_file, read_keypair},
+        signature::{gen_keypair_file, read_keypair_file},
         transaction::TransactionError,
     };
     use std::path::PathBuf;
@@ -1442,7 +1442,7 @@ mod tests {
         // Test Balance Subcommand, incl pubkey and keypair-file inputs
         let keypair_file = make_tmp_path("keypair_file");
         gen_keypair_file(&keypair_file).unwrap();
-        let keypair = read_keypair(&keypair_file).unwrap();
+        let keypair = read_keypair_file(&keypair_file).unwrap();
         let test_balance = test_commands.clone().get_matches_from(vec![
             "test",
             "balance",

--- a/cli/src/input_parsers.rs
+++ b/cli/src/input_parsers.rs
@@ -2,7 +2,7 @@ use clap::ArgMatches;
 use solana_sdk::{
     native_token::sol_to_lamports,
     pubkey::Pubkey,
-    signature::{read_keypair, Keypair, KeypairUtil},
+    signature::{read_keypair_file, Keypair, KeypairUtil},
 };
 
 // Return parsed values from matches at `name`
@@ -32,7 +32,7 @@ where
 // Return the keypair for an argument with filename `name` or None if not present.
 pub fn keypair_of(matches: &ArgMatches<'_>, name: &str) -> Option<Keypair> {
     if let Some(value) = matches.value_of(name) {
-        read_keypair(value).ok()
+        read_keypair_file(value).ok()
     } else {
         None
     }
@@ -56,7 +56,7 @@ pub fn amount_of(matches: &ArgMatches<'_>, name: &str, unit: &str) -> Option<u64
 mod tests {
     use super::*;
     use clap::{App, Arg};
-    use solana_sdk::signature::write_keypair;
+    use solana_sdk::signature::write_keypair_file;
     use std::fs;
 
     fn app<'ab, 'v>() -> App<'ab, 'v> {
@@ -120,7 +120,7 @@ mod tests {
     fn test_keypair_of() {
         let keypair = Keypair::new();
         let outfile = tmp_file_path("test_gen_keypair_file.json", &keypair.pubkey());
-        let _ = write_keypair(&keypair, &outfile).unwrap();
+        let _ = write_keypair_file(&keypair, &outfile).unwrap();
 
         let matches = app()
             .clone()
@@ -141,7 +141,7 @@ mod tests {
     fn test_pubkey_of() {
         let keypair = Keypair::new();
         let outfile = tmp_file_path("test_gen_keypair_file.json", &keypair.pubkey());
-        let _ = write_keypair(&keypair, &outfile).unwrap();
+        let _ = write_keypair_file(&keypair, &outfile).unwrap();
 
         let matches = app()
             .clone()

--- a/cli/src/input_validators.rs
+++ b/cli/src/input_validators.rs
@@ -1,5 +1,5 @@
 use solana_sdk::pubkey::Pubkey;
-use solana_sdk::signature::read_keypair;
+use solana_sdk::signature::read_keypair_file;
 
 // Return an error if a pubkey cannot be parsed.
 pub fn is_pubkey(string: String) -> Result<(), String> {
@@ -11,7 +11,7 @@ pub fn is_pubkey(string: String) -> Result<(), String> {
 
 // Return an error if a keypair file cannot be parsed.
 pub fn is_keypair(string: String) -> Result<(), String> {
-    read_keypair(&string)
+    read_keypair_file(&string)
         .map(|_| ())
         .map_err(|err| format!("{:?}", err))
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -6,7 +6,7 @@ use solana_cli::{
     display::{println_name_value, println_name_value_or},
     input_validators::is_url,
 };
-use solana_sdk::signature::{read_keypair, KeypairUtil};
+use solana_sdk::signature::{read_keypair_file, KeypairUtil};
 use std::error;
 
 fn parse_settings(matches: &ArgMatches<'_>) -> Result<bool, Box<dyn error::Error>> {
@@ -94,7 +94,7 @@ pub fn parse_args(matches: &ArgMatches<'_>) -> Result<CliConfig, Box<dyn error::
         }
         default.keypair_path
     };
-    let keypair = read_keypair(&keypair_path).or_else(|err| {
+    let keypair = read_keypair_file(&keypair_path).or_else(|err| {
         Err(CliError::BadParameter(format!(
             "{}: Unable to open keypair file: {}",
             err, keypair_path

--- a/drone/src/bin/drone.rs
+++ b/drone/src/bin/drone.rs
@@ -1,7 +1,7 @@
 use clap::{crate_description, crate_name, crate_version, App, Arg};
 use solana_drone::drone::{run_drone, Drone, DRONE_PORT};
 use solana_drone::socketaddr;
-use solana_sdk::signature::read_keypair;
+use solana_sdk::signature::read_keypair_file;
 use std::error;
 use std::net::{Ipv4Addr, SocketAddr};
 use std::sync::{Arc, Mutex};
@@ -38,8 +38,8 @@ fn main() -> Result<(), Box<dyn error::Error>> {
         )
         .get_matches();
 
-    let mint_keypair =
-        read_keypair(matches.value_of("keypair").unwrap()).expect("failed to read client keypair");
+    let mint_keypair = read_keypair_file(matches.value_of("keypair").unwrap())
+        .expect("failed to read client keypair");
 
     let time_slice: Option<u64>;
     if let Some(secs) = matches.value_of("slice") {

--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -14,7 +14,7 @@ use solana_sdk::{
     poh_config::PohConfig,
     pubkey::Pubkey,
     rent_calculator::RentCalculator,
-    signature::{read_keypair, Keypair, KeypairUtil},
+    signature::{read_keypair_file, Keypair, KeypairUtil},
     system_program, timing,
 };
 use solana_stake_api::stake_state;
@@ -298,11 +298,11 @@ fn main() -> Result<(), Box<dyn error::Error>> {
     let bootstrap_leader_stake_lamports =
         value_t_or_exit!(matches, "bootstrap_leader_stake_lamports", u64);
 
-    let bootstrap_leader_keypair = read_keypair(bootstrap_leader_keypair_file)?;
-    let bootstrap_vote_keypair = read_keypair(bootstrap_vote_keypair_file)?;
-    let bootstrap_stake_keypair = read_keypair(bootstrap_stake_keypair_file)?;
-    let bootstrap_storage_keypair = read_keypair(bootstrap_storage_keypair_file)?;
-    let mint_keypair = read_keypair(mint_keypair_file)?;
+    let bootstrap_leader_keypair = read_keypair_file(bootstrap_leader_keypair_file)?;
+    let bootstrap_vote_keypair = read_keypair_file(bootstrap_vote_keypair_file)?;
+    let bootstrap_stake_keypair = read_keypair_file(bootstrap_stake_keypair_file)?;
+    let bootstrap_storage_keypair = read_keypair_file(bootstrap_storage_keypair_file)?;
+    let mint_keypair = read_keypair_file(mint_keypair_file)?;
 
     let vote_account = vote_state::create_account(
         &bootstrap_vote_keypair.pubkey(),

--- a/install/src/command.rs
+++ b/install/src/command.rs
@@ -9,7 +9,7 @@ use solana_client::rpc_client::RpcClient;
 use solana_config_api::{config_instruction, get_config_data};
 use solana_sdk::message::Message;
 use solana_sdk::pubkey::Pubkey;
-use solana_sdk::signature::{read_keypair, Keypair, KeypairUtil, Signable};
+use solana_sdk::signature::{read_keypair_file, Keypair, KeypairUtil, Signable};
 use solana_sdk::transaction::Transaction;
 use std::fs::{self, File};
 use std::io::{self, BufReader, Read};
@@ -626,9 +626,9 @@ pub fn deploy(
     download_url: &str,
     update_manifest_keypair_file: &str,
 ) -> Result<(), String> {
-    let from_keypair = read_keypair(from_keypair_file)
+    let from_keypair = read_keypair_file(from_keypair_file)
         .map_err(|err| format!("Unable to read {}: {}", from_keypair_file, err))?;
-    let update_manifest_keypair = read_keypair(update_manifest_keypair_file)
+    let update_manifest_keypair = read_keypair_file(update_manifest_keypair_file)
         .map_err(|err| format!("Unable to read {}: {}", update_manifest_keypair_file, err))?;
 
     println_name_value("JSON RPC URL:", json_rpc_url);

--- a/keygen/src/keygen.rs
+++ b/keygen/src/keygen.rs
@@ -48,7 +48,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                     Arg::with_name("silent")
                         .short("s")
                         .long("silent")
-                        .help("Do not display mnemonic phrase"),
+                        .help("Do not display mnemonic phrase. Useful when piping output to other programs that prompt for user input, like gpg"),
                 ),
         )
         .subcommand(
@@ -145,13 +145,13 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                 write_keypair(&keypair, &mut stdout)?;
             } else {
                 write_keypair_file(&keypair, outfile)?;
-                println!("Wrote new keypair to {}", outfile);
+                eprintln!("Wrote new keypair to {}", outfile);
             }
 
             let silent = matches.is_present("silent");
             if !silent {
                 let divider = String::from_utf8(vec![b'='; phrase.len()]).unwrap();
-                println!(
+                eprintln!(
                     "{}\nSave this mnemonic phrase to recover your new keypair:\n{}\n{}",
                     &divider, phrase, &divider
                 );
@@ -170,7 +170,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                 check_for_overwrite(&outfile, &matches);
             }
 
-            let phrase = rpassword::prompt_password_stdout("Mnemonic recovery phrase: ").unwrap();
+            let phrase = rpassword::prompt_password_stderr("Mnemonic recovery phrase: ").unwrap();
             let mnemonic = Mnemonic::from_phrase(phrase.trim(), Language::English)?;
             let seed = Seed::new(&mnemonic, NO_PASSPHRASE);
             let keypair = keypair_from_seed(seed.as_bytes())?;
@@ -179,7 +179,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
             if outfile == "-" {
                 println!("{}", serialized_keypair);
             } else {
-                println!("Wrote recovered keypair to {}", outfile);
+                eprintln!("Wrote recovered keypair to {}", outfile);
             }
         }
         _ => unreachable!(),

--- a/replicator/src/main.rs
+++ b/replicator/src/main.rs
@@ -3,7 +3,7 @@ use console::style;
 use solana_core::cluster_info::{Node, FULLNODE_PORT_RANGE};
 use solana_core::contact_info::ContactInfo;
 use solana_core::replicator::Replicator;
-use solana_sdk::signature::{read_keypair, Keypair, KeypairUtil};
+use solana_sdk::signature::{read_keypair_file, Keypair, KeypairUtil};
 use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::process::exit;
@@ -11,7 +11,7 @@ use std::sync::Arc;
 
 // Return an error if a keypair file cannot be parsed.
 fn is_keypair(string: String) -> Result<(), String> {
-    read_keypair(&string)
+    read_keypair_file(&string)
         .map(|_| ())
         .map_err(|err| format!("{:?}", err))
 }
@@ -65,7 +65,7 @@ fn main() {
     let ledger_path = PathBuf::from(matches.value_of("ledger").unwrap());
 
     let keypair = if let Some(identity) = matches.value_of("identity") {
-        read_keypair(identity).unwrap_or_else(|err| {
+        read_keypair_file(identity).unwrap_or_else(|err| {
             eprintln!("{}: Unable to open keypair file: {}", err, identity);
             exit(1);
         })
@@ -73,7 +73,7 @@ fn main() {
         Keypair::new()
     };
     let storage_keypair = if let Some(storage_keypair) = matches.value_of("storage_keypair") {
-        read_keypair(storage_keypair).unwrap_or_else(|err| {
+        read_keypair_file(storage_keypair).unwrap_or_else(|err| {
             eprintln!("{}: Unable to open keypair file: {}", err, storage_keypair);
             exit(1);
         })

--- a/validator/src/lib.rs
+++ b/validator/src/lib.rs
@@ -14,7 +14,7 @@ use solana_core::socketaddr;
 use solana_core::validator::{Validator, ValidatorConfig};
 use solana_sdk::clock::Slot;
 use solana_sdk::hash::Hash;
-use solana_sdk::signature::{read_keypair, Keypair, KeypairUtil};
+use solana_sdk::signature::{read_keypair_file, Keypair, KeypairUtil};
 use std::fs::{self, File};
 use std::io::{self, Read};
 use std::net::{SocketAddr, TcpListener};
@@ -219,7 +219,7 @@ fn initialize_ledger_path(
 
 // Return an error if a keypair file cannot be parsed.
 fn is_keypair(string: String) -> Result<(), String> {
-    read_keypair(&string)
+    read_keypair_file(&string)
         .map(|_| ())
         .map_err(|err| format!("{:?}", err))
 }
@@ -419,7 +419,7 @@ pub fn main() {
 
     let mut validator_config = ValidatorConfig::default();
     let keypair = if let Some(identity) = matches.value_of("identity") {
-        read_keypair(identity).unwrap_or_else(|err| {
+        read_keypair_file(identity).unwrap_or_else(|err| {
             error!("{}: Unable to open keypair file: {}", err, identity);
             exit(1);
         })
@@ -428,7 +428,7 @@ pub fn main() {
     };
 
     let voting_keypair = if let Some(identity) = matches.value_of("voting_keypair") {
-        read_keypair(identity).unwrap_or_else(|err| {
+        read_keypair_file(identity).unwrap_or_else(|err| {
             error!("{}: Unable to open keypair file: {}", err, identity);
             exit(1);
         })
@@ -436,7 +436,7 @@ pub fn main() {
         Keypair::new()
     };
     let storage_keypair = if let Some(storage_keypair) = matches.value_of("storage_keypair") {
-        read_keypair(storage_keypair).unwrap_or_else(|err| {
+        read_keypair_file(storage_keypair).unwrap_or_else(|err| {
             error!("{}: Unable to open keypair file: {}", err, storage_keypair);
             exit(1);
         })


### PR DESCRIPTION
#### Problem

There's no mechanism to encrypt a keypair generated by `solana-keygen`

#### Summary of Changes

1) Support reading from `stdin` in `read_keypair`
2) Print all non-key text output to `stderr` in `solana-keygen`

This allows a poor man's keypair encryption via tools such as `gpg` without the keypair plaintext ever touching disk.

```
# Key pair creation
$ solana-keygen new -o - | gpg -c -o key.json.gpg
# Print pubkey
$ gpg -d key.json.gpg | solana-keygen pubkey -
```

May require `$ export GPG_TTY=$(tty)` on a Mac.  You'll see an error along the lines of `Inappropriate ioctl for device`.

#### Caveat

When using `gpg`, the phase phrase prompt gets spammed by the mnemonic output *AND* the mnemonic output is cleared when the pass phrase prompt updates.  Be sure to copy the mnemonic before entering the passphrase.