### PR TITLE
Streamline multinode-demo/ restart logic

### DIFF
--- a/ci/localnet-sanity.sh
+++ b/ci/localnet-sanity.sh
@@ -75,6 +75,7 @@ source multinode-demo/common.sh
 nodes=(
   "multinode-demo/drone.sh"
   "multinode-demo/bootstrap-leader.sh \
+    --no-restart \
     --init-complete-file init-complete-node1.log \
     --dynamic-port-range 8000-8050"
   "multinode-demo/validator.sh \

--- a/multinode-demo/validator.sh
+++ b/multinode-demo/validator.sh
@@ -278,14 +278,15 @@ setup_validator_accounts() {
   return 0
 }
 
+rpc_url=$($solana_gossip get-rpc-url --entrypoint "$gossip_entrypoint")
+
+[[ -r "$identity_keypair_path" ]] || $solana_keygen new -o "$identity_keypair_path"
+[[ -r "$voting_keypair_path" ]] || $solana_keygen new -o "$voting_keypair_path"
+[[ -r "$storage_keypair_path" ]] || $solana_keygen new -o "$storage_keypair_path"
+
+setup_validator_accounts "$node_lamports"
+
 while true; do
-  rpc_url=$($solana_gossip get-rpc-url --entrypoint "$gossip_entrypoint")
-
-  [[ -r "$identity_keypair_path" ]] || $solana_keygen new -o "$identity_keypair_path"
-  [[ -r "$voting_keypair_path" ]] || $solana_keygen new -o "$voting_keypair_path"
-  [[ -r "$storage_keypair_path" ]] || $solana_keygen new -o "$storage_keypair_path"
-
-  setup_validator_accounts "$node_lamports"
   echo "$PS4$program ${args[*]}"
 
   $program "${args[@]}" &
@@ -306,9 +307,4 @@ while true; do
   done
 
   kill_node
-  # give the cluster time to come back up
-  (
-    set -x
-    sleep 60
-  )
 done


### PR DESCRIPTION
* bootstrap-leader.sh will now restart the node automatically by default (like if it was taken down by the OOM killer)
* validator.sh doesn't bother trying to poke the RPC endpoint on a restart as the endpoint may be down at this time too (depends-on: #7093).   Instead just boot up again and hope everything works itself out, and if not solana-validator will exit and validator.sh can try again (systemd integration works similarly) 
