### PR TITLE
Book: Prod the user to verify their new paper wallet

### DIFF
--- a/book/src/paper-wallet/usage.md
+++ b/book/src/paper-wallet/usage.md
@@ -30,6 +30,10 @@ command will generate a random seed phrase, ask you to enter an optional
 passphrase, and then will display the derived public key and the generated seed
 phrase for your paper wallet.
 
+After copying down your seed phrase, you can use the
+[public key derivation](#public-key-derivation) instructions to verify that you
+have not made any errors.
+
 ```bash
 solana-keygen new --no-outfile
 ```


### PR DESCRIPTION
#### Problem

The book paper wallet usage guide does not suggest that the user verify their new paper wallet.

#### Summary of Changes

Prod the user to read and use the pubkey derivation section

Fixes #8046
