### PR TITLE
Make instruction data opaque to runtime

### DIFF
--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -1777,6 +1777,7 @@ dependencies = [
 name = "solana-runtime"
 version = "0.20.0"
 dependencies = [
+ "backtrace 0.3.37 (registry+https://github.com/rust-lang/crates.io-index)",
  "bincode 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bv 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/programs/bpf_loader_api/src/lib.rs
+++ b/programs/bpf_loader_api/src/lib.rs
@@ -167,8 +167,12 @@ pub fn process_instruction(
             }
         }
     } else {
-        warn!("Invalid instruction data: {:?}", ix_data);
-        return Err(InstructionError::GenericError);
+        warn!(
+            "Invalid instruction data ({:?}): {:?}",
+            ix_data.len(),
+            ix_data
+        );
+        return Err(InstructionError::InvalidInstructionData);
     }
     Ok(())
 }

--- a/programs/failure_program/tests/failure.rs
+++ b/programs/failure_program/tests/failure.rs
@@ -1,8 +1,8 @@
 use solana_runtime::bank::Bank;
 use solana_runtime::bank_client::BankClient;
-use solana_runtime::loader_utils::create_invoke_instruction;
-use solana_sdk::client::SyncClient;
+use solana_runtime::loader_utils::run_program;
 use solana_sdk::genesis_block::create_genesis_block;
+use solana_sdk::instruction::AccountMeta;
 use solana_sdk::instruction::InstructionError;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::KeypairUtil;
@@ -14,15 +14,20 @@ fn test_program_native_failure() {
     let program_id = Pubkey::new_rand();
     let bank = Bank::new(&genesis_block);
     bank.register_native_instruction_processor("solana_failure_program", &program_id);
+    let bank_client = BankClient::new(bank);
 
     // Call user program
-    let instruction = create_invoke_instruction(alice_keypair.pubkey(), program_id, &1u8);
-    let bank_client = BankClient::new(bank);
+    let account_metas = vec![AccountMeta::new(alice_keypair.pubkey(), true)];
     assert_eq!(
-        bank_client
-            .send_instruction(&alice_keypair, instruction)
-            .unwrap_err()
-            .unwrap(),
+        run_program(
+            &bank_client,
+            &alice_keypair,
+            &program_id,
+            account_metas,
+            &1u8,
+        )
+        .unwrap_err()
+        .unwrap(),
         TransactionError::InstructionError(0, InstructionError::GenericError)
     );
 }

--- a/runtime/benches/bank.rs
+++ b/runtime/benches/bank.rs
@@ -154,25 +154,25 @@ fn do_bench_transactions(
 }
 
 #[bench]
-// #[ignore]
+#[ignore]
 fn bench_bank_sync_process_builtin_transactions(bencher: &mut Bencher) {
     do_bench_transactions(bencher, &sync_bencher, &create_builtin_transactions);
 }
 
 #[bench]
-// #[ignore]
+#[ignore]
 fn bench_bank_sync_process_native_loader_transactions(bencher: &mut Bencher) {
     do_bench_transactions(bencher, &sync_bencher, &create_native_loader_transactions);
 }
 
 #[bench]
-// #[ignore]
+#[ignore]
 fn bench_bank_async_process_builtin_transactions(bencher: &mut Bencher) {
     do_bench_transactions(bencher, &async_bencher, &create_builtin_transactions);
 }
 
 #[bench]
-// #[ignore]
+#[ignore]
 fn bench_bank_async_process_native_loader_transactions(bencher: &mut Bencher) {
     do_bench_transactions(bencher, &async_bencher, &create_native_loader_transactions);
 }

--- a/runtime/benches/bank.rs
+++ b/runtime/benches/bank.rs
@@ -5,12 +5,13 @@ extern crate test;
 use log::*;
 use solana_runtime::bank::*;
 use solana_runtime::bank_client::BankClient;
-use solana_runtime::loader_utils::create_invoke_instruction;
 use solana_sdk::account::KeyedAccount;
 use solana_sdk::client::AsyncClient;
 use solana_sdk::client::SyncClient;
 use solana_sdk::genesis_block::create_genesis_block;
+use solana_sdk::instruction::AccountMeta;
 use solana_sdk::instruction::InstructionError;
+use solana_sdk::loader_instruction;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::{Keypair, KeypairUtil};
 use solana_sdk::transaction::Transaction;
@@ -52,7 +53,8 @@ pub fn create_builtin_transactions(
                 .transfer(10_000, &mint_keypair, &rando0.pubkey())
                 .expect(&format!("{}:{}", line!(), file!()));
 
-            let instruction = create_invoke_instruction(rando0.pubkey(), program_id, &1u8);
+            let account_metas = vec![AccountMeta::new(rando0.pubkey(), true)];
+            let instruction = loader_instruction::invoke_main(&program_id, &1u8, account_metas);
             let (blockhash, _fee_calculator) = bank_client.get_recent_blockhash().unwrap();
             Transaction::new_signed_instructions(&[&rando0], vec![instruction], blockhash)
         })
@@ -74,7 +76,8 @@ pub fn create_native_loader_transactions(
                 .transfer(10_000, &mint_keypair, &rando0.pubkey())
                 .expect(&format!("{}:{}", line!(), file!()));
 
-            let instruction = create_invoke_instruction(rando0.pubkey(), program_id, &1u8);
+            let account_metas = vec![AccountMeta::new(rando0.pubkey(), true)];
+            let instruction = loader_instruction::invoke_main(&program_id, &1u8, account_metas);
             let (blockhash, _fee_calculator) = bank_client.get_recent_blockhash().unwrap();
             Transaction::new_signed_instructions(&[&rando0], vec![instruction], blockhash)
         })
@@ -151,25 +154,25 @@ fn do_bench_transactions(
 }
 
 #[bench]
-#[ignore]
+// #[ignore]
 fn bench_bank_sync_process_builtin_transactions(bencher: &mut Bencher) {
     do_bench_transactions(bencher, &sync_bencher, &create_builtin_transactions);
 }
 
 #[bench]
-#[ignore]
+// #[ignore]
 fn bench_bank_sync_process_native_loader_transactions(bencher: &mut Bencher) {
     do_bench_transactions(bencher, &sync_bencher, &create_native_loader_transactions);
 }
 
 #[bench]
-#[ignore]
+// #[ignore]
 fn bench_bank_async_process_builtin_transactions(bencher: &mut Bencher) {
     do_bench_transactions(bencher, &async_bencher, &create_builtin_transactions);
 }
 
 #[bench]
-#[ignore]
+// #[ignore]
 fn bench_bank_async_process_native_loader_transactions(bencher: &mut Bencher) {
     do_bench_transactions(bencher, &async_bencher, &create_native_loader_transactions);
 }

--- a/runtime/src/append_vec.rs
+++ b/runtime/src/append_vec.rs
@@ -13,8 +13,8 @@ use std::{
     sync::Mutex,
 };
 
-//Data is aligned at the next 64 byte offset. Without alignment loading the memory may
-//crash on some architectures.
+// Data is aligned at the next 64 byte offset. Without alignment loading the memory may
+// crash on some architectures.
 macro_rules! align_up {
     ($addr: expr, $align: expr) => {
         ($addr + ($align - 1)) & !($align - 1)

--- a/runtime/tests/noop.rs
+++ b/runtime/tests/noop.rs
@@ -1,8 +1,8 @@
 use solana_runtime::bank::Bank;
 use solana_runtime::bank_client::BankClient;
-use solana_runtime::loader_utils::create_invoke_instruction;
-use solana_sdk::client::SyncClient;
+use solana_runtime::loader_utils::run_program;
 use solana_sdk::genesis_block::create_genesis_block;
+use solana_sdk::instruction::AccountMeta;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::KeypairUtil;
 
@@ -14,11 +14,16 @@ fn test_program_native_noop() {
     let program_id = Pubkey::new_rand();
     let bank = Bank::new(&genesis_block);
     bank.register_native_instruction_processor("solana_noop_program", &program_id);
+    let bank_client = BankClient::new(bank);
 
     // Call user program
-    let instruction = create_invoke_instruction(alice_keypair.pubkey(), program_id, &1u8);
-    let bank_client = BankClient::new(bank);
-    bank_client
-        .send_instruction(&alice_keypair, instruction)
-        .unwrap();
+    let account_metas = vec![AccountMeta::new(alice_keypair.pubkey(), true)];
+    run_program(
+        &bank_client,
+        &alice_keypair,
+        &program_id,
+        account_metas,
+        &1u8,
+    )
+    .unwrap();
 }

--- a/sdk/src/loader_instruction.rs
+++ b/sdk/src/loader_instruction.rs
@@ -1,6 +1,8 @@
 use crate::instruction::{AccountMeta, Instruction};
 use crate::pubkey::Pubkey;
 use crate::sysvar::rent;
+use bincode::serialize;
+use serde::Serialize;
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub enum LoaderInstruction {
@@ -34,6 +36,7 @@ pub enum LoaderInstruction {
     },
 }
 
+/// Create an instruction to write program data into an account
 pub fn write(
     account_pubkey: &Pubkey,
     program_id: &Pubkey,
@@ -48,10 +51,23 @@ pub fn write(
     )
 }
 
+/// Create an instruction to finalize a program data account, once finalized it can no longer be modified
 pub fn finalize(account_pubkey: &Pubkey, program_id: &Pubkey) -> Instruction {
     let account_metas = vec![
         AccountMeta::new(*account_pubkey, true),
         AccountMeta::new(rent::id(), false),
     ];
     Instruction::new(*program_id, &LoaderInstruction::Finalize, account_metas)
+}
+
+// Create an instruction to Invoke a program's "main" entrypoint with the given data
+pub fn invoke_main<T: Serialize>(
+    program_id: &Pubkey,
+    data: &T,
+    account_metas: Vec<AccountMeta>,
+) -> Instruction {
+    let ix_data = LoaderInstruction::InvokeMain {
+        data: serialize(data).unwrap().to_vec(),
+    };
+    Instruction::new(*program_id, &ix_data, account_metas)
 }


### PR DESCRIPTION
#### Problem

Solana runtime requires that all loaders implement `LoaderInstruction` and wraps the caller's data with `InvokeMain`.  Doing so constrains program writers from extending `LoaderInstruction` and artificially restricts all non-native programs to using `LoaderInstruction`

#### Summary of Changes

Pass the instruction data opaquely to the loader.

Doing so will allow loaders to extend LoaderInstruction via procedural derive macros or even define their own loader instruction enums.

One example is the Move loader which in addition to `Write`, `Finalize`, and `InvokeMain`, also implements `CreateGenesis`.  Instead of overloading the data in `InvokeMain` the Move loader could extend `LoaderInstruction` to add `CreateGenessis`.  Or the Move loader would be free to define its own `MoveLoaderInstruction`.

This change is in conjunction with https://github.com/solana-labs/solana-web3.js/pull/533

Fixes #
