### PR TITLE
put limit on account data length

### DIFF
--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -3,6 +3,7 @@ use crate::system_instruction_processor;
 use serde::{Deserialize, Serialize};
 use solana_sdk::account::{create_keyed_readonly_accounts, Account, KeyedAccount};
 use solana_sdk::clock::Epoch;
+use solana_sdk::hash::hash;
 use solana_sdk::instruction::{CompiledInstruction, InstructionError};
 use solana_sdk::instruction_processor_utils;
 use solana_sdk::loader_instruction::LoaderInstruction;
@@ -134,7 +135,7 @@ pub fn verify_account_changes(
 
     if need_account_data_checked(&pre.owner, program_id, pre.is_writable) {
         match &pre.data {
-            Some(data) if *data == post.data => (),
+            Some(data) if hash(data) == hash(&post.data) => (),
             _ => {
                 if !pre.is_writable {
                     return Err(InstructionError::ReadonlyDataModified);

--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -3,7 +3,6 @@ use crate::system_instruction_processor;
 use serde::{Deserialize, Serialize};
 use solana_sdk::account::{create_keyed_readonly_accounts, Account, KeyedAccount};
 use solana_sdk::clock::Epoch;
-use solana_sdk::hash::hash;
 use solana_sdk::instruction::{CompiledInstruction, InstructionError};
 use solana_sdk::instruction_processor_utils;
 use solana_sdk::loader_instruction::LoaderInstruction;

--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -135,7 +135,7 @@ pub fn verify_account_changes(
 
     if need_account_data_checked(&pre.owner, program_id, pre.is_writable) {
         match &pre.data {
-            Some(data) if hash(data) == hash(&post.data) => (),
+            Some(data) if *data == post.data => (),
             _ => {
                 if !pre.is_writable {
                     return Err(InstructionError::ReadonlyDataModified);

--- a/runtime/src/system_instruction_processor.rs
+++ b/runtime/src/system_instruction_processor.rs
@@ -7,8 +7,8 @@ use solana_sdk::system_instruction::{SystemError, SystemInstruction};
 use solana_sdk::system_program;
 use solana_sdk::sysvar;
 
-// 512 Kilobytes (To accommodate eBPF programs)
-const MAX_PERMITTED_DATA_LENGTH: u64 = 512 * 1024;
+// 10 MB
+const MAX_PERMITTED_DATA_LENGTH: u64 = 10 * 1024 * 1024;
 
 fn create_system_account(
     from: &mut KeyedAccount,

--- a/runtime/src/system_instruction_processor.rs
+++ b/runtime/src/system_instruction_processor.rs
@@ -248,13 +248,13 @@ mod tests {
     }
 
     #[test]
-    fn test_create_more_than_allowed_space() {
+    fn test_request_more_than_allowed_data_length() {
         let mut from_account = Account::new(100, 0, &system_program::id());
         let from_account_key = Pubkey::new_rand();
         let mut to_account = Account::default();
         let to_account_key = Pubkey::new_rand();
 
-        // Trying to allocate more space than permitted will result in failure
+        // Trying to request more data length than permitted will result in failure
         let result = create_system_account(
             &mut KeyedAccount::new(&from_account_key, true, &mut from_account),
             &mut KeyedAccount::new(&to_account_key, true, &mut to_account),
@@ -268,7 +268,7 @@ mod tests {
             SystemError::InvalidAccountDataLength.into()
         );
 
-        // Trying to allocate equal or less space than permitted will be success
+        // Trying to request equal or less data length than permitted will be success
         let result = create_system_account(
             &mut KeyedAccount::new(&from_account_key, true, &mut from_account),
             &mut KeyedAccount::new(&to_account_key, true, &mut to_account),

--- a/runtime/src/system_instruction_processor.rs
+++ b/runtime/src/system_instruction_processor.rs
@@ -7,8 +7,8 @@ use solana_sdk::system_instruction::{SystemError, SystemInstruction};
 use solana_sdk::system_program;
 use solana_sdk::sysvar;
 
-// 64 Kilobytes
-const MAX_PERMITTED_DATA_LENGTH: u64 = 64 * 1024;
+// 512 Kilobytes (To accommodate eBPF programs)
+const MAX_PERMITTED_DATA_LENGTH: u64 = 512 * 1024;
 
 fn create_system_account(
     from: &mut KeyedAccount,

--- a/runtime/src/system_instruction_processor.rs
+++ b/runtime/src/system_instruction_processor.rs
@@ -268,7 +268,7 @@ mod tests {
             SystemError::InvalidAccountDataLength.into()
         );
 
-        // Trying to request equal or less data length than permitted will be success
+        // Trying to request equal or less data length than permitted will be successful
         let result = create_system_account(
             &mut KeyedAccount::new(&from_account_key, true, &mut from_account),
             &mut KeyedAccount::new(&to_account_key, true, &mut to_account),

--- a/runtime/src/system_instruction_processor.rs
+++ b/runtime/src/system_instruction_processor.rs
@@ -55,7 +55,7 @@ fn create_system_account(
 
     if data_length > MAX_PERMITTED_DATA_LENGTH {
         debug!(
-            "CreateAccount: requested more space than maximum allowed, space requested {}",
+            "CreateAccount: requested data_length: {} is more than maximum allowed",
             data_length
         );
         return Err(SystemError::InvalidAccountDataLength.into());

--- a/runtime/src/system_instruction_processor.rs
+++ b/runtime/src/system_instruction_processor.rs
@@ -7,11 +7,14 @@ use solana_sdk::system_instruction::{SystemError, SystemInstruction};
 use solana_sdk::system_program;
 use solana_sdk::sysvar;
 
+// 64 Kilobytes
+const MAX_PERMITTED_DATA_LENGTH: u64 = 64 * 1024;
+
 fn create_system_account(
     from: &mut KeyedAccount,
     to: &mut KeyedAccount,
     lamports: u64,
-    space: u64,
+    data_length: u64,
     program_id: &Pubkey,
 ) -> Result<(), InstructionError> {
     // if lamports == 0, the from account isn't touched
@@ -50,10 +53,18 @@ fn create_system_account(
         return Err(SystemError::ResultWithNegativeLamports.into());
     }
 
+    if data_length > MAX_PERMITTED_DATA_LENGTH {
+        debug!(
+            "CreateAccount: requested more space than maximum allowed, space requested {}",
+            data_length
+        );
+        return Err(SystemError::InvalidAccountDataLength.into());
+    }
+
     assign_account_to_program(to, program_id)?;
     from.account.lamports -= lamports;
     to.account.lamports += lamports;
-    to.account.data = vec![0; space as usize];
+    to.account.data = vec![0; data_length as usize];
     to.account.executable = false;
     Ok(())
 }
@@ -234,6 +245,40 @@ mod tests {
         let from_lamports = from_account.lamports;
         assert_eq!(from_lamports, 100);
         assert_eq!(to_account, unchanged_account);
+    }
+
+    #[test]
+    fn test_create_more_than_allowed_space() {
+        let mut from_account = Account::new(100, 0, &system_program::id());
+        let from_account_key = Pubkey::new_rand();
+        let mut to_account = Account::default();
+        let to_account_key = Pubkey::new_rand();
+
+        // Trying to allocate more space than permitted will result in failure
+        let result = create_system_account(
+            &mut KeyedAccount::new(&from_account_key, true, &mut from_account),
+            &mut KeyedAccount::new(&to_account_key, true, &mut to_account),
+            50,
+            MAX_PERMITTED_DATA_LENGTH + 1,
+            &system_program::id(),
+        );
+        assert!(result.is_err());
+        assert_eq!(
+            result.err().unwrap(),
+            SystemError::InvalidAccountDataLength.into()
+        );
+
+        // Trying to allocate equal or less space than permitted will be success
+        let result = create_system_account(
+            &mut KeyedAccount::new(&from_account_key, true, &mut from_account),
+            &mut KeyedAccount::new(&to_account_key, true, &mut to_account),
+            50,
+            MAX_PERMITTED_DATA_LENGTH,
+            &system_program::id(),
+        );
+        assert!(result.is_ok());
+        assert_eq!(to_account.lamports, 50);
+        assert_eq!(to_account.data.len() as u64, MAX_PERMITTED_DATA_LENGTH);
     }
 
     #[test]

--- a/sdk/src/system_instruction.rs
+++ b/sdk/src/system_instruction.rs
@@ -10,6 +10,7 @@ pub enum SystemError {
     ResultWithNegativeLamports,
     InvalidProgramId,
     InvalidAccountId,
+    InvalidAccountDataLength,
 }
 
 impl<T> DecodeError<T> for SystemError {


### PR DESCRIPTION
#### Problem
The user can request the system create an account of size 0xFFFFFFFFFFFFFFFF, which'll probably OOM the validator:
https://github.com/solana-labs/solana/blob/ba46bc4624e694d3692e1c4b6be3021beef91e9c/sdk/src/system_instruction.rs#L39


#### Summary of Changes
putting a limit on account data length
Refactor variable name for better readability and consistency

Fixes #6413
