### PR TITLE
Allow coding shred index to be different than data shred index

### DIFF
--- a/core/benches/shredder.rs
+++ b/core/benches/shredder.rs
@@ -75,7 +75,7 @@ fn bench_deshredder(bencher: &mut Bencher) {
 fn bench_deserialize_hdr(bencher: &mut Bencher) {
     let data = vec![0; SIZE_OF_DATA_SHRED_PAYLOAD];
 
-    let shred = Shred::new_from_data(2, 1, 1, Some(&data), true, true, 0, 0);
+    let shred = Shred::new_from_data(2, 1, 1, Some(&data), true, true, 0, 0, 1);
 
     bencher.iter(|| {
         let payload = shred.payload.clone();

--- a/core/src/broadcast_stage/standard_broadcast_run.rs
+++ b/core/src/broadcast_stage/standard_broadcast_run.rs
@@ -66,6 +66,7 @@ impl StandardBroadcastRun {
                         true,
                         max_ticks_in_slot & SHRED_TICK_REFERENCE_MASK,
                         self.shred_version,
+                        last_unfinished_slot.next_shred_index,
                     ))
                 } else {
                     None

--- a/core/src/chacha.rs
+++ b/core/src/chacha.rs
@@ -166,7 +166,7 @@ mod tests {
         hasher.hash(&buf[..size]);
 
         //  golden needs to be updated if shred structure changes....
-        let golden: Hash = "3z2WAkJp2dJjvpXsqsLbZ4muc39YGT7YY3eJQGtTHLfb"
+        let golden: Hash = "2rq8nR6rns2T5zsbQAGBDZb41NVtacneLgkCH17CVxZm"
             .parse()
             .unwrap();
 

--- a/core/src/chacha.rs
+++ b/core/src/chacha.rs
@@ -166,7 +166,7 @@ mod tests {
         hasher.hash(&buf[..size]);
 
         //  golden needs to be updated if shred structure changes....
-        let golden: Hash = "9K6NR4cazo7Jzk2CpyXmNaZMGqvfXG83JzyJipkoHare"
+        let golden: Hash = "3z2WAkJp2dJjvpXsqsLbZ4muc39YGT7YY3eJQGtTHLfb"
             .parse()
             .unwrap();
 

--- a/core/src/sigverify_shreds.rs
+++ b/core/src/sigverify_shreds.rs
@@ -92,6 +92,7 @@ pub mod tests {
             true,
             0,
             0,
+            0xc0de,
         );
         let mut batch = [Packets::default(), Packets::default()];
 
@@ -110,6 +111,7 @@ pub mod tests {
             true,
             0,
             0,
+            0xc0de,
         );
         Shredder::sign_shred(&keypair, &mut shred);
         batch[1].packets.resize(1, Packet::default());
@@ -133,14 +135,32 @@ pub mod tests {
         let mut batch = vec![Packets::default()];
         batch[0].packets.resize(2, Packet::default());
 
-        let mut shred =
-            Shred::new_from_data(0, 0xc0de, 0xdead, Some(&[1, 2, 3, 4]), true, true, 0, 0);
+        let mut shred = Shred::new_from_data(
+            0,
+            0xc0de,
+            0xdead,
+            Some(&[1, 2, 3, 4]),
+            true,
+            true,
+            0,
+            0,
+            0xc0de,
+        );
         Shredder::sign_shred(&leader_keypair, &mut shred);
         batch[0].packets[0].data[0..shred.payload.len()].copy_from_slice(&shred.payload);
         batch[0].packets[0].meta.size = shred.payload.len();
 
-        let mut shred =
-            Shred::new_from_data(0, 0xbeef, 0xc0de, Some(&[1, 2, 3, 4]), true, true, 0, 0);
+        let mut shred = Shred::new_from_data(
+            0,
+            0xbeef,
+            0xc0de,
+            Some(&[1, 2, 3, 4]),
+            true,
+            true,
+            0,
+            0,
+            0xc0de,
+        );
         let wrong_keypair = Keypair::new();
         Shredder::sign_shred(&wrong_keypair, &mut shred);
         batch[0].packets[1].data[0..shred.payload.len()].copy_from_slice(&shred.payload);

--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -363,7 +363,7 @@ mod test {
         );
 
         // If it's a coding shred, test that slot >= root
-        let (common, coding) = Shredder::new_coding_shred_header(5, 5, 6, 6, 0, 0);
+        let (common, coding) = Shredder::new_coding_shred_header(5, 5, 5, 6, 6, 0, 0);
         let mut coding_shred =
             Shred::new_empty_from_header(common, DataShredHeader::default(), coding);
         Shredder::sign_shred(&leader_keypair, &mut coding_shred);

--- a/ledger/src/blocktree.rs
+++ b/ledger/src/blocktree.rs
@@ -689,7 +689,7 @@ impl Blocktree {
         if is_trusted
             || Blocktree::should_insert_coding_shred(&shred, index_meta.coding(), &self.last_root)
         {
-            let set_index = u64::from(shred.coding_header.fec_set_index);
+            let set_index = u64::from(shred.common_header.fec_set_index);
             let erasure_config = ErasureConfig::new(
                 shred.coding_header.num_data_shreds as usize,
                 shred.coding_header.num_coding_shreds as usize,
@@ -3541,7 +3541,17 @@ pub mod tests {
         let gap: u64 = 10;
         let shreds: Vec<_> = (0..64)
             .map(|i| {
-                Shred::new_from_data(slot, (i * gap) as u32, 0, None, false, false, i as u8, 0)
+                Shred::new_from_data(
+                    slot,
+                    (i * gap) as u32,
+                    0,
+                    None,
+                    false,
+                    false,
+                    i as u8,
+                    0,
+                    (i * gap) as u32,
+                )
             })
             .collect();
         blocktree.insert_shreds(shreds, None, false).unwrap();
@@ -4156,6 +4166,7 @@ pub mod tests {
                 true,
                 0,
                 0,
+                next_shred_index as u32,
             )];
 
             // With the corruption, nothing should be returned, even though an

--- a/ledger/src/sigverify_shreds.rs
+++ b/ledger/src/sigverify_shreds.rs
@@ -456,8 +456,17 @@ pub mod tests {
         solana_logger::setup();
         let mut packet = Packet::default();
         let slot = 0xdeadc0de;
-        let mut shred =
-            Shred::new_from_data(slot, 0xc0de, 0xdead, Some(&[1, 2, 3, 4]), true, true, 0, 0);
+        let mut shred = Shred::new_from_data(
+            slot,
+            0xc0de,
+            0xdead,
+            Some(&[1, 2, 3, 4]),
+            true,
+            true,
+            0,
+            0,
+            0xc0de,
+        );
         assert_eq!(shred.slot(), slot);
         let keypair = Keypair::new();
         Shredder::sign_shred(&keypair, &mut shred);
@@ -490,8 +499,17 @@ pub mod tests {
         solana_logger::setup();
         let mut batch = [Packets::default()];
         let slot = 0xdeadc0de;
-        let mut shred =
-            Shred::new_from_data(slot, 0xc0de, 0xdead, Some(&[1, 2, 3, 4]), true, true, 0, 0);
+        let mut shred = Shred::new_from_data(
+            slot,
+            0xc0de,
+            0xdead,
+            Some(&[1, 2, 3, 4]),
+            true,
+            true,
+            0,
+            0,
+            0xc0de,
+        );
         let keypair = Keypair::new();
         Shredder::sign_shred(&keypair, &mut shred);
         batch[0].packets.resize(1, Packet::default());
@@ -533,8 +551,17 @@ pub mod tests {
 
         let mut batch = [Packets::default()];
         let slot = 0xdeadc0de;
-        let mut shred =
-            Shred::new_from_data(slot, 0xc0de, 0xdead, Some(&[1, 2, 3, 4]), true, true, 0, 0);
+        let mut shred = Shred::new_from_data(
+            slot,
+            0xc0de,
+            0xdead,
+            Some(&[1, 2, 3, 4]),
+            true,
+            true,
+            0,
+            0,
+            0xc0de,
+        );
         let keypair = Keypair::new();
         Shredder::sign_shred(&keypair, &mut shred);
         batch[0].packets.resize(1, Packet::default());
@@ -598,6 +625,7 @@ pub mod tests {
                 true,
                 1,
                 2,
+                0xc0de,
             );
             shred.copy_to_packet(p);
         }
@@ -631,8 +659,17 @@ pub mod tests {
         let mut batch = [Packets::default()];
         let slot = 0xdeadc0de;
         let keypair = Keypair::new();
-        let shred =
-            Shred::new_from_data(slot, 0xc0de, 0xdead, Some(&[1, 2, 3, 4]), true, true, 0, 0);
+        let shred = Shred::new_from_data(
+            slot,
+            0xc0de,
+            0xdead,
+            Some(&[1, 2, 3, 4]),
+            true,
+            true,
+            0,
+            0,
+            0xc0de,
+        );
         batch[0].packets.resize(1, Packet::default());
         batch[0].packets[0].data[0..shred.payload.len()].copy_from_slice(&shred.payload);
         batch[0].packets[0].meta.size = shred.payload.len();

--- a/ledger/tests/shred.rs
+++ b/ledger/tests/shred.rs
@@ -63,6 +63,7 @@ fn test_multi_fec_block_coding() {
             MAX_DATA_SHREDS_PER_FEC_BLOCK as usize,
             MAX_DATA_SHREDS_PER_FEC_BLOCK as usize,
             shred_start_index,
+            shred_start_index,
             slot,
         )
         .unwrap();


### PR DESCRIPTION
#### Problem
First coding shred index must be same as the first data shred index in an FEC block. This prevents an FEC block to have more number of coding shreds than number of data shreds (as that'll cause the last coding shred index to overlap with the data shred index of the next FEC block).

#### Summary of Changes
Decoupled the coding shred index from data shred index. Also, updated erasure recovery code to use the new indexing scheme.

Reference #7428 