### PR TITLE
[unimpl-ed] Show insufficient purge_zero_lamport_account logic

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -2127,6 +2127,57 @@ pub mod tests {
     }
 
     #[test]
+    fn test_accounts_purge_chained() {
+        solana_logger::setup();
+
+        let some_lamport = 223;
+        let zero_lamport = 0;
+        let dummy_lamport = 999;
+        let no_data = 0;
+        let owner = Account::default().owner;
+
+        let account = Account::new(some_lamport, no_data, &owner);
+        let account2 = Account::new(some_lamport + 100_001, no_data, &owner);
+        let account3 = Account::new(some_lamport + 100_002, no_data, &owner);
+        let zero_lamport_account = Account::new(zero_lamport, no_data, &owner);
+
+        let pubkey = Pubkey::new_rand();
+        let purged_pubkey1 = Pubkey::new_rand();
+        let purged_pubkey2 = Pubkey::new_rand();
+
+        let dummy_account = Account::new(dummy_lamport, no_data, &owner);
+        let dummy_pubkey = Pubkey::default();
+
+        let accounts = AccountsDB::new_single();
+
+        let mut current_slot = 1;
+        accounts.store(current_slot, &[(&pubkey, &account)]);
+        accounts.store(current_slot, &[(&purged_pubkey1, &account2)]);
+        accounts.add_root(current_slot);
+
+        current_slot += 1;
+        accounts.store(current_slot, &[(&purged_pubkey1, &zero_lamport_account)]);
+        accounts.store(current_slot, &[(&purged_pubkey2, &account3)]);
+        accounts.add_root(current_slot);
+
+        current_slot += 1;
+        accounts.store(current_slot, &[(&purged_pubkey2, &zero_lamport_account)]);
+        accounts.add_root(current_slot);
+
+        current_slot += 1;
+        accounts.store(current_slot, &[(&dummy_pubkey, &dummy_account)]);
+        accounts.add_root(current_slot);
+
+        purge_zero_lamport_accounts(&accounts, current_slot);
+        let accounts = reconstruct_accounts_db_via_serialization(&accounts, current_slot);
+
+        assert_load_account(&accounts, current_slot, pubkey, some_lamport);
+        assert_load_account(&accounts, current_slot, purged_pubkey1, 0);
+        assert_load_account(&accounts, current_slot, purged_pubkey2, 0);
+        assert_load_account(&accounts, current_slot, dummy_pubkey, dummy_lamport);
+    }
+
+    #[test]
     #[ignore]
     fn test_store_account_stress() {
         let slot_id = 42;


### PR DESCRIPTION
#### Problem

Finally, I found the root cause of #8130 ...:

(Moved from #8148's description)

Snapshot's actual content can become divert from the corresponding bank hash. Currently, `purge_zero_lamport_account` simply causes too-eager storage removals when zero lamport account updates are chained across 3+ slots (For exact situation, see a test).


```patch
--- /good-snapshot-pubkeys  2020-02-06 18:57:12.813230728 +0000
+++ /bad-snapshot-pubkeys  2020-02-06 18:57:12.813230728 +0000
@@ -179,6 +179,7 @@
 key: 4vgoKb76Z2vj9V9z7hoQpZkkwJrkL1z35LWNd9EXSi2o
 key: 4x5cmzjq7MBZG4KZjRQ2hepsWG1X9PvnJs1C2Q68PQmQ
 key: 4xARLQv1SoiVNbmXmVYyQzEjG3YA67X1LfH9KkTLtzKd
+key: 4ydifDThiWuVtzV92eNGiznuQAnTZtGkb9b2XQoMGAUn
 key: 4zAe2W9b3GmQKG2ZbinimDB7VgaNvfNoQDKdNKDiHuBU
 key: 4zoHsMTdhuDAkHAHNwEZqNqEmFyyqRxUxHwGuSdeepyB
 key: 52EW9njXGZzFduTLCZWfQNjPb8QMXgLZRWxEFCN3xaAx
```

=> This diff shows the bank hash mismatch is caused by the presence of `4ydifDThiWuVtzV92eNGiznuQAnTZtGkb9b2XQoMGAUn`

```
$ less good3.log | grep 4ydifDThiWuVtzV92eNGiznuQAnTZtGkb9b2XQoMGAUn 
[2020-02-06T06:14:58.602035261Z DEBUG solana_runtime::accounts_db] ryoqun: slot_id: 0, pubkey: (StoredMeta { write_version: 176, pubkey: 4ydifDThiWuVtzV92eNGiznuQAnTZtGkb9b2XQoMGAUn, data_len: 0 }, AccountInfo { store_id: 0, offset: 18168, lamports: 500000890880 })
[2020-02-06T06:15:02.010395039Z DEBUG solana_runtime::accounts_db] ryoqun: slot_id: 112211, pubkey: (StoredMeta { write_version: 8079864, pubkey: 4ydifDThiWuVtzV92eNGiznuQAnTZtGkb9b2XQoMGAUn, data_len: 0 }, AccountInfo { store_id: 432426, offset: 0, lamports: 499973176160 })
[2020-02-06T06:15:03.103655633Z DEBUG solana_runtime::accounts_db] ryoqun: slot_id: 125761, pubkey: (StoredMeta { write_version: 9075320, pubkey: 4ydifDThiWuVtzV92eNGiznuQAnTZtGkb9b2XQoMGAUn, data_len: 0 }, AccountInfo { store_id: 484959, offset: 408, lamports: 499973176147 })
[2020-02-06T06:15:03.411181688Z DEBUG solana_runtime::accounts_db] ryoqun: slot_id: 136455, pubkey: (StoredMeta { write_version: 9867711, pubkey: 4ydifDThiWuVtzV92eNGiznuQAnTZtGkb9b2XQoMGAUn, data_len: 0 }, AccountInfo { store_id: 526476, offset: 22152, lamports: 973176143 })
[2020-02-06T06:15:03.439180800Z DEBUG solana_runtime::accounts_db] ryoqun: slot_id: 136546, pubkey: (StoredMeta { write_version: 9874694, pubkey: 4ydifDThiWuVtzV92eNGiznuQAnTZtGkb9b2XQoMGAUn, data_len: 0 }, AccountInfo { store_id: 526846, offset: 22152, lamports: 0 })
$ less bad3.log | grep 4ydifDThiWuVtzV92eNGiznuQAnTZtGkb9b2XQoMGAUn 
[2020-02-06T06:10:31.668645696Z DEBUG solana_runtime::accounts_db] ryoqun: slot_id: 0, pubkey: (StoredMeta { write_version: 176, pubkey: 4ydifDThiWuVtzV92eNGiznuQAnTZtGkb9b2XQoMGAUn, data_len: 0 }, AccountInfo { store_id: 2, offset: 8144, lamports: 500000890880 })
[2020-02-06T06:10:34.653084054Z DEBUG solana_runtime::accounts_db] ryoqun: slot_id: 112211, pubkey: (StoredMeta { write_version: 8076459, pubkey: 4ydifDThiWuVtzV92eNGiznuQAnTZtGkb9b2XQoMGAUn, data_len: 0 }, AccountInfo { store_id: 427648, offset: 29168, lamports: 499973176160 })
[2020-02-06T06:10:35.794195861Z DEBUG solana_runtime::accounts_db] ryoqun: slot_id: 125761, pubkey: (StoredMeta { write_version: 9071781, pubkey: 4ydifDThiWuVtzV92eNGiznuQAnTZtGkb9b2XQoMGAUn, data_len: 0 }, AccountInfo { store_id: 479476, offset: 136, lamports: 499973176147 })
[2020-02-06T06:10:39.134235318Z DEBUG solana_runtime::accounts_db] xoring.. account: Account { lamports: 499973176147 data.len: 0 owner: 11111111111111111111111111111111 executable: false rent_epoch: 12 hash: 8Mvx4iidAhxWNAhuUU2vFt5RLGdXdJdaRCFM1By7nPPM } slot: 125761, BankHash 6d5e6ce8b914d18c0e775feac5f20c08b60b0940b12d0867d8c4ebe8cebd4310 key: 4ydifDThiWuVtzV92eNGiznuQAnTZtGkb9b2XQoMGAUn

```

=> This shows bad snapshot doesn't contain some updates of `4ydifDThiWuVtzV92eNGiznuQAnTZtGkb9b2XQoMGAUn`, which should have occurred at slot 136455 and 136546. To be specific,  136546 removed the account itself. However, that update doesn't exist in the bad snapshot. That's why that account appears in the bank hash calculation.


```
$ grep -E '125761|136455|136546' bad-files good-files 
bad-files:-rw-r--r-- solanad/solanad 4194304 2020-02-05 07:01 accounts/125761.479477
bad-files:-rw-r--r-- solanad/solanad 4194304 2020-02-05 07:01 accounts/125761.479479
bad-files:-rw-r--r-- solanad/solanad 4194304 2020-02-05 07:01 accounts/125761.479475
bad-files:-rw-r--r-- solanad/solanad 4194304 2020-02-05 07:01 accounts/125761.479476
bad-files:-rw-r--r-- solanad/solanad 4194304 2020-02-05 07:01 accounts/125761.479478
good-files:-rw-r--r-- mvines/mvines 4194304 2020-02-06 01:16 accounts/136546.526849
good-files:-rw-r--r-- mvines/mvines 4194304 2020-02-06 01:18 accounts/136455.526480
good-files:-rw-r--r-- mvines/mvines 4194304 2020-02-06 01:19 accounts/125761.484960
good-files:-rw-r--r-- mvines/mvines 4194304 2020-02-06 01:16 accounts/136546.526848
good-files:-rw-r--r-- mvines/mvines 4194304 2020-02-06 01:18 accounts/136455.526479
good-files:-rw-r--r-- mvines/mvines 4194304 2020-02-06 01:16 accounts/136546.526846
good-files:-rw-r--r-- mvines/mvines 4194304 2020-02-06 01:19 accounts/125761.484959
good-files:-rw-r--r-- mvines/mvines 4194304 2020-02-06 01:18 accounts/136455.526478
good-files:-rw-r--r-- mvines/mvines 4194304 2020-02-06 01:19 accounts/125761.484958
good-files:-rw-r--r-- mvines/mvines 4194304 2020-02-06 01:16 accounts/136546.526851
good-files:-rw-r--r-- mvines/mvines 4194304 2020-02-06 01:16 accounts/136546.526850
good-files:-rw-r--r-- mvines/mvines 4194304 2020-02-06 01:19 accounts/125761.484962
good-files:-rw-r--r-- mvines/mvines 4194304 2020-02-06 01:18 accounts/136455.526476
good-files:-rw-r--r-- mvines/mvines 4194304 2020-02-06 01:18 accounts/136455.526477
good-files:-rw-r--r-- mvines/mvines 4194304 2020-02-06 01:19 accounts/125761.484961
good-files:-rw-r--r-- mvines/mvines 4194304 2020-02-06 01:16 accounts/136546.526847
```

=> This shows bad snapshot actually doesn't contain any storage entries for such slots first of all.


##### <a id="new-conclusive-findings">**New conclusive findings**</a>

We can confirm this is really what happened on the bad-behaving TdS validator:

Firstly, relevant slots for `4ydifDThiWuVtzV92eNGiznuQAnTZtGkb9b2XQoMGAUn` account updates are 136546, 136455 and 125761. 136455 is innocent slot which contains no zero lamport accounts and can be reclaimed normally. 136546 is the slot which contains the should-be-kept zero lamport account update (See above). 125761 is the slot which contained the reappeared old and bad account state. So we can say 136546 is chaining to 125761 via a zero lamport account update.

And there is another zero lamport account update in 125761:

```
[2020-02-06T06:15:03.103895475Z DEBUG solana_runtime::accounts_db] ryoqun: slot_id: 125761, pubkey: (StoredMeta { write_version: 9075321, pubkey: Ag51oCkwGy5rkbGEYrcP9GDjvFGMJrEdLxvedLSTSR15, data_len: 0 }, AccountInfo { store_id: 484959, offset: 544, lamports: 0 })
```

So, 125761 is definitely chaining to an older storage entry. This satisfies this bug's condition.

Remaining question is why this isn't deterministic and not cluster-wide. However, #8148 can partly explain this because that causes some not-deterministic behavior in validators.


#### Summary of Changes

Only add a test showing the bad behavior because I need [some confirmation for the further direction](https://github.com/solana-labs/solana/pull/8176#discussion_r376724915).

Fixes #8130