### PR TITLE
get epoch schedule RPC

### DIFF
--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -9,6 +9,7 @@ use serde_json::{json, Value};
 use solana_sdk::{
     account::Account,
     clock::{Slot, DEFAULT_TICKS_PER_SECOND, DEFAULT_TICKS_PER_SLOT},
+    epoch_schedule::EpochSchedule,
     fee_calculator::FeeCalculator,
     hash::Hash,
     inflation::Inflation,
@@ -134,6 +135,25 @@ impl RpcClient {
             io::Error::new(
                 io::ErrorKind::Other,
                 format!("GetEpochInfo parse failure: {}", err),
+            )
+        })
+    }
+
+    pub fn get_epoch_schedule(&self) -> io::Result<EpochSchedule> {
+        let response = self
+            .client
+            .send(&RpcRequest::GetEpochSchedule, None, 0)
+            .map_err(|err| {
+                io::Error::new(
+                    io::ErrorKind::Other,
+                    format!("GetEpochSchedule request failure: {:?}", err),
+                )
+            })?;
+
+        serde_json::from_value(response).map_err(|err| {
+            io::Error::new(
+                io::ErrorKind::Other,
+                format!("GetEpochSchedule parse failure: {}", err),
             )
         })
     }

--- a/client/src/rpc_request.rs
+++ b/client/src/rpc_request.rs
@@ -58,6 +58,7 @@ pub enum RpcRequest {
     GetBalance,
     GetClusterNodes,
     GetEpochInfo,
+    GetEpochSchedule,
     GetGenesisBlockhash,
     GetInflation,
     GetNumBlocksSinceSignatureConfirmation,
@@ -91,6 +92,7 @@ impl RpcRequest {
             RpcRequest::GetBalance => "getBalance",
             RpcRequest::GetClusterNodes => "getClusterNodes",
             RpcRequest::GetEpochInfo => "getEpochInfo",
+            RpcRequest::GetEpochSchedule => "getEpochSchedule",
             RpcRequest::GetGenesisBlockhash => "getGenesisBlockhash",
             RpcRequest::GetInflation => "getInflation",
             RpcRequest::GetNumBlocksSinceSignatureConfirmation => {


### PR DESCRIPTION
#### Problem

* uptime calculation depends on knowing how many credits were possible in an epoch 💸 
* that data isn't recorded as part of the vote program operation (just credits earned AFAICT) 💰 
* we'd like to expose the epoch schedule parameters so Network Explorer can compute the value

#### Summary of Changes

* add a getEpochSchedule RPC method w/ tests

Fixes # N/A
