### PR TITLE
Remove redundant threadpools in sigverify

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3971,6 +3971,7 @@ dependencies = [
  "ed25519-dalek 1.0.0-pre.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fs_extra 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -46,6 +46,7 @@ sys-info = "0.5.8"
 tar = "0.4.26"
 thiserror = "1.0"
 tempfile = "3.1.0"
+lazy_static = "1.4.0"
 
 [dependencies.rocksdb]
 # Avoid the vendored bzip2 within rocksdb-sys that can cause linker conflicts

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -58,6 +58,7 @@ pub const BLOCKSTORE_DIRECTORY: &str = "rocksdb";
 
 thread_local!(static PAR_THREAD_POOL: RefCell<ThreadPool> = RefCell::new(rayon::ThreadPoolBuilder::new()
                     .num_threads(get_thread_count())
+                    .thread_name(|ix| format!("blockstore_{}", ix))
                     .build()
                     .unwrap()));
 

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -39,6 +39,7 @@ use thiserror::Error;
 
 thread_local!(static PAR_THREAD_POOL: RefCell<ThreadPool> = RefCell::new(rayon::ThreadPoolBuilder::new()
                     .num_threads(get_thread_count())
+                    .thread_name(|ix| format!("blockstore_processor_{}", ix))
                     .build()
                     .unwrap())
 );

--- a/ledger/src/entry.rs
+++ b/ledger/src/entry.rs
@@ -26,6 +26,7 @@ use std::{cmp, thread};
 
 thread_local!(static PAR_THREAD_POOL: RefCell<ThreadPool> = RefCell::new(rayon::ThreadPoolBuilder::new()
                     .num_threads(get_thread_count())
+                    .thread_name(|ix| format!("entry_{}", ix))
                     .build()
                     .unwrap()));
 

--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -25,3 +25,6 @@ extern crate solana_metrics;
 
 #[macro_use]
 extern crate log;
+
+#[macro_use]
+extern crate lazy_static;

--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -46,6 +46,7 @@ pub const OFFSET_OF_SHRED_INDEX: usize = OFFSET_OF_SHRED_SLOT + SIZE_OF_SHRED_SL
 
 thread_local!(static PAR_THREAD_POOL: RefCell<ThreadPool> = RefCell::new(rayon::ThreadPoolBuilder::new()
                     .num_threads(get_thread_count())
+                    .thread_name(|ix| format!("shredder_{}", ix))
                     .build()
                     .unwrap()));
 


### PR DESCRIPTION
#### Problem

Sigverify uses `thread_local!()` threadpools for shred and transaction verification. 

A single `sigverify_stage` contains 4 sigverifier threads. Each of those threads ends up with its own threadpool. 
Our Validators have multiple sigverify_stages (for txs and shreds) and so we end up with an unnecessarily large number of threadpools per sigverify_stage.

#### Summary of Changes

Switched the duplicated threadpools to `lazy_static!` instead of `thread_local!()`, this removes over 50 threads on a 12 core machine. 

I also audited all the other `thread_local!()` pools we use as well and looked at every other thread we have running and nothing else seems out of place. The next highest number of threads comes from our socket receivers since we just have so many sockets open. 