### PR TITLE
validator/: Only check the entrypoint's RPC address

### DIFF
--- a/gossip/src/main.rs
+++ b/gossip/src/main.rs
@@ -203,10 +203,13 @@ fn main() -> Result<(), Box<dyn error::Error>> {
 
             let rpc_addrs: Vec<_> = nodes
                 .iter()
-                .filter_map(ContactInfo::valid_client_facing_addr)
-                .map(|addrs| addrs.0)
-                .filter(|rpc_addr| {
-                    matches.is_present("all") || rpc_addr.ip() == entrypoint_addr.ip()
+                .filter_map(|contact_info| {
+                    if (matches.is_present("all") || contact_info.gossip == entrypoint_addr)
+                        && ContactInfo::is_valid_address(&contact_info.rpc)
+                    {
+                        return Some(contact_info.rpc);
+                    }
+                    None
                 })
                 .collect();
 

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -181,13 +181,20 @@ fn initialize_ledger_path(
 
     let rpc_addr = nodes
         .iter()
-        .filter_map(ContactInfo::valid_client_facing_addr)
-        .map(|addrs| addrs.0)
-        .find(|rpc_addr| rpc_addr.ip() == entrypoint.gossip.ip())
+        .filter_map(|contact_info| {
+            if contact_info.gossip == entrypoint.gossip
+                && ContactInfo::is_valid_address(&contact_info.rpc)
+            {
+                Some(contact_info.rpc)
+            } else {
+                None
+            }
+        })
+        .next()
         .unwrap_or_else(|| {
             error!(
                 "Entrypoint ({:?}) is not running the RPC service",
-                entrypoint.gossip.ip()
+                entrypoint.gossip
             );
             exit(1);
         });


### PR DESCRIPTION
When `solana-validator` looks for the entrypoint's RPC service it filtered incorrectly on entrypoint's IP address, which can break if multiple nodes are running on the same system.  Instead additionally filter on the entrypoint's gossip port.  Should resolve intermittent `ci/localnet-sanity.sh` failures in CI