### PR TITLE
Fix check in should_insert_data_shred

### DIFF
--- a/ledger/src/blocktree.rs
+++ b/ledger/src/blocktree.rs
@@ -763,9 +763,7 @@ impl Blocktree {
         }
 
         let last_root = *last_root.read().unwrap();
-        verify_shred_slots(slot, slot_meta.parent_slot, last_root);
-
-        true
+        verify_shred_slots(slot, slot_meta.parent_slot, last_root)
     }
 
     fn insert_data_shred(


### PR DESCRIPTION
#### Problem
The result of `verify_shred_slots` wasn't being returned in should_insert_data_shred

#### Summary of Changes
use the result of `verify_shred_slots`
Fixes #
