### PR TITLE
Add ability to hard fork at any slot

### DIFF
--- a/net/init-metrics.sh
+++ b/net/init-metrics.sh
@@ -72,6 +72,7 @@ else
 
   query() {
     echo "$*"
+    set -x
     curl -XPOST \
       "$host/query?u=${username}&p=${password}" \
       --data-urlencode "q=$*"

--- a/runtime/src/hard_forks.rs
+++ b/runtime/src/hard_forks.rs
@@ -1,0 +1,91 @@
+//! The `hard_forks` module is used to maintain the list of slot boundaries for when a hard fork
+//! should occur.
+
+use byteorder::{ByteOrder, LittleEndian};
+use solana_sdk::clock::Slot;
+use std::ops::Add;
+
+#[derive(Default, Clone, Deserialize, Serialize)]
+pub struct HardForks {
+    hard_forks: Vec<(Slot, usize)>,
+}
+impl HardForks {
+    // Register a fork to occur at all slots >= `slot` with a parent slot < `slot`
+    pub fn register(&mut self, new_slot: Slot) {
+        if let Some(i) = self
+            .hard_forks
+            .iter()
+            .position(|(slot, _)| *slot == new_slot)
+        {
+            self.hard_forks[i] = (new_slot, self.hard_forks[i].1 + 1);
+        } else {
+            self.hard_forks.push((new_slot, 1));
+        }
+        self.hard_forks.sort();
+    }
+
+    // Returns a sorted-by-slot iterator over the registered hark forks
+    pub fn iter(&self) -> std::slice::Iter<(Slot, usize)> {
+        self.hard_forks.iter()
+    }
+
+    // Returns data to include in the bank hash for the given slot if a hard fork is scheduled
+    pub fn get_hash_data(&self, slot: Slot, parent_slot: Slot) -> Option<[u8; 8]> {
+        // The expected number of hard forks in a cluster is small.
+        // If this turns out to be false then a more efficient data
+        // structure may be needed here to avoid this linear search
+        let fork_count = self
+            .hard_forks
+            .iter()
+            .fold(0, |acc, (fork_slot, fork_count)| {
+                acc.add(if parent_slot < *fork_slot && slot >= *fork_slot {
+                    *fork_count
+                } else {
+                    0
+                })
+            });
+
+        if fork_count > 0 {
+            let mut buf = [0u8; 8];
+            LittleEndian::write_u64(&mut buf[..], fork_count as u64);
+            Some(buf)
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn iter_is_sorted() {
+        let mut hf = HardForks::default();
+        hf.register(30);
+        hf.register(20);
+        hf.register(10);
+        hf.register(20);
+
+        assert_eq!(
+            hf.iter().map(|i| *i).collect::<Vec<_>>(),
+            vec![(10, 1), (20, 2), (30, 1)]
+        );
+    }
+
+    #[test]
+    fn multiple_hard_forks_since_parent() {
+        let mut hf = HardForks::default();
+        hf.register(10);
+        hf.register(20);
+
+        assert_eq!(hf.get_hash_data(9, 0), None);
+        assert_eq!(hf.get_hash_data(10, 0), Some([1, 0, 0, 0, 0, 0, 0, 0,]));
+        assert_eq!(hf.get_hash_data(19, 0), Some([1, 0, 0, 0, 0, 0, 0, 0,]));
+        assert_eq!(hf.get_hash_data(20, 0), Some([2, 0, 0, 0, 0, 0, 0, 0,]));
+        assert_eq!(hf.get_hash_data(20, 10), Some([1, 0, 0, 0, 0, 0, 0, 0,]));
+        assert_eq!(hf.get_hash_data(20, 11), Some([1, 0, 0, 0, 0, 0, 0, 0,]));
+        assert_eq!(hf.get_hash_data(21, 11), Some([1, 0, 0, 0, 0, 0, 0, 0,]));
+        assert_eq!(hf.get_hash_data(21, 20), None);
+    }
+}

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -7,6 +7,7 @@ pub mod bank_client;
 mod blockhash_queue;
 pub mod bloom;
 pub mod genesis_utils;
+pub mod hard_forks;
 pub mod loader_utils;
 pub mod message_processor;
 mod native_loader;


### PR DESCRIPTION
When everything else fails we need the ability to rollback to a known good slot and cause a hard fork in the cluster.   

This can be now accomplished by adding one or more `--hard-fork` arguments to all `solana-validator` operators that choose to participate in the hard fork:
```bash
$ solana-validator --hard-fork 10 --hard-fork 10 --hard-fork 20 ...
```
When the *exact* bank identified by the `--hard-fork` argument is frozen, an extra cookie is added to it's bank hash to cause a ledger fork.   

The validator's shred version is now additionally derived from the `--hard-fork` arguments, so that shreds received from validators that are not participating in the hard fork will be ignored.
