### PR TITLE
Reject CI on failed mergify.io backports

### DIFF
--- a/ci/test-checks.sh
+++ b/ci/test-checks.sh
@@ -10,6 +10,9 @@ source ci/rust-version.sh nightly
 export RUST_BACKTRACE=1
 export RUSTFLAGS="-D warnings"
 
+# Look for failed mergify.io backports
+_ git show HEAD --check --oneline
+
 _ cargo +"$rust_stable" fmt --all -- --check
 
 # Clippy gets stuck for unknown reasons if sdk-c is included in the build, so check it separately.


### PR DESCRIPTION
#### Problem
https://github.com/Mergifyio/mergify-engine/issues/336 is not fixed yet

#### Summary of Changes
Look for merge conflict markers in the HEAD commit and fail the build if found.