### PR TITLE
Correctly indicate genesis activation_epoch

### DIFF
--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -571,7 +571,11 @@ pub fn process_show_stake_account(
             }
             println!(
                 "stake activates starting from epoch: {}",
-                stake.activation_epoch
+                (if stake.activation_epoch < std::u64::MAX {
+                    format!("{}", stake.activation_epoch)
+                } else {
+                    "0 (Genesis)".to_string()
+                })
             );
             if stake.deactivation_epoch < std::u64::MAX {
                 println!(

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -571,11 +571,11 @@ pub fn process_show_stake_account(
             }
             println!(
                 "stake activates starting from epoch: {}",
-                (if stake.activation_epoch < std::u64::MAX {
-                    format!("{}", stake.activation_epoch)
+                if stake.activation_epoch < std::u64::MAX {
+                    stake.activation_epoch
                 } else {
-                    "0 (Genesis)".to_string()
-                })
+                    0
+                }
             );
             if stake.deactivation_epoch < std::u64::MAX {
                 println!(


### PR DESCRIPTION
#### Problem

Our precious bootstrap stakers can get confused when running `$ ./solana show-stake-account`:

```
ryoqun@ubuqun:~/work/solana/solana/for-small-patches$ solana show-stake-account ./config/run/leader-stake-account-keypair.json
RPC Endpoint: http://127.0.0.1:8899
total stake: 0.5 SOL
credits observed: 0
delegated stake: 0.5 SOL
delegated voter pubkey: B1q1SRYQP86aAsSZuQHV9rdTbxcCBTrefQS2YgBD6h7p
stake activates starting from epoch: 18446744073709551615
authorized staker: 4v8w4YZR4e8cagWjegC9paLVQzQE3xkYeW4adUAR1wn4
authorized withdrawer: 4v8w4YZR4e8cagWjegC9paLVQzQE3xkYeW4adUAR1wn4
lockup slot: 0
lockup custodian: 11111111111111111111111111111111

```

#### Summary of Changes

Now, show the previledge:

```
ryoqun@ubuqun:~/work/solana/solana/for-small-patches$ solana show-stake-account ./config/run/leader-stake-account-keypair.json
RPC Endpoint: http://127.0.0.1:8899
total stake: 0.5 SOL
credits observed: 0
delegated stake: 0.5 SOL
delegated voter pubkey: B1q1SRYQP86aAsSZuQHV9rdTbxcCBTrefQS2YgBD6h7p
stake activates starting from epoch: 0 (Genesis)
authorized staker: 4v8w4YZR4e8cagWjegC9paLVQzQE3xkYeW4adUAR1wn4
authorized withdrawer: 4v8w4YZR4e8cagWjegC9paLVQzQE3xkYeW4adUAR1wn4
lockup epoch: 0
lockup custodian: 11111111111111111111111111111111

```

