### PR TITLE
Don't hardcode username in sys-tuner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3982,6 +3982,7 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "nix 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-clap-utils 0.22.0",
  "solana-logger 0.22.0",
  "unix_socket2 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "users 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -129,7 +129,7 @@ cat >> ~/solana/on-reboot <<EOF
   # shellcheck source=/dev/null
   SUDO_OK=1 source scripts/tune-system.sh
 
-  sudo RUST_LOG=info ~solana/.cargo/bin/solana-sys-tuner -u solana > sys-tuner.log 2>&1 &
+  sudo RUST_LOG=info ~solana/.cargo/bin/solana-sys-tuner --user $(whoami) > sys-tuner.log 2>&1 &
   echo \$! > sys-tuner.pid
 
   (

--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -129,7 +129,7 @@ cat >> ~/solana/on-reboot <<EOF
   # shellcheck source=/dev/null
   SUDO_OK=1 source scripts/tune-system.sh
 
-  sudo RUST_LOG=info ~solana/.cargo/bin/solana-sys-tuner > sys-tuner.log 2>&1 &
+  sudo RUST_LOG=info ~solana/.cargo/bin/solana-sys-tuner -u solana > sys-tuner.log 2>&1 &
   echo \$! > sys-tuner.pid
 
   (

--- a/sys-tuner/Cargo.toml
+++ b/sys-tuner/Cargo.toml
@@ -14,6 +14,7 @@ clap = "2.33.0"
 log = "0.4.8"
 libc = "0.2.66"
 semver = "0.9.0"
+solana-clap-utils = { path = "../clap-utils", version = "0.22.0" }
 solana-logger = { path = "../logger", version = "0.22.0" }
 
 [target."cfg(unix)".dependencies]

--- a/sys-tuner/src/main.rs
+++ b/sys-tuner/src/main.rs
@@ -1,4 +1,4 @@
-use clap::{crate_description, crate_name, crate_version, value_t_or_exit, App, Arg};
+use clap::{crate_description, crate_name, value_t_or_exit, App, Arg};
 use log::*;
 
 #[cfg(target_os = "linux")]
@@ -69,10 +69,9 @@ fn main() {
     solana_logger::setup();
     let matches = App::new(crate_name!())
         .about(crate_description!())
-        .version(crate_version!())
+        .version(solana_clap_utils::version!())
         .arg(
             Arg::with_name("user")
-                .short("u")
                 .long("user")
                 .value_name("user name")
                 .takes_value(true)

--- a/sys-tuner/src/main.rs
+++ b/sys-tuner/src/main.rs
@@ -1,3 +1,4 @@
+use clap::{crate_description, crate_name, crate_version, value_t_or_exit, App, Arg};
 use log::*;
 
 #[cfg(target_os = "linux")]
@@ -66,6 +67,24 @@ fn tune_system(uid: u32) {
 #[cfg(unix)]
 fn main() {
     solana_logger::setup();
+    let matches = App::new(crate_name!())
+        .about(crate_description!())
+        .version(crate_version!())
+        .arg(
+            Arg::with_name("user")
+                .short("u")
+                .long("user")
+                .value_name("user name")
+                .takes_value(true)
+                .required(true)
+                .help("Username of the peer process"),
+        )
+        .get_matches();
+
+    let user = value_t_or_exit!(matches, "file", String);
+
+    info!("Tune will service requests only from user {}", user);
+
     unsafe { libc::umask(0o077) };
     if let Err(e) = std::fs::remove_file(solana_sys_tuner::SOLANA_SYS_TUNER_PATH) {
         if e.kind() != std::io::ErrorKind::NotFound {
@@ -79,7 +98,7 @@ fn main() {
     let peer_uid;
 
     // set socket permission
-    if let Some(user) = users::get_user_by_name("solana") {
+    if let Some(user) = users::get_user_by_name(&user) {
         peer_uid = user.uid();
         info!("UID for solana is {}", peer_uid);
         nix::unistd::chown(
@@ -89,7 +108,7 @@ fn main() {
         )
         .expect("Expected to change UID of the socket file");
     } else {
-        panic!("Could not find UID for solana user");
+        panic!("Could not find UID for {:?} user", user);
     }
 
     info!("Waiting for tuning requests");

--- a/sys-tuner/src/main.rs
+++ b/sys-tuner/src/main.rs
@@ -81,7 +81,7 @@ fn main() {
         )
         .get_matches();
 
-    let user = value_t_or_exit!(matches, "file", String);
+    let user = value_t_or_exit!(matches, "user", String);
 
     info!("Tune will service requests only from user {}", user);
 


### PR DESCRIPTION
#### Problem
sys-tuner is assuming the "solana" username for peer. This will break if validator is booted with a different user account.

#### Summary of Changes
Pass username as command line argument.

Fixes #7206 
