### PR TITLE
Only allow stake to be deactivated once

### DIFF
--- a/programs/stake_api/src/stake_instruction.rs
+++ b/programs/stake_api/src/stake_instruction.rs
@@ -20,6 +20,7 @@ use solana_sdk::{
 pub enum StakeError {
     NoCreditsToRedeem,
     LockupInForce,
+    AlreadyDeactivated,
 }
 impl<E> DecodeError<E> for StakeError {
     fn type_of() -> &'static str {
@@ -31,6 +32,7 @@ impl std::fmt::Display for StakeError {
         match self {
             StakeError::NoCreditsToRedeem => write!(f, "not enough credits to redeem"),
             StakeError::LockupInForce => write!(f, "lockup has not yet expired"),
+            StakeError::AlreadyDeactivated => write!(f, "stake is already deactivated"),
         }
     }
 }


### PR DESCRIPTION
#### Problem
Stake can be deactivated more than once, pushing back the deactivation epoch and corrupting the cool down schedule

#### Summary of Changes
Return instruction error if stake is deactivated after it has already been deactivated

Fixes #
