### PR TITLE
discover() by gossip sockaddr instead of just by gossip ip address

### DIFF
--- a/gossip/src/main.rs
+++ b/gossip/src/main.rs
@@ -197,7 +197,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                 Some(1),
                 Some(timeout),
                 None,
-                Some(entrypoint_addr.ip()),
+                Some(entrypoint_addr),
                 None,
             )?;
 

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -174,7 +174,7 @@ fn initialize_ledger_path(
         Some(1),
         Some(60),
         None,
-        Some(entrypoint.gossip.ip()),
+        Some(entrypoint.gossip),
         None,
     )
     .map_err(|err| err.to_string())?;


### PR DESCRIPTION
When we pass an ip address into `discover()`, we're really trying to match the full gossip socket address for a given entrypoint.   This is essentially a follow-up to #6851, where by CI still intermittently fails with
```
[2019-11-11T08:38:31.871288461Z ERROR solana_validator] Entrypoint (V4(127.0.0.1:8001)) is not running the RPC service
```