### PR TITLE
ledger-tool/: Include full validator voting history in fork-graph

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -578,9 +578,10 @@ impl ReplayStage {
         };
 
         info!(
-            "{} voted and reset PoH at tick height {}. {}",
+            "{} voted and reset PoH to tick {} (within slot {}). {}",
             my_pubkey,
             bank.tick_height(),
+            bank.slot(),
             next_leader_msg,
         );
     }

--- a/ledger/src/blocktree.rs
+++ b/ledger/src/blocktree.rs
@@ -1139,9 +1139,12 @@ impl Blocktree {
                             serialized_shred
                                 .expect("Shred must exist if shred index was included in a range"),
                         )
-                        .map_err(|_| {
+                        .map_err(|err| {
                             BlocktreeError::InvalidShredData(Box::new(bincode::ErrorKind::Custom(
-                                "Could not reconstruct shred from shred payload".to_string(),
+                                format!(
+                                    "Could not reconstruct shred from shred payload: {:?}",
+                                    err
+                                ),
                             )))
                         })
                     })


### PR DESCRIPTION
It's helpful to view the entire voting history of each validator while looking at the fork graph.

There's also a couple freebies in this PR to improve validator logging.