### PR TITLE
Reduce verify-batch-size log

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -765,7 +765,7 @@ impl ReplayStage {
         shred_index: usize,
         bank_progress: &mut ForkProgress,
     ) -> Result<()> {
-        datapoint_info!("verify-batch-size", ("size", entries.len() as i64, i64));
+        datapoint_debug!("verify-batch-size", ("size", entries.len() as i64, i64));
         let mut verify_total = Measure::start("verify_and_process_entries");
         let last_entry = &bank_progress.last_entry;
         let mut entry_state = entries.start_verify(last_entry);

--- a/core/tests/cluster_info.rs
+++ b/core/tests/cluster_info.rs
@@ -1,5 +1,3 @@
-use rand::SeedableRng;
-use rand_chacha::ChaChaRng;
 use rayon::iter::ParallelIterator;
 use rayon::prelude::*;
 use serial_test_derive::serial;
@@ -120,7 +118,7 @@ fn run_simulation(stakes: &[u64], fanout: usize) {
                 &cluster_info.id(),
                 &peers,
                 &stakes_and_index,
-                ChaChaRng::from_seed(seed),
+                seed,
             );
             let peers = shuffled_stakes_and_indexes
                 .into_iter()


### PR DESCRIPTION
#### Problem

Too much logging and compilation failures.

#### Summary of Changes

Reduce to _debug level and fix cluster_info compile.

Fixes #
