### PR TITLE
Only return accounts that have changed since the bank's parent

### DIFF
--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -11,7 +11,7 @@ pub struct AccountsIndex<T> {
 
     pub roots: HashSet<Slot>,
 
-    //This value that needs to be stored to recover the index from AppendVec
+    // This value that needs to be stored to recover the index from AppendVec
     pub last_root: Slot,
 }
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1506,7 +1506,12 @@ impl Bank {
 
     pub fn get_account_modified_since_parent(&self, pubkey: &Pubkey) -> Option<(Account, Slot)> {
         let just_self: HashMap<u64, usize> = vec![(self.slot(), 0)].into_iter().collect();
-        self.rc.accounts.load_slow(&just_self, pubkey)
+        if let Some((account, slot)) = self.rc.accounts.load_slow(&just_self, pubkey) {
+            if slot == self.slot() {
+                return Some((account, slot));
+            }
+        }
+        None
     }
 
     pub fn transaction_count(&self) -> u64 {


### PR DESCRIPTION
#### Problem

pubsub is sending out notifications for accounts even when they have not changed. 

#### Summary of Changes

Check to ensure that the account was actually modified by the current bank.

Fixes #
