### PR TITLE
net: Add support for preemptible GCP instances

### DIFF
--- a/ci/testnet-deploy.sh
+++ b/ci/testnet-deploy.sh
@@ -362,7 +362,11 @@ if ! $skipStart; then
       op=start
     fi
     echo "--- net.sh $op"
-    args=("$op" -t "$tarChannelOrTag")
+    args=(
+      "$op"
+      -t "$tarChannelOrTag"
+      --dedicated
+    )
 
     if ! $publicNetwork; then
       args+=(-o rejectExtraNodes)

--- a/net/net.sh
+++ b/net/net.sh
@@ -840,6 +840,32 @@ stop() {
   echo "Stopping nodes took $SECONDS seconds"
 }
 
+
+checkPremptibleInstances() {
+  # The fullnodeIpList nodes may be preemptible instances that can disappear at
+  # any time.  Try to detect when a fullnode has been preempted to help the user
+  # out.
+  #
+  # Of course this isn't airtight as an instance could always disappear
+  # immediately after its successfully pinged.
+  for ipAddress in "${fullnodeIpList[@]}"; do
+    (
+      set -x
+      ping -o -t 4 "$ipAddress"
+    ) || {
+      cat <<EOF
+
+Warning: $ipAddress may have been preempted.
+
+Run |./gce.sh config| to restart it
+EOF
+      exit 1
+    }
+  done
+}
+
+checkPremptibleInstances
+
 case $command in
 restart)
   prepare_deploy

--- a/net/scripts/azure-provider.sh
+++ b/net/scripts/azure-provider.sh
@@ -8,6 +8,10 @@ cloud_DefaultZone() {
   echo "westus"
 }
 
+cloud_RestartPreemptedInstances() {
+  : # Not implemented
+}
+
 #
 # __cloud_GetConfigValueFromInstanceName
 # Return a piece of configuration information about an instance

--- a/net/scripts/colo-provider.sh
+++ b/net/scripts/colo-provider.sh
@@ -16,6 +16,10 @@ cloud_DefaultZone() {
   echo "Denver"
 }
 
+cloud_RestartPreemptedInstances() {
+  : # Not implemented
+}
+
 #
 # __cloud_FindInstances
 #
@@ -134,6 +138,7 @@ cloud_Initialize() {
 #                 has been provisioned in the GCE region that is hosting `$zone`
 # bootDiskType  - Optional specify SSD or HDD boot disk
 # additionalDiskSize - Optional specify size of additional storage volume
+# preemptible - Optionally request a preemptible instance ("true")
 #
 # Tip: use cloud_FindInstances to locate the instances once this function
 #      returns
@@ -149,7 +154,8 @@ cloud_CreateInstances() {
   #declare optionalAddress="$9" # unused
   #declare optionalBootDiskType="${10}" # unused
   #declare optionalAdditionalDiskSize="${11}" # unused
-  declare sshPrivateKey="${12}"
+  #declare optionalPreemptible="${12}" # unused
+  declare sshPrivateKey="${13}"
 
   declare -a nodes
   if [[ $numNodes = 1 ]]; then

--- a/net/scripts/ec2-provider.sh
+++ b/net/scripts/ec2-provider.sh
@@ -7,6 +7,10 @@ cloud_DefaultZone() {
   echo "us-east-1b"
 }
 
+cloud_RestartPreemptedInstances() {
+  : # Not implemented
+}
+
 # AWS region is zone with the last character removed
 __cloud_GetRegion() {
   declare zone="$1"


### PR DESCRIPTION
GCP clusters created by `net/gce.sh` now feature preemptible validator nodes by default.  The bootstrap leader and clients will never be preemptible to reduce the amount of churn as we learn how painful preemptible instances will be (if at all).

When an instance is preempted, the next `net/net.sh` command issued should detect this and instruct the user how to recover the instance (by running `net/gce.sh config`)