### PR TITLE
Extend getConfirmedBlock rpc to return account pre- and post-balances

### DIFF
--- a/client/src/rpc_request.rs
+++ b/client/src/rpc_request.rs
@@ -32,9 +32,12 @@ pub struct RpcConfirmedBlock {
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct RpcTransactionStatus {
     pub status: Result<()>,
     pub fee: u64,
+    pub pre_balance: Vec<u64>,
+    pub post_balance: Vec<u64>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]

--- a/client/src/rpc_request.rs
+++ b/client/src/rpc_request.rs
@@ -36,8 +36,8 @@ pub struct RpcConfirmedBlock {
 pub struct RpcTransactionStatus {
     pub status: Result<()>,
     pub fee: u64,
-    pub pre_balance: Vec<u64>,
-    pub post_balance: Vec<u64>,
+    pub pre_balances: Vec<u64>,
+    pub post_balances: Vec<u64>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -22,7 +22,7 @@ use solana_metrics::{inc_new_counter_debug, inc_new_counter_info, inc_new_counte
 use solana_perf::{cuda_runtime::PinnedVec, perf_libs};
 use solana_runtime::{
     accounts_db::ErrorCounters,
-    bank::{Bank, TransactionBalanceSet, TransactionProcessResult},
+    bank::{Bank, TransactionBalancesSet, TransactionProcessResult},
     transaction_batch::TransactionBatch,
 };
 use solana_sdk::{
@@ -511,7 +511,7 @@ impl BankingStage {
         // TODO: Banking stage threads should be prioritized to complete faster then this queue
         // expires.
         let txs = batch.transactions();
-        let pre_balance = if transaction_status_sender.is_some() {
+        let pre_balances = if transaction_status_sender.is_some() {
             bank.collect_balances(txs)
         } else {
             vec![]
@@ -548,14 +548,14 @@ impl BankingStage {
                 .processing_results;
 
             if let Some(sender) = transaction_status_sender {
-                let post_balance = bank.collect_balances(txs);
+                let post_balances = bank.collect_balances(txs);
                 send_transaction_status_batch(
                     bank.clone(),
                     batch.transactions(),
                     transaction_statuses,
-                    TransactionBalanceSet {
-                        pre_balance,
-                        post_balance,
+                    TransactionBalancesSet {
+                        pre_balances,
+                        post_balances,
                     },
                     sender,
                 );

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -553,10 +553,7 @@ impl BankingStage {
                     bank.clone(),
                     batch.transactions(),
                     transaction_statuses,
-                    TransactionBalancesSet {
-                        pre_balances,
-                        post_balances,
-                    },
+                    TransactionBalancesSet::new(pre_balances, post_balances),
                     sender,
                 );
             }

--- a/core/src/transaction_status_service.rs
+++ b/core/src/transaction_status_service.rs
@@ -57,11 +57,11 @@ impl TransactionStatusService {
         } = write_transaction_status_receiver.recv_timeout(Duration::from_secs(1))?;
 
         let slot = bank.slot();
-        for (((transaction, (status, hash_age_kind)), pre_balance), post_balance) in transactions
+        for (((transaction, (status, hash_age_kind)), pre_balances), post_balances) in transactions
             .iter()
             .zip(statuses)
-            .zip(balances.pre_balance)
-            .zip(balances.post_balance)
+            .zip(balances.pre_balances)
+            .zip(balances.post_balances)
         {
             if Bank::can_commit(&status) && !transaction.signatures.is_empty() {
                 let fee_hash = if let Some(HashAgeKind::DurableNonce) = hash_age_kind {
@@ -79,8 +79,8 @@ impl TransactionStatusService {
                         &RpcTransactionStatus {
                             status,
                             fee,
-                            pre_balance,
-                            post_balance,
+                            pre_balances,
+                            post_balances,
                         },
                     )
                     .expect("Expect database write to succeed");

--- a/core/src/transaction_status_service.rs
+++ b/core/src/transaction_status_service.rs
@@ -67,10 +67,19 @@ impl TransactionStatusService {
                     .get_fee_calculator(&fee_hash)
                     .expect("FeeCalculator must exist");
                 let fee = fee_calculator.calculate_fee(transaction.message());
+                let mut mock_balances: Vec<u64> = vec![];
+                for (i, _account_key) in transaction.message.account_keys.iter().enumerate() {
+                    mock_balances.push(i as u64 * 10);
+                }
                 blocktree
                     .write_transaction_status(
                         (slot, transaction.signatures[0]),
-                        &RpcTransactionStatus { status, fee },
+                        &RpcTransactionStatus {
+                            status,
+                            fee,
+                            pre_balance: mock_balances.clone(),
+                            post_balance: mock_balances,
+                        },
                     )
                     .expect("Expect database write to succeed");
             }

--- a/core/src/transaction_status_service.rs
+++ b/core/src/transaction_status_service.rs
@@ -53,10 +53,16 @@ impl TransactionStatusService {
             bank,
             transactions,
             statuses,
+            balances,
         } = write_transaction_status_receiver.recv_timeout(Duration::from_secs(1))?;
 
         let slot = bank.slot();
-        for (transaction, (status, hash_age_kind)) in transactions.iter().zip(statuses) {
+        for (((transaction, (status, hash_age_kind)), pre_balance), post_balance) in transactions
+            .iter()
+            .zip(statuses)
+            .zip(balances.pre_balance)
+            .zip(balances.post_balance)
+        {
             if Bank::can_commit(&status) && !transaction.signatures.is_empty() {
                 let fee_hash = if let Some(HashAgeKind::DurableNonce) = hash_age_kind {
                     bank.last_blockhash()
@@ -67,18 +73,14 @@ impl TransactionStatusService {
                     .get_fee_calculator(&fee_hash)
                     .expect("FeeCalculator must exist");
                 let fee = fee_calculator.calculate_fee(transaction.message());
-                let mut mock_balances: Vec<u64> = vec![];
-                for (i, _account_key) in transaction.message.account_keys.iter().enumerate() {
-                    mock_balances.push(i as u64 * 10);
-                }
                 blocktree
                     .write_transaction_status(
                         (slot, transaction.signatures[0]),
                         &RpcTransactionStatus {
                             status,
                             fee,
-                            pre_balance: mock_balances.clone(),
-                            post_balance: mock_balances,
+                            pre_balance,
+                            post_balance,
                         },
                     )
                     .expect("Expect database write to succeed");

--- a/ledger/src/blocktree.rs
+++ b/ledger/src/blocktree.rs
@@ -4513,11 +4513,11 @@ pub mod tests {
             .filter(|entry| !entry.is_tick())
             .flat_map(|entry| entry.transactions)
             .map(|transaction| {
-                let mut pre_balance: Vec<u64> = vec![];
-                let mut post_balance: Vec<u64> = vec![];
+                let mut pre_balances: Vec<u64> = vec![];
+                let mut post_balances: Vec<u64> = vec![];
                 for (i, _account_key) in transaction.message.account_keys.iter().enumerate() {
-                    pre_balance.push(i as u64 * 10);
-                    post_balance.push(i as u64 * 11);
+                    pre_balances.push(i as u64 * 10);
+                    post_balances.push(i as u64 * 11);
                 }
                 let signature = transaction.signatures[0];
                 ledger
@@ -4527,8 +4527,8 @@ pub mod tests {
                         &RpcTransactionStatus {
                             status: Ok(()),
                             fee: 42,
-                            pre_balance: pre_balance.clone(),
-                            post_balance: post_balance.clone(),
+                            pre_balances: pre_balances.clone(),
+                            post_balances: post_balances.clone(),
                         },
                     )
                     .unwrap();
@@ -4539,8 +4539,8 @@ pub mod tests {
                         &RpcTransactionStatus {
                             status: Ok(()),
                             fee: 42,
-                            pre_balance: pre_balance.clone(),
-                            post_balance: post_balance.clone(),
+                            pre_balances: pre_balances.clone(),
+                            post_balances: post_balances.clone(),
                         },
                     )
                     .unwrap();
@@ -4549,8 +4549,8 @@ pub mod tests {
                     Some(RpcTransactionStatus {
                         status: Ok(()),
                         fee: 42,
-                        pre_balance,
-                        post_balance,
+                        pre_balances,
+                        post_balances,
                     }),
                 )
             })
@@ -4669,8 +4669,8 @@ pub mod tests {
             let blocktree = Blocktree::open(&blocktree_path).unwrap();
             let transaction_status_cf = blocktree.db.column::<cf::TransactionStatus>();
 
-            let pre_balance_vec = vec![1, 2, 3];
-            let post_balance_vec = vec![3, 2, 1];
+            let pre_balances_vec = vec![1, 2, 3];
+            let post_balances_vec = vec![3, 2, 1];
 
             // result not found
             assert!(transaction_status_cf
@@ -4687,8 +4687,8 @@ pub mod tests {
                             TransactionError::AccountNotFound
                         ),
                         fee: 5u64,
-                        pre_balance: pre_balance_vec.clone(),
-                        post_balance: post_balance_vec.clone(),
+                        pre_balances: pre_balances_vec.clone(),
+                        post_balances: post_balances_vec.clone(),
                     },
                 )
                 .is_ok());
@@ -4697,16 +4697,16 @@ pub mod tests {
             let RpcTransactionStatus {
                 status,
                 fee,
-                pre_balance,
-                post_balance,
+                pre_balances,
+                post_balances,
             } = transaction_status_cf
                 .get((0, Signature::default()))
                 .unwrap()
                 .unwrap();
             assert_eq!(status, Err(TransactionError::AccountNotFound));
             assert_eq!(fee, 5u64);
-            assert_eq!(pre_balance, pre_balance_vec);
-            assert_eq!(post_balance, post_balance_vec);
+            assert_eq!(pre_balances, pre_balances_vec);
+            assert_eq!(post_balances, post_balances_vec);
 
             // insert value
             assert!(transaction_status_cf
@@ -4715,8 +4715,8 @@ pub mod tests {
                     &RpcTransactionStatus {
                         status: solana_sdk::transaction::Result::<()>::Ok(()),
                         fee: 9u64,
-                        pre_balance: pre_balance_vec.clone(),
-                        post_balance: post_balance_vec.clone(),
+                        pre_balances: pre_balances_vec.clone(),
+                        post_balances: post_balances_vec.clone(),
                     },
                 )
                 .is_ok());
@@ -4725,8 +4725,8 @@ pub mod tests {
             let RpcTransactionStatus {
                 status,
                 fee,
-                pre_balance,
-                post_balance,
+                pre_balances,
+                post_balances,
             } = transaction_status_cf
                 .get((9, Signature::default()))
                 .unwrap()
@@ -4735,8 +4735,8 @@ pub mod tests {
             // deserialize
             assert_eq!(status, Ok(()));
             assert_eq!(fee, 9u64);
-            assert_eq!(pre_balance, pre_balance_vec);
-            assert_eq!(post_balance, post_balance_vec);
+            assert_eq!(pre_balances, pre_balances_vec);
+            assert_eq!(post_balances, post_balances_vec);
         }
         Blocktree::destroy(&blocktree_path).expect("Expected successful database destruction");
     }
@@ -4782,8 +4782,8 @@ pub mod tests {
                                 TransactionError::AccountNotFound,
                             ),
                             fee: x,
-                            pre_balance: vec![],
-                            post_balance: vec![],
+                            pre_balances: vec![],
+                            post_balances: vec![],
                         },
                     )
                     .unwrap();

--- a/ledger/src/blocktree_processor.rs
+++ b/ledger/src/blocktree_processor.rs
@@ -14,7 +14,7 @@ use rayon::{prelude::*, ThreadPool};
 use solana_metrics::{datapoint, datapoint_error, inc_new_counter_debug};
 use solana_rayon_threadlimit::get_thread_count;
 use solana_runtime::{
-    bank::{Bank, TransactionProcessResult, TransactionResults},
+    bank::{Bank, TransactionBalanceSet, TransactionProcessResult, TransactionResults},
     transaction_batch::TransactionBatch,
 };
 use solana_sdk::{
@@ -54,18 +54,24 @@ fn execute_batch(
     bank: &Arc<Bank>,
     transaction_status_sender: Option<TransactionStatusSender>,
 ) -> Result<()> {
-    let TransactionResults {
-        fee_collection_results,
-        processing_results,
-    } = batch
-        .bank()
-        .load_execute_and_commit_transactions(batch, MAX_RECENT_BLOCKHASHES);
+    let (
+        TransactionResults {
+            fee_collection_results,
+            processing_results,
+        },
+        balances,
+    ) = batch.bank().load_execute_and_commit_transactions(
+        batch,
+        MAX_RECENT_BLOCKHASHES,
+        transaction_status_sender.is_some(),
+    );
 
     if let Some(sender) = transaction_status_sender {
         send_transaction_status_batch(
             bank.clone(),
             batch.transactions(),
             processing_results,
+            balances,
             sender,
         );
     }
@@ -560,6 +566,7 @@ pub struct TransactionStatusBatch {
     pub bank: Arc<Bank>,
     pub transactions: Vec<Transaction>,
     pub statuses: Vec<TransactionProcessResult>,
+    pub balances: TransactionBalanceSet,
 }
 pub type TransactionStatusSender = Sender<TransactionStatusBatch>;
 
@@ -567,6 +574,7 @@ pub fn send_transaction_status_batch(
     bank: Arc<Bank>,
     transactions: &[Transaction],
     statuses: Vec<TransactionProcessResult>,
+    balances: TransactionBalanceSet,
     transaction_status_sender: TransactionStatusSender,
 ) {
     let slot = bank.slot();
@@ -574,6 +582,7 @@ pub fn send_transaction_status_batch(
         bank,
         transactions: transactions.to_vec(),
         statuses,
+        balances,
     }) {
         trace!(
             "Slot {} transaction_status send batch failed: {:?}",

--- a/ledger/src/blocktree_processor.rs
+++ b/ledger/src/blocktree_processor.rs
@@ -14,7 +14,7 @@ use rayon::{prelude::*, ThreadPool};
 use solana_metrics::{datapoint, datapoint_error, inc_new_counter_debug};
 use solana_rayon_threadlimit::get_thread_count;
 use solana_runtime::{
-    bank::{Bank, TransactionBalanceSet, TransactionProcessResult, TransactionResults},
+    bank::{Bank, TransactionBalancesSet, TransactionProcessResult, TransactionResults},
     transaction_batch::TransactionBatch,
 };
 use solana_sdk::{
@@ -566,7 +566,7 @@ pub struct TransactionStatusBatch {
     pub bank: Arc<Bank>,
     pub transactions: Vec<Transaction>,
     pub statuses: Vec<TransactionProcessResult>,
-    pub balances: TransactionBalanceSet,
+    pub balances: TransactionBalancesSet,
 }
 pub type TransactionStatusSender = Sender<TransactionStatusBatch>;
 
@@ -574,7 +574,7 @@ pub fn send_transaction_status_batch(
     bank: Arc<Bank>,
     transactions: &[Transaction],
     statuses: Vec<TransactionProcessResult>,
-    balances: TransactionBalanceSet,
+    balances: TransactionBalancesSet,
     transaction_status_sender: TransactionStatusSender,
 ) {
     let slot = bank.slot();

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4807,4 +4807,55 @@ mod tests {
         assert_eq!(balances[0], vec![8, 11, 1]);
         assert_eq!(balances[1], vec![8, 0, 1]);
     }
+
+    #[test]
+    fn test_pre_post_transaction_balances() {
+        let (mut genesis_config, _mint_keypair) = create_genesis_config(500);
+        let fee_calculator = FeeCalculator::new(1, 0);
+        genesis_config.fee_calculator = fee_calculator;
+        let parent = Arc::new(Bank::new(&genesis_config));
+        let bank0 = Arc::new(new_from_parent(&parent));
+
+        let keypair0 = Keypair::new();
+        let keypair1 = Keypair::new();
+        let pubkey0 = Pubkey::new_rand();
+        let pubkey1 = Pubkey::new_rand();
+        let pubkey2 = Pubkey::new_rand();
+        let keypair0_account = Account::new(8, 0, &Pubkey::default());
+        let keypair1_account = Account::new(9, 0, &Pubkey::default());
+        let account0 = Account::new(11, 0, &&Pubkey::default());
+        bank0.store_account(&keypair0.pubkey(), &keypair0_account);
+        bank0.store_account(&keypair1.pubkey(), &keypair1_account);
+        bank0.store_account(&pubkey0, &account0);
+
+        let blockhash = bank0.last_blockhash();
+
+        let tx0 = system_transaction::transfer(&keypair0, &pubkey0, 2, blockhash.clone());
+        let tx1 = system_transaction::transfer(&Keypair::new(), &pubkey1, 2, blockhash.clone());
+        let tx2 = system_transaction::transfer(&keypair1, &pubkey2, 12, blockhash.clone());
+        let txs = vec![tx0, tx1, tx2];
+
+        let lock_result = bank0.prepare_batch(&txs, None);
+        let (transaction_results, transaction_balances_set) =
+            bank0.load_execute_and_commit_transactions(&lock_result, MAX_RECENT_BLOCKHASHES, true);
+
+        assert_eq!(transaction_balances_set.pre_balances.len(), 3);
+        assert_eq!(transaction_balances_set.post_balances.len(), 3);
+
+        assert!(transaction_results.processing_results[0].0.is_ok());
+        assert_eq!(transaction_balances_set.pre_balances[0], vec![8, 11, 1]);
+        assert_eq!(transaction_balances_set.post_balances[0], vec![5, 13, 1]);
+
+        // Failed transactions still produce balance sets
+        // This is a TransactionError - not possible to charge fees
+        assert!(transaction_results.processing_results[1].0.is_err());
+        assert_eq!(transaction_balances_set.pre_balances[1], vec![0, 0, 1]);
+        assert_eq!(transaction_balances_set.post_balances[1], vec![0, 0, 1]);
+
+        // Failed transactions still produce balance sets
+        // This is an InstructionError - fees charged
+        assert!(transaction_results.processing_results[2].0.is_err());
+        assert_eq!(transaction_balances_set.pre_balances[2], vec![9, 0, 1]);
+        assert_eq!(transaction_balances_set.post_balances[2], vec![8, 0, 1]);
+    }
 }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -161,9 +161,9 @@ pub struct TransactionResults {
     pub fee_collection_results: Vec<Result<()>>,
     pub processing_results: Vec<TransactionProcessResult>,
 }
-pub struct TransactionBalanceSet {
-    pub pre_balance: TransactionBalances,
-    pub post_balance: TransactionBalances,
+pub struct TransactionBalancesSet {
+    pub pre_balances: TransactionBalances,
+    pub post_balances: TransactionBalances,
 }
 pub type TransactionBalances = Vec<Vec<u64>>;
 
@@ -1390,8 +1390,8 @@ impl Bank {
         batch: &TransactionBatch,
         max_age: usize,
         collect_balances: bool,
-    ) -> (TransactionResults, TransactionBalanceSet) {
-        let pre_balance = if collect_balances {
+    ) -> (TransactionResults, TransactionBalancesSet) {
+        let pre_balances = if collect_balances {
             self.collect_balances(batch.transactions())
         } else {
             vec![]
@@ -1407,16 +1407,16 @@ impl Bank {
             tx_count,
             signature_count,
         );
-        let post_balance = if collect_balances {
+        let post_balances = if collect_balances {
             self.collect_balances(batch.transactions())
         } else {
             vec![]
         };
         (
             results,
-            TransactionBalanceSet {
-                pre_balance,
-                post_balance,
+            TransactionBalancesSet {
+                pre_balances,
+                post_balances,
             },
         )
     }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -165,6 +165,15 @@ pub struct TransactionBalancesSet {
     pub pre_balances: TransactionBalances,
     pub post_balances: TransactionBalances,
 }
+impl TransactionBalancesSet {
+    pub fn new(pre_balances: TransactionBalances, post_balances: TransactionBalances) -> Self {
+        assert_eq!(pre_balances.len(), post_balances.len());
+        Self {
+            pre_balances,
+            post_balances,
+        }
+    }
+}
 pub type TransactionBalances = Vec<Vec<u64>>;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -1414,10 +1423,7 @@ impl Bank {
         };
         (
             results,
-            TransactionBalancesSet {
-                pre_balances,
-                post_balances,
-            },
+            TransactionBalancesSet::new(pre_balances, post_balances),
         )
     }
 


### PR DESCRIPTION
#### Problem
`getConfirmedBlock` can be used to walk the entire ledger and examine each and every transaction since genesis, but is currently insufficient to generically track the balances of all accounts affected by all transaction. 

#### Summary of Changes
- Extends the TransactionStatusService to store balance information about all accounts participating in each transaction. These balances are stored as two arrays -- pre_balance and post_balance -- in the `RpcTransactionStatus` struct
- Extends the `getConfirmedBlock` transaction status object to return this balance information as preBalance and postBalance.

Fixes #7492 
