### PR TITLE
ledger-tool: Add create-snapshot command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4030,6 +4030,7 @@ dependencies = [
  "solana-runtime 0.23.0",
  "solana-sdk 0.23.0",
  "solana-vote-program 0.23.0",
+ "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/ledger-tool/Cargo.toml
+++ b/ledger-tool/Cargo.toml
@@ -22,6 +22,7 @@ solana-logger = { path = "../logger", version = "0.23.0" }
 solana-runtime = { path = "../runtime", version = "0.23.0" }
 solana-sdk = { path = "../sdk", version = "0.23.0" }
 solana-vote-program = { path = "../programs/vote", version = "0.23.0" }
+tempfile = "3.1.0"
 
 [dev-dependencies]
 assert_cmd = "0.12"


### PR DESCRIPTION
```
$ solana-ledger-tool create-snapshot --help
solana-ledger-tool-create-snapshot 
Create a new ledger snapshot

USAGE:
    solana-ledger-tool create-snapshot [FLAGS] [OPTIONS] [ARGS]

FLAGS:
    -h, --help           Prints help information
        --no-snapshot    Do not start from a local snapshot if present
    -V, --version        Prints version information

OPTIONS:
        --accounts <PATHS>    Comma separated persistent accounts location
    -l, --ledger <DIR>        Use DIR for ledger location

ARGS:
    <SLOT>    Slot at which to create the snapshot
    <DIR>     Output directory for the snapshot
```

