### PR TITLE
net: Add a stand-alone gossip node on the blocksteamer instance

### DIFF
--- a/gossip/src/main.rs
+++ b/gossip/src/main.rs
@@ -39,6 +39,13 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                         .help("Return all RPC URLs"),
                 )
                 .arg(
+                    Arg::with_name("any")
+                        .long("any")
+                        .takes_value(false)
+                        .conflicts_with("all")
+                        .help("Return any RPC URL"),
+                )
+                .arg(
                     Arg::with_name("timeout")
                         .long("timeout")
                         .value_name("SECONDS")
@@ -237,6 +244,8 @@ fn main() -> Result<(), Box<dyn error::Error>> {
             }
         }
         ("get-rpc-url", Some(matches)) => {
+            let any = matches.is_present("any");
+            let all = matches.is_present("all");
             let entrypoint_addr = parse_entrypoint(&matches);
             let timeout = value_t_or_exit!(matches, "timeout", u64);
             let (nodes, _archivers) = discover(
@@ -251,7 +260,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
             let rpc_addrs: Vec<_> = nodes
                 .iter()
                 .filter_map(|contact_info| {
-                    if (matches.is_present("all") || Some(contact_info.gossip) == entrypoint_addr)
+                    if (any || all || Some(contact_info.gossip) == entrypoint_addr)
                         && ContactInfo::is_valid_address(&contact_info.rpc)
                     {
                         return Some(contact_info.rpc);
@@ -267,6 +276,9 @@ fn main() -> Result<(), Box<dyn error::Error>> {
 
             for rpc_addr in rpc_addrs {
                 println!("http://{}", rpc_addr);
+                if any {
+                    break;
+                }
             }
         }
         ("stop", Some(matches)) => {

--- a/multinode-demo/validator.sh
+++ b/multinode-demo/validator.sh
@@ -273,7 +273,7 @@ setup_validator_accounts() {
   return 0
 }
 
-rpc_url=$($solana_gossip get-rpc-url --entrypoint "$gossip_entrypoint")
+rpc_url=$($solana_gossip get-rpc-url --entrypoint "$gossip_entrypoint" --any)
 
 [[ -r "$identity_keypair_path" ]] || $solana_keygen new --no-passphrase -so "$identity_keypair_path"
 [[ -r "$voting_keypair_path" ]] || $solana_keygen new --no-passphrase -so "$voting_keypair_path"

--- a/net/net.sh
+++ b/net/net.sh
@@ -501,6 +501,7 @@ startBootstrapLeader() {
     ssh "${sshOptions[@]}" -n "$ipAddress" \
       "./solana/net/remote/remote-node.sh \
          $deployMethod \
+         $ipAddress \
          bootstrap-leader \
          $entrypointIp \
          $((${#validatorIpList[@]} + ${#blockstreamerIpList[@]} + ${#archiverIpList[@]})) \
@@ -570,6 +571,7 @@ startNode() {
     ssh "${sshOptions[@]}" -n "$ipAddress" \
       "./solana/net/remote/remote-node.sh \
          $deployMethod \
+         $ipAddress \
          $nodeType \
          $entrypointIp \
          $((${#validatorIpList[@]} + ${#blockstreamerIpList[@]} + ${#archiverIpList[@]})) \


### PR DESCRIPTION
The blocksteamer instance is the TdS cluster entrypoint.  Running an additionally solana-gossip node allows other participants to join a cluster even if the validator node on the blocksteamer instance goes down (like it did during the last informal dry run).