### PR TITLE
gce.sh: Unwind allocation upon failure

### DIFF
--- a/net/gce.sh
+++ b/net/gce.sh
@@ -575,6 +575,14 @@ delete() {
   $metricsWriteDatapoint "testnet-deploy net-delete-complete=1"
 }
 
+create_error_cleanup() {
+  RC=$?
+  if [[ "$RC" -ne 0 ]]; then
+    delete
+  fi
+  exit $RC
+}
+
 case $command in
 delete)
   delete
@@ -586,6 +594,10 @@ create)
   delete
 
   $metricsWriteDatapoint "testnet-deploy net-create-begin=1"
+
+  if $failOnValidatorBootupFailure; then
+    trap create_error_cleanup EXIT
+  fi
 
   rm -rf "$sshPrivateKey"{,.pub}
 

--- a/net/gce.sh
+++ b/net/gce.sh
@@ -576,7 +576,7 @@ delete() {
 }
 
 create_error_cleanup() {
-  RC=$?
+  declare RC=$?
   if [[ "$RC" -ne 0 ]]; then
     delete
   fi


### PR DESCRIPTION
#### Problem

`net/gce.sh` and `net/colo.sh` leave around partially allocated testnets upon failure

#### Summary of Changes

Install a `trap` a the top of `create` if `--allow-boot-failures` was not passed.  In the trap function, call `delete` if we are exiting with error.

Fixes #6334 
