### PR TITLE
Use pinned memory for entry verify

### DIFF
--- a/perf/src/cuda_runtime.rs
+++ b/perf/src/cuda_runtime.rs
@@ -181,6 +181,13 @@ impl<T: Clone + Default + Sized> PinnedVec<T> {
         self.pinnable = true;
     }
 
+    pub fn copy_from_slice(&mut self, data: &[T])
+    where
+        T: Copy,
+    {
+        self.x.copy_from_slice(data);
+    }
+
     pub fn from_vec(source: Vec<T>) -> Self {
         Self {
             x: source,


### PR DESCRIPTION
#### Problem

PoH verify GPU path doesn't use pinned memory causing GPU stalls when it runs.

#### Summary of Changes

Use a PinnedVec for the memory.

Fixes #
