### PR TITLE
Sysvar account_into return program error rather than option

### DIFF
--- a/sdk/src/sysvar/mod.rs
+++ b/sdk/src/sysvar/mod.rs
@@ -72,7 +72,7 @@ pub trait Sysvar:
         bincode::serialize_into(&mut account.data[..], self).ok()
     }
     fn from_account_info(account_info: &AccountInfo) -> Result<Self, ProgramError> {
-        bincode::deserialize(&account_info.data.borrow()).map_err(|_|ProgramError::InvalidArgument)
+        bincode::deserialize(&account_info.data.borrow()).map_err(|_| ProgramError::InvalidArgument)
     }
     fn to_account_info(&self, account_info: &mut AccountInfo) -> Option<()> {
         bincode::serialize_into(&mut account_info.data.borrow_mut()[..], self).ok()

--- a/sdk/src/sysvar/mod.rs
+++ b/sdk/src/sysvar/mod.rs
@@ -4,6 +4,7 @@ use crate::{
     account::{Account, KeyedAccount},
     account_info::AccountInfo,
     instruction::InstructionError,
+    program_error::ProgramError,
     pubkey::Pubkey,
 };
 
@@ -70,8 +71,8 @@ pub trait Sysvar:
     fn to_account(&self, account: &mut Account) -> Option<()> {
         bincode::serialize_into(&mut account.data[..], self).ok()
     }
-    fn from_account_info(account_info: &AccountInfo) -> Option<Self> {
-        bincode::deserialize(&account_info.data.borrow()).ok()
+    fn from_account_info(account_info: &AccountInfo) -> Result<Self, ProgramError> {
+        bincode::deserialize(&account_info.data.borrow()).map_err(|_|ProgramError::InvalidArgument)
     }
     fn to_account_info(&self, account_info: &mut AccountInfo) -> Option<()> {
         bincode::serialize_into(&mut account_info.data.borrow_mut()[..], self).ok()


### PR DESCRIPTION
#### Problem

`from_account_info` does not match the signature of `from_keyed_account` in that it returns an `Option` instead of a `Result`

#### Summary of Changes

Align the two functions by returning a `Result` for both.  This allows Rust BPF programs to use `?` when attempting to convert a sysvar account.

Fixes #
