### PR TITLE
Make creating new snapshot.tar.bz2 truly-atomic

### DIFF
--- a/core/src/snapshot_packager_service.rs
+++ b/core/src/snapshot_packager_service.rs
@@ -115,7 +115,6 @@ impl SnapshotPackagerService {
 
         // Once everything is successful, overwrite the previous tarball so that other validators
         // can fetch this newly packaged snapshot
-        let _ = fs::remove_file(&snapshot_package.tar_output_file);
         let metadata = fs::metadata(&archive_path)?;
         fs::rename(&archive_path, &snapshot_package.tar_output_file)?;
 


### PR DESCRIPTION
#### Problem

This is really nano PR fixing a minor non-atomicity of snapshot file creation.

According to @mvines's [comment](https://github.com/solana-labs/solana/issues/6881#issuecomment-552949264):

> > I think it's prudent to do atomic rename here by just removing `fs::remove_file(&snapshot_package.tar_output_file)`.
> 
> Yes, I agree. Go for it!


Fixes #6881 

