### PR TITLE
bugfix: remove duplicate signal handling

### DIFF
--- a/ledger/src/blocktree.rs
+++ b/ledger/src/blocktree.rs
@@ -542,12 +542,6 @@ impl Blocktree {
         start.stop();
         let write_batch_elapsed = start.as_us();
 
-        if should_signal {
-            for signal in &self.new_shreds_signals {
-                let _ = signal.try_send(true);
-            }
-        }
-
         send_signals(
             &self.new_shreds_signals,
             &self.completed_slots_senders,


### PR DESCRIPTION
#### Problem
In `insert_shreds`, we are firing signal to new shred signal handlers multiple times in succession (first  instance is inside `insert_shreds` and second instance is inside `send_signal`), which at best is redundant, and at worst can result in un-necessary iteration of replay stage loop.

#### Summary of Changes
Remove duplication of signal handling code. 

Fixes #
