### PR TITLE
Remove workaround due to old Rust-BPF

### DIFF
--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -19,6 +19,7 @@ pub mod native_token;
 pub mod nonce_instruction;
 pub mod nonce_program;
 pub mod nonce_state;
+pub mod packet;
 pub mod poh_config;
 pub mod pubkey;
 pub mod rent;
@@ -67,8 +68,6 @@ pub mod client;
 pub mod commitment_config;
 #[cfg(not(feature = "program"))]
 pub mod genesis_config;
-#[cfg(not(feature = "program"))]
-pub mod packet;
 #[cfg(not(feature = "program"))]
 pub mod signature;
 #[cfg(not(feature = "program"))]


### PR DESCRIPTION
#### Problem

Rust-BPF was based on 1.37 and `packet.rs` was using features that came in later versions of Rust. Because of this `packet.rs` was shielded from program compilation.

#### Summary of Changes

Now that Rust-BPF has been updated to Rust 1.39 remove the workaround

Fixes #
