### PR TITLE
Add support for stake::split() via create_account_with_seed()

### DIFF
--- a/programs/stake/src/stake_state.rs
+++ b/programs/stake/src/stake_state.rs
@@ -2780,6 +2780,18 @@ mod tests {
     }
 
     #[test]
+    #[ignore]
+    #[should_panic]
+    fn test_dbg_stake_minimum_balance() {
+        let minimum_balance = Rent::default().minimum_balance(std::mem::size_of::<StakeState>());
+        panic!(
+            "stake minimum_balance: {} lamports, {} SOL",
+            minimum_balance,
+            minimum_balance as f64 / solana_sdk::native_token::LAMPORTS_PER_SOL as f64
+        );
+    }
+
+    #[test]
     fn test_authorize_delegated_stake() {
         let stake_pubkey = Pubkey::new_rand();
         let stake_lamports = 42;

--- a/runtime/src/system_instruction_processor.rs
+++ b/runtime/src/system_instruction_processor.rs
@@ -84,10 +84,8 @@ fn finish_create_account(
     }
 
     // if it looks like the `to` account is already in use, bail
-    if to.account.lamports != 0
-        || !to.account.data.is_empty()
-        || !system_program::check_id(&to.account.owner)
-    {
+    //   (note that the id check is also enforced by message_processor)
+    if !to.account.data.is_empty() || !system_program::check_id(&to.account.owner) {
         debug!(
             "CreateAccount: invalid argument; account {} already in use",
             to.unsigned_key()
@@ -116,7 +114,7 @@ fn finish_create_account(
         return Err(SystemError::InvalidAccountDataLength.into());
     }
 
-    // guard against sysvars being assigned
+    // guard against sysvars being made
     if sysvar::check_id(&program_id) {
         debug!("Assign: program id {} invalid", program_id);
         return Err(SystemError::InvalidProgramId.into());
@@ -136,12 +134,17 @@ fn assign_account_to_program(
     account: &mut KeyedAccount,
     program_id: &Pubkey,
 ) -> Result<(), InstructionError> {
+    // no work to do, just return
+    if account.account.owner == *program_id {
+        return Ok(());
+    }
+
     if account.signer_key().is_none() {
         debug!("Assign: account must sign");
         return Err(InstructionError::MissingRequiredSignature);
     }
 
-    // guard against sysvars being assigned
+    // guard against sysvars being made
     if sysvar::check_id(&program_id) {
         debug!("Assign: program id {} invalid", program_id);
         return Err(SystemError::InvalidProgramId.into());
@@ -515,6 +518,7 @@ mod tests {
 
     #[test]
     fn test_create_already_in_use() {
+        solana_logger::setup();
         // Attempt to create system account in account already owned by another program
         let new_program_owner = Pubkey::new(&[9; 32]);
         let from = Pubkey::new_rand();
@@ -538,7 +542,8 @@ mod tests {
         assert_eq!(from_lamports, 100);
         assert_eq!(owned_account, unchanged_account);
 
-        let mut owned_account = Account::new(10, 0, &Pubkey::default());
+        // Attempt to create system account in account that already has data
+        let mut owned_account = Account::new(0, 1, &Pubkey::default());
         let unchanged_account = owned_account.clone();
         let result = create_account(
             &mut KeyedAccount::new(&from, true, &mut from_account),
@@ -551,6 +556,19 @@ mod tests {
         let from_lamports = from_account.lamports;
         assert_eq!(from_lamports, 100);
         assert_eq!(owned_account, unchanged_account);
+
+        // Verify that create_account works even if `to` has a non-zero balance
+        let mut owned_account = Account::new(1, 0, &Pubkey::default());
+        let result = create_account(
+            &mut KeyedAccount::new(&from, true, &mut from_account),
+            &mut KeyedAccount::new(&owned_key, true, &mut owned_account),
+            50,
+            2,
+            &new_program_owner,
+        );
+        assert_eq!(result, Ok(()));
+        assert_eq!(from_account.lamports, from_lamports - 50);
+        assert_eq!(owned_account.lamports, 1 + 50);
     }
 
     #[test]
@@ -700,6 +718,14 @@ mod tests {
             ),
             Err(InstructionError::MissingRequiredSignature)
         );
+        // no change, no signature needed
+        assert_eq!(
+            assign_account_to_program(
+                &mut KeyedAccount::new(&from, false, &mut from_account),
+                &system_program::id(),
+            ),
+            Ok(())
+        );
 
         assert_eq!(
             process_instruction(
@@ -814,6 +840,45 @@ mod tests {
             ),
             Err(InstructionError::InvalidArgument),
         )
+    }
+
+    #[test]
+    fn test_create_account_no_transfer() {
+        solana_logger::setup();
+        let (genesis_config, alice_keypair) = create_genesis_config(100);
+        let alice_pubkey = alice_keypair.pubkey();
+        let bob_keypair = Keypair::new();
+        let bob_pubkey = bob_keypair.pubkey();
+
+        // Fund to account to bypass AccountNotFound error
+        let bank = Bank::new(&genesis_config);
+        let bank_client = BankClient::new(bank);
+        bank_client
+            .transfer(50, &alice_keypair, &bob_pubkey)
+            .unwrap();
+        let program_id = Pubkey::new_rand();
+
+        // test system_instruction: that alice's signature is not asked for
+        let instruction =
+            system_instruction::create_account(&alice_pubkey, &bob_pubkey, 0, 1, &program_id);
+
+        assert!(!instruction.accounts[0].is_signer);
+
+        // test system_instruction_processor: that alice's signature is needed
+        assert!(bank_client
+            .send_instruction(&bob_keypair, instruction)
+            .is_ok());
+
+        assert_eq!(bank_client.get_balance(&alice_pubkey).unwrap(), 50);
+        assert_eq!(
+            bank_client.get_account(&bob_pubkey).unwrap().unwrap(),
+            Account {
+                data: vec![0; 1],
+                owner: program_id,
+                lamports: 50,
+                ..Account::default()
+            }
+        );
     }
 
     #[test]

--- a/sdk/src/system_instruction.rs
+++ b/sdk/src/system_instruction.rs
@@ -147,7 +147,7 @@ pub fn create_account(
     program_id: &Pubkey,
 ) -> Instruction {
     let account_metas = vec![
-        AccountMeta::new(*from_pubkey, true),
+        AccountMeta::new(*from_pubkey, lamports != 0), // no signature required if no transfer
         AccountMeta::new(*to_pubkey, true),
     ];
     Instruction::new(
@@ -173,7 +173,7 @@ pub fn create_account_with_seed(
     program_id: &Pubkey,
 ) -> Instruction {
     let account_metas = vec![
-        AccountMeta::new(*from_pubkey, true),
+        AccountMeta::new(*from_pubkey, lamports != 0),
         AccountMeta::new(*to_pubkey, false),
     ]
     .with_signer(base);


### PR DESCRIPTION
#### Problem
 stake::split() into an account with a _with_seed() address isn't part of
 the stake_instruction API, so must be hand-rolled.

 #### Summary of Changes
 add the API to get that instruction vector
 note: depends on #7776

Fixes #