### PR TITLE
client test case(s)

### DIFF
--- a/core/tests/client.rs
+++ b/core/tests/client.rs
@@ -1,0 +1,57 @@
+use solana_client::rpc_client::RpcClient;
+use solana_core::validator::new_validator_for_tests;
+use solana_sdk::pubkey::Pubkey;
+use solana_sdk::signature::KeypairUtil;
+use solana_sdk::system_transaction;
+use std::fs::remove_dir_all;
+use std::thread::sleep;
+use std::time::{Duration, Instant};
+
+#[test]
+fn test_rpc_client() {
+    solana_logger::setup();
+
+    let (server, leader_data, alice, ledger_path) = new_validator_for_tests();
+    let bob_pubkey = Pubkey::new_rand();
+
+    let client = RpcClient::new_socket(leader_data.rpc);
+
+    assert_eq!(
+        client.get_version().unwrap(),
+        format!("{{\"solana-core\":\"{}\"}}", env!("CARGO_PKG_VERSION"))
+    );
+
+    assert_eq!(client.get_balance(&bob_pubkey).unwrap(), 0);
+
+    assert_eq!(client.get_balance(&alice.pubkey()).unwrap(), 10000);
+
+    let (blockhash, _fee_calculator) = client.get_recent_blockhash().unwrap();
+
+    let tx = system_transaction::transfer(&alice, &bob_pubkey, 20, blockhash);
+    let signature = client.send_transaction(&tx).unwrap();
+
+    let mut confirmed_tx = false;
+
+    let now = Instant::now();
+    while now.elapsed().as_secs() <= 20 {
+        let response = client.confirm_transaction(signature.as_str());
+
+        match response {
+            Ok(true) => {
+                confirmed_tx = true;
+                break;
+            }
+            _ => (),
+        }
+
+        sleep(Duration::from_millis(500));
+    }
+
+    assert!(confirmed_tx);
+
+    assert_eq!(client.get_balance(&bob_pubkey).unwrap(), 20);
+    assert_eq!(client.get_balance(&alice.pubkey()).unwrap(), 9980);
+
+    server.close().unwrap();
+    remove_dir_all(ledger_path).unwrap();
+}


### PR DESCRIPTION
#### Problem

* we don't have minimal targeted tests for rust client before doing the refactoring for #6716 
* found a case where the rust client for `get_balance` calls `get_account_info`

#### Summary of Changes

* add minimal targeted tests for `get_balance`, `confirm_transaction`, `get_recent_blockhash`, `get_account_info`
* modify `get_balance` to call `getBalance` RPC

Fixes # N/A
