### PR TITLE
Force ledger compaction via explicit rocksdb `compact_cf` calls

### DIFF
--- a/ledger/src/blocktree.rs
+++ b/ledger/src/blocktree.rs
@@ -275,8 +275,8 @@ impl Blocktree {
 
     // Returns whether or not all iterators have reached their end
     fn run_purge_batch(&self, from_slot: Slot, batch_end: Slot) -> Result<bool> {
-        let from_slot = Some(from_slot);
-        let batch_end = Some(batch_end);
+        let some_from_slot = Some(from_slot);
+        let some_batch_end = Some(batch_end);
 
         let mut write_batch = self
             .db
@@ -284,40 +284,77 @@ impl Blocktree {
             .expect("Database Error: Failed to get write batch");
         let end = self
             .meta_cf
-            .delete_slot(&mut write_batch, from_slot, batch_end)
+            .delete_slot(&mut write_batch, some_from_slot, some_batch_end)
             .unwrap_or(false)
             & self
+                .meta_cf
+                .compact_range(from_slot, batch_end)
+                .unwrap_or(false)
+            & self
                 .erasure_meta_cf
-                .delete_slot(&mut write_batch, from_slot, batch_end)
+                .delete_slot(&mut write_batch, some_from_slot, some_batch_end)
+                .unwrap_or(false)
+            & self
+                .erasure_meta_cf
+                .compact_range(from_slot, batch_end)
                 .unwrap_or(false)
             & self
                 .data_shred_cf
-                .delete_slot(&mut write_batch, from_slot, batch_end)
+                .delete_slot(&mut write_batch, some_from_slot, some_batch_end)
+                .unwrap_or(false)
+            & self
+                .data_shred_cf
+                .compact_range(from_slot, batch_end)
                 .unwrap_or(false)
             & self
                 .code_shred_cf
-                .delete_slot(&mut write_batch, from_slot, batch_end)
+                .delete_slot(&mut write_batch, some_from_slot, some_batch_end)
+                .unwrap_or(false)
+            & self
+                .code_shred_cf
+                .compact_range(from_slot, batch_end)
                 .unwrap_or(false)
             & self
                 .transaction_status_cf
-                .delete_slot(&mut write_batch, from_slot, batch_end)
+                .delete_slot(&mut write_batch, some_from_slot, some_batch_end)
+                .unwrap_or(false)
+            & self
+                .transaction_status_cf
+                .compact_range(from_slot, batch_end)
                 .unwrap_or(false)
             & self
                 .orphans_cf
-                .delete_slot(&mut write_batch, from_slot, batch_end)
+                .delete_slot(&mut write_batch, some_from_slot, some_batch_end)
+                .unwrap_or(false)
+            & self
+                .orphans_cf
+                .compact_range(from_slot, batch_end)
                 .unwrap_or(false)
             & self
                 .index_cf
-                .delete_slot(&mut write_batch, from_slot, batch_end)
+                .delete_slot(&mut write_batch, some_from_slot, some_batch_end)
+                .unwrap_or(false)
+            & self
+                .index_cf
+                .compact_range(from_slot, batch_end)
                 .unwrap_or(false)
             & self
                 .dead_slots_cf
-                .delete_slot(&mut write_batch, from_slot, batch_end)
+                .delete_slot(&mut write_batch, some_from_slot, some_batch_end)
+                .unwrap_or(false)
+            & self
+                .dead_slots_cf
+                .compact_range(from_slot, batch_end)
                 .unwrap_or(false)
             & self
                 .db
                 .column::<cf::Root>()
-                .delete_slot(&mut write_batch, from_slot, batch_end)
+                .delete_slot(&mut write_batch, some_from_slot, some_batch_end)
+                .unwrap_or(false)
+            & self
+                .db
+                .column::<cf::Root>()
+                .compact_range(from_slot, batch_end)
                 .unwrap_or(false);
 
         if let Err(e) = self.db.write(write_batch) {

--- a/ledger/src/blocktree_db.rs
+++ b/ledger/src/blocktree_db.rs
@@ -641,6 +641,17 @@ where
         Ok(end)
     }
 
+    pub fn compact_range(&self, from: Slot, to: Slot) -> Result<bool>
+    where
+        C::Index: PartialOrd + Copy,
+    {
+        let cf = self.handle();
+        let from = Some(C::key(C::as_index(from)));
+        let to = Some(C::key(C::as_index(to)));
+        self.backend.0.compact_range_cf(cf, from, to);
+        Ok(true)
+    }
+
     #[inline]
     pub fn handle(&self) -> &ColumnFamily {
         self.backend.cf_handle(C::NAME)


### PR DESCRIPTION
#### Problem

The product does not reclaim column family storage as eagerly as possible from rocksdb, leading to exagerated storage requirements.
* `ledger_cleanup_service` currently employs rocksdb `delete` functionality (mark rows deleted in metadata, and do not carry forward upon file copy), but not `compact` (rewrite storage files excluding deleted rows)
* thus, a non-trivial amount of data is wasted/not reclaimed, leading to 💸 and higher system requirements
* data usage is especially pronounced for `ShredCode` and `ShredData` column families
  (a) in a 20GB testnet (beta?) ledger from 2019/11/27, `ShredCode` is 78.4% of stored bytes, `ShredData` is 17.5% of stored bytes
  (b) in a 73GB testnet (south africa) ledger from 2019/11/26, `ShredCode` is 73.9% of stored bytes, `ShredData` is 22.4% of stored bytes

#### Summary of Changes

* Force column family storage reclamation at ledger cleanup intervals when `limit-ledger-size` option is enabled

## Supporting Data

* Tracking ticket : #7499 

#### Benchmark results 20191217 (AWS `m5.2xlarge`)

* 400k Ledger slots (`nocompact`: no compaction) : 34MB table size, insertion rate (P50,P90,P99,P999=133,135,145,148ms)
* 400k Ledger slots (`compact1`: delete only, 50k limit) : 25.8MB table size, insertion rate (P50,P90,P99,P999=145,148,154,157ms) +12,+13,+9,+9ms
* 400k Ledger slots (`compact2`: delete+compact, 50k limit) : 4.3MB table size, insertion rate (P50,P90,P99,P999=141,148,152,155ms) +8,+13,+7,+7ms

* Excel Spreadsheet : includes 1 sheet per data run (`nocompact`, `compact1`, `compact2`)

[ledger_bench_400k.xlsx](https://github.com/solana-labs/solana/files/3969815/ledger_bench_400k.xlsx)

Fixes #7139 
