### PR TITLE
Add show-stake-history command to cli

### DIFF
--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -320,14 +320,14 @@ pub fn process_show_validators(rpc_client: &RpcClient, use_lamports_unit: bool) 
 
     println_name_value(
         "Active Stake:",
-        &build_balance_message(total_active_stake as u64, use_lamports_unit),
+        &build_balance_message(total_active_stake as u64, use_lamports_unit, true),
     );
     if total_deliquent_stake > 0. {
         println_name_value(
             "Current Stake:",
             &format!(
                 "{} ({:0.2}%)",
-                &build_balance_message(total_current_stake as u64, use_lamports_unit),
+                &build_balance_message(total_current_stake as u64, use_lamports_unit, true),
                 100. * total_current_stake / total_active_stake
             ),
         );
@@ -335,7 +335,7 @@ pub fn process_show_validators(rpc_client: &RpcClient, use_lamports_unit: bool) 
             "Delinquent Stake:",
             &format!(
                 "{} ({:0.2}%)",
-                &build_balance_message(total_deliquent_stake as u64, use_lamports_unit),
+                &build_balance_message(total_deliquent_stake as u64, use_lamports_unit, true),
                 100. * total_deliquent_stake / total_active_stake
             ),
         );
@@ -385,7 +385,7 @@ pub fn process_show_validators(rpc_client: &RpcClient, use_lamports_unit: bool) 
             if vote_account.activated_stake > 0 {
                 format!(
                     "{} ({:.2}%)",
-                    build_balance_message(vote_account.activated_stake, use_lamports_unit),
+                    build_balance_message(vote_account.activated_stake, use_lamports_unit, true),
                     100. * vote_account.activated_stake as f64 / total_active_stake
                 )
             } else {

--- a/cli/src/vote.rs
+++ b/cli/src/vote.rs
@@ -334,7 +334,7 @@ pub fn process_show_vote_account(
 
     println!(
         "account balance: {}",
-        build_balance_message(vote_account.lamports, use_lamports_unit)
+        build_balance_message(vote_account.lamports, use_lamports_unit, true)
     );
     println!("node id: {}", vote_state.node_pubkey);
     println!("authorized voter: {}", vote_state.authorized_voter);


### PR DESCRIPTION
#### Problem
It would be nice to see the history of stake activations while a cluster is running

#### Summary of Changes
Add `show-stake-history` cli command for viewing the latest stake history. Optionally view in lamports

Looks like:

```
  Epoch  Effective Stake  Activating Stake  Deactivating Stake
     14      14.55191522       53.54808478                   0 SOL
     13      11.64153218       56.45846782                   0 SOL
     12       9.31322574       58.78677426                   0 SOL
     11       7.45058059       52.64941941                   0 SOL
     10       5.96046448       54.13953552                   0 SOL
      9       4.76837158       55.33162842                   0 SOL
      8       3.81469727        4.28530273                   0 SOL
      7       3.05175781        3.04824219                   0 SOL
      6       2.44140625        1.55859375                   0 SOL
      5         1.953125          2.046875                   0 SOL
      4           1.5625            2.4375                   0 SOL
      3             1.25              2.75                   0 SOL
      2                1                 2                   0 SOL
      1                1                 0                   0 SOL
      0                1                 0                   0 SOL
```
