### PR TITLE
Add mechanism to load v0.22.3 snapshots on newer Solana versions

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1888,6 +1888,121 @@ pub fn goto_end_of_slot(bank: &mut Bank) {
     }
 }
 
+// The `bank` struct as defined in Solana v0.22.3
+#[derive(Default, Deserialize, Serialize)]
+pub struct LegacyBank0223 {
+    #[serde(skip)]
+    pub rc: BankRc,
+
+    #[serde(skip)]
+    pub src: StatusCacheRc,
+
+    pub blockhash_queue: RwLock<BlockhashQueue>,
+    pub ancestors: HashMap<Slot, usize>,
+    pub hash: RwLock<Hash>,
+    pub parent_hash: Hash,
+    pub parent_slot: Slot,
+
+    #[serde(serialize_with = "serialize_atomicu64")]
+    #[serde(deserialize_with = "deserialize_atomicu64")]
+    pub transaction_count: AtomicU64,
+
+    #[serde(serialize_with = "serialize_atomicu64")]
+    #[serde(deserialize_with = "deserialize_atomicu64")]
+    pub tick_height: AtomicU64,
+
+    #[serde(serialize_with = "serialize_atomicu64")]
+    #[serde(deserialize_with = "deserialize_atomicu64")]
+    pub signature_count: AtomicU64,
+
+    #[serde(serialize_with = "serialize_atomicu64")]
+    #[serde(deserialize_with = "deserialize_atomicu64")]
+    pub capitalization: AtomicU64,
+
+    pub max_tick_height: u64,
+    pub hashes_per_tick: Option<u64>,
+    pub ticks_per_slot: u64,
+    pub ns_per_slot: u128,
+    pub genesis_creation_time: UnixTimestamp,
+    pub slots_per_year: f64,
+    pub slots_per_segment: u64,
+    pub slot: Slot,
+    pub epoch: Epoch,
+    pub block_height: u64,
+    pub collector_id: Pubkey,
+
+    #[serde(serialize_with = "serialize_atomicu64")]
+    #[serde(deserialize_with = "deserialize_atomicu64")]
+    pub collector_fees: AtomicU64,
+
+    pub fee_calculator: FeeCalculator,
+
+    #[serde(serialize_with = "serialize_atomicu64")]
+    #[serde(deserialize_with = "deserialize_atomicu64")]
+    pub collected_rent: AtomicU64,
+
+    pub rent_collector: RentCollector,
+    pub epoch_schedule: EpochSchedule,
+    pub inflation: Arc<RwLock<Inflation>>,
+    pub stakes: RwLock<Stakes>,
+    pub storage_accounts: RwLock<StorageAccounts>,
+    pub epoch_stakes: HashMap<Epoch, Stakes>,
+
+    #[serde(serialize_with = "serialize_atomicbool")]
+    #[serde(deserialize_with = "deserialize_atomicbool")]
+    pub is_delta: AtomicBool,
+
+    pub message_processor: MessageProcessor,
+
+    #[serde(skip)]
+    pub entered_epoch_callback: Arc<RwLock<Option<EnteredEpochCallback>>>,
+
+    #[serde(skip)]
+    pub last_vote_sync: AtomicU64,
+}
+
+impl From<LegacyBank0223> for Bank {
+    fn from(bank: LegacyBank0223) -> Self {
+        Bank {
+            rc: bank.rc,
+            src: bank.src,
+            slot: bank.slot,
+            epoch: bank.epoch,
+            blockhash_queue: bank.blockhash_queue,
+            hashes_per_tick: bank.hashes_per_tick,
+            ticks_per_slot: bank.ticks_per_slot,
+            ns_per_slot: bank.ns_per_slot,
+            genesis_creation_time: bank.genesis_creation_time,
+            slots_per_segment: bank.slots_per_segment,
+            slots_per_year: bank.slots_per_year,
+            epoch_schedule: bank.epoch_schedule,
+            collected_rent: bank.collected_rent,
+            rent_collector: bank.rent_collector,
+            max_tick_height: bank.max_tick_height,
+            block_height: bank.block_height,
+            fee_calculator: bank.fee_calculator,
+            capitalization: bank.capitalization,
+            inflation: bank.inflation,
+            transaction_count: bank.transaction_count,
+            stakes: bank.stakes,
+            epoch_stakes: bank.epoch_stakes,
+            storage_accounts: bank.storage_accounts,
+            parent_hash: bank.parent_hash,
+            parent_slot: bank.parent_slot,
+            collector_id: bank.collector_id,
+            collector_fees: bank.collector_fees,
+            ancestors: bank.ancestors,
+            hash: bank.hash,
+            is_delta: bank.is_delta,
+            tick_height: bank.tick_height,
+            signature_count: bank.signature_count,
+            message_processor: bank.message_processor,
+            entered_epoch_callback: bank.entered_epoch_callback,
+            last_vote_sync: bank.last_vote_sync,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
Once #7801 lands, snapshots produced by v0.22.3 (ie, version that SLP was running) will not be loadable on v0.22.4.  As a stopgap measure until #7738:

1) Add a version text file to the snapshot archive.  Snapshots without this version file are assumed to be "v0.22.3"-based.
2) Snapshots that are of the same version as the currently running code are compatible
3) Snapshots that are "v0.22.3"-based can be loaded on new versions using a `LegacyBank0223` struct 

NB: This will be landed on v0.22 first then cherry-picked up to master 