### PR TITLE
Revamp the progress of current epoch in get-epoch-info

### DIFF
--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -369,30 +369,44 @@ pub fn process_get_block_time(rpc_client: &RpcClient, slot: Slot) -> ProcessResu
     Ok(timestamp.to_string())
 }
 
+fn slot_to_human_time(slot: Slot) -> String {
+    humantime::format_duration(Duration::from_secs(
+        slot * clock::DEFAULT_TICKS_PER_SLOT / clock::DEFAULT_TICKS_PER_SECOND,
+    ))
+    .to_string()
+}
+
 pub fn process_get_epoch_info(
     rpc_client: &RpcClient,
     commitment_config: &CommitmentConfig,
 ) -> ProcessResult {
     let epoch_info = rpc_client.get_epoch_info_with_commitment(commitment_config.clone())?;
     println!();
-    println_name_value("Current epoch:", &epoch_info.epoch.to_string());
     println_name_value("Current slot:", &epoch_info.absolute_slot.to_string());
+    println_name_value("Current epoch:", &epoch_info.epoch.to_string());
     println_name_value(
-        "Total slots in current epoch:",
-        &epoch_info.slots_in_epoch.to_string(),
+        "Current epoch in percent:",
+        &format!(
+            "{:>3.3}%",
+            epoch_info.slot_index as f64 / epoch_info.slots_in_epoch as f64 * 100_f64
+        ),
     );
     let remaining_slots_in_epoch = epoch_info.slots_in_epoch - epoch_info.slot_index;
     println_name_value(
-        "Remaining slots in current epoch:",
-        &remaining_slots_in_epoch.to_string(),
-    );
-
-    let remaining_time_in_epoch = Duration::from_secs(
-        remaining_slots_in_epoch * clock::DEFAULT_TICKS_PER_SLOT / clock::DEFAULT_TICKS_PER_SECOND,
+        "Current epoch in slots:",
+        &format!(
+            "{}/{} (-{})",
+            epoch_info.slot_index, epoch_info.slots_in_epoch, remaining_slots_in_epoch
+        ),
     );
     println_name_value(
-        "Time remaining in current epoch:",
-        &humantime::format_duration(remaining_time_in_epoch).to_string(),
+        "Current epoch in time:",
+        &format!(
+            "{}/{} (-{})",
+            slot_to_human_time(epoch_info.slot_index),
+            slot_to_human_time(epoch_info.slots_in_epoch),
+            slot_to_human_time(remaining_slots_in_epoch)
+        ),
     );
     Ok("".to_string())
 }

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -382,10 +382,10 @@ pub fn process_get_epoch_info(
 ) -> ProcessResult {
     let epoch_info = rpc_client.get_epoch_info_with_commitment(commitment_config.clone())?;
     println!();
-    println_name_value("Current slot:", &epoch_info.absolute_slot.to_string());
-    println_name_value("Current epoch:", &epoch_info.epoch.to_string());
+    println_name_value("Slot:", &epoch_info.absolute_slot.to_string());
+    println_name_value("Epoch:", &epoch_info.epoch.to_string());
     println_name_value(
-        "Current epoch in percent:",
+        "Epoch completed percent:",
         &format!(
             "{:>3.3}%",
             epoch_info.slot_index as f64 / epoch_info.slots_in_epoch as f64 * 100_f64
@@ -393,16 +393,16 @@ pub fn process_get_epoch_info(
     );
     let remaining_slots_in_epoch = epoch_info.slots_in_epoch - epoch_info.slot_index;
     println_name_value(
-        "Current epoch in slots:",
+        "Epoch completed slots:",
         &format!(
-            "{}/{} (-{})",
+            "{}/{} ({} remaining)",
             epoch_info.slot_index, epoch_info.slots_in_epoch, remaining_slots_in_epoch
         ),
     );
     println_name_value(
-        "Current epoch in time:",
+        "Epoch completed time:",
         &format!(
-            "{}/{} (-{})",
+            "{}/{} ({} remaining)",
             slot_to_human_time(epoch_info.slot_index),
             slot_to_human_time(epoch_info.slots_in_epoch),
             slot_to_human_time(remaining_slots_in_epoch)


### PR DESCRIPTION
I was too bored to wait the stakes to warm up while local testing. So, I pimped what I was `$ watch`-ing for too much long time:

After:
```
ryoqun@ubuqun:~/work/solana/solana/for-small-patches$ solana get-epoch-info

Current slot: 7255
Current epoch: 17
Current epoch in percent: 23.242%
Current epoch in slots: 119/512 (-393)
Current epoch in time: 47s/3m 24s (-2m 37s)
```

Before:
```
ryoqun@ubuqun:~/work/solana/solana/for-small-patches$ solana get-epoch-info

Current epoch: 22
Current slot: 9929
Total slots in current epoch: 512
Remaining slots in current epoch: 279
Time remaining in current epoch: 1m 51s

```

In my humble aesthetics, this looks nicer and no tedious quick math in my mind. :) If this is too aggressive, I'll restore removed lines. There should be no information lost by the way.

Mandatory compat. checks for casual cli scraping:

```
ryoqun@ubuqun:~/work/solana/solana/for-small-patches$ git rev-parse HEAD
4c08184379ad323134ec5e50253af02b3f28d00a
ryoqun@ubuqun:~/work/solana/solana/for-small-patches$ git grep -E "Total slots|current epoch|Remaining slots|Time remaining" :**.sh
ryoqun@ubuqun:~/work/solana/solana/for-small-patches$ echo $?
1
```

Side product of #7736