### PR TITLE
Add mint keypair to validators for convenience

### DIFF
--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -282,11 +282,14 @@ EOF
     fi
 
     set -x
+    # Add the mint keypair to validators for convenient access from tools
+    # like bench-tps and add to blocktreamers to run a drone
+    scp "$entrypointIp":~/solana/config/mint-keypair.json config/
     if [[ $nodeType = blockstreamer ]]; then
-      # Sneak the mint-keypair.json from the bootstrap leader and run another drone
-      # with it on the blockstreamer node.  Typically the blockstreamer node has
-      # a static IP/DNS name for hosting the blockexplorer web app, and is
-      # a location that somebody would expect to be able to airdrop from
+      # Run another drone with the mint keypair on the blockstreamer node. 
+      # Typically the blockstreamer node has a static IP/DNS name for hosting
+      # the blockexplorer web app, and is a location that somebody would expect
+      # to be able to airdrop from
       scp "$entrypointIp":~/solana/config/mint-keypair.json config/
       if [[ $airdropsEnabled = true ]]; then
 cat >> ~/solana/on-reboot <<EOF
@@ -405,4 +408,3 @@ EOF
   echo "Unknown deployment method: $deployMethod"
   exit 1
 esac
-


### PR DESCRIPTION
#### Problem
Certain tools and scripts like [`bench-tps.sh`](https://github.com/solana-labs/tour-de-sol/blob/master/bench-tps.sh) rely on the bootstrap leader for the mint keypair as well as RPC calls. If bs leader goes down, these tools have no recourse

#### Summary of Changes
Add mint keypair to the solana validators too so that these tools are no longer dependent on the bs leader alone

Fixes #
