### PR TITLE
cli: Add validator catchup command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3199,6 +3199,7 @@ dependencies = [
  "criterion-stats 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ctrlc 3.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "dirs 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "indicatif 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/book/src/running-validator/validator-monitor.md
+++ b/book/src/running-validator/validator-monitor.md
@@ -14,45 +14,39 @@ From another console, confirm the IP address and **identity pubkey** of your val
 solana-gossip --entrypoint testnet.solana.com:8001 spy
 ```
 
-## Check Vote Activity
+## Monitoring Catch Up
 
-The vote pubkey for the validator can be found by running:
-
-```bash
-solana-keygen pubkey ~/validator-vote-keypair.json
-```
-
-Provide the **vote pubkey** to the `solana show-vote-account` command to view the recent voting activity from your validator:
+It may take some time to catch up with the cluster after your validator boots.
+Use the `catchup` command to monitor your validator through this process:
 
 ```bash
-solana show-vote-account 2ozWvfaXQd1X6uKh8jERoRGApDqSqcEy6fF1oN13LL2G
+solana catchup ~/validator-keypair.json
 ```
+
+Until your validator has caught up, it will not be able to vote successfully and
+stake cannot be delegated to it.
+
+Also if you find the cluster's slot advancing faster than yours, you will likely
+never catch up. This typically implies some kind of networking issue between
+your validator and the rest of the cluster.
 
 ## Check Your Balance
 
-Your account balance should decrease by the transaction fee amount as your validator submits votes, and increase after serving as the leader. Pass the `--lamports` are to observe in finer detail:
+Your account balance should decrease by the transaction fee amount as your
+validator submits votes, and increase after serving as the leader. Pass the
+`--lamports` are to observe in finer detail:
 
 ```bash
 solana balance --lamports
 ```
 
-## Check Slot Number
+## Check Vote Activity
 
-After your validator boots, it may take some time to catch up with the cluster. Use the `get-slot` command to view the current slot that the cluster is processing:
-
-```bash
-solana get-slot
-```
-
-The current slot that your validator is processing can then been seen with:
+The `solana show-vote-account` command displays the recent voting activity from your validator:
 
 ```bash
-solana --url http://127.0.0.1:8899 get-slot
+solana show-vote-account ~/validator-vote-keypair.json
 ```
-
-Until your validator has caught up, it will not be able to vote successfully and stake cannot be delegated to it.
-
-Also if you find the cluster's slot advancing faster than yours, you will likely never catch up. This typically implies some kind of networking issue between your validator and the rest of the cluster.
 
 ## Get Cluster Info
 
@@ -68,6 +62,7 @@ curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1, "m
 # Returns info about the current epoch. slotIndex should progress on subsequent calls.
 curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1, "method":"getEpochInfo"}' http://testnet.solana.com:8899
 ```
+
 
 ## Validator Metrics
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -19,6 +19,7 @@ console = "0.9.1"
 dirs = "2.0.2"
 lazy_static = "1.4.0"
 log = "0.4.8"
+indicatif = "0.13.0"
 num-traits = "0.2"
 pretty-hex = "0.1.1"
 reqwest = { version = "0.9.22", default-features = false, features = ["rustls-tls"] }

--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -4,7 +4,7 @@ use crate::{
     generic_rpc_client_request::GenericRpcClientRequest,
     mock_rpc_client_request::MockRpcClientRequest,
     rpc_client_request::RpcClientRequest,
-    rpc_request::{RpcEpochInfo, RpcRequest, RpcVersionInfo, RpcVoteAccountStatus},
+    rpc_request::{RpcContactInfo, RpcEpochInfo, RpcRequest, RpcVersionInfo, RpcVoteAccountStatus},
 };
 use bincode::serialize;
 use log::*;
@@ -173,6 +173,25 @@ impl RpcClient {
             io::Error::new(
                 io::ErrorKind::Other,
                 format!("GetVoteAccounts parse failure: {}", err),
+            )
+        })
+    }
+
+    pub fn get_cluster_nodes(&self) -> io::Result<Vec<RpcContactInfo>> {
+        let response = self
+            .client
+            .send(&RpcRequest::GetClusterNodes, None, 0, None)
+            .map_err(|err| {
+                io::Error::new(
+                    io::ErrorKind::Other,
+                    format!("GetClusterNodes request failure: {:?}", err),
+                )
+            })?;
+
+        serde_json::from_value(response).map_err(|err| {
+            io::Error::new(
+                io::ErrorKind::Other,
+                format!("GetClusterNodes parse failure: {}", err),
             )
         })
     }

--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -378,9 +378,12 @@ EOF
     waitForNodeToInit
 
     if [[ $skipSetup != true && $nodeType != blockstreamer ]]; then
+      # Wait for the validator to catch up to the bootstrap leader before
+      # delegating stake to it
+      solana --url http://"$entrypointIp":8899 catchup config/validator-identity.json
+
       args=(
         --url http://"$entrypointIp":8899
-        --force
         "$stake"
       )
       if [[ $airdropsEnabled != true ]]; then


### PR DESCRIPTION
It's janky to monitor a validator  that's trying to catch up to the cluster.  Our best solution thus far has been:
```bash
echo "me: $(solana --url http://127.0.0.1:8899 get-slot | grep '^[0-9]\+$'), cluster: $(solana --url http://tds.solana.com:8899 get-slot | grep '^[0-9]\+$')"
```

But now the `solana catchup` command blocks until the validator catches up, displaying progress along the way:
```bash
$ solana catchup <validator identity pubkey>
```
