### PR TITLE
Update Rust-BPF to v0.1.8

### DIFF
--- a/sdk/bpf/scripts/install.sh
+++ b/sdk/bpf/scripts/install.sh
@@ -80,7 +80,7 @@ if [[ ! -f llvm-native-$machine-$version.md ]]; then
 fi
 
 # Install Rust-BPF
-version=v0.1.7
+version=v0.1.8
 if [[ ! -f rust-bpf-$machine-$version.md ]]; then
   (
     filename=solana-rust-bpf-$machine.tar.bz2


### PR DESCRIPTION
#### Problem

Latest Cargo using a flag not supported by Rust-BPF's rustc.

#### Summary of Changes

Flag configures json error output, stub it for now

Fixes #
