### PR TITLE
getConfirmedBlock: add encoding optional parameter

### DIFF
--- a/book/src/api-reference/jsonrpc-api.md
+++ b/book/src/api-reference/jsonrpc-api.md
@@ -278,16 +278,17 @@ Returns identity and transaction information about a confirmed block in the ledg
 #### Parameters:
 
 * `integer` - slot, as u64 integer
+* `string` - (optional) encoding for each returned Transaction, either "json" or "binary". If not provided, the default encoding is JSON.
 
 #### Results:
 
 The result field will be an object with the following fields:
 
-* `blockhash` - the blockhash of this block
-* `previousBlockhash` - the blockhash of this block's parent
+* `blockhash` - the blockhash of this block, as base-58 encoded string
+* `previousBlockhash` - the blockhash of this block's parent, as base-58 encoded string
 * `parentSlot` - the slot index of this block's parent
 * `transactions` - an array of tuples containing:
-  * [Transaction](transaction-api.md) object, in JSON format
+  * [Transaction](transaction-api.md) object, either in JSON format or base-58 encoded binary data, depending on encoding parameter
   * Transaction status object, containing:
      * `status` - Transaction status:
        * `"Ok": null` - Transaction was successful

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -2057,7 +2057,8 @@ pub mod tests {
 
         for (transaction, result) in confirmed_block.transactions.into_iter() {
             if let RpcEncodedTransaction::Binary(transaction) = transaction {
-                let decoded_transaction: Transaction = deserialize(&transaction).unwrap();
+                let decoded_transaction: Transaction =
+                    deserialize(&bs58::decode(&transaction).into_vec().unwrap()).unwrap();
                 if decoded_transaction.signatures[0] == confirmed_block_signatures[0] {
                     assert_eq!(decoded_transaction.message.recent_blockhash, blockhash);
                     assert_eq!(result.unwrap().status, Ok(()));

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -13,7 +13,8 @@ use jsonrpc_core::{Error, Metadata, Result};
 use jsonrpc_derive::rpc;
 use solana_client::rpc_request::{
     Response, RpcConfirmedBlock, RpcContactInfo, RpcEpochInfo, RpcLeaderSchedule,
-    RpcResponseContext, RpcVersionInfo, RpcVoteAccountInfo, RpcVoteAccountStatus,
+    RpcResponseContext, RpcTransactionEncoding, RpcVersionInfo, RpcVoteAccountInfo,
+    RpcVoteAccountStatus,
 };
 use solana_faucet::faucet::request_airdrop_transaction;
 use solana_ledger::{
@@ -312,8 +313,12 @@ impl JsonRpcRequestProcessor {
         }
     }
 
-    pub fn get_confirmed_block(&self, slot: Slot) -> Result<Option<RpcConfirmedBlock>> {
-        Ok(self.blocktree.get_confirmed_block(slot).ok())
+    pub fn get_confirmed_block(
+        &self,
+        slot: Slot,
+        encoding: Option<RpcTransactionEncoding>,
+    ) -> Result<Option<RpcConfirmedBlock>> {
+        Ok(self.blocktree.get_confirmed_block(slot, encoding).ok())
     }
 
     pub fn get_confirmed_blocks(
@@ -562,6 +567,7 @@ pub trait RpcSol {
         &self,
         meta: Self::Metadata,
         slot: Slot,
+        encoding: Option<RpcTransactionEncoding>,
     ) -> Result<Option<RpcConfirmedBlock>>;
 
     #[rpc(meta, name = "getBlockTime")]
@@ -1031,11 +1037,12 @@ impl RpcSol for RpcSolImpl {
         &self,
         meta: Self::Metadata,
         slot: Slot,
+        encoding: Option<RpcTransactionEncoding>,
     ) -> Result<Option<RpcConfirmedBlock>> {
         meta.request_processor
             .read()
             .unwrap()
-            .get_confirmed_block(slot)
+            .get_confirmed_block(slot, encoding)
     }
 
     fn get_confirmed_blocks(
@@ -1063,7 +1070,9 @@ pub mod tests {
         genesis_utils::{create_genesis_config, GenesisConfigInfo},
         replay_stage::tests::create_test_transactions_and_populate_blocktree,
     };
+    use bincode::deserialize;
     use jsonrpc_core::{MetaIoHandler, Output, Response, Value};
+    use solana_client::rpc_request::RpcEncodedTransaction;
     use solana_ledger::{
         blocktree::entries_to_test_shreds, blocktree_processor::fill_blocktree_slot_with_ticks,
         entry::next_entry_mut, get_tmp_ledger_path,
@@ -2008,6 +2017,36 @@ pub mod tests {
 
         let req =
             format!(r#"{{"jsonrpc":"2.0","id":1,"method":"getConfirmedBlock","params":[0]}}"#);
+        let res = io.handle_request_sync(&req, meta.clone());
+        let result: Value = serde_json::from_str(&res.expect("actual response"))
+            .expect("actual response deserialization");
+        let confirmed_block: Option<RpcConfirmedBlock> =
+            serde_json::from_value(result["result"].clone()).unwrap();
+        let confirmed_block = confirmed_block.unwrap();
+        assert_eq!(confirmed_block.transactions.len(), 3);
+
+        for (transaction, result) in confirmed_block.transactions.into_iter() {
+            if let RpcEncodedTransaction::Json(transaction) = transaction {
+                if transaction.signatures[0] == confirmed_block_signatures[0].to_string() {
+                    assert_eq!(transaction.message.recent_blockhash, blockhash.to_string());
+                    assert_eq!(result.unwrap().status, Ok(()));
+                } else if transaction.signatures[0] == confirmed_block_signatures[1].to_string() {
+                    assert_eq!(
+                        result.unwrap().status,
+                        Err(TransactionError::InstructionError(
+                            0,
+                            InstructionError::CustomError(1)
+                        ))
+                    );
+                } else {
+                    assert_eq!(result, None);
+                }
+            }
+        }
+
+        let req = format!(
+            r#"{{"jsonrpc":"2.0","id":1,"method":"getConfirmedBlock","params":[0, "binary"]}}"#
+        );
         let res = io.handle_request_sync(&req, meta);
         let result: Value = serde_json::from_str(&res.expect("actual response"))
             .expect("actual response deserialization");
@@ -2017,19 +2056,22 @@ pub mod tests {
         assert_eq!(confirmed_block.transactions.len(), 3);
 
         for (transaction, result) in confirmed_block.transactions.into_iter() {
-            if transaction.signatures[0] == confirmed_block_signatures[0] {
-                assert_eq!(transaction.message.recent_blockhash, blockhash);
-                assert_eq!(result.unwrap().status, Ok(()));
-            } else if transaction.signatures[0] == confirmed_block_signatures[1] {
-                assert_eq!(
-                    result.unwrap().status,
-                    Err(TransactionError::InstructionError(
-                        0,
-                        InstructionError::CustomError(1)
-                    ))
-                );
-            } else {
-                assert_eq!(result, None);
+            if let RpcEncodedTransaction::Binary(transaction) = transaction {
+                let decoded_transaction: Transaction = deserialize(&transaction).unwrap();
+                if decoded_transaction.signatures[0] == confirmed_block_signatures[0] {
+                    assert_eq!(decoded_transaction.message.recent_blockhash, blockhash);
+                    assert_eq!(result.unwrap().status, Ok(()));
+                } else if decoded_transaction.signatures[0] == confirmed_block_signatures[1] {
+                    assert_eq!(
+                        result.unwrap().status,
+                        Err(TransactionError::InstructionError(
+                            0,
+                            InstructionError::CustomError(1)
+                        ))
+                    );
+                } else {
+                    assert_eq!(result, None);
+                }
             }
         }
     }

--- a/ledger/src/blocktree.rs
+++ b/ledger/src/blocktree.rs
@@ -22,8 +22,7 @@ use rayon::{
 };
 use rocksdb::DBRawIterator;
 use solana_client::rpc_request::{
-    RpcConfirmedBlock, RpcEncodedHash, RpcEncodedTransaction, RpcTransactionEncoding,
-    RpcTransactionStatus,
+    RpcConfirmedBlock, RpcEncodedTransaction, RpcTransactionEncoding, RpcTransactionStatus,
 };
 use solana_measure::measure::Measure;
 use solana_metrics::{datapoint_debug, datapoint_error};
@@ -1351,23 +1350,13 @@ impl Blocktree {
                 } else {
                     Hash::default()
                 };
-                let previous_blockhash = if encoding == RpcTransactionEncoding::Json {
-                    RpcEncodedHash::Json(previous_blockhash.to_string())
-                } else {
-                    RpcEncodedHash::Binary(previous_blockhash)
-                };
 
                 let blockhash = get_last_hash(slot_entries.iter())
                     .unwrap_or_else(|| panic!("Rooted slot {:?} must have blockhash", slot));
-                let blockhash = if encoding == RpcTransactionEncoding::Json {
-                    RpcEncodedHash::Json(blockhash.to_string())
-                } else {
-                    RpcEncodedHash::Binary(blockhash)
-                };
 
                 let block = RpcConfirmedBlock {
-                    previous_blockhash,
-                    blockhash,
+                    previous_blockhash: previous_blockhash.to_string(),
+                    blockhash: blockhash.to_string(),
                     parent_slot: slot_meta.parent_slot,
                     transactions: self.map_transactions_to_statuses(
                         slot,
@@ -4678,8 +4667,8 @@ pub mod tests {
                 })
                 .collect(),
             parent_slot: slot - 1,
-            blockhash: RpcEncodedHash::Json(blockhash.to_string()),
-            previous_blockhash: RpcEncodedHash::Json(Hash::default().to_string()),
+            blockhash: blockhash.to_string(),
+            previous_blockhash: Hash::default().to_string(),
         };
         // The previous_blockhash of `expected_block` is default because its parent slot is a
         // root, but empty of entries. This is special handling for snapshot root slots.
@@ -4700,8 +4689,8 @@ pub mod tests {
                 })
                 .collect(),
             parent_slot: slot,
-            blockhash: RpcEncodedHash::Json(blockhash.to_string()),
-            previous_blockhash: RpcEncodedHash::Json(blockhash.to_string()),
+            blockhash: blockhash.to_string(),
+            previous_blockhash: blockhash.to_string(),
         };
         assert_eq!(confirmed_block, expected_block);
 


### PR DESCRIPTION
#### Problem
Currently, the Transactions and Hashes returned by the `getConfirmedBlock` method are only nominally in JSON format... anything serialized with short_vec appears as an array of bytes, with the short_vec length as an artifact. This is not friendly for humans or machines.

#### Summary of Changes
- Add an optional encoding parameter to specify JSON or binary format ("json", "binary"). If this parameter is not provided, the method returns JSON

**Before:**

```
{"jsonrpc":"2.0","result":{"blockhash":[15,174,10,25,54,47,135,83,10,197,138,74,168,179,16,94,149,240,6,101,61,94,177,217,182,235,250,220,34,165,235,231],"parentSlot":5050,"previousBlockhash":[109,153,35,131,54,24,180,169,120,2,250,229,13,100,94,14,73,32,90,229,192,154,104,174,168,10,76,135,44,160,222,255],"transactions":[[{"message":{"accountKeys":[[5],[104,199,171,32,70,11,114,246,73,255,240,206,227,228,40,237,155,126,165,127,62,228,232,46,139,246,29,153,118,123,255,158],[22,127,165,61,250,121,95,180,243,23,123,26,125,245,158,110,40,52,159,178,80,98,129,95,175,247,232,158,252,142,100,236],[6,167,213,23,25,47,10,175,198,242,101,227,251,119,204,122,218,130,197,41,208,190,59,19,110,45,0,85,32,0,0,0],[6,167,213,23,24,199,116,201,40,86,99,152,105,29,94,182,139,94,184,163,155,75,109,92,115,85,91,33,0,0,0,0],[7,97,72,29,53,116,116,187,124,77,118,36,235,211,189,179,216,53,94,115,209,16,67,252,13,163,83,128,0,0,0,0]],"header":{"numReadonlySignedAccounts":0,"numReadonlyUnsignedAccounts":3,"numRequiredSignatures":2},"instructions":[[1],{"accounts":[[3],1,2,3],"data":[[53],2,0,0,0,1,0,0,0,0,0,0,0,186,19,0,0,0,0,0,0,254,248,120,160,6,198,155,125,91,237,67,5,174,193,8,211,87,44,56,2,228,212,94,11,35,46,35,93,223,238,114,73,0],"programIdIndex":4}],"recentBlockhash":[109,153,35,131,54,24,180,169,120,2,250,229,13,100,94,14,73,32,90,229,192,154,104,174,168,10,76,135,44,160,222,255]},"signatures":[[2],[128,197,204,227,151,23,164,209,192,104,225,55,86,183,64,136,43,175,39,153,145,216,6,60,247,172,178,13,126,56,192,158,193,88,6,206,221,34,92,59,18,126,186,207,94,211,86,180,73,139,197,244,85,237,24,161,107,55,202,231,179,237,19,6],[143,240,162,250,92,248,173,247,240,152,204,59,216,220,78,79,229,245,49,72,124,63,20,242,56,146,234,93,109,222,253,106,170,41,189,79,145,55,155,68,157,227,235,170,37,200,195,37,197,168,15,95,32,160,62,229,117,153,240,7,108,47,34,7]]},{"fee":10000,"postBalances":[499974522500,27881760,1,1,1],"preBalances":[499974532500,27881760,1,1,1],"status":{"Ok":null}}]]},"id":1}
```

**After:** (edited after 265803d)
Json:
```
{"jsonrpc":"2.0","result":{"blockhash":"Gp3t5bfDsJv1ovP8cB1SuRhXVuoTqDv7p3tymyubYg5","parentSlot":1,"previousBlockhash":"EFejToxii1L5aUF2NrK9dsbAEmZSNyN5nsipmZHQR1eA","transactions":[[{"message":{"accountKeys":["6H94zdiaYfRfPfKjYLjyr2VFBg6JHXygy84r3qhc3NsC","39UAy8hsoYPywGPGdmun747omSr79zLSjqvPJN3zetoH","SysvarS1otHashes111111111111111111111111111","SysvarC1ock11111111111111111111111111111111","Vote111111111111111111111111111111111111111"],"header":{"numReadonlySignedAccounts":0,"numReadonlyUnsignedAccounts":3,"numRequiredSignatures":2},"instructions":[{"accounts":[1,2,3],"data":"29z5mr1JoRmJYQ6ynmk3pf31cGFRziAF1M3mT3L6sFXf5cKLdkEaMXMT8AqLpD4CpcupHmuMEmtZHpomrwfdZetSomNy3d","programIdIndex":4}],"recentBlockhash":"EFejToxii1L5aUF2NrK9dsbAEmZSNyN5nsipmZHQR1eA"},"signatures":["35YGay1Lwjwgxe9zaH6APSHbt9gYQUCtBWTNL3aVwVGn9xTFw2fgds7qK5AL29mP63A9j3rh8KpN1TgSR62XCaby","4vANMjSKiwEchGSXwVrQkwHnmsbKQmy9vdrsYxWdCup1bLsFzX8gKrFTSVDCZCae2dbxJB9mPNhqB2sD1vvr4sAD"]},{"fee":18000,"postBalances":[499999972500,15298080,1,1,1],"preBalances":[499999990500,15298080,1,1,1],"status":{"Ok":null}}]]},"id":1}
```

Binary:
```
{"jsonrpc":"2.0","result":{"blockhash":"Gp3t5bfDsJv1ovP8cB1SuRhXVuoTqDv7p3tymyubYg5","parentSlot":1,"previousBlockhash":"EFejToxii1L5aUF2NrK9dsbAEmZSNyN5nsipmZHQR1eA","transactions":[["81UZJt4dh4Do66jDhrgkQudS8J2N6iG3jaVav7gJrqJSFY4Ug53iA9JFJZh2gxKWcaFdLJwhHx9mRdg9JwDAWB4ywiu5154CRwXV4FMdnPLg7bhxRLwhhYaLsVgMF5AyNRcTzjCVoBvqFgDU7P8VEKDEiMvD3qxzm1pLZVxDG1LTQpT3Dz4Uviv4KQbFQNuC22KupBoyHFB7Zh6KFdMqux4M9PvhoqcoJsJKwXjWpKu7xmEKnnrSbfLadkgjBmmjhW3fdTrFvnhQdTkhtdJxUL1xS9GMuJQer8YgSKNtUXB1eXZQwXU8bU2BjYkZE6Q5Xww8hu9Z4E4Mo4QsooVtHoP6BM3NKw8zjVbWfoCQqxTrwuSzrNCWCWt58C24LHecH67CTt2uXbYSviixvrYkK7A3t68BxTJcF1dXJitEPTFe2ceTkauLJqrJgnER4iUrsjr26T8YgWvpY9wkkWFSviQW6wV5RASTCUasVEcrDiaKj8EQMkgyDoe9HyKitSVg67vMWJFpUXpQobseWJUs5FTWWzmfHmFp8FZ",{"fee":18000,"postBalances":[499999972500,15298080,1,1,1],"preBalances":[499999990500,15298080,1,1,1],"status":{"Ok":null}}]]},"id":1}
```
