### PR TITLE
Improve bench-tps stability

### DIFF
--- a/bench-tps/src/bench.rs
+++ b/bench-tps/src/bench.rs
@@ -258,8 +258,8 @@ fn metrics_submit_lamport_balance(lamport_balance: u64) {
 
 #[cfg(feature = "move")]
 fn generate_move_txs(
-    source: &[Keypair],
-    dest: &[Keypair],
+    source: &[&Keypair],
+    dest: &VecDeque<&Keypair>,
     reclaim: bool,
     move_keypairs: &[Keypair],
     libra_pay_program_id: &Pubkey,
@@ -1047,7 +1047,7 @@ pub fn generate_and_fund_keypairs<T: Client>(
                 // Still fund the solana ones which will be used for fees.
                 let seed = [0u8; 32];
                 let mut rnd = GenKeys::new(seed);
-                let move_keypairs = rnd.gen_n_keypairs(keypair_count);
+                let move_keypairs = rnd.gen_n_keypairs(keypair_count as u64);
                 fund_move_keys(
                     client,
                     funding_key,

--- a/bench-tps/src/bench.rs
+++ b/bench-tps/src/bench.rs
@@ -90,6 +90,7 @@ where
 
     let mut source_keypair_chunks: Vec<Vec<&Keypair>> = Vec::new();
     let mut dest_keypair_chunks: Vec<VecDeque<&Keypair>> = Vec::new();
+    assert!(gen_keypairs.len() >= 2 * tx_count);
     for chunk in gen_keypairs.chunks_exact(2 * tx_count) {
         source_keypair_chunks.push(chunk[..tx_count].iter().collect());
         dest_keypair_chunks.push(chunk[tx_count..].iter().collect());
@@ -1123,8 +1124,9 @@ mod tests {
         config.tx_count = 10;
         config.duration = Duration::from_secs(5);
 
+        let keypair_count = config.tx_count * config.keypair_multiplier;
         let (keypairs, _move_keypairs, _keypair_balance) =
-            generate_and_fund_keypairs(&clients[0], None, &config.id, config.tx_count, 20, false)
+            generate_and_fund_keypairs(&clients[0], None, &config.id, keypair_count, 20, false)
                 .unwrap();
 
         do_bench_tps(clients, config, keypairs, 0, None);
@@ -1135,11 +1137,11 @@ mod tests {
         let (genesis_config, id) = create_genesis_config(10_000);
         let bank = Bank::new(&genesis_config);
         let client = BankClient::new(bank);
-        let tx_count = 10;
+        let keypair_count = 20;
         let lamports = 20;
 
         let (keypairs, _move_keypairs, _keypair_balance) =
-            generate_and_fund_keypairs(&client, None, &id, tx_count, lamports, false).unwrap();
+            generate_and_fund_keypairs(&client, None, &id, keypair_count, lamports, false).unwrap();
 
         for kp in &keypairs {
             assert_eq!(
@@ -1158,11 +1160,11 @@ mod tests {
         genesis_config.fee_calculator = fee_calculator;
         let bank = Bank::new(&genesis_config);
         let client = BankClient::new(bank);
-        let tx_count = 10;
+        let keypair_count = 20;
         let lamports = 20;
 
         let (keypairs, _move_keypairs, _keypair_balance) =
-            generate_and_fund_keypairs(&client, None, &id, tx_count, lamports, false).unwrap();
+            generate_and_fund_keypairs(&client, None, &id, keypair_count, lamports, false).unwrap();
 
         let max_fee = client
             .get_recent_blockhash_with_commitment(CommitmentConfig::recent())

--- a/bench-tps/src/bench.rs
+++ b/bench-tps/src/bench.rs
@@ -414,7 +414,7 @@ fn poll_blockhash<T: Client>(
                 if blockhash_time.elapsed().as_secs() > 30 {
                     panic!("Blockhash is not updating");
                 }
-                sleep(Duration::from_millis(100));
+                sleep(Duration::from_millis(50));
                 continue;
             }
         }

--- a/bench-tps/src/cli.rs
+++ b/bench-tps/src/cli.rs
@@ -15,6 +15,7 @@ pub struct Config {
     pub num_nodes: usize,
     pub duration: Duration,
     pub tx_count: usize,
+    pub keypair_multiplier: usize,
     pub thread_batch_sleep_ms: usize,
     pub sustained: bool,
     pub client_ids_and_stake_file: String,
@@ -36,6 +37,7 @@ impl Default for Config {
             num_nodes: 1,
             duration: Duration::new(std::u64::MAX, 0),
             tx_count: 50_000,
+            keypair_multiplier: 8,
             thread_batch_sleep_ms: 1000,
             sustained: false,
             client_ids_and_stake_file: String::new(),
@@ -123,6 +125,13 @@ pub fn build_args<'a, 'b>(version: &'b str) -> App<'a, 'b> {
                 .help("Number of transactions to send per batch")
         )
         .arg(
+            Arg::with_name("keypair_multiplier")
+                .long("keypair-multiplier")
+                .value_name("NUM")
+                .takes_value(true)
+                .help("Multiply by transaction count to determine number of keypairs to create")
+        )
+        .arg(
             Arg::with_name("thread-batch-sleep-ms")
                 .short("z")
                 .long("thread-batch-sleep-ms")
@@ -208,7 +217,15 @@ pub fn extract_args<'a>(matches: &ArgMatches<'a>) -> Config {
     }
 
     if let Some(s) = matches.value_of("tx_count") {
-        args.tx_count = s.to_string().parse().expect("can't parse tx_account");
+        args.tx_count = s.to_string().parse().expect("can't parse tx_count");
+    }
+
+    if let Some(s) = matches.value_of("keypair_multiplier") {
+        args.keypair_multiplier = s
+            .to_string()
+            .parse()
+            .expect("can't parse keypair-multiplier");
+        assert!(args.keypair_multiplier >= 2);
     }
 
     if let Some(t) = matches.value_of("thread-batch-sleep-ms") {

--- a/bench-tps/src/main.rs
+++ b/bench-tps/src/main.rs
@@ -24,6 +24,7 @@ fn main() {
         id,
         num_nodes,
         tx_count,
+        keypair_multiplier,
         client_ids_and_stake_file,
         write_to_client_file,
         read_from_client_file,
@@ -34,9 +35,10 @@ fn main() {
         ..
     } = &cli_config;
 
+    let keypair_count = *tx_count * keypair_multiplier;
     if *write_to_client_file {
-        info!("Generating {} keypairs", *tx_count * 2);
-        let (keypairs, _) = generate_keypairs(&id, *tx_count as u64 * 2);
+        info!("Generating {} keypairs", keypair_count);
+        let (keypairs, _) = generate_keypairs(&id, keypair_count as u64);
         let num_accounts = keypairs.len() as u64;
         let max_fee =
             FeeCalculator::new(*target_lamports_per_signature, 0).max_lamports_per_signature;
@@ -102,10 +104,10 @@ fn main() {
                 last_balance = primordial_account.balance;
             });
 
-        if keypairs.len() < tx_count * 2 {
+        if keypairs.len() < keypair_count {
             eprintln!(
                 "Expected {} accounts in {}, only received {} (--tx_count mismatch?)",
-                tx_count * 2,
+                keypair_count,
                 client_ids_and_stake_file,
                 keypairs.len(),
             );
@@ -121,7 +123,7 @@ fn main() {
             &client,
             Some(*faucet_addr),
             &id,
-            *tx_count,
+            keypair_count,
             *num_lamports_per_account,
             *use_move,
         )

--- a/bench-tps/tests/bench_tps.rs
+++ b/bench-tps/tests/bench_tps.rs
@@ -47,11 +47,12 @@ fn test_bench_tps_local_cluster(config: Config) {
 
     let lamports_per_account = 100;
 
+    let keypair_count = config.tx_count * config.keypair_multiplier;
     let (keypairs, move_keypairs, _keypair_balance) = generate_and_fund_keypairs(
         &client,
         Some(faucet_addr),
         &config.id,
-        config.tx_count,
+        keypair_count,
         lamports_per_account,
         config.use_move,
     )


### PR DESCRIPTION
#### Problem
Bench-TPS clients get blocked by RPC calls to get the recent blockhash for each new set of transactions

#### Summary of Changes
- Create a new thread for polling for the latest blockhash
- Rotate destination keys using a deque to avoid duplicate transactions
- Create enough keypairs such that we can avoid "account in use" errors when the sleep time is less than block time or when the network is struggling to keep up.
- Add `--keypair-multiplier` arg to specify how many times more keypairs we need than transactions
- Changed balance ping-ponging logic to accommodate keypair multiplier

#### Notes
* Users will need to adjust their mental models on how `tx_count` and `thread-batch-sleep-ms` map to TPS after this change.  From my testing, it's a lot more intuitive now and roughly maps to:

`TPS = tx_count * (1000 / thread-batch-sleep-ms)`

* More keypairs will be generated by default after this change, so more lamports need to be airdropped to the funding account than before

#### Links

https://metrics.solana.com:3000/d/testnet-edge/testnet-monitor-edge?orgId=2&from=1576614229516&to=1576617829516&var-datasource=Solana%20Metrics%20(read-only)&var-testnet=testnet-dev-jstarry&var-hostid=All