### PR TITLE
Increase node start stagger

### DIFF
--- a/net/net.sh
+++ b/net/net.sh
@@ -722,8 +722,10 @@ deploy() {
       # Stagger additional node start time. If too many nodes start simultaneously
       # the bootstrap node gets more rsync requests from the additional nodes than
       # it can handle.
-      if ((nodeIndex % 2 == 0)); then
+      if ((nodeIndex % 3 == 0)); then
         sleep 2
+      elif ((nodeIndex % 3 == 1)); then
+        sleep 4
       fi
     fi
   done

--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -105,7 +105,7 @@ waitForNodeToInit() {
   echo "--- waiting for $hostname to boot up"
   SECONDS=
   while [[ ! -r $initCompleteFile ]]; do
-    if [[ $SECONDS -ge 120 ]]; then
+    if [[ $SECONDS -ge 240 ]]; then
       echo "^^^ +++"
       echo "Error: $initCompleteFile not found in $SECONDS seconds"
       exit 1


### PR DESCRIPTION
#### Problem

50 node testnets overwhelm BS leader with rsync and scp requests upon validator boot

#### Summary of Changes

Extend the cyclic sleep in the start loop to further stagger timing and extend startup timeout.
