### PR TITLE
RPC subscriptions for new slot notifications

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -233,6 +233,7 @@ impl ReplayStage {
                         &blocktree,
                         &mut bank_forks.write().unwrap(),
                         &leader_schedule_cache,
+                        &subscriptions,
                     );
                     datapoint_debug!(
                         "replay_stage-memory",
@@ -370,6 +371,7 @@ impl ReplayStage {
                             &bank_forks,
                             &poh_recorder,
                             &leader_schedule_cache,
+                            &subscriptions,
                         );
 
                         if let Some(bank) = poh_recorder.lock().unwrap().bank() {
@@ -442,6 +444,7 @@ impl ReplayStage {
         bank_forks: &Arc<RwLock<BankForks>>,
         poh_recorder: &Arc<Mutex<PohRecorder>>,
         leader_schedule_cache: &Arc<LeaderScheduleCache>,
+        subscriptions: &Arc<RpcSubscriptions>,
     ) {
         // all the individual calls to poh_recorder.lock() are designed to
         // increase granularity, decrease contention
@@ -496,7 +499,12 @@ impl ReplayStage {
                 ("leader", next_leader.to_string(), String),
             );
 
-            info!("new fork:{} parent:{} (leader)", poh_slot, parent_slot);
+            let root_slot = bank_forks.read().unwrap().root();
+            info!(
+                "new fork:{} parent:{} (leader) root:{}",
+                poh_slot, parent_slot, root_slot
+            );
+            subscriptions.notify_slot(poh_slot, parent_slot, root_slot);
             let tpu_bank = bank_forks
                 .write()
                 .unwrap()
@@ -1085,6 +1093,7 @@ impl ReplayStage {
         blocktree: &Blocktree,
         forks: &mut BankForks,
         leader_schedule_cache: &Arc<LeaderScheduleCache>,
+        subscriptions: &Arc<RpcSubscriptions>,
     ) {
         // Find the next slot that chains to the old slot
         let frozen_banks = forks.frozen_banks();
@@ -1111,7 +1120,13 @@ impl ReplayStage {
                 let leader = leader_schedule_cache
                     .slot_leader_at(child_slot, Some(&parent_bank))
                     .unwrap();
-                info!("new fork:{} parent:{}", child_slot, parent_slot);
+                info!(
+                    "new fork:{} parent:{} root:{}",
+                    child_slot,
+                    parent_slot,
+                    forks.root()
+                );
+                subscriptions.notify_slot(child_slot, parent_slot, forks.root());
                 forks.insert(Bank::new_from_parent(&parent_bank, &leader, child_slot));
             }
         }
@@ -1170,6 +1185,7 @@ mod test {
             let genesis_config = create_genesis_config(10_000).genesis_config;
             let bank0 = Bank::new(&genesis_config);
             let leader_schedule_cache = Arc::new(LeaderScheduleCache::new_from_bank(&bank0));
+            let subscriptions = Arc::new(RpcSubscriptions::default());
             let mut bank_forks = BankForks::new(0, bank0);
             bank_forks.working_bank().freeze();
 
@@ -1181,6 +1197,7 @@ mod test {
                 &blocktree,
                 &mut bank_forks,
                 &leader_schedule_cache,
+                &subscriptions,
             );
             assert!(bank_forks.get(1).is_some());
 
@@ -1192,6 +1209,7 @@ mod test {
                 &blocktree,
                 &mut bank_forks,
                 &leader_schedule_cache,
+                &subscriptions,
             );
             assert!(bank_forks.get(1).is_some());
             assert!(bank_forks.get(2).is_some());

--- a/core/src/rpc_subscriptions.rs
+++ b/core/src/rpc_subscriptions.rs
@@ -15,6 +15,13 @@ use std::sync::{Arc, RwLock};
 
 pub type Confirmations = usize;
 
+#[derive(Serialize, Clone)]
+pub struct SlotInfo {
+    pub slot: Slot,
+    pub parent: Slot,
+    pub root: Slot,
+}
+
 type RpcAccountSubscriptions =
     RwLock<HashMap<Pubkey, HashMap<SubscriptionId, (Sink<Account>, Confirmations)>>>;
 type RpcProgramSubscriptions =
@@ -22,6 +29,7 @@ type RpcProgramSubscriptions =
 type RpcSignatureSubscriptions = RwLock<
     HashMap<Signature, HashMap<SubscriptionId, (Sink<transaction::Result<()>>, Confirmations)>>,
 >;
+type RpcSlotSubscriptions = RwLock<HashMap<SubscriptionId, Sink<SlotInfo>>>;
 
 fn add_subscription<K, S>(
     subscriptions: &mut HashMap<K, HashMap<SubscriptionId, (Sink<S>, Confirmations)>>,
@@ -119,7 +127,7 @@ fn check_confirmations_and_notify<K, S, F, N, X>(
     }
 }
 
-fn notify_account<S>(result: Option<(S, u64)>, sink: &Sink<S>, root: u64)
+fn notify_account<S>(result: Option<(S, Slot)>, sink: &Sink<S>, root: Slot)
 where
     S: Clone + Serialize,
 {
@@ -130,7 +138,7 @@ where
     }
 }
 
-fn notify_signature<S>(result: Option<S>, sink: &Sink<S>, _root: u64)
+fn notify_signature<S>(result: Option<S>, sink: &Sink<S>, _root: Slot)
 where
     S: Clone + Serialize,
 {
@@ -139,7 +147,7 @@ where
     }
 }
 
-fn notify_program(accounts: Vec<(Pubkey, Account)>, sink: &Sink<(String, Account)>, _root: u64) {
+fn notify_program(accounts: Vec<(Pubkey, Account)>, sink: &Sink<(String, Account)>, _root: Slot) {
     for (pubkey, account) in accounts.iter() {
         sink.notify(Ok((pubkey.to_string(), account.clone())))
             .wait()
@@ -151,6 +159,7 @@ pub struct RpcSubscriptions {
     account_subscriptions: RpcAccountSubscriptions,
     program_subscriptions: RpcProgramSubscriptions,
     signature_subscriptions: RpcSignatureSubscriptions,
+    slot_subscriptions: RpcSlotSubscriptions,
 }
 
 impl Default for RpcSubscriptions {
@@ -159,6 +168,7 @@ impl Default for RpcSubscriptions {
             account_subscriptions: RpcAccountSubscriptions::default(),
             program_subscriptions: RpcProgramSubscriptions::default(),
             signature_subscriptions: RpcSignatureSubscriptions::default(),
+            slot_subscriptions: RpcSlotSubscriptions::default(),
         }
     }
 }
@@ -289,6 +299,26 @@ impl RpcSubscriptions {
         };
         for signature in &signatures {
             self.check_signature(signature, current_slot, bank_forks);
+        }
+    }
+
+    pub fn add_slot_subscription(&self, sub_id: &SubscriptionId, sink: &Sink<SlotInfo>) {
+        let mut subscriptions = self.slot_subscriptions.write().unwrap();
+        subscriptions.insert(sub_id.clone(), sink.clone());
+    }
+
+    pub fn remove_slot_subscription(&self, id: &SubscriptionId) -> bool {
+        let mut subscriptions = self.slot_subscriptions.write().unwrap();
+        subscriptions.remove(id).is_some()
+    }
+
+    pub fn notify_slot(&self, slot: Slot, parent: Slot, root: Slot) {
+        info!("notify_slot!! {} from {} (root={})", slot, parent, root);
+        let subscriptions = self.slot_subscriptions.read().unwrap();
+        for (_, sink) in subscriptions.iter() {
+            sink.notify(Ok(SlotInfo { slot, parent, root }))
+                .wait()
+                .unwrap();
         }
     }
 }


### PR DESCRIPTION
#### Problem(s)

* currently, visualizing forks requires external tools and inordinate amounts of log processing
* visualizing/understanding/reasoning about forks is a prerequisite for production network operation

#### Summary of Changes

* add hooks for slot notifications to replay stage (work initially started by @mvines)
* add tests for slot subscription management
* plumb through notifications to `rpc_pubsub`

Fixes # N/A (that I'm aware of)
