### PR TITLE
Add docs for checking account balance of a paper wallet

### DIFF
--- a/book/src/paper-wallet/keypair.md
+++ b/book/src/paper-wallet/keypair.md
@@ -63,6 +63,10 @@ explicitly skip seed phrase validation.
 solana-keygen pubkey ASK --skip-seed-phrase-validation
 ```
 
+{% hint style="info" %}
+Copy the derived public key to a USB stick for easy usage on networked computers
+{% endhint %}
+
 For full usage details run:
 
 ```bash

--- a/book/src/paper-wallet/usage.md
+++ b/book/src/paper-wallet/usage.md
@@ -22,7 +22,7 @@ networked machine.
 Next, configure the `solana` CLI tool to connect to a particular cluster:
 
 ```bash
-solana set --url <CLUSTER URL> # (i.e. http://testnet.solana.com)
+solana set --url <CLUSTER URL> # (i.e. http://testnet.solana.com:8899)
 ```
 
 Finally, to check the balance, run the following command:

--- a/book/src/paper-wallet/usage.md
+++ b/book/src/paper-wallet/usage.md
@@ -19,6 +19,12 @@ To retrieve public keys securely from a paper wallet, follow the
 Public keys can then be typed manually or transferred via a USB stick into a
 networked machine.
 
+Next, configure the `solana` CLI tool to connect to a particular cluster:
+
+```bash
+solana set --url <CLUSTER URL> # (i.e. http://testnet.solana.com)
+```
+
 Finally, to check the balance, run the following command:
 
 ```bash

--- a/book/src/paper-wallet/usage.md
+++ b/book/src/paper-wallet/usage.md
@@ -10,6 +10,38 @@ written to disk by unencrypted memory swaps. It is the user's responsibility to
 protect against this scenario.
 {% endhint %}
 
+## Checking Account Balance
+
+All that is needed to check an account balance is the public key of an account.
+To retrieve public keys securely from a paper wallet, follow the
+[Public Key Derivation](keypair#public-key-derivation) instructions on an
+[air gapped computer](https://en.wikipedia.org/wiki/Air_gap_\(networking\)).
+Public keys can then be typed manually or transferred via a USB stick into a
+networked machine.
+
+Finally, to check the balance, run the following command:
+
+```bash
+solana balance <PUBKEY>
+```
+
+In order to check a list of public keys quickly, append public keys to a file
+like so:
+
+`public_keys.txt`
+```bash
+7hTw3XhprjT2DkVxVixtig9eZwHTZ2rksTSYN7Jh5niZ
+9ufAiSyboCZmmEsoStgLYQfnx9KfqP1ZtDK8Wr1j8SJV
+# ...
+```
+
+And run the following command:
+```bash
+while read PUBLIC_KEY;
+do echo "$PUBLIC_KEY: $(solana balance "$PUBLIC_KEY" | tail -n1)";
+done < public_keys.txt
+```
+
 ## Running a Validator
 
 In order to run a validator, you will need to specify an "identity keypair"


### PR DESCRIPTION
#### Problem
We don't have instructions for someone checking the balance of a paper wallet account?

#### Summary of Changes
- Add a note in public key derivation to copy the public key to a USB stick
- Write up instructions on how to get the balance from a paper wallet account
- Add an example bash command for fetching the balance of a list of public keys

Fixes #
