### PR TITLE
Avoid : in default log filename

### DIFF
--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -539,7 +539,7 @@ pub fn main() {
             let default_logfile = format!(
                 "solana-validator-{}-{}.log",
                 identity_keypair.pubkey(),
-                chrono::Local::now().to_rfc3339()
+                chrono::Utc::now().format("%Y%m%d-%H%M%S")
             );
             let logfile = matches.value_of("logfile").unwrap_or(&default_logfile);
 


### PR DESCRIPTION
The default log file that `solana-validator` creates contains colons, which confuses `scp`.  
