### PR TITLE
Add intermittent Timestamping to Votes

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -637,6 +637,8 @@ fn process_balance(
     use_lamports_unit: bool,
 ) -> ProcessResult {
     let pubkey = pubkey.unwrap_or(config.keypair.pubkey());
+    let string = solana_stake_program::id().to_string();
+    println!("{:}", string);
     let balance = rpc_client.retry_get_balance(&pubkey, 5)?;
     match balance {
         Some(lamports) => Ok(build_balance_message(lamports, use_lamports_unit, true)),

--- a/cli/src/vote.rs
+++ b/cli/src/vote.rs
@@ -353,6 +353,7 @@ pub fn process_show_vote_account(
             None => "~".to_string(),
         }
     );
+    println!("recent timestamp: {:?}", vote_state.last_timestamp);
     if !vote_state.votes.is_empty() {
         println!("recent votes:");
         for vote in &vote_state.votes {

--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -180,10 +180,7 @@ impl Tower {
         last_bank_slot: Option<Slot>,
     ) -> (Vote, usize) {
         let mut local_vote_state = local_vote_state.clone();
-        let vote = Vote {
-            slots: vec![slot],
-            hash,
-        };
+        let vote = Vote::new(vec![slot], hash);
         local_vote_state.process_vote_unchecked(&vote);
         let slots = if let Some(last_bank_slot) = last_bank_slot {
             local_vote_state
@@ -201,7 +198,7 @@ impl Tower {
             slots,
             local_vote_state.votes
         );
-        (Vote { slots, hash }, local_vote_state.votes.len() - 1)
+        (Vote::new(slots, hash), local_vote_state.votes.len() - 1)
     }
 
     fn last_bank_vote(bank: &Bank, vote_account_pubkey: &Pubkey) -> Option<Slot> {
@@ -235,10 +232,7 @@ impl Tower {
     }
 
     pub fn record_vote(&mut self, slot: Slot, hash: Hash) -> Option<Slot> {
-        let vote = Vote {
-            slots: vec![slot],
-            hash,
-        };
+        let vote = Vote::new(vec![slot], hash);
         self.record_bank_vote(vote)
     }
 
@@ -791,6 +785,7 @@ mod test {
         let vote = Vote {
             slots: vec![0],
             hash: Hash::default(),
+            timestamp: None,
         };
         local.process_vote_unchecked(&vote);
         assert_eq!(local.votes.len(), 1);
@@ -805,6 +800,7 @@ mod test {
         let vote = Vote {
             slots: vec![0],
             hash: Hash::default(),
+            timestamp: None,
         };
         local.process_vote_unchecked(&vote);
         assert_eq!(local.votes.len(), 1);

--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -9,7 +9,7 @@ use solana_sdk::{
     pubkey::Pubkey,
 };
 use solana_vote_program::vote_state::{
-    Lockout, Vote, VoteState, DEFAULT_TIMESTAMP_SLOTS, MAX_LOCKOUT_HISTORY,
+    Lockout, Vote, VoteState, TIMESTAMP_SLOT_INTERVAL, MAX_LOCKOUT_HISTORY,
 };
 use std::{
     collections::{HashMap, HashSet},
@@ -432,7 +432,7 @@ impl Tower {
 
     fn maybe_timestamp(&mut self, current_slot: Slot) -> Option<UnixTimestamp> {
         if self.last_timestamp.0 == 0
-            || self.last_timestamp.0 + DEFAULT_TIMESTAMP_SLOTS <= current_slot
+            || self.last_timestamp.0 + TIMESTAMP_SLOT_INTERVAL <= current_slot
         {
             let timestamp = Utc::now().timestamp();
             self.last_timestamp = (current_slot, timestamp);
@@ -922,7 +922,7 @@ mod test {
     #[test]
     fn test_maybe_timestamp() {
         let mut tower = Tower::default();
-        assert!(tower.maybe_timestamp(DEFAULT_TIMESTAMP_SLOTS).is_some());
+        assert!(tower.maybe_timestamp(TIMESTAMP_SLOT_INTERVAL).is_some());
         let (slot, timestamp) = tower.last_timestamp;
 
         assert_eq!(tower.maybe_timestamp(1), None);
@@ -931,7 +931,7 @@ mod test {
 
         sleep(Duration::from_secs(1));
         assert!(tower
-            .maybe_timestamp(slot + DEFAULT_TIMESTAMP_SLOTS + 1)
+            .maybe_timestamp(slot + TIMESTAMP_SLOT_INTERVAL + 1)
             .is_some());
         assert!(tower.last_timestamp.1 > timestamp);
     }

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -23,14 +23,14 @@ use solana_measure::measure::Measure;
 use solana_metrics::inc_new_counter_info;
 use solana_runtime::bank::Bank;
 use solana_sdk::{
-    clock::{Slot, DEFAULT_TIMESTAMP_INTERVAL_MINS},
+    clock::Slot,
     hash::Hash,
     pubkey::Pubkey,
     signature::{Keypair, KeypairUtil},
-    timing::{self, duration_as_ms, slots_per_interval},
+    timing::{self, duration_as_ms},
     transaction::Transaction,
 };
-use solana_vote_program::vote_instruction;
+use solana_vote_program::{vote_instruction, vote_state::DEFAULT_TIMESTAMP_INTERVAL_SLOTS};
 use std::{
     collections::{HashMap, HashSet},
     sync::{
@@ -657,9 +657,7 @@ impl ReplayStage {
 
             // Send our last few votes along with the new one
             let mut last_vote = tower.last_vote();
-            let timestamp_interval =
-                slots_per_interval(bank.slots_per_year(), DEFAULT_TIMESTAMP_INTERVAL_MINS);
-            if bank.slot() % timestamp_interval == 1 {
+            if bank.slot() % DEFAULT_TIMESTAMP_INTERVAL_SLOTS == 1 {
                 last_vote.timestamp = Some(Utc::now().timestamp());
             }
             let vote_ix =

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -9,7 +9,6 @@ use crate::{
     rpc_subscriptions::RpcSubscriptions,
     thread_mem_usage,
 };
-use chrono::prelude::*;
 use solana_ledger::{
     bank_forks::BankForks,
     block_error::BlockError,
@@ -656,14 +655,11 @@ impl ReplayStage {
             let node_keypair = cluster_info.read().unwrap().keypair.clone();
 
             // Send our last few votes along with the new one
-            let mut last_vote = tower.last_vote();
-            if tower.needs_timestamp(bank.slot()) {
-                let timestamp = Utc::now().timestamp();
-                last_vote.timestamp = Some(timestamp);
-                tower.record_recent_timestamp(bank.slot(), timestamp);
-            }
-            let vote_ix =
-                vote_instruction::vote(&vote_account, &voting_keypair.pubkey(), last_vote);
+            let vote_ix = vote_instruction::vote(
+                &vote_account,
+                &voting_keypair.pubkey(),
+                tower.last_vote_and_timestamp(),
+            );
 
             let mut vote_tx =
                 Transaction::new_with_payer(vec![vote_ix], Some(&node_keypair.pubkey()));

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -659,7 +659,7 @@ impl ReplayStage {
             let mut last_vote = tower.last_vote();
             let timestamp_interval =
                 slots_per_interval(bank.slots_per_year(), DEFAULT_TIMESTAMP_INTERVAL_MINS);
-            if bank.slot() % timestamp_interval == 0 {
+            if bank.slot() % timestamp_interval == 1 {
                 last_vote.timestamp = Some(Utc::now().timestamp());
             }
             let vote_ix =

--- a/programs/vote/src/vote_instruction.rs
+++ b/programs/vote/src/vote_instruction.rs
@@ -33,6 +33,9 @@ pub enum VoteError {
 
     #[error("vote has no slots, invalid")]
     EmptySlots,
+
+    #[error("vote timestamp not recent")]
+    TimestampTooOld,
 }
 impl<E> DecodeError<E> for VoteError {
     fn type_of() -> &'static str {

--- a/programs/vote/src/vote_state.rs
+++ b/programs/vote/src/vote_state.rs
@@ -26,8 +26,9 @@ pub const INITIAL_LOCKOUT: usize = 2;
 //  smaller numbers makes
 pub const MAX_EPOCH_CREDITS_HISTORY: usize = 64;
 
-// Frequency of timestamp Votes
-pub const DEFAULT_TIMESTAMP_SLOTS: u64 = 4500;
+// Frequency of timestamp Votes In v0.22.0, this is approximately 30min with cluster clock
+// defaults, intended to limit block time drift to < 1hr
+pub const TIMESTAMP_SLOT_INTERVAL: u64 = 4500;
 
 #[derive(Serialize, Default, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub struct Vote {

--- a/programs/vote/src/vote_state.rs
+++ b/programs/vote/src/vote_state.rs
@@ -27,7 +27,7 @@ pub const INITIAL_LOCKOUT: usize = 2;
 pub const MAX_EPOCH_CREDITS_HISTORY: usize = 64;
 
 // Frequency of timestamp Votes
-pub const DEFAULT_TIMESTAMP_INTERVAL_SLOTS: u64 = 4500;
+pub const DEFAULT_TIMESTAMP_SLOTS: u64 = 4500;
 
 #[derive(Serialize, Default, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub struct Vote {

--- a/programs/vote/src/vote_state.rs
+++ b/programs/vote/src/vote_state.rs
@@ -8,7 +8,7 @@ use serde_derive::{Deserialize, Serialize};
 use solana_sdk::{
     account::{Account, KeyedAccount},
     account_utils::State,
-    clock::{Epoch, Slot},
+    clock::{Epoch, Slot, UnixTimestamp},
     hash::Hash,
     instruction::InstructionError,
     pubkey::Pubkey,
@@ -32,11 +32,17 @@ pub struct Vote {
     pub slots: Vec<Slot>,
     /// signature of the bank's state at the last slot
     pub hash: Hash,
+    /// processing timestamp of last slot
+    pub timestamp: Option<UnixTimestamp>,
 }
 
 impl Vote {
     pub fn new(slots: Vec<Slot>, hash: Hash) -> Self {
-        Self { slots, hash }
+        Self {
+            slots,
+            hash,
+            timestamp: None,
+        }
     }
 }
 

--- a/sdk/src/clock.rs
+++ b/sdk/src/clock.rs
@@ -35,8 +35,6 @@ pub const NUM_CONSECUTIVE_LEADER_SLOTS: u64 = 4;
 
 pub const DEFAULT_MS_PER_SLOT: u64 = 1_000 * DEFAULT_TICKS_PER_SLOT / DEFAULT_TICKS_PER_SECOND;
 
-pub const DEFAULT_TIMESTAMP_INTERVAL_MINS: u64 = 30;
-
 /// The time window of recent block hash values that the bank will track the signatures
 /// of over. Once the bank discards a block hash, it will reject any transactions that use
 /// that `recent_blockhash` in a transaction. Lowering this value reduces memory consumption,

--- a/sdk/src/clock.rs
+++ b/sdk/src/clock.rs
@@ -35,6 +35,8 @@ pub const NUM_CONSECUTIVE_LEADER_SLOTS: u64 = 4;
 
 pub const DEFAULT_MS_PER_SLOT: u64 = 1_000 * DEFAULT_TICKS_PER_SLOT / DEFAULT_TICKS_PER_SECOND;
 
+pub const DEFAULT_TIMESTAMP_INTERVAL_MINS: u64 = 30;
+
 /// The time window of recent block hash values that the bank will track the signatures
 /// of over. Once the bank discards a block hash, it will reject any transactions that use
 /// that `recent_blockhash` in a transaction. Lowering this value reduces memory consumption,

--- a/sdk/src/timing.rs
+++ b/sdk/src/timing.rs
@@ -38,19 +38,13 @@ pub fn years_as_slots(years: f64, tick_duration: &Duration, ticks_per_slot: u64)
         / ticks_per_slot as f64
 }
 
-/// From slots per year to tick_duration
+/// From slots per year to slot duration
 pub fn slot_duration_from_slots_per_year(slots_per_year: f64) -> Duration {
     // Regarding division by zero potential below: for some reason, if Rust stores an `inf` f64 and
     // then converts it to a u64 on use, it always returns 0, as opposed to std::u64::MAX or any
     // other huge value
     let slot_in_ns = (SECONDS_PER_YEAR * 1_000_000_000.0) / slots_per_year;
     Duration::from_nanos(slot_in_ns as u64)
-}
-
-/// From slots per year to slots per some minutes, rounded
-pub fn slots_per_interval(slots_per_year: f64, interval_mins: u64) -> u64 {
-    let seconds = interval_mins * 60;
-    (slots_per_year * seconds as f64 / SECONDS_PER_YEAR).round() as u64
 }
 
 #[cfg(test)]
@@ -97,16 +91,5 @@ mod test {
             slot_duration_from_slots_per_year(slots_per_year),
             Duration::from_millis(1000) * ticks_per_slot
         );
-    }
-
-    #[test]
-    fn test_slots_per_interval() {
-        let slots_per_year = 1_262_277_039.0;
-
-        assert_eq!(slots_per_interval(slots_per_year, 1), 2400);
-        assert_eq!(slots_per_interval(slots_per_year, 4), 9600);
-        assert_eq!(slots_per_interval(slots_per_year, 30), 72000);
-        assert_eq!(slots_per_interval(slots_per_year, 0), 0);
-        assert_eq!(slots_per_interval(0.0, 30), 0);
     }
 }

--- a/sdk/src/timing.rs
+++ b/sdk/src/timing.rs
@@ -47,6 +47,12 @@ pub fn slot_duration_from_slots_per_year(slots_per_year: f64) -> Duration {
     Duration::from_nanos(slot_in_ns as u64)
 }
 
+/// From slots per year to slots per some minutes, rounded
+pub fn slots_per_interval(slots_per_year: f64, interval_mins: u64) -> u64 {
+    let seconds = interval_mins * 60;
+    (slots_per_year * seconds as f64 / SECONDS_PER_YEAR).round() as u64
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -91,5 +97,16 @@ mod test {
             slot_duration_from_slots_per_year(slots_per_year),
             Duration::from_millis(1000) * ticks_per_slot
         );
+    }
+
+    #[test]
+    fn test_slots_per_interval() {
+        let slots_per_year = 1_262_277_039.0;
+
+        assert_eq!(slots_per_interval(slots_per_year, 1), 2400);
+        assert_eq!(slots_per_interval(slots_per_year, 4), 9600);
+        assert_eq!(slots_per_interval(slots_per_year, 30), 72000);
+        assert_eq!(slots_per_interval(slots_per_year, 0), 0);
+        assert_eq!(slots_per_interval(0.0, 30), 0);
     }
 }


### PR DESCRIPTION
#### Problem
Users have no way to know when a Solana block was produced in real-world time.
We have a design proposal to fix that issue... here is the first step of the implementation!

#### Summary of Changes
- Add VoteState::last_timestamp field
- Add `Option<timestamp>` field to Vote
- Trigger intermittent timestamp in replay_stage::handle_votable_bank. Currently set to approximately every 30min (4500 slots, with current defaults). First timestamp occurs on slot 1
- Stash last_timestamp in Tower to keep validator timestamping regularly despite potentially missing slots

Toward #7115 

@mvines , I believe we wanted this in 0.21 too, correct? If so, I'll also cherry-pick the design proposal for completeness.