### PR TITLE
cli/: Add show-gossip command

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -84,6 +84,7 @@ pub enum CliCommand {
         timeout: Duration,
         commitment_config: CommitmentConfig,
     },
+    ShowGossip,
     ShowValidators {
         use_lamports_unit: bool,
     },
@@ -264,6 +265,10 @@ pub fn parse_command(matches: &ArgMatches<'_>) -> Result<CliCommandInfo, Box<dyn
             require_keypair: false,
         }),
         ("ping", Some(matches)) => parse_cluster_ping(matches),
+        ("show-gossip", Some(_matches)) => Ok(CliCommandInfo {
+            command: CliCommand::ShowGossip,
+            require_keypair: false,
+        }),
         ("show-validators", Some(matches)) => parse_show_validators(matches),
         // Program Deployment
         ("deploy", Some(matches)) => Ok(CliCommandInfo {
@@ -871,6 +876,7 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             timeout,
             commitment_config,
         ),
+        CliCommand::ShowGossip => process_show_gossip(&rpc_client),
         CliCommand::ShowValidators { use_lamports_unit } => {
             process_show_validators(&rpc_client, *use_lamports_unit)
         }


### PR DESCRIPTION
It's a drag to manually `curl` the `getClusterNodes` RPC API, so wrap it up in an easy to use `solana show-gossip` command.

```bash
$ solana show-gossip 
RPC Endpoint: http://edge.testnet.solana.com:8899
IP Address      | Node identifier                              | Gossip | TPU   | RPC
----------------+----------------------------------------------+--------+-------+-------
34.83.51.122    | rpc1io1gmhuEq26wTBARGJfGGw48S7GYaHfKVEf9Dvv  | 8001   | 9236  | 8899 
34.82.17.66     | boot1Z6jb15CLqpaMTn2CxktktwZpRAVAgHZEW6SxQ7  | 8001   | 8142  | 8899 
35.185.244.71   | va13en4eUarJtf8mbhFF386nvQh12g6ESkjoR7Ji8hm  | 8001   | 9270  | 8899 
35.203.169.31   | va12u4o9DipLEB2z4fuoHszroq1U9NcAB9aooFDPJSf  | 8001   | 8352  | 8899 
34.82.219.29    | va11wrZ2pD668e2dKXohuXiyALPxfVQjjH7zzpePavQ  | 8001   | 9645  | 8899 
Nodes: 5
```