### PR TITLE
Add print to bench-tps about blockhash time

### DIFF
--- a/bench-tps/src/bench.rs
+++ b/bench-tps/src/bench.rs
@@ -173,6 +173,10 @@ where
             sleep(Duration::from_millis(100));
             continue;
         }
+        info!(
+            "Took {} ms for new blockhash",
+            duration_as_ms(&blockhash_time.elapsed())
+        );
         blockhash_time = Instant::now();
         let balance = client.get_balance(&id.pubkey()).unwrap_or(0);
         metrics_submit_lamport_balance(balance);


### PR DESCRIPTION
#### Problem

Hard to tell why bench-tps stalled in transaction sending.

#### Summary of Changes

Usually it's from stalling retrieving a new blockhash, add a print to quantify how long the wait is.

Fixes #
