### PR TITLE
Rename confidence to commitment

### DIFF
--- a/book/src/api-reference/jsonrpc-api.md
+++ b/book/src/api-reference/jsonrpc-api.md
@@ -17,7 +17,7 @@ To interact with a Solana node inside a JavaScript application, use the [solana-
 * [confirmTransaction](jsonrpc-api.md#confirmtransaction)
 * [getAccountInfo](jsonrpc-api.md#getaccountinfo)
 * [getBalance](jsonrpc-api.md#getbalance)
-* [getBlockConfidence](jsonrpc-api.md#getblockconfidence)
+* [getBlockCommitment](jsonrpc-api.md#getblockcommitment)
 * [getClusterNodes](jsonrpc-api.md#getclusternodes)
 * [getEpochInfo](jsonrpc-api.md#getepochinfo)
 * [getEpochSchedule](jsonrpc-api.md#getepochschedule)
@@ -151,9 +151,9 @@ curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0", "id":1, "
 {"jsonrpc":"2.0","result":0,"id":1}
 ```
 
-### getBlockConfidence
+### getBlockCommitment
 
-Returns confidence for particular block
+Returns commitment for particular block
 
 #### Parameters:
 
@@ -163,20 +163,20 @@ Returns confidence for particular block
 
 The result field will be an array with two fields:
 
-* Confidence
+* Commitment
   * `null` - Unknown block
-  * `object` - BankConfidence
-    * `array` - confidence, array of u64 integers logging the amount of cluster stake in lamports that has voted on the block at each depth from 0 to `MAX_LOCKOUT_HISTORY`
+  * `object` - BlockCommitment
+    * `array` - commitment, array of u64 integers logging the amount of cluster stake in lamports that has voted on the block at each depth from 0 to `MAX_LOCKOUT_HISTORY`
 * 'integer' - total active stake, in lamports, of the current epoch
 
 #### Example:
 
 ```bash
 // Request
-curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1, "method":"getBlockConfidence","params":[5]}' http://localhost:8899
+curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1, "method":"getBlockCommitment","params":[5]}' http://localhost:8899
 
 // Result
-{"jsonrpc":"2.0","result":[{"confidence":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,10,32]},42],"id":1}
+{"jsonrpc":"2.0","result":[{"commitment":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,10,32]},42],"id":1}
 ```
 
 ### getClusterNodes

--- a/book/src/implemented-proposals/commitment.md
+++ b/book/src/implemented-proposals/commitment.md
@@ -1,8 +1,8 @@
 # Commitment
 
 The commitment metric aims to give clients a measure of the network confirmation
-and stake levels on a particular block. Clients can then use this information to 
-derive their own measures of confidence.
+and stake levels on a particular block. Clients can then use this information to
+derive their own measures of commitment.
 
 # Calculation RPC
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -10,7 +10,7 @@ pub mod broadcast_stage;
 pub mod chacha;
 pub mod chacha_cuda;
 pub mod cluster_info_vote_listener;
-pub mod confidence;
+pub mod commitment;
 pub mod recycler;
 pub mod shred_fetch_stage;
 #[macro_use]

--- a/core/src/rpc_service.rs
+++ b/core/src/rpc_service.rs
@@ -1,7 +1,7 @@
 //! The `rpc_service` module implements the Solana JSON RPC service.
 
 use crate::{
-    cluster_info::ClusterInfo, confidence::ForkConfidenceCache, rpc::*, service::Service,
+    cluster_info::ClusterInfo, commitment::BlockCommitmentCache, rpc::*, service::Service,
     storage_stage::StorageState, validator::ValidatorExit,
 };
 use jsonrpc_core::MetaIoHandler;
@@ -91,7 +91,7 @@ impl JsonRpcService {
         storage_state: StorageState,
         config: JsonRpcConfig,
         bank_forks: Arc<RwLock<BankForks>>,
-        fork_confidence_cache: Arc<RwLock<ForkConfidenceCache>>,
+        block_commitment_cache: Arc<RwLock<BlockCommitmentCache>>,
         ledger_path: &Path,
         genesis_blockhash: Hash,
         validator_exit: &Arc<RwLock<Option<ValidatorExit>>>,
@@ -102,7 +102,7 @@ impl JsonRpcService {
             storage_state,
             config,
             bank_forks,
-            fork_confidence_cache,
+            block_commitment_cache,
             validator_exit,
         )));
         let request_processor_ = request_processor.clone();
@@ -199,14 +199,14 @@ mod tests {
             solana_netutil::find_available_port_in_range((10000, 65535)).unwrap(),
         );
         let bank_forks = Arc::new(RwLock::new(BankForks::new(bank.slot(), bank)));
-        let fork_confidence_cache = Arc::new(RwLock::new(ForkConfidenceCache::default()));
+        let block_commitment_cache = Arc::new(RwLock::new(BlockCommitmentCache::default()));
         let mut rpc_service = JsonRpcService::new(
             &cluster_info,
             rpc_addr,
             StorageState::default(),
             JsonRpcConfig::default(),
             bank_forks,
-            fork_confidence_cache,
+            block_commitment_cache,
             &PathBuf::from("farf"),
             Hash::default(),
             &validator_exit,

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -14,7 +14,7 @@
 
 use crate::blockstream_service::BlockstreamService;
 use crate::cluster_info::ClusterInfo;
-use crate::confidence::ForkConfidenceCache;
+use crate::commitment::BlockCommitmentCache;
 use crate::ledger_cleanup_service::LedgerCleanupService;
 use crate::poh_recorder::PohRecorder;
 use crate::replay_stage::ReplayStage;
@@ -82,7 +82,7 @@ impl Tvu {
         leader_schedule_cache: &Arc<LeaderScheduleCache>,
         exit: &Arc<AtomicBool>,
         completed_slots_receiver: CompletedSlotsReceiver,
-        fork_confidence_cache: Arc<RwLock<ForkConfidenceCache>>,
+        block_commitment_cache: Arc<RwLock<BlockCommitmentCache>>,
         sigverify_disabled: bool,
     ) -> Self
     where
@@ -171,7 +171,7 @@ impl Tvu {
             leader_schedule_cache,
             vec![blockstream_slot_sender, ledger_cleanup_slot_sender],
             snapshot_package_sender,
-            fork_confidence_cache,
+            block_commitment_cache,
         );
 
         let blockstream_service = if let Some(blockstream_unix_socket) = blockstream_unix_socket {
@@ -279,7 +279,7 @@ pub mod tests {
         let voting_keypair = Keypair::new();
         let storage_keypair = Arc::new(Keypair::new());
         let leader_schedule_cache = Arc::new(LeaderScheduleCache::new_from_bank(&bank));
-        let fork_confidence_cache = Arc::new(RwLock::new(ForkConfidenceCache::default()));
+        let block_commitment_cache = Arc::new(RwLock::new(BlockCommitmentCache::default()));
         let tvu = Tvu::new(
             &voting_keypair.pubkey(),
             Some(&Arc::new(voting_keypair)),
@@ -304,7 +304,7 @@ pub mod tests {
             &leader_schedule_cache,
             &exit,
             completed_slots_receiver,
-            fork_confidence_cache,
+            block_commitment_cache,
             false,
         );
         exit.store(true, Ordering::Relaxed);

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -3,7 +3,7 @@
 use crate::{
     broadcast_stage::BroadcastStageType,
     cluster_info::{ClusterInfo, Node},
-    confidence::ForkConfidenceCache,
+    commitment::BlockCommitmentCache,
     contact_info::ContactInfo,
     gossip_service::{discover_cluster, GossipService},
     poh_recorder::PohRecorder,
@@ -181,7 +181,7 @@ impl Validator {
         let bank_info = &bank_forks_info[0];
         let bank = bank_forks[bank_info.bank_slot].clone();
         let bank_forks = Arc::new(RwLock::new(bank_forks));
-        let fork_confidence_cache = Arc::new(RwLock::new(ForkConfidenceCache::default()));
+        let block_commitment_cache = Arc::new(RwLock::new(BlockCommitmentCache::default()));
 
         let mut validator_exit = ValidatorExit::default();
         let exit_ = exit.clone();
@@ -209,7 +209,7 @@ impl Validator {
                 storage_state.clone(),
                 config.rpc_config.clone(),
                 bank_forks.clone(),
-                fork_confidence_cache.clone(),
+                block_commitment_cache.clone(),
                 ledger_path,
                 genesis_blockhash,
                 &validator_exit,
@@ -340,7 +340,7 @@ impl Validator {
             &leader_schedule_cache,
             &exit,
             completed_slots_receiver,
-            fork_confidence_cache,
+            block_commitment_cache,
             config.dev_sigverify_disabled,
         );
 


### PR DESCRIPTION
#### Problem
The book contains an implemented proposal referring to commitment, but there is no "commitment" in the code base. Inconsistency is sad.

#### Summary of Changes
- s/confidence/commitment
- Also s/fork/block and s/bank/block for clarity
