### PR TITLE
Fix ssh connection error due to too many authentication failures

### DIFF
--- a/net/common.sh
+++ b/net/common.sh
@@ -48,6 +48,7 @@ buildSshOptions() {
     -o "StrictHostKeyChecking=no"
     -o "UserKnownHostsFile=/dev/null"
     -o "User=solana"
+    -o "IdentitiesOnly=yes"
     -o "IdentityFile=$sshPrivateKey"
     -o "LogLevel=ERROR"
   )


### PR DESCRIPTION
#### Problem
Unable to boot testnet on GCP. The ssh is failing with these errors
```Received disconnect from 35.230.81.226 port 22:2: Too many authentication failures```

#### Summary of Changes
The error is due to too many keys on the local host. Added ssh option to only use the authentication identity files specified on the command line or the configured in the ssh_config file.