### PR TITLE
Proposal for optimistic finality after 1 round of Tower voting.

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -55,6 +55,7 @@
   * [Inter-chain Transaction Verification](proposals/interchain-transaction-verification.md)
   * [Snapshot Verification](proposals/snapshot-verification.md)
   * [Bankless Leader](proposals/bankless-leader.md)
+  * [One Round Finality](proposals/one-round-finality.md)
 * [Implemented Design Proposals](implemented-proposals/README.md)
   * [Blocktree](implemented-proposals/blocktree.md)
   * [Cluster Software Installation and Updates](implemented-proposals/installer.md)

--- a/book/src/proposals/one-round-finality.md
+++ b/book/src/proposals/one-round-finality.md
@@ -10,7 +10,9 @@ not to propose alternative forks.
 If only a part of the cluster has agreed not to propose alternative
 forks the deterministic leader schedule can be used to calculate
 the likelihood of a leader that is not committed of proposing a
-votable alternative fork.
+votable alternative fork. This calculation is based on the assumption
+that the partition is static, and that the same leaders will continue
+voting together.
 
 ## Overview
 

--- a/book/src/proposals/one-round-finality.md
+++ b/book/src/proposals/one-round-finality.md
@@ -1,11 +1,11 @@
 # Practical Finality in One Round of Consensus
 
 The cluster can achieve a high degree of finality though Tower
-consensus, and the cluster commits to an exponentially increasing
-of safety for a block.  This safety is based on the commitment of
-any validator from switching votes to an alternative fork.  It is
-possible to achieve finality a different way, leaders can agree not
-to propose alternative forks.
+consensus as the cluster commits to an exponentially increasing of
+safety for a block.  This safety is based on the commitment of any
+voting validator from switching votes to an alternative fork.  It
+is possible to achieve finality a different way, leaders can agree
+not to propose alternative forks.
 
 If only a part of the cluster has agreed not to propose alternative
 forks the deterministic leader schedule can be used to calculate
@@ -15,7 +15,7 @@ votable alternative fork.
 ## Overview
 
 Leaders commit to producing a block that chains to the leaders last
-vote.
+vote.  Breaking this commitment is slashable.
 
 Once a block has been voted on, the subsequent leader schedule will
 reflect the likelihood of the block being finalized.
@@ -60,7 +60,9 @@ a rough estimate of the likelihood of each streak is as follows:
 * streak of size 9 in 204 blocks 99.90%
 * streak of size 10 in 409 blocks 99.999%
 
-So the cumulative probability is roughly 93.8%.
+So the cumulative probability is roughly 93.8%.  This calculation
+would need to take into account how the non-voting leaders are
+distributed in the schedule.
 
 At any point if all 100% have voted for a descendant, then there
 is no way a block could be proposed that doesn't include the parent.

--- a/book/src/proposals/one-round-finality.md
+++ b/book/src/proposals/one-round-finality.md
@@ -21,7 +21,7 @@ Once a block has been voted on, the subsequent leader schedule will
 reflect the likelihood of the block being finalized.
 
 For example:
-* 80% of the cluster voted the block
+* 80% of the cluster voted for the block
 
 * The schedule for the next 5 leaders looks like:
 
@@ -60,9 +60,9 @@ a rough estimate of the likelihood of each streak is as follows:
 * streak of size 9 in 204 blocks 99.90%
 * streak of size 10 in 409 blocks 99.999%
 
-So the cumulative probability is roughly 93.8%.  This calculation
-would need to take into account how the non-voting leaders are
-distributed in the schedule.
+The cumulative probability is roughly 93.8%.  This calculation would
+need to take into account how the non-voting leaders are distributed
+in the schedule.
 
 At any point if all 100% have voted for a descendant, then there
 is no way a block could be proposed that doesn't include the parent.

--- a/book/src/proposals/one-round-finality.md
+++ b/book/src/proposals/one-round-finality.md
@@ -1,0 +1,104 @@
+# Practical Finality in One Round of Consensus
+
+The cluster can achieve a high degree of finality though Tower
+consensus, and the cluster commits to an exponentially increasing
+of safety for a block.  This safety is based on the commitment of
+any validator from switching votes to an alternative fork.  It is
+possible to achieve finality a different way, leaders can agree not
+to propose alternative forks.
+
+If only a part of the cluster has agreed not to propose alternative
+forks the deterministic leader schedule can be used to calculate
+the likelihood of a leader that is not committed of proposing a
+votable alternative fork.
+
+## Overview
+
+Leaders commit to producing a block that chains to the leaders last
+vote.
+
+Once a block has been voted on, the subsequent leader schedule will
+reflect the likelihood of the block being finalized.
+
+For example:
+* 80% of the cluster voted the block
+
+* The schedule for the next 5 leaders looks like:
+
+    * V,V,V, V,V,V,V, N,N,N,N, V,V,V,V, V,V,V,V
+
+Where V indicates that the leader voted on the block and N indicates
+that they haven't. By the time the `N` leader is reached, its likely
+this block would be voted on 7 times, and the lockout for this block
+would prevent the `N` leader from proposing an alternative fork
+which doesn't contain this block.
+
+## Calculating the Probability of a block succeeding
+
+This calculation assumes that the voting nodes are on the same
+partition and will vote with the same response rate.
+
+The likelihood of the block being finalized will approach the
+probability of voting streaks that accumulate enough lockout to
+skip over all the non-voting leaders.
+
+In the above example if the probability of any block being dropped
+is 2%, then probability of a streak of size 3 in the next 7 blocks
+is 98.07%, and the probability of a streak of size 4 is 97.7%, which
+should roughly equal the probability of the fork still being live
+after the non-voting leader produced an alternative fork.
+
+Each streak just needs to produce a lockout that is 2x longer than
+the streak.  Given that 20% of leaders are in the wrong partition,
+a rough estimate of the likelihood of each streak is as follows:
+
+* streak of size 4 in 7 blocks 97.7%
+* streak of size 5 in 12 blocks 98.04%
+* streak of size 6 in 25 blocks 98.6%
+* streak of size 7 in 51 blocks 99.03%
+* streak of size 8 in 108 blocks 99.63%
+* streak of size 9 in 204 blocks 99.90%
+* streak of size 10 in 409 blocks 99.999%
+
+So the cumulative probability is roughly 93.8%.
+
+At any point if all 100% have voted for a descendant, then there
+is no way a block could be proposed that doesn't include the parent.
+At this point, finality is equal to finality that is achieved when
+the cluster reaches the root slot for the block.
+
+## Agreement on Continuing a Fork
+
+A leader is committed to producing a block that is chained to the
+last vote the leader cast.  If a leader fails to do so, the leader
+will be slashed.
+
+## Slashing for Alternative Forks
+
+* Each block contains a leader signature of the blockhash the block
+height and previous block height.
+
+* A proof is composed of the chain of blockhashes starting with the
+malicious leader, and a vote for a block the malicious leader not
+included in the chain.
+
+## Impact on Liveness
+
+Current implementation leaders already commit to generating a block
+that is chained to the previous vote.  The only possible scenario
+where this is false is if the leader is restarted and loses data.
+
+* Leaders should store votes in persistent storage before transmitting
+them to the cluster.
+
+* Leaders whose persistent storage is corrupted after restart should
+vote before submitting a block.
+
+## Slashing Size
+
+For this commitment to have the same weight as vote lockouts,
+slashing must be equal in severity as slashing for violating a root
+fork lockout.
+
+## Notes
+* https://www.askamathematician.com/2010/07/q-whats-the-chance-of-getting-a-run-of-k-successes-in-n-bernoulli-trials-why-use-approximations-when-the-exact-answer-is-known/

--- a/book/src/proposals/one-round-finality.md
+++ b/book/src/proposals/one-round-finality.md
@@ -30,19 +30,31 @@ For example:
     * V,V,V, V,V,V,V, N,N,N,N, V,V,V,V, V,V,V,V
 
 Where V indicates that the leader voted on the block and N indicates
-that they haven't. By the time the `N` leader is reached, its likely
-this block would be voted on 7 times, and the lockout for this block
-would prevent the `N` leader from proposing an alternative fork
-which doesn't contain this block.
+that they haven't.  N is in some partition and N did not observe
+the block so N didn't vote. N is not slashed for proposing an
+alternative fork, N is allowed to propose forks. Only the validators
+that voted for the block can be slashed for proposing fork that
+doesn't contain it.
+
+
+By the time the `N` leader is reached, its likely this block would
+be voted on 7 times, and the lockout for this block would prevent
+the `N` leader from proposing an alternative fork which doesn't
+contain this block.
 
 ## Calculating the Probability of a block succeeding
 
-This calculation assumes that the voting nodes are on the same
-partition and will vote with the same response rate.
+This calculation assumes that the validators are on the same
+partition, that the partition is static and that validators will
+vote with the same response rate.
 
-The likelihood of the block being finalized will approach the
-probability of voting streaks that accumulate enough lockout to
-skip over all the non-voting leaders.
+To calculate the probability of the block being finalized we would
+need to count all the possible ways that future scheduled leaders
+will vote and produce blocks.  An approximation of this calculation
+is the probability of voting streaks that accumulate enough lockout
+to skip over all the non-voting leaders.  A voting streak is as
+series of votes that result in the lockout doubling for a block
+prior to the streak.
 
 In the above example if the probability of any block being dropped
 is 2%, then probability of a streak of size 3 in the next 7 blocks
@@ -54,9 +66,10 @@ block surviving is at least equal to the probability of continuous
 run of streaks that keep doubling the lockout.
 
 Each streak needs to produce a lockout that is 2x longer than the
-lockout from the previous streak.  Given that 20% of leaders are
-in the wrong partition, a rough estimate of the likelihood of each
-streak is as follows:
+lockout from the previous streak, and each streak has twice as many
+blocks in which that possibility can arise. Given that 20% of the
+stake weighted leaders are in the wrong partition, a rough estimate
+of the likelihood of each streak is as follows:
 
 * streak of size 4 in 7 blocks 97.7%
 * streak of size 5 in 12 blocks 98.04%
@@ -66,9 +79,9 @@ streak is as follows:
 * streak of size 9 in 204 blocks 99.90%
 * streak of size 10 in 409 blocks 99.999%
 
-The cumulative probability is roughly 93.8%.  This calculation would
-need to take into account how the non-voting leaders are distributed
-in the schedule.
+The cumulative probability is roughly 93.8%.  A better approximation
+of this calculation would take into account how the non-voting
+leaders are distributed in the schedule.
 
 At any point if all 100% have voted for a descendant, then there
 is no way a block could be proposed that doesn't include the parent.

--- a/book/src/proposals/one-round-finality.md
+++ b/book/src/proposals/one-round-finality.md
@@ -7,12 +7,11 @@ voting validator from switching votes to an alternative fork.  It
 is possible to achieve finality a different way, leaders can agree
 not to propose alternative forks.
 
-If only a part of the cluster has agreed not to propose alternative
-forks the deterministic leader schedule can be used to calculate
-the likelihood of a leader that is not committed of proposing a
-votable alternative fork. This calculation is based on the assumption
-that the partition is static, and that the same leaders will continue
-voting together.
+If only a part of the cluster has voted, then the set of all the
+leaders that haven't voted and the leader schedule can be used to
+simulate how lockout will grow in the future.  This calculation is
+based on the assumption that the partition is static, and that the
+same leaders will continue voting together.
 
 ## Overview
 

--- a/book/src/proposals/one-round-finality.md
+++ b/book/src/proposals/one-round-finality.md
@@ -48,9 +48,10 @@ is 98.07%, and the probability of a streak of size 4 is 97.7%, which
 should roughly equal the probability of the fork still being live
 after the non-voting leader produced an alternative fork.
 
-Each streak just needs to produce a lockout that is 2x longer than
-the streak.  Given that 20% of leaders are in the wrong partition,
-a rough estimate of the likelihood of each streak is as follows:
+Each streak needs to produce a lockout that is 2x longer than the
+lockout from the previous streak.  Given that 20% of leaders are
+in the wrong partition, a rough estimate of the likelihood of each
+streak is as follows:
 
 * streak of size 4 in 7 blocks 97.7%
 * streak of size 5 in 12 blocks 98.04%

--- a/book/src/proposals/one-round-finality.md
+++ b/book/src/proposals/one-round-finality.md
@@ -16,7 +16,8 @@ same leaders will continue voting together.
 ## Overview
 
 Leaders commit to producing a block that chains to the leaders last
-vote.  Breaking this commitment is slashable.
+vote. Breaking this commitment is slashable.  The leader is free
+to switch forks and vote for an alternative chain.
 
 Once a block has been voted on, the subsequent leader schedule will
 reflect the likelihood of the block being finalized.
@@ -47,7 +48,10 @@ In the above example if the probability of any block being dropped
 is 2%, then probability of a streak of size 3 in the next 7 blocks
 is 98.07%, and the probability of a streak of size 4 is 97.7%, which
 should roughly equal the probability of the fork still being live
-after the non-voting leader produced an alternative fork.
+after the non-voting leader produced an alternative fork.  Looking
+at the leader schedule ahead of the block, the probability of the
+block surviving is at least equal to the probability of continuous
+run of streaks that keep doubling the lockout.
 
 Each streak needs to produce a lockout that is 2x longer than the
 lockout from the previous streak.  Given that 20% of leaders are
@@ -97,6 +101,10 @@ them to the cluster.
 
 * Leaders whose persistent storage is corrupted after restart should
 vote before submitting a block.
+
+* Leaders that vote for an incorrect bankhash due to a state
+corruption are still required to chain their next block to the
+previous vote.
 
 ## Slashing Size
 


### PR DESCRIPTION
#### Problem

Full finality takes 32 rounds, it’s possible to achieve it in one round under optimistic conditions. 

#### Summary of Changes

Propose a design that allows for the network to optimistically achieve 100% finality in 1 round of voting.  As well as describe how a likelihood of finality can be calculated for any block given the set of block producers that have voted on the block.

Fixes #
