### PR TITLE
Copy all programs when starting a network

### DIFF
--- a/scripts/cargo-install-all.sh
+++ b/scripts/cargo-install-all.sh
@@ -111,6 +111,6 @@ fi
 
 set -x
 mkdir -p "$installDir/bin/deps"
-cp -fv "$programDir/target/release/deps/libsolana*program.*" "$installDir/bin/deps"
+cp -fv "target/release/deps/libsolana*program.*" "$installDir/bin/deps"
 
 echo "Done after $SECONDS seconds"

--- a/scripts/cargo-install-all.sh
+++ b/scripts/cargo-install-all.sh
@@ -109,24 +109,8 @@ if [[ -d target/perf-libs ]]; then
   cp -a target/perf-libs "$installDir"/bin/perf-libs
 fi
 
-for dir in programs/*; do
-  for program in echo target/$buildVariant/deps/libsolana_"$(basename "$dir")".{so,dylib,dll}; do
-    if [[ -f $program ]]; then
-      mkdir -p "$installDir/bin/deps"
-      rm -f "$installDir/bin/deps/$(basename "$program")"
-      cp -v "$program" "$installDir"/bin/deps
-    fi
-  done
-done
-
-for dir in programs/*; do
-  for program in echo programs/"$(basename "$dir")"/target/$buildVariant/deps/libsolana_"$(basename "$dir")".{so,dylib,dll}; do
-    if [[ -f $program ]]; then
-      mkdir -p "$installDir/bin/deps"
-      rm -f "$installDir/bin/deps/$(basename "$program")"
-      cp -v "$program" "$installDir"/bin/deps
-    fi
-  done
-done
+set -x
+mkdir -p "$installDir/bin/deps"
+cp -fv "$programDir/target/release/deps/libsolana*program.*" "$installDir/bin/deps"
 
 echo "Done after $SECONDS seconds"

--- a/scripts/cargo-install-custom-programs.sh
+++ b/scripts/cargo-install-custom-programs.sh
@@ -18,4 +18,4 @@ programDir="$2"
 
 set -x
 mkdir -p "$installDir/bin/deps"
-cp -fv $programDir/target/release/deps/libsolana*program.* "$installDir"/bin/deps
+cp -fv "$programDir/target/release/deps/libsolana*program.*" "$installDir/bin/deps"

--- a/scripts/cargo-install-custom-programs.sh
+++ b/scripts/cargo-install-custom-programs.sh
@@ -16,15 +16,6 @@ programDir="$2"
   cargo build --release
 )
 
-for dir in "$programDir"/*; do
-  for program in $programDir/target/release/deps/lib"$(basename "$dir")".{so,dylib,dll}; do
-    if [[ -f $program ]]; then
-      (
-        set -x
-        mkdir -p "$installDir/bin/deps"
-        rm -f "$installDir/bin/deps/$(basename "$program")"
-        cp -v "$program" "$installDir"/bin/deps
-      )
-    fi
-  done
-done
+set -x
+mkdir -p "$installDir/bin/deps"
+cp -fv $programDir/target/release/deps/libsolana*program.* "$installDir"/bin/deps


### PR DESCRIPTION
#### Problem

When starting a network the program binaries are copied over to the nodes.  But, the script that does it assumes that all programs have a directory name that ends with "_program" and that isn't the case anymore

#### Summary of Changes

Copy all the programs based on our known program binary signature

Fixes #
