### PR TITLE
Add method to sign raw data, enabling easier device app testing

### DIFF
--- a/remote-wallet/src/ledger.rs
+++ b/remote-wallet/src/ledger.rs
@@ -236,10 +236,10 @@ impl LedgerWallet {
 
     pub fn sign_raw_data(
         &self,
-        derivation: &DerivationPath,
+        derivation_path: &DerivationPath,
         data: &[u8],
     ) -> Result<Vec<u8>, RemoteWalletError> {
-        let mut payload = get_derivation_path(&derivation);
+        let mut payload = extend_and_serialize(&derivation_path);
         for byte in (data.len() as u16).to_be_bytes().iter() {
             payload.push(*byte);
         }
@@ -278,8 +278,8 @@ impl RemoteWallet for LedgerWallet {
             })
     }
 
-    fn get_pubkey(&self, derivation: &DerivationPath) -> Result<Pubkey, RemoteWalletError> {
-        let derivation_path = get_derivation_path(derivation);
+    fn get_pubkey(&self, derivation_path: &DerivationPath) -> Result<Pubkey, RemoteWalletError> {
+        let derivation_path = extend_and_serialize(derivation_path);
 
         let key = self.send_apdu(
             commands::GET_SOL_PUBKEY,
@@ -295,10 +295,10 @@ impl RemoteWallet for LedgerWallet {
 
     fn sign_transaction(
         &self,
-        derivation: &DerivationPath,
+        derivation_path: &DerivationPath,
         transaction: Transaction,
     ) -> Result<Signature, RemoteWalletError> {
-        let mut payload = get_derivation_path(derivation);
+        let mut payload = extend_and_serialize(derivation_path);
         let mut data = transaction.message_data();
         if data.len() > u16::max_value() as usize {
             return Err(RemoteWalletError::InvalidInput(
@@ -334,13 +334,17 @@ pub fn is_valid_ledger(vendor_id: u16, product_id: u16) -> bool {
 }
 
 /// Build the derivation path byte array from a DerivationPath selection
-fn get_derivation_path(derivation: &DerivationPath) -> Vec<u8> {
-    let byte = if derivation.change.is_some() { 4 } else { 3 };
+fn extend_and_serialize(derivation_path: &DerivationPath) -> Vec<u8> {
+    let byte = if derivation_path.change.is_some() {
+        4
+    } else {
+        3
+    };
     let mut concat_derivation = vec![byte];
     concat_derivation.extend_from_slice(&SOL_DERIVATION_PATH_BE);
     concat_derivation.extend_from_slice(&[0x80, 0]);
-    concat_derivation.extend_from_slice(&derivation.account.to_be_bytes());
-    if let Some(change) = derivation.change {
+    concat_derivation.extend_from_slice(&derivation_path.account.to_be_bytes());
+    if let Some(change) = derivation_path.change {
         concat_derivation.extend_from_slice(&[0x80, 0]);
         concat_derivation.extend_from_slice(&change.to_be_bytes());
     }

--- a/remote-wallet/src/ledger.rs
+++ b/remote-wallet/src/ledger.rs
@@ -233,6 +233,19 @@ impl LedgerWallet {
             ver[3].into(),
         ))
     }
+
+    pub fn sign_raw_data(
+        &self,
+        derivation: &DerivationPath,
+        data: &[u8],
+    ) -> Result<Vec<u8>, RemoteWalletError> {
+        let mut payload = get_derivation_path(&derivation);
+        for byte in (data.len() as u16).to_be_bytes().iter() {
+            payload.push(*byte);
+        }
+        payload.extend_from_slice(data);
+        self.send_apdu(0x03, 1, 0, &payload)
+    }
 }
 
 impl RemoteWallet for LedgerWallet {

--- a/remote-wallet/src/remote_wallet.rs
+++ b/remote-wallet/src/remote_wallet.rs
@@ -153,12 +153,12 @@ pub trait RemoteWallet {
     ) -> Result<RemoteWalletInfo, RemoteWalletError>;
 
     /// Get solana pubkey from a RemoteWallet
-    fn get_pubkey(&self, derivation: &DerivationPath) -> Result<Pubkey, RemoteWalletError>;
+    fn get_pubkey(&self, derivation_path: &DerivationPath) -> Result<Pubkey, RemoteWalletError>;
 
     /// Sign transaction data with wallet managing pubkey at derivation path m/44'/501'/<account>'/<change>'.
     fn sign_transaction(
         &self,
-        derivation: &DerivationPath,
+        derivation_path: &DerivationPath,
         transaction: Transaction,
     ) -> Result<Signature, RemoteWalletError>;
 }


### PR DESCRIPTION
#### Problem
Currently, the ledger-solana-app signs data blindly, which means a Ledger can successfully sign random (non-transaction) data. This is useful for testing device and transport configuration (data length limits, etc), but there is no public api available to take advantage of this functionality.

#### Summary of Changes
Add `sign_raw_data` method. This will be deprecated or updated to use a different command number in the future, once on-device message parsing lands.