### PR TITLE
ci/shellcheck.sh now only audits files that git knows about

### DIFF
--- a/ci/shellcheck.sh
+++ b/ci/shellcheck.sh
@@ -6,13 +6,7 @@ set -e
 cd "$(dirname "$0")/.."
 (
   set -x
-  find . -name "*.sh" \
-      -not -regex ".*/ci/semver_bash/.*" \
-      -not -regex ".*/.cargo/.*" \
-      -not -regex ".*/node_modules/.*" \
-      -not -regex ".*/target/.*" \
-      -print0 \
-    | xargs -0 \
-        ci/docker-run.sh koalaman/shellcheck --color=always --external-sources --shell=bash
+  git ls-files -- '*.sh' ':(exclude)ci/semver_bash' \
+    | xargs ci/docker-run.sh koalaman/shellcheck --color=always --external-sources --shell=bash
 )
 echo --- ok


### PR DESCRIPTION
Notably this prevents triggering shellcheck when there are locally generated ephemeral files in `net/config` 