### PR TITLE
Cli: fund validator-info accounts with rent-exempt lamports

### DIFF
--- a/cli/src/validator_info.rs
+++ b/cli/src/validator_info.rs
@@ -312,10 +312,12 @@ pub fn process_set_validator_info(
             "Publishing info for Validator {:?}",
             config.keypair.pubkey()
         );
+        let lamports = rpc_client
+            .get_minimum_balance_for_rent_exemption(ValidatorInfo::max_space() as usize)?;
         let mut instructions = config_instruction::create_account::<ValidatorInfo>(
             &config.keypair.pubkey(),
             &info_keypair.pubkey(),
-            1,
+            lamports,
             keys.clone(),
         );
         instructions.extend_from_slice(&[config_instruction::store(


### PR DESCRIPTION
#### Problem
The CLI creates validator info accounts funded with 1 lamport. With rent turned on, these accounts get rent-collected into oblivion immediately.

#### Summary of Changes
Initialize validator info accounts with minimum balance for rent exemption

Fixes #7680 
