### PR TITLE
Add Paper Wallet Installation page to sidebar

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -36,6 +36,7 @@
   * [Troubleshooting](running-validator/validator-troubleshoot.md)
 * [Running an Archiver](running-archiver.md)
 * [Paper Wallet](paper-wallet/README.md)
+  * [Installation](paper-wallet/installation.md)
   * [Creating and Using a Seed Phrase](paper-wallet/keypair.md)
   * [Paper Wallet Usage](paper-wallet/usage.md)
 * [API Reference](api-reference/README.md)


### PR DESCRIPTION
#### Problem
There is no link to "Installation" in the "Paper Wallet" section of the sidebar
