### PR TITLE
Delete "testnet participation" redirect

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -3,7 +3,6 @@
 * [Introduction](introduction.md)
 * [Terminology](terminology.md)
 * [Getting Started](getting-started/README.md)
-  * [Testnet Participation](getting-started/testnet-participation.md)
   * [Example Client: Web Wallet](getting-started/webwallet.md)
 * [Programming Model](programs/README.md)
   * [Example: Tic-Tac-Toe](programs/tictactoe.md)

--- a/book/src/getting-started/testnet-participation.md
+++ b/book/src/getting-started/testnet-participation.md
@@ -1,7 +1,0 @@
-# Testnet Participation
-
-Participate in our testnet:
-
-* [Running a Validator](../running-validator/)
-* [Running an Archiver](../running-archiver.md)
-


### PR DESCRIPTION
#### Problem

The book has multiple entrypoints and one of them appears to assume the book is primarily written for potential validators wanting to add a node to a testnet. That's not accurate. The book, in its current form, is for ramping up software developers on the innards of this codebase.

#### Summary of Changes

Remove the "Testnet Participation" redirect from an otherwise developer-oriented "Getting Started" section.