### PR TITLE
Add analyze-storage command to ledger-tool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1310,6 +1310,11 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "histogram"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "hmac"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3616,6 +3621,7 @@ dependencies = [
  "assert_cmd 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bincode 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "histogram 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5623,6 +5629,7 @@ dependencies = [
 "checksum hex-literal 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "961de220ec9a91af2e1e5bd80d02109155695e516771762381ef8581317066e0"
 "checksum hex-literal-impl 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "06095d08c7c05760f11a071b3e1d4c5b723761c01bd8d7201c30a9536668a612"
 "checksum hex_fmt 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b07f60793ff0a4d9cef0f18e63b5357e06209987153a64648c972c1e5aff336f"
+"checksum histogram 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)" = "12cb882ccb290b8646e554b157ab0b71e64e8d5bef775cd66b6531e52d302669"
 "checksum hmac 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5dcb5e64cda4c23119ab41ba960d1e170a774c8e4b9d9e6a9bc18aabf5e59695"
 "checksum http 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)" = "372bcb56f939e449117fb0869c2e8fd8753a8223d92a172c6e808cf123a5b6e4"
 "checksum http-body 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6741c859c1b2463a423a1dbce98d418e6c3c3fc720fb0d45528657320920292d"

--- a/ledger-tool/Cargo.toml
+++ b/ledger-tool/Cargo.toml
@@ -11,6 +11,7 @@ homepage = "https://solana.com/"
 [dependencies]
 bincode = "1.2.1"
 clap = "2.33.0"
+histogram = "*"
 serde = "1.0.103"
 serde_derive = "1.0.103"
 serde_json = "1.0.44"

--- a/ledger/src/blocktree.rs
+++ b/ledger/src/blocktree.rs
@@ -148,6 +148,10 @@ impl BlocktreeInsertionMetrics {
 }
 
 impl Blocktree {
+    pub fn db(self) -> Arc<Database> {
+        self.db
+    }
+
     /// Opens a Ledger in directory, provides "infinite" window of shreds
     pub fn open(ledger_path: &Path) -> Result<Blocktree> {
         fs::create_dir_all(&ledger_path)?;

--- a/ledger/src/blocktree_db.rs
+++ b/ledger/src/blocktree_db.rs
@@ -228,6 +228,10 @@ pub trait Column {
     const NAME: &'static str;
     type Index;
 
+    fn key_size() -> usize {
+        std::mem::size_of::<Self::Index>()
+    }
+
     fn key(index: Self::Index) -> Vec<u8>;
     fn index(key: &[u8]) -> Self::Index;
     fn slot(index: Self::Index) -> Slot;

--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -3,7 +3,7 @@ pub mod bank_forks_utils;
 pub mod block_error;
 #[macro_use]
 pub mod blocktree;
-mod blocktree_db;
+pub mod blocktree_db;
 mod blocktree_meta;
 pub mod blocktree_processor;
 pub mod entry;


### PR DESCRIPTION
#### Problem(s)

* prod storage is filling up quickly even for networks at rest
* admins don't have insight into which column families are using/wasting rocksdb storage
* standard rocksdb tools (a) may not be present on prod systems and (b) don't know about solana datatypes

#### Summary of Changes

* expose a `db` handle from `blocktree_db` so we can introspect the column families
* implement a `key_size()` method for `Column` instances for data usage computation
* extend ledger-tool with `analyze-storage` command to provide statistics about key/value sizes and percentiles

Fixes # N/A
