### PR TITLE
Add root to gossip

### DIFF
--- a/core/src/cluster_info.rs
+++ b/core/src/cluster_info.rs
@@ -18,7 +18,7 @@ use crate::{
     crds_gossip::CrdsGossip,
     crds_gossip_error::CrdsGossipError,
     crds_gossip_pull::{CrdsFilter, CRDS_GOSSIP_PULL_CRDS_TIMEOUT_MS},
-    crds_value::{self, CrdsData, CrdsValue, CrdsValueLabel, EpochSlots, Vote},
+    crds_value::{self, CrdsData, CrdsValue, CrdsValueLabel, EpochSlots, Root, Vote},
     packet::Packet,
     repair_service::RepairType,
     result::{Error, Result},
@@ -308,6 +308,14 @@ impl ClusterInfo {
                 "".to_string()
             }
         )
+    }
+
+    pub fn push_root(&mut self, root: u64) {
+        let now = timestamp();
+        let root = Root::new(&self.id(), root, now);
+        let entry = CrdsValue::new_signed(CrdsData::Root(root), &self.keypair);
+        self.gossip
+            .process_push_message(&self.id(), vec![entry], now);
     }
 
     pub fn push_epoch_slots(&mut self, id: Pubkey, root: u64, slots: BTreeSet<u64>) {

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -523,6 +523,7 @@ impl ReplayStage {
                 trace!("root_bank_sender failed: {:?}", e);
                 return Err(e.into());
             }
+            cluster_info.write().unwrap().push_root(new_root);
         }
         Self::update_commitment_cache(bank.clone(), total_staked, lockouts_sender);
 


### PR DESCRIPTION
#### Problem
Leaders will broadcast shreds to validators, even if they are more than one epoch behind and don't have an up to date leader schedule to verify those shreds. These validators that are far behind will just drop these transmissions and this hurts Turbine.

#### Summary of Changes
Add roots to gossip so leaders and validators will only include validators in Turbine that are far enough along (have a leader schedule for the epoch) to validate those shreds

Fixes #
