### PR TITLE
Refactor replay stage freeze

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -621,7 +621,7 @@ impl ReplayStage {
                 }
             }
             assert_eq!(*bank_slot, bank.slot());
-            if bank.tick_height() == bank.max_tick_height() {
+            if bank.is_frozen() {
                 if let Some(bank_progress) = &mut progress.get(&bank.slot()) {
                     bank_progress
                         .stats
@@ -869,7 +869,6 @@ impl ReplayStage {
         bank: Arc<Bank>,
         slot_full_senders: &[Sender<(u64, Pubkey)>],
     ) {
-        bank.freeze();
         info!("bank frozen {}", bank.slot());
         slot_full_senders.iter().for_each(|sender| {
             if let Err(e) = sender.send((bank.slot(), *bank.collector_id())) {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -795,12 +795,10 @@ impl Bank {
         // TODO: put this assert back in
         // assert!(!self.is_frozen());
         inc_new_counter_debug!("bank-register_tick-registered", 1);
+        let mut w_blockhash_queue = self.blockhash_queue.write().unwrap();
         let current_tick_height = self.tick_height.fetch_add(1, Ordering::Relaxed) as u64;
         if current_tick_height % self.ticks_per_slot == self.ticks_per_slot - 1 {
-            self.blockhash_queue
-                .write()
-                .unwrap()
-                .register_hash(hash, &self.fee_calculator);
+            w_blockhash_queue.register_hash(hash, &self.fee_calculator);
         }
     }
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -795,6 +795,9 @@ impl Bank {
         // TODO: put this assert back in
         // assert!(!self.is_frozen());
         inc_new_counter_debug!("bank-register_tick-registered", 1);
+        // Grab blockhash lock before incrementing tick height so that replay stage does
+        // not attempt to freeze after observing the last tick and before blockhash is
+        // updated
         let mut w_blockhash_queue = self.blockhash_queue.write().unwrap();
         let current_tick_height = self.tick_height.fetch_add(1, Ordering::Relaxed) as u64;
         if current_tick_height % self.ticks_per_slot == self.ticks_per_slot - 1 {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -788,21 +788,17 @@ impl Bank {
     /// the oldest ones once its internal cache is full. Once boot, the
     /// bank will reject transactions using that `hash`.
     pub fn register_tick(&self, hash: &Hash) {
-        if self.is_frozen() {
-            warn!("=========== TODO: register_tick() working on a frozen bank! ================");
-        }
-
         // TODO: put this assert back in
         // assert!(!self.is_frozen());
         inc_new_counter_debug!("bank-register_tick-registered", 1);
-        // Grab blockhash lock before incrementing tick height so that replay stage does
-        // not attempt to freeze after observing the last tick and before blockhash is
-        // updated
-        let mut w_blockhash_queue = self.blockhash_queue.write().unwrap();
         let current_tick_height = self.tick_height.fetch_add(1, Ordering::Relaxed) as u64;
         if current_tick_height % self.ticks_per_slot == self.ticks_per_slot - 1 {
-            w_blockhash_queue.register_hash(hash, &self.fee_calculator);
+            self.blockhash_queue
+                .write()
+                .unwrap()
+                .register_hash(hash, &self.fee_calculator);
         }
+        self.freeze();
     }
 
     /// Process a Transaction. This is used for unit tests and simply calls the vector


### PR DESCRIPTION
#### Problem
Currently calling freeze in replay stage requires ensuring poh recorder calling`register_tick` and replay stage calling `freeze` coordinate properly to ensure that all state is finalized (like blockhash) before replay stage moves on to potentially start another bank/replay another bank that references this state.

#### Summary of Changes
Move freeze into `register_tick`

Fixes #
