### PR TITLE
Move loader enforces account size

### DIFF
--- a/programs/librapay_api/src/librapay_transaction.rs
+++ b/programs/librapay_api/src/librapay_transaction.rs
@@ -75,7 +75,7 @@ pub fn create_accounts(
                 &from.pubkey(),
                 to,
                 lamports,
-                128,
+                200,
                 &solana_move_loader_api::id(),
             )
         })

--- a/programs/move_loader_api/src/account_state.rs
+++ b/programs/move_loader_api/src/account_state.rs
@@ -53,7 +53,7 @@ pub enum LibraAccountState {
 }
 impl LibraAccountState {
     pub fn create_unallocated() -> Self {
-        LibraAccountState::Unallocated
+        Self::Unallocated
     }
 
     pub fn create_program(
@@ -66,7 +66,7 @@ impl LibraAccountState {
         let mut extra_deps: Vec<VerifiedModule> = vec![];
         for dep in deps {
             let state: Self = bincode::deserialize(&dep).unwrap();
-            if let LibraAccountState::User(_, write_set) = state {
+            if let Self::User(_, write_set) = state {
                 for (_, write_op) in write_set.iter() {
                     if let WriteOp::Value(raw_bytes) = write_op {
                         extra_deps.push(
@@ -99,13 +99,13 @@ impl LibraAccountState {
                 .expect("Unable to serialize module");
             modules_bytes.push(buf);
         }
-        LibraAccountState::CompiledProgram(
+        Self::CompiledProgram(
             serde_json::to_string(&Program::new(script_bytes, modules_bytes, vec![])).unwrap(),
         )
     }
 
     pub fn create_user(owner: &Pubkey, write_set: WriteSet) -> Self {
-        LibraAccountState::User(*owner, write_set)
+        Self::User(*owner, write_set)
     }
 
     pub fn create_genesis(mint_balance: u64) -> Result<(Self), InstructionError> {
@@ -172,6 +172,6 @@ impl LibraAccountState {
         .freeze()
         .map_err(map_failure_error)?;
 
-        Ok(LibraAccountState::Genesis(write_set))
+        Ok(Self::Genesis(write_set))
     }
 }

--- a/programs/move_loader_api/src/error_mappers.rs
+++ b/programs/move_loader_api/src/error_mappers.rs
@@ -23,7 +23,10 @@ pub fn map_vm_binary_error(err: vm::errors::BinaryError) -> InstructionError {
 #[allow(clippy::needless_pass_by_value)]
 pub fn map_data_error(err: std::boxed::Box<bincode::ErrorKind>) -> InstructionError {
     debug!("Error: Account data: {:?}", err);
-    InstructionError::InvalidAccountData
+    match err.as_ref() {
+        bincode::ErrorKind::SizeLimit => InstructionError::AccountDataTooSmall,
+        _ => InstructionError::InvalidAccountData,
+    }
 }
 #[allow(clippy::needless_pass_by_value)]
 pub fn map_json_error(err: serde_json::error::Error) -> InstructionError {


### PR DESCRIPTION
#### Problem

Move loader is re-allocating accounts

#### Summary of Changes

Fail if the account is too small, otherwise, retain account size

Fixes #5506
