### PR TITLE
Use Slot and Epoch type aliases instead of raw u64

### DIFF
--- a/client/src/rpc_request.rs
+++ b/client/src/rpc_request.rs
@@ -1,11 +1,12 @@
 use serde_json::{json, Value};
+use solana_sdk::clock::{Epoch, Slot};
 use std::{error, fmt};
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct RpcEpochInfo {
     /// The current epoch
-    pub epoch: u64,
+    pub epoch: Epoch,
 
     /// The current slot, relative to the start of the current epoch
     pub slot_index: u64,
@@ -14,7 +15,7 @@ pub struct RpcEpochInfo {
     pub slots_in_epoch: u64,
 
     /// The absolute current slot
-    pub absolute_slot: u64,
+    pub absolute_slot: Slot,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
@@ -46,7 +47,7 @@ pub struct RpcVoteAccountInfo {
     pub last_vote: u64,
 
     /// Current root slot for this vote account (0 if not root slot exists)
-    pub root_slot: u64,
+    pub root_slot: Slot,
 }
 
 #[derive(Debug, PartialEq)]

--- a/core/benches/blocktree.rs
+++ b/core/benches/blocktree.rs
@@ -7,9 +7,11 @@ extern crate test;
 extern crate solana_ledger;
 
 use rand::Rng;
-use solana_ledger::blocktree::{entries_to_test_shreds, get_tmp_ledger_path, Blocktree};
-use solana_ledger::entry::{create_ticks, Entry};
-use solana_sdk::hash::Hash;
+use solana_ledger::{
+    blocktree::{entries_to_test_shreds, get_tmp_ledger_path, Blocktree},
+    entry::{create_ticks, Entry},
+};
+use solana_sdk::{clock::Slot, hash::Hash};
 use std::path::Path;
 use test::Bencher;
 
@@ -30,7 +32,7 @@ fn setup_read_bench(
     blocktree: &mut Blocktree,
     num_small_shreds: u64,
     num_large_shreds: u64,
-    slot: u64,
+    slot: Slot,
 ) {
     // Make some big and small entries
     let entries = create_ticks(

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -23,7 +23,7 @@ use solana_runtime::{accounts_db::ErrorCounters, bank::Bank, transaction_batch::
 use solana_sdk::clock::MAX_TRANSACTION_FORWARDING_DELAY_GPU;
 use solana_sdk::{
     clock::{
-        DEFAULT_TICKS_PER_SECOND, DEFAULT_TICKS_PER_SLOT, MAX_PROCESSING_AGE,
+        Slot, DEFAULT_TICKS_PER_SECOND, DEFAULT_TICKS_PER_SLOT, MAX_PROCESSING_AGE,
         MAX_TRANSACTION_FORWARDING_DELAY,
     },
     poh_config::PohConfig,
@@ -428,7 +428,7 @@ impl BankingStage {
 
     #[allow(clippy::match_wild_err_arm)]
     fn record_transactions(
-        bank_slot: u64,
+        bank_slot: Slot,
         txs: &[Transaction],
         results: &[transaction::Result<()>],
         poh: &Arc<Mutex<PohRecorder>>,

--- a/core/src/blockstream.rs
+++ b/core/src/blockstream.rs
@@ -7,8 +7,7 @@ use bincode::serialize;
 use chrono::{SecondsFormat, Utc};
 use serde_json::json;
 use solana_ledger::entry::Entry;
-use solana_sdk::hash::Hash;
-use solana_sdk::pubkey::Pubkey;
+use solana_sdk::{clock::Slot, hash::Hash, pubkey::Pubkey};
 use std::cell::RefCell;
 use std::path::{Path, PathBuf};
 
@@ -72,14 +71,14 @@ impl EntryWriter for EntrySocket {
 pub trait BlockstreamEvents {
     fn emit_entry_event(
         &self,
-        slot: u64,
+        slot: Slot,
         tick_height: u64,
         leader_pubkey: &Pubkey,
         entries: &Entry,
     ) -> Result<()>;
     fn emit_block_event(
         &self,
-        slot: u64,
+        slot: Slot,
         tick_height: u64,
         leader_pubkey: &Pubkey,
         blockhash: Hash,
@@ -97,7 +96,7 @@ where
 {
     fn emit_entry_event(
         &self,
-        slot: u64,
+        slot: Slot,
         tick_height: u64,
         leader_pubkey: &Pubkey,
         entry: &Entry,
@@ -123,7 +122,7 @@ where
 
     fn emit_block_event(
         &self,
-        slot: u64,
+        slot: Slot,
         tick_height: u64,
         leader_pubkey: &Pubkey,
         blockhash: Hash,

--- a/core/src/broadcast_stage/broadcast_utils.rs
+++ b/core/src/broadcast_stage/broadcast_utils.rs
@@ -2,9 +2,12 @@ use crate::poh_recorder::WorkingBankEntry;
 use crate::result::Result;
 use solana_ledger::entry::Entry;
 use solana_runtime::bank::Bank;
-use std::sync::mpsc::Receiver;
-use std::sync::Arc;
-use std::time::{Duration, Instant};
+use solana_sdk::clock::Slot;
+use std::{
+    sync::mpsc::Receiver,
+    sync::Arc,
+    time::{Duration, Instant},
+};
 
 pub(super) struct ReceiveResults {
     pub entries: Vec<Entry>,
@@ -16,8 +19,8 @@ pub(super) struct ReceiveResults {
 #[derive(Copy, Clone)]
 pub struct UnfinishedSlotInfo {
     pub next_shred_index: u32,
-    pub slot: u64,
-    pub parent: u64,
+    pub slot: Slot,
+    pub parent: Slot,
 }
 
 /// This parameter tunes how many entries are received in one iteration of recv loop

--- a/core/src/broadcast_stage/standard_broadcast_run.rs
+++ b/core/src/broadcast_stage/standard_broadcast_run.rs
@@ -282,17 +282,22 @@ mod test {
     use super::*;
     use crate::cluster_info::{ClusterInfo, Node};
     use crate::genesis_utils::create_genesis_block;
-    use solana_ledger::blocktree::{get_tmp_ledger_path, Blocktree};
-    use solana_ledger::entry::create_ticks;
-    use solana_ledger::shred::max_ticks_per_n_shreds;
+    use solana_ledger::{
+        blocktree::{get_tmp_ledger_path, Blocktree},
+        entry::create_ticks,
+        shred::max_ticks_per_n_shreds,
+    };
     use solana_runtime::bank::Bank;
-    use solana_sdk::genesis_block::GenesisBlock;
-    use solana_sdk::signature::{Keypair, KeypairUtil};
+    use solana_sdk::{
+        clock::Slot,
+        genesis_block::GenesisBlock,
+        signature::{Keypair, KeypairUtil},
+    };
     use std::sync::{Arc, RwLock};
     use std::time::Duration;
 
     fn setup(
-        num_shreds_per_slot: u64,
+        num_shreds_per_slot: Slot,
     ) -> (
         Arc<Blocktree>,
         GenesisBlock,

--- a/core/src/chacha.rs
+++ b/core/src/chacha.rs
@@ -1,4 +1,5 @@
 use solana_ledger::blocktree::Blocktree;
+use solana_sdk::clock::Slot;
 use std::fs::File;
 use std::io;
 use std::io::{BufWriter, Write};
@@ -12,7 +13,7 @@ pub const CHACHA_KEY_SIZE: usize = 32;
 
 pub fn chacha_cbc_encrypt_ledger(
     blocktree: &Arc<Blocktree>,
-    start_slot: u64,
+    start_slot: Slot,
     slots_per_segment: u64,
     out_path: &Path,
     ivec: &mut [u8; CHACHA_BLOCK_SIZE],

--- a/core/src/packet.rs
+++ b/core/src/packet.rs
@@ -1,28 +1,32 @@
 //! The `packet` module defines data structures and methods to pull data from the network.
-use crate::cuda_runtime::PinnedVec;
-use crate::recvmmsg::{recv_mmsg, NUM_RCVMMSGS};
-use crate::recycler::{Recycler, Reset};
-use crate::result::{Error, Result};
+use crate::{
+    cuda_runtime::PinnedVec,
+    recvmmsg::{recv_mmsg, NUM_RCVMMSGS},
+    recycler::{Recycler, Reset},
+    result::{Error, Result},
+};
 use bincode;
 use byteorder::{ByteOrder, LittleEndian};
 use serde::Serialize;
 use solana_ledger::erasure::ErasureConfig;
 use solana_metrics::inc_new_counter_debug;
 pub use solana_sdk::packet::{Meta, Packet, PACKET_DATA_SIZE};
-use solana_sdk::pubkey::Pubkey;
-use solana_sdk::signature::Signable;
-use solana_sdk::signature::Signature;
-use std::borrow::Cow;
-use std::cmp;
-use std::fmt;
-use std::io;
-use std::io::Cursor;
-use std::mem;
-use std::mem::size_of;
-use std::net::{SocketAddr, UdpSocket};
-use std::ops::{Deref, DerefMut};
-use std::sync::{Arc, RwLock};
-use std::time::Instant;
+use solana_sdk::{
+    clock::Slot,
+    pubkey::Pubkey,
+    signature::{Signable, Signature},
+};
+use std::{
+    borrow::Cow,
+    cmp, fmt, io,
+    io::Cursor,
+    mem,
+    mem::size_of,
+    net::{SocketAddr, UdpSocket},
+    ops::{Deref, DerefMut},
+    sync::{Arc, RwLock},
+    time::Instant,
+};
 
 pub type SharedBlob = Arc<RwLock<Blob>>;
 pub type SharedBlobs = Vec<SharedBlob>;
@@ -531,7 +535,13 @@ impl Signable for Blob {
     }
 }
 
-pub fn index_blobs(blobs: &[SharedBlob], id: &Pubkey, mut blob_index: u64, slot: u64, parent: u64) {
+pub fn index_blobs(
+    blobs: &[SharedBlob],
+    id: &Pubkey,
+    mut blob_index: u64,
+    slot: Slot,
+    parent: Slot,
+) {
     // enumerate all the blobs, those are the indices
     for blob in blobs.iter() {
         let mut blob = blob.write().unwrap();

--- a/core/src/repair_service.rs
+++ b/core/src/repair_service.rs
@@ -4,9 +4,11 @@ use crate::{
     cluster_info::ClusterInfo, cluster_info_repair_listener::ClusterInfoRepairListener,
     result::Result, service::Service,
 };
-use solana_ledger::bank_forks::BankForks;
-use solana_ledger::blocktree::{Blocktree, CompletedSlotsReceiver, SlotMeta};
-use solana_sdk::{epoch_schedule::EpochSchedule, pubkey::Pubkey};
+use solana_ledger::{
+    bank_forks::BankForks,
+    blocktree::{Blocktree, CompletedSlotsReceiver, SlotMeta},
+};
+use solana_sdk::{clock::Slot, epoch_schedule::EpochSchedule, pubkey::Pubkey};
 use std::{
     collections::BTreeSet,
     net::UdpSocket,
@@ -241,7 +243,7 @@ impl RepairService {
 
     fn generate_repairs_for_slot(
         blocktree: &Blocktree,
-        slot: u64,
+        slot: Slot,
         slot_meta: &SlotMeta,
         max_repairs: usize,
     ) -> Vec<RepairType> {
@@ -272,7 +274,7 @@ impl RepairService {
         blocktree: &Blocktree,
         repairs: &mut Vec<RepairType>,
         max_repairs: usize,
-        slot: u64,
+        slot: Slot,
     ) {
         let mut pending_slots = vec![slot];
         while repairs.len() < max_repairs && !pending_slots.is_empty() {

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -18,6 +18,7 @@ use solana_ledger::bank_forks::BankForks;
 use solana_runtime::bank::Bank;
 use solana_sdk::{
     account::Account,
+    clock::Slot,
     epoch_schedule::EpochSchedule,
     fee_calculator::FeeCalculator,
     hash::Hash,
@@ -215,7 +216,7 @@ impl JsonRpcRequestProcessor {
         Ok(self.bank().slots_per_segment())
     }
 
-    fn get_storage_pubkeys_for_slot(&self, slot: u64) -> Result<Vec<Pubkey>> {
+    fn get_storage_pubkeys_for_slot(&self, slot: Slot) -> Result<Vec<Pubkey>> {
         Ok(self
             .storage_state
             .get_pubkeys_for_slot(slot, &self.bank_forks))
@@ -710,7 +711,11 @@ impl RpcSol for RpcSolImpl {
             .get_slots_per_segment()
     }
 
-    fn get_storage_pubkeys_for_slot(&self, meta: Self::Metadata, slot: u64) -> Result<Vec<Pubkey>> {
+    fn get_storage_pubkeys_for_slot(
+        &self,
+        meta: Self::Metadata,
+        slot: Slot,
+    ) -> Result<Vec<Pubkey>> {
         meta.request_processor
             .read()
             .unwrap()

--- a/core/src/rpc_subscriptions.rs
+++ b/core/src/rpc_subscriptions.rs
@@ -2,15 +2,13 @@
 
 use core::hash::Hash;
 use jsonrpc_core::futures::Future;
-use jsonrpc_pubsub::typed::Sink;
-use jsonrpc_pubsub::SubscriptionId;
+use jsonrpc_pubsub::{typed::Sink, SubscriptionId};
 use serde::Serialize;
 use solana_ledger::bank_forks::BankForks;
 use solana_runtime::bank::Bank;
-use solana_sdk::account::Account;
-use solana_sdk::pubkey::Pubkey;
-use solana_sdk::signature::Signature;
-use solana_sdk::transaction;
+use solana_sdk::{
+    account::Account, clock::Slot, pubkey::Pubkey, signature::Signature, transaction,
+};
 use solana_vote_api::vote_state::MAX_LOCKOUT_HISTORY;
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
@@ -74,7 +72,7 @@ where
 fn check_confirmations_and_notify<K, S, F, N, X>(
     subscriptions: &HashMap<K, HashMap<SubscriptionId, (Sink<S>, Confirmations)>>,
     hashmap_key: &K,
-    current_slot: u64,
+    current_slot: Slot,
     bank_forks: &Arc<RwLock<BankForks>>,
     bank_method: F,
     notify: N,
@@ -169,7 +167,7 @@ impl RpcSubscriptions {
     pub fn check_account(
         &self,
         pubkey: &Pubkey,
-        current_slot: u64,
+        current_slot: Slot,
         bank_forks: &Arc<RwLock<BankForks>>,
     ) {
         let subscriptions = self.account_subscriptions.read().unwrap();
@@ -186,7 +184,7 @@ impl RpcSubscriptions {
     pub fn check_program(
         &self,
         program_id: &Pubkey,
-        current_slot: u64,
+        current_slot: Slot,
         bank_forks: &Arc<RwLock<BankForks>>,
     ) {
         let subscriptions = self.program_subscriptions.write().unwrap();
@@ -203,7 +201,7 @@ impl RpcSubscriptions {
     pub fn check_signature(
         &self,
         signature: &Signature,
-        current_slot: u64,
+        current_slot: Slot,
         bank_forks: &Arc<RwLock<BankForks>>,
     ) {
         let mut subscriptions = self.signature_subscriptions.write().unwrap();
@@ -268,7 +266,7 @@ impl RpcSubscriptions {
 
     /// Notify subscribers of changes to any accounts or new signatures since
     /// the bank's last checkpoint.
-    pub fn notify_subscribers(&self, current_slot: u64, bank_forks: &Arc<RwLock<BankForks>>) {
+    pub fn notify_subscribers(&self, current_slot: Slot, bank_forks: &Arc<RwLock<BankForks>>) {
         let pubkeys: Vec<_> = {
             let subs = self.account_subscriptions.read().unwrap();
             subs.keys().cloned().collect()

--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -295,6 +295,7 @@ mod test {
         shred::Shredder,
     };
     use solana_sdk::{
+        clock::Slot,
         epoch_schedule::MINIMUM_SLOTS_PER_EPOCH,
         hash::Hash,
         signature::{Keypair, KeypairUtil},
@@ -310,8 +311,8 @@ mod test {
 
     fn local_entries_to_shred(
         entries: &[Entry],
-        slot: u64,
-        parent: u64,
+        slot: Slot,
+        parent: Slot,
         keypair: &Arc<Keypair>,
     ) -> Vec<Shred> {
         let shredder = Shredder::new(slot, parent, 0.0, keypair.clone())

--- a/core/tests/bank_forks.rs
+++ b/core/tests/bank_forks.rs
@@ -5,26 +5,36 @@ mod tests {
     use bincode::serialize_into;
     use fs_extra::dir::CopyOptions;
     use itertools::Itertools;
-    use solana_core::genesis_utils::{create_genesis_block, GenesisBlockInfo};
-    use solana_core::service::Service;
-    use solana_core::snapshot_packager_service::SnapshotPackagerService;
-    use solana_ledger::bank_forks::{BankForks, SnapshotConfig};
-    use solana_ledger::snapshot_utils;
-    use solana_runtime::bank::Bank;
-    use solana_runtime::status_cache::SlotDelta;
-    use solana_runtime::status_cache::MAX_CACHE_ENTRIES;
-    use solana_sdk::hash::hashv;
-    use solana_sdk::pubkey::Pubkey;
-    use solana_sdk::signature::{Keypair, KeypairUtil};
-    use solana_sdk::system_transaction;
-    use solana_sdk::transaction::Result as TransactionResult;
-    use std::fs;
-    use std::fs::File;
-    use std::io::{BufWriter, Write};
-    use std::path::PathBuf;
-    use std::sync::atomic::AtomicBool;
-    use std::sync::mpsc::channel;
-    use std::sync::Arc;
+    use solana_core::{
+        genesis_utils::{create_genesis_block, GenesisBlockInfo},
+        service::Service,
+        snapshot_packager_service::SnapshotPackagerService,
+    };
+    use solana_ledger::{
+        bank_forks::{BankForks, SnapshotConfig},
+        snapshot_utils,
+    };
+    use solana_runtime::{
+        bank::Bank,
+        status_cache::{SlotDelta, MAX_CACHE_ENTRIES},
+    };
+    use solana_sdk::{
+        clock::Slot,
+        hash::hashv,
+        pubkey::Pubkey,
+        signature::{Keypair, KeypairUtil},
+        system_transaction,
+        transaction::Result as TransactionResult,
+    };
+    use std::{
+        fs,
+        fs::File,
+        io::{BufWriter, Write},
+        path::PathBuf,
+        sync::atomic::AtomicBool,
+        sync::mpsc::channel,
+        sync::Arc,
+    };
     use tempfile::TempDir;
 
     struct SnapshotTestConfig {
@@ -100,7 +110,7 @@ mod tests {
     // also marks each bank as root and generates snapshots
     // finally tries to restore from the last bank's snapshot and compares the restored bank to the
     // `last_slot` bank
-    fn run_bank_forks_snapshot_n<F>(last_slot: u64, f: F, set_root_interval: u64)
+    fn run_bank_forks_snapshot_n<F>(last_slot: Slot, f: F, set_root_interval: u64)
     where
         F: Fn(&mut Bank, &Keypair),
     {

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -17,7 +17,7 @@ enum LedgerOutputMethod {
     Json,
 }
 
-fn output_slot(blocktree: &Blocktree, slot: u64, method: &LedgerOutputMethod) {
+fn output_slot(blocktree: &Blocktree, slot: Slot, method: &LedgerOutputMethod) {
     let entries = blocktree
         .get_slot_entries(slot, 0, None)
         .unwrap_or_else(|err| {
@@ -36,7 +36,7 @@ fn output_slot(blocktree: &Blocktree, slot: u64, method: &LedgerOutputMethod) {
     }
 }
 
-fn output_ledger(blocktree: Blocktree, starting_slot: u64, method: LedgerOutputMethod) {
+fn output_ledger(blocktree: Blocktree, starting_slot: Slot, method: LedgerOutputMethod) {
     let rooted_slot_iterator =
         RootedSlotIterator::new(starting_slot, &blocktree).unwrap_or_else(|err| {
             eprintln!(

--- a/ledger/src/blocktree_db.rs
+++ b/ledger/src/blocktree_db.rs
@@ -299,7 +299,7 @@ impl Column for columns::Index {
     const NAME: &'static str = INDEX_CF;
     type Index = u64;
 
-    fn key(slot: u64) -> Vec<u8> {
+    fn key(slot: Slot) -> Vec<u8> {
         let mut key = vec![0; 8];
         BigEndian::write_u64(&mut key[..], slot);
         key
@@ -326,7 +326,7 @@ impl Column for columns::DeadSlots {
     const NAME: &'static str = DEAD_SLOTS_CF;
     type Index = u64;
 
-    fn key(slot: u64) -> Vec<u8> {
+    fn key(slot: Slot) -> Vec<u8> {
         let mut key = vec![0; 8];
         BigEndian::write_u64(&mut key[..], slot);
         key
@@ -353,7 +353,7 @@ impl Column for columns::Orphans {
     const NAME: &'static str = ORPHANS_CF;
     type Index = u64;
 
-    fn key(slot: u64) -> Vec<u8> {
+    fn key(slot: Slot) -> Vec<u8> {
         let mut key = vec![0; 8];
         BigEndian::write_u64(&mut key[..], slot);
         key
@@ -380,7 +380,7 @@ impl Column for columns::Root {
     const NAME: &'static str = ROOT_CF;
     type Index = u64;
 
-    fn key(slot: u64) -> Vec<u8> {
+    fn key(slot: Slot) -> Vec<u8> {
         let mut key = vec![0; 8];
         BigEndian::write_u64(&mut key[..], slot);
         key
@@ -407,7 +407,7 @@ impl Column for columns::SlotMeta {
     const NAME: &'static str = META_CF;
     type Index = u64;
 
-    fn key(slot: u64) -> Vec<u8> {
+    fn key(slot: Slot) -> Vec<u8> {
         let mut key = vec![0; 8];
         BigEndian::write_u64(&mut key[..], slot);
         key

--- a/ledger/src/blocktree_meta.rs
+++ b/ledger/src/blocktree_meta.rs
@@ -1,6 +1,7 @@
 use crate::erasure::ErasureConfig;
 use serde::{Deserialize, Serialize};
 use solana_metrics::datapoint;
+use solana_sdk::clock::Slot;
 use std::{collections::BTreeSet, ops::RangeBounds};
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, Eq, PartialEq)]
@@ -8,7 +9,7 @@ use std::{collections::BTreeSet, ops::RangeBounds};
 pub struct SlotMeta {
     // The number of slots above the root (the genesis block). The first
     // slot has slot 0.
-    pub slot: u64,
+    pub slot: Slot,
     // The total number of consecutive blobs starting from index 0
     // we have received for this slot.
     pub consumed: u64,
@@ -19,10 +20,10 @@ pub struct SlotMeta {
     // The index of the blob that is flagged as the last blob for this slot.
     pub last_index: u64,
     // The slot height of the block this one derives from.
-    pub parent_slot: u64,
-    // The list of slot heights, each of which contains a block that derives
+    pub parent_slot: Slot,
+    // The list of slots, each of which contains a block that derives
     // from this one.
-    pub next_slots: Vec<u64>,
+    pub next_slots: Vec<Slot>,
     // True if this slot is full (consumed == last_index + 1) and if every
     // slot that is a parent of this slot is also connected.
     pub is_connected: bool,
@@ -33,7 +34,7 @@ pub struct SlotMeta {
 #[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq)]
 /// Index recording presence/absence of blobs
 pub struct Index {
-    pub slot: u64,
+    pub slot: Slot,
     data: DataIndex,
     coding: CodingIndex,
 }
@@ -70,7 +71,7 @@ pub enum ErasureMetaStatus {
 }
 
 impl Index {
-    pub(crate) fn new(slot: u64) -> Self {
+    pub(crate) fn new(slot: Slot) -> Self {
         Index {
             slot,
             data: DataIndex::default(),
@@ -174,7 +175,7 @@ impl SlotMeta {
         self.parent_slot != std::u64::MAX
     }
 
-    pub(crate) fn new(slot: u64, parent_slot: u64) -> Self {
+    pub(crate) fn new(slot: Slot, parent_slot: Slot) -> Self {
         SlotMeta {
             slot,
             consumed: 0,

--- a/ledger/src/erasure.rs
+++ b/ledger/src/erasure.rs
@@ -132,6 +132,7 @@ impl Default for Session {
 pub mod test {
     use super::*;
     use log::*;
+    use solana_sdk::clock::Slot;
 
     /// Specifies the contents of a 16-data-blob and 4-coding-blob erasure set
     /// Exists to be passed to `generate_blocktree_with_coding`
@@ -147,7 +148,7 @@ pub mod test {
     /// Exists to be passed to `generate_blocktree_with_coding`
     #[derive(Debug, Clone)]
     pub struct SlotSpec {
-        pub slot: u64,
+        pub slot: Slot,
         pub set_specs: Vec<ErasureSpec>,
     }
 

--- a/ledger/src/leader_schedule_utils.rs
+++ b/ledger/src/leader_schedule_utils.rs
@@ -1,11 +1,13 @@
 use crate::leader_schedule::LeaderSchedule;
 use crate::staking_utils;
 use solana_runtime::bank::Bank;
-use solana_sdk::clock::NUM_CONSECUTIVE_LEADER_SLOTS;
-use solana_sdk::pubkey::Pubkey;
+use solana_sdk::{
+    clock::{Epoch, Slot, NUM_CONSECUTIVE_LEADER_SLOTS},
+    pubkey::Pubkey,
+};
 
 /// Return the leader schedule for the given epoch.
-pub fn leader_schedule(epoch: u64, bank: &Bank) -> Option<LeaderSchedule> {
+pub fn leader_schedule(epoch: Epoch, bank: &Bank) -> Option<LeaderSchedule> {
     staking_utils::staked_nodes_at_epoch(bank, epoch).map(|stakes| {
         let mut seed = [0u8; 32];
         seed[0..8].copy_from_slice(&epoch.to_le_bytes());
@@ -21,7 +23,7 @@ pub fn leader_schedule(epoch: u64, bank: &Bank) -> Option<LeaderSchedule> {
 }
 
 /// Return the leader for the given slot.
-pub fn slot_leader_at(slot: u64, bank: &Bank) -> Option<Pubkey> {
+pub fn slot_leader_at(slot: Slot, bank: &Bank) -> Option<Pubkey> {
     let (epoch, slot_index) = bank.get_epoch_and_slot_index(slot);
 
     leader_schedule(epoch, bank).map(|leader_schedule| leader_schedule[slot_index])

--- a/ledger/src/rooted_slot_iterator.rs
+++ b/ledger/src/rooted_slot_iterator.rs
@@ -1,14 +1,14 @@
-use crate::blocktree::*;
-use crate::blocktree_meta::SlotMeta;
+use crate::{blocktree::*, blocktree_meta::SlotMeta};
 use log::*;
+use solana_sdk::clock::Slot;
 
 pub struct RootedSlotIterator<'a> {
-    next_slots: Vec<u64>,
+    next_slots: Vec<Slot>,
     blocktree: &'a Blocktree,
 }
 
 impl<'a> RootedSlotIterator<'a> {
-    pub fn new(start_slot: u64, blocktree: &'a Blocktree) -> Result<Self> {
+    pub fn new(start_slot: Slot, blocktree: &'a Blocktree) -> Result<Self> {
         if blocktree.is_root(start_slot) {
             Ok(Self {
                 next_slots: vec![start_slot],
@@ -20,7 +20,7 @@ impl<'a> RootedSlotIterator<'a> {
     }
 }
 impl<'a> Iterator for RootedSlotIterator<'a> {
-    type Item = (u64, SlotMeta);
+    type Item = (Slot, SlotMeta);
 
     fn next(&mut self) -> Option<Self::Item> {
         // Clone b/c passing the closure to the map below requires exclusive access to

--- a/ledger/src/snapshot_utils.rs
+++ b/ledger/src/snapshot_utils.rs
@@ -4,14 +4,15 @@ use bzip2::bufread::BzDecoder;
 use fs_extra::dir::CopyOptions;
 use log::*;
 use solana_measure::measure::Measure;
-use solana_runtime::bank::Bank;
-use solana_runtime::status_cache::SlotDelta;
-use solana_sdk::transaction;
-use std::cmp::Ordering;
-use std::fs;
-use std::fs::File;
-use std::io::{BufReader, BufWriter, Error as IOError, ErrorKind};
-use std::path::{Path, PathBuf};
+use solana_runtime::{bank::Bank, status_cache::SlotDelta};
+use solana_sdk::{clock::Slot, transaction};
+use std::{
+    cmp::Ordering,
+    fs,
+    fs::File,
+    io::{BufReader, BufWriter, Error as IOError, ErrorKind},
+    path::{Path, PathBuf},
+};
 use tar::Archive;
 
 pub const SNAPSHOT_STATUS_CACHE_FILE_NAME: &str = "status_cache";
@@ -20,7 +21,7 @@ pub const TAR_ACCOUNTS_DIR: &str = "accounts";
 
 #[derive(PartialEq, Ord, Eq, Debug)]
 pub struct SlotSnapshotPaths {
-    pub slot: u64,
+    pub slot: Slot,
     pub snapshot_file_path: PathBuf,
 }
 
@@ -77,7 +78,7 @@ pub fn package_snapshot<P: AsRef<Path>, Q: AsRef<Path>>(
     snapshot_files: &SlotSnapshotPaths,
     snapshot_package_output_file: P,
     snapshot_path: Q,
-    slots_to_snapshot: &[u64],
+    slots_to_snapshot: &[Slot],
 ) -> Result<SnapshotPackage> {
     // Hard link all the snapshots we need for this package
     let snapshot_hard_links_dir = tempfile::tempdir_in(snapshot_path)?;
@@ -183,7 +184,7 @@ pub fn add_snapshot<P: AsRef<Path>>(snapshot_path: P, bank: &Bank) -> Result<()>
     Ok(())
 }
 
-pub fn remove_snapshot<P: AsRef<Path>>(slot: u64, snapshot_path: P) -> Result<()> {
+pub fn remove_snapshot<P: AsRef<Path>>(slot: Slot, snapshot_path: P) -> Result<()> {
     let slot_snapshot_dir = get_bank_snapshot_dir(&snapshot_path, slot);
     // Remove the snapshot directory for this slot
     fs::remove_dir_all(slot_snapshot_dir)?;
@@ -295,11 +296,11 @@ where
     Ok(bank)
 }
 
-fn get_snapshot_file_name(slot: u64) -> String {
+fn get_snapshot_file_name(slot: Slot) -> String {
     slot.to_string()
 }
 
-fn get_bank_snapshot_dir<P: AsRef<Path>>(path: P, slot: u64) -> PathBuf {
+fn get_bank_snapshot_dir<P: AsRef<Path>>(path: P, slot: Slot) -> PathBuf {
     path.as_ref().join(slot.to_string())
 }
 

--- a/local_cluster/src/cluster_tests.rs
+++ b/local_cluster/src/cluster_tests.rs
@@ -14,7 +14,7 @@ use solana_ledger::{
 };
 use solana_sdk::{
     client::SyncClient,
-    clock::{DEFAULT_TICKS_PER_SECOND, DEFAULT_TICKS_PER_SLOT, NUM_CONSECUTIVE_LEADER_SLOTS},
+    clock::{Slot, DEFAULT_TICKS_PER_SECOND, DEFAULT_TICKS_PER_SLOT, NUM_CONSECUTIVE_LEADER_SLOTS},
     epoch_schedule::MINIMUM_SLOTS_PER_EPOCH,
     hash::Hash,
     poh_config::PohConfig,
@@ -282,7 +282,7 @@ fn poll_all_nodes_for_signature(
     Ok(())
 }
 
-fn get_and_verify_slot_entries(blocktree: &Blocktree, slot: u64, last_entry: &Hash) -> Vec<Entry> {
+fn get_and_verify_slot_entries(blocktree: &Blocktree, slot: Slot, last_entry: &Hash) -> Vec<Entry> {
     let entries = blocktree.get_slot_entries(slot, 0, None).unwrap();
     assert!(entries.verify(last_entry));
     entries
@@ -290,7 +290,7 @@ fn get_and_verify_slot_entries(blocktree: &Blocktree, slot: u64, last_entry: &Ha
 
 fn verify_slot_ticks(
     blocktree: &Blocktree,
-    slot: u64,
+    slot: Slot,
     last_entry: &Hash,
     expected_num_ticks: Option<usize>,
 ) -> Hash {

--- a/programs/stake_api/src/stake_state.rs
+++ b/programs/stake_api/src/stake_state.rs
@@ -424,7 +424,7 @@ impl Stake {
         }
     }
 
-    fn deactivate(&mut self, epoch: u64) -> Result<(), StakeError> {
+    fn deactivate(&mut self, epoch: Epoch) -> Result<(), StakeError> {
         if self.deactivation_epoch != std::u64::MAX {
             Err(StakeError::AlreadyDeactivated)
         } else {

--- a/programs/storage_api/src/storage_contract.rs
+++ b/programs/storage_api/src/storage_contract.rs
@@ -2,14 +2,16 @@ use crate::storage_instruction::StorageAccountType;
 use log::*;
 use num_derive::FromPrimitive;
 use serde_derive::{Deserialize, Serialize};
-use solana_sdk::account::Account;
-use solana_sdk::account::KeyedAccount;
-use solana_sdk::account_utils::State;
-use solana_sdk::hash::Hash;
-use solana_sdk::instruction::InstructionError;
-use solana_sdk::pubkey::Pubkey;
-use solana_sdk::signature::Signature;
-use solana_sdk::sysvar;
+use solana_sdk::{
+    account::{Account, KeyedAccount},
+    account_utils::State,
+    clock::Epoch,
+    hash::Hash,
+    instruction::InstructionError,
+    pubkey::Pubkey,
+    signature::Signature,
+    sysvar,
+};
 use std::collections::BTreeMap;
 
 // Todo Tune this for actual use cases when PoRep is feature complete
@@ -19,15 +21,15 @@ pub const MAX_PROOFS_PER_SEGMENT: usize = 80;
 #[derive(Default, Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct Credits {
     // current epoch
-    epoch: u64,
+    epoch: Epoch,
     // currently pending credits
-    pub current_epoch: u64,
+    pub current_epoch: Epoch,
     // credits ready to be claimed
     pub redeemable: u64,
 }
 
 impl Credits {
-    pub fn update_epoch(&mut self, current_epoch: u64) {
+    pub fn update_epoch(&mut self, current_epoch: Epoch) {
         if self.epoch != current_epoch {
             self.epoch = current_epoch;
             self.redeemable += self.current_epoch;

--- a/programs/vote_api/src/vote_state.rs
+++ b/programs/vote_api/src/vote_state.rs
@@ -313,7 +313,7 @@ impl VoteState {
         self.epoch_credits.iter()
     }
 
-    fn pop_expired_votes(&mut self, slot: u64) {
+    fn pop_expired_votes(&mut self, slot: Slot) {
         loop {
             if self.votes.back().map_or(false, |v| v.is_expired(slot)) {
                 self.votes.pop_back();
@@ -465,9 +465,7 @@ pub fn create_account(
 mod tests {
     use super::*;
     use crate::vote_state;
-    use solana_sdk::account::Account;
-    use solana_sdk::account_utils::State;
-    use solana_sdk::hash::hash;
+    use solana_sdk::{account::Account, account_utils::State, hash::hash};
 
     const MAX_RECENT_VOTES: usize = 16;
 
@@ -528,7 +526,7 @@ mod tests {
         vote_account: &mut Account,
         vote: &Vote,
         slot_hashes: &[SlotHash],
-        epoch: u64,
+        epoch: Epoch,
     ) -> Result<VoteState, InstructionError> {
         process_vote(
             &mut KeyedAccount::new(vote_pubkey, true, vote_account),

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -673,7 +673,12 @@ impl Accounts {
     }
 }
 
-pub fn create_test_accounts(accounts: &Accounts, pubkeys: &mut Vec<Pubkey>, num: usize, slot: u64) {
+pub fn create_test_accounts(
+    accounts: &Accounts,
+    pubkeys: &mut Vec<Pubkey>,
+    num: usize,
+    slot: Slot,
+) {
     for t in 0..num {
         let pubkey = Pubkey::new_rand();
         let account = Account::new((t + 1) as u64, 0, &Account::default().owner);

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -115,10 +115,10 @@ impl<'de> Visitor<'de> for AccountStorageVisitor {
 
 pub struct AccountStorageSerialize<'a> {
     account_storage: &'a AccountStorage,
-    slot: u64,
+    slot: Slot,
 }
 impl<'a> AccountStorageSerialize<'a> {
-    pub fn new(account_storage: &'a AccountStorage, slot: u64) -> Self {
+    pub fn new(account_storage: &'a AccountStorage, slot: Slot) -> Self {
         Self {
             account_storage,
             slot,
@@ -323,11 +323,11 @@ pub fn get_temp_accounts_paths(count: u32) -> IOResult<(Vec<TempDir>, String)> {
 
 pub struct AccountsDBSerialize<'a> {
     accounts_db: &'a AccountsDB,
-    slot: u64,
+    slot: Slot,
 }
 
 impl<'a> AccountsDBSerialize<'a> {
-    pub fn new(accounts_db: &'a AccountsDB, slot: u64) -> Self {
+    pub fn new(accounts_db: &'a AccountsDB, slot: Slot) -> Self {
         Self { accounts_db, slot }
     }
 }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -64,11 +64,11 @@ pub struct BankRc {
     parent: RwLock<Option<Arc<Bank>>>,
 
     /// Current slot
-    slot: u64,
+    slot: Slot,
 }
 
 impl BankRc {
-    pub fn new(account_paths: String, id: AppendVecId, slot: u64) -> Self {
+    pub fn new(account_paths: String, id: AppendVecId, slot: Slot) -> Self {
         let accounts = Accounts::new(Some(account_paths));
         accounts
             .accounts_db
@@ -133,7 +133,7 @@ impl StatusCacheRc {
         sc.slot_deltas(slots)
     }
 
-    pub fn roots(&self) -> Vec<u64> {
+    pub fn roots(&self) -> Vec<Slot> {
         self.status_cache
             .read()
             .unwrap()
@@ -166,7 +166,7 @@ pub struct Bank {
     blockhash_queue: RwLock<BlockhashQueue>,
 
     /// The set of parents including this bank
-    pub ancestors: HashMap<u64, usize>,
+    pub ancestors: HashMap<Slot, usize>,
 
     /// Hash of this Bank's state. Only meaningful after freezing.
     hash: RwLock<Hash>,
@@ -246,7 +246,7 @@ pub struct Bank {
 
     /// staked nodes on epoch boundaries, saved off when a bank.slot() is at
     ///   a leader schedule calculation boundary
-    epoch_stakes: HashMap<u64, Stakes>,
+    epoch_stakes: HashMap<Epoch, Stakes>,
 
     /// A boolean reflecting whether any entries were recorded into the PoH
     /// stream for the slot == self.slot
@@ -295,7 +295,7 @@ impl Bank {
     }
 
     /// Create a new bank that points to an immutable checkpoint of another bank.
-    pub fn new_from_parent(parent: &Arc<Bank>, collector_id: &Pubkey, slot: u64) -> Self {
+    pub fn new_from_parent(parent: &Arc<Bank>, collector_id: &Pubkey, slot: Slot) -> Self {
         parent.freeze();
         assert_ne!(slot, parent.slot());
 
@@ -408,11 +408,11 @@ impl Bank {
         bank
     }
 
-    pub fn slot(&self) -> u64 {
+    pub fn slot(&self) -> Slot {
         self.slot
     }
 
-    pub fn epoch(&self) -> u64 {
+    pub fn epoch(&self) -> Epoch {
         self.epoch
     }
 
@@ -772,7 +772,7 @@ impl Bank {
     /// tick that has achieved confirmation
     pub fn get_confirmation_timestamp(
         &self,
-        mut slots_and_stakes: Vec<(u64, u64)>,
+        mut slots_and_stakes: Vec<(Slot, u64)>,
         supermajority_stake: u64,
     ) -> Option<u64> {
         // Sort by slot height
@@ -1473,7 +1473,7 @@ impl Bank {
 
     /// returns the epoch for which this bank's leader_schedule_slot_offset and slot would
     ///  need to cache leader_schedule
-    pub fn get_leader_schedule_epoch(&self, slot: u64) -> u64 {
+    pub fn get_leader_schedule_epoch(&self, slot: Slot) -> Epoch {
         self.epoch_schedule.get_leader_schedule_epoch(slot)
     }
 
@@ -1544,7 +1544,7 @@ impl Bank {
     ///
     ///  ( slot/slots_per_epoch, slot % slots_per_epoch )
     ///
-    pub fn get_epoch_and_slot_index(&self, slot: u64) -> (u64, u64) {
+    pub fn get_epoch_and_slot_index(&self, slot: Slot) -> (u64, u64) {
         self.epoch_schedule.get_epoch_and_slot_index(slot)
     }
 

--- a/sdk/src/client.rs
+++ b/sdk/src/client.rs
@@ -7,15 +7,18 @@
 //! Asynchronous implementations are expected to create transactions, sign them, and send
 //! them but without waiting to see if the server accepted it.
 
-use crate::account::Account;
-use crate::fee_calculator::FeeCalculator;
-use crate::hash::Hash;
-use crate::instruction::Instruction;
-use crate::message::Message;
-use crate::pubkey::Pubkey;
-use crate::signature::{Keypair, Signature};
-use crate::transaction;
-use crate::transport::Result;
+use crate::{
+    account::Account,
+    clock::Slot,
+    fee_calculator::FeeCalculator,
+    hash::Hash,
+    instruction::Instruction,
+    message::Message,
+    pubkey::Pubkey,
+    signature::{Keypair, Signature},
+    transaction,
+    transport::Result,
+};
 use std::io;
 
 pub trait Client: SyncClient + AsyncClient {
@@ -54,7 +57,7 @@ pub trait SyncClient {
     ) -> Result<Option<transaction::Result<()>>>;
 
     /// Get last known slot
-    fn get_slot(&self) -> Result<u64>;
+    fn get_slot(&self) -> Result<Slot>;
 
     /// Get transaction count
     fn get_transaction_count(&self) -> Result<u64>;

--- a/sdk/src/epoch_schedule.rs
+++ b/sdk/src/epoch_schedule.rs
@@ -45,7 +45,7 @@ impl EpochSchedule {
     pub fn new(slots_per_epoch: u64) -> Self {
         Self::custom(slots_per_epoch, slots_per_epoch, true)
     }
-    pub fn custom(slots_per_epoch: u64, leader_schedule_slot_offset: u64, warmup: bool) -> Self {
+    pub fn custom(slots_per_epoch: Epoch, leader_schedule_slot_offset: u64, warmup: bool) -> Self {
         assert!(slots_per_epoch >= MINIMUM_SLOTS_PER_EPOCH as u64);
         let (first_normal_epoch, first_normal_slot) = if warmup {
             let next_power_of_two = slots_per_epoch.next_power_of_two();
@@ -70,7 +70,7 @@ impl EpochSchedule {
     }
 
     /// get the length of the given epoch (in slots)
-    pub fn get_slots_in_epoch(&self, epoch: u64) -> u64 {
+    pub fn get_slots_in_epoch(&self, epoch: Epoch) -> u64 {
         if epoch < self.first_normal_epoch {
             2u64.pow(epoch as u32 + MINIMUM_SLOTS_PER_EPOCH.trailing_zeros() as u32)
         } else {
@@ -80,7 +80,7 @@ impl EpochSchedule {
 
     /// get the epoch for which the given slot should save off
     ///  information about stakers
-    pub fn get_leader_schedule_epoch(&self, slot: u64) -> u64 {
+    pub fn get_leader_schedule_epoch(&self, slot: Slot) -> Epoch {
         if slot < self.first_normal_slot {
             // until we get to normal slots, behave as if leader_schedule_slot_offset == slots_per_epoch
             self.get_epoch_and_slot_index(slot).0 + 1
@@ -92,12 +92,12 @@ impl EpochSchedule {
     }
 
     /// get epoch for the given slot
-    pub fn get_epoch(&self, slot: u64) -> u64 {
+    pub fn get_epoch(&self, slot: Slot) -> Epoch {
         self.get_epoch_and_slot_index(slot).0
     }
 
     /// get epoch and offset into the epoch for the given slot
-    pub fn get_epoch_and_slot_index(&self, slot: u64) -> (u64, u64) {
+    pub fn get_epoch_and_slot_index(&self, slot: Slot) -> (Epoch, u64) {
         if slot < self.first_normal_slot {
             let epoch = (slot + MINIMUM_SLOTS_PER_EPOCH + 1)
                 .next_power_of_two()
@@ -119,7 +119,7 @@ impl EpochSchedule {
         }
     }
 
-    pub fn get_first_slot_in_epoch(&self, epoch: u64) -> u64 {
+    pub fn get_first_slot_in_epoch(&self, epoch: Epoch) -> Slot {
         if epoch <= self.first_normal_epoch {
             (2u64.pow(epoch as u32) - 1) * MINIMUM_SLOTS_PER_EPOCH
         } else {
@@ -127,7 +127,7 @@ impl EpochSchedule {
         }
     }
 
-    pub fn get_last_slot_in_epoch(&self, epoch: u64) -> u64 {
+    pub fn get_last_slot_in_epoch(&self, epoch: Epoch) -> Slot {
         self.get_first_slot_in_epoch(epoch) + self.get_slots_in_epoch(epoch) - 1
     }
 }

--- a/sdk/src/packet.rs
+++ b/sdk/src/packet.rs
@@ -1,3 +1,4 @@
+use crate::clock::Slot;
 use std::fmt;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 
@@ -18,7 +19,7 @@ pub struct Meta {
     pub port: u16,
     pub v6: bool,
     pub seed: [u8; 32],
-    pub slot: u64,
+    pub slot: Slot,
 }
 
 #[derive(Clone)]


### PR DESCRIPTION
Improve code readability by using Slot/Epoch type aliases more.  

Freebee: sneak in more `use` cleanup.

🐃 