### PR TITLE
Fix bank hash not changing when no internal state has changed

### DIFF
--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -454,12 +454,7 @@ impl Accounts {
 
     pub fn hash_internal_state(&self, slot_id: Slot) -> Option<BankHash> {
         let slot_hashes = self.accounts_db.slot_hashes.read().unwrap();
-        let slot_hash = slot_hashes.get(&slot_id)?;
-        if slot_hash.0 {
-            Some(slot_hash.1)
-        } else {
-            None
-        }
+        slot_hashes.get(&slot_id).cloned()
     }
 
     /// This function will prevent multiple threads from modifying the same account state at the

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -870,7 +870,7 @@ impl AccountsDB {
         let mut slot_hashes = self.slot_hashes.write().unwrap();
         let slot_hash_state = slot_hashes
             .entry(slot_id)
-            .or_insert_with(BankHash::default());
+            .or_insert_with(|| BankHash::default());
         slot_hash_state.xor(hash);
     }
 

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -868,7 +868,9 @@ impl AccountsDB {
 
     pub fn xor_in_hash_state(&self, slot_id: Slot, hash: BankHash) {
         let mut slot_hashes = self.slot_hashes.write().unwrap();
-        let slot_hash_state = slot_hashes.entry(slot_id).or_insert(BankHash::default());
+        let slot_hash_state = slot_hashes
+            .entry(slot_id)
+            .or_insert_with(BankHash::default());
         slot_hash_state.xor(hash);
     }
 

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -868,9 +868,7 @@ impl AccountsDB {
 
     pub fn xor_in_hash_state(&self, slot_id: Slot, hash: BankHash) {
         let mut slot_hashes = self.slot_hashes.write().unwrap();
-        let slot_hash_state = slot_hashes
-            .entry(slot_id)
-            .or_insert_with(|| BankHash::default());
+        let slot_hash_state = slot_hashes.entry(slot_id).or_insert_with(BankHash::default);
         slot_hash_state.xor(hash);
     }
 

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -387,7 +387,7 @@ pub struct AccountsDB {
     min_num_stores: usize,
 
     /// slot to BankHash and a status flag to indicate if the hash has been initialized or not
-    pub slot_hashes: RwLock<HashMap<Slot, (bool, BankHash)>>,
+    pub slot_hashes: RwLock<HashMap<Slot, BankHash>>,
 }
 
 impl Default for AccountsDB {
@@ -512,7 +512,7 @@ impl AccountsDB {
         let version: u64 = deserialize_from(&mut stream)
             .map_err(|_| AccountsDB::get_io_error("write version deserialize error"))?;
 
-        let slot_hash: (Slot, (bool, BankHash)) = deserialize_from(&mut stream)
+        let slot_hash: (Slot, BankHash) = deserialize_from(&mut stream)
             .map_err(|_| AccountsDB::get_io_error("slot hashes deserialize error"))?;
         self.slot_hashes
             .write()
@@ -647,7 +647,7 @@ impl AccountsDB {
         let hash = *slot_hashes
             .get(&parent_slot)
             .expect("accounts_db::set_hash::no parent slot");
-        slot_hashes.insert(slot, (false, hash.1));
+        slot_hashes.insert(slot, hash);
     }
 
     pub fn load(
@@ -859,7 +859,7 @@ impl AccountsDB {
             hash_state.xor(hash);
         }
         let slot_hashes = self.slot_hashes.read().unwrap();
-        if let Some((_, state)) = slot_hashes.get(&slot) {
+        if let Some(state) = slot_hashes.get(&slot) {
             hash_state == *state
         } else {
             false
@@ -868,11 +868,8 @@ impl AccountsDB {
 
     pub fn xor_in_hash_state(&self, slot_id: Slot, hash: BankHash) {
         let mut slot_hashes = self.slot_hashes.write().unwrap();
-        let slot_hash_state = slot_hashes
-            .entry(slot_id)
-            .or_insert((false, BankHash::default()));
-        slot_hash_state.1.xor(hash);
-        slot_hash_state.0 = true;
+        let slot_hash_state = slot_hashes.entry(slot_id).or_insert(BankHash::default());
+        slot_hash_state.xor(hash);
     }
 
     fn update_index(

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2542,7 +2542,7 @@ mod tests {
         bank1.transfer(1_000, &mint_keypair, &pubkey).unwrap();
         assert_eq!(bank0.hash_internal_state(), bank1.hash_internal_state());
 
-        // Checkpointing should always change state
+        // Checkpointing should always result in a new state
         let bank2 = new_from_parent(&Arc::new(bank1));
         assert_ne!(bank0.hash_internal_state(), bank2.hash_internal_state());
 
@@ -2563,9 +2563,12 @@ mod tests {
         bank0.transfer(1_000, &mint_keypair, &pubkey).unwrap();
 
         let bank0_state = bank0.hash_internal_state();
-        // Checkpointing should change its state
-        let bank2 = new_from_parent(&Arc::new(bank0));
+        let bank0 = Arc::new(bank0);
+        // Checkpointing should result in a new state
+        let bank2 = new_from_parent(&bank0);
         assert_ne!(bank0_state, bank2.hash_internal_state());
+        // Checkpointing should never modify the checkpoints' state
+        assert_eq!(bank0_state, bank0.hash_internal_state());
 
         let pubkey2 = Pubkey::new_rand();
         info!("transfer 2 {}", pubkey2);

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3408,10 +3408,10 @@ mod tests {
         let (genesis_config, _) = create_genesis_config(500);
         let bank0 = Arc::new(Bank::new(&genesis_config));
         bank0.freeze();
-        let bank0_hash = bank0.hash_internal_state();
+        let bank0_hash = bank0.hash();
         let bank1 = Bank::new_from_parent(&bank0, &Pubkey::default(), 1);
         bank1.freeze();
-        let bank1_hash = bank1.hash_internal_state();
+        let bank1_hash = bank1.hash();
         assert_ne!(bank0_hash, bank1_hash);
     }
 }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1359,19 +1359,19 @@ impl Bank {
     ///  of the delta of the ledger since the last vote and up to now
     fn hash_internal_state(&self) -> Hash {
         // If there are no accounts, return the hash of the previous state and the latest blockhash
-        if let Some(accounts_delta_hash) = self.rc.accounts.hash_internal_state(self.slot()) {
-            let mut signature_count_buf = [0u8; 8];
-            LittleEndian::write_u64(&mut signature_count_buf[..], self.signature_count() as u64);
-
-            hashv(&[
-                self.parent_hash.as_ref(),
-                self.last_blockhash().as_ref(),
-                accounts_delta_hash.as_ref(),
-                &signature_count_buf,
-            ])
-        } else {
-            hashv(&[self.parent_hash.as_ref(), self.last_blockhash().as_ref()])
-        }
+        let accounts_delta_hash = self
+            .rc
+            .accounts
+            .hash_internal_state(self.slot())
+            .expect("No accounts delta was found for this bank, that should not be possible");
+        let mut signature_count_buf = [0u8; 8];
+        LittleEndian::write_u64(&mut signature_count_buf[..], self.signature_count() as u64);
+        hashv(&[
+            self.parent_hash.as_ref(),
+            accounts_delta_hash.as_ref(),
+            &signature_count_buf,
+            self.last_blockhash().as_ref(),
+        ])
     }
 
     /// Recalculate the hash_internal_state from the account stores. Would be used to verify a

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2567,7 +2567,7 @@ mod tests {
         // Checkpointing should result in a new state
         let bank2 = new_from_parent(&bank0);
         assert_ne!(bank0_state, bank2.hash_internal_state());
-        // Checkpointing should never modify the checkpoints' state
+        // Checkpointing should never modify the checkpoint's state
         assert_eq!(bank0_state, bank0.hash_internal_state());
 
         let pubkey2 = Pubkey::new_rand();


### PR DESCRIPTION
#### Problem

If a bank's internal state does not change, it reports the same "bank hash" as its parent. 
This is not correct, the bank is different form its parent and so must carry a different state hash.

#### Summary of Changes

Hash the parent's hash and the parent's account state even if no internal state has changed
