### PR TITLE
CLI: Fix offline signing Pay TX

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -504,7 +504,7 @@ pub fn parse_command(matches: &ArgMatches<'_>) -> Result<CliCommandInfo, Box<dyn
                     signers,
                     blockhash,
                 },
-                require_keypair: !sign_only,
+                require_keypair: true,
             })
         }
         ("show-account", Some(matches)) => {
@@ -2216,7 +2216,7 @@ mod tests {
                     signers: None,
                     blockhash: None,
                 },
-                require_keypair: false
+                require_keypair: true,
             }
         );
 


### PR DESCRIPTION
#### Problem

Offline signing a `pay` TX with CLI currently uses `!sign_only` to set the `CliCommandInfo`'s `require_keypair` field.  When `require_keypair` is `false` there is a, potentially unexpected, side-effect that the client is assigned a random keypair.  As a result, `solana pay --sign-only ...` results in the transaction being signed by a random keypair and later submission of the TX fails.  Switching the logic to use `signers.is_none()` also fails due to insufficient funds of a random fee payer keypair.

#### Summary of Changes

Always require a keypair when executing the `pay` command