### PR TITLE
Add column for slot range of epoch to epoch-info

### DIFF
--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -429,7 +429,7 @@ pub fn process_get_epoch_info(
     let start_slot = epoch_info.absolute_slot - epoch_info.slot_index;
     let end_slot = start_slot + epoch_info.slots_in_epoch;
     println_name_value(
-        "Epoch's slot range:",
+        "Epoch slot range:",
         &format!("[{}..{})", start_slot, end_slot),
     );
     println_name_value(

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -426,6 +426,12 @@ pub fn process_get_epoch_info(
     println!();
     println_name_value("Slot:", &epoch_info.absolute_slot.to_string());
     println_name_value("Epoch:", &epoch_info.epoch.to_string());
+    let start_slot = epoch_info.absolute_slot - epoch_info.slot_index;
+    let end_slot = start_slot + epoch_info.slots_in_epoch;
+    println_name_value(
+        "Epoch's slot range:",
+        &format!("[{}..{})", start_slot, end_slot),
+    );
     println_name_value(
         "Epoch completed percent:",
         &format!(


### PR DESCRIPTION
Another really small PR in continuation of #7838.

I think this will be useful. :)

```patch
 ryoqun@ubuqun:~/work/solana/solana$ solana epoch-info
 
 Slot: 128
 Epoch: 2
+Epoch slot range: [96..224)
 Epoch completed percent: 25.000%
 Epoch completed slots: 32/128 (96 remaining)
 Epoch completed time: 12s/51s (38s remaining)
```
