### PR TITLE
replay_stage: Log current slot upon PoH reset

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -578,9 +578,10 @@ impl ReplayStage {
         };
 
         info!(
-            "{} voted and reset PoH at tick height {}. {}",
+            "{} voted and reset PoH to tick {} (within slot {}). {}",
             my_pubkey,
             bank.tick_height(),
+            bank.slot(),
             next_leader_msg,
         );
     }


### PR DESCRIPTION
`... voted and reset PoH at tick height 123. My next leader slot is 456` log messages would be even better if they included the current slot, now they do