### PR TITLE
Various minor fixes and improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4005,6 +4005,7 @@ dependencies = [
  "solana-sdk 0.23.0",
  "solana-stake-program 0.23.0",
  "solana-vote-program 0.23.0",
+ "symlink 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sys-info 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "tar 0.4.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/core/src/snapshot_packager_service.rs
+++ b/core/src/snapshot_packager_service.rs
@@ -133,7 +133,8 @@ mod tests {
         }
 
         // Create a packageable snapshot
-        let output_tar_path = snapshot_utils::get_snapshot_tar_path(&snapshot_package_output_path);
+        let output_tar_path =
+            snapshot_utils::get_snapshot_archive_path(&snapshot_package_output_path);
         let snapshot_package = SnapshotPackage::new(
             5,
             vec![],

--- a/core/src/snapshot_packager_service.rs
+++ b/core/src/snapshot_packager_service.rs
@@ -1,16 +1,23 @@
-use solana_ledger::snapshot_package::{SnapshotPackage, SnapshotPackageReceiver};
-use solana_ledger::snapshot_utils::{
-    serialize_status_cache, SnapshotError, TAR_ACCOUNTS_DIR, TAR_SNAPSHOTS_DIR, TAR_VERSION_FILE,
+use solana_ledger::{
+    snapshot_package::{SnapshotPackage, SnapshotPackageReceiver},
+    snapshot_utils::{
+        serialize_status_cache, SnapshotError, TAR_ACCOUNTS_DIR, TAR_SNAPSHOTS_DIR,
+        TAR_VERSION_FILE,
+    },
 };
 use solana_measure::measure::Measure;
 use solana_metrics::datapoint_info;
-use std::fs;
-use std::process::ExitStatus;
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::mpsc::RecvTimeoutError;
-use std::sync::Arc;
-use std::thread::{self, Builder, JoinHandle};
-use std::time::Duration;
+use std::{
+    fs,
+    process::ExitStatus,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        mpsc::RecvTimeoutError,
+        Arc,
+    },
+    thread::{self, Builder, JoinHandle},
+    time::Duration,
+};
 use symlink;
 use tempfile::TempDir;
 use thiserror::Error;
@@ -284,7 +291,7 @@ mod tests {
         // before we compare, stick an empty status_cache in this dir so that the package comparision works
         // This is needed since the status_cache is added by the packager and is not collected from
         // the source dir for snapshots
-        let dummy_slot_deltas: Vec<SlotDelta<TransactionResult<()>>> = vec![];
+        let dummy_slot_deltas: Vec<SlotDelta<transaction::Result<()>>> = vec![];
         snapshot_utils::serialize_snapshot_data_file(
             &snapshots_dir.join(SNAPSHOT_STATUS_CACHE_FILE_NAME),
             MAX_SNAPSHOT_DATA_FILE_SIZE,

--- a/core/src/snapshot_packager_service.rs
+++ b/core/src/snapshot_packager_service.rs
@@ -1,15 +1,7 @@
 use solana_ledger::{
-    snapshot_package::{SnapshotPackage, SnapshotPackageReceiver},
-    snapshot_utils::{
-        serialize_status_cache, SnapshotError, TAR_ACCOUNTS_DIR, TAR_SNAPSHOTS_DIR,
-        TAR_VERSION_FILE,
-    },
+    snapshot_package::SnapshotPackageReceiver, snapshot_utils::archive_snapshot_package,
 };
-use solana_measure::measure::Measure;
-use solana_metrics::datapoint_info;
 use std::{
-    fs,
-    process::ExitStatus,
     sync::{
         atomic::{AtomicBool, Ordering},
         mpsc::RecvTimeoutError,
@@ -18,32 +10,6 @@ use std::{
     thread::{self, Builder, JoinHandle},
     time::Duration,
 };
-use symlink;
-use tempfile::TempDir;
-use thiserror::Error;
-
-#[derive(Error, Debug)]
-pub enum SnapshotServiceError {
-    #[error("I/O error")]
-    IO(#[from] std::io::Error),
-
-    #[error("serialization error")]
-    Serialize(#[from] Box<bincode::ErrorKind>),
-
-    #[error("receive timeout error")]
-    RecvTimeoutError(#[from] RecvTimeoutError),
-
-    #[error("snapshot error")]
-    SnapshotError(#[from] SnapshotError),
-
-    #[error("archive generation failure {0}")]
-    ArchiveGenerationFailure(ExitStatus),
-
-    #[error("storage path symlink is invalid")]
-    StoragePathSymlinkInvalid,
-}
-
-type Result<T> = std::result::Result<T, SnapshotServiceError>;
 
 pub struct SnapshotPackagerService {
     t_snapshot_packager: JoinHandle<()>,
@@ -58,137 +24,25 @@ impl SnapshotPackagerService {
                 if exit.load(Ordering::Relaxed) {
                     break;
                 }
-                if let Err(e) = Self::run(&snapshot_package_receiver) {
-                    match e {
-                        SnapshotServiceError::RecvTimeoutError(RecvTimeoutError::Disconnected) => {
-                            break
+
+                match snapshot_package_receiver.recv_timeout(Duration::from_secs(1)) {
+                    Ok(mut snapshot_package) => {
+                        // Only package the latest
+                        while let Ok(new_snapshot_package) = snapshot_package_receiver.try_recv() {
+                            snapshot_package = new_snapshot_package;
                         }
-                        SnapshotServiceError::RecvTimeoutError(RecvTimeoutError::Timeout) => (),
-                        _ => info!("Error from package_snapshots: {:?}", e),
+                        if let Err(err) = archive_snapshot_package(&snapshot_package) {
+                            warn!("Failed to create snapshot archive: {}", err);
+                        }
                     }
+                    Err(RecvTimeoutError::Disconnected) => break,
+                    Err(RecvTimeoutError::Timeout) => (),
                 }
             })
             .unwrap();
         Self {
             t_snapshot_packager,
         }
-    }
-
-    pub fn package_snapshots(snapshot_package: &SnapshotPackage) -> Result<()> {
-        info!(
-            "Generating snapshot tarball for root {}",
-            snapshot_package.root
-        );
-
-        serialize_status_cache(
-            snapshot_package.root,
-            &snapshot_package.slot_deltas,
-            &snapshot_package.snapshot_links,
-        )?;
-
-        let mut timer = Measure::start("snapshot_package-package_snapshots");
-        let tar_dir = snapshot_package
-            .tar_output_file
-            .parent()
-            .expect("Tar output path is invalid");
-
-        fs::create_dir_all(tar_dir)?;
-
-        // Create the staging directories
-        let staging_dir = TempDir::new()?;
-        let staging_accounts_dir = staging_dir.path().join(TAR_ACCOUNTS_DIR);
-        let staging_snapshots_dir = staging_dir.path().join(TAR_SNAPSHOTS_DIR);
-        let staging_version_file = staging_dir.path().join(TAR_VERSION_FILE);
-        fs::create_dir_all(&staging_accounts_dir)?;
-
-        // Add the snapshots to the staging directory
-        symlink::symlink_dir(
-            snapshot_package.snapshot_links.path(),
-            &staging_snapshots_dir,
-        )?;
-
-        // Add the AppendVecs into the compressible list
-        for storage in &snapshot_package.storage_entries {
-            storage.flush()?;
-            let storage_path = storage.get_path();
-            let output_path = staging_accounts_dir.join(
-                storage_path
-                    .file_name()
-                    .expect("Invalid AppendVec file path"),
-            );
-
-            // `storage_path` - The file path where the AppendVec itself is located
-            // `output_path` - The directory where the AppendVec will be placed in the staging directory.
-            let storage_path =
-                fs::canonicalize(storage_path).expect("Could not get absolute path for accounts");
-            symlink::symlink_dir(storage_path, &output_path)?;
-            if !output_path.is_file() {
-                return Err(SnapshotServiceError::StoragePathSymlinkInvalid);
-            }
-        }
-
-        // Write version file
-        {
-            use std::io::Write;
-            let snapshot_version = format!("{}\n", env!("CARGO_PKG_VERSION"));
-            let mut f = std::fs::File::create(staging_version_file)?;
-            //f.write_all(&snapshot_version.to_string().into_bytes())?;
-            f.write_all(&snapshot_version.into_bytes())?;
-        }
-
-        // Tar the staging directory into the archive at `archive_path`
-        let archive_path = tar_dir.join("new_state.tar.bz2");
-        let args = vec![
-            "jcfhS",
-            archive_path.to_str().unwrap(),
-            "-C",
-            staging_dir.path().to_str().unwrap(),
-            TAR_ACCOUNTS_DIR,
-            TAR_SNAPSHOTS_DIR,
-            TAR_VERSION_FILE,
-        ];
-
-        let output = std::process::Command::new("tar").args(&args).output()?;
-        if !output.status.success() {
-            warn!("tar command failed with exit code: {}", output.status);
-            use std::str::from_utf8;
-            info!("tar stdout: {}", from_utf8(&output.stdout).unwrap_or("?"));
-            info!("tar stderr: {}", from_utf8(&output.stderr).unwrap_or("?"));
-
-            return Err(SnapshotServiceError::ArchiveGenerationFailure(
-                output.status,
-            ));
-        }
-
-        // Once everything is successful, overwrite the previous tarball so that other validators
-        // can fetch this newly packaged snapshot
-        let metadata = fs::metadata(&archive_path)?;
-        fs::rename(&archive_path, &snapshot_package.tar_output_file)?;
-
-        timer.stop();
-        info!(
-            "Successfully created tarball. slot: {}, elapsed ms: {}, size={}",
-            snapshot_package.root,
-            timer.as_ms(),
-            metadata.len()
-        );
-        datapoint_info!(
-            "snapshot-package",
-            ("slot", snapshot_package.root, i64),
-            ("duration_ms", timer.as_ms(), i64),
-            ("size", metadata.len(), i64)
-        );
-        Ok(())
-    }
-
-    fn run(snapshot_receiver: &SnapshotPackageReceiver) -> Result<()> {
-        let mut snapshot_package = snapshot_receiver.recv_timeout(Duration::from_secs(1))?;
-        // Only package the latest
-        while let Ok(new_snapshot_package) = snapshot_receiver.try_recv() {
-            snapshot_package = new_snapshot_package;
-        }
-        Self::package_snapshots(&snapshot_package)?;
-        Ok(())
     }
 
     pub fn join(self) -> thread::Result<()> {
@@ -200,14 +54,17 @@ impl SnapshotPackagerService {
 mod tests {
     use super::*;
     use bincode::serialize_into;
-    use solana_ledger::snapshot_utils::{self, SNAPSHOT_STATUS_CACHE_FILE_NAME};
+    use solana_ledger::{
+        snapshot_package::SnapshotPackage,
+        snapshot_utils::{self, SNAPSHOT_STATUS_CACHE_FILE_NAME},
+    };
     use solana_runtime::{
         accounts_db::AccountStorageEntry, bank::MAX_SNAPSHOT_DATA_FILE_SIZE,
         status_cache::SlotDelta,
     };
-    use solana_sdk::transaction::Result as TransactionResult;
+    use solana_sdk::transaction;
     use std::{
-        fs::{remove_dir_all, OpenOptions},
+        fs::{self, remove_dir_all, OpenOptions},
         io::Write,
         path::{Path, PathBuf},
     };
@@ -286,7 +143,7 @@ mod tests {
         );
 
         // Make tarball from packageable snapshot
-        SnapshotPackagerService::package_snapshots(&snapshot_package).unwrap();
+        snapshot_utils::archive_snapshot_package(&snapshot_package).unwrap();
 
         // before we compare, stick an empty status_cache in this dir so that the package comparision works
         // This is needed since the status_cache is added by the packager and is not collected from
@@ -302,7 +159,7 @@ mod tests {
         )
         .unwrap();
 
-        // Check tarball is correct
-        snapshot_utils::verify_snapshot_tar(output_tar_path, snapshots_dir, accounts_dir);
+        // Check archive is correct
+        snapshot_utils::verify_snapshot_archive(output_tar_path, snapshots_dir, accounts_dir);
     }
 }

--- a/core/tests/bank_forks.rs
+++ b/core/tests/bank_forks.rs
@@ -22,8 +22,7 @@ mod tests {
         hash::hashv,
         pubkey::Pubkey,
         signature::{Keypair, KeypairUtil},
-        system_transaction,
-        transaction::Result as TransactionResult,
+        system_transaction, transaction,
     };
     use std::{fs, path::PathBuf, sync::atomic::AtomicBool, sync::mpsc::channel, sync::Arc};
     use tempfile::TempDir;
@@ -310,7 +309,7 @@ mod tests {
         // before we compare, stick an empty status_cache in this dir so that the package comparision works
         // This is needed since the status_cache is added by the packager and is not collected from
         // the source dir for snapshots
-        let dummy_slot_deltas: Vec<SlotDelta<TransactionResult<()>>> = vec![];
+        let dummy_slot_deltas: Vec<SlotDelta<transaction::Result<()>>> = vec![];
         snapshot_utils::serialize_snapshot_data_file(
             &saved_snapshots_dir
                 .path()

--- a/core/tests/bank_forks.rs
+++ b/core/tests/bank_forks.rs
@@ -140,7 +140,8 @@ mod tests {
             &last_bank.src.roots(),
         )
         .unwrap();
-        SnapshotPackagerService::package_snapshots(&snapshot_package).unwrap();
+
+        snapshot_utils::archive_snapshot_package(&snapshot_package).unwrap();
 
         restore_from_snapshot(bank_forks, vec![accounts_dir.path().to_path_buf()]);
     }
@@ -322,7 +323,7 @@ mod tests {
         )
         .unwrap();
 
-        snapshot_utils::verify_snapshot_tar(
+        snapshot_utils::verify_snapshot_archive(
             saved_tar,
             saved_snapshots_dir.path(),
             saved_accounts_dir

--- a/core/tests/bank_forks.rs
+++ b/core/tests/bank_forks.rs
@@ -78,7 +78,7 @@ mod tests {
                 .as_ref()
                 .unwrap()
                 .snapshot_path,
-            snapshot_utils::get_snapshot_tar_path(snapshot_package_output_path),
+            snapshot_utils::get_snapshot_archive_path(snapshot_package_output_path),
         )
         .unwrap();
 
@@ -135,7 +135,9 @@ mod tests {
             slot_snapshot_paths
                 .last()
                 .expect("no snapshots found in path"),
-            snapshot_utils::get_snapshot_tar_path(&snapshot_config.snapshot_package_output_path),
+            snapshot_utils::get_snapshot_archive_path(
+                &snapshot_config.snapshot_package_output_path,
+            ),
             &snapshot_config.snapshot_path,
             &last_bank.src.roots(),
         )

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -173,13 +173,13 @@ fn render_dot(dot: String, output_file: &str, output_format: &str) -> io::Result
 
 #[allow(clippy::cognitive_complexity)]
 fn graph_forks(
-    bank_forks: BankForks,
-    bank_forks_info: Vec<blockstore_processor::BankForksInfo>,
+    bank_forks: &BankForks,
+    bank_forks_info: &[blockstore_processor::BankForksInfo],
     include_all_votes: bool,
 ) -> String {
     // Search all forks and collect the last vote made by each validator
     let mut last_votes = HashMap::new();
-    for bfi in &bank_forks_info {
+    for bfi in bank_forks_info {
         let bank = bank_forks.banks.get(&bfi.bank_slot).unwrap();
 
         let total_stake = bank
@@ -221,7 +221,7 @@ fn graph_forks(
     dot.push("    style=invis".to_string());
     let mut styled_slots = HashSet::new();
     let mut all_votes: HashMap<Pubkey, HashMap<Slot, VoteState>> = HashMap::new();
-    for bfi in &bank_forks_info {
+    for bfi in bank_forks_info {
         let bank = bank_forks.banks.get(&bfi.bank_slot).unwrap();
         let mut bank = bank.clone();
 
@@ -737,8 +737,8 @@ fn main() {
 
                     if let Some(output_file) = arg_matches.value_of("graph_forks") {
                         let dot = graph_forks(
-                            bank_forks,
-                            bank_forks_info,
+                            &bank_forks,
+                            &bank_forks_info,
                             arg_matches.is_present("graph_forks_include_all_votes"),
                         );
 

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -3,13 +3,11 @@ use clap::{
 };
 use histogram;
 use serde_json::json;
-use solana_ledger::blockstore_db::Database;
 use solana_ledger::{
     bank_forks::{BankForks, SnapshotConfig},
     bank_forks_utils,
     blockstore::Blockstore,
-    blockstore_db,
-    blockstore_db::Column,
+    blockstore_db::{self, Column, Database},
     blockstore_processor,
     rooted_slot_iterator::RootedSlotIterator,
 };

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -43,6 +43,7 @@ solana-sdk = { path = "../sdk", version = "0.23.0" }
 solana-stake-program = { path = "../programs/stake", version = "0.23.0" }
 solana-vote-program = { path = "../programs/vote", version = "0.23.0" }
 sys-info = "0.5.8"
+symlink = "0.1.0"
 tar = "0.4.26"
 thiserror = "1.0"
 tempfile = "3.1.0"

--- a/ledger/src/bank_forks.rs
+++ b/ledger/src/bank_forks.rs
@@ -192,7 +192,7 @@ impl BankForks {
                     root,
                     &root_bank.src.roots(),
                     snapshot_package_sender.as_ref().unwrap(),
-                    snapshot_utils::get_snapshot_tar_path(&config.snapshot_package_output_path),
+                    snapshot_utils::get_snapshot_archive_path(&config.snapshot_package_output_path),
                 );
                 if r.is_err() {
                     warn!("Error generating snapshot for bank: {}, err: {:?}", root, r);

--- a/ledger/src/bank_forks_utils.rs
+++ b/ledger/src/bank_forks_utils.rs
@@ -26,8 +26,9 @@ pub fn load(
         fs::create_dir_all(&snapshot_config.snapshot_path)
             .expect("Couldn't create snapshot directory");
 
-        let tar =
-            snapshot_utils::get_snapshot_tar_path(&snapshot_config.snapshot_package_output_path);
+        let tar = snapshot_utils::get_snapshot_archive_path(
+            &snapshot_config.snapshot_package_output_path,
+        );
         if tar.exists() {
             info!("Loading snapshot package: {:?}", tar);
             // Fail hard here if snapshot fails to load, don't silently continue

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -718,10 +718,6 @@ fn process_pending_slots(
             allocated.since(initial_allocation)
         );
 
-        if slot >= dev_halt_at_slot {
-            break;
-        }
-
         process_next_slots(
             &bank,
             &meta,
@@ -730,6 +726,10 @@ fn process_pending_slots(
             &mut pending_slots,
             &mut fork_info,
         )?;
+
+        if slot >= dev_halt_at_slot {
+            break;
+        }
     }
 
     Ok(fork_info)

--- a/ledger/src/snapshot_package.rs
+++ b/ledger/src/snapshot_package.rs
@@ -1,6 +1,6 @@
 use solana_runtime::accounts_db::AccountStorageEntry;
 use solana_runtime::status_cache::SlotDelta;
-use solana_sdk::transaction::Result as TransactionResult;
+use solana_sdk::{clock::Slot, transaction};
 use std::path::PathBuf;
 use std::sync::mpsc::{Receiver, SendError, Sender};
 use std::sync::Arc;
@@ -12,8 +12,8 @@ pub type SnapshotPackageSendError = SendError<SnapshotPackage>;
 
 #[derive(Debug)]
 pub struct SnapshotPackage {
-    pub root: u64,
-    pub slot_deltas: Vec<SlotDelta<TransactionResult<()>>>,
+    pub root: Slot,
+    pub slot_deltas: Vec<SlotDelta<transaction::Result<()>>>,
     pub snapshot_links: TempDir,
     pub storage_entries: Vec<Arc<AccountStorageEntry>>,
     pub tar_output_file: PathBuf,
@@ -21,8 +21,8 @@ pub struct SnapshotPackage {
 
 impl SnapshotPackage {
     pub fn new(
-        root: u64,
-        slot_deltas: Vec<SlotDelta<TransactionResult<()>>>,
+        root: Slot,
+        slot_deltas: Vec<SlotDelta<transaction::Result<()>>>,
         snapshot_links: TempDir,
         storage_entries: Vec<Arc<AccountStorageEntry>>,
         tar_output_file: PathBuf,

--- a/ledger/src/snapshot_package.rs
+++ b/ledger/src/snapshot_package.rs
@@ -10,6 +10,7 @@ pub type SnapshotPackageSender = Sender<SnapshotPackage>;
 pub type SnapshotPackageReceiver = Receiver<SnapshotPackage>;
 pub type SnapshotPackageSendError = SendError<SnapshotPackage>;
 
+#[derive(Debug)]
 pub struct SnapshotPackage {
     pub root: u64,
     pub slot_deltas: Vec<SlotDelta<TransactionResult<()>>>,

--- a/ledger/src/snapshot_utils.rs
+++ b/ledger/src/snapshot_utils.rs
@@ -481,7 +481,7 @@ pub fn bank_from_archive<P: AsRef<Path>>(
     Ok(bank)
 }
 
-pub fn get_snapshot_tar_path<P: AsRef<Path>>(snapshot_output_dir: P) -> PathBuf {
+pub fn get_snapshot_archive_path<P: AsRef<Path>>(snapshot_output_dir: P) -> PathBuf {
     snapshot_output_dir.as_ref().join("snapshot.tar.bz2")
 }
 

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -651,12 +651,13 @@ fn test_snapshot_restart_tower() {
         .as_ref()
         .unwrap()
         .snapshot_package_output_path;
-    let tar = snapshot_utils::get_snapshot_tar_path(&snapshot_package_output_path);
+    let tar = snapshot_utils::get_snapshot_archive_path(&snapshot_package_output_path);
     wait_for_next_snapshot(&cluster, &tar);
 
     // Copy tar to validator's snapshot output directory
-    let validator_tar_path =
-        snapshot_utils::get_snapshot_tar_path(&validator_snapshot_test_config.snapshot_output_path);
+    let validator_tar_path = snapshot_utils::get_snapshot_archive_path(
+        &validator_snapshot_test_config.snapshot_output_path,
+    );
     fs::hard_link(tar, &validator_tar_path).unwrap();
 
     // Restart validator from snapshot, the validator's tower state in this snapshot
@@ -702,7 +703,7 @@ fn test_snapshots_blockstore_floor() {
 
     trace!("Waiting for snapshot tar to be generated with slot",);
 
-    let tar = snapshot_utils::get_snapshot_tar_path(&snapshot_package_output_path);
+    let tar = snapshot_utils::get_snapshot_archive_path(&snapshot_package_output_path);
     loop {
         if tar.exists() {
             trace!("snapshot tar exists");
@@ -712,8 +713,9 @@ fn test_snapshots_blockstore_floor() {
     }
 
     // Copy tar to validator's snapshot output directory
-    let validator_tar_path =
-        snapshot_utils::get_snapshot_tar_path(&validator_snapshot_test_config.snapshot_output_path);
+    let validator_tar_path = snapshot_utils::get_snapshot_archive_path(
+        &validator_snapshot_test_config.snapshot_output_path,
+    );
     fs::hard_link(tar, &validator_tar_path).unwrap();
     let slot_floor = snapshot_utils::bank_slot_from_archive(&validator_tar_path).unwrap();
 
@@ -803,7 +805,7 @@ fn test_snapshots_restart_validity() {
 
         expected_balances.extend(new_balances);
 
-        let tar = snapshot_utils::get_snapshot_tar_path(&snapshot_package_output_path);
+        let tar = snapshot_utils::get_snapshot_archive_path(&snapshot_package_output_path);
         wait_for_next_snapshot(&cluster, &tar);
 
         // Create new account paths since validator exit is not guaranteed to cleanup RPC threads,

--- a/multinode-demo/bootstrap-validator.sh
+++ b/multinode-demo/bootstrap-validator.sh
@@ -74,7 +74,6 @@ ledger_dir="$SOLANA_CONFIG_DIR"/bootstrap-validator
 }
 
 args+=(
-  --accounts "$SOLANA_CONFIG_DIR"/bootstrap-validator/accounts
   --enable-rpc-exit
   --ledger "$ledger_dir"
   --rpc-port 8899

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -348,7 +348,12 @@ impl<'a> Serialize for AccountsDBSerialize<'a> {
         let bank_hashes = self.accounts_db.bank_hashes.read().unwrap();
         serialize_into(
             &mut wr,
-            &(self.slot, &*bank_hashes.get(&self.slot).unwrap()),
+            &(
+                self.slot,
+                &*bank_hashes
+                    .get(&self.slot)
+                    .unwrap_or_else(|| panic!("No bank_hashes entry for slot {}", self.slot)),
+            ),
         )
         .map_err(Error::custom)?;
         let len = wr.position() as usize;

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1669,9 +1669,9 @@ impl Bank {
         self.rc.accounts.clone()
     }
 
-    pub fn set_bank_rc(&mut self, bank_rc: &BankRc, status_cache_rc: &StatusCacheRc) {
-        self.rc.accounts = bank_rc.accounts.clone();
-        self.src.status_cache = status_cache_rc.status_cache.clone()
+    pub fn set_bank_rc(&mut self, bank_rc: BankRc, status_cache_rc: StatusCacheRc) {
+        self.rc = bank_rc;
+        self.src = status_cache_rc;
     }
 
     pub fn set_parent(&mut self, parent: &Arc<Bank>) {
@@ -4610,7 +4610,7 @@ mod tests {
         let (_accounts_dir, dbank_paths) = get_temp_accounts_paths(4).unwrap();
         let ref_sc = StatusCacheRc::default();
         ref_sc.status_cache.write().unwrap().add_root(2);
-        dbank.set_bank_rc(&BankRc::new(dbank_paths.clone(), 0, dbank.slot()), &ref_sc);
+        dbank.set_bank_rc(BankRc::new(dbank_paths.clone(), 0, dbank.slot()), ref_sc);
         // Create a directory to simulate AppendVecs unpackaged from a snapshot tar
         let copied_accounts = TempDir::new().unwrap();
         copy_append_vecs(&bank2.rc.accounts.accounts_db, copied_accounts.path()).unwrap();

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -323,7 +323,8 @@ fn download_ledger(
     download_tar_bz2(rpc_addr, "genesis.tar.bz2", ledger_path, false)?;
 
     if !no_snapshot_fetch {
-        let snapshot_package = solana_ledger::snapshot_utils::get_snapshot_tar_path(ledger_path);
+        let snapshot_package =
+            solana_ledger::snapshot_utils::get_snapshot_archive_path(ledger_path);
         if snapshot_package.exists() {
             fs::remove_file(&snapshot_package)
                 .map_err(|err| format!("error removing {:?}: {}", snapshot_package, err))?;


### PR DESCRIPTION
Rando minor fixes and improvements:
* Serializing out a bank that was deserialized from a snapshot panics because BankRc:: accounts_from_stream() wasn't initializing the slot field
* Off by one in `--halt-at-slot`
* Expand `add_snapshot()` return
* Remove superfluous accounts arg
* ...