### PR TITLE
Increase verbosity on testnet deletion

### DIFF
--- a/system-test/testnet-automation.sh
+++ b/system-test/testnet-automation.sh
@@ -87,8 +87,10 @@ $(eval echo "$@")"
   )
 
   execution_step "Deleting Testnet"
-  net/"${CLOUD_PROVIDER}".sh delete -p "${TESTNET_TAG}"
-
+  (
+    set -x
+    net/"${CLOUD_PROVIDER}".sh delete -p "${TESTNET_TAG}"
+  )
 }
 trap 'cleanup_testnet $BASH_COMMAND' EXIT
 


### PR DESCRIPTION
#### Problem
Testnet automation is not properly deleting the testnet in between colo nightly runs, causing all but the first runs to fail on resource allocation.

#### Summary of Changes
