### PR TITLE
Cleanup the sign shreds interface

### DIFF
--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -62,3 +62,6 @@ solana-budget-program = { path = "../programs/budget", version = "0.22.0" }
 [lib]
 crate-type = ["lib"]
 name = "solana_ledger"
+
+[[bench]]
+name = "sigverify_shreds"

--- a/ledger/benches/sigverify_shreds.rs
+++ b/ledger/benches/sigverify_shreds.rs
@@ -45,7 +45,6 @@ fn bench_sigverify_shreds_sign_gpu(bencher: &mut Bencher) {
     for _ in 0..100 {
         sign_shreds_gpu(&keypair, &pinned_keypair, &mut batch, &recycler_cache);
     }
-    //unsigned
     bencher.iter(|| {
         sign_shreds_gpu(&keypair, &pinned_keypair, &mut batch, &recycler_cache);
     })
@@ -71,7 +70,6 @@ fn bench_sigverify_shreds_sign_cpu(bencher: &mut Bencher) {
     }
     let mut batch = vec![packets; NUM_BATCHES];
     let keypair = Keypair::new();
-    //unsigned
     bencher.iter(|| {
         sign_shreds_cpu(&keypair, &mut batch);
     })

--- a/ledger/benches/sigverify_shreds.rs
+++ b/ledger/benches/sigverify_shreds.rs
@@ -1,0 +1,78 @@
+#![feature(test)]
+
+extern crate test;
+use solana_ledger::shred::Shred;
+use solana_ledger::shred::SIZE_OF_DATA_SHRED_PAYLOAD;
+use solana_ledger::sigverify_shreds::{
+    sign_shreds_cpu, sign_shreds_gpu, sign_shreds_gpu_pinned_keypair,
+};
+use solana_perf::packet::{Packet, Packets};
+use solana_perf::recycler_cache::RecyclerCache;
+use solana_sdk::signature::{Keypair, KeypairUtil};
+use std::sync::Arc;
+use test::Bencher;
+
+const NUM_PACKETS: usize = 256;
+const NUM_BATCHES: usize = 1;
+#[bench]
+fn bench_sigverify_shreds_sign_gpu(bencher: &mut Bencher) {
+    let recycler_cache = RecyclerCache::default();
+
+    let mut packets = Packets::default();
+    packets.packets.set_pinnable();
+    let slot = 0xdeadc0de;
+    // need to pin explicitly since the resize will not cause re-allocation
+    packets.packets.reserve_and_pin(NUM_PACKETS);
+    packets.packets.resize(NUM_PACKETS, Packet::default());
+    for p in packets.packets.iter_mut() {
+        let shred = Shred::new_from_data(
+            slot,
+            0xc0de,
+            0xdead,
+            Some(&[5; SIZE_OF_DATA_SHRED_PAYLOAD]),
+            true,
+            true,
+            1,
+            2,
+        );
+        shred.copy_to_packet(p);
+    }
+    let mut batch = vec![packets; NUM_BATCHES];
+    let keypair = Keypair::new();
+    let pinned_keypair = sign_shreds_gpu_pinned_keypair(&keypair, &recycler_cache);
+    let pinned_keypair = Some(Arc::new(pinned_keypair));
+    //warmup
+    for _ in 0..100 {
+        sign_shreds_gpu(&keypair, &pinned_keypair, &mut batch, &recycler_cache);
+    }
+    //unsigned
+    bencher.iter(|| {
+        sign_shreds_gpu(&keypair, &pinned_keypair, &mut batch, &recycler_cache);
+    })
+}
+
+#[bench]
+fn bench_sigverify_shreds_sign_cpu(bencher: &mut Bencher) {
+    let mut packets = Packets::default();
+    let slot = 0xdeadc0de;
+    packets.packets.resize(NUM_PACKETS, Packet::default());
+    for p in packets.packets.iter_mut() {
+        let shred = Shred::new_from_data(
+            slot,
+            0xc0de,
+            0xdead,
+            Some(&[5; SIZE_OF_DATA_SHRED_PAYLOAD]),
+            true,
+            true,
+            1,
+            2,
+        );
+        shred.copy_to_packet(p);
+    }
+    let mut batch = vec![packets; NUM_BATCHES];
+    let keypair = Keypair::new();
+    //unsigned
+    bencher.iter(|| {
+        sign_shreds_cpu(&keypair, &mut batch);
+    })
+}

--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -11,6 +11,7 @@ use rayon::{
 };
 use serde::{Deserialize, Serialize};
 use solana_metrics::datapoint_debug;
+use solana_perf::packet::Packet;
 use solana_rayon_threadlimit::get_thread_count;
 use solana_sdk::{
     clock::Slot,
@@ -135,6 +136,12 @@ impl Shred {
         bincode::serialize_into(&mut buf[*index..*index + size], obj)?;
         *index += size;
         Ok(())
+    }
+
+    pub fn copy_to_packet(&self, packet: &mut Packet) {
+        let len = self.payload.len();
+        packet.data[..len].copy_from_slice(&self.payload[..]);
+        packet.meta.size = len;
     }
 
     pub fn new_from_data(


### PR DESCRIPTION
#### Problem

Sign shreds regenerated the pubkey on every call.

#### Summary of Changes

* api to convert a keypair to a pinned vec
* simplified offset calculations

Fixes #
