### PR TITLE
Map all private IP to public IP for log-analyzer

### DIFF
--- a/log-analyzer/src/main.rs
+++ b/log-analyzer/src/main.rs
@@ -101,20 +101,19 @@ fn map_ip_address(mappings: &[IPAddrMapping], target: String) -> String {
 
 fn process_iftop_logs(matches: &ArgMatches) {
     let mut map_list: Vec<IPAddrMapping> = vec![];
-    match matches.subcommand() {
-        ("map-IP", Some(args_matches)) => {
-            let mut list = args_matches
-                .value_of("list")
-                .expect("Missing list of IP address mappings")
-                .to_string();
-            list.insert(0, '[');
-            let terminate_at = list.rfind('}').expect("Didn't find a terminating '}'") + 1;
-            let _ = list.split_off(terminate_at);
-            list.push(']');
-            map_list =
-                serde_json::from_str(&list).expect("Failed to parse IP address mapping list");
-        }
-        _ => {}
+    if let ("map-IP", Some(args_matches)) = matches.subcommand() {
+        let mut list = args_matches
+            .value_of("list")
+            .expect("Missing list of IP address mappings")
+            .to_string();
+        list.insert(0, '[');
+        let terminate_at = list
+            .rfind('}')
+            .expect("Didn't find a terminating '}' in IP list")
+            + 1;
+        let _ = list.split_off(terminate_at);
+        list.push(']');
+        map_list = serde_json::from_str(&list).expect("Failed to parse IP address mapping list");
     };
 
     let log_path = PathBuf::from(value_t_or_exit!(matches, "file", String));

--- a/log-analyzer/src/main.rs
+++ b/log-analyzer/src/main.rs
@@ -12,6 +12,12 @@ use std::ops::Sub;
 use std::path::PathBuf;
 
 #[derive(Deserialize, Serialize, Debug)]
+struct IPAddrMapping {
+    private: String,
+    public: String,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
 struct LogLine {
     a: String,
     b: String,
@@ -84,29 +90,31 @@ impl Sub for &LogLine {
     }
 }
 
+fn map_ip_address(mappings: &[IPAddrMapping], target: String) -> String {
+    for mapping in mappings {
+        if target.contains(&mapping.private) {
+            return target.replace(&mapping.private, mapping.public.as_str());
+        }
+    }
+    target.to_string()
+}
+
 fn process_iftop_logs(matches: &ArgMatches) {
-    let map_address;
-    let private_address;
-    let public_address;
+    let mut map_list: Vec<IPAddrMapping> = vec![];
     match matches.subcommand() {
         ("map-IP", Some(args_matches)) => {
-            map_address = true;
-            if let Some(addr) = args_matches.value_of("priv") {
-                private_address = addr;
-            } else {
-                panic!("Private IP address must be provided");
-            };
-            if let Some(addr) = args_matches.value_of("pub") {
-                public_address = addr;
-            } else {
-                panic!("Private IP address must be provided");
-            };
+            let mut list = args_matches
+                .value_of("list")
+                .expect("Missing list of IP address mappings")
+                .to_string();
+            list.insert(0, '[');
+            let terminate_at = list.rfind('}').expect("Didn't find a terminating '}'") + 1;
+            let _ = list.split_off(terminate_at);
+            list.push(']');
+            map_list =
+                serde_json::from_str(&list).expect("Failed to parse IP address mapping list");
         }
-        _ => {
-            map_address = false;
-            private_address = "";
-            public_address = "";
-        }
+        _ => {}
     };
 
     let log_path = PathBuf::from(value_t_or_exit!(matches, "file", String));
@@ -128,15 +136,15 @@ fn process_iftop_logs(matches: &ArgMatches) {
     let output: Vec<LogLine> = unique_latest_logs
         .into_iter()
         .map(|(_, l)| {
-            if map_address {
+            if map_list.is_empty() {
+                l
+            } else {
                 LogLine {
-                    a: l.a.replace(private_address, public_address),
-                    b: l.b.replace(private_address, public_address),
+                    a: map_ip_address(&map_list, l.a),
+                    b: map_ip_address(&map_list, l.b),
                     a_to_b: l.a_to_b,
                     b_to_a: l.b_to_a,
                 }
-            } else {
-                l
             }
         })
         .collect();
@@ -208,22 +216,15 @@ fn main() {
                 )
                 .subcommand(
                     SubCommand::with_name("map-IP")
-                        .about("Public IP Address")
+                        .about("Map private IP to public IP Address")
                         .arg(
-                            Arg::with_name("priv")
-                                .long("priv")
-                                .value_name("IP Address")
+                            Arg::with_name("list")
+                                .short("l")
+                                .long("list")
+                                .value_name("JSON string")
                                 .takes_value(true)
                                 .required(true)
-                                .help("The private IP address that should be mapped"),
-                        )
-                        .arg(
-                            Arg::with_name("pub")
-                                .long("pub")
-                                .value_name("IP Address")
-                                .takes_value(true)
-                                .required(true)
-                                .help("The public IP address"),
+                                .help("JSON string with a list of mapping"),
                         ),
                 ),
         )

--- a/scripts/iftop-postprocess.sh
+++ b/scripts/iftop-postprocess.sh
@@ -26,7 +26,7 @@ awk '{ if ($3 ~ "=>") { print $2, $7 } else if ($2 ~ "<=") { print $1, $6 }} ' <
 if [ "$#" -lt 3 ]; then
   solana-log-analyzer iftop -f "$2"
 else
-  list=`cat $3`
+  list=$(cat "$3")
   solana-log-analyzer iftop -f "$2" map-IP --list "$list"
 fi
 

--- a/scripts/iftop-postprocess.sh
+++ b/scripts/iftop-postprocess.sh
@@ -26,7 +26,8 @@ awk '{ if ($3 ~ "=>") { print $2, $7 } else if ($2 ~ "<=") { print $1, $6 }} ' <
 if [ "$#" -lt 3 ]; then
   solana-log-analyzer iftop -f "$2"
 else
-  solana-log-analyzer iftop -f "$2" map-IP --list "$3"
+  list=`cat $3`
+  solana-log-analyzer iftop -f "$2" map-IP --list "$list"
 fi
 
 exit 1

--- a/scripts/iftop-postprocess.sh
+++ b/scripts/iftop-postprocess.sh
@@ -5,7 +5,7 @@
 set -e
 
 usage() {
-  echo "Usage: $0 <iftop log file> <temp file for interediate data> [optional public IP address]"
+  echo "Usage: $0 <iftop log file> <temp file for interediate data> [optional list of IP address mapping]"
   echo
   echo Processes iftop log file, and extracts latest bandwidth used by each connection
   echo
@@ -23,10 +23,10 @@ awk '{ if ($3 ~ "=>") { print $2, $7 } else if ($2 ~ "<=") { print $1, $6 }} ' <
   | awk 'NR%2{printf "%s ",$0;next;}1' \
   | awk '{ print "{ \"a\": \""$1"\", " "\"b\": \""$3"\", \"a_to_b\": \""$2"\", \"b_to_a\": \""$4"\"}," }' > "$2"
 
-if [ "$#" -lt 4 ]; then
+if [ "$#" -lt 3 ]; then
   solana-log-analyzer iftop -f "$2"
 else
-  solana-log-analyzer iftop -f "$2" map-IP --priv "$3" --pub "$4"
+  solana-log-analyzer iftop -f "$2" map-IP --list "$3"
 fi
 
 exit 1


### PR DESCRIPTION
#### Problem
The output of iftop contains a mix of public IP and private IP for peer nodes. The code currently only maps current node's private IP to public IP. Need a mechanism to map peer node's IPs as well.

#### Summary of Changes
Updated command to take a JSON list of private IP to public IP mappings. All private IPs in the list will get mapped to the corresponding public IP.

Use the following command to compute the list from testnet configuration
``` for i in "${!validatorIpList[@]}"; do  echo "{\"private\": \""${validatorIpListPrivate[$i]}""\", \"public\": \""${validatorIpList[$i]}""\"}," ; done > ip_address_map.txt ```

scp the list to each node
```for ip in "${validatorIpList[@]}"; do :; ./net/scp.sh ip_address_map.txt solana@$ip:~/solana/; done```

Use the list in log-analyzer using this command
```for ip in "${validatorIpList[@]}"; do :; ./net/ssh.sh solana@$ip 'PATH=$PATH:~/.cargo/bin/ ~/solana/scripts/iftop-postprocess.sh ~/solana/iftop.log temp.log ~solana/solana/ip_address_map.txt' > iftop-logs/$ip-iftop.log; done```