### PR TITLE
Integrated use of netem with testnet scripts

### DIFF
--- a/net/net.sh
+++ b/net/net.sh
@@ -88,6 +88,8 @@ Operate a configured testnet
 
    --use-move                         - Build the move-loader-program and add it to the cluster
 
+   --netem                            - Use netem to induce packet drops/latencies/errors
+
  sanity/start-specific options:
    -F                   - Discard validator nodes that didn't bootup successfully
    -o noInstallCheck    - Skip solana-install sanity
@@ -141,6 +143,7 @@ debugBuild=false
 doBuild=true
 gpuMode=auto
 maybeUseMove=""
+netemConfig=""
 
 command=$1
 [[ -n $command ]] || usage
@@ -204,6 +207,8 @@ while [[ -n $1 ]]; do
     elif [[ $1 = --use-move ]]; then
       maybeUseMove=$1
       shift 1
+    elif [[ $1 = --netem ]]; then
+      netemConfig=$2
     elif [[ $1 = --gpu-mode ]]; then
       gpuMode=$2
       case "$gpuMode" in
@@ -459,6 +464,7 @@ startBootstrapLeader() {
          \"$maybeNoSnapshot $maybeSkipLedgerVerify $maybeLimitLedgerSize\" \
          \"$gpuMode\" \
          \"$GEOLOCATION_API_KEY\" \
+         \"$netemConfig\" \
       "
 
   ) >> "$logFile" 2>&1 || {
@@ -526,6 +532,7 @@ startNode() {
          \"$maybeNoSnapshot $maybeSkipLedgerVerify $maybeLimitLedgerSize\" \
          \"$gpuMode\" \
          \"$GEOLOCATION_API_KEY\" \
+         \"$netemConfig\" \
       "
   ) >> "$logFile" 2>&1 &
   declare pid=$!
@@ -823,6 +830,10 @@ stopNode() {
           \$sudo kill -- -\$pgid
         fi
       done
+      if [[ -f solana/netem.cfg ]]; then
+        solana/scripts/netem.sh delete < solana/netem.cfg
+        rm -f solana/netem.cfg
+      fi
       for pattern in node solana- remote-; do
         pkill -9 \$pattern
       done

--- a/net/net.sh
+++ b/net/net.sh
@@ -209,6 +209,7 @@ while [[ -n $1 ]]; do
       shift 1
     elif [[ $1 = --netem ]]; then
       netemConfig=$2
+      shift 2
     elif [[ $1 = --gpu-mode ]]; then
       gpuMode=$2
       case "$gpuMode" in

--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -148,6 +148,11 @@ cat >> ~/solana/on-reboot <<EOF
     echo "Expected GPU, found none!"
     export SOLANA_GPU_MISSING=1
   fi
+
+  if [[ -n "$netemConfig" ]]; then
+    scripts/netem.sh add "$netemConfig"
+    echo "$netemConfig" > netem.cfg
+  fi
 EOF
 
   case $nodeType in
@@ -242,11 +247,6 @@ EOF
       solana --url http://"$entrypointIp":8899 \
         --keypair ~/solana/config/bootstrap-leader/identity-keypair.json \
         validator-info publish "$(hostname)" -n team/solana --force || true
-    fi
-
-    if [[ -n "$netemConfig" ]]; then
-      ~/solana/scripts/netem.sh add "$netemConfig"
-      echo "$netemConfig" > ~/solana/netem.cfg
     fi
     ;;
   validator|blockstreamer)
@@ -377,11 +377,6 @@ EOF
       solana --url http://"$entrypointIp":8899 \
         --keypair config/validator-identity.json \
         validator-info publish "$(hostname)" -n team/solana --force || true
-    fi
-
-    if [[ -n "$netemConfig" ]]; then
-      ~/solana/scripts/netem.sh add "$netemConfig"
-      echo "$netemConfig" > ~/solana/netem.cfg
     fi
     ;;
   archiver)

--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -26,6 +26,7 @@ genesisOptions="${17}"
 extraNodeArgs="${18}"
 gpuMode="${19:-auto}"
 GEOLOCATION_API_KEY="${20}"
+netemConfig="${21}"
 set +x
 
 # Use a very large stake (relative to the default multinode-demo/ stake of 42)
@@ -242,6 +243,11 @@ EOF
         --keypair ~/solana/config/bootstrap-leader/identity-keypair.json \
         validator-info publish "$(hostname)" -n team/solana --force || true
     fi
+
+    if [[ -n $netemConfig ]]; then
+      script/netem.sh add "$netemConfig"
+      echo "$netemConfig" > netem.cfg
+    fi
     ;;
   validator|blockstreamer)
     if [[ $deployMethod != skip ]]; then
@@ -371,6 +377,11 @@ EOF
       solana --url http://"$entrypointIp":8899 \
         --keypair config/validator-identity.json \
         validator-info publish "$(hostname)" -n team/solana --force || true
+    fi
+
+    if [[ -n $netemConfig ]]; then
+      script/netem.sh add "$netemConfig"
+      echo "$netemConfig" > netem.cfg
     fi
     ;;
   archiver)

--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -244,9 +244,9 @@ EOF
         validator-info publish "$(hostname)" -n team/solana --force || true
     fi
 
-    if [[ -n $netemConfig ]]; then
-      script/netem.sh add "$netemConfig"
-      echo "$netemConfig" > netem.cfg
+    if [[ -n "$netemConfig" ]]; then
+      ~/solana/scripts/netem.sh add "$netemConfig"
+      echo "$netemConfig" > ~/solana/netem.cfg
     fi
     ;;
   validator|blockstreamer)
@@ -379,9 +379,9 @@ EOF
         validator-info publish "$(hostname)" -n team/solana --force || true
     fi
 
-    if [[ -n $netemConfig ]]; then
-      script/netem.sh add "$netemConfig"
-      echo "$netemConfig" > netem.cfg
+    if [[ -n "$netemConfig" ]]; then
+      ~/solana/scripts/netem.sh add "$netemConfig"
+      echo "$netemConfig" > ~/solana/netem.cfg
     fi
     ;;
   archiver)

--- a/scripts/netem.sh
+++ b/scripts/netem.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+#
+# Start/Stop network emulation
+#
+set -e
+
+[[ $(uname) == Linux ]] || exit 0
+
+cd "$(dirname "$0")"
+
+sudo=
+if sudo true; then
+  sudo="sudo -n"
+fi
+
+iface="$(ifconfig | grep mtu | grep -iv loopback | grep -i running | awk 'BEGIN { FS = ":" } ; {print $1}')"
+$sudo tc qdisc "$1" dev "$iface" root netem $2

--- a/scripts/netem.sh
+++ b/scripts/netem.sh
@@ -14,4 +14,5 @@ if sudo true; then
 fi
 
 iface="$(ifconfig | grep mtu | grep -iv loopback | grep -i running | awk 'BEGIN { FS = ":" } ; {print $1}')"
+# shellcheck disable=SC2086 # Do not want to quote $2. It has space separated arguments for netem
 $sudo tc qdisc "$1" dev "$iface" root netem $2

--- a/scripts/netem.sh
+++ b/scripts/netem.sh
@@ -13,6 +13,8 @@ if sudo true; then
   sudo="sudo -n"
 fi
 
+set -x
+
 iface="$(ifconfig | grep mtu | grep -iv loopback | grep -i running | awk 'BEGIN { FS = ":" } ; {print $1}')"
 # shellcheck disable=SC2086 # Do not want to quote $2. It has space separated arguments for netem
 $sudo tc qdisc "$1" dev "$iface" root netem $2


### PR DESCRIPTION
#### Problem
Need a mechanism to induce packet errors in testnet deployments

#### Summary of Changes
The user can pass `--netem <arguments>` to net.sh script. For example
`net/net.sh start --netem "delay 200ms 40ms 25% loss 15.3% 25% duplicate 1% corrupt 0.1% reorder 5% 50%"`

If `--netem` was used while launching the testnet, `net.sh stop` will delete the rule on testnet stop.