### PR TITLE
cli: Improve get-epoch-info output for longer epoch durations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3258,6 +3258,7 @@ dependencies = [
  "criterion-stats 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ctrlc 3.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "dirs 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "humantime 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "indicatif 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -20,6 +20,7 @@ dirs = "2.0.2"
 lazy_static = "1.4.0"
 log = "0.4.8"
 indicatif = "0.13.0"
+humantime = "1.3.0"
 num-traits = "0.2"
 pretty-hex = "0.1.1"
 reqwest = { version = "0.9.22", default-features = false, features = ["rustls-tls"] }

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -360,11 +360,7 @@ pub fn process_get_epoch_info(
     );
     println_name_value(
         "Time remaining in current epoch:",
-        &format!(
-            "{} minutes, {} seconds",
-            remaining_time_in_epoch.as_secs() / 60,
-            remaining_time_in_epoch.as_secs() % 60
-        ),
+        &humantime::format_duration(remaining_time_in_epoch).to_string(),
     );
     Ok("".to_string())
 }


### PR DESCRIPTION
The `solana get-epoch-info` output was poorly suited for epochs lasting longer than 1 hour.

Old output:
```
Current epoch: 11
Current slot: 104527
Total slots in current epoch: 65536
Remaining slots in current epoch: 26513
Time remaining in current epoch: 176 minutes, 45 seconds
```

New output:
```
Current epoch: 11
Current slot: 104491
Total slots in current epoch: 65536
Remaining slots in current epoch: 26549
Time remaining in current epoch: 2h 56m 59s
```