### PR TITLE
Boot the Builder pattern from GenesisBlock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3423,9 +3423,7 @@ name = "solana-genesis"
 version = "0.20.0"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "bincode 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rayon 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3436,7 +3434,6 @@ dependencies = [
  "solana-stake-api 0.20.0",
  "solana-storage-api 0.20.0",
  "solana-vote-api 0.20.0",
- "sys-info 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/bench-exchange/src/bench.rs
+++ b/bench-exchange/src/bench.rs
@@ -11,7 +11,7 @@ use solana_drone::drone::request_airdrop_transaction;
 use solana_exchange_api::exchange_instruction;
 use solana_exchange_api::exchange_state::*;
 use solana_exchange_api::id;
-use solana_genesis::PrimordialAccountDetails;
+use solana_genesis::Base64Account;
 use solana_metrics::datapoint_info;
 use solana_sdk::client::Client;
 use solana_sdk::client::SyncClient;
@@ -89,7 +89,7 @@ pub fn create_client_accounts_file(
     keypairs.iter().for_each(|keypair| {
         accounts.insert(
             serde_json::to_string(&keypair.to_bytes().to_vec()).unwrap(),
-            PrimordialAccountDetails {
+            Base64Account {
                 balance: fund_amount,
                 executable: false,
                 owner: system_program::id().to_string(),
@@ -140,8 +140,7 @@ where
         let path = Path::new(&client_ids_and_stake_file);
         let file = File::open(path).unwrap();
 
-        let accounts: HashMap<String, PrimordialAccountDetails> =
-            serde_yaml::from_reader(file).unwrap();
+        let accounts: HashMap<String, Base64Account> = serde_yaml::from_reader(file).unwrap();
         accounts
             .into_iter()
             .map(|(keypair, _)| {

--- a/bench-tps/src/main.rs
+++ b/bench-tps/src/main.rs
@@ -2,7 +2,7 @@ use log::*;
 use solana_bench_tps::bench::{do_bench_tps, generate_and_fund_keypairs, generate_keypairs};
 use solana_bench_tps::cli;
 use solana_core::gossip_service::{discover_cluster, get_multi_client};
-use solana_genesis::PrimordialAccountDetails;
+use solana_genesis::Base64Account;
 use solana_sdk::fee_calculator::FeeCalculator;
 use solana_sdk::signature::{Keypair, KeypairUtil};
 use solana_sdk::system_program;
@@ -46,7 +46,7 @@ fn main() {
         keypairs.iter().for_each(|keypair| {
             accounts.insert(
                 serde_json::to_string(&keypair.to_bytes().to_vec()).unwrap(),
-                PrimordialAccountDetails {
+                Base64Account {
                     balance: num_lamports_per_account,
                     executable: false,
                     owner: system_program::id().to_string(),
@@ -85,8 +85,7 @@ fn main() {
         let file = File::open(path).unwrap();
 
         info!("Reading {}", client_ids_and_stake_file);
-        let accounts: HashMap<String, PrimordialAccountDetails> =
-            serde_yaml::from_reader(file).unwrap();
+        let accounts: HashMap<String, Base64Account> = serde_yaml::from_reader(file).unwrap();
         let mut keypairs = vec![];
         let mut last_balance = 0;
 

--- a/genesis/Cargo.toml
+++ b/genesis/Cargo.toml
@@ -10,7 +10,6 @@ homepage = "https://solana.com/"
 
 [dependencies]
 base64 = "0.10.1"
-bincode = "1.2.0"
 clap = "2.33.0"
 serde = "1.0.101"
 serde_derive = "1.0.101"
@@ -23,5 +22,3 @@ solana-stake-api = { path = "../programs/stake_api", version = "0.20.0" }
 solana-storage-api = { path = "../programs/storage_api", version = "0.20.0" }
 solana-vote-api = { path = "../programs/vote_api", version = "0.20.0" }
 tempfile = "3.1.0"
-sys-info = "0.5.8"
-rayon = "1.2.0"

--- a/genesis/src/lib.rs
+++ b/genesis/src/lib.rs
@@ -1,7 +1,8 @@
 use serde::{Deserialize, Serialize};
 
+/// An account where the data is encoded as a Base64 string.
 #[derive(Serialize, Deserialize, Debug)]
-pub struct PrimordialAccountDetails {
+pub struct Base64Account {
     pub balance: u64,
     pub owner: String,
     pub data: String,

--- a/programs/stake_api/src/config.rs
+++ b/programs/stake_api/src/config.rs
@@ -56,7 +56,7 @@ impl ConfigState for Config {
     }
 }
 
-pub fn genesis() -> (Pubkey, Account) {
+pub fn create_genesis_account() -> (Pubkey, Account) {
     (id(), create_config_account(vec![], &Config::default(), 100))
 }
 
@@ -83,7 +83,7 @@ mod tests {
             from_keyed_account(&KeyedAccount::new(&Pubkey::default(), false, &mut account)),
             Err(InstructionError::InvalidArgument)
         );
-        let (pubkey, mut account) = genesis();
+        let (pubkey, mut account) = create_genesis_account();
         assert_eq!(
             from_keyed_account(&KeyedAccount::new(&pubkey, false, &mut account)),
             Ok(Config::default())

--- a/programs/stake_api/src/lib.rs
+++ b/programs/stake_api/src/lib.rs
@@ -1,3 +1,7 @@
+use crate::config::create_genesis_account;
+use crate::rewards_pools::create_rewards_accounts;
+use solana_sdk::genesis_block::GenesisBlock;
+
 pub mod config;
 pub mod rewards_pools;
 pub mod stake_instruction;
@@ -13,11 +17,11 @@ solana_sdk::solana_name_id!(
     "Stake11111111111111111111111111111111111111"
 );
 
-use solana_sdk::genesis_block::Builder;
-
-pub fn genesis(mut builder: Builder) -> Builder {
-    for (pubkey, account) in crate::rewards_pools::genesis().iter() {
-        builder = builder.rewards_pool(*pubkey, account.clone());
+pub fn add_genesis_accounts(genesis_block: &mut GenesisBlock) {
+    for (pubkey, account) in create_rewards_accounts() {
+        genesis_block.add_rewards_pool(pubkey, account);
     }
-    builder.accounts(&[crate::config::genesis()])
+
+    let (pubkey, account) = create_genesis_account();
+    genesis_block.add_account(pubkey, account);
 }

--- a/programs/stake_api/src/rewards_pools.rs
+++ b/programs/stake_api/src/rewards_pools.rs
@@ -31,7 +31,7 @@ pub fn random_id() -> Pubkey {
     Pubkey::new(id.as_ref())
 }
 
-pub fn genesis() -> Vec<(Pubkey, Account)> {
+pub fn create_rewards_accounts() -> Vec<(Pubkey, Account)> {
     let mut accounts = Vec::with_capacity(NUM_REWARDS_POOLS);
     let mut pubkey = id();
 
@@ -51,7 +51,7 @@ mod tests {
 
     #[test]
     fn test() {
-        let accounts = genesis();
+        let accounts = create_rewards_accounts();
 
         for _i in 0..NUM_REWARDS_POOLS {
             let id = random_id();

--- a/programs/storage_api/src/rewards_pools.rs
+++ b/programs/storage_api/src/rewards_pools.rs
@@ -5,7 +5,7 @@
 
 use crate::storage_contract::create_rewards_pool;
 use rand::{thread_rng, Rng};
-use solana_sdk::genesis_block::Builder;
+use solana_sdk::genesis_block::GenesisBlock;
 use solana_sdk::hash::{hash, Hash};
 use solana_sdk::pubkey::Pubkey;
 
@@ -20,14 +20,13 @@ solana_sdk::solana_name_id!(ID, "StorageMiningPoo111111111111111111111111111");
 // to cut down on collisions for redemptions, we make multiple accounts
 pub const NUM_REWARDS_POOLS: usize = 32;
 
-pub fn genesis(mut builder: Builder) -> Builder {
+pub fn add_genesis_accounts(genesis_block: &mut GenesisBlock) {
     let mut pubkey = id();
 
     for _i in 0..NUM_REWARDS_POOLS {
-        builder = builder.rewards_pool(pubkey, create_rewards_pool());
+        genesis_block.add_rewards_pool(pubkey, create_rewards_pool());
         pubkey = Pubkey::new(hash(pubkey.as_ref()).as_ref());
     }
-    builder
 }
 
 pub fn random_id() -> Pubkey {
@@ -43,13 +42,11 @@ pub fn random_id() -> Pubkey {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use solana_sdk::genesis_block::Builder;
 
     #[test]
     fn test() {
-        let builder = Builder::new();
-
-        let genesis_block = genesis(builder).build();
+        let mut genesis_block = GenesisBlock::default();
+        add_genesis_accounts(&mut genesis_block);
 
         for _i in 0..NUM_REWARDS_POOLS {
             let id = random_id();


### PR DESCRIPTION
#### Problem

Rust's Builder pattern is an anti-pattern. We ran this experiment a while back with the `MessageBuilder` struct. It led to confusing code and redundant wrappers. It's especially ugly when you start using it in imperative code (`let builder = builder.do_something()`). In the case of `GenesisBlock`, it went the same way.

#### Summary of Changes

* Remove the Builder wrapper and add `&mut self` methods to GenesisBlock that move their input parameters instead of cloning them.  Use the `T { field*, ..T::default() }` pattern.
* Change some function names from ambiguous names like `genesis()` to the form `<verb>_<subject>`.
* Purge term "primordial", because it's used the same was a "genesis" everywhere else.
* Removed some unused crate dependencies.
