### PR TITLE
Add shred version filters to Crds Accessors

### DIFF
--- a/archiver-lib/src/archiver.rs
+++ b/archiver-lib/src/archiver.rs
@@ -522,6 +522,8 @@ impl Archiver {
         let mut contact_info = node_info.clone();
         contact_info.tvu = "0.0.0.0:0".parse().unwrap();
         contact_info.wallclock = timestamp();
+        // copy over the adopted shred_version from the entrypoint
+        contact_info.shred_version = cluster_info.read().unwrap().my_data().shred_version;
         {
             let mut cluster_info_w = cluster_info.write().unwrap();
             cluster_info_w.insert_self(contact_info);

--- a/core/src/gossip_service.rs
+++ b/core/src/gossip_service.rs
@@ -197,10 +197,10 @@ fn spy(
         tvu_peers = spy_ref
             .read()
             .unwrap()
-            .tvu_peers()
+            .all_tvu_peers()
             .into_iter()
             .collect::<Vec<_>>();
-        archivers = spy_ref.read().unwrap().storage_peers();
+        archivers = spy_ref.read().unwrap().all_storage_peers();
         if let Some(num) = num_nodes {
             if tvu_peers.len() + archivers.len() >= num {
                 if let Some(gossip_addr) = find_node_by_gossip_addr {


### PR DESCRIPTION
#### Problem

Gossiped Shred Versions aren't really used. 
Having clusters running with different shred versions simultaneously causes undesired interactions between clusters because of gossip.  

#### Summary of Changes

- Added a shred_version check to all `crds_version` accessor functions. 
Turbine, Broadcast, Repair should all be considering nodes running on the same version of the cluster and ignore those on different versions. 
- Added `all_*` variants to some accessor functions so that spy nodes can function correctly
- Added a workaround for Archivers where Gosssip services will automatically pick up the entrypoint's shred_version if one is not specified. 

Gossip, however, will still continue to work across all shred versions of clusters.
