### PR TITLE
Verb-noun-ify Nonce API

### DIFF
--- a/cli/src/nonce.rs
+++ b/cli/src/nonce.rs
@@ -14,8 +14,9 @@ use solana_sdk::{
     pubkey::Pubkey,
     signature::{Keypair, KeypairUtil},
     system_instruction::{
-        advance_nonce, authorize_nonce, create_address_with_seed, create_nonce_account,
-        create_nonce_account_with_seed, withdraw_nonce, NonceError, SystemError,
+        advance_nonce_account, authorize_nonce_account, create_address_with_seed,
+        create_nonce_account, create_nonce_account_with_seed, withdraw_nonce_account, NonceError,
+        SystemError,
     },
     system_program,
     transaction::Transaction,
@@ -379,7 +380,7 @@ pub fn process_authorize_nonce_account(
     let nonce_authority = nonce_authority
         .map(|a| a.keypair())
         .unwrap_or(&config.keypair);
-    let ix = authorize_nonce(nonce_account, &nonce_authority.pubkey(), new_authority);
+    let ix = authorize_nonce_account(nonce_account, &nonce_authority.pubkey(), new_authority);
     let mut tx = Transaction::new_signed_with_payer(
         vec![ix],
         Some(&config.keypair.pubkey()),
@@ -525,7 +526,7 @@ pub fn process_new_nonce(
     let nonce_authority = nonce_authority
         .map(|a| a.keypair())
         .unwrap_or(&config.keypair);
-    let ix = advance_nonce(&nonce_account, &nonce_authority.pubkey());
+    let ix = advance_nonce_account(&nonce_account, &nonce_authority.pubkey());
     let (recent_blockhash, fee_calculator) = rpc_client.get_recent_blockhash()?;
     let mut tx = Transaction::new_signed_with_payer(
         vec![ix],
@@ -600,7 +601,7 @@ pub fn process_withdraw_from_nonce_account(
     let nonce_authority = nonce_authority
         .map(|a| a.keypair())
         .unwrap_or(&config.keypair);
-    let ix = withdraw_nonce(
+    let ix = withdraw_nonce_account(
         nonce_account,
         &nonce_authority.pubkey(),
         destination_account_pubkey,

--- a/cli/src/nonce.rs
+++ b/cli/src/nonce.rs
@@ -14,8 +14,8 @@ use solana_sdk::{
     pubkey::Pubkey,
     signature::{Keypair, KeypairUtil},
     system_instruction::{
-        create_address_with_seed, create_nonce_account, create_nonce_account_with_seed,
-        nonce_advance, nonce_authorize, nonce_withdraw, NonceError, SystemError,
+        advance_nonce, authorize_nonce, create_address_with_seed, create_nonce_account,
+        create_nonce_account_with_seed, withdraw_nonce, NonceError, SystemError,
     },
     system_program,
     transaction::Transaction,
@@ -379,7 +379,7 @@ pub fn process_authorize_nonce_account(
     let nonce_authority = nonce_authority
         .map(|a| a.keypair())
         .unwrap_or(&config.keypair);
-    let ix = nonce_authorize(nonce_account, &nonce_authority.pubkey(), new_authority);
+    let ix = authorize_nonce(nonce_account, &nonce_authority.pubkey(), new_authority);
     let mut tx = Transaction::new_signed_with_payer(
         vec![ix],
         Some(&config.keypair.pubkey()),
@@ -525,7 +525,7 @@ pub fn process_new_nonce(
     let nonce_authority = nonce_authority
         .map(|a| a.keypair())
         .unwrap_or(&config.keypair);
-    let ix = nonce_advance(&nonce_account, &nonce_authority.pubkey());
+    let ix = advance_nonce(&nonce_account, &nonce_authority.pubkey());
     let (recent_blockhash, fee_calculator) = rpc_client.get_recent_blockhash()?;
     let mut tx = Transaction::new_signed_with_payer(
         vec![ix],
@@ -600,7 +600,7 @@ pub fn process_withdraw_from_nonce_account(
     let nonce_authority = nonce_authority
         .map(|a| a.keypair())
         .unwrap_or(&config.keypair);
-    let ix = nonce_withdraw(
+    let ix = withdraw_nonce(
         nonce_account,
         &nonce_authority.pubkey(),
         destination_account_pubkey,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4904,7 +4904,7 @@ mod tests {
         let nonce_hash = get_nonce(&bank, &nonce_pubkey).unwrap();
         let tx = Transaction::new_signed_with_payer(
             vec![
-                system_instruction::nonce_advance(&nonce_pubkey, &nonce_pubkey),
+                system_instruction::advance_nonce(&nonce_pubkey, &nonce_pubkey),
                 system_instruction::transfer(&custodian_pubkey, &nonce_pubkey, 100_000),
             ],
             Some(&custodian_pubkey),
@@ -4929,7 +4929,7 @@ mod tests {
         let tx = Transaction::new_signed_with_payer(
             vec![
                 system_instruction::transfer(&custodian_pubkey, &nonce_pubkey, 100_000),
-                system_instruction::nonce_advance(&nonce_pubkey, &nonce_pubkey),
+                system_instruction::advance_nonce(&nonce_pubkey, &nonce_pubkey),
             ],
             Some(&custodian_pubkey),
             &[&custodian_keypair, &nonce_keypair],
@@ -4948,7 +4948,7 @@ mod tests {
         let nonce_hash = get_nonce(&bank, &nonce_pubkey).unwrap();
         let mut tx = Transaction::new_signed_with_payer(
             vec![
-                system_instruction::nonce_advance(&nonce_pubkey, &nonce_pubkey),
+                system_instruction::advance_nonce(&nonce_pubkey, &nonce_pubkey),
                 system_instruction::transfer(&custodian_pubkey, &nonce_pubkey, 100_000),
             ],
             Some(&custodian_pubkey),
@@ -4971,7 +4971,7 @@ mod tests {
         let nonce_hash = get_nonce(&bank, &nonce_pubkey).unwrap();
         let tx = Transaction::new_signed_with_payer(
             vec![
-                system_instruction::nonce_advance(&missing_pubkey, &nonce_pubkey),
+                system_instruction::advance_nonce(&missing_pubkey, &nonce_pubkey),
                 system_instruction::transfer(&custodian_pubkey, &nonce_pubkey, 100_000),
             ],
             Some(&custodian_pubkey),
@@ -4990,7 +4990,7 @@ mod tests {
 
         let tx = Transaction::new_signed_with_payer(
             vec![
-                system_instruction::nonce_advance(&nonce_pubkey, &nonce_pubkey),
+                system_instruction::advance_nonce(&nonce_pubkey, &nonce_pubkey),
                 system_instruction::transfer(&custodian_pubkey, &nonce_pubkey, 100_000),
             ],
             Some(&custodian_pubkey),
@@ -5078,7 +5078,7 @@ mod tests {
         /* Durable Nonce transfer */
         let durable_tx = Transaction::new_signed_with_payer(
             vec![
-                system_instruction::nonce_advance(&nonce_pubkey, &nonce_pubkey),
+                system_instruction::advance_nonce(&nonce_pubkey, &nonce_pubkey),
                 system_instruction::transfer(&custodian_pubkey, &alice_pubkey, 100_000),
             ],
             Some(&custodian_pubkey),
@@ -5099,7 +5099,7 @@ mod tests {
         /* Durable Nonce re-use fails */
         let durable_tx = Transaction::new_signed_with_payer(
             vec![
-                system_instruction::nonce_advance(&nonce_pubkey, &nonce_pubkey),
+                system_instruction::advance_nonce(&nonce_pubkey, &nonce_pubkey),
                 system_instruction::transfer(&custodian_pubkey, &alice_pubkey, 100_000),
             ],
             Some(&custodian_pubkey),
@@ -5124,7 +5124,7 @@ mod tests {
 
         let durable_tx = Transaction::new_signed_with_payer(
             vec![
-                system_instruction::nonce_advance(&nonce_pubkey, &nonce_pubkey),
+                system_instruction::advance_nonce(&nonce_pubkey, &nonce_pubkey),
                 system_instruction::transfer(&custodian_pubkey, &alice_pubkey, 100_000_000),
             ],
             Some(&custodian_pubkey),

--- a/runtime/src/nonce_utils.rs
+++ b/runtime/src/nonce_utils.rs
@@ -93,7 +93,7 @@ mod tests {
         let tx = Transaction::new_signed_instructions(
             &[&from_keypair, &nonce_keypair],
             vec![
-                system_instruction::nonce_advance(&nonce_pubkey, &nonce_pubkey),
+                system_instruction::advance_nonce(&nonce_pubkey, &nonce_pubkey),
                 system_instruction::transfer(&from_pubkey, &nonce_pubkey, 42),
             ],
             Hash::default(),
@@ -131,7 +131,7 @@ mod tests {
             &[&from_keypair, &nonce_keypair],
             vec![
                 system_instruction::transfer(&from_pubkey, &nonce_pubkey, 42),
-                system_instruction::nonce_advance(&nonce_pubkey, &nonce_pubkey),
+                system_instruction::advance_nonce(&nonce_pubkey, &nonce_pubkey),
             ],
             Hash::default(),
         );
@@ -147,7 +147,7 @@ mod tests {
         let tx = Transaction::new_signed_instructions(
             &[&from_keypair, &nonce_keypair],
             vec![
-                system_instruction::nonce_withdraw(&nonce_pubkey, &nonce_pubkey, &from_pubkey, 42),
+                system_instruction::withdraw_nonce(&nonce_pubkey, &nonce_pubkey, &from_pubkey, 42),
                 system_instruction::transfer(&from_pubkey, &nonce_pubkey, 42),
             ],
             Hash::default(),
@@ -194,7 +194,7 @@ mod tests {
             let recent_blockhashes = create_test_recent_blockhashes(0);
             let authorized = nonce_account.unsigned_key().clone();
             nonce_account
-                .nonce_initialize(&authorized, &recent_blockhashes, &Rent::free())
+                .initialize_nonce(&authorized, &recent_blockhashes, &Rent::free())
                 .unwrap();
             assert!(verify_nonce(
                 &nonce_account.account.borrow(),
@@ -224,7 +224,7 @@ mod tests {
             let recent_blockhashes = create_test_recent_blockhashes(0);
             let authorized = nonce_account.unsigned_key().clone();
             nonce_account
-                .nonce_initialize(&authorized, &recent_blockhashes, &Rent::free())
+                .initialize_nonce(&authorized, &recent_blockhashes, &Rent::free())
                 .unwrap();
             assert!(!verify_nonce(
                 &nonce_account.account.borrow(),

--- a/runtime/src/nonce_utils.rs
+++ b/runtime/src/nonce_utils.rs
@@ -39,7 +39,7 @@ pub fn get_nonce_pubkey_from_instruction<'a>(
     })
 }
 
-pub fn verify_nonce(acc: &Account, hash: &Hash) -> bool {
+pub fn verify_nonce_account(acc: &Account, hash: &Hash) -> bool {
     match acc.state() {
         Ok(NonceState::Initialized(_meta, ref nonce)) => hash == nonce,
         _ => false,
@@ -93,7 +93,7 @@ mod tests {
         let tx = Transaction::new_signed_instructions(
             &[&from_keypair, &nonce_keypair],
             vec![
-                system_instruction::advance_nonce(&nonce_pubkey, &nonce_pubkey),
+                system_instruction::advance_nonce_account(&nonce_pubkey, &nonce_pubkey),
                 system_instruction::transfer(&from_pubkey, &nonce_pubkey, 42),
             ],
             Hash::default(),
@@ -131,7 +131,7 @@ mod tests {
             &[&from_keypair, &nonce_keypair],
             vec![
                 system_instruction::transfer(&from_pubkey, &nonce_pubkey, 42),
-                system_instruction::advance_nonce(&nonce_pubkey, &nonce_pubkey),
+                system_instruction::advance_nonce_account(&nonce_pubkey, &nonce_pubkey),
             ],
             Hash::default(),
         );
@@ -147,7 +147,12 @@ mod tests {
         let tx = Transaction::new_signed_instructions(
             &[&from_keypair, &nonce_keypair],
             vec![
-                system_instruction::withdraw_nonce(&nonce_pubkey, &nonce_pubkey, &from_pubkey, 42),
+                system_instruction::withdraw_nonce_account(
+                    &nonce_pubkey,
+                    &nonce_pubkey,
+                    &from_pubkey,
+                    42,
+                ),
                 system_instruction::transfer(&from_pubkey, &nonce_pubkey, 42),
             ],
             Hash::default(),
@@ -194,9 +199,9 @@ mod tests {
             let recent_blockhashes = create_test_recent_blockhashes(0);
             let authorized = nonce_account.unsigned_key().clone();
             nonce_account
-                .initialize_nonce(&authorized, &recent_blockhashes, &Rent::free())
+                .initialize_nonce_account(&authorized, &recent_blockhashes, &Rent::free())
                 .unwrap();
-            assert!(verify_nonce(
+            assert!(verify_nonce_account(
                 &nonce_account.account.borrow(),
                 &recent_blockhashes[0]
             ));
@@ -206,7 +211,7 @@ mod tests {
     #[test]
     fn verify_nonce_bad_acc_state_fail() {
         with_test_keyed_account(42, true, |nonce_account| {
-            assert!(!verify_nonce(
+            assert!(!verify_nonce_account(
                 &nonce_account.account.borrow(),
                 &Hash::default()
             ));
@@ -224,9 +229,9 @@ mod tests {
             let recent_blockhashes = create_test_recent_blockhashes(0);
             let authorized = nonce_account.unsigned_key().clone();
             nonce_account
-                .initialize_nonce(&authorized, &recent_blockhashes, &Rent::free())
+                .initialize_nonce_account(&authorized, &recent_blockhashes, &Rent::free())
                 .unwrap();
-            assert!(!verify_nonce(
+            assert!(!verify_nonce_account(
                 &nonce_account.account.borrow(),
                 &recent_blockhashes[1]
             ));

--- a/runtime/src/system_instruction_processor.rs
+++ b/runtime/src/system_instruction_processor.rs
@@ -237,7 +237,7 @@ pub fn process_instruction(
         }
         SystemInstruction::AdvanceNonceAccount => {
             let me = &mut next_keyed_account(keyed_accounts_iter)?;
-            me.advance_nonce(
+            me.advance_nonce_account(
                 &RecentBlockhashes::from_keyed_account(next_keyed_account(keyed_accounts_iter)?)?,
                 &signers,
             )
@@ -245,7 +245,7 @@ pub fn process_instruction(
         SystemInstruction::WithdrawNonceAccount(lamports) => {
             let me = &mut next_keyed_account(keyed_accounts_iter)?;
             let to = &mut next_keyed_account(keyed_accounts_iter)?;
-            me.withdraw_nonce(
+            me.withdraw_nonce_account(
                 lamports,
                 to,
                 &RecentBlockhashes::from_keyed_account(next_keyed_account(keyed_accounts_iter)?)?,
@@ -255,7 +255,7 @@ pub fn process_instruction(
         }
         SystemInstruction::InitializeNonceAccount(authorized) => {
             let me = &mut next_keyed_account(keyed_accounts_iter)?;
-            me.initialize_nonce(
+            me.initialize_nonce_account(
                 &authorized,
                 &RecentBlockhashes::from_keyed_account(next_keyed_account(keyed_accounts_iter)?)?,
                 &Rent::from_keyed_account(next_keyed_account(keyed_accounts_iter)?)?,
@@ -263,7 +263,7 @@ pub fn process_instruction(
         }
         SystemInstruction::AuthorizeNonceAccount(nonce_authority) => {
             let me = &mut next_keyed_account(keyed_accounts_iter)?;
-            me.authorize_nonce(&nonce_authority, &signers)
+            me.authorize_nonce_account(&nonce_authority, &signers)
         }
         SystemInstruction::Allocate { space } => {
             let keyed_account = next_keyed_account(keyed_accounts_iter)?;
@@ -1045,7 +1045,7 @@ mod tests {
     #[test]
     fn test_process_nonce_ix_no_acc_data_fail() {
         assert_eq!(
-            process_nonce_instruction(&system_instruction::advance_nonce(
+            process_nonce_instruction(&system_instruction::advance_nonce_account(
                 &Pubkey::default(),
                 &Pubkey::default()
             )),
@@ -1142,7 +1142,7 @@ mod tests {
     #[test]
     fn test_process_withdraw_ix_no_acc_data_fail() {
         assert_eq!(
-            process_nonce_instruction(&system_instruction::withdraw_nonce(
+            process_nonce_instruction(&system_instruction::withdraw_nonce_account(
                 &Pubkey::default(),
                 &Pubkey::default(),
                 &Pubkey::default(),
@@ -1379,7 +1379,7 @@ mod tests {
     #[test]
     fn test_process_authorize_bad_account_data_fail() {
         assert_eq!(
-            process_nonce_instruction(&system_instruction::authorize_nonce(
+            process_nonce_instruction(&system_instruction::authorize_nonce_account(
                 &Pubkey::default(),
                 &Pubkey::default(),
                 &Pubkey::default(),

--- a/runtime/src/system_instruction_processor.rs
+++ b/runtime/src/system_instruction_processor.rs
@@ -237,7 +237,7 @@ pub fn process_instruction(
         }
         SystemInstruction::AdvanceNonceAccount => {
             let me = &mut next_keyed_account(keyed_accounts_iter)?;
-            me.nonce_advance(
+            me.advance_nonce(
                 &RecentBlockhashes::from_keyed_account(next_keyed_account(keyed_accounts_iter)?)?,
                 &signers,
             )
@@ -245,7 +245,7 @@ pub fn process_instruction(
         SystemInstruction::WithdrawNonceAccount(lamports) => {
             let me = &mut next_keyed_account(keyed_accounts_iter)?;
             let to = &mut next_keyed_account(keyed_accounts_iter)?;
-            me.nonce_withdraw(
+            me.withdraw_nonce(
                 lamports,
                 to,
                 &RecentBlockhashes::from_keyed_account(next_keyed_account(keyed_accounts_iter)?)?,
@@ -255,7 +255,7 @@ pub fn process_instruction(
         }
         SystemInstruction::InitializeNonceAccount(authorized) => {
             let me = &mut next_keyed_account(keyed_accounts_iter)?;
-            me.nonce_initialize(
+            me.initialize_nonce(
                 &authorized,
                 &RecentBlockhashes::from_keyed_account(next_keyed_account(keyed_accounts_iter)?)?,
                 &Rent::from_keyed_account(next_keyed_account(keyed_accounts_iter)?)?,
@@ -263,7 +263,7 @@ pub fn process_instruction(
         }
         SystemInstruction::AuthorizeNonceAccount(nonce_authority) => {
             let me = &mut next_keyed_account(keyed_accounts_iter)?;
-            me.nonce_authorize(&nonce_authority, &signers)
+            me.authorize_nonce(&nonce_authority, &signers)
         }
         SystemInstruction::Allocate { space } => {
             let keyed_account = next_keyed_account(keyed_accounts_iter)?;
@@ -1045,7 +1045,7 @@ mod tests {
     #[test]
     fn test_process_nonce_ix_no_acc_data_fail() {
         assert_eq!(
-            process_nonce_instruction(&system_instruction::nonce_advance(
+            process_nonce_instruction(&system_instruction::advance_nonce(
                 &Pubkey::default(),
                 &Pubkey::default()
             )),
@@ -1142,7 +1142,7 @@ mod tests {
     #[test]
     fn test_process_withdraw_ix_no_acc_data_fail() {
         assert_eq!(
-            process_nonce_instruction(&system_instruction::nonce_withdraw(
+            process_nonce_instruction(&system_instruction::withdraw_nonce(
                 &Pubkey::default(),
                 &Pubkey::default(),
                 &Pubkey::default(),
@@ -1379,7 +1379,7 @@ mod tests {
     #[test]
     fn test_process_authorize_bad_account_data_fail() {
         assert_eq!(
-            process_nonce_instruction(&system_instruction::nonce_authorize(
+            process_nonce_instruction(&system_instruction::authorize_nonce(
                 &Pubkey::default(),
                 &Pubkey::default(),
                 &Pubkey::default(),

--- a/sdk/src/nonce_state.rs
+++ b/sdk/src/nonce_state.rs
@@ -45,12 +45,12 @@ impl NonceState {
 }
 
 pub trait NonceAccount {
-    fn advance_nonce(
+    fn advance_nonce_account(
         &mut self,
         recent_blockhashes: &RecentBlockhashes,
         signers: &HashSet<Pubkey>,
     ) -> Result<(), InstructionError>;
-    fn withdraw_nonce(
+    fn withdraw_nonce_account(
         &mut self,
         lamports: u64,
         to: &mut KeyedAccount,
@@ -58,13 +58,13 @@ pub trait NonceAccount {
         rent: &Rent,
         signers: &HashSet<Pubkey>,
     ) -> Result<(), InstructionError>;
-    fn initialize_nonce(
+    fn initialize_nonce_account(
         &mut self,
         nonce_authority: &Pubkey,
         recent_blockhashes: &RecentBlockhashes,
         rent: &Rent,
     ) -> Result<(), InstructionError>;
-    fn authorize_nonce(
+    fn authorize_nonce_account(
         &mut self,
         nonce_authority: &Pubkey,
         signers: &HashSet<Pubkey>,
@@ -72,7 +72,7 @@ pub trait NonceAccount {
 }
 
 impl<'a> NonceAccount for KeyedAccount<'a> {
-    fn advance_nonce(
+    fn advance_nonce_account(
         &mut self,
         recent_blockhashes: &RecentBlockhashes,
         signers: &HashSet<Pubkey>,
@@ -97,7 +97,7 @@ impl<'a> NonceAccount for KeyedAccount<'a> {
         self.set_state(&NonceState::Initialized(meta, recent_blockhashes[0]))
     }
 
-    fn withdraw_nonce(
+    fn withdraw_nonce_account(
         &mut self,
         lamports: u64,
         to: &mut KeyedAccount,
@@ -137,7 +137,7 @@ impl<'a> NonceAccount for KeyedAccount<'a> {
         Ok(())
     }
 
-    fn initialize_nonce(
+    fn initialize_nonce_account(
         &mut self,
         nonce_authority: &Pubkey,
         recent_blockhashes: &RecentBlockhashes,
@@ -161,7 +161,7 @@ impl<'a> NonceAccount for KeyedAccount<'a> {
         self.set_state(&NonceState::Initialized(meta, recent_blockhashes[0]))
     }
 
-    fn authorize_nonce(
+    fn authorize_nonce_account(
         &mut self,
         nonce_authority: &Pubkey,
         signers: &HashSet<Pubkey>,
@@ -240,7 +240,7 @@ mod test {
             let recent_blockhashes = create_test_recent_blockhashes(95);
             let authorized = keyed_account.unsigned_key().clone();
             keyed_account
-                .initialize_nonce(&authorized, &recent_blockhashes, &rent)
+                .initialize_nonce_account(&authorized, &recent_blockhashes, &rent)
                 .unwrap();
             let state: NonceState = keyed_account.state().unwrap();
             let stored = recent_blockhashes[0];
@@ -248,7 +248,7 @@ mod test {
             assert_eq!(state, NonceState::Initialized(meta, stored));
             let recent_blockhashes = create_test_recent_blockhashes(63);
             keyed_account
-                .advance_nonce(&recent_blockhashes, &signers)
+                .advance_nonce_account(&recent_blockhashes, &signers)
                 .unwrap();
             let state: NonceState = keyed_account.state().unwrap();
             let stored = recent_blockhashes[0];
@@ -256,7 +256,7 @@ mod test {
             assert_eq!(state, NonceState::Initialized(meta, stored));
             let recent_blockhashes = create_test_recent_blockhashes(31);
             keyed_account
-                .advance_nonce(&recent_blockhashes, &signers)
+                .advance_nonce_account(&recent_blockhashes, &signers)
                 .unwrap();
             let state: NonceState = keyed_account.state().unwrap();
             let stored = recent_blockhashes[0];
@@ -269,7 +269,7 @@ mod test {
                     keyed_account.account.borrow().lamports - withdraw_lamports;
                 let expect_to_lamports = to_keyed.account.borrow().lamports + withdraw_lamports;
                 keyed_account
-                    .withdraw_nonce(
+                    .withdraw_nonce_account(
                         withdraw_lamports,
                         &mut to_keyed,
                         &recent_blockhashes,
@@ -301,7 +301,7 @@ mod test {
             let authorized = nonce_account.unsigned_key().clone();
             let meta = Meta::new(&authorized);
             nonce_account
-                .initialize_nonce(&authorized, &recent_blockhashes, &rent)
+                .initialize_nonce_account(&authorized, &recent_blockhashes, &rent)
                 .unwrap();
             let pubkey = nonce_account.account.borrow().owner.clone();
             let mut nonce_account = KeyedAccount::new(&pubkey, false, nonce_account.account);
@@ -309,7 +309,7 @@ mod test {
             assert_eq!(state, NonceState::Initialized(meta, stored));
             let signers = HashSet::new();
             let recent_blockhashes = create_test_recent_blockhashes(0);
-            let result = nonce_account.advance_nonce(&recent_blockhashes, &signers);
+            let result = nonce_account.advance_nonce_account(&recent_blockhashes, &signers);
             assert_eq!(result, Err(InstructionError::MissingRequiredSignature),);
         })
     }
@@ -327,10 +327,10 @@ mod test {
             let recent_blockhashes = create_test_recent_blockhashes(0);
             let authorized = keyed_account.unsigned_key().clone();
             keyed_account
-                .initialize_nonce(&authorized, &recent_blockhashes, &rent)
+                .initialize_nonce_account(&authorized, &recent_blockhashes, &rent)
                 .unwrap();
             let recent_blockhashes = RecentBlockhashes::from_iter(vec![].into_iter());
-            let result = keyed_account.advance_nonce(&recent_blockhashes, &signers);
+            let result = keyed_account.advance_nonce_account(&recent_blockhashes, &signers);
             assert_eq!(result, Err(NonceError::NoRecentBlockhashes.into()));
         })
     }
@@ -348,9 +348,9 @@ mod test {
             let recent_blockhashes = create_test_recent_blockhashes(63);
             let authorized = keyed_account.unsigned_key().clone();
             keyed_account
-                .initialize_nonce(&authorized, &recent_blockhashes, &rent)
+                .initialize_nonce_account(&authorized, &recent_blockhashes, &rent)
                 .unwrap();
-            let result = keyed_account.advance_nonce(&recent_blockhashes, &signers);
+            let result = keyed_account.advance_nonce_account(&recent_blockhashes, &signers);
             assert_eq!(result, Err(NonceError::NotExpired.into()));
         })
     }
@@ -366,7 +366,7 @@ mod test {
             let mut signers = HashSet::new();
             signers.insert(keyed_account.signer_key().unwrap().clone());
             let recent_blockhashes = create_test_recent_blockhashes(63);
-            let result = keyed_account.advance_nonce(&recent_blockhashes, &signers);
+            let result = keyed_account.advance_nonce_account(&recent_blockhashes, &signers);
             assert_eq!(result, Err(NonceError::BadAccountState.into()));
         })
     }
@@ -385,12 +385,12 @@ mod test {
                 let recent_blockhashes = create_test_recent_blockhashes(63);
                 let authorized = nonce_authority.unsigned_key().clone();
                 nonce_account
-                    .initialize_nonce(&authorized, &recent_blockhashes, &rent)
+                    .initialize_nonce_account(&authorized, &recent_blockhashes, &rent)
                     .unwrap();
                 let mut signers = HashSet::new();
                 signers.insert(nonce_authority.signer_key().unwrap().clone());
                 let recent_blockhashes = create_test_recent_blockhashes(31);
-                let result = nonce_account.advance_nonce(&recent_blockhashes, &signers);
+                let result = nonce_account.advance_nonce_account(&recent_blockhashes, &signers);
                 assert_eq!(result, Ok(()));
             });
         });
@@ -410,9 +410,9 @@ mod test {
                 let recent_blockhashes = create_test_recent_blockhashes(63);
                 let authorized = nonce_authority.unsigned_key().clone();
                 nonce_account
-                    .initialize_nonce(&authorized, &recent_blockhashes, &rent)
+                    .initialize_nonce_account(&authorized, &recent_blockhashes, &rent)
                     .unwrap();
-                let result = nonce_account.advance_nonce(&recent_blockhashes, &signers);
+                let result = nonce_account.advance_nonce_account(&recent_blockhashes, &signers);
                 assert_eq!(result, Err(InstructionError::MissingRequiredSignature),);
             });
         });
@@ -437,7 +437,7 @@ mod test {
                     nonce_keyed.account.borrow().lamports - withdraw_lamports;
                 let expect_to_lamports = to_keyed.account.borrow().lamports + withdraw_lamports;
                 nonce_keyed
-                    .withdraw_nonce(
+                    .withdraw_nonce_account(
                         withdraw_lamports,
                         &mut to_keyed,
                         &recent_blockhashes,
@@ -471,7 +471,7 @@ mod test {
                 let signers = HashSet::new();
                 let recent_blockhashes = create_test_recent_blockhashes(0);
                 let lamports = nonce_keyed.account.borrow().lamports;
-                let result = nonce_keyed.withdraw_nonce(
+                let result = nonce_keyed.withdraw_nonce_account(
                     lamports,
                     &mut to_keyed,
                     &recent_blockhashes,
@@ -498,7 +498,7 @@ mod test {
                 signers.insert(nonce_keyed.signer_key().unwrap().clone());
                 let recent_blockhashes = create_test_recent_blockhashes(0);
                 let lamports = nonce_keyed.account.borrow().lamports + 1;
-                let result = nonce_keyed.withdraw_nonce(
+                let result = nonce_keyed.withdraw_nonce_account(
                     lamports,
                     &mut to_keyed,
                     &recent_blockhashes,
@@ -527,7 +527,7 @@ mod test {
                     nonce_keyed.account.borrow().lamports - withdraw_lamports;
                 let to_expect_lamports = to_keyed.account.borrow().lamports + withdraw_lamports;
                 nonce_keyed
-                    .withdraw_nonce(
+                    .withdraw_nonce_account(
                         withdraw_lamports,
                         &mut to_keyed,
                         &recent_blockhashes,
@@ -544,7 +544,7 @@ mod test {
                     nonce_keyed.account.borrow().lamports - withdraw_lamports;
                 let to_expect_lamports = to_keyed.account.borrow().lamports + withdraw_lamports;
                 nonce_keyed
-                    .withdraw_nonce(
+                    .withdraw_nonce_account(
                         withdraw_lamports,
                         &mut to_keyed,
                         &recent_blockhashes,
@@ -574,7 +574,7 @@ mod test {
             let authorized = nonce_keyed.unsigned_key().clone();
             let meta = Meta::new(&authorized);
             nonce_keyed
-                .initialize_nonce(&authorized, &recent_blockhashes, &rent)
+                .initialize_nonce_account(&authorized, &recent_blockhashes, &rent)
                 .unwrap();
             let state: NonceState = nonce_keyed.state().unwrap();
             let stored = recent_blockhashes[0];
@@ -585,7 +585,7 @@ mod test {
                     nonce_keyed.account.borrow().lamports - withdraw_lamports;
                 let to_expect_lamports = to_keyed.account.borrow().lamports + withdraw_lamports;
                 nonce_keyed
-                    .withdraw_nonce(
+                    .withdraw_nonce_account(
                         withdraw_lamports,
                         &mut to_keyed,
                         &recent_blockhashes,
@@ -604,7 +604,7 @@ mod test {
                     nonce_keyed.account.borrow().lamports - withdraw_lamports;
                 let to_expect_lamports = to_keyed.account.borrow().lamports + withdraw_lamports;
                 nonce_keyed
-                    .withdraw_nonce(
+                    .withdraw_nonce_account(
                         withdraw_lamports,
                         &mut to_keyed,
                         &recent_blockhashes,
@@ -629,13 +629,13 @@ mod test {
             let recent_blockhashes = create_test_recent_blockhashes(0);
             let authorized = nonce_keyed.unsigned_key().clone();
             nonce_keyed
-                .initialize_nonce(&authorized, &recent_blockhashes, &rent)
+                .initialize_nonce_account(&authorized, &recent_blockhashes, &rent)
                 .unwrap();
             with_test_keyed_account(42, false, |mut to_keyed| {
                 let mut signers = HashSet::new();
                 signers.insert(nonce_keyed.signer_key().unwrap().clone());
                 let withdraw_lamports = nonce_keyed.account.borrow().lamports;
-                let result = nonce_keyed.withdraw_nonce(
+                let result = nonce_keyed.withdraw_nonce_account(
                     withdraw_lamports,
                     &mut to_keyed,
                     &recent_blockhashes,
@@ -658,14 +658,14 @@ mod test {
             let recent_blockhashes = create_test_recent_blockhashes(95);
             let authorized = nonce_keyed.unsigned_key().clone();
             nonce_keyed
-                .initialize_nonce(&authorized, &recent_blockhashes, &rent)
+                .initialize_nonce_account(&authorized, &recent_blockhashes, &rent)
                 .unwrap();
             with_test_keyed_account(42, false, |mut to_keyed| {
                 let recent_blockhashes = create_test_recent_blockhashes(63);
                 let mut signers = HashSet::new();
                 signers.insert(nonce_keyed.signer_key().unwrap().clone());
                 let withdraw_lamports = nonce_keyed.account.borrow().lamports + 1;
-                let result = nonce_keyed.withdraw_nonce(
+                let result = nonce_keyed.withdraw_nonce_account(
                     withdraw_lamports,
                     &mut to_keyed,
                     &recent_blockhashes,
@@ -688,14 +688,14 @@ mod test {
             let recent_blockhashes = create_test_recent_blockhashes(95);
             let authorized = nonce_keyed.unsigned_key().clone();
             nonce_keyed
-                .initialize_nonce(&authorized, &recent_blockhashes, &rent)
+                .initialize_nonce_account(&authorized, &recent_blockhashes, &rent)
                 .unwrap();
             with_test_keyed_account(42, false, |mut to_keyed| {
                 let recent_blockhashes = create_test_recent_blockhashes(63);
                 let mut signers = HashSet::new();
                 signers.insert(nonce_keyed.signer_key().unwrap().clone());
                 let withdraw_lamports = nonce_keyed.account.borrow().lamports - min_lamports + 1;
-                let result = nonce_keyed.withdraw_nonce(
+                let result = nonce_keyed.withdraw_nonce_account(
                     withdraw_lamports,
                     &mut to_keyed,
                     &recent_blockhashes,
@@ -723,7 +723,8 @@ mod test {
             let stored = recent_blockhashes[0];
             let authorized = keyed_account.unsigned_key().clone();
             let meta = Meta::new(&authorized);
-            let result = keyed_account.initialize_nonce(&authorized, &recent_blockhashes, &rent);
+            let result =
+                keyed_account.initialize_nonce_account(&authorized, &recent_blockhashes, &rent);
             assert_eq!(result, Ok(()));
             let state: NonceState = keyed_account.state().unwrap();
             assert_eq!(state, NonceState::Initialized(meta, stored));
@@ -742,7 +743,8 @@ mod test {
             signers.insert(keyed_account.signer_key().unwrap().clone());
             let recent_blockhashes = RecentBlockhashes::from_iter(vec![].into_iter());
             let authorized = keyed_account.unsigned_key().clone();
-            let result = keyed_account.initialize_nonce(&authorized, &recent_blockhashes, &rent);
+            let result =
+                keyed_account.initialize_nonce_account(&authorized, &recent_blockhashes, &rent);
             assert_eq!(result, Err(NonceError::NoRecentBlockhashes.into()));
         })
     }
@@ -758,10 +760,11 @@ mod test {
             let recent_blockhashes = create_test_recent_blockhashes(31);
             let authorized = keyed_account.unsigned_key().clone();
             keyed_account
-                .initialize_nonce(&authorized, &recent_blockhashes, &rent)
+                .initialize_nonce_account(&authorized, &recent_blockhashes, &rent)
                 .unwrap();
             let recent_blockhashes = create_test_recent_blockhashes(0);
-            let result = keyed_account.initialize_nonce(&authorized, &recent_blockhashes, &rent);
+            let result =
+                keyed_account.initialize_nonce_account(&authorized, &recent_blockhashes, &rent);
             assert_eq!(result, Err(NonceError::BadAccountState.into()));
         })
     }
@@ -776,7 +779,8 @@ mod test {
         with_test_keyed_account(min_lamports - 42, true, |keyed_account| {
             let recent_blockhashes = create_test_recent_blockhashes(63);
             let authorized = keyed_account.unsigned_key().clone();
-            let result = keyed_account.initialize_nonce(&authorized, &recent_blockhashes, &rent);
+            let result =
+                keyed_account.initialize_nonce_account(&authorized, &recent_blockhashes, &rent);
             assert_eq!(result, Err(InstructionError::InsufficientFunds));
         })
     }
@@ -795,11 +799,11 @@ mod test {
             let stored = recent_blockhashes[0];
             let authorized = nonce_account.unsigned_key().clone();
             nonce_account
-                .initialize_nonce(&authorized, &recent_blockhashes, &rent)
+                .initialize_nonce_account(&authorized, &recent_blockhashes, &rent)
                 .unwrap();
             let authorized = &Pubkey::default().clone();
             let meta = Meta::new(&authorized);
-            let result = nonce_account.authorize_nonce(&Pubkey::default(), &signers);
+            let result = nonce_account.authorize_nonce_account(&Pubkey::default(), &signers);
             assert_eq!(result, Ok(()));
             let state: NonceState = nonce_account.state().unwrap();
             assert_eq!(state, NonceState::Initialized(meta, stored));
@@ -816,7 +820,7 @@ mod test {
         with_test_keyed_account(min_lamports + 42, true, |nonce_account| {
             let mut signers = HashSet::new();
             signers.insert(nonce_account.signer_key().unwrap().clone());
-            let result = nonce_account.authorize_nonce(&Pubkey::default(), &signers);
+            let result = nonce_account.authorize_nonce_account(&Pubkey::default(), &signers);
             assert_eq!(result, Err(NonceError::BadAccountState.into()));
         })
     }
@@ -834,9 +838,9 @@ mod test {
             let recent_blockhashes = create_test_recent_blockhashes(31);
             let authorized = &Pubkey::default().clone();
             nonce_account
-                .initialize_nonce(&authorized, &recent_blockhashes, &rent)
+                .initialize_nonce_account(&authorized, &recent_blockhashes, &rent)
                 .unwrap();
-            let result = nonce_account.authorize_nonce(&Pubkey::default(), &signers);
+            let result = nonce_account.authorize_nonce_account(&Pubkey::default(), &signers);
             assert_eq!(result, Err(InstructionError::MissingRequiredSignature));
         })
     }

--- a/sdk/src/nonce_state.rs
+++ b/sdk/src/nonce_state.rs
@@ -45,12 +45,12 @@ impl NonceState {
 }
 
 pub trait NonceAccount {
-    fn nonce_advance(
+    fn advance_nonce(
         &mut self,
         recent_blockhashes: &RecentBlockhashes,
         signers: &HashSet<Pubkey>,
     ) -> Result<(), InstructionError>;
-    fn nonce_withdraw(
+    fn withdraw_nonce(
         &mut self,
         lamports: u64,
         to: &mut KeyedAccount,
@@ -58,13 +58,13 @@ pub trait NonceAccount {
         rent: &Rent,
         signers: &HashSet<Pubkey>,
     ) -> Result<(), InstructionError>;
-    fn nonce_initialize(
+    fn initialize_nonce(
         &mut self,
         nonce_authority: &Pubkey,
         recent_blockhashes: &RecentBlockhashes,
         rent: &Rent,
     ) -> Result<(), InstructionError>;
-    fn nonce_authorize(
+    fn authorize_nonce(
         &mut self,
         nonce_authority: &Pubkey,
         signers: &HashSet<Pubkey>,
@@ -72,7 +72,7 @@ pub trait NonceAccount {
 }
 
 impl<'a> NonceAccount for KeyedAccount<'a> {
-    fn nonce_advance(
+    fn advance_nonce(
         &mut self,
         recent_blockhashes: &RecentBlockhashes,
         signers: &HashSet<Pubkey>,
@@ -97,7 +97,7 @@ impl<'a> NonceAccount for KeyedAccount<'a> {
         self.set_state(&NonceState::Initialized(meta, recent_blockhashes[0]))
     }
 
-    fn nonce_withdraw(
+    fn withdraw_nonce(
         &mut self,
         lamports: u64,
         to: &mut KeyedAccount,
@@ -137,7 +137,7 @@ impl<'a> NonceAccount for KeyedAccount<'a> {
         Ok(())
     }
 
-    fn nonce_initialize(
+    fn initialize_nonce(
         &mut self,
         nonce_authority: &Pubkey,
         recent_blockhashes: &RecentBlockhashes,
@@ -161,7 +161,7 @@ impl<'a> NonceAccount for KeyedAccount<'a> {
         self.set_state(&NonceState::Initialized(meta, recent_blockhashes[0]))
     }
 
-    fn nonce_authorize(
+    fn authorize_nonce(
         &mut self,
         nonce_authority: &Pubkey,
         signers: &HashSet<Pubkey>,
@@ -240,7 +240,7 @@ mod test {
             let recent_blockhashes = create_test_recent_blockhashes(95);
             let authorized = keyed_account.unsigned_key().clone();
             keyed_account
-                .nonce_initialize(&authorized, &recent_blockhashes, &rent)
+                .initialize_nonce(&authorized, &recent_blockhashes, &rent)
                 .unwrap();
             let state: NonceState = keyed_account.state().unwrap();
             let stored = recent_blockhashes[0];
@@ -248,7 +248,7 @@ mod test {
             assert_eq!(state, NonceState::Initialized(meta, stored));
             let recent_blockhashes = create_test_recent_blockhashes(63);
             keyed_account
-                .nonce_advance(&recent_blockhashes, &signers)
+                .advance_nonce(&recent_blockhashes, &signers)
                 .unwrap();
             let state: NonceState = keyed_account.state().unwrap();
             let stored = recent_blockhashes[0];
@@ -256,7 +256,7 @@ mod test {
             assert_eq!(state, NonceState::Initialized(meta, stored));
             let recent_blockhashes = create_test_recent_blockhashes(31);
             keyed_account
-                .nonce_advance(&recent_blockhashes, &signers)
+                .advance_nonce(&recent_blockhashes, &signers)
                 .unwrap();
             let state: NonceState = keyed_account.state().unwrap();
             let stored = recent_blockhashes[0];
@@ -269,7 +269,7 @@ mod test {
                     keyed_account.account.borrow().lamports - withdraw_lamports;
                 let expect_to_lamports = to_keyed.account.borrow().lamports + withdraw_lamports;
                 keyed_account
-                    .nonce_withdraw(
+                    .withdraw_nonce(
                         withdraw_lamports,
                         &mut to_keyed,
                         &recent_blockhashes,
@@ -301,7 +301,7 @@ mod test {
             let authorized = nonce_account.unsigned_key().clone();
             let meta = Meta::new(&authorized);
             nonce_account
-                .nonce_initialize(&authorized, &recent_blockhashes, &rent)
+                .initialize_nonce(&authorized, &recent_blockhashes, &rent)
                 .unwrap();
             let pubkey = nonce_account.account.borrow().owner.clone();
             let mut nonce_account = KeyedAccount::new(&pubkey, false, nonce_account.account);
@@ -309,7 +309,7 @@ mod test {
             assert_eq!(state, NonceState::Initialized(meta, stored));
             let signers = HashSet::new();
             let recent_blockhashes = create_test_recent_blockhashes(0);
-            let result = nonce_account.nonce_advance(&recent_blockhashes, &signers);
+            let result = nonce_account.advance_nonce(&recent_blockhashes, &signers);
             assert_eq!(result, Err(InstructionError::MissingRequiredSignature),);
         })
     }
@@ -327,10 +327,10 @@ mod test {
             let recent_blockhashes = create_test_recent_blockhashes(0);
             let authorized = keyed_account.unsigned_key().clone();
             keyed_account
-                .nonce_initialize(&authorized, &recent_blockhashes, &rent)
+                .initialize_nonce(&authorized, &recent_blockhashes, &rent)
                 .unwrap();
             let recent_blockhashes = RecentBlockhashes::from_iter(vec![].into_iter());
-            let result = keyed_account.nonce_advance(&recent_blockhashes, &signers);
+            let result = keyed_account.advance_nonce(&recent_blockhashes, &signers);
             assert_eq!(result, Err(NonceError::NoRecentBlockhashes.into()));
         })
     }
@@ -348,9 +348,9 @@ mod test {
             let recent_blockhashes = create_test_recent_blockhashes(63);
             let authorized = keyed_account.unsigned_key().clone();
             keyed_account
-                .nonce_initialize(&authorized, &recent_blockhashes, &rent)
+                .initialize_nonce(&authorized, &recent_blockhashes, &rent)
                 .unwrap();
-            let result = keyed_account.nonce_advance(&recent_blockhashes, &signers);
+            let result = keyed_account.advance_nonce(&recent_blockhashes, &signers);
             assert_eq!(result, Err(NonceError::NotExpired.into()));
         })
     }
@@ -366,7 +366,7 @@ mod test {
             let mut signers = HashSet::new();
             signers.insert(keyed_account.signer_key().unwrap().clone());
             let recent_blockhashes = create_test_recent_blockhashes(63);
-            let result = keyed_account.nonce_advance(&recent_blockhashes, &signers);
+            let result = keyed_account.advance_nonce(&recent_blockhashes, &signers);
             assert_eq!(result, Err(NonceError::BadAccountState.into()));
         })
     }
@@ -385,12 +385,12 @@ mod test {
                 let recent_blockhashes = create_test_recent_blockhashes(63);
                 let authorized = nonce_authority.unsigned_key().clone();
                 nonce_account
-                    .nonce_initialize(&authorized, &recent_blockhashes, &rent)
+                    .initialize_nonce(&authorized, &recent_blockhashes, &rent)
                     .unwrap();
                 let mut signers = HashSet::new();
                 signers.insert(nonce_authority.signer_key().unwrap().clone());
                 let recent_blockhashes = create_test_recent_blockhashes(31);
-                let result = nonce_account.nonce_advance(&recent_blockhashes, &signers);
+                let result = nonce_account.advance_nonce(&recent_blockhashes, &signers);
                 assert_eq!(result, Ok(()));
             });
         });
@@ -410,9 +410,9 @@ mod test {
                 let recent_blockhashes = create_test_recent_blockhashes(63);
                 let authorized = nonce_authority.unsigned_key().clone();
                 nonce_account
-                    .nonce_initialize(&authorized, &recent_blockhashes, &rent)
+                    .initialize_nonce(&authorized, &recent_blockhashes, &rent)
                     .unwrap();
-                let result = nonce_account.nonce_advance(&recent_blockhashes, &signers);
+                let result = nonce_account.advance_nonce(&recent_blockhashes, &signers);
                 assert_eq!(result, Err(InstructionError::MissingRequiredSignature),);
             });
         });
@@ -437,7 +437,7 @@ mod test {
                     nonce_keyed.account.borrow().lamports - withdraw_lamports;
                 let expect_to_lamports = to_keyed.account.borrow().lamports + withdraw_lamports;
                 nonce_keyed
-                    .nonce_withdraw(
+                    .withdraw_nonce(
                         withdraw_lamports,
                         &mut to_keyed,
                         &recent_blockhashes,
@@ -471,7 +471,7 @@ mod test {
                 let signers = HashSet::new();
                 let recent_blockhashes = create_test_recent_blockhashes(0);
                 let lamports = nonce_keyed.account.borrow().lamports;
-                let result = nonce_keyed.nonce_withdraw(
+                let result = nonce_keyed.withdraw_nonce(
                     lamports,
                     &mut to_keyed,
                     &recent_blockhashes,
@@ -498,7 +498,7 @@ mod test {
                 signers.insert(nonce_keyed.signer_key().unwrap().clone());
                 let recent_blockhashes = create_test_recent_blockhashes(0);
                 let lamports = nonce_keyed.account.borrow().lamports + 1;
-                let result = nonce_keyed.nonce_withdraw(
+                let result = nonce_keyed.withdraw_nonce(
                     lamports,
                     &mut to_keyed,
                     &recent_blockhashes,
@@ -527,7 +527,7 @@ mod test {
                     nonce_keyed.account.borrow().lamports - withdraw_lamports;
                 let to_expect_lamports = to_keyed.account.borrow().lamports + withdraw_lamports;
                 nonce_keyed
-                    .nonce_withdraw(
+                    .withdraw_nonce(
                         withdraw_lamports,
                         &mut to_keyed,
                         &recent_blockhashes,
@@ -544,7 +544,7 @@ mod test {
                     nonce_keyed.account.borrow().lamports - withdraw_lamports;
                 let to_expect_lamports = to_keyed.account.borrow().lamports + withdraw_lamports;
                 nonce_keyed
-                    .nonce_withdraw(
+                    .withdraw_nonce(
                         withdraw_lamports,
                         &mut to_keyed,
                         &recent_blockhashes,
@@ -574,7 +574,7 @@ mod test {
             let authorized = nonce_keyed.unsigned_key().clone();
             let meta = Meta::new(&authorized);
             nonce_keyed
-                .nonce_initialize(&authorized, &recent_blockhashes, &rent)
+                .initialize_nonce(&authorized, &recent_blockhashes, &rent)
                 .unwrap();
             let state: NonceState = nonce_keyed.state().unwrap();
             let stored = recent_blockhashes[0];
@@ -585,7 +585,7 @@ mod test {
                     nonce_keyed.account.borrow().lamports - withdraw_lamports;
                 let to_expect_lamports = to_keyed.account.borrow().lamports + withdraw_lamports;
                 nonce_keyed
-                    .nonce_withdraw(
+                    .withdraw_nonce(
                         withdraw_lamports,
                         &mut to_keyed,
                         &recent_blockhashes,
@@ -604,7 +604,7 @@ mod test {
                     nonce_keyed.account.borrow().lamports - withdraw_lamports;
                 let to_expect_lamports = to_keyed.account.borrow().lamports + withdraw_lamports;
                 nonce_keyed
-                    .nonce_withdraw(
+                    .withdraw_nonce(
                         withdraw_lamports,
                         &mut to_keyed,
                         &recent_blockhashes,
@@ -629,13 +629,13 @@ mod test {
             let recent_blockhashes = create_test_recent_blockhashes(0);
             let authorized = nonce_keyed.unsigned_key().clone();
             nonce_keyed
-                .nonce_initialize(&authorized, &recent_blockhashes, &rent)
+                .initialize_nonce(&authorized, &recent_blockhashes, &rent)
                 .unwrap();
             with_test_keyed_account(42, false, |mut to_keyed| {
                 let mut signers = HashSet::new();
                 signers.insert(nonce_keyed.signer_key().unwrap().clone());
                 let withdraw_lamports = nonce_keyed.account.borrow().lamports;
-                let result = nonce_keyed.nonce_withdraw(
+                let result = nonce_keyed.withdraw_nonce(
                     withdraw_lamports,
                     &mut to_keyed,
                     &recent_blockhashes,
@@ -658,14 +658,14 @@ mod test {
             let recent_blockhashes = create_test_recent_blockhashes(95);
             let authorized = nonce_keyed.unsigned_key().clone();
             nonce_keyed
-                .nonce_initialize(&authorized, &recent_blockhashes, &rent)
+                .initialize_nonce(&authorized, &recent_blockhashes, &rent)
                 .unwrap();
             with_test_keyed_account(42, false, |mut to_keyed| {
                 let recent_blockhashes = create_test_recent_blockhashes(63);
                 let mut signers = HashSet::new();
                 signers.insert(nonce_keyed.signer_key().unwrap().clone());
                 let withdraw_lamports = nonce_keyed.account.borrow().lamports + 1;
-                let result = nonce_keyed.nonce_withdraw(
+                let result = nonce_keyed.withdraw_nonce(
                     withdraw_lamports,
                     &mut to_keyed,
                     &recent_blockhashes,
@@ -688,14 +688,14 @@ mod test {
             let recent_blockhashes = create_test_recent_blockhashes(95);
             let authorized = nonce_keyed.unsigned_key().clone();
             nonce_keyed
-                .nonce_initialize(&authorized, &recent_blockhashes, &rent)
+                .initialize_nonce(&authorized, &recent_blockhashes, &rent)
                 .unwrap();
             with_test_keyed_account(42, false, |mut to_keyed| {
                 let recent_blockhashes = create_test_recent_blockhashes(63);
                 let mut signers = HashSet::new();
                 signers.insert(nonce_keyed.signer_key().unwrap().clone());
                 let withdraw_lamports = nonce_keyed.account.borrow().lamports - min_lamports + 1;
-                let result = nonce_keyed.nonce_withdraw(
+                let result = nonce_keyed.withdraw_nonce(
                     withdraw_lamports,
                     &mut to_keyed,
                     &recent_blockhashes,
@@ -723,7 +723,7 @@ mod test {
             let stored = recent_blockhashes[0];
             let authorized = keyed_account.unsigned_key().clone();
             let meta = Meta::new(&authorized);
-            let result = keyed_account.nonce_initialize(&authorized, &recent_blockhashes, &rent);
+            let result = keyed_account.initialize_nonce(&authorized, &recent_blockhashes, &rent);
             assert_eq!(result, Ok(()));
             let state: NonceState = keyed_account.state().unwrap();
             assert_eq!(state, NonceState::Initialized(meta, stored));
@@ -742,7 +742,7 @@ mod test {
             signers.insert(keyed_account.signer_key().unwrap().clone());
             let recent_blockhashes = RecentBlockhashes::from_iter(vec![].into_iter());
             let authorized = keyed_account.unsigned_key().clone();
-            let result = keyed_account.nonce_initialize(&authorized, &recent_blockhashes, &rent);
+            let result = keyed_account.initialize_nonce(&authorized, &recent_blockhashes, &rent);
             assert_eq!(result, Err(NonceError::NoRecentBlockhashes.into()));
         })
     }
@@ -758,10 +758,10 @@ mod test {
             let recent_blockhashes = create_test_recent_blockhashes(31);
             let authorized = keyed_account.unsigned_key().clone();
             keyed_account
-                .nonce_initialize(&authorized, &recent_blockhashes, &rent)
+                .initialize_nonce(&authorized, &recent_blockhashes, &rent)
                 .unwrap();
             let recent_blockhashes = create_test_recent_blockhashes(0);
-            let result = keyed_account.nonce_initialize(&authorized, &recent_blockhashes, &rent);
+            let result = keyed_account.initialize_nonce(&authorized, &recent_blockhashes, &rent);
             assert_eq!(result, Err(NonceError::BadAccountState.into()));
         })
     }
@@ -776,7 +776,7 @@ mod test {
         with_test_keyed_account(min_lamports - 42, true, |keyed_account| {
             let recent_blockhashes = create_test_recent_blockhashes(63);
             let authorized = keyed_account.unsigned_key().clone();
-            let result = keyed_account.nonce_initialize(&authorized, &recent_blockhashes, &rent);
+            let result = keyed_account.initialize_nonce(&authorized, &recent_blockhashes, &rent);
             assert_eq!(result, Err(InstructionError::InsufficientFunds));
         })
     }
@@ -795,11 +795,11 @@ mod test {
             let stored = recent_blockhashes[0];
             let authorized = nonce_account.unsigned_key().clone();
             nonce_account
-                .nonce_initialize(&authorized, &recent_blockhashes, &rent)
+                .initialize_nonce(&authorized, &recent_blockhashes, &rent)
                 .unwrap();
             let authorized = &Pubkey::default().clone();
             let meta = Meta::new(&authorized);
-            let result = nonce_account.nonce_authorize(&Pubkey::default(), &signers);
+            let result = nonce_account.authorize_nonce(&Pubkey::default(), &signers);
             assert_eq!(result, Ok(()));
             let state: NonceState = nonce_account.state().unwrap();
             assert_eq!(state, NonceState::Initialized(meta, stored));
@@ -816,7 +816,7 @@ mod test {
         with_test_keyed_account(min_lamports + 42, true, |nonce_account| {
             let mut signers = HashSet::new();
             signers.insert(nonce_account.signer_key().unwrap().clone());
-            let result = nonce_account.nonce_authorize(&Pubkey::default(), &signers);
+            let result = nonce_account.authorize_nonce(&Pubkey::default(), &signers);
             assert_eq!(result, Err(NonceError::BadAccountState.into()));
         })
     }
@@ -834,9 +834,9 @@ mod test {
             let recent_blockhashes = create_test_recent_blockhashes(31);
             let authorized = &Pubkey::default().clone();
             nonce_account
-                .nonce_initialize(&authorized, &recent_blockhashes, &rent)
+                .initialize_nonce(&authorized, &recent_blockhashes, &rent)
                 .unwrap();
-            let result = nonce_account.nonce_authorize(&Pubkey::default(), &signers);
+            let result = nonce_account.authorize_nonce(&Pubkey::default(), &signers);
             assert_eq!(result, Err(InstructionError::MissingRequiredSignature));
         })
     }

--- a/sdk/src/system_instruction.rs
+++ b/sdk/src/system_instruction.rs
@@ -363,7 +363,7 @@ pub fn create_nonce_account(
     ]
 }
 
-pub fn nonce_advance(nonce_pubkey: &Pubkey, authorized_pubkey: &Pubkey) -> Instruction {
+pub fn advance_nonce(nonce_pubkey: &Pubkey, authorized_pubkey: &Pubkey) -> Instruction {
     let account_metas = vec![
         AccountMeta::new(*nonce_pubkey, false),
         AccountMeta::new_readonly(recent_blockhashes::id(), false),
@@ -376,7 +376,7 @@ pub fn nonce_advance(nonce_pubkey: &Pubkey, authorized_pubkey: &Pubkey) -> Instr
     )
 }
 
-pub fn nonce_withdraw(
+pub fn withdraw_nonce(
     nonce_pubkey: &Pubkey,
     authorized_pubkey: &Pubkey,
     to_pubkey: &Pubkey,
@@ -396,7 +396,7 @@ pub fn nonce_withdraw(
     )
 }
 
-pub fn nonce_authorize(
+pub fn authorize_nonce(
     nonce_pubkey: &Pubkey,
     authorized_pubkey: &Pubkey,
     new_authority: &Pubkey,

--- a/sdk/src/system_instruction.rs
+++ b/sdk/src/system_instruction.rs
@@ -363,7 +363,7 @@ pub fn create_nonce_account(
     ]
 }
 
-pub fn advance_nonce(nonce_pubkey: &Pubkey, authorized_pubkey: &Pubkey) -> Instruction {
+pub fn advance_nonce_account(nonce_pubkey: &Pubkey, authorized_pubkey: &Pubkey) -> Instruction {
     let account_metas = vec![
         AccountMeta::new(*nonce_pubkey, false),
         AccountMeta::new_readonly(recent_blockhashes::id(), false),
@@ -376,7 +376,7 @@ pub fn advance_nonce(nonce_pubkey: &Pubkey, authorized_pubkey: &Pubkey) -> Instr
     )
 }
 
-pub fn withdraw_nonce(
+pub fn withdraw_nonce_account(
     nonce_pubkey: &Pubkey,
     authorized_pubkey: &Pubkey,
     to_pubkey: &Pubkey,
@@ -396,7 +396,7 @@ pub fn withdraw_nonce(
     )
 }
 
-pub fn authorize_nonce(
+pub fn authorize_nonce_account(
     nonce_pubkey: &Pubkey,
     authorized_pubkey: &Pubkey,
     new_authority: &Pubkey,

--- a/sdk/src/transaction.rs
+++ b/sdk/src/transaction.rs
@@ -110,8 +110,10 @@ impl Transaction {
         nonce_authority_pubkey: &Pubkey,
         nonce_hash: Hash,
     ) -> Self {
-        let nonce_ix =
-            system_instruction::advance_nonce(&nonce_account_pubkey, &nonce_authority_pubkey);
+        let nonce_ix = system_instruction::advance_nonce_account(
+            &nonce_account_pubkey,
+            &nonce_authority_pubkey,
+        );
         instructions.insert(0, nonce_ix);
         Self::new_signed_with_payer(instructions, payer, signing_keypairs, nonce_hash)
     }

--- a/sdk/src/transaction.rs
+++ b/sdk/src/transaction.rs
@@ -111,7 +111,7 @@ impl Transaction {
         nonce_hash: Hash,
     ) -> Self {
         let nonce_ix =
-            system_instruction::nonce_advance(&nonce_account_pubkey, &nonce_authority_pubkey);
+            system_instruction::advance_nonce(&nonce_account_pubkey, &nonce_authority_pubkey);
         instructions.insert(0, nonce_ix);
         Self::new_signed_with_payer(instructions, payer, signing_keypairs, nonce_hash)
     }


### PR DESCRIPTION
#### Problem

Nonce API doesn't follow verb-noun naming convention

#### Summary of Changes

Rename them

Fixes #7914 