### PR TITLE
Make accounts hashing benchmark useful

### DIFF
--- a/runtime/benches/accounts.rs
+++ b/runtime/benches/accounts.rs
@@ -63,7 +63,8 @@ fn test_accounts_hash_internal_state(bencher: &mut Bencher) {
     let accounts = Accounts::new(Some("bench_accounts_hash_internal".to_string()));
     let mut pubkeys: Vec<Pubkey> = vec![];
     create_test_accounts(&accounts, &mut pubkeys, 60000, 0);
+    let ancestors = vec![(0, 0)].into_iter().collect();
     bencher.iter(|| {
-        accounts.hash_internal_state(0);
+        accounts.verify_hash_internal_state(0, &ancestors);
     });
 }


### PR DESCRIPTION
#### Problem

hash_internal_state doesn't do much now.

#### Summary of Changes

Benchmark verify_hash_internal_state instead.

Fixes #
