### PR TITLE
Durable Nonce - Authorized Noncer

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -108,16 +108,21 @@ pub enum CliCommand {
     // Nonce commands
     CreateNonceAccount {
         nonce_account: KeypairEq,
+        nonce_authority: Pubkey,
         lamports: u64,
     },
     GetNonce(Pubkey),
-    NewNonce(KeypairEq),
+    NewNonce {
+        nonce_account: Pubkey,
+        nonce_authority: KeypairEq,
+    },
     ShowNonceAccount {
         nonce_account_pubkey: Pubkey,
         use_lamports_unit: bool,
     },
     WithdrawFromNonceAccount {
-        nonce_account: KeypairEq,
+        nonce_account: Pubkey,
+        nonce_authority: KeypairEq,
         destination_account_pubkey: Pubkey,
         lamports: u64,
     },
@@ -1066,16 +1071,24 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
         // Create nonce account
         CliCommand::CreateNonceAccount {
             nonce_account,
+            nonce_authority,
             lamports,
-        } => process_create_nonce_account(&rpc_client, config, nonce_account, *lamports),
+        } => process_create_nonce_account(
+            &rpc_client,
+            config,
+            nonce_account,
+            nonce_authority,
+            *lamports,
+        ),
         // Get the current nonce
         CliCommand::GetNonce(nonce_account_pubkey) => {
             process_get_nonce(&rpc_client, &nonce_account_pubkey)
         }
         // Get a new nonce
-        CliCommand::NewNonce(nonce_account) => {
-            process_new_nonce(&rpc_client, config, nonce_account)
-        }
+        CliCommand::NewNonce {
+            nonce_account,
+            nonce_authority,
+        } => process_new_nonce(&rpc_client, config, nonce_account, nonce_authority),
         // Show the contents of a nonce account
         CliCommand::ShowNonceAccount {
             nonce_account_pubkey,
@@ -1084,12 +1097,14 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
         // Withdraw lamports from a nonce account
         CliCommand::WithdrawFromNonceAccount {
             nonce_account,
+            nonce_authority,
             destination_account_pubkey,
             lamports,
         } => process_withdraw_from_nonce_account(
             &rpc_client,
             config,
             &nonce_account,
+            nonce_authority,
             &destination_account_pubkey,
             *lamports,
         ),

--- a/cli/src/nonce.rs
+++ b/cli/src/nonce.rs
@@ -22,6 +22,15 @@ pub trait NonceSubCommands {
     fn nonce_subcommands(self) -> Self;
 }
 
+fn nonce_authority_arg<'a, 'b>() -> Arg<'a, 'b> {
+    Arg::with_name("nonce_authority")
+        .long("authorized-noncer")
+        .takes_value(true)
+        .value_name("KEYPAIR")
+        .validator(is_keypair_or_ask_keyword)
+        .help("Specify nonce authority if different from account")
+}
+
 impl NonceSubCommands for App<'_, '_> {
     fn nonce_subcommands(self) -> Self {
         self.subcommand(
@@ -33,7 +42,7 @@ impl NonceSubCommands for App<'_, '_> {
                         .value_name("NONCE ACCOUNT")
                         .takes_value(true)
                         .required(true)
-                        .validator(is_keypair_or_ask_keyword)
+                        .validator(is_pubkey_or_keypair)
                         .help("Keypair of the nonce account to fund"),
                 )
                 .arg(
@@ -52,6 +61,14 @@ impl NonceSubCommands for App<'_, '_> {
                         .takes_value(true)
                         .possible_values(&["SOL", "lamports"])
                         .help("Specify unit to use for request"),
+                )
+                .arg(
+                    Arg::with_name("nonce_authority")
+                        .long("authorized-noncer")
+                        .takes_value(true)
+                        .value_name("BASE58_PUBKEY")
+                        .validator(is_pubkey_or_keypair)
+                        .help("Assign noncing authority to another entity"),
                 ),
         )
         .subcommand(
@@ -78,7 +95,8 @@ impl NonceSubCommands for App<'_, '_> {
                         .required(true)
                         .validator(is_pubkey_or_keypair)
                         .help("Address of the nonce account"),
-                ),
+                )
+                .arg(nonce_authority_arg()),
         )
         .subcommand(
             SubCommand::with_name("show-nonce-account")
@@ -136,18 +154,27 @@ impl NonceSubCommands for App<'_, '_> {
                         .takes_value(true)
                         .possible_values(&["SOL", "lamports"])
                         .help("Specify unit to use for request"),
-                ),
+                )
+                .arg(nonce_authority_arg()),
         )
     }
+}
+
+fn resolve_nonce_authority(matches: &ArgMatches<'_>) -> Keypair {
+    keypair_of(matches, "nonce_authority")
+        .unwrap_or_else(|| keypair_of(matches, "nonce_account_keypair").unwrap())
 }
 
 pub fn parse_nonce_create_account(matches: &ArgMatches<'_>) -> Result<CliCommandInfo, CliError> {
     let nonce_account = keypair_of(matches, "nonce_account_keypair").unwrap();
     let lamports = required_lamports_from(matches, "amount", "unit")?;
+    let nonce_authority =
+        pubkey_of(matches, "nonce_authority").unwrap_or_else(|| nonce_account.pubkey());
 
     Ok(CliCommandInfo {
         command: CliCommand::CreateNonceAccount {
             nonce_account: nonce_account.into(),
+            nonce_authority,
             lamports,
         },
         require_keypair: true,
@@ -164,10 +191,14 @@ pub fn parse_get_nonce(matches: &ArgMatches<'_>) -> Result<CliCommandInfo, CliEr
 }
 
 pub fn parse_new_nonce(matches: &ArgMatches<'_>) -> Result<CliCommandInfo, CliError> {
-    let nonce_account = keypair_of(matches, "nonce_account_keypair").unwrap();
+    let nonce_account = pubkey_of(matches, "nonce_account_keypair").unwrap();
+    let nonce_authority = resolve_nonce_authority(matches);
 
     Ok(CliCommandInfo {
-        command: CliCommand::NewNonce(nonce_account.into()),
+        command: CliCommand::NewNonce {
+            nonce_account,
+            nonce_authority: nonce_authority.into(),
+        },
         require_keypair: true,
     })
 }
@@ -188,13 +219,15 @@ pub fn parse_show_nonce_account(matches: &ArgMatches<'_>) -> Result<CliCommandIn
 pub fn parse_withdraw_from_nonce_account(
     matches: &ArgMatches<'_>,
 ) -> Result<CliCommandInfo, CliError> {
-    let nonce_account = keypair_of(matches, "nonce_account_keypair").unwrap();
+    let nonce_account = pubkey_of(matches, "nonce_account_keypair").unwrap();
     let destination_account_pubkey = pubkey_of(matches, "destination_account_pubkey").unwrap();
     let lamports = required_lamports_from(matches, "amount", "unit")?;
+    let nonce_authority = resolve_nonce_authority(matches);
 
     Ok(CliCommandInfo {
         command: CliCommand::WithdrawFromNonceAccount {
-            nonce_account: nonce_account.into(),
+            nonce_account,
+            nonce_authority: nonce_authority.into(),
             destination_account_pubkey,
             lamports,
         },
@@ -206,6 +239,7 @@ pub fn process_create_nonce_account(
     rpc_client: &RpcClient,
     config: &CliConfig,
     nonce_account: &Keypair,
+    nonce_authority: &Pubkey,
     lamports: u64,
 ) -> ProcessResult {
     let nonce_account_pubkey = nonce_account.pubkey();
@@ -217,7 +251,7 @@ pub fn process_create_nonce_account(
     if rpc_client.get_account(&nonce_account_pubkey).is_ok() {
         return Err(CliError::BadParameter(format!(
             "Unable to create nonce account. Nonce account already exists: {}",
-            nonce_account_pubkey
+            nonce_account_pubkey,
         ))
         .into());
     }
@@ -231,7 +265,12 @@ pub fn process_create_nonce_account(
         .into());
     }
 
-    let ixs = create_nonce_account(&config.keypair.pubkey(), &nonce_account_pubkey, lamports);
+    let ixs = create_nonce_account(
+        &config.keypair.pubkey(),
+        &nonce_account_pubkey,
+        nonce_authority,
+        lamports,
+    );
     let (recent_blockhash, fee_calculator) = rpc_client.get_recent_blockhash()?;
     let mut tx = Transaction::new_signed_with_payer(
         ixs,
@@ -272,27 +311,27 @@ pub fn process_get_nonce(rpc_client: &RpcClient, nonce_account_pubkey: &Pubkey) 
 pub fn process_new_nonce(
     rpc_client: &RpcClient,
     config: &CliConfig,
-    nonce_account: &Keypair,
+    nonce_account: &Pubkey,
+    nonce_authority: &Keypair,
 ) -> ProcessResult {
-    let nonce_account_pubkey = nonce_account.pubkey();
     check_unique_pubkeys(
         (&config.keypair.pubkey(), "cli keypair".to_string()),
-        (&nonce_account_pubkey, "nonce_account_pubkey".to_string()),
+        (&nonce_account, "nonce_account_pubkey".to_string()),
     )?;
 
-    if rpc_client.get_account(&nonce_account_pubkey).is_err() {
+    if rpc_client.get_account(&nonce_account).is_err() {
         return Err(CliError::BadParameter(
             "Unable to create new nonce, no nonce account found".to_string(),
         )
         .into());
     }
 
-    let ix = nonce(&nonce_account_pubkey);
+    let ix = nonce(&nonce_account, &nonce_authority.pubkey());
     let (recent_blockhash, fee_calculator) = rpc_client.get_recent_blockhash()?;
     let mut tx = Transaction::new_signed_with_payer(
         vec![ix],
         Some(&config.keypair.pubkey()),
-        &[&config.keypair, nonce_account],
+        &[&config.keypair, nonce_authority],
         recent_blockhash,
     );
     check_account_for_fee(
@@ -302,7 +341,7 @@ pub fn process_new_nonce(
         &tx.message,
     )?;
     let result =
-        rpc_client.send_and_confirm_transaction(&mut tx, &[&config.keypair, nonce_account]);
+        rpc_client.send_and_confirm_transaction(&mut tx, &[&config.keypair, nonce_authority]);
     log_instruction_custom_error::<SystemError>(result)
 }
 
@@ -351,21 +390,23 @@ pub fn process_show_nonce_account(
 pub fn process_withdraw_from_nonce_account(
     rpc_client: &RpcClient,
     config: &CliConfig,
-    nonce_account: &Keypair,
+    nonce_account: &Pubkey,
+    nonce_authority: &Keypair,
     destination_account_pubkey: &Pubkey,
     lamports: u64,
 ) -> ProcessResult {
     let (recent_blockhash, fee_calculator) = rpc_client.get_recent_blockhash()?;
 
     let ix = withdraw(
-        &nonce_account.pubkey(),
+        nonce_account,
+        &nonce_authority.pubkey(),
         destination_account_pubkey,
         lamports,
     );
     let mut tx = Transaction::new_signed_with_payer(
         vec![ix],
         Some(&config.keypair.pubkey()),
-        &[&config.keypair, nonce_account],
+        &[&config.keypair, nonce_authority],
         recent_blockhash,
     );
     check_account_for_fee(
@@ -375,7 +416,7 @@ pub fn process_withdraw_from_nonce_account(
         &tx.message,
     )?;
     let result =
-        rpc_client.send_and_confirm_transaction(&mut tx, &[&config.keypair, nonce_account]);
+        rpc_client.send_and_confirm_transaction(&mut tx, &[&config.keypair, nonce_authority]);
     log_instruction_custom_error::<NonceError>(result)
 }
 
@@ -413,7 +454,33 @@ mod tests {
             CliCommandInfo {
                 command: CliCommand::CreateNonceAccount {
                     nonce_account: read_keypair_file(&keypair_file).unwrap().into(),
-                    lamports: 50
+                    nonce_authority: nonce_account_pubkey,
+                    lamports: 50,
+                },
+                require_keypair: true
+            }
+        );
+
+        // Test CreateNonceAccount SubCommand with authorized noncer
+        let (authority_keypair_file, mut tmp_file2) = make_tmp_file();
+        let nonce_authority_keypair = Keypair::new();
+        write_keypair(&nonce_authority_keypair, tmp_file2.as_file_mut()).unwrap();
+        let test_create_nonce_account = test_commands.clone().get_matches_from(vec![
+            "test",
+            "create-nonce-account",
+            &keypair_file,
+            "50",
+            "lamports",
+            "--authorized-noncer",
+            &authority_keypair_file,
+        ]);
+        assert_eq!(
+            parse_command(&test_create_nonce_account).unwrap(),
+            CliCommandInfo {
+                command: CliCommand::CreateNonceAccount {
+                    nonce_account: read_keypair_file(&keypair_file).unwrap().into(),
+                    nonce_authority: read_keypair_file(&authority_keypair_file).unwrap().pubkey(),
+                    lamports: 50,
                 },
                 require_keypair: true
             }
@@ -438,10 +505,34 @@ mod tests {
             test_commands
                 .clone()
                 .get_matches_from(vec!["test", "new-nonce", &keypair_file]);
+        let nonce_account = read_keypair_file(&keypair_file).unwrap();
         assert_eq!(
             parse_command(&test_new_nonce).unwrap(),
             CliCommandInfo {
-                command: CliCommand::NewNonce(read_keypair_file(&keypair_file).unwrap().into()),
+                command: CliCommand::NewNonce {
+                    nonce_account: nonce_account.pubkey(),
+                    nonce_authority: nonce_account.into(),
+                },
+                require_keypair: true
+            }
+        );
+
+        // Test NewNonce SubCommand with authority
+        let test_new_nonce = test_commands.clone().get_matches_from(vec![
+            "test",
+            "new-nonce",
+            &keypair_file,
+            "--authorized-noncer",
+            &authority_keypair_file,
+        ]);
+        let nonce_account = read_keypair_file(&keypair_file).unwrap();
+        assert_eq!(
+            parse_command(&test_new_nonce).unwrap(),
+            CliCommandInfo {
+                command: CliCommand::NewNonce {
+                    nonce_account: nonce_account.pubkey(),
+                    nonce_authority: read_keypair_file(&authority_keypair_file).unwrap().into(),
+                },
                 require_keypair: true
             }
         );
@@ -476,7 +567,8 @@ mod tests {
             parse_command(&test_withdraw_from_nonce_account).unwrap(),
             CliCommandInfo {
                 command: CliCommand::WithdrawFromNonceAccount {
-                    nonce_account: read_keypair_file(&keypair_file).unwrap().into(),
+                    nonce_account: read_keypair_file(&keypair_file).unwrap().pubkey(),
+                    nonce_authority: read_keypair_file(&keypair_file).unwrap().into(),
                     destination_account_pubkey: nonce_account_pubkey,
                     lamports: 42
                 },
@@ -496,9 +588,34 @@ mod tests {
             parse_command(&test_withdraw_from_nonce_account).unwrap(),
             CliCommandInfo {
                 command: CliCommand::WithdrawFromNonceAccount {
-                    nonce_account: read_keypair_file(&keypair_file).unwrap().into(),
+                    nonce_account: read_keypair_file(&keypair_file).unwrap().pubkey(),
+                    nonce_authority: read_keypair_file(&keypair_file).unwrap().into(),
                     destination_account_pubkey: nonce_account_pubkey,
                     lamports: 42000000000
+                },
+                require_keypair: true
+            }
+        );
+
+        // Test WithdrawFromNonceAccount Subcommand with authority
+        let test_withdraw_from_nonce_account = test_commands.clone().get_matches_from(vec![
+            "test",
+            "withdraw-from-nonce-account",
+            &keypair_file,
+            &nonce_account_string,
+            "42",
+            "lamports",
+            "--authorized-noncer",
+            &authority_keypair_file,
+        ]);
+        assert_eq!(
+            parse_command(&test_withdraw_from_nonce_account).unwrap(),
+            CliCommandInfo {
+                command: CliCommand::WithdrawFromNonceAccount {
+                    nonce_account: read_keypair_file(&keypair_file).unwrap().pubkey(),
+                    nonce_authority: read_keypair_file(&authority_keypair_file).unwrap().into(),
+                    destination_account_pubkey: nonce_account_pubkey,
+                    lamports: 42
                 },
                 require_keypair: true
             }

--- a/cli/src/nonce.rs
+++ b/cli/src/nonce.rs
@@ -24,7 +24,7 @@ pub trait NonceSubCommands {
 
 fn nonce_authority_arg<'a, 'b>() -> Arg<'a, 'b> {
     Arg::with_name("nonce_authority")
-        .long("authorized-noncer")
+        .long("nonce-authority")
         .takes_value(true)
         .value_name("KEYPAIR")
         .validator(is_keypair_or_ask_keyword)
@@ -64,7 +64,7 @@ impl NonceSubCommands for App<'_, '_> {
                 )
                 .arg(
                     Arg::with_name("nonce_authority")
-                        .long("authorized-noncer")
+                        .long("nonce-authority")
                         .takes_value(true)
                         .value_name("BASE58_PUBKEY")
                         .validator(is_pubkey_or_keypair)
@@ -461,7 +461,7 @@ mod tests {
             }
         );
 
-        // Test CreateNonceAccount SubCommand with authorized noncer
+        // Test CreateNonceAccount SubCommand with authority
         let (authority_keypair_file, mut tmp_file2) = make_tmp_file();
         let nonce_authority_keypair = Keypair::new();
         write_keypair(&nonce_authority_keypair, tmp_file2.as_file_mut()).unwrap();
@@ -471,7 +471,7 @@ mod tests {
             &keypair_file,
             "50",
             "lamports",
-            "--authorized-noncer",
+            "--nonce-authority",
             &authority_keypair_file,
         ]);
         assert_eq!(
@@ -522,7 +522,7 @@ mod tests {
             "test",
             "new-nonce",
             &keypair_file,
-            "--authorized-noncer",
+            "--nonce-authority",
             &authority_keypair_file,
         ]);
         let nonce_account = read_keypair_file(&keypair_file).unwrap();
@@ -605,7 +605,7 @@ mod tests {
             &nonce_account_string,
             "42",
             "lamports",
-            "--authorized-noncer",
+            "--nonce-authority",
             &authority_keypair_file,
         ]);
         assert_eq!(

--- a/cli/tests/nonce.rs
+++ b/cli/tests/nonce.rs
@@ -4,7 +4,7 @@ use solana_drone::drone::run_local_drone;
 use solana_sdk::{
     hash::Hash,
     pubkey::Pubkey,
-    signature::{read_keypair_file, write_keypair, KeypairUtil},
+    signature::{read_keypair_file, write_keypair, Keypair, KeypairUtil},
 };
 use std::fs::remove_dir_all;
 use std::sync::mpsc::channel;
@@ -53,6 +53,63 @@ fn test_nonce() {
     let (keypair_file, mut tmp_file) = make_tmp_file();
     write_keypair(&config_nonce.keypair, tmp_file.as_file_mut()).unwrap();
 
+    full_battery_tests(
+        &rpc_client,
+        &drone_addr,
+        &mut config_payer,
+        &mut config_nonce,
+        &keypair_file,
+        &keypair_file,
+    );
+
+    server.close().unwrap();
+    remove_dir_all(ledger_path).unwrap();
+}
+
+#[test]
+fn test_nonce_with_authority() {
+    let (server, leader_data, alice, ledger_path) = new_validator_for_tests();
+    let (sender, receiver) = channel();
+    run_local_drone(alice, sender, None);
+    let drone_addr = receiver.recv().unwrap();
+
+    let rpc_client = RpcClient::new_socket(leader_data.rpc);
+
+    let mut config_payer = CliConfig::default();
+    config_payer.json_rpc_url =
+        format!("http://{}:{}", leader_data.rpc.ip(), leader_data.rpc.port());
+
+    let mut config_nonce = CliConfig::default();
+    config_nonce.json_rpc_url =
+        format!("http://{}:{}", leader_data.rpc.ip(), leader_data.rpc.port());
+    let (nonce_keypair_file, mut tmp_file) = make_tmp_file();
+    write_keypair(&config_nonce.keypair, tmp_file.as_file_mut()).unwrap();
+
+    let nonce_authority = Keypair::new();
+    let (authority_keypair_file, mut tmp_file2) = make_tmp_file();
+    write_keypair(&nonce_authority, tmp_file2.as_file_mut()).unwrap();
+
+    full_battery_tests(
+        &rpc_client,
+        &drone_addr,
+        &mut config_payer,
+        &mut config_nonce,
+        &nonce_keypair_file,
+        &authority_keypair_file,
+    );
+
+    server.close().unwrap();
+    remove_dir_all(ledger_path).unwrap();
+}
+
+fn full_battery_tests(
+    rpc_client: &RpcClient,
+    drone_addr: &std::net::SocketAddr,
+    config_payer: &mut CliConfig,
+    config_nonce: &mut CliConfig,
+    nonce_keypair_file: &str,
+    authority_keypair_file: &str,
+) {
     request_and_confirm_airdrop(
         &rpc_client,
         &drone_addr,
@@ -64,7 +121,8 @@ fn test_nonce() {
 
     // Create nonce account
     config_payer.command = CliCommand::CreateNonceAccount {
-        nonce_account: read_keypair_file(&keypair_file).unwrap().into(),
+        nonce_account: read_keypair_file(&nonce_keypair_file).unwrap().into(),
+        nonce_authority: read_keypair_file(&authority_keypair_file).unwrap().pubkey(),
         lamports: 1000,
     };
     process_command(&config_payer).unwrap();
@@ -84,7 +142,10 @@ fn test_nonce() {
     assert_eq!(first_nonce, second_nonce);
 
     // New nonce
-    config_payer.command = CliCommand::NewNonce(read_keypair_file(&keypair_file).unwrap().into());
+    config_payer.command = CliCommand::NewNonce {
+        nonce_account: read_keypair_file(&nonce_keypair_file).unwrap().pubkey(),
+        nonce_authority: read_keypair_file(&authority_keypair_file).unwrap().into(),
+    };
     process_command(&config_payer).unwrap();
 
     // Get nonce
@@ -97,7 +158,8 @@ fn test_nonce() {
     // Withdraw from nonce account
     let payee_pubkey = Pubkey::new_rand();
     config_payer.command = CliCommand::WithdrawFromNonceAccount {
-        nonce_account: read_keypair_file(&keypair_file).unwrap().into(),
+        nonce_account: read_keypair_file(&nonce_keypair_file).unwrap().pubkey(),
+        nonce_authority: read_keypair_file(&authority_keypair_file).unwrap().into(),
         destination_account_pubkey: payee_pubkey,
         lamports: 100,
     };
@@ -112,7 +174,4 @@ fn test_nonce() {
         use_lamports_unit: true,
     };
     process_command(&config_payer).unwrap();
-
-    server.close().unwrap();
-    remove_dir_all(ledger_path).unwrap();
 }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4396,6 +4396,7 @@ mod tests {
         mint_keypair: &Keypair,
         custodian_lamports: u64,
         nonce_lamports: u64,
+        nonce_authority: Option<Pubkey>,
     ) -> Result<(Keypair, Keypair)> {
         let custodian_keypair = Keypair::new();
         let nonce_keypair = Keypair::new();
@@ -4405,9 +4406,11 @@ mod tests {
             &custodian_keypair.pubkey(),
             custodian_lamports,
         )];
+        let nonce_authority = nonce_authority.unwrap_or(nonce_keypair.pubkey());
         setup_ixs.extend_from_slice(&nonce_instruction::create_nonce_account(
             &custodian_keypair.pubkey(),
             &nonce_keypair.pubkey(),
+            &nonce_authority,
             nonce_lamports,
         ));
         let setup_tx = Transaction::new_signed_instructions(
@@ -4424,6 +4427,7 @@ mod tests {
         mut genesis_cfg_fn: F,
         custodian_lamports: u64,
         nonce_lamports: u64,
+        nonce_authority: Option<Pubkey>,
     ) -> Result<(Arc<Bank>, Keypair, Keypair, Keypair)>
     where
         F: FnMut(&mut GenesisConfig),
@@ -4433,22 +4437,27 @@ mod tests {
         genesis_cfg_fn(&mut genesis_config);
         let mut bank = Arc::new(Bank::new(&genesis_config));
 
-        let (custodian_keypair, nonce_keypair) =
-            nonce_setup(&mut bank, &mint_keypair, custodian_lamports, nonce_lamports)?;
+        let (custodian_keypair, nonce_keypair) = nonce_setup(
+            &mut bank,
+            &mint_keypair,
+            custodian_lamports,
+            nonce_lamports,
+            nonce_authority,
+        )?;
         Ok((bank, mint_keypair, custodian_keypair, nonce_keypair))
     }
 
     #[test]
     fn test_check_tx_durable_nonce_ok() {
         let (bank, _mint_keypair, custodian_keypair, nonce_keypair) =
-            setup_nonce_with_bank(10_000_000, |_| {}, 5_000_000, 250_000).unwrap();
+            setup_nonce_with_bank(10_000_000, |_| {}, 5_000_000, 250_000, None).unwrap();
         let custodian_pubkey = custodian_keypair.pubkey();
         let nonce_pubkey = nonce_keypair.pubkey();
 
         let nonce_hash = get_nonce(&bank, &nonce_pubkey).unwrap();
         let tx = Transaction::new_signed_with_payer(
             vec![
-                nonce_instruction::nonce(&nonce_pubkey),
+                nonce_instruction::nonce(&nonce_pubkey, &nonce_pubkey),
                 system_instruction::transfer(&custodian_pubkey, &nonce_pubkey, 100_000),
             ],
             Some(&custodian_pubkey),
@@ -4461,7 +4470,7 @@ mod tests {
     #[test]
     fn test_check_tx_durable_nonce_not_durable_nonce_fail() {
         let (bank, _mint_keypair, custodian_keypair, nonce_keypair) =
-            setup_nonce_with_bank(10_000_000, |_| {}, 5_000_000, 250_000).unwrap();
+            setup_nonce_with_bank(10_000_000, |_| {}, 5_000_000, 250_000, None).unwrap();
         let custodian_pubkey = custodian_keypair.pubkey();
         let nonce_pubkey = nonce_keypair.pubkey();
 
@@ -4469,7 +4478,7 @@ mod tests {
         let tx = Transaction::new_signed_with_payer(
             vec![
                 system_instruction::transfer(&custodian_pubkey, &nonce_pubkey, 100_000),
-                nonce_instruction::nonce(&nonce_pubkey),
+                nonce_instruction::nonce(&nonce_pubkey, &nonce_pubkey),
             ],
             Some(&custodian_pubkey),
             &[&custodian_keypair, &nonce_keypair],
@@ -4481,14 +4490,14 @@ mod tests {
     #[test]
     fn test_check_tx_durable_nonce_missing_ix_pubkey_fail() {
         let (bank, _mint_keypair, custodian_keypair, nonce_keypair) =
-            setup_nonce_with_bank(10_000_000, |_| {}, 5_000_000, 250_000).unwrap();
+            setup_nonce_with_bank(10_000_000, |_| {}, 5_000_000, 250_000, None).unwrap();
         let custodian_pubkey = custodian_keypair.pubkey();
         let nonce_pubkey = nonce_keypair.pubkey();
 
         let nonce_hash = get_nonce(&bank, &nonce_pubkey).unwrap();
         let mut tx = Transaction::new_signed_with_payer(
             vec![
-                nonce_instruction::nonce(&nonce_pubkey),
+                nonce_instruction::nonce(&nonce_pubkey, &nonce_pubkey),
                 system_instruction::transfer(&custodian_pubkey, &nonce_pubkey, 100_000),
             ],
             Some(&custodian_pubkey),
@@ -4502,7 +4511,7 @@ mod tests {
     #[test]
     fn test_check_tx_durable_nonce_nonce_acc_does_not_exist_fail() {
         let (bank, _mint_keypair, custodian_keypair, nonce_keypair) =
-            setup_nonce_with_bank(10_000_000, |_| {}, 5_000_000, 250_000).unwrap();
+            setup_nonce_with_bank(10_000_000, |_| {}, 5_000_000, 250_000, None).unwrap();
         let custodian_pubkey = custodian_keypair.pubkey();
         let nonce_pubkey = nonce_keypair.pubkey();
         let missing_keypair = Keypair::new();
@@ -4511,11 +4520,11 @@ mod tests {
         let nonce_hash = get_nonce(&bank, &nonce_pubkey).unwrap();
         let tx = Transaction::new_signed_with_payer(
             vec![
-                nonce_instruction::nonce(&missing_pubkey),
+                nonce_instruction::nonce(&missing_pubkey, &nonce_pubkey),
                 system_instruction::transfer(&custodian_pubkey, &nonce_pubkey, 100_000),
             ],
             Some(&custodian_pubkey),
-            &[&custodian_keypair, &missing_keypair],
+            &[&custodian_keypair, &nonce_keypair],
             nonce_hash,
         );
         assert!(!bank.check_tx_durable_nonce(&tx));
@@ -4524,13 +4533,13 @@ mod tests {
     #[test]
     fn test_check_tx_durable_nonce_bad_tx_hash_fail() {
         let (bank, _mint_keypair, custodian_keypair, nonce_keypair) =
-            setup_nonce_with_bank(10_000_000, |_| {}, 5_000_000, 250_000).unwrap();
+            setup_nonce_with_bank(10_000_000, |_| {}, 5_000_000, 250_000, None).unwrap();
         let custodian_pubkey = custodian_keypair.pubkey();
         let nonce_pubkey = nonce_keypair.pubkey();
 
         let tx = Transaction::new_signed_with_payer(
             vec![
-                nonce_instruction::nonce(&nonce_pubkey),
+                nonce_instruction::nonce(&nonce_pubkey, &nonce_pubkey),
                 system_instruction::transfer(&custodian_pubkey, &nonce_pubkey, 100_000),
             ],
             Some(&custodian_pubkey),
@@ -4549,6 +4558,7 @@ mod tests {
             },
             5_000_000,
             250_000,
+            None,
         )
         .unwrap();
         let alice_keypair = Keypair::new();
@@ -4584,7 +4594,7 @@ mod tests {
         /* Durable Nonce transfer */
         let durable_tx = Transaction::new_signed_with_payer(
             vec![
-                nonce_instruction::nonce(&nonce_pubkey),
+                nonce_instruction::nonce(&nonce_pubkey, &nonce_pubkey),
                 system_instruction::transfer(&custodian_pubkey, &alice_pubkey, 100_000),
             ],
             Some(&custodian_pubkey),
@@ -4605,7 +4615,7 @@ mod tests {
         /* Durable Nonce re-use fails */
         let durable_tx = Transaction::new_signed_with_payer(
             vec![
-                nonce_instruction::nonce(&nonce_pubkey),
+                nonce_instruction::nonce(&nonce_pubkey, &nonce_pubkey),
                 system_instruction::transfer(&custodian_pubkey, &alice_pubkey, 100_000),
             ],
             Some(&custodian_pubkey),
@@ -4629,7 +4639,7 @@ mod tests {
 
         let durable_tx = Transaction::new_signed_with_payer(
             vec![
-                nonce_instruction::nonce(&nonce_pubkey),
+                nonce_instruction::nonce(&nonce_pubkey, &nonce_pubkey),
                 system_instruction::transfer(&custodian_pubkey, &alice_pubkey, 100_000_000),
             ],
             Some(&custodian_pubkey),

--- a/runtime/src/nonce_utils.rs
+++ b/runtime/src/nonce_utils.rs
@@ -61,7 +61,7 @@ mod tests {
         let tx = Transaction::new_signed_instructions(
             &[&from_keypair, &nonce_keypair],
             vec![
-                nonce_instruction::nonce(&nonce_pubkey),
+                nonce_instruction::nonce(&nonce_pubkey, &nonce_pubkey),
                 system_instruction::transfer(&from_pubkey, &nonce_pubkey, 42),
             ],
             Hash::default(),
@@ -99,7 +99,7 @@ mod tests {
             &[&from_keypair, &nonce_keypair],
             vec![
                 system_instruction::transfer(&from_pubkey, &nonce_pubkey, 42),
-                nonce_instruction::nonce(&nonce_pubkey),
+                nonce_instruction::nonce(&nonce_pubkey, &nonce_pubkey),
             ],
             Hash::default(),
         );
@@ -115,7 +115,7 @@ mod tests {
         let tx = Transaction::new_signed_instructions(
             &[&from_keypair, &nonce_keypair],
             vec![
-                nonce_instruction::withdraw(&nonce_pubkey, &from_pubkey, 42),
+                nonce_instruction::withdraw(&nonce_pubkey, &nonce_pubkey, &from_pubkey, 42),
                 system_instruction::transfer(&from_pubkey, &nonce_pubkey, 42),
             ],
             Hash::default(),
@@ -160,8 +160,9 @@ mod tests {
             // New is in Uninitialzed state
             assert_eq!(state, NonceState::Uninitialized);
             let recent_blockhashes = create_test_recent_blockhashes(0);
+            let authorized = nonce_account.unsigned_key().clone();
             nonce_account
-                .initialize(&recent_blockhashes, &Rent::free())
+                .initialize(&authorized, &recent_blockhashes, &Rent::free())
                 .unwrap();
             assert!(verify_nonce(&nonce_account.account, &recent_blockhashes[0]));
         });
@@ -183,8 +184,9 @@ mod tests {
             // New is in Uninitialzed state
             assert_eq!(state, NonceState::Uninitialized);
             let recent_blockhashes = create_test_recent_blockhashes(0);
+            let authorized = nonce_account.unsigned_key().clone();
             nonce_account
-                .initialize(&recent_blockhashes, &Rent::free())
+                .initialize(&authorized, &recent_blockhashes, &Rent::free())
                 .unwrap();
             assert!(!verify_nonce(
                 &nonce_account.account,

--- a/sdk/src/nonce_instruction.rs
+++ b/sdk/src/nonce_instruction.rs
@@ -75,6 +75,8 @@ pub enum NonceInstruction {
     ///     0 - A NonceAccount
     ///
     /// The `Pubkey` parameter identifies the entity to authorize
+    ///
+    /// The current authority must sign a transaction executing this instruction
     Authorize(Pubkey),
 }
 

--- a/sdk/src/nonce_instruction.rs
+++ b/sdk/src/nonce_instruction.rs
@@ -42,6 +42,7 @@ pub enum NonceInstruction {
     ///     0 - A NonceAccount
     ///     1 - RecentBlockhashes sysvar
     ///
+    /// The current authority must sign a transaction executing this instrucion
     Nonce,
 
     /// `Withdraw` transfers funds out of the nonce account
@@ -54,6 +55,8 @@ pub enum NonceInstruction {
     ///
     /// The `u64` parameter is the lamports to withdraw, which must leave the
     /// account balance above the rent exempt reserve or at zero.
+    ///
+    /// The current authority must sign a transaction executing this instruction
     Withdraw(u64),
 
     /// `Initialize` drives state of Uninitalized NonceAccount to Initialized,
@@ -66,6 +69,9 @@ pub enum NonceInstruction {
     ///
     /// The `Pubkey` parameter specifies the entity authorized to execute nonce
     /// instruction on the account
+    ///
+    /// No signatures are required to execute this instruction, enabling derived
+    /// nonce account addresses
     Initialize(Pubkey),
 
     /// `Authorize` changes the entity authorized to execute nonce instructions

--- a/sdk/src/nonce_state.rs
+++ b/sdk/src/nonce_state.rs
@@ -13,11 +13,15 @@ use serde_derive::{Deserialize, Serialize};
 use std::collections::HashSet;
 
 #[derive(Debug, Default, Serialize, Deserialize, PartialEq, Clone, Copy)]
-pub struct Meta {}
+pub struct Meta {
+    pub nonce_authority: Pubkey,
+}
 
 impl Meta {
-    pub fn new() -> Self {
-        Self {}
+    pub fn new(nonce_authority: &Pubkey) -> Self {
+        Self {
+            nonce_authority: *nonce_authority,
+        }
     }
 }
 
@@ -56,6 +60,7 @@ pub trait NonceAccount {
     ) -> Result<(), InstructionError>;
     fn initialize(
         &mut self,
+        nonce_authority: &Pubkey,
         recent_blockhashes: &RecentBlockhashes,
         rent: &Rent,
     ) -> Result<(), InstructionError>;
@@ -71,12 +76,11 @@ impl<'a> NonceAccount for KeyedAccount<'a> {
             return Err(NonceError::NoRecentBlockhashes.into());
         }
 
-        if !signers.contains(self.unsigned_key()) {
-            return Err(InstructionError::MissingRequiredSignature);
-        }
-
         let meta = match self.state()? {
             NonceState::Initialized(meta, ref hash) => {
+                if !signers.contains(&meta.nonce_authority) {
+                    return Err(InstructionError::MissingRequiredSignature);
+                }
                 if *hash == recent_blockhashes[0] {
                     return Err(NonceError::NotExpired.into());
                 }
@@ -96,17 +100,14 @@ impl<'a> NonceAccount for KeyedAccount<'a> {
         rent: &Rent,
         signers: &HashSet<Pubkey>,
     ) -> Result<(), InstructionError> {
-        if !signers.contains(self.unsigned_key()) {
-            return Err(InstructionError::MissingRequiredSignature);
-        }
-
-        match self.state()? {
+        let signer = match self.state()? {
             NonceState::Uninitialized => {
                 if lamports > self.account.lamports {
                     return Err(InstructionError::InsufficientFunds);
                 }
+                *self.unsigned_key()
             }
-            NonceState::Initialized(_meta, ref hash) => {
+            NonceState::Initialized(meta, ref hash) => {
                 if lamports == self.account.lamports {
                     if *hash == recent_blockhashes[0] {
                         return Err(NonceError::NotExpired.into());
@@ -117,7 +118,12 @@ impl<'a> NonceAccount for KeyedAccount<'a> {
                         return Err(InstructionError::InsufficientFunds);
                     }
                 }
+                meta.nonce_authority
             }
+        };
+
+        if !signers.contains(&signer) {
+            return Err(InstructionError::MissingRequiredSignature);
         }
 
         self.account.lamports -= lamports;
@@ -128,6 +134,7 @@ impl<'a> NonceAccount for KeyedAccount<'a> {
 
     fn initialize(
         &mut self,
+        nonce_authority: &Pubkey,
         recent_blockhashes: &RecentBlockhashes,
         rent: &Rent,
     ) -> Result<(), InstructionError> {
@@ -141,7 +148,7 @@ impl<'a> NonceAccount for KeyedAccount<'a> {
                 if self.account.lamports < min_balance {
                     return Err(InstructionError::InsufficientFunds);
                 }
-                Meta::new()
+                Meta::new(nonce_authority)
             }
             _ => return Err(NonceError::BadAccountState.into()),
         };
@@ -189,7 +196,8 @@ mod test {
 
     #[test]
     fn new_meta() {
-        assert_eq!(Meta::new(), Meta {});
+        let nonce_authority = Pubkey::default();
+        assert_eq!(Meta::new(&nonce_authority), Meta { nonce_authority });
     }
 
     #[test]
@@ -199,16 +207,17 @@ mod test {
             ..Rent::default()
         };
         let min_lamports = rent.minimum_balance(NonceState::size());
-        let meta = Meta::new();
         with_test_keyed_account(min_lamports + 42, true, |keyed_account| {
+            let meta = Meta::new(&keyed_account.unsigned_key());
             let mut signers = HashSet::new();
             signers.insert(keyed_account.signer_key().unwrap().clone());
             let state: NonceState = keyed_account.state().unwrap();
             // New is in Uninitialzed state
             assert_eq!(state, NonceState::Uninitialized);
             let recent_blockhashes = create_test_recent_blockhashes(95);
+            let authorized = keyed_account.unsigned_key().clone();
             keyed_account
-                .initialize(&recent_blockhashes, &rent)
+                .initialize(&authorized, &recent_blockhashes, &rent)
                 .unwrap();
             let state: NonceState = keyed_account.state().unwrap();
             let stored = recent_blockhashes[0];
@@ -255,12 +264,13 @@ mod test {
             ..Rent::default()
         };
         let min_lamports = rent.minimum_balance(NonceState::size());
-        let meta = Meta::new();
         with_test_keyed_account(min_lamports + 42, true, |nonce_account| {
             let recent_blockhashes = create_test_recent_blockhashes(31);
             let stored = recent_blockhashes[0];
+            let authorized = nonce_account.unsigned_key().clone();
+            let meta = Meta::new(&authorized);
             nonce_account
-                .initialize(&recent_blockhashes, &rent)
+                .initialize(&authorized, &recent_blockhashes, &rent)
                 .unwrap();
             let pubkey = nonce_account.account.owner.clone();
             let mut nonce_account = KeyedAccount::new(&pubkey, false, nonce_account.account);
@@ -284,8 +294,9 @@ mod test {
             let mut signers = HashSet::new();
             signers.insert(keyed_account.signer_key().unwrap().clone());
             let recent_blockhashes = create_test_recent_blockhashes(0);
+            let authorized = keyed_account.unsigned_key().clone();
             keyed_account
-                .initialize(&recent_blockhashes, &rent)
+                .initialize(&authorized, &recent_blockhashes, &rent)
                 .unwrap();
             let recent_blockhashes = RecentBlockhashes::from_iter(vec![].into_iter());
             let result = keyed_account.nonce(&recent_blockhashes, &signers);
@@ -304,8 +315,9 @@ mod test {
             let mut signers = HashSet::new();
             signers.insert(keyed_account.signer_key().unwrap().clone());
             let recent_blockhashes = create_test_recent_blockhashes(63);
+            let authorized = keyed_account.unsigned_key().clone();
             keyed_account
-                .initialize(&recent_blockhashes, &rent)
+                .initialize(&authorized, &recent_blockhashes, &rent)
                 .unwrap();
             let result = keyed_account.nonce(&recent_blockhashes, &signers);
             assert_eq!(result, Err(NonceError::NotExpired.into()));
@@ -326,6 +338,53 @@ mod test {
             let result = keyed_account.nonce(&recent_blockhashes, &signers);
             assert_eq!(result, Err(NonceError::BadAccountState.into()));
         })
+    }
+
+    #[test]
+    fn nonce_inx_independent_noncer_ok() {
+        let rent = Rent {
+            lamports_per_byte_year: 42,
+            ..Rent::default()
+        };
+        let min_lamports = rent.minimum_balance(NonceState::size());
+        with_test_keyed_account(min_lamports + 42, true, |nonce_account| {
+            with_test_keyed_account(42, true, |nonce_authority| {
+                let mut signers = HashSet::new();
+                signers.insert(nonce_account.signer_key().unwrap().clone());
+                let recent_blockhashes = create_test_recent_blockhashes(63);
+                let authorized = nonce_authority.unsigned_key().clone();
+                nonce_account
+                    .initialize(&authorized, &recent_blockhashes, &rent)
+                    .unwrap();
+                let mut signers = HashSet::new();
+                signers.insert(nonce_authority.signer_key().unwrap().clone());
+                let recent_blockhashes = create_test_recent_blockhashes(31);
+                let result = nonce_account.nonce(&recent_blockhashes, &signers);
+                assert_eq!(result, Ok(()));
+            });
+        });
+    }
+
+    #[test]
+    fn nonce_inx_no_nonce_authority_sig_fail() {
+        let rent = Rent {
+            lamports_per_byte_year: 42,
+            ..Rent::default()
+        };
+        let min_lamports = rent.minimum_balance(NonceState::size());
+        with_test_keyed_account(min_lamports + 42, true, |nonce_account| {
+            with_test_keyed_account(42, false, |nonce_authority| {
+                let mut signers = HashSet::new();
+                signers.insert(nonce_account.signer_key().unwrap().clone());
+                let recent_blockhashes = create_test_recent_blockhashes(63);
+                let authorized = nonce_authority.unsigned_key().clone();
+                nonce_account
+                    .initialize(&authorized, &recent_blockhashes, &rent)
+                    .unwrap();
+                let result = nonce_account.nonce(&recent_blockhashes, &signers);
+                assert_eq!(result, Err(InstructionError::MissingRequiredSignature),);
+            });
+        });
     }
 
     #[test]
@@ -472,12 +531,15 @@ mod test {
             ..Rent::default()
         };
         let min_lamports = rent.minimum_balance(NonceState::size());
-        let meta = Meta::new();
         with_test_keyed_account(min_lamports + 42, true, |nonce_keyed| {
             let mut signers = HashSet::new();
             signers.insert(nonce_keyed.signer_key().unwrap().clone());
             let recent_blockhashes = create_test_recent_blockhashes(31);
-            nonce_keyed.initialize(&recent_blockhashes, &rent).unwrap();
+            let authorized = nonce_keyed.unsigned_key().clone();
+            let meta = Meta::new(&authorized);
+            nonce_keyed
+                .initialize(&authorized, &recent_blockhashes, &rent)
+                .unwrap();
             let state: NonceState = nonce_keyed.state().unwrap();
             let stored = recent_blockhashes[0];
             assert_eq!(state, NonceState::Initialized(meta, stored));
@@ -527,7 +589,10 @@ mod test {
         let min_lamports = rent.minimum_balance(NonceState::size());
         with_test_keyed_account(min_lamports + 42, true, |nonce_keyed| {
             let recent_blockhashes = create_test_recent_blockhashes(0);
-            nonce_keyed.initialize(&recent_blockhashes, &rent).unwrap();
+            let authorized = nonce_keyed.unsigned_key().clone();
+            nonce_keyed
+                .initialize(&authorized, &recent_blockhashes, &rent)
+                .unwrap();
             with_test_keyed_account(42, false, |mut to_keyed| {
                 let mut signers = HashSet::new();
                 signers.insert(nonce_keyed.signer_key().unwrap().clone());
@@ -553,7 +618,10 @@ mod test {
         let min_lamports = rent.minimum_balance(NonceState::size());
         with_test_keyed_account(min_lamports + 42, true, |nonce_keyed| {
             let recent_blockhashes = create_test_recent_blockhashes(95);
-            nonce_keyed.initialize(&recent_blockhashes, &rent).unwrap();
+            let authorized = nonce_keyed.unsigned_key().clone();
+            nonce_keyed
+                .initialize(&authorized, &recent_blockhashes, &rent)
+                .unwrap();
             with_test_keyed_account(42, false, |mut to_keyed| {
                 let recent_blockhashes = create_test_recent_blockhashes(63);
                 let mut signers = HashSet::new();
@@ -580,7 +648,10 @@ mod test {
         let min_lamports = rent.minimum_balance(NonceState::size());
         with_test_keyed_account(min_lamports + 42, true, |nonce_keyed| {
             let recent_blockhashes = create_test_recent_blockhashes(95);
-            nonce_keyed.initialize(&recent_blockhashes, &rent).unwrap();
+            let authorized = nonce_keyed.unsigned_key().clone();
+            nonce_keyed
+                .initialize(&authorized, &recent_blockhashes, &rent)
+                .unwrap();
             with_test_keyed_account(42, false, |mut to_keyed| {
                 let recent_blockhashes = create_test_recent_blockhashes(63);
                 let mut signers = HashSet::new();
@@ -612,10 +683,12 @@ mod test {
             signers.insert(keyed_account.signer_key().unwrap().clone());
             let recent_blockhashes = create_test_recent_blockhashes(0);
             let stored = recent_blockhashes[0];
-            let result = keyed_account.initialize(&recent_blockhashes, &rent);
+            let authorized = keyed_account.unsigned_key().clone();
+            let meta = Meta::new(&authorized);
+            let result = keyed_account.initialize(&authorized, &recent_blockhashes, &rent);
             assert_eq!(result, Ok(()));
             let state: NonceState = keyed_account.state().unwrap();
-            assert_eq!(state, NonceState::Initialized(Meta::new(), stored));
+            assert_eq!(state, NonceState::Initialized(meta, stored));
         })
     }
 
@@ -630,7 +703,8 @@ mod test {
             let mut signers = HashSet::new();
             signers.insert(keyed_account.signer_key().unwrap().clone());
             let recent_blockhashes = RecentBlockhashes::from_iter(vec![].into_iter());
-            let result = keyed_account.initialize(&recent_blockhashes, &rent);
+            let authorized = keyed_account.unsigned_key().clone();
+            let result = keyed_account.initialize(&authorized, &recent_blockhashes, &rent);
             assert_eq!(result, Err(NonceError::NoRecentBlockhashes.into()));
         })
     }
@@ -644,11 +718,12 @@ mod test {
         let min_lamports = rent.minimum_balance(NonceState::size());
         with_test_keyed_account(min_lamports + 42, true, |keyed_account| {
             let recent_blockhashes = create_test_recent_blockhashes(31);
+            let authorized = keyed_account.unsigned_key().clone();
             keyed_account
-                .initialize(&recent_blockhashes, &rent)
+                .initialize(&authorized, &recent_blockhashes, &rent)
                 .unwrap();
             let recent_blockhashes = create_test_recent_blockhashes(0);
-            let result = keyed_account.initialize(&recent_blockhashes, &rent);
+            let result = keyed_account.initialize(&authorized, &recent_blockhashes, &rent);
             assert_eq!(result, Err(NonceError::BadAccountState.into()));
         })
     }
@@ -662,7 +737,8 @@ mod test {
         let min_lamports = rent.minimum_balance(NonceState::size());
         with_test_keyed_account(min_lamports - 42, true, |keyed_account| {
             let recent_blockhashes = create_test_recent_blockhashes(63);
-            let result = keyed_account.initialize(&recent_blockhashes, &rent);
+            let authorized = keyed_account.unsigned_key().clone();
+            let result = keyed_account.initialize(&authorized, &recent_blockhashes, &rent);
             assert_eq!(result, Err(InstructionError::InsufficientFunds));
         })
     }

--- a/sdk/src/nonce_state.rs
+++ b/sdk/src/nonce_state.rs
@@ -362,7 +362,7 @@ mod test {
     }
 
     #[test]
-    fn nonce_inx_independent_noncer_ok() {
+    fn nonce_inx_independent_nonce_authority_ok() {
         let rent = Rent {
             lamports_per_byte_year: 42,
             ..Rent::default()


### PR DESCRIPTION
#### Problem

There is no mechanism for an account to delegate noncing authority within the durable nonce program

#### Summary of Changes

Add an "Authorized Noncer"
 - Specify authority within the `Initialize` instruction
 - Change authority with an `Authorize` instruction

Fixes #7305 