### PR TITLE
CLI: Plumb stake authorities throughout

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -169,6 +169,7 @@ pub enum CliCommand {
     },
     DeactivateStake {
         stake_account_pubkey: Pubkey,
+        stake_authority: Option<KeypairEq>,
         sign_only: bool,
         signers: Option<Vec<(Pubkey, Signature)>>,
         blockhash: Option<Hash>,
@@ -178,6 +179,7 @@ pub enum CliCommand {
     DelegateStake {
         stake_account_pubkey: Pubkey,
         vote_account_pubkey: Pubkey,
+        stake_authority: Option<KeypairEq>,
         force: bool,
         sign_only: bool,
         signers: Option<Vec<(Pubkey, Signature)>>,
@@ -197,6 +199,7 @@ pub enum CliCommand {
         stake_account_pubkey: Pubkey,
         new_authorized_pubkey: Pubkey,
         stake_authorize: StakeAuthorize,
+        authority: Option<KeypairEq>,
     },
     WithdrawStake {
         stake_account_pubkey: Pubkey,
@@ -1287,6 +1290,7 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
         // Deactivate stake account
         CliCommand::DeactivateStake {
             stake_account_pubkey,
+            ref stake_authority,
             sign_only,
             ref signers,
             blockhash,
@@ -1296,6 +1300,7 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             &rpc_client,
             config,
             &stake_account_pubkey,
+            stake_authority.as_deref(),
             *sign_only,
             signers,
             *blockhash,
@@ -1305,6 +1310,7 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
         CliCommand::DelegateStake {
             stake_account_pubkey,
             vote_account_pubkey,
+            ref stake_authority,
             force,
             sign_only,
             ref signers,
@@ -1316,6 +1322,7 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             config,
             &stake_account_pubkey,
             &vote_account_pubkey,
+            stake_authority.as_deref(),
             *force,
             *sign_only,
             signers,
@@ -1347,12 +1354,14 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             stake_account_pubkey,
             new_authorized_pubkey,
             stake_authorize,
+            ref authority,
         } => process_stake_authorize(
             &rpc_client,
             config,
             &stake_account_pubkey,
             &new_authorized_pubkey,
             *stake_authorize,
+            authority.as_deref(),
         ),
 
         CliCommand::WithdrawStake {
@@ -2614,6 +2623,7 @@ mod tests {
         let stake_pubkey = Pubkey::new_rand();
         config.command = CliCommand::DeactivateStake {
             stake_account_pubkey: stake_pubkey,
+            stake_authority: None,
             sign_only: false,
             signers: None,
             blockhash: None,

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -193,7 +193,11 @@ pub enum CliCommand {
         pubkey: Pubkey,
         use_lamports_unit: bool,
     },
-    StakeAuthorize(Pubkey, Pubkey, StakeAuthorize),
+    StakeAuthorize {
+        stake_account_pubkey: Pubkey,
+        new_authorized_pubkey: Pubkey,
+        stake_authorize: StakeAuthorize,
+    },
     WithdrawStake(Pubkey, Pubkey, u64),
     // Storage Commands
     CreateStorageAccount {
@@ -1335,11 +1339,11 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
         CliCommand::ShowStakeHistory { use_lamports_unit } => {
             process_show_stake_history(&rpc_client, config, *use_lamports_unit)
         }
-        CliCommand::StakeAuthorize(
+        CliCommand::StakeAuthorize {
             stake_account_pubkey,
             new_authorized_pubkey,
             stake_authorize,
-        ) => process_stake_authorize(
+        } => process_stake_authorize(
             &rpc_client,
             config,
             &stake_account_pubkey,

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -198,7 +198,11 @@ pub enum CliCommand {
         new_authorized_pubkey: Pubkey,
         stake_authorize: StakeAuthorize,
     },
-    WithdrawStake(Pubkey, Pubkey, u64),
+    WithdrawStake {
+        stake_account_pubkey: Pubkey,
+        destination_account_pubkey: Pubkey,
+        lamports: u64,
+    },
     // Storage Commands
     CreateStorageAccount {
         account_owner: Pubkey,
@@ -1351,15 +1355,17 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             *stake_authorize,
         ),
 
-        CliCommand::WithdrawStake(stake_account_pubkey, destination_account_pubkey, lamports) => {
-            process_withdraw_stake(
-                &rpc_client,
-                config,
-                &stake_account_pubkey,
-                &destination_account_pubkey,
-                *lamports,
-            )
-        }
+        CliCommand::WithdrawStake {
+            stake_account_pubkey,
+            destination_account_pubkey,
+            lamports,
+        } => process_withdraw_stake(
+            &rpc_client,
+            config,
+            &stake_account_pubkey,
+            &destination_account_pubkey,
+            *lamports,
+        ),
 
         // Storage Commands
 
@@ -2597,7 +2603,11 @@ mod tests {
 
         let stake_pubkey = Pubkey::new_rand();
         let to_pubkey = Pubkey::new_rand();
-        config.command = CliCommand::WithdrawStake(stake_pubkey, to_pubkey, 100);
+        config.command = CliCommand::WithdrawStake {
+            stake_account_pubkey: stake_pubkey,
+            destination_account_pubkey: to_pubkey,
+            lamports: 100,
+        };
         let signature = process_command(&config);
         assert_eq!(signature.unwrap(), SIGNATURE.to_string());
 

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -205,6 +205,7 @@ pub enum CliCommand {
         stake_account_pubkey: Pubkey,
         destination_account_pubkey: Pubkey,
         lamports: u64,
+        withdraw_authority: Option<KeypairEq>,
     },
     // Storage Commands
     CreateStorageAccount {
@@ -1368,12 +1369,14 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             stake_account_pubkey,
             destination_account_pubkey,
             lamports,
+            ref withdraw_authority,
         } => process_withdraw_stake(
             &rpc_client,
             config,
             &stake_account_pubkey,
             &destination_account_pubkey,
             *lamports,
+            withdraw_authority.as_deref(),
         ),
 
         // Storage Commands
@@ -2616,6 +2619,7 @@ mod tests {
             stake_account_pubkey: stake_pubkey,
             destination_account_pubkey: to_pubkey,
             lamports: 100,
+            withdraw_authority: None,
         };
         let signature = process_command(&config);
         assert_eq!(signature.unwrap(), SIGNATURE.to_string());

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -492,11 +492,11 @@ pub fn parse_stake_withdraw_stake(matches: &ArgMatches<'_>) -> Result<CliCommand
     let lamports = required_lamports_from(matches, "amount", "unit")?;
 
     Ok(CliCommandInfo {
-        command: CliCommand::WithdrawStake(
+        command: CliCommand::WithdrawStake {
             stake_account_pubkey,
             destination_account_pubkey,
             lamports,
-        ),
+        },
         require_keypair: true,
     })
 }
@@ -1278,7 +1278,11 @@ mod tests {
         assert_eq!(
             parse_command(&test_withdraw_stake).unwrap(),
             CliCommandInfo {
-                command: CliCommand::WithdrawStake(stake_account_pubkey, stake_account_pubkey, 42),
+                command: CliCommand::WithdrawStake {
+                    stake_account_pubkey,
+                    destination_account_pubkey: stake_account_pubkey,
+                    lamports: 42,
+                },
                 require_keypair: true
             }
         );

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -436,14 +436,14 @@ pub fn parse_stake_authorize(
     stake_authorize: StakeAuthorize,
 ) -> Result<CliCommandInfo, CliError> {
     let stake_account_pubkey = pubkey_of(matches, "stake_account_pubkey").unwrap();
-    let authorized_pubkey = pubkey_of(matches, "authorized_pubkey").unwrap();
+    let new_authorized_pubkey = pubkey_of(matches, "authorized_pubkey").unwrap();
 
     Ok(CliCommandInfo {
-        command: CliCommand::StakeAuthorize(
+        command: CliCommand::StakeAuthorize {
             stake_account_pubkey,
-            authorized_pubkey,
+            new_authorized_pubkey,
             stake_authorize,
-        ),
+        },
         require_keypair: true,
     })
 }
@@ -1009,11 +1009,11 @@ mod tests {
         assert_eq!(
             parse_command(&test_authorize_staker).unwrap(),
             CliCommandInfo {
-                command: CliCommand::StakeAuthorize(
+                command: CliCommand::StakeAuthorize {
                     stake_account_pubkey,
-                    stake_account_pubkey,
-                    StakeAuthorize::Staker
-                ),
+                    new_authorized_pubkey: stake_account_pubkey,
+                    stake_authorize: StakeAuthorize::Staker,
+                },
                 require_keypair: true
             }
         );
@@ -1026,11 +1026,11 @@ mod tests {
         assert_eq!(
             parse_command(&test_authorize_withdrawer).unwrap(),
             CliCommandInfo {
-                command: CliCommand::StakeAuthorize(
+                command: CliCommand::StakeAuthorize {
                     stake_account_pubkey,
-                    stake_account_pubkey,
-                    StakeAuthorize::Withdrawer
-                ),
+                    new_authorized_pubkey: stake_account_pubkey,
+                    stake_authorize: StakeAuthorize::Withdrawer,
+                },
                 require_keypair: true
             }
         );

--- a/cli/tests/stake.rs
+++ b/cli/tests/stake.rs
@@ -111,6 +111,7 @@ fn test_seed_stake_delegation_and_deactivation() {
     config_validator.command = CliCommand::DelegateStake {
         stake_account_pubkey: stake_address,
         vote_account_pubkey: config_vote.keypair.pubkey(),
+        stake_authority: None,
         force: true,
         sign_only: false,
         signers: None,
@@ -123,6 +124,7 @@ fn test_seed_stake_delegation_and_deactivation() {
     // Deactivate stake
     config_validator.command = CliCommand::DeactivateStake {
         stake_account_pubkey: stake_address,
+        stake_authority: None,
         sign_only: false,
         signers: None,
         blockhash: None,
@@ -197,6 +199,7 @@ fn test_stake_delegation_and_deactivation() {
     config_validator.command = CliCommand::DelegateStake {
         stake_account_pubkey: config_stake.keypair.pubkey(),
         vote_account_pubkey: config_vote.keypair.pubkey(),
+        stake_authority: None,
         force: true,
         sign_only: false,
         signers: None,
@@ -209,6 +212,7 @@ fn test_stake_delegation_and_deactivation() {
     // Deactivate stake
     config_validator.command = CliCommand::DeactivateStake {
         stake_account_pubkey: config_stake.keypair.pubkey(),
+        stake_authority: None,
         sign_only: false,
         signers: None,
         blockhash: None,
@@ -287,6 +291,7 @@ fn test_offline_stake_delegation_and_deactivation() {
     config_validator.command = CliCommand::DelegateStake {
         stake_account_pubkey: config_stake.keypair.pubkey(),
         vote_account_pubkey: config_vote.keypair.pubkey(),
+        stake_authority: None,
         force: true,
         sign_only: true,
         signers: None,
@@ -312,6 +317,7 @@ fn test_offline_stake_delegation_and_deactivation() {
     config_payer.command = CliCommand::DelegateStake {
         stake_account_pubkey: config_stake.keypair.pubkey(),
         vote_account_pubkey: config_vote.keypair.pubkey(),
+        stake_authority: None,
         force: true,
         sign_only: false,
         signers: Some(signers),
@@ -324,6 +330,7 @@ fn test_offline_stake_delegation_and_deactivation() {
     // Deactivate stake offline
     config_validator.command = CliCommand::DeactivateStake {
         stake_account_pubkey: config_stake.keypair.pubkey(),
+        stake_authority: None,
         sign_only: true,
         signers: None,
         blockhash: None,
@@ -347,6 +354,7 @@ fn test_offline_stake_delegation_and_deactivation() {
     // Deactivate stake online
     config_payer.command = CliCommand::DeactivateStake {
         stake_account_pubkey: config_stake.keypair.pubkey(),
+        stake_authority: None,
         sign_only: false,
         signers: Some(signers),
         blockhash: Some(blockhash_str.parse::<Hash>().unwrap()),
@@ -432,6 +440,7 @@ fn test_nonced_stake_delegation_and_deactivation() {
     config.command = CliCommand::DelegateStake {
         stake_account_pubkey: stake_keypair.pubkey(),
         vote_account_pubkey: vote_keypair.pubkey(),
+        stake_authority: None,
         force: true,
         sign_only: false,
         signers: None,
@@ -453,6 +462,7 @@ fn test_nonced_stake_delegation_and_deactivation() {
     let config_keypair = Keypair::from_bytes(&config.keypair.to_bytes()).unwrap();
     config.command = CliCommand::DeactivateStake {
         stake_account_pubkey: stake_keypair.pubkey(),
+        stake_authority: None,
         sign_only: false,
         signers: None,
         blockhash: Some(nonce_hash),

--- a/cli/tests/stake.rs
+++ b/cli/tests/stake.rs
@@ -10,7 +10,7 @@ use solana_sdk::{
     signature::{read_keypair_file, write_keypair, Keypair, KeypairUtil, Signature},
     system_instruction::create_address_with_seed,
 };
-use solana_stake_program::stake_state::Lockup;
+use solana_stake_program::stake_state::{Lockup, StakeAuthorize, StakeState};
 use std::fs::remove_dir_all;
 use std::str::FromStr;
 use std::sync::mpsc::channel;
@@ -470,6 +470,82 @@ fn test_nonced_stake_delegation_and_deactivation() {
         nonce_authority: Some(config_keypair.into()),
     };
     process_command(&config).unwrap();
+
+    server.close().unwrap();
+    remove_dir_all(ledger_path).unwrap();
+}
+
+#[test]
+fn test_stake_authorize() {
+    solana_logger::setup();
+
+    let (server, leader_data, alice, ledger_path) = new_validator_for_tests();
+    let (sender, receiver) = channel();
+    run_local_faucet(alice, sender, None);
+    let faucet_addr = receiver.recv().unwrap();
+
+    let rpc_client = RpcClient::new_socket(leader_data.rpc);
+
+    let mut config = CliConfig::default();
+    config.json_rpc_url = format!("http://{}:{}", leader_data.rpc.ip(), leader_data.rpc.port());
+
+    request_and_confirm_airdrop(&rpc_client, &faucet_addr, &config.keypair.pubkey(), 100_000)
+        .unwrap();
+
+    // Create stake account, identity is authority
+    let stake_keypair = Keypair::new();
+    let stake_account_pubkey = stake_keypair.pubkey();
+    let (stake_keypair_file, mut tmp_file) = make_tmp_file();
+    write_keypair(&stake_keypair, tmp_file.as_file_mut()).unwrap();
+    config.command = CliCommand::CreateStakeAccount {
+        stake_account: read_keypair_file(&stake_keypair_file).unwrap().into(),
+        seed: None,
+        staker: None,
+        withdrawer: None,
+        lockup: Lockup::default(),
+        lamports: 50_000,
+    };
+    process_command(&config).unwrap();
+
+    // Assign new online stake authority
+    let online_authority = Keypair::new();
+    let online_authority_pubkey = online_authority.pubkey();
+    let (online_authority_file, mut tmp_file) = make_tmp_file();
+    write_keypair(&online_authority, tmp_file.as_file_mut()).unwrap();
+    config.command = CliCommand::StakeAuthorize {
+        stake_account_pubkey,
+        new_authorized_pubkey: online_authority_pubkey,
+        stake_authorize: StakeAuthorize::Staker,
+        authority: None,
+    };
+    process_command(&config).unwrap();
+    let stake_account = rpc_client.get_account(&stake_account_pubkey).unwrap();
+    let stake_state: StakeState = stake_account.state().unwrap();
+    let current_authority = match stake_state {
+        StakeState::Initialized(meta) => meta.authorized.staker,
+        _ => panic!("Unexpected stake state!"),
+    };
+    assert_eq!(current_authority, online_authority_pubkey);
+
+    // Assign new offline stake authority
+    let offline_authority = Keypair::new();
+    let offline_authority_pubkey = offline_authority.pubkey();
+    let (_offline_authority_file, mut tmp_file) = make_tmp_file();
+    write_keypair(&offline_authority, tmp_file.as_file_mut()).unwrap();
+    config.command = CliCommand::StakeAuthorize {
+        stake_account_pubkey,
+        new_authorized_pubkey: offline_authority_pubkey,
+        stake_authorize: StakeAuthorize::Staker,
+        authority: Some(read_keypair_file(&online_authority_file).unwrap().into()),
+    };
+    process_command(&config).unwrap();
+    let stake_account = rpc_client.get_account(&stake_account_pubkey).unwrap();
+    let stake_state: StakeState = stake_account.state().unwrap();
+    let current_authority = match stake_state {
+        StakeState::Initialized(meta) => meta.authorized.staker,
+        _ => panic!("Unexpected stake state!"),
+    };
+    assert_eq!(current_authority, offline_authority_pubkey);
 
     server.close().unwrap();
     remove_dir_all(ledger_path).unwrap();


### PR DESCRIPTION
#### Problem

CLI allows one to create a stake account with another authority, but none of the management commands allow specifying it

Prerequisite for offline/nonce stake management

#### Summary of Changes

Plumb stake authorities throughout staking subcommands