### PR TITLE
Limit minimum rent exempt balance to as low as 1 lamport

### DIFF
--- a/core/src/commitment.rs
+++ b/core/src/commitment.rs
@@ -238,7 +238,7 @@ mod tests {
     use super::*;
     use crate::genesis_utils::{create_genesis_config, GenesisConfigInfo};
     use solana_sdk::pubkey::Pubkey;
-    use solana_stake_program::stake_state;
+    use solana_stake_program::stake_state::{self, StakeState};
     use solana_vote_program::vote_state;
 
     #[test]
@@ -430,14 +430,16 @@ mod tests {
 
         let sk1 = Pubkey::new_rand();
         let pk1 = Pubkey::new_rand();
+        let rent = &genesis_config.rent;
         let mut vote_account1 = vote_state::create_account(&pk1, &Pubkey::new_rand(), 0, 100);
+        let min_stake_balance = StakeState::get_rent_exempt_reserve(rent);
         let stake_account1 =
-            stake_state::create_account(&sk1, &pk1, &vote_account1, &genesis_config.rent, 100);
+            stake_state::create_account(&sk1, &pk1, &vote_account1, rent, 100 + min_stake_balance);
         let sk2 = Pubkey::new_rand();
         let pk2 = Pubkey::new_rand();
         let mut vote_account2 = vote_state::create_account(&pk2, &Pubkey::new_rand(), 0, 50);
         let stake_account2 =
-            stake_state::create_account(&sk2, &pk2, &vote_account2, &genesis_config.rent, 50);
+            stake_state::create_account(&sk2, &pk2, &vote_account2, rent, 50 + min_stake_balance);
 
         genesis_config.accounts.extend(vec![
             (pk1, vote_account1.clone()),

--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -382,7 +382,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
         &bootstrap_vote_pubkey,
         &bootstrap_leader_pubkey,
         0,
-        VoteState::get_rent_exempt_reserve(&rent).max(1),
+        VoteState::get_rent_exempt_reserve(&rent),
     );
 
     let bootstrap_leader_stake_account = stake_state::create_account(

--- a/genesis/src/stakes.rs
+++ b/genesis/src/stakes.rs
@@ -56,7 +56,7 @@ pub fn create_and_add_stakes(
     let total_lamports = sol_to_lamports(staker_info.sol);
 
     // staker is a system account
-    let staker_rent_reserve = genesis_config.rent.minimum_balance(0).max(1);
+    let staker_rent_reserve = genesis_config.rent.minimum_balance(0);
     let staker_fees = calculate_staker_fees(genesis_config, 1.0);
 
     let mut stakes_lamports = total_lamports - staker_fees;

--- a/genesis/src/validators.rs
+++ b/genesis/src/validators.rs
@@ -37,10 +37,10 @@ pub fn create_and_add_validator(
     let node_lamports = sol_to_lamports(validator_info.node_sol);
 
     // node is the system account from which votes will be issued
-    let node_rent_reserve = genesis_config.rent.minimum_balance(0).max(1);
+    let node_rent_reserve = genesis_config.rent.minimum_balance(0);
     let node_voting_fees = calculate_voting_fees(genesis_config, 1.0);
 
-    let vote_rent_reserve = VoteState::get_rent_exempt_reserve(&genesis_config.rent).max(1);
+    let vote_rent_reserve = VoteState::get_rent_exempt_reserve(&genesis_config.rent);
 
     let mut total_lamports = node_voting_fees + vote_rent_reserve + node_lamports;
 
@@ -97,8 +97,7 @@ mod tests {
         assert!(genesis_config
             .accounts
             .iter()
-            .all(|(_pubkey, account)| account.lamports
-                >= genesis_config.rent.minimum_balance(0).max(1)));
+            .all(|(_pubkey, account)| account.lamports >= genesis_config.rent.minimum_balance(0)));
     }
 
     #[test]

--- a/programs/stake/src/config.rs
+++ b/programs/stake/src/config.rs
@@ -52,7 +52,7 @@ pub fn add_genesis_account(genesis_config: &mut GenesisConfig) -> u64 {
     let mut account = create_config_account(vec![], &Config::default(), 0);
     let lamports = genesis_config.rent.minimum_balance(account.data.len());
 
-    account.lamports = lamports.max(1);
+    account.lamports = lamports;
 
     genesis_config.add_account(id(), account);
 

--- a/runtime/src/genesis_utils.rs
+++ b/runtime/src/genesis_utils.rs
@@ -8,7 +8,7 @@ use solana_sdk::{
     signature::{Keypair, KeypairUtil},
     system_program::{self, solana_system_program},
 };
-use solana_stake_program::stake_state;
+use solana_stake_program::stake_state::{self, StakeState};
 use solana_vote_program::vote_state;
 
 // The default stake placed with the bootstrap leader
@@ -42,12 +42,13 @@ pub fn create_genesis_config_with_leader(
 
     let rent = Rent::free();
 
+    let min_stake_balance = StakeState::get_rent_exempt_reserve(&rent);
     let bootstrap_leader_stake_account = stake_state::create_account(
         &bootstrap_leader_staking_keypair.pubkey(),
         &bootstrap_leader_voting_keypair.pubkey(),
         &bootstrap_leader_vote_account,
         &rent,
-        bootstrap_leader_stake_lamports,
+        bootstrap_leader_stake_lamports + min_stake_balance,
     );
 
     let accounts = [

--- a/sdk/src/rent.rs
+++ b/sdk/src/rent.rs
@@ -48,8 +48,11 @@ impl Rent {
     /// minimum balance due for a given size Account::data.len()
     pub fn minimum_balance(&self, data_len: usize) -> u64 {
         let bytes = data_len as u64;
-        (((ACCOUNT_STORAGE_OVERHEAD + bytes) * self.lamports_per_byte_year) as f64
-            * self.exemption_threshold) as u64
+        let minimum_balance = (((ACCOUNT_STORAGE_OVERHEAD + bytes) * self.lamports_per_byte_year)
+            as f64
+            * self.exemption_threshold) as u64;
+        // accounts need at least 1 lamport to be active
+        minimum_balance.max(1)
     }
 
     /// whether a given balance and data_len would be exempt


### PR DESCRIPTION
#### Problem
It's expected that clients use `get_minimum_balance_for_rent_exemption` to determine how many lamports to give to a new account. In the case where rent is disabled on a network (usually in development), this value will be `0` which will subsequently prevent the account from being used. This situation is a footgun for app developers who will be testing against testnets without rent.

#### Summary of Changes
- Return at least `1` lamport for minimum balance for rent exemption.

Fixes #
