### PR TITLE
Gossip entrypoint is now option of spy not solana-gossip

### DIFF
--- a/net/remote/remote-sanity.sh
+++ b/net/remote/remote-sanity.sh
@@ -97,8 +97,8 @@ echo "+++ $sanityTargetIp: node count ($numSanityNodes expected)"
     nodeArg="num-nodes-exactly"
   fi
 
-  $solana_gossip --entrypoint "$sanityTargetIp:8001" \
-    spy --$nodeArg "$numSanityNodes" --timeout 60 \
+  $solana_gossip spy --entrypoint "$sanityTargetIp:8001" \
+    --$nodeArg "$numSanityNodes" --timeout 60 \
 )
 
 echo "--- $sanityTargetIp: RPC API: getTransactionCount"


### PR DESCRIPTION
#### Problem
Update where the `--entrypoint` option is passed in to solana-gossip to reflect new arguments from https://github.com/solana-labs/solana/pull/6999.  