### PR TITLE
Don't insert coding shred to blocktree on leader

### DIFF
--- a/core/src/broadcast_stage/broadcast_fake_blobs_run.rs
+++ b/core/src/broadcast_stage/broadcast_fake_blobs_run.rs
@@ -76,8 +76,7 @@ impl BroadcastRun for BroadcastFakeBlobsRun {
             self.last_blockhash = Hash::default();
         }
 
-        blocktree.insert_shreds(data_shreds.clone(), None)?;
-        blocktree.insert_shreds(coding_shreds.clone(), None)?;
+        blocktree.insert_leader_shreds(data_shreds.clone(), None)?;
 
         // 3) Start broadcast step
         let peers = cluster_info.read().unwrap().tvu_peers();

--- a/core/src/broadcast_stage/fail_entry_verification_broadcast_run.rs
+++ b/core/src/broadcast_stage/fail_entry_verification_broadcast_run.rs
@@ -59,7 +59,7 @@ impl BroadcastRun for FailEntryVerificationBroadcastRun {
             .collect::<Vec<_>>();
         let all_seeds: Vec<[u8; 32]> = all_shreds.iter().map(|s| s.seed()).collect();
         blocktree
-            .insert_shreds(all_shreds, None)
+            .insert_leader_shreds(all_shreds, None)
             .expect("Failed to insert shreds in blocktree");
 
         // 3) Start broadcast step

--- a/core/src/broadcast_stage/standard_broadcast_run.rs
+++ b/core/src/broadcast_stage/standard_broadcast_run.rs
@@ -208,7 +208,7 @@ impl StandardBroadcastRun {
         // Insert shreds into blocktree
         let insert_shreds_start = Instant::now();
         blocktree
-            .insert_shreds(shreds.clone(), None)
+            .insert_leader_shreds(shreds.clone(), None)
             .expect("Failed to insert shreds in blocktree");
         let insert_shreds_elapsed = insert_shreds_start.elapsed();
 

--- a/ledger/src/blocktree.rs
+++ b/ledger/src/blocktree.rs
@@ -466,14 +466,15 @@ impl Blocktree {
                         &mut index_meta_time,
                     )
                 } else if shred.is_code() {
-                    self.check_insert_coding_shred(
-                        shred,
-                        &mut erasure_metas,
-                        &mut index_working_set,
-                        &mut write_batch,
-                        &mut just_inserted_coding_shreds,
-                        &mut index_meta_time,
-                    )
+                    leader_schedule.is_some()
+                        && self.check_insert_coding_shred(
+                            shred,
+                            &mut erasure_metas,
+                            &mut index_working_set,
+                            &mut write_batch,
+                            &mut just_inserted_coding_shreds,
+                            &mut index_meta_time,
+                        )
                 } else {
                     panic!("There should be no other case");
                 }


### PR DESCRIPTION
#### Problem
Coding shreds are getting inserted to blocktree. On leader, it's not required, and is wasting compute time.

#### Summary of Changes
Don't insert coding shred on leader.