### PR TITLE
Move version! from core:: to clap_utils::

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3756,6 +3756,7 @@ dependencies = [
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-clap-utils 0.21.0",
  "solana-logger 0.21.0",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3664,6 +3664,7 @@ dependencies = [
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-clap-utils 0.21.0",
  "solana-logger 0.21.0",
 ]
 
@@ -3755,7 +3756,6 @@ dependencies = [
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-clap-utils 0.21.0",
  "solana-logger 0.21.0",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3035,6 +3035,7 @@ dependencies = [
  "serde_derive 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_yaml 0.8.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-clap-utils 0.21.0",
  "solana-client 0.21.0",
  "solana-core 0.21.0",
  "solana-drone 0.21.0",
@@ -3056,6 +3057,7 @@ name = "solana-bench-streamer"
 version = "0.21.0"
 dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-clap-utils 0.21.0",
  "solana-core 0.21.0",
  "solana-logger 0.21.0",
  "solana-net-utils 0.21.0",
@@ -3075,6 +3077,7 @@ dependencies = [
  "serde_yaml 0.8.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "serial_test 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serial_test_derive 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-clap-utils 0.21.0",
  "solana-client 0.21.0",
  "solana-core 0.21.0",
  "solana-drone 0.21.0",
@@ -3389,6 +3392,7 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-clap-utils 0.21.0",
  "solana-logger 0.21.0",
  "solana-metrics 0.21.0",
  "solana-sdk 0.21.0",
@@ -3448,6 +3452,7 @@ dependencies = [
  "serde_derive 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_yaml 0.8.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-clap-utils 0.21.0",
  "solana-genesis-programs 0.21.0",
  "solana-ledger 0.21.0",
  "solana-sdk 0.21.0",
@@ -3597,6 +3602,7 @@ dependencies = [
  "serde_derive 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_yaml 0.8.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-clap-utils 0.21.0",
  "solana-ledger 0.21.0",
  "solana-logger 0.21.0",
  "solana-runtime 0.21.0",
@@ -3749,6 +3755,7 @@ dependencies = [
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-clap-utils 0.21.0",
  "solana-logger 0.21.0",
 ]
 
@@ -3765,6 +3772,7 @@ dependencies = [
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "socket2 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-clap-utils 0.21.0",
  "solana-logger 0.21.0",
  "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4069,6 +4077,7 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-clap-utils 0.21.0",
  "solana-metrics 0.21.0",
  "solana-sdk 0.21.0",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3326,6 +3326,7 @@ dependencies = [
  "solana-budget-api 0.21.0",
  "solana-budget-program 0.21.0",
  "solana-chacha-sys 0.21.0",
+ "solana-clap-utils 0.21.0",
  "solana-client 0.21.0",
  "solana-drone 0.21.0",
  "solana-ledger 0.21.0",
@@ -3537,6 +3538,7 @@ dependencies = [
  "dirs 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rpassword 4.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-clap-utils 0.21.0",
  "solana-sdk 0.21.0",
  "tiny-bip39 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/archiver/src/main.rs
+++ b/archiver/src/main.rs
@@ -1,4 +1,4 @@
-use clap::{crate_description, crate_name, crate_version, App, Arg};
+use clap::{crate_description, crate_name, App, Arg};
 use console::style;
 use solana_clap_utils::input_validators::is_keypair;
 use solana_core::{
@@ -17,7 +17,7 @@ fn main() {
 
     let matches = App::new(crate_name!())
         .about(crate_description!())
-        .version(crate_version!())
+        .version(solana_clap_utils::version!())
         .arg(
             Arg::with_name("identity")
                 .short("i")
@@ -97,7 +97,7 @@ fn main() {
     println!(
         "{} version {} (branch={}, commit={})",
         style(crate_name!()).bold(),
-        crate_version!(),
+        solana_clap_utils::version!(),
         option_env!("CI_BRANCH").unwrap_or("unknown"),
         option_env!("CI_COMMIT").unwrap_or("unknown")
     );

--- a/bench-exchange/Cargo.toml
+++ b/bench-exchange/Cargo.toml
@@ -24,6 +24,7 @@ serde_derive = "1.0.102"
 serde_json = "1.0.41"
 serde_yaml = "0.8.11"
 # solana-runtime = { path = "../solana/runtime"}
+solana-clap-utils = { path = "../clap-utils", version = "0.21.0" }
 solana-core = { path = "../core", version = "0.21.0" }
 solana-genesis = { path = "../genesis", version = "0.21.0" }
 solana-client = { path = "../client", version = "0.21.0" }

--- a/bench-exchange/src/cli.rs
+++ b/bench-exchange/src/cli.rs
@@ -1,4 +1,4 @@
-use clap::{crate_description, crate_name, crate_version, value_t, App, Arg, ArgMatches};
+use clap::{crate_description, crate_name, value_t, App, Arg, ArgMatches};
 use solana_core::gen_keys::GenKeys;
 use solana_drone::drone::DRONE_PORT;
 use solana_sdk::signature::{read_keypair_file, Keypair, KeypairUtil};
@@ -44,10 +44,10 @@ impl Default for Config {
     }
 }
 
-pub fn build_args<'a, 'b>() -> App<'a, 'b> {
+pub fn build_args<'a, 'b>(version: &'b str) -> App<'a, 'b> {
     App::new(crate_name!())
         .about(crate_description!())
-        .version(crate_version!())
+        .version(version)
         .arg(
             Arg::with_name("entrypoint")
                 .short("n")

--- a/bench-exchange/src/main.rs
+++ b/bench-exchange/src/main.rs
@@ -11,7 +11,7 @@ fn main() {
     solana_logger::setup();
     solana_metrics::set_panic_hook("bench-exchange");
 
-    let matches = cli::build_args().get_matches();
+    let matches = cli::build_args(solana_clap_utils::version!()).get_matches();
     let cli_config = cli::extract_args(&matches);
 
     let cli::Config {

--- a/bench-streamer/Cargo.toml
+++ b/bench-streamer/Cargo.toml
@@ -9,6 +9,7 @@ homepage = "https://solana.com/"
 
 [dependencies]
 clap = "2.33.0"
+solana-clap-utils = { path = "../clap-utils", version = "0.21.0" }
 solana-core = { path = "../core", version = "0.21.0" }
 solana-logger = { path = "../logger", version = "0.21.0" }
 solana-net-utils = { path = "../net-utils", version = "0.21.0" }

--- a/bench-streamer/src/main.rs
+++ b/bench-streamer/src/main.rs
@@ -1,4 +1,4 @@
-use clap::{crate_description, crate_name, crate_version, App, Arg};
+use clap::{crate_description, crate_name, App, Arg};
 use solana_core::blob::BLOB_SIZE;
 use solana_core::packet::{Packet, Packets, PacketsRecycler, PACKET_DATA_SIZE};
 use solana_core::result::Result;
@@ -54,7 +54,7 @@ fn main() -> Result<()> {
 
     let matches = App::new(crate_name!())
         .about(crate_description!())
-        .version(crate_version!())
+        .version(solana_clap_utils::version!())
         .arg(
             Arg::with_name("num-recv-sockets")
                 .long("num-recv-sockets")

--- a/bench-tps/Cargo.toml
+++ b/bench-tps/Cargo.toml
@@ -16,6 +16,7 @@ serde = "1.0.102"
 serde_derive = "1.0.102"
 serde_json = "1.0.41"
 serde_yaml = "0.8.11"
+solana-clap-utils = { path = "../clap-utils", version = "0.21.0" }
 solana-core = { path = "../core", version = "0.21.0" }
 solana-genesis = { path = "../genesis", version = "0.21.0" }
 solana-client = { path = "../client", version = "0.21.0" }

--- a/bench-tps/src/cli.rs
+++ b/bench-tps/src/cli.rs
@@ -1,4 +1,4 @@
-use clap::{crate_description, crate_name, crate_version, App, Arg, ArgMatches};
+use clap::{crate_description, crate_name, App, Arg, ArgMatches};
 use solana_drone::drone::DRONE_PORT;
 use solana_sdk::fee_calculator::FeeCalculator;
 use solana_sdk::signature::{read_keypair_file, Keypair, KeypairUtil};
@@ -50,9 +50,9 @@ impl Default for Config {
 }
 
 /// Defines and builds the CLI args for a run of the benchmark
-pub fn build_args<'a, 'b>() -> App<'a, 'b> {
+pub fn build_args<'a, 'b>(version: &'b str) -> App<'a, 'b> {
     App::new(crate_name!()).about(crate_description!())
-        .version(crate_version!())
+        .version(version)
         .arg(
             Arg::with_name("entrypoint")
                 .short("n")

--- a/bench-tps/src/main.rs
+++ b/bench-tps/src/main.rs
@@ -15,7 +15,7 @@ fn main() {
     solana_logger::setup_with_filter("solana=info");
     solana_metrics::set_panic_hook("bench-tps");
 
-    let matches = cli::build_args().get_matches();
+    let matches = cli::build_args(solana_clap_utils::version!()).get_matches();
     let cli_config = cli::extract_args(&matches);
 
     let cli::Config {

--- a/clap-utils/src/lib.rs
+++ b/clap-utils/src/lib.rs
@@ -1,2 +1,21 @@
+#[macro_export]
+macro_rules! version {
+    () => {
+        &*format!(
+            "{}{}",
+            env!("CARGO_PKG_VERSION"),
+            if option_env!("CI_TAG").is_none() {
+                format!(
+                    " [channel={} commit={}]",
+                    option_env!("CHANNEL").unwrap_or("unknown"),
+                    option_env!("CI_COMMIT").unwrap_or("unknown"),
+                )
+            } else {
+                "".to_string()
+            },
+        )
+    };
+}
+
 pub mod input_parsers;
 pub mod input_validators;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -126,63 +126,67 @@ pub fn parse_args(matches: &ArgMatches<'_>) -> Result<CliConfig, Box<dyn error::
 
 fn main() -> Result<(), Box<dyn error::Error>> {
     solana_logger::setup();
-    let matches = app(crate_name!(), crate_description!(), solana_clap_utils::version!())
-        .arg({
-            let arg = Arg::with_name("config_file")
-                .short("C")
-                .long("config")
-                .value_name("PATH")
-                .takes_value(true)
-                .global(true)
-                .help("Configuration file to use");
-            if let Some(ref config_file) = *config::CONFIG_FILE {
-                arg.default_value(&config_file)
-            } else {
-                arg
-            }
-        })
-        .arg(
-            Arg::with_name("json_rpc_url")
-                .short("u")
-                .long("url")
-                .value_name("URL")
-                .takes_value(true)
-                .global(true)
-                .validator(is_url)
-                .help("JSON RPC URL for the solana cluster"),
-        )
-        .arg(
-            Arg::with_name("keypair")
-                .short("k")
-                .long("keypair")
-                .value_name("PATH")
-                .global(true)
-                .takes_value(true)
-                .help("/path/to/id.json"),
-        )
-        .subcommand(
-            SubCommand::with_name("get")
-                .about("Get cli config settings")
-                .arg(
-                    Arg::with_name("specific_setting")
-                        .index(1)
-                        .value_name("CONFIG_FIELD")
-                        .takes_value(true)
-                        .possible_values(&["url", "keypair"])
-                        .help("Return a specific config setting"),
-                ),
-        )
-        .subcommand(
-            SubCommand::with_name("set")
-                .about("Set a cli config setting")
-                .group(
-                    ArgGroup::with_name("config_settings")
-                        .args(&["json_rpc_url", "keypair"])
-                        .multiple(true)
-                        .required(true),
-                ),
-        )
-        .get_matches();
+    let matches = app(
+        crate_name!(),
+        crate_description!(),
+        solana_clap_utils::version!(),
+    )
+    .arg({
+        let arg = Arg::with_name("config_file")
+            .short("C")
+            .long("config")
+            .value_name("PATH")
+            .takes_value(true)
+            .global(true)
+            .help("Configuration file to use");
+        if let Some(ref config_file) = *config::CONFIG_FILE {
+            arg.default_value(&config_file)
+        } else {
+            arg
+        }
+    })
+    .arg(
+        Arg::with_name("json_rpc_url")
+            .short("u")
+            .long("url")
+            .value_name("URL")
+            .takes_value(true)
+            .global(true)
+            .validator(is_url)
+            .help("JSON RPC URL for the solana cluster"),
+    )
+    .arg(
+        Arg::with_name("keypair")
+            .short("k")
+            .long("keypair")
+            .value_name("PATH")
+            .global(true)
+            .takes_value(true)
+            .help("/path/to/id.json"),
+    )
+    .subcommand(
+        SubCommand::with_name("get")
+            .about("Get cli config settings")
+            .arg(
+                Arg::with_name("specific_setting")
+                    .index(1)
+                    .value_name("CONFIG_FIELD")
+                    .takes_value(true)
+                    .possible_values(&["url", "keypair"])
+                    .help("Return a specific config setting"),
+            ),
+    )
+    .subcommand(
+        SubCommand::with_name("set")
+            .about("Set a cli config setting")
+            .group(
+                ArgGroup::with_name("config_settings")
+                    .args(&["json_rpc_url", "keypair"])
+                    .multiple(true)
+                    .required(true),
+            ),
+    )
+    .get_matches();
 
     if parse_settings(&matches)? {
         let config = parse_args(&matches)?;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,4 +1,4 @@
-use clap::{crate_description, crate_name, crate_version, Arg, ArgGroup, ArgMatches, SubCommand};
+use clap::{crate_description, crate_name, Arg, ArgGroup, ArgMatches, SubCommand};
 use console::style;
 
 use solana_clap_utils::input_validators::is_url;
@@ -126,7 +126,7 @@ pub fn parse_args(matches: &ArgMatches<'_>) -> Result<CliConfig, Box<dyn error::
 
 fn main() -> Result<(), Box<dyn error::Error>> {
     solana_logger::setup();
-    let matches = app(crate_name!(), crate_description!(), crate_version!())
+    let matches = app(crate_name!(), crate_description!(), solana_clap_utils::version!())
         .arg({
             let arg = Arg::with_name("config_file")
                 .short("C")

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -47,6 +47,7 @@ serde_json = "1.0.41"
 sha2 = "0.8.0"
 solana-budget-api = { path = "../programs/budget_api", version = "0.21.0" }
 solana-budget-program = { path = "../programs/budget_program", version = "0.21.0" }
+solana-clap-utils = { path = "../clap-utils", version = "0.21.0" }
 solana-chacha-sys = { path = "../chacha-sys", version = "0.21.0" }
 solana-client = { path = "../client", version = "0.21.0" }
 solana-drone = { path = "../drone", version = "0.21.0" }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -5,24 +5,6 @@
 //! command-line tools to spin up validators and a Rust library
 //!
 
-#[macro_export]
-macro_rules! version {
-    () => {
-        &*format!(
-            "{}{}",
-            env!("CARGO_PKG_VERSION"),
-            if option_env!("CI_TAG").is_none() {
-                format!(
-                    " [channel={} commit={}]",
-                    option_env!("CHANNEL").unwrap_or("unknown"),
-                    option_env!("CI_COMMIT").unwrap_or("unknown"),
-                )
-            } else {
-                "".to_string()
-            },
-        )
-    };
-}
 pub mod banking_stage;
 pub mod blob;
 pub mod broadcast_stage;

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -967,7 +967,7 @@ impl RpcSol for RpcSolImpl {
 
     fn get_version(&self, _: Self::Metadata) -> Result<RpcVersionInfo> {
         Ok(RpcVersionInfo {
-            solana_core: crate::version!().to_string(),
+            solana_core: solana_clap_utils::version!().to_string(),
         })
     }
 

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -1714,7 +1714,7 @@ pub mod tests {
         let expected = json!({
             "jsonrpc": "2.0",
             "result": {
-                "solana-core": crate::version!().to_string()
+                "solana-core": solana_clap_utils::version!().to_string()
             },
             "id": 1
         });

--- a/core/tests/client.rs
+++ b/core/tests/client.rs
@@ -19,7 +19,7 @@ fn test_rpc_client() {
 
     assert_eq!(
         client.get_version().unwrap().solana_core,
-        solana_core::version!()
+        solana_clap_utils::version!()
     );
 
     assert_eq!(client.get_balance(&bob_pubkey).unwrap(), 0);

--- a/drone/Cargo.toml
+++ b/drone/Cargo.toml
@@ -19,6 +19,7 @@ clap = "2.33"
 log = "0.4.8"
 serde = "1.0.102"
 serde_derive = "1.0.102"
+solana-clap-utils = { path = "../clap-utils", version = "0.21.0" }
 solana-logger = { path = "../logger", version = "0.21.0" }
 solana-metrics = { path = "../metrics", version = "0.21.0" }
 solana-sdk = { path = "../sdk", version = "0.21.0" }

--- a/drone/src/bin/drone.rs
+++ b/drone/src/bin/drone.rs
@@ -1,4 +1,4 @@
-use clap::{crate_description, crate_name, crate_version, App, Arg};
+use clap::{crate_description, crate_name, App, Arg};
 use solana_drone::drone::{run_drone, Drone, DRONE_PORT};
 use solana_drone::socketaddr;
 use solana_sdk::signature::read_keypair_file;
@@ -12,7 +12,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
     solana_metrics::set_panic_hook("drone");
     let matches = App::new(crate_name!())
         .about(crate_description!())
-        .version(crate_version!())
+        .version(solana_clap_utils::version!())
         .arg(
             Arg::with_name("keypair")
                 .short("k")

--- a/genesis/Cargo.toml
+++ b/genesis/Cargo.toml
@@ -15,6 +15,7 @@ serde = "1.0.102"
 serde_derive = "1.0.102"
 serde_json = "1.0.41"
 serde_yaml = "0.8.11"
+solana-clap-utils = { path = "../clap-utils", version = "0.21.0" }
 solana-genesis-programs = { path = "../genesis-programs", version = "0.21.0" }
 solana-ledger = { path = "../ledger", version = "0.21.0" }
 solana-sdk = { path = "../sdk", version = "0.21.0" }

--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -3,7 +3,7 @@
 mod genesis_accounts;
 
 use crate::genesis_accounts::create_genesis_accounts;
-use clap::{crate_description, crate_name, crate_version, value_t_or_exit, App, Arg};
+use clap::{crate_description, crate_name, value_t_or_exit, App, Arg};
 use solana_genesis::Base64Account;
 use solana_ledger::blocktree::create_new_ledger;
 use solana_ledger::poh::compute_hashes_per_tick;
@@ -112,7 +112,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
 
     let matches = App::new(crate_name!())
         .about(crate_description!())
-        .version(crate_version!())
+        .version(solana_clap_utils::version!())
         .arg(
             Arg::with_name("bootstrap_leader_pubkey_file")
                 .short("b")

--- a/gossip/src/main.rs
+++ b/gossip/src/main.rs
@@ -1,7 +1,7 @@
 //! A command-line executable for monitoring a cluster's gossip plane.
 
 use clap::{
-    crate_description, crate_name, crate_version, value_t_or_exit, App, AppSettings, Arg,
+    crate_description, crate_name, value_t_or_exit, App, AppSettings, Arg,
     SubCommand,
 };
 use solana_clap_utils::input_validators::is_pubkey;
@@ -19,7 +19,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
     let entrypoint_string = entrypoint_addr.to_string();
     let matches = App::new(crate_name!())
         .about(crate_description!())
-        .version(crate_version!())
+        .version(solana_clap_utils::version!())
         .setting(AppSettings::SubcommandRequiredElseHelp)
         .arg(
             Arg::with_name("entrypoint")

--- a/gossip/src/main.rs
+++ b/gossip/src/main.rs
@@ -1,9 +1,6 @@
 //! A command-line executable for monitoring a cluster's gossip plane.
 
-use clap::{
-    crate_description, crate_name, value_t_or_exit, App, AppSettings, Arg,
-    SubCommand,
-};
+use clap::{crate_description, crate_name, value_t_or_exit, App, AppSettings, Arg, SubCommand};
 use solana_clap_utils::input_validators::is_pubkey;
 use solana_client::rpc_client::RpcClient;
 use solana_core::{contact_info::ContactInfo, gossip_service::discover};

--- a/install/src/lib.rs
+++ b/install/src/lib.rs
@@ -1,7 +1,7 @@
 #[macro_use]
 extern crate lazy_static;
 
-use clap::{crate_description, crate_name, crate_version, App, AppSettings, Arg, SubCommand};
+use clap::{crate_description, crate_name, App, AppSettings, Arg, SubCommand};
 use solana_clap_utils::input_validators::{is_pubkey, is_release_channel, is_semver, is_url};
 use solana_sdk::pubkey::Pubkey;
 
@@ -17,7 +17,7 @@ pub fn main() -> Result<(), String> {
 
     let matches = App::new(crate_name!())
         .about(crate_description!())
-        .version(crate_version!())
+        .version(solana_clap_utils::version!())
         .setting(AppSettings::SubcommandRequiredElseHelp)
         .arg({
             let arg = Arg::with_name("config_file")
@@ -234,7 +234,7 @@ pub fn main_init() -> Result<(), String> {
 
     let matches = App::new("solana-install-init")
         .about("initializes a new installation")
-        .version(crate_version!())
+        .version(solana_clap_utils::version!())
         .arg({
             let arg = Arg::with_name("config_file")
                 .short("c")

--- a/keygen/Cargo.toml
+++ b/keygen/Cargo.toml
@@ -14,6 +14,7 @@ clap = "2.33"
 dirs = "2.0.2"
 num_cpus = "1.11.1"
 rpassword = "4.0"
+solana-clap-utils = { path = "../clap-utils", version = "0.21.0" }
 solana-sdk = { path = "../sdk", version = "0.21.0" }
 tiny-bip39 = "0.6.2"
 

--- a/keygen/src/keygen.rs
+++ b/keygen/src/keygen.rs
@@ -1,8 +1,7 @@
 use bip39::{Language, Mnemonic, MnemonicType, Seed};
 use bs58;
 use clap::{
-    crate_description, crate_name, values_t_or_exit, App, AppSettings, Arg,
-    ArgMatches, SubCommand,
+    crate_description, crate_name, values_t_or_exit, App, AppSettings, Arg, ArgMatches, SubCommand,
 };
 use num_cpus;
 use solana_sdk::{

--- a/keygen/src/keygen.rs
+++ b/keygen/src/keygen.rs
@@ -1,7 +1,7 @@
 use bip39::{Language, Mnemonic, MnemonicType, Seed};
 use bs58;
 use clap::{
-    crate_description, crate_name, crate_version, values_t_or_exit, App, AppSettings, Arg,
+    crate_description, crate_name, values_t_or_exit, App, AppSettings, Arg,
     ArgMatches, SubCommand,
 };
 use num_cpus;
@@ -53,7 +53,7 @@ fn output_keypair(
 fn main() -> Result<(), Box<dyn error::Error>> {
     let matches = App::new(crate_name!())
         .about(crate_description!())
-        .version(crate_version!())
+        .version(solana_clap_utils::version!())
         .setting(AppSettings::SubcommandRequiredElseHelp)
         .subcommand(
             SubCommand::with_name("new")

--- a/ledger-tool/Cargo.toml
+++ b/ledger-tool/Cargo.toml
@@ -15,6 +15,7 @@ serde = "1.0.102"
 serde_derive = "1.0.102"
 serde_json = "1.0.41"
 serde_yaml = "0.8.11"
+solana-clap-utils = { path = "../clap-utils", version = "0.21.0" }
 solana-ledger = { path = "../ledger", version = "0.21.0" }
 solana-logger = { path = "../logger", version = "0.21.0" }
 solana-runtime = { path = "../runtime", version = "0.21.0" }

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -1,6 +1,5 @@
 use clap::{
-    crate_description, crate_name, value_t, value_t_or_exit, values_t_or_exit, App,
-    Arg, SubCommand,
+    crate_description, crate_name, value_t, value_t_or_exit, values_t_or_exit, App, Arg, SubCommand,
 };
 use solana_ledger::{
     bank_forks::{BankForks, SnapshotConfig},

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -1,5 +1,5 @@
 use clap::{
-    crate_description, crate_name, crate_version, value_t, value_t_or_exit, values_t_or_exit, App,
+    crate_description, crate_name, value_t, value_t_or_exit, values_t_or_exit, App,
     Arg, SubCommand,
 };
 use solana_ledger::{
@@ -402,7 +402,7 @@ fn main() {
 
     let matches = App::new(crate_name!())
         .about(crate_description!())
-        .version(crate_version!())
+        .version(solana_clap_utils::version!())
         .arg(
             Arg::with_name("ledger")
                 .short("l")

--- a/log-analyzer/Cargo.toml
+++ b/log-analyzer/Cargo.toml
@@ -17,6 +17,7 @@ semver = "0.9.0"
 serde = "1.0.102"
 serde_derive = "1.0.102"
 serde_json = "1.0.41"
+solana-clap-utils = { path = "../clap-utils", version = "0.21.0" }
 solana-logger = { path = "../logger", version = "0.21.0" }
 
 [[bin]]

--- a/log-analyzer/src/main.rs
+++ b/log-analyzer/src/main.rs
@@ -2,7 +2,7 @@ extern crate byte_unit;
 
 use byte_unit::Byte;
 use clap::{
-    crate_description, crate_name, crate_version, value_t_or_exit, App, Arg, ArgMatches, SubCommand,
+    crate_description, crate_name, value_t_or_exit, App, Arg, ArgMatches, SubCommand,
 };
 
 use serde::{Deserialize, Serialize};
@@ -201,7 +201,7 @@ fn main() {
 
     let matches = App::new(crate_name!())
         .about(crate_description!())
-        .version(crate_version!())
+        .version(solana_clap_utils::version!())
         .subcommand(
             SubCommand::with_name("iftop")
                 .about("Process iftop log file")

--- a/log-analyzer/src/main.rs
+++ b/log-analyzer/src/main.rs
@@ -1,9 +1,7 @@
 extern crate byte_unit;
 
 use byte_unit::Byte;
-use clap::{
-    crate_description, crate_name, value_t_or_exit, App, Arg, ArgMatches, SubCommand,
-};
+use clap::{crate_description, crate_name, value_t_or_exit, App, Arg, ArgMatches, SubCommand};
 
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;

--- a/net-shaper/Cargo.toml
+++ b/net-shaper/Cargo.toml
@@ -16,6 +16,7 @@ semver = "0.9.0"
 serde = "1.0.102"
 serde_derive = "1.0.102"
 serde_json = "1.0.41"
+solana-clap-utils = { path = "../clap-utils", version = "0.21.0" }
 solana-logger = { path = "../logger", version = "0.21.0" }
 
 [[bin]]

--- a/net-shaper/src/main.rs
+++ b/net-shaper/src/main.rs
@@ -1,6 +1,4 @@
-use clap::{
-    crate_description, crate_name, crate_version, value_t_or_exit, App, Arg, ArgMatches, SubCommand,
-};
+use clap::{crate_description, crate_name, value_t_or_exit, App, Arg, ArgMatches, SubCommand};
 
 use serde::{Deserialize, Serialize};
 use std::fs;
@@ -294,7 +292,7 @@ fn main() {
 
     let matches = App::new(crate_name!())
         .about(crate_description!())
-        .version(crate_version!())
+        .version(solana_clap_utils::version!())
         .subcommand(
             SubCommand::with_name("shape")
                 .about("Shape the network using config file")

--- a/net-utils/Cargo.toml
+++ b/net-utils/Cargo.toml
@@ -18,6 +18,7 @@ rand = "0.6.1"
 serde = "1.0.102"
 serde_derive = "1.0.102"
 socket2 = "0.3.11"
+solana-clap-utils = { path = "../clap-utils", version = "0.21.0" }
 solana-logger = { path = "../logger", version = "0.21.0" }
 tokio = "0.1"
 tokio-codec = "0.1"

--- a/net-utils/src/bin/ip_address.rs
+++ b/net-utils/src/bin/ip_address.rs
@@ -1,9 +1,9 @@
-use clap::{crate_version, App, Arg};
+use clap::{App, Arg};
 
 fn main() {
     solana_logger::setup();
     let matches = App::new("solana-ip-address")
-        .version(crate_version!())
+        .version(solana_clap_utils::version!())
         .arg(
             Arg::with_name("host_port")
                 .index(1)

--- a/net-utils/src/bin/ip_address_server.rs
+++ b/net-utils/src/bin/ip_address_server.rs
@@ -1,10 +1,10 @@
-use clap::{crate_version, App, Arg};
+use clap::{App, Arg};
 use std::net::{SocketAddr, TcpListener};
 
 fn main() {
     solana_logger::setup();
     let matches = App::new("solana-ip-address-server")
-        .version(crate_version!())
+        .version(solana_clap_utils::version!())
         .arg(
             Arg::with_name("port")
                 .index(1)

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -297,7 +297,7 @@ pub fn main() {
         &format!("{}-{}", VALIDATOR_PORT_RANGE.0, VALIDATOR_PORT_RANGE.1);
 
     let matches = App::new(crate_name!()).about(crate_description!())
-        .version(solana_core::version!())
+        .version(solana_clap_utils::version!())
         .arg(
             Arg::with_name("blockstream_unix_socket")
                 .long("blockstream")
@@ -591,7 +591,7 @@ pub fn main() {
     println!(
         "{} {}",
         style(crate_name!()).bold(),
-        solana_core::version!()
+        solana_clap_utils::version!()
     );
 
     let _log_redirect = {

--- a/vote-signer/Cargo.toml
+++ b/vote-signer/Cargo.toml
@@ -17,6 +17,7 @@ jsonrpc-http-server = "14.0.3"
 log = "0.4.8"
 serde = "1.0.102"
 serde_json = "1.0.41"
+solana-clap-utils = { path = "../clap-utils", version = "0.21.0" }
 solana-metrics = { path = "../metrics", version = "0.21.0" }
 solana-sdk = { path = "../sdk", version = "0.21.0" }
 

--- a/vote-signer/src/bin/main.rs
+++ b/vote-signer/src/bin/main.rs
@@ -1,4 +1,4 @@
-use clap::{crate_description, crate_name, crate_version, App, Arg};
+use clap::{crate_description, crate_name, App, Arg};
 use solana_vote_signer::rpc::VoteSignerRpcService;
 use std::error;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
@@ -11,7 +11,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
 
     let matches = App::new(crate_name!())
         .about(crate_description!())
-        .version(crate_version!())
+        .version(solana_clap_utils::version!())
         .arg(
             Arg::with_name("port")
                 .long("port")


### PR DESCRIPTION
A small clean-up following [this](https://github.com/solana-labs/solana/pull/6819):

> Future work: once #6812 lands, `solana_core::version!()` should be moved into `solana-claputil` and used in place of `clap::crate_version!()` for all CLI tools

Now:

```
ryoqun@ubuqun:~/work/solana/solana$ (export CHANNEL=on-$(whoami)-fork CI_COMMIT=$(git rev-parse HEAD) && touch keygen/src/keygen.rs && cargo run --release --bin solana-keygen -- --version)
   Compiling solana-keygen v0.21.0 (/home/ryoqun/work/solana/solana/keygen)
    Finished release [optimized] target(s) in 1.68s
     Running `target/release/solana-keygen --version`
solana-keygen 0.21.0 [channel=on-ryoqun-fork commit=a04335c1f7958eeb70d55343eb0fd63c054b039a]
```