### PR TITLE
Generate net-shaper configuration from stdin, or randomly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3752,6 +3752,7 @@ version = "0.1.0"
 dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/net-shaper/Cargo.toml
+++ b/net-shaper/Cargo.toml
@@ -18,6 +18,7 @@ serde_derive = "1.0.102"
 serde_json = "1.0.41"
 solana-clap-utils = { path = "../clap-utils", version = "0.21.0" }
 solana-logger = { path = "../logger", version = "0.21.0" }
+rand = "0.6.5"
 
 [[bin]]
 name = "solana-net-shaper"


### PR DESCRIPTION
#### Problem
Missing convenient way to generate `net-shaper` configuration file.

#### Summary of Changes
Added support to `net-shaper` program to generate config file. The user can run the tool in interactive mode to choose specific values. Or, the tool can be run to generate a random configuration file.
