### PR TITLE
Solana keygen

### DIFF
--- a/keygen/src/keygen.rs
+++ b/keygen/src/keygen.rs
@@ -380,7 +380,6 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                 count: u64,
                 found: AtomicU64
             }
-            let mut total_matches_count = 0;
             let mut grind_matches = Vec::<Match>::new();
 
             let ignore_case = matches.is_present("ignore_case");
@@ -425,7 +424,6 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                     count: args[1].parse::<u64>().unwrap(),
                     found: AtomicU64::new(0)
                 });
-                total_matches_count = total_matches_count + args[1].parse::<u64>().unwrap();
             }
             for ew in &ends_with_args {
                 let args: Vec<&str> = ew.split(':').collect(); 
@@ -435,7 +433,6 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                     count: args[1].parse::<u64>().unwrap(),
                     found: AtomicU64::new(0)
                 });
-                total_matches_count = total_matches_count + args[1].parse::<u64>().unwrap();
             }
             for swew in &starts_and_ends_with_args {
                 let args: Vec<&str> = swew.split(':').collect(); 
@@ -445,7 +442,6 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                     count: args[2].parse::<u64>().unwrap(),
                     found: AtomicU64::new(0)
                 });
-                total_matches_count = total_matches_count + args[2].parse::<u64>().unwrap();
             }
 
             let grind_matches_thread_safe = Arc::new(grind_matches);
@@ -453,7 +449,6 @@ fn main() -> Result<(), Box<dyn error::Error>> {
             let _threads = (0..num_cpus::get())
                 .map(|_| {
                     let grind_matches_thread_safe = grind_matches_thread_safe.clone();
-                    let total_matches_count = total_matches_count.clone();
 
                     thread::spawn(move || loop {
                         let keypair = Keypair::new();
@@ -485,8 +480,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                                     write_keypair_file(&keypair, &format!("{}.json", keypair.pubkey())).unwrap();
                             }
                         }
-                        println!("count: {} -- found: {}",total_matches_count,total_matches_found);
-                        if total_matches_found == total_matches_count {
+                        if total_matches_found == grind_matches_thread_safe.len() {
                             std::process::exit(0);
                         }
                     });

--- a/keygen/src/keygen.rs
+++ b/keygen/src/keygen.rs
@@ -475,8 +475,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
             let start = Instant::now();
             let done = Arc::new(AtomicBool::new(false));
 
-            let _threads = 0..num_cpus::get();
-            for _ in _threads {
+            for _ in 0..num_cpus::get() {
                 let done = done.clone();
                 let attempts = attempts.clone();
                 let found = found.clone();

--- a/keygen/src/keygen.rs
+++ b/keygen/src/keygen.rs
@@ -74,7 +74,7 @@ fn output_keypair(
 }
 
 fn grind_validator_starts_with(v: String) -> Result<(), String> {
-    if v.matches(":").count() != 1 || (v.starts_with(":") || v.ends_with(":")) {
+    if v.matches(':').count() != 1 || (v.starts_with(':') || v.ends_with(':')) {
         return Err(String::from("Expected : between PREFIX and COUNT"));
     }
     let args: Vec<&str> = v.split(':').collect();
@@ -89,7 +89,7 @@ fn grind_validator_starts_with(v: String) -> Result<(), String> {
 }
 
 fn grind_validator_ends_with(v: String) -> Result<(), String> {
-    if v.matches(":").count() != 1 || (v.starts_with(":") || v.ends_with(":")) {
+    if v.matches(':').count() != 1 || (v.starts_with(':') || v.ends_with(':')) {
         return Err(String::from("Expected : between SUFFIX and COUNT"));
     }
     let args: Vec<&str> = v.split(':').collect();
@@ -104,7 +104,7 @@ fn grind_validator_ends_with(v: String) -> Result<(), String> {
 }
 
 fn grind_validator_starts_and_ends_with(v: String) -> Result<(), String> {
-    if v.matches(":").count() != 2 || (v.starts_with(":") || v.ends_with(":")) {
+    if v.matches(':').count() != 2 || (v.starts_with(':') || v.ends_with(':')) {
         return Err(String::from(
             "Expected : between PREFIX and SUFFIX and COUNT",
         ));
@@ -434,27 +434,25 @@ fn main() -> Result<(), Box<dyn error::Error>> {
             }
 
             println!("Searching with {} threads for:", num_cpus::get());
-            for i in 0..grind_matches.len() {
-                let pk: String;
-                let st: String;
-                let en: String;
-                if grind_matches[i].count.load(Ordering::Relaxed) > 1 {
-                    pk = "pubkeys".to_string();
-                    st = "start".to_string();
-                    en = "end".to_string();
+            for gm in &grind_matches {
+                let mut msg = Vec::<String>::new();
+                if gm.count.load(Ordering::Relaxed) > 1 {
+                    msg.push("pubkeys".to_string());
+                    msg.push("start".to_string());
+                    msg.push("end".to_string());
                 } else {
-                    pk = "pubkey".to_string();
-                    st = "starts".to_string();
-                    en = "ends".to_string();
+                    msg.push("pubkey".to_string());
+                    msg.push("starts".to_string());
+                    msg.push("ends".to_string());
                 }
                 println!(
                     "\t{} {} that {} with '{}' and {} with '{}'",
-                    grind_matches[i].count.load(Ordering::Relaxed),
-                    pk,
-                    st,
-                    grind_matches[i].starts,
-                    en,
-                    grind_matches[i].ends
+                    gm.count.load(Ordering::Relaxed),
+                    msg[0],
+                    msg[1],
+                    gm.starts,
+                    msg[2],
+                    gm.ends
                 );
             }
 
@@ -487,7 +485,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                         let mut total_matches_found = 0;
                         for i in 0..grind_matches_thread_safe.len() {
                             if grind_matches_thread_safe[i].count.load(Ordering::Relaxed) == 0 {
-                                total_matches_found = total_matches_found + 1;
+                                total_matches_found += 1;
                                 continue;
                             }
                             if (!grind_matches_thread_safe[i].starts.is_empty()

--- a/keygen/src/keygen.rs
+++ b/keygen/src/keygen.rs
@@ -469,17 +469,17 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                                 total_matches_found = total_matches_found + 1;
                                 continue;
                             }
-                            if (!grind_matches_thread_safe[i].starts.is_empty() && 
-                                grind_matches_thread_safe[i].ends.is_empty() && 
-                                pubkey.starts_with(&grind_matches_thread_safe[i].starts)) || 
+                            if (!grind_matches_thread_safe[i].starts.is_empty() &&
+                                grind_matches_thread_safe[i].ends.is_empty() &&
+                                pubkey.starts_with(&grind_matches_thread_safe[i].starts)) ||
                                 
-                                (grind_matches_thread_safe[i].starts.is_empty() && 
-                                !grind_matches_thread_safe[i].ends.is_empty() && 
-                                pubkey.ends_with(&grind_matches_thread_safe[i].ends)) || 
+                                (grind_matches_thread_safe[i].starts.is_empty() &&
+                                !grind_matches_thread_safe[i].ends.is_empty() &&
+                                pubkey.ends_with(&grind_matches_thread_safe[i].ends)) ||
                                 
                                 (!grind_matches_thread_safe[i].starts.is_empty() &&
-                                !grind_matches_thread_safe[i].ends.is_empty() && 
-                                pubkey.starts_with(&grind_matches_thread_safe[i].starts) && 
+                                !grind_matches_thread_safe[i].ends.is_empty() &&
+                                pubkey.starts_with(&grind_matches_thread_safe[i].starts) &&
                                 pubkey.ends_with(&grind_matches_thread_safe[i].ends))
                             {
                                     let _found = found.fetch_add(1, Ordering::Relaxed);

--- a/keygen/src/keygen.rs
+++ b/keygen/src/keygen.rs
@@ -129,7 +129,7 @@ fn grind_validator_starts_and_ends_with(v: String) -> Result<(), String> {
     Ok(())
 }
 
-fn grind_print_info(grind_matches: &Vec<GrindMatch>) {
+fn grind_print_info(grind_matches: &[GrindMatch]) {
     println!("Searching with {} threads for:", num_cpus::get());
     for gm in grind_matches {
         let mut msg = Vec::<String>::new();

--- a/keygen/src/keygen.rs
+++ b/keygen/src/keygen.rs
@@ -73,6 +73,66 @@ fn output_keypair(
     Ok(())
 }
 
+fn grind_validator_starts_with(v: String) -> Result<(), String> {
+    if v.matches(":").count() != 1 || (v.starts_with(":") || v.ends_with(":")) {
+        return Err(String::from("Expected : between PREFFIX and COUNT"));
+    }
+    let args: Vec<&str> = v.split(':').collect();
+    let s = bs58::decode(&args[0]).into_vec()
+    .map(|_| ())
+    .map_err(|err| format!("{}: {:?}", args[0], err));
+    if s.is_err() {
+        return s;
+    }
+    let count = args[1].parse::<u32>();
+    if count.is_err() || count.unwrap() == 0 {
+        return Err(String::from("Expected COUNT to be of type u32"));
+    }
+    Ok(())
+}
+
+fn grind_validator_ends_with(v: String) -> Result<(), String> {
+    if v.matches(":").count() != 1 || (v.starts_with(":") || v.ends_with(":")) {
+        return Err(String::from("Expected : between SUFFIX and COUNT"));
+    }
+    let args: Vec<&str> = v.split(':').collect();
+    let s = bs58::decode(&args[0]).into_vec()
+    .map(|_| ())
+    .map_err(|err| format!("{}: {:?}", args[0], err));
+    if s.is_err() {
+        return s;
+    }
+    let count = args[1].parse::<u32>();
+    if count.is_err() || count.unwrap() == 0 {
+        return Err(String::from("Expected COUNT to be of type u32"));
+    }
+    Ok(())
+}
+
+fn grind_validator_starts_and_ends_with(v: String) -> Result<(), String> {
+    if v.matches(":").count() != 2 || (v.starts_with(":") || v.ends_with(":")) {
+        return Err(String::from("Expected : between PREFFIX and SUFFIX and COUNT"));
+    }
+    let args: Vec<&str> = v.split(':').collect();
+    let p = bs58::decode(&args[0]).into_vec()
+    .map(|_| ())
+    .map_err(|err| format!("{}: {:?}", args[0], err));
+    if p.is_err() {
+        return p;
+    }
+    let s = bs58::decode(&args[1]).into_vec()
+    .map(|_| ())
+    .map_err(|err| format!("{}: {:?}", args[1], err));
+    if s.is_err() {
+        return s;
+    }
+    let count = args[2].parse::<u32>();
+    if count.is_err() || count.unwrap() == 0 {
+        return Err(String::from("Expected COUNT to be a u32"));
+    }
+    Ok(())
+}
+
 fn main() -> Result<(), Box<dyn error::Error>> {
     let matches = App::new(crate_name!())
         .about(crate_description!())
@@ -153,44 +213,32 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                 .arg(
                     Arg::with_name("starts_with")
                         .long("starts-with")
-                        .value_name("PREFIX COUNT")
-                        .number_of_values(2)
+                        .value_name("PREFIX:COUNT")
+                        .number_of_values(1)
                         .takes_value(true)
                         .multiple(true)
-                        .validator(|value| {
-                            bs58::decode(&value).into_vec()
-                                .map(|_| ())
-                                .map_err(|err| format!("{}: {:?}", value, err))
-                        })
-                        .help("Saves specified number of keypairs whos public key starts with the indicated prefix\nExample: --starts-with sol 4"),
+                        .validator(grind_validator_starts_with)
+                        .help("Saves specified number of keypairs whos public key starts with the indicated prefix\nExample: --starts-with sol:4\nPREFIX type is Base58\nCOUNT type is u32"),
                 )
                 .arg(
                     Arg::with_name("ends_with")
                         .long("ends-with")
-                        .value_name("SUFFIX COUNT")
-                        .number_of_values(2)
+                        .value_name("SUFFIX:COUNT")
+                        .number_of_values(1)
                         .takes_value(true)
                         .multiple(true)
-                        .validator(|value| {
-                            bs58::decode(&value).into_vec()
-                                .map(|_| ())
-                                .map_err(|err| format!("{}: {:?}", value, err))
-                        })
-                        .help("Saves specified number of keypairs whos public key ends with the indicated suffix\nExample: --ends-with ana 4"),
+                        .validator(grind_validator_ends_with)
+                        .help("Saves specified number of keypairs whos public key ends with the indicated suffix\nExample: --ends-with ana:4\nSUFFIX type is Base58\nCOUNT type is u32"),
                 )
                 .arg(
                     Arg::with_name("starts_and_ends_with")
                         .long("starts-and-ends-with")
-                        .value_name("PREFIX SUFFIX COUNT")
-                        .number_of_values(3)
+                        .value_name("PREFIX:SUFFIX:COUNT")
+                        .number_of_values(1)
                         .takes_value(true)
                         .multiple(true)
-                        .validator(|value| {
-                            bs58::decode(&value).into_vec()
-                                .map(|_| ())
-                                .map_err(|err| format!("{}: {:?}", value, err))
-                        })
-                        .help("Saves specified number of keypairs whos public key starts and ends with the indicated perfix and suffix\nExample: --starts-and-ends-with sol ana 4"),
+                        .validator(grind_validator_starts_and_ends_with)
+                        .help("Saves specified number of keypairs whos public key starts and ends with the indicated perfix and suffix\nExample: --starts-and-ends-with sol:ana:4\nPREFFIX and SUFFIX type is Base58\nCOUNT type is u32"),
                 ),
         )
         .subcommand(

--- a/keygen/src/keygen.rs
+++ b/keygen/src/keygen.rs
@@ -78,15 +78,10 @@ fn grind_validator_starts_with(v: String) -> Result<(), String> {
         return Err(String::from("Expected : between PREFIX and COUNT"));
     }
     let args: Vec<&str> = v.split(':').collect();
-    let s = bs58::decode(&args[0]).into_vec()
-    .map(|_| ())
-    .map_err(|err| format!("{}: {:?}", args[0], err));
-    if s.is_err() {
-        return s;
-    }
+    bs58::decode(&args[0]).into_vec().map_err(|err| format!("{}: {:?}", args[0], err))?;
     let count = args[1].parse::<u64>();
     if count.is_err() || count.unwrap() == 0 {
-        return Err(String::from("Expected COUNT to be of type u32"));
+        return Err(String::from("Expected COUNT to be of type u64"));
     }
     Ok(())
 }
@@ -96,15 +91,10 @@ fn grind_validator_ends_with(v: String) -> Result<(), String> {
         return Err(String::from("Expected : between SUFFIX and COUNT"));
     }
     let args: Vec<&str> = v.split(':').collect();
-    let s = bs58::decode(&args[0]).into_vec()
-    .map(|_| ())
-    .map_err(|err| format!("{}: {:?}", args[0], err));
-    if s.is_err() {
-        return s;
-    }
+    bs58::decode(&args[0]).into_vec().map_err(|err| format!("{}: {:?}", args[0], err))?;
     let count = args[1].parse::<u64>();
     if count.is_err() || count.unwrap() == 0 {
-        return Err(String::from("Expected COUNT to be of type u32"));
+        return Err(String::from("Expected COUNT to be of type u64"));
     }
     Ok(())
 }
@@ -114,21 +104,11 @@ fn grind_validator_starts_and_ends_with(v: String) -> Result<(), String> {
         return Err(String::from("Expected : between PREFIX and SUFFIX and COUNT"));
     }
     let args: Vec<&str> = v.split(':').collect();
-    let p = bs58::decode(&args[0]).into_vec()
-    .map(|_| ())
-    .map_err(|err| format!("{}: {:?}", args[0], err));
-    if p.is_err() {
-        return p;
-    }
-    let s = bs58::decode(&args[1]).into_vec()
-    .map(|_| ())
-    .map_err(|err| format!("{}: {:?}", args[1], err));
-    if s.is_err() {
-        return s;
-    }
+    bs58::decode(&args[0]).into_vec().map_err(|err| format!("{}: {:?}", args[0], err))?;
+    bs58::decode(&args[1]).into_vec().map_err(|err| format!("{}: {:?}", args[1], err))?;
     let count = args[2].parse::<u64>();
     if count.is_err() || count.unwrap() == 0 {
-        return Err(String::from("Expected COUNT to be a u32"));
+        return Err(String::from("Expected COUNT to be a u64"));
     }
     Ok(())
 }

--- a/keygen/src/keygen.rs
+++ b/keygen/src/keygen.rs
@@ -420,37 +420,15 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                 });
             }
 
-            let mut starting_messages = Vec::<String>::new();
-            for i in 0..grind_matches.len() {
-                if !grind_matches[i].starts.is_empty() && grind_matches[i].ends.is_empty() {
-                    let pk: String;
-                    if grind_matches[i].count.load(Ordering::Relaxed) > 1 {
-                        pk = "pubkeys".to_string();
-                    } else {
-                        pk = "pubkey".to_string();
-                    }
-                    starting_messages.push(format!("{} {} that starts with '{}'",grind_matches[i].count.load(Ordering::Relaxed), pk,grind_matches[i].starts))
-                } else if grind_matches[i].starts.is_empty() && !grind_matches[i].ends.is_empty() {
-                    let pk: String;
-                    if grind_matches[i].count.load(Ordering::Relaxed) > 1 {
-                        pk = "pubkeys".to_string();
-                    } else {
-                        pk = "pubkey".to_string();
-                    }
-                    starting_messages.push(format!("{} {} that ends with '{}'",grind_matches[i].count.load(Ordering::Relaxed), pk,grind_matches[i].ends))
-                } else if !grind_matches[i].starts.is_empty() && !grind_matches[i].ends.is_empty() {                       
-                    let pk: String;
-                    if grind_matches[i].count.load(Ordering::Relaxed) > 1 {
-                        pk = "pubkeys".to_string();
-                    } else {
-                        pk = "pubkey".to_string();
-                    }
-                    starting_messages.push(format!("{} {} that starts with '{}' and ends with '{}'",grind_matches[i].count.load(Ordering::Relaxed), pk,grind_matches[i].starts,grind_matches[i].ends))
-                }
-            }
             println!("Searching with {} threads for:", num_cpus::get());
-            for el in starting_messages {
-                println!("\t{}",el);
+            for i in 0..grind_matches.len() {
+                let pk: String;
+                if grind_matches[i].count.load(Ordering::Relaxed) > 1 {
+                    pk = "pubkeys".to_string();
+                } else {
+                    pk = "pubkey".to_string();
+                }
+                println!("\t{} {} that starts with '{}' and ends with '{}'",grind_matches[i].count.load(Ordering::Relaxed), pk,grind_matches[i].starts,grind_matches[i].ends);
             }
 
             let grind_matches_thread_safe = Arc::new(grind_matches);

--- a/keygen/src/keygen.rs
+++ b/keygen/src/keygen.rs
@@ -78,7 +78,9 @@ fn grind_validator_starts_with(v: String) -> Result<(), String> {
         return Err(String::from("Expected : between PREFIX and COUNT"));
     }
     let args: Vec<&str> = v.split(':').collect();
-    bs58::decode(&args[0]).into_vec().map_err(|err| format!("{}: {:?}", args[0], err))?;
+    bs58::decode(&args[0])
+        .into_vec()
+        .map_err(|err| format!("{}: {:?}", args[0], err))?;
     let count = args[1].parse::<u64>();
     if count.is_err() || count.unwrap() == 0 {
         return Err(String::from("Expected COUNT to be of type u64"));
@@ -91,7 +93,9 @@ fn grind_validator_ends_with(v: String) -> Result<(), String> {
         return Err(String::from("Expected : between SUFFIX and COUNT"));
     }
     let args: Vec<&str> = v.split(':').collect();
-    bs58::decode(&args[0]).into_vec().map_err(|err| format!("{}: {:?}", args[0], err))?;
+    bs58::decode(&args[0])
+        .into_vec()
+        .map_err(|err| format!("{}: {:?}", args[0], err))?;
     let count = args[1].parse::<u64>();
     if count.is_err() || count.unwrap() == 0 {
         return Err(String::from("Expected COUNT to be of type u64"));
@@ -101,11 +105,17 @@ fn grind_validator_ends_with(v: String) -> Result<(), String> {
 
 fn grind_validator_starts_and_ends_with(v: String) -> Result<(), String> {
     if v.matches(":").count() != 2 || (v.starts_with(":") || v.ends_with(":")) {
-        return Err(String::from("Expected : between PREFIX and SUFFIX and COUNT"));
+        return Err(String::from(
+            "Expected : between PREFIX and SUFFIX and COUNT",
+        ));
     }
     let args: Vec<&str> = v.split(':').collect();
-    bs58::decode(&args[0]).into_vec().map_err(|err| format!("{}: {:?}", args[0], err))?;
-    bs58::decode(&args[1]).into_vec().map_err(|err| format!("{}: {:?}", args[1], err))?;
+    bs58::decode(&args[0])
+        .into_vec()
+        .map_err(|err| format!("{}: {:?}", args[0], err))?;
+    bs58::decode(&args[1])
+        .into_vec()
+        .map_err(|err| format!("{}: {:?}", args[1], err))?;
     let count = args[2].parse::<u64>();
     if count.is_err() || count.unwrap() == 0 {
         return Err(String::from("Expected COUNT to be a u64"));
@@ -357,7 +367,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
             struct Match {
                 starts: String,
                 ends: String,
-                count: AtomicU64
+                count: AtomicU64,
             }
             let mut grind_matches = Vec::<Match>::new();
 
@@ -388,7 +398,10 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                 HashSet::new()
             };
 
-            if starts_with_args.is_empty() && ends_with_args.is_empty() && starts_and_ends_with_args.is_empty() {
+            if starts_with_args.is_empty()
+                && ends_with_args.is_empty()
+                && starts_and_ends_with_args.is_empty()
+            {
                 eprintln!(
                     "Error: No keypair search criteria provided (--starts-with or --ends-with or --starts-and-ends-with)"
                 );
@@ -396,27 +409,27 @@ fn main() -> Result<(), Box<dyn error::Error>> {
             }
 
             for sw in &starts_with_args {
-                let args: Vec<&str> = sw.split(':').collect(); 
-                grind_matches.push(Match{
+                let args: Vec<&str> = sw.split(':').collect();
+                grind_matches.push(Match {
                     starts: args[0].to_lowercase(),
                     ends: "".to_string(),
-                    count: AtomicU64::new(args[1].parse::<u64>().unwrap())
+                    count: AtomicU64::new(args[1].parse::<u64>().unwrap()),
                 });
             }
             for ew in &ends_with_args {
-                let args: Vec<&str> = ew.split(':').collect(); 
-                grind_matches.push(Match{
+                let args: Vec<&str> = ew.split(':').collect();
+                grind_matches.push(Match {
                     starts: "".to_string(),
                     ends: args[0].to_lowercase(),
-                    count: AtomicU64::new(args[1].parse::<u64>().unwrap())
+                    count: AtomicU64::new(args[1].parse::<u64>().unwrap()),
                 });
             }
             for swew in &starts_and_ends_with_args {
-                let args: Vec<&str> = swew.split(':').collect(); 
-                grind_matches.push(Match{
+                let args: Vec<&str> = swew.split(':').collect();
+                grind_matches.push(Match {
                     starts: args[0].to_lowercase(),
                     ends: args[1].to_lowercase(),
-                    count: AtomicU64::new(args[2].parse::<u64>().unwrap())
+                    count: AtomicU64::new(args[2].parse::<u64>().unwrap()),
                 });
             }
 
@@ -434,7 +447,15 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                     st = "starts".to_string();
                     en = "ends".to_string();
                 }
-                println!("\t{} {} that {} with '{}' and {} with '{}'",grind_matches[i].count.load(Ordering::Relaxed), pk,st,grind_matches[i].starts,en,grind_matches[i].ends);
+                println!(
+                    "\t{} {} that {} with '{}' and {} with '{}'",
+                    grind_matches[i].count.load(Ordering::Relaxed),
+                    pk,
+                    st,
+                    grind_matches[i].starts,
+                    en,
+                    grind_matches[i].ends
+                );
             }
 
             let grind_matches_thread_safe = Arc::new(grind_matches);
@@ -469,23 +490,27 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                                 total_matches_found = total_matches_found + 1;
                                 continue;
                             }
-                            if (!grind_matches_thread_safe[i].starts.is_empty() &&
-                                grind_matches_thread_safe[i].ends.is_empty() &&
-                                pubkey.starts_with(&grind_matches_thread_safe[i].starts)) ||
-                                
-                                (grind_matches_thread_safe[i].starts.is_empty() &&
-                                !grind_matches_thread_safe[i].ends.is_empty() &&
-                                pubkey.ends_with(&grind_matches_thread_safe[i].ends)) ||
-                                
-                                (!grind_matches_thread_safe[i].starts.is_empty() &&
-                                !grind_matches_thread_safe[i].ends.is_empty() &&
-                                pubkey.starts_with(&grind_matches_thread_safe[i].starts) &&
-                                pubkey.ends_with(&grind_matches_thread_safe[i].ends))
+                            if (!grind_matches_thread_safe[i].starts.is_empty()
+                                && grind_matches_thread_safe[i].ends.is_empty()
+                                && pubkey.starts_with(&grind_matches_thread_safe[i].starts))
+                                || (grind_matches_thread_safe[i].starts.is_empty()
+                                    && !grind_matches_thread_safe[i].ends.is_empty()
+                                    && pubkey.ends_with(&grind_matches_thread_safe[i].ends))
+                                || (!grind_matches_thread_safe[i].starts.is_empty()
+                                    && !grind_matches_thread_safe[i].ends.is_empty()
+                                    && pubkey.starts_with(&grind_matches_thread_safe[i].starts)
+                                    && pubkey.ends_with(&grind_matches_thread_safe[i].ends))
                             {
-                                    let _found = found.fetch_add(1, Ordering::Relaxed);
-                                    grind_matches_thread_safe[i].count.fetch_sub(1, Ordering::Relaxed);
-                                    println!("Wrote keypair to {}", &format!("{}.json", keypair.pubkey()));
-                                    write_keypair_file(&keypair, &format!("{}.json", keypair.pubkey())).unwrap();
+                                let _found = found.fetch_add(1, Ordering::Relaxed);
+                                grind_matches_thread_safe[i]
+                                    .count
+                                    .fetch_sub(1, Ordering::Relaxed);
+                                println!(
+                                    "Wrote keypair to {}",
+                                    &format!("{}.json", keypair.pubkey())
+                                );
+                                write_keypair_file(&keypair, &format!("{}.json", keypair.pubkey()))
+                                    .unwrap();
                             }
                         }
                         if total_matches_found == grind_matches_thread_safe.len() {

--- a/keygen/src/keygen.rs
+++ b/keygen/src/keygen.rs
@@ -75,7 +75,7 @@ fn output_keypair(
 
 fn grind_validator_starts_with(v: String) -> Result<(), String> {
     if v.matches(":").count() != 1 || (v.starts_with(":") || v.ends_with(":")) {
-        return Err(String::from("Expected : between PREFFIX and COUNT"));
+        return Err(String::from("Expected : between PREFIX and COUNT"));
     }
     let args: Vec<&str> = v.split(':').collect();
     let s = bs58::decode(&args[0]).into_vec()
@@ -111,7 +111,7 @@ fn grind_validator_ends_with(v: String) -> Result<(), String> {
 
 fn grind_validator_starts_and_ends_with(v: String) -> Result<(), String> {
     if v.matches(":").count() != 2 || (v.starts_with(":") || v.ends_with(":")) {
-        return Err(String::from("Expected : between PREFFIX and SUFFIX and COUNT"));
+        return Err(String::from("Expected : between PREFIX and SUFFIX and COUNT"));
     }
     let args: Vec<&str> = v.split(':').collect();
     let p = bs58::decode(&args[0]).into_vec()
@@ -238,7 +238,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                         .takes_value(true)
                         .multiple(true)
                         .validator(grind_validator_starts_and_ends_with)
-                        .help("Saves specified number of keypairs whos public key starts and ends with the indicated perfix and suffix\nExample: --starts-and-ends-with sol:ana:4\nPREFFIX and SUFFIX type is Base58\nCOUNT type is u64"),
+                        .help("Saves specified number of keypairs whos public key starts and ends with the indicated perfix and suffix\nExample: --starts-and-ends-with sol:ana:4\nPREFIX and SUFFIX type is Base58\nCOUNT type is u64"),
                 ),
         )
         .subcommand(


### PR DESCRIPTION
#### Problem
`solana-keygen grind` lacked some functionality that may be useful to users. `solana-keygen grind` also had some behaviors that were less than optimal.

Less than optimal behaviors occurred when both `--includes` and `--starts-with` options were present. What would happen was that grind would favor `--starts-with` and `--include` would lag behind.

Some functionalities that maybe useful are as followings:
- specify a count for a desired pubkey 
- specify a suffix for a pubkey
- specify a prefix for a pubkey
- specify both a prefix and suffix for a pubkey

#### Summary of Changes

- removed `--includes`
- added being able to specify prefix and a count: `./solana-keygen --starts-with cat:2`
- added being able to specify a suffix and a count: `./solana-keygen --ends-with bat:2`
- added being able to specify a prefix and suffix and a count: `./solana-keygen --starts-and-ends-with cat:bat:2`
- each option can be used multiple times: `./solana-keygen --starts-with dad:2 --starts-with cat:3 --ends-with bat:2 --starts-and-ends-with fed:dn:2`
- `--ignore-case` is still supported
- updated `--help` for the grind option
- the count value must be a u64
- the prefix and suffix value must be base58
- updated the printing format for when a key is found
