### PR TITLE
Add inflation to epoch phases

### DIFF
--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -382,12 +382,15 @@ fn main() -> Result<(), Box<dyn error::Error>> {
     } else {
         OperatingMode::SoftLaunch
     };
-    let native_instruction_processors = solana_genesis_programs::get(operating_mode, 0).unwrap();
+    let native_instruction_processors =
+        solana_genesis_programs::get_programs(operating_mode, 0).unwrap();
+    let inflation = solana_genesis_programs::get_inflation(operating_mode, 0).unwrap();
     let mut genesis_block = GenesisBlock {
         accounts,
         native_instruction_processors,
         ticks_per_slot,
         epoch_schedule,
+        inflation,
         fee_calculator,
         rent,
         poh_config,

--- a/local_cluster/src/local_cluster.rs
+++ b/local_cluster/src/local_cluster.rs
@@ -151,12 +151,15 @@ impl LocalCluster {
         match genesis_block.operating_mode {
             OperatingMode::SoftLaunch => {
                 genesis_block.native_instruction_processors =
-                    solana_genesis_programs::get(genesis_block.operating_mode, 0).unwrap()
+                    solana_genesis_programs::get_programs(genesis_block.operating_mode, 0).unwrap()
             }
             // create_genesis_block_with_leader() assumes OperatingMode::Development so do
             // nothing...
             OperatingMode::Development => (),
         }
+
+        genesis_block.inflation =
+            solana_genesis_programs::get_inflation(genesis_block.operating_mode, 0).unwrap();
 
         genesis_block
             .native_instruction_processors

--- a/sdk/src/inflation.rs
+++ b/sdk/src/inflation.rs
@@ -42,6 +42,16 @@ impl Default for Inflation {
 }
 
 impl Inflation {
+    pub fn new_disabled() -> Self {
+        Self {
+            initial: 0.0,
+            terminal: 0.0,
+            taper: 0.0,
+            foundation: 0.0,
+            foundation_term: 0.0,
+            storage: 0.0,
+        }
+    }
     /// inflation rate at year
     pub fn total(&self, year: f64) -> f64 {
         let tapered = self.initial * ((1.0 - self.taper).powf(year));


### PR DESCRIPTION
#### Problem

No mechanism to set inflation depending on epoch phases

#### Summary of Changes

Similar too how programs are enabled depending on epoch, add a mechanism to allow inflation to be set depending on the epoch.  Currently, inflation is disabled during the initial epoch phase

Fixes #6683
