### PR TITLE
Async poh verify

### DIFF
--- a/core/src/broadcast_stage/broadcast_utils.rs
+++ b/core/src/broadcast_stage/broadcast_utils.rs
@@ -115,11 +115,15 @@ mod tests {
             })
             .collect();
 
-        let result = recv_slot_entries(&r).unwrap();
-
-        assert_eq!(result.bank.slot(), bank1.slot());
-        assert_eq!(result.last_tick_height, bank1.max_tick_height());
-        assert_eq!(result.entries, entries);
+        let mut res_entries = vec![];
+        let mut last_tick_height = 0;
+        while let Ok(result) = recv_slot_entries(&r) {
+            assert_eq!(result.bank.slot(), bank1.slot());
+            last_tick_height = result.last_tick_height;
+            res_entries.extend(result.entries);
+        }
+        assert_eq!(last_tick_height, bank1.max_tick_height());
+        assert_eq!(res_entries, entries);
     }
 
     #[test]
@@ -152,9 +156,16 @@ mod tests {
             .unwrap()
             .unwrap();
 
-        let result = recv_slot_entries(&r).unwrap();
-        assert_eq!(result.bank.slot(), bank2.slot());
-        assert_eq!(result.last_tick_height, expected_last_height);
-        assert_eq!(result.entries, vec![last_entry]);
+        let mut res_entries = vec![];
+        let mut last_tick_height = 0;
+        let mut bank_slot = 0;
+        while let Ok(result) = recv_slot_entries(&r) {
+            bank_slot = result.bank.slot();
+            last_tick_height = result.last_tick_height;
+            res_entries = result.entries;
+        }
+        assert_eq!(bank_slot, bank2.slot());
+        assert_eq!(last_tick_height, expected_last_height);
+        assert_eq!(res_entries, vec![last_entry]);
     }
 }

--- a/core/src/poh_recorder.rs
+++ b/core/src/poh_recorder.rs
@@ -963,7 +963,7 @@ mod tests {
             poh_recorder.reset(hash(b"hello"), 0, Some((4, 4))); // parent slot 0 implies tick_height of 3
             assert_eq!(poh_recorder.tick_cache.len(), 0);
             poh_recorder.tick();
-            assert_eq!(poh_recorder.tick_height, 5);
+            assert_eq!(poh_recorder.tick_height, DEFAULT_TICKS_PER_SLOT + 1);
         }
         Blocktree::destroy(&ledger_path).unwrap();
     }

--- a/core/src/sigverify.rs
+++ b/core/src/sigverify.rs
@@ -20,7 +20,6 @@ use solana_sdk::transaction::Transaction;
 use std::mem::size_of;
 
 use solana_rayon_threadlimit::get_thread_count;
-pub const NUM_THREADS: u32 = 10;
 use std::cell::RefCell;
 
 thread_local!(static PAR_THREAD_POOL: RefCell<ThreadPool> = RefCell::new(rayon::ThreadPoolBuilder::new()

--- a/ledger/src/blocktree_processor.rs
+++ b/ledger/src/blocktree_processor.rs
@@ -21,7 +21,6 @@ use std::result;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-pub const NUM_THREADS: u32 = 10;
 use solana_rayon_threadlimit::get_thread_count;
 use std::cell::RefCell;
 

--- a/ledger/src/blocktree_processor.rs
+++ b/ledger/src/blocktree_processor.rs
@@ -108,12 +108,11 @@ fn process_entries_with_callback(
 ) -> Result<()> {
     // accumulator for entries that can be processed in parallel
     let mut batches = vec![];
+    let mut tick_hashes = vec![];
     for entry in entries {
         if entry.is_tick() {
-            // if its a tick, execute the group and register the tick
-            execute_batches(bank, &batches, entry_callback)?;
-            batches.clear();
-            bank.register_tick(&entry.hash);
+            // if its a tick, save it for later
+            tick_hashes.push(entry.hash);
             continue;
         }
         // else loop on processing the entry
@@ -163,6 +162,9 @@ fn process_entries_with_callback(
         }
     }
     execute_batches(bank, &batches, entry_callback)?;
+    for hash in tick_hashes {
+        bank.register_tick(&hash);
+    }
     Ok(())
 }
 

--- a/local_cluster/src/cluster_tests.rs
+++ b/local_cluster/src/cluster_tests.rs
@@ -57,7 +57,7 @@ pub fn spend_and_verify_all_nodes<S: ::std::hash::BuildHasher>(
             system_transaction::transfer(&funding_keypair, &random_keypair.pubkey(), 1, blockhash);
         let confs = VOTE_THRESHOLD_DEPTH + 1;
         let sig = client
-            .retry_transfer_until_confirmed(&funding_keypair, &mut transaction, 5, confs)
+            .retry_transfer_until_confirmed(&funding_keypair, &mut transaction, 10, confs)
             .unwrap();
         for validator in &cluster_nodes {
             if ignore_nodes.contains(&validator.id) {

--- a/local_cluster/src/local_cluster.rs
+++ b/local_cluster/src/local_cluster.rs
@@ -420,7 +420,7 @@ impl LocalCluster {
             *dest_pubkey
         );
         client
-            .retry_transfer(&source_keypair, &mut tx, 5)
+            .retry_transfer(&source_keypair, &mut tx, 10)
             .expect("client transfer");
         client
             .wait_for_balance(dest_pubkey, Some(lamports))
@@ -458,7 +458,7 @@ impl LocalCluster {
                 client.get_recent_blockhash().unwrap().0,
             );
             client
-                .retry_transfer(&from_account, &mut transaction, 5)
+                .retry_transfer(&from_account, &mut transaction, 10)
                 .expect("fund vote");
             client
                 .wait_for_balance(&vote_account_pubkey, Some(amount))
@@ -557,7 +557,7 @@ impl LocalCluster {
         let blockhash = client.get_recent_blockhash().unwrap().0;
         let mut transaction = Transaction::new(&signer_keys, message, blockhash);
         client
-            .retry_transfer(&from_keypair, &mut transaction, 5)
+            .retry_transfer(&from_keypair, &mut transaction, 10)
             .map(|_signature| ())
     }
 }

--- a/local_cluster/src/tests/local_cluster.rs
+++ b/local_cluster/src/tests/local_cluster.rs
@@ -585,6 +585,7 @@ fn test_faulty_node(faulty_node_type: BroadcastStageType) {
 }
 
 #[test]
+#[serial]
 fn test_repairman_catchup() {
     solana_logger::setup();
     error!("test_repairman_catchup");

--- a/sdk/src/clock.rs
+++ b/sdk/src/clock.rs
@@ -2,11 +2,11 @@
 
 // The default tick rate that the cluster attempts to achieve.  Note that the actual tick
 // rate at any given time should be expected to drift
-pub const DEFAULT_TICKS_PER_SECOND: u64 = 10;
+pub const DEFAULT_TICKS_PER_SECOND: u64 = 160;
 
-// At 10 ticks/s, 4 ticks per slot implies that leader rotation and voting will happen
+// At 160 ticks/s, 64 ticks per slot implies that leader rotation and voting will happen
 // every 400 ms. A fast voting cadence ensures faster finality and convergence
-pub const DEFAULT_TICKS_PER_SLOT: u64 = 4;
+pub const DEFAULT_TICKS_PER_SLOT: u64 = 64;
 
 // 1 Epoch = 400 * 8192 ms ~= 55 minutes
 pub const DEFAULT_SLOTS_PER_EPOCH: u64 = 8192;


### PR DESCRIPTION
#### Problem

POH verify can take a while and impacts replay stage speed and thus validator nodes start to get behind.

#### Summary of Changes

Send poh verify to the GPU while processing the transactions into the bank.

Fixes #