### PR TITLE
genesis/: Improve error message when unable to read a file

### DIFF
--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -33,6 +33,7 @@ pub enum AccountFileFormat {
 fn pubkey_from_file(key_file: &str) -> Result<Pubkey, Box<dyn error::Error>> {
     read_pubkey_file(key_file)
         .or_else(|_| read_keypair_file(key_file).map(|keypair| keypair.pubkey()))
+        .map_err(|err| format!("Failed to read {}: {}", key_file, err).into())
 }
 
 fn pubkey_from_str(key_str: &str) -> Result<Pubkey, Box<dyn error::Error>> {


### PR DESCRIPTION
#### Problem
```bash
$ solana-genesis ....
Error: Os { code: 2, kind: NotFound, message: "No such file or directory" }
```
😕 

#### Summary of Changes
```bash
$ solana-genesis ....
Error: "Failed to read ./bootstrap-leader/identity-keypair.json: No such file or directory (os error 
```
💡
