### PR TITLE
Bench-tps: swap consts

### DIFF
--- a/bench-tps/src/bench.rs
+++ b/bench-tps/src/bench.rs
@@ -35,7 +35,7 @@ use std::{
 
 // The point at which transactions become "too old", in seconds.
 const MAX_TX_QUEUE_AGE: u64 =
-    MAX_PROCESSING_AGE as u64 * DEFAULT_TICKS_PER_SECOND / DEFAULT_TICKS_PER_SLOT;
+    MAX_PROCESSING_AGE as u64 * DEFAULT_TICKS_PER_SLOT / DEFAULT_TICKS_PER_SECOND;
 
 #[cfg(feature = "move")]
 use solana_librapay_api::librapay_transaction;


### PR DESCRIPTION
#### Problem
blockhash_too_old errors when running bench-tps, due to bad MAX_TX_QUEUE_AGE math

#### Summary of Changes
Swap consts in MAX_TX_QUEUE_AGE to be correct

Fyi: @sagar-solana @carllin  
