### PR TITLE
keygen: add dedicated `solana-keygen grind` command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -405,7 +405,7 @@ version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "jobserver 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -592,7 +592,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
- "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -619,7 +619,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cast 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "thread-scoped 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1099,7 +1099,7 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
- "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1231,6 +1231,14 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-segmentation 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "hermit-abi"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1881,9 +1889,10 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
+ "hermit-abi 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2511,7 +2520,7 @@ dependencies = [
  "crossbeam-queue 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3512,6 +3521,7 @@ dependencies = [
  "bs58 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "dirs 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rpassword 4.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-sdk 0.21.0",
  "tiny-bip39 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4748,7 +4758,7 @@ dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-current-thread 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4831,7 +4841,7 @@ dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4884,7 +4894,7 @@ dependencies = [
  "crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5475,6 +5485,7 @@ dependencies = [
 "checksum hash32 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "12d790435639c06a7b798af9e1e331ae245b7ef915b92f70a39b4cf8c00686af"
 "checksum hashbrown 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3bae29b6653b3412c2e71e9d486db9f9df5d701941d86683005efb9f2d28e3da"
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
+"checksum hermit-abi 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "307c3c9f937f38e3534b1d6447ecf090cafcc9744e4a6360e8b037b2cf5af120"
 "checksum hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"
 "checksum hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "023b39be39e3a2da62a94feb433e91e8bcd37676fbc8bea371daf52b7a769a3e"
 "checksum hex-literal 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "961de220ec9a91af2e1e5bd80d02109155695e516771762381ef8581317066e0"
@@ -5546,7 +5557,7 @@ dependencies = [
 "checksum num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)" = "b85e541ef8255f6cf42bbfe4ef361305c6c135d10919ecc26126c4e5ae94bc09"
 "checksum num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "92e5113e9fd4cc14ded8e499429f396a20f98c772a47cc8622a736e1ec843c31"
 "checksum num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "6ba9a427cfca2be13aa6f6403b0b7e7368fe982bfa16fccc450ce74c46cd9b32"
-"checksum num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bcef43580c035376c0705c42792c294b66974abbfd2789b511784023f71f3273"
+"checksum num_cpus 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "155394f924cdddf08149da25bfb932d226b4a593ca7468b08191ff6335941af5"
 "checksum num_enum 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "be601e38e20a6f3d01049d85801cb9b7a34a8da7a0da70df507bbde7735058c8"
 "checksum num_enum_derive 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b59f30f6a043f2606adbd0addbf1eef6f2e28e8c4968918b63b7ff97ac0db2a7"
 "checksum number_prefix 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "17b02fc0ff9a9e4b35b3342880f48e896ebf69f2967921fe8646bf5b7125956a"

--- a/keygen/Cargo.toml
+++ b/keygen/Cargo.toml
@@ -12,6 +12,7 @@ edition = "2018"
 bs58 = "0.3.0"
 clap = "2.33"
 dirs = "2.0.2"
+num_cpus = "1.11.0"
 rpassword = "4.0"
 solana-sdk = { path = "../sdk", version = "0.21.0" }
 tiny-bip39 = "0.6.2"

--- a/keygen/src/keygen.rs
+++ b/keygen/src/keygen.rs
@@ -1,16 +1,29 @@
 use bip39::{Language, Mnemonic, MnemonicType, Seed};
 use bs58;
 use clap::{
-    crate_description, crate_name, crate_version, App, AppSettings, Arg, ArgMatches, SubCommand,
+    crate_description, crate_name, crate_version, values_t_or_exit, App, AppSettings, Arg,
+    ArgMatches, SubCommand,
 };
-use solana_sdk::pubkey::write_pubkey;
-use solana_sdk::signature::{
-    keypair_from_seed, read_keypair, read_keypair_file, write_keypair, write_keypair_file, Keypair,
-    KeypairUtil,
+use num_cpus;
+use solana_sdk::{
+    pubkey::write_pubkey,
+    signature::{
+        keypair_from_seed, read_keypair, read_keypair_file, write_keypair, write_keypair_file,
+        Keypair, KeypairUtil,
+    },
 };
-use std::error;
-use std::path::Path;
-use std::process::exit;
+use std::{
+    collections::HashSet,
+    error,
+    path::Path,
+    process::exit,
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc,
+    },
+    thread,
+    time::Instant,
+};
 
 const NO_PASSPHRASE: &str = "";
 
@@ -66,17 +79,41 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                         .long("silent")
                         .help("Do not display mnemonic phrase. Useful when piping output to other programs that prompt for user input, like gpg"),
                 )
+        )
+        .subcommand(
+            SubCommand::with_name("grind")
+                .about("Grind for vanity keypairs")
+                .setting(AppSettings::DisableVersion)
+                .arg(
+                    Arg::with_name("ignore_case")
+                        .long("ignore-case")
+                        .help("Perform case insensitive matches"),
+                )
+                .arg(
+                    Arg::with_name("includes")
+                        .long("includes")
+                        .value_name("BASE58")
+                        .takes_value(true)
+                        .multiple(true)
+                        .validator(|value| {
+                            bs58::decode(&value).into_vec()
+                                .map(|_| ())
+                                .map_err(|err| format!("{}: {:?}", value, err))
+                        })
+                        .help("Save keypair if its public key includes this string\n(may be specified multiple times)"),
+                )
                 .arg(
                     Arg::with_name("starts_with")
                         .long("starts-with")
                         .value_name("BASE58 PREFIX")
                         .takes_value(true)
+                        .multiple(true)
                         .validator(|value| {
-                            bs58::decode(value).into_vec()
+                            bs58::decode(&value).into_vec()
                                 .map(|_| ())
-                                .map_err(|err| format!("{:?}", err))
+                                .map_err(|err| format!("{}: {:?}", value, err))
                         })
-                        .help("Grind a keypair with public key starting with this prefix"),
+                        .help("Save keypair if its public key starts with this prefix\n(may be specified multiple times)"),
                 ),
         )
         .subcommand(
@@ -163,27 +200,9 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                 check_for_overwrite(&outfile, &matches);
             }
 
-            let mut attempts = 0;
-            let (pubkey, keypair, mnemonic) = loop {
-                let mnemonic = Mnemonic::new(MnemonicType::Words12, Language::English);
-                let seed = Seed::new(&mnemonic, NO_PASSPHRASE);
-                let keypair = keypair_from_seed(seed.as_bytes())?;
-                let pubkey = bs58::encode(keypair.pubkey()).into_string();
-
-                if let Some(prefix) = matches.value_of("starts_with") {
-                    if !pubkey.starts_with(prefix) {
-                        if attempts % 10_000 == 0 {
-                            println!(
-                                "Searching for pubkey prefix of {} ({} attempts)",
-                                prefix, attempts
-                            );
-                        }
-                        attempts += 1;
-                        continue;
-                    }
-                }
-                break (pubkey, keypair, mnemonic);
-            };
+            let mnemonic = Mnemonic::new(MnemonicType::Words12, Language::English);
+            let seed = Seed::new(&mnemonic, NO_PASSPHRASE);
+            let keypair = keypair_from_seed(seed.as_bytes())?;
 
             output_keypair(&keypair, &outfile, "new")?;
 
@@ -193,7 +212,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                 let divider = String::from_utf8(vec![b'='; phrase.len()]).unwrap();
                 eprintln!(
                     "{}\npubkey: {}\n{}\nSave this mnemonic phrase to recover your new keypair:\n{}\n{}",
-                    &divider, pubkey, &divider, phrase, &divider
+                    &divider, keypair.pubkey(), &divider, phrase, &divider
                 );
             }
         }
@@ -216,6 +235,83 @@ fn main() -> Result<(), Box<dyn error::Error>> {
             let keypair = keypair_from_seed(seed.as_bytes())?;
 
             output_keypair(&keypair, &outfile, "recovered")?;
+        }
+        ("grind", Some(matches)) => {
+            let ignore_case = matches.is_present("ignore-case");
+            let includes = if matches.is_present("includes") {
+                values_t_or_exit!(matches, "includes", String)
+                    .into_iter()
+                    .collect()
+            } else {
+                HashSet::new()
+            };
+
+            let starts_with = if matches.is_present("starts_with") {
+                values_t_or_exit!(matches, "starts_with", String)
+                    .into_iter()
+                    .collect()
+            } else {
+                HashSet::new()
+            };
+
+            if includes.is_empty() && starts_with.is_empty() {
+                eprintln!(
+                    "Error: No keypair search criteria provided (--includes or --starts-with)"
+                );
+                exit(1);
+            }
+
+            let attempts = Arc::new(AtomicU64::new(1));
+            let found = Arc::new(AtomicU64::new(0));
+            let start = Instant::now();
+
+            println!(
+                "Searching with {} threads for a pubkey containing {:?} or starting with {:?}",
+                num_cpus::get(),
+                includes,
+                starts_with
+            );
+
+            let _threads = (0..num_cpus::get())
+                .map(|_| {
+                    let attempts = attempts.clone();
+                    let found = found.clone();
+                    let includes = includes.clone();
+                    let starts_with = starts_with.clone();
+
+                    thread::spawn(move || loop {
+                        let attempts = attempts.fetch_add(1, Ordering::Relaxed);
+                        if attempts % 5_000_000 == 0 {
+                            println!(
+                                "Searched {} keypairs in {}s. {} matches found",
+                                attempts,
+                                start.elapsed().as_secs(),
+                                found.load(Ordering::Relaxed),
+                            );
+                        }
+
+                        let keypair = Keypair::new();
+                        let mut pubkey = bs58::encode(keypair.pubkey()).into_string();
+
+                        if ignore_case {
+                            pubkey = pubkey.to_lowercase();
+                        }
+
+                        if starts_with.iter().any(|s| pubkey.starts_with(s))
+                            || includes.iter().any(|s| pubkey.contains(s))
+                        {
+                            let found = found.fetch_add(1, Ordering::Relaxed);
+                            output_keypair(
+                                &keypair,
+                                &format!("{}.json", keypair.pubkey()),
+                                &format!("{}", found),
+                            )
+                            .unwrap();
+                        }
+                    });
+                })
+                .collect::<Vec<_>>();
+            thread::park();
         }
         _ => unreachable!(),
     }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -768,36 +768,6 @@ impl Bank {
         }
     }
 
-    /// Looks through a list of tick heights and stakes, and finds the latest
-    /// tick that has achieved confirmation
-    pub fn get_confirmation_timestamp(
-        &self,
-        mut slots_and_stakes: Vec<(Slot, u64)>,
-        supermajority_stake: u64,
-    ) -> Option<u64> {
-        // Sort by slot height
-        slots_and_stakes.sort_by(|a, b| b.0.cmp(&a.0));
-
-        let max_slot = self.slot();
-        let min_slot = max_slot.saturating_sub(MAX_RECENT_BLOCKHASHES as u64);
-
-        let mut total_stake = 0;
-        for (slot, stake) in slots_and_stakes.iter() {
-            if *slot >= min_slot && *slot <= max_slot {
-                total_stake += stake;
-                if total_stake > supermajority_stake {
-                    return self
-                        .blockhash_queue
-                        .read()
-                        .unwrap()
-                        .hash_height_to_timestamp(*slot);
-                }
-            }
-        }
-
-        None
-    }
-
     /// Tell the bank which Entry IDs exist on the ledger. This function
     /// assumes subsequent calls correspond to later entries, and will boot
     /// the oldest ones once its internal cache is full. Once boot, the


### PR DESCRIPTION
The key grinding support in `solana-keygen new` is now moved to a dedicated `solana-keygen grind` command that also features:
1) Multi-threaded.  Uses all CPU cores for grinding
2) Support for multiple search strings
3) Support for a more general substring search instead of only prefix search

```
Grind for vanity keypairs

USAGE:
    solana-keygen grind [FLAGS] [OPTIONS]

FLAGS:
    -h, --help           Prints help information
        --ignore-case    Perform case insensitive matches

OPTIONS:
        --includes <BASE58>...              Save keypair if its public key includes this string
                                            (may be specified multiple times)
        --starts-with <BASE58 PREFIX>...    Save keypair if its public key starts with this prefix
                                            (may be specified multiple times)
```