### PR TITLE
Remove todo from account

### DIFF
--- a/sdk/src/account.rs
+++ b/sdk/src/account.rs
@@ -60,7 +60,6 @@ impl fmt::Debug for Account {
 }
 
 impl Account {
-    // TODO do we want to add executable and leader_owner even though they should always be false/default?
     pub fn new(lamports: u64, space: usize, owner: &Pubkey) -> Account {
         Account {
             lamports,


### PR DESCRIPTION
#### Problem

Remove TODO:
```
// TODO do we want to add executable and leader_owner even though they should always be false/default?
```
#### Summary of Changes

Those members are public, folks can set them directly in the rare case they may need to

(removes a todo #6474 )

Fixes #
