### PR TITLE
Clarify account creation error messages in CLI

### DIFF
--- a/cli/src/nonce.rs
+++ b/cli/src/nonce.rs
@@ -383,11 +383,14 @@ pub fn process_create_nonce_account(
         let err_msg = if nonce_account.owner == system_program::id()
             && State::<NonceState>::state(&nonce_account).is_ok()
         {
-            "nonce account already exists"
+            format!("Nonce account {} already exists", nonce_account_pubkey)
         } else {
-            "account already exists and is not a nonce account"
+            format!(
+                "Account {} already exists and is not a nonce account",
+                nonce_account_pubkey
+            )
         };
-        return Err(CliError::BadParameter(err_msg.to_string()).into());
+        return Err(CliError::BadParameter(err_msg).into());
     }
 
     let minimum_balance = rpc_client.get_minimum_balance_for_rent_exemption(NonceState::size())?;

--- a/cli/src/nonce.rs
+++ b/cli/src/nonce.rs
@@ -383,11 +383,11 @@ pub fn process_create_nonce_account(
         let err_msg = if nonce_account.owner == system_program::id()
             && State::<NonceState>::state(&nonce_account).is_ok()
         {
-            format!("Nonce account {} already exists", nonce_account_pubkey)
+            format!("Nonce account {} already exists", nonce_account_address)
         } else {
             format!(
                 "Account {} already exists and is not a nonce account",
-                nonce_account_pubkey
+                nonce_account_address
             )
         };
         return Err(CliError::BadParameter(err_msg).into());

--- a/cli/src/nonce.rs
+++ b/cli/src/nonce.rs
@@ -379,12 +379,15 @@ pub fn process_create_nonce_account(
         (&nonce_account_address, "nonce_account".to_string()),
     )?;
 
-    if rpc_client.get_account(&nonce_account_address).is_ok() {
-        return Err(CliError::BadParameter(format!(
-            "Unable to create nonce account. Nonce account already exists: {}",
-            nonce_account_pubkey,
-        ))
-        .into());
+    if let Ok(nonce_account) = rpc_client.get_account(&nonce_account_address) {
+        let err_msg = if nonce_account.owner == system_program::id()
+            && State::<NonceState>::state(&nonce_account).is_ok()
+        {
+            "nonce account already exists"
+        } else {
+            "account already exists and is not a nonce account"
+        };
+        return Err(CliError::BadParameter(err_msg.to_string()).into());
     }
 
     let minimum_balance = rpc_client.get_minimum_balance_for_rent_exemption(NonceState::size())?;

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -542,12 +542,13 @@ pub fn process_create_stake_account(
         (&stake_account_address, "stake_account".to_string()),
     )?;
 
-    if rpc_client.get_account(&stake_account_address).is_ok() {
-        return Err(CliError::BadParameter(format!(
-            "Unable to create stake account. Stake account already exists: {}",
-            stake_account_address
-        ))
-        .into());
+    if let Ok(stake_account) = rpc_client.get_account(&stake_account_address) {
+        let err_msg = if stake_account.owner == solana_stake_program::id() {
+            "stake account already exists"
+        } else {
+            "account already exists and is not a stake account"
+        };
+        return Err(CliError::BadParameter(err_msg.to_string()).into());
     }
 
     let minimum_balance =

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -544,11 +544,14 @@ pub fn process_create_stake_account(
 
     if let Ok(stake_account) = rpc_client.get_account(&stake_account_address) {
         let err_msg = if stake_account.owner == solana_stake_program::id() {
-            "stake account already exists"
+            format!("Stake account {} already exists", stake_account_pubkey)
         } else {
-            "account already exists and is not a stake account"
+            format!(
+                "Account {} already exists and is not a stake account",
+                stake_account_pubkey
+            )
         };
-        return Err(CliError::BadParameter(err_msg.to_string()).into());
+        return Err(CliError::BadParameter(err_msg).into());
     }
 
     let minimum_balance =

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -544,11 +544,11 @@ pub fn process_create_stake_account(
 
     if let Ok(stake_account) = rpc_client.get_account(&stake_account_address) {
         let err_msg = if stake_account.owner == solana_stake_program::id() {
-            format!("Stake account {} already exists", stake_account_pubkey)
+            format!("Stake account {} already exists", stake_account_address)
         } else {
             format!(
                 "Account {} already exists and is not a stake account",
-                stake_account_pubkey
+                stake_account_address
             )
         };
         return Err(CliError::BadParameter(err_msg).into());

--- a/cli/src/storage.rs
+++ b/cli/src/storage.rs
@@ -166,11 +166,14 @@ pub fn process_create_storage_account(
 
     if let Ok(storage_account) = rpc_client.get_account(&storage_account_pubkey) {
         let err_msg = if storage_account.owner == solana_storage_program::id() {
-            "storage account already exists"
+            format!("Storage account {} already exists", storage_account_pubkey)
         } else {
-            "account already exists and is not a storage account"
+            format!(
+                "Account {} already exists and is not a storage account",
+                storage_account_pubkey
+            )
         };
-        return Err(CliError::BadParameter(err_msg.to_string()).into());
+        return Err(CliError::BadParameter(err_msg).into());
     }
 
     use solana_storage_program::storage_contract::STORAGE_ACCOUNT_SPACE;

--- a/cli/src/storage.rs
+++ b/cli/src/storage.rs
@@ -163,6 +163,16 @@ pub fn process_create_storage_account(
             "storage_account_pubkey".to_string(),
         ),
     )?;
+
+    if let Ok(storage_account) = rpc_client.get_account(&storage_account_pubkey) {
+        let err_msg = if storage_account.owner == solana_storage_program::id() {
+            "storage account already exists"
+        } else {
+            "account already exists and is not a storage account"
+        };
+        return Err(CliError::BadParameter(err_msg.to_string()).into());
+    }
+
     use solana_storage_program::storage_contract::STORAGE_ACCOUNT_SPACE;
     let required_balance = rpc_client
         .get_minimum_balance_for_rent_exemption(STORAGE_ACCOUNT_SPACE as usize)?

--- a/cli/src/vote.rs
+++ b/cli/src/vote.rs
@@ -9,13 +9,17 @@ use crate::{
 use clap::{value_t_or_exit, App, Arg, ArgMatches, SubCommand};
 use solana_clap_utils::{input_parsers::*, input_validators::*};
 use solana_client::rpc_client::RpcClient;
-use solana_sdk::signature::Keypair;
 use solana_sdk::{
+<<<<<<< HEAD
     account::Account,
     pubkey::Pubkey,
     signature::KeypairUtil,
     system_instruction::{create_address_with_seed, SystemError},
     transaction::Transaction,
+=======
+    account::Account, pubkey::Pubkey, signature::Keypair, signature::KeypairUtil,
+    system_instruction::SystemError, transaction::Transaction,
+>>>>>>> Clarify account creation error messages in CLI
 };
 use solana_vote_program::{
     vote_instruction::{self, VoteError},
@@ -314,12 +318,13 @@ pub fn process_create_vote_account(
         (&identity_pubkey, "identity_pubkey".to_string()),
     )?;
 
-    if rpc_client.get_account(&vote_account_address).is_ok() {
-        return Err(CliError::BadParameter(format!(
-            "Unable to create vote account. Vote account already exists: {}",
-            vote_account_address
-        ))
-        .into());
+    if let Ok(vote_account) = rpc_client.get_account(&vote_account_address) {
+        let err_msg = if vote_account.owner == solana_vote_program::id() {
+            "vote account already exists"
+        } else {
+            "account already exists and is not a vote account"
+        };
+        return Err(CliError::BadParameter(err_msg.to_string()).into());
     }
 
     let required_balance = rpc_client

--- a/cli/src/vote.rs
+++ b/cli/src/vote.rs
@@ -320,11 +320,14 @@ pub fn process_create_vote_account(
 
     if let Ok(vote_account) = rpc_client.get_account(&vote_account_address) {
         let err_msg = if vote_account.owner == solana_vote_program::id() {
-            "vote account already exists"
+            format!("Vote account {} already exists", vote_account_pubkey)
         } else {
-            "account already exists and is not a vote account"
+            format!(
+                "Account {} already exists and is not a vote account",
+                vote_account_pubkey
+            )
         };
-        return Err(CliError::BadParameter(err_msg.to_string()).into());
+        return Err(CliError::BadParameter(err_msg).into());
     }
 
     let required_balance = rpc_client

--- a/cli/src/vote.rs
+++ b/cli/src/vote.rs
@@ -10,16 +10,12 @@ use clap::{value_t_or_exit, App, Arg, ArgMatches, SubCommand};
 use solana_clap_utils::{input_parsers::*, input_validators::*};
 use solana_client::rpc_client::RpcClient;
 use solana_sdk::{
-<<<<<<< HEAD
     account::Account,
     pubkey::Pubkey,
+    signature::Keypair,
     signature::KeypairUtil,
     system_instruction::{create_address_with_seed, SystemError},
     transaction::Transaction,
-=======
-    account::Account, pubkey::Pubkey, signature::Keypair, signature::KeypairUtil,
-    system_instruction::SystemError, transaction::Transaction,
->>>>>>> Clarify account creation error messages in CLI
 };
 use solana_vote_program::{
     vote_instruction::{self, VoteError},
@@ -320,11 +316,11 @@ pub fn process_create_vote_account(
 
     if let Ok(vote_account) = rpc_client.get_account(&vote_account_address) {
         let err_msg = if vote_account.owner == solana_vote_program::id() {
-            format!("Vote account {} already exists", vote_account_pubkey)
+            format!("Vote account {} already exists", vote_account_address)
         } else {
             format!(
                 "Account {} already exists and is not a vote account",
-                vote_account_pubkey
+                vote_account_address
             )
         };
         return Err(CliError::BadParameter(err_msg).into());


### PR DESCRIPTION
#### Problem
A validator in discord was confused by a cli message saying that their stake account already existed. Turns out the account existed but it was a system account, not a stake account.

#### Summary of Changes
Clarify the error message an account can't be created because it already exists.

Fixes #
