### PR TITLE
move system_instruction::transfer() `to` credit-debit

### DIFF
--- a/sdk/src/system_instruction.rs
+++ b/sdk/src/system_instruction.rs
@@ -83,7 +83,7 @@ pub fn assign(from_pubkey: &Pubkey, program_id: &Pubkey) -> Instruction {
 pub fn transfer(from_pubkey: &Pubkey, to_pubkey: &Pubkey, lamports: u64) -> Instruction {
     let account_metas = vec![
         AccountMeta::new(*from_pubkey, true),
-        AccountMeta::new_credit_only(*to_pubkey, false),
+        AccountMeta::new(*to_pubkey, false),
     ];
     Instruction::new(
         system_program::id(),


### PR DESCRIPTION
#### Problem
 committing large numbers of transfers at the end of a block is slower than committing
 as we go


Fixes #6712 