### PR TITLE
sys-tuner: Fix windows build

### DIFF
--- a/sys-tuner/src/lib.rs
+++ b/sys-tuner/src/lib.rs
@@ -1,10 +1,15 @@
 use log::*;
-use unix_socket::UnixStream;
 
 pub const SOLANA_SYS_TUNER_PATH: &str = "/tmp/solana-sys-tuner";
 
+#[cfg(unix)]
 pub fn request_realtime_poh() {
     info!("Sending tuning request");
-    let status = UnixStream::connect(SOLANA_SYS_TUNER_PATH);
+    let status = unix_socket::UnixStream::connect(SOLANA_SYS_TUNER_PATH);
     info!("Tuning request status {:?}", status);
+}
+
+#[cfg(not(unix))]
+pub fn request_realtime_poh() {
+    info!("Tuning request ignored on this platform");
 }


### PR DESCRIPTION
`use unix_socket::UnixStream;` is not available when building for Windows, hide it behind a cfg flag
