### PR TITLE
Add slot_history for slashing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3930,6 +3930,7 @@ dependencies = [
  "assert_matches 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bincode 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bs58 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bv 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ed25519-dalek 1.0.0-pre.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "generic-array 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -1830,6 +1830,7 @@ dependencies = [
  "assert_matches 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bincode 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bs58 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bv 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ed25519-dalek 1.0.0-pre.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "generic-array 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/programs/vote/src/vote_instruction.rs
+++ b/programs/vote/src/vote_instruction.rs
@@ -227,9 +227,9 @@ mod tests {
             .iter()
             .map(|meta| {
                 if sysvar::clock::check_id(&meta.pubkey) {
-                    sysvar::clock::Clock::default().create_account(1)
+                    Clock::default().create_account(1)
                 } else if sysvar::slot_hashes::check_id(&meta.pubkey) {
-                    sysvar::slot_hashes::create_account(1, &[])
+                    SlotHashes::default().create_account(1)
                 } else if sysvar::rent::check_id(&meta.pubkey) {
                     Rent::free().create_account(1)
                 } else {

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -28,6 +28,7 @@ default = [
 assert_matches = { version = "1.3.0", optional = true }
 bincode = "1.2.1"
 bs58 = "0.3.0"
+bv = { version = "0.11.0", features = ["serde"] }
 byteorder = { version = "1.3.2", optional = true }
 generic-array = { version = "0.13.2", default-features = false, features = ["serde", "more_lengths"] }
 hex = "0.4.0"

--- a/sdk/benches/slot_hashes.rs
+++ b/sdk/benches/slot_hashes.rs
@@ -3,7 +3,7 @@
 extern crate test;
 use solana_sdk::{
     hash::Hash,
-    slot_hashes::{Slot, SlotHashes, MAX_SLOT_HASHES},
+    slot_hashes::{Slot, SlotHashes, MAX_ENTRIES},
     sysvar::Sysvar,
 };
 use test::Bencher;
@@ -11,12 +11,10 @@ use test::Bencher;
 #[bench]
 fn bench_to_from_account(b: &mut Bencher) {
     let mut slot_hashes = SlotHashes::new(&[]);
-    for i in 0..MAX_SLOT_HASHES {
+    for i in 0..MAX_ENTRIES {
         slot_hashes.add(i as Slot, Hash::default());
     }
-    let mut reps = 0;
     b.iter(|| {
-        reps += 1;
         let account = slot_hashes.create_account(0);
         slot_hashes = SlotHashes::from_account(&account).unwrap();
     });

--- a/sdk/benches/slot_history.rs
+++ b/sdk/benches/slot_history.rs
@@ -1,0 +1,15 @@
+#![feature(test)]
+
+extern crate test;
+use solana_sdk::{slot_history::SlotHistory, sysvar::Sysvar};
+use test::Bencher;
+
+#[bench]
+fn bench_to_from_account(b: &mut Bencher) {
+    let mut slot_history = SlotHistory::new(1 * 1024 * 1024);
+
+    b.iter(|| {
+        let account = slot_history.create_account(0);
+        slot_history = SlotHistory::from_account(&account).unwrap();
+    });
+}

--- a/sdk/benches/slot_history.rs
+++ b/sdk/benches/slot_history.rs
@@ -6,7 +6,7 @@ use test::Bencher;
 
 #[bench]
 fn bench_to_from_account(b: &mut Bencher) {
-    let mut slot_history = SlotHistory::new(1 * 1024 * 1024);
+    let mut slot_history = SlotHistory::default();
 
     b.iter(|| {
         let account = slot_history.create_account(0);

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -26,6 +26,7 @@ pub mod rent;
 pub mod rpc_port;
 pub mod short_vec;
 pub mod slot_hashes;
+pub mod slot_history;
 pub mod system_instruction;
 pub mod system_program;
 pub mod sysvar;

--- a/sdk/src/slot_hashes.rs
+++ b/sdk/src/slot_hashes.rs
@@ -5,7 +5,7 @@
 use crate::hash::Hash;
 use std::{iter::FromIterator, ops::Deref};
 
-pub const MAX_SLOT_HASHES: usize = 512; // about 2.5 minutes to get your vote in
+pub const MAX_ENTRIES: usize = 512; // about 2.5 minutes to get your vote in
 
 pub use crate::clock::Slot;
 
@@ -21,7 +21,7 @@ impl SlotHashes {
             Ok(index) => (self.0)[index] = (slot, hash),
             Err(index) => (self.0).insert(index, (slot, hash)),
         }
-        (self.0).truncate(MAX_SLOT_HASHES);
+        (self.0).truncate(MAX_ENTRIES);
     }
     #[allow(clippy::trivially_copy_pass_by_ref)]
     pub fn get(&self, slot: &Slot) -> Option<&Hash> {
@@ -68,16 +68,16 @@ mod tests {
         );
 
         let mut slot_hashes = SlotHashes::new(&[]);
-        for i in 0..MAX_SLOT_HASHES + 1 {
+        for i in 0..MAX_ENTRIES + 1 {
             slot_hashes.add(
                 i as u64,
                 hash(&[(i >> 24) as u8, (i >> 16) as u8, (i >> 8) as u8, i as u8]),
             );
         }
-        for i in 0..MAX_SLOT_HASHES {
-            assert_eq!(slot_hashes[i].0, (MAX_SLOT_HASHES - i) as u64);
+        for i in 0..MAX_ENTRIES {
+            assert_eq!(slot_hashes[i].0, (MAX_ENTRIES - i) as u64);
         }
 
-        assert_eq!(slot_hashes.len(), MAX_SLOT_HASHES);
+        assert_eq!(slot_hashes.len(), MAX_ENTRIES);
     }
 }

--- a/sdk/src/slot_history.rs
+++ b/sdk/src/slot_history.rs
@@ -1,0 +1,72 @@
+//!
+//! slot history
+//!
+pub use crate::clock::Slot;
+use bv::BitVec;
+
+#[repr(C)]
+#[derive(Serialize, Deserialize, PartialEq, Debug)]
+pub struct SlotHistory {
+    pub bits: BitVec<u64>,
+    pub next_slot: Slot,
+}
+
+impl Default for SlotHistory {
+    fn default() -> Self {
+        let mut bits = BitVec::new_fill(false, MAX_ENTRIES);
+        bits.set(0, true);
+        Self { bits, next_slot: 1 }
+    }
+}
+
+pub const MAX_ENTRIES: u64 = 1024 * 1024; // 1 million slots is about 5 days
+
+#[derive(PartialEq, Debug)]
+pub enum Check {
+    Future,
+    TooOld,
+    Found,
+    NotFound,
+}
+
+impl SlotHistory {
+    pub fn add(&mut self, slot: Slot) {
+        for skipped in self.next_slot..slot {
+            self.bits.set(skipped % MAX_ENTRIES, false);
+        }
+        self.bits.set(slot % MAX_ENTRIES, true);
+        self.next_slot = slot + 1;
+    }
+
+    pub fn check(&self, slot: Slot) -> Check {
+        if slot >= self.next_slot {
+            Check::Future
+        } else if self.next_slot - slot > MAX_ENTRIES {
+            Check::TooOld
+        } else if self.bits.get(slot % MAX_ENTRIES) {
+            Check::Found
+        } else {
+            Check::NotFound
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test() {
+        let mut slot_history = SlotHistory::default();
+        slot_history.add(2);
+        assert_eq!(slot_history.check(0), Check::Found);
+        assert_eq!(slot_history.check(1), Check::NotFound);
+        for i in 3..MAX_ENTRIES {
+            assert_eq!(slot_history.check(i), Check::Future);
+        }
+        slot_history.add(MAX_ENTRIES);
+        assert_eq!(slot_history.check(0), Check::TooOld);
+        assert_eq!(slot_history.check(1), Check::NotFound);
+        assert_eq!(slot_history.check(2), Check::Found);
+    }
+}

--- a/sdk/src/sysvar/recent_blockhashes.rs
+++ b/sdk/src/sysvar/recent_blockhashes.rs
@@ -39,8 +39,9 @@ impl<'a> FromIterator<&'a Hash> for RecentBlockhashes {
 }
 
 impl Sysvar for RecentBlockhashes {
-    fn biggest() -> Self {
-        RecentBlockhashes(vec![Hash::default(); MAX_ENTRIES])
+    fn size_of() -> usize {
+        // hard-coded so that we don't have to construct an empty
+        1032 // golden, update if MAX_ENTRIES changes
     }
 }
 
@@ -85,6 +86,15 @@ pub fn create_test_recent_blockhashes(start: usize) -> RecentBlockhashes {
 mod tests {
     use super::*;
     use crate::hash::Hash;
+
+    #[test]
+    fn test_size_of() {
+        assert_eq!(
+            bincode::serialized_size(&RecentBlockhashes(vec![Hash::default(); MAX_ENTRIES]))
+                .unwrap() as usize,
+            RecentBlockhashes::size_of()
+        );
+    }
 
     #[test]
     fn test_create_account_empty() {

--- a/sdk/src/sysvar/slot_history.rs
+++ b/sdk/src/sysvar/slot_history.rs
@@ -1,0 +1,30 @@
+//! named accounts for synthesized data accounts for bank state, etc.
+//!
+//! this account carries a bitvector of slots present over the past
+//!   epoch
+//!
+pub use crate::slot_history::SlotHistory;
+
+use crate::sysvar::Sysvar;
+
+crate::declare_sysvar_id!("SysvarS1otHistory11111111111111111111111111", SlotHistory);
+
+impl Sysvar for SlotHistory {
+    // override
+    fn size_of() -> usize {
+        // hard-coded so that we don't have to construct an empty
+        131_097 // golden, update if MAX_ENTRIES changes
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn test_size_of() {
+        assert_eq!(
+            SlotHistory::size_of(),
+            bincode::serialized_size(&SlotHistory::default()).unwrap() as usize
+        );
+    }
+}


### PR DESCRIPTION
#### Problem
 vote account slashing requires knowing kind of a lot about which slots are
 ancestors of the current bank

 #### Summary of Changes
 * add slot_history, 1M slots in a bitvector
 * remove "Sysvar::biggest()", which was wastefully allocating another instance
    at every invocation of create_account()
 * add slot_history to bank
 * benches for slot_hashes and slot_history, our biggest sysvars

Fixes #7553 