### PR TITLE
Introduce --dummy-sig to solana-bench-tps

### DIFF
--- a/bench-tps/src/cli.rs
+++ b/bench-tps/src/cli.rs
@@ -25,6 +25,7 @@ pub struct Config {
     pub multi_client: bool,
     pub use_move: bool,
     pub num_lamports_per_account: u64,
+    pub dummy_sig: bool,
 }
 
 impl Default for Config {
@@ -47,6 +48,7 @@ impl Default for Config {
             multi_client: true,
             use_move: false,
             num_lamports_per_account: NUM_LAMPORTS_PER_ACCOUNT_DEFAULT,
+            dummy_sig: false,
         }
     }
 }
@@ -116,6 +118,11 @@ pub fn build_args<'a, 'b>(version: &'b str) -> App<'a, 'b> {
             Arg::with_name("no-multi-client")
                 .long("no-multi-client")
                 .help("Disable multi-client support, only transact with the entrypoint."),
+        )
+        .arg(
+            Arg::with_name("dummy-sig")
+                .long("dummy-sig")
+                .help("Generate dummy signatures randomly (must be paired with validator's --dev-no-sigverify)."),
         )
         .arg(
             Arg::with_name("tx_count")
@@ -254,6 +261,8 @@ pub fn extract_args<'a>(matches: &ArgMatches<'a>) -> Config {
 
     args.use_move = matches.is_present("use-move");
     args.multi_client = !matches.is_present("no-multi-client");
+
+    args.dummy_sig = matches.is_present("dummy-sig");
 
     if let Some(v) = matches.value_of("num_lamports_per_account") {
         args.num_lamports_per_account = v.to_string().parse().expect("can't parse lamports");

--- a/sdk/src/signature.rs
+++ b/sdk/src/signature.rs
@@ -30,8 +30,11 @@ impl Signature {
 
     pub fn new_rand() -> Self {
         let mut random_signature_bytes = [0u8; 64];
-        random_signature_bytes[0..20].copy_from_slice(&rand::random::<[u8; 20]>());
-        Self::new(&random_signature_bytes) // same as status cache!
+        // Break into two slices because random just doesn't implement for [u8; 64]:
+        // ref: https://docs.rs/rand/0.7.3/rand/distributions/trait.Distribution.html#impl-Distribution%3C%5BT%3B%2032%5D%3E
+        random_signature_bytes[0..32].copy_from_slice(&rand::random::<[u8; 32]>());
+        random_signature_bytes[32..64].copy_from_slice(&rand::random::<[u8; 32]>());
+        Self::new(&random_signature_bytes)
     }
 
     pub fn verify(&self, pubkey_bytes: &[u8], message_bytes: &[u8]) -> bool {

--- a/sdk/src/signature.rs
+++ b/sdk/src/signature.rs
@@ -28,6 +28,12 @@ impl Signature {
         Self(GenericArray::clone_from_slice(&signature_slice))
     }
 
+    pub fn new_rand() -> Self {
+        let mut random_signature_bytes = [0u8; 64];
+        random_signature_bytes[0..20].copy_from_slice(&rand::random::<[u8; 20]>());
+        Self::new(&random_signature_bytes) // same as status cache!
+    }
+
     pub fn verify(&self, pubkey_bytes: &[u8], message_bytes: &[u8]) -> bool {
         let pubkey = ed25519_dalek::PublicKey::from_bytes(pubkey_bytes);
         let signature = ed25519_dalek::Signature::from_bytes(self.0.as_slice());

--- a/sdk/src/system_transaction.rs
+++ b/sdk/src/system_transaction.rs
@@ -2,13 +2,31 @@
 
 use crate::{
     hash::Hash,
+    instruction::Instruction,
     pubkey::Pubkey,
     signature::{Keypair, KeypairUtil},
     system_instruction,
     transaction::Transaction,
 };
 
-/// Create and sign new SystemInstruction::CreateAccount transaction
+fn create_account_instructions(
+    from_keypair: &Keypair,
+    to_keypair: &Keypair,
+    lamports: u64,
+    space: u64,
+    program_id: &Pubkey,
+) -> Vec<Instruction> {
+    let from_pubkey = from_keypair.pubkey();
+    let to_pubkey = to_keypair.pubkey();
+    return vec![system_instruction::create_account(
+        &from_pubkey,
+        &to_pubkey,
+        lamports,
+        space,
+        program_id,
+    )];
+}
+
 pub fn create_account(
     from_keypair: &Keypair,
     to_keypair: &Keypair,
@@ -17,37 +35,80 @@ pub fn create_account(
     space: u64,
     program_id: &Pubkey,
 ) -> Transaction {
-    let from_pubkey = from_keypair.pubkey();
-    let to_pubkey = to_keypair.pubkey();
-    let create_instruction =
-        system_instruction::create_account(&from_pubkey, &to_pubkey, lamports, space, program_id);
-    let instructions = vec![create_instruction];
     Transaction::new_signed_instructions(
         &[from_keypair, to_keypair],
-        instructions,
+        create_account_instructions(from_keypair, to_keypair, lamports, space, program_id),
         recent_blockhash,
     )
 }
 
-/// Create and sign new system_instruction::Assign transaction
-pub fn assign(from_keypair: &Keypair, recent_blockhash: Hash, program_id: &Pubkey) -> Transaction {
-    let from_pubkey = from_keypair.pubkey();
-    let assign_instruction = system_instruction::assign(&from_pubkey, program_id);
-    let instructions = vec![assign_instruction];
-    Transaction::new_signed_instructions(&[from_keypair], instructions, recent_blockhash)
+pub fn create_account_with_dummy_sig(
+    from_keypair: &Keypair,
+    to_keypair: &Keypair,
+    recent_blockhash: Hash,
+    lamports: u64,
+    space: u64,
+    program_id: &Pubkey,
+) -> Transaction {
+    Transaction::new_signed_instructions_random(
+        create_account_instructions(from_keypair, to_keypair, lamports, space, program_id),
+        recent_blockhash,
+    )
 }
 
-/// Create and sign new system_instruction::Transfer transaction
+pub fn assign_instructions(from_keypair: &Keypair, program_id: &Pubkey) -> Vec<Instruction> {
+    let from_pubkey = from_keypair.pubkey();
+    let assign_instruction = system_instruction::assign(&from_pubkey, program_id);
+    return vec![assign_instruction];
+}
+
+pub fn assign(from_keypair: &Keypair, recent_blockhash: Hash, program_id: &Pubkey) -> Transaction {
+    Transaction::new_signed_instructions(
+        &[from_keypair],
+        assign_instructions(from_keypair, program_id),
+        recent_blockhash,
+    )
+}
+
+pub fn assign_with_dummy_sig(
+    from_keypair: &Keypair,
+    recent_blockhash: Hash,
+    program_id: &Pubkey,
+) -> Transaction {
+    Transaction::new_signed_instructions_random(
+        assign_instructions(from_keypair, program_id),
+        recent_blockhash,
+    )
+}
+
+fn transfer_instructions(from_keypair: &Keypair, to: &Pubkey, lamports: u64) -> Vec<Instruction> {
+    let from_pubkey = from_keypair.pubkey();
+    return vec![system_instruction::transfer(&from_pubkey, to, lamports)];
+}
+
 pub fn transfer(
     from_keypair: &Keypair,
     to: &Pubkey,
     lamports: u64,
     recent_blockhash: Hash,
 ) -> Transaction {
-    let from_pubkey = from_keypair.pubkey();
-    let transfer_instruction = system_instruction::transfer(&from_pubkey, to, lamports);
-    let instructions = vec![transfer_instruction];
-    Transaction::new_signed_instructions(&[from_keypair], instructions, recent_blockhash)
+    Transaction::new_signed_instructions(
+        &[from_keypair],
+        transfer_instructions(from_keypair, to, lamports),
+        recent_blockhash,
+    )
+}
+
+pub fn transfer_with_dummy_sig(
+    from_keypair: &Keypair,
+    to: &Pubkey,
+    lamports: u64,
+    recent_blockhash: Hash,
+) -> Transaction {
+    Transaction::new_signed_instructions_random(
+        transfer_instructions(from_keypair, to, lamports),
+        recent_blockhash,
+    )
 }
 
 /// Create and sign new nonced system_instruction::Transfer transaction

--- a/sdk/src/transaction.rs
+++ b/sdk/src/transaction.rs
@@ -8,6 +8,7 @@ use crate::short_vec;
 use crate::signature::{KeypairUtil, Signature};
 use crate::system_instruction;
 use bincode::serialize;
+use std::convert::TryInto;
 use std::result;
 use thiserror::Error;
 
@@ -119,6 +120,23 @@ impl Transaction {
     pub fn new_unsigned_instructions(instructions: Vec<Instruction>) -> Self {
         let message = Message::new(instructions);
         Self::new_unsigned(message)
+    }
+
+    pub fn new_signed_instructions_random(
+        instructions: Vec<Instruction>,
+        recent_blockhash: Hash,
+    ) -> Self {
+        let mut tx = Self::new_unsigned_instructions(instructions);
+        tx.signatures = vec![
+            Signature::new_rand();
+            tx.message
+                .header
+                .num_required_signatures
+                .try_into()
+                .unwrap()
+        ];
+        tx.message.recent_blockhash = recent_blockhash;
+        tx
     }
 
     pub fn new<T: KeypairUtil>(


### PR DESCRIPTION
#### Problem

When profiling on the cryptography-unrelated system logic code path for `solana-validator` _to the extreme_, `solana-bench-tps` can be bottle-necked.

Because `solana-validator` does a heavy-lifting of ed25519 verification by default, `perf top` is littered with entries related to it. So I first filtered them out by `--dev-no-sigverify` to concentrate on the transaction processing code for concurrency and scalability in search of potential bottlenecks in there. Then, in turn, `solana-bench-tps`'s ed25519 signing got the next bottleneck!

I need to disable it too to stress `solana-validator` enough to really expose throughput issues in TPU/TVU. Ultimately, when most of crypto workloads are offloaded to the GPU, the bottlenecks in TPU/TVU will be the next priority.

#### Solution

Introduce **`--dummy-sig`** flag to `solana-bench-tps`, which is paired with `solana-validator`'s `--dev-no-sigverify`.

This is still a draft, not final, rather collecting feedback from you! I think this option might be useful, or is there other better way to profile for the mentioned profiling scenario?

#### Background

I'm trying to profile `solana-validator` with Linux's `perf`, already finding some small wins (stay tuned for more PRs!), by the middle course of familiarizing myself with the code base from another viewpoint.