### PR TITLE
Log blocktree and snapshot open times

### DIFF
--- a/ledger/src/blocktree.rs
+++ b/ledger/src/blocktree.rs
@@ -140,6 +140,7 @@ impl Blocktree {
         adjust_ulimit_nofile();
 
         // Open the database
+        let measure = Measure::start("open");
         let db = Database::open(&blocktree_path)?;
 
         // Create the metadata column family
@@ -169,6 +170,7 @@ impl Blocktree {
             .unwrap_or(0);
         let last_root = Arc::new(RwLock::new(max_root));
 
+        info!("{:?} {}", blocktree_path, measure);
         Ok(Blocktree {
             db,
             meta_cf,


### PR DESCRIPTION
Sometimes it seemingly takes a long time to open blocktree and/or a snapshot.  Add more granular timing information for when this delay is next observed. 
