### PR TITLE
Update testnet testcases to point at new buildkite agent queues

### DIFF
--- a/system-test/performance-testcases/aws-cpu-only-perf-10-node.yml
+++ b/system-test/performance-testcases/aws-cpu-only-perf-10-node.yml
@@ -17,4 +17,4 @@ steps:
       USE_PUBLIC_IP_ADDRESSES: "true"
       ADDITIONAL_FLAGS: ""
     agents:
-      - "queue=testnet-deploy"
+      - "queue=aws-deploy"

--- a/system-test/performance-testcases/aws-cpu-only-perf-5-node.yml
+++ b/system-test/performance-testcases/aws-cpu-only-perf-5-node.yml
@@ -17,4 +17,4 @@ steps:
       USE_PUBLIC_IP_ADDRESSES: "true"
       ADDITIONAL_FLAGS: ""
     agents:
-      - "queue=testnet-deploy"
+      - "queue=aws-deploy"

--- a/system-test/performance-testcases/azure-cpu-only-perf-5-node.yml
+++ b/system-test/performance-testcases/azure-cpu-only-perf-5-node.yml
@@ -16,4 +16,4 @@ steps:
       USE_PUBLIC_IP_ADDRESSES: "true"
       ADDITIONAL_FLAGS: ""
     agents:
-      - "queue=testnet-deploy"
+      - "queue=azure-deploy"

--- a/system-test/performance-testcases/gce-cpu-only-perf-10-node.yml
+++ b/system-test/performance-testcases/gce-cpu-only-perf-10-node.yml
@@ -16,4 +16,4 @@ steps:
       USE_PUBLIC_IP_ADDRESSES: "true"
       ADDITIONAL_FLAGS: ""
     agents:
-      - "queue=testnet-deploy"
+      - "queue=gce-deploy"

--- a/system-test/performance-testcases/gce-cpu-only-perf-5-node.yml
+++ b/system-test/performance-testcases/gce-cpu-only-perf-5-node.yml
@@ -16,4 +16,4 @@ steps:
       USE_PUBLIC_IP_ADDRESSES: "true"
       ADDITIONAL_FLAGS: "--dedicated"
     agents:
-      - "queue=testnet-deploy"
+      - "queue=gce-deploy"

--- a/system-test/performance-testcases/gce-gpu-perf-10-node.yml
+++ b/system-test/performance-testcases/gce-gpu-perf-10-node.yml
@@ -16,4 +16,4 @@ steps:
       USE_PUBLIC_IP_ADDRESSES: "true"
       ADDITIONAL_FLAGS: "--dedicated"
     agents:
-      - "queue=testnet-deploy"
+      - "queue=gce-deploy"

--- a/system-test/performance-testcases/gce-gpu-perf-100-node.yml
+++ b/system-test/performance-testcases/gce-gpu-perf-100-node.yml
@@ -17,4 +17,4 @@ steps:
       USE_PUBLIC_IP_ADDRESSES: "true"
       ADDITIONAL_FLAGS: "--dedicated"
     agents:
-      - "queue=testnet-deploy"
+      - "queue=gce-deploy"

--- a/system-test/performance-testcases/gce-gpu-perf-25-node.yml
+++ b/system-test/performance-testcases/gce-gpu-perf-25-node.yml
@@ -16,4 +16,4 @@ steps:
       USE_PUBLIC_IP_ADDRESSES: "true"
       ADDITIONAL_FLAGS: "--dedicated"
     agents:
-      - "queue=testnet-deploy"
+      - "queue=gce-deploy"

--- a/system-test/performance-testcases/gce-gpu-perf-5-node.yml
+++ b/system-test/performance-testcases/gce-gpu-perf-5-node.yml
@@ -16,4 +16,4 @@ steps:
       USE_PUBLIC_IP_ADDRESSES: "true"
       ADDITIONAL_FLAGS: "--dedicated"
     agents:
-      - "queue=testnet-deploy"
+      - "queue=gce-deploy"

--- a/system-test/performance-testcases/gce-gpu-perf-50-node.yml
+++ b/system-test/performance-testcases/gce-gpu-perf-50-node.yml
@@ -17,4 +17,4 @@ steps:
       USE_PUBLIC_IP_ADDRESSES: "true"
       ADDITIONAL_FLAGS: "--dedicated"
     agents:
-      - "queue=testnet-deploy"
+      - "queue=gce-deploy"

--- a/system-test/stability-testcases/gce-stability-5-node.yml
+++ b/system-test/stability-testcases/gce-stability-5-node.yml
@@ -15,4 +15,4 @@ steps:
       USE_PUBLIC_IP_ADDRESSES: "true"
       ADDITIONAL_FLAGS: "--dedicated"
     agents:
-      - "queue=testnet-deploy"
+      - "queue=stability-deploy"

--- a/system-test/testnet-automation.sh
+++ b/system-test/testnet-automation.sh
@@ -87,63 +87,8 @@ $(eval echo "$@")"
   )
 
   execution_step "Deleting Testnet"
-  case $CLOUD_PROVIDER in
-  gce)
-  (
-    cat <<EOF
-- wait: ~
-  continue_on_failure: true
+  net/"${CLOUD_PROVIDER}".sh delete -p "${TESTNET_TAG}"
 
-- command: "net/gce.sh delete -p ${TESTNET_TAG}"
-  label: "Delete Testnet"
-  agents:
-    - "queue=testnet-deploy"
-EOF
-  ) | buildkite-agent pipeline upload
-  ;;
-  ec2)
-  (
-    cat <<EOF
-- wait: ~
-  continue_on_failure: true
-
-- command: "net/ec2.sh delete -p ${TESTNET_TAG}"
-  label: "Delete Testnet"
-  agents:
-    - "queue=testnet-deploy"
-EOF
-  ) | buildkite-agent pipeline upload
-  ;;
-  azure)
-  (
-    cat <<EOF
-- wait: ~
-  continue_on_failure: true
-
-- command: "net/azure.sh delete -p ${TESTNET_TAG}"
-  label: "Delete Testnet"
-  agents:
-    - "queue=testnet-deploy"
-EOF
-  ) | buildkite-agent pipeline upload
-  ;;
-  colo)
-    (
-    cat <<EOF
-- wait: ~
-  continue_on_failure: true
-
-- command: "net/colo.sh delete -p ${TESTNET_TAG}"
-  label: "Delete Testnet"
-  agents:
-    - "queue=colo-deploy"
-EOF
-  ) | buildkite-agent pipeline upload
-  ;;
-  *)
-    echo "Error: Unsupported cloud provider: $CLOUD_PROVIDER"
-    ;;
-  esac
 }
 trap 'cleanup_testnet $BASH_COMMAND' EXIT
 


### PR DESCRIPTION
#### Problem
Launching a testnet through automation is a very low resource task, but time consuming.  We have had only 1 or 2 buildkite agents with the cloud provider CLI tools to do the launch, leading to unnecessary serializing of nightly test runs or public testnet restarts.

#### Summary of Changes
Create a new VM instance dedicated to launching/deleting testnets, with a bunch of agents running in parallel to support concurrent launches.  Update testcase definitions and automation script to point at the appropriate buildkite agent queue.

Fixes #6139 
