### PR TITLE
genesis: rename mint account to faucet account and make it optional

### DIFF
--- a/ci/testnet-deploy.sh
+++ b/ci/testnet-deploy.sh
@@ -28,7 +28,6 @@ maybeDisableAirdrops=
 maybeInternalNodesStakeLamports=
 maybeInternalNodesLamports=
 maybeExternalPrimordialAccountsFile=
-maybeLamports=
 maybeSlotsPerEpoch=
 maybeTargetLamportsPerSignature=
 maybeSlotsPerEpoch=
@@ -113,9 +112,6 @@ while [[ -n $1 ]]; do
       shift 2
     elif [[ $1 = --slots-per-epoch ]]; then
       maybeSlotsPerEpoch="$1 $2"
-      shift 2
-    elif [[ $1 = --lamports ]]; then
-      maybeLamports="$1 $2"
       shift 2
     elif [[ $1 = --target-lamports-per-signature ]]; then
       maybeTargetLamportsPerSignature="$1 $2"
@@ -412,7 +408,6 @@ if ! $skipStart; then
       $maybeInternalNodesStakeLamports
       $maybeInternalNodesLamports
       $maybeExternalPrimordialAccountsFile
-      $maybeLamports
       $maybeSlotsPerEpoch
       $maybeTargetLamportsPerSignature
       $maybeNoSnapshot

--- a/ci/testnet-manager.sh
+++ b/ci/testnet-manager.sh
@@ -536,7 +536,6 @@ deploy() {
         ${maybeInternalNodesStakeLamports} \
         ${maybeInternalNodesLamports} \
         ${maybeExternalAccountsFile} \
-        ${maybeLamports} \
         --target-lamports-per-signature 1 \
         --slots-per-epoch 4096 \
         ${maybeAdditionalDisk}

--- a/ci/testnet-manager.sh
+++ b/ci/testnet-manager.sh
@@ -506,14 +506,6 @@ deploy() {
         maybeExternalAccountsFile="--external-accounts-file ${EXTERNAL_ACCOUNTS_FILE}"
       fi
 
-      if [[ -z $LAMPORTS ]]; then
-        maybeLamports="--lamports 500000000000000000"
-      elif [[ $LAMPORTS == skip ]]; then
-        maybeLamports=""
-      else
-        maybeLamports="--lamports ${LAMPORTS}"
-      fi
-
       if [[ -z $ADDITIONAL_DISK_SIZE_GB ]]; then
         maybeAdditionalDisk="--validator-additional-disk-size-gb 32000"
       elif [[ $ADDITIONAL_DISK_SIZE_GB == skip ]]; then
@@ -521,7 +513,6 @@ deploy() {
       else
         maybeAdditionalDisk="--validator-additional-disk-size-gb ${ADDITIONAL_DISK_SIZE_GB}"
       fi
-
 
       # Multiple V100 GPUs are available in us-west1, us-central1 and europe-west4
       # shellcheck disable=SC2068

--- a/genesis/src/genesis_accounts.rs
+++ b/genesis/src/genesis_accounts.rs
@@ -1,16 +1,7 @@
-use solana_sdk::{account::Account, pubkey::Pubkey, system_program};
+use solana_sdk::{account::Account, pubkey::Pubkey};
 
-pub(crate) fn create_genesis_accounts(
-    mint_pubkey: &Pubkey,
-    mint_lamports: u64,
-) -> Vec<(Pubkey, Account)> {
-    vec![
-        // the mint
-        (
-            *mint_pubkey,
-            Account::new(mint_lamports, 0, &system_program::id()),
-        ),
-    ]
+pub(crate) fn create_genesis_accounts() -> Vec<(Pubkey, Account)> {
+    vec![]
 }
 
 #[cfg(test)]
@@ -19,9 +10,6 @@ mod tests {
 
     #[test]
     fn test_create_genesis_accounts() {
-        let mint_lamports = 42;
-        let accounts = create_genesis_accounts(&Pubkey::default(), mint_lamports);
-        let genesis_lamports: u64 = accounts.iter().map(|(_, account)| account.lamports).sum();
-        assert_eq!(genesis_lamports, mint_lamports);
+        assert_eq!(create_genesis_accounts(), vec![]);
     }
 }

--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -146,7 +146,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
             Arg::with_name("faucet_pubkey_file")
                 .short("m")
                 .long("faucet-pubkey")
-                .value_name("MINT")
+                .value_name("PUBKEY")
                 .takes_value(true)
                 .requires("faucet_lamports")
                 .help("Path to file containing the faucet's pubkey"),
@@ -358,12 +358,12 @@ fn main() -> Result<(), Box<dyn error::Error>> {
     ];
 
     if let Some(faucet_pubkey_file) = faucet_pubkey_file {
-        let faucet_pubkey = pubkey_from_file(faucet_pubkey_file)?;
-        accounts.append(&mut create_genesis_accounts(
-            &faucet_pubkey,
-            faucet_lamports.unwrap(),
-        ));
+        accounts.append(&mut vec![(
+            pubkey_from_file(faucet_pubkey_file)?,
+            Account::new(faucet_lamports.unwrap(), 0, &system_program::id()),
+        )]);
     }
+    accounts.append(&mut create_genesis_accounts());
 
     let ticks_per_slot = value_t_or_exit!(matches, "ticks_per_slot", u64);
     let slots_per_epoch = value_t_or_exit!(matches, "slots_per_epoch", u64);

--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -134,22 +134,22 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                 .help("Use directory as persistent ledger location"),
         )
         .arg(
-            Arg::with_name("mint_lamports")
+            Arg::with_name("faucet_lamports")
                 .short("t")
-                .long("mint-lamports")
+                .long("faucet-lamports")
                 .value_name("LAMPORTS")
                 .takes_value(true)
-                .requires("mint_pubkey_file")
-                .help("Number of lamports to assign to the mint"),
+                .requires("faucet_pubkey_file")
+                .help("Number of lamports to assign to the faucet"),
         )
         .arg(
-            Arg::with_name("mint_pubkey_file")
+            Arg::with_name("faucet_pubkey_file")
                 .short("m")
-                .long("mint-pubkey")
+                .long("faucet-pubkey")
                 .value_name("MINT")
                 .takes_value(true)
-                .requires("mint_lamports")
-                .help("Path to file containing the mint's pubkey"),
+                .requires("faucet_lamports")
+                .help("Path to file containing the faucet's pubkey"),
         )
         .arg(
             Arg::with_name("bootstrap_vote_pubkey_file")
@@ -312,8 +312,8 @@ fn main() -> Result<(), Box<dyn error::Error>> {
     let bootstrap_vote_pubkey_file = matches.value_of("bootstrap_vote_pubkey_file").unwrap();
     let bootstrap_stake_pubkey_file = matches.value_of("bootstrap_stake_pubkey_file").unwrap();
     let bootstrap_storage_pubkey_file = matches.value_of("bootstrap_storage_pubkey_file").unwrap();
-    let mint_pubkey_file = matches.value_of("mint_pubkey_file");
-    let mint_lamports = value_t!(matches, "mint_lamports", u64);
+    let faucet_pubkey_file = matches.value_of("faucet_pubkey_file");
+    let faucet_lamports = value_t!(matches, "faucet_lamports", u64);
     let ledger_path = PathBuf::from(matches.value_of("ledger_path").unwrap());
     let bootstrap_leader_lamports = value_t_or_exit!(matches, "bootstrap_leader_lamports", u64);
     let bootstrap_leader_stake_lamports =
@@ -357,11 +357,11 @@ fn main() -> Result<(), Box<dyn error::Error>> {
         ),
     ];
 
-    if let Some(mint_pubkey_file) = mint_pubkey_file {
-        let mint_pubkey = pubkey_from_file(mint_pubkey_file)?;
+    if let Some(faucet_pubkey_file) = faucet_pubkey_file {
+        let faucet_pubkey = pubkey_from_file(faucet_pubkey_file)?;
         accounts.append(&mut create_genesis_accounts(
-            &mint_pubkey,
-            mint_lamports.unwrap(),
+            &faucet_pubkey,
+            faucet_lamports.unwrap(),
         ));
     }
 

--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -3,7 +3,7 @@
 mod genesis_accounts;
 
 use crate::genesis_accounts::create_genesis_accounts;
-use clap::{crate_description, crate_name, value_t_or_exit, App, Arg};
+use clap::{crate_description, crate_name, value_t, value_t_or_exit, App, Arg};
 use solana_genesis::Base64Account;
 use solana_ledger::blocktree::create_new_ledger;
 use solana_ledger::poh::compute_hashes_per_tick;
@@ -88,7 +88,6 @@ pub fn add_genesis_accounts(file: &str, genesis_config: &mut GenesisConfig) -> i
 fn main() -> Result<(), Box<dyn error::Error>> {
     let default_bootstrap_leader_lamports = &sol_to_lamports(500.0).to_string();
     let default_bootstrap_leader_stake_lamports = &sol_to_lamports(0.5).to_string();
-    let default_lamports = &sol_to_lamports(500_000_000.0).to_string();
     let default_target_lamports_per_signature = &FeeCalculator::default()
         .target_lamports_per_signature
         .to_string();
@@ -135,23 +134,22 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                 .help("Use directory as persistent ledger location"),
         )
         .arg(
-            Arg::with_name("lamports")
+            Arg::with_name("mint_lamports")
                 .short("t")
-                .long("lamports")
+                .long("mint-lamports")
                 .value_name("LAMPORTS")
                 .takes_value(true)
-                .default_value(default_lamports)
-                .required(true)
-                .help("Number of lamports to create in the mint"),
+                .requires("mint_pubkey_file")
+                .help("Number of lamports to assign to the mint"),
         )
         .arg(
             Arg::with_name("mint_pubkey_file")
                 .short("m")
-                .long("mint")
+                .long("mint-pubkey")
                 .value_name("MINT")
                 .takes_value(true)
-                .required(true)
-                .help("Path to file containing keys of the mint"),
+                .requires("mint_lamports")
+                .help("Path to file containing the mint's pubkey"),
         )
         .arg(
             Arg::with_name("bootstrap_vote_pubkey_file")
@@ -314,9 +312,9 @@ fn main() -> Result<(), Box<dyn error::Error>> {
     let bootstrap_vote_pubkey_file = matches.value_of("bootstrap_vote_pubkey_file").unwrap();
     let bootstrap_stake_pubkey_file = matches.value_of("bootstrap_stake_pubkey_file").unwrap();
     let bootstrap_storage_pubkey_file = matches.value_of("bootstrap_storage_pubkey_file").unwrap();
-    let mint_pubkey_file = matches.value_of("mint_pubkey_file").unwrap();
+    let mint_pubkey_file = matches.value_of("mint_pubkey_file");
+    let mint_lamports = value_t!(matches, "mint_lamports", u64);
     let ledger_path = PathBuf::from(matches.value_of("ledger_path").unwrap());
-    let lamports = value_t_or_exit!(matches, "lamports", u64);
     let bootstrap_leader_lamports = value_t_or_exit!(matches, "bootstrap_leader_lamports", u64);
     let bootstrap_leader_stake_lamports =
         value_t_or_exit!(matches, "bootstrap_leader_stake_lamports", u64);
@@ -325,7 +323,6 @@ fn main() -> Result<(), Box<dyn error::Error>> {
     let bootstrap_vote_pubkey = pubkey_from_file(bootstrap_vote_pubkey_file)?;
     let bootstrap_stake_pubkey = pubkey_from_file(bootstrap_stake_pubkey_file)?;
     let bootstrap_storage_pubkey = pubkey_from_file(bootstrap_storage_pubkey_file)?;
-    let mint_pubkey = pubkey_from_file(mint_pubkey_file)?;
 
     let bootstrap_leader_vote_account =
         vote_state::create_account(&bootstrap_vote_pubkey, &bootstrap_leader_pubkey, 0, 1);
@@ -359,7 +356,14 @@ fn main() -> Result<(), Box<dyn error::Error>> {
             storage_contract::create_validator_storage_account(bootstrap_leader_pubkey, 1),
         ),
     ];
-    accounts.append(&mut create_genesis_accounts(&mint_pubkey, lamports));
+
+    if let Some(mint_pubkey_file) = mint_pubkey_file {
+        let mint_pubkey = pubkey_from_file(mint_pubkey_file)?;
+        accounts.append(&mut create_genesis_accounts(
+            &mint_pubkey,
+            mint_lamports.unwrap(),
+        ));
+    }
 
     let ticks_per_slot = value_t_or_exit!(matches, "ticks_per_slot", u64);
     let slots_per_epoch = value_t_or_exit!(matches, "slots_per_epoch", u64);

--- a/multinode-demo/drone.sh
+++ b/multinode-demo/drone.sh
@@ -7,8 +7,8 @@ here=$(dirname "$0")
 # shellcheck source=multinode-demo/common.sh
 source "$here"/common.sh
 
-[[ -f "$SOLANA_CONFIG_DIR"/mint-keypair.json ]] || {
-  echo "$SOLANA_CONFIG_DIR/mint-keypair.json not found, create it by running:"
+[[ -f "$SOLANA_CONFIG_DIR"/faucet-keypair.json ]] || {
+  echo "$SOLANA_CONFIG_DIR/faucet-keypair.json not found, create it by running:"
   echo
   echo "  ${here}/setup.sh"
   exit 1
@@ -16,4 +16,4 @@ source "$here"/common.sh
 
 set -x
 # shellcheck disable=SC2086 # Don't want to double quote $solana_drone
-exec $solana_drone --keypair "$SOLANA_CONFIG_DIR"/mint-keypair.json "$@"
+exec $solana_drone --keypair "$SOLANA_CONFIG_DIR"/faucet-keypair.json "$@"

--- a/multinode-demo/setup.sh
+++ b/multinode-demo/setup.sh
@@ -10,10 +10,10 @@ rm -rf "$SOLANA_CONFIG_DIR"/bootstrap-leader
 mkdir -p "$SOLANA_CONFIG_DIR"/bootstrap-leader
 
 # Create genesis ledger
-if [[ -r $MINT_KEYPAIR ]]; then
-  cp -f "$MINT_KEYPAIR" "$SOLANA_CONFIG_DIR"/mint-keypair.json
+if [[ -r $FAUCET_KEYPAIR ]]; then
+  cp -f "$FAUCET_KEYPAIR" "$SOLANA_CONFIG_DIR"/faucet-keypair.json
 else
-  $solana_keygen new -f -o "$SOLANA_CONFIG_DIR"/mint-keypair.json
+  $solana_keygen new -f -o "$SOLANA_CONFIG_DIR"/faucet-keypair.json
 fi
 
 if [[ -f $BOOTSTRAP_LEADER_IDENTITY_KEYPAIR ]]; then
@@ -32,8 +32,8 @@ default_arg --bootstrap-vote-pubkey "$SOLANA_CONFIG_DIR"/bootstrap-leader/vote-k
 default_arg --bootstrap-stake-pubkey "$SOLANA_CONFIG_DIR"/bootstrap-leader/stake-keypair.json
 default_arg --bootstrap-storage-pubkey "$SOLANA_CONFIG_DIR"/bootstrap-leader/storage-keypair.json
 default_arg --ledger "$SOLANA_CONFIG_DIR"/bootstrap-leader
-default_arg --mint-pubkey "$SOLANA_CONFIG_DIR"/mint-keypair.json
-default_arg --mint-lamports 500000000000000000
+default_arg --faucet-pubkey "$SOLANA_CONFIG_DIR"/faucet-keypair.json
+default_arg --faucet-lamports 500000000000000000
 default_arg --hashes-per-tick auto
 default_arg --operating-mode development
 $solana_genesis "${args[@]}"

--- a/multinode-demo/setup.sh
+++ b/multinode-demo/setup.sh
@@ -32,7 +32,8 @@ default_arg --bootstrap-vote-pubkey "$SOLANA_CONFIG_DIR"/bootstrap-leader/vote-k
 default_arg --bootstrap-stake-pubkey "$SOLANA_CONFIG_DIR"/bootstrap-leader/stake-keypair.json
 default_arg --bootstrap-storage-pubkey "$SOLANA_CONFIG_DIR"/bootstrap-leader/storage-keypair.json
 default_arg --ledger "$SOLANA_CONFIG_DIR"/bootstrap-leader
-default_arg --mint "$SOLANA_CONFIG_DIR"/mint-keypair.json
+default_arg --mint-pubkey "$SOLANA_CONFIG_DIR"/mint-keypair.json
+default_arg --mint-lamports 500000000000000000
 default_arg --hashes-per-tick auto
 default_arg --operating-mode development
 $solana_genesis "${args[@]}"

--- a/net/net.sh
+++ b/net/net.sh
@@ -61,7 +61,7 @@ Operate a configured testnet
                                       - Override the default --hashes-per-tick for the cluster
    --no-airdrop
                                       - If set, disables airdrops.  Nodes must be funded in genesis config when airdrops are disabled.
-   --lamports NUM_LAMPORTS_TO_MINT
+   --mint-lamports NUM_LAMPORTS_TO_MINT
                                       - Override the default 500000000000000000 lamports minted in genesis
    --internal-nodes-stake-lamports NUM_LAMPORTS_PER_NODE
                                       - Amount to stake internal nodes.
@@ -172,7 +172,7 @@ while [[ -n $1 ]]; do
     elif [[ $1 = --target-lamports-per-signature ]]; then
       genesisOptions="$genesisOptions $1 $2"
       shift 2
-    elif [[ $1 = --lamports ]]; then
+    elif [[ $1 = --mint-lamports ]]; then
       genesisOptions="$genesisOptions $1 $2"
       shift 2
     elif [[ $1 = --operating-mode ]]; then

--- a/net/net.sh
+++ b/net/net.sh
@@ -61,7 +61,7 @@ Operate a configured testnet
                                       - Override the default --hashes-per-tick for the cluster
    --no-airdrop
                                       - If set, disables airdrops.  Nodes must be funded in genesis config when airdrops are disabled.
-   --mint-lamports NUM_LAMPORTS_TO_MINT
+   --faucet-lamports NUM_LAMPORTS_TO_MINT
                                       - Override the default 500000000000000000 lamports minted in genesis
    --internal-nodes-stake-lamports NUM_LAMPORTS_PER_NODE
                                       - Amount to stake internal nodes.
@@ -172,7 +172,7 @@ while [[ -n $1 ]]; do
     elif [[ $1 = --target-lamports-per-signature ]]; then
       genesisOptions="$genesisOptions $1 $2"
       shift 2
-    elif [[ $1 = --mint-lamports ]]; then
+    elif [[ $1 = --faucet-lamports ]]; then
       genesisOptions="$genesisOptions $1 $2"
       shift 2
     elif [[ $1 = --operating-mode ]]; then

--- a/net/remote/remote-client.sh
+++ b/net/remote/remote-client.sh
@@ -77,7 +77,7 @@ solana-bench-exchange)
 idle)
   # Add the mint keypair to idle clients for convenience
   net/scripts/rsync-retry.sh -vPrc \
-    "$entrypointIp":~/solana/config/mint-keypair.json ~/solana/
+    "$entrypointIp":~/solana/config/faucet-keypair.json ~/solana/
   exit 0
   ;;
 *)

--- a/net/remote/remote-deploy-update.sh
+++ b/net/remote/remote-deploy-update.sh
@@ -36,5 +36,5 @@ PATH="$HOME"/.cargo/bin:"$PATH"
 
 set -x
 scripts/solana-install-deploy.sh \
-  --keypair config/mint-keypair.json \
+  --keypair config/faucet-keypair.json \
   localhost "$releaseChannel" "$updatePlatform"

--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -230,7 +230,7 @@ EOF
       args+=($genesisOptions)
 
       if [[ -f net/keypairs/mint.json ]]; then
-        export MINT_KEYPAIR=net/keypairs/mint.json
+        export FAUCET_KEYPAIR=net/keypairs/mint.json
       fi
       if [[ -f net/keypairs/bootstrap-leader-identity.json ]]; then
         export BOOTSTRAP_LEADER_IDENTITY_KEYPAIR=net/keypairs/bootstrap-leader-identity.json
@@ -312,13 +312,13 @@ EOF
     set -x
     # Add the mint keypair to validators for convenient access from tools
     # like bench-tps and add to blocktreamers to run a drone
-    scp "$entrypointIp":~/solana/config/mint-keypair.json config/
+    scp "$entrypointIp":~/solana/config/faucet-keypair.json config/
     if [[ $nodeType = blockstreamer ]]; then
       # Run another drone with the mint keypair on the blockstreamer node.
       # Typically the blockstreamer node has a static IP/DNS name for hosting
       # the blockexplorer web app, and is a location that somebody would expect
       # to be able to airdrop from
-      scp "$entrypointIp":~/solana/config/mint-keypair.json config/
+      scp "$entrypointIp":~/solana/config/faucet-keypair.json config/
       if [[ $airdropsEnabled = true ]]; then
 cat >> ~/solana/on-reboot <<EOF
         multinode-demo/drone.sh > drone.log 2>&1 &

--- a/run.sh
+++ b/run.sh
@@ -59,12 +59,12 @@ if [[ -e $leader_stake_account_keypair ]]; then
 else
   solana-keygen new -o "$leader_stake_account_keypair"
 fi
-solana-keygen new -f -o "$dataDir"/drone-keypair.json
+solana-keygen new -f -o "$dataDir"/faucet-keypair.json
 solana-keygen new -f -o "$dataDir"/leader-storage-account-keypair.json
 
 solana-genesis \
   --hashes-per-tick sleep \
-  --mint "$dataDir"/drone-keypair.json \
+  --faucet-keypair "$dataDir"/faucet-keypair.json \
   --bootstrap-leader-pubkey "$dataDir"/leader-keypair.json \
   --bootstrap-vote-pubkey "$dataDir"/leader-vote-account-keypair.json \
   --bootstrap-stake-pubkey "$dataDir"/leader-stake-account-keypair.json \
@@ -78,7 +78,7 @@ abort() {
 }
 trap abort INT TERM EXIT
 
-solana-drone --keypair "$dataDir"/drone-keypair.json &
+solana-drone --keypair "$dataDir"/faucet-keypair.json &
 drone=$!
 
 args=(

--- a/sdk/src/genesis_config.rs
+++ b/sdk/src/genesis_config.rs
@@ -44,16 +44,16 @@ pub struct GenesisConfig {
 
 // useful for basic tests
 pub fn create_genesis_config(lamports: u64) -> (GenesisConfig, Keypair) {
-    let mint_keypair = Keypair::new();
+    let faucet_keypair = Keypair::new();
     (
         GenesisConfig::new(
             &[(
-                mint_keypair.pubkey(),
+                faucet_keypair.pubkey(),
                 Account::new(lamports, 0, &system_program::id()),
             )],
             &[solana_system_program()],
         ),
-        mint_keypair,
+        faucet_keypair,
     )
 }
 
@@ -180,19 +180,21 @@ mod tests {
 
     #[test]
     fn test_genesis_config() {
-        let mint_keypair = Keypair::new();
+        let faucet_keypair = Keypair::new();
         let mut config = GenesisConfig::default();
         config.add_account(
-            mint_keypair.pubkey(),
+            faucet_keypair.pubkey(),
             Account::new(10_000, 0, &Pubkey::default()),
         );
         config.add_account(Pubkey::new_rand(), Account::new(1, 0, &Pubkey::default()));
         config.add_native_instruction_processor("hi".to_string(), Pubkey::new_rand());
 
         assert_eq!(config.accounts.len(), 2);
-        assert!(config.accounts.iter().any(
-            |(pubkey, account)| *pubkey == mint_keypair.pubkey() && account.lamports == 10_000
-        ));
+        assert!(config
+            .accounts
+            .iter()
+            .any(|(pubkey, account)| *pubkey == faucet_keypair.pubkey()
+                && account.lamports == 10_000));
 
         let path = &make_tmp_path("genesis_config");
         config.write(&path).expect("write");


### PR DESCRIPTION
It's not always desirable to create a faucet account at genesis.  I also renamed some `solana-genesis` arguments for clarity and consistency:
1. `--mint` ▶️  `--faucet-pubkey`
2. `--lamports` ▶️  `--faucet-lamports`
