### PR TITLE
Filter any net/log* directory from rsync

### DIFF
--- a/net/net.sh
+++ b/net/net.sh
@@ -416,7 +416,7 @@ startCommon() {
   fi
   [[ -z "$externalNodeSshKey" ]] || ssh-copy-id -f -i "$externalNodeSshKey" "${sshOptions[@]}" "solana@$ipAddress"
   rsync -vPrc -e "ssh ${sshOptions[*]}" \
-    --exclude 'net/log' \
+    --exclude 'net/log*' \
     "$SOLANA_ROOT"/{fetch-perf-libs.sh,scripts,net,multinode-demo} \
     "$ipAddress":~/solana/
 }


### PR DESCRIPTION
#### Problem

With multiple net/log-xx directories, the rsync exclude doesn't exclude them all.

#### Summary of Changes

Filter anything with net/log*

Fixes #
