### PR TITLE
Generate votes only if the proposed bank is not censoring the validator

### DIFF
--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -210,9 +210,19 @@ impl Tower {
         bank_vote_state.votes.iter().map(|v| v.slot).last()
     }
 
-    pub fn new_vote_from_bank(&self, bank: &Bank, vote_account_pubkey: &Pubkey) -> Option<(Vote, usize)> {
+    pub fn new_vote_from_bank(
+        &self,
+        bank: &Bank,
+        vote_account_pubkey: &Pubkey,
+    ) -> Option<(Vote, usize)> {
         let last_vote = Self::last_bank_vote(bank, vote_account_pubkey);
-        Self::new_vote(self.threshold_depth, &self.lockouts, bank.slot(), bank.hash(), last_vote)
+        Self::new_vote(
+            self.threshold_depth,
+            &self.lockouts,
+            bank.slot(),
+            bank.hash(),
+            last_vote,
+        )
     }
 
     pub fn record_bank_vote(&mut self, vote: Vote) -> Option<Slot> {
@@ -845,7 +855,7 @@ mod test {
         let mut local = VoteState::default();
         //network is censoring
         let vote = Vote {
-            slots: vec![0,1,2,3],
+            slots: vec![0, 1, 2, 3],
             hash: Hash::default(),
         };
         local.process_vote_unchecked(&vote);
@@ -853,12 +863,14 @@ mod test {
         assert_eq!(Tower::new_vote(4, &local, 4, Hash::default(), None), None);
         //vote 6 has expried vote 3, and should be at threshold 4
         let vote = Vote {
-            slots: vec![0,1,2,6],
+            slots: vec![0, 1, 2, 6],
             hash: Hash::default(),
         };
-        assert_eq!(Tower::new_vote(4, &local, 6, Hash::default(), None), Some((vote, 4)));
+        assert_eq!(
+            Tower::new_vote(4, &local, 6, Hash::default(), None),
+            Some((vote, 3))
+        );
     }
-
 
     #[test]
     fn test_check_vote_threshold_forks() {

--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -861,6 +861,19 @@ mod test {
         local.process_vote_unchecked(&vote);
         //vote 4 should be at threshold 5
         assert_eq!(Tower::new_vote(4, &local, 4, Hash::default(), None), None);
+
+        //bank has 0 as the last root
+        //Threshold is not met
+        let vote = Vote {
+            slots: vec![1, 2, 3, 4],
+            hash: Hash::default(),
+        };
+        //Tower length is 5, 0-, so index for this vote is 4
+        assert_eq!(
+            Tower::new_vote(4, &local, 4, Hash::default(), Some(0)),
+            Some((vote, 4))
+        );
+
         //vote 6 has expried vote 3, and should be at threshold 4
         let vote = Vote {
             slots: vec![0, 1, 2, 6],

--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -842,14 +842,21 @@ mod test {
 
     #[test]
     fn test_new_vote_threshold() {
-        let local = VoteState::default();
+        let mut local = VoteState::default();
         //network is censoring
         let vote = Vote {
             slots: vec![0,1,2,3],
             hash: Hash::default(),
         };
-        assert_eq!(Tower::new_vote(3, &local, 1, Hash::default(), Some(0)), None);
-        assert_eq!(Tower::new_vote(4, &local, 0, Hash::default(), Some(0)), Some((vote, 4)));
+        local.process_vote_unchecked(&vote);
+        //vote 4 should be at threshold 5
+        assert_eq!(Tower::new_vote(4, &local, 4, Hash::default(), None), None);
+        //vote 6 has expried vote 3, and should be at threshold 4
+        let vote = Vote {
+            slots: vec![0,1,2,6],
+            hash: Hash::default(),
+        };
+        assert_eq!(Tower::new_vote(4, &local, 6, Hash::default(), None), Some((vote, 4)));
     }
 
 

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -496,7 +496,7 @@ impl ReplayStage {
             inc_new_counter_info!("replay_stage-voted_empty_bank", 1);
         }
         trace!("handle votable bank {}", bank.slot());
-        let (vote, tower_index) = tower.new_vote_from_bank(bank, vote_account);
+        if let Some((vote, tower_index)) = tower.new_vote_from_bank(bank, vote_account) {
         if let Some(new_root) = tower.record_bank_vote(vote) {
             // get the root bank before squash
             let root_bank = bank_forks
@@ -547,6 +547,10 @@ impl ReplayStage {
                 .unwrap()
                 .push_vote(tower_index, vote_tx);
         }
+      } else {
+        warn!("Vote dropped for bank {}, bank censorship failure!!!", bank.slot());
+        inc_new_counter_info!("replay_stage-votable_bank_censorship_failure", 1);
+       }
         Ok(())
     }
 


### PR DESCRIPTION
#### Problem

Validators may continue voting even though the network is dropping the votes.

#### Summary of Changes

If the delta between expected vote state and current vote state > THRESHOLD, consensus stops voting and lets some votes expire.


Fixes #6727
