### PR TITLE
CLI: Support offline authorities

### DIFF
--- a/clap-utils/src/input_validators.rs
+++ b/clap-utils/src/input_validators.rs
@@ -43,6 +43,11 @@ pub fn is_pubkey_or_keypair(string: String) -> Result<(), String> {
     is_pubkey(string.clone()).or_else(|_| is_keypair(string))
 }
 
+// Return an error if string cannot be parsed as pubkey or keypair file or keypair ask keyword
+pub fn is_pubkey_or_keypair_or_ask_keyword(string: String) -> Result<(), String> {
+    is_pubkey(string.clone()).or_else(|_| is_keypair_or_ask_keyword(string))
+}
+
 // Return an error if string cannot be parsed as pubkey=signature string
 pub fn is_pubkey_sig(string: String) -> Result<(), String> {
     let mut signer = string.split('=');

--- a/cli/tests/nonce.rs
+++ b/cli/tests/nonce.rs
@@ -1,5 +1,5 @@
 use solana_cli::cli::{
-    process_command, request_and_confirm_airdrop, CliCommand, CliConfig, KeypairEq,
+    process_command, request_and_confirm_airdrop, CliCommand, CliConfig, SigningAuthority,
 };
 use solana_client::rpc_client::RpcClient;
 use solana_faucet::faucet::run_local_faucet;
@@ -141,7 +141,7 @@ fn test_nonce_with_authority() {
     remove_dir_all(ledger_path).unwrap();
 }
 
-fn read_keypair_from_option(keypair_file: &Option<&str>) -> Option<KeypairEq> {
+fn read_keypair_from_option(keypair_file: &Option<&str>) -> Option<SigningAuthority> {
     keypair_file.map(|akf| read_keypair_file(&akf).unwrap().into())
 }
 
@@ -175,7 +175,7 @@ fn full_battery_tests(
         nonce_account: read_keypair_file(&nonce_keypair_file).unwrap().into(),
         seed,
         nonce_authority: read_keypair_from_option(&authority_keypair_file)
-            .map(|na: KeypairEq| na.pubkey()),
+            .map(|na: SigningAuthority| na.pubkey()),
         lamports: 1000,
     };
 

--- a/cli/tests/stake.rs
+++ b/cli/tests/stake.rs
@@ -574,8 +574,7 @@ fn test_stake_authorize() {
         stake_account_pubkey,
         new_authorized_pubkey: nonced_authority_pubkey,
         stake_authorize: StakeAuthorize::Staker,
-        // We need to be able to specify the authority by pubkey/sig pair here
-        authority: Some(read_keypair_file(&offline_authority_file).unwrap().into()),
+        authority: Some(offline_authority_pubkey.into()),
         sign_only: false,
         signers: Some(signers),
         blockhash: Some(blockhash),
@@ -614,7 +613,7 @@ fn test_stake_authorize() {
         _ => panic!("Nonce is not initialized"),
     };
 
-    // Nonced assignment of new nonced stake authority
+    // Nonced assignment of new online stake authority
     let online_authority = Keypair::new();
     let online_authority_pubkey = online_authority.pubkey();
     let (_online_authority_file, mut tmp_file) = make_tmp_file();
@@ -629,7 +628,6 @@ fn test_stake_authorize() {
         blockhash: Some(nonce_hash),
         nonce_account: Some(nonce_account.pubkey()),
         nonce_authority: None,
-        //nonce_authority: Some(read_keypair_file(&nonce_keypair_file).unwrap().into()),
     };
     let sign_reply = process_command(&config).unwrap();
     let (blockhash, signers) = parse_sign_only_reply_string(&sign_reply);
@@ -638,8 +636,7 @@ fn test_stake_authorize() {
         stake_account_pubkey,
         new_authorized_pubkey: online_authority_pubkey,
         stake_authorize: StakeAuthorize::Staker,
-        // We need to be able to specify the authority by pubkey/sig pair here
-        authority: Some(read_keypair_file(&nonced_authority_file).unwrap().into()),
+        authority: Some(nonced_authority_pubkey.into()),
         sign_only: false,
         signers: Some(signers),
         blockhash: Some(blockhash),


### PR DESCRIPTION
#### Problem

CLI `--*-authority` args only accept a `Keypair` limiting them to online authorities

#### Summary of Changes

Allow `--*-authority` to accept a `Pubkey` if there is a matching `--signer BASE58_PUBKEY=BASE58_SIGNATURE` passed also

This is a stop gap  to a more thorough (and intrusive) implementation as described [here](https://github.com/solana-labs/solana/pull/7831#discussion_r367145166)