### PR TITLE
Fix timestamp overflow

### DIFF
--- a/programs/vote/src/vote_state.rs
+++ b/programs/vote/src/vote_state.rs
@@ -404,7 +404,8 @@ impl VoteState {
     ) -> Result<(), VoteError> {
         if (slot < self.last_timestamp.slot || timestamp < self.last_timestamp.timestamp)
             || ((slot == self.last_timestamp.slot || timestamp == self.last_timestamp.timestamp)
-                && BlockTimestamp { slot, timestamp } != self.last_timestamp)
+                && BlockTimestamp { slot, timestamp } != self.last_timestamp
+                && self.last_timestamp.slot != 0)
         {
             return Err(VoteError::TimestampTooOld);
         }
@@ -1403,5 +1404,9 @@ mod tests {
                 timestamp: timestamp + 1
             }
         );
+
+        // Test initial vote
+        vote_state.last_timestamp = BlockTimestamp::default();
+        assert_eq!(vote_state.process_timestamp(0, timestamp), Ok(()));
     }
 }


### PR DESCRIPTION
#### Problem
On a testnet with very high stakes, `solana get-block-time` returns unexpected, unrealistic value (see #7781 ).
Stake-weighted blocktime calculation accumulators currently use u64 integer types; stake quantities are represented in lamports, and also use the u64 integer type. Thus, it is easy to make the stake-weighted timestamp calculation overflow when multiplying a moderately high stake number with a UnixTimestamp (i64).

(This bug produces a skewed timestamp on testnet, instead of panicking the node as it does in the unit test; TIL Rust only checks for integer overflow in debug builds.)

#### Summary of Changes
- Use u128 integers to handle stake-weighting timestamps
- Also sneak in fix to Vote error occurring frequently in slot 1

Fixes #7781 
