### PR TITLE
Increase airdrop request limit to 1_000_000 SOL

### DIFF
--- a/drone/src/drone.rs
+++ b/drone/src/drone.rs
@@ -41,7 +41,7 @@ macro_rules! socketaddr {
 }
 
 pub const TIME_SLICE: u64 = 60;
-pub const REQUEST_CAP: u64 = 100_000_000_000_000;
+pub const REQUEST_CAP: u64 = solana_sdk::native_token::SOL_LAMPORTS * 1_000_000;
 pub const DRONE_PORT: u16 = 9900;
 pub const DRONE_PORT_STR: &str = "9900";
 


### PR DESCRIPTION
#### Problem

High node count GCE testnets are failing to launch to due airdrop failures

```
[2019-10-22T15:27:45.007555133Z WARN  solana_drone::drone] Airdrop transaction failed: Custom { kind: Other, error: "token limit reached; req: 8589934592000 current: 94489285178673 cap: 100000000000000" }
[2019-10-22T15:27:45.007563642Z INFO  solana_drone::drone] Error in request: Custom { kind: Other, error: "token limit reached; req: 8589934592000 current: 94489285178673 cap: 100000000000000" }
[2019-10-22T15:27:45.260893539Z INFO  solana_drone::drone] Airdrop transaction requested...GetAirdrop { lamports: 8589934592000, to: AhrUfTHsKpfqiwroPEAVJtEndUmU7viLKDdYdAdN7zLk, blockhash: 3bqc6HTTUMsJ5ANyQvKMrdf1eBCB1Ro3beJpocK7RYNd }
```

#### Summary of Changes

Increase airdrop request cap
