### PR TITLE
Fix unrealistic hash rate expectations in genesis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3426,6 +3426,7 @@ dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bincode 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rayon 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3436,6 +3437,7 @@ dependencies = [
  "solana-stake-api 0.20.0",
  "solana-storage-api 0.20.0",
  "solana-vote-api 0.20.0",
+ "sys-info 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/genesis/Cargo.toml
+++ b/genesis/Cargo.toml
@@ -23,3 +23,5 @@ solana-stake-api = { path = "../programs/stake_api", version = "0.20.0" }
 solana-storage-api = { path = "../programs/storage_api", version = "0.20.0" }
 solana-vote-api = { path = "../programs/vote_api", version = "0.20.0" }
 tempfile = "3.1.0"
+sys-info = "0.5.8"
+rayon = "1.2.0"


### PR DESCRIPTION
#### Problem

`solana-genesis` generates our target hash rate based on a single thread's performance. 
On most modern cpus this can result in a much higher hash rate than what is really possible while a Validator is running on the machine.
Unrealistically high hash rates can cause drifts in the cluster.

#### Summary of Changes

Attempt to run 1 million hashes in parallel on all cores. This simulates a more realistic "heavy load" on the cpu and results in lower clock speeds.

Here's the differences in the time it takes to generate 1 million hashes in parallel vs on a single core. 3 different runs are shown per configuration. The single core numbers are identical with and without rayon (rayon limited to 1 job at a time). 

```
all cores (hashes/tick)
148,809 | 143,678 | 139,275

single core (hashes/tick)
353,356 | 346,020 | 344,827
```