### PR TITLE
Fix offline stakes payer

### DIFF
--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -423,7 +423,12 @@ pub fn process_ping(
 
         let transaction =
             system_transaction::transfer(&config.keypair, &to, lamports, recent_blockhash);
-        check_account_for_fee(rpc_client, config, &fee_calculator, &transaction.message)?;
+        check_account_for_fee(
+            rpc_client,
+            &config.keypair.pubkey(),
+            &fee_calculator,
+            &transaction.message,
+        )?;
 
         match rpc_client.send_transaction(&transaction) {
             Ok(signature) => {

--- a/cli/src/storage.rs
+++ b/cli/src/storage.rs
@@ -176,7 +176,12 @@ pub fn process_create_storage_account(
         ixs,
         recent_blockhash,
     );
-    check_account_for_fee(rpc_client, config, &fee_calculator, &tx.message)?;
+    check_account_for_fee(
+        rpc_client,
+        &config.keypair.pubkey(),
+        &fee_calculator,
+        &tx.message,
+    )?;
     let result =
         rpc_client.send_and_confirm_transaction(&mut tx, &[&config.keypair, &storage_account]);
     log_instruction_custom_error::<SystemError>(result)
@@ -196,7 +201,12 @@ pub fn process_claim_storage_reward(
     let message = Message::new_with_payer(vec![instruction], Some(&signers[0].pubkey()));
 
     let mut tx = Transaction::new(&signers, message, recent_blockhash);
-    check_account_for_fee(rpc_client, config, &fee_calculator, &tx.message)?;
+    check_account_for_fee(
+        rpc_client,
+        &config.keypair.pubkey(),
+        &fee_calculator,
+        &tx.message,
+    )?;
     let signature_str = rpc_client.send_and_confirm_transaction(&mut tx, &signers)?;
     Ok(signature_str.to_string())
 }

--- a/cli/src/validator_info.rs
+++ b/cli/src/validator_info.rs
@@ -347,7 +347,12 @@ pub fn process_set_validator_info(
     // Submit transaction
     let (recent_blockhash, fee_calculator) = rpc_client.get_recent_blockhash()?;
     let mut tx = Transaction::new(&signers, message, recent_blockhash);
-    check_account_for_fee(rpc_client, config, &fee_calculator, &tx.message)?;
+    check_account_for_fee(
+        rpc_client,
+        &config.keypair.pubkey(),
+        &fee_calculator,
+        &tx.message,
+    )?;
     let signature_str = rpc_client.send_and_confirm_transaction(&mut tx, &signers)?;
 
     println!("Success! Validator info published at: {:?}", info_pubkey);

--- a/cli/src/vote.rs
+++ b/cli/src/vote.rs
@@ -268,7 +268,12 @@ pub fn process_create_vote_account(
         ixs,
         recent_blockhash,
     );
-    check_account_for_fee(rpc_client, config, &fee_calculator, &tx.message)?;
+    check_account_for_fee(
+        rpc_client,
+        &config.keypair.pubkey(),
+        &fee_calculator,
+        &tx.message,
+    )?;
     let result = rpc_client.send_and_confirm_transaction(&mut tx, &[&config.keypair, vote_account]);
     log_instruction_custom_error::<SystemError>(result)
 }
@@ -298,7 +303,12 @@ pub fn process_vote_authorize(
         &[&config.keypair],
         recent_blockhash,
     );
-    check_account_for_fee(rpc_client, config, &fee_calculator, &tx.message)?;
+    check_account_for_fee(
+        rpc_client,
+        &config.keypair.pubkey(),
+        &fee_calculator,
+        &tx.message,
+    )?;
     let result = rpc_client.send_and_confirm_transaction(&mut tx, &[&config.keypair]);
     log_instruction_custom_error::<VoteError>(result)
 }

--- a/cli/tests/stake.rs
+++ b/cli/tests/stake.rs
@@ -1,0 +1,252 @@
+use serde_json::Value;
+use solana_cli::cli::{process_command, request_and_confirm_airdrop, CliCommand, CliConfig};
+use solana_client::rpc_client::RpcClient;
+use solana_drone::drone::run_local_drone;
+use solana_sdk::{
+    hash::Hash,
+    pubkey::Pubkey,
+    signature::{read_keypair_file, write_keypair, KeypairUtil, Signature},
+};
+use solana_stake_program::stake_state::Lockup;
+use std::fs::remove_dir_all;
+use std::str::FromStr;
+use std::sync::mpsc::channel;
+
+#[cfg(test)]
+use solana_core::validator::new_validator_for_tests;
+use std::thread::sleep;
+use std::time::Duration;
+
+use tempfile::NamedTempFile;
+
+fn make_tmp_file() -> (String, NamedTempFile) {
+    let tmp_file = NamedTempFile::new().unwrap();
+    (String::from(tmp_file.path().to_str().unwrap()), tmp_file)
+}
+
+fn check_balance(expected_balance: u64, client: &RpcClient, pubkey: &Pubkey) {
+    (0..5).for_each(|tries| {
+        let balance = client.retry_get_balance(pubkey, 1).unwrap().unwrap();
+        if balance == expected_balance {
+            return;
+        }
+        if tries == 4 {
+            assert_eq!(balance, expected_balance);
+        }
+        sleep(Duration::from_millis(500));
+    });
+}
+
+#[test]
+fn test_stake_delegation_and_deactivation() {
+    solana_logger::setup();
+
+    let (server, leader_data, alice, ledger_path) = new_validator_for_tests();
+    let (sender, receiver) = channel();
+    run_local_drone(alice, sender, None);
+    let drone_addr = receiver.recv().unwrap();
+
+    let rpc_client = RpcClient::new_socket(leader_data.rpc);
+
+    let mut config_validator = CliConfig::default();
+    config_validator.json_rpc_url =
+        format!("http://{}:{}", leader_data.rpc.ip(), leader_data.rpc.port());
+
+    let mut config_vote = CliConfig::default();
+    config_vote.json_rpc_url =
+        format!("http://{}:{}", leader_data.rpc.ip(), leader_data.rpc.port());
+    let (vote_keypair_file, mut tmp_file) = make_tmp_file();
+    write_keypair(&config_vote.keypair, tmp_file.as_file_mut()).unwrap();
+
+    let mut config_stake = CliConfig::default();
+    config_stake.json_rpc_url =
+        format!("http://{}:{}", leader_data.rpc.ip(), leader_data.rpc.port());
+    let (stake_keypair_file, mut tmp_file) = make_tmp_file();
+    write_keypair(&config_stake.keypair, tmp_file.as_file_mut()).unwrap();
+
+    request_and_confirm_airdrop(
+        &rpc_client,
+        &drone_addr,
+        &config_validator.keypair.pubkey(),
+        100_000,
+    )
+    .unwrap();
+    check_balance(100_000, &rpc_client, &config_validator.keypair.pubkey());
+
+    // Create vote account
+    config_validator.command = CliCommand::CreateVoteAccount {
+        vote_account: read_keypair_file(&vote_keypair_file).unwrap().into(),
+        node_pubkey: config_validator.keypair.pubkey(),
+        authorized_voter: None,
+        authorized_withdrawer: None,
+        commission: 0,
+    };
+    process_command(&config_validator).unwrap();
+
+    // Create stake account
+    config_validator.command = CliCommand::CreateStakeAccount {
+        stake_account: read_keypair_file(&stake_keypair_file).unwrap().into(),
+        staker: None,
+        withdrawer: None,
+        lockup: Lockup {
+            custodian: Pubkey::default(),
+            epoch: 0,
+        },
+        lamports: 50_000,
+    };
+    process_command(&config_validator).unwrap();
+
+    // Delegate stake
+    config_validator.command = CliCommand::DelegateStake {
+        stake_account_pubkey: config_stake.keypair.pubkey(),
+        vote_account_pubkey: config_vote.keypair.pubkey(),
+        force: true,
+        sign_only: false,
+        signers: None,
+        blockhash: None,
+    };
+    process_command(&config_validator).unwrap();
+
+    // Deactivate stake
+    config_validator.command = CliCommand::DeactivateStake {
+        stake_account_pubkey: config_stake.keypair.pubkey(),
+        sign_only: false,
+        signers: None,
+        blockhash: None,
+    };
+    process_command(&config_validator).unwrap();
+
+    server.close().unwrap();
+    remove_dir_all(ledger_path).unwrap();
+}
+
+#[test]
+fn test_stake_delegation_and_deactivation_offline() {
+    solana_logger::setup();
+
+    let (server, leader_data, alice, ledger_path) = new_validator_for_tests();
+    let (sender, receiver) = channel();
+    run_local_drone(alice, sender, None);
+    let drone_addr = receiver.recv().unwrap();
+
+    let rpc_client = RpcClient::new_socket(leader_data.rpc);
+
+    let mut config_validator = CliConfig::default();
+    config_validator.json_rpc_url =
+        format!("http://{}:{}", leader_data.rpc.ip(), leader_data.rpc.port());
+
+    let mut config_payer = CliConfig::default();
+    config_payer.json_rpc_url =
+        format!("http://{}:{}", leader_data.rpc.ip(), leader_data.rpc.port());
+
+    let mut config_vote = CliConfig::default();
+    config_vote.json_rpc_url =
+        format!("http://{}:{}", leader_data.rpc.ip(), leader_data.rpc.port());
+    let (vote_keypair_file, mut tmp_file) = make_tmp_file();
+    write_keypair(&config_vote.keypair, tmp_file.as_file_mut()).unwrap();
+
+    let mut config_stake = CliConfig::default();
+    config_stake.json_rpc_url =
+        format!("http://{}:{}", leader_data.rpc.ip(), leader_data.rpc.port());
+    let (stake_keypair_file, mut tmp_file) = make_tmp_file();
+    write_keypair(&config_stake.keypair, tmp_file.as_file_mut()).unwrap();
+
+    request_and_confirm_airdrop(
+        &rpc_client,
+        &drone_addr,
+        &config_validator.keypair.pubkey(),
+        100_000,
+    )
+    .unwrap();
+    check_balance(100_000, &rpc_client, &config_validator.keypair.pubkey());
+
+    // Create vote account
+    config_validator.command = CliCommand::CreateVoteAccount {
+        vote_account: read_keypair_file(&vote_keypair_file).unwrap().into(),
+        node_pubkey: config_validator.keypair.pubkey(),
+        authorized_voter: None,
+        authorized_withdrawer: None,
+        commission: 0,
+    };
+    process_command(&config_validator).unwrap();
+
+    // Create stake account
+    config_validator.command = CliCommand::CreateStakeAccount {
+        stake_account: read_keypair_file(&stake_keypair_file).unwrap().into(),
+        staker: None,
+        withdrawer: None,
+        lockup: Lockup {
+            custodian: Pubkey::default(),
+            epoch: 0,
+        },
+        lamports: 50_000,
+    };
+    process_command(&config_validator).unwrap();
+
+    // Delegate stake offline
+    config_validator.command = CliCommand::DelegateStake {
+        stake_account_pubkey: config_stake.keypair.pubkey(),
+        vote_account_pubkey: config_vote.keypair.pubkey(),
+        force: true,
+        sign_only: true,
+        signers: None,
+        blockhash: None,
+    };
+    let sig_response = process_command(&config_validator).unwrap();
+    let object: Value = serde_json::from_str(&sig_response).unwrap();
+    let blockhash_str = object.get("blockhash").unwrap().as_str().unwrap();
+    let signer_strings = object.get("signers").unwrap().as_array().unwrap();
+    let signers: Vec<_> = signer_strings
+        .iter()
+        .map(|signer_string| {
+            let mut signer = signer_string.as_str().unwrap().split('=');
+            let key = Pubkey::from_str(signer.next().unwrap()).unwrap();
+            let sig = Signature::from_str(signer.next().unwrap()).unwrap();
+            (key, sig)
+        })
+        .collect();
+
+    // Delegate stake online
+    config_payer.command = CliCommand::DelegateStake {
+        stake_account_pubkey: config_stake.keypair.pubkey(),
+        vote_account_pubkey: config_vote.keypair.pubkey(),
+        force: true,
+        sign_only: false,
+        signers: Some(signers),
+        blockhash: Some(blockhash_str.parse::<Hash>().unwrap()),
+    };
+    process_command(&config_payer).unwrap();
+
+    // Deactivate stake offline
+    config_validator.command = CliCommand::DeactivateStake {
+        stake_account_pubkey: config_stake.keypair.pubkey(),
+        sign_only: true,
+        signers: None,
+        blockhash: None,
+    };
+    let sig_response = process_command(&config_validator).unwrap();
+    let object: Value = serde_json::from_str(&sig_response).unwrap();
+    let blockhash_str = object.get("blockhash").unwrap().as_str().unwrap();
+    let signer_strings = object.get("signers").unwrap().as_array().unwrap();
+    let signers: Vec<_> = signer_strings
+        .iter()
+        .map(|signer_string| {
+            let mut signer = signer_string.as_str().unwrap().split('=');
+            let key = Pubkey::from_str(signer.next().unwrap()).unwrap();
+            let sig = Signature::from_str(signer.next().unwrap()).unwrap();
+            (key, sig)
+        })
+        .collect();
+
+    // Deactivate stake online
+    config_payer.command = CliCommand::DeactivateStake {
+        stake_account_pubkey: config_stake.keypair.pubkey(),
+        sign_only: false,
+        signers: Some(signers),
+        blockhash: Some(blockhash_str.parse::<Hash>().unwrap()),
+    };
+    process_command(&config_payer).unwrap();
+
+    server.close().unwrap();
+    remove_dir_all(ledger_path).unwrap();
+}


### PR DESCRIPTION
#### Problem

- Offline signed stake transaction must be submitted online with the original signer's pubkey
- Missing stake tests

#### Summary of Changes

- Fix offline stake `DelegateStake` and `DeactivateStake` to use the passed in payer pubkey
- Use the original signer's account when checking that the payer account has enough to cover fees
- Add integration tests for both online and offline staking

Fixes #
