### PR TITLE
cli: --verbose now causes show-block-production to list all slots and highlight the specific misses

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -1136,7 +1136,7 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             commitment_config,
         ),
         CliCommand::ShowBlockProduction { epoch, slot_limit } => {
-            process_show_block_production(&rpc_client, *epoch, *slot_limit)
+            process_show_block_production(&rpc_client, config, *epoch, *slot_limit)
         }
         CliCommand::ShowGossip => process_show_gossip(&rpc_client),
         CliCommand::ShowValidators { use_lamports_unit } => {


### PR DESCRIPTION
When digging into why a given validator is not producing blocks as expected, it's useful to see the full leader schedule and markers for each individual miss.    