### PR TITLE
Dont process entries in case of failed CPU verification

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -1118,7 +1118,7 @@ mod tests {
                 .collect();
             trace!("done");
             assert_eq!(entries.len(), genesis_config.ticks_per_slot as usize);
-            assert!(entries.verify(&start_hash));
+            assert_eq!(entries.verify(&start_hash), true);
             assert_eq!(entries[entries.len() - 1].hash, bank.last_blockhash());
             banking_stage.join().unwrap();
         }
@@ -1220,7 +1220,7 @@ mod tests {
                     .map(|(_bank, (entry, _tick_height))| entry)
                     .collect();
 
-                assert!(entries.verify(&blockhash));
+                assert_eq!(entries.verify(&blockhash), true);
                 if !entries.is_empty() {
                     blockhash = entries.last().unwrap().hash;
                     for entry in entries {

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -9,6 +9,7 @@ use crate::{
     rpc_subscriptions::RpcSubscriptions,
     thread_mem_usage,
 };
+use solana_ledger::entry::EntryVerificationStatus;
 use solana_ledger::{
     bank_forks::BankForks,
     block_error::BlockError,
@@ -1070,6 +1071,10 @@ impl ReplayStage {
         datapoint_debug!("verify-batch-size", ("size", entries.len() as i64, i64));
         let mut verify_total = Measure::start("verify_and_process_entries");
         let mut entry_state = entries.start_verify(last_entry, recyclers.clone());
+
+        if entry_state.status() == EntryVerificationStatus::Failure {
+            return handle_block_error(BlockError::InvalidEntryHash);
+        }
 
         let mut replay_elapsed = Measure::start("replay_elapsed");
         let res =

--- a/local-cluster/src/cluster_tests.rs
+++ b/local-cluster/src/cluster_tests.rs
@@ -303,7 +303,7 @@ fn poll_all_nodes_for_signature(
 
 fn get_and_verify_slot_entries(blocktree: &Blocktree, slot: Slot, last_entry: &Hash) -> Vec<Entry> {
     let entries = blocktree.get_slot_entries(slot, 0, None).unwrap();
-    assert!(entries.verify(last_entry));
+    assert_eq!(entries.verify(last_entry), true);
     entries
 }
 


### PR DESCRIPTION
#### Problem
In case of CPU entry verification, we are processing entries even though the verification is already failed.

#### Summary of Changes
Refactor `EntryVerificationState` to include a `EntryVerificationStatus` enum and `status` method, which can be used to bail out earlier in case verification is failed

Fixes #7168
