### PR TITLE
Fix call to BPF build script

### DIFF
--- a/programs/bpf/build.rs
+++ b/programs/bpf/build.rs
@@ -83,12 +83,11 @@ fn main() {
                 "cargo:warning=(not a warning) Building Rust-based BPF programs: solana_bpf_rust_{}",
                 program
             );
-            assert!(Command::new("./do.sh")
+            assert!(Command::new("bash")
                 .current_dir("rust")
-                .arg("build")
-                .arg(program)
+                .args(&["./do.sh", "build", program])
                 .status()
-                .expect("Error calling rust/do.sh")
+                .expect("Error calling do.sh from build.rs")
                 .success());
             let src = format!(
                 "target/bpfel-unknown-unknown/release/solana_bpf_rust_{}.so",


### PR DESCRIPTION
#### Problem

Calling a bash script directly and relying on the shabang can be problematic:

```
thread 'main' panicked at 'Error calling rust/do.sh: Os { code: 2, kind: NotFound, message: "No such file or directory" }', src/libcore/result.rs:1165:5
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace.
```

#### Summary of Changes

Call bash and pass the script to be called

Fixes #
