### PR TITLE
Improve run.sh for better developer experience

### DIFF
--- a/ci/run-sanity.sh
+++ b/ci/run-sanity.sh
@@ -1,8 +1,7 @@
 #!/usr/bin/env bash
+set -e
 
 cd "$(dirname "$0")/.."
-
-set -ex
 
 rm -f config/run/init-completed
 

--- a/ci/run-sanity.sh
+++ b/ci/run-sanity.sh
@@ -7,6 +7,7 @@ rm -f config/run/init-completed
 timeout 15 ./run.sh &
 run=$!
 
+# shellcheck disable=SC2034
 for _i in $(seq 10)
 do
   if [ -e config/run/init-completed ]

--- a/ci/run-sanity.sh
+++ b/ci/run-sanity.sh
@@ -1,23 +1,23 @@
 #!/usr/bin/env bash
 
+cd "$(dirname "$0")/.."
+
 set -ex
 
 rm -f config/run/init-completed
 
 timeout 15 ./run.sh &
-run=$!
+pid=$!
 
-# shellcheck disable=SC2034
-for _i in $(seq 10)
-do
-  if [ -e config/run/init-completed ]
-  then
-    break
-  else
-    sleep 1
+attempts=10
+while [[ ! -f config/run/init-completed ]]; do
+  sleep 1
+  if ((--attempts == 0)); then
+     echo "Error: validator failed to boot"
+     exit 1
   fi
 done
 
-curl -X POST -H 'Content-Type: application/json' -d '{"jsonrpc":"2.0","id":1, "method":"validatorExit"}' http://localhost:8899 || true
+curl -X POST -H 'Content-Type: application/json' -d '{"jsonrpc":"2.0","id":1, "method":"validatorExit"}' http://localhost:8899
 
-wait $run
+wait $pid

--- a/ci/run-sanity.sh
+++ b/ci/run-sanity.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -ex
+
+rm -f config/run/init-completed
+
+timeout 15 ./run.sh &
+run=$!
+
+for _i in $(seq 10)
+do
+  if [ -e config/run/init-completed ]
+  then
+    break
+  else
+    sleep 1
+  fi
+done
+
+curl -X POST -H 'Content-Type: application/json' -d '{"jsonrpc":"2.0","id":1, "method":"validatorExit"}' http://localhost:8899 || true
+
+wait $run

--- a/ci/test-stable.sh
+++ b/ci/test-stable.sh
@@ -127,3 +127,10 @@ export CARGO_TOOLCHAIN=+"$rust_stable"
   set -x
   ci/localnet-sanity.sh -x
 )
+
+echo --- ci/run-sanity.sh
+export CARGO_TOOLCHAIN=+"$rust_stable"
+(
+  set -x
+  ci/run-sanity.sh -x
+)

--- a/ci/test-stable.sh
+++ b/ci/test-stable.sh
@@ -121,14 +121,11 @@ test-local-cluster)
   ;;
 esac
 
-echo --- ci/localnet-sanity.sh
 (
-  set -x
-  CARGO_TOOLCHAIN=+"$rust_stable" ci/localnet-sanity.sh -x
-)
+  export CARGO_TOOLCHAIN=+"$rust_stable"
+  echo --- ci/localnet-sanity.sh
+  ci/localnet-sanity.sh -x
 
-echo --- ci/run-sanity.sh
-(
-  set -x
-  CARGO_TOOLCHAIN=+"$rust_stable" ci/run-sanity.sh -x
+  echo --- ci/run-sanity.sh
+  ci/run-sanity.sh -x
 )

--- a/ci/test-stable.sh
+++ b/ci/test-stable.sh
@@ -122,15 +122,13 @@ test-local-cluster)
 esac
 
 echo --- ci/localnet-sanity.sh
-export CARGO_TOOLCHAIN=+"$rust_stable"
 (
   set -x
-  ci/localnet-sanity.sh -x
+  CARGO_TOOLCHAIN=+"$rust_stable" ci/localnet-sanity.sh -x
 )
 
 echo --- ci/run-sanity.sh
-export CARGO_TOOLCHAIN=+"$rust_stable"
 (
   set -x
-  ci/run-sanity.sh -x
+  CARGO_TOOLCHAIN=+"$rust_stable" ci/run-sanity.sh -x
 )

--- a/run.sh
+++ b/run.sh
@@ -82,6 +82,7 @@ tar jcfS "$ledgerDir/genesis.tar.bz2" -C "$ledgerDir" genesis.bin rocksdb
 abort() {
   set +e
   kill "$drone" "$validator"
+  wait $validator
 }
 trap abort INT TERM EXIT
 
@@ -98,6 +99,8 @@ args=(
   --rpc-drone-address 127.0.0.1:9900
   --accounts "$dataDir"/accounts
   --log -
+  --enable-rpc-exit
+  --init-complete-file "$dataDir"/init-completed
 )
 if [[ -n $blockstreamSocket ]]; then
   args+=(--blockstream "$blockstreamSocket")

--- a/run.sh
+++ b/run.sh
@@ -92,7 +92,7 @@ tar jcfS "$ledgerDir/genesis.tar.bz2" -C "$ledgerDir" genesis.bin rocksdb
 abort() {
   set +e
   kill "$drone" "$validator"
-  wait $validator
+  wait "$validator"
 }
 trap abort INT TERM EXIT
 

--- a/run.sh
+++ b/run.sh
@@ -72,6 +72,7 @@ solana-genesis \
   --bootstrap-storage-pubkey "$dataDir"/leader-storage-account-keypair.json \
   --ledger "$ledgerDir" \
   --operating-mode development
+tar jcfS "$ledgerDir/genesis.tar.bz2" -C "$ledgerDir" genesis.bin rocksdb
 
 abort() {
   set +e

--- a/run.sh
+++ b/run.sh
@@ -64,8 +64,18 @@ if [[ -e $leader_stake_account_keypair ]]; then
 else
   solana-keygen new -o "$leader_stake_account_keypair"
 fi
-solana-keygen new -f -o "$dataDir"/faucet-keypair.json
-solana-keygen new -f -o "$dataDir"/leader-storage-account-keypair.json
+faucet_keypair="$dataDir"/faucet-keypair.json
+if [[ -e $faucet_keypair ]]; then
+  echo "Use existing faucet keypair"
+else
+  solana-keygen new -f -o "$faucet_keypair"
+fi
+leader_storage_account_keypair="$dataDir"/leader-storage-account-keypair.json
+if [[ -e $leader_storage_account_keypair ]]; then
+  echo "Use existing leader storage account keypair"
+else
+  solana-keygen new -f -o "$leader_storage_account_keypair"
+fi
 
 solana-genesis \
   --hashes-per-tick sleep \

--- a/run.sh
+++ b/run.sh
@@ -9,7 +9,12 @@ set -e
 
 # Prefer possible `cargo build` binaries over PATH binaries
 cd "$(dirname "$0")/"
-PATH=$PWD/target/debug:$PATH
+
+profile=debug
+if [[ -n $NDEBUG ]]; then
+  profile=release
+fi
+PATH=$PWD/target/$profile:$PATH
 
 ok=true
 for program in solana-{drone,genesis,keygen,validator}; do


### PR DESCRIPTION
I think these are handy :)

- Honor `$NDEBUG` for the `release` profile.
- Create `genesis.tar.bz2` to make it easy to add ad-hoc normal validators to the cluster of `run.sh` (more right fix is coming with PR for #6953. 
- Enable CI for run.sh; Prevent like [this](https://github.com/solana-labs/solana/pull/6785)
- Avoid unnecessary re-generation of keys if exists, resulting normally-idempotent `solana-genesis` and transitively, `run.sh` too. (i.e. can simply re-run `run.sh`)