### PR TITLE
Bump perf-libs version to v0.16.2 to get cudaMalloc opt

### DIFF
--- a/fetch-perf-libs.sh
+++ b/fetch-perf-libs.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-PERF_LIBS_VERSION=v0.16.1
+PERF_LIBS_VERSION=v0.16.2
 VERSION=$PERF_LIBS_VERSION-1
 
 set -e


### PR DESCRIPTION
#### Problem

Perf libs v0.16.1 will sometimes make a cudaFree/cudaMalloc in the `sign_many` path when it doesn't need to.

#### Summary of Changes

Pick up the new version v0.16.2 which doesn't do this.

Fixes #
