### PR TITLE
run.sh logs validators to stderr

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -90,6 +90,7 @@ args=(
   --rpc-port 8899
   --rpc-drone-address 127.0.0.1:9900
   --accounts "$dataDir"/accounts
+  --log -
 )
 if [[ -n $blockstreamSocket ]]; then
   args+=(--blockstream "$blockstreamSocket")


### PR DESCRIPTION
#### Problem

For development logging to stderr is nicer than only to a log fiile.

#### Summary of Changes

Return run.sh and thus localnet to logging to stderr.  Fixes `npm run localnet:logs` in the examples

Fixes #
