### PR TITLE
collect rent from accounts (take:2)

### DIFF
--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -119,9 +119,7 @@ impl Accounts {
             {
                 let (account, rent) = AccountsDB::load(storage, ancestors, accounts_index, key)
                     .and_then(|(mut account, _)| {
-                        if let (Some(_), rent_collected) =
-                            rent_collector.update(&mut account, false)
-                        {
+                        if let (Some(_), rent_collected) = rent_collector.update(&mut account) {
                             Some((account, rent_collected))
                         } else {
                             None
@@ -627,7 +625,7 @@ impl Accounts {
                         .unwrap_or_default();
                 account.lamports += credit;
 
-                if let (Some(_), rent) = rent_collector.update(&mut account, false) {
+                if let (Some(_), rent) = rent_collector.update(&mut account) {
                     total_rent_collected += rent;
                     accounts.push((pubkey, account));
                 }

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -622,8 +622,7 @@ impl Accounts {
 
                 // We don't want newly created credit account to be saved if it cannot even
                 // pay for current cycle of rent.
-                if let Some((mut account, rent)) = rent_collector.update(account) {
-                    account.lamports -= rent;
+                if let Some((account, rent)) = rent_collector.update(account) {
                     total_rent_collected += rent;
                     accounts.push((pubkey, account));
                 }

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -604,7 +604,7 @@ impl Accounts {
     where
         I: IntoIterator<Item = (Pubkey, CreditOnlyLock)>,
     {
-        let mut accounts: HashMap<Pubkey, Account> = HashMap::new();
+        let mut accounts: Vec<(Pubkey, Account)> = vec![];
         let mut total_rent_collected = 0;
 
         {
@@ -636,7 +636,7 @@ impl Accounts {
                 }
 
                 account.lamports += credit;
-                accounts.insert(pubkey, account);
+                accounts.push((pubkey, account));
             }
         }
 

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -620,8 +620,6 @@ impl Accounts {
                 account.lamports += credit;
                 total_credit_credited += credit;
 
-                // We don't want newly created credit account to be saved if it cannot even
-                // pay for current cycle of rent.
                 if let Some((account, rent)) = rent_collector.update(account) {
                     total_rent_collected += rent;
                     accounts.push((pubkey, account));

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -96,7 +96,6 @@ impl Accounts {
         fee: u64,
         error_counters: &mut ErrorCounters,
         rent_collector: &RentCollector,
-        w_credit_only_account_locks: &mut RwLockWriteGuard<Option<HashMap<Pubkey, CreditOnlyLock>>>,
     ) -> Result<(TransactionAccounts, TransactionCredits, TransactionRents)> {
         // Copy all the accounts
         let message = tx.message();
@@ -109,19 +108,15 @@ impl Accounts {
                 return Err(TransactionError::AccountLoadedTwice);
             }
 
-            let credit_only_account_locks = w_credit_only_account_locks.as_mut().unwrap();
-            let mut credit_only_keys: HashSet<Pubkey> = HashSet::new();
-
             // There is no way to predict what program will execute without an error
             // If a fee can pay for execution then the program will be scheduled
             let mut accounts: TransactionAccounts = vec![];
             let mut credits: TransactionCredits = vec![];
             let mut rents: TransactionRents = vec![];
-            for (i, key) in message
+            for key in message
                 .account_keys
                 .iter()
                 .filter(|key| !message.program_ids().contains(&key))
-                .enumerate()
             {
                 let (account, rent) = AccountsDB::load(storage, ancestors, accounts_index, key)
                     .and_then(
@@ -131,10 +126,6 @@ impl Accounts {
                         },
                     )
                     .unwrap_or_default();
-
-                if !message.is_debitable(i) {
-                    credit_only_keys.insert(*key);
-                }
 
                 accounts.push(account);
                 credits.push(0);
@@ -152,11 +143,6 @@ impl Accounts {
                 Err(TransactionError::InsufficientFundsForFee)
             } else {
                 accounts[0].lamports -= fee;
-                for key in credit_only_keys {
-                    credit_only_account_locks.entry(key).and_modify(|mut lock| {
-                        lock.rent_debtor = true;
-                    });
-                }
                 Ok((accounts, credits, rents))
             }
         }
@@ -249,7 +235,6 @@ impl Accounts {
         //TODO: two locks usually leads to deadlocks, should this be one structure?
         let accounts_index = self.accounts_db.accounts_index.read().unwrap();
         let storage = self.accounts_db.storage.read().unwrap();
-        let mut w_credit_only_account_locks = self.credit_only_account_locks.write().unwrap();
         OrderedIterator::new(txs, txs_iteration_order)
             .zip(lock_results.into_iter())
             .map(|etx| match etx {
@@ -267,7 +252,6 @@ impl Accounts {
                         fee,
                         error_counters,
                         rent_collector,
-                        &mut w_credit_only_account_locks,
                     )?;
                     let loaders = Self::load_loaders(
                         &storage,
@@ -694,18 +678,17 @@ impl Accounts {
             {
                 if message.is_debitable(i) {
                     accounts.push((key, account));
-                }
-                if *credit > 0 {
-                    // Increment credit-only account balance Atomic
+                } else {
                     self.credit_only_account_locks
-                        .read()
+                        .write()
                         .unwrap()
-                        .as_ref()
+                        .as_mut()
                         .expect("Collect accounts should only be called before a commit, and credit only account locks should exist before a commit")
-                        .get(key)
-                        .unwrap()
-                        .credits
-                        .fetch_add(*credit, Ordering::Relaxed);
+                        .entry(*key)
+                        .and_modify(|lock| {
+                            lock.rent_debtor = true;
+                            lock.credits.fetch_add(*credit, Ordering::Relaxed);
+                        });
                 }
             }
         }

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -548,7 +548,8 @@ impl Accounts {
         self.accounts_db.add_root(fork)
     }
 
-    /// Commit remaining credit-only changes, regardless of reference count
+    /// Commit remaining credit-only changes (crediting credit and deducting rent),
+    /// regardless of reference count
     ///
     /// We do a take() on `self.credit_only_account_locks` so that the hashmap is no longer
     /// available to be written to. This prevents any transactions from reinserting into the hashmap.

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -222,6 +222,10 @@ pub struct Bank {
     #[serde(deserialize_with = "deserialize_atomicu64")]
     collector_fees: AtomicU64,
 
+    #[serde(serialize_with = "serialize_atomicu64")]
+    #[serde(deserialize_with = "deserialize_atomicu64")]
+    collected_rent: AtomicU64,
+
     /// Latest transaction fees for transactions processed by this bank
     fee_calculator: FeeCalculator,
 
@@ -333,6 +337,7 @@ impl Bank {
             parent_hash: parent.hash(),
             collector_id: *collector_id,
             collector_fees: AtomicU64::new(0),
+            collected_rent: AtomicU64::new(0),
             ancestors: HashMap::new(),
             hash: RwLock::new(Hash::default()),
             is_delta: AtomicBool::new(false),
@@ -1119,6 +1124,45 @@ impl Bank {
         )
     }
 
+    fn collect_rent(
+        &self,
+        txs: &[Transaction],
+        iteration_order: Option<&[usize]>,
+        loaded_accounts: &mut [Result<TransactionLoadResult>],
+    ) {
+        let mut collected_rent = 0;
+        let mut seen_credit_only_account: HashSet<Pubkey> = HashSet::new();
+        for (tx, loaded_account) in
+            OrderedIterator::new(txs, iteration_order).zip(loaded_accounts.iter())
+        {
+            if loaded_account.is_err() {
+                continue;
+            }
+            let (_account, _loaders, _credits, rents) = loaded_account.as_ref().unwrap();
+
+            let message = tx.message();
+
+            for ((i, key), rent) in message
+                .account_keys
+                .iter()
+                .enumerate()
+                .filter(|(_i, key)| !message.program_ids().contains(&key))
+                .zip(rents.iter())
+            {
+                if seen_credit_only_account.contains(&key) {
+                    continue;
+                }
+                collected_rent += rent;
+                if !message.is_debitable(i) {
+                    seen_credit_only_account.insert(*key);
+                }
+            }
+        }
+
+        self.collected_rent
+            .fetch_add(collected_rent, Ordering::Relaxed);
+    }
+
     fn filter_program_errors_and_collect_fee(
         &self,
         txs: &[Transaction],
@@ -1198,6 +1242,7 @@ impl Bank {
         write_time.stop();
         debug!("store: {}us txs_len={}", write_time.as_us(), txs.len(),);
         self.update_transaction_statuses(txs, iteration_order, &executed);
+        self.collect_rent(txs, iteration_order, loaded_accounts);
         self.filter_program_errors_and_collect_fee(txs, iteration_order, executed)
     }
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1578,12 +1578,15 @@ impl Bank {
             .rc
             .accounts
             .commit_credit_only_collected_rent(&self.ancestors, self.slot());
-        let burned_portion = (total_rent_collected
-            * u64::from(self.rent_collector.rent_calculator.burn_percent))
-            / 100;
-        let _rent_to_be_distributed = total_rent_collected - burned_portion;
-        // TODO: distribute remaining rent amount to validators
-        // self.capitalization.fetch_sub(burned_portion, Ordering::Relaxed);
+
+        if total_rent_collected != 0 {
+            let burned_portion = (total_rent_collected
+                * u64::from(self.rent_collector.rent_calculator.burn_percent))
+                / 100;
+            let _rent_to_be_distributed = total_rent_collected - burned_portion;
+            // TODO: distribute remaining rent amount to validators
+            // self.capitalization.fetch_sub(burned_portion, Ordering::Relaxed);
+        }
     }
 }
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1821,7 +1821,7 @@ mod tests {
 
     #[test]
     fn test_tallied_credit_debit_rent() {
-        let (mut genesis_block, mint_keypair) = create_genesis_block(10);
+        let (mut genesis_block, _mint_keypair) = create_genesis_block(10);
         let key1 = Pubkey::new_rand();
         let key2 = Pubkey::new_rand();
         let rich_keypair1: Keypair = Keypair::new();

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1820,7 +1820,165 @@ mod tests {
     }
 
     #[test]
-    fn test_tallied_credit_debit_rent() {
+    fn test_credit_debit_rent_no_side_effect_on_hash() {
+        let (mut genesis_block, _mint_keypair) = create_genesis_block(10);
+        let credit_only_key1 = Pubkey::new_rand();
+        let credit_only_key2 = Pubkey::new_rand();
+        let credit_debit_keypair1: Keypair = Keypair::new();
+        let credit_debit_keypair2: Keypair = Keypair::new();
+
+        let rent_overdue_credit_only_key1 = Pubkey::new_rand();
+        let rent_overdue_credit_only_key2 = Pubkey::new_rand();
+        let rent_overdue_credit_debit_keypair1 = Keypair::new();
+        let rent_overdue_credit_debit_keypair2 = Keypair::new();
+
+        genesis_block.rent_calculator = RentCalculator {
+            lamports_per_byte_year: 1,
+            exemption_threshold: 21.0,
+            burn_percent: 10,
+        };
+
+        let root_bank = Arc::new(Bank::new(&genesis_block));
+        let bank = Bank::new_from_parent(
+            &root_bank,
+            &Pubkey::default(),
+            2 * (SECONDS_PER_YEAR
+                //  * (ns/s)/(ns/tick) / ticks/slot = 1/s/1/tick = ticks/s
+                *(1_000_000_000.0 / duration_as_ns(&genesis_block.poh_config.target_tick_duration) as f64)
+                //  / ticks/slot
+                / genesis_block.ticks_per_slot as f64) as u64,
+        );
+
+        let root_bank_2 = Arc::new(Bank::new(&genesis_block));
+        let bank_with_success_txs = Bank::new_from_parent(
+            &root_bank_2,
+            &Pubkey::default(),
+            2 * (SECONDS_PER_YEAR
+                //  * (ns/s)/(ns/tick) / ticks/slot = 1/s/1/tick = ticks/s
+                *(1_000_000_000.0 / duration_as_ns(&genesis_block.poh_config.target_tick_duration) as f64)
+                //  / ticks/slot
+                / genesis_block.ticks_per_slot as f64) as u64,
+        );
+        assert_eq!(bank.last_blockhash(), genesis_block.hash());
+
+        // Initialize credit-debit and credit only accounts
+        let credit_debit_account1 = Account::new(20, 1, &Pubkey::default());
+        let credit_debit_account2 = Account::new(20, 1, &Pubkey::default());
+        let credit_only_account1 = Account::new(3, 1, &Pubkey::default());
+        let credit_only_account2 = Account::new(3, 1, &Pubkey::default());
+
+        bank.store_account(&credit_debit_keypair1.pubkey(), &credit_debit_account1);
+        bank.store_account(&credit_debit_keypair2.pubkey(), &credit_debit_account2);
+        bank.store_account(&credit_only_key1, &credit_only_account1);
+        bank.store_account(&credit_only_key2, &credit_only_account2);
+
+        bank_with_success_txs
+            .store_account(&credit_debit_keypair1.pubkey(), &credit_debit_account1);
+        bank_with_success_txs
+            .store_account(&credit_debit_keypair2.pubkey(), &credit_debit_account2);
+        bank_with_success_txs.store_account(&credit_only_key1, &credit_only_account1);
+        bank_with_success_txs.store_account(&credit_only_key2, &credit_only_account2);
+
+        let rent_overdue_credit_debit_account1 = Account::new(2, 1, &Pubkey::default());
+        let rent_overdue_credit_debit_account2 = Account::new(2, 1, &Pubkey::default());
+        let rent_overdue_credit_only_account1 = Account::new(1, 1, &Pubkey::default());
+        let rent_overdue_credit_only_account2 = Account::new(1, 1, &Pubkey::default());
+
+        bank.store_account(
+            &rent_overdue_credit_debit_keypair1.pubkey(),
+            &rent_overdue_credit_debit_account1,
+        );
+        bank.store_account(
+            &rent_overdue_credit_debit_keypair2.pubkey(),
+            &rent_overdue_credit_debit_account2,
+        );
+        bank.store_account(
+            &rent_overdue_credit_only_key1,
+            &rent_overdue_credit_only_account1,
+        );
+        bank.store_account(
+            &rent_overdue_credit_only_key2,
+            &rent_overdue_credit_only_account2,
+        );
+
+        bank_with_success_txs.store_account(
+            &rent_overdue_credit_debit_keypair1.pubkey(),
+            &rent_overdue_credit_debit_account1,
+        );
+        bank_with_success_txs.store_account(
+            &rent_overdue_credit_debit_keypair2.pubkey(),
+            &rent_overdue_credit_debit_account2,
+        );
+        bank_with_success_txs.store_account(
+            &rent_overdue_credit_only_key1,
+            &rent_overdue_credit_only_account1,
+        );
+        bank_with_success_txs.store_account(
+            &rent_overdue_credit_only_key2,
+            &rent_overdue_credit_only_account2,
+        );
+
+        // Make native instruction loader rent exempt
+        let system_program_id = solana_system_program().1;
+        let mut system_program_account = bank.get_account(&system_program_id).unwrap();
+        system_program_account.lamports =
+            bank.get_minimum_balance_for_rent_exemption(system_program_account.data.len());
+        bank.store_account(&system_program_id, &system_program_account);
+        bank_with_success_txs.store_account(&system_program_id, &system_program_account);
+
+        let t1 = system_transaction::transfer(
+            &credit_debit_keypair1,
+            &rent_overdue_credit_only_key1,
+            1,
+            genesis_block.hash(),
+        );
+        let t2 = system_transaction::transfer(
+            &rent_overdue_credit_debit_keypair1,
+            &credit_only_key1,
+            1,
+            genesis_block.hash(),
+        );
+        let t3 = system_transaction::transfer(
+            &credit_debit_keypair2,
+            &credit_only_key2,
+            1,
+            genesis_block.hash(),
+        );
+        let t4 = system_transaction::transfer(
+            &rent_overdue_credit_debit_keypair2,
+            &rent_overdue_credit_only_key2,
+            1,
+            genesis_block.hash(),
+        );
+        let res = bank.process_transactions(&vec![t1.clone(), t2.clone(), t3.clone(), t4.clone()]);
+
+        assert_eq!(res.len(), 4);
+        assert_eq!(res[0], Ok(()));
+        assert_eq!(res[1], Err(TransactionError::AccountNotFound));
+        assert_eq!(res[2], Ok(()));
+        assert_eq!(res[3], Err(TransactionError::AccountNotFound));
+
+        bank.freeze();
+
+        let rwlockguard_bank_hash = bank.hash.read().unwrap();
+        let bank_hash = rwlockguard_bank_hash.as_ref();
+
+        let res = bank_with_success_txs.process_transactions(&vec![t3.clone(), t1.clone()]);
+
+        assert_eq!(res.len(), 2);
+        assert_eq!(res[0], Ok(()));
+        assert_eq!(res[1], Ok(()));
+
+        bank_with_success_txs.freeze();
+
+        let rwlockguard_bank_with_success_txs_hash = bank_with_success_txs.hash.read().unwrap();
+        let bank_with_success_txs_hash = rwlockguard_bank_with_success_txs_hash.as_ref();
+
+        assert_eq!(bank_with_success_txs_hash, bank_hash);
+    }
+
+    #[test]
+    fn test_credit_debit_rent() {
         let (mut genesis_block, _mint_keypair) = create_genesis_block(10);
         let credit_only_key1 = Pubkey::new_rand();
         let credit_only_key2 = Pubkey::new_rand();

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1604,7 +1604,7 @@ impl Bank {
                 .3
                 .iter()
                 .enumerate()
-                .filter(|(i, _rent)| !message.is_debitable(*i))
+                .filter(|(i, _rent)| message.is_debitable(*i))
             {
                 collected_rent += rent;
             }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -559,7 +559,7 @@ impl Bank {
             // finish up any deferred changes to account state
             self.commit_credits();
             self.collect_fees();
-            self.commit_credit_only_collected_rent();
+            self.commit_and_distribute_credit_only_collected_rent();
 
             // freeze is a one-way trip, idempotent
             *hash = self.hash_internal_state();
@@ -1573,10 +1573,17 @@ impl Bank {
             .commit_credits(&self.ancestors, self.slot());
     }
 
-    fn commit_credit_only_collected_rent(&self) {
-        self.rc
+    fn commit_and_distribute_credit_only_collected_rent(&self) {
+        let total_rent_collected = self
+            .rc
             .accounts
             .commit_credit_only_collected_rent(&self.ancestors, self.slot());
+        let burned_portion = (total_rent_collected
+            * u64::from(self.rent_collector.rent_calculator.burn_percent))
+            / 100;
+        let _rent_to_be_distributed = total_rent_collected - burned_portion;
+        // TODO: distribute remaining rent amount to validators
+        // self.capitalization.fetch_sub(burned_portion, Ordering::Relaxed);
     }
 }
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -565,7 +565,7 @@ impl Bank {
             // finish up any deferred changes to account state
             self.collect_fees();
 
-            let (_, collected_rent) = self.commit_credits_and_rents();
+            let collected_rent = self.commit_credits_and_rents();
             self.distribute_rent(collected_rent);
 
             // freeze is a one-way trip, idempotent
@@ -1577,7 +1577,7 @@ impl Bank {
         );
     }
 
-    fn commit_credits_and_rents(&self) -> (u64, u64) {
+    fn commit_credits_and_rents(&self) -> u64 {
         self.rc.accounts.commit_credits_and_rents(
             &self.rent_collector,
             &self.ancestors,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2048,6 +2048,16 @@ mod tests {
             bank.get_minimum_balance_for_rent_exemption(system_program_account.data.len());
         bank.store_account(&system_program_id, &system_program_account);
 
+        let total_lamports_before_txs = system_program_account.lamports
+            + rent_overdue_credit_debit_account1.lamports
+            + rent_overdue_credit_debit_account2.lamports
+            + rent_overdue_credit_only_account1.lamports
+            + rent_overdue_credit_only_account2.lamports
+            + credit_debit_account1.lamports
+            + credit_debit_account2.lamports
+            + credit_only_account1.lamports
+            + credit_only_account2.lamports;
+
         let t1 = system_transaction::transfer(
             &credit_debit_keypair1,
             &rent_overdue_credit_only_key1,
@@ -2074,6 +2084,8 @@ mod tests {
         );
         let res = bank.process_transactions(&vec![t1.clone(), t2.clone(), t3.clone(), t4.clone()]);
 
+        let mut total_lamports_after_txs = 0;
+
         assert_eq!(res.len(), 4);
         assert_eq!(res[0], Ok(()));
         assert_eq!(res[1], Err(TransactionError::AccountNotFound));
@@ -2086,33 +2098,48 @@ mod tests {
         assert_eq!(bank.get_balance(&rent_overdue_credit_only_key1), 1);
         assert_eq!(bank.get_balance(&rent_overdue_credit_only_key2), 1);
 
+        assert_eq!(
+            bank.get_balance(&system_program_id),
+            system_program_account.lamports
+        );
+        total_lamports_after_txs += bank.get_balance(&system_program_id);
+
         // Credit-debit account's rent is already deducted
         // 20 - 1(Transferred) - 2(Rent)
         assert_eq!(bank.get_balance(&credit_debit_keypair1.pubkey()), 17);
+        total_lamports_after_txs += bank.get_balance(&credit_debit_keypair1.pubkey());
         assert_eq!(bank.get_balance(&credit_debit_keypair2.pubkey()), 17);
+        total_lamports_after_txs += bank.get_balance(&credit_debit_keypair2.pubkey());
         // Since this credit-debit accounts are unable to pay rent, load_tx_account failed, as they are
         // the signer account. No change was done.
         assert_eq!(
             bank.get_balance(&rent_overdue_credit_debit_keypair1.pubkey()),
             2
         );
+        total_lamports_after_txs += bank.get_balance(&rent_overdue_credit_debit_keypair1.pubkey());
         assert_eq!(
             bank.get_balance(&rent_overdue_credit_debit_keypair2.pubkey()),
             2
         );
+        total_lamports_after_txs += bank.get_balance(&rent_overdue_credit_debit_keypair2.pubkey());
 
         // Credit-debit account's rent is stored in `tallied_credit_debit_rent`
         // Rent deducted is: 2+2
         assert_eq!(bank.get_tallied_credit_debit_rent(), 4);
+        total_lamports_after_txs += bank.get_tallied_credit_debit_rent();
 
         // Rent deducted is: 2+1
-        assert_eq!(bank.commit_credits_and_rents(), 3);
+        let commited_credit_only_rent = bank.commit_credits_and_rents();
+        assert_eq!(commited_credit_only_rent, 3);
+        total_lamports_after_txs += commited_credit_only_rent;
 
         // No rent deducted because tx failed
         assert_eq!(bank.get_balance(&credit_only_key1), 3);
+        total_lamports_after_txs += bank.get_balance(&credit_only_key1);
         // Now, we have credited credits and debited rent
         // 3 + 1(Transferred) - 2(Rent)
         assert_eq!(bank.get_balance(&credit_only_key2), 2);
+        total_lamports_after_txs += bank.get_balance(&credit_only_key2);
 
         // Since we were unable to pay rent, the account was reset, rent got deducted.
         // And credit went to that overwritten account
@@ -2125,9 +2152,14 @@ mod tests {
                 .len(),
             0
         );
+        total_lamports_after_txs += bank.get_balance(&rent_overdue_credit_only_key1);
 
-        // No rent got deducted as, we were unable to load accouns (load_tx_accounts errored out)
+        // No rent got deducted as, we were unable to load accounts (load_tx_accounts errored out)
         assert_eq!(bank.get_balance(&rent_overdue_credit_only_key2), 1);
+        total_lamports_after_txs += bank.get_balance(&rent_overdue_credit_only_key2);
+
+        // total lamports in circulation should be same
+        assert_eq!(total_lamports_after_txs, total_lamports_before_txs);
     }
 
     #[test]

--- a/runtime/src/rent_collector.rs
+++ b/runtime/src/rent_collector.rs
@@ -55,7 +55,7 @@ impl RentCollector {
                     account.lamports -= rent_due;
                     (Some(account), rent_due)
                 } else {
-                    (None, 0)
+                    (None, account.lamports)
                 }
             } else {
                 // maybe collect rent later, leave account alone

--- a/runtime/src/rent_collector.rs
+++ b/runtime/src/rent_collector.rs
@@ -35,9 +35,9 @@ impl RentCollector {
     // updates this account's lamports and status and returns
     //  the account rent collected, if any
     //
-    pub fn update<'a>(&self, account: &'a mut Account) -> (Option<&'a Account>, u64) {
+    pub fn update(&self, account: &mut Account) -> u64 {
         if account.data.is_empty() || account.rent_epoch > self.epoch {
-            (Some(account), 0)
+            0
         } else {
             let slots_elapsed: u64 = (account.rent_epoch..=self.epoch)
                 .map(|epoch| self.epoch_schedule.get_slots_in_epoch(epoch + 1))
@@ -53,13 +53,15 @@ impl RentCollector {
                 if account.lamports > rent_due {
                     account.rent_epoch = self.epoch + 1;
                     account.lamports -= rent_due;
-                    (Some(account), rent_due)
+                    rent_due
                 } else {
-                    (None, account.lamports)
+                    let rent_charged = account.lamports;
+                    *account = Account::default();
+                    rent_charged
                 }
             } else {
                 // maybe collect rent later, leave account alone
-                (Some(account), 0)
+                0
             }
         }
     }

--- a/runtime/src/rent_collector.rs
+++ b/runtime/src/rent_collector.rs
@@ -30,7 +30,7 @@ impl RentCollector {
         let (rent_due_per_slot, _) = self.rent_calculator.due(
             account.lamports,
             account.data.len(),
-            1 as f64 / self.slots_per_year,
+            1_f64 / self.slots_per_year,
         );
 
         let able_to_pay_for_slots = account.lamports / rent_due_per_slot;

--- a/runtime/src/rent_collector.rs
+++ b/runtime/src/rent_collector.rs
@@ -26,6 +26,33 @@ impl RentCollector {
         }
     }
 
+    fn able_to_cover_rent_till_epoch(&self, account: &Account) -> u64 {
+        let (rent_due_per_slot, _) = self.rent_calculator.due(
+            account.lamports,
+            account.data.len(),
+            1 as f64 / self.slots_per_year,
+        );
+
+        let able_to_pay_for_slots = account.lamports / rent_due_per_slot;
+        let mut remaining_slots_to_consume = able_to_pay_for_slots;
+
+        (account.rent_epoch + 1..=self.epoch)
+            .take_while(|epoch| {
+                let slots_in_current_epoch = self.epoch_schedule.get_slots_in_epoch(*epoch);
+                if remaining_slots_to_consume == 0 {
+                    false
+                } else if remaining_slots_to_consume < slots_in_current_epoch {
+                    remaining_slots_to_consume = 0;
+                    true
+                } else {
+                    remaining_slots_to_consume -= slots_in_current_epoch;
+                    true
+                }
+            })
+            .last()
+            .unwrap_or(account.rent_epoch)
+    }
+
     pub fn clone_with_epoch(&self, epoch: Epoch) -> Self {
         Self {
             epoch,
@@ -35,9 +62,13 @@ impl RentCollector {
     // updates this account's lamports and status and returns
     //  the account rent collected, if any
     //
-    pub fn update(&self, mut account: Account) -> Option<(Account, u64)> {
+    pub fn update<'a>(
+        &self,
+        account: &'a mut Account,
+        deduct_partial_rent: bool,
+    ) -> (Option<&'a Account>, u64) {
         if account.data.is_empty() || account.rent_epoch > self.epoch {
-            Some((account, 0))
+            (Some(account), 0)
         } else {
             let slots_elapsed: u64 = (account.rent_epoch..=self.epoch)
                 .map(|epoch| self.epoch_schedule.get_slots_in_epoch(epoch + 1))
@@ -53,13 +84,19 @@ impl RentCollector {
                 if account.lamports > rent_due {
                     account.rent_epoch = self.epoch + 1;
                     account.lamports -= rent_due;
-                    Some((account, rent_due))
+                    (Some(account), rent_due)
+                } else if !deduct_partial_rent {
+                    (None, 0)
                 } else {
-                    None
+                    let epoch_to_forward = self.able_to_cover_rent_till_epoch(account);
+                    let rent_due = account.lamports;
+                    account.lamports -= rent_due;
+                    account.rent_epoch = epoch_to_forward;
+                    (Some(account), rent_due)
                 }
             } else {
                 // maybe collect rent later, leave account alone
-                Some((account, 0))
+                (Some(account), 0)
             }
         }
     }


### PR DESCRIPTION
#### Problem
We are collecting rent from Accounts in `TransactionRents` but not doing anything with it.

#### Summary of Changes
This PR does following: 
- collect credit-only rent in `credit_only_collected_rent` hashmap
- collect credit-debit rent in `tallied_credit_debit_rent` `AtomicU64`
- sync credit only accounts' rent at the end of the slot (Just before we are freezing the bank)

Distributing this rent (credit_debit + credit_only) to validators while burning some portion as per config, will be in separate PR.

#### Note: 
While collecting rent, credit only accounts are considered once time per slot only. 

Fixes #5817 
Fixes #5816 