### PR TITLE
Fix getting stale validator ContactInfo after restart in LocalCluster

### DIFF
--- a/local-cluster/src/cluster.rs
+++ b/local-cluster/src/cluster.rs
@@ -38,6 +38,7 @@ impl ClusterValidatorInfo {
 pub trait Cluster {
     fn get_node_pubkeys(&self) -> Vec<Pubkey>;
     fn get_validator_client(&self, pubkey: &Pubkey) -> Option<ThinClient>;
+    fn get_contact_info(&self, pubkey: &Pubkey) -> Option<&ContactInfo>;
     fn exit_node(&mut self, pubkey: &Pubkey) -> ClusterValidatorInfo;
     fn restart_node(&mut self, pubkey: &Pubkey, cluster_validator_info: ClusterValidatorInfo);
     fn exit_restart_node(&mut self, pubkey: &Pubkey, config: ValidatorConfig);

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -695,6 +695,10 @@ impl Cluster for LocalCluster {
         cluster_validator_info.config = validator_config;
         self.restart_node(pubkey, cluster_validator_info);
     }
+
+    fn get_contact_info(&self, pubkey: &Pubkey) -> Option<&ContactInfo> {
+        self.validators.get(pubkey).map(|v| &v.info.contact_info)
+    }
 }
 
 impl Drop for LocalCluster {

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -662,8 +662,11 @@ fn test_snapshot_restart_tower() {
     cluster.restart_node(&validator_id, validator_info);
 
     // Test cluster can still make progress and get confirmations in tower
+    // Use the restarted node as the discovery point so that we get updated
+    // validator's ContactInfo
+    let restarted_node_info = cluster.get_contact_info(&validator_id).unwrap();
     cluster_tests::spend_and_verify_all_nodes(
-        &cluster.entry_point_info,
+        &restarted_node_info,
         &cluster.funding_keypair,
         1,
         HashSet::new(),


### PR DESCRIPTION
#### Problem
`test_snapshot_restart_tower` has two validators `A` and `B`. After restarting validator `B`, there's a race where the spy node in the test may get stale validator `ContactInfo` for `B` from validator `A`, causing RPC failures

#### Summary of Changes
Use the restarted node as the entrypoint to the cluster `discover` functionality so that it gets up-to-date ContactInfo's.
Fixes #
