### PR TITLE
distribute leftover lamports

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2202,7 +2202,7 @@ mod tests {
         let rent = Rent::free();
 
         let validator_1_pubkey = Pubkey::new_rand();
-        let validator_1_stake_lamports = 23;
+        let validator_1_stake_lamports = 20;
         let validator_1_staking_keypair = Keypair::new();
         let validator_1_voting_keypair = Keypair::new();
 
@@ -2235,7 +2235,7 @@ mod tests {
         );
 
         let validator_2_pubkey = Pubkey::new_rand();
-        let validator_2_stake_lamports = 22;
+        let validator_2_stake_lamports = 20;
         let validator_2_staking_keypair = Keypair::new();
         let validator_2_voting_keypair = Keypair::new();
 
@@ -2268,7 +2268,7 @@ mod tests {
         );
 
         let validator_3_pubkey = Pubkey::new_rand();
-        let validator_3_stake_lamports = 25;
+        let validator_3_stake_lamports = 30;
         let validator_3_staking_keypair = Keypair::new();
         let validator_3_voting_keypair = Keypair::new();
 
@@ -2356,16 +2356,25 @@ mod tests {
             bootstrap_leader_portion + bootstrap_leader_initial_balance
         );
 
-        let validator_1_portion =
-            ((validator_1_stake_lamports * rent_to_be_distributed) as f64 / 100.0) as u64 + 1;
+        // Since, validator 1 and validator 2 has equal smallest stake, it comes down to comparison
+        // between their pubkey.
+        let mut validator_1_portion =
+            ((validator_1_stake_lamports * rent_to_be_distributed) as f64 / 100.0) as u64;
+        if validator_1_pubkey > validator_2_pubkey {
+            validator_1_portion += 1;
+        }
         assert_eq!(
             bank.get_balance(&validator_1_pubkey),
             validator_1_portion + 42
         );
 
-        // No leftover lamport for you, as you have smallest of stake
-        let validator_2_portion =
+        // Since, validator 1 and validator 2 has equal smallest stake, it comes down to comparison
+        // between their pubkey.
+        let mut validator_2_portion =
             ((validator_2_stake_lamports * rent_to_be_distributed) as f64 / 100.0) as u64;
+        if validator_2_pubkey > validator_1_pubkey {
+            validator_2_portion += 1;
+        }
         assert_eq!(
             bank.get_balance(&validator_2_pubkey),
             validator_2_portion + 42

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1283,10 +1283,10 @@ impl Bank {
         let node_stakes_and_rent = node_stakes
             .iter()
             .map(|(pubkey, staked)| {
-                let rent_in_initial_round =
+                let rent_share =
                     (((*staked * rent_to_be_distributed) as f64) / (total_staked as f64)) as u64;
-                rent_distributed_in_initial_round += rent_in_initial_round;
-                (*pubkey, *staked, rent_in_initial_round)
+                rent_distributed_in_initial_round += rent_share;
+                (*pubkey, *staked, rent_share)
             })
             .collect::<Vec<(Pubkey, u64, u64)>>();
 
@@ -1296,12 +1296,12 @@ impl Bank {
 
         node_stakes_and_rent
             .iter()
-            .for_each(|(pubkey, _staked, rent)| {
+            .for_each(|(pubkey, _staked, rent_share)| {
                 let rent_to_be_paid = if leftover_lamports > 0 {
                     leftover_lamports -= 1;
-                    *rent + 1
+                    *rent_share + 1
                 } else {
-                    *rent
+                    *rent_share
                 };
                 let mut account = self.get_account(pubkey).unwrap_or_default();
                 account.lamports += rent_to_be_paid;


### PR DESCRIPTION
#### Problem
Currently, rent payment to validator is as a fraction of collected rent in accordance with their stake weight. Since lamports are atomic, the calculation results in leftover lamports (for N validators, maximum N lamports), which are then lost. 

#### Proposed Solution
Distribute those leftover lamports among the validators from descending order of stake weight.
Each validator gets 1 lamport from the leftover lamports, until all leftover lamports are exhausted. 

Fixes #7381
