### PR TITLE
Move Date oracle to Config program

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3269,6 +3269,7 @@ name = "solana-config-program"
 version = "0.21.0"
 dependencies = [
  "bincode 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/programs/config/Cargo.toml
+++ b/programs/config/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2018"
 
 [dependencies]
 bincode = "1.2.0"
+chrono = { version = "0.4.9", features = ["serde"] }
 log = "0.4.8"
 serde = "1.0.102"
 serde_derive = "1.0.102"

--- a/programs/config/src/date_instruction.rs
+++ b/programs/config/src/date_instruction.rs
@@ -1,3 +1,4 @@
+use crate::{config_instruction, ConfigState};
 ///
 /// A library for creating a trusted date oracle.
 ///
@@ -7,7 +8,6 @@ use chrono::{
     serde::ts_seconds,
 };
 use serde_derive::{Deserialize, Serialize};
-use solana_config_program::{config_instruction, ConfigState};
 use solana_sdk::{instruction::Instruction, pubkey::Pubkey};
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]

--- a/programs/config/src/lib.rs
+++ b/programs/config/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod config_instruction;
 pub mod config_processor;
+pub mod date_instruction;
 
 use crate::config_processor::process_instruction;
 use bincode::{deserialize, serialize, serialized_size};

--- a/programs/vest/src/lib.rs
+++ b/programs/vest/src/lib.rs
@@ -1,4 +1,3 @@
-pub mod date_instruction;
 pub mod vest_instruction;
 pub mod vest_processor;
 pub mod vest_schedule;

--- a/programs/vest/src/vest_processor.rs
+++ b/programs/vest/src/vest_processor.rs
@@ -1,10 +1,10 @@
 //! vest program
-use crate::date_instruction::DateConfig;
 use crate::{
     vest_instruction::{VestError, VestInstruction},
     vest_state::VestState,
 };
 use chrono::prelude::*;
+use solana_config_program::date_instruction::DateConfig;
 use solana_config_program::get_config_data;
 use solana_sdk::{
     account::{Account, KeyedAccount},
@@ -143,9 +143,9 @@ pub fn process_instruction(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::date_instruction;
     use crate::id;
     use crate::vest_instruction;
+    use solana_config_program::date_instruction;
     use solana_runtime::bank::Bank;
     use solana_runtime::bank_client::BankClient;
     use solana_sdk::client::SyncClient;


### PR DESCRIPTION
#### Problem

The Date oracle defined in the Vest program is processed by the Config program.  Using it from outside Vest would require depending on both the Vest and Config programs, when the Vest instruction processor would be unused.  The situation is convoluted and assumes nobody outside Vest would use that library.

#### Summary of Changes

Move the Date oracle into the Config program. This oddly makes Config depend on `chrono` and adds a specific usage of Config to an otherwise generic crate.  That said, the module seems too small to justify its own crate, and this placement feels better than the current situation.
