### PR TITLE
Fix Rpc inconsistencies

### DIFF
--- a/book/src/api-reference/jsonrpc-api.md
+++ b/book/src/api-reference/jsonrpc-api.md
@@ -146,8 +146,8 @@ The result value will be an RpcResponse JSON object containing an AccountInfo JS
 
 * `RpcResponse<AccountInfo>`, RpcResponse JSON object with `value` field set to AccountInfo, a JSON object containing:
 * `lamports`, number of lamports assigned to this account, as a u64
-* `owner`, array of 32 bytes representing the program this account has been assigned to
-* `data`, array of bytes representing any data associated with the account
+* `owner`, base-58 encoded pubkey of the program this account has been assigned to
+* `data`, base-58 encoded data associated with the account
 * `executable`, boolean indicating if the account contains a program \(and is strictly read-only\)
 
 #### Example:
@@ -157,7 +157,7 @@ The result value will be an RpcResponse JSON object containing an AccountInfo JS
 curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0", "id":1, "method":"getAccountInfo", "params":["2gVkYWexTHR5Hb2aLeQN3tnngvWzisFKXDUPrgMHpdST"]}' http://localhost:8899
 
 // Result
-{"jsonrpc":"2.0","result":{"context":{"slot":1},"value":{"executable":false,"owner":[1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"lamports":1,"data":[3,0,0,0,0,0,0,0,1,0,0,0,0,0,1,0,0,0,0,0,0,0.23.0,0,0,0,0,0,0,50,48,53,48,45,48,49,45,48,49,84,48,48,58,48,48,58,48,48,90,252,10,7,28,246,140,88,177,98,82,10,227,89,81,18,30,194,101,199,16,11,73,133,20,246,62,114,39,20,113,189,32,50,0,0,0,0,0,0,0,247,15,36,102,167,83,225,42,133,127,82,34,36,224,207,130,109,230,224,188,163,33,213,13,5,117,211,251,65,159,197,51,0,0,0,0,0,0]}},"id":1}
+{"jsonrpc":"2.0","result":{"context":{"slot":1},"value":{"executable":false,"owner":"4uQeVj5tqViQh7yWWGStvkEG1Zmhx6uasJtWCJziofM","lamports":1,"data":"Joig2k8Ax4JPMpWhXRyc2jMa7Wejz4X1xqVi3i7QRkmVj1ChUgNc4VNpGUQePJGBAui3c6886peU9GEbjsyeANN8JGStprwLbLwcw5wpPjuQQb9mwrjVmoDQBjj3MzZKgeHn6wmnQ5k8DBFuoCYKWWsJfH2gv9FvCzrN6K1CRcQZzF"}},"id":1}
 ```
 
 ### getBalance
@@ -500,18 +500,18 @@ The result field will be an array of arrays. Each sub array will contain:
 
 * `string` - the account Pubkey as base-58 encoded string and a JSON object, with the following sub fields:
 * `lamports`, number of lamports assigned to this account, as a u64
-* `owner`, array of 32 bytes representing the program this account has been assigned to
-* `data`, array of bytes representing any data associated with the account
+* `owner`, base-58 encoded pubkey of the program this account has been assigned to
+* `data`, base-58 encoded data associated with the account
 * `executable`, boolean indicating if the account contains a program \(and is strictly read-only\)
 
 #### Example:
 
 ```bash
 // Request
-curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0", "id":1, "method":"getProgramAccounts", "params":["8nQwAgzN2yyUzrukXsCa3JELBYqDQrqJ3UyHiWazWxHR"]}' http://localhost:8899
+curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0", "id":1, "method":"getProgramAccounts", "params":["4Nd1mBQtrMJVYVfKf2PJy9NZUZdTAsp7D4xWLs4gDB4T"]}' http://localhost:8899
 
 // Result
-{"jsonrpc":"2.0","result":[["BqGKYtAKu69ZdWEBtZHh4xgJY1BYa2YBiBReQE3pe383", {"executable":false,"owner":[50,28,250,90,221,24,94,136,147,165,253,136,1,62,196,215,225,34,222,212,99,84,202,223,245,13,149,99,149,231,91,96],"lamports":1,"data":[]], ["4Nd1mBQtrMJVYVfKf2PJy9NZUZdTAsp7D4xWLs4gDB4T", {"executable":false,"owner":[50,28,250,90,221,24,94,136,147,165,253,136,1,62,196,215,225,34,222,212,99,84,202,223,245,13,149,99,149,231,91,96],"lamports":10,"data":[]]]},"id":1}
+{"jsonrpc":"2.0","result":[["BqGKYtAKu69ZdWEBtZHh4xgJY1BYa2YBiBReQE3pe383", {"executable":false,"owner":"4Nd1mBQtrMJVYVfKf2PJy9NZUZdTAsp7D4xWLs4gDB4T","lamports":1,"data":"", ["8nQwAgzN2yyUzrukXsCa3JELBYqDQrqJ3UyHiWazWxHR", {"executable":false,"owner":"4Nd1mBQtrMJVYVfKf2PJy9NZUZdTAsp7D4xWLs4gDB4T","lamports":10,"data":[]]]},"id":1}
 ```
 
 ### getRecentBlockhash
@@ -524,7 +524,7 @@ Returns a recent block hash from the ledger, and a fee schedule that can be used
 
 #### Results:
 
-An RpcResponse containing an array consisting of a string blockhash and FeeCalculator JSON object.
+An RpcResponse containing a JSON object consisting of a string blockhash and FeeCalculator JSON object.
 
 * `RpcResponse<array>` - RpcResponse JSON object with `value` field set to a JSON object including:
 * `blockhash` - a Hash as base-58 encoded string
@@ -537,7 +537,7 @@ An RpcResponse containing an array consisting of a string blockhash and FeeCalcu
 curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1, "method":"getRecentBlockhash"}' http://localhost:8899
 
 // Result
-{"jsonrpc":"2.0","result":{"context":{"slot":1},"value":["GH7ome3EiwEr7tu9JuTh2dpYWBJK3z69Xm1ZE3MEE6JC",{"lamportsPerSignature": 0}]},"id":1}
+{"jsonrpc":"2.0","result":{"context":{"slot":1},"value":{"blockhash": "GH7ome3EiwEr7tu9JuTh2dpYWBJK3z69Xm1ZE3MEE6JC","feeCalculator":{"lamportsPerSignature": 0}}},"id":1}
 ```
 
 ### getSignatureStatus
@@ -870,7 +870,7 @@ Subscribe to an account to receive notifications when the lamports or data for a
 #### Notification Format:
 
 ```bash
-{"jsonrpc": "2.0","method": "accountNotification", "params": {"result": {"executable":false,"owner":[1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"lamports":1,"data":[3,0,0,0,0,0,0,0,1,0,0,0,0,0,1,0,0,0,0,0,0,0.23.0,0,0,0,0,0,0,50,48,53,48,45,48,49,45,48,49,84,48,48,58,48,48,58,48,48,90,252,10,7,28,246,140,88,177,98,82,10,227,89,81,18,30,194,101,199,16,11,73,133,20,246,62,114,39,20,113,189,32,50,0,0,0,0,0,0,0,247,15,36,102,167,83,225,42,133,127,82,34,36,224,207,130,109,230,224,188,163,33,213,13,5,117,211,251,65,159,197,51,0,0,0,0,0,0]},"subscription":0}}
+{"jsonrpc": "2.0","method": "accountNotification", "params": {"result": {"executable":false,"owner":"4uQeVj5tqViQh7yWWGStvkEG1Zmhx6uasJtWCJziofM","lamports":1,"data":"Joig2k8Ax4JPMpWhXRyc2jMa7Wejz4X1xqVi3i7QRkmVj1ChUgNc4VNpGUQePJGBAui3c6886peU9GEbjsyeANN8JGStprwLbLwcw5wpPjuQQb9mwrjVmoDQBjj3MzZKgeHn6wmnQ5k8DBFuoCYKWWsJfH2gv9FvCzrN6K1CRcQZzF"},"subscription":0}}
 ```
 
 ### accountUnsubscribe
@@ -928,7 +928,7 @@ Subscribe to a program to receive notifications when the lamports or data for a 
 * `object` - account info JSON object \(see [getAccountInfo](jsonrpc-api.md#getaccountinfo) for field details\)
 
   ```bash
-  {"jsonrpc":"2.0","method":"programNotification","params":{{"result":["8Rshv2oMkPu5E4opXTRyuyBeZBqQ4S477VG26wUTFxUM",{"executable":false,"lamports":1,"owner":[129,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"data":[1,1,1,0,0,0,0,0,0,0.23.0,0,0,0,0,0,0,50,48,49,56,45,49,50,45,50,52,84,50,51,58,53,57,58,48,48,90,235,233,39,152,15,44,117,176,41,89,100,86,45,61,2,44,251,46,212,37,35,118,163,189,247,84,27,235,178,62,55,89,0,0,0,0,50,0,0,0,0,0,0,0,235,233,39,152,15,44,117,176,41,89,100,86,45,61,2,44,251,46,212,37,35,118,163,189,247,84,27,235,178,62,45,4,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]}],"subscription":0}}
+  {"jsonrpc":"2.0","method":"programNotification","params":{{"result":["8Rshv2oMkPu5E4opXTRyuyBeZBqQ4S477VG26wUTFxUM",{"executable":false,"lamports":1,"owner":"9gZbPtbtHrs6hEWgd6MbVY9VPFtS5Z8xKtnYwA2NynHV","data":"4SZWhnbSt3njU4QHVgPrWeekz1BudU4ttmdr9ezmrL4X6XeLeL83xVAo6ZdxwU3oXgHNeF2q6tWZbnVnBXmvNyeLVEGt8ZQ4ZmgjHfVNCEwBtzh2aDrHgQSjBFLYAdmM3uwBhcm1EyHJLeUiFqpsoAUhn6Vphwrpf44dWRAGsAJZbzvVrUW9bfucpR7xudHHg2MxQ2CdqsfS3TfWUJY3vaf2A4AUNzfAmNPHBGi99nU2hYubGSVSPcpVPpdRWQkydgqasBmTosd"}],"subscription":0}}
   ```
 
 ### programUnsubscribe

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -1990,7 +1990,7 @@ mod tests {
     use solana_client::{
         mock_rpc_client_request::SIGNATURE,
         rpc_request::RpcRequest,
-        rpc_response::{Response, RpcResponseContext},
+        rpc_response::{Response, RpcAccount, RpcResponseContext},
     };
     use solana_sdk::{
         account::Account,
@@ -2672,12 +2672,14 @@ mod tests {
         let blockhash = Hash::default();
         let nonce_response = json!(Response {
             context: RpcResponseContext { slot: 1 },
-            value: json!(Account::new_data(
-                1,
-                &NonceState::Initialized(NonceMeta::new(&config.keypair.pubkey()), blockhash),
-                &system_program::ID,
-            )
-            .unwrap()),
+            value: json!(RpcAccount::encode(
+                Account::new_data(
+                    1,
+                    &NonceState::Initialized(NonceMeta::new(&config.keypair.pubkey()), blockhash),
+                    &system_program::ID,
+                )
+                .unwrap()
+            )),
         });
         let mut mocks = HashMap::new();
         mocks.insert(RpcRequest::GetAccountInfo, nonce_response);
@@ -2698,12 +2700,14 @@ mod tests {
         let blockhash = Hash::default();
         let nonce_authority_response = json!(Response {
             context: RpcResponseContext { slot: 1 },
-            value: json!(Account::new_data(
-                1,
-                &NonceState::Initialized(NonceMeta::new(&bob_pubkey), blockhash),
-                &system_program::ID,
-            )
-            .unwrap()),
+            value: json!(RpcAccount::encode(
+                Account::new_data(
+                    1,
+                    &NonceState::Initialized(NonceMeta::new(&bob_pubkey), blockhash),
+                    &system_program::ID,
+                )
+                .unwrap()
+            )),
         });
         let mut mocks = HashMap::new();
         mocks.insert(RpcRequest::GetAccountInfo, nonce_authority_response);

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -306,10 +306,14 @@ impl JsonRpcRequestProcessor {
         Ok(self.bank(commitment).slots_per_segment())
     }
 
-    fn get_storage_pubkeys_for_slot(&self, slot: Slot) -> Result<Vec<Pubkey>> {
-        Ok(self
+    fn get_storage_pubkeys_for_slot(&self, slot: Slot) -> Result<Vec<String>> {
+        let pubkeys: Vec<String> = self
             .storage_state
-            .get_pubkeys_for_slot(slot, &self.bank_forks))
+            .get_pubkeys_for_slot(slot, &self.bank_forks)
+            .iter()
+            .map(|pubkey| pubkey.to_string())
+            .collect();
+        Ok(pubkeys)
     }
 
     pub fn validator_exit(&self) -> Result<bool> {
@@ -547,7 +551,7 @@ pub trait RpcSol {
     ) -> Result<u64>;
 
     #[rpc(meta, name = "getStoragePubkeysForSlot")]
-    fn get_storage_pubkeys_for_slot(&self, meta: Self::Metadata, slot: u64) -> Result<Vec<Pubkey>>;
+    fn get_storage_pubkeys_for_slot(&self, meta: Self::Metadata, slot: u64) -> Result<Vec<String>>;
 
     #[rpc(meta, name = "validatorExit")]
     fn validator_exit(&self, meta: Self::Metadata) -> Result<bool>;
@@ -1023,7 +1027,7 @@ impl RpcSol for RpcSolImpl {
         &self,
         meta: Self::Metadata,
         slot: Slot,
-    ) -> Result<Vec<Pubkey>> {
+    ) -> Result<Vec<String>> {
         meta.request_processor
             .read()
             .unwrap()

--- a/core/src/rpc_pubsub.rs
+++ b/core/src/rpc_pubsub.rs
@@ -4,8 +4,8 @@ use crate::rpc_subscriptions::{Confirmations, RpcSubscriptions, SlotInfo};
 use jsonrpc_core::{Error, ErrorCode, Result};
 use jsonrpc_derive::rpc;
 use jsonrpc_pubsub::{typed::Subscriber, Session, SubscriptionId};
-use solana_client::rpc_response::RpcKeyedAccount;
-use solana_sdk::{account::Account, pubkey::Pubkey, signature::Signature, transaction};
+use solana_client::rpc_response::{RpcAccount, RpcKeyedAccount};
+use solana_sdk::{pubkey::Pubkey, signature::Signature, transaction};
 use std::sync::{atomic, Arc};
 
 // Suppress needless_return due to
@@ -26,7 +26,7 @@ pub trait RpcSolPubSub {
     fn account_subscribe(
         &self,
         meta: Self::Metadata,
-        subscriber: Subscriber<Account>,
+        subscriber: Subscriber<RpcAccount>,
         pubkey_str: String,
         confirmations: Option<Confirmations>,
     );
@@ -133,7 +133,7 @@ impl RpcSolPubSub for RpcSolPubSubImpl {
     fn account_subscribe(
         &self,
         _meta: Self::Metadata,
-        subscriber: Subscriber<Account>,
+        subscriber: Subscriber<RpcAccount>,
         pubkey_str: String,
         confirmations: Option<Confirmations>,
     ) {
@@ -467,9 +467,9 @@ mod tests {
            "method": "accountNotification",
            "params": {
                "result": {
-                   "owner": budget_program_id,
+                   "owner": budget_program_id.to_string(),
                    "lamports": 51,
-                   "data": expected_data,
+                   "data": bs58::encode(expected_data).into_string(),
                    "executable": false,
                    "rentEpoch": 1,
                },
@@ -614,9 +614,9 @@ mod tests {
            "method": "accountNotification",
            "params": {
                "result": {
-                   "owner": system_program::id(),
+                   "owner": system_program::id().to_string(),
                    "lamports": 100,
-                   "data": [],
+                   "data": "",
                    "executable": false,
                    "rentEpoch": 1,
                },

--- a/sdk/src/inflation.rs
+++ b/sdk/src/inflation.rs
@@ -1,6 +1,7 @@
 //! configuration for network inflation
 
 #[derive(Serialize, Deserialize, PartialEq, Clone, Debug, Copy)]
+#[serde(rename_all = "camelCase")]
 pub struct Inflation {
     /// Initial inflation percentage, from time=0
     pub initial: f64,


### PR DESCRIPTION
#### Problem
There are a few lingering inconsistencies with Rpc response formatting, the most obvious being in the case of accounts, which use the native Account type and return owner and data information in byte arrays.

#### Summary of Changes
- Base58-encode byte arrays in accounts in Rpc responses
- Camel-case Inflation struct
- Return stringified Pubkeys in getStoragePubkeysForSlot (I could not determine if this method is being used anywhere, so hopefully this doesn't break anything)
- Update docs (toward #7808 )

@mvines , s/b last one
