### PR TITLE
Include channel and commit info in the version of pre-release builds

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -5,6 +5,24 @@
 //! command-line tools to spin up validators and a Rust library
 //!
 
+#[macro_export]
+macro_rules! version {
+    () => {
+        &*format!(
+            "{}{}",
+            env!("CARGO_PKG_VERSION"),
+            if option_env!("CI_TAG").is_none() {
+                format!(
+                    " [channel={} commit={}]",
+                    option_env!("CHANNEL").unwrap_or("unknown"),
+                    option_env!("CI_COMMIT").unwrap_or("unknown"),
+                )
+            } else {
+                "".to_string()
+            },
+        )
+    };
+}
 pub mod banking_stage;
 pub mod blob;
 pub mod broadcast_stage;
@@ -57,7 +75,6 @@ pub mod streamer;
 pub mod tpu;
 pub mod tvu;
 pub mod validator;
-pub(crate) mod version;
 pub mod weighted_shuffle;
 pub mod window_service;
 

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -7,7 +7,6 @@ use crate::{
     packet::PACKET_DATA_SIZE,
     storage_stage::StorageState,
     validator::ValidatorExit,
-    version::VERSION,
 };
 use bincode::serialize;
 use jsonrpc_core::{Error, Metadata, Result};
@@ -913,7 +912,7 @@ impl RpcSol for RpcSolImpl {
 
     fn get_version(&self, _: Self::Metadata) -> Result<RpcVersionInfo> {
         Ok(RpcVersionInfo {
-            solana_core: VERSION.to_string(),
+            solana_core: crate::version!().to_string(),
         })
     }
 
@@ -1582,7 +1581,7 @@ pub mod tests {
         let expected = json!({
             "jsonrpc": "2.0",
             "result": {
-                "solana-core": VERSION
+                "solana-core": crate::version!().to_string()
             },
             "id": 1
         });

--- a/core/src/version.rs
+++ b/core/src/version.rs
@@ -1,1 +1,0 @@
-pub(crate) const VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/core/tests/client.rs
+++ b/core/tests/client.rs
@@ -18,7 +18,7 @@ fn test_rpc_client() {
 
     assert_eq!(
         client.get_version().unwrap(),
-        format!("{{\"solana-core\":\"{}\"}}", env!("CARGO_PKG_VERSION"))
+        format!("{{\"solana-core\":\"{}\"}}", solana_core::version!())
     );
 
     assert_eq!(client.get_balance(&bob_pubkey).unwrap(), 0);

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1,5 +1,5 @@
 use bzip2::bufread::BzDecoder;
-use clap::{crate_description, crate_name, crate_version, value_t, value_t_or_exit, App, Arg};
+use clap::{crate_description, crate_name, value_t, value_t_or_exit, App, Arg};
 use console::{style, Emoji};
 use indicatif::{ProgressBar, ProgressStyle};
 use log::*;
@@ -237,7 +237,7 @@ pub fn main() {
         &format!("{}-{}", VALIDATOR_PORT_RANGE.0, VALIDATOR_PORT_RANGE.1);
 
     let matches = App::new(crate_name!()).about(crate_description!())
-        .version(crate_version!())
+        .version(solana_core::version!())
         .arg(
             Arg::with_name("blockstream_unix_socket")
                 .long("blockstream")
@@ -527,11 +527,9 @@ pub fn main() {
         .map(|s| Hash::from_str(&s).unwrap());
 
     println!(
-        "{} version {} (branch={}, commit={})",
+        "{} {}",
         style(crate_name!()).bold(),
-        crate_version!(),
-        option_env!("CI_BRANCH").unwrap_or("unknown"),
-        option_env!("CI_COMMIT").unwrap_or("unknown")
+        solana_core::version!()
     );
 
     let _log_redirect = {


### PR DESCRIPTION
The version of all pre-release builds leading up the an official release is all the same (ie, master builds are currently always set to `0.22.0`), which is very misleading.

`solana-validator -V` and the `getVersion` RPC API now include the release channel and git commit of the software if it's not a tagged release.

Future work: once #6812 lands, `solana_core::version!()` should be moved into `solana-claputil` and used in place of `clap::crate_version!()` for all CLI tools