### PR TITLE
Add Blocktree api to get transactions by slot

### DIFF
--- a/ledger/src/blocktree.rs
+++ b/ledger/src/blocktree.rs
@@ -25,6 +25,7 @@ use solana_sdk::genesis_config::GenesisConfig;
 use solana_sdk::hash::Hash;
 use solana_sdk::signature::{Keypair, KeypairUtil};
 use solana_sdk::timing::timestamp;
+use solana_sdk::transaction::Transaction;
 use std::cell::RefCell;
 use std::cmp;
 use std::collections::HashMap;
@@ -1101,6 +1102,16 @@ impl Blocktree {
             )
         } else {
             vec![]
+        }
+    }
+
+    pub fn get_confirmed_block_transactions(&self, slot: Slot) -> Result<Vec<Transaction>> {
+        if self.is_root(slot) {
+            Ok(self.get_slot_entries(slot, 0, None)?.iter().cloned().flat_map(|entry| {
+                entry.transactions
+            }).collect())
+        } else {
+            Err(BlocktreeError::SlotNotRooted)
         }
     }
 


### PR DESCRIPTION
#### Problem
Our main downstream use case only needs to introspect confirmed blocks, with an empty result from unconfirmed ones. Currently, blocktree offers no api to return transactions in a slot.

#### Summary of Changes
- Adds blocktree api `get_confirmed_block_transactions`. Method checks whether block is confirmed (slot `is_root()`) first; if so, it flattens the slot entries vec into a vec of transactions to return.
It may make more sense to return an Iterator from this method in order to map each Transaction to its Result, once that data is available in blocktree. Will reassess when those apis are implemented.
- Updates `getConfirmedBlock` rpc to use now blocktree api. If `get_confirmed_block_transactions` returns an error, rpc method returns an empty result. `JsonRpcRequestProcessor::get_confirmed_block()` generates mock transactions statuses, since persistent status cache is not yet implemented (CC: #6958 )

Toward #6867 
FYI: @sunnygleason 
