### PR TITLE
Remove circular dependencies in core

### DIFF
--- a/core/src/blocktree/db.rs
+++ b/core/src/blocktree/db.rs
@@ -1,4 +1,4 @@
-use crate::result::{Error, Result};
+use crate::blocktree::{BlocktreeError, Result};
 
 use bincode::{deserialize, serialize};
 
@@ -64,7 +64,7 @@ pub trait Backend: Sized + Send + Sync {
     type Cursor: DbCursor<Self>;
     type Iter: Iterator<Item = (Box<Self::Key>, Box<[u8]>)>;
     type WriteBatch: IWriteBatch<Self>;
-    type Error: Into<Error>;
+    type Error: Into<BlocktreeError>;
 
     fn open(path: &Path) -> Result<Self>;
 

--- a/core/src/blocktree/rocks.rs
+++ b/core/src/blocktree/rocks.rs
@@ -2,8 +2,7 @@ use crate::blocktree::db::columns as cf;
 use crate::blocktree::db::{
     Backend, Column, DbCursor, IWriteBatch, IteratorDirection, IteratorMode, TypedColumn,
 };
-use crate::blocktree::BlocktreeError;
-use crate::result::{Error, Result};
+use crate::blocktree::{BlocktreeError, Result};
 use solana_sdk::clock::Slot;
 
 use byteorder::{BigEndian, ByteOrder};
@@ -412,9 +411,9 @@ impl IWriteBatch<Rocks> for RWriteBatch {
     }
 }
 
-impl std::convert::From<rocksdb::Error> for Error {
-    fn from(e: rocksdb::Error) -> Error {
-        Error::BlocktreeError(BlocktreeError::RocksDb(e))
+impl std::convert::From<rocksdb::Error> for BlocktreeError {
+    fn from(e: rocksdb::Error) -> BlocktreeError {
+        BlocktreeError::RocksDb(e)
     }
 }
 

--- a/core/src/blocktree/rooted_slot_iterator.rs
+++ b/core/src/blocktree/rooted_slot_iterator.rs
@@ -13,7 +13,7 @@ impl<'a> RootedSlotIterator<'a> {
                 blocktree,
             })
         } else {
-            Err(Error::BlocktreeError(BlocktreeError::SlotNotRooted))
+            Err(BlocktreeError::SlotNotRooted)
         }
     }
 }

--- a/core/src/perf_libs.rs
+++ b/core/src/perf_libs.rs
@@ -1,6 +1,6 @@
-use crate::packet::Packet;
 use core::ffi::c_void;
 use dlopen::symbor::{Container, SymBorApi, Symbol};
+use solana_sdk::packet::Packet;
 use std::env;
 use std::ffi::OsStr;
 use std::fs;

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -743,7 +743,9 @@ impl ReplayStage {
         bank_progress: &mut ForkProgress,
     ) -> Result<(Vec<Entry>, usize, u64, u64)> {
         let bank_slot = bank.slot();
-        blocktree.get_slot_entries_with_shred_count(bank_slot, bank_progress.num_shreds as u64)
+        let entries_and_count = blocktree
+            .get_slot_entries_with_shred_count(bank_slot, bank_progress.num_shreds as u64)?;
+        Ok(entries_and_count)
     }
 
     fn replay_entries_into_bank(

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -12,7 +12,6 @@ pub mod loader_instruction;
 pub mod message;
 pub mod native_loader;
 pub mod native_token;
-pub mod packet;
 pub mod poh_config;
 pub mod pubkey;
 pub mod rent_calculator;
@@ -36,6 +35,8 @@ pub mod bank_hash;
 pub mod client;
 #[cfg(not(feature = "program"))]
 pub mod genesis_block;
+#[cfg(not(feature = "program"))]
+pub mod packet;
 #[cfg(not(feature = "program"))]
 pub mod signature;
 #[cfg(not(feature = "program"))]

--- a/sdk/src/packet.rs
+++ b/sdk/src/packet.rs
@@ -1,5 +1,102 @@
+use std::fmt;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
+
 /// Maximum over-the-wire size of a Transaction
 ///   1280 is IPv6 minimum MTU
 ///   40 bytes is the size of the IPv6 header
 ///   8 bytes is the size of the fragment header
 pub const PACKET_DATA_SIZE: usize = 1280 - 40 - 8;
+
+#[derive(Clone, Default, Debug, PartialEq, Serialize, Deserialize)]
+#[repr(C)]
+pub struct Meta {
+    pub size: usize,
+    pub forward: bool,
+    pub repair: bool,
+    pub addr: [u16; 8],
+    pub port: u16,
+    pub v6: bool,
+    pub seed: [u8; 32],
+    pub slot: u64,
+}
+
+#[derive(Clone)]
+#[repr(C)]
+pub struct Packet {
+    pub data: [u8; PACKET_DATA_SIZE],
+    pub meta: Meta,
+}
+
+impl Packet {
+    pub fn new(data: [u8; PACKET_DATA_SIZE], meta: Meta) -> Self {
+        Self { data, meta }
+    }
+}
+
+impl fmt::Debug for Packet {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "Packet {{ size: {:?}, addr: {:?} }}",
+            self.meta.size,
+            self.meta.addr()
+        )
+    }
+}
+
+impl Default for Packet {
+    fn default() -> Packet {
+        Packet {
+            data: unsafe { std::mem::MaybeUninit::uninit().assume_init() },
+            meta: Meta::default(),
+        }
+    }
+}
+
+impl PartialEq for Packet {
+    fn eq(&self, other: &Packet) -> bool {
+        let self_data: &[u8] = self.data.as_ref();
+        let other_data: &[u8] = other.data.as_ref();
+        self.meta == other.meta && self_data[..self.meta.size] == other_data[..other.meta.size]
+    }
+}
+
+impl Meta {
+    pub fn addr(&self) -> SocketAddr {
+        if !self.v6 {
+            let addr = [
+                self.addr[0] as u8,
+                self.addr[1] as u8,
+                self.addr[2] as u8,
+                self.addr[3] as u8,
+            ];
+            let ipv4: Ipv4Addr = From::<[u8; 4]>::from(addr);
+            SocketAddr::new(IpAddr::V4(ipv4), self.port)
+        } else {
+            let ipv6: Ipv6Addr = From::<[u16; 8]>::from(self.addr);
+            SocketAddr::new(IpAddr::V6(ipv6), self.port)
+        }
+    }
+
+    pub fn set_addr(&mut self, a: &SocketAddr) {
+        match *a {
+            SocketAddr::V4(v4) => {
+                let ip = v4.ip().octets();
+                self.addr[0] = u16::from(ip[0]);
+                self.addr[1] = u16::from(ip[1]);
+                self.addr[2] = u16::from(ip[2]);
+                self.addr[3] = u16::from(ip[3]);
+                self.addr[4] = 0;
+                self.addr[5] = 0;
+                self.addr[6] = 0;
+                self.addr[7] = 0;
+                self.v6 = false;
+            }
+            SocketAddr::V6(v6) => {
+                self.addr = v6.ip().segments();
+                self.v6 = true;
+            }
+        }
+        self.port = a.port();
+    }
+}


### PR DESCRIPTION
#### Problem

Iterating on Blocktree (to upgrade RocksDB) requires running the core test suite and the core test suite takes ~100 times longer than the Blocktree test suite.

#### Summary of Changes

* Remove core::result dependency from blocktree, shred, and entry
* Move Packet from core::packet to sdk::packet to alleviate the need to split perf_libs (cc: #6410)
