### PR TITLE
Move loader does not need genesis auth key

### DIFF
--- a/programs/move_loader_api/Cargo.lock
+++ b/programs/move_loader_api/Cargo.lock
@@ -2055,6 +2055,7 @@ dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "cc 1.0.46 (registry+https://github.com/rust-lang/crates.io-index)",
  "curve25519-dalek 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ed25519-dalek 1.0.0-pre.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2063,24 +2064,10 @@ dependencies = [
  "regex-syntax 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.9.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-ed25519-dalek 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "solana-ed25519-dalek"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "clear_on_drop 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "curve25519-dalek 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
- "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2130,6 +2117,7 @@ dependencies = [
  "bs58 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ed25519-dalek 1.0.0-pre.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "generic-array 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2146,7 +2134,6 @@ dependencies = [
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-crate-features 0.21.0",
- "solana-ed25519-dalek 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-logger 0.21.0",
  "untrusted 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -3542,7 +3529,6 @@ dependencies = [
 "checksum slog-stdlog 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "be4d87903baf655da2d82bc3ac3f7ef43868c58bf712b3a661fda72009304c23"
 "checksum slog-term 2.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "54b50e85b73c2bd42ceb97b6ded235576d405bd1e974242ccfe634fa269f6da7"
 "checksum smallvec 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)" = "cefaa50e76a6f10b86f36e640eb1739eafbd4084865067778463913e43a77ff3"
-"checksum solana-ed25519-dalek 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1c21f9d5aa62959872194dfd086feb4e8efec1c2589d27e6a0339904759e99fc"
 "checksum solana_libra_bytecode_verifier 0.0.1-sol4 (registry+https://github.com/rust-lang/crates.io-index)" = "79c3b7e9555da6f04a3f542a40e92bbbd46d0f05bd270ae3ff8c0283c329a179"
 "checksum solana_libra_canonical_serialization 0.0.1-sol4 (registry+https://github.com/rust-lang/crates.io-index)" = "c674689dd2d17b0bab49501f0d63ec71b3e1f8fab2eae86174e37768435a54aa"
 "checksum solana_libra_compiler 0.0.1-sol4 (registry+https://github.com/rust-lang/crates.io-index)" = "908b00b637e6eaf835d67bea2329bbee82e75f8e162744fd707ca9c9e4c1400b"

--- a/programs/move_loader_api/src/account_state.rs
+++ b/programs/move_loader_api/src/account_state.rs
@@ -9,7 +9,6 @@ use stdlib::stdlib_modules;
 use types::{
     account_address::AccountAddress,
     account_config,
-    byte_array::ByteArray,
     identifier::Identifier,
     transaction::Program,
     write_set::{WriteOp, WriteSet},

--- a/programs/move_loader_api/src/account_state.rs
+++ b/programs/move_loader_api/src/account_state.rs
@@ -124,8 +124,6 @@ impl LibraAccountState {
         let state_view = DataStore::default();
         let vm_cache = VMModuleCache::new(&arena);
         let genesis_addr = account_config::association_address();
-        // TODO: Need this?
-        let genesis_auth_key = ByteArray::new(genesis_addr.to_vec());
 
         let write_set = {
             let fake_fetcher =
@@ -161,14 +159,6 @@ impl LibraAccountState {
                     &ACCOUNT_MODULE,
                     &Identifier::new("mint_to_address").unwrap(),
                     vec![Value::address(genesis_addr), Value::u64(mint_balance)],
-                )
-                .map_err(map_err_vm_status)?;
-
-            txn_executor
-                .execute_function(
-                    &ACCOUNT_MODULE,
-                    &Identifier::new("rotate_authentication_key").unwrap(),
-                    vec![Value::byte_array(genesis_auth_key)],
                 )
                 .map_err(map_err_vm_status)?;
 


### PR DESCRIPTION
#### Problem

#### Summary of Changes

Remove its addition to the genesis and thus a todo (#6474)

Fixes #
