### PR TITLE
Fix shellcheck docker

### DIFF
--- a/ci/shellcheck.sh
+++ b/ci/shellcheck.sh
@@ -13,6 +13,6 @@ cd "$(dirname "$0")/.."
       -not -regex ".*/target/.*" \
       -print0 \
     | xargs -0 \
-        ci/docker-run.sh koalaman/shellcheck --color=always --external-sources --shell=bash
+        ci/docker-run.sh koalaman/shellcheck@sha256:fe24ab9a9b6b62d3adb162f4a80e006b6a63cae8c6ffafbae45772bab85e7294 --color=always --external-sources --shell=bash
 )
 echo --- ok


### PR DESCRIPTION
Shellcheck latest docker is busted.  Fix it to a working version rather than tracking tip.
