### PR TITLE
Add getConfirmedBlock test to rpc

### DIFF
--- a/client/src/rpc_request.rs
+++ b/client/src/rpc_request.rs
@@ -22,7 +22,7 @@ pub struct Response<T> {
     pub value: T,
 }
 
-#[derive(Debug, Default, PartialEq, Serialize)]
+#[derive(Debug, Default, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RpcConfirmedBlock {
     pub previous_blockhash: Hash,


### PR DESCRIPTION
#### Problem
Comments indicate that getConfirmedBlock is not fully implemented. This is incorrect. However, there is no test of the rpc method to confirm.

#### Summary of Changes
- Add test and remove comment

Fixes #6867 
