### PR TITLE
Compute max blockhash age accounting for slot duration

### DIFF
--- a/sdk/src/clock.rs
+++ b/sdk/src/clock.rs
@@ -29,7 +29,8 @@ pub const NUM_CONSECUTIVE_LEADER_SLOTS: u64 = 4;
 pub const MAX_HASH_AGE_IN_SECONDS: usize = 120;
 
 // This must be <= MAX_HASH_AGE_IN_SECONDS, otherwise there's risk for DuplicateSignature errors
-pub const MAX_RECENT_BLOCKHASHES: usize = MAX_HASH_AGE_IN_SECONDS;
+pub const MAX_RECENT_BLOCKHASHES: usize =
+    MAX_HASH_AGE_IN_SECONDS * DEFAULT_TICKS_PER_SECOND as usize / DEFAULT_TICKS_PER_SLOT as usize;
 
 // The maximum age of a blockhash that will be accepted by the leader
 pub const MAX_PROCESSING_AGE: usize = MAX_RECENT_BLOCKHASHES / 2;

--- a/sdk/src/clock.rs
+++ b/sdk/src/clock.rs
@@ -28,7 +28,7 @@ pub const NUM_CONSECUTIVE_LEADER_SLOTS: u64 = 4;
 /// not be processed by the network.
 pub const MAX_HASH_AGE_IN_SECONDS: usize = 120;
 
-// This must be <= MAX_HASH_AGE_IN_SECONDS, otherwise there's risk for DuplicateSignature errors
+// Number of maximum recent blockhashes (one blockhash per slot)
 pub const MAX_RECENT_BLOCKHASHES: usize =
     MAX_HASH_AGE_IN_SECONDS * DEFAULT_TICKS_PER_SECOND as usize / DEFAULT_TICKS_PER_SLOT as usize;
 


### PR DESCRIPTION
#### Problem
The max blockhash age is used as number of slots. The value is currently being set = `MAX_AGE_IN_SECONDS` ignoring that slot duration is not same as 1 second. This reduces the maximum age. 

#### Summary of Changes
Compute the max age accounting for slot duration