### PR TITLE
ADDITIONAL_FLAGS not handling multiple flags correctly

### DIFF
--- a/system-test/testnet-performance/testnet-automation.sh
+++ b/system-test/testnet-performance/testnet-automation.sh
@@ -91,6 +91,7 @@ launchTestnet() {
         -p "$TESTNET_TAG" ${TESTNET_CLOUD_ZONES[@]/#/"-z "} ${ADDITIONAL_FLAGS[@]/#/" "}
       ;;
     colo)
+    # shellcheck disable=SC2068
       net/colo.sh create \
         -n "$NUMBER_OF_VALIDATOR_NODES" -c "$NUMBER_OF_CLIENT_NODES" -g \
         -p "$TESTNET_TAG" ${ADDITIONAL_FLAGS[@]/#/" "}

--- a/system-test/testnet-performance/testnet-automation.sh
+++ b/system-test/testnet-performance/testnet-automation.sh
@@ -88,12 +88,12 @@ launchTestnet() {
         -d pd-ssd \
         -n "$NUMBER_OF_VALIDATOR_NODES" -c "$NUMBER_OF_CLIENT_NODES" \
         "$maybeMachineType" "$VALIDATOR_NODE_MACHINE_TYPE" \
-        -p "$TESTNET_TAG" ${TESTNET_CLOUD_ZONES[@]/#/"-z "} "$ADDITIONAL_FLAGS"
+        -p "$TESTNET_TAG" ${TESTNET_CLOUD_ZONES[@]/#/"-z "} ${ADDITIONAL_FLAGS[@]/#/" "}
       ;;
     colo)
       net/colo.sh create \
         -n "$NUMBER_OF_VALIDATOR_NODES" -c "$NUMBER_OF_CLIENT_NODES" -g \
-        -p "$TESTNET_TAG" "$ADDITIONAL_FLAGS"
+        -p "$TESTNET_TAG" ${ADDITIONAL_FLAGS[@]/#/" "}
       ;;
     *)
       echo "Error: Unsupported cloud provider: $CLOUD_PROVIDER"


### PR DESCRIPTION
Fix the parsing of multiple flags so when `ADDITIONAL_FLAGS="--foo --bar"`, we correctly call `gce.sh/colo.sh [args] --foo --bar`
