### PR TITLE
Add parent slot to getConfirmedBlock

### DIFF
--- a/client/src/rpc_request.rs
+++ b/client/src/rpc_request.rs
@@ -26,6 +26,7 @@ pub struct Response<T> {
 pub struct RpcConfirmedBlock {
     pub previous_blockhash: Hash,
     pub blockhash: Hash,
+    pub parent_slot: Slot,
     pub transactions: Vec<(Transaction, Option<RpcTransactionStatus>)>,
 }
 

--- a/client/src/rpc_request.rs
+++ b/client/src/rpc_request.rs
@@ -23,6 +23,7 @@ pub struct Response<T> {
 }
 
 #[derive(Debug, Default, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct RpcConfirmedBlock {
     pub previous_blockhash: Hash,
     pub blockhash: Hash,

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -512,7 +512,7 @@ pub trait RpcSol {
     #[rpc(meta, name = "setLogFilter")]
     fn set_log_filter(&self, _meta: Self::Metadata, filter: String) -> Result<()>;
 
-    #[rpc(meta, name = "getRpcConfirmedBlock")]
+    #[rpc(meta, name = "getConfirmedBlock")]
     fn get_confirmed_block(
         &self,
         meta: Self::Metadata,

--- a/ledger/src/blocktree.rs
+++ b/ledger/src/blocktree.rs
@@ -1148,6 +1148,7 @@ impl Blocktree {
                     .expect("Rooted parent slot must have blockhash"),
                 blockhash: get_last_hash(slot_entries.iter())
                     .expect("Rooted slot must have blockhash"),
+                parent_slot: slot_meta.parent_slot,
                 transactions: self.map_transactions_to_statuses(slot, slot_transaction_iterator),
             };
             Ok(block)

--- a/sdk/src/message.rs
+++ b/sdk/src/message.rs
@@ -124,6 +124,7 @@ fn get_program_ids(instructions: &[Instruction]) -> Vec<Pubkey> {
 }
 
 #[derive(Serialize, Deserialize, Default, Debug, PartialEq, Eq, Clone)]
+#[serde(rename_all = "camelCase")]
 pub struct MessageHeader {
     /// The number of signatures required for this message to be considered valid. The
     /// signatures must match the first `num_required_signatures` of `account_keys`.
@@ -141,6 +142,7 @@ pub struct MessageHeader {
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
+#[serde(rename_all = "camelCase")]
 pub struct Message {
     /// The message header, identifying signed and read-only `account_keys`
     /// NOTE: Serialization-related changes must be paired with the direct read at sigverify.


### PR DESCRIPTION
#### Summary of Changes
- Adds parent slot to RpcConfirmedBlock struct, and populates in blocktree
- Makes getConfirmedBlock rpc fields consistent with camelCase
- Cleans up bad text-replace in method name

Toward #6867 
