### PR TITLE
Avoid alloc due to vector pushes

### DIFF
--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -116,8 +116,8 @@ impl Accounts {
 
             // There is no way to predict what program will execute without an error
             // If a fee can pay for execution then the program will be scheduled
-            let mut accounts: TransactionAccounts = vec![];
-            let mut rents: TransactionRents = vec![];
+            let mut accounts: TransactionAccounts = Vec::with_capacity(message.account_keys.len());
+            let mut rents: TransactionRents = Vec::with_capacity(message.account_keys.len());
             for key in message
                 .account_keys
                 .iter()
@@ -633,7 +633,7 @@ impl Accounts {
         res: &'a [Result<()>],
         loaded: &'a mut [Result<TransactionLoadResult>],
     ) -> Vec<(&'a Pubkey, &'a Account)> {
-        let mut accounts = Vec::new();
+        let mut accounts = Vec::with_capacity(loaded.len());
         for (i, (raccs, tx)) in loaded
             .iter_mut()
             .zip(OrderedIterator::new(txs, txs_iteration_order))

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -811,7 +811,7 @@ impl AccountsDB {
                 (meta, *account)
             })
             .collect();
-        let mut infos: Vec<AccountInfo> = vec![];
+        let mut infos: Vec<AccountInfo> = Vec::with_capacity(with_meta.len());
         while infos.len() < with_meta.len() {
             let storage = self.find_storage_candidate(slot_id);
             let rvs = storage
@@ -882,15 +882,21 @@ impl AccountsDB {
         accounts: &[(&Pubkey, &Account)],
     ) -> (Vec<(Slot, AccountInfo)>, u64) {
         let mut reclaims: Vec<(Slot, AccountInfo)> = Vec::with_capacity(infos.len() * 2);
-        let mut inserts = vec![];
         let index = self.accounts_index.read().unwrap();
         let mut update_index_work = Measure::start("update_index_work");
-        for (info, pubkey_account) in infos.into_iter().zip(accounts.iter()) {
-            let pubkey = pubkey_account.0;
-            if let Some(info) = index.update(slot_id, pubkey, info, &mut reclaims) {
-                inserts.push((pubkey, info));
-            }
-        }
+        let inserts: Vec<_> = infos
+            .into_iter()
+            .zip(accounts.iter())
+            .filter_map(|(info, pubkey_account)| {
+                let pubkey = pubkey_account.0;
+                if let Some(info) = index.update(slot_id, pubkey, info, &mut reclaims) {
+                    Some((pubkey, info))
+                } else {
+                    None
+                }
+            })
+            .collect();
+
         let last_root = index.last_root;
         drop(index);
         if !inserts.is_empty() {
@@ -955,30 +961,32 @@ impl AccountsDB {
     }
 
     fn hash_accounts(&self, slot_id: Slot, accounts: &[(&Pubkey, &Account)]) -> Vec<Hash> {
-        let mut hashes = vec![];
         let mut hash_state = BankHash::default();
         let mut had_account = false;
-        for (pubkey, account) in accounts {
-            if !sysvar::check_id(&account.owner) {
-                let hash = BankHash::from_hash(&account.hash);
-                let new_hash = Self::hash_account(slot_id, account, pubkey);
-                let new_bank_hash = BankHash::from_hash(&new_hash);
-                debug!(
-                    "hash_accounts: key: {} xor {} current: {}",
-                    pubkey, hash, hash_state
-                );
-                if !had_account {
-                    hash_state = hash;
-                    had_account = true;
+        let hashes: Vec<_> = accounts
+            .iter()
+            .map(|(pubkey, account)| {
+                if !sysvar::check_id(&account.owner) {
+                    let hash = BankHash::from_hash(&account.hash);
+                    let new_hash = Self::hash_account(slot_id, account, pubkey);
+                    let new_bank_hash = BankHash::from_hash(&new_hash);
+                    debug!(
+                        "hash_accounts: key: {} xor {} current: {}",
+                        pubkey, hash, hash_state
+                    );
+                    if !had_account {
+                        hash_state = hash;
+                        had_account = true;
+                    } else {
+                        hash_state.xor(hash);
+                    }
+                    hash_state.xor(new_bank_hash);
+                    new_hash
                 } else {
-                    hash_state.xor(hash);
+                    Hash::default()
                 }
-                hash_state.xor(new_bank_hash);
-                hashes.push(new_hash);
-            } else {
-                hashes.push(Hash::default());
-            }
-        }
+            })
+            .collect();
 
         if had_account {
             self.xor_in_hash_state(slot_id, hash_state);

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -889,7 +889,9 @@ impl AccountsDB {
             .zip(accounts.iter())
             .filter_map(|(info, pubkey_account)| {
                 let pubkey = pubkey_account.0;
-                index.update(slot_id, pubkey, info, &mut reclaims).map(|info| (pubkey, info))
+                index
+                    .update(slot_id, pubkey, info, &mut reclaims)
+                    .map(|info| (pubkey, info))
             })
             .collect();
 

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -889,11 +889,7 @@ impl AccountsDB {
             .zip(accounts.iter())
             .filter_map(|(info, pubkey_account)| {
                 let pubkey = pubkey_account.0;
-                if let Some(info) = index.update(slot_id, pubkey, info, &mut reclaims) {
-                    Some((pubkey, info))
-                } else {
-                    None
-                }
+                index.update(slot_id, pubkey, info, &mut reclaims).map(|info| (pubkey, info))
             })
             .collect();
 

--- a/runtime/src/append_vec.rs
+++ b/runtime/src/append_vec.rs
@@ -292,7 +292,7 @@ impl AppendVec {
         hashes: &[Hash],
     ) -> Vec<usize> {
         let mut offset = self.append_offset.lock().unwrap();
-        let mut rv = vec![];
+        let mut rv = Vec::with_capacity(accounts.len());
         for ((stored_meta, account), hash) in accounts.iter().zip(hashes) {
             let meta_ptr = stored_meta as *const StoredMeta;
             let account_meta = AccountMeta {


### PR DESCRIPTION
#### Problem

Pushing elements to an empty vector causes alloc/free, especially for the first few.

#### Summary of Changes

Preallocate either explicitly or take advantage of `collect`'s pre-allocation.

Fixes #
