### PR TITLE
Setup each bench-tps account with 1 SOL by default

### DIFF
--- a/bench-tps/src/cli.rs
+++ b/bench-tps/src/cli.rs
@@ -4,7 +4,7 @@ use solana_sdk::fee_calculator::FeeCalculator;
 use solana_sdk::signature::{read_keypair_file, Keypair, KeypairUtil};
 use std::{net::SocketAddr, process::exit, time::Duration};
 
-const NUM_LAMPORTS_PER_ACCOUNT_DEFAULT: u64 = 64 * 1024;
+const NUM_LAMPORTS_PER_ACCOUNT_DEFAULT: u64 = solana_sdk::native_token::SOL_LAMPORTS;
 
 /// Holds the configuration for a single run of the benchmark
 pub struct Config {


### PR DESCRIPTION
The previous default of 0xFFFF lamports is insufficient as of #6436 

At 50k TPS 1 SOL should enable each account to pay for ~100,000 transactions, which will be good for ~27 hours if each account transacts once a second.