### PR TITLE
gce.sh: Rename -f flag to better reflect usage

### DIFF
--- a/ci/testnet-manager.sh
+++ b/ci/testnet-manager.sh
@@ -425,7 +425,7 @@ deploy() {
       # shellcheck disable=SC2068
       NO_VALIDATOR_SANITY=1 \
         ci/testnet-deploy.sh -p demo-testnet-solana-com -C gce ${GCE_ZONE_ARGS[@]} \
-          -t "$CHANNEL_OR_TAG" -n "$GCE_NODE_COUNT" -c 0 -P -u -f \
+          -t "$CHANNEL_OR_TAG" -n "$GCE_NODE_COUNT" -c 0 -P -u --allow-boot-failures \
           --skip-remote-log-retrieval \
           -a demo-testnet-solana-com \
           ${skipCreate:+-e} \
@@ -437,7 +437,7 @@ deploy() {
         # shellcheck disable=SC2068
         NO_VALIDATOR_SANITY=1 \
           ci/testnet-deploy.sh -p demo-testnet-solana-com2 -C gce ${GCE_LOW_QUOTA_ZONE_ARGS[@]} \
-            -t "$CHANNEL_OR_TAG" -n "$GCE_LOW_QUOTA_NODE_COUNT" -c 0 -P -f -x \
+            -t "$CHANNEL_OR_TAG" -n "$GCE_LOW_QUOTA_NODE_COUNT" -c 0 -P --allow-boot-failures -x \
             --skip-remote-log-retrieval \
             ${skipCreate:+-e} \
             ${skipStart:+-s} \

--- a/net/gce.sh
+++ b/net/gce.sh
@@ -119,7 +119,9 @@ Manage testnet instances
                       zone
    -x               - append to the existing configuration instead of creating a
                       new configuration
-   -f               - Discard validator nodes that didn't bootup successfully
+   --allow-boot-failures
+                    - Discard from config validator nodes that didn't bootup
+                      successfully
 
  create-specific options:
    -n [number]      - Number of additional fullnodes (default: $additionalFullNodeCount)
@@ -174,6 +176,9 @@ while [[ -n $1 ]]; do
       shift 2
     elif [[ $1 == --machine-type* || $1 == --custom-cpu* ]]; then # Bypass quoted long args for GPUs
       shortArgs+=("$1")
+      shift
+    elif [[ $1 == --allow-boot-failures ]]; then
+      failOnValidatorBootupFailure=false
       shift
     else
       usage "Unknown long option: $1"
@@ -231,9 +236,6 @@ while getopts "h?p:Pn:c:r:z:gG:a:d:uxf" opt "${shortArgs[@]}"; do
     ;;
   x)
     externalNodes=true
-    ;;
-  f)
-    failOnValidatorBootupFailure=false
     ;;
   *)
     usage "unhandled option: $opt"


### PR DESCRIPTION
#### Problem

`net/gce.sh`'s `-f` flag is somewhat unintuitively named

#### Summary of Changes

Call it `--allow-boot-failures` instead