### PR TITLE
credit_only credits forwarding

### DIFF
--- a/bench-tps/src/bench.rs
+++ b/bench-tps/src/bench.rs
@@ -306,7 +306,7 @@ fn generate_system_txs(
         .par_iter()
         .map(|(from, to)| {
             (
-                system_transaction::transfer_now(from, &to.pubkey(), 1, *blockhash),
+                system_transaction::transfer(from, &to.pubkey(), 1, *blockhash),
                 timestamp(),
             )
         })

--- a/bench-tps/src/bench.rs
+++ b/bench-tps/src/bench.rs
@@ -634,15 +634,22 @@ pub fn airdrop_lamports<T: Client>(
         let (blockhash, _fee_calculator) = get_recent_blockhash(client);
         match request_airdrop_transaction(&drone_addr, &id.pubkey(), airdrop_amount, blockhash) {
             Ok(transaction) => {
-                let signature = client.async_send_transaction(transaction).unwrap();
-                client
-                    .poll_for_signature_confirmation(&signature, 1)
-                    .unwrap_or_else(|_| {
+                let mut tries = 0;
+                loop {
+                    tries += 1;
+                    let signature = client.async_send_transaction(transaction.clone()).unwrap();
+                    let result = client.poll_for_signature_confirmation(&signature, 1);
+
+                    if result.is_ok() {
+                        break;
+                    }
+                    if tries >= 5 {
                         panic!(
-                            "Error requesting airdrop: to addr: {:?} amount: {}",
-                            drone_addr, airdrop_amount
+                            "Error requesting airdrop: to addr: {:?} amount: {} {:?}",
+                            drone_addr, airdrop_amount, result
                         )
-                    })
+                    }
+                }
             }
             Err(err) => {
                 panic!(

--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -871,7 +871,7 @@ mod tests {
         let key = Keypair::new();
         let to = Pubkey::new_rand();
         let blockhash = Hash::default();
-        let tx = system_transaction::transfer_now(&key, &to, 50, blockhash);
+        let tx = system_transaction::transfer(&key, &to, 50, blockhash);
 
         let signature = rpc_client.send_transaction(&tx);
         assert_eq!(signature.unwrap(), SIGNATURE.to_string());
@@ -920,7 +920,7 @@ mod tests {
         let key = Keypair::new();
         let to = Pubkey::new_rand();
         let blockhash = Hash::default();
-        let mut tx = system_transaction::transfer_now(&key, &to, 50, blockhash);
+        let mut tx = system_transaction::transfer(&key, &to, 50, blockhash);
 
         let result = rpc_client.send_and_confirm_transaction(&mut tx, &[&key]);
         result.unwrap();
@@ -943,8 +943,8 @@ mod tests {
         let blockhash: Hash = "HUu3LwEzGRsUkuJS121jzkPJW39Kq62pXCTmTa1F9jDL"
             .parse()
             .unwrap();
-        let prev_tx = system_transaction::transfer_now(&key, &to, 50, blockhash);
-        let mut tx = system_transaction::transfer_now(&key, &to, 50, blockhash);
+        let prev_tx = system_transaction::transfer(&key, &to, 50, blockhash);
+        let mut tx = system_transaction::transfer(&key, &to, 50, blockhash);
 
         rpc_client.resign_transaction(&mut tx, &[&key]).unwrap();
 

--- a/core/benches/poh_verify.rs
+++ b/core/benches/poh_verify.rs
@@ -37,7 +37,7 @@ fn bench_poh_verify_transaction_entries(bencher: &mut Bencher) {
 
     let mut ticks: Vec<Entry> = Vec::with_capacity(NUM_ENTRIES);
     for _ in 0..NUM_ENTRIES {
-        let tx = system_transaction::transfer_now(&keypair1, &pubkey1, 42, cur_hash);
+        let tx = system_transaction::transfer(&keypair1, &pubkey1, 42, cur_hash);
         ticks.push(next_entry_mut(&mut cur_hash, NUM_HASHES, vec![tx]));
     }
 

--- a/core/src/blockstream_service.rs
+++ b/core/src/blockstream_service.rs
@@ -138,7 +138,7 @@ mod test {
 
         let keypair = Keypair::new();
         let mut blockhash = entries[3].hash;
-        let tx = system_transaction::transfer_now(&keypair, &keypair.pubkey(), 1, Hash::default());
+        let tx = system_transaction::transfer(&keypair, &keypair.pubkey(), 1, Hash::default());
         let entry = Entry::new(&mut blockhash, 1, vec![tx]);
         blockhash = entry.hash;
         entries.push(entry);

--- a/core/src/broadcast_stage/broadcast_utils.rs
+++ b/core/src/broadcast_stage/broadcast_utils.rs
@@ -87,7 +87,7 @@ mod tests {
             ..
         } = create_genesis_block(2);
         let bank0 = Arc::new(Bank::new(&genesis_block));
-        let tx = system_transaction::transfer_now(
+        let tx = system_transaction::transfer(
             &mint_keypair,
             &Pubkey::new_rand(),
             1,

--- a/core/src/chacha.rs
+++ b/core/src/chacha.rs
@@ -101,7 +101,7 @@ mod tests {
                 Entry::new_mut(
                     &mut id,
                     &mut num_hashes,
-                    vec![system_transaction::transfer_now(
+                    vec![system_transaction::transfer(
                         &keypair,
                         &keypair.pubkey(),
                         1,

--- a/core/src/packet.rs
+++ b/core/src/packet.rs
@@ -602,7 +602,7 @@ mod tests {
     fn test_to_packets() {
         let keypair = Keypair::new();
         let hash = Hash::new(&[1; 32]);
-        let tx = system_transaction::transfer_now(&keypair, &keypair.pubkey(), 1, hash);
+        let tx = system_transaction::transfer(&keypair, &keypair.pubkey(), 1, hash);
         let rv = to_packets(&vec![tx.clone(); 1]);
         assert_eq!(rv.len(), 1);
         assert_eq!(rv[0].packets.len(), 1);

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -956,7 +956,7 @@ mod test {
                 blockhash,
                 1,
                 vec![
-                    system_transaction::transfer_now(&keypair1, &keypair2.pubkey(), 2, *blockhash), // should be fine,
+                    system_transaction::transfer(&keypair1, &keypair2.pubkey(), 2, *blockhash), // should be fine,
                     system_transaction::transfer(
                         &missing_keypair,
                         &missing_keypair2.pubkey(),
@@ -983,7 +983,7 @@ mod test {
                 // Use wrong blockhash so that the entry causes an entry verification failure
                 &bad_hash,
                 1,
-                vec![system_transaction::transfer_now(
+                vec![system_transaction::transfer(
                     &genesis_keypair,
                     &keypair2.pubkey(),
                     2,

--- a/core/src/rpc_pubsub.rs
+++ b/core/src/rpc_pubsub.rs
@@ -391,7 +391,7 @@ mod tests {
             None,
         );
 
-        let tx = system_transaction::transfer_now(&alice, &contract_funds.pubkey(), 51, blockhash);
+        let tx = system_transaction::transfer(&alice, &contract_funds.pubkey(), 51, blockhash);
         process_transaction_and_notify(&bank_forks, &tx, &rpc.subscriptions).unwrap();
 
         let ixs = budget_instruction::when_signed(
@@ -435,7 +435,7 @@ mod tests {
             assert_eq!(serde_json::to_string(&expected).unwrap(), response);
         }
 
-        let tx = system_transaction::transfer_now(&alice, &witness.pubkey(), 1, blockhash);
+        let tx = system_transaction::transfer(&alice, &witness.pubkey(), 1, blockhash);
         process_transaction_and_notify(&bank_forks, &tx, &rpc.subscriptions).unwrap();
         sleep(Duration::from_millis(200));
         let ix = budget_instruction::apply_signature(

--- a/core/src/test_tx.rs
+++ b/core/src/test_tx.rs
@@ -10,7 +10,7 @@ pub fn test_tx() -> Transaction {
     let keypair1 = Keypair::new();
     let pubkey1 = keypair1.pubkey();
     let zero = Hash::default();
-    system_transaction::transfer_now(&keypair1, &pubkey1, 42, zero)
+    system_transaction::transfer(&keypair1, &pubkey1, 42, zero)
 }
 
 pub fn test_multisig_tx() -> Transaction {

--- a/core/tests/bank_forks.rs
+++ b/core/tests/bank_forks.rs
@@ -156,12 +156,8 @@ mod tests {
             4,
             |bank, mint_keypair| {
                 let key1 = Keypair::new().pubkey();
-                let tx = system_transaction::transfer_now(
-                    &mint_keypair,
-                    &key1,
-                    1,
-                    bank.last_blockhash(),
-                );
+                let tx =
+                    system_transaction::transfer(&mint_keypair, &key1, 1, bank.last_blockhash());
                 assert_eq!(bank.process_transaction(&tx), Ok(()));
                 bank.freeze();
             },
@@ -224,8 +220,7 @@ mod tests {
             );
             let slot = bank.slot();
             let key1 = Keypair::new().pubkey();
-            let tx =
-                system_transaction::transfer_now(&mint_keypair, &key1, 1, genesis_block.hash());
+            let tx = system_transaction::transfer(&mint_keypair, &key1, 1, genesis_block.hash());
             assert_eq!(bank.process_transaction(&tx), Ok(()));
             bank.freeze();
             bank_forks.insert(bank);

--- a/drone/src/drone.rs
+++ b/drone/src/drone.rs
@@ -121,11 +121,8 @@ impl Drone {
                     );
                     info!("Requesting airdrop of {} to {:?}", lamports, to);
 
-                    let create_instruction = system_instruction::transfer_now(
-                        &self.mint_keypair.pubkey(),
-                        &to,
-                        lamports,
-                    );
+                    let create_instruction =
+                        system_instruction::transfer(&self.mint_keypair.pubkey(), &to, lamports);
                     let message = Message::new(vec![create_instruction]);
                     Ok(Transaction::new(&[&self.mint_keypair], message, blockhash))
                 } else {
@@ -411,8 +408,7 @@ mod tests {
         bytes.put(&req[..]);
 
         let keypair = Keypair::new();
-        let expected_instruction =
-            system_instruction::transfer_now(&keypair.pubkey(), &to, lamports);
+        let expected_instruction = system_instruction::transfer(&keypair.pubkey(), &to, lamports);
         let message = Message::new(vec![expected_instruction]);
         let expected_tx = Transaction::new(&[&keypair], message, blockhash);
         let expected_bytes = serialize(&expected_tx).unwrap();

--- a/drone/src/drone_mock.rs
+++ b/drone/src/drone_mock.rs
@@ -18,7 +18,7 @@ pub fn request_airdrop_transaction(
         let key = Keypair::new();
         let to = Pubkey::new_rand();
         let blockhash = Hash::default();
-        let tx = system_transaction::transfer_now(&key, &to, lamports, blockhash);
+        let tx = system_transaction::transfer(&key, &to, lamports, blockhash);
         Ok(tx)
     }
 }

--- a/drone/tests/local-drone.rs
+++ b/drone/tests/local-drone.rs
@@ -13,7 +13,7 @@ fn test_local_drone() {
     let to = Pubkey::new_rand();
     let lamports = 50;
     let blockhash = Hash::new(&to.as_ref());
-    let create_instruction = system_instruction::transfer_now(&keypair.pubkey(), &to, lamports);
+    let create_instruction = system_instruction::transfer(&keypair.pubkey(), &to, lamports);
     let message = Message::new(vec![create_instruction]);
     let expected_tx = Transaction::new(&[&keypair], message, blockhash);
 

--- a/ledger/src/blocktree_processor.rs
+++ b/ledger/src/blocktree_processor.rs
@@ -842,7 +842,7 @@ pub mod tests {
         let bank = Arc::new(Bank::new(&genesis_block));
         let keypair = Keypair::new();
         let slot_entries = create_ticks(genesis_block.ticks_per_slot, genesis_block.hash());
-        let tx = system_transaction::transfer_now(
+        let tx = system_transaction::transfer(
             &mint_keypair,
             &keypair.pubkey(),
             1,
@@ -879,8 +879,7 @@ pub mod tests {
         for _ in 0..deducted_from_mint {
             // Transfer one token from the mint to a random account
             let keypair = Keypair::new();
-            let tx =
-                system_transaction::transfer_now(&mint_keypair, &keypair.pubkey(), 1, blockhash);
+            let tx = system_transaction::transfer(&mint_keypair, &keypair.pubkey(), 1, blockhash);
             let entry = Entry::new(&last_entry_hash, 1, vec![tx]);
             last_entry_hash = entry.hash;
             entries.push(entry);
@@ -888,7 +887,7 @@ pub mod tests {
             // Add a second Transaction that will produce a
             // InstructionError<0, ResultWithNegativeLamports> error when processed
             let keypair2 = Keypair::new();
-            let tx = system_transaction::transfer_now(&keypair, &keypair2.pubkey(), 42, blockhash);
+            let tx = system_transaction::transfer(&keypair, &keypair2.pubkey(), 42, blockhash);
             let entry = Entry::new(&last_entry_hash, 1, vec![tx]);
             last_entry_hash = entry.hash;
             entries.push(entry);
@@ -997,12 +996,10 @@ pub mod tests {
         let blockhash = genesis_block.hash();
         let keypairs = [Keypair::new(), Keypair::new(), Keypair::new()];
 
-        let tx =
-            system_transaction::transfer_now(&mint_keypair, &keypairs[0].pubkey(), 1, blockhash);
+        let tx = system_transaction::transfer(&mint_keypair, &keypairs[0].pubkey(), 1, blockhash);
         let entry_1 = next_entry(&last_entry_hash, 1, vec![tx]);
 
-        let tx =
-            system_transaction::transfer_now(&mint_keypair, &keypairs[1].pubkey(), 1, blockhash);
+        let tx = system_transaction::transfer(&mint_keypair, &keypairs[1].pubkey(), 1, blockhash);
         let entry_2 = next_entry(&entry_1.hash, 1, vec![tx]);
 
         let mut entries = vec![entry_1, entry_2];
@@ -1067,14 +1064,14 @@ pub mod tests {
         let blockhash = bank.last_blockhash();
 
         // ensure bank can process 2 entries that have a common account and no tick is registered
-        let tx = system_transaction::transfer_now(
+        let tx = system_transaction::transfer(
             &mint_keypair,
             &keypair1.pubkey(),
             2,
             bank.last_blockhash(),
         );
         let entry_1 = next_entry(&blockhash, 1, vec![tx]);
-        let tx = system_transaction::transfer_now(
+        let tx = system_transaction::transfer(
             &mint_keypair,
             &keypair2.pubkey(),
             2,
@@ -1107,7 +1104,7 @@ pub mod tests {
         let entry_1_to_mint = next_entry(
             &bank.last_blockhash(),
             1,
-            vec![system_transaction::transfer_now(
+            vec![system_transaction::transfer(
                 &keypair1,
                 &mint_keypair.pubkey(),
                 1,
@@ -1119,13 +1116,13 @@ pub mod tests {
             &entry_1_to_mint.hash,
             1,
             vec![
-                system_transaction::transfer_now(
+                system_transaction::transfer(
                     &keypair2,
                     &keypair3.pubkey(),
                     2,
                     bank.last_blockhash(),
                 ), // should be fine
-                system_transaction::transfer_now(
+                system_transaction::transfer(
                     &keypair1,
                     &mint_keypair.pubkey(),
                     2,
@@ -1167,7 +1164,7 @@ pub mod tests {
             &bank.last_blockhash(),
             1,
             vec![
-                system_transaction::transfer_now(
+                system_transaction::transfer(
                     &keypair1,
                     &mint_keypair.pubkey(),
                     1,
@@ -1186,13 +1183,13 @@ pub mod tests {
             &entry_1_to_mint.hash,
             1,
             vec![
-                system_transaction::transfer_now(
+                system_transaction::transfer(
                     &keypair2,
                     &keypair3.pubkey(),
                     2,
                     bank.last_blockhash(),
                 ), // should be fine
-                system_transaction::transfer_now(
+                system_transaction::transfer(
                     &keypair1,
                     &mint_keypair.pubkey(),
                     2,
@@ -1265,7 +1262,7 @@ pub mod tests {
             &entry_1_to_mint.hash,
             1,
             vec![
-                system_transaction::transfer_now(
+                system_transaction::transfer(
                     &keypair2,
                     &keypair3.pubkey(),
                     2,
@@ -1338,14 +1335,14 @@ pub mod tests {
         let keypair4 = Keypair::new();
 
         //load accounts
-        let tx = system_transaction::transfer_now(
+        let tx = system_transaction::transfer(
             &mint_keypair,
             &keypair1.pubkey(),
             1,
             bank.last_blockhash(),
         );
         assert_eq!(bank.process_transaction(&tx), Ok(()));
-        let tx = system_transaction::transfer_now(
+        let tx = system_transaction::transfer(
             &mint_keypair,
             &keypair2.pubkey(),
             1,
@@ -1355,19 +1352,11 @@ pub mod tests {
 
         // ensure bank can process 2 entries that do not have a common account and no tick is registered
         let blockhash = bank.last_blockhash();
-        let tx = system_transaction::transfer_now(
-            &keypair1,
-            &keypair3.pubkey(),
-            1,
-            bank.last_blockhash(),
-        );
+        let tx =
+            system_transaction::transfer(&keypair1, &keypair3.pubkey(), 1, bank.last_blockhash());
         let entry_1 = next_entry(&blockhash, 1, vec![tx]);
-        let tx = system_transaction::transfer_now(
-            &keypair2,
-            &keypair4.pubkey(),
-            1,
-            bank.last_blockhash(),
-        );
+        let tx =
+            system_transaction::transfer(&keypair2, &keypair4.pubkey(), 1, bank.last_blockhash());
         let entry_2 = next_entry(&entry_1.hash, 1, vec![tx]);
         assert_eq!(process_entries(&bank, &[entry_1, entry_2], true), Ok(()));
         assert_eq!(bank.get_balance(&keypair3.pubkey()), 1);
@@ -1448,7 +1437,7 @@ pub mod tests {
 
         for _ in 0..num_accounts {
             let keypair = Keypair::new();
-            let create_account_tx = system_transaction::transfer_now(
+            let create_account_tx = system_transaction::transfer(
                 &mint_keypair,
                 &keypair.pubkey(),
                 0,
@@ -1516,14 +1505,14 @@ pub mod tests {
         let keypair4 = Keypair::new();
 
         //load accounts
-        let tx = system_transaction::transfer_now(
+        let tx = system_transaction::transfer(
             &mint_keypair,
             &keypair1.pubkey(),
             1,
             bank.last_blockhash(),
         );
         assert_eq!(bank.process_transaction(&tx), Ok(()));
-        let tx = system_transaction::transfer_now(
+        let tx = system_transaction::transfer(
             &mint_keypair,
             &keypair2.pubkey(),
             1,
@@ -1537,15 +1526,11 @@ pub mod tests {
         }
 
         // ensure bank can process 2 entries that do not have a common account and tick is registered
-        let tx = system_transaction::transfer_now(&keypair2, &keypair3.pubkey(), 1, blockhash);
+        let tx = system_transaction::transfer(&keypair2, &keypair3.pubkey(), 1, blockhash);
         let entry_1 = next_entry(&blockhash, 1, vec![tx]);
         let tick = next_entry(&entry_1.hash, 1, vec![]);
-        let tx = system_transaction::transfer_now(
-            &keypair1,
-            &keypair4.pubkey(),
-            1,
-            bank.last_blockhash(),
-        );
+        let tx =
+            system_transaction::transfer(&keypair1, &keypair4.pubkey(), 1, bank.last_blockhash());
         let entry_2 = next_entry(&tick.hash, 1, vec![tx]);
         assert_eq!(
             process_entries(
@@ -1559,12 +1544,8 @@ pub mod tests {
         assert_eq!(bank.get_balance(&keypair4.pubkey()), 1);
 
         // ensure that an error is returned for an empty account (keypair2)
-        let tx = system_transaction::transfer_now(
-            &keypair2,
-            &keypair3.pubkey(),
-            1,
-            bank.last_blockhash(),
-        );
+        let tx =
+            system_transaction::transfer(&keypair2, &keypair3.pubkey(), 1, bank.last_blockhash());
         let entry_3 = next_entry(&entry_2.hash, 1, vec![tx]);
         assert_eq!(
             process_entries(&bank, &[entry_3], true),
@@ -1598,7 +1579,7 @@ pub mod tests {
         );
 
         // Make sure other errors don't update the signature cache
-        let tx = system_transaction::transfer_now(&mint_keypair, &pubkey, 1000, Hash::default());
+        let tx = system_transaction::transfer(&mint_keypair, &pubkey, 1000, Hash::default());
         let signature = tx.signatures[0];
 
         // Should fail with blockhash not found
@@ -1624,13 +1605,13 @@ pub mod tests {
         let bank = Arc::new(Bank::new(&genesis_block));
         let keypair1 = Keypair::new();
         let keypair2 = Keypair::new();
-        let success_tx = system_transaction::transfer_now(
+        let success_tx = system_transaction::transfer(
             &mint_keypair,
             &keypair1.pubkey(),
             1,
             bank.last_blockhash(),
         );
-        let fail_tx = system_transaction::transfer_now(
+        let fail_tx = system_transaction::transfer(
             &mint_keypair,
             &keypair2.pubkey(),
             2,

--- a/ledger/src/blocktree_processor.rs
+++ b/ledger/src/blocktree_processor.rs
@@ -887,7 +887,8 @@ pub mod tests {
             // Add a second Transaction that will produce a
             // InstructionError<0, ResultWithNegativeLamports> error when processed
             let keypair2 = Keypair::new();
-            let tx = system_transaction::transfer(&keypair, &keypair2.pubkey(), 42, blockhash);
+            let tx =
+                system_transaction::transfer(&mint_keypair, &keypair2.pubkey(), 101, blockhash);
             let entry = Entry::new(&last_entry_hash, 1, vec![tx]);
             last_entry_hash = entry.hash;
             entries.push(entry);

--- a/ledger/src/entry.rs
+++ b/ledger/src/entry.rs
@@ -412,8 +412,8 @@ mod tests {
 
         // First, verify entries
         let keypair = Keypair::new();
-        let tx0 = system_transaction::transfer_now(&keypair, &keypair.pubkey(), 0, zero);
-        let tx1 = system_transaction::transfer_now(&keypair, &keypair.pubkey(), 1, zero);
+        let tx0 = system_transaction::transfer(&keypair, &keypair.pubkey(), 0, zero);
+        let tx1 = system_transaction::transfer(&keypair, &keypair.pubkey(), 1, zero);
         let mut e0 = Entry::new(&zero, 0, vec![tx0.clone(), tx1.clone()]);
         assert!(e0.verify(&zero));
 
@@ -463,7 +463,7 @@ mod tests {
     fn test_next_entry_panic() {
         let zero = Hash::default();
         let keypair = Keypair::new();
-        let tx = system_transaction::transfer_now(&keypair, &keypair.pubkey(), 0, zero);
+        let tx = system_transaction::transfer(&keypair, &keypair.pubkey(), 0, zero);
         next_entry(&zero, 0, vec![tx]);
     }
 

--- a/ledger/src/snapshot_utils.rs
+++ b/ledger/src/snapshot_utils.rs
@@ -87,7 +87,7 @@ pub fn package_snapshot<P: AsRef<Path>, Q: AsRef<Path>>(
         .rc
         .get_storage_entries()
         .into_iter()
-        .filter(|x| x.fork_id() <= bank.slot())
+        .filter(|x| x.slot_id() <= bank.slot())
         .collect();
 
     // Create a snapshot package

--- a/local_cluster/src/local_cluster.rs
+++ b/local_cluster/src/local_cluster.rs
@@ -426,7 +426,7 @@ impl LocalCluster {
         trace!("getting leader blockhash");
         let (blockhash, _fee_calculator) = client.get_recent_blockhash().unwrap();
         let mut tx =
-            system_transaction::transfer_now(&source_keypair, dest_pubkey, lamports, blockhash);
+            system_transaction::transfer(&source_keypair, dest_pubkey, lamports, blockhash);
         info!(
             "executing transfer of {} from {} to {}",
             lamports,

--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -117,10 +117,8 @@ mod bpf {
                 } = create_genesis_block(50);
                 let bank = Arc::new(Bank::new(&genesis_block));
                 // Create bank with specific slot, used by solana_bpf_rust_sysvar test
-                dbg!(bank.epoch());
                 let bank =
                     Bank::new_from_parent(&bank, &Pubkey::default(), DEFAULT_SLOTS_PER_EPOCH + 1);
-                dbg!(bank.epoch());
                 let bank_client = BankClient::new(bank);
 
                 // Call user program

--- a/programs/storage_program/tests/storage_processor.rs
+++ b/programs/storage_program/tests/storage_processor.rs
@@ -469,7 +469,7 @@ fn init_storage_accounts(
     archiver_accounts_to_create: &[&Pubkey],
     lamports: u64,
 ) {
-    let mut ixs: Vec<_> = vec![system_instruction::transfer_now(&mint.pubkey(), owner, 1)];
+    let mut ixs: Vec<_> = vec![system_instruction::transfer(&mint.pubkey(), owner, 1)];
     ixs.append(
         &mut validator_accounts_to_create
             .into_iter()

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1795,7 +1795,7 @@ mod tests {
         for _ in 0..10 {
             let blockhash = bank.last_blockhash();
             let pubkey = Pubkey::new_rand();
-            let tx = system_transaction::transfer_now(&mint_keypair, &pubkey, 0, blockhash);
+            let tx = system_transaction::transfer(&mint_keypair, &pubkey, 0, blockhash);
             bank.process_transaction(&tx).unwrap();
             bank.squash();
             bank = Arc::new(new_from_parent(&bank));
@@ -1808,13 +1808,13 @@ mod tests {
         let bank0 = Arc::new(new_from_parent(&bank));
         let blockhash = bank.last_blockhash();
         let keypair = Keypair::new();
-        let tx = system_transaction::transfer_now(&mint_keypair, &keypair.pubkey(), 10, blockhash);
+        let tx = system_transaction::transfer(&mint_keypair, &keypair.pubkey(), 10, blockhash);
         bank0.process_transaction(&tx).unwrap();
 
         let bank1 = Arc::new(new_from_parent(&bank0));
         let pubkey = Pubkey::new_rand();
         let blockhash = bank.last_blockhash();
-        let tx = system_transaction::transfer_now(&keypair, &pubkey, 10, blockhash);
+        let tx = system_transaction::transfer(&keypair, &pubkey, 10, blockhash);
         bank1.process_transaction(&tx).unwrap();
 
         assert_eq!(bank0.get_account(&keypair.pubkey()).unwrap().lamports, 10);

--- a/sdk-c/src/lib.rs
+++ b/sdk-c/src/lib.rs
@@ -501,7 +501,7 @@ mod tests {
         let key = KeypairNative::new();
         let to = Pubkey::new_rand();
         let blockhash = Hash::default();
-        let tx = system_transaction::transfer_now(&key, &to, 50, blockhash);
+        let tx = system_transaction::transfer(&key, &to, 50, blockhash);
         let serialized = serialize(&tx).unwrap();
         let tx = Box::new(Transaction::from_native(tx));
         let tx = Box::into_raw(tx);
@@ -520,7 +520,7 @@ mod tests {
         let key = KeypairNative::new();
         let to = Pubkey::new_rand();
         let blockhash = Hash::default();
-        let tx = system_transaction::transfer_now(&key, &to, 50, blockhash);
+        let tx = system_transaction::transfer(&key, &to, 50, blockhash);
         let serialized = serialize(&tx).unwrap();
         let deserialized;
         unsafe {
@@ -559,7 +559,7 @@ mod tests {
         let key_native = KeypairNative::new();
         let to = Pubkey::new_rand();
         let blockhash = Hash::default();
-        let mut tx_native = system_transaction::transfer_now(&key_native, &to, 50, blockhash);
+        let mut tx_native = system_transaction::transfer(&key_native, &to, 50, blockhash);
         let tx = Box::into_raw(Box::new(Transaction::from_native(tx_native.clone())));
         let key = Keypair::from_native(&key_native);
         let tx2;

--- a/sdk/src/epoch_schedule.rs
+++ b/sdk/src/epoch_schedule.rs
@@ -24,10 +24,10 @@ pub struct EpochSchedule {
     /// whether epochs start short and grow
     pub warmup: bool,
 
-    /// basically: log2(slots_per_epoch) - log2(MINIMUM_SLOT_LEN)
+    /// basically: log2(slots_per_epoch) - log2(MINIMUM_SLOTS_PER_EPOCH)
     pub first_normal_epoch: Epoch,
 
-    /// basically: 2.pow(first_normal_epoch) - MINIMUM_SLOT_LEN
+    /// basically: MINIMUM_SLOTS_PER_EPOCH * (2.pow(first_normal_epoch) - 1)
     pub first_normal_slot: Slot,
 }
 

--- a/sdk/src/system_instruction.rs
+++ b/sdk/src/system_instruction.rs
@@ -69,19 +69,6 @@ pub fn create_account(
     )
 }
 
-/// transfer with to as credit-debit
-pub fn transfer_now(from_pubkey: &Pubkey, to_pubkey: &Pubkey, lamports: u64) -> Instruction {
-    let account_metas = vec![
-        AccountMeta::new(*from_pubkey, true),
-        AccountMeta::new(*to_pubkey, false),
-    ];
-    Instruction::new(
-        system_program::id(),
-        &SystemInstruction::Transfer { lamports },
-        account_metas,
-    )
-}
-
 pub fn assign(from_pubkey: &Pubkey, program_id: &Pubkey) -> Instruction {
     let account_metas = vec![AccountMeta::new(*from_pubkey, true)];
     Instruction::new(

--- a/sdk/src/system_transaction.rs
+++ b/sdk/src/system_transaction.rs
@@ -24,19 +24,6 @@ pub fn create_account(
     Transaction::new_signed_instructions(&[from_keypair], instructions, recent_blockhash)
 }
 
-/// Create and sign new system_instruction::Transfer transaction, but don't use a CO "to"
-pub fn transfer_now(
-    from_keypair: &Keypair,
-    to: &Pubkey,
-    lamports: u64,
-    recent_blockhash: Hash,
-) -> Transaction {
-    let from_pubkey = from_keypair.pubkey();
-    let transfer_instruction = system_instruction::transfer_now(&from_pubkey, to, lamports);
-    let instructions = vec![transfer_instruction];
-    Transaction::new_signed_instructions(&[from_keypair], instructions, recent_blockhash)
-}
-
 /// Create and sign new system_instruction::Assign transaction
 pub fn assign(from_keypair: &Keypair, recent_blockhash: Hash, program_id: &Pubkey) -> Transaction {
     let from_pubkey = from_keypair.pubkey();


### PR DESCRIPTION
#### Problem

 bank.get_account() doesn't reflect credits accrued to credit-only accounts
   unless bank.process_transaction() is used to propagate the state change

 #### Summary of Changes

 * add the capability for accounts to return information about pending credits
   (should be able to whack transfer_now())
 * remove nasty replicode for the credit only locks
 * use self methods instead of Self:: methods were obviously better

Fixes #