### PR TITLE
Increase signature confirmation timeout to fix wallet sanity

### DIFF
--- a/ci/localnet-sanity.sh
+++ b/ci/localnet-sanity.sh
@@ -313,7 +313,7 @@ flag_error() {
 
 if ! $skipSetup; then
   clear_config_dir "$SOLANA_CONFIG_DIR"
-  multinode-demo/setup.sh
+  multinode-demo/setup.sh --hashes-per-tick sleep
 else
   verifyLedger
 fi

--- a/ci/localnet-sanity.sh
+++ b/ci/localnet-sanity.sh
@@ -365,7 +365,7 @@ while [[ $iteration -le $iterations ]]; do
   echo "--- Wallet sanity ($iteration)"
   (
     set -x
-    timeout 105s scripts/wallet-sanity.sh --url http://127.0.0.1"$walletRpcPort"
+    timeout 60s scripts/wallet-sanity.sh --url http://127.0.0.1"$walletRpcPort"
   ) || flag_error
 
   iteration=$((iteration + 1))

--- a/ci/localnet-sanity.sh
+++ b/ci/localnet-sanity.sh
@@ -86,17 +86,19 @@ nodes=(
     --rpc-port 18899"
 )
 
-for i in $(seq 1 $extraNodes); do
-  portStart=$((8100 + i * 50))
-  portEnd=$((portStart + 49))
-  nodes+=(
-    "multinode-demo/validator.sh \
-      --no-restart \
-      --dynamic-port-range $portStart-$portEnd
-      --label dyn$i \
-      --init-complete-file init-complete-node$((2 + i)).log"
-  )
-done
+if [[ extraNodes -gt 0 ]]; then
+  for i in $(seq 1 $extraNodes); do
+    portStart=$((8100 + i * 50))
+    portEnd=$((portStart + 49))
+    nodes+=(
+      "multinode-demo/validator.sh \
+        --no-restart \
+        --dynamic-port-range $portStart-$portEnd
+        --label dyn$i \
+        --init-complete-file init-complete-node$((2 + i)).log"
+    )
+  done
+fi
 numNodes=$((2 + extraNodes))
 
 pids=()


### PR DESCRIPTION
#### Problem
Wallet sanity check is timing out in CI, causing builds to fail. My hypothesis is that it is failing due to slow confirmation times when airdropping tokens

#### Summary of Changes
- Fix `local-sanity.sh` check when `extraNodes=0`
- Use `--hashes-per-tick sleep` to avoid hash calculation
- Decrease wallet sanity timeout

Fixes https://github.com/solana-labs/solana/issues/7274
