### PR TITLE
Don't exit early if add. validators not found during gce.sh config

### DIFF
--- a/net/gce.sh
+++ b/net/gce.sh
@@ -868,6 +868,7 @@ EOF
   ;;
 
 config)
+  failOnValidatorBootupFailure=false
   prepareInstancesAndWriteConfigFile
   ;;
 info)


### PR DESCRIPTION
#### Problem
Default behaviour of `./gce.sh` commands exits early if no additional validator nodes (besides bootstrap node) are detected. This behaviour doesn't make sense for the `./gce.sh config -p ...` command. It should just find everything it can without exiting early.

Came across this issue because the stable testnet doesn't have any additional validators now.

#### Summary of Changes
Don't exit early

Fixes #
