### PR TITLE
Fix num nodes metrics

### DIFF
--- a/core/src/cluster_info.rs
+++ b/core/src/cluster_info.rs
@@ -745,7 +745,11 @@ impl ClusterInfo {
         let (peers, peers_and_stakes) = self.sorted_tvu_peers_and_stakes(stakes);
         let broadcast_len = peers_and_stakes.len();
         if broadcast_len == 0 {
-            datapoint_debug!("cluster_info-num_nodes", ("count", 1, i64));
+            datapoint_debug!(
+                "cluster_info-num_nodes",
+                ("live_count", 1, i64),
+                ("broadcast_count", 1, i64)
+            );
             return Ok(());
         }
         let mut packets: Vec<_> = shreds
@@ -769,13 +773,17 @@ impl ClusterInfo {
         }
 
         let mut num_live_peers = 1i64;
-        len = peers.iter().for_each(|p| {
+        peers.iter().for_each(|p| {
             // A peer is considered live if they generated their contact info recently
             if timestamp() - p.wallclock <= CRDS_GOSSIP_PULL_CRDS_TIMEOUT_MS {
                 num_live_peers += 1;
             }
         });
-        datapoint_debug!("cluster_info-num_nodes", ("count", num_live_peers, i64));
+        datapoint_debug!(
+            "cluster_info-num_nodes",
+            ("live_count", num_live_peers, i64),
+            ("broadcast_count", broadcast_len + 1, i64)
+        );
         Ok(())
     }
 

--- a/core/src/cluster_info.rs
+++ b/core/src/cluster_info.rs
@@ -768,7 +768,14 @@ impl ClusterInfo {
             }
         }
 
-        datapoint_debug!("cluster_info-num_nodes", ("count", broadcast_len + 1, i64));
+        let mut num_live_peers = 1i64;
+        len = peers.iter().for_each(|p| {
+            // A peer is considered live if they generated their contact info recently
+            if timestamp() - p.wallclock <= CRDS_GOSSIP_PULL_CRDS_TIMEOUT_MS {
+                num_live_peers += 1;
+            }
+        });
+        datapoint_debug!("cluster_info-num_nodes", ("count", num_live_peers, i64));
         Ok(())
     }
 

--- a/metrics/scripts/grafana-provisioning/dashboards/testnet-monitor.json
+++ b/metrics/scripts/grafana-provisioning/dashboards/testnet-monitor.json
@@ -236,7 +236,7 @@
           "hide": false,
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "SELECT LAST(median) FROM ( SELECT median(count) FROM \"$testnet\".\"autogen\".\"cluster_info-num_nodes\" WHERE $timeFilter AND count > 0 GROUP BY time(5s) )\n",
+          "query": "SELECT LAST(median) FROM ( SELECT median(live_count) FROM \"$testnet\".\"autogen\".\"cluster_info-num_nodes\" WHERE $timeFilter AND live_count > 0 GROUP BY time(5s) )\n",
           "rawQuery": true,
           "refId": "A",
           "resultFormat": "time_series",
@@ -1713,9 +1713,47 @@
           "hide": false,
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "SELECT median(\"count\") AS \"total\" FROM \"$testnet\".\"autogen\".\"cluster_info-num_nodes\" WHERE $timeFilter AND count > 0 GROUP BY time(5s)",
+          "query": "SELECT median(\"broadcast_count\") AS \"broadcast_total\" FROM \"$testnet\".\"autogen\".\"cluster_info-num_nodes\" WHERE $timeFilter AND broadcast_count > 0 GROUP BY time(5s)",
           "rawQuery": true,
-          "refId": "C",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT median(\"live_count\") AS \"live_total\" FROM \"$testnet\".\"autogen\".\"cluster_info-num_nodes\" WHERE $timeFilter AND live_count > 0 GROUP BY time(5s)",
+          "rawQuery": true,
+          "refId": "B",
           "resultFormat": "time_series",
           "select": [
             [


### PR DESCRIPTION
#### Problem

Since ContactInfo timeouts have been increased to 1 epoch, if a node leaves the cluster, the num_nodes metric will not reflect that correctly.

#### Summary of Changes

- Compute the list of live peers from the list of peers that were broadcasted to
- Add both broadcasted count and live node count to metrics

![image](https://user-images.githubusercontent.com/44789711/69281262-d421a580-0b9c-11ea-8cbc-a6220d0c2b29.png)
