### PR TITLE
Revive the parallel bank client

### DIFF
--- a/runtime/src/bank_client.rs
+++ b/runtime/src/bank_client.rs
@@ -239,7 +239,11 @@ impl SyncClient for BankClient {
 impl BankClient {
     fn run(bank: &Bank, transaction_receiver: Receiver<Transaction>) {
         while let Ok(tx) = transaction_receiver.recv() {
-            let _ = bank.process_transaction(&tx);
+            let mut transactions = vec![tx];
+            while let Ok(tx) = transaction_receiver.try_recv() {
+                transactions.push(tx);
+            }
+            let _ = bank.process_transactions(&transactions);
         }
     }
 


### PR DESCRIPTION
#### Problem

A validator processes transactions in parallel. BankClient (used by unit tests) used to process transactions in parallel too back in v0.16, but was changed to process them sequentially to improve CI stability.

#### Summary of Changes

Resurrect the parallelism and see if it exposes any real bugs.

cc: @rob-solana 