### PR TITLE
code cleanup, storage_size() was Option<u64>, now Result<u64>

### DIFF
--- a/core/src/ledger_cleanup_service.rs
+++ b/core/src/ledger_cleanup_service.rs
@@ -66,7 +66,7 @@ impl LedgerCleanupService {
 
         let disk_utilization_post = blocktree.storage_size();
 
-        if let (Some(disk_utilization_pre), Some(disk_utilization_post)) =
+        if let (Ok(disk_utilization_pre), Ok(disk_utilization_post)) =
             (disk_utilization_pre, disk_utilization_post)
         {
             datapoint_debug!(

--- a/ledger/src/blocktree.rs
+++ b/ledger/src/blocktree.rs
@@ -1499,9 +1499,7 @@ impl Blocktree {
         self.last_root()
     }
 
-    // return the approximate size in bytes of the storage directory, or `None` if an error occurs
-    // while reading the directory (directory not found, file deleted, etc)
-    pub fn storage_size(&self) -> Option<u64> {
+    pub fn storage_size(&self) -> Result<u64> {
         self.db.storage_size()
     }
 }


### PR DESCRIPTION
#### Problem

* not a problem, code beautification

#### Summary of Changes

* `Option<u64>` -> `Result<u64>`
* requires morphing `fs_extra::error::Error` into `Blocktree::Error`

