### PR TITLE
[wip] Correctly purge zero lamport accounts

### DIFF
--- a/ledger/src/snapshot_utils.rs
+++ b/ledger/src/snapshot_utils.rs
@@ -224,6 +224,7 @@ pub fn bank_from_archive<P: AsRef<Path>>(
         unpacked_accounts_dir,
     )?;
 
+    bank.purge_zero_lamport_accounts();
     if !bank.verify_snapshot_bank() {
         panic!("Snapshot bank failed to verify");
     }

--- a/ledger/src/snapshot_utils.rs
+++ b/ledger/src/snapshot_utils.rs
@@ -151,7 +151,7 @@ where
 }
 
 pub fn add_snapshot<P: AsRef<Path>>(snapshot_path: P, bank: &Bank) -> Result<()> {
-    error!("ryoqun saving snapshot");
+    trace!("ryoqun saving snapshot");
     bank.purge_zero_lamport_accounts();
     let slot = bank.slot();
     // snapshot_path/slot
@@ -212,7 +212,7 @@ pub fn bank_from_archive<P: AsRef<Path>>(
     snapshot_path: &PathBuf,
     snapshot_tar: P,
 ) -> Result<Bank> {
-    error!("ryoqun loading snapshot");
+    trace!("ryoqun loading snapshot");
     // Untar the snapshot into a temp directory under `snapshot_config.snapshot_path()`
     let unpack_dir = tempfile::tempdir_in(snapshot_path)?;
     untar_snapshot_in(&snapshot_tar, &unpack_dir)?;

--- a/ledger/src/snapshot_utils.rs
+++ b/ledger/src/snapshot_utils.rs
@@ -151,6 +151,7 @@ where
 }
 
 pub fn add_snapshot<P: AsRef<Path>>(snapshot_path: P, bank: &Bank) -> Result<()> {
+    error!("ryoqun saving snapshot");
     bank.purge_zero_lamport_accounts();
     let slot = bank.slot();
     // snapshot_path/slot
@@ -211,6 +212,7 @@ pub fn bank_from_archive<P: AsRef<Path>>(
     snapshot_path: &PathBuf,
     snapshot_tar: P,
 ) -> Result<Bank> {
+    error!("ryoqun loading snapshot");
     // Untar the snapshot into a temp directory under `snapshot_config.snapshot_path()`
     let unpack_dir = tempfile::tempdir_in(snapshot_path)?;
     untar_snapshot_in(&snapshot_tar, &unpack_dir)?;

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -331,6 +331,10 @@ impl Accounts {
         self.accounts_db.verify_hash_internal_state(slot, ancestors)
     }
 
+    pub fn verify_account_balances(&self, ancestors: &HashMap<Slot, usize>) -> bool {
+        self.accounts_db.verify_account_balances(ancestors)
+    }
+
     pub fn load_by_program(
         &self,
         ancestors: &HashMap<Slot, usize>,

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -1,4 +1,6 @@
-use crate::accounts_db::{AccountInfo, AccountStorage, AccountStorageEntry, AccountsDB, AppendVecId, ErrorCounters};
+use crate::accounts_db::{
+    AccountInfo, AccountStorage, AccountStorageEntry, AccountsDB, AppendVecId, ErrorCounters,
+};
 use crate::accounts_index::AccountsIndex;
 use crate::append_vec::StoredAccount;
 use crate::blockhash_queue::BlockhashQueue;

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -297,8 +297,7 @@ impl Accounts {
             slot,
             |stored_account: &StoredAccount,
              _id: AppendVecId,
-             accum: &mut Vec<(Pubkey, u64, B)>,
-             _: &AccountStorageEntry| {
+             accum: &mut Vec<(Pubkey, u64, B)>| {
                 if let Some(val) = func(stored_account) {
                     accum.push((
                         stored_account.meta.pubkey,

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -1,6 +1,4 @@
-use crate::accounts_db::{
-    AccountInfo, AccountStorage, AccountsDB, AppendVecId, ErrorCounters,
-};
+use crate::accounts_db::{AccountInfo, AccountStorage, AccountsDB, AppendVecId, ErrorCounters};
 use crate::accounts_index::AccountsIndex;
 use crate::append_vec::StoredAccount;
 use crate::blockhash_queue::BlockhashQueue;

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -1,4 +1,4 @@
-use crate::accounts_db::{AccountInfo, AccountStorage, AccountsDB, AppendVecId, ErrorCounters};
+use crate::accounts_db::{AccountInfo, AccountStorage, AccountStorageEntry, AccountsDB, AppendVecId, ErrorCounters};
 use crate::accounts_index::AccountsIndex;
 use crate::append_vec::StoredAccount;
 use crate::blockhash_queue::BlockhashQueue;
@@ -295,7 +295,8 @@ impl Accounts {
             slot,
             |stored_account: &StoredAccount,
              _id: AppendVecId,
-             accum: &mut Vec<(Pubkey, u64, B)>| {
+             accum: &mut Vec<(Pubkey, u64, B)>,
+             _: &AccountStorageEntry| {
                 if let Some(val) = func(stored_account) {
                     accum.push((
                         stored_account.meta.pubkey,

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -1,5 +1,5 @@
 use crate::accounts_db::{
-    AccountInfo, AccountStorage, AccountStorageEntry, AccountsDB, AppendVecId, ErrorCounters,
+    AccountInfo, AccountStorage, AccountsDB, AppendVecId, ErrorCounters,
 };
 use crate::accounts_index::AccountsIndex;
 use crate::append_vec::StoredAccount;

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -298,7 +298,7 @@ impl AccountStorageEntry {
         if count > 0 {
             *count_and_status = (count - 1, status);
         } else {
-            // XXX promoted this to critical because unconsistent ref count directly translates into a corrupted ledger
+            // promoted this to critical because unconsistent ref count directly translates into a corrupted ledger
             panic!(
                 "ryoqun count value 0 for slot {}, {:?}",
                 self.slot_id, status

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -1282,8 +1282,8 @@ pub mod tests {
         let slot_b = slot_a + 1;
         db.add_root(slot_b);
 
-        debug!("{:?}", db.store(slot_a, &[(&key0, &account0)]));
-        debug!("{:?}", db.store(slot_a, &[(&key1, &account1)]));
+        db.store(slot_a, &[(&key0, &account0)]);
+        db.store(slot_a, &[(&key1, &account1)]);
 
         {
             let stores = db.storage.read().unwrap();
@@ -1303,10 +1303,8 @@ pub mod tests {
                 vec![2]
             );
         }
-        debug!(
-            "{:?}",
-            db.store(slot_b, &[(&key0, &account0), (&key2, &account2)])
-        );
+
+        db.store(slot_b, &[(&key0, &account0), (&key2, &account2)]);
 
         {
             let stores = db.storage.read().unwrap();
@@ -1349,7 +1347,7 @@ pub mod tests {
         let lamport_0 = 0;
         let account3 = Account::new(lamport_0, 0, &Account::default().owner);
         assert!(db.verify_account_balances(&ancestors));
-        debug!("{:?}", db.store(slot_b, &[(&key3, &account3)]));
+        db.store(slot_b, &[(&key3, &account3)]);
 
         let mut db2 = AccountsDB::new(None);
         db2.storage = RwLock::new(db.storage.read().unwrap().clone());

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -1210,15 +1210,9 @@ impl AccountsDB {
                     storage_maps.iter().for_each(|storage| {
                         storage.all_existing_accounts().iter().for_each(|a| {
                             if a.meta.pubkey == *pubkey && *version != a.meta.write_version {
-                                trace!(
-                                    "ryoqun: hi: slot: {:?} {:?} {:?}",
-                                    (*slot_id, storage.slot_id, storage_entry.slot_id),
-                                    *pubkey,
-                                    a
-                                );
-                                storage.remove_account();
-                                //ZZZ remove slots?
-                                trace!("ryoqun: hi end");
+                                if storage.remove_account() == 0 {
+                                    dead_slots.insert(*slot_id);
+                                }
                             }
                         })
                     });
@@ -1243,9 +1237,7 @@ impl AccountsDB {
                                 slot_id, store.slot_id,
                                 "AccountDB::accounts_index corrupted. Storage should only point to one slot"
                             );
-                            let count = store.remove_account();
-                            trace!("ryoqun count, {}", count);
-                            if count == 0 {
+                            if store.remove_account() == 0 {
                                 dead_slots.insert(slot_id);
                             }
                         }

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -298,7 +298,8 @@ impl AccountStorageEntry {
         if count > 0 {
             *count_and_status = (count - 1, status);
         } else {
-            warn!("count value 0 for slot {}", self.slot_id);
+            // XXX promoted this to critical because unconsistent ref count directly translates into a corrupted ledger
+            panic!("ryoqun count value 0 for slot {}, {:?}", self.slot_id, status);
         }
         count_and_status.0
     }

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -698,7 +698,7 @@ impl AccountsDB {
                 accounts.iter().for_each(|stored_account| {
                     scan_func(stored_account, storage.id, &mut retval, storage.clone())
                 });
-                3236
+                retval
             })
             .collect()
     }

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -576,6 +576,7 @@ impl AccountsDB {
         let mut purges = Vec::new();
         accounts_index.scan_accounts(ancestors, |pubkey, (account_info, slot)| {
             if account_info.lamports == 0 && accounts_index.is_root(slot) {
+                error!("ryoqun purging....{} {} {:?} {}", pubkey, slot, account_info,  accounts_index.is_root(slot));
                 purges.push(*pubkey);
             }
         });
@@ -585,10 +586,13 @@ impl AccountsDB {
         for purge in &purges {
             reclaims.extend(accounts_index.purge(purge));
         }
+        error!("ryoqun: zla reclaims {:?}", reclaims);
         let last_root = accounts_index.last_root;
         drop(accounts_index);
         let mut dead_slots = self.remove_dead_accounts(reclaims);
+        error!("ryoqun: zla dead slots 2 {:?}", dead_slots);
         self.cleanup_dead_slots(&mut dead_slots, last_root);
+        error!("ryoqun: zla dead slots 2 {:?}", dead_slots);
         for slot in dead_slots {
             self.purge_slot(slot);
         }
@@ -874,7 +878,7 @@ impl AccountsDB {
                 oldest_slot = *slot;
             }
         }
-        info!("accounts_db: total_stores: {} newest_slot: {} oldest_slot: {} max_slot: {} (num={}) min_slot: {} (num={})",
+        error!("ryoqun accounts_db: total_stores: {} newest_slot: {} oldest_slot: {} max_slot: {} (num={}) min_slot: {} (num={})",
               total_count, newest_slot, oldest_slot, max_slot, max, min_slot, min);
         datapoint_info!("accounts_db-stores", ("total_count", total_count, i64));
     }

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -259,7 +259,6 @@ impl AccountStorageEntry {
     }
 
     fn add_account(&self) {
-        error!("adding account");
         let mut count_and_status = self.count_and_status.write().unwrap();
         *count_and_status = (count_and_status.0 + 1, count_and_status.1);
     }
@@ -277,7 +276,6 @@ impl AccountStorageEntry {
     }
 
     fn remove_account(&self) -> usize {
-        error!("removing account");
         let mut count_and_status = self.count_and_status.write().unwrap();
         let (count, mut status) = *count_and_status;
 

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -2018,6 +2018,7 @@ pub mod tests {
 
         let account = Account::new(some_lamport, no_data, &owner);
         let pubkey = Pubkey::new_rand();
+        let pubkey2 = Pubkey::new_rand();
         let zero_lamport_account = Account::new(zero_lamport, no_data, &owner);
 
         let filler_account = Account::new(some_lamport, no_data, &owner);
@@ -2027,6 +2028,7 @@ pub mod tests {
 
         let mut current_slot = 1;
         accounts.store(current_slot, &[(&pubkey, &account)]);
+        //accounts.store(current_slot, &[(&pubkey2, &account)]); // <= Enabling this line causes even my PR fails...
         error!("#1: {:#?}", accounts.get_storage_entries()); // #1
         accounts.add_root(current_slot);
 

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -1135,30 +1135,25 @@ impl AccountsDB {
                 storage.restore_account_count();
             }
 
-            let mut accumulator: Vec<HashMap<Pubkey, (u64, AccountInfo)>> = self
+            let mut accumulator: Vec<Vec<(u64, AccountInfo)>> = self
                 .scan_account_storage(
                     *slot_id,
                     |stored_account: &StoredAccount,
                      id: AppendVecId,
-                     accum: &mut HashMap<Pubkey, (u64, AccountInfo)>| {
+                     accum: &mut Vec<(u64, AccountInfo)>| {
                         let account_info = AccountInfo {
                             id,
                             offset: stored_account.offset,
                             lamports: stored_account.account_meta.lamports,
                         };
                         error!("count");
-                        accum.insert(
-                            stored_account.meta.pubkey,
-                            (stored_account.meta.write_version, account_info),
+                        accum.push(
+                            (stored_account.meta.write_version, account_info)
                         );
                     },
                 );
 
-            let mut account_maps = accumulator.pop().unwrap();
-            while let Some(maps) = accumulator.pop() {
-                AccountsDB::merge(&mut account_maps, &maps);
-            }
-            if !account_maps.is_empty() {
+            for accum in accumulator {
                 accounts_index.roots.insert(*slot_id);
                 error!("account_maps: {:?}", account_maps.len());
                 let mut reclaims: Vec<(u64, AccountInfo)> = vec![];

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -676,7 +676,6 @@ impl AccountsDB {
         })
     }
 
-    // PERF: Sequentially read each storage entry in parallel
     pub fn set_hash(&self, slot: Slot, parent_slot: Slot) {
         let mut slot_hashes = self.slot_hashes.write().unwrap();
         let hash = *slot_hashes

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -1972,7 +1972,8 @@ pub mod tests {
         expected_lamports: u64,
     ) {
         let ancestors = vec![(slot, 0)].into_iter().collect();
-        let (account, slot) = accounts.load_slow(&ancestors, &pubkey).unwrap();
+        let owner = Account::default().owner;
+        let (account, slot) = accounts.load_slow(&ancestors, &pubkey).unwrap_or((Account::new(0, 0, &owner), slot));
         assert_eq!((account.lamports, slot), (expected_lamports, slot));
     }
 

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -256,7 +256,10 @@ impl AccountStorageEntry {
     pub fn restore_account_count(&self) {
         let mut count_and_status = self.count_and_status.write().unwrap();
         let new_count = self.all_existing_accounts().len();
-        error!("ryoqun: restored storage: from {:?} {:?} to {}", self, *count_and_status, new_count);
+        error!(
+            "ryoqun: restored storage: from {:?} {:?} to {}",
+            self, *count_and_status, new_count
+        );
         *count_and_status = (new_count, count_and_status.1);
     }
 

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -1221,7 +1221,7 @@ pub mod tests {
         //assert_eq!(*db2.accounts_index.read().unwrap().account_maps.map(|m| m.read().unwrap()), *db.accounts_index.read().unwrap());
 
         let ancestors = vec![(slot_a, 1), (slot_b, 1)].into_iter().collect();
-        let index = db.accounts_index.read().unwrap();
+        let index = db2.accounts_index.read().unwrap();
 
         {
             let (list, _index) = index.get(&key0, &ancestors).unwrap();

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -912,7 +912,7 @@ impl AccountsDB {
         }
     }
 
-    fn verify_account_balance(&self, ancestors: &HashMap<Slot, usize>) -> bool {
+    pub fn verify_account_balances(&self, ancestors: &HashMap<Slot, usize>) -> bool {
         !self.scan_accounts(
             &ancestors,
             |collector: &mut bool, option| {

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -249,6 +249,10 @@ impl AccountStorageEntry {
         self.accounts.flush()
     }
 
+    pub fn all_existing_accounts(&self) -> Vec<StoredAccount> {
+        self.accounts.accounts(0)
+    }
+
     fn add_account(&self) {
         error!("adding account");
         let mut count_and_status = self.count_and_status.write().unwrap();
@@ -1198,6 +1202,7 @@ pub mod tests {
             let stores = db.storage.read().unwrap();
             let slot_a_stores = &stores.0.get(&slot_a).unwrap();
             assert_eq!(slot_a_stores.values().map(|v| v.count()).collect::<Vec<usize>>(), vec![2]);
+            assert_eq!(slot_a_stores.values().map(|v| v.all_existing_accounts().len()).collect::<Vec<usize>>(), vec![2]);
         }
         debug!("{:?}", db.store(slot_b, &[(&key0, &account0), (&key2, &account2)]));
 
@@ -1205,8 +1210,10 @@ pub mod tests {
             let stores = db.storage.read().unwrap();
             let slot_a_stores = &stores.0.get(&slot_a).unwrap();
             assert_eq!(slot_a_stores.values().map(|v| v.count()).collect::<Vec<usize>>(), vec![1]);
+            assert_eq!(slot_a_stores.values().map(|v| v.all_existing_accounts().len()).collect::<Vec<usize>>(), vec![2]);
             let slot_b_stores = &stores.0.get(&slot_b).unwrap();
             assert_eq!(slot_b_stores.values().map(|v| v.count()).collect::<Vec<usize>>(), vec![2]);
+            assert_eq!(slot_b_stores.values().map(|v| v.all_existing_accounts().len()).collect::<Vec<usize>>(), vec![2]);
         }
     }
 

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -1222,10 +1222,15 @@ pub mod tests {
 
         let ancestors = vec![(slot_a, 1), (slot_b, 1)].into_iter().collect();
         let index = db.accounts_index.read().unwrap();
-        let (list, index) = index.get(&key0, &ancestors).unwrap();
-        assert_eq!((&*list).first().map(|item| item.0), Some(slot_b));
 
         {
+            let (list, _index) = index.get(&key0, &ancestors).unwrap();
+            assert_eq!((&*list).first().map(|item| item.0), Some(slot_b));
+            let (list, _index) = index.get(&key1, &ancestors).unwrap();
+            assert_eq!((&*list).first().map(|item| item.0), Some(slot_a));
+            let (list, _index) = index.get(&key2, &ancestors).unwrap();
+            assert_eq!((&*list).first().map(|item| item.0), Some(slot_b));
+
             let stores = db2.storage.read().unwrap();
             let slot_a_stores = &stores.0.get(&slot_a).unwrap();
             assert_eq!(slot_a_stores.values().map(|v| v.count()).collect::<Vec<usize>>(), vec![1]);

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -299,7 +299,10 @@ impl AccountStorageEntry {
             *count_and_status = (count - 1, status);
         } else {
             // XXX promoted this to critical because unconsistent ref count directly translates into a corrupted ledger
-            panic!("ryoqun count value 0 for slot {}, {:?}", self.slot_id, status);
+            panic!(
+                "ryoqun count value 0 for slot {}, {:?}",
+                self.slot_id, status
+            );
         }
         count_and_status.0
     }
@@ -576,7 +579,13 @@ impl AccountsDB {
         let mut purges = Vec::new();
         accounts_index.scan_accounts(ancestors, |pubkey, (account_info, slot)| {
             if account_info.lamports == 0 && accounts_index.is_root(slot) {
-                error!("ryoqun purging....{} {} {:?} {}", pubkey, slot, account_info,  accounts_index.is_root(slot));
+                error!(
+                    "ryoqun purging....{} {} {:?} {}",
+                    pubkey,
+                    slot,
+                    account_info,
+                    accounts_index.is_root(slot)
+                );
                 purges.push(*pubkey);
             }
         });
@@ -909,16 +918,13 @@ impl AccountsDB {
     }
 
     pub fn verify_account_balances(&self, ancestors: &HashMap<Slot, usize>) -> bool {
-        !self.scan_accounts(
-            &ancestors,
-            |collector: &mut bool, option| {
-                if let Some((_, account, _)) = option {
-                    if account.lamports == 0 {
-                        *collector = true;
-                    }
+        !self.scan_accounts(&ancestors, |collector: &mut bool, option| {
+            if let Some((_, account, _)) = option {
+                if account.lamports == 0 {
+                    *collector = true;
                 }
-            },
-        )
+            }
+        })
     }
 
     pub fn xor_in_hash_state(&self, slot_id: Slot, hash: BankHash) {
@@ -1241,19 +1247,58 @@ pub mod tests {
         {
             let stores = db.storage.read().unwrap();
             let slot_a_stores = &stores.0.get(&slot_a).unwrap();
-            assert_eq!(slot_a_stores.values().map(|v| v.count()).collect::<Vec<usize>>(), vec![2]);
-            assert_eq!(slot_a_stores.values().map(|v| v.all_existing_accounts().len()).collect::<Vec<usize>>(), vec![2]);
+            assert_eq!(
+                slot_a_stores
+                    .values()
+                    .map(|v| v.count())
+                    .collect::<Vec<usize>>(),
+                vec![2]
+            );
+            assert_eq!(
+                slot_a_stores
+                    .values()
+                    .map(|v| v.all_existing_accounts().len())
+                    .collect::<Vec<usize>>(),
+                vec![2]
+            );
         }
-        debug!("{:?}", db.store(slot_b, &[(&key0, &account0), (&key2, &account2)]));
+        debug!(
+            "{:?}",
+            db.store(slot_b, &[(&key0, &account0), (&key2, &account2)])
+        );
 
         {
             let stores = db.storage.read().unwrap();
             let slot_a_stores = &stores.0.get(&slot_a).unwrap();
-            assert_eq!(slot_a_stores.values().map(|v| v.count()).collect::<Vec<usize>>(), vec![1]);
-            assert_eq!(slot_a_stores.values().map(|v| v.all_existing_accounts().len()).collect::<Vec<usize>>(), vec![2]);
+            assert_eq!(
+                slot_a_stores
+                    .values()
+                    .map(|v| v.count())
+                    .collect::<Vec<usize>>(),
+                vec![1]
+            );
+            assert_eq!(
+                slot_a_stores
+                    .values()
+                    .map(|v| v.all_existing_accounts().len())
+                    .collect::<Vec<usize>>(),
+                vec![2]
+            );
             let slot_b_stores = &stores.0.get(&slot_b).unwrap();
-            assert_eq!(slot_b_stores.values().map(|v| v.count()).collect::<Vec<usize>>(), vec![2]);
-            assert_eq!(slot_b_stores.values().map(|v| v.all_existing_accounts().len()).collect::<Vec<usize>>(), vec![2]);
+            assert_eq!(
+                slot_b_stores
+                    .values()
+                    .map(|v| v.count())
+                    .collect::<Vec<usize>>(),
+                vec![2]
+            );
+            assert_eq!(
+                slot_b_stores
+                    .values()
+                    .map(|v| v.all_existing_accounts().len())
+                    .collect::<Vec<usize>>(),
+                vec![2]
+            );
         }
 
         let ancestors = vec![(slot_a, 1), (slot_b, 1)].into_iter().collect();
@@ -1284,11 +1329,35 @@ pub mod tests {
 
             let stores = db2.storage.read().unwrap();
             let slot_a_stores = &stores.0.get(&slot_a).unwrap();
-            assert_eq!(slot_a_stores.values().map(|v| v.count()).collect::<Vec<usize>>(), vec![1]);
-            assert_eq!(slot_a_stores.values().map(|v| v.all_existing_accounts().len()).collect::<Vec<usize>>(), vec![2]);
+            assert_eq!(
+                slot_a_stores
+                    .values()
+                    .map(|v| v.count())
+                    .collect::<Vec<usize>>(),
+                vec![1]
+            );
+            assert_eq!(
+                slot_a_stores
+                    .values()
+                    .map(|v| v.all_existing_accounts().len())
+                    .collect::<Vec<usize>>(),
+                vec![2]
+            );
             let slot_b_stores = &stores.0.get(&slot_b).unwrap();
-            assert_eq!(slot_b_stores.values().map(|v| v.count()).collect::<Vec<usize>>(), vec![2]);
-            assert_eq!(slot_b_stores.values().map(|v| v.all_existing_accounts().len()).collect::<Vec<usize>>(), vec![2+1]);
+            assert_eq!(
+                slot_b_stores
+                    .values()
+                    .map(|v| v.count())
+                    .collect::<Vec<usize>>(),
+                vec![2]
+            );
+            assert_eq!(
+                slot_b_stores
+                    .values()
+                    .map(|v| v.all_existing_accounts().len())
+                    .collect::<Vec<usize>>(),
+                vec![2 + 1]
+            );
         }
     }
 

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -2027,21 +2027,27 @@ pub mod tests {
 
         let mut current_slot = 1;
         accounts.store(current_slot, &[(&pubkey, &account)]);
+        error!("#1: {:#?}", accounts.get_storage_entries()); // #1
         accounts.add_root(current_slot);
 
         current_slot += 1;
         accounts.store(current_slot, &[(&pubkey, &zero_lamport_account)]);
+        error!("#2: {:#?}", accounts.get_storage_entries()); // #2
         for _ in 0..33000 {
             accounts.store(current_slot, &[(&filler_account_pubkey, &filler_account)]);
         }
+        error!("#3: {:#?}", accounts.get_storage_entries()); // #3
         accounts.add_root(current_slot);
 
         error!("doesn't fail:");
-        assert_load_account(&accounts, current_slot, pubkey, zero_lamport);
+        assert_load_account(&accounts, current_slot, pubkey, zero_lamport); // #4
 
-        purge_zero_lamport_accounts(&accounts, current_slot);
+        purge_zero_lamport_accounts(&accounts, current_slot); // #5
+        error!("#6: {:#?}", accounts.get_storage_entries()); // #6
+
         let accounts = reconstruct_accounts_db_via_serialization(accounts, current_slot);
 
+        error!("#7: {:#?}", accounts.get_storage_entries()); // #7
         error!("does fail due to a reconstruction bug:");
         assert_load_account(&accounts, current_slot, pubkey, zero_lamport);
     }

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -1305,16 +1305,16 @@ pub mod tests {
         //assert!(db.verify_hash_internal_state(slot_b, &ancestors));
 
         let key3 = Pubkey::new_rand();
-        let lamportZ = 0;
-        let account3 = Account::new(lamportZ, 0, &Account::default().owner);
-        assert!(db.verify_account_balance(&ancestors));
+        let lamport_0 = 0;
+        let account3 = Account::new(lamport_0, 0, &Account::default().owner);
+        assert!(db.verify_account_balances(&ancestors));
         debug!("{:?}", db.store(slot_b, &[(&key3, &account3)]));
 
         let mut db2 = AccountsDB::new(None);
         db2.storage = RwLock::new(db.storage.read().unwrap().clone());
         db2.generate_index();
         db2.purge_zero_lamport_accounts(&ancestors);
-        assert!(db2.verify_account_balance(&ancestors));
+        assert!(db2.verify_account_balances(&ancestors));
         //assert_eq!(*db2.accounts_index.read().unwrap().account_maps.map(|m| m.read().unwrap()), *db.accounts_index.read().unwrap());
 
         let index = db2.accounts_index.read().unwrap();

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -1197,16 +1197,16 @@ pub mod tests {
         {
             let stores = db.storage.read().unwrap();
             let slot_a_stores = &stores.0.get(&slot_a).unwrap();
-            assert_eq!(slot_a_stores.values().map(|v| v.count_and_status.read().unwrap().0).collect::<Vec<usize>>(), vec![2]);
+            assert_eq!(slot_a_stores.values().map(|v| v.count()).collect::<Vec<usize>>(), vec![2]);
         }
         debug!("{:?}", db.store(slot_b, &[(&key0, &account0), (&key2, &account2)]));
 
         {
             let stores = db.storage.read().unwrap();
             let slot_a_stores = &stores.0.get(&slot_a).unwrap();
-            assert_eq!(slot_a_stores.values().map(|v| v.count_and_status.read().unwrap().0).collect::<Vec<usize>>(), vec![1]);
+            assert_eq!(slot_a_stores.values().map(|v| v.count()).collect::<Vec<usize>>(), vec![1]);
             let slot_b_stores = &stores.0.get(&slot_b).unwrap();
-            assert_eq!(slot_b_stores.values().map(|v| v.count_and_status.read().unwrap().0).collect::<Vec<usize>>(), vec![2]);
+            assert_eq!(slot_b_stores.values().map(|v| v.count()).collect::<Vec<usize>>(), vec![2]);
         }
     }
 

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -767,15 +767,6 @@ impl AccountsDB {
         }
     }
 
-    pub fn hash_stored_account(slot: Slot, account: &StoredAccount) -> Hash {
-        Self::hash_account_data(
-            slot,
-            account.account_meta.lamports,
-            account.data,
-            &account.meta.pubkey,
-        )
-    }
-
     pub fn hash_account(slot: Slot, account: &Account, pubkey: &Pubkey) -> Hash {
         Self::hash_account_data(slot, account.lamports, &account.data, pubkey)
     }

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -1973,7 +1973,9 @@ pub mod tests {
     ) {
         let ancestors = vec![(slot, 0)].into_iter().collect();
         let owner = Account::default().owner;
-        let (account, slot) = accounts.load_slow(&ancestors, &pubkey).unwrap_or((Account::new(0, 0, &owner), slot));
+        let (account, slot) = accounts
+            .load_slow(&ancestors, &pubkey)
+            .unwrap_or((Account::new(0, 0, &owner), slot));
         assert_eq!((account.lamports, slot), (expected_lamports, slot));
     }
 

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -1142,24 +1142,23 @@ impl AccountsDB {
                 storage.restore_account_count();
             }
 
-            let mut accumulator: Vec<
-                HashMap<Pubkey, (u64, AccountInfo)>,
-            > = self.scan_account_storage(
-                *slot_id,
-                |stored_account: &StoredAccount,
-                 id: AppendVecId,
-                 accum: &mut HashMap<Pubkey, (u64, AccountInfo)>| {
-                    let account_info = AccountInfo {
-                        id,
-                        offset: stored_account.offset,
-                        lamports: stored_account.account_meta.lamports,
-                    };
-                    accum.insert(
-                        stored_account.meta.pubkey,
-                        (stored_account.meta.write_version, account_info),
-                    );
-                },
-            );
+            let mut accumulator: Vec<HashMap<Pubkey, (u64, AccountInfo)>> = self
+                .scan_account_storage(
+                    *slot_id,
+                    |stored_account: &StoredAccount,
+                     id: AppendVecId,
+                     accum: &mut HashMap<Pubkey, (u64, AccountInfo)>| {
+                        let account_info = AccountInfo {
+                            id,
+                            offset: stored_account.offset,
+                            lamports: stored_account.account_meta.lamports,
+                        };
+                        accum.insert(
+                            stored_account.meta.pubkey,
+                            (stored_account.meta.write_version, account_info),
+                        );
+                    },
+                );
 
             let mut account_maps = accumulator.pop().unwrap();
             while let Some(maps) = accumulator.pop() {
@@ -1179,10 +1178,11 @@ impl AccountsDB {
                 for (pubkey, (version, _account_info)) in account_maps.iter() {
                     storage_maps.iter().for_each(|storage| {
                         storage.all_existing_accounts().iter().for_each(|a| {
-                            if a.meta.pubkey == *pubkey && *version != a.meta.write_version {
-                                if storage.remove_account() == 0 {
-                                    dead_slots.insert(*slot_id);
-                                }
+                            if a.meta.pubkey == *pubkey
+                                && *version != a.meta.write_version
+                                && storage.remove_account() == 0
+                            {
+                                dead_slots.insert(*slot_id);
                             }
                         })
                     });

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -1170,6 +1170,20 @@ pub mod tests {
         assert_eq!(db.load_slow(&ancestors, &key), Some((account0, 0)));
     }
 
+    fn test_accountsdb_generate_index() {
+        solana_logger::setup();
+        let ancestors = vec![(1, 1)].into_iter().collect();
+        let db = AccountsDB::new(None);
+        db.scan_accounts(ancestors: &HashMap<Slot, usize>, scan_func: F)
+        db.generate_index()
+        let key = Pubkey::default();
+        let account0 = Account::new(1, 0, &key);
+
+        db.store(0, &[(&key, &account0)]);
+        db.add_root(0);
+        assert_eq!(db.load_slow(&ancestors, &key), Some((account0, 0)));
+    }
+
     #[test]
     fn test_accountsdb_latest_ancestor() {
         solana_logger::setup();

--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -91,7 +91,7 @@ impl<T: Clone> AccountsIndex<T> {
         let _slot_vec = self
             .account_maps
             .entry(*pubkey)
-            .or_insert_with(|| RwLock::new(Vec::with_capacity(32))); // XXX magic number; use the lockout consant?
+            .or_insert_with(|| RwLock::new(Vec::with_capacity(32))); // magic number; use the lockout consant?
         self.update(slot, pubkey, account_info, reclaims);
     }
 

--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -91,7 +91,7 @@ impl<T: Clone> AccountsIndex<T> {
         let _slot_vec = self
             .account_maps
             .entry(*pubkey)
-            .or_insert_with(|| RwLock::new(Vec::with_capacity(32)));
+            .or_insert_with(|| RwLock::new(Vec::with_capacity(32))); // XXX magic number; use the lockout consant?
         self.update(slot, pubkey, account_info, reclaims);
     }
 

--- a/runtime/src/append_vec.rs
+++ b/runtime/src/append_vec.rs
@@ -452,6 +452,21 @@ pub mod tests {
     }
 
     #[test]
+    fn test_append_vec_accounts() {
+        let path = get_append_vec_path("test_append");
+
+        let av = AppendVec::new(&path.path, true, 1024 * 1024);
+        assert_eq!(av.accounts(0).len(), 0);
+
+        let account = create_test_account(0);
+        av.append_account_test(&account).unwrap();
+        assert_eq!(av.accounts(0).len(), 1);
+
+        av.reset();
+        assert_eq!(av.accounts(0).len(), 0);
+    }
+
+    #[test]
     fn test_append_vec_one() {
         let path = get_append_vec_path("test_append");
         let av = AppendVec::new(&path.path, true, 1024 * 1024);

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1442,7 +1442,6 @@ impl Bank {
     /// A snapshot bank should be purged of 0 lamport accounts which are not part of the hash
     /// calculation and could shield other real accounts.
     pub fn verify_snapshot_bank(&self) -> bool {
-        self.purge_zero_lamport_accounts();
         self.rc
             .accounts
             .verify_hash_internal_state(self.slot(), &self.ancestors)

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1442,8 +1442,10 @@ impl Bank {
     /// A snapshot bank should be purged of 0 lamport accounts which are not part of the hash
     /// calculation and could shield other real accounts.
     pub fn verify_snapshot_bank(&self) -> bool {
-        self.rc.accounts.verify_hash_internal_state(self.slot(), &self.ancestors)
-          && self.rc.accounts.verify_account_balances(&self.ancestors)
+        self.rc
+            .accounts
+            .verify_hash_internal_state(self.slot(), &self.ancestors)
+            && self.rc.accounts.verify_account_balances(&self.ancestors)
     }
 
     /// Return the number of hashes per tick

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1442,23 +1442,8 @@ impl Bank {
     /// A snapshot bank should be purged of 0 lamport accounts which are not part of the hash
     /// calculation and could shield other real accounts.
     pub fn verify_snapshot_bank(&self) -> bool {
-        self.rc
-            .accounts
-            .verify_hash_internal_state(self.slot(), &self.ancestors)
-            && !self.has_accounts_with_zero_lamports()
-    }
-
-    fn has_accounts_with_zero_lamports(&self) -> bool {
-        self.rc.accounts.accounts_db.scan_accounts(
-            &self.ancestors,
-            |collector: &mut bool, option| {
-                if let Some((_, account, _)) = option {
-                    if account.lamports == 0 {
-                        *collector = true;
-                    }
-                }
-            },
-        )
+        self.rc.accounts.verify_hash_internal_state(self.slot(), &self.ancestors)
+          && self.rc.accounts.verify_account_balances(&self.ancestors)
     }
 
     /// Return the number of hashes per tick
@@ -2316,7 +2301,7 @@ mod tests {
     }
 
     fn assert_no_zero_balance_accounts(bank: &Arc<Bank>) {
-        assert!(!bank.has_accounts_with_zero_lamports());
+        assert!(bank.rc.accounts.verify_account_balances(&bank.ancestors));
     }
 
     // Test that purging 0 lamports accounts works.


### PR DESCRIPTION
## [READ FIRST] REVIEW POINTS

**This is still a draft. Code is full of any kinds of dirtiness/roughness. It seems the current impl mostly works as intended.**

I want reviews for following points to be sure I can continue to the correct direction before wasting time for wrong direction:

- The descriptions of following problem and solution.
- [This new purging logic](https://github.com/solana-labs/solana/pull/7013/files#diff-ef68c28d9d63e66355c44904d9877825R41).
- [This new validating logic](https://github.com/solana-labs/solana/pull/7013/files#diff-2099c5256db4eb5975c8834af38f6456R845).

## Problem

Sometimes snapshot restore fails (#6890). At first I thought this is a vote-account-specific issue. But it turned out this is not correct. The more general problem description is that **snapshots restoration can't handle any kinds of accounts with 0 lamport balance at the moment**, albeit prior attempt to fix [this](https://github.com/solana-labs/solana/pull/6315).
This means this can easily be triggered by just running `solana pay XXXXXX 0 lamports`. (By the way, `solana pay` should at least warn for such a meaningless transfer of 0 lamports...)

The problem is that removed zero lamport account can reappear when restoring from snapshots, although we intended to purge them when creating snapshots.
As for the in-process state consistency, validator correctly purges zero accounts by `purge_zero_lamport_accounts`. And indeed, it can successfully do this periodically while creating newer snapshots  until it restarts, because the running validator never actually uses the snapshot.

Then, when restoring from snapshot after simple restart or by different validator startup, the solana-validator loads the snapshot. Such bad snapshots aborts the restoration.

The reason zero lamport accounts can reappear is that while `purge_zero_lamport_accounts` does correctly purges zero lamport accounts from the in-process AccountsIndex, it fails to update the ref-counted AccountStorage correctly.

## Solution

First, leaving zero lamport accounts as is in the AccountStorage is not acceptable. Because this allows malicious snapshot-serving validators enlarge the active dataset of account db as they like via a crafted snapshot. Also they can shield otherwise legitimate accounts as zero balance.

On the other hand, merely decrementing the ref-count of AccountStorage is not sufficient with the hope the GC nature of AccountStorage solves everything for us, because accounts are first grouped, then those groups are ref-counted as the minimum unit. When the group containing zero lamport account contains other active account, the group as a whole can not be purged.

Also, it's preferable to preserve copy-on-write semantics wherever possible for sound solutions. So inplace update isn't well welcomed.

In these constraints, I'd like to propose **to retain the zero lamport account with greatest slot value, while purging older ones.**

This rather not a straight fix. This is because there isn't a good way to convey this info (the `purged`-ness of accounts) to next invocation or joining validator.

So, in my solution, the retained zero lamport account works as special marker as the purged entry. And older account entries shadowed by copy-on-writes will eventually removed as the cluster moves the state forward and uses fewer old slots, then finally the special marker itself can be removed. I think this introduces exploitable fragmentation like normal accounts can cause today. So for that fix, we'll need a genral compaction mechanism.

### Other possible solutions

- In-place overwrite of accounts data? (maybe bad for performance, rollback, bankhash, security)
- Introduce some end-of-life marker for zero-lamport accounts? (what about bankhash?, moderate cost to implement =~ considerable risks for more bugs for such low-level system component.)
- Teach serializer/deserializer to specially handle accounts marked as purged with a tombstone? (This might be a leaky abstraction; on top of that, the same applies for impl cost and risks.)
- start serializing/deserializing the index as well (takes more time for snapshot creation).