### PR TITLE
Add reference tick to data shreds

### DIFF
--- a/core/benches/shredder.rs
+++ b/core/benches/shredder.rs
@@ -35,7 +35,7 @@ fn bench_shredder_ticks(bencher: &mut Bencher) {
     let num_ticks = max_ticks_per_n_shreds(1) * num_shreds as u64;
     let entries = create_ticks(num_ticks, 0, Hash::default());
     bencher.iter(|| {
-        let shredder = Shredder::new(1, 0, RECOMMENDED_FEC_RATE, kp.clone()).unwrap();
+        let shredder = Shredder::new(1, 0, RECOMMENDED_FEC_RATE, kp.clone(), 0).unwrap();
         shredder.entries_to_shreds(&entries, true, 0);
     })
 }
@@ -50,7 +50,7 @@ fn bench_shredder_large_entries(bencher: &mut Bencher) {
     let entries = make_large_unchained_entries(txs_per_entry, num_entries);
     // 1Mb
     bencher.iter(|| {
-        let shredder = Shredder::new(1, 0, RECOMMENDED_FEC_RATE, kp.clone()).unwrap();
+        let shredder = Shredder::new(1, 0, RECOMMENDED_FEC_RATE, kp.clone(), 0).unwrap();
         shredder.entries_to_shreds(&entries, true, 0);
     })
 }
@@ -63,7 +63,7 @@ fn bench_deshredder(bencher: &mut Bencher) {
     let num_shreds = ((10000 * 1000) + (shred_size - 1)) / shred_size;
     let num_ticks = max_ticks_per_n_shreds(1) * num_shreds as u64;
     let entries = create_ticks(num_ticks, 0, Hash::default());
-    let shredder = Shredder::new(1, 0, RECOMMENDED_FEC_RATE, kp).unwrap();
+    let shredder = Shredder::new(1, 0, RECOMMENDED_FEC_RATE, kp, 0).unwrap();
     let data_shreds = shredder.entries_to_shreds(&entries, true, 0).0;
     bencher.iter(|| {
         let raw = &mut Shredder::deshred(&data_shreds).unwrap();
@@ -75,7 +75,7 @@ fn bench_deshredder(bencher: &mut Bencher) {
 fn bench_deserialize_hdr(bencher: &mut Bencher) {
     let data = vec![0; SIZE_OF_DATA_SHRED_PAYLOAD];
 
-    let shred = Shred::new_from_data(2, 1, 1, Some(&data), true, true);
+    let shred = Shred::new_from_data(2, 1, 1, Some(&data), true, true, 0);
 
     bencher.iter(|| {
         let payload = shred.payload.clone();

--- a/core/src/broadcast_stage/broadcast_fake_blobs_run.rs
+++ b/core/src/broadcast_stage/broadcast_fake_blobs_run.rs
@@ -44,6 +44,7 @@ impl BroadcastRun for BroadcastFakeBlobsRun {
             bank.parent().unwrap().slot(),
             RECOMMENDED_FEC_RATE,
             keypair.clone(),
+            (bank.tick_height() % bank.ticks_per_slot()) as u8,
         )
         .expect("Expected to create a new shredder");
 

--- a/core/src/broadcast_stage/fail_entry_verification_broadcast_run.rs
+++ b/core/src/broadcast_stage/fail_entry_verification_broadcast_run.rs
@@ -42,6 +42,7 @@ impl BroadcastRun for FailEntryVerificationBroadcastRun {
             bank.parent().unwrap().slot(),
             RECOMMENDED_FEC_RATE,
             keypair.clone(),
+            (bank.tick_height() % bank.ticks_per_slot()) as u8,
         )
         .expect("Expected to create a new shredder");
 

--- a/core/src/chacha.rs
+++ b/core/src/chacha.rs
@@ -166,7 +166,7 @@ mod tests {
         hasher.hash(&buf[..size]);
 
         //  golden needs to be updated if blob stuff changes....
-        let golden: Hash = "BdmY3efqu7zbnFuGRAeFANwa35HkDdQ7hwhYez3xGXiM"
+        let golden: Hash = "HLzH7Nrh4q2K5WTh3e9vPNFZ1QVYhVDRMN9u5v51GqpJ"
             .parse()
             .unwrap();
 

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -1137,7 +1137,7 @@ mod test {
             let payload_len = SIZE_OF_DATA_SHRED_PAYLOAD;
             let gibberish = [0xa5u8; PACKET_DATA_SIZE];
             let mut data_header = DataShredHeader::default();
-            data_header.flags = DATA_COMPLETE_SHRED;
+            data_header.flags |= DATA_COMPLETE_SHRED;
             let mut shred = Shred::new_empty_from_header(
                 ShredCommonHeader::default(),
                 data_header,

--- a/core/src/sigverify_shreds.rs
+++ b/core/src/sigverify_shreds.rs
@@ -96,8 +96,15 @@ pub mod tests {
     #[test]
     fn test_sigverify_shreds_read_slots() {
         solana_logger::setup();
-        let mut shred =
-            Shred::new_from_data(0xdeadc0de, 0xc0de, 0xdead, Some(&[1, 2, 3, 4]), true, true);
+        let mut shred = Shred::new_from_data(
+            0xdeadc0de,
+            0xc0de,
+            0xdead,
+            Some(&[1, 2, 3, 4]),
+            true,
+            true,
+            0,
+        );
         let mut batch = [Packets::default(), Packets::default()];
 
         let keypair = Keypair::new();
@@ -106,8 +113,15 @@ pub mod tests {
         batch[0].packets[0].data[0..shred.payload.len()].copy_from_slice(&shred.payload);
         batch[0].packets[0].meta.size = shred.payload.len();
 
-        let mut shred =
-            Shred::new_from_data(0xc0dedead, 0xc0de, 0xdead, Some(&[1, 2, 3, 4]), true, true);
+        let mut shred = Shred::new_from_data(
+            0xc0dedead,
+            0xc0de,
+            0xdead,
+            Some(&[1, 2, 3, 4]),
+            true,
+            true,
+            0,
+        );
         Shredder::sign_shred(&keypair, &mut shred);
         batch[1].packets.resize(1, Packet::default());
         batch[1].packets[0].data[0..shred.payload.len()].copy_from_slice(&shred.payload);
@@ -130,12 +144,12 @@ pub mod tests {
         let mut batch = vec![Packets::default()];
         batch[0].packets.resize(2, Packet::default());
 
-        let mut shred = Shred::new_from_data(0, 0xc0de, 0xdead, Some(&[1, 2, 3, 4]), true, true);
+        let mut shred = Shred::new_from_data(0, 0xc0de, 0xdead, Some(&[1, 2, 3, 4]), true, true, 0);
         Shredder::sign_shred(&leader_keypair, &mut shred);
         batch[0].packets[0].data[0..shred.payload.len()].copy_from_slice(&shred.payload);
         batch[0].packets[0].meta.size = shred.payload.len();
 
-        let mut shred = Shred::new_from_data(0, 0xbeef, 0xc0de, Some(&[1, 2, 3, 4]), true, true);
+        let mut shred = Shred::new_from_data(0, 0xbeef, 0xc0de, Some(&[1, 2, 3, 4]), true, true, 0);
         let wrong_keypair = Keypair::new();
         Shredder::sign_shred(&wrong_keypair, &mut shred);
         batch[0].packets[1].data[0..shred.payload.len()].copy_from_slice(&shred.payload);

--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -315,7 +315,7 @@ mod test {
         parent: Slot,
         keypair: &Arc<Keypair>,
     ) -> Vec<Shred> {
-        let shredder = Shredder::new(slot, parent, 0.0, keypair.clone())
+        let shredder = Shredder::new(slot, parent, 0.0, keypair.clone(), 0)
             .expect("Failed to create entry shredder");
         shredder.entries_to_shreds(&entries, true, 0).0
     }

--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -51,8 +51,9 @@ pub const MAX_DATA_SHREDS_PER_FEC_BLOCK: u32 = 16;
 /// Based on rse benchmarks, the optimal erasure config uses 16 data shreds and 4 coding shreds
 pub const RECOMMENDED_FEC_RATE: f32 = 0.25;
 
-const LAST_SHRED_IN_SLOT: u8 = 0b0000_0001;
-pub const DATA_COMPLETE_SHRED: u8 = 0b0000_0010;
+pub const SHRED_TICK_REFERENCE_MASK: u8 = 0b0011_1111;
+const LAST_SHRED_IN_SLOT: u8 = 0b1000_0000;
+pub const DATA_COMPLETE_SHRED: u8 = 0b0100_0000;
 
 #[derive(Debug)]
 pub enum ShredError {
@@ -143,6 +144,7 @@ impl Shred {
         data: Option<&[u8]>,
         is_last_data: bool,
         is_last_in_slot: bool,
+        reference_tick: u8,
     ) -> Self {
         let mut payload = vec![0; PACKET_DATA_SIZE];
         let mut common_header = ShredCommonHeader::default();
@@ -151,6 +153,7 @@ impl Shred {
 
         let mut data_header = DataShredHeader::default();
         data_header.parent_offset = parent_offset;
+        data_header.flags = reference_tick.min(SHRED_TICK_REFERENCE_MASK);
 
         if is_last_data {
             data_header.flags |= DATA_COMPLETE_SHRED
@@ -336,6 +339,14 @@ impl Shred {
         }
     }
 
+    pub fn reference_tick(&self) -> u8 {
+        if self.is_data() {
+            self.data_header.flags & SHRED_TICK_REFERENCE_MASK
+        } else {
+            SHRED_TICK_REFERENCE_MASK
+        }
+    }
+
     pub fn verify(&self, pubkey: &Pubkey) -> bool {
         self.signature()
             .verify(pubkey.as_ref(), &self.payload[SIZE_OF_SIGNATURE..])
@@ -349,6 +360,7 @@ pub struct Shredder {
     fec_rate: f32,
     keypair: Arc<Keypair>,
     pub signing_coding_time: u128,
+    reference_tick: u8,
 }
 
 impl Shredder {
@@ -357,6 +369,7 @@ impl Shredder {
         parent_slot: Slot,
         fec_rate: f32,
         keypair: Arc<Keypair>,
+        reference_tick: u8,
     ) -> Result<Self> {
         if fec_rate > 1.0 || fec_rate < 0.0 {
             Err(ShredError::InvalidFecRate(fec_rate))
@@ -369,6 +382,7 @@ impl Shredder {
                 fec_rate,
                 keypair,
                 signing_coding_time: 0,
+                reference_tick,
             })
         }
     }
@@ -412,6 +426,7 @@ impl Shredder {
                             Some(shred_data),
                             is_last_data,
                             is_last_in_slot,
+                            self.reference_tick,
                         );
 
                         Shredder::sign_shred(&self.keypair, &mut shred);
@@ -814,7 +829,7 @@ pub mod tests {
 
         // Test that parent cannot be > current slot
         assert_matches!(
-            Shredder::new(slot, slot + 1, 1.00, keypair.clone()),
+            Shredder::new(slot, slot + 1, 1.00, keypair.clone(), 0),
             Err(ShredError::SlotTooLow {
                 slot: _,
                 parent_slot: _,
@@ -822,7 +837,7 @@ pub mod tests {
         );
         // Test that slot - parent cannot be > u16 MAX
         assert_matches!(
-            Shredder::new(slot, slot - 1 - 0xffff, 1.00, keypair.clone()),
+            Shredder::new(slot, slot - 1 - 0xffff, 1.00, keypair.clone(), 0),
             Err(ShredError::SlotTooLow {
                 slot: _,
                 parent_slot: _,
@@ -831,7 +846,7 @@ pub mod tests {
 
         let fec_rate = 0.25;
         let parent_slot = slot - 5;
-        let shredder = Shredder::new(slot, parent_slot, fec_rate, keypair.clone())
+        let shredder = Shredder::new(slot, parent_slot, fec_rate, keypair.clone(), 0)
             .expect("Failed in creating shredder");
 
         let entries: Vec<_> = (0..5)
@@ -906,7 +921,7 @@ pub mod tests {
         let slot = 1;
 
         let parent_slot = 0;
-        let shredder = Shredder::new(slot, parent_slot, 0.0, keypair.clone())
+        let shredder = Shredder::new(slot, parent_slot, 0.0, keypair.clone(), 0)
             .expect("Failed in creating shredder");
 
         let entries: Vec<_> = (0..5)
@@ -927,17 +942,78 @@ pub mod tests {
     }
 
     #[test]
+    fn test_shred_reference_tick() {
+        let keypair = Arc::new(Keypair::new());
+        let slot = 1;
+
+        let parent_slot = 0;
+        let shredder = Shredder::new(slot, parent_slot, 0.0, keypair.clone(), 5)
+            .expect("Failed in creating shredder");
+
+        let entries: Vec<_> = (0..5)
+            .map(|_| {
+                let keypair0 = Keypair::new();
+                let keypair1 = Keypair::new();
+                let tx0 =
+                    system_transaction::transfer(&keypair0, &keypair1.pubkey(), 1, Hash::default());
+                Entry::new(&Hash::default(), 1, vec![tx0])
+            })
+            .collect();
+
+        let data_shreds = shredder.entries_to_shreds(&entries, true, 0).0;
+        data_shreds.iter().for_each(|s| {
+            assert_eq!(s.reference_tick(), 5);
+        });
+
+        let deserialized_shred =
+            Shred::new_from_serialized_shred(data_shreds.last().unwrap().payload.clone()).unwrap();
+        assert_eq!(deserialized_shred.reference_tick(), 5);
+    }
+
+    #[test]
+    fn test_shred_reference_tick_overflow() {
+        let keypair = Arc::new(Keypair::new());
+        let slot = 1;
+
+        let parent_slot = 0;
+        let shredder = Shredder::new(slot, parent_slot, 0.0, keypair.clone(), u8::max_value())
+            .expect("Failed in creating shredder");
+
+        let entries: Vec<_> = (0..5)
+            .map(|_| {
+                let keypair0 = Keypair::new();
+                let keypair1 = Keypair::new();
+                let tx0 =
+                    system_transaction::transfer(&keypair0, &keypair1.pubkey(), 1, Hash::default());
+                Entry::new(&Hash::default(), 1, vec![tx0])
+            })
+            .collect();
+
+        let data_shreds = shredder.entries_to_shreds(&entries, true, 0).0;
+        data_shreds.iter().for_each(|s| {
+            assert_eq!(s.reference_tick(), SHRED_TICK_REFERENCE_MASK);
+        });
+
+        let deserialized_shred =
+            Shred::new_from_serialized_shred(data_shreds.last().unwrap().payload.clone()).unwrap();
+        assert_eq!(
+            deserialized_shred.reference_tick(),
+            SHRED_TICK_REFERENCE_MASK
+        );
+    }
+
+    #[test]
     fn test_data_and_code_shredder() {
         let keypair = Arc::new(Keypair::new());
 
         let slot = 0x123456789abcdef0;
         // Test that FEC rate cannot be > 1.0
         assert_matches!(
-            Shredder::new(slot, slot - 5, 1.001, keypair.clone()),
+            Shredder::new(slot, slot - 5, 1.001, keypair.clone(), 0),
             Err(ShredError::InvalidFecRate(_))
         );
 
-        let shredder = Shredder::new(0x123456789abcdef0, slot - 5, 1.0, keypair.clone())
+        let shredder = Shredder::new(0x123456789abcdef0, slot - 5, 1.0, keypair.clone(), 0)
             .expect("Failed in creating shredder");
 
         // Create enough entries to make > 1 shred
@@ -979,7 +1055,7 @@ pub mod tests {
     fn test_recovery_and_reassembly() {
         let keypair = Arc::new(Keypair::new());
         let slot = 0x123456789abcdef0;
-        let shredder = Shredder::new(slot, slot - 5, 1.0, keypair.clone())
+        let shredder = Shredder::new(slot, slot - 5, 1.0, keypair.clone(), 0)
             .expect("Failed in creating shredder");
 
         let keypair0 = Keypair::new();
@@ -1225,7 +1301,7 @@ pub mod tests {
     fn test_multi_fec_block_coding() {
         let keypair = Arc::new(Keypair::new());
         let slot = 0x123456789abcdef0;
-        let shredder = Shredder::new(slot, slot - 5, 1.0, keypair.clone())
+        let shredder = Shredder::new(slot, slot - 5, 1.0, keypair.clone(), 0)
             .expect("Failed in creating shredder");
 
         let num_fec_sets = 100;

--- a/ledger/src/sigverify_shreds.rs
+++ b/ledger/src/sigverify_shreds.rs
@@ -500,7 +500,8 @@ pub mod tests {
         solana_logger::setup();
         let mut packet = Packet::default();
         let slot = 0xdeadc0de;
-        let mut shred = Shred::new_from_data(slot, 0xc0de, 0xdead, Some(&[1, 2, 3, 4]), true, true);
+        let mut shred =
+            Shred::new_from_data(slot, 0xc0de, 0xdead, Some(&[1, 2, 3, 4]), true, true, 0);
         assert_eq!(shred.slot(), slot);
         let keypair = Keypair::new();
         Shredder::sign_shred(&keypair, &mut shred);
@@ -533,7 +534,8 @@ pub mod tests {
         solana_logger::setup();
         let mut batch = [Packets::default()];
         let slot = 0xdeadc0de;
-        let mut shred = Shred::new_from_data(slot, 0xc0de, 0xdead, Some(&[1, 2, 3, 4]), true, true);
+        let mut shred =
+            Shred::new_from_data(slot, 0xc0de, 0xdead, Some(&[1, 2, 3, 4]), true, true, 0);
         let keypair = Keypair::new();
         Shredder::sign_shred(&keypair, &mut shred);
         batch[0].packets.resize(1, Packet::default());
@@ -577,7 +579,8 @@ pub mod tests {
 
         let mut batch = [Packets::default()];
         let slot = 0xdeadc0de;
-        let mut shred = Shred::new_from_data(slot, 0xc0de, 0xdead, Some(&[1, 2, 3, 4]), true, true);
+        let mut shred =
+            Shred::new_from_data(slot, 0xc0de, 0xdead, Some(&[1, 2, 3, 4]), true, true, 0);
         let keypair = Keypair::new();
         Shredder::sign_shred(&keypair, &mut shred);
         batch[0].packets.resize(1, Packet::default());
@@ -656,7 +659,7 @@ pub mod tests {
         let mut batch = [Packets::default()];
         let slot = 0xdeadc0de;
         let keypair = Keypair::new();
-        let shred = Shred::new_from_data(slot, 0xc0de, 0xdead, Some(&[1, 2, 3, 4]), true, true);
+        let shred = Shred::new_from_data(slot, 0xc0de, 0xdead, Some(&[1, 2, 3, 4]), true, true, 0);
         batch[0].packets.resize(1, Packet::default());
         batch[0].packets[0].data[0..shred.payload.len()].copy_from_slice(&shred.payload);
         batch[0].packets[0].meta.size = shred.payload.len();
@@ -713,7 +716,7 @@ pub mod tests {
         let mut batch = [Packets::default()];
         let slot = 0xdeadc0de;
         let keypair = Keypair::new();
-        let shred = Shred::new_from_data(slot, 0xc0de, 0xdead, Some(&[1, 2, 3, 4]), true, true);
+        let shred = Shred::new_from_data(slot, 0xc0de, 0xdead, Some(&[1, 2, 3, 4]), true, true, 0);
         batch[0].packets.resize(1, Packet::default());
         batch[0].packets[0].data[0..shred.payload.len()].copy_from_slice(&shred.payload);
         batch[0].packets[0].meta.size = shred.payload.len();


### PR DESCRIPTION
#### Problem
Need a mechanism to associate time when a shred is generated. This will be useful in delaying repairs for shreds, based on the creation time.

#### Summary of Changes
Added a reference tick to data shreds. The reference tick corresponds to the bank tick when the shredder was created. 

Fixes #
