### PR TITLE
Strictly sanitize mmapped AppendVec file contents

### DIFF
--- a/runtime/src/append_vec.rs
+++ b/runtime/src/append_vec.rs
@@ -510,7 +510,7 @@ pub mod tests {
             executable_byte
         }
 
-        fn set_exeutable_as_byte(&self, new_executable_byte: u8) {
+        fn set_executable_as_byte(&self, new_executable_byte: u8) {
             let executable_ref: &bool = &self.account_meta.executable;
             #[allow(mutable_transmutes)]
             // UNSAFE: Force to interpret mmap-backed &bool as &u8 to write some crafted value;
@@ -673,7 +673,7 @@ pub mod tests {
         let account = &accounts[0];
         let crafted_executable = u8::max_value() - 1;
 
-        account.set_exeutable_as_byte(crafted_executable);
+        account.set_executable_as_byte(crafted_executable);
 
         // reload crafted accounts
         let accounts = av.accounts(0);

--- a/runtime/src/append_vec.rs
+++ b/runtime/src/append_vec.rs
@@ -676,8 +676,7 @@ pub mod tests {
             // *executable_bool is true but its actual memory value is crafted_executable, not 1
             assert!(*executable_bool != true);
             // UNSAFE: Force to interpret mmap-backed bool as u8 to really read the actual memory content
-            let executable_byte: &u8 =
-                unsafe { std::mem::transmute::<&bool, &u8>(executable_bool) };
+            let executable_byte: &u8 = unsafe { &*(executable_bool as *const bool as *const u8) };
             assert_eq!(*executable_byte, crafted_executable);
         }
 

--- a/runtime/src/append_vec.rs
+++ b/runtime/src/append_vec.rs
@@ -677,9 +677,12 @@ pub mod tests {
         // we can observe crafted value by ref
         {
             let executable_bool: &bool = &account.account_meta.executable;
-            // we can not use assert_eq!...
-            // *executable_bool is true but its actual memory value is crafted_executable, not 1 (=true)
-            assert!(*executable_bool != true);
+            // Depending on use, *executable_bool can be truthy or falsy due to direct memory manipulation
+            // *executable_bool is falsy but its actual memory value is crafted_executable, not 0 (=false)
+            assert_eq!(*executable_bool, false);
+            if *executable_bool == false {
+                panic!("This didn't occur if this test passed.");
+            }
             assert_eq!(*account.ref_executable_byte(), crafted_executable);
         }
 

--- a/runtime/src/append_vec.rs
+++ b/runtime/src/append_vec.rs
@@ -74,7 +74,7 @@ impl<'a> StoredAccount<'a> {
 
     fn sanitize(&self) -> bool {
         // Sanitize executable
-        // Use extra references to avoid value silently cramped to 1 (=true) and 0 (=false)
+        // Use extra references to avoid value silently clamped to 1 (=true) and 0 (=false)
         // Yes, this really happens; see test_set_file_crafted_executable
         let executable_bool: &bool = &self.account_meta.executable;
         // UNSAFE: Force to interpret mmap-backed bool as u8 to ensure higher 7-bits are cleared correctly.

--- a/runtime/src/append_vec.rs
+++ b/runtime/src/append_vec.rs
@@ -678,7 +678,7 @@ pub mod tests {
         {
             let executable_bool: &bool = &account.account_meta.executable;
             // Depending on use, *executable_bool can be truthy or falsy due to direct memory manipulation
-            // *executable_bool is falsy but its actual memory value is crafted_executable, not 0 (=false)
+            // assert_eq! thinks *exeutable_bool is equal to false but the if condition thinks it's not, contradictly.
             assert_eq!(*executable_bool, false);
             if *executable_bool == false {
                 panic!("This didn't occur if this test passed.");

--- a/runtime/src/append_vec.rs
+++ b/runtime/src/append_vec.rs
@@ -75,7 +75,7 @@ impl<'a> StoredAccount<'a> {
     fn sanitize(&self) -> bool {
         // Sanitize executable
         // Use extra references to avoid value silently cramped to 1 (=true) and 0 (=false)
-        // Yes, this really hannpens; see test_set_file_crafted_executable
+        // Yes, this really happens; see test_set_file_crafted_executable
         let executable_bool: &bool = &self.account_meta.executable;
         // UNSAFE: Force to interpret mmap-backed bool as u8 to ensure higher 7-bits are cleared correctly.
         let executable_byte: &u8 = unsafe { &*(executable_bool as *const bool as *const u8) };

--- a/runtime/src/append_vec.rs
+++ b/runtime/src/append_vec.rs
@@ -382,8 +382,8 @@ impl Serialize for AppendVec {
         S: serde::ser::Serializer,
     {
         use serde::ser::Error;
-        let len = std::mem::size_of::<usize>() as u64;
-        let mut buf = vec![0u8; len as usize];
+        let len = std::mem::size_of::<usize>();
+        let mut buf = vec![0u8; len];
         let mut wr = Cursor::new(&mut buf[..]);
         serialize_into(&mut wr, &(self.current_len.load(Ordering::Relaxed) as u64))
             .map_err(Error::custom)?;

--- a/runtime/src/append_vec.rs
+++ b/runtime/src/append_vec.rs
@@ -213,6 +213,11 @@ impl AppendVec {
     fn sanitize_layout_and_length(&self) -> bool {
         let mut offset = 0;
 
+        // This discards allocated accounts immediately after check at each loop iteration.
+        //
+        // This code should not reuse AppendVec.accounts() method as the current form or
+        // extend it to be reused here because it would allow attackers to accumulate
+        // some measurable amount of memory needlessly.
         while let Some((account, next_offset)) = self.get_account(offset) {
             if !account.sanitize() {
                 return false;


### PR DESCRIPTION
#### Problem

Currently, It's very easy to cause DoS with crafted AppendVec data file. That's because `data_len` is directly used to allocate the `data_len` number of `u8[]`, and is used for the offset calculation without overflow check, for example.

Also, I've carefully audited the fields in the `AppendVec` data file this time. Most of fields including `Pubkey`, `Hash` and `lamports` can legally contain arbitrary values for its type domain. So there aren't much to sanitize them at the `AppendVec` layer. However there are only two exceptions: `data_len` and `executable`.

As mentioned before, `data_len` must be sensible `u64` for memory allocation. This is obvious and simple.

And `exeutable` is a bit subtle. It's `bool` consuming 1 bit logically in Rust land, but it consumes 8 bits physically. That means the higher 7 bits are usually not touched, however we must sanitize those bits to be cleared when snapshot ingestion. Otherwise, it's **undefined behavior** so bogus checks for `exeutable` could be possible depending on some myriad of combination of runtime configuration (rust version, compiler optimization, machine architecture, OS varieties).

After all, we should be super careful; we're fearless and very rare people to dare **to mmap completely untrusted (=not even semi-trusted) data directly with minimal sanitization**... :p _We're proudly performance-obsessed. :)_

#### Summary of Changes

- Small preparatory clean up two commits
- The actual meat including some `unsafe {}`s in both **production** and test code (mandatory due to the need to prepare malicious (=crafted) bytes and to guard against it)
  - `data_len`: Protect by the way of strict offset calculation sanitization. This PR doesn't explicitly impose limits on it; In combination with #7373, it'll effectively limit huge memory allocation because `data_len` in this PR won't be greater than AppendVec's `file_size`.
  - `executable`: Simply forbid any bad value other than `0b0000_0000` and `0b0000_00001`.

Part of #7167 