### PR TITLE
make sysvar creation a bit more foolproof

### DIFF
--- a/sdk/src/sysvar/clock.rs
+++ b/sdk/src/sysvar/clock.rs
@@ -12,7 +12,7 @@ const ID: [u8; 32] = [
     75, 109, 92, 115, 85, 91, 33, 0, 0, 0, 0,
 ];
 
-crate::solana_name_id!(ID, "SysvarC1ock11111111111111111111111111111111");
+crate::solana_sysvar_id!(ID, "SysvarC1ock11111111111111111111111111111111");
 
 #[repr(C)]
 #[derive(Serialize, Deserialize, Debug, Default, PartialEq)]

--- a/sdk/src/sysvar/epoch_schedule.rs
+++ b/sdk/src/sysvar/epoch_schedule.rs
@@ -14,7 +14,7 @@ const ID: [u8; 32] = [
     30, 63, 80, 135, 25, 168, 5, 0, 0, 0,
 ];
 
-crate::solana_name_id!(ID, "SysvarEpochSchedu1e111111111111111111111111");
+crate::solana_sysvar_id!(ID, "SysvarEpochSchedu1e111111111111111111111111");
 
 impl EpochSchedule {
     pub fn deserialize(account: &Account) -> Result<Self, bincode::Error> {

--- a/sdk/src/sysvar/fees.rs
+++ b/sdk/src/sysvar/fees.rs
@@ -12,7 +12,7 @@ const ID: [u8; 32] = [
     111, 196, 237, 82, 106, 156, 144, 0, 0, 0, 0,
 ];
 
-crate::solana_name_id!(ID, "SysvarFees111111111111111111111111111111111");
+crate::solana_sysvar_id!(ID, "SysvarFees111111111111111111111111111111111");
 
 #[repr(C)]
 #[derive(Serialize, Deserialize, Debug, Default)]

--- a/sdk/src/sysvar/mod.rs
+++ b/sdk/src/sysvar/mod.rs
@@ -11,8 +11,29 @@ pub mod slot_hashes;
 pub mod stake_history;
 
 pub fn is_sysvar_id(id: &Pubkey) -> bool {
-    clock::check_id(id) || fees::check_id(id) || rewards::check_id(id) || slot_hashes::check_id(id)
+    clock::check_id(id)
+        || epoch_schedule::check_id(id)
+        || fees::check_id(id)
+        || rent::check_id(id)
+        || rewards::check_id(id)
+        || slot_hashes::check_id(id)
+        || stake_history::check_id(id)
 }
+
+#[macro_export]
+macro_rules! solana_sysvar_id(
+    ($id:ident, $name:expr) => (
+        $crate::solana_name_id!($id, $name);
+
+        #[cfg(test)]
+        #[test]
+        fn test_sysvar_id() {
+            if !$crate::sysvar::is_sysvar_id(&id()) {
+                panic!("sysvar::is_sysvar_id() doesn't know about {}", $name);
+            }
+        }
+    )
+);
 
 /// "Sysvar1111111111111111111111111111111111111"
 ///   owner pubkey for sysvar accounts

--- a/sdk/src/sysvar/rent.rs
+++ b/sdk/src/sysvar/rent.rs
@@ -15,7 +15,7 @@ const ID: [u8; 32] = [
     253, 68, 227, 219, 217, 138, 0, 0, 0, 0,
 ];
 
-crate::solana_name_id!(ID, "SysvarRent111111111111111111111111111111111");
+crate::solana_sysvar_id!(ID, "SysvarRent111111111111111111111111111111111");
 
 #[repr(C)]
 #[derive(Serialize, Deserialize, Debug, Default)]

--- a/sdk/src/sysvar/rewards.rs
+++ b/sdk/src/sysvar/rewards.rs
@@ -11,7 +11,7 @@ const ID: [u8; 32] = [
     130, 184, 161, 97, 145, 87, 141, 128, 0, 0, 0,
 ];
 
-crate::solana_name_id!(ID, "SysvarRewards111111111111111111111111111111");
+crate::solana_sysvar_id!(ID, "SysvarRewards111111111111111111111111111111");
 
 #[repr(C)]
 #[derive(Serialize, Deserialize, Debug, Default, PartialEq)]

--- a/sdk/src/sysvar/slot_hashes.rs
+++ b/sdk/src/sysvar/slot_hashes.rs
@@ -11,7 +11,7 @@ const ID: [u8; 32] = [
     208, 190, 59, 19, 110, 45, 0, 85, 32, 0, 0, 0,
 ];
 
-crate::solana_name_id!(ID, "SysvarS1otHashes111111111111111111111111111");
+crate::solana_sysvar_id!(ID, "SysvarS1otHashes111111111111111111111111111");
 
 pub const MAX_SLOT_HASHES: usize = 512; // 512 slots to get your vote in
 

--- a/sdk/src/sysvar/stake_history.rs
+++ b/sdk/src/sysvar/stake_history.rs
@@ -13,7 +13,7 @@ const ID: [u8; 32] = [
     87, 184, 86, 108, 197, 55, 95, 244, 0, 0, 0,
 ];
 
-crate::solana_name_id!(ID, "SysvarStakeHistory1111111111111111111111111");
+crate::solana_sysvar_id!(ID, "SysvarStakeHistory1111111111111111111111111");
 
 pub const MAX_STAKE_HISTORY: usize = 512; // it should never take as many as 512 epochs to warm up or cool down
 


### PR DESCRIPTION
#### Problem
 some sysvars were missing from is_sysvar_id()

 #### Summary of Changes
 * add the missing ids
 * add a macro that should make it easier to verify they're in the list

Fixes #