### PR TITLE
Sign shreds on the GPU

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3329,6 +3329,7 @@ dependencies = [
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "serial_test 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serial_test_derive 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-budget-api 0.21.0",
  "solana-budget-program 0.21.0",
  "solana-chacha-sys 0.21.0",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -45,6 +45,7 @@ rayon = "1.2.0"
 serde = "1.0.102"
 serde_derive = "1.0.102"
 serde_json = "1.0.41"
+sha2 = "0.8.0"
 solana-budget-api = { path = "../programs/budget_api", version = "0.21.0" }
 solana-budget-program = { path = "../programs/budget_program", version = "0.21.0" }
 solana-chacha-sys = { path = "../chacha-sys", version = "0.21.0" }

--- a/core/src/cuda_runtime.rs
+++ b/core/src/cuda_runtime.rs
@@ -67,15 +67,9 @@ pub struct PinnedVec<T> {
     pinnable: bool,
 }
 
-impl Reset for PinnedVec<u8> {
+impl<T: Default + Clone> Reset for PinnedVec<T> {
     fn reset(&mut self) {
-        self.resize(0, 0u8);
-    }
-}
-
-impl Reset for PinnedVec<u32> {
-    fn reset(&mut self) {
-        self.resize(0, 0u32);
+        self.resize(0, T::default());
     }
 }
 

--- a/core/src/packet.rs
+++ b/core/src/packet.rs
@@ -58,12 +58,6 @@ impl Reset for Packets {
     }
 }
 
-impl Reset for PinnedVec<Packet> {
-    fn reset(&mut self) {
-        self.resize(0, Packet::default());
-    }
-}
-
 //auto derive doesn't support large arrays
 impl Default for Packets {
     fn default() -> Packets {

--- a/core/src/sigverify_shreds.rs
+++ b/core/src/sigverify_shreds.rs
@@ -29,7 +29,7 @@ pub struct ShredSigVerifier {
     bank_forks: Arc<RwLock<BankForks>>,
     leader_schedule_cache: Arc<LeaderScheduleCache>,
     recycler_offsets: Recycler<TxOffset>,
-    recycler_pubkeys: Recycler<PinnedVec<[u8; 32]>>,
+    recycler_keys: Recycler<PinnedVec<[u8; 32]>>,
     recycler_out: Recycler<PinnedVec<u8>>,
 }
 
@@ -43,7 +43,7 @@ impl ShredSigVerifier {
             bank_forks,
             leader_schedule_cache,
             recycler_offsets: Recycler::default(),
-            recycler_pubkeys: Recycler::default(),
+            recycler_keys: Recycler::default(),
             recycler_out: Recycler::default(),
         }
     }
@@ -86,7 +86,7 @@ impl SigVerifier for ShredSigVerifier {
             &batches,
             &leader_slots,
             &self.recycler_offsets,
-            &self.recycler_pubkeys,
+            &self.recycler_keys,
             &self.recycler_out,
         );
         batches.into_iter().zip(r).collect()

--- a/core/src/sigverify_shreds.rs
+++ b/core/src/sigverify_shreds.rs
@@ -223,10 +223,10 @@ fn slot_key_data_for_gpu<
         (keyvec.len() * size_of::<T>() + (size_of::<Packet>() - 1)) / size_of::<Packet>();
     trace!("num_in_packets {}", num_in_packets);
     //number of bytes missing
-    let missing = num_in_packets * size_of::<Packet>() - keyvec.len() * size_of::<[u8; 32]>();
+    let missing = num_in_packets * size_of::<Packet>() - keyvec.len() * size_of::<T>();
     trace!("missing {}", missing);
     //extra Pubkeys needed to fill the buffer
-    let extra = (missing + size_of::<T>() - 1) / size_of::<[u8; 32]>();
+    let extra = (missing + size_of::<T>() - 1) / size_of::<T>();
     trace!("extra {}", extra);
     trace!("keyvec {}", keyvec.len());
     for _ in 0..extra {

--- a/core/src/sigverify_shreds.rs
+++ b/core/src/sigverify_shreds.rs
@@ -5,9 +5,9 @@ use crate::recycler::Recycler;
 use crate::recycler::Reset;
 use crate::sigverify::{self, TxOffset};
 use crate::sigverify_stage::SigVerifier;
-use rayon::iter::IndexedParallelIterator;
 use crate::sigverify_stage::VerifiedPackets;
 use bincode::deserialize;
+use rayon::iter::IndexedParallelIterator;
 use rayon::iter::IntoParallelIterator;
 use rayon::iter::IntoParallelRefMutIterator;
 use rayon::iter::ParallelIterator;
@@ -413,7 +413,7 @@ fn sign_shreds_cpu(
     use rayon::prelude::*;
     let count = sigverify::batch_size(batches);
     debug!("CPU SHRED ECDSA for {}", count);
-    let rv = PAR_THREAD_POOL.with(|thread_pool| {
+    PAR_THREAD_POOL.with(|thread_pool| {
         thread_pool.borrow().install(|| {
             batches.par_iter_mut().for_each(|p| {
                 p.packets.iter_mut().for_each(|mut p| {
@@ -423,7 +423,6 @@ fn sign_shreds_cpu(
         })
     });
     inc_new_counter_debug!("ed25519_shred_verify_cpu", count);
-    rv
 }
 
 pub fn sign_shreds_gpu(

--- a/core/src/sigverify_shreds.rs
+++ b/core/src/sigverify_shreds.rs
@@ -435,14 +435,18 @@ pub fn sign_shreds_gpu(
         return sign_shreds_cpu(batches, slot_leaders_pubkeys, slot_leaders_privkeys);
     }
     let slot_leaders_secrets: HashMap<u64, Signature> = slot_leaders_privkeys
-        .into_iter()
+        .iter()
         .map(|(k, v)| {
             if *k == std::u64::MAX {
                 (*k, Signature::default())
             } else {
                 let mut hasher = Sha512::default();
                 hasher.input(&v);
-                let sig = Signature::new(hasher.result().as_slice());
+                let mut result = hasher.result();
+                result[0] &= 248;
+                result[31] &= 63;
+                result[31] |= 64;
+                let sig = Signature::new(result.as_slice());
                 (*k, sig)
             }
         })

--- a/core/src/sigverify_shreds.rs
+++ b/core/src/sigverify_shreds.rs
@@ -755,6 +755,9 @@ pub mod tests {
             &recycler_pubkeys,
             &recycler_out,
         );
+        let rv = verify_shreds_cpu(&batch, &pubkeys);
+        assert_eq!(rv, vec![vec![1]]);
+
         let rv = verify_shreds_gpu(
             &batch,
             &pubkeys,

--- a/core/src/sigverify_shreds.rs
+++ b/core/src/sigverify_shreds.rs
@@ -679,6 +679,30 @@ pub mod tests {
         );
         assert_eq!(rv, vec![vec![0]]);
     }
+    
+    #[test]
+    fn test_sigverify_shreds_sign_gpu() {
+        solana_logger::setup();
+        let recycler_offsets = Recycler::default();
+        let recycler_pubkeys = Recycler::default();
+
+        let mut batch = [Packets::default()];
+        let slot = 0xdeadc0de;
+        let mut shred = Shred::new_from_data(slot, 0xc0de, 0xdead, Some(&[1, 2, 3, 4]), true, true);
+        let keypair = Keypair::new();
+        batch[0].packets.resize(1, Packet::default());
+        batch[0].packets[0].data[0..shred.payload.len()].copy_from_slice(&shred.payload);
+        batch[0].packets[0].meta.size = shred.payload.len();
+        let pubkeys = [
+            (slot, keypair.pubkey().to_array()),
+            (std::u64::MAX, [0u8; 32]),
+        ];
+        let privkeys = [
+            (slot, keypair.secret().to_array()),
+            (std::u64::MAX, [0u8; 32]),
+        ];
+        sigverify_sign_shreds_gpu(&mut batch, &pubkeys, &privkeys, &recycler_offsets, &recycler_pubkeys);
+    }
 
     #[test]
     fn test_sigverify_shreds_read_slots() {

--- a/core/src/sigverify_shreds.rs
+++ b/core/src/sigverify_shreds.rs
@@ -736,6 +736,40 @@ pub mod tests {
     }
 
     #[test]
+    fn test_sigverify_shreds_sign_cpu() {
+        solana_logger::setup();
+
+        let mut batch = [Packets::default()];
+        let slot = 0xdeadc0de;
+        let keypair = Keypair::new();
+        let shred = Shred::new_from_data(slot, 0xc0de, 0xdead, Some(&[1, 2, 3, 4]), true, true);
+        batch[0].packets.resize(1, Packet::default());
+        batch[0].packets[0].data[0..shred.payload.len()].copy_from_slice(&shred.payload);
+        batch[0].packets[0].meta.size = shred.payload.len();
+        let pubkeys = [
+            (slot, keypair.pubkey().to_bytes()),
+            (std::u64::MAX, [0u8; 32]),
+        ]
+        .iter()
+        .cloned()
+        .collect();
+        let privkeys = [
+            (slot, keypair.secret.to_bytes()),
+            (std::u64::MAX, [0u8; 32]),
+        ]
+        .iter()
+        .cloned()
+        .collect();
+        //unsigned
+        let rv = verify_shreds_cpu(&batch, &pubkeys);
+        assert_eq!(rv, vec![vec![0]]);
+        //signed
+        sign_shreds_cpu(&mut batch, &pubkeys, &privkeys);
+        let rv = verify_shreds_cpu(&batch, &pubkeys);
+        assert_eq!(rv, vec![vec![1]]);
+    }
+
+    #[test]
     fn test_sigverify_shreds_read_slots() {
         solana_logger::setup();
         let mut shred =

--- a/fetch-perf-libs.sh
+++ b/fetch-perf-libs.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-PERF_LIBS_VERSION=v0.16.0
+PERF_LIBS_VERSION=v0.16.1
 VERSION=$PERF_LIBS_VERSION-1
 
 set -e

--- a/fetch-perf-libs.sh
+++ b/fetch-perf-libs.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-PERF_LIBS_VERSION=v0.15.0
+PERF_LIBS_VERSION=v0.16.0
 VERSION=$PERF_LIBS_VERSION-1
 
 set -e

--- a/ledger/src/perf_libs.rs
+++ b/ledger/src/perf_libs.rs
@@ -50,8 +50,8 @@ pub struct Api<'a> {
             message_lens: *const u32,
             pubkey_offsets: *const u32,
             privkey_offsets: *const u32,
-            signature_offsets: *const u32,
             signed_message_offsets: *const u32,
+            sgnatures_out: *mut u8, //combined length of all the items in vecs
             use_non_default_stream: u8,
         ) -> u32,
     >,

--- a/ledger/src/perf_libs.rs
+++ b/ledger/src/perf_libs.rs
@@ -39,6 +39,23 @@ pub struct Api<'a> {
         ) -> u32,
     >,
 
+    pub ed25519_sign_many: Symbol<
+        'a,
+        unsafe extern "C" fn(
+            vecs: *mut Elems,
+            num: u32,          //number of vecs
+            message_size: u32, //size of each element inside the elems field of the vec
+            total_packets: u32,
+            total_signatures: u32,
+            message_lens: *const u32,
+            pubkey_offsets: *const u32,
+            privkey_offsets: *const u32,
+            signature_offsets: *const u32,
+            signed_message_offsets: *const u32,
+            use_non_default_stream: u8,
+        ) -> u32,
+    >,
+
     pub chacha_cbc_encrypt_many_sample: Symbol<
         'a,
         unsafe extern "C" fn(

--- a/ledger/src/perf_libs.rs
+++ b/ledger/src/perf_libs.rs
@@ -39,6 +39,7 @@ pub struct Api<'a> {
         ) -> u32,
     >,
 
+    #[allow(clippy::type_complexity)]
     pub ed25519_sign_many: Symbol<
         'a,
         unsafe extern "C" fn(

--- a/sdk/src/pubkey.rs
+++ b/sdk/src/pubkey.rs
@@ -58,6 +58,9 @@ impl Pubkey {
             sol_log_64(0, 0, 0, i as u64, u64::from(*k));
         }
     }
+    pub fn to_array(self) -> [u8; 32] {
+        self.0
+    }
 }
 
 impl AsRef<[u8]> for Pubkey {

--- a/sdk/src/pubkey.rs
+++ b/sdk/src/pubkey.rs
@@ -58,7 +58,7 @@ impl Pubkey {
             sol_log_64(0, 0, 0, i as u64, u64::from(*k));
         }
     }
-    pub fn to_array(self) -> [u8; 32] {
+    pub fn to_bytes(self) -> [u8; 32] {
         self.0
     }
 }


### PR DESCRIPTION
#### Problem

Signing shreds takes a lot of CPU time.

#### Summary of Changes

API to sign shreds on the GPU.  Depends on perf-libs update.

Fixes #
