### PR TITLE
CLI: Harden offline signing and tests

### DIFF
--- a/cli/tests/stake.rs
+++ b/cli/tests/stake.rs
@@ -300,7 +300,7 @@ fn test_offline_stake_delegation_and_deactivation() {
     config_validator.command = CliCommand::CreateStakeAccount {
         stake_account: read_keypair_file(&stake_keypair_file).unwrap().into(),
         seed: None,
-        staker: None,
+        staker: Some(config_offline.keypair.pubkey().into()),
         withdrawer: None,
         lockup: Lockup::default(),
         lamports: 50_000,
@@ -326,14 +326,14 @@ fn test_offline_stake_delegation_and_deactivation() {
     config_payer.command = CliCommand::DelegateStake {
         stake_account_pubkey: config_stake.keypair.pubkey(),
         vote_account_pubkey: config_vote.keypair.pubkey(),
-        stake_authority: None,
+        stake_authority: Some(config_offline.keypair.pubkey().into()),
         force: true,
         sign_only: false,
         signers: Some(signers),
         blockhash_query: BlockhashQuery::None(blockhash, FeeCalculator::default()),
         nonce_account: None,
         nonce_authority: None,
-        fee_payer: None,
+        fee_payer: Some(config_offline.keypair.pubkey().into()),
     };
     process_command(&config_payer).unwrap();
 
@@ -353,13 +353,13 @@ fn test_offline_stake_delegation_and_deactivation() {
     let (blockhash, signers) = parse_sign_only_reply_string(&sig_response);
     config_payer.command = CliCommand::DeactivateStake {
         stake_account_pubkey: config_stake.keypair.pubkey(),
-        stake_authority: None,
+        stake_authority: Some(config_offline.keypair.pubkey().into()),
         sign_only: false,
         signers: Some(signers),
         blockhash_query: BlockhashQuery::FeeCalculator(blockhash),
         nonce_account: None,
         nonce_authority: None,
-        fee_payer: None,
+        fee_payer: Some(config_offline.keypair.pubkey().into()),
     };
     process_command(&config_payer).unwrap();
 
@@ -599,7 +599,7 @@ fn test_stake_authorize() {
         blockhash_query: BlockhashQuery::FeeCalculator(blockhash),
         nonce_account: None,
         nonce_authority: None,
-        fee_payer: None,
+        fee_payer: Some(offline_authority_pubkey.into()),
     };
     process_command(&config).unwrap();
     let stake_account = rpc_client.get_account(&stake_account_pubkey).unwrap();
@@ -620,7 +620,7 @@ fn test_stake_authorize() {
     config.command = CliCommand::CreateNonceAccount {
         nonce_account: read_keypair_file(&nonce_keypair_file).unwrap().into(),
         seed: None,
-        nonce_authority: Some(config.keypair.pubkey()),
+        nonce_authority: Some(config_offline.keypair.pubkey()),
         lamports: minimum_nonce_balance,
     };
     process_command(&config).unwrap();
@@ -662,8 +662,8 @@ fn test_stake_authorize() {
         signers: Some(signers),
         blockhash_query: BlockhashQuery::FeeCalculator(blockhash),
         nonce_account: Some(nonce_account.pubkey()),
-        nonce_authority: None,
-        fee_payer: None,
+        nonce_authority: Some(offline_authority_pubkey.into()),
+        fee_payer: Some(offline_authority_pubkey.into()),
     };
     process_command(&config).unwrap();
     let stake_account = rpc_client.get_account(&stake_account_pubkey).unwrap();

--- a/cli/tests/stake.rs
+++ b/cli/tests/stake.rs
@@ -17,7 +17,9 @@ use std::fs::remove_dir_all;
 use std::sync::mpsc::channel;
 
 #[cfg(test)]
-use solana_core::validator::{new_validator_for_tests, new_validator_for_tests_ex, new_validator_for_tests_with_vote_pubkey};
+use solana_core::validator::{
+    new_validator_for_tests, new_validator_for_tests_ex, new_validator_for_tests_with_vote_pubkey,
+};
 use std::thread::sleep;
 use std::time::Duration;
 
@@ -122,7 +124,8 @@ fn test_stake_delegation_force() {
 fn test_seed_stake_delegation_and_deactivation() {
     solana_logger::setup();
 
-    let (server, leader_data, alice, ledger_path, vote_pubkey) = new_validator_for_tests_with_vote_pubkey();
+    let (server, leader_data, alice, ledger_path, vote_pubkey) =
+        new_validator_for_tests_with_vote_pubkey();
     let (sender, receiver) = channel();
     run_local_faucet(alice, sender, None);
     let faucet_addr = receiver.recv().unwrap();
@@ -204,7 +207,8 @@ fn test_seed_stake_delegation_and_deactivation() {
 fn test_stake_delegation_and_deactivation() {
     solana_logger::setup();
 
-    let (server, leader_data, alice, ledger_path, vote_pubkey) = new_validator_for_tests_with_vote_pubkey();
+    let (server, leader_data, alice, ledger_path, vote_pubkey) =
+        new_validator_for_tests_with_vote_pubkey();
     let (sender, receiver) = channel();
     run_local_faucet(alice, sender, None);
     let faucet_addr = receiver.recv().unwrap();
@@ -277,7 +281,8 @@ fn test_stake_delegation_and_deactivation() {
 fn test_offline_stake_delegation_and_deactivation() {
     solana_logger::setup();
 
-    let (server, leader_data, alice, ledger_path, vote_pubkey) = new_validator_for_tests_with_vote_pubkey();
+    let (server, leader_data, alice, ledger_path, vote_pubkey) =
+        new_validator_for_tests_with_vote_pubkey();
     let (sender, receiver) = channel();
     run_local_faucet(alice, sender, None);
     let faucet_addr = receiver.recv().unwrap();
@@ -397,7 +402,8 @@ fn test_offline_stake_delegation_and_deactivation() {
 fn test_nonced_stake_delegation_and_deactivation() {
     solana_logger::setup();
 
-    let (server, leader_data, alice, ledger_path, vote_pubkey) = new_validator_for_tests_with_vote_pubkey();
+    let (server, leader_data, alice, ledger_path, vote_pubkey) =
+        new_validator_for_tests_with_vote_pubkey();
     let (sender, receiver) = channel();
     run_local_faucet(alice, sender, None);
     let faucet_addr = receiver.recv().unwrap();
@@ -512,8 +518,13 @@ fn test_stake_authorize() {
     // Verfiy that we cannot reach the cluster
     process_command(&config_offline).unwrap_err();
 
-    request_and_confirm_airdrop(&rpc_client, &faucet_addr, &config_offline.keypair.pubkey(), 100_000)
-        .unwrap();
+    request_and_confirm_airdrop(
+        &rpc_client,
+        &faucet_addr,
+        &config_offline.keypair.pubkey(),
+        100_000,
+    )
+    .unwrap();
 
     // Create stake account, identity is authority
     let stake_keypair = Keypair::new();
@@ -702,7 +713,8 @@ fn test_stake_authorize_with_fee_payer() {
     solana_logger::setup();
     const SIG_FEE: u64 = 42;
 
-    let (server, leader_data, alice, ledger_path, _voter) = new_validator_for_tests_ex(SIG_FEE, 42_000);
+    let (server, leader_data, alice, ledger_path, _voter) =
+        new_validator_for_tests_ex(SIG_FEE, 42_000);
     let (sender, receiver) = channel();
     run_local_faucet(alice, sender, None);
     let faucet_addr = receiver.recv().unwrap();

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -586,7 +586,8 @@ pub fn new_validator_for_tests() -> (Validator, ContactInfo, Keypair, PathBuf) {
     (node, contact_info, mint_keypair, ledger_path)
 }
 
-pub fn new_validator_for_tests_with_vote_pubkey() -> (Validator, ContactInfo, Keypair, PathBuf, Pubkey) {
+pub fn new_validator_for_tests_with_vote_pubkey(
+) -> (Validator, ContactInfo, Keypair, PathBuf, Pubkey) {
     use crate::genesis_utils::BOOTSTRAP_VALIDATOR_LAMPORTS;
     new_validator_for_tests_ex(0, BOOTSTRAP_VALIDATOR_LAMPORTS)
 }

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -581,6 +581,12 @@ fn wait_for_supermajority(
 }
 
 pub fn new_validator_for_tests() -> (Validator, ContactInfo, Keypair, PathBuf) {
+    let (node, contact_info, mint_keypair, ledger_path, _vote_pubkey) =
+        new_validator_for_tests_with_vote_pubkey();
+    (node, contact_info, mint_keypair, ledger_path)
+}
+
+pub fn new_validator_for_tests_with_vote_pubkey() -> (Validator, ContactInfo, Keypair, PathBuf, Pubkey) {
     use crate::genesis_utils::BOOTSTRAP_VALIDATOR_LAMPORTS;
     new_validator_for_tests_ex(0, BOOTSTRAP_VALIDATOR_LAMPORTS)
 }
@@ -588,7 +594,7 @@ pub fn new_validator_for_tests() -> (Validator, ContactInfo, Keypair, PathBuf) {
 pub fn new_validator_for_tests_ex(
     fees: u64,
     bootstrap_validator_lamports: u64,
-) -> (Validator, ContactInfo, Keypair, PathBuf) {
+) -> (Validator, ContactInfo, Keypair, PathBuf, Pubkey) {
     use crate::genesis_utils::{create_genesis_config_with_leader_ex, GenesisConfigInfo};
     use solana_sdk::fee_calculator::FeeCalculator;
 
@@ -635,7 +641,13 @@ pub fn new_validator_for_tests_ex(
         &config,
     );
     discover_cluster(&contact_info.gossip, 1).expect("Node startup failed");
-    (node, contact_info, mint_keypair, ledger_path)
+    (
+        node,
+        contact_info,
+        mint_keypair,
+        ledger_path,
+        leader_voting_keypair.pubkey(),
+    )
 }
 
 fn report_target_features() {


### PR DESCRIPTION
#### Problem

Various holes exists in CLI tests for offline signing allowing operations intended to be offline to perform cluster queries

#### Summary of Changes

Create a separate `CliConfig` for offline operations, verify that it is offline and use it
Fix everything that breaks as a result

Requires #8009