### PR TITLE
validator/: Clean up --gossip-port argument

### DIFF
--- a/clap-utils/src/input_validators.rs
+++ b/clap-utils/src/input_validators.rs
@@ -48,3 +48,9 @@ pub fn is_release_channel(channel: &str) -> Result<(), String> {
         _ => Err(format!("Invalid release channel {}", channel)),
     }
 }
+
+pub fn is_port(port: String) -> Result<(), String> {
+    port.parse::<u16>()
+        .map(|_| ())
+        .map_err(|e| format!("{:?}", e))
+}

--- a/net-utils/src/lib.rs
+++ b/net-utils/src/lib.rs
@@ -176,6 +176,10 @@ pub fn parse_host(host: &str) -> Result<IpAddr, String> {
     }
 }
 
+pub fn is_host(string: String) -> Result<(), String> {
+    parse_host(&string).map(|_| ())
+}
+
 pub fn parse_host_port(host_port: &str) -> Result<SocketAddr, String> {
     let addrs: Vec<_> = host_port
         .to_socket_addrs()
@@ -189,8 +193,7 @@ pub fn parse_host_port(host_port: &str) -> Result<SocketAddr, String> {
 }
 
 pub fn is_host_port(string: String) -> Result<(), String> {
-    parse_host_port(&string)?;
-    Ok(())
+    parse_host_port(&string).map(|_| ())
 }
 
 #[cfg(windows)]

--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -238,7 +238,8 @@ EOF
       multinode-demo/setup.sh "${args[@]}"
     fi
     args=(
-      --gossip-port "$entrypointIp":8001
+      --gossip-host "$entrypointIp"
+      --gossip-port 8001
       --init-complete-file "$initCompleteFile"
     )
 


### PR DESCRIPTION
--gossip-port now specifies exactly that, the gossip port to use.  The new --gossip-host argument can be used to specify the DNS name/IP address for gossip if --entrypoint is not supplied (when --entrypoint is supplied, the gossip address is automatically set to the node's ip address as observed by the entrypoint)

