### PR TITLE
Give book chapters more precise titles

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -1,8 +1,7 @@
 # Table of contents
 
-* [Introduction](introduction.md)
-* [Terminology](terminology.md)
-* [Getting Started](getting-started/README.md)
+* [The Solana Codebase](introduction.md)
+* [Building from Source](getting-started/README.md)
   * [Example Client: Web Wallet](getting-started/webwallet.md)
 * [Programming Model](programs/README.md)
   * [Example: Tic-Tac-Toe](programs/tictactoe.md)
@@ -46,6 +45,7 @@
   * [JSON RPC API](api-reference/jsonrpc-api.md)
   * [JavaScript API](api-reference/javascript-api.md)
   * [solana CLI](api-reference/cli.md)
+* [Terminology](terminology.md)
 * [Accepted Design Proposals](proposals/README.md)
   * [Ledger Replication](proposals/ledger-replication-to-implement.md)
   * [Secure Vote Signing](proposals/vote-signing-to-implement.md)


### PR DESCRIPTION
#### Problem

The book was written in the context of its original entrypoint, the GitHub README. It's being reorganized, such that end users can learn how to use the product. In that new context, the chapter titles "Introduction" and "Getting Started" are too vague.

#### Summary of Changes

* Rename chapters
* Move terminology section to the back. Terms are defined as
they are introduced. Longer-term, each term should just reference
the definition from earlier in the book.
