### PR TITLE
Increase tx_count to 20k for all 5 node testcases

### DIFF
--- a/system-test/testnet-performance/aws-cpu-only-perf-5-node.yml
+++ b/system-test/testnet-performance/aws-cpu-only-perf-5-node.yml
@@ -12,7 +12,7 @@ steps:
       # Up to 3.1 GHz Intel Xeon® Platinum 8175, 16 vCPU, 64GB RAM
       VALIDATOR_NODE_MACHINE_TYPE: "m5.4xlarge"
       NUMBER_OF_CLIENT_NODES: 2
-      CLIENT_OPTIONS: "bench-tps=2=--tx_count 15000 --thread-batch-sleep-ms 250"
+      CLIENT_OPTIONS: "bench-tps=2=--tx_count 20000 --thread-batch-sleep-ms 250"
       TESTNET_ZONES: "us-west-1a,us-west-1c,us-east-1a,eu-west-1a"
       USE_PUBLIC_IP_ADDRESSES: "true"
       ADDITIONAL_FLAGS: ""

--- a/system-test/testnet-performance/azure-cpu-only-perf-5-node.yml
+++ b/system-test/testnet-performance/azure-cpu-only-perf-5-node.yml
@@ -11,7 +11,7 @@ steps:
       ENABLE_GPU: "false"
       VALIDATOR_NODE_MACHINE_TYPE: "Standard_D16s_v3"
       NUMBER_OF_CLIENT_NODES: 2
-      CLIENT_OPTIONS: "bench-tps=2=--tx_count 15000 --thread-batch-sleep-ms 250"
+      CLIENT_OPTIONS: "bench-tps=2=--tx_count 20000 --thread-batch-sleep-ms 250"
       TESTNET_ZONES: "westus"
       USE_PUBLIC_IP_ADDRESSES: "true"
       ADDITIONAL_FLAGS: ""

--- a/system-test/testnet-performance/colo-cpu-only-perf.yml
+++ b/system-test/testnet-performance/colo-cpu-only-perf.yml
@@ -10,7 +10,7 @@ steps:
       TEST_DURATION_SECONDS: 600
       NUMBER_OF_VALIDATOR_NODES: 4
       NUMBER_OF_CLIENT_NODES: 2
-      CLIENT_OPTIONS: "bench-tps=2=--tx_count 15000 --thread-batch-sleep-ms 250"
+      CLIENT_OPTIONS: "bench-tps=2=--tx_count 20000 --thread-batch-sleep-ms 250"
       ADDITIONAL_FLAGS: ""
     agents:
       - "queue=colo-deploy"

--- a/system-test/testnet-performance/colo-gpu-perf.yml
+++ b/system-test/testnet-performance/colo-gpu-perf.yml
@@ -10,7 +10,7 @@ steps:
       TEST_DURATION_SECONDS: 600
       NUMBER_OF_VALIDATOR_NODES: 4
       NUMBER_OF_CLIENT_NODES: 2
-      CLIENT_OPTIONS: "bench-tps=2=--tx_count 15000 --thread-batch-sleep-ms 250"
+      CLIENT_OPTIONS: "bench-tps=2=--tx_count 20000 --thread-batch-sleep-ms 250"
       ADDITIONAL_FLAGS: ""
     agents:
       - "queue=colo-deploy"

--- a/system-test/testnet-performance/gce-cpu-only-perf-5-node.yml
+++ b/system-test/testnet-performance/gce-cpu-only-perf-5-node.yml
@@ -11,7 +11,7 @@ steps:
       ENABLE_GPU: "false"
       VALIDATOR_NODE_MACHINE_TYPE: "--machine-type n1-standard-16"
       NUMBER_OF_CLIENT_NODES: 2
-      CLIENT_OPTIONS: "bench-tps=2=--tx_count 15000 --thread-batch-sleep-ms 250"
+      CLIENT_OPTIONS: "bench-tps=2=--tx_count 20000 --thread-batch-sleep-ms 250"
       TESTNET_ZONES: "us-west1-a,us-west1-b,us-central1-a,europe-west4-a"
       USE_PUBLIC_IP_ADDRESSES: "true"
       ADDITIONAL_FLAGS: "--dedicated"

--- a/system-test/testnet-performance/gce-gpu-perf-5-node.yml
+++ b/system-test/testnet-performance/gce-gpu-perf-5-node.yml
@@ -11,7 +11,7 @@ steps:
       ENABLE_GPU: "true"
       VALIDATOR_NODE_MACHINE_TYPE: "--machine-type n1-standard-16 --accelerator count=2,type=nvidia-tesla-v100"
       NUMBER_OF_CLIENT_NODES: 2
-      CLIENT_OPTIONS: "bench-tps=2=--tx_count 15000 --thread-batch-sleep-ms 250"
+      CLIENT_OPTIONS: "bench-tps=2=--tx_count 20000 --thread-batch-sleep-ms 250"
       TESTNET_ZONES: "us-west1-a,us-west1-b,us-central1-a,europe-west4-a"
       USE_PUBLIC_IP_ADDRESSES: "true"
       ADDITIONAL_FLAGS: "--dedicated"


### PR DESCRIPTION
#### Problem
Since we're generating blocks at 400ms now instead of 250ms (which was a bug) the average tps coming from the clients has dropped a bit. Current perf results on colo are just the client's tps input, not a correct measure of maximum performance.

#### Summary of Changes
Raise tx_count from 15k to 20k to saturate the cluster and get a more accurate TPS perf limit.
