### PR TITLE
Fix cli program deploys by avoiding zero account balance

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -801,7 +801,7 @@ fn process_deploy(
         &config.keypair,
         &program_id,
         blockhash,
-        minimum_balance,
+        minimum_balance.max(1),
         program_data.len() as u64,
         &bpf_loader::id(),
     );


### PR DESCRIPTION
#### Problem
When rent is disabled on a testnet, the minimum rent exempt balance for any account is `0`. We were using this value for the number of lamports to give to the program account in the cli deploy command. Since the program had no balance, the program finalization transaction was failing.

#### Summary of Changes
Ensure that the program account balance for a new deployed program is always at least `1` lamport.
