### PR TITLE
Do not retransmit Repair responses

### DIFF
--- a/core/src/cluster_info.rs
+++ b/core/src/cluster_info.rs
@@ -456,6 +456,7 @@ impl ClusterInfo {
             .filter_map(|x| x.value.contact_info())
             .filter(|x| x.id != me)
             .filter(|x| ContactInfo::is_valid_address(&x.tvu))
+            .filter(|x| ContactInfo::is_valid_address(&x.tvu_forwards))
             .cloned()
             .collect()
     }

--- a/core/src/packet.rs
+++ b/core/src/packet.rs
@@ -41,6 +41,7 @@ pub const PACKETS_BATCH_SIZE: usize = (PACKETS_PER_BATCH * PACKET_DATA_SIZE);
 pub struct Meta {
     pub size: usize,
     pub forward: bool,
+    pub repair: bool,
     pub addr: [u16; 8],
     pub port: u16,
     pub v6: bool,

--- a/core/src/replicator.rs
+++ b/core/src/replicator.rs
@@ -253,9 +253,8 @@ impl Replicator {
         };
 
         let repair_socket = Arc::new(node.sockets.repair);
-        let mut blob_sockets: Vec<Arc<UdpSocket>> =
+        let blob_sockets: Vec<Arc<UdpSocket>> =
             node.sockets.tvu.into_iter().map(Arc::new).collect();
-        blob_sockets.push(repair_socket.clone());
         let blob_forward_sockets: Vec<Arc<UdpSocket>> = node
             .sockets
             .tvu_forwards
@@ -266,6 +265,7 @@ impl Replicator {
         let fetch_stage = ShredFetchStage::new(
             blob_sockets,
             blob_forward_sockets,
+            repair_socket.clone(),
             &blob_fetch_sender,
             &exit,
         );

--- a/core/src/retransmit_stage.rs
+++ b/core/src/retransmit_stage.rs
@@ -234,3 +234,82 @@ impl Service for RetransmitStage {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::blocktree::create_new_tmp_ledger;
+    use crate::blocktree_processor::{process_blocktree, ProcessOptions};
+    use crate::contact_info::ContactInfo;
+    use crate::genesis_utils::{create_genesis_block, GenesisBlockInfo};
+    use crate::packet::{Meta, Packet, Packets};
+    use solana_netutil::find_available_port_in_range;
+    use solana_sdk::pubkey::Pubkey;
+
+    #[test]
+    fn test_skip_repair() {
+        let GenesisBlockInfo { genesis_block, .. } = create_genesis_block(123);
+        let (ledger_path, _blockhash) = create_new_tmp_ledger!(&genesis_block);
+        let blocktree = Blocktree::open(&ledger_path).unwrap();
+        let opts = ProcessOptions {
+            full_leader_cache: true,
+            ..ProcessOptions::default()
+        };
+        let (bank_forks, _, cached_leader_schedule) =
+            process_blocktree(&genesis_block, &blocktree, None, opts).unwrap();
+        let leader_schedule_cache = Arc::new(cached_leader_schedule);
+        let bank_forks = Arc::new(RwLock::new(bank_forks));
+
+        let mut me = ContactInfo::new_localhost(&Pubkey::new_rand(), 0);
+        let port = find_available_port_in_range((8000, 10000)).unwrap();
+        let me_retransmit = UdpSocket::bind(format!("127.0.0.1:{}", port)).unwrap();
+        // need to make sure tvu and tpu are valid addresses
+        me.tvu_forwards = me_retransmit.local_addr().unwrap();
+        let port = find_available_port_in_range((8000, 10000)).unwrap();
+        me.tvu = UdpSocket::bind(format!("127.0.0.1:{}", port))
+            .unwrap()
+            .local_addr()
+            .unwrap();
+
+        let other = ContactInfo::new_localhost(&Pubkey::new_rand(), 0);
+        let mut cluster_info = ClusterInfo::new_with_invalid_keypair(other);
+        cluster_info.insert_info(me);
+
+        let retransmit_socket = Arc::new(UdpSocket::bind("0.0.0.0:0").unwrap());
+        let cluster_info = Arc::new(RwLock::new(cluster_info));
+
+        let (retransmit_sender, retransmit_receiver) = channel();
+        let t_retransmit = retransmitter(
+            retransmit_socket,
+            bank_forks,
+            &leader_schedule_cache,
+            cluster_info,
+            retransmit_receiver,
+        );
+        let _thread_hdls = vec![t_retransmit];
+
+        let packets = Packets::new(vec![Packet::default()]);
+        // it should send this over the sockets.
+        retransmit_sender.send(packets).unwrap();
+        let mut packets = Packets::new(vec![]);
+        packets.recv_from(&me_retransmit).unwrap();
+        assert_eq!(packets.packets.len(), 1);
+        assert_eq!(packets.packets[0].meta.repair, false);
+
+        let repair = Packet {
+            meta: Meta {
+                repair: true,
+                ..Meta::default()
+            },
+            ..Packet::default()
+        };
+
+        // send 1 repair and 1 "regular" packet so that we don't block forever on the recv_from
+        let packets = Packets::new(vec![repair, Packet::default()]);
+        retransmit_sender.send(packets).unwrap();
+        let mut packets = Packets::new(vec![]);
+        packets.recv_from(&me_retransmit).unwrap();
+        assert_eq!(packets.packets.len(), 1);
+        assert_eq!(packets.packets[0].meta.repair, false);
+    }
+}

--- a/core/src/retransmit_stage.rs
+++ b/core/src/retransmit_stage.rs
@@ -58,6 +58,11 @@ pub fn retransmit(
     let mut compute_turbine_peers_total = 0;
     for packets in packet_v {
         for packet in &packets.packets {
+            // skip repair packets
+            if packet.meta.repair {
+                total_packets -= 1;
+                continue;
+            }
             let mut compute_turbine_peers = Measure::start("turbine_start");
             let (my_index, mut shuffled_stakes_and_index) = ClusterInfo::shuffle_peers_and_index(
                 &me.id,

--- a/core/src/shred_fetch_stage.rs
+++ b/core/src/shred_fetch_stage.rs
@@ -22,7 +22,7 @@ impl ShredFetchStage {
         F: Fn(&mut Packet),
     {
         while let Some(mut p) = recvr.iter().next() {
-            p.packets.iter_mut().for_each(|p| p.meta.forward = true);
+            p.packets.iter_mut().for_each(|p| modify(p));
             if sendr.send(p).is_err() {
                 break;
             }
@@ -85,7 +85,7 @@ impl ShredFetchStage {
         let fwd_thread_hdl = Builder::new()
             .name("solana-tvu-fetch-stage-fwd-rcvr".to_string())
             .spawn(move || {
-                Self::modify_packets(&forward_receiver, &sender, |p| p.meta.forward = true)
+                Self::modify_packets(&forward_receiver, &fwd_sender, |p| p.meta.forward = true)
             })
             .unwrap();
 

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -99,8 +99,7 @@ impl Tvu {
         let (fetch_sender, fetch_receiver) = channel();
 
         let repair_socket = Arc::new(repair_socket);
-        let mut fetch_sockets: Vec<Arc<UdpSocket>> =
-            fetch_sockets.into_iter().map(Arc::new).collect();
+        let fetch_sockets: Vec<Arc<UdpSocket>> = fetch_sockets.into_iter().map(Arc::new).collect();
         let forward_sockets: Vec<Arc<UdpSocket>> =
             tvu_forward_sockets.into_iter().map(Arc::new).collect();
         let fetch_stage = ShredFetchStage::new(

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -101,11 +101,15 @@ impl Tvu {
         let repair_socket = Arc::new(repair_socket);
         let mut fetch_sockets: Vec<Arc<UdpSocket>> =
             fetch_sockets.into_iter().map(Arc::new).collect();
-        fetch_sockets.push(repair_socket.clone());
         let forward_sockets: Vec<Arc<UdpSocket>> =
             tvu_forward_sockets.into_iter().map(Arc::new).collect();
-        let fetch_stage =
-            ShredFetchStage::new(fetch_sockets, forward_sockets, &fetch_sender, &exit);
+        let fetch_stage = ShredFetchStage::new(
+            fetch_sockets,
+            forward_sockets,
+            repair_socket.clone(),
+            &fetch_sender,
+            &exit,
+        );
 
         //TODO
         //the packets coming out of blob_receiver need to be sent to the GPU and verified


### PR DESCRIPTION
#### Problem

Our Repair protocol is greedy and starts generating repairs as soon as it receives a shred for a slot (not accounting for the fact that it will likely receive everything from Turbine in a short while). 

In larger clusters what this amounts to is every single node generating repairs for a slot as soon as they see any shred for that slot. They do this every 100ms. This effectively results in magnification of packets in flight on the network. 

1 leader -> 49 validators -> 10 repairs per validator -> 490 repair requests, each of the 10 repairs get retransmitted to all 50 peers resulting in 24500 retransmits every 100ms or so. 

#### Summary of Changes

Added a field to packet's meta and added a separate receiver for repair responses. 
Responses are marked as such when they're received and retransmit_stage will not send them through turbine. 

Fixes #4739
