### PR TITLE
Limit deserialization of program inputs

### DIFF
--- a/programs/bpf_loader_api/src/lib.rs
+++ b/programs/bpf_loader_api/src/lib.rs
@@ -18,6 +18,7 @@ use log::*;
 use solana_rbpf::{memory_region::MemoryRegion, EbpfVm};
 use solana_sdk::account::KeyedAccount;
 use solana_sdk::instruction::InstructionError;
+use solana_sdk::instruction_processor_utils::limited_deserialize;
 use solana_sdk::loader_instruction::LoaderInstruction;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::sysvar::rent;
@@ -89,7 +90,7 @@ pub fn process_instruction(
 ) -> Result<(), InstructionError> {
     solana_logger::setup();
 
-    if let Ok(instruction) = bincode::deserialize(ix_data) {
+    if let Ok(instruction) = limited_deserialize(ix_data) {
         match instruction {
             LoaderInstruction::Write { offset, bytes } => {
                 if keyed_accounts[0].signer_key().is_none() {

--- a/programs/btc_spv_api/src/spv_processor.rs
+++ b/programs/btc_spv_api/src/spv_processor.rs
@@ -8,6 +8,7 @@ use hex;
 use log::*;
 use solana_sdk::account::KeyedAccount;
 use solana_sdk::instruction::InstructionError;
+use solana_sdk::instruction_processor_utils::limited_deserialize;
 use solana_sdk::pubkey::Pubkey;
 
 pub struct SpvProcessor {}
@@ -103,10 +104,7 @@ pub fn process_instruction(
 ) -> Result<(), InstructionError> {
     // solana_logger::setup();
 
-    let command = bincode::deserialize::<SpvInstruction>(data).map_err(|err| {
-        info!("invalid instruction data: {:?} {:?}", data, err);
-        InstructionError::InvalidInstructionData
-    })?;
+    let command = limited_deserialize::<SpvInstruction>(data)?;
 
     trace!("{:?}", command);
 

--- a/programs/budget_api/src/budget_processor.rs
+++ b/programs/budget_api/src/budget_processor.rs
@@ -4,11 +4,11 @@ use crate::{
     budget_instruction::{BudgetError, BudgetInstruction},
     budget_state::BudgetState,
 };
-use bincode::deserialize;
 use chrono::prelude::{DateTime, Utc};
 use log::*;
 use solana_sdk::{
-    account::KeyedAccount, hash::hash, instruction::InstructionError, pubkey::Pubkey,
+    account::KeyedAccount, hash::hash, instruction::InstructionError,
+    instruction_processor_utils::limited_deserialize, pubkey::Pubkey,
 };
 
 /// Process a Witness Signature. Any payment plans waiting on this signature
@@ -106,10 +106,7 @@ pub fn process_instruction(
     keyed_accounts: &mut [KeyedAccount],
     data: &[u8],
 ) -> Result<(), InstructionError> {
-    let instruction = deserialize(data).map_err(|err| {
-        info!("Invalid transaction data: {:?} {:?}", data, err);
-        InstructionError::InvalidInstructionData
-    })?;
+    let instruction = limited_deserialize(data)?;
 
     trace!("process_instruction: {:?}", instruction);
 

--- a/programs/config_api/src/config_processor.rs
+++ b/programs/config_api/src/config_processor.rs
@@ -5,7 +5,7 @@ use bincode::deserialize;
 use log::*;
 use solana_sdk::account::KeyedAccount;
 use solana_sdk::instruction::InstructionError;
-use solana_sdk::instruction_processor_utils::next_keyed_account;
+use solana_sdk::instruction_processor_utils::{limited_deserialize, next_keyed_account};
 use solana_sdk::pubkey::Pubkey;
 
 pub fn process_instruction(
@@ -13,11 +13,7 @@ pub fn process_instruction(
     keyed_accounts: &mut [KeyedAccount],
     data: &[u8],
 ) -> Result<(), InstructionError> {
-    let key_list: ConfigKeys = deserialize(data).map_err(|err| {
-        error!("Invalid ConfigKeys data: {:?} {:?}", data, err);
-        InstructionError::InvalidInstructionData
-    })?;
-
+    let key_list: ConfigKeys = limited_deserialize(data)?;
     let keyed_accounts_iter = &mut keyed_accounts.iter_mut();
     let config_keyed_account = &mut next_keyed_account(keyed_accounts_iter)?;
     let current_data: ConfigKeys =

--- a/programs/exchange_api/src/exchange_processor.rs
+++ b/programs/exchange_api/src/exchange_processor.rs
@@ -7,6 +7,7 @@ use log::*;
 use solana_metrics::inc_new_counter_info;
 use solana_sdk::account::KeyedAccount;
 use solana_sdk::instruction::InstructionError;
+use solana_sdk::instruction_processor_utils::limited_deserialize;
 use solana_sdk::pubkey::Pubkey;
 use std::cmp;
 
@@ -432,14 +433,7 @@ pub fn process_instruction(
 ) -> Result<(), InstructionError> {
     solana_logger::setup();
 
-    let command = bincode::deserialize::<ExchangeInstruction>(data).map_err(|err| {
-        info!("Invalid transaction data: {:?} {:?}", data, err);
-        InstructionError::InvalidInstructionData
-    })?;
-
-    trace!("{:?}", command);
-
-    match command {
+    match limited_deserialize::<ExchangeInstruction>(data)? {
         ExchangeInstruction::AccountRequest => {
             ExchangeProcessor::do_account_request(keyed_accounts)
         }

--- a/programs/storage_api/src/storage_processor.rs
+++ b/programs/storage_api/src/storage_processor.rs
@@ -5,6 +5,7 @@ use crate::storage_contract::StorageAccount;
 use crate::storage_instruction::StorageInstruction;
 use solana_sdk::account::KeyedAccount;
 use solana_sdk::instruction::InstructionError;
+use solana_sdk::instruction_processor_utils::limited_deserialize;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::sysvar;
 
@@ -19,7 +20,7 @@ pub fn process_instruction(
     let me_unsigned = me[0].signer_key().is_none();
     let mut storage_account = StorageAccount::new(*me[0].unsigned_key(), &mut me[0].account);
 
-    match bincode::deserialize(data).map_err(|_| InstructionError::InvalidInstructionData)? {
+    match limited_deserialize(data)? {
         StorageInstruction::InitializeStorage {
             owner,
             account_type,

--- a/programs/vest_api/Cargo.toml
+++ b/programs/vest_api/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://solana.com/"
 edition = "2018"
 
 [dependencies]
-bincode = "1.1.4"
+bincode = "1.2.0"
 chrono = { version = "0.4.9", features = ["serde"] }
 log = "0.4.8"
 num-derive = "0.2"

--- a/programs/vest_api/src/vest_processor.rs
+++ b/programs/vest_api/src/vest_processor.rs
@@ -4,13 +4,12 @@ use crate::{
     vest_instruction::{VestError, VestInstruction},
     vest_state::VestState,
 };
-use bincode::deserialize;
 use chrono::prelude::*;
 use solana_config_api::get_config_data;
 use solana_sdk::{
     account::{Account, KeyedAccount},
     instruction::InstructionError,
-    instruction_processor_utils::next_keyed_account,
+    instruction_processor_utils::{limited_deserialize, next_keyed_account},
     pubkey::Pubkey,
 };
 
@@ -62,7 +61,7 @@ pub fn process_instruction(
     let keyed_accounts_iter = &mut keyed_accounts.iter_mut();
     let contract_account = &mut next_keyed_account(keyed_accounts_iter)?.account;
 
-    let instruction = deserialize(data).map_err(|_| InstructionError::InvalidInstructionData)?;
+    let instruction = limited_deserialize(data)?;
 
     let mut vest_state = if let VestInstruction::InitializeAccount {
         terminator_pubkey,

--- a/programs/vote_api/src/vote_instruction.rs
+++ b/programs/vote_api/src/vote_instruction.rs
@@ -5,7 +5,6 @@ use crate::{
     id,
     vote_state::{self, Vote, VoteAuthorize, VoteInit, VoteState},
 };
-use bincode::deserialize;
 use log::*;
 use num_derive::{FromPrimitive, ToPrimitive};
 use serde_derive::{Deserialize, Serialize};
@@ -13,7 +12,7 @@ use solana_metrics::datapoint_debug;
 use solana_sdk::{
     account::KeyedAccount,
     instruction::{AccountMeta, Instruction, InstructionError},
-    instruction_processor_utils::DecodeError,
+    instruction_processor_utils::{limited_deserialize, DecodeError},
     pubkey::Pubkey,
     system_instruction,
     sysvar::{self, rent},
@@ -178,7 +177,7 @@ pub fn process_instruction(
     let me = &mut me[0];
 
     // TODO: data-driven unpack and dispatch of KeyedAccounts
-    match deserialize(data).map_err(|_| InstructionError::InvalidInstructionData)? {
+    match limited_deserialize(data)? {
         VoteInstruction::InitializeAccount(vote_init) => {
             if rest.is_empty() {
                 return Err(InstructionError::InvalidInstructionData);

--- a/sdk/src/instruction_processor_utils.rs
+++ b/sdk/src/instruction_processor_utils.rs
@@ -1,4 +1,6 @@
-use crate::{account::KeyedAccount, instruction::InstructionError, pubkey::Pubkey};
+use crate::{
+    account::KeyedAccount, instruction::InstructionError, packet::PACKET_DATA_SIZE, pubkey::Pubkey,
+};
 use num_traits::{FromPrimitive, ToPrimitive};
 
 // All native programs export a symbol named process()
@@ -39,6 +41,16 @@ where
 /// Return the next KeyedAccount or a NotEnoughAccountKeys instruction error
 pub fn next_keyed_account<I: Iterator>(iter: &mut I) -> Result<I::Item, InstructionError> {
     iter.next().ok_or(InstructionError::NotEnoughAccountKeys)
+}
+
+pub fn limited_deserialize<T>(data: &[u8]) -> Result<(T), InstructionError>
+where
+    T: serde::de::DeserializeOwned,
+{
+    bincode::config()
+        .limit(PACKET_DATA_SIZE as u64)
+        .deserialize(data)
+        .map_err(|_| InstructionError::InvalidInstructionData)
 }
 
 pub trait DecodeError<E> {

--- a/sdk/src/instruction_processor_utils.rs
+++ b/sdk/src/instruction_processor_utils.rs
@@ -47,9 +47,8 @@ where
 {
     #[cfg(not(feature = "program"))]
     let limit = crate::packet::PACKET_DATA_SIZE as u64;
-    #[cfg(not(feature = "program"))]
+    #[cfg(feature = "program")]
     let limit = 1024;
-
     bincode::config()
         .limit(limit)
         .deserialize(data)

--- a/sdk/src/instruction_processor_utils.rs
+++ b/sdk/src/instruction_processor_utils.rs
@@ -1,6 +1,4 @@
-use crate::{
-    account::KeyedAccount, instruction::InstructionError, packet::PACKET_DATA_SIZE, pubkey::Pubkey,
-};
+use crate::{account::KeyedAccount, instruction::InstructionError, pubkey::Pubkey};
 use num_traits::{FromPrimitive, ToPrimitive};
 
 // All native programs export a symbol named process()
@@ -47,8 +45,13 @@ pub fn limited_deserialize<T>(data: &[u8]) -> Result<(T), InstructionError>
 where
     T: serde::de::DeserializeOwned,
 {
+    #[cfg(not(feature = "program"))]
+    let limit = crate::packet::PACKET_DATA_SIZE as u64;
+    #[cfg(not(feature = "program"))]
+    let limit = 1024;
+
     bincode::config()
-        .limit(PACKET_DATA_SIZE as u64)
+        .limit(limit)
         .deserialize(data)
         .map_err(|_| InstructionError::InvalidInstructionData)
 }


### PR DESCRIPTION
#### Problem

A program's input data comes directly from the client and deserializing could result in DDoS in some cases (vectors).

#### Summary of Changes

Explicitly limit the deserialization size to the maximum size of a packet

Fixes #
