### PR TITLE
install: Account for rent

### DIFF
--- a/install/src/command.rs
+++ b/install/src/command.rs
@@ -7,7 +7,7 @@ use chrono::{Local, TimeZone};
 use console::{style, Emoji};
 use indicatif::{ProgressBar, ProgressStyle};
 use solana_client::rpc_client::RpcClient;
-use solana_config_program::{config_instruction, get_config_data};
+use solana_config_program::{config_instruction, get_config_data, ConfigState};
 use solana_sdk::{
     hash::{Hash, Hasher},
     message::Message,
@@ -202,10 +202,13 @@ fn new_update_manifest(
     {
         let (recent_blockhash, _fee_calculator) = rpc_client.get_recent_blockhash()?;
 
+        let lamports = rpc_client
+            .get_minimum_balance_for_rent_exemption(SignedUpdateManifest::max_space() as usize)?;
+
         let new_account = config_instruction::create_account::<SignedUpdateManifest>(
             &from_keypair.pubkey(),
             &update_manifest_keypair.pubkey(),
-            1,      // lamports
+            lamports,
             vec![], // additional keys
         );
         let mut transaction = Transaction::new_unsigned_instructions(new_account);

--- a/programs/config/src/config_processor.rs
+++ b/programs/config/src/config_processor.rs
@@ -18,7 +18,12 @@ pub fn process_instruction(
     let config_keyed_account = &mut next_keyed_account(keyed_accounts_iter)?;
     let current_data: ConfigKeys =
         deserialize(&config_keyed_account.account.data).map_err(|err| {
-            error!("Invalid data in account[0]: {:?} {:?}", data, err);
+            error!(
+                "Unable to deserialize account[0]: {:?} (len={}): {:?}",
+                config_keyed_account.account.data,
+                config_keyed_account.account.data.len(),
+                err
+            );
             InstructionError::InvalidAccountData
         })?;
     let current_signer_keys: Vec<Pubkey> = current_data


### PR DESCRIPTION
`solana-install deploy` was failing because the update manifest account had insufficient lamports for rent