### PR TITLE
More fullnode to validator renaming

### DIFF
--- a/ci/localnet-sanity.sh
+++ b/ci/localnet-sanity.sh
@@ -207,7 +207,7 @@ killNodes() {
       set -x
       curl --retry 5 --retry-delay 2 --retry-connrefused \
         -X POST -H 'Content-Type: application/json' \
-        -d '{"jsonrpc":"2.0","id":1, "method":"fullnodeExit"}' \
+        -d '{"jsonrpc":"2.0","id":1, "method":"validatorExit"}' \
         http://localhost:$port
     )
   done

--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -679,20 +679,20 @@ impl RpcClient {
         })
     }
 
-    pub fn fullnode_exit(&self) -> io::Result<bool> {
+    pub fn validator_exit(&self) -> io::Result<bool> {
         let response = self
             .client
-            .send(&RpcRequest::FullnodeExit, None, 0)
+            .send(&RpcRequest::ValidatorExit, None, 0)
             .map_err(|err| {
                 io::Error::new(
                     io::ErrorKind::Other,
-                    format!("FullnodeExit request failure: {:?}", err),
+                    format!("ValidatorExit request failure: {:?}", err),
                 )
             })?;
         serde_json::from_value(response).map_err(|err| {
             io::Error::new(
                 io::ErrorKind::Other,
-                format!("FullnodeExit parse failure: {:?}", err),
+                format!("ValidatorExit parse failure: {:?}", err),
             )
         })
     }

--- a/client/src/rpc_request.rs
+++ b/client/src/rpc_request.rs
@@ -21,7 +21,7 @@ pub struct RpcEpochInfo {
 pub enum RpcRequest {
     ConfirmTransaction,
     DeregisterNode,
-    FullnodeExit,
+    ValidatorExit,
     GetAccountInfo,
     GetBalance,
     GetClusterNodes,
@@ -54,7 +54,7 @@ impl RpcRequest {
         let method = match self {
             RpcRequest::ConfirmTransaction => "confirmTransaction",
             RpcRequest::DeregisterNode => "deregisterNode",
-            RpcRequest::FullnodeExit => "fullnodeExit",
+            RpcRequest::ValidatorExit => "validatorExit",
             RpcRequest::GetAccountInfo => "getAccountInfo",
             RpcRequest::GetBalance => "getBalance",
             RpcRequest::GetClusterNodes => "getClusterNodes",

--- a/client/src/thin_client.rs
+++ b/client/src/thin_client.rs
@@ -268,8 +268,8 @@ impl ThinClient {
         self.rpc_client().check_signature(signature)
     }
 
-    pub fn fullnode_exit(&self) -> io::Result<bool> {
-        self.rpc_client().fullnode_exit()
+    pub fn validator_exit(&self) -> io::Result<bool> {
+        self.rpc_client().validator_exit()
     }
 
     pub fn get_num_blocks_since_signature_confirmation(

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -2,7 +2,7 @@
 //! It includes a full Rust implementation of the architecture (see
 //! [Validator](server/struct.Validator.html)) as well as hooks to GPU implementations of its most
 //! paralellizable components (i.e. [SigVerify](sigverify/index.html)).  It also includes
-//! command-line tools to spin up fullnodes and a Rust library
+//! command-line tools to spin up validators and a Rust library
 //!
 
 pub mod bank_forks;

--- a/core/src/local_vote_signer_service.rs
+++ b/core/src/local_vote_signer_service.rs
@@ -1,4 +1,4 @@
-//! The `local_vote_signer_service` can be started locally to sign fullnode votes
+//! The `local_vote_signer_service` can be started locally to sign validator votes
 
 use crate::service::Service;
 use solana_netutil::PortRange;

--- a/core/src/sigverify.rs
+++ b/core/src/sigverify.rs
@@ -194,7 +194,7 @@ pub fn ed25519_verify(
     // micro-benchmarks show GPU time for smallest batch around 15-20ms
     // and CPU speed for 64-128 sigverifies around 10-20ms. 64 is a nice
     // power-of-two number around that accounting for the fact that the CPU
-    // may be busy doing other things while being a real fullnode
+    // may be busy doing other things while being a real validator
     // TODO: dynamically adjust this crossover
     if count < 64 {
         return ed25519_verify_cpu(batches);

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1,4 +1,4 @@
-//! The `fullnode` module hosts all the fullnode microservices.
+//! The `validator` module hosts all the validator microservices.
 
 use crate::bank_forks::{BankForks, SnapshotConfig};
 use crate::blocktree::{Blocktree, CompletedSlotsReceiver};

--- a/gossip/src/main.rs
+++ b/gossip/src/main.rs
@@ -229,7 +229,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
             }
             println!("\nSending stop request to node {:?}", pubkey);
 
-            let result = RpcClient::new_socket(node.rpc).fullnode_exit()?;
+            let result = RpcClient::new_socket(node.rpc).validator_exit()?;
             if result {
                 println!("Stop signal accepted");
             } else {

--- a/local_cluster/src/cluster_tests.rs
+++ b/local_cluster/src/cluster_tests.rs
@@ -114,17 +114,17 @@ pub fn send_many_transactions(
     expected_balances
 }
 
-pub fn fullnode_exit(entry_point_info: &ContactInfo, nodes: usize) {
+pub fn validator_exit(entry_point_info: &ContactInfo, nodes: usize) {
     let (cluster_nodes, _) = discover_cluster(&entry_point_info.gossip, nodes).unwrap();
     assert!(cluster_nodes.len() >= nodes);
     for node in &cluster_nodes {
         let client = create_client(node.client_facing_addr(), VALIDATOR_PORT_RANGE);
-        assert!(client.fullnode_exit().unwrap());
+        assert!(client.validator_exit().unwrap());
     }
     sleep(Duration::from_millis(DEFAULT_SLOT_MILLIS));
     for node in &cluster_nodes {
         let client = create_client(node.client_facing_addr(), VALIDATOR_PORT_RANGE);
-        assert!(client.fullnode_exit().is_err());
+        assert!(client.validator_exit().is_err());
     }
 }
 
@@ -198,7 +198,7 @@ pub fn kill_entry_and_spend_and_verify_rest(
     ));
     info!("done sleeping for first 2 warmup epochs");
     info!("killing entry point: {}", entry_point_info.id);
-    assert!(client.fullnode_exit().unwrap());
+    assert!(client.validator_exit().unwrap());
     info!("sleeping for some time");
     sleep(Duration::from_millis(
         slot_millis * NUM_CONSECUTIVE_LEADER_SLOTS,

--- a/metrics/scripts/grafana-provisioning/dashboards/testnet-monitor.json
+++ b/metrics/scripts/grafana-provisioning/dashboards/testnet-monitor.json
@@ -4815,7 +4815,7 @@
       },
       "id": 41,
       "panels": [],
-      "title": "Fullnode Streamer",
+      "title": "Validator Streamer",
       "type": "row"
     },
     {

--- a/net/scripts/ec2-security-group-config.json
+++ b/net/scripts/ec2-security-group-config.json
@@ -24,7 +24,7 @@
             "FromPort": 8000,
             "IpRanges": [
                 {
-                    "Description": "fullnode UDP range",
+                    "Description": "validator UDP range",
                     "CidrIp": "0.0.0.0/0"
                 }
             ],
@@ -34,7 +34,7 @@
             "Ipv6Ranges": [
                 {
                     "CidrIpv6": "::/0",
-                    "Description": "fullnode UDP range"
+                    "Description": "validator UDP range"
                 }
             ]
         },
@@ -100,7 +100,7 @@
             "FromPort": 8000,
             "IpRanges": [
                 {
-                    "Description": "fullnode TCP range",
+                    "Description": "validator TCP range",
                     "CidrIp": "0.0.0.0/0"
                 }
             ],
@@ -110,7 +110,7 @@
             "Ipv6Ranges": [
                 {
                     "CidrIpv6": "::/0",
-                    "Description": "fullnode TCP range"
+                    "Description": "validator TCP range"
                 }
             ]
         },

--- a/scripts/tune-system.sh
+++ b/scripts/tune-system.sh
@@ -1,6 +1,6 @@
 # |source| this file
 #
-# Adjusts system settings for optimal fullnode performance
+# Adjusts system settings for optimal validator performance
 #
 
 sysctl_write() {

--- a/validator/src/lib.rs
+++ b/validator/src/lib.rs
@@ -335,7 +335,7 @@ pub fn main() {
             Arg::with_name("enable_rpc_exit")
                 .long("enable-rpc-exit")
                 .takes_value(false)
-                .help("Enable the JSON RPC 'fullnodeExit' API.  Only enable in a debug environment"),
+                .help("Enable the JSON RPC 'validatorExit' API.  Only enable in a debug environment"),
         )
         .arg(
             Arg::with_name("rpc_drone_addr")
@@ -457,7 +457,7 @@ pub fn main() {
 
     validator_config.voting_disabled = matches.is_present("no_voting");
 
-    validator_config.rpc_config.enable_fullnode_exit = matches.is_present("enable_rpc_exit");
+    validator_config.rpc_config.enable_validator_exit = matches.is_present("enable_rpc_exit");
 
     validator_config.rpc_config.drone_addr = matches.value_of("rpc_drone_addr").map(|address| {
         solana_netutil::parse_host_port(address).expect("failed to parse drone address")


### PR DESCRIPTION
#### Problem

Legacy term "fullnode" lingering

#### Summary of Changes

Rename all remaining uses of "fullnode" in Rust modules to "validator"
