### PR TITLE
Not enough information of process state during an OOM

### DIFF
--- a/core/file.txt
+++ b/core/file.txt
@@ -1,3 +1,0 @@
-{
-  "thread_mem_usage::tests::test_thread_memory_map": 128
-}

--- a/core/file.txt
+++ b/core/file.txt
@@ -1,0 +1,3 @@
+{
+  "thread_mem_usage::tests::test_thread_memory_map": 128
+}

--- a/core/src/rpc_pubsub.rs
+++ b/core/src/rpc_pubsub.rs
@@ -345,7 +345,10 @@ mod tests {
             let expected_res: Option<transaction::Result<()>> = Some(Ok(()));
             let expected_res_str =
                 serde_json::to_string(&serde_json::to_value(expected_res).unwrap()).unwrap();
-            let expected = format!(r#"{{"jsonrpc":"2.0","method":"signatureNotification","params":{{"result":{},"subscription":0}}}}"#, expected_res_str);
+            let expected = format!(
+                r#"{{"jsonrpc":"2.0","method":"signatureNotification","params":{{"result":{},"subscription":0}}}}"#,
+                expected_res_str
+            );
             assert_eq!(expected, response);
         }
     }
@@ -389,7 +392,9 @@ mod tests {
         let req =
             format!(r#"{{"jsonrpc":"2.0","id":1,"method":"signatureUnsubscribe","params":[1]}}"#);
         let res = io.handle_request_sync(&req, session.clone());
-        let expected = format!(r#"{{"jsonrpc":"2.0","error":{{"code":-32602,"message":"Invalid Request: Subscription id does not exist"}},"id":1}}"#);
+        let expected = format!(
+            r#"{{"jsonrpc":"2.0","error":{{"code":-32602,"message":"Invalid Request: Subscription id does not exist"}},"id":1}}"#
+        );
         let expected: Response = serde_json::from_str(&expected).unwrap();
 
         let result: Response = serde_json::from_str(&res.unwrap()).unwrap();
@@ -529,7 +534,9 @@ mod tests {
         let req =
             format!(r#"{{"jsonrpc":"2.0","id":1,"method":"accountUnsubscribe","params":[1]}}"#);
         let res = io.handle_request_sync(&req, session.clone());
-        let expected = format!(r#"{{"jsonrpc":"2.0","error":{{"code":-32602,"message":"Invalid Request: Subscription id does not exist"}},"id":1}}"#);
+        let expected = format!(
+            r#"{{"jsonrpc":"2.0","error":{{"code":-32602,"message":"Invalid Request: Subscription id does not exist"}},"id":1}}"#
+        );
         let expected: Response = serde_json::from_str(&expected).unwrap();
 
         let result: Response = serde_json::from_str(&res.unwrap()).unwrap();
@@ -640,7 +647,10 @@ mod tests {
             };
             let expected_res_str =
                 serde_json::to_string(&serde_json::to_value(expected_res).unwrap()).unwrap();
-            let expected = format!(r#"{{"jsonrpc":"2.0","method":"slotNotification","params":{{"result":{},"subscription":0}}}}"#, expected_res_str);
+            let expected = format!(
+                r#"{{"jsonrpc":"2.0","method":"slotNotification","params":{{"result":{},"subscription":0}}}}"#,
+                expected_res_str
+            );
             assert_eq!(expected, response);
         }
     }
@@ -662,7 +672,10 @@ mod tests {
             };
             let expected_res_str =
                 serde_json::to_string(&serde_json::to_value(expected_res).unwrap()).unwrap();
-            let expected = format!(r#"{{"jsonrpc":"2.0","method":"slotNotification","params":{{"result":{},"subscription":0}}}}"#, expected_res_str);
+            let expected = format!(
+                r#"{{"jsonrpc":"2.0","method":"slotNotification","params":{{"result":{},"subscription":0}}}}"#,
+                expected_res_str
+            );
             assert_eq!(expected, response);
         }
 

--- a/core/src/rpc_subscriptions.rs
+++ b/core/src/rpc_subscriptions.rs
@@ -375,7 +375,9 @@ mod tests {
         subscriptions.check_account(&alice.pubkey(), 0, &bank_forks);
         let string = transport_receiver.poll();
         if let Async::Ready(Some(response)) = string.unwrap() {
-            let expected = format!(r#"{{"jsonrpc":"2.0","method":"accountNotification","params":{{"result":{{"data":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"executable":false,"lamports":1,"owner":[2,203,81,223,225,24,34,35,203,214,138,130,144,208,35,77,63,16,87,51,47,198,115,123,98,188,19,160,0,0,0,0],"rent_epoch":1}},"subscription":0}}}}"#);
+            let expected = format!(
+                r#"{{"jsonrpc":"2.0","method":"accountNotification","params":{{"result":{{"data":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"executable":false,"lamports":1,"owner":[2,203,81,223,225,24,34,35,203,214,138,130,144,208,35,77,63,16,87,51,47,198,115,123,98,188,19,160,0,0,0,0],"rent_epoch":1}},"subscription":0}}}}"#
+            );
             assert_eq!(expected, response);
         }
 
@@ -430,7 +432,10 @@ mod tests {
         subscriptions.check_program(&solana_budget_program::id(), 0, &bank_forks);
         let string = transport_receiver.poll();
         if let Async::Ready(Some(response)) = string.unwrap() {
-            let expected = format!(r#"{{"jsonrpc":"2.0","method":"programNotification","params":{{"result":["{:?}",{{"data":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"executable":false,"lamports":1,"owner":[2,203,81,223,225,24,34,35,203,214,138,130,144,208,35,77,63,16,87,51,47,198,115,123,98,188,19,160,0,0,0,0],"rent_epoch":1}}],"subscription":0}}}}"#, alice.pubkey());
+            let expected = format!(
+                r#"{{"jsonrpc":"2.0","method":"programNotification","params":{{"result":["{:?}",{{"data":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"executable":false,"lamports":1,"owner":[2,203,81,223,225,24,34,35,203,214,138,130,144,208,35,77,63,16,87,51,47,198,115,123,98,188,19,160,0,0,0,0],"rent_epoch":1}}],"subscription":0}}}}"#,
+                alice.pubkey()
+            );
             assert_eq!(expected, response);
         }
 
@@ -481,7 +486,10 @@ mod tests {
             let expected_res: Option<transaction::Result<()>> = Some(Ok(()));
             let expected_res_str =
                 serde_json::to_string(&serde_json::to_value(expected_res).unwrap()).unwrap();
-            let expected = format!(r#"{{"jsonrpc":"2.0","method":"signatureNotification","params":{{"result":{},"subscription":0}}}}"#, expected_res_str);
+            let expected = format!(
+                r#"{{"jsonrpc":"2.0","method":"signatureNotification","params":{{"result":{},"subscription":0}}}}"#,
+                expected_res_str
+            );
             assert_eq!(expected, response);
         }
 
@@ -517,7 +525,10 @@ mod tests {
             };
             let expected_res_str =
                 serde_json::to_string(&serde_json::to_value(expected_res).unwrap()).unwrap();
-            let expected = format!(r#"{{"jsonrpc":"2.0","method":"slotNotification","params":{{"result":{},"subscription":0}}}}"#, expected_res_str);
+            let expected = format!(
+                r#"{{"jsonrpc":"2.0","method":"slotNotification","params":{{"result":{},"subscription":0}}}}"#,
+                expected_res_str
+            );
             assert_eq!(expected, response);
         }
 

--- a/core/src/thread_mem_usage.rs
+++ b/core/src/thread_mem_usage.rs
@@ -1,10 +1,15 @@
+use serde_derive::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::fs::File;
+use std::io::{Read, Write};
+use std::path::Path;
 #[cfg(unix)]
-use jemalloc_ctl::thread;
+use std::thread;
 
 pub fn datapoint(_name: &'static str) {
     #[cfg(unix)]
     {
-        let allocated = thread::allocatedp::mib().unwrap();
+        let allocated = jemalloc_ctl::thread::allocatedp::mib().unwrap();
         let allocated = allocated.read().unwrap();
         let mem = allocated.get();
         solana_metrics::datapoint_debug!("thread-memory", (_name, mem as i64, i64));
@@ -13,14 +18,14 @@ pub fn datapoint(_name: &'static str) {
 
 pub struct Allocatedp {
     #[cfg(unix)]
-    allocated: thread::ThreadLocal<u64>,
+    allocated: jemalloc_ctl::thread::ThreadLocal<u64>,
 }
 
 impl Allocatedp {
     pub fn default() -> Self {
         #[cfg(unix)]
         {
-            let allocated = thread::allocatedp::mib().unwrap();
+            let allocated = jemalloc_ctl::thread::allocatedp::mib().unwrap();
             let allocated = allocated.read().unwrap();
             Self { allocated }
         }
@@ -35,5 +40,51 @@ impl Allocatedp {
         }
         #[cfg(not(unix))]
         0
+    }
+}
+
+#[derive(PartialEq, Debug, Serialize, Deserialize)]
+struct MapFile(HashMap<String, u64>);
+
+impl MapFile {
+    pub fn write_to_file(&self, path: &Path) {
+        let mut file = File::create(path).expect("Failed to create / write a file.");
+        let str = serde_json::to_string_pretty(self).expect("Error serializing the file.");
+        if let Err(err) = file.write_all(str.as_bytes()) {
+            panic!("Failed to write a file {}", err);
+        }
+    }
+
+    pub fn from_file(path: &Path) -> Self {
+        let mut file = File::open(path).expect("Could not open a file.");
+        let mut content = String::new();
+        file.read_to_string(&mut content)
+            .expect("Could not read from key file.");
+        serde_json::from_str(&content).expect("Failed to deserialize KeyFile")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_thread_memory_map() {
+        let adp = Allocatedp::default();
+        let mem = adp.get();
+
+        let current_thread = thread::current();
+        let name = current_thread.name().unwrap();
+
+        let mut map: HashMap<String, u64> = HashMap::new();
+        map.insert(name.to_string(), mem);
+
+        let file = MapFile(map);
+        let path = Path::new("file.txt");
+        file.write_to_file(&path);
+
+        let new_file = MapFile::from_file(&path);
+
+        assert_eq!(file, new_file);
     }
 }

--- a/core/src/thread_mem_usage.rs
+++ b/core/src/thread_mem_usage.rs
@@ -1,6 +1,6 @@
 use serde_derive::{Deserialize, Serialize};
 use std::collections::HashMap;
-use std::fs::File;
+use std::fs;
 use std::io::{Read, Write};
 use std::path::Path;
 #[cfg(unix)]
@@ -48,7 +48,7 @@ struct MapFile(HashMap<String, u64>);
 
 impl MapFile {
     pub fn write_to_file(&self, path: &Path) {
-        let mut file = File::create(path).expect("Failed to create / write a file.");
+        let mut file = fs::File::create(path).expect("Failed to create / write a file.");
         let str = serde_json::to_string_pretty(self).expect("Error serializing the file.");
         if let Err(err) = file.write_all(str.as_bytes()) {
             panic!("Failed to write a file {}", err);
@@ -56,11 +56,18 @@ impl MapFile {
     }
 
     pub fn from_file(path: &Path) -> Self {
-        let mut file = File::open(path).expect("Could not open a file.");
+        let mut file = fs::File::open(path).expect("Could not open a file.");
         let mut content = String::new();
         file.read_to_string(&mut content)
             .expect("Could not read from key file.");
         serde_json::from_str(&content).expect("Failed to deserialize KeyFile")
+    }
+
+    pub fn default() {
+        let path = Path::new("farf/file.txt");
+        if path.exists() {
+            fs::remove_file(&path).expect("Could not delete a file.");
+        }
     }
 }
 
@@ -80,11 +87,14 @@ mod tests {
         map.insert(name.to_string(), mem);
 
         let file = MapFile(map);
-        let path = Path::new("file.txt");
+
+        let path = Path::new("farf/file.txt");
         file.write_to_file(&path);
 
         let new_file = MapFile::from_file(&path);
 
         assert_eq!(file, new_file);
+
+        MapFile::default();
     }
 }


### PR DESCRIPTION
#### Problem

Not enough information of process state during an OOM

#### Summary of Changes

Following @sakridge suggestion :
- Add File struct with HashMap that maps current process's name to amount of bytes allocated
- Add write_to_file and from_file methods for serialization and deserialization of File struct.
- Add test test_thread_memory_map() to test this functionality 
test thread_mem_usage::tests::test_thread_memory_map ... ok

Fixes #7031

Need some guidance to proceed further.


