### PR TITLE
Allow Vest to set terminator

### DIFF
--- a/programs/vest_api/src/vest_instruction.rs
+++ b/programs/vest_api/src/vest_instruction.rs
@@ -54,6 +54,9 @@ pub enum VestInstruction {
         total_lamports: u64, // The number of lamports to send the payee if the schedule completes
     },
 
+    /// Change the terminator pubkey
+    SetTerminator(Pubkey),
+
     /// Change the payee pubkey
     SetPayee(Pubkey),
 
@@ -110,12 +113,24 @@ pub fn create_account(
     ]
 }
 
-pub fn set_payee(contract: &Pubkey, old_payee: &Pubkey, new_payee: &Pubkey) -> Instruction {
+pub fn set_terminator(contract: &Pubkey, old_pubkey: &Pubkey, new_pubkey: &Pubkey) -> Instruction {
     let account_metas = vec![
         AccountMeta::new(*contract, false),
-        AccountMeta::new(*old_payee, true),
+        AccountMeta::new(*old_pubkey, true),
     ];
-    Instruction::new(id(), &VestInstruction::SetPayee(*new_payee), account_metas)
+    Instruction::new(
+        id(),
+        &VestInstruction::SetTerminator(*new_pubkey),
+        account_metas,
+    )
+}
+
+pub fn set_payee(contract: &Pubkey, old_pubkey: &Pubkey, new_pubkey: &Pubkey) -> Instruction {
+    let account_metas = vec![
+        AccountMeta::new(*contract, false),
+        AccountMeta::new(*old_pubkey, true),
+    ];
+    Instruction::new(id(), &VestInstruction::SetPayee(*new_pubkey), account_metas)
 }
 
 pub fn redeem_tokens(contract: &Pubkey, date_pubkey: &Pubkey, to: &Pubkey) -> Instruction {

--- a/programs/vest_api/src/vest_instruction.rs
+++ b/programs/vest_api/src/vest_instruction.rs
@@ -88,6 +88,7 @@ fn initialize_account(
 }
 
 pub fn create_account(
+    payer_pubkey: &Pubkey,
     terminator_pubkey: &Pubkey,
     contract_pubkey: &Pubkey,
     payee_pubkey: &Pubkey,
@@ -97,13 +98,7 @@ pub fn create_account(
 ) -> Vec<Instruction> {
     let space = serialized_size(&VestState::default()).unwrap();
     vec![
-        system_instruction::create_account(
-            &terminator_pubkey,
-            contract_pubkey,
-            lamports,
-            space,
-            &id(),
-        ),
+        system_instruction::create_account(&payer_pubkey, contract_pubkey, lamports, space, &id()),
         initialize_account(
             terminator_pubkey,
             payee_pubkey,

--- a/programs/vest_api/src/vest_processor.rs
+++ b/programs/vest_api/src/vest_processor.rs
@@ -136,7 +136,7 @@ mod tests {
     use solana_sdk::message::Message;
     use solana_sdk::signature::{Keypair, KeypairUtil, Signature};
     use solana_sdk::transaction::TransactionError;
-    use solana_sdk::transport::TransportError;
+    use solana_sdk::transport::Result;
     use std::sync::Arc;
 
     fn create_bank(lamports: u64) -> (Bank, Keypair) {
@@ -161,7 +161,7 @@ mod tests {
         date_keypair: &Keypair,
         payer_keypair: &Keypair,
         date: Date<Utc>,
-    ) -> Result<Signature, TransportError> {
+    ) -> Result<Signature> {
         let date_pubkey = date_keypair.pubkey();
 
         let mut instructions =
@@ -177,7 +177,7 @@ mod tests {
         date_keypair: &Keypair,
         payer_keypair: &Keypair,
         date: Date<Utc>,
-    ) -> Result<Signature, TransportError> {
+    ) -> Result<Signature> {
         let date_pubkey = date_keypair.pubkey();
         let instruction = date_instruction::store(&date_pubkey, date);
         let message = Message::new_with_payer(vec![instruction], Some(&payer_keypair.pubkey()));
@@ -193,7 +193,7 @@ mod tests {
         start_date: Date<Utc>,
         date_pubkey: &Pubkey,
         lamports: u64,
-    ) -> Result<Signature, TransportError> {
+    ) -> Result<Signature> {
         let instructions = vest_instruction::create_account(
             &payer_keypair.pubkey(),
             &terminator_pubkey,
@@ -212,7 +212,7 @@ mod tests {
         contract_pubkey: &Pubkey,
         old_payee_keypair: &Keypair,
         new_payee_pubkey: &Pubkey,
-    ) -> Result<Signature, TransportError> {
+    ) -> Result<Signature> {
         let instruction = vest_instruction::set_payee(
             &contract_pubkey,
             &old_payee_keypair.pubkey(),
@@ -227,7 +227,7 @@ mod tests {
         payer_keypair: &Keypair,
         payee_pubkey: &Pubkey,
         date_pubkey: &Pubkey,
-    ) -> Result<Signature, TransportError> {
+    ) -> Result<Signature> {
         let instruction =
             vest_instruction::redeem_tokens(&contract_pubkey, &date_pubkey, &payee_pubkey);
         let message = Message::new_with_payer(vec![instruction], Some(&payer_keypair.pubkey()));

--- a/programs/vest_api/src/vest_processor.rs
+++ b/programs/vest_api/src/vest_processor.rs
@@ -188,6 +188,7 @@ mod tests {
         bank_client: &BankClient,
         contract_pubkey: &Pubkey,
         payer_keypair: &Keypair,
+        terminator_pubkey: &Pubkey,
         payee_pubkey: &Pubkey,
         start_date: Date<Utc>,
         date_pubkey: &Pubkey,
@@ -195,6 +196,7 @@ mod tests {
     ) -> Result<Signature, TransportError> {
         let instructions = vest_instruction::create_account(
             &payer_keypair.pubkey(),
+            &terminator_pubkey,
             &contract_pubkey,
             &payee_pubkey,
             start_date,
@@ -315,6 +317,7 @@ mod tests {
             &alice_keypair.pubkey(),
             &Pubkey::new_rand(),
             &Pubkey::new_rand(),
+            &Pubkey::new_rand(),
             Utc::now().date(),
             &Pubkey::new_rand(),
             1,
@@ -334,6 +337,7 @@ mod tests {
     #[test]
     fn test_set_payee() {
         let (bank_client, alice_keypair) = create_bank_client(38);
+        let alice_pubkey = alice_keypair.pubkey();
         let date_pubkey = Pubkey::new_rand();
         let contract_pubkey = Pubkey::new_rand();
         let bob_keypair = Keypair::new();
@@ -344,6 +348,7 @@ mod tests {
             &bank_client,
             &contract_pubkey,
             &alice_keypair,
+            &alice_pubkey,
             &bob_pubkey,
             start_date,
             &date_pubkey,
@@ -401,6 +406,7 @@ mod tests {
             &bank_client,
             &contract_pubkey,
             &alice_keypair,
+            &alice_pubkey,
             &bob_pubkey,
             start_date,
             &date_pubkey,
@@ -467,6 +473,7 @@ mod tests {
             &bank_client,
             &contract_pubkey,
             &alice_keypair,
+            &alice_pubkey,
             &bob_pubkey,
             start_date,
             &date_pubkey,


### PR DESCRIPTION
#### Problem

Per @rob-solana's earlier PR feedback, the account authorized to terminate contracts couldn't change the key they send that instruction from.  Also, the terminator had to fund the contract, but might (and likely will be) a different entity.

#### Summary of Changes

* Add SetTerminator instruction
* Allow separate payer and terminator
