### PR TITLE
Remove `nightly` requirement when installing/upgrading xargo

### DIFF
--- a/sdk/bpf/scripts/install.sh
+++ b/sdk/bpf/scripts/install.sh
@@ -39,7 +39,6 @@ then
     echo "Updating xargo from $current to $latest"
     cargo install xargo --force
 fi
-xargo --version > xargo.md 2>&1
 
 # Install Criterion
 version=v2.3.2

--- a/sdk/bpf/scripts/install.sh
+++ b/sdk/bpf/scripts/install.sh
@@ -23,7 +23,22 @@ download() {
 }
 
 # Install or upgrade xargo
-cargo +nightly install xargo -Z install-upgrade
+regex=".*xargo[= \"]+([0-9]+.[0-9]+.[0-9]+).*"
+if [[ $(xargo --version 2>&1) =~  $regex ]]; then
+    current=${BASH_REMATCH[1]}
+else
+    echo "${LINENO}: Failed to get current version of xargo!"; exit
+fi
+if [[ $(cargo search --limit 1 xargo) =~  $regex ]]; then
+    latest=${BASH_REMATCH[1]}
+else
+    echo "Failed to get latest version of xargo!"; exit
+fi
+if [[ $current != $latest ]]
+then
+    echo "Updating xargo from $current to $latest"
+    cargo install xargo --force
+fi
 xargo --version > xargo.md 2>&1
 
 # Install Criterion


### PR DESCRIPTION
#### Problem

Cargo's `install-upgrade` option is only available on nightly and we don't want to add nightly as an SDK requirement

#### Summary of Changes

Check xargo versions directly and force install if necessary to get the latest.

Fixes #
