### PR TITLE
Move create_dir_all to AccountsDB::new

### DIFF
--- a/core/src/snapshot_packager_service.rs
+++ b/core/src/snapshot_packager_service.rs
@@ -230,6 +230,7 @@ mod tests {
         let snapshot_package_output_path = temp_dir.join("snapshots_output");
         fs::create_dir_all(&snapshot_package_output_path).unwrap();
 
+        fs::create_dir_all(&accounts_dir).unwrap();
         // Create some storage entries
         let storage_entries: Vec<_> = (0..5)
             .map(|i| Arc::new(AccountStorageEntry::new(&accounts_dir, 0, i, 10)))

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -407,7 +407,7 @@ impl Default for AccountsDB {
 
 impl AccountsDB {
     pub fn new(paths: Vec<PathBuf>) -> Self {
-        if !paths.is_empty() {
+        let new = if !paths.is_empty() {
             Self {
                 paths: RwLock::new(paths),
                 temp_paths: None,
@@ -422,7 +422,14 @@ impl AccountsDB {
                 temp_paths: Some(temp_dirs),
                 ..Self::default()
             }
+        };
+        {
+            let paths = new.paths.read().unwrap();
+            for path in paths.iter() {
+                std::fs::create_dir_all(path).expect("Create directory failed.");
+            }
         }
+        new
     }
 
     #[cfg(test)]

--- a/runtime/src/append_vec.rs
+++ b/runtime/src/append_vec.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use solana_sdk::{account::Account, clock::Epoch, hash::Hash, pubkey::Pubkey};
 use std::{
     fmt,
-    fs::{create_dir_all, remove_file, OpenOptions},
+    fs::{remove_file, OpenOptions},
     io,
     io::{Cursor, Seek, SeekFrom, Write},
     mem,
@@ -95,9 +95,6 @@ impl AppendVec {
     pub fn new(file: &Path, create: bool, size: usize) -> Self {
         if create {
             let _ignored = remove_file(file);
-            if let Some(parent) = file.parent() {
-                create_dir_all(parent).expect("Create directory failed");
-            }
         }
 
         let mut data = OpenOptions::new()


### PR DESCRIPTION
#### Problem

Stalls on `create_dir_all` on AppendVec create.

#### Summary of Changes

Create all paths on AccountsDB constructor and not in AppendVec.

Fixes #
