### PR TITLE
Tool to tune system parameters like PoH service priority

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1866,6 +1866,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "nodrop"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3967,9 +3979,11 @@ version = "0.22.0"
 dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nix 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-logger 0.22.0",
  "unix_socket2 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "users 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -5090,7 +5104,7 @@ name = "unix_socket2"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -5121,6 +5135,14 @@ dependencies = [
  "idna 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "percent-encoding 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "users"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -5620,6 +5642,7 @@ dependencies = [
 "checksum nibble_vec 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "c8d77f3db4bce033f4d04db08079b2ef1c3d02b44e86f25d08886fafa7756ffa"
 "checksum nix 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6c722bee1037d430d0f8e687bbdbf222f27cc6e4e68d5caf630857bb2b6dbdce"
 "checksum nix 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3b2e0b4f3320ed72aaedb9a5ac838690a8047c7b275da22711fddff4f8a14229"
+"checksum nix 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "19a8300bf427d432716764070ff70d5b2b7801c958b9049686e6cbd8b06fad92"
 "checksum nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9667ddcc6cc8a43afc9b7917599d7216aa09c463919ea32c59ed6cac8bc945"
 "checksum nom 4.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2ad2a91a8e869eeb30b9cb3119ae87773a8f4ae617f41b1eb9c154b2905f7bd6"
 "checksum num-derive 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "eafd0b45c5537c3ba526f79d3e75120036502bebacbb3f3220914067ce39dbf2"
@@ -5849,6 +5872,7 @@ dependencies = [
 "checksum untrusted 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "60369ef7a31de49bcb3f6ca728d4ba7300d9a1658f94c727d4cab8c8d9f4aece"
 "checksum url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a"
 "checksum url 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "75b414f6c464c879d7f9babf951f23bc3743fb7313c081b2e6ca719067ea9d61"
+"checksum users 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c72f4267aea0c3ec6d07eaabea6ead7c5ddacfafc5e22bcf8d186706851fb4cf"
 "checksum utf8-ranges 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a1ca13c08c41c9c3e04224ed9ff80461d97e121589ff27c753a16cb10830ae0f"
 "checksum uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "90dbc611eb48397705a6b0f6e917da23ae517e4d127123d2cf7674206627d32a"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3961,6 +3961,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-sys-tuner"
+version = "0.1.0"
+dependencies = [
+ "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-clap-utils 0.21.0",
+ "solana-logger 0.21.0",
+ "thread-priority 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unix_socket2 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "solana-upload-perf"
 version = "0.22.0"
 dependencies = [
@@ -4725,6 +4738,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread-priority"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "thread-scoped"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5072,6 +5093,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "unicode-xid"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "unix_socket2"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "unsigned-varint"
@@ -5788,6 +5817,7 @@ dependencies = [
 "checksum thiserror-impl 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "45ba8d810d9c48fc456b7ad54574e8bfb7c7918a57ad7a6e6a0985d7959e8597"
 "checksum thread-id 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a9539db560102d1cef46b8b78ce737ff0bb64e7e18d35b2a5688f7d097d0ff03"
 "checksum thread-id 3.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c7fbf4c9d56b320106cd64fd024dadfa0be7cb4706725fc44a7d7ce952d820c1"
+"checksum thread-priority 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e655c097854cf47b40825a61c2edf7b96119ce9e02a9ff09e8b609b67f3c05e2"
 "checksum thread-scoped 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bcbb6aa301e5d3b0b5ef639c9a9c7e2f1c944f177b460c04dc24c69b1fa2bd99"
 "checksum thread_local 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "8576dbbfcaef9641452d5cf0df9b0e7eeab7694956dd33bb61515fb8f18cfdd5"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
@@ -5824,6 +5854,7 @@ dependencies = [
 "checksum unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
+"checksum unix_socket2 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b57c6eace16c00eccb98a28e85db3370eab0685bdd5e13831d59e2bcb49a1d8a"
 "checksum unsigned-varint 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2c64cdf40b4a9645534a943668681bcb219faf51874d4b65d2e0abda1b10a2ab"
 "checksum untrusted 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "60369ef7a31de49bcb3f6ca728d4ba7300d9a1658f94c727d4cab8c8d9f4aece"
 "checksum url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3969,7 +3969,6 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-logger 0.22.0",
- "thread-priority 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unix_socket2 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -4735,14 +4734,6 @@ dependencies = [
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "thread-priority"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -5817,7 +5808,6 @@ dependencies = [
 "checksum thiserror-impl 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "45ba8d810d9c48fc456b7ad54574e8bfb7c7918a57ad7a6e6a0985d7959e8597"
 "checksum thread-id 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a9539db560102d1cef46b8b78ce737ff0bb64e7e18d35b2a5688f7d097d0ff03"
 "checksum thread-id 3.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c7fbf4c9d56b320106cd64fd024dadfa0be7cb4706725fc44a7d7ce952d820c1"
-"checksum thread-priority 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e655c097854cf47b40825a61c2edf7b96119ce9e02a9ff09e8b609b67f3c05e2"
 "checksum thread-scoped 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bcbb6aa301e5d3b0b5ef639c9a9c7e2f1c944f177b460c04dc24c69b1fa2bd99"
 "checksum thread_local 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "8576dbbfcaef9641452d5cf0df9b0e7eeab7694956dd33bb61515fb8f18cfdd5"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3351,6 +3351,7 @@ dependencies = [
  "solana-sdk 0.22.0",
  "solana-stake-program 0.22.0",
  "solana-storage-program 0.22.0",
+ "solana-sys-tuner 0.22.0",
  "solana-vote-program 0.22.0",
  "solana-vote-signer 0.22.0",
  "symlink 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3962,13 +3963,12 @@ dependencies = [
 
 [[package]]
 name = "solana-sys-tuner"
-version = "0.1.0"
+version = "0.22.0"
 dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-clap-utils 0.21.0",
- "solana-logger 0.21.0",
+ "solana-logger 0.22.0",
  "thread-priority 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unix_socket2 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ members = [
     "runtime",
     "sdk",
     "sdk-c",
+    "sys-tuner",
     "upload-perf",
     "net-utils",
     "fixed-buf",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -60,6 +60,7 @@ solana-stake-program = { path = "../programs/stake", version = "0.22.0" }
 solana-storage-program = { path = "../programs/storage", version = "0.22.0" }
 solana-vote-program = { path = "../programs/vote", version = "0.22.0" }
 solana-vote-signer = { path = "../vote-signer", version = "0.22.0" }
+solana-sys-tuner = { path = "../sys-tuner", version = "0.22.0" }
 symlink = "0.1.0"
 sys-info = "0.5.8"
 tempfile = "3.1.0"

--- a/core/src/poh_service.rs
+++ b/core/src/poh_service.rs
@@ -31,7 +31,7 @@ impl PohService {
         let tick_producer = Builder::new()
             .name("solana-poh-service-tick_producer".to_string())
             .spawn(move || {
-                solana_sys_tuner::request_system_tuning();
+                solana_sys_tuner::request_realtime_poh();
                 if poh_config.hashes_per_tick.is_none() {
                     if poh_config.target_tick_count.is_none() {
                         Self::sleepy_tick_producer(poh_recorder, &poh_config, &poh_exit_);

--- a/core/src/poh_service.rs
+++ b/core/src/poh_service.rs
@@ -3,6 +3,7 @@
 use crate::poh_recorder::PohRecorder;
 use core_affinity;
 use solana_sdk::poh_config::PohConfig;
+use solana_sys_tuner;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::thread::{self, sleep, Builder, JoinHandle};
@@ -47,6 +48,7 @@ impl PohService {
                     if let Some(cores) = core_affinity::get_core_ids() {
                         core_affinity::set_for_current(cores[0]);
                     }
+                    solana_sys_tuner::request_system_tuning();
                     Self::tick_producer(poh_recorder, &poh_exit_);
                 }
                 poh_exit_.store(true, Ordering::Relaxed);

--- a/core/src/poh_service.rs
+++ b/core/src/poh_service.rs
@@ -31,6 +31,7 @@ impl PohService {
         let tick_producer = Builder::new()
             .name("solana-poh-service-tick_producer".to_string())
             .spawn(move || {
+                solana_sys_tuner::request_system_tuning();
                 if poh_config.hashes_per_tick.is_none() {
                     if poh_config.target_tick_count.is_none() {
                         Self::sleepy_tick_producer(poh_recorder, &poh_config, &poh_exit_);
@@ -48,7 +49,6 @@ impl PohService {
                     if let Some(cores) = core_affinity::get_core_ids() {
                         core_affinity::set_for_current(cores[0]);
                     }
-                    solana_sys_tuner::request_system_tuning();
                     Self::tick_producer(poh_recorder, &poh_exit_);
                 }
                 poh_exit_.store(true, Ordering::Relaxed);

--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -129,7 +129,8 @@ cat >> ~/solana/on-reboot <<EOF
   # shellcheck source=/dev/null
   SUDO_OK=1 source scripts/tune-system.sh
 
-  sudo solana-sys-tuner &
+  sudo RUST_LOG=info ~solana/.cargo/bin/solana-sys-tuner > sys-tuner.log 2>&1 &
+  echo \$! > sys-tuner.pid
 
   (
     sudo SOLANA_METRICS_CONFIG="$SOLANA_METRICS_CONFIG" scripts/oom-monitor.sh

--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -129,6 +129,8 @@ cat >> ~/solana/on-reboot <<EOF
   # shellcheck source=/dev/null
   SUDO_OK=1 source scripts/tune-system.sh
 
+  sudo solana-sys-tuner &
+
   (
     sudo SOLANA_METRICS_CONFIG="$SOLANA_METRICS_CONFIG" scripts/oom-monitor.sh
   ) > oom-monitor.log 2>&1 &

--- a/scripts/cargo-install-all.sh
+++ b/scripts/cargo-install-all.sh
@@ -82,6 +82,7 @@ BINS=(
   solana-log-analyzer
   solana-net-shaper
   solana-archiver
+  solana-sys-tuner
   solana-validator
 )
 

--- a/sys-tuner/Cargo.toml
+++ b/sys-tuner/Cargo.toml
@@ -21,7 +21,6 @@ users = "0.9.1"
 nix = "0.16.0"
 
 [lib]
-crate-type = ["lib"]
 name = "solana_sys_tuner"
 
 [[bin]]

--- a/sys-tuner/Cargo.toml
+++ b/sys-tuner/Cargo.toml
@@ -17,7 +17,7 @@ solana-clap-utils = { path = "../clap-utils", version = "0.21.0" }
 solana-logger = { path = "../logger", version = "0.21.0" }
 unix_socket2 = "0.5.4"
 
-[target."cfg(linux)".dependencies]
+[target."cfg(unix)".dependencies]
 thread-priority = "0.1.0"
 
 [[bin]]

--- a/sys-tuner/Cargo.toml
+++ b/sys-tuner/Cargo.toml
@@ -14,7 +14,11 @@ clap = "2.33.0"
 log = "0.4.8"
 semver = "0.9.0"
 solana-logger = { path = "../logger", version = "0.22.0" }
+
+[target."cfg(unix)".dependencies]
 unix_socket2 = "0.5.4"
+users = "0.9.1"
+nix = "0.16.0"
 
 [lib]
 crate-type = ["lib"]

--- a/sys-tuner/Cargo.toml
+++ b/sys-tuner/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Solana Maintainers <maintainers@solana.com>"]
 edition = "2018"
 name = "solana-sys-tuner"
 description = "The solana cluster system tuner daemon"
-version = "0.1.0"
+version = "0.22.0"
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 homepage = "https://solana.com/"
@@ -13,12 +13,15 @@ publish = true
 clap = "2.33.0"
 log = "0.4.8"
 semver = "0.9.0"
-solana-clap-utils = { path = "../clap-utils", version = "0.21.0" }
-solana-logger = { path = "../logger", version = "0.21.0" }
+solana-logger = { path = "../logger", version = "0.22.0" }
 unix_socket2 = "0.5.4"
 
-[target."cfg(unix)".dependencies]
+[target."cfg(target_os = \"linux\")".dependencies]
 thread-priority = "0.1.0"
+
+[lib]
+crate-type = ["lib"]
+name = "solana_sys_tuner"
 
 [[bin]]
 name = "solana-sys-tuner"

--- a/sys-tuner/Cargo.toml
+++ b/sys-tuner/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+authors = ["Solana Maintainers <maintainers@solana.com>"]
+edition = "2018"
+name = "solana-sys-tuner"
+description = "The solana cluster system tuner daemon"
+version = "0.1.0"
+repository = "https://github.com/solana-labs/solana"
+license = "Apache-2.0"
+homepage = "https://solana.com/"
+publish = true
+
+[dependencies]
+clap = "2.33.0"
+log = "0.4.8"
+semver = "0.9.0"
+solana-clap-utils = { path = "../clap-utils", version = "0.21.0" }
+solana-logger = { path = "../logger", version = "0.21.0" }
+unix_socket2 = "0.5.4"
+
+[target."cfg(linux)".dependencies]
+thread-priority = "0.1.0"
+
+[[bin]]
+name = "solana-sys-tuner"
+path = "src/main.rs"

--- a/sys-tuner/Cargo.toml
+++ b/sys-tuner/Cargo.toml
@@ -16,9 +16,6 @@ semver = "0.9.0"
 solana-logger = { path = "../logger", version = "0.22.0" }
 unix_socket2 = "0.5.4"
 
-[target."cfg(target_os = \"linux\")".dependencies]
-thread-priority = "0.1.0"
-
 [lib]
 crate-type = ["lib"]
 name = "solana_sys_tuner"

--- a/sys-tuner/src/lib.rs
+++ b/sys-tuner/src/lib.rs
@@ -1,8 +1,7 @@
-use crate::main::SOLANA_SYS_TUNER_PATH;
 use log::*;
 use unix_socket::UnixStream;
 
-pub mod main;
+pub const SOLANA_SYS_TUNER_PATH: &str = "/tmp/solana-sys-tuner";
 
 pub fn request_realtime_poh() {
     info!("Sending tuning request");

--- a/sys-tuner/src/lib.rs
+++ b/sys-tuner/src/lib.rs
@@ -1,8 +1,11 @@
 use crate::main::SOLANA_SYS_TUNER_PATH;
+use log::*;
 use unix_socket::UnixStream;
 
 pub mod main;
 
 pub fn request_system_tuning() {
-    let _ignore = UnixStream::connect(SOLANA_SYS_TUNER_PATH);
+    info!("Sending tuning request");
+    let status = UnixStream::connect(SOLANA_SYS_TUNER_PATH);
+    info!("Tuning request status {:?}", status);
 }

--- a/sys-tuner/src/lib.rs
+++ b/sys-tuner/src/lib.rs
@@ -1,0 +1,8 @@
+use crate::main::SOLANA_SYS_TUNER_PATH;
+use unix_socket::UnixStream;
+
+pub mod main;
+
+pub fn request_system_tuning() {
+    let _ignore = UnixStream::connect(SOLANA_SYS_TUNER_PATH);
+}

--- a/sys-tuner/src/lib.rs
+++ b/sys-tuner/src/lib.rs
@@ -4,7 +4,7 @@ use unix_socket::UnixStream;
 
 pub mod main;
 
-pub fn request_system_tuning() {
+pub fn request_realtime_poh() {
     info!("Sending tuning request");
     let status = UnixStream::connect(SOLANA_SYS_TUNER_PATH);
     info!("Tuning request status {:?}", status);

--- a/sys-tuner/src/main.rs
+++ b/sys-tuner/src/main.rs
@@ -5,10 +5,10 @@ use unix_socket::UnixListener;
 pub const SOLANA_SYS_TUNER_PATH: &str = "/tmp/solana-sys-tuner";
 
 // Use abstract sockets for Unix builds
-#[cfg(all(unix, target_os = "unix"))]
+#[cfg(all(unix, target_os = "linux"))]
 pub const SOLANA_SYS_TUNER_PATH: &str = "\0/tmp/solana-sys-tuner";
 
-#[cfg(target_os = "unix")]
+#[cfg(target_os = "linux")]
 fn tune_system() {
     use std::process::Command;
     use std::str::from_utf8;
@@ -25,9 +25,8 @@ fn tune_system() {
             for t in threads.iter_mut() {
                 if let Some(_) = t.find("solana-poh-ser") {
                     let pids: Vec<&str> = t.split_whitespace().collect();
-                    println!("{}", pids[1]);
-                    let thread_id = pids[1].parse::<i32>().unwrap();
-                    set_thread_priority(
+                    let thread_id = pids[1].parse::<u64>().unwrap();
+                    let _ignored = set_thread_priority(
                         thread_id,
                         ThreadPriority::Max,
                         ThreadSchedulePolicy::Realtime(RealtimeThreadSchedulePolicy::Fifo),
@@ -36,8 +35,6 @@ fn tune_system() {
                 }
             }
         }
-    } else {
-        println!("stderr: {}", from_utf8(&output.stderr).unwrap_or("?"));
     }
 }
 

--- a/sys-tuner/src/main.rs
+++ b/sys-tuner/src/main.rs
@@ -1,0 +1,62 @@
+use std::fs;
+use unix_socket::UnixListener;
+
+#[cfg(any(not(unix), target_os = "macos"))]
+pub const SOLANA_SYS_TUNER_PATH: &str = "/tmp/solana-sys-tuner";
+
+// Use abstract sockets for Unix builds
+#[cfg(all(unix, target_os = "unix"))]
+pub const SOLANA_SYS_TUNER_PATH: &str = "\0/tmp/solana-sys-tuner";
+
+#[cfg(target_os = "unix")]
+fn tune_system() {
+    use std::process::Command;
+    use std::str::from_utf8;
+    use thread_priority::*;
+
+    let output = Command::new("ps")
+        .arg("-eT")
+        .output()
+        .expect("Expected to see all threads");
+
+    if output.status.success() {
+        if let Ok(threads) = from_utf8(&output.stdout) {
+            let mut threads: Vec<&str> = threads.split('\n').collect();
+            for t in threads.iter_mut() {
+                if let Some(_) = t.find("solana-poh-ser") {
+                    let pids: Vec<&str> = t.split_whitespace().collect();
+                    println!("{}", pids[1]);
+                    let thread_id = pids[1].parse::<i32>().unwrap();
+                    set_thread_priority(
+                        thread_id,
+                        ThreadPriority::Max,
+                        ThreadSchedulePolicy::Realtime(RealtimeThreadSchedulePolicy::Fifo),
+                    );
+                    break;
+                }
+            }
+        }
+    } else {
+        println!("stderr: {}", from_utf8(&output.stderr).unwrap_or("?"));
+    }
+}
+
+#[cfg(any(not(unix), target_os = "macos"))]
+fn tune_system() {}
+
+fn main() {
+    solana_logger::setup();
+    let listener = match UnixListener::bind(SOLANA_SYS_TUNER_PATH) {
+        Ok(l) => l,
+        Err(_) => {
+            fs::remove_file(SOLANA_SYS_TUNER_PATH).unwrap();
+            UnixListener::bind(SOLANA_SYS_TUNER_PATH).unwrap()
+        }
+    };
+
+    for stream in listener.incoming() {
+        if stream.is_ok() {
+            tune_system();
+        }
+    }
+}

--- a/sys-tuner/src/main.rs
+++ b/sys-tuner/src/main.rs
@@ -8,6 +8,7 @@ pub const SOLANA_SYS_TUNER_PATH: &str = "/tmp/solana-sys-tuner";
 #[cfg(all(unix, target_os = "linux"))]
 pub const SOLANA_SYS_TUNER_PATH: &str = "\0/tmp/solana-sys-tuner";
 
+#[allow(dead_code)]
 #[cfg(target_os = "linux")]
 fn tune_system() {
     use std::process::Command;
@@ -23,7 +24,7 @@ fn tune_system() {
         if let Ok(threads) = from_utf8(&output.stdout) {
             let mut threads: Vec<&str> = threads.split('\n').collect();
             for t in threads.iter_mut() {
-                if let Some(_) = t.find("solana-poh-ser") {
+                if t.find("solana-poh-ser").is_some() {
                     let pids: Vec<&str> = t.split_whitespace().collect();
                     let thread_id = pids[1].parse::<u64>().unwrap();
                     let _ignored = set_thread_priority(
@@ -38,9 +39,11 @@ fn tune_system() {
     }
 }
 
+#[allow(dead_code)]
 #[cfg(any(not(unix), target_os = "macos"))]
 fn tune_system() {}
 
+#[allow(dead_code)]
 fn main() {
     solana_logger::setup();
     let listener = match UnixListener::bind(SOLANA_SYS_TUNER_PATH) {

--- a/sys-tuner/src/main.rs
+++ b/sys-tuner/src/main.rs
@@ -1,14 +1,17 @@
 use log::*;
 use std::{fs, io};
 
-use std::fs::DirEntry;
-use std::path::Path;
+use solana_sys_tuner::SOLANA_SYS_TUNER_PATH;
+
 #[cfg(unix)]
 use unix_socket::UnixListener;
 
-pub const SOLANA_SYS_TUNER_PATH: &str = "/tmp/solana-sys-tuner";
+#[cfg(target_os = "linux")]
+use std::fs::DirEntry;
+#[cfg(target_os = "linux")]
+use std::path::Path;
 
-#[allow(dead_code)]
+#[cfg(target_os = "linux")]
 fn find_pid<P: AsRef<Path>, F>(name: &str, path: P, processor: F) -> Option<u64>
 where
     F: Fn(&DirEntry) -> Option<u64>,
@@ -30,7 +33,6 @@ where
     None
 }
 
-#[allow(dead_code)]
 #[cfg(target_os = "linux")]
 fn tune_system() {
     use std::process::Command;
@@ -63,7 +65,6 @@ fn tune_system() {
     }
 }
 
-#[allow(dead_code)]
 #[cfg(any(not(unix), target_os = "macos"))]
 fn tune_system() {}
 
@@ -84,11 +85,9 @@ fn set_socket_permissions() {
     }
 }
 
-#[allow(dead_code)]
 #[cfg(any(not(unix), target_os = "macos"))]
 fn set_socket_permissions() {}
 
-#[allow(dead_code)]
 fn main() {
     solana_logger::setup();
     if let Err(e) = fs::remove_file(SOLANA_SYS_TUNER_PATH) {


### PR DESCRIPTION
#### Problem
The PoH service thread scheduling policy and priority cannot be tuned unless we use a shell script. Using the shell script is not a viable option for external nodes.

#### Summary of Changes
Added a new daemon `sys_tuner` that runs at a higher privilege. It listens on a local domain socket. When validator boots up, the `poh_service` connects to the socket. It triggers the `sys_tuner` to look up `poh_service's` thread ID, and adjust its priority and scheduling policy.

Fixes #6482 
