### PR TITLE
Verify frozen bank from snapshot by hashing

### DIFF
--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -374,6 +374,7 @@ impl Accounts {
         })
     }
 
+    #[must_use]
     pub fn verify_bank_hash(&self, slot: Slot, ancestors: &HashMap<Slot, usize>) -> bool {
         if let Err(err) = self.accounts_db.verify_bank_hash(slot, ancestors) {
             warn!("verify_bank_hash failed: {:?}", err);


### PR DESCRIPTION
#### Problem

The actually recorded frozen hash of the bank in a snapshot isn't verified. It seems that it's lacking simply because of unintentional omission like #7559.

#### Summary of Changes

Just start to verify it.

Also, this is the base of the upcoming PR of more exhaustive protection for various bank fields. Currently, there are numerous unprotected fields, which could result in accepting tampered snapshot with unpredictable future behavior.

Part of #7167
