### PR TITLE
Remove tower initialization from vote state

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -185,7 +185,7 @@ impl ReplayStage {
 
         let (root_bank_sender, root_bank_receiver) = channel();
         trace!("replay stage");
-        let mut tower = Tower::new(&my_pubkey, &vote_account, &bank_forks.read().unwrap());
+        let mut tower = Tower::new(&my_pubkey, &bank_forks.read().unwrap());
 
         // Start the replay stage loop
 


### PR DESCRIPTION
#### Problem
Starting from a snapshot with slot greater than slots in the vote state in that snapshot  triggers the `is_locked_out` check because ancestor information is not included in the snapshot

#### Summary of Changes
Don't initialize tower state from vote state, clear the tower state and set root == BankForks root
Fixes #
