### PR TITLE
Validators now log to a file by default (use `-o -`/`--log -` for stderr)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1111,6 +1111,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "gag"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "gcc"
 version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3960,8 +3969,10 @@ name = "solana-validator"
 version = "0.21.0"
 dependencies = [
  "bzip2 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "console 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gag 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "indicatif 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.9.22 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5499,6 +5510,7 @@ dependencies = [
 "checksum futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)" = "45dc39533a6cae6da2b56da48edae506bb767ec07370f86f70fc062e9d435869"
 "checksum futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "ab90cde24b3319636588d0c35fe03b1333857621051837ed769faefb4c2162e4"
 "checksum fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+"checksum gag 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "8cc0b9f53275dc5fada808f1d2f82e3688a6c14d735633d1590b7be8eb2307b5"
 "checksum gcc 0.3.55 (registry+https://github.com/rust-lang/crates.io-index)" = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
 "checksum generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
 "checksum generic-array 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0ed1e761351b56f54eb9dcd0cfaca9fd0daecf93918e1cfc01c8a3d26ee7adcd"

--- a/multinode-demo/bootstrap-leader.sh
+++ b/multinode-demo/bootstrap-leader.sh
@@ -37,6 +37,9 @@ while [[ -n $1 ]]; do
     elif [[ $1 = --skip-poh-verify ]]; then
       args+=("$1")
       shift
+    elif [[ $1 = --log ]]; then
+      args+=("$1" "$2")
+      shift 2
     else
       echo "Unknown argument: $1"
       $program --help
@@ -79,6 +82,7 @@ args+=(
   --rpc-drone-address 127.0.0.1:9900
 )
 default_arg --gossip-port 8001
+default_arg --log -
 
 set -x
 # shellcheck disable=SC2086 # Don't want to double quote $program

--- a/multinode-demo/validator.sh
+++ b/multinode-demo/validator.sh
@@ -143,6 +143,9 @@ while [[ -n $1 ]]; do
     elif [[ $1 = --skip-poh-verify ]]; then
       args+=("$1")
       shift
+    elif [[ $1 = --log ]]; then
+      args+=("$1" "$2")
+      shift 2
     elif [[ $1 = -h ]]; then
       usage "$@"
     else
@@ -216,6 +219,7 @@ default_arg --identity "$identity_keypair_path"
 default_arg --voting-keypair "$voting_keypair_path"
 default_arg --storage-keypair "$storage_keypair_path"
 default_arg --ledger "$ledger_dir"
+default_arg --log -
 
 if [[ -n $SOLANA_CUDA ]]; then
   program=$solana_validator_cuda

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -11,6 +11,7 @@ homepage = "https://solana.com/"
 [dependencies]
 bzip2 = "0.3.3"
 clap = "2.33.0"
+chrono = { version = "0.4.9", features = ["serde"] }
 console = "0.9.1"
 log = "0.4.8"
 indicatif = "0.13.0"
@@ -30,3 +31,6 @@ solana-vote-api = { path = "../programs/vote_api", version = "0.21.0" }
 solana-vote-signer = { path = "../vote-signer", version = "0.21.0" }
 tempfile = "3.1.0"
 tar = "0.4.26"
+
+[target."cfg(unix)".dependencies]
+gag = "0.1.10"


### PR DESCRIPTION
It's too easy to forget to capture the `solana-validator` log output, making debugging failures hard.   By default `solana-validator` will now redirect its log output to a file, and a quick `-o -` restores the previous behavior.  `./multinode-demo/` scripts automatically add `-o -` by default to avoid impacting dev workflows. 

Once this lands, https://github.com/solana-labs/tour-de-sol/search?q=%22solana_tds-%24%28date+--utc+%2B%25Y%25m%25d-%25H%25M%25S%29.log%22&unscoped_q=%22solana_tds-%24%28date+--utc+%2B%25Y%25m%25d-%25H%25M%25S%29.log%22 can go away!