### PR TITLE
Add --use-move flag to cargo-install-all.sh and net/net.sh

### DIFF
--- a/ci/publish-tarball.sh
+++ b/ci/publish-tarball.sh
@@ -68,7 +68,7 @@ echo --- Creating tarball
   ) > solana-release/version.yml
 
   source ci/rust-version.sh stable
-  scripts/cargo-install-all.sh +"$rust_stable" solana-release
+  scripts/cargo-install-all.sh +"$rust_stable" --use-move solana-release
 
   # Reduce the Windows archive size until
   # https://github.com/appveyor/ci/issues/2997 is fixed

--- a/net/net.sh
+++ b/net/net.sh
@@ -86,6 +86,8 @@ Operate a configured testnet
    --deploy-if-newer                  - Only deploy if newer software is
                                         available (requires -t or -T)
 
+   --use-move                         - Build the move-loader-program and add it to the cluster
+
  sanity/start-specific options:
    -F                   - Discard validator nodes that didn't bootup successfully
    -o noInstallCheck    - Skip solana-install sanity
@@ -138,6 +140,7 @@ maybeDisableAirdrops=""
 debugBuild=false
 doBuild=true
 gpuMode=auto
+maybeUseMove=""
 
 command=$1
 [[ -n $command ]] || usage
@@ -197,6 +200,9 @@ while [[ -n $1 ]]; do
       shift 1
     elif [[ $1 = --debug ]]; then
       debugBuild=true
+      shift 1
+    elif [[ $1 = --use-move ]]; then
+      maybeUseMove=$1
       shift 1
     elif [[ $1 = --gpu-mode ]]; then
       gpuMode=$2
@@ -367,7 +373,7 @@ build() {
 
     $MAYBE_DOCKER bash -c "
       set -ex
-      scripts/cargo-install-all.sh farf \"$buildVariant\"
+      scripts/cargo-install-all.sh farf \"$buildVariant\" \"$maybeUseMove\"
       if [[ -n \"$customPrograms\" ]]; then
         scripts/cargo-install-custom-programs.sh farf $customPrograms
       fi

--- a/scripts/cargo-install-all.sh
+++ b/scripts/cargo-install-all.sh
@@ -4,27 +4,52 @@
 # other workspace crates or native program crates.
 set -e
 
-export rust_version=
-if [[ $1 =~ \+ ]]; then
-  export rust_version=$1
-  shift
-fi
+usage() {
+  exitcode=0
+  if [[ -n "$1" ]]; then
+    exitcode=1
+    echo "Error: $*"
+  fi
+  cat <<EOF
+usage: $0 [+<cargo version>] [--use-move] [--debug] <install directory>
+EOF
+  exit $exitcode
+}
 
-if [[ -z $1 ]]; then
-  echo Install directory not specified
+maybeRustVersion=
+useMove=false
+installDir=
+buildVariant=release
+maybeReleaseFlag=--release
+
+while [[ -n $1 ]]; do
+  if [[ ${1:0:1} = - ]]; then
+    if [[ $1 = --use-move ]]; then
+      useMove=true
+      shift
+    elif [[ $1 = --debug ]]; then
+      maybeReleaseFlag=
+      buildVariant=debug
+      shift
+    else
+      usage "Unknown option: $1"
+    fi
+  elif [[ ${1:0:1} = \+ ]]; then
+    maybeRustVersion=$1
+    shift
+  else
+    installDir=$1
+    shift
+  fi
+done
+
+if [[ -z "$installDir" ]]; then
+  usage "Install directory not specified"
   exit 1
 fi
 
-installDir="$(mkdir -p "$1"; cd "$1"; pwd)"
+installDir="$(mkdir -p "$installDir"; cd "$installDir"; pwd)"
 cargo=cargo
-debugBuild="$2"
-
-buildVariant=release
-maybeReleaseFlag=--release
-if [[ -n "$debugBuild" ]]; then
-  maybeReleaseFlag=
-  buildVariant=debug
-fi
 
 echo "Install location: $installDir ($buildVariant)"
 
@@ -36,10 +61,12 @@ SECONDS=0
 (
   set -x
   # shellcheck disable=SC2086 # Don't want to double quote $rust_version
-  $cargo $rust_version build $maybeReleaseFlag
+  $cargo $maybeRustVersion build $maybeReleaseFlag
 
-  # shellcheck disable=SC2086 # Don't want to double quote $rust_version
-  $cargo $rust_version build $maybeReleaseFlag --manifest-path programs/move_loader_program/Cargo.toml
+  if $useMove; then
+    # shellcheck disable=SC2086 # Don't want to double quote $rust_version
+    $cargo $maybeRustVersion build $maybeReleaseFlag --manifest-path programs/move_loader_program/Cargo.toml
+  fi
 )
 
 BINS=(
@@ -68,7 +95,7 @@ done
 (
   set -x
   # shellcheck disable=SC2086 # Don't want to double quote $rust_version
-  $cargo $rust_version build $maybeReleaseFlag "${binArgs[@]}"
+  $cargo $maybeRustVersion build $maybeReleaseFlag "${binArgs[@]}"
 )
 
 mkdir -p "$installDir/bin"

--- a/sdk/docker-solana/build.sh
+++ b/sdk/docker-solana/build.sh
@@ -14,7 +14,7 @@ fi
 cd "$(dirname "$0")"
 rm -rf usr/
 ../../ci/docker-run.sh "$rust_stable_docker_image" \
-  scripts/cargo-install-all.sh sdk/docker-solana/usr
+  scripts/cargo-install-all.sh --use-move sdk/docker-solana/usr
 
 cp -f ../../run.sh usr/bin/solana-run.sh
 


### PR DESCRIPTION
#### Problem

`cargo-install-all.sh` builds move even when called in situations where it isn't wanted.

#### Summary of Changes

Add a `--use-move` flag that enables the build. Also pipe that option through `net/net.sh`. Have `sdk/docker-solana/build.sh` and `ci/publish-tarball.sh` always call that option.

Fixes #6661
