### PR TITLE
Remove special handling of first ledger tick

### DIFF
--- a/banking_bench/src/main.rs
+++ b/banking_bench/src/main.rs
@@ -41,7 +41,7 @@ fn check_txs(
     let now = Instant::now();
     let mut no_bank = false;
     loop {
-        if let Ok((_bank, (entry, _tick_count))) = receiver.recv_timeout(Duration::from_millis(10))
+        if let Ok((_bank, (entry, _tick_height))) = receiver.recv_timeout(Duration::from_millis(10))
         {
             total += entry.transactions.len();
         }

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -1052,7 +1052,7 @@ mod tests {
                 .map(|(_bank, (entry, _tick_height))| entry)
                 .collect();
             trace!("done");
-            assert_eq!(entries.len(), genesis_block.ticks_per_slot as usize - 1);
+            assert_eq!(entries.len(), genesis_block.ticks_per_slot as usize);
             assert!(entries.verify(&start_hash));
             assert_eq!(entries[entries.len() - 1].hash, bank.last_blockhash());
             banking_stage.join().unwrap();

--- a/core/src/blockstream.rs
+++ b/core/src/blockstream.rs
@@ -215,7 +215,7 @@ mod test {
         let mut entries = Vec::new();
         let mut expected_entries = Vec::new();
 
-        let tick_height_initial = 0;
+        let tick_height_initial = 1;
         let tick_height_final = tick_height_initial + ticks_per_slot + 2;
         let mut curr_slot = 0;
         let leader_pubkey = Pubkey::new_rand();
@@ -223,7 +223,7 @@ mod test {
         for tick_height in tick_height_initial..=tick_height_final {
             if tick_height == 5 {
                 blockstream
-                    .emit_block_event(curr_slot, tick_height - 1, &leader_pubkey, blockhash)
+                    .emit_block_event(curr_slot, tick_height, &leader_pubkey, blockhash)
                     .unwrap();
                 curr_slot += 1;
             }
@@ -238,7 +238,7 @@ mod test {
 
         assert_eq!(
             blockstream.entries().len() as u64,
-            // one entry per tick (0..=N+2) is +3, plus one block
+            // one entry per tick (1..=N+2) is +3, plus one block
             ticks_per_slot + 3 + 1
         );
 

--- a/core/src/blockstream_service.rs
+++ b/core/src/blockstream_service.rs
@@ -66,12 +66,9 @@ impl BlockstreamService {
         } else {
             Some(blocktree_meta.parent_slot)
         };
-        let ticks_per_slot = entries
-            .iter()
-            .filter(|entry| entry.is_tick())
-            .fold(0, |acc, _| acc + 1);
+        let ticks_per_slot = entries.iter().filter(|entry| entry.is_tick()).count() as u64;
         let mut tick_height = if slot > 0 && ticks_per_slot > 0 {
-            ticks_per_slot * slot - 1
+            ticks_per_slot * slot
         } else {
             0
         };
@@ -158,7 +155,7 @@ mod test {
         entries.extend_from_slice(&final_tick);
 
         let expected_entries = entries.clone();
-        let expected_tick_heights = [5, 6, 7, 8, 8, 9];
+        let expected_tick_heights = [6, 7, 8, 9, 9, 10];
 
         blocktree
             .write_entries(
@@ -234,7 +231,7 @@ mod test {
             let slot = json["s"].as_u64().unwrap();
             assert_eq!(1, slot);
             let height = json["h"].as_u64().unwrap();
-            assert_eq!(2 * ticks_per_slot - 1, height);
+            assert_eq!(2 * ticks_per_slot, height);
         }
     }
 }

--- a/core/src/blockstream_service.rs
+++ b/core/src/blockstream_service.rs
@@ -67,11 +67,7 @@ impl BlockstreamService {
             Some(blocktree_meta.parent_slot)
         };
         let ticks_per_slot = entries.iter().filter(|entry| entry.is_tick()).count() as u64;
-        let mut tick_height = if slot > 0 && ticks_per_slot > 0 {
-            ticks_per_slot * slot
-        } else {
-            0
-        };
+        let mut tick_height = ticks_per_slot * slot;
 
         for (i, entry) in entries.iter().enumerate() {
             if entry.is_tick() {

--- a/core/src/blocktree.rs
+++ b/core/src/blocktree.rs
@@ -805,7 +805,6 @@ impl Blocktree {
         self.code_shred_cf.get_bytes((slot, index))
     }
 
-    #[cfg(test)]
     pub fn write_entries(
         &self,
         start_slot: u64,

--- a/core/src/blocktree.rs
+++ b/core/src/blocktree.rs
@@ -805,6 +805,7 @@ impl Blocktree {
         self.code_shred_cf.get_bytes((slot, index))
     }
 
+    #[cfg(test)]
     pub fn write_entries(
         &self,
         start_slot: u64,

--- a/core/src/broadcast_stage/broadcast_fake_blobs_run.rs
+++ b/core/src/broadcast_stage/broadcast_fake_blobs_run.rs
@@ -28,7 +28,7 @@ impl BroadcastRun for BroadcastFakeBlobsRun {
         // 1) Pull entries from banking stage
         let receive_results = broadcast_utils::recv_slot_entries(receiver)?;
         let bank = receive_results.bank.clone();
-        let last_tick = receive_results.last_tick;
+        let last_tick_height = receive_results.last_tick_height;
 
         let keypair = &cluster_info.read().unwrap().keypair.clone();
         let next_shred_index = blocktree
@@ -49,7 +49,7 @@ impl BroadcastRun for BroadcastFakeBlobsRun {
 
         let (data_shreds, coding_shreds, _) = shredder.entries_to_shreds(
             &receive_results.entries,
-            last_tick == bank.max_tick_height(),
+            last_tick_height == bank.max_tick_height(),
             next_shred_index,
         );
 
@@ -65,13 +65,13 @@ impl BroadcastRun for BroadcastFakeBlobsRun {
 
         let (fake_data_shreds, fake_coding_shreds, _) = shredder.entries_to_shreds(
             &fake_entries,
-            last_tick == bank.max_tick_height(),
+            last_tick_height == bank.max_tick_height(),
             next_shred_index,
         );
 
         // If it's the last tick, reset the last block hash to default
         // this will cause next run to grab last bank's blockhash
-        if last_tick == bank.max_tick_height() {
+        if last_tick_height == bank.max_tick_height() {
             self.last_blockhash = Hash::default();
         }
 

--- a/core/src/broadcast_stage/broadcast_utils.rs
+++ b/core/src/broadcast_stage/broadcast_utils.rs
@@ -20,7 +20,7 @@ pub struct UnfinishedSlotInfo {
     pub parent: u64,
 }
 
-/// Theis parameter tunes how many entries are received in one iteration of recv loop
+/// This parameter tunes how many entries are received in one iteration of recv loop
 /// This will prevent broadcast stage from consuming more entries, that could have led
 /// to delays in shredding, and broadcasting shreds to peer validators
 const RECEIVE_ENTRY_COUNT_THRESHOLD: usize = 8;
@@ -106,7 +106,7 @@ mod tests {
         let mut last_hash = genesis_block.hash();
 
         assert!(bank1.max_tick_height() > 1);
-        let entries: Vec<_> = (0..bank1.max_tick_height() + 1)
+        let entries: Vec<_> = (1..bank1.max_tick_height() + 1)
             .map(|i| {
                 let entry = Entry::new(&last_hash, 1, vec![tx.clone()]);
                 last_hash = entry.hash;

--- a/core/src/broadcast_stage/broadcast_utils.rs
+++ b/core/src/broadcast_stage/broadcast_utils.rs
@@ -10,7 +10,7 @@ pub(super) struct ReceiveResults {
     pub entries: Vec<Entry>,
     pub time_elapsed: Duration,
     pub bank: Arc<Bank>,
-    pub last_tick: u64,
+    pub last_tick_height: u64,
 }
 
 #[derive(Copy, Clone)]
@@ -28,15 +28,15 @@ const RECEIVE_ENTRY_COUNT_THRESHOLD: usize = 8;
 pub(super) fn recv_slot_entries(receiver: &Receiver<WorkingBankEntry>) -> Result<ReceiveResults> {
     let timer = Duration::new(1, 0);
     let recv_start = Instant::now();
-    let (mut bank, (entry, mut last_tick)) = receiver.recv_timeout(timer)?;
+    let (mut bank, (entry, mut last_tick_height)) = receiver.recv_timeout(timer)?;
 
     let mut entries = vec![entry];
     let mut slot = bank.slot();
     let mut max_tick_height = bank.max_tick_height();
 
-    assert!(last_tick <= max_tick_height);
+    assert!(last_tick_height <= max_tick_height);
 
-    if last_tick != max_tick_height {
+    if last_tick_height != max_tick_height {
         while let Ok((try_bank, (entry, tick_height))) = receiver.try_recv() {
             // If the bank changed, that implies the previous slot was interrupted and we do not have to
             // broadcast its entries.
@@ -47,15 +47,15 @@ pub(super) fn recv_slot_entries(receiver: &Receiver<WorkingBankEntry>) -> Result
                 slot = bank.slot();
                 max_tick_height = bank.max_tick_height();
             }
-            last_tick = tick_height;
+            last_tick_height = tick_height;
             entries.push(entry);
 
             if entries.len() >= RECEIVE_ENTRY_COUNT_THRESHOLD {
                 break;
             }
 
-            assert!(last_tick <= max_tick_height);
-            if last_tick == max_tick_height {
+            assert!(last_tick_height <= max_tick_height);
+            if last_tick_height == max_tick_height {
                 break;
             }
         }
@@ -66,7 +66,7 @@ pub(super) fn recv_slot_entries(receiver: &Receiver<WorkingBankEntry>) -> Result
         entries,
         time_elapsed,
         bank,
-        last_tick,
+        last_tick_height,
     })
 }
 
@@ -118,7 +118,7 @@ mod tests {
         let result = recv_slot_entries(&r).unwrap();
 
         assert_eq!(result.bank.slot(), bank1.slot());
-        assert_eq!(result.last_tick, bank1.max_tick_height());
+        assert_eq!(result.last_tick_height, bank1.max_tick_height());
         assert_eq!(result.entries, entries);
     }
 
@@ -133,17 +133,18 @@ mod tests {
         let mut last_hash = genesis_block.hash();
         assert!(bank1.max_tick_height() > 1);
         // Simulate slot 2 interrupting slot 1's transmission
-        let expected_last_index = bank1.max_tick_height() - 1;
-        let last_entry = (0..bank1.max_tick_height())
-            .map(|i| {
+        let expected_last_height = bank1.max_tick_height();
+        let last_entry = (1..=bank1.max_tick_height())
+            .map(|tick_height| {
                 let entry = Entry::new(&last_hash, 1, vec![tx.clone()]);
                 last_hash = entry.hash;
                 // Interrupt slot 1 right before the last tick
-                if i == expected_last_index {
-                    s.send((bank2.clone(), (entry.clone(), i))).unwrap();
+                if tick_height == expected_last_height {
+                    s.send((bank2.clone(), (entry.clone(), tick_height)))
+                        .unwrap();
                     Some(entry)
                 } else {
-                    s.send((bank1.clone(), (entry, i))).unwrap();
+                    s.send((bank1.clone(), (entry, tick_height))).unwrap();
                     None
                 }
             })
@@ -153,7 +154,7 @@ mod tests {
 
         let result = recv_slot_entries(&r).unwrap();
         assert_eq!(result.bank.slot(), bank2.slot());
-        assert_eq!(result.last_tick, expected_last_index);
+        assert_eq!(result.last_tick_height, expected_last_height);
         assert_eq!(result.entries, vec![last_entry]);
     }
 }

--- a/core/src/broadcast_stage/fail_entry_verification_broadcast_run.rs
+++ b/core/src/broadcast_stage/fail_entry_verification_broadcast_run.rs
@@ -21,11 +21,11 @@ impl BroadcastRun for FailEntryVerificationBroadcastRun {
         // 1) Pull entries from banking stage
         let mut receive_results = broadcast_utils::recv_slot_entries(receiver)?;
         let bank = receive_results.bank.clone();
-        let last_tick = receive_results.last_tick;
+        let last_tick_height = receive_results.last_tick_height;
 
         // 2) Convert entries to blobs + generate coding blobs. Set a garbage PoH on the last entry
         // in the slot to make verification fail on validators
-        if last_tick == bank.max_tick_height() {
+        if last_tick_height == bank.max_tick_height() {
             let mut last_entry = receive_results.entries.last_mut().unwrap();
             last_entry.hash = Hash::default();
         }
@@ -47,7 +47,7 @@ impl BroadcastRun for FailEntryVerificationBroadcastRun {
 
         let (data_shreds, coding_shreds, _) = shredder.entries_to_shreds(
             &receive_results.entries,
-            last_tick == bank.max_tick_height(),
+            last_tick_height == bank.max_tick_height(),
             next_shred_index,
         );
 

--- a/core/src/broadcast_stage/standard_broadcast_run.rs
+++ b/core/src/broadcast_stage/standard_broadcast_run.rs
@@ -144,7 +144,7 @@ impl StandardBroadcastRun {
         let mut receive_elapsed = receive_results.time_elapsed;
         let num_entries = receive_results.entries.len();
         let bank = receive_results.bank.clone();
-        let last_tick = receive_results.last_tick;
+        let last_tick_height = receive_results.last_tick_height;
         inc_new_counter_info!("broadcast_service-entries_received", num_entries);
 
         if self.current_slot_and_parent.is_none()
@@ -173,7 +173,7 @@ impl StandardBroadcastRun {
         let (data_shreds, coding_shreds) = self.entries_to_shreds(
             blocktree,
             &receive_results.entries,
-            last_tick == bank.max_tick_height(),
+            last_tick_height == bank.max_tick_height(),
         );
         let to_shreds_elapsed = to_shreds_start.elapsed();
 
@@ -214,7 +214,7 @@ impl StandardBroadcastRun {
             duration_as_us(&insert_shreds_elapsed),
             duration_as_us(&broadcast_elapsed),
             duration_as_us(&clone_and_seed_elapsed),
-            last_tick == bank.max_tick_height(),
+            last_tick_height == bank.max_tick_height(),
         );
 
         if last_tick == bank.max_tick_height() {

--- a/core/src/broadcast_stage/standard_broadcast_run.rs
+++ b/core/src/broadcast_stage/standard_broadcast_run.rs
@@ -353,7 +353,7 @@ mod test {
             entries: ticks.clone(),
             time_elapsed: Duration::new(3, 0),
             bank: bank0.clone(),
-            last_tick: (ticks.len() - 1) as u64,
+            last_tick_height: (ticks.len() - 1) as u64,
         };
 
         // Step 1: Make an incomplete transmission for slot 0
@@ -391,7 +391,7 @@ mod test {
             entries: ticks.clone(),
             time_elapsed: Duration::new(2, 0),
             bank: bank2.clone(),
-            last_tick: (ticks.len() - 1) as u64,
+            last_tick_height: (ticks.len() - 1) as u64,
         };
         standard_broadcast_run
             .process_receive_results(&cluster_info, &socket, &blocktree, receive_results)
@@ -420,7 +420,7 @@ mod test {
             entries: ticks.clone(),
             time_elapsed: Duration::new(3, 0),
             bank: bank0.clone(),
-            last_tick: (ticks.len() - 1) as u64,
+            last_tick_height: (ticks.len() - 1) as u64,
         };
 
         let mut standard_broadcast_run = StandardBroadcastRun::new(leader_keypair);

--- a/core/src/broadcast_stage/standard_broadcast_run.rs
+++ b/core/src/broadcast_stage/standard_broadcast_run.rs
@@ -217,7 +217,7 @@ impl StandardBroadcastRun {
             last_tick_height == bank.max_tick_height(),
         );
 
-        if last_tick == bank.max_tick_height() {
+        if last_tick_height == bank.max_tick_height() {
             self.unfinished_slot = None;
         }
 

--- a/core/src/broadcast_stage/standard_broadcast_run.rs
+++ b/core/src/broadcast_stage/standard_broadcast_run.rs
@@ -420,7 +420,7 @@ mod test {
             entries: ticks.clone(),
             time_elapsed: Duration::new(3, 0),
             bank: bank0.clone(),
-            last_tick_height: (ticks.len() - 1) as u64,
+            last_tick_height: ticks.len() as u64,
         };
 
         let mut standard_broadcast_run = StandardBroadcastRun::new(leader_keypair);

--- a/core/src/leader_schedule_utils.rs
+++ b/core/src/leader_schedule_utils.rs
@@ -30,7 +30,7 @@ pub fn slot_leader_at(slot: u64, bank: &Bank) -> Option<Pubkey> {
 // Returns the number of ticks remaining from the specified tick_height to the end of the
 // slot implied by the tick_height
 pub fn num_ticks_left_in_slot(bank: &Bank, tick_height: u64) -> u64 {
-    bank.ticks_per_slot() - tick_height % bank.ticks_per_slot() - 1
+    bank.ticks_per_slot() - tick_height % bank.ticks_per_slot()
 }
 
 fn sort_stakes(stakes: &mut Vec<(Pubkey, u64)>) {

--- a/core/src/poh_recorder.rs
+++ b/core/src/poh_recorder.rs
@@ -279,8 +279,9 @@ impl PohRecorder {
                 working_bank.max_tick_height,
                 working_bank.bank.slot()
             );
-            self.start_slot = working_bank.max_tick_height / self.ticks_per_slot - 1;
-            self.start_tick = (self.start_slot + 1) * self.ticks_per_slot + 1;
+            let current_slot = working_bank.max_tick_height / self.ticks_per_slot;
+            self.start_slot = current_slot.saturating_sub(1);
+            self.start_tick = current_slot * self.ticks_per_slot + 1;
             self.clear_bank();
         }
         if send_result.is_err() {
@@ -1041,7 +1042,7 @@ mod tests {
             );
 
             let end_slot = 3;
-            let max_tick_height = (end_slot + 1) * ticks_per_slot - 1;
+            let max_tick_height = (end_slot + 1) * ticks_per_slot;
             let working_bank = WorkingBank {
                 bank: bank.clone(),
                 min_tick_height: 1,

--- a/core/src/poh_recorder.rs
+++ b/core/src/poh_recorder.rs
@@ -51,9 +51,9 @@ pub struct PohRecorder {
     pub poh: Arc<Mutex<Poh>>,
     tick_height: u64,
     clear_bank_signal: Option<SyncSender<bool>>,
-    start_slot: Slot,       // parent slot
-    start_tick_height: u64, // first tick_height this recorder will observe
-    tick_cache: Vec<(Entry, u64)>,
+    start_slot: Slot,              // parent slot
+    start_tick_height: u64,        // first tick_height this recorder will observe
+    tick_cache: Vec<(Entry, u64)>, // cache of entry and its tick_height
     working_bank: Option<WorkingBank>,
     sender: Sender<WorkingBankEntry>,
     leader_first_tick_height: Option<u64>,

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -1008,7 +1008,7 @@ mod test {
         genesis_block.epoch_schedule.warmup = false;
         genesis_block.ticks_per_slot = 4;
         let bank0 = Bank::new(&genesis_block);
-        for _ in 1..genesis_block.ticks_per_slot {
+        for _ in 0..genesis_block.ticks_per_slot {
             bank0.register_tick(&Hash::default());
         }
         bank0.freeze();

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -288,14 +288,14 @@ impl ReplayStage {
 
         assert!(!poh_recorder.lock().unwrap().has_bank());
 
-        let (reached_leader_tick, _grace_ticks, poh_slot, parent_slot) =
-            poh_recorder.lock().unwrap().reached_leader_tick();
+        let (reached_leader_slot, _grace_ticks, poh_slot, parent_slot) =
+            poh_recorder.lock().unwrap().reached_leader_slot();
 
-        if !reached_leader_tick {
-            trace!("{} poh_recorder hasn't reached_leader_tick", my_pubkey);
+        if !reached_leader_slot {
+            trace!("{} poh_recorder hasn't reached_leader_slot", my_pubkey);
             return;
         }
-        trace!("{} reached_leader_tick", my_pubkey,);
+        trace!("{} reached_leader_slot", my_pubkey);
 
         let parent = bank_forks
             .read()

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -318,7 +318,7 @@ impl Bank {
             slots_per_year: parent.slots_per_year,
             epoch_schedule,
             rent_collector: parent.rent_collector.clone_with_epoch(epoch),
-            max_tick_height: (slot + 1) * parent.ticks_per_slot - 1,
+            max_tick_height: (slot + 1) * parent.ticks_per_slot,
             block_height: parent.block_height + 1,
             fee_calculator: FeeCalculator::new_derived(
                 &parent.fee_calculator,
@@ -648,7 +648,7 @@ impl Bank {
 
         self.ticks_per_slot = genesis_block.ticks_per_slot;
         self.slots_per_segment = genesis_block.slots_per_segment;
-        self.max_tick_height = (self.slot + 1) * self.ticks_per_slot - 1;
+        self.max_tick_height = (self.slot + 1) * self.ticks_per_slot;
         //   ticks/year     =      seconds/year ...
         self.slots_per_year = SECONDS_PER_YEAR
         //  * (ns/s)/(ns/tick) / ticks/slot = 1/s/1/tick = ticks/s
@@ -795,7 +795,7 @@ impl Bank {
         let should_register_hash = {
             if self.ticks_per_slot() != 1 || self.slot() != 0 {
                 let lock = {
-                    if (current_tick_height + 1) % self.ticks_per_slot == self.ticks_per_slot - 1 {
+                    if current_tick_height % self.ticks_per_slot == self.ticks_per_slot - 1 {
                         Some(self.blockhash_queue.write().unwrap())
                     } else {
                         None
@@ -804,7 +804,7 @@ impl Bank {
                 self.tick_height.fetch_add(1, Ordering::Relaxed);
                 inc_new_counter_debug!("bank-register_tick-registered", 1);
                 lock
-            } else if current_tick_height % self.ticks_per_slot == self.ticks_per_slot - 1 {
+            } else if current_tick_height % self.ticks_per_slot == 0 {
                 // Register a new block hash if at the last tick in the slot
                 Some(self.blockhash_queue.write().unwrap())
             } else {
@@ -2816,7 +2816,7 @@ mod tests {
         assert_eq!(bank.is_votable(), false);
 
         // Register enough ticks to hit max tick height
-        for i in 0..genesis_block.ticks_per_slot - 1 {
+        for i in 0..genesis_block.ticks_per_slot {
             bank.register_tick(&hash::hash(format!("hello world {}", i).as_bytes()));
         }
 
@@ -2829,7 +2829,7 @@ mod tests {
         assert_eq!(bank.is_votable(), false);
 
         // Register enough ticks to hit max tick height
-        for i in 0..genesis_block.ticks_per_slot - 1 {
+        for i in 0..genesis_block.ticks_per_slot {
             bank.register_tick(&hash::hash(format!("hello world {}", i).as_bytes()));
         }
         // empty banks aren't votable even at max tick height
@@ -2940,7 +2940,7 @@ mod tests {
         let (genesis_block, _) = create_genesis_block(500);
         let bank = Arc::new(Bank::new(&genesis_block));
         //set tick height to max
-        let max_tick_height = (bank.slot + 1) * bank.ticks_per_slot - 1;
+        let max_tick_height = (bank.slot + 1) * bank.ticks_per_slot;
         bank.tick_height.store(max_tick_height, Ordering::Relaxed);
         assert!(bank.is_votable());
     }


### PR DESCRIPTION
#### Problem
Handling slot 0 currently requires special handling due to how the first ledger tick is treated. For some reason the first tick was not registered. It seems that this was due to a past implementation detail that is no longer relevant.

#### Summary of Changes
* Remove special handling of first tick
* Change `tick_height` and `max_tick_height` to be accurate (include the first tick)
* Add `_height` suffix to `..._tick` variables to avoid ambiguity