### PR TITLE
fix: update run.sh arguments to solana-genesis

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -65,12 +65,13 @@ solana-keygen new -f -o "$dataDir"/leader-storage-account-keypair.json
 solana-genesis \
   --hashes-per-tick sleep \
   --faucet-pubkey "$dataDir"/faucet-keypair.json \
+  --faucet-lamports 500000000000000000 \
   --bootstrap-leader-pubkey "$dataDir"/leader-keypair.json \
   --bootstrap-vote-pubkey "$dataDir"/leader-vote-account-keypair.json \
   --bootstrap-stake-pubkey "$dataDir"/leader-stake-account-keypair.json \
   --bootstrap-storage-pubkey "$dataDir"/leader-storage-account-keypair.json \
   --ledger "$ledgerDir" \
-  --dev
+  --operating-mode development
 
 abort() {
   set +e


### PR DESCRIPTION
#### Problem

* solana-genesis has new arguments, current arguments in run.sh don't work ☔️ 
* this broke the solana-web3.js `localnet:up` command

#### Summary of Changes

* provide updated arguments to solana-genesis 🌈 

Fixes # N/A
