### PR TITLE
Report last tower distance and add partition testcase

### DIFF
--- a/system-test/partition-testcases/colo-partition-once-then-stabilize.yml
+++ b/system-test/partition-testcases/colo-partition-once-then-stabilize.yml
@@ -1,0 +1,19 @@
+steps:
+  - command: "system-test/testnet-automation.sh"
+    label: "Colo - CPU Only - 1 minute partition then 5 minute stabilization"
+    env:
+      UPLOAD_RESULTS_TO_SLACK: "true"
+      CLOUD_PROVIDER: "colo"
+      TESTNET_TAG: "colo-perf-cpu-only"
+      NUMBER_OF_VALIDATOR_NODES: 4
+      ENABLE_GPU: "false"
+      NUMBER_OF_CLIENT_NODES: 2
+      CLIENT_OPTIONS: "bench-tps=2=--tx_count 15000 --thread-batch-sleep-ms 250"
+      ADDITIONAL_FLAGS: ""
+      APPLY_PARTITIONS: "true"
+      NETEM_CONFIG_FILE: "system-test/netem-configs/partial-loss-three-partitions"
+      PARTITION_ACTIVE_DURATION: 60
+      PARTITION_INACTIVE_DURATION: 300
+      PARTITION_ITERATION_COUNT: 1
+    agents:
+      - "queue=colo-deploy"

--- a/system-test/partition-testcases/gce-partition-once-then-stabilize.yml
+++ b/system-test/partition-testcases/gce-partition-once-then-stabilize.yml
@@ -1,0 +1,22 @@
+steps:
+  - command: "system-test/testnet-automation.sh"
+    label: "GCE - CPU Only - 1 minute partition then 5 minute stabilization"
+    env:
+      UPLOAD_RESULTS_TO_SLACK: "true"
+      CLOUD_PROVIDER: "gce"
+      TESTNET_TAG: "gce-perf-cpu-only"
+      NUMBER_OF_VALIDATOR_NODES: 5
+      ENABLE_GPU: "false"
+      VALIDATOR_NODE_MACHINE_TYPE: "--machine-type n1-standard-16"
+      NUMBER_OF_CLIENT_NODES: 2
+      CLIENT_OPTIONS: "bench-tps=2=--tx_count 15000 --thread-batch-sleep-ms 250"
+      TESTNET_ZONES: "us-west1-a"
+      USE_PUBLIC_IP_ADDRESSES: "true"
+      ADDITIONAL_FLAGS: "--dedicated"
+      APPLY_PARTITIONS: "true"
+      NETEM_CONFIG_FILE: "system-test/netem-configs/partial-loss-three-partitions"
+      PARTITION_ACTIVE_DURATION: 60
+      PARTITION_INACTIVE_DURATION: 300
+      PARTITION_ITERATION_COUNT: 1
+    agents:
+      - "queue=gce-deploy"

--- a/system-test/testnet-automation.sh
+++ b/system-test/testnet-automation.sh
@@ -267,9 +267,15 @@ function launchTestnet() {
         WHERE time > now() - '"$TEST_DURATION_SECONDS"'s
         GROUP BY time(1s), host_id)'
 
+  declare q_last_tower_distance_observed='
+      SELECT MEAN("tower_distance") as "last_tower_distance" FROM (
+            SELECT last("slot") - last("root") as "tower_distance"
+              FROM "'$TESTNET_TAG'"."autogen"."tower-observed"
+              GROUP BY host_id)'
+
   curl -G "${INFLUX_HOST}/query?u=ro&p=topsecret" \
     --data-urlencode "db=${TESTNET_TAG}" \
-    --data-urlencode "q=$q_mean_tps;$q_max_tps;$q_mean_confirmation;$q_max_confirmation;$q_99th_confirmation;$q_max_tower_distance_observed" |
+    --data-urlencode "q=$q_mean_tps;$q_max_tps;$q_mean_confirmation;$q_max_confirmation;$q_99th_confirmation;$q_max_tower_distance_observed;$q_last_tower_distance_observed" |
     python system-test/testnet-automation-json-parser.py >>"$RESULT_FILE"
 
   execution_step "Writing test results to ${RESULT_FILE}"


### PR DESCRIPTION
#### Problem
We don't report the last tower distance after restoring from a partition testcase which is needed to ensure the cluster has stabilized after resolving partitions.

#### Summary of Changes
Report last_tower_distance recorded at the end of a testcase and add a test to perform a single long partition then give the cluster five minutes to recover.
