### PR TITLE
Use rooted bank by default in rpc bank selection

### DIFF
--- a/archiver/src/main.rs
+++ b/archiver/src/main.rs
@@ -1,13 +1,15 @@
 use clap::{crate_description, crate_name, crate_version, App, Arg};
 use console::style;
-use solana_core::archiver::Archiver;
-use solana_core::cluster_info::{Node, VALIDATOR_PORT_RANGE};
-use solana_core::contact_info::ContactInfo;
-use solana_sdk::signature::{read_keypair_file, Keypair, KeypairUtil};
-use std::net::SocketAddr;
-use std::path::PathBuf;
-use std::process::exit;
-use std::sync::Arc;
+use solana_core::{
+    archiver::Archiver,
+    cluster_info::{Node, VALIDATOR_PORT_RANGE},
+    contact_info::ContactInfo,
+};
+use solana_sdk::{
+    commitment_config::CommitmentConfig,
+    signature::{read_keypair_file, Keypair, KeypairUtil},
+};
+use std::{net::SocketAddr, path::PathBuf, process::exit, sync::Arc};
 
 // Return an error if a keypair file cannot be parsed.
 fn is_keypair(string: String) -> Result<(), String> {
@@ -118,6 +120,7 @@ fn main() {
         entrypoint_info,
         Arc::new(keypair),
         Arc::new(storage_keypair),
+        CommitmentConfig::recent(),
     )
     .unwrap();
 

--- a/book/src/api-reference/jsonrpc-api.md
+++ b/book/src/api-reference/jsonrpc-api.md
@@ -78,6 +78,24 @@ Requests can be sent in batches by sending an array of JSON-RPC request objects 
 * Signature: An Ed25519 signature of a chunk of data.
 * Transaction: A Solana instruction signed by a client key-pair.
 
+## Configuring State Commitment
+
+Solana nodes choose which bank state to query based on a commitment requirement
+set by the client. Clients may specify either:
+* `{"commitment":"max"}` - the node will query the most recent bank having reached `MAX_LOCKOUT_HISTORY` confirmations
+* `{"commitment":"recent"}` - the node will query its most recent bank state
+
+The commitment parameter should be included as the last element in the `params` array:
+
+```bash
+curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0", "id":1, "method":"getBalance", "params":["83astBRguLMdt2h5U1Tpdq5tjFoJ6noeGwaY3mDLVcri",{"commitment":"max"}]}' 192.168.1.88:8899
+```
+
+#### Default:
+If commitment configuration is not provided, the node will default to `"commitment":"max"`
+
+Only methods that query bank state accept the commitment parameter. They are indicated in the API Reference below.
+
 ## JSON RPC API Reference
 
 ### confirmTransaction
@@ -91,6 +109,7 @@ Returns a transaction receipt
 #### Results:
 
 * `boolean` - Transaction status, true if Transaction is confirmed
+* `object` - (optional) [Commitment](jsonrpc-api.md#configuring-state-commitment)
 
 #### Example:
 
@@ -109,6 +128,7 @@ Returns all information associated with the account of provided Pubkey
 #### Parameters:
 
 * `string` - Pubkey of account to query, as base-58 encoded string
+* `object` - (optional) [Commitment](jsonrpc-api.md#configuring-state-commitment)
 
 #### Results:
 
@@ -136,6 +156,7 @@ Returns the balance of the account of provided Pubkey
 #### Parameters:
 
 * `string` - Pubkey of account to query, as base-58 encoded string
+* `object` - (optional) [Commitment](jsonrpc-api.md#configuring-state-commitment)
 
 #### Results:
 
@@ -212,7 +233,7 @@ Returns information about the current epoch
 
 #### Parameters:
 
-None
+* `object` - (optional) [Commitment](jsonrpc-api.md#configuring-state-commitment)
 
 #### Results:
 
@@ -288,7 +309,7 @@ Returns the leader schedule for the current epoch
 
 #### Parameters:
 
-None
+* `object` - (optional) [Commitment](jsonrpc-api.md#configuring-state-commitment)
 
 #### Results:
 
@@ -311,6 +332,7 @@ Returns minimum balance required to make account rent exempt.
 #### Parameters:
 
 * `integer` - account data length, as unsigned integer
+* `object` - (optional) [Commitment](jsonrpc-api.md#configuring-state-commitment)
 
 #### Results:
 
@@ -333,6 +355,7 @@ Returns the current number of blocks since signature has been confirmed.
 #### Parameters:
 
 * `string` - Signature of Transaction to confirm, as base-58 encoded string
+* `object` - (optional) [Commitment](jsonrpc-api.md#configuring-state-commitment)
 
 #### Results:
 
@@ -355,6 +378,7 @@ Returns all accounts owned by the provided program Pubkey
 #### Parameters:
 
 * `string` - Pubkey of program, as base-58 encoded string
+* `object` - (optional) [Commitment](jsonrpc-api.md#configuring-state-commitment)
 
 #### Results:
 
@@ -382,7 +406,7 @@ Returns a recent block hash from the ledger, and a fee schedule that can be used
 
 #### Parameters:
 
-None
+* `object` - (optional) [Commitment](jsonrpc-api.md#configuring-state-commitment)
 
 #### Results:
 
@@ -408,6 +432,7 @@ Returns the status of a given signature. This method is similar to [confirmTrans
 #### Parameters:
 
 * `string` - Signature of Transaction to confirm, as base-58 encoded string
+* `object` - (optional) [Commitment](jsonrpc-api.md#configuring-state-commitment)
 
 #### Results:
 
@@ -432,7 +457,7 @@ Returns the current slot the node is processing
 
 #### Parameters:
 
-None
+* `object` - (optional) [Commitment](jsonrpc-api.md#configuring-state-commitment)
 
 #### Results:
 
@@ -454,7 +479,7 @@ Returns the current slot leader
 
 #### Parameters:
 
-None
+* `object` - (optional) [Commitment](jsonrpc-api.md#configuring-state-commitment)
 
 #### Results:
 
@@ -476,7 +501,7 @@ Returns the current storage segment size in terms of slots
 
 #### Parameters:
 
-None
+* `object` - (optional) [Commitment](jsonrpc-api.md#configuring-state-commitment)
 
 #### Results:
 
@@ -542,7 +567,7 @@ Returns the current Transaction count from the ledger
 
 #### Parameters:
 
-None
+* `object` - (optional) [Commitment](jsonrpc-api.md#configuring-state-commitment)
 
 #### Results:
 
@@ -569,6 +594,7 @@ None
 #### Results:
 
 * `integer` - Total supply, as unsigned 64-bit integer
+* `object` - (optional) [Commitment](jsonrpc-api.md#configuring-state-commitment)
 
 #### Example:
 
@@ -609,7 +635,7 @@ Returns the account info and associated stake for all the voting accounts in the
 
 #### Parameters:
 
-None
+* `object` - (optional) [Commitment](jsonrpc-api.md#configuring-state-commitment)
 
 #### Results:
 
@@ -640,6 +666,7 @@ Requests an airdrop of lamports to a Pubkey
 
 * `string` - Pubkey of account to receive lamports, as base-58 encoded string
 * `integer` - lamports, as a signed 64-bit integer
+* `object` - (optional) [Commitment](jsonrpc-api.md#configuring-state-commitment) (used for retrieving blockhash and verifying airdrop success)
 
 #### Results:
 

--- a/ci/localnet-sanity.sh
+++ b/ci/localnet-sanity.sh
@@ -364,7 +364,7 @@ while [[ $iteration -le $iterations ]]; do
   echo "--- Wallet sanity ($iteration)"
   (
     set -x
-    timeout 60s scripts/wallet-sanity.sh --url http://127.0.0.1"$walletRpcPort"
+    timeout 90s scripts/wallet-sanity.sh --url http://127.0.0.1"$walletRpcPort"
   ) || flag_error
 
   iteration=$((iteration + 1))

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -11,6 +11,7 @@ use serde_json::Value;
 use solana_client::{rpc_client::RpcClient, rpc_request::RpcVoteAccountInfo};
 use solana_sdk::{
     clock,
+    commitment_config::CommitmentConfig,
     hash::Hash,
     signature::{Keypair, KeypairUtil},
     system_transaction,
@@ -221,7 +222,10 @@ pub fn process_ping(
             Ok(signature) => {
                 let transaction_sent = Instant::now();
                 loop {
-                    let signature_status = rpc_client.get_signature_status(&signature)?;
+                    let signature_status = rpc_client.get_signature_status_with_commitment(
+                        &signature,
+                        CommitmentConfig::recent(),
+                    )?;
                     let elapsed_time = Instant::now().duration_since(transaction_sent);
                     if let Some(transaction_status) = signature_status {
                         match transaction_status {

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -72,7 +72,7 @@ impl ClusterQuerySubCommands for App<'_, '_> {
                         .long("timeout")
                         .value_name("SECONDS")
                         .takes_value(true)
-                        .default_value("10")
+                        .default_value("15")
                         .help("Wait up to timeout seconds for transaction confirmation"),
                 ),
         )

--- a/cli/src/validator_info.rs
+++ b/cli/src/validator_info.rs
@@ -11,11 +11,14 @@ use serde_derive::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 use solana_client::rpc_client::RpcClient;
 use solana_config_api::{config_instruction, get_config_data, ConfigKeys, ConfigState};
-use solana_sdk::account::Account;
-use solana_sdk::message::Message;
-use solana_sdk::pubkey::Pubkey;
-use solana_sdk::signature::{Keypair, KeypairUtil};
-use solana_sdk::transaction::Transaction;
+use solana_sdk::{
+    account::Account,
+    commitment_config::CommitmentConfig,
+    message::Message,
+    pubkey::Pubkey,
+    signature::{Keypair, KeypairUtil},
+    transaction::Transaction,
+};
 use std::error;
 
 pub const MAX_SHORT_FIELD_LENGTH: usize = 70;
@@ -297,7 +300,9 @@ pub fn process_set_validator_info(
     };
 
     // Check existence of validator-info account
-    let balance = rpc_client.poll_get_balance(&info_pubkey).unwrap_or(0);
+    let balance = rpc_client
+        .poll_get_balance_with_commitment(&info_pubkey, CommitmentConfig::default())
+        .unwrap_or(0);
 
     let keys = vec![(id(), false), (config.keypair.pubkey(), true)];
     let (message, signers): (Message, Vec<&Keypair>) = if balance == 0 {

--- a/client/src/generic_rpc_client_request.rs
+++ b/client/src/generic_rpc_client_request.rs
@@ -1,5 +1,5 @@
-use crate::client_error::ClientError;
-use crate::rpc_request::RpcRequest;
+use crate::{client_error::ClientError, rpc_request::RpcRequest};
+use solana_sdk::commitment_config::CommitmentConfig;
 
 pub(crate) trait GenericRpcClientRequest {
     fn send(
@@ -7,5 +7,6 @@ pub(crate) trait GenericRpcClientRequest {
         request: &RpcRequest,
         params: Option<serde_json::Value>,
         retries: usize,
+        commitment_config: Option<CommitmentConfig>,
     ) -> Result<serde_json::Value, ClientError>;
 }

--- a/client/src/mock_rpc_client_request.rs
+++ b/client/src/mock_rpc_client_request.rs
@@ -1,9 +1,13 @@
-use crate::client_error::ClientError;
-use crate::generic_rpc_client_request::GenericRpcClientRequest;
-use crate::rpc_request::RpcRequest;
+use crate::{
+    client_error::ClientError, generic_rpc_client_request::GenericRpcClientRequest,
+    rpc_request::RpcRequest,
+};
 use serde_json::{Number, Value};
-use solana_sdk::fee_calculator::FeeCalculator;
-use solana_sdk::transaction::{self, TransactionError};
+use solana_sdk::{
+    commitment_config::CommitmentConfig,
+    fee_calculator::FeeCalculator,
+    transaction::{self, TransactionError},
+};
 
 pub const PUBKEY: &str = "7RoSF9fUmdphVCpabEoefH81WwrW7orsWonXWqTXkKV8";
 pub const SIGNATURE: &str =
@@ -25,6 +29,7 @@ impl GenericRpcClientRequest for MockRpcClientRequest {
         request: &RpcRequest,
         params: Option<serde_json::Value>,
         _retries: usize,
+        _commitment_config: Option<CommitmentConfig>,
     ) -> Result<serde_json::Value, ClientError> {
         if self.url == "fails" {
             return Ok(Value::Null);

--- a/client/src/perf_utils.rs
+++ b/client/src/perf_utils.rs
@@ -1,10 +1,13 @@
 use log::*;
-use solana_sdk::client::Client;
-use solana_sdk::timing::duration_as_s;
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, RwLock};
-use std::thread::sleep;
-use std::time::{Duration, Instant};
+use solana_sdk::{client::Client, timing::duration_as_s};
+use std::{
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc, RwLock,
+    },
+    thread::sleep,
+    time::{Duration, Instant},
+};
 
 #[derive(Default)]
 pub struct SampleStats {

--- a/client/src/perf_utils.rs
+++ b/client/src/perf_utils.rs
@@ -1,5 +1,5 @@
 use log::*;
-use solana_sdk::{client::Client, timing::duration_as_s};
+use solana_sdk::{client::Client, commitment_config::CommitmentConfig, timing::duration_as_s};
 use std::{
     sync::{
         atomic::{AtomicBool, Ordering},
@@ -32,7 +32,9 @@ pub fn sample_txs<T>(
     let mut total_txs;
     let mut now = Instant::now();
     let start_time = now;
-    let initial_txs = client.get_transaction_count().expect("transaction count");
+    let initial_txs = client
+        .get_transaction_count_with_commitment(CommitmentConfig::recent())
+        .expect("transaction count");
     let mut last_txs = initial_txs;
 
     loop {
@@ -40,7 +42,7 @@ pub fn sample_txs<T>(
         let elapsed = now.elapsed();
         now = Instant::now();
         let mut txs;
-        match client.get_transaction_count() {
+        match client.get_transaction_count_with_commitment(CommitmentConfig::recent()) {
             Err(e) => {
                 // ThinClient with multiple options should pick a better one now.
                 info!("Couldn't get transaction count {:?}", e);

--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -1,14 +1,17 @@
-use crate::client_error::ClientError;
-use crate::generic_rpc_client_request::GenericRpcClientRequest;
-use crate::mock_rpc_client_request::MockRpcClientRequest;
-use crate::rpc_client_request::RpcClientRequest;
-use crate::rpc_request::{RpcEpochInfo, RpcRequest, RpcVoteAccountStatus};
+use crate::{
+    client_error::ClientError,
+    generic_rpc_client_request::GenericRpcClientRequest,
+    mock_rpc_client_request::MockRpcClientRequest,
+    rpc_client_request::RpcClientRequest,
+    rpc_request::{RpcEpochInfo, RpcRequest, RpcVoteAccountStatus},
+};
 use bincode::serialize;
 use log::*;
 use serde_json::{json, Value};
 use solana_sdk::{
     account::Account,
     clock::{Slot, DEFAULT_TICKS_PER_SECOND, DEFAULT_TICKS_PER_SLOT},
+    commitment_config::CommitmentConfig,
     epoch_schedule::EpochSchedule,
     fee_calculator::FeeCalculator,
     hash::Hash,
@@ -54,10 +57,10 @@ impl RpcClient {
 
     pub fn send_transaction(&self, transaction: &Transaction) -> Result<String, ClientError> {
         let serialized = serialize(transaction).unwrap();
-        let params = json!([serialized]);
+        let params = json!(serialized);
         let signature = self
             .client
-            .send(&RpcRequest::SendTransaction, Some(params), 5)?;
+            .send(&RpcRequest::SendTransaction, Some(params), 5, None)?;
         if signature.as_str().is_none() {
             Err(io::Error::new(
                 io::ErrorKind::Other,
@@ -73,19 +76,37 @@ impl RpcClient {
         &self,
         signature: &str,
     ) -> Result<Option<transaction::Result<()>>, ClientError> {
-        let params = json!([signature.to_string()]);
-        let signature_status =
-            self.client
-                .send(&RpcRequest::GetSignatureStatus, Some(params), 5)?;
+        self.get_signature_status_with_commitment(signature, CommitmentConfig::default())
+    }
+
+    pub fn get_signature_status_with_commitment(
+        &self,
+        signature: &str,
+        commitment_config: CommitmentConfig,
+    ) -> Result<Option<transaction::Result<()>>, ClientError> {
+        let params = json!(signature.to_string());
+        let signature_status = self.client.send(
+            &RpcRequest::GetSignatureStatus,
+            Some(params),
+            5,
+            commitment_config.ok(),
+        )?;
         let result: Option<transaction::Result<()>> =
             serde_json::from_value(signature_status).unwrap();
         Ok(result)
     }
 
     pub fn get_slot(&self) -> io::Result<Slot> {
+        self.get_slot_with_commitment(CommitmentConfig::default())
+    }
+
+    pub fn get_slot_with_commitment(
+        &self,
+        commitment_config: CommitmentConfig,
+    ) -> io::Result<Slot> {
         let response = self
             .client
-            .send(&RpcRequest::GetSlot, None, 0)
+            .send(&RpcRequest::GetSlot, None, 0, commitment_config.ok())
             .map_err(|err| {
                 io::Error::new(
                     io::ErrorKind::Other,
@@ -104,7 +125,7 @@ impl RpcClient {
     pub fn get_vote_accounts(&self) -> io::Result<RpcVoteAccountStatus> {
         let response = self
             .client
-            .send(&RpcRequest::GetVoteAccounts, None, 0)
+            .send(&RpcRequest::GetVoteAccounts, None, 0, None)
             .map_err(|err| {
                 io::Error::new(
                     io::ErrorKind::Other,
@@ -123,7 +144,7 @@ impl RpcClient {
     pub fn get_epoch_info(&self) -> io::Result<RpcEpochInfo> {
         let response = self
             .client
-            .send(&RpcRequest::GetEpochInfo, None, 0)
+            .send(&RpcRequest::GetEpochInfo, None, 0, None)
             .map_err(|err| {
                 io::Error::new(
                     io::ErrorKind::Other,
@@ -142,7 +163,7 @@ impl RpcClient {
     pub fn get_epoch_schedule(&self) -> io::Result<EpochSchedule> {
         let response = self
             .client
-            .send(&RpcRequest::GetEpochSchedule, None, 0)
+            .send(&RpcRequest::GetEpochSchedule, None, 0, None)
             .map_err(|err| {
                 io::Error::new(
                     io::ErrorKind::Other,
@@ -161,7 +182,7 @@ impl RpcClient {
     pub fn get_inflation(&self) -> io::Result<Inflation> {
         let response = self
             .client
-            .send(&RpcRequest::GetInflation, None, 0)
+            .send(&RpcRequest::GetInflation, None, 0, None)
             .map_err(|err| {
                 io::Error::new(
                     io::ErrorKind::Other,
@@ -180,7 +201,7 @@ impl RpcClient {
     pub fn get_version(&self) -> io::Result<String> {
         let response = self
             .client
-            .send(&RpcRequest::GetVersion, None, 0)
+            .send(&RpcRequest::GetVersion, None, 0, None)
             .map_err(|err| {
                 io::Error::new(
                     io::ErrorKind::Other,
@@ -329,19 +350,30 @@ impl RpcClient {
         pubkey: &Pubkey,
         retries: usize,
     ) -> Result<Option<u64>, Box<dyn error::Error>> {
-        let params = json!([format!("{}", pubkey)]);
+        let params = json!(format!("{}", pubkey));
         let res = self
             .client
-            .send(&RpcRequest::GetBalance, Some(params), retries)?
+            .send(&RpcRequest::GetBalance, Some(params), retries, None)?
             .as_u64();
         Ok(res)
     }
 
     pub fn get_account(&self, pubkey: &Pubkey) -> io::Result<Account> {
-        let params = json!([format!("{}", pubkey)]);
-        let response = self
-            .client
-            .send(&RpcRequest::GetAccountInfo, Some(params), 0);
+        self.get_account_with_commitment(pubkey, CommitmentConfig::default())
+    }
+
+    pub fn get_account_with_commitment(
+        &self,
+        pubkey: &Pubkey,
+        commitment_config: CommitmentConfig,
+    ) -> io::Result<Account> {
+        let params = json!(format!("{}", pubkey));
+        let response = self.client.send(
+            &RpcRequest::GetAccountInfo,
+            Some(params),
+            0,
+            commitment_config.ok(),
+        );
 
         response
             .and_then(|account_json| {
@@ -362,13 +394,14 @@ impl RpcClient {
     }
 
     pub fn get_minimum_balance_for_rent_exemption(&self, data_len: usize) -> io::Result<u64> {
-        let params = json!([data_len]);
+        let params = json!(data_len);
         let minimum_balance_json = self
             .client
             .send(
                 &RpcRequest::GetMinimumBalanceForRentExemption,
                 Some(params),
                 0,
+                None,
             )
             .map_err(|err| {
                 io::Error::new(
@@ -394,18 +427,25 @@ impl RpcClient {
         Ok(minimum_balance)
     }
 
-    /// Request the balance of the user holding `pubkey`. This method blocks
-    /// until the server sends a response. If the response packet is dropped
-    /// by the network, this method will hang indefinitely.
+    /// Request the balance of the account `pubkey`.
     pub fn get_balance(&self, pubkey: &Pubkey) -> io::Result<u64> {
-        self.get_account(pubkey).map(|account| account.lamports)
+        self.get_balance_with_commitment(pubkey, CommitmentConfig::default())
+    }
+
+    pub fn get_balance_with_commitment(
+        &self,
+        pubkey: &Pubkey,
+        commitment_config: CommitmentConfig,
+    ) -> io::Result<u64> {
+        self.get_account_with_commitment(pubkey, commitment_config)
+            .map(|account| account.lamports)
     }
 
     pub fn get_program_accounts(&self, pubkey: &Pubkey) -> io::Result<Vec<(Pubkey, Account)>> {
-        let params = json!([format!("{}", pubkey)]);
+        let params = json!(format!("{}", pubkey));
         let response = self
             .client
-            .send(&RpcRequest::GetProgramAccounts, Some(params), 0)
+            .send(&RpcRequest::GetProgramAccounts, Some(params), 0, None)
             .map_err(|err| {
                 io::Error::new(
                     io::ErrorKind::Other,
@@ -434,12 +474,23 @@ impl RpcClient {
         Ok(pubkey_accounts)
     }
 
-    /// Request the transaction count.  If the response packet is dropped by the network,
-    /// this method will try again 5 times.
+    /// Request the transaction count.
     pub fn get_transaction_count(&self) -> io::Result<u64> {
+        self.get_transaction_count_with_commitment(CommitmentConfig::default())
+    }
+
+    pub fn get_transaction_count_with_commitment(
+        &self,
+        commitment_config: CommitmentConfig,
+    ) -> io::Result<u64> {
         let response = self
             .client
-            .send(&RpcRequest::GetTransactionCount, None, 0)
+            .send(
+                &RpcRequest::GetTransactionCount,
+                None,
+                0,
+                commitment_config.ok(),
+            )
             .map_err(|err| {
                 io::Error::new(
                     io::ErrorKind::Other,
@@ -456,9 +507,21 @@ impl RpcClient {
     }
 
     pub fn get_recent_blockhash(&self) -> io::Result<(Hash, FeeCalculator)> {
+        self.get_recent_blockhash_with_commitment(CommitmentConfig::default())
+    }
+
+    pub fn get_recent_blockhash_with_commitment(
+        &self,
+        commitment_config: CommitmentConfig,
+    ) -> io::Result<(Hash, FeeCalculator)> {
         let response = self
             .client
-            .send(&RpcRequest::GetRecentBlockhash, None, 0)
+            .send(
+                &RpcRequest::GetRecentBlockhash,
+                None,
+                0,
+                commitment_config.ok(),
+            )
             .map_err(|err| {
                 io::Error::new(
                     io::ErrorKind::Other,
@@ -514,7 +577,7 @@ impl RpcClient {
     pub fn get_genesis_blockhash(&self) -> io::Result<Hash> {
         let response = self
             .client
-            .send(&RpcRequest::GetGenesisBlockhash, None, 0)
+            .send(&RpcRequest::GetGenesisBlockhash, None, 0, None)
             .map_err(|err| {
                 io::Error::new(
                     io::ErrorKind::Other,
@@ -538,15 +601,16 @@ impl RpcClient {
         Ok(blockhash)
     }
 
-    pub fn poll_balance_with_timeout(
+    pub fn poll_balance_with_timeout_and_commitment(
         &self,
         pubkey: &Pubkey,
         polling_frequency: &Duration,
         timeout: &Duration,
+        commitment_config: CommitmentConfig,
     ) -> io::Result<u64> {
         let now = Instant::now();
         loop {
-            match self.get_balance(&pubkey) {
+            match self.get_balance_with_commitment(&pubkey, commitment_config.clone()) {
                 Ok(bal) => {
                     return Ok(bal);
                 }
@@ -560,14 +624,29 @@ impl RpcClient {
         }
     }
 
-    pub fn poll_get_balance(&self, pubkey: &Pubkey) -> io::Result<u64> {
-        self.poll_balance_with_timeout(pubkey, &Duration::from_millis(100), &Duration::from_secs(1))
+    pub fn poll_get_balance_with_commitment(
+        &self,
+        pubkey: &Pubkey,
+        commitment_config: CommitmentConfig,
+    ) -> io::Result<u64> {
+        self.poll_balance_with_timeout_and_commitment(
+            pubkey,
+            &Duration::from_millis(100),
+            &Duration::from_secs(1),
+            commitment_config,
+        )
     }
 
-    pub fn wait_for_balance(&self, pubkey: &Pubkey, expected_balance: Option<u64>) -> Option<u64> {
+    pub fn wait_for_balance_with_commitment(
+        &self,
+        pubkey: &Pubkey,
+        expected_balance: Option<u64>,
+        commitment_config: CommitmentConfig,
+    ) -> Option<u64> {
         const LAST: usize = 30;
         for run in 0..LAST {
-            let balance_result = self.poll_get_balance(pubkey);
+            let balance_result =
+                self.poll_get_balance_with_commitment(pubkey, commitment_config.clone());
             if expected_balance.is_none() {
                 return balance_result.ok();
             }
@@ -603,12 +682,15 @@ impl RpcClient {
     /// Check a signature in the bank.
     pub fn check_signature(&self, signature: &Signature) -> bool {
         trace!("check_signature: {:?}", signature);
-        let params = json!([format!("{}", signature)]);
+        let params = json!(format!("{}", signature));
 
         for _ in 0..30 {
-            let response =
-                self.client
-                    .send(&RpcRequest::ConfirmTransaction, Some(params.clone()), 0);
+            let response = self.client.send(
+                &RpcRequest::ConfirmTransaction,
+                Some(params.clone()),
+                0,
+                None,
+            );
 
             match response {
                 Ok(confirmation) => {
@@ -662,7 +744,7 @@ impl RpcClient {
                     debug!("check_confirmations request failed: {:?}", err);
                 }
             };
-            if now.elapsed().as_secs() > 15 {
+            if now.elapsed().as_secs() > 20 {
                 info!(
                     "signature {} confirmed {} out of {} failed after {} ms",
                     signature,
@@ -686,13 +768,14 @@ impl RpcClient {
         &self,
         sig: &Signature,
     ) -> io::Result<usize> {
-        let params = json!([format!("{}", sig)]);
+        let params = json!(format!("{}", sig));
         let response = self
             .client
             .send(
                 &RpcRequest::GetNumBlocksSinceSignatureConfirmation,
                 Some(params.clone()),
                 1,
+                CommitmentConfig::recent().ok(),
             )
             .map_err(|err| {
                 io::Error::new(
@@ -717,7 +800,7 @@ impl RpcClient {
     pub fn validator_exit(&self) -> io::Result<bool> {
         let response = self
             .client
-            .send(&RpcRequest::ValidatorExit, None, 0)
+            .send(&RpcRequest::ValidatorExit, None, 0, None)
             .map_err(|err| {
                 io::Error::new(
                     io::ErrorKind::Other,
@@ -739,7 +822,7 @@ impl RpcClient {
         params: Option<Value>,
         retries: usize,
     ) -> Result<Value, ClientError> {
-        self.client.send(request, params, retries)
+        self.client.send(request, params, retries, None)
     }
 }
 
@@ -759,11 +842,12 @@ mod tests {
     use jsonrpc_http_server::{AccessControlAllowOrigin, DomainsValidation, ServerBuilder};
     use serde_json::Number;
     use solana_logger;
-    use solana_sdk::signature::{Keypair, KeypairUtil};
-    use solana_sdk::system_transaction;
-    use solana_sdk::transaction::TransactionError;
-    use std::sync::mpsc::channel;
-    use std::thread;
+    use solana_sdk::{
+        signature::{Keypair, KeypairUtil},
+        system_transaction,
+        transaction::TransactionError,
+    };
+    use std::{sync::mpsc::channel, thread};
 
     #[test]
     fn test_make_rpc_request() {

--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -203,7 +203,7 @@ impl RpcClient {
     ) -> Result<String, ClientError> {
         let mut send_retries = 20;
         loop {
-            let mut status_retries = 4;
+            let mut status_retries = 15;
             let signature_str = self.send_transaction(transaction)?;
             let status = loop {
                 let status = self.get_signature_status(&signature_str)?;
@@ -216,10 +216,8 @@ impl RpcClient {
                     break status;
                 }
                 if cfg!(not(test)) {
-                    // Retry ~twice during a slot
-                    sleep(Duration::from_millis(
-                        500 * DEFAULT_TICKS_PER_SLOT / DEFAULT_TICKS_PER_SECOND,
-                    ));
+                    // Retry twice a second
+                    sleep(Duration::from_millis(500));
                 }
             };
             send_retries = if let Some(result) = status.clone() {
@@ -252,7 +250,7 @@ impl RpcClient {
     ) -> Result<(), Box<dyn error::Error>> {
         let mut send_retries = 5;
         loop {
-            let mut status_retries = 4;
+            let mut status_retries = 15;
 
             // Send all transactions
             let mut transactions_signatures = vec![];
@@ -273,10 +271,8 @@ impl RpcClient {
                 status_retries -= 1;
 
                 if cfg!(not(test)) {
-                    // Retry ~twice during a slot
-                    sleep(Duration::from_millis(
-                        500 * DEFAULT_TICKS_PER_SLOT / DEFAULT_TICKS_PER_SECOND,
-                    ));
+                    // Retry twice a second
+                    sleep(Duration::from_millis(500));
                 }
 
                 transactions_signatures = transactions_signatures

--- a/client/src/rpc_client_request.rs
+++ b/client/src/rpc_client_request.rs
@@ -1,11 +1,15 @@
-use crate::client_error::ClientError;
-use crate::generic_rpc_client_request::GenericRpcClientRequest;
-use crate::rpc_request::{RpcError, RpcRequest};
+use crate::{
+    client_error::ClientError,
+    generic_rpc_client_request::GenericRpcClientRequest,
+    rpc_request::{RpcError, RpcRequest},
+};
 use log::*;
 use reqwest::{self, header::CONTENT_TYPE};
-use solana_sdk::clock::{DEFAULT_TICKS_PER_SECOND, DEFAULT_TICKS_PER_SLOT};
-use std::thread::sleep;
-use std::time::Duration;
+use solana_sdk::{
+    clock::{DEFAULT_TICKS_PER_SECOND, DEFAULT_TICKS_PER_SLOT},
+    commitment_config::CommitmentConfig,
+};
+use std::{thread::sleep, time::Duration};
 
 pub struct RpcClientRequest {
     client: reqwest::Client,
@@ -36,11 +40,12 @@ impl GenericRpcClientRequest for RpcClientRequest {
         request: &RpcRequest,
         params: Option<serde_json::Value>,
         mut retries: usize,
+        commitment_config: Option<CommitmentConfig>,
     ) -> Result<serde_json::Value, ClientError> {
         // Concurrent requests are not supported so reuse the same request id for all requests
         let request_id = 1;
 
-        let request_json = request.build_request_json(request_id, params);
+        let request_json = request.build_request_json(request_id, params, commitment_config);
 
         loop {
             match self

--- a/client/src/thin_client.rs
+++ b/client/src/thin_client.rs
@@ -6,25 +6,32 @@
 use crate::rpc_client::RpcClient;
 use bincode::{serialize_into, serialized_size};
 use log::*;
-use solana_sdk::account::Account;
-use solana_sdk::client::{AsyncClient, Client, SyncClient};
-use solana_sdk::clock::MAX_PROCESSING_AGE;
-use solana_sdk::fee_calculator::FeeCalculator;
-use solana_sdk::hash::Hash;
-use solana_sdk::instruction::Instruction;
-use solana_sdk::message::Message;
-use solana_sdk::packet::PACKET_DATA_SIZE;
-use solana_sdk::pubkey::Pubkey;
-use solana_sdk::signature::{Keypair, KeypairUtil, Signature};
-use solana_sdk::system_instruction;
-use solana_sdk::timing::duration_as_ms;
-use solana_sdk::transaction::{self, Transaction};
-use solana_sdk::transport::Result as TransportResult;
-use std::io;
-use std::net::{SocketAddr, UdpSocket};
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
-use std::sync::RwLock;
-use std::time::{Duration, Instant};
+use solana_sdk::{
+    account::Account,
+    client::{AsyncClient, Client, SyncClient},
+    clock::MAX_PROCESSING_AGE,
+    commitment_config::CommitmentConfig,
+    fee_calculator::FeeCalculator,
+    hash::Hash,
+    instruction::Instruction,
+    message::Message,
+    packet::PACKET_DATA_SIZE,
+    pubkey::Pubkey,
+    signature::{Keypair, KeypairUtil, Signature},
+    system_instruction,
+    timing::duration_as_ms,
+    transaction::{self, Transaction},
+    transport::Result as TransportResult,
+};
+use std::{
+    io,
+    net::{SocketAddr, UdpSocket},
+    sync::{
+        atomic::{AtomicBool, AtomicUsize, Ordering},
+        RwLock,
+    },
+    time::{Duration, Instant},
+};
 
 struct ClientOptimizer {
     cur_index: AtomicUsize,
@@ -250,16 +257,47 @@ impl ThinClient {
         polling_frequency: &Duration,
         timeout: &Duration,
     ) -> io::Result<u64> {
-        self.rpc_client()
-            .poll_balance_with_timeout(pubkey, polling_frequency, timeout)
+        self.rpc_client().poll_balance_with_timeout_and_commitment(
+            pubkey,
+            polling_frequency,
+            timeout,
+            CommitmentConfig::default(),
+        )
     }
 
     pub fn poll_get_balance(&self, pubkey: &Pubkey) -> io::Result<u64> {
-        self.rpc_client().poll_get_balance(pubkey)
+        self.rpc_client()
+            .poll_get_balance_with_commitment(pubkey, CommitmentConfig::default())
+    }
+
+    pub fn poll_get_balance_with_commitment(
+        &self,
+        pubkey: &Pubkey,
+        commitment_config: CommitmentConfig,
+    ) -> io::Result<u64> {
+        self.rpc_client()
+            .poll_get_balance_with_commitment(pubkey, commitment_config)
     }
 
     pub fn wait_for_balance(&self, pubkey: &Pubkey, expected_balance: Option<u64>) -> Option<u64> {
-        self.rpc_client().wait_for_balance(pubkey, expected_balance)
+        self.rpc_client().wait_for_balance_with_commitment(
+            pubkey,
+            expected_balance,
+            CommitmentConfig::default(),
+        )
+    }
+
+    pub fn wait_for_balance_with_commitment(
+        &self,
+        pubkey: &Pubkey,
+        expected_balance: Option<u64>,
+        commitment_config: CommitmentConfig,
+    ) -> Option<u64> {
+        self.rpc_client().wait_for_balance_with_commitment(
+            pubkey,
+            expected_balance,
+            commitment_config,
+        )
     }
 
     /// Check a signature in the bank. This method blocks
@@ -323,15 +361,45 @@ impl SyncClient for ThinClient {
         Ok(self.rpc_client().get_account(pubkey).ok())
     }
 
+    fn get_account_with_commitment(
+        &self,
+        pubkey: &Pubkey,
+        commitment_config: CommitmentConfig,
+    ) -> TransportResult<Option<Account>> {
+        Ok(self
+            .rpc_client()
+            .get_account_with_commitment(pubkey, commitment_config)
+            .ok())
+    }
+
     fn get_balance(&self, pubkey: &Pubkey) -> TransportResult<u64> {
         let balance = self.rpc_client().get_balance(pubkey)?;
         Ok(balance)
     }
 
+    fn get_balance_with_commitment(
+        &self,
+        pubkey: &Pubkey,
+        commitment_config: CommitmentConfig,
+    ) -> TransportResult<u64> {
+        let balance = self
+            .rpc_client()
+            .get_balance_with_commitment(pubkey, commitment_config)?;
+        Ok(balance)
+    }
+
     fn get_recent_blockhash(&self) -> TransportResult<(Hash, FeeCalculator)> {
+        self.get_recent_blockhash_with_commitment(CommitmentConfig::default())
+    }
+
+    fn get_recent_blockhash_with_commitment(
+        &self,
+        commitment_config: CommitmentConfig,
+    ) -> TransportResult<(Hash, FeeCalculator)> {
         let index = self.optimizer.experiment();
         let now = Instant::now();
-        let recent_blockhash = self.rpc_clients[index].get_recent_blockhash();
+        let recent_blockhash =
+            self.rpc_clients[index].get_recent_blockhash_with_commitment(commitment_config);
         match recent_blockhash {
             Ok(recent_blockhash) => {
                 self.optimizer.report(index, duration_as_ms(&now.elapsed()));
@@ -360,13 +428,40 @@ impl SyncClient for ThinClient {
         Ok(status)
     }
 
+    fn get_signature_status_with_commitment(
+        &self,
+        signature: &Signature,
+        commitment_config: CommitmentConfig,
+    ) -> TransportResult<Option<transaction::Result<()>>> {
+        let status = self
+            .rpc_client()
+            .get_signature_status_with_commitment(&signature.to_string(), commitment_config)
+            .map_err(|err| {
+                io::Error::new(
+                    io::ErrorKind::Other,
+                    format!("send_transaction failed with error {:?}", err),
+                )
+            })?;
+        Ok(status)
+    }
+
     fn get_slot(&self) -> TransportResult<u64> {
-        let slot = self.rpc_client().get_slot().map_err(|err| {
-            io::Error::new(
-                io::ErrorKind::Other,
-                format!("send_transaction failed with error {:?}", err),
-            )
-        })?;
+        self.get_slot_with_commitment(CommitmentConfig::default())
+    }
+
+    fn get_slot_with_commitment(
+        &self,
+        commitment_config: CommitmentConfig,
+    ) -> TransportResult<u64> {
+        let slot = self
+            .rpc_client()
+            .get_slot_with_commitment(commitment_config)
+            .map_err(|err| {
+                io::Error::new(
+                    io::ErrorKind::Other,
+                    format!("send_transaction failed with error {:?}", err),
+                )
+            })?;
         Ok(slot)
     }
 
@@ -374,6 +469,27 @@ impl SyncClient for ThinClient {
         let index = self.optimizer.experiment();
         let now = Instant::now();
         match self.rpc_client().get_transaction_count() {
+            Ok(transaction_count) => {
+                self.optimizer.report(index, duration_as_ms(&now.elapsed()));
+                Ok(transaction_count)
+            }
+            Err(e) => {
+                self.optimizer.report(index, std::u64::MAX);
+                Err(e.into())
+            }
+        }
+    }
+
+    fn get_transaction_count_with_commitment(
+        &self,
+        commitment_config: CommitmentConfig,
+    ) -> TransportResult<u64> {
+        let index = self.optimizer.experiment();
+        let now = Instant::now();
+        match self
+            .rpc_client()
+            .get_transaction_count_with_commitment(commitment_config)
+        {
             Ok(transaction_count) => {
                 self.optimizer.report(index, duration_as_ms(&now.elapsed()));
                 Ok(transaction_count)

--- a/client/src/thin_client.rs
+++ b/client/src/thin_client.rs
@@ -251,6 +251,21 @@ impl ThinClient {
         ))
     }
 
+    pub fn poll_balance_with_timeout_and_commitment(
+        &self,
+        pubkey: &Pubkey,
+        polling_frequency: &Duration,
+        timeout: &Duration,
+        commitment_config: CommitmentConfig,
+    ) -> io::Result<u64> {
+        self.rpc_client().poll_balance_with_timeout_and_commitment(
+            pubkey,
+            polling_frequency,
+            timeout,
+            commitment_config,
+        )
+    }
+
     pub fn poll_balance_with_timeout(
         &self,
         pubkey: &Pubkey,
@@ -298,6 +313,16 @@ impl ThinClient {
             expected_balance,
             commitment_config,
         )
+    }
+
+    pub fn poll_for_signature_with_commitment(
+        &self,
+        signature: &Signature,
+        commitment_config: CommitmentConfig,
+    ) -> TransportResult<()> {
+        Ok(self
+            .rpc_client()
+            .poll_for_signature_with_commitment(signature, commitment_config)?)
     }
 
     /// Check a signature in the bank. This method blocks

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -116,7 +116,7 @@ impl JsonRpcRequestProcessor {
         (blockhash.to_string(), fee_calculator)
     }
 
-    fn get_block_commitment(&self, block: u64) -> (Option<BlockCommitment>, u64) {
+    fn get_block_commitment(&self, block: Slot) -> (Option<BlockCommitment>, u64) {
         let r_block_commitment = self.block_commitment_cache.read().unwrap();
         (
             r_block_commitment.get_block_commitment(block).cloned(),
@@ -281,129 +281,146 @@ pub trait RpcSol {
     type Metadata;
 
     #[rpc(meta, name = "confirmTransaction")]
-    fn confirm_transaction(&self, _: Self::Metadata, _: String) -> Result<bool>;
+    fn confirm_transaction(&self, meta: Self::Metadata, signature_str: String) -> Result<bool>;
 
     #[rpc(meta, name = "getAccountInfo")]
-    fn get_account_info(&self, _: Self::Metadata, _: String) -> Result<Account>;
+    fn get_account_info(&self, meta: Self::Metadata, pubkey_str: String) -> Result<Account>;
 
     #[rpc(meta, name = "getProgramAccounts")]
-    fn get_program_accounts(&self, _: Self::Metadata, _: String) -> Result<Vec<(String, Account)>>;
+    fn get_program_accounts(
+        &self,
+        meta: Self::Metadata,
+        program_id_str: String,
+    ) -> Result<Vec<(String, Account)>>;
 
     #[rpc(meta, name = "getMinimumBalanceForRentExemption")]
-    fn get_minimum_balance_for_rent_exemption(&self, _: Self::Metadata, _: usize) -> Result<u64>;
+    fn get_minimum_balance_for_rent_exemption(
+        &self,
+        meta: Self::Metadata,
+        data_len: usize,
+    ) -> Result<u64>;
 
     #[rpc(meta, name = "getInflation")]
-    fn get_inflation(&self, _: Self::Metadata) -> Result<Inflation>;
+    fn get_inflation(&self, meta: Self::Metadata) -> Result<Inflation>;
 
     #[rpc(meta, name = "getEpochSchedule")]
-    fn get_epoch_schedule(&self, _: Self::Metadata) -> Result<EpochSchedule>;
+    fn get_epoch_schedule(&self, meta: Self::Metadata) -> Result<EpochSchedule>;
 
     #[rpc(meta, name = "getBalance")]
-    fn get_balance(&self, _: Self::Metadata, _: String) -> Result<u64>;
+    fn get_balance(&self, meta: Self::Metadata, pubkey_str: String) -> Result<u64>;
 
     #[rpc(meta, name = "getClusterNodes")]
-    fn get_cluster_nodes(&self, _: Self::Metadata) -> Result<Vec<RpcContactInfo>>;
+    fn get_cluster_nodes(&self, meta: Self::Metadata) -> Result<Vec<RpcContactInfo>>;
 
     #[rpc(meta, name = "getEpochInfo")]
-    fn get_epoch_info(&self, _: Self::Metadata) -> Result<RpcEpochInfo>;
+    fn get_epoch_info(&self, meta: Self::Metadata) -> Result<RpcEpochInfo>;
 
     #[rpc(meta, name = "getBlockCommitment")]
     fn get_block_commitment(
         &self,
-        _: Self::Metadata,
-        _: u64,
+        meta: Self::Metadata,
+        block: u64,
     ) -> Result<(Option<BlockCommitment>, u64)>;
 
     #[rpc(meta, name = "getGenesisBlockhash")]
-    fn get_genesis_blockhash(&self, _: Self::Metadata) -> Result<String>;
+    fn get_genesis_blockhash(&self, meta: Self::Metadata) -> Result<String>;
 
     #[rpc(meta, name = "getLeaderSchedule")]
-    fn get_leader_schedule(&self, _: Self::Metadata) -> Result<Option<Vec<String>>>;
+    fn get_leader_schedule(&self, meta: Self::Metadata) -> Result<Option<Vec<String>>>;
 
     #[rpc(meta, name = "getRecentBlockhash")]
-    fn get_recent_blockhash(&self, _: Self::Metadata) -> Result<(String, FeeCalculator)>;
+    fn get_recent_blockhash(&self, meta: Self::Metadata) -> Result<(String, FeeCalculator)>;
 
     #[rpc(meta, name = "getSignatureStatus")]
     fn get_signature_status(
         &self,
-        _: Self::Metadata,
-        _: String,
+        meta: Self::Metadata,
+        signature_str: String,
     ) -> Result<Option<transaction::Result<()>>>;
 
     #[rpc(meta, name = "getSlot")]
-    fn get_slot(&self, _: Self::Metadata) -> Result<u64>;
+    fn get_slot(&self, meta: Self::Metadata) -> Result<u64>;
 
     #[rpc(meta, name = "getTransactionCount")]
-    fn get_transaction_count(&self, _: Self::Metadata) -> Result<u64>;
+    fn get_transaction_count(&self, meta: Self::Metadata) -> Result<u64>;
 
     #[rpc(meta, name = "getTotalSupply")]
-    fn get_total_supply(&self, _: Self::Metadata) -> Result<u64>;
+    fn get_total_supply(&self, meta: Self::Metadata) -> Result<u64>;
 
     #[rpc(meta, name = "requestAirdrop")]
-    fn request_airdrop(&self, _: Self::Metadata, _: String, _: u64) -> Result<String>;
+    fn request_airdrop(
+        &self,
+        meta: Self::Metadata,
+        pubkey_str: String,
+        lamports: u64,
+    ) -> Result<String>;
 
     #[rpc(meta, name = "sendTransaction")]
-    fn send_transaction(&self, _: Self::Metadata, _: Vec<u8>) -> Result<String>;
+    fn send_transaction(&self, meta: Self::Metadata, data: Vec<u8>) -> Result<String>;
 
     #[rpc(meta, name = "getSlotLeader")]
-    fn get_slot_leader(&self, _: Self::Metadata) -> Result<String>;
+    fn get_slot_leader(&self, meta: Self::Metadata) -> Result<String>;
 
     #[rpc(meta, name = "getVoteAccounts")]
-    fn get_vote_accounts(&self, _: Self::Metadata) -> Result<RpcVoteAccountStatus>;
+    fn get_vote_accounts(&self, meta: Self::Metadata) -> Result<RpcVoteAccountStatus>;
 
     #[rpc(meta, name = "getStorageTurnRate")]
-    fn get_storage_turn_rate(&self, _: Self::Metadata) -> Result<u64>;
+    fn get_storage_turn_rate(&self, meta: Self::Metadata) -> Result<u64>;
 
     #[rpc(meta, name = "getStorageTurn")]
-    fn get_storage_turn(&self, _: Self::Metadata) -> Result<(String, u64)>;
+    fn get_storage_turn(&self, meta: Self::Metadata) -> Result<(String, u64)>;
 
     #[rpc(meta, name = "getSlotsPerSegment")]
-    fn get_slots_per_segment(&self, _: Self::Metadata) -> Result<u64>;
+    fn get_slots_per_segment(&self, meta: Self::Metadata) -> Result<u64>;
 
     #[rpc(meta, name = "getStoragePubkeysForSlot")]
-    fn get_storage_pubkeys_for_slot(&self, _: Self::Metadata, _: u64) -> Result<Vec<Pubkey>>;
+    fn get_storage_pubkeys_for_slot(&self, meta: Self::Metadata, slot: u64) -> Result<Vec<Pubkey>>;
 
     #[rpc(meta, name = "validatorExit")]
-    fn validator_exit(&self, _: Self::Metadata) -> Result<bool>;
+    fn validator_exit(&self, meta: Self::Metadata) -> Result<bool>;
 
     #[rpc(meta, name = "getNumBlocksSinceSignatureConfirmation")]
     fn get_num_blocks_since_signature_confirmation(
         &self,
-        _: Self::Metadata,
-        _: String,
+        meta: Self::Metadata,
+        signature_str: String,
     ) -> Result<Option<usize>>;
 
     #[rpc(meta, name = "getSignatureConfirmation")]
     fn get_signature_confirmation(
         &self,
-        _: Self::Metadata,
-        _: String,
+        meta: Self::Metadata,
+        signature_str: String,
     ) -> Result<Option<(usize, transaction::Result<()>)>>;
 
     #[rpc(meta, name = "getVersion")]
-    fn get_version(&self, _: Self::Metadata) -> Result<RpcVersionInfo>;
+    fn get_version(&self, meta: Self::Metadata) -> Result<RpcVersionInfo>;
 
     #[rpc(meta, name = "setLogFilter")]
-    fn set_log_filter(&self, _: Self::Metadata, _: String) -> Result<()>;
+    fn set_log_filter(&self, _meta: Self::Metadata, filter: String) -> Result<()>;
 }
 
 pub struct RpcSolImpl;
 impl RpcSol for RpcSolImpl {
     type Metadata = Meta;
 
-    fn confirm_transaction(&self, meta: Self::Metadata, id: String) -> Result<bool> {
-        debug!("confirm_transaction rpc request received: {:?}", id);
-        self.get_signature_status(meta, id).map(|status_option| {
-            if status_option.is_none() {
-                return false;
-            }
-            status_option.unwrap().is_ok()
-        })
+    fn confirm_transaction(&self, meta: Self::Metadata, signature_str: String) -> Result<bool> {
+        debug!(
+            "confirm_transaction rpc request received: {:?}",
+            signature_str
+        );
+        self.get_signature_status(meta, signature_str)
+            .map(|status_option| {
+                if status_option.is_none() {
+                    return false;
+                }
+                status_option.unwrap().is_ok()
+            })
     }
 
-    fn get_account_info(&self, meta: Self::Metadata, id: String) -> Result<Account> {
-        debug!("get_account_info rpc request received: {:?}", id);
-        let pubkey = verify_pubkey(id)?;
+    fn get_account_info(&self, meta: Self::Metadata, pubkey_str: String) -> Result<Account> {
+        debug!("get_account_info rpc request received: {:?}", pubkey_str);
+        let pubkey = verify_pubkey(pubkey_str)?;
         meta.request_processor
             .read()
             .unwrap()
@@ -428,10 +445,13 @@ impl RpcSol for RpcSolImpl {
     fn get_program_accounts(
         &self,
         meta: Self::Metadata,
-        id: String,
+        program_id_str: String,
     ) -> Result<Vec<(String, Account)>> {
-        debug!("get_program_accounts rpc request received: {:?}", id);
-        let program_id = verify_pubkey(id)?;
+        debug!(
+            "get_program_accounts rpc request received: {:?}",
+            program_id_str
+        );
+        let program_id = verify_pubkey(program_id_str)?;
         meta.request_processor
             .read()
             .unwrap()
@@ -458,9 +478,9 @@ impl RpcSol for RpcSolImpl {
             .unwrap())
     }
 
-    fn get_balance(&self, meta: Self::Metadata, id: String) -> Result<u64> {
-        debug!("get_balance rpc request received: {:?}", id);
-        let pubkey = verify_pubkey(id)?;
+    fn get_balance(&self, meta: Self::Metadata, pubkey_str: String) -> Result<u64> {
+        debug!("get_balance rpc request received: {:?}", pubkey_str);
+        let pubkey = verify_pubkey(pubkey_str)?;
         Ok(meta.request_processor.read().unwrap().get_balance(&pubkey))
     }
 
@@ -507,7 +527,7 @@ impl RpcSol for RpcSolImpl {
     fn get_block_commitment(
         &self,
         meta: Self::Metadata,
-        block: u64,
+        block: Slot,
     ) -> Result<(Option<BlockCommitment>, u64)> {
         Ok(meta
             .request_processor
@@ -548,9 +568,9 @@ impl RpcSol for RpcSolImpl {
     fn get_signature_status(
         &self,
         meta: Self::Metadata,
-        id: String,
+        signature_str: String,
     ) -> Result<Option<transaction::Result<()>>> {
-        self.get_signature_confirmation(meta, id)
+        self.get_signature_confirmation(meta, signature_str)
             .map(|res| res.map(|x| x.1))
     }
 
@@ -561,19 +581,22 @@ impl RpcSol for RpcSolImpl {
     fn get_num_blocks_since_signature_confirmation(
         &self,
         meta: Self::Metadata,
-        id: String,
+        signature_str: String,
     ) -> Result<Option<usize>> {
-        self.get_signature_confirmation(meta, id)
+        self.get_signature_confirmation(meta, signature_str)
             .map(|res| res.map(|x| x.0))
     }
 
     fn get_signature_confirmation(
         &self,
         meta: Self::Metadata,
-        id: String,
+        signature_str: String,
     ) -> Result<Option<(usize, transaction::Result<()>)>> {
-        debug!("get_signature_confirmation rpc request received: {:?}", id);
-        let signature = verify_signature(&id)?;
+        debug!(
+            "get_signature_confirmation rpc request received: {:?}",
+            signature_str
+        );
+        let signature = verify_signature(&signature_str)?;
         Ok(meta
             .request_processor
             .read()
@@ -594,8 +617,13 @@ impl RpcSol for RpcSolImpl {
         meta.request_processor.read().unwrap().get_total_supply()
     }
 
-    fn request_airdrop(&self, meta: Self::Metadata, id: String, lamports: u64) -> Result<String> {
-        trace!("request_airdrop id={} lamports={}", id, lamports);
+    fn request_airdrop(
+        &self,
+        meta: Self::Metadata,
+        pubkey_str: String,
+        lamports: u64,
+    ) -> Result<String> {
+        trace!("request_airdrop id={} lamports={}", pubkey_str, lamports);
 
         let drone_addr = meta
             .request_processor
@@ -604,7 +632,7 @@ impl RpcSol for RpcSolImpl {
             .config
             .drone_addr
             .ok_or_else(Error::invalid_request)?;
-        let pubkey = verify_pubkey(id)?;
+        let pubkey = verify_pubkey(pubkey_str)?;
 
         let blockhash = meta
             .request_processor
@@ -732,7 +760,7 @@ impl RpcSol for RpcSolImpl {
         })
     }
 
-    fn set_log_filter(&self, _: Self::Metadata, filter: String) -> Result<()> {
+    fn set_log_filter(&self, _meta: Self::Metadata, filter: String) -> Result<()> {
         solana_logger::setup_with_filter(&filter);
         Ok(())
     }

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -19,6 +19,7 @@ use solana_runtime::bank::Bank;
 use solana_sdk::{
     account::Account,
     clock::Slot,
+    commitment_config::{CommitmentConfig, CommitmentLevel},
     epoch_schedule::EpochSchedule,
     fee_calculator::FeeCalculator,
     hash::Hash,
@@ -60,8 +61,18 @@ pub struct JsonRpcRequestProcessor {
 }
 
 impl JsonRpcRequestProcessor {
-    fn bank(&self) -> Arc<Bank> {
-        self.bank_forks.read().unwrap().working_bank()
+    fn bank(&self, commitment: Option<CommitmentConfig>) -> Arc<Bank> {
+        debug!("RPC commitment_config: {:?}", commitment);
+        let r_bank_forks = self.bank_forks.read().unwrap();
+        if commitment.is_some() && commitment.unwrap().commitment == CommitmentLevel::Recent {
+            let bank = r_bank_forks.working_bank();
+            debug!("RPC using working_bank: {:?}", bank.slot());
+            bank
+        } else {
+            let slot = r_bank_forks.root();
+            debug!("RPC using block: {:?}", slot);
+            r_bank_forks.get(slot).cloned().unwrap()
+        }
     }
 
     pub fn new(
@@ -80,39 +91,58 @@ impl JsonRpcRequestProcessor {
         }
     }
 
-    pub fn get_account_info(&self, pubkey: &Pubkey) -> Result<Account> {
-        self.bank()
+    pub fn get_account_info(
+        &self,
+        pubkey: &Pubkey,
+        commitment: Option<CommitmentConfig>,
+    ) -> Result<Account> {
+        self.bank(commitment)
             .get_account(&pubkey)
             .ok_or_else(Error::invalid_request)
     }
 
-    pub fn get_minimum_balance_for_rent_exemption(&self, data_len: usize) -> Result<u64> {
-        Ok(self.bank().get_minimum_balance_for_rent_exemption(data_len))
+    pub fn get_minimum_balance_for_rent_exemption(
+        &self,
+        data_len: usize,
+        commitment: Option<CommitmentConfig>,
+    ) -> Result<u64> {
+        Ok(self
+            .bank(commitment)
+            .get_minimum_balance_for_rent_exemption(data_len))
     }
 
-    pub fn get_program_accounts(&self, program_id: &Pubkey) -> Result<Vec<(String, Account)>> {
+    pub fn get_program_accounts(
+        &self,
+        program_id: &Pubkey,
+        commitment: Option<CommitmentConfig>,
+    ) -> Result<Vec<(String, Account)>> {
         Ok(self
-            .bank()
+            .bank(commitment)
             .get_program_accounts(&program_id)
             .into_iter()
             .map(|(pubkey, account)| (pubkey.to_string(), account))
             .collect())
     }
 
-    pub fn get_inflation(&self) -> Result<Inflation> {
-        Ok(self.bank().inflation())
+    pub fn get_inflation(&self, commitment: Option<CommitmentConfig>) -> Result<Inflation> {
+        Ok(self.bank(commitment).inflation())
     }
 
     pub fn get_epoch_schedule(&self) -> Result<EpochSchedule> {
-        Ok(*self.bank().epoch_schedule())
+        // Since epoch schedule data comes from the genesis block, any commitment level should be
+        // fine
+        Ok(*self.bank(None).epoch_schedule())
     }
 
-    pub fn get_balance(&self, pubkey: &Pubkey) -> u64 {
-        self.bank().get_balance(&pubkey)
+    pub fn get_balance(&self, pubkey: &Pubkey, commitment: Option<CommitmentConfig>) -> u64 {
+        self.bank(commitment).get_balance(&pubkey)
     }
 
-    fn get_recent_blockhash(&self) -> (String, FeeCalculator) {
-        let (blockhash, fee_calculator) = self.bank().confirmed_last_blockhash();
+    fn get_recent_blockhash(
+        &self,
+        commitment: Option<CommitmentConfig>,
+    ) -> (String, FeeCalculator) {
+        let (blockhash, fee_calculator) = self.bank(commitment).confirmed_last_blockhash();
         (blockhash.to_string(), fee_calculator)
     }
 
@@ -124,41 +154,36 @@ impl JsonRpcRequestProcessor {
         )
     }
 
-    pub fn get_signature_status(&self, signature: Signature) -> Option<transaction::Result<()>> {
-        self.get_signature_confirmation_status(signature)
-            .map(|x| x.1)
-    }
-
-    pub fn get_signature_confirmations(&self, signature: Signature) -> Option<usize> {
-        self.get_signature_confirmation_status(signature)
-            .map(|x| x.0)
-    }
-
     pub fn get_signature_confirmation_status(
         &self,
         signature: Signature,
+        commitment: Option<CommitmentConfig>,
     ) -> Option<(usize, transaction::Result<()>)> {
-        self.bank().get_signature_confirmation_status(&signature)
+        self.bank(commitment)
+            .get_signature_confirmation_status(&signature)
     }
 
-    fn get_slot(&self) -> Result<u64> {
-        Ok(self.bank().slot())
+    fn get_slot(&self, commitment: Option<CommitmentConfig>) -> Result<u64> {
+        Ok(self.bank(commitment).slot())
     }
 
-    fn get_slot_leader(&self) -> Result<String> {
-        Ok(self.bank().collector_id().to_string())
+    fn get_slot_leader(&self, commitment: Option<CommitmentConfig>) -> Result<String> {
+        Ok(self.bank(commitment).collector_id().to_string())
     }
 
-    fn get_transaction_count(&self) -> Result<u64> {
-        Ok(self.bank().transaction_count() as u64)
+    fn get_transaction_count(&self, commitment: Option<CommitmentConfig>) -> Result<u64> {
+        Ok(self.bank(commitment).transaction_count() as u64)
     }
 
-    fn get_total_supply(&self) -> Result<u64> {
-        Ok(self.bank().capitalization())
+    fn get_total_supply(&self, commitment: Option<CommitmentConfig>) -> Result<u64> {
+        Ok(self.bank(commitment).capitalization())
     }
 
-    fn get_vote_accounts(&self) -> Result<RpcVoteAccountStatus> {
-        let bank = self.bank();
+    fn get_vote_accounts(
+        &self,
+        commitment: Option<CommitmentConfig>,
+    ) -> Result<RpcVoteAccountStatus> {
+        let bank = self.bank(commitment);
         let vote_accounts = bank.vote_accounts();
         let epoch_vote_accounts = bank
             .epoch_vote_accounts(bank.get_epoch_and_slot_index(bank.slot()).0)
@@ -212,8 +237,8 @@ impl JsonRpcRequestProcessor {
         ))
     }
 
-    fn get_slots_per_segment(&self) -> Result<u64> {
-        Ok(self.bank().slots_per_segment())
+    fn get_slots_per_segment(&self, commitment: Option<CommitmentConfig>) -> Result<u64> {
+        Ok(self.bank(commitment).slots_per_segment())
     }
 
     fn get_storage_pubkeys_for_slot(&self, slot: Slot) -> Result<Vec<Pubkey>> {
@@ -281,16 +306,27 @@ pub trait RpcSol {
     type Metadata;
 
     #[rpc(meta, name = "confirmTransaction")]
-    fn confirm_transaction(&self, meta: Self::Metadata, signature_str: String) -> Result<bool>;
+    fn confirm_transaction(
+        &self,
+        meta: Self::Metadata,
+        signature_str: String,
+        commitment: Option<CommitmentConfig>,
+    ) -> Result<bool>;
 
     #[rpc(meta, name = "getAccountInfo")]
-    fn get_account_info(&self, meta: Self::Metadata, pubkey_str: String) -> Result<Account>;
+    fn get_account_info(
+        &self,
+        meta: Self::Metadata,
+        pubkey_str: String,
+        commitment: Option<CommitmentConfig>,
+    ) -> Result<Account>;
 
     #[rpc(meta, name = "getProgramAccounts")]
     fn get_program_accounts(
         &self,
         meta: Self::Metadata,
         program_id_str: String,
+        commitment: Option<CommitmentConfig>,
     ) -> Result<Vec<(String, Account)>>;
 
     #[rpc(meta, name = "getMinimumBalanceForRentExemption")]
@@ -298,22 +334,36 @@ pub trait RpcSol {
         &self,
         meta: Self::Metadata,
         data_len: usize,
+        commitment: Option<CommitmentConfig>,
     ) -> Result<u64>;
 
     #[rpc(meta, name = "getInflation")]
-    fn get_inflation(&self, meta: Self::Metadata) -> Result<Inflation>;
+    fn get_inflation(
+        &self,
+        meta: Self::Metadata,
+        commitment: Option<CommitmentConfig>,
+    ) -> Result<Inflation>;
 
     #[rpc(meta, name = "getEpochSchedule")]
     fn get_epoch_schedule(&self, meta: Self::Metadata) -> Result<EpochSchedule>;
 
     #[rpc(meta, name = "getBalance")]
-    fn get_balance(&self, meta: Self::Metadata, pubkey_str: String) -> Result<u64>;
+    fn get_balance(
+        &self,
+        meta: Self::Metadata,
+        pubkey_str: String,
+        commitment: Option<CommitmentConfig>,
+    ) -> Result<u64>;
 
     #[rpc(meta, name = "getClusterNodes")]
     fn get_cluster_nodes(&self, meta: Self::Metadata) -> Result<Vec<RpcContactInfo>>;
 
     #[rpc(meta, name = "getEpochInfo")]
-    fn get_epoch_info(&self, meta: Self::Metadata) -> Result<RpcEpochInfo>;
+    fn get_epoch_info(
+        &self,
+        meta: Self::Metadata,
+        commitment: Option<CommitmentConfig>,
+    ) -> Result<RpcEpochInfo>;
 
     #[rpc(meta, name = "getBlockCommitment")]
     fn get_block_commitment(
@@ -326,26 +376,43 @@ pub trait RpcSol {
     fn get_genesis_blockhash(&self, meta: Self::Metadata) -> Result<String>;
 
     #[rpc(meta, name = "getLeaderSchedule")]
-    fn get_leader_schedule(&self, meta: Self::Metadata) -> Result<Option<Vec<String>>>;
+    fn get_leader_schedule(
+        &self,
+        meta: Self::Metadata,
+        commitment: Option<CommitmentConfig>,
+    ) -> Result<Option<Vec<String>>>;
 
     #[rpc(meta, name = "getRecentBlockhash")]
-    fn get_recent_blockhash(&self, meta: Self::Metadata) -> Result<(String, FeeCalculator)>;
+    fn get_recent_blockhash(
+        &self,
+        meta: Self::Metadata,
+        commitment: Option<CommitmentConfig>,
+    ) -> Result<(String, FeeCalculator)>;
 
     #[rpc(meta, name = "getSignatureStatus")]
     fn get_signature_status(
         &self,
         meta: Self::Metadata,
         signature_str: String,
+        commitment: Option<CommitmentConfig>,
     ) -> Result<Option<transaction::Result<()>>>;
 
     #[rpc(meta, name = "getSlot")]
-    fn get_slot(&self, meta: Self::Metadata) -> Result<u64>;
+    fn get_slot(&self, meta: Self::Metadata, commitment: Option<CommitmentConfig>) -> Result<u64>;
 
     #[rpc(meta, name = "getTransactionCount")]
-    fn get_transaction_count(&self, meta: Self::Metadata) -> Result<u64>;
+    fn get_transaction_count(
+        &self,
+        meta: Self::Metadata,
+        commitment: Option<CommitmentConfig>,
+    ) -> Result<u64>;
 
     #[rpc(meta, name = "getTotalSupply")]
-    fn get_total_supply(&self, meta: Self::Metadata) -> Result<u64>;
+    fn get_total_supply(
+        &self,
+        meta: Self::Metadata,
+        commitment: Option<CommitmentConfig>,
+    ) -> Result<u64>;
 
     #[rpc(meta, name = "requestAirdrop")]
     fn request_airdrop(
@@ -353,16 +420,25 @@ pub trait RpcSol {
         meta: Self::Metadata,
         pubkey_str: String,
         lamports: u64,
+        commitment: Option<CommitmentConfig>,
     ) -> Result<String>;
 
     #[rpc(meta, name = "sendTransaction")]
     fn send_transaction(&self, meta: Self::Metadata, data: Vec<u8>) -> Result<String>;
 
     #[rpc(meta, name = "getSlotLeader")]
-    fn get_slot_leader(&self, meta: Self::Metadata) -> Result<String>;
+    fn get_slot_leader(
+        &self,
+        meta: Self::Metadata,
+        commitment: Option<CommitmentConfig>,
+    ) -> Result<String>;
 
     #[rpc(meta, name = "getVoteAccounts")]
-    fn get_vote_accounts(&self, meta: Self::Metadata) -> Result<RpcVoteAccountStatus>;
+    fn get_vote_accounts(
+        &self,
+        meta: Self::Metadata,
+        commitment: Option<CommitmentConfig>,
+    ) -> Result<RpcVoteAccountStatus>;
 
     #[rpc(meta, name = "getStorageTurnRate")]
     fn get_storage_turn_rate(&self, meta: Self::Metadata) -> Result<u64>;
@@ -371,7 +447,11 @@ pub trait RpcSol {
     fn get_storage_turn(&self, meta: Self::Metadata) -> Result<(String, u64)>;
 
     #[rpc(meta, name = "getSlotsPerSegment")]
-    fn get_slots_per_segment(&self, meta: Self::Metadata) -> Result<u64>;
+    fn get_slots_per_segment(
+        &self,
+        meta: Self::Metadata,
+        commitment: Option<CommitmentConfig>,
+    ) -> Result<u64>;
 
     #[rpc(meta, name = "getStoragePubkeysForSlot")]
     fn get_storage_pubkeys_for_slot(&self, meta: Self::Metadata, slot: u64) -> Result<Vec<Pubkey>>;
@@ -384,6 +464,7 @@ pub trait RpcSol {
         &self,
         meta: Self::Metadata,
         signature_str: String,
+        commitment: Option<CommitmentConfig>,
     ) -> Result<Option<usize>>;
 
     #[rpc(meta, name = "getSignatureConfirmation")]
@@ -391,6 +472,7 @@ pub trait RpcSol {
         &self,
         meta: Self::Metadata,
         signature_str: String,
+        commitment: Option<CommitmentConfig>,
     ) -> Result<Option<(usize, transaction::Result<()>)>>;
 
     #[rpc(meta, name = "getVersion")]
@@ -404,12 +486,17 @@ pub struct RpcSolImpl;
 impl RpcSol for RpcSolImpl {
     type Metadata = Meta;
 
-    fn confirm_transaction(&self, meta: Self::Metadata, signature_str: String) -> Result<bool> {
+    fn confirm_transaction(
+        &self,
+        meta: Self::Metadata,
+        signature_str: String,
+        commitment: Option<CommitmentConfig>,
+    ) -> Result<bool> {
         debug!(
             "confirm_transaction rpc request received: {:?}",
             signature_str
         );
-        self.get_signature_status(meta, signature_str)
+        self.get_signature_status(meta, signature_str, commitment)
             .map(|status_option| {
                 if status_option.is_none() {
                     return false;
@@ -418,19 +505,25 @@ impl RpcSol for RpcSolImpl {
             })
     }
 
-    fn get_account_info(&self, meta: Self::Metadata, pubkey_str: String) -> Result<Account> {
+    fn get_account_info(
+        &self,
+        meta: Self::Metadata,
+        pubkey_str: String,
+        commitment: Option<CommitmentConfig>,
+    ) -> Result<Account> {
         debug!("get_account_info rpc request received: {:?}", pubkey_str);
         let pubkey = verify_pubkey(pubkey_str)?;
         meta.request_processor
             .read()
             .unwrap()
-            .get_account_info(&pubkey)
+            .get_account_info(&pubkey, commitment)
     }
 
     fn get_minimum_balance_for_rent_exemption(
         &self,
         meta: Self::Metadata,
         data_len: usize,
+        commitment: Option<CommitmentConfig>,
     ) -> Result<u64> {
         debug!(
             "get_minimum_balance_for_rent_exemption rpc request received: {:?}",
@@ -439,13 +532,14 @@ impl RpcSol for RpcSolImpl {
         meta.request_processor
             .read()
             .unwrap()
-            .get_minimum_balance_for_rent_exemption(data_len)
+            .get_minimum_balance_for_rent_exemption(data_len, commitment)
     }
 
     fn get_program_accounts(
         &self,
         meta: Self::Metadata,
         program_id_str: String,
+        commitment: Option<CommitmentConfig>,
     ) -> Result<Vec<(String, Account)>> {
         debug!(
             "get_program_accounts rpc request received: {:?}",
@@ -455,16 +549,20 @@ impl RpcSol for RpcSolImpl {
         meta.request_processor
             .read()
             .unwrap()
-            .get_program_accounts(&program_id)
+            .get_program_accounts(&program_id, commitment)
     }
 
-    fn get_inflation(&self, meta: Self::Metadata) -> Result<Inflation> {
+    fn get_inflation(
+        &self,
+        meta: Self::Metadata,
+        commitment: Option<CommitmentConfig>,
+    ) -> Result<Inflation> {
         debug!("get_inflation rpc request received");
         Ok(meta
             .request_processor
             .read()
             .unwrap()
-            .get_inflation()
+            .get_inflation(commitment)
             .unwrap())
     }
 
@@ -478,10 +576,19 @@ impl RpcSol for RpcSolImpl {
             .unwrap())
     }
 
-    fn get_balance(&self, meta: Self::Metadata, pubkey_str: String) -> Result<u64> {
+    fn get_balance(
+        &self,
+        meta: Self::Metadata,
+        pubkey_str: String,
+        commitment: Option<CommitmentConfig>,
+    ) -> Result<u64> {
         debug!("get_balance rpc request received: {:?}", pubkey_str);
         let pubkey = verify_pubkey(pubkey_str)?;
-        Ok(meta.request_processor.read().unwrap().get_balance(&pubkey))
+        Ok(meta
+            .request_processor
+            .read()
+            .unwrap()
+            .get_balance(&pubkey, commitment))
     }
 
     fn get_cluster_nodes(&self, meta: Self::Metadata) -> Result<Vec<RpcContactInfo>> {
@@ -511,8 +618,12 @@ impl RpcSol for RpcSolImpl {
             .collect())
     }
 
-    fn get_epoch_info(&self, meta: Self::Metadata) -> Result<RpcEpochInfo> {
-        let bank = meta.request_processor.read().unwrap().bank();
+    fn get_epoch_info(
+        &self,
+        meta: Self::Metadata,
+        commitment: Option<CommitmentConfig>,
+    ) -> Result<RpcEpochInfo> {
+        let bank = meta.request_processor.read().unwrap().bank(commitment);
         let epoch_schedule = bank.epoch_schedule();
         let (epoch, slot_index) = epoch_schedule.get_epoch_and_slot_index(bank.slot());
         let slot = bank.slot();
@@ -541,8 +652,12 @@ impl RpcSol for RpcSolImpl {
         Ok(meta.genesis_blockhash.to_string())
     }
 
-    fn get_leader_schedule(&self, meta: Self::Metadata) -> Result<Option<Vec<String>>> {
-        let bank = meta.request_processor.read().unwrap().bank();
+    fn get_leader_schedule(
+        &self,
+        meta: Self::Metadata,
+        commitment: Option<CommitmentConfig>,
+    ) -> Result<Option<Vec<String>>> {
+        let bank = meta.request_processor.read().unwrap().bank(commitment);
         Ok(
             solana_ledger::leader_schedule_utils::leader_schedule(bank.epoch(), &bank).map(
                 |leader_schedule| {
@@ -556,34 +671,40 @@ impl RpcSol for RpcSolImpl {
         )
     }
 
-    fn get_recent_blockhash(&self, meta: Self::Metadata) -> Result<(String, FeeCalculator)> {
+    fn get_recent_blockhash(
+        &self,
+        meta: Self::Metadata,
+        commitment: Option<CommitmentConfig>,
+    ) -> Result<(String, FeeCalculator)> {
         debug!("get_recent_blockhash rpc request received");
         Ok(meta
             .request_processor
             .read()
             .unwrap()
-            .get_recent_blockhash())
+            .get_recent_blockhash(commitment))
     }
 
     fn get_signature_status(
         &self,
         meta: Self::Metadata,
         signature_str: String,
+        commitment: Option<CommitmentConfig>,
     ) -> Result<Option<transaction::Result<()>>> {
-        self.get_signature_confirmation(meta, signature_str)
+        self.get_signature_confirmation(meta, signature_str, commitment)
             .map(|res| res.map(|x| x.1))
     }
 
-    fn get_slot(&self, meta: Self::Metadata) -> Result<u64> {
-        meta.request_processor.read().unwrap().get_slot()
+    fn get_slot(&self, meta: Self::Metadata, commitment: Option<CommitmentConfig>) -> Result<u64> {
+        meta.request_processor.read().unwrap().get_slot(commitment)
     }
 
     fn get_num_blocks_since_signature_confirmation(
         &self,
         meta: Self::Metadata,
         signature_str: String,
+        commitment: Option<CommitmentConfig>,
     ) -> Result<Option<usize>> {
-        self.get_signature_confirmation(meta, signature_str)
+        self.get_signature_confirmation(meta, signature_str, commitment)
             .map(|res| res.map(|x| x.0))
     }
 
@@ -591,6 +712,7 @@ impl RpcSol for RpcSolImpl {
         &self,
         meta: Self::Metadata,
         signature_str: String,
+        commitment: Option<CommitmentConfig>,
     ) -> Result<Option<(usize, transaction::Result<()>)>> {
         debug!(
             "get_signature_confirmation rpc request received: {:?}",
@@ -601,20 +723,31 @@ impl RpcSol for RpcSolImpl {
             .request_processor
             .read()
             .unwrap()
-            .get_signature_confirmation_status(signature))
+            .get_signature_confirmation_status(signature, commitment))
     }
 
-    fn get_transaction_count(&self, meta: Self::Metadata) -> Result<u64> {
+    fn get_transaction_count(
+        &self,
+        meta: Self::Metadata,
+        commitment: Option<CommitmentConfig>,
+    ) -> Result<u64> {
         debug!("get_transaction_count rpc request received");
         meta.request_processor
             .read()
             .unwrap()
-            .get_transaction_count()
+            .get_transaction_count(commitment)
     }
 
-    fn get_total_supply(&self, meta: Self::Metadata) -> Result<u64> {
+    fn get_total_supply(
+        &self,
+        meta: Self::Metadata,
+        commitment: Option<CommitmentConfig>,
+    ) -> Result<u64> {
         debug!("get_total_supply rpc request received");
-        meta.request_processor.read().unwrap().get_total_supply()
+        meta.request_processor
+            .read()
+            .unwrap()
+            .get_total_supply(commitment)
     }
 
     fn request_airdrop(
@@ -622,6 +755,7 @@ impl RpcSol for RpcSolImpl {
         meta: Self::Metadata,
         pubkey_str: String,
         lamports: u64,
+        commitment: Option<CommitmentConfig>,
     ) -> Result<String> {
         trace!("request_airdrop id={} lamports={}", pubkey_str, lamports);
 
@@ -638,7 +772,7 @@ impl RpcSol for RpcSolImpl {
             .request_processor
             .read()
             .unwrap()
-            .bank()
+            .bank(commitment.clone())
             .confirmed_last_blockhash()
             .0;
         let transaction = request_airdrop_transaction(&drone_addr, &pubkey, lamports, blockhash)
@@ -669,7 +803,8 @@ impl RpcSol for RpcSolImpl {
                 .request_processor
                 .read()
                 .unwrap()
-                .get_signature_status(signature);
+                .get_signature_confirmation_status(signature, commitment.clone())
+                .map(|x| x.1);
 
             if signature_status == Some(Ok(())) {
                 info!("airdrop signature ok");
@@ -713,12 +848,26 @@ impl RpcSol for RpcSolImpl {
         Ok(signature)
     }
 
-    fn get_slot_leader(&self, meta: Self::Metadata) -> Result<String> {
-        meta.request_processor.read().unwrap().get_slot_leader()
+    fn get_slot_leader(
+        &self,
+        meta: Self::Metadata,
+        commitment: Option<CommitmentConfig>,
+    ) -> Result<String> {
+        meta.request_processor
+            .read()
+            .unwrap()
+            .get_slot_leader(commitment)
     }
 
-    fn get_vote_accounts(&self, meta: Self::Metadata) -> Result<RpcVoteAccountStatus> {
-        meta.request_processor.read().unwrap().get_vote_accounts()
+    fn get_vote_accounts(
+        &self,
+        meta: Self::Metadata,
+        commitment: Option<CommitmentConfig>,
+    ) -> Result<RpcVoteAccountStatus> {
+        meta.request_processor
+            .read()
+            .unwrap()
+            .get_vote_accounts(commitment)
     }
 
     fn get_storage_turn_rate(&self, meta: Self::Metadata) -> Result<u64> {
@@ -732,11 +881,15 @@ impl RpcSol for RpcSolImpl {
         meta.request_processor.read().unwrap().get_storage_turn()
     }
 
-    fn get_slots_per_segment(&self, meta: Self::Metadata) -> Result<u64> {
+    fn get_slots_per_segment(
+        &self,
+        meta: Self::Metadata,
+        commitment: Option<CommitmentConfig>,
+    ) -> Result<u64> {
         meta.request_processor
             .read()
             .unwrap()
-            .get_slots_per_segment()
+            .get_slots_per_segment(commitment)
     }
 
     fn get_storage_pubkeys_for_slot(
@@ -887,7 +1040,7 @@ pub mod tests {
         })
         .join()
         .unwrap();
-        assert_eq!(request_processor.get_transaction_count().unwrap(), 1);
+        assert_eq!(request_processor.get_transaction_count(None).unwrap(), 1);
     }
 
     #[test]

--- a/core/src/rpc_service.rs
+++ b/core/src/rpc_service.rs
@@ -220,7 +220,7 @@ mod tests {
                 .request_processor
                 .read()
                 .unwrap()
-                .get_balance(&mint_keypair.pubkey())
+                .get_balance(&mint_keypair.pubkey(), None)
         );
         rpc_service.exit();
         rpc_service.join().unwrap();

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -511,7 +511,7 @@ pub fn new_validator_for_tests() -> (Validator, ContactInfo, Keypair, PathBuf) {
     let GenesisBlockInfo {
         mut genesis_block,
         mint_keypair,
-        ..
+        voting_keypair,
     } = create_genesis_block_with_leader(10_000, &contact_info.id, 42);
     genesis_block
         .native_instruction_processors
@@ -522,14 +522,14 @@ pub fn new_validator_for_tests() -> (Validator, ContactInfo, Keypair, PathBuf) {
 
     let (ledger_path, _blockhash) = create_new_tmp_ledger!(&genesis_block);
 
-    let voting_keypair = Arc::new(Keypair::new());
+    let leader_voting_keypair = Arc::new(voting_keypair);
     let storage_keypair = Arc::new(Keypair::new());
     let node = Validator::new(
         node,
         &node_keypair,
         &ledger_path,
-        &voting_keypair.pubkey(),
-        &voting_keypair,
+        &leader_voting_keypair.pubkey(),
+        &leader_voting_keypair,
         &storage_keypair,
         None,
         true,

--- a/local_cluster/src/cluster_tests.rs
+++ b/local_cluster/src/cluster_tests.rs
@@ -1,9 +1,9 @@
-use rand::{thread_rng, Rng};
-use solana_client::thin_client::create_client;
 /// Cluster independant integration tests
 ///
 /// All tests must start from an entry point and a funding keypair and
 /// discover the rest of the network.
+use rand::{thread_rng, Rng};
+use solana_client::thin_client::create_client;
 use solana_core::{
     cluster_info::VALIDATOR_PORT_RANGE, consensus::VOTE_THRESHOLD_DEPTH, contact_info::ContactInfo,
     gossip_service::discover_cluster,
@@ -15,6 +15,7 @@ use solana_ledger::{
 use solana_sdk::{
     client::SyncClient,
     clock::{Slot, DEFAULT_TICKS_PER_SECOND, DEFAULT_TICKS_PER_SLOT, NUM_CONSECUTIVE_LEADER_SLOTS},
+    commitment_config::CommitmentConfig,
     epoch_schedule::MINIMUM_SLOTS_PER_EPOCH,
     hash::Hash,
     poh_config::PohConfig,
@@ -49,10 +50,12 @@ pub fn spend_and_verify_all_nodes<S: ::std::hash::BuildHasher>(
         let random_keypair = Keypair::new();
         let client = create_client(ingress_node.client_facing_addr(), VALIDATOR_PORT_RANGE);
         let bal = client
-            .poll_get_balance(&funding_keypair.pubkey())
+            .poll_get_balance_with_commitment(&funding_keypair.pubkey(), CommitmentConfig::recent())
             .expect("balance in source");
         assert!(bal > 0);
-        let (blockhash, _fee_calculator) = client.get_recent_blockhash().unwrap();
+        let (blockhash, _fee_calculator) = client
+            .get_recent_blockhash_with_commitment(CommitmentConfig::recent())
+            .unwrap();
         let mut transaction =
             system_transaction::transfer(&funding_keypair, &random_keypair.pubkey(), 1, blockhash);
         let confs = VOTE_THRESHOLD_DEPTH + 1;
@@ -75,7 +78,9 @@ pub fn verify_balances<S: ::std::hash::BuildHasher>(
 ) {
     let client = create_client(node.client_facing_addr(), VALIDATOR_PORT_RANGE);
     for (pk, b) in expected_balances {
-        let bal = client.poll_get_balance(&pk).expect("balance in source");
+        let bal = client
+            .poll_get_balance_with_commitment(&pk, CommitmentConfig::recent())
+            .expect("balance in source");
         assert_eq!(bal, b);
     }
 }
@@ -91,10 +96,12 @@ pub fn send_many_transactions(
     for _ in 0..num_txs {
         let random_keypair = Keypair::new();
         let bal = client
-            .poll_get_balance(&funding_keypair.pubkey())
+            .poll_get_balance_with_commitment(&funding_keypair.pubkey(), CommitmentConfig::recent())
             .expect("balance in source");
         assert!(bal > 0);
-        let (blockhash, _fee_calculator) = client.get_recent_blockhash().unwrap();
+        let (blockhash, _fee_calculator) = client
+            .get_recent_blockhash_with_commitment(CommitmentConfig::recent())
+            .unwrap();
         let transfer_amount = thread_rng().gen_range(1, max_tokens_per_transfer);
 
         let mut transaction = system_transaction::transfer(
@@ -188,7 +195,7 @@ pub fn kill_entry_and_spend_and_verify_rest(
 
     for ingress_node in &cluster_nodes {
         client
-            .poll_get_balance(&ingress_node.id)
+            .poll_get_balance_with_commitment(&ingress_node.id, CommitmentConfig::recent())
             .unwrap_or_else(|err| panic!("Node {} has no balance: {}", ingress_node.id, err));
     }
 
@@ -212,7 +219,7 @@ pub fn kill_entry_and_spend_and_verify_rest(
 
         let client = create_client(ingress_node.client_facing_addr(), VALIDATOR_PORT_RANGE);
         let balance = client
-            .poll_get_balance(&funding_keypair.pubkey())
+            .poll_get_balance_with_commitment(&funding_keypair.pubkey(), CommitmentConfig::recent())
             .expect("balance in source");
         assert_ne!(balance, 0);
 
@@ -225,7 +232,9 @@ pub fn kill_entry_and_spend_and_verify_rest(
             }
 
             let random_keypair = Keypair::new();
-            let (blockhash, _fee_calculator) = client.get_recent_blockhash().unwrap();
+            let (blockhash, _fee_calculator) = client
+                .get_recent_blockhash_with_commitment(CommitmentConfig::recent())
+                .unwrap();
             let mut transaction = system_transaction::transfer(
                 &funding_keypair,
                 &random_keypair.pubkey(),

--- a/local_cluster/src/local_cluster.rs
+++ b/local_cluster/src/local_cluster.rs
@@ -387,6 +387,7 @@ impl LocalCluster {
             self.entry_point_info.clone(),
             archiver_keypair,
             storage_keypair,
+            CommitmentConfig::recent(),
         )
         .unwrap_or_else(|err| panic!("Archiver::new() failed: {:?}", err));
 

--- a/local_cluster/src/local_cluster.rs
+++ b/local_cluster/src/local_cluster.rs
@@ -13,6 +13,7 @@ use solana_ledger::blocktree::create_new_tmp_ledger;
 use solana_sdk::{
     client::SyncClient,
     clock::{DEFAULT_SLOTS_PER_EPOCH, DEFAULT_SLOTS_PER_SEGMENT, DEFAULT_TICKS_PER_SLOT},
+    commitment_config::CommitmentConfig,
     epoch_schedule::EpochSchedule,
     genesis_block::{GenesisBlock, OperatingMode},
     message::Message,
@@ -424,7 +425,9 @@ impl LocalCluster {
         lamports: u64,
     ) -> u64 {
         trace!("getting leader blockhash");
-        let (blockhash, _fee_calculator) = client.get_recent_blockhash().unwrap();
+        let (blockhash, _fee_calculator) = client
+            .get_recent_blockhash_with_commitment(CommitmentConfig::recent())
+            .unwrap();
         let mut tx =
             system_transaction::transfer(&source_keypair, dest_pubkey, lamports, blockhash);
         info!(
@@ -437,7 +440,11 @@ impl LocalCluster {
             .retry_transfer(&source_keypair, &mut tx, 10)
             .expect("client transfer");
         client
-            .wait_for_balance(dest_pubkey, Some(lamports))
+            .wait_for_balance_with_commitment(
+                dest_pubkey,
+                Some(lamports),
+                CommitmentConfig::recent(),
+            )
             .expect("get balance")
     }
 
@@ -453,7 +460,11 @@ impl LocalCluster {
         let stake_account_pubkey = stake_account_keypair.pubkey();
 
         // Create the vote account if necessary
-        if client.poll_get_balance(&vote_account_pubkey).unwrap_or(0) == 0 {
+        if client
+            .poll_get_balance_with_commitment(&vote_account_pubkey, CommitmentConfig::recent())
+            .unwrap_or(0)
+            == 0
+        {
             // 1) Create vote account
 
             let mut transaction = Transaction::new_signed_instructions(
@@ -469,13 +480,20 @@ impl LocalCluster {
                     },
                     amount,
                 ),
-                client.get_recent_blockhash().unwrap().0,
+                client
+                    .get_recent_blockhash_with_commitment(CommitmentConfig::recent())
+                    .unwrap()
+                    .0,
             );
             client
                 .retry_transfer(&from_account, &mut transaction, 10)
                 .expect("fund vote");
             client
-                .wait_for_balance(&vote_account_pubkey, Some(amount))
+                .wait_for_balance_with_commitment(
+                    &vote_account_pubkey,
+                    Some(amount),
+                    CommitmentConfig::recent(),
+                )
                 .expect("get balance");
 
             let mut transaction = Transaction::new_signed_instructions(
@@ -487,7 +505,10 @@ impl LocalCluster {
                     &StakeAuthorized::auto(&stake_account_pubkey),
                     amount,
                 ),
-                client.get_recent_blockhash().unwrap().0,
+                client
+                    .get_recent_blockhash_with_commitment(CommitmentConfig::recent())
+                    .unwrap()
+                    .0,
             );
 
             client
@@ -499,7 +520,11 @@ impl LocalCluster {
                 )
                 .expect("delegate stake");
             client
-                .wait_for_balance(&stake_account_pubkey, Some(amount))
+                .wait_for_balance_with_commitment(
+                    &stake_account_pubkey,
+                    Some(amount),
+                    CommitmentConfig::recent(),
+                )
                 .expect("get balance");
         } else {
             warn!(
@@ -509,8 +534,8 @@ impl LocalCluster {
         }
         info!("Checking for vote account registration of {}", node_pubkey);
         match (
-            client.get_account(&stake_account_pubkey),
-            client.get_account(&vote_account_pubkey),
+            client.get_account_with_commitment(&stake_account_pubkey, CommitmentConfig::recent()),
+            client.get_account_with_commitment(&vote_account_pubkey, CommitmentConfig::recent()),
         ) {
             (Ok(Some(stake_account)), Ok(Some(vote_account))) => {
                 match (
@@ -568,7 +593,10 @@ impl LocalCluster {
             Some(&from_keypair.pubkey()),
         );
         let signer_keys = vec![from_keypair.as_ref()];
-        let blockhash = client.get_recent_blockhash().unwrap().0;
+        let blockhash = client
+            .get_recent_blockhash_with_commitment(CommitmentConfig::recent())
+            .unwrap()
+            .0;
         let mut transaction = Transaction::new(&signer_keys, message, blockhash);
         client
             .retry_transfer(&from_keypair, &mut transaction, 10)

--- a/local_cluster/src/tests/archiver.rs
+++ b/local_cluster/src/tests/archiver.rs
@@ -1,17 +1,23 @@
 use crate::local_cluster::{ClusterConfig, LocalCluster};
 use serial_test_derive::serial;
 use solana_client::thin_client::create_client;
-use solana_core::archiver::Archiver;
-use solana_core::cluster_info::{ClusterInfo, Node, VALIDATOR_PORT_RANGE};
-use solana_core::contact_info::ContactInfo;
-use solana_core::gossip_service::discover_cluster;
-use solana_core::storage_stage::SLOTS_PER_TURN_TEST;
-use solana_core::validator::ValidatorConfig;
+use solana_core::{
+    archiver::Archiver,
+    cluster_info::{ClusterInfo, Node, VALIDATOR_PORT_RANGE},
+    contact_info::ContactInfo,
+    gossip_service::discover_cluster,
+    storage_stage::SLOTS_PER_TURN_TEST,
+    validator::ValidatorConfig,
+};
 use solana_ledger::blocktree::{create_new_tmp_ledger, get_tmp_ledger_path, Blocktree};
-use solana_sdk::genesis_block::create_genesis_block;
-use solana_sdk::signature::{Keypair, KeypairUtil};
-use std::fs::remove_dir_all;
-use std::sync::{Arc, RwLock};
+use solana_sdk::{
+    genesis_block::create_genesis_block,
+    signature::{Keypair, KeypairUtil},
+};
+use std::{
+    fs::remove_dir_all,
+    sync::{Arc, RwLock},
+};
 
 /// Start the cluster with the given configuration and wait till the archivers are discovered
 /// Then download blobs from one of them.

--- a/local_cluster/src/tests/archiver.rs
+++ b/local_cluster/src/tests/archiver.rs
@@ -11,6 +11,7 @@ use solana_core::{
 };
 use solana_ledger::blocktree::{create_new_tmp_ledger, get_tmp_ledger_path, Blocktree};
 use solana_sdk::{
+    commitment_config::CommitmentConfig,
     genesis_block::create_genesis_block,
     signature::{Keypair, KeypairUtil},
 };
@@ -105,6 +106,7 @@ fn test_archiver_startup_leader_hang() {
             leader_info,
             archiver_keypair,
             storage_keypair,
+            CommitmentConfig::recent(),
         );
 
         assert!(archiver_res.is_err());
@@ -140,6 +142,7 @@ fn test_archiver_startup_ledger_hang() {
         cluster.entry_point_info.clone(),
         bad_keys,
         storage_keypair,
+        CommitmentConfig::recent(),
     );
 
     assert!(archiver_res.is_err());
@@ -174,7 +177,10 @@ fn test_account_setup() {
     cluster.archiver_infos.iter().for_each(|(_, value)| {
         assert_eq!(
             client
-                .poll_get_balance(&value.archiver_storage_pubkey)
+                .poll_get_balance_with_commitment(
+                    &value.archiver_storage_pubkey,
+                    CommitmentConfig::recent()
+                )
                 .unwrap(),
             1
         );

--- a/local_cluster/src/tests/local_cluster.rs
+++ b/local_cluster/src/tests/local_cluster.rs
@@ -15,14 +15,15 @@ use solana_runtime::accounts_db::AccountsDB;
 use solana_sdk::{
     client::SyncClient,
     clock,
+    commitment_config::CommitmentConfig,
     epoch_schedule::{EpochSchedule, MINIMUM_SLOTS_PER_EPOCH},
     genesis_block::OperatingMode,
     poh_config::PohConfig,
 };
-use std::path::{Path, PathBuf};
 use std::{
     collections::{HashMap, HashSet},
     fs,
+    path::{Path, PathBuf},
     thread::sleep,
     time::Duration,
 };
@@ -329,7 +330,12 @@ fn test_softlaunch_operating_mode() {
     .iter()
     {
         assert_eq!(
-            (program_id, client.get_account(program_id).unwrap()),
+            (
+                program_id,
+                client
+                    .get_account_with_commitment(program_id, CommitmentConfig::recent())
+                    .unwrap()
+            ),
             (program_id, None)
         );
     }
@@ -460,7 +466,7 @@ fn test_snapshots_blocktree_floor() {
     let target_slot = slot_floor + 40;
     while current_slot <= target_slot {
         trace!("current_slot: {}", current_slot);
-        if let Ok(slot) = validator_client.get_slot() {
+        if let Ok(slot) = validator_client.get_slot_with_commitment(CommitmentConfig::recent()) {
             current_slot = slot;
         } else {
             continue;
@@ -711,7 +717,7 @@ fn run_repairman_catchup(num_repairmen: u64) {
     let target_slot = (num_warmup_epochs) * num_slots_per_epoch + 1;
     while current_slot <= target_slot {
         trace!("current_slot: {}", current_slot);
-        if let Ok(slot) = repairee_client.get_slot() {
+        if let Ok(slot) = repairee_client.get_slot_with_commitment(CommitmentConfig::recent()) {
             current_slot = slot;
         } else {
             continue;
@@ -725,7 +731,9 @@ fn wait_for_next_snapshot<P: AsRef<Path>>(cluster: &LocalCluster, tar: P) {
     let client = cluster
         .get_validator_client(&cluster.entry_point_info.id)
         .unwrap();
-    let last_slot = client.get_slot().expect("Couldn't get slot");
+    let last_slot = client
+        .get_slot_with_commitment(CommitmentConfig::recent())
+        .expect("Couldn't get slot");
 
     // Wait for a snapshot for a bank >= last_slot to be made so we know that the snapshot
     // must include the transactions just pushed

--- a/runtime/src/bank_client.rs
+++ b/runtime/src/bank_client.rs
@@ -1,22 +1,27 @@
 use crate::bank::Bank;
-use solana_sdk::account::Account;
-use solana_sdk::client::{AsyncClient, Client, SyncClient};
-use solana_sdk::fee_calculator::FeeCalculator;
-use solana_sdk::hash::Hash;
-use solana_sdk::instruction::Instruction;
-use solana_sdk::message::Message;
-use solana_sdk::pubkey::Pubkey;
-use solana_sdk::signature::Signature;
-use solana_sdk::signature::{Keypair, KeypairUtil};
-use solana_sdk::system_instruction;
-use solana_sdk::transaction::{self, Transaction};
-use solana_sdk::transport::{Result, TransportError};
-use std::io;
-use std::sync::mpsc::{channel, Receiver, Sender};
-use std::sync::Arc;
-use std::sync::Mutex;
-use std::thread::{sleep, Builder};
-use std::time::{Duration, Instant};
+use solana_sdk::{
+    account::Account,
+    client::{AsyncClient, Client, SyncClient},
+    commitment_config::CommitmentConfig,
+    fee_calculator::FeeCalculator,
+    hash::Hash,
+    instruction::Instruction,
+    message::Message,
+    pubkey::Pubkey,
+    signature::{Keypair, KeypairUtil, Signature},
+    system_instruction,
+    transaction::{self, Transaction},
+    transport::{Result, TransportError},
+};
+use std::{
+    io,
+    sync::{
+        mpsc::{channel, Receiver, Sender},
+        Arc, Mutex,
+    },
+    thread::{sleep, Builder},
+    time::{Duration, Instant},
+};
 
 pub struct BankClient {
     bank: Arc<Bank>,
@@ -100,11 +105,34 @@ impl SyncClient for BankClient {
         Ok(self.bank.get_account(pubkey))
     }
 
+    fn get_account_with_commitment(
+        &self,
+        pubkey: &Pubkey,
+        _commitment_config: CommitmentConfig,
+    ) -> Result<Option<Account>> {
+        Ok(self.bank.get_account(pubkey))
+    }
+
     fn get_balance(&self, pubkey: &Pubkey) -> Result<u64> {
         Ok(self.bank.get_balance(pubkey))
     }
 
+    fn get_balance_with_commitment(
+        &self,
+        pubkey: &Pubkey,
+        _commitment_config: CommitmentConfig,
+    ) -> Result<u64> {
+        Ok(self.bank.get_balance(pubkey))
+    }
+
     fn get_recent_blockhash(&self) -> Result<(Hash, FeeCalculator)> {
+        Ok(self.bank.last_blockhash_with_fee_calculator())
+    }
+
+    fn get_recent_blockhash_with_commitment(
+        &self,
+        _commitment_config: CommitmentConfig,
+    ) -> Result<(Hash, FeeCalculator)> {
         Ok(self.bank.last_blockhash_with_fee_calculator())
     }
 
@@ -115,11 +143,30 @@ impl SyncClient for BankClient {
         Ok(self.bank.get_signature_status(signature))
     }
 
+    fn get_signature_status_with_commitment(
+        &self,
+        signature: &Signature,
+        _commitment_config: CommitmentConfig,
+    ) -> Result<Option<transaction::Result<()>>> {
+        Ok(self.bank.get_signature_status(signature))
+    }
+
     fn get_slot(&self) -> Result<u64> {
         Ok(self.bank.slot())
     }
 
+    fn get_slot_with_commitment(&self, _commitment_config: CommitmentConfig) -> Result<u64> {
+        Ok(self.bank.slot())
+    }
+
     fn get_transaction_count(&self) -> Result<u64> {
+        Ok(self.bank.transaction_count())
+    }
+
+    fn get_transaction_count_with_commitment(
+        &self,
+        _commitment_config: CommitmentConfig,
+    ) -> Result<u64> {
         Ok(self.bank.transaction_count())
     }
 

--- a/sdk/src/client.rs
+++ b/sdk/src/client.rs
@@ -10,6 +10,7 @@
 use crate::{
     account::Account,
     clock::Slot,
+    commitment_config::CommitmentConfig,
     fee_calculator::FeeCalculator,
     hash::Hash,
     instruction::Instruction,
@@ -44,11 +45,31 @@ pub trait SyncClient {
     /// Get an account or None if not found.
     fn get_account(&self, pubkey: &Pubkey) -> Result<Option<Account>>;
 
+    /// Get an account or None if not found. Uses explicit commitment configuration.
+    fn get_account_with_commitment(
+        &self,
+        pubkey: &Pubkey,
+        commitment_config: CommitmentConfig,
+    ) -> Result<Option<Account>>;
+
     /// Get account balance or 0 if not found.
     fn get_balance(&self, pubkey: &Pubkey) -> Result<u64>;
 
+    /// Get account balance or 0 if not found. Uses explicit commitment configuration.
+    fn get_balance_with_commitment(
+        &self,
+        pubkey: &Pubkey,
+        commitment_config: CommitmentConfig,
+    ) -> Result<u64>;
+
     /// Get recent blockhash
     fn get_recent_blockhash(&self) -> Result<(Hash, FeeCalculator)>;
+
+    /// Get recent blockhash. Uses explicit commitment configuration.
+    fn get_recent_blockhash_with_commitment(
+        &self,
+        commitment_config: CommitmentConfig,
+    ) -> Result<(Hash, FeeCalculator)>;
 
     /// Get signature status.
     fn get_signature_status(
@@ -56,11 +77,27 @@ pub trait SyncClient {
         signature: &Signature,
     ) -> Result<Option<transaction::Result<()>>>;
 
+    /// Get signature status. Uses explicit commitment configuration.
+    fn get_signature_status_with_commitment(
+        &self,
+        signature: &Signature,
+        commitment_config: CommitmentConfig,
+    ) -> Result<Option<transaction::Result<()>>>;
+
     /// Get last known slot
     fn get_slot(&self) -> Result<Slot>;
 
+    /// Get last known slot. Uses explicit commitment configuration.
+    fn get_slot_with_commitment(&self, commitment_config: CommitmentConfig) -> Result<u64>;
+
     /// Get transaction count
     fn get_transaction_count(&self) -> Result<u64>;
+
+    /// Get transaction count. Uses explicit commitment configuration.
+    fn get_transaction_count_with_commitment(
+        &self,
+        commitment_config: CommitmentConfig,
+    ) -> Result<u64>;
 
     /// Poll until the signature has been confirmed by at least `min_confirmed_blocks`
     fn poll_for_signature_confirmation(

--- a/sdk/src/commitment_config.rs
+++ b/sdk/src/commitment_config.rs
@@ -18,6 +18,14 @@ impl CommitmentConfig {
             commitment: CommitmentLevel::Recent,
         }
     }
+
+    pub fn ok(&self) -> Option<Self> {
+        if self == &Self::default() {
+            None
+        } else {
+            Some(self.clone())
+        }
+    }
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]

--- a/sdk/src/commitment_config.rs
+++ b/sdk/src/commitment_config.rs
@@ -1,0 +1,28 @@
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct CommitmentConfig {
+    pub commitment: CommitmentLevel,
+}
+
+impl Default for CommitmentConfig {
+    fn default() -> Self {
+        CommitmentConfig {
+            commitment: CommitmentLevel::Max,
+        }
+    }
+}
+
+impl CommitmentConfig {
+    pub fn recent() -> Self {
+        Self {
+            commitment: CommitmentLevel::Recent,
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub enum CommitmentLevel {
+    Max,
+    Recent,
+}

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -35,6 +35,8 @@ pub mod bank_hash;
 #[cfg(not(feature = "program"))]
 pub mod client;
 #[cfg(not(feature = "program"))]
+pub mod commitment_config;
+#[cfg(not(feature = "program"))]
 pub mod genesis_block;
 #[cfg(not(feature = "program"))]
 pub mod packet;


### PR DESCRIPTION
#### Problem
The RPC API returns results based on either the latest bank, or a bank from a couple blocks ago, instead of results unlikely to be rolled back.

#### Summary of Changes
Add optional commitment configuration to relevant rpc endpoints. Use defaults -- rooted bank -- when config is not provided

Commitment config examples:
* `{"commitment":"max"}`
* `{"commitment":"recent"}`

Fixes #6346 
Replaces #6538 

Follow-up work needed:
- Extend optional params into solana-client (partially done by this PR; determine whether a more general solution is needed)
- Extend optional params into solana-cli
- Apply to PubSub methods
- The client crate is an unholy mess, especially around polling/retries. Clean it up.
