### PR TITLE
net-utils: Ensure IpEchoServerMessage is not fragmented

### DIFF
--- a/net-utils/src/ip_echo_server.rs
+++ b/net-utils/src/ip_echo_server.rs
@@ -70,6 +70,19 @@ pub fn ip_echo_server(tcp: std::net::TcpListener) -> IpEchoServer {
                         ));
                     }
 
+                    let expected_len =
+                        bincode::serialized_size(&IpEchoServerMessage::default()).unwrap() as usize;
+                    let actual_len = data[4..].len();
+                    if actual_len < expected_len {
+                        return Err(io::Error::new(
+                            io::ErrorKind::Other,
+                            format!(
+                                "Request too short, actual {} < expected {}",
+                                actual_len, expected_len
+                            ),
+                        ));
+                    }
+
                     bincode::deserialize::<IpEchoServerMessage>(&data[4..])
                         .map(Some)
                         .or_else(|err| {


### PR DESCRIPTION
This is likely the cause of the CI failures today that don't reproduce locally