### PR TITLE
Move bank purge to a service

### DIFF
--- a/core/src/bank_cleanup_service.rs
+++ b/core/src/bank_cleanup_service.rs
@@ -1,0 +1,81 @@
+// Service to purge 0 lamport accounts from the accounts_db.
+
+use crate::service::Service;
+use solana_ledger::bank_forks::BankForks;
+use solana_measure::measure::Measure;
+use std::string::ToString;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, RwLock};
+use std::thread;
+use std::thread::{Builder, JoinHandle};
+use std::time::Duration;
+
+pub struct BankCleanupService {
+    t_cleanup: JoinHandle<()>,
+}
+
+impl BankCleanupService {
+    pub fn new(bank_forks: &Arc<RwLock<BankForks>>, exit: &Arc<AtomicBool>) -> Self {
+        info!("BankCleanupService active.");
+        let exit = exit.clone();
+        let bank_forks = bank_forks.clone();
+        let t_cleanup = Builder::new()
+            .name("solana-bank-cleanup".to_string())
+            .spawn(move || loop {
+                if exit.load(Ordering::Relaxed) {
+                    break;
+                }
+                let (bank, root) = {
+                    let bank_forks = bank_forks.read().unwrap();
+                    let banks = bank_forks.frozen_banks();
+                    let root = bank_forks.root();
+                    (banks[&root].clone(), root)
+                };
+                let mut time = Measure::start("purge_zero_lamport_accounts");
+                bank.purge_zero_lamport_accounts();
+                time.stop();
+                info!("bank clean up {} took {}ms", root, time.as_ms());
+                thread::sleep(Duration::from_secs(10));
+            })
+            .unwrap();
+        Self { t_cleanup }
+    }
+}
+
+impl Service for BankCleanupService {
+    type JoinReturnType = ();
+
+    fn join(self) -> thread::Result<()> {
+        self.t_cleanup.join()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::genesis_utils::{create_genesis_block, GenesisBlockInfo};
+    use solana_runtime::bank::Bank;
+    use std::thread::sleep;
+
+    #[test]
+    fn test_cleanup() {
+        let exit = Arc::new(AtomicBool::new(false));
+        let GenesisBlockInfo { genesis_block, .. } = create_genesis_block(1000);
+        let bank = Arc::new(Bank::new(&genesis_block));
+        let bank_forks = Arc::new(RwLock::new(BankForks::new_from_banks(
+            &[bank.clone()],
+            vec![0],
+        )));
+
+        let service = BankCleanupService::new(&bank_forks, &exit);
+        for _ in 0..10 {
+            if !bank_forks.read().unwrap()[0].has_accounts_with_zero_lamports() {
+                break;
+            }
+            sleep(Duration::from_millis(10));
+        }
+        assert!(!bank_forks.read().unwrap()[0].has_accounts_with_zero_lamports());
+        exit.store(true, Ordering::Relaxed);
+        let _ = service.join();
+    }
+}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -5,6 +5,7 @@
 //! command-line tools to spin up validators and a Rust library
 //!
 
+pub mod bank_cleanup_service;
 pub mod banking_stage;
 pub mod blob;
 pub mod broadcast_stage;

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -12,6 +12,7 @@
 //! 4. StorageStage
 //! - Generating the keys used to encrypt the ledger and sample it for storage mining.
 
+use crate::bank_cleanup_service::BankCleanupService;
 use crate::blockstream_service::BlockstreamService;
 use crate::cluster_info::ClusterInfo;
 use crate::commitment::BlockCommitmentCache;
@@ -48,6 +49,7 @@ pub struct Tvu {
     ledger_cleanup_service: Option<LedgerCleanupService>,
     storage_stage: StorageStage,
     snapshot_packager_service: Option<SnapshotPackagerService>,
+    bank_cleanup_service: BankCleanupService,
 }
 
 pub struct Sockets {
@@ -206,6 +208,8 @@ impl Tvu {
             &cluster_info,
         );
 
+        let bank_cleanup_service = BankCleanupService::new(&bank_forks, &exit);
+
         Tvu {
             fetch_stage,
             sigverify_stage,
@@ -215,6 +219,7 @@ impl Tvu {
             ledger_cleanup_service,
             storage_stage,
             snapshot_packager_service,
+            bank_cleanup_service,
         }
     }
 }
@@ -237,6 +242,7 @@ impl Service for Tvu {
         if let Some(s) = self.snapshot_packager_service {
             s.join()?;
         }
+        self.bank_cleanup_service.join()?;
         Ok(())
     }
 }

--- a/ledger/src/snapshot_utils.rs
+++ b/ledger/src/snapshot_utils.rs
@@ -151,7 +151,6 @@ where
 }
 
 pub fn add_snapshot<P: AsRef<Path>>(snapshot_path: P, bank: &Bank) -> Result<()> {
-    bank.purge_zero_lamport_accounts();
     let slot = bank.slot();
     // snapshot_path/slot
     let slot_snapshot_dir = get_bank_snapshot_dir(snapshot_path, slot);

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1388,13 +1388,14 @@ impl Bank {
     /// A snapshot bank should be purged of 0 lamport accounts which are not part of the hash
     /// calculation and could shield other real accounts.
     pub fn verify_snapshot_bank(&self) -> bool {
+        self.purge_zero_lamport_accounts();
         self.rc
             .accounts
             .verify_hash_internal_state(self.slot(), &self.ancestors)
             && !self.has_accounts_with_zero_lamports()
     }
 
-    fn has_accounts_with_zero_lamports(&self) -> bool {
+    pub fn has_accounts_with_zero_lamports(&self) -> bool {
         self.rc.accounts.accounts_db.scan_accounts(
             &self.ancestors,
             |collector: &mut bool, option| {


### PR DESCRIPTION
#### Problem

Purging zero lamport accounts is in the blocking path for replay_stage processing votes and replaying banks and can take 100ms.

#### Summary of Changes

Offload the work to an asynchronous thread for the validator and make the client do the purge on snapshot ingestion.

Fixes #
