### PR TITLE
Get rid of verified packets and use the Meta::discard flag

### DIFF
--- a/banking_bench/src/main.rs
+++ b/banking_bench/src/main.rs
@@ -25,7 +25,6 @@ use solana_sdk::signature::Signature;
 use solana_sdk::system_transaction;
 use solana_sdk::timing::{duration_as_us, timestamp};
 use solana_sdk::transaction::Transaction;
-use std::iter;
 use std::sync::atomic::Ordering;
 use std::sync::mpsc::Receiver;
 use std::sync::{Arc, Mutex, RwLock};
@@ -142,13 +141,7 @@ fn main() {
         assert!(r.is_ok(), "sanity parallel execution");
     }
     bank.clear_signatures();
-    let mut verified: Vec<_> = to_packets_chunked(&transactions.clone(), PACKETS_PER_BATCH)
-        .into_iter()
-        .map(|x| {
-            let len = x.packets.len();
-            (x, iter::repeat(1).take(len).collect())
-        })
-        .collect();
+    let mut verified: Vec<_> = to_packets_chunked(&transactions.clone(), PACKETS_PER_BATCH);
     let ledger_path = get_tmp_ledger_path!();
     {
         let blocktree = Arc::new(
@@ -209,7 +202,7 @@ fn main() {
                     index,
                 );
                 for xv in v {
-                    sent += xv.0.packets.len();
+                    sent += xv.packets.len();
                 }
                 verified_sender.send(v.to_vec()).unwrap();
             }
@@ -288,13 +281,7 @@ fn main() {
                     let sig: Vec<u8> = (0..64).map(|_| thread_rng().gen()).collect();
                     tx.signatures[0] = Signature::new(&sig[0..64]);
                 }
-                verified = to_packets_chunked(&transactions.clone(), PACKETS_PER_BATCH)
-                    .into_iter()
-                    .map(|x| {
-                        let len = x.packets.len();
-                        (x, iter::repeat(1).take(len).collect())
-                    })
-                    .collect();
+                verified = to_packets_chunked(&transactions.clone(), PACKETS_PER_BATCH);
             }
 
             start += chunk_len;

--- a/core/benches/banking_stage.rs
+++ b/core/benches/banking_stage.rs
@@ -30,7 +30,6 @@ use solana_sdk::system_instruction;
 use solana_sdk::system_transaction;
 use solana_sdk::timing::{duration_as_us, timestamp};
 use solana_sdk::transaction::Transaction;
-use std::iter;
 use std::sync::atomic::Ordering;
 use std::sync::mpsc::Receiver;
 use std::sync::{Arc, RwLock};
@@ -184,13 +183,7 @@ fn bench_banking(bencher: &mut Bencher, tx_type: TransactionType) {
         assert!(r.is_ok(), "sanity parallel execution");
     }
     bank.clear_signatures();
-    let verified: Vec<_> = to_packets_chunked(&transactions.clone(), PACKETS_PER_BATCH)
-        .into_iter()
-        .map(|x| {
-            let len = x.packets.len();
-            (x, iter::repeat(1).take(len).collect())
-        })
-        .collect();
+    let verified: Vec<_> = to_packets_chunked(&transactions.clone(), PACKETS_PER_BATCH);
     let ledger_path = get_tmp_ledger_path!();
     {
         let blocktree = Arc::new(
@@ -229,7 +222,7 @@ fn bench_banking(bencher: &mut Bencher, tx_type: TransactionType) {
                     v.len(),
                 );
                 for xv in v {
-                    sent += xv.0.packets.len();
+                    sent += xv.packets.len();
                 }
                 verified_sender.send(v.to_vec()).unwrap();
             }

--- a/core/benches/sigverify_stage.rs
+++ b/core/benches/sigverify_stage.rs
@@ -71,8 +71,8 @@ fn bench_sigverify_stage(bencher: &mut Bencher) {
         loop {
             if let Ok(mut verifieds) = verified_r.recv_timeout(Duration::from_millis(10)) {
                 while let Some(v) = verifieds.pop() {
-                    received += v.0.packets.len();
-                    batches.push(v.0);
+                    received += v.packets.len();
+                    batches.push(v);
                 }
                 if received >= sent_len {
                     break;

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -1068,9 +1068,12 @@ mod tests {
     }
 
     pub fn convert_from_old_verified(mut with_vers: Vec<(Packets, Vec<u8>)>) -> Vec<Packets> {
-        with_vers
-            .iter_mut()
-            .for_each(|(b, v)| b.packets.iter_mut().zip(v).for_each(|(p, f)| p.meta.discard = *f == 0));
+        with_vers.iter_mut().for_each(|(b, v)| {
+            b.packets
+                .iter_mut()
+                .zip(v)
+                .for_each(|(p, f)| p.meta.discard = *f == 0)
+        });
         with_vers.into_iter().map(|(b, _)| b).collect()
     }
 

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -9,7 +9,6 @@ use crate::{
     poh_service::PohService,
     result::{Error, Result},
     service::Service,
-    sigverify_stage::VerifiedPackets,
 };
 use bincode::deserialize;
 use crossbeam_channel::{Receiver as CrossbeamReceiver, RecvTimeoutError};
@@ -74,8 +73,8 @@ impl BankingStage {
     pub fn new(
         cluster_info: &Arc<RwLock<ClusterInfo>>,
         poh_recorder: &Arc<Mutex<PohRecorder>>,
-        verified_receiver: CrossbeamReceiver<VerifiedPackets>,
-        verified_vote_receiver: CrossbeamReceiver<VerifiedPackets>,
+        verified_receiver: CrossbeamReceiver<Vec<Packets>>,
+        verified_vote_receiver: CrossbeamReceiver<Vec<Packets>>,
     ) -> Self {
         Self::new_num_threads(
             cluster_info,
@@ -89,8 +88,8 @@ impl BankingStage {
     fn new_num_threads(
         cluster_info: &Arc<RwLock<ClusterInfo>>,
         poh_recorder: &Arc<Mutex<PohRecorder>>,
-        verified_receiver: CrossbeamReceiver<VerifiedPackets>,
-        verified_vote_receiver: CrossbeamReceiver<VerifiedPackets>,
+        verified_receiver: CrossbeamReceiver<Vec<Packets>>,
+        verified_vote_receiver: CrossbeamReceiver<Vec<Packets>>,
         num_threads: u32,
     ) -> Self {
         let batch_limit = TOTAL_BUFFERED_PACKETS / ((num_threads - 1) as usize * PACKETS_PER_BATCH);
@@ -345,7 +344,7 @@ impl BankingStage {
 
     pub fn process_loop(
         my_pubkey: Pubkey,
-        verified_receiver: &CrossbeamReceiver<VerifiedPackets>,
+        verified_receiver: &CrossbeamReceiver<Vec<Packets>>,
         poh_recorder: &Arc<Mutex<PohRecorder>>,
         cluster_info: &Arc<RwLock<ClusterInfo>>,
         recv_start: &mut Instant,
@@ -793,17 +792,23 @@ impl BankingStage {
         filtered_unprocessed_packet_indexes
     }
 
-    fn generate_packet_indexes(vers: Vec<u8>) -> Vec<usize> {
+    fn generate_packet_indexes(vers: &[Packet]) -> Vec<usize> {
         vers.iter()
             .enumerate()
-            .filter_map(|(index, ver)| if *ver != 0 { Some(index) } else { None })
+            .filter_map(|(index, ver)| {
+                if ver.meta.discard == false {
+                    Some(index)
+                } else {
+                    None
+                }
+            })
             .collect()
     }
 
     /// Process the incoming packets
     pub fn process_packets(
         my_pubkey: &Pubkey,
-        verified_receiver: &CrossbeamReceiver<VerifiedPackets>,
+        verified_receiver: &CrossbeamReceiver<Vec<Packets>>,
         poh: &Arc<Mutex<PohRecorder>>,
         recv_start: &mut Instant,
         recv_timeout: Duration,
@@ -815,7 +820,7 @@ impl BankingStage {
         recv_time.stop();
 
         let mms_len = mms.len();
-        let count: usize = mms.iter().map(|x| x.1.len()).sum();
+        let count: usize = mms.iter().map(|x| x.packets.len()).sum();
         debug!(
             "@{:?} process start stalled for: {:?}ms txs: {} id: {}",
             timestamp(),
@@ -830,8 +835,8 @@ impl BankingStage {
         let mut mms_iter = mms.into_iter();
         let mut unprocessed_packets = vec![];
         let mut dropped_batches_count = 0;
-        while let Some((msgs, vers)) = mms_iter.next() {
-            let packet_indexes = Self::generate_packet_indexes(vers);
+        while let Some(msgs) = mms_iter.next() {
+            let packet_indexes = Self::generate_packet_indexes(&msgs.packets);
             let bank = poh.lock().unwrap().bank();
             if bank.is_none() {
                 Self::push_unprocessed(
@@ -863,8 +868,8 @@ impl BankingStage {
                 let next_leader = poh.lock().unwrap().next_slot_leader();
                 // Walk thru rest of the transactions and filter out the invalid (e.g. too old) ones
                 #[allow(clippy::while_let_on_iterator)]
-                while let Some((msgs, vers)) = mms_iter.next() {
-                    let packet_indexes = Self::generate_packet_indexes(vers);
+                while let Some(msgs) = mms_iter.next() {
+                    let packet_indexes = Self::generate_packet_indexes(&msgs.packets);
                     let unprocessed_indexes = Self::filter_unprocessed_packets(
                         &bank,
                         &msgs,
@@ -1062,6 +1067,13 @@ mod tests {
         Blocktree::destroy(&ledger_path).unwrap();
     }
 
+    pub fn convert_from_old_verified(mut with_vers: Vec<(Packets, Vec<u8>)>) -> Vec<Packets> {
+        with_vers
+            .iter_mut()
+            .for_each(|(b, v)| b.packets.iter_mut().zip(v).for_each(|(p, f)| p.meta.discard = *f == 0));
+        with_vers.into_iter().map(|(b, _)| b).collect()
+    }
+
     #[test]
     fn test_banking_stage_entries_only() {
         solana_logger::setup();
@@ -1122,7 +1134,7 @@ mod tests {
                 .into_iter()
                 .map(|packets| (packets, vec![0u8, 1u8, 1u8]))
                 .collect();
-
+            let packets = convert_from_old_verified(packets);
             verified_sender // no_ver, anf, tx
                 .send(packets)
                 .unwrap();
@@ -1194,6 +1206,7 @@ mod tests {
             .into_iter()
             .map(|packets| (packets, vec![1u8]))
             .collect();
+        let packets = convert_from_old_verified(packets);
         verified_sender.send(packets).unwrap();
 
         // Process a second batch that uses the same from account, so conflicts with above TX
@@ -1204,6 +1217,7 @@ mod tests {
             .into_iter()
             .map(|packets| (packets, vec![1u8]))
             .collect();
+        let packets = convert_from_old_verified(packets);
         verified_sender.send(packets).unwrap();
 
         let (vote_sender, vote_receiver) = unbounded();

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -796,7 +796,7 @@ impl BankingStage {
         vers.iter()
             .enumerate()
             .filter_map(|(index, ver)| {
-                if ver.meta.discard == false {
+                if !ver.meta.discard {
                     Some(index)
                 } else {
                     None

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -795,13 +795,15 @@ impl BankingStage {
     fn generate_packet_indexes(vers: &[Packet]) -> Vec<usize> {
         vers.iter()
             .enumerate()
-            .filter_map(|(index, ver)| {
-                if !ver.meta.discard {
-                    Some(index)
-                } else {
-                    None
-                }
-            })
+            .filter_map(
+                |(index, ver)| {
+                    if !ver.meta.discard {
+                        Some(index)
+                    } else {
+                        None
+                    }
+                },
+            )
             .collect()
     }
 

--- a/core/src/cluster_info_vote_listener.rs
+++ b/core/src/cluster_info_vote_listener.rs
@@ -2,7 +2,7 @@ use crate::cluster_info::{ClusterInfo, GOSSIP_SLEEP_MILLIS};
 use crate::poh_recorder::PohRecorder;
 use crate::result::Result;
 use crate::service::Service;
-use crate::sigverify_stage::VerifiedPackets;
+use crate::packet::Packets;
 use crate::{packet, sigverify};
 use crossbeam_channel::Sender as CrossbeamSender;
 use solana_metrics::inc_new_counter_debug;
@@ -20,7 +20,7 @@ impl ClusterInfoVoteListener {
         exit: &Arc<AtomicBool>,
         cluster_info: Arc<RwLock<ClusterInfo>>,
         sigverify_disabled: bool,
-        sender: CrossbeamSender<VerifiedPackets>,
+        sender: CrossbeamSender<Vec<Packets>>,
         poh_recorder: &Arc<Mutex<PohRecorder>>,
     ) -> Self {
         let exit = exit.clone();
@@ -45,7 +45,7 @@ impl ClusterInfoVoteListener {
         exit: Arc<AtomicBool>,
         cluster_info: &Arc<RwLock<ClusterInfo>>,
         sigverify_disabled: bool,
-        sender: &CrossbeamSender<VerifiedPackets>,
+        sender: &CrossbeamSender<Vec<Packets>>,
         poh_recorder: Arc<Mutex<PohRecorder>>,
     ) -> Result<()> {
         let mut last_ts = 0;
@@ -57,14 +57,20 @@ impl ClusterInfoVoteListener {
             if poh_recorder.lock().unwrap().has_bank() {
                 last_ts = new_ts;
                 inc_new_counter_debug!("cluster_info_vote_listener-recv_count", votes.len());
-                let msgs = packet::to_packets(&votes);
+                let mut msgs = packet::to_packets(&votes);
                 if !msgs.is_empty() {
                     let r = if sigverify_disabled {
                         sigverify::ed25519_verify_disabled(&msgs)
                     } else {
                         sigverify::ed25519_verify_cpu(&msgs)
                     };
-                    sender.send(msgs.into_iter().zip(r).collect())?;
+                    msgs.iter_mut().zip(r).for_each(|(b, v)| {
+                        b.packets
+                            .iter_mut()
+                            .zip(v)
+                            .for_each(|(p, f)| p.meta.discard = f == 0)
+                    });
+                    sender.send(msgs)?;
                 }
             }
             sleep(Duration::from_millis(GOSSIP_SLEEP_MILLIS));

--- a/core/src/cluster_info_vote_listener.rs
+++ b/core/src/cluster_info_vote_listener.rs
@@ -64,12 +64,7 @@ impl ClusterInfoVoteListener {
                     } else {
                         sigverify::ed25519_verify_cpu(&msgs)
                     };
-                    msgs.iter_mut().zip(r).for_each(|(b, v)| {
-                        b.packets
-                            .iter_mut()
-                            .zip(v)
-                            .for_each(|(p, f)| p.meta.discard = f == 0)
-                    });
+                    sigverify::mark_disabled(&mut msgs, &r);
                     sender.send(msgs)?;
                 }
             }

--- a/core/src/cluster_info_vote_listener.rs
+++ b/core/src/cluster_info_vote_listener.rs
@@ -1,8 +1,8 @@
 use crate::cluster_info::{ClusterInfo, GOSSIP_SLEEP_MILLIS};
+use crate::packet::Packets;
 use crate::poh_recorder::PohRecorder;
 use crate::result::Result;
 use crate::service::Service;
-use crate::packet::Packets;
 use crate::{packet, sigverify};
 use crossbeam_channel::Sender as CrossbeamSender;
 use solana_metrics::inc_new_counter_debug;

--- a/core/src/retransmit_stage.rs
+++ b/core/src/retransmit_stage.rs
@@ -2,11 +2,11 @@
 
 use crate::{
     cluster_info::{compute_retransmit_peers, ClusterInfo, DATA_PLANE_FANOUT},
+    packet::Packets,
     repair_service::RepairStrategy,
     result::{Error, Result},
     service::Service,
     streamer::PacketReceiver,
-    packet::Packets,
     window_service::{should_retransmit_and_persist, WindowService},
 };
 use crossbeam_channel::Receiver as CrossbeamReceiver;

--- a/core/src/retransmit_stage.rs
+++ b/core/src/retransmit_stage.rs
@@ -5,8 +5,8 @@ use crate::{
     repair_service::RepairStrategy,
     result::{Error, Result},
     service::Service,
-    sigverify_stage::VerifiedPackets,
     streamer::PacketReceiver,
+    packet::Packets,
     window_service::{should_retransmit_and_persist, WindowService},
 };
 use crossbeam_channel::Receiver as CrossbeamReceiver;
@@ -208,7 +208,7 @@ impl RetransmitStage {
         cluster_info: &Arc<RwLock<ClusterInfo>>,
         retransmit_sockets: Arc<Vec<UdpSocket>>,
         repair_socket: Arc<UdpSocket>,
-        verified_receiver: CrossbeamReceiver<VerifiedPackets>,
+        verified_receiver: CrossbeamReceiver<Vec<Packets>>,
         exit: &Arc<AtomicBool>,
         completed_slots_receiver: CompletedSlotsReceiver,
         epoch_schedule: EpochSchedule,

--- a/core/src/sigverify.rs
+++ b/core/src/sigverify.rs
@@ -7,7 +7,7 @@
 use crate::cuda_runtime::PinnedVec;
 use crate::packet::{Packet, Packets};
 use crate::recycler::Recycler;
-use crate::sigverify_stage::{SigVerifier};
+use crate::sigverify_stage::SigVerifier;
 use bincode::serialized_size;
 use rayon::ThreadPool;
 use solana_ledger::perf_libs;
@@ -45,12 +45,12 @@ impl SigVerifier for TransactionSigVerifier {
 }
 
 pub fn mark_disabled(batches: &mut Vec<Packets>, r: &[Vec<u8>]) {
-                    batches.iter_mut().zip(r).for_each(|(b, v)| {
-                        b.packets
-                            .iter_mut()
-                            .zip(v)
-                            .for_each(|(p, f)| p.meta.discard = *f == 0)
-                    });
+    batches.iter_mut().zip(r).for_each(|(b, v)| {
+        b.packets
+            .iter_mut()
+            .zip(v)
+            .for_each(|(p, f)| p.meta.discard = *f == 0)
+    });
 }
 
 use solana_rayon_threadlimit::get_thread_count;

--- a/core/src/sigverify.rs
+++ b/core/src/sigverify.rs
@@ -7,7 +7,7 @@
 use crate::cuda_runtime::PinnedVec;
 use crate::packet::{Packet, Packets};
 use crate::recycler::Recycler;
-use crate::sigverify_stage::{SigVerifier, VerifiedPackets};
+use crate::sigverify_stage::{SigVerifier};
 use bincode::serialized_size;
 use rayon::ThreadPool;
 use solana_ledger::perf_libs;
@@ -37,10 +37,20 @@ impl Default for TransactionSigVerifier {
 }
 
 impl SigVerifier for TransactionSigVerifier {
-    fn verify_batch(&self, batch: Vec<Packets>) -> VerifiedPackets {
+    fn verify_batch(&self, mut batch: Vec<Packets>) -> Vec<Packets> {
         let r = ed25519_verify(&batch, &self.recycler, &self.recycler_out);
-        batch.into_iter().zip(r).collect()
+        mark_disabled(&mut batch, &r);
+        batch
     }
+}
+
+pub fn mark_disabled(batches: &mut Vec<Packets>, r: &[Vec<u8>]) {
+                    batches.iter_mut().zip(r).for_each(|(b, v)| {
+                        b.packets
+                            .iter_mut()
+                            .zip(v)
+                            .for_each(|(p, f)| p.meta.discard = *f == 0)
+                    });
 }
 
 use solana_rayon_threadlimit::get_thread_count;

--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -2,10 +2,10 @@
 //!   blocktree and retransmitting where required
 //!
 use crate::cluster_info::ClusterInfo;
+use crate::packet::Packets;
 use crate::repair_service::{RepairService, RepairStrategy};
 use crate::result::{Error, Result};
 use crate::service::Service;
-use crate::packet::Packets;
 use crate::streamer::PacketSender;
 use crossbeam_channel::{Receiver as CrossbeamReceiver, RecvTimeoutError};
 use rayon::iter::IntoParallelRefMutIterator;

--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -5,7 +5,7 @@ use crate::cluster_info::ClusterInfo;
 use crate::repair_service::{RepairService, RepairStrategy};
 use crate::result::{Error, Result};
 use crate::service::Service;
-use crate::sigverify_stage::VerifiedPackets;
+use crate::packet::Packets;
 use crate::streamer::PacketSender;
 use crossbeam_channel::{Receiver as CrossbeamReceiver, RecvTimeoutError};
 use rayon::iter::IntoParallelRefMutIterator;
@@ -67,7 +67,7 @@ pub fn should_retransmit_and_persist(
 fn recv_window<F>(
     blocktree: &Arc<Blocktree>,
     my_pubkey: &Pubkey,
-    verified_receiver: &CrossbeamReceiver<VerifiedPackets>,
+    verified_receiver: &CrossbeamReceiver<Vec<Packets>>,
     retransmit: &PacketSender,
     shred_filter: F,
     thread_pool: &ThreadPool,
@@ -78,10 +78,10 @@ where
 {
     let timer = Duration::from_millis(200);
     let mut packets = verified_receiver.recv_timeout(timer)?;
-    let mut total_packets: usize = packets.iter().map(|(p, _)| p.packets.len()).sum();
+    let mut total_packets: usize = packets.iter().map(|p| p.packets.len()).sum();
 
     while let Ok(mut more_packets) = verified_receiver.try_recv() {
-        let count: usize = more_packets.iter().map(|(p, _)| p.packets.len()).sum();
+        let count: usize = more_packets.iter().map(|p| p.packets.len()).sum();
         total_packets += count;
         packets.append(&mut more_packets)
     }
@@ -93,14 +93,12 @@ where
     let shreds: Vec<_> = thread_pool.install(|| {
         packets
             .par_iter_mut()
-            .flat_map(|(packets, sigs)| {
+            .flat_map(|packets| {
                 packets
                     .packets
                     .iter_mut()
-                    .zip(sigs.iter())
-                    .filter_map(|(packet, sigcheck)| {
-                        if *sigcheck == 0 {
-                            packet.meta.discard = true;
+                    .filter_map(|packet| {
+                        if packet.meta.discard {
                             inc_new_counter_debug!("streamer-recv_window-invalid_signature", 1);
                             None
                         } else if let Ok(shred) =
@@ -128,7 +126,7 @@ where
 
     trace!("{} num total shreds received: {}", my_pubkey, total_packets);
 
-    for (packets, _) in packets.into_iter() {
+    for packets in packets.into_iter() {
         if !packets.packets.is_empty() {
             // Ignore the send error, as the retransmit is optional (e.g. archivers don't retransmit)
             let _ = retransmit.send(packets);
@@ -174,7 +172,7 @@ impl WindowService {
     pub fn new<F>(
         blocktree: Arc<Blocktree>,
         cluster_info: Arc<RwLock<ClusterInfo>>,
-        verified_receiver: CrossbeamReceiver<VerifiedPackets>,
+        verified_receiver: CrossbeamReceiver<Vec<Packets>>,
         retransmit: PacketSender,
         repair_socket: Arc<UdpSocket>,
         exit: &Arc<AtomicBool>,
@@ -410,7 +408,7 @@ mod test {
     }
 
     fn make_test_window(
-        verified_receiver: CrossbeamReceiver<VerifiedPackets>,
+        verified_receiver: CrossbeamReceiver<Vec<Packets>>,
         exit: Arc<AtomicBool>,
     ) -> WindowService {
         let blocktree_path = get_tmp_ledger_path!();
@@ -453,24 +451,18 @@ mod test {
             })
             .collect();
         let mut packets = Packets::new(packets);
-        let verified = vec![1; packets.packets.len()];
-        packet_sender
-            .send(vec![(packets.clone(), verified)])
-            .unwrap();
+        packet_sender.send(vec![packets.clone()]).unwrap();
         sleep(Duration::from_millis(500));
 
         // add some empty packets to the data set. These should fail to deserialize
         packets.packets.append(&mut vec![Packet::default(); 10]);
         packets.packets.shuffle(&mut thread_rng());
-        let verified = vec![1; packets.packets.len()];
-        packet_sender
-            .send(vec![(packets.clone(), verified)])
-            .unwrap();
+        packet_sender.send(vec![packets.clone()]).unwrap();
         sleep(Duration::from_millis(500));
 
         // send 1 empty packet that cannot deserialize into a shred
         packet_sender
-            .send(vec![(Packets::new(vec![Packet::default(); 1]), vec![1])])
+            .send(vec![Packets::new(vec![Packet::default(); 1])])
             .unwrap();
         sleep(Duration::from_millis(500));
 


### PR DESCRIPTION
#### Problem

VerifiedPackets is useless now that meta caries a discard flag.

#### Summary of Changes

Get rid of VerifiedPackets

Fixes #
