### PR TITLE
Fix roots overrunning broadcast

### DIFF
--- a/core/benches/blocktree.rs
+++ b/core/benches/blocktree.rs
@@ -22,7 +22,7 @@ fn bench_write_shreds(bench: &mut Bencher, entries: Vec<Entry>, ledger_path: &Pa
         Blocktree::open(ledger_path).expect("Expected to be able to open database ledger");
     bench.iter(move || {
         let shreds = entries_to_test_shreds(entries.clone(), 0, 0, true);
-        blocktree.insert_shreds(shreds, None).unwrap();
+        blocktree.insert_shreds(shreds, None, false).unwrap();
     });
 
     Blocktree::destroy(ledger_path).expect("Expected successful database destruction");
@@ -45,7 +45,7 @@ fn setup_read_bench(
     // Convert the entries to shreds, write the shreds to the ledger
     let shreds = entries_to_test_shreds(entries, slot, slot.saturating_sub(1), true);
     blocktree
-        .insert_shreds(shreds, None)
+        .insert_shreds(shreds, None, false)
         .expect("Expectd successful insertion of shreds into ledger");
 }
 
@@ -137,7 +137,7 @@ fn bench_insert_data_shred_small(bench: &mut Bencher) {
     let entries = create_ticks(num_entries, 0, Hash::default());
     bench.iter(move || {
         let shreds = entries_to_test_shreds(entries.clone(), 0, 0, true);
-        blocktree.insert_shreds(shreds, None).unwrap();
+        blocktree.insert_shreds(shreds, None, false).unwrap();
     });
     Blocktree::destroy(&ledger_path).expect("Expected successful database destruction");
 }
@@ -152,7 +152,7 @@ fn bench_insert_data_shred_big(bench: &mut Bencher) {
     let entries = create_ticks(num_entries, 0, Hash::default());
     bench.iter(move || {
         let shreds = entries_to_test_shreds(entries.clone(), 0, 0, true);
-        blocktree.insert_shreds(shreds, None).unwrap();
+        blocktree.insert_shreds(shreds, None, false).unwrap();
     });
     Blocktree::destroy(&ledger_path).expect("Expected successful database destruction");
 }

--- a/core/src/archiver.rs
+++ b/core/src/archiver.rs
@@ -927,7 +927,7 @@ impl Archiver {
                     .into_iter()
                     .filter_map(|p| Shred::new_from_serialized_shred(p.data.to_vec()).ok())
                     .collect();
-                blocktree.insert_shreds(shreds, None)?;
+                blocktree.insert_shreds(shreds, None, false)?;
             }
             // check if all the slots in the segment are complete
             if Self::segment_complete(start_slot, slots_per_segment, blocktree) {

--- a/core/src/broadcast_stage/broadcast_fake_blobs_run.rs
+++ b/core/src/broadcast_stage/broadcast_fake_blobs_run.rs
@@ -76,7 +76,7 @@ impl BroadcastRun for BroadcastFakeBlobsRun {
             self.last_blockhash = Hash::default();
         }
 
-        blocktree.insert_shreds(data_shreds.clone(), None)?;
+        blocktree.insert_shreds(data_shreds.clone(), None, true)?;
 
         // 3) Start broadcast step
         let peers = cluster_info.read().unwrap().tvu_peers();

--- a/core/src/broadcast_stage/fail_entry_verification_broadcast_run.rs
+++ b/core/src/broadcast_stage/fail_entry_verification_broadcast_run.rs
@@ -59,7 +59,7 @@ impl BroadcastRun for FailEntryVerificationBroadcastRun {
             .collect::<Vec<_>>();
         let all_seeds: Vec<[u8; 32]> = all_shreds.iter().map(|s| s.seed()).collect();
         blocktree
-            .insert_shreds(all_shreds, None)
+            .insert_shreds(all_shreds, None, true)
             .expect("Failed to insert shreds in blocktree");
 
         // 3) Start broadcast step

--- a/core/src/broadcast_stage/standard_broadcast_run.rs
+++ b/core/src/broadcast_stage/standard_broadcast_run.rs
@@ -218,7 +218,7 @@ impl StandardBroadcastRun {
         let insert_shreds_start = Instant::now();
         if insert {
             blocktree
-                .insert_shreds(shreds.clone(), None)
+                .insert_shreds(shreds.clone(), None, true)
                 .expect("Failed to insert shreds in blocktree");
         }
         let insert_shreds_elapsed = insert_shreds_start.elapsed();

--- a/core/src/cluster_info.rs
+++ b/core/src/cluster_info.rs
@@ -1992,7 +1992,7 @@ mod tests {
             );
 
             blocktree
-                .insert_shreds(vec![shred_info], None)
+                .insert_shreds(vec![shred_info], None, false)
                 .expect("Expect successful ledger write");
 
             let rv = ClusterInfo::run_window_request(
@@ -2074,7 +2074,7 @@ mod tests {
             let (shreds, _) = make_many_slot_entries(1, 3, 5);
 
             blocktree
-                .insert_shreds(shreds, None)
+                .insert_shreds(shreds, None, false)
                 .expect("Expect successful ledger write");
 
             // We don't have slot 4, so we don't know how to service this requeset

--- a/core/src/cluster_info_repair_listener.rs
+++ b/core/src/cluster_info_repair_listener.rs
@@ -670,7 +670,7 @@ mod tests {
         let blocktree = Blocktree::open(&blocktree_path).unwrap();
         let num_slots = 2;
         let (shreds, _) = make_many_slot_entries(0, num_slots, 1);
-        blocktree.insert_shreds(shreds, None).unwrap();
+        blocktree.insert_shreds(shreds, None, false).unwrap();
 
         // Write roots so that these slots will qualify to be sent by the repairman
         let last_root = num_slots - 1;
@@ -741,7 +741,7 @@ mod tests {
         let num_shreds_per_slot = shreds.len() as u64 / num_slots;
 
         // Write slots in the range [0, num_slots] to blocktree
-        blocktree.insert_shreds(shreds, None).unwrap();
+        blocktree.insert_shreds(shreds, None, false).unwrap();
 
         // Write roots so that these slots will qualify to be sent by the repairman
         let roots: Vec<_> = (0..=num_slots - 1).collect();
@@ -819,7 +819,7 @@ mod tests {
         // Create blobs for first two epochs and write them to blocktree
         let total_slots = slots_per_epoch * 2;
         let (shreds, _) = make_many_slot_entries(0, total_slots, 1);
-        blocktree.insert_shreds(shreds, None).unwrap();
+        blocktree.insert_shreds(shreds, None, false).unwrap();
 
         // Write roots so that these slots will qualify to be sent by the repairman
         let roots: Vec<_> = (0..=slots_per_epoch * 2 - 1).collect();

--- a/core/src/ledger_cleanup_service.rs
+++ b/core/src/ledger_cleanup_service.rs
@@ -79,7 +79,7 @@ mod tests {
         let blocktree_path = get_tmp_ledger_path!();
         let blocktree = Blocktree::open(&blocktree_path).unwrap();
         let (shreds, _) = make_many_slot_entries(0, 50, 5);
-        blocktree.insert_shreds(shreds, None).unwrap();
+        blocktree.insert_shreds(shreds, None, false).unwrap();
         let blocktree = Arc::new(blocktree);
         let (sender, receiver) = channel();
 

--- a/core/src/repair_service.rs
+++ b/core/src/repair_service.rs
@@ -411,7 +411,7 @@ mod test {
             let (mut shreds, _) = make_slot_entries(1, 0, 1);
             let (shreds2, _) = make_slot_entries(5, 2, 1);
             shreds.extend(shreds2);
-            blocktree.insert_shreds(shreds, None).unwrap();
+            blocktree.insert_shreds(shreds, None, false).unwrap();
             assert_eq!(
                 RepairService::generate_repairs(&blocktree, 0, 2).unwrap(),
                 vec![RepairType::HighestBlob(0, 0), RepairType::Orphan(2)]
@@ -431,7 +431,7 @@ mod test {
 
             // Write this blob to slot 2, should chain to slot 0, which we haven't received
             // any blobs for
-            blocktree.insert_shreds(shreds, None).unwrap();
+            blocktree.insert_shreds(shreds, None, false).unwrap();
 
             // Check that repair tries to patch the empty slot
             assert_eq!(
@@ -467,7 +467,9 @@ mod test {
                     missing_indexes_per_slot.insert(0, index);
                 }
             }
-            blocktree.insert_shreds(shreds_to_write, None).unwrap();
+            blocktree
+                .insert_shreds(shreds_to_write, None, false)
+                .unwrap();
             // sleep so that the holes are ready for repair
             sleep(Duration::from_secs(1));
             let expected: Vec<RepairType> = (0..num_slots)
@@ -506,7 +508,7 @@ mod test {
             // Remove last shred (which is also last in slot) so that slot is not complete
             shreds.pop();
 
-            blocktree.insert_shreds(shreds, None).unwrap();
+            blocktree.insert_shreds(shreds, None, false).unwrap();
 
             // We didn't get the last blob for this slot, so ask for the highest blob for that slot
             let expected: Vec<RepairType> =
@@ -532,7 +534,7 @@ mod test {
             let shreds = make_chaining_slot_entries(&slots, num_entries_per_slot);
             for (mut slot_shreds, _) in shreds.into_iter() {
                 slot_shreds.remove(0);
-                blocktree.insert_shreds(slot_shreds, None).unwrap();
+                blocktree.insert_shreds(slot_shreds, None, false).unwrap();
             }
             // sleep to make slot eligible for repair
             sleep(Duration::from_secs(1));
@@ -585,7 +587,7 @@ mod test {
                 let parent = if i > 0 { i - 1 } else { 0 };
                 let (shreds, _) = make_slot_entries(i, parent, num_entries_per_slot as u64);
 
-                blocktree.insert_shreds(shreds, None).unwrap();
+                blocktree.insert_shreds(shreds, None, false).unwrap();
             }
 
             let end = 4;
@@ -638,9 +640,9 @@ mod test {
                 .collect();
             let mut full_slots = BTreeSet::new();
 
-            blocktree.insert_shreds(fork1_shreds, None).unwrap();
+            blocktree.insert_shreds(fork1_shreds, None, false).unwrap();
             blocktree
-                .insert_shreds(fork2_incomplete_shreds, None)
+                .insert_shreds(fork2_incomplete_shreds, None, false)
                 .unwrap();
 
             // Test that only slots > root from fork1 were included
@@ -664,7 +666,7 @@ mod test {
                 .into_iter()
                 .flat_map(|(shreds, _)| shreds)
                 .collect();
-            blocktree.insert_shreds(fork3_shreds, None).unwrap();
+            blocktree.insert_shreds(fork3_shreds, None, false).unwrap();
             RepairService::get_completed_slots_past_root(
                 &blocktree,
                 &mut full_slots,
@@ -711,7 +713,9 @@ mod test {
                         let step = rng.gen_range(1, max_step + 1) as usize;
                         let step = std::cmp::min(step, num_shreds - i);
                         let shreds_to_insert = shreds.drain(..step).collect_vec();
-                        blocktree_.insert_shreds(shreds_to_insert, None).unwrap();
+                        blocktree_
+                            .insert_shreds(shreds_to_insert, None, false)
+                            .unwrap();
                         sleep(Duration::from_millis(repair_interval_ms));
                         i += step;
                     }
@@ -741,7 +745,7 @@ mod test {
             // Update with new root, should filter out the slots <= root
             root = num_slots / 2;
             let (shreds, _) = make_slot_entries(num_slots + 2, num_slots + 1, entries_per_slot);
-            blocktree.insert_shreds(shreds, None).unwrap();
+            blocktree.insert_shreds(shreds, None, false).unwrap();
             RepairService::update_epoch_slots(
                 Pubkey::default(),
                 root,

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -973,7 +973,7 @@ mod test {
 
             // Insert blob for slot 1, generate new forks, check result
             let (shreds, _) = make_slot_entries(1, 0, 8);
-            blocktree.insert_shreds(shreds, None).unwrap();
+            blocktree.insert_shreds(shreds, None, false).unwrap();
             assert!(bank_forks.get(1).is_none());
             ReplayStage::generate_new_bank_forks(
                 &blocktree,
@@ -984,7 +984,7 @@ mod test {
 
             // Insert blob for slot 3, generate new forks, check result
             let (shreds, _) = make_slot_entries(2, 0, 8);
-            blocktree.insert_shreds(shreds, None).unwrap();
+            blocktree.insert_shreds(shreds, None, false).unwrap();
             assert!(bank_forks.get(2).is_none());
             ReplayStage::generate_new_bank_forks(
                 &blocktree,
@@ -1230,7 +1230,7 @@ mod test {
             let last_blockhash = bank0.last_blockhash();
             progress.insert(bank0.slot(), ForkProgress::new(0, last_blockhash));
             let shreds = shred_to_insert(&mint_keypair, bank0.clone());
-            blocktree.insert_shreds(shreds, None).unwrap();
+            blocktree.insert_shreds(shreds, None, false).unwrap();
             let (res, _tx_count) =
                 ReplayStage::replay_blocktree_into_bank(&bank0, &blocktree, &mut progress);
 

--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -132,7 +132,8 @@ where
         }
     }
 
-    let blocktree_insert_metrics = blocktree.insert_shreds(shreds, Some(leader_schedule_cache))?;
+    let blocktree_insert_metrics =
+        blocktree.insert_shreds(shreds, Some(leader_schedule_cache), false)?;
     blocktree_insert_metrics.report_metrics("recv-window-insert-shreds");
 
     trace!(
@@ -322,7 +323,7 @@ mod test {
         let mut shreds = local_entries_to_shred(&original_entries, 0, 0, &Arc::new(Keypair::new()));
         shreds.reverse();
         blocktree
-            .insert_shreds(shreds, None)
+            .insert_shreds(shreds, None, false)
             .expect("Expect successful processing of shred");
 
         assert_eq!(

--- a/ledger/src/blocktree.rs
+++ b/ledger/src/blocktree.rs
@@ -3965,4 +3965,28 @@ pub mod tests {
         }
         Blocktree::destroy(&blocktree_path).expect("Expected successful database destruction");
     }
+
+    #[test]
+    fn test_trusted_insert_shreds() {
+        // Make shred for slot 1
+        let (shreds1, _) = make_slot_entries(1, 0, 1);
+        let blocktree_path = get_tmp_ledger_path!();
+        let last_root = 100;
+        {
+            let blocktree = Blocktree::open(&blocktree_path).unwrap();
+            blocktree.set_roots(&[last_root]).unwrap();
+
+            // Insert will fail, slot < root
+            blocktree
+                .insert_shreds(shreds1.clone()[..].to_vec(), None, false)
+                .unwrap();
+            assert!(blocktree.get_data_shred(1, 0).unwrap().is_none());
+
+            // Insert through trusted path will succeed
+            blocktree
+                .insert_shreds(shreds1[..].to_vec(), None, true)
+                .unwrap();
+            assert!(blocktree.get_data_shred(1, 0).unwrap().is_some());
+        }
+    }
 }

--- a/ledger/src/blocktree.rs
+++ b/ledger/src/blocktree.rs
@@ -465,9 +465,9 @@ impl Blocktree {
         let mut start = Measure::start("Shred insertion");
         let mut num_inserted = 0;
         let mut index_meta_time = 0;
-        for shred in shreds {
+        shreds.into_iter().for_each(|shred| {
             if shred.is_data() {
-                self.check_insert_data_shred(
+                if self.check_insert_data_shred(
                     shred,
                     &mut index_working_set,
                     &mut slot_meta_working_set,
@@ -475,8 +475,9 @@ impl Blocktree {
                     &mut just_inserted_data_shreds,
                     &mut index_meta_time,
                     is_trusted,
-                )?;
-                num_inserted += 1;
+                ) {
+                    num_inserted += 1;
+                }
             } else if shred.is_code() {
                 self.check_cache_coding_shred(
                     shred,
@@ -489,7 +490,7 @@ impl Blocktree {
             } else {
                 panic!("There should be no other case");
             }
-        }
+        });
         start.stop();
 
         let insert_shreds_elapsed = start.as_us();
@@ -505,7 +506,7 @@ impl Blocktree {
             );
 
             num_recovered = recovered_data.len();
-            for shred in recovered_data {
+            recovered_data.into_iter().for_each(|shred| {
                 if let Some(leader) = leader_schedule_cache.slot_leader_at(shred.slot(), None) {
                     if shred.verify(&leader) {
                         self.check_insert_data_shred(
@@ -516,23 +517,25 @@ impl Blocktree {
                             &mut just_inserted_data_shreds,
                             &mut index_meta_time,
                             is_trusted,
-                        )?;
+                        );
                     }
                 }
-            }
+            });
         }
         start.stop();
         let shred_recovery_elapsed = start.as_us();
 
-        for ((_, _), shred) in just_inserted_coding_shreds {
-            self.check_insert_coding_shred(
-                shred,
-                &mut index_working_set,
-                &mut write_batch,
-                &mut index_meta_time,
-            )?;
-            num_inserted += 1;
-        }
+        just_inserted_coding_shreds
+            .into_iter()
+            .for_each(|((_, _), shred)| {
+                self.check_insert_coding_shred(
+                    shred,
+                    &mut index_working_set,
+                    &mut write_batch,
+                    &mut index_meta_time,
+                );
+                num_inserted += 1;
+            });
 
         let mut start = Measure::start("Shred recovery");
         // Handle chaining for the members of the slot_meta_working_set that were inserted into,
@@ -589,14 +592,13 @@ impl Blocktree {
         })
     }
 
-    // Should only error if there's a database error
     fn check_insert_coding_shred(
         &self,
         shred: Shred,
         index_working_set: &mut HashMap<u64, IndexMetaWorkingSetEntry>,
         write_batch: &mut WriteBatch,
         index_meta_time: &mut u64,
-    ) -> Result<()> {
+    ) -> bool {
         let slot = shred.slot();
 
         let index_meta_working_set_entry =
@@ -609,6 +611,7 @@ impl Blocktree {
             .map(|_| {
                 index_meta_working_set_entry.did_insert_occur = true;
             })
+            .is_ok()
     }
 
     fn check_cache_coding_shred(
@@ -664,7 +667,6 @@ impl Blocktree {
         }
     }
 
-    // Should only error if there's a database error
     fn check_insert_data_shred(
         &self,
         shred: Shred,
@@ -674,7 +676,7 @@ impl Blocktree {
         just_inserted_data_shreds: &mut HashMap<(u64, u64), Shred>,
         index_meta_time: &mut u64,
         is_trusted: bool,
-    ) -> Result<bool> {
+    ) -> bool {
         let slot = shred.slot();
         let shred_index = u64::from(shred.index());
 
@@ -687,24 +689,27 @@ impl Blocktree {
 
         let slot_meta = &mut slot_meta_entry.new_slot_meta.borrow_mut();
 
-        let should_insert = is_trusted
+        if is_trusted
             || Blocktree::should_insert_data_shred(
                 &shred,
                 slot_meta,
                 index_meta.data(),
                 &self.last_root,
-            );
-
-        if should_insert {
-            // Can't call `insert_data_shred.map` here b/c slot_meta is borrowed and cannot be
-            // reborrowed into a closure
-            self.insert_data_shred(slot_meta, index_meta.data_mut(), &shred, write_batch)?;
-            just_inserted_data_shreds.insert((slot, shred_index), shred);
-            index_meta_working_set_entry.did_insert_occur = true;
-            slot_meta_entry.did_insert_occur = true;
+            )
+        {
+            if let Ok(()) =
+                self.insert_data_shred(slot_meta, index_meta.data_mut(), &shred, write_batch)
+            {
+                just_inserted_data_shreds.insert((slot, shred_index), shred);
+                index_meta_working_set_entry.did_insert_occur = true;
+                slot_meta_entry.did_insert_occur = true;
+                true
+            } else {
+                false
+            }
+        } else {
+            false
         }
-
-        Ok(should_insert)
     }
 
     fn should_insert_coding_shred(

--- a/ledger/src/leader_schedule_cache.rs
+++ b/ledger/src/leader_schedule_cache.rs
@@ -438,7 +438,7 @@ mod tests {
             // Write a blob into slot 2 that chains to slot 1,
             // but slot 1 is empty so should not be skipped
             let (shreds, _) = make_slot_entries(2, 1, 1);
-            blocktree.insert_shreds(shreds, None).unwrap();
+            blocktree.insert_shreds(shreds, None, false).unwrap();
             assert_eq!(
                 cache
                     .next_leader_slot(&pubkey, 0, &bank, Some(&blocktree))
@@ -451,7 +451,7 @@ mod tests {
             let (shreds, _) = make_slot_entries(1, 0, 1);
 
             // Check that slot 1 and 2 are skipped
-            blocktree.insert_shreds(shreds, None).unwrap();
+            blocktree.insert_shreds(shreds, None, false).unwrap();
             assert_eq!(
                 cache
                     .next_leader_slot(&pubkey, 0, &bank, Some(&blocktree))

--- a/ledger/tests/blocktree.rs
+++ b/ledger/tests/blocktree.rs
@@ -25,7 +25,7 @@ fn test_multiple_threads_insert_shred() {
                 Builder::new()
                     .name("blocktree-writer".to_string())
                     .spawn(move || {
-                        blocktree_.insert_shreds(shreds, None).unwrap();
+                        blocktree_.insert_shreds(shreds, None, false).unwrap();
                     })
                     .unwrap()
             })


### PR DESCRIPTION
#### Problem
When broadcast is slow, a leader's  root can move ahead of blocktree insert, causing inserts for the leader's own slots to fail

#### Summary of Changes
Disable verification when leader is inserting into his own slot

Fixes #
