### PR TITLE
Add redeem_vote_credits to runtime

### DIFF
--- a/programs/stake/src/stake_state.rs
+++ b/programs/stake/src/stake_state.rs
@@ -371,7 +371,7 @@ impl Stake {
     ///   * staker_rewards to be distributed
     ///   * new value for credits_observed in the stake
     //  returns None if there's no payout or if any deserved payout is < 1 lamport
-    fn calculate_rewards(
+    pub fn calculate_rewards(
         &self,
         point_value: f64,
         vote_state: &VoteState,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -653,19 +653,14 @@ impl Bank {
                     (Some(mut stake_account), Some(mut vote_account)) => {
                         match (stake_account.state(), vote_account.state()) {
                             (Ok(StakeState::Stake(meta, mut stake)), Ok(vote_state)) => {
-                                // we've recovered everything we need to do redemption at this point
-                                if let Some((voters_reward, stakers_reward, credits_observed)) =
-                                    stake.calculate_rewards(
-                                        validator_point_value,
-                                        &vote_state,
-                                        Some(&stake_history),
-                                    )
-                                {
+                                // we've recovered everything we need to do redemption
+                                if let Some((voters_reward, stakers_reward)) = stake.redeem_rewards(
+                                    validator_point_value,
+                                    &vote_state,
+                                    Some(&stake_history),
+                                ) {
                                     stake_account.lamports += stakers_reward;
                                     vote_account.lamports += voters_reward;
-
-                                    stake.credits_observed = credits_observed;
-                                    stake.delegation.stake += stakers_reward;
 
                                     if stake_account
                                         .set_state(&StakeState::Stake(meta, stake))

--- a/runtime/tests/stake.rs
+++ b/runtime/tests/stake.rs
@@ -1,4 +1,3 @@
-use assert_matches::assert_matches;
 use solana_runtime::{
     bank::Bank,
     bank_client::BankClient,
@@ -11,7 +10,7 @@ use solana_sdk::{
     pubkey::Pubkey,
     signature::{Keypair, KeypairUtil},
     system_instruction::create_address_with_seed,
-    sysvar::{self, rewards::Rewards, stake_history::StakeHistory, Sysvar},
+    sysvar::{self, stake_history::StakeHistory, Sysvar},
 };
 use solana_stake_program::{
     stake_instruction::{self},
@@ -241,6 +240,14 @@ fn test_stake_account_lifetime() {
         assert!(false, "wrong account type found")
     }
 
+    loop {
+        if warmed_up(&bank, &stake_pubkey) {
+            break;
+        }
+        // Cycle thru banks until we're fully warmed up
+        bank = next_epoch(&bank);
+    }
+
     // Reward redemption
     // Submit enough votes to generate rewards
     bank = fill_epoch_with_votes(&bank, &vote_keypair, &mint_keypair);
@@ -254,32 +261,10 @@ fn test_stake_account_lifetime() {
     assert_eq!(vote_state.credits(), 1);
     bank = fill_epoch_with_votes(&bank, &vote_keypair, &mint_keypair);
 
-    loop {
-        if warmed_up(&bank, &stake_pubkey) {
-            break;
-        }
-        // Cycle thru banks until we're fully warmed up
-        bank = next_epoch(&bank);
-    }
-
-    // Test that rewards are there
-    let rewards_account = bank
-        .get_account(&sysvar::rewards::id())
-        .expect("account not found");
-    assert_matches!(Rewards::from_account(&rewards_account), Some(_));
-
     let pre_staked = get_staked(&bank, &stake_pubkey);
 
-    // Redeem the credit
-    let bank_client = BankClient::new_shared(&bank);
-    let message = Message::new_with_payer(
-        vec![stake_instruction::redeem_vote_credits(
-            &stake_pubkey,
-            &vote_pubkey,
-        )],
-        Some(&mint_pubkey),
-    );
-    assert_matches!(bank_client.send_message(&[&mint_keypair], message), Ok(_));
+    // next epoch bank should pay rewards
+    bank = next_epoch(&bank);
 
     // Test that balance increased, and that the balance got staked
     let staked = get_staked(&bank, &stake_pubkey);

--- a/runtime/tests/stake.rs
+++ b/runtime/tests/stake.rs
@@ -258,7 +258,8 @@ fn test_stake_account_lifetime() {
 
     // 1 less vote, as the first vote should have cleared the lockout
     assert_eq!(vote_state.votes.len(), 31);
-    assert_eq!(vote_state.credits(), 1);
+    // one vote per slot, might be more slots than 32 in the epoch
+    assert!(vote_state.credits() >= 1);
     bank = fill_epoch_with_votes(&bank, &vote_keypair, &mint_keypair);
 
     let pre_staked = get_staked(&bank, &stake_pubkey);
@@ -275,6 +276,8 @@ fn test_stake_account_lifetime() {
     // split the stake
     let split_stake_keypair = Keypair::new();
     let split_stake_pubkey = split_stake_keypair.pubkey();
+
+    let bank_client = BankClient::new_shared(&bank);
     // Test split
     let message = Message::new_with_payer(
         stake_instruction::split(

--- a/sdk/src/account_utils.rs
+++ b/sdk/src/account_utils.rs
@@ -1,6 +1,8 @@
 //! useful extras for Account state
-use crate::account::{Account, KeyedAccount};
-use crate::instruction::InstructionError;
+use crate::{
+    account::{Account, KeyedAccount},
+    instruction::InstructionError,
+};
 use bincode::ErrorKind;
 
 /// Convenience trait to covert bincode errors to instruction errors.


### PR DESCRIPTION
#### Problem
RedeemVoteCredits has a number of problems:

Somebody must issue this instruction every MAX_EPOCH_CREDITS_HISTORY epochs for each stake/vote account or rewards evaporate.
Reward point values are computed based on the latest epoch, which can produce confusing and hard to understand results as this example from TdS DR6 shows:
After the first 24 hours of idling, redeeming votes
using a ~1 SOL stake produced ~6221 SOL in voter rewards. Redeeming
that same stake 12 hours later produced ~54 SOL in voter rewards. The reason
for this huge reward drop is because the total stake increased from 435 SOL to 25695
SOL in those 12 hours, so the credit point value was much smaller.
The stake/vote accounts/programs as well as runtime contains code/data bloat that exists only to enable RedeemVoteCredits in its current form.
The first two points highlight the unintentional game that will be played around RedeemVoteCredits: if you see observe stake decreasing in the cluster than you're better off delaying RedeemVoteCredits if possible to capitalize on the increasing credit point value. But don't delay too long or you'll lost it all. Worse, RedeemVoteCredits can be run by anybody so others can inflict less desirable credit point values on you.

The alternative is to dispense of RedeemVoteCredits entirely, and have banks automatically redeem vote credits at the end of each epoch for all parties.


 #### Summary of Changes
 add redeem_vote_credits to runtime

CC #7835