### PR TITLE
Publish bpf-sdk releases

### DIFF
--- a/ci/publish-bpf-sdk.sh
+++ b/ci/publish-bpf-sdk.sh
@@ -10,7 +10,6 @@ else
   CHANNEL_OR_TAG=$CHANNEL
 fi
 
-echo --- Creating tarball
 (
   set -x
   sdk/bpf/scripts/package.sh

--- a/ci/publish-bpf-sdk.sh
+++ b/ci/publish-bpf-sdk.sh
@@ -4,6 +4,13 @@ set -e
 cd "$(dirname "$0")/.."
 eval "$(ci/channel-info.sh)"
 
+TAG=
+if [[ -n "$CI_TAG" ]]; then
+  CHANNEL_OR_TAG=$CI_TAG
+else
+  CHANNEL_OR_TAG=$CHANNEL
+fi
+
 echo --- Creating tarball
 (
   set -x
@@ -12,7 +19,7 @@ echo --- Creating tarball
 )
 
 echo --- AWS S3 Store
-if [[ -z $CHANNEL ]]; then
+if [[ -z $CHANNEL_OR_TAG ]]; then
   echo Skipped
 else
   (
@@ -24,7 +31,7 @@ else
       --volume "$PWD:/solana" \
       eremite/aws-cli:2018.12.18 \
       /usr/bin/s3cmd --acl-public put /solana/bpf-sdk.tar.bz2 \
-      s3://solana-sdk/"$CHANNEL"/bpf-sdk.tar.bz2
+      s3://solana-sdk/"$CHANNEL_OR_TAG"/bpf-sdk.tar.bz2
   )
 fi
 

--- a/ci/publish-bpf-sdk.sh
+++ b/ci/publish-bpf-sdk.sh
@@ -4,7 +4,6 @@ set -e
 cd "$(dirname "$0")/.."
 eval "$(ci/channel-info.sh)"
 
-TAG=
 if [[ -n "$CI_TAG" ]]; then
   CHANNEL_OR_TAG=$CI_TAG
 else

--- a/ci/publish-tarball.sh
+++ b/ci/publish-tarball.sh
@@ -53,7 +53,7 @@ windows)
   ;;
 esac
 
-echo --- Creating tarball
+echo --- Creating release tarball
 (
   set -x
   rm -rf solana-release/
@@ -95,9 +95,15 @@ if [[ "$CI_OS_NAME" = linux ]]; then
   MAYBE_METRICS_TARBALL=solana-metrics.tar.bz2
 fi
 
+(
+  set -x
+  sdk/bpf/scripts/package.sh
+  [[ -f bpf-sdk.tar.bz2 ]]
+)
+
 source ci/upload-ci-artifact.sh
 
-for file in solana-release-$TARGET.tar.bz2 solana-release-$TARGET.yml solana-install-init-"$TARGET"* $MAYBE_METRICS_TARBALL; do
+for file in solana-release-$TARGET.tar.bz2 solana-release-$TARGET.yml solana-install-init-"$TARGET"* $MAYBE_METRICS_TARBALL bpf-sdk.tar.bz2; do
   upload-ci-artifact "$file"
 
   if [[ -n $DO_NOT_PUBLISH_TAR ]]; then

--- a/sdk/bpf/scripts/package.sh
+++ b/sdk/bpf/scripts/package.sh
@@ -3,6 +3,8 @@ set -ex
 
 cd "$(dirname "$0")"/../../..
 
+echo --- Creating bpf-sdk tarball
+
 rm -rf bpf-sdk.tar.bz2 bpf-sdk/
 mkdir bpf-sdk/
 cp LICENSE bpf-sdk/


### PR DESCRIPTION
#### Problem

bpf-sdk published only for channels, no releases tied to a Solana version

#### Summary of Changes

Published a bpf-sdk for each tagged Solana release.

Fixes #
