### PR TITLE
CLI: Fix default nonce authority resolution

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -132,18 +132,18 @@ pub enum CliCommand {
     // Nonce commands
     AuthorizeNonceAccount {
         nonce_account: Pubkey,
-        nonce_authority: KeypairEq,
+        nonce_authority: Option<KeypairEq>,
         new_authority: Pubkey,
     },
     CreateNonceAccount {
         nonce_account: KeypairEq,
-        nonce_authority: Pubkey,
+        nonce_authority: Option<Pubkey>,
         lamports: u64,
     },
     GetNonce(Pubkey),
     NewNonce {
         nonce_account: Pubkey,
-        nonce_authority: KeypairEq,
+        nonce_authority: Option<KeypairEq>,
     },
     ShowNonceAccount {
         nonce_account_pubkey: Pubkey,
@@ -151,7 +151,7 @@ pub enum CliCommand {
     },
     WithdrawFromNonceAccount {
         nonce_account: Pubkey,
-        nonce_authority: KeypairEq,
+        nonce_authority: Option<KeypairEq>,
         destination_account_pubkey: Pubkey,
         lamports: u64,
     },
@@ -1190,13 +1190,13 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
         // Assign authority to nonce account
         CliCommand::AuthorizeNonceAccount {
             nonce_account,
-            nonce_authority,
+            ref nonce_authority,
             new_authority,
         } => process_authorize_nonce_account(
             &rpc_client,
             config,
             nonce_account,
-            nonce_authority,
+            nonce_authority.as_deref(),
             new_authority,
         ),
         // Create nonce account
@@ -1208,7 +1208,7 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             &rpc_client,
             config,
             nonce_account,
-            nonce_authority,
+            *nonce_authority,
             *lamports,
         ),
         // Get the current nonce
@@ -1218,8 +1218,8 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
         // Get a new nonce
         CliCommand::NewNonce {
             nonce_account,
-            nonce_authority,
-        } => process_new_nonce(&rpc_client, config, nonce_account, nonce_authority),
+            ref nonce_authority,
+        } => process_new_nonce(&rpc_client, config, nonce_account, nonce_authority.as_deref()),
         // Show the contents of a nonce account
         CliCommand::ShowNonceAccount {
             nonce_account_pubkey,
@@ -1228,14 +1228,14 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
         // Withdraw lamports from a nonce account
         CliCommand::WithdrawFromNonceAccount {
             nonce_account,
-            nonce_authority,
+            ref nonce_authority,
             destination_account_pubkey,
             lamports,
         } => process_withdraw_from_nonce_account(
             &rpc_client,
             config,
             &nonce_account,
-            nonce_authority,
+            nonce_authority.as_deref(),
             &destination_account_pubkey,
             *lamports,
         ),

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -1219,7 +1219,12 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
         CliCommand::NewNonce {
             nonce_account,
             ref nonce_authority,
-        } => process_new_nonce(&rpc_client, config, nonce_account, nonce_authority.as_deref()),
+        } => process_new_nonce(
+            &rpc_client,
+            config,
+            nonce_account,
+            nonce_authority.as_deref(),
+        ),
         // Show the contents of a nonce account
         CliCommand::ShowNonceAccount {
             nonce_account_pubkey,

--- a/cli/src/nonce.rs
+++ b/cli/src/nonce.rs
@@ -227,7 +227,6 @@ pub fn parse_nonce_create_account(matches: &ArgMatches<'_>) -> Result<CliCommand
     let nonce_account = keypair_of(matches, "nonce_account_keypair").unwrap();
     let lamports = required_lamports_from(matches, "amount", "unit")?;
     let nonce_authority = pubkey_of(matches, "nonce_authority");
-    println!("na: {:?}", nonce_authority);
 
     Ok(CliCommandInfo {
         command: CliCommand::CreateNonceAccount {

--- a/cli/src/nonce.rs
+++ b/cli/src/nonce.rs
@@ -208,20 +208,15 @@ impl NonceSubCommands for App<'_, '_> {
     }
 }
 
-fn resolve_nonce_authority(matches: &ArgMatches<'_>) -> Keypair {
-    keypair_of(matches, "nonce_authority")
-        .unwrap_or_else(|| keypair_of(matches, "nonce_account_keypair").unwrap())
-}
-
 pub fn parse_authorize_nonce_account(matches: &ArgMatches<'_>) -> Result<CliCommandInfo, CliError> {
     let nonce_account = pubkey_of(matches, "nonce_account_keypair").unwrap();
     let new_authority = pubkey_of(matches, "new_authority").unwrap();
-    let nonce_authority = resolve_nonce_authority(matches);
+    let nonce_authority = keypair_of(matches, "nonce_authority").map(|kp| kp.into());
 
     Ok(CliCommandInfo {
         command: CliCommand::AuthorizeNonceAccount {
             nonce_account,
-            nonce_authority: nonce_authority.into(),
+            nonce_authority,
             new_authority,
         },
         require_keypair: true,
@@ -231,8 +226,8 @@ pub fn parse_authorize_nonce_account(matches: &ArgMatches<'_>) -> Result<CliComm
 pub fn parse_nonce_create_account(matches: &ArgMatches<'_>) -> Result<CliCommandInfo, CliError> {
     let nonce_account = keypair_of(matches, "nonce_account_keypair").unwrap();
     let lamports = required_lamports_from(matches, "amount", "unit")?;
-    let nonce_authority =
-        pubkey_of(matches, "nonce_authority").unwrap_or_else(|| nonce_account.pubkey());
+    let nonce_authority = pubkey_of(matches, "nonce_authority");
+    println!("na: {:?}", nonce_authority);
 
     Ok(CliCommandInfo {
         command: CliCommand::CreateNonceAccount {
@@ -255,12 +250,12 @@ pub fn parse_get_nonce(matches: &ArgMatches<'_>) -> Result<CliCommandInfo, CliEr
 
 pub fn parse_new_nonce(matches: &ArgMatches<'_>) -> Result<CliCommandInfo, CliError> {
     let nonce_account = pubkey_of(matches, "nonce_account_keypair").unwrap();
-    let nonce_authority = resolve_nonce_authority(matches);
+    let nonce_authority = keypair_of(matches, "nonce_authority").map(|kp| kp.into());
 
     Ok(CliCommandInfo {
         command: CliCommand::NewNonce {
             nonce_account,
-            nonce_authority: nonce_authority.into(),
+            nonce_authority: nonce_authority,
         },
         require_keypair: true,
     })
@@ -285,12 +280,12 @@ pub fn parse_withdraw_from_nonce_account(
     let nonce_account = pubkey_of(matches, "nonce_account_keypair").unwrap();
     let destination_account_pubkey = pubkey_of(matches, "destination_account_pubkey").unwrap();
     let lamports = required_lamports_from(matches, "amount", "unit")?;
-    let nonce_authority = resolve_nonce_authority(matches);
+    let nonce_authority = keypair_of(matches, "nonce_authority").map(|kp| kp.into());
 
     Ok(CliCommandInfo {
         command: CliCommand::WithdrawFromNonceAccount {
             nonce_account,
-            nonce_authority: nonce_authority.into(),
+            nonce_authority: nonce_authority,
             destination_account_pubkey,
             lamports,
         },
@@ -330,11 +325,12 @@ pub fn process_authorize_nonce_account(
     rpc_client: &RpcClient,
     config: &CliConfig,
     nonce_account: &Pubkey,
-    nonce_authority: &Keypair,
+    nonce_authority: Option<&Keypair>,
     new_authority: &Pubkey,
 ) -> ProcessResult {
     let (recent_blockhash, fee_calculator) = rpc_client.get_recent_blockhash()?;
 
+    let nonce_authority = nonce_authority.unwrap_or(&config.keypair);
     let ix = authorize(nonce_account, &nonce_authority.pubkey(), new_authority);
     let mut tx = Transaction::new_signed_with_payer(
         vec![ix],
@@ -357,7 +353,7 @@ pub fn process_create_nonce_account(
     rpc_client: &RpcClient,
     config: &CliConfig,
     nonce_account: &Keypair,
-    nonce_authority: &Pubkey,
+    nonce_authority: Option<Pubkey>,
     lamports: u64,
 ) -> ProcessResult {
     let nonce_account_pubkey = nonce_account.pubkey();
@@ -383,10 +379,11 @@ pub fn process_create_nonce_account(
         .into());
     }
 
+    let nonce_authority = nonce_authority.unwrap_or(config.keypair.pubkey());
     let ixs = create_nonce_account(
         &config.keypair.pubkey(),
         &nonce_account_pubkey,
-        nonce_authority,
+        &nonce_authority,
         lamports,
     );
     let (recent_blockhash, fee_calculator) = rpc_client.get_recent_blockhash()?;
@@ -431,7 +428,7 @@ pub fn process_new_nonce(
     rpc_client: &RpcClient,
     config: &CliConfig,
     nonce_account: &Pubkey,
-    nonce_authority: &Keypair,
+    nonce_authority: Option<&Keypair>,
 ) -> ProcessResult {
     check_unique_pubkeys(
         (&config.keypair.pubkey(), "cli keypair".to_string()),
@@ -445,6 +442,7 @@ pub fn process_new_nonce(
         .into());
     }
 
+    let nonce_authority = nonce_authority.unwrap_or(&config.keypair);
     let ix = nonce(&nonce_account, &nonce_authority.pubkey());
     let (recent_blockhash, fee_calculator) = rpc_client.get_recent_blockhash()?;
     let mut tx = Transaction::new_signed_with_payer(
@@ -511,12 +509,13 @@ pub fn process_withdraw_from_nonce_account(
     rpc_client: &RpcClient,
     config: &CliConfig,
     nonce_account: &Pubkey,
-    nonce_authority: &Keypair,
+    nonce_authority: Option<&Keypair>,
     destination_account_pubkey: &Pubkey,
     lamports: u64,
 ) -> ProcessResult {
     let (recent_blockhash, fee_calculator) = rpc_client.get_recent_blockhash()?;
 
+    let nonce_authority = nonce_authority.unwrap_or(&config.keypair);
     let ix = withdraw(
         nonce_account,
         &nonce_authority.pubkey(),
@@ -583,7 +582,7 @@ mod tests {
             CliCommandInfo {
                 command: CliCommand::AuthorizeNonceAccount {
                     nonce_account: nonce_account_pubkey,
-                    nonce_authority: read_keypair_file(&keypair_file).unwrap().into(),
+                    nonce_authority: None,
                     new_authority: Pubkey::default(),
                 },
                 require_keypair: true,
@@ -604,7 +603,7 @@ mod tests {
             CliCommandInfo {
                 command: CliCommand::AuthorizeNonceAccount {
                     nonce_account: read_keypair_file(&keypair_file).unwrap().pubkey(),
-                    nonce_authority: read_keypair_file(&authority_keypair_file).unwrap().into(),
+                    nonce_authority: Some(read_keypair_file(&authority_keypair_file).unwrap().into()),
                     new_authority: Pubkey::default(),
                 },
                 require_keypair: true,
@@ -624,7 +623,7 @@ mod tests {
             CliCommandInfo {
                 command: CliCommand::CreateNonceAccount {
                     nonce_account: read_keypair_file(&keypair_file).unwrap().into(),
-                    nonce_authority: nonce_account_pubkey,
+                    nonce_authority: None,
                     lamports: 50,
                 },
                 require_keypair: true
@@ -646,7 +645,7 @@ mod tests {
             CliCommandInfo {
                 command: CliCommand::CreateNonceAccount {
                     nonce_account: read_keypair_file(&keypair_file).unwrap().into(),
-                    nonce_authority: read_keypair_file(&authority_keypair_file).unwrap().pubkey(),
+                    nonce_authority: Some(read_keypair_file(&authority_keypair_file).unwrap().pubkey()),
                     lamports: 50,
                 },
                 require_keypair: true
@@ -678,7 +677,7 @@ mod tests {
             CliCommandInfo {
                 command: CliCommand::NewNonce {
                     nonce_account: nonce_account.pubkey(),
-                    nonce_authority: nonce_account.into(),
+                    nonce_authority: None,
                 },
                 require_keypair: true
             }
@@ -698,7 +697,7 @@ mod tests {
             CliCommandInfo {
                 command: CliCommand::NewNonce {
                     nonce_account: nonce_account.pubkey(),
-                    nonce_authority: read_keypair_file(&authority_keypair_file).unwrap().into(),
+                    nonce_authority: Some(read_keypair_file(&authority_keypair_file).unwrap().into()),
                 },
                 require_keypair: true
             }
@@ -735,7 +734,7 @@ mod tests {
             CliCommandInfo {
                 command: CliCommand::WithdrawFromNonceAccount {
                     nonce_account: read_keypair_file(&keypair_file).unwrap().pubkey(),
-                    nonce_authority: read_keypair_file(&keypair_file).unwrap().into(),
+                    nonce_authority: None,
                     destination_account_pubkey: nonce_account_pubkey,
                     lamports: 42
                 },
@@ -756,7 +755,7 @@ mod tests {
             CliCommandInfo {
                 command: CliCommand::WithdrawFromNonceAccount {
                     nonce_account: read_keypair_file(&keypair_file).unwrap().pubkey(),
-                    nonce_authority: read_keypair_file(&keypair_file).unwrap().into(),
+                    nonce_authority: None,
                     destination_account_pubkey: nonce_account_pubkey,
                     lamports: 42000000000
                 },
@@ -780,7 +779,7 @@ mod tests {
             CliCommandInfo {
                 command: CliCommand::WithdrawFromNonceAccount {
                     nonce_account: read_keypair_file(&keypair_file).unwrap().pubkey(),
-                    nonce_authority: read_keypair_file(&authority_keypair_file).unwrap().into(),
+                    nonce_authority: Some(read_keypair_file(&authority_keypair_file).unwrap().into()),
                     destination_account_pubkey: nonce_account_pubkey,
                     lamports: 42
                 },

--- a/cli/src/nonce.rs
+++ b/cli/src/nonce.rs
@@ -255,7 +255,7 @@ pub fn parse_new_nonce(matches: &ArgMatches<'_>) -> Result<CliCommandInfo, CliEr
     Ok(CliCommandInfo {
         command: CliCommand::NewNonce {
             nonce_account,
-            nonce_authority: nonce_authority,
+            nonce_authority,
         },
         require_keypair: true,
     })
@@ -285,7 +285,7 @@ pub fn parse_withdraw_from_nonce_account(
     Ok(CliCommandInfo {
         command: CliCommand::WithdrawFromNonceAccount {
             nonce_account,
-            nonce_authority: nonce_authority,
+            nonce_authority,
             destination_account_pubkey,
             lamports,
         },
@@ -379,7 +379,7 @@ pub fn process_create_nonce_account(
         .into());
     }
 
-    let nonce_authority = nonce_authority.unwrap_or(config.keypair.pubkey());
+    let nonce_authority = nonce_authority.unwrap_or_else(|| config.keypair.pubkey());
     let ixs = create_nonce_account(
         &config.keypair.pubkey(),
         &nonce_account_pubkey,
@@ -603,7 +603,9 @@ mod tests {
             CliCommandInfo {
                 command: CliCommand::AuthorizeNonceAccount {
                     nonce_account: read_keypair_file(&keypair_file).unwrap().pubkey(),
-                    nonce_authority: Some(read_keypair_file(&authority_keypair_file).unwrap().into()),
+                    nonce_authority: Some(
+                        read_keypair_file(&authority_keypair_file).unwrap().into()
+                    ),
                     new_authority: Pubkey::default(),
                 },
                 require_keypair: true,
@@ -645,7 +647,9 @@ mod tests {
             CliCommandInfo {
                 command: CliCommand::CreateNonceAccount {
                     nonce_account: read_keypair_file(&keypair_file).unwrap().into(),
-                    nonce_authority: Some(read_keypair_file(&authority_keypair_file).unwrap().pubkey()),
+                    nonce_authority: Some(
+                        read_keypair_file(&authority_keypair_file).unwrap().pubkey()
+                    ),
                     lamports: 50,
                 },
                 require_keypair: true
@@ -697,7 +701,9 @@ mod tests {
             CliCommandInfo {
                 command: CliCommand::NewNonce {
                     nonce_account: nonce_account.pubkey(),
-                    nonce_authority: Some(read_keypair_file(&authority_keypair_file).unwrap().into()),
+                    nonce_authority: Some(
+                        read_keypair_file(&authority_keypair_file).unwrap().into()
+                    ),
                 },
                 require_keypair: true
             }
@@ -779,7 +785,9 @@ mod tests {
             CliCommandInfo {
                 command: CliCommand::WithdrawFromNonceAccount {
                     nonce_account: read_keypair_file(&keypair_file).unwrap().pubkey(),
-                    nonce_authority: Some(read_keypair_file(&authority_keypair_file).unwrap().into()),
+                    nonce_authority: Some(
+                        read_keypair_file(&authority_keypair_file).unwrap().into()
+                    ),
                     destination_account_pubkey: nonce_account_pubkey,
                     lamports: 42
                 },

--- a/cli/tests/nonce.rs
+++ b/cli/tests/nonce.rs
@@ -122,7 +122,7 @@ fn full_battery_tests(
     // Create nonce account
     config_payer.command = CliCommand::CreateNonceAccount {
         nonce_account: read_keypair_file(&nonce_keypair_file).unwrap().into(),
-        nonce_authority: read_keypair_file(&authority_keypair_file).unwrap().pubkey(),
+        nonce_authority: Some(read_keypair_file(&authority_keypair_file).unwrap().pubkey()),
         lamports: 1000,
     };
     process_command(&config_payer).unwrap();
@@ -144,7 +144,7 @@ fn full_battery_tests(
     // New nonce
     config_payer.command = CliCommand::NewNonce {
         nonce_account: read_keypair_file(&nonce_keypair_file).unwrap().pubkey(),
-        nonce_authority: read_keypair_file(&authority_keypair_file).unwrap().into(),
+        nonce_authority: Some(read_keypair_file(&authority_keypair_file).unwrap().into()),
     };
     process_command(&config_payer).unwrap();
 
@@ -159,7 +159,7 @@ fn full_battery_tests(
     let payee_pubkey = Pubkey::new_rand();
     config_payer.command = CliCommand::WithdrawFromNonceAccount {
         nonce_account: read_keypair_file(&nonce_keypair_file).unwrap().pubkey(),
-        nonce_authority: read_keypair_file(&authority_keypair_file).unwrap().into(),
+        nonce_authority: Some(read_keypair_file(&authority_keypair_file).unwrap().into()),
         destination_account_pubkey: payee_pubkey,
         lamports: 100,
     };
@@ -181,7 +181,7 @@ fn full_battery_tests(
     write_keypair(&new_authority, tmp_file.as_file_mut()).unwrap();
     config_payer.command = CliCommand::AuthorizeNonceAccount {
         nonce_account: read_keypair_file(&nonce_keypair_file).unwrap().pubkey(),
-        nonce_authority: read_keypair_file(&authority_keypair_file).unwrap().into(),
+        nonce_authority: Some(read_keypair_file(&authority_keypair_file).unwrap().into()),
         new_authority: read_keypair_file(&new_authority_keypair_file)
             .unwrap()
             .pubkey(),
@@ -191,25 +191,25 @@ fn full_battery_tests(
     // Old authority fails now
     config_payer.command = CliCommand::NewNonce {
         nonce_account: read_keypair_file(&nonce_keypair_file).unwrap().pubkey(),
-        nonce_authority: read_keypair_file(&authority_keypair_file).unwrap().into(),
+        nonce_authority: Some(read_keypair_file(&authority_keypair_file).unwrap().into()),
     };
     process_command(&config_payer).unwrap_err();
 
     // New authority can advance nonce
     config_payer.command = CliCommand::NewNonce {
         nonce_account: read_keypair_file(&nonce_keypair_file).unwrap().pubkey(),
-        nonce_authority: read_keypair_file(&new_authority_keypair_file)
+        nonce_authority: Some(read_keypair_file(&new_authority_keypair_file)
             .unwrap()
-            .into(),
+            .into()),
     };
     process_command(&config_payer).unwrap();
 
     // New authority can withdraw from nonce account
     config_payer.command = CliCommand::WithdrawFromNonceAccount {
         nonce_account: read_keypair_file(&nonce_keypair_file).unwrap().pubkey(),
-        nonce_authority: read_keypair_file(&new_authority_keypair_file)
+        nonce_authority: Some(read_keypair_file(&new_authority_keypair_file)
             .unwrap()
-            .into(),
+            .into()),
         destination_account_pubkey: payee_pubkey,
         lamports: 100,
     };

--- a/cli/tests/nonce.rs
+++ b/cli/tests/nonce.rs
@@ -1,4 +1,6 @@
-use solana_cli::cli::{process_command, request_and_confirm_airdrop, CliCommand, CliConfig};
+use solana_cli::cli::{
+    process_command, request_and_confirm_airdrop, CliCommand, CliConfig, KeypairEq,
+};
 use solana_client::rpc_client::RpcClient;
 use solana_faucet::faucet::run_local_faucet;
 use solana_sdk::{
@@ -59,7 +61,7 @@ fn test_nonce() {
         &mut config_payer,
         &mut config_nonce,
         &keypair_file,
-        &keypair_file,
+        None,
     );
 
     server.close().unwrap();
@@ -95,11 +97,15 @@ fn test_nonce_with_authority() {
         &mut config_payer,
         &mut config_nonce,
         &nonce_keypair_file,
-        &authority_keypair_file,
+        Some(&authority_keypair_file),
     );
 
     server.close().unwrap();
     remove_dir_all(ledger_path).unwrap();
+}
+
+fn read_keypair_from_option(keypair_file: &Option<&str>) -> Option<KeypairEq> {
+    keypair_file.map(|akf| read_keypair_file(&akf).unwrap().into())
 }
 
 fn full_battery_tests(
@@ -108,7 +114,7 @@ fn full_battery_tests(
     config_payer: &mut CliConfig,
     config_nonce: &mut CliConfig,
     nonce_keypair_file: &str,
-    authority_keypair_file: &str,
+    authority_keypair_file: Option<&str>,
 ) {
     request_and_confirm_airdrop(
         &rpc_client,
@@ -122,7 +128,8 @@ fn full_battery_tests(
     // Create nonce account
     config_payer.command = CliCommand::CreateNonceAccount {
         nonce_account: read_keypair_file(&nonce_keypair_file).unwrap().into(),
-        nonce_authority: Some(read_keypair_file(&authority_keypair_file).unwrap().pubkey()),
+        nonce_authority: read_keypair_from_option(&authority_keypair_file)
+            .map(|na: KeypairEq| na.pubkey()),
         lamports: 1000,
     };
     process_command(&config_payer).unwrap();
@@ -144,7 +151,7 @@ fn full_battery_tests(
     // New nonce
     config_payer.command = CliCommand::NewNonce {
         nonce_account: read_keypair_file(&nonce_keypair_file).unwrap().pubkey(),
-        nonce_authority: Some(read_keypair_file(&authority_keypair_file).unwrap().into()),
+        nonce_authority: read_keypair_from_option(&authority_keypair_file),
     };
     process_command(&config_payer).unwrap();
 
@@ -159,7 +166,7 @@ fn full_battery_tests(
     let payee_pubkey = Pubkey::new_rand();
     config_payer.command = CliCommand::WithdrawFromNonceAccount {
         nonce_account: read_keypair_file(&nonce_keypair_file).unwrap().pubkey(),
-        nonce_authority: Some(read_keypair_file(&authority_keypair_file).unwrap().into()),
+        nonce_authority: read_keypair_from_option(&authority_keypair_file),
         destination_account_pubkey: payee_pubkey,
         lamports: 100,
     };
@@ -181,7 +188,7 @@ fn full_battery_tests(
     write_keypair(&new_authority, tmp_file.as_file_mut()).unwrap();
     config_payer.command = CliCommand::AuthorizeNonceAccount {
         nonce_account: read_keypair_file(&nonce_keypair_file).unwrap().pubkey(),
-        nonce_authority: Some(read_keypair_file(&authority_keypair_file).unwrap().into()),
+        nonce_authority: read_keypair_from_option(&authority_keypair_file),
         new_authority: read_keypair_file(&new_authority_keypair_file)
             .unwrap()
             .pubkey(),
@@ -191,7 +198,7 @@ fn full_battery_tests(
     // Old authority fails now
     config_payer.command = CliCommand::NewNonce {
         nonce_account: read_keypair_file(&nonce_keypair_file).unwrap().pubkey(),
-        nonce_authority: Some(read_keypair_file(&authority_keypair_file).unwrap().into()),
+        nonce_authority: read_keypair_from_option(&authority_keypair_file),
     };
     process_command(&config_payer).unwrap_err();
 

--- a/cli/tests/nonce.rs
+++ b/cli/tests/nonce.rs
@@ -198,18 +198,22 @@ fn full_battery_tests(
     // New authority can advance nonce
     config_payer.command = CliCommand::NewNonce {
         nonce_account: read_keypair_file(&nonce_keypair_file).unwrap().pubkey(),
-        nonce_authority: Some(read_keypair_file(&new_authority_keypair_file)
-            .unwrap()
-            .into()),
+        nonce_authority: Some(
+            read_keypair_file(&new_authority_keypair_file)
+                .unwrap()
+                .into(),
+        ),
     };
     process_command(&config_payer).unwrap();
 
     // New authority can withdraw from nonce account
     config_payer.command = CliCommand::WithdrawFromNonceAccount {
         nonce_account: read_keypair_file(&nonce_keypair_file).unwrap().pubkey(),
-        nonce_authority: Some(read_keypair_file(&new_authority_keypair_file)
-            .unwrap()
-            .into()),
+        nonce_authority: Some(
+            read_keypair_file(&new_authority_keypair_file)
+                .unwrap()
+                .into(),
+        ),
         destination_account_pubkey: payee_pubkey,
         lamports: 100,
     };

--- a/cli/tests/pay.rs
+++ b/cli/tests/pay.rs
@@ -368,7 +368,7 @@ fn test_nonced_pay_tx() {
     write_keypair(&nonce_account, tmp_file.as_file_mut()).unwrap();
     config.command = CliCommand::CreateNonceAccount {
         nonce_account: read_keypair_file(&nonce_keypair_file).unwrap().into(),
-        nonce_authority: config.keypair.pubkey(),
+        nonce_authority: Some(config.keypair.pubkey()),
         lamports: minimum_nonce_balance,
     };
     process_command(&config).unwrap();

--- a/cli/tests/stake.rs
+++ b/cli/tests/stake.rs
@@ -312,7 +312,7 @@ fn test_nonced_stake_delegation_and_deactivation() {
     write_keypair(&nonce_account, tmp_file.as_file_mut()).unwrap();
     config.command = CliCommand::CreateNonceAccount {
         nonce_account: read_keypair_file(&nonce_keypair_file).unwrap().into(),
-        nonce_authority: config.keypair.pubkey(),
+        nonce_authority: Some(config.keypair.pubkey()),
         lamports: minimum_nonce_balance,
     };
     process_command(&config).unwrap();


### PR DESCRIPTION
#### Problem

If the nonce authority was not explicitly provided, the nonce account itself was erroneously assigned authority rather than the account creator

#### Summary of Changes

Resolve unspecified nonce authority to the nonce account's creator