### PR TITLE
Make solana ping take optional lamports argument

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -79,6 +79,7 @@ pub enum CliCommand {
     GetSlot,
     GetTransactionCount,
     Ping {
+        lamports: u64,
         interval: Duration,
         count: Option<u64>,
         timeout: Duration,
@@ -864,6 +865,7 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
         CliCommand::GetEpochInfo => process_get_epoch_info(&rpc_client),
         CliCommand::GetTransactionCount => process_get_transaction_count(&rpc_client),
         CliCommand::Ping {
+            lamports,
             interval,
             count,
             timeout,
@@ -871,6 +873,7 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
         } => process_ping(
             &rpc_client,
             config,
+            *lamports,
             interval,
             count,
             timeout,

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -85,6 +85,13 @@ impl ClusterQuerySubCommands for App<'_, '_> {
                         .help("Stop after submitting count transactions"),
                 )
                 .arg(
+                    Arg::with_name("lamports")
+                        .long("lamports")
+                        .value_name("NUMBER")
+                        .takes_value(true)
+                        .help("Number of lamports to transfer for each transaction [default: 1]"),
+                )
+                .arg(
                     Arg::with_name("timeout")
                         .short("t")
                         .long("timeout")
@@ -128,6 +135,11 @@ pub fn parse_catchup(matches: &ArgMatches<'_>) -> Result<CliCommandInfo, CliErro
 }
 
 pub fn parse_cluster_ping(matches: &ArgMatches<'_>) -> Result<CliCommandInfo, CliError> {
+    let lamports = if matches.is_present("lamports") {
+        value_t_or_exit!(matches, "lamports", u64)
+    } else {
+        1
+    };
     let interval = Duration::from_secs(value_t_or_exit!(matches, "interval", u64));
     let count = if matches.is_present("count") {
         Some(value_t_or_exit!(matches, "count", u64))
@@ -142,6 +154,7 @@ pub fn parse_cluster_ping(matches: &ArgMatches<'_>) -> Result<CliCommandInfo, Cl
     };
     Ok(CliCommandInfo {
         command: CliCommand::Ping {
+            lamports,
             interval,
             count,
             timeout,
@@ -288,6 +301,7 @@ pub fn process_get_transaction_count(rpc_client: &RpcClient) -> ProcessResult {
 pub fn process_ping(
     rpc_client: &RpcClient,
     config: &CliConfig,
+    lamports: u64,
     interval: &Duration,
     count: &Option<u64>,
     timeout: &Duration,
@@ -314,7 +328,8 @@ pub fn process_ping(
         let (recent_blockhash, fee_calculator) = rpc_client.get_new_blockhash(&last_blockhash)?;
         last_blockhash = recent_blockhash;
 
-        let transaction = system_transaction::transfer(&config.keypair, &to, 1, recent_blockhash);
+        let transaction =
+            system_transaction::transfer(&config.keypair, &to, lamports, recent_blockhash);
         check_account_for_fee(rpc_client, config, &fee_calculator, &transaction.message)?;
 
         match rpc_client.send_transaction(&transaction) {
@@ -332,8 +347,8 @@ pub fn process_ping(
                                 let elapsed_time_millis = elapsed_time.as_millis() as u64;
                                 confirmation_time.push_back(elapsed_time_millis);
                                 println!(
-                                    "{}1 lamport transferred: seq={:<3} time={:>4}ms signature={}",
-                                    CHECK_MARK, seq, elapsed_time_millis, signature
+                                    "{}{} lamport(s) transferred: seq={:<3} time={:>4}ms signature={}",
+                                    CHECK_MARK, lamports, seq, elapsed_time_millis, signature
                                 );
                                 confirmed_count += 1;
                             }
@@ -631,6 +646,7 @@ mod tests {
             parse_command(&test_ping).unwrap(),
             CliCommandInfo {
                 command: CliCommand::Ping {
+                    lamports: 1,
                     interval: Duration::from_secs(1),
                     count: Some(2),
                     timeout: Duration::from_secs(3),

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -89,7 +89,8 @@ impl ClusterQuerySubCommands for App<'_, '_> {
                         .long("lamports")
                         .value_name("NUMBER")
                         .takes_value(true)
-                        .help("Number of lamports to transfer for each transaction [default: 1]"),
+                        .default_value("1")
+                        .help("Number of lamports to transfer for each transaction"),
                 )
                 .arg(
                     Arg::with_name("timeout")
@@ -135,11 +136,7 @@ pub fn parse_catchup(matches: &ArgMatches<'_>) -> Result<CliCommandInfo, CliErro
 }
 
 pub fn parse_cluster_ping(matches: &ArgMatches<'_>) -> Result<CliCommandInfo, CliError> {
-    let lamports = if matches.is_present("lamports") {
-        value_t_or_exit!(matches, "lamports", u64)
-    } else {
-        1
-    };
+    let lamports = value_t_or_exit!(matches, "lamports", u64);
     let interval = Duration::from_secs(value_t_or_exit!(matches, "interval", u64));
     let count = if matches.is_present("count") {
         Some(value_t_or_exit!(matches, "count", u64))


### PR DESCRIPTION
No strong usecase, but it's handy to able to set arbitrary number of lamports to send when `ping`-ing.

Particularly in my case, I needed this for 0 lamport while working on #6890 to create consistent flow of TXs avoiding some oneliners.