### PR TITLE
Bump wallet-sanity timeout

### DIFF
--- a/ci/localnet-sanity.sh
+++ b/ci/localnet-sanity.sh
@@ -365,7 +365,7 @@ while [[ $iteration -le $iterations ]]; do
   echo "--- Wallet sanity ($iteration)"
   (
     set -x
-    timeout 90s scripts/wallet-sanity.sh --url http://127.0.0.1"$walletRpcPort"
+    timeout 105s scripts/wallet-sanity.sh --url http://127.0.0.1"$walletRpcPort"
   ) || flag_error
 
   iteration=$((iteration + 1))


### PR DESCRIPTION
#### Problem
Wallet-sanity times out in CI intermittently. While @jstarry is investigating the root cause of why the script is taking so much longer, this should enable CI to pass more consistently in the meantime.

#### Summary of Changes
Bump wallet-sanity timeout 15sec
