### PR TITLE
Use commitment in rpc bank selection

### DIFF
--- a/bench-exchange/src/bench.rs
+++ b/bench-exchange/src/bench.rs
@@ -659,7 +659,7 @@ fn verify_funding_transfer<T: SyncClient + ?Sized>(
 ) -> bool {
     if verify_transaction(client, tx) {
         for a in &tx.message().account_keys[1..] {
-            if client.get_balance(a).unwrap_or(0) >= amount {
+            if client.get_balance_now(a).unwrap_or(0) >= amount {
                 return true;
             }
         }
@@ -945,12 +945,12 @@ pub fn airdrop_lamports(client: &dyn Client, drone_addr: &SocketAddr, id: &Keypa
                 let signature = client.async_send_transaction(transaction).unwrap();
 
                 for _ in 0..30 {
-                    if let Ok(Some(_)) = client.get_signature_status(&signature) {
+                    if let Ok(Some(_)) = client.get_signature_status_now(&signature) {
                         break;
                     }
                     sleep(Duration::from_millis(100));
                 }
-                if client.get_balance(&id.pubkey()).unwrap_or(0) >= amount {
+                if client.get_balance_now(&id.pubkey()).unwrap_or(0) >= amount {
                     break;
                 }
             }

--- a/bench-exchange/src/bench.rs
+++ b/bench-exchange/src/bench.rs
@@ -381,7 +381,10 @@ fn swapper<T>(
             let mut tries = 0;
             let mut trade_index = 0;
             while client
-                .get_balance(&trade_infos[trade_index].trade_account)
+                .get_balance_with_commitment(
+                    &trade_infos[trade_index].trade_account,
+                    CommitmentConfig::recent(),
+                )
                 .unwrap_or(0)
                 == 0
             {
@@ -435,7 +438,7 @@ fn swapper<T>(
             account_group = (account_group + 1) % account_groups as usize;
 
             let (blockhash, _fee_calculator) = client
-                .get_recent_blockhash()
+                .get_recent_blockhash_with_commitment(CommitmentConfig::recent())
                 .expect("Failed to get blockhash");
             let to_swap_txs: Vec<_> = to_swap
                 .par_iter()
@@ -563,7 +566,7 @@ fn trader<T>(
         account_group = (account_group + 1) % account_groups as usize;
 
         let (blockhash, _fee_calculator) = client
-            .get_recent_blockhash()
+            .get_recent_blockhash_with_commitment(CommitmentConfig::recent())
             .expect("Failed to get blockhash");
 
         trades.chunks(chunk_size).for_each(|chunk| {
@@ -639,7 +642,9 @@ where
     T: SyncClient + ?Sized,
 {
     for s in &tx.signatures {
-        if let Ok(Some(r)) = sync_client.get_signature_status(s) {
+        if let Ok(Some(r)) =
+            sync_client.get_signature_status_with_commitment(s, CommitmentConfig::recent())
+        {
             match r {
                 Ok(_) => {
                     return true;
@@ -669,7 +674,6 @@ fn verify_funding_transfer<T: SyncClient + ?Sized>(
             }
         }
     }
-
     false
 }
 
@@ -747,8 +751,9 @@ pub fn fund_keys(client: &dyn Client, source: &Keypair, dests: &[Arc<Keypair>], 
                     to_fund_txs.len(),
                 );
 
-                let (blockhash, _fee_calculator) =
-                    client.get_recent_blockhash().expect("blockhash");
+                let (blockhash, _fee_calculator) = client
+                    .get_recent_blockhash_with_commitment(CommitmentConfig::recent())
+                    .expect("blockhash");
                 to_fund_txs.par_iter_mut().for_each(|(k, tx)| {
                     tx.sign(&[*k], blockhash);
                 });
@@ -785,7 +790,11 @@ pub fn fund_keys(client: &dyn Client, source: &Keypair, dests: &[Arc<Keypair>], 
         });
         funded.append(&mut new_funded);
         funded.retain(|(k, b)| {
-            client.get_balance(&k.pubkey()).unwrap_or(0) > lamports && *b > lamports
+            client
+                .get_balance_with_commitment(&k.pubkey(), CommitmentConfig::recent())
+                .unwrap_or(0)
+                > lamports
+                && *b > lamports
         });
         debug!("  Funded: {} left: {}", funded.len(), notfunded.len());
     }
@@ -824,7 +833,7 @@ pub fn create_token_accounts(client: &dyn Client, signers: &[Arc<Keypair>], acco
             let mut retries = 0;
             while !to_create_txs.is_empty() {
                 let (blockhash, _fee_calculator) = client
-                    .get_recent_blockhash()
+                    .get_recent_blockhash_with_commitment(CommitmentConfig::recent())
                     .expect("Failed to get blockhash");
                 to_create_txs.par_iter_mut().for_each(|(k, tx)| {
                     let kp: &Keypair = k;
@@ -868,7 +877,11 @@ pub fn create_token_accounts(client: &dyn Client, signers: &[Arc<Keypair>], acco
 
         let mut new_notfunded: Vec<(&Arc<Keypair>, &Pubkey)> = vec![];
         for f in &notfunded {
-            if client.get_balance(&f.1).unwrap_or(0) == 0 {
+            if client
+                .get_balance_with_commitment(&f.1, CommitmentConfig::recent())
+                .unwrap_or(0)
+                == 0
+            {
                 new_notfunded.push(*f)
             }
         }
@@ -925,7 +938,7 @@ fn generate_keypairs(num: u64) -> Vec<Keypair> {
 }
 
 pub fn airdrop_lamports(client: &dyn Client, drone_addr: &SocketAddr, id: &Keypair, amount: u64) {
-    let balance = client.get_balance(&id.pubkey());
+    let balance = client.get_balance_with_commitment(&id.pubkey(), CommitmentConfig::recent());
     let balance = balance.unwrap_or(0);
     if balance >= amount {
         return;
@@ -943,7 +956,7 @@ pub fn airdrop_lamports(client: &dyn Client, drone_addr: &SocketAddr, id: &Keypa
     let mut tries = 0;
     loop {
         let (blockhash, _fee_calculator) = client
-            .get_recent_blockhash()
+            .get_recent_blockhash_with_commitment(CommitmentConfig::recent())
             .expect("Failed to get blockhash");
         match request_airdrop_transaction(&drone_addr, &id.pubkey(), amount_to_drop, blockhash) {
             Ok(transaction) => {

--- a/bench-tps/src/bench.rs
+++ b/bench-tps/src/bench.rs
@@ -451,7 +451,7 @@ fn do_tx_transfers<T: Client>(
 
 fn verify_funding_transfer<T: Client>(client: &T, tx: &Transaction, amount: u64) -> bool {
     for a in &tx.message().account_keys[1..] {
-        if client.get_balance(a).unwrap_or(0) >= amount {
+        if client.get_balance_now(a).unwrap_or(0) >= amount {
             return true;
         }
     }
@@ -645,7 +645,7 @@ pub fn airdrop_lamports<T: Client>(
                 loop {
                     tries += 1;
                     let signature = client.async_send_transaction(transaction.clone()).unwrap();
-                    let result = client.poll_for_signature_confirmation(&signature, 1);
+                    let result = client.poll_for_signature_confirmation(&signature, 31);
 
                     if result.is_ok() {
                         break;
@@ -666,7 +666,7 @@ pub fn airdrop_lamports<T: Client>(
             }
         };
 
-        let current_balance = client.get_balance(&id.pubkey()).unwrap_or_else(|e| {
+        let current_balance = client.get_balance_now(&id.pubkey()).unwrap_or_else(|e| {
             info!("airdrop error {}", e);
             starting_balance
         });

--- a/bench-tps/src/bench.rs
+++ b/bench-tps/src/bench.rs
@@ -815,7 +815,7 @@ fn fund_move_keys<T: Client>(
     let create_len = 8;
     let mut funding_time = Measure::start("funding_time");
     for (i, keys) in keypairs.chunks(create_len).enumerate() {
-        if client.get_balance(&keys[0].pubkey()).unwrap_or(0) > 0 {
+        if client.get_balance_now(&keys[0].pubkey()).unwrap_or(0) > 0 {
             // already created these accounts.
             break;
         }
@@ -853,7 +853,7 @@ fn fund_move_keys<T: Client>(
     client.send_message(&[funding_key], tx.message).unwrap();
     let mut balance = 0;
     for _ in 0..20 {
-        if let Ok(balance_) = client.get_balance(&funding_keys[0].pubkey()) {
+        if let Ok(balance_) = client.get_balance_now(&funding_keys[0].pubkey()) {
             if balance_ > 0 {
                 balance = balance_;
                 break;

--- a/bench-tps/src/bench.rs
+++ b/bench-tps/src/bench.rs
@@ -645,7 +645,7 @@ pub fn airdrop_lamports<T: Client>(
                 loop {
                     tries += 1;
                     let signature = client.async_send_transaction(transaction.clone()).unwrap();
-                    let result = client.poll_for_signature_confirmation(&signature, 31);
+                    let result = client.poll_for_signature_confirmation(&signature, 1);
 
                     if result.is_ok() {
                         break;

--- a/bench-tps/src/bench.rs
+++ b/bench-tps/src/bench.rs
@@ -56,7 +56,7 @@ type LibraKeys = (Keypair, Pubkey, Pubkey, Vec<Keypair>);
 
 fn get_recent_blockhash<T: Client>(client: &T) -> (Hash, FeeCalculator) {
     loop {
-        match client.get_recent_blockhash() {
+        match client.get_recent_blockhash_with_commitment(CommitmentConfig::recent()) {
             Ok((blockhash, fee_calculator)) => return (blockhash, fee_calculator),
             Err(err) => {
                 info!("Couldn't get recent blockhash: {:?}", err);
@@ -1091,7 +1091,12 @@ mod tests {
             generate_and_fund_keypairs(&client, None, &id, tx_count, lamports, false).unwrap();
 
         for kp in &keypairs {
-            assert_eq!(client.get_balance(&kp.pubkey()).unwrap(), lamports);
+            assert_eq!(
+                client
+                    .get_balance_with_commitment(&kp.pubkey(), CommitmentConfig::recent())
+                    .unwrap(),
+                lamports
+            );
         }
     }
 
@@ -1109,7 +1114,7 @@ mod tests {
             generate_and_fund_keypairs(&client, None, &id, tx_count, lamports, false).unwrap();
 
         let max_fee = client
-            .get_recent_blockhash()
+            .get_recent_blockhash_with_commitment(CommitmentConfig::recent())
             .unwrap()
             .1
             .max_lamports_per_signature;

--- a/book/src/api-reference/jsonrpc-api.md
+++ b/book/src/api-reference/jsonrpc-api.md
@@ -82,7 +82,7 @@ Requests can be sent in batches by sending an array of JSON-RPC request objects 
 
 Solana nodes choose which bank state to query based on commitment requirements
 set by the client. Clients may specify two parameters:
-* confirmations - how many confirmed blocks the node should require
+* confirmations - how many confirmed blocks the node should require, up to `MAX_LOCKOUT_HISTORY`
 * percentage - how much of the cluster stake must have registered `confirmations`, as a decimal between 0.0 and 1.0
 
 The commitment parameter should be included as the last element in the `params` array:
@@ -91,19 +91,17 @@ The commitment parameter should be included as the last element in the `params` 
 curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0", "id":1, "method":"getBalance", "params":["83astBRguLMdt2h5U1Tpdq5tjFoJ6noeGwaY3mDLVcri",{"confirmations":15,"percentage":0.60}]}' 192.168.1.88:8899
 ```
 
-For convenience, the confidence configuration can include a `bankType` of either
-`rooted` or `recent`.
-* `rooted` sets confirmations to `MAX_LOCKOUT_HISTORY`
-* `recent` sets confirmations to `1`, which means the node will query its most recent bank state
+For convenience, the confirmations parameter can be set to `max`, which defaults
+to `MAX_LOCKOUT_HISTORY`
 
 ```bash
-curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0", "id":1, "method":"getBalance", "params":["83astBRguLMdt2h5U1Tpdq5tjFoJ6noeGwaY3mDLVcri",{"bankType":"rooted"}]}' 192.168.1.88:8899
+curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0", "id":1, "method":"getBalance", "params":["83astBRguLMdt2h5U1Tpdq5tjFoJ6noeGwaY3mDLVcri",{"confirmations":"max"}]}' 192.168.1.88:8899
 ```
 
 #### Defaults:
 Used if commitment configuration is not provided, or for missing parameters
 * `confirmations`: MAX_LOCKOUT_HISTORY
-* `percentage`: DEFAULT_PERCENT_COMMITMENT
+* `percentage`: DEFAULT_PERCENT_COMMITMENT (2/3 of the total cluster stake + 1)
 
 Only methods that query bank state accept the commitment parameter. They are indicated in the API Reference below.
 

--- a/book/src/api-reference/jsonrpc-api.md
+++ b/book/src/api-reference/jsonrpc-api.md
@@ -101,7 +101,7 @@ curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0", "id":1, "
 #### Defaults:
 Used if commitment configuration is not provided, or for missing parameters
 * `confirmations`: MAX_LOCKOUT_HISTORY
-* `percentage`: DEFAULT_PERCENT_COMMITMENT (2/3 of the total cluster stake + 1)
+* `percentage`: DEFAULT_PERCENT_COMMITMENT (2/3 of the total cluster stake)
 
 Only methods that query bank state accept the commitment parameter. They are indicated in the API Reference below.
 

--- a/book/src/api-reference/jsonrpc-api.md
+++ b/book/src/api-reference/jsonrpc-api.md
@@ -78,6 +78,35 @@ Requests can be sent in batches by sending an array of JSON-RPC request objects 
 * Signature: An Ed25519 signature of a chunk of data.
 * Transaction: A Solana instruction signed by a client key-pair.
 
+## Configuring State Commitment
+
+Solana nodes choose which bank state to query based on commitment requirements
+set by the client. Clients may specify two parameters:
+* confirmations - how many confirmed blocks the node should require
+* percentage - how much of the cluster stake must have registered `confirmations`, as a decimal between 0.0 and 1.0
+
+The commitment parameter should be included as the last element in the `params` array:
+
+```bash
+curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0", "id":1, "method":"getBalance", "params":["83astBRguLMdt2h5U1Tpdq5tjFoJ6noeGwaY3mDLVcri",{"confirmations":15,"percentage":0.60}]}' 192.168.1.88:8899
+```
+
+For convenience, the confidence configuration can include a `bankType` of either
+`rooted` or `recent`.
+* `rooted` sets confirmations to `MAX_LOCKOUT_HISTORY`
+* `recent` sets confirmations to `1`, which means the node will query its most recent bank state
+
+```bash
+curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0", "id":1, "method":"getBalance", "params":["83astBRguLMdt2h5U1Tpdq5tjFoJ6noeGwaY3mDLVcri",{"bankType":"rooted"}]}' 192.168.1.88:8899
+```
+
+#### Defaults:
+Used if commitment configuration is not provided, or for missing parameters
+* `confirmations`: MAX_LOCKOUT_HISTORY
+* `percentage`: DEFAULT_PERCENT_CONFIDENCE
+
+Only methods that query bank state accept the commitment parameter. They are indicated in the API Reference below.
+
 ## JSON RPC API Reference
 
 ### confirmTransaction
@@ -91,6 +120,7 @@ Returns a transaction receipt
 #### Results:
 
 * `boolean` - Transaction status, true if Transaction is confirmed
+* `object` - (optional) [Commitment](jsonrpc-api.md#configuring-state-commitment)
 
 #### Example:
 
@@ -109,6 +139,7 @@ Returns all information associated with the account of provided Pubkey
 #### Parameters:
 
 * `string` - Pubkey of account to query, as base-58 encoded string
+* `object` - (optional) [Commitment](jsonrpc-api.md#configuring-state-commitment)
 
 #### Results:
 
@@ -136,6 +167,7 @@ Returns the balance of the account of provided Pubkey
 #### Parameters:
 
 * `string` - Pubkey of account to query, as base-58 encoded string
+* `object` - (optional) [Commitment](jsonrpc-api.md#configuring-state-commitment)
 
 #### Results:
 
@@ -212,7 +244,7 @@ Returns information about the current epoch
 
 #### Parameters:
 
-None
+* `object` - (optional) [Commitment](jsonrpc-api.md#configuring-state-commitment)
 
 #### Results:
 
@@ -288,7 +320,7 @@ Returns the leader schedule for the current epoch
 
 #### Parameters:
 
-None
+* `object` - (optional) [Commitment](jsonrpc-api.md#configuring-state-commitment)
 
 #### Results:
 
@@ -311,6 +343,7 @@ Returns minimum balance required to make account rent exempt.
 #### Parameters:
 
 * `integer` - account data length, as unsigned integer
+* `object` - (optional) [Commitment](jsonrpc-api.md#configuring-state-commitment)
 
 #### Results:
 
@@ -333,6 +366,7 @@ Returns the current number of blocks since signature has been confirmed.
 #### Parameters:
 
 * `string` - Signature of Transaction to confirm, as base-58 encoded string
+* `object` - (optional) [Commitment](jsonrpc-api.md#configuring-state-commitment)
 
 #### Results:
 
@@ -355,6 +389,7 @@ Returns all accounts owned by the provided program Pubkey
 #### Parameters:
 
 * `string` - Pubkey of program, as base-58 encoded string
+* `object` - (optional) [Commitment](jsonrpc-api.md#configuring-state-commitment)
 
 #### Results:
 
@@ -382,7 +417,7 @@ Returns a recent block hash from the ledger, and a fee schedule that can be used
 
 #### Parameters:
 
-None
+* `object` - (optional) [Commitment](jsonrpc-api.md#configuring-state-commitment)
 
 #### Results:
 
@@ -408,6 +443,7 @@ Returns the status of a given signature. This method is similar to [confirmTrans
 #### Parameters:
 
 * `string` - Signature of Transaction to confirm, as base-58 encoded string
+* `object` - (optional) [Commitment](jsonrpc-api.md#configuring-state-commitment)
 
 #### Results:
 
@@ -432,7 +468,7 @@ Returns the current slot the node is processing
 
 #### Parameters:
 
-None
+* `object` - (optional) [Commitment](jsonrpc-api.md#configuring-state-commitment)
 
 #### Results:
 
@@ -454,7 +490,7 @@ Returns the current slot leader
 
 #### Parameters:
 
-None
+* `object` - (optional) [Commitment](jsonrpc-api.md#configuring-state-commitment)
 
 #### Results:
 
@@ -476,7 +512,7 @@ Returns the current storage segment size in terms of slots
 
 #### Parameters:
 
-None
+* `object` - (optional) [Commitment](jsonrpc-api.md#configuring-state-commitment)
 
 #### Results:
 
@@ -542,7 +578,7 @@ Returns the current Transaction count from the ledger
 
 #### Parameters:
 
-None
+* `object` - (optional) [Commitment](jsonrpc-api.md#configuring-state-commitment)
 
 #### Results:
 
@@ -569,6 +605,7 @@ None
 #### Results:
 
 * `integer` - Total supply, as unsigned 64-bit integer
+* `object` - (optional) [Commitment](jsonrpc-api.md#configuring-state-commitment)
 
 #### Example:
 
@@ -609,7 +646,7 @@ Returns the account info and associated stake for all the voting accounts in the
 
 #### Parameters:
 
-None
+* `object` - (optional) [Commitment](jsonrpc-api.md#configuring-state-commitment)
 
 #### Results:
 
@@ -640,6 +677,7 @@ Requests an airdrop of lamports to a Pubkey
 
 * `string` - Pubkey of account to receive lamports, as base-58 encoded string
 * `integer` - lamports, as a signed 64-bit integer
+* `object` - (optional) [Commitment](jsonrpc-api.md#configuring-state-commitment) (used for retrieving blockhash and verifying airdrop success)
 
 #### Results:
 

--- a/book/src/api-reference/jsonrpc-api.md
+++ b/book/src/api-reference/jsonrpc-api.md
@@ -103,7 +103,7 @@ curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0", "id":1, "
 #### Defaults:
 Used if commitment configuration is not provided, or for missing parameters
 * `confirmations`: MAX_LOCKOUT_HISTORY
-* `percentage`: DEFAULT_PERCENT_CONFIDENCE
+* `percentage`: DEFAULT_PERCENT_COMMITMENT
 
 Only methods that query bank state accept the commitment parameter. They are indicated in the API Reference below.
 

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -72,7 +72,7 @@ impl ClusterQuerySubCommands for App<'_, '_> {
                         .long("timeout")
                         .value_name("SECONDS")
                         .takes_value(true)
-                        .default_value("10")
+                        .default_value("15")
                         .help("Wait up to timeout seconds for transaction confirmation"),
                 ),
         )

--- a/cli/src/validator_info.rs
+++ b/cli/src/validator_info.rs
@@ -9,7 +9,7 @@ use clap::{App, Arg, ArgMatches, SubCommand};
 use reqwest::Client;
 use serde_derive::{Deserialize, Serialize};
 use serde_json::{Map, Value};
-use solana_client::rpc_client::RpcClient;
+use solana_client::{rpc_client::RpcClient, rpc_request::RpcConfidenceConfig};
 use solana_config_api::{config_instruction, get_config_data, ConfigKeys, ConfigState};
 use solana_sdk::account::Account;
 use solana_sdk::message::Message;
@@ -297,7 +297,9 @@ pub fn process_set_validator_info(
     };
 
     // Check existence of validator-info account
-    let balance = rpc_client.poll_get_balance(&info_pubkey).unwrap_or(0);
+    let balance = rpc_client
+        .poll_get_balance_with_confidence(&info_pubkey, RpcConfidenceConfig::default())
+        .unwrap_or(0);
 
     let keys = vec![(id(), false), (config.keypair.pubkey(), true)];
     let (message, signers): (Message, Vec<&Keypair>) = if balance == 0 {

--- a/cli/src/validator_info.rs
+++ b/cli/src/validator_info.rs
@@ -9,9 +9,10 @@ use clap::{App, Arg, ArgMatches, SubCommand};
 use reqwest::Client;
 use serde_derive::{Deserialize, Serialize};
 use serde_json::{Map, Value};
-use solana_client::{rpc_client::RpcClient, rpc_request::RpcCommitmentConfig};
+use solana_client::rpc_client::RpcClient;
 use solana_config_api::{config_instruction, get_config_data, ConfigKeys, ConfigState};
 use solana_sdk::account::Account;
+use solana_sdk::commitment_config::CommitmentConfig;
 use solana_sdk::message::Message;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::{Keypair, KeypairUtil};
@@ -298,7 +299,7 @@ pub fn process_set_validator_info(
 
     // Check existence of validator-info account
     let balance = rpc_client
-        .poll_get_balance_with_commitment(&info_pubkey, RpcCommitmentConfig::default())
+        .poll_get_balance_with_commitment(&info_pubkey, CommitmentConfig::default())
         .unwrap_or(0);
 
     let keys = vec![(id(), false), (config.keypair.pubkey(), true)];

--- a/cli/src/validator_info.rs
+++ b/cli/src/validator_info.rs
@@ -9,7 +9,7 @@ use clap::{App, Arg, ArgMatches, SubCommand};
 use reqwest::Client;
 use serde_derive::{Deserialize, Serialize};
 use serde_json::{Map, Value};
-use solana_client::{rpc_client::RpcClient, rpc_request::RpcConfidenceConfig};
+use solana_client::{rpc_client::RpcClient, rpc_request::RpcCommitmentConfig};
 use solana_config_api::{config_instruction, get_config_data, ConfigKeys, ConfigState};
 use solana_sdk::account::Account;
 use solana_sdk::message::Message;
@@ -298,7 +298,7 @@ pub fn process_set_validator_info(
 
     // Check existence of validator-info account
     let balance = rpc_client
-        .poll_get_balance_with_confidence(&info_pubkey, RpcConfidenceConfig::default())
+        .poll_get_balance_with_commitment(&info_pubkey, RpcCommitmentConfig::default())
         .unwrap_or(0);
 
     let keys = vec![(id(), false), (config.keypair.pubkey(), true)];

--- a/cli/tests/deploy.rs
+++ b/cli/tests/deploy.rs
@@ -57,7 +57,7 @@ fn test_cli_deploy_program() {
         .as_str()
         .unwrap();
 
-    let params = json!([program_id_str]);
+    let params = json!(program_id_str);
     let account_info = rpc_client
         .retry_make_rpc_request(&RpcRequest::GetAccountInfo, Some(params), 0)
         .unwrap();

--- a/cli/tests/deploy.rs
+++ b/cli/tests/deploy.rs
@@ -1,6 +1,5 @@
 use serde_json::{json, Value};
 use solana_cli::cli::{process_command, CliCommand, CliConfig};
-use solana_client::rpc_client::RpcClient;
 use solana_client::rpc_request::RpcRequest;
 use solana_core::validator::new_validator_for_tests;
 use solana_drone::drone::run_local_drone;
@@ -20,13 +19,11 @@ fn test_cli_deploy_program() {
     pathbuf.push("noop");
     pathbuf.set_extension("so");
 
-    let (server, leader_data, alice, ledger_path) = new_validator_for_tests();
+    let (server, leader_data, alice, ledger_path, rpc_client) = new_validator_for_tests();
 
     let (sender, receiver) = channel();
     run_local_drone(alice, sender, None);
     let drone_addr = receiver.recv().unwrap();
-
-    let rpc_client = RpcClient::new_socket(leader_data.rpc);
 
     let mut file = File::open(pathbuf.to_str().unwrap()).unwrap();
     let mut program_data = Vec::new();

--- a/cli/tests/pay.rs
+++ b/cli/tests/pay.rs
@@ -28,14 +28,12 @@ fn check_balance(expected_balance: u64, client: &RpcClient, pubkey: &Pubkey) {
 
 #[test]
 fn test_cli_timestamp_tx() {
-    let (server, leader_data, alice, ledger_path) = new_validator_for_tests();
+    let (server, leader_data, alice, ledger_path, rpc_client) = new_validator_for_tests();
     let bob_pubkey = Pubkey::new_rand();
 
     let (sender, receiver) = channel();
     run_local_drone(alice, sender, None);
     let drone_addr = receiver.recv().unwrap();
-
-    let rpc_client = RpcClient::new_socket(leader_data.rpc);
 
     let mut config_payer = CliConfig::default();
     config_payer.json_rpc_url =
@@ -99,14 +97,12 @@ fn test_cli_timestamp_tx() {
 
 #[test]
 fn test_cli_witness_tx() {
-    let (server, leader_data, alice, ledger_path) = new_validator_for_tests();
+    let (server, leader_data, alice, ledger_path, rpc_client) = new_validator_for_tests();
     let bob_pubkey = Pubkey::new_rand();
 
     let (sender, receiver) = channel();
     run_local_drone(alice, sender, None);
     let drone_addr = receiver.recv().unwrap();
-
-    let rpc_client = RpcClient::new_socket(leader_data.rpc);
 
     let mut config_payer = CliConfig::default();
     config_payer.json_rpc_url =
@@ -166,14 +162,12 @@ fn test_cli_witness_tx() {
 
 #[test]
 fn test_cli_cancel_tx() {
-    let (server, leader_data, alice, ledger_path) = new_validator_for_tests();
+    let (server, leader_data, alice, ledger_path, rpc_client) = new_validator_for_tests();
     let bob_pubkey = Pubkey::new_rand();
 
     let (sender, receiver) = channel();
     run_local_drone(alice, sender, None);
     let drone_addr = receiver.recv().unwrap();
-
-    let rpc_client = RpcClient::new_socket(leader_data.rpc);
 
     let mut config_payer = CliConfig::default();
     config_payer.json_rpc_url =

--- a/cli/tests/request_airdrop.rs
+++ b/cli/tests/request_airdrop.rs
@@ -1,5 +1,4 @@
 use solana_cli::cli::{process_command, CliCommand, CliConfig};
-use solana_client::rpc_client::RpcClient;
 use solana_core::validator::new_validator_for_tests;
 use solana_drone::drone::run_local_drone;
 use solana_sdk::signature::KeypairUtil;
@@ -8,7 +7,7 @@ use std::sync::mpsc::channel;
 
 #[test]
 fn test_cli_request_airdrop() {
-    let (server, leader_data, alice, ledger_path) = new_validator_for_tests();
+    let (server, leader_data, alice, ledger_path, rpc_client) = new_validator_for_tests();
     let (sender, receiver) = channel();
     run_local_drone(alice, sender, None);
     let drone_addr = receiver.recv().unwrap();
@@ -24,8 +23,6 @@ fn test_cli_request_airdrop() {
 
     let sig_response = process_command(&bob_config);
     sig_response.unwrap();
-
-    let rpc_client = RpcClient::new_socket(leader_data.rpc);
 
     let balance = rpc_client
         .retry_get_balance(&bob_config.keypair.pubkey(), 1)

--- a/client/src/generic_rpc_client_request.rs
+++ b/client/src/generic_rpc_client_request.rs
@@ -1,5 +1,5 @@
 use crate::client_error::ClientError;
-use crate::rpc_request::RpcRequest;
+use crate::rpc_request::{RpcCommitmentConfig, RpcRequest};
 
 pub(crate) trait GenericRpcClientRequest {
     fn send(
@@ -7,5 +7,6 @@ pub(crate) trait GenericRpcClientRequest {
         request: &RpcRequest,
         params: Option<serde_json::Value>,
         retries: usize,
+        commitment_config: Option<RpcCommitmentConfig>,
     ) -> Result<serde_json::Value, ClientError>;
 }

--- a/client/src/generic_rpc_client_request.rs
+++ b/client/src/generic_rpc_client_request.rs
@@ -1,5 +1,6 @@
 use crate::client_error::ClientError;
-use crate::rpc_request::{RpcCommitmentConfig, RpcRequest};
+use crate::rpc_request::RpcRequest;
+use solana_sdk::commitment_config::CommitmentConfig;
 
 pub(crate) trait GenericRpcClientRequest {
     fn send(
@@ -7,6 +8,6 @@ pub(crate) trait GenericRpcClientRequest {
         request: &RpcRequest,
         params: Option<serde_json::Value>,
         retries: usize,
-        commitment_config: Option<RpcCommitmentConfig>,
+        commitment_config: Option<CommitmentConfig>,
     ) -> Result<serde_json::Value, ClientError>;
 }

--- a/client/src/mock_rpc_client_request.rs
+++ b/client/src/mock_rpc_client_request.rs
@@ -1,7 +1,8 @@
 use crate::client_error::ClientError;
 use crate::generic_rpc_client_request::GenericRpcClientRequest;
-use crate::rpc_request::{RpcCommitmentConfig, RpcRequest};
+use crate::rpc_request::RpcRequest;
 use serde_json::{Number, Value};
+use solana_sdk::commitment_config::CommitmentConfig;
 use solana_sdk::fee_calculator::FeeCalculator;
 use solana_sdk::transaction::{self, TransactionError};
 
@@ -25,7 +26,7 @@ impl GenericRpcClientRequest for MockRpcClientRequest {
         request: &RpcRequest,
         params: Option<serde_json::Value>,
         _retries: usize,
-        _commitment_config: Option<RpcCommitmentConfig>,
+        _commitment_config: Option<CommitmentConfig>,
     ) -> Result<serde_json::Value, ClientError> {
         if self.url == "fails" {
             return Ok(Value::Null);

--- a/client/src/mock_rpc_client_request.rs
+++ b/client/src/mock_rpc_client_request.rs
@@ -1,6 +1,6 @@
 use crate::client_error::ClientError;
 use crate::generic_rpc_client_request::GenericRpcClientRequest;
-use crate::rpc_request::RpcRequest;
+use crate::rpc_request::{RpcCommitmentConfig, RpcRequest};
 use serde_json::{Number, Value};
 use solana_sdk::fee_calculator::FeeCalculator;
 use solana_sdk::transaction::{self, TransactionError};
@@ -25,6 +25,7 @@ impl GenericRpcClientRequest for MockRpcClientRequest {
         request: &RpcRequest,
         params: Option<serde_json::Value>,
         _retries: usize,
+        _commitment_config: Option<RpcCommitmentConfig>,
     ) -> Result<serde_json::Value, ClientError> {
         if self.url == "fails" {
             return Ok(Value::Null);

--- a/client/src/perf_utils.rs
+++ b/client/src/perf_utils.rs
@@ -29,7 +29,9 @@ pub fn sample_txs<T>(
     let mut total_txs;
     let mut now = Instant::now();
     let start_time = now;
-    let initial_txs = client.get_transaction_count().expect("transaction count");
+    let initial_txs = client
+        .get_transaction_count_now()
+        .expect("transaction count");
     let mut last_txs = initial_txs;
 
     loop {
@@ -37,7 +39,7 @@ pub fn sample_txs<T>(
         let elapsed = now.elapsed();
         now = Instant::now();
         let mut txs;
-        match client.get_transaction_count() {
+        match client.get_transaction_count_now() {
             Err(e) => {
                 // ThinClient with multiple options should pick a better one now.
                 info!("Couldn't get transaction count {:?}", e);

--- a/client/src/perf_utils.rs
+++ b/client/src/perf_utils.rs
@@ -1,5 +1,6 @@
 use log::*;
 use solana_sdk::client::Client;
+use solana_sdk::commitment_config::CommitmentConfig;
 use solana_sdk::timing::duration_as_s;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, RwLock};
@@ -30,7 +31,7 @@ pub fn sample_txs<T>(
     let mut now = Instant::now();
     let start_time = now;
     let initial_txs = client
-        .get_transaction_count_now()
+        .get_transaction_count_with_commitment(CommitmentConfig::recent())
         .expect("transaction count");
     let mut last_txs = initial_txs;
 
@@ -39,7 +40,7 @@ pub fn sample_txs<T>(
         let elapsed = now.elapsed();
         now = Instant::now();
         let mut txs;
-        match client.get_transaction_count_now() {
+        match client.get_transaction_count_with_commitment(CommitmentConfig::recent()) {
             Err(e) => {
                 // ThinClient with multiple options should pick a better one now.
                 info!("Couldn't get transaction count {:?}", e);

--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -350,7 +350,11 @@ impl RpcClient {
         Ok(res)
     }
 
+<<<<<<< HEAD
     fn get_account_with_commitment(
+=======
+    pub fn get_account_with_confidence(
+>>>>>>> Add get_account_now method to client
         &self,
         pubkey: &Pubkey,
         commitment_config: RpcCommitmentConfig,

--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -619,11 +619,16 @@ impl RpcClient {
         )
     }
 
-    pub fn wait_for_balance(&self, pubkey: &Pubkey, expected_balance: Option<u64>) -> Option<u64> {
+    pub fn wait_for_balance_with_confidence(
+        &self,
+        pubkey: &Pubkey,
+        expected_balance: Option<u64>,
+        confidence_config: RpcConfidenceConfig,
+    ) -> Option<u64> {
         const LAST: usize = 30;
         for run in 0..LAST {
             let balance_result =
-                self.poll_get_balance_with_confidence(pubkey, RpcConfidenceConfig::default());
+                self.poll_get_balance_with_confidence(pubkey, confidence_config.clone());
             if expected_balance.is_none() {
                 return balance_result.ok();
             }

--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -54,10 +54,10 @@ impl RpcClient {
 
     pub fn send_transaction(&self, transaction: &Transaction) -> Result<String, ClientError> {
         let serialized = serialize(transaction).unwrap();
-        let params = json!([serialized]);
+        let params = json!(serialized);
         let signature = self
             .client
-            .send(&RpcRequest::SendTransaction, Some(params), 5)?;
+            .send(&RpcRequest::SendTransaction, Some(params), 5, None)?;
         if signature.as_str().is_none() {
             Err(io::Error::new(
                 io::ErrorKind::Other,
@@ -73,10 +73,10 @@ impl RpcClient {
         &self,
         signature: &str,
     ) -> Result<Option<transaction::Result<()>>, ClientError> {
-        let params = json!([signature.to_string()]);
+        let params = json!(signature.to_string());
         let signature_status =
             self.client
-                .send(&RpcRequest::GetSignatureStatus, Some(params), 5)?;
+                .send(&RpcRequest::GetSignatureStatus, Some(params), 5, None)?;
         let result: Option<transaction::Result<()>> =
             serde_json::from_value(signature_status).unwrap();
         Ok(result)
@@ -85,7 +85,7 @@ impl RpcClient {
     pub fn get_slot(&self) -> io::Result<Slot> {
         let response = self
             .client
-            .send(&RpcRequest::GetSlot, None, 0)
+            .send(&RpcRequest::GetSlot, None, 0, None)
             .map_err(|err| {
                 io::Error::new(
                     io::ErrorKind::Other,
@@ -104,7 +104,7 @@ impl RpcClient {
     pub fn get_vote_accounts(&self) -> io::Result<RpcVoteAccountStatus> {
         let response = self
             .client
-            .send(&RpcRequest::GetVoteAccounts, None, 0)
+            .send(&RpcRequest::GetVoteAccounts, None, 0, None)
             .map_err(|err| {
                 io::Error::new(
                     io::ErrorKind::Other,
@@ -123,7 +123,7 @@ impl RpcClient {
     pub fn get_epoch_info(&self) -> io::Result<RpcEpochInfo> {
         let response = self
             .client
-            .send(&RpcRequest::GetEpochInfo, None, 0)
+            .send(&RpcRequest::GetEpochInfo, None, 0, None)
             .map_err(|err| {
                 io::Error::new(
                     io::ErrorKind::Other,
@@ -142,7 +142,7 @@ impl RpcClient {
     pub fn get_epoch_schedule(&self) -> io::Result<EpochSchedule> {
         let response = self
             .client
-            .send(&RpcRequest::GetEpochSchedule, None, 0)
+            .send(&RpcRequest::GetEpochSchedule, None, 0, None)
             .map_err(|err| {
                 io::Error::new(
                     io::ErrorKind::Other,
@@ -161,7 +161,7 @@ impl RpcClient {
     pub fn get_inflation(&self) -> io::Result<Inflation> {
         let response = self
             .client
-            .send(&RpcRequest::GetInflation, None, 0)
+            .send(&RpcRequest::GetInflation, None, 0, None)
             .map_err(|err| {
                 io::Error::new(
                     io::ErrorKind::Other,
@@ -180,7 +180,7 @@ impl RpcClient {
     pub fn get_version(&self) -> io::Result<String> {
         let response = self
             .client
-            .send(&RpcRequest::GetVersion, None, 0)
+            .send(&RpcRequest::GetVersion, None, 0, None)
             .map_err(|err| {
                 io::Error::new(
                     io::ErrorKind::Other,
@@ -329,19 +329,19 @@ impl RpcClient {
         pubkey: &Pubkey,
         retries: usize,
     ) -> Result<Option<u64>, Box<dyn error::Error>> {
-        let params = json!([format!("{}", pubkey)]);
+        let params = json!(format!("{}", pubkey));
         let res = self
             .client
-            .send(&RpcRequest::GetBalance, Some(params), retries)?
+            .send(&RpcRequest::GetBalance, Some(params), retries, None)?
             .as_u64();
         Ok(res)
     }
 
     pub fn get_account(&self, pubkey: &Pubkey) -> io::Result<Account> {
-        let params = json!([format!("{}", pubkey)]);
+        let params = json!(format!("{}", pubkey));
         let response = self
             .client
-            .send(&RpcRequest::GetAccountInfo, Some(params), 0);
+            .send(&RpcRequest::GetAccountInfo, Some(params), 0, None);
 
         response
             .and_then(|account_json| {
@@ -362,13 +362,14 @@ impl RpcClient {
     }
 
     pub fn get_minimum_balance_for_rent_exemption(&self, data_len: usize) -> io::Result<u64> {
-        let params = json!([data_len]);
+        let params = json!(data_len);
         let minimum_balance_json = self
             .client
             .send(
                 &RpcRequest::GetMinimumBalanceForRentExemption,
                 Some(params),
                 0,
+                None,
             )
             .map_err(|err| {
                 io::Error::new(
@@ -402,10 +403,10 @@ impl RpcClient {
     }
 
     pub fn get_program_accounts(&self, pubkey: &Pubkey) -> io::Result<Vec<(Pubkey, Account)>> {
-        let params = json!([format!("{}", pubkey)]);
+        let params = json!(format!("{}", pubkey));
         let response = self
             .client
-            .send(&RpcRequest::GetProgramAccounts, Some(params), 0)
+            .send(&RpcRequest::GetProgramAccounts, Some(params), 0, None)
             .map_err(|err| {
                 io::Error::new(
                     io::ErrorKind::Other,
@@ -439,7 +440,7 @@ impl RpcClient {
     pub fn get_transaction_count(&self) -> io::Result<u64> {
         let response = self
             .client
-            .send(&RpcRequest::GetTransactionCount, None, 0)
+            .send(&RpcRequest::GetTransactionCount, None, 0, None)
             .map_err(|err| {
                 io::Error::new(
                     io::ErrorKind::Other,
@@ -458,7 +459,7 @@ impl RpcClient {
     pub fn get_recent_blockhash(&self) -> io::Result<(Hash, FeeCalculator)> {
         let response = self
             .client
-            .send(&RpcRequest::GetRecentBlockhash, None, 0)
+            .send(&RpcRequest::GetRecentBlockhash, None, 0, None)
             .map_err(|err| {
                 io::Error::new(
                     io::ErrorKind::Other,
@@ -514,7 +515,7 @@ impl RpcClient {
     pub fn get_genesis_blockhash(&self) -> io::Result<Hash> {
         let response = self
             .client
-            .send(&RpcRequest::GetGenesisBlockhash, None, 0)
+            .send(&RpcRequest::GetGenesisBlockhash, None, 0, None)
             .map_err(|err| {
                 io::Error::new(
                     io::ErrorKind::Other,
@@ -603,12 +604,12 @@ impl RpcClient {
     /// Check a signature in the bank.
     pub fn check_signature(&self, signature: &Signature) -> bool {
         trace!("check_signature: {:?}", signature);
-        let params = json!([format!("{}", signature)]);
+        let params = json!(format!("{}", signature));
 
         for _ in 0..30 {
             let response =
                 self.client
-                    .send(&RpcRequest::ConfirmTransaction, Some(params.clone()), 0);
+                    .send(&RpcRequest::ConfirmTransaction, Some(params.clone()), 0, None);
 
             match response {
                 Ok(confirmation) => {
@@ -686,13 +687,14 @@ impl RpcClient {
         &self,
         sig: &Signature,
     ) -> io::Result<usize> {
-        let params = json!([format!("{}", sig)]);
+        let params = json!(format!("{}", sig));
         let response = self
             .client
             .send(
                 &RpcRequest::GetNumBlocksSinceSignatureConfirmation,
                 Some(params.clone()),
                 1,
+                None,
             )
             .map_err(|err| {
                 io::Error::new(
@@ -717,7 +719,7 @@ impl RpcClient {
     pub fn validator_exit(&self) -> io::Result<bool> {
         let response = self
             .client
-            .send(&RpcRequest::ValidatorExit, None, 0)
+            .send(&RpcRequest::ValidatorExit, None, 0, None)
             .map_err(|err| {
                 io::Error::new(
                     io::ErrorKind::Other,
@@ -739,7 +741,7 @@ impl RpcClient {
         params: Option<Value>,
         retries: usize,
     ) -> Result<Value, ClientError> {
-        self.client.send(request, params, retries)
+        self.client.send(request, params, retries, None)
     }
 }
 

--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -350,11 +350,7 @@ impl RpcClient {
         Ok(res)
     }
 
-<<<<<<< HEAD
-    fn get_account_with_commitment(
-=======
-    pub fn get_account_with_confidence(
->>>>>>> Add get_account_now method to client
+    pub fn get_account_with_commitment(
         &self,
         pubkey: &Pubkey,
         commitment_config: RpcCommitmentConfig,
@@ -427,15 +423,15 @@ impl RpcClient {
     /// until the server sends a response. If the response packet is dropped
     /// by the network, this method will hang indefinitely.
     pub fn get_balance(&self, pubkey: &Pubkey) -> io::Result<u64> {
-        self.get_balance_with_confidence(pubkey, RpcConfidenceConfig::default())
+        self.get_balance_with_commitment(pubkey, RpcCommitmentConfig::default())
     }
 
-    pub fn get_balance_with_confidence(
+    pub fn get_balance_with_commitment(
         &self,
         pubkey: &Pubkey,
-        confidence_config: RpcConfidenceConfig,
+        commitment_config: RpcCommitmentConfig,
     ) -> io::Result<u64> {
-        self.get_account_with_confidence(pubkey, confidence_config)
+        self.get_account_with_commitment(pubkey, commitment_config)
             .map(|account| account.lamports)
     }
 
@@ -472,7 +468,7 @@ impl RpcClient {
         Ok(pubkey_accounts)
     }
 
-    pub fn get_transaction_count_with_confidence(
+    pub fn get_transaction_count_with_commitment(
         &self,
         commitment_config: RpcCommitmentConfig,
     ) -> io::Result<u64> {
@@ -587,16 +583,16 @@ impl RpcClient {
         Ok(blockhash)
     }
 
-    pub fn poll_balance_with_timeout_and_confidence(
+    pub fn poll_balance_with_timeout_and_commitment(
         &self,
         pubkey: &Pubkey,
         polling_frequency: &Duration,
         timeout: &Duration,
-        confidence_config: RpcConfidenceConfig,
+        commitment_config: RpcCommitmentConfig,
     ) -> io::Result<u64> {
         let now = Instant::now();
         loop {
-            match self.get_balance_with_confidence(&pubkey, confidence_config.clone()) {
+            match self.get_balance_with_commitment(&pubkey, commitment_config.clone()) {
                 Ok(bal) => {
                     return Ok(bal);
                 }
@@ -610,29 +606,29 @@ impl RpcClient {
         }
     }
 
-    pub fn poll_get_balance_with_confidence(
+    pub fn poll_get_balance_with_commitment(
         &self,
         pubkey: &Pubkey,
-        confidence_config: RpcConfidenceConfig,
+        commitment_config: RpcCommitmentConfig,
     ) -> io::Result<u64> {
-        self.poll_balance_with_timeout_and_confidence(
+        self.poll_balance_with_timeout_and_commitment(
             pubkey,
             &Duration::from_millis(100),
             &Duration::from_secs(1),
-            confidence_config,
+            commitment_config,
         )
     }
 
-    pub fn wait_for_balance_with_confidence(
+    pub fn wait_for_balance_with_commitment(
         &self,
         pubkey: &Pubkey,
         expected_balance: Option<u64>,
-        confidence_config: RpcConfidenceConfig,
+        commitment_config: RpcCommitmentConfig,
     ) -> Option<u64> {
         const LAST: usize = 30;
         for run in 0..LAST {
             let balance_result =
-                self.poll_get_balance_with_confidence(pubkey, confidence_config.clone());
+                self.poll_get_balance_with_commitment(pubkey, commitment_config.clone());
             if expected_balance.is_none() {
                 return balance_result.ok();
             }
@@ -761,7 +757,7 @@ impl RpcClient {
                 &RpcRequest::GetNumBlocksSinceSignatureConfirmation,
                 Some(params.clone()),
                 1,
-                RpcConfidenceConfig::recent().ok(),
+                None,
             )
             .map_err(|err| {
                 io::Error::new(

--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -761,7 +761,7 @@ impl RpcClient {
                 &RpcRequest::GetNumBlocksSinceSignatureConfirmation,
                 Some(params.clone()),
                 1,
-                None,
+                RpcConfidenceConfig::recent().ok(),
             )
             .map_err(|err| {
                 io::Error::new(

--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -203,7 +203,7 @@ impl RpcClient {
     ) -> Result<String, ClientError> {
         let mut send_retries = 20;
         loop {
-            let mut status_retries = 4;
+            let mut status_retries = 15;
             let signature_str = self.send_transaction(transaction)?;
             let status = loop {
                 let status = self.get_signature_status(&signature_str)?;
@@ -216,10 +216,8 @@ impl RpcClient {
                     break status;
                 }
                 if cfg!(not(test)) {
-                    // Retry ~twice during a slot
-                    sleep(Duration::from_millis(
-                        500 * DEFAULT_TICKS_PER_SLOT / DEFAULT_TICKS_PER_SECOND,
-                    ));
+                    // Retry twice a second
+                    sleep(Duration::from_millis(500));
                 }
             };
             send_retries = if let Some(result) = status.clone() {
@@ -252,7 +250,7 @@ impl RpcClient {
     ) -> Result<(), Box<dyn error::Error>> {
         let mut send_retries = 5;
         loop {
-            let mut status_retries = 4;
+            let mut status_retries = 15;
 
             // Send all transactions
             let mut transactions_signatures = vec![];
@@ -273,10 +271,8 @@ impl RpcClient {
                 status_retries -= 1;
 
                 if cfg!(not(test)) {
-                    // Retry ~twice during a slot
-                    sleep(Duration::from_millis(
-                        500 * DEFAULT_TICKS_PER_SLOT / DEFAULT_TICKS_PER_SECOND,
-                    ));
+                    // Retry twice a second
+                    sleep(Duration::from_millis(500));
                 }
 
                 transactions_signatures = transactions_signatures

--- a/client/src/rpc_client_request.rs
+++ b/client/src/rpc_client_request.rs
@@ -1,9 +1,10 @@
 use crate::client_error::ClientError;
 use crate::generic_rpc_client_request::GenericRpcClientRequest;
-use crate::rpc_request::{RpcCommitmentConfig, RpcError, RpcRequest};
+use crate::rpc_request::{RpcError, RpcRequest};
 use log::*;
 use reqwest::{self, header::CONTENT_TYPE};
 use solana_sdk::clock::{DEFAULT_TICKS_PER_SECOND, DEFAULT_TICKS_PER_SLOT};
+use solana_sdk::commitment_config::CommitmentConfig;
 use std::thread::sleep;
 use std::time::Duration;
 
@@ -36,7 +37,7 @@ impl GenericRpcClientRequest for RpcClientRequest {
         request: &RpcRequest,
         params: Option<serde_json::Value>,
         mut retries: usize,
-        commitment_config: Option<RpcCommitmentConfig>,
+        commitment_config: Option<CommitmentConfig>,
     ) -> Result<serde_json::Value, ClientError> {
         // Concurrent requests are not supported so reuse the same request id for all requests
         let request_id = 1;

--- a/client/src/rpc_client_request.rs
+++ b/client/src/rpc_client_request.rs
@@ -1,6 +1,6 @@
 use crate::client_error::ClientError;
 use crate::generic_rpc_client_request::GenericRpcClientRequest;
-use crate::rpc_request::{RpcError, RpcRequest};
+use crate::rpc_request::{RpcCommitmentConfig, RpcError, RpcRequest};
 use log::*;
 use reqwest::{self, header::CONTENT_TYPE};
 use solana_sdk::clock::{DEFAULT_TICKS_PER_SECOND, DEFAULT_TICKS_PER_SLOT};
@@ -36,11 +36,12 @@ impl GenericRpcClientRequest for RpcClientRequest {
         request: &RpcRequest,
         params: Option<serde_json::Value>,
         mut retries: usize,
+        commitment_config: Option<RpcCommitmentConfig>,
     ) -> Result<serde_json::Value, ClientError> {
         // Concurrent requests are not supported so reuse the same request id for all requests
         let request_id = 1;
 
-        let request_json = request.build_request_json(request_id, params);
+        let request_json = request.build_request_json(request_id, params, commitment_config);
 
         loop {
             match self

--- a/client/src/rpc_request.rs
+++ b/client/src/rpc_request.rs
@@ -229,7 +229,8 @@ mod tests {
 
         // Test request with RpcCommitmentConfig and params
         let test_request = RpcRequest::GetBalance;
-        let request = test_request.build_request_json(1, Some(addr.clone()), Some(commitment_config.clone()));
+        let request =
+            test_request.build_request_json(1, Some(addr.clone()), Some(commitment_config.clone()));
         assert_eq!(request["params"], json!([addr, commitment_config]));
     }
 }

--- a/client/src/rpc_request.rs
+++ b/client/src/rpc_request.rs
@@ -2,11 +2,28 @@ use serde_json::{json, Value};
 use solana_sdk::clock::{Epoch, Slot};
 use std::{error, fmt};
 
-#[derive(Serialize, Deserialize, Clone, Debug, Default)]
+#[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct RpcCommitmentConfig {
     pub confirmations: Option<Value>,
     pub percentage: Option<f64>,
+}
+
+impl RpcConfidenceConfig {
+    pub fn recent() -> Self {
+        Self {
+            confirmations: Some(1.into()),
+            percentage: None,
+        }
+    }
+
+    pub fn ok(&self) -> Option<Self> {
+        if self == &Self::default() {
+            None
+        } else {
+            Some(self.clone())
+        }
+    }
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]

--- a/client/src/rpc_request.rs
+++ b/client/src/rpc_request.rs
@@ -9,7 +9,7 @@ pub struct RpcCommitmentConfig {
     pub percentage: Option<f64>,
 }
 
-impl RpcConfidenceConfig {
+impl RpcCommitmentConfig {
     pub fn recent() -> Self {
         Self {
             confirmations: Some(1.into()),

--- a/client/src/rpc_request.rs
+++ b/client/src/rpc_request.rs
@@ -1,30 +1,9 @@
 use serde_json::{json, Value};
-use solana_sdk::clock::{Epoch, Slot};
+use solana_sdk::{
+    clock::{Epoch, Slot},
+    commitment_config::CommitmentConfig,
+};
 use std::{error, fmt};
-
-#[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq)]
-#[serde(rename_all = "camelCase")]
-pub struct RpcCommitmentConfig {
-    pub confirmations: Option<Value>,
-    pub percentage: Option<f64>,
-}
-
-impl RpcCommitmentConfig {
-    pub fn recent() -> Self {
-        Self {
-            confirmations: Some(1.into()),
-            percentage: None,
-        }
-    }
-
-    pub fn ok(&self) -> Option<Self> {
-        if self == &Self::default() {
-            None
-        } else {
-            Some(self.clone())
-        }
-    }
-}
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
@@ -111,7 +90,7 @@ impl RpcRequest {
         &self,
         id: u64,
         params: Option<Value>,
-        commitment_config: Option<RpcCommitmentConfig>,
+        commitment_config: Option<CommitmentConfig>,
     ) -> Value {
         let jsonrpc = "2.0";
         let method = match self {
@@ -233,18 +212,18 @@ mod tests {
 
     #[test]
     fn test_build_request_json_config_options() {
-        let commitment_config = RpcCommitmentConfig {
+        let commitment_config = CommitmentConfig {
             confirmations: Some(10.into()),
             percentage: Some(0.7),
         };
         let addr = json!("deadbeefXjn8o3yroDHxUtKsZZgoy4GPkPPXfouKNHhx");
 
-        // Test request with RpcCommitmentConfig and no params
+        // Test request with CommitmentConfig and no params
         let test_request = RpcRequest::GetRecentBlockhash;
         let request = test_request.build_request_json(1, None, Some(commitment_config.clone()));
         assert_eq!(request["params"], json!([commitment_config.clone()]));
 
-        // Test request with RpcCommitmentConfig and params
+        // Test request with CommitmentConfig and params
         let test_request = RpcRequest::GetBalance;
         let request =
             test_request.build_request_json(1, Some(addr.clone()), Some(commitment_config.clone()));

--- a/client/src/rpc_request.rs
+++ b/client/src/rpc_request.rs
@@ -2,6 +2,13 @@ use serde_json::{json, Value};
 use solana_sdk::clock::{Epoch, Slot};
 use std::{error, fmt};
 
+#[derive(Serialize, Deserialize, Clone, Debug, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct RpcCommitmentConfig {
+    pub confirmations: Option<Value>,
+    pub percentage: Option<f64>,
+}
+
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct RpcEpochInfo {
@@ -83,7 +90,12 @@ pub enum RpcRequest {
 }
 
 impl RpcRequest {
-    pub(crate) fn build_request_json(&self, id: u64, params: Option<Value>) -> Value {
+    pub(crate) fn build_request_json(
+        &self,
+        id: u64,
+        params: Option<Value>,
+        commitment_config: Option<RpcCommitmentConfig>,
+    ) -> Value {
         let jsonrpc = "2.0";
         let method = match self {
             RpcRequest::ConfirmTransaction => "confirmTransaction",
@@ -123,7 +135,13 @@ impl RpcRequest {
            "method": method,
         });
         if let Some(param_string) = params {
-            request["params"] = param_string;
+            if let Some(config) = commitment_config {
+                request["params"] = json!([param_string, config]);
+            } else {
+                request["params"] = json!([param_string]);
+            }
+        } else if let Some(config) = commitment_config {
+            request["params"] = json!([config]);
         }
         request
     }
@@ -158,41 +176,60 @@ mod tests {
     #[test]
     fn test_build_request_json() {
         let test_request = RpcRequest::GetAccountInfo;
-        let addr = json!(["deadbeefXjn8o3yroDHxUtKsZZgoy4GPkPPXfouKNHhx"]);
-        let request = test_request.build_request_json(1, Some(addr.clone()));
+        let addr = json!("deadbeefXjn8o3yroDHxUtKsZZgoy4GPkPPXfouKNHhx");
+        let request = test_request.build_request_json(1, Some(addr.clone()), None);
         assert_eq!(request["method"], "getAccountInfo");
-        assert_eq!(request["params"], addr,);
+        assert_eq!(request["params"], json!([addr]));
 
         let test_request = RpcRequest::GetBalance;
-        let request = test_request.build_request_json(1, Some(addr));
+        let request = test_request.build_request_json(1, Some(addr), None);
         assert_eq!(request["method"], "getBalance");
 
         let test_request = RpcRequest::GetEpochInfo;
-        let request = test_request.build_request_json(1, None);
+        let request = test_request.build_request_json(1, None, None);
         assert_eq!(request["method"], "getEpochInfo");
 
         let test_request = RpcRequest::GetInflation;
-        let request = test_request.build_request_json(1, None);
+        let request = test_request.build_request_json(1, None, None);
         assert_eq!(request["method"], "getInflation");
 
         let test_request = RpcRequest::GetRecentBlockhash;
-        let request = test_request.build_request_json(1, None);
+        let request = test_request.build_request_json(1, None, None);
         assert_eq!(request["method"], "getRecentBlockhash");
 
         let test_request = RpcRequest::GetSlot;
-        let request = test_request.build_request_json(1, None);
+        let request = test_request.build_request_json(1, None, None);
         assert_eq!(request["method"], "getSlot");
 
         let test_request = RpcRequest::GetTransactionCount;
-        let request = test_request.build_request_json(1, None);
+        let request = test_request.build_request_json(1, None, None);
         assert_eq!(request["method"], "getTransactionCount");
 
         let test_request = RpcRequest::RequestAirdrop;
-        let request = test_request.build_request_json(1, None);
+        let request = test_request.build_request_json(1, None, None);
         assert_eq!(request["method"], "requestAirdrop");
 
         let test_request = RpcRequest::SendTransaction;
-        let request = test_request.build_request_json(1, None);
+        let request = test_request.build_request_json(1, None, None);
         assert_eq!(request["method"], "sendTransaction");
+    }
+
+    #[test]
+    fn test_build_request_json_config_options() {
+        let commitment_config = RpcCommitmentConfig {
+            confirmations: Some(10.into()),
+            percentage: Some(0.7),
+        };
+        let addr = json!("deadbeefXjn8o3yroDHxUtKsZZgoy4GPkPPXfouKNHhx");
+
+        // Test request with RpcCommitmentConfig and no params
+        let test_request = RpcRequest::GetRecentBlockhash;
+        let request = test_request.build_request_json(1, None, Some(commitment_config.clone()));
+        assert_eq!(request["params"], json!([commitment_config.clone()]));
+
+        // Test request with RpcCommitmentConfig and params
+        let test_request = RpcRequest::GetBalance;
+        let request = test_request.build_request_json(1, Some(addr.clone()), Some(commitment_config.clone()));
+        assert_eq!(request["params"], json!([addr, commitment_config]));
     }
 }

--- a/client/src/thin_client.rs
+++ b/client/src/thin_client.rs
@@ -387,9 +387,17 @@ impl SyncClient for ThinClient {
     }
 
     fn get_recent_blockhash(&self) -> TransportResult<(Hash, FeeCalculator)> {
+        self.get_recent_blockhash_with_commitment(CommitmentConfig::default())
+    }
+
+    fn get_recent_blockhash_with_commitment(
+        &self,
+        commitment_config: CommitmentConfig,
+    ) -> TransportResult<(Hash, FeeCalculator)> {
         let index = self.optimizer.experiment();
         let now = Instant::now();
-        let recent_blockhash = self.rpc_clients[index].get_recent_blockhash();
+        let recent_blockhash =
+            self.rpc_clients[index].get_recent_blockhash_with_commitment(commitment_config);
         match recent_blockhash {
             Ok(recent_blockhash) => {
                 self.optimizer.report(index, duration_as_ms(&now.elapsed()));
@@ -436,12 +444,22 @@ impl SyncClient for ThinClient {
     }
 
     fn get_slot(&self) -> TransportResult<u64> {
-        let slot = self.rpc_client().get_slot().map_err(|err| {
-            io::Error::new(
-                io::ErrorKind::Other,
-                format!("send_transaction failed with error {:?}", err),
-            )
-        })?;
+        self.get_slot_with_commitment(CommitmentConfig::default())
+    }
+
+    fn get_slot_with_commitment(
+        &self,
+        commitment_config: CommitmentConfig,
+    ) -> TransportResult<u64> {
+        let slot = self
+            .rpc_client()
+            .get_slot_with_commitment(commitment_config)
+            .map_err(|err| {
+                io::Error::new(
+                    io::ErrorKind::Other,
+                    format!("send_transaction failed with error {:?}", err),
+                )
+            })?;
         Ok(slot)
     }
 

--- a/client/src/thin_client.rs
+++ b/client/src/thin_client.rs
@@ -277,7 +277,24 @@ impl ThinClient {
     }
 
     pub fn wait_for_balance(&self, pubkey: &Pubkey, expected_balance: Option<u64>) -> Option<u64> {
-        self.rpc_client().wait_for_balance(pubkey, expected_balance)
+        self.rpc_client().wait_for_balance_with_confidence(
+            pubkey,
+            expected_balance,
+            RpcConfidenceConfig::default(),
+        )
+    }
+
+    pub fn wait_for_balance_with_confidence(
+        &self,
+        pubkey: &Pubkey,
+        expected_balance: Option<u64>,
+        confidence_config: RpcConfidenceConfig,
+    ) -> Option<u64> {
+        self.rpc_client().wait_for_balance_with_confidence(
+            pubkey,
+            expected_balance,
+            confidence_config,
+        )
     }
 
     /// Check a signature in the bank. This method blocks

--- a/client/src/thin_client.rs
+++ b/client/src/thin_client.rs
@@ -358,6 +358,13 @@ impl SyncClient for ThinClient {
         Ok(self.rpc_client().get_account(pubkey).ok())
     }
 
+    fn get_account_now(&self, pubkey: &Pubkey) -> TransportResult<Option<Account>> {
+        Ok(self
+            .rpc_client()
+            .get_account_with_confidence(pubkey, RpcConfidenceConfig::recent())
+            .ok())
+    }
+
     fn get_balance(&self, pubkey: &Pubkey) -> TransportResult<u64> {
         let balance = self.rpc_client().get_balance(pubkey)?;
         Ok(balance)

--- a/client/src/thin_client.rs
+++ b/client/src/thin_client.rs
@@ -254,12 +254,26 @@ impl ThinClient {
         polling_frequency: &Duration,
         timeout: &Duration,
     ) -> io::Result<u64> {
-        self.rpc_client()
-            .poll_balance_with_timeout(pubkey, polling_frequency, timeout)
+        self.rpc_client().poll_balance_with_timeout_and_confidence(
+            pubkey,
+            polling_frequency,
+            timeout,
+            RpcConfidenceConfig::default(),
+        )
     }
 
     pub fn poll_get_balance(&self, pubkey: &Pubkey) -> io::Result<u64> {
-        self.rpc_client().poll_get_balance(pubkey)
+        self.rpc_client()
+            .poll_get_balance_with_confidence(pubkey, RpcConfidenceConfig::default())
+    }
+
+    pub fn poll_get_balance_with_confidence(
+        &self,
+        pubkey: &Pubkey,
+        confidence_config: RpcConfidenceConfig,
+    ) -> io::Result<u64> {
+        self.rpc_client()
+            .poll_get_balance_with_confidence(pubkey, confidence_config)
     }
 
     pub fn wait_for_balance(&self, pubkey: &Pubkey, expected_balance: Option<u64>) -> Option<u64> {

--- a/client/src/thin_client.rs
+++ b/client/src/thin_client.rs
@@ -3,7 +3,7 @@
 //! messages to the network directly. The binary encoding of its messages are
 //! unstable and may change in future releases.
 
-use crate::{rpc_client::RpcClient, rpc_request::RpcConfidenceConfig};
+use crate::{rpc_client::RpcClient, rpc_request::RpcCommitmentConfig};
 use bincode::{serialize_into, serialized_size};
 use log::*;
 use solana_sdk::{
@@ -254,46 +254,46 @@ impl ThinClient {
         polling_frequency: &Duration,
         timeout: &Duration,
     ) -> io::Result<u64> {
-        self.rpc_client().poll_balance_with_timeout_and_confidence(
+        self.rpc_client().poll_balance_with_timeout_and_commitment(
             pubkey,
             polling_frequency,
             timeout,
-            RpcConfidenceConfig::default(),
+            RpcCommitmentConfig::default(),
         )
     }
 
     pub fn poll_get_balance(&self, pubkey: &Pubkey) -> io::Result<u64> {
         self.rpc_client()
-            .poll_get_balance_with_confidence(pubkey, RpcConfidenceConfig::default())
+            .poll_get_balance_with_commitment(pubkey, RpcCommitmentConfig::default())
     }
 
-    pub fn poll_get_balance_with_confidence(
+    pub fn poll_get_balance_with_commitment(
         &self,
         pubkey: &Pubkey,
-        confidence_config: RpcConfidenceConfig,
+        commitment_config: RpcCommitmentConfig,
     ) -> io::Result<u64> {
         self.rpc_client()
-            .poll_get_balance_with_confidence(pubkey, confidence_config)
+            .poll_get_balance_with_commitment(pubkey, commitment_config)
     }
 
     pub fn wait_for_balance(&self, pubkey: &Pubkey, expected_balance: Option<u64>) -> Option<u64> {
-        self.rpc_client().wait_for_balance_with_confidence(
+        self.rpc_client().wait_for_balance_with_commitment(
             pubkey,
             expected_balance,
-            RpcConfidenceConfig::default(),
+            RpcCommitmentConfig::default(),
         )
     }
 
-    pub fn wait_for_balance_with_confidence(
+    pub fn wait_for_balance_with_commitment(
         &self,
         pubkey: &Pubkey,
         expected_balance: Option<u64>,
-        confidence_config: RpcConfidenceConfig,
+        commitment_config: RpcCommitmentConfig,
     ) -> Option<u64> {
-        self.rpc_client().wait_for_balance_with_confidence(
+        self.rpc_client().wait_for_balance_with_commitment(
             pubkey,
             expected_balance,
-            confidence_config,
+            commitment_config,
         )
     }
 
@@ -361,7 +361,7 @@ impl SyncClient for ThinClient {
     fn get_account_now(&self, pubkey: &Pubkey) -> TransportResult<Option<Account>> {
         Ok(self
             .rpc_client()
-            .get_account_with_confidence(pubkey, RpcConfidenceConfig::recent())
+            .get_account_with_commitment(pubkey, RpcCommitmentConfig::recent())
             .ok())
     }
 
@@ -373,7 +373,7 @@ impl SyncClient for ThinClient {
     fn get_balance_now(&self, pubkey: &Pubkey) -> TransportResult<u64> {
         let balance = self
             .rpc_client()
-            .get_balance_with_confidence(pubkey, RpcConfidenceConfig::recent())?;
+            .get_balance_with_commitment(pubkey, RpcCommitmentConfig::recent())?;
         Ok(balance)
     }
 
@@ -415,9 +415,9 @@ impl SyncClient for ThinClient {
     ) -> TransportResult<Option<transaction::Result<()>>> {
         let status = self
             .rpc_client()
-            .get_signature_status_with_confidence(
+            .get_signature_status_with_commitment(
                 &signature.to_string(),
-                RpcConfidenceConfig::recent(),
+                RpcCommitmentConfig::recent(),
             )
             .map_err(|err| {
                 io::Error::new(
@@ -458,7 +458,7 @@ impl SyncClient for ThinClient {
         let now = Instant::now();
         match self
             .rpc_client()
-            .get_transaction_count_with_confidence(RpcConfidenceConfig::recent())
+            .get_transaction_count_with_commitment(RpcCommitmentConfig::recent())
         {
             Ok(transaction_count) => {
                 self.optimizer.report(index, duration_as_ms(&now.elapsed()));

--- a/core/src/commitment.rs
+++ b/core/src/commitment.rs
@@ -16,7 +16,7 @@ use std::{
     time::Duration,
 };
 
-pub const DEFAULT_PERCENT_COMMITMENT: f64 = 0.66667;
+pub const DEFAULT_PERCENT_COMMITMENT: f64 = 2_f64 / 3_f64;
 
 #[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
 pub struct BlockCommitment {
@@ -74,7 +74,7 @@ impl BlockCommitmentCache {
                     .cloned()
                     .sum();
                 block_stake_minimum_depth as f64 / self.total_stake as f64
-                    >= commitment_config.percentage
+                    > commitment_config.percentage
             })
             .map(|(slot, _)| *slot)
             .max()
@@ -287,11 +287,11 @@ mod tests {
         // Build BlockCommitmentCache with votes at depths 0 and 1 for 2 slots
         let mut cache0 = BlockCommitment::default();
         cache0.increase_confirmation_stake(1, 15);
-        cache0.increase_confirmation_stake(2, 25);
+        cache0.increase_confirmation_stake(2, 26);
 
         let mut cache1 = BlockCommitment::default();
         cache1.increase_confirmation_stake(1, 10);
-        cache1.increase_confirmation_stake(2, 20);
+        cache1.increase_confirmation_stake(2, 21);
 
         let mut block_commitment = HashMap::new();
         block_commitment.entry(0).or_insert(cache0.clone());

--- a/core/src/commitment.rs
+++ b/core/src/commitment.rs
@@ -63,7 +63,7 @@ impl BlockCommitmentCache {
 
     pub fn get_block_with_depth_commitment(
         &self,
-        commitment_config: CommitmentConfig,
+        commitment_config: ParsedCommitment,
     ) -> Option<u64> {
         self.block_commitment
             .iter()
@@ -241,12 +241,12 @@ impl Service for AggregateCommitmentService {
 }
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct CommitmentConfig {
+pub struct ParsedCommitment {
     pub confirmations: usize,
     pub percentage: f64,
 }
 
-impl CommitmentConfig {
+impl ParsedCommitment {
     pub fn new(confirmations: usize, percentage: f64) -> Self {
         Self {
             confirmations,
@@ -255,9 +255,9 @@ impl CommitmentConfig {
     }
 }
 
-impl Default for CommitmentConfig {
+impl Default for ParsedCommitment {
     fn default() -> Self {
-        CommitmentConfig {
+        ParsedCommitment {
             confirmations: MAX_LOCKOUT_HISTORY,
             percentage: DEFAULT_PERCENT_COMMITMENT,
         }
@@ -300,27 +300,27 @@ pub(crate) mod tests {
 
         // Neither slot meets the minimum level of commitment 0.6 at depth 1
         assert_eq!(
-            block_commitment_cache.get_block_with_depth_commitment(CommitmentConfig::new(2, 0.6)),
+            block_commitment_cache.get_block_with_depth_commitment(ParsedCommitment::new(2, 0.6)),
             None
         );
         // Only slot 0 meets the minimum level of commitment 0.5 at depth 1
         assert_eq!(
-            block_commitment_cache.get_block_with_depth_commitment(CommitmentConfig::new(2, 0.5)),
+            block_commitment_cache.get_block_with_depth_commitment(ParsedCommitment::new(2, 0.5)),
             Some(0)
         );
         // If multiple slots meet the minimum level of commitment, method should return the most recent
         assert_eq!(
-            block_commitment_cache.get_block_with_depth_commitment(CommitmentConfig::new(2, 0.4)),
+            block_commitment_cache.get_block_with_depth_commitment(ParsedCommitment::new(2, 0.4)),
             Some(1)
         );
         // If multiple slots meet the minimum level of commitment, method should return the most recent
         assert_eq!(
-            block_commitment_cache.get_block_with_depth_commitment(CommitmentConfig::new(1, 0.6)),
+            block_commitment_cache.get_block_with_depth_commitment(ParsedCommitment::new(1, 0.6)),
             Some(1)
         );
         // Neither slot meets the minimum level of commitment 0.9 at depth 0
         assert_eq!(
-            block_commitment_cache.get_block_with_depth_commitment(CommitmentConfig::new(1, 0.9)),
+            block_commitment_cache.get_block_with_depth_commitment(ParsedCommitment::new(1, 0.9)),
             None
         );
     }

--- a/core/src/commitment.rs
+++ b/core/src/commitment.rs
@@ -265,7 +265,7 @@ impl Default for CommitmentConfig {
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use super::*;
     use crate::genesis_utils::{create_genesis_block, GenesisBlockInfo};
     use solana_sdk::pubkey::Pubkey;
@@ -323,6 +323,19 @@ mod tests {
             block_commitment_cache.get_block_with_depth_commitment(CommitmentConfig::new(1, 0.9)),
             None
         );
+    }
+
+    pub fn get_full_block_commitment_cache() -> BlockCommitmentCache {
+        let stake = 42;
+        let mut block_commitment_map: HashMap<u64, BlockCommitment> = HashMap::new();
+        for i in 1..MAX_LOCKOUT_HISTORY + 1 {
+            let mut commitment = BlockCommitment::default();
+            commitment.increase_confirmation_stake(i, stake);
+            block_commitment_map
+                .entry((MAX_LOCKOUT_HISTORY - i) as u64)
+                .or_insert(commitment);
+        }
+        BlockCommitmentCache::new(block_commitment_map, stake)
     }
 
     #[test]

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -12,8 +12,7 @@ use crate::{
 use bincode::{deserialize, serialize};
 use jsonrpc_core::{Error, Metadata, Params, Result};
 use jsonrpc_derive::rpc;
-use serde_json::Value;
-use solana_client::rpc_request::{RpcEpochInfo, RpcVoteAccountInfo, RpcVoteAccountStatus};
+use solana_client::rpc_request::{RpcCommitmentConfig, RpcEpochInfo, RpcVoteAccountInfo, RpcVoteAccountStatus};
 use solana_drone::drone::request_airdrop_transaction;
 use solana_ledger::bank_forks::BankForks;
 use solana_runtime::bank::Bank;
@@ -295,13 +294,6 @@ pub struct RpcContactInfo {
 pub struct RpcVersionInfo {
     /// The current version of solana-core
     pub solana_core: String,
-}
-
-#[derive(Serialize, Deserialize, Debug, Default)]
-#[serde(rename_all = "camelCase")]
-pub struct RpcCommitmentConfig {
-    confirmations: Option<Value>,
-    percentage: Option<f64>,
 }
 
 fn parse_params(params: Option<Params>) -> Result<CommitmentConfig> {

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -12,7 +12,9 @@ use crate::{
 use bincode::{deserialize, serialize};
 use jsonrpc_core::{Error, Metadata, Params, Result};
 use jsonrpc_derive::rpc;
-use solana_client::rpc_request::{RpcCommitmentConfig, RpcEpochInfo, RpcVoteAccountInfo, RpcVoteAccountStatus};
+use solana_client::rpc_request::{
+    RpcCommitmentConfig, RpcEpochInfo, RpcVoteAccountInfo, RpcVoteAccountStatus,
+};
 use solana_drone::drone::request_airdrop_transaction;
 use solana_ledger::bank_forks::BankForks;
 use solana_runtime::bank::Bank;

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -138,24 +138,6 @@ impl JsonRpcRequestProcessor {
         )
     }
 
-    pub fn get_signature_status(
-        &self,
-        signature: Signature,
-        commitment_params: Option<CommitmentParams>,
-    ) -> Option<transaction::Result<()>> {
-        self.get_signature_confirmation_status(signature, commitment_params)
-            .map(|x| x.1)
-    }
-
-    pub fn get_signature_confirmations(
-        &self,
-        signature: Signature,
-        commitment_params: Option<CommitmentParams>,
-    ) -> Option<usize> {
-        self.get_signature_confirmation_status(signature, commitment_params)
-            .map(|x| x.0)
-    }
-
     pub fn get_signature_confirmation_status(
         &self,
         signature: Signature,
@@ -839,7 +821,8 @@ impl RpcSol for RpcSolImpl {
                 .request_processor
                 .read()
                 .unwrap()
-                .get_signature_status(signature, CommitmentParams::default());
+                .get_signature_confirmation_status(signature, CommitmentParams::default())
+                .map(|x| x.1);
 
             if signature_status == Some(Ok(())) {
                 info!("airdrop signature ok");

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -116,7 +116,7 @@ impl JsonRpcRequestProcessor {
         (blockhash.to_string(), fee_calculator)
     }
 
-    fn get_block_commitment(&self, block: u64) -> (Option<BlockCommitment>, u64) {
+    fn get_block_commitment(&self, block: Slot) -> (Option<BlockCommitment>, u64) {
         let r_block_commitment = self.block_commitment_cache.read().unwrap();
         (
             r_block_commitment.get_block_commitment(block).cloned(),
@@ -281,129 +281,146 @@ pub trait RpcSol {
     type Metadata;
 
     #[rpc(meta, name = "confirmTransaction")]
-    fn confirm_transaction(&self, _: Self::Metadata, _: String) -> Result<bool>;
+    fn confirm_transaction(&self, meta: Self::Metadata, signature_str: String) -> Result<bool>;
 
     #[rpc(meta, name = "getAccountInfo")]
-    fn get_account_info(&self, _: Self::Metadata, _: String) -> Result<Account>;
+    fn get_account_info(&self, meta: Self::Metadata, pubkey_str: String) -> Result<Account>;
 
     #[rpc(meta, name = "getProgramAccounts")]
-    fn get_program_accounts(&self, _: Self::Metadata, _: String) -> Result<Vec<(String, Account)>>;
+    fn get_program_accounts(
+        &self,
+        meta: Self::Metadata,
+        program_id_str: String,
+    ) -> Result<Vec<(String, Account)>>;
 
     #[rpc(meta, name = "getMinimumBalanceForRentExemption")]
-    fn get_minimum_balance_for_rent_exemption(&self, _: Self::Metadata, _: usize) -> Result<u64>;
+    fn get_minimum_balance_for_rent_exemption(
+        &self,
+        meta: Self::Metadata,
+        data_len: usize,
+    ) -> Result<u64>;
 
     #[rpc(meta, name = "getInflation")]
-    fn get_inflation(&self, _: Self::Metadata) -> Result<Inflation>;
+    fn get_inflation(&self, meta: Self::Metadata) -> Result<Inflation>;
 
     #[rpc(meta, name = "getEpochSchedule")]
-    fn get_epoch_schedule(&self, _: Self::Metadata) -> Result<EpochSchedule>;
+    fn get_epoch_schedule(&self, meta: Self::Metadata) -> Result<EpochSchedule>;
 
     #[rpc(meta, name = "getBalance")]
-    fn get_balance(&self, _: Self::Metadata, _: String) -> Result<u64>;
+    fn get_balance(&self, meta: Self::Metadata, pubkey_str: String) -> Result<u64>;
 
     #[rpc(meta, name = "getClusterNodes")]
-    fn get_cluster_nodes(&self, _: Self::Metadata) -> Result<Vec<RpcContactInfo>>;
+    fn get_cluster_nodes(&self, meta: Self::Metadata) -> Result<Vec<RpcContactInfo>>;
 
     #[rpc(meta, name = "getEpochInfo")]
-    fn get_epoch_info(&self, _: Self::Metadata) -> Result<RpcEpochInfo>;
+    fn get_epoch_info(&self, meta: Self::Metadata) -> Result<RpcEpochInfo>;
 
     #[rpc(meta, name = "getBlockCommitment")]
     fn get_block_commitment(
         &self,
-        _: Self::Metadata,
-        _: u64,
+        meta: Self::Metadata,
+        block: u64,
     ) -> Result<(Option<BlockCommitment>, u64)>;
 
     #[rpc(meta, name = "getGenesisBlockhash")]
-    fn get_genesis_blockhash(&self, _: Self::Metadata) -> Result<String>;
+    fn get_genesis_blockhash(&self, meta: Self::Metadata) -> Result<String>;
 
     #[rpc(meta, name = "getLeaderSchedule")]
-    fn get_leader_schedule(&self, _: Self::Metadata) -> Result<Option<Vec<String>>>;
+    fn get_leader_schedule(&self, meta: Self::Metadata) -> Result<Option<Vec<String>>>;
 
     #[rpc(meta, name = "getRecentBlockhash")]
-    fn get_recent_blockhash(&self, _: Self::Metadata) -> Result<(String, FeeCalculator)>;
+    fn get_recent_blockhash(&self, meta: Self::Metadata) -> Result<(String, FeeCalculator)>;
 
     #[rpc(meta, name = "getSignatureStatus")]
     fn get_signature_status(
         &self,
-        _: Self::Metadata,
-        _: String,
+        meta: Self::Metadata,
+        signature_str: String,
     ) -> Result<Option<transaction::Result<()>>>;
 
     #[rpc(meta, name = "getSlot")]
-    fn get_slot(&self, _: Self::Metadata) -> Result<u64>;
+    fn get_slot(&self, meta: Self::Metadata) -> Result<u64>;
 
     #[rpc(meta, name = "getTransactionCount")]
-    fn get_transaction_count(&self, _: Self::Metadata) -> Result<u64>;
+    fn get_transaction_count(&self, meta: Self::Metadata) -> Result<u64>;
 
     #[rpc(meta, name = "getTotalSupply")]
-    fn get_total_supply(&self, _: Self::Metadata) -> Result<u64>;
+    fn get_total_supply(&self, meta: Self::Metadata) -> Result<u64>;
 
     #[rpc(meta, name = "requestAirdrop")]
-    fn request_airdrop(&self, _: Self::Metadata, _: String, _: u64) -> Result<String>;
+    fn request_airdrop(
+        &self,
+        meta: Self::Metadata,
+        pubkey_str: String,
+        lamports: u64,
+    ) -> Result<String>;
 
     #[rpc(meta, name = "sendTransaction")]
-    fn send_transaction(&self, _: Self::Metadata, _: Vec<u8>) -> Result<String>;
+    fn send_transaction(&self, meta: Self::Metadata, data: Vec<u8>) -> Result<String>;
 
     #[rpc(meta, name = "getSlotLeader")]
-    fn get_slot_leader(&self, _: Self::Metadata) -> Result<String>;
+    fn get_slot_leader(&self, meta: Self::Metadata) -> Result<String>;
 
     #[rpc(meta, name = "getVoteAccounts")]
-    fn get_vote_accounts(&self, _: Self::Metadata) -> Result<RpcVoteAccountStatus>;
+    fn get_vote_accounts(&self, meta: Self::Metadata) -> Result<RpcVoteAccountStatus>;
 
     #[rpc(meta, name = "getStorageTurnRate")]
-    fn get_storage_turn_rate(&self, _: Self::Metadata) -> Result<u64>;
+    fn get_storage_turn_rate(&self, meta: Self::Metadata) -> Result<u64>;
 
     #[rpc(meta, name = "getStorageTurn")]
-    fn get_storage_turn(&self, _: Self::Metadata) -> Result<(String, u64)>;
+    fn get_storage_turn(&self, meta: Self::Metadata) -> Result<(String, u64)>;
 
     #[rpc(meta, name = "getSlotsPerSegment")]
-    fn get_slots_per_segment(&self, _: Self::Metadata) -> Result<u64>;
+    fn get_slots_per_segment(&self, meta: Self::Metadata) -> Result<u64>;
 
     #[rpc(meta, name = "getStoragePubkeysForSlot")]
-    fn get_storage_pubkeys_for_slot(&self, _: Self::Metadata, _: u64) -> Result<Vec<Pubkey>>;
+    fn get_storage_pubkeys_for_slot(&self, meta: Self::Metadata, slot: u64) -> Result<Vec<Pubkey>>;
 
     #[rpc(meta, name = "validatorExit")]
-    fn validator_exit(&self, _: Self::Metadata) -> Result<bool>;
+    fn validator_exit(&self, meta: Self::Metadata) -> Result<bool>;
 
     #[rpc(meta, name = "getNumBlocksSinceSignatureConfirmation")]
     fn get_num_blocks_since_signature_confirmation(
         &self,
-        _: Self::Metadata,
-        _: String,
+        meta: Self::Metadata,
+        signature_str: String,
     ) -> Result<Option<usize>>;
 
     #[rpc(meta, name = "getSignatureConfirmation")]
     fn get_signature_confirmation(
         &self,
-        _: Self::Metadata,
-        _: String,
+        meta: Self::Metadata,
+        signature_str: String,
     ) -> Result<Option<(usize, transaction::Result<()>)>>;
 
     #[rpc(meta, name = "getVersion")]
-    fn get_version(&self, _: Self::Metadata) -> Result<RpcVersionInfo>;
+    fn get_version(&self, meta: Self::Metadata) -> Result<RpcVersionInfo>;
 
     #[rpc(meta, name = "setLogFilter")]
-    fn set_log_filter(&self, _: Self::Metadata, _: String) -> Result<()>;
+    fn set_log_filter(&self, _meta: Self::Metadata, filter: String) -> Result<()>;
 }
 
 pub struct RpcSolImpl;
 impl RpcSol for RpcSolImpl {
     type Metadata = Meta;
 
-    fn confirm_transaction(&self, meta: Self::Metadata, id: String) -> Result<bool> {
-        debug!("confirm_transaction rpc request received: {:?}", id);
-        self.get_signature_status(meta, id).map(|status_option| {
-            if status_option.is_none() {
-                return false;
-            }
-            status_option.unwrap().is_ok()
-        })
+    fn confirm_transaction(&self, meta: Self::Metadata, signature_str: String) -> Result<bool> {
+        debug!(
+            "confirm_transaction rpc request received: {:?}",
+            signature_str
+        );
+        self.get_signature_status(meta, signature_str)
+            .map(|status_option| {
+                if status_option.is_none() {
+                    return false;
+                }
+                status_option.unwrap().is_ok()
+            })
     }
 
-    fn get_account_info(&self, meta: Self::Metadata, id: String) -> Result<Account> {
-        debug!("get_account_info rpc request received: {:?}", id);
-        let pubkey = verify_pubkey(id)?;
+    fn get_account_info(&self, meta: Self::Metadata, pubkey_str: String) -> Result<Account> {
+        debug!("get_account_info rpc request received: {:?}", pubkey_str);
+        let pubkey = verify_pubkey(pubkey_str)?;
         meta.request_processor
             .read()
             .unwrap()
@@ -428,10 +445,13 @@ impl RpcSol for RpcSolImpl {
     fn get_program_accounts(
         &self,
         meta: Self::Metadata,
-        id: String,
+        program_id_str: String,
     ) -> Result<Vec<(String, Account)>> {
-        debug!("get_program_accounts rpc request received: {:?}", id);
-        let program_id = verify_pubkey(id)?;
+        debug!(
+            "get_program_accounts rpc request received: {:?}",
+            program_id_str
+        );
+        let program_id = verify_pubkey(program_id_str)?;
         meta.request_processor
             .read()
             .unwrap()
@@ -458,9 +478,9 @@ impl RpcSol for RpcSolImpl {
             .unwrap())
     }
 
-    fn get_balance(&self, meta: Self::Metadata, id: String) -> Result<u64> {
-        debug!("get_balance rpc request received: {:?}", id);
-        let pubkey = verify_pubkey(id)?;
+    fn get_balance(&self, meta: Self::Metadata, pubkey_str: String) -> Result<u64> {
+        debug!("get_balance rpc request received: {:?}", pubkey_str);
+        let pubkey = verify_pubkey(pubkey_str)?;
         Ok(meta.request_processor.read().unwrap().get_balance(&pubkey))
     }
 
@@ -507,7 +527,7 @@ impl RpcSol for RpcSolImpl {
     fn get_block_commitment(
         &self,
         meta: Self::Metadata,
-        block: u64,
+        block: Slot,
     ) -> Result<(Option<BlockCommitment>, u64)> {
         Ok(meta
             .request_processor
@@ -548,9 +568,9 @@ impl RpcSol for RpcSolImpl {
     fn get_signature_status(
         &self,
         meta: Self::Metadata,
-        id: String,
+        signature_str: String,
     ) -> Result<Option<transaction::Result<()>>> {
-        self.get_signature_confirmation(meta, id)
+        self.get_signature_confirmation(meta, signature_str)
             .map(|res| res.map(|x| x.1))
     }
 
@@ -561,19 +581,22 @@ impl RpcSol for RpcSolImpl {
     fn get_num_blocks_since_signature_confirmation(
         &self,
         meta: Self::Metadata,
-        id: String,
+        signature_str: String,
     ) -> Result<Option<usize>> {
-        self.get_signature_confirmation(meta, id)
+        self.get_signature_confirmation(meta, signature_str)
             .map(|res| res.map(|x| x.0))
     }
 
     fn get_signature_confirmation(
         &self,
         meta: Self::Metadata,
-        id: String,
+        signature_str: String,
     ) -> Result<Option<(usize, transaction::Result<()>)>> {
-        debug!("get_signature_confirmation rpc request received: {:?}", id);
-        let signature = verify_signature(&id)?;
+        debug!(
+            "get_signature_confirmation rpc request received: {:?}",
+            signature_str
+        );
+        let signature = verify_signature(&signature_str)?;
         Ok(meta
             .request_processor
             .read()
@@ -594,8 +617,13 @@ impl RpcSol for RpcSolImpl {
         meta.request_processor.read().unwrap().get_total_supply()
     }
 
-    fn request_airdrop(&self, meta: Self::Metadata, id: String, lamports: u64) -> Result<String> {
-        trace!("request_airdrop id={} lamports={}", id, lamports);
+    fn request_airdrop(
+        &self,
+        meta: Self::Metadata,
+        pubkey_str: String,
+        lamports: u64,
+    ) -> Result<String> {
+        trace!("request_airdrop id={} lamports={}", pubkey_str, lamports);
 
         let drone_addr = meta
             .request_processor
@@ -604,7 +632,7 @@ impl RpcSol for RpcSolImpl {
             .config
             .drone_addr
             .ok_or_else(Error::invalid_request)?;
-        let pubkey = verify_pubkey(id)?;
+        let pubkey = verify_pubkey(pubkey_str)?;
 
         let blockhash = meta
             .request_processor
@@ -732,7 +760,7 @@ impl RpcSol for RpcSolImpl {
         })
     }
 
-    fn set_log_filter(&self, _: Self::Metadata, filter: String) -> Result<()> {
+    fn set_log_filter(&self, _meta: Self::Metadata, filter: String) -> Result<()> {
         solana_logger::setup_with_filter(&filter);
         Ok(())
     }

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     cluster_info::ClusterInfo,
-    commitment::{BlockCommitment, BlockCommitmentCache},
+    commitment::{BlockCommitment, CommitmentConfig, BlockCommitmentCache},
     contact_info::ContactInfo,
     packet::PACKET_DATA_SIZE,
     storage_stage::StorageState,
@@ -34,38 +34,6 @@ use std::{
     thread::sleep,
     time::{Duration, Instant},
 };
-
-pub const DEFAULT_PERCENT_COMMITMENT: f64 = 0.66667;
-
-#[derive(Clone, Debug, PartialEq)]
-pub struct CommitmentConfig {
-    confirmations: usize,
-    percentage: f64,
-}
-
-impl CommitmentConfig {
-    pub fn new(confirmations: usize, percentage: f64) -> Self {
-        Self {
-            confirmations,
-            percentage,
-        }
-    }
-    pub fn minimum_depth(&self) -> usize {
-        self.confirmations
-    }
-    pub fn minimum_stake_percentage(&self) -> f64 {
-        self.percentage
-    }
-}
-
-impl Default for CommitmentConfig {
-    fn default() -> Self {
-        CommitmentConfig {
-            confirmations: MAX_LOCKOUT_HISTORY,
-            percentage: DEFAULT_PERCENT_COMMITMENT,
-        }
-    }
-}
 
 #[derive(Debug, Clone)]
 pub struct JsonRpcConfig {
@@ -952,6 +920,7 @@ impl RpcSol for RpcSolImpl {
 pub mod tests {
     use super::*;
     use crate::{
+        commitment::DEFAULT_PERCENT_COMMITMENT,
         contact_info::ContactInfo,
         genesis_utils::{create_genesis_block, GenesisBlockInfo},
     };

--- a/core/src/rpc_service.rs
+++ b/core/src/rpc_service.rs
@@ -175,7 +175,7 @@ mod tests {
     use super::*;
     use crate::contact_info::ContactInfo;
     use crate::genesis_utils::{create_genesis_block, GenesisBlockInfo};
-    use crate::rpc::tests::create_validator_exit;
+    use crate::rpc::{tests::create_validator_exit, CommitmentParams};
     use solana_runtime::bank::Bank;
     use solana_sdk::signature::KeypairUtil;
     use std::net::{IpAddr, Ipv4Addr, SocketAddr};
@@ -220,7 +220,7 @@ mod tests {
                 .request_processor
                 .read()
                 .unwrap()
-                .get_balance(&mint_keypair.pubkey())
+                .get_balance(&mint_keypair.pubkey(), CommitmentParams::default())
         );
         rpc_service.exit();
         rpc_service.join().unwrap();

--- a/core/src/rpc_service.rs
+++ b/core/src/rpc_service.rs
@@ -175,7 +175,7 @@ mod tests {
     use super::*;
     use crate::contact_info::ContactInfo;
     use crate::genesis_utils::{create_genesis_block, GenesisBlockInfo};
-    use crate::rpc::{tests::create_validator_exit, CommitmentParams};
+    use crate::rpc::{tests::create_validator_exit, CommitmentConfig};
     use solana_runtime::bank::Bank;
     use solana_sdk::signature::KeypairUtil;
     use std::net::{IpAddr, Ipv4Addr, SocketAddr};
@@ -220,7 +220,7 @@ mod tests {
                 .request_processor
                 .read()
                 .unwrap()
-                .get_balance(&mint_keypair.pubkey(), CommitmentParams::default())
+                .get_balance(&mint_keypair.pubkey(), CommitmentConfig::default())
         );
         rpc_service.exit();
         rpc_service.join().unwrap();

--- a/core/src/rpc_service.rs
+++ b/core/src/rpc_service.rs
@@ -174,7 +174,7 @@ impl Service for JsonRpcService {
 mod tests {
     use super::*;
     use crate::{
-        commitment::CommitmentConfig,
+        commitment::{tests::get_full_block_commitment_cache, CommitmentConfig},
         contact_info::ContactInfo,
         genesis_utils::{create_genesis_block, GenesisBlockInfo},
         rpc::tests::create_validator_exit,
@@ -204,7 +204,7 @@ mod tests {
             solana_netutil::find_available_port_in_range((10000, 65535)).unwrap(),
         );
         let bank_forks = Arc::new(RwLock::new(BankForks::new(bank.slot(), bank)));
-        let block_commitment_cache = Arc::new(RwLock::new(BlockCommitmentCache::default()));
+        let block_commitment_cache = Arc::new(RwLock::new(get_full_block_commitment_cache()));
         let mut rpc_service = JsonRpcService::new(
             &cluster_info,
             rpc_addr,
@@ -226,6 +226,7 @@ mod tests {
                 .read()
                 .unwrap()
                 .get_balance(&mint_keypair.pubkey(), CommitmentConfig::default())
+                .unwrap()
         );
         rpc_service.exit();
         rpc_service.join().unwrap();

--- a/core/src/rpc_service.rs
+++ b/core/src/rpc_service.rs
@@ -173,13 +173,18 @@ impl Service for JsonRpcService {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::contact_info::ContactInfo;
-    use crate::genesis_utils::{create_genesis_block, GenesisBlockInfo};
-    use crate::rpc::{tests::create_validator_exit, CommitmentConfig};
+    use crate::{
+        commitment::CommitmentConfig,
+        contact_info::ContactInfo,
+        genesis_utils::{create_genesis_block, GenesisBlockInfo},
+        rpc::tests::create_validator_exit,
+    };
     use solana_runtime::bank::Bank;
     use solana_sdk::signature::KeypairUtil;
-    use std::net::{IpAddr, Ipv4Addr, SocketAddr};
-    use std::sync::atomic::AtomicBool;
+    use std::{
+        net::{IpAddr, Ipv4Addr, SocketAddr},
+        sync::atomic::AtomicBool,
+    };
 
     #[test]
     fn test_rpc_new() {

--- a/core/src/rpc_service.rs
+++ b/core/src/rpc_service.rs
@@ -174,7 +174,7 @@ impl Service for JsonRpcService {
 mod tests {
     use super::*;
     use crate::{
-        commitment::{tests::get_full_block_commitment_cache, CommitmentConfig},
+        commitment::{tests::get_full_block_commitment_cache, ParsedCommitment},
         contact_info::ContactInfo,
         genesis_utils::{create_genesis_block, GenesisBlockInfo},
         rpc::tests::create_validator_exit,
@@ -225,7 +225,7 @@ mod tests {
                 .request_processor
                 .read()
                 .unwrap()
-                .get_balance(&mint_keypair.pubkey(), CommitmentConfig::default())
+                .get_balance(&mint_keypair.pubkey(), ParsedCommitment::default())
                 .unwrap()
         );
         rpc_service.exit();

--- a/core/tests/rpc.rs
+++ b/core/tests/rpc.rs
@@ -15,7 +15,7 @@ use std::time::Duration;
 fn test_rpc_send_tx() {
     solana_logger::setup();
 
-    let (server, leader_data, alice, ledger_path) = new_validator_for_tests();
+    let (server, leader_data, alice, ledger_path, _client) = new_validator_for_tests();
     let bob_pubkey = Pubkey::new_rand();
 
     let client = reqwest::Client::new();

--- a/local_cluster/src/cluster_tests.rs
+++ b/local_cluster/src/cluster_tests.rs
@@ -3,7 +3,7 @@
 /// All tests must start from an entry point and a funding keypair and
 /// discover the rest of the network.
 use rand::{thread_rng, Rng};
-use solana_client::{rpc_request::RpcCommitmentConfig, thin_client::create_client};
+use solana_client::thin_client::create_client;
 use solana_core::{
     cluster_info::VALIDATOR_PORT_RANGE, consensus::VOTE_THRESHOLD_DEPTH, contact_info::ContactInfo,
     gossip_service::discover_cluster,
@@ -15,6 +15,7 @@ use solana_ledger::{
 use solana_sdk::{
     client::SyncClient,
     clock::{Slot, DEFAULT_TICKS_PER_SECOND, DEFAULT_TICKS_PER_SLOT, NUM_CONSECUTIVE_LEADER_SLOTS},
+    commitment_config::CommitmentConfig,
     epoch_schedule::MINIMUM_SLOTS_PER_EPOCH,
     hash::Hash,
     poh_config::PohConfig,
@@ -49,10 +50,7 @@ pub fn spend_and_verify_all_nodes<S: ::std::hash::BuildHasher>(
         let random_keypair = Keypair::new();
         let client = create_client(ingress_node.client_facing_addr(), VALIDATOR_PORT_RANGE);
         let bal = client
-            .poll_get_balance_with_commitment(
-                &funding_keypair.pubkey(),
-                RpcCommitmentConfig::recent(),
-            )
+            .poll_get_balance_with_commitment(&funding_keypair.pubkey(), CommitmentConfig::recent())
             .expect("balance in source");
         assert!(bal > 0);
         let (blockhash, _fee_calculator) = client.get_recent_blockhash().unwrap();
@@ -79,7 +77,7 @@ pub fn verify_balances<S: ::std::hash::BuildHasher>(
     let client = create_client(node.client_facing_addr(), VALIDATOR_PORT_RANGE);
     for (pk, b) in expected_balances {
         let bal = client
-            .poll_get_balance_with_commitment(&pk, RpcCommitmentConfig::recent())
+            .poll_get_balance_with_commitment(&pk, CommitmentConfig::recent())
             .expect("balance in source");
         assert_eq!(bal, b);
     }
@@ -96,10 +94,7 @@ pub fn send_many_transactions(
     for _ in 0..num_txs {
         let random_keypair = Keypair::new();
         let bal = client
-            .poll_get_balance_with_commitment(
-                &funding_keypair.pubkey(),
-                RpcCommitmentConfig::recent(),
-            )
+            .poll_get_balance_with_commitment(&funding_keypair.pubkey(), CommitmentConfig::recent())
             .expect("balance in source");
         assert!(bal > 0);
         let (blockhash, _fee_calculator) = client.get_recent_blockhash().unwrap();
@@ -196,7 +191,7 @@ pub fn kill_entry_and_spend_and_verify_rest(
 
     for ingress_node in &cluster_nodes {
         client
-            .poll_get_balance_with_commitment(&ingress_node.id, RpcCommitmentConfig::recent())
+            .poll_get_balance_with_commitment(&ingress_node.id, CommitmentConfig::recent())
             .unwrap_or_else(|err| panic!("Node {} has no balance: {}", ingress_node.id, err));
     }
 
@@ -220,10 +215,7 @@ pub fn kill_entry_and_spend_and_verify_rest(
 
         let client = create_client(ingress_node.client_facing_addr(), VALIDATOR_PORT_RANGE);
         let balance = client
-            .poll_get_balance_with_commitment(
-                &funding_keypair.pubkey(),
-                RpcCommitmentConfig::recent(),
-            )
+            .poll_get_balance_with_commitment(&funding_keypair.pubkey(), CommitmentConfig::recent())
             .expect("balance in source");
         assert_ne!(balance, 0);
 

--- a/local_cluster/src/cluster_tests.rs
+++ b/local_cluster/src/cluster_tests.rs
@@ -53,7 +53,9 @@ pub fn spend_and_verify_all_nodes<S: ::std::hash::BuildHasher>(
             .poll_get_balance_with_commitment(&funding_keypair.pubkey(), CommitmentConfig::recent())
             .expect("balance in source");
         assert!(bal > 0);
-        let (blockhash, _fee_calculator) = client.get_recent_blockhash().unwrap();
+        let (blockhash, _fee_calculator) = client
+            .get_recent_blockhash_with_commitment(CommitmentConfig::recent())
+            .unwrap();
         let mut transaction =
             system_transaction::transfer(&funding_keypair, &random_keypair.pubkey(), 1, blockhash);
         let confs = VOTE_THRESHOLD_DEPTH + 1;
@@ -97,7 +99,9 @@ pub fn send_many_transactions(
             .poll_get_balance_with_commitment(&funding_keypair.pubkey(), CommitmentConfig::recent())
             .expect("balance in source");
         assert!(bal > 0);
-        let (blockhash, _fee_calculator) = client.get_recent_blockhash().unwrap();
+        let (blockhash, _fee_calculator) = client
+            .get_recent_blockhash_with_commitment(CommitmentConfig::recent())
+            .unwrap();
         let transfer_amount = thread_rng().gen_range(1, max_tokens_per_transfer);
 
         let mut transaction = system_transaction::transfer(
@@ -228,7 +232,9 @@ pub fn kill_entry_and_spend_and_verify_rest(
             }
 
             let random_keypair = Keypair::new();
-            let (blockhash, _fee_calculator) = client.get_recent_blockhash().unwrap();
+            let (blockhash, _fee_calculator) = client
+                .get_recent_blockhash_with_commitment(CommitmentConfig::recent())
+                .unwrap();
             let mut transaction = system_transaction::transfer(
                 &funding_keypair,
                 &random_keypair.pubkey(),

--- a/local_cluster/src/cluster_tests.rs
+++ b/local_cluster/src/cluster_tests.rs
@@ -3,7 +3,7 @@
 /// All tests must start from an entry point and a funding keypair and
 /// discover the rest of the network.
 use rand::{thread_rng, Rng};
-use solana_client::{rpc_request::RpcConfidenceConfig, thin_client::create_client};
+use solana_client::{rpc_request::RpcCommitmentConfig, thin_client::create_client};
 use solana_core::{
     cluster_info::VALIDATOR_PORT_RANGE, consensus::VOTE_THRESHOLD_DEPTH, contact_info::ContactInfo,
     gossip_service::discover_cluster,
@@ -49,9 +49,9 @@ pub fn spend_and_verify_all_nodes<S: ::std::hash::BuildHasher>(
         let random_keypair = Keypair::new();
         let client = create_client(ingress_node.client_facing_addr(), VALIDATOR_PORT_RANGE);
         let bal = client
-            .poll_get_balance_with_confidence(
+            .poll_get_balance_with_commitment(
                 &funding_keypair.pubkey(),
-                RpcConfidenceConfig::recent(),
+                RpcCommitmentConfig::recent(),
             )
             .expect("balance in source");
         assert!(bal > 0);
@@ -79,7 +79,7 @@ pub fn verify_balances<S: ::std::hash::BuildHasher>(
     let client = create_client(node.client_facing_addr(), VALIDATOR_PORT_RANGE);
     for (pk, b) in expected_balances {
         let bal = client
-            .poll_get_balance_with_confidence(&pk, RpcConfidenceConfig::recent())
+            .poll_get_balance_with_commitment(&pk, RpcCommitmentConfig::recent())
             .expect("balance in source");
         assert_eq!(bal, b);
     }
@@ -96,9 +96,9 @@ pub fn send_many_transactions(
     for _ in 0..num_txs {
         let random_keypair = Keypair::new();
         let bal = client
-            .poll_get_balance_with_confidence(
+            .poll_get_balance_with_commitment(
                 &funding_keypair.pubkey(),
-                RpcConfidenceConfig::recent(),
+                RpcCommitmentConfig::recent(),
             )
             .expect("balance in source");
         assert!(bal > 0);
@@ -196,7 +196,7 @@ pub fn kill_entry_and_spend_and_verify_rest(
 
     for ingress_node in &cluster_nodes {
         client
-            .poll_get_balance_with_confidence(&ingress_node.id, RpcConfidenceConfig::recent())
+            .poll_get_balance_with_commitment(&ingress_node.id, RpcCommitmentConfig::recent())
             .unwrap_or_else(|err| panic!("Node {} has no balance: {}", ingress_node.id, err));
     }
 
@@ -220,9 +220,9 @@ pub fn kill_entry_and_spend_and_verify_rest(
 
         let client = create_client(ingress_node.client_facing_addr(), VALIDATOR_PORT_RANGE);
         let balance = client
-            .poll_get_balance_with_confidence(
+            .poll_get_balance_with_commitment(
                 &funding_keypair.pubkey(),
-                RpcConfidenceConfig::recent(),
+                RpcCommitmentConfig::recent(),
             )
             .expect("balance in source");
         assert_ne!(balance, 0);

--- a/local_cluster/src/local_cluster.rs
+++ b/local_cluster/src/local_cluster.rs
@@ -712,7 +712,7 @@ mod test {
         validator_config.rpc_config.enable_validator_exit = true;
         validator_config.storage_slots_per_turn = SLOTS_PER_TURN_TEST;
         const NUM_NODES: usize = 1;
-        let num_archivers = 1;
+        let num_archivers = 0;
         let config = ClusterConfig {
             validator_configs: vec![ValidatorConfig::default(); NUM_NODES],
             num_archivers,

--- a/local_cluster/src/local_cluster.rs
+++ b/local_cluster/src/local_cluster.rs
@@ -1,5 +1,8 @@
 use crate::cluster::{Cluster, ClusterValidatorInfo, ValidatorInfo};
-use solana_client::thin_client::{create_client, ThinClient};
+use solana_client::{
+    rpc_request::RpcConfidenceConfig,
+    thin_client::{create_client, ThinClient},
+};
 use solana_core::{
     archiver::Archiver,
     cluster_info::{Node, VALIDATOR_PORT_RANGE},
@@ -453,7 +456,11 @@ impl LocalCluster {
         let stake_account_pubkey = stake_account_keypair.pubkey();
 
         // Create the vote account if necessary
-        if client.poll_get_balance(&vote_account_pubkey).unwrap_or(0) == 0 {
+        if client
+            .poll_get_balance_with_confidence(&vote_account_pubkey, RpcConfidenceConfig::recent())
+            .unwrap_or(0)
+            == 0
+        {
             // 1) Create vote account
 
             let mut transaction = Transaction::new_signed_instructions(

--- a/local_cluster/src/local_cluster.rs
+++ b/local_cluster/src/local_cluster.rs
@@ -1,8 +1,5 @@
 use crate::cluster::{Cluster, ClusterValidatorInfo, ValidatorInfo};
-use solana_client::{
-    rpc_request::RpcCommitmentConfig,
-    thin_client::{create_client, ThinClient},
-};
+use solana_client::thin_client::{create_client, ThinClient};
 use solana_core::{
     archiver::Archiver,
     cluster_info::{Node, VALIDATOR_PORT_RANGE},
@@ -16,6 +13,7 @@ use solana_ledger::blocktree::create_new_tmp_ledger;
 use solana_sdk::{
     client::SyncClient,
     clock::{DEFAULT_SLOTS_PER_EPOCH, DEFAULT_SLOTS_PER_SEGMENT, DEFAULT_TICKS_PER_SLOT},
+    commitment_config::CommitmentConfig,
     epoch_schedule::EpochSchedule,
     genesis_block::{GenesisBlock, OperatingMode},
     message::Message,
@@ -443,7 +441,7 @@ impl LocalCluster {
             .wait_for_balance_with_commitment(
                 dest_pubkey,
                 Some(lamports),
-                RpcCommitmentConfig::recent(),
+                CommitmentConfig::recent(),
             )
             .expect("get balance")
     }
@@ -461,7 +459,7 @@ impl LocalCluster {
 
         // Create the vote account if necessary
         if client
-            .poll_get_balance_with_commitment(&vote_account_pubkey, RpcCommitmentConfig::recent())
+            .poll_get_balance_with_commitment(&vote_account_pubkey, CommitmentConfig::recent())
             .unwrap_or(0)
             == 0
         {
@@ -489,7 +487,7 @@ impl LocalCluster {
                 .wait_for_balance_with_commitment(
                     &vote_account_pubkey,
                     Some(amount),
-                    RpcCommitmentConfig::recent(),
+                    CommitmentConfig::recent(),
                 )
                 .expect("get balance");
 
@@ -517,7 +515,7 @@ impl LocalCluster {
                 .wait_for_balance_with_commitment(
                     &stake_account_pubkey,
                     Some(amount),
-                    RpcCommitmentConfig::recent(),
+                    CommitmentConfig::recent(),
                 )
                 .expect("get balance");
         } else {
@@ -528,8 +526,8 @@ impl LocalCluster {
         }
         info!("Checking for vote account registration of {}", node_pubkey);
         match (
-            client.get_account_now(&stake_account_pubkey),
-            client.get_account_now(&vote_account_pubkey),
+            client.get_account_with_commitment(&stake_account_pubkey, CommitmentConfig::recent()),
+            client.get_account_with_commitment(&vote_account_pubkey, CommitmentConfig::recent()),
         ) {
             (Ok(Some(stake_account)), Ok(Some(vote_account))) => {
                 match (

--- a/local_cluster/src/local_cluster.rs
+++ b/local_cluster/src/local_cluster.rs
@@ -425,7 +425,9 @@ impl LocalCluster {
         lamports: u64,
     ) -> u64 {
         trace!("getting leader blockhash");
-        let (blockhash, _fee_calculator) = client.get_recent_blockhash().unwrap();
+        let (blockhash, _fee_calculator) = client
+            .get_recent_blockhash_with_commitment(CommitmentConfig::recent())
+            .unwrap();
         let mut tx =
             system_transaction::transfer(&source_keypair, dest_pubkey, lamports, blockhash);
         info!(
@@ -478,7 +480,10 @@ impl LocalCluster {
                     },
                     amount,
                 ),
-                client.get_recent_blockhash().unwrap().0,
+                client
+                    .get_recent_blockhash_with_commitment(CommitmentConfig::recent())
+                    .unwrap()
+                    .0,
             );
             client
                 .retry_transfer(&from_account, &mut transaction, 10)
@@ -500,7 +505,10 @@ impl LocalCluster {
                     &StakeAuthorized::auto(&stake_account_pubkey),
                     amount,
                 ),
-                client.get_recent_blockhash().unwrap().0,
+                client
+                    .get_recent_blockhash_with_commitment(CommitmentConfig::recent())
+                    .unwrap()
+                    .0,
             );
 
             client
@@ -585,7 +593,10 @@ impl LocalCluster {
             Some(&from_keypair.pubkey()),
         );
         let signer_keys = vec![from_keypair.as_ref()];
-        let blockhash = client.get_recent_blockhash().unwrap().0;
+        let blockhash = client
+            .get_recent_blockhash_with_commitment(CommitmentConfig::recent())
+            .unwrap()
+            .0;
         let mut transaction = Transaction::new(&signer_keys, message, blockhash);
         client
             .retry_transfer(&from_keypair, &mut transaction, 10)

--- a/local_cluster/src/local_cluster.rs
+++ b/local_cluster/src/local_cluster.rs
@@ -1,6 +1,6 @@
 use crate::cluster::{Cluster, ClusterValidatorInfo, ValidatorInfo};
 use solana_client::{
-    rpc_request::RpcConfidenceConfig,
+    rpc_request::RpcCommitmentConfig,
     thin_client::{create_client, ThinClient},
 };
 use solana_core::{
@@ -440,10 +440,10 @@ impl LocalCluster {
             .retry_transfer(&source_keypair, &mut tx, 10)
             .expect("client transfer");
         client
-            .wait_for_balance_with_confidence(
+            .wait_for_balance_with_commitment(
                 dest_pubkey,
                 Some(lamports),
-                RpcConfidenceConfig::recent(),
+                RpcCommitmentConfig::recent(),
             )
             .expect("get balance")
     }
@@ -461,7 +461,7 @@ impl LocalCluster {
 
         // Create the vote account if necessary
         if client
-            .poll_get_balance_with_confidence(&vote_account_pubkey, RpcConfidenceConfig::recent())
+            .poll_get_balance_with_commitment(&vote_account_pubkey, RpcCommitmentConfig::recent())
             .unwrap_or(0)
             == 0
         {
@@ -486,10 +486,10 @@ impl LocalCluster {
                 .retry_transfer(&from_account, &mut transaction, 10)
                 .expect("fund vote");
             client
-                .wait_for_balance_with_confidence(
+                .wait_for_balance_with_commitment(
                     &vote_account_pubkey,
                     Some(amount),
-                    RpcConfidenceConfig::recent(),
+                    RpcCommitmentConfig::recent(),
                 )
                 .expect("get balance");
 
@@ -514,10 +514,10 @@ impl LocalCluster {
                 )
                 .expect("delegate stake");
             client
-                .wait_for_balance_with_confidence(
+                .wait_for_balance_with_commitment(
                     &stake_account_pubkey,
                     Some(amount),
-                    RpcConfidenceConfig::recent(),
+                    RpcCommitmentConfig::recent(),
                 )
                 .expect("get balance");
         } else {

--- a/local_cluster/src/local_cluster.rs
+++ b/local_cluster/src/local_cluster.rs
@@ -440,7 +440,11 @@ impl LocalCluster {
             .retry_transfer(&source_keypair, &mut tx, 10)
             .expect("client transfer");
         client
-            .wait_for_balance(dest_pubkey, Some(lamports))
+            .wait_for_balance_with_confidence(
+                dest_pubkey,
+                Some(lamports),
+                RpcConfidenceConfig::recent(),
+            )
             .expect("get balance")
     }
 
@@ -482,7 +486,11 @@ impl LocalCluster {
                 .retry_transfer(&from_account, &mut transaction, 10)
                 .expect("fund vote");
             client
-                .wait_for_balance(&vote_account_pubkey, Some(amount))
+                .wait_for_balance_with_confidence(
+                    &vote_account_pubkey,
+                    Some(amount),
+                    RpcConfidenceConfig::recent(),
+                )
                 .expect("get balance");
 
             let mut transaction = Transaction::new_signed_instructions(
@@ -506,7 +514,11 @@ impl LocalCluster {
                 )
                 .expect("delegate stake");
             client
-                .wait_for_balance(&stake_account_pubkey, Some(amount))
+                .wait_for_balance_with_confidence(
+                    &stake_account_pubkey,
+                    Some(amount),
+                    RpcConfidenceConfig::recent(),
+                )
                 .expect("get balance");
         } else {
             warn!(

--- a/local_cluster/src/local_cluster.rs
+++ b/local_cluster/src/local_cluster.rs
@@ -528,8 +528,8 @@ impl LocalCluster {
         }
         info!("Checking for vote account registration of {}", node_pubkey);
         match (
-            client.get_account(&stake_account_pubkey),
-            client.get_account(&vote_account_pubkey),
+            client.get_account_now(&stake_account_pubkey),
+            client.get_account_now(&vote_account_pubkey),
         ) {
             (Ok(Some(stake_account)), Ok(Some(vote_account))) => {
                 match (

--- a/local_cluster/src/tests/archiver.rs
+++ b/local_cluster/src/tests/archiver.rs
@@ -1,5 +1,5 @@
 use crate::local_cluster::{ClusterConfig, LocalCluster};
-use serial_test_derive::serial;
+// use serial_test_derive::serial;
 use solana_client::thin_client::create_client;
 use solana_core::archiver::Archiver;
 use solana_core::cluster_info::{ClusterInfo, Node, VALIDATOR_PORT_RANGE};
@@ -61,19 +61,19 @@ fn run_archiver_startup_basic(num_nodes: usize, num_archivers: usize) {
 }
 
 #[test]
-#[serial]
+#[ignore]
 fn test_archiver_startup_1_node() {
     run_archiver_startup_basic(1, 1);
 }
 
 #[test]
-#[serial]
+#[ignore]
 fn test_archiver_startup_2_nodes() {
     run_archiver_startup_basic(2, 1);
 }
 
 #[test]
-#[serial]
+#[ignore]
 fn test_archiver_startup_leader_hang() {
     use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
@@ -112,7 +112,7 @@ fn test_archiver_startup_leader_hang() {
 }
 
 #[test]
-#[serial]
+#[ignore]
 fn test_archiver_startup_ledger_hang() {
     solana_logger::setup();
     info!("starting archiver test");
@@ -141,7 +141,7 @@ fn test_archiver_startup_ledger_hang() {
 }
 
 #[test]
-#[serial]
+#[ignore]
 fn test_account_setup() {
     let num_nodes = 1;
     let num_archivers = 1;

--- a/local_cluster/src/tests/archiver.rs
+++ b/local_cluster/src/tests/archiver.rs
@@ -1,6 +1,6 @@
 use crate::local_cluster::{ClusterConfig, LocalCluster};
 use serial_test_derive::serial;
-use solana_client::{rpc_request::RpcConfidenceConfig, thin_client::create_client};
+use solana_client::{rpc_request::RpcCommitmentConfig, thin_client::create_client};
 use solana_core::archiver::Archiver;
 use solana_core::cluster_info::{ClusterInfo, Node, VALIDATOR_PORT_RANGE};
 use solana_core::contact_info::ContactInfo;
@@ -168,9 +168,9 @@ fn test_account_setup() {
     cluster.archiver_infos.iter().for_each(|(_, value)| {
         assert_eq!(
             client
-                .poll_get_balance_with_confidence(
+                .poll_get_balance_with_commitment(
                     &value.archiver_storage_pubkey,
-                    RpcConfidenceConfig::recent()
+                    RpcCommitmentConfig::recent()
                 )
                 .unwrap(),
             1

--- a/local_cluster/src/tests/archiver.rs
+++ b/local_cluster/src/tests/archiver.rs
@@ -1,6 +1,6 @@
 use crate::local_cluster::{ClusterConfig, LocalCluster};
 use serial_test_derive::serial;
-use solana_client::thin_client::create_client;
+use solana_client::{rpc_request::RpcConfidenceConfig, thin_client::create_client};
 use solana_core::archiver::Archiver;
 use solana_core::cluster_info::{ClusterInfo, Node, VALIDATOR_PORT_RANGE};
 use solana_core::contact_info::ContactInfo;
@@ -168,7 +168,10 @@ fn test_account_setup() {
     cluster.archiver_infos.iter().for_each(|(_, value)| {
         assert_eq!(
             client
-                .poll_get_balance(&value.archiver_storage_pubkey)
+                .poll_get_balance_with_confidence(
+                    &value.archiver_storage_pubkey,
+                    RpcConfidenceConfig::recent()
+                )
                 .unwrap(),
             1
         );

--- a/local_cluster/src/tests/archiver.rs
+++ b/local_cluster/src/tests/archiver.rs
@@ -1,6 +1,6 @@
 use crate::local_cluster::{ClusterConfig, LocalCluster};
 use serial_test_derive::serial;
-use solana_client::{rpc_request::RpcCommitmentConfig, thin_client::create_client};
+use solana_client::thin_client::create_client;
 use solana_core::archiver::Archiver;
 use solana_core::cluster_info::{ClusterInfo, Node, VALIDATOR_PORT_RANGE};
 use solana_core::contact_info::ContactInfo;
@@ -8,6 +8,7 @@ use solana_core::gossip_service::discover_cluster;
 use solana_core::storage_stage::SLOTS_PER_TURN_TEST;
 use solana_core::validator::ValidatorConfig;
 use solana_ledger::blocktree::{create_new_tmp_ledger, get_tmp_ledger_path, Blocktree};
+use solana_sdk::commitment_config::CommitmentConfig;
 use solana_sdk::genesis_block::create_genesis_block;
 use solana_sdk::signature::{Keypair, KeypairUtil};
 use std::fs::remove_dir_all;
@@ -170,7 +171,7 @@ fn test_account_setup() {
             client
                 .poll_get_balance_with_commitment(
                     &value.archiver_storage_pubkey,
-                    RpcCommitmentConfig::recent()
+                    CommitmentConfig::recent()
                 )
                 .unwrap(),
             1

--- a/local_cluster/src/tests/local_cluster.rs
+++ b/local_cluster/src/tests/local_cluster.rs
@@ -466,7 +466,7 @@ fn test_snapshots_blocktree_floor() {
     let target_slot = slot_floor + 40;
     while current_slot <= target_slot {
         trace!("current_slot: {}", current_slot);
-        if let Ok(slot) = validator_client.get_slot() {
+        if let Ok(slot) = validator_client.get_slot_with_commitment(CommitmentConfig::recent()) {
             current_slot = slot;
         } else {
             continue;
@@ -717,7 +717,7 @@ fn run_repairman_catchup(num_repairmen: u64) {
     let target_slot = (num_warmup_epochs) * num_slots_per_epoch + 1;
     while current_slot <= target_slot {
         trace!("current_slot: {}", current_slot);
-        if let Ok(slot) = repairee_client.get_slot() {
+        if let Ok(slot) = repairee_client.get_slot_with_commitment(CommitmentConfig::recent()) {
             current_slot = slot;
         } else {
             continue;
@@ -731,7 +731,9 @@ fn wait_for_next_snapshot<P: AsRef<Path>>(cluster: &LocalCluster, tar: P) {
     let client = cluster
         .get_validator_client(&cluster.entry_point_info.id)
         .unwrap();
-    let last_slot = client.get_slot().expect("Couldn't get slot");
+    let last_slot = client
+        .get_slot_with_commitment(CommitmentConfig::recent())
+        .expect("Couldn't get slot");
 
     // Wait for a snapshot for a bank >= last_slot to be made so we know that the snapshot
     // must include the transactions just pushed

--- a/local_cluster/src/tests/local_cluster.rs
+++ b/local_cluster/src/tests/local_cluster.rs
@@ -329,7 +329,7 @@ fn test_softlaunch_operating_mode() {
     .iter()
     {
         assert_eq!(
-            (program_id, client.get_account(program_id).unwrap()),
+            (program_id, client.get_account_now(program_id).unwrap()),
             (program_id, None)
         );
     }

--- a/local_cluster/src/tests/local_cluster.rs
+++ b/local_cluster/src/tests/local_cluster.rs
@@ -15,6 +15,7 @@ use solana_runtime::accounts_db::AccountsDB;
 use solana_sdk::{
     client::SyncClient,
     clock,
+    commitment_config::CommitmentConfig,
     epoch_schedule::{EpochSchedule, MINIMUM_SLOTS_PER_EPOCH},
     genesis_block::OperatingMode,
     poh_config::PohConfig,
@@ -329,7 +330,12 @@ fn test_softlaunch_operating_mode() {
     .iter()
     {
         assert_eq!(
-            (program_id, client.get_account_now(program_id).unwrap()),
+            (
+                program_id,
+                client
+                    .get_account_with_commitment(program_id, CommitmentConfig::recent())
+                    .unwrap()
+            ),
             (program_id, None)
         );
     }

--- a/multinode-demo/validator.sh
+++ b/multinode-demo/validator.sh
@@ -311,6 +311,12 @@ while true; do
   [[ -r "$voting_keypair_path" ]] || $solana_keygen new -o "$voting_keypair_path"
   [[ -r "$storage_keypair_path" ]] || $solana_keygen new -o "$storage_keypair_path"
 
+  while true; do
+    if wallet get-transaction-count; then
+      break
+    fi
+  done
+
   setup_validator_accounts "$node_lamports"
   echo "$PS4$program ${args[*]}"
 

--- a/runtime/src/bank_client.rs
+++ b/runtime/src/bank_client.rs
@@ -104,6 +104,10 @@ impl SyncClient for BankClient {
         Ok(self.bank.get_balance(pubkey))
     }
 
+    fn get_balance_now(&self, pubkey: &Pubkey) -> Result<u64> {
+        Ok(self.bank.get_balance(pubkey))
+    }
+
     fn get_recent_blockhash(&self) -> Result<(Hash, FeeCalculator)> {
         Ok(self.bank.last_blockhash_with_fee_calculator())
     }
@@ -115,11 +119,22 @@ impl SyncClient for BankClient {
         Ok(self.bank.get_signature_status(signature))
     }
 
+    fn get_signature_status_now(
+        &self,
+        signature: &Signature,
+    ) -> Result<Option<transaction::Result<()>>> {
+        Ok(self.bank.get_signature_status(signature))
+    }
+
     fn get_slot(&self) -> Result<u64> {
         Ok(self.bank.slot())
     }
 
     fn get_transaction_count(&self) -> Result<u64> {
+        Ok(self.bank.transaction_count())
+    }
+
+    fn get_transaction_count_now(&self) -> Result<u64> {
         Ok(self.bank.transaction_count())
     }
 

--- a/runtime/src/bank_client.rs
+++ b/runtime/src/bank_client.rs
@@ -1,6 +1,7 @@
 use crate::bank::Bank;
 use solana_sdk::account::Account;
 use solana_sdk::client::{AsyncClient, Client, SyncClient};
+use solana_sdk::commitment_config::CommitmentConfig;
 use solana_sdk::fee_calculator::FeeCalculator;
 use solana_sdk::hash::Hash;
 use solana_sdk::instruction::Instruction;
@@ -100,7 +101,11 @@ impl SyncClient for BankClient {
         Ok(self.bank.get_account(pubkey))
     }
 
-    fn get_account_now(&self, pubkey: &Pubkey) -> Result<Option<Account>> {
+    fn get_account_with_commitment(
+        &self,
+        pubkey: &Pubkey,
+        _commitment_config: CommitmentConfig,
+    ) -> Result<Option<Account>> {
         Ok(self.bank.get_account(pubkey))
     }
 
@@ -108,7 +113,11 @@ impl SyncClient for BankClient {
         Ok(self.bank.get_balance(pubkey))
     }
 
-    fn get_balance_now(&self, pubkey: &Pubkey) -> Result<u64> {
+    fn get_balance_with_commitment(
+        &self,
+        pubkey: &Pubkey,
+        _commitment_config: CommitmentConfig,
+    ) -> Result<u64> {
         Ok(self.bank.get_balance(pubkey))
     }
 
@@ -123,9 +132,10 @@ impl SyncClient for BankClient {
         Ok(self.bank.get_signature_status(signature))
     }
 
-    fn get_signature_status_now(
+    fn get_signature_status_with_commitment(
         &self,
         signature: &Signature,
+        _commitment_config: CommitmentConfig,
     ) -> Result<Option<transaction::Result<()>>> {
         Ok(self.bank.get_signature_status(signature))
     }
@@ -138,7 +148,10 @@ impl SyncClient for BankClient {
         Ok(self.bank.transaction_count())
     }
 
-    fn get_transaction_count_now(&self) -> Result<u64> {
+    fn get_transaction_count_with_commitment(
+        &self,
+        _commitment_config: CommitmentConfig,
+    ) -> Result<u64> {
         Ok(self.bank.transaction_count())
     }
 

--- a/runtime/src/bank_client.rs
+++ b/runtime/src/bank_client.rs
@@ -100,6 +100,10 @@ impl SyncClient for BankClient {
         Ok(self.bank.get_account(pubkey))
     }
 
+    fn get_account_now(&self, pubkey: &Pubkey) -> Result<Option<Account>> {
+        Ok(self.bank.get_account(pubkey))
+    }
+
     fn get_balance(&self, pubkey: &Pubkey) -> Result<u64> {
         Ok(self.bank.get_balance(pubkey))
     }

--- a/runtime/src/bank_client.rs
+++ b/runtime/src/bank_client.rs
@@ -125,6 +125,13 @@ impl SyncClient for BankClient {
         Ok(self.bank.last_blockhash_with_fee_calculator())
     }
 
+    fn get_recent_blockhash_with_commitment(
+        &self,
+        _commitment_config: CommitmentConfig,
+    ) -> Result<(Hash, FeeCalculator)> {
+        Ok(self.bank.last_blockhash_with_fee_calculator())
+    }
+
     fn get_signature_status(
         &self,
         signature: &Signature,
@@ -141,6 +148,10 @@ impl SyncClient for BankClient {
     }
 
     fn get_slot(&self) -> Result<u64> {
+        Ok(self.bank.slot())
+    }
+
+    fn get_slot_with_commitment(&self, _commitment_config: CommitmentConfig) -> Result<u64> {
         Ok(self.bank.slot())
     }
 

--- a/scripts/wallet-sanity.sh
+++ b/scripts/wallet-sanity.sh
@@ -19,9 +19,9 @@ $solana_keygen new -f
 
 node_readiness=false
 timeout=60
+set +e
 while [[ $timeout -gt 0 ]]; do
-  output=$($solana_cli "${args[@]}" get-transaction-count)
-  if [[ -n $output ]]; then
+  if $solana_cli "${args[@]}" get-transaction-count; then
     node_readiness=true
     break
   fi
@@ -33,6 +33,7 @@ if ! "$node_readiness"; then
   exit 1
 fi
 
+set -e
 (
   set -x
   $solana_cli "${args[@]}" address

--- a/sdk/src/client.rs
+++ b/sdk/src/client.rs
@@ -47,6 +47,9 @@ pub trait SyncClient {
     /// Get account balance or 0 if not found.
     fn get_balance(&self, pubkey: &Pubkey) -> Result<u64>;
 
+    /// Get account balance or 0 if not found. Does not wait for default confirmations.
+    fn get_balance_now(&self, pubkey: &Pubkey) -> Result<u64>;
+
     /// Get recent blockhash
     fn get_recent_blockhash(&self) -> Result<(Hash, FeeCalculator)>;
 
@@ -56,11 +59,20 @@ pub trait SyncClient {
         signature: &Signature,
     ) -> Result<Option<transaction::Result<()>>>;
 
+    /// Get signature status. Does not wait for default confirmations.
+    fn get_signature_status_now(
+        &self,
+        signature: &Signature,
+    ) -> Result<Option<transaction::Result<()>>>;
+
     /// Get last known slot
     fn get_slot(&self) -> Result<Slot>;
 
     /// Get transaction count
     fn get_transaction_count(&self) -> Result<u64>;
+
+    /// Get transaction count. Does not wait for default confirmations.
+    fn get_transaction_count_now(&self) -> Result<u64>;
 
     /// Poll until the signature has been confirmed by at least `min_confirmed_blocks`
     fn poll_for_signature_confirmation(

--- a/sdk/src/client.rs
+++ b/sdk/src/client.rs
@@ -10,6 +10,7 @@
 use crate::{
     account::Account,
     clock::Slot,
+    commitment_config::CommitmentConfig,
     fee_calculator::FeeCalculator,
     hash::Hash,
     instruction::Instruction,
@@ -44,14 +45,22 @@ pub trait SyncClient {
     /// Get an account or None if not found.
     fn get_account(&self, pubkey: &Pubkey) -> Result<Option<Account>>;
 
-    /// Get an account or None if not found.  Does not wait for default confirmations.
-    fn get_account_now(&self, pubkey: &Pubkey) -> Result<Option<Account>>;
+    /// Get an account or None if not found. Uses explicit commitment configuration.
+    fn get_account_with_commitment(
+        &self,
+        pubkey: &Pubkey,
+        commitment_config: CommitmentConfig,
+    ) -> Result<Option<Account>>;
 
     /// Get account balance or 0 if not found.
     fn get_balance(&self, pubkey: &Pubkey) -> Result<u64>;
 
-    /// Get account balance or 0 if not found. Does not wait for default confirmations.
-    fn get_balance_now(&self, pubkey: &Pubkey) -> Result<u64>;
+    /// Get account balance or 0 if not found. Uses explicit commitment configuration.
+    fn get_balance_with_commitment(
+        &self,
+        pubkey: &Pubkey,
+        commitment_config: CommitmentConfig,
+    ) -> Result<u64>;
 
     /// Get recent blockhash
     fn get_recent_blockhash(&self) -> Result<(Hash, FeeCalculator)>;
@@ -62,10 +71,11 @@ pub trait SyncClient {
         signature: &Signature,
     ) -> Result<Option<transaction::Result<()>>>;
 
-    /// Get signature status. Does not wait for default confirmations.
-    fn get_signature_status_now(
+    /// Get signature status. Uses explicit commitment configuration.
+    fn get_signature_status_with_commitment(
         &self,
         signature: &Signature,
+        commitment_config: CommitmentConfig,
     ) -> Result<Option<transaction::Result<()>>>;
 
     /// Get last known slot
@@ -74,8 +84,11 @@ pub trait SyncClient {
     /// Get transaction count
     fn get_transaction_count(&self) -> Result<u64>;
 
-    /// Get transaction count. Does not wait for default confirmations.
-    fn get_transaction_count_now(&self) -> Result<u64>;
+    /// Get transaction count. Uses explicit commitment configuration.
+    fn get_transaction_count_with_commitment(
+        &self,
+        commitment_config: CommitmentConfig,
+    ) -> Result<u64>;
 
     /// Poll until the signature has been confirmed by at least `min_confirmed_blocks`
     fn poll_for_signature_confirmation(

--- a/sdk/src/client.rs
+++ b/sdk/src/client.rs
@@ -44,6 +44,9 @@ pub trait SyncClient {
     /// Get an account or None if not found.
     fn get_account(&self, pubkey: &Pubkey) -> Result<Option<Account>>;
 
+    /// Get an account or None if not found.  Does not wait for default confirmations.
+    fn get_account_now(&self, pubkey: &Pubkey) -> Result<Option<Account>>;
+
     /// Get account balance or 0 if not found.
     fn get_balance(&self, pubkey: &Pubkey) -> Result<u64>;
 

--- a/sdk/src/client.rs
+++ b/sdk/src/client.rs
@@ -65,6 +65,12 @@ pub trait SyncClient {
     /// Get recent blockhash
     fn get_recent_blockhash(&self) -> Result<(Hash, FeeCalculator)>;
 
+    /// Get recent blockhash. Uses explicit commitment configuration.
+    fn get_recent_blockhash_with_commitment(
+        &self,
+        commitment_config: CommitmentConfig,
+    ) -> Result<(Hash, FeeCalculator)>;
+
     /// Get signature status.
     fn get_signature_status(
         &self,
@@ -80,6 +86,9 @@ pub trait SyncClient {
 
     /// Get last known slot
     fn get_slot(&self) -> Result<Slot>;
+
+    /// Get last known slot. Uses explicit commitment configuration.
+    fn get_slot_with_commitment(&self, commitment_config: CommitmentConfig) -> Result<u64>;
 
     /// Get transaction count
     fn get_transaction_count(&self) -> Result<u64>;

--- a/sdk/src/commitment_config.rs
+++ b/sdk/src/commitment_config.rs
@@ -1,0 +1,25 @@
+use serde_json::Value;
+
+#[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct CommitmentConfig {
+    pub confirmations: Option<Value>,
+    pub percentage: Option<f64>,
+}
+
+impl CommitmentConfig {
+    pub fn recent() -> Self {
+        Self {
+            confirmations: Some(1.into()),
+            percentage: None,
+        }
+    }
+
+    pub fn ok(&self) -> Option<Self> {
+        if self == &Self::default() {
+            None
+        } else {
+            Some(self.clone())
+        }
+    }
+}

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -35,6 +35,8 @@ pub mod bank_hash;
 #[cfg(not(feature = "program"))]
 pub mod client;
 #[cfg(not(feature = "program"))]
+pub mod commitment_config;
+#[cfg(not(feature = "program"))]
 pub mod genesis_block;
 #[cfg(not(feature = "program"))]
 pub mod packet;


### PR DESCRIPTION
#### Problem
The RPC API returns results based on either the latest bank, or a bank from a couple blocks ago, instead of results based on how much of the cluster has voted on the results.

#### Summary of Changes
- Add optional commitment configuration to relevant rpc endpoints. Use defaults when config is not provided, or for missing parameters. Defaults: rooted results with 2/3+ stake voting

Commitment config examples:
* `{"confirmations":15,"percentage":0.60}`
* `{"confirmations":"max"}`

Fixes #6346 

Follow-up work needed:
- Extend optional params into solana-client (partially done by this PR; determine whether a more general solution is needed)
- Extend optional params into solana-cli
- Apply to PubSub methods
- The client crate is an unholy mess, especially around polling/retries. Clean it up.
