### PR TITLE
Add net/ support for reusable identity keypairs

### DIFF
--- a/ci/testnet-deploy.sh
+++ b/ci/testnet-deploy.sh
@@ -262,6 +262,11 @@ trap shutdown EXIT INT
 
 set -x
 
+# Fetch reusable testnet keypairs
+if [[ ! -d net/keypairs ]]; then
+  git clone git@github.com:solana-labs/testnet-keypairs.git net/keypairs
+fi
+
 # Build a string to pass zone opts to $cloudProvider.sh: "-z zone1 -z zone2 ..."
 zone_args=()
 for val in "${zone[@]}"; do

--- a/multinode-demo/setup.sh
+++ b/multinode-demo/setup.sh
@@ -10,9 +10,18 @@ rm -rf "$SOLANA_CONFIG_DIR"/bootstrap-leader
 mkdir -p "$SOLANA_CONFIG_DIR"/bootstrap-leader
 
 # Create genesis ledger
-$solana_keygen new -f -o "$SOLANA_CONFIG_DIR"/mint-keypair.json
+if [[ -r $MINT_KEYPAIR ]]; then
+  cp -f "$MINT_KEYPAIR" "$SOLANA_CONFIG_DIR"/mint-keypair.json
+else
+  $solana_keygen new -f -o "$SOLANA_CONFIG_DIR"/mint-keypair.json
+fi
 
-$solana_keygen new -o "$SOLANA_CONFIG_DIR"/bootstrap-leader/identity-keypair.json
+if [[ -f $BOOTSTRAP_LEADER_IDENTITY_KEYPAIR ]]; then
+  cp -f "$BOOTSTRAP_LEADER_IDENTITY_KEYPAIR" "$SOLANA_CONFIG_DIR"/bootstrap-leader/identity-keypair.json
+else
+  $solana_keygen new -o "$SOLANA_CONFIG_DIR"/bootstrap-leader/identity-keypair.json
+fi
+
 $solana_keygen new -o "$SOLANA_CONFIG_DIR"/bootstrap-leader/vote-keypair.json
 $solana_keygen new -o "$SOLANA_CONFIG_DIR"/bootstrap-leader/stake-keypair.json
 $solana_keygen new -o "$SOLANA_CONFIG_DIR"/bootstrap-leader/storage-keypair.json


### PR DESCRIPTION
The ephemeral identity keypairs for the persistent and TdS testnets make it harder than it needs to be to pour over log files.  To improve quality of life, some identity keypairs have been ground out:
* bootstrap leader identity starts with `boot`
* validator 1-9 identities start with `va11`, `val12`, ..., `va19`
* blockstreamer identity starts with `rpc1`

Example:
```
solana --url http://35.247.91.234:8899 show-validators
RPC Endpoint: http://35.247.91.234:8899
Active Stake: 0.000530303 SOL

  Identity Pubkey                               Vote Account Pubkey                           Commission    Last Vote   Root Block  Active Stake
  boot1Z6jb15CLqpaMTn2CxktktwZpRAVAgHZEW6SxQ7   64bPCnZDHVJbuSHCwhNwfJ5MPmn9XBTAo6qh7PFJjHJx    0 ( 0.0%)         390          359  0.000424243 SOL (80.00%)
  va134udXLzWi4nh2bJ81ajE3yBi88Sm6dVnC5LgL8Qb   FbYHrz3SeAXMZDTcpxJdPjZ9EpuwJmF9egzm7gq5cerx  127 (49.8%)         387          356  0.000021212 SOL (4.00%)
  va15TFvvi8eAz3xVwYDaXPjxqmoWHZWhgRXJyeeHK41   s2apE2cJi4Ak6CXFri6dPtPoTf2uR31L8fzFPWYmW2E   127 (49.8%)         389          358  0.000021212 SOL (4.00%)
  va12u4o9DipLEB2z4fuoHszroq1U9NcAB9aooFDPJSf   ERTVCKcvF2heKjLpKXnrvBYEptFZbpscYebPq195tb7a  127 (49.8%)         388          357  0.000021212 SOL (4.00%)
  va11wrZ2pD668e2dKXohuXiyALPxfVQjjH7zzpePavQ   7pEi2A38jC2aheoYKVTFVbaE4Jytvzw7ekmcg5rJ6QA3  127 (49.8%)         388          357  0.000021212 SOL (4.00%)
  va14Az8gSxeGHozLUaT4qp4AUFERvxq4YhXS2efCQVv   7WQvqRjYGR63PZ7RqQaR5N57Mr9MWwakTT9kq3aBVJPK  127 (49.8%)         389          358  0.000021212 SOL (4.00%)
! rpc1io1gmhuEq26wTBARGJfGGw48S7GYaHfKVEf9Dvv   7vEja9mjkReEudEAmXkzQhhr7Wx6jaWPf9WfYuzyKdfd  127 (49.8%)           -            -            -
```
