### PR TITLE
Correct influxDB database names for automated testcases

### DIFF
--- a/system-test/testnet-performance/colo-cpu-only-perf.yml
+++ b/system-test/testnet-performance/colo-cpu-only-perf.yml
@@ -4,7 +4,7 @@ steps:
     env:
       UPLOAD_RESULTS_TO_SLACK: "true"
       CLOUD_PROVIDER: "colo"
-      TESTNET_TAG: "colo-edge-perf-cpu-only"
+      TESTNET_TAG: "colo-perf-cpu-only"
       ENABLE_GPU: "false"
       RAMP_UP_TIME: 0
       TEST_DURATION_SECONDS: 600

--- a/system-test/testnet-performance/colo-gpu-perf.yml
+++ b/system-test/testnet-performance/colo-gpu-perf.yml
@@ -4,7 +4,7 @@ steps:
     env:
       UPLOAD_RESULTS_TO_SLACK: "true"
       CLOUD_PROVIDER: "colo"
-      TESTNET_TAG: "colo-edge-perf-gpu-enabled"
+      TESTNET_TAG: "colo-perf-gpu-enabled"
       ENABLE_GPU: "true"
       RAMP_UP_TIME: 0
       TEST_DURATION_SECONDS: 600

--- a/system-test/testnet-performance/gce-cpu-only-perf-10-node.yml
+++ b/system-test/testnet-performance/gce-cpu-only-perf-10-node.yml
@@ -4,9 +4,9 @@ steps:
     env:
       UPLOAD_RESULTS_TO_SLACK: "true"
       CLOUD_PROVIDER: "gce"
-      TESTNET_TAG: "gce-edge-perf-cpu-only"
-      RAMP_UP_TIME: 60
-      TEST_DURATION_SECONDS: 300
+      TESTNET_TAG: "gce-perf-cpu-only"
+      RAMP_UP_TIME: 0
+      TEST_DURATION_SECONDS: 600
       NUMBER_OF_VALIDATOR_NODES: 10
       ENABLE_GPU: "false"
       VALIDATOR_NODE_MACHINE_TYPE: "--machine-type n1-standard-16"

--- a/system-test/testnet-performance/gce-cpu-only-perf-5-node.yml
+++ b/system-test/testnet-performance/gce-cpu-only-perf-5-node.yml
@@ -4,7 +4,7 @@ steps:
     env:
       UPLOAD_RESULTS_TO_SLACK: "true"
       CLOUD_PROVIDER: "gce"
-      TESTNET_TAG: "gce-edge-perf-cpu-only"
+      TESTNET_TAG: "gce-perf-cpu-only"
       RAMP_UP_TIME: 0
       TEST_DURATION_SECONDS: 600
       NUMBER_OF_VALIDATOR_NODES: 5

--- a/system-test/testnet-performance/gce-gpu-perf-10-node.yml
+++ b/system-test/testnet-performance/gce-gpu-perf-10-node.yml
@@ -4,7 +4,7 @@ steps:
     env:
       UPLOAD_RESULTS_TO_SLACK: "true"
       CLOUD_PROVIDER: "gce"
-      TESTNET_TAG: "gce-edge-perf-gpu-enabled"
+      TESTNET_TAG: "gce-perf-gpu-enabled"
       RAMP_UP_TIME: 0
       TEST_DURATION_SECONDS: 600
       NUMBER_OF_VALIDATOR_NODES: 10

--- a/system-test/testnet-performance/gce-gpu-perf-100-node.yml
+++ b/system-test/testnet-performance/gce-gpu-perf-100-node.yml
@@ -4,7 +4,7 @@ steps:
     env:
       UPLOAD_RESULTS_TO_SLACK: "true"
       CLOUD_PROVIDER: "gce"
-      TESTNET_TAG: "gce-edge-perf-gpu-enabled"
+      TESTNET_TAG: "gce-perf-gpu-enabled"
       RAMP_UP_TIME: 0
       TEST_DURATION_SECONDS: 600
       NUMBER_OF_VALIDATOR_NODES: 100

--- a/system-test/testnet-performance/gce-gpu-perf-25-node.yml
+++ b/system-test/testnet-performance/gce-gpu-perf-25-node.yml
@@ -4,7 +4,7 @@ steps:
     env:
       UPLOAD_RESULTS_TO_SLACK: "true"
       CLOUD_PROVIDER: "gce"
-      TESTNET_TAG: "gce-edge-perf-gpu-enabled"
+      TESTNET_TAG: "gce-perf-gpu-enabled"
       RAMP_UP_TIME: 0
       TEST_DURATION_SECONDS: 600
       NUMBER_OF_VALIDATOR_NODES: 25

--- a/system-test/testnet-performance/gce-gpu-perf-5-node.yml
+++ b/system-test/testnet-performance/gce-gpu-perf-5-node.yml
@@ -4,7 +4,7 @@ steps:
     env:
       UPLOAD_RESULTS_TO_SLACK: "true"
       CLOUD_PROVIDER: "gce"
-      TESTNET_TAG: "gce-edge-perf-gpu-enabled"
+      TESTNET_TAG: "gce-perf-gpu-enabled"
       RAMP_UP_TIME: 0
       TEST_DURATION_SECONDS: 600
       NUMBER_OF_VALIDATOR_NODES: 5

--- a/system-test/testnet-performance/gce-gpu-perf-50-node.yml
+++ b/system-test/testnet-performance/gce-gpu-perf-50-node.yml
@@ -4,7 +4,7 @@ steps:
     env:
       UPLOAD_RESULTS_TO_SLACK: "true"
       CLOUD_PROVIDER: "gce"
-      TESTNET_TAG: "gce-edge-perf-gpu-enabled"
+      TESTNET_TAG: "gce-perf-gpu-enabled"
       RAMP_UP_TIME: 0
       TEST_DURATION_SECONDS: 600
       NUMBER_OF_VALIDATOR_NODES: 50


### PR DESCRIPTION
#### Problem
Testcases were initially written to run a specific branch, this is no longer the case.  Tests were pointing at branch-specific DB names.

#### Summary of Changes
Remove the `edge`/`beta` portions of the DB names.
