### PR TITLE
Protect sys-tuner socket access at create

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3978,6 +3978,7 @@ name = "solana-sys-tuner"
 version = "0.22.0"
 dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "nix 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/sys-tuner/Cargo.toml
+++ b/sys-tuner/Cargo.toml
@@ -12,6 +12,7 @@ publish = true
 [dependencies]
 clap = "2.33.0"
 log = "0.4.8"
+libc = "0.2.66"
 semver = "0.9.0"
 solana-logger = { path = "../logger", version = "0.22.0" }
 

--- a/sys-tuner/src/main.rs
+++ b/sys-tuner/src/main.rs
@@ -56,6 +56,7 @@ fn tune_system() {
 #[cfg(unix)]
 fn main() {
     solana_logger::setup();
+    unsafe { libc::umask(0o077) };
     if let Err(e) = std::fs::remove_file(solana_sys_tuner::SOLANA_SYS_TUNER_PATH) {
         if e.kind() != std::io::ErrorKind::NotFound {
             panic!("Failed to remove stale socket file: {:?}", e)


### PR DESCRIPTION
#### Problem
The socket used by `sys-tuner` grants random processes read and execute permissions. This is a potential security hole, as the daemon runs as root user.

#### Summary of Changes
Set umask to 077, so that only owner of socket has permissions to access it.

Fixes #7212 
