### PR TITLE
Colo: Fix lockfile syntax

### DIFF
--- a/net/scripts/colo-node-onacquire.sh
+++ b/net/scripts/colo-node-onacquire.sh
@@ -16,7 +16,7 @@ if [[ ! -f "${SOLANA_LOCK_FILE}" ]]; then
   {
     echo "export SOLANA_LOCK_USER=${SOLANA_USER}"
     echo "export SOLANA_LOCK_INSTANCENAME=${INSTANCE_NAME}"
-    echo "[[ -v SSH_TTY -a -f \"${HOME}/.solana-motd\" ]] && cat \"${HOME}/.solana-motd\" 1>&2"
+    echo "[[ -v SSH_TTY && -f \"${HOME}/.solana-motd\" ]] && cat \"${HOME}/.solana-motd\" 1>&2"
   } >&9
   exec 9>&-
   cat > /solana-scratch/id_ecdsa <<EOF


### PR DESCRIPTION
#### Problem

A syntax error was introduced in `.solana.lock` with the switch to double brackets

#### Summary of Changes

Use the correct logical AND operator

Fixes #7423
