### PR TITLE
Cleanup shred header structures

### DIFF
--- a/core/benches/shredder.rs
+++ b/core/benches/shredder.rs
@@ -6,7 +6,7 @@ use solana_core::entry::create_ticks;
 use solana_core::entry::Entry;
 use solana_core::shred::{
     max_entries_per_n_shred, max_ticks_per_n_shreds, Shred, Shredder, RECOMMENDED_FEC_RATE,
-    SIZE_OF_DATA_SHRED_HEADER,
+    SIZE_OF_SHRED_HEADER,
 };
 use solana_core::test_tx;
 use solana_sdk::hash::Hash;
@@ -31,7 +31,7 @@ fn make_large_unchained_entries(txs_per_entry: u64, num_entries: u64) -> Vec<Ent
 #[bench]
 fn bench_shredder_ticks(bencher: &mut Bencher) {
     let kp = Arc::new(Keypair::new());
-    let shred_size = PACKET_DATA_SIZE - *SIZE_OF_DATA_SHRED_HEADER;
+    let shred_size = PACKET_DATA_SIZE - *SIZE_OF_SHRED_HEADER;
     let num_shreds = ((1000 * 1000) + (shred_size - 1)) / shred_size;
     // ~1Mb
     let num_ticks = max_ticks_per_n_shreds(1) * num_shreds as u64;
@@ -45,7 +45,7 @@ fn bench_shredder_ticks(bencher: &mut Bencher) {
 #[bench]
 fn bench_shredder_large_entries(bencher: &mut Bencher) {
     let kp = Arc::new(Keypair::new());
-    let shred_size = PACKET_DATA_SIZE - *SIZE_OF_DATA_SHRED_HEADER;
+    let shred_size = PACKET_DATA_SIZE - *SIZE_OF_SHRED_HEADER;
     let num_shreds = ((1000 * 1000) + (shred_size - 1)) / shred_size;
     let txs_per_entry = 128;
     let num_entries = max_entries_per_n_shred(&make_test_entry(txs_per_entry), num_shreds as u64);
@@ -60,7 +60,7 @@ fn bench_shredder_large_entries(bencher: &mut Bencher) {
 #[bench]
 fn bench_deshredder(bencher: &mut Bencher) {
     let kp = Arc::new(Keypair::new());
-    let shred_size = PACKET_DATA_SIZE - *SIZE_OF_DATA_SHRED_HEADER;
+    let shred_size = PACKET_DATA_SIZE - *SIZE_OF_SHRED_HEADER;
     // ~10Mb
     let num_shreds = ((10000 * 1000) + (shred_size - 1)) / shred_size;
     let num_ticks = max_ticks_per_n_shreds(1) * num_shreds as u64;
@@ -75,7 +75,7 @@ fn bench_deshredder(bencher: &mut Bencher) {
 
 #[bench]
 fn bench_deserialize_hdr(bencher: &mut Bencher) {
-    let data = vec![0; PACKET_DATA_SIZE - *SIZE_OF_DATA_SHRED_HEADER];
+    let data = vec![0; PACKET_DATA_SIZE - *SIZE_OF_SHRED_HEADER];
 
     let shred = Shred::new_from_data(2, 1, 1, Some(&data), true, true);
 

--- a/core/src/blocktree.rs
+++ b/core/src/blocktree.rs
@@ -3175,7 +3175,7 @@ pub mod tests {
             // Trying to insert the same shred again should fail
             {
                 let index = index_cf
-                    .get(shred.common_header.coding_header.slot)
+                    .get(shred.coding_header.common_header.slot)
                     .unwrap()
                     .unwrap();
                 assert!(!Blocktree::should_insert_coding_shred(
@@ -3185,13 +3185,13 @@ pub mod tests {
                 ));
             }
 
-            shred.common_header.coding_header.index += 1;
+            shred.coding_header.common_header.index += 1;
 
             // Establish a baseline that works
             {
                 let coding_shred = Shred::new_empty_from_header(shred.clone());
                 let index = index_cf
-                    .get(shred.common_header.coding_header.slot)
+                    .get(shred.coding_header.common_header.slot)
                     .unwrap()
                     .unwrap();
                 assert!(Blocktree::should_insert_coding_shred(
@@ -3204,7 +3204,7 @@ pub mod tests {
             // Trying to insert a shred with index < position should fail
             {
                 let mut coding_shred = Shred::new_empty_from_header(shred.clone());
-                let index = coding_shred.headers.common_header.position - 1;
+                let index = coding_shred.headers.coding_header.position - 1;
                 coding_shred.set_index(index as u32);
 
                 let index = index_cf.get(coding_shred.slot()).unwrap().unwrap();
@@ -3218,7 +3218,7 @@ pub mod tests {
             // Trying to insert shred with num_coding == 0 should fail
             {
                 let mut coding_shred = Shred::new_empty_from_header(shred.clone());
-                coding_shred.headers.common_header.num_coding_shreds = 0;
+                coding_shred.headers.coding_header.num_coding_shreds = 0;
                 let index = index_cf.get(coding_shred.slot()).unwrap().unwrap();
                 assert!(!Blocktree::should_insert_coding_shred(
                     &coding_shred,
@@ -3230,8 +3230,8 @@ pub mod tests {
             // Trying to insert shred with pos >= num_coding should fail
             {
                 let mut coding_shred = Shred::new_empty_from_header(shred.clone());
-                coding_shred.headers.common_header.num_coding_shreds =
-                    coding_shred.headers.common_header.position;
+                coding_shred.headers.coding_header.num_coding_shreds =
+                    coding_shred.headers.coding_header.position;
                 let index = index_cf.get(coding_shred.slot()).unwrap().unwrap();
                 assert!(!Blocktree::should_insert_coding_shred(
                     &coding_shred,
@@ -3244,9 +3244,9 @@ pub mod tests {
             // has index > u32::MAX should fail
             {
                 let mut coding_shred = Shred::new_empty_from_header(shred.clone());
-                coding_shred.headers.common_header.num_coding_shreds = 3;
-                coding_shred.headers.common_header.coding_header.index = std::u32::MAX - 1;
-                coding_shred.headers.common_header.position = 0;
+                coding_shred.headers.coding_header.num_coding_shreds = 3;
+                coding_shred.headers.coding_header.common_header.index = std::u32::MAX - 1;
+                coding_shred.headers.coding_header.position = 0;
                 let index = index_cf.get(coding_shred.slot()).unwrap().unwrap();
                 assert!(!Blocktree::should_insert_coding_shred(
                     &coding_shred,
@@ -3255,7 +3255,7 @@ pub mod tests {
                 ));
 
                 // Decreasing the number of num_coding_shreds will put it within the allowed limit
-                coding_shred.headers.common_header.num_coding_shreds = 2;
+                coding_shred.headers.coding_header.num_coding_shreds = 2;
                 assert!(Blocktree::should_insert_coding_shred(
                     &coding_shred,
                     index.coding(),

--- a/core/src/cluster_info.rs
+++ b/core/src/cluster_info.rs
@@ -1787,7 +1787,7 @@ mod tests {
     use crate::repair_service::RepairType;
     use crate::result::Error;
     use crate::shred::max_ticks_per_n_shreds;
-    use crate::shred::{DataShredHeader, Shred};
+    use crate::shred::{Shred, ShredHeader};
     use crate::test_tx::test_tx;
     use rayon::prelude::*;
     use solana_sdk::hash::Hash;
@@ -1947,10 +1947,10 @@ mod tests {
                 0,
             );
             assert!(rv.is_empty());
-            let mut data_shred = DataShredHeader::default();
-            data_shred.data_header.slot = 2;
-            data_shred.parent_offset = 1;
-            data_shred.data_header.index = 1;
+            let mut data_shred = ShredHeader::default();
+            data_shred.data_header.common_header.slot = 2;
+            data_shred.data_header.parent_offset = 1;
+            data_shred.data_header.common_header.index = 1;
             let shred_info = Shred::new_empty_from_header(data_shred);
 
             blocktree


### PR DESCRIPTION
#### Problem
Shred header structure names are convoluted and it makes code harder to grok.

#### Summary of Changes
Simplified the names (as per the structure usage).
