### PR TITLE
Increase buffer size for erasure meta DB column

### DIFF
--- a/core/src/blocktree/rocks.rs
+++ b/core/src/blocktree/rocks.rs
@@ -419,11 +419,11 @@ impl std::convert::From<rocksdb::Error> for Error {
 }
 
 fn get_cf_options(name: &'static str) -> Options {
-    use crate::blocktree::db::columns::{ShredCode, ShredData, Index};
+    use crate::blocktree::db::columns::{ErasureMeta, Index, ShredCode, ShredData};
 
     let mut options = Options::default();
     match name {
-        ShredCode::NAME | ShredData::NAME | Index::NAME => {
+        ShredCode::NAME | ShredData::NAME | Index::NAME | ErasureMeta::NAME => {
             // 512MB * 8 = 4GB. 2 of these columns should take no more than 8GB of RAM
             options.set_max_write_buffer_number(8);
             options.set_write_buffer_size(MAX_WRITE_BUFFER_SIZE as usize);


### PR DESCRIPTION
#### Problem
There are more erasure meta now, compared to when we were using blobs. The DB column size for erasure meta should be adjusted.

#### Summary of Changes
Increased size for erasure meta DB column