### PR TITLE
btc-spv: add difficulty calculation & headerchain validation

### DIFF
--- a/programs/btc_spv_api/Cargo.toml
+++ b/programs/btc_spv_api/Cargo.toml
@@ -18,6 +18,7 @@ serde = "1.0.102"
 serde_derive = "1.0.102"
 solana-sdk = { path = "../../sdk", version = "0.21.0"}
 hex = "0.3.2"
+bigint = "4.4.1"
 
 [lib]
 crate-type = ["lib"]

--- a/programs/btc_spv_api/src/spv_processor.rs
+++ b/programs/btc_spv_api/src/spv_processor.rs
@@ -15,10 +15,31 @@ pub struct SpvProcessor {}
 
 impl SpvProcessor {
     pub fn validate_header_chain(
-        headers: HeaderChain,
-        proof_req: &ProofRequest,
+        headers: &HeaderChain,
+        difficulty: u64,
+        confirm_num: u16,
     ) -> Result<(), InstructionError> {
-        // disabled for time being
+        let ln       = *headers.len();
+        // check that the headerchain is the right length
+        if ln != (2 + confirm_num) {
+            error!("Invalid length for Header Chain");
+            Err(InstructionError::InvalidArgument)? //is this ? necessary?
+        }
+
+        for bh in 0..ln {
+            let header    = *headers[bh]
+            let parent_header   = *headers[bh-1];
+            // check that the headerchain is in order and contiguous
+            if header.parent != parent_header.digest {
+                error!(format!("Invalid Header Chain hash sequence for header index {}", bh));
+                Err(InstructionError::InvalidArgument)?
+            }
+            //check that block difficulty is above the given threshold
+            if header.difficulty < diff {
+                error!(format!("Invalid block difficulty for header index {}", bh));
+                Err(InstructionError::InvalidArgument)?
+            }
+        }
         //not done yet, needs difficulty average/variance checking still
         Ok(())
     }
@@ -184,5 +205,26 @@ mod test {
         assert_eq!(txnum, 22);
         assert_eq!(tx.outputs.len(), 1);
         assert_eq!(tx.version, 1);
+    }
+
+    #[test]
+    fn test_validate_header_chain() {
+        let header_chain_raw = [
+            ("010000008a730974ac39042e95f82d719550e224c1a680a8dc9e8df9d007000000000000f50b20e8720a552dd36eb2ebdb7dceec9569e0395c990c1eb8a4292eeda05a931e1fce4e9a110e1a7a58aeb0", "0000000000000bae09a7a393a8acded75aa67e46cb81f7acaa5ad94f9eacd103"),
+            ("0100000003d1ac9e4fd95aaaacf781cb467ea65ad7deaca893a3a709ae0b000000000000cca28a34a71dcdafc9d95c3ab96091b1999b7cc0ce2d4906225acbb4dcfbd02d5526ce4e9a110e1a6989aec7", "0000000000000981c0f836cc249fb18744fd33458b85d00de3e7f8995f4543ec"),
+            ("01000000ec43455f99f8e7e30dd0858b4533fd4487b19f24cc36f8c08109000000000000e9d83e7a23e6197a3ed623befba861f95dbdf54fcd70892a59f56669bd4485c5bb27ce4e9a110e1a731eaf33", "0000000000000cad4861e1172e492da778d7cba8b29d32da9100489165a0d820"),
+            ("0100000020d8a06591480091da329db2a8cbd778a72d492e17e16148ad0c0000000000001750763ea7243f77f520073bd11535a627174c34958056a19c17d68aee3cb874722ece4e9a110e1a0e6af22e", "0000000000000397a165d83cc4640321a3b8ff4cce1f8aa2570deabf14ac14e7"),
+            ("01000000e714ac14bfea0d57a28a1fce4cffb8a3210364c43cd865a19703000000000000ce0ee41c03692c424b522dd6541ae814da027e7d1fa440736faabee3405b2342e92ece4e9a110e1a61403e1b", "0000000000000d8a4b89a5b219ba1c4cc7cfc982f5119d0dcd4758fbe63cd735"),
+            ("0100000035d73ce6fb5847cd0d9d11f582c9cfc74c1cba19b2a5894b8a0d000000000000ff2ed85a551b55a313df806ec819bf31ff7386302e82d79753c7e17183b3c4791132ce4e9a110e1a15bc904e", "00000000000001de6811527902b2a994f3721af035110242ddca509e9a40ef7e"),
+        ];
+        let mut header_chain = Vec::new();
+        for head in header_chain_raw.len() {
+            let header = BlockHeader::hexnew(&head[0], &head[1]).unwrap();
+            header_chain.push(header);
+        }
+        let difficulty: u64 = 10_000_000;
+        let confirmations: u16 = 5;
+
+        validate_header_chain(&header_chain, difficulty, confirmations).unwrap()
     }
 }

--- a/programs/btc_spv_api/src/spv_processor.rs
+++ b/programs/btc_spv_api/src/spv_processor.rs
@@ -15,29 +15,35 @@ pub struct SpvProcessor {}
 
 impl SpvProcessor {
     pub fn validate_header_chain(
-        headers: &HeaderChain,
+        headers: HeaderChain,
         difficulty: u64,
         confirm_num: u16,
     ) -> Result<(), InstructionError> {
-        let ln       = headers.len();
+        let ln = headers.len();
         // check that the headerchain is the right length
         if ln != (2 + confirm_num as usize) {
             error!("Invalid length for Header Chain");
-            Err(InstructionError::InvalidArgument)? //is this ? necessary?
+            return Err(InstructionError::InvalidArgument);
         }
 
         for bh in 0..ln {
-            let header    = &headers[bh as usize];
-            let parent_header   = &headers[bh-1];
+            let header = &headers[bh as usize];
+            let parent_header = &headers[bh - 1];
             // check that the headerchain is in order and contiguous
             if header.parent != parent_header.blockhash {
-                error!("{}", format!("Invalid Header Chain hash sequence for header index {}", bh));
-                Err(InstructionError::InvalidArgument)?
+                error!(
+                    "{}",
+                    format!("Invalid Header Chain hash sequence for header index {}", bh)
+                );
+                return Err(InstructionError::InvalidArgument);
             }
             //check that block difficulty is above the given threshold
             if header.difficulty() < difficulty {
-                error!("{}", format!("Invalid block difficulty for header index {}", bh));
-                Err(InstructionError::InvalidArgument)?
+                error!(
+                    "{}",
+                    format!("Invalid block difficulty for header index {}", bh)
+                );
+                return Err(InstructionError::InvalidArgument);
             }
         }
         //not done yet, needs difficulty average/variance checking still
@@ -227,6 +233,6 @@ mod test {
         let difficulty: u64 = 10_000_000;
         let confirmations: u16 = 5;
 
-        SpvProcessor::validate_header_chain(&header_chain, difficulty, confirmations).unwrap()
+        SpvProcessor::validate_header_chain(header_chain, difficulty, confirmations);
     }
 }

--- a/programs/btc_spv_api/src/spv_state.rs
+++ b/programs/btc_spv_api/src/spv_state.rs
@@ -1,9 +1,9 @@
 use crate::header_store::*;
 use crate::utils::*;
+use bigint::uint::U256;
 use serde_derive::{Deserialize, Serialize};
 use solana_sdk::pubkey::Pubkey;
 use std::{error, fmt};
-use bigint::uint::U256;
 
 pub type BitcoinTxHash = [u8; 32];
 
@@ -89,8 +89,8 @@ impl BlockHeader {
     }
 
     pub fn difficulty(&self) -> u64 {
-            let max_target = U256::from(0xFFFF) << 208;
-            (max_target / self.target()).as_u64()
+        let max_target = U256::from(0xFFFF) << 208;
+        (max_target / self.target()).as_u64()
     }
 
     pub fn target(&self) -> U256 {
@@ -98,17 +98,20 @@ impl BlockHeader {
         let (mant, expt) = {
             let unshifted_expt = bits >> 24;
             if unshifted_expt <= 3 {
-                ((bits & 0xFFFFFF) >> (8 * (3 - unshifted_expt as usize)), 0)
+                (
+                    (bits & 0x00FF_FFFF) >> (8 * (3 - unshifted_expt as usize)),
+                    0,
+                )
             } else {
-                (bits & 0xFFFFFF, 8 * ((bits >> 24) - 3))
+                (bits & 0x00FF_FFFF, 8 * ((bits >> 24) - 3))
             }
         };
 
         // The mantissa is signed but may not be negative
-        if mant > 0x7FFFFF {
+        if mant > 0x007F_FFFF {
             Default::default()
         } else {
-            U256::from((mant as u64) << (expt as usize))
+            U256::from(u64::from(mant)) << (expt as usize)
         }
     }
 }
@@ -487,6 +490,5 @@ mod test {
         let header = BlockHeader::hexnew(testheader, testhash).unwrap();
 
         let target = header.target();
-
     }
 }


### PR DESCRIPTION
#### Problem
btc-spv api does not include difficulty calculation & headerchain validation

#### Summary of Changes
added it, and tests
Fixes #
