### PR TITLE
Surface shred version more in tools

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -19,7 +19,6 @@ use crate::{
     tvu::{Sockets, Tvu},
 };
 use crossbeam_channel::unbounded;
-use solana_ledger::shred::Shred;
 use solana_ledger::{
     bank_forks::{BankForks, SnapshotConfig},
     bank_forks_utils,
@@ -28,13 +27,14 @@ use solana_ledger::{
     create_new_tmp_ledger,
     leader_schedule::FixedSchedule,
     leader_schedule_cache::LeaderScheduleCache,
+    shred_version::compute_shred_version,
 };
 use solana_metrics::datapoint_info;
-use solana_runtime::{bank::Bank, hard_forks::HardForks};
+use solana_runtime::bank::Bank;
 use solana_sdk::{
     clock::{Slot, DEFAULT_SLOTS_PER_TURN},
     genesis_config::GenesisConfig,
-    hash::{extend_and_hash, Hash},
+    hash::Hash,
     poh_config::PohConfig,
     pubkey::Pubkey,
     signature::{Keypair, KeypairUtil},
@@ -193,7 +193,7 @@ impl Validator {
 
         node.info.wallclock = timestamp();
         node.info.shred_version =
-            compute_shred_version(&genesis_hash, &bank.hard_forks().read().unwrap());
+            compute_shred_version(&genesis_hash, Some(&bank.hard_forks().read().unwrap()));
         Self::print_node_info(&node);
 
         if let Some(expected_shred_version) = config.expected_shred_version {
@@ -471,20 +471,6 @@ impl Validator {
     }
 }
 
-fn compute_shred_version(genesis_hash: &Hash, hard_forks: &HardForks) -> u16 {
-    use byteorder::{ByteOrder, LittleEndian};
-
-    let mut hash = *genesis_hash;
-    for (slot, count) in hard_forks.iter() {
-        let mut buf = [0u8; 16];
-        LittleEndian::write_u64(&mut buf[..8], *slot);
-        LittleEndian::write_u64(&mut buf[8..], *count as u64);
-        hash = extend_and_hash(&hash, &buf);
-    }
-
-    Shred::version_from_hash(&hash)
-}
-
 fn new_banks_from_blockstore(
     expected_genesis_hash: Option<Hash>,
     blockstore_path: &Path,
@@ -682,16 +668,6 @@ mod tests {
     use super::*;
     use crate::genesis_utils::create_genesis_config_with_leader;
     use std::fs::remove_dir_all;
-
-    #[test]
-    fn test_compute_shred_version() {
-        let mut hard_forks = HardForks::default();
-        assert_eq!(compute_shred_version(&Hash::default(), &hard_forks), 1);
-        hard_forks.register(1);
-        assert_eq!(compute_shred_version(&Hash::default(), &hard_forks), 55551);
-        hard_forks.register(1);
-        assert_eq!(compute_shred_version(&Hash::default(), &hard_forks), 46353);
-    }
 
     #[test]
     fn validator_exit() {

--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -7,7 +7,10 @@ use solana_clap_utils::{
     input_validators::{is_rfc3339_datetime, is_valid_percentage},
 };
 use solana_genesis::{genesis_accounts::add_genesis_accounts, Base64Account};
-use solana_ledger::{blockstore::create_new_ledger, poh::compute_hashes_per_tick};
+use solana_ledger::{
+    blockstore::create_new_ledger, poh::compute_hashes_per_tick,
+    shred_version::compute_shred_version,
+};
 use solana_sdk::{
     account::Account,
     clock,
@@ -521,10 +524,19 @@ fn main() -> Result<(), Box<dyn error::Error>> {
     create_new_ledger(&ledger_path, &genesis_config)?;
 
     println!(
-        "Genesis hash: {}\nCreation time: {}\nOperating mode: {:?}\nHashes per tick: {:?}\nSlots per epoch: {}\nCapitalization: {} SOL in {} accounts",
-        genesis_config.hash(),
+        "\
+         Creation time: {}\n\
+         Operating mode: {:?}\n\
+         Genesis hash: {}\n\
+         Shred version: {}\n\
+         Hashes per tick: {:?}\n\
+         Slots per epoch: {}\n\
+         Capitalization: {} SOL in {} accounts\
+         ",
         Utc.timestamp(genesis_config.creation_time, 0).to_rfc3339(),
         operating_mode,
+        genesis_config.hash(),
+        compute_shred_version(&genesis_config.hash(), None),
         genesis_config.poh_config.hashes_per_tick,
         slots_per_epoch,
         lamports_to_sol(
@@ -537,7 +549,8 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                     }
                     account.lamports
                 })
-                .sum::<u64>()),
+                .sum::<u64>()
+        ),
         genesis_config.accounts.len()
     );
 

--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -15,6 +15,7 @@ pub mod leader_schedule_utils;
 pub mod poh;
 pub mod rooted_slot_iterator;
 pub mod shred;
+pub mod shred_version;
 pub mod sigverify_shreds;
 pub mod snapshot_package;
 pub mod snapshot_utils;

--- a/ledger/src/shred_version.rs
+++ b/ledger/src/shred_version.rs
@@ -1,0 +1,44 @@
+use crate::shred::Shred;
+use solana_runtime::hard_forks::HardForks;
+use solana_sdk::hash::{extend_and_hash, Hash};
+
+pub fn compute_shred_version(genesis_hash: &Hash, hard_forks: Option<&HardForks>) -> u16 {
+    use byteorder::{ByteOrder, LittleEndian};
+
+    let mut hash = *genesis_hash;
+    if let Some(hard_forks) = hard_forks {
+        for (slot, count) in hard_forks.iter() {
+            let mut buf = [0u8; 16];
+            LittleEndian::write_u64(&mut buf[..8], *slot);
+            LittleEndian::write_u64(&mut buf[8..], *count as u64);
+            hash = extend_and_hash(&hash, &buf);
+        }
+    }
+
+    Shred::version_from_hash(&hash)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_compute_shred_version() {
+        assert_eq!(compute_shred_version(&Hash::default(), None), 1);
+        let mut hard_forks = HardForks::default();
+        assert_eq!(
+            compute_shred_version(&Hash::default(), Some(&hard_forks)),
+            1
+        );
+        hard_forks.register(1);
+        assert_eq!(
+            compute_shred_version(&Hash::default(), Some(&hard_forks)),
+            55551
+        );
+        hard_forks.register(1);
+        assert_eq!(
+            compute_shred_version(&Hash::default(), Some(&hard_forks)),
+            46353
+        );
+    }
+}


### PR DESCRIPTION
The shred version is becoming increasingly important, as multiple clusters can easily share the same gossip network.

* `solana-genesis` now emits the shred version in it's summary output
* `solana-ledger-tool create-snapshot` now emits the shred version in it's summary output
*  The new `solana-ledger-tool shred-version` command can be used to output the shred version of the given ledger.