### PR TITLE
Correctly integrate buildkite with codecov

### DIFF
--- a/ci/docker-run.sh
+++ b/ci/docker-run.sh
@@ -77,9 +77,7 @@ ARGS+=(
 
 # Also propagate environment variables needed for codecov
 # https://docs.codecov.io/docs/testing-with-docker#section-codecov-inside-docker
-ARGS+=(
-  $(bash <(curl -s https://codecov.io/env))
-)
+CODECOV_ENVS=$(bash <(curl -s https://codecov.io/env))
 
 if $INTERACTIVE; then
   if [[ -n $1 ]]; then
@@ -88,8 +86,10 @@ if $INTERACTIVE; then
     echo
   fi
   set -x
-  exec docker run --interactive --tty "${ARGS[@]}" "$IMAGE" bash
+  # shellcheck disable=SC2086
+  exec docker run --interactive --tty "${ARGS[@]}" $CODECOV_ENVS "$IMAGE" bash
 fi
 
 set -x
-exec docker run "${ARGS[@]}" "$IMAGE" "$@"
+# shellcheck disable=SC2086
+exec docker run "${ARGS[@]}" $CODECOV_ENVS "$IMAGE" "$@"

--- a/ci/docker-run.sh
+++ b/ci/docker-run.sh
@@ -72,8 +72,13 @@ ARGS+=(
   --env CI_JOB_ID
   --env CI_PULL_REQUEST
   --env CI_REPO_SLUG
-  --env CODECOV_TOKEN
   --env CRATES_IO_TOKEN
+)
+
+# Also propagate environment variables needed for codecov
+# https://docs.codecov.io/docs/testing-with-docker#section-codecov-inside-docker
+ARGS+=(
+  $(bash <(curl -s https://codecov.io/env))
 )
 
 if $INTERACTIVE; then

--- a/ci/docker-run.sh
+++ b/ci/docker-run.sh
@@ -77,7 +77,8 @@ ARGS+=(
 
 # Also propagate environment variables needed for codecov
 # https://docs.codecov.io/docs/testing-with-docker#section-codecov-inside-docker
-CODECOV_ENVS=$(bash <(curl -s https://codecov.io/env))
+# We normalize CI to `1`; but codecov expects it to be `true` to detect Buildkite...
+CODECOV_ENVS=$(CI=true bash <(curl -s https://codecov.io/env))
 
 if $INTERACTIVE; then
   if [[ -n $1 ]]; then

--- a/ci/test-coverage.sh
+++ b/ci/test-coverage.sh
@@ -41,7 +41,8 @@ if [[ -z "$CODECOV_TOKEN" ]]; then
   echo "^^^ +++"
   echo CODECOV_TOKEN undefined, codecov.io upload skipped
 else
-  bash <(curl -s https://codecov.io/bash) -X gcov -f target/cov/lcov.info
+  # We normalize CI to `1`; but codecov expects it to be `true` to detect Buildkite...
+  CI=true bash <(curl -s https://codecov.io/bash) -X gcov -f target/cov/lcov.info
 
   annotate --style success --context codecov.io \
     "CodeCov report: https://codecov.io/github/solana-labs/solana/commit/${CI_COMMIT:0:9}"


### PR DESCRIPTION
#### Problem

Some commits are incorrectly put under the `master` branch in the per-branch codecov report. Such examples are backporting commits, which obviously go under the `v0.22`/`v0.21` branch:

- https://codecov.io/gh/solana-labs/solana/branch/master/commits

Because of that, it seems that even if we landed #7576, the master branch's coverage report is flaky..

Also, codecov.io report output warns about no detected CI provider:

```
codecov.io report
 
  _____          _
 / ____|        | |
| |     ___   __| | ___  ___ _____   __
| |    / _ \ / _` |/ _ \/ __/ _ \ \ / /
| |___| (_) | (_| |  __/ (_| (_) \ V /
 \_____\___/ \__,_|\___|\___\___/ \_/
                              Bash-20191211-b8db533
 
x> No CI provider detected.
    Testing inside Docker? http://docs.codecov.io/docs/testing-with-docker
    Testing with Tox? https://docs.codecov.io/docs/python#section-testing-with-tox
project root: .
```

This might be the cause of flaky integration.

#### Summary of Changes

Follow codecov's guideline for testing inside Docker, and see if mysterious problem is solved. :)