### PR TITLE
Log solana-validator args on startup to aid debugging

### DIFF
--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -765,6 +765,8 @@ pub fn main() {
         .join(","),
     );
 
+    info!("Starting validator with: {:#?}", std::env::args_os());
+
     let vote_account = pubkey_of(&matches, "vote_account").unwrap_or_else(|| {
         // Disable voting because normal (=not bootstrapping) validator rejects
         // non-voting accounts (= ephemeral keypairs).


### PR DESCRIPTION
#### Problem
The validator log output does not include the command-line argument used to invoke the validator. This is a problem because those args are important for debugging and forces us to ask validators what they used.

#### Summary of Changes
Once logger is setup, log info message with cli args

```
[2020-01-29T09:55:08.215980000Z INFO  solana_validator] Starting validator with: ArgsOs {
        inner: [
            "target/debug/solana-validator",
            "--ledger",
            "tmp",
            "--wait-for-supermajority",
            "--log",
            "-",
        ],
    }
```

Fixes https://github.com/solana-labs/solana/issues/8011
