### PR TITLE
Broadcast final shred for slots that are interrupted

### DIFF
--- a/core/benches/shredder.rs
+++ b/core/benches/shredder.rs
@@ -4,7 +4,7 @@ extern crate test;
 
 use solana_core::entry::create_ticks;
 use solana_core::shred::{
-    max_ticks_per_shred, Shredder, RECOMMENDED_FEC_RATE, SIZE_OF_DATA_SHRED_HEADER,
+    max_ticks_per_n_shreds, Shredder, RECOMMENDED_FEC_RATE, SIZE_OF_DATA_SHRED_HEADER,
 };
 use solana_sdk::hash::Hash;
 use solana_sdk::packet::PACKET_DATA_SIZE;
@@ -18,7 +18,7 @@ fn bench_shredder(bencher: &mut Bencher) {
     let shred_size = PACKET_DATA_SIZE - *SIZE_OF_DATA_SHRED_HEADER;
     let num_shreds = ((1000 * 1000) + (shred_size - 1)) / shred_size;
     // ~1Mb
-    let num_ticks = max_ticks_per_shred() * num_shreds as u64;
+    let num_ticks = max_ticks_per_n_shreds(1) * num_shreds as u64;
     let entries = create_ticks(num_ticks, Hash::default());
     bencher.iter(|| {
         let shredder = Shredder::new(1, 0, RECOMMENDED_FEC_RATE, kp.clone()).unwrap();
@@ -32,7 +32,7 @@ fn bench_deshredder(bencher: &mut Bencher) {
     let shred_size = PACKET_DATA_SIZE - *SIZE_OF_DATA_SHRED_HEADER;
     // ~10Mb
     let num_shreds = ((10000 * 1000) + (shred_size - 1)) / shred_size;
-    let num_ticks = max_ticks_per_shred() * num_shreds as u64;
+    let num_ticks = max_ticks_per_n_shreds(1) * num_shreds as u64;
     let entries = create_ticks(num_ticks, Hash::default());
     let shredder = Shredder::new(1, 0, RECOMMENDED_FEC_RATE, kp).unwrap();
     let data_shreds = shredder.entries_to_shreds(&entries, true, 0).0;

--- a/core/src/blocktree.rs
+++ b/core/src/blocktree.rs
@@ -1653,7 +1653,7 @@ pub mod tests {
     use super::*;
     use crate::entry::{create_ticks, Entry};
     use crate::genesis_utils::{create_genesis_block, GenesisBlockInfo};
-    use crate::shred::max_ticks_per_shred;
+    use crate::shred::max_ticks_per_n_shreds;
     use itertools::Itertools;
     use rand::seq::SliceRandom;
     use rand::thread_rng;
@@ -1682,7 +1682,7 @@ pub mod tests {
     #[test]
     fn test_insert_get_bytes() {
         // Create enough entries to ensure there are at least two shreds created
-        let num_entries = max_ticks_per_shred() + 1;
+        let num_entries = max_ticks_per_n_shreds(1) + 1;
         assert!(num_entries > 1);
 
         let (mut shreds, _) = make_slot_entries(0, 0, num_entries);
@@ -1921,7 +1921,7 @@ pub mod tests {
     #[test]
     fn test_insert_data_shreds_basic() {
         // Create enough entries to ensure there are at least two shreds created
-        let num_entries = max_ticks_per_shred() + 1;
+        let num_entries = max_ticks_per_n_shreds(1) + 1;
         assert!(num_entries > 1);
 
         let (mut shreds, entries) = make_slot_entries(0, 0, num_entries);
@@ -2144,7 +2144,7 @@ pub mod tests {
         {
             let blocktree = Blocktree::open(&blocktree_path).unwrap();
             // Create enough entries to ensure there are at least two shreds created
-            let min_entries = max_ticks_per_shred() + 1;
+            let min_entries = max_ticks_per_n_shreds(1) + 1;
             for i in 0..4 {
                 let slot = i;
                 let parent_slot = if i == 0 { 0 } else { i - 1 };
@@ -2557,7 +2557,7 @@ pub mod tests {
             let blocktree = Blocktree::open(&blocktree_path).unwrap();
             let num_slots = 15;
             // Create enough entries to ensure there are at least two shreds created
-            let entries_per_slot = max_ticks_per_shred() + 1;
+            let entries_per_slot = max_ticks_per_n_shreds(1) + 1;
             assert!(entries_per_slot > 1);
 
             let (mut shreds, _) = make_many_slot_entries(0, num_slots, entries_per_slot);
@@ -2907,7 +2907,7 @@ pub mod tests {
         let gap: u64 = 10;
         assert!(gap > 3);
         // Create enough entries to ensure there are at least two shreds created
-        let num_entries = max_ticks_per_shred() + 1;
+        let num_entries = max_ticks_per_n_shreds(1) + 1;
         let entries = create_ticks(num_entries, Hash::default());
         let mut shreds = entries_to_test_shreds(entries, slot, 0, true);
         let num_shreds = shreds.len();

--- a/core/src/broadcast_stage.rs
+++ b/core/src/broadcast_stage.rs
@@ -8,7 +8,7 @@ use crate::poh_recorder::WorkingBankEntry;
 use crate::result::{Error, Result};
 use crate::service::Service;
 use crate::staking_utils;
-use solana_metrics::{datapoint_debug, inc_new_counter_error, inc_new_counter_info};
+use solana_metrics::{inc_new_counter_error, inc_new_counter_info};
 use std::net::UdpSocket;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::{Receiver, RecvTimeoutError};

--- a/core/src/broadcast_stage/broadcast_utils.rs
+++ b/core/src/broadcast_stage/broadcast_utils.rs
@@ -15,7 +15,7 @@ pub(super) struct ReceiveResults {
 
 #[derive(Copy, Clone)]
 pub struct UnfinishedSlotInfo {
-    pub next_index: u64,
+    pub next_shred_index: u32,
     pub slot: u64,
     pub parent: u64,
 }

--- a/core/src/broadcast_stage/standard_broadcast_run.rs
+++ b/core/src/broadcast_stage/standard_broadcast_run.rs
@@ -313,6 +313,15 @@ mod test {
         // Modify the stats, should reset later
         standard_broadcast_run.stats.receive_elapsed = 10;
 
+        // Try to fetch ticks from blocktree, nothing should break
+        assert_eq!(blocktree.get_slot_entries(0, 0, None).unwrap(), ticks);
+        assert_eq!(
+            blocktree
+                .get_slot_entries(0, num_shreds_per_slot, None)
+                .unwrap(),
+            vec![],
+        );
+
         // Step 2: Make a transmission for another bank that interrupts the transmission for
         // slot 0
         let bank2 = Arc::new(Bank::new_from_parent(&bank0, &leader_pubkey, 2));

--- a/core/src/cluster_info.rs
+++ b/core/src/cluster_info.rs
@@ -1771,7 +1771,7 @@ mod tests {
     use crate::crds_value::CrdsValueLabel;
     use crate::repair_service::RepairType;
     use crate::result::Error;
-    use crate::shred::max_ticks_per_shred;
+    use crate::shred::max_ticks_per_n_shreds;
     use crate::shred::{DataShredHeader, Shred};
     use crate::test_tx::test_tx;
     use solana_sdk::hash::Hash;
@@ -1976,7 +1976,7 @@ mod tests {
 
             let _ = fill_blocktree_slot_with_ticks(
                 &blocktree,
-                max_ticks_per_shred() + 1,
+                max_ticks_per_n_shreds(1) + 1,
                 2,
                 1,
                 Hash::default(),

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -7,6 +7,8 @@
 
 pub mod bank_forks;
 pub mod banking_stage;
+#[macro_use]
+pub mod blocktree;
 pub mod broadcast_stage;
 pub mod chacha;
 pub mod chacha_cuda;
@@ -17,20 +19,18 @@ pub mod recycler;
 pub mod shred_fetch_stage;
 #[macro_use]
 pub mod contact_info;
-pub mod crds;
-pub mod crds_gossip;
-pub mod crds_gossip_error;
-pub mod crds_gossip_pull;
-pub mod crds_gossip_push;
-pub mod crds_value;
-#[macro_use]
-pub mod blocktree;
 pub mod blockstream;
 pub mod blockstream_service;
 pub mod blocktree_processor;
 pub mod cluster_info;
 pub mod cluster_info_repair_listener;
 pub mod consensus;
+pub mod crds;
+pub mod crds_gossip;
+pub mod crds_gossip_error;
+pub mod crds_gossip_pull;
+pub mod crds_gossip_push;
+pub mod crds_value;
 pub mod cuda_runtime;
 pub mod entry;
 pub mod erasure;

--- a/core/src/repair_service.rs
+++ b/core/src/repair_service.rs
@@ -406,7 +406,7 @@ mod test {
     };
     use crate::blocktree::{get_tmp_ledger_path, Blocktree};
     use crate::cluster_info::Node;
-    use crate::shred::max_ticks_per_shred;
+    use crate::shred::max_ticks_per_n_shreds;
     use itertools::Itertools;
     use rand::seq::SliceRandom;
     use rand::{thread_rng, Rng};
@@ -538,7 +538,7 @@ mod test {
             let blocktree = Blocktree::open(&blocktree_path).unwrap();
 
             let slots: Vec<u64> = vec![1, 3, 5, 7, 8];
-            let num_entries_per_slot = max_ticks_per_shred() + 1;
+            let num_entries_per_slot = max_ticks_per_n_shreds(1) + 1;
 
             let shreds = make_chaining_slot_entries(&slots, num_entries_per_slot);
             for (mut slot_shreds, _) in shreds.into_iter() {

--- a/core/src/shred.rs
+++ b/core/src/shred.rs
@@ -673,9 +673,9 @@ impl Shredder {
     }
 }
 
-pub fn max_ticks_per_shred() -> u64 {
+pub fn max_ticks_per_n_shreds(num_shreds: u64) -> u64 {
     let ticks = create_ticks(1, Hash::default());
-    max_entries_per_n_shred(&ticks[0], 1)
+    max_entries_per_n_shred(&ticks[0], num_shreds)
 }
 
 pub fn max_entries_per_n_shred(entry: &Entry, num_shreds: u64) -> u64 {
@@ -858,7 +858,7 @@ pub mod tests {
             .expect("Failed in creating shredder");
 
         // Create enough entries to make > 1 shred
-        let num_entries = max_ticks_per_shred() + 1;
+        let num_entries = max_ticks_per_n_shreds(1) + 1;
         let entries: Vec<_> = (0..num_entries)
             .map(|_| {
                 let keypair0 = Keypair::new();


### PR DESCRIPTION
#### Problem
Slots that are interrupted by a later slot in broadcast never send a shred to mark themselves as completed.

#### Summary of Changes
Re-introduce `last_unfinished_slot` to broadcast to track the last indexes for which a slot has broadcasted, and send an empty shred to denote the end of uninterrupted slots
Fixes #
