### PR TITLE
multiple deactivation

### DIFF
--- a/programs/stake_api/src/stake_instruction.rs
+++ b/programs/stake_api/src/stake_instruction.rs
@@ -20,6 +20,7 @@ use solana_sdk::{
 pub enum StakeError {
     NoCreditsToRedeem,
     LockupInForce,
+    AlreadyDeactivated,
 }
 impl<E> DecodeError<E> for StakeError {
     fn type_of() -> &'static str {
@@ -31,6 +32,7 @@ impl std::fmt::Display for StakeError {
         match self {
             StakeError::NoCreditsToRedeem => write!(f, "not enough credits to redeem"),
             StakeError::LockupInForce => write!(f, "lockup has not yet expired"),
+            StakeError::AlreadyDeactivated => write!(f, "stake already deactivated"),
         }
     }
 }

--- a/programs/stake_api/src/stake_state.rs
+++ b/programs/stake_api/src/stake_state.rs
@@ -396,8 +396,13 @@ impl Stake {
         }
     }
 
-    fn deactivate(&mut self, epoch: u64) {
-        self.deactivation_epoch = epoch;
+    fn deactivate(&mut self, epoch: u64) -> Result<(), StakeError> {
+        if self.deactivation_epoch != std::u64::MAX {
+            Err(StakeError::AlreadyDeactivated)
+        } else {
+            self.deactivation_epoch = epoch;
+            Ok(())
+        }
     }
 }
 
@@ -512,7 +517,7 @@ impl<'a> StakeAccount for KeyedAccount<'a> {
     ) -> Result<(), InstructionError> {
         if let StakeState::Stake(authorized, lockup, mut stake) = self.state()? {
             authorized.check(signers, StakeAuthorize::Staker)?;
-            stake.deactivate(clock.epoch);
+            stake.deactivate(clock.epoch)?;
 
             self.set_state(&StakeState::Stake(authorized, lockup, stake))
         } else {
@@ -1184,6 +1189,12 @@ mod tests {
         assert_eq!(
             stake_keyed_account.deactivate_stake(&clock, &signers),
             Ok(())
+        );
+
+        // verify that deactivate() only works once
+        assert_eq!(
+            stake_keyed_account.deactivate_stake(&clock, &signers),
+            Err(StakeError::AlreadyDeactivated.into())
         );
     }
 


### PR DESCRIPTION
#### Problem
 stake deactivation can be delayed by deactivating multiple times
 stake can be re-activated by calling deactivate()

 #### Summary of Changes
 guard against multiple deactivate() calls

Fixes #