### PR TITLE
Tune repair to be less aggressive

### DIFF
--- a/core/src/repair_service.rs
+++ b/core/src/repair_service.rs
@@ -20,8 +20,8 @@ use std::{
     time::Duration,
 };
 
-pub const MAX_REPAIR_LENGTH: usize = 1024;
-pub const REPAIR_MS: u64 = 50;
+pub const MAX_REPAIR_LENGTH: usize = 512;
+pub const REPAIR_MS: u64 = 100;
 pub const MAX_ORPHANS: usize = 5;
 
 pub enum RepairStrategy {


### PR DESCRIPTION
#### Problem

After erasure was bumped, Repair no longer needs to be capable of repairing 20k indexes in a second.

#### Summary of Changes

Reduce repair aggressiveness to ~5k slots a second. This should be more than sufficient to pull validators out of the weeds. 
