### PR TITLE
Stub out `getBlocksSince` and `getBlock` methods

### DIFF
--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -274,6 +274,10 @@ impl JsonRpcRequestProcessor {
             .collect())
     }
 
+    // The `get_block` method is not fully implemented. It currenlty returns a batch of test transaction
+    // tuples (Transaction, transaction::Result) to demonstrate message format and
+    // TransactionErrors. Transaction count == slot, and transaction keys are derived
+    // deterministically to allow testers to track the pubkeys across slots.
     pub fn get_block(&self, slot: Slot) -> Result<Vec<(Transaction, transaction::Result<()>)>> {
         Ok(make_test_transactions(slot))
     }

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -13,7 +13,9 @@ use jsonrpc_core::{Error, Metadata, Result};
 use jsonrpc_derive::rpc;
 use solana_client::rpc_request::{RpcEpochInfo, RpcVoteAccountInfo, RpcVoteAccountStatus};
 use solana_drone::drone::request_airdrop_transaction;
-use solana_ledger::bank_forks::BankForks;
+use solana_ledger::{
+    bank_forks::BankForks, blocktree::Blocktree, rooted_slot_iterator::RootedSlotIterator,
+};
 use solana_runtime::bank::Bank;
 use solana_sdk::{
     account::Account,
@@ -54,8 +56,9 @@ impl Default for JsonRpcConfig {
 pub struct JsonRpcRequestProcessor {
     bank_forks: Arc<RwLock<BankForks>>,
     block_commitment_cache: Arc<RwLock<BlockCommitmentCache>>,
-    storage_state: StorageState,
+    blocktree: Arc<Blocktree>,
     config: JsonRpcConfig,
+    storage_state: StorageState,
     validator_exit: Arc<RwLock<Option<ValidatorExit>>>,
 }
 
@@ -75,17 +78,19 @@ impl JsonRpcRequestProcessor {
     }
 
     pub fn new(
-        storage_state: StorageState,
         config: JsonRpcConfig,
         bank_forks: Arc<RwLock<BankForks>>,
         block_commitment_cache: Arc<RwLock<BlockCommitmentCache>>,
+        blocktree: Arc<Blocktree>,
+        storage_state: StorageState,
         validator_exit: &Arc<RwLock<Option<ValidatorExit>>>,
     ) -> Self {
         JsonRpcRequestProcessor {
+            config,
             bank_forks,
             block_commitment_cache,
+            blocktree,
             storage_state,
-            config,
             validator_exit: validator_exit.clone(),
         }
     }
@@ -257,6 +262,14 @@ impl JsonRpcRequestProcessor {
             debug!("validator_exit ignored");
             Ok(false)
         }
+    }
+
+    pub fn get_blocks_since(&self, slot: Slot) -> Result<Vec<Slot>> {
+        Ok(RootedSlotIterator::new(slot, &self.blocktree)
+            .map_err(|err| Error::invalid_params(format!("Slot {:?}: {:?}", slot, err)))?
+            .into_iter()
+            .map(|(slot, _)| slot)
+            .collect())
     }
 }
 
@@ -479,6 +492,9 @@ pub trait RpcSol {
 
     #[rpc(meta, name = "setLogFilter")]
     fn set_log_filter(&self, _meta: Self::Metadata, filter: String) -> Result<()>;
+
+    #[rpc(meta, name = "getBlocksSince")]
+    fn get_blocks_since(&self, meta: Self::Metadata, slot: Slot) -> Result<Vec<Slot>>;
 }
 
 pub struct RpcSolImpl;
@@ -929,6 +945,13 @@ impl RpcSol for RpcSolImpl {
         solana_logger::setup_with_filter(&filter);
         Ok(())
     }
+
+    fn get_blocks_since(&self, meta: Self::Metadata, slot: Slot) -> Result<Vec<Slot>> {
+        meta.request_processor
+            .read()
+            .unwrap()
+            .get_blocks_since(slot)
+    }
 }
 
 #[cfg(test)]
@@ -939,6 +962,7 @@ pub mod tests {
         genesis_utils::{create_genesis_config, GenesisConfigInfo},
     };
     use jsonrpc_core::{MetaIoHandler, Output, Response, Value};
+    use solana_ledger::blocktree::get_tmp_ledger_path;
     use solana_sdk::{
         fee_calculator::DEFAULT_BURN_PERCENT,
         hash::{hash, Hash},
@@ -980,6 +1004,8 @@ pub mod tests {
             .or_insert(commitment_slot1.clone());
         let block_commitment_cache =
             Arc::new(RwLock::new(BlockCommitmentCache::new(block_commitment, 42)));
+        let ledger_path = get_tmp_ledger_path!();
+        let blocktree = Blocktree::open(&ledger_path).unwrap();
 
         let leader_pubkey = *bank.collector_id();
         let exit = Arc::new(AtomicBool::new(false));
@@ -993,10 +1019,11 @@ pub mod tests {
         let _ = bank.process_transaction(&tx);
 
         let request_processor = Arc::new(RwLock::new(JsonRpcRequestProcessor::new(
-            StorageState::default(),
             JsonRpcConfig::default(),
             bank_forks,
             block_commitment_cache.clone(),
+            Arc::new(blocktree),
+            StorageState::default(),
             &validator_exit,
         )));
         let cluster_info = Arc::new(RwLock::new(ClusterInfo::new_with_invalid_keypair(
@@ -1038,11 +1065,14 @@ pub mod tests {
         let (bank_forks, alice) = new_bank_forks();
         let bank = bank_forks.read().unwrap().working_bank();
         let block_commitment_cache = Arc::new(RwLock::new(BlockCommitmentCache::default()));
+        let ledger_path = get_tmp_ledger_path!();
+        let blocktree = Blocktree::open(&ledger_path).unwrap();
         let request_processor = JsonRpcRequestProcessor::new(
-            StorageState::default(),
             JsonRpcConfig::default(),
             bank_forks,
             block_commitment_cache,
+            Arc::new(blocktree),
+            StorageState::default(),
             &validator_exit,
         );
         thread::spawn(move || {
@@ -1453,6 +1483,8 @@ pub mod tests {
         let exit = Arc::new(AtomicBool::new(false));
         let validator_exit = create_validator_exit(&exit);
         let block_commitment_cache = Arc::new(RwLock::new(BlockCommitmentCache::default()));
+        let ledger_path = get_tmp_ledger_path!();
+        let blocktree = Blocktree::open(&ledger_path).unwrap();
 
         let mut io = MetaIoHandler::default();
         let rpc = RpcSolImpl;
@@ -1460,10 +1492,11 @@ pub mod tests {
         let meta = Meta {
             request_processor: {
                 let request_processor = JsonRpcRequestProcessor::new(
-                    StorageState::default(),
                     JsonRpcConfig::default(),
                     new_bank_forks().0,
                     block_commitment_cache,
+                    Arc::new(blocktree),
+                    StorageState::default(),
                     &validator_exit,
                 );
                 Arc::new(RwLock::new(request_processor))
@@ -1551,11 +1584,14 @@ pub mod tests {
         let exit = Arc::new(AtomicBool::new(false));
         let validator_exit = create_validator_exit(&exit);
         let block_commitment_cache = Arc::new(RwLock::new(BlockCommitmentCache::default()));
+        let ledger_path = get_tmp_ledger_path!();
+        let blocktree = Blocktree::open(&ledger_path).unwrap();
         let request_processor = JsonRpcRequestProcessor::new(
-            StorageState::default(),
             JsonRpcConfig::default(),
             new_bank_forks().0,
             block_commitment_cache,
+            Arc::new(blocktree),
+            StorageState::default(),
             &validator_exit,
         );
         assert_eq!(request_processor.validator_exit(), Ok(false));
@@ -1567,13 +1603,16 @@ pub mod tests {
         let exit = Arc::new(AtomicBool::new(false));
         let validator_exit = create_validator_exit(&exit);
         let block_commitment_cache = Arc::new(RwLock::new(BlockCommitmentCache::default()));
+        let ledger_path = get_tmp_ledger_path!();
+        let blocktree = Blocktree::open(&ledger_path).unwrap();
         let mut config = JsonRpcConfig::default();
         config.enable_validator_exit = true;
         let request_processor = JsonRpcRequestProcessor::new(
-            StorageState::default(),
             config,
             new_bank_forks().0,
             block_commitment_cache,
+            Arc::new(blocktree),
+            StorageState::default(),
             &validator_exit,
         );
         assert_eq!(request_processor.validator_exit(), Ok(true));
@@ -1616,14 +1655,17 @@ pub mod tests {
             .or_insert(commitment_slot1.clone());
         let block_commitment_cache =
             Arc::new(RwLock::new(BlockCommitmentCache::new(block_commitment, 42)));
+        let ledger_path = get_tmp_ledger_path!();
+        let blocktree = Blocktree::open(&ledger_path).unwrap();
 
         let mut config = JsonRpcConfig::default();
         config.enable_validator_exit = true;
         let request_processor = JsonRpcRequestProcessor::new(
-            StorageState::default(),
             config,
             new_bank_forks().0,
             block_commitment_cache,
+            Arc::new(blocktree),
+            StorageState::default(),
             &validator_exit,
         );
         assert_eq!(

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -270,7 +270,6 @@ impl JsonRpcRequestProcessor {
     pub fn get_blocks_since(&self, slot: Slot) -> Result<Vec<Slot>> {
         Ok(RootedSlotIterator::new(slot, &self.blocktree)
             .map_err(|err| Error::invalid_params(format!("Slot {:?}: {:?}", slot, err)))?
-            .into_iter()
             .map(|(slot, _)| slot)
             .collect())
     }

--- a/core/src/rpc_service.rs
+++ b/core/src/rpc_service.rs
@@ -85,6 +85,7 @@ impl RequestMiddleware for RpcRequestMiddleware {
 }
 
 impl JsonRpcService {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         rpc_addr: SocketAddr,
         config: JsonRpcConfig,

--- a/core/src/rpc_service.rs
+++ b/core/src/rpc_service.rs
@@ -9,13 +9,12 @@ use jsonrpc_http_server::{
     hyper, AccessControlAllowOrigin, CloseHandle, DomainsValidation, RequestMiddleware,
     RequestMiddlewareAction, ServerBuilder,
 };
-use solana_ledger::bank_forks::BankForks;
+use solana_ledger::{bank_forks::BankForks, blocktree::Blocktree};
 use solana_sdk::hash::Hash;
 use std::{
     net::SocketAddr,
     path::{Path, PathBuf},
-    sync::mpsc::channel,
-    sync::{Arc, RwLock},
+    sync::{mpsc::channel, Arc, RwLock},
     thread::{self, Builder, JoinHandle},
 };
 use tokio::prelude::Future;
@@ -87,23 +86,25 @@ impl RequestMiddleware for RpcRequestMiddleware {
 
 impl JsonRpcService {
     pub fn new(
-        cluster_info: &Arc<RwLock<ClusterInfo>>,
         rpc_addr: SocketAddr,
-        storage_state: StorageState,
         config: JsonRpcConfig,
         bank_forks: Arc<RwLock<BankForks>>,
         block_commitment_cache: Arc<RwLock<BlockCommitmentCache>>,
-        ledger_path: &Path,
+        blocktree: Arc<Blocktree>,
+        cluster_info: &Arc<RwLock<ClusterInfo>>,
         genesis_hash: Hash,
+        ledger_path: &Path,
+        storage_state: StorageState,
         validator_exit: &Arc<RwLock<Option<ValidatorExit>>>,
     ) -> Self {
         info!("rpc bound to {:?}", rpc_addr);
         info!("rpc configuration: {:?}", config);
         let request_processor = Arc::new(RwLock::new(JsonRpcRequestProcessor::new(
-            storage_state,
             config,
             bank_forks,
             block_commitment_cache,
+            blocktree,
+            storage_state,
             validator_exit,
         )));
         let request_processor_ = request_processor.clone();
@@ -174,9 +175,12 @@ impl Service for JsonRpcService {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::contact_info::ContactInfo;
-    use crate::genesis_utils::{create_genesis_config, GenesisConfigInfo};
-    use crate::rpc::tests::create_validator_exit;
+    use crate::{
+        contact_info::ContactInfo,
+        genesis_utils::{create_genesis_config, GenesisConfigInfo},
+        rpc::tests::create_validator_exit,
+    };
+    use solana_ledger::blocktree::get_tmp_ledger_path;
     use solana_runtime::bank::Bank;
     use solana_sdk::signature::KeypairUtil;
     use std::net::{IpAddr, Ipv4Addr, SocketAddr};
@@ -201,15 +205,18 @@ mod tests {
         );
         let bank_forks = Arc::new(RwLock::new(BankForks::new(bank.slot(), bank)));
         let block_commitment_cache = Arc::new(RwLock::new(BlockCommitmentCache::default()));
+        let ledger_path = get_tmp_ledger_path!();
+        let blocktree = Blocktree::open(&ledger_path).unwrap();
         let mut rpc_service = JsonRpcService::new(
-            &cluster_info,
             rpc_addr,
-            StorageState::default(),
             JsonRpcConfig::default(),
             bank_forks,
             block_commitment_cache,
-            &PathBuf::from("farf"),
+            Arc::new(blocktree),
+            &cluster_info,
             Hash::default(),
+            &PathBuf::from("farf"),
+            StorageState::default(),
             &validator_exit,
         );
         let thread = rpc_service.thread_hdl.thread();

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -199,18 +199,21 @@ impl Validator {
             bank.slots_per_segment(),
         );
 
+        let blocktree = Arc::new(blocktree);
+
         let rpc_service = if node.info.rpc.port() == 0 {
             None
         } else {
             Some(JsonRpcService::new(
-                &cluster_info,
                 SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), node.info.rpc.port()),
-                storage_state.clone(),
                 config.rpc_config.clone(),
                 bank_forks.clone(),
                 block_commitment_cache.clone(),
-                ledger_path,
+                blocktree.clone(),
+                &cluster_info,
                 genesis_hash,
+                ledger_path,
+                storage_state.clone(),
                 &validator_exit,
             ))
         };
@@ -243,8 +246,6 @@ impl Validator {
             warn!("Validator halted");
             std::thread::park();
         }
-
-        let blocktree = Arc::new(blocktree);
 
         let poh_config = Arc::new(poh_config);
         let (mut poh_recorder, entry_receiver) = PohRecorder::new_with_clear_signal(


### PR DESCRIPTION
#### Problem
Solana users need a way to introspect particular blocks on the ledger via a request/response workflow.

#### Summary of Changes
- Add `getBlocksSince` rpc method to return the chain of rooted slots from a particular slot until the current root. This method is complete and returning real data.
- Add `getBlock` rpc method stub; currently returns a batch of test transaction tuples `(Transaction, transaction::Result)` to demonstrate message format and a couple TransactionErrors. Transaction count == slot, and transaction keys are derived deterministically to allow testers to track the pubkeys across slots. (Most of this code, incl `make_test_transactions()` will be removed as part of item #3 below)

Follow-up work:
- [ ] Plumb methods into solana-web3.js
- [ ] Add persistent Transaction-status store to ledger
- [ ] Parse `get_slot_entries` from blocktree to return real data from `getBlock`
- [ ] Flesh out unit tests in rpc.rs vis-a-vis real data
- [ ] Update jsonrpc-api.md to document the new methods
