### PR TITLE
Add support in BlockStore for tracking duplicate slots

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3907,6 +3907,7 @@ dependencies = [
  "rayon 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rocksdb 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_bytes 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-budget-program 0.23.0",

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -394,7 +394,9 @@ fn graph_forks(
     dot.join("\n")
 }
 
-fn analyze_column<T: solana_ledger::blockstore_db::Column>(
+fn analyze_column<
+    T: solana_ledger::blockstore_db::Column + solana_ledger::blockstore_db::ColumnName,
+>(
     db: &Database,
     name: &str,
     key_size: usize,

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -28,6 +28,7 @@ rand_chacha = "0.1.1"
 rayon = "1.2.0"
 reed-solomon-erasure = { package = "solana-reed-solomon-erasure", version = "4.0.1-3", features = ["simd-accel"] }
 serde = "1.0.104"
+serde_bytes = "0.11.3"
 serde_derive = "1.0.103"
 solana-client = { path = "../client", version = "0.23.0" }
 solana-genesis-programs = { path = "../genesis-programs", version = "0.23.0" }

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -305,43 +305,43 @@ impl Blockstore {
         let columns_empty = self
             .db
             .delete_range_cf::<cf::SlotMeta>(&mut write_batch, from_slot, to_slot)
-            .unwrap_or_else(|_| false)
+            .unwrap_or(false)
             & self
                 .db
                 .delete_range_cf::<cf::Root>(&mut write_batch, from_slot, to_slot)
-                .unwrap_or_else(|_| false)
+                .unwrap_or(false)
             & self
                 .db
                 .delete_range_cf::<cf::ShredData>(&mut write_batch, from_slot, to_slot)
-                .unwrap_or_else(|_| false)
+                .unwrap_or(false)
             & self
                 .db
                 .delete_range_cf::<cf::ShredCode>(&mut write_batch, from_slot, to_slot)
-                .unwrap_or_else(|_| false)
+                .unwrap_or(false)
             & self
                 .db
                 .delete_range_cf::<cf::DeadSlots>(&mut write_batch, from_slot, to_slot)
-                .unwrap_or_else(|_| false)
+                .unwrap_or(false)
             & self
                 .db
                 .delete_range_cf::<cf::DuplicateSlots>(&mut write_batch, from_slot, to_slot)
-                .unwrap_or_else(|_| false)
+                .unwrap_or(false)
             & self
                 .db
                 .delete_range_cf::<cf::ErasureMeta>(&mut write_batch, from_slot, to_slot)
-                .unwrap_or_else(|_| false)
+                .unwrap_or(false)
             & self
                 .db
                 .delete_range_cf::<cf::Orphans>(&mut write_batch, from_slot, to_slot)
-                .unwrap_or_else(|_| false)
+                .unwrap_or(false)
             & self
                 .db
                 .delete_range_cf::<cf::Index>(&mut write_batch, from_slot, to_slot)
-                .unwrap_or_else(|_| false)
+                .unwrap_or(false)
             & self
                 .db
                 .delete_range_cf::<cf::TransactionStatus>(&mut write_batch, from_slot, to_slot)
-                .unwrap_or_else(|_| false);
+                .unwrap_or(false);
         if let Err(e) = self.db.write(write_batch) {
             error!(
                 "Error: {:?} while submitting write batch for slot {:?} retrying...",

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -238,7 +238,6 @@ impl Rocks {
 }
 
 pub trait Column {
-    const NAME: &'static str;
     type Index;
 
     fn key_size() -> usize {
@@ -251,6 +250,10 @@ pub trait Column {
     fn as_index(slot: Slot) -> Self::Index;
 }
 
+pub trait ColumnName {
+    const NAME: &'static str;
+}
+
 pub trait TypedColumn: Column {
     type Type: Serialize + DeserializeOwned;
 }
@@ -259,8 +262,31 @@ impl TypedColumn for columns::TransactionStatus {
     type Type = RpcTransactionStatus;
 }
 
+pub trait SlotColumn<Index = u64> {}
+
+impl<T: SlotColumn> Column for T {
+    type Index = u64;
+
+    fn key(slot: u64) -> Vec<u8> {
+        let mut key = vec![0; 8];
+        BigEndian::write_u64(&mut key[..], slot);
+        key
+    }
+
+    fn index(key: &[u8]) -> u64 {
+        BigEndian::read_u64(&key[..8])
+    }
+
+    fn slot(index: u64) -> Slot {
+        index
+    }
+
+    fn as_index(slot: Slot) -> u64 {
+        slot
+    }
+}
+
 impl Column for columns::TransactionStatus {
-    const NAME: &'static str = TRANSACTION_STATUS_CF;
     type Index = (Slot, Signature);
 
     fn key((slot, index): (Slot, Signature)) -> Vec<u8> {
@@ -285,8 +311,11 @@ impl Column for columns::TransactionStatus {
     }
 }
 
+impl ColumnName for columns::TransactionStatus {
+    const NAME: &'static str = TRANSACTION_STATUS_CF;
+}
+
 impl Column for columns::ShredCode {
-    const NAME: &'static str = CODE_SHRED_CF;
     type Index = (u64, u64);
 
     fn key(index: (u64, u64)) -> Vec<u8> {
@@ -306,8 +335,11 @@ impl Column for columns::ShredCode {
     }
 }
 
+impl ColumnName for columns::ShredCode {
+    const NAME: &'static str = CODE_SHRED_CF;
+}
+
 impl Column for columns::ShredData {
-    const NAME: &'static str = DATA_SHRED_CF;
     type Index = (u64, u64);
 
     fn key((slot, index): (u64, u64)) -> Vec<u8> {
@@ -332,170 +364,59 @@ impl Column for columns::ShredData {
     }
 }
 
-impl Column for columns::Index {
-    const NAME: &'static str = INDEX_CF;
-    type Index = u64;
-
-    fn key(slot: Slot) -> Vec<u8> {
-        let mut key = vec![0; 8];
-        BigEndian::write_u64(&mut key[..], slot);
-        key
-    }
-
-    fn index(key: &[u8]) -> u64 {
-        BigEndian::read_u64(&key[..8])
-    }
-
-    fn slot(index: Self::Index) -> Slot {
-        index
-    }
-
-    fn as_index(slot: Slot) -> Self::Index {
-        slot
-    }
+impl ColumnName for columns::ShredData {
+    const NAME: &'static str = DATA_SHRED_CF;
 }
 
+impl SlotColumn for columns::Index {}
+impl ColumnName for columns::Index {
+    const NAME: &'static str = INDEX_CF;
+}
 impl TypedColumn for columns::Index {
     type Type = blockstore_meta::Index;
 }
 
-impl Column for columns::DeadSlots {
+impl SlotColumn for columns::DeadSlots {}
+impl ColumnName for columns::DeadSlots {
     const NAME: &'static str = DEAD_SLOTS_CF;
-    type Index = u64;
-
-    fn key(slot: Slot) -> Vec<u8> {
-        let mut key = vec![0; 8];
-        BigEndian::write_u64(&mut key[..], slot);
-        key
-    }
-
-    fn index(key: &[u8]) -> u64 {
-        BigEndian::read_u64(&key[..8])
-    }
-
-    fn slot(index: Self::Index) -> Slot {
-        index
-    }
-
-    fn as_index(slot: Slot) -> Self::Index {
-        slot
-    }
 }
-
 impl TypedColumn for columns::DeadSlots {
     type Type = bool;
 }
 
-impl Column for columns::DuplicateSlots {
+impl SlotColumn for columns::DuplicateSlots {}
+impl ColumnName for columns::DuplicateSlots {
     const NAME: &'static str = DUPLICATE_SLOTS_CF;
-    type Index = u64;
-
-    fn key(slot: Slot) -> Vec<u8> {
-        let mut key = vec![0; 8];
-        BigEndian::write_u64(&mut key[..], slot);
-        key
-    }
-
-    fn index(key: &[u8]) -> u64 {
-        BigEndian::read_u64(&key[..8])
-    }
-
-    fn slot(index: Self::Index) -> Slot {
-        index
-    }
-
-    fn as_index(slot: Slot) -> Self::Index {
-        slot
-    }
 }
-
 impl TypedColumn for columns::DuplicateSlots {
-    type Type = blocktree_meta::DuplicateSlotProof;
+    type Type = blockstore_meta::DuplicateSlotProof;
 }
 
-impl Column for columns::Orphans {
+impl SlotColumn for columns::Orphans {}
+impl ColumnName for columns::Orphans {
     const NAME: &'static str = ORPHANS_CF;
-    type Index = u64;
-
-    fn key(slot: Slot) -> Vec<u8> {
-        let mut key = vec![0; 8];
-        BigEndian::write_u64(&mut key[..], slot);
-        key
-    }
-
-    fn index(key: &[u8]) -> u64 {
-        BigEndian::read_u64(&key[..8])
-    }
-
-    fn slot(index: Self::Index) -> Slot {
-        index
-    }
-
-    fn as_index(slot: Slot) -> Self::Index {
-        slot
-    }
 }
-
 impl TypedColumn for columns::Orphans {
     type Type = bool;
 }
 
-impl Column for columns::Root {
+impl SlotColumn for columns::Root {}
+impl ColumnName for columns::Root {
     const NAME: &'static str = ROOT_CF;
-    type Index = u64;
-
-    fn key(slot: Slot) -> Vec<u8> {
-        let mut key = vec![0; 8];
-        BigEndian::write_u64(&mut key[..], slot);
-        key
-    }
-
-    fn index(key: &[u8]) -> u64 {
-        BigEndian::read_u64(&key[..8])
-    }
-
-    fn slot(index: Self::Index) -> Slot {
-        index
-    }
-
-    fn as_index(slot: Slot) -> Self::Index {
-        slot
-    }
 }
-
 impl TypedColumn for columns::Root {
     type Type = bool;
 }
 
-impl Column for columns::SlotMeta {
+impl SlotColumn for columns::SlotMeta {}
+impl ColumnName for columns::SlotMeta {
     const NAME: &'static str = META_CF;
-    type Index = u64;
-
-    fn key(slot: Slot) -> Vec<u8> {
-        let mut key = vec![0; 8];
-        BigEndian::write_u64(&mut key[..], slot);
-        key
-    }
-
-    fn index(key: &[u8]) -> u64 {
-        BigEndian::read_u64(&key[..8])
-    }
-
-    fn slot(index: Self::Index) -> Slot {
-        index
-    }
-
-    fn as_index(slot: Slot) -> Self::Index {
-        slot
-    }
 }
-
 impl TypedColumn for columns::SlotMeta {
     type Type = blockstore_meta::SlotMeta;
 }
 
 impl Column for columns::ErasureMeta {
-    const NAME: &'static str = ERASURE_META_CF;
     type Index = (u64, u64);
 
     fn index(key: &[u8]) -> (u64, u64) {
@@ -520,7 +441,9 @@ impl Column for columns::ErasureMeta {
         (slot, 0)
     }
 }
-
+impl ColumnName for columns::ErasureMeta {
+    const NAME: &'static str = ERASURE_META_CF;
+}
 impl TypedColumn for columns::ErasureMeta {
     type Type = blockstore_meta::ErasureMeta;
 }
@@ -563,7 +486,7 @@ impl Database {
 
     pub fn get<C>(&self, key: C::Index) -> Result<Option<C::Type>>
     where
-        C: TypedColumn,
+        C: TypedColumn + ColumnName,
     {
         if let Some(serialized_value) = self.backend.get_cf(self.cf_handle::<C>(), &C::key(key))? {
             let value = deserialize(&serialized_value)?;
@@ -579,7 +502,7 @@ impl Database {
         iterator_mode: IteratorMode<C::Index>,
     ) -> Result<impl Iterator<Item = (C::Index, Box<[u8]>)> + 'a>
     where
-        C: Column,
+        C: Column + ColumnName,
     {
         let cf = self.cf_handle::<C>();
         let iter = self.backend.iterator_cf::<C>(cf, iterator_mode)?;
@@ -587,16 +510,16 @@ impl Database {
     }
 
     #[inline]
-    pub fn cf_handle<C>(&self) -> &ColumnFamily
+    pub fn cf_handle<C: ColumnName>(&self) -> &ColumnFamily
     where
-        C: Column,
+        C: Column + ColumnName,
     {
         self.backend.cf_handle(C::NAME)
     }
 
     pub fn column<C>(&self) -> LedgerColumn<C>
     where
-        C: Column,
+        C: Column + ColumnName,
     {
         LedgerColumn {
             backend: Arc::clone(&self.backend),
@@ -633,7 +556,7 @@ impl Database {
     // its end
     pub fn delete_range_cf<C>(&self, batch: &mut WriteBatch, from: Slot, to: Slot) -> Result<bool>
     where
-        C: Column,
+        C: Column + ColumnName,
     {
         let cf = self.cf_handle::<C>();
         let from_index = C::as_index(from);
@@ -651,7 +574,7 @@ impl Database {
 
 impl<C> LedgerColumn<C>
 where
-    C: Column,
+    C: Column + ColumnName,
 {
     pub fn get_bytes(&self, key: C::Index) -> Result<Option<Vec<u8>>> {
         self.backend.get_cf(self.handle(), &C::key(key))
@@ -673,7 +596,7 @@ where
         to: Option<Slot>,
     ) -> Result<bool>
     where
-        C::Index: PartialOrd + Copy,
+        C::Index: PartialOrd + Copy + ColumnName,
     {
         let mut end = true;
         let iter_config = match from {
@@ -730,7 +653,7 @@ where
 
 impl<C> LedgerColumn<C>
 where
-    C: TypedColumn,
+    C: TypedColumn + ColumnName,
 {
     pub fn get(&self, key: C::Index) -> Result<Option<C::Type>> {
         if let Some(serialized_value) = self.backend.get_cf(self.handle(), &C::key(key))? {
@@ -751,19 +674,23 @@ where
 }
 
 impl<'a> WriteBatch<'a> {
-    pub fn put_bytes<C: Column>(&mut self, key: C::Index, bytes: &[u8]) -> Result<()> {
+    pub fn put_bytes<C: Column + ColumnName>(&mut self, key: C::Index, bytes: &[u8]) -> Result<()> {
         self.write_batch
             .put_cf(self.get_cf::<C>(), &C::key(key), bytes)?;
         Ok(())
     }
 
-    pub fn delete<C: Column>(&mut self, key: C::Index) -> Result<()> {
+    pub fn delete<C: Column + ColumnName>(&mut self, key: C::Index) -> Result<()> {
         self.write_batch
             .delete_cf(self.get_cf::<C>(), &C::key(key))?;
         Ok(())
     }
 
-    pub fn put<C: TypedColumn>(&mut self, key: C::Index, value: &C::Type) -> Result<()> {
+    pub fn put<C: TypedColumn + ColumnName>(
+        &mut self,
+        key: C::Index,
+        value: &C::Type,
+    ) -> Result<()> {
         let serialized_value = serialize(&value)?;
         self.write_batch
             .put_cf(self.get_cf::<C>(), &C::key(key), &serialized_value)?;
@@ -771,7 +698,7 @@ impl<'a> WriteBatch<'a> {
     }
 
     #[inline]
-    fn get_cf<C: Column>(&self) -> &'a ColumnFamily {
+    fn get_cf<C: Column + ColumnName>(&self) -> &'a ColumnFamily {
         self.map[C::NAME]
     }
 

--- a/ledger/src/blockstore_meta.rs
+++ b/ledger/src/blockstore_meta.rs
@@ -60,6 +60,14 @@ pub struct ErasureMeta {
     pub config: ErasureConfig,
 }
 
+#[derive(Deserialize, Serialize)]
+pub struct DuplicateSlotProof {
+    #[serde(with = "serde_bytes")]
+    pub shred1: Vec<u8>,
+    #[serde(with = "serde_bytes")]
+    pub shred2: Vec<u8>,
+}
+
 #[derive(Debug, PartialEq)]
 pub enum ErasureMetaStatus {
     CanRecover,
@@ -206,6 +214,12 @@ impl ErasureMeta {
 
     pub fn size(&self) -> usize {
         self.size
+    }
+}
+
+impl DuplicateSlotProof {
+    pub(crate) fn new(shred1: Vec<u8>, shred2: Vec<u8>) -> Self {
+        DuplicateSlotProof { shred1, shred2 }
     }
 }
 


### PR DESCRIPTION
#### Problem
BlockStore doesn't currently support tracking duplicate shreds for a slot

#### Summary of Changes
Add a column family for tracking a proof of duplicate shreds

Fixes #
