### PR TITLE
increase rocks buffer sizes

### DIFF
--- a/core/src/blocktree/rocks.rs
+++ b/core/src/blocktree/rocks.rs
@@ -419,11 +419,11 @@ impl std::convert::From<rocksdb::Error> for Error {
 }
 
 fn get_cf_options(name: &'static str) -> Options {
-    use crate::blocktree::db::columns::{ShredCode, ShredData};
+    use crate::blocktree::db::columns::{ShredCode, ShredData, Index};
 
     let mut options = Options::default();
     match name {
-        ShredCode::NAME | ShredData::NAME => {
+        ShredCode::NAME | ShredData::NAME | Index::NAME => {
             // 512MB * 8 = 4GB. 2 of these columns should take no more than 8GB of RAM
             options.set_max_write_buffer_number(8);
             options.set_write_buffer_size(MAX_WRITE_BUFFER_SIZE as usize);


### PR DESCRIPTION
#### Problem
Inserts into blocktree are slowed by small buffer sizes on certain column families

#### Summary of Changes
Increase blocktree column sizes

Fixes #
