### PR TITLE
Colo: Factor out inlined scripts to own files

### DIFF
--- a/net/scripts/colo-node-onacquire-sh
+++ b/net/scripts/colo-node-onacquire-sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+# XXX: This file isn't *quite* a script.  It is intended to be passed via stdin
+# to a node to requisition logic up node creation.  Currently this is done in
+# colo_node_requisition using the eval-cat trick.  While this gets us what we
+# want, care must be taken to ensure variable expansion happens at the right
+# time. Any unescaped variable references ($X) in this file will be expanded by
+# eval in colo_node_requisition. Escaped variable references (\$X) will be
+# expanded upon execution on the remote node.
+
+if [ ! -f "$SOLANA_LOCK_FILE" ]; then
+  exec 9>>"$SOLANA_LOCK_FILE"
+  flock -x -n 9 || exit 1
+  [ -n "\$SOLANA_USER" ] && {
+    echo "export SOLANA_LOCK_USER=\$SOLANA_USER"
+    echo "export SOLANA_LOCK_INSTANCENAME=$INSTANCE_NAME"
+    echo "[ -v SSH_TTY -a -f \"\${HOME}/.solana-motd\" ] && cat \"\${HOME}/.solana-motd\" 1>&2"
+  } >&9 || ( rm "$SOLANA_LOCK_FILE" && false )
+  9>&-
+  cat > /solana-scratch/id_ecdsa <<EOK
+$(cat "$SSH_PRIVATE_KEY")
+EOK
+  cat > /solana-scratch/id_ecdsa.pub <<EOK
+$(cat "${SSH_PRIVATE_KEY}.pub")
+EOK
+  chmod 0600 /solana-scratch/id_ecdsa
+  cat > /solana-scratch/authorized_keys <<EOAK
+$("$__colo_here"/add-datacenter-solana-user-authorized_keys.sh 2> /dev/null)
+$(cat "${SSH_PRIVATE_KEY}.pub")
+EOAK
+  cp /solana-scratch/id_ecdsa "\${HOME}/.ssh/id_ecdsa"
+  cp /solana-scratch/id_ecdsa.pub "\${HOME}/.ssh/id_ecdsa.pub"
+  cp /solana-scratch/authorized_keys "\${HOME}/.ssh/authorized_keys"
+  cat > "\${HOME}/.solana-motd" <<EOM
+
+
+$(printNetworkInfo)
+$(creationInfo)
+EOM
+
+  # XXX: Stamp creation MUST be last!
+  touch /solana-scratch/.instance-startup-complete
+else
+  false
+fi

--- a/net/scripts/colo-node-onfree-sh
+++ b/net/scripts/colo-node-onfree-sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+# XXX: This file isn't *quite* a script.  It is intended to be passed via stdin
+# to a node to execute cleanup logic upon deletion.  Currently this is done in
+# colo_node_free using the eval-cat trick.  While this gets us what we want,
+# care must be taken to ensure variable expansion happens at the right time.
+# Any unescaped variable references ($X) in this file will be expanded by eval
+# in colo_node_free. Escaped variable references (\$X) will be expanded upon
+# execution on the remote node.
+
+RC=false
+if [ -f "$SOLANA_LOCK_FILE" ]; then
+  exec 9<>"$SOLANA_LOCK_FILE"
+  flock -x -n 9 || exit 1
+  . "$SOLANA_LOCK_FILE"
+  if [ "\$SOLANA_LOCK_USER" = "\$SOLANA_USER" ]; then
+    git clean -qxdff
+    rm -f /solana-scratch/* /solana-scratch/.[^.]*
+    cat > "\${HOME}/.ssh/authorized_keys" <<EOAK
+$("$__colo_here"/add-datacenter-solana-user-authorized_keys.sh 2> /dev/null)
+EOAK
+    RC=true
+  fi
+  9>&-
+fi
+\$RC
+

--- a/net/scripts/colo-utils.sh
+++ b/net/scripts/colo-utils.sh
@@ -182,45 +182,10 @@ colo_node_requisition() {
   INDEX=$(colo_res_index_from_ip "$IP")
   declare RC=false
 
-  colo_instance_run "$IP" "$(
-cat <<EOF
-  if [ ! -f "$SOLANA_LOCK_FILE" ]; then
-    exec 9>>"$SOLANA_LOCK_FILE"
-    flock -x -n 9 || exit 1
-    [ -n "\$SOLANA_USER" ] && {
-      echo "export SOLANA_LOCK_USER=\$SOLANA_USER"
-      echo "export SOLANA_LOCK_INSTANCENAME=$INSTANCE_NAME"
-      echo "[ -v SSH_TTY -a -f \"\${HOME}/.solana-motd\" ] && cat \"\${HOME}/.solana-motd\" 1>&2"
-    } >&9 || ( rm "$SOLANA_LOCK_FILE" && false )
-    9>&-
-    cat > /solana-scratch/id_ecdsa <<EOK
-$(cat "$SSH_PRIVATE_KEY")
-EOK
-    cat > /solana-scratch/id_ecdsa.pub <<EOK
-$(cat "${SSH_PRIVATE_KEY}.pub")
-EOK
-    chmod 0600 /solana-scratch/id_ecdsa
-    cat > /solana-scratch/authorized_keys <<EOAK
-$("$__colo_here"/add-datacenter-solana-user-authorized_keys.sh 2> /dev/null)
-$(cat "${SSH_PRIVATE_KEY}.pub")
-EOAK
-    cp /solana-scratch/id_ecdsa "\${HOME}/.ssh/id_ecdsa"
-    cp /solana-scratch/id_ecdsa.pub "\${HOME}/.ssh/id_ecdsa.pub"
-    cp /solana-scratch/authorized_keys "\${HOME}/.ssh/authorized_keys"
-    cat > "\${HOME}/.solana-motd" <<EOM
-
-
-$(printNetworkInfo)
-$(creationInfo)
-EOM
-
-    # XXX: Stamp creation MUST be last!
-    touch /solana-scratch/.instance-startup-complete
-  else
-    false
-  fi
+  colo_instance_run "$IP" "$(eval "cat <<EOF
+  $(<"$__colo_here"/colo-node-onacquire-sh)
 EOF
-  )"
+  ")"
   # shellcheck disable=SC2181
   if [[ 0 -eq $? ]]; then
     COLO_RES_REQUISITIONED+=("$INDEX")
@@ -255,26 +220,10 @@ colo_machine_types_compatible() {
 
 colo_node_free() {
   declare IP=$1
-  colo_instance_run "$IP" "$(
-cat <<EOF
-  RC=false
-  if [ -f "$SOLANA_LOCK_FILE" ]; then
-    exec 9<>"$SOLANA_LOCK_FILE"
-    flock -x -n 9 || exit 1
-    . "$SOLANA_LOCK_FILE"
-    if [ "\$SOLANA_LOCK_USER" = "\$SOLANA_USER" ]; then
-      git clean -qxdff
-      rm -f /solana-scratch/* /solana-scratch/.[^.]*
-      cat > "\${HOME}/.ssh/authorized_keys" <<EOAK
-$("$__colo_here"/add-datacenter-solana-user-authorized_keys.sh 2> /dev/null)
-EOAK
-      RC=true
-    fi
-    9>&-
-  fi
-  \$RC
+  colo_instance_run "$IP" "$(eval "cat <<EOF
+  $(<"$__colo_here"/colo-node-onfree-sh)
 EOF
-  )"
+  ")"
 }
 
 

--- a/net/scripts/colo-utils.sh
+++ b/net/scripts/colo-utils.sh
@@ -175,7 +175,9 @@ colo_node_status_all() {
 export COLO_RES_REQUISITIONED=()
 colo_node_requisition() {
   declare IP=$1
+  # shellcheck disable=SC2034
   declare INSTANCE_NAME=$2
+  # shellcheck disable=SC2034
   declare SSH_PRIVATE_KEY="$3"
 
   declare INDEX


### PR DESCRIPTION
#### Problem

Inlined acquisition and free scripts are getting a little big for their britches 

#### Summary of Changes

Copy them out to their own files and eval-cat them back into `colo-utils.sh` at runtime.

This is a logical NOP