### PR TITLE
Save tower state persistently

### DIFF
--- a/core/benches/consensus.rs
+++ b/core/benches/consensus.rs
@@ -1,0 +1,30 @@
+#![feature(test)]
+
+extern crate solana_core;
+extern crate test;
+
+use solana_core::consensus::{Tower, VOTE_THRESHOLD_DEPTH, VOTE_THRESHOLD_SIZE};
+use solana_ledger::bank_forks::BankForks;
+use solana_runtime::bank::Bank;
+use solana_sdk::{
+    pubkey::Pubkey,
+    signature::{Keypair, KeypairUtil},
+};
+use tempfile::TempDir;
+use test::Bencher;
+
+#[bench]
+fn bench_save_tower(bench: &mut Bencher) {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().to_path_buf();
+    let tower = Tower::new(
+        &Pubkey::default(),
+        &Pubkey::default(),
+        &BankForks::new(0, Bank::default()),
+    );
+    let keypair = Keypair::new();
+
+    bench.iter(move || {
+        tower.save_to_file(&path, &keypair).unwrap();
+    });
+}

--- a/core/benches/consensus.rs
+++ b/core/benches/consensus.rs
@@ -16,15 +16,16 @@ use test::Bencher;
 #[bench]
 fn bench_save_tower(bench: &mut Bencher) {
     let dir = TempDir::new().unwrap();
-    let path = dir.path().to_path_buf();
+    let path = dir.path();
     let tower = Tower::new(
         &Pubkey::default(),
         &Pubkey::default(),
         &BankForks::new(0, Bank::default()),
+        path,
     );
     let keypair = Keypair::new();
 
     bench.iter(move || {
-        tower.save_to_file(&path, &keypair).unwrap();
+        tower.save_to_file(&keypair).unwrap();
     });
 }

--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -37,8 +37,9 @@ impl StakeLockout {
     }
 }
 
+#[derive(Clone, Serialize, Deserialize)]
 pub struct Tower {
-    node_pubkey: Pubkey,
+    pub node_pubkey: Pubkey,
     threshold_depth: usize,
     threshold_size: f64,
     lockouts: VoteState,

--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -37,7 +37,7 @@ impl StakeLockout {
     }
 }
 
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
 pub struct Tower {
     pub node_pubkey: Pubkey,
     threshold_depth: usize,

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -12,6 +12,7 @@ use crate::{
 use solana_ledger::{
     bank_forks::BankForks,
     blockstore::Blockstore,
+    blockstore_db,
     blockstore_processor::{
         self, BlockstoreProcessorError, ConfirmationProgress, ConfirmationTiming,
         TransactionStatusSender,
@@ -217,12 +218,9 @@ impl ReplayStage {
             }
         };
 
-        // Tower gets written to before blocktree, so the root may be missing from blocktree
-        if let Some(tower_root) = tower.root() {
-            if !blockstore.is_root(tower_root) {
-                blockstore.set_roots(&[tower_root]).unwrap();
-            }
-        }
+        // Tower gets written to before blockstore, so roots may be missing from blocktstore
+        Self::reconcile_blockstore_roots_with_tower(&tower, &blockstore)
+            .expect("failed to reconcile blockstore roots with tower");
 
         // Start the replay stage loop
 
@@ -479,6 +477,24 @@ impl ReplayStage {
             },
             root_bank_receiver,
         )
+    }
+
+    fn reconcile_blockstore_roots_with_tower(
+        tower: &Tower,
+        blockstore: &Blockstore,
+    ) -> blockstore_db::Result<()> {
+        if let Some(troot) = tower.root() {
+            let broot = blockstore.last_root();
+            if broot < troot {
+                let new_roots: Vec<_> = blockstore
+                    .slot_meta_iterator(broot + 1)?
+                    .map(|(slot, _)| slot)
+                    .take_while(|slot| *slot <= troot)
+                    .collect();
+                return blockstore.set_roots(&new_roots);
+            }
+        }
+        Ok(())
     }
 
     fn log_leader_change(
@@ -1135,7 +1151,7 @@ pub(crate) mod tests {
         iter,
         sync::{Arc, RwLock},
     };
-    use trees::tr;
+    use trees::{tr, Tree};
 
     struct ForkInfo {
         leader: usize,
@@ -2023,5 +2039,74 @@ pub(crate) mod tests {
                 .fork_weight;
             assert!(second >= first);
         }
+    }
+
+    fn build_tree(n: u64) -> Tree<u64> {
+        _build_tree(n - 1, n - 1)
+    }
+    fn _build_tree(n: u64, i: u64) -> Tree<u64> {
+        if i > 0 {
+            tr(n - i) / _build_tree(n, i - 1)
+        } else {
+            tr(n)
+        }
+    }
+
+    #[test]
+    fn test_reconcile_blockstore_roots_with_tower() {
+        let blockstore_path = get_tmp_ledger_path!();
+        {
+            let blockstore = Blockstore::open(&blockstore_path).unwrap();
+            let node_keypair = Keypair::new();
+            let vote_keypair = Keypair::new();
+            let stake_keypair = Keypair::new();
+            let node_pubkey = node_keypair.pubkey();
+            let mut keypairs = HashMap::new();
+            keypairs.insert(
+                node_pubkey,
+                ValidatorVoteKeypairs::new(node_keypair, vote_keypair, stake_keypair),
+            );
+
+            let (bank_forks, mut progress) = initialize_state(&keypairs);
+            let bank_forks = Arc::new(RwLock::new(bank_forks));
+            let mut tower = Tower::new_with_key(&node_pubkey);
+
+            // Create the tree of banks in a BankForks object
+            let forks = build_tree(42);
+
+            let mut voting_simulator = VoteSimulator::new(&forks);
+            let mut cluster_votes: HashMap<Pubkey, Vec<Slot>> = HashMap::new();
+            let votes: Vec<Slot> = (0..42).collect();
+
+            for slot in &votes {
+                let slot = *slot;
+                let (shreds, _) = make_slot_entries(slot + 1, slot, 1);
+                blockstore.insert_shreds(shreds, None, false).unwrap();
+                assert_eq!(
+                    voting_simulator.simulate_vote(
+                        slot,
+                        &bank_forks,
+                        &mut cluster_votes,
+                        &keypairs,
+                        keypairs.get(&node_pubkey).unwrap(),
+                        &mut progress,
+                        &mut tower,
+                    ),
+                    VoteResult::Ok
+                );
+            }
+            let tower_root = tower.root().unwrap();
+            let set_roots: Vec<_> = (0..(tower_root / 2)).collect();
+            blockstore.set_roots(&set_roots).unwrap();
+            assert!(blockstore.last_root() < tower_root);
+            assert!(
+                ReplayStage::reconcile_blockstore_roots_with_tower(&tower, &blockstore).is_ok()
+            );
+            assert_eq!(blockstore.last_root(), tower.root().unwrap());
+            assert!(
+                ReplayStage::reconcile_blockstore_roots_with_tower(&tower, &blockstore).is_ok()
+            );
+        }
+        Blockstore::destroy(&blockstore_path).expect("Expected successful database destruction");
     }
 }

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -211,6 +211,13 @@ impl ReplayStage {
             }
         };
 
+        // Tower gets written to before blocktree, so the root may be missing from blocktree
+        if let Some(tower_root) = tower.root() {
+            if !blockstore.is_root(tower_root) {
+                blockstore.set_roots(&[tower_root]).unwrap();
+            }
+        }
+
         // Start the replay stage loop
 
         let (lockouts_sender, commitment_service) =

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -667,7 +667,7 @@ impl ReplayStage {
             vote_tx.partial_sign(&[node_keypair.as_ref()], blockhash);
             vote_tx.partial_sign(&[voting_keypair.as_ref()], blockhash);
             // before publishing the latest vote on the network, snapshot the tower for persistent save
-            if let Err(e) = tower.save_to_file(&tower_snapshot_path) {
+            if let Err(e) = tower.save_to_file(&tower_snapshot_path, voting_keypair.as_ref()) {
                 panic!("Unable to backup tower, {:?}", e);
             }
             cluster_info

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -34,8 +34,6 @@ use solana_sdk::{
 use solana_vote_program::vote_instruction;
 use std::{
     collections::{HashMap, HashSet},
-    fs::{self, File},
-    io::{self, BufReader, Write},
     path::PathBuf,
     result,
     sync::{
@@ -47,7 +45,6 @@ use std::{
     time::{Duration, Instant},
 };
 
-static TOWER_SNAPSHOT_NAME: &str = "tower";
 pub const MAX_ENTRY_RECV_PER_ITER: usize = 512;
 
 // Implement a destructor for the ReplayStage thread to signal it exited
@@ -193,7 +190,7 @@ impl ReplayStage {
         let (root_bank_sender, root_bank_receiver) = channel();
         trace!("replay stage");
         let mut tower =
-            Self::reload_tower(&my_pubkey, &tower_snapshot_path, &vote_account, &bank_forks);
+            Tower::reload_from_file(&tower_snapshot_path, &my_pubkey, &vote_account, &bank_forks);
 
         // Start the replay stage loop
 
@@ -670,7 +667,7 @@ impl ReplayStage {
             vote_tx.partial_sign(&[node_keypair.as_ref()], blockhash);
             vote_tx.partial_sign(&[voting_keypair.as_ref()], blockhash);
             // before publishing the latest vote on the network, snapshot the tower for persistent save
-            if let Err(e) = Self::snapshot_tower(&tower_snapshot_path, &tower) {
+            if let Err(e) = tower.save_to_file(&tower_snapshot_path) {
                 panic!("Unable to backup tower, {:?}", e);
             }
             cluster_info
@@ -679,56 +676,6 @@ impl ReplayStage {
                 .push_vote(tower_index, vote_tx);
         }
         Ok(())
-    }
-
-    fn snapshot_tower(tower_snapshot_path: &PathBuf, tower: &Tower) -> Result<()> {
-        let timer = Instant::now();
-        fs::create_dir_all(tower_snapshot_path)?;
-        let mut snapshot_file = File::create(tower_snapshot_path.join(TOWER_SNAPSHOT_NAME))?;
-        snapshot_file.write_all(&bincode::serialize(&tower).expect("tower serialize failed"))?;
-        snapshot_file.flush()?;
-        let snapshot_time = timer.elapsed().as_millis() as usize;
-        inc_new_counter_info!("replay_stage-tower_snapshot_duration_ms", snapshot_time);
-        Ok(())
-    }
-
-    fn reload_tower(
-        my_pubkey: &Pubkey,
-        tower_snapshot_path: &PathBuf,
-        vote_account: &Pubkey,
-        bank_forks: &Arc<RwLock<BankForks>>,
-    ) -> Tower {
-        // try to reload tower from disk, otherwise reconstruct one
-        let tower =
-            File::open(tower_snapshot_path.join(TOWER_SNAPSHOT_NAME)).and_then(|tower_file| {
-                let mut stream = BufReader::new(tower_file);
-                let tower: bincode::Result<Tower> = bincode::deserialize_from(&mut stream);
-                tower.map_err(|err| io::Error::new(io::ErrorKind::Other, format!("{:?}", err)))
-            });
-        // check that the tower actually belongs to this node
-        match tower {
-            Ok(tower) => {
-                if &tower.node_pubkey != my_pubkey {
-                    error!(
-                        "Wrong tower state found. My pubkey {:?} but found tower for {:?}",
-                        my_pubkey, tower.node_pubkey
-                    );
-                    Tower::new(&my_pubkey, &vote_account, &bank_forks.read().unwrap())
-                } else {
-                    info!("Restoring tower from saved state..");
-                    tower
-                }
-            }
-            Err(e) => {
-                if e.kind() != std::io::ErrorKind::NotFound {
-                    error!(
-                            "Error: {:?} Unable to restore tower, generating a new one from from bank forks",
-                            e
-                        );
-                }
-                Tower::new(&my_pubkey, &vote_account, &bank_forks.read().unwrap())
-            }
-        }
     }
 
     fn update_commitment_cache(
@@ -1141,7 +1088,6 @@ pub(crate) mod tests {
     use solana_runtime::genesis_utils::{GenesisConfigInfo, ValidatorVoteKeypairs};
     use solana_sdk::{
         account::Account,
-        genesis_config::GenesisConfig,
         hash::{hash, Hash},
         instruction::InstructionError,
         packet::PACKET_DATA_SIZE,
@@ -1153,12 +1099,10 @@ pub(crate) mod tests {
     use solana_stake_program::stake_state;
     use solana_vote_program::vote_state::{self, Vote, VoteState};
     use std::{
-        fs::{remove_dir_all, remove_file, OpenOptions},
-        io::{Read, Seek, SeekFrom},
+        fs::remove_dir_all,
         iter,
         sync::{Arc, RwLock},
     };
-    use tempfile::TempDir;
     use trees::tr;
 
     struct ForkInfo {
@@ -2047,89 +1991,5 @@ pub(crate) mod tests {
                 .fork_weight;
             assert!(second >= first);
         }
-    }
-
-    fn run_test_load_tower_snapshot<F, G>(
-        modify_original: F,
-        modify_serialized: G,
-        expect_original: bool,
-    ) where
-        F: Fn(&mut Tower, &Pubkey) -> (),
-        G: Fn(&PathBuf) -> (),
-    {
-        let dir = TempDir::new().unwrap();
-        // Use values that will not match the default derived from BankFroks
-        let mut tower = Tower::new_for_tests(10, 0.9);
-        let my_keypair = Keypair::new();
-        modify_original(&mut tower, &my_keypair.pubkey());
-        let vote_keypair = Keypair::new();
-        let genesis_config = GenesisConfig::default();
-        let bank = Bank::new(&genesis_config);
-        let bank_forks = Arc::new(RwLock::new(BankForks::new(0, bank)));
-
-        ReplayStage::snapshot_tower(&dir.path().to_path_buf(), &tower).unwrap();
-        modify_serialized(&dir.path().to_path_buf());
-        let loaded = ReplayStage::reload_tower(
-            &my_keypair.pubkey(),
-            &dir.path().to_path_buf(),
-            &vote_keypair.pubkey(),
-            &bank_forks,
-        );
-
-        if expect_original {
-            assert_eq!(loaded, tower);
-        } else {
-            let default = Tower::new(
-                &my_keypair.pubkey(),
-                &vote_keypair.pubkey(),
-                &bank_forks.read().unwrap(),
-            );
-            assert_eq!(loaded, default)
-        }
-    }
-
-    #[test]
-    fn test_load_tower_snapshot_good() {
-        run_test_load_tower_snapshot(|tower, pubkey| tower.node_pubkey = *pubkey, |_| (), true)
-    }
-
-    #[test]
-    fn test_load_tower_snapshot_wrong_owner() {
-        run_test_load_tower_snapshot(
-            |tower, _| tower.node_pubkey = Keypair::new().pubkey(),
-            |_| (),
-            false,
-        )
-    }
-
-    #[test]
-    fn test_load_tower_snapshot_deser_failure() {
-        run_test_load_tower_snapshot(
-            |tower, pubkey| tower.node_pubkey = *pubkey,
-            |path| {
-                let mut file = OpenOptions::new()
-                    .read(true)
-                    .write(true)
-                    .open(path.join(TOWER_SNAPSHOT_NAME))
-                    .unwrap();
-                let mut buf = [0u8];
-                assert_eq!(file.read(&mut buf).unwrap(), 1);
-                buf[0] = buf[0] + 1;
-                assert_eq!(file.seek(SeekFrom::Start(0)).unwrap(), 0);
-                assert_eq!(file.write(&buf).unwrap(), 1);
-            },
-            false,
-        )
-    }
-
-    #[test]
-    fn test_load_tower_snapshot_missing() {
-        run_test_load_tower_snapshot(
-            |tower, pubkey| tower.node_pubkey = *pubkey,
-            |path| {
-                remove_file(path.join(TOWER_SNAPSHOT_NAME)).unwrap();
-            },
-            false,
-        )
     }
 }

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -82,6 +82,7 @@ pub struct ReplayStageConfig {
     pub transaction_status_sender: Option<TransactionStatusSender>,
     pub rewards_recorder_sender: Option<RewardsRecorderSender>,
     pub tower_snapshot_path: PathBuf,
+    pub allow_missing_tower_state: bool,
 }
 
 pub struct ReplayStage {
@@ -186,6 +187,7 @@ impl ReplayStage {
             transaction_status_sender,
             rewards_recorder_sender,
             tower_snapshot_path,
+            allow_missing_tower_state,
         } = config;
 
         let (root_bank_sender, root_bank_receiver) = channel();
@@ -203,7 +205,11 @@ impl ReplayStage {
                 {
                     if let Some(vote_state) = VoteState::from(&account) {
                         if !vote_state.votes.is_empty() {
-                            panic!("Found initialized vote account with votes, but opening saved tower failed with {:?}", e);
+                            if allow_missing_tower_state {
+                                error!("Found initialized vote account with votes, but opening saved tower failed with {:?}", e);
+                            } else {
+                                panic!("Found initialized vote account with votes, but opening saved tower failed with {:?}", e);
+                            }
                         }
                     }
                 }

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -3,7 +3,7 @@
 use crate::{
     cluster_info::ClusterInfo,
     commitment::{AggregateCommitmentService, BlockCommitmentCache, CommitmentAggregationData},
-    consensus::{StakeLockout, Tower},
+    consensus::{reconcile_blockstore_roots_with_tower, StakeLockout, Tower},
     poh_recorder::PohRecorder,
     result::Result,
     rewards_recorder_service::RewardsRecorderSender,
@@ -12,7 +12,6 @@ use crate::{
 use solana_ledger::{
     bank_forks::BankForks,
     blockstore::Blockstore,
-    blockstore_db,
     blockstore_processor::{
         self, BlockstoreProcessorError, ConfirmationProgress, ConfirmationTiming,
         TransactionStatusSender,
@@ -219,7 +218,7 @@ impl ReplayStage {
         };
 
         // Tower gets written to before blockstore, so roots may be missing from blocktstore
-        Self::reconcile_blockstore_roots_with_tower(&tower, &blockstore)
+        reconcile_blockstore_roots_with_tower(&tower, &blockstore)
             .expect("failed to reconcile blockstore roots with tower");
 
         // Start the replay stage loop
@@ -477,24 +476,6 @@ impl ReplayStage {
             },
             root_bank_receiver,
         )
-    }
-
-    fn reconcile_blockstore_roots_with_tower(
-        tower: &Tower,
-        blockstore: &Blockstore,
-    ) -> blockstore_db::Result<()> {
-        if let Some(troot) = tower.root() {
-            let broot = blockstore.last_root();
-            if broot < troot {
-                let new_roots: Vec<_> = blockstore
-                    .slot_meta_iterator(broot + 1)?
-                    .map(|(slot, _)| slot)
-                    .take_while(|slot| *slot <= troot)
-                    .collect();
-                return blockstore.set_roots(&new_roots);
-            }
-        }
-        Ok(())
     }
 
     fn log_leader_change(
@@ -1151,7 +1132,7 @@ pub(crate) mod tests {
         iter,
         sync::{Arc, RwLock},
     };
-    use trees::{tr, Tree};
+    use trees::tr;
 
     struct ForkInfo {
         leader: usize,
@@ -2039,74 +2020,5 @@ pub(crate) mod tests {
                 .fork_weight;
             assert!(second >= first);
         }
-    }
-
-    fn build_tree(n: u64) -> Tree<u64> {
-        _build_tree(n - 1, n - 1)
-    }
-    fn _build_tree(n: u64, i: u64) -> Tree<u64> {
-        if i > 0 {
-            tr(n - i) / _build_tree(n, i - 1)
-        } else {
-            tr(n)
-        }
-    }
-
-    #[test]
-    fn test_reconcile_blockstore_roots_with_tower() {
-        let blockstore_path = get_tmp_ledger_path!();
-        {
-            let blockstore = Blockstore::open(&blockstore_path).unwrap();
-            let node_keypair = Keypair::new();
-            let vote_keypair = Keypair::new();
-            let stake_keypair = Keypair::new();
-            let node_pubkey = node_keypair.pubkey();
-            let mut keypairs = HashMap::new();
-            keypairs.insert(
-                node_pubkey,
-                ValidatorVoteKeypairs::new(node_keypair, vote_keypair, stake_keypair),
-            );
-
-            let (bank_forks, mut progress) = initialize_state(&keypairs);
-            let bank_forks = Arc::new(RwLock::new(bank_forks));
-            let mut tower = Tower::new_with_key(&node_pubkey);
-
-            // Create the tree of banks in a BankForks object
-            let forks = build_tree(42);
-
-            let mut voting_simulator = VoteSimulator::new(&forks);
-            let mut cluster_votes: HashMap<Pubkey, Vec<Slot>> = HashMap::new();
-            let votes: Vec<Slot> = (0..42).collect();
-
-            for slot in &votes {
-                let slot = *slot;
-                let (shreds, _) = make_slot_entries(slot + 1, slot, 1);
-                blockstore.insert_shreds(shreds, None, false).unwrap();
-                assert_eq!(
-                    voting_simulator.simulate_vote(
-                        slot,
-                        &bank_forks,
-                        &mut cluster_votes,
-                        &keypairs,
-                        keypairs.get(&node_pubkey).unwrap(),
-                        &mut progress,
-                        &mut tower,
-                    ),
-                    VoteResult::Ok
-                );
-            }
-            let tower_root = tower.root().unwrap();
-            let set_roots: Vec<_> = (0..(tower_root / 2)).collect();
-            blockstore.set_roots(&set_roots).unwrap();
-            assert!(blockstore.last_root() < tower_root);
-            assert!(
-                ReplayStage::reconcile_blockstore_roots_with_tower(&tower, &blockstore).is_ok()
-            );
-            assert_eq!(blockstore.last_root(), tower.root().unwrap());
-            assert!(
-                ReplayStage::reconcile_blockstore_roots_with_tower(&tower, &blockstore).is_ok()
-            );
-        }
-        Blockstore::destroy(&blockstore_path).expect("Expected successful database destruction");
     }
 }

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -89,6 +89,7 @@ impl Tvu {
         transaction_status_sender: Option<TransactionStatusSender>,
         rewards_recorder_sender: Option<RewardsRecorderSender>,
         tower_snapshot_path: &Path,
+        allow_missing_tower_state: bool,
     ) -> Self {
         let keypair: Arc<Keypair> = cluster_info
             .read()
@@ -175,6 +176,7 @@ impl Tvu {
             transaction_status_sender,
             rewards_recorder_sender,
             tower_snapshot_path: tower_snapshot_path.to_path_buf(),
+            allow_missing_tower_state,
         };
 
         let (replay_stage, root_bank_receiver) = ReplayStage::new(
@@ -319,6 +321,7 @@ pub mod tests {
             None,
             None,
             &blockstore_path,
+            false,
         );
         exit.store(true, Ordering::Relaxed);
         tvu.join().unwrap();

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -30,7 +30,7 @@ use solana_sdk::{
 };
 use std::{
     net::UdpSocket,
-    path::PathBuf,
+    path::{Path, PathBuf},
     sync::{
         atomic::AtomicBool,
         mpsc::{channel, Receiver},
@@ -88,6 +88,7 @@ impl Tvu {
         shred_version: u16,
         transaction_status_sender: Option<TransactionStatusSender>,
         rewards_recorder_sender: Option<RewardsRecorderSender>,
+        tower_snapshot_path: &Path,
     ) -> Self {
         let keypair: Arc<Keypair> = cluster_info
             .read()
@@ -173,6 +174,7 @@ impl Tvu {
             block_commitment_cache,
             transaction_status_sender,
             rewards_recorder_sender,
+            tower_snapshot_path: tower_snapshot_path.to_path_buf(),
         };
 
         let (replay_stage, root_bank_receiver) = ReplayStage::new(
@@ -316,6 +318,7 @@ pub mod tests {
             0,
             None,
             None,
+            &blockstore_path,
         );
         exit.store(true, Ordering::Relaxed);
         tvu.join().unwrap();

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -405,6 +405,7 @@ impl Validator {
             node.info.shred_version,
             transaction_status_sender.clone(),
             rewards_recorder_sender,
+            ledger_path,
         );
 
         if config.dev_sigverify_disabled {

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -133,6 +133,7 @@ pub struct Validator {
 
 impl Validator {
     #[allow(clippy::cognitive_complexity)]
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         mut node: Node,
         keypair: &Arc<Keypair>,
@@ -142,6 +143,7 @@ impl Validator {
         storage_keypair: &Arc<Keypair>,
         entrypoint_info_option: Option<&ContactInfo>,
         poh_verify: bool,
+        allow_missing_tower_state: bool,
         config: &ValidatorConfig,
     ) -> Self {
         let id = keypair.pubkey();
@@ -406,6 +408,7 @@ impl Validator {
             transaction_status_sender.clone(),
             rewards_recorder_sender,
             ledger_path,
+            allow_missing_tower_state,
         );
 
         if config.dev_sigverify_disabled {
@@ -659,6 +662,7 @@ pub fn new_validator_for_tests_ex(
         &storage_keypair,
         None,
         true,
+        false,
         &config,
     );
     discover_cluster(&contact_info.gossip, 1).expect("Node startup failed");
@@ -762,6 +766,7 @@ mod tests {
             &storage_keypair,
             Some(&leader_node.info),
             true,
+            false,
             &config,
         );
         validator.close().unwrap();
@@ -801,6 +806,7 @@ mod tests {
                     &storage_keypair,
                     Some(&leader_node.info),
                     true,
+                    false,
                     &config,
                 )
             })

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -53,7 +53,7 @@ pub enum BlockstoreError {
     FsExtraError(#[from] fs_extra::error::Error),
     SlotCleanedUp,
 }
-pub(crate) type Result<T> = std::result::Result<T, BlockstoreError>;
+pub type Result<T> = std::result::Result<T, BlockstoreError>;
 
 impl std::fmt::Display for BlockstoreError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -233,13 +233,12 @@ impl LocalCluster {
                 &leader_pubkey,
                 &leader_voting_keypair.pubkey(),
                 &BankForks::new(0, Bank::default()),
+                &leader_ledger_path,
             );
             for vote in votes {
                 tower.record_bank_vote(vote.clone());
             }
-            tower
-                .save_to_file(&leader_ledger_path, &*leader_voting_keypair)
-                .unwrap();
+            tower.save_to_file(&*leader_voting_keypair).unwrap();
         }
 
         let leader_server = Validator::new(
@@ -364,11 +363,12 @@ impl LocalCluster {
                 &validator_pubkey,
                 &voting_keypair.pubkey(),
                 &BankForks::new(0, Bank::default()),
+                &ledger_path,
             );
             for vote in votes {
                 tower.record_bank_vote(vote.clone());
             }
-            tower.save_to_file(&ledger_path, &voting_keypair).unwrap();
+            tower.save_to_file(&voting_keypair).unwrap();
         }
 
         if validator_config.voting_disabled {

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -251,6 +251,7 @@ impl LocalCluster {
             &leader_storage_keypair,
             None,
             true,
+            false,
             &leader_config,
         );
 
@@ -413,6 +414,7 @@ impl LocalCluster {
             &storage_keypair,
             Some(&self.entry_point_info),
             true,
+            false,
             &config,
         );
 
@@ -750,6 +752,7 @@ impl Cluster for LocalCluster {
             &validator_info.storage_keypair,
             entry_point_info,
             true,
+            false,
             &cluster_validator_info.config,
         );
 

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -587,6 +587,12 @@ pub fn main() {
                 .help("Skip ledger verification at node bootup"),
         )
         .arg(
+            clap::Arg::with_name("allow_missing_tower_state")
+                .long("allow-missing-tower-state")
+                .takes_value(false)
+                .help("Don't panic if the saved tower state is missing"),
+        )
+        .arg(
             clap::Arg::with_name("cuda")
                 .long("cuda")
                 .takes_value(false)
@@ -665,6 +671,7 @@ pub fn main() {
     let entrypoint = matches.value_of("entrypoint");
     let init_complete_file = matches.value_of("init_complete_file");
     let skip_poh_verify = matches.is_present("skip_poh_verify");
+    let allow_missing_tower_state = matches.is_present("allow_missing_tower_state");
     let cuda = matches.is_present("cuda");
     let no_genesis_fetch = matches.is_present("no_genesis_fetch");
     let no_snapshot_fetch = matches.is_present("no_snapshot_fetch");
@@ -965,6 +972,7 @@ pub fn main() {
         &Arc::new(storage_keypair),
         cluster_entrypoint.as_ref(),
         !skip_poh_verify,
+        allow_missing_tower_state,
         &validator_config,
     );
 


### PR DESCRIPTION
#### Problem

The `Tower` state of a validator is lost if the validator stops/crashes. This could lead to the validator voting in a slashable way upon reboot.

#### Summary of Changes

Have replay stage save its `Tower` state when generating a new vote, before sending the vote to the cluster. Also have replay stage try to load the saved state when it starts.

Thanks to @sagar-solana for the original work on this.
