### PR TITLE
Manage durable nonce stored value in runtime

### DIFF
--- a/core/src/transaction_status_service.rs
+++ b/core/src/transaction_status_service.rs
@@ -59,7 +59,7 @@ impl TransactionStatusService {
             .zip(balances.post_balances)
         {
             if Bank::can_commit(&status) && !transaction.signatures.is_empty() {
-                let fee_hash = if let Some(HashAgeKind::DurableNonce) = hash_age_kind {
+                let fee_hash = if let Some(HashAgeKind::DurableNonce(_, _)) = hash_age_kind {
                     bank.last_blockhash()
                 } else {
                     transaction.message().recent_blockhash

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -4,6 +4,7 @@ use crate::append_vec::StoredAccount;
 use crate::bank::{HashAgeKind, TransactionProcessResult};
 use crate::blockhash_queue::BlockhashQueue;
 use crate::message_processor::has_duplicates;
+use crate::nonce_utils::prepare_if_nonce_account;
 use crate::rent_collector::RentCollector;
 use crate::system_instruction_processor::{get_system_account_kind, SystemAccountKind};
 use log::*;
@@ -12,6 +13,7 @@ use solana_metrics::inc_new_counter_error;
 use solana_sdk::account::Account;
 use solana_sdk::bank_hash::BankHash;
 use solana_sdk::clock::Slot;
+use solana_sdk::hash::Hash;
 use solana_sdk::native_loader;
 use solana_sdk::nonce_state::NonceState;
 use solana_sdk::pubkey::Pubkey;
@@ -559,9 +561,16 @@ impl Accounts {
         res: &[TransactionProcessResult],
         loaded: &mut [(Result<TransactionLoadResult>, Option<HashAgeKind>)],
         rent_collector: &RentCollector,
+        last_blockhash: &Hash,
     ) {
-        let accounts_to_store =
-            self.collect_accounts_to_store(txs, txs_iteration_order, res, loaded, rent_collector);
+        let accounts_to_store = self.collect_accounts_to_store(
+            txs,
+            txs_iteration_order,
+            res,
+            loaded,
+            rent_collector,
+            last_blockhash,
+        );
         self.accounts_db.store(slot, &accounts_to_store);
     }
 
@@ -582,6 +591,7 @@ impl Accounts {
         res: &'a [TransactionProcessResult],
         loaded: &'a mut [(Result<TransactionLoadResult>, Option<HashAgeKind>)],
         rent_collector: &RentCollector,
+        last_blockhash: &Hash,
     ) -> Vec<(&'a Pubkey, &'a Account)> {
         let mut accounts = Vec::with_capacity(loaded.len());
         for (i, ((raccs, _hash_age_kind), tx)) in loaded
@@ -611,6 +621,7 @@ impl Accounts {
                 .enumerate()
                 .zip(acc.0.iter_mut())
             {
+                prepare_if_nonce_account(account, key, res, maybe_nonce, last_blockhash);
                 if message.is_writable(i) {
                     if account.rent_epoch == 0 {
                         account.rent_epoch = rent_collector.epoch;
@@ -1610,8 +1621,14 @@ mod tests {
                 },
             );
         }
-        let collected_accounts =
-            accounts.collect_accounts_to_store(&txs, None, &loaders, &mut loaded, &rent_collector);
+        let collected_accounts = accounts.collect_accounts_to_store(
+            &txs,
+            None,
+            &loaders,
+            &mut loaded,
+            &rent_collector,
+            &Hash::default(),
+        );
         assert_eq!(collected_accounts.len(), 2);
         assert!(collected_accounts
             .iter()

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -247,7 +247,7 @@ impl Accounts {
             .zip(lock_results.into_iter())
             .map(|etx| match etx {
                 (tx, (Ok(()), hash_age_kind)) => {
-                    let fee_hash = if let Some(HashAgeKind::DurableNonce) = hash_age_kind {
+                    let fee_hash = if let Some(HashAgeKind::DurableNonce(_, _)) = hash_age_kind {
                         hash_queue.last_hash()
                     } else {
                         tx.message().recent_blockhash

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1322,6 +1322,7 @@ impl Bank {
             executed,
             loaded_accounts,
             &self.rent_collector,
+            &self.last_blockhash(),
         );
         self.collect_rent(executed, loaded_accounts);
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -188,6 +188,15 @@ pub enum HashAgeKind {
     DurableNonce(Pubkey, Account),
 }
 
+impl HashAgeKind {
+    pub fn is_durable_nonce(&self) -> bool {
+        match self {
+            HashAgeKind::DurableNonce(_, _) => true,
+            _ => false,
+        }
+    }
+}
+
 /// Manager for the state of all accounts and programs after processing its entries.
 #[derive(Default, Deserialize, Serialize)]
 pub struct Bank {
@@ -1930,6 +1939,14 @@ mod tests {
     };
     use std::{io::Cursor, result, time::Duration};
     use tempfile::TempDir;
+
+    #[test]
+    fn test_hash_age_kind_is_durable_nonce() {
+        assert!(
+            HashAgeKind::DurableNonce(Pubkey::default(), Account::default()).is_durable_nonce()
+        );
+        assert!(!HashAgeKind::Extant.is_durable_nonce());
+    }
 
     #[test]
     fn test_bank_unix_timestamp() {

--- a/runtime/src/nonce_utils.rs
+++ b/runtime/src/nonce_utils.rs
@@ -1,7 +1,14 @@
 use solana_sdk::{
-    account::Account, account_utils::State, hash::Hash, instruction::CompiledInstruction,
-    instruction_processor_utils::limited_deserialize, nonce_state::NonceState, pubkey::Pubkey,
-    system_instruction::SystemInstruction, system_program, transaction::Transaction,
+    account::Account,
+    account_utils::State,
+    hash::Hash,
+    instruction::CompiledInstruction,
+    instruction_processor_utils::limited_deserialize,
+    nonce_state::NonceState,
+    pubkey::Pubkey,
+    system_instruction::SystemInstruction,
+    system_program,
+    transaction::{self, Transaction},
 };
 
 pub fn transaction_uses_durable_nonce(tx: &Transaction) -> Option<&CompiledInstruction> {
@@ -39,12 +46,38 @@ pub fn verify_nonce(acc: &Account, hash: &Hash) -> bool {
     }
 }
 
+pub fn prepare_if_nonce_account(
+    account: &mut Account,
+    account_pubkey: &Pubkey,
+    tx_result: &transaction::Result<()>,
+    maybe_nonce: Option<(&Pubkey, &Account)>,
+    last_blockhash: &Hash,
+) {
+    if let Some((nonce_key, nonce_acc)) = maybe_nonce {
+        if account_pubkey == nonce_key {
+            // Nonce TX failed with an InstructionError. Roll back
+            // its account state
+            if tx_result.is_err() {
+                *account = nonce_acc.clone()
+            }
+            // Since hash_age_kind is DurableNonce, unwrap is safe here
+            if let NonceState::Initialized(meta, _) = account.state().unwrap() {
+                account
+                    .set_state(&NonceState::Initialized(meta, *last_blockhash))
+                    .unwrap();
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use solana_sdk::{
+        account::Account,
         hash::Hash,
-        nonce_state::{with_test_keyed_account, NonceAccount},
+        instruction::InstructionError,
+        nonce_state::{with_test_keyed_account, Meta, NonceAccount},
         pubkey::Pubkey,
         signature::{Keypair, KeypairUtil},
         system_instruction,
@@ -192,5 +225,142 @@ mod tests {
                 &recent_blockhashes[1]
             ));
         });
+    }
+
+    fn create_accounts_prepare_if_nonce_account() -> (Pubkey, Account, Account, Hash) {
+        let stored_nonce = Hash::default();
+        let account = Account::new_data(
+            42,
+            &NonceState::Initialized(Meta::new(&Pubkey::default()), stored_nonce),
+            &system_program::id(),
+        )
+        .unwrap();
+        let pre_account = Account {
+            lamports: 43,
+            ..account.clone()
+        };
+        (
+            Pubkey::default(),
+            pre_account,
+            account,
+            Hash::new(&[1u8; 32]),
+        )
+    }
+
+    fn run_prepare_if_nonce_account_test(
+        account: &mut Account,
+        account_pubkey: &Pubkey,
+        tx_result: &transaction::Result<()>,
+        maybe_nonce: Option<(&Pubkey, &Account)>,
+        last_blockhash: &Hash,
+        expect_account: &Account,
+    ) -> bool {
+        // Verify expect_account's relationship
+        match maybe_nonce {
+            Some((nonce_pubkey, _nonce_account))
+                if nonce_pubkey == account_pubkey && tx_result.is_ok() =>
+            {
+                assert_ne!(expect_account, account)
+            }
+            Some((nonce_pubkey, nonce_account)) if nonce_pubkey == account_pubkey => {
+                assert_ne!(expect_account, nonce_account)
+            }
+            _ => assert_eq!(expect_account, account),
+        }
+
+        prepare_if_nonce_account(
+            account,
+            account_pubkey,
+            tx_result,
+            maybe_nonce,
+            last_blockhash,
+        );
+        expect_account == account
+    }
+
+    #[test]
+    fn test_prepare_if_nonce_account_expected() {
+        let (pre_account_pubkey, pre_account, mut post_account, last_blockhash) =
+            create_accounts_prepare_if_nonce_account();
+        let post_account_pubkey = pre_account_pubkey;
+
+        let mut expect_account = post_account.clone();
+        expect_account
+            .set_state(&NonceState::Initialized(
+                Meta::new(&Pubkey::default()),
+                last_blockhash,
+            ))
+            .unwrap();
+
+        assert!(run_prepare_if_nonce_account_test(
+            &mut post_account,
+            &post_account_pubkey,
+            &Ok(()),
+            Some((&pre_account_pubkey, &pre_account)),
+            &last_blockhash,
+            &expect_account,
+        ));
+    }
+
+    #[test]
+    fn test_prepare_if_nonce_account_not_nonce_tx() {
+        let (pre_account_pubkey, _pre_account, _post_account, last_blockhash) =
+            create_accounts_prepare_if_nonce_account();
+        let post_account_pubkey = pre_account_pubkey;
+
+        let mut post_account = Account::default();
+        let expect_account = post_account.clone();
+        assert!(run_prepare_if_nonce_account_test(
+            &mut post_account,
+            &post_account_pubkey,
+            &Ok(()),
+            None,
+            &last_blockhash,
+            &expect_account,
+        ));
+    }
+
+    #[test]
+    fn test_prepare_if_nonce_naccount_ot_nonce_pubkey() {
+        let (pre_account_pubkey, pre_account, mut post_account, last_blockhash) =
+            create_accounts_prepare_if_nonce_account();
+
+        let expect_account = post_account.clone();
+        // Wrong key
+        assert!(run_prepare_if_nonce_account_test(
+            &mut post_account,
+            &Pubkey::new(&[1u8; 32]),
+            &Ok(()),
+            Some((&pre_account_pubkey, &pre_account)),
+            &last_blockhash,
+            &expect_account,
+        ));
+    }
+
+    #[test]
+    fn test_prepare_if_nonce_account_tx_error() {
+        let (pre_account_pubkey, pre_account, mut post_account, last_blockhash) =
+            create_accounts_prepare_if_nonce_account();
+        let post_account_pubkey = pre_account_pubkey;
+
+        let mut expect_account = pre_account.clone();
+        expect_account
+            .set_state(&NonceState::Initialized(
+                Meta::new(&Pubkey::default()),
+                last_blockhash,
+            ))
+            .unwrap();
+
+        assert!(run_prepare_if_nonce_account_test(
+            &mut post_account,
+            &post_account_pubkey,
+            &Err(transaction::TransactionError::InstructionError(
+                0,
+                InstructionError::InvalidArgument.into(),
+            )),
+            Some((&pre_account_pubkey, &pre_account)),
+            &last_blockhash,
+            &expect_account,
+        ));
     }
 }


### PR DESCRIPTION
#### Problem

As per #7443, managing the stored durable nonce value in a program instruction leaves executions resulting in `InstructionError` open to continuous replay and fee theft until the stored nonce is successfully advanced.

#### Summary of Changes

Store nonce account of durable nonce TXs that fail with `InstructionError`
Check nonce premature-usage in runtime
Advance nonce in runtime

Fixes #7443
