### PR TITLE
RPC: encode serialized transaction in sendTransaction

### DIFF
--- a/book/src/api-reference/jsonrpc-api.md
+++ b/book/src/api-reference/jsonrpc-api.md
@@ -836,7 +836,7 @@ Creates new transaction
 
 ```bash
 // Request
-curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1, "method":"sendTransaction", "params":[[61, 98, 55, 49, 15, 187, 41, 215, 176, 49, 234, 229, 228, 77, 129, 221, 239, 88, 145, 227, 81, 158, 223, 123, 14, 229, 235, 247, 191, 115, 199, 71, 121, 17, 32, 67, 63, 209, 239, 160, 161, 2, 94, 105, 48, 159, 235, 235, 93, 98, 172, 97, 63, 197, 160, 164, 192, 20, 92, 111, 57, 145, 251, 6, 40, 240, 124, 194, 149, 155, 16, 138, 31, 113, 119, 101, 212, 128, 103, 78, 191, 80, 182, 234, 216, 21, 121, 243, 35, 100, 122, 68, 47, 57, 13, 39, 0, 0, 0, 0, 50, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 50, 0, 0, 0, 0, 0, 0, 0, 40, 240, 124, 194, 149, 155, 16, 138, 31, 113, 119, 101, 212, 128, 103, 78, 191, 80, 182, 234, 216, 21, 121, 243, 35, 100, 122, 68, 47, 57, 11, 12, 106, 49, 74, 226, 201, 16, 161, 192, 28, 84, 124, 97, 190, 201, 171, 186, 6, 18, 70, 142, 89, 185, 176, 154, 115, 61, 26, 163, 77, 1, 88, 98, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]]}' http://localhost:8899
+curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1, "method":"sendTransaction", "params":["3gKEMTuxvm3DKEJc4UyiyoNz1sxwdVRW2pyDDXqaCvUjGApnsazGh2y4W92zuaSSdJhBbWLYAkZokBt4N5oW27R7zCVaLLpLxvATL2GgheEh9DmmDR1P9r1ZqirVXM2fF3z5cafmc4EtwWc1UErFdCWj1qYvy4bDGMLXRYLURxaKytEEqrxz6JXj8rUHhDpjTZeFxmC6iAW3hZr6cmaAzewQCQfiEv2HfydriwHDtN95u3Y1EF6SuXxcRqox2aTjGye2Ln9zFj4XbnAtjCmkZhR"]}' http://localhost:8899
 
 // Result
 {"jsonrpc":"2.0","result":"2EBVM6cB8vAAD93Ktr6Vd8p67XPbQzCJX47MpReuiCXJAtcjaxpvWpcg9Ege1Nr5Tk3a2GFrByT7WPBjdsTycY9b","id":1}

--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -100,10 +100,10 @@ impl RpcClient {
     }
 
     pub fn send_transaction(&self, transaction: &Transaction) -> Result<String, ClientError> {
-        let serialized = serialize(transaction).unwrap();
-        let signature = self
-            .client
-            .send(&RpcRequest::SendTransaction, json!([serialized]), 5)?;
+        let serialized_encoded = bs58::encode(serialize(transaction).unwrap()).into_string();
+        let signature =
+            self.client
+                .send(&RpcRequest::SendTransaction, json!([serialized_encoded]), 5)?;
         if signature.as_str().is_none() {
             Err(io::Error::new(
                 io::ErrorKind::Other,

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -534,7 +534,7 @@ pub trait RpcSol {
     ) -> Result<String>;
 
     #[rpc(meta, name = "sendTransaction")]
-    fn send_transaction(&self, meta: Self::Metadata, data: Vec<u8>) -> Result<String>;
+    fn send_transaction(&self, meta: Self::Metadata, data: String) -> Result<String>;
 
     #[rpc(meta, name = "getSlotLeader")]
     fn get_slot_leader(
@@ -960,7 +960,8 @@ impl RpcSol for RpcSolImpl {
         }
     }
 
-    fn send_transaction(&self, meta: Self::Metadata, data: Vec<u8>) -> Result<String> {
+    fn send_transaction(&self, meta: Self::Metadata, data: String) -> Result<String> {
+        let data = bs58::decode(data).into_vec().unwrap();
         if data.len() >= PACKET_DATA_SIZE {
             info!(
                 "send_transaction: transaction too large: {} bytes (max: {} bytes)",
@@ -1834,8 +1835,7 @@ pub mod tests {
             genesis_hash: Hash::default(),
         };
 
-        let req =
-            r#"{"jsonrpc":"2.0","id":1,"method":"sendTransaction","params":[[0,0,0,0,0,0,0,0]]}"#;
+        let req = r#"{"jsonrpc":"2.0","id":1,"method":"sendTransaction","params":["37u9WtQpcm6ULa3Vmu7ySnANv"]}"#;
         let res = io.handle_request_sync(req, meta.clone());
         let expected =
             r#"{"jsonrpc":"2.0","error":{"code":-32600,"message":"Invalid request"},"id":1}"#;

--- a/core/tests/rpc.rs
+++ b/core/tests/rpc.rs
@@ -42,14 +42,14 @@ fn test_rpc_send_tx() {
 
     info!("blockhash: {:?}", blockhash);
     let tx = system_transaction::transfer(&alice, &bob_pubkey, 20, blockhash);
-    let serial_tx = serialize(&tx).unwrap();
+    let serialized_encoded_tx = bs58::encode(serialize(&tx).unwrap()).into_string();
 
     let client = reqwest::blocking::Client::new();
     let request = json!({
        "jsonrpc": "2.0",
        "id": 1,
        "method": "sendTransaction",
-       "params": json!([serial_tx])
+       "params": json!([serialized_encoded_tx])
     });
     let rpc_addr = leader_data.rpc;
     let rpc_string = get_rpc_request_str(rpc_addr, false);


### PR DESCRIPTION
#### Problem
The JSON-RPC method `sendTransaction` accepts an array of bytes as input, but it would make the message much shorter, and be more consistent with the current RPC responses (ref `getConfirmedBlock`), to accept a transaction encoded as a base58 string.

#### Summary of Changes
- Change `sendTransaction` rpc input type to String
- Update rpc_client to encode serialized Transaction

