### PR TITLE
vote update node_id

### DIFF
--- a/programs/vote/src/vote_instruction.rs
+++ b/programs/vote/src/vote_instruction.rs
@@ -49,6 +49,9 @@ pub enum VoteInstruction {
     ///  to withdraw
     Authorize(Pubkey, VoteAuthorize),
 
+    /// Update the vote account's node id
+    UpdateNode(Pubkey),
+
     /// A Vote instruction with recent votes
     Vote(Vote),
 
@@ -92,6 +95,20 @@ pub fn authorize(
     Instruction::new(
         id(),
         &VoteInstruction::Authorize(*new_authorized_pubkey, vote_authorize),
+        account_metas,
+    )
+}
+
+pub fn update_node(
+    vote_pubkey: &Pubkey,       // vote account
+    authorized_pubkey: &Pubkey, // currently authorized
+    node_pubkey: &Pubkey,
+) -> Instruction {
+    let account_metas = vec![AccountMeta::new(*vote_pubkey, false)].with_signer(authorized_pubkey);
+
+    Instruction::new(
+        id(),
+        &VoteInstruction::UpdateNode(*node_pubkey),
         account_metas,
     )
 }
@@ -144,6 +161,9 @@ pub fn process_instruction(
         }
         VoteInstruction::Authorize(voter_pubkey, vote_authorize) => {
             vote_state::authorize(me, &voter_pubkey, vote_authorize, &signers)
+        }
+        VoteInstruction::UpdateNode(node_pubkey) => {
+            vote_state::update_node(me, &node_pubkey, &signers)
         }
         VoteInstruction::Vote(vote) => {
             datapoint_debug!("vote-native", ("count", 1, i64));
@@ -237,6 +257,15 @@ mod tests {
             )),
             Err(InstructionError::InvalidAccountData),
         );
+        assert_eq!(
+            process_instruction(&update_node(
+                &Pubkey::default(),
+                &Pubkey::default(),
+                &Pubkey::default(),
+            )),
+            Err(InstructionError::InvalidAccountData),
+        );
+
         assert_eq!(
             process_instruction(&withdraw(
                 &Pubkey::default(),

--- a/programs/vote/src/vote_instruction.rs
+++ b/programs/vote/src/vote_instruction.rs
@@ -49,14 +49,14 @@ pub enum VoteInstruction {
     ///  to withdraw
     Authorize(Pubkey, VoteAuthorize),
 
-    /// Update the vote account's node id
-    UpdateNode(Pubkey),
-
     /// A Vote instruction with recent votes
     Vote(Vote),
 
     /// Withdraw some amount of funds
     Withdraw(u64),
+
+    /// Update the vote account's node id
+    UpdateNode(Pubkey),
 }
 
 fn initialize_account(vote_pubkey: &Pubkey, vote_init: &VoteInit) -> Instruction {


### PR DESCRIPTION
#### Problem
 nodes may come and go, but it's really hard to redirect stakes
 from a vote account that's stuck on an old node

 #### Summary of Changes
 add a facility for updating the node_pubkey in a vote account


Fixes #7063