### PR TITLE
Fix repair slowness when most peers are unable to serve requests

### DIFF
--- a/core/src/cluster_info.rs
+++ b/core/src/cluster_info.rs
@@ -317,10 +317,10 @@ impl ClusterInfo {
         )
     }
 
-    pub fn push_epoch_slots(&mut self, id: Pubkey, root: u64, slots: BTreeSet<u64>) {
+    pub fn push_epoch_slots(&mut self, id: Pubkey, root: Slot, min: Slot, slots: BTreeSet<u64>) {
         let now = timestamp();
         let entry = CrdsValue::new_signed(
-            CrdsData::EpochSlots(EpochSlots::new(id, root, slots, now)),
+            CrdsData::EpochSlots(EpochSlots::new(id, root, min, slots, now)),
             &self.keypair,
         );
         self.gossip
@@ -489,13 +489,18 @@ impl ClusterInfo {
             .collect()
     }
 
-    /// all tvu peers with valid gossip addrs
-    fn repair_peers(&self) -> Vec<ContactInfo> {
+    /// all tvu peers with valid gossip addrs that likely have the slot being requested
+    fn repair_peers(&self, slot: Slot) -> Vec<ContactInfo> {
         let me = self.my_data().id;
         ClusterInfo::tvu_peers(self)
             .into_iter()
             .filter(|x| x.id != me)
             .filter(|x| ContactInfo::is_valid_address(&x.gossip))
+            .filter(|x| {
+                self.get_epoch_state_for_node(&x.id, None)
+                    .map(|(epoch_slots, _)| epoch_slots.lowest <= slot)
+                    .unwrap_or_else(|| /* fallback to legacy behavior */ true)
+            })
             .collect()
     }
 
@@ -840,9 +845,9 @@ impl ClusterInfo {
     }
 
     pub fn repair_request(&self, repair_request: &RepairType) -> Result<(SocketAddr, Vec<u8>)> {
-        // find a peer that appears to be accepting replication, as indicated
-        //  by a valid tvu port location
-        let valid: Vec<_> = self.repair_peers();
+        // find a peer that appears to be accepting replication and has the desired slot, as indicated
+        // by a valid tvu port location
+        let valid: Vec<_> = self.repair_peers(repair_request.slot());
         if valid.is_empty() {
             return Err(ClusterInfoError::NoPeers.into());
         }
@@ -2555,6 +2560,7 @@ mod tests {
         let value = CrdsValue::new_unsigned(CrdsData::EpochSlots(EpochSlots {
             from: Pubkey::default(),
             root: 0,
+            lowest: 0,
             slots: btree_slots,
             wallclock: 0,
         }));
@@ -2571,6 +2577,7 @@ mod tests {
         let mut value = CrdsValue::new_unsigned(CrdsData::EpochSlots(EpochSlots {
             from: Pubkey::default(),
             root: 0,
+            lowest: 0,
             slots: BTreeSet::new(),
             wallclock: 0,
         }));
@@ -2588,6 +2595,7 @@ mod tests {
             value.data = CrdsData::EpochSlots(EpochSlots {
                 from: Pubkey::default(),
                 root: 0,
+                lowest: 0,
                 slots,
                 wallclock: 0,
             });
@@ -2698,6 +2706,37 @@ mod tests {
         let pulls = cluster_info.new_pull_requests(&stakes);
         assert_eq!(1, pulls.len() as u64);
         assert_eq!(pulls.get(0).unwrap().0, other_node.gossip);
+    }
+
+    #[test]
+    fn test_repair_peers() {
+        let node_keypair = Arc::new(Keypair::new());
+        let mut cluster_info = ClusterInfo::new(
+            ContactInfo::new_localhost(&node_keypair.pubkey(), timestamp()),
+            node_keypair,
+        );
+        for i in 0..10 {
+            let mut peer_root = 5;
+            let mut peer_lowest = 0;
+            if i >= 5 {
+                // make these invalid for the upcoming repair request
+                peer_root = 15;
+                peer_lowest = 10;
+            }
+            let other_node_pubkey = Pubkey::new_rand();
+            let other_node = ContactInfo::new_localhost(&other_node_pubkey, timestamp());
+            cluster_info.insert_info(other_node.clone());
+            let value = CrdsValue::new_unsigned(CrdsData::EpochSlots(EpochSlots::new(
+                other_node_pubkey,
+                peer_root,
+                peer_lowest,
+                BTreeSet::new(),
+                timestamp(),
+            )));
+            let _ = cluster_info.gossip.crds.insert(value, timestamp());
+        }
+        // only half the visible peers should be eligible to serve this repair
+        assert_eq!(cluster_info.repair_peers(5).len(), 5);
     }
 
     #[test]

--- a/core/src/cluster_info.rs
+++ b/core/src/cluster_info.rs
@@ -317,7 +317,7 @@ impl ClusterInfo {
         )
     }
 
-    pub fn push_epoch_slots(&mut self, id: Pubkey, root: Slot, min: Slot, slots: BTreeSet<u64>) {
+    pub fn push_epoch_slots(&mut self, id: Pubkey, root: Slot, min: Slot, slots: BTreeSet<Slot>) {
         let now = timestamp();
         let entry = CrdsValue::new_signed(
             CrdsData::EpochSlots(EpochSlots::new(id, root, min, slots, now)),

--- a/core/src/crds_value.rs
+++ b/core/src/crds_value.rs
@@ -1,5 +1,6 @@
 use crate::contact_info::ContactInfo;
 use bincode::{serialize, serialized_size};
+use solana_sdk::clock::Slot;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::{Keypair, Signable, Signature};
 use solana_sdk::transaction::Transaction;
@@ -63,16 +64,24 @@ pub enum CrdsData {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct EpochSlots {
     pub from: Pubkey,
-    pub root: u64,
-    pub slots: BTreeSet<u64>,
+    pub root: Slot,
+    pub lowest: Slot,
+    pub slots: BTreeSet<Slot>,
     pub wallclock: u64,
 }
 
 impl EpochSlots {
-    pub fn new(from: Pubkey, root: u64, slots: BTreeSet<u64>, wallclock: u64) -> Self {
+    pub fn new(
+        from: Pubkey,
+        root: Slot,
+        lowest: Slot,
+        slots: BTreeSet<Slot>,
+        wallclock: u64,
+    ) -> Self {
         Self {
             from,
             root,
+            lowest,
             slots,
             wallclock,
         }
@@ -271,6 +280,7 @@ mod test {
         let v = CrdsValue::new_unsigned(CrdsData::EpochSlots(EpochSlots::new(
             Pubkey::default(),
             0,
+            0,
             BTreeSet::new(),
             0,
         )));
@@ -296,6 +306,7 @@ mod test {
         let btreeset: BTreeSet<u64> = vec![1, 2, 3, 6, 8].into_iter().collect();
         v = CrdsValue::new_unsigned(CrdsData::EpochSlots(EpochSlots::new(
             keypair.pubkey(),
+            0,
             0,
             btreeset,
             timestamp(),

--- a/core/src/crds_value.rs
+++ b/core/src/crds_value.rs
@@ -303,7 +303,7 @@ mod test {
             Vote::new(&keypair.pubkey(), test_tx(), timestamp()),
         ));
         verify_signatures(&mut v, &keypair, &wrong_keypair);
-        let btreeset: BTreeSet<u64> = vec![1, 2, 3, 6, 8].into_iter().collect();
+        let btreeset: BTreeSet<Slot> = vec![1, 2, 3, 6, 8].into_iter().collect();
         v = CrdsValue::new_unsigned(CrdsData::EpochSlots(EpochSlots::new(
             keypair.pubkey(),
             0,

--- a/core/src/repair_service.rs
+++ b/core/src/repair_service.rs
@@ -35,14 +35,24 @@ pub enum RepairStrategy {
 
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RepairType {
-    Orphan(u64),
-    HighestShred(u64, u64),
-    Shred(u64, u64),
+    Orphan(Slot),
+    HighestShred(Slot, u64),
+    Shred(Slot, u64),
+}
+
+impl RepairType {
+    pub fn slot(&self) -> Slot {
+        match self {
+            RepairType::Orphan(slot) => *slot,
+            RepairType::HighestShred(slot, _) => *slot,
+            RepairType::Shred(slot, _) => *slot,
+        }
+    }
 }
 
 pub struct RepairSlotRange {
-    pub start: u64,
-    pub end: u64,
+    pub start: Slot,
+    pub end: Slot,
 }
 
 impl Default for RepairSlotRange {
@@ -144,9 +154,11 @@ impl RepairService {
                         ..
                     } => {
                         let new_root = blocktree.last_root();
+                        let lowest_slot = blocktree.lowest_slot();
                         Self::update_epoch_slots(
                             id,
                             new_root,
+                            lowest_slot,
                             &mut current_root,
                             &mut epoch_slots,
                             &cluster_info,
@@ -216,7 +228,7 @@ impl RepairService {
 
     fn generate_repairs(
         blocktree: &Blocktree,
-        root: u64,
+        root: Slot,
         max_repairs: usize,
     ) -> Result<Vec<RepairType>> {
         // Slot height and shred indexes for shreds we want to repair
@@ -290,7 +302,7 @@ impl RepairService {
     fn get_completed_slots_past_root(
         blocktree: &Blocktree,
         slots_in_gossip: &mut BTreeSet<u64>,
-        root: u64,
+        root: Slot,
         epoch_schedule: &EpochSchedule,
     ) {
         let last_confirmed_epoch = epoch_schedule.get_leader_schedule_epoch(root);
@@ -314,7 +326,7 @@ impl RepairService {
         id: Pubkey,
         blocktree: &Blocktree,
         slots_in_gossip: &mut BTreeSet<u64>,
-        root: u64,
+        root: Slot,
         epoch_schedule: &EpochSchedule,
         cluster_info: &RwLock<ClusterInfo>,
     ) {
@@ -324,19 +336,22 @@ impl RepairService {
         // also be updated with the latest root (done in blocktree_processor) and thus
         // will provide a schedule to window_service for any incoming shreds up to the
         // last_confirmed_epoch.
-        cluster_info
-            .write()
-            .unwrap()
-            .push_epoch_slots(id, root, slots_in_gossip.clone());
+        cluster_info.write().unwrap().push_epoch_slots(
+            id,
+            root,
+            blocktree.lowest_slot(),
+            slots_in_gossip.clone(),
+        );
     }
 
     // Update the gossiped structure used for the "Repairmen" repair protocol. See book
     // for details.
     fn update_epoch_slots(
         id: Pubkey,
-        latest_known_root: u64,
-        prev_root: &mut u64,
-        slots_in_gossip: &mut BTreeSet<u64>,
+        latest_known_root: Slot,
+        lowest_slot: Slot,
+        prev_root: &mut Slot,
+        slots_in_gossip: &mut BTreeSet<Slot>,
         cluster_info: &RwLock<ClusterInfo>,
         completed_slots_receiver: &CompletedSlotsReceiver,
     ) {
@@ -362,12 +377,13 @@ impl RepairService {
             cluster_info.write().unwrap().push_epoch_slots(
                 id,
                 latest_known_root,
+                lowest_slot,
                 slots_in_gossip.clone(),
             );
         }
     }
 
-    fn retain_slots_greater_than_root(slot_set: &mut BTreeSet<u64>, root: u64) {
+    fn retain_slots_greater_than_root(slot_set: &mut BTreeSet<u64>, root: Slot) {
         *slot_set = slot_set
             .range((Excluded(&root), Unbounded))
             .cloned()
@@ -732,6 +748,7 @@ mod test {
                 RepairService::update_epoch_slots(
                     Pubkey::default(),
                     root,
+                    blocktree.lowest_slot(),
                     &mut root.clone(),
                     &mut completed_slots,
                     &cluster_info,
@@ -749,6 +766,7 @@ mod test {
             RepairService::update_epoch_slots(
                 Pubkey::default(),
                 root,
+                0,
                 &mut 0,
                 &mut completed_slots,
                 &cluster_info,
@@ -782,6 +800,7 @@ mod test {
         RepairService::update_epoch_slots(
             my_pubkey.clone(),
             current_root,
+            0,
             &mut current_root.clone(),
             &mut completed_slots,
             &cluster_info,
@@ -812,6 +831,7 @@ mod test {
         RepairService::update_epoch_slots(
             my_pubkey.clone(),
             current_root,
+            0,
             &mut current_root,
             &mut completed_slots,
             &cluster_info,
@@ -830,6 +850,7 @@ mod test {
         RepairService::update_epoch_slots(
             my_pubkey.clone(),
             current_root + 1,
+            0,
             &mut current_root,
             &mut completed_slots,
             &cluster_info,

--- a/core/src/repair_service.rs
+++ b/core/src/repair_service.rs
@@ -116,7 +116,7 @@ impl RepairService {
         cluster_info: &Arc<RwLock<ClusterInfo>>,
         repair_strategy: RepairStrategy,
     ) {
-        let mut epoch_slots: BTreeSet<u64> = BTreeSet::new();
+        let mut epoch_slots: BTreeSet<Slot> = BTreeSet::new();
         let id = cluster_info.read().unwrap().id();
         let mut current_root = 0;
         if let RepairStrategy::RepairAll {
@@ -301,7 +301,7 @@ impl RepairService {
 
     fn get_completed_slots_past_root(
         blocktree: &Blocktree,
-        slots_in_gossip: &mut BTreeSet<u64>,
+        slots_in_gossip: &mut BTreeSet<Slot>,
         root: Slot,
         epoch_schedule: &EpochSchedule,
     ) {
@@ -325,7 +325,7 @@ impl RepairService {
     fn initialize_epoch_slots(
         id: Pubkey,
         blocktree: &Blocktree,
-        slots_in_gossip: &mut BTreeSet<u64>,
+        slots_in_gossip: &mut BTreeSet<Slot>,
         root: Slot,
         epoch_schedule: &EpochSchedule,
         cluster_info: &RwLock<ClusterInfo>,
@@ -383,7 +383,7 @@ impl RepairService {
         }
     }
 
-    fn retain_slots_greater_than_root(slot_set: &mut BTreeSet<u64>, root: Slot) {
+    fn retain_slots_greater_than_root(slot_set: &mut BTreeSet<Slot>, root: Slot) {
         *slot_set = slot_set
             .range((Excluded(&root), Unbounded))
             .cloned()


### PR DESCRIPTION
#### Problem

- Repair and Repairman both think they live in a world where everyone has the entire ledger
- The Repair Client randomly asks a peer for shreds even though that peer may never have that data because they booted with a snapshot newer than the requested repair slot
- Repairman protocol attempts to divvy up catchup responsibilities among peers that report new enough root slots. This doesn't however ensure that the peers actually have that data (see above)

These problems result in Repair being slow(more misses if fewer nodes have the requested slot) and Repairman not sending all the required data(assuming peers will take over some of that responsibility). 

#### Summary of Changes

- Add lowest available slot to the gossiped repair information
- Filter out peers that simply cannot serve repairs from both repair and repairman protocols

This fixes repair's ability to bring nodes that are really far behind back up to the cluster

Fixes #7100
