### PR TITLE
Rename slot_hash => bank_hash in AcoountsDB

### DIFF
--- a/ci/buildkite.yml
+++ b/ci/buildkite.yml
@@ -20,7 +20,7 @@ steps:
     timeout_in_minutes: 30
   - command: ". ci/rust-version.sh; ci/docker-run.sh $$rust_stable_docker_image ci/test-stable.sh"
     name: "stable"
-    timeout_in_minutes: 50
+    timeout_in_minutes: 40
     artifact_paths: "log-*.txt"
   - command: ". ci/rust-version.sh; ci/docker-run.sh $$rust_stable_docker_image ci/test-move.sh"
     name: "move"

--- a/ci/buildkite.yml
+++ b/ci/buildkite.yml
@@ -20,7 +20,7 @@ steps:
     timeout_in_minutes: 30
   - command: ". ci/rust-version.sh; ci/docker-run.sh $$rust_stable_docker_image ci/test-stable.sh"
     name: "stable"
-    timeout_in_minutes: 40
+    timeout_in_minutes: 50
     artifact_paths: "log-*.txt"
   - command: ". ci/rust-version.sh; ci/docker-run.sh $$rust_stable_docker_image ci/test-move.sh"
     name: "move"

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -477,10 +477,10 @@ impl Accounts {
     }
 
     pub fn bank_hash_at(&self, slot_id: Slot) -> BankHash {
-        let slot_hashes = self.accounts_db.slot_hashes.read().unwrap();
-        *slot_hashes
+        let bank_hashes = self.accounts_db.bank_hashes.read().unwrap();
+        *bank_hashes
             .get(&slot_id)
-            .expect("No accounts hash was found for this bank, that should not be possible")
+            .expect("No bank hash was found for this bank, that should not be possible")
     }
 
     /// This function will prevent multiple threads from modifying the same account state at the


### PR DESCRIPTION
Quick follow-up PR as per [this](https://github.com/solana-labs/solana/pull/7559):

> I avoided renaming the `AccontsDB::slot_hashes` field to `AccountsDB::bank_hashes` as it will introduce too noise for this PR, which is already a bit sizable. I'll do a quick dumb-replace PR after this PR.
