### PR TITLE
Fixup running-validator docs

### DIFF
--- a/book/src/running-archiver.md
+++ b/book/src/running-archiver.md
@@ -29,7 +29,7 @@ Before starting an archiver node, sanity check that the cluster is accessible to
 Fetch the current transaction count over JSON RPC:
 
 ```bash
-$ curl -X POST -H 'Content-Type: application/json' -d '{"jsonrpc":"2.0","id":1, "method":"getTransactionCount"}' http://testnet.solana.com:8899
+curl -X POST -H 'Content-Type: application/json' -d '{"jsonrpc":"2.0","id":1, "method":"getTransactionCount"}' http://testnet.solana.com:8899
 ```
 
 Inspect the blockexplorer at [http://testnet.solana.com/](http://testnet.solana.com/) for activity.
@@ -47,13 +47,13 @@ The `solana-install` tool can be used to easily install and upgrade the cluster 
 #### Linux and mac OS
 
 ```bash
-$ curl -sSf https://raw.githubusercontent.com/solana-labs/solana/v0.18.0/install/solana-install-init.sh | sh -s
+curl -sSf https://raw.githubusercontent.com/solana-labs/solana/v0.18.0/install/solana-install-init.sh | sh -s
 ```
 
 Alternatively build the `solana-install` program from source and run the following command to obtain the same result:
 
 ```bash
-$ solana-install init
+solana-install init
 ```
 
 #### Windows
@@ -71,9 +71,9 @@ If you would rather not use `solana-install` to manage the install, you can manu
 Download the binaries by navigating to [https://github.com/solana-labs/solana/releases/latest](https://github.com/solana-labs/solana/releases/latest), download **solana-release-x86\_64-unknown-linux-gnu.tar.bz2**, then extract the archive:
 
 ```bash
-$ tar jxf solana-release-x86_64-unknown-linux-gnu.tar.bz2
-$ cd solana-release/
-$ export PATH=$PWD/bin:$PATH
+tar jxf solana-release-x86_64-unknown-linux-gnu.tar.bz2
+cd solana-release/
+export PATH=$PWD/bin:$PATH
 ```
 
 #### mac OS
@@ -81,9 +81,9 @@ $ export PATH=$PWD/bin:$PATH
 Download the binaries by navigating to [https://github.com/solana-labs/solana/releases/latest](https://github.com/solana-labs/solana/releases/latest), download **solana-release-x86\_64-apple-darwin.tar.bz2**, then extract the archive:
 
 ```bash
-$ tar jxf solana-release-x86_64-apple-darwin.tar.bz2
-$ cd solana-release/
-$ export PATH=$PWD/bin:$PATH
+tar jxf solana-release-x86_64-apple-darwin.tar.bz2
+cd solana-release/
+export PATH=$PWD/bin:$PATH
 ```
 
 #### Windows
@@ -95,7 +95,7 @@ Download the binaries by navigating to [https://github.com/solana-labs/solana/re
 Try running following command to join the gossip network and view all the other nodes in the cluster:
 
 ```bash
-$ solana-gossip --entrypoint testnet.solana.com:8001 spy
+solana-gossip --entrypoint testnet.solana.com:8001 spy
 # Press ^C to exit
 ```
 
@@ -104,8 +104,8 @@ Now configure the keypairs for your archiver by running:
 Navigate to the solana install location and open a cmd prompt
 
 ```bash
-$ solana-keygen new -o archiver-keypair.json
-$ solana-keygen new -o storage-keypair.json
+solana-keygen new -o archiver-keypair.json
+solana-keygen new -o storage-keypair.json
 ```
 
 Use solana-keygen to show the public keys for each of the keypairs, they will be needed in the next step:
@@ -114,23 +114,23 @@ Use solana-keygen to show the public keys for each of the keypairs, they will be
 
   ```bash
   # The archiver's identity
-  $ solana-keygen pubkey archiver-keypair.json
-  $ solana-keygen pubkey storage-keypair.json
+  solana-keygen pubkey archiver-keypair.json
+  solana-keygen pubkey storage-keypair.json
   ```
 
 * Linux and mac OS
 
   \`\`\`bash
 
-  $ export ARCHIVER\_IDENTITY=$\(solana-keygen pubkey archiver-keypair.json\)
+  export ARCHIVER\_IDENTITY=$\(solana-keygen pubkey archiver-keypair.json\)
 
-  $ export STORAGE\_IDENTITY=$\(solana-keygen pubkey storage-keypair.json\)
+  export STORAGE\_IDENTITY=$\(solana-keygen pubkey storage-keypair.json\)
 
 ```text
 Then set up the storage accounts for your archiver by running:
 ```bash
-$ solana --keypair archiver-keypair.json airdrop 100000 lamports
-$ solana --keypair archiver-keypair.json create-archiver-storage-account $ARCHIVER_IDENTITY $STORAGE_IDENTITY
+solana --keypair archiver-keypair.json airdrop 100000 lamports
+solana --keypair archiver-keypair.json create-archiver-storage-account $ARCHIVER_IDENTITY $STORAGE_IDENTITY
 ```
 
 Note: Every time the testnet restarts, run the steps to setup the archiver accounts again.
@@ -138,7 +138,7 @@ Note: Every time the testnet restarts, run the steps to setup the archiver accou
 To start the archiver:
 
 ```bash
-$ solana-archiver --entrypoint testnet.solana.com:8001 --identity archiver-keypair.json --storage-keypair storage-keypair.json --ledger archiver-ledger
+solana-archiver --entrypoint testnet.solana.com:8001 --identity archiver-keypair.json --storage-keypair storage-keypair.json --ledger archiver-ledger
 ```
 
 ## Verify Archiver Setup
@@ -146,12 +146,11 @@ $ solana-archiver --entrypoint testnet.solana.com:8001 --identity archiver-keypa
 From another console, confirm the IP address and **identity pubkey** of your archiver is visible in the gossip network by running:
 
 ```bash
-$ solana-gossip --entrypoint testnet.solana.com:8001 spy
+solana-gossip --entrypoint testnet.solana.com:8001 spy
 ```
 
 Provide the **storage account pubkey** to the `solana show-storage-account` command to view the recent mining activity from your archiver:
 
 ```bash
-$ solana --keypair storage-keypair.json show-storage-account $STORAGE_IDENTITY
+solana --keypair storage-keypair.json show-storage-account $STORAGE_IDENTITY
 ```
-

--- a/book/src/running-validator/validator-info.md
+++ b/book/src/running-validator/validator-info.md
@@ -7,13 +7,13 @@ You can publish your validator information to the chain to be publicly visible t
 Run the solana CLI to populate a validator info account:
 
 ```bash
-$ solana validator-info publish --keypair ~/validator-keypair.json <VALIDATOR_INFO_ARGS> <VALIDATOR_NAME>
+solana validator-info publish --keypair ~/validator-keypair.json <VALIDATOR_INFO_ARGS> <VALIDATOR_NAME>
 ```
 
 For details about optional fields for VALIDATOR\_INFO\_ARGS:
 
 ```bash
-$ solana validator-info publish --help
+solana validator-info publish --help
 ```
 
 ## Keybase
@@ -33,4 +33,3 @@ Including a Keybase username allows client applications \(like the Solana Networ
 3. Add or update your `solana validator-info` with your Keybase username. The
 
    CLI will verify the `validator-<PUBKEY>` file
-

--- a/book/src/running-validator/validator-monitor.md
+++ b/book/src/running-validator/validator-monitor.md
@@ -5,13 +5,13 @@
 The **identity pubkey** for your validator can also be found by running:
 
 ```bash
-$ solana-keygen pubkey ~/validator-keypair.json
+solana-keygen pubkey ~/validator-keypair.json
 ```
 
 From another console, confirm the IP address and **identity pubkey** of your validator is visible in the gossip network by running:
 
 ```bash
-$ solana-gossip --entrypoint testnet.solana.com:8001 spy
+solana-gossip --entrypoint testnet.solana.com:8001 spy
 ```
 
 ## Check Vote Activity
@@ -19,13 +19,13 @@ $ solana-gossip --entrypoint testnet.solana.com:8001 spy
 The vote pubkey for the validator can be found by running:
 
 ```bash
-$ solana-keygen pubkey ~/validator-vote-keypair.json
+solana-keygen pubkey ~/validator-vote-keypair.json
 ```
 
 Provide the **vote pubkey** to the `solana show-vote-account` command to view the recent voting activity from your validator:
 
 ```bash
-$ solana show-vote-account 2ozWvfaXQd1X6uKh8jERoRGApDqSqcEy6fF1oN13LL2G
+solana show-vote-account 2ozWvfaXQd1X6uKh8jERoRGApDqSqcEy6fF1oN13LL2G
 ```
 
 ## Check Your Balance
@@ -33,7 +33,7 @@ $ solana show-vote-account 2ozWvfaXQd1X6uKh8jERoRGApDqSqcEy6fF1oN13LL2G
 Your account balance should decrease by the transaction fee amount as your validator submits votes, and increase after serving as the leader. Pass the `--lamports` are to observe in finer detail:
 
 ```bash
-$ solana balance --lamports
+solana balance --lamports
 ```
 
 ## Check Slot Number
@@ -41,13 +41,13 @@ $ solana balance --lamports
 After your validator boots, it may take some time to catch up with the cluster. Use the `get-slot` command to view the current slot that the cluster is processing:
 
 ```bash
-$ solana get-slot
+solana get-slot
 ```
 
 The current slot that your validator is processing can then been seen with:
 
 ```bash
-$ solana --url http://127.0.0.1:8899 get-slot
+solana --url http://127.0.0.1:8899 get-slot
 ```
 
 Until your validator has caught up, it will not be able to vote successfully and stake cannot be delegated to it.
@@ -60,11 +60,11 @@ There are several useful JSON-RPC endpoints for monitoring your validator on the
 
 ```bash
 # Similar to solana-gossip, you should see your validator in the list of cluster nodes
-$ curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1, "method":"getClusterNodes"}' http://testnet.solana.com:8899
+curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1, "method":"getClusterNodes"}' http://testnet.solana.com:8899
 # If your validator is properly voting, it should appear in the list of `current` vote accounts. If staked, `stake` should be > 0
-$ curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1, "method":"getVoteAccounts"}' http://testnet.solana.com:8899
+curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1, "method":"getVoteAccounts"}' http://testnet.solana.com:8899
 # Returns the current leader schedule
-$ curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1, "method":"getLeaderSchedule"}' http://testnet.solana.com:8899
+curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1, "method":"getLeaderSchedule"}' http://testnet.solana.com:8899
 # Returns info about the current epoch. slotIndex should progress on subsequent calls.
 curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1, "method":"getEpochInfo"}' http://testnet.solana.com:8899
 ```
@@ -76,9 +76,9 @@ Metrics are available for local monitoring of your validator.
 Docker must be installed and the current user added to the docker group. Then download `solana-metrics.tar.bz2` from the Github Release and run
 
 ```bash
-$ tar jxf solana-metrics.tar.bz2
-$ cd solana-metrics/
-$ ./start.sh
+tar jxf solana-metrics.tar.bz2
+cd solana-metrics/
+./start.sh
 ```
 
 A local InfluxDB and Grafana instance is now running on your machine. Define `SOLANA_METRICS_CONFIG` in your environment as described at the end of the `start.sh` output and restart your validator.
@@ -92,6 +92,5 @@ Log messages emitted by your validator include a timestamp. When sharing logs wi
 To make it easier to compare logs between different sources we request that everybody use Pacific Time on their validator nodes. In Linux this can be accomplished by running:
 
 ```bash
-$ sudo ln -sf /usr/share/zoneinfo/America/Los_Angeles /etc/localtime
+sudo ln -sf /usr/share/zoneinfo/America/Los_Angeles /etc/localtime
 ```
-

--- a/book/src/running-validator/validator-software.md
+++ b/book/src/running-validator/validator-software.md
@@ -5,13 +5,13 @@
 The `solana-install` tool can be used to easily install and upgrade the validator software on Linux x86\_64 and mac OS systems.
 
 ```bash
-$ curl -sSf https://raw.githubusercontent.com/solana-labs/solana/v0.18.0/install/solana-install-init.sh | sh -s
+curl -sSf https://raw.githubusercontent.com/solana-labs/solana/v0.18.0/install/solana-install-init.sh | sh -s
 ```
 
 Alternatively build the `solana-install` program from source and run the following command to obtain the same result:
 
 ```bash
-$ solana-install init
+solana-install init
 ```
 
 After a successful install, `solana-install update` may be used to easily update the cluster software to a newer version at any time.
@@ -25,9 +25,9 @@ If you would rather not use `solana-install` to manage the install, you can manu
 Download the binaries by navigating to [https://github.com/solana-labs/solana/releases/latest](https://github.com/solana-labs/solana/releases/latest), download **solana-release-x86\_64-unknown-linux-gnu.tar.bz2**, then extract the archive:
 
 ```bash
-$ tar jxf solana-release-x86_64-unknown-linux-gnu.tar.bz2
-$ cd solana-release/
-$ export PATH=$PWD/bin:$PATH
+tar jxf solana-release-x86_64-unknown-linux-gnu.tar.bz2
+cd solana-release/
+export PATH=$PWD/bin:$PATH
 ```
 
 ### mac OS
@@ -35,9 +35,9 @@ $ export PATH=$PWD/bin:$PATH
 Download the binaries by navigating to [https://github.com/solana-labs/solana/releases/latest](https://github.com/solana-labs/solana/releases/latest), download **solana-release-x86\_64-apple-darwin.tar.bz2**, then extract the archive:
 
 ```bash
-$ tar jxf solana-release-x86_64-apple-darwin.tar.bz2
-$ cd solana-release/
-$ export PATH=$PWD/bin:$PATH
+tar jxf solana-release-x86_64-apple-darwin.tar.bz2
+cd solana-release/
+export PATH=$PWD/bin:$PATH
 ```
 
 ## Build From Source
@@ -45,7 +45,6 @@ $ export PATH=$PWD/bin:$PATH
 If you are unable to use the prebuilt binaries or prefer to build it yourself from source, navigate to [https://github.com/solana-labs/solana/releases/latest](https://github.com/solana-labs/solana/releases/latest), and download the **Source Code** archive. Extract the code and build the binaries with:
 
 ```bash
-$ ./scripts/cargo-install-all.sh .
-$ export PATH=$PWD/bin:$PATH
+./scripts/cargo-install-all.sh .
+export PATH=$PWD/bin:$PATH
 ```
-

--- a/book/src/running-validator/validator-stake.md
+++ b/book/src/running-validator/validator-stake.md
@@ -7,14 +7,14 @@ Adding stake can be accomplished by using the `solana` CLI
 First create a stake account keypair with `solana-keygen`:
 
 ```bash
-$ solana-keygen new -o ~/validator-config/stake-keypair.json
+$ solana-keygen new -o ~/validator-stake-keypair.json
 ```
 
-and use the cli's `create-stake-account` and `delegate-stake` commands to stake your validator with 42 lamports:
+and use the cli's `create-stake-account` and `delegate-stake` commands to stake your validator with 4242 lamports:
 
 ```bash
-$ solana create-stake-account ~/validator-config/stake-keypair.json 42 lamports
-$ solana delegate-stake ~/validator-config/stake-keypair.json ~/validator-vote-keypair.json
+$ solana create-stake-account ~/validator-stake-keypair.json 4242 lamports
+$ solana delegate-stake ~/validator-stake-keypair.json ~/validator-vote-keypair.json
 ```
 
 Note that stakes need to warm up, and warmup increments are applied at Epoch boundaries, so it can take an hour or more for the change to fully take effect.
@@ -22,13 +22,13 @@ Note that stakes need to warm up, and warmup increments are applied at Epoch bou
 Stakes can be re-delegated to another node at any time with the same command, but only one re-delegation is permitted per epoch:
 
 ```bash
-$ solana delegate-stake ~/validator-config/stake-keypair.json ~/some-other-validator-vote-keypair.json
+$ solana delegate-stake ~/validator-stake-keypair.json ~/some-other-validator-vote-keypair.json
 ```
 
 Assuming the node is voting, now you're up and running and generating validator rewards. You'll want to periodically redeem/claim your rewards:
 
 ```bash
-$ solana redeem-vote-credits ~/validator-config/stake-keypair.json ~/validator-vote-keypair.json
+$ solana redeem-vote-credits ~/validator-stake-keypair.json ~/validator-vote-keypair.json
 ```
 
 The rewards lamports earned are split between your stake account and the vote account according to the commission rate set in the vote account. Rewards can only be earned while the validator is up and running. Further, once staked, the validator becomes an important part of the network. In order to safely remove a validator from the network, first deactivate its stake.
@@ -36,7 +36,7 @@ The rewards lamports earned are split between your stake account and the vote ac
 Stake can be deactivated by running:
 
 ```bash
-$ solana deactivate-stake ~/validator-config/stake-keypair.json
+$ solana deactivate-stake ~/validator-stake-keypair.json
 ```
 
 The stake will cool down, deactivate over time. While cooling down, your stake will continue to earn rewards. Only after stake cooldown is it safe to turn off your validator or withdraw it from the network. Cooldown may take several epochs to complete, depending on active stake and the size of your stake.

--- a/book/src/running-validator/validator-stake.md
+++ b/book/src/running-validator/validator-stake.md
@@ -7,14 +7,14 @@ Adding stake can be accomplished by using the `solana` CLI
 First create a stake account keypair with `solana-keygen`:
 
 ```bash
-$ solana-keygen new -o ~/validator-stake-keypair.json
+solana-keygen new -o ~/validator-stake-keypair.json
 ```
 
 and use the cli's `create-stake-account` and `delegate-stake` commands to stake your validator with 4242 lamports:
 
 ```bash
-$ solana create-stake-account ~/validator-stake-keypair.json 4242 lamports
-$ solana delegate-stake ~/validator-stake-keypair.json ~/validator-vote-keypair.json
+solana create-stake-account ~/validator-stake-keypair.json 4242 lamports
+solana delegate-stake ~/validator-stake-keypair.json ~/validator-vote-keypair.json
 ```
 
 Note that stakes need to warm up, and warmup increments are applied at Epoch boundaries, so it can take an hour or more for the change to fully take effect.
@@ -22,13 +22,13 @@ Note that stakes need to warm up, and warmup increments are applied at Epoch bou
 Stakes can be re-delegated to another node at any time with the same command, but only one re-delegation is permitted per epoch:
 
 ```bash
-$ solana delegate-stake ~/validator-stake-keypair.json ~/some-other-validator-vote-keypair.json
+solana delegate-stake ~/validator-stake-keypair.json ~/some-other-validator-vote-keypair.json
 ```
 
 Assuming the node is voting, now you're up and running and generating validator rewards. You'll want to periodically redeem/claim your rewards:
 
 ```bash
-$ solana redeem-vote-credits ~/validator-stake-keypair.json ~/validator-vote-keypair.json
+solana redeem-vote-credits ~/validator-stake-keypair.json ~/validator-vote-keypair.json
 ```
 
 The rewards lamports earned are split between your stake account and the vote account according to the commission rate set in the vote account. Rewards can only be earned while the validator is up and running. Further, once staked, the validator becomes an important part of the network. In order to safely remove a validator from the network, first deactivate its stake.
@@ -36,7 +36,7 @@ The rewards lamports earned are split between your stake account and the vote ac
 Stake can be deactivated by running:
 
 ```bash
-$ solana deactivate-stake ~/validator-stake-keypair.json
+solana deactivate-stake ~/validator-stake-keypair.json
 ```
 
 The stake will cool down, deactivate over time. While cooling down, your stake will continue to earn rewards. Only after stake cooldown is it safe to turn off your validator or withdraw it from the network. Cooldown may take several epochs to complete, depending on active stake and the size of your stake.

--- a/book/src/running-validator/validator-start.md
+++ b/book/src/running-validator/validator-start.md
@@ -51,24 +51,24 @@ $ solana set --keypair ~/validator-keypair.json
 **All following solana commands assume you have set `--keypair` config to** your validator identity keypair.\*\* If you haven't, you will need to add the `--keypair` argument to each command, like:
 
 ```bash
-$ solana --keypair ~/validator-keypair.json airdrop 1000 lamports
+$ solana --keypair ~/validator-keypair.json airdrop 10
 ```
 
 \(You can always override the set configuration by explicitly passing the `--keypair` argument with a command.\)
 
 ### Validator Start
 
-Airdrop yourself some lamports to get started:
+Airdrop yourself some SOL to get started:
 
 ```bash
-$ solana airdrop 1000 lamports
+$ solana airdrop 10
 ```
 
 Your validator will need a vote account. Create it now with the following commands:
 
 ```bash
 $ solana-keygen new -o ~/validator-vote-keypair.json
-$ solana create-vote-account ~/validator-vote-keypair.json ~/validator-keypair.json 1 lamports
+$ solana create-vote-account ~/validator-vote-keypair.json ~/validator-keypair.json
 ```
 
 Then use one of the following commands, depending on your installation choice, to start the node:
@@ -110,4 +110,3 @@ By default the validator will dynamically select available network ports in the 
 ### Limiting ledger size to conserve disk space
 
 By default the validator will retain the full ledger. To conserve disk space start the validator with the `--limit-ledger-size`, which will instruct the validator to only retain the last couple hours of ledger.
-

--- a/book/src/running-validator/validator-start.md
+++ b/book/src/running-validator/validator-start.md
@@ -7,7 +7,7 @@ Before attaching a validator node, sanity check that the cluster is accessible t
 Fetch the current transaction count over JSON RPC:
 
 ```bash
-$ curl -X POST -H 'Content-Type: application/json' -d '{"jsonrpc":"2.0","id":1, "method":"getTransactionCount"}' http://testnet.solana.com:8899
+curl -X POST -H 'Content-Type: application/json' -d '{"jsonrpc":"2.0","id":1, "method":"getTransactionCount"}' http://testnet.solana.com:8899
 ```
 
 Inspect the network explorer at [https://explorer.solana.com/](https://explorer.solana.com/) for activity.
@@ -19,16 +19,16 @@ View the [metrics dashboard](https://metrics.solana.com:3000/d/testnet-beta/test
 Sanity check that you are able to interact with the cluster by receiving a small airdrop of lamports from the testnet drone:
 
 ```bash
-$ solana set --url http://testnet.solana.com:8899
-$ solana get
-$ solana airdrop 123 lamports
-$ solana balance --lamports
+solana set --url http://testnet.solana.com:8899
+solana get
+solana airdrop 123 lamports
+solana balance --lamports
 ```
 
 Also try running following command to join the gossip network and view all the other nodes in the cluster:
 
 ```bash
-$ solana-gossip --entrypoint testnet.solana.com:8001 spy
+solana-gossip --entrypoint testnet.solana.com:8001 spy
 # Press ^C to exit
 ```
 
@@ -37,7 +37,7 @@ $ solana-gossip --entrypoint testnet.solana.com:8001 spy
 Create an identity keypair for your validator by running:
 
 ```bash
-$ solana-keygen new -o ~/validator-keypair.json
+solana-keygen new -o ~/validator-keypair.json
 ```
 
 ### Wallet Configuration
@@ -45,13 +45,13 @@ $ solana-keygen new -o ~/validator-keypair.json
 You can set solana configuration to use your validator keypair for all following commands:
 
 ```bash
-$ solana set --keypair ~/validator-keypair.json
+solana set --keypair ~/validator-keypair.json
 ```
 
 **All following solana commands assume you have set `--keypair` config to** your validator identity keypair.\*\* If you haven't, you will need to add the `--keypair` argument to each command, like:
 
 ```bash
-$ solana --keypair ~/validator-keypair.json airdrop 10
+solana --keypair ~/validator-keypair.json airdrop 10
 ```
 
 \(You can always override the set configuration by explicitly passing the `--keypair` argument with a command.\)
@@ -61,14 +61,14 @@ $ solana --keypair ~/validator-keypair.json airdrop 10
 Airdrop yourself some SOL to get started:
 
 ```bash
-$ solana airdrop 10
+solana airdrop 10
 ```
 
 Your validator will need a vote account. Create it now with the following commands:
 
 ```bash
-$ solana-keygen new -o ~/validator-vote-keypair.json
-$ solana create-vote-account ~/validator-vote-keypair.json ~/validator-keypair.json
+solana-keygen new -o ~/validator-vote-keypair.json
+solana create-vote-account ~/validator-vote-keypair.json ~/validator-keypair.json
 ```
 
 Then use one of the following commands, depending on your installation choice, to start the node:
@@ -76,19 +76,19 @@ Then use one of the following commands, depending on your installation choice, t
 If this is a `solana-install`-installation:
 
 ```bash
-$ solana-validator --identity ~/validator-keypair.json --voting-keypair ~/validator-vote-keypair.json --ledger ~/validator-config --rpc-port 8899 --entrypoint testnet.solana.com:8001
+solana-validator --identity ~/validator-keypair.json --voting-keypair ~/validator-vote-keypair.json --ledger ~/validator-config --rpc-port 8899 --entrypoint testnet.solana.com:8001
 ```
 
 Alternatively, the `solana-install run` command can be used to run the validator node while periodically checking for and applying software updates:
 
 ```bash
-$ solana-install run solana-validator -- --identity ~/validator-keypair.json --voting-keypair ~/validator-vote-keypair.json --ledger ~/validator-config --rpc-port 8899 --entrypoint testnet.solana.com:8001
+solana-install run solana-validator -- --identity ~/validator-keypair.json --voting-keypair ~/validator-vote-keypair.json --ledger ~/validator-config --rpc-port 8899 --entrypoint testnet.solana.com:8001
 ```
 
 If you built from source:
 
 ```bash
-$ NDEBUG=1 USE_INSTALL=1 ./multinode-demo/validator.sh --identity ~/validator-keypair.json --voting-keypair ~/validator-vote-keypair.json --rpc-port 8899 --entrypoint testnet.solana.com:8001
+NDEBUG=1 USE_INSTALL=1 ./multinode-demo/validator.sh --identity ~/validator-keypair.json --voting-keypair ~/validator-vote-keypair.json --rpc-port 8899 --entrypoint testnet.solana.com:8001
 ```
 
 ### Enabling CUDA
@@ -98,7 +98,7 @@ If your machine has a GPU with CUDA installed \(Linux-only currently\), include 
 Or if you built from source, define the SOLANA\_CUDA flag in your environment _before_ running any of the previously mentioned commands
 
 ```bash
-$ export SOLANA_CUDA=1
+export SOLANA_CUDA=1
 ```
 
 When your validator is started look for the following log message to indicate that CUDA is enabled: `"[<timestamp> solana::validator] CUDA is enabled"`

--- a/book/src/running-validator/validator-testnet.md
+++ b/book/src/running-validator/validator-testnet.md
@@ -15,7 +15,7 @@ Prior to mainnet, the testnets may be running different versions of solana softw
 You can submit a JSON-RPC request to see the specific version of the cluster.
 
 ```bash
-$ curl -X POST -H 'Content-Type: application/json' -d '{"jsonrpc":"2.0","id":1, "method":"getVersion"}' edge.testnet.solana.com:8899
+curl -X POST -H 'Content-Type: application/json' -d '{"jsonrpc":"2.0","id":1, "method":"getVersion"}' edge.testnet.solana.com:8899
 {"jsonrpc":"2.0","result":{"solana-core":"0.18.0-pre1"},"id":1}
 ```
 
@@ -28,17 +28,17 @@ This guide is written in the context of testnet.solana.com, our most stable clus
 If you are bootstrapping with `solana-install`, you can specify the release tag or named channel to install to match your desired testnet.
 
 ```bash
-$ curl -sSf https://raw.githubusercontent.com/solana-labs/solana/v0.18.0/install/solana-install-init.sh | sh -s - 0.18.0
+curl -sSf https://raw.githubusercontent.com/solana-labs/solana/v0.18.0/install/solana-install-init.sh | sh -s - 0.18.0
 ```
 
 ```bash
-$ curl -sSf https://raw.githubusercontent.com/solana-labs/solana/v0.18.0/install/solana-install-init.sh | sh -s - beta
+curl -sSf https://raw.githubusercontent.com/solana-labs/solana/v0.18.0/install/solana-install-init.sh | sh -s - beta
 ```
 
 Similarly, you can add this argument to the `solana-install` command if you've built the program from source:
 
 ```bash
-$ solana-install init 0.18.0
+solana-install init 0.18.0
 ```
 
 If you are downloading pre-compiled binaries or building from source, simply choose the release matching your desired testnet.
@@ -48,14 +48,14 @@ If you are downloading pre-compiled binaries or building from source, simply cho
 The Solana CLI tool points at testnet.solana.com by default. Include a `--url` argument to point at a different testnet. For instance:
 
 ```bash
-$ solana --url http://beta.testnet.solana.com:8899 balance
+solana --url http://beta.testnet.solana.com:8899 balance
 ```
 
 The solana cli includes `get` and `set` configuration commands to automatically set the `--url` argument for future cli commands. For example:
 
 ```bash
-$ solana set --url http://beta.testnet.solana.com:8899
-$ solana balance # Same result as command above
+solana set --url http://beta.testnet.solana.com:8899
+solana balance # Same result as command above
 ```
 
 \(You can always override the set configuration by explicitly passing the `--url` argument with a command.\)
@@ -63,12 +63,11 @@ $ solana balance # Same result as command above
 Solana-gossip and solana-validator commands already require an explicit `--entrypoint` argument. Simply replace testnet.solana.com in the examples with an alternate url to interact with a different testnet. For example:
 
 ```bash
-$ solana-validator --identity ~/validator-keypair.json --voting-keypair ~/validator-vote-keypair.json --ledger ~/validator-config --rpc-port 8899 beta.testnet.solana.com
+solana-validator --identity ~/validator-keypair.json --voting-keypair ~/validator-vote-keypair.json --ledger ~/validator-config --rpc-port 8899 beta.testnet.solana.com
 ```
 
 You can also submit JSON-RPC requests to a different testnet, like:
 
 ```bash
-$ curl -X POST -H 'Content-Type: application/json' -d '{"jsonrpc":"2.0","id":1, "method":"getTransactionCount"}' http://beta.testnet.solana.com:8899
+curl -X POST -H 'Content-Type: application/json' -d '{"jsonrpc":"2.0","id":1, "method":"getTransactionCount"}' http://beta.testnet.solana.com:8899
 ```
-


### PR DESCRIPTION
#### Problem
https://docs.solana.com/book/running-validator/validator-start and https://docs.solana.com/book/running-validator/validator-stake contain some deprecated command syntax.

#### Summary of Changes
- Fixes up `solana create-vote-account` command, which no longer takes an amount arg
- Also increases docs staking amount to something that will show up on the network explorer
- Also also removes `$`s, because it's awfully nice to be able to use gitbook's copy command button
