### PR TITLE
Filter repairman peers based on shred_version

### DIFF
--- a/core/src/cluster_info_repair_listener.rs
+++ b/core/src/cluster_info_repair_listener.rs
@@ -135,7 +135,7 @@ impl ClusterInfoRepairListener {
             }
 
             let lowest_slot = blockstore.lowest_slot();
-            let peers = cluster_info.read().unwrap().gossip_peers();
+            let peers = cluster_info.read().unwrap().tvu_peers();
             let mut peers_needing_repairs: HashMap<Pubkey, EpochSlots> = HashMap::new();
 
             // Iterate through all the known nodes in the network, looking for ones that


### PR DESCRIPTION
#### Problem

Repairman looks through all gossip peers for potential repairees. This is not correct as gossip might span across forks.

A Repairer should only look for repairees on the same fork.

#### Summary of Changes

Updated the gossip crds lookup to use a function that filters peers based on shred_version and on then being validators(having a valid tvu). 