### PR TITLE
Report validator rewards in getConfirmedBlock JSON RPC

### DIFF
--- a/book/src/apps/jsonrpc-api.md
+++ b/book/src/apps/jsonrpc-api.md
@@ -303,6 +303,9 @@ The result field will be an object with the following fields:
      * `fee: <u64>` - fee this transaction was charged, as u64 integer
      * `preBalances: <array>` - array of u64 account balances from before the transaction was processed
      * `postBalances: <array>` - array of u64 account balances after the transaction was processed
+* `rewards: <array>` - an array of JSON objects containing:
+  * `pubkey: <string>` - The public key, as base-58 encoded string, of the account that received the reward
+  * `lamports: <i64>`- number of reward lamports credited or debited by the account, as a i64
 
 #### Example:
 

--- a/client/src/rpc_response.rs
+++ b/client/src/rpc_response.rs
@@ -33,12 +33,21 @@ pub struct RpcBlockCommitment<T> {
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
+pub struct RpcReward {
+    pub pubkey: String,
+    pub lamports: i64,
+}
+
+pub type RpcRewards = Vec<RpcReward>;
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RpcConfirmedBlock {
     pub previous_blockhash: String,
     pub blockhash: String,
     pub parent_slot: Slot,
     pub transactions: Vec<RpcTransactionWithStatusMeta>,
+    pub rewards: RpcRewards,
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -36,6 +36,7 @@ pub mod repair_service;
 pub mod replay_stage;
 mod result;
 pub mod retransmit_stage;
+pub mod rewards_recorder_service;
 pub mod rpc;
 pub mod rpc_pubsub;
 pub mod rpc_pubsub_service;

--- a/core/src/rewards_recorder_service.rs
+++ b/core/src/rewards_recorder_service.rs
@@ -1,0 +1,67 @@
+use crossbeam_channel::{Receiver, RecvTimeoutError, Sender};
+use solana_client::rpc_response::RpcReward;
+use solana_ledger::blockstore::Blockstore;
+use solana_sdk::{clock::Slot, pubkey::Pubkey};
+use std::{
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+    thread::{self, Builder, JoinHandle},
+    time::Duration,
+};
+
+pub type RewardsRecorderReceiver = Receiver<(Slot, Vec<(Pubkey, i64)>)>;
+pub type RewardsRecorderSender = Sender<(Slot, Vec<(Pubkey, i64)>)>;
+
+pub struct RewardsRecorderService {
+    thread_hdl: JoinHandle<()>,
+}
+
+impl RewardsRecorderService {
+    #[allow(clippy::new_ret_no_self)]
+    pub fn new(
+        rewards_receiver: RewardsRecorderReceiver,
+        blockstore: Arc<Blockstore>,
+        exit: &Arc<AtomicBool>,
+    ) -> Self {
+        let exit = exit.clone();
+        let thread_hdl = Builder::new()
+            .name("solana-rewards-writer".to_string())
+            .spawn(move || loop {
+                if exit.load(Ordering::Relaxed) {
+                    break;
+                }
+                if let Err(RecvTimeoutError::Disconnected) =
+                    Self::write_rewards(&rewards_receiver, &blockstore)
+                {
+                    break;
+                }
+            })
+            .unwrap();
+        Self { thread_hdl }
+    }
+
+    fn write_rewards(
+        rewards_receiver: &RewardsRecorderReceiver,
+        blockstore: &Arc<Blockstore>,
+    ) -> Result<(), RecvTimeoutError> {
+        let (slot, rewards) = rewards_receiver.recv_timeout(Duration::from_secs(1))?;
+        let rpc_rewards = rewards
+            .into_iter()
+            .map(|(pubkey, lamports)| RpcReward {
+                pubkey: pubkey.to_string(),
+                lamports,
+            })
+            .collect();
+
+        blockstore
+            .write_rewards(slot, rpc_rewards)
+            .expect("Expect database write to succeed");
+        Ok(())
+    }
+
+    pub fn join(self) -> thread::Result<()> {
+        self.thread_hdl.join()
+    }
+}

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -9,6 +9,7 @@ use crate::{
     poh_recorder::PohRecorder,
     replay_stage::{ReplayStage, ReplayStageConfig},
     retransmit_stage::RetransmitStage,
+    rewards_recorder_service::RewardsRecorderSender,
     rpc_subscriptions::RpcSubscriptions,
     shred_fetch_stage::ShredFetchStage,
     sigverify_shreds::ShredSigVerifier,
@@ -86,6 +87,7 @@ impl Tvu {
         cfg: Option<Arc<AtomicBool>>,
         shred_version: u16,
         transaction_status_sender: Option<TransactionStatusSender>,
+        rewards_sender: Option<RewardsRecorderSender>,
     ) -> Self {
         let keypair: Arc<Keypair> = cluster_info
             .read()
@@ -170,6 +172,7 @@ impl Tvu {
             snapshot_package_sender,
             block_commitment_cache,
             transaction_status_sender,
+            rewards_sender,
         };
 
         let (replay_stage, root_bank_receiver) = ReplayStage::new(
@@ -311,6 +314,7 @@ pub mod tests {
             false,
             None,
             0,
+            None,
             None,
         );
         exit.store(true, Ordering::Relaxed);

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -8,6 +8,7 @@ use crate::{
     gossip_service::{discover_cluster, GossipService},
     poh_recorder::PohRecorder,
     poh_service::PohService,
+    rewards_recorder_service::RewardsRecorderService,
     rpc::JsonRpcConfig,
     rpc_pubsub_service::PubSubService,
     rpc_service::JsonRpcService,
@@ -120,6 +121,7 @@ pub struct Validator {
     validator_exit: Arc<RwLock<Option<ValidatorExit>>>,
     rpc_service: Option<(JsonRpcService, PubSubService)>,
     transaction_status_service: Option<TransactionStatusService>,
+    rewards_recorder_service: Option<RewardsRecorderService>,
     gossip_service: GossipService,
     poh_recorder: Arc<Mutex<PohRecorder>>,
     poh_service: PohService,
@@ -265,6 +267,21 @@ impl Validator {
                 (None, None)
             };
 
+        let (rewards_sender, rewards_recorder_service) =
+            if rpc_service.is_some() && !config.transaction_status_service_disabled {
+                let (rewards_sender, rewards_receiver) = unbounded();
+                (
+                    Some(rewards_sender),
+                    Some(RewardsRecorderService::new(
+                        rewards_receiver,
+                        blockstore.clone(),
+                        &exit,
+                    )),
+                )
+            } else {
+                (None, None)
+            };
+
         info!(
             "Starting PoH: epoch={} slot={} tick_height={} blockhash={} leader={:?}",
             bank.epoch(),
@@ -378,6 +395,7 @@ impl Validator {
             config.enable_partition.clone(),
             node.info.shred_version,
             transaction_status_sender.clone(),
+            rewards_sender,
         );
 
         if config.dev_sigverify_disabled {
@@ -405,6 +423,7 @@ impl Validator {
             gossip_service,
             rpc_service,
             transaction_status_service,
+            rewards_recorder_service,
             tpu,
             tvu,
             poh_service,
@@ -460,6 +479,10 @@ impl Validator {
         }
         if let Some(transaction_status_service) = self.transaction_status_service {
             transaction_status_service.join()?;
+        }
+
+        if let Some(rewards_recorder_service) = self.rewards_recorder_service {
+            rewards_recorder_service.join()?;
         }
 
         self.gossip_service.join()?;

--- a/programs/stake/src/stake_state.rs
+++ b/programs/stake/src/stake_state.rs
@@ -776,7 +776,7 @@ pub fn redeem_rewards(
     vote_account: &mut Account,
     point_value: f64,
     stake_history: Option<&StakeHistory>,
-) -> Result<u64, InstructionError> {
+) -> Result<(u64, u64), InstructionError> {
     if let StakeState::Stake(meta, mut stake) = stake_account.state()? {
         let vote_state = vote_account.state()?;
 
@@ -788,7 +788,7 @@ pub fn redeem_rewards(
 
             stake_account.set_state(&StakeState::Stake(meta, stake))?;
 
-            Ok(stakers_reward + voters_reward)
+            Ok((stakers_reward, voters_reward))
         } else {
             Err(StakeError::NoCreditsToRedeem.into())
         }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -333,6 +333,10 @@ pub struct Bank {
     /// Last time when the cluster info vote listener has synced with this bank
     #[serde(skip)]
     pub last_vote_sync: AtomicU64,
+
+    /// Rewards that were paid out immediately after this bank was created
+    #[serde(skip)]
+    pub rewards: Option<Vec<(Pubkey, i64)>>,
 }
 
 impl Default for BlockhashQueue {
@@ -429,6 +433,7 @@ impl Bank {
             entered_epoch_callback: parent.entered_epoch_callback.clone(),
             hard_forks: parent.hard_forks.clone(),
             last_vote_sync: AtomicU64::new(parent.last_vote_sync.load(Ordering::Relaxed)),
+            rewards: None,
         };
 
         datapoint_debug!(
@@ -614,15 +619,16 @@ impl Bank {
         //  years_elapsed =   slots_elapsed                               /  slots/year
         let period = self.epoch_schedule.get_slots_in_epoch(epoch) as f64 / self.slots_per_year;
 
-        let inflation = self.inflation.read().unwrap();
+        let (validator_rewards, storage_rewards) = {
+            let inflation = self.inflation.read().unwrap();
 
-        let validator_rewards =
-            (*inflation).validator(year) * self.capitalization() as f64 * period;
+            (
+                (*inflation).validator(year) * self.capitalization() as f64 * period,
+                (*inflation).storage(year) * self.capitalization() as f64 * period,
+            )
+        };
 
         let validator_points = self.stakes.write().unwrap().claim_points();
-
-        let storage_rewards = (*inflation).storage(year) * self.capitalization() as f64 * period;
-
         let storage_points = self.storage_accounts.write().unwrap().claim_points();
 
         let (validator_point_value, storage_point_value) = self.check_point_values(
@@ -634,7 +640,6 @@ impl Bank {
         });
 
         let validator_rewards = self.pay_validator_rewards(validator_point_value);
-
         self.capitalization.fetch_add(
             validator_rewards + storage_rewards as u64,
             Ordering::Relaxed,
@@ -643,9 +648,12 @@ impl Bank {
 
     /// iterate over all stakes, redeem vote credits for each stake we can
     ///   successfully load and parse, return total payout
-    fn pay_validator_rewards(&self, point_value: f64) -> u64 {
+    fn pay_validator_rewards(&mut self, point_value: f64) -> u64 {
         let stake_history = self.stakes.read().unwrap().history().clone();
-        self.stake_delegations()
+        let mut validator_rewards = HashMap::new();
+
+        let total_validator_rewards = self
+            .stake_delegations()
             .iter()
             .map(|(stake_pubkey, delegation)| {
                 match (
@@ -659,10 +667,22 @@ impl Bank {
                             point_value,
                             Some(&stake_history),
                         );
-                        if let Ok(rewards) = rewards {
+                        if let Ok((stakers_reward, voters_reward)) = rewards {
                             self.store_account(&stake_pubkey, &stake_account);
                             self.store_account(&delegation.voter_pubkey, &vote_account);
-                            rewards
+
+                            if voters_reward > 0 {
+                                *validator_rewards
+                                    .entry(delegation.voter_pubkey)
+                                    .or_insert(0i64) += voters_reward as i64;
+                            }
+
+                            if stakers_reward > 0 {
+                                *validator_rewards.entry(*stake_pubkey).or_insert(0i64) +=
+                                    stakers_reward as i64;
+                            }
+
+                            stakers_reward + voters_reward
                         } else {
                             debug!(
                                 "stake_state::redeem_rewards() failed for {}: {:?}",
@@ -674,7 +694,11 @@ impl Bank {
                     (_, _) => 0,
                 }
             })
-            .sum()
+            .sum();
+
+        assert_eq!(self.rewards, None);
+        self.rewards = Some(validator_rewards.drain().collect());
+        total_validator_rewards
     }
 
     pub fn update_recent_blockhashes(&self) {
@@ -2984,6 +3008,7 @@ mod tests {
             ..GenesisConfig::default()
         }));
         assert_eq!(bank.capitalization(), 42 * 1_000_000_000);
+        assert_eq!(bank.rewards, None);
 
         let ((vote_id, mut vote_account), (stake_id, stake_account)) =
             crate::stakes::tests::create_staked_node_accounts(1_0000);
@@ -3041,6 +3066,16 @@ mod tests {
                 - inflation as f64)
                 .abs()
                 < 1.0 // rounding, truncating
+        );
+
+        // verify validator rewards show up in bank1.rewards vector
+        // (currently storage rewards will not show up)
+        assert_eq!(
+            bank1.rewards,
+            Some(vec![(
+                stake_id,
+                (rewards.validator_point_value * validator_points as f64) as i64
+            )])
         );
     }
 


### PR DESCRIPTION
With the removal of the redeem-vote-credits instruction there's no mechanism to figure the vote and stake rewards that occur upon epoch boundaries.

To resolve this, the `getConfirmedBlock` JSON RPC API now includes a `rewards` array that contains all the account pubkey keys and corresponding lamport balance whenever a rewards payout occurs.  Note that for most slots this `rewards` array will be empty