### PR TITLE
Restore CUDA-based unit tests

### DIFF
--- a/ci/test-stable.sh
+++ b/ci/test-stable.sh
@@ -80,7 +80,7 @@ test-stable-perf)
   fi
 
   _ cargo +"$rust_stable" build --bins ${V:+--verbose}
-  _ cargo +"$rust_stable" test --package solana-core --lib ${V:+--verbose} -- --nocapture
+  _ cargo +"$rust_stable" test --package solana-ledger --package solana-core --lib ${V:+--verbose} -- --nocapture
   ;;
 test-local-cluster)
   echo "Executing $testName"

--- a/ledger/src/perf_libs.rs
+++ b/ledger/src/perf_libs.rs
@@ -159,7 +159,6 @@ pub fn init_cuda() {
 }
 
 pub fn api() -> Option<&'static Container<Api<'static>>> {
-    #[cfg(test)]
     {
         static INIT_HOOK: Once = Once::new();
         INIT_HOOK.call_once(|| {


### PR DESCRIPTION
When perf_libs.rs was moved out of core/ we lost all our CUDA-based tests.