### PR TITLE
Clean up net/log symlinks

### DIFF
--- a/net/.gitignore
+++ b/net/.gitignore
@@ -1,2 +1,2 @@
 /config/
-/log/
+/log

--- a/net/common.sh
+++ b/net/common.sh
@@ -19,7 +19,7 @@ if [[ -d $netLogDir && ! -L $netLogDir ]]; then
   mv "$netLogDir" "$netDir"/log.old
 fi
 mkdir -p "$netConfigDir" "$netLogDateDir"
-ln -sf "$netLogDateDir" "$netLogDir"
+ln -sfh "$netLogDateDir" "$netLogDir"
 
 SOLANA_ROOT="$netDir"/..
 # shellcheck source=scripts/configure-metrics.sh
@@ -131,4 +131,3 @@ _setup_secondary_mount() {
     fi
   )
 }
-


### PR DESCRIPTION
#### Problem
* net/log symlink is not gitignore'd
* subsequent log symlinks should not follow the existing symlink

```
Untracked files:
  (use "git add <file>..." to include in what will be committed)

	net/log
	net/log-2019-11-06_20_33_06/
```

Introduced here: https://github.com/solana-labs/solana/pull/6701

#### Solution
* Fix gitignore rule
* Fix symlinking by adding -h