### PR TITLE
Stop running local-test and stable testsuites when only the book is modified

### DIFF
--- a/ci/affects-files.sh
+++ b/ci/affects-files.sh
@@ -8,6 +8,8 @@
 #     ./affects-files.sh .rs     -- also matches foo.rs.bar
 #     ./affects-files.sh ^snap/  -- anything under the snap/ subdirectory
 #     ./affects-files.sh snap/   -- also matches foo/snap/
+# Any pattern starting with the ! character will be negated:
+#     ./affects-files.sh !^book/  -- anything *not* under the book/ subdirectory
 #
 set -e
 cd "$(dirname "$0")"/..
@@ -18,11 +20,19 @@ if [[ -n $CI_PULL_REQUEST ]]; then
 
   IFS=':' read -ra files <<< "$affectedFiles"
   for pattern in "$@"; do
-    for file in "${files[@]}"; do
-      if [[ $file =~ $pattern ]]; then
-        exit 0
-      fi
-    done
+    if [[ ${pattern:0:1} = "!" ]]; then
+      for file in "${files[@]}"; do
+        if [[ ! $file =~ ${pattern:1} ]]; then
+          exit 0
+        fi
+      done
+    else
+      for file in "${files[@]}"; do
+        if [[ $file =~ $pattern ]]; then
+          exit 0
+        fi
+      done
+    fi
   done
 
   exit 1

--- a/ci/test-stable.sh
+++ b/ci/test-stable.sh
@@ -10,6 +10,18 @@ annotate() {
   }
 }
 
+# Run the appropriate test based on entrypoint
+testName=$(basename "$0" .sh)
+
+# Skip if only the book has been modified
+ci/affects-files.sh \
+  \!^book/ \
+|| {
+  annotate --style info \
+    "Skipped $testName as only book files were modified"
+  exit 0
+}
+
 source ci/rust-version.sh stable
 
 export RUST_BACKTRACE=1
@@ -26,8 +38,6 @@ test -d target/release/bpf && find target/release/bpf -name '*.d' -delete
 # Clear the BPF sysroot files, they are not automatically rebuilt
 rm -rf target/xargo # Issue #3105
 
-# Run the appropriate test based on entrypoint
-testName=$(basename "$0" .sh)
 echo "Executing $testName"
 case $testName in
 test-stable)


### PR DESCRIPTION
#### Problem

The `local-test` and `stable` testsuites get run even if only the book has changed.

#### Summary of Changes

Add the `ci/affects-files.sh` check to all runs of `ci/test-stable.sh`, enabled by modifying `ci/affects-files.sh` to allow negated patterns