### PR TITLE
solana-gossip: Display 'none' instead of 0.0.0.0

### DIFF
--- a/core/src/cluster_info.rs
+++ b/core/src/cluster_info.rs
@@ -273,7 +273,11 @@ impl ClusterInfo {
                 let ip_addr = node.gossip.ip();
                 format!(
                     "{:15} {:2}| {:5} | {:44} | {:5}| {:5}| {:5} | {:5}| {:5} | {:5}| {:5} | {:5}| {:5}\n",
-                    ip_addr.to_string(),
+                    if ContactInfo::is_valid_address(&node.gossip) {
+                        ip_addr.to_string()
+                    } else {
+                        "none".to_string()
+                    },
                     if node.id == my_pubkey { "me" } else { "" }.to_string(),
                     now.saturating_sub(last_updated),
                     node.id.to_string(),


### PR DESCRIPTION
When the output from `solana-gossip spy` was improved recently, invalid node IP addresses started showing as 0.0.0.0 instead of the more friendly "none" (like v0.20 does).  This threw me off for a moment and made me think we had a new gossip bug 😱 