### PR TITLE
Add ConfirmedBlock struct, and rework Blocktree apis to include block…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3573,6 +3573,7 @@ dependencies = [
  "serde_derive 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-budget-api 0.21.0",
+ "solana-client 0.21.0",
  "solana-genesis-programs 0.21.0",
  "solana-logger 0.21.0",
  "solana-measure 0.21.0",

--- a/client/src/rpc_request.rs
+++ b/client/src/rpc_request.rs
@@ -3,6 +3,8 @@ use serde_json::{json, Value};
 use solana_sdk::{
     clock::{Epoch, Slot},
     commitment_config::CommitmentConfig,
+    hash::Hash,
+    transaction::{Result, Transaction},
 };
 use std::{error, fmt, io, net::SocketAddr};
 
@@ -18,6 +20,13 @@ pub struct RpcResponseContext {
 pub struct Response<T> {
     pub context: RpcResponseContext,
     pub value: T,
+}
+
+#[derive(Debug, Default, PartialEq, Serialize)]
+pub struct RpcConfirmedBlock {
+    pub previous_blockhash: Hash,
+    pub blockhash: Hash,
+    pub transactions: Vec<(Transaction, Result<()>)>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -28,6 +28,7 @@ rayon = "1.2.0"
 reed-solomon-erasure = { package = "solana-reed-solomon-erasure", version = "4.0.1-3", features = ["simd-accel"] }
 serde = "1.0.102"
 serde_derive = "1.0.102"
+solana-client = { path = "../client", version = "0.21.0" }
 solana-genesis-programs = { path = "../genesis-programs", version = "0.21.0" }
 solana-logger = { path = "../logger", version = "0.21.0" }
 solana-measure = { path = "../measure", version = "0.21.0" }

--- a/ledger/src/blocktree_db.rs
+++ b/ledger/src/blocktree_db.rs
@@ -275,7 +275,7 @@ impl Column for columns::TransactionStatus {
         key
     }
 
-    fn index<'a>(key: &[u8]) -> (Slot, Signature) {
+    fn index(key: &[u8]) -> (Slot, Signature) {
         let slot = BigEndian::read_u64(&key[..8]);
         let index = Signature::new(&key[8..72]);
         (slot, index)


### PR DESCRIPTION
…hash info and dummy tx statuses

#### Problem
The `getConfirmedBlock` rpc endpoint only returns part of the data needed about a confirmed block by our main downstream use case. It is missing blockhash, previous_blockhash, and real transaction status data.

#### Summary of Changes
- Adds `RpcConfirmedBlock` struct, to organize data needed from Blocktree and to be returned by RPC
- Extends Blocktree api to get blockhash and previous_blockhash for a confirmed block
- Adds Blocktree api to map transactions to their statuses. This does not yet return real transaction status data, but moves the generation of dummy statuses from rpc.rs up into blocktree.rs, ready to be plugged in after #6958 and implementation of writes into that store

Toward #6867 

This will break `getConfirmedBlock` in https://github.com/solana-labs/solana-web3.js again
(sorry, @jstarry ...)
