### PR TITLE
Reduce kernel networking buffer for rmem and wmem

### DIFF
--- a/net/datacenter-node-install/setup-procfs-knobs.sh
+++ b/net/datacenter-node-install/setup-procfs-knobs.sh
@@ -11,10 +11,10 @@ ensure_env || exit 1
 cat > /etc/sysctl.d/20-solana-node.conf <<EOF
 
 # Solana networking requirements
-net.core.rmem_default=1610612736
-net.core.rmem_max=1610612736
-net.core.wmem_default=1610612736
-net.core.wmem_max=1610612736
+net.core.rmem_default=134217728
+net.core.rmem_max=134217728
+net.core.wmem_default=134217728
+net.core.wmem_max=134217728
 
 # Solana earlyoom setup
 kernel.sysrq=$(( $(cat /proc/sys/kernel/sysrq) | 64 ))

--- a/net/scripts/network-config.sh
+++ b/net/scripts/network-config.sh
@@ -4,11 +4,11 @@ set -ex
 [[ $(uname) = Linux ]] || exit 1
 [[ $USER = root ]] || exit 1
 
-sudo sysctl -w net.core.rmem_default=1610612736
-sudo sysctl -w net.core.rmem_max=1610612736
+sudo sysctl -w net.core.rmem_default=134217728
+sudo sysctl -w net.core.rmem_max=134217728
 
-sudo sysctl -w net.core.wmem_default=1610612736
-sudo sysctl -w net.core.wmem_max=1610612736
+sudo sysctl -w net.core.wmem_default=134217728
+sudo sysctl -w net.core.wmem_max=134217728
 
 echo "MaxAuthTries 60" | sudo tee -a /etc/ssh/sshd_config
 sudo service sshd restart

--- a/scripts/tune-system.sh
+++ b/scripts/tune-system.sh
@@ -32,10 +32,10 @@ sysctl_write() {
 case $(uname) in
 Linux)
   # Reference: https://medium.com/@CameronSparr/increase-os-udp-buffers-to-improve-performance-51d167bb1360
-  sysctl_write net.core.rmem_max 161061273
-  sysctl_write net.core.rmem_default 161061273
-  sysctl_write net.core.wmem_max 161061273
-  sysctl_write net.core.wmem_default 161061273
+  sysctl_write net.core.rmem_max 134217728
+  sysctl_write net.core.rmem_default 134217728
+  sysctl_write net.core.wmem_max 134217728
+  sysctl_write net.core.wmem_default 134217728
   ;;
 *)
   ;;


### PR DESCRIPTION
#### Problem
The kernel network buffers are excessively large. Since we are using MTU sized packets now, the kernel doesn't need to buffer a lot of segmented IP packets to reassemble them. The buffer requirements should be low.

#### Summary of Changes
Reduced buffers from 1.5G to 128M

Fixes #
