### PR TITLE
GetLeaderSchedule RPC API can now return a schedule for arbitrary epoches

### DIFF
--- a/book/src/api-reference/jsonrpc-api.md
+++ b/book/src/api-reference/jsonrpc-api.md
@@ -373,15 +373,16 @@ curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1, "m
 
 ### getLeaderSchedule
 
-Returns the leader schedule for the current epoch
+Returns the leader schedule for an epoch
 
 #### Parameters:
 
+* `slot` - (optional) Fetch the leader schedule for the epoch that corresponds to the provided slot.  If unspecified, the leader schedule for the current epoch is fetch
 * `object` - (optional) [Commitment](jsonrpc-api.md#configuring-state-commitment)
 
 #### Results:
 
-The result field will be an array of leader public keys \(as base-58 encoded strings\) for each slot in the current epoch
+The result field will be an array of leader public keys \(as base-58 encoded strings\) for each slot in the epoch
 
 #### Example:
 

--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -248,6 +248,39 @@ impl RpcClient {
         })
     }
 
+    pub fn get_leader_schedule(&self, slot: Option<Slot>) -> io::Result<Option<Vec<String>>> {
+        self.get_leader_schedule_with_commitment(slot, CommitmentConfig::default())
+    }
+
+    pub fn get_leader_schedule_with_commitment(
+        &self,
+        slot: Option<Slot>,
+        commitment_config: CommitmentConfig,
+    ) -> io::Result<Option<Vec<String>>> {
+        let params = slot.map(|slot| json!(slot));
+        let response = self
+            .client
+            .send(
+                &RpcRequest::GetLeaderSchedule,
+                params,
+                0,
+                commitment_config.ok(),
+            )
+            .map_err(|err| {
+                io::Error::new(
+                    io::ErrorKind::Other,
+                    format!("GetLeaderSchedule request failure: {:?}", err),
+                )
+            })?;
+
+        serde_json::from_value(response).map_err(|err| {
+            io::Error::new(
+                io::ErrorKind::Other,
+                format!("GetLeaderSchedule failure: {}", err),
+            )
+        })
+    }
+
     pub fn get_epoch_schedule(&self) -> io::Result<EpochSchedule> {
         let response = self
             .client

--- a/client/src/rpc_request.rs
+++ b/client/src/rpc_request.rs
@@ -121,6 +121,7 @@ pub enum RpcRequest {
     GetEpochSchedule,
     GetGenesisHash,
     GetInflation,
+    GetLeaderSchedule,
     GetNumBlocksSinceSignatureConfirmation,
     GetProgramAccounts,
     GetRecentBlockhash,
@@ -161,6 +162,7 @@ impl RpcRequest {
             RpcRequest::GetEpochSchedule => "getEpochSchedule",
             RpcRequest::GetGenesisHash => "getGenesisHash",
             RpcRequest::GetInflation => "getInflation",
+            RpcRequest::GetLeaderSchedule => "getLeaderSchedule",
             RpcRequest::GetNumBlocksSinceSignatureConfirmation => {
                 "getNumBlocksSinceSignatureConfirmation"
             }


### PR DESCRIPTION
`GetLeaderSchedule` returns the current leader schedule but as a client I:
1. have no guarantees about the actual epoch that schedule was for -- at an epoch boundary I might get confused.
2. have no way to ask for an older epoch, if the node has that data.

