### PR TITLE
CLI: Support offline and nonced stake subcommands

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -200,6 +200,9 @@ pub enum CliCommand {
         new_authorized_pubkey: Pubkey,
         stake_authorize: StakeAuthorize,
         authority: Option<KeypairEq>,
+        sign_only: bool,
+        signers: Option<Vec<(Pubkey, Signature)>>,
+        blockhash: Option<Hash>,
     },
     WithdrawStake {
         stake_account_pubkey: Pubkey,
@@ -1356,6 +1359,9 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             new_authorized_pubkey,
             stake_authorize,
             ref authority,
+            sign_only,
+            ref signers,
+            blockhash,
         } => process_stake_authorize(
             &rpc_client,
             config,
@@ -1363,6 +1369,9 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             &new_authorized_pubkey,
             *stake_authorize,
             authority.as_deref(),
+            *sign_only,
+            signers,
+            *blockhash,
         ),
 
         CliCommand::WithdrawStake {

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -203,6 +203,8 @@ pub enum CliCommand {
         sign_only: bool,
         signers: Option<Vec<(Pubkey, Signature)>>,
         blockhash: Option<Hash>,
+        nonce_account: Option<Pubkey>,
+        nonce_authority: Option<KeypairEq>,
     },
     WithdrawStake {
         stake_account_pubkey: Pubkey,
@@ -1362,6 +1364,8 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             sign_only,
             ref signers,
             blockhash,
+            nonce_account,
+            ref nonce_authority,
         } => process_stake_authorize(
             &rpc_client,
             config,
@@ -1372,6 +1376,8 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             *sign_only,
             signers,
             *blockhash,
+            *nonce_account,
+            nonce_authority.as_deref(),
         ),
 
         CliCommand::WithdrawStake {

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -236,6 +236,29 @@ impl StakeSubCommands for App<'_, '_> {
                         .help("New authorized staker")
                 )
                 .arg(stake_authority_arg())
+                .arg(
+                    Arg::with_name("sign_only")
+                        .long("sign-only")
+                        .takes_value(false)
+                        .help("Sign the transaction offline"),
+                )
+                .arg(
+                    Arg::with_name("signer")
+                        .long("signer")
+                        .value_name("PUBKEY=BASE58_SIG")
+                        .takes_value(true)
+                        .validator(is_pubkey_sig)
+                        .multiple(true)
+                        .help("Provide a public-key/signature pair for the transaction"),
+                )
+                .arg(
+                    Arg::with_name("blockhash")
+                        .long("blockhash")
+                        .value_name("BLOCKHASH")
+                        .takes_value(true)
+                        .validator(is_hash)
+                        .help("Use the supplied blockhash"),
+                )
         )
         .subcommand(
             SubCommand::with_name("stake-authorize-withdrawer")
@@ -259,6 +282,29 @@ impl StakeSubCommands for App<'_, '_> {
                         .help("New authorized withdrawer")
                 )
                 .arg(withdraw_authority_arg())
+                .arg(
+                    Arg::with_name("sign_only")
+                        .long("sign-only")
+                        .takes_value(false)
+                        .help("Sign the transaction offline"),
+                )
+                .arg(
+                    Arg::with_name("signer")
+                        .long("signer")
+                        .value_name("PUBKEY=BASE58_SIG")
+                        .takes_value(true)
+                        .validator(is_pubkey_sig)
+                        .multiple(true)
+                        .help("Provide a public-key/signature pair for the transaction"),
+                )
+                .arg(
+                    Arg::with_name("blockhash")
+                        .long("blockhash")
+                        .value_name("BLOCKHASH")
+                        .takes_value(true)
+                        .validator(is_hash)
+                        .help("Use the supplied blockhash"),
+                )
         )
         .subcommand(
             SubCommand::with_name("deactivate-stake")
@@ -492,6 +538,9 @@ pub fn parse_stake_authorize(
     } else {
         None
     };
+    let sign_only = matches.is_present("sign_only");
+    let signers = pubkeys_sigs_of(&matches, "signer");
+    let blockhash = value_of(matches, "blockhash");
 
     Ok(CliCommandInfo {
         command: CliCommand::StakeAuthorize {
@@ -499,6 +548,9 @@ pub fn parse_stake_authorize(
             new_authorized_pubkey,
             stake_authorize,
             authority,
+            sign_only,
+            signers,
+            blockhash,
         },
         require_keypair: true,
     })
@@ -693,13 +745,17 @@ pub fn process_stake_authorize(
     authorized_pubkey: &Pubkey,
     stake_authorize: StakeAuthorize,
     authority: Option<&Keypair>,
+    sign_only: bool,
+    signers: &Option<Vec<(Pubkey, Signature)>>,
+    blockhash: Option<Hash>,
 ) -> ProcessResult {
     check_unique_pubkeys(
         (stake_account_pubkey, "stake_account_pubkey".to_string()),
         (authorized_pubkey, "new_authorized_pubkey".to_string()),
     )?;
     let authority = authority.unwrap_or(&config.keypair);
-    let (recent_blockhash, fee_calculator) = rpc_client.get_recent_blockhash()?;
+    let (recent_blockhash, fee_calculator) =
+        get_blockhash_fee_calculator(rpc_client, sign_only, blockhash)?;
     let ixs = vec![stake_instruction::authorize(
         stake_account_pubkey, // stake account to update
         &authority.pubkey(),  // currently authorized
@@ -713,14 +769,21 @@ pub fn process_stake_authorize(
         &[&config.keypair, authority],
         recent_blockhash,
     );
-    check_account_for_fee(
-        rpc_client,
-        &config.keypair.pubkey(),
-        &fee_calculator,
-        &tx.message,
-    )?;
-    let result = rpc_client.send_and_confirm_transaction(&mut tx, &[&config.keypair]);
-    log_instruction_custom_error::<StakeError>(result)
+    if let Some(signers) = signers {
+        replace_signatures(&mut tx, &signers)?;
+    }
+    if sign_only {
+        return_signers(&tx)
+    } else {
+        check_account_for_fee(
+            rpc_client,
+            &tx.message.account_keys[0],
+            &fee_calculator,
+            &tx.message,
+        )?;
+        let result = rpc_client.send_and_confirm_transaction(&mut tx, &[&config.keypair]);
+        log_instruction_custom_error::<StakeError>(result)
+    }
 }
 
 pub fn process_deactivate_stake_account(
@@ -1100,6 +1163,9 @@ mod tests {
                     new_authorized_pubkey: stake_account_pubkey,
                     stake_authorize,
                     authority: None,
+                    sign_only: false,
+                    signers: None,
+                    blockhash: None,
                 },
                 require_keypair: true
             }
@@ -1121,6 +1187,114 @@ mod tests {
                     new_authorized_pubkey: stake_account_pubkey,
                     stake_authorize,
                     authority: Some(read_keypair_file(&authority_keypair_file).unwrap().into()),
+                    sign_only: false,
+                    signers: None,
+                    blockhash: None,
+                },
+                require_keypair: true
+            }
+        );
+        // Test Authorize Subcommand w/ sign-only
+        let test_authorize = test_commands.clone().get_matches_from(vec![
+            "test",
+            &subcommand,
+            &stake_account_string,
+            &stake_account_string,
+            "--sign-only",
+        ]);
+        assert_eq!(
+            parse_command(&test_authorize).unwrap(),
+            CliCommandInfo {
+                command: CliCommand::StakeAuthorize {
+                    stake_account_pubkey,
+                    new_authorized_pubkey: stake_account_pubkey,
+                    stake_authorize,
+                    authority: None,
+                    sign_only: true,
+                    signers: None,
+                    blockhash: None,
+                },
+                require_keypair: true
+            }
+        );
+        // Test Authorize Subcommand w/ signer
+        let keypair = Keypair::new();
+        let sig = keypair.sign_message(&[0u8]);
+        let signer = format!("{}={}", keypair.pubkey(), sig);
+        let test_authorize = test_commands.clone().get_matches_from(vec![
+            "test",
+            &subcommand,
+            &stake_account_string,
+            &stake_account_string,
+            "--signer",
+            &signer,
+        ]);
+        assert_eq!(
+            parse_command(&test_authorize).unwrap(),
+            CliCommandInfo {
+                command: CliCommand::StakeAuthorize {
+                    stake_account_pubkey,
+                    new_authorized_pubkey: stake_account_pubkey,
+                    stake_authorize,
+                    authority: None,
+                    sign_only: false,
+                    signers: Some(vec![(keypair.pubkey(), sig)]),
+                    blockhash: None,
+                },
+                require_keypair: true
+            }
+        );
+        // Test Authorize Subcommand w/ signers
+        let keypair2 = Keypair::new();
+        let sig2 = keypair.sign_message(&[0u8]);
+        let signer2 = format!("{}={}", keypair2.pubkey(), sig2);
+        let test_authorize = test_commands.clone().get_matches_from(vec![
+            "test",
+            &subcommand,
+            &stake_account_string,
+            &stake_account_string,
+            "--signer",
+            &signer,
+            "--signer",
+            &signer2,
+        ]);
+        assert_eq!(
+            parse_command(&test_authorize).unwrap(),
+            CliCommandInfo {
+                command: CliCommand::StakeAuthorize {
+                    stake_account_pubkey,
+                    new_authorized_pubkey: stake_account_pubkey,
+                    stake_authorize,
+                    authority: None,
+                    sign_only: false,
+                    signers: Some(vec![(keypair.pubkey(), sig), (keypair2.pubkey(), sig2),]),
+                    blockhash: None,
+                },
+                require_keypair: true
+            }
+        );
+        // Test Authorize Subcommand w/ blockhash
+        let blockhash = Hash::default();
+        let blockhash_string = format!("{}", blockhash);
+        let test_authorize = test_commands.clone().get_matches_from(vec![
+            "test",
+            &subcommand,
+            &stake_account_string,
+            &stake_account_string,
+            "--blockhash",
+            &blockhash_string,
+        ]);
+        assert_eq!(
+            parse_command(&test_authorize).unwrap(),
+            CliCommandInfo {
+                command: CliCommand::StakeAuthorize {
+                    stake_account_pubkey,
+                    new_authorized_pubkey: stake_account_pubkey,
+                    stake_authorize,
+                    authority: None,
+                    sign_only: false,
+                    signers: None,
+                    blockhash: Some(blockhash),
                 },
                 require_keypair: true
             }

--- a/cli/tests/stake.rs
+++ b/cli/tests/stake.rs
@@ -515,6 +515,8 @@ fn test_stake_authorize() {
         sign_only: false,
         signers: None,
         blockhash: None,
+        nonce_account: None,
+        nonce_authority: None,
     };
     process_command(&config).unwrap();
     let stake_account = rpc_client.get_account(&stake_account_pubkey).unwrap();
@@ -538,6 +540,8 @@ fn test_stake_authorize() {
         sign_only: false,
         signers: None,
         blockhash: None,
+        nonce_account: None,
+        nonce_authority: None,
     };
     process_command(&config).unwrap();
     let stake_account = rpc_client.get_account(&stake_account_pubkey).unwrap();
@@ -551,7 +555,7 @@ fn test_stake_authorize() {
     // Offline assignment of new nonced stake authority
     let nonced_authority = Keypair::new();
     let nonced_authority_pubkey = nonced_authority.pubkey();
-    let (_nonced_authority_file, mut tmp_file) = make_tmp_file();
+    let (nonced_authority_file, mut tmp_file) = make_tmp_file();
     write_keypair(&nonced_authority, tmp_file.as_file_mut()).unwrap();
     config.command = CliCommand::StakeAuthorize {
         stake_account_pubkey,
@@ -561,6 +565,8 @@ fn test_stake_authorize() {
         sign_only: true,
         signers: None,
         blockhash: None,
+        nonce_account: None,
+        nonce_authority: None,
     };
     let sign_reply = process_command(&config).unwrap();
     let (blockhash, signers) = parse_sign_only_reply_string(&sign_reply);
@@ -573,6 +579,8 @@ fn test_stake_authorize() {
         sign_only: false,
         signers: Some(signers),
         blockhash: Some(blockhash),
+        nonce_account: None,
+        nonce_authority: None,
     };
     process_command(&config).unwrap();
     let stake_account = rpc_client.get_account(&stake_account_pubkey).unwrap();
@@ -583,6 +591,76 @@ fn test_stake_authorize() {
     };
     assert_eq!(current_authority, nonced_authority_pubkey);
 
+    // Create nonce account
+    let minimum_nonce_balance = rpc_client
+        .get_minimum_balance_for_rent_exemption(NonceState::size())
+        .unwrap();
+    let nonce_account = Keypair::new();
+    let (nonce_keypair_file, mut tmp_file) = make_tmp_file();
+    write_keypair(&nonce_account, tmp_file.as_file_mut()).unwrap();
+    config.command = CliCommand::CreateNonceAccount {
+        nonce_account: read_keypair_file(&nonce_keypair_file).unwrap().into(),
+        seed: None,
+        nonce_authority: Some(config.keypair.pubkey()),
+        lamports: minimum_nonce_balance,
+    };
+    process_command(&config).unwrap();
+
+    // Fetch nonce hash
+    let account = rpc_client.get_account(&nonce_account.pubkey()).unwrap();
+    let nonce_state: NonceState = account.state().unwrap();
+    let nonce_hash = match nonce_state {
+        NonceState::Initialized(_meta, hash) => hash,
+        _ => panic!("Nonce is not initialized"),
+    };
+
+    // Nonced assignment of new nonced stake authority
+    let online_authority = Keypair::new();
+    let online_authority_pubkey = online_authority.pubkey();
+    let (_online_authority_file, mut tmp_file) = make_tmp_file();
+    write_keypair(&online_authority, tmp_file.as_file_mut()).unwrap();
+    config.command = CliCommand::StakeAuthorize {
+        stake_account_pubkey,
+        new_authorized_pubkey: online_authority_pubkey,
+        stake_authorize: StakeAuthorize::Staker,
+        authority: Some(read_keypair_file(&nonced_authority_file).unwrap().into()),
+        sign_only: true,
+        signers: None,
+        blockhash: Some(nonce_hash),
+        nonce_account: Some(nonce_account.pubkey()),
+        nonce_authority: None,
+        //nonce_authority: Some(read_keypair_file(&nonce_keypair_file).unwrap().into()),
+    };
+    let sign_reply = process_command(&config).unwrap();
+    let (blockhash, signers) = parse_sign_only_reply_string(&sign_reply);
+    assert_eq!(blockhash, nonce_hash);
+    config.command = CliCommand::StakeAuthorize {
+        stake_account_pubkey,
+        new_authorized_pubkey: online_authority_pubkey,
+        stake_authorize: StakeAuthorize::Staker,
+        // We need to be able to specify the authority by pubkey/sig pair here
+        authority: Some(read_keypair_file(&nonced_authority_file).unwrap().into()),
+        sign_only: false,
+        signers: Some(signers),
+        blockhash: Some(blockhash),
+        nonce_account: Some(nonce_account.pubkey()),
+        nonce_authority: None,
+    };
+    process_command(&config).unwrap();
+    let stake_account = rpc_client.get_account(&stake_account_pubkey).unwrap();
+    let stake_state: StakeState = stake_account.state().unwrap();
+    let current_authority = match stake_state {
+        StakeState::Initialized(meta) => meta.authorized.staker,
+        _ => panic!("Unexpected stake state!"),
+    };
+    assert_eq!(current_authority, online_authority_pubkey);
+    let account = rpc_client.get_account(&nonce_account.pubkey()).unwrap();
+    let nonce_state: NonceState = account.state().unwrap();
+    let new_nonce_hash = match nonce_state {
+        NonceState::Initialized(_meta, hash) => hash,
+        _ => panic!("Nonce is not initialized"),
+    };
+    assert_ne!(nonce_hash, new_nonce_hash);
     server.close().unwrap();
     remove_dir_all(ledger_path).unwrap();
 }

--- a/cli/tests/stake.rs
+++ b/cli/tests/stake.rs
@@ -512,6 +512,9 @@ fn test_stake_authorize() {
         new_authorized_pubkey: online_authority_pubkey,
         stake_authorize: StakeAuthorize::Staker,
         authority: None,
+        sign_only: false,
+        signers: None,
+        blockhash: None,
     };
     process_command(&config).unwrap();
     let stake_account = rpc_client.get_account(&stake_account_pubkey).unwrap();
@@ -525,13 +528,16 @@ fn test_stake_authorize() {
     // Assign new offline stake authority
     let offline_authority = Keypair::new();
     let offline_authority_pubkey = offline_authority.pubkey();
-    let (_offline_authority_file, mut tmp_file) = make_tmp_file();
+    let (offline_authority_file, mut tmp_file) = make_tmp_file();
     write_keypair(&offline_authority, tmp_file.as_file_mut()).unwrap();
     config.command = CliCommand::StakeAuthorize {
         stake_account_pubkey,
         new_authorized_pubkey: offline_authority_pubkey,
         stake_authorize: StakeAuthorize::Staker,
         authority: Some(read_keypair_file(&online_authority_file).unwrap().into()),
+        sign_only: false,
+        signers: None,
+        blockhash: None,
     };
     process_command(&config).unwrap();
     let stake_account = rpc_client.get_account(&stake_account_pubkey).unwrap();
@@ -541,6 +547,41 @@ fn test_stake_authorize() {
         _ => panic!("Unexpected stake state!"),
     };
     assert_eq!(current_authority, offline_authority_pubkey);
+
+    // Offline assignment of new nonced stake authority
+    let nonced_authority = Keypair::new();
+    let nonced_authority_pubkey = nonced_authority.pubkey();
+    let (_nonced_authority_file, mut tmp_file) = make_tmp_file();
+    write_keypair(&nonced_authority, tmp_file.as_file_mut()).unwrap();
+    config.command = CliCommand::StakeAuthorize {
+        stake_account_pubkey,
+        new_authorized_pubkey: nonced_authority_pubkey,
+        stake_authorize: StakeAuthorize::Staker,
+        authority: Some(read_keypair_file(&offline_authority_file).unwrap().into()),
+        sign_only: true,
+        signers: None,
+        blockhash: None,
+    };
+    let sign_reply = process_command(&config).unwrap();
+    let (blockhash, signers) = parse_sign_only_reply_string(&sign_reply);
+    config.command = CliCommand::StakeAuthorize {
+        stake_account_pubkey,
+        new_authorized_pubkey: nonced_authority_pubkey,
+        stake_authorize: StakeAuthorize::Staker,
+        // We need to be able to specify the authority by pubkey/sig pair here
+        authority: Some(read_keypair_file(&offline_authority_file).unwrap().into()),
+        sign_only: false,
+        signers: Some(signers),
+        blockhash: Some(blockhash),
+    };
+    process_command(&config).unwrap();
+    let stake_account = rpc_client.get_account(&stake_account_pubkey).unwrap();
+    let stake_state: StakeState = stake_account.state().unwrap();
+    let current_authority = match stake_state {
+        StakeState::Initialized(meta) => meta.authorized.staker,
+        _ => panic!("Unexpected stake state!"),
+    };
+    assert_eq!(current_authority, nonced_authority_pubkey);
 
     server.close().unwrap();
     remove_dir_all(ledger_path).unwrap();


### PR DESCRIPTION
#### Problem

CLI's stake management subcommands do not support offline or nonced transactions

#### Summary of Changes

Plumb offline signing and durable nonces throughout