### PR TITLE
Specify where VM images are coming from across GCE projects

### DIFF
--- a/net/scripts/gce-provider.sh
+++ b/net/scripts/gce-provider.sh
@@ -174,7 +174,7 @@ cloud_CreateInstances() {
     # the stock Ubuntu 18.04 image and programmatically install CUDA after the
     # instance boots
     #
-    imageName="ubuntu-1804-bionic-v20181029-with-cuda-10-and-cuda-9-2"
+    imageName="ubuntu-1804-bionic-v20181029-with-cuda-10-and-cuda-9-2 --image-project principal-lane-200702"
   else
     # Upstream Ubuntu 18.04 LTS image
     imageName="ubuntu-1804-bionic-v20190813a --image-project ubuntu-os-cloud"


### PR DESCRIPTION
#### Problem
Since we split apart our GCE VM usage into multiple projects, we need to specify which project an image is owned by when it is not owned by the project that is creating the VMs.

#### Summary of Changes
Add the`--image-project` flag to the GPU GCE image command line to point at the Development project, where the image lives.  Also, added IAM permissions for the API user from each of the new projects to read images owned by the development project.   (https://cloud.google.com/deployment-manager/docs/configuration/using-images-from-other-projects-for-vm-instances)
