### PR TITLE
Have move programs use the workspace target directory

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,2 @@
+[build]
+target-dir = "target"

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,8 @@
 /target/
 
 **/*.rs.bk
-.cargo
+.cargo/*
+!.cargo/config
 
 /config/
 

--- a/programs/librapay_api/.cargo/config
+++ b/programs/librapay_api/.cargo/config
@@ -1,0 +1,2 @@
+[build]
+target-dir = "../../target"

--- a/programs/move_loader_api/.cargo/config
+++ b/programs/move_loader_api/.cargo/config
@@ -1,0 +1,2 @@
+[build]
+target-dir = "../../target"

--- a/programs/move_loader_program/.cargo/config
+++ b/programs/move_loader_program/.cargo/config
@@ -1,0 +1,2 @@
+[build]
+target-dir = "../../target"


### PR DESCRIPTION
#### Problem

As of #6605, the move programs use their own `target` directories. This prevents `scripts/cargo-install-all.sh` from finding the `move-loader-program`.

#### Summary of Changes

Add cargo config files that tell cargo to always use the workspace `target` directory.
