### PR TITLE
Fix cli call to stakes

### DIFF
--- a/multinode-demo/delegate-stake.sh
+++ b/multinode-demo/delegate-stake.sh
@@ -105,4 +105,4 @@ $solana_cli "${common_args[@]}" \
   create-stake-account "$stake_keypair_path" "$stake_lamports" lamports
 $solana_cli "${common_args[@]}" \
   delegate-stake $maybe_force "$stake_keypair_path" "$vote_keypair_path"
-$solana_cli "${common_args[@]}" stake-account "$stake_keypair_path"
+$solana_cli "${common_args[@]}" stakes "$stake_keypair_path"


### PR DESCRIPTION
#### Problem
solana cli `stake-account` got renamed to `stakes` but this was not reflected in `multinode-demo/delegate-stakes.sh`

#### Summary of Changes
Fix it