### PR TITLE
Update solana_rbpf v0.1.20

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3561,7 +3561,7 @@ dependencies = [
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-logger 0.24.0",
  "solana-sdk 0.24.0",
- "solana_rbpf 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_rbpf 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -4900,7 +4900,7 @@ dependencies = [
 
 [[package]]
 name = "solana_rbpf"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6368,7 +6368,7 @@ dependencies = [
 "checksum solana_libra_vm_genesis 0.0.1-sol4 (registry+https://github.com/rust-lang/crates.io-index)" = "d2c98f2663f28ff221b119a471fd790dbbf1e87664fce4c40421120252c09b8e"
 "checksum solana_libra_vm_runtime 0.0.1-sol4 (registry+https://github.com/rust-lang/crates.io-index)" = "ff9f8a7b8212dc4ece5d93f2839896e633c34d7463856e4a555cbcb5c67e9c26"
 "checksum solana_libra_vm_runtime_types 0.0.1-sol4 (registry+https://github.com/rust-lang/crates.io-index)" = "254c23c8f30e7c82ae4dc6694e743400d674c66d371b700eec03378ba994f00b"
-"checksum solana_rbpf 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)" = "cb45776e861c7a71ed3ccb629c076889dc91a9ba7c1e58e44f8c7b9f916f07c9"
+"checksum solana_rbpf 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)" = "3a42509c38aaba4e771b6067d8d7bbfeb83e2b314fb2f3da401acdec9b8425ba"
 "checksum sourcefile 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4bf77cb82ba8453b42b6ae1d692e4cdc92f9a47beaf89a847c8be83f4e328ad3"
 "checksum spin 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -1935,7 +1935,7 @@ dependencies = [
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-logger 0.24.0",
  "solana-sdk 0.24.0",
- "solana_rbpf 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_rbpf 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1949,7 +1949,7 @@ dependencies = [
  "solana-logger 0.24.0",
  "solana-runtime 0.24.0",
  "solana-sdk 0.24.0",
- "solana_rbpf 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_rbpf 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 2.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2275,7 +2275,7 @@ dependencies = [
 
 [[package]]
 name = "solana_rbpf"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3236,7 +3236,7 @@ dependencies = [
 "checksum sha2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "27044adfd2e1f077f649f59deb9490d3941d674002f7d062870a60ebe9bd47a0"
 "checksum slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 "checksum smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "ab606a9c5e214920bb66c458cd7be8ef094f813f20fe77a54cc7dbfff220d4b7"
-"checksum solana_rbpf 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)" = "cb45776e861c7a71ed3ccb629c076889dc91a9ba7c1e58e44f8c7b9f916f07c9"
+"checksum solana_rbpf 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)" = "3a42509c38aaba4e771b6067d8d7bbfeb83e2b314fb2f3da401acdec9b8425ba"
 "checksum sourcefile 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4bf77cb82ba8453b42b6ae1d692e4cdc92f9a47beaf89a847c8be83f4e328ad3"
 "checksum spin 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"

--- a/programs/bpf/Cargo.toml
+++ b/programs/bpf/Cargo.toml
@@ -26,7 +26,7 @@ solana-bpf-loader-program = { path = "../bpf_loader", version = "0.24.0" }
 solana-logger = { path = "../../logger", version = "0.24.0" }
 solana-runtime = { path = "../../runtime", version = "0.24.0" }
 solana-sdk = { path = "../../sdk", version = "0.24.0" }
-solana_rbpf = "=0.1.19"
+solana_rbpf = "=0.1.20"
 
 [[bench]]
 name = "bpf_loader"

--- a/programs/bpf_loader/Cargo.toml
+++ b/programs/bpf_loader/Cargo.toml
@@ -16,7 +16,7 @@ log = "0.4.8"
 serde = "1.0.104"
 solana-logger = { path = "../../logger", version = "0.24.0" }
 solana-sdk = { path = "../../sdk", version = "0.24.0" }
-solana_rbpf = "=0.1.19"
+solana_rbpf = "=0.1.20"
 
 [lib]
 crate-type = ["lib", "cdylib"]


### PR DESCRIPTION
#### Problem

Bug in `mov32` that sign extended the `imm` rather then clear the top 32 bits.

#### Summary of Changes

Don't sign extend

Fixes #
