### PR TITLE
Secure sysvars under hash by freezing all strictly

### DIFF
--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -664,7 +664,6 @@ mod tests {
     use solana_sdk::rent::Rent;
     use solana_sdk::signature::{Keypair, KeypairUtil};
     use solana_sdk::system_program;
-    use solana_sdk::sysvar;
     use solana_sdk::transaction::Transaction;
     use std::io::Cursor;
     use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
@@ -1292,14 +1291,6 @@ mod tests {
     #[should_panic]
     fn test_accounts_empty_bank_hash() {
         let accounts = Accounts::new(Vec::new());
-        accounts.bank_hash_at(0);
-    }
-
-    #[test]
-    #[should_panic]
-    fn test_accounts_empty_account_bank_hash() {
-        let accounts = Accounts::new(Vec::new());
-        accounts.store_slow(0, &Pubkey::default(), &Account::new(1, 0, &sysvar::id()));
         accounts.bank_hash_at(0);
     }
 

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -760,8 +760,8 @@ impl AccountsDB {
             .expect("accounts_db::set_hash::no parent slot");
         if bank_hashes.get(&slot).is_some() {
             error!(
-                "set_hash: already exists; forks with same child slot: {}!?",
-                slot
+                "set_hash: already exists; multiple forks with shared slot {} as child (parent: {})!?",
+                slot, parent_slot,
             );
             return;
         }

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -38,7 +38,6 @@ use solana_sdk::bank_hash::BankHash;
 use solana_sdk::clock::{Epoch, Slot};
 use solana_sdk::hash::{Hash, Hasher};
 use solana_sdk::pubkey::Pubkey;
-use solana_sdk::sysvar;
 use std::collections::{HashMap, HashSet};
 use std::fmt;
 use std::io::{BufReader, Cursor, Error as IOError, ErrorKind, Read, Result as IOResult};
@@ -1028,18 +1027,16 @@ impl AccountsDB {
             |(collector, mismatch_found): &mut (Vec<BankHash>, bool),
              option: Option<(&Pubkey, Account, Slot)>| {
                 if let Some((pubkey, account, slot)) = option {
-                    if !sysvar::check_id(&account.owner) {
-                        let hash = Self::hash_account(slot, &account, pubkey);
-                        if hash != account.hash {
-                            *mismatch_found = true;
-                        }
-                        if *mismatch_found {
-                            return;
-                        }
-                        let hash = BankHash::from_hash(&hash);
-                        debug!("xoring..{} key: {}", hash, pubkey);
-                        collector.push(hash);
+                    let hash = Self::hash_account(slot, &account, pubkey);
+                    if hash != account.hash {
+                        *mismatch_found = true;
                     }
+                    if *mismatch_found {
+                        return;
+                    }
+                    let hash = BankHash::from_hash(&hash);
+                    debug!("xoring..{} key: {}", hash, pubkey);
+                    collector.push(hash);
                 }
             },
         );
@@ -1162,26 +1159,22 @@ impl AccountsDB {
         let hashes: Vec<_> = accounts
             .iter()
             .map(|(pubkey, account)| {
-                if !sysvar::check_id(&account.owner) {
-                    let hash = BankHash::from_hash(&account.hash);
-                    stats.update(account);
-                    let new_hash = Self::hash_account(slot_id, account, pubkey);
-                    let new_bank_hash = BankHash::from_hash(&new_hash);
-                    debug!(
-                        "hash_accounts: key: {} xor {} current: {}",
-                        pubkey, hash, hash_state
-                    );
-                    if !had_account {
-                        hash_state = hash;
-                        had_account = true;
-                    } else {
-                        hash_state.xor(hash);
-                    }
-                    hash_state.xor(new_bank_hash);
-                    new_hash
+                let hash = BankHash::from_hash(&account.hash);
+                stats.update(account);
+                let new_hash = Self::hash_account(slot_id, account, pubkey);
+                let new_bank_hash = BankHash::from_hash(&new_hash);
+                debug!(
+                    "hash_accounts: key: {} xor {} current: {}",
+                    pubkey, hash, hash_state
+                );
+                if !had_account {
+                    hash_state = hash;
+                    had_account = true;
                 } else {
-                    Hash::default()
+                    hash_state.xor(hash);
                 }
+                hash_state.xor(new_bank_hash);
+                new_hash
             })
             .collect();
 

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -758,6 +758,14 @@ impl AccountsDB {
         let hash_info = bank_hashes
             .get(&parent_slot)
             .expect("accounts_db::set_hash::no parent slot");
+        if bank_hashes.get(&slot).is_some() {
+            error!(
+                "set_hash: already exists; forks with same child slot: {}!?",
+                slot
+            );
+            return;
+        }
+
         let hash = hash_info.hash;
         let new_hash_info = BankHashInfo {
             hash,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -446,7 +446,7 @@ impl Bank {
             new.ancestors.insert(p.slot(), i + 1);
         });
 
-        new.update_slot_hashes(parent.slot(), parent.hash());
+        new.update_slot_hashes();
         new.update_rewards(parent.epoch());
         new.update_stake_history(Some(parent.epoch()));
         new.update_clock();
@@ -556,13 +556,13 @@ impl Bank {
         });
     }
 
-    fn update_slot_hashes(&self, parent_slot: Slot, parent_hash: Hash) {
+    fn update_slot_hashes(&self) {
         self.update_sysvar_account(&sysvar::slot_hashes::id(), |account| {
             let mut slot_hashes = account
                 .as_ref()
                 .map(|account| SlotHashes::from_account(&account).unwrap())
                 .unwrap_or_default();
-            slot_hashes.add(parent_slot, parent_hash);
+            slot_hashes.add(self.parent_slot, self.parent_hash);
             slot_hashes.create_account(1)
         });
     }
@@ -1717,7 +1717,7 @@ impl Bank {
     //
     // Being idempotent is needed to make the lazy initialization possible,
     // especially for update_slot_hashes at the moment, which can be called
-    // multiple times with the same slot in the case of forking.
+    // multiple times with the same parent_slot in the case of forking.
     //
     // Generally, all of sysvar update granularity should be slot boundaries.
     fn get_cold_account(&self, pubkey: &Pubkey) -> Option<Account> {


### PR DESCRIPTION
#### Problem

`sysvar` account data inside snapshots can be changed without affecting the bank hash (meaning being unable to detect malicious snapshots) because it's excluded from the bank hash calculation.
it's a security risk.
Also, it's desirable to save `sysvar`s in the snapshot instead of not doing so because we can't always dynamically create all of `sysvar`s when starting a validator. Not hashing some of them would relax us from creating deterministically serialized sysvar data; However I've opted not to do so because otherwise we can't guarantee the exact sysvar state when replaying the ledger when debugging ledger inconsistency. And general consistency with normal accounts.


I'm not completely sure the exact reason for the unconditional special handling of all `sysvar`'s exclusion from the bank hash, but I think this is due to some outdated implementation restriction for the historical reasons as far as I glanced the history of git/discord. So, just remove the special handling altogether! :)

#### Summary of changes

Remove the special handling by adjusting sysvar updates and include sysvar accounts into the bank hash calcuration like any other accounts, resulting in beautifier design. :)

To make it possible:
- delay the slot hashes `sysvar`'s update from inside `Bank::freeze()` to `Bank::new_from_parent()` like other sysvar updates.
- Correctly carry previous stateful `sysvar`'s account hash by defining `Bank::update_sysvar_account()`.
- Minor cleanups: unify `set_hash` and `freeze`

#### Todo/Notes

- [x] Write more tests
- [x] Additional cost for sorting and hashing shouldn't be problem?

part of #7167 