### PR TITLE
Testing stable-perf on colo nodes

### DIFF
--- a/ci/buildkite.yml
+++ b/ci/buildkite.yml
@@ -2,43 +2,10 @@
 #
 # Release tags use buildkite-release.yml instead
 steps:
-  - command: "ci/shellcheck.sh"
-    name: "shellcheck"
-    timeout_in_minutes: 5
-  - command: ". ci/rust-version.sh; ci/docker-run.sh $$rust_nightly_docker_image ci/test-checks.sh"
-    name: "checks"
-    timeout_in_minutes: 20
-  - wait
   - command: "ci/test-stable-perf.sh"
     name: "stable-perf"
     timeout_in_minutes: 40
     artifact_paths: "log-*.txt"
     agents:
-      - "queue=cuda"
-  - command: "ci/test-bench.sh"
-    name: "bench"
-    timeout_in_minutes: 30
-  - command: ". ci/rust-version.sh; ci/docker-run.sh $$rust_stable_docker_image ci/test-stable.sh"
-    name: "stable"
-    timeout_in_minutes: 60
-    artifact_paths: "log-*.txt"
-  - command: ". ci/rust-version.sh; ci/docker-run.sh $$rust_stable_docker_image ci/test-move.sh"
-    name: "move"
-    timeout_in_minutes: 20
-  - command: ". ci/rust-version.sh; ci/docker-run.sh $$rust_stable_docker_image ci/test-local-cluster.sh"
-    name: "local-cluster"
-    timeout_in_minutes: 30
-    artifact_paths: "log-*.txt"
-  - command: ". ci/rust-version.sh; ci/docker-run.sh $$rust_nightly_docker_image ci/test-coverage.sh"
-    name: "coverage"
-    timeout_in_minutes: 30
-  - wait
-  - trigger: "solana-secondary"
-    branches: "!pull/*"
-    async: true
-    build:
-      message: "${BUILDKITE_MESSAGE}"
-      commit: "${BUILDKITE_COMMIT}"
-      branch: "${BUILDKITE_BRANCH}"
-      env:
-        TRIGGERED_BUILDKITE_TAG: "${BUILDKITE_TAG}"
+      - "queue=colo-cuda"
+

--- a/ci/test-stable.sh
+++ b/ci/test-stable.sh
@@ -45,23 +45,23 @@ test-stable)
   _ cargo +"$rust_stable" test --manifest-path bench-tps/Cargo.toml --features=move ${V:+--verbose} test_bench_tps_local_cluster_move -- --nocapture
   ;;
 test-stable-perf)
-  ci/affects-files.sh \
-    .rs$ \
-    Cargo.lock$ \
-    Cargo.toml$ \
-    ^ci/rust-version.sh \
-    ^ci/test-stable-perf.sh \
-    ^ci/test-stable.sh \
-    ^ci/test-local-cluster.sh \
-    ^core/build.rs \
-    ^fetch-perf-libs.sh \
-    ^programs/ \
-    ^sdk/ \
-  || {
-    annotate --style info \
-      "Skipped $testName as no relevant files were modified"
-    exit 0
-  }
+#  ci/affects-files.sh \
+#    .rs$ \
+#    Cargo.lock$ \
+#    Cargo.toml$ \
+#    ^ci/rust-version.sh \
+#    ^ci/test-stable-perf.sh \
+#    ^ci/test-stable.sh \
+#    ^ci/test-local-cluster.sh \
+#    ^core/build.rs \
+#    ^fetch-perf-libs.sh \
+#    ^programs/ \
+#    ^sdk/ \
+#  || {
+#    annotate --style info \
+#      "Skipped $testName as no relevant files were modified"
+#    exit 0
+#  }
 
   # BPF program tests
   _ make -C programs/bpf/c tests


### PR DESCRIPTION
Triggering a buildkite job on a GPU colo node to test its suitability for replacing the Azure GPU CI nodes.