### PR TITLE
update genesis config to use BTreeMap for accounts

### DIFF
--- a/genesis/src/genesis_accounts.rs
+++ b/genesis/src/genesis_accounts.rs
@@ -650,15 +650,5 @@ mod tests {
             .sum::<u64>();
 
         assert_eq!(issued_lamports, lamports);
-
-        genesis_config
-            .accounts
-            .sort_by(|(ka, _), (kb, _)| ka.cmp(kb));
-
-        let len = genesis_config.accounts.len();
-        genesis_config
-            .accounts
-            .dedup_by(|(ka, _), (kb, _)| ka == kb);
-        assert_eq!(genesis_config.accounts.len(), len);
     }
 }

--- a/programs/storage/src/rewards_pools.rs
+++ b/programs/storage/src/rewards_pools.rs
@@ -45,12 +45,7 @@ mod tests {
         add_genesis_accounts(&mut genesis_config);
 
         for _i in 0..NUM_REWARDS_POOLS {
-            let id = random_id();
-            assert!(genesis_config
-                .rewards_pools
-                .iter()
-                .position(|x| x.0 == id)
-                .is_some());
+            assert!(genesis_config.rewards_pools.get(&random_id()).is_some())
         }
     }
 }

--- a/runtime/src/genesis_utils.rs
+++ b/runtime/src/genesis_utils.rs
@@ -49,7 +49,7 @@ pub fn create_genesis_config_with_leader(
         bootstrap_leader_stake_lamports,
     );
 
-    let accounts = vec![
+    let accounts = [
         (
             mint_keypair.pubkey(),
             Account::new(mint_lamports, 0, &system_program::id()),
@@ -66,7 +66,10 @@ pub fn create_genesis_config_with_leader(
             bootstrap_leader_staking_keypair.pubkey(),
             bootstrap_leader_stake_account,
         ),
-    ];
+    ]
+    .iter()
+    .cloned()
+    .collect();
 
     // Bare minimum program set
     let native_instruction_processors = vec![


### PR DESCRIPTION
#### Problem
 when building genesis stakes, staker accounts need to be found and updated with lamports
 for TX fees, and a vector of accounts is clumsy for that

 #### Summary of Changes
 use BTreeMaps for accounts (simplified some other code, too)

Fixes #