### PR TITLE
Stop more processes on `net.sh stop/restart/stopnode`

### DIFF
--- a/net/net.sh
+++ b/net/net.sh
@@ -893,8 +893,8 @@ stopNode() {
         rm -f solana/netem.cfg
       fi
       solana/scripts/net-shaper.sh force_cleanup
-      for pattern in node solana- remote-; do
-        pkill -9 \$pattern
+      for pattern in solana- remote- iftop validator client node; do
+        pkill -9 -f \$pattern
       done
     "
   ) >> "$logFile" 2>&1 &


### PR DESCRIPTION
#### Problem
The remote script called during stopnode() is missing `iftop` and `validator.sh` processes, which can cause subsequent cluster starts to fail.

#### Summary of Changes
Extend the `pkill` pattern matching across the command line, and kill anything matching `validator`

Fixes #7475