### PR TITLE
validator: Enable JSON RPC request/response logging by default

### DIFF
--- a/core/src/rpc_service.rs
+++ b/core/src/rpc_service.rs
@@ -53,6 +53,7 @@ impl RpcRequestMiddleware {
     }
 
     fn get(&self, filename: &str) -> RequestMiddlewareAction {
+        info!("get {}", filename);
         let filename = self.ledger_path.join(filename);
         RequestMiddlewareAction::Respond {
             should_validate_hosts: true,

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -225,7 +225,13 @@ fn is_keypair(string: String) -> Result<(), String> {
 }
 
 pub fn main() {
-    solana_logger::setup_with_filter("solana=info");
+    solana_logger::setup_with_filter(
+        &[
+            "solana=info", /* info logging for all solana modules */
+            "rpc=trace",   /* json_rpc request/response logging */
+        ]
+        .join(","),
+    );
     solana_metrics::set_panic_hook("validator");
 
     let default_dynamic_port_range =


### PR DESCRIPTION
We have almost no insight into the JSON RPC requests being made to a node.  This is especially important for nodes like tds.solana.com that are (probably?) getting hit pretty hard, and it really hurts when they stop working (like what happened during DR5).

#6627 would be best but extra logging is a super quick and cheap way to get most of the way there.
