### PR TITLE
ci: Move move tests into its own job

### DIFF
--- a/ci/buildkite.yml
+++ b/ci/buildkite.yml
@@ -7,7 +7,7 @@ steps:
     timeout_in_minutes: 5
   - command: ". ci/rust-version.sh; ci/docker-run.sh $$rust_nightly_docker_image ci/test-checks.sh"
     name: "checks"
-    timeout_in_minutes: 35
+    timeout_in_minutes: 20
   - wait
   - command: "ci/test-stable-perf.sh"
     name: "stable-perf"
@@ -17,18 +17,21 @@ steps:
       - "queue=cuda"
   - command: "ci/test-bench.sh"
     name: "bench"
-    timeout_in_minutes: 60
+    timeout_in_minutes: 30
   - command: ". ci/rust-version.sh; ci/docker-run.sh $$rust_stable_docker_image ci/test-stable.sh"
     name: "stable"
     timeout_in_minutes: 40
     artifact_paths: "log-*.txt"
+  - command: ". ci/rust-version.sh; ci/docker-run.sh $$rust_stable_docker_image ci/test-move.sh"
+    name: "move"
+    timeout_in_minutes: 20
   - command: ". ci/rust-version.sh; ci/docker-run.sh $$rust_stable_docker_image ci/test-local-cluster.sh"
     name: "local-cluster"
-    timeout_in_minutes: 40
+    timeout_in_minutes: 30
     artifact_paths: "log-*.txt"
   - command: ". ci/rust-version.sh; ci/docker-run.sh $$rust_nightly_docker_image ci/test-coverage.sh"
     name: "coverage"
-    timeout_in_minutes: 40
+    timeout_in_minutes: 30
   - wait
   - trigger: "solana-secondary"
     branches: "!pull/*"

--- a/ci/test-move.sh
+++ b/ci/test-move.sh
@@ -1,0 +1,1 @@
+test-stable.sh

--- a/ci/test-stable.sh
+++ b/ci/test-stable.sh
@@ -28,18 +28,13 @@ rm -rf target/xargo # Issue #3105
 
 # Run the appropriate test based on entrypoint
 testName=$(basename "$0" .sh)
+echo "Executing $testName"
 case $testName in
 test-stable)
-  echo "Executing $testName"
   _ cargo +"$rust_stable" test --all --exclude solana-local-cluster ${V:+--verbose} -- --nocapture
   _ cargo +"$rust_stable" test --manifest-path local_cluster/Cargo.toml --features=move ${V:+--verbose} test_bench_tps_local_cluster_move -- --nocapture
-  _ cargo +"$rust_stable" test --manifest-path programs/move_loader_api/Cargo.toml ${V:+--verbose} -- --nocapture
-  _ cargo +"$rust_stable" test --manifest-path programs/move_loader_program/Cargo.toml ${V:+--verbose} -- --nocapture
-  _ cargo +"$rust_stable" test --manifest-path programs/librapay_api/Cargo.toml ${V:+--verbose} -- --nocapture
   ;;
 test-stable-perf)
-  echo "Executing $testName"
-
   ci/affects-files.sh \
     .rs$ \
     Cargo.lock$ \
@@ -54,7 +49,7 @@ test-stable-perf)
     ^sdk/ \
   || {
     annotate --style info \
-      "Skipped test-stable-perf as no relevant files were modified"
+      "Skipped $testName as no relevant files were modified"
     exit 0
   }
 
@@ -83,8 +78,30 @@ test-stable-perf)
   _ cargo +"$rust_stable" build --bins ${V:+--verbose}
   _ cargo +"$rust_stable" test --package solana-ledger --package solana-core --lib ${V:+--verbose} -- --nocapture
   ;;
+test-move)
+  ci/affects-files.sh \
+    Cargo.lock$ \
+    Cargo.toml$ \
+    ^ci/rust-version.sh \
+    ^ci/test-stable.sh \
+    ^ci/test-move.sh \
+    ^programs/move_loader_api \
+    ^programs/move_loader_program \
+    ^programs/librapay_api \
+    ^logger/ \
+    ^runtime/ \
+    ^sdk/ \
+  || {
+    annotate --style info \
+      "Skipped $testName as no relevant files were modified"
+    exit 0
+  }
+  _ cargo +"$rust_stable" test --manifest-path programs/move_loader_api/Cargo.toml ${V:+--verbose} -- --nocapture
+  _ cargo +"$rust_stable" test --manifest-path programs/move_loader_program/Cargo.toml ${V:+--verbose} -- --nocapture
+  _ cargo +"$rust_stable" test --manifest-path programs/librapay_api/Cargo.toml ${V:+--verbose} -- --nocapture
+  exit 0
+  ;;
 test-local-cluster)
-  echo "Executing $testName"
   _ cargo +"$rust_stable" build --release --bins ${V:+--verbose}
   _ cargo +"$rust_stable" test --release --package solana-local-cluster ${V:+--verbose} -- --nocapture
   exit 0


### PR DESCRIPTION
test-stable is too bloated and is starting to time out again.  👢 move into it's own job.