### PR TITLE
Update to hashes_per_tick computation, and tick duration datapoint

### DIFF
--- a/core/src/poh_service.rs
+++ b/core/src/poh_service.rs
@@ -2,10 +2,12 @@
 //! "ticks", a measure of time in the PoH stream
 use crate::poh_recorder::PohRecorder;
 use core_affinity;
+use solana_sdk::clock::DEFAULT_TICKS_PER_SLOT;
 use solana_sdk::poh_config::PohConfig;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::thread::{self, sleep, Builder, JoinHandle};
+use std::time::Instant;
 
 pub struct PohService {
     tick_producer: JoinHandle<()>,
@@ -85,10 +87,22 @@ impl PohService {
 
     fn tick_producer(poh_recorder: Arc<Mutex<PohRecorder>>, poh_exit: &AtomicBool) {
         let poh = poh_recorder.lock().unwrap().poh.clone();
+        let mut now = Instant::now();
+        let mut num_ticks = 0;
         loop {
             if poh.lock().unwrap().hash(NUM_HASHES_PER_BATCH) {
                 // Lock PohRecorder only for the final hash...
                 poh_recorder.lock().unwrap().tick();
+                num_ticks += 1;
+                if num_ticks >= DEFAULT_TICKS_PER_SLOT * 2 {
+                    datapoint_debug!(
+                        "poh-service",
+                        ("ticks", num_ticks as i64, i64),
+                        ("elapsed_ms", now.elapsed().as_millis() as i64, i64),
+                    );
+                    num_ticks = 0;
+                    now = Instant::now();
+                }
                 if poh_exit.load(Ordering::Relaxed) {
                     break;
                 }

--- a/ledger/src/poh.rs
+++ b/ledger/src/poh.rs
@@ -1,7 +1,6 @@
 //! The `Poh` module provides an object for generating a Proof of History.
 use log::*;
 use solana_sdk::hash::{hash, hashv, Hash};
-use std::thread::{Builder, JoinHandle};
 use std::time::{Duration, Instant};
 
 pub struct Poh {
@@ -84,34 +83,18 @@ impl Poh {
 }
 
 pub fn compute_hashes_per_tick(duration: Duration, hashes_sample_size: u64) -> u64 {
-    let num_cpu = sys_info::cpu_num().unwrap();
     // calculate hash rate with the system under maximum load
     info!(
         "Running {} hashes in parallel on all threads...",
         hashes_sample_size
     );
-    let threads: Vec<JoinHandle<u64>> = (0..num_cpu)
-        .map(|_| {
-            Builder::new()
-                .name("solana-poh".to_string())
-                .spawn(move || {
-                    let mut v = Hash::default();
-                    let start = Instant::now();
-                    for _ in 0..hashes_sample_size {
-                        v = hash(&v.as_ref());
-                    }
-                    start.elapsed().as_millis() as u64
-                })
-                .unwrap()
-        })
-        .collect();
-
-    let avg_elapsed = (threads
-        .into_iter()
-        .map(|elapsed| elapsed.join().unwrap())
-        .sum::<u64>())
-        / u64::from(num_cpu);
-    duration.as_millis() as u64 * hashes_sample_size / avg_elapsed
+    let mut v = Hash::default();
+    let start = Instant::now();
+    for _ in 0..hashes_sample_size {
+        v = hash(&v.as_ref());
+    }
+    let elapsed = start.elapsed().as_millis() as u64;
+    duration.as_millis() as u64 * hashes_sample_size / elapsed
 }
 
 #[cfg(test)]

--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -113,6 +113,7 @@ waitForNodeToInit() {
     sleep 5
   done
   echo "$hostname booted up"
+  sudo chrt -r -p 99 `ps -eT | grep solana-poh-serv | awk '{print $2}'`
 }
 
 case $deployMethod in

--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -113,8 +113,6 @@ waitForNodeToInit() {
     sleep 5
   done
   echo "$hostname booted up"
-  # shellcheck disable=SC2009 # cannot use pgrep to find pid of thread
-  sudo chrt -r -p 99 "$(ps -eT | grep solana-poh-serv | awk '{print $2}')"
 }
 
 case $deployMethod in

--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -113,7 +113,7 @@ waitForNodeToInit() {
     sleep 5
   done
   echo "$hostname booted up"
-  sudo chrt -r -p 99 `ps -eT | grep solana-poh-serv | awk '{print $2}'`
+  sudo chrt -r -p 99 "$(ps -eT | grep solana-poh-serv | awk '{print $2}')"
 }
 
 case $deployMethod in

--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -113,6 +113,7 @@ waitForNodeToInit() {
     sleep 5
   done
   echo "$hostname booted up"
+  # shellcheck disable=SC2009 # cannot use pgrep to find pid of thread
   sudo chrt -r -p 99 "$(ps -eT | grep solana-poh-serv | awk '{print $2}')"
 }
 


### PR DESCRIPTION
#### Problem
PoH service generates a certain number of hashes (configured via Genesis block, as hashes_per_tick) before registering a tick. The service thread sets the CPU affinity, but due to OS scheduling, there is no guarantee that no other thread will get scheduled on the CPU core. This causes different node types (leader/validator) to take different amount of time to compute the same number of hashes. This causes network drift as nodes complete their respective slots at different times. End result can be leader timeouts, and dropped slots.

#### Summary of Changes
Added a counter to track time consumed in PoH tick. Updated `remote-node` script to change priority and scheduling policy of PoH service thread.

Fixes #6482
