### PR TITLE
Pipeline broadcast socket transmit and blocktree record

### DIFF
--- a/core/benches/cluster_info.rs
+++ b/core/benches/cluster_info.rs
@@ -9,6 +9,7 @@ use solana_sdk::pubkey::Pubkey;
 use solana_sdk::timing::timestamp;
 use std::collections::HashMap;
 use std::net::UdpSocket;
+use std::sync::Arc;
 use test::Bencher;
 
 #[bench]
@@ -31,10 +32,11 @@ fn broadcast_shreds_bench(bencher: &mut Bencher) {
         cluster_info.insert_info(contact_info);
         stakes.insert(id, thread_rng().gen_range(1, NUM_PEERS) as u64);
     }
+    let stakes = Arc::new(stakes);
     bencher.iter(move || {
         let shreds = shreds.clone();
         cluster_info
-            .broadcast_shreds(&socket, shreds, &seeds, Some(&stakes))
+            .broadcast_shreds(&socket, shreds, &seeds, Some(stakes.clone()))
             .unwrap();
     });
 }

--- a/core/src/broadcast_stage.rs
+++ b/core/src/broadcast_stage.rs
@@ -189,13 +189,7 @@ impl BroadcastStage {
             .name("solana-broadcaster".to_string())
             .spawn(move || {
                 let _finalizer = Finalizer::new(exit);
-                Self::run(
-                    &btree,
-                    &receiver,
-                    &socket_sender,
-                    &blocktree_sender,
-                    bs_run,
-                )
+                Self::run(&btree, &receiver, &socket_sender, &blocktree_sender, bs_run)
             })
             .unwrap();
         let mut thread_hdls = vec![thread_hdl];
@@ -239,7 +233,7 @@ impl BroadcastStage {
 
     pub fn join(self) -> thread::Result<BroadcastStageReturnType> {
         for thread_hdl in self.thread_hdls.into_iter() {
-            thread_hdl.join();
+            let _ = thread_hdl.join();
         }
         return Ok(BroadcastStageReturnType::ChannelDisconnected);
     }

--- a/core/src/broadcast_stage/broadcast_fake_shreds_run.rs
+++ b/core/src/broadcast_stage/broadcast_fake_shreds_run.rs
@@ -83,15 +83,15 @@ impl BroadcastRun for BroadcastFakeShredsRun {
         }
 
         let data_shreds = Arc::new(data_shreds);
-        blocktree_sender.send(data_shreds.clone());
+        blocktree_sender.send(data_shreds.clone())?;
 
         // 3) Start broadcast step
         //some indicates fake shreds
-        socket_sender.send((Some(Arc::new(HashMap::new())), Arc::new(fake_data_shreds)));
-        socket_sender.send((Some(Arc::new(HashMap::new())), Arc::new(fake_coding_shreds)));
+        socket_sender.send((Some(Arc::new(HashMap::new())), Arc::new(fake_data_shreds)))?;
+        socket_sender.send((Some(Arc::new(HashMap::new())), Arc::new(fake_coding_shreds)))?;
         //none indicates real shreds
-        socket_sender.send((None, data_shreds));
-        socket_sender.send((None, Arc::new(coding_shreds)));
+        socket_sender.send((None, data_shreds))?;
+        socket_sender.send((None, Arc::new(coding_shreds)))?;
 
         Ok(())
     }

--- a/core/src/broadcast_stage/broadcast_fake_shreds_run.rs
+++ b/core/src/broadcast_stage/broadcast_fake_shreds_run.rs
@@ -12,8 +12,7 @@ pub(super) struct BroadcastFakeShredsRun {
 }
 
 impl BroadcastFakeShredsRun {
-    //let keypair = &cluster_info.read().unwrap().keypair.clone();
-    pub(super) fn new(keypair: Keypair, partition: usize, shred_version: u16) -> Self {
+    pub(super) fn new(keypair: Arc<Keypair>, partition: usize, shred_version: u16) -> Self {
         Self {
             last_blockhash: Hash::default(),
             partition,
@@ -29,7 +28,7 @@ impl BroadcastRun for BroadcastFakeShredsRun {
         blocktree: &Arc<Blocktree>,
         receiver: &Receiver<WorkingBankEntry>,
         socket_sender: &Sender<(Option<Arc<HashMap<Pubkey, u64>>>, Arc<Vec<Shred>>)>,
-        blocktree_sender: &Receiver<Arc<Vec<Shred>>>,
+        blocktree_sender: &Sender<Arc<Vec<Shred>>>,
     ) -> Result<()> {
         // 1) Pull entries from banking stage
         let receive_results = broadcast_utils::recv_slot_entries(receiver)?;

--- a/core/src/broadcast_stage/broadcast_fake_shreds_run.rs
+++ b/core/src/broadcast_stage/broadcast_fake_shreds_run.rs
@@ -1,5 +1,6 @@
 use super::*;
 use solana_ledger::entry::Entry;
+use solana_sdk::signature::Keypair;
 use solana_ledger::shred::{Shredder, RECOMMENDED_FEC_RATE};
 use solana_sdk::hash::Hash;
 
@@ -7,14 +8,17 @@ pub(super) struct BroadcastFakeShredsRun {
     last_blockhash: Hash,
     partition: usize,
     shred_version: u16,
+    keypair: Arc<Keypair>,
 }
 
 impl BroadcastFakeShredsRun {
-    pub(super) fn new(partition: usize, shred_version: u16) -> Self {
+    //let keypair = &cluster_info.read().unwrap().keypair.clone();
+    pub(super) fn new(keypair: Keypair, partition: usize, shred_version: u16) -> Self {
         Self {
             last_blockhash: Hash::default(),
             partition,
             shred_version,
+            keypair,
         }
     }
 }
@@ -22,17 +26,16 @@ impl BroadcastFakeShredsRun {
 impl BroadcastRun for BroadcastFakeShredsRun {
     fn run(
         &mut self,
-        cluster_info: &Arc<RwLock<ClusterInfo>>,
-        receiver: &Receiver<WorkingBankEntry>,
-        sock: &UdpSocket,
         blocktree: &Arc<Blocktree>,
+        receiver: &Receiver<WorkingBankEntry>,
+        socket_sender: &Sender<(Option<Arc<HashMap<Pubkey, u64>>>, Arc<Vec<Shred>>)>,
+        blocktree_sender: &Receiver<Arc<Vec<Shred>>>,
     ) -> Result<()> {
         // 1) Pull entries from banking stage
         let receive_results = broadcast_utils::recv_slot_entries(receiver)?;
         let bank = receive_results.bank.clone();
         let last_tick_height = receive_results.last_tick_height;
 
-        let keypair = &cluster_info.read().unwrap().keypair.clone();
         let next_shred_index = blocktree
             .meta(bank.slot())
             .expect("Database error")
@@ -45,7 +48,7 @@ impl BroadcastRun for BroadcastFakeShredsRun {
             bank.slot(),
             bank.parent().unwrap().slot(),
             RECOMMENDED_FEC_RATE,
-            keypair.clone(),
+            self.keypair.clone(),
             (bank.tick_height() % bank.ticks_per_slot()) as u8,
             self.shred_version,
         )
@@ -79,31 +82,54 @@ impl BroadcastRun for BroadcastFakeShredsRun {
             self.last_blockhash = Hash::default();
         }
 
-        blocktree.insert_shreds(data_shreds.clone(), None, true)?;
+        blocktree_sender.send(data_shreds.clone());
 
         // 3) Start broadcast step
-        let peers = cluster_info.read().unwrap().tvu_peers();
-        peers.iter().enumerate().for_each(|(i, peer)| {
-            if i <= self.partition {
-                // Send fake shreds to the first N peers
-                fake_data_shreds
-                    .iter()
-                    .chain(fake_coding_shreds.iter())
-                    .for_each(|b| {
-                        sock.send_to(&b.payload, &peer.tvu_forwards).unwrap();
-                    });
-            } else {
-                data_shreds
-                    .iter()
-                    .chain(coding_shreds.iter())
-                    .for_each(|b| {
-                        sock.send_to(&b.payload, &peer.tvu_forwards).unwrap();
-                    });
-            }
-        });
+        //some indicates fake shreds
+        socket_sender.send((Some(HashMap::new()), fake_data_shreds));
+        socket_sender.send((Some(HashMap::new()), fake_coding_shreds));
+        //none indicates real shreds
+        socket_sender.send((None, data_shreds));
+        socket_sender.send((None, coding_shreds));
 
         Ok(())
     }
+    fn transmit(
+        &self,
+        receiver: &Receiver<(Option<Arc<HashMap<Pubkey, u64>>>, Arc<Vec<Shred>>)>,
+        cluster_info: &Arc<RwLock<ClusterInfo>>,
+        sock: &UdpSocket,
+    ) -> Result<()> {
+        for (stakes, data_shreds) in receiver.iter() {
+            let peers = cluster_info.read().unwrap().tvu_peers();
+            peers.iter().enumerate().for_each(|(i, peer)| {
+                if i <= self.partition && stakes.is_some() {
+                    // Send fake shreds to the first N peers
+                    data_shreds
+                        .iter()
+                        .for_each(|b| {
+                            sock.send_to(&b.payload, &peer.tvu_forwards).unwrap();
+                        });
+                } else if i > self.partition && stakes.is_none() {
+                    data_shreds
+                        .iter()
+                        .for_each(|b| {
+                            sock.send_to(&b.payload, &peer.tvu_forwards).unwrap();
+                        });
+                }
+            });
+        }
+    }
+    fn record(
+        &self,
+        receiver: &Receiver<Arc<Vec<Shred>>>,
+        blocktree: &Arc<Blocktree>,
+    ) -> Result<()> {
+        for data_shreds in receiver.iter() {
+            blocktree.insert_shreds(data_shreds, None, true)?;
+        }
+    }
+
 }
 
 #[cfg(test)]

--- a/core/src/broadcast_stage/broadcast_fake_shreds_run.rs
+++ b/core/src/broadcast_stage/broadcast_fake_shreds_run.rs
@@ -28,7 +28,7 @@ impl BroadcastRun for BroadcastFakeShredsRun {
         &mut self,
         blocktree: &Arc<Blocktree>,
         receiver: &Receiver<WorkingBankEntry>,
-        socket_sender: &Sender<(Option<Arc<HashMap<Pubkey, u64>>>, Arc<Vec<Shred>>)>,
+        socket_sender: &Sender<TransmitShreds>,
         blocktree_sender: &Sender<Arc<Vec<Shred>>>,
     ) -> Result<()> {
         // 1) Pull entries from banking stage
@@ -97,7 +97,7 @@ impl BroadcastRun for BroadcastFakeShredsRun {
     }
     fn transmit(
         &self,
-        receiver: &Arc<Mutex<Receiver<(Option<Arc<HashMap<Pubkey, u64>>>, Arc<Vec<Shred>>)>>>,
+        receiver: &Arc<Mutex<Receiver<TransmitShreds>>>,
         cluster_info: &Arc<RwLock<ClusterInfo>>,
         sock: &UdpSocket,
     ) -> Result<()> {

--- a/core/src/broadcast_stage/fail_entry_verification_broadcast_run.rs
+++ b/core/src/broadcast_stage/fail_entry_verification_broadcast_run.rs
@@ -10,7 +10,6 @@ pub(super) struct FailEntryVerificationBroadcastRun {
 }
 
 impl FailEntryVerificationBroadcastRun {
-    //let keypair = cluster_info.read().unwrap().keypair.clone();
     pub(super) fn new(keypair: Arc<Keypair>, shred_version: u16) -> Self {
         Self {
             shred_version,

--- a/core/src/broadcast_stage/fail_entry_verification_broadcast_run.rs
+++ b/core/src/broadcast_stage/fail_entry_verification_broadcast_run.rs
@@ -24,7 +24,7 @@ impl BroadcastRun for FailEntryVerificationBroadcastRun {
         &mut self,
         blocktree: &Arc<Blocktree>,
         receiver: &Receiver<WorkingBankEntry>,
-        socket_sender: &Sender<(Option<Arc<HashMap<Pubkey, u64>>>, Arc<Vec<Shred>>)>,
+        socket_sender: &Sender<TransmitShreds>,
         blocktree_sender: &Sender<Arc<Vec<Shred>>>,
     ) -> Result<()> {
         // 1) Pull entries from banking stage
@@ -67,14 +67,14 @@ impl BroadcastRun for FailEntryVerificationBroadcastRun {
         let bank_epoch = bank.get_leader_schedule_epoch(bank.slot());
         let stakes = staking_utils::staked_nodes_at_epoch(&bank, bank_epoch);
 
-        let stakes = stakes.map(|s| Arc::new(s));
+        let stakes = stakes.map(Arc::new);
         socket_sender.send((stakes.clone(), data_shreds))?;
         socket_sender.send((stakes, Arc::new(coding_shreds)))?;
         Ok(())
     }
     fn transmit(
         &self,
-        receiver: &Arc<Mutex<Receiver<(Option<Arc<HashMap<Pubkey, u64>>>, Arc<Vec<Shred>>)>>>,
+        receiver: &Arc<Mutex<Receiver<TransmitShreds>>>,
         cluster_info: &Arc<RwLock<ClusterInfo>>,
         sock: &UdpSocket,
     ) -> Result<()> {

--- a/core/src/broadcast_stage/standard_broadcast_run.rs
+++ b/core/src/broadcast_stage/standard_broadcast_run.rs
@@ -275,26 +275,26 @@ impl BroadcastRun for StandardBroadcastRun {
         blocktree: &Arc<Blocktree>,
         receiver: &Receiver<WorkingBankEntry>,
         socket_sender: &Sender<(Option<Arc<HashMap<Pubkey, u64>>>, Arc<Vec<Shred>>)>,
-        blocktree_sender: &Receiver<Arc<Vec<Shred>>>,
+        blocktree_sender: &Sender<Arc<Vec<Shred>>>,
     ) -> Result<()> {
         let receive_results = broadcast_utils::recv_slot_entries(receiver)?;
         self.process_receive_results(blocktree, socket_sender, blocktree_sender, receive_results)
     }
     fn transmit(
         &self,
-        receiver: &Receiver<(Option<Arc<HashMap<Pubkey, u64>>>, Arc<Vec<Shred>>)>,
+        receiver: &Arc<Mutex<Receiver<(Option<Arc<HashMap<Pubkey, u64>>>, Arc<Vec<Shred>>)>>>,
         cluster_info: &Arc<RwLock<ClusterInfo>>,
         sock: &UdpSocket,
     ) -> Result<()> {
-        let (stakes, shreds) = receiver.recv()?;
+        let (stakes, shreds) = receiver.lock().unwrap().recv()?;
         self.broadcast(cluster_info, sock, stakes, shreds);
     }
     fn record(
         &self,
-        receiver: &Receiver<Arc<Vec<Shred>>>,
+        receiver: &Arc<Mutex<Receiver<Arc<Vec<Shred>>>>>,
         blocktree: &Arc<Blocktree>,
     ) -> Result<()> {
-        let (stakes, shreds) = receiver.recv()?;
+        let (stakes, shreds) = receiver.lock().unwrap().recv()?;
         self.insert(blocktree, shreds);
     }
 }

--- a/core/src/broadcast_stage/standard_broadcast_run.rs
+++ b/core/src/broadcast_stage/standard_broadcast_run.rs
@@ -128,7 +128,7 @@ impl StandardBroadcastRun {
     fn process_receive_results(
         &mut self,
         blocktree: &Arc<Blocktree>,
-        socket_sender: &Sender<(Option<Arc<HashMap<Pubkey, u64>>>, Arc<Vec<Shred>>)>,
+        socket_sender: &Sender<TransmitShreds>,
         blocktree_sender: &Sender<Arc<Vec<Shred>>>,
         receive_results: ReceiveResults,
     ) -> Result<()> {
@@ -169,7 +169,7 @@ impl StandardBroadcastRun {
 
         let bank_epoch = bank.get_leader_schedule_epoch(bank.slot());
         let stakes = staking_utils::staked_nodes_at_epoch(&bank, bank_epoch);
-        let stakes = stakes.map(|s| Arc::new(s));
+        let stakes = stakes.map(Arc::new);
         let data_shreds = Arc::new(data_shreds);
         socket_sender.send((stakes.clone(), data_shreds.clone()))?;
         let coding_shreds = Arc::new(coding_shreds);
@@ -275,7 +275,7 @@ impl BroadcastRun for StandardBroadcastRun {
         &mut self,
         blocktree: &Arc<Blocktree>,
         receiver: &Receiver<WorkingBankEntry>,
-        socket_sender: &Sender<(Option<Arc<HashMap<Pubkey, u64>>>, Arc<Vec<Shred>>)>,
+        socket_sender: &Sender<TransmitShreds>,
         blocktree_sender: &Sender<Arc<Vec<Shred>>>,
     ) -> Result<()> {
         let receive_results = broadcast_utils::recv_slot_entries(receiver)?;
@@ -283,7 +283,7 @@ impl BroadcastRun for StandardBroadcastRun {
     }
     fn transmit(
         &self,
-        receiver: &Arc<Mutex<Receiver<(Option<Arc<HashMap<Pubkey, u64>>>, Arc<Vec<Shred>>)>>>,
+        receiver: &Arc<Mutex<Receiver<TransmitShreds>>>,
         cluster_info: &Arc<RwLock<ClusterInfo>>,
         sock: &UdpSocket,
     ) -> Result<()> {

--- a/core/src/broadcast_stage/standard_broadcast_run.rs
+++ b/core/src/broadcast_stage/standard_broadcast_run.rs
@@ -282,7 +282,7 @@ impl BroadcastRun for StandardBroadcastRun {
     }
     fn transmit(
         &self,
-        receiver: &Receiver<Arc<Vec<Shred>>>,
+        receiver: &Receiver<(Option<Arc<HashMap<Pubkey, u64>>>, Arc<Vec<Shred>>)>,
         cluster_info: &Arc<RwLock<ClusterInfo>>,
         sock: &UdpSocket,
     ) -> Result<()> {

--- a/core/src/cluster_info.rs
+++ b/core/src/cluster_info.rs
@@ -526,7 +526,11 @@ impl ClusterInfo {
             .map(|(i, c)| {
                 // For stake weighted shuffle a valid weight is atleast 1. Weight 0 is
                 // assumed to be missing entry. So let's make sure stake weights are atleast 1
-                let stake = 1.max(stakes.map_or(1, |stakes| *stakes.get(&c.id).unwrap_or(&1)));
+                let stake = 1.max(
+                    stakes
+                        .as_ref()
+                        .map_or(1, |stakes| *stakes.get(&c.id).unwrap_or(&1)),
+                );
                 (stake, i)
             })
             .sorted_by(|(l_stake, l_info), (r_stake, r_info)| {

--- a/core/src/cluster_info.rs
+++ b/core/src/cluster_info.rs
@@ -518,7 +518,7 @@ impl ClusterInfo {
 
     fn sorted_stakes_with_index<S: std::hash::BuildHasher>(
         peers: &[ContactInfo],
-        stakes: Option<&HashMap<Pubkey, u64, S>>,
+        stakes: Option<Arc<HashMap<Pubkey, u64, S>>>,
     ) -> Vec<(u64, usize)> {
         let stakes_and_index: Vec<_> = peers
             .iter()
@@ -555,7 +555,7 @@ impl ClusterInfo {
     // Return sorted_retransmit_peers(including self) and their stakes
     pub fn sorted_retransmit_peers_and_stakes(
         &self,
-        stakes: Option<&HashMap<Pubkey, u64>>,
+        stakes: Option<Arc<HashMap<Pubkey, u64>>>,
     ) -> (Vec<ContactInfo>, Vec<(u64, usize)>) {
         let mut peers = self.retransmit_peers();
         // insert "self" into this list for the layer and neighborhood computation
@@ -729,7 +729,7 @@ impl ClusterInfo {
 
     fn sorted_tvu_peers_and_stakes(
         &self,
-        stakes: Option<&HashMap<Pubkey, u64>>,
+        stakes: Option<Arc<HashMap<Pubkey, u64>>>,
     ) -> (Vec<ContactInfo>, Vec<(u64, usize)>) {
         let mut peers = self.tvu_peers();
         peers.dedup();
@@ -744,7 +744,7 @@ impl ClusterInfo {
         s: &UdpSocket,
         shreds: Vec<Vec<u8>>,
         seeds: &[[u8; 32]],
-        stakes: Option<&HashMap<Pubkey, u64>>,
+        stakes: Option<Arc<HashMap<Pubkey, u64>>>,
     ) -> Result<()> {
         let (peers, peers_and_stakes) = self.sorted_tvu_peers_and_stakes(stakes);
         let broadcast_len = peers_and_stakes.len();

--- a/core/src/cluster_info.rs
+++ b/core/src/cluster_info.rs
@@ -2662,7 +2662,8 @@ mod tests {
         cluster_info.insert_info(contact_info);
         stakes.insert(id3, 10);
 
-        let (peers, peers_and_stakes) = cluster_info.sorted_tvu_peers_and_stakes(Some(&stakes));
+        let stakes = Arc::new(stakes);
+        let (peers, peers_and_stakes) = cluster_info.sorted_tvu_peers_and_stakes(Some(stakes));
         assert_eq!(peers.len(), 2);
         assert_eq!(peers[0].id, id);
         assert_eq!(peers[1].id, id2);

--- a/core/src/cluster_info.rs
+++ b/core/src/cluster_info.rs
@@ -1703,7 +1703,7 @@ pub struct Sockets {
     pub tvu_forwards: Vec<UdpSocket>,
     pub tpu: Vec<UdpSocket>,
     pub tpu_forwards: Vec<UdpSocket>,
-    pub broadcast: UdpSocket,
+    pub broadcast: Vec<UdpSocket>,
     pub repair: UdpSocket,
     pub retransmit_sockets: Vec<UdpSocket>,
     pub storage: Option<UdpSocket>,
@@ -1728,7 +1728,7 @@ impl Node {
         let empty = "0.0.0.0:0".parse().unwrap();
         let repair = UdpSocket::bind("127.0.0.1:0").unwrap();
 
-        let broadcast = UdpSocket::bind("0.0.0.0:0").unwrap();
+        let broadcast = vec![UdpSocket::bind("0.0.0.0:0").unwrap()];
         let retransmit = UdpSocket::bind("0.0.0.0:0").unwrap();
         let info = ContactInfo::new(
             pubkey,
@@ -1774,7 +1774,7 @@ impl Node {
         let rpc_pubsub_addr =
             SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), rpc_pubsub_port);
 
-        let broadcast = UdpSocket::bind("0.0.0.0:0").unwrap();
+        let broadcast = vec![UdpSocket::bind("0.0.0.0:0").unwrap()];
         let retransmit_socket = UdpSocket::bind("0.0.0.0:0").unwrap();
         let storage = UdpSocket::bind("0.0.0.0:0").unwrap();
         let info = ContactInfo::new(
@@ -1845,7 +1845,7 @@ impl Node {
             multi_bind_in_range(port_range, 8).expect("retransmit multi_bind");
 
         let (repair_port, repair) = Self::bind(port_range);
-        let (_, broadcast) = Self::bind(port_range);
+        let (_, broadcast) = multi_bind_in_range(port_range, 4).expect("broadcast multi_bind");
 
         let info = ContactInfo::new(
             pubkey,

--- a/core/src/retransmit_stage.rs
+++ b/core/src/retransmit_stage.rs
@@ -62,7 +62,7 @@ fn retransmit(
     let bank_epoch = r_bank.get_leader_schedule_epoch(r_bank.slot());
     let mut peers_len = 0;
     let stakes = staking_utils::staked_nodes_at_epoch(&r_bank, bank_epoch);
-    let stakes = stakes.map(|s| Arc::new(s));
+    let stakes = stakes.map(Arc::new);
     let (peers, stakes_and_index) = cluster_info
         .read()
         .unwrap()

--- a/core/src/retransmit_stage.rs
+++ b/core/src/retransmit_stage.rs
@@ -62,10 +62,11 @@ fn retransmit(
     let bank_epoch = r_bank.get_leader_schedule_epoch(r_bank.slot());
     let mut peers_len = 0;
     let stakes = staking_utils::staked_nodes_at_epoch(&r_bank, bank_epoch);
+    let stakes = stakes.map(|s| Arc::new(s));
     let (peers, stakes_and_index) = cluster_info
         .read()
         .unwrap()
-        .sorted_retransmit_peers_and_stakes(stakes.as_ref());
+        .sorted_retransmit_peers_and_stakes(stakes);
     let me = cluster_info.read().unwrap().my_data().clone();
     let mut discard_total = 0;
     let mut repair_total = 0;

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -39,7 +39,7 @@ impl Tpu {
         entry_receiver: Receiver<WorkingBankEntry>,
         transactions_sockets: Vec<UdpSocket>,
         tpu_forwards_sockets: Vec<UdpSocket>,
-        broadcast_socket: UdpSocket,
+        broadcast_sockets: Vec<UdpSocket>,
         sigverify_disabled: bool,
         transaction_status_sender: Option<TransactionStatusSender>,
         blocktree: &Arc<Blocktree>,
@@ -83,7 +83,7 @@ impl Tpu {
         );
 
         let broadcast_stage = broadcast_type.new_broadcast_stage(
-            broadcast_socket,
+            broadcast_sockets,
             cluster_info.clone(),
             entry_receiver,
             &exit,

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -432,7 +432,12 @@ impl Validator {
         );
         info!(
             "local broadcast address: {}",
-            node.sockets.broadcast.first().unwrap().local_addr().unwrap()
+            node.sockets
+                .broadcast
+                .first()
+                .unwrap()
+                .local_addr()
+                .unwrap()
         );
         info!(
             "local repair address: {}",

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -432,7 +432,7 @@ impl Validator {
         );
         info!(
             "local broadcast address: {}",
-            node.sockets.broadcast.local_addr().unwrap()
+            node.sockets.broadcast.first().unwrap().local_addr().unwrap()
         );
         info!(
             "local repair address: {}",

--- a/core/tests/cluster_info.rs
+++ b/core/tests/cluster_info.rs
@@ -75,7 +75,7 @@ fn run_simulation(stakes: &[u64], fanout: usize) {
     let mut cluster_info = ClusterInfo::new_with_invalid_keypair(leader_info.clone());
 
     // setup staked nodes
-    let mut staked_nodes = HashMap::new();
+    let mut staked_nodes = Arc::new(HashMap::new());
 
     // setup accounts for all nodes (leader has 0 bal)
     let (s, r) = channel();

--- a/core/tests/cluster_info.rs
+++ b/core/tests/cluster_info.rs
@@ -75,7 +75,7 @@ fn run_simulation(stakes: &[u64], fanout: usize) {
     let mut cluster_info = ClusterInfo::new_with_invalid_keypair(leader_info.clone());
 
     // setup staked nodes
-    let mut staked_nodes = Arc::new(HashMap::new());
+    let mut staked_nodes = HashMap::new();
 
     // setup accounts for all nodes (leader has 0 bal)
     let (s, r) = channel();
@@ -107,13 +107,14 @@ fn run_simulation(stakes: &[u64], fanout: usize) {
     });
     let c_info = cluster_info.clone();
 
+    let staked_nodes = Arc::new(staked_nodes);
     let shreds_len = 100;
     let shuffled_peers: Vec<Vec<ContactInfo>> = (0..shreds_len as i32)
         .map(|i| {
             let mut seed = [0; 32];
             seed[0..4].copy_from_slice(&i.to_le_bytes());
             let (peers, stakes_and_index) =
-                cluster_info.sorted_retransmit_peers_and_stakes(Some(&staked_nodes));
+                cluster_info.sorted_retransmit_peers_and_stakes(Some(staked_nodes.clone()));
             let (_, shuffled_stakes_and_indexes) = ClusterInfo::shuffle_peers_and_index(
                 &cluster_info.id(),
                 &peers,

--- a/ledger/benches/sigverify_shreds.rs
+++ b/ledger/benches/sigverify_shreds.rs
@@ -34,6 +34,7 @@ fn bench_sigverify_shreds_sign_gpu(bencher: &mut Bencher) {
             true,
             1,
             2,
+            0,
         );
         shred.copy_to_packet(p);
     }
@@ -65,6 +66,7 @@ fn bench_sigverify_shreds_sign_cpu(bencher: &mut Bencher) {
             true,
             1,
             2,
+            0,
         );
         shred.copy_to_packet(p);
     }

--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -402,8 +402,8 @@ impl Shred {
 
 #[derive(Debug)]
 pub struct Shredder {
-    slot: Slot,
-    parent_slot: Slot,
+    pub slot: Slot,
+    pub parent_slot: Slot,
     version: u16,
     fec_rate: f32,
     keypair: Arc<Keypair>,

--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -436,6 +436,7 @@ impl Shredder {
             })
         }
     }
+
     pub fn entries_to_shreds(
         &self,
         entries: &[Entry],
@@ -445,7 +446,7 @@ impl Shredder {
         let (data_shreds, last_shred_index) =
             self.entries_to_data_shreds(entries, is_last_in_slot, next_shred_index);
         let coding_shreds = self.data_shreds_to_coding_shreds(&data_shreds);
-        (data_shreds, coding_shreds, last_shred_index + 1)
+        (data_shreds, coding_shreds, last_shred_index)
     }
 
     pub fn entries_to_data_shreds(

--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -436,13 +436,23 @@ impl Shredder {
             })
         }
     }
-
     pub fn entries_to_shreds(
         &self,
         entries: &[Entry],
         is_last_in_slot: bool,
         next_shred_index: u32,
     ) -> (Vec<Shred>, Vec<Shred>, u32) {
+    let (data_shreds, last_shred_index) = self.entries_to_data_shreds(entries, is_last_in_slot, next_shred_index);
+    let coding_shreds = self.data_shreds_to_coding_shreds(&data_shreds); 
+        (data_shreds, coding_shreds, last_shred_index + 1)
+    }
+
+    pub fn entries_to_data_shreds(
+        &self,
+        entries: &[Entry],
+        is_last_in_slot: bool,
+        next_shred_index: u32,
+    ) -> (Vec<Shred>, u32) {
         let now = Instant::now();
         let serialized_shreds =
             bincode::serialize(entries).expect("Expect to serialize all entries");
@@ -495,7 +505,17 @@ impl Shredder {
             })
         });
         let gen_data_time = now.elapsed().as_millis();
+        datapoint_debug!(
+            "shredding-stats",
+            ("slot", self.slot as i64, i64),
+            ("num_data_shreds", data_shreds.len() as i64, i64),
+            ("serializing", serialize_time as i64, i64),
+            ("gen_data", gen_data_time as i64, i64),
+        );
+        (data_shreds, last_shred_index + 1)
+    }
 
+    pub fn  data_shreds_to_coding_shreds(&self, data_shreds: &[Shred]) -> Vec<Shred> {
         let now = Instant::now();
         // 2) Generate coding shreds
         let mut coding_shreds: Vec<_> = PAR_THREAD_POOL.with(|thread_pool| {
@@ -528,16 +548,11 @@ impl Shredder {
 
         datapoint_debug!(
             "shredding-stats",
-            ("slot", self.slot as i64, i64),
-            ("num_data_shreds", data_shreds.len() as i64, i64),
             ("num_coding_shreds", coding_shreds.len() as i64, i64),
-            ("serializing", serialize_time as i64, i64),
-            ("gen_data", gen_data_time as i64, i64),
             ("gen_coding", gen_coding_time as i64, i64),
             ("sign_coding", sign_coding_time as i64, i64),
         );
-
-        (data_shreds, coding_shreds, last_shred_index + 1)
+        coding_shreds
     }
 
     pub fn sign_shred(signer: &Keypair, shred: &mut Shred) {

--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -442,8 +442,9 @@ impl Shredder {
         is_last_in_slot: bool,
         next_shred_index: u32,
     ) -> (Vec<Shred>, Vec<Shred>, u32) {
-    let (data_shreds, last_shred_index) = self.entries_to_data_shreds(entries, is_last_in_slot, next_shred_index);
-    let coding_shreds = self.data_shreds_to_coding_shreds(&data_shreds); 
+        let (data_shreds, last_shred_index) =
+            self.entries_to_data_shreds(entries, is_last_in_slot, next_shred_index);
+        let coding_shreds = self.data_shreds_to_coding_shreds(&data_shreds);
         (data_shreds, coding_shreds, last_shred_index + 1)
     }
 
@@ -515,7 +516,7 @@ impl Shredder {
         (data_shreds, last_shred_index + 1)
     }
 
-    pub fn  data_shreds_to_coding_shreds(&self, data_shreds: &[Shred]) -> Vec<Shred> {
+    pub fn data_shreds_to_coding_shreds(&self, data_shreds: &[Shred]) -> Vec<Shred> {
         let now = Instant::now();
         // 2) Generate coding shreds
         let mut coding_shreds: Vec<_> = PAR_THREAD_POOL.with(|thread_pool| {

--- a/net-utils/src/ip_echo_server.rs
+++ b/net-utils/src/ip_echo_server.rs
@@ -15,8 +15,8 @@ pub type IpEchoServer = Runtime;
 
 #[derive(Serialize, Deserialize, Default)]
 pub(crate) struct IpEchoServerMessage {
-    tcp_ports: [u16; 4], // Fixed size list of ports to avoid vec serde
-    udp_ports: [u16; 4], // Fixed size list of ports to avoid vec serde
+    tcp_ports: [u16; 8], // Fixed size list of ports to avoid vec serde
+    udp_ports: [u16; 8], // Fixed size list of ports to avoid vec serde
 }
 
 impl IpEchoServerMessage {

--- a/net-utils/src/ip_echo_server.rs
+++ b/net-utils/src/ip_echo_server.rs
@@ -15,8 +15,8 @@ pub type IpEchoServer = Runtime;
 
 #[derive(Serialize, Deserialize, Default)]
 pub(crate) struct IpEchoServerMessage {
-    tcp_ports: [u16; 8], // Fixed size list of ports to avoid vec serde
-    udp_ports: [u16; 8], // Fixed size list of ports to avoid vec serde
+    tcp_ports: [u16; 4], // Fixed size list of ports to avoid vec serde
+    udp_ports: [u16; 4], // Fixed size list of ports to avoid vec serde
 }
 
 impl IpEchoServerMessage {

--- a/perf/benches/sigverify.rs
+++ b/perf/benches/sigverify.rs
@@ -35,10 +35,6 @@ fn bench_get_offsets(bencher: &mut Bencher) {
     bencher.iter(|| {
         let ans = sigverify::generate_offsets(&batches, &recycler);
         assert!(ans.is_ok());
-        let ans = ans.unwrap();
-        recycler.recycle(ans.0);
-        recycler.recycle(ans.1);
-        recycler.recycle(ans.2);
-        recycler.recycle(ans.3);
+        let _ans = ans.unwrap();
     })
 }

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -761,10 +761,7 @@ pub fn main() {
     };
 
     if let Some(ref cluster_entrypoint) = cluster_entrypoint {
-        let mut udp_sockets = vec![&node.sockets.gossip, &node.sockets.repair];
-        if let Some(s) = node.sockets.broadcast.first() {
-            udp_sockets.push(s)
-        }
+        let udp_sockets = vec![&node.sockets.gossip, &node.sockets.repair];
 
         let mut tcp_listeners: Vec<(_, _)> = tcp_ports
             .iter()

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -762,7 +762,9 @@ pub fn main() {
 
     if let Some(ref cluster_entrypoint) = cluster_entrypoint {
         let mut udp_sockets = vec![&node.sockets.gossip, &node.sockets.repair];
-        node.sockets.broadcast.first().map(|s| udp_sockets.push(s));
+        if let Some(s) = node.sockets.broadcast.first() {
+            udp_sockets.push(s)
+        }
 
         let mut tcp_listeners: Vec<(_, _)> = tcp_ports
             .iter()

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -761,11 +761,11 @@ pub fn main() {
     };
 
     if let Some(ref cluster_entrypoint) = cluster_entrypoint {
-        let udp_sockets = [
-            &node.sockets.gossip,
-            &node.sockets.broadcast,
-            &node.sockets.repair,
-        ];
+        let mut udp_sockets = vec![&node.sockets.gossip, &node.sockets.repair];
+        node.sockets
+            .broadcast
+            .iter()
+            .for_each(|s| udp_sockets.push(s));
 
         let mut tcp_listeners: Vec<(_, _)> = tcp_ports
             .iter()

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -762,10 +762,7 @@ pub fn main() {
 
     if let Some(ref cluster_entrypoint) = cluster_entrypoint {
         let mut udp_sockets = vec![&node.sockets.gossip, &node.sockets.repair];
-        node.sockets
-            .broadcast
-            .first()
-            .map(|s| udp_sockets.push(s));
+        node.sockets.broadcast.first().map(|s| udp_sockets.push(s));
 
         let mut tcp_listeners: Vec<(_, _)> = tcp_ports
             .iter()

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -764,8 +764,8 @@ pub fn main() {
         let mut udp_sockets = vec![&node.sockets.gossip, &node.sockets.repair];
         node.sockets
             .broadcast
-            .iter()
-            .for_each(|s| udp_sockets.push(s));
+            .first()
+            .map(|s| udp_sockets.push(s));
 
         let mut tcp_listeners: Vec<(_, _)> = tcp_ports
             .iter()


### PR DESCRIPTION
#### Problem

Broadcast stage does a sequential 
1. generate shreds (a bunch of steps)
2. send data shreds
3. record blocktree shrds
4. send coding shreds

#### Summary of Changes

split out record and send Into their own threads.  Sockets, blocktree, signing touch 3 different pieces of hardware.  

new pipeline looks like
```
1. generate data shreds
2. async send data shreds
3. async record data shreds
4. generate coding shreds
5. async send coding shreds
```

Broadcast spikes are gone!!!  Confirmation time is 40% better.  Seems like we lost 7% of average perf, but peaks are 20% higher.  Seems like a win.  I am also seeing 200+ shreds to sign, so it might start making sense to go to the GPU.


Before:

<img width="680" alt="Screen Shot 2019-12-14 at 1 17 37 PM" src="https://user-images.githubusercontent.com/1029046/70854704-4de34100-1e74-11ea-8d76-4fa8164e7f5f.png">
<img width="1280" alt="Screen Shot 2019-12-14 at 1 17 48 PM" src="https://user-images.githubusercontent.com/1029046/70854706-4fad0480-1e74-11ea-8dee-1024a7f0e0d5.png">

After:
<img width="691" alt="Screen Shot 2019-12-14 at 12 41 07 PM" src="https://user-images.githubusercontent.com/1029046/70854713-5f2c4d80-1e74-11ea-9684-15cbb27f2160.png">
<img width="1280" alt="Screen Shot 2019-12-14 at 12 41 23 PM" src="https://user-images.githubusercontent.com/1029046/70854718-62273e00-1e74-11ea-9786-520de735be1b.png">


Fixes #
