### PR TITLE
Improve bench-tps keypair generation

### DIFF
--- a/bench-tps/src/bench.rs
+++ b/bench-tps/src/bench.rs
@@ -1046,9 +1046,9 @@ pub fn generate_and_fund_keypairs<T: 'static + Client + Send + Sync>(
         #[cfg(feature = "move")]
         {
             if use_move {
-                let libra_genesis_keypair = create_genesis(&funding_key, client, 10_000_000);
-                let libra_mint_program_id = upload_mint_script(&funding_key, client);
-                let libra_pay_program_id = upload_payment_script(&funding_key, client);
+                let libra_genesis_keypair = create_genesis(&funding_key, client.as_ref(), 10_000_000);
+                let libra_mint_program_id = upload_mint_script(&funding_key, client.as_ref());
+                let libra_pay_program_id = upload_payment_script(&funding_key, client.as_ref());
 
                 // Generate another set of keypairs for move accounts.
                 // Still fund the solana ones which will be used for fees.
@@ -1056,7 +1056,7 @@ pub fn generate_and_fund_keypairs<T: 'static + Client + Send + Sync>(
                 let mut rnd = GenKeys::new(seed);
                 let move_keypairs = rnd.gen_n_keypairs(keypair_count as u64);
                 fund_move_keys(
-                    client,
+                    client.as_ref(),
                     funding_key,
                     &move_keypairs,
                     total / 3,

--- a/bench-tps/src/bench.rs
+++ b/bench-tps/src/bench.rs
@@ -1046,7 +1046,8 @@ pub fn generate_and_fund_keypairs<T: 'static + Client + Send + Sync>(
         #[cfg(feature = "move")]
         {
             if use_move {
-                let libra_genesis_keypair = create_genesis(&funding_key, client.as_ref(), 10_000_000);
+                let libra_genesis_keypair =
+                    create_genesis(&funding_key, client.as_ref(), 10_000_000);
                 let libra_mint_program_id = upload_mint_script(&funding_key, client.as_ref());
                 let libra_pay_program_id = upload_payment_script(&funding_key, client.as_ref());
 


### PR DESCRIPTION
#### Problem
Account generation at the beginning of bench-tps can sometimes be really slow. This could be due to a number of reasons:
1. If a large portion of a batch of transfers fails, generation has no way to bail out of attempting to verify each transfer.
2. RPC requests are slow due to geographic latency

#### Summary of Changes
* Parallelize fund verification so that RPC requests are less of a bottleneck
* Short circuit fund verification if more than half of the tx's failed
* Short circuit verification of a tx if any of the "to" keypairs is funded or not funded
* Transfer direction  changes more frequently so that source/dest keypair funds stay balanced
* Made the initial funds check much more lenient so that we can avoid re-running fund generation
* General code cleanup

Fixes: https://github.com/solana-labs/solana/issues/7597