### PR TITLE
faucet: Increase token cap

### DIFF
--- a/faucet/src/faucet.rs
+++ b/faucet/src/faucet.rs
@@ -45,7 +45,7 @@ macro_rules! socketaddr {
 }
 
 pub const TIME_SLICE: u64 = 60;
-pub const REQUEST_CAP: u64 = solana_sdk::native_token::LAMPORTS_PER_SOL * 1_000_000;
+pub const REQUEST_CAP: u64 = solana_sdk::native_token::LAMPORTS_PER_SOL * 10_000_000;
 pub const FAUCET_PORT: u16 = 9900;
 pub const FAUCET_PORT_STR: &str = "9900";
 


### PR DESCRIPTION
bench-tps recently has become a hungry hungry hippo and needs more tokens to work.  

The standard workaround whenever somebody runs into this issue is to advise running `./multinode-demo/faucet.sh --cap 2000000000000000`.  Let's make it work out directly of the box instead.