### PR TITLE
Reduce rpc client pre-flight requests by setting max-age header

### DIFF
--- a/core/src/rpc_service.rs
+++ b/core/src/rpc_service.rs
@@ -131,6 +131,7 @@ impl JsonRpcService {
                         .cors(DomainsValidation::AllowOnly(vec![
                             AccessControlAllowOrigin::Any,
                         ]))
+                        .cors_max_age(86400)
                         .request_middleware(RpcRequestMiddleware::new(ledger_path))
                         .start_http(&rpc_addr);
                 if let Err(e) = server {


### PR DESCRIPTION
#### Problem
Noticed in the "Break Solana" dapp that the browser was sending many pre-flight options requests. Turns out our RPC http server is not setting the `Access-Control-Max-Age` header

#### Summary of Changes
Set max duration (24hr) for cors max age

(verified this works)

Fixes #
