### PR TITLE
Don't keep generating transactions in non-sustained bench-tps mode

### DIFF
--- a/bench-tps/src/bench.rs
+++ b/bench-tps/src/bench.rs
@@ -197,7 +197,9 @@ where
                 sleep(Duration::from_millis(1));
             }
         } else {
-            while shared_tx_active_thread_count.load(Ordering::Relaxed) > 0 {
+            while !shared_txs.read().unwrap().is_empty()
+                || shared_tx_active_thread_count.load(Ordering::Relaxed) > 0
+            {
                 sleep(Duration::from_millis(1));
             }
         }


### PR DESCRIPTION
#### Problem

Transaction sending threads can be sleeping before this check is hit and such will try to keep signing transactions when it doesn't need to.

#### Summary of Changes

Also check that the sending threads have exhausted the transactions generated so far in addition to waiting for thread idle.

Fixes #
