### PR TITLE
Speed up getLeaderSchedule RPC call by reducing pubkey duplication

### DIFF
--- a/book/src/api-reference/jsonrpc-api.md
+++ b/book/src/api-reference/jsonrpc-api.md
@@ -384,7 +384,9 @@ Returns the leader schedule for an epoch
 
 #### Results:
 
-The result field will be an array of leader public keys \(as base-58 encoded strings\) for each slot in the epoch
+The result field will be a dictionary of leader public keys \(as base-58 encoded
+strings\) and their corresponding leader slot indices as values (indices are to
+the first slot in the requested epoch)
 
 #### Example:
 
@@ -393,7 +395,7 @@ The result field will be an array of leader public keys \(as base-58 encoded str
 curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1, "method":"getLeaderSchedule"}' http://localhost:8899
 
 // Result
-{"jsonrpc":"2.0","result":[...],"id":1}
+{"jsonrpc":"2.0","result":{"4Qkev8aNZcqFNSRhQzwyLMFSsi94jHqE8WNVTJzTP99F":[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63]},"id":1}
 ```
 
 ### getMinimumBalanceForRentExemption

--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -4,7 +4,10 @@ use crate::{
     generic_rpc_client_request::GenericRpcClientRequest,
     mock_rpc_client_request::MockRpcClientRequest,
     rpc_client_request::RpcClientRequest,
-    rpc_request::{RpcContactInfo, RpcEpochInfo, RpcRequest, RpcVersionInfo, RpcVoteAccountStatus},
+    rpc_request::{
+        RpcContactInfo, RpcEpochInfo, RpcLeaderSchedule, RpcRequest, RpcVersionInfo,
+        RpcVoteAccountStatus,
+    },
 };
 use bincode::serialize;
 use log::*;
@@ -248,7 +251,7 @@ impl RpcClient {
         })
     }
 
-    pub fn get_leader_schedule(&self, slot: Option<Slot>) -> io::Result<Option<Vec<String>>> {
+    pub fn get_leader_schedule(&self, slot: Option<Slot>) -> io::Result<Option<RpcLeaderSchedule>> {
         self.get_leader_schedule_with_commitment(slot, CommitmentConfig::default())
     }
 
@@ -256,7 +259,7 @@ impl RpcClient {
         &self,
         slot: Option<Slot>,
         commitment_config: CommitmentConfig,
-    ) -> io::Result<Option<Vec<String>>> {
+    ) -> io::Result<Option<RpcLeaderSchedule>> {
         let params = slot.map(|slot| json!(slot));
         let response = self
             .client

--- a/client/src/rpc_request.rs
+++ b/client/src/rpc_request.rs
@@ -6,7 +6,7 @@ use solana_sdk::{
     hash::Hash,
     transaction::{Result, Transaction},
 };
-use std::{error, fmt, io, net::SocketAddr};
+use std::{collections::HashMap, error, fmt, io, net::SocketAddr};
 
 pub type RpcResponseIn<T> = JsonResult<Response<T>>;
 pub type RpcResponse<T> = io::Result<Response<T>>;
@@ -51,6 +51,9 @@ pub struct RpcContactInfo {
     /// JSON RPC port
     pub rpc: Option<SocketAddr>,
 }
+
+/// Map of leader base58 identity pubkeys to the slot indices relative to the first epoch slot
+pub type RpcLeaderSchedule = HashMap<String, Vec<usize>>;
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]


### PR DESCRIPTION
Fetching a `getLeaderSchedule` with production Epochs is extremely slow due to all the repeated base58 pubkeys.   Break the API and return a dictionary of pubkeys to slot indices instead.