### PR TITLE
change blocktree*::storage_size() to return Option<u64> to handle live fs changes

### DIFF
--- a/core/src/ledger_cleanup_service.rs
+++ b/core/src/ledger_cleanup_service.rs
@@ -66,16 +66,20 @@ impl LedgerCleanupService {
 
         let disk_utilization_post = blocktree.storage_size();
 
-        datapoint_debug!(
-            "ledger_disk_utilization",
-            ("disk_utilization_pre", disk_utilization_pre as i64, i64),
-            ("disk_utilization_post", disk_utilization_post as i64, i64),
-            (
-                "disk_utilization_delta",
-                (disk_utilization_pre as i64 - disk_utilization_post as i64),
-                i64
-            )
-        );
+        if let (Some(disk_utilization_pre), Some(disk_utilization_post)) =
+            (disk_utilization_pre, disk_utilization_post)
+        {
+            datapoint_debug!(
+                "ledger_disk_utilization",
+                ("disk_utilization_pre", disk_utilization_pre as i64, i64),
+                ("disk_utilization_post", disk_utilization_post as i64, i64),
+                (
+                    "disk_utilization_delta",
+                    (disk_utilization_pre as i64 - disk_utilization_post as i64),
+                    i64
+                )
+            );
+        }
 
         Ok(())
     }

--- a/ledger/src/blocktree.rs
+++ b/ledger/src/blocktree.rs
@@ -1493,7 +1493,7 @@ impl Blocktree {
         self.last_root()
     }
 
-    pub fn storage_size(&self) -> u64 {
+    pub fn storage_size(&self) -> Option<u64> {
         self.db.storage_size()
     }
 }

--- a/ledger/src/blocktree_db.rs
+++ b/ledger/src/blocktree_db.rs
@@ -580,8 +580,8 @@ impl Database {
         self.backend.write(batch.write_batch)
     }
 
-    pub fn storage_size(&self) -> u64 {
-        get_size(&self.path).expect("failure while reading ledger directory size")
+    pub fn storage_size(&self) -> Option<u64> {
+        get_size(&self.path).ok()
     }
 }
 


### PR DESCRIPTION
#### Problem

* ledger cleanup thread panics when reading file system directory size (see #7389)

#### Summary of Changes

* modify `blocktree*::storage_size()` to return `Option<u64>` instead of "`u64` via  `expect()`"

Fixes #7389
