### PR TITLE
Reuse accounts_db stores

### DIFF
--- a/runtime/src/append_vec.rs
+++ b/runtime/src/append_vec.rs
@@ -172,8 +172,8 @@ impl AppendVec {
         append_vec_path.as_ref().file_name().map(PathBuf::from)
     }
 
-    pub fn new_relative_path(fork_id: u64, id: usize) -> PathBuf {
-        PathBuf::from(&format!("{}.{}", fork_id, id))
+    pub fn new_relative_path(id: usize) -> PathBuf {
+        PathBuf::from(&format!("{}", id))
     }
 
     #[allow(clippy::mutex_atomic)]
@@ -516,7 +516,7 @@ pub mod tests {
 
     #[test]
     fn test_relative_path() {
-        let relative_path = AppendVec::new_relative_path(0, 2);
+        let relative_path = AppendVec::new_relative_path(2);
         let full_path = Path::new("/tmp").join(&relative_path);
         assert_eq!(
             relative_path,


### PR DESCRIPTION
#### Problem

AppendVecs are always created new. We have observed when the snapshot creation is happening that these disk operations of creating new directory/new file can stall for a while and cause bank creation to take multiple seconds.

#### Summary of Changes

When we remove a store from disk, save it to a GC list and re-use it when we need a store later.

TODO:
- [ ] testnet produces incorrect hash errors and no transactions when tested.

Fixes #
