### PR TITLE
Limit deserialization of data coming off the wire

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3281,6 +3281,7 @@ dependencies = [
  "jsonrpc-pubsub 14.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-ws-server 14.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "memmap 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/core/src/archiver.rs
+++ b/core/src/archiver.rs
@@ -4,7 +4,7 @@ use crate::{
     cluster_info::{ClusterInfo, Node, VALIDATOR_PORT_RANGE},
     contact_info::ContactInfo,
     gossip_service::GossipService,
-    packet::PACKET_DATA_SIZE,
+    packet::{limited_deserialize, PACKET_DATA_SIZE},
     repair_service,
     repair_service::{RepairService, RepairSlotRange, RepairStrategy},
     result::{Error, Result},
@@ -161,9 +161,7 @@ fn create_request_processor(
             if let Ok(packets) = packets {
                 for packet in &packets.packets {
                     let req: result::Result<ArchiverRequest, Box<bincode::ErrorKind>> =
-                        bincode::config()
-                            .limit(PACKET_DATA_SIZE as u64)
-                            .deserialize(&packet.data[..packet.meta.size]);
+                        limited_deserialize(&packet.data[..packet.meta.size]);
                     match req {
                         Ok(ArchiverRequest::GetSlotHeight(from)) => {
                             if let Ok(blob) = to_shared_blob(slot, from) {

--- a/core/src/archiver.rs
+++ b/core/src/archiver.rs
@@ -4,6 +4,7 @@ use crate::{
     cluster_info::{ClusterInfo, Node, VALIDATOR_PORT_RANGE},
     contact_info::ContactInfo,
     gossip_service::GossipService,
+    packet::PACKET_DATA_SIZE,
     repair_service,
     repair_service::{RepairService, RepairSlotRange, RepairStrategy},
     result::{Error, Result},
@@ -14,7 +15,6 @@ use crate::{
     streamer::{receiver, responder, PacketReceiver},
     window_service::WindowService,
 };
-use bincode::deserialize;
 use crossbeam_channel::unbounded;
 use rand::{thread_rng, Rng, SeedableRng};
 use rand_chacha::ChaChaRng;
@@ -161,7 +161,9 @@ fn create_request_processor(
             if let Ok(packets) = packets {
                 for packet in &packets.packets {
                     let req: result::Result<ArchiverRequest, Box<bincode::ErrorKind>> =
-                        deserialize(&packet.data[..packet.meta.size]);
+                        bincode::config()
+                            .limit(PACKET_DATA_SIZE as u64)
+                            .deserialize(&packet.data[..packet.meta.size]);
                     match req {
                         Ok(ArchiverRequest::GetSlotHeight(from)) => {
                             if let Ok(blob) = to_shared_blob(slot, from) {
@@ -933,7 +935,10 @@ impl Archiver {
             socket.send_to(&serialized_req, to).unwrap();
             let mut buf = [0; 1024];
             if let Ok((size, _addr)) = socket.recv_from(&mut buf) {
-                return deserialize(&buf[..size]).unwrap();
+                return bincode::config()
+                    .limit(PACKET_DATA_SIZE as u64)
+                    .deserialize(&buf[..size])
+                    .unwrap();
             }
             sleep(Duration::from_millis(500));
         }

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -3,7 +3,7 @@
 //! can do its processing in parallel with signature verification on the GPU.
 use crate::{
     cluster_info::ClusterInfo,
-    packet::{Packet, Packets, PACKETS_PER_BATCH, PACKET_DATA_SIZE},
+    packet::{limited_deserialize, Packet, Packets, PACKETS_PER_BATCH},
     poh_recorder::{PohRecorder, PohRecorderError, WorkingBankEntry},
     poh_service::PohService,
     result::{Error, Result},
@@ -419,12 +419,7 @@ impl BankingStage {
     fn deserialize_transactions(p: &Packets) -> Vec<Option<Transaction>> {
         p.packets
             .iter()
-            .map(|x| {
-                bincode::config()
-                    .limit(PACKET_DATA_SIZE as u64)
-                    .deserialize(&x.data[0..x.meta.size])
-                    .ok()
-            })
+            .map(|x| limited_deserialize(&x.data[0..x.meta.size]).ok())
             .collect()
     }
 

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -3,13 +3,12 @@
 //! can do its processing in parallel with signature verification on the GPU.
 use crate::{
     cluster_info::ClusterInfo,
-    packet::{Packet, Packets, PACKETS_PER_BATCH},
+    packet::{Packet, Packets, PACKETS_PER_BATCH, PACKET_DATA_SIZE},
     poh_recorder::{PohRecorder, PohRecorderError, WorkingBankEntry},
     poh_service::PohService,
     result::{Error, Result},
     service::Service,
 };
-use bincode::deserialize;
 use crossbeam_channel::{Receiver as CrossbeamReceiver, RecvTimeoutError};
 use itertools::Itertools;
 use solana_ledger::{
@@ -19,11 +18,10 @@ use solana_measure::measure::Measure;
 use solana_metrics::{inc_new_counter_debug, inc_new_counter_info, inc_new_counter_warn};
 use solana_perf::perf_libs;
 use solana_runtime::{accounts_db::ErrorCounters, bank::Bank, transaction_batch::TransactionBatch};
-use solana_sdk::clock::MAX_TRANSACTION_FORWARDING_DELAY_GPU;
 use solana_sdk::{
     clock::{
         Slot, DEFAULT_TICKS_PER_SECOND, DEFAULT_TICKS_PER_SLOT, MAX_PROCESSING_AGE,
-        MAX_TRANSACTION_FORWARDING_DELAY,
+        MAX_TRANSACTION_FORWARDING_DELAY, MAX_TRANSACTION_FORWARDING_DELAY_GPU,
     },
     poh_config::PohConfig,
     pubkey::Pubkey,
@@ -421,7 +419,12 @@ impl BankingStage {
     fn deserialize_transactions(p: &Packets) -> Vec<Option<Transaction>> {
         p.packets
             .iter()
-            .map(|x| deserialize(&x.data[0..x.meta.size]).ok())
+            .map(|x| {
+                bincode::config()
+                    .limit(PACKET_DATA_SIZE as u64)
+                    .deserialize(&x.data[0..x.meta.size])
+                    .ok()
+            })
             .collect()
     }
 

--- a/core/src/blob.rs
+++ b/core/src/blob.rs
@@ -404,6 +404,13 @@ pub fn index_blobs(
     }
 }
 
+pub fn limited_deserialize<T>(data: &[u8]) -> bincode::Result<T>
+where
+    T: serde::de::DeserializeOwned,
+{
+    bincode::config().limit(BLOB_SIZE as u64).deserialize(data)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/core/src/cluster_info.rs
+++ b/core/src/cluster_info.rs
@@ -19,14 +19,14 @@ use crate::{
     crds_gossip_error::CrdsGossipError,
     crds_gossip_pull::{CrdsFilter, CRDS_GOSSIP_PULL_CRDS_TIMEOUT_MS},
     crds_value::{self, CrdsData, CrdsValue, CrdsValueLabel, EpochSlots, Vote},
-    packet::Packet,
+    packet::{Packet, PACKET_DATA_SIZE},
     repair_service::RepairType,
     result::{Error, Result},
     sendmmsg::{multicast, send_mmsg},
     streamer::{BlobReceiver, BlobSender},
     weighted_shuffle::{weighted_best, weighted_shuffle},
 };
-use bincode::{deserialize, serialize, serialized_size};
+use bincode::{serialize, serialized_size};
 use core::cmp;
 use itertools::Itertools;
 use rand::{thread_rng, Rng};
@@ -38,7 +38,6 @@ use solana_netutil::{
 };
 use solana_sdk::{
     clock::Slot,
-    packet::PACKET_DATA_SIZE,
     pubkey::Pubkey,
     signature::{Keypair, KeypairUtil, Signable, Signature},
     timing::{duration_as_ms, timestamp},
@@ -1175,7 +1174,9 @@ impl ClusterInfo {
         blobs.iter().for_each(|blob| {
             let blob = blob.read().unwrap();
             let from_addr = blob.meta.addr();
-            deserialize(&blob.data[..blob.meta.size])
+            bincode::config()
+                .limit(PACKET_DATA_SIZE as u64)
+                .deserialize(&blob.data[..blob.meta.size])
                 .into_iter()
                 .for_each(|request| match request {
                     Protocol::PullRequest(filter, caller) => {

--- a/core/src/cluster_info.rs
+++ b/core/src/cluster_info.rs
@@ -13,7 +13,7 @@
 //!
 //! Bank needs to provide an interface for us to query the stake weight
 use crate::{
-    blob::{to_shared_blob, Blob, SharedBlob},
+    blob::{limited_deserialize, to_shared_blob, Blob, SharedBlob},
     contact_info::ContactInfo,
     crds_gossip::CrdsGossip,
     crds_gossip_error::CrdsGossipError,
@@ -1174,9 +1174,7 @@ impl ClusterInfo {
         blobs.iter().for_each(|blob| {
             let blob = blob.read().unwrap();
             let from_addr = blob.meta.addr();
-            bincode::config()
-                .limit(PACKET_DATA_SIZE as u64)
-                .deserialize(&blob.data[..blob.meta.size])
+            limited_deserialize(&blob.data[..blob.meta.size])
                 .into_iter()
                 .for_each(|request| match request {
                     Protocol::PullRequest(filter, caller) => {

--- a/core/src/packet.rs
+++ b/core/src/packet.rs
@@ -85,6 +85,15 @@ pub fn to_packets<T: Serialize>(xs: &[T]) -> Vec<Packets> {
     to_packets_chunked(xs, NUM_PACKETS)
 }
 
+pub fn limited_deserialize<T>(data: &[u8]) -> bincode::Result<T>
+where
+    T: serde::de::DeserializeOwned,
+{
+    bincode::config()
+        .limit(PACKET_DATA_SIZE as u64)
+        .deserialize(data)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/core/src/sigverify_shreds.rs
+++ b/core/src/sigverify_shreds.rs
@@ -1,8 +1,7 @@
 #![allow(clippy::implicit_hasher)]
-use crate::packet::{Packet, Packets};
+use crate::packet::{Packet, Packets, PACKET_DATA_SIZE};
 use crate::sigverify::{self, TxOffset};
 use crate::sigverify_stage::SigVerifier;
-use bincode::deserialize;
 use rayon::iter::IndexedParallelIterator;
 use rayon::iter::IntoParallelIterator;
 use rayon::iter::IntoParallelRefMutIterator;
@@ -57,7 +56,10 @@ impl ShredSigVerifier {
                     let slot_end = slot_start + size_of::<u64>();
                     trace!("slot {} {}", slot_start, slot_end,);
                     if slot_end <= packet.meta.size {
-                        let slot: u64 = deserialize(&packet.data[slot_start..slot_end]).ok()?;
+                        let slot: u64 = bincode::config()
+                            .limit(PACKET_DATA_SIZE as u64)
+                            .deserialize(&packet.data[slot_start..slot_end])
+                            .ok()?;
                         Some(slot)
                     } else {
                         None
@@ -120,7 +122,10 @@ fn verify_shred_cpu(packet: &Packet, slot_leaders: &HashMap<u64, [u8; 32]>) -> O
     if packet.meta.size < slot_end {
         return Some(0);
     }
-    let slot: u64 = deserialize(&packet.data[slot_start..slot_end]).ok()?;
+    let slot: u64 = bincode::config()
+        .limit(PACKET_DATA_SIZE as u64)
+        .deserialize(&packet.data[slot_start..slot_end])
+        .ok()?;
     trace!("slot {}", slot);
     let pubkey = slot_leaders.get(&slot)?;
     if packet.meta.size < sig_end {
@@ -179,8 +184,10 @@ fn slot_key_data_for_gpu<
                             if packet.meta.size < slot_end {
                                 return std::u64::MAX;
                             }
-                            let slot: Option<u64> =
-                                deserialize(&packet.data[slot_start..slot_end]).ok();
+                            let slot: Option<u64> = bincode::config()
+                                .limit(PACKET_DATA_SIZE as u64)
+                                .deserialize(&packet.data[slot_start..slot_end])
+                                .ok();
                             match slot {
                                 Some(slot) if slot_keys.get(&slot).is_some() => slot,
                                 _ => std::u64::MAX,
@@ -378,8 +385,10 @@ fn sign_shred_cpu(
         packet.meta.size >= slot_end,
         "packet is not large enough for a slot"
     );
-    let slot: u64 =
-        deserialize(&packet.data[slot_start..slot_end]).expect("can't deserialize slot");
+    let slot: u64 = bincode::config()
+        .limit(PACKET_DATA_SIZE as u64)
+        .deserialize(&packet.data[slot_start..slot_end])
+        .expect("can't deserialize slot");
     trace!("slot {}", slot);
     let pubkey = slot_leaders_pubkeys
         .get(&slot)

--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -115,7 +115,9 @@ impl Shred {
     where
         T: Deserialize<'de>,
     {
-        let ret = bincode::deserialize(&buf[*index..*index + size])?;
+        let ret = bincode::config()
+            .limit(PACKET_DATA_SIZE as u64)
+            .deserialize(&buf[*index..*index + size])?;
         *index += size;
         Ok(ret)
     }

--- a/runtime/src/system_instruction_processor.rs
+++ b/runtime/src/system_instruction_processor.rs
@@ -1,7 +1,7 @@
 use log::*;
 use solana_sdk::account::KeyedAccount;
 use solana_sdk::instruction::InstructionError;
-use solana_sdk::instruction_processor_utils::next_keyed_account;
+use solana_sdk::instruction_processor_utils::{limited_deserialize, next_keyed_account};
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::system_instruction::{SystemError, SystemInstruction};
 use solana_sdk::system_program;
@@ -102,8 +102,7 @@ pub fn process_instruction(
     keyed_accounts: &mut [KeyedAccount],
     data: &[u8],
 ) -> Result<(), InstructionError> {
-    let instruction =
-        bincode::deserialize(data).map_err(|_| InstructionError::InvalidInstructionData)?;
+    let instruction = limited_deserialize(data)?;
 
     trace!("process_instruction: {:?}", instruction);
     trace!("keyed_accounts: {:?}", keyed_accounts);


### PR DESCRIPTION
#### Problem

Deserializing data received from unknown sources can be dangerous and open up the system to DDoS attacks.  One way is to send serialized vectors that are spoofed to appear very large, causing the system to potentially allocate very large buffers.

#### Summary of Changes

To prevent this limit all deserialization of data from unknown sources.

Fixes #5779 

