### PR TITLE
system_instruction_processor updates

### DIFF
--- a/bench-tps/src/bench.rs
+++ b/bench-tps/src/bench.rs
@@ -306,7 +306,7 @@ fn generate_system_txs(
         .par_iter()
         .map(|(from, to)| {
             (
-                system_transaction::create_user_account(from, &to.pubkey(), 1, *blockhash),
+                system_transaction::transfer_now(from, &to.pubkey(), 1, *blockhash),
                 timestamp(),
             )
         })

--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -851,7 +851,7 @@ mod tests {
         let key = Keypair::new();
         let to = Pubkey::new_rand();
         let blockhash = Hash::default();
-        let tx = system_transaction::create_user_account(&key, &to, 50, blockhash);
+        let tx = system_transaction::transfer_now(&key, &to, 50, blockhash);
 
         let signature = rpc_client.send_transaction(&tx);
         assert_eq!(signature.unwrap(), SIGNATURE.to_string());
@@ -900,7 +900,7 @@ mod tests {
         let key = Keypair::new();
         let to = Pubkey::new_rand();
         let blockhash = Hash::default();
-        let mut tx = system_transaction::create_user_account(&key, &to, 50, blockhash);
+        let mut tx = system_transaction::transfer_now(&key, &to, 50, blockhash);
 
         let result = rpc_client.send_and_confirm_transaction(&mut tx, &[&key]);
         result.unwrap();
@@ -923,8 +923,8 @@ mod tests {
         let blockhash: Hash = "HUu3LwEzGRsUkuJS121jzkPJW39Kq62pXCTmTa1F9jDL"
             .parse()
             .unwrap();
-        let prev_tx = system_transaction::create_user_account(&key, &to, 50, blockhash);
-        let mut tx = system_transaction::create_user_account(&key, &to, 50, blockhash);
+        let prev_tx = system_transaction::transfer_now(&key, &to, 50, blockhash);
+        let mut tx = system_transaction::transfer_now(&key, &to, 50, blockhash);
 
         rpc_client.resign_transaction(&mut tx, &[&key]).unwrap();
 

--- a/core/benches/poh_verify.rs
+++ b/core/benches/poh_verify.rs
@@ -37,7 +37,7 @@ fn bench_poh_verify_transaction_entries(bencher: &mut Bencher) {
 
     let mut ticks: Vec<Entry> = Vec::with_capacity(NUM_ENTRIES);
     for _ in 0..NUM_ENTRIES {
-        let tx = system_transaction::create_user_account(&keypair1, &pubkey1, 42, cur_hash);
+        let tx = system_transaction::transfer_now(&keypair1, &pubkey1, 42, cur_hash);
         ticks.push(next_entry_mut(&mut cur_hash, NUM_HASHES, vec![tx]));
     }
 

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -1095,26 +1095,22 @@ mod tests {
 
             // fund another account so we can send 2 good transactions in a single batch.
             let keypair = Keypair::new();
-            let fund_tx = system_transaction::create_user_account(
-                &mint_keypair,
-                &keypair.pubkey(),
-                2,
-                start_hash,
-            );
+            let fund_tx =
+                system_transaction::transfer_now(&mint_keypair, &keypair.pubkey(), 2, start_hash);
             bank.process_transaction(&fund_tx).unwrap();
 
             // good tx
             let to = Pubkey::new_rand();
-            let tx = system_transaction::create_user_account(&mint_keypair, &to, 1, start_hash);
+            let tx = system_transaction::transfer_now(&mint_keypair, &to, 1, start_hash);
 
             // good tx, but no verify
             let to2 = Pubkey::new_rand();
-            let tx_no_ver = system_transaction::create_user_account(&keypair, &to2, 2, start_hash);
+            let tx_no_ver = system_transaction::transfer_now(&keypair, &to2, 2, start_hash);
 
             // bad tx, AccountNotFound
             let keypair = Keypair::new();
             let to3 = Pubkey::new_rand();
-            let tx_anf = system_transaction::create_user_account(&keypair, &to3, 1, start_hash);
+            let tx_anf = system_transaction::transfer_now(&keypair, &to3, 1, start_hash);
 
             // send 'em over
             let packets = to_packets(&[tx_no_ver, tx_anf, tx]);
@@ -1190,7 +1186,7 @@ mod tests {
 
         // Process a batch that includes a transaction that receives two lamports.
         let alice = Keypair::new();
-        let tx = system_transaction::create_user_account(
+        let tx = system_transaction::transfer_now(
             &mint_keypair,
             &alice.pubkey(),
             2,
@@ -1205,7 +1201,7 @@ mod tests {
         verified_sender.send(packets).unwrap();
 
         // Process a second batch that spends one of those lamports.
-        let tx = system_transaction::create_user_account(
+        let tx = system_transaction::transfer_now(
             &alice,
             &mint_keypair.pubkey(),
             1,
@@ -1611,7 +1607,7 @@ mod tests {
         let bank = Arc::new(Bank::new(&genesis_block));
         let pubkey = Pubkey::new_rand();
 
-        let transactions = vec![system_transaction::create_user_account(
+        let transactions = vec![system_transaction::transfer_now(
             &mint_keypair,
             &pubkey,
             1,

--- a/core/src/blockstream_service.rs
+++ b/core/src/blockstream_service.rs
@@ -138,12 +138,7 @@ mod test {
 
         let keypair = Keypair::new();
         let mut blockhash = entries[3].hash;
-        let tx = system_transaction::create_user_account(
-            &keypair,
-            &keypair.pubkey(),
-            1,
-            Hash::default(),
-        );
+        let tx = system_transaction::transfer_now(&keypair, &keypair.pubkey(), 1, Hash::default());
         let entry = Entry::new(&mut blockhash, 1, vec![tx]);
         blockhash = entry.hash;
         entries.push(entry);

--- a/core/src/broadcast_stage/broadcast_utils.rs
+++ b/core/src/broadcast_stage/broadcast_utils.rs
@@ -87,7 +87,7 @@ mod tests {
             ..
         } = create_genesis_block(2);
         let bank0 = Arc::new(Bank::new(&genesis_block));
-        let tx = system_transaction::create_user_account(
+        let tx = system_transaction::transfer_now(
             &mint_keypair,
             &Pubkey::new_rand(),
             1,

--- a/core/src/chacha.rs
+++ b/core/src/chacha.rs
@@ -78,12 +78,12 @@ mod tests {
     use solana_ledger::blocktree::Blocktree;
     use solana_ledger::entry::Entry;
     use solana_sdk::hash::{hash, Hash, Hasher};
+    use solana_sdk::pubkey::Pubkey;
     use solana_sdk::signature::KeypairUtil;
     use solana_sdk::system_transaction;
     use std::fs::remove_file;
     use std::fs::File;
     use std::io::Read;
-    use std::path::Path;
     use std::sync::Arc;
 
     fn make_tiny_deterministic_test_entries(num: usize) -> Vec<Entry> {
@@ -112,6 +112,18 @@ mod tests {
             .collect()
     }
 
+    use std::{env, fs::create_dir_all, path::PathBuf};
+    fn tmp_file_path(name: &str) -> PathBuf {
+        let out_dir = env::var("FARF_DIR").unwrap_or_else(|_| "farf".to_string());
+        let mut path = PathBuf::new();
+        path.push(out_dir);
+        path.push("tmp");
+        create_dir_all(&path).unwrap();
+
+        path.push(format!("{}-{}", name, Pubkey::new_rand()));
+        path
+    }
+
     #[test]
     fn test_encrypt_ledger() {
         solana_logger::setup();
@@ -120,7 +132,7 @@ mod tests {
         let ticks_per_slot = 16;
         let slots_per_segment = 32;
         let blocktree = Arc::new(Blocktree::open(&ledger_path).unwrap());
-        let out_path = Path::new("test_chacha_encrypt_file_output.txt.enc");
+        let out_path = tmp_file_path("test_encrypt_ledger");
 
         let seed = [2u8; 32];
         let mut rnd = GenKeys::new(seed);
@@ -144,9 +156,9 @@ mod tests {
             "abcd1234abcd1234abcd1234abcd1234 abcd1234abcd1234abcd1234abcd1234
                             abcd1234abcd1234abcd1234abcd1234 abcd1234abcd1234abcd1234abcd1234"
         );
-        chacha_cbc_encrypt_ledger(&blocktree, 0, slots_per_segment as u64, out_path, &mut key)
+        chacha_cbc_encrypt_ledger(&blocktree, 0, slots_per_segment as u64, &out_path, &mut key)
             .unwrap();
-        let mut out_file = File::open(out_path).unwrap();
+        let mut out_file = File::open(&out_path).unwrap();
         let mut buf = vec![];
         let size = out_file.read_to_end(&mut buf).unwrap();
         let mut hasher = Hasher::default();
@@ -158,6 +170,6 @@ mod tests {
             .unwrap();
 
         assert_eq!(hasher.result(), golden);
-        remove_file(out_path).unwrap();
+        remove_file(&out_path).unwrap();
     }
 }

--- a/core/src/chacha.rs
+++ b/core/src/chacha.rs
@@ -101,7 +101,7 @@ mod tests {
                 Entry::new_mut(
                     &mut id,
                     &mut num_hashes,
-                    vec![system_transaction::create_user_account(
+                    vec![system_transaction::transfer_now(
                         &keypair,
                         &keypair.pubkey(),
                         1,

--- a/core/src/chacha.rs
+++ b/core/src/chacha.rs
@@ -153,7 +153,7 @@ mod tests {
         hasher.hash(&buf[..size]);
 
         //  golden needs to be updated if blob stuff changes....
-        let golden: Hash = "F3Grk43JpRUPeCuB8CbYovjxq2Bh77bh4uLB2UXKBFN8"
+        let golden: Hash = "BdmY3efqu7zbnFuGRAeFANwa35HkDdQ7hwhYez3xGXiM"
             .parse()
             .unwrap();
 

--- a/core/src/packet.rs
+++ b/core/src/packet.rs
@@ -602,7 +602,7 @@ mod tests {
     fn test_to_packets() {
         let keypair = Keypair::new();
         let hash = Hash::new(&[1; 32]);
-        let tx = system_transaction::create_user_account(&keypair, &keypair.pubkey(), 1, hash);
+        let tx = system_transaction::transfer_now(&keypair, &keypair.pubkey(), 1, hash);
         let rv = to_packets(&vec![tx.clone(); 1]);
         assert_eq!(rv.len(), 1);
         assert_eq!(rv[0].packets.len(), 1);

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -952,12 +952,7 @@ mod test {
                 blockhash,
                 1,
                 vec![
-                    system_transaction::create_user_account(
-                        &keypair1,
-                        &keypair2.pubkey(),
-                        2,
-                        *blockhash,
-                    ), // should be fine,
+                    system_transaction::transfer_now(&keypair1, &keypair2.pubkey(), 2, *blockhash), // should be fine,
                     system_transaction::transfer(
                         &missing_keypair,
                         &missing_keypair2.pubkey(),
@@ -985,7 +980,7 @@ mod test {
                 // User wrong blockhash so that the entry causes an entry verification failure
                 &bad_hash,
                 1,
-                vec![system_transaction::create_user_account(
+                vec![system_transaction::transfer_now(
                     &keypair1,
                     &keypair2.pubkey(),
                     2,

--- a/core/src/rpc_pubsub.rs
+++ b/core/src/rpc_pubsub.rs
@@ -391,12 +391,7 @@ mod tests {
             None,
         );
 
-        let tx = system_transaction::create_user_account(
-            &alice,
-            &contract_funds.pubkey(),
-            51,
-            blockhash,
-        );
+        let tx = system_transaction::transfer_now(&alice, &contract_funds.pubkey(), 51, blockhash);
         process_transaction_and_notify(&bank_forks, &tx, &rpc.subscriptions).unwrap();
 
         let ixs = budget_instruction::when_signed(
@@ -440,7 +435,7 @@ mod tests {
             assert_eq!(serde_json::to_string(&expected).unwrap(), response);
         }
 
-        let tx = system_transaction::create_user_account(&alice, &witness.pubkey(), 1, blockhash);
+        let tx = system_transaction::transfer_now(&alice, &witness.pubkey(), 1, blockhash);
         process_transaction_and_notify(&bank_forks, &tx, &rpc.subscriptions).unwrap();
         sleep(Duration::from_millis(200));
         let ix = budget_instruction::apply_signature(

--- a/core/src/test_tx.rs
+++ b/core/src/test_tx.rs
@@ -10,7 +10,7 @@ pub fn test_tx() -> Transaction {
     let keypair1 = Keypair::new();
     let pubkey1 = keypair1.pubkey();
     let zero = Hash::default();
-    system_transaction::create_user_account(&keypair1, &pubkey1, 42, zero)
+    system_transaction::transfer_now(&keypair1, &pubkey1, 42, zero)
 }
 
 pub fn test_multisig_tx() -> Transaction {

--- a/core/tests/bank_forks.rs
+++ b/core/tests/bank_forks.rs
@@ -224,12 +224,8 @@ mod tests {
             );
             let slot = bank.slot();
             let key1 = Keypair::new().pubkey();
-            let tx = system_transaction::transfer_now(
-                &mint_keypair,
-                &key1,
-                1,
-                genesis_block.hash(),
-            );
+            let tx =
+                system_transaction::transfer_now(&mint_keypair, &key1, 1, genesis_block.hash());
             assert_eq!(bank.process_transaction(&tx), Ok(()));
             bank.freeze();
             bank_forks.insert(bank);

--- a/core/tests/bank_forks.rs
+++ b/core/tests/bank_forks.rs
@@ -156,7 +156,7 @@ mod tests {
             4,
             |bank, mint_keypair| {
                 let key1 = Keypair::new().pubkey();
-                let tx = system_transaction::create_user_account(
+                let tx = system_transaction::transfer_now(
                     &mint_keypair,
                     &key1,
                     1,
@@ -224,7 +224,7 @@ mod tests {
             );
             let slot = bank.slot();
             let key1 = Keypair::new().pubkey();
-            let tx = system_transaction::create_user_account(
+            let tx = system_transaction::transfer_now(
                 &mint_keypair,
                 &key1,
                 1,

--- a/drone/src/drone.rs
+++ b/drone/src/drone.rs
@@ -121,7 +121,7 @@ impl Drone {
                     );
                     info!("Requesting airdrop of {} to {:?}", lamports, to);
 
-                    let create_instruction = system_instruction::create_user_account(
+                    let create_instruction = system_instruction::transfer_now(
                         &self.mint_keypair.pubkey(),
                         &to,
                         lamports,
@@ -419,7 +419,7 @@ mod tests {
 
         let keypair = Keypair::new();
         let expected_instruction =
-            system_instruction::create_user_account(&keypair.pubkey(), &to, lamports);
+            system_instruction::transfer_now(&keypair.pubkey(), &to, lamports);
         let message = Message::new(vec![expected_instruction]);
         let expected_tx = Transaction::new(&[&keypair], message, blockhash);
         let expected_bytes = serialize(&expected_tx).unwrap();

--- a/drone/src/drone.rs
+++ b/drone/src/drone.rs
@@ -388,14 +388,7 @@ mod tests {
 
         assert_eq!(message.instructions.len(), 1);
         let instruction: SystemInstruction = deserialize(&message.instructions[0].data).unwrap();
-        assert_eq!(
-            instruction,
-            SystemInstruction::CreateAccount {
-                lamports: 2,
-                space: 0,
-                program_id: Pubkey::default()
-            }
-        );
+        assert_eq!(instruction, SystemInstruction::Transfer { lamports: 2 });
 
         let mint = Keypair::new();
         drone = Drone::new(mint, None, Some(1));

--- a/drone/src/drone_mock.rs
+++ b/drone/src/drone_mock.rs
@@ -18,7 +18,7 @@ pub fn request_airdrop_transaction(
         let key = Keypair::new();
         let to = Pubkey::new_rand();
         let blockhash = Hash::default();
-        let tx = system_transaction::create_user_account(&key, &to, lamports, blockhash);
+        let tx = system_transaction::transfer_now(&key, &to, lamports, blockhash);
         Ok(tx)
     }
 }

--- a/drone/tests/local-drone.rs
+++ b/drone/tests/local-drone.rs
@@ -13,8 +13,7 @@ fn test_local_drone() {
     let to = Pubkey::new_rand();
     let lamports = 50;
     let blockhash = Hash::new(&to.as_ref());
-    let create_instruction =
-        system_instruction::create_user_account(&keypair.pubkey(), &to, lamports);
+    let create_instruction = system_instruction::transfer_now(&keypair.pubkey(), &to, lamports);
     let message = Message::new(vec![create_instruction]);
     let expected_tx = Transaction::new(&[&keypair], message, blockhash);
 

--- a/ledger/.gitignore
+++ b/ledger/.gitignore
@@ -1,0 +1,2 @@
+/target/
+/farf/

--- a/ledger/src/entry.rs
+++ b/ledger/src/entry.rs
@@ -375,8 +375,8 @@ mod tests {
 
         // First, verify entries
         let keypair = Keypair::new();
-        let tx0 = system_transaction::create_user_account(&keypair, &keypair.pubkey(), 0, zero);
-        let tx1 = system_transaction::create_user_account(&keypair, &keypair.pubkey(), 1, zero);
+        let tx0 = system_transaction::transfer_now(&keypair, &keypair.pubkey(), 0, zero);
+        let tx1 = system_transaction::transfer_now(&keypair, &keypair.pubkey(), 1, zero);
         let mut e0 = Entry::new(&zero, 0, vec![tx0.clone(), tx1.clone()]);
         assert!(e0.verify(&zero));
 
@@ -426,7 +426,7 @@ mod tests {
     fn test_next_entry_panic() {
         let zero = Hash::default();
         let keypair = Keypair::new();
-        let tx = system_transaction::create_user_account(&keypair, &keypair.pubkey(), 0, zero);
+        let tx = system_transaction::transfer_now(&keypair, &keypair.pubkey(), 0, zero);
         next_entry(&zero, 0, vec![tx]);
     }
 

--- a/local_cluster/src/local_cluster.rs
+++ b/local_cluster/src/local_cluster.rs
@@ -411,12 +411,8 @@ impl LocalCluster {
     ) -> u64 {
         trace!("getting leader blockhash");
         let (blockhash, _fee_calculator) = client.get_recent_blockhash().unwrap();
-        let mut tx = system_transaction::create_user_account(
-            &source_keypair,
-            dest_pubkey,
-            lamports,
-            blockhash,
-        );
+        let mut tx =
+            system_transaction::transfer_now(&source_keypair, dest_pubkey, lamports, blockhash);
         info!(
             "executing transfer of {} from {} to {}",
             lamports,

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -62,7 +62,7 @@ name = "atty"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.64 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -78,7 +78,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "backtrace-sys 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.64 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -89,7 +89,7 @@ version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cc 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.64 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -248,7 +248,7 @@ name = "chrono"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.64 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -488,7 +488,7 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -543,7 +543,7 @@ version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "crc32fast 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.64 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "miniz_oxide 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -621,7 +621,7 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.64 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasi 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -777,7 +777,7 @@ name = "iovec"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.64 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -808,7 +808,7 @@ version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "getrandom 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.64 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -839,7 +839,7 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.64"
+version = "0.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -883,7 +883,7 @@ name = "memmap"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.64 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -926,12 +926,22 @@ dependencies = [
  "fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.64 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "mio-uds"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -951,7 +961,7 @@ version = "0.2.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.64 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1009,7 +1019,7 @@ name = "num_cpus"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.64 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1039,7 +1049,7 @@ name = "parking_lot_core"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.64 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1132,7 +1142,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.64 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1144,7 +1154,7 @@ version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "autocfg 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.64 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_hc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1162,7 +1172,7 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "getrandom 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.64 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_chacha 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_hc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1236,7 +1246,7 @@ name = "rand_jitter"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.64 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1248,7 +1258,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.64 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1377,7 +1387,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cc 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.64 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "spin 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "untrusted 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "web-sys 0.3.27 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1463,6 +1473,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_bytes"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "serde_derive"
 version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1531,7 +1549,7 @@ version = "0.20.0"
 dependencies = [
  "bincode 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.64 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-logger 0.20.0",
@@ -1694,13 +1712,15 @@ dependencies = [
  "either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.64 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex-syntax 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.9.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-ed25519-dalek 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1721,7 +1741,7 @@ dependencies = [
 name = "solana-logger"
 version = "0.20.0"
 dependencies = [
- "env_logger 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1737,7 +1757,7 @@ dependencies = [
 name = "solana-metrics"
 version = "0.20.0"
 dependencies = [
- "env_logger 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.9.22 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1764,7 +1784,7 @@ dependencies = [
  "fs_extra 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.64 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "libloading 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "memmap 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1809,6 +1829,7 @@ dependencies = [
  "rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_bytes 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1900,7 +1921,7 @@ dependencies = [
  "combine 2.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "elfkit 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "hash32 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.64 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1994,7 +2015,7 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cc 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.64 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2003,7 +2024,7 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.64 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
  "remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2039,7 +2060,7 @@ name = "time"
 version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.64 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2053,13 +2074,18 @@ dependencies = [
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-current-thread 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-fs 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-reactor 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-sync 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-tcp 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-threadpool 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-udp 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-uds 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2070,6 +2096,16 @@ dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tokio-codec"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2088,6 +2124,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tokio-fs"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-threadpool 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2178,6 +2224,37 @@ dependencies = [
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tokio-udp"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-reactor 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tokio-uds"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio-uds 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-reactor 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2549,7 +2626,7 @@ dependencies = [
 "checksum encoding_rs 0.8.20 (registry+https://github.com/rust-lang/crates.io-index)" = "87240518927716f79692c2ed85bfe6e98196d18c6401ec75355760233a7e12e9"
 "checksum enum-primitive-derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e2b90e520ec62c1864c8c78d637acbfe8baf5f63240f2fb8165b8325c07812dd"
 "checksum env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)" = "15b0a4d2e39f8420210be8b27eeda28029729e2fd4291019455016c348240c38"
-"checksum env_logger 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "39ecdb7dd54465526f0a56d666e3b2dd5f3a218665a030b6e4ad9e70fa95d8fa"
+"checksum env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
 "checksum error-chain 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3ab49e9dcb602294bc42f9a7dfc9bc6e936fca4418ea300dbfb84fe16de0b7d9"
 "checksum failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "795bd83d3abeb9220f257e597aa0080a508b27533824adf336529648f6abf7e2"
 "checksum failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ea1063915fd7ef4309e222a5a07cf9c319fb9c7836b1f89b85458672dbb127e1"
@@ -2589,7 +2666,7 @@ dependencies = [
 "checksum js-sys 0.3.27 (registry+https://github.com/rust-lang/crates.io-index)" = "1efc4f2a556c58e79c5500912e221dd826bec64ff4aabd8ce71ccef6da02d7d4"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-"checksum libc 0.2.64 (registry+https://github.com/rust-lang/crates.io-index)" = "74dfca3d9957906e8d1e6a0b641dc9a59848e793f1da2165889fd4f62d10d79c"
+"checksum libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)" = "1a31a0627fdf1f6a39ec0dd577e101440b7db22672c0901fe00a9a6fbb5c24e8"
 "checksum libloading 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f2b111a074963af1d37a139918ac6d49ad1d0d5e47f72fd55388619691a7d753"
 "checksum lock_api 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "62ebf1391f6acad60e5c8b43706dde4582df75c06698ab44511d15016bc2442c"
 "checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
@@ -2601,6 +2678,7 @@ dependencies = [
 "checksum mime_guess 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1a0ed03949aef72dbdf3116a383d7b38b4768e6f960528cd6a6044aa9ed68599"
 "checksum miniz_oxide 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7108aff85b876d06f22503dcce091e29f76733b2bfdd91eebce81f5e68203a10"
 "checksum mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)" = "83f51996a3ed004ef184e16818edc51fadffe8e7ca68be67f9dee67d84d0ff23"
+"checksum mio-uds 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)" = "966257a94e196b11bb43aca423754d87429960a768de9414f3691d6957abf125"
 "checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
 "checksum net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88"
 "checksum nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9667ddcc6cc8a43afc9b7917599d7216aa09c463919ea32c59ed6cac8bc945"
@@ -2661,6 +2739,7 @@ dependencies = [
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 "checksum serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)" = "9796c9b7ba2ffe7a9ce53c2287dfc48080f4b2b362fcc245a259b3a7201119dd"
+"checksum serde_bytes 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)" = "45af0182ff64abaeea290235eb67da3825a576c5d53e642c4d5b652e12e6effc"
 "checksum serde_derive 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)" = "4b133a43a1ecd55d4086bd5b4dc6c1751c68b1bfbeba7a5040442022c7e7c02e"
 "checksum serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)" = "2f72eb2a68a7dc3f9a691bfda9305a1c017a6215e5a4545c258500d2099a37c2"
 "checksum serde_urlencoded 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)" = "642dd69105886af2efd227f75a520ec9b44a820d65bc133a9131f7d229fd165a"
@@ -2689,8 +2768,10 @@ dependencies = [
 "checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
 "checksum tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)" = "5a09c0b5bb588872ab2f09afa13ee6e9dac11e10a0ec9e8e3ba39a5a5d530af6"
 "checksum tokio-buf 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8fb220f46c53859a4b7ec083e41dec9778ff0b1851c0942b211edb89e0ccdc46"
+"checksum tokio-codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5c501eceaf96f0e1793cf26beb63da3d11c738c4a943fdf3746d81d64684c39f"
 "checksum tokio-current-thread 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "d16217cad7f1b840c5a97dfb3c43b0c871fef423a6e8d2118c604e843662a443"
 "checksum tokio-executor 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "0f27ee0e6db01c5f0b2973824547ce7e637b2ed79b891a9677b0de9bd532b6ac"
+"checksum tokio-fs 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "3fe6dc22b08d6993916647d108a1a7d15b9cd29c4f4496c62b92c45b5041b7af"
 "checksum tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "5090db468dad16e1a7a54c8c67280c5e4b544f3d3e018f0b913b400261f85926"
 "checksum tokio-reactor 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "6af16bfac7e112bea8b0442542161bfc41cbfa4466b580bdda7d18cb88b911ce"
 "checksum tokio-rustls 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e3ccd44da3ebf1a7afa996a47d9a4d67e212de399a87e91f6bfb331c8d8f1a7"
@@ -2698,6 +2779,8 @@ dependencies = [
 "checksum tokio-tcp 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1d14b10654be682ac43efee27401d792507e30fd8d26389e1da3b185de2e4119"
 "checksum tokio-threadpool 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)" = "90ca01319dea1e376a001e8dc192d42ebde6dd532532a5bad988ac37db365b19"
 "checksum tokio-timer 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "f2106812d500ed25a4f38235b9cae8f78a09edf43203e16e59c3b769a342a60e"
+"checksum tokio-udp 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "f02298505547f73e60f568359ef0d016d5acd6e830ab9bc7c4a5b3403440121b"
+"checksum tokio-uds 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "037ffc3ba0e12a0ab4aca92e5234e0dedeb48fddf6ccd260f1f150a36a9f2445"
 "checksum try-lock 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e604eb7b43c06650e854be16a2a03155743d3752dd1c943f6829e26b7a36e382"
 "checksum try_from 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "283d3b89e1368717881a9d51dad843cc435380d8109c9e47d38780a324698d8b"
 "checksum typenum 1.11.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6d2783fe2d6b8c1101136184eb41be8b1ad379e4657050b8aaff0c79ee7575f9"

--- a/programs/storage_program/tests/storage_processor.rs
+++ b/programs/storage_program/tests/storage_processor.rs
@@ -592,15 +592,11 @@ fn test_bank_storage() {
     let x2 = x * 2;
     let storage_blockhash = hash(&[x2]);
 
-    bank_client
-        .transfer(10, &mint_keypair, &replicator_pubkey)
-        .unwrap();
-
     let message = Message::new(storage_instruction::create_storage_account(
         &mint_pubkey,
         &Pubkey::default(),
         &replicator_pubkey,
-        1,
+        11,
         StorageAccountType::Replicator,
     ));
     bank_client.send_message(&[&mint_keypair], message).unwrap();

--- a/programs/storage_program/tests/storage_processor.rs
+++ b/programs/storage_program/tests/storage_processor.rs
@@ -472,11 +472,7 @@ fn init_storage_accounts(
     replicator_accounts_to_create: &[&Pubkey],
     lamports: u64,
 ) {
-    let mut ixs: Vec<_> = vec![system_instruction::create_user_account(
-        &mint.pubkey(),
-        owner,
-        1,
-    )];
+    let mut ixs: Vec<_> = vec![system_instruction::transfer_now(&mint.pubkey(), owner, 1)];
     ixs.append(
         &mut validator_accounts_to_create
             .into_iter()

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1839,7 +1839,7 @@ mod tests {
         let dest = Keypair::new();
 
         // source with 0 program context
-        let tx = system_transaction::create_user_account(
+        let tx = system_transaction::transfer_now(
             &mint_keypair,
             &dest.pubkey(),
             2,
@@ -2128,13 +2128,13 @@ mod tests {
         let (genesis_block, mint_keypair) = create_genesis_block(2);
         let bank = Bank::new(&genesis_block);
         let keypair = Keypair::new();
-        let tx0 = system_transaction::create_user_account(
+        let tx0 = system_transaction::transfer_now(
             &mint_keypair,
             &keypair.pubkey(),
             2,
             genesis_block.hash(),
         );
-        let tx1 = system_transaction::create_user_account(
+        let tx1 = system_transaction::transfer_now(
             &keypair,
             &mint_keypair.pubkey(),
             1,
@@ -2206,7 +2206,7 @@ mod tests {
         let alice = Keypair::new();
         let bob = Keypair::new();
 
-        let tx1 = system_transaction::create_user_account(
+        let tx1 = system_transaction::transfer_now(
             &mint_keypair,
             &alice.pubkey(),
             1,
@@ -2975,7 +2975,7 @@ mod tests {
 
         let keypair1 = Keypair::new();
         let keypair2 = Keypair::new();
-        let fail_tx = system_transaction::create_user_account(
+        let fail_tx = system_transaction::transfer_now(
             &keypair1,
             &keypair2.pubkey(),
             1,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1231,7 +1231,7 @@ impl Bank {
     /// `n` lamports where `blockhash` is the last Entry ID observed by the client.
     pub fn transfer(&self, n: u64, keypair: &Keypair, to: &Pubkey) -> Result<Signature> {
         let blockhash = self.last_blockhash();
-        let tx = system_transaction::create_user_account(keypair, to, n, blockhash);
+        let tx = system_transaction::transfer(keypair, to, n, blockhash);
         let signature = tx.signatures[0];
         self.process_transaction(&tx).map(|_| signature)
     }

--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -71,7 +71,7 @@ fn verify_instruction(
     if pre.owner != post.owner && (!is_debitable || !system_program::check_id(&program_id)) {
         return Err(InstructionError::ModifiedProgramId);
     }
-    // For accounts unassigned to the program, the individual balance of each accounts cannot decrease.
+    // An account not assigned to the program cannot have its balance decrease.
     if *program_id != post.owner && pre.lamports > post.lamports {
         return Err(InstructionError::ExternalAccountLamportSpend);
     }

--- a/runtime/src/storage_utils.rs
+++ b/runtime/src/storage_utils.rs
@@ -110,26 +110,20 @@ pub(crate) mod tests {
         let bank = Arc::new(bank);
         let bank_client = BankClient::new_shared(&bank);
 
-        bank_client
-            .transfer(10, &mint_keypair, &replicator_pubkey)
-            .unwrap();
         let message = Message::new(storage_instruction::create_storage_account(
             &mint_pubkey,
             &Pubkey::default(),
             &replicator_pubkey,
-            1,
+            11,
             StorageAccountType::Replicator,
         ));
         bank_client.send_message(&[&mint_keypair], message).unwrap();
 
-        bank_client
-            .transfer(10, &mint_keypair, &validator_pubkey)
-            .unwrap();
         let message = Message::new(storage_instruction::create_storage_account(
             &mint_pubkey,
             &Pubkey::default(),
             &validator_pubkey,
-            1,
+            11,
             StorageAccountType::Validator,
         ));
         bank_client.send_message(&[&mint_keypair], message).unwrap();

--- a/sdk-c/src/lib.rs
+++ b/sdk-c/src/lib.rs
@@ -501,7 +501,7 @@ mod tests {
         let key = KeypairNative::new();
         let to = Pubkey::new_rand();
         let blockhash = Hash::default();
-        let tx = system_transaction::create_user_account(&key, &to, 50, blockhash);
+        let tx = system_transaction::transfer_now(&key, &to, 50, blockhash);
         let serialized = serialize(&tx).unwrap();
         let tx = Box::new(Transaction::from_native(tx));
         let tx = Box::into_raw(tx);
@@ -520,7 +520,7 @@ mod tests {
         let key = KeypairNative::new();
         let to = Pubkey::new_rand();
         let blockhash = Hash::default();
-        let tx = system_transaction::create_user_account(&key, &to, 50, blockhash);
+        let tx = system_transaction::transfer_now(&key, &to, 50, blockhash);
         let serialized = serialize(&tx).unwrap();
         let deserialized;
         unsafe {
@@ -559,8 +559,7 @@ mod tests {
         let key_native = KeypairNative::new();
         let to = Pubkey::new_rand();
         let blockhash = Hash::default();
-        let mut tx_native =
-            system_transaction::create_user_account(&key_native, &to, 50, blockhash);
+        let mut tx_native = system_transaction::transfer_now(&key_native, &to, 50, blockhash);
         let tx = Box::into_raw(Box::new(Transaction::from_native(tx_native.clone())));
         let key = Keypair::from_native(&key_native);
         let tx2;

--- a/sdk/src/system_instruction.rs
+++ b/sdk/src/system_instruction.rs
@@ -69,10 +69,17 @@ pub fn create_account(
     )
 }
 
-/// Create and sign a transaction to create a system account
-pub fn create_user_account(from_pubkey: &Pubkey, to_pubkey: &Pubkey, lamports: u64) -> Instruction {
-    let program_id = system_program::id();
-    create_account(from_pubkey, to_pubkey, lamports, 0, &program_id)
+/// transfer with target as credit-debit
+pub fn transfer_now(from_pubkey: &Pubkey, to_pubkey: &Pubkey, lamports: u64) -> Instruction {
+    let account_metas = vec![
+        AccountMeta::new(*from_pubkey, true),
+        AccountMeta::new(*to_pubkey, false),
+    ];
+    Instruction::new(
+        system_program::id(),
+        &SystemInstruction::Transfer { lamports },
+        account_metas,
+    )
 }
 
 pub fn assign(from_pubkey: &Pubkey, program_id: &Pubkey) -> Instruction {

--- a/sdk/src/system_instruction.rs
+++ b/sdk/src/system_instruction.rs
@@ -69,7 +69,7 @@ pub fn create_account(
     )
 }
 
-/// transfer with target as credit-debit
+/// transfer with to as credit-debit
 pub fn transfer_now(from_pubkey: &Pubkey, to_pubkey: &Pubkey, lamports: u64) -> Instruction {
     let account_metas = vec![
         AccountMeta::new(*from_pubkey, true),

--- a/sdk/src/system_instruction.rs
+++ b/sdk/src/system_instruction.rs
@@ -8,7 +8,6 @@ use num_derive::{FromPrimitive, ToPrimitive};
 pub enum SystemError {
     AccountAlreadyInUse,
     ResultWithNegativeLamports,
-    SourceNotSystemAccount,
     InvalidProgramId,
     InvalidAccountId,
 }

--- a/sdk/src/system_transaction.rs
+++ b/sdk/src/system_transaction.rs
@@ -1,11 +1,12 @@
 //! The `system_transaction` module provides functionality for creating system transactions.
 
-use crate::hash::Hash;
-use crate::pubkey::Pubkey;
-use crate::signature::{Keypair, KeypairUtil};
-use crate::system_instruction;
-use crate::system_program;
-use crate::transaction::Transaction;
+use crate::{
+    hash::Hash,
+    pubkey::Pubkey,
+    signature::{Keypair, KeypairUtil},
+    system_instruction,
+    transaction::Transaction,
+};
 
 /// Create and sign new SystemInstruction::CreateAccount transaction
 pub fn create_account(
@@ -23,15 +24,17 @@ pub fn create_account(
     Transaction::new_signed_instructions(&[from_keypair], instructions, recent_blockhash)
 }
 
-/// Create and sign a transaction to create a system account
-pub fn create_user_account(
+/// Create and sign new system_instruction::Transfer transaction, but don't use a CO "to"
+pub fn transfer_now(
     from_keypair: &Keypair,
     to: &Pubkey,
     lamports: u64,
     recent_blockhash: Hash,
 ) -> Transaction {
-    let program_id = system_program::id();
-    create_account(from_keypair, to, recent_blockhash, lamports, 0, &program_id)
+    let from_pubkey = from_keypair.pubkey();
+    let transfer_instruction = system_instruction::transfer_now(&from_pubkey, to, lamports);
+    let instructions = vec![transfer_instruction];
+    Transaction::new_signed_instructions(&[from_keypair], instructions, recent_blockhash)
 }
 
 /// Create and sign new system_instruction::Assign transaction


### PR DESCRIPTION
#### Problem
 create_account doesn't check if the 'to' account is empty before
 assigning the owner, which would allow an attacker to steal any balance by
 assigning to their own program

 #### Summary of Changes
 * verify that `to` is empty before assigning, this is a band-aid, need to sign `to` #6449 
 * add support for zero transfers
 * increased test coverage
 * removed redundant check for source program id (is already enforced by runtime)
 * whacked create_system_account(), which tests were using like transfer(), expecting that to work
      multiple times (which this band-aid now prevents)


Fixes #