### PR TITLE
Git should ignore symlinked logdir in repo root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 # log files
 *.log
 log-*.txt
+log-*/
 
 # intellij files
 /.idea/


### PR DESCRIPTION
We've been git ignoring log dirs within `net/log` but the new symlink `solana/log -> solana/net/log-[date]` was not covered by `.gitignore`