### PR TITLE
cli: Better space out show-stake-history columns

### DIFF
--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -725,7 +725,7 @@ pub fn process_show_stake_history(
     println!(
         "{}",
         style(format!(
-            "  {:<5}  {:>15}  {:>16}  {:>18}",
+            "  {:<5}  {:>20}  {:>20}  {:>20}",
             "Epoch", "Effective Stake", "Activating Stake", "Deactivating Stake",
         ))
         .bold()
@@ -733,7 +733,7 @@ pub fn process_show_stake_history(
 
     for (epoch, entry) in stake_history.deref() {
         println!(
-            "  {:>5}  {:>15}  {:>16}  {:>18} {}",
+            "  {:>5}  {:>20}  {:>20}  {:>20} {}",
             epoch,
             build_balance_message(entry.effective, use_lamports_unit, false),
             build_balance_message(entry.activating, use_lamports_unit, false),


### PR DESCRIPTION
Old:
```
  Epoch  Effective Stake  Activating Stake  Deactivating Stake
     11  1220703.124999991  9279296.875000007                   0 SOL
     10  976562.499999994  8523437.500000006                   0 SOL
      9  781249.999999998  8718750.000000002                   0 SOL
      8           625000           4875000                   0 SOL
      7           500000           4000000                   0 SOL
      6           500000                 0                   0 SOL
      5           500000                 0                   0 SOL
      4           500000                 0                   0 SOL
      3           500000                 0                   0 SOL
      2           500000                 0                   0 SOL
      1           500000                 0                   0 SOL
      0           500000                 0                   0 SOL
```

New:
```
  Epoch       Effective Stake      Activating Stake    Deactivating Stake
     11     1220703.124999991     9279296.875000007                     0 SOL
     10      976562.499999994     8523437.500000006                     0 SOL
      9      781249.999999998     8718750.000000002                     0 SOL
      8                625000               4875000                     0 SOL
      7                500000               4000000                     0 SOL
      6                500000                     0                     0 SOL
      5                500000                     0                     0 SOL
      4                500000                     0                     0 SOL
      3                500000                     0                     0 SOL
      2                500000                     0                     0 SOL
      1                500000                     0                     0 SOL
      0                500000                     0                     0 SOL
```