### PR TITLE
Extend Stable CI job timeout to 60 minutes

### DIFF
--- a/ci/buildkite.yml
+++ b/ci/buildkite.yml
@@ -20,7 +20,7 @@ steps:
     timeout_in_minutes: 30
   - command: ". ci/rust-version.sh; ci/docker-run.sh $$rust_stable_docker_image ci/test-stable.sh"
     name: "stable"
-    timeout_in_minutes: 40
+    timeout_in_minutes: 60
     artifact_paths: "log-*.txt"
   - command: ". ci/rust-version.sh; ci/docker-run.sh $$rust_stable_docker_image ci/test-move.sh"
     name: "move"


### PR DESCRIPTION
#### Problem
Tests in `ci/test-stable.sh` have been taking longer to finish recently, causing buildkite jobs to timeout and fail, and subsequent tarball-building not to run.

#### Proposed Solution
Extend the timeout to 60 minutes.  Longer term solution should be to reduce the set of blocking tests to get satisfactory PRs in faster and run more exhaustive tests nightly.  For now, this shouldn't be blocking our development cycle.
