### PR TITLE
Create development vs production environment hooks into net scripts

### DIFF
--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -110,7 +110,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
         &timing::duration_as_ms(&PohConfig::default().target_tick_duration).to_string();
     let default_ticks_per_slot = &clock::DEFAULT_TICKS_PER_SLOT.to_string();
     let default_slots_per_epoch = &EpochSchedule::default().slots_per_epoch.to_string();
-    let default_operating_mode = "production";
+    let default_operating_mode = "softlaunch";
 
     let matches = App::new(crate_name!())
         .about(crate_description!())
@@ -298,12 +298,13 @@ fn main() -> Result<(), Box<dyn error::Error>> {
         .arg(
             Arg::with_name("operating_mode")
                 .long("operating-mode")
-                .value_name("\"development\"|\"production\"")
+                .possible_value("development")
+                .possible_value("softlaunch")
                 .takes_value(true)
                 .default_value(default_operating_mode)
                 .help(
-                    "Configure the cluster for DEVELOPMENT mode where all features are available at epoch 0, \
-                    or PRODUCTION mode where some features are disabled at epoch 0"
+                    "Configure the cluster for \"development\" mode where all features are available at epoch 0, \
+                    or \"softlaunch\" mode where some features are disabled at epoch 0"
                 ),
         )
         .get_matches();

--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -110,6 +110,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
         &timing::duration_as_ms(&PohConfig::default().target_tick_duration).to_string();
     let default_ticks_per_slot = &clock::DEFAULT_TICKS_PER_SLOT.to_string();
     let default_slots_per_epoch = &EpochSchedule::default().slots_per_epoch.to_string();
+    let default_operating_mode = "production";
 
     let matches = App::new(crate_name!())
         .about(crate_description!())
@@ -295,9 +296,15 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                 .help("The location of pubkey for primordial accounts and balance"),
         )
         .arg(
-            Arg::with_name("development")
-                .long("dev")
-                .help("Configure the cluster for development mode where all features are available at epoch 0"),
+            Arg::with_name("operating_mode")
+                .long("operating-mode")
+                .value_name("\"development\"|\"production\"")
+                .takes_value(true)
+                .default_value(default_operating_mode)
+                .help(
+                    "Configure the cluster for DEVELOPMENT mode where all features are available at epoch 0, \
+                    or PRODUCTION mode where some features are disabled at epoch 0"
+                ),
         )
         .get_matches();
 
@@ -380,7 +387,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
         }
     }
 
-    let operating_mode = if matches.is_present("development") {
+    let operating_mode = if matches.value_of("operating_mode").unwrap() == "development" {
         OperatingMode::Development
     } else {
         OperatingMode::SoftLaunch

--- a/multinode-demo/setup.sh
+++ b/multinode-demo/setup.sh
@@ -34,7 +34,6 @@ default_arg --bootstrap-storage-pubkey "$SOLANA_CONFIG_DIR"/bootstrap-leader/sto
 default_arg --ledger "$SOLANA_CONFIG_DIR"/bootstrap-leader
 default_arg --mint "$SOLANA_CONFIG_DIR"/mint-keypair.json
 default_arg --hashes-per-tick auto
-default_arg --dev
 $solana_genesis "${args[@]}"
 
 (

--- a/multinode-demo/setup.sh
+++ b/multinode-demo/setup.sh
@@ -34,6 +34,7 @@ default_arg --bootstrap-storage-pubkey "$SOLANA_CONFIG_DIR"/bootstrap-leader/sto
 default_arg --ledger "$SOLANA_CONFIG_DIR"/bootstrap-leader
 default_arg --mint "$SOLANA_CONFIG_DIR"/mint-keypair.json
 default_arg --hashes-per-tick auto
+default_arg --operating-mode development
 $solana_genesis "${args[@]}"
 
 (

--- a/net/net.sh
+++ b/net/net.sh
@@ -88,9 +88,9 @@ Operate a configured testnet
 
    --use-move                         - Build the move-loader-program and add it to the cluster
 
-   --operating-mode development|production
-                                      - Specify whether or not to launch the cluster in development mode with all features enabled at epoch 0,
-                                        or production mode with some features disabled at epoch 0 (default: development)
+   --operating-mode development|softlaunch
+                                      - Specify whether or not to launch the cluster in "development" mode with all features enabled at epoch 0,
+                                        or "softlaunch" mode with some features disabled at epoch 0 (default: development)
 
  sanity/start-specific options:
    -F                   - Discard validator nodes that didn't bootup successfully
@@ -173,7 +173,7 @@ while [[ -n $1 ]]; do
       shift 2
     elif [[ $1 = --operating-mode ]]; then
       case "$2" in
-        development|production)
+        development|softlaunch)
           ;;
         *)
           echo "Unexpected operating mode: \"$2\""

--- a/net/net.sh
+++ b/net/net.sh
@@ -88,6 +88,8 @@ Operate a configured testnet
 
    --use-move                         - Build the move-loader-program and add it to the cluster
 
+   --restricted-environment           - Configure genesis block and cluster only to enable certain features for production launch
+
  sanity/start-specific options:
    -F                   - Discard validator nodes that didn't bootup successfully
    -o noInstallCheck    - Skip solana-install sanity
@@ -147,6 +149,7 @@ gpuMode=auto
 maybeUseMove=""
 netemPartition=""
 netemConfig=""
+maybeRestrictedEnvironment=""
 
 command=$1
 [[ -n $command ]] || usage
@@ -227,6 +230,9 @@ while [[ -n $1 ]]; do
           ;;
       esac
       shift 2
+    elif [[ $1 = --restricted-environment ]]; then
+      maybeRestrictedEnvironment="$1"
+      shift 1
     else
       usage "Unknown long option: $1"
     fi
@@ -489,6 +495,7 @@ startBootstrapLeader() {
          \"$maybeNoSnapshot $maybeSkipLedgerVerify $maybeLimitLedgerSize\" \
          \"$gpuMode\" \
          \"$GEOLOCATION_API_KEY\" \
+         \"$maybeRestrictedEnvironment\" \
       "
 
   ) >> "$logFile" 2>&1 || {

--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -26,8 +26,6 @@ genesisOptions="${17}"
 extraNodeArgs="${18}"
 gpuMode="${19:-auto}"
 GEOLOCATION_API_KEY="${20}"
-maybeRestrictedEnvironment="${21}"
-
 set +x
 
 # Use a very large stake (relative to the default multinode-demo/ stake of 42)
@@ -54,12 +52,6 @@ airdropsEnabled=true
 if [[ -n $maybeDisableAirdrops ]]; then
   airdropsEnabled=false
 fi
-
-restrictedEnvironment=false
-if [[ -n $maybeRestrictedEnvironment ]]; then
-  restrictedEnvironment=true
-fi
-
 cat > deployConfig <<EOF
 deployMethod="$deployMethod"
 entrypointIp="$entrypointIp"
@@ -67,7 +59,6 @@ numNodes="$numNodes"
 failOnValidatorBootupFailure=$failOnValidatorBootupFailure
 genesisOptions="$genesisOptions"
 airdropsEnabled=$airdropsEnabled
-restrictedEnvironment=$restrictedEnvironment
 EOF
 
 source net/common.sh
@@ -227,9 +218,6 @@ EOF
       fi
       if [[ -f config/client-accounts.yml ]]; then
         genesisOptions+=" --primordial-accounts-file config/client-accounts.yml"
-      fi
-      if [[ $restrictedEnvironment = "false" ]] ; then
-        genesisOptions+="--dev"
       fi
 
       args=(

--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -26,6 +26,8 @@ genesisOptions="${17}"
 extraNodeArgs="${18}"
 gpuMode="${19:-auto}"
 GEOLOCATION_API_KEY="${20}"
+maybeRestrictedEnvironment="${21}"
+
 set +x
 
 # Use a very large stake (relative to the default multinode-demo/ stake of 42)
@@ -52,6 +54,12 @@ airdropsEnabled=true
 if [[ -n $maybeDisableAirdrops ]]; then
   airdropsEnabled=false
 fi
+
+restrictedEnvironment=false
+if [[ -n $maybeRestrictedEnvironment ]]; then
+  restrictedEnvironment=true
+fi
+
 cat > deployConfig <<EOF
 deployMethod="$deployMethod"
 entrypointIp="$entrypointIp"
@@ -59,6 +67,7 @@ numNodes="$numNodes"
 failOnValidatorBootupFailure=$failOnValidatorBootupFailure
 genesisOptions="$genesisOptions"
 airdropsEnabled=$airdropsEnabled
+restrictedEnvironment=$restrictedEnvironment
 EOF
 
 source net/common.sh
@@ -218,6 +227,9 @@ EOF
       fi
       if [[ -f config/client-accounts.yml ]]; then
         genesisOptions+=" --primordial-accounts-file config/client-accounts.yml"
+      fi
+      if [[ $restrictedEnvironment = "false" ]] ; then
+        genesisOptions+="--dev"
       fi
 
       args=(


### PR DESCRIPTION
#### Problem
We have no way to set the SLP "production" restricted environment from the CI/net scripts.

#### Summary of Changes
Allow development vs production environment mode to be explicitly set through the stack.

Partial solution to #6397 
