### PR TITLE
Allow override of RUST_LOG

### DIFF
--- a/bench-tps/src/main.rs
+++ b/bench-tps/src/main.rs
@@ -12,7 +12,7 @@ use std::{collections::HashMap, fs::File, io::prelude::*, path::Path, process::e
 pub const NUM_SIGNATURES_FOR_TXS: u64 = 100_000 * 60 * 60 * 24 * 7;
 
 fn main() {
-    solana_logger::setup_with_filter("solana=info");
+    solana_logger::setup_with_default("solana=info");
     solana_metrics::set_panic_hook("bench-tps");
 
     let matches = cli::build_args(solana_clap_utils::version!()).get_matches();

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -1023,7 +1023,7 @@ impl RpcSol for RpcSolImpl {
     }
 
     fn set_log_filter(&self, _meta: Self::Metadata, filter: String) -> Result<()> {
-        solana_logger::setup_with_filter(&filter);
+        solana_logger::setup_with(&filter);
         Ok(())
     }
 

--- a/faucet/src/bin/faucet.rs
+++ b/faucet/src/bin/faucet.rs
@@ -12,7 +12,7 @@ use std::{
 };
 
 fn main() -> Result<(), Box<dyn error::Error>> {
-    solana_logger::setup_with_filter("solana=info");
+    solana_logger::setup_with_default("solana=info");
     solana_metrics::set_panic_hook("faucet");
     let matches = App::new(crate_name!())
         .about(crate_description!())

--- a/gossip/src/main.rs
+++ b/gossip/src/main.rs
@@ -13,7 +13,7 @@ use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::process::exit;
 
 fn main() -> Result<(), Box<dyn error::Error>> {
-    solana_logger::setup_with_filter("solana=info");
+    solana_logger::setup_with_default("solana=info");
 
     let matches = App::new(crate_name!())
         .about(crate_description!())

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -515,7 +515,7 @@ fn open_database(ledger_path: &Path) -> Database {
 #[allow(clippy::cognitive_complexity)]
 fn main() {
     const DEFAULT_ROOT_COUNT: &str = "1";
-    solana_logger::setup_with_filter("solana=info");
+    solana_logger::setup_with_default("solana=info");
 
     let starting_slot_arg = Arg::with_name("starting_slot")
         .long("starting-slot")

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -93,7 +93,7 @@ pub fn process_instruction(
     keyed_accounts: &mut [KeyedAccount],
     ix_data: &[u8],
 ) -> Result<(), InstructionError> {
-    solana_logger::setup();
+    solana_logger::setup_with_default("solana=info");
 
     if let Ok(instruction) = limited_deserialize(ix_data) {
         match instruction {

--- a/programs/vote/src/vote_instruction.rs
+++ b/programs/vote/src/vote_instruction.rs
@@ -179,7 +179,7 @@ pub fn process_instruction(
     keyed_accounts: &mut [KeyedAccount],
     data: &[u8],
 ) -> Result<(), InstructionError> {
-    solana_logger::setup_with_filter("solana=info");
+    solana_logger::setup_with_default("solana=info");
 
     trace!("process_instruction: {:?}", data);
     trace!("keyed_accounts: {:?}", keyed_accounts);

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -692,7 +692,7 @@ pub fn main() {
         }
     };
 
-    solana_logger::setup_with_filter(
+    solana_logger::setup_with_default(
         &[
             "solana=info", /* info logging for all solana modules */
             "rpc=trace",   /* json_rpc request/response logging */

--- a/watchtower/src/main.rs
+++ b/watchtower/src/main.rs
@@ -48,7 +48,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
     let json_rpc_url = value_t_or_exit!(matches, "json_rpc_url", String);
     let validator_identity = pubkey_of(&matches, "validator_identity").map(|i| i.to_string());
 
-    solana_logger::setup_with_filter("solana=info");
+    solana_logger::setup_with_default("solana=info");
     solana_metrics::set_panic_hook("watchtower");
 
     let rpc_client = RpcClient::new(json_rpc_url);


### PR DESCRIPTION
#### Problem

Calling `solana_logger::setup_with_filter` uses RUST_LOG if defined.  RPC was calling it intending to override RUST_LOG.  This means that if RUST_LOG is defined locally than the RPC request to change the logs filter will have not effect

#### Summary of Changes

Add a new function that allows RPC to override RUST_LOG and reword the existing functions to make it more clear that calling it with a filter only uses the filter as a default if RUST_LOG is not defined.  This still retains the ability to force a filter by setting `_RUST_LOG`

Fixes #
