### PR TITLE
Sign shreds on gpu without a stage.

### DIFF
--- a/core/benches/blocktree.rs
+++ b/core/benches/blocktree.rs
@@ -5,22 +5,34 @@ extern crate solana_ledger;
 extern crate test;
 
 use rand::Rng;
+use solana_ledger::sigverify_shreds::sign_shreds_gpu_pinned_keypair;
 use solana_ledger::{
     blocktree::{entries_to_test_shreds, Blocktree},
     entry::{create_ticks, Entry},
     get_tmp_ledger_path,
+    shred::Shredder,
 };
-use solana_sdk::{clock::Slot, hash::Hash};
+use solana_perf::recycler_cache::RecyclerCache;
+use solana_sdk::{
+    clock::Slot,
+    hash::Hash,
+    signature::{Keypair, KeypairUtil},
+};
 use std::path::Path;
+use std::sync::Arc;
 use test::Bencher;
 
 // Given some shreds and a ledger at ledger_path, benchmark writing the shreds to the ledger
 fn bench_write_shreds(bench: &mut Bencher, entries: Vec<Entry>, ledger_path: &Path) {
+    let cache = RecyclerCache::warmed();
+    let kp = Arc::new(Keypair::new());
+    let pkp = Some(Arc::new(sign_shreds_gpu_pinned_keypair(&kp, &cache)));
+    let shredder = Shredder::new(0, 0, 0.0, kp, pkp, 0, 0).expect("shredder");
     let blocktree =
         Blocktree::open(ledger_path).expect("Expected to be able to open database ledger");
     bench.iter(move || {
-        let shreds = entries_to_test_shreds(entries.clone(), 0, 0, true, 0);
-        blocktree.insert_shreds(shreds, None, false).unwrap();
+        let packets = shredder.entries_to_shreds(&cache, &entries, true, 0).0;
+        blocktree.insert_batch(&packets, None, false).unwrap();
     });
 
     Blocktree::destroy(ledger_path).expect("Expected successful database destruction");
@@ -43,7 +55,7 @@ fn setup_read_bench(
     // Convert the entries to shreds, write the shreds to the ledger
     let shreds = entries_to_test_shreds(entries, slot, slot.saturating_sub(1), true, 0);
     blocktree
-        .insert_shreds(shreds, None, false)
+        .insert_test_shreds(shreds, None, false)
         .expect("Expectd successful insertion of shreds into ledger");
 }
 
@@ -135,7 +147,7 @@ fn bench_insert_data_shred_small(bench: &mut Bencher) {
     let entries = create_ticks(num_entries, 0, Hash::default());
     bench.iter(move || {
         let shreds = entries_to_test_shreds(entries.clone(), 0, 0, true, 0);
-        blocktree.insert_shreds(shreds, None, false).unwrap();
+        blocktree.insert_test_shreds(shreds, None, false).unwrap();
     });
     Blocktree::destroy(&ledger_path).expect("Expected successful database destruction");
 }
@@ -150,7 +162,7 @@ fn bench_insert_data_shred_big(bench: &mut Bencher) {
     let entries = create_ticks(num_entries, 0, Hash::default());
     bench.iter(move || {
         let shreds = entries_to_test_shreds(entries.clone(), 0, 0, true, 0);
-        blocktree.insert_shreds(shreds, None, false).unwrap();
+        blocktree.insert_test_shreds(shreds, None, false).unwrap();
     });
     Blocktree::destroy(&ledger_path).expect("Expected successful database destruction");
 }

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -1955,7 +1955,7 @@ mod tests {
             poh_recorder.lock().unwrap().set_working_bank(working_bank);
 
             let shreds = entries_to_test_shreds(entries.clone(), bank.slot(), 0, true, 0);
-            blocktree.insert_shreds(shreds, None, false).unwrap();
+            blocktree.insert_test_shreds(shreds, None, false).unwrap();
             blocktree.set_roots(&[bank.slot()]).unwrap();
 
             let (transaction_status_sender, transaction_status_receiver) = unbounded();

--- a/core/src/broadcast_stage/broadcast_fake_shreds_run.rs
+++ b/core/src/broadcast_stage/broadcast_fake_shreds_run.rs
@@ -1,18 +1,21 @@
 use super::*;
 use solana_ledger::entry::Entry;
 use solana_ledger::shred::{Shredder, RECOMMENDED_FEC_RATE};
+use solana_perf::recycler_cache::RecyclerCache;
 use solana_sdk::hash::Hash;
 
 pub(super) struct BroadcastFakeShredsRun {
     last_blockhash: Hash,
     partition: usize,
     shred_version: u16,
+    recycler_cache: RecyclerCache,
 }
 
 impl BroadcastFakeShredsRun {
     pub(super) fn new(partition: usize, shred_version: u16) -> Self {
         Self {
             last_blockhash: Hash::default(),
+            recycler_cache: RecyclerCache::warmed(),
             partition,
             shred_version,
         }
@@ -46,12 +49,14 @@ impl BroadcastRun for BroadcastFakeShredsRun {
             bank.parent().unwrap().slot(),
             RECOMMENDED_FEC_RATE,
             keypair.clone(),
+            None,
             (bank.tick_height() % bank.ticks_per_slot()) as u8,
             self.shred_version,
         )
         .expect("Expected to create a new shredder");
 
         let (data_shreds, coding_shreds, _) = shredder.entries_to_shreds(
+            &self.recycler_cache,
             &receive_results.entries,
             last_tick_height == bank.max_tick_height(),
             next_shred_index,
@@ -68,6 +73,7 @@ impl BroadcastRun for BroadcastFakeShredsRun {
             .collect();
 
         let (fake_data_shreds, fake_coding_shreds, _) = shredder.entries_to_shreds(
+            &self.recycler_cache,
             &fake_entries,
             last_tick_height == bank.max_tick_height(),
             next_shred_index,
@@ -79,7 +85,7 @@ impl BroadcastRun for BroadcastFakeShredsRun {
             self.last_blockhash = Hash::default();
         }
 
-        blocktree.insert_shreds(data_shreds.clone(), None, true)?;
+        blocktree.insert_batch(&data_shreds, None, true)?;
 
         // 3) Start broadcast step
         let peers = cluster_info.read().unwrap().tvu_peers();
@@ -89,19 +95,22 @@ impl BroadcastRun for BroadcastFakeShredsRun {
                 fake_data_shreds
                     .iter()
                     .chain(fake_coding_shreds.iter())
-                    .for_each(|b| {
-                        sock.send_to(&b.payload, &peer.tvu_forwards).unwrap();
+                    .for_each(|packets| {
+                        packets.packets.iter().for_each(|p| {
+                            sock.send_to(&p.data, &peer.tvu_forwards).unwrap();
+                        });
                     });
             } else {
                 data_shreds
                     .iter()
                     .chain(coding_shreds.iter())
-                    .for_each(|b| {
-                        sock.send_to(&b.payload, &peer.tvu_forwards).unwrap();
+                    .for_each(|packets| {
+                        packets.packets.iter().for_each(|p| {
+                            sock.send_to(&p.data, &peer.tvu_forwards).unwrap();
+                        });
                     });
             }
         });
-
         Ok(())
     }
 }

--- a/core/src/broadcast_stage/fail_entry_verification_broadcast_run.rs
+++ b/core/src/broadcast_stage/fail_entry_verification_broadcast_run.rs
@@ -1,14 +1,20 @@
 use super::*;
-use solana_ledger::shred::{Shredder, RECOMMENDED_FEC_RATE};
+use solana_ledger::shred::{ShredCommonHeader, Shredder, RECOMMENDED_FEC_RATE};
+use solana_perf::packet::Packets;
+use solana_perf::recycler_cache::RecyclerCache;
 use solana_sdk::hash::Hash;
 
 pub(super) struct FailEntryVerificationBroadcastRun {
     shred_version: u16,
+    recycler_cache: RecyclerCache,
 }
 
 impl FailEntryVerificationBroadcastRun {
     pub(super) fn new(shred_version: u16) -> Self {
-        Self { shred_version }
+        Self {
+            shred_version,
+            recycler_cache: RecyclerCache::warmed(),
+        }
     }
 }
 
@@ -44,41 +50,48 @@ impl BroadcastRun for FailEntryVerificationBroadcastRun {
             bank.parent().unwrap().slot(),
             RECOMMENDED_FEC_RATE,
             keypair.clone(),
+            None,
             (bank.tick_height() % bank.ticks_per_slot()) as u8,
             self.shred_version,
         )
         .expect("Expected to create a new shredder");
 
         let (data_shreds, coding_shreds, _) = shredder.entries_to_shreds(
+            &self.recycler_cache,
             &receive_results.entries,
             last_tick_height == bank.max_tick_height(),
             next_shred_index,
         );
 
-        let all_shreds = data_shreds
+        let mut all_shreds: Vec<Packets> = data_shreds
             .iter()
             .cloned()
             .chain(coding_shreds.iter().cloned())
-            .collect::<Vec<_>>();
-        let all_seeds: Vec<[u8; 32]> = all_shreds.iter().map(|s| s.seed()).collect();
+            .collect();
+        let all_seeds: Vec<Vec<[u8; 32]>> = all_shreds
+            .iter()
+            .map(|p| {
+                p.packets
+                    .iter()
+                    .map(|p| {
+                        ShredCommonHeader::from_packet(p)
+                            .expect("invalid packet")
+                            .seed()
+                    })
+                    .collect()
+            })
+            .collect();
         blocktree
-            .insert_shreds(all_shreds, None, true)
+            .insert_batch(&all_shreds, None, true)
             .expect("Failed to insert shreds in blocktree");
 
         // 3) Start broadcast step
         let bank_epoch = bank.get_leader_schedule_epoch(bank.slot());
         let stakes = staking_utils::staked_nodes_at_epoch(&bank, bank_epoch);
 
-        let all_shred_bufs: Vec<Vec<u8>> = data_shreds
-            .into_iter()
-            .chain(coding_shreds.into_iter())
-            .map(|s| s.payload)
-            .collect();
-
-        // Broadcast data
         cluster_info.read().unwrap().broadcast_shreds(
             sock,
-            all_shred_bufs,
+            &mut all_shreds,
             &all_seeds,
             stakes.as_ref(),
         )?;

--- a/core/src/broadcast_stage/standard_broadcast_run.rs
+++ b/core/src/broadcast_stage/standard_broadcast_run.rs
@@ -3,6 +3,11 @@ use super::*;
 use crate::broadcast_stage::broadcast_utils::UnfinishedSlotInfo;
 use solana_ledger::entry::Entry;
 use solana_ledger::shred::{Shred, Shredder, RECOMMENDED_FEC_RATE, SHRED_TICK_REFERENCE_MASK};
+use solana_ledger::sigverify_shreds::sign_shreds_gpu_pinned_keypair;
+use solana_perf::cuda_runtime::PinnedVec;
+use solana_perf::packet::Packets;
+use solana_perf::recycler_cache::RecyclerCache;
+use solana_sdk::packet::Packet;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::Keypair;
 use solana_sdk::timing::duration_as_us;
@@ -35,18 +40,24 @@ pub(super) struct StandardBroadcastRun {
     current_slot_and_parent: Option<(u64, u64)>,
     slot_broadcast_start: Option<Instant>,
     keypair: Arc<Keypair>,
+    pinned_keypair: Arc<PinnedVec<u8>>,
     shred_version: u16,
+    recycler_cache: RecyclerCache,
 }
 
 impl StandardBroadcastRun {
     pub(super) fn new(keypair: Arc<Keypair>, shred_version: u16) -> Self {
+        let recycler_cache = RecyclerCache::warmed();
+        let pinned_keypair = Arc::new(sign_shreds_gpu_pinned_keypair(&keypair, &recycler_cache));
         Self {
             stats: BroadcastStats::default(),
             unfinished_slot: None,
             current_slot_and_parent: None,
             slot_broadcast_start: None,
             keypair,
+            pinned_keypair,
             shred_version,
+            recycler_cache,
         }
     }
 
@@ -88,13 +99,14 @@ impl StandardBroadcastRun {
         entries: &[Entry],
         is_slot_end: bool,
         reference_tick: u8,
-    ) -> (Vec<Shred>, Vec<Shred>) {
+    ) -> (Vec<Packets>, Vec<Packets>) {
         let (slot, parent_slot) = self.current_slot_and_parent.unwrap();
         let shredder = Shredder::new(
             slot,
             parent_slot,
             RECOMMENDED_FEC_RATE,
             self.keypair.clone(),
+            Some(self.pinned_keypair.clone()),
             reference_tick,
             self.shred_version,
         )
@@ -111,8 +123,12 @@ impl StandardBroadcastRun {
                     .unwrap_or(0) as u32
             });
 
-        let (data_shreds, coding_shreds, new_next_shred_index) =
-            shredder.entries_to_shreds(entries, is_slot_end, next_shred_index);
+        let (data_shreds, coding_shreds, new_next_shred_index) = shredder.entries_to_shreds(
+            &self.recycler_cache,
+            entries,
+            is_slot_end,
+            next_shred_index,
+        );
 
         self.unfinished_slot = Some(UnfinishedSlotInfo {
             next_shred_index: new_next_shred_index,
@@ -161,7 +177,9 @@ impl StandardBroadcastRun {
             (bank.tick_height() % bank.ticks_per_slot()) as u8,
         );
         if let Some(last_shred) = last_unfinished_slot_shred {
-            data_shreds.push(last_shred);
+            let mut p = Packet::default();
+            last_shred.copy_to_packet(&mut p);
+            data_shreds.last_mut().unwrap().packets.push(p);
         }
         let to_shreds_elapsed = to_shreds_start.elapsed();
 
@@ -198,10 +216,9 @@ impl StandardBroadcastRun {
 
         Ok(())
     }
-
     fn maybe_insert_and_broadcast(
         &mut self,
-        shreds: Vec<Shred>,
+        mut shreds: Vec<Packets>,
         insert: bool,
         blocktree: &Arc<Blocktree>,
         cluster_info: &Arc<RwLock<ClusterInfo>>,
@@ -209,27 +226,28 @@ impl StandardBroadcastRun {
         sock: &UdpSocket,
     ) -> Result<()> {
         let seed_start = Instant::now();
-        let seeds: Vec<[u8; 32]> = shreds.iter().map(|s| s.seed()).collect();
+        let seeds: Vec<Vec<[u8; 32]>> = Shredder::seeds(&shreds);
         let seed_elapsed = seed_start.elapsed();
 
         // Insert shreds into blocktree
         let insert_shreds_start = Instant::now();
         if insert {
             blocktree
-                .insert_shreds(shreds.clone(), None, true)
+                .insert_batch(&shreds, None, true)
                 .expect("Failed to insert shreds in blocktree");
         }
         let insert_shreds_elapsed = insert_shreds_start.elapsed();
 
         // Broadcast the shreds
         let broadcast_start = Instant::now();
-        let shred_bufs: Vec<Vec<u8>> = shreds.into_iter().map(|s| s.payload).collect();
-        trace!("Broadcasting {:?} shreds", shred_bufs.len());
+
+        let num: usize = shreds.iter().map(|x| x.packets.len()).sum();
+        trace!("Broadcasting {} shreds", num);
 
         cluster_info
             .read()
             .unwrap()
-            .broadcast_shreds(sock, shred_bufs, &seeds, stakes)?;
+            .broadcast_shreds(sock, &mut shreds, &seeds, stakes)?;
 
         let broadcast_elapsed = broadcast_start.elapsed();
 

--- a/core/src/cluster_info_repair_listener.rs
+++ b/core/src/cluster_info_repair_listener.rs
@@ -698,7 +698,7 @@ mod tests {
         let blocktree = Blocktree::open(&blocktree_path).unwrap();
         let num_slots = 2;
         let (shreds, _) = make_many_slot_entries(0, num_slots, 1);
-        blocktree.insert_shreds(shreds, None, false).unwrap();
+        blocktree.insert_test_shreds(shreds, None, false).unwrap();
 
         // Write roots so that these slots will qualify to be sent by the repairman
         let last_root = num_slots - 1;
@@ -769,7 +769,7 @@ mod tests {
         let num_shreds_per_slot = shreds.len() as u64 / num_slots;
 
         // Write slots in the range [0, num_slots] to blocktree
-        blocktree.insert_shreds(shreds, None, false).unwrap();
+        blocktree.insert_test_shreds(shreds, None, false).unwrap();
 
         // Write roots so that these slots will qualify to be sent by the repairman
         let roots: Vec<_> = (0..=num_slots - 1).collect();
@@ -858,7 +858,7 @@ mod tests {
         // Create shreds for first two epochs and write them to blocktree
         let total_slots = slots_per_epoch * 2;
         let (shreds, _) = make_many_slot_entries(0, total_slots, 1);
-        blocktree.insert_shreds(shreds, None, false).unwrap();
+        blocktree.insert_test_shreds(shreds, None, false).unwrap();
 
         // Write roots so that these slots will qualify to be sent by the repairman
         let roots: Vec<_> = (0..=slots_per_epoch * 2 - 1).collect();

--- a/core/src/ledger_cleanup_service.rs
+++ b/core/src/ledger_cleanup_service.rs
@@ -100,7 +100,7 @@ mod tests {
         let blocktree_path = get_tmp_ledger_path!();
         let blocktree = Blocktree::open(&blocktree_path).unwrap();
         let (shreds, _) = make_many_slot_entries(0, 50, 5);
-        blocktree.insert_shreds(shreds, None, false).unwrap();
+        blocktree.insert_test_shreds(shreds, None, false).unwrap();
         let blocktree = Arc::new(blocktree);
         let (sender, receiver) = channel();
 

--- a/core/src/partition_cfg.rs
+++ b/core/src/partition_cfg.rs
@@ -1,5 +1,5 @@
 use solana_ledger::leader_schedule_cache::LeaderScheduleCache;
-use solana_ledger::shred::Shred;
+use solana_ledger::shred::ShredHeaders;
 use solana_runtime::bank::Bank;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::timing::timestamp;
@@ -41,7 +41,7 @@ impl PartitionCfg {
         &self,
         bank: &Option<Arc<Bank>>,
         leader_schedule_cache: &Arc<LeaderScheduleCache>,
-        shred: &Shred,
+        shred: &ShredHeaders,
     ) -> bool {
         if bank.is_none() {
             return true;

--- a/core/src/repair_service.rs
+++ b/core/src/repair_service.rs
@@ -427,7 +427,7 @@ mod test {
             let (mut shreds, _) = make_slot_entries(1, 0, 1);
             let (shreds2, _) = make_slot_entries(5, 2, 1);
             shreds.extend(shreds2);
-            blocktree.insert_shreds(shreds, None, false).unwrap();
+            blocktree.insert_test_shreds(shreds, None, false).unwrap();
             assert_eq!(
                 RepairService::generate_repairs(&blocktree, 0, 2).unwrap(),
                 vec![RepairType::HighestShred(0, 0), RepairType::Orphan(2)]
@@ -447,7 +447,7 @@ mod test {
 
             // Write this shred to slot 2, should chain to slot 0, which we haven't received
             // any shreds for
-            blocktree.insert_shreds(shreds, None, false).unwrap();
+            blocktree.insert_test_shreds(shreds, None, false).unwrap();
 
             // Check that repair tries to patch the empty slot
             assert_eq!(
@@ -484,7 +484,7 @@ mod test {
                 }
             }
             blocktree
-                .insert_shreds(shreds_to_write, None, false)
+                .insert_test_shreds(shreds_to_write, None, false)
                 .unwrap();
             // sleep so that the holes are ready for repair
             sleep(Duration::from_secs(1));
@@ -524,7 +524,7 @@ mod test {
             // Remove last shred (which is also last in slot) so that slot is not complete
             shreds.pop();
 
-            blocktree.insert_shreds(shreds, None, false).unwrap();
+            blocktree.insert_test_shreds(shreds, None, false).unwrap();
 
             // We didn't get the last shred for this slot, so ask for the highest shred for that slot
             let expected: Vec<RepairType> =
@@ -550,7 +550,9 @@ mod test {
             let shreds = make_chaining_slot_entries(&slots, num_entries_per_slot);
             for (mut slot_shreds, _) in shreds.into_iter() {
                 slot_shreds.remove(0);
-                blocktree.insert_shreds(slot_shreds, None, false).unwrap();
+                blocktree
+                    .insert_test_shreds(slot_shreds, None, false)
+                    .unwrap();
             }
             // sleep to make slot eligible for repair
             sleep(Duration::from_secs(1));
@@ -603,7 +605,7 @@ mod test {
                 let parent = if i > 0 { i - 1 } else { 0 };
                 let (shreds, _) = make_slot_entries(i, parent, num_entries_per_slot as u64);
 
-                blocktree.insert_shreds(shreds, None, false).unwrap();
+                blocktree.insert_test_shreds(shreds, None, false).unwrap();
             }
 
             let end = 4;
@@ -656,9 +658,11 @@ mod test {
                 .collect();
             let mut full_slots = BTreeSet::new();
 
-            blocktree.insert_shreds(fork1_shreds, None, false).unwrap();
             blocktree
-                .insert_shreds(fork2_incomplete_shreds, None, false)
+                .insert_test_shreds(fork1_shreds, None, false)
+                .unwrap();
+            blocktree
+                .insert_test_shreds(fork2_incomplete_shreds, None, false)
                 .unwrap();
 
             // Test that only slots > root from fork1 were included
@@ -682,7 +686,9 @@ mod test {
                 .into_iter()
                 .flat_map(|(shreds, _)| shreds)
                 .collect();
-            blocktree.insert_shreds(fork3_shreds, None, false).unwrap();
+            blocktree
+                .insert_test_shreds(fork3_shreds, None, false)
+                .unwrap();
             RepairService::get_completed_slots_past_root(
                 &blocktree,
                 &mut full_slots,
@@ -730,7 +736,7 @@ mod test {
                         let step = std::cmp::min(step, num_shreds - i);
                         let shreds_to_insert = shreds.drain(..step).collect_vec();
                         blocktree_
-                            .insert_shreds(shreds_to_insert, None, false)
+                            .insert_test_shreds(shreds_to_insert, None, false)
                             .unwrap();
                         sleep(Duration::from_millis(repair_interval_ms));
                         i += step;
@@ -762,7 +768,7 @@ mod test {
             // Update with new root, should filter out the slots <= root
             root = num_slots / 2;
             let (shreds, _) = make_slot_entries(num_slots + 2, num_slots + 1, entries_per_slot);
-            blocktree.insert_shreds(shreds, None, false).unwrap();
+            blocktree.insert_test_shreds(shreds, None, false).unwrap();
             RepairService::update_epoch_slots(
                 Pubkey::default(),
                 root,

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -1487,7 +1487,7 @@ pub(crate) mod tests {
 
             // Insert shred for slot 1, generate new forks, check result
             let (shreds, _) = make_slot_entries(1, 0, 8);
-            blocktree.insert_shreds(shreds, None, false).unwrap();
+            blocktree.insert_test_shreds(shreds, None, false).unwrap();
             assert!(bank_forks.get(1).is_none());
             ReplayStage::generate_new_bank_forks(
                 &blocktree,
@@ -1499,7 +1499,7 @@ pub(crate) mod tests {
 
             // Insert shred for slot 3, generate new forks, check result
             let (shreds, _) = make_slot_entries(2, 0, 8);
-            blocktree.insert_shreds(shreds, None, false).unwrap();
+            blocktree.insert_test_shreds(shreds, None, false).unwrap();
             assert!(bank_forks.get(2).is_none());
             ReplayStage::generate_new_bank_forks(
                 &blocktree,
@@ -1752,7 +1752,7 @@ pub(crate) mod tests {
                 .entry(bank0.slot())
                 .or_insert_with(|| ForkProgress::new(0, last_blockhash));
             let shreds = shred_to_insert(&mint_keypair, bank0.clone());
-            blocktree.insert_shreds(shreds, None, false).unwrap();
+            blocktree.insert_test_shreds(shreds, None, false).unwrap();
             let (res, _tx_count) = ReplayStage::replay_blocktree_into_bank(
                 &bank0,
                 &blocktree,
@@ -1907,7 +1907,7 @@ pub(crate) mod tests {
         let entries = vec![entry_1, entry_2, entry_3];
 
         let shreds = entries_to_test_shreds(entries.clone(), slot, previous_slot, true, 0);
-        blocktree.insert_shreds(shreds, None, false).unwrap();
+        blocktree.insert_test_shreds(shreds, None, false).unwrap();
         blocktree.set_roots(&[slot]).unwrap();
 
         let (transaction_status_sender, transaction_status_receiver) = unbounded();

--- a/core/src/sigverify.rs
+++ b/core/src/sigverify.rs
@@ -9,9 +9,7 @@ use solana_perf::cuda_runtime::PinnedVec;
 use solana_perf::packet::Packets;
 use solana_perf::recycler::Recycler;
 use solana_perf::sigverify;
-pub use solana_perf::sigverify::{
-    batch_size, ed25519_verify_cpu, ed25519_verify_disabled, init, TxOffset,
-};
+pub use solana_perf::sigverify::{ed25519_verify_cpu, ed25519_verify_disabled, init, TxOffset};
 
 #[derive(Clone)]
 pub struct TransactionSigVerifier {
@@ -39,10 +37,12 @@ impl SigVerifier for TransactionSigVerifier {
 
 pub fn mark_disabled(batches: &mut Vec<Packets>, r: &[Vec<u8>]) {
     batches.iter_mut().zip(r).for_each(|(b, v)| {
-        b.packets
-            .iter_mut()
-            .zip(v)
-            .for_each(|(p, f)| p.meta.discard = *f == 0)
+        b.packets.iter_mut().zip(v).for_each(|(p, f)| {
+            p.meta.discard = *f == 0;
+            if p.meta.discard {
+                debug!("packet discarded: failed sig_verify");
+            }
+        })
     });
 }
 

--- a/core/src/sigverify_shreds.rs
+++ b/core/src/sigverify_shreds.rs
@@ -1,15 +1,13 @@
 #![allow(clippy::implicit_hasher)]
-use crate::packet::{limited_deserialize, Packets};
+use crate::packet::Packets;
 use crate::sigverify;
 use crate::sigverify_stage::SigVerifier;
 use solana_ledger::bank_forks::BankForks;
 use solana_ledger::leader_schedule_cache::LeaderScheduleCache;
-use solana_ledger::shred::ShredType;
+use solana_ledger::shred::ShredCommonHeader;
 use solana_ledger::sigverify_shreds::verify_shreds_gpu;
 use solana_perf::recycler_cache::RecyclerCache;
-use solana_sdk::signature::Signature;
 use std::collections::{HashMap, HashSet};
-use std::mem::size_of;
 use std::sync::{Arc, RwLock};
 
 #[derive(Clone)]
@@ -31,29 +29,12 @@ impl ShredSigVerifier {
             recycler_cache: RecyclerCache::warmed(),
         }
     }
-    fn read_slots(batches: &[Packets]) -> HashSet<u64> {
-        batches
-            .iter()
-            .flat_map(|batch| {
-                batch.packets.iter().filter_map(|packet| {
-                    let slot_start = size_of::<Signature>() + size_of::<ShredType>();
-                    let slot_end = slot_start + size_of::<u64>();
-                    trace!("slot {} {}", slot_start, slot_end,);
-                    if slot_end <= packet.meta.size {
-                        limited_deserialize(&packet.data[slot_start..slot_end]).ok()
-                    } else {
-                        None
-                    }
-                })
-            })
-            .collect()
-    }
 }
 
 impl SigVerifier for ShredSigVerifier {
     fn verify_batch(&self, mut batches: Vec<Packets>) -> Vec<Packets> {
         let r_bank = self.bank_forks.read().unwrap().working_bank();
-        let slots: HashSet<u64> = Self::read_slots(&batches);
+        let slots: HashSet<u64> = read_slots(&batches);
         let mut leader_slots: HashMap<u64, [u8; 32]> = slots
             .into_iter()
             .filter_map(|slot| {
@@ -71,6 +52,18 @@ impl SigVerifier for ShredSigVerifier {
     }
 }
 
+fn read_slots(batches: &[Packets]) -> HashSet<u64> {
+    batches
+        .iter()
+        .flat_map(|batch| {
+            batch.packets.iter().filter_map(|packet| {
+                let header = ShredCommonHeader::from_packet(packet).ok()?;
+                Some(header.slot)
+            })
+        })
+        .collect()
+}
+
 #[cfg(test)]
 pub mod tests {
     use super::*;
@@ -81,7 +74,37 @@ pub mod tests {
     use solana_sdk::signature::{Keypair, KeypairUtil};
 
     #[test]
-    fn test_sigverify_shreds_read_slots() {
+    fn test_sigverify_shreds_verify_batch() {
+        let leader_keypair = Arc::new(Keypair::new());
+        let leader_pubkey = leader_keypair.pubkey();
+        let bank =
+            Bank::new(&create_genesis_config_with_leader(100, &leader_pubkey, 10).genesis_config);
+        let cache = Arc::new(LeaderScheduleCache::new_from_bank(&bank));
+        let bf = Arc::new(RwLock::new(BankForks::new(0, bank)));
+        let verifier = ShredSigVerifier::new(bf, cache);
+
+        let mut batch = vec![Packets::default()];
+        batch[0].packets.resize(2, Packet::default());
+
+        let mut shred =
+            Shred::new_from_data(0, 0xc0de, 0xdead, Some(&[1, 2, 3, 4]), true, true, 0, 0);
+        Shredder::sign_shred(&leader_keypair, &mut shred);
+        batch[0].packets[0].data[0..shred.payload.len()].copy_from_slice(&shred.payload);
+        batch[0].packets[0].meta.size = shred.payload.len();
+
+        let mut shred =
+            Shred::new_from_data(0, 0xbeef, 0xc0de, Some(&[1, 2, 3, 4]), true, true, 0, 0);
+        let wrong_keypair = Keypair::new();
+        Shredder::sign_shred(&wrong_keypair, &mut shred);
+        batch[0].packets[1].data[0..shred.payload.len()].copy_from_slice(&shred.payload);
+        batch[0].packets[1].meta.size = shred.payload.len();
+
+        let rv = verifier.verify_batch(batch);
+        assert_eq!(rv[0].packets[0].meta.discard, false);
+        assert_eq!(rv[0].packets[1].meta.discard, true);
+    }
+    #[test]
+    fn test_read_slots() {
         solana_logger::setup();
         let mut shred = Shred::new_from_data(
             0xdeadc0de,
@@ -117,37 +140,6 @@ pub mod tests {
         batch[1].packets[0].meta.size = shred.payload.len();
 
         let expected: HashSet<u64> = [0xc0dedead, 0xdeadc0de].iter().cloned().collect();
-        assert_eq!(ShredSigVerifier::read_slots(&batch), expected);
-    }
-
-    #[test]
-    fn test_sigverify_shreds_verify_batch() {
-        let leader_keypair = Arc::new(Keypair::new());
-        let leader_pubkey = leader_keypair.pubkey();
-        let bank =
-            Bank::new(&create_genesis_config_with_leader(100, &leader_pubkey, 10).genesis_config);
-        let cache = Arc::new(LeaderScheduleCache::new_from_bank(&bank));
-        let bf = Arc::new(RwLock::new(BankForks::new(0, bank)));
-        let verifier = ShredSigVerifier::new(bf, cache);
-
-        let mut batch = vec![Packets::default()];
-        batch[0].packets.resize(2, Packet::default());
-
-        let mut shred =
-            Shred::new_from_data(0, 0xc0de, 0xdead, Some(&[1, 2, 3, 4]), true, true, 0, 0);
-        Shredder::sign_shred(&leader_keypair, &mut shred);
-        batch[0].packets[0].data[0..shred.payload.len()].copy_from_slice(&shred.payload);
-        batch[0].packets[0].meta.size = shred.payload.len();
-
-        let mut shred =
-            Shred::new_from_data(0, 0xbeef, 0xc0de, Some(&[1, 2, 3, 4]), true, true, 0, 0);
-        let wrong_keypair = Keypair::new();
-        Shredder::sign_shred(&wrong_keypair, &mut shred);
-        batch[0].packets[1].data[0..shred.payload.len()].copy_from_slice(&shred.payload);
-        batch[0].packets[1].meta.size = shred.payload.len();
-
-        let rv = verifier.verify_batch(batch);
-        assert_eq!(rv[0].packets[0].meta.discard, false);
-        assert_eq!(rv[0].packets[1].meta.discard, true);
+        assert_eq!(read_slots(&batch), expected);
     }
 }

--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -12,7 +12,7 @@ use rayon::iter::ParallelIterator;
 use rayon::ThreadPool;
 use solana_ledger::blocktree::{self, Blocktree};
 use solana_ledger::leader_schedule_cache::LeaderScheduleCache;
-use solana_ledger::shred::Shred;
+use solana_ledger::shred::ShredHeaders;
 use solana_metrics::{inc_new_counter_debug, inc_new_counter_error};
 use solana_rayon_threadlimit::get_thread_count;
 use solana_runtime::bank::Bank;
@@ -24,20 +24,19 @@ use std::sync::{Arc, RwLock};
 use std::thread::{self, Builder, JoinHandle};
 use std::time::{Duration, Instant};
 
-fn verify_shred_slot(shred: &Shred, root: u64) -> bool {
-    if shred.is_data() {
-        // Only data shreds have parent information
-        blocktree::verify_shred_slots(shred.slot(), shred.parent(), root)
-    } else {
-        // Filter out outdated coding shreds
-        shred.slot() >= root
+fn verify_shred_slot(shred: &ShredHeaders, root: u64) -> bool {
+    match shred {
+        ShredHeaders::Data { common_header, .. } => {
+            blocktree::verify_shred_slots(common_header.slot, shred.parent(), root)
+        }
+        ShredHeaders::Coding { common_header, .. } => common_header.slot >= root,
     }
 }
 
 /// drop shreds that are from myself or not from the correct leader for the
 /// shred's slot
 pub fn should_retransmit_and_persist(
-    shred: &Shred,
+    shred: &ShredHeaders,
     bank: Option<Arc<Bank>>,
     leader_schedule_cache: &Arc<LeaderScheduleCache>,
     my_pubkey: &Pubkey,
@@ -50,12 +49,15 @@ pub fn should_retransmit_and_persist(
     };
     if let Some(leader_id) = slot_leader_pubkey {
         if leader_id == *my_pubkey {
+            debug!("packet discarded: shred pubkey check failed");
             inc_new_counter_debug!("streamer-recv_window-circular_transmission", 1);
             false
         } else if !verify_shred_slot(shred, root) {
+            debug!("packet discarded: shred slot check failed");
             inc_new_counter_debug!("streamer-recv_window-outdated_transmission", 1);
             false
         } else if shred.version() != shred_version {
+            debug!("packet discarded: shred version check failed");
             inc_new_counter_debug!("streamer-recv_window-incorrect_shred_version", 1);
             false
         } else {
@@ -66,7 +68,12 @@ pub fn should_retransmit_and_persist(
         false
     }
 }
-
+fn count_valid_packets(packets: &[Packets]) -> usize {
+    fn count_all(packets: &Packets) -> usize {
+        packets.packets.iter().filter(|p| !p.meta.discard).count()
+    }
+    packets.iter().map(|p| count_all(p)).sum()
+}
 fn recv_window<F>(
     blocktree: &Arc<Blocktree>,
     my_pubkey: &Pubkey,
@@ -77,7 +84,7 @@ fn recv_window<F>(
     leader_schedule_cache: &Arc<LeaderScheduleCache>,
 ) -> Result<()>
 where
-    F: Fn(&Shred, u64) -> bool + Sync,
+    F: Fn(&ShredHeaders, u64) -> bool + Sync,
 {
     let timer = Duration::from_millis(200);
     let mut packets = verified_receiver.recv_timeout(timer)?;
@@ -93,41 +100,34 @@ where
     inc_new_counter_debug!("streamer-recv_window-recv", total_packets);
 
     let last_root = blocktree.last_root();
-    let shreds: Vec<_> = thread_pool.install(|| {
-        packets
-            .par_iter_mut()
-            .flat_map(|packets| {
-                packets
-                    .packets
-                    .iter_mut()
-                    .filter_map(|packet| {
-                        if packet.meta.discard {
-                            inc_new_counter_debug!("streamer-recv_window-invalid_signature", 1);
-                            None
-                        } else if let Ok(shred) =
-                            Shred::new_from_serialized_shred(packet.data.to_vec())
-                        {
-                            if shred_filter(&shred, last_root) {
-                                packet.meta.slot = shred.slot();
-                                packet.meta.seed = shred.seed();
-                                Some(shred)
-                            } else {
-                                packet.meta.discard = true;
-                                None
-                            }
-                        } else {
-                            packet.meta.discard = true;
-                            None
-                        }
-                    })
-                    .collect::<Vec<_>>()
-            })
-            .collect()
+    thread_pool.install(|| {
+        packets.par_iter_mut().for_each(|packets| {
+            packets.packets.iter_mut().for_each(|packet| {
+                if packet.meta.discard {
+                    inc_new_counter_debug!("streamer-recv_window-invalid_signature", 1);
+                } else if let Ok(shred) = ShredHeaders::from_packet(&packet) {
+                    if shred_filter(&shred, last_root) {
+                        packet.meta.slot = shred.slot();
+                        packet.meta.seed = shred.seed();
+                    } else {
+                        packet.meta.discard = true;
+                    }
+                } else {
+                    packet.meta.discard = true;
+                }
+            });
+        });
     });
+    let count: usize = count_valid_packets(&packets);
 
-    trace!("{:?} shreds from packets", shreds.len());
+    trace!("{:?} shreds from packets", count);
 
     trace!("{} num total shreds received: {}", my_pubkey, total_packets);
+
+    let metrics = blocktree.insert_batch(&packets, Some(leader_schedule_cache), false)?;
+    for metrics in &metrics {
+        metrics.report_metrics("recv-window-insert-shreds");
+    }
 
     for packets in packets.into_iter() {
         if !packets.is_empty() {
@@ -135,10 +135,6 @@ where
             let _ = retransmit.send(packets);
         }
     }
-
-    let blocktree_insert_metrics =
-        blocktree.insert_shreds(shreds, Some(leader_schedule_cache), false)?;
-    blocktree_insert_metrics.report_metrics("recv-window-insert-shreds");
 
     trace!(
         "Elapsed processing time in recv_window(): {}",
@@ -186,7 +182,7 @@ impl WindowService {
     ) -> WindowService
     where
         F: 'static
-            + Fn(&Pubkey, &Shred, Option<Arc<Bank>>, u64) -> bool
+            + Fn(&Pubkey, &ShredHeaders, Option<Arc<Bank>>, u64) -> bool
             + std::marker::Send
             + std::marker::Sync,
     {
@@ -286,12 +282,14 @@ mod test {
     use crossbeam_channel::unbounded;
     use rand::thread_rng;
     use solana_ledger::shred::DataShredHeader;
+    use solana_ledger::shred::Shred;
     use solana_ledger::{
         blocktree::{make_many_slot_entries, Blocktree},
         entry::{create_ticks, Entry},
         get_tmp_ledger_path,
         shred::Shredder,
     };
+    use solana_perf::recycler_cache::RecyclerCache;
     use solana_sdk::{
         clock::Slot,
         epoch_schedule::MINIMUM_SLOTS_PER_EPOCH,
@@ -313,9 +311,10 @@ mod test {
         parent: Slot,
         keypair: &Arc<Keypair>,
     ) -> Vec<Shred> {
-        let shredder = Shredder::new(slot, parent, 0.0, keypair.clone(), 0, 0)
+        let cache = RecyclerCache::default();
+        let shredder = Shredder::new(slot, parent, 0.0, keypair.clone(), None, 0, 0)
             .expect("Failed to create entry shredder");
-        shredder.entries_to_shreds(&entries, true, 0).0
+        Shred::from_packets(shredder.entries_to_shreds(&cache, &entries, true, 0).0)
     }
 
     #[test]
@@ -327,7 +326,7 @@ mod test {
         let mut shreds = local_entries_to_shred(&original_entries, 0, 0, &Arc::new(Keypair::new()));
         shreds.reverse();
         blocktree
-            .insert_shreds(shreds, None, false)
+            .insert_test_shreds(shreds, None, false)
             .expect("Expect successful processing of shred");
 
         assert_eq!(
@@ -353,12 +352,26 @@ mod test {
 
         // with a Bank for slot 0, shred continues
         assert_eq!(
-            should_retransmit_and_persist(&shreds[0], Some(bank.clone()), &cache, &me_id, 0, 0),
+            should_retransmit_and_persist(
+                &shreds[0].headers(),
+                Some(bank.clone()),
+                &cache,
+                &me_id,
+                0,
+                0
+            ),
             true
         );
         // with the wrong shred_version, shred gets thrown out
         assert_eq!(
-            should_retransmit_and_persist(&shreds[0], Some(bank.clone()), &cache, &me_id, 0, 1),
+            should_retransmit_and_persist(
+                &shreds[0].headers(),
+                Some(bank.clone()),
+                &cache,
+                &me_id,
+                0,
+                1
+            ),
             false
         );
 
@@ -368,22 +381,50 @@ mod test {
             Shred::new_empty_from_header(common, DataShredHeader::default(), coding);
         Shredder::sign_shred(&leader_keypair, &mut coding_shred);
         assert_eq!(
-            should_retransmit_and_persist(&coding_shred, Some(bank.clone()), &cache, &me_id, 0, 0),
+            should_retransmit_and_persist(
+                &coding_shred.headers(),
+                Some(bank.clone()),
+                &cache,
+                &me_id,
+                0,
+                0
+            ),
             true
         );
         assert_eq!(
-            should_retransmit_and_persist(&coding_shred, Some(bank.clone()), &cache, &me_id, 5, 0),
+            should_retransmit_and_persist(
+                &coding_shred.headers(),
+                Some(bank.clone()),
+                &cache,
+                &me_id,
+                5,
+                0
+            ),
             true
         );
         assert_eq!(
-            should_retransmit_and_persist(&coding_shred, Some(bank.clone()), &cache, &me_id, 6, 0),
+            should_retransmit_and_persist(
+                &coding_shred.headers(),
+                Some(bank.clone()),
+                &cache,
+                &me_id,
+                6,
+                0
+            ),
             false
         );
 
         // with a Bank and no idea who leader is, shred gets thrown out
         shreds[0].set_slot(MINIMUM_SLOTS_PER_EPOCH as u64 * 3);
         assert_eq!(
-            should_retransmit_and_persist(&shreds[0], Some(bank.clone()), &cache, &me_id, 0, 0),
+            should_retransmit_and_persist(
+                &shreds[0].headers(),
+                Some(bank.clone()),
+                &cache,
+                &me_id,
+                0,
+                0
+            ),
             false
         );
 
@@ -391,7 +432,14 @@ mod test {
         let slot = MINIMUM_SLOTS_PER_EPOCH as u64 * 3;
         let shreds = local_entries_to_shred(&[Entry::default()], slot, slot - 1, &leader_keypair);
         assert_eq!(
-            should_retransmit_and_persist(&shreds[0], Some(bank.clone()), &cache, &me_id, slot, 0),
+            should_retransmit_and_persist(
+                &shreds[0].headers(),
+                Some(bank.clone()),
+                &cache,
+                &me_id,
+                slot,
+                0
+            ),
             false
         );
 
@@ -400,13 +448,20 @@ mod test {
         let shreds =
             local_entries_to_shred(&[Entry::default()], slot + 1, slot - 1, &leader_keypair);
         assert_eq!(
-            should_retransmit_and_persist(&shreds[0], Some(bank.clone()), &cache, &me_id, slot, 0),
+            should_retransmit_and_persist(
+                &shreds[0].headers(),
+                Some(bank.clone()),
+                &cache,
+                &me_id,
+                slot,
+                0
+            ),
             false
         );
 
         // if the shred came back from me, it doesn't continue, whether or not I have a bank
         assert_eq!(
-            should_retransmit_and_persist(&shreds[0], None, &cache, &me_id, 0, 0),
+            should_retransmit_and_persist(&shreds[0].headers(), None, &cache, &me_id, 0, 0),
             false
         );
     }

--- a/ledger/src/leader_schedule_cache.rs
+++ b/ledger/src/leader_schedule_cache.rs
@@ -458,7 +458,7 @@ mod tests {
             // Write a shred into slot 2 that chains to slot 1,
             // but slot 1 is empty so should not be skipped
             let (shreds, _) = make_slot_entries(2, 1, 1);
-            blocktree.insert_shreds(shreds, None, false).unwrap();
+            blocktree.insert_test_shreds(shreds, None, false).unwrap();
             assert_eq!(
                 cache
                     .next_leader_slot(&pubkey, 0, &bank, Some(&blocktree))
@@ -471,7 +471,7 @@ mod tests {
             let (shreds, _) = make_slot_entries(1, 0, 1);
 
             // Check that slot 1 and 2 are skipped
-            blocktree.insert_shreds(shreds, None, false).unwrap();
+            blocktree.insert_test_shreds(shreds, None, false).unwrap();
             assert_eq!(
                 cache
                     .next_leader_slot(&pubkey, 0, &bank, Some(&blocktree))

--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -2,25 +2,30 @@
 use crate::{
     entry::{create_ticks, Entry},
     erasure::Session,
+    sigverify_shreds,
 };
 use core::cell::RefCell;
+use core::mem::size_of;
+use rayon::iter::IntoParallelRefIterator;
 use rayon::{
-    iter::{IndexedParallelIterator, IntoParallelRefMutIterator, ParallelIterator},
+    iter::{IndexedParallelIterator, ParallelIterator},
     slice::ParallelSlice,
     ThreadPool,
 };
 use serde::{Deserialize, Serialize};
 use solana_metrics::datapoint_debug;
-use solana_perf::packet::Packet;
+use solana_perf::cuda_runtime::PinnedVec;
+use solana_perf::packet::batch_size;
+use solana_perf::packet::Packets;
+use solana_perf::recycler_cache::{RecyclerCache, PACKETS_CAPACITY};
 use solana_rayon_threadlimit::get_thread_count;
 use solana_sdk::{
     clock::Slot,
     hash::Hash,
-    packet::PACKET_DATA_SIZE,
+    packet::{Packet, PACKET_DATA_SIZE},
     pubkey::Pubkey,
     signature::{Keypair, KeypairUtil, Signature},
 };
-use std::mem::size_of;
 use std::{sync::Arc, time::Instant};
 use thiserror::Error;
 
@@ -88,6 +93,25 @@ pub struct ShredCommonHeader {
     pub index: u32,
     pub version: u16,
 }
+impl ShredCommonHeader {
+    pub fn read_packet(start: &mut usize, packet: &Packet) -> Result<Self> {
+        let common_header: ShredCommonHeader =
+            Shred::deserialize_obj(start, SIZE_OF_COMMON_SHRED_HEADER, &packet.data)?;
+        Ok(common_header)
+    }
+
+    pub fn from_packet(packet: &Packet) -> Result<Self> {
+        let mut start = 0;
+        Self::read_packet(&mut start, packet)
+    }
+    pub fn seed(&self) -> [u8; 32] {
+        let mut seed = [0; 32];
+        let seed_len = seed.len();
+        let sig = self.signature.as_ref();
+        seed[0..seed_len].copy_from_slice(&sig[(sig.len() - seed_len)..]);
+        seed
+    }
+}
 
 /// The data shred header has parent offset and flags
 #[derive(Serialize, Clone, Default, Deserialize, PartialEq, Debug)]
@@ -102,6 +126,84 @@ pub struct CodingShredHeader {
     pub num_data_shreds: u16,
     pub num_coding_shreds: u16,
     pub position: u16,
+}
+
+#[derive(Debug, PartialEq)]
+pub enum ShredHeaders {
+    Data {
+        common_header: ShredCommonHeader,
+        data_header: DataShredHeader,
+    },
+    Coding {
+        common_header: ShredCommonHeader,
+        coding_header: CodingShredHeader,
+    },
+}
+
+impl ShredHeaders {
+    pub fn from_packet(packet: &Packet) -> Result<Self> {
+        let mut start = 0;
+        let common_header = ShredCommonHeader::read_packet(&mut start, packet)?;
+        if common_header.shred_type == ShredType(DATA_SHRED) {
+            let data_header: DataShredHeader =
+                Shred::deserialize_obj(&mut start, SIZE_OF_DATA_SHRED_HEADER, &packet.data)?;
+            Ok(ShredHeaders::Data {
+                common_header,
+                data_header,
+            })
+        } else if common_header.shred_type == ShredType(CODING_SHRED) {
+            let coding_header: CodingShredHeader =
+                Shred::deserialize_obj(&mut start, SIZE_OF_CODING_SHRED_HEADER, &packet.data)?;
+            Ok(ShredHeaders::Coding {
+                common_header,
+                coding_header,
+            })
+        } else {
+            Err(ShredError::InvalidShredType)
+        }
+    }
+    pub fn from_shred(shred: &Shred) -> Self {
+        let common_header = shred.common_header.clone();
+        if common_header.shred_type == ShredType(DATA_SHRED) {
+            ShredHeaders::Data {
+                common_header,
+                data_header: shred.data_header.clone(),
+            }
+        } else {
+            assert_eq!(common_header.shred_type, ShredType(CODING_SHRED));
+            ShredHeaders::Coding {
+                common_header,
+                coding_header: shred.coding_header.clone(),
+            }
+        }
+    }
+    pub fn parent(&self) -> Slot {
+        match self {
+            ShredHeaders::Data {
+                common_header,
+                data_header,
+            } => common_header.slot - u64::from(data_header.parent_offset),
+            _ => std::u64::MAX,
+        }
+    }
+    pub fn slot(&self) -> Slot {
+        match self {
+            ShredHeaders::Data { common_header, .. } => common_header.slot,
+            ShredHeaders::Coding { common_header, .. } => common_header.slot,
+        }
+    }
+    pub fn seed(&self) -> [u8; 32] {
+        match self {
+            ShredHeaders::Data { common_header, .. } => common_header.seed(),
+            ShredHeaders::Coding { common_header, .. } => common_header.seed(),
+        }
+    }
+    pub fn version(&self) -> u16 {
+        match self {
+            ShredHeaders::Data { common_header, .. } => common_header.version,
+            ShredHeaders::Coding { common_header, .. } => common_header.version,
+        }
+    }
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -136,6 +238,29 @@ impl Shred {
         bincode::serialize_into(&mut buf[*index..*index + size], obj)?;
         *index += size;
         Ok(())
+    }
+
+    pub fn headers(&self) -> ShredHeaders {
+        ShredHeaders::from_shred(self)
+    }
+    pub fn from_packet(packet: &Packet) -> Self {
+        Self::new_from_serialized_shred(packet.data.to_vec()).expect("valid shred")
+    }
+
+    pub fn make_packets(shreds: &[Shred]) -> Packets {
+        let mut packets = Packets::default();
+        for s in shreds {
+            let mut p = Packet::default();
+            s.copy_to_packet(&mut p);
+            packets.packets.push(p);
+        }
+        packets
+    }
+    pub fn from_packets(packets: Vec<Packets>) -> Vec<Shred> {
+        packets
+            .iter()
+            .flat_map(|p| p.packets.iter().map(|p| Shred::from_packet(p)))
+            .collect()
     }
 
     pub fn copy_to_packet(&self, packet: &mut Packet) {
@@ -327,11 +452,7 @@ impl Shred {
     }
 
     pub fn seed(&self) -> [u8; 32] {
-        let mut seed = [0; 32];
-        let seed_len = seed.len();
-        let sig = self.common_header.signature.as_ref();
-        seed[0..seed_len].copy_from_slice(&sig[(sig.len() - seed_len)..]);
-        seed
+        self.common_header.seed()
     }
 
     pub fn is_data(&self) -> bool {
@@ -404,6 +525,7 @@ pub struct Shredder {
     version: u16,
     fec_rate: f32,
     keypair: Arc<Keypair>,
+    pinned_keypair: Option<Arc<PinnedVec<u8>>>,
     pub signing_coding_time: u128,
     reference_tick: u8,
 }
@@ -414,6 +536,7 @@ impl Shredder {
         parent_slot: Slot,
         fec_rate: f32,
         keypair: Arc<Keypair>,
+        pinned_keypair: Option<Arc<PinnedVec<u8>>>,
         reference_tick: u8,
         version: u16,
     ) -> Result<Self> {
@@ -426,6 +549,7 @@ impl Shredder {
                 slot,
                 parent_slot,
                 fec_rate,
+                pinned_keypair,
                 keypair,
                 signing_coding_time: 0,
                 reference_tick,
@@ -434,17 +558,17 @@ impl Shredder {
         }
     }
 
-    pub fn entries_to_shreds(
+    pub fn entries_to_unsigned_data_shreds(
         &self,
+        recycler_cache: &RecyclerCache,
         entries: &[Entry],
         is_last_in_slot: bool,
         next_shred_index: u32,
-    ) -> (Vec<Shred>, Vec<Shred>, u32) {
+    ) -> (Vec<Packets>, u32) {
         let now = Instant::now();
         let serialized_shreds =
             bincode::serialize(entries).expect("Expect to serialize all entries");
-        let serialize_time = now.elapsed().as_millis();
-
+        let serialize_time = now.elapsed().as_micros();
         let now = Instant::now();
 
         let no_header_size = SIZE_OF_DATA_SHRED_PAYLOAD;
@@ -452,49 +576,108 @@ impl Shredder {
         let last_shred_index = next_shred_index + num_shreds as u32 - 1;
 
         // 1) Generate data shreds
-        let data_shreds: Vec<Shred> = PAR_THREAD_POOL.with(|thread_pool| {
+        let data_shreds: Vec<Packets> = PAR_THREAD_POOL.with(|thread_pool| {
             thread_pool.borrow().install(|| {
                 serialized_shreds
                     .par_chunks(no_header_size)
                     .enumerate()
-                    .map(|(i, shred_data)| {
-                        let shred_index = next_shred_index + i as u32;
-
-                        let (is_last_data, is_last_in_slot) = {
-                            if shred_index == last_shred_index {
-                                (true, is_last_in_slot)
-                            } else {
-                                (false, false)
-                            }
-                        };
-
-                        let mut shred = Shred::new_from_data(
-                            self.slot,
-                            shred_index,
-                            (self.slot - self.parent_slot) as u16,
-                            Some(shred_data),
-                            is_last_data,
-                            is_last_in_slot,
-                            self.reference_tick,
-                            self.version,
+                    .chunks(PACKETS_CAPACITY)
+                    .map(|chunk| {
+                        let mut packets = Packets::new_with_recycler(
+                            recycler_cache.packets().clone(),
+                            PACKETS_CAPACITY as usize,
+                            "data shreds",
                         );
+                        for (i, shred_data) in &chunk {
+                            let shred_index = next_shred_index + *i as u32;
 
-                        Shredder::sign_shred(&self.keypair, &mut shred);
-                        shred
+                            let (is_last_data, is_last_in_slot) = {
+                                if shred_index == last_shred_index {
+                                    (true, is_last_in_slot)
+                                } else {
+                                    (false, false)
+                                }
+                            };
+
+                            let shred = Shred::new_from_data(
+                                self.slot,
+                                shred_index,
+                                (self.slot - self.parent_slot) as u16,
+                                Some(shred_data),
+                                is_last_data,
+                                is_last_in_slot,
+                                self.reference_tick,
+                                self.version,
+                            );
+                            let mut p = Packet::default();
+                            shred.copy_to_packet(&mut p);
+                            packets.packets.push(p);
+                        }
+                        packets.packets.resize(chunk.len(), Packet::default());
+                        packets
                     })
                     .collect()
             })
         });
-        let gen_data_time = now.elapsed().as_millis();
+        let gen_data_time = now.elapsed().as_micros();
+        datapoint_debug!(
+            "shredding-stats",
+            ("slot", self.slot as i64, i64),
+            ("num_shreds", num_shreds as i64, i64),
+            ("serialzing", serialize_time as i64, i64),
+            ("gen_data", gen_data_time as i64, i64),
+        );
+
+        (data_shreds, last_shred_index)
+    }
+
+    pub fn test_entries_to_shreds(
+        &self,
+        entries: &[Entry],
+        is_last_in_slot: bool,
+        next_shred_index: u32,
+    ) -> (Vec<Shred>, Vec<Shred>, u32) {
+        let recycler_cache = RecyclerCache::default();
+        let (data, coding, sz) =
+            self.entries_to_shreds(&recycler_cache, entries, is_last_in_slot, next_shred_index);
+        let data = Shred::from_packets(data);
+        let coding = Shred::from_packets(coding);
+        (data, coding, sz)
+    }
+
+    pub fn entries_to_shreds(
+        &self,
+        recycler_cache: &RecyclerCache,
+        entries: &[Entry],
+        is_last_in_slot: bool,
+        next_shred_index: u32,
+    ) -> (Vec<Packets>, Vec<Packets>, u32) {
+        let (mut data_shreds, last_shred_index) = self.entries_to_unsigned_data_shreds(
+            recycler_cache,
+            entries,
+            is_last_in_slot,
+            next_shred_index,
+        );
+
+        let now = Instant::now();
+        //key values
+        sigverify_shreds::sign_shreds_gpu(
+            &self.keypair,
+            &self.pinned_keypair,
+            &mut data_shreds,
+            recycler_cache,
+        );
+        let sign_data_time = now.elapsed().as_micros();
 
         let now = Instant::now();
         // 2) Generate coding shreds
-        let mut coding_shreds: Vec<_> = PAR_THREAD_POOL.with(|thread_pool| {
+        let mut coding_shreds: Vec<Packets> = PAR_THREAD_POOL.with(|thread_pool| {
             thread_pool.borrow().install(|| {
                 data_shreds
-                    .par_chunks(MAX_DATA_SHREDS_PER_FEC_BLOCK as usize)
-                    .flat_map(|shred_data_batch| {
+                    .par_iter()
+                    .filter_map(|shred_data_batch| {
                         Shredder::generate_coding_shreds(
+                            recycler_cache,
                             self.slot,
                             self.fec_rate,
                             shred_data_batch,
@@ -504,28 +687,25 @@ impl Shredder {
                     .collect()
             })
         });
-        let gen_coding_time = now.elapsed().as_millis();
+        let gen_coding_time = now.elapsed().as_micros();
 
         let now = Instant::now();
-        // 3) Sign coding shreds
-        PAR_THREAD_POOL.with(|thread_pool| {
-            thread_pool.borrow().install(|| {
-                coding_shreds.par_iter_mut().for_each(|mut coding_shred| {
-                    Shredder::sign_shred(&self.keypair, &mut coding_shred);
-                })
-            })
-        });
-        let sign_coding_time = now.elapsed().as_millis();
+        sigverify_shreds::sign_shreds_gpu(
+            &self.keypair,
+            &self.pinned_keypair,
+            &mut coding_shreds,
+            recycler_cache,
+        );
+        let sign_coding_time = now.elapsed().as_micros();
 
         datapoint_debug!(
             "shredding-stats",
             ("slot", self.slot as i64, i64),
-            ("num_data_shreds", data_shreds.len() as i64, i64),
-            ("num_coding_shreds", coding_shreds.len() as i64, i64),
-            ("serializing", serialize_time as i64, i64),
-            ("gen_data", gen_data_time as i64, i64),
+            ("num_data_shreds", batch_size(&data_shreds) as i64, i64),
+            ("num_coding_shreds", batch_size(&coding_shreds) as i64, i64),
             ("gen_coding", gen_coding_time as i64, i64),
             ("sign_coding", sign_coding_time as i64, i64),
+            ("sign_data", sign_data_time as i64, i64),
         );
 
         (data_shreds, coding_shreds, last_shred_index + 1)
@@ -565,29 +745,52 @@ impl Shredder {
 
     /// Generates coding shreds for the data shreds in the current FEC set
     pub fn generate_coding_shreds(
+        recycler_cache: &RecyclerCache,
         slot: Slot,
         fec_rate: f32,
-        data_shred_batch: &[Shred],
+        data_shred_batch: &Packets,
         version: u16,
-    ) -> Vec<Shred> {
-        assert!(!data_shred_batch.is_empty());
-        if fec_rate != 0.0 {
-            let num_data = data_shred_batch.len();
+    ) -> Option<Packets> {
+        if fec_rate == 0.0 {
+            return None;
+        }
+        // Create empty coding shreds, with correctly populated headers
+        let mut coding_shreds = Packets::new_with_recycler(
+            recycler_cache.packets().clone(),
+            PACKETS_CAPACITY as usize,
+            "coding shreds",
+        );
+        assert!(!data_shred_batch.packets.is_empty());
+        let end = (data_shred_batch.packets.len() / MAX_DATA_SHREDS_PER_FEC_BLOCK as usize) + 1;
+        for i in 0..end {
+            let start = i * MAX_DATA_SHREDS_PER_FEC_BLOCK as usize;
+            let end = std::cmp::min(
+                data_shred_batch.packets.len(),
+                start + MAX_DATA_SHREDS_PER_FEC_BLOCK as usize,
+            );
+            let packets = &data_shred_batch.packets[start..end];
+            let num_data = packets.len();
+            if num_data == 0 {
+                continue;
+            }
+            assert!(num_data <= MAX_DATA_SHREDS_PER_FEC_BLOCK as usize);
             // always generate at least 1 coding shred even if the fec_rate doesn't allow it
             let num_coding = Self::calculate_num_coding_shreds(num_data as f32, fec_rate);
+            assert!(num_coding > 0);
             let session =
                 Session::new(num_data, num_coding).expect("Failed to create erasure session");
-            let start_index = data_shred_batch[0].common_header.index;
+            let common_header =
+                ShredCommonHeader::from_packet(&packets[0]).expect("invalid packet");
+            let start_index = common_header.index;
 
             // All information after coding shred field in a data shred is encoded
             let valid_data_len = PACKET_DATA_SIZE - SIZE_OF_DATA_SHRED_IGNORED_TAIL;
-            let data_ptrs: Vec<_> = data_shred_batch
+            let data_ptrs: Vec<_> = packets
                 .iter()
-                .map(|data| &data.payload[..valid_data_len])
+                .map(|packet| &packet.data[..valid_data_len])
                 .collect();
 
-            // Create empty coding shreds, with correctly populated headers
-            let mut coding_shreds = Vec::with_capacity(num_coding);
+            let start = coding_shreds.packets.len();
             (0..num_coding).for_each(|i| {
                 let (header, coding_header) = Self::new_coding_shred_header(
                     slot,
@@ -599,45 +802,24 @@ impl Shredder {
                 );
                 let shred =
                     Shred::new_empty_from_header(header, DataShredHeader::default(), coding_header);
-                coding_shreds.push(shred.payload);
+                let mut p = Packet::default();
+                shred.copy_to_packet(&mut p);
+                coding_shreds.packets.push(p);
             });
 
             // Grab pointers for the coding blocks
             let coding_block_offset = SIZE_OF_COMMON_SHRED_HEADER + SIZE_OF_CODING_SHRED_HEADER;
-            let mut coding_ptrs: Vec<_> = coding_shreds
+            let mut coding_ptrs: Vec<_> = coding_shreds.packets[start..]
                 .iter_mut()
-                .map(|buffer| &mut buffer[coding_block_offset..])
+                .map(|packet| &mut packet.data[coding_block_offset..])
                 .collect();
 
-            // Create coding blocks
+            // Create coding blocks in place
             session
                 .encode(&data_ptrs, coding_ptrs.as_mut_slice())
                 .expect("Failed in erasure encode");
-
-            // append to the shred list
-            coding_shreds
-                .into_iter()
-                .enumerate()
-                .map(|(i, payload)| {
-                    let (common_header, coding_header) = Self::new_coding_shred_header(
-                        slot,
-                        start_index + i as u32,
-                        num_data,
-                        num_coding,
-                        i,
-                        version,
-                    );
-                    Shred {
-                        common_header,
-                        data_header: DataShredHeader::default(),
-                        coding_header,
-                        payload,
-                    }
-                })
-                .collect()
-        } else {
-            vec![]
         }
+        Some(coding_shreds)
     }
 
     fn calculate_num_coding_shreds(num_data_shreds: f32, fec_rate: f32) -> usize {
@@ -808,6 +990,21 @@ impl Shredder {
             .cloned()
             .collect()
     }
+    fn packet_seed(packet: &Packet) -> Result<[u8; 32]> {
+        Ok(ShredCommonHeader::from_packet(packet)?.seed())
+    }
+    pub fn seeds(shreds: &[Packets]) -> Vec<Vec<[u8; 32]>> {
+        shreds
+            .iter()
+            .map(|packets| {
+                packets
+                    .packets
+                    .iter()
+                    .map(|s| Shredder::packet_seed(s).expect("invalid packet"))
+                    .collect()
+            })
+            .collect()
+    }
 }
 
 pub fn max_ticks_per_n_shreds(num_shreds: u64) -> u64 {
@@ -893,11 +1090,12 @@ pub mod tests {
     #[test]
     fn test_data_shredder() {
         let keypair = Arc::new(Keypair::new());
+        let recycler_cache = RecyclerCache::default();
         let slot = 0x123456789abcdef0;
 
         // Test that parent cannot be > current slot
         assert_matches!(
-            Shredder::new(slot, slot + 1, 1.00, keypair.clone(), 0, 0),
+            Shredder::new(slot, slot + 1, 1.00, keypair.clone(), None, 0, 0),
             Err(ShredError::SlotTooLow {
                 slot: _,
                 parent_slot: _,
@@ -905,7 +1103,7 @@ pub mod tests {
         );
         // Test that slot - parent cannot be > u16 MAX
         assert_matches!(
-            Shredder::new(slot, slot - 1 - 0xffff, 1.00, keypair.clone(), 0, 0),
+            Shredder::new(slot, slot - 1 - 0xffff, 1.00, keypair.clone(), None, 0, 0),
             Err(ShredError::SlotTooLow {
                 slot: _,
                 parent_slot: _,
@@ -914,7 +1112,7 @@ pub mod tests {
 
         let fec_rate = 0.25;
         let parent_slot = slot - 5;
-        let shredder = Shredder::new(slot, parent_slot, fec_rate, keypair.clone(), 0, 0)
+        let shredder = Shredder::new(slot, parent_slot, fec_rate, keypair.clone(), None, 0, 0)
             .expect("Failed in creating shredder");
 
         let entries: Vec<_> = (0..5)
@@ -935,11 +1133,12 @@ pub mod tests {
 
         let start_index = 0;
         let (data_shreds, coding_shreds, next_index) =
-            shredder.entries_to_shreds(&entries, true, start_index);
+            shredder.entries_to_shreds(&recycler_cache, &entries, true, start_index);
         assert_eq!(next_index as u64, num_expected_data_shreds);
 
         let mut data_shred_indexes = HashSet::new();
         let mut coding_shred_indexes = HashSet::new();
+        let data_shreds = Shred::from_packets(data_shreds);
         for shred in data_shreds.iter() {
             assert_eq!(shred.common_header.shred_type, ShredType(DATA_SHRED));
             let index = shred.common_header.index;
@@ -958,6 +1157,7 @@ pub mod tests {
             data_shred_indexes.insert(index);
         }
 
+        let coding_shreds = Shred::from_packets(coding_shreds);
         for shred in coding_shreds.iter() {
             let index = shred.common_header.index;
             assert_eq!(shred.common_header.shred_type, ShredType(CODING_SHRED));
@@ -985,11 +1185,12 @@ pub mod tests {
 
     #[test]
     fn test_deserialize_shred_payload() {
+        let recycler_cache = RecyclerCache::default();
         let keypair = Arc::new(Keypair::new());
         let slot = 1;
 
         let parent_slot = 0;
-        let shredder = Shredder::new(slot, parent_slot, 0.0, keypair.clone(), 0, 0)
+        let shredder = Shredder::new(slot, parent_slot, 0.0, keypair.clone(), None, 0, 0)
             .expect("Failed in creating shredder");
 
         let entries: Vec<_> = (0..5)
@@ -1002,8 +1203,10 @@ pub mod tests {
             })
             .collect();
 
-        let data_shreds = shredder.entries_to_shreds(&entries, true, 0).0;
-
+        let data_shreds = shredder
+            .entries_to_shreds(&recycler_cache, &entries, true, 0)
+            .0;
+        let data_shreds = Shred::from_packets(data_shreds);
         let deserialized_shred =
             Shred::new_from_serialized_shred(data_shreds.last().unwrap().payload.clone()).unwrap();
         assert_eq!(deserialized_shred, *data_shreds.last().unwrap());
@@ -1011,11 +1214,12 @@ pub mod tests {
 
     #[test]
     fn test_shred_reference_tick() {
+        let recycler_cache = RecyclerCache::default();
         let keypair = Arc::new(Keypair::new());
         let slot = 1;
 
         let parent_slot = 0;
-        let shredder = Shredder::new(slot, parent_slot, 0.0, keypair.clone(), 5, 0)
+        let shredder = Shredder::new(slot, parent_slot, 0.0, keypair.clone(), None, 5, 0)
             .expect("Failed in creating shredder");
 
         let entries: Vec<_> = (0..5)
@@ -1028,7 +1232,10 @@ pub mod tests {
             })
             .collect();
 
-        let data_shreds = shredder.entries_to_shreds(&entries, true, 0).0;
+        let data_shreds = shredder
+            .entries_to_shreds(&recycler_cache, &entries, true, 0)
+            .0;
+        let data_shreds = Shred::from_packets(data_shreds);
         data_shreds.iter().for_each(|s| {
             assert_eq!(s.reference_tick(), 5);
             assert_eq!(Shred::reference_tick_from_data(&s.payload), 5);
@@ -1041,12 +1248,21 @@ pub mod tests {
 
     #[test]
     fn test_shred_reference_tick_overflow() {
+        let recycler_cache = RecyclerCache::default();
         let keypair = Arc::new(Keypair::new());
         let slot = 1;
 
         let parent_slot = 0;
-        let shredder = Shredder::new(slot, parent_slot, 0.0, keypair.clone(), u8::max_value(), 0)
-            .expect("Failed in creating shredder");
+        let shredder = Shredder::new(
+            slot,
+            parent_slot,
+            0.0,
+            keypair.clone(),
+            None,
+            u8::max_value(),
+            0,
+        )
+        .expect("Failed in creating shredder");
 
         let entries: Vec<_> = (0..5)
             .map(|_| {
@@ -1058,7 +1274,10 @@ pub mod tests {
             })
             .collect();
 
-        let data_shreds = shredder.entries_to_shreds(&entries, true, 0).0;
+        let data_shreds = shredder
+            .entries_to_shreds(&recycler_cache, &entries, true, 0)
+            .0;
+        let data_shreds = Shred::from_packets(data_shreds);
         data_shreds.iter().for_each(|s| {
             assert_eq!(s.reference_tick(), SHRED_TICK_REFERENCE_MASK);
             assert_eq!(
@@ -1077,17 +1296,26 @@ pub mod tests {
 
     #[test]
     fn test_data_and_code_shredder() {
+        let recycler_cache = RecyclerCache::default();
         let keypair = Arc::new(Keypair::new());
 
         let slot = 0x123456789abcdef0;
         // Test that FEC rate cannot be > 1.0
         assert_matches!(
-            Shredder::new(slot, slot - 5, 1.001, keypair.clone(), 0, 0),
+            Shredder::new(slot, slot - 5, 1.001, keypair.clone(), None, 0, 0),
             Err(ShredError::InvalidFecRate(_))
         );
 
-        let shredder = Shredder::new(0x123456789abcdef0, slot - 5, 1.0, keypair.clone(), 0, 0)
-            .expect("Failed in creating shredder");
+        let shredder = Shredder::new(
+            0x123456789abcdef0,
+            slot - 5,
+            1.0,
+            keypair.clone(),
+            None,
+            0,
+            0,
+        )
+        .expect("Failed in creating shredder");
 
         // Create enough entries to make > 1 shred
         let num_entries = max_ticks_per_n_shreds(1) + 1;
@@ -1101,8 +1329,11 @@ pub mod tests {
             })
             .collect();
 
-        let (data_shreds, coding_shreds, _) = shredder.entries_to_shreds(&entries, true, 0);
+        let (data_shreds, coding_shreds, _) =
+            shredder.entries_to_shreds(&recycler_cache, &entries, true, 0);
 
+        let data_shreds = Shred::from_packets(data_shreds);
+        let coding_shreds = Shred::from_packets(coding_shreds);
         // Must have created an equal number of coding and data shreds
         assert_eq!(data_shreds.len(), coding_shreds.len());
 
@@ -1126,9 +1357,10 @@ pub mod tests {
 
     #[test]
     fn test_recovery_and_reassembly() {
+        let recycler_cache = RecyclerCache::default();
         let keypair = Arc::new(Keypair::new());
         let slot = 0x123456789abcdef0;
-        let shredder = Shredder::new(slot, slot - 5, 1.0, keypair.clone(), 0, 0)
+        let shredder = Shredder::new(slot, slot - 5, 1.0, keypair.clone(), None, 0, 0)
             .expect("Failed in creating shredder");
 
         let keypair0 = Keypair::new();
@@ -1149,7 +1381,10 @@ pub mod tests {
             .collect();
 
         let serialized_entries = bincode::serialize(&entries).unwrap();
-        let (data_shreds, coding_shreds, _) = shredder.entries_to_shreds(&entries, true, 0);
+        let (data_shreds, coding_shreds, _) =
+            shredder.entries_to_shreds(&recycler_cache, &entries, true, 0);
+        let data_shreds = Shred::from_packets(data_shreds);
+        let coding_shreds = Shred::from_packets(coding_shreds);
 
         // We should have 10 shreds now, an equal number of coding shreds
         assert_eq!(data_shreds.len(), num_data_shreds);
@@ -1292,7 +1527,10 @@ pub mod tests {
         // Test5: Try recovery/reassembly with non zero index full slot with 3 missing data shreds
         // and 2 missing coding shreds. Hint: should work
         let serialized_entries = bincode::serialize(&entries).unwrap();
-        let (data_shreds, coding_shreds, _) = shredder.entries_to_shreds(&entries, true, 25);
+        let (data_shreds, coding_shreds, _) =
+            shredder.entries_to_shreds(&recycler_cache, &entries, true, 25);
+        let data_shreds = Shred::from_packets(data_shreds);
+        let coding_shreds = Shred::from_packets(coding_shreds);
 
         // We should have 10 shreds now, an equal number of coding shreds
         assert_eq!(data_shreds.len(), num_data_shreds);
@@ -1375,9 +1613,10 @@ pub mod tests {
         let keypair = Arc::new(Keypair::new());
         let hash = hash(Hash::default().as_ref());
         let version = Shred::version_from_hash(&hash);
+        let recycler_cache = RecyclerCache::default();
         assert_ne!(version, 0);
-        let shredder =
-            Shredder::new(0, 0, 1.0, keypair, 0, version).expect("Failed in creating shredder");
+        let shredder = Shredder::new(0, 0, 1.0, keypair, None, 0, version)
+            .expect("Failed in creating shredder");
 
         let entries: Vec<_> = (0..5)
             .map(|_| {
@@ -1390,11 +1629,11 @@ pub mod tests {
             .collect();
 
         let (data_shreds, coding_shreds, _next_index) =
-            shredder.entries_to_shreds(&entries, true, 0);
-        assert!(!data_shreds
+            shredder.entries_to_shreds(&recycler_cache, &entries, true, 0);
+        assert!(!data_shreds.iter().chain(coding_shreds.iter()).any(|s| s
+            .packets
             .iter()
-            .chain(coding_shreds.iter())
-            .any(|s| s.version() != version));
+            .any(|p| Shred::from_packet(p).version() != version)));
     }
 
     #[test]
@@ -1418,5 +1657,31 @@ pub mod tests {
         ];
         let version = Shred::version_from_hash(&Hash::new(&hash));
         assert_eq!(version, 0x5a5a);
+    }
+
+    #[test]
+    fn test_to_from_packets() {
+        solana_logger::setup();
+        let mut shred = Shred::new_from_data(
+            0xdeadc0de,
+            0xc0de,
+            0xdead,
+            Some(&[1, 2, 3, 4]),
+            true,
+            true,
+            0,
+            0,
+        );
+
+        let keypair = Keypair::new();
+        Shredder::sign_shred(&keypair, &mut shred);
+        let packets = Shred::make_packets(&vec![shred.clone()]);
+        let from_packets = Shred::from_packets(vec![packets.clone()]);
+        assert_eq!(shred, from_packets[0]);
+        assert_eq!(shred.headers(), from_packets[0].headers());
+        assert_eq!(
+            shred.headers(),
+            ShredHeaders::from_packet(&packets.packets[0]).unwrap()
+        );
     }
 }

--- a/ledger/src/sigverify_shreds.rs
+++ b/ledger/src/sigverify_shreds.rs
@@ -13,7 +13,7 @@ use solana_perf::{
     packet::{batch_size, limited_deserialize, Packet, Packets},
     perf_libs,
     recycler_cache::RecyclerCache,
-    sigverify::{self, batch_size, TxOffset},
+    sigverify::{self, TxOffset},
 };
 use solana_rayon_threadlimit::get_thread_count;
 use solana_sdk::pubkey::Pubkey;

--- a/ledger/src/sigverify_shreds.rs
+++ b/ledger/src/sigverify_shreds.rs
@@ -10,7 +10,7 @@ use sha2::{Digest, Sha512};
 use solana_metrics::inc_new_counter_debug;
 use solana_perf::{
     cuda_runtime::PinnedVec,
-    packet::{limited_deserialize, Packet, Packets},
+    packet::{batch_size, limited_deserialize, Packet, Packets},
     perf_libs,
     recycler_cache::RecyclerCache,
     sigverify::{self, batch_size, TxOffset},

--- a/ledger/tests/blocktree.rs
+++ b/ledger/tests/blocktree.rs
@@ -25,7 +25,7 @@ fn test_multiple_threads_insert_shred() {
                 Builder::new()
                     .name("blocktree-writer".to_string())
                     .spawn(move || {
-                        blocktree_.insert_shreds(shreds, None, false).unwrap();
+                        blocktree_.insert_test_shreds(shreds, None, false).unwrap();
                     })
                     .unwrap()
             })

--- a/perf/src/cuda_runtime.rs
+++ b/perf/src/cuda_runtime.rs
@@ -161,6 +161,16 @@ impl<'a, T: Clone + Send + Sync + Default + Sized> IntoParallelIterator for &'a 
     }
 }
 
+impl<'a, T: Clone + Default + Sized + Send + Sync> IntoParallelRefMutIterator<'a>
+    for &'a mut PinnedVec<T>
+{
+    type Iter = rayon::slice::IterMut<'a, T>;
+    type Item = &'a mut T;
+    fn par_iter_mut(&'a mut self) -> Self::Iter {
+        self.x.par_iter_mut()
+    }
+}
+
 impl<T: Clone + Default + Sized> PinnedVec<T> {
     pub fn reserve_and_pin(&mut self, size: usize) {
         if self.x.capacity() < size {
@@ -213,6 +223,10 @@ impl<T: Clone + Default + Sized> PinnedVec<T> {
 
     pub fn len(&self) -> usize {
         self.x.len()
+    }
+
+    pub fn last(&self) -> Option<&T> {
+        self.x.last()
     }
 
     pub fn as_ptr(&self) -> *const T {

--- a/perf/src/packet.rs
+++ b/perf/src/packet.rs
@@ -15,6 +15,10 @@ pub struct Packets {
     pub packets: PinnedVec<Packet>,
 }
 
+pub fn batch_size(batches: &[Packets]) -> usize {
+    batches.iter().map(|p| p.packets.len()).sum()
+}
+
 //auto derive doesn't support large arrays
 impl Default for Packets {
     fn default() -> Packets {

--- a/perf/src/recycler_cache.rs
+++ b/perf/src/recycler_cache.rs
@@ -1,9 +1,13 @@
 use crate::cuda_runtime::PinnedVec;
+use crate::packet::PacketsRecycler;
 use crate::recycler::Recycler;
 use crate::sigverify::TxOffset;
 
+pub const PACKETS_CAPACITY: usize = 32;
+
 #[derive(Default, Clone)]
 pub struct RecyclerCache {
+    recycler_packets: PacketsRecycler,
     recycler_offsets: Recycler<TxOffset>,
     recycler_buffer: Recycler<PinnedVec<u8>>,
 }
@@ -11,9 +15,13 @@ pub struct RecyclerCache {
 impl RecyclerCache {
     pub fn warmed() -> Self {
         Self {
+            recycler_packets: Recycler::warmed(1000, PACKETS_CAPACITY),
             recycler_offsets: Recycler::warmed(50, 4096),
             recycler_buffer: Recycler::warmed(50, 4096),
         }
+    }
+    pub fn packets(&self) -> &PacketsRecycler {
+        &self.recycler_packets
     }
     pub fn offsets(&self) -> &Recycler<TxOffset> {
         &self.recycler_offsets

--- a/perf/src/sigverify.rs
+++ b/perf/src/sigverify.rs
@@ -5,7 +5,7 @@
 //!
 
 use crate::cuda_runtime::PinnedVec;
-use crate::packet::{Packet, Packets};
+use crate::packet::{batch_size, Packet, Packets};
 use crate::perf_libs;
 use crate::recycler::Recycler;
 use bincode::serialized_size;
@@ -112,10 +112,6 @@ fn verify_packet(packet: &Packet) -> u8 {
         sig_start += size_of::<Signature>();
     }
     1
-}
-
-pub fn batch_size(batches: &[Packets]) -> usize {
-    batches.iter().map(|p| p.packets.len()).sum()
 }
 
 // internal function to be unit-tested; should be used only by get_packet_offsets


### PR DESCRIPTION
#### Problem

1. Signing takes CPU time
2. Shred are allocated using the regular Vec heap

#### Summary of Changes

1. Allocate shreds directly into Packets which use a PinnedVec/Recycler
2. Sign packets on the GPU

Todo:
- [x] RAM usage is 40%? (@sagar-solana Resident ram seems fine)
- [x] broadcast seems to be much slower with CPU sigverify (not sure if its just warmup)

Separate PR
- [ ] separate the entries_to_shreds as a stage
- [ ] avoid converting back to a Shred inside blocktree insert

Fixes #
