### PR TITLE
Add time since genesis to sysvar::clock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3934,19 +3934,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-storage-tests"
-version = "0.22.0"
-dependencies = [
- "assert_matches 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "bincode 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-logger 0.22.0",
- "solana-runtime 0.22.0",
- "solana-sdk 0.22.0",
- "solana-storage-program 0.22.0",
-]
-
-[[package]]
 name = "solana-sys-tuner"
 version = "0.22.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3428,6 +3428,7 @@ name = "solana-genesis"
 version = "0.22.0"
 dependencies = [
  "base64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/genesis/Cargo.toml
+++ b/genesis/Cargo.toml
@@ -11,6 +11,7 @@ homepage = "https://solana.com/"
 [dependencies]
 base64 = "0.11.0"
 clap = "2.33.0"
+chrono = "0.4"
 hex = "0.4.0"
 serde = "1.0.103"
 serde_derive = "1.0.103"

--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -1,8 +1,8 @@
 //! A command-line executable for generating the chain's genesis config.
 
+use chrono::DateTime;
 use clap::{crate_description, crate_name, value_t, value_t_or_exit, App, Arg, ArgMatches};
-use solana_clap_utils::input_parsers::pubkey_of;
-use solana_clap_utils::input_validators::is_valid_percentage;
+use solana_clap_utils::{input_parsers::pubkey_of, input_validators::is_valid_percentage};
 use solana_genesis::{genesis_accounts::add_genesis_accounts, Base64Account};
 use solana_ledger::{blocktree::create_new_ledger, poh::compute_hashes_per_tick};
 use solana_sdk::{
@@ -126,6 +126,13 @@ fn main() -> Result<(), Box<dyn error::Error>> {
     let matches = App::new(crate_name!())
         .about(crate_description!())
         .version(solana_clap_utils::version!())
+        .arg(
+            Arg::with_name("creation_time")
+                .long("creation-time")
+                .value_name("RFC3339 DATE TIME")
+                .takes_value(true)
+                .help("Time when the bootrap leader will start, defaults to current system time"),
+        )
         .arg(
             Arg::with_name("bootstrap_leader_pubkey_file")
                 .short("b")
@@ -434,6 +441,10 @@ fn main() -> Result<(), Box<dyn error::Error>> {
         operating_mode,
         ..GenesisConfig::default()
     };
+
+    if let Some(creation_time) = matches.value_of("creation_time") {
+        genesis_config.creation_time = DateTime::parse_from_rfc3339(creation_time)?.timestamp();
+    }
 
     if let Some(faucet_pubkey) = faucet_pubkey {
         genesis_config.add_account(

--- a/programs/stake/src/stake_instruction.rs
+++ b/programs/stake/src/stake_instruction.rs
@@ -358,7 +358,7 @@ mod tests {
             .iter()
             .map(|meta| {
                 if sysvar::clock::check_id(&meta.pubkey) {
-                    sysvar::clock::create_account(1, 0, 0, 0, 0)
+                    sysvar::clock::Clock::default().create_account(1)
                 } else if sysvar::rewards::check_id(&meta.pubkey) {
                     sysvar::rewards::create_account(1, 0.0, 0.0)
                 } else if sysvar::stake_history::check_id(&meta.pubkey) {
@@ -582,7 +582,7 @@ mod tests {
                     KeyedAccount::new(
                         &sysvar::clock::id(),
                         false,
-                        &mut sysvar::clock::create_account(1, 0, 0, 0, 0)
+                        &mut sysvar::clock::Clock::default().create_account(1)
                     ),
                     KeyedAccount::new(
                         &config::id(),

--- a/programs/storage/src/storage_processor.rs
+++ b/programs/storage/src/storage_processor.rs
@@ -159,7 +159,7 @@ mod tests {
             Hash::default(),
         );
         // the proof is for segment 0, need to move the slot into segment 2
-        let mut clock_account = clock::create_account(1, 0, 0, 0, 0);
+        let mut clock_account = Clock::default().create_account(1);
         Clock::to_account(
             &Clock {
                 slot: DEFAULT_SLOTS_PER_SEGMENT * 2,
@@ -186,7 +186,7 @@ mod tests {
         let clock_id = clock::id();
         let mut keyed_accounts = Vec::new();
         let mut user_account = Account::default();
-        let mut clock_account = clock::create_account(1, 0, 0, 0, 0);
+        let mut clock_account = Clock::default().create_account(1);
         keyed_accounts.push(KeyedAccount::new(&pubkey, true, &mut user_account));
         keyed_accounts.push(KeyedAccount::new(&clock_id, false, &mut clock_account));
 
@@ -211,7 +211,7 @@ mod tests {
             Hash::default(),
         );
         // move tick height into segment 1
-        let mut clock_account = clock::create_account(1, 0, 0, 0, 0);
+        let mut clock_account = Clock::default().create_account(1);
         Clock::to_account(
             &Clock {
                 slot: 16,
@@ -270,7 +270,7 @@ mod tests {
             Hash::default(),
         );
         // move slot into segment 1
-        let mut clock_account = clock::create_account(1, 0, 0, 0, 0);
+        let mut clock_account = Clock::default().create_account(1);
         Clock::to_account(
             &Clock {
                 slot: DEFAULT_SLOTS_PER_SEGMENT,

--- a/programs/vote/src/vote_instruction.rs
+++ b/programs/vote/src/vote_instruction.rs
@@ -203,7 +203,7 @@ mod tests {
             .iter()
             .map(|meta| {
                 if sysvar::clock::check_id(&meta.pubkey) {
-                    sysvar::clock::create_account(1, 0, 0, 0, 0)
+                    sysvar::clock::Clock::default().create_account(1)
                 } else if sysvar::slot_hashes::check_id(&meta.pubkey) {
                     sysvar::slot_hashes::create_account(1, &[])
                 } else if sysvar::rent::check_id(&meta.pubkey) {

--- a/sdk/src/clock.rs
+++ b/sdk/src/clock.rs
@@ -108,6 +108,9 @@ pub struct Clock {
     /// the future Epoch for which the leader schedule has
     ///  most recently been calculated
     pub leader_schedule_epoch: Epoch,
+    /// computed from genesis creation time and network time
+    ///  in slots, drifts!
+    pub unix_timestamp: UnixTimestamp,
 }
 
 #[cfg(test)]

--- a/sdk/src/genesis_config.rs
+++ b/sdk/src/genesis_config.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     account::Account,
-    clock::{DEFAULT_SLOTS_PER_SEGMENT, DEFAULT_TICKS_PER_SLOT},
+    clock::{UnixTimestamp, DEFAULT_SLOTS_PER_SEGMENT, DEFAULT_TICKS_PER_SLOT},
     epoch_schedule::EpochSchedule,
     fee_calculator::FeeCalculator,
     hash::{hash, Hash},
@@ -20,6 +20,7 @@ use std::{
     fs::{File, OpenOptions},
     io::Write,
     path::{Path, PathBuf},
+    time::{SystemTime, UNIX_EPOCH},
 };
 
 #[derive(Serialize, Deserialize, Debug, Clone, Copy)]
@@ -30,6 +31,7 @@ pub enum OperatingMode {
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct GenesisConfig {
+    pub creation_time: UnixTimestamp,
     pub accounts: BTreeMap<Pubkey, Account>,
     pub native_instruction_processors: Vec<(String, Pubkey)>,
     pub rewards_pools: BTreeMap<Pubkey, Account>,
@@ -61,6 +63,10 @@ pub fn create_genesis_config(lamports: u64) -> (GenesisConfig, Keypair) {
 impl Default for GenesisConfig {
     fn default() -> Self {
         Self {
+            creation_time: SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_secs() as UnixTimestamp,
             accounts: BTreeMap::default(),
             native_instruction_processors: Vec::default(),
             rewards_pools: BTreeMap::default(),

--- a/sdk/src/genesis_config.rs
+++ b/sdk/src/genesis_config.rs
@@ -31,17 +31,27 @@ pub enum OperatingMode {
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct GenesisConfig {
+    /// when the network (bootstrap leader) was started relative to the UNIX Epoch
     pub creation_time: UnixTimestamp,
+    /// initial accounts
     pub accounts: BTreeMap<Pubkey, Account>,
+    /// built-in programs
     pub native_instruction_processors: Vec<(String, Pubkey)>,
+    /// accounts for network rewards, these do not count towards capitalization
     pub rewards_pools: BTreeMap<Pubkey, Account>,
     pub ticks_per_slot: u64,
     pub slots_per_segment: u64,
+    /// network speed configuration
     pub poh_config: PohConfig,
+    /// transaction fee config
     pub fee_calculator: FeeCalculator,
+    /// rent config
     pub rent: Rent,
+    /// inflation config
     pub inflation: Inflation,
+    /// how slots map to epochs
     pub epoch_schedule: EpochSchedule,
+    /// network runlevel
     pub operating_mode: OperatingMode,
 }
 

--- a/sdk/src/sysvar/clock.rs
+++ b/sdk/src/sysvar/clock.rs
@@ -2,40 +2,8 @@
 //!
 pub use crate::clock::Clock;
 
-use crate::{
-    account::Account,
-    clock::{Epoch, Segment, Slot},
-    sysvar::Sysvar,
-};
+use crate::sysvar::Sysvar;
 
 crate::declare_sysvar_id!("SysvarC1ock11111111111111111111111111111111", Clock);
 
 impl Sysvar for Clock {}
-
-pub fn create_account(
-    lamports: u64,
-    slot: Slot,
-    segment: Segment,
-    epoch: Epoch,
-    leader_schedule_epoch: Epoch,
-) -> Account {
-    Clock {
-        slot,
-        segment,
-        epoch,
-        leader_schedule_epoch,
-    }
-    .create_account(lamports)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_new() {
-        let account = create_account(1, 0, 0, 0, 0);
-        let clock = Clock::from_account(&account).unwrap();
-        assert_eq!(clock, Clock::default());
-    }
-}


### PR DESCRIPTION
#### Problem
 no notion of wallclock available to programs

 #### Summary of Changes
 add simple, good enough unix_timestamp to bank, sysvar::clock, based
   on genesis creation timestamp

Fixes #