### PR TITLE
Restore status check to bubble up TransactionError

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3290,6 +3290,7 @@ dependencies = [
 name = "solana-client"
 version = "0.22.0"
 dependencies = [
+ "assert_matches 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bincode 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bs58 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-core 14.0.5 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -23,6 +23,7 @@ solana-net-utils = { path = "../net-utils", version = "0.22.0" }
 solana-sdk = { path = "../sdk", version = "0.22.0" }
 
 [dev-dependencies]
+assert_matches = "1.3.0"
 jsonrpc-core = "14.0.5"
 jsonrpc-http-server = "14.0.5"
 solana-logger = { path = "../logger", version = "0.22.0" }

--- a/client/src/mock_rpc_client_request.rs
+++ b/client/src/mock_rpc_client_request.rs
@@ -7,6 +7,7 @@ use serde_json::{Number, Value};
 use solana_sdk::{
     commitment_config::CommitmentConfig,
     fee_calculator::FeeCalculator,
+    instruction::InstructionError,
     transaction::{self, TransactionError},
 };
 
@@ -64,6 +65,11 @@ impl GenericRpcClientRequest for MockRpcClientRequest {
             RpcRequest::GetSignatureStatus => {
                 let response: Option<transaction::Result<()>> = if self.url == "account_in_use" {
                     Some(Err(TransactionError::AccountInUse))
+                } else if self.url == "instruction_error" {
+                    Some(Err(TransactionError::InstructionError(
+                        0,
+                        InstructionError::UninitializedAccount,
+                    )))
                 } else if self.url == "sig_not_found" {
                     None
                 } else {

--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -343,11 +343,15 @@ impl RpcClient {
                 send_retries - 1
             };
             if send_retries == 0 {
-                return Err(io::Error::new(
-                    io::ErrorKind::Other,
-                    format!("Transaction {:?} failed: {:?}", signature_str, status),
-                )
-                .into());
+                if let Some(err) = status {
+                    return Err(err.unwrap_err().into());
+                } else {
+                    return Err(io::Error::new(
+                        io::ErrorKind::Other,
+                        format!("Transaction {:?} failed: {:?}", signature_str, status),
+                    )
+                    .into());
+                }
             }
         }
     }


### PR DESCRIPTION
#### Problem
Transaction errors print something like this in CLI:
```
Error: Io(Custom { kind: Other, error: "Transaction \"39ekLAsZNiE7LBhtata3i6gkWqnMAftaLhgcsJEn3h5sr4GSK8CSoMv6ou2pZdaJmEvp5FNc7jPpWP4GFqTWWb8S\" failed: Some(Err(InstructionError(0, CustomError(0))))" })
```

What does that mean??

#### Summary of Changes
`log_instruction_custom_error()` should have been converting this to the Stake error print: `Error: NoCreditsToRedeem`
But all errors were returning as ClientError::IoError as of this: https://github.com/solana-labs/solana/pull/6219

- Restores functionality to `RpcClient::send_and_confirm_transaction()` to return wrapped Transaction errors that get properly understood as custom program errors.

Fixes #7377 
