### PR TITLE
CLI cosmetic: make config get and verbose prints consistent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3681,6 +3681,7 @@ dependencies = [
  "solana-vote-program 0.24.0",
  "solana-vote-signer 0.24.0",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "titlecase 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -5290,6 +5291,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "titlecase"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "tokio"
 version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6421,6 +6431,7 @@ dependencies = [
 "checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
 "checksum tiny-bip39 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1cd1fb03fe8e07d17cd851a624a9fff74642a997b67fbd1ccd77533241640d92"
 "checksum tiny-keccak 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d8a021c69bb74a44ccedb824a046447e2c84a01df9e5c20779750acb38e11b2"
+"checksum titlecase 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f565e410cfc24c2f2a89960b023ca192689d7f77d3f8d4f4af50c2d8affe1117"
 "checksum tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)" = "5a09c0b5bb588872ab2f09afa13ee6e9dac11e10a0ec9e8e3ba39a5a5d530af6"
 "checksum tokio 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0e1bef565a52394086ecac0a6fa3b8ace4cb3a138ee1d96bd2b93283b56824e3"
 "checksum tokio-buf 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8fb220f46c53859a4b7ec083e41dec9778ff0b1851c0942b211edb89e0ccdc46"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -40,6 +40,7 @@ solana-stake-program = { path = "../programs/stake", version = "0.24.0" }
 solana-storage-program = { path = "../programs/storage", version = "0.24.0" }
 solana-vote-program = { path = "../programs/vote", version = "0.24.0" }
 solana-vote-signer = { path = "../vote-signer", version = "0.24.0" }
+titlecase = "1.1.0"
 url = "2.1.1"
 
 [dev-dependencies]

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -1233,10 +1233,10 @@ fn process_witness(
 
 pub fn process_command(config: &CliConfig) -> ProcessResult {
     if config.verbose {
+        println_name_value("RPC URL:", &config.json_rpc_url);
         if let Some(keypair_path) = &config.keypair_path {
-            println_name_value("Keypair:", keypair_path);
+            println_name_value("Keypair Path:", keypair_path);
         }
-        println_name_value("RPC Endpoint:", &config.json_rpc_url);
     }
 
     let mut _rpc_client;

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -451,11 +451,11 @@ pub fn process_get_epoch_info(
     let start_slot = epoch_info.absolute_slot - epoch_info.slot_index;
     let end_slot = start_slot + epoch_info.slots_in_epoch;
     println_name_value(
-        "Epoch slot range:",
+        "Epoch Slot Range:",
         &format!("[{}..{})", start_slot, end_slot),
     );
     println_name_value(
-        "Epoch completed percent:",
+        "Epoch Completed Percent:",
         &format!(
             "{:>3.3}%",
             epoch_info.slot_index as f64 / epoch_info.slots_in_epoch as f64 * 100_f64
@@ -463,14 +463,14 @@ pub fn process_get_epoch_info(
     );
     let remaining_slots_in_epoch = epoch_info.slots_in_epoch - epoch_info.slot_index;
     println_name_value(
-        "Epoch completed slots:",
+        "Epoch Completed Slots:",
         &format!(
             "{}/{} ({} remaining)",
             epoch_info.slot_index, epoch_info.slots_in_epoch, remaining_slots_in_epoch
         ),
     );
     println_name_value(
-        "Epoch completed time:",
+        "Epoch Completed Time:",
         &format!(
             "{}/{} ({} remaining)",
             slot_to_human_time(epoch_info.slot_index),
@@ -695,8 +695,8 @@ pub fn process_ping(
 ) -> ProcessResult {
     let to = Keypair::new().pubkey();
 
-    println_name_value("Source account:", &config.keypair.pubkey().to_string());
-    println_name_value("Destination account:", &to.to_string());
+    println_name_value("Source Account:", &config.keypair.pubkey().to_string());
+    println_name_value("Destination Account:", &to.to_string());
     println!();
 
     let (signal_sender, signal_receiver) = std::sync::mpsc::channel();

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -24,21 +24,25 @@ fn parse_settings(matches: &ArgMatches<'_>) -> Result<bool, Box<dyn error::Error
                 if let Some(config_file) = matches.value_of("config_file") {
                     let config = Config::load(config_file).unwrap_or_default();
                     if let Some(field) = subcommand_matches.value_of("specific_setting") {
-                        let (value, default_value) = match field {
-                            "url" => (config.url, CliConfig::default_json_rpc_url()),
-                            "keypair" => (config.keypair_path, CliConfig::default_keypair_path()),
+                        let (field_name, value, default_value) = match field {
+                            "url" => ("RPC Url", config.url, CliConfig::default_json_rpc_url()),
+                            "keypair" => (
+                                "Key Path",
+                                config.keypair_path,
+                                CliConfig::default_keypair_path(),
+                            ),
                             _ => unreachable!(),
                         };
-                        println_name_value_or(&format!("* {}:", field), &value, &default_value);
+                        println_name_value_or(&format!("{}:", field_name), &value, &default_value);
                     } else {
-                        println_name_value("Wallet Config:", config_file);
+                        println_name_value("Config File:", config_file);
                         println_name_value_or(
-                            "* url:",
+                            "RPC Url:",
                             &config.url,
                             &CliConfig::default_json_rpc_url(),
                         );
                         println_name_value_or(
-                            "* keypair:",
+                            "Key Path:",
                             &config.keypair_path,
                             &CliConfig::default_keypair_path(),
                         );
@@ -61,9 +65,9 @@ fn parse_settings(matches: &ArgMatches<'_>) -> Result<bool, Box<dyn error::Error
                         config.keypair_path = keypair.to_string();
                     }
                     config.save(config_file)?;
-                    println_name_value("Wallet Config Updated:", config_file);
-                    println_name_value("* url:", &config.url);
-                    println_name_value("* keypair:", &config.keypair_path);
+                    println_name_value("Config File:", config_file);
+                    println_name_value("RPC URL:", &config.url);
+                    println_name_value("Keypair Path:", &config.keypair_path);
                 } else {
                     println!(
                         "{} Either provide the `--config` arg or ensure home directory exists to use the default config location",

--- a/cli/src/nonce.rs
+++ b/cli/src/nonce.rs
@@ -540,11 +540,11 @@ pub fn process_show_nonce_account(
     }
     let print_account = |data: Option<(Meta, Hash)>| {
         println!(
-            "balance: {}",
+            "Balance: {}",
             build_balance_message(nonce_account.lamports, use_lamports_unit, true)
         );
         println!(
-            "minimum balance required: {}",
+            "Minimum Balance Required: {}",
             build_balance_message(
                 rpc_client.get_minimum_balance_for_rent_exemption(NonceState::size())?,
                 use_lamports_unit,
@@ -553,12 +553,12 @@ pub fn process_show_nonce_account(
         );
         match data {
             Some((meta, hash)) => {
-                println!("nonce: {}", hash);
-                println!("authority: {}", meta.nonce_authority);
+                println!("Nonce: {}", hash);
+                println!("Authority: {}", meta.nonce_authority);
             }
             None => {
-                println!("nonce: uninitialized");
-                println!("authority: uninitialized");
+                println!("Nonce: uninitialized");
+                println!("Authority: uninitialized");
             }
         }
         Ok("".to_string())

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -958,12 +958,12 @@ pub fn process_split_stake(
 
 pub fn print_stake_state(stake_lamports: u64, stake_state: &StakeState, use_lamports_unit: bool) {
     fn show_authorized(authorized: &Authorized) {
-        println!("authorized staker: {}", authorized.staker);
-        println!("authorized withdrawer: {}", authorized.withdrawer);
+        println!("Authorized Staker: {}", authorized.staker);
+        println!("Authorized Withdrawer: {}", authorized.withdrawer);
     }
     fn show_lockup(lockup: &Lockup) {
-        println!("lockup epoch: {}", lockup.epoch);
-        println!("lockup custodian: {}", lockup.custodian);
+        println!("Lockup Epoch: {}", lockup.epoch);
+        println!("Lockup Custodian: {}", lockup.custodian);
     }
     match stake_state {
         StakeState::Stake(
@@ -973,19 +973,19 @@ pub fn print_stake_state(stake_lamports: u64, stake_state: &StakeState, use_lamp
             stake,
         ) => {
             println!(
-                "total stake: {}",
+                "Total Stake: {}",
                 build_balance_message(stake_lamports, use_lamports_unit, true)
             );
-            println!("credits observed: {}", stake.credits_observed);
+            println!("Credits Observed: {}", stake.credits_observed);
             println!(
-                "delegated stake: {}",
+                "Delegated Stake: {}",
                 build_balance_message(stake.delegation.stake, use_lamports_unit, true)
             );
             if stake.delegation.voter_pubkey != Pubkey::default() {
-                println!("delegated voter pubkey: {}", stake.delegation.voter_pubkey);
+                println!("Delegated Voter Pubkey: {}", stake.delegation.voter_pubkey);
             }
             println!(
-                "stake activates starting from epoch: {}",
+                "Stake activates starting from epoch: {}",
                 if stake.delegation.activation_epoch < std::u64::MAX {
                     stake.delegation.activation_epoch
                 } else {
@@ -994,23 +994,23 @@ pub fn print_stake_state(stake_lamports: u64, stake_state: &StakeState, use_lamp
             );
             if stake.delegation.deactivation_epoch < std::u64::MAX {
                 println!(
-                    "stake deactivates starting from epoch: {}",
+                    "Stake deactivates starting from epoch: {}",
                     stake.delegation.deactivation_epoch
                 );
             }
             show_authorized(&authorized);
             show_lockup(&lockup);
         }
-        StakeState::RewardsPool => println!("stake account is a rewards pool"),
-        StakeState::Uninitialized => println!("stake account is uninitialized"),
+        StakeState::RewardsPool => println!("Stake account is a rewards pool"),
+        StakeState::Uninitialized => println!("Stake account is uninitialized"),
         StakeState::Initialized(Meta {
             authorized, lockup, ..
         }) => {
             println!(
-                "total stake: {}",
+                "Total Stake: {}",
                 build_balance_message(stake_lamports, use_lamports_unit, true)
             );
-            println!("stake account is undelegated");
+            println!("Stake account is undelegated");
             show_authorized(&authorized);
             show_lockup(&lockup);
         }

--- a/cli/src/storage.rs
+++ b/cli/src/storage.rs
@@ -251,7 +251,7 @@ pub fn process_show_storage_account(
         CliError::RpcRequestError(format!("Unable to deserialize storage account: {:?}", err))
     })?;
     println!("{:#?}", storage_contract);
-    println!("account lamports: {}", account.lamports);
+    println!("Account Lamports: {}", account.lamports);
     Ok("".to_string())
 }
 

--- a/cli/src/validator_info.rs
+++ b/cli/src/validator_info.rs
@@ -22,8 +22,8 @@ use solana_sdk::{
     signature::{Keypair, KeypairUtil},
     transaction::Transaction,
 };
-
 use std::error;
+use titlecase::titlecase;
 
 pub const MAX_SHORT_FIELD_LENGTH: usize = 70;
 pub const MAX_LONG_FIELD_LENGTH: usize = 300;
@@ -390,9 +390,12 @@ pub fn process_get_validator_info(rpc_client: &RpcClient, pubkey: Option<Pubkey>
             parse_validator_info(&validator_info_pubkey, &validator_info_account)?;
         println!();
         println_name_value("Validator Identity Pubkey:", &validator_pubkey.to_string());
-        println_name_value("  info pubkey:", &validator_info_pubkey.to_string());
+        println_name_value("  Info Pubkey:", &validator_info_pubkey.to_string());
         for (key, value) in validator_info.iter() {
-            println_name_value(&format!("  {}:", key), &value.as_str().unwrap_or("?"));
+            println_name_value(
+                &format!("  {}:", titlecase(key)),
+                &value.as_str().unwrap_or("?"),
+            );
         }
     }
 

--- a/cli/src/vote.rs
+++ b/cli/src/vote.rs
@@ -429,25 +429,25 @@ pub fn process_show_vote_account(
     let epoch_schedule = rpc_client.get_epoch_schedule()?;
 
     println!(
-        "account balance: {}",
+        "Account Balance: {}",
         build_balance_message(vote_account.lamports, use_lamports_unit, true)
     );
-    println!("validator identity: {}", vote_state.node_pubkey);
-    println!("authorized voter: {}", vote_state.authorized_voter);
+    println!("Validator Identity: {}", vote_state.node_pubkey);
+    println!("Authorized Voter: {}", vote_state.authorized_voter);
     println!(
-        "authorized withdrawer: {}",
+        "Authorized Withdrawer: {}",
         vote_state.authorized_withdrawer
     );
-    println!("credits: {}", vote_state.credits());
-    println!("commission: {}%", vote_state.commission);
+    println!("Credits: {}", vote_state.credits());
+    println!("Commission: {}%", vote_state.commission);
     println!(
-        "root slot: {}",
+        "Root Slot: {}",
         match vote_state.root_slot {
             Some(slot) => slot.to_string(),
             None => "~".to_string(),
         }
     );
-    println!("recent timestamp: {:?}", vote_state.last_timestamp);
+    println!("Recent Timestamp: {:?}", vote_state.last_timestamp);
     if !vote_state.votes.is_empty() {
         println!("recent votes:");
         for vote in &vote_state.votes {
@@ -457,7 +457,7 @@ pub fn process_show_vote_account(
             );
         }
 
-        println!("epoch voting history:");
+        println!("Epoch Voting History:");
         for (epoch, credits, prev_credits) in vote_state.epoch_credits() {
             let credits_earned = credits - prev_credits;
             let slots_in_epoch = epoch_schedule.get_slots_in_epoch(*epoch);


### PR DESCRIPTION
#### Problem
The results from `solana config get` and passing the `--verbose` flag with a command like `solana balance` are not consistent.

#### Summary of Changes
Make them consistent.
This updates the name of the "keypair" field to "Key Path" in preparation for remote wallet implementation. At present this is a purely cosmetic change, and does not alter the fields in the config or the input ags. I toyed with making those updates -- ie. `--keypair` arg to `--key-path` and `--url` to `--rpc-url` -- but it caused a ton of downstream churn in bash scripts (some of which use those args to target multiple crates, eg. solana-install, solana-faucet).

New responses:

```
$ solana config get
Config File: ~/.config/solana/cli/config.yml
RPC Url: http://testnet.solana.com:8899
Key Path: ~/keypair.json

$ solana balance --verbose
RPC Url: http://testnet.solana.com:8899
Key Path: ~/keypair.json
9 SOL
```
