### PR TITLE
ledger size and cleanup metrics

### DIFF
--- a/ledger/src/blocktree.rs
+++ b/ledger/src/blocktree.rs
@@ -1469,6 +1469,10 @@ impl Blocktree {
         // This means blocktree is empty, should never get here aside from right at boot.
         self.last_root()
     }
+
+    pub fn storage_size(&self) -> u64 {
+        self.db.storage_size()
+    }
 }
 
 fn update_slot_meta(


### PR DESCRIPTION
#### Problem(s)

* the ledger is growing in an unbounded manner (see https://github.com/solana-labs/solana/issues/7139)
* ledger compaction is presently buggy/broken (see https://github.com/solana-labs/solana/issues/6521)
* as a prerequisite to test & verify solutions, we need metrics about the ledger growth (can't fix what we can't measure)
* metrics will enable better debugging of compaction techniques & impact on CPU/IOPS

#### Summary of Changes

* add a `storage_size()` method to blocktree
* publish ledger storage size metrics from `ledger_cleanup_service`

Fixes # N/A
