### PR TITLE
Update default node balance to 500 SOL and default stake to 1 SOL for all testnet deployments

### DIFF
--- a/ci/testnet-manager.sh
+++ b/ci/testnet-manager.sh
@@ -487,7 +487,7 @@ deploy() {
       fi
 
       if [[ -z $INTERNAL_NODES_LAMPORTS ]]; then
-        maybeInternalNodesLamports="--internal-nodes-lamports 2000000000" # 2 SOL
+        maybeInternalNodesLamports="--internal-nodes-lamports 500000000000" # 500 SOL
       elif [[ $INTERNAL_NODES_LAMPORTS == skip ]]; then
         maybeInternalNodesLamports=""
       else

--- a/multinode-demo/delegate-stake.sh
+++ b/multinode-demo/delegate-stake.sh
@@ -8,7 +8,7 @@ here=$(dirname "$0")
 # shellcheck source=multinode-demo/common.sh
 source "$here"/common.sh
 
-stake_lamports=500000000   # default number of lamports to assign as stake (0.5 SOL)
+stake_lamports=1000000000   # default number of lamports to assign as stake (1 SOL)
 url=http://127.0.0.1:8899   # default RPC url
 
 usage() {

--- a/multinode-demo/validator.sh
+++ b/multinode-demo/validator.sh
@@ -6,6 +6,16 @@ here=$(dirname "$0")
 # shellcheck source=multinode-demo/common.sh
 source "$here"/common.sh
 
+args=()
+airdrops_enabled=1
+node_lamports=500000000000 # 500 SOL: number of lamports to airdrop the node for transaction fees and vote account rent exemption (ignored if airdrops_enabled=0)
+label=
+identity_keypair_path=
+voting_keypair_path=
+no_restart=0
+gossip_entrypoint=
+ledger_dir=
+
 usage() {
   if [[ -n $1 ]]; then
     echo "$*"
@@ -23,7 +33,7 @@ OPTIONS:
   --init-complete-file FILE - create this file, if it doesn't already exist, once node initialization is complete
   --label LABEL             - Append the given label to the configuration files, useful when running
                               multiple validators in the same workspace
-  --node-lamports LAMPORTS  - Number of lamports this node has been funded from the genesis config
+  --node-lamports LAMPORTS  - Number of lamports this node has been funded from the genesis config (default: $node_lamports)
   --no-voting               - start node without vote signer
   --rpc-port port           - custom RPC port for this node
   --no-restart              - do not restart the node if it exits
@@ -32,16 +42,6 @@ OPTIONS:
 EOF
   exit 1
 }
-
-args=()
-airdrops_enabled=1
-node_lamports=500000000000 # 500 SOL: number of lamports to airdrop the node for transaction fees and vote account rent exemption (ignored if airdrops_enabled=0)
-label=
-identity_keypair_path=
-voting_keypair_path=
-no_restart=0
-gossip_entrypoint=
-ledger_dir=
 
 positional_args=()
 while [[ -n $1 ]]; do

--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -28,7 +28,6 @@ gpuMode="${19:-auto}"
 GEOLOCATION_API_KEY="${20}"
 set +x
 
-
 missing() {
   echo "Error: $1 not specified"
   exit 1
@@ -214,7 +213,7 @@ EOF
       fi
 
       if [[ -n $internalNodesStakeLamports ]]; then
-          args+=(--bootstrap-leader-stake-lamports "$internalNodesStakesLamports")
+        args+=(--bootstrap-leader-stake-lamports "$internalNodesStakesLamports")
       fi
       if [[ -n $internalNodesLamports ]]; then
         args+=(--bootstrap-leader-lamports "$internalNodesLamports")
@@ -388,7 +387,7 @@ EOF
         args+=(--keypair config/validator-identity.json)
       fi
 
-      multinode-demo/delegate-stake.sh "${args[@]}"
+      multinode-demo/delegate-stake.sh "${args[@]}" "$internalNodesStakeLamports"
     fi
 
     if [[ $skipSetup != true ]]; then


### PR DESCRIPTION
#### Problem
Some of our testnet deployment scripts have been assigning inadequate or inconsistent amount of funds and stake delegations to nodes.  This has led to rent exemption failures and general challenges in debugging testnet failures.

#### Summary of Changes
All validator nodes including bootstrap leader should get funded with 500 SOL and delegate 1 SOL by default.  This can be overridden with `--internal-nodes-lamports` and `--internal-nodes-stake-lamports` flags when calling `net.sh [re]start`
