### PR TITLE
The getConfirmedBlock RPC API is now disabled by default

### DIFF
--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -87,7 +87,7 @@ impl Tvu {
         cfg: Option<Arc<AtomicBool>>,
         shred_version: u16,
         transaction_status_sender: Option<TransactionStatusSender>,
-        rewards_sender: Option<RewardsRecorderSender>,
+        rewards_recorder_sender: Option<RewardsRecorderSender>,
     ) -> Self {
         let keypair: Arc<Keypair> = cluster_info
             .read()
@@ -172,7 +172,7 @@ impl Tvu {
             snapshot_package_sender,
             block_commitment_cache,
             transaction_status_sender,
-            rewards_sender,
+            rewards_recorder_sender,
         };
 
         let (replay_stage, root_bank_receiver) = ReplayStage::new(

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -211,7 +211,6 @@ impl LocalCluster {
             leader_node.info.rpc.port(),
             leader_node.info.rpc_pubsub.port(),
         ));
-        leader_config.transaction_status_service_disabled = true;
         let leader_server = Validator::new(
             leader_node,
             &leader_keypair,
@@ -359,7 +358,6 @@ impl LocalCluster {
             validator_node.info.rpc.port(),
             validator_node.info.rpc_pubsub.port(),
         ));
-        config.transaction_status_service_disabled = true;
         let voting_keypair = Arc::new(voting_keypair);
         let validator_server = Validator::new(
             validator_node,
@@ -668,9 +666,6 @@ impl Cluster for LocalCluster {
         cluster_validator_info.info.contact_info = node.info.clone();
         cluster_validator_info.config.rpc_ports =
             Some((node.info.rpc.port(), node.info.rpc_pubsub.port()));
-        cluster_validator_info
-            .config
-            .transaction_status_service_disabled = true;
 
         let entry_point_info = {
             if *pubkey == self.entry_point_info.id {

--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -285,6 +285,7 @@ EOF
         --blockstream /tmp/solana-blockstream.sock
         --no-voting
         --dev-no-sigverify
+        --enable-rpc-get-confirmed-block
       )
     else
       args+=(--enable-rpc-exit)

--- a/run.sh
+++ b/run.sh
@@ -112,6 +112,7 @@ args=(
   --rpc-faucet-address 127.0.0.1:9900
   --log -
   --enable-rpc-exit
+  --enable-rpc-get-confirmed-block
   --init-complete-file "$dataDir"/init-completed
 )
 if [[ -n $blockstreamSocket ]]; then

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -508,6 +508,12 @@ pub fn main() {
                 .help("Enable the JSON RPC 'validatorExit' API.  Only enable in a debug environment"),
         )
         .arg(
+            Arg::with_name("enable_rpc_get_confirmed_block")
+                .long("enable-rpc-get-confirmed-block")
+                .takes_value(false)
+                .help("Enable the JSON RPC 'getConfirmedBlock' API.  This will cause an increase in disk usage and IOPS"),
+        )
+        .arg(
             Arg::with_name("rpc_faucet_addr")
                 .long("rpc-faucet-address")
                 .value_name("HOST:PORT")
@@ -684,6 +690,7 @@ pub fn main() {
         new_hard_forks: hardforks_of(&matches, "hard_forks"),
         rpc_config: JsonRpcConfig {
             enable_validator_exit: matches.is_present("enable_rpc_exit"),
+            enable_get_confirmed_block: matches.is_present("enable_rpc_get_confirmed_block"),
             faucet_addr: matches.value_of("rpc_faucet_addr").map(|address| {
                 solana_net_utils::parse_host_port(address).expect("failed to parse faucet address")
             }),


### PR DESCRIPTION
The --enable-rpc-get-confirmed-block flag allows validators to opt-in to
the higher disk usage and IOPS.

<s>
#### Problem

#### Summary of Changes

Fixes #
</s>