### PR TITLE
enforce proper range for rent burn_percent

### DIFF
--- a/clap-utils/src/input_validators.rs
+++ b/clap-utils/src/input_validators.rs
@@ -97,3 +97,24 @@ pub fn is_port(port: String) -> Result<(), String> {
         .map(|_| ())
         .map_err(|e| format!("{:?}", e))
 }
+
+pub fn is_valid_percentage(percentage: String) -> Result<(), String> {
+    percentage
+        .parse::<u8>()
+        .map_err(|e| {
+            format!(
+                "Unable to parse input percentage, provided: {}, err: {:?}",
+                percentage, e
+            )
+        })
+        .and_then(|v| {
+            if v > 100 {
+                Err(format!(
+                    "Percentage must be in range of 0 to 100, provided: {}",
+                    v
+                ))
+            } else {
+                Ok(())
+            }
+        })
+}

--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -120,7 +120,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
         (
             &rent.lamports_per_byte_year.to_string(),
             &rent.exemption_threshold.to_string(),
-            &rent.burn_percent.to_string(),
+            &rent.get_burn_percentage().to_string(),
         )
     };
     let default_target_tick_duration =
@@ -333,11 +333,19 @@ fn main() -> Result<(), Box<dyn error::Error>> {
     let bootstrap_storage_pubkey = pubkey_of(&matches, "bootstrap_storage_pubkey_file");
     let faucet_pubkey = pubkey_of(&matches, "faucet_pubkey_file");
 
-    let rent = Rent {
-        lamports_per_byte_year: value_t_or_exit!(matches, "lamports_per_byte_year", u64),
-        exemption_threshold: value_t_or_exit!(matches, "rent_exemption_threshold", f64),
-        burn_percent: value_t_or_exit!(matches, "rent_burn_percentage", u8),
-    };
+    let rent_burn_percentage = value_t_or_exit!(matches, "rent_burn_percentage", u8);
+    if rent_burn_percentage > 100 {
+        panic!(
+            "rent burn percentage cannot be greater than 100, provided: {}",
+            rent_burn_percentage
+        );
+    }
+
+    let rent = Rent::new(
+        value_t_or_exit!(matches, "lamports_per_byte_year", u64),
+        value_t_or_exit!(matches, "rent_exemption_threshold", f64),
+        rent_burn_percentage,
+    );
 
     let bootstrap_leader_vote_account =
         vote_state::create_account(&bootstrap_vote_pubkey, &bootstrap_leader_pubkey, 0, 1);

--- a/genesis/src/stakes.rs
+++ b/genesis/src/stakes.rs
@@ -178,7 +178,11 @@ mod tests {
     fn test_create_stakes() {
         // 2 unlocks
 
-        let rent = Rent::new(1, 1.0, 100);
+        let rent = Rent {
+            lamports_per_byte_year: 1,
+            exemption_threshold: 1.0,
+            ..Rent::default()
+        };
 
         let reserve = get_stake_rent_exempt_reserve(&rent);
 

--- a/genesis/src/stakes.rs
+++ b/genesis/src/stakes.rs
@@ -178,11 +178,7 @@ mod tests {
     fn test_create_stakes() {
         // 2 unlocks
 
-        let rent = Rent {
-            lamports_per_byte_year: 1,
-            exemption_threshold: 1.0,
-            ..Rent::default()
-        };
+        let rent = Rent::new(1, 1.0, 100);
 
         let reserve = get_stake_rent_exempt_reserve(&rent);
 

--- a/programs/stake/src/stake_state.rs
+++ b/programs/stake/src/stake_state.rs
@@ -1391,7 +1391,10 @@ mod tests {
             stake_keyed_account.initialize(
                 &Authorized::default(),
                 &Lockup::default(),
-                &Rent::new(42, 1.0, 100),
+                &Rent {
+                    lamports_per_byte_year: 42,
+                    ..Rent::default()
+                },
             ),
             Err(InstructionError::InsufficientFunds)
         );

--- a/programs/stake/src/stake_state.rs
+++ b/programs/stake/src/stake_state.rs
@@ -1391,10 +1391,7 @@ mod tests {
             stake_keyed_account.initialize(
                 &Authorized::default(),
                 &Lockup::default(),
-                &Rent {
-                    lamports_per_byte_year: 42,
-                    ..Rent::default()
-                }
+                &Rent::new(42, 1.0, 100),
             ),
             Err(InstructionError::InsufficientFunds)
         );

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1214,9 +1214,8 @@ impl Bank {
         let total_rent_collected = self.collected_rent.load(Ordering::Relaxed);
 
         if total_rent_collected != 0 {
-            let burned_portion = (total_rent_collected
-                * u64::from(self.rent_collector.rent.get_burn_percentage()))
-                / 100;
+            let burned_portion =
+                (total_rent_collected * u64::from(self.rent_collector.rent.burn_percent)) / 100;
             let _rent_to_be_distributed = total_rent_collected - burned_portion;
             // TODO: distribute remaining rent amount to validators
             // self.capitalization.fetch_sub(burned_portion, Ordering::Relaxed);
@@ -1708,7 +1707,11 @@ mod tests {
             dummy_leader_lamports,
         );
 
-        genesis_config.rent = Rent::new(5, 1.2, 5);
+        genesis_config.rent = Rent {
+            lamports_per_byte_year: 5,
+            exemption_threshold: 1.2,
+            burn_percent: 5,
+        };
 
         let bank = Bank::new(&genesis_config);
         assert_eq!(bank.get_balance(&mint_keypair.pubkey()), mint_lamports);
@@ -1720,7 +1723,7 @@ mod tests {
         let rent_account = bank.get_account(&sysvar::rent::id()).unwrap();
         let rent = sysvar::rent::Rent::from_account(&rent_account).unwrap();
 
-        assert_eq!(rent.get_burn_percentage(), 5);
+        assert_eq!(rent.burn_percent, 5);
         assert_eq!(rent.exemption_threshold, 1.2);
         assert_eq!(rent.lamports_per_byte_year, 5);
     }
@@ -1789,7 +1792,11 @@ mod tests {
         let keypair5: Keypair = Keypair::new();
         let keypair6: Keypair = Keypair::new();
 
-        genesis_config.rent = Rent::new(1, 21.0, 10);
+        genesis_config.rent = Rent {
+            lamports_per_byte_year: 1,
+            exemption_threshold: 21.0,
+            burn_percent: 10,
+        };
 
         let root_bank = Arc::new(Bank::new(&genesis_config));
         let bank = Bank::new_from_parent(
@@ -2058,7 +2065,11 @@ mod tests {
             keypairs.push(Keypair::new());
         }
 
-        genesis_config.rent = Rent::new(1, 1000.0, 10);
+        genesis_config.rent = Rent {
+            lamports_per_byte_year: 1,
+            exemption_threshold: 21.0,
+            burn_percent: 10,
+        };
 
         let root_bank = Arc::new(Bank::new(&genesis_config));
         let bank = create_child_bank_for_rent_test(&root_bank, &genesis_config, mock_program_id);

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2067,7 +2067,7 @@ mod tests {
 
         genesis_config.rent = Rent {
             lamports_per_byte_year: 1,
-            exemption_threshold: 21.0,
+            exemption_threshold: 1000.0,
             burn_percent: 10,
         };
 

--- a/sdk/src/rent.rs
+++ b/sdk/src/rent.rs
@@ -10,7 +10,7 @@ pub struct Rent {
     pub exemption_threshold: f64,
 
     // What portion of collected rent are to be destroyed, percentage-wise
-    burn_percent: u8,
+    pub burn_percent: u8,
 }
 
 /// default rental rate in lamports/byte-year, based on:
@@ -40,10 +40,6 @@ impl Default for Rent {
 }
 
 impl Rent {
-    pub fn get_burn_percentage(&self) -> u8 {
-        self.burn_percent
-    }
-
     /// minimum balance due for a given size Account::data.len()
     pub fn minimum_balance(&self, data_len: usize) -> u64 {
         let bytes = data_len as u64;
@@ -67,16 +63,6 @@ impl Rent {
                     * years_elapsed) as u64,
                 false,
             )
-        }
-    }
-
-    pub fn new(lamports_per_byte_year: u64, exemption_threshold: f64, burn_percent: u8) -> Self {
-        assert!(burn_percent <= 100);
-
-        Rent {
-            lamports_per_byte_year,
-            exemption_threshold,
-            burn_percent,
         }
     }
 

--- a/sdk/src/rent.rs
+++ b/sdk/src/rent.rs
@@ -10,7 +10,7 @@ pub struct Rent {
     pub exemption_threshold: f64,
 
     // What portion of collected rent are to be destroyed, percentage-wise
-    pub burn_percent: u8,
+    burn_percent: u8,
 }
 
 /// default rental rate in lamports/byte-year, based on:
@@ -23,8 +23,8 @@ pub const DEFAULT_LAMPORTS_PER_BYTE_YEAR: u64 = 0; //1_000_000_000 / 100 * 365 /
 /// default amount of time (in years) the balance has to include rent for
 pub const DEFAULT_EXEMPTION_THRESHOLD: f64 = 2.0;
 
-/// default amount of rent to burn, as a fraction of std::u8::MAX
-pub const DEFAULT_BURN_PERCENT: u8 = ((50usize * std::u8::MAX as usize) / 100usize) as u8;
+/// default percentage of rent to burn (Valid values are 0 to 100)
+pub const DEFAULT_BURN_PERCENT: u8 = 100;
 
 /// account storage overhead for calculation of base rent
 pub const ACCOUNT_STORAGE_OVERHEAD: u64 = 128;
@@ -40,6 +40,10 @@ impl Default for Rent {
 }
 
 impl Rent {
+    pub fn get_burn_percentage(&self) -> u8 {
+        self.burn_percent
+    }
+
     /// minimum balance due for a given size Account::data.len()
     pub fn minimum_balance(&self, data_len: usize) -> u64 {
         let bytes = data_len as u64;
@@ -63,6 +67,16 @@ impl Rent {
                     * years_elapsed) as u64,
                 false,
             )
+        }
+    }
+
+    pub fn new(lamports_per_byte_year: u64, exemption_threshold: f64, burn_percent: u8) -> Self {
+        assert!(burn_percent <= 100);
+
+        Rent {
+            lamports_per_byte_year,
+            exemption_threshold,
+            burn_percent,
         }
     }
 


### PR DESCRIPTION
#### Problem
Currently, rent burn percent is defined to be in range of 0 to 255 (std::u8::Max), which is unnecessary, and offers little advantage over standard percentage range of 0 to 100.

#### Summary of Changes
proper range for `burn_percent` is enforced.

Fixes #7189 
