### PR TITLE
Make bank weights consistent

### DIFF
--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -451,17 +451,22 @@ mod test {
         let ancestors = vec![(1, vec![0].into_iter().collect()), (0, HashSet::new())]
             .into_iter()
             .collect();
-        let (staked_lockouts, total_staked) =
+        let (staked_lockouts, total_staked, bank_weight) =
             tower.collect_vote_lockouts(1, accounts.into_iter(), &ancestors);
         assert_eq!(staked_lockouts[&0].stake, 2);
         assert_eq!(staked_lockouts[&0].lockout, 2 + 2 + 4 + 4);
         assert_eq!(total_staked, 2);
+
+        // Each acccount has 1 vote in it. After simulating a vote in collect_vote_lockouts,
+        // the account will have 2 votes, with lockout 2 + 4 = 6. So expected weight for
+        // two acccounts is 2 * 6 = 12
+        assert_eq!(bank_weight, 12)
     }
 
     #[test]
     fn test_collect_vote_lockouts_root() {
         let votes: Vec<u64> = (0..MAX_LOCKOUT_HISTORY as u64).into_iter().collect();
-        //two accounts voting for slot 0 with 1 token staked
+        //two accounts voting for slots 0..MAX_LOCKOUT_HISTORY with 1 token staked
         let accounts = gen_stakes(&[(1, &votes), (1, &votes)]);
         let mut tower = Tower::new_for_tests(0, 0.67);
         let mut ancestors = HashMap::new();
@@ -469,8 +474,21 @@ mod test {
             tower.record_vote(i as u64, Hash::default());
             ancestors.insert(i as u64, (0..i as u64).into_iter().collect());
         }
+        let root = Lockout {
+            confirmation_count: MAX_LOCKOUT_HISTORY as u32,
+            slot: 0,
+        };
+        let root_weight = root.lockout() as u128;
+        let vote_account_expected_weight = tower
+            .lockouts
+            .votes
+            .iter()
+            .map(|v| v.lockout() as u128)
+            .sum::<u128>()
+            + root_weight;
+        let expected_bank_weight = 2 * vote_account_expected_weight;
         assert_eq!(tower.lockouts.root_slot, Some(0));
-        let (staked_lockouts, _total_staked) = tower.collect_vote_lockouts(
+        let (staked_lockouts, _total_staked, bank_weight) = tower.collect_vote_lockouts(
             MAX_LOCKOUT_HISTORY as u64,
             accounts.into_iter(),
             &ancestors,
@@ -480,46 +498,7 @@ mod test {
         }
         // should be the sum of all the weights for root
         assert!(staked_lockouts[&0].lockout > (2 * (1 << MAX_LOCKOUT_HISTORY)));
-    }
-
-    #[test]
-    fn test_calculate_weight_skips_root() {
-        let mut tower = Tower::new_for_tests(0, 0.67);
-        tower.lockouts.root_slot = Some(1);
-        let stakes = vec![
-            (
-                0,
-                StakeLockout {
-                    stake: 1,
-                    lockout: 8,
-                },
-            ),
-            (
-                1,
-                StakeLockout {
-                    stake: 1,
-                    lockout: 8,
-                },
-            ),
-        ]
-        .into_iter()
-        .collect();
-        assert_eq!(tower.calculate_weight(&stakes), 0u128);
-    }
-
-    #[test]
-    fn test_calculate_weight() {
-        let tower = Tower::new_for_tests(0, 0.67);
-        let stakes = vec![(
-            0,
-            StakeLockout {
-                stake: 1,
-                lockout: 8,
-            },
-        )]
-        .into_iter()
-        .collect();
-        assert_eq!(tower.calculate_weight(&stakes), 8u128);
+        assert_eq!(bank_weight, expected_bank_weight);
     }
 
     #[test]
@@ -869,7 +848,7 @@ mod test {
         for vote in &tower_votes {
             tower.record_vote(*vote, Hash::default());
         }
-        let (staked_lockouts, total_staked) =
+        let (staked_lockouts, total_staked, _) =
             tower.collect_vote_lockouts(vote_to_evaluate, accounts.clone().into_iter(), &ancestors);
         assert!(tower.check_vote_stake_threshold(vote_to_evaluate, &staked_lockouts, total_staked));
 
@@ -877,7 +856,7 @@ mod test {
         // will expire the vote in one of the vote accounts, so we should have insufficient
         // stake to pass the threshold
         let vote_to_evaluate = VOTE_THRESHOLD_DEPTH as u64 + 1;
-        let (staked_lockouts, total_staked) =
+        let (staked_lockouts, total_staked, _) =
             tower.collect_vote_lockouts(vote_to_evaluate, accounts.into_iter(), &ancestors);
         assert!(!tower.check_vote_stake_threshold(
             vote_to_evaluate,

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -778,7 +778,7 @@ impl ReplayStage {
                     Self::confirm_forks(tower, &stake_lockouts, total_staked, progress, bank_forks);
                     stats.total_staked = total_staked;
                     stats.weight = bank_weight;
-                    datapoint_warn!(
+                    datapoint_error!(
                         "bank_weight",
                         ("slot", bank.slot(), i64),
                         // u128 too large for influx, convert to hex
@@ -817,11 +817,7 @@ impl ReplayStage {
             .filter(|s| s.is_recent && !s.has_voted && !s.vote_threshold)
             .count();
 
-        let mut candidates: Vec<_> = frozen_banks
-            .iter()
-            .zip(stats.iter())
-            .filter(|(_, stats)| stats.is_recent && !stats.has_voted)
-            .collect();
+        let mut candidates: Vec<_> = frozen_banks.iter().zip(stats.iter()).collect();
 
         //highest weight, lowest slot first
         candidates.sort_by_key(|b| (b.1.weight, 0i64 - b.1.slot as i64));

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -770,14 +770,20 @@ impl ReplayStage {
 
                 if !stats.computed {
                     stats.slot = bank.slot();
-                    let (stake_lockouts, total_staked) = tower.collect_vote_lockouts(
+                    let (stake_lockouts, total_staked, bank_weight) = tower.collect_vote_lockouts(
                         bank.slot(),
                         bank.vote_accounts().into_iter(),
                         &ancestors,
                     );
                     Self::confirm_forks(tower, &stake_lockouts, total_staked, progress, bank_forks);
                     stats.total_staked = total_staked;
-                    stats.weight = tower.calculate_weight(&stake_lockouts);
+                    stats.weight = bank_weight;
+                    datapoint_warn!(
+                        "bank_weight",
+                        ("slot", bank.slot(), i64),
+                        // u128 too large for influx, convert to hex
+                        ("weight", format!("{:X}", stats.weight), String),
+                    );
                     stats.stake_lockouts = stake_lockouts;
                     stats.block_height = bank.block_height();
                 }

--- a/ledger/src/bank_forks.rs
+++ b/ledger/src/bank_forks.rs
@@ -174,6 +174,7 @@ impl BankForks {
         root: Slot,
         snapshot_package_sender: &Option<SnapshotPackageSender>,
     ) {
+        info!("set root: {}", root);
         self.root = root;
         let set_root_start = Instant::now();
         let root_bank = self
@@ -193,7 +194,6 @@ impl BankForks {
         // of banks since the last snapshot
         if self.snapshot_config.is_some() && snapshot_package_sender.is_some() {
             let config = self.snapshot_config.as_ref().unwrap();
-            info!("setting snapshot root: {}", root);
             if root - self.last_snapshot_slot >= config.snapshot_interval_slots as Slot {
                 let mut snapshot_time = Measure::start("total-snapshot-ms");
                 let r = self.generate_snapshot(


### PR DESCRIPTION
#### Problem
Bank weights can vary between validators based on voting behavior. This potentially leads to different validators picking different forks, even though they observed the same banks

#### Summary of Changes
1) Remove dependency on voting behavior in calculation of bank state.
2) Log bank weight in Grafana

Fixes #
