### PR TITLE
Add flag to mark a packet as discarded

### DIFF
--- a/core/src/retransmit_stage.rs
+++ b/core/src/retransmit_stage.rs
@@ -69,8 +69,8 @@ fn retransmit(
     let mut compute_turbine_peers_total = 0;
     for mut packets in packet_v {
         for packet in packets.packets.iter_mut() {
-            // skip repair packets
-            if packet.meta.repair {
+            // skip discarded packets and repair packets
+            if packet.meta.discard || packet.meta.repair {
                 total_packets -= 1;
                 continue;
             }

--- a/sdk/src/packet.rs
+++ b/sdk/src/packet.rs
@@ -13,6 +13,7 @@ pub struct Meta {
     pub size: usize,
     pub forward: bool,
     pub repair: bool,
+    pub discard: bool,
     pub addr: [u16; 8],
     pub port: u16,
     pub v6: bool,


### PR DESCRIPTION
#### Problem

Window service needs to track the indexes of packets to figure out which ones to drop before sending them to Retransmit. 
Dropping some packets (via a call to `retain`) will unnecessarily move memory around. 

#### Summary of Changes

Avoid the call to `retain` entirely by adding the ability to mark a packet as `discard` so that Retransmit doesn't process it at all and just skips over it. 

