### PR TITLE
keygen: Don't create keypair files with go+r

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -1482,7 +1482,7 @@ mod tests {
     use serde_json::Value;
     use solana_client::mock_rpc_client_request::SIGNATURE;
     use solana_sdk::{
-        signature::{gen_keypair_file, read_keypair_file},
+        signature::{read_keypair_file, write_keypair_file},
         transaction::TransactionError,
     };
     use std::path::PathBuf;
@@ -1540,7 +1540,7 @@ mod tests {
 
         // Test Balance Subcommand, incl pubkey and keypair-file inputs
         let keypair_file = make_tmp_path("keypair_file");
-        gen_keypair_file(&keypair_file).unwrap();
+        write_keypair_file(&Keypair::new(), &keypair_file).unwrap();
         let keypair = read_keypair_file(&keypair_file).unwrap();
         let test_balance = test_commands.clone().get_matches_from(vec![
             "test",


### PR DESCRIPTION
`solana-keygen new` no longer creates keypair files with group/other read permission.  