### PR TITLE
Enable blockstreamer sigverify in softlaunch mode

### DIFF
--- a/net/net.sh
+++ b/net/net.sh
@@ -155,6 +155,7 @@ netemPartition=""
 netemConfig=""
 netemConfigFile=""
 netemCommand="add"
+maybeNoSigVerify="--dev-no-sigverify"
 
 command=$1
 [[ -n $command ]] || usage
@@ -177,7 +178,11 @@ while [[ -n $1 ]]; do
       shift 2
     elif [[ $1 = --operating-mode ]]; then
       case "$2" in
-        development|softlaunch)
+        development)
+          maybeNoSigVerify="--dev-no-sigverify"
+          ;;
+        softlaunch)
+          maybeNoSigVerify=""
           ;;
         *)
           echo "Unexpected operating mode: \"$2\""
@@ -514,6 +519,7 @@ startBootstrapLeader() {
          \"$maybeNoSnapshot $maybeSkipLedgerVerify $maybeLimitLedgerSize\" \
          \"$gpuMode\" \
          \"$GEOLOCATION_API_KEY\" \
+         \"$maybeNoSigVerify\" \
       "
 
   ) >> "$logFile" 2>&1 || {
@@ -583,6 +589,7 @@ startNode() {
          \"$maybeNoSnapshot $maybeSkipLedgerVerify $maybeLimitLedgerSize\" \
          \"$gpuMode\" \
          \"$GEOLOCATION_API_KEY\" \
+         \"$maybeNoSigVerify\" \
       "
   ) >> "$logFile" 2>&1 &
   declare pid=$!

--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -26,6 +26,8 @@ genesisOptions="${17}"
 extraNodeArgs="${18}"
 gpuMode="${19:-auto}"
 GEOLOCATION_API_KEY="${20}"
+maybeNoSigVerify="${21}"
+
 set +x
 
 # Use a very large stake (relative to the default multinode-demo/ stake of 42)
@@ -291,8 +293,10 @@ EOF
       args+=(
         --blockstream /tmp/solana-blockstream.sock
         --no-voting
-        --dev-no-sigverify
       )
+      if [[ -n $maybeNoSigVerify ]] ; then
+        args+=("$maybeNoSigVerify")
+      fi
     else
       args+=(--enable-rpc-exit)
       if [[ -n $internalNodesLamports ]]; then


### PR DESCRIPTION
#### Problem
We have hard-coded developer options set for the blockstreamer in remote-node.sh

#### Summary of Changes
Keep the default behavior unchanged but allow override from net.sh flags

Fixes #6998 
