### PR TITLE
Replay should respect order of register_ticks with respect to blockhashes

### DIFF
--- a/ledger/src/blocktree_processor.rs
+++ b/ledger/src/blocktree_processor.rs
@@ -117,6 +117,16 @@ fn process_entries_with_callback(
         if entry.is_tick() {
             // if its a tick, save it for later
             tick_hashes.push(entry.hash);
+            if bank.is_block_boundary(bank.tick_height() + tick_hashes.len() as u64) {
+                // if its a tick that will cause a new blockhash to be created,
+                // execute the group and register the tick
+                execute_batches(bank, &batches, entry_callback)?;
+                batches.clear();
+                for hash in &tick_hashes {
+                    bank.register_tick(hash);
+                }
+                tick_hashes.clear();
+            }
             continue;
         }
         // else loop on processing the entry

--- a/ledger/src/blocktree_processor.rs
+++ b/ledger/src/blocktree_processor.rs
@@ -115,10 +115,10 @@ fn process_entries_with_callback(
     let mut tick_hashes = vec![];
     for entry in entries {
         if entry.is_tick() {
-            // if its a tick, save it for later
+            // If it's a tick, save it for later
             tick_hashes.push(entry.hash);
             if bank.is_block_boundary(bank.tick_height() + tick_hashes.len() as u64) {
-                // if its a tick that will cause a new blockhash to be created,
+                // If it's a tick that will cause a new blockhash to be created,
                 // execute the group and register the tick
                 execute_batches(bank, &batches, entry_callback)?;
                 batches.clear();

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -796,12 +796,16 @@ impl Bank {
         // assert!(!self.is_frozen());
         inc_new_counter_debug!("bank-register_tick-registered", 1);
         let current_tick_height = self.tick_height.fetch_add(1, Ordering::Relaxed) as u64;
-        if current_tick_height % self.ticks_per_slot == self.ticks_per_slot - 1 {
+        if self.is_block_boundary(current_tick_height + 1) {
             self.blockhash_queue
                 .write()
                 .unwrap()
                 .register_hash(hash, &self.fee_calculator);
         }
+    }
+
+    pub fn is_block_boundary(&self, tick_height: u64) -> bool {
+        tick_height % self.ticks_per_slot == 0
     }
 
     /// Process a Transaction. This is used for unit tests and simply calls the vector


### PR DESCRIPTION
#### Problem
We register multiple blockhashes for the same slot if that slot's block contains ticks from other blocks
(virtual ticks). Because `process_entries_with_callback` doesn't respect ledger ordering of ticks, this can cause validators to have different replay behavior

#### Summary of Changes
Only register blockhash when tick_height == max_tick_height

Fixes #
