### PR TITLE
Canonicalize paths before symlink-ing when generating snapshots

### DIFF
--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -575,7 +575,7 @@ pub fn main() {
     let ledger_path = fs::canonicalize(&ledger_path).unwrap_or_else(|err| {
         eprintln!("Unable to access ledger path: {:?}", err);
         exit(1);
-    })
+    });
 
     let mut validator_config = ValidatorConfig::default();
     validator_config.dev_sigverify_disabled = matches.is_present("dev_no_sigverify");

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -571,6 +571,12 @@ pub fn main() {
     let no_snapshot_fetch = matches.is_present("no_snapshot_fetch");
     let rpc_port = value_t!(matches, "rpc_port", u16);
 
+    // Canonicalize ledger path to avoid issues with symlink creation
+    let ledger_path = fs::canonicalize(&ledger_path).unwrap_or_else(|err| {
+        eprintln!("Unable to access ledger path: {:?}", err);
+        exit(1);
+    })
+
     let mut validator_config = ValidatorConfig::default();
     validator_config.dev_sigverify_disabled = matches.is_present("dev_no_sigverify");
     validator_config.dev_halt_at_slot = value_t!(matches, "dev_halt_at_slot", Slot).ok();


### PR DESCRIPTION
#### Problem
solana-validator accepts a relative path to the ledger for the --ledger option, and it mostly operates successfully. However, snapshot creation fails, silently.

#### Summary of Changes
- Return an error if snapshot creation fails due to symlink-ing issues
- Add a test for snapshot generation with a relative path
- Canonicalize account storage paths before symlinking
- Canonicalize ledger path before using it (for peace of mind)

Fixes https://github.com/solana-labs/solana/issues/7258
