### PR TITLE
Add lock to synchronize slot-based Blocktree operations and LedgerCleanupService

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -527,6 +527,9 @@ impl ReplayStage {
         let tx_count = tx_count_after - tx_count_before;
 
         confirm_result.map_err(|err| {
+            // LedgerCleanupService should not be cleaning up anything
+            // that comes after the root, so we should not see any
+            // errors related to the slot being purged
             let slot = bank.slot();
             warn!("Fatal replay error in slot: {}, err: {:?}", slot, err);
             datapoint_error!(

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -383,7 +383,11 @@ impl JsonRpcRequestProcessor {
         let stakes = HashMap::new();
         let stakes = bank.epoch_vote_accounts(epoch).unwrap_or(&stakes);
 
-        Ok(self.blockstore.get_block_time(slot, slot_duration, stakes))
+        Ok(self
+            .blockstore
+            .get_block_time(slot, slot_duration, stakes)
+            .ok()
+            .unwrap_or(None))
     }
 }
 

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -49,6 +49,7 @@ pub enum BlockstoreError {
     IO(#[from] std::io::Error),
     Serialize(#[from] Box<bincode::ErrorKind>),
     FsExtraError(#[from] fs_extra::error::Error),
+    SlotCleanedUp,
 }
 pub(crate) type Result<T> = std::result::Result<T, BlockstoreError>;
 


### PR DESCRIPTION
#### Problem
LedgerCleanupService can delete state while certain Blocktree functions expect that state to still be there

#### Summary of Changes
Introduce a RwLock to make sure Blocktree operations on slots < root are atomic with respect to ledger cleanup operations 

Fixes #7828 
