### PR TITLE
Mark PRs stale after 7 days instead of 30

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,7 +1,7 @@
 only: pulls
 
 # Number of days of inactivity before a pull request becomes stale
-daysUntilStale: 30
+daysUntilStale: 7
 
 # Number of days of inactivity before a stale pull request is closed
 daysUntilClose: 7


### PR DESCRIPTION
#### Problem

PRs are being left open too long. Can't distinguish what needs review from what's been abandoned.

#### Summary of Changes

Have stalebot mark PRs stale after 7 days instead of 30.
