### PR TITLE
Fix root slot considered votable

### DIFF
--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -264,6 +264,10 @@ impl Tower {
     }
 
     pub fn has_voted(&self, slot: u64) -> bool {
+        if Some(slot) == self.root() {
+            return true;
+        }
+
         for vote in &self.lockouts.votes {
             if vote.slot == slot {
                 return true;
@@ -603,6 +607,16 @@ mod test {
         tower.record_vote(0, Hash::default());
         assert!(tower.has_voted(0));
         assert!(!tower.has_voted(1));
+    }
+
+    #[test]
+    fn test_check_root_counts_as_voted() {
+        let mut tower = Tower::new_for_tests(0, 0.67);
+        for i in 0..64 {
+            tower.record_vote(i, Hash::default());
+        }
+        assert_eq!(tower.root().unwrap(), 32);
+        assert!(tower.has_voted(tower.root().unwrap()));
     }
 
     #[test]

--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -264,7 +264,8 @@ impl Tower {
     }
 
     pub fn has_voted(&self, slot: u64) -> bool {
-        if Some(slot) == self.root() {
+        // slot 0 is special since it is a known root but it also needs to be voted on
+        if slot > 0 && Some(slot) == self.root() {
             return true;
         }
 
@@ -617,6 +618,8 @@ mod test {
         }
         assert_eq!(tower.root().unwrap(), 32);
         assert!(tower.has_voted(tower.root().unwrap()));
+        // allow votes for 0, the `is_locked_out` check will prevent actual repeated votes
+        assert!(!tower.has_voted(0));
     }
 
     #[test]


### PR DESCRIPTION
#### Problem

Tower consensus falsely reports the root slot as "votable". This is incorrect. Roots _have_(except for genesis apparently) to have been voted on and so should be "already voted" on. 

#### Summary of Changes

A root slot _had_ to have been voted on, consider them "already voted". Added an exception for Block 0 (genesis)
