### PR TITLE
Tune bench-tps blockhash poller and stop panicking

### DIFF
--- a/bench-tps/src/bench.rs
+++ b/bench-tps/src/bench.rs
@@ -24,6 +24,7 @@ use std::{
     cmp,
     collections::VecDeque,
     net::SocketAddr,
+    process::exit,
     sync::{
         atomic::{AtomicBool, AtomicIsize, AtomicUsize, Ordering},
         Arc, RwLock,
@@ -411,7 +412,10 @@ fn poll_blockhash<T: Client>(
                 blockhash_last_updated = Instant::now();
                 true
             } else {
-                if blockhash_last_updated.elapsed().as_secs() > 30 {
+                if blockhash_last_updated.elapsed().as_secs() > 120 {
+                    eprintln!("Blockhash is stuck");
+                    exit(1)
+                } else if blockhash_last_updated.elapsed().as_secs() > 30 {
                     error!("Blockhash is not updating");
                 }
                 false

--- a/bench-tps/src/bench.rs
+++ b/bench-tps/src/bench.rs
@@ -402,29 +402,33 @@ fn poll_blockhash<T: Client>(
     client: &Arc<T>,
     id: &Pubkey,
 ) {
-    let mut blockhash_time;
+    let mut blockhash_last_updated = Instant::now();
     loop {
-        blockhash_time = Instant::now();
-        loop {
+        let blockhash_updated = {
             let old_blockhash = *blockhash.read().unwrap();
             if let Ok((new_blockhash, _fee)) = client.get_new_blockhash(&old_blockhash) {
                 *blockhash.write().unwrap() = new_blockhash;
-                break;
+                blockhash_last_updated = Instant::now();
+                true
             } else {
-                if blockhash_time.elapsed().as_secs() > 30 {
-                    panic!("Blockhash is not updating");
+                if blockhash_last_updated.elapsed().as_secs() > 30 {
+                    error!("Blockhash is not updating");
                 }
-                sleep(Duration::from_millis(50));
-                continue;
+                false
             }
-        }
+        };
 
-        let balance = client.get_balance(id).unwrap_or(0);
-        metrics_submit_lamport_balance(balance);
+        if blockhash_updated {
+            let balance = client.get_balance(id).unwrap_or(0);
+            metrics_submit_lamport_balance(balance);
+        }
 
         if exit_signal.load(Ordering::Relaxed) {
             break;
         }
+
+        // Wait a slot before checking again
+        sleep(Duration::from_millis(400));
     }
 }
 

--- a/bench-tps/src/bench.rs
+++ b/bench-tps/src/bench.rs
@@ -404,6 +404,7 @@ fn poll_blockhash<T: Client>(
     id: &Pubkey,
 ) {
     let mut blockhash_last_updated = Instant::now();
+    let mut last_error_log = Instant::now();
     loop {
         let blockhash_updated = {
             let old_blockhash = *blockhash.read().unwrap();
@@ -416,7 +417,10 @@ fn poll_blockhash<T: Client>(
                     eprintln!("Blockhash is stuck");
                     exit(1)
                 } else if blockhash_last_updated.elapsed().as_secs() > 30 {
-                    error!("Blockhash is not updating");
+                    if last_error_log.elapsed().as_secs() >= 1 {
+                        last_error_log = Instant::now();
+                        error!("Blockhash is not updating");
+                    }
                 }
                 false
             }

--- a/bench-tps/src/bench.rs
+++ b/bench-tps/src/bench.rs
@@ -427,8 +427,7 @@ fn poll_blockhash<T: Client>(
             break;
         }
 
-        // Wait a slot before checking again
-        sleep(Duration::from_millis(400));
+        sleep(Duration::from_millis(50));
     }
 }
 

--- a/bench-tps/src/bench.rs
+++ b/bench-tps/src/bench.rs
@@ -416,11 +416,11 @@ fn poll_blockhash<T: Client>(
                 if blockhash_last_updated.elapsed().as_secs() > 120 {
                     eprintln!("Blockhash is stuck");
                     exit(1)
-                } else if blockhash_last_updated.elapsed().as_secs() > 30 {
-                    if last_error_log.elapsed().as_secs() >= 1 {
-                        last_error_log = Instant::now();
-                        error!("Blockhash is not updating");
-                    }
+                } else if blockhash_last_updated.elapsed().as_secs() > 30
+                    && last_error_log.elapsed().as_secs() >= 1
+                {
+                    last_error_log = Instant::now();
+                    error!("Blockhash is not updating");
                 }
                 false
             }


### PR DESCRIPTION
#### Problem
The bench-tps blockhash poller panics after 30s if a new blockhash hasn't been found.

This behaviour doesn't make sense now because the bench-tps client doesn't block on receiving a new blockhash. It can now continue using the same blockhash until it's no longer valid. Also, the poller doesn't need to be nearly as aggressive as it is currently. Once per slot is more than enough since it has ~2min to find a new one.

#### Summary of Changes
* Remove panic when a new blockhash hasn't been found
* Decrease polling frequency of blockhash

Fixes #
