### PR TITLE
solana-cli: selectively require keypair

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -190,7 +190,7 @@ pub fn parse_command(
     let response = match matches.subcommand() {
         // Cluster Query Commands
         ("cluster-version", Some(_matches)) => Ok(CliCommand::ClusterVersion),
-        ("fees", Some(_fees_matches)) => Ok(CliCommand::Fees),
+        ("fees", Some(_matches)) => Ok(CliCommand::Fees),
         ("get-epoch-info", Some(_matches)) => Ok(CliCommand::GetEpochInfo),
         ("get-genesis-blockhash", Some(_matches)) => Ok(CliCommand::GetGenesisBlockhash),
         ("get-slot", Some(_matches)) => Ok(CliCommand::GetSlot),
@@ -198,11 +198,8 @@ pub fn parse_command(
         ("ping", Some(matches)) => parse_cluster_ping(matches),
         ("show-validators", Some(matches)) => parse_show_validators(matches),
         // Program Deployment
-        ("deploy", Some(deploy_matches)) => Ok(CliCommand::Deploy(
-            deploy_matches
-                .value_of("program_location")
-                .unwrap()
-                .to_string(),
+        ("deploy", Some(matches)) => Ok(CliCommand::Deploy(
+            matches.value_of("program_location").unwrap().to_string(),
         )),
         // Stake Commands
         ("create-stake-account", Some(matches)) => parse_stake_create_account(pubkey, matches),
@@ -249,9 +246,9 @@ pub fn parse_command(
         ("show-vote-account", Some(matches)) => parse_vote_get_account_command(matches),
         ("uptime", Some(matches)) => parse_vote_uptime_command(matches),
         // Wallet Commands
-        ("address", Some(_address_matches)) => Ok(CliCommand::Address),
-        ("airdrop", Some(airdrop_matches)) => {
-            let drone_port = airdrop_matches
+        ("address", Some(_matches)) => Ok(CliCommand::Address),
+        ("airdrop", Some(matches)) => {
+            let drone_port = matches
                 .value_of("drone_port")
                 .unwrap()
                 .parse()
@@ -272,9 +269,9 @@ pub fn parse_command(
             } else {
                 None
             };
-            let lamports = amount_of(airdrop_matches, "amount", "unit").expect("Invalid amount");
-            let use_lamports_unit = airdrop_matches.value_of("unit").is_some()
-                && airdrop_matches.value_of("unit").unwrap() == "lamports";
+            let lamports = amount_of(matches, "amount", "unit").expect("Invalid amount");
+            let use_lamports_unit = matches.value_of("unit").is_some()
+                && matches.value_of("unit").unwrap() == "lamports";
             Ok(CliCommand::Airdrop {
                 drone_host,
                 drone_port,
@@ -282,44 +279,42 @@ pub fn parse_command(
                 use_lamports_unit,
             })
         }
-        ("balance", Some(balance_matches)) => {
-            let pubkey = pubkey_of(&balance_matches, "pubkey").unwrap_or(*pubkey);
-            let use_lamports_unit = balance_matches.is_present("lamports");
+        ("balance", Some(matches)) => {
+            let pubkey = pubkey_of(&matches, "pubkey").unwrap_or(*pubkey);
+            let use_lamports_unit = matches.is_present("lamports");
             Ok(CliCommand::Balance {
                 pubkey,
                 use_lamports_unit,
             })
         }
-        ("cancel", Some(cancel_matches)) => {
-            let process_id = value_of(cancel_matches, "process_id").unwrap();
+        ("cancel", Some(matches)) => {
+            let process_id = value_of(matches, "process_id").unwrap();
             Ok(CliCommand::Cancel(process_id))
         }
-        ("confirm", Some(confirm_matches)) => {
-            match confirm_matches.value_of("signature").unwrap().parse() {
-                Ok(signature) => Ok(CliCommand::Confirm(signature)),
-                _ => {
-                    eprintln!("{}", confirm_matches.usage());
-                    Err(CliError::BadParameter("Invalid signature".to_string()))
-                }
+        ("confirm", Some(matches)) => match matches.value_of("signature").unwrap().parse() {
+            Ok(signature) => Ok(CliCommand::Confirm(signature)),
+            _ => {
+                eprintln!("{}", matches.usage());
+                Err(CliError::BadParameter("Invalid signature".to_string()))
             }
-        }
-        ("pay", Some(pay_matches)) => {
-            let lamports = amount_of(pay_matches, "amount", "unit").expect("Invalid amount");
-            let to = value_of(&pay_matches, "to").unwrap_or(*pubkey);
-            let timestamp = if pay_matches.is_present("timestamp") {
+        },
+        ("pay", Some(matches)) => {
+            let lamports = amount_of(matches, "amount", "unit").expect("Invalid amount");
+            let to = value_of(&matches, "to").unwrap_or(*pubkey);
+            let timestamp = if matches.is_present("timestamp") {
                 // Parse input for serde_json
-                let date_string = if !pay_matches.value_of("timestamp").unwrap().contains('Z') {
-                    format!("\"{}Z\"", pay_matches.value_of("timestamp").unwrap())
+                let date_string = if !matches.value_of("timestamp").unwrap().contains('Z') {
+                    format!("\"{}Z\"", matches.value_of("timestamp").unwrap())
                 } else {
-                    format!("\"{}\"", pay_matches.value_of("timestamp").unwrap())
+                    format!("\"{}\"", matches.value_of("timestamp").unwrap())
                 };
                 Some(serde_json::from_str(&date_string)?)
             } else {
                 None
             };
-            let timestamp_pubkey = value_of(&pay_matches, "timestamp_pubkey");
-            let witnesses = values_of(&pay_matches, "witness");
-            let cancelable = if pay_matches.is_present("cancelable") {
+            let timestamp_pubkey = value_of(&matches, "timestamp_pubkey");
+            let witnesses = values_of(&matches, "witness");
+            let cancelable = if matches.is_present("cancelable") {
                 Some(*pubkey)
             } else {
                 None
@@ -344,24 +339,20 @@ pub fn parse_command(
                 use_lamports_unit,
             })
         }
-        ("send-signature", Some(sig_matches)) => {
-            let to = value_of(&sig_matches, "to").unwrap();
-            let process_id = value_of(&sig_matches, "process_id").unwrap();
+        ("send-signature", Some(matches)) => {
+            let to = value_of(&matches, "to").unwrap();
+            let process_id = value_of(&matches, "process_id").unwrap();
             Ok(CliCommand::Witness(to, process_id))
         }
-        ("send-timestamp", Some(timestamp_matches)) => {
-            let to = value_of(&timestamp_matches, "to").unwrap();
-            let process_id = value_of(&timestamp_matches, "process_id").unwrap();
-            let dt = if timestamp_matches.is_present("datetime") {
+        ("send-timestamp", Some(matches)) => {
+            let to = value_of(&matches, "to").unwrap();
+            let process_id = value_of(&matches, "process_id").unwrap();
+            let dt = if matches.is_present("datetime") {
                 // Parse input for serde_json
-                let date_string = if !timestamp_matches
-                    .value_of("datetime")
-                    .unwrap()
-                    .contains('Z')
-                {
-                    format!("\"{}Z\"", timestamp_matches.value_of("datetime").unwrap())
+                let date_string = if !matches.value_of("datetime").unwrap().contains('Z') {
+                    format!("\"{}Z\"", matches.value_of("datetime").unwrap())
                 } else {
-                    format!("\"{}\"", timestamp_matches.value_of("datetime").unwrap())
+                    format!("\"{}\"", matches.value_of("datetime").unwrap())
                 };
                 serde_json::from_str(&date_string)?
             } else {

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -1313,78 +1313,7 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                         .help("Display balance in lamports instead of SOL"),
                 ),
         )
-        .subcommand(
-            SubCommand::with_name("validator-info")
-                .about("Publish/get Validator info on Solana")
-                .subcommand(
-                    SubCommand::with_name("publish")
-                        .about("Publish Validator info on Solana")
-                        .arg(
-                            Arg::with_name("info_pubkey")
-                                .short("p")
-                                .long("info-pubkey")
-                                .value_name("PUBKEY")
-                                .takes_value(true)
-                                .validator(is_pubkey)
-                                .help("The pubkey of the Validator info account to update"),
-                        )
-                        .arg(
-                            Arg::with_name("name")
-                                .index(1)
-                                .value_name("NAME")
-                                .takes_value(true)
-                                .required(true)
-                                .validator(is_short_field)
-                                .help("Validator name"),
-                        )
-                        .arg(
-                            Arg::with_name("website")
-                                .short("w")
-                                .long("website")
-                                .value_name("URL")
-                                .takes_value(true)
-                                .validator(check_url)
-                                .help("Validator website url"),
-                        )
-                        .arg(
-                            Arg::with_name("keybase_username")
-                                .short("n")
-                                .long("keybase")
-                                .value_name("USERNAME")
-                                .takes_value(true)
-                                .validator(is_short_field)
-                                .help("Validator Keybase username"),
-                        )
-                        .arg(
-                            Arg::with_name("details")
-                                .short("d")
-                                .long("details")
-                                .value_name("DETAILS")
-                                .takes_value(true)
-                                .validator(check_details_length)
-                                .help("Validator description")
-                        )
-                        .arg(
-                            Arg::with_name("force")
-                                .long("force")
-                                .takes_value(false)
-                                .hidden(true) // Don't document this argument to discourage its use
-                                .help("Override keybase username validity check"),
-                        ),
-                )
-                .subcommand(
-                    SubCommand::with_name("get")
-                        .about("Get and parse Solana Validator info")
-                        .arg(
-                            Arg::with_name("info_pubkey")
-                                .index(1)
-                                .value_name("PUBKEY")
-                                .takes_value(true)
-                                .validator(is_pubkey)
-                                .help("The pubkey of the Validator info account; without this argument, returns all"),
-                        ),
-                )
-        )
+        .validator_info_subcommands()
         .vote_subcommands()
 }
 

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -88,7 +88,7 @@ impl ClusterQuerySubCommands for App<'_, '_> {
     }
 }
 
-pub fn parse_cluster_ping(matches: &ArgMatches<'_>) -> Result<CliCommand, CliError> {
+pub fn parse_cluster_ping(matches: &ArgMatches<'_>) -> Result<(CliCommand, bool), CliError> {
     let interval = Duration::from_secs(value_t_or_exit!(matches, "interval", u64));
     let count = if matches.is_present("count") {
         Some(value_t_or_exit!(matches, "count", u64))
@@ -96,17 +96,20 @@ pub fn parse_cluster_ping(matches: &ArgMatches<'_>) -> Result<CliCommand, CliErr
         None
     };
     let timeout = Duration::from_secs(value_t_or_exit!(matches, "timeout", u64));
-    Ok(CliCommand::Ping {
-        interval,
-        count,
-        timeout,
-    })
+    Ok((
+        CliCommand::Ping {
+            interval,
+            count,
+            timeout,
+        },
+        true,
+    ))
 }
 
-pub fn parse_show_validators(matches: &ArgMatches<'_>) -> Result<CliCommand, CliError> {
+pub fn parse_show_validators(matches: &ArgMatches<'_>) -> Result<(CliCommand, bool), CliError> {
     let use_lamports_unit = matches.is_present("lamports");
 
-    Ok(CliCommand::ShowValidators { use_lamports_unit })
+    Ok((CliCommand::ShowValidators { use_lamports_unit }, false))
 }
 
 pub fn process_cluster_version(rpc_client: &RpcClient, config: &CliConfig) -> ProcessResult {
@@ -358,69 +361,70 @@ pub fn process_show_validators(rpc_client: &RpcClient, use_lamports_unit: bool) 
 mod tests {
     use super::*;
     use crate::cli::{app, parse_command};
-    use solana_sdk::pubkey::Pubkey;
 
     #[test]
     fn test_parse_command() {
         let test_commands = app("test", "desc", "version");
-        let pubkey = Pubkey::new_rand();
 
         let test_cluster_version = test_commands
             .clone()
             .get_matches_from(vec!["test", "cluster-version"]);
         assert_eq!(
-            parse_command(&pubkey, &test_cluster_version).unwrap(),
-            CliCommand::ClusterVersion
+            parse_command(&test_cluster_version).unwrap(),
+            (CliCommand::ClusterVersion, false)
         );
 
         let test_fees = test_commands.clone().get_matches_from(vec!["test", "fees"]);
         assert_eq!(
-            parse_command(&pubkey, &test_fees).unwrap(),
-            CliCommand::Fees
+            parse_command(&test_fees).unwrap(),
+            (CliCommand::Fees, false)
         );
 
         let test_get_epoch_info = test_commands
             .clone()
             .get_matches_from(vec!["test", "get-epoch-info"]);
         assert_eq!(
-            parse_command(&pubkey, &test_get_epoch_info).unwrap(),
-            CliCommand::GetEpochInfo
+            parse_command(&test_get_epoch_info).unwrap(),
+            (CliCommand::GetEpochInfo, false)
         );
 
         let test_get_genesis_blockhash = test_commands
             .clone()
             .get_matches_from(vec!["test", "get-genesis-blockhash"]);
         assert_eq!(
-            parse_command(&pubkey, &test_get_genesis_blockhash).unwrap(),
-            CliCommand::GetGenesisBlockhash
+            parse_command(&test_get_genesis_blockhash).unwrap(),
+            (CliCommand::GetGenesisBlockhash, false)
         );
 
         let test_get_slot = test_commands
             .clone()
             .get_matches_from(vec!["test", "get-slot"]);
         assert_eq!(
-            parse_command(&pubkey, &test_get_slot).unwrap(),
-            CliCommand::GetSlot
+            parse_command(&test_get_slot).unwrap(),
+            (CliCommand::GetSlot, false)
         );
 
         let test_transaction_count = test_commands
             .clone()
             .get_matches_from(vec!["test", "get-transaction-count"]);
         assert_eq!(
-            parse_command(&pubkey, &test_transaction_count).unwrap(),
-            CliCommand::GetTransactionCount
+            parse_command(&test_transaction_count).unwrap(),
+            (CliCommand::GetTransactionCount, false)
         );
 
         let test_ping = test_commands
             .clone()
             .get_matches_from(vec!["test", "ping", "-i", "1", "-c", "2", "-t", "3"]);
         assert_eq!(
-            parse_command(&pubkey, &test_ping).unwrap(),
-            CliCommand::Ping {
-                interval: Duration::from_secs(1),
-                count: Some(2),
-                timeout: Duration::from_secs(3),
-            }
+            parse_command(&test_ping).unwrap(),
+            (
+                CliCommand::Ping {
+                    interval: Duration::from_secs(1),
+                    count: Some(2),
+                    timeout: Duration::from_secs(3),
+                },
+                true
+            )
         );
     }
     // TODO: Add process tests

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,7 +1,7 @@
 use clap::{crate_description, crate_name, crate_version, Arg, ArgGroup, ArgMatches, SubCommand};
 use console::style;
 use solana_cli::{
-    cli::{app, parse_command, process_command, CliConfig, CliError},
+    cli::{app, parse_command, process_command, CliCommandInfo, CliConfig, CliError},
     config::{self, Config},
     display::{println_name_value, println_name_value_or},
     input_validators::is_url,
@@ -80,9 +80,12 @@ pub fn parse_args(matches: &ArgMatches<'_>) -> Result<CliConfig, Box<dyn error::
         default.json_rpc_url
     };
 
-    let (command, need_keypair) = parse_command(&matches)?;
+    let CliCommandInfo {
+        command,
+        require_keypair,
+    } = parse_command(&matches)?;
 
-    let (keypair, keypair_path) = if need_keypair {
+    let (keypair, keypair_path) = if require_keypair {
         let keypair_path = if matches.is_present("keypair") {
             matches.value_of("keypair").unwrap().to_string()
         } else if config.keypair != "" {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -6,7 +6,7 @@ use solana_cli::{
     display::{println_name_value, println_name_value_or},
     input_validators::is_url,
 };
-use solana_sdk::signature::{read_keypair_file, KeypairUtil};
+use solana_sdk::signature::read_keypair_file;
 use std::error;
 
 fn parse_settings(matches: &ArgMatches<'_>) -> Result<bool, Box<dyn error::Error>> {
@@ -18,7 +18,7 @@ fn parse_settings(matches: &ArgMatches<'_>) -> Result<bool, Box<dyn error::Error
                 if let Some(field) = subcommand_matches.value_of("specific_setting") {
                     let (value, default_value) = match field {
                         "url" => (config.url, default_cli_config.json_rpc_url),
-                        "keypair" => (config.keypair, default_cli_config.keypair_path),
+                        "keypair" => (config.keypair, default_cli_config.keypair_path.unwrap()),
                         _ => unreachable!(),
                     };
                     println_name_value_or(&format!("* {}:", field), &value, &default_value);
@@ -28,7 +28,7 @@ fn parse_settings(matches: &ArgMatches<'_>) -> Result<bool, Box<dyn error::Error
                     println_name_value_or(
                         "* keypair:",
                         &config.keypair,
-                        &default_cli_config.keypair_path,
+                        &default_cli_config.keypair_path.unwrap(),
                     );
                 }
             } else {
@@ -80,34 +80,41 @@ pub fn parse_args(matches: &ArgMatches<'_>) -> Result<CliConfig, Box<dyn error::
         default.json_rpc_url
     };
 
-    let keypair_path = if matches.is_present("keypair") {
-        matches.value_of("keypair").unwrap().to_string()
-    } else if config.keypair != "" {
-        config.keypair
+    let (command, need_keypair) = parse_command(&matches)?;
+
+    let (keypair, keypair_path) = if need_keypair {
+        let keypair_path = if matches.is_present("keypair") {
+            matches.value_of("keypair").unwrap().to_string()
+        } else if config.keypair != "" {
+            config.keypair
+        } else {
+            let default = CliConfig::default();
+            let maybe_keypair_path = default.keypair_path.unwrap();
+            if !std::path::Path::new(&maybe_keypair_path).exists() {
+                return Err(CliError::KeypairFileNotFound(
+                    "Generate a new keypair with `solana-keygen new`".to_string(),
+                )
+                .into());
+            }
+            maybe_keypair_path
+        };
+        let keypair = read_keypair_file(&keypair_path).or_else(|err| {
+            Err(CliError::BadParameter(format!(
+                "{}: Unable to open keypair file: {}",
+                err, keypair_path
+            )))
+        })?;
+        (keypair, Some(keypair_path.to_string()))
     } else {
         let default = CliConfig::default();
-        if !std::path::Path::new(&default.keypair_path).exists() {
-            return Err(CliError::KeypairFileNotFound(
-                "Generate a new keypair with `solana-keygen new`".to_string(),
-            )
-            .into());
-        }
-        default.keypair_path
+        (default.keypair, None)
     };
-    let keypair = read_keypair_file(&keypair_path).or_else(|err| {
-        Err(CliError::BadParameter(format!(
-            "{}: Unable to open keypair file: {}",
-            err, keypair_path
-        )))
-    })?;
-
-    let command = parse_command(&keypair.pubkey(), &matches)?;
 
     Ok(CliConfig {
         command,
         json_rpc_url,
         keypair,
-        keypair_path: keypair_path.to_string(),
+        keypair_path,
         rpc_client: None,
     })
 }

--- a/cli/src/storage.rs
+++ b/cli/src/storage.rs
@@ -100,40 +100,56 @@ impl StorageSubCommands for App<'_, '_> {
 
 pub fn parse_storage_create_archiver_account(
     matches: &ArgMatches<'_>,
-) -> Result<CliCommand, CliError> {
+) -> Result<(CliCommand, bool), CliError> {
     let account_owner = pubkey_of(matches, "storage_account_owner").unwrap();
     let storage_account_pubkey = pubkey_of(matches, "storage_account_pubkey").unwrap();
-    Ok(CliCommand::CreateStorageAccount {
-        account_owner,
-        storage_account_pubkey,
-        account_type: StorageAccountType::Archiver,
-    })
+    Ok((
+        CliCommand::CreateStorageAccount {
+            account_owner,
+            storage_account_pubkey,
+            account_type: StorageAccountType::Archiver,
+        },
+        true,
+    ))
 }
 
 pub fn parse_storage_create_validator_account(
     matches: &ArgMatches<'_>,
-) -> Result<CliCommand, CliError> {
+) -> Result<(CliCommand, bool), CliError> {
     let account_owner = pubkey_of(matches, "storage_account_owner").unwrap();
     let storage_account_pubkey = pubkey_of(matches, "storage_account_pubkey").unwrap();
-    Ok(CliCommand::CreateStorageAccount {
-        account_owner,
-        storage_account_pubkey,
-        account_type: StorageAccountType::Validator,
-    })
+    Ok((
+        CliCommand::CreateStorageAccount {
+            account_owner,
+            storage_account_pubkey,
+            account_type: StorageAccountType::Validator,
+        },
+        true,
+    ))
 }
 
-pub fn parse_storage_claim_reward(matches: &ArgMatches<'_>) -> Result<CliCommand, CliError> {
+pub fn parse_storage_claim_reward(
+    matches: &ArgMatches<'_>,
+) -> Result<(CliCommand, bool), CliError> {
     let node_account_pubkey = pubkey_of(matches, "node_account_pubkey").unwrap();
     let storage_account_pubkey = pubkey_of(matches, "storage_account_pubkey").unwrap();
-    Ok(CliCommand::ClaimStorageReward {
-        node_account_pubkey,
-        storage_account_pubkey,
-    })
+    Ok((
+        CliCommand::ClaimStorageReward {
+            node_account_pubkey,
+            storage_account_pubkey,
+        },
+        true,
+    ))
 }
 
-pub fn parse_storage_get_account_command(matches: &ArgMatches<'_>) -> Result<CliCommand, CliError> {
+pub fn parse_storage_get_account_command(
+    matches: &ArgMatches<'_>,
+) -> Result<(CliCommand, bool), CliError> {
     let storage_account_pubkey = pubkey_of(matches, "storage_account_pubkey").unwrap();
-    Ok(CliCommand::ShowStorageAccount(storage_account_pubkey))
+    Ok((
+        CliCommand::ShowStorageAccount(storage_account_pubkey),
+        false,
+    ))
 }
 
 pub fn process_create_storage_account(
@@ -228,12 +244,15 @@ mod tests {
             &storage_account_string,
         ]);
         assert_eq!(
-            parse_command(&pubkey, &test_create_archiver_storage_account).unwrap(),
-            CliCommand::CreateStorageAccount {
-                account_owner: pubkey,
-                storage_account_pubkey,
-                account_type: StorageAccountType::Archiver,
-            }
+            parse_command(&test_create_archiver_storage_account).unwrap(),
+            (
+                CliCommand::CreateStorageAccount {
+                    account_owner: pubkey,
+                    storage_account_pubkey,
+                    account_type: StorageAccountType::Archiver,
+                },
+                true
+            )
         );
 
         let test_create_validator_storage_account = test_commands.clone().get_matches_from(vec![
@@ -243,12 +262,15 @@ mod tests {
             &storage_account_string,
         ]);
         assert_eq!(
-            parse_command(&pubkey, &test_create_validator_storage_account).unwrap(),
-            CliCommand::CreateStorageAccount {
-                account_owner: pubkey,
-                storage_account_pubkey,
-                account_type: StorageAccountType::Validator,
-            }
+            parse_command(&test_create_validator_storage_account).unwrap(),
+            (
+                CliCommand::CreateStorageAccount {
+                    account_owner: pubkey,
+                    storage_account_pubkey,
+                    account_type: StorageAccountType::Validator,
+                },
+                true
+            )
         );
 
         let test_claim_storage_reward = test_commands.clone().get_matches_from(vec![
@@ -258,11 +280,14 @@ mod tests {
             &storage_account_string,
         ]);
         assert_eq!(
-            parse_command(&pubkey, &test_claim_storage_reward).unwrap(),
-            CliCommand::ClaimStorageReward {
-                node_account_pubkey: pubkey,
-                storage_account_pubkey,
-            }
+            parse_command(&test_claim_storage_reward).unwrap(),
+            (
+                CliCommand::ClaimStorageReward {
+                    node_account_pubkey: pubkey,
+                    storage_account_pubkey,
+                },
+                true
+            )
         );
     }
     // TODO: Add process tests

--- a/cli/src/storage.rs
+++ b/cli/src/storage.rs
@@ -1,7 +1,7 @@
 use crate::{
     cli::{
         check_account_for_fee, check_unique_pubkeys, log_instruction_custom_error, CliCommand,
-        CliConfig, CliError, ProcessResult,
+        CliCommandInfo, CliConfig, CliError, ProcessResult,
     },
     input_parsers::*,
     input_validators::*,
@@ -100,56 +100,54 @@ impl StorageSubCommands for App<'_, '_> {
 
 pub fn parse_storage_create_archiver_account(
     matches: &ArgMatches<'_>,
-) -> Result<(CliCommand, bool), CliError> {
+) -> Result<CliCommandInfo, CliError> {
     let account_owner = pubkey_of(matches, "storage_account_owner").unwrap();
     let storage_account_pubkey = pubkey_of(matches, "storage_account_pubkey").unwrap();
-    Ok((
-        CliCommand::CreateStorageAccount {
+    Ok(CliCommandInfo {
+        command: CliCommand::CreateStorageAccount {
             account_owner,
             storage_account_pubkey,
             account_type: StorageAccountType::Archiver,
         },
-        true,
-    ))
+        require_keypair: true,
+    })
 }
 
 pub fn parse_storage_create_validator_account(
     matches: &ArgMatches<'_>,
-) -> Result<(CliCommand, bool), CliError> {
+) -> Result<CliCommandInfo, CliError> {
     let account_owner = pubkey_of(matches, "storage_account_owner").unwrap();
     let storage_account_pubkey = pubkey_of(matches, "storage_account_pubkey").unwrap();
-    Ok((
-        CliCommand::CreateStorageAccount {
+    Ok(CliCommandInfo {
+        command: CliCommand::CreateStorageAccount {
             account_owner,
             storage_account_pubkey,
             account_type: StorageAccountType::Validator,
         },
-        true,
-    ))
+        require_keypair: true,
+    })
 }
 
-pub fn parse_storage_claim_reward(
-    matches: &ArgMatches<'_>,
-) -> Result<(CliCommand, bool), CliError> {
+pub fn parse_storage_claim_reward(matches: &ArgMatches<'_>) -> Result<CliCommandInfo, CliError> {
     let node_account_pubkey = pubkey_of(matches, "node_account_pubkey").unwrap();
     let storage_account_pubkey = pubkey_of(matches, "storage_account_pubkey").unwrap();
-    Ok((
-        CliCommand::ClaimStorageReward {
+    Ok(CliCommandInfo {
+        command: CliCommand::ClaimStorageReward {
             node_account_pubkey,
             storage_account_pubkey,
         },
-        true,
-    ))
+        require_keypair: true,
+    })
 }
 
 pub fn parse_storage_get_account_command(
     matches: &ArgMatches<'_>,
-) -> Result<(CliCommand, bool), CliError> {
+) -> Result<CliCommandInfo, CliError> {
     let storage_account_pubkey = pubkey_of(matches, "storage_account_pubkey").unwrap();
-    Ok((
-        CliCommand::ShowStorageAccount(storage_account_pubkey),
-        false,
-    ))
+    Ok(CliCommandInfo {
+        command: CliCommand::ShowStorageAccount(storage_account_pubkey),
+        require_keypair: false,
+    })
 }
 
 pub fn process_create_storage_account(
@@ -245,14 +243,14 @@ mod tests {
         ]);
         assert_eq!(
             parse_command(&test_create_archiver_storage_account).unwrap(),
-            (
-                CliCommand::CreateStorageAccount {
+            CliCommandInfo {
+                command: CliCommand::CreateStorageAccount {
                     account_owner: pubkey,
                     storage_account_pubkey,
                     account_type: StorageAccountType::Archiver,
                 },
-                true
-            )
+                require_keypair: true
+            }
         );
 
         let test_create_validator_storage_account = test_commands.clone().get_matches_from(vec![
@@ -263,14 +261,14 @@ mod tests {
         ]);
         assert_eq!(
             parse_command(&test_create_validator_storage_account).unwrap(),
-            (
-                CliCommand::CreateStorageAccount {
+            CliCommandInfo {
+                command: CliCommand::CreateStorageAccount {
                     account_owner: pubkey,
                     storage_account_pubkey,
                     account_type: StorageAccountType::Validator,
                 },
-                true
-            )
+                require_keypair: true
+            }
         );
 
         let test_claim_storage_reward = test_commands.clone().get_matches_from(vec![
@@ -281,13 +279,13 @@ mod tests {
         ]);
         assert_eq!(
             parse_command(&test_claim_storage_reward).unwrap(),
-            (
-                CliCommand::ClaimStorageReward {
+            CliCommandInfo {
+                command: CliCommand::ClaimStorageReward {
                     node_account_pubkey: pubkey,
                     storage_account_pubkey,
                 },
-                true
-            )
+                require_keypair: true
+            }
         );
     }
     // TODO: Add process tests

--- a/cli/src/validator_info.rs
+++ b/cli/src/validator_info.rs
@@ -1,5 +1,5 @@
 use crate::{
-    cli::{check_account_for_fee, CliCommand, CliConfig, CliError, ProcessResult},
+    cli::{check_account_for_fee, CliCommand, CliCommandInfo, CliConfig, CliError, ProcessResult},
     input_parsers::pubkey_of,
     input_validators::{is_pubkey, is_url},
 };
@@ -224,27 +224,28 @@ impl ValidatorInfoSubCommands for App<'_, '_> {
     }
 }
 
-pub fn parse_validator_info_command(
-    matches: &ArgMatches<'_>,
-) -> Result<(CliCommand, bool), CliError> {
+pub fn parse_validator_info_command(matches: &ArgMatches<'_>) -> Result<CliCommandInfo, CliError> {
     let info_pubkey = pubkey_of(matches, "info_pubkey");
     // Prepare validator info
     let validator_info = parse_args(&matches);
-    Ok((
-        CliCommand::SetValidatorInfo {
+    Ok(CliCommandInfo {
+        command: CliCommand::SetValidatorInfo {
             validator_info,
             force_keybase: matches.is_present("force"),
             info_pubkey,
         },
-        true,
-    ))
+        require_keypair: true,
+    })
 }
 
 pub fn parse_get_validator_info_command(
     matches: &ArgMatches<'_>,
-) -> Result<(CliCommand, bool), CliError> {
+) -> Result<CliCommandInfo, CliError> {
     let info_pubkey = pubkey_of(matches, "info_pubkey");
-    Ok((CliCommand::GetValidatorInfo(info_pubkey), false))
+    Ok(CliCommandInfo {
+        command: CliCommand::GetValidatorInfo(info_pubkey),
+        require_keypair: false,
+    })
 }
 
 pub fn process_set_validator_info(

--- a/cli/src/validator_info.rs
+++ b/cli/src/validator_info.rs
@@ -224,20 +224,27 @@ impl ValidatorInfoSubCommands for App<'_, '_> {
     }
 }
 
-pub fn parse_validator_info_command(matches: &ArgMatches<'_>) -> Result<CliCommand, CliError> {
+pub fn parse_validator_info_command(
+    matches: &ArgMatches<'_>,
+) -> Result<(CliCommand, bool), CliError> {
     let info_pubkey = pubkey_of(matches, "info_pubkey");
     // Prepare validator info
     let validator_info = parse_args(&matches);
-    Ok(CliCommand::SetValidatorInfo {
-        validator_info,
-        force_keybase: matches.is_present("force"),
-        info_pubkey,
-    })
+    Ok((
+        CliCommand::SetValidatorInfo {
+            validator_info,
+            force_keybase: matches.is_present("force"),
+            info_pubkey,
+        },
+        true,
+    ))
 }
 
-pub fn parse_get_validator_info_command(matches: &ArgMatches<'_>) -> Result<CliCommand, CliError> {
+pub fn parse_get_validator_info_command(
+    matches: &ArgMatches<'_>,
+) -> Result<(CliCommand, bool), CliError> {
     let info_pubkey = pubkey_of(matches, "info_pubkey");
-    Ok(CliCommand::GetValidatorInfo(info_pubkey))
+    Ok((CliCommand::GetValidatorInfo(info_pubkey), false))
 }
 
 pub fn process_set_validator_info(

--- a/cli/src/validator_info.rs
+++ b/cli/src/validator_info.rs
@@ -1,9 +1,9 @@
 use crate::{
     cli::{check_account_for_fee, CliCommand, CliConfig, CliError, ProcessResult},
-    input_validators::is_url,
+    input_validators::{is_pubkey, is_url},
 };
 use bincode::deserialize;
-use clap::ArgMatches;
+use clap::{App, Arg, ArgMatches, SubCommand};
 use reqwest::Client;
 use serde_derive::{Deserialize, Serialize};
 use serde_json::{Map, Value};
@@ -151,6 +151,87 @@ fn parse_info_pubkey(matches: &ArgMatches<'_>) -> Result<Option<Pubkey>, CliErro
         None
     };
     Ok(info_pubkey)
+}
+
+pub trait ValidatorInfoSubCommands {
+    fn validator_info_subcommands(self) -> Self;
+}
+
+impl ValidatorInfoSubCommands for App<'_, '_> {
+    fn validator_info_subcommands(self) -> Self {
+        self.subcommand(
+            SubCommand::with_name("validator-info")
+                .about("Publish/get Validator info on Solana")
+                .subcommand(
+                    SubCommand::with_name("publish")
+                        .about("Publish Validator info on Solana")
+                        .arg(
+                            Arg::with_name("info_pubkey")
+                                .short("p")
+                                .long("info-pubkey")
+                                .value_name("PUBKEY")
+                                .takes_value(true)
+                                .validator(is_pubkey)
+                                .help("The pubkey of the Validator info account to update"),
+                        )
+                        .arg(
+                            Arg::with_name("name")
+                                .index(1)
+                                .value_name("NAME")
+                                .takes_value(true)
+                                .required(true)
+                                .validator(is_short_field)
+                                .help("Validator name"),
+                        )
+                        .arg(
+                            Arg::with_name("website")
+                                .short("w")
+                                .long("website")
+                                .value_name("URL")
+                                .takes_value(true)
+                                .validator(check_url)
+                                .help("Validator website url"),
+                        )
+                        .arg(
+                            Arg::with_name("keybase_username")
+                                .short("n")
+                                .long("keybase")
+                                .value_name("USERNAME")
+                                .takes_value(true)
+                                .validator(is_short_field)
+                                .help("Validator Keybase username"),
+                        )
+                        .arg(
+                            Arg::with_name("details")
+                                .short("d")
+                                .long("details")
+                                .value_name("DETAILS")
+                                .takes_value(true)
+                                .validator(check_details_length)
+                                .help("Validator description")
+                        )
+                        .arg(
+                            Arg::with_name("force")
+                                .long("force")
+                                .takes_value(false)
+                                .hidden(true) // Don't document this argument to discourage its use
+                                .help("Override keybase username validity check"),
+                        ),
+                )
+                .subcommand(
+                    SubCommand::with_name("get")
+                        .about("Get and parse Solana Validator info")
+                        .arg(
+                            Arg::with_name("info_pubkey")
+                                .index(1)
+                                .value_name("PUBKEY")
+                                .takes_value(true)
+                                .validator(is_pubkey)
+                                .help("The pubkey of the Validator info account; without this argument, returns all"),
+                        ),
+                )
+        )
+    }
 }
 
 pub fn parse_validator_info_command(

--- a/cli/src/vote.rs
+++ b/cli/src/vote.rs
@@ -159,25 +159,20 @@ impl VoteSubCommands for App<'_, '_> {
     }
 }
 
-pub fn parse_vote_create_account(
-    pubkey: &Pubkey,
-    matches: &ArgMatches<'_>,
-) -> Result<CliCommand, CliError> {
+pub fn parse_vote_create_account(matches: &ArgMatches<'_>) -> Result<CliCommand, CliError> {
     let vote_account_pubkey = pubkey_of(matches, "vote_account_pubkey").unwrap();
     let node_pubkey = pubkey_of(matches, "node_pubkey").unwrap();
     let commission = value_of(&matches, "commission").unwrap_or(0);
-    let authorized_voter = pubkey_of(matches, "authorized_voter").unwrap_or(vote_account_pubkey);
-    let authorized_withdrawer = pubkey_of(matches, "authorized_withdrawer").unwrap_or(*pubkey);
+    let authorized_voter = pubkey_of(matches, "authorized_voter");
+    let authorized_withdrawer = pubkey_of(matches, "authorized_withdrawer");
 
-    Ok(CliCommand::CreateVoteAccount(
+    Ok(CliCommand::CreateVoteAccount {
         vote_account_pubkey,
-        VoteInit {
-            node_pubkey,
-            authorized_voter,
-            authorized_withdrawer,
-            commission,
-        },
-    ))
+        node_pubkey,
+        authorized_voter,
+        authorized_withdrawer,
+        commission,
+    })
 }
 
 pub fn parse_vote_authorize(
@@ -222,11 +217,14 @@ pub fn process_create_vote_account(
     rpc_client: &RpcClient,
     config: &CliConfig,
     vote_account_pubkey: &Pubkey,
-    vote_init: &VoteInit,
+    node_pubkey: &Pubkey,
+    authorized_voter: &Option<Pubkey>,
+    authorized_withdrawer: &Option<Pubkey>,
+    commission: u8,
 ) -> ProcessResult {
     check_unique_pubkeys(
         (vote_account_pubkey, "vote_account_pubkey".to_string()),
-        (&vote_init.node_pubkey, "node_pubkey".to_string()),
+        (&node_pubkey, "node_pubkey".to_string()),
     )?;
     check_unique_pubkeys(
         (&config.keypair.pubkey(), "cli keypair".to_string()),
@@ -239,10 +237,16 @@ pub fn process_create_vote_account(
     } else {
         1
     };
+    let vote_init = VoteInit {
+        node_pubkey: *node_pubkey,
+        authorized_voter: authorized_voter.unwrap_or(*vote_account_pubkey),
+        authorized_withdrawer: authorized_withdrawer.unwrap_or(config.keypair.pubkey()),
+        commission,
+    };
     let ixs = vote_instruction::create_account(
         &config.keypair.pubkey(),
         vote_account_pubkey,
-        vote_init,
+        &vote_init,
         lamports,
     );
     let (recent_blockhash, fee_calculator) = rpc_client.get_recent_blockhash()?;
@@ -458,15 +462,13 @@ mod tests {
         ]);
         assert_eq!(
             parse_command(&pubkey, &test_create_vote_account).unwrap(),
-            CliCommand::CreateVoteAccount(
-                pubkey,
-                VoteInit {
-                    node_pubkey,
-                    authorized_voter: pubkey,
-                    authorized_withdrawer: pubkey,
-                    commission: 10
-                }
-            )
+            CliCommand::CreateVoteAccount {
+                vote_account_pubkey: pubkey,
+                node_pubkey,
+                authorized_voter: None,
+                authorized_withdrawer: None,
+                commission: 10,
+            }
         );
         let test_create_vote_account2 = test_commands.clone().get_matches_from(vec![
             "test",
@@ -476,15 +478,13 @@ mod tests {
         ]);
         assert_eq!(
             parse_command(&pubkey, &test_create_vote_account2).unwrap(),
-            CliCommand::CreateVoteAccount(
-                pubkey,
-                VoteInit {
-                    node_pubkey,
-                    authorized_voter: pubkey,
-                    authorized_withdrawer: pubkey,
-                    commission: 0
-                }
-            )
+            CliCommand::CreateVoteAccount {
+                vote_account_pubkey: pubkey,
+                node_pubkey,
+                authorized_voter: None,
+                authorized_withdrawer: None,
+                commission: 0,
+            }
         );
         // test init with an authed voter
         let authed = Pubkey::new_rand();
@@ -498,15 +498,13 @@ mod tests {
         ]);
         assert_eq!(
             parse_command(&pubkey, &test_create_vote_account3).unwrap(),
-            CliCommand::CreateVoteAccount(
-                pubkey,
-                VoteInit {
-                    node_pubkey,
-                    authorized_voter: authed,
-                    authorized_withdrawer: pubkey,
-                    commission: 0
-                }
-            )
+            CliCommand::CreateVoteAccount {
+                vote_account_pubkey: pubkey,
+                node_pubkey,
+                authorized_voter: Some(authed),
+                authorized_withdrawer: None,
+                commission: 0
+            }
         );
         // test init with an authed withdrawer
         let test_create_vote_account4 = test_commands.clone().get_matches_from(vec![
@@ -519,15 +517,13 @@ mod tests {
         ]);
         assert_eq!(
             parse_command(&pubkey, &test_create_vote_account4).unwrap(),
-            CliCommand::CreateVoteAccount(
-                pubkey,
-                VoteInit {
-                    node_pubkey,
-                    authorized_voter: pubkey,
-                    authorized_withdrawer: authed,
-                    commission: 0
-                }
-            )
+            CliCommand::CreateVoteAccount {
+                vote_account_pubkey: pubkey,
+                node_pubkey,
+                authorized_voter: None,
+                authorized_withdrawer: Some(authed),
+                commission: 0
+            }
         );
 
         // Test Uptime Subcommand

--- a/cli/tests/pay.rs
+++ b/cli/tests/pay.rs
@@ -70,7 +70,7 @@ fn test_cli_timestamp_tx() {
         timestamp: Some(dt),
         timestamp_pubkey: Some(config_witness.keypair.pubkey()),
         witnesses: None,
-        cancelable: None,
+        cancelable: false,
     };
     let sig_response = process_command(&config_payer);
 
@@ -137,7 +137,7 @@ fn test_cli_witness_tx() {
         timestamp: None,
         timestamp_pubkey: None,
         witnesses: Some(vec![config_witness.keypair.pubkey()]),
-        cancelable: None,
+        cancelable: false,
     };
     let sig_response = process_command(&config_payer);
 
@@ -197,7 +197,7 @@ fn test_cli_cancel_tx() {
         timestamp: None,
         timestamp_pubkey: None,
         witnesses: Some(vec![config_witness.keypair.pubkey()]),
-        cancelable: Some(config_payer.keypair.pubkey()),
+        cancelable: true,
     };
     let sig_response = process_command(&config_payer).unwrap();
 


### PR DESCRIPTION
#### Problem
solana-cli insists on a valid keypair file for a bunch of actions that don't require a keypair; namely, querying for data from the cluster. This is annoying.

#### Summary of Changes
- Return need_keypair boolean from `parse_command()`; only run through keypair checks if `true`
(requirs refactoring branches that utilize keypair.pubkey() within `parse_command()`)
- Only print keypair path if keypair is being utilized in the command
- Also moves validator-info cli args into the validator-info module for general cleanup

Fixes #6375 
