### PR TITLE
Better output layout for iftop logs

### DIFF
--- a/log-analyzer/src/main.rs
+++ b/log-analyzer/src/main.rs
@@ -33,11 +33,13 @@ impl Default for LogLine {
 impl LogLine {
     fn output(a: &str, b: &str, v1: u128, v2: u128) -> String {
         format!(
-            "Lost {} bytes ({} - {}, {}%)  from {} to {}",
-            v1 - v2,
-            v1,
-            v2,
+            "Lost {}%, {}, ({} - {}), sender {}, receiver {}",
             ((v1 - v2) * 100 / v1),
+            Byte::from_bytes(v1 - v2)
+                .get_appropriate_unit(true)
+                .to_string(),
+            Byte::from_bytes(v1).get_appropriate_unit(true).to_string(),
+            Byte::from_bytes(v2).get_appropriate_unit(true).to_string(),
             a,
             b
         )


### PR DESCRIPTION
#### Problem
Processed logs from `iftop` are hard to read.

#### Summary of Changes
Improved the layout of the output. Also, use KB/MB to show bytes, instead of raw value.
The old log can be seen in https://github.com/solana-labs/solana/pull/6684

The new layout looks like this
```
$ ./target/debug/solana-log-analyzer analyze -f ./iftop-logs/ | grep -v 35.231.14.175 | grep -v 8001 | sort -k 2 -g
Lost 0%, 292.97 KiB, (29.37 MiB - 29.09 MiB), sender 10.1.1.21:8843, receiver 10.1.1.22:8903
Lost 0%, 292.97 KiB, (32.14 MiB - 31.85 MiB), sender 10.1.1.22:8556, receiver 10.1.1.21:8437
Lost 0%, 292.97 KiB, (32.71 MiB - 32.42 MiB), sender 10.1.1.24:9937, receiver 10.1.1.22:8556
Lost 0%, 9.76 KiB, (2.68 MiB - 2.67 MiB), sender 10.1.1.23:8899, receiver 10.1.1.20:40762
Lost 0%, 9.76 KiB, (2.68 MiB - 2.67 MiB), sender 10.1.1.23:8899, receiver 10.1.1.21:59442
Lost 0%, 9.76 KiB, (5.55 MiB - 5.54 MiB), sender 10.1.1.23:8899, receiver 10.1.1.20:40764
Lost 0%, 97.66 KiB, (32.14 MiB - 32.04 MiB), sender 10.1.1.24:9937, receiver 10.1.1.21:8843
Lost 1%, 390.62 KiB, (29.37 MiB - 28.99 MiB), sender 10.1.1.22:8903, receiver 10.1.1.24:8163
Lost 1%, 390.62 KiB, (30.04 MiB - 29.66 MiB), sender 10.1.1.22:8903, receiver 10.1.1.20:8966
Lost 1%, 390.62 KiB, (33.28 MiB - 32.90 MiB), sender 10.1.1.23:9844, receiver 10.1.1.21:9576
Lost 1%, 390.62 KiB, (35.67 MiB - 35.29 MiB), sender 10.1.1.24:8030, receiver 10.1.1.23:9844
Lost 1%, 488.28 KiB, (31.85 MiB - 31.38 MiB), sender 10.1.1.21:8437, receiver 10.1.1.24:8163
Lost 1%, 488.28 KiB, (31.95 MiB - 31.47 MiB), sender 10.1.1.20:8471, receiver 10.1.1.22:8556
Lost 1%, 585.94 KiB, (32.23 MiB - 31.66 MiB), sender 10.1.1.23:9844, receiver 10.1.1.22:8875
Lost 2%, 781.25 KiB, (31.85 MiB - 31.09 MiB), sender 10.1.1.21:8437, receiver 10.1.1.20:8966
Lost 2%, 878.91 KiB, (31.66 MiB - 30.80 MiB), sender 10.1.1.20:8471, receiver 10.1.1.24:8163
Lost 2%, 878.91 KiB, (31.66 MiB - 30.80 MiB), sender 10.1.1.24:9937, receiver 10.1.1.20:8966
Lost 2%, 878.91 KiB, (31.76 MiB - 30.90 MiB), sender 10.1.1.20:8471, receiver 10.1.1.21:8843
Lost 3%, 1.14 MiB, (30.99 MiB - 29.85 MiB), sender 10.1.1.23:9844, receiver 10.1.1.20:8776
Lost 5%, 683.59 KiB, (11.54 MiB - 10.87 MiB), sender 10.1.1.24:8163, receiver 10.1.1.23:9771
Lost 5%, 976.56 KiB, (17.26 MiB - 16.31 MiB), sender 10.1.1.23:9771, receiver 10.1.1.22:8556
Lost 6%, 498.05 KiB, (7.55 MiB - 7.07 MiB), sender 10.1.1.23:8110, receiver 10.1.1.24:9557
Lost 7%, 517.58 KiB, (6.69 MiB - 6.19 MiB), sender 10.1.1.21:8406, receiver 10.1.1.23:8110
Lost 11%, 1.34 MiB, (12.11 MiB - 10.78 MiB), sender 10.1.1.23:9771, receiver 10.1.1.21:8843
Lost 13%, 2.38 MiB, (18.31 MiB - 15.93 MiB), sender 10.1.1.23:9771, receiver 10.1.1.20:8966
Lost 33%, 498.05 KiB, (1.44 MiB - 976.56 KiB), sender 10.1.1.20:8770, receiver 10.1.1.23:8110
Lost 48%, 503.91 KiB, (1.02 MiB - 541.02 KiB), sender 10.1.1.22:9011, receiver 10.1.1.23:8110
```
Fixes #
