### PR TITLE
Print more program error info to user when using CLI

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -1776,7 +1776,12 @@ where
             {
                 if let Some(specific_error) = E::decode_custom_error_to_enum(code) {
                     error!("{}::{:?}", E::type_of(), specific_error);
-                    eprintln!("Program Error ({}::{:?}): {}", E::type_of(), specific_error, specific_error);
+                    eprintln!(
+                        "Program Error ({}::{:?}): {}",
+                        E::type_of(),
+                        specific_error,
+                        specific_error
+                    );
                     return Err(specific_error.into());
                 }
             }

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -1776,6 +1776,7 @@ where
             {
                 if let Some(specific_error) = E::decode_custom_error_to_enum(code) {
                     error!("{}::{:?}", E::type_of(), specific_error);
+                    eprintln!("Program Error ({}::{:?}): {}", E::type_of(), specific_error, specific_error);
                     return Err(specific_error.into());
                 }
             }

--- a/sdk/src/system_instruction.rs
+++ b/sdk/src/system_instruction.rs
@@ -10,14 +10,19 @@ use crate::{
 use num_derive::{FromPrimitive, ToPrimitive};
 use thiserror::Error;
 
-#[derive(Serialize, Debug, Clone, PartialEq, FromPrimitive, ToPrimitive)]
+#[derive(Error, Debug, Serialize, Clone, PartialEq, FromPrimitive, ToPrimitive)]
 pub enum SystemError {
+    #[error("an account with the same Pubkey already exists")]
     AccountAlreadyInUse,
+    #[error("account does not have enought lamports to perform the operation")]
     ResultWithNegativeLamports,
+    #[error("cannot assign account to this program id")]
     InvalidProgramId,
+    #[error("cannot allocate account data of that length")]
     InvalidAccountDataLength,
-    InvalidSeed,
+    #[error("length of requsted seed is too long")]
     MaxSeedLengthExceeded,
+    #[error("provided address does not match addressed derived from seed")]
     AddressWithSeedMismatch,
 }
 
@@ -26,13 +31,6 @@ impl<T> DecodeError<T> for SystemError {
         "SystemError"
     }
 }
-
-impl std::fmt::Display for SystemError {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "error")
-    }
-}
-impl std::error::Error for SystemError {}
 
 #[derive(Error, Debug, Clone, PartialEq, FromPrimitive, ToPrimitive)]
 pub enum NonceError {

--- a/sdk/src/system_instruction.rs
+++ b/sdk/src/system_instruction.rs
@@ -12,13 +12,13 @@ use thiserror::Error;
 
 #[derive(Error, Debug, Serialize, Clone, PartialEq, FromPrimitive, ToPrimitive)]
 pub enum SystemError {
-    #[error("an account with the same Pubkey already exists")]
+    #[error("an account with the same addreess already exists")]
     AccountAlreadyInUse,
     #[error("account does not have enought lamports to perform the operation")]
     ResultWithNegativeLamports,
     #[error("cannot assign account to this program id")]
     InvalidProgramId,
-    #[error("cannot allocate account data of that length")]
+    #[error("cannot allocate account data of this length")]
     InvalidAccountDataLength,
     #[error("length of requsted seed is too long")]
     MaxSeedLengthExceeded,

--- a/sdk/src/transaction.rs
+++ b/sdk/src/transaction.rs
@@ -66,7 +66,7 @@ pub type Result<T> = result::Result<T, TransactionError>;
 
 impl std::fmt::Display for TransactionError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "transaction error")
+        write!(f, "TransactionError::{:?}", self)
     }
 }
 


### PR DESCRIPTION
#### Problem

Limited error information provided to the user when a built-in program fails via the CLI

#### Summary of Changes

Give'em more

Fixes #
