### PR TITLE
Send repairman shreds to the repair socket

### DIFF
--- a/core/src/cluster_info.rs
+++ b/core/src/cluster_info.rs
@@ -1507,6 +1507,7 @@ impl ClusterInfo {
             daddr,
             daddr,
             daddr,
+            daddr,
             timestamp(),
         );
         (node, gossip_socket, Some(ip_echo))
@@ -1519,6 +1520,7 @@ impl ClusterInfo {
 
         let node = ContactInfo::new(
             id,
+            daddr,
             daddr,
             daddr,
             daddr,
@@ -1610,6 +1612,7 @@ impl Node {
             gossip.local_addr().unwrap(),
             tvu.local_addr().unwrap(),
             tvu_forwards.local_addr().unwrap(),
+            repair.local_addr().unwrap(),
             empty,
             empty,
             storage.local_addr().unwrap(),
@@ -1658,6 +1661,7 @@ impl Node {
             tvu_forwards.local_addr().unwrap(),
             tpu.local_addr().unwrap(),
             tpu_forwards.local_addr().unwrap(),
+            repair.local_addr().unwrap(),
             storage.local_addr().unwrap(),
             rpc_addr,
             rpc_pubsub_addr,
@@ -1717,7 +1721,7 @@ impl Node {
         let (_, retransmit_sockets) =
             multi_bind_in_range(port_range, 8).expect("retransmit multi_bind");
 
-        let (_, repair) = Self::bind(port_range);
+        let (repair_port, repair) = Self::bind(port_range);
         let (_, broadcast) = Self::bind(port_range);
 
         let info = ContactInfo::new(
@@ -1725,6 +1729,7 @@ impl Node {
             SocketAddr::new(gossip_addr.ip(), gossip_port),
             SocketAddr::new(gossip_addr.ip(), tvu_port),
             SocketAddr::new(gossip_addr.ip(), tvu_forwards_port),
+            SocketAddr::new(gossip_addr.ip(), repair_port),
             SocketAddr::new(gossip_addr.ip(), tpu_port),
             SocketAddr::new(gossip_addr.ip(), tpu_forwards_port),
             socketaddr_any!(),
@@ -1882,6 +1887,7 @@ mod tests {
             socketaddr!([127, 0, 0, 1], 1239),
             socketaddr!([127, 0, 0, 1], 1240),
             socketaddr!([127, 0, 0, 1], 1241),
+            socketaddr!([127, 0, 0, 1], 1242),
             0,
         );
         cluster_info.insert_info(nxt.clone());
@@ -1902,6 +1908,7 @@ mod tests {
             socketaddr!([127, 0, 0, 1], 1239),
             socketaddr!([127, 0, 0, 1], 1240),
             socketaddr!([127, 0, 0, 1], 1241),
+            socketaddr!([127, 0, 0, 1], 1242),
             0,
         );
         cluster_info.insert_info(nxt);
@@ -1939,6 +1946,7 @@ mod tests {
                 socketaddr!("127.0.0.1:1239"),
                 socketaddr!("127.0.0.1:1240"),
                 socketaddr!("127.0.0.1:1241"),
+                socketaddr!("127.0.0.1:1242"),
                 0,
             );
             let rv = ClusterInfo::run_window_request(

--- a/core/src/contact_info.rs
+++ b/core/src/contact_info.rs
@@ -20,8 +20,10 @@ pub struct ContactInfo {
     pub gossip: SocketAddr,
     /// address to connect to for replication
     pub tvu: SocketAddr,
-    /// address to forward blobs to
+    /// address to forward shreds to
     pub tvu_forwards: SocketAddr,
+    /// address to send repairs to
+    pub repair: SocketAddr,
     /// transactions address
     pub tpu: SocketAddr,
     /// address to forward unprocessed transactions to
@@ -80,6 +82,7 @@ impl Default for ContactInfo {
             gossip: socketaddr_any!(),
             tvu: socketaddr_any!(),
             tvu_forwards: socketaddr_any!(),
+            repair: socketaddr_any!(),
             tpu: socketaddr_any!(),
             tpu_forwards: socketaddr_any!(),
             storage_addr: socketaddr_any!(),
@@ -98,6 +101,7 @@ impl ContactInfo {
         gossip: SocketAddr,
         tvu: SocketAddr,
         tvu_forwards: SocketAddr,
+        repair: SocketAddr,
         tpu: SocketAddr,
         tpu_forwards: SocketAddr,
         storage_addr: SocketAddr,
@@ -111,6 +115,7 @@ impl ContactInfo {
             gossip,
             tvu,
             tvu_forwards,
+            repair,
             tpu,
             tpu_forwards,
             storage_addr,
@@ -131,6 +136,7 @@ impl ContactInfo {
             socketaddr!("127.0.0.1:1239"),
             socketaddr!("127.0.0.1:1240"),
             socketaddr!("127.0.0.1:1241"),
+            socketaddr!("127.0.0.1:1242"),
             now,
         )
     }
@@ -142,6 +148,7 @@ impl ContactInfo {
         assert!(addr.ip().is_multicast());
         Self::new(
             &Pubkey::new_rand(),
+            addr,
             addr,
             addr,
             addr,
@@ -167,6 +174,7 @@ impl ContactInfo {
         let tvu_addr = next_port(&bind_addr, 2);
         let tpu_forwards_addr = next_port(&bind_addr, 3);
         let tvu_forwards_addr = next_port(&bind_addr, 4);
+        let repair = next_port(&bind_addr, 5);
         let rpc_addr = SocketAddr::new(bind_addr.ip(), rpc_port::DEFAULT_RPC_PORT);
         let rpc_pubsub_addr = SocketAddr::new(bind_addr.ip(), rpc_port::DEFAULT_RPC_PUBSUB_PORT);
         Self::new(
@@ -174,6 +182,7 @@ impl ContactInfo {
             gossip_addr,
             tvu_addr,
             tvu_forwards_addr,
+            repair,
             tpu_addr,
             tpu_forwards_addr,
             "0.0.0.0:0".parse().unwrap(),
@@ -195,6 +204,7 @@ impl ContactInfo {
         Self::new(
             &Pubkey::default(),
             *gossip_addr,
+            daddr,
             daddr,
             daddr,
             daddr,
@@ -245,6 +255,7 @@ impl Signable for ContactInfo {
             tvu: SocketAddr,
             tpu: SocketAddr,
             tpu_forwards: SocketAddr,
+            repair: SocketAddr,
             storage_addr: SocketAddr,
             rpc: SocketAddr,
             rpc_pubsub: SocketAddr,
@@ -259,6 +270,7 @@ impl Signable for ContactInfo {
             tpu: me.tpu,
             storage_addr: me.storage_addr,
             tpu_forwards: me.tpu_forwards,
+            repair: me.repair,
             rpc: me.rpc,
             rpc_pubsub: me.rpc_pubsub,
             wallclock: me.wallclock,


### PR DESCRIPTION
#### Problem

Repairman protocol sends shreds to a node's TVU. The node then sends those shreds through Turbine causing unnecessary packet duplication and traffic. 

#### Summary of Changes

Advertise the repair socket in Contact Info. Send repairman responses to the repair socket so that Validators don't send them through turbine again. 