### PR TITLE
Add next_account_info()

### DIFF
--- a/sdk/src/instruction_processor_utils.rs
+++ b/sdk/src/instruction_processor_utils.rs
@@ -1,15 +1,21 @@
 use crate::{
-    account::KeyedAccount, instruction::InstructionError, program_error::ProgramError,
-    pubkey::Pubkey,
+    account::KeyedAccount, account_info::AccountInfo, instruction::InstructionError,
+    program_error::ProgramError, pubkey::Pubkey,
 };
 use num_traits::FromPrimitive;
 
-pub fn next_keyed_account<I: Iterator>(iter: &mut I) -> Result<I::Item, InstructionError> {
+/// Return the next KeyedAccount or a NotEnoughAccountKeys error
+pub fn next_keyed_account<'a, I: Iterator<Item = &'a KeyedAccount<'a>>>(
+    iter: &mut I,
+) -> Result<I::Item, InstructionError> {
+>>>>>>> nudge
     iter.next().ok_or(InstructionError::NotEnoughAccountKeys)
 }
 
 /// Return the next AccountInfo or a NotEnoughAccountKeys error
-pub fn next_account_info<I: Iterator>(iter: &mut I) -> Result<I::Item, ProgramError> {
+pub fn next_account_info<'a, I: Iterator<Item = &'a AccountInfo<'a>>>(
+    iter: &mut I,
+) -> Result<I::Item, ProgramError> {
     iter.next().ok_or(ProgramError::NotEnoughAccountKeys)
 }
 

--- a/sdk/src/instruction_processor_utils.rs
+++ b/sdk/src/instruction_processor_utils.rs
@@ -1,9 +1,16 @@
-use crate::{account::KeyedAccount, instruction::InstructionError};
+use crate::{
+    account::KeyedAccount, instruction::InstructionError, program_error::ProgramError,
+    pubkey::Pubkey,
+};
 use num_traits::FromPrimitive;
 
-/// Return the next KeyedAccount or a NotEnoughAccountKeys instruction error
 pub fn next_keyed_account<I: Iterator>(iter: &mut I) -> Result<I::Item, InstructionError> {
     iter.next().ok_or(InstructionError::NotEnoughAccountKeys)
+}
+
+/// Return the next AccountInfo or a NotEnoughAccountKeys error
+pub fn next_account_info<I: Iterator>(iter: &mut I) -> Result<I::Item, ProgramError> {
+    iter.next().ok_or(ProgramError::NotEnoughAccountKeys)
 }
 
 /// Return true if the first keyed_account is executable, used to determine if

--- a/sdk/src/instruction_processor_utils.rs
+++ b/sdk/src/instruction_processor_utils.rs
@@ -5,14 +5,14 @@ use crate::{
 use num_traits::FromPrimitive;
 
 /// Return the next KeyedAccount or a NotEnoughAccountKeys error
-pub fn next_keyed_account<'a, I: Iterator<Item = &'a KeyedAccount<'a>>>(
+pub fn next_keyed_account<'a, 'b, I: Iterator<Item = &'a KeyedAccount<'b>>>(
     iter: &mut I,
 ) -> Result<I::Item, InstructionError> {
     iter.next().ok_or(InstructionError::NotEnoughAccountKeys)
 }
 
 /// Return the next AccountInfo or a NotEnoughAccountKeys error
-pub fn next_account_info<'a, I: Iterator<Item = &'a AccountInfo<'a>>>(
+pub fn next_account_info<'a, 'b, I: Iterator<Item = &'a AccountInfo<'b>>>(
     iter: &mut I,
 ) -> Result<I::Item, ProgramError> {
     iter.next().ok_or(ProgramError::NotEnoughAccountKeys)
@@ -24,6 +24,8 @@ pub fn is_executable(keyed_accounts: &[KeyedAccount]) -> Result<bool, Instructio
     Ok(!keyed_accounts.is_empty() && keyed_accounts[0].executable()?)
 }
 
+/// Deserialize with a limit based the maximum amount of data a program can expect to get.
+/// This function should be used in place of direct deserialization to help prevent OOM errors
 pub fn limited_deserialize<T>(instruction_data: &[u8]) -> Result<T, InstructionError>
 where
     T: serde::de::DeserializeOwned,
@@ -35,6 +37,7 @@ where
         .map_err(|_| InstructionError::InvalidInstructionData)
 }
 
+/// Allows customer errors to be decoded back to their original enum
 pub trait DecodeError<E> {
     fn decode_custom_error_to_enum(custom: u32) -> Option<E>
     where

--- a/sdk/src/instruction_processor_utils.rs
+++ b/sdk/src/instruction_processor_utils.rs
@@ -1,6 +1,6 @@
 use crate::{
     account::KeyedAccount, account_info::AccountInfo, instruction::InstructionError,
-    program_error::ProgramError, pubkey::Pubkey,
+    program_error::ProgramError,
 };
 use num_traits::FromPrimitive;
 
@@ -8,7 +8,6 @@ use num_traits::FromPrimitive;
 pub fn next_keyed_account<'a, I: Iterator<Item = &'a KeyedAccount<'a>>>(
     iter: &mut I,
 ) -> Result<I::Item, InstructionError> {
->>>>>>> nudge
     iter.next().ok_or(InstructionError::NotEnoughAccountKeys)
 }
 


### PR DESCRIPTION
#### Problem

No helper function for Rust BPF programs to iterate `AccountInfo` like there is for `KeyedAccounts`

#### Summary of Changes

Add one

Fixes #
