### PR TITLE
Fix recv_from allocating unnecessary memory

### DIFF
--- a/core/src/retransmit_stage.rs
+++ b/core/src/retransmit_stage.rs
@@ -331,7 +331,7 @@ mod tests {
         // it should send this over the sockets.
         retransmit_sender.send(packets).unwrap();
         let mut packets = Packets::new(vec![]);
-        packet::recv_from(&mut packets, &me_retransmit).unwrap();
+        packet::recv_from(&mut packets, &me_retransmit, 1).unwrap();
         assert_eq!(packets.packets.len(), 1);
         assert_eq!(packets.packets[0].meta.repair, false);
 
@@ -347,7 +347,7 @@ mod tests {
         let packets = Packets::new(vec![repair, Packet::default()]);
         retransmit_sender.send(packets).unwrap();
         let mut packets = Packets::new(vec![]);
-        packet::recv_from(&mut packets, &me_retransmit).unwrap();
+        packet::recv_from(&mut packets, &me_retransmit, 1).unwrap();
         assert_eq!(packets.packets.len(), 1);
         assert_eq!(packets.packets[0].meta.repair, false);
     }

--- a/core/src/streamer.rs
+++ b/core/src/streamer.rs
@@ -49,7 +49,7 @@ fn recv_loop(
             if exit.load(Ordering::Relaxed) {
                 return Ok(());
             }
-            if let Ok(len) = packet::recv_from(&mut msgs, sock) {
+            if let Ok(len) = packet::recv_from(&mut msgs, sock, 1) {
                 if len == NUM_RCVMMSGS {
                     num_max_received += 1;
                 }

--- a/perf/src/cuda_runtime.rs
+++ b/perf/src/cuda_runtime.rs
@@ -151,6 +151,10 @@ impl<T: Clone + Default + Sized> PinnedVec<T> {
     pub fn iter_mut(&mut self) -> PinnedIterMut<T> {
         PinnedIterMut(self.x.iter_mut())
     }
+
+    pub fn capacity(&self) -> usize {
+        self.x.capacity()
+    }
 }
 
 impl<'a, T: Clone + Send + Sync + Default + Sized> IntoParallelIterator for &'a PinnedVec<T> {


### PR DESCRIPTION
#### Problem
recv_from() can allocate more memory in the Packets buffer than it needs

#### Summary of Changes
Make sure recv_from() doesn't allocate more than `PACKETS_PER_BATCH` number of packets

Fixes #
