### PR TITLE
Clean up net logs

### DIFF
--- a/net/.gitignore
+++ b/net/.gitignore
@@ -1,2 +1,2 @@
 /config/
-/log/
+/log

--- a/net/common.sh
+++ b/net/common.sh
@@ -17,6 +17,8 @@ netLogDir="$netDir"/log
 if [[ -d $netLogDir && ! -L $netLogDir ]]; then
   echo "Warning: moving $netLogDir to make way for symlink."
   mv "$netLogDir" "$netDir"/log.old
+elif [[ -L $netLogDir ]]; then
+  rm "$netLogDir"
 fi
 mkdir -p "$netConfigDir" "$netLogDateDir"
 ln -sf "$netLogDateDir" "$netLogDir"
@@ -131,4 +133,3 @@ _setup_secondary_mount() {
     fi
   )
 }
-


### PR DESCRIPTION
#### Problem
- net/log symlink is not gitignore'd
- subsequent log symlinks should not follow the existing symlink

```
Untracked files:
  (use "git add <file>..." to include in what will be committed)

	net/log
	net/log-2019-11-06_20_33_06/
```
#### Solution
- gitignore net/log symlink
- remove existing symlink before creating a new one
