### PR TITLE
Check that transaction fee-payer is a debitable account

### DIFF
--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -371,7 +371,12 @@ pub fn process_create_stake_account(
         lamports,
     );
     let (recent_blockhash, fee_calculator) = rpc_client.get_recent_blockhash()?;
-    let mut tx = Transaction::new_signed_instructions(&[&config.keypair], ixs, recent_blockhash);
+    let mut tx = Transaction::new_signed_with_payer(
+        ixs,
+        Some(&config.keypair.pubkey()),
+        &[&config.keypair],
+        recent_blockhash,
+    );
     check_account_for_fee(rpc_client, config, &fee_calculator, &tx.message)?;
     let result = rpc_client.send_and_confirm_transaction(&mut tx, &[&config.keypair]);
     log_instruction_custom_error::<SystemError>(result)
@@ -396,7 +401,12 @@ pub fn process_stake_authorize(
         stake_authorize,          // stake or withdraw
     )];
 
-    let mut tx = Transaction::new_signed_instructions(&[&config.keypair], ixs, recent_blockhash);
+    let mut tx = Transaction::new_signed_with_payer(
+        ixs,
+        Some(&config.keypair.pubkey()),
+        &[&config.keypair],
+        recent_blockhash,
+    );
     check_account_for_fee(rpc_client, config, &fee_calculator, &tx.message)?;
     let result = rpc_client.send_and_confirm_transaction(&mut tx, &[&config.keypair]);
     log_instruction_custom_error::<StakeError>(result)
@@ -412,7 +422,12 @@ pub fn process_deactivate_stake_account(
         stake_account_pubkey,
         &config.keypair.pubkey(),
     )];
-    let mut tx = Transaction::new_signed_instructions(&[&config.keypair], ixs, recent_blockhash);
+    let mut tx = Transaction::new_signed_with_payer(
+        ixs,
+        Some(&config.keypair.pubkey()),
+        &[&config.keypair],
+        recent_blockhash,
+    );
     check_account_for_fee(rpc_client, config, &fee_calculator, &tx.message)?;
     let result = rpc_client.send_and_confirm_transaction(&mut tx, &[&config.keypair]);
     log_instruction_custom_error::<StakeError>(result)
@@ -434,7 +449,12 @@ pub fn process_withdraw_stake(
         lamports,
     )];
 
-    let mut tx = Transaction::new_signed_instructions(&[&config.keypair], ixs, recent_blockhash);
+    let mut tx = Transaction::new_signed_with_payer(
+        ixs,
+        Some(&config.keypair.pubkey()),
+        &[&config.keypair],
+        recent_blockhash,
+    );
     check_account_for_fee(rpc_client, config, &fee_calculator, &tx.message)?;
     let result = rpc_client.send_and_confirm_transaction(&mut tx, &[&config.keypair]);
     log_instruction_custom_error::<StakeError>(result)
@@ -587,7 +607,12 @@ pub fn process_delegate_stake(
         vote_account_pubkey,
     )];
 
-    let mut tx = Transaction::new_signed_instructions(&[&config.keypair], ixs, recent_blockhash);
+    let mut tx = Transaction::new_signed_with_payer(
+        ixs,
+        Some(&config.keypair.pubkey()),
+        &[&config.keypair],
+        recent_blockhash,
+    );
     check_account_for_fee(rpc_client, config, &fee_calculator, &tx.message)?;
     let result = rpc_client.send_and_confirm_transaction(&mut tx, &[&config.keypair]);
     log_instruction_custom_error::<StakeError>(result)

--- a/cli/src/vote.rs
+++ b/cli/src/vote.rs
@@ -271,7 +271,12 @@ pub fn process_vote_authorize(
         vote_authorize,           // vote or withdraw
     )];
 
-    let mut tx = Transaction::new_signed_instructions(&[&config.keypair], ixs, recent_blockhash);
+    let mut tx = Transaction::new_signed_with_payer(
+        ixs,
+        Some(&config.keypair.pubkey()),
+        &[&config.keypair],
+        recent_blockhash,
+    );
     check_account_for_fee(rpc_client, config, &fee_calculator, &tx.message)?;
     let result = rpc_client.send_and_confirm_transaction(&mut tx, &[&config.keypair]);
     log_instruction_custom_error::<VoteError>(result)


### PR DESCRIPTION
#### Problem
Currently, all credit-debit checks happen inside message_processor::process_message. However, transaction fees get charged upstream in accounts::load_tx_accounts. This means that if a credit-only account is the first signer, it gets successfully charged the fee if it can afford it, potentially adding non-determinism to the chain.

#### Summary of Changes
- Add debitable check of first signer account (fee payer) to sigveryify::do_get_offsets so that it gets executed before any signature verification or transaction deserialization occurs
- Also updates relevant solana-cli stake and vote transactions to use Transaction::new_signed_with_payer to ensure they don't fail this new processing.

Fixes #6339 
