### PR TITLE
Book: Add blockhash to terminology

### DIFF
--- a/book/src/api-reference/blockstreamer.md
+++ b/book/src/api-reference/blockstreamer.md
@@ -24,5 +24,5 @@ The stream will output a series of JSON objects:
   * `s`, the slot height, as unsigned 64-bit integer
   * `h`, the tick height, as unsigned 64-bit integer
   * `l`, the slot leader id, as base-58 encoded string
-  * `id`, the block id, as base-58 encoded string
+  * `id`, the [blockhash](terminology.md#blockhash), as base-58 encoded string
 

--- a/book/src/api-reference/blockstreamer.md
+++ b/book/src/api-reference/blockstreamer.md
@@ -24,5 +24,5 @@ The stream will output a series of JSON objects:
   * `s`, the slot height, as unsigned 64-bit integer
   * `h`, the tick height, as unsigned 64-bit integer
   * `l`, the slot leader id, as base-58 encoded string
-  * `id`, the [blockhash](terminology.md#blockhash), as base-58 encoded string
+  * `hash`, the [blockhash](terminology.md#blockhash), as base-58 encoded string
 

--- a/book/src/implemented-proposals/leader-validator-transition.md
+++ b/book/src/implemented-proposals/leader-validator-transition.md
@@ -20,7 +20,7 @@ Slot leaders and validators use a PoH Recorder for both estimating slot height a
 
 ### PoH Recorder when Validating
 
-The PoH Recorder acts as a simple VDF when validating. It tells the validator when it needs to switch to the slot leader role. Every time the validator votes on a fork, it should use the fork's latest block id to re-seed the VDF. Re-seeding solves two problems. First, it synchronizes its VDF to the leader's, allowing it to more accurately determine when its leader slot begins. Second, if the previous leader goes down, all wallclock time is accounted for in the next leader's PoH stream. For example, if one block is missing when the leader starts, the block it produces should have a PoH duration of two blocks. The longer duration ensures the following leader isn't attempting to snip all the transactions from the previous leader's slot.
+The PoH Recorder acts as a simple VDF when validating. It tells the validator when it needs to switch to the slot leader role. Every time the validator votes on a fork, it should use the fork's latest [blockhash](terminology.md#blockhash) to re-seed the VDF. Re-seeding solves two problems. First, it synchronizes its VDF to the leader's, allowing it to more accurately determine when its leader slot begins. Second, if the previous leader goes down, all wallclock time is accounted for in the next leader's PoH stream. For example, if one block is missing when the leader starts, the block it produces should have a PoH duration of two blocks. The longer duration ensures the following leader isn't attempting to snip all the transactions from the previous leader's slot.
 
 ### PoH Recorder when Leading
 

--- a/book/src/terminology.md
+++ b/book/src/terminology.md
@@ -18,6 +18,10 @@ The result of interpreting all programs on the ledger at a given [tick height](t
 
 A contiguous set of [entries](terminology.md#entry) on the ledger covered by a [vote](terminology.md#ledger-vote). A [leader](terminology.md#leader) produces at most one block per [slot](terminology.md#slot).
 
+## blockhash
+
+The hash over a bank's state upon freeze.  Used to historically identify the block originated from the bank.
+
 ## block height
 
 The number of [blocks](terminology.md#block) beneath the current block. The first block after the [genesis block](terminology.md#genesis-block) has height one.

--- a/book/src/terminology.md
+++ b/book/src/terminology.md
@@ -72,7 +72,13 @@ An entry on the [ledger](terminology.md#ledger) either a [tick](terminology.md#t
 
 ## entry id
 
-A globally unique identifier that is also a proof that the [entry](terminology.md#entry) was generated after a duration of time, all [transactions](terminology.md#transaction) included in the entry, and all previous entries on the [ledger](terminology.md#ledger). See [Proof of History](terminology.md#proof-of-history).
+A preimage resistant [hash](terminology.md#hash) over the final contents of an entry, which acts as the [entry's](terminology.md#entry) globally unique identifier. The hash serves as evidence of:
+
+ * The entry being generated after a duration of time
+ * The specified [transactions](terminology.md#transaction) are those included in the entry
+ * The entry's position with respect to other entries in [ledger](terminology.md#ledger)
+
+See [Proof of History](terminology.md#proof-of-history).
 
 ## epoch
 

--- a/book/src/terminology.md
+++ b/book/src/terminology.md
@@ -20,15 +20,11 @@ A contiguous set of [entries](terminology.md#entry) on the ledger covered by a [
 
 ## blockhash
 
-A preimage resistant [hash](terminology.md#hash) of the [ledger](terminology.md#ledger) at a given [block height](terminology.md#block-height).
+A preimage resistant [hash](terminology.md#hash) of the [ledger](terminology.md#ledger) at a given [block height](terminology.md#block-height). Taken from the last [entry id](terminology.md#entry-id) in the slot
 
 ## block height
 
 The number of [blocks](terminology.md#block) beneath the current block. The first block after the [genesis block](terminology.md#genesis-block) has height one.
-
-## block id
-
-The [entry id](terminology.md#entry-id) of the last entry in a [block](terminology.md#block).
 
 ## bootstrap leader
 

--- a/book/src/terminology.md
+++ b/book/src/terminology.md
@@ -20,7 +20,7 @@ A contiguous set of [entries](terminology.md#entry) on the ledger covered by a [
 
 ## blockhash
 
-A preimage resistant [hash](terminology.md#hash) of the [ledger](terminology.md#ledger) state at a given [block height](terminology.md#block-height).
+A preimage resistant [hash](terminology.md#hash) of the [ledger](terminology.md#ledger) at a given [block height](terminology.md#block-height).
 
 ## block height
 

--- a/book/src/terminology.md
+++ b/book/src/terminology.md
@@ -20,7 +20,7 @@ A contiguous set of [entries](terminology.md#entry) on the ledger covered by a [
 
 ## blockhash
 
-The hash over a bank's state upon freeze.  Used to historically identify the block originated from the bank.
+A preimage resistant [hash](terminology.md#hash) of the [ledger](terminology.md#ledger) state at a given [block height](terminology.md#block-height).
 
 ## block height
 


### PR DESCRIPTION
#### Problem

`blockhash` is missing from terminology

#### Summary of Changes

Add it.

As requested in #6663