### PR TITLE
Remove get-/show- prefix from cli commands

### DIFF
--- a/book/src/api-reference/cli.md
+++ b/book/src/api-reference/cli.md
@@ -199,14 +199,18 @@ OPTIONS:
     -k, --keypair <PATH>                    /path/to/id.json
 
 SUBCOMMANDS:
+    account                             Show the contents of an account
     address                             Get your public key
     airdrop                             Request lamports
     authorize-nonce-account             Assign account authority to a new entity
     balance                             Get your balance
+    block-production                    Show information about block production
+    block-time                          Get estimated production time of a block
     cancel                              Cancel a transfer
     catchup                             Wait for a validator to catch up to the cluster
     claim-storage-reward                Redeem storage reward credits
     cluster-version                     Get the version of the cluster entrypoint
+    config                              Solana command-line tool configuration settings
     confirm                             Confirm transaction by signature
     create-address-with-seed            Generate a dervied account address with a seed
     create-archiver-storage-account     Create an archiver storage account
@@ -217,35 +221,30 @@ SUBCOMMANDS:
     deactivate-stake                    Deactivate the delegated stake from the stake account
     delegate-stake                      Delegate stake to a vote account
     deploy                              Deploy a program
+    epoch-info                          Get information about the current epoch
     fees                                Display current cluster fees
-    get                                 Get cli config settings
-    get-block-time                      Get estimated production time of a block
-    get-epoch-info                      Get information about the current epoch
-    get-genesis-hash                    Get the genesis hash
-    get-nonce                           Get the current nonce value
-    get-slot                            Get current slot
-    get-transaction-count               Get current transaction count
+    genesis-hash                        Get the genesis hash
+    gossip                              Show the current gossip network nodes
     help                                Prints this message or the help of the given subcommand(s)
     new-nonce                           Generate a new nonce, rendering the existing nonce useless
+    nonce                               Get the current nonce value
+    nonce-account                       Show the contents of a nonce account
     pay                                 Send a payment
     ping                                Submit transactions sequentially
     redeem-vote-credits                 Redeem credits in the stake account
     send-signature                      Send a signature to authorize a transfer
     send-timestamp                      Send a timestamp to unlock a transfer
-    set                                 Set a cli config setting
-    show-account                        Show the contents of an account
-    show-block-production               Show information about block production
-    show-gossip                         Show the current gossip network nodes
-    show-nonce-account                  Show the contents of a nonce account
-    show-stake-account                  Show the contents of a stake account
-    show-stake-history                  Show the stake history
-    show-storage-account                Show the contents of a storage account
-    show-validators                     Show information about the current validators
-    show-vote-account                   Show the contents of a vote account
+    slot                                Get current slot
+    stake-account                       Show the contents of a stake account
     stake-authorize-staker              Authorize a new stake signing keypair for the given stake account
     stake-authorize-withdrawer          Authorize a new withdraw signing keypair for the given stake account
+    stake-history                       Show the stake history
+    storage-account                     Show the contents of a storage account
+    transaction-count                   Get current transaction count
     uptime                              Show the uptime of a validator, based on epoch voting history
     validator-info                      Publish/get Validator info on Solana
+    validators                          Show information about the current validators
+    vote-account                        Show the contents of a vote account
     vote-authorize-voter                Authorize a new vote signing keypair for the given vote account
     vote-authorize-withdrawer           Authorize a new withdraw signing keypair for the given vote account
     vote-update-validator               Update the vote account's validator identity
@@ -255,7 +254,7 @@ SUBCOMMANDS:
 
 #### solana-address
 ```text
-solana-address 
+solana-address
 Get your public key
 
 USAGE:
@@ -279,7 +278,7 @@ OPTIONS:
 
 #### solana-airdrop
 ```text
-solana-airdrop 
+solana-airdrop
 Request lamports
 
 USAGE:
@@ -309,7 +308,7 @@ ARGS:
 
 #### solana-authorize-nonce-account
 ```text
-solana-authorize-nonce-account 
+solana-authorize-nonce-account
 Assign account authority to a new entity
 
 USAGE:
@@ -338,7 +337,7 @@ ARGS:
 
 #### solana-balance
 ```text
-solana-balance 
+solana-balance
 Get your balance
 
 USAGE:
@@ -366,7 +365,7 @@ ARGS:
 
 #### solana-cancel
 ```text
-solana-cancel 
+solana-cancel
 Cancel a transfer
 
 USAGE:
@@ -393,7 +392,7 @@ ARGS:
 
 #### solana-catchup
 ```text
-solana-catchup 
+solana-catchup
 Wait for a validator to catch up to the cluster
 
 USAGE:
@@ -420,7 +419,7 @@ ARGS:
 
 #### solana-claim-storage-reward
 ```text
-solana-claim-storage-reward 
+solana-claim-storage-reward
 Redeem storage reward credits
 
 USAGE:
@@ -448,7 +447,7 @@ ARGS:
 
 #### solana-cluster-version
 ```text
-solana-cluster-version 
+solana-cluster-version
 Get the version of the cluster entrypoint
 
 USAGE:
@@ -472,7 +471,7 @@ OPTIONS:
 
 #### solana-confirm
 ```text
-solana-confirm 
+solana-confirm
 Confirm transaction by signature
 
 USAGE:
@@ -499,7 +498,7 @@ ARGS:
 
 #### solana-create-address-with-seed
 ```text
-solana-create-address-with-seed 
+solana-create-address-with-seed
 Generate a dervied account address with a seed
 
 USAGE:
@@ -523,13 +522,13 @@ OPTIONS:
 
 ARGS:
     <SEED_STRING>    The seed.  Must not take more than 32 bytes to encode as utf-8
-    <PROGRAM_ID>     The program_id that the address will ultimately be used for, 
+    <PROGRAM_ID>     The program_id that the address will ultimately be used for,
                      or one of STAKE, VOTE, NONCE, and STORAGE keywords
 ```
 
 #### solana-create-archiver-storage-account
 ```text
-solana-create-archiver-storage-account 
+solana-create-archiver-storage-account
 Create an archiver storage account
 
 USAGE:
@@ -551,13 +550,13 @@ OPTIONS:
     -k, --keypair <PATH>                    /path/to/id.json
 
 ARGS:
-    <STORAGE ACCOUNT OWNER PUBKEY>    
-    <STORAGE ACCOUNT>                 
+    <STORAGE ACCOUNT OWNER PUBKEY>
+    <STORAGE ACCOUNT>
 ```
 
 #### solana-create-nonce-account
 ```text
-solana-create-nonce-account 
+solana-create-nonce-account
 Create a nonce account
 
 USAGE:
@@ -587,7 +586,7 @@ ARGS:
 
 #### solana-create-stake-account
 ```text
-solana-create-stake-account 
+solana-create-stake-account
 Create a stake account
 
 USAGE:
@@ -621,7 +620,7 @@ ARGS:
 
 #### solana-create-validator-storage-account
 ```text
-solana-create-validator-storage-account 
+solana-create-validator-storage-account
 Create a validator storage account
 
 USAGE:
@@ -643,13 +642,13 @@ OPTIONS:
     -k, --keypair <PATH>                    /path/to/id.json
 
 ARGS:
-    <STORAGE ACCOUNT OWNER PUBKEY>    
-    <STORAGE ACCOUNT>                 
+    <STORAGE ACCOUNT OWNER PUBKEY>
+    <STORAGE ACCOUNT>
 ```
 
 #### solana-create-vote-account
 ```text
-solana-create-vote-account 
+solana-create-vote-account
 Create a vote account
 
 USAGE:
@@ -680,7 +679,7 @@ ARGS:
 
 #### solana-deactivate-stake
 ```text
-solana-deactivate-stake 
+solana-deactivate-stake
 Deactivate the delegated stake from the stake account
 
 USAGE:
@@ -702,9 +701,9 @@ OPTIONS:
                                                ~/.config/solana/cli/config.yml]
     -u, --url <URL>                            JSON RPC URL for the solana cluster
     -k, --keypair <PATH>                       /path/to/id.json
-        --nonce <PUBKEY>                       Provide the nonce account to use when creating a nonced 
-                                               transaction. Nonced transactions are useful when a transaction 
-                                               requires a lengthy signing process. Learn more about nonced 
+        --nonce <PUBKEY>                       Provide the nonce account to use when creating a nonced
+                                               transaction. Nonced transactions are useful when a transaction
+                                               requires a lengthy signing process. Learn more about nonced
                                                transactions at https://docs.solana.com/offline-signing/durable-nonce
         --nonce-authority <nonce_authority>    Provide the nonce authority keypair to use when signing a nonced
                                                transaction
@@ -716,7 +715,7 @@ ARGS:
 
 #### solana-delegate-stake
 ```text
-solana-delegate-stake 
+solana-delegate-stake
 Delegate stake to a vote account
 
 USAGE:
@@ -738,9 +737,9 @@ OPTIONS:
                                                ~/.config/solana/cli/config.yml]
     -u, --url <URL>                            JSON RPC URL for the solana cluster
     -k, --keypair <PATH>                       /path/to/id.json
-        --nonce <PUBKEY>                       Provide the nonce account to use when creating a nonced 
-                                               transaction. Nonced transactions are useful when a transaction 
-                                               requires a lengthy signing process. Learn more about nonced 
+        --nonce <PUBKEY>                       Provide the nonce account to use when creating a nonced
+                                               transaction. Nonced transactions are useful when a transaction
+                                               requires a lengthy signing process. Learn more about nonced
                                                transactions at https://docs.solana.com/offline-signing/durable-nonce
         --nonce-authority <nonce_authority>    Provide the nonce authority keypair to use when signing a nonced
                                                transaction
@@ -753,7 +752,7 @@ ARGS:
 
 #### solana-deploy
 ```text
-solana-deploy 
+solana-deploy
 Deploy a program
 
 USAGE:
@@ -780,7 +779,7 @@ ARGS:
 
 #### solana-fees
 ```text
-solana-fees 
+solana-fees
 Display current cluster fees
 
 USAGE:
@@ -804,7 +803,7 @@ OPTIONS:
 
 #### solana-get
 ```text
-solana-get 
+solana-get
 Get cli config settings
 
 USAGE:
@@ -831,11 +830,11 @@ ARGS:
 
 #### solana-get-block-time
 ```text
-solana-get-block-time 
+solana-get-block-time
 Get estimated production time of a block
 
 USAGE:
-    solana get-block-time [FLAGS] [OPTIONS] <SLOT>
+    solana block-time [FLAGS] [OPTIONS] <SLOT>
 
 FLAGS:
     -h, --help                           Prints help information
@@ -858,11 +857,11 @@ ARGS:
 
 #### solana-get-epoch-info
 ```text
-solana-get-epoch-info 
+solana-get-epoch-info
 Get information about the current epoch
 
 USAGE:
-    solana get-epoch-info [FLAGS] [OPTIONS]
+    solana epoch-info [FLAGS] [OPTIONS]
 
 FLAGS:
         --confirmed                      Return information at maximum-lockout commitment level
@@ -883,11 +882,11 @@ OPTIONS:
 
 #### solana-get-genesis-hash
 ```text
-solana-get-genesis-hash 
+solana-get-genesis-hash
 Get the genesis hash
 
 USAGE:
-    solana get-genesis-hash [FLAGS] [OPTIONS]
+    solana genesis-hash [FLAGS] [OPTIONS]
 
 FLAGS:
     -h, --help                           Prints help information
@@ -907,11 +906,11 @@ OPTIONS:
 
 #### solana-get-nonce
 ```text
-solana-get-nonce 
+solana-get-nonce
 Get the current nonce value
 
 USAGE:
-    solana get-nonce [FLAGS] [OPTIONS] <NONCE ACCOUNT>
+    solana nonce [FLAGS] [OPTIONS] <NONCE ACCOUNT>
 
 FLAGS:
     -h, --help                           Prints help information
@@ -934,11 +933,11 @@ ARGS:
 
 #### solana-get-slot
 ```text
-solana-get-slot 
+solana-get-slot
 Get current slot
 
 USAGE:
-    solana get-slot [FLAGS] [OPTIONS]
+    solana slot [FLAGS] [OPTIONS]
 
 FLAGS:
         --confirmed                      Return slot at maximum-lockout commitment level
@@ -959,11 +958,11 @@ OPTIONS:
 
 #### solana-get-transaction-count
 ```text
-solana-get-transaction-count 
+solana-get-transaction-count
 Get current transaction count
 
 USAGE:
-    solana get-transaction-count [FLAGS] [OPTIONS]
+    solana transaction-count [FLAGS] [OPTIONS]
 
 FLAGS:
         --confirmed                      Return count at maximum-lockout commitment level
@@ -984,7 +983,7 @@ OPTIONS:
 
 #### solana-help
 ```text
-solana-help 
+solana-help
 Prints this message or the help of the given subcommand(s)
 
 USAGE:
@@ -996,7 +995,7 @@ ARGS:
 
 #### solana-new-nonce
 ```text
-solana-new-nonce 
+solana-new-nonce
 Generate a new nonce, rendering the existing nonce useless
 
 USAGE:
@@ -1024,14 +1023,14 @@ ARGS:
 
 #### solana-pay
 ```text
-solana-pay 
+solana-pay
 Send a payment
 
 USAGE:
     solana pay [FLAGS] [OPTIONS] <TO PUBKEY> <AMOUNT> [--] [UNIT]
 
 FLAGS:
-        --cancelable                     
+        --cancelable
     -h, --help                           Prints help information
         --sign-only                      Sign the transaction offline
         --skip-seed-phrase-validation    Skip validation of seed phrases. Use this if your phrase does not use the BIP39
@@ -1047,9 +1046,9 @@ OPTIONS:
                                                 ~/.config/solana/cli/config.yml]
     -u, --url <URL>                             JSON RPC URL for the solana cluster
     -k, --keypair <PATH>                        /path/to/id.json
-        --nonce <PUBKEY>                        Provide the nonce account to use when creating a nonced 
-                                                transaction. Nonced transactions are useful when a transaction 
-                                                requires a lengthy signing process. Learn more about nonced 
+        --nonce <PUBKEY>                        Provide the nonce account to use when creating a nonced
+                                                transaction. Nonced transactions are useful when a transaction
+                                                requires a lengthy signing process. Learn more about nonced
                                                 transactions at https://docs.solana.com/offline-signing/durable-nonce
         --nonce-authority <nonce_authority>     Provide the nonce authority keypair to use when signing a nonced
                                                 transaction
@@ -1066,7 +1065,7 @@ ARGS:
 
 #### solana-ping
 ```text
-solana-ping 
+solana-ping
 Submit transactions sequentially
 
 USAGE:
@@ -1095,7 +1094,7 @@ OPTIONS:
 
 #### solana-redeem-vote-credits
 ```text
-solana-redeem-vote-credits 
+solana-redeem-vote-credits
 Redeem credits in the stake account
 
 USAGE:
@@ -1123,7 +1122,7 @@ ARGS:
 
 #### solana-send-signature
 ```text
-solana-send-signature 
+solana-send-signature
 Send a signature to authorize a transfer
 
 USAGE:
@@ -1151,7 +1150,7 @@ ARGS:
 
 #### solana-send-timestamp
 ```text
-solana-send-timestamp 
+solana-send-timestamp
 Send a timestamp to unlock a transfer
 
 USAGE:
@@ -1180,7 +1179,7 @@ ARGS:
 
 #### solana-set
 ```text
-solana-set 
+solana-set
 Set a cli config setting
 
 USAGE:
@@ -1202,13 +1201,13 @@ OPTIONS:
     -k, --keypair <PATH>                    /path/to/id.json
 ```
 
-#### solana-show-account
+#### solana-account
 ```text
-solana-show-account 
+solana-account
 Show the contents of an account
 
 USAGE:
-    solana show-account [FLAGS] [OPTIONS] <ACCOUNT PUBKEY>
+    solana account [FLAGS] [OPTIONS] <ACCOUNT PUBKEY>
 
 FLAGS:
     -h, --help                           Prints help information
@@ -1231,13 +1230,13 @@ ARGS:
     <ACCOUNT PUBKEY>    Account pubkey
 ```
 
-#### solana-show-block-production
+#### solana-block-production
 ```text
-solana-show-block-production 
+solana-block-production
 Show information about block production
 
 USAGE:
-    solana show-block-production [FLAGS] [OPTIONS]
+    solana block-production [FLAGS] [OPTIONS]
 
 FLAGS:
     -h, --help                           Prints help information
@@ -1258,13 +1257,13 @@ OPTIONS:
                                             epoch]
 ```
 
-#### solana-show-gossip
+#### solana-gossip
 ```text
-solana-show-gossip 
+solana-gossip
 Show the current gossip network nodes
 
 USAGE:
-    solana show-gossip [FLAGS] [OPTIONS]
+    solana gossip [FLAGS] [OPTIONS]
 
 FLAGS:
     -h, --help                           Prints help information
@@ -1282,13 +1281,13 @@ OPTIONS:
     -k, --keypair <PATH>                    /path/to/id.json
 ```
 
-#### solana-show-nonce-account
+#### solana-nonce-account
 ```text
-solana-show-nonce-account 
+solana-nonce-account
 Show the contents of a nonce account
 
 USAGE:
-    solana show-nonce-account [FLAGS] [OPTIONS] <NONCE ACCOUNT>
+    solana nonce-account [FLAGS] [OPTIONS] <NONCE ACCOUNT>
 
 FLAGS:
     -h, --help                           Prints help information
@@ -1310,13 +1309,13 @@ ARGS:
     <NONCE ACCOUNT>    Address of the nonce account to display
 ```
 
-#### solana-show-stake-account
+#### solana-stake-account
 ```text
-solana-show-stake-account 
+solana-stake-account
 Show the contents of a stake account
 
 USAGE:
-    solana show-stake-account [FLAGS] [OPTIONS] <STAKE ACCOUNT>
+    solana stake-account [FLAGS] [OPTIONS] <STAKE ACCOUNT>
 
 FLAGS:
     -h, --help                           Prints help information
@@ -1338,13 +1337,13 @@ ARGS:
     <STAKE ACCOUNT>    Address of the stake account to display
 ```
 
-#### solana-show-stake-history
+#### solana-stake-history
 ```text
-solana-show-stake-history 
+solana-stake-history
 Show the stake history
 
 USAGE:
-    solana show-stake-history [FLAGS] [OPTIONS]
+    solana stake-history [FLAGS] [OPTIONS]
 
 FLAGS:
     -h, --help                           Prints help information
@@ -1363,13 +1362,13 @@ OPTIONS:
     -k, --keypair <PATH>                    /path/to/id.json
 ```
 
-#### solana-show-storage-account
+#### solana-storage-account
 ```text
-solana-show-storage-account 
+solana-storage-account
 Show the contents of a storage account
 
 USAGE:
-    solana show-storage-account [FLAGS] [OPTIONS] <STORAGE ACCOUNT PUBKEY>
+    solana storage-account [FLAGS] [OPTIONS] <STORAGE ACCOUNT PUBKEY>
 
 FLAGS:
     -h, --help                           Prints help information
@@ -1390,13 +1389,13 @@ ARGS:
     <STORAGE ACCOUNT PUBKEY>    Storage account pubkey
 ```
 
-#### solana-show-validators
+#### solana-validators
 ```text
-solana-show-validators 
+solana-validators
 Show information about the current validators
 
 USAGE:
-    solana show-validators [FLAGS] [OPTIONS]
+    solana validators [FLAGS] [OPTIONS]
 
 FLAGS:
     -h, --help                           Prints help information
@@ -1415,13 +1414,13 @@ OPTIONS:
     -k, --keypair <PATH>                    /path/to/id.json
 ```
 
-#### solana-show-vote-account
+#### solana-vote-account
 ```text
-solana-show-vote-account 
+solana-vote-account
 Show the contents of a vote account
 
 USAGE:
-    solana show-vote-account [FLAGS] [OPTIONS] <VOTE ACCOUNT PUBKEY>
+    solana vote-account [FLAGS] [OPTIONS] <VOTE ACCOUNT PUBKEY>
 
 FLAGS:
     -h, --help                           Prints help information
@@ -1445,7 +1444,7 @@ ARGS:
 
 #### solana-stake-authorize-staker
 ```text
-solana-stake-authorize-staker 
+solana-stake-authorize-staker
 Authorize a new stake signing keypair for the given stake account
 
 USAGE:
@@ -1473,7 +1472,7 @@ ARGS:
 
 #### solana-stake-authorize-withdrawer
 ```text
-solana-stake-authorize-withdrawer 
+solana-stake-authorize-withdrawer
 Authorize a new withdraw signing keypair for the given stake account
 
 USAGE:
@@ -1501,7 +1500,7 @@ ARGS:
 
 #### solana-uptime
 ```text
-solana-uptime 
+solana-uptime
 Show the uptime of a validator, based on epoch voting history
 
 USAGE:
@@ -1530,7 +1529,7 @@ ARGS:
 
 #### solana-validator-info
 ```text
-solana-validator-info 
+solana-validator-info
 Publish/get Validator info on Solana
 
 USAGE:
@@ -1559,7 +1558,7 @@ SUBCOMMANDS:
 
 #### solana-vote-authorize-voter
 ```text
-solana-vote-authorize-voter 
+solana-vote-authorize-voter
 Authorize a new vote signing keypair for the given vote account
 
 USAGE:
@@ -1587,7 +1586,7 @@ ARGS:
 
 #### solana-vote-authorize-withdrawer
 ```text
-solana-vote-authorize-withdrawer 
+solana-vote-authorize-withdrawer
 Authorize a new withdraw signing keypair for the given vote account
 
 USAGE:
@@ -1615,7 +1614,7 @@ ARGS:
 
 #### solana-vote-update-validator
 ```text
-solana-vote-update-validator 
+solana-vote-update-validator
 Update the vote account's validator identity
 
 USAGE:
@@ -1644,7 +1643,7 @@ ARGS:
 
 #### solana-withdraw-from-nonce-account
 ```text
-solana-withdraw-from-nonce-account 
+solana-withdraw-from-nonce-account
 Withdraw lamports from the nonce account
 
 USAGE:
@@ -1675,7 +1674,7 @@ ARGS:
 
 #### solana-withdraw-stake
 ```text
-solana-withdraw-stake 
+solana-withdraw-stake
 Withdraw the unstaked lamports from the stake account
 
 USAGE:

--- a/book/src/offline-signing/durable-nonce.md
+++ b/book/src/offline-signing/durable-nonce.md
@@ -64,7 +64,7 @@ presently stored nonce value with
 - Command
 
 ```bash
-solana get-nonce nonce-keypair.json 
+solana nonce nonce-keypair.json 
 ```
 
 - Output
@@ -105,7 +105,7 @@ Inspect a nonce account in a more human friendly format with
 - Command
 
 ```bash
-solana show-nonce-account nonce-keypair.json 
+solana nonce-account nonce-keypair.json 
 ```
 
 - Output
@@ -117,7 +117,7 @@ nonce: DZar6t2EaCFQTbUP4DHKwZ1wT8gCPW2aRfkVWhydkBvS
 ```
 
 {% hint style="info" %}
-[Full usage documentation](../api-reference/cli.md#solana-show-nonce-account)
+[Full usage documentation](../api-reference/cli.md#solana-nonce-account)
 {% endhint %}
 
 ### Withdraw Funds from a Nonce Account
@@ -236,7 +236,7 @@ Remember, `alice.json` is the [nonce authority](#nonce-authority) in this exampl
 {% endhint %}
 
 ```bash
-$ solana show-nonce-account nonce.json 
+$ solana nonce-account nonce.json 
 balance: 1 SOL
 minimum balance required: 0.00136416 SOL
 nonce: F7vmkY3DTaxfagttWjQweib42b6ZHADSx94Tw8gHx3W7
@@ -256,7 +256,7 @@ $ solana balance -k bob.json
 1 SOL
 ```
 ```bash
-$ solana show-nonce-account nonce.json 
+$ solana nonce-account nonce.json 
 balance: 1 SOL
 minimum balance required: 0.00136416 SOL
 nonce: 6bjroqDcZgTv6Vavhqf81oBHTv3aMnX19UTB51YhAZnN

--- a/book/src/running-archiver.md
+++ b/book/src/running-archiver.md
@@ -149,8 +149,8 @@ From another console, confirm the IP address and **identity pubkey** of your arc
 solana-gossip spy --entrypoint testnet.solana.com:8001
 ```
 
-Provide the **storage account pubkey** to the `solana show-storage-account` command to view the recent mining activity from your archiver:
+Provide the **storage account pubkey** to the `solana storage-account` command to view the recent mining activity from your archiver:
 
 ```bash
-solana --keypair storage-keypair.json show-storage-account $STORAGE_IDENTITY
+solana --keypair storage-keypair.json storage-account $STORAGE_IDENTITY
 ```

--- a/book/src/running-validator/validator-monitor.md
+++ b/book/src/running-validator/validator-monitor.md
@@ -21,11 +21,11 @@ solana balance --lamports
 
 ## Check Vote Activity
 
-The `solana show-vote-account` command displays the recent voting activity from
+The `solana vote-account` command displays the recent voting activity from
 your validator:
 
 ```bash
-solana show-vote-account ~/validator-vote-keypair.json
+solana vote-account ~/validator-vote-keypair.json
 ```
 
 ## Get Cluster Info

--- a/book/src/running-validator/validator-stake.md
+++ b/book/src/running-validator/validator-stake.md
@@ -85,11 +85,11 @@ so it can take an hour or more for stake to come fully online.
 
 To monitor your validator during its warmup period:
 
-* View your vote account:`solana show-vote-account ~/validator-vote-keypair.json` This displays the current state of all the votes the validator has submitted to the network.
-* View your stake account, the delegation preference and details of your stake:`solana show-stake-account ~/validator-stake-keypair.json`
+* View your vote account:`solana vote-account ~/validator-vote-keypair.json` This displays the current state of all the votes the validator has submitted to the network.
+* View your stake account, the delegation preference and details of your stake:`solana stake-account ~/validator-stake-keypair.json`
 * `solana uptime ~/validator-vote-keypair.json` will display the voting history \(aka, uptime\) of your validator over recent Epochs
-* `solana show-validators` displays the current active stake of all validators, including yours
-* `solana show-stake-history ` shows the history of stake warming up and cooling down over recent epochs
+* `solana validators` displays the current active stake of all validators, including yours
+* `solana stake-history ` shows the history of stake warming up and cooling down over recent epochs
 * Look for log messages on your validator indicating your next leader slot: `[2019-09-27T20:16:00.319721164Z INFO solana_core::replay_stage] <VALIDATOR_IDENTITY_PUBKEY> voted and reset PoH at tick height ####. My next leader slot is ####`
 * Once your stake is warmed up, you will see a stake balance listed for your validator on the [Solana Network Explorer](http://explorer.solana.com/validators)
 

--- a/book/src/running-validator/validator-start.md
+++ b/book/src/running-validator/validator-start.md
@@ -18,7 +18,7 @@ Before attaching a validator node, sanity check that the cluster is accessible
 to your machine by fetching the transaction count:
 
 ```bash
-solana get-transaction-count
+solana transaction-count
 ```
 
 Inspect the network explorer at

--- a/ci/localnet-sanity.sh
+++ b/ci/localnet-sanity.sh
@@ -179,7 +179,7 @@ startNodes() {
       (
         set -x
         $solana_cli --keypair config/bootstrap-leader/identity-keypair.json \
-          --url http://127.0.0.1:8899 get-genesis-hash
+          --url http://127.0.0.1:8899 genesis-hash
       ) | tee genesis-hash.log
       maybeExpectedGenesisHash="--expected-genesis-hash $(tail -n1 genesis-hash.log)"
     fi

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -370,28 +370,28 @@ pub fn parse_command(matches: &ArgMatches<'_>) -> Result<CliCommandInfo, Box<dyn
             command: CliCommand::Fees,
             require_keypair: false,
         }),
-        ("get-block-time", Some(matches)) => parse_get_block_time(matches),
-        ("get-epoch-info", Some(matches)) => parse_get_epoch_info(matches),
-        ("get-genesis-hash", Some(_matches)) => Ok(CliCommandInfo {
+        ("block-time", Some(matches)) => parse_get_block_time(matches),
+        ("epoch-info", Some(matches)) => parse_get_epoch_info(matches),
+        ("genesis-hash", Some(_matches)) => Ok(CliCommandInfo {
             command: CliCommand::GetGenesisHash,
             require_keypair: false,
         }),
-        ("get-slot", Some(matches)) => parse_get_slot(matches),
-        ("get-transaction-count", Some(matches)) => parse_get_transaction_count(matches),
+        ("slot", Some(matches)) => parse_get_slot(matches),
+        ("transaction-count", Some(matches)) => parse_get_transaction_count(matches),
         ("ping", Some(matches)) => parse_cluster_ping(matches),
-        ("show-block-production", Some(matches)) => parse_show_block_production(matches),
-        ("show-gossip", Some(_matches)) => Ok(CliCommandInfo {
+        ("block-production", Some(matches)) => parse_show_block_production(matches),
+        ("gossip", Some(_matches)) => Ok(CliCommandInfo {
             command: CliCommand::ShowGossip,
             require_keypair: false,
         }),
-        ("show-stakes", Some(matches)) => parse_show_stakes(matches),
-        ("show-validators", Some(matches)) => parse_show_validators(matches),
+        ("stakes", Some(matches)) => parse_show_stakes(matches),
+        ("validators", Some(matches)) => parse_show_validators(matches),
         // Nonce Commands
         ("authorize-nonce-account", Some(matches)) => parse_authorize_nonce_account(matches),
         ("create-nonce-account", Some(matches)) => parse_nonce_create_account(matches),
-        ("get-nonce", Some(matches)) => parse_get_nonce(matches),
+        ("nonce", Some(matches)) => parse_get_nonce(matches),
         ("new-nonce", Some(matches)) => parse_new_nonce(matches),
-        ("show-nonce-account", Some(matches)) => parse_show_nonce_account(matches),
+        ("nonce-account", Some(matches)) => parse_show_nonce_account(matches),
         ("withdraw-from-nonce-account", Some(matches)) => {
             parse_withdraw_from_nonce_account(matches)
         }
@@ -412,8 +412,8 @@ pub fn parse_command(matches: &ArgMatches<'_>) -> Result<CliCommandInfo, Box<dyn
             parse_stake_authorize(matches, StakeAuthorize::Withdrawer)
         }
         ("redeem-vote-credits", Some(matches)) => parse_redeem_vote_credits(matches),
-        ("show-stake-account", Some(matches)) => parse_show_stake_account(matches),
-        ("show-stake-history", Some(matches)) => parse_show_stake_history(matches),
+        ("stake-account", Some(matches)) => parse_show_stake_account(matches),
+        ("stake-history", Some(matches)) => parse_show_stake_history(matches),
         // Storage Commands
         ("create-archiver-storage-account", Some(matches)) => {
             parse_storage_create_archiver_account(matches)
@@ -422,17 +422,11 @@ pub fn parse_command(matches: &ArgMatches<'_>) -> Result<CliCommandInfo, Box<dyn
             parse_storage_create_validator_account(matches)
         }
         ("claim-storage-reward", Some(matches)) => parse_storage_claim_reward(matches),
-        ("show-storage-account", Some(matches)) => parse_storage_get_account_command(matches),
+        ("storage-account", Some(matches)) => parse_storage_get_account_command(matches),
         // Validator Info Commands
         ("validator-info", Some(matches)) => match matches.subcommand() {
             ("publish", Some(matches)) => parse_validator_info_command(matches),
             ("get", Some(matches)) => parse_get_validator_info_command(matches),
-            ("", None) => {
-                eprintln!("{}", matches.usage());
-                Err(CliError::CommandNotRecognized(
-                    "no validator-info subcommand given".to_string(),
-                ))
-            }
             _ => unreachable!(),
         },
         // Vote Commands
@@ -444,7 +438,7 @@ pub fn parse_command(matches: &ArgMatches<'_>) -> Result<CliCommandInfo, Box<dyn
         ("vote-authorize-withdrawer", Some(matches)) => {
             parse_vote_authorize(matches, VoteAuthorize::Withdrawer)
         }
-        ("show-vote-account", Some(matches)) => parse_vote_get_account_command(matches),
+        ("vote-account", Some(matches)) => parse_vote_get_account_command(matches),
         ("uptime", Some(matches)) => parse_vote_uptime_command(matches),
         // Wallet Commands
         ("address", Some(_matches)) => Ok(CliCommandInfo {
@@ -560,7 +554,7 @@ pub fn parse_command(matches: &ArgMatches<'_>) -> Result<CliCommandInfo, Box<dyn
                 require_keypair: true,
             })
         }
-        ("show-account", Some(matches)) => {
+        ("account", Some(matches)) => {
             let account_pubkey = pubkey_of(matches, "account_pubkey").unwrap();
             let output_file = matches.value_of("output_file");
             let use_lamports_unit = matches.is_present("lamports");
@@ -2003,8 +1997,9 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                 ),
         )
         .subcommand(
-            SubCommand::with_name("show-account")
+            SubCommand::with_name("account")
                 .about("Show the contents of an account")
+                .alias("account")
                 .arg(
                     Arg::with_name("account_pubkey")
                         .index(1)

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -55,8 +55,9 @@ impl ClusterQuerySubCommands for App<'_, '_> {
                 .about("Get the version of the cluster entrypoint"),
         )
         .subcommand(SubCommand::with_name("fees").about("Display current cluster fees"))
-        .subcommand(SubCommand::with_name("get-block-time")
+        .subcommand(SubCommand::with_name("block-time")
             .about("Get estimated production time of a block")
+            .alias("get-block-time")
             .arg(
                 Arg::with_name("slot")
                     .index(1)
@@ -67,8 +68,9 @@ impl ClusterQuerySubCommands for App<'_, '_> {
             )
         )
         .subcommand(
-            SubCommand::with_name("get-epoch-info")
+            SubCommand::with_name("epoch-info")
             .about("Get information about the current epoch")
+            .alias("get-epoch-info")
             .arg(
                 Arg::with_name("confirmed")
                     .long("confirmed")
@@ -79,10 +81,13 @@ impl ClusterQuerySubCommands for App<'_, '_> {
             ),
         )
         .subcommand(
-            SubCommand::with_name("get-genesis-hash").about("Get the genesis hash"),
+            SubCommand::with_name("genesis-hash")
+            .about("Get the genesis hash")
+            .alias("get-genesis-hash")
         )
         .subcommand(
-            SubCommand::with_name("get-slot").about("Get current slot")
+            SubCommand::with_name("slot").about("Get current slot")
+            .alias("get-slot")
             .arg(
                 Arg::with_name("confirmed")
                     .long("confirmed")
@@ -93,7 +98,8 @@ impl ClusterQuerySubCommands for App<'_, '_> {
             ),
         )
         .subcommand(
-            SubCommand::with_name("get-transaction-count").about("Get current transaction count")
+            SubCommand::with_name("transaction-count").about("Get current transaction count")
+            .alias("get-transaction-count")
             .arg(
                 Arg::with_name("confirmed")
                     .long("confirmed")
@@ -151,8 +157,9 @@ impl ClusterQuerySubCommands for App<'_, '_> {
                 ),
         )
         .subcommand(
-            SubCommand::with_name("show-block-production")
+            SubCommand::with_name("block-production")
                 .about("Show information about block production")
+                .alias("show-block-production")
                 .arg(
                     Arg::with_name("epoch")
                         .long("epoch")
@@ -167,11 +174,12 @@ impl ClusterQuerySubCommands for App<'_, '_> {
                 ),
         )
         .subcommand(
-            SubCommand::with_name("show-gossip")
-                .about("Show the current gossip network nodes"),
+            SubCommand::with_name("gossip")
+                .about("Show the current gossip network nodes")
+                .alias("show-gossip")
         )
         .subcommand(
-            SubCommand::with_name("show-stakes")
+            SubCommand::with_name("stakes")
                 .about("Show stake account information")
                 .arg(
                     Arg::with_name("vote_account_pubkeys")
@@ -190,8 +198,9 @@ impl ClusterQuerySubCommands for App<'_, '_> {
                 ),
         )
         .subcommand(
-            SubCommand::with_name("show-validators")
+            SubCommand::with_name("validators")
                 .about("Show summary information about the current validators")
+                .alias("show-validators")
                 .arg(
                     Arg::with_name("lamports")
                         .long("lamports")
@@ -985,11 +994,10 @@ mod tests {
         );
 
         let slot = 100;
-        let test_get_block_time = test_commands.clone().get_matches_from(vec![
-            "test",
-            "get-block-time",
-            &slot.to_string(),
-        ]);
+        let test_get_block_time =
+            test_commands
+                .clone()
+                .get_matches_from(vec!["test", "block-time", &slot.to_string()]);
         assert_eq!(
             parse_command(&test_get_block_time).unwrap(),
             CliCommandInfo {
@@ -1000,7 +1008,7 @@ mod tests {
 
         let test_get_epoch_info = test_commands
             .clone()
-            .get_matches_from(vec!["test", "get-epoch-info"]);
+            .get_matches_from(vec!["test", "epoch-info"]);
         assert_eq!(
             parse_command(&test_get_epoch_info).unwrap(),
             CliCommandInfo {
@@ -1013,7 +1021,7 @@ mod tests {
 
         let test_get_genesis_hash = test_commands
             .clone()
-            .get_matches_from(vec!["test", "get-genesis-hash"]);
+            .get_matches_from(vec!["test", "genesis-hash"]);
         assert_eq!(
             parse_command(&test_get_genesis_hash).unwrap(),
             CliCommandInfo {
@@ -1022,9 +1030,7 @@ mod tests {
             }
         );
 
-        let test_get_slot = test_commands
-            .clone()
-            .get_matches_from(vec!["test", "get-slot"]);
+        let test_get_slot = test_commands.clone().get_matches_from(vec!["test", "slot"]);
         assert_eq!(
             parse_command(&test_get_slot).unwrap(),
             CliCommandInfo {
@@ -1037,7 +1043,7 @@ mod tests {
 
         let test_transaction_count = test_commands
             .clone()
-            .get_matches_from(vec!["test", "get-transaction-count"]);
+            .get_matches_from(vec!["test", "transaction-count"]);
         assert_eq!(
             parse_command(&test_transaction_count).unwrap(),
             CliCommandInfo {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,4 +1,4 @@
-use clap::{crate_description, crate_name, Arg, ArgGroup, ArgMatches, SubCommand};
+use clap::{crate_description, crate_name, AppSettings, Arg, ArgGroup, ArgMatches, SubCommand};
 use console::style;
 
 use solana_clap_utils::{
@@ -19,58 +19,61 @@ use std::error;
 
 fn parse_settings(matches: &ArgMatches<'_>) -> Result<bool, Box<dyn error::Error>> {
     let parse_args = match matches.subcommand() {
-        ("get", Some(subcommand_matches)) => {
-            if let Some(config_file) = matches.value_of("config_file") {
-                let config = Config::load(config_file).unwrap_or_default();
-                if let Some(field) = subcommand_matches.value_of("specific_setting") {
-                    let (value, default_value) = match field {
-                        "url" => (config.url, CliConfig::default_json_rpc_url()),
-                        "keypair" => (config.keypair_path, CliConfig::default_keypair_path()),
-                        _ => unreachable!(),
-                    };
-                    println_name_value_or(&format!("* {}:", field), &value, &default_value);
+        ("config", Some(matches)) => match matches.subcommand() {
+            ("get", Some(subcommand_matches)) => {
+                if let Some(config_file) = matches.value_of("config_file") {
+                    let config = Config::load(config_file).unwrap_or_default();
+                    if let Some(field) = subcommand_matches.value_of("specific_setting") {
+                        let (value, default_value) = match field {
+                            "url" => (config.url, CliConfig::default_json_rpc_url()),
+                            "keypair" => (config.keypair_path, CliConfig::default_keypair_path()),
+                            _ => unreachable!(),
+                        };
+                        println_name_value_or(&format!("* {}:", field), &value, &default_value);
+                    } else {
+                        println_name_value("Wallet Config:", config_file);
+                        println_name_value_or(
+                            "* url:",
+                            &config.url,
+                            &CliConfig::default_json_rpc_url(),
+                        );
+                        println_name_value_or(
+                            "* keypair:",
+                            &config.keypair_path,
+                            &CliConfig::default_keypair_path(),
+                        );
+                    }
                 } else {
-                    println_name_value("Wallet Config:", config_file);
-                    println_name_value_or(
-                        "* url:",
-                        &config.url,
-                        &CliConfig::default_json_rpc_url(),
-                    );
-                    println_name_value_or(
-                        "* keypair:",
-                        &config.keypair_path,
-                        &CliConfig::default_keypair_path(),
+                    println!(
+                        "{} Either provide the `--config` arg or ensure home directory exists to use the default config location",
+                        style("No config file found.").bold()
                     );
                 }
-            } else {
-                println!(
-                    "{} Either provide the `--config` arg or ensure home directory exists to use the default config location",
-                    style("No config file found.").bold()
-                );
+                false
             }
-            false
-        }
-        ("set", Some(subcommand_matches)) => {
-            if let Some(config_file) = matches.value_of("config_file") {
-                let mut config = Config::load(config_file).unwrap_or_default();
-                if let Some(url) = subcommand_matches.value_of("json_rpc_url") {
-                    config.url = url.to_string();
+            ("set", Some(subcommand_matches)) => {
+                if let Some(config_file) = matches.value_of("config_file") {
+                    let mut config = Config::load(config_file).unwrap_or_default();
+                    if let Some(url) = subcommand_matches.value_of("json_rpc_url") {
+                        config.url = url.to_string();
+                    }
+                    if let Some(keypair) = subcommand_matches.value_of("keypair") {
+                        config.keypair_path = keypair.to_string();
+                    }
+                    config.save(config_file)?;
+                    println_name_value("Wallet Config Updated:", config_file);
+                    println_name_value("* url:", &config.url);
+                    println_name_value("* keypair:", &config.keypair_path);
+                } else {
+                    println!(
+                        "{} Either provide the `--config` arg or ensure home directory exists to use the default config location",
+                        style("No config file found.").bold()
+                    );
                 }
-                if let Some(keypair) = subcommand_matches.value_of("keypair") {
-                    config.keypair_path = keypair.to_string();
-                }
-                config.save(config_file)?;
-                println_name_value("Wallet Config Updated:", config_file);
-                println_name_value("* url:", &config.url);
-                println_name_value("* keypair:", &config.keypair_path);
-            } else {
-                println!(
-                    "{} Either provide the `--config` arg or ensure home directory exists to use the default config location",
-                    style("No config file found.").bold()
-                );
+                false
             }
-            false
-        }
+            _ => unreachable!(),
+        },
         _ => true,
     };
     Ok(parse_args)
@@ -207,25 +210,31 @@ fn main() -> Result<(), Box<dyn error::Error>> {
             .help(SKIP_SEED_PHRASE_VALIDATION_ARG.help),
     )
     .subcommand(
-        SubCommand::with_name("get")
-            .about("Get cli config settings")
-            .arg(
-                Arg::with_name("specific_setting")
-                    .index(1)
-                    .value_name("CONFIG_FIELD")
-                    .takes_value(true)
-                    .possible_values(&["url", "keypair"])
-                    .help("Return a specific config setting"),
-            ),
-    )
-    .subcommand(
-        SubCommand::with_name("set")
-            .about("Set a cli config setting")
-            .group(
-                ArgGroup::with_name("config_settings")
-                    .args(&["json_rpc_url", "keypair"])
-                    .multiple(true)
-                    .required(true),
+        SubCommand::with_name("config")
+            .about("Solana command-line tool configuration settings")
+            .aliases(&["get", "set"])
+            .setting(AppSettings::SubcommandRequiredElseHelp)
+            .subcommand(
+                SubCommand::with_name("get")
+                    .about("Get current config settings")
+                    .arg(
+                        Arg::with_name("specific_setting")
+                            .index(1)
+                            .value_name("CONFIG_FIELD")
+                            .takes_value(true)
+                            .possible_values(&["url", "keypair"])
+                            .help("Return a specific config setting"),
+                    ),
+            )
+            .subcommand(
+                SubCommand::with_name("set")
+                    .about("Set a config setting")
+                    .group(
+                        ArgGroup::with_name("config_settings")
+                            .args(&["json_rpc_url", "keypair"])
+                            .multiple(true)
+                            .required(true),
+                    ),
             ),
     )
     .get_matches();

--- a/cli/src/nonce.rs
+++ b/cli/src/nonce.rs
@@ -129,8 +129,9 @@ impl NonceSubCommands for App<'_, '_> {
                 ),
         )
         .subcommand(
-            SubCommand::with_name("get-nonce")
+            SubCommand::with_name("nonce")
                 .about("Get the current nonce value")
+                .alias("get-nonce")
                 .arg(
                     Arg::with_name("nonce_account_pubkey")
                         .index(1)
@@ -156,8 +157,9 @@ impl NonceSubCommands for App<'_, '_> {
                 .arg(nonce_authority_arg()),
         )
         .subcommand(
-            SubCommand::with_name("show-nonce-account")
+            SubCommand::with_name("nonce-account")
                 .about("Show the contents of a nonce account")
+                .alias("show-nonce-account")
                 .arg(
                     Arg::with_name("nonce_account_pubkey")
                         .index(1)
@@ -756,7 +758,7 @@ mod tests {
         // Test ShowNonceAccount Subcommand
         let test_show_nonce_account = test_commands.clone().get_matches_from(vec![
             "test",
-            "show-nonce-account",
+            "nonce-account",
             &nonce_account_string,
         ]);
         assert_eq!(

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -455,8 +455,9 @@ impl StakeSubCommands for App<'_, '_> {
                 )
         )
         .subcommand(
-            SubCommand::with_name("show-stake-account")
+            SubCommand::with_name("stake-account")
                 .about("Show the contents of a stake account")
+                .alias("show-stake-account")
                 .arg(
                     Arg::with_name("stake_account_pubkey")
                         .index(1)
@@ -474,8 +475,9 @@ impl StakeSubCommands for App<'_, '_> {
                 )
         )
         .subcommand(
-            SubCommand::with_name("show-stake-history")
+            SubCommand::with_name("stake-history")
                 .about("Show the stake history")
+                .alias("show-stake-history")
                 .arg(
                     Arg::with_name("lamports")
                         .long("lamports")

--- a/cli/src/storage.rs
+++ b/cli/src/storage.rs
@@ -81,8 +81,9 @@ impl StorageSubCommands for App<'_, '_> {
                 ),
         )
         .subcommand(
-            SubCommand::with_name("show-storage-account")
+            SubCommand::with_name("storage-account")
                 .about("Show the contents of a storage account")
+                .alias("show-storage-account")
                 .arg(
                     Arg::with_name("storage_account_pubkey")
                         .index(1)

--- a/cli/src/validator_info.rs
+++ b/cli/src/validator_info.rs
@@ -3,7 +3,7 @@ use crate::{
     display::println_name_value,
 };
 use bincode::deserialize;
-use clap::{App, Arg, ArgMatches, SubCommand};
+use clap::{App, AppSettings, Arg, ArgMatches, SubCommand};
 use reqwest::blocking::Client;
 use serde_derive::{Deserialize, Serialize};
 use serde_json::{Map, Value};
@@ -151,6 +151,7 @@ impl ValidatorInfoSubCommands for App<'_, '_> {
         self.subcommand(
             SubCommand::with_name("validator-info")
                 .about("Publish/get Validator info on Solana")
+                .setting(AppSettings::SubcommandRequiredElseHelp)
                 .subcommand(
                     SubCommand::with_name("publish")
                         .about("Publish Validator info on Solana")

--- a/cli/src/vote.rs
+++ b/cli/src/vote.rs
@@ -157,8 +157,9 @@ impl VoteSubCommands for App<'_, '_> {
                 ),
         )
         .subcommand(
-            SubCommand::with_name("show-vote-account")
+            SubCommand::with_name("vote-account")
                 .about("Show the contents of a vote account")
+                .alias("show-vote-account")
                 .arg(
                     Arg::with_name("vote_account_pubkey")
                         .index(1)

--- a/gossip/src/main.rs
+++ b/gossip/src/main.rs
@@ -20,7 +20,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
         .version(solana_clap_utils::version!())
         .setting(AppSettings::SubcommandRequiredElseHelp)
         .subcommand(
-            SubCommand::with_name("get-rpc-url")
+            SubCommand::with_name("rpc-url")
                 .about("Get an RPC URL for the cluster")
                 .arg(
                     Arg::with_name("entrypoint")
@@ -243,7 +243,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                 }
             }
         }
-        ("get-rpc-url", Some(matches)) => {
+        ("rpc-url", Some(matches)) => {
             let any = matches.is_present("any");
             let all = matches.is_present("all");
             let entrypoint_addr = parse_entrypoint(&matches);

--- a/multinode-demo/archiver.sh
+++ b/multinode-demo/archiver.sh
@@ -56,7 +56,7 @@ done
 : "${storage_keypair:="$SOLANA_ROOT"/farf/archiver-storage-keypair"$label".json}"
 ledger="$SOLANA_ROOT"/farf/archiver-ledger"$label"
 
-rpc_url=$($solana_gossip get-rpc-url --entrypoint "$entrypoint")
+rpc_url=$($solana_gossip rpc-url --entrypoint "$entrypoint")
 
 if [[ ! -r $identity_keypair ]]; then
   $solana_keygen new --no-passphrase -so "$identity_keypair"

--- a/multinode-demo/delegate-stake.sh
+++ b/multinode-demo/delegate-stake.sh
@@ -100,9 +100,9 @@ $solana_keygen new --no-passphrase -so "$stake_keypair_path"
 
 set -x
 $solana_cli "${common_args[@]}" \
-  show-vote-account "$vote_keypair_path"
+  vote-account "$vote_keypair_path"
 $solana_cli "${common_args[@]}" \
   create-stake-account "$stake_keypair_path" "$stake_lamports" lamports
 $solana_cli "${common_args[@]}" \
   delegate-stake $maybe_force "$stake_keypair_path" "$vote_keypair_path"
-$solana_cli "${common_args[@]}" show-stake-account "$stake_keypair_path"
+$solana_cli "${common_args[@]}" stake-account "$stake_keypair_path"

--- a/multinode-demo/validator.sh
+++ b/multinode-demo/validator.sh
@@ -250,7 +250,7 @@ wallet() {
 setup_validator_accounts() {
   declare node_lamports=$1
 
-  if ! wallet show-vote-account "$voting_keypair_path"; then
+  if ! wallet vote-account "$voting_keypair_path"; then
     if ((airdrops_enabled)); then
       echo "Adding $node_lamports to validator identity account:"
       wallet airdrop "$node_lamports" lamports || return $?
@@ -261,7 +261,7 @@ setup_validator_accounts() {
   fi
   echo "Validator vote account configured"
 
-  if ! wallet show-storage-account "$storage_keypair_path"; then
+  if ! wallet storage-account "$storage_keypair_path"; then
     echo "Creating validator storage account"
     wallet create-validator-storage-account "$identity_keypair_path" "$storage_keypair_path" || return $?
   fi
@@ -273,7 +273,7 @@ setup_validator_accounts() {
   return 0
 }
 
-rpc_url=$($solana_gossip get-rpc-url --entrypoint "$gossip_entrypoint" --any)
+rpc_url=$($solana_gossip rpc-url --entrypoint "$gossip_entrypoint" --any)
 
 [[ -r "$identity_keypair_path" ]] || $solana_keygen new --no-passphrase -so "$identity_keypair_path"
 [[ -r "$voting_keypair_path" ]] || $solana_keygen new --no-passphrase -so "$voting_keypair_path"

--- a/net/remote/remote-sanity.sh
+++ b/net/remote/remote-sanity.sh
@@ -85,7 +85,7 @@ fi
 echo "+++ $sanityTargetIp: validators"
 (
   set -x
-  $solana_cli --url http://"$sanityTargetIp":8899 show-validators
+  $solana_cli --url http://"$sanityTargetIp":8899 validators
 )
 
 echo "+++ $sanityTargetIp: node count ($numSanityNodes expected)"

--- a/scripts/wallet-sanity.sh
+++ b/scripts/wallet-sanity.sh
@@ -20,7 +20,7 @@ $solana_keygen new --no-passphrase -sf
 node_readiness=false
 timeout=60
 while [[ $timeout -gt 0 ]]; do
-  output=$($solana_cli "${args[@]}" get-transaction-count)
+  output=$($solana_cli "${args[@]}" transaction-count)
   if [[ -n $output ]]; then
     node_readiness=true
     break

--- a/system-test/testnet-automation.sh
+++ b/system-test/testnet-automation.sh
@@ -59,7 +59,7 @@ function wait_for_bootstrap_leader_stake_drop {
   loadConfigFile
 
   while true; do
-    bootstrap_leader_validator_info="$(ssh "${sshOptions[@]}" "${validatorIpList[0]}" '$HOME/.cargo/bin/solana show-validators | grep "$($HOME/.cargo/bin/solana-keygen pubkey ~/solana/config/bootstrap-leader/identity-keypair.json)"')"
+    bootstrap_leader_validator_info="$(ssh "${sshOptions[@]}" "${validatorIpList[0]}" '$HOME/.cargo/bin/solana validators | grep "$($HOME/.cargo/bin/solana-keygen pubkey ~/solana/config/bootstrap-leader/identity-keypair.json)"')"
     bootstrap_leader_stake_percentage="$(echo "$bootstrap_leader_validator_info" | awk '{gsub(/[\(,\),\%]/,""); print $9}')"
 
     if [[ $(echo "$bootstrap_leader_stake_percentage < $max_stake" | bc) -ne 0 ]]; then


### PR DESCRIPTION
`show-` and `get-` have been purged from all cli commands, with hidden aliases for the previous values for a seamless migration.

The migration for `solana get` and `solana set` are not as nice: `solana get` and `solana set` have been replaced with `solana config get` and `solana config set`, and using the old get/set will hit the help for `solana config`.  This'll cause some minor support hiccups once v0.23 ships

Fixes #7873
