### PR TITLE
Allow vest's terminator to recapture tokens

### DIFF
--- a/programs/vest/src/vest_instruction.rs
+++ b/programs/vest/src/vest_instruction.rs
@@ -57,6 +57,9 @@ pub enum VestInstruction {
     /// already vested are unaffected. Use this instead of `Terminate` to minimize
     /// the number of token transfers.
     Renege(u64),
+
+    /// Mark all available tokens as redeemable, regardless of the date.
+    VestAll,
 }
 
 fn initialize_account(
@@ -153,4 +156,12 @@ pub fn renege(contract: &Pubkey, from: &Pubkey, to: &Pubkey, lamports: u64) -> I
         account_metas.push(AccountMeta::new(*to, false));
     }
     Instruction::new(id(), &VestInstruction::Renege(lamports), account_metas)
+}
+
+pub fn vest_all(contract: &Pubkey, from: &Pubkey) -> Instruction {
+    let account_metas = vec![
+        AccountMeta::new(*contract, false),
+        AccountMeta::new(*from, true),
+    ];
+    Instruction::new(id(), &VestInstruction::VestAll, account_metas)
 }

--- a/programs/vest/src/vest_instruction.rs
+++ b/programs/vest/src/vest_instruction.rs
@@ -52,6 +52,11 @@ pub enum VestInstruction {
     /// Tell the contract that the `InitializeAccount` with `Signature` has been
     /// signed by the containing transaction's `Pubkey`.
     Terminate,
+
+    /// Reduce total_lamports by the given number of lamports. Tokens that have
+    /// already vested are unaffected. Use this instead of `Terminate` to minimize
+    /// the number of token transfers.
+    Renege(u64),
 }
 
 fn initialize_account(
@@ -137,4 +142,15 @@ pub fn terminate(contract: &Pubkey, from: &Pubkey, to: &Pubkey) -> Instruction {
         account_metas.push(AccountMeta::new(*to, false));
     }
     Instruction::new(id(), &VestInstruction::Terminate, account_metas)
+}
+
+pub fn renege(contract: &Pubkey, from: &Pubkey, to: &Pubkey, lamports: u64) -> Instruction {
+    let mut account_metas = vec![
+        AccountMeta::new(*contract, false),
+        AccountMeta::new(*from, true),
+    ];
+    if from != to {
+        account_metas.push(AccountMeta::new(*to, false));
+    }
+    Instruction::new(id(), &VestInstruction::Renege(lamports), account_metas)
 }

--- a/programs/vest/src/vest_processor.rs
+++ b/programs/vest/src/vest_processor.rs
@@ -78,6 +78,7 @@ pub fn process_instruction(
             date_pubkey,
             total_lamports,
             redeemed_lamports: 0,
+            reneged_lamports: 0,
         }
     } else {
         VestState::deserialize(&contract_account.data)?
@@ -121,7 +122,20 @@ pub fn process_instruction(
             } else {
                 terminator_account
             };
-            vest_state.terminate(contract_account, payee_account);
+            vest_state.renege(contract_account, payee_account, contract_account.lamports);
+        }
+        VestInstruction::Renege(lamports) => {
+            let terminator_account = verify_signed_account(
+                next_keyed_account(keyed_accounts_iter)?,
+                &vest_state.terminator_pubkey,
+            )?;
+            let payee_keyed_account = keyed_accounts_iter.next();
+            let payee_account = if let Some(payee_keyed_account) = payee_keyed_account {
+                &mut payee_keyed_account.account
+            } else {
+                terminator_account
+            };
+            vest_state.renege(contract_account, payee_account, lamports);
         }
     }
 
@@ -620,6 +634,51 @@ mod tests {
         let carol_pubkey = Pubkey::new_rand();
         let instruction =
             vest_instruction::terminate(&contract_pubkey, &alice_pubkey, &carol_pubkey);
+        bank_client
+            .send_instruction(&alice_keypair, instruction)
+            .unwrap();
+        assert_eq!(bank_client.get_balance(&alice_pubkey).unwrap(), 1);
+        assert_eq!(bank_client.get_balance(&carol_pubkey).unwrap(), 1);
+        assert_eq!(
+            bank_client.get_account_data(&contract_pubkey).unwrap(),
+            None
+        );
+        assert_eq!(bank_client.get_account_data(&bob_pubkey).unwrap(), None);
+    }
+
+    #[test]
+    fn test_renege_and_send_funds() {
+        let (bank_client, alice_keypair) = create_bank_client(3);
+        let alice_pubkey = alice_keypair.pubkey();
+        let contract_keypair = Keypair::new();
+        let contract_pubkey = contract_keypair.pubkey();
+        let bob_pubkey = Pubkey::new_rand();
+        let start_date = Utc::now().date();
+
+        let date_keypair = Keypair::new();
+        let date_pubkey = date_keypair.pubkey();
+
+        let current_date = Utc.ymd(2019, 1, 1);
+        create_date_account(&bank_client, &date_keypair, &alice_keypair, current_date).unwrap();
+
+        create_vest_account(
+            &bank_client,
+            &contract_keypair,
+            &alice_keypair,
+            &alice_pubkey,
+            &bob_pubkey,
+            start_date,
+            &date_pubkey,
+            1,
+        )
+        .unwrap();
+        assert_eq!(bank_client.get_balance(&alice_pubkey).unwrap(), 1);
+        assert_eq!(bank_client.get_balance(&contract_pubkey).unwrap(), 1);
+
+        // Now, renege on a token. carol gets it.
+        let carol_pubkey = Pubkey::new_rand();
+        let instruction =
+            vest_instruction::renege(&contract_pubkey, &alice_pubkey, &carol_pubkey, 1);
         bank_client
             .send_instruction(&alice_keypair, instruction)
             .unwrap();

--- a/programs/vest/src/vest_processor.rs
+++ b/programs/vest/src/vest_processor.rs
@@ -111,20 +111,12 @@ pub fn process_instruction(
             )?;
             vest_state.redeem_tokens(contract_account, current_date, payee_account);
         }
-        VestInstruction::Terminate => {
-            let terminator_account = verify_signed_account(
-                next_keyed_account(keyed_accounts_iter)?,
-                &vest_state.terminator_pubkey,
-            )?;
-            let payee_keyed_account = keyed_accounts_iter.next();
-            let payee_account = if let Some(payee_keyed_account) = payee_keyed_account {
-                &mut payee_keyed_account.account
+        VestInstruction::Terminate | VestInstruction::Renege(_) => {
+            let lamports = if let VestInstruction::Renege(lamports) = instruction {
+                lamports
             } else {
-                terminator_account
+                contract_account.lamports
             };
-            vest_state.renege(contract_account, payee_account, contract_account.lamports);
-        }
-        VestInstruction::Renege(lamports) => {
             let terminator_account = verify_signed_account(
                 next_keyed_account(keyed_accounts_iter)?,
                 &vest_state.terminator_pubkey,

--- a/programs/vest/src/vest_processor.rs
+++ b/programs/vest/src/vest_processor.rs
@@ -77,8 +77,7 @@ pub fn process_instruction(
             start_date_time,
             date_pubkey,
             total_lamports,
-            redeemed_lamports: 0,
-            reneged_lamports: 0,
+            ..VestState::default()
         }
     } else {
         VestState::deserialize(&contract_account.data)?
@@ -128,6 +127,13 @@ pub fn process_instruction(
                 terminator_account
             };
             vest_state.renege(contract_account, payee_account, lamports);
+        }
+        VestInstruction::VestAll => {
+            verify_signed_account(
+                next_keyed_account(keyed_accounts_iter)?,
+                &vest_state.terminator_pubkey,
+            )?;
+            vest_state.vest_all();
         }
     }
 

--- a/programs/vest/src/vest_state.rs
+++ b/programs/vest/src/vest_state.rs
@@ -8,6 +8,7 @@ use chrono::{
 };
 use serde_derive::{Deserialize, Serialize};
 use solana_sdk::{account::Account, instruction::InstructionError, pubkey::Pubkey};
+use std::cmp::min;
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct VestState {
@@ -29,6 +30,9 @@ pub struct VestState {
 
     /// The number of lamports the payee has already redeemed
     pub redeemed_lamports: u64,
+
+    /// The number of lamports the terminator repurchased
+    pub reneged_lamports: u64,
 }
 
 impl Default for VestState {
@@ -40,6 +44,7 @@ impl Default for VestState {
             date_pubkey: Pubkey::default(),
             total_lamports: 0,
             redeemed_lamports: 0,
+            reneged_lamports: 0,
         }
     }
 }
@@ -53,13 +58,7 @@ impl VestState {
         deserialize(input).map_err(|_| InstructionError::InvalidAccountData)
     }
 
-    /// Redeem vested tokens.
-    pub fn redeem_tokens(
-        &mut self,
-        contract_account: &mut Account,
-        current_date: Date<Utc>,
-        payee_account: &mut Account,
-    ) {
+    fn calc_vested_lamports(&self, current_date: Date<Utc>) -> u64 {
         let schedule = create_vesting_schedule(self.start_date_time.date(), self.total_lamports);
 
         let vested_lamports = schedule
@@ -68,6 +67,17 @@ impl VestState {
             .map(|(_, lamports)| lamports)
             .sum::<u64>();
 
+        min(vested_lamports, self.total_lamports - self.reneged_lamports)
+    }
+
+    /// Redeem vested tokens.
+    pub fn redeem_tokens(
+        &mut self,
+        contract_account: &mut Account,
+        current_date: Date<Utc>,
+        payee_account: &mut Account,
+    ) {
+        let vested_lamports = self.calc_vested_lamports(current_date);
         let redeemable_lamports = vested_lamports.saturating_sub(self.redeemed_lamports);
 
         contract_account.lamports -= redeemable_lamports;
@@ -76,10 +86,18 @@ impl VestState {
         self.redeemed_lamports += redeemable_lamports;
     }
 
-    /// Terminate the contract and return all tokens to the given pubkey.
-    pub fn terminate(&mut self, contract_account: &mut Account, payee_account: &mut Account) {
-        payee_account.lamports += contract_account.lamports;
-        contract_account.lamports = 0;
+    /// Renege on the given number of tokens and send them to the given payee.
+    pub fn renege(
+        &mut self,
+        contract_account: &mut Account,
+        payee_account: &mut Account,
+        lamports: u64,
+    ) {
+        let reneged_lamports = min(contract_account.lamports, lamports);
+        payee_account.lamports += reneged_lamports;
+        contract_account.lamports -= reneged_lamports;
+
+        self.reneged_lamports += reneged_lamports;
     }
 }
 
@@ -88,6 +106,7 @@ mod test {
     use super::*;
     use crate::id;
     use solana_sdk::account::Account;
+    use solana_sdk::system_program;
 
     #[test]
     fn test_serializer() {
@@ -106,5 +125,28 @@ mod test {
             b.serialize(&mut a.data),
             Err(InstructionError::AccountDataTooSmall)
         );
+    }
+
+    #[test]
+    fn test_schedule_after_renege() {
+        let total_lamports = 3;
+        let mut contract_account = Account::new(total_lamports, 512, &id());
+        let mut payee_account = Account::new(0, 0, &system_program::id());
+        let mut vest_state = VestState {
+            total_lamports,
+            start_date_time: Utc.ymd(2019, 1, 1).and_hms(0, 0, 0),
+            ..VestState::default()
+        };
+        vest_state.serialize(&mut contract_account.data).unwrap();
+        let current_date = Utc.ymd(2020, 1, 1);
+        assert_eq!(vest_state.calc_vested_lamports(current_date), 1);
+
+        // Verify vesting schedule is calculated with original amount.
+        vest_state.renege(&mut contract_account, &mut payee_account, 1);
+        assert_eq!(vest_state.calc_vested_lamports(current_date), 1);
+        assert_eq!(vest_state.reneged_lamports, 1);
+
+        // Verify reneged tokens aren't redeemable.
+        assert_eq!(vest_state.calc_vested_lamports(Utc.ymd(2022, 1, 1)), 2);
     }
 }


### PR DESCRIPTION
#### Problem

Reducing the tokens in a `vest` contract currently requires terminating it. If tokens were purchased upfront, terminating has the look of repurchasing *all* the tokens, even though recreating the second contract likely represents a wash trade.

#### Summary of Changes

* Rather than hoping the double-transfer implies a wash trade, add an instruction that allows a terminator to recapture only a portion of the vest tokens.
* Also, add a `VestAll` instruction for when it's practical to get tokens into a plain old system account.