### PR TITLE
Track a Bank's parent slot independently from parent bank

### DIFF
--- a/core/src/broadcast_stage/standard_broadcast_run.rs
+++ b/core/src/broadcast_stage/standard_broadcast_run.rs
@@ -141,13 +141,7 @@ impl StandardBroadcastRun {
         {
             self.slot_broadcast_start = Some(Instant::now());
             let slot = bank.slot();
-            let parent_slot = {
-                if let Some(parent_bank) = bank.parent() {
-                    parent_bank.slot()
-                } else {
-                    0
-                }
-            };
+            let parent_slot = bank.parent_slot();
 
             self.current_slot_and_parent = Some((slot, parent_slot));
             receive_elapsed = Duration::new(0, 0);

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -180,6 +180,8 @@ pub struct Bank {
     /// Hash of this Bank's parent's state
     parent_hash: Hash,
 
+    parent_slot: u64,
+
     /// The number of transactions processed without error
     #[serde(serialize_with = "serialize_atomicu64")]
     #[serde(deserialize_with = "deserialize_atomicu64")]
@@ -358,6 +360,7 @@ impl Bank {
             epoch_stakes: parent.epoch_stakes.clone(),
             storage_accounts: RwLock::new(parent.storage_accounts.read().unwrap().clone()),
             parent_hash: parent.hash(),
+            parent_slot: parent.slot(),
             collector_id: *collector_id,
             collector_fees: AtomicU64::new(0),
             ancestors: HashMap::new(),
@@ -660,6 +663,10 @@ impl Bank {
     /// Return the more recent checkpoint of this bank instance.
     pub fn parent(&self) -> Option<Arc<Bank>> {
         self.rc.parent.read().unwrap().clone()
+    }
+
+    pub fn parent_slot(&self) -> u64 {
+        self.parent_slot
     }
 
     fn process_genesis_config(&mut self, genesis_config: &GenesisConfig) {


### PR DESCRIPTION
#### Problem

When broadcast gets backed up,  the leader is setting roots way faster than they're able to broadcast. 
Eventually the leader reaches a point where the bank that's being broadcast is already a root and so has no parent information. 
So when they broadcast it they're supposed to mark what the parent slot is for the broadcast, but they don't know it anymore so they just say "0". Which is completely wrong.

#### Summary of Changes

Cache the parent's slot as soon as the bank is created and use that when broadcasting. 

Fixes #7119

@danpaul000 
