### PR TITLE
Move tick_height into the Bank

### DIFF
--- a/runtime/src/blockhash_queue.rs
+++ b/runtime/src/blockhash_queue.rs
@@ -17,6 +17,8 @@ pub struct BlockhashQueue {
     /// updated whenever an hash is registered
     hash_height: u64,
 
+    tick_height: u64,
+
     /// last hash to be registered
     last_hash: Option<Hash>,
 
@@ -31,6 +33,7 @@ impl BlockhashQueue {
         Self {
             ages: HashMap::new(),
             hash_height: 0,
+            tick_height: 0,
             last_hash: None,
             max_age,
         }
@@ -39,6 +42,15 @@ impl BlockhashQueue {
     #[allow(dead_code)]
     pub fn hash_height(&self) -> u64 {
         self.hash_height
+    }
+
+    /// Return the number of ticks since genesis.
+    pub fn tick_height(&self) -> u64 {
+        self.tick_height
+    }
+
+    pub fn set_tick_height(&mut self, n: u64) {
+        self.tick_height = n;
     }
 
     pub fn last_hash(&self) -> Hash {

--- a/runtime/tests/bank.rs
+++ b/runtime/tests/bank.rs
@@ -1,0 +1,41 @@
+use solana_runtime::bank::Bank;
+use solana_sdk::genesis_block::create_genesis_block;
+use solana_sdk::hash::hash;
+use solana_sdk::pubkey::Pubkey;
+use std::sync::Arc;
+use std::thread::Builder;
+
+#[test]
+fn test_race_register_tick_freeze() {
+    solana_logger::setup();
+
+    let (mut genesis_block, _) = create_genesis_block(50);
+    genesis_block.ticks_per_slot = 1;
+    let p = Pubkey::new_rand();
+    let hash = hash(p.as_ref());
+
+    for _ in 0..1000 {
+        let bank0 = Arc::new(Bank::new(&genesis_block));
+        let bank0_ = bank0.clone();
+        let freeze_thread = Builder::new()
+            .name("freeze".to_string())
+            .spawn(move || loop {
+                if bank0_.tick_height() == bank0_.max_tick_height() {
+                    assert_eq!(bank0_.last_blockhash(), hash);
+                    break;
+                }
+            })
+            .unwrap();
+
+        let bank0_ = bank0.clone();
+        let register_tick_thread = Builder::new()
+            .name("register_tick".to_string())
+            .spawn(move || {
+                bank0_.register_tick(&hash);
+            })
+            .unwrap();
+
+        register_tick_thread.join().unwrap();
+        freeze_thread.join().unwrap();
+    }
+}


### PR DESCRIPTION
#### Problem

Downstream code assumes consistency between `Bank::tick_height` and `BlockhashQueue::hash_height`, but those values are guarded by separate locks. The separation creates the possibility for race conditions. Those races can only be tested with long-running threads and the crossing of fingers that with enough attempts, the race will occur. Those tests are slow, hard to read, and unreliable.

#### Summary of Changes

Toss both state variables under the same lock.

TODO:
- [ ] Verify the mutex doesn't cause a significant slowdown compared to the atomic
- [ ] Verify calls to tick_height() doesn't introduce contention with BlockhashQueue
- [ ] Delete the integration test if this PR is approved

Refix #6003
cc #6799