### PR TITLE
Fix progress map losing banks and recomputing stats

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -1350,11 +1350,13 @@ mod test {
             let bank0 = Arc::new(Bank::new(&genesis_config));
             let mut progress = HashMap::new();
             let last_blockhash = bank0.last_blockhash();
-            progress.insert(bank0.slot(), ForkProgress::new(0, last_blockhash));
+            let mut bank0_progress = progress
+                .entry(bank0.slot())
+                .or_insert_with(|| ForkProgress::new(0, last_blockhash));
             let shreds = shred_to_insert(&mint_keypair, bank0.clone());
             blocktree.insert_shreds(shreds, None, false).unwrap();
             let (res, _tx_count) =
-                ReplayStage::replay_blocktree_into_bank(&bank0, &blocktree, &mut progress);
+                ReplayStage::replay_blocktree_into_bank(&bank0, &blocktree, &mut bank0_progress);
 
             // Check that the erroring bank was marked as dead in the progress map
             assert!(progress

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -204,6 +204,10 @@ impl ReplayStage {
             .spawn(move || {
                 let _exit = Finalizer::new(exit_.clone());
                 let mut progress = HashMap::new();
+                // Initialize progress map with any root banks
+                for bank in bank_forks.read().unwrap().frozen_banks().values() {
+                    progress.insert(bank.slot(), ForkProgress::new(bank.slot(), bank.last_blockhash()));
+                }
                 let mut current_leader = None;
                 let mut last_reset = Hash::default();
                 let mut partition = false;


### PR DESCRIPTION
#### Problem
Progress map will recompute bank stats b/c:

1) `confirm_forks` removes banks from the progress map, even if they haven't been voted on
2) The leader's own bank is never added to the progress map

#### Summary of Changes
1) Remove `confirm_forks`
2) Add leader's own banks to progress map if they're missing in `select_fork`

Fixes #
