### PR TITLE
gce.sh: Be strict about fullnode count w/o --allow-boot-failures

### DIFF
--- a/net/gce.sh
+++ b/net/gce.sh
@@ -487,24 +487,24 @@ EOF
   fi
 
   if [[ $additionalFullNodeCount -gt 0 ]]; then
-    num_zones=${#zones[@]}
-    if [[ $additionalFullNodeCount -gt $num_zones ]]; then
-      numNodesPerZone=$((additionalFullNodeCount / num_zones))
-      numLeftOverNodes=$((additionalFullNodeCount % num_zones))
+    numZones=${#zones[@]}
+    if [[ $additionalFullNodeCount -gt $numZones ]]; then
+      numNodesPerZone=$((additionalFullNodeCount / numZones))
+      numLeftOverNodes=$((additionalFullNodeCount % numZones))
     else
       numNodesPerZone=1
       numLeftOverNodes=0
     fi
 
-    for ((i=((num_zones - 1)); i >= 0; i--)); do
+    for ((i=((numZones - 1)); i >= 0; i--)); do
       zone=${zones[i]}
       if [[ $i -eq 0 ]]; then
         numNodesPerZone=$((numNodesPerZone + numLeftOverNodes))
       fi
       echo "Looking for additional fullnode instances in $zone ..."
       cloud_FindInstances "$prefix-$zone-fullnode"
-      declare n_inst=${#instances[@]}
-      if [[ $n_inst -eq $numNodesPerZone || ( ! $failOnValidatorBootupFailure && $n_inst -gt 0 ) ]]; then
+      declare numInstances=${#instances[@]}
+      if [[ $numInstances -eq $numNodesPerZone || ( ! $failOnValidatorBootupFailure && $numInstances -gt 0 ) ]]; then
         cloud_ForEachInstance recordInstanceIp "$failOnValidatorBootupFailure" fullnodeIpList
       else
         echo "Unable to find additional fullnodes"

--- a/net/gce.sh
+++ b/net/gce.sh
@@ -487,10 +487,24 @@ EOF
   fi
 
   if [[ $additionalFullNodeCount -gt 0 ]]; then
-    for zone in "${zones[@]}"; do
+    num_zones=${#zones[@]}
+    if [[ $additionalFullNodeCount -gt $num_zones ]]; then
+      numNodesPerZone=$((additionalFullNodeCount / num_zones))
+      numLeftOverNodes=$((additionalFullNodeCount % num_zones))
+    else
+      numNodesPerZone=1
+      numLeftOverNodes=0
+    fi
+
+    for ((i=((num_zones - 1)); i >= 0; i--)); do
+      zone=${zones[i]}
+      if [[ $i -eq 0 ]]; then
+        numNodesPerZone=$((numNodesPerZone + numLeftOverNodes))
+      fi
       echo "Looking for additional fullnode instances in $zone ..."
       cloud_FindInstances "$prefix-$zone-fullnode"
-      if [[ ${#instances[@]} -gt 0 ]]; then
+      declare n_inst=${#instances[@]}
+      if [[ $n_inst -eq $numNodesPerZone || ( ! $failOnValidatorBootupFailure && $n_inst -gt 0 ) ]]; then
         cloud_ForEachInstance recordInstanceIp "$failOnValidatorBootupFailure" fullnodeIpList
       else
         echo "Unable to find additional fullnodes"


### PR DESCRIPTION
#### Problem

`net/gce.sh` happily allocates a testnet with fewer than the requested number of fullnodes so long as more than zero showed up, even without `--allow-boot-failures` (formerly `-f`).

#### Summary of Changes

Strictly check the the fullnode count unless `--allow-boot-failures` was passed