### PR TITLE
datapoint for best fork weight and slot in replay

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -889,6 +889,11 @@ impl ReplayStage {
                 if child_stats.is_locked_out || !child_stats.vote_threshold {
                     continue;
                 }
+                datapoint_info!(
+                    "replay_stage-pick_best_fork",
+                    ("slot", best_bank.slot(), i64),
+                    ("weight", child_stats.weight, f64),
+                );
                 inc_new_counter_info!("replay_stage-pick_best_fork-child", 1);
                 debug!("best bank found child: {}", child_stats.slot);
                 vote = Some(((*child).clone(), child_stats.total_staked));


### PR DESCRIPTION
#### Problem

No way to see if weight calculations are consistent in the dashboard.

#### Summary of Changes

Add datapoint for weight and slot.

Fixes #
