### PR TITLE
remove verify_hash_internal_state

### DIFF
--- a/core/src/snapshot_utils.rs
+++ b/core/src/snapshot_utils.rs
@@ -136,10 +136,6 @@ pub fn add_snapshot<P: AsRef<Path>>(snapshot_path: P, bank: &Bank) -> Result<()>
         bank.slot(),
         snapshot_file_path,
     );
-    if !bank.verify_hash_internal_state() {
-        // Sanity check that the new snapshot is valid.  If not then there's a bad bug somewhere
-        panic!("Snapshot bank failed to verify");
-    }
 
     let snapshot_file = File::create(&snapshot_file_path)?;
     // snapshot writer


### PR DESCRIPTION
#### Problem
Call to `verify_hash_internal_state()` in `add_snapshot()` is expensive and causes squash times to reach 1 second or more

#### Summary of Changes
Remove call to `verify_hash_internal_state()` in `add_snapshot()`

Fixes #
