### PR TITLE
net.sh: Add support for selecting validator GPU mode

### DIFF
--- a/multinode-demo/bootstrap-leader.sh
+++ b/multinode-demo/bootstrap-leader.sh
@@ -8,6 +8,11 @@ here=$(dirname "$0")
 # shellcheck source=multinode-demo/common.sh
 source "$here"/common.sh
 
+if [[ "$SOLANA_GPU_MISSING" -eq 1 ]]; then
+  echo "Testnet requires GPUs, but none were found!  Aborting..."
+  exit 1
+fi
+
 if [[ -n $SOLANA_CUDA ]]; then
   program=$solana_validator_cuda
 else

--- a/multinode-demo/validator.sh
+++ b/multinode-demo/validator.sh
@@ -152,6 +152,11 @@ while [[ -n $1 ]]; do
   fi
 done
 
+if [[ "$SOLANA_GPU_MISSING" -eq 1 ]]; then
+  echo "Testnet requires GPUs, but none were found!  Aborting..."
+  exit 1
+fi
+
 if [[ ${#positional_args[@]} -gt 1 ]]; then
   usage "$@"
 fi

--- a/net/net.sh
+++ b/net/net.sh
@@ -49,7 +49,7 @@ Operate a configured testnet
                                         This will start 2 bench-tps clients, and supply "--tx_count 25000"
                                         to the bench-tps client.
    -n NUM_FULL_NODES                  - Number of fullnodes to apply command to.
-   -g / --gpu-mode GPU_MODE           - Specify GPU mode to launch validators with (default: $gpuMode).
+   --gpu-mode GPU_MODE                - Specify GPU mode to launch validators with (default: $gpuMode).
                                         MODE must be one of
                                           on - GPU *required*, any vendor *
                                           off - No GPU, CPU-only
@@ -196,6 +196,14 @@ while [[ -n $1 ]]; do
       shift 1
     elif [[ $1 = --gpu-mode ]]; then
       gpuMode=$2
+      case "$gpuMode" in
+        on|off|auto|cuda)
+          ;;
+        *)
+          echo "Unexpected GPU mode: \"$gpuMode\""
+          exit 1
+          ;;
+      esac
       shift 2
     else
       usage "Unknown long option: $1"
@@ -206,7 +214,7 @@ while [[ -n $1 ]]; do
   fi
 done
 
-while getopts "h?T:t:o:f:rD:c:Fn:g:i:d" opt "${shortArgs[@]}"; do
+while getopts "h?T:t:o:f:rD:c:Fn:i:d" opt "${shortArgs[@]}"; do
   case $opt in
   h | \?)
     usage
@@ -229,9 +237,6 @@ while getopts "h?T:t:o:f:rD:c:Fn:g:i:d" opt "${shortArgs[@]}"; do
     ;;
   n)
     numFullnodesRequested=$OPTARG
-    ;;
-  g)
-    gpuMode=$OPTARG
     ;;
   r)
     skipSetup=true
@@ -296,8 +301,6 @@ while getopts "h?T:t:o:f:rD:c:Fn:g:i:d" opt "${shortArgs[@]}"; do
     ;;
   esac
 done
-
-grep -qE '^(on|off|auto|cuda)$' <<<"$gpuMode" || ( echo "Unexpected GPU mode: \"$gpuMode\"" && exit 1 )
 
 loadConfigFile
 


### PR DESCRIPTION
#### Problem

There is currently no way to switch between launching a CPU and GPU testnet without reallocating the underlying instances.  If the instances have GPUs, a CUDA-enabled validators are launched, if not CPU-only validators.  This is tedious with GCE and untenable on colo where most of the nodes just *have* GPUs.

#### Summary of Changes

Adds a flag to `net/net.sh` to allow selecting the GPU mode.  Defaults to "auto", which is the current behavior, as described above.

WIP: Until I can get a hold of a couple GPU nodes on colo for testing

Fixes #6100
