### PR TITLE
Change from using fixed number of ticks in delay calculation

### DIFF
--- a/ledger/src/blocktree.rs
+++ b/ledger/src/blocktree.rs
@@ -58,7 +58,7 @@ thread_local!(static PAR_THREAD_POOL: RefCell<ThreadPool> = RefCell::new(rayon::
                     .unwrap()));
 
 pub const MAX_COMPLETED_SLOTS_IN_CHANNEL: usize = 100_000;
-pub const MAX_TURBINE_PROPAGATION_DELAY_TICKS: u64 = 16;
+pub const MAX_TURBINE_PROPAGATION_IN_MS: u64 = 100;
 
 pub type CompletedSlotsReceiver = Receiver<Vec<u64>>;
 
@@ -1082,7 +1082,9 @@ impl Blocktree {
                 &db_iterator.value().expect("couldn't read value"),
             ));
 
-            if ticks_since_first_insert < reference_tick + MAX_TURBINE_PROPAGATION_DELAY_TICKS {
+            let ms_per_tick = 1000 / DEFAULT_TICKS_PER_SECOND;
+            let turbine_delay_in_ticks = MAX_TURBINE_PROPAGATION_IN_MS / ms_per_tick;
+            if ticks_since_first_insert < reference_tick + turbine_delay_in_ticks {
                 // The higher index holes have not timed out yet
                 break 'outer;
             }

--- a/sdk/src/clock.rs
+++ b/sdk/src/clock.rs
@@ -4,6 +4,8 @@
 // rate at any given time should be expected to drift
 pub const DEFAULT_TICKS_PER_SECOND: u64 = 160;
 
+pub const MS_PER_TICK: u64 = 1000 / DEFAULT_TICKS_PER_SECOND;
+
 // At 160 ticks/s, 64 ticks per slot implies that leader rotation and voting will happen
 // every 400 ms. A fast voting cadence ensures faster finality and convergence
 pub const DEFAULT_TICKS_PER_SLOT: u64 = 64;


### PR DESCRIPTION
#### Problem
Using a fixed number of ticks breaks if we change the number of ticks per slot.

#### Summary of Changes
Calculate the delay using DEFAULT_TICKS_PER_SECOND which is not validator config dependant
Fixes #
