### PR TITLE
Make solana-validator check vote account at start

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -422,7 +422,7 @@ impl Validator {
             } else {
                 error!("Vote account not found: {}:", vote_account);
             }
-            process::exit(1);
+            panic!("aaaaaaa");
         }
     }
 }

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -181,7 +181,11 @@ impl Validator {
         let bank_info = &bank_forks_info[0];
         let bank = bank_forks[bank_info.bank_slot].clone();
 
-        Self::check_vote_account(&bank, vote_account);
+        // Only do this check if started as a bootstrap leader.
+        // Normal validators can encounter newly-created vote accounts, which to be synced with this new validator.
+        if entrypoint_info_option.is_none() {
+          Self::check_vote_account(&bank, vote_account);
+        }
 
         let bank_forks = Arc::new(RwLock::new(bank_forks));
         let block_commitment_cache = Arc::new(RwLock::new(BlockCommitmentCache::default()));

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -184,7 +184,7 @@ impl Validator {
         // Only do this check if started as a bootstrap leader.
         // Normal validators can encounter newly-created vote accounts, which to be synced with this new validator.
         if entrypoint_info_option.is_none() {
-          Self::check_vote_account(&bank, vote_account);
+            Self::check_vote_account(&bank, vote_account);
         }
 
         let bank_forks = Arc::new(RwLock::new(bank_forks));

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -584,6 +584,7 @@ mod tests {
         } = create_genesis_config_with_leader(10_000, &leader_keypair.pubkey(), 1000);
         let (validator_ledger_path, _blockhash) = create_new_tmp_ledger!(&genesis_config);
 
+        let voting_keypair = Arc::new(voting_keypair);
         let storage_keypair = Arc::new(Keypair::new());
         let validator = Validator::new(
             validator_node,

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -577,14 +577,13 @@ mod tests {
 
         // Abuse leader_keypair which is backed by voting_keypair instead of manually creating
         let validator_node = Node::new_localhost_with_pubkey(&leader_keypair.pubkey());
-        let GenesiConfigInfo {
+        let GenesisConfigInfo {
             genesis_config,
             voting_keypair,
             ..
-        } = create_genesis_block_with_leader(10_000, &leader_keypair.pubkey(), 1000);
+        } = create_genesis_config_with_leader(10_000, &leader_keypair.pubkey(), 1000);
         let (validator_ledger_path, _blockhash) = create_new_tmp_ledger!(&genesis_config);
 
-        let voting_keypair = Arc::new(voting_keypair);
         let storage_keypair = Arc::new(Keypair::new());
         let validator = Validator::new(
             validator_node,

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -183,7 +183,7 @@ impl Validator {
 
         // Only do this check if started as a bootstrap leader.
         // Normal validators can encounter newly-created vote accounts, which to be synced with this new validator.
-        if entrypoint_info_option.is_none() {
+        if entrypoint_info_option.is_none() && !config.voting_disabled {
             Self::check_vote_account(&bank, vote_account);
         }
 

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -420,7 +420,7 @@ impl Validator {
                     found_account.owner, vote_account
                 );
             } else {
-                error!("Vote account not found: {}:", vote_account);
+                error!("Vote account not found: {}", vote_account);
             }
             panic!("aaaaaaa");
         }

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -723,12 +723,17 @@ pub fn main() {
                 });
             }
 
-            let genesis_hash =
-                initialize_ledger_path(&rpc_addr, &rpc_client, &ledger_path, no_genesis_fetch, no_snapshot_fetch)
-                    .unwrap_or_else(|err| {
-                        error!("Failed to download ledger: {}", err);
-                        exit(1);
-                    });
+            let genesis_hash = initialize_ledger_path(
+                &rpc_addr,
+                &rpc_client,
+                &ledger_path,
+                no_genesis_fetch,
+                no_snapshot_fetch,
+            )
+            .unwrap_or_else(|err| {
+                error!("Failed to download ledger: {}", err);
+                exit(1);
+            });
 
             if let Some(expected_genesis_hash) = validator_config.expected_genesis_hash {
                 if expected_genesis_hash != genesis_hash {

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -244,6 +244,7 @@ fn initialize_ledger_path(
     rpc_addr: &std::net::SocketAddr,
     rpc_client: &RpcClient,
     ledger_path: &Path,
+    no_genesis_fetch: bool,
     no_snapshot_fetch: bool,
 ) -> Result<Hash, String> {
     let genesis_hash = rpc_client

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -184,9 +184,16 @@ fn create_rpc_client(
 
     let rpc_addr = nodes
         .iter()
-        .filter_map(ContactInfo::valid_client_facing_addr)
-        .map(|addrs| addrs.0)
-        .find(|rpc_addr| rpc_addr.ip() == entrypoint.gossip.ip());
+        .filter_map(|contact_info| {
+            if contact_info.gossip == entrypoint.gossip
+                && ContactInfo::is_valid_address(&contact_info.rpc)
+            {
+                Some(contact_info.rpc)
+            } else {
+                None
+            }
+        })
+        .next()
 
     if let Some(rpc_addr) = rpc_addr {
         Ok((rpc_addr, RpcClient::new_socket(rpc_addr)))

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -721,11 +721,10 @@ pub fn main() {
             &udp_sockets,
         );
 
-        let (rpc_addr, rpc_client) = create_rpc_client(cluster_entrypoint)
-            .unwrap_or_else(|err| {
-                error!("unable to create rpc client: {}", err);
-                std::process::exit(1);
-            });
+        let (rpc_addr, rpc_client) = create_rpc_client(cluster_entrypoint).unwrap_or_else(|err| {
+            error!("unable to create rpc client: {}", err);
+            std::process::exit(1);
+        });
 
         if !validator_config.voting_disabled {
             check_vote_account(

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -632,7 +632,6 @@ pub fn main() {
         voting_keypair.pubkey()
     });
 
-
     solana_metrics::set_host_id(identity_keypair.pubkey().to_string());
     solana_metrics::set_panic_hook("validator");
 

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -219,7 +219,7 @@ fn initialize_ledger_path(
     ledger_path: &Path,
     no_snapshot_fetch: bool,
 ) -> Result<Hash, String> {
-    let genesis_blockhash = rpc_client
+    let genesis_hash = rpc_client
         .get_genesis_blockhash()
         .map_err(|err| err.to_string())?;
 

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -241,8 +241,8 @@ fn check_vote_account(
         }
         if found_vote_account.node_pubkey != *node_pubkey {
             return Err(format!(
-                "account's node pubkey does ({}) not match to the given identity keypair ({}).",
-                found_vote_account.authorized_voter, node_pubkey
+                "account's node pubkey ({}) does not match to the given identity keypair ({}).",
+                found_vote_account.node_pubkey, node_pubkey
             ));
         }
     } else {

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -224,15 +224,13 @@ fn check_vote_account(
         if found_vote_account.authorized_voter != *voting_pubkey {
             return Err(format!(
                 "account's authorized voter ({}) does not match to the given voting keypair ({}).",
-                found_vote_account.authorized_voter,
-                voting_pubkey
+                found_vote_account.authorized_voter, voting_pubkey
             ));
         }
         if found_vote_account.node_pubkey != *node_pubkey {
             return Err(format!(
                 "account's node pubkey does ({}) not match to the given identity keypair ({}).",
-                found_vote_account.authorized_voter,
-                node_pubkey
+                found_vote_account.authorized_voter, node_pubkey
             ));
         }
     } else {

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -193,7 +193,7 @@ fn create_rpc_client(
                 None
             }
         })
-        .next()
+        .next();
 
     if let Some(rpc_addr) = rpc_addr {
         Ok((rpc_addr, RpcClient::new_socket(rpc_addr)))

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -220,7 +220,7 @@ fn initialize_ledger_path(
     no_snapshot_fetch: bool,
 ) -> Result<Hash, String> {
     let genesis_hash = rpc_client
-        .get_genesis_blockhash()
+        .get_genesis_hash()
         .map_err(|err| err.to_string())?;
 
     fs::create_dir_all(ledger_path).map_err(|err| err.to_string())?;

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -182,17 +182,15 @@ fn create_rpc_client(
     )
     .map_err(|err| err.to_string())?;
 
-    let rpc_addr = nodes
-        .iter()
-        .find_map(|contact_info| {
-            if contact_info.gossip == entrypoint.gossip
-                && ContactInfo::is_valid_address(&contact_info.rpc)
-            {
-                Some(contact_info.rpc)
-            } else {
-                None
-            }
-        });
+    let rpc_addr = nodes.iter().find_map(|contact_info| {
+        if contact_info.gossip == entrypoint.gossip
+            && ContactInfo::is_valid_address(&contact_info.rpc)
+        {
+            Some(contact_info.rpc)
+        } else {
+            None
+        }
+    });
 
     if let Some(rpc_addr) = rpc_addr {
         Ok((rpc_addr, RpcClient::new_socket(rpc_addr)))
@@ -224,10 +222,16 @@ fn check_vote_account(
     let found_vote_account = solana_vote_api::vote_state::VoteState::from(&found_account);
     if let Some(found_vote_account) = found_vote_account {
         if found_vote_account.authorized_voter != *voting_keypair {
-            return Err(format!("authorized voter does not match to given voting keypair: {}", found_vote_account.authorized_voter));
+            return Err(format!(
+                "authorized voter does not match to given voting keypair: {}",
+                found_vote_account.authorized_voter
+            ));
         }
         if found_vote_account.node_pubkey != *identity_keypair {
-            return Err(format!("node pubkey does not match to given identity keypair: {}", found_vote_account.authorized_voter));
+            return Err(format!(
+                "node pubkey does not match to given identity keypair: {}",
+                found_vote_account.authorized_voter
+            ));
         }
     } else {
         return Err(format!("invalid vote account data: {}", vote_account));
@@ -706,7 +710,13 @@ pub fn main() {
 
         if let Ok((rpc_addr, rpc_client)) = create_rpc_client(cluster_entrypoint) {
             if !validator_config.voting_disabled {
-                check_vote_account(&rpc_client, &vote_account, &voting_keypair.pubkey(), &identity_keypair.pubkey()).unwrap_or_else(|err| {
+                check_vote_account(
+                    &rpc_client,
+                    &vote_account,
+                    &voting_keypair.pubkey(),
+                    &identity_keypair.pubkey(),
+                )
+                .unwrap_or_else(|err| {
                     error!("Failed to check vote account: {}", err);
                     exit(1);
                 });

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -624,8 +624,9 @@ pub fn main() {
     }
 
     let vote_account = pubkey_of(&matches, "vote_account").unwrap_or_else(|| {
-        // Disable because validator rejects non voting accounts (= ephemeral keypairs)
-        if ephemeral_voting_keypair {
+        // Disable voting because normal (=not bootstrapping) validator rejects
+        // non-voting accounts (= ephemeral keypairs).
+        if ephemeral_voting_keypair && entrypoint.is_some() {
             warn!("Disabled voting due to the use of ephemeral key for vote account");
             validator_config.voting_disabled = true;
         };

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -184,7 +184,7 @@ fn create_rpc_client(
 
     let rpc_addr = nodes
         .iter()
-        .filter_map(|contact_info| {
+        .find_map(|contact_info| {
             if contact_info.gossip == entrypoint.gossip
                 && ContactInfo::is_valid_address(&contact_info.rpc)
             {
@@ -192,14 +192,13 @@ fn create_rpc_client(
             } else {
                 None
             }
-        })
-        .next();
+        });
 
     if let Some(rpc_addr) = rpc_addr {
         Ok((rpc_addr, RpcClient::new_socket(rpc_addr)))
     } else {
         Err(format!(
-            "No node including entrypoint ({:?}) is running the RPC service",
+            "Entrypoint ({:?}) is not running the RPC service",
             entrypoint.gossip
         ))
     }

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -207,7 +207,7 @@ fn check_vote_account(rpc_client: &RpcClient, vote_account: &Pubkey) -> Result<(
         Ok(())
     } else {
         Err(format!(
-            "not correct vote account (owned by {})): {}",
+            "not a vote account (owned by {}): {}",
             found_vote_account.owner, vote_account
         ))
     }


### PR DESCRIPTION
#### Problem

From #6628
> It's easy to forget to run `solana create-vote-account` before starting a validator and then get confused as to why it's not possible to `solana delegate-stake` to your vote account that doesn't exist. 


#### Summary of Changes

Again from #6628:
> We can help the user by having `solana-validator` ensure the vote account it was provided actually exists.

### Memo

~This should be backported to v0.20.3.~

Fixes #6628
