### PR TITLE
net: Add ~/.cargo/bin to PATH on nodes

### DIFF
--- a/net/scripts/create-solana-user.sh
+++ b/net/scripts/create-solana-user.sh
@@ -17,6 +17,7 @@ else
   [[ -r /solana-scratch/id_ecdsa.pub ]] || exit 1
 
   sudo -u solana bash -c "
+    echo 'PATH=\"/home/solana/.cargo/bin:$PATH\"' > /home/solana/.profile
     mkdir -p /home/solana/.ssh/
     cd /home/solana/.ssh/
     cp /solana-scratch/id_ecdsa.pub authorized_keys


### PR DESCRIPTION
Manually adding ~/.cargo/bin to PATH every time you ssh into a node is no fun.