### PR TITLE
Add special handling for snapshot root slot in get_confirmed_block

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3566,6 +3566,7 @@ dependencies = [
 name = "solana-ledger"
 version = "0.22.0"
 dependencies = [
+ "assert_matches 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bincode 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bzip2 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/client/src/rpc_request.rs
+++ b/client/src/rpc_request.rs
@@ -31,7 +31,7 @@ pub struct RpcConfirmedBlock {
     pub transactions: Vec<(Transaction, Option<RpcTransactionStatus>)>,
 }
 
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct RpcTransactionStatus {
     pub status: Result<()>,
     pub fee: u64,

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -55,6 +55,7 @@ default-features = false
 features = ["lz4"]
 
 [dev-dependencies]
+assert_matches = "1.3.0"
 matches = "0.1.6"
 solana-budget-program = { path = "../programs/budget", version = "0.22.0" }
 

--- a/ledger/src/blocktree.rs
+++ b/ledger/src/blocktree.rs
@@ -2143,11 +2143,13 @@ pub mod tests {
         leader_schedule::{FixedSchedule, LeaderSchedule},
         shred::{max_ticks_per_n_shreds, DataShredHeader},
     };
+    use assert_matches::assert_matches;
+    use bincode::serialize;
     use itertools::Itertools;
     use rand::{seq::SliceRandom, thread_rng};
     use solana_runtime::bank::Bank;
     use solana_sdk::{
-        hash::{self, Hash},
+        hash::{self, hash, Hash},
         instruction::CompiledInstruction,
         packet::PACKET_DATA_SIZE,
         pubkey::Pubkey,
@@ -2159,7 +2161,7 @@ pub mod tests {
     // used for tests only
     fn make_slot_entries_with_transactions(num_entries: u64) -> Vec<Entry> {
         let mut entries: Vec<Entry> = Vec::new();
-        for _ in 0..num_entries {
+        for x in 0..num_entries {
             let transaction = Transaction::new_with_compiled_instructions(
                 &[&Keypair::new()],
                 &[Pubkey::new_rand()],
@@ -2168,7 +2170,7 @@ pub mod tests {
                 vec![CompiledInstruction::new(1, &(), vec![0])],
             );
             entries.push(next_entry_mut(&mut Hash::default(), 0, vec![transaction]));
-            let mut tick = create_ticks(1, 0, Hash::default());
+            let mut tick = create_ticks(1, 0, hash(&serialize(&x).unwrap()));
             entries.append(&mut tick);
         }
         entries
@@ -4214,13 +4216,22 @@ pub mod tests {
 
     #[test]
     fn test_get_confirmed_block() {
-        let slot = 0;
+        let slot = 10;
         let entries = make_slot_entries_with_transactions(100);
-        let shreds = entries_to_test_shreds(entries.clone(), slot, 0, true, 0);
+        let blockhash = get_last_hash(entries.iter()).unwrap();
+        let shreds = entries_to_test_shreds(entries.clone(), slot, slot - 1, true, 0);
+        let more_shreds = entries_to_test_shreds(entries.clone(), slot + 1, slot, true, 0);
         let ledger_path = get_tmp_ledger_path!();
         let ledger = Blocktree::open(&ledger_path).unwrap();
         ledger.insert_shreds(shreds, None, false).unwrap();
-        ledger.set_roots(&[0]).unwrap();
+        ledger.insert_shreds(more_shreds, None, false).unwrap();
+        ledger.set_roots(&[slot - 1, slot, slot + 1]).unwrap();
+
+        let mut parent_meta = SlotMeta::default();
+        parent_meta.parent_slot = std::u64::MAX;
+        ledger
+            .put_meta_bytes(slot - 1, &serialize(&parent_meta).unwrap())
+            .unwrap();
 
         let expected_transactions: Vec<(Transaction, Option<RpcTransactionStatus>)> = entries
             .iter()
@@ -4239,6 +4250,16 @@ pub mod tests {
                         },
                     )
                     .unwrap();
+                ledger
+                    .transaction_status_cf
+                    .put(
+                        (slot + 1, signature),
+                        &RpcTransactionStatus {
+                            status: Ok(()),
+                            fee: 42,
+                        },
+                    )
+                    .unwrap();
                 (
                     transaction,
                     Some(RpcTransactionStatus {
@@ -4249,17 +4270,33 @@ pub mod tests {
             })
             .collect();
 
-        let confirmed_block = ledger.get_confirmed_block(0).unwrap();
+        // Even if marked as root, a slot that is empty of entries should return an error
+        let confirmed_block_err = ledger.get_confirmed_block(slot - 1).unwrap_err();
+        assert_matches!(confirmed_block_err, BlocktreeError::SlotNotRooted);
+
+        let confirmed_block = ledger.get_confirmed_block(slot).unwrap();
+        assert_eq!(confirmed_block.transactions.len(), 100);
+
+        let mut expected_block = RpcConfirmedBlock::default();
+        expected_block.transactions = expected_transactions.clone();
+        expected_block.parent_slot = slot - 1;
+        expected_block.blockhash = blockhash;
+        // The previous_blockhash of `expected_block` is default because its parent slot is a
+        // root, but empty of entries. This is special handling for snapshot root slots.
+        assert_eq!(confirmed_block, expected_block);
+
+        let confirmed_block = ledger.get_confirmed_block(slot + 1).unwrap();
         assert_eq!(confirmed_block.transactions.len(), 100);
 
         let mut expected_block = RpcConfirmedBlock::default();
         expected_block.transactions = expected_transactions;
-        // The blockhash and previous_blockhash of `expected_block` are default only because
-        // `make_slot_entries_with_transactions` sets all entry hashes to default
+        expected_block.parent_slot = slot;
+        expected_block.previous_blockhash = blockhash;
+        expected_block.blockhash = blockhash;
         assert_eq!(confirmed_block, expected_block);
 
-        let not_root = ledger.get_confirmed_block(1);
-        assert!(not_root.is_err());
+        let not_root = ledger.get_confirmed_block(slot + 2).unwrap_err();
+        assert_matches!(not_root, BlocktreeError::SlotNotRooted);
 
         drop(ledger);
         Blocktree::destroy(&ledger_path).expect("Expected successful database destruction");


### PR DESCRIPTION
#### Problem
Testnet panics when downstream user calls getConfirmedBlock rpc on all slots. (And when all the rpc threads have panicked due to retries, the rpc node becomes unresponsive to further queries.)

In particular, the panic occurs on getConfirmedBlock on the first blocktree root (aside from slot 0). Blocktree::get_confirmed_block assumes a root always has a valid parent slot, but when a node is booted from a snapshot (as the rpc node is on testnet boot), the snapshot root doesn't contain any entries or have a valid parent root in blocktree.

#### Summary of Changes
- Add handling for snapshot root slot (no parent root, no entries; returns BlocktreeError::SlotNotRooted), and next slot (parent slot has no entries, and therefore no blockhash; returns `previous_blockhash: Hash::default()`)

Technically, this means the results of getConfirmedBlock for snapshot root and snapshot root+1 are slightly incorrect. But we expect our main downstream use case to run a node without snapshots, so this should not be an issue.
If it becomes an issue, the more general solution would be to preserve the entries of snapshot root in each snapshot.

This should fix testnet.solana.com, when deployed there.

Fixes #7418 
