### PR TITLE
cli: Add show-block-production command

### DIFF
--- a/book/src/api-reference/jsonrpc-api.md
+++ b/book/src/api-reference/jsonrpc-api.md
@@ -405,7 +405,7 @@ Returns the leader schedule for an epoch
 
 #### Parameters:
 
-* `slot` - (optional) Fetch the leader schedule for the epoch that corresponds to the provided slot.  If unspecified, the leader schedule for the current epoch is fetch
+* `slot` - (optional) Fetch the leader schedule for the epoch that corresponds to the provided slot.  If unspecified, the leader schedule for the current epoch is fetched
 * `object` - (optional) [Commitment](jsonrpc-api.md#configuring-state-commitment)
 
 #### Results:

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -21,7 +21,7 @@ use solana_faucet::faucet::request_airdrop_transaction;
 use solana_faucet::faucet_mock::request_airdrop_transaction;
 use solana_sdk::{
     bpf_loader,
-    clock::Slot,
+    clock::{Epoch, Slot},
     commitment_config::CommitmentConfig,
     fee_calculator::FeeCalculator,
     hash::Hash,
@@ -105,6 +105,10 @@ pub enum CliCommand {
         count: Option<u64>,
         timeout: Duration,
         commitment_config: CommitmentConfig,
+    },
+    ShowBlockProduction {
+        epoch: Option<Epoch>,
+        slot_limit: Option<u64>,
     },
     ShowGossip,
     ShowValidators {
@@ -336,6 +340,7 @@ pub fn parse_command(matches: &ArgMatches<'_>) -> Result<CliCommandInfo, Box<dyn
         ("get-slot", Some(matches)) => parse_get_slot(matches),
         ("get-transaction-count", Some(matches)) => parse_get_transaction_count(matches),
         ("ping", Some(matches)) => parse_cluster_ping(matches),
+        ("show-block-production", Some(matches)) => parse_show_block_production(matches),
         ("show-gossip", Some(_matches)) => Ok(CliCommandInfo {
             command: CliCommand::ShowGossip,
             require_keypair: false,
@@ -1126,6 +1131,9 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             timeout,
             commitment_config,
         ),
+        CliCommand::ShowBlockProduction { epoch, slot_limit } => {
+            process_show_block_production(&rpc_client, *epoch, *slot_limit)
+        }
         CliCommand::ShowGossip => process_show_gossip(&rpc_client),
         CliCommand::ShowValidators { use_lamports_unit } => {
             process_show_validators(&rpc_client, *use_lamports_unit)

--- a/sdk/src/commitment_config.rs
+++ b/sdk/src/commitment_config.rs
@@ -19,6 +19,12 @@ impl CommitmentConfig {
         }
     }
 
+    pub fn max() -> Self {
+        Self {
+            commitment: CommitmentLevel::Max,
+        }
+    }
+
     pub fn ok(&self) -> Option<Self> {
         if self == &Self::default() {
             None


### PR DESCRIPTION
```
$ solana show-block-production --slot-limit 100
RPC Endpoint: http://beta.testnet.solana.com:8899

  Identity Pubkey                                  Leader Slots  Blocks Produced     Missed Slots  Missed Block Percentage
  va11wrZ2pD668e2dKXohuXiyALPxfVQjjH7zzpePavQ                20               20                0                    0.00%
  boot1Z6jb15CLqpaMTn2CxktktwZpRAVAgHZEW6SxQ7                16               16                0                    0.00%
  va12u4o9DipLEB2z4fuoHszroq1U9NcAB9aooFDPJSf                36               36                0                    0.00%
  va13en4eUarJtf8mbhFF386nvQh12g6ESkjoR7Ji8hm                28               28                0                    0.00%

  Epoch 26 total:                                           100              100                0                    0.00%
  (using data from 100 slots: 161359 to 161459)
```


This command will be extremely slow to run until #7538 is fixed and made use of here.