### PR TITLE
WIP: Fix Move Local Cluster Bench Tps test

### DIFF
--- a/bench-tps/src/bench.rs
+++ b/bench-tps/src/bench.rs
@@ -232,6 +232,8 @@ where
         total_tx_sent_count.load(Ordering::Relaxed),
     );
 
+    println!("MAXES({:#?})", maxes.read().unwrap());
+
     let r_maxes = maxes.read().unwrap();
     r_maxes.first().unwrap().1.txs
 }

--- a/bench-tps/src/bench.rs
+++ b/bench-tps/src/bench.rs
@@ -159,6 +159,9 @@ where
     let mut i = keypair0_balance;
     let mut blockhash = Hash::default();
     let mut blockhash_time = Instant::now();
+
+    println!("Starting to send txs at                {:?}", start);
+
     while start.elapsed() < duration {
         // ping-pong between source and destination accounts for each loop iteration
         // this seems to be faster than trying to determine the balance of individual
@@ -206,6 +209,10 @@ where
 
     // Stop the sampling threads so it will collect the stats
     exit_signal.store(true, Ordering::Relaxed);
+    println!(
+        "Stopped the sampling threads at        {:?}",
+        Instant::now()
+    );
 
     info!("Waiting for validator threads...");
     for t in v_threads {

--- a/ci/buildkite.yml
+++ b/ci/buildkite.yml
@@ -2,40 +2,40 @@
 #
 # Release tags use buildkite-release.yml instead
 steps:
-  - command: "ci/shellcheck.sh"
-    name: "shellcheck"
-    timeout_in_minutes: 5
-  - command: ". ci/rust-version.sh; ci/docker-run.sh $$rust_nightly_docker_image ci/test-checks.sh"
-    name: "checks"
-    timeout_in_minutes: 35
-  - wait
-  - command: "ci/test-stable-perf.sh"
-    name: "stable-perf"
-    timeout_in_minutes: 40
-    artifact_paths: "log-*.txt"
-    agents:
-      - "queue=cuda"
-  - command: "ci/test-bench.sh"
-    name: "bench"
-    timeout_in_minutes: 60
+#  - command: "ci/shellcheck.sh"
+#    name: "shellcheck"
+#    timeout_in_minutes: 5
+#  - command: ". ci/rust-version.sh; ci/docker-run.sh $$rust_nightly_docker_image ci/test-checks.sh"
+#    name: "checks"
+#    timeout_in_minutes: 35
+#  - wait
+#  - command: "ci/test-stable-perf.sh"
+#    name: "stable-perf"
+#    timeout_in_minutes: 40
+#    artifact_paths: "log-*.txt"
+#    agents:
+#      - "queue=cuda"
+#  - command: "ci/test-bench.sh"
+#    name: "bench"
+#    timeout_in_minutes: 60
   - command: ". ci/rust-version.sh; ci/docker-run.sh $$rust_stable_docker_image ci/test-stable.sh"
     name: "stable"
     timeout_in_minutes: 40
     artifact_paths: "log-*.txt"
-  - command: ". ci/rust-version.sh; ci/docker-run.sh $$rust_stable_docker_image ci/test-local-cluster.sh"
-    name: "local-cluster"
-    timeout_in_minutes: 40
-    artifact_paths: "log-*.txt"
-  - command: ". ci/rust-version.sh; ci/docker-run.sh $$rust_nightly_docker_image ci/test-coverage.sh"
-    name: "coverage"
-    timeout_in_minutes: 40
-  - wait
-  - trigger: "solana-secondary"
-    branches: "!pull/*"
-    async: true
-    build:
-      message: "${BUILDKITE_MESSAGE}"
-      commit: "${BUILDKITE_COMMIT}"
-      branch: "${BUILDKITE_BRANCH}"
-      env:
-        TRIGGERED_BUILDKITE_TAG: "${BUILDKITE_TAG}"
+#  - command: ". ci/rust-version.sh; ci/docker-run.sh $$rust_stable_docker_image ci/test-local-cluster.sh"
+#    name: "local-cluster"
+#    timeout_in_minutes: 40
+#    artifact_paths: "log-*.txt"
+#  - command: ". ci/rust-version.sh; ci/docker-run.sh $$rust_nightly_docker_image ci/test-coverage.sh"
+#    name: "coverage"
+#    timeout_in_minutes: 40
+#  - wait
+#  - trigger: "solana-secondary"
+#    branches: "!pull/*"
+#    async: true
+#    build:
+#      message: "${BUILDKITE_MESSAGE}"
+#      commit: "${BUILDKITE_COMMIT}"
+#      branch: "${BUILDKITE_BRANCH}"
+#      env:
+#        TRIGGERED_BUILDKITE_TAG: "${BUILDKITE_TAG}"

--- a/ci/test-stable.sh
+++ b/ci/test-stable.sh
@@ -98,5 +98,5 @@ echo --- ci/localnet-sanity.sh
 export CARGO_TOOLCHAIN=+"$rust_stable"
 (
   set -x
-  ci/localnet-sanity.sh -x
+#  ci/localnet-sanity.sh -x
 )

--- a/ci/test-stable.sh
+++ b/ci/test-stable.sh
@@ -31,11 +31,11 @@ testName=$(basename "$0" .sh)
 case $testName in
 test-stable)
   echo "Executing $testName"
-  _ cargo +"$rust_stable" test --all --exclude solana-local-cluster ${V:+--verbose} -- --nocapture
+#  _ cargo +"$rust_stable" test --all --exclude solana-local-cluster ${V:+--verbose} -- --nocapture
   _ cargo +"$rust_stable" test --manifest-path local_cluster/Cargo.toml --features=move ${V:+--verbose} test_bench_tps_local_cluster_move -- --nocapture
-  _ cargo +"$rust_stable" test --manifest-path programs/move_loader_api/Cargo.toml ${V:+--verbose} -- --nocapture
-  _ cargo +"$rust_stable" test --manifest-path programs/move_loader_program/Cargo.toml ${V:+--verbose} -- --nocapture
-  _ cargo +"$rust_stable" test --manifest-path programs/librapay_api/Cargo.toml ${V:+--verbose} -- --nocapture
+#  _ cargo +"$rust_stable" test --manifest-path programs/move_loader_api/Cargo.toml ${V:+--verbose} -- --nocapture
+#  _ cargo +"$rust_stable" test --manifest-path programs/move_loader_program/Cargo.toml ${V:+--verbose} -- --nocapture
+#  _ cargo +"$rust_stable" test --manifest-path programs/librapay_api/Cargo.toml ${V:+--verbose} -- --nocapture
   ;;
 test-stable-perf)
   echo "Executing $testName"

--- a/client/src/perf_utils.rs
+++ b/client/src/perf_utils.rs
@@ -32,6 +32,11 @@ pub fn sample_txs<T>(
     let initial_txs = client.get_transaction_count().expect("transaction count");
     let mut last_txs = initial_txs;
 
+    println!(
+        "Starting sample at slot {}",
+        client.get_slot().expect("Start slot")
+    );
+
     loop {
         total_elapsed = start_time.elapsed();
         let elapsed = now.elapsed();
@@ -80,6 +85,11 @@ pub fn sample_txs<T>(
                 .write()
                 .unwrap()
                 .push((client.tpu_addr(), stats));
+
+            println!(
+                "Stopped sampling, slot is {}",
+                client.get_slot().expect("End slot")
+            );
             return;
         }
         sleep(Duration::from_secs(sample_period));

--- a/client/src/perf_utils.rs
+++ b/client/src/perf_utils.rs
@@ -6,7 +6,7 @@ use std::sync::{Arc, RwLock};
 use std::thread::sleep;
 use std::time::{Duration, Instant};
 
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct SampleStats {
     /// Maximum TPS reported by this node
     pub tps: f32,

--- a/client/src/perf_utils.rs
+++ b/client/src/perf_utils.rs
@@ -33,8 +33,9 @@ pub fn sample_txs<T>(
     let mut last_txs = initial_txs;
 
     println!(
-        "Starting sample at slot {}",
-        client.get_slot().expect("Start slot")
+        "Starting sample at slot {}, time       {:?}",
+        client.get_slot().expect("Start slot"),
+        now
     );
 
     loop {
@@ -87,8 +88,9 @@ pub fn sample_txs<T>(
                 .push((client.tpu_addr(), stats));
 
             println!(
-                "Stopped sampling, slot is {}",
-                client.get_slot().expect("End slot")
+                "Stopped sampling, slot is {}, time is {:?}",
+                client.get_slot().expect("End slot"),
+                now
             );
             return;
         }

--- a/local_cluster/src/tests/bench_tps.rs
+++ b/local_cluster/src/tests/bench_tps.rs
@@ -113,7 +113,7 @@ fn test_bench_tps_local_cluster_solana() {
 fn test_bench_tps_local_cluster_move() {
     let mut config = Config::default();
     config.tx_count = 100;
-    config.duration = Duration::from_secs(25);
+    config.duration = Duration::from_secs(30);
     config.use_move = true;
 
     test_bench_tps_local_cluster(config);


### PR DESCRIPTION
#### Problem

The `tests::bench_tps::test_bench_tps_local_cluster_move` test fails often on CI.

#### Summary of Changes

Add a ledger dump to confirm that by increasing the timeout we are actually counting enough move transactions, not just counting vote transactions.

Fixes #6618
