### PR TITLE
Expose stake delegations from bank for winner tool

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -46,6 +46,7 @@ use solana_sdk::{
     transaction::{Result, Transaction, TransactionError},
 };
 use solana_vote_program::vote_state::VoteState;
+use solana_stake_program::stake_state::Delegation;
 use std::{
     collections::HashMap,
     io::{BufReader, Cursor, Error as IOError, Read},
@@ -1628,6 +1629,11 @@ impl Bank {
 
     pub fn storage_accounts(&self) -> StorageAccounts {
         self.storage_accounts.read().unwrap().clone()
+    }
+
+    /// current stake delegations for this bank
+    pub fn stake_delegations(&self) -> HashMap<Pubkey, Delegation> {
+        self.stakes.read().unwrap().stake_delegations().clone()
     }
 
     /// current vote accounts for this bank along with the stake

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -45,8 +45,8 @@ use solana_sdk::{
     timing::years_as_slots,
     transaction::{Result, Transaction, TransactionError},
 };
-use solana_vote_program::vote_state::VoteState;
 use solana_stake_program::stake_state::Delegation;
+use solana_vote_program::vote_state::VoteState;
 use std::{
     collections::HashMap,
     io::{BufReader, Cursor, Error as IOError, Read},

--- a/runtime/src/stakes.rs
+++ b/runtime/src/stakes.rs
@@ -178,6 +178,10 @@ impl Stakes {
         &self.vote_accounts
     }
 
+    pub fn stake_delegations(&self) -> &HashMap<Pubkey, Delegation> {
+        &self.stake_delegations
+    }
+
     pub fn highest_staked_node(&self) -> Option<Pubkey> {
         self.vote_accounts
             .iter()


### PR DESCRIPTION
#### Problem
The winner tool needs to get the active stake delegations for a bank but the api was removed.

#### Summary of Changes
- Expose `bank::stake_degations()` publicly

Fixes #
