### PR TITLE
Add --dev-no-sigsign to disable signing shreds

### DIFF
--- a/core/benches/shredder.rs
+++ b/core/benches/shredder.rs
@@ -35,7 +35,7 @@ fn bench_shredder_ticks(bencher: &mut Bencher) {
     let num_ticks = max_ticks_per_n_shreds(1) * num_shreds as u64;
     let entries = create_ticks(num_ticks, 0, Hash::default());
     bencher.iter(|| {
-        let shredder = Shredder::new(1, 0, RECOMMENDED_FEC_RATE, kp.clone(), 0, 0).unwrap();
+        let shredder = Shredder::new(1, 0, RECOMMENDED_FEC_RATE, kp.clone(), 0, 0, false).unwrap();
         shredder.entries_to_shreds(&entries, true, 0);
     })
 }
@@ -50,7 +50,7 @@ fn bench_shredder_large_entries(bencher: &mut Bencher) {
     let entries = make_large_unchained_entries(txs_per_entry, num_entries);
     // 1Mb
     bencher.iter(|| {
-        let shredder = Shredder::new(1, 0, RECOMMENDED_FEC_RATE, kp.clone(), 0, 0).unwrap();
+        let shredder = Shredder::new(1, 0, RECOMMENDED_FEC_RATE, kp.clone(), 0, 0, false).unwrap();
         shredder.entries_to_shreds(&entries, true, 0);
     })
 }
@@ -63,7 +63,7 @@ fn bench_deshredder(bencher: &mut Bencher) {
     let num_shreds = ((10000 * 1000) + (shred_size - 1)) / shred_size;
     let num_ticks = max_ticks_per_n_shreds(1) * num_shreds as u64;
     let entries = create_ticks(num_ticks, 0, Hash::default());
-    let shredder = Shredder::new(1, 0, RECOMMENDED_FEC_RATE, kp, 0, 0).unwrap();
+    let shredder = Shredder::new(1, 0, RECOMMENDED_FEC_RATE, kp, 0, 0, false).unwrap();
     let data_shreds = shredder.entries_to_shreds(&entries, true, 0).0;
     bencher.iter(|| {
         let raw = &mut Shredder::deshred(&data_shreds).unwrap();

--- a/core/src/broadcast_stage.rs
+++ b/core/src/broadcast_stage.rs
@@ -46,6 +46,7 @@ impl BroadcastStageType {
         exit_sender: &Arc<AtomicBool>,
         blockstore: &Arc<Blockstore>,
         shred_version: u16,
+        sigsign_disabled: bool,
     ) -> BroadcastStage {
         let keypair = cluster_info.read().unwrap().keypair.clone();
         match self {
@@ -55,7 +56,7 @@ impl BroadcastStageType {
                 receiver,
                 exit_sender,
                 blockstore,
-                StandardBroadcastRun::new(keypair, shred_version),
+                StandardBroadcastRun::new(keypair, shred_version, sigsign_disabled),
             ),
 
             BroadcastStageType::FailEntryVerification => BroadcastStage::new(
@@ -306,7 +307,7 @@ mod test {
             entry_receiver,
             &exit_sender,
             &blockstore,
-            StandardBroadcastRun::new(leader_keypair, 0),
+            StandardBroadcastRun::new(leader_keypair, 0, false),
         );
 
         MockBroadcastStage {

--- a/core/src/broadcast_stage/broadcast_fake_shreds_run.rs
+++ b/core/src/broadcast_stage/broadcast_fake_shreds_run.rs
@@ -51,6 +51,7 @@ impl BroadcastRun for BroadcastFakeShredsRun {
             self.keypair.clone(),
             (bank.tick_height() % bank.ticks_per_slot()) as u8,
             self.shred_version,
+            false,
         )
         .expect("Expected to create a new shredder");
 

--- a/core/src/broadcast_stage/fail_entry_verification_broadcast_run.rs
+++ b/core/src/broadcast_stage/fail_entry_verification_broadcast_run.rs
@@ -51,6 +51,7 @@ impl BroadcastRun for FailEntryVerificationBroadcastRun {
             self.keypair.clone(),
             (bank.tick_height() % bank.ticks_per_slot()) as u8,
             self.shred_version,
+            false,
         )
         .expect("Expected to create a new shredder");
 

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -41,6 +41,7 @@ impl Tpu {
         tpu_forwards_sockets: Vec<UdpSocket>,
         broadcast_sockets: Vec<UdpSocket>,
         sigverify_disabled: bool,
+        sigsign_disabled: bool,
         transaction_status_sender: Option<TransactionStatusSender>,
         blockstore: &Arc<Blockstore>,
         broadcast_type: &BroadcastStageType,
@@ -89,6 +90,7 @@ impl Tpu {
             &exit,
             blockstore,
             shred_version,
+            sigsign_disabled,
         );
 
         Self {

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -55,6 +55,7 @@ use std::{
 #[derive(Clone, Debug)]
 pub struct ValidatorConfig {
     pub dev_sigverify_disabled: bool,
+    pub dev_sigsign_disabled: bool,
     pub dev_halt_at_slot: Option<Slot>,
     pub expected_genesis_hash: Option<Hash>,
     pub voting_disabled: bool,
@@ -75,6 +76,7 @@ impl Default for ValidatorConfig {
     fn default() -> Self {
         Self {
             dev_sigverify_disabled: false,
+            dev_sigsign_disabled: false,
             dev_halt_at_slot: None,
             expected_genesis_hash: None,
             voting_disabled: false,
@@ -351,6 +353,14 @@ impl Validator {
             "New shred signal for the TVU should be the same as the clear bank signal."
         );
 
+        if config.dev_sigverify_disabled {
+            warn!("signature verification disabled");
+        }
+
+        if config.dev_sigsign_disabled {
+            warn!("dummy signature enabled");
+        }
+
         let tvu = Tvu::new(
             vote_account,
             voting_keypair,
@@ -375,10 +385,6 @@ impl Validator {
             transaction_status_sender.clone(),
         );
 
-        if config.dev_sigverify_disabled {
-            warn!("signature verification disabled");
-        }
-
         let tpu = Tpu::new(
             &cluster_info,
             &poh_recorder,
@@ -387,6 +393,7 @@ impl Validator {
             node.sockets.tpu_forwards,
             node.sockets.broadcast,
             config.dev_sigverify_disabled,
+            config.dev_sigsign_disabled,
             transaction_status_sender,
             &blockstore,
             &config.broadcast_stage_type,

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -127,6 +127,7 @@ pub struct Validator {
 }
 
 impl Validator {
+    #[allow(clippy::cognitive_complexity)]
     pub fn new(
         mut node: Node,
         keypair: &Arc<Keypair>,

--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -511,7 +511,7 @@ mod test {
         parent: Slot,
         keypair: &Arc<Keypair>,
     ) -> Vec<Shred> {
-        let shredder = Shredder::new(slot, parent, 0.0, keypair.clone(), 0, 0)
+        let shredder = Shredder::new(slot, parent, 0.0, keypair.clone(), 0, 0, false)
             .expect("Failed to create entry shredder");
         shredder.entries_to_shreds(&entries, true, 0).0
     }

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -1114,9 +1114,16 @@ impl Blockstore {
         let mut remaining_ticks_in_slot = num_slots * ticks_per_slot - num_ticks_in_start_slot;
 
         let mut current_slot = start_slot;
-        let mut shredder =
-            Shredder::new(current_slot, parent_slot, 0.0, keypair.clone(), 0, version)
-                .expect("Failed to create entry shredder");
+        let mut shredder = Shredder::new(
+            current_slot,
+            parent_slot,
+            0.0,
+            keypair.clone(),
+            0,
+            version,
+            false,
+        )
+        .expect("Failed to create entry shredder");
         let mut all_shreds = vec![];
         let mut slot_entries = vec![];
         // Find all the entries for start_slot
@@ -1145,6 +1152,7 @@ impl Blockstore {
                     keypair.clone(),
                     (ticks_per_slot - remaining_ticks_in_slot) as u8,
                     version,
+                    false,
                 )
                 .expect("Failed to create entry shredder");
             }
@@ -2196,7 +2204,7 @@ pub fn create_new_ledger(ledger_path: &Path, genesis_config: &GenesisConfig) -> 
     let last_hash = entries.last().unwrap().hash;
     let version = Shred::version_from_hash(&last_hash);
 
-    let shredder = Shredder::new(0, 0, 0.0, Arc::new(Keypair::new()), 0, version)
+    let shredder = Shredder::new(0, 0, 0.0, Arc::new(Keypair::new()), 0, version, false)
         .expect("Failed to create entry shredder");
     let shreds = shredder.entries_to_shreds(&entries, true, 0).0;
     assert!(shreds.last().unwrap().last_in_slot());
@@ -2312,8 +2320,16 @@ pub fn entries_to_test_shreds(
     is_full_slot: bool,
     version: u16,
 ) -> Vec<Shred> {
-    let shredder = Shredder::new(slot, parent_slot, 0.0, Arc::new(Keypair::new()), 0, version)
-        .expect("Failed to create entry shredder");
+    let shredder = Shredder::new(
+        slot,
+        parent_slot,
+        0.0,
+        Arc::new(Keypair::new()),
+        0,
+        version,
+        false,
+    )
+    .expect("Failed to create entry shredder");
 
     shredder.entries_to_shreds(&entries, is_full_slot, 0).0
 }
@@ -5233,6 +5249,7 @@ pub mod tests {
             leader_keypair.clone(),
             0,
             0,
+            false,
         )
         .expect("Failed in creating shredder");
         let (data_shreds, coding_shreds, _) = shredder.entries_to_shreds(&entries, true, 0);
@@ -5286,7 +5303,7 @@ pub mod tests {
         let entries1 = make_slot_entries_with_transactions(1);
         let entries2 = make_slot_entries_with_transactions(1);
         let leader_keypair = Arc::new(Keypair::new());
-        let shredder = Shredder::new(slot, 0, 1.0, leader_keypair.clone(), 0, 0)
+        let shredder = Shredder::new(slot, 0, 1.0, leader_keypair.clone(), 0, 0, false)
             .expect("Failed in creating shredder");
         let (shreds, _, _) = shredder.entries_to_shreds(&entries1, true, 0);
         let (duplicate_shreds, _, _) = shredder.entries_to_shreds(&entries2, true, 0);

--- a/ledger/tests/shred.rs
+++ b/ledger/tests/shred.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 fn test_multi_fec_block_coding() {
     let keypair = Arc::new(Keypair::new());
     let slot = 0x123456789abcdef0;
-    let shredder = Shredder::new(slot, slot - 5, 1.0, keypair.clone(), 0, 0)
+    let shredder = Shredder::new(slot, slot - 5, 1.0, keypair.clone(), 0, 0, false)
         .expect("Failed in creating shredder");
 
     let num_fec_sets = 100;

--- a/sdk/src/signature.rs
+++ b/sdk/src/signature.rs
@@ -28,6 +28,15 @@ impl Signature {
         Self(GenericArray::clone_from_slice(&signature_slice))
     }
 
+    pub fn new_rand() -> Self {
+        let mut random_signature_bytes = [0u8; 64];
+        // Break into two slices because random just doesn't implement for [u8; 64]:
+        // ref: https://docs.rs/rand/0.7.3/rand/distributions/trait.Distribution.html#impl-Distribution%3C%5BT%3B%2032%5D%3E
+        random_signature_bytes[0..32].copy_from_slice(&rand::random::<[u8; 32]>());
+        random_signature_bytes[32..64].copy_from_slice(&rand::random::<[u8; 32]>());
+        Self::new(&random_signature_bytes)
+    }
+
     pub fn verify(&self, pubkey_bytes: &[u8], message_bytes: &[u8]) -> bool {
         let pubkey = ed25519_dalek::PublicKey::from_bytes(pubkey_bytes);
         let signature = ed25519_dalek::Signature::from_bytes(self.0.as_slice());

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -454,6 +454,12 @@ pub fn main() {
                 .help("Run without signature verification"),
         )
         .arg(
+            Arg::with_name("dev_no_sigsign")
+                .long("dev-no-sigsign")
+                .takes_value(false)
+                .help("Run with dummy signature generation"),
+        )
+        .arg(
             Arg::with_name("dev_halt_at_slot")
                 .long("dev-halt-at-slot")
                 .value_name("SLOT")
@@ -613,6 +619,7 @@ pub fn main() {
 
     let mut validator_config = ValidatorConfig::default();
     validator_config.dev_sigverify_disabled = matches.is_present("dev_no_sigverify");
+    validator_config.dev_sigsign_disabled = matches.is_present("dev_no_sigsign");
     validator_config.dev_halt_at_slot = value_t!(matches, "dev_halt_at_slot", Slot).ok();
 
     validator_config.rpc_config.enable_validator_exit = matches.is_present("enable_rpc_exit");


### PR DESCRIPTION
#### Problem

signature generation takes so much system load, which makes it harder to reproduce race conditions (like #7736) and to profile `solana-validator` with general system tools like Linux's `perf`.

#### Summary of Changes

Introduce a new flag (`--dev-no-sign`) to `solana-validator` and pass that flag into the very shred signing code.

Side product of #7736 
