### PR TITLE
Separate RefCells for lamports and data

### DIFF
--- a/programs/bpf/rust/dup_accounts/src/lib.rs
+++ b/programs/bpf/rust/dup_accounts/src/lib.rs
@@ -16,32 +16,32 @@ fn process_instruction(
     match instruction_data[0] {
         1 => {
             info!("modify first account data");
-            accounts[2].borrow_mut().data[0] = 1;
+            accounts[2].data.borrow_mut()[0] = 1;
         }
         2 => {
             info!("modify first account data");
-            accounts[3].borrow_mut().data[0] = 2;
+            accounts[3].data.borrow_mut()[0] = 2;
         }
         3 => {
             info!("modify both account data");
-            accounts[2].borrow_mut().data[0] += 1;
-            accounts[3].borrow_mut().data[0] += 2;
+            accounts[2].data.borrow_mut()[0] += 1;
+            accounts[3].data.borrow_mut()[0] += 2;
         }
         4 => {
             info!("modify first account lamports");
-            *accounts[1].borrow_mut().lamports -= 1;
-            *accounts[2].borrow_mut().lamports += 1;
+            **accounts[1].lamports.borrow_mut() -= 1;
+            **accounts[2].lamports.borrow_mut() += 1;
         }
         5 => {
             info!("modify first account lamports");
-            *accounts[1].borrow_mut().lamports -= 2;
-            *accounts[3].borrow_mut().lamports += 2;
+            **accounts[1].lamports.borrow_mut() -= 2;
+            **accounts[3].lamports.borrow_mut() += 2;
         }
         6 => {
             info!("modify both account lamports");
-            *accounts[1].borrow_mut().lamports -= 3;
-            *accounts[2].borrow_mut().lamports += 1;
-            *accounts[3].borrow_mut().lamports += 2;
+            **accounts[1].lamports.borrow_mut() -= 3;
+            **accounts[2].lamports.borrow_mut() += 1;
+            **accounts[3].lamports.borrow_mut() += 2;
         }
         _ => {
             info!("Unrecognized command");

--- a/programs/bpf/rust/external_spend/src/lib.rs
+++ b/programs/bpf/rust/external_spend/src/lib.rs
@@ -12,7 +12,7 @@ fn process_instruction(
     // account 0 is the mint and not owned by this program, any debit of its lamports
     // should result in a failed program execution.  Test to ensure that this debit
     // is seen by the runtime and fails as expected
-    *accounts[0].borrow_mut().lamports -= 1;
+    **accounts[0].lamports.borrow_mut() -= 1;
 
     SUCCESS
 }

--- a/sdk/src/sysvar/mod.rs
+++ b/sdk/src/sysvar/mod.rs
@@ -71,10 +71,10 @@ pub trait Sysvar:
         bincode::serialize_into(&mut account.data[..], self).ok()
     }
     fn from_account_info(account_info: &AccountInfo) -> Option<Self> {
-        bincode::deserialize(&account_info.m.borrow().data).ok()
+        bincode::deserialize(&account_info.data.borrow()).ok()
     }
     fn to_account_info(&self, account_info: &mut AccountInfo) -> Option<()> {
-        bincode::serialize_into(&mut account_info.m.borrow_mut().data[..], self).ok()
+        bincode::serialize_into(&mut account_info.data.borrow_mut()[..], self).ok()
     }
     fn from_keyed_account(keyed_account: &KeyedAccount) -> Result<Self, InstructionError> {
         if !Self::check_id(keyed_account.unsigned_key()) {


### PR DESCRIPTION
#### Problem

In the account information sent to a BPF program's `process_instruction` function, both lamports and data are contained in the same `RefCell`.  This means the borrowed lifetimes of each are linked.  There is no reason these lifetimes should be linked and doing so can cause the user to do gymnastics or copy data to avoid borrow-checking errors.

#### Summary of Changes

Wrap each mutable member of the `AccountInfo` structure with their own `RefCell`

Fixes #
