### PR TITLE
Silence cargo install error in bpf script

### DIFF
--- a/sdk/bpf/scripts/install.sh
+++ b/sdk/bpf/scripts/install.sh
@@ -23,7 +23,7 @@ download() {
 }
 
 # Install or upgrade xargo
-cargo install cargo-update
+cargo install cargo-update 2> /dev/null
 cargo install-update -i xargo
 xargo --version > xargo.md 2>&1
 


### PR DESCRIPTION
#### Problem
Whenever running the bpf build scripts it outputs:
```
error: binary `cargo-install-update` already exists in destination as part of `cargo-update v2.3.1`
binary `cargo-install-update-config` already exists in destination as part of `cargo-update v2.3.1`
Add --force to overwrite
```
Which might confusingly look like a real issue to a developer

#### Summary of Changes
Silience output `>2 /dev/null`

Fixes #
