### PR TITLE
Store and persists full stack of tower votes in gossip

### DIFF
--- a/core/src/cluster_info.rs
+++ b/core/src/cluster_info.rs
@@ -12,13 +12,12 @@
 //! * layer 2 - Everyone else, if layer 1 is `2^10`, layer 2 should be able to fit `2^20` number of nodes.
 //!
 //! Bank needs to provide an interface for us to query the stake weight
-use crate::crds_value::CrdsValue;
 use crate::{
     contact_info::ContactInfo,
     crds_gossip::CrdsGossip,
     crds_gossip_error::CrdsGossipError,
     crds_gossip_pull::{CrdsFilter, CRDS_GOSSIP_PULL_CRDS_TIMEOUT_MS},
-    crds_value::{CrdsData, CrdsValueLabel, EpochSlots, Vote},
+    crds_value::{self, CrdsData, CrdsValue, CrdsValueLabel, EpochSlots, Vote},
     packet::{to_shared_blob, Blob, Packet, SharedBlob},
     repair_service::RepairType,
     result::{Error, Result},
@@ -307,10 +306,18 @@ impl ClusterInfo {
             .process_push_message(&self.id(), vec![entry], now);
     }
 
-    pub fn push_vote(&mut self, vote: Transaction) {
+    pub fn push_vote(&mut self, tower_index: usize, vote: Transaction) {
         let now = timestamp();
         let vote = Vote::new(&self.id(), vote, now);
-        let entry = CrdsValue::new_signed(CrdsData::Vote(vote), &self.keypair);
+        let current_votes: Vec<_> = (0..crds_value::MAX_VOTES)
+            .filter_map(|ix| {
+                self.gossip
+                    .crds
+                    .lookup(&CrdsValueLabel::Vote(ix, self.id()))
+            })
+            .collect();
+        let vote_ix = CrdsValue::compute_vote_index(tower_index, current_votes);
+        let entry = CrdsValue::new_signed(CrdsData::Vote(vote_ix, vote), &self.keypair);
         self.gossip
             .process_push_message(&self.id(), vec![entry], now);
     }
@@ -2345,7 +2352,7 @@ mod tests {
 
         // add a vote
         let tx = test_tx();
-        cluster_info.push_vote(tx.clone());
+        cluster_info.push_vote(0, tx.clone());
 
         // -1 to make sure that the clock is strictly lower then when insert occurred
         let (votes, max_ts) = cluster_info.get_votes(now - 1);

--- a/core/src/crds_value.rs
+++ b/core/src/crds_value.rs
@@ -5,7 +5,11 @@ use solana_sdk::signature::{Keypair, Signable, Signature};
 use solana_sdk::transaction::Transaction;
 use std::borrow::Cow;
 use std::collections::BTreeSet;
+use std::collections::HashSet;
 use std::fmt;
+
+pub type VoteIndex = u8;
+pub const MAX_VOTES: VoteIndex = 32;
 
 /// CrdsValue that is replicated across the cluster
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
@@ -39,7 +43,7 @@ pub enum CrdsData {
     /// * Merge Strategy - Latest wallclock is picked
     ContactInfo(ContactInfo),
     /// * Merge Strategy - Latest wallclock is picked
-    Vote(Vote),
+    Vote(VoteIndex, Vote),
     /// * Merge Strategy - Latest wallclock is picked
     EpochSlots(EpochSlots),
 }
@@ -85,7 +89,7 @@ impl Vote {
 #[derive(PartialEq, Hash, Eq, Clone, Debug)]
 pub enum CrdsValueLabel {
     ContactInfo(Pubkey),
-    Vote(Pubkey),
+    Vote(VoteIndex, Pubkey),
     EpochSlots(Pubkey),
 }
 
@@ -93,7 +97,7 @@ impl fmt::Display for CrdsValueLabel {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             CrdsValueLabel::ContactInfo(_) => write!(f, "ContactInfo({})", self.pubkey()),
-            CrdsValueLabel::Vote(_) => write!(f, "Vote({})", self.pubkey()),
+            CrdsValueLabel::Vote(ix, _) => write!(f, "Vote({}, {})", ix, self.pubkey()),
             CrdsValueLabel::EpochSlots(_) => write!(f, "EpochSlots({})", self.pubkey()),
         }
     }
@@ -103,7 +107,7 @@ impl CrdsValueLabel {
     pub fn pubkey(&self) -> Pubkey {
         match self {
             CrdsValueLabel::ContactInfo(p) => *p,
-            CrdsValueLabel::Vote(p) => *p,
+            CrdsValueLabel::Vote(_, p) => *p,
             CrdsValueLabel::EpochSlots(p) => *p,
         }
     }
@@ -128,21 +132,21 @@ impl CrdsValue {
     pub fn wallclock(&self) -> u64 {
         match &self.data {
             CrdsData::ContactInfo(contact_info) => contact_info.wallclock,
-            CrdsData::Vote(vote) => vote.wallclock,
+            CrdsData::Vote(_, vote) => vote.wallclock,
             CrdsData::EpochSlots(vote) => vote.wallclock,
         }
     }
     pub fn pubkey(&self) -> Pubkey {
         match &self.data {
             CrdsData::ContactInfo(contact_info) => contact_info.id,
-            CrdsData::Vote(vote) => vote.from,
+            CrdsData::Vote(_, vote) => vote.from,
             CrdsData::EpochSlots(slots) => slots.from,
         }
     }
     pub fn label(&self) -> CrdsValueLabel {
         match &self.data {
             CrdsData::ContactInfo(_) => CrdsValueLabel::ContactInfo(self.pubkey()),
-            CrdsData::Vote(_) => CrdsValueLabel::Vote(self.pubkey()),
+            CrdsData::Vote(ix, _) => CrdsValueLabel::Vote(ix, self.pubkey()),
             CrdsData::EpochSlots(_) => CrdsValueLabel::EpochSlots(self.pubkey()),
         }
     }
@@ -154,10 +158,18 @@ impl CrdsValue {
     }
     pub fn vote(&self) -> Option<&Vote> {
         match &self.data {
-            CrdsData::Vote(vote) => Some(vote),
+            CrdsData::Vote(_, vote) => Some(vote),
             _ => None,
         }
     }
+
+    pub fn vote_index(&self) -> Option<VoteIndex> {
+        match self {
+            CrdsValue::Vote(ix, _) => Some(*ix),
+            _ => None,
+        }
+    }
+
     pub fn epoch_slots(&self) -> Option<&EpochSlots> {
         match &self.data {
             CrdsData::EpochSlots(slots) => Some(slots),
@@ -165,17 +177,45 @@ impl CrdsValue {
         }
     }
     /// Return all the possible labels for a record identified by Pubkey.
-    pub fn record_labels(key: &Pubkey) -> [CrdsValueLabel; 3] {
-        [
+    pub fn record_labels(key: &Pubkey) -> Vec<CrdsValueLabel> {
+        let mut labels = vec![
             CrdsValueLabel::ContactInfo(*key),
-            CrdsValueLabel::Vote(*key),
             CrdsValueLabel::EpochSlots(*key),
-        ]
+        ];
+        labels.extend((0..MAX_VOTES).map(|ix| CrdsValueLabel::Vote(ix, *key)));
+        labels
     }
 
     /// Returns the size (in bytes) of a CrdsValue
     pub fn size(&self) -> u64 {
         serialized_size(&self).expect("unable to serialize contact info")
+    }
+
+    pub fn compute_vote_index(tower_index: usize, mut votes: Vec<&CrdsValue>) -> VoteIndex {
+        let mut available: HashSet<VoteIndex> = (0..MAX_VOTES).collect();
+        votes.iter().filter_map(|v| v.vote_index()).for_each(|ix| {
+            available.remove(&ix);
+        });
+
+        // free index
+        if !available.is_empty() {
+            return *available.iter().next().unwrap();
+        }
+
+        assert!(votes.len() == MAX_VOTES as usize);
+        votes.sort_by_key(|v| v.vote().expect("all values must be votes").wallclock);
+
+        // If Tower is full, oldest removed first
+        if tower_index + 1 == MAX_VOTES as usize {
+            return votes[0].vote_index().expect("all values must be votes");
+        }
+
+        // If Tower is not full, the early votes have expired
+        assert!(tower_index < MAX_VOTES as usize);
+
+        votes[tower_index]
+            .vote_index()
+            .expect("all values must be votes")
     }
 }
 
@@ -190,13 +230,13 @@ mod test {
 
     #[test]
     fn test_labels() {
-        let mut hits = [false; 3];
+        let mut hits = [false; 2 + MAX_VOTES as usize];
         // this method should cover all the possible labels
         for v in &CrdsValue::record_labels(&Pubkey::default()) {
             match v {
                 CrdsValueLabel::ContactInfo(_) => hits[0] = true,
-                CrdsValueLabel::Vote(_) => hits[1] = true,
-                CrdsValueLabel::EpochSlots(_) => hits[2] = true,
+                CrdsValueLabel::EpochSlots(_) => hits[1] = true,
+                CrdsValueLabel::Vote(ix, _) => hits[*ix as usize + 2] = true,
             }
         }
         assert!(hits.iter().all(|x| *x));
@@ -208,11 +248,13 @@ mod test {
         let key = v.clone().contact_info().unwrap().id;
         assert_eq!(v.label(), CrdsValueLabel::ContactInfo(key));
 
-        let v =
-            CrdsValue::new_unsigned(CrdsData::Vote(Vote::new(&Pubkey::default(), test_tx(), 0)));
+        let v = CrdsValue::new_unsigned(CrdsData::Vote(
+            0,
+            Vote::new(&Pubkey::default(), test_tx(), 0),
+        ));
         assert_eq!(v.wallclock(), 0);
         let key = v.clone().vote().unwrap().from;
-        assert_eq!(v.label(), CrdsValueLabel::Vote(key));
+        assert_eq!(v.label(), CrdsValueLabel::Vote(0, key));
 
         let v = CrdsValue::new_unsigned(CrdsData::EpochSlots(EpochSlots::new(
             Pubkey::default(),
@@ -224,6 +266,7 @@ mod test {
         let key = v.clone().epoch_slots().unwrap().from;
         assert_eq!(v.label(), CrdsValueLabel::EpochSlots(key));
     }
+
     #[test]
     fn test_signature() {
         let keypair = Keypair::new();
@@ -233,11 +276,10 @@ mod test {
             timestamp(),
         )));
         verify_signatures(&mut v, &keypair, &wrong_keypair);
-        v = CrdsValue::new_unsigned(CrdsData::Vote(Vote::new(
-            &keypair.pubkey(),
-            test_tx(),
-            timestamp(),
-        )));
+        v = CrdsValue::new_unsigned(CrdsData::Vote(
+            0,
+            Vote::new(&keypair.pubkey(), test_tx(), timestamp()),
+        ));
         verify_signatures(&mut v, &keypair, &wrong_keypair);
         let btreeset: BTreeSet<u64> = vec![1, 2, 3, 6, 8].into_iter().collect();
         v = CrdsValue::new_unsigned(CrdsData::EpochSlots(EpochSlots::new(
@@ -249,7 +291,54 @@ mod test {
         verify_signatures(&mut v, &keypair, &wrong_keypair);
     }
 
-    fn test_serialize_deserialize_value(value: &mut CrdsValue, keypair: &Keypair) {
+    #[test]
+    fn test_max_vote_index() {
+        let keypair = Keypair::new();
+        let mut vote = CrdsValue::Vote(
+            MAX_VOTES,
+            Vote::new(&keypair.pubkey(), test_tx(), timestamp()),
+        );
+        vote.sign(&keypair);
+        assert!(!vote.verify());
+    }
+
+    #[test]
+    fn test_compute_vote_index_empty() {
+        for i in 0..MAX_VOTES {
+            let votes = vec![];
+            assert!(CrdsValue::compute_vote_index(i as usize, votes) < MAX_VOTES);
+        }
+    }
+
+    #[test]
+    fn test_compute_vote_index_one() {
+        let keypair = Keypair::new();
+        let vote = CrdsValue::Vote(0, Vote::new(&keypair.pubkey(), test_tx(), 0));
+        for i in 0..MAX_VOTES {
+            let votes = vec![&vote];
+            assert!(CrdsValue::compute_vote_index(i as usize, votes) > 0);
+            let votes = vec![&vote];
+            assert!(CrdsValue::compute_vote_index(i as usize, votes) < MAX_VOTES);
+        }
+    }
+
+    #[test]
+    fn test_compute_vote_index_full() {
+        let keypair = Keypair::new();
+        let votes: Vec<_> = (0..MAX_VOTES)
+            .map(|x| CrdsValue::Vote(x, Vote::new(&keypair.pubkey(), test_tx(), x as u64)))
+            .collect();
+        let vote_refs = votes.iter().collect();
+        //pick the oldest vote when full
+        assert_eq!(CrdsValue::compute_vote_index(31, vote_refs), 0);
+        //pick the index
+        let vote_refs = votes.iter().collect();
+        assert_eq!(CrdsValue::compute_vote_index(0, vote_refs), 0);
+        let vote_refs = votes.iter().collect();
+        assert_eq!(CrdsValue::compute_vote_index(30, vote_refs), 30);
+    }
+
+    fn serialize_deserialize_value(value: &mut CrdsValue, keypair: &Keypair) {
         let num_tries = 10;
         value.sign(keypair);
         let original_signature = value.get_signature();
@@ -276,6 +365,6 @@ mod test {
         assert!(value.verify());
         value.sign(&wrong_keypair);
         assert!(!value.verify());
-        test_serialize_deserialize_value(value, correct_keypair);
+        serialize_deserialize_value(value, correct_keypair);
     }
 }

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -493,7 +493,7 @@ impl ReplayStage {
         T: 'static + KeypairUtil + Send + Sync,
     {
         trace!("handle votable bank {}", bank.slot());
-        let vote = tower.new_vote_from_bank(bank, vote_account);
+        let (vote, tower_index) = tower.new_vote_from_bank(bank, vote_account);
         if let Some(new_root) = tower.record_bank_vote(vote) {
             // get the root bank before squash
             let root_bank = bank_forks
@@ -539,7 +539,10 @@ impl ReplayStage {
             let blockhash = bank.last_blockhash();
             vote_tx.partial_sign(&[node_keypair.as_ref()], blockhash);
             vote_tx.partial_sign(&[voting_keypair.as_ref()], blockhash);
-            cluster_info.write().unwrap().push_vote(vote_tx);
+            cluster_info
+                .write()
+                .unwrap()
+                .push_vote(tower_index, vote_tx);
         }
         Ok(())
     }

--- a/programs/vote_api/src/vote_state.rs
+++ b/programs/vote_api/src/vote_state.rs
@@ -195,7 +195,7 @@ impl VoteState {
             j -= 1;
         }
         if j == slot_hashes.len() {
-            warn!(
+            debug!(
                 "{} dropped vote {:?} too old: {:?} ",
                 self.node_pubkey, vote, slot_hashes
             );


### PR DESCRIPTION
#### Problem

Storing the only the last vote may create a race between propagating votes and encoding them into the bank and updating votes to a new fork.  The timestamp that the vote listener uses needs to be fork specific, since forks may be based on older banks and could process more votes.

#### Summary of Changes

1. Full stack of tower votes is stored in the bank.
2. When tower is full, oldest vote is evicted first.
3. When tower is not full, expired votes are evicted first.  This is based on the tower_height.
4. Each Bank tracks the last time votes have been synced.

- [x] test tower to gossip vote index calculation
- [x] test tower returns the right index when full or when expired
- [x] test that invalid indexes are rejected in gossip
- [x] test each bank forks inherit the last vote sync time

Fixes #

tag: @sagar-solana 