### PR TITLE
getVoteAccounts RPC API no longer returns "idle" vote accounts

### DIFF
--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -255,6 +255,10 @@ impl JsonRpcRequestProcessor {
                     last_vote,
                 }
             })
+            .filter(|vote_account_info| {
+                // Remove vote accounts that have never voted and also have no stake
+                vote_account_info.last_vote == 0 && vote_account_info.activated_stake == 0
+            })
             .partition(|vote_account_info| {
                 if bank.slot() >= MAX_LOCKOUT_HISTORY as u64 {
                     vote_account_info.last_vote > bank.slot() - MAX_LOCKOUT_HISTORY as u64


### PR DESCRIPTION
Whenever somebody runs `solana create-vote-account` or a vote account is added to genesis, `solana show-validators` will forever show a line item corresponding to that vote account -- even if there has been no activity on that vote account.   This clutter is even worse on the v0.21 branch where we now have 42 spare vote accounts in genesis.

The solution is to simply filter out vote accounts that have never been used to vote *and* have no stake from the getVoteAccounts RPC API.