### PR TITLE
coverage over multiple packages

### DIFF
--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -12,11 +12,10 @@ source ci/_
 : "${CI_COMMIT:=local}"
 reportName="lcov-${CI_COMMIT:0:9}"
 
-if [[ -n $1 ]]; then
-  crate="--package $1"
-  shift
+if [[ -z $1 ]]; then
+   packages=( --lib --all --exclude solana-local-cluster )
 else
-  crate="--all --exclude solana-local-cluster"
+  packages=( "$@" )
 fi
 
 coverageFlags=(-Zprofile)                # Enable coverage
@@ -37,10 +36,9 @@ fi
 rm -rf target/cov/$reportName
 
 source ci/rust-version.sh nightly
-# shellcheck disable=SC2086 #
-RUST_LOG=solana=trace _ cargo +$rust_nightly test --target-dir target/cov --lib --no-run $crate "$@"
-# shellcheck disable=SC2086 #
-RUST_LOG=solana=trace _ cargo +$rust_nightly test --target-dir target/cov --lib $crate "$@" 2> target/cov/coverage-stderr.log
+
+RUST_LOG=solana=trace _ cargo +$rust_nightly test --target-dir target/cov --no-run "${packages[@]}"
+RUST_LOG=solana=trace _ cargo +$rust_nightly test --target-dir target/cov "${packages[@]}" 2> target/cov/coverage-stderr.log
 
 echo "--- grcov"
 


### PR DESCRIPTION
#### Problem
 while it's desire-able to check coverage on packages standalone, some
 packages cover others from outside with extra dependencies (e.g. solana-stake-api gets meaningful coverage from solana-stake-tests, which can depend on sealevel)

 #### Summary of Changes
 support multiple package args

Fixes #