### PR TITLE
Exclude net/log in rsync script

### DIFF
--- a/net/net.sh
+++ b/net/net.sh
@@ -389,6 +389,7 @@ startCommon() {
   fi
   [[ -z "$externalNodeSshKey" ]] || ssh-copy-id -f -i "$externalNodeSshKey" "${sshOptions[@]}" "solana@$ipAddress"
   rsync -vPrc -e "ssh ${sshOptions[*]}" \
+    --exclude 'net/log' \
     "$SOLANA_ROOT"/{fetch-perf-libs.sh,scripts,net,multinode-demo} \
     "$ipAddress":~/solana/
 }


### PR DESCRIPTION
#### Problem

`net/net.sh restart` takes too long

#### Summary of Changes

don't rsync the whole net/log directory

Fixes #
