### PR TITLE
Add ReplayStageConfig

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -346,7 +346,7 @@ impl Validator {
         let voting_keypair = if config.voting_disabled {
             None
         } else {
-            Some(voting_keypair)
+            Some(voting_keypair.clone())
         };
 
         let tvu = Tvu::new(


### PR DESCRIPTION
#### Problem

The `ReplayStage::new()` function takes way too many parameters. This makes it difficult to write tests that call that function.

#### Summary of Changes

Add a `ReplayStageConfig` struct that is passed to `ReplayStage::new()`. Un-genericise `ReplayStage::new()` and `Tvu::new()` over the `voting_keypair` argument. Re-enable two clippy lints.
