### PR TITLE
Increase FEC ratio to 32:32

### DIFF
--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -45,11 +45,7 @@ thread_local!(static PAR_THREAD_POOL: RefCell<ThreadPool> = RefCell::new(rayon::
 pub const DATA_SHRED: u8 = 0b1010_0101;
 pub const CODING_SHRED: u8 = 0b0101_1010;
 
-/// This limit comes from reed solomon library, but unfortunately they don't have
-/// a public constant defined for it.
 pub const MAX_DATA_SHREDS_PER_FEC_BLOCK: u32 = 32;
-
-/// Based on rse benchmarks, the optimal erasure config uses 16 data shreds and 4 coding shreds
 pub const RECOMMENDED_FEC_RATE: f32 = 1.0;
 
 pub const SHRED_TICK_REFERENCE_MASK: u8 = 0b0011_1111;

--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -47,10 +47,10 @@ pub const CODING_SHRED: u8 = 0b0101_1010;
 
 /// This limit comes from reed solomon library, but unfortunately they don't have
 /// a public constant defined for it.
-pub const MAX_DATA_SHREDS_PER_FEC_BLOCK: u32 = 16;
+pub const MAX_DATA_SHREDS_PER_FEC_BLOCK: u32 = 32;
 
 /// Based on rse benchmarks, the optimal erasure config uses 16 data shreds and 4 coding shreds
-pub const RECOMMENDED_FEC_RATE: f32 = 0.25;
+pub const RECOMMENDED_FEC_RATE: f32 = 1.0;
 
 pub const SHRED_TICK_REFERENCE_MASK: u8 = 0b0011_1111;
 const LAST_SHRED_IN_SLOT: u8 = 0b1000_0000;


### PR DESCRIPTION
#### Problem
The network is not stable if there are enough packet drops. In experiments, a 15% packet drop is fatal to the network stability.

#### Summary of Changes
FEC ration of 16:4 is not sufficient to recover dropped shreds using erasure. Increasing FEC ratio to 32:32 increases possibility of recovery exponentially.

On a flip side, this impacts the TPS performance. We are still able to achieve ~50K TPS on GCP testnet. 
Going beyond this FEC rate (i.e. 64:64 or 128:128) severely impacts TPS. 