### PR TITLE
owner and executable checks

### DIFF
--- a/runtime/benches/is_zeroed.rs
+++ b/runtime/benches/is_zeroed.rs
@@ -1,0 +1,34 @@
+#![feature(test)]
+
+extern crate test;
+
+use solana_runtime::message_processor::is_zeroed;
+use test::Bencher;
+
+const BUFSIZE: usize = 1024 * 1024 + 127;
+static BUF0: [u8; BUFSIZE] = [0; BUFSIZE];
+static BUF1: [u8; BUFSIZE] = [1; BUFSIZE];
+
+#[bench]
+fn bench_is_zeroed(bencher: &mut Bencher) {
+    bencher.iter(|| {
+        is_zeroed(&BUF0);
+    });
+}
+
+#[bench]
+fn bench_is_zeroed_not(bencher: &mut Bencher) {
+    bencher.iter(|| {
+        is_zeroed(&BUF1);
+    });
+}
+
+#[bench]
+fn bench_is_zeroed_by_iter(bencher: &mut Bencher) {
+    bencher.iter(|| BUF0.iter().all(|item| *item == 0));
+}
+
+#[bench]
+fn bench_is_zeroed_not_by_iter(bencher: &mut Bencher) {
+    bencher.iter(|| BUF1.iter().all(|item| *item == 0));
+}

--- a/runtime/src/system_instruction_processor.rs
+++ b/runtime/src/system_instruction_processor.rs
@@ -62,10 +62,6 @@ fn assign_account_to_program(
     account: &mut KeyedAccount,
     program_id: &Pubkey,
 ) -> Result<(), InstructionError> {
-    if !system_program::check_id(&account.account.owner) {
-        return Err(InstructionError::IncorrectProgramId);
-    }
-
     if account.signer_key().is_none() {
         debug!("Assign: account must sign");
         return Err(InstructionError::MissingRequiredSignature);
@@ -394,20 +390,6 @@ mod tests {
             ),
             Ok(())
         );
-
-        let from_owner = from_account.owner;
-        assert_eq!(from_owner, new_program_owner);
-
-        // Attempt to assign account not owned by system program
-        let another_program_owner = Pubkey::new(&[8; 32]);
-        let mut keyed_accounts = [KeyedAccount::new(&from, true, &mut from_account)];
-        let instruction = SystemInstruction::Assign {
-            program_id: another_program_owner,
-        };
-        let data = serialize(&instruction).unwrap();
-        let result = process_instruction(&system_program::id(), &mut keyed_accounts, &data);
-        assert_eq!(result, Err(InstructionError::IncorrectProgramId));
-        assert_eq!(from_account.owner, new_program_owner);
     }
 
     #[test]


### PR DESCRIPTION
#### Problem
 system_program special cases in verify_instruction were incomplete or overly restrictive
 coverage in message_processor is a bit low

 #### Summary of Changes

 * move owner checks from system_instruction_processor into verify_instruction
 * remove system_program as a special case of owner changer and executable
    changer (which it never did)
 * remove system_program special cases for owner changes
 * add support for account.owner update if done by the owner and IFF any data is first cleared

Fixes #