### PR TITLE
Remove word pair from address generator seed string

### DIFF
--- a/genesis/src/address_generator.rs
+++ b/genesis/src/address_generator.rs
@@ -3,16 +3,14 @@ use solana_sdk::{pubkey::Pubkey, system_instruction::create_address_with_seed};
 #[derive(Default)]
 pub struct AddressGenerator {
     base_pubkey: Pubkey,
-    base_seed: String,
     program_id: Pubkey,
     nth: usize,
 }
 
 impl AddressGenerator {
-    pub fn new(base_pubkey: &Pubkey, base_seed: &str, program_id: &Pubkey) -> Self {
+    pub fn new(base_pubkey: &Pubkey, program_id: &Pubkey) -> Self {
         Self {
             base_pubkey: *base_pubkey,
-            base_seed: base_seed.to_string(),
             program_id: *program_id,
             nth: 0,
         }
@@ -21,7 +19,7 @@ impl AddressGenerator {
     pub fn nth(&self, nth: usize) -> Pubkey {
         create_address_with_seed(
             &self.base_pubkey,
-            &format!("{}:{}", self.base_seed, nth),
+            &format!("{}", nth),
             &self.program_id,
         )
         .unwrap()

--- a/genesis/src/address_generator.rs
+++ b/genesis/src/address_generator.rs
@@ -17,12 +17,7 @@ impl AddressGenerator {
     }
 
     pub fn nth(&self, nth: usize) -> Pubkey {
-        create_address_with_seed(
-            &self.base_pubkey,
-            &format!("{}", nth),
-            &self.program_id,
-        )
-        .unwrap()
+        create_address_with_seed(&self.base_pubkey, &format!("{}", nth), &self.program_id).unwrap()
     }
 
     #[allow(clippy::should_implement_trait)]

--- a/genesis/src/address_generator.rs
+++ b/genesis/src/address_generator.rs
@@ -17,7 +17,12 @@ impl AddressGenerator {
     }
 
     pub fn nth(&self, nth: usize) -> Pubkey {
-        create_address_with_seed(&self.base_pubkey, &format!("{}", nth), &self.program_id).unwrap()
+        create_address_with_seed(
+            &self.base_pubkey,
+            &format!("{}", nth),
+            &self.program_id,
+        )
+        .unwrap()
     }
 
     #[allow(clippy::should_implement_trait)]

--- a/genesis/src/genesis_accounts.rs
+++ b/genesis/src/genesis_accounts.rs
@@ -34,107 +34,86 @@ const UNLOCKS_ALL_DAY_ZERO: UnlockInfo = UnlockInfo {
 
 pub const BATCH_FOUR_STAKER_INFOS: &[StakerInfo] = &[
     StakerInfo {
-        name: "impossible pizza",
         staker: "CDtJpwRSiPRDGeKrvymWQKM7JY9M3hU7iimEKBDxZyoP",
         lamports: 5_000_000 * LAMPORTS_PER_SOL,
     },
     StakerInfo {
-        name: "wretched texture",
         staker: "HbENu65qjWLEB5TrMouSSWLq9mbtGx2bvfhPjk2FpYek",
         lamports: 225_000 * LAMPORTS_PER_SOL,
     },
     StakerInfo {
-        name: "nutritious examination",
         staker: "C9CfFpmLDsQsz6wt7MrrZquNB5oS4QkpJkmDAiboVEZZ",
         lamports: 5_000_000 * LAMPORTS_PER_SOL,
     },
     StakerInfo {
-        name: "tidy impression",
         staker: "6ne6Rbag4FAnop1KNgVdM1SEHnJEysHSWyqvRpFrzaig",
         lamports: 5_000_000 * LAMPORTS_PER_SOL,
     },
     StakerInfo {
-        name: "unbecoming silver",
         staker: "42yapY7Vrs5jqht9TCKZsPoyb4vDFYcPfRkqAP85NSAQ",
         lamports: 28_800 * LAMPORTS_PER_SOL,
     },
     StakerInfo {
-        name: "dramatic treatment",
         staker: "GTyawCMwt3kMb51AgDtfdp97mDot7jNwc8ifuS9qqANg",
         lamports: 1_205_602 * LAMPORTS_PER_SOL,
     },
     StakerInfo {
-        name: "angry noise",
         staker: "Fqxs9MhqjKuMq6YwjBG4ktEapuZQ3kj19mpuHLZKtkg9",
         lamports: 5_000_000 * LAMPORTS_PER_SOL,
     },
     StakerInfo {
-        name: "hard cousin",
         staker: "9MYDzj7QuAX9QAK7da1GhzPB4gA3qbPNWsW3MMSZobru",
         lamports: 5_000_000 * LAMPORTS_PER_SOL,
     },
     StakerInfo {
-        name: "inexpensive uncle",
         staker: "E4DLNkmdL34ejA48ApfPDoFVuD9XWAFqi8bXzBGRhKst",
         lamports: 300_000 * LAMPORTS_PER_SOL,
     },
     StakerInfo {
-        name: "lopsided skill",
         staker: "8cV7zCTF5UMrZakZXiL2Jw5uY3ms2Wz4twzFXEY9Kge2",
         lamports: 5_000_000 * LAMPORTS_PER_SOL,
     },
     StakerInfo {
-        name: "red snake",
         staker: "JBGnGdLyo7V2z9hz51mnnbyDp9sBACtw5WYH9YRG8n7e",
         lamports: 3_655_292 * LAMPORTS_PER_SOL,
     },
     StakerInfo {
-        name: "hellish money",
         staker: "CqKdQ57mBj2mKcAbpjWc28Ls7yXzBXboxSTCRWocmUVj",
         lamports: 200_000 * LAMPORTS_PER_SOL,
     },
     StakerInfo {
-        name: "full grape",
         staker: "2SCJKvh7wWo32PtfUZdVZQ84WnMWoUpF4WTm6ZxcCJ15",
         lamports: 450_000 * LAMPORTS_PER_SOL,
     },
     StakerInfo {
-        name: "nice ghost",
         staker: "FeumxB3gfzrVQzABBiha8AacKPY3Rf4BTFSh2aZWHqR8",
         lamports: 650_000 * LAMPORTS_PER_SOL,
     },
     StakerInfo {
-        name: "jolly year",
         staker: "HBwFWNGPVZgkf3yqUKxuAds5aANGWX62LzUFvZVCWLdJ",
         lamports: 5_000_000 * LAMPORTS_PER_SOL,
     },
     StakerInfo {
-        name: "typical initiative",
         staker: "3JMz3kaDUZEVK2JVjRqwERGMp7LbWbgUjAFBb42qxoHb",
         lamports: 5_000_000 * LAMPORTS_PER_SOL,
     },
     StakerInfo {
-        name: "deserted window",
         staker: "XTeBBZextvHkoRqDF8yb4hihjcraKQDwTEXhzjd8fip",
         lamports: 3_655_292 * LAMPORTS_PER_SOL,
     },
     StakerInfo {
-        name: "eight nation",
         staker: "E5bSU5ywqPiz3ije89ef5gaEC7jy81BAc72Zeb9MqeHY",
         lamports: 103_519 * LAMPORTS_PER_SOL,
     },
     StakerInfo {
-        name: "earsplitting meaning",
         staker: "4ZemkSoE75RFE1SVLnnmHcaNWT4qN8KFrKP2wAYfv8CB",
         lamports: 5_000_000 * LAMPORTS_PER_SOL,
     },
     StakerInfo {
-        name: "alike cheese",
         staker: "72BGEwYee5txFonmpEarTEKCZVN2UxcSUgdphdhcx3V",
         lamports: 3_880_295 * LAMPORTS_PER_SOL,
     },
     StakerInfo {
-        name: "noisy honey",
         staker: "DRp1Scyn4yJZQfMAdQew2x8RtvRmsNELN37JTK5Xvzgn",
         lamports: 5_000_000 * LAMPORTS_PER_SOL,
     },
@@ -142,12 +121,10 @@ pub const BATCH_FOUR_STAKER_INFOS: &[StakerInfo] = &[
 
 pub const FOUNDATION_STAKER_INFOS: &[StakerInfo] = &[
     StakerInfo {
-        name: "lyrical supermarket",
         staker: "GRZwoJGisLTszcxtWpeREJ98EGg8pZewhbtcrikoU7b3",
         lamports: 5_000_000 * LAMPORTS_PER_SOL,
     },
     StakerInfo {
-        name: "frequent description",
         staker: "J51tinoLdmEdUR27LUVymrb2LB3xQo1aSHSgmbSGdj58",
         lamports: 57_500_000 * LAMPORTS_PER_SOL,
     },
@@ -155,12 +132,10 @@ pub const FOUNDATION_STAKER_INFOS: &[StakerInfo] = &[
 
 pub const GRANTS_STAKER_INFOS: &[StakerInfo] = &[
     StakerInfo {
-        name: "rightful agreement",
         staker: "DNaKiBwwbbqk1wVoC5AQxWQbuDhvaDVbAtXzsVos9mrc",
         lamports: 5_000_000 * LAMPORTS_PER_SOL,
     },
     StakerInfo {
-        name: "tasty location",
         staker: "HvXQPXAijjG1vnQs6HXVtUUtFVzi5HNgXV9LGnHvYF85",
         lamports: 15_000_000 * LAMPORTS_PER_SOL,
     },
@@ -168,17 +143,14 @@ pub const GRANTS_STAKER_INFOS: &[StakerInfo] = &[
 
 pub const COMMUNITY_STAKER_INFOS: &[StakerInfo] = &[
     StakerInfo {
-        name: "shrill charity",
         staker: "BzuqQFnu7oNUeok9ZoJezpqu2vZJU7XR1PxVLkk6wwUD",
         lamports: 5_000_000 * LAMPORTS_PER_SOL,
     },
     StakerInfo {
-        name: "legal gate",
         staker: "FwMbkDZUb78aiMWhZY4BEroAcqmnrXZV77nwrg71C57d",
         lamports: 16_086_641 * LAMPORTS_PER_SOL,
     },
     StakerInfo {
-        name: "cluttered complaint",
         staker: "4h1rt2ic4AXwG7p3Qqhw57EMDD4c3tLYb5J3QstGA2p5",
         lamports: 153_333_633 * LAMPORTS_PER_SOL + 41 * LAMPORTS_PER_SOL / 100,
     },
@@ -288,7 +260,6 @@ pub fn add_genesis_accounts(genesis_config: &mut GenesisConfig, mut issued_lampo
     create_and_add_stakes(
         genesis_config,
         &StakerInfo {
-            name: "one thanks",
             staker: "3b7akieYUyCgz3Cwt5sTSErMWjg8NEygD6mbGjhGkduB",
             lamports: 500_000_000 * LAMPORTS_PER_SOL - issued_lamports,
         },

--- a/genesis/src/genesis_accounts.rs
+++ b/genesis/src/genesis_accounts.rs
@@ -34,86 +34,107 @@ const UNLOCKS_ALL_DAY_ZERO: UnlockInfo = UnlockInfo {
 
 pub const BATCH_FOUR_STAKER_INFOS: &[StakerInfo] = &[
     StakerInfo {
+        name: "impossible pizza",
         staker: "CDtJpwRSiPRDGeKrvymWQKM7JY9M3hU7iimEKBDxZyoP",
         lamports: 5_000_000 * LAMPORTS_PER_SOL,
     },
     StakerInfo {
+        name: "wretched texture",
         staker: "HbENu65qjWLEB5TrMouSSWLq9mbtGx2bvfhPjk2FpYek",
         lamports: 225_000 * LAMPORTS_PER_SOL,
     },
     StakerInfo {
+        name: "nutritious examination",
         staker: "C9CfFpmLDsQsz6wt7MrrZquNB5oS4QkpJkmDAiboVEZZ",
         lamports: 5_000_000 * LAMPORTS_PER_SOL,
     },
     StakerInfo {
+        name: "tidy impression",
         staker: "6ne6Rbag4FAnop1KNgVdM1SEHnJEysHSWyqvRpFrzaig",
         lamports: 5_000_000 * LAMPORTS_PER_SOL,
     },
     StakerInfo {
+        name: "unbecoming silver",
         staker: "42yapY7Vrs5jqht9TCKZsPoyb4vDFYcPfRkqAP85NSAQ",
         lamports: 28_800 * LAMPORTS_PER_SOL,
     },
     StakerInfo {
+        name: "dramatic treatment",
         staker: "GTyawCMwt3kMb51AgDtfdp97mDot7jNwc8ifuS9qqANg",
         lamports: 1_205_602 * LAMPORTS_PER_SOL,
     },
     StakerInfo {
+        name: "angry noise",
         staker: "Fqxs9MhqjKuMq6YwjBG4ktEapuZQ3kj19mpuHLZKtkg9",
         lamports: 5_000_000 * LAMPORTS_PER_SOL,
     },
     StakerInfo {
+        name: "hard cousin",
         staker: "9MYDzj7QuAX9QAK7da1GhzPB4gA3qbPNWsW3MMSZobru",
         lamports: 5_000_000 * LAMPORTS_PER_SOL,
     },
     StakerInfo {
+        name: "inexpensive uncle",
         staker: "E4DLNkmdL34ejA48ApfPDoFVuD9XWAFqi8bXzBGRhKst",
         lamports: 300_000 * LAMPORTS_PER_SOL,
     },
     StakerInfo {
+        name: "lopsided skill",
         staker: "8cV7zCTF5UMrZakZXiL2Jw5uY3ms2Wz4twzFXEY9Kge2",
         lamports: 5_000_000 * LAMPORTS_PER_SOL,
     },
     StakerInfo {
+        name: "red snake",
         staker: "JBGnGdLyo7V2z9hz51mnnbyDp9sBACtw5WYH9YRG8n7e",
         lamports: 3_655_292 * LAMPORTS_PER_SOL,
     },
     StakerInfo {
+        name: "hellish money",
         staker: "CqKdQ57mBj2mKcAbpjWc28Ls7yXzBXboxSTCRWocmUVj",
         lamports: 200_000 * LAMPORTS_PER_SOL,
     },
     StakerInfo {
+        name: "full grape",
         staker: "2SCJKvh7wWo32PtfUZdVZQ84WnMWoUpF4WTm6ZxcCJ15",
         lamports: 450_000 * LAMPORTS_PER_SOL,
     },
     StakerInfo {
+        name: "nice ghost",
         staker: "FeumxB3gfzrVQzABBiha8AacKPY3Rf4BTFSh2aZWHqR8",
         lamports: 650_000 * LAMPORTS_PER_SOL,
     },
     StakerInfo {
+        name: "jolly year",
         staker: "HBwFWNGPVZgkf3yqUKxuAds5aANGWX62LzUFvZVCWLdJ",
         lamports: 5_000_000 * LAMPORTS_PER_SOL,
     },
     StakerInfo {
+        name: "typical initiative",
         staker: "3JMz3kaDUZEVK2JVjRqwERGMp7LbWbgUjAFBb42qxoHb",
         lamports: 5_000_000 * LAMPORTS_PER_SOL,
     },
     StakerInfo {
+        name: "deserted window",
         staker: "XTeBBZextvHkoRqDF8yb4hihjcraKQDwTEXhzjd8fip",
         lamports: 3_655_292 * LAMPORTS_PER_SOL,
     },
     StakerInfo {
+        name: "eight nation",
         staker: "E5bSU5ywqPiz3ije89ef5gaEC7jy81BAc72Zeb9MqeHY",
         lamports: 103_519 * LAMPORTS_PER_SOL,
     },
     StakerInfo {
+        name: "earsplitting meaning",
         staker: "4ZemkSoE75RFE1SVLnnmHcaNWT4qN8KFrKP2wAYfv8CB",
         lamports: 5_000_000 * LAMPORTS_PER_SOL,
     },
     StakerInfo {
+        name: "alike cheese",
         staker: "72BGEwYee5txFonmpEarTEKCZVN2UxcSUgdphdhcx3V",
         lamports: 3_880_295 * LAMPORTS_PER_SOL,
     },
     StakerInfo {
+        name: "noisy honey",
         staker: "DRp1Scyn4yJZQfMAdQew2x8RtvRmsNELN37JTK5Xvzgn",
         lamports: 5_000_000 * LAMPORTS_PER_SOL,
     },
@@ -121,10 +142,12 @@ pub const BATCH_FOUR_STAKER_INFOS: &[StakerInfo] = &[
 
 pub const FOUNDATION_STAKER_INFOS: &[StakerInfo] = &[
     StakerInfo {
+        name: "lyrical supermarket",
         staker: "GRZwoJGisLTszcxtWpeREJ98EGg8pZewhbtcrikoU7b3",
         lamports: 5_000_000 * LAMPORTS_PER_SOL,
     },
     StakerInfo {
+        name: "frequent description",
         staker: "J51tinoLdmEdUR27LUVymrb2LB3xQo1aSHSgmbSGdj58",
         lamports: 57_500_000 * LAMPORTS_PER_SOL,
     },
@@ -132,10 +155,12 @@ pub const FOUNDATION_STAKER_INFOS: &[StakerInfo] = &[
 
 pub const GRANTS_STAKER_INFOS: &[StakerInfo] = &[
     StakerInfo {
+        name: "rightful agreement",
         staker: "DNaKiBwwbbqk1wVoC5AQxWQbuDhvaDVbAtXzsVos9mrc",
         lamports: 5_000_000 * LAMPORTS_PER_SOL,
     },
     StakerInfo {
+        name: "tasty location",
         staker: "HvXQPXAijjG1vnQs6HXVtUUtFVzi5HNgXV9LGnHvYF85",
         lamports: 15_000_000 * LAMPORTS_PER_SOL,
     },
@@ -143,14 +168,17 @@ pub const GRANTS_STAKER_INFOS: &[StakerInfo] = &[
 
 pub const COMMUNITY_STAKER_INFOS: &[StakerInfo] = &[
     StakerInfo {
+        name: "shrill charity",
         staker: "BzuqQFnu7oNUeok9ZoJezpqu2vZJU7XR1PxVLkk6wwUD",
         lamports: 5_000_000 * LAMPORTS_PER_SOL,
     },
     StakerInfo {
+        name: "legal gate",
         staker: "FwMbkDZUb78aiMWhZY4BEroAcqmnrXZV77nwrg71C57d",
         lamports: 16_086_641 * LAMPORTS_PER_SOL,
     },
     StakerInfo {
+        name: "cluttered complaint",
         staker: "4h1rt2ic4AXwG7p3Qqhw57EMDD4c3tLYb5J3QstGA2p5",
         lamports: 153_333_633 * LAMPORTS_PER_SOL + 41 * LAMPORTS_PER_SOL / 100,
     },
@@ -260,6 +288,7 @@ pub fn add_genesis_accounts(genesis_config: &mut GenesisConfig, mut issued_lampo
     create_and_add_stakes(
         genesis_config,
         &StakerInfo {
+            name: "one thanks",
             staker: "3b7akieYUyCgz3Cwt5sTSErMWjg8NEygD6mbGjhGkduB",
             lamports: 500_000_000 * LAMPORTS_PER_SOL - issued_lamports,
         },

--- a/genesis/src/stakes.rs
+++ b/genesis/src/stakes.rs
@@ -91,7 +91,6 @@ pub fn create_and_add_stakes(
 
     let mut address_generator = AddressGenerator::new(
         &authorized.staker,
-        staker_info.name,
         &solana_stake_program::id(),
     );
 

--- a/genesis/src/stakes.rs
+++ b/genesis/src/stakes.rs
@@ -89,10 +89,8 @@ pub fn create_and_add_stakes(
         genesis_config.ticks_per_slot,
     );
 
-    let mut address_generator = AddressGenerator::new(
-        &authorized.staker,
-        &solana_stake_program::id(),
-    );
+    let mut address_generator =
+        AddressGenerator::new(&authorized.staker, &solana_stake_program::id());
 
     let stake_rent_reserve = StakeState::get_rent_exempt_reserve(&genesis_config.rent);
 

--- a/genesis/src/stakes.rs
+++ b/genesis/src/stakes.rs
@@ -14,6 +14,7 @@ use solana_stake_program::{
 
 #[derive(Debug)]
 pub struct StakerInfo {
+    pub name: &'static str,
     pub staker: &'static str,
     pub lamports: u64,
 }
@@ -88,8 +89,10 @@ pub fn create_and_add_stakes(
         genesis_config.ticks_per_slot,
     );
 
-    let mut address_generator =
-        AddressGenerator::new(&authorized.staker, &solana_stake_program::id());
+    let mut address_generator = AddressGenerator::new(
+        &authorized.staker,
+        &solana_stake_program::id(),
+    );
 
     let stake_rent_reserve = StakeState::get_rent_exempt_reserve(&genesis_config.rent);
 

--- a/genesis/src/stakes.rs
+++ b/genesis/src/stakes.rs
@@ -235,6 +235,7 @@ mod tests {
                 ..GenesisConfig::default()
             },
             &StakerInfo {
+                name: "fun",
                 staker: "P1aceHo1derPubkey11111111111111111111111111",
                 lamports: total_lamports,
             },
@@ -259,6 +260,7 @@ mod tests {
                 ..GenesisConfig::default()
             },
             &StakerInfo {
+                name: "fun",
                 staker: "P1aceHo1derPubkey11111111111111111111111111",
                 lamports: total_lamports,
             },
@@ -283,6 +285,7 @@ mod tests {
                 ..GenesisConfig::default()
             },
             &StakerInfo {
+                name: "fun",
                 staker: "P1aceHo1derPubkey11111111111111111111111111",
                 lamports: total_lamports,
             },
@@ -306,6 +309,7 @@ mod tests {
                 ..GenesisConfig::default()
             },
             &StakerInfo {
+                name: "fun",
                 staker: "P1aceHo1derPubkey11111111111111111111111111",
                 lamports: total_lamports,
             },

--- a/genesis/src/stakes.rs
+++ b/genesis/src/stakes.rs
@@ -14,7 +14,6 @@ use solana_stake_program::{
 
 #[derive(Debug)]
 pub struct StakerInfo {
-    pub name: &'static str,
     pub staker: &'static str,
     pub lamports: u64,
 }
@@ -89,10 +88,8 @@ pub fn create_and_add_stakes(
         genesis_config.ticks_per_slot,
     );
 
-    let mut address_generator = AddressGenerator::new(
-        &authorized.staker,
-        &solana_stake_program::id(),
-    );
+    let mut address_generator =
+        AddressGenerator::new(&authorized.staker, &solana_stake_program::id());
 
     let stake_rent_reserve = StakeState::get_rent_exempt_reserve(&genesis_config.rent);
 

--- a/genesis/src/stakes.rs
+++ b/genesis/src/stakes.rs
@@ -235,7 +235,6 @@ mod tests {
                 ..GenesisConfig::default()
             },
             &StakerInfo {
-                name: "fun",
                 staker: "P1aceHo1derPubkey11111111111111111111111111",
                 lamports: total_lamports,
             },
@@ -260,7 +259,6 @@ mod tests {
                 ..GenesisConfig::default()
             },
             &StakerInfo {
-                name: "fun",
                 staker: "P1aceHo1derPubkey11111111111111111111111111",
                 lamports: total_lamports,
             },
@@ -285,7 +283,6 @@ mod tests {
                 ..GenesisConfig::default()
             },
             &StakerInfo {
-                name: "fun",
                 staker: "P1aceHo1derPubkey11111111111111111111111111",
                 lamports: total_lamports,
             },
@@ -309,7 +306,6 @@ mod tests {
                 ..GenesisConfig::default()
             },
             &StakerInfo {
-                name: "fun",
                 staker: "P1aceHo1derPubkey11111111111111111111111111",
                 lamports: total_lamports,
             },


### PR DESCRIPTION
#### Problem
Stake account address generation relies on a word-pair string that is unnecessary and may not be known to the owner of the system account.

#### Summary of Changes
Remove the word-pair string from address generation so the only information needed to create/retrieve a derived address is the system account pubkey and a numeric index.

Fixes #
