### PR TITLE
Fix cluster collapse due to no proper shifted read

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -958,7 +958,7 @@ impl AccountsDB {
             let storage = self.find_storage_candidate(slot_id);
             let rvs = storage
                 .accounts
-                .append_accounts(&with_meta[infos.len()..], &hashes);
+                .append_accounts(&with_meta[infos.len()..], &hashes[infos.len()..]);
             if rvs.is_empty() {
                 storage.set_status(AccountStorageStatus::Full);
 


### PR DESCRIPTION
@sakridge
TBD; My stamina is exhausted; there is moderate number of issues/PRs to submit and tests to write; Those are needed to get here... It was very long journey... ;)

Introduced by months ago: https://github.com/solana-labs/solana/pull/5573/files#diff-2099c5256db4eb5975c8834af38f6456R782.

It seems TdS DR6 finally managed to expose this bug.

The findings at #7736 are now all clear; Every mysterious pieces are put together in place.
And no wonder if this thing happens randomly on several validators with enough stake at the same time, this indeed will lead to mismatched bank hashes across the cluster and the inevitable total consensus failure.

Fixes #7736 