### PR TITLE
Sanitize whitespace in seed phrase input

### DIFF
--- a/clap-utils/src/keypair.rs
+++ b/clap-utils/src/keypair.rs
@@ -69,7 +69,12 @@ pub fn keypair_from_seed_phrase(
         let passphrase = prompt_passphrase(&passphrase_prompt)?;
         keypair_from_seed_phrase_and_passphrase(&seed_phrase, &passphrase)
     } else {
-        let mnemonic = Mnemonic::from_phrase(seed_phrase, Language::English)?;
+        let sanitized = seed_phrase
+            .split(" ")
+            .filter(|word| !word.is_empty())
+            .collect::<Vec<&str>>()
+            .join(" ");
+        let mnemonic = Mnemonic::from_phrase(sanitized, Language::English)?;
         let passphrase = prompt_passphrase(&passphrase_prompt)?;
         let seed = Seed::new(&mnemonic, &passphrase);
         keypair_from_seed(seed.as_bytes())

--- a/clap-utils/src/keypair.rs
+++ b/clap-utils/src/keypair.rs
@@ -69,11 +69,7 @@ pub fn keypair_from_seed_phrase(
         let passphrase = prompt_passphrase(&passphrase_prompt)?;
         keypair_from_seed_phrase_and_passphrase(&seed_phrase, &passphrase)
     } else {
-        let sanitized = seed_phrase
-            .split(' ')
-            .filter(|word| !word.is_empty())
-            .collect::<Vec<&str>>()
-            .join(" ");
+        let sanitized = sanitize_seed_phrase(seed_phrase);
         let mnemonic = Mnemonic::from_phrase(sanitized, Language::English)?;
         let passphrase = prompt_passphrase(&passphrase_prompt)?;
         let seed = Seed::new(&mnemonic, &passphrase);
@@ -117,6 +113,13 @@ pub fn keypair_input(
     }
 }
 
+fn sanitize_seed_phrase(seed_phrase: &str) -> String {
+    seed_phrase
+        .split_whitespace()
+        .collect::<Vec<&str>>()
+        .join(" ")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -127,5 +130,14 @@ mod tests {
         let arg_matches = ArgMatches::default();
         let KeypairWithSource { source, .. } = keypair_input(&arg_matches, "").unwrap();
         assert_eq!(source, Source::Generated);
+    }
+
+    #[test]
+    fn test_sanitize_seed_phrase() {
+        let seed_phrase = " Mary   had\ta\u{2009}little  \n\t lamb";
+        assert_eq!(
+            "Mary had a little lamb".to_owned(),
+            sanitize_seed_phrase(seed_phrase)
+        );
     }
 }

--- a/clap-utils/src/keypair.rs
+++ b/clap-utils/src/keypair.rs
@@ -70,7 +70,7 @@ pub fn keypair_from_seed_phrase(
         keypair_from_seed_phrase_and_passphrase(&seed_phrase, &passphrase)
     } else {
         let sanitized = seed_phrase
-            .split(" ")
+            .split(' ')
             .filter(|word| !word.is_empty())
             .collect::<Vec<&str>>()
             .join(" ");


### PR DESCRIPTION
#### Problem
Mnemonic seed phrase input is too strict about whitespace (it fails if words have more than one space between them)

#### Summary of Changes
When "skip validation" is not enabled, sanitize whitespace between words to improve user experience

Related to https://github.com/solana-labs/solana/issues/7248
