### PR TITLE
net/gce.sh: Switch /bin/sh from dash to bash

### DIFF
--- a/net/gce.sh
+++ b/net/gce.sh
@@ -674,6 +674,11 @@ chmod 444 /solana-scratch/id_ecdsa
 
 USER=\$(id -un)
 export DEBIAN_FRONTEND=noninteractive
+
+# /bin/sh from dash to bash
+echo "dash dash/sh boolean false" | debconf-set-selections
+dpkg-reconfigure dash
+
 $(
   cd "$here"/scripts/
   cat \


### PR DESCRIPTION
#### Problem

I need `at` for #6363.  `at` runs commands under `/bin/sh`, which on ubuntu is `dash` by default.  The rest of our shell script is `bash` and `shellcheck` enforces `dash`-incompatible syntax

#### Summary of Changes

Change `/bin/sh` to `bash`