### PR TITLE
Don't insert coding shreds into blocktree on leader

### DIFF
--- a/core/src/broadcast_stage/broadcast_fake_blobs_run.rs
+++ b/core/src/broadcast_stage/broadcast_fake_blobs_run.rs
@@ -77,7 +77,6 @@ impl BroadcastRun for BroadcastFakeBlobsRun {
         }
 
         blocktree.insert_shreds(data_shreds.clone(), None)?;
-        blocktree.insert_shreds(coding_shreds.clone(), None)?;
 
         // 3) Start broadcast step
         let peers = cluster_info.read().unwrap().tvu_peers();


### PR DESCRIPTION
#### Problem
Coding shreds are getting inserted to blocktree. On leader, it's not required, and is wasting compute time.

#### Summary of Changes
Don't insert coding shred on leader.
