### PR TITLE
CLI: Don't hide errors when fees are disabled

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -806,12 +806,11 @@ fn check_account_for_multiple_fees(
 ) -> Result<(), Box<dyn error::Error>> {
     let balance = rpc_client.retry_get_balance(account_pubkey, 5)?;
     if let Some(lamports) = balance {
-        if lamports
-            >= messages
-                .iter()
-                .map(|message| fee_calculator.calculate_fee(message))
-                .sum()
-        {
+        let fee = messages
+            .iter()
+            .map(|message| fee_calculator.calculate_fee(message))
+            .sum();
+        if lamports != 0 && lamports >= fee {
             return Ok(());
         }
     }

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -3198,7 +3198,6 @@ mod tests {
         };
         assert!(process_command(&config).is_ok());
 
-        config.rpc_client = Some(RpcClient::new_mock("airdrop".to_string()));
         config.command = CliCommand::TimeElapsed(bob_pubkey, process_id, dt);
         let signature = process_command(&config);
         assert_eq!(signature.unwrap(), SIGNATURE.to_string());

--- a/client/src/mock_rpc_client_request.rs
+++ b/client/src/mock_rpc_client_request.rs
@@ -60,13 +60,10 @@ impl GenericRpcClientRequest for MockRpcClientRequest {
                     Value::Null
                 }
             }
-            RpcRequest::GetBalance => {
-                let n = if self.url == "airdrop" { 0 } else { 50 };
-                serde_json::to_value(Response {
-                    context: RpcResponseContext { slot: 1 },
-                    value: Value::Number(Number::from(n)),
-                })?
-            }
+            RpcRequest::GetBalance => serde_json::to_value(Response {
+                context: RpcResponseContext { slot: 1 },
+                value: Value::Number(Number::from(50)),
+            })?,
             RpcRequest::GetRecentBlockhash => serde_json::to_value(Response {
                 context: RpcResponseContext { slot: 1 },
                 value: (


### PR DESCRIPTION
#### Problem

The CLI fee account balance pre-check succeeds when a non-existent account is specified and the cluster has fees disabled because `0 == 0`. Leads to tests passing that should fail, ala #8198. 

#### Summary of Changes

Explicitly reject a zero-balance