### PR TITLE
Use multicast to send retransmit packets

### DIFF
--- a/core/src/retransmit_stage.rs
+++ b/core/src/retransmit_stage.rs
@@ -67,8 +67,8 @@ fn retransmit(
     let me = cluster_info.read().unwrap().my_data().clone();
     let mut retransmit_total = 0;
     let mut compute_turbine_peers_total = 0;
-    for packets in packet_v {
-        for packet in &packets.packets {
+    for mut packets in packet_v {
+        for packet in packets.packets.iter_mut() {
             // skip repair packets
             if packet.meta.repair {
                 total_packets -= 1;
@@ -100,10 +100,10 @@ fn retransmit(
                 leader_schedule_cache.slot_leader_at(packet.meta.slot, Some(r_bank.as_ref()));
             let mut retransmit_time = Measure::start("retransmit_to");
             if !packet.meta.forward {
-                ClusterInfo::retransmit_to(&me.id, &neighbors, packet, leader, sock, true)?;
-                ClusterInfo::retransmit_to(&me.id, &children, packet, leader, sock, false)?;
+                ClusterInfo::retransmit_to(&neighbors, packet, leader, sock, true)?;
+                ClusterInfo::retransmit_to(&children, packet, leader, sock, false)?;
             } else {
-                ClusterInfo::retransmit_to(&me.id, &children, packet, leader, sock, true)?;
+                ClusterInfo::retransmit_to(&children, packet, leader, sock, true)?;
             }
             retransmit_time.stop();
             retransmit_total += retransmit_time.as_ms();

--- a/core/tests/gossip.rs
+++ b/core/tests/gossip.rs
@@ -177,9 +177,8 @@ pub fn cluster_info_retransmit() -> result::Result<()> {
     let mut p = Packet::default();
     p.meta.size = 10;
     let peers = c1.read().unwrap().retransmit_peers();
-    let self_id = c1.read().unwrap().id();
     let retransmit_peers: Vec<_> = peers.iter().collect();
-    ClusterInfo::retransmit_to(&self_id, &retransmit_peers, &p, None, &tn1, false)?;
+    ClusterInfo::retransmit_to(&retransmit_peers, &mut p, None, &tn1, false)?;
     let res: Vec<_> = [tn1, tn2, tn3]
         .into_par_iter()
         .map(|s| {


### PR DESCRIPTION
#### Problem
Retransmit stage is sending same packet iteratively to multiple destinations. This can be optimized by using `multicast`.

#### Summary of Changes
Use the new `multicast` API
