### PR TITLE
Update genesis addrgen to system_instruction::create_address_with_seed()

### DIFF
--- a/genesis/src/address_generator.rs
+++ b/genesis/src/address_generator.rs
@@ -1,29 +1,32 @@
-use solana_sdk::{hash::hashv, pubkey::Pubkey};
+use solana_sdk::{pubkey::Pubkey, system_instruction::create_address_with_seed};
 
 #[derive(Default)]
 pub struct AddressGenerator {
     base_pubkey: Pubkey,
-    base_name: String,
+    base_seed: String,
+    program_id: Pubkey,
     nth: usize,
 }
 
 impl AddressGenerator {
-    pub fn new(base_pubkey: &Pubkey, base_name: &str) -> Self {
+    pub fn new(base_pubkey: &Pubkey, base_seed: &str, program_id: &Pubkey) -> Self {
         Self {
             base_pubkey: *base_pubkey,
-            base_name: base_name.to_string(),
+            base_seed: base_seed.to_string(),
+            program_id: *program_id,
             nth: 0,
         }
     }
+
     pub fn nth(&self, nth: usize) -> Pubkey {
-        Pubkey::new(
-            hashv(&[
-                self.base_pubkey.as_ref(),
-                format!("{}:{}", self.base_name, nth).as_bytes(),
-            ])
-            .as_ref(),
+        create_address_with_seed(
+            &self.base_pubkey,
+            &format!("{}:{}", self.base_seed, nth),
+            &self.program_id,
         )
+        .unwrap()
     }
+
     #[allow(clippy::should_implement_trait)]
     pub fn next(&mut self) -> Pubkey {
         let nth = self.nth;

--- a/genesis/src/stakes.rs
+++ b/genesis/src/stakes.rs
@@ -7,8 +7,9 @@ use solana_sdk::{
     account::Account, clock::Slot, genesis_config::GenesisConfig, native_token::sol_to_lamports,
     pubkey::Pubkey, system_program, timing::years_as_slots,
 };
-use solana_stake_program::stake_state::{
-    create_lockup_stake_account, Authorized, Lockup, StakeState,
+use solana_stake_program::{
+    self,
+    stake_state::{create_lockup_stake_account, Authorized, Lockup, StakeState},
 };
 
 #[derive(Debug)]
@@ -88,7 +89,11 @@ pub fn create_and_add_stakes(
         genesis_config.ticks_per_slot,
     );
 
-    let mut address_generator = AddressGenerator::new(&authorized.staker, staker_info.name);
+    let mut address_generator = AddressGenerator::new(
+        &authorized.staker,
+        staker_info.name,
+        &solana_stake_program::id(),
+    );
 
     let stake_rent_reserve = StakeState::get_rent_exempt_reserve(&genesis_config.rent);
 


### PR DESCRIPTION
#### Problem
genesis creates addresses with it's own strategy that doesn't match the system_program's facilities, which require the signature of the base pubkey

 #### Summary of Changes
 moved genesis over to system_instruction::create_address_with_seed()

Fixes #7504