### PR TITLE
Enable system program at SoftLaunch epoch 0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3610,6 +3610,7 @@ dependencies = [
 name = "solana-local-cluster"
 version = "0.22.0"
 dependencies = [
+ "assert_matches 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/genesis-programs/src/lib.rs
+++ b/genesis-programs/src/lib.rs
@@ -73,17 +73,20 @@ pub fn get_programs(operating_mode: OperatingMode, epoch: Epoch) -> Option<Vec<(
         }
         OperatingMode::SoftLaunch => {
             if epoch == 0 {
-                // Voting and Staking only at epoch 0
-                Some(vec![solana_stake_program!(), solana_vote_program!()])
+                // Voting, Staking and System Program only at epoch 0
+                Some(vec![
+                    solana_stake_program!(),
+                    solana_system_program(),
+                    solana_vote_program!(),
+                ])
             } else if epoch == std::u64::MAX - 1 {
-                // System program and Archivers are activated next
+                // Archivers are activated next
                 //
                 // The epoch of std::u64::MAX - 1 is a placeholder and is expected to be reduced in
                 // a future hard fork.
                 Some(vec![
                     solana_config_program!(),
                     solana_storage_program!(),
-                    solana_system_program(),
                     solana_vest_program!(),
                 ])
             } else if epoch == std::u64::MAX {
@@ -165,7 +168,11 @@ mod tests {
     fn test_softlaunch_programs() {
         assert_eq!(
             get_programs(OperatingMode::SoftLaunch, 0),
-            Some(vec![solana_stake_program!(), solana_vote_program!(),])
+            Some(vec![
+                solana_stake_program!(),
+                solana_system_program(),
+                solana_vote_program!(),
+            ])
         );
         assert_eq!(get_programs(OperatingMode::SoftLaunch, 1), None);
         assert!(get_programs(OperatingMode::SoftLaunch, std::u64::MAX - 1).is_some());

--- a/local-cluster/Cargo.toml
+++ b/local-cluster/Cargo.toml
@@ -31,5 +31,6 @@ tempfile = "3.1.0"
 solana-rayon-threadlimit = { path = "../rayon-threadlimit", version = "0.22.0" }
 
 [dev-dependencies]
+assert_matches = "1.3.0"
 serial_test = "0.3.1"
 serial_test_derive = "0.3.1"

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -170,9 +170,11 @@ impl LocalCluster {
                         .into_iter()
                         .collect()
             }
-            // create_genesis_config_with_leader() assumes OperatingMode::Development so do
-            // nothing...
-            OperatingMode::Development => (),
+            OperatingMode::Development => {
+                genesis_config
+                    .native_instruction_processors
+                    .push(solana_storage_program!());
+            }
         }
 
         genesis_config.inflation =
@@ -181,9 +183,6 @@ impl LocalCluster {
         genesis_config
             .native_instruction_processors
             .extend_from_slice(&config.native_instruction_processors);
-        genesis_config
-            .native_instruction_processors
-            .push(solana_storage_program!());
 
         let storage_keypair = Keypair::new();
         genesis_config.add_account(

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -1,3 +1,4 @@
+use assert_matches::assert_matches;
 use log::*;
 use serial_test_derive::serial;
 use solana_client::thin_client::create_client;
@@ -565,11 +566,30 @@ fn test_softlaunch_operating_mode() {
         solana_core::cluster_info::VALIDATOR_PORT_RANGE,
     );
 
-    // Programs that are not available at soft launch
+    // Programs that are available at soft launch epoch 0
+    for program_id in [
+        &solana_sdk::system_program::id(),
+        &solana_vote_program::id(),
+        &solana_stake_program::id(),
+    ]
+    .iter()
+    {
+        assert_matches!(
+            (
+                program_id,
+                client
+                    .get_account_with_commitment(program_id, CommitmentConfig::recent())
+                    .unwrap()
+            ),
+            (_program_id, Some(_))
+        );
+    }
+
+    // Programs that are not available at soft launch epoch 0
     for program_id in [
         &solana_config_program::id(),
         &solana_sdk::bpf_loader::id(),
-        &solana_sdk::system_program::id(),
+        &solana_storage_program::id(),
         &solana_vest_program::id(),
     ]
     .iter()


### PR DESCRIPTION
With all notable SOL locked up in Stake accounts for soft launch epoch 0, there's not much benefit to disabling the system program (and it actively inhibits our ability to selectively on-board lead partners)

Fixes #7309
