### PR TITLE
Use wrappable code snippet for paper wallet installation

### DIFF
--- a/book/src/paper-wallet/installation.md
+++ b/book/src/paper-wallet/installation.md
@@ -11,16 +11,12 @@ version instead replace `latest/download` with `download/VERSION` where VERSION
 is a tag name from https://github.com/solana-labs/solana/releases (ie. v0.21.1).
 
 MacOS
-```bash
-$ curl -L -sSf -o solana-release.tar.bz2 'https://github.com/solana-labs/solana/releases/latest/download/solana-release-x86_64-apple-darwin.tar.bz2'
-```
-**`'https://github.com/solana-labs/solana/releases/latest/download/solana-release-x86_64-apple-darwin.tar.bz2'`**
+
+`$ curl -L -sSf -o solana-release.tar.bz2 'https://github.com/solana-labs/solana/releases/latest/download/solana-release-x86_64-apple-darwin.tar.bz2'`
 
 Linux
-```bash
-$ curl -L -sSf -o solana-release.tar.bz2 'https://github.com/solana-labs/solana/releases/latest/download/solana-release-x86_64-unknown-linux-gnu.tar.bz2'
-```
-**`'https://github.com/solana-labs/solana/releases/latest/download/solana-release-x86_64-unknown-linux-gnu.tar.bz2'`**
+
+`$ curl -L -sSf -o solana-release.tar.bz2 'https://github.com/solana-labs/solana/releases/latest/download/solana-release-x86_64-unknown-linux-gnu.tar.bz2'`
 
 Next, extract the tarball
 ```bash


### PR DESCRIPTION
#### Problem
Curl commands in the paper wallet instructions get cutoff. Experience is less than ideal

#### Summary of Changes
Use a wrappable code snippet

Fixes #
