### PR TITLE
Broaden pattern in nits.sh to be less fragile

### DIFF
--- a/ci/nits.sh
+++ b/ci/nits.sh
@@ -26,12 +26,11 @@ declare print_free_tree=(
   ':runtime/src/**.rs'
   ':sdk/bpf/rust/rust-utils/**.rs'
   ':sdk/**.rs'
-  ':programs/bpf/rust/**.rs'
-  ':programs/stake/src/**.rs'
-  ':programs/vote/src/**.rs'
+  ':programs/**.rs'
   ':^**bin**.rs'
   ':^**bench**.rs'
   ':^**test**.rs'
+  ':^**/build.rs'
 )
 
 if _ git --no-pager grep -n "${prints[@]/#/-e}" -- "${print_free_tree[@]}"; then

--- a/ci/nits.sh
+++ b/ci/nits.sh
@@ -18,20 +18,23 @@ declare prints=(
 
 # Parts of the tree that are expected to be print free
 declare print_free_tree=(
-  'core/src'
-  'faucet/src'
-  'ledger/src'
-  'metrics/src'
-  'net-utils/src'
-  'runtime/src'
-  'sdk/bpf/rust/rust-utils'
-  'sdk/src'
-  'programs/bpf/rust'
-  'programs/stake/src'
-  'programs/vote/src'
+  ':core/src/**.rs'
+  ':faucet/src/**.rs'
+  ':ledger/src/**.rs'
+  ':metrics/src/**.rs'
+  ':net-utils/src/**.rs'
+  ':runtime/src/**.rs'
+  ':sdk/bpf/rust/rust-utils/**.rs'
+  ':sdk/**.rs'
+  ':programs/bpf/rust/**.rs'
+  ':programs/stake/src/**.rs'
+  ':programs/vote/src/**.rs'
+  ':^**bin**.rs'
+  ':^**bench**.rs'
+  ':^**test**.rs'
 )
 
-if _ git --no-pager grep -n --max-depth=0 "${prints[@]/#/-e }" -- "${print_free_tree[@]}"; then
+if _ git --no-pager grep -n "${prints[@]/#/-e}" -- "${print_free_tree[@]}"; then
     exit 1
 fi
 


### PR DESCRIPTION
#### problem

Some files are escaping from the `nits.sh` check.

#### solution

Those files should be checked!

#### result

Before:
```
ryoqun@ubuqun:~/work/solana/solana/for-small-patches$ git --no-pager grep -n --max-depth=0 --files-with-matches  ^ -- core/src faucet/src ledger/src metrics/src net-utils/src runtime/src sdk/bpf/rust/rust-utils sdk/src programs/bpf/rust programs/stake/src programs/vote/src | wc -l
154
```

After:
```
ryoqun@ubuqun:~/work/solana/solana/for-small-patches$ git --no-pager grep -n --files-with-matches  ^ -- :core/src/**.rs :faucet/src/**.rs :ledger/src/**.rs :metrics/src/**.rs :net-utils/src/**.rs :runtime/src/**.rs :sdk/bpf/rust/rust-utils/**.rs :sdk/**.rs :programs/**.rs :^**bin**.rs :^**bench**.rs :^**test**.rs :^**/build.rs | wc -l
231
```

#### background

from https://github.com/solana-labs/solana/pull/8012/files#r373918404