### PR TITLE
Fix limited iftop output and failure to stop iftop

### DIFF
--- a/net/net.sh
+++ b/net/net.sh
@@ -814,13 +814,13 @@ stopNode() {
       ! tmux list-sessions || tmux kill-session
       declare sudo=
       if sudo true; then
-      sudo="sudo -n"
+        sudo="sudo -n"
       fi
 
       for pid in solana/*.pid; do
         pgid=\$(ps opgid= \$(cat \$pid) | tr -d '[:space:]')
         if [[ -n \$pgid ]]; then
-          $sudo kill -- -\$pgid
+          \$sudo kill -- -\$pgid
         fi
       done
       for pattern in node solana- remote-; do

--- a/net/net.sh
+++ b/net/net.sh
@@ -812,7 +812,7 @@ stopNode() {
       PS4=\"$PS4\"
       set -x
       ! tmux list-sessions || tmux kill-session
-      sudo=
+      declare sudo=
       if sudo true; then
       sudo="sudo -n"
       fi

--- a/net/net.sh
+++ b/net/net.sh
@@ -812,10 +812,15 @@ stopNode() {
       PS4=\"$PS4\"
       set -x
       ! tmux list-sessions || tmux kill-session
+      sudo=
+      if sudo true; then
+      sudo="sudo -n"
+      fi
+
       for pid in solana/*.pid; do
         pgid=\$(ps opgid= \$(cat \$pid) | tr -d '[:space:]')
         if [[ -n \$pgid ]]; then
-          sudo kill -- -\$pgid
+          $sudo kill -- -\$pgid
         fi
       done
       for pattern in node solana- remote-; do

--- a/scripts/iftop.sh
+++ b/scripts/iftop.sh
@@ -13,4 +13,4 @@ if sudo true; then
 sudo="sudo -n"
 fi
 
-exec $sudo iftop -i "$(ifconfig | grep mtu | grep -iv loopback | grep -i running | awk 'BEGIN { FS = ":" } ; {print $1}')" -nNbBP -t -L 1000
+exec "$sudo" iftop -i "$(ifconfig | grep mtu | grep -iv loopback | grep -i running | awk 'BEGIN { FS = ":" } ; {print $1}')" -nNbBP -t -L 1000

--- a/scripts/iftop.sh
+++ b/scripts/iftop.sh
@@ -13,4 +13,4 @@ if sudo true; then
 sudo="sudo -n"
 fi
 
-$sudo iftop -i "$(ifconfig | grep mtu | grep -iv loopback | grep -i running | awk 'BEGIN { FS = ":" } ; {print $1}')" -nNbBP  -t
+exec $sudo iftop -i "$(ifconfig | grep mtu | grep -iv loopback | grep -i running | awk 'BEGIN { FS = ":" } ; {print $1}')" -nNbBP -t -L 1000

--- a/scripts/iftop.sh
+++ b/scripts/iftop.sh
@@ -12,5 +12,5 @@ sudo=
 if sudo true; then
 sudo="sudo -n"
 fi
-
-exec "$sudo" iftop -i "$(ifconfig | grep mtu | grep -iv loopback | grep -i running | awk 'BEGIN { FS = ":" } ; {print $1}')" -nNbBP -t -L 1000
+# shellcheck disable=SC2086
+exec $sudo iftop -i "$(ifconfig | grep mtu | grep -iv loopback | grep -i running | awk 'BEGIN { FS = ":" } ; {print $1}')" -nNbBP -t -L 1000


### PR DESCRIPTION
#### Problem

- By default iftop only prints 10 send/recv items and can cause us to lose track of some connections.
- iftop doesn't stop on colo

#### Summary of Changes

- kill iftop properly even if we have no sudo
- extend the iftop limit to 1000 lines instead of 10


Fixes #
