### PR TITLE
CLI: Fix tests. sign_only=true requires a blockhash

### DIFF
--- a/cli/tests/pay.rs
+++ b/cli/tests/pay.rs
@@ -289,9 +289,11 @@ fn test_offline_pay_tx() {
     check_balance(50, &rpc_client, &config_offline.keypair.pubkey());
     check_balance(50, &rpc_client, &config_online.keypair.pubkey());
 
+    let (blockhash, _) = rpc_client.get_recent_blockhash().unwrap();
     config_offline.command = CliCommand::Pay(PayCommand {
         lamports: 10,
         to: bob_pubkey,
+        blockhash: Some(blockhash),
         sign_only: true,
         ..PayCommand::default()
     });

--- a/cli/tests/stake.rs
+++ b/cli/tests/stake.rs
@@ -305,6 +305,7 @@ fn test_offline_stake_delegation_and_deactivation() {
     process_command(&config_validator).unwrap();
 
     // Delegate stake offline
+    let (blockhash, _) = rpc_client.get_recent_blockhash().unwrap();
     config_validator.command = CliCommand::DelegateStake {
         stake_account_pubkey: config_stake.keypair.pubkey(),
         vote_account_pubkey: config_vote.keypair.pubkey(),
@@ -312,7 +313,7 @@ fn test_offline_stake_delegation_and_deactivation() {
         force: true,
         sign_only: true,
         signers: None,
-        blockhash: None,
+        blockhash: Some(blockhash),
         nonce_account: None,
         nonce_authority: None,
     };
@@ -334,12 +335,13 @@ fn test_offline_stake_delegation_and_deactivation() {
     process_command(&config_payer).unwrap();
 
     // Deactivate stake offline
+    let (blockhash, _) = rpc_client.get_recent_blockhash().unwrap();
     config_validator.command = CliCommand::DeactivateStake {
         stake_account_pubkey: config_stake.keypair.pubkey(),
         stake_authority: None,
         sign_only: true,
         signers: None,
-        blockhash: None,
+        blockhash: Some(blockhash),
         nonce_account: None,
         nonce_authority: None,
     };
@@ -557,6 +559,7 @@ fn test_stake_authorize() {
     let nonced_authority_pubkey = nonced_authority.pubkey();
     let (nonced_authority_file, mut tmp_file) = make_tmp_file();
     write_keypair(&nonced_authority, tmp_file.as_file_mut()).unwrap();
+    let (blockhash, _) = rpc_client.get_recent_blockhash().unwrap();
     config.command = CliCommand::StakeAuthorize {
         stake_account_pubkey,
         new_authorized_pubkey: nonced_authority_pubkey,
@@ -564,7 +567,7 @@ fn test_stake_authorize() {
         authority: Some(read_keypair_file(&offline_authority_file).unwrap().into()),
         sign_only: true,
         signers: None,
-        blockhash: None,
+        blockhash: Some(blockhash),
         nonce_account: None,
         nonce_authority: None,
     };


### PR DESCRIPTION
#### Problem

A few of CLI's offline tests omit the `blockhash` parameter when `sign_only` is `true`.  This isn't a valid combination as per argument parsing but can slide by the code side until #7981 is in.

#### Summary of Changes

Always pass a blockhash when `sign_only` is true

I'm breaking this out of #7981 since it's a bit held up in review and I need it in place to move forward with merging other fixes