### PR TITLE
Add time in net/logs path

### DIFF
--- a/net/common.sh
+++ b/net/common.sh
@@ -12,8 +12,14 @@ netDir=$(
   echo "$PWD"
 )
 netConfigDir="$netDir"/config
+netLogDateDir="$netDir"/log-$(date +"%Y-%m-%d_%H_%M_%S")
 netLogDir="$netDir"/log
-mkdir -p "$netConfigDir" "$netLogDir"
+if [[ -d $netLogDir && ! -L $netLogDir ]]; then
+  echo "Warning: moving $netLogDir to make way for symlink."
+  mv "$netLogDir" "$netDir"/log.old
+fi
+mkdir -p "$netConfigDir" "$netLogDateDir"
+ln -sf "$netLogDateDir" "$netLogDir"
 
 SOLANA_ROOT="$netDir"/..
 # shellcheck source=scripts/configure-metrics.sh


### PR DESCRIPTION
#### Problem

net/logs flat structure doesn't make it easy to tell what logs are from which run.

#### Summary of Changes

Add another directory for each run which is based on the current date and time so one can tell which are the latest logs quickly.

Fixes #
