### PR TITLE
enforce proper range for tx fee burn_percent

### DIFF
--- a/sdk/src/fee_calculator.rs
+++ b/sdk/src/fee_calculator.rs
@@ -28,7 +28,9 @@ pub struct FeeCalculator {
 pub const DEFAULT_TARGET_LAMPORTS_PER_SIGNATURE: u64 = 10_000;
 pub const DEFAULT_TARGET_SIGNATURES_PER_SLOT: usize =
     50_000 * DEFAULT_TICKS_PER_SLOT as usize / DEFAULT_TICKS_PER_SECOND as usize;
-pub const DEFAULT_BURN_PERCENT: u8 = ((50usize * std::u8::MAX as usize) / 100usize) as u8;
+
+// Percentage of tx fees to burn
+pub const DEFAULT_BURN_PERCENT: u8 = 50;
 
 impl Default for FeeCalculator {
     fn default() -> Self {
@@ -123,8 +125,8 @@ impl FeeCalculator {
 
     /// calculate unburned fee from a fee total, returns (unburned, burned)
     pub fn burn(&self, fees: u64) -> (u64, u64) {
-        let unburned = fees * u64::from(std::u8::MAX - self.burn_percent) / u64::from(std::u8::MAX);
-        (unburned, fees - unburned)
+        let burned = fees * u64::from(self.burn_percent) / 100;
+        (fees - burned, burned)
     }
 }
 
@@ -137,13 +139,12 @@ mod tests {
     #[test]
     fn test_fee_calculator_burn() {
         let mut fee_calculator = FeeCalculator::default();
-
         assert_eq!(fee_calculator.burn(2), (1, 1));
 
         fee_calculator.burn_percent = 0;
-
         assert_eq!(fee_calculator.burn(2), (2, 0));
-        fee_calculator.burn_percent = std::u8::MAX;
+
+        fee_calculator.burn_percent = 100;
         assert_eq!(fee_calculator.burn(2), (0, 2));
     }
 


### PR DESCRIPTION
#### Problem
Currently, tx fee burn percent is defined to be in range of 0 to 255 (std::u8::Max), which is unnecessary, and offers little advantage over standard percentage range of 0 to 100.

#### Summary of Changes
proper range for burn_percent is enforced.
