### PR TITLE
Rename from account userdata to data

### DIFF
--- a/book/src/implemented-proposals/installer.md
+++ b/book/src/implemented-proposals/installer.md
@@ -77,7 +77,7 @@ pub struct UpdateManifest {
     pub download_sha256: String, // SHA256 digest of the release tar.bz2 file
 }
 
-/// Userdata of an Update Manifest program Account.
+/// Data of an Update Manifest program Account.
 #[derive(Serialize, Deserialize, Default, Debug, PartialEq)]
 pub struct SignedUpdateManifest {
     pub manifest: UpdateManifest,

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -53,7 +53,7 @@ use std::{
     {error, fmt},
 };
 
-const USERDATA_CHUNK_SIZE: usize = 229; // Keep program chunks under PACKET_DATA_SIZE
+const DATA_CHUNK_SIZE: usize = 229; // Keep program chunks under PACKET_DATA_SIZE
 
 pub const FEE_PAYER_ARG: ArgConstant<'static> = ArgConstant {
     name: "fee_payer",
@@ -1046,13 +1046,13 @@ fn process_deploy(
     messages.push(&create_account_tx.message);
     let signers = [&config.keypair, &program_id];
     let write_transactions: Vec<_> = program_data
-        .chunks(USERDATA_CHUNK_SIZE)
+        .chunks(DATA_CHUNK_SIZE)
         .zip(0..)
         .map(|(chunk, i)| {
             let instruction = loader_instruction::write(
                 &program_id.pubkey(),
                 &bpf_loader::id(),
-                (i * USERDATA_CHUNK_SIZE) as u32,
+                (i * DATA_CHUNK_SIZE) as u32,
                 chunk.to_vec(),
             );
             let message = Message::new_with_payer(vec![instruction], Some(&signers[0].pubkey()));

--- a/install/src/update_manifest.rs
+++ b/install/src/update_manifest.rs
@@ -15,7 +15,7 @@ pub struct UpdateManifest {
     pub download_sha256: Hash, // SHA256 digest of the release tar.bz2 file
 }
 
-/// Userdata of an Update Manifest program Account.
+/// Data of an Update Manifest program Account.
 #[derive(Serialize, Deserialize, Default, Debug, PartialEq)]
 pub struct SignedUpdateManifest {
     pub manifest: UpdateManifest,

--- a/programs/bpf/c/src/dup_accounts/dup_accounts.c
+++ b/programs/bpf/c/src/dup_accounts/dup_accounts.c
@@ -18,17 +18,17 @@ extern uint64_t entrypoint(const uint8_t *input) {
 
   switch (params.data[0]) {
     case(1):
-        sol_log("modify first account userdata");
-        ka[2].userdata[0] = 1;
+        sol_log("modify first account data");
+        ka[2].data[0] = 1;
         break;
     case(2):
-        sol_log("modify first account userdata");
-        ka[3].userdata[0] = 2;
+        sol_log("modify first account data");
+        ka[3].data[0] = 2;
         break;
     case(3):
-        sol_log("modify both account userdata");
-        ka[2].userdata[0] += 1;
-        ka[3].userdata[0] += 2;
+        sol_log("modify both account data");
+        ka[2].data[0] += 1;
+        ka[3].data[0] += 2;
         break;
     case(4):
         sol_log("modify first account lamports");

--- a/programs/btc_spv/src/spv_state.rs
+++ b/programs/btc_spv/src/spv_state.rs
@@ -386,7 +386,7 @@ pub enum AccountState {
     Verification(Proof),
     // Account holds a HeaderStore structure
     Headers(HeaderAccountInfo),
-    // Account's userdata is Unallocated
+    // Account's data is Unallocated
     Unallocated,
     // Invalid
     Invalid,

--- a/programs/exchange/src/exchange_state.rs
+++ b/programs/exchange/src/exchange_state.rs
@@ -211,7 +211,7 @@ pub fn check_trade(side: OrderSide, tokens: u64, price: u64) -> Result<(), Excha
 /// Type of exchange account, account's user data is populated with this enum
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub enum ExchangeState {
-    /// Account's Userdata is unallocated
+    /// Account's data is unallocated
     Unallocated,
     // Token account
     Account(TokenAccountInfo),

--- a/sdk/bpf/c/inc/solana_sdk.h
+++ b/sdk/bpf/c/inc/solana_sdk.h
@@ -169,13 +169,13 @@ SOL_FN_PREFIX bool SolPubkey_same(const SolPubkey *one, const SolPubkey *two) {
  * Keyed Account
  */
 typedef struct {
-  SolPubkey *key;        /** Public key of the account */
-  bool is_signer;        /** Transaction was signed by this account's key? */
-  bool is_writable;      /** Is the account writable? */
-  uint64_t *lamports;    /** Number of lamports owned by this account */
-  uint64_t userdata_len; /** Length of data in bytes */
-  uint8_t *userdata;     /** On-chain data within this account */
-  SolPubkey *owner;      /** Program that owns this account */
+  SolPubkey *key;      /** Public key of the account */
+  bool is_signer;      /** Transaction was signed by this account's key? */
+  bool is_writable;    /** Is the account writable? */
+  uint64_t *lamports;  /** Number of lamports owned by this account */
+  uint64_t data_len;   /** Length of data in bytes */
+  uint8_t *data;       /** On-chain data within this account */
+  SolPubkey *owner;    /** Program that owns this account */
 } SolKeyedAccount;
 
 /**
@@ -233,7 +233,7 @@ SOL_FN_PREFIX size_t sol_strlen(const char *s) {
  * Panics
  *
  * Prints the line number where the panic occurred and then causes
- * the BPF VM to immediately halt execution. No accounts' userdata are updated
+ * the BPF VM to immediately halt execution. No accounts' data are updated
  */
 void sol_panic_(const char *, uint64_t, uint64_t, uint64_t);
 #define sol_panic() sol_panic_(__FILE__, sizeof(__FILE__), __LINE__, 0)
@@ -306,11 +306,11 @@ SOL_FN_PREFIX bool sol_deserialize(
       params->ka[i].lamports = (uint64_t *) input;
       input += sizeof(uint64_t);
 
-      // account userdata
-      params->ka[i].userdata_len = *(uint64_t *) input;
+      // account data
+      params->ka[i].data_len = *(uint64_t *) input;
       input += sizeof(uint64_t);
-      params->ka[i].userdata = (uint8_t *) input;
-      input += params->ka[i].userdata_len;
+      params->ka[i].data = (uint8_t *) input;
+      input += params->ka[i].data_len;
 
       // owner
       params->ka[i].owner = (SolPubkey *) input;
@@ -319,8 +319,8 @@ SOL_FN_PREFIX bool sol_deserialize(
       params->ka[i].is_signer = params->ka[dup_info].is_signer;
       params->ka[i].key = params->ka[dup_info].key;
       params->ka[i].lamports = params->ka[dup_info].lamports;
-      params->ka[i].userdata_len = params->ka[dup_info].userdata_len;
-      params->ka[i].userdata = params->ka[dup_info].userdata;
+      params->ka[i].data_len = params->ka[dup_info].data_len;
+      params->ka[i].data = params->ka[dup_info].data;
       params->ka[i].owner = params->ka[dup_info].owner;
     }
   }
@@ -383,8 +383,8 @@ SOL_FN_PREFIX void sol_log_params(const SolParameters *params) {
     sol_log_key(params->ka[i].key);
     sol_log("  - Lamports");
     sol_log_64(0, 0, 0, 0, *params->ka[i].lamports);
-    sol_log("  - Userdata");
-    sol_log_array(params->ka[i].userdata, params->ka[i].userdata_len);
+    sol_log("  - data");
+    sol_log_array(params->ka[i].data, params->ka[i].data_len);
     sol_log("  - Owner");
     sol_log_key(params->ka[i].owner);
   }


### PR DESCRIPTION
#### Problem

Account data sometimes referred to or named `userdata`

#### Summary of Changes

Use 'data' instead

Fixes #
