### PR TITLE
Add genesis_accounts module

### DIFF
--- a/genesis/src/genesis_accounts.rs
+++ b/genesis/src/genesis_accounts.rs
@@ -1,0 +1,27 @@
+use solana_sdk::{account::Account, pubkey::Pubkey, system_program};
+
+pub(crate) fn create_genesis_accounts(
+    mint_pubkey: &Pubkey,
+    mint_lamports: u64,
+) -> Vec<(Pubkey, Account)> {
+    vec![
+        // the mint
+        (
+            *mint_pubkey,
+            Account::new(mint_lamports, 0, &system_program::id()),
+        ),
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_create_genesis_accounts() {
+        let mint_lamports = 42;
+        let accounts = create_genesis_accounts(&Pubkey::default(), mint_lamports);
+        let genesis_lamports: u64 = accounts.iter().map(|(_, account)| account.lamports).sum();
+        assert_eq!(genesis_lamports, mint_lamports);
+    }
+}

--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -1,5 +1,8 @@
 //! A command-line executable for generating the chain's genesis block.
 
+mod genesis_accounts;
+
+use crate::genesis_accounts::create_genesis_accounts;
 use clap::{crate_description, crate_name, crate_version, value_t_or_exit, App, Arg};
 use solana_genesis::Base64Account;
 use solana_ledger::blocktree::create_new_ledger;
@@ -330,12 +333,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
         bootstrap_leader_stake_lamports,
     );
 
-    let accounts = vec![
-        // the mint
-        (
-            mint_keypair.pubkey(),
-            Account::new(lamports, 0, &system_program::id()),
-        ),
+    let mut accounts = vec![
         // node needs an account to issue votes from
         (
             bootstrap_leader_keypair.pubkey(),
@@ -359,6 +357,10 @@ fn main() -> Result<(), Box<dyn error::Error>> {
             ),
         ),
     ];
+    accounts.append(&mut create_genesis_accounts(
+        &mint_keypair.pubkey(),
+        lamports,
+    ));
 
     let ticks_per_slot = value_t_or_exit!(matches, "ticks_per_slot", u64);
     let slots_per_epoch = value_t_or_exit!(matches, "slots_per_epoch", u64);


### PR DESCRIPTION
#### Problem

No means of adding a generated list of accounts to the genesis block.

#### Summary of Changes

Add `genesis_accounts.rs`.  Follow up PRs can work towards eliminating various CLI options. For example, CLI accepts only keypairs, but only public keys are used. It also accepts "primordial accounts", but not yet clear how to get it out.

Fixes #6686
