### PR TITLE
Add and use minimumLedgerSlot RPC API in block-production command

### DIFF
--- a/book/src/api-reference/jsonrpc-api.md
+++ b/book/src/api-reference/jsonrpc-api.md
@@ -40,6 +40,7 @@ To interact with a Solana node inside a JavaScript application, use the [solana-
 * [getTotalSupply](jsonrpc-api.md#gettotalsupply)
 * [getVersion](jsonrpc-api.md#getversion)
 * [getVoteAccounts](jsonrpc-api.md#getvoteaccounts)
+* [minimumLedgerSlot](jsonrpc-api.md#minimumledgerslot)
 * [requestAirdrop](jsonrpc-api.md#requestairdrop)
 * [sendTransaction](jsonrpc-api.md#sendtransaction)
 * [startSubscriptionChannel](jsonrpc-api.md#startsubscriptionchannel)
@@ -585,7 +586,7 @@ Returns the current slot the node is processing
 curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1, "method":"getSlot"}' http://localhost:8899
 
 // Result
-{"jsonrpc":"2.0","result":"1234","id":1}
+{"jsonrpc":"2.0","result":1234,"id":1}
 ```
 
 ### getSlotLeader
@@ -628,7 +629,7 @@ Returns the current storage segment size in terms of slots
 // Request
 curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1, "method":"getSlotsPerSegment"}' http://localhost:8899
 // Result
-{"jsonrpc":"2.0","result":"1024","id":1}
+{"jsonrpc":"2.0","result":1024,"id":1}
 ```
 
 ### getStorageTurn
@@ -770,6 +771,29 @@ curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1, "m
 
 // Result
 {"jsonrpc":"2.0","result":{"current":[{"commission":0,"epochVoteAccount":true,"nodePubkey":"B97CCUW3AEZFGy6uUg6zUdnNYvnVq5VG8PUtb2HayTDD","lastVote":147,"activatedStake":42,"votePubkey":"3ZT31jkAGhUaw8jsy4bTknwBMP8i4Eueh52By4zXcsVw"}],"delinquent":[{"commission":127,"epochVoteAccount":false,"nodePubkey":"6ZPxeQaDo4bkZLRsdNrCzchNQr5LN9QMc9sipXv9Kw8f","lastVote":0,"activatedStake":0,"votePubkey":"CmgCk4aMS7KW1SHX3s9K5tBJ6Yng2LBaC8MFov4wx9sm"}]},"id":1}
+```
+
+### minimumLedgerSlot
+
+Returns the lowest slot that the node has information about in its ledger.  This
+value may increase over time if the node is configured to purge older ledger data
+
+#### Parameters:
+
+None
+
+#### Results:
+
+* `u64` - Minimum ledger slot
+
+#### Example:
+
+```bash
+// Request
+curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1, "method":"minimumLedgerSlot"}' http://localhost:8899
+
+// Result
+{"jsonrpc":"2.0","result":1234,"id":1}
 ```
 
 ### requestAirdrop

--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -386,6 +386,25 @@ impl RpcClient {
         })
     }
 
+    pub fn minimum_ledger_slot(&self) -> io::Result<Slot> {
+        let response = self
+            .client
+            .send(&RpcRequest::MinimumLedgerSlot, Value::Null, 0)
+            .map_err(|err| {
+                io::Error::new(
+                    io::ErrorKind::Other,
+                    format!("MinimumLedgerSlot request failure: {:?}", err),
+                )
+            })?;
+
+        serde_json::from_value(response).map_err(|err| {
+            io::Error::new(
+                io::ErrorKind::Other,
+                format!("MinimumLedgerSlot parse failure: {}", err),
+            )
+        })
+    }
+
     pub fn send_and_confirm_transaction<T: KeypairUtil>(
         &self,
         transaction: &mut Transaction,

--- a/client/src/rpc_request.rs
+++ b/client/src/rpc_request.rs
@@ -35,6 +35,7 @@ pub enum RpcRequest {
     SendTransaction,
     SignVote,
     GetMinimumBalanceForRentExemption,
+    MinimumLedgerSlot,
 }
 
 impl RpcRequest {
@@ -75,6 +76,7 @@ impl RpcRequest {
             RpcRequest::SendTransaction => "sendTransaction",
             RpcRequest::SignVote => "signVote",
             RpcRequest::GetMinimumBalanceForRentExemption => "getMinimumBalanceForRentExemption",
+            RpcRequest::MinimumLedgerSlot => "minimumLedgerSlot",
         };
         json!({
            "jsonrpc": jsonrpc,


### PR DESCRIPTION
`solana block-production` is broken with longer epoch due to `--limit-ledger-size`'s purging of ledger slots.   With the addition of the `minimumLedgerSlot` RPC API, `solana block-production` can now detect and handle requests for purged blocks.