### PR TITLE
Don't panic on packet data

### DIFF
--- a/core/src/archiver.rs
+++ b/core/src/archiver.rs
@@ -933,10 +933,13 @@ impl Archiver {
             socket.send_to(&serialized_req, to).unwrap();
             let mut buf = [0; 1024];
             if let Ok((size, _addr)) = socket.recv_from(&mut buf) {
-                return bincode::config()
+                // Ignore bad packet and try again
+                if let Ok(slot) = bincode::config()
                     .limit(PACKET_DATA_SIZE as u64)
                     .deserialize(&buf[..size])
-                    .unwrap();
+                {
+                    return slot;
+                }
             }
             sleep(Duration::from_millis(500));
         }

--- a/core/src/cluster_info.rs
+++ b/core/src/cluster_info.rs
@@ -1183,8 +1183,8 @@ impl ClusterInfo {
                                 "cluster_info-gossip_pull_request_verify_fail",
                                 1
                             );
-                        } else if caller.contact_info().is_some() {
-                            if caller.contact_info().unwrap().id == me.read().unwrap().gossip.id {
+                        } else if let Some(contact_info) = caller.contact_info() {
+                            if contact_info.id == me.read().unwrap().gossip.id {
                                 warn!("PullRequest ignored, I'm talking to myself");
                                 inc_new_counter_debug!("cluster_info-window-request-loopback", 1);
                             } else {

--- a/core/src/sigverify_shreds.rs
+++ b/core/src/sigverify_shreds.rs
@@ -45,9 +45,7 @@ impl ShredSigVerifier {
                     let slot_end = slot_start + size_of::<u64>();
                     trace!("slot {} {}", slot_start, slot_end,);
                     if slot_end <= packet.meta.size {
-                        let slot: u64 =
-                            limited_deserialize(&packet.data[slot_start..slot_end]).ok()?;
-                        Some(slot)
+                        limited_deserialize(&packet.data[slot_start..slot_end]).ok()
                     } else {
                         None
                     }

--- a/sdk/src/short_vec.rs
+++ b/sdk/src/short_vec.rs
@@ -179,8 +179,8 @@ impl<'de, T: Deserialize<'de>> Deserialize<'de> for ShortVec<T> {
 /// Return the decoded value and how many bytes it consumed.
 pub fn decode_len(bytes: &[u8]) -> Result<(usize, usize), Box<bincode::ErrorKind>> {
     let short_len: ShortU16 = bincode::deserialize(bytes)?;
-    let num_bytes = bincode::serialized_size(&short_len).unwrap() as usize;
-    Ok((short_len.0 as usize, num_bytes))
+    let num_bytes = bincode::serialized_size(&short_len)?;
+    Ok((short_len.0 as usize, num_bytes as usize))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
#### Problem

Malformed or malicious packets could cause panics

#### Summary of Changes

Handle bad packets gracefully.

In general packet handling was analyzed looking for cases where a bad packet would cause a panic.  The changes in this PR are more nits that were found during that analysis.

One question is core/src/archiver.rs - download_from_archiver().  This function returns a result but is full of calls to `unwrap()` or functions that can panic.  Should this function be allowed to panic?

Fixes #1274
