### PR TITLE
Make last shred for an interrupted slot signed + typed

### DIFF
--- a/ledger/src/blocktree.rs
+++ b/ledger/src/blocktree.rs
@@ -3801,7 +3801,7 @@ pub mod tests {
                 slot,
                 next_shred_index as u32,
                 1,
-                None,
+                Some(&[1, 1, 1]),
                 true,
                 true,
             )];

--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -158,22 +158,23 @@ impl Shred {
             data_header.flags |= LAST_SHRED_IN_SLOT
         }
 
+        let mut start = 0;
+        Self::serialize_obj_into(
+            &mut start,
+            SIZE_OF_COMMON_SHRED_HEADER,
+            &mut payload,
+            &common_header,
+        )
+        .expect("Failed to write header into shred buffer");
+        Self::serialize_obj_into(
+            &mut start,
+            SIZE_OF_DATA_SHRED_HEADER,
+            &mut payload,
+            &data_header,
+        )
+        .expect("Failed to write data header into shred buffer");
+
         if let Some(data) = data {
-            let mut start = 0;
-            Self::serialize_obj_into(
-                &mut start,
-                SIZE_OF_COMMON_SHRED_HEADER,
-                &mut payload,
-                &common_header,
-            )
-            .expect("Failed to write header into shred buffer");
-            Self::serialize_obj_into(
-                &mut start,
-                SIZE_OF_DATA_SHRED_HEADER,
-                &mut payload,
-                &data_header,
-            )
-            .expect("Failed to write data header into shred buffer");
             payload[start..start + data.len()].clone_from_slice(data);
         }
 


### PR DESCRIPTION
#### Problem
When a slot is interrupted, the last shred it generates to signal the end of an incomplete slot is not signed, and the type is not serialized into the shred buffer.

#### Summary of Changes
Fix the above

Fixes #
