### PR TITLE
CLI: Require --blockhash with --sign-only and --signer 

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -2362,12 +2362,16 @@ mod tests {
         );
 
         // Test Pay Subcommand w/ sign-only
+        let blockhash = Hash::default();
+        let blockhash_string = format!("{}", blockhash);
         let test_pay = test_commands.clone().get_matches_from(vec![
             "test",
             "pay",
             &pubkey_string,
             "50",
             "lamports",
+            "--blockhash",
+            &blockhash_string,
             "--sign-only",
         ]);
         assert_eq!(
@@ -2376,6 +2380,7 @@ mod tests {
                 command: CliCommand::Pay(PayCommand {
                     lamports: 50,
                     to: pubkey,
+                    blockhash: Some(blockhash),
                     sign_only: true,
                     ..PayCommand::default()
                 }),
@@ -2393,6 +2398,8 @@ mod tests {
             &pubkey_string,
             "50",
             "lamports",
+            "--blockhash",
+            &blockhash_string,
             "--signer",
             &signer1,
         ]);
@@ -2402,6 +2409,7 @@ mod tests {
                 command: CliCommand::Pay(PayCommand {
                     lamports: 50,
                     to: pubkey,
+                    blockhash: Some(blockhash),
                     signers: Some(vec![(key1, sig1)]),
                     ..PayCommand::default()
                 }),
@@ -2419,6 +2427,8 @@ mod tests {
             &pubkey_string,
             "50",
             "lamports",
+            "--blockhash",
+            &blockhash_string,
             "--signer",
             &signer1,
             "--signer",
@@ -2430,6 +2440,7 @@ mod tests {
                 command: CliCommand::Pay(PayCommand {
                     lamports: 50,
                     to: pubkey,
+                    blockhash: Some(blockhash),
                     signers: Some(vec![(key1, sig1), (key2, sig2)]),
                     ..PayCommand::default()
                 }),
@@ -2438,8 +2449,6 @@ mod tests {
         );
 
         // Test Pay Subcommand w/ Blockhash
-        let blockhash = Hash::default();
-        let blockhash_string = format!("{}", blockhash);
         let test_pay = test_commands.clone().get_matches_from(vec![
             "test",
             "pay",

--- a/cli/src/offline.rs
+++ b/cli/src/offline.rs
@@ -35,6 +35,7 @@ fn sign_only_arg<'a, 'b>() -> Arg<'a, 'b> {
     Arg::with_name(SIGN_ONLY_ARG.name)
         .long(SIGN_ONLY_ARG.long)
         .takes_value(false)
+        .requires(BLOCKHASH_ARG.name)
         .help(SIGN_ONLY_ARG.help)
 }
 
@@ -44,6 +45,7 @@ fn signer_arg<'a, 'b>() -> Arg<'a, 'b> {
         .takes_value(true)
         .value_name("BASE58_PUBKEY=BASE58_SIG")
         .validator(is_pubkey_sig)
+        .requires(BLOCKHASH_ARG.name)
         .multiple(true)
         .help(SIGNER_ARG.help)
 }

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -1090,11 +1090,15 @@ mod tests {
             }
         );
         // Test Authorize Subcommand w/ sign-only
+        let blockhash = Hash::default();
+        let blockhash_string = format!("{}", blockhash);
         let test_authorize = test_commands.clone().get_matches_from(vec![
             "test",
             &subcommand,
             &stake_account_string,
             &stake_account_string,
+            "--blockhash",
+            &blockhash_string,
             "--sign-only",
         ]);
         assert_eq!(
@@ -1107,7 +1111,7 @@ mod tests {
                     authority: None,
                     sign_only: true,
                     signers: None,
-                    blockhash: None,
+                    blockhash: Some(blockhash),
                     nonce_account: None,
                     nonce_authority: None,
                 },
@@ -1123,6 +1127,8 @@ mod tests {
             &subcommand,
             &stake_account_string,
             &stake_account_string,
+            "--blockhash",
+            &blockhash_string,
             "--signer",
             &signer,
         ]);
@@ -1136,7 +1142,7 @@ mod tests {
                     authority: None,
                     sign_only: false,
                     signers: Some(vec![(keypair.pubkey(), sig)]),
-                    blockhash: None,
+                    blockhash: Some(blockhash),
                     nonce_account: None,
                     nonce_authority: None,
                 },
@@ -1152,6 +1158,8 @@ mod tests {
             &subcommand,
             &stake_account_string,
             &stake_account_string,
+            "--blockhash",
+            &blockhash_string,
             "--signer",
             &signer,
             "--signer",
@@ -1167,7 +1175,7 @@ mod tests {
                     authority: None,
                     sign_only: false,
                     signers: Some(vec![(keypair.pubkey(), sig), (keypair2.pubkey(), sig2),]),
-                    blockhash: None,
+                    blockhash: Some(blockhash),
                     nonce_account: None,
                     nonce_authority: None,
                 },
@@ -1175,8 +1183,6 @@ mod tests {
             }
         );
         // Test Authorize Subcommand w/ blockhash
-        let blockhash = Hash::default();
-        let blockhash_string = format!("{}", blockhash);
         let test_authorize = test_commands.clone().get_matches_from(vec![
             "test",
             &subcommand,
@@ -1451,6 +1457,8 @@ mod tests {
             "delegate-stake",
             &stake_account_string,
             &vote_account_string,
+            "--blockhash",
+            &blockhash_string,
             "--sign-only",
         ]);
         assert_eq!(
@@ -1463,7 +1471,7 @@ mod tests {
                     force: false,
                     sign_only: true,
                     signers: None,
-                    blockhash: None,
+                    blockhash: Some(blockhash),
                     nonce_account: None,
                     nonce_authority: None,
                 },
@@ -1480,6 +1488,8 @@ mod tests {
             "delegate-stake",
             &stake_account_string,
             &vote_account_string,
+            "--blockhash",
+            &blockhash_string,
             "--signer",
             &signer1,
         ]);
@@ -1493,7 +1503,7 @@ mod tests {
                     force: false,
                     sign_only: false,
                     signers: Some(vec![(key1, sig1)]),
-                    blockhash: None,
+                    blockhash: Some(blockhash),
                     nonce_account: None,
                     nonce_authority: None,
                 },
@@ -1510,6 +1520,8 @@ mod tests {
             "delegate-stake",
             &stake_account_string,
             &vote_account_string,
+            "--blockhash",
+            &blockhash_string,
             "--signer",
             &signer1,
             "--signer",
@@ -1525,7 +1537,7 @@ mod tests {
                     force: false,
                     sign_only: false,
                     signers: Some(vec![(key1, sig1), (key2, sig2)]),
-                    blockhash: None,
+                    blockhash: Some(blockhash),
                     nonce_account: None,
                     nonce_authority: None,
                 },
@@ -1665,6 +1677,8 @@ mod tests {
             "test",
             "deactivate-stake",
             &stake_account_string,
+            "--blockhash",
+            &blockhash_string,
             "--sign-only",
         ]);
         assert_eq!(
@@ -1675,7 +1689,7 @@ mod tests {
                     stake_authority: None,
                     sign_only: true,
                     signers: None,
-                    blockhash: None,
+                    blockhash: Some(blockhash),
                     nonce_account: None,
                     nonce_authority: None,
                 },
@@ -1691,6 +1705,8 @@ mod tests {
             "test",
             "deactivate-stake",
             &stake_account_string,
+            "--blockhash",
+            &blockhash_string,
             "--signer",
             &signer1,
         ]);
@@ -1702,7 +1718,7 @@ mod tests {
                     stake_authority: None,
                     sign_only: false,
                     signers: Some(vec![(key1, sig1)]),
-                    blockhash: None,
+                    blockhash: Some(blockhash),
                     nonce_account: None,
                     nonce_authority: None,
                 },
@@ -1718,6 +1734,8 @@ mod tests {
             "test",
             "deactivate-stake",
             &stake_account_string,
+            "--blockhash",
+            &blockhash_string,
             "--signer",
             &signer1,
             "--signer",
@@ -1731,7 +1749,7 @@ mod tests {
                     stake_authority: None,
                     sign_only: false,
                     signers: Some(vec![(key1, sig1), (key2, sig2)]),
-                    blockhash: None,
+                    blockhash: Some(blockhash),
                     nonce_account: None,
                     nonce_authority: None,
                 },


### PR DESCRIPTION
#### Problem

`--sign-only` implies we're offline and cannot query the cluster for a blockhash, as is enforced by #7981. Similarly we cannot know what blockhash the absentee signer, specified by `--signer`, used to create their signature. In both cases, not passing `--blockhash` is an error and this is not communicated to the user.

#### Summary of Changes

Set `requires()` on the `Arg`s
Fix tests