### PR TITLE
Fix Blocktree Config

### DIFF
--- a/ledger/src/blocktree_db.rs
+++ b/ledger/src/blocktree_db.rs
@@ -706,8 +706,15 @@ fn get_cf_options() -> Options {
     // 256 * 8 = 2GB. 6 of these columns should take at most 12GB of RAM
     options.set_max_write_buffer_number(8);
     options.set_write_buffer_size(MAX_WRITE_BUFFER_SIZE as usize);
-    options.set_target_file_size_base(MAX_WRITE_BUFFER_SIZE / 10);
-    options.set_max_bytes_for_level_base(MAX_WRITE_BUFFER_SIZE);
+    let file_num_compaction_trigger = 4;
+    // Recommend that this be around the size of level 0. Level 0 estimated size in stable state is
+    // write_buffer_size * min_write_buffer_number_to_merge * level0_file_num_compaction_trigger
+    // Source: https://docs.rs/rocksdb/0.6.0/rocksdb/struct.Options.html#method.set_level_zero_file_num_compaction_trigger
+    let total_size_base = MAX_WRITE_BUFFER_SIZE * file_num_compaction_trigger;
+    let file_size_base = total_size_base / 10;
+    options.set_level_zero_file_num_compaction_trigger(file_num_compaction_trigger as i32);
+    options.set_max_bytes_for_level_base(total_size_base);
+    options.set_target_file_size_base(file_size_base);
     options
 }
 


### PR DESCRIPTION
#### Problem
Files in Level 1 in blocktree too small compared to level 0, leads to expensive compactions

#### Summary of Changes
Set size of level 1 based on recommended limits

Difference in insertion times:
![image](https://user-images.githubusercontent.com/3374799/70524981-2b12fe80-1afb-11ea-9d27-72b0949f288e.png)

Fixes #
