### PR TITLE
Production epoch and hash rate timing values

### DIFF
--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -110,7 +110,6 @@ fn main() -> Result<(), Box<dyn error::Error>> {
     let default_target_tick_duration =
         &timing::duration_as_ms(&PohConfig::default().target_tick_duration).to_string();
     let default_ticks_per_slot = &clock::DEFAULT_TICKS_PER_SLOT.to_string();
-    let default_slots_per_epoch = &EpochSchedule::default().slots_per_epoch.to_string();
     let default_operating_mode = "softlaunch";
 
     let matches = App::new(crate_name!())
@@ -285,7 +284,6 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                 .long("slots-per-epoch")
                 .value_name("SLOTS")
                 .takes_value(true)
-                .default_value(default_slots_per_epoch)
                 .help("The number of slots in an epoch"),
         )
         .arg(
@@ -362,8 +360,6 @@ fn main() -> Result<(), Box<dyn error::Error>> {
     accounts.append(&mut create_genesis_accounts(&mint_pubkey, lamports));
 
     let ticks_per_slot = value_t_or_exit!(matches, "ticks_per_slot", u64);
-    let slots_per_epoch = value_t_or_exit!(matches, "slots_per_epoch", u64);
-    let epoch_schedule = EpochSchedule::new(slots_per_epoch);
 
     let fee_calculator = FeeCalculator::new(
         value_t_or_exit!(matches, "target_lamports_per_signature", u64),
@@ -374,13 +370,25 @@ fn main() -> Result<(), Box<dyn error::Error>> {
     poh_config.target_tick_duration =
         Duration::from_millis(value_t_or_exit!(matches, "target_tick_duration", u64));
 
+    let operating_mode = if matches.value_of("operating_mode").unwrap() == "development" {
+        OperatingMode::Development
+    } else {
+        OperatingMode::SoftLaunch
+    };
+
     match matches.value_of("hashes_per_tick").unwrap() {
-        "auto" => {
-            let hashes_per_tick =
-                compute_hashes_per_tick(poh_config.target_tick_duration, 1_000_000);
-            println!("Hashes per tick: {}", hashes_per_tick);
-            poh_config.hashes_per_tick = Some(hashes_per_tick);
-        }
+        "auto" => match operating_mode {
+            OperatingMode::Development => {
+                let hashes_per_tick =
+                    compute_hashes_per_tick(poh_config.target_tick_duration, 1_000_000);
+                println!("Hashes per tick: {}", hashes_per_tick);
+                poh_config.hashes_per_tick = Some(hashes_per_tick);
+            }
+            OperatingMode::SoftLaunch => {
+                poh_config.hashes_per_tick =
+                    Some(clock::DEFAULT_HASHES_PER_SECOND / clock::DEFAULT_TICKS_PER_SECOND);
+            }
+        },
         "sleep" => {
             poh_config.hashes_per_tick = None;
         }
@@ -389,11 +397,20 @@ fn main() -> Result<(), Box<dyn error::Error>> {
         }
     }
 
-    let operating_mode = if matches.value_of("operating_mode").unwrap() == "development" {
-        OperatingMode::Development
+    let slots_per_epoch = if matches.value_of("slots_per_epoch").is_some() {
+        value_t_or_exit!(matches, "slots_per_epoch", u64)
     } else {
-        OperatingMode::SoftLaunch
+        match operating_mode {
+            OperatingMode::Development => clock::DEFAULT_DEV_SLOTS_PER_EPOCH,
+            OperatingMode::SoftLaunch => clock::DEFAULT_SLOTS_PER_EPOCH,
+        }
     };
+    let epoch_schedule = EpochSchedule::new(slots_per_epoch);
+    println!(
+        "Genesis mode: {:?} hashes per tick: {:?} slots_per_epoch: {}",
+        operating_mode, poh_config.hashes_per_tick, slots_per_epoch
+    );
+
     let native_instruction_processors =
         solana_genesis_programs::get_programs(operating_mode, 0).unwrap();
     let inflation = solana_genesis_programs::get_inflation(operating_mode, 0).unwrap();

--- a/ledger/src/leader_schedule_cache.rs
+++ b/ledger/src/leader_schedule_cache.rs
@@ -376,11 +376,11 @@ mod tests {
         );
         assert_eq!(
             cache.next_leader_slot(&pubkey, 0, &bank, None),
-            Some((1, 16383))
+            Some((1, 6047999))
         );
         assert_eq!(
             cache.next_leader_slot(&pubkey, 1, &bank, None),
-            Some((2, 16383))
+            Some((2, 6047999))
         );
         assert_eq!(
             cache.next_leader_slot(

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -12,7 +12,7 @@ use solana_core::{
 use solana_ledger::create_new_tmp_ledger;
 use solana_sdk::{
     client::SyncClient,
-    clock::{DEFAULT_SLOTS_PER_EPOCH, DEFAULT_SLOTS_PER_SEGMENT, DEFAULT_TICKS_PER_SLOT},
+    clock::{DEFAULT_DEV_SLOTS_PER_EPOCH, DEFAULT_SLOTS_PER_SEGMENT, DEFAULT_TICKS_PER_SLOT},
     commitment_config::CommitmentConfig,
     epoch_schedule::EpochSchedule,
     genesis_config::{GenesisConfig, OperatingMode},
@@ -88,9 +88,9 @@ impl Default for ClusterConfig {
             node_stakes: vec![],
             cluster_lamports: 0,
             ticks_per_slot: DEFAULT_TICKS_PER_SLOT,
-            slots_per_epoch: DEFAULT_SLOTS_PER_EPOCH,
+            slots_per_epoch: DEFAULT_DEV_SLOTS_PER_EPOCH,
             slots_per_segment: DEFAULT_SLOTS_PER_SEGMENT,
-            stakers_slot_offset: DEFAULT_SLOTS_PER_EPOCH,
+            stakers_slot_offset: DEFAULT_DEV_SLOTS_PER_EPOCH,
             native_instruction_processors: vec![],
             operating_mode: OperatingMode::Development,
             poh_config: PohConfig::default(),

--- a/sdk/src/clock.rs
+++ b/sdk/src/clock.rs
@@ -8,8 +8,19 @@ pub const DEFAULT_TICKS_PER_SECOND: u64 = 160;
 // every 400 ms. A fast voting cadence ensures faster finality and convergence
 pub const DEFAULT_TICKS_PER_SLOT: u64 = 64;
 
-// 1 Epoch = 400 * 8192 ms ~= 55 minutes
-pub const DEFAULT_SLOTS_PER_EPOCH: u64 = 8192;
+// GCP n1-standard hardware and also a xeon e5-2520 v4 are about this rate of hashes/s
+pub const DEFAULT_HASHES_PER_SECOND: u64 = 2_000_000;
+
+// 1 Dev Epoch = 400 ms * 8192 ~= 55 minutes
+pub const DEFAULT_DEV_SLOTS_PER_EPOCH: u64 = 8192;
+
+pub const SECONDS_PER_DAY: u64 = 24 * 60 * 60;
+pub const SECONDS_PER_WEEK: u64 = 7 * SECONDS_PER_DAY;
+pub const SECONDS_PER_FORTNIGHT: u64 = 2 * SECONDS_PER_WEEK;
+pub const TICKS_PER_FORTNIGHT: u64 = DEFAULT_TICKS_PER_SECOND * SECONDS_PER_FORTNIGHT;
+
+// 1 Epoch ~= 2 weeks
+pub const DEFAULT_SLOTS_PER_EPOCH: u64 = TICKS_PER_FORTNIGHT / DEFAULT_TICKS_PER_SLOT;
 
 // Storage segment configuration
 pub const DEFAULT_SLOTS_PER_SEGMENT: u64 = 1024;


### PR DESCRIPTION
#### Problem

Slots per epoch and hash rate is set for cluster development and not real world network partitions.

#### Summary of Changes

When --dev is not passed to genesis config, then set the production values of 1 fortnight for epoch length and 2m hashes per second rate.

Fixes #6767
