### PR TITLE
Blocktree metrics

### DIFF
--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -85,7 +85,7 @@ where
         total_packets += more_packets.packets.len();
         packets.push(more_packets)
     }
-    let now = Instant::now();
+    
     inc_new_counter_debug!("streamer-recv_window-recv", total_packets);
 
     let last_root = blocktree.last_root();
@@ -130,12 +130,12 @@ where
     let num_shreds = shreds.len();
     let now = Instant::now();
     blocktree.insert_shreds(shreds, Some(leader_schedule_cache))?;
-    let elapsed = now.elapsed.as_millis();
+    let elapsed = now.elapsed().as_millis();
 
     datapoint_info!(
         "recv-window",
-        ("num_shreds", num_shreds i64, i64),
-        ("insert_time", elapsed as i64, i64),
+        ("num_shreds", num_shreds as i64, i64),
+        ("elapsed", elapsed as i64, i64)
     );
 
     trace!(

--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -129,13 +129,44 @@ where
 
     let num_shreds = shreds.len();
     let now = Instant::now();
-    blocktree.insert_shreds(shreds, Some(leader_schedule_cache))?;
+    let metrics = blocktree.insert_shreds(shreds, Some(leader_schedule_cache))?;
     let elapsed = now.elapsed().as_millis();
 
     datapoint_info!(
         "recv-window",
         ("num_shreds", num_shreds as i64, i64),
-        ("elapsed", elapsed as i64, i64)
+        ("elapsed", elapsed as i64, i64),
+        (
+            "insert_lock_elapsed",
+            metrics.insert_lock_elapsed as i64,
+            i64
+        ),
+        (
+            "insert_shreds_elapsed",
+            metrics.insert_shreds_elapsed as i64,
+            i64
+        ),
+        (
+            "shred_recovery_elapsed",
+            metrics.shred_recovery_elapsed as i64,
+            i64
+        ),
+        ("chaining_elapsed", metrics.chaining_elapsed as i64, i64),
+        (
+            "commit_working_sets_elapsed",
+            metrics.commit_working_sets_elapsed as i64,
+            i64
+        ),
+        (
+            "write_batch_elapsed",
+            metrics.write_batch_elapsed as i64,
+            i64
+        ),
+        (
+            "total_insert_bytes_time",
+            metrics.total_insert_bytes_time as i64,
+            i64
+        ),
     );
 
     trace!(

--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -127,7 +127,16 @@ where
         }
     }
 
+    let num_shreds = shreds.len();
+    let now = Instant::now();
     blocktree.insert_shreds(shreds, Some(leader_schedule_cache))?;
+    let elapsed = now.elapsed.as_millis();
+
+    datapoint_info!(
+        "recv-window",
+        ("num_shreds", num_shreds i64, i64),
+        ("insert_time", elapsed as i64, i64),
+    );
 
     trace!(
         "Elapsed processing time in recv_window(): {}",

--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -130,10 +130,10 @@ where
     let num_shreds = shreds.len();
     let now = Instant::now();
     let metrics = blocktree.insert_shreds(shreds, Some(leader_schedule_cache))?;
-    let elapsed = now.elapsed().as_millis();
+    let elapsed = now.elapsed().as_micros();
 
     datapoint_info!(
-        "recv-window",
+        "recv-window-insert-shreds",
         ("num_shreds", num_shreds as i64, i64),
         ("elapsed", elapsed as i64, i64),
         (

--- a/ledger/src/blocktree.rs
+++ b/ledger/src/blocktree.rs
@@ -62,12 +62,42 @@ pub struct Blocktree {
 }
 
 pub struct BlocktreeInsertionMetrics {
+    pub num_shreds: usize,
     pub insert_lock_elapsed: u64,
     pub insert_shreds_elapsed: u64,
     pub shred_recovery_elapsed: u64,
     pub chaining_elapsed: u64,
     pub commit_working_sets_elapsed: u64,
     pub write_batch_elapsed: u64,
+    pub total_elapsed: u64,
+}
+
+impl BlocktreeInsertionMetrics {
+    pub fn report_metrics(&self, metric_name: &'static str) {
+        datapoint_info!(
+            metric_name,
+            ("num_shreds", self.num_shreds as i64, i64),
+            ("total_elapsed", self.total_elapsed as i64, i64),
+            ("insert_lock_elapsed", self.insert_lock_elapsed as i64, i64),
+            (
+                "insert_shreds_elapsed",
+                self.insert_shreds_elapsed as i64,
+                i64
+            ),
+            (
+                "shred_recovery_elapsed",
+                self.shred_recovery_elapsed as i64,
+                i64
+            ),
+            ("chaining_elapsed", self.chaining_elapsed as i64, i64),
+            (
+                "commit_working_sets_elapsed",
+                self.commit_working_sets_elapsed as i64,
+                i64
+            ),
+            ("write_batch_elapsed", self.write_batch_elapsed as i64, i64),
+        );
+    }
 }
 
 impl Blocktree {
@@ -375,6 +405,7 @@ impl Blocktree {
         let _lock = self.insert_shreds_lock.lock().unwrap();
         start.stop();
         let insert_lock_elapsed = start.as_us();
+        
         let db = &*self.db;
         let mut write_batch = db.batch()?;
 
@@ -384,6 +415,7 @@ impl Blocktree {
         let mut slot_meta_working_set = HashMap::new();
         let mut index_working_set = HashMap::new();
 
+        let num_shreds = shreds.len();
         let mut start = Measure::start("Shred insertion");
         shreds.into_iter().for_each(|shred| {
             if shred.is_data() {
@@ -475,7 +507,11 @@ impl Blocktree {
             newly_completed_slots,
         )?;
 
+        total_start.stop();
+
         Ok(BlocktreeInsertionMetrics {
+            num_shreds,
+            total_elapsed: total_start.as_us(),
             insert_lock_elapsed,
             insert_shreds_elapsed,
             shred_recovery_elapsed,

--- a/ledger/src/blocktree.rs
+++ b/ledger/src/blocktree.rs
@@ -70,6 +70,8 @@ pub struct BlocktreeInsertionMetrics {
     pub commit_working_sets_elapsed: u64,
     pub write_batch_elapsed: u64,
     pub total_elapsed: u64,
+    pub num_inserted: u64,
+    pub num_recovered: usize,
 }
 
 impl BlocktreeInsertionMetrics {
@@ -96,6 +98,8 @@ impl BlocktreeInsertionMetrics {
                 i64
             ),
             ("write_batch_elapsed", self.write_batch_elapsed as i64, i64),
+            ("num_inserted", self.num_inserted as i64, i64),
+            ("num_recovered", self.num_recovered as i64, i64),
         );
     }
 }
@@ -400,12 +404,13 @@ impl Blocktree {
         &self,
         shreds: Vec<Shred>,
         leader_schedule: Option<&Arc<LeaderScheduleCache>>,
-    ) -> Result<BlocktreeInsertionMetrics>  {
+    ) -> Result<BlocktreeInsertionMetrics> {
+        let mut total_start = Measure::start("Total elapsed");
         let mut start = Measure::start("Blocktree lock");
         let _lock = self.insert_shreds_lock.lock().unwrap();
         start.stop();
         let insert_lock_elapsed = start.as_us();
-        
+
         let db = &*self.db;
         let mut write_batch = db.batch()?;
 
@@ -417,29 +422,38 @@ impl Blocktree {
 
         let num_shreds = shreds.len();
         let mut start = Measure::start("Shred insertion");
+        let mut num_inserted = 0;
         shreds.into_iter().for_each(|shred| {
-            if shred.is_data() {
-                self.check_insert_data_shred(
-                    shred,
-                    &mut index_working_set,
-                    &mut slot_meta_working_set,
-                    &mut write_batch,
-                    &mut just_inserted_data_shreds,
-                );
-            } else if shred.is_code() {
-                self.check_insert_coding_shred(
-                    shred,
-                    &mut erasure_metas,
-                    &mut index_working_set,
-                    &mut write_batch,
-                    &mut just_inserted_coding_shreds,
-                );
+            let insert_success = {
+                if shred.is_data() {
+                    self.check_insert_data_shred(
+                        shred,
+                        &mut index_working_set,
+                        &mut slot_meta_working_set,
+                        &mut write_batch,
+                        &mut just_inserted_data_shreds,
+                    )
+                } else if shred.is_code() {
+                    self.check_insert_coding_shred(
+                        shred,
+                        &mut erasure_metas,
+                        &mut index_working_set,
+                        &mut write_batch,
+                        &mut just_inserted_coding_shreds,
+                    )
+                } else {
+                    panic!("There should be no other case");
+                }
+            };
+            if insert_success {
+                num_inserted += 1;
             }
         });
         start.stop();
         let insert_shreds_elapsed = start.as_us();
 
         let mut start = Measure::start("Shred recovery");
+        let mut num_recovered = 0;
         if let Some(leader_schedule_cache) = leader_schedule {
             let recovered_data = Self::try_shred_recovery(
                 &db,
@@ -449,6 +463,7 @@ impl Blocktree {
                 &mut just_inserted_coding_shreds,
             );
 
+            num_recovered = recovered_data.len();
             recovered_data.into_iter().for_each(|shred| {
                 if let Some(leader) = leader_schedule_cache.slot_leader_at(shred.slot(), None) {
                     if shred.verify(&leader) {
@@ -458,7 +473,7 @@ impl Blocktree {
                             &mut slot_meta_working_set,
                             &mut write_batch,
                             &mut just_inserted_coding_shreds,
-                        )
+                        );
                     }
                 }
             });
@@ -518,6 +533,8 @@ impl Blocktree {
             chaining_elapsed,
             commit_working_sets_elapsed,
             write_batch_elapsed,
+            num_inserted,
+            num_recovered,
         })
     }
 
@@ -528,7 +545,7 @@ impl Blocktree {
         index_working_set: &mut HashMap<u64, Index>,
         write_batch: &mut WriteBatch,
         just_inserted_coding_shreds: &mut HashMap<(u64, u64), Shred>,
-    ) {
+    ) -> bool {
         let slot = shred.slot();
         let shred_index = u64::from(shred.index());
 
@@ -539,13 +556,16 @@ impl Blocktree {
         // This gives the index of first coding shred in this FEC block
         // So, all coding shreds in a given FEC block will have the same set index
         if Blocktree::should_insert_coding_shred(&shred, index_meta.coding(), &self.last_root) {
-            if let Ok(()) = self.insert_coding_shred(erasure_metas, index_meta, &shred, write_batch)
-            {
-                just_inserted_coding_shreds
-                    .entry((slot, shred_index))
-                    .or_insert_with(|| shred);
-                new_index_meta.map(|n| index_working_set.insert(slot, n));
-            }
+            self.insert_coding_shred(erasure_metas, index_meta, &shred, write_batch)
+                .map(|_| {
+                    just_inserted_coding_shreds
+                        .entry((slot, shred_index))
+                        .or_insert_with(|| shred);
+                    new_index_meta.map(|n| index_working_set.insert(slot, n))
+                })
+                .is_ok()
+        } else {
+            false
         }
     }
 
@@ -556,7 +576,7 @@ impl Blocktree {
         slot_meta_working_set: &mut HashMap<u64, SlotMetaWorkingSetEntry>,
         write_batch: &mut WriteBatch,
         just_inserted_data_shreds: &mut HashMap<(u64, u64), Shred>,
-    ) {
+    ) -> bool {
         let slot = shred.slot();
         let shred_index = u64::from(shred.index());
         let (index_meta, mut new_index_meta) =
@@ -595,6 +615,8 @@ impl Blocktree {
         if insert_success {
             new_slot_meta_entry.map(|n| slot_meta_working_set.insert(slot, n));
         }
+
+        insert_success
     }
 
     fn should_insert_coding_shred(


### PR DESCRIPTION
#### Problem
Blocktree `insert_shreds` occasionally spikes into seconds, no metrics breaking down perf

#### Summary of Changes
Add metrics for various steps of blocktree insertion

Fixes #
