### PR TITLE
add documentation for storage_size() method

### DIFF
--- a/ledger/src/blocktree.rs
+++ b/ledger/src/blocktree.rs
@@ -1493,6 +1493,8 @@ impl Blocktree {
         self.last_root()
     }
 
+    // return the approximate size in bytes of the storage directory, or `None` if an error occurs
+    // while reading the directory (directory not found, file deleted, etc)
     pub fn storage_size(&self) -> Option<u64> {
         self.db.storage_size()
     }

--- a/ledger/src/blocktree_db.rs
+++ b/ledger/src/blocktree_db.rs
@@ -580,6 +580,8 @@ impl Database {
         self.backend.write(batch.write_batch)
     }
 
+    // return the approximate size in bytes of the storage directory, or `None` if an error occurs
+    // while reading the directory (directory not found, file deleted, etc)
     pub fn storage_size(&self) -> Option<u64> {
         get_size(&self.path).ok()
     }


### PR DESCRIPTION
(documentation-only, explain why method returns `Option<u64>`)