### PR TITLE
Consolidate entry tick verification into one function

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -505,7 +505,6 @@ impl ReplayStage {
         }
     }
 
-    // Returns the replay result and the number of replayed transactions
     fn replay_blockstore_into_bank(
         bank: &Arc<Bank>,
         blockstore: &Blockstore,
@@ -728,14 +727,12 @@ impl ReplayStage {
                 }
             }
             assert_eq!(*bank_slot, bank.slot());
-            if bank.tick_height() == bank.max_tick_height() {
-                if let Some(bank_progress) = &mut progress.get(&bank.slot()) {
-                    bank_progress.replay_stats.report_stats(
-                        bank.slot(),
-                        bank_progress.replay_progress.num_entries,
-                        bank_progress.replay_progress.num_shreds,
-                    );
-                }
+            if bank.is_complete() {
+                bank_progress.replay_stats.report_stats(
+                    bank.slot(),
+                    bank_progress.replay_progress.num_entries,
+                    bank_progress.replay_progress.num_shreds,
+                );
                 did_complete_bank = true;
                 Self::process_completed_bank(my_pubkey, bank, slot_full_senders);
             } else {

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -529,15 +529,6 @@ impl ReplayStage {
         confirm_result.map_err(|err| {
             let slot = bank.slot();
             warn!("Fatal replay error in slot: {}, err: {:?}", slot, err);
-            if let BlockstoreProcessorError::InvalidBlock(_) = &err {
-                let last_entry = &bank_progress.replay_progress.last_entry;
-                datapoint_error!(
-                    "replay-stage-block-error",
-                    ("slot", slot, i64),
-                    ("last_entry", last_entry.to_string(), String),
-                );
-            }
-
             datapoint_error!(
                 "replay-stage-mark_dead_slot",
                 ("error", format!("error: {:?}", err), String),

--- a/ledger/src/bank_forks_utils.rs
+++ b/ledger/src/bank_forks_utils.rs
@@ -2,6 +2,7 @@ use crate::{
     bank_forks::{BankForks, SnapshotConfig},
     blockstore::Blockstore,
     blockstore_processor::{self, BankForksInfo, BlockstoreProcessorError, ProcessOptions},
+    entry::VerifyRecyclers,
     leader_schedule_cache::LeaderScheduleCache,
     snapshot_utils,
 };
@@ -47,6 +48,7 @@ pub fn load(
                 blockstore,
                 Arc::new(deserialized_bank),
                 &process_options,
+                &VerifyRecyclers::default(),
             );
         } else {
             info!("Snapshot package does not exist: {:?}", tar);

--- a/ledger/src/block_error.rs
+++ b/ledger/src/block_error.rs
@@ -2,6 +2,10 @@ use thiserror::Error;
 
 #[derive(Error, Debug, PartialEq)]
 pub enum BlockError {
+    /// Block did not have enough ticks or was not marked full
+    #[error("incomplete block")]
+    Incomplete,
+
     /// Block entries hashes must all be valid
     #[error("invalid entry hash")]
     InvalidEntryHash,

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -1456,7 +1456,7 @@ impl Blockstore {
         &self,
         slot: Slot,
         start_index: u64,
-    ) -> Result<(Vec<Entry>, usize, bool)> {
+    ) -> Result<(Vec<Entry>, u64, bool)> {
         if self.is_dead(slot) {
             return Err(BlockstoreError::DeadSlot);
         }
@@ -1479,7 +1479,7 @@ impl Blockstore {
         let num_shreds = completed_ranges
             .last()
             .map(|(_, end_index)| u64::from(*end_index) - start_index + 1)
-            .unwrap_or(0) as usize;
+            .unwrap_or(0);
 
         let entries: Result<Vec<Vec<Entry>>> = PAR_THREAD_POOL.with(|thread_pool| {
             thread_pool.borrow().install(|| {

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -366,6 +366,50 @@ pub fn process_blockstore_from_root(
     Ok((bank_forks, bank_forks_info, leader_schedule_cache))
 }
 
+/// Verify that a segment of entries has the correct number of ticks and hashes
+pub fn verify_ticks(
+    bank: &Arc<Bank>,
+    entries: &[Entry],
+    slot_full: bool,
+    tick_hash_count: &mut u64,
+) -> std::result::Result<(), BlockError> {
+    let next_bank_tick_height = bank.tick_height() + entries.tick_count();
+    let max_bank_tick_height = bank.max_tick_height();
+    if next_bank_tick_height > max_bank_tick_height {
+        warn!("Too many entry ticks found in slot: {}", bank.slot());
+        return Err(BlockError::InvalidTickCount);
+    }
+
+    if next_bank_tick_height < max_bank_tick_height && slot_full {
+        warn!("Too few entry ticks found in slot: {}", bank.slot());
+        return Err(BlockError::InvalidTickCount);
+    }
+
+    if next_bank_tick_height == max_bank_tick_height {
+        let has_trailing_entry = !entries.last().unwrap().is_tick();
+        if has_trailing_entry {
+            warn!("Slot: {} did not end with a tick entry", bank.slot());
+            return Err(BlockError::TrailingEntry);
+        }
+
+        if !slot_full {
+            warn!("Slot: {} was not marked full", bank.slot());
+            return Err(BlockError::InvalidLastTick);
+        }
+    }
+
+    let hashes_per_tick = bank.hashes_per_tick().unwrap_or(0);
+    if !entries.verify_tick_hash_count(tick_hash_count, hashes_per_tick) {
+        warn!(
+            "Tick with invalid number of hashes found in slot: {}",
+            bank.slot()
+        );
+        return Err(BlockError::InvalidTickHashCount);
+    }
+
+    Ok(())
+}
+
 fn verify_and_process_slot_entries(
     bank: &Arc<Bank>,
     entries: &[Entry],
@@ -375,29 +419,7 @@ fn verify_and_process_slot_entries(
     assert!(!entries.is_empty());
 
     if opts.poh_verify {
-        let next_bank_tick_height = bank.tick_height() + entries.tick_count();
-        let max_bank_tick_height = bank.max_tick_height();
-        if next_bank_tick_height != max_bank_tick_height {
-            warn!(
-                "Invalid number of entry ticks found in slot: {}",
-                bank.slot()
-            );
-            return Err(BlockError::InvalidTickCount.into());
-        } else if !entries.last().unwrap().is_tick() {
-            warn!("Slot: {} did not end with a tick entry", bank.slot());
-            return Err(BlockError::TrailingEntry.into());
-        }
-
-        if let Some(hashes_per_tick) = bank.hashes_per_tick() {
-            if !entries.verify_tick_hash_count(&mut 0, *hashes_per_tick) {
-                warn!(
-                    "Tick with invalid number of hashes found in slot: {}",
-                    bank.slot()
-                );
-                return Err(BlockError::InvalidTickHashCount.into());
-            }
-        }
-
+        verify_ticks(bank, entries, true, &mut 0)?;
         if !entries.verify(&last_entry_hash) {
             warn!("Ledger proof of history failed at slot: {}", bank.slot());
             return Err(BlockError::InvalidEntryHash.into());

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -434,7 +434,8 @@ fn confirm_full_slot(
         opts.entry_callback.as_ref(),
         recyclers,
     )?;
-    if !progress.is_full {
+
+    if !bank.is_complete() {
         Err(BlockstoreProcessorError::InvalidBlock(
             BlockError::Incomplete,
         ))
@@ -465,7 +466,6 @@ impl Default for ConfirmationTiming {
 
 #[derive(Default)]
 pub struct ConfirmationProgress {
-    pub is_full: bool,
     pub last_entry: Hash,
     pub tick_hash_count: u64,
     pub num_shreds: u64,
@@ -573,7 +573,6 @@ pub fn confirm_slot(
 
     process_result?;
 
-    progress.is_full = slot_full;
     progress.num_shreds += num_shreds;
     progress.num_entries += num_entries;
     progress.num_txs += num_txs;

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -537,7 +537,6 @@ pub fn confirm_slot(
         })?;
     }
 
-    let mut verify_total = Measure::start("verify_and_process_entries");
     let verifier = if !skip_verification {
         datapoint_debug!("verify-batch-size", ("size", num_entries as i64, i64));
         let entry_state = entries.start_verify(&progress.last_entry, recyclers.clone());
@@ -567,8 +566,7 @@ pub fn confirm_slot(
             warn!("Ledger proof of history failed at slot: {}", bank.slot());
             return Err(BlockError::InvalidEntryHash.into());
         }
-        verify_total.stop();
-        timing.verify_elapsed += verify_total.as_us() - replay_elapsed.as_us();
+        timing.verify_elapsed += verifier.duration_ms();
     }
 
     process_result?;

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -902,6 +902,10 @@ impl Bank {
         }
     }
 
+    pub fn is_complete(&self) -> bool {
+        self.tick_height() == self.max_tick_height()
+    }
+
     pub fn is_block_boundary(&self, tick_height: u64) -> bool {
         tick_height % self.ticks_per_slot == 0
     }

--- a/runtime/tests/bank.rs
+++ b/runtime/tests/bank.rs
@@ -20,7 +20,7 @@ fn test_race_register_tick_freeze() {
         let freeze_thread = Builder::new()
             .name("freeze".to_string())
             .spawn(move || loop {
-                if bank0_.tick_height() == bank0_.max_tick_height() {
+                if bank0_.is_complete() {
                     assert_eq!(bank0_.last_blockhash(), hash);
                     break;
                 }

--- a/sdk/src/transaction.rs
+++ b/sdk/src/transaction.rs
@@ -9,9 +9,10 @@ use crate::signature::{KeypairUtil, Signature};
 use crate::system_instruction;
 use bincode::serialize;
 use std::result;
+use thiserror::Error;
 
 /// Reasons a transaction might be rejected.
-#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
+#[derive(Error, Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub enum TransactionError {
     /// This Pubkey is being processed in another transaction
     AccountInUse,
@@ -58,6 +59,12 @@ pub enum TransactionError {
 }
 
 pub type Result<T> = result::Result<T, TransactionError>;
+
+impl std::fmt::Display for TransactionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "transaction error")
+    }
+}
 
 /// An atomic transaction
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
#### Problem
The replay stage and blocktree processor have their own implementations for verifying entries and handling corrupt slots.

#### Summary of Changes
* Mark corrupt slots as dead in blocktree processor to avoid replaying them in replay stage
* Consolidate tick verification code from replay stage and blocktree processor into one method
* Speed up ledger verification by parallelizing entry verification and processing and using warmed up pinned memory

Fixes #
