### PR TITLE
require `to` account signature 

### DIFF
--- a/bench-exchange/src/bench.rs
+++ b/bench-exchange/src/bench.rs
@@ -178,27 +178,28 @@ where
 
     info!("Generating {:?} account keys", total_keys);
     let mut account_keypairs = generate_keypairs(total_keys);
-    let src_pubkeys: Vec<_> = account_keypairs
+    let src_keypairs: Vec<_> = account_keypairs
         .drain(0..accounts_in_groups)
-        .map(|keypair| keypair.pubkey())
+        .map(|keypair| keypair)
         .collect();
-    let profit_pubkeys: Vec<_> = account_keypairs
+    let src_pubkeys: Vec<Pubkey> = src_keypairs
+        .iter()
+        .map(|keypair| keypair.pubkey().clone())
+        .collect();
+
+    let profit_keypairs: Vec<_> = account_keypairs
         .drain(0..accounts_in_groups)
-        .map(|keypair| keypair.pubkey())
+        .map(|keypair| keypair)
+        .collect();
+    let profit_pubkeys: Vec<Pubkey> = profit_keypairs
+        .iter()
+        .map(|keypair| keypair.pubkey().clone())
         .collect();
 
     info!("Create {:?} source token accounts", src_pubkeys.len());
-    create_token_accounts(
-        client,
-        &trader_signers,
-        &account_keypairs[0..accounts_in_groups],
-    );
+    create_token_accounts(client, &trader_signers, &src_keypairs);
     info!("Create {:?} profit token accounts", profit_pubkeys.len());
-    create_token_accounts(
-        client,
-        &swapper_signers,
-        &account_keypairs[0..accounts_in_groups],
-    );
+    create_token_accounts(client, &swapper_signers, &profit_keypairs);
 
     // Collect the max transaction rate and total tx count seen (single node only)
     let sample_stats = Arc::new(RwLock::new(Vec::new()));

--- a/bench-exchange/src/bench.rs
+++ b/bench-exchange/src/bench.rs
@@ -867,9 +867,7 @@ pub fn create_token_accounts(client: &dyn Client, signers: &[Arc<Keypair>], acco
                 to_create_txs
                     .par_iter_mut()
                     .for_each(|((from_keypair, to_keypair), tx)| {
-                        let from: &Keypair = from_keypair;
-                        let to: &Keypair = to_keypair;
-                        tx.sign(&[from, to], blockhash);
+                        tx.sign(&[from_keypair.as_ref(), to_keypair], blockhash);
                     });
                 to_create_txs.iter().for_each(|(_, tx)| {
                     client.async_send_transaction(tx.clone()).expect("transfer");

--- a/bench-exchange/src/bench.rs
+++ b/bench-exchange/src/bench.rs
@@ -184,7 +184,7 @@ where
         .collect();
     let src_pubkeys: Vec<Pubkey> = src_keypairs
         .iter()
-        .map(|keypair| keypair.pubkey().clone())
+        .map(|keypair| keypair.pubkey())
         .collect();
 
     let profit_keypairs: Vec<_> = account_keypairs
@@ -193,7 +193,7 @@ where
         .collect();
     let profit_pubkeys: Vec<Pubkey> = profit_keypairs
         .iter()
-        .map(|keypair| keypair.pubkey().clone())
+        .map(|keypair| keypair.pubkey())
         .collect();
 
     info!("Create {:?} source token accounts", src_pubkeys.len());

--- a/bench-exchange/src/bench.rs
+++ b/bench-exchange/src/bench.rs
@@ -586,7 +586,6 @@ fn trader<T>(
                 .map(|(owner, trade, side, src)| {
                     let o: &Keypair = &owner;
                     let t: &Keypair = &trade;
-                    let trade_signer: &Keypair = &trade;
                     let owner_pubkey = &owner.pubkey();
                     let trade_pubkey = &trade.pubkey();
                     let space = mem::size_of::<ExchangeState>() as u64;

--- a/bench-exchange/src/bench.rs
+++ b/bench-exchange/src/bench.rs
@@ -584,13 +584,11 @@ fn trader<T>(
             let trades_txs: Vec<_> = chunk
                 .par_iter()
                 .map(|(owner, trade, side, src)| {
-                    let o: &Keypair = &owner;
-                    let t: &Keypair = &trade;
                     let owner_pubkey = &owner.pubkey();
                     let trade_pubkey = &trade.pubkey();
                     let space = mem::size_of::<ExchangeState>() as u64;
                     Transaction::new_signed_instructions(
-                        &[o, t],
+                        &[owner.as_ref(), trade],
                         vec![
                             system_instruction::create_account(
                                 owner_pubkey,

--- a/bench-tps/src/bench.rs
+++ b/bench-tps/src/bench.rs
@@ -795,13 +795,10 @@ fn fund_move_keys<T: Client>(
 
     info!("creating the libra funding account..");
     let libra_funding_key = Keypair::new();
-    let tx = librapay_transaction::create_account(
-        funding_key,
-        &libra_funding_key.pubkey(),
-        1,
-        blockhash,
-    );
-    client.send_message(&[funding_key], tx.message).unwrap();
+    let tx = librapay_transaction::create_account(funding_key, &libra_funding_key, 1, blockhash);
+    client
+        .send_message(&[funding_key, &libra_funding_key], tx.message)
+        .unwrap();
 
     info!("minting to funding keypair");
     let tx = librapay_transaction::mint_tokens(
@@ -829,8 +826,8 @@ fn fund_move_keys<T: Client>(
             break;
         }
 
-        let pubkeys: Vec<_> = keys.iter().map(|k| k.pubkey()).collect();
-        let tx = librapay_transaction::create_accounts(funding_key, &pubkeys, 1, blockhash);
+        let keypairs: Vec<_> = keys.iter().map(|k| k).collect();
+        let tx = librapay_transaction::create_accounts(funding_key, &keypairs, 1, blockhash);
 
         let ser_size = bincode::serialized_size(&tx).unwrap();
 
@@ -877,10 +874,9 @@ fn fund_move_keys<T: Client>(
 
     let libra_funding_keys: Vec<_> = (0..NUM_FUNDING_KEYS).map(|_| Keypair::new()).collect();
     for (i, key) in libra_funding_keys.iter().enumerate() {
-        let tx =
-            librapay_transaction::create_account(&funding_keys[i], &key.pubkey(), 1, blockhash);
+        let tx = librapay_transaction::create_account(&funding_keys[i], &key, 1, blockhash);
         client
-            .send_message(&[&funding_keys[i]], tx.message)
+            .send_message(&[&funding_keys[i], &key], tx.message)
             .unwrap();
 
         let tx = librapay_transaction::transfer(

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -622,7 +622,7 @@ fn process_deploy(
     let minimum_balance = rpc_client.get_minimum_balance_for_rent_exemption(program_data.len())?;
     let mut create_account_tx = system_transaction::create_account(
         &config.keypair,
-        &program_id.pubkey(),
+        &program_id,
         blockhash,
         minimum_balance,
         program_data.len() as u64,

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -656,8 +656,7 @@ fn process_deploy(
     check_account_for_multiple_fees(rpc_client, config, &fee_calculator, &messages)?;
 
     trace!("Creating program account");
-    let result =
-        rpc_client.send_and_confirm_transaction(&mut create_account_tx, &[&config.keypair]);
+    let result = rpc_client.send_and_confirm_transaction(&mut create_account_tx, &signers);
     log_instruction_custom_error::<SystemError>(result)
         .map_err(|_| CliError::DynamicProgramError("Program allocate space failed".to_string()))?;
 
@@ -723,9 +722,14 @@ fn process_pay(
             cancelable,
             lamports,
         );
-        let mut tx = Transaction::new_signed_instructions(&[&config.keypair], ixs, blockhash);
+        let mut tx = Transaction::new_signed_instructions(
+            &[&config.keypair, &contract_state],
+            ixs,
+            blockhash,
+        );
         check_account_for_fee(rpc_client, config, &fee_calculator, &tx.message)?;
-        let result = rpc_client.send_and_confirm_transaction(&mut tx, &[&config.keypair]);
+        let result =
+            rpc_client.send_and_confirm_transaction(&mut tx, &[&config.keypair, &contract_state]);
         let signature_str = log_instruction_custom_error::<BudgetError>(result)?;
 
         Ok(json!({
@@ -756,8 +760,13 @@ fn process_pay(
             cancelable,
             lamports,
         );
-        let mut tx = Transaction::new_signed_instructions(&[&config.keypair], ixs, blockhash);
-        let result = rpc_client.send_and_confirm_transaction(&mut tx, &[&config.keypair]);
+        let mut tx = Transaction::new_signed_instructions(
+            &[&config.keypair, &contract_state],
+            ixs,
+            blockhash,
+        );
+        let result =
+            rpc_client.send_and_confirm_transaction(&mut tx, &[&config.keypair, &contract_state]);
         check_account_for_fee(rpc_client, config, &fee_calculator, &tx.message)?;
         let signature_str = log_instruction_custom_error::<BudgetError>(result)?;
 

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -424,11 +424,12 @@ pub fn process_create_stake_account(
     let mut tx = Transaction::new_signed_with_payer(
         ixs,
         Some(&config.keypair.pubkey()),
-        &[&config.keypair],
+        &[&config.keypair, stake_account],
         recent_blockhash,
     );
     check_account_for_fee(rpc_client, config, &fee_calculator, &tx.message)?;
-    let result = rpc_client.send_and_confirm_transaction(&mut tx, &[&config.keypair]);
+    let result =
+        rpc_client.send_and_confirm_transaction(&mut tx, &[&config.keypair, stake_account]);
     log_instruction_custom_error::<SystemError>(result)
 }
 

--- a/cli/src/storage.rs
+++ b/cli/src/storage.rs
@@ -174,9 +174,14 @@ pub fn process_create_storage_account(
         1,
         account_type,
     );
-    let mut tx = Transaction::new_signed_instructions(&[&config.keypair], ixs, recent_blockhash);
+    let mut tx = Transaction::new_signed_instructions(
+        &[&config.keypair, &storage_account],
+        ixs,
+        recent_blockhash,
+    );
     check_account_for_fee(rpc_client, config, &fee_calculator, &tx.message)?;
-    let result = rpc_client.send_and_confirm_transaction(&mut tx, &[&config.keypair]);
+    let result =
+        rpc_client.send_and_confirm_transaction(&mut tx, &[&config.keypair, &storage_account]);
     log_instruction_custom_error::<SystemError>(result)
 }
 

--- a/cli/src/vote.rs
+++ b/cli/src/vote.rs
@@ -267,9 +267,13 @@ pub fn process_create_vote_account(
         lamports,
     );
     let (recent_blockhash, fee_calculator) = rpc_client.get_recent_blockhash()?;
-    let mut tx = Transaction::new_signed_instructions(&[&config.keypair], ixs, recent_blockhash);
+    let mut tx = Transaction::new_signed_instructions(
+        &[&config.keypair, vote_account],
+        ixs,
+        recent_blockhash,
+    );
     check_account_for_fee(rpc_client, config, &fee_calculator, &tx.message)?;
-    let result = rpc_client.send_and_confirm_transaction(&mut tx, &[&config.keypair]);
+    let result = rpc_client.send_and_confirm_transaction(&mut tx, &[&config.keypair, vote_account]);
     log_instruction_custom_error::<SystemError>(result)
 }
 

--- a/core/src/rpc_pubsub.rs
+++ b/core/src/rpc_pubsub.rs
@@ -402,7 +402,11 @@ mod tests {
             None,
             51,
         );
-        let tx = Transaction::new_signed_instructions(&[&contract_funds], ixs, blockhash);
+        let tx = Transaction::new_signed_instructions(
+            &[&contract_funds, &contract_state],
+            ixs,
+            blockhash,
+        );
         process_transaction_and_notify(&bank_forks, &tx, &rpc.subscriptions).unwrap();
         sleep(Duration::from_millis(200));
 

--- a/core/src/rpc_subscriptions.rs
+++ b/core/src/rpc_subscriptions.rs
@@ -316,7 +316,7 @@ mod tests {
         let alice = Keypair::new();
         let tx = system_transaction::create_account(
             &mint_keypair,
-            &alice.pubkey(),
+            &alice,
             blockhash,
             1,
             16,
@@ -371,7 +371,7 @@ mod tests {
         let alice = Keypair::new();
         let tx = system_transaction::create_account(
             &mint_keypair,
-            &alice.pubkey(),
+            &alice,
             blockhash,
             1,
             16,

--- a/core/tests/storage_stage.rs
+++ b/core/tests/storage_stage.rs
@@ -86,7 +86,7 @@ mod tests {
             StorageAccountType::Archiver,
         );
         let account_tx = Transaction::new_signed_instructions(
-            &[&mint_keypair],
+            &[&mint_keypair, &archiver_keypair],
             account_ix,
             bank.last_blockhash(),
         );

--- a/ledger/src/blocktree_processor.rs
+++ b/ledger/src/blocktree_processor.rs
@@ -534,6 +534,7 @@ pub mod tests {
     };
     use matches::assert_matches;
     use rand::{thread_rng, Rng};
+    use solana_sdk::account::Account;
     use solana_sdk::{
         epoch_schedule::EpochSchedule,
         hash::Hash,
@@ -1576,6 +1577,10 @@ pub mod tests {
         }
         let mut hash = bank.last_blockhash();
 
+        let present_account_key = Keypair::new();
+        let present_account = Account::new(1, 10, &Pubkey::default());
+        bank.store_account(&present_account_key.pubkey(), &present_account);
+
         let entries: Vec<_> = (0..NUM_TRANSFERS)
             .step_by(NUM_TRANSFERS_PER_ENTRY)
             .map(|i| {
@@ -1592,7 +1597,7 @@ pub mod tests {
 
                 transactions.push(system_transaction::create_account(
                     &mint_keypair,
-                    &solana_sdk::sysvar::clock::id(), // puts a TX error in results
+                    &present_account_key, // puts a TX error in results
                     bank.last_blockhash(),
                     1,
                     0,
@@ -1926,6 +1931,10 @@ pub mod tests {
                 .expect("funding failed");
         }
 
+        let present_account_key = Keypair::new();
+        let present_account = Account::new(1, 10, &Pubkey::default());
+        bank.store_account(&present_account_key.pubkey(), &present_account);
+
         let mut i = 0;
         let mut hash = bank.last_blockhash();
         let mut root: Option<Arc<Bank>> = None;
@@ -1947,7 +1956,7 @@ pub mod tests {
 
                         transactions.push(system_transaction::create_account(
                             &mint_keypair,
-                            &solana_sdk::sysvar::clock::id(), // puts a TX error in results
+                            &present_account_key, // puts a TX error in results
                             bank.last_blockhash(),
                             100,
                             100,

--- a/ledger/src/entry.rs
+++ b/ledger/src/entry.rs
@@ -392,6 +392,7 @@ mod tests {
     use crate::entry::Entry;
     use chrono::prelude::Utc;
     use solana_budget_api::budget_instruction;
+    use solana_sdk::pubkey::Pubkey;
     use solana_sdk::{
         hash::{hash, Hash},
         message::Message,
@@ -402,7 +403,8 @@ mod tests {
 
     fn create_sample_payment(keypair: &Keypair, hash: Hash) -> Transaction {
         let pubkey = keypair.pubkey();
-        let ixs = budget_instruction::payment(&pubkey, &pubkey, 1);
+        let budget_pubkey = Pubkey::new_rand();
+        let ixs = budget_instruction::payment(&pubkey, &pubkey, &budget_pubkey, 1);
         Transaction::new_signed_instructions(&[keypair], ixs, hash)
     }
 

--- a/ledger/src/entry.rs
+++ b/ledger/src/entry.rs
@@ -392,7 +392,6 @@ mod tests {
     use crate::entry::Entry;
     use chrono::prelude::Utc;
     use solana_budget_api::budget_instruction;
-    use solana_sdk::pubkey::Pubkey;
     use solana_sdk::{
         hash::{hash, Hash},
         message::Message,
@@ -403,9 +402,10 @@ mod tests {
 
     fn create_sample_payment(keypair: &Keypair, hash: Hash) -> Transaction {
         let pubkey = keypair.pubkey();
-        let budget_pubkey = Pubkey::new_rand();
+        let budget_contract = Keypair::new();
+        let budget_pubkey = budget_contract.pubkey();
         let ixs = budget_instruction::payment(&pubkey, &pubkey, &budget_pubkey, 1);
-        Transaction::new_signed_instructions(&[keypair], ixs, hash)
+        Transaction::new_signed_instructions(&[keypair, &budget_contract], ixs, hash)
     }
 
     fn create_sample_timestamp(keypair: &Keypair, hash: Hash) -> Transaction {

--- a/ledger/src/leader_schedule_cache.rs
+++ b/ledger/src/leader_schedule_cache.rs
@@ -247,6 +247,7 @@ mod tests {
         EpochSchedule, DEFAULT_LEADER_SCHEDULE_SLOT_OFFSET, DEFAULT_SLOTS_PER_EPOCH,
         MINIMUM_SLOTS_PER_EPOCH,
     };
+    use solana_sdk::signature::{Keypair, KeypairUtil};
     use std::{sync::mpsc::channel, sync::Arc, thread::Builder};
 
     #[test]
@@ -496,11 +497,11 @@ mod tests {
 
         // Create new vote account
         let node_pubkey = Pubkey::new_rand();
-        let vote_pubkey = Pubkey::new_rand();
+        let vote_account = Keypair::new();
         setup_vote_and_stake_accounts(
             &bank,
             &mint_keypair,
-            &vote_pubkey,
+            &vote_account,
             &node_pubkey,
             BOOTSTRAP_LEADER_LAMPORTS,
         );

--- a/ledger/src/staking_utils.rs
+++ b/ledger/src/staking_utils.rs
@@ -195,7 +195,6 @@ pub(crate) mod tests {
 
         let bank = Bank::new(&genesis_block);
         let vote_account = Keypair::new();
-        let vote_pubkey = vote_account.pubkey();
 
         // Give the validator some stake but don't setup a staking account
         // Validator has no lamports staked, so they get filtered out. Only the bootstrap leader

--- a/ledger/src/staking_utils.rs
+++ b/ledger/src/staking_utils.rs
@@ -88,7 +88,7 @@ where
     // Find if any slot has achieved sufficient votes for supermajority lockout
     let mut total = 0;
     for (stake, slot) in stakes_and_lockouts {
-        total += stake;
+        total += *stake;
         if total > supermajority_stake {
             return Some(slot);
         }
@@ -125,10 +125,11 @@ pub(crate) mod tests {
     pub(crate) fn setup_vote_and_stake_accounts(
         bank: &Bank,
         from_account: &Keypair,
-        vote_pubkey: &Pubkey,
+        vote_account: &Keypair,
         node_pubkey: &Pubkey,
         amount: u64,
     ) {
+        let vote_pubkey = vote_account.pubkey();
         fn process_instructions<T: KeypairUtil>(
             bank: &Bank,
             keypairs: &[&T],
@@ -145,14 +146,14 @@ pub(crate) mod tests {
 
         process_instructions(
             bank,
-            &[from_account],
+            &[from_account, vote_account],
             vote_instruction::create_account(
                 &from_account.pubkey(),
-                vote_pubkey,
+                &vote_pubkey,
                 &VoteInit {
                     node_pubkey: *node_pubkey,
-                    authorized_voter: *vote_pubkey,
-                    authorized_withdrawer: *vote_pubkey,
+                    authorized_voter: vote_pubkey,
+                    authorized_withdrawer: vote_pubkey,
                     commission: 0,
                 },
                 amount,
@@ -168,7 +169,7 @@ pub(crate) mod tests {
             stake_instruction::create_stake_account_and_delegate_stake(
                 &from_account.pubkey(),
                 &stake_account_pubkey,
-                vote_pubkey,
+                &vote_pubkey,
                 &Authorized::auto(&stake_account_pubkey),
                 amount,
             ),
@@ -193,7 +194,8 @@ pub(crate) mod tests {
         } = create_genesis_block(10_000);
 
         let bank = Bank::new(&genesis_block);
-        let vote_pubkey = Pubkey::new_rand();
+        let vote_account = Keypair::new();
+        let vote_pubkey = vote_account.pubkey();
 
         // Give the validator some stake but don't setup a staking account
         // Validator has no lamports staked, so they get filtered out. Only the bootstrap leader
@@ -206,7 +208,7 @@ pub(crate) mod tests {
         setup_vote_and_stake_accounts(
             &bank,
             &mint_keypair,
-            &vote_pubkey,
+            &vote_account,
             &mint_keypair.pubkey(),
             stake,
         );

--- a/local_cluster/src/local_cluster.rs
+++ b/local_cluster/src/local_cluster.rs
@@ -472,7 +472,7 @@ impl LocalCluster {
             // 1) Create vote account
 
             let mut transaction = Transaction::new_signed_instructions(
-                &[from_account.as_ref()],
+                &[from_account.as_ref(), vote_account],
                 vote_instruction::create_account(
                     &from_account.pubkey(),
                     &vote_account_pubkey,

--- a/local_cluster/src/local_cluster.rs
+++ b/local_cluster/src/local_cluster.rs
@@ -596,7 +596,8 @@ impl LocalCluster {
             ),
             Some(&from_keypair.pubkey()),
         );
-        let signer_keys = vec![from_keypair.as_ref()];
+
+        let signer_keys = vec![from_keypair.as_ref(), &storage_keypair];
         let blockhash = client
             .get_recent_blockhash_with_commitment(CommitmentConfig::recent())
             .unwrap()

--- a/programs/budget_api/src/budget_instruction.rs
+++ b/programs/budget_api/src/budget_instruction.rs
@@ -82,8 +82,7 @@ pub fn create_account(
 }
 
 /// Create a new payment script.
-pub fn payment(from: &Pubkey, to: &Pubkey, lamports: u64) -> Vec<Instruction> {
-    let contract = Pubkey::new_rand();
+pub fn payment(from: &Pubkey, to: &Pubkey, contract: &Pubkey, lamports: u64) -> Vec<Instruction> {
     let expr = BudgetExpr::new_payment(lamports, to);
     create_account(from, &contract, lamports, expr)
 }
@@ -181,7 +180,8 @@ mod tests {
     fn test_budget_instruction_verify() {
         let alice_pubkey = Pubkey::new_rand();
         let bob_pubkey = Pubkey::new_rand();
-        payment(&alice_pubkey, &bob_pubkey, 1); // No panic! indicates success.
+        let budget_pubkey = Pubkey::new_rand();
+        payment(&alice_pubkey, &bob_pubkey, &budget_pubkey, 1); // No panic! indicates success.
     }
 
     #[test]

--- a/programs/budget_api/src/budget_processor.rs
+++ b/programs/budget_api/src/budget_processor.rs
@@ -210,10 +210,13 @@ mod tests {
         let bank_client = BankClient::new(bank);
         let alice_pubkey = alice_keypair.pubkey();
         let bob_pubkey = Pubkey::new_rand();
-        let instructions = budget_instruction::payment(&alice_pubkey, &bob_pubkey, 100);
+        let budget_keypair = Keypair::new();
+        let budget_pubkey = budget_keypair.pubkey();
+        let instructions =
+            budget_instruction::payment(&alice_pubkey, &bob_pubkey, &budget_pubkey, 100);
         let message = Message::new(instructions);
         bank_client
-            .send_message(&[&alice_keypair], message)
+            .send_message(&[&alice_keypair, &budget_keypair], message)
             .unwrap();
         assert_eq!(bank_client.get_balance(&bob_pubkey).unwrap(), 100);
     }
@@ -225,7 +228,8 @@ mod tests {
         let alice_pubkey = alice_keypair.pubkey();
 
         // Initialize BudgetState
-        let budget_pubkey = Pubkey::new_rand();
+        let budget_keypair = Keypair::new();
+        let budget_pubkey = budget_keypair.pubkey();
         let bob_pubkey = Pubkey::new_rand();
         let witness = Pubkey::new_rand();
         let instructions = budget_instruction::when_signed(
@@ -238,7 +242,7 @@ mod tests {
         );
         let message = Message::new(instructions);
         bank_client
-            .send_message(&[&alice_keypair], message)
+            .send_message(&[&alice_keypair, &budget_keypair], message)
             .unwrap();
 
         // Attack! Part 1: Sign a witness transaction with a random key.
@@ -273,7 +277,8 @@ mod tests {
         let alice_pubkey = alice_keypair.pubkey();
 
         // Initialize BudgetState
-        let budget_pubkey = Pubkey::new_rand();
+        let budget_keypair = Keypair::new();
+        let budget_pubkey = budget_keypair.pubkey();
         let bob_pubkey = Pubkey::new_rand();
         let dt = Utc::now();
         let instructions = budget_instruction::on_date(
@@ -287,7 +292,7 @@ mod tests {
         );
         let message = Message::new(instructions);
         bank_client
-            .send_message(&[&alice_keypair], message)
+            .send_message(&[&alice_keypair, &budget_keypair], message)
             .unwrap();
 
         // Attack! Part 1: Sign a timestamp transaction with a random key.
@@ -320,10 +325,12 @@ mod tests {
         let (bank, alice_keypair) = create_bank(2);
         let bank_client = BankClient::new(bank);
         let alice_pubkey = alice_keypair.pubkey();
-        let budget_pubkey = Pubkey::new_rand();
+        let budget_keypair = Keypair::new();
+        let budget_pubkey = budget_keypair.pubkey();
         let bob_pubkey = Pubkey::new_rand();
         let mallory_pubkey = Pubkey::new_rand();
         let dt = Utc::now();
+
         let instructions = budget_instruction::on_date(
             &alice_pubkey,
             &bob_pubkey,
@@ -335,7 +342,7 @@ mod tests {
         );
         let message = Message::new(instructions);
         bank_client
-            .send_message(&[&alice_keypair], message)
+            .send_message(&[&alice_keypair, &budget_keypair], message)
             .unwrap();
         assert_eq!(bank_client.get_balance(&alice_pubkey).unwrap(), 1);
         assert_eq!(bank_client.get_balance(&budget_pubkey).unwrap(), 1);
@@ -389,7 +396,8 @@ mod tests {
         let (bank, alice_keypair) = create_bank(3);
         let bank_client = BankClient::new(bank);
         let alice_pubkey = alice_keypair.pubkey();
-        let budget_pubkey = Pubkey::new_rand();
+        let budget_keypair = Keypair::new();
+        let budget_pubkey = budget_keypair.pubkey();
         let bob_pubkey = Pubkey::new_rand();
         let dt = Utc::now();
 
@@ -404,7 +412,7 @@ mod tests {
         );
         let message = Message::new(instructions);
         bank_client
-            .send_message(&[&alice_keypair], message)
+            .send_message(&[&alice_keypair, &budget_keypair], message)
             .unwrap();
         assert_eq!(bank_client.get_balance(&alice_pubkey).unwrap(), 2);
         assert_eq!(bank_client.get_balance(&budget_pubkey).unwrap(), 1);
@@ -461,7 +469,8 @@ mod tests {
 
         let alice_pubkey = alice_keypair.pubkey();
         let game_hash = hash(&[1, 2, 3]);
-        let budget_pubkey = Pubkey::new_rand();
+        let budget_keypair = Keypair::new();
+        let budget_pubkey = budget_keypair.pubkey();
         let bob_keypair = Keypair::new();
         let bob_pubkey = bob_keypair.pubkey();
 
@@ -481,7 +490,7 @@ mod tests {
         );
         let message = Message::new(instructions);
         bank_client
-            .send_message(&[&alice_keypair], message)
+            .send_message(&[&alice_keypair, &budget_keypair], message)
             .unwrap();
         assert_eq!(bank_client.get_balance(&alice_pubkey).unwrap(), 0);
         assert_eq!(bank_client.get_balance(&budget_pubkey).unwrap(), 41);

--- a/programs/config_tests/tests/config_processor.rs
+++ b/programs/config_tests/tests/config_processor.rs
@@ -371,10 +371,11 @@ fn test_config_updates_requiring_config() {
 fn test_config_initialize_no_panic() {
     let (bank, alice_keypair) = create_bank(3);
     let bank_client = BankClient::new(bank);
+    let config_account = Keypair::new();
 
     let mut instructions = config_instruction::create_account::<MyConfig>(
         &alice_keypair.pubkey(),
-        &Pubkey::new_rand(),
+        &config_account.pubkey(),
         1,
         vec![],
     );
@@ -383,7 +384,7 @@ fn test_config_initialize_no_panic() {
     let message = Message::new(instructions);
     assert_eq!(
         bank_client
-            .send_message(&[&alice_keypair], message)
+            .send_message(&[&alice_keypair, &config_account], message)
             .unwrap_err()
             .unwrap(),
         TransactionError::InstructionError(1, InstructionError::NotEnoughAccountKeys)

--- a/programs/exchange_api/src/exchange_processor.rs
+++ b/programs/exchange_api/src/exchange_processor.rs
@@ -458,6 +458,7 @@ mod test {
     use solana_runtime::bank_client::BankClient;
     use solana_sdk::client::SyncClient;
     use solana_sdk::genesis_block::create_genesis_block;
+    use solana_sdk::message::Message;
     use solana_sdk::signature::{Keypair, KeypairUtil};
     use solana_sdk::system_instruction;
     use std::mem;
@@ -557,18 +558,20 @@ mod test {
     }
 
     fn create_account(client: &BankClient, owner: &Keypair) -> Pubkey {
-        let new = Pubkey::new_rand();
+        let new = Keypair::new();
+
         let instruction = system_instruction::create_account(
             &owner.pubkey(),
-            &new,
+            &new.pubkey(),
             1,
             mem::size_of::<ExchangeState>() as u64,
             &id(),
         );
+
         client
-            .send_instruction(&owner, instruction)
+            .send_message(&[owner, &new], Message::new(vec![instruction]))
             .expect(&format!("{}:{}", line!(), file!()));
-        new
+        new.pubkey()
     }
 
     fn create_token_account(client: &BankClient, owner: &Keypair) -> Pubkey {

--- a/programs/librapay_api/src/lib.rs
+++ b/programs/librapay_api/src/lib.rs
@@ -36,7 +36,13 @@ pub fn create_genesis<T: Client>(from_key: &Keypair, client: &T, amount: u64) ->
             as u64,
         &solana_sdk::move_loader::id(),
     );
-    client.send_instruction(&from_key, instruction).unwrap();
+
+    client
+        .send_message(
+            &[&from_key, &libra_genesis_key],
+            Message::new(vec![instruction]),
+        )
+        .unwrap();
 
     let instruction = librapay_instruction::genesis(&libra_genesis_key.pubkey(), amount);
     let message = Message::new_with_payer(vec![instruction], Some(&from_key.pubkey()));

--- a/programs/librapay_api/src/librapay_transaction.rs
+++ b/programs/librapay_api/src/librapay_transaction.rs
@@ -175,12 +175,7 @@ mod tests {
         let from = Keypair::new();
         let to = Keypair::new();
 
-        let tx = create_accounts(
-            &mint_keypair,
-            &[from.pubkey(), to.pubkey()],
-            1,
-            bank.last_blockhash(),
-        );
+        let tx = create_accounts(&mint_keypair, &[&from, &to], 1, bank.last_blockhash());
         bank.process_transaction(&tx).unwrap();
 
         info!(

--- a/programs/librapay_api/src/librapay_transaction.rs
+++ b/programs/librapay_api/src/librapay_transaction.rs
@@ -63,32 +63,35 @@ pub fn transfer(
 
 pub fn create_accounts(
     from: &Keypair,
-    tos: &[Pubkey],
+    to: &[&Keypair],
     lamports: u64,
     recent_blockhash: Hash,
 ) -> Transaction {
-    let instructions = tos
+    let instructions = to
         .iter()
         .map(|to| {
             system_instruction::create_account(
                 &from.pubkey(),
-                to,
+                &to.pubkey(),
                 lamports,
                 400,
                 &solana_sdk::move_loader::id(),
             )
         })
         .collect();
-    Transaction::new_signed_instructions(&[from], instructions, recent_blockhash)
+
+    let mut from_signers = vec![from];
+    from_signers.extend_from_slice(to);
+    Transaction::new_signed_instructions(&from_signers, instructions, recent_blockhash)
 }
 
 pub fn create_account(
     from: &Keypair,
-    to: &Pubkey,
+    to: &Keypair,
     lamports: u64,
     recent_blockhash: Hash,
 ) -> Transaction {
-    create_accounts(from, &[*to], lamports, recent_blockhash)
+    create_accounts(from, &[to], lamports, recent_blockhash)
 }
 
 #[derive(Debug)]

--- a/programs/stake_tests/tests/stake_instruction.rs
+++ b/programs/stake_tests/tests/stake_instruction.rs
@@ -92,7 +92,7 @@ fn test_stake_account_delegate() {
         10,
     ));
     bank_client
-        .send_message(&[&mint_keypair], message)
+        .send_message(&[&mint_keypair, &vote_keypair], message)
         .expect("failed to create vote account");
 
     let authorized = stake_state::Authorized::auto(&staker_pubkey);

--- a/programs/vest_api/src/vest_processor.rs
+++ b/programs/vest_api/src/vest_processor.rs
@@ -192,7 +192,7 @@ mod tests {
 
     fn create_vest_account(
         bank_client: &BankClient,
-        contract_pubkey: &Pubkey,
+        contract_keypair: &Keypair,
         payer_keypair: &Keypair,
         terminator_pubkey: &Pubkey,
         payee_pubkey: &Pubkey,
@@ -203,14 +203,14 @@ mod tests {
         let instructions = vest_instruction::create_account(
             &payer_keypair.pubkey(),
             &terminator_pubkey,
-            &contract_pubkey,
+            &contract_keypair.pubkey(),
             &payee_pubkey,
             start_date,
             &date_pubkey,
             lamports,
         );
         let message = Message::new(instructions);
-        bank_client.send_message(&[&payer_keypair], message)
+        bank_client.send_message(&[&payer_keypair, &contract_keypair], message)
     }
 
     fn send_set_terminator(
@@ -327,10 +327,12 @@ mod tests {
     fn test_initialize_no_panic() {
         let (bank_client, alice_keypair) = create_bank_client(3);
 
+        let contract_keypair = Keypair::new();
+
         let mut instructions = vest_instruction::create_account(
             &alice_keypair.pubkey(),
             &Pubkey::new_rand(),
-            &Pubkey::new_rand(),
+            &contract_keypair.pubkey(),
             &Pubkey::new_rand(),
             Utc::now().date(),
             &Pubkey::new_rand(),
@@ -341,7 +343,7 @@ mod tests {
         let message = Message::new(instructions);
         assert_eq!(
             bank_client
-                .send_message(&[&alice_keypair], message)
+                .send_message(&[&alice_keypair, &contract_keypair], message)
                 .unwrap_err()
                 .unwrap(),
             TransactionError::InstructionError(1, InstructionError::NotEnoughAccountKeys)
@@ -352,14 +354,15 @@ mod tests {
         let (bank_client, alice_keypair) = create_bank_client(39);
         let alice_pubkey = alice_keypair.pubkey();
         let date_pubkey = Pubkey::new_rand();
-        let contract_pubkey = Pubkey::new_rand();
+        let contract_keypair = Keypair::new();
+        let contract_pubkey = contract_keypair.pubkey();
         let bob_keypair = Keypair::new();
         let bob_pubkey = bob_keypair.pubkey();
         let start_date = Utc.ymd(2018, 1, 1);
 
         create_vest_account(
             &bank_client,
-            &contract_pubkey,
+            &contract_keypair,
             &alice_keypair,
             &alice_pubkey,
             &bob_pubkey,
@@ -422,14 +425,15 @@ mod tests {
         let (bank_client, alice_keypair) = create_bank_client(38);
         let alice_pubkey = alice_keypair.pubkey();
         let date_pubkey = Pubkey::new_rand();
-        let contract_pubkey = Pubkey::new_rand();
+        let contract_keypair = Keypair::new();
+        let contract_pubkey = contract_keypair.pubkey();
         let bob_keypair = Keypair::new();
         let bob_pubkey = bob_keypair.pubkey();
         let start_date = Utc.ymd(2018, 1, 1);
 
         create_vest_account(
             &bank_client,
-            &contract_pubkey,
+            &contract_keypair,
             &alice_keypair,
             &alice_pubkey,
             &bob_pubkey,
@@ -481,13 +485,14 @@ mod tests {
         let current_date = Utc.ymd(2019, 1, 1);
         create_date_account(&bank_client, &date_keypair, &alice_keypair, current_date).unwrap();
 
-        let contract_pubkey = Pubkey::new_rand();
+        let contract_keypair = Keypair::new();
+        let contract_pubkey = contract_keypair.pubkey();
         let bob_pubkey = Pubkey::new_rand();
         let start_date = Utc.ymd(2018, 1, 1);
 
         create_vest_account(
             &bank_client,
-            &contract_pubkey,
+            &contract_keypair,
             &alice_keypair,
             &alice_pubkey,
             &bob_pubkey,
@@ -542,7 +547,8 @@ mod tests {
     fn test_terminate_and_refund() {
         let (bank_client, alice_keypair) = create_bank_client(3);
         let alice_pubkey = alice_keypair.pubkey();
-        let contract_pubkey = Pubkey::new_rand();
+        let contract_keypair = Keypair::new();
+        let contract_pubkey = contract_keypair.pubkey();
         let bob_pubkey = Pubkey::new_rand();
         let start_date = Utc::now().date();
 
@@ -554,7 +560,7 @@ mod tests {
 
         create_vest_account(
             &bank_client,
-            &contract_pubkey,
+            &contract_keypair,
             &alice_keypair,
             &alice_pubkey,
             &bob_pubkey,
@@ -585,7 +591,8 @@ mod tests {
     fn test_terminate_and_send_funds() {
         let (bank_client, alice_keypair) = create_bank_client(3);
         let alice_pubkey = alice_keypair.pubkey();
-        let contract_pubkey = Pubkey::new_rand();
+        let contract_keypair = Keypair::new();
+        let contract_pubkey = contract_keypair.pubkey();
         let bob_pubkey = Pubkey::new_rand();
         let start_date = Utc::now().date();
 
@@ -597,7 +604,7 @@ mod tests {
 
         create_vest_account(
             &bank_client,
-            &contract_pubkey,
+            &contract_keypair,
             &alice_keypair,
             &alice_pubkey,
             &bob_pubkey,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3066,7 +3066,7 @@ mod tests {
         );
 
         let transaction = Transaction::new_signed_instructions(
-            &[&mint_keypair],
+            &[&mint_keypair, &vote_keypair],
             instructions,
             bank.last_blockhash(),
         );
@@ -3287,7 +3287,7 @@ mod tests {
         );
 
         let transaction = Transaction::new_signed_instructions(
-            &[&mint_keypair],
+            &[&mint_keypair, &mock_account],
             instructions,
             bank.last_blockhash(),
         );
@@ -3328,7 +3328,7 @@ mod tests {
         );
 
         let transaction = Transaction::new_signed_instructions(
-            &[&mint_keypair],
+            &[&mint_keypair, &mock_account],
             instructions,
             bank.last_blockhash(),
         );

--- a/runtime/src/loader_utils.rs
+++ b/runtime/src/loader_utils.rs
@@ -24,7 +24,10 @@ pub fn load_program<T: Client>(
         loader_pubkey,
     );
     bank_client
-        .send_instruction(&from_keypair, instruction)
+        .send_message(
+            &[from_keypair, &program_keypair],
+            Message::new(vec![instruction]),
+        )
         .unwrap();
 
     let chunk_size = 256; // Size of chunk just needs to fit into tx

--- a/runtime/src/storage_utils.rs
+++ b/runtime/src/storage_utils.rs
@@ -117,7 +117,9 @@ pub(crate) mod tests {
             11,
             StorageAccountType::Archiver,
         ));
-        bank_client.send_message(&[&mint_keypair], message).unwrap();
+        bank_client
+            .send_message(&[&mint_keypair, &archiver_keypair], message)
+            .unwrap();
 
         let message = Message::new(storage_instruction::create_storage_account(
             &mint_pubkey,
@@ -126,7 +128,9 @@ pub(crate) mod tests {
             11,
             StorageAccountType::Validator,
         ));
-        bank_client.send_message(&[&mint_keypair], message).unwrap();
+        bank_client
+            .send_message(&[&mint_keypair, &validator_keypair], message)
+            .unwrap();
 
         assert_eq!(validator_accounts(bank.as_ref()).len(), 1);
         assert_eq!(archiver_accounts(bank.as_ref()).len(), 1);

--- a/runtime/src/system_instruction_processor.rs
+++ b/runtime/src/system_instruction_processor.rs
@@ -162,7 +162,7 @@ mod tests {
         assert_eq!(
             create_system_account(
                 &mut KeyedAccount::new(&from, true, &mut from_account),
-                &mut KeyedAccount::new(&to, false, &mut to_account),
+                &mut KeyedAccount::new(&to, true, &mut to_account),
                 50,
                 2,
                 &new_program_owner,
@@ -193,7 +193,7 @@ mod tests {
         assert_eq!(
             create_system_account(
                 &mut KeyedAccount::new(&from, false, &mut from_account), // no signer
-                &mut KeyedAccount::new(&to, false, &mut to_account),
+                &mut KeyedAccount::new(&to, true, &mut to_account),
                 0,
                 2,
                 &new_program_owner,
@@ -224,7 +224,7 @@ mod tests {
 
         let result = create_system_account(
             &mut KeyedAccount::new(&from, true, &mut from_account),
-            &mut KeyedAccount::new(&to, false, &mut to_account),
+            &mut KeyedAccount::new(&to, true, &mut to_account),
             150,
             2,
             &new_program_owner,
@@ -249,7 +249,7 @@ mod tests {
 
         let result = create_system_account(
             &mut KeyedAccount::new(&from, true, &mut from_account),
-            &mut KeyedAccount::new(&owned_key, false, &mut owned_account),
+            &mut KeyedAccount::new(&owned_key, true, &mut owned_account),
             50,
             2,
             &new_program_owner,
@@ -264,7 +264,7 @@ mod tests {
         let unchanged_account = owned_account.clone();
         let result = create_system_account(
             &mut KeyedAccount::new(&from, true, &mut from_account),
-            &mut KeyedAccount::new(&owned_key, false, &mut owned_account),
+            &mut KeyedAccount::new(&owned_key, true, &mut owned_account),
             50,
             2,
             &new_program_owner,
@@ -300,7 +300,7 @@ mod tests {
         // support creation/assignment with zero lamports (ephemeral account)
         let result = create_system_account(
             &mut KeyedAccount::new(&from, false, &mut from_account),
-            &mut KeyedAccount::new(&owned_key, false, &mut owned_account),
+            &mut KeyedAccount::new(&owned_key, true, &mut owned_account),
             0,
             2,
             &new_program_owner,
@@ -322,7 +322,7 @@ mod tests {
         // fail to create a sysvar::id() owned account
         let result = create_system_account(
             &mut KeyedAccount::new(&from, true, &mut from_account),
-            &mut KeyedAccount::new(&to, false, &mut to_account),
+            &mut KeyedAccount::new(&to, true, &mut to_account),
             50,
             2,
             &sysvar::id(),
@@ -362,7 +362,7 @@ mod tests {
 
         let result = create_system_account(
             &mut KeyedAccount::new(&from, true, &mut from_account),
-            &mut KeyedAccount::new(&populated_key, false, &mut populated_account),
+            &mut KeyedAccount::new(&populated_key, true, &mut populated_account),
             50,
             2,
             &new_program_owner,

--- a/runtime/src/system_instruction_processor.rs
+++ b/runtime/src/system_instruction_processor.rs
@@ -20,6 +20,11 @@ fn create_system_account(
         return Err(InstructionError::MissingRequiredSignature);
     }
 
+    if to.signer_key().is_none() {
+        debug!("CreateAccount: to must sign");
+        return Err(InstructionError::MissingRequiredSignature);
+    }
+
     // if it looks like the to account is already in use, bail
     if to.account.lamports != 0
         || !to.account.data.is_empty()

--- a/runtime/src/system_instruction_processor.rs
+++ b/runtime/src/system_instruction_processor.rs
@@ -335,7 +335,7 @@ mod tests {
         // fail to create an account with a sysvar id
         let result = create_system_account(
             &mut KeyedAccount::new(&from, true, &mut from_account),
-            &mut KeyedAccount::new(&to, false, &mut to_account),
+            &mut KeyedAccount::new(&to, true, &mut to_account),
             50,
             2,
             &system_program::id(),

--- a/runtime/src/system_instruction_processor.rs
+++ b/runtime/src/system_instruction_processor.rs
@@ -286,8 +286,21 @@ mod tests {
         let mut owned_account = Account::new(0, 0, &Pubkey::default());
         let unchanged_account = owned_account.clone();
 
+        // Haven't signed from account
         let result = create_system_account(
             &mut KeyedAccount::new(&from, false, &mut from_account),
+            &mut KeyedAccount::new(&owned_key, true, &mut owned_account),
+            50,
+            2,
+            &new_program_owner,
+        );
+        assert_eq!(result, Err(InstructionError::MissingRequiredSignature));
+        assert_eq!(from_account.lamports, 100);
+        assert_eq!(owned_account, unchanged_account);
+
+        // Haven't signed to account
+        let result = create_system_account(
+            &mut KeyedAccount::new(&from, true, &mut from_account),
             &mut KeyedAccount::new(&owned_key, false, &mut owned_account),
             50,
             2,

--- a/sdk/src/system_instruction.rs
+++ b/sdk/src/system_instruction.rs
@@ -56,7 +56,7 @@ pub fn create_account(
 ) -> Instruction {
     let account_metas = vec![
         AccountMeta::new(*from_pubkey, true),
-        AccountMeta::new(*to_pubkey, false),
+        AccountMeta::new(*to_pubkey, true),
     ];
     Instruction::new(
         system_program::id(),

--- a/sdk/src/system_transaction.rs
+++ b/sdk/src/system_transaction.rs
@@ -11,17 +11,22 @@ use crate::{
 /// Create and sign new SystemInstruction::CreateAccount transaction
 pub fn create_account(
     from_keypair: &Keypair,
-    to: &Pubkey,
+    to_keypair: &Keypair,
     recent_blockhash: Hash,
     lamports: u64,
     space: u64,
     program_id: &Pubkey,
 ) -> Transaction {
     let from_pubkey = from_keypair.pubkey();
+    let to_pubkey = to_keypair.pubkey();
     let create_instruction =
-        system_instruction::create_account(&from_pubkey, to, lamports, space, program_id);
+        system_instruction::create_account(&from_pubkey, &to_pubkey, lamports, space, program_id);
     let instructions = vec![create_instruction];
-    Transaction::new_signed_instructions(&[from_keypair], instructions, recent_blockhash)
+    Transaction::new_signed_instructions(
+        &[from_keypair, to_keypair],
+        instructions,
+        recent_blockhash,
+    )
 }
 
 /// Create and sign new system_instruction::Assign transaction


### PR DESCRIPTION
#### Problem
See #6449

#### Summary of Changes
- Modify `create_account` to expect signature of `to` pubkey
- Modify clients to sign the message using `to`'s keypair

Fixes #6449 

Remaining: 
- [x] Add test
- [x] Fix any broken code
- [x] Update CLI
