### PR TITLE
net.sh: Ensure external disk link is setup before cleaning config dir

### DIFF
--- a/net/common.sh
+++ b/net/common.sh
@@ -99,14 +99,15 @@ SOLANA_CONFIG_DIR=$SOLANA_ROOT/config
 # Clear the current cluster configuration
 clear_config_dir() {
   declare config_dir="$1"
+
+  setup_secondary_mount
+
   (
     set -x
     rm -rf "${config_dir:?}/" # <-- $i might be a symlink, rm the other side of it first
     rm -rf "$config_dir"
     mkdir -p "$config_dir"
   )
-
-  setup_secondary_mount
 }
 
 SECONDARY_DISK_MOUNT_POINT=/mnt/extra-disk


### PR DESCRIPTION
#### Problem

On clean up, if external disks are in use, our config dir symlink gets blown away before deleting the contents backing it.

#### Summary of Changes

Ensure our link before cleanup

H/t @danpaul000 - https://github.com/solana-labs/solana/pull/6371/commits/f89743fb5112249ab6b20265edf7e01abecb8d68