### PR TITLE
[wip] Retain N epochs worth of epoch_stakes

### DIFF
--- a/ledger/src/leader_schedule_cache.rs
+++ b/ledger/src/leader_schedule_cache.rs
@@ -87,7 +87,9 @@ impl LeaderScheduleCache {
         let slot_epoch = self.epoch_schedule.get_epoch_and_slot_index(slot).0;
         if slot_epoch < *self.max_epoch.read().unwrap() - MAX_LEADER_SCHEDULE_STAKES {
             panic!(
-                "Requested too old epoch!: {} < {}", slot_epoch, *self.max_epoch.read().unwrap()
+                "Requested too old epoch!: {} < {}",
+                slot_epoch,
+                *self.max_epoch.read().unwrap()
             );
         }
 
@@ -120,8 +122,15 @@ impl LeaderScheduleCache {
             );
             return None;
         }
-        if (self.get_epoch_schedule_else_compute(epoch, bank).is_none() /* && epoch < bank.epoch()*/) {
-            panic!("getting failed! epoch: {}, slot: {}, bank epoch: {}", epoch, current_slot, bank.epoch());
+        if self.get_epoch_schedule_else_compute(epoch, bank).is_none()
+        /* && epoch < bank.epoch()*/
+        {
+            panic!(
+                "getting failed! epoch: {}, slot: {}, bank epoch: {}",
+                epoch,
+                current_slot,
+                bank.epoch()
+            );
         }
         while let Some(leader_schedule) = self.get_epoch_schedule_else_compute(epoch, bank) {
             // clippy thinks I should do this:

--- a/ledger/src/leader_schedule_cache.rs
+++ b/ledger/src/leader_schedule_cache.rs
@@ -48,7 +48,9 @@ impl LeaderScheduleCache {
 
         // Calculate the schedule for all epochs between 0 and leader_schedule_epoch(root)
         let leader_schedule_epoch = epoch_schedule.get_leader_schedule_epoch(root_bank.slot());
-        for epoch in (leader_schedule_epoch - MAX_LEADER_SCHEDULE_STAKES)..leader_schedule_epoch {
+        for epoch in (leader_schedule_epoch.max(MAX_LEADER_SCHEDULE_STAKES)
+            - MAX_LEADER_SCHEDULE_STAKES)..leader_schedule_epoch
+        {
             let first_slot_in_epoch = epoch_schedule.get_first_slot_in_epoch(epoch);
             cache.slot_leader_at(first_slot_in_epoch, Some(root_bank));
         }
@@ -85,7 +87,14 @@ impl LeaderScheduleCache {
 
     pub fn slot_leader_at(&self, slot: Slot, bank: Option<&Bank>) -> Option<Pubkey> {
         let slot_epoch = self.epoch_schedule.get_epoch_and_slot_index(slot).0;
-        if slot_epoch < *self.max_epoch.read().unwrap() - MAX_LEADER_SCHEDULE_STAKES {
+        if slot_epoch
+            < self
+                .max_epoch
+                .read()
+                .unwrap()
+                .max(MAX_LEADER_SCHEDULE_STAKES)
+                - MAX_LEADER_SCHEDULE_STAKES
+        {
             panic!(
                 "Requested too old epoch!: {} < {}",
                 slot_epoch,

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -716,6 +716,7 @@ mod test {
             cluster_lamports: 100,
             ticks_per_slot: 8,
             slots_per_epoch: MINIMUM_SLOTS_PER_EPOCH as u64,
+            stakers_slot_offset: MINIMUM_SLOTS_PER_EPOCH as u64,
             ..ClusterConfig::default()
         };
         let cluster = LocalCluster::new(&config);

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -307,6 +307,7 @@ fn test_two_unbalanced_stakes() {
         validator_configs: vec![validator_config.clone(); 2],
         ticks_per_slot: num_ticks_per_slot,
         slots_per_epoch: num_slots_per_epoch,
+        stakers_slot_offset: num_slots_per_epoch,
         poh_config: PohConfig::new_sleep(Duration::from_millis(1000 / num_ticks_per_second)),
         ..ClusterConfig::default()
     });

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -54,6 +54,8 @@ use std::{
 
 pub const SECONDS_PER_YEAR: f64 = (365.25 * 24.0 * 60.0 * 60.0);
 
+const MAX_LEADER_SCHEDULE_STAKES: Epoch = 200; // what value shold this be???
+
 type BankStatusCache = StatusCache<Result<()>>;
 
 #[derive(Default)]
@@ -386,14 +388,7 @@ impl Bank {
             }
         }
 
-        // update epoch_stakes cache
-        //  if my parent didn't populate for this staker's epoch, we've
-        //  crossed a boundary
-        if new.epoch_stakes.get(&leader_schedule_epoch).is_none() {
-            new.epoch_stakes
-                .insert(leader_schedule_epoch, new.stakes.read().unwrap().clone());
-        }
-
+        new.update_epoch_stakes(leader_schedule_epoch);
         new.ancestors.insert(new.slot(), 0);
         new.parents().iter().enumerate().for_each(|(i, p)| {
             new.ancestors.insert(p.slot(), i + 1);
@@ -484,6 +479,23 @@ impl Bank {
         slot_hashes.to_account(&mut account).unwrap();
 
         self.store_account(&sysvar::slot_hashes::id(), &account);
+    }
+
+    fn update_epoch_stakes(&mut self, leader_schedule_epoch: Epoch) {
+        // update epoch_stakes cache
+        //  if my parent didn't populate for this staker's epoch, we've
+        //  crossed a boundary
+        if self.epoch_stakes.get(&leader_schedule_epoch).is_none() {
+            // should add assertion for incremental insersion for epochs?
+
+            self.epoch_stakes
+                .insert(leader_schedule_epoch, self.stakes.read().unwrap().clone());
+
+            if leader_schedule_epoch >= MAX_LEADER_SCHEDULE_STAKES {
+                self.epoch_stakes
+                    .remove(&(leader_schedule_epoch - MAX_LEADER_SCHEDULE_STAKES));
+            }
+        }
     }
 
     fn update_fees(&self) {
@@ -1741,6 +1753,45 @@ mod tests {
         assert_eq!(bank0.block_height(), 0);
         let bank1 = Arc::new(new_from_parent(&bank0));
         assert_eq!(bank1.block_height(), 1);
+    }
+
+    impl Bank {
+        fn epoch_stake_keys(&self) -> Vec<Epoch> {
+            let mut keys: Vec<Epoch> = self.epoch_stakes.keys().map(|k| *k).collect();
+            keys.sort();
+            keys
+        }
+
+        fn epoch_stake_key_info(&self) -> (Epoch, Epoch, usize) {
+            let mut keys: Vec<Epoch> = self.epoch_stakes.keys().map(|k| *k).collect();
+            keys.sort();
+            (*keys.first().unwrap(), *keys.last().unwrap(), keys.len())
+        }
+    }
+
+    #[test]
+    fn test_bank_update_epoch_stakes() {
+        let (genesis_config, mint_keypair) = create_genesis_config(100_000);
+        let mut bank = Bank::new(&genesis_config);
+
+        let initial_epochs = bank.epoch_stake_keys();
+        assert_eq!(initial_epochs, vec![0, 1]);
+
+        for existing_epoch in &initial_epochs {
+            bank.update_epoch_stakes(*existing_epoch);
+            assert_eq!(bank.epoch_stake_keys(), initial_epochs);
+        }
+
+        for epoch in (initial_epochs.len() as Epoch)..MAX_LEADER_SCHEDULE_STAKES {
+            bank.update_epoch_stakes(epoch);
+            assert_eq!(bank.epoch_stakes.len() as Epoch, epoch + 1);
+        }
+
+        bank.update_epoch_stakes(MAX_LEADER_SCHEDULE_STAKES);
+        assert_eq!(bank.epoch_stake_key_info(), (1, 200, 200));
+
+        bank.update_epoch_stakes(MAX_LEADER_SCHEDULE_STAKES + 1);
+        assert_eq!(bank.epoch_stake_key_info(), (2, 201, 200));
     }
 
     #[test]

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1771,7 +1771,7 @@ mod tests {
 
     #[test]
     fn test_bank_update_epoch_stakes() {
-        let (genesis_config, mint_keypair) = create_genesis_config(100_000);
+        let (genesis_config, _mint_keypair) = create_genesis_config(100_000);
         let mut bank = Bank::new(&genesis_config);
 
         let initial_epochs = bank.epoch_stake_keys();

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -54,7 +54,7 @@ use std::{
 
 pub const SECONDS_PER_YEAR: f64 = (365.25 * 24.0 * 60.0 * 60.0);
 
-const MAX_LEADER_SCHEDULE_STAKES: Epoch = 32;
+pub const MAX_LEADER_SCHEDULE_STAKES: Epoch = 3;
 
 type BankStatusCache = StatusCache<Result<()>>;
 
@@ -493,6 +493,7 @@ impl Bank {
                 self.epoch_stakes
                     .remove(&(leader_schedule_epoch - MAX_LEADER_SCHEDULE_STAKES));
             }
+            error!("new epoch stakes: {:#?}", self.epoch_stakes.keys().collect::<Vec<_>>());
         }
     }
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -493,7 +493,10 @@ impl Bank {
                 self.epoch_stakes
                     .remove(&(leader_schedule_epoch - MAX_LEADER_SCHEDULE_STAKES));
             }
-            error!("new epoch stakes: {:#?}", self.epoch_stakes.keys().collect::<Vec<_>>());
+            error!(
+                "new epoch stakes: {:#?}",
+                self.epoch_stakes.keys().collect::<Vec<_>>()
+            );
         }
     }
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1789,13 +1789,13 @@ mod tests {
             assert_eq!(bank.epoch_stakes.len() as Epoch, epoch + 1);
         }
 
-        assert_eq!(bank.epoch_stake_key_info(), (0, 31, 32));
+        assert_eq!(bank.epoch_stake_key_info(), (0, 2, 3));
 
         bank.update_epoch_stakes(MAX_LEADER_SCHEDULE_STAKES);
-        assert_eq!(bank.epoch_stake_key_info(), (1, 32, 32));
+        assert_eq!(bank.epoch_stake_key_info(), (1, 3, 3));
 
         bank.update_epoch_stakes(MAX_LEADER_SCHEDULE_STAKES + 1);
-        assert_eq!(bank.epoch_stake_key_info(), (2, 33, 32));
+        assert_eq!(bank.epoch_stake_key_info(), (2, 4, 3));
     }
 
     #[test]

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1785,11 +1785,13 @@ mod tests {
             assert_eq!(bank.epoch_stakes.len() as Epoch, epoch + 1);
         }
 
+        assert_eq!(bank.epoch_stake_key_info(), (0, 31, 32));
+
         bank.update_epoch_stakes(MAX_LEADER_SCHEDULE_STAKES);
-        assert_eq!(bank.epoch_stake_key_info(), (1, 200, 200));
+        assert_eq!(bank.epoch_stake_key_info(), (1, 32, 32));
 
         bank.update_epoch_stakes(MAX_LEADER_SCHEDULE_STAKES + 1);
-        assert_eq!(bank.epoch_stake_key_info(), (2, 201, 200));
+        assert_eq!(bank.epoch_stake_key_info(), (2, 33, 32));
     }
 
     #[test]

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -54,7 +54,7 @@ use std::{
 
 pub const SECONDS_PER_YEAR: f64 = (365.25 * 24.0 * 60.0 * 60.0);
 
-const MAX_LEADER_SCHEDULE_STAKES: Epoch = 200; // what value shold this be???
+const MAX_LEADER_SCHEDULE_STAKES: Epoch = 32;
 
 type BankStatusCache = StatusCache<Result<()>>;
 
@@ -486,8 +486,6 @@ impl Bank {
         //  if my parent didn't populate for this staker's epoch, we've
         //  crossed a boundary
         if self.epoch_stakes.get(&leader_schedule_epoch).is_none() {
-            // should add assertion for incremental insersion for epochs?
-
             self.epoch_stakes
                 .insert(leader_schedule_epoch, self.stakes.read().unwrap().clone());
 


### PR DESCRIPTION
#### Problem

From #6991:
 
> the bank never culls epoch stakes

#### Solution

Again From #6991:
 
> retain at most N epochs worth of epoch_stakes

#### Misc

- I added @rob-solana as a reviewer guessing from issue creator can review this, nice to meet you!
- Also, I tried to make added tests readable as much as possible. A bit too much, but I hope our test assets could be close to them by enriching test vocabulary like this...

Fixes #6991