### PR TITLE
Signal and process duplicate slots in ReplayStage

### DIFF
--- a/archiver-lib/src/archiver.rs
+++ b/archiver-lib/src/archiver.rs
@@ -461,6 +461,7 @@ impl Archiver {
             DisabledSigVerifier::default(),
         );
 
+        let (duplicate_slots_sender, _) = unbounded();
         let window_service = WindowService::new(
             blockstore.clone(),
             cluster_info.clone(),
@@ -471,6 +472,7 @@ impl Archiver {
             RepairStrategy::RepairRange(repair_slot_range),
             &Arc::new(LeaderScheduleCache::default()),
             |_, _, _, _| true,
+            duplicate_slots_sender,
         );
         info!("waiting for ledger download");
         Self::wait_for_segment_download(

--- a/core/src/poh_recorder.rs
+++ b/core/src/poh_recorder.rs
@@ -163,6 +163,10 @@ impl PohRecorder {
                 && !self.received_any_previous_leader_data(current_slot))
     }
 
+    pub fn last_reset_slot(&self) -> Slot {
+        self.start_slot
+    }
+
     /// returns if leader slot has been reached, how many grace ticks were afforded,
     ///   imputed leader_slot and self.start_slot
     /// reached_leader_slot() == true means "ready for a bank"

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -7,6 +7,7 @@ use crate::{
     poh_recorder::PohRecorder,
     result::Result,
     rpc_subscriptions::RpcSubscriptions,
+    window_service::DuplicateSlotReceiver,
 };
 use solana_ledger::{
     bank_forks::BankForks,
@@ -165,6 +166,7 @@ impl ReplayStage {
         bank_forks: Arc<RwLock<BankForks>>,
         cluster_info: Arc<RwLock<ClusterInfo>>,
         ledger_signal_receiver: Receiver<bool>,
+        duplicate_slots_receiver: DuplicateSlotReceiver,
         poh_recorder: Arc<Mutex<PohRecorder>>,
     ) -> (Self, Receiver<Vec<Arc<Bank>>>) {
         let ReplayStageConfig {
@@ -186,7 +188,6 @@ impl ReplayStage {
         let mut tower = Tower::new(&my_pubkey, &vote_account, &bank_forks.read().unwrap());
 
         // Start the replay stage loop
-
         let (lockouts_sender, commitment_service) =
             AggregateCommitmentService::new(&exit, block_commitment_cache);
 

--- a/core/src/retransmit_stage.rs
+++ b/core/src/retransmit_stage.rs
@@ -8,7 +8,7 @@ use crate::{
     streamer::PacketReceiver,
     window_service::{should_retransmit_and_persist, WindowService},
 };
-use crossbeam_channel::Receiver as CrossbeamReceiver;
+use crossbeam_channel::{Receiver, Sender};
 use solana_ledger::{
     bank_forks::BankForks,
     blockstore::{Blockstore, CompletedSlotsReceiver},
@@ -17,6 +17,7 @@ use solana_ledger::{
 };
 use solana_measure::measure::Measure;
 use solana_metrics::inc_new_counter_error;
+use solana_sdk::clock::Slot;
 use solana_sdk::epoch_schedule::EpochSchedule;
 use std::{
     cmp,
@@ -208,12 +209,13 @@ impl RetransmitStage {
         cluster_info: &Arc<RwLock<ClusterInfo>>,
         retransmit_sockets: Arc<Vec<UdpSocket>>,
         repair_socket: Arc<UdpSocket>,
-        verified_receiver: CrossbeamReceiver<Vec<Packets>>,
+        verified_receiver: Receiver<Vec<Packets>>,
         exit: &Arc<AtomicBool>,
         completed_slots_receiver: CompletedSlotsReceiver,
         epoch_schedule: EpochSchedule,
         cfg: Option<Arc<AtomicBool>>,
         shred_version: u16,
+        duplicate_slots_sender: Sender<Slot>,
     ) -> Self {
         let (retransmit_sender, retransmit_receiver) = channel();
 
@@ -256,6 +258,7 @@ impl RetransmitStage {
                 );
                 rv && is_connected
             },
+            duplicate_slots_sender,
         );
 
         let thread_hdls = t_retransmit;

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -129,6 +129,7 @@ impl Tvu {
             )
         };
 
+        let (duplicate_slots_sender, duplicate_slots_receiver) = unbounded();
         let retransmit_stage = RetransmitStage::new(
             bank_forks.clone(),
             leader_schedule_cache,
@@ -142,6 +143,7 @@ impl Tvu {
             *bank_forks.read().unwrap().working_bank().epoch_schedule(),
             cfg,
             shred_version,
+            duplicate_slots_sender,
         );
 
         let (blockstream_slot_sender, blockstream_slot_receiver) = channel();
@@ -178,6 +180,7 @@ impl Tvu {
             bank_forks.clone(),
             cluster_info.clone(),
             ledger_signal_receiver,
+            duplicate_slots_receiver,
             poh_recorder.clone(),
         );
 

--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -19,6 +19,7 @@ use solana_ledger::shred::Shred;
 use solana_metrics::{inc_new_counter_debug, inc_new_counter_error};
 use solana_rayon_threadlimit::get_thread_count;
 use solana_runtime::bank::Bank;
+use solana_sdk::clock::Slot;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::timing::duration_as_ms;
 use std::net::UdpSocket;
@@ -26,6 +27,9 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, RwLock};
 use std::thread::{self, Builder, JoinHandle};
 use std::time::{Duration, Instant};
+
+pub type DuplicateSlotSender = CrossbeamSender<Slot>;
+pub type DuplicateSlotReceiver = CrossbeamReceiver<Slot>;
 
 fn verify_shred_slot(shred: &Shred, root: u64) -> bool {
     if shred.is_data() {
@@ -76,17 +80,21 @@ pub fn should_retransmit_and_persist(
 fn run_check_duplicate(
     blockstore: &Arc<Blockstore>,
     shred_receiver: &CrossbeamReceiver<Shred>,
+    duplicate_slot_sender: &DuplicateSlotSender,
 ) -> Result<()> {
     let check_duplicate = |shred: Shred| -> Result<()> {
         if !blockstore.has_duplicate_shreds_in_slot(shred.slot()) {
             if let Some(existing_shred_payload) =
                 blockstore.is_shred_duplicate(shred.slot(), shred.index(), &shred.payload)
             {
+                let shred_slot = shred.slot();
                 blockstore.store_duplicate_slot(
-                    shred.slot(),
+                    shred_slot,
                     existing_shred_payload,
                     shred.payload,
                 )?;
+
+                duplicate_slot_sender.send(shred_slot)?;
             }
         }
 
@@ -252,6 +260,7 @@ impl WindowService {
         repair_strategy: RepairStrategy,
         leader_schedule_cache: &Arc<LeaderScheduleCache>,
         shred_filter: F,
+        duplicate_slots_sender: DuplicateSlotSender,
     ) -> WindowService
     where
         F: 'static
@@ -273,17 +282,21 @@ impl WindowService {
         );
 
         let (insert_sender, insert_receiver) = unbounded();
-        let (duplicate_sender, duplicate_receiver) = unbounded();
+        let (check_duplicate_sender, check_duplicate_receiver) = unbounded();
 
-        let t_check_duplicate =
-            Self::start_check_duplicate_thread(exit, &blockstore, duplicate_receiver);
+        let t_check_duplicate = Self::start_check_duplicate_thread(
+            exit,
+            &blockstore,
+            check_duplicate_receiver,
+            duplicate_slots_sender,
+        );
 
         let t_insert = Self::start_window_insert_thread(
             exit,
             &blockstore,
             leader_schedule_cache,
             insert_receiver,
-            duplicate_sender,
+            check_duplicate_sender,
         );
 
         let t_window = Self::start_recv_window_thread(
@@ -308,7 +321,8 @@ impl WindowService {
     fn start_check_duplicate_thread(
         exit: &Arc<AtomicBool>,
         blockstore: &Arc<Blockstore>,
-        duplicate_receiver: CrossbeamReceiver<Shred>,
+        check_duplicate_receiver: CrossbeamReceiver<Shred>,
+        duplicate_slot_sender: DuplicateSlotSender,
     ) -> JoinHandle<()> {
         let exit = exit.clone();
         let blockstore = blockstore.clone();
@@ -323,7 +337,11 @@ impl WindowService {
                 }
 
                 let mut noop = || {};
-                if let Err(e) = run_check_duplicate(&blockstore, &duplicate_receiver) {
+                if let Err(e) = run_check_duplicate(
+                    &blockstore,
+                    &check_duplicate_receiver,
+                    &duplicate_slot_sender,
+                ) {
                     if Self::should_exit_on_error(e, &mut noop, &handle_error) {
                         break;
                     }
@@ -337,7 +355,7 @@ impl WindowService {
         blockstore: &Arc<Blockstore>,
         leader_schedule_cache: &Arc<LeaderScheduleCache>,
         insert_receiver: CrossbeamReceiver<Vec<Shred>>,
-        duplicate_sender: CrossbeamSender<Shred>,
+        check_duplicate_sender: CrossbeamSender<Shred>,
     ) -> JoinHandle<()> {
         let exit = exit.clone();
         let blockstore = blockstore.clone();
@@ -351,7 +369,7 @@ impl WindowService {
             .name("solana-window-insert".to_string())
             .spawn(move || {
                 let handle_duplicate = |shred| {
-                    let _ = duplicate_sender.send(shred);
+                    let _ = check_duplicate_sender.send(shred);
                 };
                 loop {
                     if exit.load(Ordering::Relaxed) {
@@ -456,6 +474,7 @@ impl WindowService {
                 handle_timeout();
                 false
             }
+            Error::CrossbeamSendError => true,
             _ => {
                 handle_error();
                 error!("thread {:?} error {:?}", thread::current().name(), e);
@@ -491,7 +510,6 @@ mod test {
         shred::Shredder,
     };
     use solana_sdk::{
-        clock::Slot,
         epoch_schedule::MINIMUM_SLOTS_PER_EPOCH,
         hash::Hash,
         signature::{Keypair, KeypairUtil},
@@ -623,6 +641,7 @@ mod test {
             ContactInfo::new_localhost(&Pubkey::default(), 0),
         )));
         let repair_sock = Arc::new(UdpSocket::bind(socketaddr_any!()).unwrap());
+        let (duplicate_slots_sender, _) = unbounded();
         let window = WindowService::new(
             blockstore,
             cluster_info,
@@ -633,6 +652,7 @@ mod test {
             RepairStrategy::RepairRange(RepairSlotRange { start: 0, end: 0 }),
             &Arc::new(LeaderScheduleCache::default()),
             |_, _, _, _| true,
+            duplicate_slots_sender,
         );
         window
     }
@@ -677,6 +697,7 @@ mod test {
         let blockstore_path = get_tmp_ledger_path!();
         let blockstore = Arc::new(Blockstore::open(&blockstore_path).unwrap());
         let (sender, receiver) = unbounded();
+        let (duplicate_slot_sender, duplicate_slot_receiver) = unbounded();
         let (shreds, _) = make_many_slot_entries(5, 5, 10);
         blockstore
             .insert_shreds(shreds.clone(), None, false)
@@ -686,7 +707,11 @@ mod test {
         let duplicate_shred_slot = duplicate_shred.slot();
         sender.send(duplicate_shred).unwrap();
         assert!(!blockstore.has_duplicate_shreds_in_slot(duplicate_shred_slot));
-        run_check_duplicate(&blockstore, &receiver).unwrap();
+        run_check_duplicate(&blockstore, &receiver, &duplicate_slot_sender).unwrap();
         assert!(blockstore.has_duplicate_shreds_in_slot(duplicate_shred_slot));
+        assert_eq!(
+            duplicate_slot_receiver.try_recv().unwrap(),
+            duplicate_shred_slot
+        );
     }
 }

--- a/ledger/src/bank_forks.rs
+++ b/ledger/src/bank_forks.rs
@@ -157,6 +157,10 @@ impl BankForks {
         bank
     }
 
+    pub fn remove(&mut self, slot: Slot) -> Option<Arc<Bank>> {
+        self.banks.remove(&slot)
+    }
+
     pub fn working_bank(&self) -> Arc<Bank> {
         self.working_bank.clone()
     }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -887,6 +887,14 @@ impl Bank {
         self.src.status_cache.write().unwrap().clear_signatures();
     }
 
+    pub fn clear_slot_signatures(&self, slot: Slot) {
+        self.src
+            .status_cache
+            .write()
+            .unwrap()
+            .clear_slot_signatures(slot);
+    }
+
     pub fn can_commit(result: &Result<()>) -> bool {
         match result {
             Ok(_) => true,

--- a/runtime/src/status_cache.rs
+++ b/runtime/src/status_cache.rs
@@ -7,7 +7,7 @@ use solana_sdk::{
     signature::Signature,
 };
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{hash_map::Entry, HashMap, HashSet},
     sync::{Arc, Mutex},
 };
 
@@ -73,6 +73,46 @@ impl<T: Serialize + Clone + PartialEq> PartialEq for StatusCache<T> {
 }
 
 impl<T: Serialize + Clone> StatusCache<T> {
+    pub fn clear_slot_signatures(&mut self, slot: Slot) {
+        let slot_deltas = self.slot_deltas.remove(&slot);
+        if let Some(slot_deltas) = slot_deltas {
+            let slot_deltas = slot_deltas.lock().unwrap();
+            for (blockhash, (_, signature_list)) in slot_deltas.iter() {
+                // Any blockhash that exists in self.slot_deltas must also exist
+                // in self.cache, because in self.purge_roots(), when an entry
+                // (b, (max_slot, _, _)) is removed from self.cache, this implies
+                // all entries in self.slot_deltas < max_slot are also removed
+                if let Entry::Occupied(mut o_blockhash_entries) = self.cache.entry(*blockhash) {
+                    let (_, _, all_sig_maps) = o_blockhash_entries.get_mut();
+
+                    for (sig_slice, _) in signature_list {
+                        if let Entry::Occupied(mut o_sig_list) = all_sig_maps.entry(*sig_slice) {
+                            let sig_list = o_sig_list.get_mut();
+                            sig_list.retain(|(updated_slot, _)| *updated_slot != slot);
+                            if sig_list.is_empty() {
+                                o_sig_list.remove_entry();
+                            }
+                        } else {
+                            panic!(
+                                "Map for signature must exist if siganture exists in self.slot_deltas, slot: {}",
+                                slot
+                            )
+                        }
+                    }
+
+                    if all_sig_maps.is_empty() {
+                        o_blockhash_entries.remove_entry();
+                    }
+                } else {
+                    panic!(
+                        "Blockhash must exist if it exists in self.slot_deltas, slot: {}",
+                        slot
+                    )
+                }
+            }
+        }
+    }
+
     /// Check if the signature from a transaction is in any of the forks in the ancestors set.
     pub fn get_signature_status(
         &self,
@@ -428,6 +468,8 @@ mod tests {
             status_cache.add_root(i as u64);
         }
         let slots: Vec<_> = (0_u64..MAX_CACHE_ENTRIES as u64 + 1).collect();
+        assert_eq!(status_cache.slot_deltas.len(), 1);
+        assert!(status_cache.slot_deltas.get(&1).is_some());
         let slot_deltas = status_cache.slot_deltas(&slots);
         let cache = StatusCache::from_slot_deltas(&slot_deltas);
         assert_eq!(cache, status_cache);
@@ -436,5 +478,52 @@ mod tests {
     #[test]
     fn test_age_sanity() {
         assert!(MAX_CACHE_ENTRIES <= MAX_RECENT_BLOCKHASHES);
+    }
+
+    #[test]
+    fn test_clear_slot_signatures() {
+        let sig = Signature::default();
+        let mut status_cache = BankStatusCache::default();
+        let blockhash = hash(Hash::default().as_ref());
+        let blockhash2 = hash(blockhash.as_ref());
+        status_cache.insert(&blockhash, &sig, 0, ());
+        status_cache.insert(&blockhash, &sig, 1, ());
+        status_cache.insert(&blockhash2, &sig, 1, ());
+
+        let mut ancestors0 = HashMap::new();
+        ancestors0.insert(0, 0);
+        let mut ancestors1 = HashMap::new();
+        ancestors1.insert(1, 0);
+
+        // Clear slot 0 related data
+        assert!(status_cache
+            .get_signature_status(&sig, &blockhash, &ancestors0)
+            .is_some());
+        status_cache.clear_slot_signatures(0);
+        assert!(status_cache
+            .get_signature_status(&sig, &blockhash, &ancestors0)
+            .is_none());
+        assert!(status_cache
+            .get_signature_status(&sig, &blockhash, &ancestors1)
+            .is_some());
+        assert!(status_cache
+            .get_signature_status(&sig, &blockhash2, &ancestors1)
+            .is_some());
+
+        // Check that the slot delta for slot 0 is gone, but slot 1 still
+        // exists
+        assert!(status_cache.slot_deltas.get(&0).is_none());
+        assert!(status_cache.slot_deltas.get(&1).is_some());
+
+        // Clear slot 1 related data
+        status_cache.clear_slot_signatures(1);
+        assert!(status_cache.slot_deltas.is_empty());
+        assert!(status_cache
+            .get_signature_status(&sig, &blockhash, &ancestors1)
+            .is_none());
+        assert!(status_cache
+            .get_signature_status(&sig, &blockhash2, &ancestors1)
+            .is_none());
+        assert!(status_cache.cache.is_empty());
     }
 }


### PR DESCRIPTION
#### Problem
ReplayStage does not currently handle leaders sending multiple versions of a slot, an easy attack vector

#### Summary of Changes
1) Add channel to notify ReplayStage of duplicate slots
2) Process duplicate slots in ReplayStage, resetting PoH if PoH was descended from an unconfirmed duplicate slot
3) Add ability to clear signatures for duplicate slots that are not confirmed

TODO's in follow-up PR's:
1) Update RepairService to repair duplicate slots that are confirmed
2) Update BlockstoreProcessor to handle duplicate slots on boot that were not handled before last restart (ReplayStage got the signal but node crashed before the duplicate slot was processed)

Fixes #
