### PR TITLE
Skip ledger verification on restart to avoid timing out net/

### DIFF
--- a/ci/testnet-manager.sh
+++ b/ci/testnet-manager.sh
@@ -216,7 +216,7 @@ maybe_deploy_software() {
   (
     echo "--- net.sh restart"
     set -x
-    time net/net.sh restart --skip-setup -t "$CHANNEL_OR_TAG" "$arg"
+    time net/net.sh restart --skip-setup -t "$CHANNEL_OR_TAG" --skip-ledger-verify "$arg"
   ) || ok=false
   if ! $ok; then
     net/net.sh logs


### PR DESCRIPTION
cc: b4ed88e0f

Example failure from 11am yesterday: https://buildkite.com/solana-labs/testnet-management/builds/55403