### PR TITLE
Pass RUST_LOG through on testnet creation

### DIFF
--- a/ci/testnet-manager.sh
+++ b/ci/testnet-manager.sh
@@ -204,6 +204,7 @@ steps:
         TESTNET_DB_HOST: "$TESTNET_DB_HOST"
         GCE_NODE_COUNT: "$GCE_NODE_COUNT"
         GCE_LOW_QUOTA_NODE_COUNT: "$GCE_LOW_QUOTA_NODE_COUNT"
+        RUST_LOG: "$RUST_LOG"
 EOF
     ) | buildkite-agent pipeline upload
     exit 0


### PR DESCRIPTION
#### Problem

RUST_LOG is not propagated from buildkite to gce when starting a testnet

#### Summary of Changes

Pass it through

Fixes #
