### PR TITLE
Use get_slot_with_commitment in test_no_voting

### DIFF
--- a/local_cluster/src/tests/local_cluster.rs
+++ b/local_cluster/src/tests/local_cluster.rs
@@ -650,7 +650,9 @@ fn test_no_voting() {
         .get_validator_client(&cluster.entry_point_info.id)
         .unwrap();
     loop {
-        let last_slot = client.get_slot().expect("Couldn't get slot");
+        let last_slot = client
+            .get_slot_with_commitment(CommitmentConfig::recent())
+            .expect("Couldn't get slot");
         if last_slot > 4 * VOTE_THRESHOLD_DEPTH as u64 {
             break;
         }


### PR DESCRIPTION
#### Problem
local_cluster tests never complete

#### Summary of Changes
test_no_voting is stuck in a loop due to get_slot not progressing using default commitment.
Update to recent commitment.

Fixes ... borken CI
