### PR TITLE
Add getBlockConfidence rpc endpoint

### DIFF
--- a/book/src/api-reference/jsonrpc-api.md
+++ b/book/src/api-reference/jsonrpc-api.md
@@ -17,6 +17,7 @@ To interact with a Solana node inside a JavaScript application, use the [solana-
 * [confirmTransaction](jsonrpc-api.md#confirmtransaction)
 * [getAccountInfo](jsonrpc-api.md#getaccountinfo)
 * [getBalance](jsonrpc-api.md#getbalance)
+* [getBlockConfidence](jsonrpc-api.md#getblockconfidence)
 * [getClusterNodes](jsonrpc-api.md#getclusternodes)
 * [getEpochInfo](jsonrpc-api.md#getepochinfo)
 * [getGenesisBlockhash](jsonrpc-api.md#getgenesisblockhash)
@@ -147,6 +148,34 @@ curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0", "id":1, "
 
 // Result
 {"jsonrpc":"2.0","result":0,"id":1}
+```
+
+### getBlockConfidence
+
+Returns confidence for particular block
+
+#### Parameters:
+
+* `u64` - block, identified by Slot
+
+#### Results:
+
+The result field will be an array with two fields:
+
+* Confidence
+  * `null` - Unknown block
+  * `object` - BankConfidence
+    * `array` - confidence, array of u64 integers logging the amount of cluster stake in lamports that has voted on the block at each depth from 0 to `MAX_LOCKOUT_HISTORY`
+* 'integer' - total active stake, in lamports, of the current epoch
+
+#### Example:
+
+```bash
+// Request
+curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1, "method":"getBlockConfidence","params":[5]}' http://localhost:8899
+
+// Result
+{"jsonrpc":"2.0","result":[{"confidence":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,10,32]},42],"id":1}
 ```
 
 ### getClusterNodes
@@ -808,4 +837,3 @@ Unsubscribe from signature confirmation notification
 // Result
 {"jsonrpc": "2.0","result": true,"id": 1}
 ```
-

--- a/core/src/confidence.rs
+++ b/core/src/confidence.rs
@@ -10,7 +10,7 @@ use std::sync::{Arc, RwLock};
 use std::thread::{self, Builder, JoinHandle};
 use std::time::Duration;
 
-#[derive(Debug, Default, Eq, PartialEq)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
 pub struct BankConfidence {
     confidence: [u64; MAX_LOCKOUT_HISTORY],
 }
@@ -25,24 +25,32 @@ impl BankConfidence {
         assert!(confirmation_count > 0 && confirmation_count <= MAX_LOCKOUT_HISTORY);
         self.confidence[confirmation_count - 1]
     }
+    #[cfg(test)]
+    pub(crate) fn new(confidence: [u64; MAX_LOCKOUT_HISTORY]) -> Self {
+        Self { confidence }
+    }
 }
 
 #[derive(Debug, Default)]
 pub struct ForkConfidenceCache {
     bank_confidence: HashMap<u64, BankConfidence>,
-    _total_stake: u64,
+    total_stake: u64,
 }
 
 impl ForkConfidenceCache {
     pub fn new(bank_confidence: HashMap<u64, BankConfidence>, total_stake: u64) -> Self {
         Self {
             bank_confidence,
-            _total_stake: total_stake,
+            total_stake,
         }
     }
 
     pub fn get_fork_confidence(&self, fork: u64) -> Option<&BankConfidence> {
         self.bank_confidence.get(&fork)
+    }
+
+    pub fn total_stake(&self) -> u64 {
+        self.total_stake
     }
 }
 

--- a/core/src/confidence.rs
+++ b/core/src/confidence.rs
@@ -27,7 +27,7 @@ impl BankConfidence {
     }
 }
 
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct ForkConfidenceCache {
     bank_confidence: HashMap<u64, BankConfidence>,
     _total_stake: u64,

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -1,9 +1,14 @@
 //! The `rpc` module implements the Solana RPC interface.
 
 use crate::{
-    bank_forks::BankForks, cluster_info::ClusterInfo, confidence::ForkConfidenceCache,
-    contact_info::ContactInfo, packet::PACKET_DATA_SIZE, storage_stage::StorageState,
-    validator::ValidatorExit, version::VERSION,
+    bank_forks::BankForks,
+    cluster_info::ClusterInfo,
+    confidence::{BankConfidence, ForkConfidenceCache},
+    contact_info::ContactInfo,
+    packet::PACKET_DATA_SIZE,
+    storage_stage::StorageState,
+    validator::ValidatorExit,
+    version::VERSION,
 };
 use bincode::{deserialize, serialize};
 use jsonrpc_core::{Error, Metadata, Result};
@@ -103,6 +108,14 @@ impl JsonRpcRequestProcessor {
     fn get_recent_blockhash(&self) -> (String, FeeCalculator) {
         let (blockhash, fee_calculator) = self.bank().confirmed_last_blockhash();
         (blockhash.to_string(), fee_calculator)
+    }
+
+    fn get_fork_confidence(&self, fork: u64) -> (Option<BankConfidence>, u64) {
+        let r_fork_confidence = self.fork_confidence_cache.read().unwrap();
+        (
+            r_fork_confidence.get_fork_confidence(fork).cloned(),
+            r_fork_confidence.total_stake(),
+        )
     }
 
     pub fn get_signature_status(&self, signature: Signature) -> Option<transaction::Result<()>> {
@@ -312,6 +325,13 @@ pub trait RpcSol {
     #[rpc(meta, name = "getEpochInfo")]
     fn get_epoch_info(&self, _: Self::Metadata) -> Result<RpcEpochInfo>;
 
+    #[rpc(meta, name = "getForkConfidence")]
+    fn get_fork_confidence(
+        &self,
+        _: Self::Metadata,
+        _: u64,
+    ) -> Result<(Option<BankConfidence>, u64)>;
+
     #[rpc(meta, name = "getGenesisBlockhash")]
     fn get_genesis_blockhash(&self, _: Self::Metadata) -> Result<String>;
 
@@ -490,6 +510,18 @@ impl RpcSol for RpcSolImpl {
             slots_in_epoch: epoch_schedule.get_slots_in_epoch(epoch),
             absolute_slot: slot,
         })
+    }
+
+    fn get_fork_confidence(
+        &self,
+        meta: Self::Metadata,
+        fork: u64,
+    ) -> Result<(Option<BankConfidence>, u64)> {
+        Ok(meta
+            .request_processor
+            .read()
+            .unwrap()
+            .get_fork_confidence(fork))
     }
 
     fn get_genesis_blockhash(&self, meta: Self::Metadata) -> Result<String> {
@@ -713,26 +745,49 @@ impl RpcSol for RpcSolImpl {
 #[cfg(test)]
 pub mod tests {
     use super::*;
-    use crate::contact_info::ContactInfo;
-    use crate::genesis_utils::{create_genesis_block, GenesisBlockInfo};
+    use crate::{
+        contact_info::ContactInfo,
+        genesis_utils::{create_genesis_block, GenesisBlockInfo},
+    };
     use jsonrpc_core::{MetaIoHandler, Output, Response, Value};
-    use solana_sdk::fee_calculator::DEFAULT_BURN_PERCENT;
-    use solana_sdk::hash::{hash, Hash};
-    use solana_sdk::instruction::InstructionError;
-    use solana_sdk::signature::{Keypair, KeypairUtil};
-    use solana_sdk::system_transaction;
-    use solana_sdk::transaction::TransactionError;
-    use std::sync::atomic::{AtomicBool, Ordering};
-    use std::thread;
+    use solana_sdk::{
+        fee_calculator::DEFAULT_BURN_PERCENT,
+        hash::{hash, Hash},
+        instruction::InstructionError,
+        signature::{Keypair, KeypairUtil},
+        system_transaction,
+        transaction::TransactionError,
+    };
+    use std::{
+        collections::HashMap,
+        sync::atomic::{AtomicBool, Ordering},
+        thread,
+    };
 
     const TEST_MINT_LAMPORTS: u64 = 10_000;
 
-    fn start_rpc_handler_with_tx(
-        pubkey: &Pubkey,
-    ) -> (MetaIoHandler<Meta>, Meta, Arc<Bank>, Hash, Keypair, Pubkey) {
+    struct RpcHandler {
+        io: MetaIoHandler<Meta>,
+        meta: Meta,
+        bank: Arc<Bank>,
+        blockhash: Hash,
+        alice: Keypair,
+        leader_pubkey: Pubkey,
+        fork_confidence_cache: Arc<RwLock<ForkConfidenceCache>>,
+    }
+
+    fn start_rpc_handler_with_tx(pubkey: &Pubkey) -> RpcHandler {
         let (bank_forks, alice) = new_bank_forks();
         let bank = bank_forks.read().unwrap().working_bank();
-        let fork_confidence_cache = Arc::new(RwLock::new(ForkConfidenceCache::default()));
+
+        let confidence_slot0 = BankConfidence::new([8; MAX_LOCKOUT_HISTORY]);
+        let confidence_slot1 = BankConfidence::new([9; MAX_LOCKOUT_HISTORY]);
+        let mut bank_confidence: HashMap<u64, BankConfidence> = HashMap::new();
+        bank_confidence.entry(0).or_insert(confidence_slot0.clone());
+        bank_confidence.entry(1).or_insert(confidence_slot1.clone());
+        let fork_confidence_cache =
+            Arc::new(RwLock::new(ForkConfidenceCache::new(bank_confidence, 42)));
+
         let leader_pubkey = *bank.collector_id();
         let exit = Arc::new(AtomicBool::new(false));
         let validator_exit = create_validator_exit(&exit);
@@ -748,7 +803,7 @@ pub mod tests {
             StorageState::default(),
             JsonRpcConfig::default(),
             bank_forks,
-            fork_confidence_cache,
+            fork_confidence_cache.clone(),
             &validator_exit,
         )));
         let cluster_info = Arc::new(RwLock::new(ClusterInfo::new_with_invalid_keypair(
@@ -771,7 +826,15 @@ pub mod tests {
             cluster_info,
             genesis_blockhash: Hash::default(),
         };
-        (io, meta, bank, blockhash, alice, leader_pubkey)
+        RpcHandler {
+            io,
+            meta,
+            bank,
+            blockhash,
+            alice,
+            leader_pubkey,
+            fork_confidence_cache,
+        }
     }
 
     #[test]
@@ -802,8 +865,7 @@ pub mod tests {
     #[test]
     fn test_rpc_get_balance() {
         let bob_pubkey = Pubkey::new_rand();
-        let (io, meta, _bank, _blockhash, _alice, _leader_pubkey) =
-            start_rpc_handler_with_tx(&bob_pubkey);
+        let RpcHandler { io, meta, .. } = start_rpc_handler_with_tx(&bob_pubkey);
 
         let req = format!(
             r#"{{"jsonrpc":"2.0","id":1,"method":"getBalance","params":["{}"]}}"#,
@@ -821,8 +883,12 @@ pub mod tests {
     #[test]
     fn test_rpc_get_cluster_nodes() {
         let bob_pubkey = Pubkey::new_rand();
-        let (io, meta, _bank, _blockhash, _alice, leader_pubkey) =
-            start_rpc_handler_with_tx(&bob_pubkey);
+        let RpcHandler {
+            io,
+            meta,
+            leader_pubkey,
+            ..
+        } = start_rpc_handler_with_tx(&bob_pubkey);
 
         let req = format!(r#"{{"jsonrpc":"2.0","id":1,"method":"getClusterNodes"}}"#);
         let res = io.handle_request_sync(&req, meta);
@@ -842,8 +908,12 @@ pub mod tests {
     #[test]
     fn test_rpc_get_slot_leader() {
         let bob_pubkey = Pubkey::new_rand();
-        let (io, meta, _bank, _blockhash, _alice, leader_pubkey) =
-            start_rpc_handler_with_tx(&bob_pubkey);
+        let RpcHandler {
+            io,
+            meta,
+            leader_pubkey,
+            ..
+        } = start_rpc_handler_with_tx(&bob_pubkey);
 
         let req = format!(r#"{{"jsonrpc":"2.0","id":1,"method":"getSlotLeader"}}"#);
         let res = io.handle_request_sync(&req, meta);
@@ -858,8 +928,7 @@ pub mod tests {
     #[test]
     fn test_rpc_get_tx_count() {
         let bob_pubkey = Pubkey::new_rand();
-        let (io, meta, _bank, _blockhash, _alice, _leader_pubkey) =
-            start_rpc_handler_with_tx(&bob_pubkey);
+        let RpcHandler { io, meta, .. } = start_rpc_handler_with_tx(&bob_pubkey);
 
         let req = format!(r#"{{"jsonrpc":"2.0","id":1,"method":"getTransactionCount"}}"#);
         let res = io.handle_request_sync(&req, meta);
@@ -874,8 +943,7 @@ pub mod tests {
     #[test]
     fn test_rpc_get_total_supply() {
         let bob_pubkey = Pubkey::new_rand();
-        let (io, meta, _bank, _blockhash, _alice, _leader_pubkey) =
-            start_rpc_handler_with_tx(&bob_pubkey);
+        let RpcHandler { io, meta, .. } = start_rpc_handler_with_tx(&bob_pubkey);
 
         let req = format!(r#"{{"jsonrpc":"2.0","id":1,"method":"getTotalSupply"}}"#);
         let rep = io.handle_request_sync(&req, meta);
@@ -901,8 +969,7 @@ pub mod tests {
     fn test_rpc_get_minimum_balance_for_rent_exemption() {
         let bob_pubkey = Pubkey::new_rand();
         let data_len = 50;
-        let (io, meta, bank, _blockhash, _alice, _leader_pubkey) =
-            start_rpc_handler_with_tx(&bob_pubkey);
+        let RpcHandler { io, meta, bank, .. } = start_rpc_handler_with_tx(&bob_pubkey);
 
         let req = format!(
             r#"{{"jsonrpc":"2.0","id":1,"method":"getMinimumBalanceForRentExemption","params":[{}]}}"#,
@@ -933,8 +1000,7 @@ pub mod tests {
     #[test]
     fn test_rpc_get_inflation() {
         let bob_pubkey = Pubkey::new_rand();
-        let (io, meta, bank, _blockhash, _alice, _leader_pubkey) =
-            start_rpc_handler_with_tx(&bob_pubkey);
+        let RpcHandler { io, meta, bank, .. } = start_rpc_handler_with_tx(&bob_pubkey);
 
         let req = format!(r#"{{"jsonrpc":"2.0","id":1,"method":"getInflation"}}"#);
         let rep = io.handle_request_sync(&req, meta);
@@ -955,8 +1021,7 @@ pub mod tests {
     #[test]
     fn test_rpc_get_account_info() {
         let bob_pubkey = Pubkey::new_rand();
-        let (io, meta, _bank, _blockhash, _alice, _leader_pubkey) =
-            start_rpc_handler_with_tx(&bob_pubkey);
+        let RpcHandler { io, meta, .. } = start_rpc_handler_with_tx(&bob_pubkey);
 
         let req = format!(
             r#"{{"jsonrpc":"2.0","id":1,"method":"getAccountInfo","params":["{}"]}}"#,
@@ -984,8 +1049,13 @@ pub mod tests {
     #[test]
     fn test_rpc_get_program_accounts() {
         let bob = Keypair::new();
-        let (io, meta, bank, blockhash, _alice, _leader_pubkey) =
-            start_rpc_handler_with_tx(&bob.pubkey());
+        let RpcHandler {
+            io,
+            meta,
+            bank,
+            blockhash,
+            ..
+        } = start_rpc_handler_with_tx(&bob.pubkey());
 
         let new_program_id = Pubkey::new_rand();
         let tx = system_transaction::assign(&bob, blockhash, &new_program_id);
@@ -1020,8 +1090,13 @@ pub mod tests {
     #[test]
     fn test_rpc_confirm_tx() {
         let bob_pubkey = Pubkey::new_rand();
-        let (io, meta, _bank, blockhash, alice, _leader_pubkey) =
-            start_rpc_handler_with_tx(&bob_pubkey);
+        let RpcHandler {
+            io,
+            meta,
+            blockhash,
+            alice,
+            ..
+        } = start_rpc_handler_with_tx(&bob_pubkey);
         let tx = system_transaction::transfer(&alice, &bob_pubkey, 20, blockhash);
 
         let req = format!(
@@ -1040,8 +1115,13 @@ pub mod tests {
     #[test]
     fn test_rpc_get_signature_status() {
         let bob_pubkey = Pubkey::new_rand();
-        let (io, meta, _bank, blockhash, alice, _leader_pubkey) =
-            start_rpc_handler_with_tx(&bob_pubkey);
+        let RpcHandler {
+            io,
+            meta,
+            blockhash,
+            alice,
+            ..
+        } = start_rpc_handler_with_tx(&bob_pubkey);
         let tx = system_transaction::transfer(&alice, &bob_pubkey, 20, blockhash);
 
         let req = format!(
@@ -1105,8 +1185,12 @@ pub mod tests {
     #[test]
     fn test_rpc_get_recent_blockhash() {
         let bob_pubkey = Pubkey::new_rand();
-        let (io, meta, _bank, blockhash, _alice, _leader_pubkey) =
-            start_rpc_handler_with_tx(&bob_pubkey);
+        let RpcHandler {
+            io,
+            meta,
+            blockhash,
+            ..
+        } = start_rpc_handler_with_tx(&bob_pubkey);
 
         let req = format!(r#"{{"jsonrpc":"2.0","id":1,"method":"getRecentBlockhash"}}"#);
         let res = io.handle_request_sync(&req, meta);
@@ -1132,8 +1216,7 @@ pub mod tests {
     #[test]
     fn test_rpc_fail_request_airdrop() {
         let bob_pubkey = Pubkey::new_rand();
-        let (io, meta, _bank, _blockhash, _alice, _leader_pubkey) =
-            start_rpc_handler_with_tx(&bob_pubkey);
+        let RpcHandler { io, meta, .. } = start_rpc_handler_with_tx(&bob_pubkey);
 
         // Expect internal error because no drone is available
         let req = format!(
@@ -1285,7 +1368,7 @@ pub mod tests {
     #[test]
     fn test_rpc_get_version() {
         let bob_pubkey = Pubkey::new_rand();
-        let (io, meta, ..) = start_rpc_handler_with_tx(&bob_pubkey);
+        let RpcHandler { io, meta, .. } = start_rpc_handler_with_tx(&bob_pubkey);
 
         let req = format!(r#"{{"jsonrpc":"2.0","id":1,"method":"getVersion"}}"#);
         let res = io.handle_request_sync(&req, meta);
@@ -1301,5 +1384,91 @@ pub mod tests {
         let result: Response = serde_json::from_str(&res.expect("actual response"))
             .expect("actual response deserialization");
         assert_eq!(expected, result);
+    }
+
+    #[test]
+    fn test_rpc_processor_get_fork_confidence() {
+        let exit = Arc::new(AtomicBool::new(false));
+        let validator_exit = create_validator_exit(&exit);
+        let confidence_slot0 = BankConfidence::new([8; MAX_LOCKOUT_HISTORY]);
+        let confidence_slot1 = BankConfidence::new([9; MAX_LOCKOUT_HISTORY]);
+        let mut bank_confidence: HashMap<u64, BankConfidence> = HashMap::new();
+        bank_confidence.entry(0).or_insert(confidence_slot0.clone());
+        bank_confidence.entry(1).or_insert(confidence_slot1.clone());
+        let fork_confidence_cache =
+            Arc::new(RwLock::new(ForkConfidenceCache::new(bank_confidence, 42)));
+
+        let mut config = JsonRpcConfig::default();
+        config.enable_validator_exit = true;
+        let request_processor = JsonRpcRequestProcessor::new(
+            StorageState::default(),
+            config,
+            new_bank_forks().0,
+            fork_confidence_cache,
+            &validator_exit,
+        );
+        assert_eq!(
+            request_processor.get_fork_confidence(0),
+            (Some(confidence_slot0), 42)
+        );
+        assert_eq!(
+            request_processor.get_fork_confidence(1),
+            (Some(confidence_slot1), 42)
+        );
+        assert_eq!(request_processor.get_fork_confidence(2), (None, 42));
+    }
+
+    #[test]
+    fn test_rpc_get_fork_confidence() {
+        let bob_pubkey = Pubkey::new_rand();
+        let RpcHandler {
+            io,
+            meta,
+            fork_confidence_cache,
+            ..
+        } = start_rpc_handler_with_tx(&bob_pubkey);
+
+        let req =
+            format!(r#"{{"jsonrpc":"2.0","id":1,"method":"getForkConfidence","params":[0]}}"#);
+        let res = io.handle_request_sync(&req, meta.clone());
+        let result: Response = serde_json::from_str(&res.expect("actual response"))
+            .expect("actual response deserialization");
+        let (confidence, total_staked): (Option<BankConfidence>, u64) =
+            if let Response::Single(res) = result {
+                if let Output::Success(res) = res {
+                    serde_json::from_value(res.result).unwrap()
+                } else {
+                    panic!("Expected success");
+                }
+            } else {
+                panic!("Expected single response");
+            };
+        assert_eq!(
+            confidence,
+            fork_confidence_cache
+                .read()
+                .unwrap()
+                .get_fork_confidence(0)
+                .cloned()
+        );
+        assert_eq!(total_staked, 42);
+
+        let req =
+            format!(r#"{{"jsonrpc":"2.0","id":1,"method":"getForkConfidence","params":[2]}}"#);
+        let res = io.handle_request_sync(&req, meta);
+        let result: Response = serde_json::from_str(&res.expect("actual response"))
+            .expect("actual response deserialization");
+        let (confidence, total_staked): (Option<BankConfidence>, u64) =
+            if let Response::Single(res) = result {
+                if let Output::Success(res) = res {
+                    serde_json::from_value(res.result).unwrap()
+                } else {
+                    panic!("Expected success");
+                }
+            } else {
+                panic!("Expected single response");
+            };
+        assert_eq!(confidence, None);
+        assert_eq!(total_staked, 42);
     }
 }

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -158,6 +158,7 @@ impl Validator {
         let bank_info = &bank_forks_info[0];
         let bank = bank_forks[bank_info.bank_slot].clone();
         let bank_forks = Arc::new(RwLock::new(bank_forks));
+        let fork_confidence_cache = Arc::new(RwLock::new(ForkConfidenceCache::default()));
 
         let mut validator_exit = ValidatorExit::default();
         let exit_ = exit.clone();
@@ -185,6 +186,7 @@ impl Validator {
                 storage_state.clone(),
                 config.rpc_config.clone(),
                 bank_forks.clone(),
+                fork_confidence_cache.clone(),
                 ledger_path,
                 genesis_blockhash,
                 &validator_exit,
@@ -298,7 +300,6 @@ impl Validator {
             Some(voting_keypair)
         };
 
-        let fork_confidence_cache = Arc::new(RwLock::new(ForkConfidenceCache::default()));
         let tvu = Tvu::new(
             vote_account,
             voting_keypair,


### PR DESCRIPTION
#### Problem
The RPC API returns results based on either the latest bank, or a bank from a couple blocks ago. But what clients really want is results based on how much of the cluster has voted on the results.

Each validator maintains a confidence cache -- ie. a table of how much stake has voted for a particular fork at slot depths back through root -- but there is no way for clients to access this data.

#### Summary of Changes
- Passes ForkConfidenceCache into JsonRpcRequestProcessor
- Adds getBlockConfidence rpc endpoint to expose raw confidence data to clients

Toward #6346 
This is foundational work. Next steps are to build mechanisms to examine the cache to find the latest block that meets confidence criteria (default: rooted, 2/3 of stake voted; customizable by client) and use that bank-fork for RPC results.