### PR TITLE
Remove credit-only account handling

### DIFF
--- a/book/src/api-reference/transaction-api.md
+++ b/book/src/api-reference/transaction-api.md
@@ -14,7 +14,7 @@
 
       * **num\_credit\_only\_signed\_accounts:** The last
 
-        `num_credit_only_signed_accounts` signatures refer to signing
+        `num_read_only_signed_accounts` signatures refer to signing
 
         credit only accounts. Credit only accounts can be used concurrently
 
@@ -24,7 +24,7 @@
 
       * **num\_credit\_only\_unsigned\_accounts:** The last
 
-        `num_credit_only_unsigned_accounts` public keys in `account_keys` refer
+        `num_read_only_unsigned_accounts` public keys in `account_keys` refer
 
         to non-signing credit only accounts
 
@@ -60,4 +60,3 @@ A `Transaction` is signed by using an ed25519 keypair to sign the serialization 
 ## Transaction Serialization
 
 `Transaction`s \(and their `message`s\) are serialized and deserialized using the [bincode](https://crates.io/crates/bincode) crate with a non-standard vector serialization that uses only one byte for the length if it can be encoded in 7 bits, 2 bytes if it fits in 14 bits, or 3 bytes if it requires 15 or 16 bits. The vector serialization is defined by Solana's [short-vec](https://github.com/solana-labs/solana/blob/master/sdk/src/short_vec.rs).
-

--- a/book/src/api-reference/transaction-api.md
+++ b/book/src/api-reference/transaction-api.md
@@ -14,7 +14,7 @@
 
       * **num\_credit\_only\_signed\_accounts:** The last
 
-        `num_read_only_signed_accounts` signatures refer to signing
+        `num_readonly_signed_accounts` signatures refer to signing
 
         credit only accounts. Credit only accounts can be used concurrently
 
@@ -24,7 +24,7 @@
 
       * **num\_credit\_only\_unsigned\_accounts:** The last
 
-        `num_read_only_unsigned_accounts` public keys in `account_keys` refer
+        `num_readonly_unsigned_accounts` public keys in `account_keys` refer
 
         to non-signing credit only accounts
 

--- a/book/src/proposals/rent.md
+++ b/book/src/proposals/rent.md
@@ -32,7 +32,7 @@ Collecting rent on an as-needed basis \(i.e. whenever accounts were loaded/acces
 
 * accounts loaded as "credit only" for a transaction could very reasonably be expected to have rent due,
 
-  but would not be debitable during any such transaction
+  but would not be writable during any such transaction
 
 * a mechanism to "beat the bushes" \(i.e. go find accounts that need to pay rent\) is desirable,
 

--- a/book/src/terminology.md
+++ b/book/src/terminology.md
@@ -84,7 +84,7 @@ A proof which has the same format as a storage proof, but the sha state is actua
 
 ## fee account
 
-The fee account in the transaction is the account pays for the cost of including the transaction in the ledger. This is the first account in the transaction. This account must be declared as Credit-Debit in the transaction since paying for the transaction reduces the account balance.
+The fee account in the transaction is the account pays for the cost of including the transaction in the ledger. This is the first account in the transaction. This account must be declared as Read-Write (writable) in the transaction since paying for the transaction reduces the account balance.
 
 ## finality
 

--- a/book/src/transaction.md
+++ b/book/src/transaction.md
@@ -1,12 +1,12 @@
 # Anatomy of a Transaction
 
-Transactions encode lists of instructions that are executed sequentially, and only committed if all the instructions complete successfully. All account updates are reverted upon the failure of a transaction. Each transaction details the accounts used, including which must sign and which are credit only, a recent blockhash, the instructions, and any signatures.
+Transactions encode lists of instructions that are executed sequentially, and only committed if all the instructions complete successfully. All account updates are reverted upon the failure of a transaction. Each transaction details the accounts used, including which must sign and which are read only, a recent blockhash, the instructions, and any signatures.
 
 ## Accounts and Signatures
 
 Each transaction explicitly lists all account public keys referenced by the transaction's instructions. A subset of those public keys are each accompanied by a transaction signature. Those signatures signal on-chain programs that the account holder has authorized the transaction. Typically, the program uses the authorization to permit debiting the account or modifying its data.
 
-The transaction also marks some accounts as _credit-only accounts_. The runtime permits credit-only accounts to be credited concurrently. If a program attempts to debit a credit-only account or modify its account data, the transaction is rejected by the runtime.
+The transaction also marks some accounts as _read-only accounts_. The runtime permits read-only accounts to be read concurrently. If a program attempts to modify a read-only account, the transaction is rejected by the runtime.
 
 ## Recent Blockhash
 
@@ -15,4 +15,3 @@ A Transaction includes a recent blockhash to prevent duplication and to give tra
 ## Instructions
 
 Each instruction specifies a single program account \(which must be marked executable\), a subset of the transaction's accounts that should be passed to the program, and a data byte array instruction that is passed to the program. The program interprets the data array and operates on the accounts specified by the instructions. The program can return successfully, or with an error code. An error return causes the entire transaction to fail immediately.
-

--- a/book/src/validator/runtime.md
+++ b/book/src/validator/runtime.md
@@ -2,7 +2,7 @@
 
 ## The Runtime
 
-The runtime is a concurrent transaction processor. Transactions specify their data dependencies upfront and dynamic memory allocation is explicit. By separating program code from the state it operates on, the runtime is able to choreograph concurrent access. Transactions accessing only credit-only accounts are executed in parallel whereas transactions accessing writable accounts are serialized. The runtime interacts with the program through an entrypoint with a well-defined interface. The data stored in an account is an opaque type, an array of bytes. The program has full control over its contents.
+The runtime is a concurrent transaction processor. Transactions specify their data dependencies upfront and dynamic memory allocation is explicit. By separating program code from the state it operates on, the runtime is able to choreograph concurrent access. Transactions accessing only read-only accounts are executed in parallel whereas transactions accessing writable accounts are serialized. The runtime interacts with the program through an entrypoint with a well-defined interface. The data stored in an account is an opaque type, an array of bytes. The program has full control over its contents.
 
 The transaction structure specifies a list of public keys and signatures for those keys and a sequential list of instructions that will operate over the states associated with the account keys. For the transaction to be committed all the instructions must execute successfully; if any abort the whole transaction fails to commit.
 
@@ -28,7 +28,7 @@ The runtime enforces the following rules:
 
 1. Only the _owner_ program may modify the contents of an account. This means that upon assignment data vector is guaranteed to be zero.
 2. Total balances on all the accounts is equal before and after execution of a transaction.
-3. After the transaction is executed, balances of credit-only accounts must be greater than or equal to the balances before the transaction.
+3. After the transaction is executed, balances of read-only accounts must be equal to the balances before the transaction.
 4. All instructions in the transaction executed atomically. If one fails, all account modifications are discarded.
 
 Execution of the program involves mapping the program's public key to an entrypoint which takes a pointer to the transaction, and an array of loaded accounts.
@@ -62,4 +62,3 @@ To pass messages between programs, the receiving program must accept the message
 * \[Continuations and Signals for long running
 
   Transactions\]\([https://github.com/solana-labs/solana/issues/1485](https://github.com/solana-labs/solana/issues/1485)\)
-

--- a/core/src/sigverify.rs
+++ b/core/src/sigverify.rs
@@ -92,7 +92,7 @@ pub enum PacketError {
     InvalidShortVec,
     InvalidSignatureLen,
     MismatchSignatureLen,
-    PayerNotDebitable,
+    PayerNotWritable,
 }
 
 impl std::convert::From<std::boxed::Box<bincode::ErrorKind>> for PacketError {
@@ -182,11 +182,11 @@ fn do_get_packet_offsets(
     let message_account_keys_len_offset = msg_start_offset + message_header_size;
 
     // This reads and compares the MessageHeader num_required_signatures and
-    // num_credit_only_signed_accounts bytes. If num_required_signatures is not larger than
-    // num_credit_only_signed_accounts, the first account is not debitable, and cannot be charged
+    // num_read_only_signed_accounts bytes. If num_required_signatures is not larger than
+    // num_read_only_signed_accounts, the first account is not writable, and cannot be charged
     // required transaction fees.
     if packet.data[msg_start_offset] <= packet.data[msg_start_offset + 1] {
-        return Err(PacketError::PayerNotDebitable);
+        return Err(PacketError::PayerNotWritable);
     }
 
     // read the length of Message.account_keys (serialized with short_vec)
@@ -487,8 +487,8 @@ mod tests {
         let message = Message {
             header: MessageHeader {
                 num_required_signatures: required_num_sigs,
-                num_credit_only_signed_accounts: 12,
-                num_credit_only_unsigned_accounts: 11,
+                num_read_only_signed_accounts: 12,
+                num_read_only_unsigned_accounts: 11,
             },
             account_keys: vec![],
             recent_blockhash: Hash::default(),
@@ -585,12 +585,12 @@ mod tests {
     }
 
     #[test]
-    fn test_fee_payer_is_debitable() {
+    fn test_fee_payer_is_writable() {
         let message = Message {
             header: MessageHeader {
                 num_required_signatures: 1,
-                num_credit_only_signed_accounts: 1,
-                num_credit_only_unsigned_accounts: 1,
+                num_read_only_signed_accounts: 1,
+                num_read_only_unsigned_accounts: 1,
             },
             account_keys: vec![],
             recent_blockhash: Hash::default(),
@@ -601,7 +601,7 @@ mod tests {
         let packet = sigverify::make_packet_from_transaction(tx.clone());
         let res = sigverify::do_get_packet_offsets(&packet, 0);
 
-        assert_eq!(res, Err(PacketError::PayerNotDebitable));
+        assert_eq!(res, Err(PacketError::PayerNotWritable));
     }
 
     #[test]

--- a/core/src/sigverify.rs
+++ b/core/src/sigverify.rs
@@ -182,8 +182,8 @@ fn do_get_packet_offsets(
     let message_account_keys_len_offset = msg_start_offset + message_header_size;
 
     // This reads and compares the MessageHeader num_required_signatures and
-    // num_read_only_signed_accounts bytes. If num_required_signatures is not larger than
-    // num_read_only_signed_accounts, the first account is not writable, and cannot be charged
+    // num_readonly_signed_accounts bytes. If num_required_signatures is not larger than
+    // num_readonly_signed_accounts, the first account is not writable, and cannot be charged
     // required transaction fees.
     if packet.data[msg_start_offset] <= packet.data[msg_start_offset + 1] {
         return Err(PacketError::PayerNotWritable);
@@ -487,8 +487,8 @@ mod tests {
         let message = Message {
             header: MessageHeader {
                 num_required_signatures: required_num_sigs,
-                num_read_only_signed_accounts: 12,
-                num_read_only_unsigned_accounts: 11,
+                num_readonly_signed_accounts: 12,
+                num_readonly_unsigned_accounts: 11,
             },
             account_keys: vec![],
             recent_blockhash: Hash::default(),
@@ -589,8 +589,8 @@ mod tests {
         let message = Message {
             header: MessageHeader {
                 num_required_signatures: 1,
-                num_read_only_signed_accounts: 1,
-                num_read_only_unsigned_accounts: 1,
+                num_readonly_signed_accounts: 1,
+                num_readonly_unsigned_accounts: 1,
             },
             account_keys: vec![],
             recent_blockhash: Hash::default(),

--- a/programs/budget_api/src/budget_instruction.rs
+++ b/programs/budget_api/src/budget_instruction.rs
@@ -55,7 +55,7 @@ pub enum BudgetInstruction {
 fn initialize_account(contract: &Pubkey, expr: BudgetExpr) -> Instruction {
     let mut keys = vec![];
     if let BudgetExpr::Pay(payment) = &expr {
-        keys.push(AccountMeta::new_read_only(payment.to, false));
+        keys.push(AccountMeta::new(payment.to, false));
     }
     keys.push(AccountMeta::new(*contract, false));
     Instruction::new(
@@ -146,7 +146,7 @@ pub fn apply_timestamp(
         AccountMeta::new(*contract, false),
     ];
     if from != to {
-        account_metas.push(AccountMeta::new_read_only(*to, false));
+        account_metas.push(AccountMeta::new(*to, false));
     }
     Instruction::new(id(), &BudgetInstruction::ApplyTimestamp(dt), account_metas)
 }
@@ -157,7 +157,7 @@ pub fn apply_signature(from: &Pubkey, contract: &Pubkey, to: &Pubkey) -> Instruc
         AccountMeta::new(*contract, false),
     ];
     if from != to {
-        account_metas.push(AccountMeta::new_read_only(*to, false));
+        account_metas.push(AccountMeta::new(*to, false));
     }
     Instruction::new(id(), &BudgetInstruction::ApplySignature, account_metas)
 }
@@ -167,7 +167,7 @@ pub fn apply_account_data(witness_pubkey: &Pubkey, contract: &Pubkey, to: &Pubke
     let account_metas = vec![
         AccountMeta::new_read_only(*witness_pubkey, false),
         AccountMeta::new(*contract, false),
-        AccountMeta::new_read_only(*to, false),
+        AccountMeta::new(*to, false),
     ];
     Instruction::new(id(), &BudgetInstruction::ApplyAccountData, account_metas)
 }

--- a/programs/budget_api/src/budget_instruction.rs
+++ b/programs/budget_api/src/budget_instruction.rs
@@ -55,7 +55,7 @@ pub enum BudgetInstruction {
 fn initialize_account(contract: &Pubkey, expr: BudgetExpr) -> Instruction {
     let mut keys = vec![];
     if let BudgetExpr::Pay(payment) = &expr {
-        keys.push(AccountMeta::new_credit_only(payment.to, false));
+        keys.push(AccountMeta::new_read_only(payment.to, false));
     }
     keys.push(AccountMeta::new(*contract, false));
     Instruction::new(
@@ -146,7 +146,7 @@ pub fn apply_timestamp(
         AccountMeta::new(*contract, false),
     ];
     if from != to {
-        account_metas.push(AccountMeta::new_credit_only(*to, false));
+        account_metas.push(AccountMeta::new_read_only(*to, false));
     }
     Instruction::new(id(), &BudgetInstruction::ApplyTimestamp(dt), account_metas)
 }
@@ -157,7 +157,7 @@ pub fn apply_signature(from: &Pubkey, contract: &Pubkey, to: &Pubkey) -> Instruc
         AccountMeta::new(*contract, false),
     ];
     if from != to {
-        account_metas.push(AccountMeta::new_credit_only(*to, false));
+        account_metas.push(AccountMeta::new_read_only(*to, false));
     }
     Instruction::new(id(), &BudgetInstruction::ApplySignature, account_metas)
 }
@@ -165,9 +165,9 @@ pub fn apply_signature(from: &Pubkey, contract: &Pubkey, to: &Pubkey) -> Instruc
 /// Apply account data to a contract waiting on an AccountData witness.
 pub fn apply_account_data(witness_pubkey: &Pubkey, contract: &Pubkey, to: &Pubkey) -> Instruction {
     let account_metas = vec![
-        AccountMeta::new_credit_only(*witness_pubkey, false),
+        AccountMeta::new_read_only(*witness_pubkey, false),
         AccountMeta::new(*contract, false),
-        AccountMeta::new_credit_only(*to, false),
+        AccountMeta::new_read_only(*to, false),
     ];
     Instruction::new(id(), &BudgetInstruction::ApplyAccountData, account_metas)
 }

--- a/programs/budget_api/src/budget_instruction.rs
+++ b/programs/budget_api/src/budget_instruction.rs
@@ -165,7 +165,7 @@ pub fn apply_signature(from: &Pubkey, contract: &Pubkey, to: &Pubkey) -> Instruc
 /// Apply account data to a contract waiting on an AccountData witness.
 pub fn apply_account_data(witness_pubkey: &Pubkey, contract: &Pubkey, to: &Pubkey) -> Instruction {
     let account_metas = vec![
-        AccountMeta::new_read_only(*witness_pubkey, false),
+        AccountMeta::new_readonly(*witness_pubkey, false),
         AccountMeta::new(*contract, false),
         AccountMeta::new(*to, false),
     ];

--- a/programs/librapay_api/src/librapay_instruction.rs
+++ b/programs/librapay_api/src/librapay_instruction.rs
@@ -36,7 +36,7 @@ pub fn mint(
     let ix_data = LoaderInstruction::InvokeMain { data };
 
     let accounts = vec![
-        AccountMeta::new_credit_only(*program_pubkey, false),
+        AccountMeta::new_read_only(*program_pubkey, false),
         AccountMeta::new(*from_pubkey, true),
         AccountMeta::new(*to_pubkey, false),
     ];
@@ -65,8 +65,8 @@ pub fn transfer(
     let ix_data = LoaderInstruction::InvokeMain { data };
 
     let accounts = vec![
-        AccountMeta::new_credit_only(*program_pubkey, false),
-        AccountMeta::new_credit_only(*mint_pubkey, false),
+        AccountMeta::new_read_only(*program_pubkey, false),
+        AccountMeta::new_read_only(*mint_pubkey, false),
         AccountMeta::new(*from_pubkey, true),
         AccountMeta::new(*to_pubkey, false),
     ];

--- a/programs/librapay_api/src/librapay_instruction.rs
+++ b/programs/librapay_api/src/librapay_instruction.rs
@@ -36,7 +36,7 @@ pub fn mint(
     let ix_data = LoaderInstruction::InvokeMain { data };
 
     let accounts = vec![
-        AccountMeta::new_read_only(*program_pubkey, false),
+        AccountMeta::new_readonly(*program_pubkey, false),
         AccountMeta::new(*from_pubkey, true),
         AccountMeta::new(*to_pubkey, false),
     ];
@@ -65,8 +65,8 @@ pub fn transfer(
     let ix_data = LoaderInstruction::InvokeMain { data };
 
     let accounts = vec![
-        AccountMeta::new_read_only(*program_pubkey, false),
-        AccountMeta::new_read_only(*mint_pubkey, false),
+        AccountMeta::new_readonly(*program_pubkey, false),
+        AccountMeta::new_readonly(*mint_pubkey, false),
         AccountMeta::new(*from_pubkey, true),
         AccountMeta::new(*to_pubkey, false),
     ];

--- a/programs/stake_api/src/stake_instruction.rs
+++ b/programs/stake_api/src/stake_instruction.rs
@@ -137,7 +137,7 @@ pub fn initialize(stake_pubkey: &Pubkey, authorized: &Authorized, lockup: &Locku
         &StakeInstruction::Initialize(*authorized, *lockup),
         vec![
             AccountMeta::new(*stake_pubkey, false),
-            AccountMeta::new_read_only(sysvar::rent::id(), false),
+            AccountMeta::new_readonly(sysvar::rent::id(), false),
         ],
     )
 }
@@ -235,7 +235,7 @@ fn metas_with_signer(
     }
 
     // signer wasn't in metas, append it after normal parameters
-    metas.push(AccountMeta::new_read_only(*signer, true));
+    metas.push(AccountMeta::new_readonly(*signer, true));
 
     metas
 }
@@ -261,8 +261,8 @@ pub fn redeem_vote_credits(stake_pubkey: &Pubkey, vote_pubkey: &Pubkey) -> Instr
         AccountMeta::new(*stake_pubkey, false),
         AccountMeta::new(*vote_pubkey, false),
         AccountMeta::new(crate::rewards_pools::random_id(), false),
-        AccountMeta::new_read_only(sysvar::rewards::id(), false),
-        AccountMeta::new_read_only(sysvar::stake_history::id(), false),
+        AccountMeta::new_readonly(sysvar::rewards::id(), false),
+        AccountMeta::new_readonly(sysvar::stake_history::id(), false),
     ];
     Instruction::new(id(), &StakeInstruction::RedeemVoteCredits, account_metas)
 }
@@ -275,9 +275,9 @@ pub fn delegate_stake(
     let account_metas = metas_with_signer(
         &[
             AccountMeta::new(*stake_pubkey, false),
-            AccountMeta::new_read_only(*vote_pubkey, false),
-            AccountMeta::new_read_only(sysvar::clock::id(), false),
-            AccountMeta::new_read_only(crate::config::id(), false),
+            AccountMeta::new_readonly(*vote_pubkey, false),
+            AccountMeta::new_readonly(sysvar::clock::id(), false),
+            AccountMeta::new_readonly(crate::config::id(), false),
         ],
         authorized_pubkey,
     );
@@ -294,8 +294,8 @@ pub fn withdraw(
         &[
             AccountMeta::new(*stake_pubkey, false),
             AccountMeta::new(*to_pubkey, false),
-            AccountMeta::new_read_only(sysvar::clock::id(), false),
-            AccountMeta::new_read_only(sysvar::stake_history::id(), false),
+            AccountMeta::new_readonly(sysvar::clock::id(), false),
+            AccountMeta::new_readonly(sysvar::stake_history::id(), false),
         ],
         authorized_pubkey,
     );
@@ -306,7 +306,7 @@ pub fn deactivate_stake(stake_pubkey: &Pubkey, authorized_pubkey: &Pubkey) -> In
     let account_metas = metas_with_signer(
         &[
             AccountMeta::new(*stake_pubkey, false),
-            AccountMeta::new_read_only(sysvar::clock::id(), false),
+            AccountMeta::new_readonly(sysvar::clock::id(), false),
         ],
         authorized_pubkey,
     );

--- a/programs/stake_api/src/stake_instruction.rs
+++ b/programs/stake_api/src/stake_instruction.rs
@@ -137,7 +137,7 @@ pub fn initialize(stake_pubkey: &Pubkey, authorized: &Authorized, lockup: &Locku
         &StakeInstruction::Initialize(*authorized, *lockup),
         vec![
             AccountMeta::new(*stake_pubkey, false),
-            AccountMeta::new_credit_only(sysvar::rent::id(), false),
+            AccountMeta::new_read_only(sysvar::rent::id(), false),
         ],
     )
 }
@@ -235,7 +235,7 @@ fn metas_with_signer(
     }
 
     // signer wasn't in metas, append it after normal parameters
-    metas.push(AccountMeta::new_credit_only(*signer, true));
+    metas.push(AccountMeta::new_read_only(*signer, true));
 
     metas
 }
@@ -259,10 +259,10 @@ pub fn authorize(
 pub fn redeem_vote_credits(stake_pubkey: &Pubkey, vote_pubkey: &Pubkey) -> Instruction {
     let account_metas = vec![
         AccountMeta::new(*stake_pubkey, false),
-        AccountMeta::new_credit_only(*vote_pubkey, false),
+        AccountMeta::new_read_only(*vote_pubkey, false),
         AccountMeta::new(crate::rewards_pools::random_id(), false),
-        AccountMeta::new_credit_only(sysvar::rewards::id(), false),
-        AccountMeta::new_credit_only(sysvar::stake_history::id(), false),
+        AccountMeta::new_read_only(sysvar::rewards::id(), false),
+        AccountMeta::new_read_only(sysvar::stake_history::id(), false),
     ];
     Instruction::new(id(), &StakeInstruction::RedeemVoteCredits, account_metas)
 }
@@ -275,9 +275,9 @@ pub fn delegate_stake(
     let account_metas = metas_with_signer(
         &[
             AccountMeta::new(*stake_pubkey, false),
-            AccountMeta::new_credit_only(*vote_pubkey, false),
-            AccountMeta::new_credit_only(sysvar::clock::id(), false),
-            AccountMeta::new_credit_only(crate::config::id(), false),
+            AccountMeta::new_read_only(*vote_pubkey, false),
+            AccountMeta::new_read_only(sysvar::clock::id(), false),
+            AccountMeta::new_read_only(crate::config::id(), false),
         ],
         authorized_pubkey,
     );
@@ -293,9 +293,9 @@ pub fn withdraw(
     let account_metas = metas_with_signer(
         &[
             AccountMeta::new(*stake_pubkey, false),
-            AccountMeta::new_credit_only(*to_pubkey, false),
-            AccountMeta::new_credit_only(sysvar::clock::id(), false),
-            AccountMeta::new_credit_only(sysvar::stake_history::id(), false),
+            AccountMeta::new_read_only(*to_pubkey, false),
+            AccountMeta::new_read_only(sysvar::clock::id(), false),
+            AccountMeta::new_read_only(sysvar::stake_history::id(), false),
         ],
         authorized_pubkey,
     );
@@ -306,7 +306,7 @@ pub fn deactivate_stake(stake_pubkey: &Pubkey, authorized_pubkey: &Pubkey) -> In
     let account_metas = metas_with_signer(
         &[
             AccountMeta::new(*stake_pubkey, false),
-            AccountMeta::new_credit_only(sysvar::clock::id(), false),
+            AccountMeta::new_read_only(sysvar::clock::id(), false),
         ],
         authorized_pubkey,
     );

--- a/programs/stake_api/src/stake_instruction.rs
+++ b/programs/stake_api/src/stake_instruction.rs
@@ -259,7 +259,7 @@ pub fn authorize(
 pub fn redeem_vote_credits(stake_pubkey: &Pubkey, vote_pubkey: &Pubkey) -> Instruction {
     let account_metas = vec![
         AccountMeta::new(*stake_pubkey, false),
-        AccountMeta::new_read_only(*vote_pubkey, false),
+        AccountMeta::new(*vote_pubkey, false),
         AccountMeta::new(crate::rewards_pools::random_id(), false),
         AccountMeta::new_read_only(sysvar::rewards::id(), false),
         AccountMeta::new_read_only(sysvar::stake_history::id(), false),
@@ -293,7 +293,7 @@ pub fn withdraw(
     let account_metas = metas_with_signer(
         &[
             AccountMeta::new(*stake_pubkey, false),
-            AccountMeta::new_read_only(*to_pubkey, false),
+            AccountMeta::new(*to_pubkey, false),
             AccountMeta::new_read_only(sysvar::clock::id(), false),
             AccountMeta::new_read_only(sysvar::stake_history::id(), false),
         ],

--- a/programs/vest_api/src/vest_instruction.rs
+++ b/programs/vest_api/src/vest_instruction.rs
@@ -122,8 +122,8 @@ pub fn set_payee(contract: &Pubkey, old_pubkey: &Pubkey, new_pubkey: &Pubkey) ->
 pub fn redeem_tokens(contract: &Pubkey, date_pubkey: &Pubkey, to: &Pubkey) -> Instruction {
     let account_metas = vec![
         AccountMeta::new(*contract, false),
-        AccountMeta::new_credit_only(*date_pubkey, false),
-        AccountMeta::new_credit_only(*to, false),
+        AccountMeta::new_read_only(*date_pubkey, false),
+        AccountMeta::new_read_only(*to, false),
     ];
     Instruction::new(id(), &VestInstruction::RedeemTokens, account_metas)
 }
@@ -134,7 +134,7 @@ pub fn terminate(contract: &Pubkey, from: &Pubkey, to: &Pubkey) -> Instruction {
         AccountMeta::new(*from, true),
     ];
     if from != to {
-        account_metas.push(AccountMeta::new_credit_only(*to, false));
+        account_metas.push(AccountMeta::new_read_only(*to, false));
     }
     Instruction::new(id(), &VestInstruction::Terminate, account_metas)
 }

--- a/programs/vest_api/src/vest_instruction.rs
+++ b/programs/vest_api/src/vest_instruction.rs
@@ -122,7 +122,7 @@ pub fn set_payee(contract: &Pubkey, old_pubkey: &Pubkey, new_pubkey: &Pubkey) ->
 pub fn redeem_tokens(contract: &Pubkey, date_pubkey: &Pubkey, to: &Pubkey) -> Instruction {
     let account_metas = vec![
         AccountMeta::new(*contract, false),
-        AccountMeta::new_read_only(*date_pubkey, false),
+        AccountMeta::new_readonly(*date_pubkey, false),
         AccountMeta::new(*to, false),
     ];
     Instruction::new(id(), &VestInstruction::RedeemTokens, account_metas)

--- a/programs/vest_api/src/vest_instruction.rs
+++ b/programs/vest_api/src/vest_instruction.rs
@@ -123,7 +123,7 @@ pub fn redeem_tokens(contract: &Pubkey, date_pubkey: &Pubkey, to: &Pubkey) -> In
     let account_metas = vec![
         AccountMeta::new(*contract, false),
         AccountMeta::new_read_only(*date_pubkey, false),
-        AccountMeta::new_read_only(*to, false),
+        AccountMeta::new(*to, false),
     ];
     Instruction::new(id(), &VestInstruction::RedeemTokens, account_metas)
 }
@@ -134,7 +134,7 @@ pub fn terminate(contract: &Pubkey, from: &Pubkey, to: &Pubkey) -> Instruction {
         AccountMeta::new(*from, true),
     ];
     if from != to {
-        account_metas.push(AccountMeta::new_read_only(*to, false));
+        account_metas.push(AccountMeta::new(*to, false));
     }
     Instruction::new(id(), &VestInstruction::Terminate, account_metas)
 }

--- a/programs/vote_api/src/vote_instruction.rs
+++ b/programs/vote_api/src/vote_instruction.rs
@@ -152,7 +152,7 @@ pub fn withdraw(
     let account_metas = metas_for_authorized_signer(
         vote_pubkey,
         withdrawer_pubkey,
-        &[AccountMeta::new_read_only(*to_pubkey, false)],
+        &[AccountMeta::new(*to_pubkey, false)],
     );
 
     Instruction::new(id(), &VoteInstruction::Withdraw(lamports), account_metas)

--- a/programs/vote_api/src/vote_instruction.rs
+++ b/programs/vote_api/src/vote_instruction.rs
@@ -106,7 +106,7 @@ fn metas_for_authorized_signer(
 
     // append signer at the end
     if !is_own_signer {
-        account_metas.push(AccountMeta::new_read_only(*authorized_signer, true))
+        account_metas.push(AccountMeta::new_readonly(*authorized_signer, true))
         // signer
     }
 
@@ -134,9 +134,9 @@ pub fn vote(vote_pubkey: &Pubkey, authorized_voter_pubkey: &Pubkey, vote: Vote) 
         authorized_voter_pubkey,
         &[
             // request slot_hashes sysvar account after vote_pubkey
-            AccountMeta::new_read_only(sysvar::slot_hashes::id(), false),
+            AccountMeta::new_readonly(sysvar::slot_hashes::id(), false),
             // request clock sysvar account after that
-            AccountMeta::new_read_only(sysvar::clock::id(), false),
+            AccountMeta::new_readonly(sysvar::clock::id(), false),
         ],
     );
 

--- a/programs/vote_api/src/vote_instruction.rs
+++ b/programs/vote_api/src/vote_instruction.rs
@@ -106,7 +106,7 @@ fn metas_for_authorized_signer(
 
     // append signer at the end
     if !is_own_signer {
-        account_metas.push(AccountMeta::new_credit_only(*authorized_signer, true))
+        account_metas.push(AccountMeta::new_read_only(*authorized_signer, true))
         // signer
     }
 
@@ -134,9 +134,9 @@ pub fn vote(vote_pubkey: &Pubkey, authorized_voter_pubkey: &Pubkey, vote: Vote) 
         authorized_voter_pubkey,
         &[
             // request slot_hashes sysvar account after vote_pubkey
-            AccountMeta::new_credit_only(sysvar::slot_hashes::id(), false),
+            AccountMeta::new_read_only(sysvar::slot_hashes::id(), false),
             // request clock sysvar account after that
-            AccountMeta::new_credit_only(sysvar::clock::id(), false),
+            AccountMeta::new_read_only(sysvar::clock::id(), false),
         ],
     );
 
@@ -152,7 +152,7 @@ pub fn withdraw(
     let account_metas = metas_for_authorized_signer(
         vote_pubkey,
         withdrawer_pubkey,
-        &[AccountMeta::new_credit_only(*to_pubkey, false)],
+        &[AccountMeta::new_read_only(*to_pubkey, false)],
     );
 
     Instruction::new(id(), &VoteInstruction::Withdraw(lamports), account_metas)

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2221,7 +2221,7 @@ mod tests {
     }
 
     #[test]
-    fn test_read_only_accounts() {
+    fn test_readonly_accounts() {
         let GenesisBlockInfo {
             genesis_block,
             mint_keypair,
@@ -2291,7 +2291,7 @@ mod tests {
         );
         let txs = vec![tx0, tx1];
         let results = bank.process_transactions(&txs);
-        // However, an account may not be locked as read-only and read-write at the same time.
+        // However, an account may not be locked as read-only and writable at the same time.
         assert_eq!(results[0], Ok(()));
         assert_eq!(results[1], Err(TransactionError::AccountInUse));
     }
@@ -2330,7 +2330,7 @@ mod tests {
     }
 
     #[test]
-    fn test_read_only_relaxed_locks() {
+    fn test_readonly_relaxed_locks() {
         let (genesis_block, _) = create_genesis_block(3);
         let bank = Bank::new(&genesis_block);
         let key0 = Keypair::new();
@@ -2341,8 +2341,8 @@ mod tests {
         let message = Message {
             header: MessageHeader {
                 num_required_signatures: 1,
-                num_read_only_signed_accounts: 0,
-                num_read_only_unsigned_accounts: 1,
+                num_readonly_signed_accounts: 0,
+                num_readonly_unsigned_accounts: 1,
             },
             account_keys: vec![key0.pubkey(), key3],
             recent_blockhash: Hash::default(),
@@ -2354,13 +2354,13 @@ mod tests {
         let batch0 = bank.prepare_batch(&txs, None);
         assert!(batch0.lock_results()[0].is_ok());
 
-        // Try locking accounts, locking a previously read-only account as read-write
+        // Try locking accounts, locking a previously read-only account as writable
         // should fail
         let message = Message {
             header: MessageHeader {
                 num_required_signatures: 1,
-                num_read_only_signed_accounts: 0,
-                num_read_only_unsigned_accounts: 0,
+                num_readonly_signed_accounts: 0,
+                num_readonly_unsigned_accounts: 0,
             },
             account_keys: vec![key1.pubkey(), key3],
             recent_blockhash: Hash::default(),
@@ -2376,8 +2376,8 @@ mod tests {
         let message = Message {
             header: MessageHeader {
                 num_required_signatures: 1,
-                num_read_only_signed_accounts: 0,
-                num_read_only_unsigned_accounts: 1,
+                num_readonly_signed_accounts: 0,
+                num_readonly_unsigned_accounts: 1,
             },
             account_keys: vec![key2.pubkey(), key3],
             recent_blockhash: Hash::default(),

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -594,7 +594,6 @@ impl Bank {
 
         if *hash == Hash::default() {
             // finish up any deferred changes to account state
-            self.commit_credits();
             self.collect_fees();
 
             // freeze is a one-way trip, idempotent
@@ -807,15 +806,10 @@ impl Bank {
     }
 
     /// Process a Transaction. This is used for unit tests and simply calls the vector
-    /// Bank::process_transactions method, and commits read-only credits.
+    /// Bank::process_transactions method
     pub fn process_transaction(&self, tx: &Transaction) -> Result<()> {
         let txs = vec![tx.clone()];
         self.process_transactions(&txs)[0].clone()?;
-        // Call this instead of commit_credits(), so that the read-only locks hashmap on this
-        // bank isn't deleted
-        self.rc
-            .accounts
-            .commit_credits_unsafe(&self.ancestors, self.slot());
         tx.signatures
             .get(0)
             .map_or(Ok(()), |sig| self.get_signature_status(sig).unwrap())
@@ -1061,10 +1055,10 @@ impl Bank {
             .zip(OrderedIterator::new(txs, batch.iteration_order()))
             .map(|(accs, tx)| match accs {
                 Err(e) => Err(e.clone()),
-                Ok((accounts, loaders, credits, _rents)) => {
+                Ok((accounts, loaders, _rents)) => {
                     signature_count += u64::from(tx.message().header.num_required_signatures);
                     self.message_processor
-                        .process_message(tx.message(), loaders, accounts, credits)
+                        .process_message(tx.message(), loaders, accounts)
                 }
             })
             .collect();
@@ -1595,12 +1589,6 @@ impl Bank {
         );
     }
 
-    fn commit_credits(&self) {
-        self.rc
-            .accounts
-            .commit_credits(&self.ancestors, self.slot());
-    }
-
     pub fn purge_zero_lamport_accounts(&self) {
         self.rc
             .accounts
@@ -1646,19 +1634,18 @@ mod tests {
         epoch_schedule::MINIMUM_SLOTS_PER_EPOCH,
         genesis_block::create_genesis_block,
         hash,
-        instruction::{AccountMeta, Instruction, InstructionError},
+        instruction::InstructionError,
         message::{Message, MessageHeader},
         poh_config::PohConfig,
         rent::Rent,
         signature::{Keypair, KeypairUtil},
-        system_instruction::{self, SystemInstruction},
-        system_program, system_transaction,
+        system_instruction,
         sysvar::{fees::Fees, rewards::Rewards},
     };
     use solana_stake_api::stake_state::Stake;
     use solana_vote_api::{
         vote_instruction,
-        vote_state::{VoteInit, VoteState, MAX_LOCKOUT_HISTORY},
+        vote_state::{self, Vote, VoteInit, VoteState, MAX_LOCKOUT_HISTORY},
     };
     use std::{io::Cursor, time::Duration};
     use tempfile::TempDir;
@@ -1881,7 +1868,6 @@ mod tests {
         let t1 = system_transaction::transfer(&mint_keypair, &key1, 1, genesis_block.hash());
         let t2 = system_transaction::transfer(&mint_keypair, &key2, 1, genesis_block.hash());
         let res = bank.process_transactions(&vec![t1.clone(), t2.clone()]);
-        bank.commit_credits();
 
         assert_eq!(res.len(), 2);
         assert_eq!(res[0], Ok(()));
@@ -2234,57 +2220,75 @@ mod tests {
         assert_eq!(bank.transaction_count(), 1);
     }
 
-    fn transfer_read_only(
-        from: &Keypair,
-        to: &Pubkey,
-        lamports: u64,
-        recent_blockhash: Hash,
-    ) -> Transaction {
-        Transaction::new_signed_instructions(
-            &[from],
-            vec![Instruction::new(
-                system_program::id(),
-                &SystemInstruction::Transfer { lamports },
-                vec![
-                    AccountMeta::new(from.pubkey(), true),
-                    AccountMeta::new_read_only(*to, false),
-                ],
-            )],
-            recent_blockhash,
-        )
-    }
-
     #[test]
     fn test_read_only_accounts() {
-        let (genesis_block, mint_keypair) = create_genesis_block(100);
+        let GenesisBlockInfo {
+            genesis_block,
+            mint_keypair,
+            ..
+        } = create_genesis_block_with_leader(500, &Pubkey::new_rand(), 0);
         let bank = Bank::new(&genesis_block);
+
+        let vote_pubkey0 = Pubkey::new_rand();
+        let vote_pubkey1 = Pubkey::new_rand();
+        let vote_pubkey2 = Pubkey::new_rand();
+        let authorized_voter = Keypair::new();
         let payer0 = Keypair::new();
         let payer1 = Keypair::new();
-        let recipient = Keypair::new();
-        // Fund additional payers
-        bank.transfer(3, &mint_keypair, &payer0.pubkey()).unwrap();
-        bank.transfer(3, &mint_keypair, &payer1.pubkey()).unwrap();
-        let tx0 = transfer_read_only(&mint_keypair, &recipient.pubkey(), 1, genesis_block.hash());
-        let tx1 = transfer_read_only(&payer0, &recipient.pubkey(), 1, genesis_block.hash());
-        let tx2 = transfer_read_only(&payer1, &recipient.pubkey(), 1, genesis_block.hash());
-        let txs = vec![tx0, tx1, tx2];
+
+        // Create vote accounts
+        let vote_account0 =
+            vote_state::create_account(&vote_pubkey0, &authorized_voter.pubkey(), 0, 100);
+        let vote_account1 =
+            vote_state::create_account(&vote_pubkey1, &authorized_voter.pubkey(), 0, 100);
+        let vote_account2 =
+            vote_state::create_account(&vote_pubkey2, &authorized_voter.pubkey(), 0, 100);
+        bank.store_account(&vote_pubkey0, &vote_account0);
+        bank.store_account(&vote_pubkey1, &vote_account1);
+        bank.store_account(&vote_pubkey2, &vote_account2);
+
+        // Fund payers
+        bank.transfer(10, &mint_keypair, &payer0.pubkey()).unwrap();
+        bank.transfer(10, &mint_keypair, &payer1.pubkey()).unwrap();
+        bank.transfer(1, &mint_keypair, &authorized_voter.pubkey())
+            .unwrap();
+
+        let vote = Vote::new(vec![1], Hash::default());
+        let ix0 = vote_instruction::vote(&vote_pubkey0, &authorized_voter.pubkey(), vote.clone());
+        let tx0 = Transaction::new_signed_with_payer(
+            vec![ix0],
+            Some(&payer0.pubkey()),
+            &[&payer0, &authorized_voter],
+            bank.last_blockhash(),
+        );
+        let ix1 = vote_instruction::vote(&vote_pubkey1, &authorized_voter.pubkey(), vote.clone());
+        let tx1 = Transaction::new_signed_with_payer(
+            vec![ix1],
+            Some(&payer1.pubkey()),
+            &[&payer1, &authorized_voter],
+            bank.last_blockhash(),
+        );
+        let txs = vec![tx0, tx1];
         let results = bank.process_transactions(&txs);
 
-        // If multiple transactions attempt to deposit into the same account, they should succeed,
-        // since System Transfer `To` accounts are given read-only handling
+        // If multiple transactions attempt to read the same account, they should succeed.
+        // Vote authorized_voter and sysvar accounts are given read-only handling
         assert_eq!(results[0], Ok(()));
         assert_eq!(results[1], Ok(()));
-        assert_eq!(results[2], Ok(()));
-        assert_eq!(bank.get_balance(&recipient.pubkey()), 3);
 
-        let tx0 = system_transaction::transfer(
-            &mint_keypair,
-            &recipient.pubkey(),
-            2,
-            genesis_block.hash(),
+        let ix0 = vote_instruction::vote(&vote_pubkey2, &authorized_voter.pubkey(), vote.clone());
+        let tx0 = Transaction::new_signed_with_payer(
+            vec![ix0],
+            Some(&payer0.pubkey()),
+            &[&payer0, &authorized_voter],
+            bank.last_blockhash(),
         );
-        let tx1 =
-            system_transaction::transfer(&recipient, &payer0.pubkey(), 1, genesis_block.hash());
+        let tx1 = system_transaction::transfer(
+            &authorized_voter,
+            &Pubkey::new_rand(),
+            1,
+            bank.last_blockhash(),
+        );
         let txs = vec![tx0, tx1];
         let results = bank.process_transactions(&txs);
         // However, an account may not be locked as read-only and read-write at the same time.

--- a/runtime/src/system_instruction_processor.rs
+++ b/runtime/src/system_instruction_processor.rs
@@ -423,7 +423,7 @@ mod tests {
         let mut to_account = Account::new(1, 0, &Pubkey::new(&[3; 32])); // account owner should not matter
         transfer_lamports(
             &mut KeyedAccount::new(&from, true, &mut from_account),
-            &mut KeyedAccount::new_credit_only(&to, false, &mut to_account),
+            &mut KeyedAccount::new_read_only(&to, false, &mut to_account),
             50,
         )
         .unwrap();
@@ -435,7 +435,7 @@ mod tests {
         // Attempt to move more lamports than remaining in from_account
         let result = transfer_lamports(
             &mut KeyedAccount::new(&from, true, &mut from_account),
-            &mut KeyedAccount::new_credit_only(&to, false, &mut to_account),
+            &mut KeyedAccount::new_read_only(&to, false, &mut to_account),
             100,
         );
         assert_eq!(result, Err(SystemError::ResultWithNegativeLamports.into()));
@@ -445,7 +445,7 @@ mod tests {
         // test unsigned transfer of zero
         assert!(transfer_lamports(
             &mut KeyedAccount::new(&from, false, &mut from_account),
-            &mut KeyedAccount::new_credit_only(&to, false, &mut to_account),
+            &mut KeyedAccount::new_read_only(&to, false, &mut to_account),
             0,
         )
         .is_ok(),);

--- a/runtime/src/system_instruction_processor.rs
+++ b/runtime/src/system_instruction_processor.rs
@@ -423,7 +423,7 @@ mod tests {
         let mut to_account = Account::new(1, 0, &Pubkey::new(&[3; 32])); // account owner should not matter
         transfer_lamports(
             &mut KeyedAccount::new(&from, true, &mut from_account),
-            &mut KeyedAccount::new_read_only(&to, false, &mut to_account),
+            &mut KeyedAccount::new(&to, false, &mut to_account),
             50,
         )
         .unwrap();
@@ -435,7 +435,7 @@ mod tests {
         // Attempt to move more lamports than remaining in from_account
         let result = transfer_lamports(
             &mut KeyedAccount::new(&from, true, &mut from_account),
-            &mut KeyedAccount::new_read_only(&to, false, &mut to_account),
+            &mut KeyedAccount::new(&to, false, &mut to_account),
             100,
         );
         assert_eq!(result, Err(SystemError::ResultWithNegativeLamports.into()));
@@ -445,7 +445,7 @@ mod tests {
         // test unsigned transfer of zero
         assert!(transfer_lamports(
             &mut KeyedAccount::new(&from, false, &mut from_account),
-            &mut KeyedAccount::new_read_only(&to, false, &mut to_account),
+            &mut KeyedAccount::new(&to, false, &mut to_account),
             0,
         )
         .is_ok(),);

--- a/sdk-c/src/lib.rs
+++ b/sdk-c/src/lib.rs
@@ -64,7 +64,7 @@ impl Transaction {
 #[repr(C)]
 #[derive(Debug)]
 pub struct Message {
-    /// The message header, identifying signed and credit-only `account_keys`
+    /// The message header, identifying signed and read-only `account_keys`
     pub header: MessageHeader,
 
     /// All the account keys used by this transaction
@@ -164,30 +164,30 @@ pub struct MessageHeader {
     /// signatures must match the first `num_required_signatures` of `account_keys`.
     pub num_required_signatures: u8,
 
-    /// The last num_credit_only_signed_accounts of the signed keys are credit-only accounts.
-    /// Programs may process multiple transactions that add lamports to the same credit-only
-    /// account within a single PoH entry, but are not permitted to debit lamports or modify
-    /// account data. Transactions targeting the same debit account are evaluated sequentially.
-    pub num_credit_only_signed_accounts: u8,
+    /// The last num_read_only_signed_accounts of the signed keys are read-only accounts. Programs
+    /// may process multiple transactions that load read-only accounts within a single PoH entry,
+    /// but are not permitted to credit or debit lamports or modify account data. Transactions
+    /// targeting the same read-write account are evaluated sequentially.
+    pub num_read_only_signed_accounts: u8,
 
-    /// The last num_credit_only_unsigned_accounts of the unsigned keys are credit-only accounts.
-    pub num_credit_only_unsigned_accounts: u8,
+    /// The last num_read_only_unsigned_accounts of the unsigned keys are read-only accounts.
+    pub num_read_only_unsigned_accounts: u8,
 }
 
 impl MessageHeader {
     pub fn from_native(h: MessageHeaderNative) -> Self {
         Self {
             num_required_signatures: h.num_required_signatures,
-            num_credit_only_signed_accounts: h.num_credit_only_signed_accounts,
-            num_credit_only_unsigned_accounts: h.num_credit_only_unsigned_accounts,
+            num_read_only_signed_accounts: h.num_read_only_signed_accounts,
+            num_read_only_unsigned_accounts: h.num_read_only_unsigned_accounts,
         }
     }
 
     pub fn into_native(self) -> MessageHeaderNative {
         MessageHeaderNative {
             num_required_signatures: self.num_required_signatures,
-            num_credit_only_signed_accounts: self.num_credit_only_signed_accounts,
-            num_credit_only_unsigned_accounts: self.num_credit_only_unsigned_accounts,
+            num_read_only_signed_accounts: self.num_read_only_signed_accounts,
+            num_read_only_unsigned_accounts: self.num_read_only_unsigned_accounts,
         }
     }
 }

--- a/sdk-c/src/lib.rs
+++ b/sdk-c/src/lib.rs
@@ -164,30 +164,30 @@ pub struct MessageHeader {
     /// signatures must match the first `num_required_signatures` of `account_keys`.
     pub num_required_signatures: u8,
 
-    /// The last num_read_only_signed_accounts of the signed keys are read-only accounts. Programs
+    /// The last num_readonly_signed_accounts of the signed keys are read-only accounts. Programs
     /// may process multiple transactions that load read-only accounts within a single PoH entry,
     /// but are not permitted to credit or debit lamports or modify account data. Transactions
     /// targeting the same read-write account are evaluated sequentially.
-    pub num_read_only_signed_accounts: u8,
+    pub num_readonly_signed_accounts: u8,
 
-    /// The last num_read_only_unsigned_accounts of the unsigned keys are read-only accounts.
-    pub num_read_only_unsigned_accounts: u8,
+    /// The last num_readonly_unsigned_accounts of the unsigned keys are read-only accounts.
+    pub num_readonly_unsigned_accounts: u8,
 }
 
 impl MessageHeader {
     pub fn from_native(h: MessageHeaderNative) -> Self {
         Self {
             num_required_signatures: h.num_required_signatures,
-            num_read_only_signed_accounts: h.num_read_only_signed_accounts,
-            num_read_only_unsigned_accounts: h.num_read_only_unsigned_accounts,
+            num_readonly_signed_accounts: h.num_readonly_signed_accounts,
+            num_readonly_unsigned_accounts: h.num_readonly_unsigned_accounts,
         }
     }
 
     pub fn into_native(self) -> MessageHeaderNative {
         MessageHeaderNative {
             num_required_signatures: self.num_required_signatures,
-            num_read_only_signed_accounts: self.num_read_only_signed_accounts,
-            num_read_only_unsigned_accounts: self.num_read_only_unsigned_accounts,
+            num_readonly_signed_accounts: self.num_readonly_signed_accounts,
+            num_readonly_unsigned_accounts: self.num_readonly_unsigned_accounts,
         }
     }
 }

--- a/sdk/src/account.rs
+++ b/sdk/src/account.rs
@@ -115,7 +115,7 @@ pub type LamportCredit = u64;
 #[derive(Debug)]
 pub struct KeyedAccount<'a> {
     is_signer: bool, // Transaction was signed by this account's key
-    is_debitable: bool,
+    is_writable: bool,
     key: &'a Pubkey,
     pub account: &'a mut Account,
 }
@@ -133,27 +133,27 @@ impl<'a> KeyedAccount<'a> {
         self.key
     }
 
-    pub fn is_debitable(&self) -> bool {
-        self.is_debitable
+    pub fn is_writable(&self) -> bool {
+        self.is_writable
     }
 
     pub fn new(key: &'a Pubkey, is_signer: bool, account: &'a mut Account) -> KeyedAccount<'a> {
         KeyedAccount {
             is_signer,
-            is_debitable: true,
+            is_writable: true,
             key,
             account,
         }
     }
 
-    pub fn new_credit_only(
+    pub fn new_read_only(
         key: &'a Pubkey,
         is_signer: bool,
         account: &'a mut Account,
     ) -> KeyedAccount<'a> {
         KeyedAccount {
             is_signer,
-            is_debitable: false,
+            is_writable: false,
             key,
             account,
         }
@@ -164,7 +164,7 @@ impl<'a> From<(&'a Pubkey, &'a mut Account)> for KeyedAccount<'a> {
     fn from((key, account): (&'a Pubkey, &'a mut Account)) -> Self {
         KeyedAccount {
             is_signer: false,
-            is_debitable: true,
+            is_writable: true,
             key,
             account,
         }
@@ -175,7 +175,7 @@ impl<'a> From<&'a mut (Pubkey, Account)> for KeyedAccount<'a> {
     fn from((key, account): &'a mut (Pubkey, Account)) -> Self {
         KeyedAccount {
             is_signer: false,
-            is_debitable: true,
+            is_writable: true,
             key,
             account,
         }
@@ -186,12 +186,12 @@ pub fn create_keyed_accounts(accounts: &mut [(Pubkey, Account)]) -> Vec<KeyedAcc
     accounts.iter_mut().map(Into::into).collect()
 }
 
-pub fn create_keyed_credit_only_accounts(accounts: &mut [(Pubkey, Account)]) -> Vec<KeyedAccount> {
+pub fn create_keyed_read_only_accounts(accounts: &mut [(Pubkey, Account)]) -> Vec<KeyedAccount> {
     accounts
         .iter_mut()
         .map(|(key, account)| KeyedAccount {
             is_signer: false,
-            is_debitable: false,
+            is_writable: false,
             key,
             account,
         })

--- a/sdk/src/account.rs
+++ b/sdk/src/account.rs
@@ -144,7 +144,7 @@ impl<'a> KeyedAccount<'a> {
         }
     }
 
-    pub fn new_read_only(
+    pub fn new_readonly(
         key: &'a Pubkey,
         is_signer: bool,
         account: &'a mut Account,
@@ -184,7 +184,7 @@ pub fn create_keyed_accounts(accounts: &mut [(Pubkey, Account)]) -> Vec<KeyedAcc
     accounts.iter_mut().map(Into::into).collect()
 }
 
-pub fn create_keyed_read_only_accounts(accounts: &mut [(Pubkey, Account)]) -> Vec<KeyedAccount> {
+pub fn create_keyed_readonly_accounts(accounts: &mut [(Pubkey, Account)]) -> Vec<KeyedAccount> {
     accounts
         .iter_mut()
         .map(|(key, account)| KeyedAccount {

--- a/sdk/src/account.rs
+++ b/sdk/src/account.rs
@@ -109,8 +109,6 @@ impl Account {
     }
 }
 
-pub type LamportCredit = u64;
-
 #[repr(C)]
 #[derive(Debug)]
 pub struct KeyedAccount<'a> {

--- a/sdk/src/instruction.rs
+++ b/sdk/src/instruction.rs
@@ -53,10 +53,10 @@ pub enum InstructionError {
     ExternalAccountDataModified,
 
     /// Read-only account modified lamports
-    ReadOnlyLamportChange,
+    ReadonlyLamportChange,
 
     /// Read-only account modified data
-    ReadOnlyDataModified,
+    ReadonlyDataModified,
 
     /// An account was referenced more than once in a single instruction
     DuplicateAccountIndex,
@@ -129,7 +129,7 @@ impl AccountMeta {
         }
     }
 
-    pub fn new_read_only(pubkey: Pubkey, is_signer: bool) -> Self {
+    pub fn new_readonly(pubkey: Pubkey, is_signer: bool) -> Self {
         Self {
             pubkey,
             is_signer,

--- a/sdk/src/instruction.rs
+++ b/sdk/src/instruction.rs
@@ -52,11 +52,11 @@ pub enum InstructionError {
     /// Program modified the data of an account that doesn't belong to it
     ExternalAccountDataModified,
 
-    /// Credit-only account spent lamports
-    CreditOnlyLamportSpend,
+    /// Read-only account modified lamports
+    ReadOnlyLamportChange,
 
-    /// Credit-only account modified data
-    CreditOnlyDataModified,
+    /// Read-only account modified data
+    ReadOnlyDataModified,
 
     /// An account was referenced more than once in a single instruction
     DuplicateAccountIndex,
@@ -116,8 +116,8 @@ pub struct AccountMeta {
     pub pubkey: Pubkey,
     /// True if an Instruciton requires a Transaction signature matching `pubkey`.
     pub is_signer: bool,
-    /// True if the `pubkey` can be loaded as a credit-debit account.
-    pub is_debitable: bool,
+    /// True if the `pubkey` can be loaded as a read-write account.
+    pub is_writable: bool,
 }
 
 impl AccountMeta {
@@ -125,15 +125,15 @@ impl AccountMeta {
         Self {
             pubkey,
             is_signer,
-            is_debitable: true,
+            is_writable: true,
         }
     }
 
-    pub fn new_credit_only(pubkey: Pubkey, is_signer: bool) -> Self {
+    pub fn new_read_only(pubkey: Pubkey, is_signer: bool) -> Self {
         Self {
             pubkey,
             is_signer,
-            is_debitable: false,
+            is_writable: false,
         }
     }
 }

--- a/sdk/src/message.rs
+++ b/sdk/src/message.rs
@@ -227,16 +227,16 @@ impl Message {
     }
 
     pub fn get_account_keys_by_lock_type(&self) -> (Vec<&Pubkey>, Vec<&Pubkey>) {
-        let mut credit_debit_keys = vec![];
+        let mut read_write_keys = vec![];
         let mut read_only_keys = vec![];
         for (i, key) in self.account_keys.iter().enumerate() {
             if self.is_writable(i) {
-                credit_debit_keys.push(key);
+                read_write_keys.push(key);
             } else {
                 read_only_keys.push(key);
             }
         }
-        (credit_debit_keys, read_only_keys)
+        (read_write_keys, read_only_keys)
     }
 }
 

--- a/sdk/src/message.rs
+++ b/sdk/src/message.rs
@@ -30,34 +30,34 @@ fn compile_instructions(ixs: Vec<Instruction>, keys: &[Pubkey]) -> Vec<CompiledI
         .collect()
 }
 
-/// A helper struct to collect pubkeys referenced by a set of instructions and credit-only counts
+/// A helper struct to collect pubkeys referenced by a set of instructions and read-only counts
 #[derive(Debug, PartialEq, Eq)]
 struct InstructionKeys {
     pub signed_keys: Vec<Pubkey>,
     pub unsigned_keys: Vec<Pubkey>,
-    pub num_credit_only_signed_accounts: u8,
-    pub num_credit_only_unsigned_accounts: u8,
+    pub num_read_only_signed_accounts: u8,
+    pub num_read_only_unsigned_accounts: u8,
 }
 
 impl InstructionKeys {
     fn new(
         signed_keys: Vec<Pubkey>,
         unsigned_keys: Vec<Pubkey>,
-        num_credit_only_signed_accounts: u8,
-        num_credit_only_unsigned_accounts: u8,
+        num_read_only_signed_accounts: u8,
+        num_read_only_unsigned_accounts: u8,
     ) -> Self {
         Self {
             signed_keys,
             unsigned_keys,
-            num_credit_only_signed_accounts,
-            num_credit_only_unsigned_accounts,
+            num_read_only_signed_accounts,
+            num_read_only_unsigned_accounts,
         }
     }
 }
 
 /// Return pubkeys referenced by all instructions, with the ones needing signatures first. If the
-/// payer key is provided, it is always placed first in the list of signed keys. Credit-only signed
-/// accounts are placed last in the set of signed accounts. Credit-only unsigned accounts,
+/// payer key is provided, it is always placed first in the list of signed keys. Read-only signed
+/// accounts are placed last in the set of signed accounts. Read-only unsigned accounts,
 /// including program ids, are placed last in the set. No duplicates and order is preserved.
 fn get_keys(instructions: &[Instruction], payer: Option<&Pubkey>) -> InstructionKeys {
     let programs: Vec<_> = get_program_ids(instructions)
@@ -65,7 +65,7 @@ fn get_keys(instructions: &[Instruction], payer: Option<&Pubkey>) -> Instruction
         .map(|program_id| AccountMeta {
             pubkey: *program_id,
             is_signer: false,
-            is_debitable: false,
+            is_writable: false,
         })
         .collect();
     let mut keys_and_signed: Vec<_> = instructions
@@ -76,7 +76,7 @@ fn get_keys(instructions: &[Instruction], payer: Option<&Pubkey>) -> Instruction
     keys_and_signed.sort_by(|x, y| {
         y.is_signer
             .cmp(&x.is_signer)
-            .then(y.is_debitable.cmp(&x.is_debitable))
+            .then(y.is_writable.cmp(&x.is_writable))
     });
 
     let payer_account_meta;
@@ -84,33 +84,33 @@ fn get_keys(instructions: &[Instruction], payer: Option<&Pubkey>) -> Instruction
         payer_account_meta = AccountMeta {
             pubkey: *payer,
             is_signer: true,
-            is_debitable: true,
+            is_writable: true,
         };
         keys_and_signed.insert(0, &payer_account_meta);
     }
 
     let mut signed_keys = vec![];
     let mut unsigned_keys = vec![];
-    let mut num_credit_only_signed_accounts = 0;
-    let mut num_credit_only_unsigned_accounts = 0;
+    let mut num_read_only_signed_accounts = 0;
+    let mut num_read_only_unsigned_accounts = 0;
     for account_meta in keys_and_signed.into_iter().unique_by(|x| x.pubkey) {
         if account_meta.is_signer {
             signed_keys.push(account_meta.pubkey);
-            if !account_meta.is_debitable {
-                num_credit_only_signed_accounts += 1;
+            if !account_meta.is_writable {
+                num_read_only_signed_accounts += 1;
             }
         } else {
             unsigned_keys.push(account_meta.pubkey);
-            if !account_meta.is_debitable {
-                num_credit_only_unsigned_accounts += 1;
+            if !account_meta.is_writable {
+                num_read_only_unsigned_accounts += 1;
             }
         }
     }
     InstructionKeys::new(
         signed_keys,
         unsigned_keys,
-        num_credit_only_signed_accounts,
-        num_credit_only_unsigned_accounts,
+        num_read_only_signed_accounts,
+        num_read_only_unsigned_accounts,
     )
 }
 
@@ -130,19 +130,19 @@ pub struct MessageHeader {
     /// NOTE: Serialization-related changes must be paired with the direct read at sigverify.
     pub num_required_signatures: u8,
 
-    /// The last num_credit_only_signed_accounts of the signed keys are credit-only accounts.
-    /// Programs may process multiple transactions that add lamports to the same credit-only
-    /// account within a single PoH entry, but are not permitted to debit lamports or modify
-    /// account data. Transactions targeting the same debit account are evaluated sequentially.
-    pub num_credit_only_signed_accounts: u8,
+    /// The last num_read_only_signed_accounts of the signed keys are read-only accounts. Programs
+    /// may process multiple transactions that load read-only accounts within a single PoH entry,
+    /// but are not permitted to credit or debit lamports or modify account data. Transactions
+    /// targeting the same read-write account are evaluated sequentially.
+    pub num_read_only_signed_accounts: u8,
 
-    /// The last num_credit_only_unsigned_accounts of the unsigned keys are credit-only accounts.
-    pub num_credit_only_unsigned_accounts: u8,
+    /// The last num_read_only_unsigned_accounts of the unsigned keys are read-only accounts.
+    pub num_read_only_unsigned_accounts: u8,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub struct Message {
-    /// The message header, identifying signed and credit-only `account_keys`
+    /// The message header, identifying signed and read-only `account_keys`
     /// NOTE: Serialization-related changes must be paired with the direct read at sigverify.
     pub header: MessageHeader,
 
@@ -162,8 +162,8 @@ pub struct Message {
 impl Message {
     pub fn new_with_compiled_instructions(
         num_required_signatures: u8,
-        num_credit_only_signed_accounts: u8,
-        num_credit_only_unsigned_accounts: u8,
+        num_read_only_signed_accounts: u8,
+        num_read_only_unsigned_accounts: u8,
         account_keys: Vec<Pubkey>,
         recent_blockhash: Hash,
         instructions: Vec<CompiledInstruction>,
@@ -171,8 +171,8 @@ impl Message {
         Self {
             header: MessageHeader {
                 num_required_signatures,
-                num_credit_only_signed_accounts,
-                num_credit_only_unsigned_accounts,
+                num_read_only_signed_accounts,
+                num_read_only_unsigned_accounts,
             },
             account_keys,
             recent_blockhash,
@@ -188,16 +188,16 @@ impl Message {
         let InstructionKeys {
             mut signed_keys,
             unsigned_keys,
-            num_credit_only_signed_accounts,
-            num_credit_only_unsigned_accounts,
+            num_read_only_signed_accounts,
+            num_read_only_unsigned_accounts,
         } = get_keys(&instructions, payer);
         let num_required_signatures = signed_keys.len() as u8;
         signed_keys.extend(&unsigned_keys);
         let instructions = compile_instructions(instructions, &signed_keys);
         Self::new_with_compiled_instructions(
             num_required_signatures,
-            num_credit_only_signed_accounts,
-            num_credit_only_unsigned_accounts,
+            num_read_only_signed_accounts,
+            num_read_only_unsigned_accounts,
             signed_keys,
             Hash::default(),
             instructions,
@@ -218,25 +218,25 @@ impl Message {
             .position(|&&pubkey| pubkey == self.account_keys[index])
     }
 
-    pub fn is_debitable(&self, i: usize) -> bool {
-        i < (self.header.num_required_signatures - self.header.num_credit_only_signed_accounts)
+    pub fn is_writable(&self, i: usize) -> bool {
+        i < (self.header.num_required_signatures - self.header.num_read_only_signed_accounts)
             as usize
             || (i >= self.header.num_required_signatures as usize
                 && i < self.account_keys.len()
-                    - self.header.num_credit_only_unsigned_accounts as usize)
+                    - self.header.num_read_only_unsigned_accounts as usize)
     }
 
     pub fn get_account_keys_by_lock_type(&self) -> (Vec<&Pubkey>, Vec<&Pubkey>) {
         let mut credit_debit_keys = vec![];
-        let mut credit_only_keys = vec![];
+        let mut read_only_keys = vec![];
         for (i, key) in self.account_keys.iter().enumerate() {
-            if self.is_debitable(i) {
+            if self.is_writable(i) {
                 credit_debit_keys.push(key);
             } else {
-                credit_only_keys.push(key);
+                read_only_keys.push(key);
             }
         }
-        (credit_debit_keys, credit_only_keys)
+        (credit_debit_keys, read_only_keys)
     }
 }
 
@@ -399,7 +399,7 @@ mod tests {
     }
 
     #[test]
-    fn test_message_credit_only_keys_last() {
+    fn test_message_read_only_keys_last() {
         let program_id = Pubkey::default();
         let id0 = Pubkey::default(); // Identical key/program_id should be de-duped
         let id1 = Pubkey::new_rand();
@@ -407,16 +407,8 @@ mod tests {
         let id3 = Pubkey::new_rand();
         let keys = get_keys(
             &[
-                Instruction::new(
-                    program_id,
-                    &0,
-                    vec![AccountMeta::new_credit_only(id0, false)],
-                ),
-                Instruction::new(
-                    program_id,
-                    &0,
-                    vec![AccountMeta::new_credit_only(id1, true)],
-                ),
+                Instruction::new(program_id, &0, vec![AccountMeta::new_read_only(id0, false)]),
+                Instruction::new(program_id, &0, vec![AccountMeta::new_read_only(id1, true)]),
                 Instruction::new(program_id, &0, vec![AccountMeta::new(id2, false)]),
                 Instruction::new(program_id, &0, vec![AccountMeta::new(id3, true)]),
             ],
@@ -484,16 +476,8 @@ mod tests {
         let id1 = Pubkey::new_rand();
         let keys = get_keys(
             &[
-                Instruction::new(
-                    program_id,
-                    &0,
-                    vec![AccountMeta::new_credit_only(id0, false)],
-                ),
-                Instruction::new(
-                    program_id,
-                    &0,
-                    vec![AccountMeta::new_credit_only(id1, true)],
-                ),
+                Instruction::new(program_id, &0, vec![AccountMeta::new_read_only(id0, false)]),
+                Instruction::new(program_id, &0, vec![AccountMeta::new_read_only(id1, true)]),
             ],
             None,
         );
@@ -518,7 +502,7 @@ mod tests {
     }
 
     #[test]
-    fn test_is_debitable() {
+    fn test_is_writable() {
         let key0 = Pubkey::new_rand();
         let key1 = Pubkey::new_rand();
         let key2 = Pubkey::new_rand();
@@ -529,19 +513,19 @@ mod tests {
         let message = Message {
             header: MessageHeader {
                 num_required_signatures: 3,
-                num_credit_only_signed_accounts: 2,
-                num_credit_only_unsigned_accounts: 1,
+                num_read_only_signed_accounts: 2,
+                num_read_only_unsigned_accounts: 1,
             },
             account_keys: vec![key0, key1, key2, key3, key4, key5],
             recent_blockhash: Hash::default(),
             instructions: vec![],
         };
-        assert_eq!(message.is_debitable(0), true);
-        assert_eq!(message.is_debitable(1), false);
-        assert_eq!(message.is_debitable(2), false);
-        assert_eq!(message.is_debitable(3), true);
-        assert_eq!(message.is_debitable(4), true);
-        assert_eq!(message.is_debitable(5), false);
+        assert_eq!(message.is_writable(0), true);
+        assert_eq!(message.is_writable(1), false);
+        assert_eq!(message.is_writable(2), false);
+        assert_eq!(message.is_writable(3), true);
+        assert_eq!(message.is_writable(4), true);
+        assert_eq!(message.is_writable(5), false);
     }
 
     #[test]
@@ -554,16 +538,8 @@ mod tests {
         let message = Message::new(vec![
             Instruction::new(program_id, &0, vec![AccountMeta::new(id0, false)]),
             Instruction::new(program_id, &0, vec![AccountMeta::new(id1, true)]),
-            Instruction::new(
-                program_id,
-                &0,
-                vec![AccountMeta::new_credit_only(id2, false)],
-            ),
-            Instruction::new(
-                program_id,
-                &0,
-                vec![AccountMeta::new_credit_only(id3, true)],
-            ),
+            Instruction::new(program_id, &0, vec![AccountMeta::new_read_only(id2, false)]),
+            Instruction::new(program_id, &0, vec![AccountMeta::new_read_only(id3, true)]),
         ]);
         assert_eq!(
             message.get_account_keys_by_lock_type(),

--- a/sdk/src/transaction.rs
+++ b/sdk/src/transaction.rs
@@ -418,12 +418,12 @@ mod tests {
 
         let len_size = 1;
         let num_required_sigs_size = 1;
-        let num_credit_only_accounts_size = 2;
+        let num_read_only_accounts_size = 2;
         let blockhash_size = size_of::<Hash>();
         let expected_transaction_size = len_size
             + (tx.signatures.len() * size_of::<Signature>())
             + num_required_sigs_size
-            + num_credit_only_accounts_size
+            + num_read_only_accounts_size
             + len_size
             + (tx.message.account_keys.len() * size_of::<Pubkey>())
             + blockhash_size

--- a/sdk/src/transaction.rs
+++ b/sdk/src/transaction.rs
@@ -418,12 +418,12 @@ mod tests {
 
         let len_size = 1;
         let num_required_sigs_size = 1;
-        let num_read_only_accounts_size = 2;
+        let num_readonly_accounts_size = 2;
         let blockhash_size = size_of::<Hash>();
         let expected_transaction_size = len_size
             + (tx.signatures.len() * size_of::<Signature>())
             + num_required_sigs_size
-            + num_read_only_accounts_size
+            + num_readonly_accounts_size
             + len_size
             + (tx.message.account_keys.len() * size_of::<Pubkey>())
             + blockhash_size


### PR DESCRIPTION
#### Problem
Credit-only account handling adds much more complexity to the code base than originally anticipated. Committing credits to accounts also degrades performance significantly (see #6713 ). The benefits of credit-only accounts do not currently seem worth the cost.

#### Summary of Changes
- Convert credit-only accounts to read-only accounts, enabling accounts that need not change (like sysvars) to still be loaded in transactions processed in parallel
- Remove collection, processing, and commit of credits
- Check for any account change in read-only accounts in runtime (message_processor::verify_instruction).
- Rename credit-only/credit-debit to readonly/writable

Fixes #6655 
