### PR TITLE
Increase number of transaction send retries.

### DIFF
--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -162,7 +162,7 @@ impl RpcClient {
         transaction: &mut Transaction,
         signer_keys: &[&T],
     ) -> Result<String, ClientError> {
-        let mut send_retries = 5;
+        let mut send_retries = 20;
         loop {
             let mut status_retries = 4;
             let signature_str = self.send_transaction(transaction)?;


### PR DESCRIPTION
#### Problem

Airdrop transaction can fail on validator node startup and mess up the cluster start scripts.

#### Summary of Changes

Add some more retry.

Fixes #
