### PR TITLE
Generate max coding shreds when necessary

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -5333,7 +5333,7 @@ pub mod tests {
                 .iter()
                 .cloned()
                 .chain(
-                    coding_shreds[coding_shreds.len() / 2 - 1..data_shreds.len() / 2]
+                    coding_shreds[coding_shreds.len() / 2 - 1..coding_shreds.len() / 2]
                         .iter()
                         .cloned(),
                 )

--- a/ledger/src/blockstore_meta.rs
+++ b/ledger/src/blockstore_meta.rs
@@ -194,19 +194,17 @@ impl ErasureMeta {
             .data()
             .present_in_bounds(self.set_index..self.set_index + self.config.num_data() as u64);
 
-        let (data_missing, coding_missing) = (
-            self.config.num_data() - num_data,
-            self.config.num_coding() - num_coding,
+        let (data_missing, num_needed) = (
+            self.config.num_data().saturating_sub(num_data),
+            self.config.num_data().saturating_sub(num_data + num_coding),
         );
 
-        let total_missing = data_missing + coding_missing;
-
-        if data_missing > 0 && total_missing <= self.config.num_coding() {
-            CanRecover
-        } else if data_missing == 0 {
+        if data_missing == 0 {
             DataFull
+        } else if num_needed == 0 {
+            CanRecover
         } else {
-            StillNeed(total_missing - self.config.num_coding())
+            StillNeed(num_needed)
         }
     }
 


### PR DESCRIPTION
#### Problem
PR, that generated maximum coding shreds for all FEC blocks, was reverted. The FEC blocks with empty ticks also contained maximum number of coding shreds. This caused increase in network bandwidth usage for idling cluster.

However, there are instances where we want to generate more coding shreds than data shreds. The relevant portion of reverted PR needs to be resurrected, with more checks to limit when maximum coding shreds are generated.

#### Summary of Changes
Limited the conditions for generating MAX_DATA_SHREDS_PER_FEC_BLOCK coding shreds for FEC blocks with less number of data shreds. For example,

- The shreds generated from a `Vec<Entry>` got split into multiple FEC blocks. The current FEC block contains a part (most likely, tail) of the shred set.

Fixes #7902 
