### PR TITLE
Fixup accounts count when importing snapshot append vecs

### DIFF
--- a/core/tests/bank_forks.rs
+++ b/core/tests/bank_forks.rs
@@ -168,6 +168,12 @@ mod tests {
                 let tx =
                     system_transaction::transfer(&mint_keypair, &key1, 1, bank.last_blockhash());
                 assert_eq!(bank.process_transaction(&tx), Ok(()));
+
+                let key2 = Keypair::new().pubkey();
+                let tx =
+                    system_transaction::transfer(&mint_keypair, &key2, 0, bank.last_blockhash());
+                assert_eq!(bank.process_transaction(&tx), Ok(()));
+
                 bank.freeze();
             },
             1,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3605,6 +3605,9 @@ mod tests {
         bank.deposit(&key.pubkey(), 10);
         assert_eq!(bank.get_balance(&key.pubkey()), 10);
 
+        let key2 = Keypair::new();
+        bank.deposit(&key2.pubkey(), 0);
+
         let len = serialized_size(&bank).unwrap() + serialized_size(&bank.rc).unwrap();
         let mut buf = vec![0u8; len as usize];
         let mut writer = Cursor::new(&mut buf[..]);
@@ -3629,6 +3632,7 @@ mod tests {
             .accounts_from_stream(&mut reader, dbank_paths, copied_accounts.path())
             .unwrap();
         assert_eq!(dbank.get_balance(&key.pubkey()), 10);
+        assert_eq!(dbank.get_balance(&key2.pubkey()), 0);
         bank.compare_bank(&dbank);
     }
 


### PR DESCRIPTION
#### Problem

count_and_status is not accurate from the serialized snapshot, because the snapshot creator could have removed some accounts from it's append vec view and thus decremented the count.

#### Summary of Changes

Update count_and_status by reading in the append_vec and correcting the accounts count.

Fixes #
