### PR TITLE
validator: add --private-rpc flag

### DIFF
--- a/core/src/contact_info.rs
+++ b/core/src/contact_info.rs
@@ -299,8 +299,8 @@ mod tests {
         assert_eq!(ci.gossip.port(), 11);
         assert_eq!(ci.tvu.port(), 12);
         assert_eq!(ci.tpu_forwards.port(), 13);
-        assert_eq!(ci.rpc.port(), 8899);
-        assert_eq!(ci.rpc_pubsub.port(), 8900);
+        assert_eq!(ci.rpc.port(), rpc_port::DEFAULT_RPC_PORT);
+        assert_eq!(ci.rpc_pubsub.port(), rpc_port::DEFAULT_RPC_PUBSUB_PORT);
         assert!(ci.storage_addr.ip().is_unspecified());
     }
     #[test]
@@ -315,8 +315,14 @@ mod tests {
         assert_eq!(d1.tvu, socketaddr!("127.0.0.1:1236"));
         assert_eq!(d1.tpu_forwards, socketaddr!("127.0.0.1:1237"));
         assert_eq!(d1.tpu, socketaddr!("127.0.0.1:1234"));
-        assert_eq!(d1.rpc, socketaddr!("127.0.0.1:8899"));
-        assert_eq!(d1.rpc_pubsub, socketaddr!("127.0.0.1:8900"));
+        assert_eq!(
+            d1.rpc,
+            socketaddr!(format!("127.0.0.1:{}", rpc_port::DEFAULT_RPC_PORT))
+        );
+        assert_eq!(
+            d1.rpc_pubsub,
+            socketaddr!(format!("127.0.0.1:{}", rpc_port::DEFAULT_RPC_PUBSUB_PORT))
+        );
     }
 
     #[test]

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -47,8 +47,7 @@ fn new_response<T>(bank: &Bank, value: T) -> RpcResponse<T> {
 
 #[derive(Debug, Default, Clone)]
 pub struct JsonRpcConfig {
-    pub rpc_ports: Option<(u16, u16)>, // (API, PubSub)
-    pub enable_validator_exit: bool,   // Enable the 'validatorExit' command
+    pub enable_validator_exit: bool, // Enable the 'validatorExit' command
     pub faucet_addr: Option<SocketAddr>,
 }
 

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -45,19 +45,11 @@ fn new_response<T>(bank: &Bank, value: T) -> RpcResponse<T> {
     Ok(Response { context, value })
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Default, Clone)]
 pub struct JsonRpcConfig {
-    pub enable_validator_exit: bool, // Enable the 'validatorExit' command
+    pub rpc_ports: Option<(u16, u16)>, // (API, PubSub)
+    pub enable_validator_exit: bool,   // Enable the 'validatorExit' command
     pub faucet_addr: Option<SocketAddr>,
-}
-
-impl Default for JsonRpcConfig {
-    fn default() -> Self {
-        Self {
-            enable_validator_exit: false,
-            faucet_addr: None,
-        }
-    }
 }
 
 #[derive(Clone)]

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -1116,6 +1116,7 @@ pub mod tests {
         fee_calculator::DEFAULT_BURN_PERCENT,
         hash::{hash, Hash},
         instruction::InstructionError,
+        rpc_port,
         signature::{Keypair, KeypairUtil},
         system_transaction,
         transaction::TransactionError,
@@ -1354,8 +1355,9 @@ pub mod tests {
             .expect("actual response deserialization");
 
         let expected = format!(
-            r#"{{"jsonrpc":"2.0","result":[{{"pubkey": "{}", "gossip": "127.0.0.1:1235", "tpu": "127.0.0.1:1234", "rpc": "127.0.0.1:8899"}}],"id":1}}"#,
+            r#"{{"jsonrpc":"2.0","result":[{{"pubkey": "{}", "gossip": "127.0.0.1:1235", "tpu": "127.0.0.1:1234", "rpc": "127.0.0.1:{}"}}],"id":1}}"#,
             leader_pubkey,
+            rpc_port::DEFAULT_RPC_PORT
         );
 
         let expected: Response =

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -207,6 +207,10 @@ impl LocalCluster {
         let leader_storage_keypair = Arc::new(storage_keypair);
         let leader_voting_keypair = Arc::new(voting_keypair);
         let mut leader_config = config.validator_configs[0].clone();
+        leader_config.rpc_ports = Some((
+            leader_node.info.rpc.port(),
+            leader_node.info.rpc_pubsub.port(),
+        ));
         leader_config.transaction_status_service_disabled = true;
         let leader_server = Validator::new(
             leader_node,
@@ -351,6 +355,10 @@ impl LocalCluster {
         }
 
         let mut config = validator_config.clone();
+        config.rpc_ports = Some((
+            validator_node.info.rpc.port(),
+            validator_node.info.rpc_pubsub.port(),
+        ));
         config.transaction_status_service_disabled = true;
         let voting_keypair = Arc::new(voting_keypair);
         let validator_server = Validator::new(
@@ -658,6 +666,8 @@ impl Cluster for LocalCluster {
         // Update the stored ContactInfo for this node
         let node = Node::new_localhost_with_pubkey(&pubkey);
         cluster_validator_info.info.contact_info = node.info.clone();
+        cluster_validator_info.config.rpc_ports =
+            Some((node.info.rpc.port(), node.info.rpc_pubsub.port()));
         cluster_validator_info
             .config
             .transaction_status_service_disabled = true;

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -497,6 +497,12 @@ pub fn main() {
                 .help("RPC port to use for this node"),
         )
         .arg(
+            Arg::with_name("private_rpc")
+                .long("--private-rpc")
+                .takes_value(false)
+                .help("Do not publish the RPC port for use by other nodes")
+        )
+        .arg(
             Arg::with_name("enable_rpc_exit")
                 .long("enable-rpc-exit")
                 .takes_value(false)
@@ -657,7 +663,7 @@ pub fn main() {
     let cuda = matches.is_present("cuda");
     let no_genesis_fetch = matches.is_present("no_genesis_fetch");
     let no_snapshot_fetch = matches.is_present("no_snapshot_fetch");
-    let rpc_port = value_t!(matches, "rpc_port", u16);
+    let private_rpc = matches.is_present("private_rpc");
 
     // Canonicalize ledger path to avoid issues with symlink creation
     let _ = fs::create_dir_all(&ledger_path);
@@ -678,6 +684,9 @@ pub fn main() {
         expected_shred_version: value_t!(matches, "expected_shred_version", u16).ok(),
         new_hard_forks: hardforks_of(&matches, "hard_forks"),
         rpc_config: JsonRpcConfig {
+            rpc_ports: value_t!(matches, "rpc_port", u16)
+                .ok()
+                .map(|rpc_port| (rpc_port, rpc_port + 1)),
             enable_validator_exit: matches.is_present("enable_rpc_exit"),
             faucet_addr: matches.value_of("rpc_faucet_addr").map(|address| {
                 solana_net_utils::parse_host_port(address).expect("failed to parse faucet address")
@@ -852,12 +861,14 @@ pub fn main() {
     let mut tcp_ports = vec![];
     let mut node =
         Node::new_with_external_ip(&identity_keypair.pubkey(), &gossip_addr, dynamic_port_range);
-    if let Ok(rpc_port) = rpc_port {
-        let rpc_pubsub_port = rpc_port + 1;
-        node.info.rpc = SocketAddr::new(node.info.gossip.ip(), rpc_port);
-        node.info.rpc_pubsub = SocketAddr::new(node.info.gossip.ip(), rpc_pubsub_port);
-        tcp_ports = vec![rpc_port, rpc_pubsub_port];
-    };
+
+    if !private_rpc {
+        if let Some((rpc_port, rpc_pubsub_port)) = validator_config.rpc_config.rpc_ports {
+            node.info.rpc = SocketAddr::new(node.info.gossip.ip(), rpc_port);
+            node.info.rpc_pubsub = SocketAddr::new(node.info.gossip.ip(), rpc_pubsub_port);
+            tcp_ports = vec![rpc_port, rpc_pubsub_port];
+        }
+    }
 
     if let Some(ref cluster_entrypoint) = cluster_entrypoint {
         let udp_sockets = vec![&node.sockets.gossip, &node.sockets.repair];

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -684,14 +684,14 @@ pub fn main() {
         expected_shred_version: value_t!(matches, "expected_shred_version", u16).ok(),
         new_hard_forks: hardforks_of(&matches, "hard_forks"),
         rpc_config: JsonRpcConfig {
-            rpc_ports: value_t!(matches, "rpc_port", u16)
-                .ok()
-                .map(|rpc_port| (rpc_port, rpc_port + 1)),
             enable_validator_exit: matches.is_present("enable_rpc_exit"),
             faucet_addr: matches.value_of("rpc_faucet_addr").map(|address| {
                 solana_net_utils::parse_host_port(address).expect("failed to parse faucet address")
             }),
         },
+        rpc_ports: value_t!(matches, "rpc_port", u16)
+            .ok()
+            .map(|rpc_port| (rpc_port, rpc_port + 1)),
         voting_disabled: matches.is_present("no_voting"),
         wait_for_supermajority: !matches.is_present("no_wait_for_supermajority"),
         ..ValidatorConfig::default()
@@ -863,7 +863,7 @@ pub fn main() {
         Node::new_with_external_ip(&identity_keypair.pubkey(), &gossip_addr, dynamic_port_range);
 
     if !private_rpc {
-        if let Some((rpc_port, rpc_pubsub_port)) = validator_config.rpc_config.rpc_ports {
+        if let Some((rpc_port, rpc_pubsub_port)) = validator_config.rpc_ports {
             node.info.rpc = SocketAddr::new(node.info.gossip.ip(), rpc_port);
             node.info.rpc_pubsub = SocketAddr::new(node.info.gossip.ip(), rpc_pubsub_port);
             tcp_ports = vec![rpc_port, rpc_pubsub_port];


### PR DESCRIPTION
Validators sometimes want to use RPC privately without publishing that RPC to the entire cluster.

Fixes #7942
