### PR TITLE
Fix unpin argument

### DIFF
--- a/perf/src/cuda_runtime.rs
+++ b/perf/src/cuda_runtime.rs
@@ -160,7 +160,7 @@ impl<T: Clone> PinnedVec<T> {
     pub fn reserve_and_pin(&mut self, size: usize) {
         if self.x.capacity() < size {
             if self.pinned {
-                unpin(&mut self.x);
+                unpin(self.x.as_mut_ptr());
                 self.pinned = false;
             }
             self.x.reserve(size);

--- a/perf/src/packet.rs
+++ b/perf/src/packet.rs
@@ -153,4 +153,12 @@ mod tests {
         assert_eq!(rv[0].packets.len(), NUM_PACKETS);
         assert_eq!(rv[1].packets.len(), 1);
     }
+
+    #[test]
+    fn test_to_packets_pinning() {
+        let recycler = PacketsRecycler::default();
+        for i in 0..2 {
+            let _first_packets = Packets::new_with_recycler(recycler.clone(), i + 1, "first one");
+        }
+    }
 }


### PR DESCRIPTION
#### Problem

Crashes when pinning is enabled for unpinning pointers which are not pinned.

#### Summary of Changes

Change argument of unpin to be self.x.as_mut_ptr, not the &mut self.x borrow.

Fixes #
