### PR TITLE
|solana-gossip spy| no longer requires an entrypoint

### DIFF
--- a/ci/localnet-sanity.sh
+++ b/ci/localnet-sanity.sh
@@ -324,7 +324,7 @@ while [[ $iteration -le $iterations ]]; do
     set -x
     client_keypair=/tmp/client-id.json-$$
     $solana_keygen new -f -o $client_keypair || exit $?
-    $solana_gossip spy --num-nodes-exactly $numNodes || exit $?
+    $solana_gossip spy -n 127.0.0.1:8001 --num-nodes-exactly $numNodes || exit $?
     rm -rf $client_keypair
   ) || flag_error
 

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -172,11 +172,11 @@ fn create_rpc_client(
     entrypoint: &ContactInfo,
 ) -> Result<(std::net::SocketAddr, RpcClient), String> {
     let (nodes, _archivers) = discover(
-        &entrypoint.gossip,
+        Some(&entrypoint.gossip),
         Some(1),
         Some(60),
         None,
-        Some(entrypoint.gossip),
+        Some(&entrypoint.gossip),
         None,
     )
     .map_err(|err| err.to_string())?;


### PR DESCRIPTION
`solana-gossip spy --gossip-port 8001` now brings up a standalone gossip node that can be connected to by `solana-gossip spy --entrypoint 127.0.0.1:8001`.

Fixes #6971
