### PR TITLE
Specify version for solana-sdk-macro to enable crate.io publishing

### DIFF
--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -49,7 +49,7 @@ thiserror = "1.0"
 ed25519-dalek = { version = "=1.0.0-pre.1", optional = true }
 solana-crate-features = { path = "../crate-features", version = "0.23.0", optional = true }
 solana-logger = { path = "../logger", version = "0.23.0", optional = true }
-solana-sdk-macro = { path = "macro" }
+solana-sdk-macro = { path = "macro", version = "0.23.0" }
 
 [dev-dependencies]
 tiny-bip39 = "0.6.2"


### PR DESCRIPTION
#### Problem

Publishing scripts fail due to missing solana-sdk-macro version

#### Summary of Changes

Add version

Fixes #
