### PR TITLE
Use reusable provider-specific testnet keypairs

### DIFF
--- a/system-test/testnet-performance/testnet-automation.sh
+++ b/system-test/testnet-performance/testnet-automation.sh
@@ -137,8 +137,8 @@ function launchTestnet() {
   if [[ ! -d net/keypairs ]] ; then
     git clone git@github.com:solana-labs/testnet-keypairs.git net/keypairs
     # If we have provider-specific keys (CoLo*, GCE*, etc) use them instead of generic val*
-    if [[ -d net/keypairs/${CLOUD_PROVIDER} ]] ; then
-      cp net/keypairs/${CLOUD_PROVIDER}/* net/keypairs/
+    if [[ -d net/keypairs/"${CLOUD_PROVIDER}" ]] ; then
+      cp net/keypairs/"${CLOUD_PROVIDER}"/* net/keypairs/
     fi
   fi
 

--- a/system-test/testnet-performance/testnet-automation.sh
+++ b/system-test/testnet-performance/testnet-automation.sh
@@ -133,6 +133,15 @@ function launchTestnet() {
   echo --- configure database
   net/init-metrics.sh -e
 
+  echo --- fetch reusable testnet keypairs
+  if [[ ! -d net/keypairs ]] ; then
+    git clone git@github.com:solana-labs/testnet-keypairs.git net/keypairs
+    # If we have provider-specific keys (CoLo*, GCE*, etc) use them instead of generic val*
+    if [[ -d net/keypairs/${CLOUD_PROVIDER} ]] ; then
+      cp net/keypairs/${CLOUD_PROVIDER}/* net/keypairs/
+    fi
+  fi
+
   echo --- start "$NUMBER_OF_VALIDATOR_NODES" node test
   if [[ -n $CHANNEL ]]; then
     # shellcheck disable=SC2068


### PR DESCRIPTION
#### Problem

Use reusable keypairs from https://github.com/solana-labs/testnet-keypairs when spinning up an automation test network

#### Summary of Changes

Depending on which provider we are using, see if we have pubkeys that specify the provider, otherwise use the generic ones.  Without modifying our `net start` this works for a single cloud provider network.

Fixes #6855 
