### PR TITLE
cli: Add --confirmed option to a couple commands, also add --no-header

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -223,6 +223,7 @@ pub struct CliConfig {
     pub keypair: Keypair,
     pub keypair_path: Option<String>,
     pub rpc_client: Option<RpcClient>,
+    pub print_header: bool,
 }
 
 impl CliConfig {
@@ -248,6 +249,7 @@ impl Default for CliConfig {
             keypair: Keypair::new(),
             keypair_path: Some(Self::default_keypair_path()),
             rpc_client: None,
+            print_header: true,
         }
     }
 }
@@ -841,14 +843,16 @@ fn process_witness(
 }
 
 pub fn process_command(config: &CliConfig) -> ProcessResult {
-    if let Some(keypair_path) = &config.keypair_path {
-        println_name_value("Keypair:", keypair_path);
+    if config.print_header {
+        if let Some(keypair_path) = &config.keypair_path {
+            println_name_value("Keypair:", keypair_path);
+        }
+        if let CliCommand::Address = config.command {
+            // Get address of this client
+            return Ok(format!("{}", config.keypair.pubkey()));
+        }
+        println_name_value("RPC Endpoint:", &config.json_rpc_url);
     }
-    if let CliCommand::Address = config.command {
-        // Get address of this client
-        return Ok(format!("{}", config.keypair.pubkey()));
-    }
-    println_name_value("RPC Endpoint:", &config.json_rpc_url);
 
     let mut _rpc_client;
     let rpc_client = if config.rpc_client.is_none() {

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -74,10 +74,16 @@ pub enum CliCommand {
     },
     ClusterVersion,
     Fees,
-    GetEpochInfo,
+    GetEpochInfo {
+        commitment_config: CommitmentConfig,
+    },
     GetGenesisHash,
-    GetSlot,
-    GetTransactionCount,
+    GetSlot {
+        commitment_config: CommitmentConfig,
+    },
+    GetTransactionCount {
+        commitment_config: CommitmentConfig,
+    },
     Ping {
         lamports: u64,
         interval: Duration,
@@ -258,22 +264,13 @@ pub fn parse_command(matches: &ArgMatches<'_>) -> Result<CliCommandInfo, Box<dyn
             command: CliCommand::Fees,
             require_keypair: false,
         }),
-        ("get-epoch-info", Some(_matches)) => Ok(CliCommandInfo {
-            command: CliCommand::GetEpochInfo,
-            require_keypair: false,
-        }),
+        ("get-epoch-info", Some(matches)) => parse_get_epoch_info(matches),
         ("get-genesis-hash", Some(_matches)) => Ok(CliCommandInfo {
             command: CliCommand::GetGenesisHash,
             require_keypair: false,
         }),
-        ("get-slot", Some(_matches)) => Ok(CliCommandInfo {
-            command: CliCommand::GetSlot,
-            require_keypair: false,
-        }),
-        ("get-transaction-count", Some(_matches)) => Ok(CliCommandInfo {
-            command: CliCommand::GetTransactionCount,
-            require_keypair: false,
-        }),
+        ("get-slot", Some(matches)) => parse_get_slot(matches),
+        ("get-transaction-count", Some(matches)) => parse_get_transaction_count(matches),
         ("ping", Some(matches)) => parse_cluster_ping(matches),
         ("show-gossip", Some(_matches)) => Ok(CliCommandInfo {
             command: CliCommand::ShowGossip,
@@ -870,9 +867,15 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
         CliCommand::ClusterVersion => process_cluster_version(&rpc_client),
         CliCommand::Fees => process_fees(&rpc_client),
         CliCommand::GetGenesisHash => process_get_genesis_hash(&rpc_client),
-        CliCommand::GetSlot => process_get_slot(&rpc_client),
-        CliCommand::GetEpochInfo => process_get_epoch_info(&rpc_client),
-        CliCommand::GetTransactionCount => process_get_transaction_count(&rpc_client),
+        CliCommand::GetEpochInfo { commitment_config } => {
+            process_get_epoch_info(&rpc_client, commitment_config)
+        }
+        CliCommand::GetSlot { commitment_config } => {
+            process_get_slot(&rpc_client, commitment_config)
+        }
+        CliCommand::GetTransactionCount { commitment_config } => {
+            process_get_transaction_count(&rpc_client, commitment_config)
+        }
         CliCommand::Ping {
             lamports,
             interval,
@@ -1888,10 +1891,14 @@ mod tests {
         let signature = process_command(&config);
         assert_eq!(signature.unwrap(), SIGNATURE.to_string());
 
-        config.command = CliCommand::GetSlot;
+        config.command = CliCommand::GetSlot {
+            commitment_config: CommitmentConfig::default(),
+        };
         assert_eq!(process_command(&config).unwrap(), "0");
 
-        config.command = CliCommand::GetTransactionCount;
+        config.command = CliCommand::GetTransactionCount {
+            commitment_config: CommitmentConfig::default(),
+        };
         assert_eq!(process_command(&config).unwrap(), "1234");
 
         config.command = CliCommand::Pay {
@@ -2025,10 +2032,14 @@ mod tests {
         config.command = CliCommand::VoteAuthorize(bob_pubkey, bob_pubkey, VoteAuthorize::Voter);
         assert!(process_command(&config).is_err());
 
-        config.command = CliCommand::GetSlot;
+        config.command = CliCommand::GetSlot {
+            commitment_config: CommitmentConfig::default(),
+        };
         assert!(process_command(&config).is_err());
 
-        config.command = CliCommand::GetTransactionCount;
+        config.command = CliCommand::GetTransactionCount {
+            commitment_config: CommitmentConfig::default(),
+        };
         assert!(process_command(&config).is_err());
 
         config.command = CliCommand::Pay {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -133,12 +133,15 @@ pub fn parse_args(matches: &ArgMatches<'_>) -> Result<CliConfig, Box<dyn error::
         (default.keypair, None)
     };
 
+    let print_header = !matches.is_present("no_header");
+
     Ok(CliConfig {
         command,
         json_rpc_url,
         keypair,
         keypair_path,
         rpc_client: None,
+        print_header,
     })
 }
 
@@ -181,6 +184,12 @@ fn main() -> Result<(), Box<dyn error::Error>> {
             .global(true)
             .takes_value(true)
             .help("/path/to/id.json"),
+    )
+    .arg(
+        Arg::with_name("no_header")
+            .long("no-header")
+            .global(true)
+            .help("Disable information header"),
     )
     .arg(
         Arg::with_name(ASK_SEED_PHRASE_ARG.name)

--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -197,9 +197,16 @@ impl RpcClient {
     }
 
     pub fn get_epoch_info(&self) -> io::Result<RpcEpochInfo> {
+        self.get_epoch_info_with_commitment(CommitmentConfig::default())
+    }
+
+    pub fn get_epoch_info_with_commitment(
+        &self,
+        commitment_config: CommitmentConfig,
+    ) -> io::Result<RpcEpochInfo> {
         let response = self
             .client
-            .send(&RpcRequest::GetEpochInfo, None, 0, None)
+            .send(&RpcRequest::GetEpochInfo, None, 0, commitment_config.ok())
             .map_err(|err| {
                 io::Error::new(
                     io::ErrorKind::Other,


### PR DESCRIPTION
* Add --confirmed option to get-slot, get-epoch-info, get-transaction-count
* Add --no-header option to suppress "RPC/Keypair" command headers that are scripting unfriendly