### PR TITLE
Better surface bank hash verification failures

### DIFF
--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -375,7 +375,12 @@ impl Accounts {
     }
 
     pub fn verify_bank_hash(&self, slot: Slot, ancestors: &HashMap<Slot, usize>) -> bool {
-        self.accounts_db.verify_bank_hash(slot, ancestors).is_ok()
+        if let Err(err) = self.accounts_db.verify_bank_hash(slot, ancestors) {
+            warn!("verify_bank_hash failed: {:?}", err);
+            false
+        } else {
+            true
+        }
     }
 
     pub fn load_by_program(

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -1071,6 +1071,10 @@ impl AccountsDB {
             if calculated_hash == found_hash_info.hash {
                 Ok(())
             } else {
+                warn!(
+                    "mismatched bank hash for slot {}: {} (calculated) != {} (expected)",
+                    slot, calculated_hash, found_hash_info.hash
+                );
                 Err(MismatchedBankHash)
             }
         } else {


### PR DESCRIPTION
`.is_ok()` eats useful errors.  🙅‍♂ 

cc: #8130