### PR TITLE
Legitimately map transactions to statuses in blocktree

### DIFF
--- a/client/src/rpc_request.rs
+++ b/client/src/rpc_request.rs
@@ -26,7 +26,13 @@ pub struct Response<T> {
 pub struct RpcConfirmedBlock {
     pub previous_blockhash: Hash,
     pub blockhash: Hash,
-    pub transactions: Vec<(Transaction, Result<()>)>,
+    pub transactions: Vec<(Transaction, Option<RpcTransactionStatus>)>,
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+pub struct RpcTransactionStatus {
+    pub status: Result<()>,
+    pub fee: u64,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -304,8 +304,8 @@ impl JsonRpcRequestProcessor {
     // The `get_confirmed_block` method is not fully implemented. It currenlty returns a partially
     // complete RpcConfirmedBlock. The `blockhash` and `previous_blockhash` fields are legitimate
     // data, while the `transactions` field contains transaction tuples (Transaction,
-    // transaction::Result), where the Transaction is a legitimate transaction, but the Result is
-    // always `Ok()`.
+    // transaction::Result), where the Transaction is a legitimate transaction, but the
+    // Option<RpcTransactionStatus> is always None.
     pub fn get_confirmed_block(&self, slot: Slot) -> Result<Option<RpcConfirmedBlock>> {
         Ok(self.blocktree.get_confirmed_block(slot).ok())
     }

--- a/ledger/src/blocktree_db.rs
+++ b/ledger/src/blocktree_db.rs
@@ -11,11 +11,7 @@ use serde::de::DeserializeOwned;
 use serde::Serialize;
 use solana_client::rpc_request::RpcTransactionStatus;
 use solana_sdk::{clock::Slot, signature::Signature};
-use std::collections::HashMap;
-use std::fs;
-use std::marker::PhantomData;
-use std::path::Path;
-use std::sync::Arc;
+use std::{collections::HashMap, fs, marker::PhantomData, path::Path, sync::Arc};
 
 // A good value for this is the number of cores on the machine
 const TOTAL_THREADS: i32 = 8;

--- a/ledger/src/blocktree_db.rs
+++ b/ledger/src/blocktree_db.rs
@@ -9,6 +9,7 @@ use rocksdb::{
 };
 use serde::de::DeserializeOwned;
 use serde::Serialize;
+use solana_client::rpc_request::RpcTransactionStatus;
 use solana_sdk::{clock::Slot, signature::Signature};
 use std::collections::HashMap;
 use std::fs;
@@ -261,7 +262,7 @@ pub trait TypedColumn: Column {
 }
 
 impl TypedColumn for columns::TransactionStatus {
-    type Type = (solana_sdk::transaction::Result<()>, u64);
+    type Type = RpcTransactionStatus;
 }
 
 impl Column for columns::TransactionStatus {


### PR DESCRIPTION
#### Problem
`getConfirmedBlock` RPC returns dummy transaction status data, because `Blocktree::map_transactions_to_statuses()` isn't hooked up.

#### Summary of Changes
- Get data from TransactionStatus db column and map to transactions by Signature
- Refactor TransactionStatus store and RpcConfirmedBlock to use a named struct for clarity. RpcConfirmedBlock wraps this `RpcTransactionStatus` in an `Option` in order to allow `getConfirmedBlock` to function on validators that have not enabled the TransactionStatus store. (Statuses that cannot be found return None.) When #6867 item 5 is implemented, it should probably also prevent `map_transactions_to_statuses()` from firing at all to save all the db get attempts on an empty column.

... Since there are no apis writing data to the TransactionsStatus store, `getConfirmedBlock` returns None for all RpcTransactionStatuses.

Toward #6867 

This will break `getConfirmedBlock` in https://github.com/solana-labs/solana-web3.js again, again
