### PR TITLE
Adjust crate-features to prevent rebuilds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3340,7 +3340,9 @@ dependencies = [
  "reqwest 0.9.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-ed25519-dalek 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/crate-features/Cargo.toml
+++ b/crate-features/Cargo.toml
@@ -22,5 +22,7 @@ regex-syntax = { version = "0.6.12" }
 reqwest = { version = "0.9.20", default-features = false, features = ["rustls-tls"] }
 serde = { version = "1.0.100", features = ["rc"] }
 solana-ed25519-dalek = { version = "0.2.0", features = ["serde"] }
-syn = { version = "1.0.3", features = ["extra-traits", "full"] }
+syn_0_15 = { package = "syn", version = "0.15.42", features = ["extra-traits", "fold", "full"] }
+syn_1_0 = { package = "syn", version = "1.0.3", features = ["extra-traits", "fold", "full"] }
+tokio = { version = "0.1.22",features=["bytes", "codec", "default", "fs", "io", "mio", "num_cpus", "reactor", "rt-full", "sync", "tcp", "timer", "tokio-codec", "tokio-current-thread", "tokio-executor", "tokio-io", "tokio-io", "tokio-reactor", "tokio-tcp", "tokio-tcp", "tokio-threadpool", "tokio-timer", "tokio-udp", "tokio-uds", "udp", "uds"] }
 winapi = { version = "0.3.8", features=["basetsd", "consoleapi", "errhandlingapi", "fileapi", "handleapi", "impl-debug", "impl-default", "knownfolders", "libloaderapi", "memoryapi", "minwinbase", "minwindef", "ntdef", "ntsecapi", "ntstatus", "objbase", "processenv", "processthreadsapi", "profileapi", "shlobj", "std", "synchapi", "sysinfoapi", "timezoneapi", "utilapiset", "winbase", "wincon", "windef", "winerror", "winnls", "winnt", "winreg", "winsock2", "winuser", "ws2def", "ws2ipdef", "ws2tcpip", "wtypesbase"] }


### PR DESCRIPTION
Unwanted cargo rebuilds are back, adjust crate-features hack to squash them
