### PR TITLE
Allow voting on empty banks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3281,6 +3281,7 @@ dependencies = [
  "jsonrpc-pubsub 14.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-ws-server 14.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "memmap 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -492,6 +492,9 @@ impl ReplayStage {
     where
         T: 'static + KeypairUtil + Send + Sync,
     {
+        if bank.is_empty() {
+            inc_new_counter_info!("replay_stage-voted_empty_bank", 1);
+        }
         trace!("handle votable bank {}", bank.slot());
         let (vote, tower_index) = tower.new_vote_from_bank(bank, vote_account);
         if let Some(new_root) = tower.record_bank_vote(vote) {
@@ -650,11 +653,6 @@ impl ReplayStage {
         trace!("frozen_banks {}", frozen_banks.len());
         let mut votable: Vec<(u128, Arc<Bank>, HashMap<u64, StakeLockout>, u64)> = frozen_banks
             .values()
-            .filter(|b| {
-                let is_votable = b.is_votable();
-                trace!("bank is votable: {} {}", b.slot(), is_votable);
-                is_votable
-            })
             .filter(|b| {
                 let has_voted = tower.has_voted(b.slot());
                 trace!("bank has_voted: {} {}", b.slot(), has_voted);

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -147,7 +147,7 @@ fn graph_forks(
                         "".to_string()
                     },
                     if first { "filled," } else { "" },
-                    if !bank.is_votable() { "dotted," } else { "" }
+                    ""
                 ));
                 styled_slots.insert(bank.slot());
             }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1630,7 +1630,6 @@ mod tests {
         clock::DEFAULT_TICKS_PER_SLOT,
         epoch_schedule::MINIMUM_SLOTS_PER_EPOCH,
         genesis_block::create_genesis_block,
-        hash,
         instruction::InstructionError,
         message::{Message, MessageHeader},
         poh_config::PohConfig,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -693,9 +693,6 @@ impl Bank {
         //  / ticks/slot
             / self.ticks_per_slot as f64;
 
-        // make bank 0 votable
-        self.is_delta.store(true, Ordering::Relaxed);
-
         self.epoch_schedule = genesis_block.epoch_schedule;
 
         self.inflation = genesis_block.inflation;
@@ -2940,19 +2937,14 @@ mod tests {
         let bank0 = Arc::new(Bank::new(&genesis_block));
         let key1 = Keypair::new();
 
-        // The zeroth bank is not empty because it processes transactions
-        assert_eq!(bank0.is_empty(), false);
-
-        let bank1 = Bank::new_from_parent(&bank0, &Pubkey::default(), 1);
-
-        // The first bank is empty becasue there are no transactions
-        assert_eq!(bank1.is_empty(), true);
+        // The zeroth bank is empty becasue there are no transactions
+        assert_eq!(bank0.is_empty(), true);
 
         // Set is_delta to true, bank is no longer empty
         let tx_transfer_mint_to_1 =
             system_transaction::transfer(&mint_keypair, &key1.pubkey(), 1, genesis_block.hash());
-        assert_eq!(bank1.process_transaction(&tx_transfer_mint_to_1), Ok(()));
-        assert_eq!(bank1.is_empty(), false);
+        assert_eq!(bank0.process_transaction(&tx_transfer_mint_to_1), Ok(()));
+        assert_eq!(bank0.is_empty(), false);
     }
 
     #[test]


### PR DESCRIPTION
#### Problem
Disallowing votes on empty banks leads can stall the network when their parents are also non-votable due to threshold failures. This is possible when the parents have included all the consumable transactions on the network.

#### Summary of Changes
1) Allow votes on empty banks
2) Add test to check that even when there is no activity on the network, banks still chain correctly

Fixes #
