### PR TITLE
Keygen grind fix and improve --ignore-case

### DIFF
--- a/keygen/src/keygen.rs
+++ b/keygen/src/keygen.rs
@@ -241,6 +241,13 @@ fn main() -> Result<(), Box<dyn error::Error>> {
             let includes = if matches.is_present("includes") {
                 values_t_or_exit!(matches, "includes", String)
                     .into_iter()
+                    .map(|s| {
+                        if ignore_case {
+                            s.to_lowercase()
+                        } else {
+                            s
+                        }
+                    })
                     .collect()
             } else {
                 HashSet::new()
@@ -249,6 +256,13 @@ fn main() -> Result<(), Box<dyn error::Error>> {
             let starts_with = if matches.is_present("starts_with") {
                 values_t_or_exit!(matches, "starts_with", String)
                     .into_iter()
+                    .map(|s| {
+                        if ignore_case {
+                            s.to_lowercase()
+                        } else {
+                            s
+                        }
+                    })
                     .collect()
             } else {
                 HashSet::new()

--- a/keygen/src/keygen.rs
+++ b/keygen/src/keygen.rs
@@ -241,13 +241,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
             let includes = if matches.is_present("includes") {
                 values_t_or_exit!(matches, "includes", String)
                     .into_iter()
-                    .map(|s| {
-                        if ignore_case {
-                            s.to_lowercase()
-                        } else {
-                            s
-                        }
-                    })
+                    .map(|s| if ignore_case { s.to_lowercase() } else { s })
                     .collect()
             } else {
                 HashSet::new()
@@ -256,13 +250,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
             let starts_with = if matches.is_present("starts_with") {
                 values_t_or_exit!(matches, "starts_with", String)
                     .into_iter()
-                    .map(|s| {
-                        if ignore_case {
-                            s.to_lowercase()
-                        } else {
-                            s
-                        }
-                    })
+                    .map(|s| if ignore_case { s.to_lowercase() } else { s })
                     .collect()
             } else {
                 HashSet::new()

--- a/keygen/src/keygen.rs
+++ b/keygen/src/keygen.rs
@@ -237,7 +237,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
             output_keypair(&keypair, &outfile, "recovered")?;
         }
         ("grind", Some(matches)) => {
-            let ignore_case = matches.is_present("ignore-case");
+            let ignore_case = matches.is_present("ignore_case");
             let includes = if matches.is_present("includes") {
                 values_t_or_exit!(matches, "includes", String)
                     .into_iter()


### PR DESCRIPTION
#### Problem

`solana-keygen grind`'s `--ignore-case` a) is not honored and b) has poor ergonomics

#### Summary of Changes

* Fix typo in argument match search
* lowercase search terms when `--ignore-case` is passed