### PR TITLE
Fix substitution of private IP with public IP in iftop logs

### DIFF
--- a/scripts/iftop-postprocess.sh
+++ b/scripts/iftop-postprocess.sh
@@ -23,10 +23,10 @@ awk '{ if ($3 ~ "=>") { print $2, $7 } else if ($2 ~ "<=") { print $1, $6 }} ' <
   | awk 'NR%2{printf "%s ",$0;next;}1' \
   | awk '{ print "{ \"a\": \""$1"\", " "\"b\": \""$3"\", \"a_to_b\": \""$2"\", \"b_to_a\": \""$4"\"}," }' > "$2"
 
-if [ "$#" -ne 3 ]; then
+if [ "$#" -lt 4 ]; then
   solana-log-analyzer iftop -f "$2"
 else
-  solana-log-analyzer iftop -f "$2" map-IP --priv "$(hostname -i)" --pub "$3"
+  solana-log-analyzer iftop -f "$2" map-IP --priv "$3" --pub "$4"
 fi
 
 exit 1


### PR DESCRIPTION
#### Problem
The private IP is not correctly mapped to public IP in iftop logs.

#### Summary of Changes
Use testnet configuration to find private IP, and substitute it with corresponding public IP.

The command to download the logs has changed to
```for i in "${!validatorIpList[@]}"; do :; ./net/ssh.sh solana@${validatorIpList[$i]} 'PATH=$PATH:~/.cargo/bin/ ~/solana/scripts/iftop-postprocess.sh ~/solana/iftop.log temp.log' ${validatorIpListPrivate[$i]} ${validatorIpList[$i]} > iftop-logs/${validatorIpList[$i]}-iftop.log; done```