### PR TITLE
Use camelCase

### DIFF
--- a/sdk/src/instruction.rs
+++ b/sdk/src/instruction.rs
@@ -165,6 +165,7 @@ impl WithSigner for Vec<AccountMeta> {
 
 /// An instruction to execute a program
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
+#[serde(rename_all = "camelCase")]
 pub struct CompiledInstruction {
     /// Index into the transaction keys array indicating the program account that executes this instruction
     pub program_id_index: u8,


### PR DESCRIPTION
#### Problem
Missed `program_id_index`

#### Summary of Changes
camelCase for consistency in rpc `getConfirmedBlock`
