### PR TITLE
Offload insertion of shreds in broadcast

### DIFF
--- a/core/src/broadcast_stage/broadcast_fake_blobs_run.rs
+++ b/core/src/broadcast_stage/broadcast_fake_blobs_run.rs
@@ -2,6 +2,7 @@ use super::*;
 use crate::entry::Entry;
 use crate::shred::{Shredder, RECOMMENDED_FEC_RATE};
 use solana_sdk::hash::Hash;
+use std::sync::mpsc::Sender;
 
 pub(super) struct BroadcastFakeBlobsRun {
     last_blockhash: Hash,
@@ -23,6 +24,7 @@ impl BroadcastRun for BroadcastFakeBlobsRun {
         cluster_info: &Arc<RwLock<ClusterInfo>>,
         receiver: &Receiver<WorkingBankEntry>,
         sock: &UdpSocket,
+        _insert_blocktree_sender: &Sender<Vec<Shred>>,
         blocktree: &Arc<Blocktree>,
     ) -> Result<()> {
         // 1) Pull entries from banking stage

--- a/core/src/broadcast_stage/broadcast_utils.rs
+++ b/core/src/broadcast_stage/broadcast_utils.rs
@@ -18,6 +18,7 @@ pub struct UnfinishedSlotInfo {
     pub next_shred_index: u32,
     pub slot: u64,
     pub parent: u64,
+    pub is_marked_in_blocktree: bool,
 }
 
 /// Theis parameter tunes how many entries are received in one iteration of recv loop

--- a/core/src/broadcast_stage/drop_slots_from_blocktree_run.rs
+++ b/core/src/broadcast_stage/drop_slots_from_blocktree_run.rs
@@ -1,0 +1,52 @@
+use crate::blocktree::Blocktree;
+use crate::broadcast_stage::standard_broadcast_run::StandardBroadcastRun;
+use crate::broadcast_stage::BroadcastRun;
+use crate::cluster_info::ClusterInfo;
+use crate::poh_recorder::WorkingBankEntry;
+use crate::result::Result;
+use crate::shred::Shred;
+use solana_sdk::signature::Keypair;
+use std::collections::HashSet;
+use std::net::UdpSocket;
+use std::sync::mpsc::{channel, Receiver, Sender};
+use std::sync::{Arc, RwLock};
+
+pub struct DropSlotsFromBlocktreeRun {
+    slots_to_ignore: HashSet<u64>,
+    standard_broadcast_run: StandardBroadcastRun,
+}
+impl DropSlotsFromBlocktreeRun {
+    pub fn new(slots_to_ignore: HashSet<u64>, keypair: Arc<Keypair>) -> Self {
+        let standard_broadcast_run = StandardBroadcastRun::new(keypair);
+        Self {
+            slots_to_ignore,
+            standard_broadcast_run,
+        }
+    }
+}
+impl BroadcastRun for DropSlotsFromBlocktreeRun {
+    fn run(
+        &mut self,
+        cluster_info: &Arc<RwLock<ClusterInfo>>,
+        receiver: &Receiver<WorkingBankEntry>,
+        sock: &UdpSocket,
+        insert_blocktree_sender: &Sender<Vec<Shred>>,
+        blocktree: &Arc<Blocktree>,
+    ) -> Result<()> {
+        let (send_intercept, receive_intercept) = channel();
+        let result = self.standard_broadcast_run.run(
+            cluster_info,
+            receiver,
+            sock,
+            &send_intercept,
+            blocktree,
+        );
+        if let Ok(mut shreds) = receive_intercept.try_recv() {
+            shreds.retain(|s| !self.slots_to_ignore.contains(&s.slot()));
+            insert_blocktree_sender
+                .send(shreds)
+                .expect("Sender should not have been dropped");
+        }
+        result
+    }
+}

--- a/core/src/broadcast_stage/fail_entry_verification_broadcast_run.rs
+++ b/core/src/broadcast_stage/fail_entry_verification_broadcast_run.rs
@@ -1,6 +1,7 @@
 use super::*;
 use crate::shred::{Shredder, RECOMMENDED_FEC_RATE};
 use solana_sdk::hash::Hash;
+use std::sync::mpsc::Sender;
 
 pub(super) struct FailEntryVerificationBroadcastRun {}
 
@@ -16,6 +17,7 @@ impl BroadcastRun for FailEntryVerificationBroadcastRun {
         cluster_info: &Arc<RwLock<ClusterInfo>>,
         receiver: &Receiver<WorkingBankEntry>,
         sock: &UdpSocket,
+        _insert_blocktree_sender: &Sender<Vec<Shred>>,
         blocktree: &Arc<Blocktree>,
     ) -> Result<()> {
         // 1) Pull entries from banking stage

--- a/local_cluster/src/local_cluster.rs
+++ b/local_cluster/src/local_cluster.rs
@@ -113,7 +113,7 @@ impl LocalCluster {
         num_nodes: usize,
         cluster_lamports: u64,
         lamports_per_node: u64,
-    ) -> Self {
+    ) -> (Self, ClusterConfig) {
         let stakes: Vec<_> = (0..num_nodes).map(|_| lamports_per_node).collect();
         let config = ClusterConfig {
             node_stakes: stakes,
@@ -121,7 +121,7 @@ impl LocalCluster {
             validator_configs: vec![ValidatorConfig::default(); num_nodes],
             ..ClusterConfig::default()
         };
-        Self::new(&config)
+        (Self::new(&config), config)
     }
 
     pub fn new(config: &ClusterConfig) -> Self {
@@ -646,7 +646,7 @@ mod test {
     fn test_local_cluster_start_and_exit() {
         solana_logger::setup();
         let num_nodes = 1;
-        let cluster = LocalCluster::new_with_equal_stakes(num_nodes, 100, 3);
+        let cluster = LocalCluster::new_with_equal_stakes(num_nodes, 100, 3).0;
         assert_eq!(cluster.validators.len(), num_nodes);
         assert_eq!(cluster.replicators.len(), 0);
     }

--- a/local_cluster/src/tests/replicator.rs
+++ b/local_cluster/src/tests/replicator.rs
@@ -125,7 +125,7 @@ fn test_replicator_startup_ledger_hang() {
     info!("starting replicator test");
     let mut validator_config = ValidatorConfig::default();
     validator_config.storage_slots_per_turn = SLOTS_PER_TURN_TEST;
-    let cluster = LocalCluster::new_with_equal_stakes(2, 10_000, 100);
+    let cluster = LocalCluster::new_with_equal_stakes(2, 10_000, 100).0;
 
     info!("starting replicator node");
     let bad_keys = Arc::new(Keypair::new());

--- a/programs/stake_api/src/stake_state.rs
+++ b/programs/stake_api/src/stake_state.rs
@@ -1003,8 +1003,8 @@ mod tests {
         }];
         // give 2 epochs of cooldown
         let epochs = 7;
-        // make boostrap stake smaller than warmup so warmup/cooldownn
-        //  increment is always smaller than 1
+        // make bootstrap stake smaller than warmup so warmup/cooldown
+        // increment is always smaller than 1
         let bootstrap = (stakes[0].config.warmup_rate * 100.0 / 2.0) as u64;
         let stake_history = create_stake_history_from_stakes(Some(bootstrap), 0..epochs, &stakes);
         let mut max_stake = 0;


### PR DESCRIPTION
#### Problem
Broadcast blocks on ledger insertion before releasing shreds to the network. This can slow broadcast down by about 25-30%.

#### Summary of Changes
1) Only block broadcast to write first shred in a slot to the ledger so that leader won't try to retransmit for that slot again on restart.

Offload remaining shreds to separate writer thread.

2) Add local_cluster test that simulates leaders not writing to blocktree in broadcast, and test their ability to successfully stop/restart/repair back to the tip.

Fixes #
