### PR TITLE
Various fixes/improvements resulting from SLP 1.1 restart debug

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -193,6 +193,7 @@ pub enum CliCommand {
     GetTransactionCount {
         commitment_config: CommitmentConfig,
     },
+    LeaderSchedule,
     Ping {
         lamports: u64,
         interval: Duration,
@@ -456,6 +457,10 @@ pub fn parse_command(matches: &ArgMatches<'_>) -> Result<CliCommandInfo, Box<dyn
         }),
         ("slot", Some(matches)) => parse_get_slot(matches),
         ("transaction-count", Some(matches)) => parse_get_transaction_count(matches),
+        ("leader-schedule", Some(_matches)) => Ok(CliCommandInfo {
+            command: CliCommand::LeaderSchedule,
+            require_keypair: false,
+        }),
         ("ping", Some(matches)) => parse_cluster_ping(matches),
         ("block-production", Some(matches)) => parse_show_block_production(matches),
         ("gossip", Some(_matches)) => Ok(CliCommandInfo {
@@ -1261,6 +1266,7 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
         CliCommand::GetTransactionCount { commitment_config } => {
             process_get_transaction_count(&rpc_client, commitment_config)
         }
+        CliCommand::LeaderSchedule => process_leader_schedule(&rpc_client),
         CliCommand::Ping {
             lamports,
             interval,

--- a/core/src/cluster_info.rs
+++ b/core/src/cluster_info.rs
@@ -272,7 +272,7 @@ impl ClusterInfo {
 
                 let ip_addr = node.gossip.ip();
                 format!(
-                    "{:15} {:2}| {:5} | {:44} | {:5}| {:5}| {:5} | {:5}| {:5} | {:5}| {:5} | {:5}| {:5}| v{}\n",
+                    "{:15} {:2}| {:5} | {:44} | {:5}| {:5}| {:5} | {:5}| {:5} | {:5}| {:5} | {:5}| {:5}| {}\n",
                     if ContactInfo::is_valid_address(&node.gossip) {
                         ip_addr.to_string()
                     } else {

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -728,11 +728,14 @@ impl RpcSol for RpcSolImpl {
                 None
             }
         }
+        let shred_version = cluster_info.my_data().shred_version;
         Ok(cluster_info
             .all_peers()
             .iter()
             .filter_map(|(contact_info, _)| {
-                if ContactInfo::is_valid_address(&contact_info.gossip) {
+                if shred_version == contact_info.shred_version
+                    && ContactInfo::is_valid_address(&contact_info.gossip)
+                {
                     Some(RpcContactInfo {
                         pubkey: contact_info.id.to_string(),
                         gossip: Some(contact_info.gossip),

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -56,6 +56,7 @@ pub struct ValidatorConfig {
     pub dev_sigverify_disabled: bool,
     pub dev_halt_at_slot: Option<Slot>,
     pub expected_genesis_hash: Option<Hash>,
+    pub expected_shred_version: Option<u16>,
     pub voting_disabled: bool,
     pub transaction_status_service_disabled: bool,
     pub blockstream_unix_socket: Option<PathBuf>,
@@ -77,6 +78,7 @@ impl Default for ValidatorConfig {
             dev_sigverify_disabled: false,
             dev_halt_at_slot: None,
             expected_genesis_hash: None,
+            expected_shred_version: None,
             voting_disabled: false,
             transaction_status_service_disabled: false,
             blockstream_unix_socket: None,
@@ -193,6 +195,16 @@ impl Validator {
         node.info.shred_version =
             compute_shred_version(&genesis_hash, &bank.hard_forks().read().unwrap());
         Self::print_node_info(&node);
+
+        if let Some(expected_shred_version) = config.expected_shred_version {
+            if expected_shred_version != node.info.shred_version {
+                error!(
+                    "shred version mismatch: expected {}",
+                    expected_shred_version
+                );
+                process::exit(1);
+            }
+        }
 
         let cluster_info = Arc::new(RwLock::new(ClusterInfo::new(
             node.info.clone(),

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -584,10 +584,17 @@ pub fn main() {
                 .help("Redirect logging to the specified file, '-' for standard error"),
         )
         .arg(
+            Arg::with_name("no_wait_for_supermajority")
+                .long("no-wait-for-supermajority")
+                .takes_value(false)
+                .help("After processing the ledger, do not wait until a supermajority of stake is visible on gossip before starting PoH"),
+        )
+        .arg(
+            // Legacy flag that is now enabled by default.  Remove this flag a couple months after the 0.23.0
+            // release
             Arg::with_name("wait_for_supermajority")
                 .long("wait-for-supermajority")
-                .takes_value(false)
-                .help("After processing the ledger, wait until a supermajority of stake is visible on gossip before starting PoH"),
+                .hidden(true)
         )
         .arg(
             Arg::with_name("hard_forks")
@@ -655,7 +662,7 @@ pub fn main() {
             }),
         },
         voting_disabled: matches.is_present("no_voting"),
-        wait_for_supermajority: matches.is_present("wait_for_supermajority"),
+        wait_for_supermajority: !matches.is_present("no_wait_for_supermajority"),
         ..ValidatorConfig::default()
     };
 


### PR DESCRIPTION
1. RPC getClusterNodes now excludes validators with a different shred version.  There's no reason to surface validators that are on a different hard-fork via RPC
2. Validators now wait for a supermajority of stake by default, add --no-wait-for-supermajority flag to override.
3. Add --expected-shred-version option to `solana-validator`, to avoid SLP infra gymnastics when multiple hard forks are on the same gossip network
4. Add `solana leader-schedule` subcommand 