### PR TITLE
Use solana-cli config keypair in solana-keygen

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3658,7 +3658,6 @@ dependencies = [
  "dirs 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "humantime 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "indicatif 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty-hex 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3666,9 +3665,9 @@ dependencies = [
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_yaml 0.8.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-budget-program 0.24.0",
  "solana-clap-utils 0.24.0",
+ "solana-cli-config 0.24.0",
  "solana-client 0.24.0",
  "solana-config-program 0.24.0",
  "solana-core 0.24.0",
@@ -3683,6 +3682,17 @@ dependencies = [
  "solana-vote-signer 0.24.0",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "solana-cli-config"
+version = "0.24.0"
+dependencies = [
+ "dirs 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_yaml 0.8.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3948,7 +3958,7 @@ dependencies = [
  "num_cpus 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rpassword 4.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-clap-utils 0.24.0",
- "solana-cli 0.24.0",
+ "solana-cli-config 0.24.0",
  "solana-sdk 0.24.0",
  "tiny-bip39 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3948,6 +3948,7 @@ dependencies = [
  "num_cpus 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rpassword 4.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-clap-utils 0.24.0",
+ "solana-cli 0.24.0",
  "solana-sdk 0.24.0",
  "tiny-bip39 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "chacha",
     "chacha-cuda",
     "chacha-sys",
+    "cli-config",
     "client",
     "core",
     "faucet",

--- a/cli-config/Cargo.toml
+++ b/cli-config/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+authors = ["Solana Maintainers <maintainers@solana.com>"]
+edition = "2018"
+name = "solana-cli-config"
+description = "Blockchain, Rebuilt for Scale"
+version = "0.24.0"
+repository = "https://github.com/solana-labs/solana"
+license = "Apache-2.0"
+homepage = "https://solana.com/"
+
+[dependencies]
+dirs = "2.0.2"
+lazy_static = "1.4.0"
+serde = "1.0.104"
+serde_derive = "1.0.103"
+serde_yaml = "0.8.11"

--- a/cli-config/src/config.rs
+++ b/cli-config/src/config.rs
@@ -1,8 +1,10 @@
 // Wallet settings that can be configured for long-term use
 use serde_derive::{Deserialize, Serialize};
-use std::fs::{create_dir_all, File};
-use std::io::{self, Write};
-use std::path::Path;
+use std::{
+    fs::{create_dir_all, File},
+    io::{self, Write},
+    path::Path,
+};
 
 lazy_static! {
     pub static ref CONFIG_FILE: Option<String> = {

--- a/cli-config/src/lib.rs
+++ b/cli-config/src/lib.rs
@@ -1,0 +1,4 @@
+#[macro_use]
+extern crate lazy_static;
+
+pub mod config;

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -17,7 +17,6 @@ criterion-stats = "0.3.0"
 ctrlc = { version = "3.1.3", features = ["termination"] }
 console = "0.9.2"
 dirs = "2.0.2"
-lazy_static = "1.4.0"
 log = "0.4.8"
 indicatif = "0.14.0"
 humantime = "2.0.0"
@@ -27,9 +26,9 @@ reqwest = { version = "0.10.1", default-features = false, features = ["blocking"
 serde = "1.0.104"
 serde_derive = "1.0.103"
 serde_json = "1.0.44"
-serde_yaml = "0.8.11"
 solana-budget-program = { path = "../programs/budget", version = "0.24.0" }
 solana-clap-utils = { path = "../clap-utils", version = "0.24.0" }
+solana-cli-config = { path = "../cli-config", version = "0.24.0" }
 solana-client = { path = "../client", version = "0.24.0" }
 solana-config-program = { path = "../programs/config", version = "0.24.0" }
 solana-faucet = { path = "../faucet", version = "0.24.0" }

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1,9 +1,5 @@
-#[macro_use]
-extern crate lazy_static;
-
 pub mod cli;
 pub mod cluster_query;
-pub mod config;
 pub mod display;
 pub mod nonce;
 pub mod offline;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -10,9 +10,9 @@ use solana_clap_utils::{
 };
 use solana_cli::{
     cli::{app, parse_command, process_command, CliCommandInfo, CliConfig, CliError},
-    config::{self, Config},
     display::{println_name_value, println_name_value_or},
 };
+use solana_cli_config::config::{Config, CONFIG_FILE};
 use solana_sdk::signature::read_keypair_file;
 
 use std::error;
@@ -162,7 +162,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
             .takes_value(true)
             .global(true)
             .help("Configuration file to use");
-        if let Some(ref config_file) = *config::CONFIG_FILE {
+        if let Some(ref config_file) = *CONFIG_FILE {
             arg.default_value(&config_file)
         } else {
             arg

--- a/keygen/Cargo.toml
+++ b/keygen/Cargo.toml
@@ -15,7 +15,7 @@ dirs = "2.0.2"
 num_cpus = "1.12.0"
 rpassword = "4.0"
 solana-clap-utils = { path = "../clap-utils", version = "0.24.0" }
-solana-cli = { path = "../cli", version = "0.24.0" }
+solana-cli-config = { path = "../cli-config", version = "0.24.0" }
 solana-sdk = { path = "../sdk", version = "0.24.0" }
 tiny-bip39 = "0.7.0"
 

--- a/keygen/Cargo.toml
+++ b/keygen/Cargo.toml
@@ -15,6 +15,7 @@ dirs = "2.0.2"
 num_cpus = "1.12.0"
 rpassword = "4.0"
 solana-clap-utils = { path = "../clap-utils", version = "0.24.0" }
+solana-cli = { path = "../cli", version = "0.24.0" }
 solana-sdk = { path = "../sdk", version = "0.24.0" }
 tiny-bip39 = "0.7.0"
 

--- a/keygen/src/keygen.rs
+++ b/keygen/src/keygen.rs
@@ -50,8 +50,8 @@ fn get_keypair_from_matches(
     config: Config,
 ) -> Result<Keypair, Box<dyn error::Error>> {
     let mut path = dirs::home_dir().expect("home directory");
-    let infile = if matches.is_present("infile") {
-        matches.value_of("infile").unwrap()
+    let keypair = if matches.is_present("keypair") {
+        matches.value_of("keypair").unwrap()
     } else if config.keypair_path != "" {
         &config.keypair_path
     } else {
@@ -59,14 +59,14 @@ fn get_keypair_from_matches(
         path.to_str().unwrap()
     };
 
-    if infile == "-" {
+    if keypair == "-" {
         let mut stdin = std::io::stdin();
         read_keypair(&mut stdin)
-    } else if infile == ASK_KEYWORD {
+    } else if keypair == ASK_KEYWORD {
         let skip_validation = matches.is_present(SKIP_SEED_PHRASE_VALIDATION_ARG.name);
         keypair_from_seed_phrase("pubkey recovery", skip_validation, false)
     } else {
-        read_keypair_file(infile)
+        read_keypair_file(keypair)
     }
 }
 
@@ -225,7 +225,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                         .help("Public key"),
                 )
                 .arg(
-                    Arg::with_name("infile")
+                    Arg::with_name("keypair")
                         .index(2)
                         .value_name("PATH")
                         .takes_value(true)
@@ -322,7 +322,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                 .about("Display the pubkey from a keypair file")
                 .setting(AppSettings::DisableVersion)
                 .arg(
-                    Arg::with_name("infile")
+                    Arg::with_name("keypair")
                         .index(1)
                         .value_name("PATH")
                         .takes_value(true)

--- a/keygen/src/keygen.rs
+++ b/keygen/src/keygen.rs
@@ -8,7 +8,7 @@ use num_cpus;
 use solana_clap_utils::keypair::{
     keypair_from_seed_phrase, prompt_passphrase, ASK_KEYWORD, SKIP_SEED_PHRASE_VALIDATION_ARG,
 };
-use solana_cli::config::{Config, CONFIG_FILE};
+use solana_cli_config::config::{Config, CONFIG_FILE};
 use solana_sdk::{
     pubkey::write_pubkey_file,
     signature::{

--- a/keygen/src/keygen.rs
+++ b/keygen/src/keygen.rs
@@ -8,6 +8,7 @@ use num_cpus;
 use solana_clap_utils::keypair::{
     keypair_from_seed_phrase, prompt_passphrase, ASK_KEYWORD, SKIP_SEED_PHRASE_VALIDATION_ARG,
 };
+use solana_cli::config::{Config, CONFIG_FILE};
 use solana_sdk::{
     pubkey::write_pubkey_file,
     signature::{
@@ -44,10 +45,15 @@ fn check_for_overwrite(outfile: &str, matches: &ArgMatches) {
     }
 }
 
-fn get_keypair_from_matches(matches: &ArgMatches) -> Result<Keypair, Box<dyn error::Error>> {
+fn get_keypair_from_matches(
+    matches: &ArgMatches,
+    config: Config,
+) -> Result<Keypair, Box<dyn error::Error>> {
     let mut path = dirs::home_dir().expect("home directory");
     let infile = if matches.is_present("infile") {
         matches.value_of("infile").unwrap()
+    } else if config.keypair_path != "" {
+        &config.keypair_path
     } else {
         path.extend(&[".config", "solana", "id.json"]);
         path.to_str().unwrap()
@@ -193,22 +199,37 @@ fn main() -> Result<(), Box<dyn error::Error>> {
         .about(crate_description!())
         .version(solana_clap_utils::version!())
         .setting(AppSettings::SubcommandRequiredElseHelp)
+        .arg({
+            let arg = Arg::with_name("config_file")
+                .short("C")
+                .long("config")
+                .value_name("PATH")
+                .takes_value(true)
+                .global(true)
+                .help("Configuration file to use");
+            if let Some(ref config_file) = *CONFIG_FILE {
+                arg.default_value(&config_file)
+            } else {
+                arg
+            }
+        })
         .subcommand(
             SubCommand::with_name("verify")
                 .about("Verify a keypair can sign and verify a message.")
                 .arg(
-                    Arg::with_name("infile")
+                    Arg::with_name("pubkey")
                         .index(1)
+                        .value_name("BASE58_PUBKEY")
+                        .takes_value(true)
+                        .required(true)
+                        .help("Public key"),
+                )
+                .arg(
+                    Arg::with_name("infile")
+                        .index(2)
                         .value_name("PATH")
                         .takes_value(true)
                         .help("Path to keypair file"),
-                )
-                .arg(
-                    Arg::with_name("pubkey")
-                        .index(2)
-                        .value_name("BASE58_PUBKEY")
-                        .takes_value(true)
-                        .help("Public key"),
                 )
         )
         .subcommand(
@@ -353,10 +374,15 @@ fn main() -> Result<(), Box<dyn error::Error>> {
 
         )
         .get_matches();
+    let config = if let Some(config_file) = matches.value_of("config_file") {
+        Config::load(config_file).unwrap_or_default()
+    } else {
+        Config::default()
+    };
 
     match matches.subcommand() {
         ("pubkey", Some(matches)) => {
-            let keypair = get_keypair_from_matches(matches)?;
+            let keypair = get_keypair_from_matches(matches, config)?;
 
             if matches.is_present("outfile") {
                 let outfile = matches.value_of("outfile").unwrap();
@@ -533,7 +559,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
             }
         }
         ("verify", Some(matches)) => {
-            let keypair = get_keypair_from_matches(matches)?;
+            let keypair = get_keypair_from_matches(matches, config)?;
             let test_data = b"test";
             let signature = Signature::new(&keypair.sign(test_data).to_bytes());
             let pubkey_bs58 = matches.value_of("pubkey").unwrap();


### PR DESCRIPTION
#### Problem
It would be handy to use the keypair override from `solana get` in solana-keygen, especially as we move toward supporting hardware wallets in these tools. Desired flow something like:

```
$ solana set --keypair <keypair_filepath_or_path_to_hardware_wallet>
$ solana-keygen pubkey
E13eqyhs8uJvXtKfmTkt82tiEk1hbz3R2E7GgbMtEYBH
```

#### Summary of Changes
- ~~Import solana-cli::config into solana-keygen~~ Move solana-cli::config into its own crate for more general use
- Add `--config` arg to solana-keygen to specify config file location (default: ~/.config/solana/cli/config.yml)
- If keypair_path is set in existing config, use that keypair for `solana-keygen pubkey` and `solana-keygen verify`. (Swapped arg order in `verify` to make this work)
- Also, I made the `verify --pubkey` arg required, as it was tacitly so, and would panic if not provided.

(Addition)
I think that keypair arg handling, like `get_keypair_from_matches()` should probably be moved somewhere general: either into the new solana-cli-config crate or solana-clap-utils::keypair. I will do that in a separate PR as part of implementation in cli and/or solana-validator.
