### PR TITLE
Add mint keypair to solana clients for convenience

### DIFF
--- a/net/remote/remote-client.sh
+++ b/net/remote/remote-client.sh
@@ -75,6 +75,8 @@ solana-bench-exchange)
   "
   ;;
 idle)
+  # Add the mint keypair to idle clients for convenience
+  scp "$entrypointIp":~/solana/config/mint-keypair.json config/
   exit 0
   ;;
 *)


### PR DESCRIPTION
#### Problem
Idle clients are not using a drone for running bench-tps and so need the mint keypair to fund accounts. 

#### Summary of Changes
Rather than pulling the mint keypair from the bootstrap leader, make it available on idle clients

Fixes #
