### PR TITLE
Fix move testing

### DIFF
--- a/local_cluster/Cargo.toml
+++ b/local_cluster/Cargo.toml
@@ -36,4 +36,4 @@ serial_test = "0.2.0"
 serial_test_derive = "0.2.0"
 
 [features]
-move = ["solana-move-loader-api", "solana-move-loader-program"]
+move = ["solana-bench-tps/move", "solana-move-loader-api", "solana-move-loader-program"]


### PR DESCRIPTION
#### Problem

Local cluster was not passing the move feature on to bench-tps which meant that Move testing was not actually testing move.

#### Summary of Changes

Pass it on

Fixes #
