### PR TITLE
Fix Shellcheck Docker

### DIFF
--- a/ci/shellcheck.sh
+++ b/ci/shellcheck.sh
@@ -7,6 +7,6 @@ cd "$(dirname "$0")/.."
 (
   set -x
   git ls-files -- '*.sh' ':(exclude)ci/semver_bash' \
-    | xargs ci/docker-run.sh koalaman/shellcheck --color=always --external-sources --shell=bash
+    | xargs ci/docker-run.sh koalaman/shellcheck@sha256:fe24ab9a9b6b62d3adb162f4a80e006b6a63cae8c6ffafbae45772bab85e7294 --color=always --external-sources --shell=bash
 )
 echo --- ok


### PR DESCRIPTION
#### Problem
The tip of the shellcheck docker image is broken.

#### Summary of Changes
Pull a fixed image digest that is known to work
