### PR TITLE
Install xargo if a new version is available

### DIFF
--- a/sdk/bpf/scripts/install.sh
+++ b/sdk/bpf/scripts/install.sh
@@ -23,7 +23,8 @@ download() {
 }
 
 # Install or upgrade xargo
-cargo +nightly install xargo -Z install-upgrade
+cargo install cargo-update
+cargo install-update -i xargo
 xargo --version > xargo.md 2>&1
 
 # Install Criterion


### PR DESCRIPTION
#### Problem
Current implementation of conditional install for xargo relies on nightly.

#### Summary of Changes
Temporarily use [`cargo-update`](https://crates.io/crates/cargo-update) until https://github.com/rust-lang/cargo/pull/7560 stabilizes

Context: https://github.com/solana-labs/solana/pull/6869#issuecomment-552663398

