### PR TITLE
Test account doesn't need RefCell

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2966,8 +2966,8 @@ mod tests {
 
         // set up stakes, vote, and storage accounts
         bank.store_account(&stake_id, &stake_account);
-        bank.store_account(&validator_id, &validator_account.borrow());
-        bank.store_account(&archiver_id, &archiver_account.borrow());
+        bank.store_account(&validator_id, &validator_account);
+        bank.store_account(&archiver_id, &archiver_account);
 
         // generate some rewards
         let mut vote_state = VoteState::from(&vote_account).unwrap();

--- a/runtime/src/storage_utils.rs
+++ b/runtime/src/storage_utils.rs
@@ -149,20 +149,20 @@ pub(crate) mod tests {
         let ((validator_pubkey, validator_account), (archiver_pubkey, archiver_account)) =
             create_storage_accounts_with_credits(credits);
 
-        storage_accounts.store(&validator_pubkey, &validator_account.borrow());
-        storage_accounts.store(&archiver_pubkey, &archiver_account.borrow());
+        storage_accounts.store(&validator_pubkey, &validator_account);
+        storage_accounts.store(&archiver_pubkey, &archiver_account);
         // check that 2x credits worth of points are available
         assert_eq!(storage_accounts.points(), credits * 2);
         let ((validator_pubkey, validator_account), (archiver_pubkey, archiver_account)) =
             create_storage_accounts_with_credits(credits);
 
-        storage_accounts.store(&validator_pubkey, &validator_account.borrow());
-        storage_accounts.store(&archiver_pubkey, &archiver_account.borrow());
+        storage_accounts.store(&validator_pubkey, &validator_account);
+        storage_accounts.store(&archiver_pubkey, &archiver_account);
         // check that 4x credits worth of points are available
         assert_eq!(storage_accounts.points(), credits * 2 * 2);
 
-        storage_accounts.store(&validator_pubkey, &validator_account.borrow());
-        storage_accounts.store(&archiver_pubkey, &archiver_account.borrow());
+        storage_accounts.store(&validator_pubkey, &validator_account);
+        storage_accounts.store(&archiver_pubkey, &archiver_account);
         // check that storing again has no effect
         assert_eq!(storage_accounts.points(), credits * 2 * 2);
 
@@ -191,8 +191,8 @@ pub(crate) mod tests {
     pub fn create_storage_accounts_with_credits(
         credits: u64,
     ) -> (
-        (Pubkey, Rc<RefCell<Account>>),
-        (Pubkey, Rc<RefCell<Account>>),
+        (Pubkey, Account),
+        (Pubkey, Account),
     ) {
         let validator_pubkey = Pubkey::new_rand();
         let archiver_pubkey = Pubkey::new_rand();
@@ -240,8 +240,8 @@ pub(crate) mod tests {
                 .unwrap();
         }
         (
-            (validator_pubkey, validator_account),
-            (archiver_pubkey, archiver_account),
+            (validator_pubkey, validator_account.into_inner()),
+            (archiver_pubkey, archiver_account.into_inner()),
         )
     }
 }

--- a/runtime/src/storage_utils.rs
+++ b/runtime/src/storage_utils.rs
@@ -190,10 +190,7 @@ pub(crate) mod tests {
 
     pub fn create_storage_accounts_with_credits(
         credits: u64,
-    ) -> (
-        (Pubkey, Account),
-        (Pubkey, Account),
-    ) {
+    ) -> ((Pubkey, Account), (Pubkey, Account)) {
         let validator_pubkey = Pubkey::new_rand();
         let archiver_pubkey = Pubkey::new_rand();
         let validator_account = Account::new_ref(

--- a/runtime/src/storage_utils.rs
+++ b/runtime/src/storage_utils.rs
@@ -91,7 +91,7 @@ pub(crate) mod tests {
         storage_instruction::{self, StorageAccountType},
         storage_processor,
     };
-    use std::{cell::RefCell, rc::Rc, sync::Arc};
+    use std::{rc::Rc, sync::Arc};
 
     #[test]
     fn test_store_and_recover() {
@@ -153,7 +153,7 @@ pub(crate) mod tests {
         storage_accounts.store(&archiver_pubkey, &archiver_account);
         // check that 2x credits worth of points are available
         assert_eq!(storage_accounts.points(), credits * 2);
-        let ((validator_pubkey, validator_account), (archiver_pubkey, archiver_account)) =
+        let ((validator_pubkey, validator_account), (archiver_pubkey, mut archiver_account)) =
             create_storage_accounts_with_credits(credits);
 
         storage_accounts.store(&validator_pubkey, &validator_account);
@@ -166,7 +166,7 @@ pub(crate) mod tests {
         // check that storing again has no effect
         assert_eq!(storage_accounts.points(), credits * 2 * 2);
 
-        let storage_contract = &mut archiver_account.borrow().state().unwrap();
+        let storage_contract = &mut archiver_account.state().unwrap();
         if let StorageContract::ArchiverStorage {
             credits: account_credits,
             ..
@@ -174,11 +174,8 @@ pub(crate) mod tests {
         {
             account_credits.current_epoch += 1;
         }
-        archiver_account
-            .borrow_mut()
-            .set_state(storage_contract)
-            .unwrap();
-        storage_accounts.store(&archiver_pubkey, &archiver_account.borrow());
+        archiver_account.set_state(storage_contract).unwrap();
+        storage_accounts.store(&archiver_pubkey, &archiver_account);
 
         // check that incremental store increases credits
         assert_eq!(storage_accounts.points(), credits * 2 * 2 + 1);
@@ -237,8 +234,14 @@ pub(crate) mod tests {
                 .unwrap();
         }
         (
-            (validator_pubkey, validator_account.into_inner()),
-            (archiver_pubkey, archiver_account.into_inner()),
+            (
+                validator_pubkey,
+                Rc::try_unwrap(validator_account).unwrap().into_inner(),
+            ),
+            (
+                archiver_pubkey,
+                Rc::try_unwrap(archiver_account).unwrap().into_inner(),
+            ),
         )
     }
 }


### PR DESCRIPTION
#### Problem

Unnecessary RefCell on accounts returned for testing purposes

#### Summary of Changes

Just return regular `Account`

Fixes #
