### PR TITLE
getVoteAccounts RPC API no longer returns "idle" vote accounts, take II

### DIFF
--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -255,10 +255,6 @@ impl JsonRpcRequestProcessor {
                     last_vote,
                 }
             })
-            .filter(|vote_account_info| {
-                // Remove vote accounts that have never voted and also have no stake
-                vote_account_info.last_vote == 0 && vote_account_info.activated_stake == 0
-            })
             .partition(|vote_account_info| {
                 if bank.slot() >= MAX_LOCKOUT_HISTORY as u64 {
                     vote_account_info.last_vote > bank.slot() - MAX_LOCKOUT_HISTORY as u64


### PR DESCRIPTION
#7341 was an epic fail.  Back it out, and try again.  This time with a unit test that proves it actually works