### PR TITLE
Remove debug datapoint that isn't being plotted

### DIFF
--- a/core/src/repair_service.rs
+++ b/core/src/repair_service.rs
@@ -170,7 +170,7 @@ impl RepairService {
                     })
                     .collect();
 
-                for ((to, req), repair_request) in reqs {
+                for ((to, req), _) in reqs {
                     repair_socket.send_to(&req, to).unwrap_or_else(|e| {
                         info!("{} repair req send_to({}) error {:?}", id, to, e);
                         0

--- a/core/src/repair_service.rs
+++ b/core/src/repair_service.rs
@@ -171,14 +171,6 @@ impl RepairService {
                     .collect();
 
                 for ((to, req), repair_request) in reqs {
-                    if let Ok(local_addr) = repair_socket.local_addr() {
-                        datapoint_debug!(
-                            "repair_service",
-                            ("repair_request", format!("{:?}", repair_request), String),
-                            ("to", to.to_string(), String),
-                            ("from", local_addr.to_string(), String),
-                        );
-                    }
                     repair_socket.send_to(&req, to).unwrap_or_else(|e| {
                         info!("{} repair req send_to({}) error {:?}", id, to, e);
                         0


### PR DESCRIPTION
#### Problem

New faster repair is causing dropped datapoints

#### Summary of Changes

Ease up on metrics by disabling one of the repair metrics that isn't actively used. 
