### PR TITLE
return bank slot info with block-related results

### DIFF
--- a/book/src/api-reference/jsonrpc-api.md
+++ b/book/src/api-reference/jsonrpc-api.md
@@ -96,6 +96,13 @@ If commitment configuration is not provided, the node will default to `"commitme
 
 Only methods that query bank state accept the commitment parameter. They are indicated in the API Reference below.
 
+#### RpcResponse Structure
+Many methods that take a commitment parameter return an RpcResponse JSON object comprised of two parts:
+
+* `context` : An RpcResponseContext JSON structure including a `slot` field at which the operation was evaluated.
+* `value` : The value returned by the operation itself.
+
+
 ## JSON RPC API Reference
 
 ### confirmTransaction
@@ -109,7 +116,7 @@ Returns a transaction receipt
 
 #### Results:
 
-* `boolean` - Transaction status, true if Transaction is confirmed
+* `RpcResponse<boolean>` - RpcResponse JSON object with `value` field set to Transaction status, boolean true if Transaction is confirmed
 
 #### Example:
 
@@ -118,7 +125,7 @@ Returns a transaction receipt
 curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0", "id":1, "method":"confirmTransaction", "params":["5VERv8NMvzbJMEkV8xnrLkEaWRtSz9CosKDYjCJjBRnbJLgp8uirBgmQpjKhoR4tjF3ZpRzrFmBV6UjKdiSZkQUW"]}' http://localhost:8899
 
 // Result
-{"jsonrpc":"2.0","result":true,"id":1}
+{"jsonrpc":"2.0","result":{"context":{"slot":1},"value":true},"id":1}
 ```
 
 ### getAccountInfo
@@ -132,8 +139,9 @@ Returns all information associated with the account of provided Pubkey
 
 #### Results:
 
-The result field will be a JSON object with the following sub fields:
+The result value will be an RpcResponse JSON object containing an AccountInfo JSON object.
 
+* `RpcResponse<AccountInfo>`, RpcResponse JSON object with `value` field set to AccountInfo, a JSON object containing:
 * `lamports`, number of lamports assigned to this account, as a signed 64-bit integer
 * `owner`, array of 32 bytes representing the program this account has been assigned to
 * `data`, array of bytes representing any data associated with the account
@@ -146,7 +154,7 @@ The result field will be a JSON object with the following sub fields:
 curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0", "id":1, "method":"getAccountInfo", "params":["2gVkYWexTHR5Hb2aLeQN3tnngvWzisFKXDUPrgMHpdST"]}' http://localhost:8899
 
 // Result
-{"jsonrpc":"2.0","result":{"executable":false,"owner":[1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"lamports":1,"data":[3,0,0,0,0,0,0,0,1,0,0,0,0,0,1,0,0,0,0,0,0,0.21.0,0,0,0,0,0,0,50,48,53,48,45,48,49,45,48,49,84,48,48,58,48,48,58,48,48,90,252,10,7,28,246,140,88,177,98,82,10,227,89,81,18,30,194,101,199,16,11,73,133,20,246,62,114,39,20,113,189,32,50,0,0,0,0,0,0,0,247,15,36,102,167,83,225,42,133,127,82,34,36,224,207,130,109,230,224,188,163,33,213,13,5,117,211,251,65,159,197,51,0,0,0,0,0,0]},"id":1}
+{"jsonrpc":"2.0","result":{"context":{"slot":1},"value":{"executable":false,"owner":[1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"lamports":1,"data":[3,0,0,0,0,0,0,0,1,0,0,0,0,0,1,0,0,0,0,0,0,0.21.0,0,0,0,0,0,0,50,48,53,48,45,48,49,45,48,49,84,48,48,58,48,48,58,48,48,90,252,10,7,28,246,140,88,177,98,82,10,227,89,81,18,30,194,101,199,16,11,73,133,20,246,62,114,39,20,113,189,32,50,0,0,0,0,0,0,0,247,15,36,102,167,83,225,42,133,127,82,34,36,224,207,130,109,230,224,188,163,33,213,13,5,117,211,251,65,159,197,51,0,0,0,0,0,0]}},"id":1}
 ```
 
 ### getBalance
@@ -160,7 +168,7 @@ Returns the balance of the account of provided Pubkey
 
 #### Results:
 
-* `integer` - quantity, as a signed 64-bit integer
+* `RpcResponse<integer>` - RpcResponse JSON object with `value` field set to quantity, as a signed 64-bit integer
 
 #### Example:
 
@@ -169,7 +177,7 @@ Returns the balance of the account of provided Pubkey
 curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0", "id":1, "method":"getBalance", "params":["83astBRguLMdt2h5U1Tpdq5tjFoJ6noeGwaY3mDLVcri"]}' http://localhost:8899
 
 // Result
-{"jsonrpc":"2.0","result":0,"id":1}
+{"jsonrpc":"2.0","result":{"context":{"slot":1},"value":0},"id":1}
 ```
 
 ### getBlockCommitment
@@ -410,8 +418,9 @@ Returns a recent block hash from the ledger, and a fee schedule that can be used
 
 #### Results:
 
-An array consisting of
+An RpcResponse containing an array consisting of a string blockhash and FeeCalculator JSON object.
 
+* `RpcResponse<array>` - RpcResponse JSON object with `value` field set to an array including:
 * `string` - a Hash as base-58 encoded string
 * `FeeCalculator object` - the fee schedule for this block hash
 
@@ -422,7 +431,7 @@ An array consisting of
 curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1, "method":"getRecentBlockhash"}' http://localhost:8899
 
 // Result
-{"jsonrpc":"2.0","result":["GH7ome3EiwEr7tu9JuTh2dpYWBJK3z69Xm1ZE3MEE6JC",{"lamportsPerSignature": 0}],"id":1}
+{"jsonrpc":"2.0","result":{"context":{"slot":1},"value":["GH7ome3EiwEr7tu9JuTh2dpYWBJK3z69Xm1ZE3MEE6JC",{"lamportsPerSignature": 0}]},"id":1}
 ```
 
 ### getSignatureStatus

--- a/cli/tests/deploy.rs
+++ b/cli/tests/deploy.rs
@@ -3,7 +3,7 @@ use solana_cli::cli::{process_command, CliCommand, CliConfig};
 use solana_client::rpc_client::RpcClient;
 use solana_core::validator::new_validator_for_tests;
 use solana_drone::drone::run_local_drone;
-use solana_sdk::{bpf_loader, commitment_config::CommitmentConfig, pubkey::Pubkey};
+use solana_sdk::{bpf_loader, pubkey::Pubkey};
 use std::{
     fs::{remove_dir_all, File},
     io::Read,
@@ -59,10 +59,7 @@ fn test_cli_deploy_program() {
         .as_str()
         .unwrap();
     let program_id = Pubkey::from_str(&program_id_str).unwrap();
-
-    let account = rpc_client
-        .get_account_with_commitment(&program_id, CommitmentConfig::recent())
-        .unwrap();
+    let account = rpc_client.get_account(&program_id).unwrap();
     assert_eq!(account.lamports, minimum_balance_for_rent_exemption);
     assert_eq!(account.owner, bpf_loader::id());
     assert_eq!(account.executable, true);

--- a/client/src/rpc_request.rs
+++ b/client/src/rpc_request.rs
@@ -1,9 +1,24 @@
+use jsonrpc_core::Result as JsonResult;
 use serde_json::{json, Value};
 use solana_sdk::{
     clock::{Epoch, Slot},
     commitment_config::CommitmentConfig,
 };
-use std::{error, fmt};
+use std::{error, fmt, io};
+
+pub type RpcResponseIn<T> = JsonResult<Response<T>>;
+pub type RpcResponse<T> = io::Result<Response<T>>;
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RpcResponseContext {
+    pub slot: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Response<T> {
+    pub context: RpcResponseContext,
+    pub value: T,
+}
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]

--- a/core/src/rpc_service.rs
+++ b/core/src/rpc_service.rs
@@ -229,7 +229,9 @@ mod tests {
                 .request_processor
                 .read()
                 .unwrap()
-                .get_balance(&mint_keypair.pubkey(), None)
+                .get_balance(Ok(mint_keypair.pubkey()), None)
+                .unwrap()
+                .value
         );
         rpc_service.exit();
         rpc_service.join().unwrap();

--- a/core/tests/client.rs
+++ b/core/tests/client.rs
@@ -1,5 +1,6 @@
 use solana_client::rpc_client::RpcClient;
 use solana_core::validator::new_validator_for_tests;
+use solana_sdk::commitment_config::CommitmentConfig;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::KeypairUtil;
 use solana_sdk::system_transaction;
@@ -22,7 +23,6 @@ fn test_rpc_client() {
     );
 
     assert_eq!(client.get_balance(&bob_pubkey).unwrap(), 0);
-
     assert_eq!(client.get_balance(&alice.pubkey()).unwrap(), 10000);
 
     let (blockhash, _fee_calculator) = client.get_recent_blockhash().unwrap();
@@ -34,14 +34,13 @@ fn test_rpc_client() {
 
     let now = Instant::now();
     while now.elapsed().as_secs() <= 20 {
-        let response = client.confirm_transaction(signature.as_str());
+        let response = client
+            .confirm_transaction_with_commitment(signature.as_str(), CommitmentConfig::default())
+            .unwrap();
 
-        match response {
-            Ok(true) => {
-                confirmed_tx = true;
-                break;
-            }
-            _ => (),
+        if response.value {
+            confirmed_tx = true;
+            break;
         }
 
         sleep(Duration::from_millis(500));

--- a/core/tests/rpc.rs
+++ b/core/tests/rpc.rs
@@ -34,7 +34,11 @@ fn test_rpc_send_tx() {
         .send()
         .unwrap();
     let json: Value = serde_json::from_str(&response.text().unwrap()).unwrap();
-    let blockhash: Hash = json["result"][0].as_str().unwrap().parse().unwrap();
+    let blockhash: Hash = json["result"]["value"][0]
+        .as_str()
+        .unwrap()
+        .parse()
+        .unwrap();
 
     info!("blockhash: {:?}", blockhash);
     let tx = system_transaction::transfer(&alice, &bob_pubkey, 20, blockhash);
@@ -78,7 +82,7 @@ fn test_rpc_send_tx() {
         let response_json_text = response.text().unwrap();
         let json: Value = serde_json::from_str(&response_json_text).unwrap();
 
-        if true == json["result"] {
+        if true == json["result"]["value"] {
             confirmed_tx = true;
             break;
         }


### PR DESCRIPTION
#### Problem

* we should return 1 or more "bank information" data points with certain results
* see issue #6679

#### Summary of Changes

* introduce an `RpcResponseContext` struct (containing just `slot` for now)
* Introduce an `RpcResponse` struct (encapsulating `context` and `value`)
* change RPC responses to return `RpcResponse` wrapping their original result

### Drawbacks

* `RpcResponse` is not a `Result`, so when we return an `Error` outside the bank context, we need to wrap the `BankResult` in a `Result`, resulting in a `BankResult` sandwich (or, provide an error without context) 🍞 
* As we start getting into confirmation results, this will impact a deep call tree of methods
* These changes will affect the RPC clients across a *lot* of methods

### Alternatives Considered

* return bank information as "X-BankInfo-" HTTP headers (drawback, tightly coupled to HTTP)
* extend existing result objects with `bank_info_slot`, `bank_info_leader` (etc) fields (drawback, polluting the structs)
* return tuples `(BankContext, T)` from methods (drawback, tuples aren't named)
* add new methods that include the bank context (drawback, proliferation/clutter)
* NOTE: there are some new methods with `_with_commitment` suffix to balance API breakage with convenience

Fixes #6679 
