### PR TITLE
Fix Weighted Best calculation

### DIFF
--- a/core/src/weighted_shuffle.rs
+++ b/core/src/weighted_shuffle.rs
@@ -9,11 +9,10 @@ use std::ops::Div;
 
 /// Returns a list of indexes shuffled based on the input weights
 /// Note - The sum of all weights must not exceed `u64::MAX`
-pub fn weighted_shuffle<T>(weights: Vec<T>, rng: ChaChaRng) -> Vec<usize>
+pub fn weighted_shuffle<T>(weights: Vec<T>, mut rng: ChaChaRng) -> Vec<usize>
 where
     T: Copy + PartialOrd + iter::Sum + Div<T, Output = T> + FromPrimitive + ToPrimitive,
 {
-    let mut rng = rng;
     let total_weight: T = weights.clone().into_iter().sum();
     weights
         .into_iter()
@@ -37,8 +36,7 @@ where
 
 /// Returns the highest index after computing a weighted shuffle.
 /// Saves doing any sorting for O(n) max calculation.
-pub fn weighted_best(weights_and_indexes: &[(u64, usize)], rng: ChaChaRng) -> usize {
-    let mut rng = rng;
+pub fn weighted_best(weights_and_indexes: &[(u64, usize)], mut rng: ChaChaRng) -> usize {
     if weights_and_indexes.is_empty() {
         return 0;
     }

--- a/core/src/weighted_shuffle.rs
+++ b/core/src/weighted_shuffle.rs
@@ -26,7 +26,7 @@ where
             (
                 i,
                 // capture the u64 into u128s to prevent overflow
-                (&mut rng).gen_range(1, u128::from(std::u16::MAX)) * u128::from(x),
+                rng.gen_range(1, u128::from(std::u16::MAX)) * u128::from(x),
             )
         })
         // sort in ascending order
@@ -37,21 +37,21 @@ where
 
 /// Returns the highest index after computing a weighted shuffle.
 /// Saves doing any sorting for O(n) max calculation.
-pub fn weighted_best(weights_and_indicies: &[(u64, usize)], rng: ChaChaRng) -> usize {
+pub fn weighted_best(weights_and_indexes: &[(u64, usize)], rng: ChaChaRng) -> usize {
     let mut rng = rng;
-    if weights_and_indicies.is_empty() {
+    if weights_and_indexes.is_empty() {
         return 0;
     }
-    let total_weight: u64 = weights_and_indicies.iter().map(|x| x.0).sum();
+    let total_weight: u64 = weights_and_indexes.iter().map(|x| x.0).sum();
     let mut lowest_weight = std::u128::MAX;
     let mut best_index = 0;
-    for v in weights_and_indicies {
+    for v in weights_and_indexes {
         // This generates an "inverse" weight but it avoids floating point math
         let x = (total_weight / v.0)
             .to_u64()
             .expect("values > u64::max are not supported");
         // capture the u64 into u128s to prevent overflow
-        let computed_weight = (&mut rng).gen_range(1, u128::from(std::u16::MAX)) * u128::from(x);
+        let computed_weight = rng.gen_range(1, u128::from(std::u16::MAX)) * u128::from(x);
         // The highest input weight maps to the lowest computed weight
         if computed_weight < lowest_weight {
             lowest_weight = computed_weight;
@@ -124,8 +124,12 @@ mod tests {
 
     #[test]
     fn test_weighted_best() {
-        let weights = vec![(100, 0), (1000, 1), (10_000, 2), (10, 3)];
-        let best = weighted_best(&weights, ChaChaRng::from_seed([0x5b; 32]));
-        assert_eq!(best, 2);
+        let weights_and_indexes: Vec<_> = vec![100u64, 1000, 10_000, 10]
+            .into_iter()
+            .enumerate()
+            .map(|(i, weight)| (weight, i))
+            .collect();
+        let best_index = weighted_best(&weights_and_indexes, ChaChaRng::from_seed([0x5b; 32]));
+        assert_eq!(best_index, 2);
     }
 }


### PR DESCRIPTION
#### Problem

`weighted_best()` picks the worst weight.
This causes broadcast to prioritize validators with the lowest stake.

#### Summary of Changes

Fixed the weight comparison