### PR TITLE
Limit maximum number of shreds in a slot to 32K

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -536,6 +536,7 @@ impl ReplayStage {
             }
             Err(Error::BlockError(_)) => true,
             Err(Error::BlocktreeError(BlocktreeError::InvalidShredData(_))) => true,
+            Err(Error::BlocktreeError(BlocktreeError::DeadSlot)) => true,
             _ => false,
         }
     }

--- a/core/src/sigverify_shreds.rs
+++ b/core/src/sigverify_shreds.rs
@@ -4,12 +4,10 @@ use crate::sigverify;
 use crate::sigverify_stage::SigVerifier;
 use solana_ledger::bank_forks::BankForks;
 use solana_ledger::leader_schedule_cache::LeaderScheduleCache;
-use solana_ledger::shred::ShredType;
+use solana_ledger::shred::{OFFSET_OF_SHRED_SLOT, SIZE_OF_SHRED_SLOT};
 use solana_ledger::sigverify_shreds::verify_shreds_gpu;
 use solana_perf::recycler_cache::RecyclerCache;
-use solana_sdk::signature::Signature;
 use std::collections::{HashMap, HashSet};
-use std::mem::size_of;
 use std::sync::{Arc, RwLock};
 
 #[derive(Clone)]
@@ -36,8 +34,8 @@ impl ShredSigVerifier {
             .iter()
             .flat_map(|batch| {
                 batch.packets.iter().filter_map(|packet| {
-                    let slot_start = size_of::<Signature>() + size_of::<ShredType>();
-                    let slot_end = slot_start + size_of::<u64>();
+                    let slot_start = OFFSET_OF_SHRED_SLOT;
+                    let slot_end = slot_start + SIZE_OF_SHRED_SLOT;
                     trace!("slot {} {}", slot_start, slot_end,);
                     if slot_end <= packet.meta.size {
                         limited_deserialize(&packet.data[slot_start..slot_end]).ok()

--- a/ledger/src/blocktree_db.rs
+++ b/ledger/src/blocktree_db.rs
@@ -41,6 +41,7 @@ pub enum BlocktreeError {
     InvalidShredData(Box<bincode::ErrorKind>),
     RocksDb(#[from] rocksdb::Error),
     SlotNotRooted,
+    DeadSlot,
     IO(#[from] std::io::Error),
     Serialize(#[from] Box<bincode::ErrorKind>),
     FsExtraError(#[from] fs_extra::error::Error),

--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -31,12 +31,18 @@ pub const SIZE_OF_COMMON_SHRED_HEADER: usize = 83;
 pub const SIZE_OF_DATA_SHRED_HEADER: usize = 3;
 pub const SIZE_OF_CODING_SHRED_HEADER: usize = 6;
 pub const SIZE_OF_SIGNATURE: usize = 64;
+pub const SIZE_OF_SHRED_TYPE: usize = 1;
+pub const SIZE_OF_SHRED_SLOT: usize = 8;
+pub const SIZE_OF_SHRED_INDEX: usize = 4;
 pub const SIZE_OF_DATA_SHRED_IGNORED_TAIL: usize =
     SIZE_OF_COMMON_SHRED_HEADER + SIZE_OF_CODING_SHRED_HEADER;
 pub const SIZE_OF_DATA_SHRED_PAYLOAD: usize = PACKET_DATA_SIZE
     - SIZE_OF_COMMON_SHRED_HEADER
     - SIZE_OF_DATA_SHRED_HEADER
     - SIZE_OF_DATA_SHRED_IGNORED_TAIL;
+
+pub const OFFSET_OF_SHRED_SLOT: usize = SIZE_OF_SIGNATURE + SIZE_OF_SHRED_TYPE;
+pub const OFFSET_OF_SHRED_INDEX: usize = OFFSET_OF_SHRED_SLOT + SIZE_OF_SHRED_SLOT;
 
 thread_local!(static PAR_THREAD_POOL: RefCell<ThreadPool> = RefCell::new(rayon::ThreadPoolBuilder::new()
                     .num_threads(get_thread_count())
@@ -923,6 +929,18 @@ pub mod tests {
         assert_eq!(
             SIZE_OF_SIGNATURE,
             bincode::serialized_size(&Signature::default()).unwrap() as usize
+        );
+        assert_eq!(
+            SIZE_OF_SHRED_TYPE,
+            bincode::serialized_size(&ShredType::default()).unwrap() as usize
+        );
+        assert_eq!(
+            SIZE_OF_SHRED_SLOT,
+            bincode::serialized_size(&Slot::default()).unwrap() as usize
+        );
+        assert_eq!(
+            SIZE_OF_SHRED_INDEX,
+            bincode::serialized_size(&ShredCommonHeader::default().index).unwrap() as usize
         );
     }
 

--- a/ledger/src/sigverify_shreds.rs
+++ b/ledger/src/sigverify_shreds.rs
@@ -45,6 +45,9 @@ fn verify_shred_cpu(packet: &Packet, slot_leaders: &HashMap<u64, [u8; 32]>) -> O
     let slot_end = slot_start + size_of::<u64>();
     let msg_start = sig_end;
     let msg_end = packet.meta.size;
+    if packet.meta.discard {
+        return Some(0);
+    }
     trace!("slot start and end {} {}", slot_start, slot_end);
     if packet.meta.size < slot_end {
         return Some(0);
@@ -104,7 +107,7 @@ fn slot_key_data_for_gpu<
                         .map(|packet| {
                             let slot_start = size_of::<Signature>() + size_of::<ShredType>();
                             let slot_end = slot_start + size_of::<u64>();
-                            if packet.meta.size < slot_end {
+                            if packet.meta.size < slot_end || packet.meta.discard {
                                 return std::u64::MAX;
                             }
                             let slot: Option<u64> =


### PR DESCRIPTION
#### Problem
A malicious node can determine its next leader slot in an epoch. It can generate/cache excessive number of pre-processed transactions. This can potentially lead to DDoS attack on the cluster.

#### Summary of Changes
Limit maximum number of shreds in a slot to 32K. This allows peak txs in a slot to ~128K (or 320K TPS). The slot with more shreds will be marked dead.

Fixes #7531 
