### PR TITLE
bank.rs: Restore is_frozen() asserts

### DIFF
--- a/ledger/src/blocktree_processor.rs
+++ b/ledger/src/blocktree_processor.rs
@@ -1932,10 +1932,10 @@ pub mod tests {
         };
         process_bank_0(&bank0, &blocktree, &opts).unwrap();
         let bank1 = Arc::new(Bank::new_from_parent(&bank0, &Pubkey::default(), 1));
-        bank1.squash();
         let slot1_entries = blocktree.get_slot_entries(1, 0, None).unwrap();
         verify_and_process_slot_entries(&bank1, &slot1_entries, bank0.last_blockhash(), &opts)
             .unwrap();
+        bank1.squash();
 
         // Test process_blocktree_from_root() from slot 1 onwards
         let (bank_forks, bank_forks_info, _) =

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -788,12 +788,11 @@ impl Bank {
     /// the oldest ones once its internal cache is full. Once boot, the
     /// bank will reject transactions using that `hash`.
     pub fn register_tick(&self, hash: &Hash) {
-        if self.is_frozen() {
-            warn!("=========== TODO: register_tick() working on a frozen bank! ================");
-        }
+        assert!(
+            !self.is_frozen(),
+            "register_tick() working on a frozen bank!"
+        );
 
-        // TODO: put this assert back in
-        // assert!(!self.is_frozen());
         inc_new_counter_debug!("bank-register_tick-registered", 1);
         // Grab blockhash lock before incrementing tick height so that replay stage does
         // not attempt to freeze after observing the last tick and before blockhash is
@@ -824,11 +823,10 @@ impl Bank {
         txs: &'b [Transaction],
         iteration_order: Option<Vec<usize>>,
     ) -> TransactionBatch<'a, 'b> {
-        if self.is_frozen() {
-            warn!("=========== TODO: lock_accounts() working on a frozen bank! ================");
-        }
-        // TODO: put this assert back in
-        // assert!(!self.is_frozen());
+        assert!(
+            !self.is_frozen(),
+            "prepare_batch() working on a frozen bank!"
+        );
         let results = self
             .rc
             .accounts
@@ -1154,9 +1152,10 @@ impl Bank {
         tx_count: u64,
         signature_count: u64,
     ) -> Vec<Result<()>> {
-        if self.is_frozen() {
-            warn!("=========== TODO: commit_transactions() working on a frozen bank! ================");
-        }
+        assert!(
+            !self.is_frozen(),
+            "commit_transactions() working on a frozen bank!"
+        );
 
         self.increment_transaction_count(tx_count);
         self.increment_signature_count(signature_count);
@@ -1168,8 +1167,6 @@ impl Bank {
             self.is_delta.store(true, Ordering::Relaxed);
         }
 
-        // TODO: put this assert back in
-        // assert!(!self.is_frozen());
         let mut write_time = Measure::start("write_time");
         self.rc.accounts.store_accounts(
             self.slot(),


### PR DESCRIPTION
The `assert!(!self.is_frozen());` sanity checks in the bank were disabled until bugs were squashed. Turn those asserts back on and see if we need to squish more bugs.

Towards #6474