### PR TITLE
Remove unnecessary locking in retransmit stage

### DIFF
--- a/core/src/retransmit_stage.rs
+++ b/core/src/retransmit_stage.rs
@@ -55,10 +55,10 @@ pub fn retransmit(
     let me = cluster_info.read().unwrap().my_data().clone();
     bank_time.stop();
     let mut retransmit_total = 0;
-    let mut turbine_total = 0;
+    let mut compute_turbine_peers_total = 0;
     for packets in packet_v {
         for packet in &packets.packets {
-            let mut turbine_start = Measure::start("turbine_start");
+            let mut compute_turbine_peers = Measure::start("turbine_start");
             let (my_index, mut shuffled_stakes_and_index) = ClusterInfo::shuffle_peers_and_index(
                 &me.id,
                 &peers,
@@ -77,8 +77,8 @@ pub fn retransmit(
                 compute_retransmit_peers(DATA_PLANE_FANOUT, my_index, indexes);
             let neighbors: Vec<_> = neighbors.into_iter().map(|index| &peers[index]).collect();
             let children: Vec<_> = children.into_iter().map(|index| &peers[index]).collect();
-            turbine_start.stop();
-            turbine_total += turbine_start.as_ms();
+            compute_turbine_peers.stop();
+            compute_turbine_peers_total += compute_turbine_peers.as_ms();
 
             let leader =
                 leader_schedule_cache.slot_leader_at(packet.meta.slot, Some(r_bank.as_ref()));
@@ -106,7 +106,7 @@ pub fn retransmit(
         ("total_time", timer_start.as_ms() as i64, i64),
         ("total_packets", total_packets as i64, i64),
         ("retransmit_total", retransmit_total as i64, i64),
-        ("turbine_total", turbine_total as i64, i64),
+        ("compute_turbine", compute_turbine_peers_total as i64, i64),
         ("extra_recv", extra_recv_time.as_ms() as i64, i64),
         ("bank_time", bank_time.as_ms() as i64, i64),
     );

--- a/core/src/retransmit_stage.rs
+++ b/core/src/retransmit_stage.rs
@@ -36,14 +36,11 @@ pub fn retransmit(
     let mut timer_start = Measure::start("retransmit");
     let mut total_packets = packets.packets.len();
     let mut packet_v = vec![packets];
-    let mut extra_recv_time = Measure::start("recv_time");
     while let Ok(nq) = r.try_recv() {
         total_packets += nq.packets.len();
         packet_v.push(nq);
     }
-    extra_recv_time.stop();
 
-    let mut bank_time = Measure::start("bank_time");
     let r_bank = bank_forks.read().unwrap().working_bank();
     let bank_epoch = r_bank.get_stakers_epoch(r_bank.slot());
     let mut peers_len = 0;
@@ -53,7 +50,6 @@ pub fn retransmit(
         .unwrap()
         .sorted_retransmit_peers_and_stakes(stakes.as_ref());
     let me = cluster_info.read().unwrap().my_data().clone();
-    bank_time.stop();
     let mut retransmit_total = 0;
     let mut compute_turbine_peers_total = 0;
     for packets in packet_v {
@@ -107,8 +103,6 @@ pub fn retransmit(
         ("total_packets", total_packets as i64, i64),
         ("retransmit_total", retransmit_total as i64, i64),
         ("compute_turbine", compute_turbine_peers_total as i64, i64),
-        ("extra_recv", extra_recv_time.as_ms() as i64, i64),
-        ("bank_time", bank_time.as_ms() as i64, i64),
     );
     Ok(())
 }

--- a/core/tests/cluster_info.rs
+++ b/core/tests/cluster_info.rs
@@ -116,7 +116,8 @@ fn run_simulation(stakes: &[u64], fanout: usize) {
             seed[0..4].copy_from_slice(&i.to_le_bytes());
             let (peers, stakes_and_index) =
                 cluster_info.sorted_retransmit_peers_and_stakes(Some(&staked_nodes));
-            let (_, shuffled_stakes_and_indexes) = cluster_info.shuffle_peers_and_index(
+            let (_, shuffled_stakes_and_indexes) = ClusterInfo::shuffle_peers_and_index(
+                &cluster_info.id(),
                 &peers,
                 &stakes_and_index,
                 ChaChaRng::from_seed(seed),

--- a/core/tests/gossip.rs
+++ b/core/tests/gossip.rs
@@ -177,8 +177,9 @@ pub fn cluster_info_retransmit() -> result::Result<()> {
     let mut p = Packet::default();
     p.meta.size = 10;
     let peers = c1.read().unwrap().retransmit_peers();
+    let self_id = c1.read().unwrap().id();
     let retransmit_peers: Vec<_> = peers.iter().collect();
-    ClusterInfo::retransmit_to(&c1, &retransmit_peers, &p, None, &tn1, false)?;
+    ClusterInfo::retransmit_to(&self_id, &retransmit_peers, &p, None, &tn1, false)?;
     let res: Vec<_> = [tn1, tn2, tn3]
         .into_par_iter()
         .map(|s| {


### PR DESCRIPTION
#### Problem

- Retransmit locks on cluster_info to repeatedly pull the node's pubkey. This is really wasteful. 
- We need a more convenient view of the time retransmit_stage is taking 

#### Summary of Changes

- Removed unnecessary locking
- Added more detailed metrics

