### PR TITLE
 net: Hide setup_secondary_mount within clear_config_dir

### DIFF
--- a/multinode-demo/bootstrap-leader.sh
+++ b/multinode-demo/bootstrap-leader.sh
@@ -54,8 +54,6 @@ if [[ -z $CI ]]; then # Skip in CI
   source "$here"/../scripts/tune-system.sh
 fi
 
-setup_secondary_mount
-
 # These keypairs are created by ./setup.sh and included in the genesis block
 identity_keypair=$SOLANA_CONFIG_DIR/bootstrap-leader/identity-keypair.json
 vote_keypair="$SOLANA_CONFIG_DIR"/bootstrap-leader/vote-keypair.json

--- a/multinode-demo/setup.sh
+++ b/multinode-demo/setup.sh
@@ -3,7 +3,6 @@
 here=$(dirname "$0")
 # shellcheck source=multinode-demo/common.sh
 source "$here"/common.sh
-setup_secondary_mount
 
 set -e
 

--- a/multinode-demo/validator.sh
+++ b/multinode-demo/validator.sh
@@ -185,8 +185,6 @@ if [[ -z "$ledger_dir" ]]; then
 fi
 mkdir -p "$ledger_dir"
 
-setup_secondary_mount
-
 if [[ -n $gossip_entrypoint ]]; then
   # Prefer the --entrypoint argument if supplied...
   if [[ ${#positional_args[@]} -gt 0 ]]; then

--- a/net/common.sh
+++ b/net/common.sh
@@ -100,7 +100,7 @@ SOLANA_CONFIG_DIR=$SOLANA_ROOT/config
 clear_config_dir() {
   declare config_dir="$1"
 
-  setup_secondary_mount
+  _setup_secondary_mount
 
   (
     set -x
@@ -108,10 +108,12 @@ clear_config_dir() {
     rm -rf "$config_dir"
     mkdir -p "$config_dir"
   )
+
+  _setup_secondary_mount
 }
 
 SECONDARY_DISK_MOUNT_POINT=/mnt/extra-disk
-setup_secondary_mount() {
+_setup_secondary_mount() {
   # If there is a secondary disk, symlink the config/ dir there
   (
     set -x


### PR DESCRIPTION
`setup_secondary_mount` is used in too many places which causes the node configuration to be removed on a machine reboot.  Instead only `setup_secondary_mount` when the configuration directory is first cleared during initialization.