### PR TITLE
Fix typo, grammar, and formatting in Paper Wallet documentation

### DIFF
--- a/book/src/paper-wallet/installation.md
+++ b/book/src/paper-wallet/installation.md
@@ -8,30 +8,36 @@ After installation, ensure your version is `0.21.1` or higher by running `solana
 First, download the desired release tarball from GitHub. The examples below will
 retrieve the most recent release. If you would like to download a specific
 version instead replace `latest/download` with `download/VERSION` where VERSION
-is a tag name from https://github.com/solana-labs/solana/releases (ie. v0.21.1).
+is a tag name from https://github.com/solana-labs/solana/releases (e.g. v0.21.1).
 
 MacOS
-
-`$ curl -L -sSf -o solana-release.tar.bz2 'https://github.com/solana-labs/solana/releases/latest/download/solana-release-x86_64-apple-darwin.tar.bz2'`
+```bash
+solana_downloads=https://github.com/solana-labs/solana/releases/latest/download
+solana_release=solana-release-x86_64-apple-darwin.tar.bz2
+curl -L -sSf -o solana-release.tar.bz2 $solana_downloads/$solana_release
+```
 
 Linux
-
-`$ curl -L -sSf -o solana-release.tar.bz2 'https://github.com/solana-labs/solana/releases/latest/download/solana-release-x86_64-unknown-linux-gnu.tar.bz2'`
+```bash
+solana_downloads=https://github.com/solana-labs/solana/releases/latest/download
+solana_release=solana-release-x86_64-unknown-linux-gnu.tar.bz2
+curl -L -sSf -o solana-release.tar.bz2 $solana_downloads/$solana_release
+```
 
 Next, extract the tarball
 ```bash
-$ tar xf solana-release.tar.bz2
+tar xf solana-release.tar.bz2
 ```
 
 Finally, `solana-keygen` can be run by
 ```bash
-$ solana-release/bin/solana-keygen
+solana-release/bin/solana-keygen
 ```
 
 If you would like to follow the remainder of these instructions without typing
 the leading path to `solana-keygen`, add it to your PATH environment variable
 with the following command
 ```bash
-$ export PATH="$(pwd)/solana-release/bin:${PATH}"
+export PATH="$(pwd)/solana-release/bin:${PATH}"
 ```
 This can be made permanent by adding it to your `~/.profile`

--- a/book/src/paper-wallet/installation.md
+++ b/book/src/paper-wallet/installation.md
@@ -26,7 +26,7 @@ First, download the latest release tarball from GitHub.
   solana_release=solana-release-x86_64-unknown-linux-gnu.tar.bz2
   ```
 
-2. Download
+3. Download
 
   ```bash
   curl -L -sSf -o solana-release.tar.bz2 $solana_downloads/$solana_release

--- a/book/src/paper-wallet/installation.md
+++ b/book/src/paper-wallet/installation.md
@@ -5,39 +5,39 @@ Follow this guide to setup Solana's key generation tool called `solana-keygen`
 After installation, ensure your version is `0.21.1` or higher by running `solana-keygen -V`
 {% endhint %}
 
-First, download the desired release tarball from GitHub. The examples below will
-retrieve the most recent release. If you would like to download a specific
-version instead replace `latest/download` with `download/VERSION` where VERSION
-is a tag name from https://github.com/solana-labs/solana/releases (e.g. v0.21.1).
+## Download
+First, download the latest release tarball from GitHub.
 
-MacOS
+**MacOS**
 ```bash
 solana_downloads=https://github.com/solana-labs/solana/releases/latest/download
 solana_release=solana-release-x86_64-apple-darwin.tar.bz2
 curl -L -sSf -o solana-release.tar.bz2 $solana_downloads/$solana_release
 ```
 
-Linux
+**Linux**
 ```bash
 solana_downloads=https://github.com/solana-labs/solana/releases/latest/download
 solana_release=solana-release-x86_64-unknown-linux-gnu.tar.bz2
 curl -L -sSf -o solana-release.tar.bz2 $solana_downloads/$solana_release
 ```
 
+## Extract
 Next, extract the tarball
 ```bash
 tar xf solana-release.tar.bz2
 ```
 
-Finally, `solana-keygen` can be run by
-```bash
-solana-release/bin/solana-keygen
-```
-
-If you would like to follow the remainder of these instructions without typing
-the leading path to `solana-keygen`, add it to your PATH environment variable
-with the following command
+## Add to "PATH"
+Now add the tool to your PATH environment variable with the following command
 ```bash
 export PATH="$(pwd)/solana-release/bin:${PATH}"
 ```
-This can be made permanent by adding it to your `~/.profile`
+
+This can be made permanent by adding the above line to your `~/.profile`
+
+## Check
+Finally, check that `solana-keygen` can be run by running
+```bash
+solana-keygen
+```

--- a/book/src/paper-wallet/installation.md
+++ b/book/src/paper-wallet/installation.md
@@ -8,19 +8,29 @@ After installation, ensure your version is `0.21.1` or higher by running `solana
 ## Download
 First, download the latest release tarball from GitHub.
 
-**MacOS**
-```bash
-solana_downloads=https://github.com/solana-labs/solana/releases/latest/download
-solana_release=solana-release-x86_64-apple-darwin.tar.bz2
-curl -L -sSf -o solana-release.tar.bz2 $solana_downloads/$solana_release
-```
+1. Setup download url
 
-**Linux**
-```bash
-solana_downloads=https://github.com/solana-labs/solana/releases/latest/download
-solana_release=solana-release-x86_64-unknown-linux-gnu.tar.bz2
-curl -L -sSf -o solana-release.tar.bz2 $solana_downloads/$solana_release
-```
+  ```bash
+  solana_downloads=https://github.com/solana-labs/solana/releases/latest/download
+  ```
+
+2. Specify the download file based on your machine
+
+  **MacOS**
+  ```bash
+  solana_release=solana-release-x86_64-apple-darwin.tar.bz2
+  ```
+
+  **Linux**
+  ```bash
+  solana_release=solana-release-x86_64-unknown-linux-gnu.tar.bz2
+  ```
+
+2. Download
+
+  ```bash
+  curl -L -sSf -o solana-release.tar.bz2 $solana_downloads/$solana_release
+  ```
 
 ## Extract
 Next, extract the tarball
@@ -37,5 +47,5 @@ export PATH="$(pwd)/solana-release/bin:${PATH}"
 ## Check
 Finally, check that `solana-keygen` can be run by running
 ```bash
-solana-keygen
+solana-keygen -V
 ```

--- a/book/src/paper-wallet/installation.md
+++ b/book/src/paper-wallet/installation.md
@@ -34,8 +34,6 @@ Now add the tool to your PATH environment variable with the following command
 export PATH="$(pwd)/solana-release/bin:${PATH}"
 ```
 
-This can be made permanent by adding the above line to your `~/.profile`
-
 ## Check
 Finally, check that `solana-keygen` can be run by running
 ```bash

--- a/book/src/paper-wallet/keypair.md
+++ b/book/src/paper-wallet/keypair.md
@@ -23,13 +23,13 @@ solana-keygen new --no-outfile
 ```
 
 {% hint style="warning" %}
-If `--no-outfile` is **not** specified, the default behavior is to write the
+If the `--no-outfile` flag is **omitted**, the default behavior is to write the
 keypair to `~/.config/solana/id.json`
 {% endhint %}
 
 {% hint style="info" %}
 For added security, increase the seed phrase word count using the `--word-count`
-argumment
+argument
 {% endhint %}
 
 For full usage details run:


### PR DESCRIPTION
#### Problem
- `curl` command cannot be copy/pasted from PDF when it wraps to a newline
- typo and grammar issues

#### Changes
- Fix inconsistency with `$` prefixed commands
- Split curl commands into multiple lines
- Simplify and streamline installation instructions
- `ie` -> `e.g.`
- `argumment` -> `argument`
- Remove `.profile` step
