### PR TITLE
Add error logging to dead slots

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -488,7 +488,11 @@ impl ReplayStage {
                 bank.slot(),
                 replay_result
             );
-            datapoint_warn!("replay-stage-mark_dead_slot", ("slot", bank.slot(), i64),);
+            datapoint_error!(
+                "replay-stage-mark_dead_slot",
+                ("error", format!("error: {:?}", replay_result), String),
+                ("slot", bank.slot(), i64)
+            );
             Self::mark_dead_slot(bank.slot(), blocktree, progress);
         }
 

--- a/metrics/scripts/grafana-provisioning/dashboards/testnet-monitor.json
+++ b/metrics/scripts/grafana-provisioning/dashboards/testnet-monitor.json
@@ -4109,7 +4109,7 @@
           "hide": false,
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "SELECT host_id, slot FROM \"$testnet\".\"autogen\".\"replay-stage-mark_dead_slot\"  WHERE $timeFilter ORDER BY time DESC ",
+          "query": "SELECT host_id, error, slot FROM \"$testnet\".\"autogen\".\"replay-stage-mark_dead_slot\"  WHERE $timeFilter ORDER BY time DESC ",
           "rawQuery": true,
           "refId": "A",
           "resultFormat": "table",


### PR DESCRIPTION
#### Problem
Dead slots metric does not log the actual error

#### Summary of Changes
Add error logging to dead slots
Fixes #
