### PR TITLE
CLI: Cleanup authority arg usage inconsistencies

### DIFF
--- a/book/src/api-reference/cli.md
+++ b/book/src/api-reference/cli.md
@@ -352,15 +352,20 @@ FLAGS:
     -v, --verbose                        Show extra information header
 
 OPTIONS:
-        --ask-seed-phrase <KEYPAIR NAME>    Recover a keypair using a seed phrase and optional passphrase [possible
-                                            values: keypair]
-    -C, --config <PATH>                     Configuration file to use [default:
-                                            ~/.config/solana/cli/config.yml]
-    -u, --url <URL>                         JSON RPC URL for the solana cluster
-    -k, --keypair <PATH>                    /path/to/id.json
-        --nonce-authority <KEYPAIR>         Specify nonce authority if different from account
-        --seed <SEED STRING>                Seed for address generation; if specified, the resulting account will be at
-                                            a derived address of the NONCE_ACCOUNT pubkey
+        --ask-seed-phrase <KEYPAIR NAME>
+            Recover a keypair using a seed phrase and optional passphrase [possible values: keypair]
+
+    -C, --config <PATH>
+            Configuration file to use [default: ~/.config/solana/cli/config.yml]
+
+    -u, --url <URL>                              JSON RPC URL for the solana cluster
+    -k, --keypair <PATH>                         /path/to/id.json
+        --nonce-authority <KEYPAIR or PUBKEY>
+            Provide the nonce authority keypair to use when signing a nonced transaction
+
+        --seed <SEED STRING>
+            Seed for address generation; if specified, the resulting account will be at a derived address of the
+            NONCE_ACCOUNT pubkey
 
 ARGS:
     <NONCE_ACCOUNT>           Address of the nonce account
@@ -813,21 +818,25 @@ FLAGS:
     -v, --verbose                        Show extra information header
 
 OPTIONS:
-        --ask-seed-phrase <KEYPAIR NAME>       Recover a keypair using a seed phrase and optional passphrase [possible
-                                               values: keypair]
-        --blockhash <BLOCKHASH>                Use the supplied blockhash
-    -C, --config <PATH>                        Configuration file to use [default:
-                                               ~/.config/solana/cli/config.yml]
-    -u, --url <URL>                            JSON RPC URL for the solana cluster
-    -k, --keypair <PATH>                       /path/to/id.json
-        --nonce <PUBKEY>                       Provide the nonce account to use when creating a nonced 
-                                               transaction. Nonced transactions are useful when a transaction 
-                                               requires a lengthy signing process. Learn more about nonced 
-                                               transactions at https://docs.solana.com/offline-signing/durable-nonce
-        --nonce-authority <nonce_authority>    Provide the nonce authority keypair to use when signing a nonced
-                                               transaction
-        --signer <PUBKEY=BASE58_SIG>...        Provide a public-key/signature pair for the transaction
-        --stake-authority <KEYPAIR>            Public key of authorized staker (defaults to cli config pubkey)
+        --ask-seed-phrase <KEYPAIR NAME>
+            Recover a keypair using a seed phrase and optional passphrase [possible values: keypair]
+
+        --blockhash <BLOCKHASH>                  Use the supplied blockhash
+    -C, --config <PATH>
+            Configuration file to use [default: ~/.config/solana/cli/config.yml]
+
+    -u, --url <URL>                              JSON RPC URL for the solana cluster
+    -k, --keypair <PATH>                         /path/to/id.json
+        --nonce <PUBKEY>
+            Provide the nonce account to use when creating a nonced 
+            transaction. Nonced transactions are useful when a transaction 
+            requires a lengthy signing process. Learn more about nonced 
+            transactions at https://docs.solana.com/offline-signing/durable-nonce
+        --nonce-authority <KEYPAIR or PUBKEY>
+            Provide the nonce authority keypair to use when signing a nonced transaction
+
+        --signer <PUBKEY=BASE58_SIG>...          Provide a public-key/signature pair for the transaction
+        --stake-authority <KEYPAIR of PUBKEY>    Public key of authorized staker (defaults to cli config pubkey)
 
 ARGS:
     <STAKE ACCOUNT>    Stake account to be deactivated.
@@ -850,21 +859,25 @@ FLAGS:
     -v, --verbose                        Show extra information header
 
 OPTIONS:
-        --ask-seed-phrase <KEYPAIR NAME>       Recover a keypair using a seed phrase and optional passphrase [possible
-                                               values: keypair]
-        --blockhash <BLOCKHASH>                Use the supplied blockhash
-    -C, --config <PATH>                        Configuration file to use [default:
-                                               ~/.config/solana/cli/config.yml]
-    -u, --url <URL>                            JSON RPC URL for the solana cluster
-    -k, --keypair <PATH>                       /path/to/id.json
-        --nonce <PUBKEY>                       Provide the nonce account to use when creating a nonced 
-                                               transaction. Nonced transactions are useful when a transaction 
-                                               requires a lengthy signing process. Learn more about nonced 
-                                               transactions at https://docs.solana.com/offline-signing/durable-nonce
-        --nonce-authority <nonce_authority>    Provide the nonce authority keypair to use when signing a nonced
-                                               transaction
-        --signer <PUBKEY=BASE58_SIG>...        Provide a public-key/signature pair for the transaction
-        --stake-authority <KEYPAIR>            Public key of authorized staker (defaults to cli config pubkey)
+        --ask-seed-phrase <KEYPAIR NAME>
+            Recover a keypair using a seed phrase and optional passphrase [possible values: keypair]
+
+        --blockhash <BLOCKHASH>                  Use the supplied blockhash
+    -C, --config <PATH>
+            Configuration file to use [default: ~/.config/solana/cli/config.yml]
+
+    -u, --url <URL>                              JSON RPC URL for the solana cluster
+    -k, --keypair <PATH>                         /path/to/id.json
+        --nonce <PUBKEY>
+            Provide the nonce account to use when creating a nonced 
+            transaction. Nonced transactions are useful when a transaction 
+            requires a lengthy signing process. Learn more about nonced 
+            transactions at https://docs.solana.com/offline-signing/durable-nonce
+        --nonce-authority <KEYPAIR or PUBKEY>
+            Provide the nonce authority keypair to use when signing a nonced transaction
+
+        --signer <PUBKEY=BASE58_SIG>...          Provide a public-key/signature pair for the transaction
+        --stake-authority <KEYPAIR of PUBKEY>    Public key of authorized staker (defaults to cli config pubkey)
 
 ARGS:
     <STAKE ACCOUNT>    Stake account to delegate
@@ -1023,13 +1036,17 @@ FLAGS:
     -v, --verbose                        Show extra information header
 
 OPTIONS:
-        --ask-seed-phrase <KEYPAIR NAME>    Recover a keypair using a seed phrase and optional passphrase [possible
-                                            values: keypair]
-    -C, --config <PATH>                     Configuration file to use [default:
-                                            ~/.config/solana/cli/config.yml]
-    -u, --url <URL>                         JSON RPC URL for the solana cluster
-    -k, --keypair <PATH>                    /path/to/id.json
-        --nonce-authority <KEYPAIR>         Specify nonce authority if different from account
+        --ask-seed-phrase <KEYPAIR NAME>
+            Recover a keypair using a seed phrase and optional passphrase [possible values: keypair]
+
+    -C, --config <PATH>
+            Configuration file to use [default: ~/.config/solana/cli/config.yml]
+
+    -u, --url <URL>                              JSON RPC URL for the solana cluster
+    -k, --keypair <PATH>                         /path/to/id.json
+        --nonce-authority <KEYPAIR or PUBKEY>
+            Provide the nonce authority keypair to use when signing a nonced transaction
+
 
 ARGS:
     <NONCE ACCOUNT>    Address of the nonce account
@@ -1108,23 +1125,27 @@ FLAGS:
     -v, --verbose                        Show extra information header
 
 OPTIONS:
-        --ask-seed-phrase <KEYPAIR NAME>        Recover a keypair using a seed phrase and optional passphrase [possible
-                                                values: keypair]
-        --blockhash <BLOCKHASH>                 Use the supplied blockhash
-    -C, --config <PATH>                         Configuration file to use [default:
-                                                ~/.config/solana/cli/config.yml]
-    -u, --url <URL>                             JSON RPC URL for the solana cluster
-    -k, --keypair <PATH>                        /path/to/id.json
-        --nonce <PUBKEY>                        Provide the nonce account to use when creating a nonced 
-                                                transaction. Nonced transactions are useful when a transaction 
-                                                requires a lengthy signing process. Learn more about nonced 
-                                                transactions at https://docs.solana.com/offline-signing/durable-nonce
-        --nonce-authority <nonce_authority>     Provide the nonce authority keypair to use when signing a nonced
-                                                transaction
-        --signer <PUBKEY=BASE58_SIG>...         Provide a public-key/signature pair for the transaction
-        --after <DATETIME>                      A timestamp after which transaction will execute
-        --require-timestamp-from <PUBKEY>       Require timestamp from this third party
-        --require-signature-from <PUBKEY>...    Any third party signatures required to unlock the lamports
+        --ask-seed-phrase <KEYPAIR NAME>
+            Recover a keypair using a seed phrase and optional passphrase [possible values: keypair]
+
+        --blockhash <BLOCKHASH>                  Use the supplied blockhash
+    -C, --config <PATH>
+            Configuration file to use [default: ~/.config/solana/cli/config.yml]
+
+    -u, --url <URL>                              JSON RPC URL for the solana cluster
+    -k, --keypair <PATH>                         /path/to/id.json
+        --nonce <PUBKEY>
+            Provide the nonce account to use when creating a nonced 
+            transaction. Nonced transactions are useful when a transaction 
+            requires a lengthy signing process. Learn more about nonced 
+            transactions at https://docs.solana.com/offline-signing/durable-nonce
+        --nonce-authority <KEYPAIR or PUBKEY>
+            Provide the nonce authority keypair to use when signing a nonced transaction
+
+        --signer <PUBKEY=BASE58_SIG>...          Provide a public-key/signature pair for the transaction
+        --after <DATETIME>                       A timestamp after which transaction will execute
+        --require-timestamp-from <PUBKEY>        Require timestamp from this third party
+        --require-signature-from <PUBKEY>...     Any third party signatures required to unlock the lamports
 
 ARGS:
     <TO PUBKEY>    The pubkey of recipient
@@ -1316,21 +1337,25 @@ FLAGS:
     -v, --verbose                        Show extra information header
 
 OPTIONS:
-        --ask-seed-phrase <KEYPAIR NAME>       Recover a keypair using a seed phrase and optional passphrase [possible
-                                               values: keypair]
-        --blockhash <BLOCKHASH>                Use the supplied blockhash
-    -C, --config <PATH>                        Configuration file to use [default:
-                                               ~/.config/solana/cli/config.yml]
-    -u, --url <URL>                            JSON RPC URL for the solana cluster
-    -k, --keypair <PATH>                       /path/to/id.json
-        --nonce <PUBKEY>                       Provide the nonce account to use when creating a nonced 
-                                               transaction. Nonced transactions are useful when a transaction 
-                                               requires a lengthy signing process. Learn more about nonced 
-                                               transactions at https://docs.solana.com/offline-signing/durable-nonce
-        --nonce-authority <nonce_authority>    Provide the nonce authority keypair to use when signing a nonced
-                                               transaction
-        --signer <PUBKEY=BASE58_SIG>...        Provide a public-key/signature pair for the transaction
-        --stake-authority <KEYPAIR>            Public key of authorized staker (defaults to cli config pubkey)
+        --ask-seed-phrase <KEYPAIR NAME>
+            Recover a keypair using a seed phrase and optional passphrase [possible values: keypair]
+
+        --blockhash <BLOCKHASH>                  Use the supplied blockhash
+    -C, --config <PATH>
+            Configuration file to use [default: ~/.config/solana/cli/config.yml]
+
+    -u, --url <URL>                              JSON RPC URL for the solana cluster
+    -k, --keypair <PATH>                         /path/to/id.json
+        --nonce <PUBKEY>
+            Provide the nonce account to use when creating a nonced 
+            transaction. Nonced transactions are useful when a transaction 
+            requires a lengthy signing process. Learn more about nonced 
+            transactions at https://docs.solana.com/offline-signing/durable-nonce
+        --nonce-authority <KEYPAIR or PUBKEY>
+            Provide the nonce authority keypair to use when signing a nonced transaction
+
+        --signer <PUBKEY=BASE58_SIG>...          Provide a public-key/signature pair for the transaction
+        --stake-authority <KEYPAIR of PUBKEY>    Public key of authorized staker (defaults to cli config pubkey)
 
 ARGS:
     <STAKE ACCOUNT>       Stake account in which to set the authorized staker
@@ -1354,21 +1379,25 @@ FLAGS:
     -v, --verbose                        Show extra information header
 
 OPTIONS:
-        --ask-seed-phrase <KEYPAIR NAME>       Recover a keypair using a seed phrase and optional passphrase [possible
-                                               values: keypair]
-        --blockhash <BLOCKHASH>                Use the supplied blockhash
-    -C, --config <PATH>                        Configuration file to use [default:
-                                               ~/.config/solana/cli/config.yml]
-    -u, --url <URL>                            JSON RPC URL for the solana cluster
-    -k, --keypair <PATH>                       /path/to/id.json
-        --nonce <PUBKEY>                       Provide the nonce account to use when creating a nonced 
-                                               transaction. Nonced transactions are useful when a transaction 
-                                               requires a lengthy signing process. Learn more about nonced 
-                                               transactions at https://docs.solana.com/offline-signing/durable-nonce
-        --nonce-authority <nonce_authority>    Provide the nonce authority keypair to use when signing a nonced
-                                               transaction
-        --signer <PUBKEY=BASE58_SIG>...        Provide a public-key/signature pair for the transaction
-        --withdraw-authority <KEYPAIR>         Public key of authorized withdrawer (defaults to cli config pubkey)
+        --ask-seed-phrase <KEYPAIR NAME>
+            Recover a keypair using a seed phrase and optional passphrase [possible values: keypair]
+
+        --blockhash <BLOCKHASH>                     Use the supplied blockhash
+    -C, --config <PATH>
+            Configuration file to use [default: ~/.config/solana/cli/config.yml]
+
+    -u, --url <URL>                                 JSON RPC URL for the solana cluster
+    -k, --keypair <PATH>                            /path/to/id.json
+        --nonce <PUBKEY>
+            Provide the nonce account to use when creating a nonced 
+            transaction. Nonced transactions are useful when a transaction 
+            requires a lengthy signing process. Learn more about nonced 
+            transactions at https://docs.solana.com/offline-signing/durable-nonce
+        --nonce-authority <KEYPAIR or PUBKEY>
+            Provide the nonce authority keypair to use when signing a nonced transaction
+
+        --signer <PUBKEY=BASE58_SIG>...             Provide a public-key/signature pair for the transaction
+        --withdraw-authority <KEYPAIR or PUBKEY>    Public key of authorized withdrawer (defaults to cli config pubkey)
 
 ARGS:
     <STAKE ACCOUNT>       Stake account in which to set the authorized withdrawer
@@ -1692,13 +1721,17 @@ FLAGS:
     -v, --verbose                        Show extra information header
 
 OPTIONS:
-        --ask-seed-phrase <KEYPAIR NAME>    Recover a keypair using a seed phrase and optional passphrase [possible
-                                            values: keypair]
-    -C, --config <PATH>                     Configuration file to use [default:
-                                            ~/.config/solana/cli/config.yml]
-    -u, --url <URL>                         JSON RPC URL for the solana cluster
-    -k, --keypair <PATH>                    /path/to/id.json
-        --nonce-authority <KEYPAIR>         Specify nonce authority if different from account
+        --ask-seed-phrase <KEYPAIR NAME>
+            Recover a keypair using a seed phrase and optional passphrase [possible values: keypair]
+
+    -C, --config <PATH>
+            Configuration file to use [default: ~/.config/solana/cli/config.yml]
+
+    -u, --url <URL>                              JSON RPC URL for the solana cluster
+    -k, --keypair <PATH>                         /path/to/id.json
+        --nonce-authority <KEYPAIR or PUBKEY>
+            Provide the nonce authority keypair to use when signing a nonced transaction
+
 
 ARGS:
     <NONCE ACCOUNT>          Nonce account from to withdraw from
@@ -1723,13 +1756,15 @@ FLAGS:
     -v, --verbose                        Show extra information header
 
 OPTIONS:
-        --ask-seed-phrase <KEYPAIR NAME>    Recover a keypair using a seed phrase and optional passphrase [possible
-                                            values: keypair]
-    -C, --config <PATH>                     Configuration file to use [default:
-                                            ~/.config/solana/cli/config.yml]
-    -u, --url <URL>                         JSON RPC URL for the solana cluster
-    -k, --keypair <PATH>                    /path/to/id.json
-        --withdraw-authority <KEYPAIR>      Public key of authorized withdrawer (defaults to cli config pubkey)
+        --ask-seed-phrase <KEYPAIR NAME>
+            Recover a keypair using a seed phrase and optional passphrase [possible values: keypair]
+
+    -C, --config <PATH>
+            Configuration file to use [default: ~/.config/solana/cli/config.yml]
+
+    -u, --url <URL>                                 JSON RPC URL for the solana cluster
+    -k, --keypair <PATH>                            /path/to/id.json
+        --withdraw-authority <KEYPAIR or PUBKEY>    Public key of authorized withdrawer (defaults to cli config pubkey)
 
 ARGS:
     <STAKE ACCOUNT>          Stake account from which to withdraw

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -1,7 +1,7 @@
 use crate::{
     cluster_query::*,
     display::{println_name_value, println_signers},
-    nonce::*,
+    nonce::{self, *},
     stake::*,
     storage::*,
     validator_info::*,
@@ -144,6 +144,10 @@ impl PartialEq for SigningAuthority {
             }
         }
     }
+}
+
+pub fn nonce_authority_arg<'a, 'b>() -> Arg<'a, 'b> {
+    nonce::nonce_authority_arg().requires(NONCE_ARG.name)
 }
 
 #[derive(Default, Debug, PartialEq)]
@@ -1985,23 +1989,8 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                         .takes_value(false)
                         .help("Sign the transaction offline"),
                 )
-                .arg(
-                    Arg::with_name(NONCE_ARG.name)
-                        .long(NONCE_ARG.long)
-                        .takes_value(true)
-                        .value_name("PUBKEY")
-                        .requires("blockhash")
-                        .validator(is_pubkey_or_keypair)
-                        .help(NONCE_ARG.help),
-                )
-                .arg(
-                    Arg::with_name(NONCE_AUTHORITY_ARG.name)
-                        .long(NONCE_AUTHORITY_ARG.long)
-                        .takes_value(true)
-                        .requires(NONCE_ARG.name)
-                        .validator(is_pubkey_or_keypair_or_ask_keyword)
-                        .help(NONCE_AUTHORITY_ARG.help),
-                )
+                .arg(nonce_arg())
+                .arg(nonce_authority_arg())
                 .arg(
                     Arg::with_name("signer")
                         .long("signer")

--- a/cli/src/nonce.rs
+++ b/cli/src/nonce.rs
@@ -49,13 +49,23 @@ pub trait NonceSubCommands {
     fn nonce_subcommands(self) -> Self;
 }
 
-fn nonce_authority_arg<'a, 'b>() -> Arg<'a, 'b> {
-    Arg::with_name("nonce_authority")
-        .long("nonce-authority")
+pub fn nonce_arg<'a, 'b>() -> Arg<'a, 'b> {
+    Arg::with_name(NONCE_ARG.name)
+        .long(NONCE_ARG.long)
         .takes_value(true)
-        .value_name("KEYPAIR")
+        .value_name("PUBKEY")
+        .requires("blockhash")
+        .validator(is_pubkey)
+        .help(NONCE_ARG.help)
+}
+
+pub fn nonce_authority_arg<'a, 'b>() -> Arg<'a, 'b> {
+    Arg::with_name(NONCE_AUTHORITY_ARG.name)
+        .long(NONCE_AUTHORITY_ARG.long)
+        .takes_value(true)
+        .value_name("KEYPAIR or PUBKEY")
         .validator(is_pubkey_or_keypair_or_ask_keyword)
-        .help("Specify nonce authority if different from account")
+        .help(NONCE_AUTHORITY_ARG.help)
 }
 
 impl NonceSubCommands for App<'_, '_> {
@@ -120,8 +130,8 @@ impl NonceSubCommands for App<'_, '_> {
                         .help("Specify unit to use for request"),
                 )
                 .arg(
-                    Arg::with_name("nonce_authority")
-                        .long("nonce-authority")
+                    Arg::with_name(NONCE_AUTHORITY_ARG.name)
+                        .long(NONCE_AUTHORITY_ARG.long)
                         .takes_value(true)
                         .value_name("BASE58_PUBKEY")
                         .validator(is_pubkey_or_keypair)
@@ -246,7 +256,7 @@ pub fn parse_nonce_create_account(matches: &ArgMatches<'_>) -> Result<CliCommand
     let nonce_account = keypair_of(matches, "nonce_account_keypair").unwrap();
     let seed = matches.value_of("seed").map(|s| s.to_string());
     let lamports = required_lamports_from(matches, "amount", "unit")?;
-    let nonce_authority = pubkey_of(matches, "nonce_authority");
+    let nonce_authority = pubkey_of(matches, NONCE_AUTHORITY_ARG.name);
 
     Ok(CliCommandInfo {
         command: CliCommand::CreateNonceAccount {

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -1,11 +1,11 @@
 use crate::{
     cli::{
         build_balance_message, check_account_for_fee, check_unique_pubkeys,
-        get_blockhash_fee_calculator, log_instruction_custom_error, replace_signatures,
-        required_lamports_from, return_signers, CliCommand, CliCommandInfo, CliConfig, CliError,
-        ProcessResult, SigningAuthority,
+        get_blockhash_fee_calculator, log_instruction_custom_error, nonce_authority_arg,
+        replace_signatures, required_lamports_from, return_signers, CliCommand, CliCommandInfo,
+        CliConfig, CliError, ProcessResult, SigningAuthority,
     },
-    nonce::{check_nonce_account, NONCE_ARG, NONCE_AUTHORITY_ARG},
+    nonce::{check_nonce_account, nonce_arg, NONCE_ARG, NONCE_AUTHORITY_ARG},
 };
 use clap::{App, Arg, ArgMatches, SubCommand};
 use console::style;
@@ -47,7 +47,7 @@ fn stake_authority_arg<'a, 'b>() -> Arg<'a, 'b> {
     Arg::with_name(STAKE_AUTHORITY_ARG.name)
         .long(STAKE_AUTHORITY_ARG.long)
         .takes_value(true)
-        .value_name("KEYPAIR")
+        .value_name("KEYPAIR of PUBKEY")
         .validator(is_pubkey_or_keypair_or_ask_keyword)
         .help(STAKE_AUTHORITY_ARG.help)
 }
@@ -56,7 +56,7 @@ fn withdraw_authority_arg<'a, 'b>() -> Arg<'a, 'b> {
     Arg::with_name(WITHDRAW_AUTHORITY_ARG.name)
         .long(WITHDRAW_AUTHORITY_ARG.long)
         .takes_value(true)
-        .value_name("KEYPAIR")
+        .value_name("KEYPAIR or PUBKEY")
         .validator(is_pubkey_or_keypair_or_ask_keyword)
         .help(WITHDRAW_AUTHORITY_ARG.help)
 }
@@ -195,23 +195,8 @@ impl StakeSubCommands for App<'_, '_> {
                         .validator(is_hash)
                         .help("Use the supplied blockhash"),
                 )
-                .arg(
-                    Arg::with_name(NONCE_ARG.name)
-                        .long(NONCE_ARG.long)
-                        .takes_value(true)
-                        .value_name("PUBKEY")
-                        .requires("blockhash")
-                        .validator(is_pubkey)
-                        .help(NONCE_ARG.help)
-                )
-                .arg(
-                    Arg::with_name(NONCE_AUTHORITY_ARG.name)
-                        .long(NONCE_AUTHORITY_ARG.long)
-                        .takes_value(true)
-                        .requires(NONCE_ARG.name)
-                        .validator(is_keypair_or_ask_keyword)
-                        .help(NONCE_AUTHORITY_ARG.help)
-                ),
+                .arg(nonce_arg())
+                .arg(nonce_authority_arg())
         )
         .subcommand(
             SubCommand::with_name("stake-authorize-staker")
@@ -258,23 +243,8 @@ impl StakeSubCommands for App<'_, '_> {
                         .validator(is_hash)
                         .help("Use the supplied blockhash"),
                 )
-                .arg(
-                    Arg::with_name(NONCE_ARG.name)
-                        .long(NONCE_ARG.long)
-                        .takes_value(true)
-                        .value_name("PUBKEY")
-                        .requires("blockhash")
-                        .validator(is_pubkey)
-                        .help(NONCE_ARG.help)
-                )
-                .arg(
-                    Arg::with_name(NONCE_AUTHORITY_ARG.name)
-                        .long(NONCE_AUTHORITY_ARG.long)
-                        .takes_value(true)
-                        .requires(NONCE_ARG.name)
-                        .validator(is_keypair_or_ask_keyword)
-                        .help(NONCE_AUTHORITY_ARG.help)
-                ),
+                .arg(nonce_arg())
+                .arg(nonce_authority_arg())
         )
         .subcommand(
             SubCommand::with_name("stake-authorize-withdrawer")
@@ -321,23 +291,8 @@ impl StakeSubCommands for App<'_, '_> {
                         .validator(is_hash)
                         .help("Use the supplied blockhash"),
                 )
-                .arg(
-                    Arg::with_name(NONCE_ARG.name)
-                        .long(NONCE_ARG.long)
-                        .takes_value(true)
-                        .value_name("PUBKEY")
-                        .requires("blockhash")
-                        .validator(is_pubkey)
-                        .help(NONCE_ARG.help)
-                )
-                .arg(
-                    Arg::with_name(NONCE_AUTHORITY_ARG.name)
-                        .long(NONCE_AUTHORITY_ARG.long)
-                        .takes_value(true)
-                        .requires(NONCE_ARG.name)
-                        .validator(is_keypair_or_ask_keyword)
-                        .help(NONCE_AUTHORITY_ARG.help)
-                ),
+                .arg(nonce_arg())
+                .arg(nonce_authority_arg())
         )
         .subcommand(
             SubCommand::with_name("deactivate-stake")
@@ -374,23 +329,8 @@ impl StakeSubCommands for App<'_, '_> {
                         .validator(is_hash)
                         .help("Use the supplied blockhash"),
                 )
-                .arg(
-                    Arg::with_name(NONCE_ARG.name)
-                        .long(NONCE_ARG.long)
-                        .takes_value(true)
-                        .value_name("PUBKEY")
-                        .requires("blockhash")
-                        .validator(is_pubkey)
-                        .help(NONCE_ARG.help)
-                )
-                .arg(
-                    Arg::with_name(NONCE_AUTHORITY_ARG.name)
-                        .long(NONCE_AUTHORITY_ARG.long)
-                        .takes_value(true)
-                        .requires(NONCE_ARG.name)
-                        .validator(is_keypair_or_ask_keyword)
-                        .help(NONCE_AUTHORITY_ARG.help)
-                ),
+                .arg(nonce_arg())
+                .arg(nonce_authority_arg())
         )
         .subcommand(
             SubCommand::with_name("withdraw-stake")


### PR DESCRIPTION
#### Problem

CLI's authority args are specified and referenced inconsistently

#### Summary of Changes

Make use of constants and helper functions throughout
Sync docs