### PR TITLE
Include shred version in gossip

### DIFF
--- a/core/src/contact_info.rs
+++ b/core/src/contact_info.rs
@@ -31,6 +31,8 @@ pub struct ContactInfo {
     pub rpc_pubsub: SocketAddr,
     /// latest wallclock picked
     pub wallclock: u64,
+    /// node shred version
+    pub shred_version: u16,
 }
 
 impl Ord for ContactInfo {
@@ -84,6 +86,7 @@ impl Default for ContactInfo {
             rpc: socketaddr_any!(),
             rpc_pubsub: socketaddr_any!(),
             wallclock: 0,
+            shred_version: 0,
         }
     }
 }
@@ -115,6 +118,7 @@ impl ContactInfo {
             rpc,
             rpc_pubsub,
             wallclock: now,
+            shred_version: 0,
         }
     }
 

--- a/core/src/gossip_service.rs
+++ b/core/src/gossip_service.rs
@@ -199,7 +199,6 @@ fn spy(
             .unwrap()
             .tvu_peers()
             .into_iter()
-            .filter(|node| !ClusterInfo::is_archiver(&node))
             .collect::<Vec<_>>();
         archivers = spy_ref.read().unwrap().storage_peers();
         if let Some(num) = num_nodes {


### PR DESCRIPTION
Nodes with differing shred versions will not ingest each other's shreds, so ignore tvu/rpc nodes on gossip with differing shred versions when `--wait-for-supermajority` validator argument is used.