### PR TITLE
Cleanup register_tick special handling

### DIFF
--- a/ledger/src/blocktree_processor.rs
+++ b/ledger/src/blocktree_processor.rs
@@ -943,7 +943,7 @@ pub mod tests {
         assert_eq!(bank_forks_info.len(), 1);
         assert_eq!(bank_forks_info[0], BankForksInfo { bank_slot: 0 });
         let bank = bank_forks[0].clone();
-        assert_eq!(bank.tick_height(), 0);
+        assert_eq!(bank.tick_height(), 1);
     }
 
     #[test]


### PR DESCRIPTION
#### Problem
There seems to be unnecessary special handling in register_tick for slot 0 and when ticks_per_slot is 1. Special handling for slot 0 was removed here: https://github.com/solana-labs/solana/pull/6263 but did not clean up this method

#### Solution
Remove special handling
