### PR TITLE
Use serde-bytes to serialize u8 efficiently

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2793,6 +2793,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_bytes"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "serde_derive"
 version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3628,6 +3636,7 @@ dependencies = [
  "libc 0.2.64 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_bytes 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-logger 0.20.0",
@@ -3769,6 +3778,7 @@ dependencies = [
  "rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_bytes 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5678,6 +5688,7 @@ dependencies = [
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 "checksum serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)" = "9796c9b7ba2ffe7a9ce53c2287dfc48080f4b2b362fcc245a259b3a7201119dd"
+"checksum serde_bytes 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)" = "45af0182ff64abaeea290235eb67da3825a576c5d53e642c4d5b652e12e6effc"
 "checksum serde_derive 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)" = "4b133a43a1ecd55d4086bd5b4dc6c1751c68b1bfbeba7a5040442022c7e7c02e"
 "checksum serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)" = "2f72eb2a68a7dc3f9a691bfda9305a1c017a6215e5a4545c258500d2099a37c2"
 "checksum serde_urlencoded 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)" = "642dd69105886af2efd227f75a520ec9b44a820d65bc133a9131f7d229fd165a"

--- a/programs/move_loader_api/Cargo.toml
+++ b/programs/move_loader_api/Cargo.toml
@@ -15,6 +15,7 @@ indexmap = "1.1.0"
 libc = "0.2.64"
 log = "0.4.8"
 serde = "1.0.101"
+serde_bytes = "0.11"
 serde_derive = "1.0.101"
 serde_json = "1.0.41"
 solana-logger = { path = "../../logger", version = "0.20.0" }

--- a/programs/move_loader_api/src/account_state.rs
+++ b/programs/move_loader_api/src/account_state.rs
@@ -34,6 +34,12 @@ fn to_array_32(array: &[u8]) -> &[u8; 32] {
     array.try_into().expect("slice with incorrect length")
 }
 
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct ModuleBytes {
+    #[serde(with = "serde_bytes")]
+    pub bytes: Vec<u8>,
+}
+
 /// Type of Libra account held by a Solana account
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub enum LibraAccountState {
@@ -43,8 +49,9 @@ pub enum LibraAccountState {
     CompiledProgram(String),
     /// Serialized verified program bytes
     VerifiedProgram {
+        #[serde(with = "serde_bytes")]
         script_bytes: Vec<u8>,
-        modules_bytes: Vec<Vec<u8>>,
+        modules_bytes: Vec<ModuleBytes>,
     },
     /// Associated genesis account and the write set containing the Libra account data
     User(Pubkey, WriteSet),

--- a/programs/move_loader_api/src/processor.rs
+++ b/programs/move_loader_api/src/processor.rs
@@ -1,4 +1,4 @@
-use crate::account_state::{pubkey_to_address, LibraAccountState};
+use crate::account_state::{pubkey_to_address, LibraAccountState, ModuleBytes};
 use crate::data_store::DataStore;
 use crate::error_mappers::*;
 use crate::id;
@@ -127,7 +127,7 @@ impl MoveProcessor {
                 .as_inner()
                 .serialize(&mut buf)
                 .map_err(map_failure_error)?;
-            modules_bytes.push(buf);
+            modules_bytes.push(ModuleBytes { bytes: buf });
         }
         Ok(LibraAccountState::VerifiedProgram {
             script_bytes,
@@ -172,7 +172,7 @@ impl MoveProcessor {
                     VerifiedScript::deserialize(&script_bytes).map_err(map_vm_binary_error)?;
                 let modules = modules_bytes
                     .iter()
-                    .map(|bytes| VerifiedModule::deserialize(&bytes))
+                    .map(|module_bytes| VerifiedModule::deserialize(&module_bytes.bytes))
                     .collect::<Result<Vec<_>, _>>()
                     .map_err(map_vm_binary_error)?;
 

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -44,6 +44,7 @@ rand = { version = "0.6.5", optional = true }
 rand_chacha = { version = "0.1.1", optional = true }
 rayon = { version = "1.2.0", optional = true }
 serde = "1.0.101"
+serde_bytes = "0.11"
 serde_derive = "1.0.101"
 serde_json = { version = "1.0.41", optional = true }
 sha2 = "0.8.0"

--- a/sdk/src/account.rs
+++ b/sdk/src/account.rs
@@ -9,6 +9,7 @@ pub struct Account {
     /// lamports in the account
     pub lamports: u64,
     /// data held in this account
+    #[serde(with = "serde_bytes")]
     pub data: Vec<u8>,
     /// the program that owns this account. If executable, the program that loads this account.
     pub owner: Pubkey,
@@ -18,7 +19,7 @@ pub struct Account {
     pub rent_epoch: Epoch,
     /// Hash of this account's state, skip serializing as to not expose to external api
     /// Used for keeping the accounts state hash updated.
-    #[serde(skip_serializing, skip_deserializing)]
+    #[serde(skip)]
     pub hash: Hash,
 }
 

--- a/sdk/src/loader_instruction.rs
+++ b/sdk/src/loader_instruction.rs
@@ -24,7 +24,10 @@ pub enum LoaderInstruction {
     /// Invoke the "main" entrypoint with the given data.
     ///
     /// * key[0] - an executable account
-    InvokeMain { data: Vec<u8> },
+    InvokeMain {
+        #[serde(with = "serde_bytes")]
+        data: Vec<u8>,
+    },
 }
 
 pub fn write(

--- a/sdk/src/loader_instruction.rs
+++ b/sdk/src/loader_instruction.rs
@@ -9,7 +9,11 @@ pub enum LoaderInstruction {
     /// * key[0] - the account to write into.
     ///
     /// The transaction must be signed by key[0]
-    Write { offset: u32, bytes: Vec<u8> },
+    Write {
+        offset: u32,
+        #[serde(with = "serde_bytes")]
+        bytes: Vec<u8>,
+    },
 
     /// Finalize an account loaded with program data for execution.
     /// The exact preparation steps is loader specific but on success the loader must set the executable


### PR DESCRIPTION
#### Problem

Serializing a sequence does so element by element which for byte sequences can be expensive.

#### Summary of Changes

Take advantage of serde-bytes for sequences of u8 data which will write the bytes in one operation which considerably speeds up the serialization process.

Fixes #
