### PR TITLE
Implement non-GPU mode testcase for colo

### DIFF
--- a/system-test/testnet-performance/colo-cpu-only-perf.yml
+++ b/system-test/testnet-performance/colo-cpu-only-perf.yml
@@ -1,0 +1,16 @@
+steps:
+  - command: "system-test/testnet-performance/testnet-automation.sh"
+    label: "COLO performance testnet CPU only"
+    env:
+      UPLOAD_RESULTS_TO_SLACK: "true"
+      CLOUD_PROVIDER: "colo"
+      TESTNET_TAG: "colo-edge-perf-cpu-only"
+      ENABLE_GPU: "false"
+      RAMP_UP_TIME: 0
+      TEST_DURATION_SECONDS: 600
+      NUMBER_OF_VALIDATOR_NODES: 4
+      NUMBER_OF_CLIENT_NODES: 2
+      CLIENT_OPTIONS: "bench-tps=2=--tx_count 15000 --thread-batch-sleep-ms 250"
+      ADDITIONAL_FLAGS: ""
+    agents:
+      - "queue=colo-deploy"

--- a/system-test/testnet-performance/testnet-automation.sh
+++ b/system-test/testnet-performance/testnet-automation.sh
@@ -114,7 +114,7 @@ function launchTestnet() {
     # shellcheck disable=SC2068
     # shellcheck disable=SC2086
       net/colo.sh create \
-        -n "$NUMBER_OF_VALIDATOR_NODES" -c "$NUMBER_OF_CLIENT_NODES" "$maybeEnableGpu" \
+        -n "$NUMBER_OF_VALIDATOR_NODES" -c "$NUMBER_OF_CLIENT_NODES" $maybeEnableGpu \
         -p "$TESTNET_TAG" ${ADDITIONAL_FLAGS[@]/#/" "}
       ;;
     *)
@@ -129,11 +129,15 @@ function launchTestnet() {
   if [[ -n $CHANNEL ]]; then
     # shellcheck disable=SC2068
     # shellcheck disable=SC2086
-    net/net.sh restart -t "$CHANNEL" "$maybeClientOptions" "$CLIENT_OPTIONS" $maybeStartAllowBootFailures
+    net/net.sh restart -t "$CHANNEL" \
+      "$maybeClientOptions" "$CLIENT_OPTIONS" $maybeStartAllowBootFailures \
+      --gpu-mode $startGpuMode
   else
     # shellcheck disable=SC2068
     # shellcheck disable=SC2086
-    net/net.sh restart -T solana-release*.tar.bz2 "$maybeClientOptions" "$CLIENT_OPTIONS" $maybeStartAllowBootFailures
+    net/net.sh restart -T solana-release*.tar.bz2 \
+      "$maybeClientOptions" "$CLIENT_OPTIONS" $maybeStartAllowBootFailures \
+      --gpu-mode $startGpuMode
   fi
 
   echo --- wait "$RAMP_UP_TIME" seconds for network throughput to stabilize
@@ -204,11 +208,13 @@ if [[ -z $NUMBER_OF_VALIDATOR_NODES ]] ; then
   exit 1
 fi
 
+startGpuMode="off"
 if [[ -z $ENABLE_GPU ]] ; then
   ENABLE_GPU=false
 fi
 if [[ "$ENABLE_GPU" = "true" ]] ; then
   maybeEnableGpu="--enable-gpu"
+  startGpuMode="on"
 fi
 
 if [[ -z $NUMBER_OF_CLIENT_NODES ]] ; then


### PR DESCRIPTION
Add CPU-only option and nightly testcase to colo setup to have an apples to apples test compared to GCE GPU/CPU nightlies.