### PR TITLE
feat: implement websocket_url as get/set-able global parameter

### DIFF
--- a/cli-config/src/config.rs
+++ b/cli-config/src/config.rs
@@ -18,13 +18,15 @@ lazy_static! {
 #[derive(Serialize, Deserialize, Default, Debug, PartialEq)]
 pub struct Config {
     pub url: String,
+    pub websocket_url: String,
     pub keypair_path: String,
 }
 
 impl Config {
-    pub fn new(url: &str, keypair_path: &str) -> Self {
+    pub fn new(url: &str, websocket_url: &str, keypair_path: &str) -> Self {
         Self {
             url: url.to_string(),
+            websocket_url: websocket_url.to_string(),
             keypair_path: keypair_path.to_string(),
         }
     }

--- a/cli/src/display.rs
+++ b/cli/src/display.rs
@@ -1,3 +1,4 @@
+use crate::cli::SettingType;
 use console::style;
 use solana_sdk::transaction::Transaction;
 
@@ -11,17 +12,19 @@ pub fn println_name_value(name: &str, value: &str) {
     println!("{} {}", style(name).bold(), styled_value);
 }
 
-pub fn println_name_value_or(name: &str, value: &str, default_value: &str) {
-    if value == "" {
-        println!(
-            "{} {} {}",
-            style(name).bold(),
-            style(default_value),
-            style("(default)").italic()
-        );
-    } else {
-        println!("{} {}", style(name).bold(), style(value));
+pub fn println_name_value_or(name: &str, value: &str, setting_type: SettingType) {
+    let description = match setting_type {
+        SettingType::Explicit => "",
+        SettingType::Computed => "(computed)",
+        SettingType::SystemDefault => "(default)",
     };
+
+    println!(
+        "{} {} {}",
+        style(name).bold(),
+        style(value),
+        style(description).italic(),
+    );
 }
 
 pub fn println_signers(tx: &Transaction) {


### PR DESCRIPTION
#### Problem

The current product makes it harder than necessary to run `live-slots` because
the WebSocket URL isn't persisted to config.yml.

#### Summary of Changes

* Plumb `websocket_url` through the YAML
* Minor cosmetic change: show both old and new slot info when root delta changes

Fixes #8188 
