### PR TITLE
Spy just for RPC to avoid premature supermajority

### DIFF
--- a/core/src/cluster_info.rs
+++ b/core/src/cluster_info.rs
@@ -1616,6 +1616,30 @@ impl ClusterInfo {
             .unwrap()
     }
 
+    pub fn gossip_contact_info(id: &Pubkey, gossip_addr: SocketAddr) -> ContactInfo {
+        let dummy_addr = socketaddr_any!();
+
+        ContactInfo::new(
+            id,
+            gossip_addr,
+            dummy_addr,
+            dummy_addr,
+            dummy_addr,
+            dummy_addr,
+            dummy_addr,
+            dummy_addr,
+            dummy_addr,
+            dummy_addr,
+            timestamp(),
+        )
+    }
+
+    pub fn spy_contact_info(id: &Pubkey) -> ContactInfo {
+        let dummy_addr = socketaddr_any!();
+
+        Self::gossip_contact_info(id, dummy_addr)
+    }
+
     /// An alternative to Spy Node that has a valid gossip address and fully participate in Gossip.
     pub fn gossip_node(
         id: &Pubkey,
@@ -1623,43 +1647,17 @@ impl ClusterInfo {
     ) -> (ContactInfo, UdpSocket, Option<TcpListener>) {
         let (port, (gossip_socket, ip_echo)) =
             Node::get_gossip_port(gossip_addr, VALIDATOR_PORT_RANGE);
-        let daddr = socketaddr_any!();
+        let contact_info = Self::gossip_contact_info(id, SocketAddr::new(gossip_addr.ip(), port));
 
-        let node = ContactInfo::new(
-            id,
-            SocketAddr::new(gossip_addr.ip(), port),
-            daddr,
-            daddr,
-            daddr,
-            daddr,
-            daddr,
-            daddr,
-            daddr,
-            daddr,
-            timestamp(),
-        );
-        (node, gossip_socket, Some(ip_echo))
+        (contact_info, gossip_socket, Some(ip_echo))
     }
 
-    /// A Node with invalid ports to spy on gossip via pull requests
+    /// A Node with dummy ports to spy on gossip via pull requests
     pub fn spy_node(id: &Pubkey) -> (ContactInfo, UdpSocket, Option<TcpListener>) {
         let (_, gossip_socket) = bind_in_range(VALIDATOR_PORT_RANGE).unwrap();
-        let daddr = socketaddr_any!();
+        let contact_info = Self::spy_contact_info(id);
 
-        let node = ContactInfo::new(
-            id,
-            daddr,
-            daddr,
-            daddr,
-            daddr,
-            daddr,
-            daddr,
-            daddr,
-            daddr,
-            daddr,
-            timestamp(),
-        );
-        (node, gossip_socket, None)
+        (contact_info, gossip_socket, None)
     }
 }
 

--- a/core/src/cluster_info.rs
+++ b/core/src/cluster_info.rs
@@ -1616,7 +1616,7 @@ impl ClusterInfo {
             .unwrap()
     }
 
-   fn gossip_contact_info(id: &Pubkey, gossip_addr: SocketAddr) -> ContactInfo {
+    fn gossip_contact_info(id: &Pubkey, gossip_addr: SocketAddr) -> ContactInfo {
         let dummy_addr = socketaddr_any!();
 
         ContactInfo::new(

--- a/core/src/cluster_info.rs
+++ b/core/src/cluster_info.rs
@@ -1616,7 +1616,7 @@ impl ClusterInfo {
             .unwrap()
     }
 
-    pub fn gossip_contact_info(id: &Pubkey, gossip_addr: SocketAddr) -> ContactInfo {
+   fn gossip_contact_info(id: &Pubkey, gossip_addr: SocketAddr) -> ContactInfo {
         let dummy_addr = socketaddr_any!();
 
         ContactInfo::new(

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -198,7 +198,10 @@ fn get_rpc_addr(
     identity_keypair: &Arc<Keypair>,
     entrypoint_gossip: &SocketAddr,
 ) -> (RpcClient, SocketAddr) {
-    let mut cluster_info = ClusterInfo::new(node.info.clone(), identity_keypair.clone());
+    let mut cluster_info = ClusterInfo::new(
+        ClusterInfo::spy_contact_info(&identity_keypair.pubkey()),
+        identity_keypair.clone(),
+    );
     cluster_info.set_entrypoint(ContactInfo::new_gossip_entry_point(entrypoint_gossip));
     let cluster_info = Arc::new(RwLock::new(cluster_info));
 


### PR DESCRIPTION
#### Problem

As quoted from #7786:

> `solana-validator`'s `--wait-for-supermajority` does wait for the supermajority and it's very handy. However, it doesn't account for the newly-joined validator's snapshot resumption delay. In production and stress-testing settings, snapshots are large and takes some time for started validator process to resume from it.

> Normally, this is ok thanks to our fork selection rules. Such extra forks should eventually will be abandoned.

#### Summary of Changes

This PR does effectively this as quoted from #7786 by not advertising itself as a fully running validator when initially starting `solana-validator`:

> - Delay gossip-ing until snapshot resumption is finished

Fixes #7786