### PR TITLE
cli: Delete uptime command, report total credits in `solana validators` instead

### DIFF
--- a/book/src/cli/usage.md
+++ b/book/src/cli/usage.md
@@ -241,7 +241,6 @@ SUBCOMMANDS:
     stakes                              Show stake account information
     storage-account                     Show the contents of a storage account
     transaction-count                   Get current transaction count
-    uptime                              Show the uptime of a validator, based on epoch voting history
     validator-info                      Publish/get Validator info on Solana
     validators                          Show summary information about the current validators
     vote-account                        Show the contents of a vote account
@@ -254,7 +253,7 @@ SUBCOMMANDS:
 
 #### solana-account
 ```text
-solana-account 
+solana-account
 Show the contents of an account
 
 USAGE:
@@ -283,7 +282,7 @@ ARGS:
 
 #### solana-address
 ```text
-solana-address 
+solana-address
 Get your public key
 
 USAGE:
@@ -307,7 +306,7 @@ OPTIONS:
 
 #### solana-airdrop
 ```text
-solana-airdrop 
+solana-airdrop
 Request lamports
 
 USAGE:
@@ -337,7 +336,7 @@ ARGS:
 
 #### solana-authorize-nonce-account
 ```text
-solana-authorize-nonce-account 
+solana-authorize-nonce-account
 Assign account authority to a new entity
 
 USAGE:
@@ -373,7 +372,7 @@ ARGS:
 
 #### solana-balance
 ```text
-solana-balance 
+solana-balance
 Get your balance
 
 USAGE:
@@ -401,7 +400,7 @@ ARGS:
 
 #### solana-block-production
 ```text
-solana-block-production 
+solana-block-production
 Show information about block production
 
 USAGE:
@@ -428,7 +427,7 @@ OPTIONS:
 
 #### solana-block-time
 ```text
-solana-block-time 
+solana-block-time
 Get estimated production time of a block
 
 USAGE:
@@ -455,7 +454,7 @@ ARGS:
 
 #### solana-cancel
 ```text
-solana-cancel 
+solana-cancel
 Cancel a transfer
 
 USAGE:
@@ -482,7 +481,7 @@ ARGS:
 
 #### solana-catchup
 ```text
-solana-catchup 
+solana-catchup
 Wait for a validator to catch up to the cluster
 
 USAGE:
@@ -509,7 +508,7 @@ ARGS:
 
 #### solana-claim-storage-reward
 ```text
-solana-claim-storage-reward 
+solana-claim-storage-reward
 Redeem storage reward credits
 
 USAGE:
@@ -537,7 +536,7 @@ ARGS:
 
 #### solana-cluster-version
 ```text
-solana-cluster-version 
+solana-cluster-version
 Get the version of the cluster entrypoint
 
 USAGE:
@@ -561,7 +560,7 @@ OPTIONS:
 
 #### solana-config
 ```text
-solana-config 
+solana-config
 Solana command-line tool configuration settings
 
 USAGE:
@@ -590,7 +589,7 @@ SUBCOMMANDS:
 
 #### solana-confirm
 ```text
-solana-confirm 
+solana-confirm
 Confirm transaction by signature
 
 USAGE:
@@ -617,7 +616,7 @@ ARGS:
 
 #### solana-create-address-with-seed
 ```text
-solana-create-address-with-seed 
+solana-create-address-with-seed
 Generate a derived account address with a seed
 
 USAGE:
@@ -641,13 +640,13 @@ OPTIONS:
 
 ARGS:
     <SEED_STRING>    The seed.  Must not take more than 32 bytes to encode as utf-8
-    <PROGRAM_ID>     The program_id that the address will ultimately be used for, 
+    <PROGRAM_ID>     The program_id that the address will ultimately be used for,
                      or one of STAKE, VOTE, and STORAGE keywords
 ```
 
 #### solana-create-archiver-storage-account
 ```text
-solana-create-archiver-storage-account 
+solana-create-archiver-storage-account
 Create an archiver storage account
 
 USAGE:
@@ -669,13 +668,13 @@ OPTIONS:
     -k, --keypair <PATH>                    /path/to/id.json
 
 ARGS:
-    <STORAGE ACCOUNT OWNER PUBKEY>    
-    <STORAGE ACCOUNT>                 
+    <STORAGE ACCOUNT OWNER PUBKEY>
+    <STORAGE ACCOUNT>
 ```
 
 #### solana-create-nonce-account
 ```text
-solana-create-nonce-account 
+solana-create-nonce-account
 Create a nonce account
 
 USAGE:
@@ -705,7 +704,7 @@ ARGS:
 
 #### solana-create-stake-account
 ```text
-solana-create-stake-account 
+solana-create-stake-account
 Create a stake account
 
 USAGE:
@@ -741,7 +740,7 @@ ARGS:
 
 #### solana-create-validator-storage-account
 ```text
-solana-create-validator-storage-account 
+solana-create-validator-storage-account
 Create a validator storage account
 
 USAGE:
@@ -763,13 +762,13 @@ OPTIONS:
     -k, --keypair <PATH>                    /path/to/id.json
 
 ARGS:
-    <STORAGE ACCOUNT OWNER PUBKEY>    
-    <STORAGE ACCOUNT>                 
+    <STORAGE ACCOUNT OWNER PUBKEY>
+    <STORAGE ACCOUNT>
 ```
 
 #### solana-create-vote-account
 ```text
-solana-create-vote-account 
+solana-create-vote-account
 Create a vote account
 
 USAGE:
@@ -802,7 +801,7 @@ ARGS:
 
 #### solana-deactivate-stake
 ```text
-solana-deactivate-stake 
+solana-deactivate-stake
 Deactivate the delegated stake from the stake account
 
 USAGE:
@@ -827,9 +826,9 @@ OPTIONS:
     -u, --url <URL>                              JSON RPC URL for the solana cluster
     -k, --keypair <PATH>                         /path/to/id.json
         --nonce <PUBKEY>
-            Provide the nonce account to use when creating a nonced 
-            transaction. Nonced transactions are useful when a transaction 
-            requires a lengthy signing process. Learn more about nonced 
+            Provide the nonce account to use when creating a nonced
+            transaction. Nonced transactions are useful when a transaction
+            requires a lengthy signing process. Learn more about nonced
             transactions at https://docs.solana.com/offline-signing/durable-nonce
         --nonce-authority <KEYPAIR or PUBKEY>
             Provide the nonce authority keypair to use when signing a nonced transaction
@@ -843,7 +842,7 @@ ARGS:
 
 #### solana-delegate-stake
 ```text
-solana-delegate-stake 
+solana-delegate-stake
 Delegate stake to a vote account
 
 USAGE:
@@ -868,9 +867,9 @@ OPTIONS:
     -u, --url <URL>                              JSON RPC URL for the solana cluster
     -k, --keypair <PATH>                         /path/to/id.json
         --nonce <PUBKEY>
-            Provide the nonce account to use when creating a nonced 
-            transaction. Nonced transactions are useful when a transaction 
-            requires a lengthy signing process. Learn more about nonced 
+            Provide the nonce account to use when creating a nonced
+            transaction. Nonced transactions are useful when a transaction
+            requires a lengthy signing process. Learn more about nonced
             transactions at https://docs.solana.com/offline-signing/durable-nonce
         --nonce-authority <KEYPAIR or PUBKEY>
             Provide the nonce authority keypair to use when signing a nonced transaction
@@ -885,7 +884,7 @@ ARGS:
 
 #### solana-deploy
 ```text
-solana-deploy 
+solana-deploy
 Deploy a program
 
 USAGE:
@@ -912,7 +911,7 @@ ARGS:
 
 #### solana-epoch-info
 ```text
-solana-epoch-info 
+solana-epoch-info
 Get information about the current epoch
 
 USAGE:
@@ -937,7 +936,7 @@ OPTIONS:
 
 #### solana-fees
 ```text
-solana-fees 
+solana-fees
 Display current cluster fees
 
 USAGE:
@@ -961,7 +960,7 @@ OPTIONS:
 
 #### solana-genesis-hash
 ```text
-solana-genesis-hash 
+solana-genesis-hash
 Get the genesis hash
 
 USAGE:
@@ -985,7 +984,7 @@ OPTIONS:
 
 #### solana-gossip
 ```text
-solana-gossip 
+solana-gossip
 Show the current gossip network nodes
 
 USAGE:
@@ -1009,7 +1008,7 @@ OPTIONS:
 
 #### solana-help
 ```text
-solana-help 
+solana-help
 Prints this message or the help of the given subcommand(s)
 
 USAGE:
@@ -1021,7 +1020,7 @@ ARGS:
 
 #### solana-new-nonce
 ```text
-solana-new-nonce 
+solana-new-nonce
 Generate a new nonce, rendering the existing nonce useless
 
 USAGE:
@@ -1053,7 +1052,7 @@ ARGS:
 
 #### solana-nonce
 ```text
-solana-nonce 
+solana-nonce
 Get the current nonce value
 
 USAGE:
@@ -1080,7 +1079,7 @@ ARGS:
 
 #### solana-nonce-account
 ```text
-solana-nonce-account 
+solana-nonce-account
 Show the contents of a nonce account
 
 USAGE:
@@ -1108,14 +1107,14 @@ ARGS:
 
 #### solana-pay
 ```text
-solana-pay 
+solana-pay
 Send a payment
 
 USAGE:
     solana pay [FLAGS] [OPTIONS] <TO PUBKEY> <AMOUNT> [--] [UNIT]
 
 FLAGS:
-        --cancelable                     
+        --cancelable
     -h, --help                           Prints help information
         --sign-only                      Sign the transaction offline
         --skip-seed-phrase-validation    Skip validation of seed phrases. Use this if your phrase does not use the BIP39
@@ -1134,9 +1133,9 @@ OPTIONS:
     -u, --url <URL>                              JSON RPC URL for the solana cluster
     -k, --keypair <PATH>                         /path/to/id.json
         --nonce <PUBKEY>
-            Provide the nonce account to use when creating a nonced 
-            transaction. Nonced transactions are useful when a transaction 
-            requires a lengthy signing process. Learn more about nonced 
+            Provide the nonce account to use when creating a nonced
+            transaction. Nonced transactions are useful when a transaction
+            requires a lengthy signing process. Learn more about nonced
             transactions at https://docs.solana.com/offline-signing/durable-nonce
         --nonce-authority <KEYPAIR or PUBKEY>
             Provide the nonce authority keypair to use when signing a nonced transaction
@@ -1154,7 +1153,7 @@ ARGS:
 
 #### solana-ping
 ```text
-solana-ping 
+solana-ping
 Submit transactions sequentially
 
 USAGE:
@@ -1183,7 +1182,7 @@ OPTIONS:
 
 #### solana-send-signature
 ```text
-solana-send-signature 
+solana-send-signature
 Send a signature to authorize a transfer
 
 USAGE:
@@ -1211,7 +1210,7 @@ ARGS:
 
 #### solana-send-timestamp
 ```text
-solana-send-timestamp 
+solana-send-timestamp
 Send a timestamp to unlock a transfer
 
 USAGE:
@@ -1240,7 +1239,7 @@ ARGS:
 
 #### solana-show-stake-account
 ```text
-solana-show-stake-account 
+solana-show-stake-account
 Show the contents of a stake account
 
 USAGE:
@@ -1268,7 +1267,7 @@ ARGS:
 
 #### solana-slot
 ```text
-solana-slot 
+solana-slot
 Get current slot
 
 USAGE:
@@ -1293,7 +1292,7 @@ OPTIONS:
 
 #### solana-stake-authorize-staker
 ```text
-solana-stake-authorize-staker 
+solana-stake-authorize-staker
 Authorize a new stake signing keypair for the given stake account
 
 USAGE:
@@ -1318,9 +1317,9 @@ OPTIONS:
     -u, --url <URL>                              JSON RPC URL for the solana cluster
     -k, --keypair <PATH>                         /path/to/id.json
         --nonce <PUBKEY>
-            Provide the nonce account to use when creating a nonced 
-            transaction. Nonced transactions are useful when a transaction 
-            requires a lengthy signing process. Learn more about nonced 
+            Provide the nonce account to use when creating a nonced
+            transaction. Nonced transactions are useful when a transaction
+            requires a lengthy signing process. Learn more about nonced
             transactions at https://docs.solana.com/offline-signing/durable-nonce
         --nonce-authority <KEYPAIR or PUBKEY>
             Provide the nonce authority keypair to use when signing a nonced transaction
@@ -1335,7 +1334,7 @@ ARGS:
 
 #### solana-stake-authorize-withdrawer
 ```text
-solana-stake-authorize-withdrawer 
+solana-stake-authorize-withdrawer
 Authorize a new withdraw signing keypair for the given stake account
 
 USAGE:
@@ -1360,9 +1359,9 @@ OPTIONS:
     -u, --url <URL>                                 JSON RPC URL for the solana cluster
     -k, --keypair <PATH>                            /path/to/id.json
         --nonce <PUBKEY>
-            Provide the nonce account to use when creating a nonced 
-            transaction. Nonced transactions are useful when a transaction 
-            requires a lengthy signing process. Learn more about nonced 
+            Provide the nonce account to use when creating a nonced
+            transaction. Nonced transactions are useful when a transaction
+            requires a lengthy signing process. Learn more about nonced
             transactions at https://docs.solana.com/offline-signing/durable-nonce
         --nonce-authority <KEYPAIR or PUBKEY>
             Provide the nonce authority keypair to use when signing a nonced transaction
@@ -1377,7 +1376,7 @@ ARGS:
 
 #### solana-stake-history
 ```text
-solana-stake-history 
+solana-stake-history
 Show the stake history
 
 USAGE:
@@ -1402,7 +1401,7 @@ OPTIONS:
 
 #### solana-stakes
 ```text
-solana-stakes 
+solana-stakes
 Show stake account information
 
 USAGE:
@@ -1430,7 +1429,7 @@ ARGS:
 
 #### solana-storage-account
 ```text
-solana-storage-account 
+solana-storage-account
 Show the contents of a storage account
 
 USAGE:
@@ -1457,7 +1456,7 @@ ARGS:
 
 #### solana-transaction-count
 ```text
-solana-transaction-count 
+solana-transaction-count
 Get current transaction count
 
 USAGE:
@@ -1480,38 +1479,9 @@ OPTIONS:
     -k, --keypair <PATH>                    /path/to/id.json
 ```
 
-#### solana-uptime
-```text
-solana-uptime 
-Show the uptime of a validator, based on epoch voting history
-
-USAGE:
-    solana uptime [FLAGS] [OPTIONS] <VOTE ACCOUNT PUBKEY>
-
-FLAGS:
-        --aggregate                      Aggregate uptime data across span
-    -h, --help                           Prints help information
-        --skip-seed-phrase-validation    Skip validation of seed phrases. Use this if your phrase does not use the BIP39
-                                         official English word list
-    -V, --version                        Prints version information
-    -v, --verbose                        Show extra information header
-
-OPTIONS:
-        --ask-seed-phrase <KEYPAIR NAME>    Recover a keypair using a seed phrase and optional passphrase [possible
-                                            values: keypair]
-    -C, --config <PATH>                     Configuration file to use [default:
-                                            ~/.config/solana/cli/config.yml]
-    -u, --url <URL>                         JSON RPC URL for the solana cluster
-    -k, --keypair <PATH>                    /path/to/id.json
-        --span <NUM OF EPOCHS>              Number of recent epochs to examine
-
-ARGS:
-    <VOTE ACCOUNT PUBKEY>    Vote account pubkey
-```
-
 #### solana-validator-info
 ```text
-solana-validator-info 
+solana-validator-info
 Publish/get Validator info on Solana
 
 USAGE:
@@ -1540,7 +1510,7 @@ SUBCOMMANDS:
 
 #### solana-validators
 ```text
-solana-validators 
+solana-validators
 Show summary information about the current validators
 
 USAGE:
@@ -1565,7 +1535,7 @@ OPTIONS:
 
 #### solana-vote-account
 ```text
-solana-vote-account 
+solana-vote-account
 Show the contents of a vote account
 
 USAGE:
@@ -1593,7 +1563,7 @@ ARGS:
 
 #### solana-vote-authorize-voter
 ```text
-solana-vote-authorize-voter 
+solana-vote-authorize-voter
 Authorize a new vote signing keypair for the given vote account
 
 USAGE:
@@ -1621,7 +1591,7 @@ ARGS:
 
 #### solana-vote-authorize-withdrawer
 ```text
-solana-vote-authorize-withdrawer 
+solana-vote-authorize-withdrawer
 Authorize a new withdraw signing keypair for the given vote account
 
 USAGE:
@@ -1649,7 +1619,7 @@ ARGS:
 
 #### solana-vote-update-validator
 ```text
-solana-vote-update-validator 
+solana-vote-update-validator
 Update the vote account's validator identity
 
 USAGE:
@@ -1678,7 +1648,7 @@ ARGS:
 
 #### solana-withdraw-from-nonce-account
 ```text
-solana-withdraw-from-nonce-account 
+solana-withdraw-from-nonce-account
 Withdraw lamports from the nonce account
 
 USAGE:
@@ -1713,7 +1683,7 @@ ARGS:
 
 #### solana-withdraw-stake
 ```text
-solana-withdraw-stake 
+solana-withdraw-stake
 Withdraw the unstaked lamports from the stake account
 
 USAGE:

--- a/book/src/running-validator/validator-stake.md
+++ b/book/src/running-validator/validator-stake.md
@@ -83,7 +83,6 @@ To monitor your validator during its warmup period:
 
 * View your vote account:`solana vote-account ~/validator-vote-keypair.json` This displays the current state of all the votes the validator has submitted to the network.
 * View your stake account, the delegation preference and details of your stake:`solana stake-account ~/validator-stake-keypair.json`
-* `solana uptime ~/validator-vote-keypair.json` will display the voting history \(aka, uptime\) of your validator over recent Epochs
 * `solana validators` displays the current active stake of all validators, including yours
 * `solana stake-history ` shows the history of stake warming up and cooling down over recent epochs
 * Look for log messages on your validator indicating your next leader slot: `[2019-09-27T20:16:00.319721164Z INFO solana_core::replay_stage] <VALIDATOR_IDENTITY_PUBKEY> voted and reset PoH at tick height ####. My next leader slot is ####`

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -343,11 +343,6 @@ pub enum CliCommand {
         pubkey: Pubkey,
         use_lamports_unit: bool,
     },
-    Uptime {
-        pubkey: Pubkey,
-        aggregate: bool,
-        span: Option<u64>,
-    },
     VoteAuthorize {
         vote_account_pubkey: Pubkey,
         new_authorized_pubkey: Pubkey,
@@ -539,7 +534,6 @@ pub fn parse_command(matches: &ArgMatches<'_>) -> Result<CliCommandInfo, Box<dyn
             parse_vote_authorize(matches, VoteAuthorize::Withdrawer)
         }
         ("vote-account", Some(matches)) => parse_vote_get_account_command(matches),
-        ("uptime", Some(matches)) => parse_vote_uptime_command(matches),
         // Wallet Commands
         ("address", Some(_matches)) => Ok(CliCommandInfo {
             command: CliCommand::Address,
@@ -1609,11 +1603,6 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             &new_identity_pubkey,
             authorized_voter,
         ),
-        CliCommand::Uptime {
-            pubkey: vote_account_pubkey,
-            aggregate,
-            span,
-        } => process_uptime(&rpc_client, config, &vote_account_pubkey, *aggregate, *span),
 
         // Wallet Commands
 


### PR DESCRIPTION
The `solana uptime` command output is misleading and there's no clear way to resolve.  The improvement recommended by #7425 is not sufficient because it's not a strict requirement that validators vote on every block.  

Until there's a clear resolution, this PR abandons `solana uptime` entirely and modifies `solana validators` to replace the "Uptime" column with a "Credits" column, where "Credits" displays all the earned credits to date for the validator's vote account

Fixes #7425 (by removing the problem entirely)