### PR TITLE
Tighten up AWS testcase definition

### DIFF
--- a/system-test/testnet-performance/aws-cpu-only-perf-10-node.yml
+++ b/system-test/testnet-performance/aws-cpu-only-perf-10-node.yml
@@ -6,13 +6,13 @@ steps:
       CLOUD_PROVIDER: "ec2"
       TESTNET_TAG: "aws-perf-cpu-only"
       RAMP_UP_TIME: 0
-      TEST_DURATION_SECONDS: 300
+      TEST_DURATION_SECONDS: 600
       NUMBER_OF_VALIDATOR_NODES: 10
       ENABLE_GPU: "false"
       # Up to 3.1 GHz Intel Xeon® Platinum 8175, 16 vCPU, 64GB RAM
       VALIDATOR_NODE_MACHINE_TYPE: "m5.4xlarge"
-      NUMBER_OF_CLIENT_NODES: 2
-      CLIENT_OPTIONS: "bench-tps=2=--tx_count 15000 --thread-batch-sleep-ms 250"
+      NUMBER_OF_CLIENT_NODES: 1
+      CLIENT_OPTIONS: "bench-tps=1=--tx_count 80000 --thread-batch-sleep-ms 1000"
       TESTNET_ZONES: "us-west-1a,us-west-1c,us-east-1a,eu-west-1a"
       USE_PUBLIC_IP_ADDRESSES: "true"
       ADDITIONAL_FLAGS: ""

--- a/system-test/testnet-performance/aws-cpu-only-perf-5-node.yml
+++ b/system-test/testnet-performance/aws-cpu-only-perf-5-node.yml
@@ -6,7 +6,7 @@ steps:
       CLOUD_PROVIDER: "ec2"
       TESTNET_TAG: "aws-perf-cpu-only"
       RAMP_UP_TIME: 0
-      TEST_DURATION_SECONDS: 300
+      TEST_DURATION_SECONDS: 600
       NUMBER_OF_VALIDATOR_NODES: 5
       ENABLE_GPU: "false"
       # Up to 3.1 GHz Intel Xeon® Platinum 8175, 16 vCPU, 64GB RAM


### PR DESCRIPTION
#### Problem

AWS testnet tests were not apples to apples with our GCE/colo benchmark

#### Summary of Changes

Set test configurations such that these cases should give comparable environments and, ideally, comparable results.