### PR TITLE
Allow secure keypair input for solana-validator cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3878,6 +3878,7 @@ dependencies = [
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-crate-features 0.21.0",
  "solana-logger 0.21.0",
+ "tiny-bip39 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -135,6 +135,15 @@ dependencies = [
 
 [[package]]
 name = "base64"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "safemem 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "base64"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -2123,8 +2132,13 @@ name = "pbkdf2"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
+ "base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "crypto-mac 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hmac 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "subtle 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2406,6 +2420,18 @@ dependencies = [
  "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2776,6 +2802,11 @@ dependencies = [
 [[package]]
 name = "ryu"
 version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "safemem"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -3197,8 +3228,10 @@ name = "solana-clap-utils"
 version = "0.21.0"
 dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rpassword 4.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-sdk 0.21.0",
+ "tiny-bip39 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3859,12 +3892,14 @@ dependencies = [
  "ed25519-dalek 1.0.0-pre.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "generic-array 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hmac 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "memmap 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pbkdf2 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5377,6 +5412,7 @@ dependencies = [
 "checksum backtrace-sys 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)" = "5d6575f128516de27e3ce99689419835fce9643a9b215a14d2b5b685be018491"
 "checksum base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
 "checksum base64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
+"checksum base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "489d6c0ed21b11d038c31b6ceccca973e65d73ba3bd8ecb9a2babf5546164643"
 "checksum bech32 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "58946044516aa9dc922182e0d6e9d124a31aafe6b421614654eb27cf90cec09c"
 "checksum bincode 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b8ab639324e3ee8774d296864fbc0dbbb256cf1a41c490b94cba90c082915f92"
 "checksum bindgen 0.49.2 (registry+https://github.com/rust-lang/crates.io-index)" = "846a1fba6535362a01487ef6b10f0275faa12e5c5d835c5c1c627aabc46ccbd6"
@@ -5630,6 +5666,7 @@ dependencies = [
 "checksum quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
 "checksum radix_trie 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "ebcf72e767017c1aa4b63d4dd0b0b836a243b648fd81d41c6bf6e850ef7a95c7"
 "checksum rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
+"checksum rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c618c47cd3ebd209790115ab837de41425723956ad3ce2e6a7f09890947cacb9"
 "checksum rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
 "checksum rand 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d47eab0e83d9693d40f825f86948aa16eff6750ead4bdffc4ab95b8b3a7f052c"
 "checksum rand04 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "58595cc8bb12add45412667f9b422d5a9842d61d36e8607bc7c84ff738bf9263"
@@ -5668,6 +5705,7 @@ dependencies = [
 "checksum rustls 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b25a18b1bf7387f0145e7f8324e700805aade3842dd3db2e74e4cdeb4677c09e"
 "checksum rusty-fork 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3dd93264e10c577503e926bd1430193eeb5d21b059148910082245309b424fae"
 "checksum ryu 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c92464b447c0ee8c4fb3824ecc8383b81717b9f1e74ba2e72540aef7b9f82997"
+"checksum safemem 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
 "checksum same-file 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "585e8ddcedc187886a30fa705c47985c3fa88d06624095856b36ca0b82ff4421"
 "checksum scoped_threadpool 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "1d51f5df5af43ab3f1360b429fa5e0152ac5ce8c0bd6485cae490332e96846a8"
 "checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -135,15 +135,6 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "safemem 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "base64"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -2132,13 +2123,8 @@ name = "pbkdf2"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "crypto-mac 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "hmac 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "subtle 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2420,18 +2406,6 @@ dependencies = [
  "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "rand"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2802,11 +2776,6 @@ dependencies = [
 [[package]]
 name = "ryu"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "safemem"
-version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -5412,7 +5381,6 @@ dependencies = [
 "checksum backtrace-sys 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)" = "5d6575f128516de27e3ce99689419835fce9643a9b215a14d2b5b685be018491"
 "checksum base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
 "checksum base64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
-"checksum base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "489d6c0ed21b11d038c31b6ceccca973e65d73ba3bd8ecb9a2babf5546164643"
 "checksum bech32 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "58946044516aa9dc922182e0d6e9d124a31aafe6b421614654eb27cf90cec09c"
 "checksum bincode 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b8ab639324e3ee8774d296864fbc0dbbb256cf1a41c490b94cba90c082915f92"
 "checksum bindgen 0.49.2 (registry+https://github.com/rust-lang/crates.io-index)" = "846a1fba6535362a01487ef6b10f0275faa12e5c5d835c5c1c627aabc46ccbd6"
@@ -5666,7 +5634,6 @@ dependencies = [
 "checksum quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
 "checksum radix_trie 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "ebcf72e767017c1aa4b63d4dd0b0b836a243b648fd81d41c6bf6e850ef7a95c7"
 "checksum rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
-"checksum rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c618c47cd3ebd209790115ab837de41425723956ad3ce2e6a7f09890947cacb9"
 "checksum rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
 "checksum rand 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d47eab0e83d9693d40f825f86948aa16eff6750ead4bdffc4ab95b8b3a7f052c"
 "checksum rand04 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "58595cc8bb12add45412667f9b422d5a9842d61d36e8607bc7c84ff738bf9263"
@@ -5705,7 +5672,6 @@ dependencies = [
 "checksum rustls 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b25a18b1bf7387f0145e7f8324e700805aade3842dd3db2e74e4cdeb4677c09e"
 "checksum rusty-fork 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3dd93264e10c577503e926bd1430193eeb5d21b059148910082245309b424fae"
 "checksum ryu 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c92464b447c0ee8c4fb3824ecc8383b81717b9f1e74ba2e72540aef7b9f82997"
-"checksum safemem 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
 "checksum same-file 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "585e8ddcedc187886a30fa705c47985c3fa88d06624095856b36ca0b82ff4421"
 "checksum scoped_threadpool 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "1d51f5df5af43ab3f1360b429fa5e0152ac5ce8c0bd6485cae490332e96846a8"
 "checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"

--- a/book/src/running-validator/validator-start.md
+++ b/book/src/running-validator/validator-start.md
@@ -76,19 +76,19 @@ Then use one of the following commands, depending on your installation choice, t
 If this is a `solana-install`-installation:
 
 ```bash
-solana-validator --identity ~/validator-keypair.json --voting-keypair ~/validator-vote-keypair.json --ledger ~/validator-config --rpc-port 8899 --entrypoint testnet.solana.com:8001
+solana-validator --identity-keypair ~/validator-keypair.json --voting-keypair ~/validator-vote-keypair.json --ledger ~/validator-config --rpc-port 8899 --entrypoint testnet.solana.com:8001
 ```
 
 Alternatively, the `solana-install run` command can be used to run the validator node while periodically checking for and applying software updates:
 
 ```bash
-solana-install run solana-validator -- --identity ~/validator-keypair.json --voting-keypair ~/validator-vote-keypair.json --ledger ~/validator-config --rpc-port 8899 --entrypoint testnet.solana.com:8001
+solana-install run solana-validator -- --identity-keypair ~/validator-keypair.json --voting-keypair ~/validator-vote-keypair.json --ledger ~/validator-config --rpc-port 8899 --entrypoint testnet.solana.com:8001
 ```
 
 If you built from source:
 
 ```bash
-NDEBUG=1 USE_INSTALL=1 ./multinode-demo/validator.sh --identity ~/validator-keypair.json --voting-keypair ~/validator-vote-keypair.json --rpc-port 8899 --entrypoint testnet.solana.com:8001
+NDEBUG=1 USE_INSTALL=1 ./multinode-demo/validator.sh --identity-keypair ~/validator-keypair.json --voting-keypair ~/validator-vote-keypair.json --rpc-port 8899 --entrypoint testnet.solana.com:8001
 ```
 
 ### Enabling CUDA

--- a/book/src/running-validator/validator-testnet.md
+++ b/book/src/running-validator/validator-testnet.md
@@ -63,7 +63,7 @@ solana balance # Same result as command above
 Solana-gossip and solana-validator commands already require an explicit `--entrypoint` argument. Simply replace testnet.solana.com in the examples with an alternate url to interact with a different testnet. For example:
 
 ```bash
-solana-validator --identity ~/validator-keypair.json --voting-keypair ~/validator-vote-keypair.json --ledger ~/validator-config --rpc-port 8899 beta.testnet.solana.com
+solana-validator --identity-keypair ~/validator-keypair.json --voting-keypair ~/validator-vote-keypair.json --ledger ~/validator-config --rpc-port 8899 beta.testnet.solana.com
 ```
 
 You can also submit JSON-RPC requests to a different testnet, like:

--- a/clap-utils/Cargo.toml
+++ b/clap-utils/Cargo.toml
@@ -10,8 +10,10 @@ edition = "2018"
 
 [dependencies]
 clap = "2.33.0"
+rpassword = "4.0"
 semver = "0.9.0"
 solana-sdk = { path = "../sdk", version = "0.21.0" }
+tiny-bip39 = "0.6.2"
 url = "2.1.0"
 
 [lib]

--- a/clap-utils/src/keypair.rs
+++ b/clap-utils/src/keypair.rs
@@ -2,28 +2,28 @@ use bip39::{Language, Mnemonic, Seed};
 use clap::values_t;
 use rpassword::prompt_password_stderr;
 use solana_sdk::signature::{
-    keypair_from_mnemonic_and_passphrase, keypair_from_seed, read_keypair_file, Keypair,
+    keypair_from_seed_phrase_and_passphrase, keypair_from_seed, read_keypair_file, Keypair,
     KeypairUtil,
 };
 use std::error;
 
-pub const ASK_MNEMONIC_ARG: &str = "ask_mnemonic";
-pub const SKIP_MNEMONIC_VALIDATION_ARG: &str = "skip_mnemonic_validation";
+pub const ASK_SEED_PHRASE_ARG: &str = "ask_seed_phrase";
+pub const SKIP_SEED_PHRASE_VALIDATION_ARG: &str = "skip_seed_phrase_validation";
 
-/// Reads user input from stdin to retrieve a mnemonic and passphrase for keypair derivation
-pub fn keypair_from_mnemonic(
+/// Reads user input from stdin to retrieve a seed phrase and passphrase for keypair derivation
+pub fn keypair_from_seed_phrase(
     keypair_name: &str,
     skip_validation: bool,
 ) -> Result<Keypair, Box<dyn error::Error>> {
-    let mnemonic_phrase = prompt_password_stderr(&format!("[{}] mnemonic phrase: ", keypair_name))?;
-    let mnemonic_phrase = mnemonic_phrase.trim();
+    let seed_phrase = prompt_password_stderr(&format!("[{}] seed phrase: ", keypair_name))?;
+    let seed_phrase = seed_phrase.trim();
 
     if skip_validation {
         let passphrase =
             prompt_password_stderr(&format!("[{}] (optional) passphrase: ", keypair_name))?;
-        keypair_from_mnemonic_and_passphrase(&mnemonic_phrase, &passphrase)
+        keypair_from_seed_phrase_and_passphrase(&seed_phrase, &passphrase)
     } else {
-        let mnemonic = Mnemonic::from_phrase(mnemonic_phrase, Language::English)?;
+        let mnemonic = Mnemonic::from_phrase(seed_phrase, Language::English)?;
         let passphrase =
             prompt_password_stderr(&format!("[{}] (optional) passphrase: ", keypair_name))?;
         let seed = Seed::new(&mnemonic, &passphrase);
@@ -50,24 +50,24 @@ pub fn keypair_input(
     matches: &clap::ArgMatches,
     keypair_name: &str,
 ) -> Result<KeypairWithGenerated, Box<dyn error::Error>> {
-    let mnemonic_matches =
-        values_t!(matches.values_of(ASK_MNEMONIC_ARG), String).unwrap_or_default();
+    let ask_seed_phrase_matches =
+        values_t!(matches.values_of(ASK_SEED_PHRASE_ARG), String).unwrap_or_default();
     let keypair_match_name = keypair_name.replace('-', "_");
-    if mnemonic_matches.iter().any(|s| s.as_str() == keypair_name) {
+    if ask_seed_phrase_matches.iter().any(|s| s.as_str() == keypair_name) {
         if matches.value_of(keypair_match_name).is_some() {
-            let ask_mnemonic_kebab = ASK_MNEMONIC_ARG.replace('_', "-");
+            let ask_seed_phrase_kebab = ASK_SEED_PHRASE_ARG.replace('_', "-");
             clap::Error::with_description(
                 &format!(
                     "`--{} {}` cannot be used with `{} <PATH>`",
-                    ask_mnemonic_kebab, keypair_name, keypair_name
+                    ask_seed_phrase_kebab, keypair_name, keypair_name
                 ),
                 clap::ErrorKind::ArgumentConflict,
             )
             .exit();
         }
 
-        let skip_validation = matches.is_present(SKIP_MNEMONIC_VALIDATION_ARG);
-        keypair_from_mnemonic(keypair_name, skip_validation)
+        let skip_validation = matches.is_present(SKIP_SEED_PHRASE_VALIDATION_ARG);
+        keypair_from_seed_phrase(keypair_name, skip_validation)
             .map(|keypair| KeypairWithGenerated::new(keypair, false))
     } else if let Some(keypair_file) = matches.value_of(keypair_match_name) {
         read_keypair_file(keypair_file).map(|keypair| KeypairWithGenerated::new(keypair, false))

--- a/clap-utils/src/keypair.rs
+++ b/clap-utils/src/keypair.rs
@@ -1,0 +1,78 @@
+use bip39::{Language, Mnemonic, Seed};
+use clap::values_t;
+use rpassword::prompt_password_stderr;
+use solana_sdk::signature::{
+    keypair_from_mnemonic_and_passphrase, keypair_from_seed, read_keypair_file, Keypair,
+    KeypairUtil,
+};
+use std::{
+    error,
+    io::{stdin, stdout, Write},
+};
+
+/// Reads user input from stdin to retrieve a mnemonic and passphrase for keypair derivation
+pub fn keypair_from_mnemonic(keypair_name: &str) -> Result<Keypair, Box<dyn error::Error>> {
+    let mnemonic_phrase =
+        prompt_password_stderr(&format!("[{}] mnemonic phrase: ", keypair_name)).unwrap();
+    match Mnemonic::from_phrase(mnemonic_phrase.trim(), Language::English) {
+        Ok(mnemonic) => {
+            let passphrase =
+                prompt_password_stderr(&format!("[{}] (optional) passphrase: ", keypair_name))
+                    .unwrap();
+            let seed = Seed::new(&mnemonic, &passphrase);
+            keypair_from_seed(seed.as_bytes())
+        }
+        Err(err) => {
+            print!(
+                "[{}] mnemonic phrase validation failed, continue anyways? (y/n): ",
+                keypair_name
+            );
+            stdout().flush().unwrap();
+
+            let mut buffer = String::new();
+            stdin().read_line(&mut buffer).unwrap();
+            if buffer.trim() != "y" {
+                return Err(err.into());
+            }
+
+            let passphrase =
+                prompt_password_stderr(&format!("[{}] (optional) passphrase: ", keypair_name))
+                    .unwrap();
+
+            keypair_from_mnemonic_and_passphrase(&mnemonic_phrase, &passphrase)
+        }
+    }
+}
+
+/// Checks CLI arguments to determine whether a keypair should be:
+///   - inputted securely via stdin,
+///   - read in from a file,
+///   - or newly generated
+///
+/// Returns the keypair result and whether it was generated.
+pub fn keypair_input(
+    matches: &clap::ArgMatches,
+    keypair_name: &str,
+) -> Result<(Keypair, bool), Box<dyn error::Error>> {
+    let mnemonic_matches =
+        values_t!(matches.values_of("mnemonic_stdin"), String).unwrap_or_default();
+    let keypair_match_name = keypair_name.replace('-', "_");
+    if mnemonic_matches.iter().any(|s| s.as_str() == keypair_name) {
+        if matches.value_of(keypair_match_name).is_some() {
+            clap::Error::with_description(
+                &format!(
+                    "`--mnemonic-stdin {}` cannot be used with `{} <PATH>`",
+                    keypair_name, keypair_name
+                ),
+                clap::ErrorKind::ArgumentConflict,
+            )
+            .exit();
+        }
+
+        keypair_from_mnemonic(keypair_name).map(|keypair| (keypair, false))
+    } else if let Some(keypair_file) = matches.value_of(keypair_match_name) {
+        read_keypair_file(keypair_file).map(|keypair| (keypair, false))
+    } else {
+        Ok((Keypair::new(), true))
+    }
+}

--- a/clap-utils/src/keypair.rs
+++ b/clap-utils/src/keypair.rs
@@ -75,3 +75,16 @@ pub fn keypair_input(
         Ok(KeypairWithGenerated::new(Keypair::new(), true))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::ArgMatches;
+
+    #[test]
+    fn test_keypair_input() {
+        let arg_matches = ArgMatches::default();
+        let KeypairWithGenerated { generated, .. } = keypair_input(&arg_matches, "").unwrap();
+        assert!(generated);
+    }
+}

--- a/clap-utils/src/keypair.rs
+++ b/clap-utils/src/keypair.rs
@@ -5,39 +5,29 @@ use solana_sdk::signature::{
     keypair_from_mnemonic_and_passphrase, keypair_from_seed, read_keypair_file, Keypair,
     KeypairUtil,
 };
-use std::{
-    error,
-    io::{stdin, stdout, Write},
-};
+use std::error;
+
+pub const ASK_MNEMONIC_ARG: &str = "ask_mnemonic";
+pub const SKIP_MNEMONIC_VALIDATION_ARG: &str = "skip_mnemonic_validation";
 
 /// Reads user input from stdin to retrieve a mnemonic and passphrase for keypair derivation
-pub fn keypair_from_mnemonic(keypair_name: &str) -> Result<Keypair, Box<dyn error::Error>> {
+pub fn keypair_from_mnemonic(
+    keypair_name: &str,
+    skip_validation: bool,
+) -> Result<Keypair, Box<dyn error::Error>> {
     let mnemonic_phrase = prompt_password_stderr(&format!("[{}] mnemonic phrase: ", keypair_name))?;
-    match Mnemonic::from_phrase(mnemonic_phrase.trim(), Language::English) {
-        Ok(mnemonic) => {
-            let passphrase =
-                prompt_password_stderr(&format!("[{}] (optional) passphrase: ", keypair_name))?;
-            let seed = Seed::new(&mnemonic, &passphrase);
-            keypair_from_seed(seed.as_bytes())
-        }
-        Err(err) => {
-            print!(
-                "Your mnemonic phrase failed to validate with the official BIP39 English word list.
-If your phrase used a different word list, you can optionally continue. (y/n): "
-            );
-            stdout().flush()?;
+    let mnemonic_phrase = mnemonic_phrase.trim();
 
-            let mut buffer = String::new();
-            stdin().read_line(&mut buffer)?;
-            if buffer.trim().to_lowercase() != "y" {
-                return Err(err.into());
-            }
-
-            let passphrase =
-                prompt_password_stderr(&format!("[{}] (optional) passphrase: ", keypair_name))?;
-
-            keypair_from_mnemonic_and_passphrase(&mnemonic_phrase, &passphrase)
-        }
+    if skip_validation {
+        let passphrase =
+            prompt_password_stderr(&format!("[{}] (optional) passphrase: ", keypair_name))?;
+        keypair_from_mnemonic_and_passphrase(&mnemonic_phrase, &passphrase)
+    } else {
+        let mnemonic = Mnemonic::from_phrase(mnemonic_phrase, Language::English)?;
+        let passphrase =
+            prompt_password_stderr(&format!("[{}] (optional) passphrase: ", keypair_name))?;
+        let seed = Seed::new(&mnemonic, &passphrase);
+        keypair_from_seed(seed.as_bytes())
     }
 }
 
@@ -51,21 +41,24 @@ pub fn keypair_input(
     matches: &clap::ArgMatches,
     keypair_name: &str,
 ) -> Result<(Keypair, bool), Box<dyn error::Error>> {
-    let mnemonic_matches = values_t!(matches.values_of("ask_mnemonic"), String).unwrap_or_default();
+    let mnemonic_matches =
+        values_t!(matches.values_of(ASK_MNEMONIC_ARG), String).unwrap_or_default();
     let keypair_match_name = keypair_name.replace('-', "_");
     if mnemonic_matches.iter().any(|s| s.as_str() == keypair_name) {
         if matches.value_of(keypair_match_name).is_some() {
+            let ask_mnemonic_kebab = ASK_MNEMONIC_ARG.replace('_', "-");
             clap::Error::with_description(
                 &format!(
-                    "`--ask-mnemonic {}` cannot be used with `{} <PATH>`",
-                    keypair_name, keypair_name
+                    "`--{} {}` cannot be used with `{} <PATH>`",
+                    ask_mnemonic_kebab, keypair_name, keypair_name
                 ),
                 clap::ErrorKind::ArgumentConflict,
             )
             .exit();
         }
 
-        keypair_from_mnemonic(keypair_name).map(|keypair| (keypair, false))
+        let skip_validation = matches.is_present(SKIP_MNEMONIC_VALIDATION_ARG);
+        keypair_from_mnemonic(keypair_name, skip_validation).map(|keypair| (keypair, false))
     } else if let Some(keypair_file) = matches.value_of(keypair_match_name) {
         read_keypair_file(keypair_file).map(|keypair| (keypair, false))
     } else {

--- a/clap-utils/src/keypair.rs
+++ b/clap-utils/src/keypair.rs
@@ -38,10 +38,7 @@ pub struct KeypairWithGenerated {
 
 impl KeypairWithGenerated {
     fn new(keypair: Keypair, generated: bool) -> Self {
-        Self {
-            keypair,
-            generated,
-        }
+        Self { keypair, generated }
     }
 }
 

--- a/clap-utils/src/lib.rs
+++ b/clap-utils/src/lib.rs
@@ -19,3 +19,4 @@ macro_rules! version {
 
 pub mod input_parsers;
 pub mod input_validators;
+pub mod keypair;

--- a/multinode-demo/bootstrap-leader.sh
+++ b/multinode-demo/bootstrap-leader.sh
@@ -76,10 +76,10 @@ ledger_dir="$SOLANA_CONFIG_DIR"/bootstrap-leader
 args+=(
   --accounts "$SOLANA_CONFIG_DIR"/bootstrap-leader/accounts
   --enable-rpc-exit
-  --identity "$identity_keypair"
   --ledger "$ledger_dir"
   --rpc-port 8899
   --snapshot-interval-slots 100
+  --identity-keypair "$identity_keypair"
   --storage-keypair "$storage_keypair"
   --voting-keypair "$vote_keypair"
   --rpc-drone-address 127.0.0.1:9900

--- a/multinode-demo/validator.sh
+++ b/multinode-demo/validator.sh
@@ -70,7 +70,7 @@ while [[ -n $1 ]]; do
     elif [[ $1 = --expected-genesis-hash ]]; then
       args+=("$1" "$2")
       shift 2
-    elif [[ $1 = --identity ]]; then
+    elif [[ $1 = --identity-keypair ]]; then
       identity_keypair_path=$2
       args+=("$1" "$2")
       shift 2
@@ -170,7 +170,7 @@ fi
 
 if [[ -n $REQUIRE_KEYPAIRS ]]; then
   if [[ -z $identity_keypair_path ]]; then
-    usage "Error: --identity not specified"
+    usage "Error: --identity-keypair not specified"
   fi
   if [[ -z $voting_keypair_path ]]; then
     usage "Error: --voting-keypair not specified"
@@ -209,7 +209,7 @@ if ((airdrops_enabled)); then
   default_arg --rpc-drone-address "$drone_address"
 fi
 
-default_arg --identity "$identity_keypair_path"
+default_arg --identity-keypair "$identity_keypair_path"
 default_arg --voting-keypair "$voting_keypair_path"
 default_arg --storage-keypair "$storage_keypair_path"
 default_arg --ledger "$ledger_dir"

--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -304,7 +304,7 @@ EOF
     if [[ ! -f config/validator-identity.json ]]; then
       solana-keygen new -o config/validator-identity.json
     fi
-    args+=(--identity config/validator-identity.json)
+    args+=(--identity-keypair config/validator-identity.json)
 
     if [[ $airdropsEnabled != true ]]; then
       args+=(--no-airdrop)

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -376,6 +376,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-mac"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "subtle 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "ct-logs"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -680,6 +689,15 @@ dependencies = [
 name = "hex"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "hmac"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crypto-mac 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "http"
@@ -1067,6 +1085,15 @@ dependencies = [
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "pbkdf2"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crypto-mac 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1557,7 +1584,7 @@ version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "solana-bpf-loader-api"
+name = "solana-bpf-loader-program"
 version = "0.21.0"
 dependencies = [
  "bincode 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1571,23 +1598,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-bpf-loader-program"
-version = "0.21.0"
-dependencies = [
- "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-bpf-loader-api 0.21.0",
- "solana-logger 0.21.0",
- "solana-sdk 0.21.0",
-]
-
-[[package]]
 name = "solana-bpf-programs"
 version = "0.21.0"
 dependencies = [
  "bincode 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "elf 0.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-bpf-loader-api 0.21.0",
+ "solana-bpf-loader-program 0.21.0",
  "solana-logger 0.21.0",
  "solana-runtime 0.21.0",
  "solana-sdk 0.21.0",
@@ -1704,13 +1721,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-config-api"
+name = "solana-config-program"
 version = "0.21.0"
 dependencies = [
  "bincode 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-logger 0.21.0",
  "solana-sdk 0.21.0",
 ]
 
@@ -1793,17 +1811,14 @@ dependencies = [
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-bpf-loader-api 0.21.0",
  "solana-bpf-loader-program 0.21.0",
  "solana-logger 0.21.0",
  "solana-measure 0.21.0",
  "solana-metrics 0.21.0",
  "solana-rayon-threadlimit 0.21.0",
  "solana-sdk 0.21.0",
- "solana-stake-api 0.21.0",
  "solana-stake-program 0.21.0",
- "solana-storage-api 0.21.0",
- "solana-vote-api 0.21.0",
+ "solana-storage-program 0.21.0",
  "solana-vote-program 0.21.0",
  "sys-info 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1820,11 +1835,14 @@ dependencies = [
  "ed25519-dalek 1.0.0-pre.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "generic-array 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hmac 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "memmap 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pbkdf2 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1841,35 +1859,25 @@ name = "solana-sdk-bpf-test"
 version = "0.21.0"
 
 [[package]]
-name = "solana-stake-api"
-version = "0.21.0"
-dependencies = [
- "bincode 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-config-api 0.21.0",
- "solana-logger 0.21.0",
- "solana-metrics 0.21.0",
- "solana-sdk 0.21.0",
- "solana-vote-api 0.21.0",
-]
-
-[[package]]
 name = "solana-stake-program"
 version = "0.21.0"
 dependencies = [
+ "bincode 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-config-program 0.21.0",
  "solana-logger 0.21.0",
+ "solana-metrics 0.21.0",
  "solana-sdk 0.21.0",
- "solana-stake-api 0.21.0",
+ "solana-vote-program 0.21.0",
 ]
 
 [[package]]
-name = "solana-storage-api"
+name = "solana-storage-program"
 version = "0.21.0"
 dependencies = [
  "bincode 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1880,21 +1888,6 @@ dependencies = [
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-logger 0.21.0",
- "solana-sdk 0.21.0",
-]
-
-[[package]]
-name = "solana-vote-api"
-version = "0.21.0"
-dependencies = [
- "bincode 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-logger 0.21.0",
- "solana-metrics 0.21.0",
  "solana-sdk 0.21.0",
 ]
 
@@ -1902,10 +1895,15 @@ dependencies = [
 name = "solana-vote-program"
 version = "0.21.0"
 dependencies = [
+ "bincode 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-logger 0.21.0",
+ "solana-metrics 0.21.0",
  "solana-sdk 0.21.0",
- "solana-vote-api 0.21.0",
 ]
 
 [[package]]
@@ -1949,6 +1947,11 @@ dependencies = [
 [[package]]
 name = "strsim"
 version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "subtle"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -2611,6 +2614,7 @@ dependencies = [
 "checksum crossbeam-epoch 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "fedcd6772e37f3da2a9af9bf12ebe046c0dfe657992377b4df982a2b54cd37a9"
 "checksum crossbeam-queue 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7c979cd6cfe72335896575c6b5688da489e420d36a27a0b9eb0c73db574b4a4b"
 "checksum crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)" = "04973fa96e96579258a5091af6003abde64af786b860f18622b82e026cca60e6"
+"checksum crypto-mac 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4434400df11d95d556bac068ddfedd482915eb18fe8bea89bc80b6e4b1c179e5"
 "checksum ct-logs 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4d3686f5fa27dbc1d76c751300376e167c5a43387f44bb451fd1c24776e49113"
 "checksum curve25519-dalek 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8b7dcd30ba50cdf88b55b033456138b7c0ac4afdc436d82e1b79f370f24cc66d"
 "checksum digest 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "03b072242a8cbaf9c145665af9d250c59af3b958f83ed6824e13533cf76d5b90"
@@ -2646,6 +2650,7 @@ dependencies = [
 "checksum hash32 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "12d790435639c06a7b798af9e1e331ae245b7ef915b92f70a39b4cf8c00686af"
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
 "checksum hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "023b39be39e3a2da62a94feb433e91e8bcd37676fbc8bea371daf52b7a769a3e"
+"checksum hmac 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5dcb5e64cda4c23119ab41ba960d1e170a774c8e4b9d9e6a9bc18aabf5e59695"
 "checksum http 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)" = "372bcb56f939e449117fb0869c2e8fd8753a8223d92a172c6e808cf123a5b6e4"
 "checksum http-body 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6741c859c1b2463a423a1dbce98d418e6c3c3fc720fb0d45528657320920292d"
 "checksum httparse 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "cd179ae861f0c2e53da70d892f5f3029f9594be0c41dc5269cd371691b1dc2f9"
@@ -2689,6 +2694,7 @@ dependencies = [
 "checksum owning_ref 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "49a4b8ea2179e6a2e27411d3bca09ca6dd630821cf6894c6c7c8467a8ee7ef13"
 "checksum parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ab41b4aed082705d1056416ae4468b6ea99d52599ecf3169b00088d43113e337"
 "checksum parking_lot_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "94c8c7923936b28d546dfd14d4472eaf34c99b14e1c973a32b3e6d4eb04298c9"
+"checksum pbkdf2 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "006c038a43a45995a9670da19e67600114740e8511d4333bf97a56e66a7542d9"
 "checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 "checksum percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 "checksum ppv-lite86 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e3cbf9f658cdb5000fcf6f362b8ea2ba154b9f146a61c7a20d647034c6b6561b"
@@ -2750,6 +2756,7 @@ dependencies = [
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 "checksum string 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d24114bfcceb867ca7f71a0d3fe45d45619ec47a6fbfa98cb14e14250bfa5d6d"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+"checksum subtle 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
 "checksum subtle 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "01f40907d9ffc762709e4ff3eb4a6f6b41b650375a3f09ac92b641942b7fb082"
 "checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
 "checksum syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)" = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"

--- a/run.sh
+++ b/run.sh
@@ -99,7 +99,7 @@ solana-drone --keypair "$dataDir"/faucet-keypair.json &
 drone=$!
 
 args=(
-  --identity "$dataDir"/leader-keypair.json
+  --identity-keypair "$dataDir"/leader-keypair.json
   --storage-keypair "$dataDir"/leader-storage-account-keypair.json
   --voting-keypair "$dataDir"/leader-vote-account-keypair.json
   --ledger "$ledgerDir"

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -38,7 +38,7 @@ log = { version = "0.4.8" }
 memmap = { version = "0.6.2", optional = true }
 num-derive = { version = "0.3" }
 num-traits = { version = "0.2" }
-pbkdf2 = "0.3.0"
+pbkdf2 = { version = "0.3.0", default-features = false }
 rand = { version = "0.6.5", optional = true }
 rand_chacha = { version = "0.1.1", optional = true }
 serde = "1.0.102"

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -49,3 +49,6 @@ sha2 = "0.8.0"
 ed25519-dalek = { version = "1.0.0-pre.1", optional = true }
 solana-logger = { path = "../logger", version = "0.21.0", optional = true }
 solana-crate-features = { path = "../crate-features", version = "0.21.0", optional = true }
+
+[dev-dependencies]
+tiny-bip39 = "0.6.2"

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -31,12 +31,14 @@ bs58 = "0.3.0"
 byteorder = { version = "1.3.2", optional = true }
 generic-array = { version = "0.13.2", default-features = false, features = ["serde", "more_lengths"] }
 hex = "0.4.0"
+hmac = "0.7.0"
 itertools = { version = "0.8.1" }
 lazy_static = "1.4.0"
 log = { version = "0.4.8" }
 memmap = { version = "0.6.2", optional = true }
 num-derive = { version = "0.3" }
 num-traits = { version = "0.2" }
+pbkdf2 = "0.3.0"
 rand = { version = "0.6.5", optional = true }
 rand_chacha = { version = "0.1.1", optional = true }
 serde = "1.0.102"

--- a/sdk/src/signature.rs
+++ b/sdk/src/signature.rs
@@ -328,7 +328,8 @@ mod tests {
         let passphrase = "42";
         let seed = Seed::new(&mnemonic, passphrase);
         let expected_keypair = keypair_from_seed(seed.as_bytes()).unwrap();
-        let keypair = keypair_from_seed_phrase_and_passphrase(mnemonic.phrase(), passphrase).unwrap();
+        let keypair =
+            keypair_from_seed_phrase_and_passphrase(mnemonic.phrase(), passphrase).unwrap();
         assert_eq!(keypair.pubkey(), expected_keypair.pubkey());
     }
 }

--- a/sdk/src/signature.rs
+++ b/sdk/src/signature.rs
@@ -187,8 +187,8 @@ pub fn keypair_from_seed(seed: &[u8]) -> Result<Keypair, Box<dyn error::Error>> 
     Ok(keypair)
 }
 
-pub fn keypair_from_mnemonic_and_passphrase(
-    mnemonic: &str,
+pub fn keypair_from_seed_phrase_and_passphrase(
+    seed_phrase: &str,
     passphrase: &str,
 ) -> Result<Keypair, Box<dyn error::Error>> {
     const PBKDF2_ROUNDS: usize = 2048;
@@ -198,7 +198,7 @@ pub fn keypair_from_mnemonic_and_passphrase(
 
     let mut seed = vec![0u8; PBKDF2_BYTES];
     pbkdf2::pbkdf2::<Hmac<sha2::Sha512>>(
-        mnemonic.as_bytes(),
+        seed_phrase.as_bytes(),
         salt.as_bytes(),
         PBKDF2_ROUNDS,
         &mut seed,
@@ -323,12 +323,12 @@ mod tests {
     }
 
     #[test]
-    fn test_keypair_from_mnemonic_and_passphrase() {
+    fn test_keypair_from_seed_phrase_and_passphrase() {
         let mnemonic = Mnemonic::new(MnemonicType::Words12, Language::English);
         let passphrase = "42";
         let seed = Seed::new(&mnemonic, passphrase);
         let expected_keypair = keypair_from_seed(seed.as_bytes()).unwrap();
-        let keypair = keypair_from_mnemonic_and_passphrase(mnemonic.phrase(), passphrase).unwrap();
+        let keypair = keypair_from_seed_phrase_and_passphrase(mnemonic.phrase(), passphrase).unwrap();
         assert_eq!(keypair.pubkey(), expected_keypair.pubkey());
     }
 }

--- a/sdk/src/signature.rs
+++ b/sdk/src/signature.rs
@@ -209,6 +209,7 @@ pub fn keypair_from_mnemonic_and_passphrase(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use bip39::{Language, Mnemonic, MnemonicType, Seed};
     use std::mem;
 
     fn tmp_file_path(name: &str) -> String {
@@ -319,5 +320,15 @@ mod tests {
             signature_base58_str.parse::<Signature>(),
             Err(ParseSignatureError::Invalid)
         );
+    }
+
+    #[test]
+    fn test_keypair_from_mnemonic_and_passphrase() {
+        let mnemonic = Mnemonic::new(MnemonicType::Words12, Language::English);
+        let passphrase = "42";
+        let seed = Seed::new(&mnemonic, passphrase);
+        let expected_keypair = keypair_from_seed(seed.as_bytes()).unwrap();
+        let keypair = keypair_from_mnemonic_and_passphrase(mnemonic.phrase(), passphrase).unwrap();
+        assert_eq!(keypair.pubkey(), expected_keypair.pubkey());
     }
 }

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -30,8 +30,8 @@ solana-runtime = { path = "../runtime", version = "0.21.0" }
 solana-sdk = { path = "../sdk", version = "0.21.0" }
 solana-vote-program = { path = "../programs/vote", version = "0.21.0" }
 solana-vote-signer = { path = "../vote-signer", version = "0.21.0" }
-tempfile = "3.1.0"
 tar = "0.4.26"
+tempfile = "3.1.0"
 
 [target."cfg(unix)".dependencies]
 gag = "0.1.10"

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -6,7 +6,9 @@ use log::*;
 use solana_clap_utils::{
     input_parsers::pubkey_of,
     input_validators::{is_keypair, is_pubkey_or_keypair},
-    keypair::{keypair_input, ASK_MNEMONIC_ARG, SKIP_MNEMONIC_VALIDATION_ARG},
+    keypair::{
+        keypair_input, KeypairWithGenerated, ASK_MNEMONIC_ARG, SKIP_MNEMONIC_VALIDATION_ARG,
+    },
 };
 use solana_client::rpc_client::RpcClient;
 use solana_core::{
@@ -542,19 +544,21 @@ pub fn main() {
                 eprintln!("Identity keypair input failed: {}", err);
                 exit(1);
             })
-            .0,
+            .keypair,
     );
-    let (voting_keypair, ephemeral_voting_keypair) = keypair_input(&matches, "voting-keypair")
-        .unwrap_or_else(|err| {
-            eprintln!("Voting keypair input failed: {}", err);
-            exit(1);
-        });
+    let KeypairWithGenerated {
+        keypair: voting_keypair,
+        generated: ephemeral_voting_keypair,
+    } = keypair_input(&matches, "voting-keypair").unwrap_or_else(|err| {
+        eprintln!("Voting keypair input failed: {}", err);
+        exit(1);
+    });
     let storage_keypair = keypair_input(&matches, "storage-keypair")
         .unwrap_or_else(|err| {
             eprintln!("Storage keypair input failed: {}", err);
             exit(1);
         })
-        .0;
+        .keypair;
 
     let ledger_path = PathBuf::from(matches.value_of("ledger_path").unwrap());
     let entrypoint = matches.value_of("entrypoint");

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -7,7 +7,7 @@ use solana_clap_utils::{
     input_parsers::pubkey_of,
     input_validators::{is_keypair, is_pubkey_or_keypair},
     keypair::{
-        keypair_input, KeypairWithGenerated, ASK_MNEMONIC_ARG, SKIP_MNEMONIC_VALIDATION_ARG,
+        keypair_input, KeypairWithGenerated, ASK_SEED_PHRASE_ARG, SKIP_SEED_PHRASE_VALIDATION_ARG,
     },
 };
 use solana_client::rpc_client::RpcClient;
@@ -326,19 +326,19 @@ pub fn main() {
                 .help("Stream entries to this unix domain socket path")
         )
         .arg(
-            Arg::with_name(ASK_MNEMONIC_ARG)
-                .long("ask-mnemonic")
+            Arg::with_name(ASK_SEED_PHRASE_ARG)
+                .long("ask-seed-phrase")
                 .value_name("KEYPAIR NAME")
                 .multiple(true)
                 .takes_value(true)
                 .possible_values(&["identity-keypair", "storage-keypair", "voting-keypair"])
-                .help("Securely input a mnemonic code and optional passphrase for a keypair"),
+                .help("Securely recover a keypair using a seed phrase and optional passphrase"),
         )
         .arg(
-            Arg::with_name(SKIP_MNEMONIC_VALIDATION_ARG)
-                .long("skip-mnemonic-validation")
-                .requires(ASK_MNEMONIC_ARG)
-                .help("Skip validation of mnemonic phrases. Use this if your phrase does not use the BIP39 official English word list"),
+            Arg::with_name(SKIP_SEED_PHRASE_VALIDATION_ARG)
+                .long("skip-seed-phrase-validation")
+                .requires(ASK_SEED_PHRASE_ARG)
+                .help("Skip validation of seed phrases. Use this if your phrase does not use the BIP39 official English word list"),
         )
         .arg(
             Arg::with_name("identity_keypair")

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -6,7 +6,7 @@ use log::*;
 use solana_clap_utils::{
     input_parsers::pubkey_of,
     input_validators::{is_keypair, is_pubkey_or_keypair},
-    keypair::keypair_input,
+    keypair::{keypair_input, ASK_MNEMONIC_ARG, SKIP_MNEMONIC_VALIDATION_ARG},
 };
 use solana_client::rpc_client::RpcClient;
 use solana_core::{
@@ -324,13 +324,19 @@ pub fn main() {
                 .help("Stream entries to this unix domain socket path")
         )
         .arg(
-            Arg::with_name("ask_mnemonic")
+            Arg::with_name(ASK_MNEMONIC_ARG)
                 .long("ask-mnemonic")
                 .value_name("KEYPAIR NAME")
                 .multiple(true)
                 .takes_value(true)
                 .possible_values(&["identity-keypair", "storage-keypair", "voting-keypair"])
                 .help("Securely input a mnemonic code and optional passphrase for a keypair"),
+        )
+        .arg(
+            Arg::with_name(SKIP_MNEMONIC_VALIDATION_ARG)
+                .long("skip-mnemonic-validation")
+                .requires(ASK_MNEMONIC_ARG)
+                .help("Skip validation of mnemonic phrases. Use this if your phrase does not use the BIP39 official English word list"),
         )
         .arg(
             Arg::with_name("identity_keypair")


### PR DESCRIPTION
#### Problem
Our CLI tools don't facilitate inputting key pairs directly from seed

#### Summary of Changes
- Rename `--identity` arg for `solana-validator` to `--identity-keypair`
- Add utilities for secure keypair input using the BIP39 standard in `solana-clap-utils`
- Add a `--skip-seed-phrase-validation` cli arg to allow seed phrases from other word lists
- Add a `--ask-seed-phrase` cli arg which accepts "keypair names". The valid values will be specific to the CLI this new arg is used in. For example, I've updated `solana-validator` to accept seed phrase input for `identity-keypair`, `storage-keypair`, and `voting-keypair`. Invocation looks like this:

```
solana-validator --ask-seed-phrase identity-keypair storage-keypair --voting-keypair ~/.config/solana/id.json --ledger tmp`
```

In the above example, the identity and storage keypairs will be inputted securely and the voting keypair will be read from a file.

#### Features
* Optional passphrase (used as a salt for key derivation)
* Option to bypass validation when using a different word list from what our CLI expects (non-English for example)

```
[identity-keypair] seed phrase: 
[identity-keypair] (optional) passphrase: 
```

Related to #6870
(Full fix involves more CLI tools)