### PR TITLE
Support nonced transactions in the CLI

### DIFF
--- a/cli/src/nonce.rs
+++ b/cli/src/nonce.rs
@@ -4,9 +4,10 @@ use crate::cli::{
     CliError, ProcessResult,
 };
 use clap::{App, Arg, ArgMatches, SubCommand};
-use solana_clap_utils::{input_parsers::*, input_validators::*};
+use solana_clap_utils::{input_parsers::*, input_validators::*, ArgConstant};
 use solana_client::rpc_client::RpcClient;
 use solana_sdk::{
+    account::Account,
     account_utils::State,
     hash::Hash,
     nonce_instruction::{authorize, create_nonce_account, nonce, withdraw, NonceError},
@@ -16,6 +17,30 @@ use solana_sdk::{
     signature::{Keypair, KeypairUtil},
     system_instruction::SystemError,
     transaction::Transaction,
+};
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum CliNonceError {
+    InvalidAccountOwner,
+    InvalidAccountData,
+    InvalidHash,
+    InvalidAuthority,
+    InvalidState,
+}
+
+pub const NONCE_ARG: ArgConstant<'static> = ArgConstant {
+    name: "nonce",
+    long: "nonce",
+    help: "Provide the nonce account to use when creating a nonced \n\
+           transaction. Nonced transactions are useful when a transaction \n\
+           requires a lengthy signing process. Learn more about nonced \n\
+           transactions at https://docs.solana.com/offline-signing",
+};
+
+pub const NONCE_AUTHORITY_ARG: ArgConstant<'static> = ArgConstant {
+    name: "nonce_authority",
+    long: "nonce-authority",
+    help: "Provide the nonce authority keypair to use when signing a nonced transaction",
 };
 
 pub trait NonceSubCommands {
@@ -273,6 +298,34 @@ pub fn parse_withdraw_from_nonce_account(
     })
 }
 
+/// Check if a nonce account is initialized with the given authority and hash
+pub fn check_nonce_account(
+    nonce_account: &Account,
+    nonce_authority: &Pubkey,
+    nonce_hash: &Hash,
+) -> Result<(), Box<CliError>> {
+    if nonce_account.owner != nonce_program::ID {
+        return Err(CliError::InvalidNonce(CliNonceError::InvalidAccountOwner).into());
+    }
+    let nonce_state: NonceState = nonce_account
+        .state()
+        .map_err(|_| Box::new(CliError::InvalidNonce(CliNonceError::InvalidAccountData)))?;
+    match nonce_state {
+        NonceState::Initialized(meta, hash) => {
+            if &hash != nonce_hash {
+                Err(CliError::InvalidNonce(CliNonceError::InvalidHash).into())
+            } else if nonce_authority != &meta.nonce_authority {
+                Err(CliError::InvalidNonce(CliNonceError::InvalidAuthority).into())
+            } else {
+                Ok(())
+            }
+        }
+        NonceState::Uninitialized => {
+            Err(CliError::InvalidNonce(CliNonceError::InvalidState).into())
+        }
+    }
+}
+
 pub fn process_authorize_nonce_account(
     rpc_client: &RpcClient,
     config: &CliConfig,
@@ -491,7 +544,13 @@ pub fn process_withdraw_from_nonce_account(
 mod tests {
     use super::*;
     use crate::cli::{app, parse_command};
-    use solana_sdk::signature::{read_keypair_file, write_keypair};
+    use solana_sdk::{
+        account::Account,
+        hash::hash,
+        nonce_state::{Meta as NonceMeta, NonceState},
+        signature::{read_keypair_file, write_keypair},
+        system_program,
+    };
     use tempfile::NamedTempFile;
 
     fn make_tmp_file() -> (String, NamedTempFile) {
@@ -727,6 +786,68 @@ mod tests {
                 },
                 require_keypair: true
             }
+        );
+    }
+
+    #[test]
+    fn test_check_nonce_account() {
+        let blockhash = Hash::default();
+        let nonce_pubkey = Pubkey::new_rand();
+        let valid = Account::new_data(
+            1,
+            &NonceState::Initialized(NonceMeta::new(&nonce_pubkey), blockhash),
+            &nonce_program::ID,
+        );
+        assert!(check_nonce_account(&valid.unwrap(), &nonce_pubkey, &blockhash).is_ok());
+
+        let invalid_owner = Account::new_data(
+            1,
+            &NonceState::Initialized(NonceMeta::new(&nonce_pubkey), blockhash),
+            &system_program::ID,
+        );
+        assert_eq!(
+            check_nonce_account(&invalid_owner.unwrap(), &nonce_pubkey, &blockhash),
+            Err(Box::new(CliError::InvalidNonce(
+                CliNonceError::InvalidAccountOwner
+            ))),
+        );
+
+        let invalid_data = Account::new_data(1, &"invalid", &nonce_program::ID);
+        assert_eq!(
+            check_nonce_account(&invalid_data.unwrap(), &nonce_pubkey, &blockhash),
+            Err(Box::new(CliError::InvalidNonce(
+                CliNonceError::InvalidAccountData
+            ))),
+        );
+
+        let invalid_hash = Account::new_data(
+            1,
+            &NonceState::Initialized(NonceMeta::new(&nonce_pubkey), hash(b"invalid")),
+            &nonce_program::ID,
+        );
+        assert_eq!(
+            check_nonce_account(&invalid_hash.unwrap(), &nonce_pubkey, &blockhash),
+            Err(Box::new(CliError::InvalidNonce(CliNonceError::InvalidHash))),
+        );
+
+        let invalid_authority = Account::new_data(
+            1,
+            &NonceState::Initialized(NonceMeta::new(&Pubkey::new_rand()), blockhash),
+            &nonce_program::ID,
+        );
+        assert_eq!(
+            check_nonce_account(&invalid_authority.unwrap(), &nonce_pubkey, &blockhash),
+            Err(Box::new(CliError::InvalidNonce(
+                CliNonceError::InvalidAuthority
+            ))),
+        );
+
+        let invalid_state = Account::new_data(1, &NonceState::Uninitialized, &nonce_program::ID);
+        assert_eq!(
+            check_nonce_account(&invalid_state.unwrap(), &nonce_pubkey, &blockhash),
+            Err(Box::new(CliError::InvalidNonce(
+                CliNonceError::InvalidState
+            ))),
         );
     }
 }

--- a/cli/src/nonce.rs
+++ b/cli/src/nonce.rs
@@ -34,7 +34,7 @@ pub const NONCE_ARG: ArgConstant<'static> = ArgConstant {
     help: "Provide the nonce account to use when creating a nonced \n\
            transaction. Nonced transactions are useful when a transaction \n\
            requires a lengthy signing process. Learn more about nonced \n\
-           transactions at https://docs.solana.com/offline-signing",
+           transactions at https://docs.solana.com/offline-signing/durable-nonce",
 };
 
 pub const NONCE_AUTHORITY_ARG: ArgConstant<'static> = ArgConstant {

--- a/cli/tests/pay.rs
+++ b/cli/tests/pay.rs
@@ -1,9 +1,17 @@
 use chrono::prelude::*;
 use serde_json::Value;
-use solana_cli::cli::{process_command, request_and_confirm_airdrop, CliCommand, CliConfig};
+use solana_cli::cli::{
+    process_command, request_and_confirm_airdrop, CliCommand, CliConfig, PayCommand,
+};
 use solana_client::rpc_client::RpcClient;
 use solana_faucet::faucet::run_local_faucet;
-use solana_sdk::{hash::Hash, pubkey::Pubkey, signature::KeypairUtil, signature::Signature};
+use solana_sdk::{
+    account_utils::State,
+    hash::Hash,
+    nonce_state::NonceState,
+    pubkey::Pubkey,
+    signature::{read_keypair_file, write_keypair, Keypair, KeypairUtil, Signature},
+};
 use std::fs::remove_dir_all;
 use std::str::FromStr;
 use std::sync::mpsc::channel;
@@ -12,6 +20,12 @@ use std::sync::mpsc::channel;
 use solana_core::validator::new_validator_for_tests;
 use std::thread::sleep;
 use std::time::Duration;
+use tempfile::NamedTempFile;
+
+fn make_tmp_file() -> (String, NamedTempFile) {
+    let tmp_file = NamedTempFile::new().unwrap();
+    (String::from(tmp_file.path().to_str().unwrap()), tmp_file)
+}
 
 fn check_balance(expected_balance: u64, client: &RpcClient, pubkey: &Pubkey) {
     (0..5).for_each(|tries| {
@@ -69,17 +83,13 @@ fn test_cli_timestamp_tx() {
     // Make transaction (from config_payer to bob_pubkey) requiring timestamp from config_witness
     let date_string = "\"2018-09-19T17:30:59Z\"";
     let dt: DateTime<Utc> = serde_json::from_str(&date_string).unwrap();
-    config_payer.command = CliCommand::Pay {
+    config_payer.command = CliCommand::Pay(PayCommand {
         lamports: 10,
         to: bob_pubkey,
         timestamp: Some(dt),
         timestamp_pubkey: Some(config_witness.keypair.pubkey()),
-        witnesses: None,
-        cancelable: false,
-        sign_only: false,
-        signers: None,
-        blockhash: None,
-    };
+        ..PayCommand::default()
+    });
     let sig_response = process_command(&config_payer);
 
     let object: Value = serde_json::from_str(&sig_response.unwrap()).unwrap();
@@ -144,17 +154,12 @@ fn test_cli_witness_tx() {
     .unwrap();
 
     // Make transaction (from config_payer to bob_pubkey) requiring witness signature from config_witness
-    config_payer.command = CliCommand::Pay {
+    config_payer.command = CliCommand::Pay(PayCommand {
         lamports: 10,
         to: bob_pubkey,
-        timestamp: None,
-        timestamp_pubkey: None,
         witnesses: Some(vec![config_witness.keypair.pubkey()]),
-        cancelable: false,
-        sign_only: false,
-        signers: None,
-        blockhash: None,
-    };
+        ..PayCommand::default()
+    });
     let sig_response = process_command(&config_payer);
 
     let object: Value = serde_json::from_str(&sig_response.unwrap()).unwrap();
@@ -212,17 +217,13 @@ fn test_cli_cancel_tx() {
     .unwrap();
 
     // Make transaction (from config_payer to bob_pubkey) requiring witness signature from config_witness
-    config_payer.command = CliCommand::Pay {
+    config_payer.command = CliCommand::Pay(PayCommand {
         lamports: 10,
         to: bob_pubkey,
-        timestamp: None,
-        timestamp_pubkey: None,
         witnesses: Some(vec![config_witness.keypair.pubkey()]),
         cancelable: true,
-        sign_only: false,
-        signers: None,
-        blockhash: None,
-    };
+        ..PayCommand::default()
+    });
     let sig_response = process_command(&config_payer).unwrap();
 
     let object: Value = serde_json::from_str(&sig_response).unwrap();
@@ -288,17 +289,12 @@ fn test_offline_pay_tx() {
     check_balance(50, &rpc_client, &config_offline.keypair.pubkey());
     check_balance(50, &rpc_client, &config_online.keypair.pubkey());
 
-    config_offline.command = CliCommand::Pay {
+    config_offline.command = CliCommand::Pay(PayCommand {
         lamports: 10,
         to: bob_pubkey,
-        timestamp: None,
-        timestamp_pubkey: None,
-        witnesses: None,
-        cancelable: false,
         sign_only: true,
-        signers: None,
-        blockhash: None,
-    };
+        ..PayCommand::default()
+    });
     let sig_response = process_command(&config_offline).unwrap();
 
     check_balance(50, &rpc_client, &config_offline.keypair.pubkey());
@@ -318,22 +314,96 @@ fn test_offline_pay_tx() {
         })
         .collect();
 
-    config_online.command = CliCommand::Pay {
+    config_online.command = CliCommand::Pay(PayCommand {
         lamports: 10,
         to: bob_pubkey,
-        timestamp: None,
-        timestamp_pubkey: None,
-        witnesses: None,
-        cancelable: false,
-        sign_only: false,
         signers: Some(signers),
         blockhash: Some(blockhash_str.parse::<Hash>().unwrap()),
-    };
+        ..PayCommand::default()
+    });
     process_command(&config_online).unwrap();
 
     check_balance(40, &rpc_client, &config_offline.keypair.pubkey());
     check_balance(50, &rpc_client, &config_online.keypair.pubkey());
     check_balance(10, &rpc_client, &bob_pubkey);
+
+    server.close().unwrap();
+    remove_dir_all(ledger_path).unwrap();
+}
+
+#[test]
+fn test_nonced_pay_tx() {
+    solana_logger::setup();
+
+    let (server, leader_data, alice, ledger_path) = new_validator_for_tests();
+    let (sender, receiver) = channel();
+    run_local_faucet(alice, sender, None);
+    let faucet_addr = receiver.recv().unwrap();
+
+    let rpc_client = RpcClient::new_socket(leader_data.rpc);
+
+    let mut config = CliConfig::default();
+    config.json_rpc_url = format!("http://{}:{}", leader_data.rpc.ip(), leader_data.rpc.port());
+
+    let minimum_nonce_balance = rpc_client
+        .get_minimum_balance_for_rent_exemption(NonceState::size())
+        .unwrap();
+
+    request_and_confirm_airdrop(
+        &rpc_client,
+        &faucet_addr,
+        &config.keypair.pubkey(),
+        50 + minimum_nonce_balance,
+    )
+    .unwrap();
+    check_balance(
+        50 + minimum_nonce_balance,
+        &rpc_client,
+        &config.keypair.pubkey(),
+    );
+
+    // Create nonce account
+    let nonce_account = Keypair::new();
+    let (nonce_keypair_file, mut tmp_file) = make_tmp_file();
+    write_keypair(&nonce_account, tmp_file.as_file_mut()).unwrap();
+    config.command = CliCommand::CreateNonceAccount {
+        nonce_account: read_keypair_file(&nonce_keypair_file).unwrap().into(),
+        nonce_authority: config.keypair.pubkey(),
+        lamports: minimum_nonce_balance,
+    };
+    process_command(&config).unwrap();
+
+    check_balance(50, &rpc_client, &config.keypair.pubkey());
+    check_balance(minimum_nonce_balance, &rpc_client, &nonce_account.pubkey());
+
+    // Fetch nonce hash
+    let account = rpc_client.get_account(&nonce_account.pubkey()).unwrap();
+    let nonce_state: NonceState = account.state().unwrap();
+    let nonce_hash = match nonce_state {
+        NonceState::Initialized(_meta, hash) => hash,
+        _ => panic!("Nonce is not initialized"),
+    };
+
+    let bob_pubkey = Pubkey::new_rand();
+    config.command = CliCommand::Pay(PayCommand {
+        lamports: 10,
+        to: bob_pubkey,
+        blockhash: Some(nonce_hash),
+        nonce_account: Some(nonce_account.pubkey()),
+        ..PayCommand::default()
+    });
+    process_command(&config).expect("failed to process pay command");
+
+    check_balance(40, &rpc_client, &config.keypair.pubkey());
+    check_balance(10, &rpc_client, &bob_pubkey);
+
+    // Verify that nonce has been used
+    let account = rpc_client.get_account(&nonce_account.pubkey()).unwrap();
+    let nonce_state: NonceState = account.state().unwrap();
+    match nonce_state {
+        NonceState::Initialized(_meta, hash) => assert_ne!(hash, nonce_hash),
+        _ => assert!(false, "Nonce is not initialized"),
+    }
 
     server.close().unwrap();
     remove_dir_all(ledger_path).unwrap();

--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -2,7 +2,7 @@ use crate::rpc_request::{Response, RpcResponse};
 use crate::{
     client_error::ClientError,
     generic_rpc_client_request::GenericRpcClientRequest,
-    mock_rpc_client_request::MockRpcClientRequest,
+    mock_rpc_client_request::{MockRpcClientRequest, Mocks},
     rpc_client_request::RpcClientRequest,
     rpc_request::{
         RpcConfirmedBlock, RpcContactInfo, RpcEpochInfo, RpcLeaderSchedule, RpcRequest,
@@ -45,6 +45,12 @@ impl RpcClient {
     pub fn new_mock(url: String) -> Self {
         Self {
             client: Box::new(MockRpcClientRequest::new(url)),
+        }
+    }
+
+    pub fn new_mock_with_mocks(url: String, mocks: Mocks) -> Self {
+        Self {
+            client: Box::new(MockRpcClientRequest::new_with_mocks(url, mocks)),
         }
     }
 

--- a/client/src/rpc_request.rs
+++ b/client/src/rpc_request.rs
@@ -113,7 +113,7 @@ pub struct RpcVoteAccountInfo {
     pub root_slot: Slot,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq, Hash)]
 pub enum RpcRequest {
     ConfirmTransaction,
     DeregisterNode,

--- a/sdk/src/system_transaction.rs
+++ b/sdk/src/system_transaction.rs
@@ -49,3 +49,25 @@ pub fn transfer(
     let instructions = vec![transfer_instruction];
     Transaction::new_signed_instructions(&[from_keypair], instructions, recent_blockhash)
 }
+
+/// Create and sign new nonced system_instruction::Transfer transaction
+pub fn nonced_transfer(
+    from_keypair: &Keypair,
+    to: &Pubkey,
+    lamports: u64,
+    nonce_account: &Pubkey,
+    nonce_authority: &Keypair,
+    nonce_hash: Hash,
+) -> Transaction {
+    let from_pubkey = from_keypair.pubkey();
+    let transfer_instruction = system_instruction::transfer(&from_pubkey, to, lamports);
+    let instructions = vec![transfer_instruction];
+    Transaction::new_signed_with_nonce(
+        instructions,
+        Some(&from_pubkey),
+        &[from_keypair, nonce_authority],
+        nonce_account,
+        &nonce_authority.pubkey(),
+        nonce_hash,
+    )
+}

--- a/sdk/src/transaction.rs
+++ b/sdk/src/transaction.rs
@@ -3,6 +3,7 @@
 use crate::hash::Hash;
 use crate::instruction::{CompiledInstruction, Instruction, InstructionError};
 use crate::message::Message;
+use crate::nonce_instruction;
 use crate::pubkey::Pubkey;
 use crate::short_vec;
 use crate::signature::{KeypairUtil, Signature};
@@ -92,6 +93,19 @@ impl Transaction {
     ) -> Self {
         let message = Message::new_with_payer(instructions, payer);
         Self::new(signing_keypairs, message, recent_blockhash)
+    }
+
+    pub fn new_signed_with_nonce<T: KeypairUtil>(
+        mut instructions: Vec<Instruction>,
+        payer: Option<&Pubkey>,
+        signing_keypairs: &[&T],
+        nonce_account_pubkey: &Pubkey,
+        nonce_authority_pubkey: &Pubkey,
+        nonce_hash: Hash,
+    ) -> Self {
+        let nonce_ix = nonce_instruction::nonce(&nonce_account_pubkey, &nonce_authority_pubkey);
+        instructions.insert(0, nonce_ix);
+        Self::new_signed_with_payer(instructions, payer, signing_keypairs, nonce_hash)
     }
 
     pub fn new_unsigned_instructions(instructions: Vec<Instruction>) -> Self {


### PR DESCRIPTION
#### Problem
The CLI does not support creating nonced transactions. A nonced transaction needs to use a "nonce blockhash" as its "recent blockhash" and needs to begin with a `nonce_instruction::Nonce` instruction which references an initialized nonce account. Lastly, the transaction needs to be signed by the nonce account's authorized key. (The blockhash in the initialized nonce account must match the "nonce blockhash" used for the transaction's "recent blockhash")

#### Summary of Changes
- Add nonce support to `pay`, `delegate-stake`, and `deactivate-stake` with a new `--nonce` arg
- Add `--nonce-authority` arg for optionally specifying a nonce authority keypair (in the case where the payer keypair is not the nonce authority)
- Verify that nonce information is valid before sending the transaction
- Add a bit more functionality to `MockRpcRequest`
- Bulk of the changes are tests

Fixes https://github.com/solana-labs/solana/issues/7121
