### PR TITLE
add credit-debit rent handling

### DIFF
--- a/core/src/rpc_pubsub.rs
+++ b/core/src/rpc_pubsub.rs
@@ -431,7 +431,7 @@ mod tests {
                    "lamports": 51,
                    "data": expected_data,
                    "executable": false,
-                   "rent_epoch": 0,
+                   "rent_epoch": 1,
                },
                "subscription": 0,
            }
@@ -576,7 +576,7 @@ mod tests {
                    "lamports": 100,
                    "data": [],
                    "executable": false,
-                   "rent_epoch": 0,
+                   "rent_epoch": 1,
                },
                "subscription": 0,
            }

--- a/core/src/rpc_subscriptions.rs
+++ b/core/src/rpc_subscriptions.rs
@@ -346,7 +346,7 @@ mod tests {
         subscriptions.check_account(&alice.pubkey(), 0, &bank_forks);
         let string = transport_receiver.poll();
         if let Async::Ready(Some(response)) = string.unwrap() {
-            let expected = format!(r#"{{"jsonrpc":"2.0","method":"accountNotification","params":{{"result":{{"data":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"executable":false,"lamports":1,"owner":[2,203,81,223,225,24,34,35,203,214,138,130,144,208,35,77,63,16,87,51,47,198,115,123,98,188,19,160,0,0,0,0],"rent_epoch":0}},"subscription":0}}}}"#);
+            let expected = format!(r#"{{"jsonrpc":"2.0","method":"accountNotification","params":{{"result":{{"data":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"executable":false,"lamports":1,"owner":[2,203,81,223,225,24,34,35,203,214,138,130,144,208,35,77,63,16,87,51,47,198,115,123,98,188,19,160,0,0,0,0],"rent_epoch":1}},"subscription":0}}}}"#);
             assert_eq!(expected, response);
         }
 
@@ -401,7 +401,7 @@ mod tests {
         subscriptions.check_program(&solana_budget_api::id(), 0, &bank_forks);
         let string = transport_receiver.poll();
         if let Async::Ready(Some(response)) = string.unwrap() {
-            let expected = format!(r#"{{"jsonrpc":"2.0","method":"programNotification","params":{{"result":["{:?}",{{"data":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"executable":false,"lamports":1,"owner":[2,203,81,223,225,24,34,35,203,214,138,130,144,208,35,77,63,16,87,51,47,198,115,123,98,188,19,160,0,0,0,0],"rent_epoch":0}}],"subscription":0}}}}"#, alice.pubkey());
+            let expected = format!(r#"{{"jsonrpc":"2.0","method":"programNotification","params":{{"result":["{:?}",{{"data":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"executable":false,"lamports":1,"owner":[2,203,81,223,225,24,34,35,203,214,138,130,144,208,35,77,63,16,87,51,47,198,115,123,98,188,19,160,0,0,0,0],"rent_epoch":1}}],"subscription":0}}}}"#, alice.pubkey());
             assert_eq!(expected, response);
         }
 

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -46,10 +46,10 @@ pub struct Accounts {
 
 // for the load instructions
 pub type TransactionAccounts = Vec<Account>;
-pub type TransactionRents = Vec<u64>;
+pub type TransactionRent = u64;
 pub type TransactionLoaders = Vec<Vec<(Pubkey, Account)>>;
 
-pub type TransactionLoadResult = (TransactionAccounts, TransactionLoaders, TransactionRents);
+pub type TransactionLoadResult = (TransactionAccounts, TransactionLoaders, TransactionRent);
 
 impl Accounts {
     pub fn new(paths: Option<String>) -> Self {
@@ -92,7 +92,7 @@ impl Accounts {
         fee: u64,
         error_counters: &mut ErrorCounters,
         rent_collector: &RentCollector,
-    ) -> Result<(TransactionAccounts, TransactionRents)> {
+    ) -> Result<(TransactionAccounts, TransactionRent)> {
         // Copy all the accounts
         let message = tx.message();
         if tx.signatures.is_empty() && fee != 0 {
@@ -107,21 +107,27 @@ impl Accounts {
             // There is no way to predict what program will execute without an error
             // If a fee can pay for execution then the program will be scheduled
             let mut accounts: TransactionAccounts = Vec::with_capacity(message.account_keys.len());
-            let mut rents: TransactionRents = Vec::with_capacity(message.account_keys.len());
-            for key in message
+            let mut tx_rent: TransactionRent = 0;
+            for (i, key) in message
                 .account_keys
                 .iter()
-                .filter(|key| !message.program_ids().contains(key))
+                .enumerate()
+                .filter(|(_, key)| !message.program_ids().contains(key))
             {
                 let (account, rent) = AccountsDB::load(storage, ancestors, accounts_index, key)
                     .and_then(|(mut account, _)| {
-                        let rent_due = rent_collector.update(&mut account);
-                        Some((account, rent_due))
+                        let rent_due: u64;
+                        if message.is_writable(i) {
+                            rent_due = rent_collector.update(&mut account);
+                            Some((account, rent_due))
+                        } else {
+                            Some((account, 0))
+                        }
                     })
                     .unwrap_or_default();
 
                 accounts.push(account);
-                rents.push(rent);
+                tx_rent += rent;
             }
 
             if accounts.is_empty() || accounts[0].lamports == 0 {
@@ -135,7 +141,7 @@ impl Accounts {
                 Err(TransactionError::InsufficientFundsForFee)
             } else {
                 accounts[0].lamports -= fee;
-                Ok((accounts, rents))
+                Ok((accounts, tx_rent))
             }
         }
     }
@@ -551,16 +557,16 @@ impl Accounts {
 
             let message = &tx.message();
             let acc = raccs.as_mut().unwrap();
-            for ((i, key), (account, rent)) in message
+            for ((i, key), account) in message
                 .account_keys
                 .iter()
                 .enumerate()
-                .zip(acc.0.iter_mut().zip(acc.2.iter_mut()))
+                .zip(acc.0.iter_mut())
             {
                 if message.is_writable(i) {
                     if account.rent_epoch == 0 {
                         account.rent_epoch = rent_collector.epoch;
-                        *rent += rent_collector.update(account);
+                        acc.2 += rent_collector.update(account);
                     }
                     accounts.push((key, &*account));
                 }
@@ -1371,20 +1377,20 @@ mod tests {
 
         let transaction_accounts0 = vec![account0, account2.clone()];
         let transaction_loaders0 = vec![];
-        let transaction_rents0 = vec![0, 0];
+        let transaction_rent0 = 0;
         let loaded0 = Ok((
             transaction_accounts0,
             transaction_loaders0,
-            transaction_rents0,
+            transaction_rent0,
         ));
 
         let transaction_accounts1 = vec![account1, account2.clone()];
         let transaction_loaders1 = vec![];
-        let transaction_rents1 = vec![0, 0];
+        let transaction_rent1 = 0;
         let loaded1 = Ok((
             transaction_accounts1,
             transaction_loaders1,
-            transaction_rents1,
+            transaction_rent1,
         ));
 
         let mut loaded = vec![loaded0, loaded1];

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1323,6 +1323,8 @@ impl Bank {
 
     pub fn deposit(&self, pubkey: &Pubkey, lamports: u64) {
         let mut account = self.get_account(pubkey).unwrap_or_default();
+        self.collected_rent
+            .fetch_add(self.rent_collector.update(&mut account), Ordering::Relaxed);
         account.lamports += lamports;
         self.store_account(pubkey, &account);
     }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1816,10 +1816,10 @@ mod tests {
         assert_eq!(bank.last_blockhash(), genesis_block.hash());
 
         // Initialize credit-debit and credit only accounts
-        let account1 = Account::new(260, 1, &Pubkey::default());
-        let account2 = Account::new(260, 1, &Pubkey::default());
-        let account3 = Account::new(260, 1, &Pubkey::default());
-        let account4 = Account::new(260, 1, &Pubkey::default());
+        let account1 = Account::new(264, 1, &Pubkey::default());
+        let account2 = Account::new(264, 1, &Pubkey::default());
+        let account3 = Account::new(264, 1, &Pubkey::default());
+        let account4 = Account::new(264, 1, &Pubkey::default());
         let account5 = Account::new(10, 1, &Pubkey::default());
         let account6 = Account::new(10, 1, &Pubkey::default());
 
@@ -1933,19 +1933,19 @@ mod tests {
         let mut account_pairs: Vec<(Pubkey, Account)> = Vec::with_capacity(keypairs.len() - 1);
         account_pairs.push((
             keypairs[0].pubkey(),
-            Account::new(50270, 1, &Pubkey::default()),
+            Account::new(51224, 1, &Pubkey::default()),
         ));
         account_pairs.push((
             keypairs[1].pubkey(),
-            Account::new(50270, 1, &Pubkey::default()),
+            Account::new(51224, 1, &Pubkey::default()),
         ));
         account_pairs.push((
             keypairs[2].pubkey(),
-            Account::new(50270, 1, &Pubkey::default()),
+            Account::new(51224, 1, &Pubkey::default()),
         ));
         account_pairs.push((
             keypairs[3].pubkey(),
-            Account::new(50270, 1, &Pubkey::default()),
+            Account::new(51224, 1, &Pubkey::default()),
         ));
         account_pairs.push((
             keypairs[4].pubkey(),
@@ -1957,12 +1957,12 @@ mod tests {
         ));
         account_pairs.push((
             keypairs[6].pubkey(),
-            Account::new(100_560, 1, &Pubkey::default()),
+            Account::new(102_468, 1, &Pubkey::default()),
         ));
 
         account_pairs.push((
             keypairs[8].pubkey(),
-            Account::new(50284, 1, &Pubkey::default()),
+            Account::new(52153, 1, &Pubkey::default()),
         ));
         account_pairs.push((
             keypairs[9].pubkey(),
@@ -1972,15 +1972,15 @@ mod tests {
         // Feeding to MockProgram to test read only rent behaviour
         account_pairs.push((
             keypairs[10].pubkey(),
-            Account::new(50271, 1, &Pubkey::default()),
+            Account::new(51225, 1, &Pubkey::default()),
         ));
         account_pairs.push((
             keypairs[11].pubkey(),
-            Account::new(50271, 1, &mock_program_id),
+            Account::new(51225, 1, &mock_program_id),
         ));
         account_pairs.push((
             keypairs[12].pubkey(),
-            Account::new(50271, 1, &mock_program_id),
+            Account::new(51225, 1, &mock_program_id),
         ));
         account_pairs.push((
             keypairs[13].pubkey(),
@@ -2063,13 +2063,13 @@ mod tests {
         let t4 = system_transaction::transfer(
             &keypairs[6],
             &keypairs[7].pubkey(),
-            50269,
+            51223,
             genesis_block.hash(),
         );
         let t5 = system_transaction::transfer(
             &keypairs[8],
             &keypairs[9].pubkey(),
-            14,
+            929,
             genesis_block.hash(),
         );
 
@@ -2103,64 +2103,64 @@ mod tests {
 
         let mut rent_collected = 0;
 
-        // 50270 - 50268(Rent) - 1(transfer)
+        // 51224 - 51222(Rent) - 1(transfer)
         assert_eq!(bank.get_balance(&keypairs[0].pubkey()), 1);
-        rent_collected += 50268;
+        rent_collected += 51222;
 
-        // 50270 - 50268(Rent) + 1(transfer)
+        // 51224 - 51222(Rent) - 1(transfer)
         assert_eq!(bank.get_balance(&keypairs[1].pubkey()), 3);
-        rent_collected += 50268;
+        rent_collected += 51222;
 
-        // 50270 - 50268(Rent) - 1(transfer)
+        // 51224 - 51222(Rent) - 1(transfer)
         assert_eq!(bank.get_balance(&keypairs[2].pubkey()), 1);
-        rent_collected += 50268;
+        rent_collected += 51222;
 
-        // 50270 - 50268(Rent) + 1(transfer)
+        // 51224 - 51222(Rent) - 1(transfer)
         assert_eq!(bank.get_balance(&keypairs[3].pubkey()), 3);
-        rent_collected += 50268;
+        rent_collected += 51222;
 
         // No rent deducted
         assert_eq!(bank.get_balance(&keypairs[4].pubkey()), 10);
         assert_eq!(bank.get_balance(&keypairs[5].pubkey()), 10);
 
-        // 100_560 - 50268(Rent) - 50269(transfer)
+        // 102_468 - 51222(Rent) - 51223(transfer)
         assert_eq!(bank.get_balance(&keypairs[6].pubkey()), 23);
-        rent_collected += 50268;
+        rent_collected += 51222;
 
-        // 0 + 50269(transfer) - 2(Rent)
-        assert_eq!(bank.get_balance(&keypairs[7].pubkey()), 50267);
+        // 0 + 51223(transfer) - 917(Rent)
+        assert_eq!(bank.get_balance(&keypairs[7].pubkey()), 50306);
         // Epoch should be updated
         // Rent deducted on store side
         let account8 = bank.get_account(&keypairs[7].pubkey()).unwrap();
         // Epoch should be set correctly.
         assert_eq!(account8.rent_epoch, bank.epoch + 1);
-        rent_collected += 2;
+        rent_collected += 917;
 
-        // 50284 - 50268(Rent) - 14(Transfer)
+        // 52153 - 51222(Rent) - 929(Transfer)
         assert_eq!(bank.get_balance(&keypairs[8].pubkey()), 2);
-        rent_collected += 50268;
+        rent_collected += 51222;
 
         let account10 = bank.get_account(&keypairs[9].pubkey()).unwrap();
         // Account was overwritten at load time, since it didn't have sufficient balance to pay rent
-        // Then, at store time we deducted 2 rent for the current epoch, once it has balance
+        // Then, at store time we deducted 917 rent for the current epoch, once it has balance
         assert_eq!(account10.rent_epoch, bank.epoch + 1);
         // account data is blank now
         assert_eq!(account10.data.len(), 0);
-        // 10 - 10(Rent) + 14(Transfer) - 2(Rent)
+        // 10 - 10(Rent) + 929(Transfer) - 917(Rent)
         assert_eq!(account10.lamports, 12);
-        rent_collected += 12;
+        rent_collected += 927;
 
-        // 50271 - 50268(Rent)
+        // 51225 - 51222(Rent)
         assert_eq!(bank.get_balance(&keypairs[10].pubkey()), 3);
-        rent_collected += 50268;
+        rent_collected += 51222;
 
-        // 50271 - 50268(Rent) + 1(Addition by program)
+        // 51225 - 51222(Rent) + 1(Addition by program)
         assert_eq!(bank.get_balance(&keypairs[11].pubkey()), 4);
-        rent_collected += 50268;
+        rent_collected += 51222;
 
-        // 50271 - 50268(Rent) - 1(Deduction by program)
+        // 51225 - 51222(Rent) - 1(Deduction by program)
         assert_eq!(bank.get_balance(&keypairs[12].pubkey()), 2);
-        rent_collected += 50268;
+        rent_collected += 51222;
 
         // No rent for read-only account
         assert_eq!(bank.get_balance(&keypairs[13].pubkey()), 14);

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2019,6 +2019,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::cognitive_complexity)]
     fn test_rent() {
         let mock_program_id = Pubkey::new(&[2u8; 32]);
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1901,6 +1901,69 @@ mod tests {
         }
     }
 
+    fn store_accounts(bank: &Bank, keypairs: &mut Vec<Keypair>, mock_program_id: Pubkey) {
+        let mut stored_account: Vec<(Pubkey, Account)> = Vec::with_capacity(keypairs.len() - 1);
+        stored_account.push((
+            keypairs[0].pubkey(),
+            Account::new(50270, 1, &Pubkey::default()),
+        ));
+        stored_account.push((
+            keypairs[1].pubkey(),
+            Account::new(50270, 1, &Pubkey::default()),
+        ));
+        stored_account.push((
+            keypairs[2].pubkey(),
+            Account::new(50270, 1, &Pubkey::default()),
+        ));
+        stored_account.push((
+            keypairs[3].pubkey(),
+            Account::new(50270, 1, &Pubkey::default()),
+        ));
+        stored_account.push((
+            keypairs[4].pubkey(),
+            Account::new(10, 1, &Pubkey::default()),
+        ));
+        stored_account.push((
+            keypairs[5].pubkey(),
+            Account::new(10, 1, &Pubkey::default()),
+        ));
+        stored_account.push((
+            keypairs[6].pubkey(),
+            Account::new(100_560, 1, &Pubkey::default()),
+        ));
+
+        stored_account.push((
+            keypairs[8].pubkey(),
+            Account::new(50284, 1, &Pubkey::default()),
+        ));
+        stored_account.push((
+            keypairs[9].pubkey(),
+            Account::new(10, 1, &Pubkey::default()),
+        ));
+
+        // Feeding to MockProgram to test read only rent behaviour
+        stored_account.push((
+            keypairs[10].pubkey(),
+            Account::new(50271, 1, &Pubkey::default()),
+        ));
+        stored_account.push((
+            keypairs[11].pubkey(),
+            Account::new(50271, 1, &mock_program_id),
+        ));
+        stored_account.push((
+            keypairs[12].pubkey(),
+            Account::new(50271, 1, &mock_program_id),
+        ));
+        stored_account.push((
+            keypairs[13].pubkey(),
+            Account::new(14, 23, &mock_program_id),
+        ));
+
+        for i in 0..13 {
+            bank.store_account(&stored_account[i].0, &stored_account[i].1);
+        }
+    }
+
     #[test]
     fn test_credit_debit_rent() {
         let mock_program_id = Pubkey::new(&[2u8; 32]);
@@ -1932,67 +1995,7 @@ mod tests {
 
         assert_eq!(bank.last_blockhash(), genesis_block.hash());
 
-        let mut accounts: Vec<(Pubkey, Account)> = Vec::with_capacity(13);
-        // Initialize credit-debit and credit only accounts
-        accounts.push((
-            keypairs[0].pubkey(),
-            Account::new(50270, 1, &Pubkey::default()),
-        ));
-        accounts.push((
-            keypairs[1].pubkey(),
-            Account::new(50270, 1, &Pubkey::default()),
-        ));
-        accounts.push((
-            keypairs[2].pubkey(),
-            Account::new(50270, 1, &Pubkey::default()),
-        ));
-        accounts.push((
-            keypairs[3].pubkey(),
-            Account::new(50270, 1, &Pubkey::default()),
-        ));
-        accounts.push((
-            keypairs[4].pubkey(),
-            Account::new(10, 1, &Pubkey::default()),
-        ));
-        accounts.push((
-            keypairs[5].pubkey(),
-            Account::new(10, 1, &Pubkey::default()),
-        ));
-        accounts.push((
-            keypairs[6].pubkey(),
-            Account::new(100_560, 1, &Pubkey::default()),
-        ));
-
-        accounts.push((
-            keypairs[8].pubkey(),
-            Account::new(50284, 1, &Pubkey::default()),
-        ));
-        accounts.push((
-            keypairs[9].pubkey(),
-            Account::new(10, 1, &Pubkey::default()),
-        ));
-
-        // Feeding to MockProgram to test read only rent behaviour
-        accounts.push((
-            keypairs[10].pubkey(),
-            Account::new(50271, 1, &Pubkey::default()),
-        ));
-        accounts.push((
-            keypairs[11].pubkey(),
-            Account::new(50271, 1, &mock_program_id),
-        ));
-        accounts.push((
-            keypairs[12].pubkey(),
-            Account::new(50271, 1, &mock_program_id),
-        ));
-        accounts.push((
-            keypairs[13].pubkey(),
-            Account::new(14, 23, &mock_program_id),
-        ));
-
-        for i in 0..13 {
-            bank.store_account(&accounts[i].0, &accounts[i].1);
-        }
+        store_accounts(&bank, &mut keypairs, mock_program_id);
 
         // Make native instruction loader rent exempt
         let system_program_id = solana_system_program().1;


### PR DESCRIPTION
#### Problem
1. We are collecting rent at load time, but we aren't doing anything with it.
2. We are not setting correct rent epoch, when a `create_account` or `transfer` instruction has created a new account with some lamports in it, which results in those account paying rent for epoch 0..=current_epoch, which is incorrect.

#### Summary of Changes
1. We are now collecting rent at load and store both, which is then synced to `collected_rent` atomic variable in bank.
2. We are setting correct `rent_epoch` for accounts, created/overwritten during tx execution. 

#### Remaining
- [x] tests

Fixes #
