### PR TITLE
Sanitize AppendVec's file_size

### DIFF
--- a/runtime/src/append_vec.rs
+++ b/runtime/src/append_vec.rs
@@ -128,7 +128,6 @@ impl AppendVec {
         data.seek(SeekFrom::Start((size - 1) as u64)).unwrap();
         data.write_all(&[0]).unwrap();
         data.seek(SeekFrom::Start(0)).unwrap();
-        //data.set_len(size as u64);
         data.flush().unwrap();
         //UNSAFE: Required to create a Mmap
         let map = unsafe { MmapMut::map_mut(&data).expect("failed to map the data file") };

--- a/runtime/src/append_vec.rs
+++ b/runtime/src/append_vec.rs
@@ -91,15 +91,15 @@ impl Drop for AppendVec {
 impl AppendVec {
     #[allow(clippy::mutex_atomic)]
     pub fn new(file: &Path, create: bool, size: usize) -> Self {
+        let initial_len = 0;
+        AppendVec::sanitize_len_and_size(initial_len, size).unwrap();
+
         if create {
             let _ignored = remove_file(file);
             if let Some(parent) = file.parent() {
                 create_dir_all(parent).expect("Create directory failed");
             }
         }
-
-        let initial_len = 0;
-        AppendVec::sanitize_len_and_size(initial_len, size).unwrap();
 
         let mut data = OpenOptions::new()
             .read(true)

--- a/runtime/src/append_vec.rs
+++ b/runtime/src/append_vec.rs
@@ -502,7 +502,6 @@ pub mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "too small file size 0 for AppendVec")]
     fn test_append_vec_set_file_bad_size() {
         let file = get_append_vec_path("test_append_vec_set_file_bad_size");
         let path = &file.path;
@@ -515,35 +514,38 @@ pub mod tests {
             .open(&path)
             .expect("create a test file for mmap");
 
-        av.set_file(path).unwrap();
+        let result = av.set_file(path);
+        assert_matches!(result, Err(ref message) if message.to_string() == *"too small file size 0 for AppendVec");
     }
 
     #[test]
-    #[should_panic(expected = "too small file size 0 for AppendVec")]
     fn test_append_vec_sanitize_len_and_size_too_small() {
-        AppendVec::sanitize_len_and_size(0, 0).unwrap();
+        let result = AppendVec::sanitize_len_and_size(0, 0);
+        assert_matches!(result, Err(ref message) if message.to_string() == *"too small file size 0 for AppendVec");
     }
 
     #[test]
     fn test_append_vec_sanitize_len_and_size_maximum() {
-        AppendVec::sanitize_len_and_size(0, 16 * 1024 * 1024 * 1024).unwrap();
+        let result = AppendVec::sanitize_len_and_size(0, 16 * 1024 * 1024 * 1024);
+        assert_matches!(result, Ok(_));
     }
 
     #[test]
-    #[should_panic(expected = "too large file size 17179869185 for AppendVec")]
     fn test_append_vec_sanitize_len_and_size_too_large() {
-        AppendVec::sanitize_len_and_size(0, 16 * 1024 * 1024 * 1024 + 1).unwrap();
+        let result = AppendVec::sanitize_len_and_size(0, 16 * 1024 * 1024 * 1024 + 1);
+        assert_matches!(result, Err(ref message) if message.to_string() == *"too large file size 17179869185 for AppendVec");
     }
 
     #[test]
     fn test_append_vec_sanitize_len_and_size_full_and_same_as_current_len() {
-        AppendVec::sanitize_len_and_size(1 * 1024 * 1024, 1 * 1024 * 1024).unwrap();
+        let result = AppendVec::sanitize_len_and_size(1 * 1024 * 1024, 1 * 1024 * 1024);
+        assert_matches!(result, Ok(_));
     }
 
     #[test]
-    #[should_panic(expected = "current_len is larger than file size (1048576)")]
     fn test_append_vec_sanitize_len_and_size_larger_current_len() {
-        AppendVec::sanitize_len_and_size(1 * 1024 * 1024 + 1, 1 * 1024 * 1024).unwrap();
+        let result = AppendVec::sanitize_len_and_size(1 * 1024 * 1024 + 1, 1 * 1024 * 1024);
+        assert_matches!(result, Err(ref message) if message.to_string() == *"current_len is larger than file size (1048576)");
     }
 
     #[test]

--- a/runtime/src/append_vec.rs
+++ b/runtime/src/append_vec.rs
@@ -143,6 +143,7 @@ impl AppendVec {
         }
     }
 
+    #[allow(clippy::mutex_atomic)]
     pub fn new_empty_map(current_len: usize) -> Self {
         let map = MmapMut::map_anon(1).expect("failed to map the data file");
 
@@ -157,9 +158,15 @@ impl AppendVec {
 
     fn sanitize_mmap_size(size: usize) -> io::Result<()> {
         if size == 0 {
-            Err(std::io::Error::new(std::io::ErrorKind::Other, format!("too small file size {} for AppendVec", size)))
+            Err(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                format!("too small file size {} for AppendVec", size),
+            ))
         } else if size > MAXIMUM_APPEND_VEC_FILE_SIZE {
-            Err(std::io::Error::new(std::io::ErrorKind::Other, format!("too large file size {} for AppendVec", size)))
+            Err(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                format!("too large file size {} for AppendVec", size),
+            ))
         } else {
             Ok(())
         }
@@ -446,7 +453,6 @@ impl<'a> serde::de::Visitor<'a> for AppendVecVisitor {
         formatter.write_str("Expecting AppendVec")
     }
 
-    #[allow(clippy::mutex_atomic)]
     fn visit_bytes<E>(self, data: &[u8]) -> std::result::Result<Self::Value, E>
     where
         E: serde::de::Error,

--- a/runtime/src/append_vec.rs
+++ b/runtime/src/append_vec.rs
@@ -144,7 +144,7 @@ impl AppendVec {
     }
 
     #[allow(clippy::mutex_atomic)]
-    pub fn new_empty_map(current_len: usize) -> Self {
+    fn new_empty_map(current_len: usize) -> Self {
         let map = MmapMut::map_anon(1).expect("failed to map the data file");
 
         AppendVec {

--- a/runtime/src/append_vec.rs
+++ b/runtime/src/append_vec.rs
@@ -482,6 +482,7 @@ impl<'de> Deserialize<'de> for AppendVec {
 pub mod tests {
     use super::test_utils::*;
     use super::*;
+    use assert_matches::assert_matches;
     use log::*;
     use rand::{thread_rng, Rng};
     use solana_sdk::timing::duration_as_ms;
@@ -496,14 +497,14 @@ pub mod tests {
     #[test]
     #[should_panic(expected = "too small file size 0 for AppendVec")]
     fn test_append_vec_new_bad_size() {
-        let path = get_append_vec_path("test_append_too_bad_size");
+        let path = get_append_vec_path("test_append_vec_new_bad_size");
         let _av = AppendVec::new(&path.path, true, 0);
     }
 
     #[test]
     #[should_panic(expected = "too small file size 0 for AppendVec")]
     fn test_append_vec_set_file_bad_size() {
-        let file = get_append_vec_path("test_append_too_bad_size");
+        let file = get_append_vec_path("test_append_vec_set_file_bad_size");
         let path = &file.path;
         let mut av = AppendVec::new_empty_map(0);
 


### PR DESCRIPTION
#### Problem

Creation and restoration of `AppendVec` is not secure with regard to size of mmap.
Currently, validators can easily be `panic!`-ed just by putting empty (0-sized) appendvec file or very large sparse appendvec file. The former is forbidden by the specs of `mmap` and the later will cause panics depending on system configuration/load.

#### Summary of Changes

- cap the maximum mmaped appendvec size to 16GiB. This effectively limits the maximum account data size to roughly 8GiB (half of 16GB according to current AppendVec capacity reservation policy) with plenty of margin to the hotly debated limit on the individual account sizes (ref: #7320). 
- minor runtime behavior change and code cleanup along wide the above.

Part of #7167 