### PR TITLE
{genesis,cli}/: Add input validation for --creation-time/--lockup-date args

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3489,6 +3489,7 @@ name = "solana-genesis"
 version = "0.23.0"
 dependencies = [
  "base64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/clap-utils/src/input_parsers.rs
+++ b/clap-utils/src/input_parsers.rs
@@ -33,7 +33,10 @@ where
     }
 }
 
-pub fn unix_timestamp_of(matches: &ArgMatches<'_>, name: &str) -> Option<UnixTimestamp> {
+pub fn unix_timestamp_from_rfc3339_datetime(
+    matches: &ArgMatches<'_>,
+    name: &str,
+) -> Option<UnixTimestamp> {
     matches.value_of(name).and_then(|value| {
         DateTime::parse_from_rfc3339(value)
             .ok()

--- a/clap-utils/src/input_validators.rs
+++ b/clap-utils/src/input_validators.rs
@@ -1,4 +1,5 @@
 use crate::keypair::ASK_KEYWORD;
+use chrono::DateTime;
 use solana_sdk::hash::Hash;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::{read_keypair_file, Signature};
@@ -128,4 +129,10 @@ pub fn is_amount(amount: String) -> Result<(), String> {
             amount
         ))
     }
+}
+
+pub fn is_rfc3339_datetime(value: String) -> Result<(), String> {
+    DateTime::parse_from_rfc3339(&value)
+        .map(|_| ())
+        .map_err(|e| format!("{:?}", e))
 }

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -86,6 +86,7 @@ impl StakeSubCommands for App<'_, '_> {
                     Arg::with_name("lockup_date")
                         .long("lockup-date")
                         .value_name("RFC3339 DATE TIME")
+                        .validator(is_rfc3339_datetime)
                         .takes_value(true)
                         .help("The date and time at which this account will be available for withdrawal")
                 )
@@ -367,7 +368,7 @@ impl StakeSubCommands for App<'_, '_> {
 pub fn parse_stake_create_account(matches: &ArgMatches<'_>) -> Result<CliCommandInfo, CliError> {
     let stake_account = keypair_of(matches, "stake_account").unwrap();
     let epoch = value_of(&matches, "lockup_epoch").unwrap_or(0);
-    let unix_timestamp = unix_timestamp_of(&matches, "lockup_date").unwrap_or(0);
+    let unix_timestamp = unix_timestamp_from_rfc3339_datetime(&matches, "lockup_date").unwrap_or(0);
     let custodian = pubkey_of(matches, "custodian").unwrap_or_default();
     let staker = pubkey_of(matches, "authorized_staker");
     let withdrawer = pubkey_of(matches, "authorized_withdrawer");

--- a/genesis/Cargo.toml
+++ b/genesis/Cargo.toml
@@ -11,6 +11,7 @@ homepage = "https://solana.com/"
 [dependencies]
 base64 = "0.11.0"
 clap = "2.33.0"
+chrono = "0.4"
 hex = "0.4.0"
 serde = "1.0.104"
 serde_derive = "1.0.103"


### PR DESCRIPTION
1. Passing an invalid `--creation-time` argument causes `solana-genesis` to use a default instead of erroring. 🙅‍♂ 
2. Same for the cli's `--lockup-date` argument.

Instead fail so the user can correct their input.