### PR TITLE
Update sol:lamport ratio to base-10

### DIFF
--- a/book/src/introduction.md
+++ b/book/src/introduction.md
@@ -34,5 +34,4 @@ A cluster is a set of computers that work together and can be viewed from the ou
 
 ## What are SOLs?
 
-A SOL is the name of Solana's native token, which can be passed to nodes in a Solana cluster in exchange for running an on-chain program or validating its output. The system may perform micropayments of fractional SOLs and a SOL may be split as many as 34 times. The fractional sol is called a _lamport_. It is named in honor of Solana's biggest technical influence, [Leslie Lamport](https://en.wikipedia.org/wiki/Leslie_Lamport). A lamport has a value of approximately 0.0000000000582 sol \(2^-34\).
-
+A SOL is the name of Solana's native token, which can be passed to nodes in a Solana cluster in exchange for running an on-chain program or validating its output. The system may perform micropayments of fractional SOLs and a SOL may be split as many as 34 times. The fractional sol is called a _lamport_. It is named in honor of Solana's biggest technical influence, [Leslie Lamport](https://en.wikipedia.org/wiki/Leslie_Lamport). A lamport has a value of 0.000000001 sol.

--- a/book/src/terminology.md
+++ b/book/src/terminology.md
@@ -112,7 +112,7 @@ A [public key](terminology.md#public-key) and corresponding [private key](termin
 
 ## lamport
 
-A fractional [native token](terminology.md#native-token) with the value of approximately 0.0000000000582 [sol](terminology.md#sol) \(2^-34\).
+A fractional [native token](terminology.md#native-token) with the value of 0.000000001 [sol](terminology.md#sol).
 
 ## loader
 
@@ -293,4 +293,3 @@ A reward tally for validators. A vote credit is awarded to a validator in its vo
 ## warmup period
 
 Some number of epochs after stake has been delegated while it progressively becomes effective. During this period, the stake is considered to be "activating". More info about: [warmup and cooldown](cluster/stake-delegation-and-rewards.md#stake-warmup-cooldown-withdrawal)
-

--- a/ci/testnet-deploy.sh
+++ b/ci/testnet-deploy.sh
@@ -85,7 +85,7 @@ Deploys a CD testnet
    --hashes-per-tick NUM_HASHES|sleep|auto
                         - Override the default --hashes-per-tick for the cluster
    --lamports NUM_LAMPORTS
-                        - Specify the number of lamports to mint (default 100000000000000)
+                        - Specify the number of lamports to mint (default 500000000000000000)
    --skip-deploy-update
                         - If set, will skip software update deployment
    --skip-remote-log-retrieval

--- a/ci/testnet-manager.sh
+++ b/ci/testnet-manager.sh
@@ -479,7 +479,7 @@ deploy() {
       fi
 
       if [[ -z $INTERNAL_NODES_STAKE_LAMPORTS ]]; then
-        maybeInternalNodesStakeLamports="--internal-nodes-stake-lamports 17179869184" # 1 SOL
+        maybeInternalNodesStakeLamports="--internal-nodes-stake-lamports 1000000000" # 1 SOL
       elif [[ $INTERNAL_NODES_STAKE_LAMPORTS == skip ]]; then
         maybeInternalNodesStakeLamports=""
       else
@@ -487,7 +487,7 @@ deploy() {
       fi
 
       if [[ -z $INTERNAL_NODES_LAMPORTS ]]; then
-        maybeInternalNodesLamports="--internal-nodes-lamports 34359738368" # 2 SOL
+        maybeInternalNodesLamports="--internal-nodes-lamports 2000000000" # 2 SOL
       elif [[ $INTERNAL_NODES_LAMPORTS == skip ]]; then
         maybeInternalNodesLamports=""
       else
@@ -507,7 +507,7 @@ deploy() {
       fi
 
       if [[ -z $LAMPORTS ]]; then
-        maybeLamports="--lamports 8589934592000000000"
+        maybeLamports="--lamports 500000000000000000"
       elif [[ $LAMPORTS == skip ]]; then
         maybeLamports=""
       else

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -1177,7 +1177,7 @@ pub(crate) fn build_balance_message(
         format!("{:?}{}", lamports, unit)
     } else {
         let sol = lamports_to_sol(lamports);
-        let sol_str = format!("{:.8}", sol);
+        let sol_str = format!("{:.9}", sol);
         let pretty_sol = sol_str.trim_end_matches('0').trim_end_matches('.');
         let unit = if show_unit { " SOL" } else { "" };
         format!("{}{}", pretty_sol, unit)
@@ -1773,7 +1773,7 @@ mod tests {
             pubkey: None,
             use_lamports_unit: false,
         };
-        assert_eq!(process_command(&config).unwrap(), "0 SOL");
+        assert_eq!(process_command(&config).unwrap(), "0.00000005 SOL");
 
         let process_id = Pubkey::new_rand();
         config.command = CliCommand::Cancel(process_id);

--- a/multinode-demo/delegate-stake.sh
+++ b/multinode-demo/delegate-stake.sh
@@ -8,7 +8,7 @@ here=$(dirname "$0")
 # shellcheck source=multinode-demo/common.sh
 source "$here"/common.sh
 
-stake_lamports=8589934592   # default number of lamports to assign as stake (0.5 SOL)
+stake_lamports=500000000   # default number of lamports to assign as stake (0.5 SOL)
 url=http://127.0.0.1:8899   # default RPC url
 
 usage() {

--- a/multinode-demo/validator.sh
+++ b/multinode-demo/validator.sh
@@ -35,7 +35,7 @@ EOF
 
 args=()
 airdrops_enabled=1
-node_lamports=8589934592000 # 500 SOL: number of lamports to airdrop the node for transaction fees (ignored if airdrops_enabled=0)
+node_lamports=500000000000 # 500 SOL: number of lamports to airdrop the node for transaction fees (ignored if airdrops_enabled=0)
 poll_for_new_genesis_block=0
 label=
 identity_keypair_path=

--- a/net/net.sh
+++ b/net/net.sh
@@ -62,7 +62,7 @@ Operate a configured testnet
    --no-airdrop
                                       - If set, disables airdrops.  Nodes must be funded in genesis block when airdrops are disabled.
    --lamports NUM_LAMPORTS_TO_MINT
-                                      - Override the default 100000000000000 lamports minted in genesis
+                                      - Override the default 500000000000000000 lamports minted in genesis
    --internal-nodes-stake-lamports NUM_LAMPORTS_PER_NODE
                                       - Amount to stake internal nodes.
    --internal-nodes-lamports NUM_LAMPORTS_PER_NODE

--- a/scripts/wallet-sanity.sh
+++ b/scripts/wallet-sanity.sh
@@ -36,7 +36,7 @@ fi
 (
   set -x
   $solana_cli "${args[@]}" address
-  $solana_cli "${args[@]}" airdrop 0.0001
+  $solana_cli "${args[@]}" airdrop 0.01
   $solana_cli "${args[@]}" balance --lamports
   $solana_cli "${args[@]}" ping --count 5 --interval 0
   $solana_cli "${args[@]}" balance --lamports

--- a/sdk/src/native_token.rs
+++ b/sdk/src/native_token.rs
@@ -1,5 +1,5 @@
 /// There are 2^34 lamports in one sol
-pub const SOL_LAMPORTS: u64 = 17_179_869_184;
+pub const SOL_LAMPORTS: u64 = 1_000_000_000;
 
 /// Approximately convert fractional native tokens (lamports) into native tokens (sol)
 pub fn lamports_to_sol(lamports: u64) -> f64 {


### PR DESCRIPTION
#### Problem
Lamport definition is a power of 2. If users want to withdraw 1.25 SOL the conversion requires to round. This will cause UX issues with payments processors that have a legal requirement to display exact values.

#### Summary of Changes
- Updates sol:lamport ratio -> 1 SOL = 1_000_000_000 lamports (this allows a bit upwards of 18-billion SOL in the system, if stored as lamports in a u64)
- Also updates solana-cli to print SOL to 9 decimals

Fixes #6504 
