### PR TITLE
Upgrade xargo if old

### DIFF
--- a/sdk/bpf/scripts/install.sh
+++ b/sdk/bpf/scripts/install.sh
@@ -22,11 +22,9 @@ download() {
   wget "${args[@]}"
 }
 
-# Install xargo
-if [[ ! -r xargo.md ]]; then
-  cargo install xargo
-  xargo --version > xargo.md 2>&1
-fi
+# Install or upgrade xargo
+cargo +nightly install xargo -Z install-upgrade
+xargo --version > xargo.md 2>&1
 
 # Install Criterion
 version=v2.3.2


### PR DESCRIPTION
#### Problem

Install scripts only install xargo if xargo not already installed.  If already installed the existing version will be used.  The result is a mismatch of versions across installs that may not be compatible with the current SDK

#### Summary of Changes

Install xargo is not already installed or upgrade to latest if is

Fixes #
