### PR TITLE
Fail faster on boot up

### DIFF
--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -102,7 +102,7 @@ waitForNodeToInit() {
   echo "--- waiting for node to boot up"
   SECONDS=
   while [[ ! -r $initCompleteFile ]]; do
-    if [[ $SECONDS -ge 720 ]]; then
+    if [[ $SECONDS -ge 120 ]]; then
       echo "^^^ +++"
       echo "Error: $initCompleteFile not found in $SECONDS seconds"
       exit 1


### PR DESCRIPTION
If a validator or bs-leader is going to succeed or fail to boot up, it does so pretty quickly after this counter is started.  I just did a 4-continent GCE test with nodes that booted successfully and they all passed this wait check after 15 seconds.

The existing 12 minute wait has been slowing down my infra testing iterations quite a bit.  @pgarg66 or @mvines is there a case where we legitimately need to wait close to the existing 12-minute mark here?
