### PR TITLE
Avoid jemalloc in windows build

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -70,6 +70,8 @@ tokio-io = "0.1"
 untrusted = "0.7.0"
 solana-rayon-threadlimit = { path = "../rayon-threadlimit", version = "0.21.0" }
 reed-solomon-erasure = { package = "solana-reed-solomon-erasure", version = "4.0.1-3", features = ["simd-accel"] }
+
+[target."cfg(unix)".dependencies]
 jemallocator = "0.3.2"
 jemalloc-ctl = "0.3.2"
 

--- a/core/src/cluster_info.rs
+++ b/core/src/cluster_info.rs
@@ -1220,7 +1220,7 @@ impl ClusterInfo {
         response_sender: &PacketSender,
     ) {
         // iter over the packets, collect pulls separately and process everything else
-        let allocated = thread_mem_usage::Allocatedp::new();
+        let allocated = thread_mem_usage::Allocatedp::default();
         let mut gossip_pull_data: Vec<PullData> = vec![];
         packets.packets.iter().for_each(|packet| {
             let from_addr = packet.meta.addr();

--- a/core/src/cluster_info.rs
+++ b/core/src/cluster_info.rs
@@ -30,7 +30,6 @@ use crate::{
 use bincode::{serialize, serialized_size};
 use core::cmp;
 use itertools::Itertools;
-use jemalloc_ctl::thread::allocatedp;
 use rand::{thread_rng, Rng};
 use solana_ledger::{bank_forks::BankForks, blocktree::Blocktree, staking_utils};
 use solana_metrics::{datapoint_debug, inc_new_counter_debug, inc_new_counter_error};
@@ -1221,8 +1220,7 @@ impl ClusterInfo {
         response_sender: &PacketSender,
     ) {
         // iter over the packets, collect pulls separately and process everything else
-        let allocated = allocatedp::mib().unwrap();
-        let allocated = allocated.read().unwrap();
+        let allocated = thread_mem_usage::Allocatedp::new();
         let mut gossip_pull_data: Vec<PullData> = vec![];
         packets.packets.iter().for_each(|packet| {
             let from_addr = packet.meta.addr();

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -85,7 +85,9 @@ extern crate solana_metrics;
 #[macro_use]
 extern crate matches;
 
+#[cfg(unix)]
 extern crate jemallocator;
 
+#[cfg(unix)]
 #[global_allocator]
 static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -219,7 +219,7 @@ impl ReplayStage {
                 let mut last_reset = Hash::default();
                 let mut partition = false;
                 loop {
-                    let allocated = thread_mem_usage::Allocatedp::new();
+                    let allocated = thread_mem_usage::Allocatedp::default();
 
                     thread_mem_usage::datapoint("solana-replay-stage");
                     let now = Instant::now();

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -9,7 +9,6 @@ use crate::{
     rpc_subscriptions::RpcSubscriptions,
     thread_mem_usage,
 };
-use jemalloc_ctl::thread::allocatedp;
 use solana_ledger::{
     bank_forks::BankForks,
     block_error::BlockError,
@@ -220,8 +219,7 @@ impl ReplayStage {
                 let mut last_reset = Hash::default();
                 let mut partition = false;
                 loop {
-                    let allocated = allocatedp::mib().unwrap();
-                    let allocated = allocated.read().unwrap();
+                    let allocated = thread_mem_usage::Allocatedp::new();
 
                     thread_mem_usage::datapoint("solana-replay-stage");
                     let now = Instant::now();

--- a/core/src/thread_mem_usage.rs
+++ b/core/src/thread_mem_usage.rs
@@ -1,9 +1,39 @@
+#[cfg(unix)]
 use jemalloc_ctl::thread;
-use solana_metrics::datapoint_debug;
 
-pub fn datapoint(name: &'static str) {
-    let allocated = thread::allocatedp::mib().unwrap();
-    let allocated = allocated.read().unwrap();
-    let mem = allocated.get();
-    datapoint_debug!("thread-memory", (name, mem as i64, i64));
+pub fn datapoint(_name: &'static str) {
+    #[cfg(unix)]
+    {
+        let allocated = thread::allocatedp::mib().unwrap();
+        let allocated = allocated.read().unwrap();
+        let mem = allocated.get();
+        solana_metrics::datapoint_debug!("thread-memory", (_name, mem as i64, i64));
+    }
+}
+
+pub struct Allocatedp {
+    #[cfg(unix)]
+    allocated: thread::ThreadLocal<u64>,
+}
+
+impl Allocatedp {
+    pub fn new() -> Self {
+        #[cfg(unix)]
+        {
+            let allocated = thread::allocatedp::mib().unwrap();
+            let allocated = allocated.read().unwrap();
+            Self { allocated }
+        }
+        #[cfg(not(unix))]
+        Self {}
+    }
+
+    pub fn get(&self) -> u64 {
+        #[cfg(unix)]
+        {
+            self.allocated.get()
+        }
+        #[cfg(not(unix))]
+        0
+    }
 }

--- a/core/src/thread_mem_usage.rs
+++ b/core/src/thread_mem_usage.rs
@@ -17,7 +17,7 @@ pub struct Allocatedp {
 }
 
 impl Allocatedp {
-    pub fn new() -> Self {
+    pub fn default() -> Self {
         #[cfg(unix)]
         {
             let allocated = thread::allocatedp::mib().unwrap();


### PR DESCRIPTION
jemalloc crate is not usable in windows, stub it out when `cfg(not(unix))`