### PR TITLE
Fix gpu memory pinning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3772,6 +3772,7 @@ dependencies = [
  "bincode 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "dlopen 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "dlopen_derive 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/core/src/archiver.rs
+++ b/core/src/archiver.rs
@@ -921,7 +921,7 @@ impl Archiver {
             let res = r_reader.recv_timeout(Duration::new(1, 0));
             if let Ok(mut packets) = res {
                 while let Ok(mut more) = r_reader.try_recv() {
-                    packets.packets.append(&mut more.packets);
+                    packets.packets.append_pinned(&mut more.packets);
                 }
                 let shreds: Vec<Shred> = packets
                     .packets

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -16,6 +16,7 @@ use solana_ledger::{
 };
 use solana_measure::measure::Measure;
 use solana_metrics::{inc_new_counter_debug, inc_new_counter_info, inc_new_counter_warn};
+use solana_perf::cuda_runtime::PinnedVec;
 use solana_perf::perf_libs;
 use solana_runtime::{accounts_db::ErrorCounters, bank::Bank, transaction_batch::TransactionBatch};
 use solana_sdk::{
@@ -789,7 +790,7 @@ impl BankingStage {
         filtered_unprocessed_packet_indexes
     }
 
-    fn generate_packet_indexes(vers: &[Packet]) -> Vec<usize> {
+    fn generate_packet_indexes(vers: &PinnedVec<Packet>) -> Vec<usize> {
         vers.iter()
             .enumerate()
             .filter_map(

--- a/core/src/fetch_stage.rs
+++ b/core/src/fetch_stage.rs
@@ -1,6 +1,7 @@
 //! The `fetch_stage` batches input from a UDP socket and sends it to a channel.
 
 use crate::banking_stage::FORWARD_TRANSACTIONS_TO_LEADER_AT_SLOT_OFFSET;
+use crate::packet::PacketsRecycler;
 use crate::poh_recorder::PohRecorder;
 use crate::result::{Error, Result};
 use crate::service::Service;
@@ -92,7 +93,8 @@ impl FetchStage {
         sender: &PacketSender,
         poh_recorder: &Arc<Mutex<PohRecorder>>,
     ) -> Self {
-        let recycler = Recycler::default();
+        let recycler: PacketsRecycler = Recycler::warmed(1000, 1024);
+
         let tpu_threads = sockets.into_iter().map(|socket| {
             streamer::receiver(
                 socket,

--- a/core/src/shred_fetch_stage.rs
+++ b/core/src/shred_fetch_stage.rs
@@ -1,6 +1,6 @@
 //! The `shred_fetch_stage` pulls shreds from UDP sockets and sends it to a channel.
 
-use crate::packet::Packet;
+use crate::packet::{Packet, PacketsRecycler};
 use crate::service::Service;
 use crate::streamer::{self, PacketReceiver, PacketSender};
 use solana_perf::cuda_runtime::PinnedVec;
@@ -67,7 +67,8 @@ impl ShredFetchStage {
         sender: &PacketSender,
         exit: &Arc<AtomicBool>,
     ) -> Self {
-        let recycler = Recycler::default();
+        let recycler: PacketsRecycler = Recycler::warmed(100, 1024);
+
         let tvu_threads = sockets.into_iter().map(|socket| {
             streamer::receiver(
                 socket,

--- a/core/src/sigverify.rs
+++ b/core/src/sigverify.rs
@@ -23,8 +23,8 @@ impl Default for TransactionSigVerifier {
     fn default() -> Self {
         init();
         Self {
-            recycler: Recycler::default(),
-            recycler_out: Recycler::default(),
+            recycler: Recycler::warmed(50, 4096),
+            recycler_out: Recycler::warmed(50, 4096),
         }
     }
 }

--- a/core/src/sigverify_shreds.rs
+++ b/core/src/sigverify_shreds.rs
@@ -30,8 +30,8 @@ impl ShredSigVerifier {
         Self {
             bank_forks,
             leader_schedule_cache,
-            recycler_offsets: Recycler::default(),
-            recycler_out: Recycler::default(),
+            recycler_offsets: Recycler::warmed(50, 4096),
+            recycler_out: Recycler::warmed(50, 4096),
         }
     }
     fn read_slots(batches: &[Packets]) -> HashSet<u64> {

--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -287,7 +287,7 @@ mod test {
         service::Service,
     };
     use crossbeam_channel::unbounded;
-    use rand::{seq::SliceRandom, thread_rng};
+    use rand::thread_rng;
     use solana_ledger::shred::DataShredHeader;
     use solana_ledger::{
         blocktree::{get_tmp_ledger_path, make_many_slot_entries, Blocktree},

--- a/perf/Cargo.toml
+++ b/perf/Cargo.toml
@@ -16,6 +16,7 @@ rayon = "1.2.0"
 serde = "1.0.102"
 serde_derive = "1.0.102"
 dlopen_derive = "0.1.4"
+lazy_static = "1.4.0"
 log = "0.4.8"
 solana-sdk = { path = "../sdk", version = "0.21.0" }
 solana-rayon-threadlimit = { path = "../rayon-threadlimit", version = "0.21.0" }

--- a/perf/src/lib.rs
+++ b/perf/src/lib.rs
@@ -6,6 +6,9 @@ pub mod sigverify;
 pub mod test_tx;
 
 #[macro_use]
+extern crate lazy_static;
+
+#[macro_use]
 extern crate log;
 
 #[cfg(test)]

--- a/perf/src/packet.rs
+++ b/perf/src/packet.rs
@@ -33,6 +33,11 @@ impl Reset for Packets {
     fn reset(&mut self) {
         self.packets.resize(0, Packet::default());
     }
+
+    fn warm(&mut self, size_hint: usize) {
+        self.packets.set_pinnable();
+        self.packets.resize(size_hint, Packet::default());
+    }
 }
 
 //auto derive doesn't support large arrays

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -12,6 +12,7 @@ use solana_core::service::Service;
 use solana_core::socketaddr;
 use solana_core::validator::{Validator, ValidatorConfig};
 use solana_ledger::bank_forks::SnapshotConfig;
+use solana_perf::recycler::enable_recycler_warming;
 use solana_sdk::clock::Slot;
 use solana_sdk::hash::Hash;
 use solana_sdk::signature::{read_keypair_file, Keypair, KeypairUtil};
@@ -574,6 +575,7 @@ pub fn main() {
 
     if cuda {
         solana_perf::perf_libs::init_cuda();
+        enable_recycler_warming();
     }
 
     let mut gossip_addr = solana_netutil::parse_port_or_addr(


### PR DESCRIPTION
#### Problem

Pinning is disabled since deref got out of hand and re-allocated the vec in places that were not expected.

#### Summary of Changes

Remove Deref implementations and add more pass-throughs to the PinnedVec
wrapper.

Fixes #
