### PR TITLE
Print slot meta when printing a slot

### DIFF
--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -30,6 +30,7 @@ enum LedgerOutputMethod {
 }
 
 fn output_slot(blocktree: &Blocktree, slot: Slot, method: &LedgerOutputMethod) {
+    println!("Slot Meta {:?}", blocktree.meta(slot));
     let entries = blocktree
         .get_slot_entries(slot, 0, None)
         .unwrap_or_else(|err| {

--- a/ledger-tool/tests/basic.rs
+++ b/ledger-tool/tests/basic.rs
@@ -31,6 +31,7 @@ fn bad_arguments() {
 fn nominal() {
     let genesis_config = create_genesis_config(100).genesis_config;
     let ticks_per_slot = genesis_config.ticks_per_slot;
+    let meta_lines = 1;
 
     let (ledger_path, _blockhash) = create_new_tmp_ledger!(&genesis_config);
     let ticks = ticks_per_slot as usize;
@@ -44,5 +45,5 @@ fn nominal() {
     // Print everything
     let output = run_ledger_tool(&["-l", &ledger_path, "print"]);
     assert!(output.status.success());
-    assert_eq!(count_newlines(&output.stdout), ticks + 1);
+    assert_eq!(count_newlines(&output.stdout), ticks + meta_lines + 1);
 }


### PR DESCRIPTION
#### Problem

No way to see the meta for a slot using ledger-tool. 

Slot meta carries a lot of important information and can indicate things that just printing the entries in slot cannot. 


#### Summary of Changes

Print the slot meta while using ledger-tool to print a slot