### PR TITLE
Fix caching data shreds as coding shreds

### DIFF
--- a/ledger/src/blocktree.rs
+++ b/ledger/src/blocktree.rs
@@ -512,7 +512,7 @@ impl Blocktree {
                             &mut index_working_set,
                             &mut slot_meta_working_set,
                             &mut write_batch,
-                            &mut just_inserted_coding_shreds,
+                            &mut just_inserted_data_shreds,
                             &mut index_meta_time,
                         );
                     }
@@ -733,12 +733,7 @@ impl Blocktree {
 
         // Assert guaranteed by integrity checks on the shred that happen before
         // `insert_coding_shred` is called
-        if shred.is_data() || shred_index < u64::from(shred.coding_header.position) {
-            error!("Due to earlier validation, shred index must be >= pos");
-            return Err(BlocktreeError::InvalidShredData(Box::new(
-                bincode::ErrorKind::Custom("shred index < pos".to_string()),
-            )));
-        }
+        assert!(shred.is_code() && shred_index >= u64::from(shred.coding_header.position));
 
         // Commit step: commit all changes to the mutable structures at once, or none at all.
         // We don't want only a subset of these changes going through.


### PR DESCRIPTION
#### Problem

Blocktree is incorrectly caching recovered data shreds as coding shreds and then trying to insert them.
Causing tons of log spam. 

#### Summary of Changes

Fix incorrect caching of recovered data shreds.
