### PR TITLE
Add note to book about drone throughput limitations

### DIFF
--- a/book/src/programs/drones.md
+++ b/book/src/programs/drones.md
@@ -16,7 +16,7 @@ Creator of on-chain game tic-tac-toe hosts a drone that responds to airdrop requ
 
 Creator of a new on-chain token \(ERC-20 interface\), may wish to do a worldwide airdrop to distribute its tokens to millions of users over just a few seconds. That drone cannot spend resources interacting with the Solana cluster. Instead, the drone should only verify the client is unique and human, and then return the signature. It may also want to listen to the Solana cluster for recent entry IDs to support client retries and to ensure the airdrop is targeting the desired cluster.
 
-Note: the Solana cluster will not parallelize transactions funded by the same fee payer account. This means that the throughput of a single fee payer account is limited to the number of _ticks_ processed per second by the current leader. In order to circumvent this limitation, it's advised to have a drone manage many accounts for signing and funding transactions.
+Note: the Solana cluster will not parallelize transactions funded by the same fee-paying account. This means that the max throughput of a single fee-paying account is limited to the number of _ticks_ processed per second by the current leader. Add additional fee-paying accounts to improve throughput.
 
 ## Attack vectors
 

--- a/book/src/programs/drones.md
+++ b/book/src/programs/drones.md
@@ -16,7 +16,7 @@ Creator of on-chain game tic-tac-toe hosts a drone that responds to airdrop requ
 
 Creator of a new on-chain token \(ERC-20 interface\), may wish to do a worldwide airdrop to distribute its tokens to millions of users over just a few seconds. That drone cannot spend resources interacting with the Solana cluster. Instead, the drone should only verify the client is unique and human, and then return the signature. It may also want to listen to the Solana cluster for recent entry IDs to support client retries and to ensure the airdrop is targeting the desired cluster.
 
-Note: the Solana cluster will not parallelize transactions funded by the same fee payer account. This means that the throughput of a single fee payer account is limited to the number of _ticks_ processed per second by the current leader. In order to circumvent this limitation, it's advised to have a drone manage many accounts for signing and funding transactions. 
+Note: the Solana cluster will not parallelize transactions funded by the same fee payer account. This means that the throughput of a single fee payer account is limited to the number of _ticks_ processed per second by the current leader. In order to circumvent this limitation, it's advised to have a drone manage many accounts for signing and funding transactions.
 
 ## Attack vectors
 

--- a/book/src/programs/drones.md
+++ b/book/src/programs/drones.md
@@ -16,6 +16,8 @@ Creator of on-chain game tic-tac-toe hosts a drone that responds to airdrop requ
 
 Creator of a new on-chain token \(ERC-20 interface\), may wish to do a worldwide airdrop to distribute its tokens to millions of users over just a few seconds. That drone cannot spend resources interacting with the Solana cluster. Instead, the drone should only verify the client is unique and human, and then return the signature. It may also want to listen to the Solana cluster for recent entry IDs to support client retries and to ensure the airdrop is targeting the desired cluster.
 
+Note: the Solana cluster will not parallelize transactions funded by the same fee payer account. This means that the throughput of a single fee payer account is limited to the number of _ticks_ processed per second by the current leader. In order to circumvent this limitation, it's advised to have a drone manage many accounts for signing and funding transactions. 
+
 ## Attack vectors
 
 ### Invalid recent\_blockhash


### PR DESCRIPTION
#### Problem
The drone section of the book describes an abstraction which would allow millions of transactions to be processed in a few seconds but makes no mention of the workarounds needed to achieve that goal given Solana's runtime limitations.

#### Summary of Changes
Add a note to inform readers that a single payer account can only be used once per tick and recommending to have a drone service manage many accounts to increase throughput.

Fixes #
