### PR TITLE
Fix consensus threshold when new root is created (bp #8093) v0.23

### DIFF
--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -327,21 +327,16 @@ impl Tower {
                     fork_stake.stake,
                     total_staked
                 );
-                for (new_lockout, original_lockout) in
-                    lockouts.votes.iter().zip(self.lockouts.votes.iter())
-                {
-                    if new_lockout.slot == original_lockout.slot {
-                        if new_lockout.confirmation_count <= self.threshold_depth as u32 {
-                            break;
+                if vote.confirmation_count as usize > self.threshold_depth {
+                    for old_vote in &self.lockouts.votes {
+                        if old_vote.slot == vote.slot
+                            && old_vote.confirmation_count == vote.confirmation_count
+                        {
+                            return true;
                         }
-                        if new_lockout.confirmation_count != original_lockout.confirmation_count {
-                            return lockout > self.threshold_size;
-                        }
-                    } else {
-                        break;
                     }
                 }
-                true
+                lockout > self.threshold_size
             } else {
                 false
             }
@@ -554,6 +549,24 @@ mod test {
         .into_iter()
         .collect();
         assert!(tower.check_vote_stake_threshold(0, &stakes, 2));
+    }
+
+    #[test]
+    fn test_check_vote_threshold_no_skip_lockout_with_new_root() {
+        solana_logger::setup();
+        let mut tower = Tower::new_for_tests(4, 0.67);
+        let mut stakes = HashMap::new();
+        for i in 0..(MAX_LOCKOUT_HISTORY as u64 + 1) {
+            stakes.insert(
+                i,
+                StakeLockout {
+                    stake: 1,
+                    lockout: 8,
+                },
+            );
+            tower.record_vote(i, Hash::default());
+        }
+        assert!(!tower.check_vote_stake_threshold(MAX_LOCKOUT_HISTORY as u64 + 1, &stakes, 2));
     }
 
     #[test]


### PR DESCRIPTION
#### Problem

When a new root is created, the oldest slot is popped off
but when the logic checks for identical slots, it assumes
that any difference means a slot was popped off the front.

#### Summary of Changes

Fixes #
