### PR TITLE
Switch to crossbeam channels for retransmit/streamer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3037,6 +3037,7 @@ name = "solana-bench-streamer"
 version = "0.20.0"
 dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-core 0.20.0",
  "solana-logger 0.20.0",
  "solana-netutil 0.20.0",
@@ -3263,7 +3264,7 @@ dependencies = [
  "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "core_affinity 0.5.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "crc 1.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossbeam-channel 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "dir-diff 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "dlopen 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "dlopen_derive 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/bench-streamer/Cargo.toml
+++ b/bench-streamer/Cargo.toml
@@ -12,3 +12,4 @@ clap = "2.33.0"
 solana-core = { path = "../core", version = "0.20.0" }
 solana-logger = { path = "../logger", version = "0.20.0" }
 solana-netutil = { path = "../netutil", version = "0.20.0" }
+crossbeam = "0.7.2"

--- a/bench-streamer/src/main.rs
+++ b/bench-streamer/src/main.rs
@@ -1,4 +1,5 @@
 use clap::{crate_description, crate_name, crate_version, App, Arg};
+use crossbeam::crossbeam_channel::unbounded;
 use solana_core::packet::PacketsRecycler;
 use solana_core::packet::{Packet, Packets, BLOB_SIZE, PACKET_DATA_SIZE};
 use solana_core::result::Result;
@@ -6,7 +7,6 @@ use solana_core::streamer::{receiver, PacketReceiver};
 use std::cmp::max;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr, UdpSocket};
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
-use std::sync::mpsc::channel;
 use std::sync::Arc;
 use std::thread::sleep;
 use std::thread::{spawn, JoinHandle};
@@ -83,7 +83,7 @@ fn main() -> Result<()> {
         addr = read.local_addr().unwrap();
         port = addr.port();
 
-        let (s_reader, r_reader) = channel();
+        let (s_reader, r_reader) = unbounded();
         read_channels.push(r_reader);
         read_threads.push(receiver(
             Arc::new(read),

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -25,7 +25,7 @@ bzip2 = "0.3.3"
 chrono = { version = "0.4.9", features = ["serde"] }
 core_affinity = "0.5.9"
 crc = { version = "1.8.1", optional = true }
-crossbeam-channel = "0.3"
+crossbeam = "0.7.2"
 dir-diff = "0.3.2"
 dlopen = "0.1.8"
 dlopen_derive = "0.1.4"

--- a/core/benches/banking_stage.rs
+++ b/core/benches/banking_stage.rs
@@ -4,7 +4,7 @@ extern crate test;
 #[macro_use]
 extern crate solana_core;
 
-use crossbeam_channel::unbounded;
+use crossbeam::crossbeam_channel::unbounded;
 use log::*;
 use rand::{thread_rng, Rng};
 use rayon::prelude::*;

--- a/core/benches/retransmit_stage.rs
+++ b/core/benches/retransmit_stage.rs
@@ -3,6 +3,7 @@
 extern crate solana_core;
 extern crate test;
 
+use crossbeam::crossbeam_channel::unbounded;
 use log::*;
 use solana_core::bank_forks::BankForks;
 use solana_core::cluster_info::{ClusterInfo, Node};
@@ -18,8 +19,6 @@ use solana_sdk::pubkey::Pubkey;
 use solana_sdk::timing::timestamp;
 use std::net::UdpSocket;
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::mpsc::channel;
-use std::sync::Mutex;
 use std::sync::{Arc, RwLock};
 use std::thread::sleep;
 use std::thread::Builder;
@@ -52,8 +51,8 @@ fn bench_retransmitter(bencher: &mut Bencher) {
     let bank_forks = BankForks::new(0, bank0);
     let bank = bank_forks.working_bank();
     let bank_forks = Arc::new(RwLock::new(bank_forks));
-    let (packet_sender, packet_receiver) = channel();
-    let packet_receiver = Arc::new(Mutex::new(packet_receiver));
+    let (packet_sender, packet_receiver) = unbounded();
+    let packet_receiver = Arc::new(packet_receiver);
     const NUM_THREADS: usize = 2;
     let sockets = (0..NUM_THREADS)
         .map(|_| UdpSocket::bind("0.0.0.0:0").unwrap())

--- a/core/benches/sigverify_stage.rs
+++ b/core/benches/sigverify_stage.rs
@@ -3,7 +3,7 @@
 extern crate solana_core;
 extern crate test;
 
-use crossbeam_channel::unbounded;
+use crossbeam::crossbeam_channel::unbounded;
 use log::*;
 use rand::{thread_rng, Rng};
 use solana_core::packet::to_packets_chunked;
@@ -14,14 +14,13 @@ use solana_sdk::hash::Hash;
 use solana_sdk::signature::{Keypair, KeypairUtil};
 use solana_sdk::system_transaction;
 use solana_sdk::timing::duration_as_ms;
-use std::sync::mpsc::channel;
 use std::time::{Duration, Instant};
 use test::Bencher;
 
 #[bench]
 fn bench_sigverify_stage(bencher: &mut Bencher) {
     solana_logger::setup();
-    let (packet_s, packet_r) = channel();
+    let (packet_s, packet_r) = unbounded();
     let (verified_s, verified_r) = unbounded();
     let sigverify_disabled = false;
     let stage = SigVerifyStage::new(packet_r, sigverify_disabled, verified_s);

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -16,7 +16,7 @@ use crate::{
     sigverify_stage::VerifiedPackets,
 };
 use bincode::deserialize;
-use crossbeam_channel::{Receiver as CrossbeamReceiver, RecvTimeoutError};
+use crossbeam::crossbeam_channel::{Receiver as CrossbeamReceiver, RecvTimeoutError};
 use itertools::Itertools;
 use solana_measure::measure::Measure;
 use solana_metrics::{inc_new_counter_debug, inc_new_counter_info, inc_new_counter_warn};
@@ -973,7 +973,7 @@ mod tests {
     use crate::packet::to_packets;
     use crate::poh_recorder::WorkingBank;
     use crate::{get_tmp_ledger_path, tmp_ledger_name};
-    use crossbeam_channel::unbounded;
+    use crossbeam::crossbeam_channel::unbounded;
     use itertools::Itertools;
     use solana_sdk::instruction::InstructionError;
     use solana_sdk::signature::{Keypair, KeypairUtil};

--- a/core/src/cluster_info_repair_listener.rs
+++ b/core/src/cluster_info_repair_listener.rs
@@ -484,10 +484,9 @@ mod tests {
     use crate::cluster_info::Node;
     use crate::packet::{Blob, SharedBlob};
     use crate::streamer;
+    use crossbeam::crossbeam_channel::{unbounded, Receiver};
     use std::collections::BTreeSet;
     use std::sync::atomic::{AtomicBool, Ordering};
-    use std::sync::mpsc::channel;
-    use std::sync::mpsc::Receiver;
     use std::sync::Arc;
     use std::thread::sleep;
     use std::time::Duration;
@@ -519,7 +518,7 @@ mod tests {
 
         pub fn make_mock_repairee() -> Self {
             let id = Pubkey::new_rand();
-            let (repairee_sender, repairee_receiver) = channel();
+            let (repairee_sender, repairee_receiver) = unbounded();
             let repairee_socket = Arc::new(UdpSocket::bind("0.0.0.0:0").unwrap());
             let repairee_tvu_addr = repairee_socket.local_addr().unwrap();
             let repairee_exit = Arc::new(AtomicBool::new(false));

--- a/core/src/cluster_info_vote_listener.rs
+++ b/core/src/cluster_info_vote_listener.rs
@@ -4,7 +4,7 @@ use crate::result::Result;
 use crate::service::Service;
 use crate::sigverify_stage::VerifiedPackets;
 use crate::{packet, sigverify};
-use crossbeam_channel::Sender as CrossbeamSender;
+use crossbeam::crossbeam_channel::Sender as CrossbeamSender;
 use solana_metrics::inc_new_counter_debug;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, RwLock};

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -106,7 +106,6 @@ extern crate solana_metrics;
 extern crate matches;
 
 extern crate bzip2;
-extern crate crossbeam_channel;
 extern crate dir_diff;
 extern crate fs_extra;
 extern crate symlink;

--- a/core/src/result.rs
+++ b/core/src/result.rs
@@ -17,8 +17,9 @@ pub enum Error {
     AddrParse(std::net::AddrParseError),
     JoinError(Box<dyn Any + Send + 'static>),
     RecvError(std::sync::mpsc::RecvError),
-    TryCrossbeamRecvError(crossbeam_channel::TryRecvError),
-    CrossbeamRecvTimeoutError(crossbeam_channel::RecvTimeoutError),
+    TryCrossbeamRecvError(crossbeam::crossbeam_channel::TryRecvError),
+    CrossbeamRecvError(crossbeam::crossbeam_channel::RecvError),
+    CrossbeamRecvTimeoutError(crossbeam::crossbeam_channel::RecvTimeoutError),
     RecvTimeoutError(std::sync::mpsc::RecvTimeoutError),
     CrossbeamSendError,
     TryRecvError(std::sync::mpsc::TryRecvError),
@@ -49,9 +50,14 @@ impl std::convert::From<std::sync::mpsc::RecvError> for Error {
         Error::RecvError(e)
     }
 }
-impl std::convert::From<crossbeam_channel::TryRecvError> for Error {
-    fn from(e: crossbeam_channel::TryRecvError) -> Error {
+impl std::convert::From<crossbeam::crossbeam_channel::TryRecvError> for Error {
+    fn from(e: crossbeam::crossbeam_channel::TryRecvError) -> Error {
         Error::TryCrossbeamRecvError(e)
+    }
+}
+impl std::convert::From<crossbeam::crossbeam_channel::RecvError> for Error {
+    fn from(e: crossbeam::crossbeam_channel::RecvError) -> Error {
+        Error::CrossbeamRecvError(e)
     }
 }
 impl std::convert::From<std::sync::mpsc::TryRecvError> for Error {
@@ -59,8 +65,8 @@ impl std::convert::From<std::sync::mpsc::TryRecvError> for Error {
         Error::TryRecvError(e)
     }
 }
-impl std::convert::From<crossbeam_channel::RecvTimeoutError> for Error {
-    fn from(e: crossbeam_channel::RecvTimeoutError) -> Error {
+impl std::convert::From<crossbeam::crossbeam_channel::RecvTimeoutError> for Error {
+    fn from(e: crossbeam::crossbeam_channel::RecvTimeoutError) -> Error {
         Error::CrossbeamRecvTimeoutError(e)
     }
 }
@@ -84,8 +90,8 @@ impl std::convert::From<reed_solomon_erasure::Error> for Error {
         Error::ErasureError(e)
     }
 }
-impl<T> std::convert::From<crossbeam_channel::SendError<T>> for Error {
-    fn from(_e: crossbeam_channel::SendError<T>) -> Error {
+impl<T> std::convert::From<crossbeam::crossbeam_channel::SendError<T>> for Error {
+    fn from(_e: crossbeam::crossbeam_channel::SendError<T>) -> Error {
         Error::CrossbeamSendError
     }
 }

--- a/core/src/shred_fetch_stage.rs
+++ b/core/src/shred_fetch_stage.rs
@@ -5,9 +5,9 @@ use crate::packet::Packet;
 use crate::recycler::Recycler;
 use crate::service::Service;
 use crate::streamer::{self, PacketReceiver, PacketSender};
+use crossbeam::crossbeam_channel::unbounded;
 use std::net::UdpSocket;
 use std::sync::atomic::AtomicBool;
-use std::sync::mpsc::channel;
 use std::sync::Arc;
 use std::thread::{self, Builder, JoinHandle};
 
@@ -39,7 +39,7 @@ impl ShredFetchStage {
     where
         F: Fn(&mut Packet) + Send + 'static,
     {
-        let (packet_sender, packet_receiver) = channel();
+        let (packet_sender, packet_receiver) = unbounded();
         let streamers = sockets
             .into_iter()
             .map(|s| {

--- a/core/src/sigverify_stage.rs
+++ b/core/src/sigverify_stage.rs
@@ -14,11 +14,10 @@ use crate::service::Service;
 use crate::sigverify;
 use crate::sigverify::TxOffset;
 use crate::streamer::{self, PacketReceiver};
-use crossbeam_channel::Sender as CrossbeamSender;
+use crossbeam::crossbeam_channel::{Receiver, RecvTimeoutError, Sender as CrossbeamSender};
 use solana_measure::measure::Measure;
 use solana_metrics::{datapoint_debug, inc_new_counter_info};
 use solana_sdk::timing;
-use std::sync::mpsc::{Receiver, RecvTimeoutError};
 use std::sync::{Arc, Mutex};
 use std::thread::{self, Builder, JoinHandle};
 
@@ -141,9 +140,9 @@ impl SigVerifyStage {
                         &recycler_out,
                     ) {
                         match e {
-                            Error::RecvTimeoutError(RecvTimeoutError::Disconnected) => break,
-                            Error::RecvTimeoutError(RecvTimeoutError::Timeout) => (),
-                            Error::SendError => {
+                            Error::CrossbeamRecvTimeoutError(RecvTimeoutError::Disconnected) => break,
+                            Error::CrossbeamRecvTimeoutError(RecvTimeoutError::Timeout) => (),
+                            Error::CrossbeamSendError => {
                                 break;
                             }
                             _ => error!("{:?}", e),

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -10,10 +10,10 @@ use crate::fetch_stage::FetchStage;
 use crate::poh_recorder::{PohRecorder, WorkingBankEntry};
 use crate::service::Service;
 use crate::sigverify_stage::SigVerifyStage;
-use crossbeam_channel::unbounded;
+use crossbeam::crossbeam_channel::unbounded;
 use std::net::UdpSocket;
 use std::sync::atomic::AtomicBool;
-use std::sync::mpsc::{channel, Receiver};
+use std::sync::mpsc::Receiver;
 use std::sync::{Arc, Mutex, RwLock};
 use std::thread;
 
@@ -39,7 +39,7 @@ impl Tpu {
         broadcast_type: &BroadcastStageType,
         exit: &Arc<AtomicBool>,
     ) -> Self {
-        let (packet_sender, packet_receiver) = channel();
+        let (packet_sender, packet_receiver) = unbounded();
         let fetch_stage = FetchStage::new_with_sender(
             transactions_sockets,
             tpu_forwards_sockets,

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -27,6 +27,7 @@ use crate::service::Service;
 use crate::shred_fetch_stage::ShredFetchStage;
 use crate::snapshot_package::SnapshotPackagerService;
 use crate::storage_stage::{StorageStage, StorageState};
+use crossbeam::crossbeam_channel::unbounded;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::{Keypair, KeypairUtil};
 use std::net::UdpSocket;
@@ -96,7 +97,7 @@ impl Tvu {
             forwards: tvu_forward_sockets,
         } = sockets;
 
-        let (fetch_sender, fetch_receiver) = channel();
+        let (fetch_sender, fetch_receiver) = unbounded();
 
         let repair_socket = Arc::new(repair_socket);
         let fetch_sockets: Vec<Arc<UdpSocket>> = fetch_sockets.into_iter().map(Arc::new).collect();

--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -295,6 +295,7 @@ mod test {
         shred::Shredder,
         shred::SIZE_OF_SHRED_TYPE,
     };
+    use crossbeam::crossbeam_channel::{unbounded, Receiver};
     use rand::{seq::SliceRandom, thread_rng};
     use solana_sdk::{
         epoch_schedule::MINIMUM_SLOTS_PER_EPOCH,
@@ -304,7 +305,6 @@ mod test {
     use std::{
         net::UdpSocket,
         sync::atomic::{AtomicBool, Ordering},
-        sync::mpsc::{channel, Receiver},
         sync::{Arc, RwLock},
         thread::sleep,
         time::Duration,
@@ -435,7 +435,7 @@ mod test {
             .expect("Expected to be able to open database ledger");
 
         let blocktree = Arc::new(blocktree);
-        let (retransmit_sender, _retransmit_receiver) = channel();
+        let (retransmit_sender, _retransmit_receiver) = unbounded();
         let cluster_info = Arc::new(RwLock::new(ClusterInfo::new_with_invalid_keypair(
             ContactInfo::new_localhost(&Pubkey::default(), 0),
         )));
@@ -456,7 +456,7 @@ mod test {
 
     #[test]
     fn test_recv_window() {
-        let (packet_sender, packet_receiver) = channel();
+        let (packet_sender, packet_receiver) = unbounded();
         let exit = Arc::new(AtomicBool::new(false));
         let window = make_test_window(packet_receiver, exit.clone());
         // send 5 slots worth of data to the window


### PR DESCRIPTION
#### Problem

Retransmit could be faster without a lock. mpsc needs a lock for multiple consumers and we want multiple retransmit threads.

#### Summary of Changes

Switch to crossbeam crate for streamer channels.

Fixes #
