### PR TITLE
Magically improve coverage

### DIFF
--- a/ci/test-coverage.sh
+++ b/ci/test-coverage.sh
@@ -29,6 +29,7 @@ scripts/coverage.sh
 report=coverage-"${CI_COMMIT:0:9}".tar.gz
 mv target/cov/report.tar.gz "$report"
 upload-ci-artifact "$report"
+upload-ci-artifact target/cov/coverage-stderr.log
 annotate --style success --context lcov-report \
   "lcov report: <a href=\"artifact://$report\">$report</a>"
 

--- a/ci/test-coverage.sh
+++ b/ci/test-coverage.sh
@@ -30,10 +30,8 @@ report=coverage-"${CI_COMMIT:0:9}".tar.gz
 mv target/cov/report.tar.gz "$report"
 upload-ci-artifact "$report"
 
-stderr_log=target/cov/coverage-stderr.log
-compressed_stderr_log="${stderr_log}.gz"
-gzip < "$stderr_log" > "$compressed_stderr_log"
-upload-ci-artifact "$compressed_stderr_log"
+gzip target/cov/coverage-stderr.log
+upload-ci-artifact target/cov/coverage-stderr.log.gz
 
 annotate --style success --context lcov-report \
   "lcov report: <a href=\"artifact://$report\">$report</a>"

--- a/ci/test-coverage.sh
+++ b/ci/test-coverage.sh
@@ -29,7 +29,12 @@ scripts/coverage.sh
 report=coverage-"${CI_COMMIT:0:9}".tar.gz
 mv target/cov/report.tar.gz "$report"
 upload-ci-artifact "$report"
-upload-ci-artifact target/cov/coverage-stderr.log
+
+stderr_log=target/cov/coverage-stderr.log
+compressed_stderr_log="${stderr_log}.gz"
+gzip < "$stderr_log" > "$compressed_stderr_log"
+upload-ci-artifact "$compressed_stderr_log"
+
 annotate --style success --context lcov-report \
   "lcov report: <a href=\"artifact://$report\">$report</a>"
 

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -14,6 +14,7 @@ reportName="lcov-${CI_COMMIT:0:9}"
 
 if [[ -n $1 ]]; then
   crate="--package $1"
+  shift
 else
   crate="--all --exclude solana-local-cluster"
 fi
@@ -37,7 +38,9 @@ rm -rf target/cov/$reportName
 
 source ci/rust-version.sh nightly
 # shellcheck disable=SC2086 #
-RUST_LOG=solana=trace _ cargo +$rust_nightly test --target-dir target/cov --lib $crate 2> /dev/null
+RUST_LOG=solana=trace _ cargo +$rust_nightly test --target-dir target/cov --lib --no-run $crate "$@"
+# shellcheck disable=SC2086 #
+RUST_LOG=solana=trace _ cargo +$rust_nightly test --target-dir target/cov --lib $crate "$@" 2> /dev/null
 
 echo "--- grcov"
 

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -20,6 +20,7 @@ fi
 
 coverageFlags=(-Zprofile)                # Enable coverage
 coverageFlags+=("-Clink-dead-code")      # Dead code should appear red in the report
+coverageFlags+=("-Ccodegen-units=1")     # Disable code generation parallelism which is unsupported under -Zprofile (see [rustc issue #51705]).
 coverageFlags+=("-Cinline-threshold=0")  # Disable inlining, which complicates control flow.
 coverageFlags+=("-Coverflow-checks=off") # Disable overflow checks, which create unnecessary branches.
 

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -40,7 +40,7 @@ source ci/rust-version.sh nightly
 # shellcheck disable=SC2086 #
 RUST_LOG=solana=trace _ cargo +$rust_nightly test --target-dir target/cov --lib --no-run $crate "$@"
 # shellcheck disable=SC2086 #
-RUST_LOG=solana=trace _ cargo +$rust_nightly test --target-dir target/cov --lib $crate "$@" 2> /dev/null
+RUST_LOG=solana=trace _ cargo +$rust_nightly test --target-dir target/cov --lib $crate "$@" 2> target/cov/coverage-stderr.log
 
 echo "--- grcov"
 

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -20,7 +20,6 @@ fi
 
 coverageFlags=(-Zprofile)                # Enable coverage
 coverageFlags+=("-Clink-dead-code")      # Dead code should appear red in the report
-coverageFlags+=("-Ccodegen-units=1")     # Disable ThinLTO which corrupts debuginfo (see [rustc issue #45511]).
 coverageFlags+=("-Cinline-threshold=0")  # Disable inlining, which complicates control flow.
 coverageFlags+=("-Coverflow-checks=off") # Disable overflow checks, which create unnecessary branches.
 
@@ -37,7 +36,7 @@ rm -rf target/cov/$reportName
 
 source ci/rust-version.sh nightly
 # shellcheck disable=SC2086 #
-_ cargo +$rust_nightly test --target-dir target/cov --lib $crate
+RUST_LOG=solana=trace _ cargo +$rust_nightly test --target-dir target/cov --lib $crate 2> /dev/null
 
 echo "--- grcov"
 


### PR DESCRIPTION
#### Problem

There is an outdated workaround. And logging macros are red by default, which is a kind of eyesore..

#### Summary of Changes

Now that the upstream bug (rust-lang#45511) is fixed. Remove this workaround!
Also, enable logging with maximum level and discard 'em all just for more greens with no extra effort! :D
