### PR TITLE
Move Keypair::new to a utility function

### DIFF
--- a/bench-exchange/src/bench.rs
+++ b/bench-exchange/src/bench.rs
@@ -15,7 +15,7 @@ use solana_sdk::{
     client::{Client, SyncClient},
     commitment_config::CommitmentConfig,
     pubkey::Pubkey,
-    signature::{Keypair, KeypairUtil},
+    signature::{generate_keypair, Keypair, KeypairUtil},
     timing::{duration_as_ms, duration_as_s},
     transaction::Transaction,
     {system_instruction, system_program},
@@ -63,7 +63,7 @@ pub struct Config {
 impl Default for Config {
     fn default() -> Self {
         Self {
-            identity: Keypair::new(),
+            identity: generate_keypair(),
             threads: 4,
             duration: Duration::new(u64::max_value(), 0),
             transfer_delay: 0,
@@ -963,7 +963,7 @@ fn compute_and_report_stats(maxes: &Arc<RwLock<Vec<(String, SampleStats)>>>, tot
 
 fn generate_keypairs(num: u64) -> Vec<Keypair> {
     let mut seed = [0_u8; 32];
-    seed.copy_from_slice(&Keypair::new().pubkey().as_ref());
+    seed.copy_from_slice(&generate_keypair().pubkey().as_ref());
     let mut rnd = GenKeys::new(seed);
     rnd.gen_n_keypairs(num)
 }

--- a/bench-exchange/src/cli.rs
+++ b/bench-exchange/src/cli.rs
@@ -1,7 +1,7 @@
 use clap::{crate_description, crate_name, value_t, App, Arg, ArgMatches};
 use solana_core::gen_keys::GenKeys;
 use solana_faucet::faucet::FAUCET_PORT;
-use solana_sdk::signature::{read_keypair_file, Keypair, KeypairUtil};
+use solana_sdk::signature::{generate_keypair, read_keypair_file, Keypair};
 use std::net::SocketAddr;
 use std::process::exit;
 use std::time::Duration;
@@ -28,7 +28,7 @@ impl Default for Config {
         Self {
             entrypoint_addr: SocketAddr::from(([127, 0, 0, 1], 8001)),
             faucet_addr: SocketAddr::from(([127, 0, 0, 1], FAUCET_PORT)),
-            identity: Keypair::new(),
+            identity: generate_keypair(),
             num_nodes: 1,
             threads: 4,
             duration: Duration::new(u64::max_value(), 0),

--- a/bench-exchange/tests/bench_exchange.rs
+++ b/bench-exchange/tests/bench_exchange.rs
@@ -10,7 +10,7 @@ use solana_local_cluster::local_cluster::{ClusterConfig, LocalCluster};
 use solana_runtime::bank::Bank;
 use solana_runtime::bank_client::BankClient;
 use solana_sdk::genesis_config::create_genesis_config;
-use solana_sdk::signature::{Keypair, KeypairUtil};
+use solana_sdk::signature::{generate_keypair, KeypairUtil};
 use std::process::exit;
 use std::sync::mpsc::channel;
 use std::time::Duration;
@@ -23,7 +23,7 @@ fn test_exchange_local_cluster() {
     const NUM_NODES: usize = 1;
 
     let mut config = Config::default();
-    config.identity = Keypair::new();
+    config.identity = generate_keypair();
     config.duration = Duration::from_secs(1);
     config.fund_amount = 100_000;
     config.threads = 1;
@@ -47,7 +47,7 @@ fn test_exchange_local_cluster() {
         ..ClusterConfig::default()
     });
 
-    let faucet_keypair = Keypair::new();
+    let faucet_keypair = generate_keypair();
     cluster.transfer(
         &cluster.funding_keypair,
         &faucet_keypair.pubkey(),

--- a/bench-tps/src/bench.rs
+++ b/bench-tps/src/bench.rs
@@ -1,6 +1,8 @@
 use crate::cli::Config;
 use log::*;
 use rayon::prelude::*;
+#[cfg(feature = "move")]
+use signature::generate_keypair;
 use solana_client::perf_utils::{sample_txs, SampleStats};
 use solana_core::gen_keys::GenKeys;
 use solana_faucet::faucet::request_airdrop_transaction;
@@ -873,7 +875,7 @@ fn fund_move_keys<T: Client>(
     let (mut blockhash, _fee_calculator) = get_recent_blockhash(client);
 
     info!("creating the libra funding account..");
-    let libra_funding_key = Keypair::new();
+    let libra_funding_key = generate_keypair();
     let tx = librapay_transaction::create_account(funding_key, &libra_funding_key, 1, blockhash);
     client
         .send_message(&[funding_key, &libra_funding_key], tx.message)
@@ -924,7 +926,7 @@ fn fund_move_keys<T: Client>(
     }
 
     const NUM_FUNDING_KEYS: usize = 10;
-    let funding_keys: Vec<_> = (0..NUM_FUNDING_KEYS).map(|_| Keypair::new()).collect();
+    let funding_keys: Vec<_> = (0..NUM_FUNDING_KEYS).map(|_| generate_keypair()).collect();
     let pubkey_amounts: Vec<_> = funding_keys
         .iter()
         .map(|key| (key.pubkey(), total / NUM_FUNDING_KEYS as u64))
@@ -953,7 +955,7 @@ fn fund_move_keys<T: Client>(
         balance
     );
 
-    let libra_funding_keys: Vec<_> = (0..NUM_FUNDING_KEYS).map(|_| Keypair::new()).collect();
+    let libra_funding_keys: Vec<_> = (0..NUM_FUNDING_KEYS).map(|_| generate_keypair()).collect();
     for (i, key) in libra_funding_keys.iter().enumerate() {
         let tx = librapay_transaction::create_account(&funding_keys[i], &key, 1, blockhash);
         client

--- a/bench-tps/src/cli.rs
+++ b/bench-tps/src/cli.rs
@@ -1,7 +1,7 @@
 use clap::{crate_description, crate_name, App, Arg, ArgMatches};
 use solana_faucet::faucet::FAUCET_PORT;
 use solana_sdk::fee_calculator::FeeCalculator;
-use solana_sdk::signature::{read_keypair_file, Keypair, KeypairUtil};
+use solana_sdk::signature::{generate_keypair, read_keypair_file, Keypair};
 use std::{net::SocketAddr, process::exit, time::Duration};
 
 const NUM_LAMPORTS_PER_ACCOUNT_DEFAULT: u64 = solana_sdk::native_token::LAMPORTS_PER_SOL;
@@ -32,7 +32,7 @@ impl Default for Config {
         Config {
             entrypoint_addr: SocketAddr::from(([127, 0, 0, 1], 8001)),
             faucet_addr: SocketAddr::from(([127, 0, 0, 1], FAUCET_PORT)),
-            id: Keypair::new(),
+            id: generate_keypair(),
             threads: 4,
             num_nodes: 1,
             duration: Duration::new(std::u64::MAX, 0),

--- a/bench-tps/tests/bench_tps.rs
+++ b/bench-tps/tests/bench_tps.rs
@@ -8,7 +8,7 @@ use solana_faucet::faucet::run_local_faucet;
 use solana_local_cluster::local_cluster::{ClusterConfig, LocalCluster};
 #[cfg(feature = "move")]
 use solana_sdk::move_loader::solana_move_loader_program;
-use solana_sdk::signature::{Keypair, KeypairUtil};
+use solana_sdk::signature::{generate_keypair, KeypairUtil};
 use std::sync::{mpsc::channel, Arc};
 use std::time::Duration;
 
@@ -29,7 +29,7 @@ fn test_bench_tps_local_cluster(config: Config) {
         ..ClusterConfig::default()
     });
 
-    let faucet_keypair = Keypair::new();
+    let faucet_keypair = generate_keypair();
     cluster.transfer(
         &cluster.funding_keypair,
         &faucet_keypair.pubkey(),

--- a/book/src/proposals/cluster-test-framework.md
+++ b/book/src/proposals/cluster-test-framework.md
@@ -22,7 +22,7 @@ Each CTF test starts with an opaque entry point and a funded keypair. The test s
 
 ```text
 use crate::contact_info::ContactInfo;
-use solana_sdk::signature::{Keypair, KeypairUtil};
+use solana_sdk::signature::{generate_keypair, KeypairUtil};
 pub fn test_this_behavior(
     entry_point_info: &ContactInfo,
     funding_keypair: &Keypair,

--- a/chacha-cuda/src/chacha_cuda.rs
+++ b/chacha-cuda/src/chacha_cuda.rs
@@ -118,7 +118,7 @@ mod tests {
     use solana_ledger::entry::create_ticks;
     use solana_ledger::get_tmp_ledger_path;
     use solana_sdk::clock::DEFAULT_SLOTS_PER_SEGMENT;
-    use solana_sdk::signature::{Keypair, KeypairUtil};
+    use solana_sdk::signature::generate_keypair;
     use std::fs::{remove_dir_all, remove_file};
     use std::path::Path;
 
@@ -144,7 +144,7 @@ mod tests {
                 ticks_per_slot,
                 Some(0),
                 true,
-                &Arc::new(Keypair::new()),
+                &Arc::new(generate_keypair()),
                 entries,
                 0,
             )
@@ -205,7 +205,7 @@ mod tests {
                 ticks_per_slot,
                 Some(0),
                 true,
-                &Arc::new(Keypair::new()),
+                &Arc::new(generate_keypair()),
                 entries,
                 0,
             )

--- a/clap-utils/src/input_parsers.rs
+++ b/clap-utils/src/input_parsers.rs
@@ -115,7 +115,7 @@ pub fn derivation_of(matches: &ArgMatches<'_>, name: &str) -> Option<DerivationP
 mod tests {
     use super::*;
     use clap::{App, Arg};
-    use solana_sdk::signature::write_keypair_file;
+    use solana_sdk::signature::{generate_keypair, write_keypair_file};
     use std::fs;
 
     fn app<'ab, 'v>() -> App<'ab, 'v> {
@@ -178,7 +178,7 @@ mod tests {
 
     #[test]
     fn test_keypair_of() {
-        let keypair = Keypair::new();
+        let keypair = generate_keypair();
         let outfile = tmp_file_path("test_keypair_of.json", &keypair.pubkey());
         let _ = write_keypair_file(&keypair, &outfile).unwrap();
 
@@ -202,7 +202,7 @@ mod tests {
 
     #[test]
     fn test_pubkey_of() {
-        let keypair = Keypair::new();
+        let keypair = generate_keypair();
         let outfile = tmp_file_path("test_pubkey_of.json", &keypair.pubkey());
         let _ = write_keypair_file(&keypair, &outfile).unwrap();
 
@@ -229,7 +229,7 @@ mod tests {
 
     #[test]
     fn test_pubkeys_of() {
-        let keypair = Keypair::new();
+        let keypair = generate_keypair();
         let outfile = tmp_file_path("test_pubkeys_of.json", &keypair.pubkey());
         let _ = write_keypair_file(&keypair, &outfile).unwrap();
 
@@ -251,8 +251,8 @@ mod tests {
     fn test_pubkeys_sigs_of() {
         let key1 = Pubkey::new_rand();
         let key2 = Pubkey::new_rand();
-        let sig1 = Keypair::new().sign_message(&[0u8]);
-        let sig2 = Keypair::new().sign_message(&[1u8]);
+        let sig1 = generate_keypair().sign_message(&[0u8]);
+        let sig2 = generate_keypair().sign_message(&[1u8]);
         let signer1 = format!("{}={}", key1, sig1);
         let signer2 = format!("{}={}", key2, sig2);
         let matches = app().clone().get_matches_from(vec![

--- a/clap-utils/src/keypair.rs
+++ b/clap-utils/src/keypair.rs
@@ -5,8 +5,8 @@ use rpassword::prompt_password_stderr;
 use solana_sdk::{
     pubkey::Pubkey,
     signature::{
-        keypair_from_seed, keypair_from_seed_phrase_and_passphrase, read_keypair_file, Keypair,
-        KeypairUtil,
+        generate_keypair, keypair_from_seed, keypair_from_seed_phrase_and_passphrase,
+        read_keypair_file, Keypair,
     },
 };
 use std::{
@@ -132,13 +132,16 @@ pub fn keypair_input(
             .map(|keypair| KeypairWithSource::new(keypair, Source::SeedPhrase))
     } else if let Some(keypair_file) = matches.value_of(keypair_match_name) {
         if keypair_file.starts_with("usb://") {
-            Ok(KeypairWithSource::new(Keypair::new(), Source::Path))
+            Ok(KeypairWithSource::new(generate_keypair(), Source::Path))
         } else {
             read_keypair_file(keypair_file)
                 .map(|keypair| KeypairWithSource::new(keypair, Source::Path))
         }
     } else {
-        Ok(KeypairWithSource::new(Keypair::new(), Source::Generated))
+        Ok(KeypairWithSource::new(
+            generate_keypair(),
+            Source::Generated,
+        ))
     }
 }
 

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -21,7 +21,7 @@ use solana_sdk::{
     epoch_schedule::Epoch,
     hash::Hash,
     pubkey::Pubkey,
-    signature::{Keypair, KeypairUtil},
+    signature::{generate_keypair, KeypairUtil},
     system_transaction,
 };
 use std::{
@@ -722,7 +722,7 @@ pub fn process_ping(
     timeout: &Duration,
     commitment_config: &CommitmentConfig,
 ) -> ProcessResult {
-    let to = Keypair::new().pubkey();
+    let to = generate_keypair().pubkey();
 
     println_name_value("Source Account:", &config.keypair.pubkey().to_string());
     println_name_value("Destination Account:", &to.to_string());

--- a/cli/src/nonce.rs
+++ b/cli/src/nonce.rs
@@ -618,7 +618,7 @@ mod tests {
         account::Account,
         hash::hash,
         nonce_state::{Meta as NonceMeta, NonceState},
-        signature::{read_keypair_file, write_keypair},
+        signature::{generate_keypair, read_keypair_file, write_keypair},
         system_program,
     };
     use tempfile::NamedTempFile;
@@ -632,13 +632,13 @@ mod tests {
     fn test_parse_command() {
         let test_commands = app("test", "desc", "version");
         let (keypair_file, mut tmp_file) = make_tmp_file();
-        let nonce_account_keypair = Keypair::new();
+        let nonce_account_keypair = generate_keypair();
         write_keypair(&nonce_account_keypair, tmp_file.as_file_mut()).unwrap();
         let nonce_account_pubkey = nonce_account_keypair.pubkey();
         let nonce_account_string = nonce_account_pubkey.to_string();
 
         let (authority_keypair_file, mut tmp_file2) = make_tmp_file();
-        let nonce_authority_keypair = Keypair::new();
+        let nonce_authority_keypair = generate_keypair();
         write_keypair(&nonce_authority_keypair, tmp_file2.as_file_mut()).unwrap();
 
         // Test AuthorizeNonceAccount Subcommand

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -1230,7 +1230,9 @@ mod tests {
     use solana_sdk::{
         fee_calculator::FeeCalculator,
         hash::Hash,
-        signature::{keypair_from_seed, read_keypair_file, write_keypair, KeypairUtil},
+        signature::{
+            generate_keypair, keypair_from_seed, read_keypair_file, write_keypair, KeypairUtil,
+        },
     };
     use tempfile::NamedTempFile;
 
@@ -1335,7 +1337,7 @@ mod tests {
             }
         );
         // Test Authorize Subcommand w/ signer
-        let keypair = Keypair::new();
+        let keypair = generate_keypair();
         let sig = keypair.sign_message(&[0u8]);
         let signer = format!("{}={}", keypair.pubkey(), sig);
         let test_authorize = test_commands.clone().get_matches_from(vec![
@@ -1367,7 +1369,7 @@ mod tests {
             }
         );
         // Test Authorize Subcommand w/ signers
-        let keypair2 = Keypair::new();
+        let keypair2 = generate_keypair();
         let sig2 = keypair.sign_message(&[0u8]);
         let signer2 = format!("{}={}", keypair2.pubkey(), sig2);
         let test_authorize = test_commands.clone().get_matches_from(vec![
@@ -1429,7 +1431,7 @@ mod tests {
         );
         // Test Authorize Subcommand w/ nonce
         let (nonce_keypair_file, mut nonce_tmp_file) = make_tmp_file();
-        let nonce_authority_keypair = Keypair::new();
+        let nonce_authority_keypair = generate_keypair();
         write_keypair(&nonce_authority_keypair, nonce_tmp_file.as_file_mut()).unwrap();
         let nonce_account_pubkey = nonce_authority_keypair.pubkey();
         let nonce_account_string = nonce_account_pubkey.to_string();
@@ -1465,7 +1467,7 @@ mod tests {
         );
         // Test Authorize Subcommand w/ fee-payer
         let (fee_payer_keypair_file, mut fee_payer_tmp_file) = make_tmp_file();
-        let fee_payer_keypair = Keypair::new();
+        let fee_payer_keypair = generate_keypair();
         write_keypair(&fee_payer_keypair, fee_payer_tmp_file.as_file_mut()).unwrap();
         let fee_payer_pubkey = fee_payer_keypair.pubkey();
         let fee_payer_string = fee_payer_pubkey.to_string();
@@ -1534,11 +1536,11 @@ mod tests {
     fn test_parse_command() {
         let test_commands = app("test", "desc", "version");
         let (keypair_file, mut tmp_file) = make_tmp_file();
-        let stake_account_keypair = Keypair::new();
+        let stake_account_keypair = generate_keypair();
         write_keypair(&stake_account_keypair, tmp_file.as_file_mut()).unwrap();
         let stake_account_pubkey = stake_account_keypair.pubkey();
         let (stake_authority_keypair_file, mut tmp_file) = make_tmp_file();
-        let stake_authority_keypair = Keypair::new();
+        let stake_authority_keypair = generate_keypair();
         write_keypair(&stake_authority_keypair, tmp_file.as_file_mut()).unwrap();
 
         parse_authorize_tests(
@@ -1594,7 +1596,7 @@ mod tests {
         );
 
         let (keypair_file, mut tmp_file) = make_tmp_file();
-        let stake_account_keypair = Keypair::new();
+        let stake_account_keypair = generate_keypair();
         write_keypair(&stake_account_keypair, tmp_file.as_file_mut()).unwrap();
         let stake_account_pubkey = stake_account_keypair.pubkey();
         let stake_account_string = stake_account_pubkey.to_string();
@@ -1771,7 +1773,7 @@ mod tests {
 
         // Test Delegate Subcommand w/ signer
         let key1 = Pubkey::new_rand();
-        let sig1 = Keypair::new().sign_message(&[0u8]);
+        let sig1 = generate_keypair().sign_message(&[0u8]);
         let signer1 = format!("{}={}", key1, sig1);
         let test_delegate_stake = test_commands.clone().get_matches_from(vec![
             "test",
@@ -1804,7 +1806,7 @@ mod tests {
 
         // Test Delegate Subcommand w/ signers
         let key2 = Pubkey::new_rand();
-        let sig2 = Keypair::new().sign_message(&[0u8]);
+        let sig2 = generate_keypair().sign_message(&[0u8]);
         let signer2 = format!("{}={}", key2, sig2);
         let test_delegate_stake = test_commands.clone().get_matches_from(vec![
             "test",
@@ -1839,7 +1841,7 @@ mod tests {
 
         // Test Delegate Subcommand w/ fee-payer
         let (fee_payer_keypair_file, mut fee_payer_tmp_file) = make_tmp_file();
-        let fee_payer_keypair = Keypair::new();
+        let fee_payer_keypair = generate_keypair();
         write_keypair(&fee_payer_keypair, fee_payer_tmp_file.as_file_mut()).unwrap();
         let fee_payer_pubkey = fee_payer_keypair.pubkey();
         let fee_payer_string = fee_payer_pubkey.to_string();
@@ -2062,7 +2064,7 @@ mod tests {
 
         // Test Deactivate Subcommand w/ signers
         let key1 = Pubkey::new_rand();
-        let sig1 = Keypair::new().sign_message(&[0u8]);
+        let sig1 = generate_keypair().sign_message(&[0u8]);
         let signer1 = format!("{}={}", key1, sig1);
         let test_deactivate_stake = test_commands.clone().get_matches_from(vec![
             "test",
@@ -2092,7 +2094,7 @@ mod tests {
 
         // Test Deactivate Subcommand w/ signers
         let key2 = Pubkey::new_rand();
-        let sig2 = Keypair::new().sign_message(&[0u8]);
+        let sig2 = generate_keypair().sign_message(&[0u8]);
         let signer2 = format!("{}={}", key2, sig2);
         let test_deactivate_stake = test_commands.clone().get_matches_from(vec![
             "test",
@@ -2180,10 +2182,10 @@ mod tests {
 
         // Test SplitStake SubCommand
         let (keypair_file, mut tmp_file) = make_tmp_file();
-        let stake_account_keypair = Keypair::new();
+        let stake_account_keypair = generate_keypair();
         write_keypair(&stake_account_keypair, tmp_file.as_file_mut()).unwrap();
         let (split_stake_account_keypair_file, mut tmp_file) = make_tmp_file();
-        let split_stake_account_keypair = Keypair::new();
+        let split_stake_account_keypair = generate_keypair();
         write_keypair(&split_stake_account_keypair, tmp_file.as_file_mut()).unwrap();
 
         let test_split_stake_account = test_commands.clone().get_matches_from(vec![

--- a/cli/src/storage.rs
+++ b/cli/src/storage.rs
@@ -259,7 +259,7 @@ pub fn process_show_storage_account(
 mod tests {
     use super::*;
     use crate::cli::{app, parse_command};
-    use solana_sdk::signature::write_keypair;
+    use solana_sdk::signature::{generate_keypair, write_keypair};
     use tempfile::NamedTempFile;
 
     fn make_tmp_file() -> (String, NamedTempFile) {
@@ -274,7 +274,7 @@ mod tests {
         let pubkey_string = pubkey.to_string();
 
         let (keypair_file, mut tmp_file) = make_tmp_file();
-        let storage_account_keypair = Keypair::new();
+        let storage_account_keypair = generate_keypair();
         write_keypair(&storage_account_keypair, tmp_file.as_file_mut()).unwrap();
 
         let test_create_archiver_storage_account = test_commands.clone().get_matches_from(vec![
@@ -296,7 +296,7 @@ mod tests {
         );
 
         let (keypair_file, mut tmp_file) = make_tmp_file();
-        let storage_account_keypair = Keypair::new();
+        let storage_account_keypair = generate_keypair();
         write_keypair(&storage_account_keypair, tmp_file.as_file_mut()).unwrap();
         let storage_account_pubkey = storage_account_keypair.pubkey();
         let storage_account_string = storage_account_pubkey.to_string();

--- a/cli/src/validator_info.rs
+++ b/cli/src/validator_info.rs
@@ -19,7 +19,7 @@ use solana_sdk::{
     commitment_config::CommitmentConfig,
     message::Message,
     pubkey::Pubkey,
-    signature::{Keypair, KeypairUtil},
+    signature::{generate_keypair, Keypair, KeypairUtil},
     transaction::Transaction,
 };
 use std::error;
@@ -286,7 +286,7 @@ pub fn process_set_validator_info(
         });
 
     // Create validator-info keypair to use if info_pubkey not provided or does not exist
-    let info_keypair = Keypair::new();
+    let info_keypair = generate_keypair();
     let mut info_pubkey = if let Some(pubkey) = info_pubkey {
         pubkey
     } else if let Some(validator_info) = existing_account {

--- a/cli/src/vote.rs
+++ b/cli/src/vote.rs
@@ -474,7 +474,7 @@ pub fn process_show_vote_account(
 mod tests {
     use super::*;
     use crate::cli::{app, parse_command};
-    use solana_sdk::signature::write_keypair;
+    use solana_sdk::signature::{generate_keypair, write_keypair};
     use tempfile::NamedTempFile;
 
     fn make_tmp_file() -> (String, NamedTempFile) {
@@ -485,10 +485,10 @@ mod tests {
     #[test]
     fn test_parse_command() {
         let test_commands = app("test", "desc", "version");
-        let keypair = Keypair::new();
+        let keypair = generate_keypair();
         let pubkey = keypair.pubkey();
         let pubkey_string = pubkey.to_string();
-        let keypair2 = Keypair::new();
+        let keypair2 = generate_keypair();
         let pubkey2 = keypair2.pubkey();
         let pubkey2_string = pubkey2.to_string();
 
@@ -511,7 +511,7 @@ mod tests {
         );
 
         let (keypair_file, mut tmp_file) = make_tmp_file();
-        let keypair = Keypair::new();
+        let keypair = generate_keypair();
         write_keypair(&keypair, tmp_file.as_file_mut()).unwrap();
         // Test CreateVoteAccount SubCommand
         let node_pubkey = Pubkey::new_rand();
@@ -540,7 +540,7 @@ mod tests {
         );
 
         let (keypair_file, mut tmp_file) = make_tmp_file();
-        let keypair = Keypair::new();
+        let keypair = generate_keypair();
         write_keypair(&keypair, tmp_file.as_file_mut()).unwrap();
 
         let test_create_vote_account2 = test_commands.clone().get_matches_from(vec![
@@ -567,7 +567,7 @@ mod tests {
         // test init with an authed voter
         let authed = Pubkey::new_rand();
         let (keypair_file, mut tmp_file) = make_tmp_file();
-        let keypair = Keypair::new();
+        let keypair = generate_keypair();
         write_keypair(&keypair, tmp_file.as_file_mut()).unwrap();
 
         let test_create_vote_account3 = test_commands.clone().get_matches_from(vec![
@@ -594,7 +594,7 @@ mod tests {
         );
 
         let (keypair_file, mut tmp_file) = make_tmp_file();
-        let keypair = Keypair::new();
+        let keypair = generate_keypair();
         write_keypair(&keypair, tmp_file.as_file_mut()).unwrap();
         // test init with an authed withdrawer
         let test_create_vote_account4 = test_commands.clone().get_matches_from(vec![

--- a/cli/tests/nonce.rs
+++ b/cli/tests/nonce.rs
@@ -6,7 +6,7 @@ use solana_faucet::faucet::run_local_faucet;
 use solana_sdk::{
     hash::Hash,
     pubkey::Pubkey,
-    signature::{read_keypair_file, write_keypair, Keypair, KeypairUtil},
+    signature::{generate_keypair, read_keypair_file, write_keypair, KeypairUtil},
     system_instruction::create_address_with_seed,
     system_program,
 };
@@ -123,7 +123,7 @@ fn test_nonce_with_authority() {
     let (nonce_keypair_file, mut tmp_file) = make_tmp_file();
     write_keypair(&config_nonce.keypair, tmp_file.as_file_mut()).unwrap();
 
-    let nonce_authority = Keypair::new();
+    let nonce_authority = generate_keypair();
     let (authority_keypair_file, mut tmp_file2) = make_tmp_file();
     write_keypair(&nonce_authority, tmp_file2.as_file_mut()).unwrap();
 
@@ -230,7 +230,7 @@ fn full_battery_tests(
     process_command(&config_payer).unwrap();
 
     // Set new authority
-    let new_authority = Keypair::new();
+    let new_authority = generate_keypair();
     let (new_authority_keypair_file, mut tmp_file) = make_tmp_file();
     write_keypair(&new_authority, tmp_file.as_file_mut()).unwrap();
     config_payer.command = CliCommand::AuthorizeNonceAccount {

--- a/cli/tests/pay.rs
+++ b/cli/tests/pay.rs
@@ -11,7 +11,7 @@ use solana_sdk::{
     fee_calculator::FeeCalculator,
     nonce_state::NonceState,
     pubkey::Pubkey,
-    signature::{read_keypair_file, write_keypair, Keypair, KeypairUtil},
+    signature::{generate_keypair, read_keypair_file, write_keypair, KeypairUtil},
 };
 use std::fs::remove_dir_all;
 use std::sync::mpsc::channel;
@@ -353,7 +353,7 @@ fn test_nonced_pay_tx() {
     );
 
     // Create nonce account
-    let nonce_account = Keypair::new();
+    let nonce_account = generate_keypair();
     let (nonce_keypair_file, mut tmp_file) = make_tmp_file();
     write_keypair(&nonce_account, tmp_file.as_file_mut()).unwrap();
     config.command = CliCommand::CreateNonceAccount {

--- a/cli/tests/stake.rs
+++ b/cli/tests/stake.rs
@@ -9,7 +9,9 @@ use solana_sdk::{
     fee_calculator::FeeCalculator,
     nonce_state::NonceState,
     pubkey::Pubkey,
-    signature::{keypair_from_seed, read_keypair_file, write_keypair, Keypair, KeypairUtil},
+    signature::{
+        generate_keypair, keypair_from_seed, read_keypair_file, write_keypair, Keypair, KeypairUtil,
+    },
     system_instruction::create_address_with_seed,
 };
 use solana_stake_program::stake_state::{Lockup, StakeAuthorize, StakeState};
@@ -59,7 +61,7 @@ fn test_stake_delegation_force() {
         .unwrap();
 
     // Create vote account
-    let vote_keypair = Keypair::new();
+    let vote_keypair = generate_keypair();
     let (vote_keypair_file, mut tmp_file) = make_tmp_file();
     write_keypair(&vote_keypair, tmp_file.as_file_mut()).unwrap();
     config.command = CliCommand::CreateVoteAccount {
@@ -73,7 +75,7 @@ fn test_stake_delegation_force() {
     process_command(&config).unwrap();
 
     // Create stake account
-    let stake_keypair = Keypair::new();
+    let stake_keypair = generate_keypair();
     let (stake_keypair_file, mut tmp_file) = make_tmp_file();
     write_keypair(&stake_keypair, tmp_file.as_file_mut()).unwrap();
     config.command = CliCommand::CreateStakeAccount {
@@ -421,7 +423,7 @@ fn test_nonced_stake_delegation_and_deactivation() {
         .unwrap();
 
     // Create stake account
-    let stake_keypair = Keypair::new();
+    let stake_keypair = generate_keypair();
     let (stake_keypair_file, mut tmp_file) = make_tmp_file();
     write_keypair(&stake_keypair, tmp_file.as_file_mut()).unwrap();
     config.command = CliCommand::CreateStakeAccount {
@@ -435,7 +437,7 @@ fn test_nonced_stake_delegation_and_deactivation() {
     process_command(&config).unwrap();
 
     // Create nonce account
-    let nonce_account = Keypair::new();
+    let nonce_account = generate_keypair();
     let (nonce_keypair_file, mut tmp_file) = make_tmp_file();
     write_keypair(&nonce_account, tmp_file.as_file_mut()).unwrap();
     config.command = CliCommand::CreateNonceAccount {
@@ -527,7 +529,7 @@ fn test_stake_authorize() {
     .unwrap();
 
     // Create stake account, identity is authority
-    let stake_keypair = Keypair::new();
+    let stake_keypair = generate_keypair();
     let stake_account_pubkey = stake_keypair.pubkey();
     let (stake_keypair_file, mut tmp_file) = make_tmp_file();
     write_keypair(&stake_keypair, tmp_file.as_file_mut()).unwrap();
@@ -542,7 +544,7 @@ fn test_stake_authorize() {
     process_command(&config).unwrap();
 
     // Assign new online stake authority
-    let online_authority = Keypair::new();
+    let online_authority = generate_keypair();
     let online_authority_pubkey = online_authority.pubkey();
     let (online_authority_file, mut tmp_file) = make_tmp_file();
     write_keypair(&online_authority, tmp_file.as_file_mut()).unwrap();
@@ -593,7 +595,7 @@ fn test_stake_authorize() {
     assert_eq!(current_authority, offline_authority_pubkey);
 
     // Offline assignment of new nonced stake authority
-    let nonced_authority = Keypair::new();
+    let nonced_authority = generate_keypair();
     let nonced_authority_pubkey = nonced_authority.pubkey();
     let (nonced_authority_file, mut tmp_file) = make_tmp_file();
     write_keypair(&nonced_authority, tmp_file.as_file_mut()).unwrap();
@@ -637,7 +639,7 @@ fn test_stake_authorize() {
     let minimum_nonce_balance = rpc_client
         .get_minimum_balance_for_rent_exemption(NonceState::size())
         .unwrap();
-    let nonce_account = Keypair::new();
+    let nonce_account = generate_keypair();
     let (nonce_keypair_file, mut tmp_file) = make_tmp_file();
     write_keypair(&nonce_account, tmp_file.as_file_mut()).unwrap();
     config.command = CliCommand::CreateNonceAccount {
@@ -657,7 +659,7 @@ fn test_stake_authorize() {
     };
 
     // Nonced assignment of new online stake authority
-    let online_authority = Keypair::new();
+    let online_authority = generate_keypair();
     let online_authority_pubkey = online_authority.pubkey();
     let (_online_authority_file, mut tmp_file) = make_tmp_file();
     write_keypair(&online_authority, tmp_file.as_file_mut()).unwrap();
@@ -750,7 +752,7 @@ fn test_stake_authorize_with_fee_payer() {
     check_balance(100_000, &rpc_client, &offline_pubkey);
 
     // Create stake account, identity is authority
-    let stake_keypair = Keypair::new();
+    let stake_keypair = generate_keypair();
     let stake_account_pubkey = stake_keypair.pubkey();
     let (stake_keypair_file, mut tmp_file) = make_tmp_file();
     write_keypair(&stake_keypair, tmp_file.as_file_mut()).unwrap();

--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -1129,9 +1129,7 @@ mod tests {
     use serde_json::Number;
     use solana_logger;
     use solana_sdk::{
-        instruction::InstructionError,
-        signature::{Keypair, KeypairUtil},
-        system_transaction,
+        instruction::InstructionError, signature::generate_keypair, system_transaction,
         transaction::TransactionError,
     };
     use std::{sync::mpsc::channel, thread};
@@ -1231,7 +1229,7 @@ mod tests {
     fn test_send_transaction() {
         let rpc_client = RpcClient::new_mock("succeeds".to_string());
 
-        let key = Keypair::new();
+        let key = generate_keypair();
         let to = Pubkey::new_rand();
         let blockhash = Hash::default();
         let tx = system_transaction::transfer(&key, &to, 50, blockhash);
@@ -1280,7 +1278,7 @@ mod tests {
     fn test_send_and_confirm_transaction() {
         let rpc_client = RpcClient::new_mock("succeeds".to_string());
 
-        let key = Keypair::new();
+        let key = generate_keypair();
         let to = Pubkey::new_rand();
         let blockhash = Hash::default();
         let mut tx = system_transaction::transfer(&key, &to, 50, blockhash);
@@ -1313,7 +1311,7 @@ mod tests {
     fn test_resign_transaction() {
         let rpc_client = RpcClient::new_mock("succeeds".to_string());
 
-        let key = Keypair::new();
+        let key = generate_keypair();
         let to = Pubkey::new_rand();
         let blockhash: Hash = "HUu3LwEzGRsUkuJS121jzkPJW39Kq62pXCTmTa1F9jDL"
             .parse()

--- a/core/benches/banking_stage.rs
+++ b/core/benches/banking_stage.rs
@@ -112,7 +112,7 @@ fn make_programs_txs(txes: usize, hash: Hash) -> Vec<Transaction> {
         .into_iter()
         .map(|_| {
             let mut instructions = vec![];
-            let from_key = Keypair::new();
+            let from_key = generate_keypair();
             for _ in 1..progs {
                 let to_key = Pubkey::new_rand();
                 instructions.push(system_instruction::transfer(&from_key.pubkey(), &to_key, 1));
@@ -310,7 +310,7 @@ fn bench_process_entries(randomize_txs: bool, bencher: &mut Bencher) {
     let tx_vector: Vec<Transaction> = Vec::with_capacity(num_accounts / 2);
 
     for _ in 0..num_accounts {
-        let keypair = Keypair::new();
+        let keypair = generate_keypair();
         keypairs.push(keypair);
     }
 

--- a/core/benches/poh_verify.rs
+++ b/core/benches/poh_verify.rs
@@ -3,7 +3,7 @@ extern crate test;
 
 use solana_ledger::entry::{next_entry_mut, Entry, EntrySlice};
 use solana_sdk::hash::{hash, Hash};
-use solana_sdk::signature::{Keypair, KeypairUtil};
+use solana_sdk::signature::{generate_keypair, KeypairUtil};
 use solana_sdk::system_transaction;
 use test::Bencher;
 
@@ -32,7 +32,7 @@ fn bench_poh_verify_transaction_entries(bencher: &mut Bencher) {
     let mut cur_hash = hash(&zero.as_ref());
     let start = *&cur_hash;
 
-    let keypair1 = Keypair::new();
+    let keypair1 = generate_keypair();
     let pubkey1 = keypair1.pubkey();
 
     let mut ticks: Vec<Entry> = Vec::with_capacity(NUM_ENTRIES);

--- a/core/benches/shredder.rs
+++ b/core/benches/shredder.rs
@@ -9,7 +9,7 @@ use solana_ledger::shred::{
 };
 use solana_perf::test_tx;
 use solana_sdk::hash::Hash;
-use solana_sdk::signature::{Keypair, KeypairUtil};
+use solana_sdk::signature::{generate_keypair, KeypairUtil};
 use std::sync::Arc;
 use test::Bencher;
 
@@ -28,7 +28,7 @@ fn make_large_unchained_entries(txs_per_entry: u64, num_entries: u64) -> Vec<Ent
 
 #[bench]
 fn bench_shredder_ticks(bencher: &mut Bencher) {
-    let kp = Arc::new(Keypair::new());
+    let kp = Arc::new(generate_keypair());
     let shred_size = SIZE_OF_DATA_SHRED_PAYLOAD;
     let num_shreds = ((1000 * 1000) + (shred_size - 1)) / shred_size;
     // ~1Mb
@@ -42,7 +42,7 @@ fn bench_shredder_ticks(bencher: &mut Bencher) {
 
 #[bench]
 fn bench_shredder_large_entries(bencher: &mut Bencher) {
-    let kp = Arc::new(Keypair::new());
+    let kp = Arc::new(generate_keypair());
     let shred_size = SIZE_OF_DATA_SHRED_PAYLOAD;
     let num_shreds = ((1000 * 1000) + (shred_size - 1)) / shred_size;
     let txs_per_entry = 128;
@@ -57,7 +57,7 @@ fn bench_shredder_large_entries(bencher: &mut Bencher) {
 
 #[bench]
 fn bench_deshredder(bencher: &mut Bencher) {
-    let kp = Arc::new(Keypair::new());
+    let kp = Arc::new(generate_keypair());
     let shred_size = SIZE_OF_DATA_SHRED_PAYLOAD;
     // ~10Mb
     let num_shreds = ((10000 * 1000) + (shred_size - 1)) / shred_size;

--- a/core/benches/sigverify_stage.rs
+++ b/core/benches/sigverify_stage.rs
@@ -11,7 +11,7 @@ use solana_core::sigverify::TransactionSigVerifier;
 use solana_core::sigverify_stage::SigVerifyStage;
 use solana_perf::test_tx::test_tx;
 use solana_sdk::hash::Hash;
-use solana_sdk::signature::{Keypair, KeypairUtil};
+use solana_sdk::signature::{generate_keypair, KeypairUtil};
 use solana_sdk::system_transaction;
 use solana_sdk::timing::duration_as_ms;
 use std::sync::mpsc::channel;
@@ -34,8 +34,8 @@ fn bench_sigverify_stage(bencher: &mut Bencher) {
         let tx = test_tx();
         to_packets_chunked(&vec![tx; len], chunk_size)
     } else {
-        let from_keypair = Keypair::new();
-        let to_keypair = Keypair::new();
+        let from_keypair = generate_keypair();
+        let to_keypair = generate_keypair();
         let txs: Vec<_> = (0..len)
             .into_iter()
             .map(|_| {

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -1026,7 +1026,7 @@ mod tests {
     use solana_runtime::bank::HashAgeKind;
     use solana_sdk::{
         instruction::InstructionError,
-        signature::{Keypair, KeypairUtil},
+        signature::{generate_keypair, KeypairUtil},
         system_transaction,
         transaction::TransactionError,
     };
@@ -1160,7 +1160,7 @@ mod tests {
             );
 
             // fund another account so we can send 2 good transactions in a single batch.
-            let keypair = Keypair::new();
+            let keypair = generate_keypair();
             let fund_tx =
                 system_transaction::transfer(&mint_keypair, &keypair.pubkey(), 2, start_hash);
             bank.process_transaction(&fund_tx).unwrap();
@@ -1174,7 +1174,7 @@ mod tests {
             let tx_no_ver = system_transaction::transfer(&keypair, &to2, 2, start_hash);
 
             // bad tx, AccountNotFound
-            let keypair = Keypair::new();
+            let keypair = generate_keypair();
             let to3 = Pubkey::new_rand();
             let tx_anf = system_transaction::transfer(&keypair, &to3, 1, start_hash);
 
@@ -1251,7 +1251,7 @@ mod tests {
         let (verified_sender, verified_receiver) = unbounded();
 
         // Process a batch that includes a transaction that receives two lamports.
-        let alice = Keypair::new();
+        let alice = generate_keypair();
         let tx =
             system_transaction::transfer(&mint_keypair, &alice.pubkey(), 2, genesis_config.hash());
 
@@ -1366,7 +1366,7 @@ mod tests {
 
             poh_recorder.lock().unwrap().set_working_bank(working_bank);
             let pubkey = Pubkey::new_rand();
-            let keypair2 = Keypair::new();
+            let keypair2 = generate_keypair();
             let pubkey2 = Pubkey::new_rand();
 
             let transactions = vec![
@@ -1908,7 +1908,7 @@ mod tests {
         let bank = Arc::new(Bank::new(&genesis_config));
         let pubkey = Pubkey::new_rand();
         let pubkey1 = Pubkey::new_rand();
-        let keypair1 = Keypair::new();
+        let keypair1 = generate_keypair();
 
         let success_tx =
             system_transaction::transfer(&mint_keypair, &pubkey, 1, genesis_config.hash());

--- a/core/src/blockstream.rs
+++ b/core/src/blockstream.rs
@@ -180,7 +180,7 @@ mod test {
     use chrono::{DateTime, FixedOffset};
     use serde_json::Value;
     use solana_sdk::hash::Hash;
-    use solana_sdk::signature::{Keypair, KeypairUtil};
+    use solana_sdk::signature::{generate_keypair, KeypairUtil};
     use solana_sdk::system_transaction;
     use std::collections::HashSet;
     use std::path::PathBuf;
@@ -191,8 +191,8 @@ mod test {
         let empty_vec: Vec<Vec<u8>> = vec![];
         assert_eq!(serialize_transactions(&entry), empty_vec);
 
-        let keypair0 = Keypair::new();
-        let keypair1 = Keypair::new();
+        let keypair0 = generate_keypair();
+        let keypair1 = generate_keypair();
         let tx0 = system_transaction::transfer(&keypair0, &keypair1.pubkey(), 1, Hash::default());
         let tx1 = system_transaction::transfer(&keypair1, &keypair0.pubkey(), 2, Hash::default());
         let serialized_tx0 = serialize(&tx0).unwrap();

--- a/core/src/blockstream_service.rs
+++ b/core/src/blockstream_service.rs
@@ -107,7 +107,7 @@ mod test {
     use solana_ledger::create_new_tmp_ledger;
     use solana_ledger::entry::{create_ticks, Entry};
     use solana_sdk::hash::Hash;
-    use solana_sdk::signature::{Keypair, KeypairUtil};
+    use solana_sdk::signature::{generate_keypair, KeypairUtil};
     use solana_sdk::system_transaction;
     use std::path::PathBuf;
     use std::sync::mpsc::channel;
@@ -135,7 +135,7 @@ mod test {
         // Create entries - 4 ticks + 1 populated entry + 1 tick
         let mut entries = create_ticks(4, 0, Hash::default());
 
-        let keypair = Keypair::new();
+        let keypair = generate_keypair();
         let mut blockhash = entries[3].hash;
         let tx = system_transaction::transfer(&keypair, &keypair.pubkey(), 1, Hash::default());
         let entry = Entry::new(&mut blockhash, 1, vec![tx]);
@@ -155,7 +155,7 @@ mod test {
                 ticks_per_slot,
                 None,
                 true,
-                &Arc::new(Keypair::new()),
+                &Arc::new(generate_keypair()),
                 entries,
                 0,
             )

--- a/core/src/broadcast_stage.rs
+++ b/core/src/broadcast_stage.rs
@@ -259,7 +259,7 @@ mod test {
     use solana_runtime::bank::Bank;
     use solana_sdk::hash::Hash;
     use solana_sdk::pubkey::Pubkey;
-    use solana_sdk::signature::{Keypair, KeypairUtil};
+    use solana_sdk::signature::{generate_keypair, KeypairUtil};
     use std::path::Path;
     use std::sync::atomic::AtomicBool;
     use std::sync::mpsc::channel;
@@ -285,7 +285,7 @@ mod test {
         let leader_info = Node::new_localhost_with_pubkey(leader_pubkey);
 
         // Make a node to broadcast to
-        let buddy_keypair = Keypair::new();
+        let buddy_keypair = generate_keypair();
         let broadcast_buddy = Node::new_localhost_with_pubkey(&buddy_keypair.pubkey());
 
         // Fill the cluster_info with the buddy's info
@@ -323,7 +323,7 @@ mod test {
 
         {
             // Create the leader scheduler
-            let leader_keypair = Keypair::new();
+            let leader_keypair = generate_keypair();
 
             let (entry_sender, entry_receiver) = channel();
             let broadcast_service = setup_dummy_broadcast_service(

--- a/core/src/broadcast_stage/standard_broadcast_run.rs
+++ b/core/src/broadcast_stage/standard_broadcast_run.rs
@@ -362,7 +362,7 @@ mod test {
     use solana_sdk::{
         clock::Slot,
         genesis_config::GenesisConfig,
-        signature::{Keypair, KeypairUtil},
+        signature::{generate_keypair, KeypairUtil},
     };
     use std::sync::{Arc, RwLock};
     use std::time::Duration;
@@ -382,7 +382,7 @@ mod test {
         let blockstore = Arc::new(
             Blockstore::open(&ledger_path).expect("Expected to be able to open database ledger"),
         );
-        let leader_keypair = Arc::new(Keypair::new());
+        let leader_keypair = Arc::new(generate_keypair());
         let leader_pubkey = leader_keypair.pubkey();
         let leader_info = Node::new_localhost_with_pubkey(&leader_pubkey);
         let cluster_info = Arc::new(RwLock::new(ClusterInfo::new_with_invalid_keypair(
@@ -404,7 +404,7 @@ mod test {
 
     #[test]
     fn test_interrupted_slot_last_shred() {
-        let keypair = Arc::new(Keypair::new());
+        let keypair = Arc::new(generate_keypair());
         let mut run = StandardBroadcastRun::new(keypair.clone(), 0);
 
         // Set up the slot to be interrupted

--- a/core/src/cluster_info.rs
+++ b/core/src/cluster_info.rs
@@ -39,7 +39,7 @@ use solana_perf::packet::{to_packets_with_destination, Packets, PacketsRecycler}
 use solana_sdk::{
     clock::{Slot, DEFAULT_MS_PER_SLOT},
     pubkey::Pubkey,
-    signature::{Keypair, KeypairUtil, Signable, Signature},
+    signature::{generate_keypair, Keypair, Signable, Signature},
     timing::{duration_as_ms, timestamp},
     transaction::Transaction,
 };
@@ -174,7 +174,7 @@ enum Protocol {
 impl ClusterInfo {
     /// Without a valid keypair gossip will not function. Only useful for tests.
     pub fn new_with_invalid_keypair(contact_info: ContactInfo) -> Self {
-        Self::new(contact_info, Arc::new(Keypair::new()))
+        Self::new(contact_info, Arc::new(generate_keypair()))
     }
 
     pub fn new(contact_info: ContactInfo, keypair: Arc<Keypair>) -> Self {
@@ -1730,7 +1730,7 @@ mod tests {
     use crate::crds_value::CrdsValueLabel;
     use rayon::prelude::*;
     use solana_perf::test_tx::test_tx;
-    use solana_sdk::signature::{Keypair, KeypairUtil};
+    use solana_sdk::signature::{generate_keypair, KeypairUtil};
     use std::collections::HashSet;
     use std::net::{IpAddr, Ipv4Addr};
     use std::sync::{Arc, RwLock};
@@ -1882,8 +1882,8 @@ mod tests {
     #[test]
     fn test_gossip_signature_verification() {
         //create new cluster info, leader, and peer
-        let keypair = Keypair::new();
-        let peer_keypair = Keypair::new();
+        let keypair = generate_keypair();
+        let peer_keypair = generate_keypair();
         let contact_info = ContactInfo::new_localhost(&keypair.pubkey(), 0);
         let peer = ContactInfo::new_localhost(&peer_keypair.pubkey(), 0);
         let mut cluster_info = ClusterInfo::new(contact_info.clone(), Arc::new(keypair));
@@ -2051,7 +2051,7 @@ mod tests {
 
     #[test]
     fn test_push_vote() {
-        let keys = Keypair::new();
+        let keys = generate_keypair();
         let now = timestamp();
         let contact_info = ContactInfo::new_localhost(&keys.pubkey(), 0);
         let mut cluster_info = ClusterInfo::new_with_invalid_keypair(contact_info);
@@ -2078,7 +2078,7 @@ mod tests {
 
     #[test]
     fn test_add_entrypoint() {
-        let node_keypair = Arc::new(Keypair::new());
+        let node_keypair = Arc::new(generate_keypair());
         let mut cluster_info = ClusterInfo::new(
             ContactInfo::new_localhost(&node_keypair.pubkey(), timestamp()),
             node_keypair,
@@ -2257,7 +2257,7 @@ mod tests {
 
     #[test]
     fn test_pull_from_entrypoint_if_not_present() {
-        let node_keypair = Arc::new(Keypair::new());
+        let node_keypair = Arc::new(generate_keypair());
         let mut cluster_info = ClusterInfo::new(
             ContactInfo::new_localhost(&node_keypair.pubkey(), timestamp()),
             node_keypair,
@@ -2298,7 +2298,7 @@ mod tests {
 
     #[test]
     fn test_repair_peers() {
-        let node_keypair = Arc::new(Keypair::new());
+        let node_keypair = Arc::new(generate_keypair());
         let mut cluster_info = ClusterInfo::new(
             ContactInfo::new_localhost(&node_keypair.pubkey(), timestamp()),
             node_keypair,

--- a/core/src/cluster_info_vote_listener.rs
+++ b/core/src/cluster_info_vote_listener.rs
@@ -84,7 +84,7 @@ impl ClusterInfoVoteListener {
 mod tests {
     use crate::packet;
     use solana_sdk::hash::Hash;
-    use solana_sdk::signature::{Keypair, KeypairUtil};
+    use solana_sdk::signature::{generate_keypair, KeypairUtil};
     use solana_sdk::transaction::Transaction;
     use solana_vote_program::vote_instruction;
     use solana_vote_program::vote_state::Vote;
@@ -92,8 +92,8 @@ mod tests {
     #[test]
     fn test_max_vote_tx_fits() {
         solana_logger::setup();
-        let node_keypair = Keypair::new();
-        let vote_keypair = Keypair::new();
+        let node_keypair = generate_keypair();
+        let vote_keypair = generate_keypair();
         let slots: Vec<_> = (0..31).into_iter().collect();
         let votes = Vote::new(slots, Hash::default());
         let vote_ix = vote_instruction::vote(&vote_keypair.pubkey(), &vote_keypair.pubkey(), votes);

--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -479,7 +479,7 @@ pub mod test {
         clock::Slot,
         hash::Hash,
         pubkey::Pubkey,
-        signature::{Keypair, KeypairUtil},
+        signature::{generate_keypair, Keypair, KeypairUtil},
         transaction::Transaction,
     };
     use solana_stake_program::stake_state;
@@ -790,8 +790,8 @@ pub mod test {
 
     #[test]
     fn test_simple_votes() {
-        let node_keypair = Keypair::new();
-        let vote_keypair = Keypair::new();
+        let node_keypair = generate_keypair();
+        let vote_keypair = generate_keypair();
         let node_pubkey = node_keypair.pubkey();
 
         let mut keypairs = HashMap::new();
@@ -839,8 +839,8 @@ pub mod test {
     #[test]
     fn test_double_partition() {
         solana_logger::setup();
-        let node_keypair = Keypair::new();
-        let vote_keypair = Keypair::new();
+        let node_keypair = generate_keypair();
+        let vote_keypair = generate_keypair();
         let node_pubkey = node_keypair.pubkey();
         let vote_pubkey = vote_keypair.pubkey();
 

--- a/core/src/contact_info.rs
+++ b/core/src/contact_info.rs
@@ -2,7 +2,7 @@ use solana_sdk::pubkey::Pubkey;
 #[cfg(test)]
 use solana_sdk::rpc_port;
 #[cfg(test)]
-use solana_sdk::signature::{Keypair, KeypairUtil};
+use solana_sdk::signature::{generate_keypair, KeypairUtil};
 use solana_sdk::timing::timestamp;
 use std::cmp::{Ord, Ordering, PartialEq, PartialOrd};
 use std::net::{IpAddr, SocketAddr};
@@ -200,7 +200,7 @@ impl ContactInfo {
 
     #[cfg(test)]
     pub(crate) fn new_with_socketaddr(bind_addr: &SocketAddr) -> Self {
-        let keypair = Keypair::new();
+        let keypair = generate_keypair();
         Self::new_with_pubkey_socketaddr(&keypair.pubkey(), bind_addr)
     }
 
@@ -320,7 +320,7 @@ mod tests {
 
     #[test]
     fn replayed_data_new_with_socketaddr_with_pubkey() {
-        let keypair = Keypair::new();
+        let keypair = generate_keypair();
         let d1 = ContactInfo::new_with_pubkey_socketaddr(
             &keypair.pubkey(),
             &socketaddr!("127.0.0.1:1234"),

--- a/core/src/crds_value.rs
+++ b/core/src/crds_value.rs
@@ -246,7 +246,7 @@ mod test {
     use crate::contact_info::ContactInfo;
     use bincode::deserialize;
     use solana_perf::test_tx::test_tx;
-    use solana_sdk::signature::{Keypair, KeypairUtil};
+    use solana_sdk::signature::{generate_keypair, KeypairUtil};
     use solana_sdk::timing::timestamp;
 
     #[test]
@@ -291,8 +291,8 @@ mod test {
 
     #[test]
     fn test_signature() {
-        let keypair = Keypair::new();
-        let wrong_keypair = Keypair::new();
+        let keypair = generate_keypair();
+        let wrong_keypair = generate_keypair();
         let mut v = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
             &keypair.pubkey(),
             timestamp(),
@@ -316,7 +316,7 @@ mod test {
 
     #[test]
     fn test_max_vote_index() {
-        let keypair = Keypair::new();
+        let keypair = generate_keypair();
         let vote = CrdsValue::new_signed(
             CrdsData::Vote(
                 MAX_VOTES,
@@ -337,7 +337,7 @@ mod test {
 
     #[test]
     fn test_compute_vote_index_one() {
-        let keypair = Keypair::new();
+        let keypair = generate_keypair();
         let vote = CrdsValue::new_unsigned(CrdsData::Vote(
             0,
             Vote::new(&keypair.pubkey(), test_tx(), 0),
@@ -352,7 +352,7 @@ mod test {
 
     #[test]
     fn test_compute_vote_index_full() {
-        let keypair = Keypair::new();
+        let keypair = generate_keypair();
         let votes: Vec<_> = (0..MAX_VOTES)
             .map(|x| {
                 CrdsValue::new_unsigned(CrdsData::Vote(

--- a/core/src/gossip_service.rs
+++ b/core/src/gossip_service.rs
@@ -8,7 +8,7 @@ use solana_client::thin_client::{create_client, ThinClient};
 use solana_ledger::bank_forks::BankForks;
 use solana_perf::recycler::Recycler;
 use solana_sdk::pubkey::Pubkey;
-use solana_sdk::signature::{Keypair, KeypairUtil};
+use solana_sdk::signature::{generate_keypair, KeypairUtil};
 use std::net::{SocketAddr, TcpListener, UdpSocket};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::channel;
@@ -269,7 +269,7 @@ fn make_gossip_node(
     exit: &Arc<AtomicBool>,
     gossip_addr: Option<&SocketAddr>,
 ) -> (GossipService, Option<TcpListener>, Arc<RwLock<ClusterInfo>>) {
-    let keypair = Arc::new(Keypair::new());
+    let keypair = Arc::new(generate_keypair());
     let (node, gossip_socket, ip_echo) = if let Some(gossip_addr) = gossip_addr {
         ClusterInfo::gossip_node(&keypair.pubkey(), gossip_addr)
     } else {
@@ -306,7 +306,7 @@ mod tests {
 
     #[test]
     fn test_gossip_services_spy() {
-        let keypair = Keypair::new();
+        let keypair = generate_keypair();
         let peer0 = Pubkey::new_rand();
         let peer1 = Pubkey::new_rand();
         let contact_info = ContactInfo::new_localhost(&keypair.pubkey(), 0);

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -1081,7 +1081,7 @@ pub(crate) mod tests {
         instruction::InstructionError,
         packet::PACKET_DATA_SIZE,
         rent::Rent,
-        signature::{Keypair, KeypairUtil, Signature},
+        signature::{generate_keypair, KeypairUtil, Signature},
         system_transaction,
         transaction::TransactionError,
     };
@@ -1338,22 +1338,22 @@ pub(crate) mod tests {
         let validators: Vec<ValidatorInfo> = vec![
             ValidatorInfo {
                 stake: 34_000_000,
-                keypair: Keypair::new(),
-                voting_keypair: Keypair::new(),
-                staking_keypair: Keypair::new(),
+                keypair: generate_keypair(),
+                voting_keypair: generate_keypair(),
+                staking_keypair: generate_keypair(),
             },
             ValidatorInfo {
                 stake: 33_000_000,
-                keypair: Keypair::new(),
-                voting_keypair: Keypair::new(),
-                staking_keypair: Keypair::new(),
+                keypair: generate_keypair(),
+                voting_keypair: generate_keypair(),
+                staking_keypair: generate_keypair(),
             },
             // Malicious Node
             ValidatorInfo {
                 stake: 33_000_000,
-                keypair: Keypair::new(),
-                voting_keypair: Keypair::new(),
-                staking_keypair: Keypair::new(),
+                keypair: generate_keypair(),
+                voting_keypair: generate_keypair(),
+                staking_keypair: generate_keypair(),
             },
         ];
 
@@ -1446,10 +1446,10 @@ pub(crate) mod tests {
 
     #[test]
     fn test_dead_fork_transaction_error() {
-        let keypair1 = Keypair::new();
-        let keypair2 = Keypair::new();
-        let missing_keypair = Keypair::new();
-        let missing_keypair2 = Keypair::new();
+        let keypair1 = generate_keypair();
+        let keypair2 = generate_keypair();
+        let missing_keypair = generate_keypair();
+        let missing_keypair2 = generate_keypair();
 
         let res = check_dead_fork(|_keypair, bank| {
             let blockhash = bank.last_blockhash();
@@ -1481,7 +1481,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_dead_fork_entry_verification_failure() {
-        let keypair2 = Keypair::new();
+        let keypair2 = generate_keypair();
         let res = check_dead_fork(|genesis_keypair, bank| {
             let blockhash = bank.last_blockhash();
             let slot = bank.slot();
@@ -1600,7 +1600,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_dead_fork_trailing_entry() {
-        let keypair = Keypair::new();
+        let keypair = generate_keypair();
         let res = check_dead_fork(|genesis_keypair, bank| {
             let blockhash = bank.last_blockhash();
             let slot = bank.slot();
@@ -1868,9 +1868,9 @@ pub(crate) mod tests {
                 .expect("Expected to successfully open database ledger");
             let blockstore = Arc::new(blockstore);
 
-            let keypair1 = Keypair::new();
-            let keypair2 = Keypair::new();
-            let keypair3 = Keypair::new();
+            let keypair1 = generate_keypair();
+            let keypair2 = generate_keypair();
+            let keypair3 = generate_keypair();
 
             let bank0 = Arc::new(Bank::new(&genesis_config));
             bank0
@@ -1915,8 +1915,8 @@ pub(crate) mod tests {
 
     #[test]
     fn test_child_bank_heavier() {
-        let node_keypair = Keypair::new();
-        let vote_keypair = Keypair::new();
+        let node_keypair = generate_keypair();
+        let vote_keypair = generate_keypair();
         let node_pubkey = node_keypair.pubkey();
         let mut keypairs = HashMap::new();
         keypairs.insert(

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -1115,7 +1115,7 @@ pub mod tests {
         hash::{hash, Hash},
         instruction::InstructionError,
         rpc_port,
-        signature::{Keypair, KeypairUtil},
+        signature::{generate_keypair, Keypair, KeypairUtil},
         system_transaction,
         transaction::TransactionError,
     };
@@ -1172,9 +1172,9 @@ pub mod tests {
         let blockstore = Blockstore::open(&ledger_path).unwrap();
         let blockstore = Arc::new(blockstore);
 
-        let keypair1 = Keypair::new();
-        let keypair2 = Keypair::new();
-        let keypair3 = Keypair::new();
+        let keypair1 = generate_keypair();
+        let keypair2 = generate_keypair();
+        let keypair3 = generate_keypair();
         bank.transfer(4, &alice, &keypair2.pubkey()).unwrap();
         let confirmed_block_signatures = create_test_transactions_and_populate_blockstore(
             vec![&alice, &keypair1, &keypair2, &keypair3],
@@ -1605,7 +1605,7 @@ pub mod tests {
 
     #[test]
     fn test_rpc_get_program_accounts() {
-        let bob = Keypair::new();
+        let bob = generate_keypair();
         let RpcHandler {
             io,
             meta,
@@ -1871,7 +1871,8 @@ pub mod tests {
 
     #[test]
     fn test_rpc_verify_signature() {
-        let tx = system_transaction::transfer(&Keypair::new(), &Pubkey::new_rand(), 20, hash(&[0]));
+        let tx =
+            system_transaction::transfer(&generate_keypair(), &Pubkey::new_rand(), 20, hash(&[0]));
         assert_eq!(
             verify_signature(&tx.signatures[0].to_string()).unwrap(),
             tx.signatures[0]
@@ -2273,7 +2274,7 @@ pub mod tests {
         assert_eq!(bank.vote_accounts().len(), 1);
 
         // Create a vote account with no stake.
-        let alice_vote_keypair = Keypair::new();
+        let alice_vote_keypair = generate_keypair();
         let instructions = vote_instruction::create_account(
             &alice.pubkey(),
             &alice_vote_keypair.pubkey(),

--- a/core/src/rpc_pubsub.rs
+++ b/core/src/rpc_pubsub.rs
@@ -288,7 +288,7 @@ mod tests {
     use solana_runtime::bank::Bank;
     use solana_sdk::{
         pubkey::Pubkey,
-        signature::{Keypair, KeypairUtil},
+        signature::{generate_keypair, KeypairUtil},
         system_program, system_transaction,
         transaction::{self, Transaction},
     };
@@ -320,7 +320,7 @@ mod tests {
             mint_keypair: alice,
             ..
         } = create_genesis_config(10_000);
-        let bob = Keypair::new();
+        let bob = generate_keypair();
         let bob_pubkey = bob.pubkey();
         let bank = Bank::new(&genesis_config);
         let blockhash = bank.last_blockhash();
@@ -411,9 +411,9 @@ mod tests {
             .push(solana_budget_program!());
 
         let bob_pubkey = Pubkey::new_rand();
-        let witness = Keypair::new();
-        let contract_funds = Keypair::new();
-        let contract_state = Keypair::new();
+        let witness = generate_keypair();
+        let contract_funds = generate_keypair();
+        let contract_state = generate_keypair();
         let budget_program_id = solana_budget_program::id();
         let bank = Bank::new(&genesis_config);
         let blockhash = bank.last_blockhash();
@@ -548,7 +548,7 @@ mod tests {
         let bank = Bank::new(&genesis_config);
         let blockhash = bank.last_blockhash();
         let bank_forks = Arc::new(RwLock::new(BankForks::new(0, bank)));
-        let bob = Keypair::new();
+        let bob = generate_keypair();
 
         let rpc = RpcSolPubSubImpl::default();
         let session = create_session();
@@ -579,7 +579,7 @@ mod tests {
         let bank = Bank::new(&genesis_config);
         let blockhash = bank.last_blockhash();
         let bank_forks = Arc::new(RwLock::new(BankForks::new(0, bank)));
-        let bob = Keypair::new();
+        let bob = generate_keypair();
 
         let rpc = RpcSolPubSubImpl::default();
         let session = create_session();

--- a/core/src/rpc_subscriptions.rs
+++ b/core/src/rpc_subscriptions.rs
@@ -486,7 +486,7 @@ pub(crate) mod tests {
     use jsonrpc_pubsub::typed::Subscriber;
     use solana_budget_program;
     use solana_sdk::{
-        signature::{Keypair, KeypairUtil},
+        signature::{generate_keypair, KeypairUtil},
         system_transaction,
     };
     use tokio::prelude::{Async, Stream};
@@ -521,7 +521,7 @@ pub(crate) mod tests {
         let bank = Bank::new(&genesis_config);
         let blockhash = bank.last_blockhash();
         let bank_forks = Arc::new(RwLock::new(BankForks::new(0, bank)));
-        let alice = Keypair::new();
+        let alice = generate_keypair();
         let tx = system_transaction::create_account(
             &mint_keypair,
             &alice,
@@ -577,7 +577,7 @@ pub(crate) mod tests {
         let bank = Bank::new(&genesis_config);
         let blockhash = bank.last_blockhash();
         let bank_forks = Arc::new(RwLock::new(BankForks::new(0, bank)));
-        let alice = Keypair::new();
+        let alice = generate_keypair();
         let tx = system_transaction::create_account(
             &mint_keypair,
             &alice,
@@ -634,7 +634,7 @@ pub(crate) mod tests {
         let bank = Bank::new(&genesis_config);
         let blockhash = bank.last_blockhash();
         let bank_forks = Arc::new(RwLock::new(BankForks::new(0, bank)));
-        let alice = Keypair::new();
+        let alice = generate_keypair();
         let tx = system_transaction::transfer(&mint_keypair, &alice.pubkey(), 20, blockhash);
         let signature = tx.signatures[0];
         bank_forks

--- a/core/src/sigverify_shreds.rs
+++ b/core/src/sigverify_shreds.rs
@@ -76,7 +76,7 @@ pub mod tests {
     use crate::packet::Packet;
     use solana_ledger::shred::{Shred, Shredder};
     use solana_runtime::bank::Bank;
-    use solana_sdk::signature::{Keypair, KeypairUtil};
+    use solana_sdk::signature::{generate_keypair, KeypairUtil};
 
     #[test]
     fn test_sigverify_shreds_read_slots() {
@@ -94,7 +94,7 @@ pub mod tests {
         );
         let mut batch = [Packets::default(), Packets::default()];
 
-        let keypair = Keypair::new();
+        let keypair = generate_keypair();
         Shredder::sign_shred(&keypair, &mut shred);
         batch[0].packets.resize(1, Packet::default());
         batch[0].packets[0].data[0..shred.payload.len()].copy_from_slice(&shred.payload);
@@ -122,7 +122,7 @@ pub mod tests {
 
     #[test]
     fn test_sigverify_shreds_verify_batch() {
-        let leader_keypair = Arc::new(Keypair::new());
+        let leader_keypair = Arc::new(generate_keypair());
         let leader_pubkey = leader_keypair.pubkey();
         let bank =
             Bank::new(&create_genesis_config_with_leader(100, &leader_pubkey, 10).genesis_config);
@@ -159,7 +159,7 @@ pub mod tests {
             0,
             0xc0de,
         );
-        let wrong_keypair = Keypair::new();
+        let wrong_keypair = generate_keypair();
         Shredder::sign_shred(&wrong_keypair, &mut shred);
         batch[0].packets[1].data[0..shred.payload.len()].copy_from_slice(&shred.payload);
         batch[0].packets[1].meta.size = shred.payload.len();

--- a/core/src/storage_stage.rs
+++ b/core/src/storage_stage.rs
@@ -649,7 +649,7 @@ mod tests {
     use rayon::prelude::*;
     use solana_runtime::bank::Bank;
     use solana_sdk::hash::Hasher;
-    use solana_sdk::signature::{Keypair, KeypairUtil};
+    use solana_sdk::signature::{generate_keypair, KeypairUtil};
     use std::cmp::{max, min};
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
     use std::sync::mpsc::channel;
@@ -657,8 +657,8 @@ mod tests {
 
     #[test]
     fn test_storage_stage_none_ledger() {
-        let keypair = Arc::new(Keypair::new());
-        let storage_keypair = Arc::new(Keypair::new());
+        let keypair = Arc::new(generate_keypair());
+        let storage_keypair = Arc::new(generate_keypair());
         let exit = Arc::new(AtomicBool::new(false));
 
         let cluster_info = test_cluster_info(&keypair.pubkey());
@@ -701,7 +701,7 @@ mod tests {
             (0..(32 * NUM_IDENTITIES))
                 .into_par_iter()
                 .for_each(move |_| {
-                    let keypair = Keypair::new();
+                    let keypair = generate_keypair();
                     let hash = hasher.clone().result();
                     let signature = keypair.sign_message(&hash.as_ref());
                     let ix = get_identity_index_from_signature(&signature);

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -255,13 +255,14 @@ pub mod tests {
     use crate::genesis_utils::{create_genesis_config, GenesisConfigInfo};
     use solana_ledger::create_new_tmp_ledger;
     use solana_runtime::bank::Bank;
+    use solana_sdk::signature::generate_keypair;
     use std::sync::atomic::Ordering;
 
     #[test]
     fn test_tvu_exit() {
         solana_logger::setup();
         let leader = Node::new_localhost();
-        let target1_keypair = Keypair::new();
+        let target1_keypair = generate_keypair();
         let target1 = Node::new_localhost_with_pubkey(&target1_keypair.pubkey());
 
         let starting_balance = 10_000;
@@ -282,8 +283,8 @@ pub mod tests {
         let bank = bank_forks.working_bank();
         let (exit, poh_recorder, poh_service, _entry_receiver) =
             create_test_recorder(&bank, &blockstore, None);
-        let voting_keypair = Keypair::new();
-        let storage_keypair = Arc::new(Keypair::new());
+        let voting_keypair = generate_keypair();
+        let storage_keypair = Arc::new(generate_keypair());
         let leader_schedule_cache = Arc::new(LeaderScheduleCache::new_from_bank(&bank));
         let block_commitment_cache = Arc::new(RwLock::new(BlockCommitmentCache::default()));
         let tvu = Tvu::new(

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -40,7 +40,7 @@ use solana_sdk::{
     hash::Hash,
     poh_config::PohConfig,
     pubkey::Pubkey,
-    signature::{Keypair, KeypairUtil},
+    signature::{generate_keypair, Keypair, KeypairUtil},
     timing::timestamp,
 };
 use std::{
@@ -618,7 +618,7 @@ pub fn new_validator_for_tests_ex(
     use crate::genesis_utils::{create_genesis_config_with_leader_ex, GenesisConfigInfo};
     use solana_sdk::fee_calculator::FeeCalculator;
 
-    let node_keypair = Arc::new(Keypair::new());
+    let node_keypair = Arc::new(generate_keypair());
     let node = Node::new_localhost_with_pubkey(&node_keypair.pubkey());
     let contact_info = node.info.clone();
 
@@ -643,7 +643,7 @@ pub fn new_validator_for_tests_ex(
     let (ledger_path, _blockhash) = create_new_tmp_ledger!(&genesis_config);
 
     let leader_voting_keypair = Arc::new(voting_keypair);
-    let storage_keypair = Arc::new(Keypair::new());
+    let storage_keypair = Arc::new(generate_keypair());
     let config = ValidatorConfig {
         rpc_ports: Some((node.info.rpc.port(), node.info.rpc_pubsub.port())),
         ..ValidatorConfig::default()
@@ -732,18 +732,18 @@ mod tests {
     #[test]
     fn validator_exit() {
         solana_logger::setup();
-        let leader_keypair = Keypair::new();
+        let leader_keypair = generate_keypair();
         let leader_node = Node::new_localhost_with_pubkey(&leader_keypair.pubkey());
 
-        let validator_keypair = Keypair::new();
+        let validator_keypair = generate_keypair();
         let validator_node = Node::new_localhost_with_pubkey(&validator_keypair.pubkey());
         let genesis_config =
             create_genesis_config_with_leader(10_000, &leader_keypair.pubkey(), 1000)
                 .genesis_config;
         let (validator_ledger_path, _blockhash) = create_new_tmp_ledger!(&genesis_config);
 
-        let voting_keypair = Arc::new(Keypair::new());
-        let storage_keypair = Arc::new(Keypair::new());
+        let voting_keypair = Arc::new(generate_keypair());
+        let storage_keypair = Arc::new(generate_keypair());
         let config = ValidatorConfig {
             rpc_ports: Some((
                 validator_node.info.rpc.port(),
@@ -768,21 +768,21 @@ mod tests {
 
     #[test]
     fn validator_parallel_exit() {
-        let leader_keypair = Keypair::new();
+        let leader_keypair = generate_keypair();
         let leader_node = Node::new_localhost_with_pubkey(&leader_keypair.pubkey());
 
         let mut ledger_paths = vec![];
         let mut validators: Vec<Validator> = (0..2)
             .map(|_| {
-                let validator_keypair = Keypair::new();
+                let validator_keypair = generate_keypair();
                 let validator_node = Node::new_localhost_with_pubkey(&validator_keypair.pubkey());
                 let genesis_config =
                     create_genesis_config_with_leader(10_000, &leader_keypair.pubkey(), 1000)
                         .genesis_config;
                 let (validator_ledger_path, _blockhash) = create_new_tmp_ledger!(&genesis_config);
                 ledger_paths.push(validator_ledger_path.clone());
-                let voting_keypair = Arc::new(Keypair::new());
-                let storage_keypair = Arc::new(Keypair::new());
+                let voting_keypair = Arc::new(generate_keypair());
+                let storage_keypair = Arc::new(generate_keypair());
                 let config = ValidatorConfig {
                     rpc_ports: Some((
                         validator_node.info.rpc.port(),

--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -494,7 +494,7 @@ mod test {
         clock::Slot,
         epoch_schedule::MINIMUM_SLOTS_PER_EPOCH,
         hash::Hash,
-        signature::{Keypair, KeypairUtil},
+        signature::{generate_keypair, Keypair, KeypairUtil},
     };
     use std::{
         net::UdpSocket,
@@ -522,7 +522,8 @@ mod test {
         let blockstore = Arc::new(Blockstore::open(&blockstore_path).unwrap());
         let num_entries = 10;
         let original_entries = create_ticks(num_entries, 0, Hash::default());
-        let mut shreds = local_entries_to_shred(&original_entries, 0, 0, &Arc::new(Keypair::new()));
+        let mut shreds =
+            local_entries_to_shred(&original_entries, 0, 0, &Arc::new(generate_keypair()));
         shreds.reverse();
         blockstore
             .insert_shreds(shreds, None, false)
@@ -540,7 +541,7 @@ mod test {
     #[test]
     fn test_should_retransmit_and_persist() {
         let me_id = Pubkey::new_rand();
-        let leader_keypair = Arc::new(Keypair::new());
+        let leader_keypair = Arc::new(generate_keypair());
         let leader_pubkey = leader_keypair.pubkey();
         let bank = Arc::new(Bank::new(
             &create_genesis_config_with_leader(100, &leader_pubkey, 10).genesis_config,

--- a/core/tests/bank_forks.rs
+++ b/core/tests/bank_forks.rs
@@ -21,7 +21,7 @@ mod tests {
         clock::Slot,
         hash::hashv,
         pubkey::Pubkey,
-        signature::{Keypair, KeypairUtil},
+        signature::{generate_keypair, Keypair, KeypairUtil},
         system_transaction,
     };
     use std::{fs, path::PathBuf, sync::atomic::AtomicBool, sync::mpsc::channel, sync::Arc};
@@ -155,12 +155,12 @@ mod tests {
         run_bank_forks_snapshot_n(
             4,
             |bank, mint_keypair| {
-                let key1 = Keypair::new().pubkey();
+                let key1 = generate_keypair().pubkey();
                 let tx =
                     system_transaction::transfer(&mint_keypair, &key1, 1, bank.last_blockhash());
                 assert_eq!(bank.process_transaction(&tx), Ok(()));
 
-                let key2 = Keypair::new().pubkey();
+                let key2 = generate_keypair().pubkey();
                 let tx =
                     system_transaction::transfer(&mint_keypair, &key2, 0, bank.last_blockhash());
                 assert_eq!(bank.process_transaction(&tx), Ok(()));
@@ -225,7 +225,7 @@ mod tests {
                 (forks + 1) as u64,
             );
             let slot = bank.slot();
-            let key1 = Keypair::new().pubkey();
+            let key1 = generate_keypair().pubkey();
             let tx = system_transaction::transfer(&mint_keypair, &key1, 1, genesis_config.hash());
             assert_eq!(bank.process_transaction(&tx), Ok(()));
             bank.squash();
@@ -379,8 +379,8 @@ mod tests {
         // this is done to ensure the AccountStorageEntries keep getting cleaned up as the root moves
         // ahead. Also tests the status_cache purge and status cache snapshotting.
         // Makes sure that the last bank is restored correctly
-        let key1 = Keypair::new().pubkey();
-        let key2 = Keypair::new().pubkey();
+        let key1 = generate_keypair().pubkey();
+        let key2 = generate_keypair().pubkey();
         for set_root_interval in &[1, 4] {
             run_bank_forks_snapshot_n(
                 (MAX_CACHE_ENTRIES * 2 + 1) as u64,

--- a/core/tests/gossip.rs
+++ b/core/tests/gossip.rs
@@ -6,7 +6,7 @@ use solana_core::cluster_info::{ClusterInfo, Node};
 use solana_core::gossip_service::GossipService;
 
 use solana_core::packet::Packet;
-use solana_sdk::signature::{Keypair, KeypairUtil};
+use solana_sdk::signature::{generate_keypair, KeypairUtil};
 use solana_sdk::timing::timestamp;
 use std::net::UdpSocket;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -15,7 +15,7 @@ use std::thread::sleep;
 use std::time::Duration;
 
 fn test_node(exit: &Arc<AtomicBool>) -> (Arc<RwLock<ClusterInfo>>, GossipService, UdpSocket) {
-    let keypair = Arc::new(Keypair::new());
+    let keypair = Arc::new(generate_keypair());
     let mut test_node = Node::new_localhost_with_pubkey(&keypair.pubkey());
     let cluster_info = Arc::new(RwLock::new(ClusterInfo::new(
         test_node.info.clone(),

--- a/core/tests/storage_stage.rs
+++ b/core/tests/storage_stage.rs
@@ -15,7 +15,7 @@ mod tests {
     use solana_sdk::hash::Hash;
     use solana_sdk::message::Message;
     use solana_sdk::pubkey::Pubkey;
-    use solana_sdk::signature::{Keypair, KeypairUtil};
+    use solana_sdk::signature::{generate_keypair, KeypairUtil};
     use solana_sdk::transaction::Transaction;
     use solana_storage_program::storage_instruction;
     use solana_storage_program::storage_instruction::StorageAccountType;
@@ -29,9 +29,9 @@ mod tests {
     #[test]
     fn test_storage_stage_process_account_proofs() {
         solana_logger::setup();
-        let keypair = Arc::new(Keypair::new());
-        let storage_keypair = Arc::new(Keypair::new());
-        let archiver_keypair = Arc::new(Keypair::new());
+        let keypair = Arc::new(generate_keypair());
+        let storage_keypair = Arc::new(generate_keypair());
+        let archiver_keypair = Arc::new(generate_keypair());
         let exit = Arc::new(AtomicBool::new(false));
 
         let GenesisConfigInfo {
@@ -97,7 +97,7 @@ mod tests {
             reference_keys.copy_from_slice(keys);
         }
 
-        let keypair = Keypair::new();
+        let keypair = generate_keypair();
 
         let mining_proof_ix = storage_instruction::mining_proof(
             &archiver_keypair.pubkey(),
@@ -157,8 +157,8 @@ mod tests {
     #[test]
     fn test_storage_stage_process_banks() {
         solana_logger::setup();
-        let keypair = Arc::new(Keypair::new());
-        let storage_keypair = Arc::new(Keypair::new());
+        let keypair = Arc::new(generate_keypair());
+        let storage_keypair = Arc::new(generate_keypair());
         let exit = Arc::new(AtomicBool::new(false));
 
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(1000);
@@ -191,7 +191,7 @@ mod tests {
         );
         bank_sender.send(vec![bank.clone()]).unwrap();
 
-        let keypair = Keypair::new();
+        let keypair = generate_keypair();
         let hash = Hash::default();
         let signature = keypair.sign_message(&hash.as_ref());
 

--- a/faucet/src/faucet.rs
+++ b/faucet/src/faucet.rs
@@ -307,12 +307,13 @@ pub fn run_faucet(
 mod tests {
     use super::*;
     use bytes::BufMut;
+    use solana_sdk::signature::generate_keypair;
     use solana_sdk::system_instruction::SystemInstruction;
     use std::time::Duration;
 
     #[test]
     fn test_check_request_limit() {
-        let keypair = Keypair::new();
+        let keypair = generate_keypair();
         let mut faucet = Faucet::new(keypair, None, Some(3));
         assert!(faucet.check_request_limit(1));
         faucet.request_current = 3;
@@ -321,7 +322,7 @@ mod tests {
 
     #[test]
     fn test_clear_request_count() {
-        let keypair = Keypair::new();
+        let keypair = generate_keypair();
         let mut faucet = Faucet::new(keypair, None, None);
         faucet.request_current = faucet.request_current + 256;
         assert_eq!(faucet.request_current, 256);
@@ -331,7 +332,7 @@ mod tests {
 
     #[test]
     fn test_add_ip_to_cache() {
-        let keypair = Keypair::new();
+        let keypair = generate_keypair();
         let mut faucet = Faucet::new(keypair, None, None);
         let ip = "127.0.0.1".parse().expect("create IpAddr from string");
         assert_eq!(faucet.ip_cache.len(), 0);
@@ -342,7 +343,7 @@ mod tests {
 
     #[test]
     fn test_clear_ip_cache() {
-        let keypair = Keypair::new();
+        let keypair = generate_keypair();
         let mut faucet = Faucet::new(keypair, None, None);
         let ip = "127.0.0.1".parse().expect("create IpAddr from string");
         assert_eq!(faucet.ip_cache.len(), 0);
@@ -355,7 +356,7 @@ mod tests {
 
     #[test]
     fn test_faucet_default_init() {
-        let keypair = Keypair::new();
+        let keypair = generate_keypair();
         let time_slice: Option<u64> = None;
         let request_cap: Option<u64> = None;
         let faucet = Faucet::new(keypair, time_slice, request_cap);
@@ -373,7 +374,7 @@ mod tests {
             blockhash,
         };
 
-        let mint = Keypair::new();
+        let mint = generate_keypair();
         let mint_pubkey = mint.pubkey();
         let mut faucet = Faucet::new(mint, None, None);
 
@@ -391,7 +392,7 @@ mod tests {
         let instruction: SystemInstruction = deserialize(&message.instructions[0].data).unwrap();
         assert_eq!(instruction, SystemInstruction::Transfer { lamports: 2 });
 
-        let mint = Keypair::new();
+        let mint = generate_keypair();
         faucet = Faucet::new(mint, None, Some(1));
         let tx = faucet.build_airdrop_transaction(request);
         assert!(tx.is_err());
@@ -411,7 +412,7 @@ mod tests {
         let mut bytes = BytesMut::with_capacity(req.len());
         bytes.put(&req[..]);
 
-        let keypair = Keypair::new();
+        let keypair = generate_keypair();
         let expected_instruction = system_instruction::transfer(&keypair.pubkey(), &to, lamports);
         let message = Message::new(vec![expected_instruction]);
         let expected_tx = Transaction::new(&[&keypair], message, blockhash);

--- a/faucet/src/faucet_mock.rs
+++ b/faucet/src/faucet_mock.rs
@@ -1,8 +1,5 @@
 use solana_sdk::{
-    hash::Hash,
-    pubkey::Pubkey,
-    signature::{Keypair, KeypairUtil},
-    system_transaction,
+    hash::Hash, pubkey::Pubkey, signature::generate_keypair, system_transaction,
     transaction::Transaction,
 };
 use std::{
@@ -19,7 +16,7 @@ pub fn request_airdrop_transaction(
     if lamports == 0 {
         Err(Error::new(ErrorKind::Other, "Airdrop failed"))
     } else {
-        let key = Keypair::new();
+        let key = generate_keypair();
         let to = Pubkey::new_rand();
         let blockhash = Hash::default();
         let tx = system_transaction::transfer(&key, &to, lamports, blockhash);

--- a/faucet/tests/local-faucet.rs
+++ b/faucet/tests/local-faucet.rs
@@ -3,7 +3,7 @@ use solana_sdk::{
     hash::Hash,
     message::Message,
     pubkey::Pubkey,
-    signature::{Keypair, KeypairUtil},
+    signature::{generate_keypair, KeypairUtil},
     system_instruction,
     transaction::Transaction,
 };
@@ -11,7 +11,7 @@ use std::sync::mpsc::channel;
 
 #[test]
 fn test_local_faucet() {
-    let keypair = Keypair::new();
+    let keypair = generate_keypair();
     let to = Pubkey::new_rand();
     let lamports = 50;
     let blockhash = Hash::new(&to.as_ref());

--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -22,7 +22,7 @@ use solana_sdk::{
     poh_config::PohConfig,
     pubkey::Pubkey,
     rent::Rent,
-    signature::{Keypair, KeypairUtil},
+    signature::{generate_keypair, Keypair, KeypairUtil},
     system_program, timing,
 };
 use solana_stake_program::stake_state::{self, StakeState};
@@ -730,7 +730,7 @@ mod tests {
         }
 
         // Test accounts from keypairs can be appended
-        let account_keypairs: Vec<_> = (0..3).map(|_| Keypair::new()).collect();
+        let account_keypairs: Vec<_> = (0..3).map(|_| generate_keypair()).collect();
         let mut genesis_accounts2 = HashMap::new();
         genesis_accounts2.insert(
             serde_json::to_string(&account_keypairs[0].to_bytes().to_vec()).unwrap(),

--- a/keygen/src/keygen.rs
+++ b/keygen/src/keygen.rs
@@ -20,8 +20,8 @@ use solana_remote_wallet::{
 use solana_sdk::{
     pubkey::{write_pubkey_file, Pubkey},
     signature::{
-        keypair_from_seed, read_keypair, read_keypair_file, write_keypair, write_keypair_file,
-        Keypair, KeypairUtil, Signature,
+        generate_keypair, keypair_from_seed, read_keypair, read_keypair_file, write_keypair,
+        write_keypair_file, Keypair, KeypairUtil, Signature,
     },
 };
 use std::{
@@ -572,7 +572,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                             found.load(Ordering::Relaxed),
                         );
                     }
-                    let keypair = Keypair::new();
+                    let keypair = generate_keypair();
                     let mut pubkey = bs58::encode(keypair.pubkey()).into_string();
                     if ignore_case {
                         pubkey = pubkey.to_lowercase();

--- a/ledger/benches/sigverify_shreds.rs
+++ b/ledger/benches/sigverify_shreds.rs
@@ -8,7 +8,7 @@ use solana_ledger::sigverify_shreds::{
 };
 use solana_perf::packet::{Packet, Packets};
 use solana_perf::recycler_cache::RecyclerCache;
-use solana_sdk::signature::{Keypair, KeypairUtil};
+use solana_sdk::signature::{generate_keypair, KeypairUtil};
 use std::sync::Arc;
 use test::Bencher;
 
@@ -39,7 +39,7 @@ fn bench_sigverify_shreds_sign_gpu(bencher: &mut Bencher) {
         shred.copy_to_packet(p);
     }
     let mut batch = vec![packets; NUM_BATCHES];
-    let keypair = Keypair::new();
+    let keypair = generate_keypair();
     let pinned_keypair = sign_shreds_gpu_pinned_keypair(&keypair, &recycler_cache);
     let pinned_keypair = Some(Arc::new(pinned_keypair));
     //warmup
@@ -71,7 +71,7 @@ fn bench_sigverify_shreds_sign_cpu(bencher: &mut Bencher) {
         shred.copy_to_packet(p);
     }
     let mut batch = vec![packets; NUM_BATCHES];
-    let keypair = Keypair::new();
+    let keypair = generate_keypair();
     bencher.iter(|| {
         sign_shreds_cpu(&keypair, &mut batch);
     })

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -23,7 +23,7 @@ use solana_sdk::{
     clock::{Slot, MAX_RECENT_BLOCKHASHES},
     genesis_config::GenesisConfig,
     hash::Hash,
-    signature::{Keypair, KeypairUtil},
+    signature::generate_keypair,
     timing::duration_as_ms,
     transaction::{Result, Transaction, TransactionError},
 };
@@ -840,7 +840,7 @@ pub fn fill_blockstore_slot_with_ticks(
             ticks_per_slot,
             Some(parent_slot),
             true,
-            &Arc::new(Keypair::new()),
+            &Arc::new(generate_keypair()),
             entries,
             0,
         )
@@ -898,7 +898,7 @@ pub mod tests {
                 ticks_per_slot,
                 Some(parent_slot),
                 true,
-                &Arc::new(Keypair::new()),
+                &Arc::new(generate_keypair()),
                 entries,
                 0,
             ),
@@ -941,7 +941,7 @@ pub mod tests {
                 ticks_per_slot,
                 Some(parent_slot),
                 true,
-                &Arc::new(Keypair::new()),
+                &Arc::new(generate_keypair()),
                 entries,
                 0,
             ),
@@ -996,7 +996,7 @@ pub mod tests {
 
         let mut entries = create_ticks(ticks_per_slot, 0, blockhash);
         let trailing_entry = {
-            let keypair = Keypair::new();
+            let keypair = generate_keypair();
             let tx = system_transaction::transfer(&mint_keypair, &keypair.pubkey(), 1, blockhash);
             next_entry(&blockhash, 1, vec![tx])
         };
@@ -1014,7 +1014,7 @@ pub mod tests {
                 ticks_per_slot + 1,
                 Some(parent_slot),
                 true,
-                &Arc::new(Keypair::new()),
+                &Arc::new(generate_keypair()),
                 entries,
                 0,
             ),
@@ -1075,7 +1075,7 @@ pub mod tests {
                     ticks_per_slot,
                     Some(parent_slot),
                     false,
-                    &Arc::new(Keypair::new()),
+                    &Arc::new(generate_keypair()),
                     entries,
                     0,
                 ),
@@ -1557,7 +1557,7 @@ pub mod tests {
             ..
         } = create_genesis_config(2);
         let bank = Arc::new(Bank::new(&genesis_config));
-        let keypair = Keypair::new();
+        let keypair = generate_keypair();
         let slot_entries = create_ticks(genesis_config.ticks_per_slot, 1, genesis_config.hash());
         let tx = system_transaction::transfer(
             &mint_keypair,
@@ -1597,14 +1597,14 @@ pub mod tests {
         let blockhash = genesis_config.hash();
         for _ in 0..deducted_from_mint {
             // Transfer one token from the mint to a random account
-            let keypair = Keypair::new();
+            let keypair = generate_keypair();
             let tx = system_transaction::transfer(&mint_keypair, &keypair.pubkey(), 1, blockhash);
             let entry = next_entry_mut(&mut last_entry_hash, 1, vec![tx]);
             entries.push(entry);
 
             // Add a second Transaction that will produce a
             // InstructionError<0, ResultWithNegativeLamports> error when processed
-            let keypair2 = Keypair::new();
+            let keypair2 = generate_keypair();
             let tx =
                 system_transaction::transfer(&mint_keypair, &keypair2.pubkey(), 101, blockhash);
             let entry = next_entry_mut(&mut last_entry_hash, 1, vec![tx]);
@@ -1633,7 +1633,7 @@ pub mod tests {
                 genesis_config.ticks_per_slot,
                 None,
                 true,
-                &Arc::new(Keypair::new()),
+                &Arc::new(generate_keypair()),
                 entries,
                 0,
             )
@@ -1722,7 +1722,7 @@ pub mod tests {
         let blockstore =
             Blockstore::open(&ledger_path).expect("Expected to successfully open database ledger");
         let blockhash = genesis_config.hash();
-        let keypairs = [Keypair::new(), Keypair::new(), Keypair::new()];
+        let keypairs = [generate_keypair(), generate_keypair(), generate_keypair()];
 
         let tx = system_transaction::transfer(&mint_keypair, &keypairs[0].pubkey(), 1, blockhash);
         let entry_1 = next_entry(&last_entry_hash, 1, vec![tx]);
@@ -1744,7 +1744,7 @@ pub mod tests {
                 genesis_config.ticks_per_slot,
                 None,
                 true,
-                &Arc::new(Keypair::new()),
+                &Arc::new(generate_keypair()),
                 entries,
                 0,
             )
@@ -1791,8 +1791,8 @@ pub mod tests {
             ..
         } = create_genesis_config(1000);
         let bank = Arc::new(Bank::new(&genesis_config));
-        let keypair1 = Keypair::new();
-        let keypair2 = Keypair::new();
+        let keypair1 = generate_keypair();
+        let keypair2 = generate_keypair();
 
         let blockhash = bank.last_blockhash();
 
@@ -1828,9 +1828,9 @@ pub mod tests {
             ..
         } = create_genesis_config(1000);
         let bank = Arc::new(Bank::new(&genesis_config));
-        let keypair1 = Keypair::new();
-        let keypair2 = Keypair::new();
-        let keypair3 = Keypair::new();
+        let keypair1 = generate_keypair();
+        let keypair2 = generate_keypair();
+        let keypair3 = generate_keypair();
 
         // fund: put 4 in each of 1 and 2
         assert_matches!(bank.transfer(4, &mint_keypair, &keypair1.pubkey()), Ok(_));
@@ -1890,10 +1890,10 @@ pub mod tests {
             ..
         } = create_genesis_config(1000);
         let bank = Arc::new(Bank::new(&genesis_config));
-        let keypair1 = Keypair::new();
-        let keypair2 = Keypair::new();
-        let keypair3 = Keypair::new();
-        let keypair4 = Keypair::new();
+        let keypair1 = generate_keypair();
+        let keypair2 = generate_keypair();
+        let keypair3 = generate_keypair();
+        let keypair4 = generate_keypair();
 
         // fund: put 4 in each of 1 and 2
         assert_matches!(bank.transfer(4, &mint_keypair, &keypair1.pubkey()), Ok(_));
@@ -1976,9 +1976,9 @@ pub mod tests {
             ..
         } = create_genesis_config(1000);
         let bank = Arc::new(Bank::new(&genesis_config));
-        let keypair1 = Keypair::new();
-        let keypair2 = Keypair::new();
-        let keypair3 = Keypair::new();
+        let keypair1 = generate_keypair();
+        let keypair2 = generate_keypair();
+        let keypair3 = generate_keypair();
 
         // fund: put some money in each of 1 and 2
         assert_matches!(bank.transfer(5, &mint_keypair, &keypair1.pubkey()), Ok(_));
@@ -2072,10 +2072,10 @@ pub mod tests {
             ..
         } = create_genesis_config(1000);
         let bank = Arc::new(Bank::new(&genesis_config));
-        let keypair1 = Keypair::new();
-        let keypair2 = Keypair::new();
-        let keypair3 = Keypair::new();
-        let keypair4 = Keypair::new();
+        let keypair1 = generate_keypair();
+        let keypair2 = generate_keypair();
+        let keypair3 = generate_keypair();
+        let keypair4 = generate_keypair();
 
         //load accounts
         let tx = system_transaction::transfer(
@@ -2123,7 +2123,7 @@ pub mod tests {
         const NUM_TRANSFERS: usize = NUM_TRANSFERS_PER_ENTRY * 32;
         // large enough to scramble locks and results
 
-        let keypairs: Vec<_> = (0..NUM_TRANSFERS * 2).map(|_| Keypair::new()).collect();
+        let keypairs: Vec<_> = (0..NUM_TRANSFERS * 2).map(|_| generate_keypair()).collect();
 
         // give everybody one lamport
         for keypair in &keypairs {
@@ -2132,7 +2132,7 @@ pub mod tests {
         }
         let mut hash = bank.last_blockhash();
 
-        let present_account_key = Keypair::new();
+        let present_account_key = generate_keypair();
         let present_account = Account::new(1, 10, &Pubkey::default());
         bank.store_account(&present_account_key.pubkey(), &present_account);
 
@@ -2186,7 +2186,7 @@ pub mod tests {
         let mut keypairs: Vec<Keypair> = vec![];
 
         for _ in 0..num_accounts {
-            let keypair = Keypair::new();
+            let keypair = generate_keypair();
             let create_account_tx = system_transaction::transfer(
                 &mint_keypair,
                 &keypair.pubkey(),
@@ -2249,10 +2249,10 @@ pub mod tests {
             ..
         } = create_genesis_config(1000);
         let bank = Arc::new(Bank::new(&genesis_config));
-        let keypair1 = Keypair::new();
-        let keypair2 = Keypair::new();
-        let keypair3 = Keypair::new();
-        let keypair4 = Keypair::new();
+        let keypair1 = generate_keypair();
+        let keypair2 = generate_keypair();
+        let keypair3 = generate_keypair();
+        let keypair4 = generate_keypair();
 
         //load accounts
         let tx = system_transaction::transfer(
@@ -2354,8 +2354,8 @@ pub mod tests {
             ..
         } = create_genesis_config(11_000);
         let bank = Arc::new(Bank::new(&genesis_config));
-        let keypair1 = Keypair::new();
-        let keypair2 = Keypair::new();
+        let keypair1 = generate_keypair();
+        let keypair2 = generate_keypair();
         let success_tx = system_transaction::transfer(
             &mint_keypair,
             &keypair1.pubkey(),
@@ -2486,7 +2486,7 @@ pub mod tests {
         const NUM_TRANSFERS_PER_ENTRY: usize = 8;
         const NUM_TRANSFERS: usize = NUM_TRANSFERS_PER_ENTRY * 32;
 
-        let keypairs: Vec<_> = (0..NUM_TRANSFERS * 2).map(|_| Keypair::new()).collect();
+        let keypairs: Vec<_> = (0..NUM_TRANSFERS * 2).map(|_| generate_keypair()).collect();
 
         // give everybody one lamport
         for keypair in &keypairs {
@@ -2494,7 +2494,7 @@ pub mod tests {
                 .expect("funding failed");
         }
 
-        let present_account_key = Keypair::new();
+        let present_account_key = generate_keypair();
         let present_account = Account::new(1, 10, &Pubkey::default());
         bank.store_account(&present_account_key.pubkey(), &present_account);
 
@@ -2589,7 +2589,7 @@ pub mod tests {
         } = create_genesis_config(100);
         let bank0 = Arc::new(Bank::new(&genesis_config));
         let genesis_hash = genesis_config.hash();
-        let keypair = Keypair::new();
+        let keypair = generate_keypair();
 
         // Simulate a slot of virtual ticks, creates a new blockhash
         let mut entries = create_ticks(genesis_config.ticks_per_slot, 1, genesis_hash);

--- a/ledger/src/entry.rs
+++ b/ledger/src/entry.rs
@@ -457,14 +457,14 @@ mod tests {
     use solana_sdk::{
         hash::{hash, Hash},
         message::Message,
-        signature::{Keypair, KeypairUtil},
+        signature::{generate_keypair, Keypair, KeypairUtil},
         system_transaction,
         transaction::Transaction,
     };
 
     fn create_sample_payment(keypair: &Keypair, hash: Hash) -> Transaction {
         let pubkey = keypair.pubkey();
-        let budget_contract = Keypair::new();
+        let budget_contract = generate_keypair();
         let budget_pubkey = budget_contract.pubkey();
         let ixs = budget_instruction::payment(&pubkey, &pubkey, &budget_pubkey, 1);
         Transaction::new_signed_instructions(&[keypair, &budget_contract], ixs, hash)
@@ -497,7 +497,7 @@ mod tests {
         let zero = Hash::default();
 
         // First, verify entries
-        let keypair = Keypair::new();
+        let keypair = generate_keypair();
         let tx0 = system_transaction::transfer(&keypair, &keypair.pubkey(), 0, zero);
         let tx1 = system_transaction::transfer(&keypair, &keypair.pubkey(), 1, zero);
         let mut e0 = Entry::new(&zero, 0, vec![tx0.clone(), tx1.clone()]);
@@ -514,7 +514,7 @@ mod tests {
         let zero = Hash::default();
 
         // First, verify entries
-        let keypair = Keypair::new();
+        let keypair = generate_keypair();
         let tx0 = create_sample_timestamp(&keypair, zero);
         let tx1 = create_sample_apply_signature(&keypair, zero);
         let mut e0 = Entry::new(&zero, 0, vec![tx0.clone(), tx1.clone()]);
@@ -537,7 +537,7 @@ mod tests {
         assert_eq!(tick.num_hashes, 0);
         assert_eq!(tick.hash, zero);
 
-        let keypair = Keypair::new();
+        let keypair = generate_keypair();
         let tx0 = create_sample_timestamp(&keypair, zero);
         let entry0 = next_entry(&zero, 1, vec![tx0.clone()]);
         assert_eq!(entry0.num_hashes, 1);
@@ -548,7 +548,7 @@ mod tests {
     #[should_panic]
     fn test_next_entry_panic() {
         let zero = Hash::default();
-        let keypair = Keypair::new();
+        let keypair = generate_keypair();
         let tx = system_transaction::transfer(&keypair, &keypair.pubkey(), 0, zero);
         next_entry(&zero, 0, vec![tx]);
     }

--- a/ledger/src/leader_schedule_cache.rs
+++ b/ledger/src/leader_schedule_cache.rs
@@ -265,7 +265,7 @@ mod tests {
         EpochSchedule, DEFAULT_LEADER_SCHEDULE_SLOT_OFFSET, DEFAULT_SLOTS_PER_EPOCH,
         MINIMUM_SLOTS_PER_EPOCH,
     };
-    use solana_sdk::signature::{Keypair, KeypairUtil};
+    use solana_sdk::signature::generate_keypair;
     use std::{sync::mpsc::channel, sync::Arc, thread::Builder};
 
     #[test]
@@ -516,7 +516,7 @@ mod tests {
 
         // Create new vote account
         let node_pubkey = Pubkey::new_rand();
-        let vote_account = Keypair::new();
+        let vote_account = generate_keypair();
         setup_vote_and_stake_accounts(
             &bank,
             &mint_keypair,

--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -920,7 +920,7 @@ pub mod tests {
     use bincode::serialized_size;
     use matches::assert_matches;
     use solana_sdk::hash::hash;
-    use solana_sdk::system_transaction;
+    use solana_sdk::{signature::generate_keypair, system_transaction};
     use std::collections::HashSet;
     use std::convert::TryInto;
 
@@ -966,7 +966,7 @@ pub mod tests {
 
     #[test]
     fn test_data_shredder() {
-        let keypair = Arc::new(Keypair::new());
+        let keypair = Arc::new(generate_keypair());
         let slot = 0x123456789abcdef0;
 
         // Test that parent cannot be > current slot
@@ -993,8 +993,8 @@ pub mod tests {
 
         let entries: Vec<_> = (0..5)
             .map(|_| {
-                let keypair0 = Keypair::new();
-                let keypair1 = Keypair::new();
+                let keypair0 = generate_keypair();
+                let keypair1 = generate_keypair();
                 let tx0 =
                     system_transaction::transfer(&keypair0, &keypair1.pubkey(), 1, Hash::default());
                 Entry::new(&Hash::default(), 1, vec![tx0])
@@ -1059,7 +1059,7 @@ pub mod tests {
 
     #[test]
     fn test_deserialize_shred_payload() {
-        let keypair = Arc::new(Keypair::new());
+        let keypair = Arc::new(generate_keypair());
         let slot = 1;
 
         let parent_slot = 0;
@@ -1068,8 +1068,8 @@ pub mod tests {
 
         let entries: Vec<_> = (0..5)
             .map(|_| {
-                let keypair0 = Keypair::new();
-                let keypair1 = Keypair::new();
+                let keypair0 = generate_keypair();
+                let keypair1 = generate_keypair();
                 let tx0 =
                     system_transaction::transfer(&keypair0, &keypair1.pubkey(), 1, Hash::default());
                 Entry::new(&Hash::default(), 1, vec![tx0])
@@ -1085,7 +1085,7 @@ pub mod tests {
 
     #[test]
     fn test_shred_reference_tick() {
-        let keypair = Arc::new(Keypair::new());
+        let keypair = Arc::new(generate_keypair());
         let slot = 1;
 
         let parent_slot = 0;
@@ -1094,8 +1094,8 @@ pub mod tests {
 
         let entries: Vec<_> = (0..5)
             .map(|_| {
-                let keypair0 = Keypair::new();
-                let keypair1 = Keypair::new();
+                let keypair0 = generate_keypair();
+                let keypair1 = generate_keypair();
                 let tx0 =
                     system_transaction::transfer(&keypair0, &keypair1.pubkey(), 1, Hash::default());
                 Entry::new(&Hash::default(), 1, vec![tx0])
@@ -1115,7 +1115,7 @@ pub mod tests {
 
     #[test]
     fn test_shred_reference_tick_overflow() {
-        let keypair = Arc::new(Keypair::new());
+        let keypair = Arc::new(generate_keypair());
         let slot = 1;
 
         let parent_slot = 0;
@@ -1124,8 +1124,8 @@ pub mod tests {
 
         let entries: Vec<_> = (0..5)
             .map(|_| {
-                let keypair0 = Keypair::new();
-                let keypair1 = Keypair::new();
+                let keypair0 = generate_keypair();
+                let keypair1 = generate_keypair();
                 let tx0 =
                     system_transaction::transfer(&keypair0, &keypair1.pubkey(), 1, Hash::default());
                 Entry::new(&Hash::default(), 1, vec![tx0])
@@ -1151,7 +1151,7 @@ pub mod tests {
 
     #[test]
     fn test_data_and_code_shredder() {
-        let keypair = Arc::new(Keypair::new());
+        let keypair = Arc::new(generate_keypair());
 
         let slot = 0x123456789abcdef0;
         // Test that FEC rate cannot be > 1.0
@@ -1167,8 +1167,8 @@ pub mod tests {
         let num_entries = max_ticks_per_n_shreds(1) + 1;
         let entries: Vec<_> = (0..num_entries)
             .map(|_| {
-                let keypair0 = Keypair::new();
-                let keypair1 = Keypair::new();
+                let keypair0 = generate_keypair();
+                let keypair1 = generate_keypair();
                 let tx0 =
                     system_transaction::transfer(&keypair0, &keypair1.pubkey(), 1, Hash::default());
                 Entry::new(&Hash::default(), 1, vec![tx0])
@@ -1197,13 +1197,13 @@ pub mod tests {
 
     #[test]
     fn test_recovery_and_reassembly() {
-        let keypair = Arc::new(Keypair::new());
+        let keypair = Arc::new(generate_keypair());
         let slot = 0x123456789abcdef0;
         let shredder = Shredder::new(slot, slot - 5, 1.0, keypair.clone(), 0, 0)
             .expect("Failed in creating shredder");
 
-        let keypair0 = Keypair::new();
-        let keypair1 = Keypair::new();
+        let keypair0 = generate_keypair();
+        let keypair1 = generate_keypair();
         let tx0 = system_transaction::transfer(&keypair0, &keypair1.pubkey(), 1, Hash::default());
         let entry = Entry::new(&Hash::default(), 1, vec![tx0]);
 
@@ -1211,8 +1211,8 @@ pub mod tests {
         let num_entries = max_entries_per_n_shred(&entry, num_data_shreds as u64);
         let entries: Vec<_> = (0..num_entries)
             .map(|_| {
-                let keypair0 = Keypair::new();
-                let keypair1 = Keypair::new();
+                let keypair0 = generate_keypair();
+                let keypair1 = generate_keypair();
                 let tx0 =
                     system_transaction::transfer(&keypair0, &keypair1.pubkey(), 1, Hash::default());
                 Entry::new(&Hash::default(), 1, vec![tx0])
@@ -1449,7 +1449,7 @@ pub mod tests {
 
     #[test]
     fn test_shred_version() {
-        let keypair = Arc::new(Keypair::new());
+        let keypair = Arc::new(generate_keypair());
         let hash = hash(Hash::default().as_ref());
         let version = Shred::version_from_hash(&hash);
         assert_ne!(version, 0);
@@ -1458,8 +1458,8 @@ pub mod tests {
 
         let entries: Vec<_> = (0..5)
             .map(|_| {
-                let keypair0 = Keypair::new();
-                let keypair1 = Keypair::new();
+                let keypair0 = generate_keypair();
+                let keypair1 = generate_keypair();
                 let tx0 =
                     system_transaction::transfer(&keypair0, &keypair1.pubkey(), 1, Hash::default());
                 Entry::new(&Hash::default(), 1, vec![tx0])
@@ -1499,7 +1499,7 @@ pub mod tests {
 
     #[test]
     fn test_shred_fec_set_index() {
-        let keypair = Arc::new(Keypair::new());
+        let keypair = Arc::new(generate_keypair());
         let hash = hash(Hash::default().as_ref());
         let version = Shred::version_from_hash(&hash);
         assert_ne!(version, 0);
@@ -1508,8 +1508,8 @@ pub mod tests {
 
         let entries: Vec<_> = (0..500)
             .map(|_| {
-                let keypair0 = Keypair::new();
-                let keypair1 = Keypair::new();
+                let keypair0 = generate_keypair();
+                let keypair1 = generate_keypair();
                 let tx0 =
                     system_transaction::transfer(&keypair0, &keypair1.pubkey(), 1, Hash::default());
                 Entry::new(&Hash::default(), 1, vec![tx0])
@@ -1537,7 +1537,7 @@ pub mod tests {
 
     #[test]
     fn test_max_coding_shreds() {
-        let keypair = Arc::new(Keypair::new());
+        let keypair = Arc::new(generate_keypair());
         let hash = hash(Hash::default().as_ref());
         let version = Shred::version_from_hash(&hash);
         assert_ne!(version, 0);
@@ -1546,8 +1546,8 @@ pub mod tests {
 
         let entries: Vec<_> = (0..500)
             .map(|_| {
-                let keypair0 = Keypair::new();
-                let keypair1 = Keypair::new();
+                let keypair0 = generate_keypair();
+                let keypair1 = generate_keypair();
                 let tx0 =
                     system_transaction::transfer(&keypair0, &keypair1.pubkey(), 1, Hash::default());
                 Entry::new(&Hash::default(), 1, vec![tx0])

--- a/ledger/src/sigverify_shreds.rs
+++ b/ledger/src/sigverify_shreds.rs
@@ -447,7 +447,7 @@ pub mod tests {
     use super::*;
     use crate::shred::SIZE_OF_DATA_SHRED_PAYLOAD;
     use crate::shred::{Shred, Shredder};
-    use solana_sdk::signature::{Keypair, KeypairUtil};
+    use solana_sdk::signature::{generate_keypair, KeypairUtil};
     #[test]
     fn test_sigverify_shred_cpu() {
         solana_logger::setup();
@@ -465,7 +465,7 @@ pub mod tests {
             0xc0de,
         );
         assert_eq!(shred.slot(), slot);
-        let keypair = Keypair::new();
+        let keypair = generate_keypair();
         Shredder::sign_shred(&keypair, &mut shred);
         trace!("signature {}", shred.common_header.signature);
         packet.data[0..shred.payload.len()].copy_from_slice(&shred.payload);
@@ -478,7 +478,7 @@ pub mod tests {
         let rv = verify_shred_cpu(&packet, &leader_slots);
         assert_eq!(rv, Some(1));
 
-        let wrong_keypair = Keypair::new();
+        let wrong_keypair = generate_keypair();
         let leader_slots = [(slot, wrong_keypair.pubkey().to_bytes())]
             .iter()
             .cloned()
@@ -507,7 +507,7 @@ pub mod tests {
             0,
             0xc0de,
         );
-        let keypair = Keypair::new();
+        let keypair = generate_keypair();
         Shredder::sign_shred(&keypair, &mut shred);
         batch[0].packets.resize(1, Packet::default());
         batch[0].packets[0].data[0..shred.payload.len()].copy_from_slice(&shred.payload);
@@ -520,7 +520,7 @@ pub mod tests {
         let rv = verify_shreds_cpu(&batch, &leader_slots);
         assert_eq!(rv, vec![vec![1]]);
 
-        let wrong_keypair = Keypair::new();
+        let wrong_keypair = generate_keypair();
         let leader_slots = [(slot, wrong_keypair.pubkey().to_bytes())]
             .iter()
             .cloned()
@@ -559,7 +559,7 @@ pub mod tests {
             0,
             0xc0de,
         );
-        let keypair = Keypair::new();
+        let keypair = generate_keypair();
         Shredder::sign_shred(&keypair, &mut shred);
         batch[0].packets.resize(1, Packet::default());
         batch[0].packets[0].data[0..shred.payload.len()].copy_from_slice(&shred.payload);
@@ -575,7 +575,7 @@ pub mod tests {
         let rv = verify_shreds_gpu(&batch, &leader_slots, &recycler_cache);
         assert_eq!(rv, vec![vec![1]]);
 
-        let wrong_keypair = Keypair::new();
+        let wrong_keypair = generate_keypair();
         let leader_slots = [
             (std::u64::MAX, Pubkey::default().to_bytes()),
             (slot, wrong_keypair.pubkey().to_bytes()),
@@ -627,7 +627,7 @@ pub mod tests {
             shred.copy_to_packet(p);
         }
         let mut batch = vec![packets; num_batches];
-        let keypair = Keypair::new();
+        let keypair = generate_keypair();
         let pinned_keypair = sign_shreds_gpu_pinned_keypair(&keypair, &recycler_cache);
         let pinned_keypair = Some(Arc::new(pinned_keypair));
         let pubkeys = [
@@ -655,7 +655,7 @@ pub mod tests {
 
         let mut batch = [Packets::default()];
         let slot = 0xdeadc0de;
-        let keypair = Keypair::new();
+        let keypair = generate_keypair();
         let shred = Shred::new_from_data(
             slot,
             0xc0de,

--- a/ledger/src/staking_utils.rs
+++ b/ledger/src/staking_utils.rs
@@ -107,7 +107,7 @@ pub(crate) mod tests {
         clock::Clock,
         instruction::Instruction,
         pubkey::Pubkey,
-        signature::{Keypair, KeypairUtil},
+        signature::{generate_keypair, Keypair, KeypairUtil},
         sysvar::{
             stake_history::{self, StakeHistory},
             Sysvar,
@@ -163,7 +163,7 @@ pub(crate) mod tests {
             ),
         );
 
-        let stake_account_keypair = Keypair::new();
+        let stake_account_keypair = generate_keypair();
         let stake_account_pubkey = stake_account_keypair.pubkey();
 
         process_instructions(
@@ -193,7 +193,7 @@ pub(crate) mod tests {
             ..Stake::default()
         };
 
-        let validator = Keypair::new();
+        let validator = generate_keypair();
 
         let GenesisConfigInfo {
             genesis_config,
@@ -202,7 +202,7 @@ pub(crate) mod tests {
         } = create_genesis_config(10_000);
 
         let bank = Bank::new(&genesis_config);
-        let vote_account = Keypair::new();
+        let vote_account = generate_keypair();
 
         // Give the validator some stake but don't setup a staking account
         // Validator has no lamports staked, so they get filtered out. Only the bootstrap validator

--- a/ledger/tests/shred.rs
+++ b/ledger/tests/shred.rs
@@ -2,30 +2,30 @@ use solana_ledger::entry::Entry;
 use solana_ledger::shred::{
     max_entries_per_n_shred, verify_test_data_shred, Shred, Shredder, MAX_DATA_SHREDS_PER_FEC_BLOCK,
 };
-use solana_sdk::signature::{Keypair, KeypairUtil};
+use solana_sdk::signature::{generate_keypair, KeypairUtil};
 use solana_sdk::{hash::Hash, system_transaction};
 use std::convert::TryInto;
 use std::sync::Arc;
 
 #[test]
 fn test_multi_fec_block_coding() {
-    let keypair = Arc::new(Keypair::new());
+    let keypair = Arc::new(generate_keypair());
     let slot = 0x123456789abcdef0;
     let shredder = Shredder::new(slot, slot - 5, 1.0, keypair.clone(), 0, 0)
         .expect("Failed in creating shredder");
 
     let num_fec_sets = 100;
     let num_data_shreds = (MAX_DATA_SHREDS_PER_FEC_BLOCK * num_fec_sets) as usize;
-    let keypair0 = Keypair::new();
-    let keypair1 = Keypair::new();
+    let keypair0 = generate_keypair();
+    let keypair1 = generate_keypair();
     let tx0 = system_transaction::transfer(&keypair0, &keypair1.pubkey(), 1, Hash::default());
     let entry = Entry::new(&Hash::default(), 1, vec![tx0]);
     let num_entries = max_entries_per_n_shred(&entry, num_data_shreds as u64);
 
     let entries: Vec<_> = (0..num_entries)
         .map(|_| {
-            let keypair0 = Keypair::new();
-            let keypair1 = Keypair::new();
+            let keypair0 = generate_keypair();
+            let keypair1 = generate_keypair();
             let tx0 =
                 system_transaction::transfer(&keypair0, &keypair1.pubkey(), 1, Hash::default());
             Entry::new(&Hash::default(), 1, vec![tx0])

--- a/local-cluster/src/cluster_tests.rs
+++ b/local-cluster/src/cluster_tests.rs
@@ -24,7 +24,7 @@ use solana_sdk::{
     hash::Hash,
     poh_config::PohConfig,
     pubkey::Pubkey,
-    signature::{Keypair, KeypairUtil, Signature},
+    signature::{generate_keypair, Keypair, KeypairUtil, Signature},
     system_transaction,
     timing::duration_as_ms,
     transport::TransportError,
@@ -51,7 +51,7 @@ pub fn spend_and_verify_all_nodes<S: ::std::hash::BuildHasher>(
         if ignore_nodes.contains(&ingress_node.id) {
             continue;
         }
-        let random_keypair = Keypair::new();
+        let random_keypair = generate_keypair();
         let client = create_client(ingress_node.client_facing_addr(), VALIDATOR_PORT_RANGE);
         let bal = client
             .poll_get_balance_with_commitment(&funding_keypair.pubkey(), CommitmentConfig::recent())
@@ -98,7 +98,7 @@ pub fn send_many_transactions(
     let client = create_client(node.client_facing_addr(), VALIDATOR_PORT_RANGE);
     let mut expected_balances = HashMap::new();
     for _ in 0..num_txs {
-        let random_keypair = Keypair::new();
+        let random_keypair = generate_keypair();
         let bal = client
             .poll_get_balance_with_commitment(&funding_keypair.pubkey(), CommitmentConfig::recent())
             .expect("balance in source");
@@ -241,7 +241,7 @@ pub fn kill_entry_and_spend_and_verify_rest(
                 result.unwrap();
             }
 
-            let random_keypair = Keypair::new();
+            let random_keypair = generate_keypair();
             let (blockhash, _fee_calculator) = client
                 .get_recent_blockhash_with_commitment(CommitmentConfig::recent())
                 .unwrap();

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -20,7 +20,7 @@ use solana_sdk::{
     message::Message,
     poh_config::PohConfig,
     pubkey::Pubkey,
-    signature::{Keypair, KeypairUtil},
+    signature::{generate_keypair, Keypair, KeypairUtil},
     system_transaction,
     transaction::Transaction,
 };
@@ -137,7 +137,7 @@ impl LocalCluster {
                 assert_eq!(config.validator_configs.len(), keys.len());
                 keys.clone()
             } else {
-                iter::repeat_with(|| Arc::new(Keypair::new()))
+                iter::repeat_with(|| Arc::new(generate_keypair()))
                     .take(config.validator_configs.len())
                     .collect()
             }
@@ -184,7 +184,7 @@ impl LocalCluster {
             .native_instruction_processors
             .extend_from_slice(&config.native_instruction_processors);
 
-        let storage_keypair = Keypair::new();
+        let storage_keypair = generate_keypair();
         genesis_config.add_account(
             storage_keypair.pubkey(),
             storage_contract::create_validator_storage_account(leader_pubkey, 1),
@@ -263,7 +263,7 @@ impl LocalCluster {
             ..config.validator_configs[0].clone()
         };
         (0..config.num_listeners).for_each(|_| {
-            cluster.add_validator(&listener_config, 0, Arc::new(Keypair::new()));
+            cluster.add_validator(&listener_config, 0, Arc::new(generate_keypair()));
         });
 
         discover_cluster(
@@ -318,8 +318,8 @@ impl LocalCluster {
         );
 
         // Must have enough tokens to fund vote account and set delegate
-        let voting_keypair = Keypair::new();
-        let storage_keypair = Arc::new(Keypair::new());
+        let voting_keypair = generate_keypair();
+        let storage_keypair = Arc::new(generate_keypair());
         let validator_pubkey = validator_keypair.pubkey();
         let validator_node = Node::new_localhost_with_pubkey(&validator_keypair.pubkey());
         let contact_info = validator_node.info.clone();
@@ -389,9 +389,9 @@ impl LocalCluster {
     }
 
     fn add_archiver(&mut self) {
-        let archiver_keypair = Arc::new(Keypair::new());
+        let archiver_keypair = Arc::new(generate_keypair());
         let archiver_pubkey = archiver_keypair.pubkey();
-        let storage_keypair = Arc::new(Keypair::new());
+        let storage_keypair = Arc::new(generate_keypair());
         let storage_pubkey = storage_keypair.pubkey();
         let client = create_client(
             self.entry_point_info.client_facing_addr(),
@@ -486,7 +486,7 @@ impl LocalCluster {
     ) -> Result<()> {
         let vote_account_pubkey = vote_account.pubkey();
         let node_pubkey = from_account.pubkey();
-        let stake_account_keypair = Keypair::new();
+        let stake_account_keypair = generate_keypair();
         let stake_account_pubkey = stake_account_keypair.pubkey();
 
         // Create the vote account if necessary

--- a/local-cluster/tests/archiver.rs
+++ b/local-cluster/tests/archiver.rs
@@ -15,7 +15,7 @@ use solana_local_cluster::local_cluster::{ClusterConfig, LocalCluster};
 use solana_sdk::{
     commitment_config::CommitmentConfig,
     genesis_config::create_genesis_config,
-    signature::{Keypair, KeypairUtil},
+    signature::{generate_keypair, KeypairUtil},
 };
 use std::{
     fs::remove_dir_all,
@@ -101,8 +101,8 @@ fn test_archiver_startup_leader_hang() {
     let (archiver_ledger_path, _blockhash) = create_new_tmp_ledger!(&genesis_config);
 
     {
-        let archiver_keypair = Arc::new(Keypair::new());
-        let storage_keypair = Arc::new(Keypair::new());
+        let archiver_keypair = Arc::new(generate_keypair());
+        let storage_keypair = Arc::new(generate_keypair());
 
         info!("starting archiver node");
         let archiver_node = Node::new_localhost_with_pubkey(&archiver_keypair.pubkey());
@@ -138,8 +138,8 @@ fn test_archiver_startup_ledger_hang() {
     let cluster = LocalCluster::new_with_equal_stakes(2, 10_000, 100);
 
     info!("starting archiver node");
-    let bad_keys = Arc::new(Keypair::new());
-    let storage_keypair = Arc::new(Keypair::new());
+    let bad_keys = Arc::new(generate_keypair());
+    let storage_keypair = Arc::new(generate_keypair());
     let mut archiver_node = Node::new_localhost_with_pubkey(&bad_keys.pubkey());
 
     // Pass bad TVU sockets to prevent successful ledger download

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -23,7 +23,7 @@ use solana_sdk::{
     epoch_schedule::{EpochSchedule, MINIMUM_SLOTS_PER_EPOCH},
     genesis_config::OperatingMode,
     poh_config::PohConfig,
-    signature::{Keypair, KeypairUtil},
+    signature::{generate_keypair, Keypair, KeypairUtil},
 };
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::{
@@ -237,7 +237,7 @@ fn run_cluster_partition(
             )
         } else {
             (
-                iter::repeat_with(|| Arc::new(Keypair::new()))
+                iter::repeat_with(|| Arc::new(generate_keypair()))
                     .take(partitions.len())
                     .collect(),
                 10_000,
@@ -404,7 +404,7 @@ fn test_kill_partition() {
     let mut leader_schedule = vec![];
     let num_slots_per_validator = 8;
     let partitions: [&[(usize, bool)]; 3] = [&[(9, true)], &[(10, false)], &[(10, false)]];
-    let validator_keys: Vec<_> = iter::repeat_with(|| Arc::new(Keypair::new()))
+    let validator_keys: Vec<_> = iter::repeat_with(|| Arc::new(generate_keypair()))
         .take(partitions.len())
         .collect();
     for (i, k) in validator_keys.iter().enumerate() {
@@ -724,7 +724,7 @@ fn test_snapshots_blockstore_floor() {
     cluster.add_validator(
         &validator_snapshot_test_config.validator_config,
         validator_stake,
-        Arc::new(Keypair::new()),
+        Arc::new(generate_keypair()),
     );
     let all_pubkeys = cluster.get_node_pubkeys();
     let validator_id = all_pubkeys

--- a/perf/src/packet.rs
+++ b/perf/src/packet.rs
@@ -105,12 +105,12 @@ where
 mod tests {
     use super::*;
     use solana_sdk::hash::Hash;
-    use solana_sdk::signature::{Keypair, KeypairUtil};
+    use solana_sdk::signature::{generate_keypair, KeypairUtil};
     use solana_sdk::system_transaction;
 
     #[test]
     fn test_to_packets() {
-        let keypair = Keypair::new();
+        let keypair = generate_keypair();
         let hash = Hash::new(&[1; 32]);
         let tx = system_transaction::transfer(&keypair, &keypair.pubkey(), 1, hash);
         let rv = to_packets(&vec![tx.clone(); 1]);

--- a/perf/src/test_tx.rs
+++ b/perf/src/test_tx.rs
@@ -1,21 +1,21 @@
 use solana_sdk::hash::Hash;
 use solana_sdk::instruction::CompiledInstruction;
-use solana_sdk::signature::{Keypair, KeypairUtil};
+use solana_sdk::signature::{generate_keypair, KeypairUtil};
 use solana_sdk::system_instruction::SystemInstruction;
 use solana_sdk::system_program;
 use solana_sdk::system_transaction;
 use solana_sdk::transaction::Transaction;
 
 pub fn test_tx() -> Transaction {
-    let keypair1 = Keypair::new();
+    let keypair1 = generate_keypair();
     let pubkey1 = keypair1.pubkey();
     let zero = Hash::default();
     system_transaction::transfer(&keypair1, &pubkey1, 42, zero)
 }
 
 pub fn test_multisig_tx() -> Transaction {
-    let keypair0 = Keypair::new();
-    let keypair1 = Keypair::new();
+    let keypair0 = generate_keypair();
+    let keypair1 = generate_keypair();
     let keypairs = vec![&keypair0, &keypair1];
     let lamports = 5;
     let blockhash = Hash::default();

--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -225,7 +225,7 @@ mod bpf {
             clock::DEFAULT_SLOTS_PER_EPOCH,
             instruction::{AccountMeta, Instruction, InstructionError},
             pubkey::Pubkey,
-            signature::{Keypair, KeypairUtil},
+            signature::{generate_keypair, KeypairUtil},
             sysvar::{clock, fees, rent, rewards, slot_hashes, stake_history},
             transaction::TransactionError,
         };
@@ -270,7 +270,7 @@ mod bpf {
                 let program_id = load_program(&bank_client, &mint_keypair, &bpf_loader::id(), elf);
                 let account_metas = vec![
                     AccountMeta::new(mint_keypair.pubkey(), true),
-                    AccountMeta::new(Keypair::new().pubkey(), false),
+                    AccountMeta::new(generate_keypair().pubkey(), false),
                     AccountMeta::new(clock::id(), false),
                     AccountMeta::new(fees::id(), false),
                     AccountMeta::new(rewards::id(), false),

--- a/programs/budget/src/budget_processor.rs
+++ b/programs/budget/src/budget_processor.rs
@@ -232,7 +232,7 @@ mod tests {
     use solana_sdk::hash::hash;
     use solana_sdk::instruction::InstructionError;
     use solana_sdk::message::Message;
-    use solana_sdk::signature::{Keypair, KeypairUtil};
+    use solana_sdk::signature::{generate_keypair, Keypair, KeypairUtil};
     use solana_sdk::transaction::TransactionError;
 
     fn create_bank(lamports: u64) -> (Bank, Keypair) {
@@ -248,7 +248,7 @@ mod tests {
         let bank_client = BankClient::new(bank);
 
         let alice_pubkey = alice_keypair.pubkey();
-        let budget_keypair = Keypair::new();
+        let budget_keypair = generate_keypair();
         let budget_pubkey = budget_keypair.pubkey();
         let bob_pubkey = Pubkey::new_rand();
 
@@ -272,7 +272,7 @@ mod tests {
         let bank_client = BankClient::new(bank);
         let alice_pubkey = alice_keypair.pubkey();
         let bob_pubkey = Pubkey::new_rand();
-        let budget_keypair = Keypair::new();
+        let budget_keypair = generate_keypair();
         let budget_pubkey = budget_keypair.pubkey();
         let instructions =
             budget_instruction::payment(&alice_pubkey, &bob_pubkey, &budget_pubkey, 100);
@@ -290,7 +290,7 @@ mod tests {
         let alice_pubkey = alice_keypair.pubkey();
 
         // Initialize BudgetState
-        let budget_keypair = Keypair::new();
+        let budget_keypair = generate_keypair();
         let budget_pubkey = budget_keypair.pubkey();
         let bob_pubkey = Pubkey::new_rand();
         let witness = Pubkey::new_rand();
@@ -308,7 +308,7 @@ mod tests {
             .unwrap();
 
         // Attack! Part 1: Sign a witness transaction with a random key.
-        let mallory_keypair = Keypair::new();
+        let mallory_keypair = generate_keypair();
         let mallory_pubkey = mallory_keypair.pubkey();
         bank_client
             .transfer(1, &alice_keypair, &mallory_pubkey)
@@ -339,7 +339,7 @@ mod tests {
         let alice_pubkey = alice_keypair.pubkey();
 
         // Initialize BudgetState
-        let budget_keypair = Keypair::new();
+        let budget_keypair = generate_keypair();
         let budget_pubkey = budget_keypair.pubkey();
         let bob_pubkey = Pubkey::new_rand();
         let dt = Utc::now();
@@ -358,7 +358,7 @@ mod tests {
             .unwrap();
 
         // Attack! Part 1: Sign a timestamp transaction with a random key.
-        let mallory_keypair = Keypair::new();
+        let mallory_keypair = generate_keypair();
         let mallory_pubkey = mallory_keypair.pubkey();
         bank_client
             .transfer(1, &alice_keypair, &mallory_pubkey)
@@ -387,7 +387,7 @@ mod tests {
         let (bank, alice_keypair) = create_bank(2);
         let bank_client = BankClient::new(bank);
         let alice_pubkey = alice_keypair.pubkey();
-        let budget_keypair = Keypair::new();
+        let budget_keypair = generate_keypair();
         let budget_pubkey = budget_keypair.pubkey();
         let bob_pubkey = Pubkey::new_rand();
         let mallory_pubkey = Pubkey::new_rand();
@@ -458,7 +458,7 @@ mod tests {
         let (bank, alice_keypair) = create_bank(3);
         let bank_client = BankClient::new(bank);
         let alice_pubkey = alice_keypair.pubkey();
-        let budget_keypair = Keypair::new();
+        let budget_keypair = generate_keypair();
         let budget_pubkey = budget_keypair.pubkey();
         let bob_pubkey = Pubkey::new_rand();
         let dt = Utc::now();
@@ -487,7 +487,7 @@ mod tests {
         assert!(budget_state.is_pending());
 
         // Attack! try to put the lamports into the wrong account with cancel
-        let mallory_keypair = Keypair::new();
+        let mallory_keypair = generate_keypair();
         let mallory_pubkey = mallory_keypair.pubkey();
         bank_client
             .transfer(1, &alice_keypair, &mallory_pubkey)
@@ -531,9 +531,9 @@ mod tests {
 
         let alice_pubkey = alice_keypair.pubkey();
         let game_hash = hash(&[1, 2, 3]);
-        let budget_keypair = Keypair::new();
+        let budget_keypair = generate_keypair();
         let budget_pubkey = budget_keypair.pubkey();
-        let bob_keypair = Keypair::new();
+        let bob_keypair = generate_keypair();
         let bob_pubkey = bob_keypair.pubkey();
 
         // Give Bob some lamports so he can sign the witness transaction.

--- a/programs/config/src/config_processor.rs
+++ b/programs/config/src/config_processor.rs
@@ -108,7 +108,7 @@ mod tests {
     use serde_derive::{Deserialize, Serialize};
     use solana_sdk::{
         account::{create_keyed_is_signer_accounts, Account},
-        signature::{Keypair, KeypairUtil},
+        signature::{generate_keypair, Keypair, KeypairUtil},
         system_instruction::SystemInstruction,
     };
     use std::cell::RefCell;
@@ -139,7 +139,7 @@ mod tests {
 
     fn create_config_account(keys: Vec<(Pubkey, bool)>) -> (Keypair, RefCell<Account>) {
         let from_pubkey = Pubkey::new_rand();
-        let config_keypair = Keypair::new();
+        let config_keypair = generate_keypair();
         let config_pubkey = config_keypair.pubkey();
 
         let instructions =

--- a/programs/exchange/src/exchange_processor.rs
+++ b/programs/exchange/src/exchange_processor.rs
@@ -469,7 +469,7 @@ mod test {
     use solana_sdk::client::SyncClient;
     use solana_sdk::genesis_config::create_genesis_config;
     use solana_sdk::message::Message;
-    use solana_sdk::signature::{Keypair, KeypairUtil};
+    use solana_sdk::signature::{generate_keypair, Keypair, KeypairUtil};
     use solana_sdk::system_instruction;
     use std::mem;
 
@@ -558,7 +558,7 @@ mod test {
     }
 
     fn create_client(bank: Bank, mint_keypair: Keypair) -> (BankClient, Keypair) {
-        let owner = Keypair::new();
+        let owner = generate_keypair();
         let bank_client = BankClient::new(bank);
         bank_client
             .transfer(42, &mint_keypair, &owner.pubkey())
@@ -568,7 +568,7 @@ mod test {
     }
 
     fn create_account(client: &BankClient, owner: &Keypair) -> Pubkey {
-        let new = Keypair::new();
+        let new = generate_keypair();
 
         let instruction = system_instruction::create_account(
             &owner.pubkey(),

--- a/programs/librapay/src/lib.rs
+++ b/programs/librapay/src/lib.rs
@@ -13,14 +13,14 @@ use solana_sdk::{
     instruction::InstructionError,
     message::Message,
     pubkey::Pubkey,
-    signature::{Keypair, KeypairUtil},
+    signature::{generate_keypair, KeypairUtil},
     system_instruction,
 };
 
 use types::account_config;
 
 pub fn create_genesis<T: Client>(from: &Keypair, client: &T, amount: u64) -> Keypair {
-    let genesis = Keypair::new();
+    let genesis = generate_keypair();
 
     let instruction = system_instruction::create_account(
         &from.pubkey(),

--- a/programs/librapay/src/librapay_transaction.rs
+++ b/programs/librapay/src/librapay_transaction.rs
@@ -9,7 +9,7 @@ use solana_sdk::{
     commitment_config::CommitmentConfig,
     hash::Hash,
     pubkey::Pubkey,
-    signature::{Keypair, KeypairUtil},
+    signature::{generate_keypair, KeypairUtil},
     system_instruction,
     transaction::Transaction,
 };
@@ -155,7 +155,7 @@ mod tests {
     use solana_runtime::bank::Bank;
     use solana_runtime::bank_client::BankClient;
     use solana_sdk::genesis_config::create_genesis_config;
-    use solana_sdk::signature::{Keypair, KeypairUtil};
+    use solana_sdk::signature::{generate_keypair, KeypairUtil};
     use std::sync::Arc;
 
     fn create_bank(lamports: u64) -> (Arc<Bank>, Keypair, Keypair, Pubkey, Pubkey) {
@@ -186,8 +186,8 @@ mod tests {
 
         let (bank, mint, genesis_keypair, mint_script_pubkey, payment_script_pubkey) =
             create_bank(10_000);
-        let from_keypair = Keypair::new();
-        let to_keypair = Keypair::new();
+        let from_keypair = generate_keypair();
+        let to_keypair = generate_keypair();
 
         let tx = create_accounts(
             &mint,

--- a/programs/ownable/src/ownable_processor.rs
+++ b/programs/ownable/src/ownable_processor.rs
@@ -63,7 +63,7 @@ mod tests {
         client::SyncClient,
         genesis_config::create_genesis_config,
         message::Message,
-        signature::{Keypair, KeypairUtil, Signature},
+        signature::{generate_keypair, Keypair, KeypairUtil, Signature},
         system_program,
         transport::Result,
     };
@@ -116,9 +116,9 @@ mod tests {
     #[test]
     fn test_ownable_set_owner() {
         let (bank_client, payer_keypair) = create_bank_client(2);
-        let account_keypair = Keypair::new();
+        let account_keypair = generate_keypair();
         let account_pubkey = account_keypair.pubkey();
-        let owner_keypair = Keypair::new();
+        let owner_keypair = generate_keypair();
         let owner_pubkey = owner_keypair.pubkey();
 
         create_ownable_account(
@@ -130,7 +130,7 @@ mod tests {
         )
         .unwrap();
 
-        let new_owner_keypair = Keypair::new();
+        let new_owner_keypair = generate_keypair();
         let new_owner_pubkey = new_owner_keypair.pubkey();
         send_set_owner(
             &bank_client,

--- a/programs/vest/src/vest_processor.rs
+++ b/programs/vest/src/vest_processor.rs
@@ -153,7 +153,7 @@ mod tests {
     use solana_sdk::genesis_config::create_genesis_config;
     use solana_sdk::hash::hash;
     use solana_sdk::message::Message;
-    use solana_sdk::signature::{Keypair, KeypairUtil, Signature};
+    use solana_sdk::signature::{generate_keypair, Keypair, KeypairUtil, Signature};
     use solana_sdk::transaction::TransactionError;
     use solana_sdk::transport::Result;
     use std::sync::Arc;
@@ -340,7 +340,7 @@ mod tests {
     fn test_initialize_no_panic() {
         let (bank_client, alice_keypair) = create_bank_client(3);
 
-        let contract_keypair = Keypair::new();
+        let contract_keypair = generate_keypair();
 
         let mut instructions = vest_instruction::create_account(
             &alice_keypair.pubkey(),
@@ -367,9 +367,9 @@ mod tests {
         let (bank_client, alice_keypair) = create_bank_client(39);
         let alice_pubkey = alice_keypair.pubkey();
         let date_pubkey = Pubkey::new_rand();
-        let contract_keypair = Keypair::new();
+        let contract_keypair = generate_keypair();
         let contract_pubkey = contract_keypair.pubkey();
-        let bob_keypair = Keypair::new();
+        let bob_keypair = generate_keypair();
         let bob_pubkey = bob_keypair.pubkey();
         let start_date = Utc.ymd(2018, 1, 1);
 
@@ -389,7 +389,7 @@ mod tests {
 
         // Ensure some rando can't change the payee.
         // Transfer bob a token to pay the transaction fee.
-        let mallory_keypair = Keypair::new();
+        let mallory_keypair = generate_keypair();
         bank_client
             .transfer(1, &alice_keypair, &mallory_keypair.pubkey())
             .unwrap();
@@ -438,9 +438,9 @@ mod tests {
         let (bank_client, alice_keypair) = create_bank_client(38);
         let alice_pubkey = alice_keypair.pubkey();
         let date_pubkey = Pubkey::new_rand();
-        let contract_keypair = Keypair::new();
+        let contract_keypair = generate_keypair();
         let contract_pubkey = contract_keypair.pubkey();
-        let bob_keypair = Keypair::new();
+        let bob_keypair = generate_keypair();
         let bob_pubkey = bob_keypair.pubkey();
         let start_date = Utc.ymd(2018, 1, 1);
 
@@ -460,7 +460,7 @@ mod tests {
 
         // Ensure some rando can't change the payee.
         // Transfer bob a token to pay the transaction fee.
-        let mallory_keypair = Keypair::new();
+        let mallory_keypair = generate_keypair();
         bank_client
             .transfer(1, &alice_keypair, &mallory_keypair.pubkey())
             .unwrap();
@@ -492,13 +492,13 @@ mod tests {
         let bank_client = BankClient::new_shared(&bank);
         let alice_pubkey = alice_keypair.pubkey();
 
-        let date_keypair = Keypair::new();
+        let date_keypair = generate_keypair();
         let date_pubkey = date_keypair.pubkey();
 
         let current_date = Utc.ymd(2019, 1, 1);
         create_date_account(&bank_client, &date_keypair, &alice_keypair, current_date).unwrap();
 
-        let contract_keypair = Keypair::new();
+        let contract_keypair = generate_keypair();
         let contract_pubkey = contract_keypair.pubkey();
         let bob_pubkey = Pubkey::new_rand();
         let start_date = Utc.ymd(2018, 1, 1);
@@ -560,12 +560,12 @@ mod tests {
     fn test_terminate_and_refund() {
         let (bank_client, alice_keypair) = create_bank_client(3);
         let alice_pubkey = alice_keypair.pubkey();
-        let contract_keypair = Keypair::new();
+        let contract_keypair = generate_keypair();
         let contract_pubkey = contract_keypair.pubkey();
         let bob_pubkey = Pubkey::new_rand();
         let start_date = Utc::now().date();
 
-        let date_keypair = Keypair::new();
+        let date_keypair = generate_keypair();
         let date_pubkey = date_keypair.pubkey();
 
         let current_date = Utc.ymd(2019, 1, 1);
@@ -604,12 +604,12 @@ mod tests {
     fn test_terminate_and_send_funds() {
         let (bank_client, alice_keypair) = create_bank_client(3);
         let alice_pubkey = alice_keypair.pubkey();
-        let contract_keypair = Keypair::new();
+        let contract_keypair = generate_keypair();
         let contract_pubkey = contract_keypair.pubkey();
         let bob_pubkey = Pubkey::new_rand();
         let start_date = Utc::now().date();
 
-        let date_keypair = Keypair::new();
+        let date_keypair = generate_keypair();
         let date_pubkey = date_keypair.pubkey();
 
         let current_date = Utc.ymd(2019, 1, 1);
@@ -649,12 +649,12 @@ mod tests {
     fn test_renege_and_send_funds() {
         let (bank_client, alice_keypair) = create_bank_client(3);
         let alice_pubkey = alice_keypair.pubkey();
-        let contract_keypair = Keypair::new();
+        let contract_keypair = generate_keypair();
         let contract_pubkey = contract_keypair.pubkey();
         let bob_pubkey = Pubkey::new_rand();
         let start_date = Utc::now().date();
 
-        let date_keypair = Keypair::new();
+        let date_keypair = generate_keypair();
         let date_pubkey = date_keypair.pubkey();
 
         let current_date = Utc.ymd(2019, 1, 1);

--- a/runtime/benches/bank.rs
+++ b/runtime/benches/bank.rs
@@ -12,7 +12,7 @@ use solana_sdk::{
     genesis_config::create_genesis_config,
     instruction::InstructionError,
     pubkey::Pubkey,
-    signature::{Keypair, KeypairUtil},
+    signature::{generate_keypair, KeypairUtil},
     transaction::Transaction,
 };
 use std::{sync::Arc, thread::sleep, time::Duration};
@@ -46,7 +46,7 @@ pub fn create_builtin_transactions(
         .into_iter()
         .map(|_| {
             // Seed the signer account
-            let rando0 = Keypair::new();
+            let rando0 = generate_keypair();
             bank_client
                 .transfer(10_000, &mint_keypair, &rando0.pubkey())
                 .expect(&format!("{}:{}", line!(), file!()));
@@ -68,7 +68,7 @@ pub fn create_native_loader_transactions(
         .into_iter()
         .map(|_| {
             // Seed the signer account©41
-            let rando0 = Keypair::new();
+            let rando0 = generate_keypair();
             bank_client
                 .transfer(10_000, &mint_keypair, &rando0.pubkey())
                 .expect(&format!("{}:{}", line!(), file!()));

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -678,7 +678,7 @@ mod tests {
         message::Message,
         nonce_state,
         rent::Rent,
-        signature::{Keypair, KeypairUtil},
+        signature::{generate_keypair, Keypair, KeypairUtil},
         system_program,
         transaction::Transaction,
     };
@@ -767,7 +767,7 @@ mod tests {
         let accounts: Vec<(Pubkey, Account)> = Vec::new();
         let mut error_counters = ErrorCounters::default();
 
-        let keypair = Keypair::new();
+        let keypair = generate_keypair();
 
         let instructions = vec![CompiledInstruction::new(1, &(), vec![0])];
         let tx = Transaction::new_with_compiled_instructions(
@@ -796,7 +796,7 @@ mod tests {
         let mut accounts: Vec<(Pubkey, Account)> = Vec::new();
         let mut error_counters = ErrorCounters::default();
 
-        let keypair = Keypair::new();
+        let keypair = generate_keypair();
         let key0 = keypair.pubkey();
         let key1 = Pubkey::new(&[5u8; 32]);
 
@@ -833,7 +833,7 @@ mod tests {
         let mut accounts: Vec<(Pubkey, Account)> = Vec::new();
         let mut error_counters = ErrorCounters::default();
 
-        let keypair = Keypair::new();
+        let keypair = generate_keypair();
         let key0 = keypair.pubkey();
 
         let account = Account::new(1, 0, &Pubkey::default());
@@ -870,7 +870,7 @@ mod tests {
         let mut accounts: Vec<(Pubkey, Account)> = Vec::new();
         let mut error_counters = ErrorCounters::default();
 
-        let keypair = Keypair::new();
+        let keypair = generate_keypair();
         let key0 = keypair.pubkey();
 
         let account = Account::new(1, 1, &Pubkey::new_rand()); // <-- owner is not the system program
@@ -914,7 +914,7 @@ mod tests {
             .rent
             .minimum_balance(nonce_state::NonceState::size());
         let fee_calculator = FeeCalculator::new(min_balance, 0);
-        let nonce = Keypair::new();
+        let nonce = generate_keypair();
         let mut accounts = vec![(
             nonce.pubkey(),
             Account::new_data(
@@ -981,7 +981,7 @@ mod tests {
         let mut accounts: Vec<(Pubkey, Account)> = Vec::new();
         let mut error_counters = ErrorCounters::default();
 
-        let keypair = Keypair::new();
+        let keypair = generate_keypair();
         let key0 = keypair.pubkey();
         let key1 = Pubkey::new(&[5u8; 32]);
 
@@ -1025,7 +1025,7 @@ mod tests {
         let mut accounts: Vec<(Pubkey, Account)> = Vec::new();
         let mut error_counters = ErrorCounters::default();
 
-        let keypair = Keypair::new();
+        let keypair = generate_keypair();
         let key0 = keypair.pubkey();
         let key1 = Pubkey::new(&[5u8; 32]);
         let key2 = Pubkey::new(&[6u8; 32]);
@@ -1094,7 +1094,7 @@ mod tests {
         let mut accounts: Vec<(Pubkey, Account)> = Vec::new();
         let mut error_counters = ErrorCounters::default();
 
-        let keypair = Keypair::new();
+        let keypair = generate_keypair();
         let key0 = keypair.pubkey();
         let key1 = Pubkey::new(&[5u8; 32]);
 
@@ -1133,7 +1133,7 @@ mod tests {
         let mut accounts: Vec<(Pubkey, Account)> = Vec::new();
         let mut error_counters = ErrorCounters::default();
 
-        let keypair = Keypair::new();
+        let keypair = generate_keypair();
         let key0 = keypair.pubkey();
         let key1 = Pubkey::new(&[5u8; 32]);
 
@@ -1171,7 +1171,7 @@ mod tests {
         let mut accounts: Vec<(Pubkey, Account)> = Vec::new();
         let mut error_counters = ErrorCounters::default();
 
-        let keypair = Keypair::new();
+        let keypair = generate_keypair();
         let key0 = keypair.pubkey();
         let key1 = Pubkey::new(&[5u8; 32]);
         let key2 = Pubkey::new(&[6u8; 32]);
@@ -1234,7 +1234,7 @@ mod tests {
         let mut accounts: Vec<(Pubkey, Account)> = Vec::new();
         let mut error_counters = ErrorCounters::default();
 
-        let keypair = Keypair::new();
+        let keypair = generate_keypair();
         let pubkey = keypair.pubkey();
 
         let account = Account::new(10, 1, &Pubkey::default());
@@ -1362,10 +1362,10 @@ mod tests {
 
     #[test]
     fn test_accounts_locks() {
-        let keypair0 = Keypair::new();
-        let keypair1 = Keypair::new();
-        let keypair2 = Keypair::new();
-        let keypair3 = Keypair::new();
+        let keypair0 = generate_keypair();
+        let keypair1 = generate_keypair();
+        let keypair2 = generate_keypair();
+        let keypair3 = generate_keypair();
 
         let account0 = Account::new(1, 0, &Pubkey::default());
         let account1 = Account::new(2, 0, &Pubkey::default());
@@ -1476,9 +1476,9 @@ mod tests {
         let counter = Arc::new(AtomicU64::new(0));
         let exit = Arc::new(AtomicBool::new(false));
 
-        let keypair0 = Keypair::new();
-        let keypair1 = Keypair::new();
-        let keypair2 = Keypair::new();
+        let keypair0 = generate_keypair();
+        let keypair1 = generate_keypair();
+        let keypair2 = generate_keypair();
 
         let account0 = Account::new(1, 0, &Pubkey::default());
         let account1 = Account::new(2, 0, &Pubkey::default());
@@ -1550,8 +1550,8 @@ mod tests {
 
     #[test]
     fn test_collect_accounts_to_store() {
-        let keypair0 = Keypair::new();
-        let keypair1 = Keypair::new();
+        let keypair0 = generate_keypair();
+        let keypair1 = generate_keypair();
         let pubkey = Pubkey::new_rand();
 
         let rent_collector = RentCollector::default();

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -2396,7 +2396,7 @@ pub mod tests {
 
     #[test]
     fn test_bad_bank_hash() {
-        use solana_sdk::signature::{Keypair, KeypairUtil};
+        use solana_sdk::signature::{generate_keypair, KeypairUtil};
         let db = AccountsDB::new(Vec::new());
 
         let some_slot: Slot = 0;
@@ -2407,7 +2407,7 @@ pub mod tests {
             let accounts_keys: Vec<_> = (0..num_accounts)
                 .into_iter()
                 .map(|_| {
-                    let key = Keypair::new().pubkey();
+                    let key = generate_keypair().pubkey();
                     let lamports = thread_rng().gen_range(0, 100);
                     let some_data_len = thread_rng().gen_range(0, 1000);
                     let account = Account::new(lamports, some_data_len, &key);

--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -178,11 +178,11 @@ impl<T: Clone> AccountsIndex<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use solana_sdk::signature::{Keypair, KeypairUtil};
+    use solana_sdk::signature::{generate_keypair, KeypairUtil};
 
     #[test]
     fn test_get_empty() {
-        let key = Keypair::new();
+        let key = generate_keypair();
         let index = AccountsIndex::<bool>::default();
         let ancestors = HashMap::new();
         assert!(index.get(&key.pubkey(), &ancestors).is_none());
@@ -194,7 +194,7 @@ mod tests {
 
     #[test]
     fn test_insert_no_ancestors() {
-        let key = Keypair::new();
+        let key = generate_keypair();
         let mut index = AccountsIndex::<bool>::default();
         let mut gc = Vec::new();
         index.insert(0, &key.pubkey(), true, &mut gc);
@@ -210,7 +210,7 @@ mod tests {
 
     #[test]
     fn test_insert_wrong_ancestors() {
-        let key = Keypair::new();
+        let key = generate_keypair();
         let mut index = AccountsIndex::<bool>::default();
         let mut gc = Vec::new();
         index.insert(0, &key.pubkey(), true, &mut gc);
@@ -226,7 +226,7 @@ mod tests {
 
     #[test]
     fn test_insert_with_ancestors() {
-        let key = Keypair::new();
+        let key = generate_keypair();
         let mut index = AccountsIndex::<bool>::default();
         let mut gc = Vec::new();
         index.insert(0, &key.pubkey(), true, &mut gc);
@@ -258,7 +258,7 @@ mod tests {
 
     #[test]
     fn test_insert_with_root() {
-        let key = Keypair::new();
+        let key = generate_keypair();
         let mut index = AccountsIndex::<bool>::default();
         let mut gc = Vec::new();
         index.insert(0, &key.pubkey(), true, &mut gc);
@@ -316,7 +316,7 @@ mod tests {
 
     #[test]
     fn test_update_last_wins() {
-        let key = Keypair::new();
+        let key = generate_keypair();
         let mut index = AccountsIndex::<bool>::default();
         let ancestors = vec![(0, 0)].into_iter().collect();
         let mut gc = Vec::new();
@@ -336,7 +336,7 @@ mod tests {
     #[test]
     fn test_update_new_slot() {
         solana_logger::setup();
-        let key = Keypair::new();
+        let key = generate_keypair();
         let mut index = AccountsIndex::<bool>::default();
         let ancestors = vec![(0, 0)].into_iter().collect();
         let mut gc = Vec::new();
@@ -353,7 +353,7 @@ mod tests {
 
     #[test]
     fn test_update_gc_purged_slot() {
-        let key = Keypair::new();
+        let key = generate_keypair();
         let mut index = AccountsIndex::<bool>::default();
         let mut gc = Vec::new();
         index.insert(0, &key.pubkey(), true, &mut gc);
@@ -385,7 +385,7 @@ mod tests {
 
     #[test]
     fn test_purge() {
-        let key = Keypair::new();
+        let key = generate_keypair();
         let mut index = AccountsIndex::<u64>::default();
         let mut gc = Vec::new();
         assert_eq!(Some(12), index.update(1, &key.pubkey(), 12, &mut gc));

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2134,7 +2134,7 @@ mod tests {
         nonce_state,
         poh_config::PohConfig,
         rent::Rent,
-        signature::{Keypair, KeypairUtil},
+        signature::{generate_keypair, KeypairUtil},
         system_instruction,
         system_program::{self, solana_system_program},
         sysvar::{fees::Fees, rewards::Rewards},
@@ -2330,14 +2330,14 @@ mod tests {
     #[test]
     fn test_credit_debit_rent_no_side_effect_on_hash() {
         let (mut genesis_config, _mint_keypair) = create_genesis_config(10);
-        let keypair1: Keypair = Keypair::new();
-        let keypair2: Keypair = Keypair::new();
-        let keypair3: Keypair = Keypair::new();
-        let keypair4: Keypair = Keypair::new();
+        let keypair1: Keypair = generate_keypair();
+        let keypair2: Keypair = generate_keypair();
+        let keypair3: Keypair = generate_keypair();
+        let keypair4: Keypair = generate_keypair();
 
         // Transaction between these two keypairs will fail
-        let keypair5: Keypair = Keypair::new();
-        let keypair6: Keypair = Keypair::new();
+        let keypair5: Keypair = generate_keypair();
+        let keypair6: Keypair = generate_keypair();
 
         genesis_config.rent = Rent {
             lamports_per_byte_year: 1,
@@ -2628,8 +2628,8 @@ mod tests {
 
         let validator_1_pubkey = Pubkey::new_rand();
         let validator_1_stake_lamports = 20;
-        let validator_1_staking_keypair = Keypair::new();
-        let validator_1_voting_keypair = Keypair::new();
+        let validator_1_staking_keypair = generate_keypair();
+        let validator_1_voting_keypair = generate_keypair();
 
         let validator_1_vote_account = vote_state::create_account(
             &validator_1_voting_keypair.pubkey(),
@@ -2661,8 +2661,8 @@ mod tests {
 
         let validator_2_pubkey = Pubkey::new_rand();
         let validator_2_stake_lamports = 20;
-        let validator_2_staking_keypair = Keypair::new();
-        let validator_2_voting_keypair = Keypair::new();
+        let validator_2_staking_keypair = generate_keypair();
+        let validator_2_voting_keypair = generate_keypair();
 
         let validator_2_vote_account = vote_state::create_account(
             &validator_2_voting_keypair.pubkey(),
@@ -2694,8 +2694,8 @@ mod tests {
 
         let validator_3_pubkey = Pubkey::new_rand();
         let validator_3_stake_lamports = 30;
-        let validator_3_staking_keypair = Keypair::new();
-        let validator_3_voting_keypair = Keypair::new();
+        let validator_3_staking_keypair = generate_keypair();
+        let validator_3_voting_keypair = generate_keypair();
 
         let validator_3_vote_account = vote_state::create_account(
             &validator_3_voting_keypair.pubkey(),
@@ -2736,11 +2736,11 @@ mod tests {
         bank.rent_collector.epoch = 5;
         bank.rent_collector.slots_per_year = 192.0;
 
-        let payer = Keypair::new();
+        let payer = generate_keypair();
         let payer_account = Account::new(400, 0, &system_program::id());
         bank.store_account(&payer.pubkey(), &payer_account);
 
-        let payee = Keypair::new();
+        let payee = generate_keypair();
         let payee_account = Account::new(70, 1, &system_program::id());
         bank.store_account(&payee.pubkey(), &payee_account);
 
@@ -2833,7 +2833,7 @@ mod tests {
         let (mut genesis_config, _mint_keypair) = create_genesis_config(10);
         let mut keypairs: Vec<Keypair> = Vec::with_capacity(14);
         for _i in 0..14 {
-            keypairs.push(Keypair::new());
+            keypairs.push(generate_keypair());
         }
 
         genesis_config.rent = Rent {
@@ -3118,7 +3118,7 @@ mod tests {
 
         let bank0 = Arc::new(new_from_parent(&bank));
         let blockhash = bank.last_blockhash();
-        let keypair = Keypair::new();
+        let keypair = generate_keypair();
         let tx = system_transaction::transfer(&mint_keypair, &keypair.pubkey(), 10, blockhash);
         bank0.process_transaction(&tx).unwrap();
 
@@ -3246,7 +3246,7 @@ mod tests {
         genesis_config.fee_calculator.lamports_per_signature = 1;
         let bank = Bank::new(&genesis_config);
 
-        let dest = Keypair::new();
+        let dest = generate_keypair();
 
         // source with 0 program context
         let tx =
@@ -3273,7 +3273,7 @@ mod tests {
     fn test_account_not_found() {
         let (genesis_config, mint_keypair) = create_genesis_config(0);
         let bank = Bank::new(&genesis_config);
-        let keypair = Keypair::new();
+        let keypair = generate_keypair();
         assert_eq!(
             bank.transfer(1, &keypair, &mint_keypair.pubkey()),
             Err(TransactionError::AccountNotFound)
@@ -3319,7 +3319,7 @@ mod tests {
         let bank = Bank::new(&genesis_config);
 
         // Test new account
-        let key = Keypair::new();
+        let key = generate_keypair();
         bank.deposit(&key.pubkey(), 10);
         assert_eq!(bank.get_balance(&key.pubkey()), 10);
 
@@ -3334,7 +3334,7 @@ mod tests {
         let bank = Bank::new(&genesis_config);
 
         // Test no account
-        let key = Keypair::new();
+        let key = generate_keypair();
         assert_eq!(
             bank.withdraw(&key.pubkey(), 10),
             Err(TransactionError::AccountNotFound)
@@ -3362,7 +3362,7 @@ mod tests {
 
         let min_balance =
             bank.get_minimum_balance_for_rent_exemption(nonce_state::NonceState::size());
-        let nonce = Keypair::new();
+        let nonce = generate_keypair();
         let nonce_account = Account::new_data(
             min_balance + 42,
             &nonce_state::NonceState::Initialized(
@@ -3413,7 +3413,7 @@ mod tests {
 
         let capitalization = bank.capitalization();
 
-        let key = Keypair::new();
+        let key = generate_keypair();
         let tx = system_transaction::transfer(
             &mint_keypair,
             &key.pubkey(),
@@ -3494,7 +3494,7 @@ mod tests {
         let bank = Bank::new_from_parent(&Arc::new(bank), &leader, 2);
 
         // Send a transfer using cheap_blockhash
-        let key = Keypair::new();
+        let key = generate_keypair();
         let initial_mint_balance = bank.get_balance(&mint_keypair.pubkey());
         let tx = system_transaction::transfer(&mint_keypair, &key.pubkey(), 1, cheap_blockhash);
         assert_eq!(bank.process_transaction(&tx), Ok(()));
@@ -3505,7 +3505,7 @@ mod tests {
         );
 
         // Send a transfer using expensive_blockhash
-        let key = Keypair::new();
+        let key = generate_keypair();
         let initial_mint_balance = bank.get_balance(&mint_keypair.pubkey());
         let tx = system_transaction::transfer(&mint_keypair, &key.pubkey(), 1, expensive_blockhash);
         assert_eq!(bank.process_transaction(&tx), Ok(()));
@@ -3527,7 +3527,7 @@ mod tests {
         genesis_config.fee_calculator.lamports_per_signature = 2;
         let bank = Bank::new(&genesis_config);
 
-        let key = Keypair::new();
+        let key = generate_keypair();
         let tx1 =
             system_transaction::transfer(&mint_keypair, &key.pubkey(), 2, genesis_config.hash());
         let tx2 =
@@ -3563,7 +3563,7 @@ mod tests {
     fn test_debits_before_credits() {
         let (genesis_config, mint_keypair) = create_genesis_config(2);
         let bank = Bank::new(&genesis_config);
-        let keypair = Keypair::new();
+        let keypair = generate_keypair();
         let tx0 = system_transaction::transfer(
             &mint_keypair,
             &keypair.pubkey(),
@@ -3596,9 +3596,9 @@ mod tests {
         let vote_pubkey0 = Pubkey::new_rand();
         let vote_pubkey1 = Pubkey::new_rand();
         let vote_pubkey2 = Pubkey::new_rand();
-        let authorized_voter = Keypair::new();
-        let payer0 = Keypair::new();
-        let payer1 = Keypair::new();
+        let authorized_voter = generate_keypair();
+        let payer0 = generate_keypair();
+        let payer1 = generate_keypair();
 
         // Create vote accounts
         let vote_account0 =
@@ -3664,8 +3664,8 @@ mod tests {
     fn test_interleaving_locks() {
         let (genesis_config, mint_keypair) = create_genesis_config(3);
         let bank = Bank::new(&genesis_config);
-        let alice = Keypair::new();
-        let bob = Keypair::new();
+        let alice = generate_keypair();
+        let bob = generate_keypair();
 
         let tx1 =
             system_transaction::transfer(&mint_keypair, &alice.pubkey(), 1, genesis_config.hash());
@@ -3699,9 +3699,9 @@ mod tests {
     fn test_readonly_relaxed_locks() {
         let (genesis_config, _) = create_genesis_config(3);
         let bank = Bank::new(&genesis_config);
-        let key0 = Keypair::new();
-        let key1 = Keypair::new();
-        let key2 = Keypair::new();
+        let key0 = generate_keypair();
+        let key1 = generate_keypair();
+        let key2 = generate_keypair();
         let key3 = Pubkey::new_rand();
 
         let message = Message {
@@ -3759,7 +3759,7 @@ mod tests {
     #[test]
     fn test_bank_invalid_account_index() {
         let (genesis_config, mint_keypair) = create_genesis_config(1);
-        let keypair = Keypair::new();
+        let keypair = generate_keypair();
         let bank = Bank::new(&genesis_config);
 
         let tx = system_transaction::transfer(
@@ -3787,7 +3787,7 @@ mod tests {
     #[test]
     fn test_bank_pay_to_self() {
         let (genesis_config, mint_keypair) = create_genesis_config(1);
-        let key1 = Keypair::new();
+        let key1 = generate_keypair();
         let bank = Bank::new(&genesis_config);
 
         bank.transfer(1, &mint_keypair, &key1.pubkey()).unwrap();
@@ -3823,7 +3823,7 @@ mod tests {
     #[test]
     fn test_bank_parent_duplicate_signature() {
         let (genesis_config, mint_keypair) = create_genesis_config(2);
-        let key1 = Keypair::new();
+        let key1 = generate_keypair();
         let parent = Arc::new(Bank::new(&genesis_config));
 
         let tx =
@@ -3840,8 +3840,8 @@ mod tests {
     #[test]
     fn test_bank_parent_account_spend() {
         let (genesis_config, mint_keypair) = create_genesis_config(2);
-        let key1 = Keypair::new();
-        let key2 = Keypair::new();
+        let key1 = generate_keypair();
+        let key2 = generate_keypair();
         let parent = Arc::new(Bank::new(&genesis_config));
 
         let tx =
@@ -3996,7 +3996,7 @@ mod tests {
         assert_ne!(orig, bank.hash_internal_state());
 
         let orig = bank.hash_internal_state();
-        let empty_keypair = Keypair::new();
+        let empty_keypair = generate_keypair();
         assert!(bank.transfer(1000, &empty_keypair, &key0).is_err());
         assert_eq!(orig, bank.hash_internal_state());
     }
@@ -4024,8 +4024,8 @@ mod tests {
     fn test_bank_squash() {
         solana_logger::setup();
         let (genesis_config, mint_keypair) = create_genesis_config(2);
-        let key1 = Keypair::new();
-        let key2 = Keypair::new();
+        let key1 = generate_keypair();
+        let key2 = generate_keypair();
         let parent = Arc::new(Bank::new(&genesis_config));
 
         let tx_transfer_mint_to_1 =
@@ -4087,7 +4087,7 @@ mod tests {
         let (genesis_config, mint_keypair) = create_genesis_config(500);
         let parent = Arc::new(Bank::new(&genesis_config));
 
-        let key1 = Keypair::new();
+        let key1 = generate_keypair();
 
         parent.transfer(1, &mint_keypair, &key1.pubkey()).unwrap();
         assert_eq!(parent.get_balance(&key1.pubkey()), 1);
@@ -4102,7 +4102,7 @@ mod tests {
         let (genesis_config, mint_keypair) = create_genesis_config(500);
         let bank0 = Arc::new(Bank::new(&genesis_config));
 
-        let key1 = Keypair::new();
+        let key1 = generate_keypair();
 
         bank0.transfer(1, &mint_keypair, &key1.pubkey()).unwrap();
         assert_eq!(bank0.get_balance(&key1.pubkey()), 1);
@@ -4365,7 +4365,7 @@ mod tests {
         let (genesis_config, mint_keypair) = create_genesis_config(500);
         let mut bank = Bank::new(&genesis_config);
         bank.fee_calculator.lamports_per_signature = 2;
-        let key = Keypair::new();
+        let key = generate_keypair();
 
         let mut transfer_instruction =
             system_instruction::transfer(&mint_keypair.pubkey(), &key.pubkey(), 0);
@@ -4437,7 +4437,7 @@ mod tests {
     fn test_is_delta_true() {
         let (genesis_config, mint_keypair) = create_genesis_config(500);
         let bank = Arc::new(Bank::new(&genesis_config));
-        let key1 = Keypair::new();
+        let key1 = generate_keypair();
         let tx_transfer_mint_to_1 =
             system_transaction::transfer(&mint_keypair, &key1.pubkey(), 1, genesis_config.hash());
         assert_eq!(bank.process_transaction(&tx_transfer_mint_to_1), Ok(()));
@@ -4457,7 +4457,7 @@ mod tests {
     fn test_is_empty() {
         let (genesis_config, mint_keypair) = create_genesis_config(500);
         let bank0 = Arc::new(Bank::new(&genesis_config));
-        let key1 = Keypair::new();
+        let key1 = generate_keypair();
 
         // The zeroth bank is empty becasue there are no transactions
         assert_eq!(bank0.is_empty(), true);
@@ -4483,7 +4483,7 @@ mod tests {
         assert_eq!(
             bank1.process_transaction(&system_transaction::transfer(
                 &mint_keypair,
-                &Keypair::new().pubkey(),
+                &generate_keypair().pubkey(),
                 1,
                 genesis_config.hash(),
             )),
@@ -4534,7 +4534,7 @@ mod tests {
         assert_eq!(vote_accounts.len(), 1); // bootstrap validator has
                                             // to have a vote account
 
-        let vote_keypair = Keypair::new();
+        let vote_keypair = generate_keypair();
         let instructions = vote_instruction::create_account(
             &mint_keypair.pubkey(),
             &vote_keypair.pubkey(),
@@ -4581,7 +4581,7 @@ mod tests {
         assert_eq!(stake_delegations.len(), 1); // bootstrap validator has
                                                 // to have a stake delegation
 
-        let vote_keypair = Keypair::new();
+        let vote_keypair = generate_keypair();
         let mut instructions = vote_instruction::create_account(
             &mint_keypair.pubkey(),
             &vote_keypair.pubkey(),
@@ -4594,7 +4594,7 @@ mod tests {
             10,
         );
 
-        let stake_keypair = Keypair::new();
+        let stake_keypair = generate_keypair();
         instructions.extend(stake_instruction::create_account_and_delegate_stake(
             &mint_keypair.pubkey(),
             &stake_keypair.pubkey(),
@@ -4638,8 +4638,8 @@ mod tests {
         let bank = Bank::new(&genesis_config);
         bank.is_delta.store(false, Ordering::Relaxed);
 
-        let keypair1 = Keypair::new();
-        let keypair2 = Keypair::new();
+        let keypair1 = generate_keypair();
+        let keypair2 = generate_keypair();
         let fail_tx =
             system_transaction::transfer(&keypair1, &keypair2.pubkey(), 1, bank.last_blockhash());
 
@@ -4676,17 +4676,17 @@ mod tests {
         bank0.squash();
 
         // Create an account on a non-root fork
-        let key1 = Keypair::new();
+        let key1 = generate_keypair();
         bank1.deposit(&key1.pubkey(), 5);
 
         let bank2 = Bank::new_from_parent(&bank0, &Pubkey::default(), 2);
 
         // Test new account
-        let key2 = Keypair::new();
+        let key2 = generate_keypair();
         bank2.deposit(&key2.pubkey(), 10);
         assert_eq!(bank2.get_balance(&key2.pubkey()), 10);
 
-        let key3 = Keypair::new();
+        let key3 = generate_keypair();
         bank2.deposit(&key3.pubkey(), 0);
 
         bank2.squash();
@@ -4823,7 +4823,7 @@ mod tests {
         bank.add_instruction_processor(solana_vote_program::id(), mock_vote_processor);
         assert!(bank.get_account(&solana_vote_program::id()).is_some());
 
-        let mock_account = Keypair::new();
+        let mock_account = generate_keypair();
         let instructions = vote_instruction::create_account(
             &mint_keypair.pubkey(),
             &mock_account.pubkey(),
@@ -4864,7 +4864,7 @@ mod tests {
             Err(InstructionError::CustomError(42))
         }
 
-        let mock_account = Keypair::new();
+        let mock_account = generate_keypair();
         let instructions = vote_instruction::create_account(
             &mint_keypair.pubkey(),
             &mock_account.pubkey(),
@@ -5039,8 +5039,8 @@ mod tests {
         nonce_lamports: u64,
         nonce_authority: Option<Pubkey>,
     ) -> Result<(Keypair, Keypair)> {
-        let custodian_keypair = Keypair::new();
-        let nonce_keypair = Keypair::new();
+        let custodian_keypair = generate_keypair();
+        let nonce_keypair = generate_keypair();
         /* Setup accounts */
         let mut setup_ixs = vec![system_instruction::transfer(
             &mint_keypair.pubkey(),
@@ -5159,7 +5159,7 @@ mod tests {
             setup_nonce_with_bank(10_000_000, |_| {}, 5_000_000, 250_000, None).unwrap();
         let custodian_pubkey = custodian_keypair.pubkey();
         let nonce_pubkey = nonce_keypair.pubkey();
-        let missing_keypair = Keypair::new();
+        let missing_keypair = generate_keypair();
         let missing_pubkey = missing_keypair.pubkey();
 
         let nonce_hash = get_nonce_account(&bank, &nonce_pubkey).unwrap();
@@ -5198,7 +5198,7 @@ mod tests {
     fn test_assign_from_nonce_account_fail() {
         let (genesis_config, _mint_keypair) = create_genesis_config(100_000_000);
         let bank = Arc::new(Bank::new(&genesis_config));
-        let nonce = Keypair::new();
+        let nonce = generate_keypair();
         let nonce_account = Account::new_data(
             42424242,
             &nonce_state::NonceState::Initialized(
@@ -5239,7 +5239,7 @@ mod tests {
             None,
         )
         .unwrap();
-        let alice_keypair = Keypair::new();
+        let alice_keypair = generate_keypair();
         let alice_pubkey = alice_keypair.pubkey();
         let custodian_pubkey = custodian_keypair.pubkey();
         let nonce_pubkey = nonce_keypair.pubkey();
@@ -5350,7 +5350,7 @@ mod tests {
         let parent = Arc::new(Bank::new(&genesis_config));
         let bank0 = Arc::new(new_from_parent(&parent));
 
-        let keypair = Keypair::new();
+        let keypair = generate_keypair();
         let pubkey0 = Pubkey::new_rand();
         let pubkey1 = Pubkey::new_rand();
         let program_id = Pubkey::new(&[2; 32]);
@@ -5391,8 +5391,8 @@ mod tests {
         let parent = Arc::new(Bank::new(&genesis_config));
         let bank0 = Arc::new(new_from_parent(&parent));
 
-        let keypair0 = Keypair::new();
-        let keypair1 = Keypair::new();
+        let keypair0 = generate_keypair();
+        let keypair1 = generate_keypair();
         let pubkey0 = Pubkey::new_rand();
         let pubkey1 = Pubkey::new_rand();
         let pubkey2 = Pubkey::new_rand();
@@ -5406,7 +5406,7 @@ mod tests {
         let blockhash = bank0.last_blockhash();
 
         let tx0 = system_transaction::transfer(&keypair0, &pubkey0, 2, blockhash.clone());
-        let tx1 = system_transaction::transfer(&Keypair::new(), &pubkey1, 2, blockhash.clone());
+        let tx1 = system_transaction::transfer(&generate_keypair(), &pubkey1, 2, blockhash.clone());
         let tx2 = system_transaction::transfer(&keypair1, &pubkey2, 12, blockhash.clone());
         let txs = vec![tx0, tx1, tx2];
 

--- a/runtime/src/bank_client.rs
+++ b/runtime/src/bank_client.rs
@@ -274,13 +274,16 @@ impl BankClient {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use solana_sdk::{genesis_config::create_genesis_config, instruction::AccountMeta};
+    use solana_sdk::{
+        genesis_config::create_genesis_config, instruction::AccountMeta,
+        signature::generate_keypair,
+    };
 
     #[test]
     fn test_bank_client_new_with_keypairs() {
         let (genesis_config, john_doe_keypair) = create_genesis_config(10_000);
         let john_pubkey = john_doe_keypair.pubkey();
-        let jane_doe_keypair = Keypair::new();
+        let jane_doe_keypair = generate_keypair();
         let jane_pubkey = jane_doe_keypair.pubkey();
         let doe_keypairs = vec![&john_doe_keypair, &jane_doe_keypair];
         let bank = Bank::new(&genesis_config);

--- a/runtime/src/genesis_utils.rs
+++ b/runtime/src/genesis_utils.rs
@@ -4,7 +4,7 @@ use solana_sdk::{
     genesis_config::GenesisConfig,
     pubkey::Pubkey,
     rent::Rent,
-    signature::{Keypair, KeypairUtil},
+    signature::{generate_keypair, Keypair, KeypairUtil},
     system_program::{self, solana_system_program},
 };
 use solana_stake_program::stake_state;
@@ -42,9 +42,9 @@ pub fn create_genesis_config_with_leader_ex(
     bootstrap_validator_stake_lamports: u64,
     bootstrap_validator_lamports: u64,
 ) -> GenesisConfigInfo {
-    let mint_keypair = Keypair::new();
-    let bootstrap_validator_voting_keypair = Keypair::new();
-    let bootstrap_validator_staking_keypair = Keypair::new();
+    let mint_keypair = generate_keypair();
+    let bootstrap_validator_voting_keypair = generate_keypair();
+    let bootstrap_validator_staking_keypair = generate_keypair();
 
     let bootstrap_validator_vote_account = vote_state::create_account(
         &bootstrap_validator_voting_keypair.pubkey(),

--- a/runtime/src/loader_utils.rs
+++ b/runtime/src/loader_utils.rs
@@ -5,7 +5,7 @@ use solana_sdk::{
     loader_instruction,
     message::Message,
     pubkey::Pubkey,
-    signature::{Keypair, KeypairUtil},
+    signature::{generate_keypair, Keypair, KeypairUtil},
     system_instruction,
 };
 
@@ -15,7 +15,7 @@ pub fn load_program<T: Client>(
     loader_pubkey: &Pubkey,
     program: Vec<u8>,
 ) -> Pubkey {
-    let program_keypair = Keypair::new();
+    let program_keypair = generate_keypair();
     let program_pubkey = program_keypair.pubkey();
 
     let instruction = system_instruction::create_account(

--- a/runtime/src/nonce_utils.rs
+++ b/runtime/src/nonce_utils.rs
@@ -79,16 +79,16 @@ mod tests {
         instruction::InstructionError,
         nonce_state::{with_test_keyed_account, Meta, NonceAccount},
         pubkey::Pubkey,
-        signature::{Keypair, KeypairUtil},
+        signature::{generate_keypair, KeypairUtil},
         system_instruction,
         sysvar::{recent_blockhashes::create_test_recent_blockhashes, rent::Rent},
     };
     use std::collections::HashSet;
 
     fn nonced_transfer_tx() -> (Pubkey, Pubkey, Transaction) {
-        let from_keypair = Keypair::new();
+        let from_keypair = generate_keypair();
         let from_pubkey = from_keypair.pubkey();
-        let nonce_keypair = Keypair::new();
+        let nonce_keypair = generate_keypair();
         let nonce_pubkey = nonce_keypair.pubkey();
         let tx = Transaction::new_signed_instructions(
             &[&from_keypair, &nonce_keypair],
@@ -110,7 +110,7 @@ mod tests {
     #[test]
     fn tx_uses_nonce_empty_ix_fail() {
         let tx =
-            Transaction::new_signed_instructions(&[&Keypair::new(); 0], vec![], Hash::default());
+            Transaction::new_signed_instructions(&[&generate_keypair(); 0], vec![], Hash::default());
         assert!(transaction_uses_durable_nonce(&tx).is_none());
     }
 
@@ -123,9 +123,9 @@ mod tests {
 
     #[test]
     fn tx_uses_nonce_first_prog_id_not_nonce_fail() {
-        let from_keypair = Keypair::new();
+        let from_keypair = generate_keypair();
         let from_pubkey = from_keypair.pubkey();
-        let nonce_keypair = Keypair::new();
+        let nonce_keypair = generate_keypair();
         let nonce_pubkey = nonce_keypair.pubkey();
         let tx = Transaction::new_signed_instructions(
             &[&from_keypair, &nonce_keypair],
@@ -140,9 +140,9 @@ mod tests {
 
     #[test]
     fn tx_uses_nonce_wrong_first_nonce_ix_fail() {
-        let from_keypair = Keypair::new();
+        let from_keypair = generate_keypair();
         let from_pubkey = from_keypair.pubkey();
-        let nonce_keypair = Keypair::new();
+        let nonce_keypair = generate_keypair();
         let nonce_pubkey = nonce_keypair.pubkey();
         let tx = Transaction::new_signed_instructions(
             &[&from_keypair, &nonce_keypair],

--- a/runtime/src/storage_utils.rs
+++ b/runtime/src/storage_utils.rs
@@ -84,7 +84,7 @@ pub(crate) mod tests {
         client::SyncClient,
         genesis_config::create_genesis_config,
         message::Message,
-        signature::{Keypair, KeypairUtil},
+        signature::{generate_keypair, KeypairUtil},
     };
     use solana_storage_program::{
         storage_contract::{StorageAccount, STORAGE_ACCOUNT_SPACE},
@@ -98,9 +98,9 @@ pub(crate) mod tests {
         let (mut genesis_config, mint_keypair) = create_genesis_config(1000);
         genesis_config.rent.lamports_per_byte_year = 0;
         let mint_pubkey = mint_keypair.pubkey();
-        let archiver_keypair = Keypair::new();
+        let archiver_keypair = generate_keypair();
         let archiver_pubkey = archiver_keypair.pubkey();
-        let validator_keypair = Keypair::new();
+        let validator_keypair = generate_keypair();
         let validator_pubkey = validator_keypair.pubkey();
         let mut bank = Bank::new(&genesis_config);
         bank.add_instruction_processor(

--- a/runtime/src/system_instruction_processor.rs
+++ b/runtime/src/system_instruction_processor.rs
@@ -329,7 +329,7 @@ mod tests {
         instruction::{AccountMeta, Instruction, InstructionError},
         message::Message,
         nonce_state,
-        signature::{Keypair, KeypairUtil},
+        signature::{generate_keypair, KeypairUtil},
         system_instruction, system_program, sysvar,
         transaction::TransactionError,
     };
@@ -904,7 +904,7 @@ mod tests {
         let bank = Bank::new(&genesis_config);
         let bank_client = BankClient::new(bank);
 
-        let alice_keypair = Keypair::new();
+        let alice_keypair = generate_keypair();
         let alice_pubkey = alice_keypair.pubkey();
         let seed = "seed";
         let program_id = Pubkey::new_rand();
@@ -942,7 +942,7 @@ mod tests {
         let bank = Bank::new(&genesis_config);
         let bank_client = BankClient::new(bank);
 
-        let alice_keypair = Keypair::new();
+        let alice_keypair = generate_keypair();
         let alice_pubkey = alice_keypair.pubkey();
         let seed = "seed";
         let program_id = Pubkey::new_rand();
@@ -971,7 +971,7 @@ mod tests {
     fn test_system_unsigned_transaction() {
         let (genesis_config, alice_keypair) = create_genesis_config(100);
         let alice_pubkey = alice_keypair.pubkey();
-        let mallory_keypair = Keypair::new();
+        let mallory_keypair = generate_keypair();
         let mallory_pubkey = mallory_keypair.pubkey();
 
         // Fund to account to bypass AccountNotFound error

--- a/runtime/src/transaction_batch.rs
+++ b/runtime/src/transaction_batch.rs
@@ -57,11 +57,7 @@ impl<'a, 'b> Drop for TransactionBatch<'a, 'b> {
 mod tests {
     use super::*;
     use crate::genesis_utils::{create_genesis_config_with_leader, GenesisConfigInfo};
-    use solana_sdk::{
-        pubkey::Pubkey,
-        signature::{Keypair, KeypairUtil},
-        system_transaction,
-    };
+    use solana_sdk::{pubkey::Pubkey, signature::generate_keypair, system_transaction};
 
     #[test]
     fn test_transaction_batch() {
@@ -95,7 +91,7 @@ mod tests {
         let bank = Bank::new(&genesis_config);
 
         let pubkey = Pubkey::new_rand();
-        let keypair2 = Keypair::new();
+        let keypair2 = generate_keypair();
         let pubkey2 = Pubkey::new_rand();
 
         let txs = vec![

--- a/runtime/tests/stake.rs
+++ b/runtime/tests/stake.rs
@@ -8,7 +8,7 @@ use solana_sdk::{
     client::SyncClient,
     message::Message,
     pubkey::Pubkey,
-    signature::{Keypair, KeypairUtil},
+    signature::{generate_keypair, Keypair, KeypairUtil},
     system_instruction::create_address_with_seed,
     sysvar::{self, stake_history::StakeHistory, Sysvar},
 };
@@ -159,9 +159,9 @@ fn test_stake_create_and_split_single_signature() {
 
 #[test]
 fn test_stake_account_lifetime() {
-    let stake_keypair = Keypair::new();
+    let stake_keypair = generate_keypair();
     let stake_pubkey = stake_keypair.pubkey();
-    let vote_keypair = Keypair::new();
+    let vote_keypair = generate_keypair();
     let vote_pubkey = vote_keypair.pubkey();
     let node_pubkey = Pubkey::new_rand();
 
@@ -274,7 +274,7 @@ fn test_stake_account_lifetime() {
     assert!(lamports > 1_000_000);
 
     // split the stake
-    let split_stake_keypair = Keypair::new();
+    let split_stake_keypair = generate_keypair();
     let split_stake_pubkey = split_stake_keypair.pubkey();
 
     let bank_client = BankClient::new_shared(&bank);
@@ -390,7 +390,7 @@ fn test_stake_account_lifetime() {
 
 #[test]
 fn test_create_stake_account_from_seed() {
-    let vote_keypair = Keypair::new();
+    let vote_keypair = generate_keypair();
     let vote_pubkey = vote_keypair.pubkey();
     let node_pubkey = Pubkey::new_rand();
 

--- a/runtime/tests/storage.rs
+++ b/runtime/tests/storage.rs
@@ -13,7 +13,7 @@ use solana_sdk::{
     hash::{hash, Hash},
     message::Message,
     pubkey::Pubkey,
-    signature::{Keypair, KeypairUtil, Signature},
+    signature::{generate_keypair, Keypair, KeypairUtil, Signature},
     system_instruction,
     sysvar::{
         rewards::{self, Rewards},
@@ -33,9 +33,9 @@ const TICKS_IN_SEGMENT: u64 = DEFAULT_SLOTS_PER_SEGMENT * DEFAULT_TICKS_PER_SLOT
 #[test]
 fn test_account_owner() {
     let account_owner = Pubkey::new_rand();
-    let validator_storage_keypair = Keypair::new();
+    let validator_storage_keypair = generate_keypair();
     let validator_storage_pubkey = validator_storage_keypair.pubkey();
-    let archiver_storage_keypair = Keypair::new();
+    let archiver_storage_keypair = generate_keypair();
     let archiver_storage_pubkey = archiver_storage_keypair.pubkey();
 
     let GenesisConfigInfo {
@@ -105,13 +105,13 @@ fn test_validate_mining() {
     // 1 owner for all archiver and validator accounts for the test
     let owner_pubkey = Pubkey::new_rand();
 
-    let archiver_1_storage_keypair = Keypair::new();
+    let archiver_1_storage_keypair = generate_keypair();
     let archiver_1_storage_id = archiver_1_storage_keypair.pubkey();
 
-    let archiver_2_storage_keypair = Keypair::new();
+    let archiver_2_storage_keypair = generate_keypair();
     let archiver_2_storage_id = archiver_2_storage_keypair.pubkey();
 
-    let validator_storage_keypair = Keypair::new();
+    let validator_storage_keypair = generate_keypair();
     let validator_storage_id = validator_storage_keypair.pubkey();
 
     let bank = Bank::new(&genesis_config);
@@ -403,9 +403,9 @@ fn test_bank_storage() {
         .native_instruction_processors
         .push(solana_storage_program::solana_storage_program!());
     let mint_pubkey = mint_keypair.pubkey();
-    let archiver_keypair = Keypair::new();
+    let archiver_keypair = generate_keypair();
     let archiver_pubkey = archiver_keypair.pubkey();
-    let validator_keypair = Keypair::new();
+    let validator_keypair = generate_keypair();
     let validator_pubkey = validator_keypair.pubkey();
 
     let bank = Bank::new(&genesis_config);

--- a/sdk/src/genesis_config.rs
+++ b/sdk/src/genesis_config.rs
@@ -10,7 +10,7 @@ use crate::{
     poh_config::PohConfig,
     pubkey::Pubkey,
     rent::Rent,
-    signature::{Keypair, KeypairUtil},
+    signature::{generate_keypair, Keypair, KeypairUtil},
     system_program::{self, solana_system_program},
 };
 use bincode::{deserialize, serialize};
@@ -57,7 +57,7 @@ pub struct GenesisConfig {
 
 // useful for basic tests
 pub fn create_genesis_config(lamports: u64) -> (GenesisConfig, Keypair) {
-    let faucet_keypair = Keypair::new();
+    let faucet_keypair = generate_keypair();
     (
         GenesisConfig::new(
             &[(
@@ -175,12 +175,12 @@ impl GenesisConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::signature::{Keypair, KeypairUtil};
+    use crate::signature::KeypairUtil;
     use std::path::PathBuf;
 
     fn make_tmp_path(name: &str) -> PathBuf {
         let out_dir = std::env::var("FARF_DIR").unwrap_or_else(|_| "farf".to_string());
-        let keypair = Keypair::new();
+        let keypair = generate_keypair();
 
         let path = [
             out_dir,
@@ -200,7 +200,7 @@ mod tests {
 
     #[test]
     fn test_genesis_config() {
-        let faucet_keypair = Keypair::new();
+        let faucet_keypair = generate_keypair();
         let mut config = GenesisConfig::default();
         config.add_account(
             faucet_keypair.pubkey(),

--- a/sdk/src/message.rs
+++ b/sdk/src/message.rs
@@ -249,7 +249,7 @@ mod tests {
     use super::*;
     use crate::{
         instruction::AccountMeta,
-        signature::{Keypair, KeypairUtil},
+        signature::{generate_keypair, KeypairUtil},
     };
 
     #[test]
@@ -431,7 +431,7 @@ mod tests {
         let program_id0 = Pubkey::new_rand();
         let program_id1 = Pubkey::new_rand();
         let id0 = Pubkey::default();
-        let keypair1 = Keypair::new();
+        let keypair1 = generate_keypair();
         let id1 = keypair1.pubkey();
         let message = Message::new(vec![
             Instruction::new(program_id0, &0, vec![AccountMeta::new(id0, false)]),

--- a/sdk/src/transaction.rs
+++ b/sdk/src/transaction.rs
@@ -339,7 +339,12 @@ impl Transaction {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{hash::hash, instruction::AccountMeta, signature::Keypair, system_instruction};
+    use crate::{
+        hash::hash,
+        instruction::AccountMeta,
+        signature::{generate_keypair, Keypair},
+        system_instruction,
+    };
     use bincode::{deserialize, serialize, serialized_size};
     use std::mem::size_of;
 
@@ -351,7 +356,7 @@ mod tests {
 
     #[test]
     fn test_refs() {
-        let key = Keypair::new();
+        let key = generate_keypair();
         let key1 = Pubkey::new_rand();
         let key2 = Pubkey::new_rand();
         let prog1 = Pubkey::new_rand();
@@ -392,7 +397,7 @@ mod tests {
     }
     #[test]
     fn test_refs_invalid_program_id() {
-        let key = Keypair::new();
+        let key = generate_keypair();
         let instructions = vec![CompiledInstruction::new(1, &(), vec![])];
         let tx = Transaction::new_with_compiled_instructions(
             &[&key],
@@ -405,7 +410,7 @@ mod tests {
     }
     #[test]
     fn test_refs_invalid_account() {
-        let key = Keypair::new();
+        let key = generate_keypair();
         let instructions = vec![CompiledInstruction::new(1, &(), vec![2])];
         let tx = Transaction::new_with_compiled_instructions(
             &[&key],
@@ -455,7 +460,7 @@ mod tests {
     /// Detect changes to the serialized size of payment transactions, which affects TPS.
     #[test]
     fn test_transaction_minimum_serialized_size() {
-        let alice_keypair = Keypair::new();
+        let alice_keypair = generate_keypair();
         let alice_pubkey = alice_keypair.pubkey();
         let bob_pubkey = Pubkey::new_rand();
         let ix = system_instruction::transfer(&alice_pubkey, &bob_pubkey, 42);
@@ -526,14 +531,14 @@ mod tests {
     #[test]
     #[should_panic]
     fn test_transaction_missing_key() {
-        let keypair = Keypair::new();
+        let keypair = generate_keypair();
         Transaction::new_unsigned_instructions(vec![]).sign(&[&keypair], Hash::default());
     }
 
     #[test]
     #[should_panic]
     fn test_partial_sign_mismatched_key() {
-        let keypair = Keypair::new();
+        let keypair = generate_keypair();
         Transaction::new_unsigned_instructions(vec![Instruction::new(
             Pubkey::default(),
             &0,
@@ -544,9 +549,9 @@ mod tests {
 
     #[test]
     fn test_partial_sign() {
-        let keypair0 = Keypair::new();
-        let keypair1 = Keypair::new();
-        let keypair2 = Keypair::new();
+        let keypair0 = generate_keypair();
+        let keypair1 = generate_keypair();
+        let keypair2 = generate_keypair();
         let mut tx = Transaction::new_unsigned_instructions(vec![Instruction::new(
             Pubkey::default(),
             &0,
@@ -573,7 +578,7 @@ mod tests {
     #[should_panic]
     fn test_transaction_missing_keypair() {
         let program_id = Pubkey::default();
-        let keypair0 = Keypair::new();
+        let keypair0 = generate_keypair();
         let id0 = keypair0.pubkey();
         let ix = Instruction::new(program_id, &0, vec![AccountMeta::new(id0, true)]);
         Transaction::new_unsigned_instructions(vec![ix])
@@ -584,7 +589,7 @@ mod tests {
     #[should_panic]
     fn test_transaction_wrong_key() {
         let program_id = Pubkey::default();
-        let keypair0 = Keypair::new();
+        let keypair0 = generate_keypair();
         let wrong_id = Pubkey::default();
         let ix = Instruction::new(program_id, &0, vec![AccountMeta::new(wrong_id, true)]);
         Transaction::new_unsigned_instructions(vec![ix]).sign(&[&keypair0], Hash::default());
@@ -593,7 +598,7 @@ mod tests {
     #[test]
     fn test_transaction_correct_key() {
         let program_id = Pubkey::default();
-        let keypair0 = Keypair::new();
+        let keypair0 = generate_keypair();
         let id0 = keypair0.pubkey();
         let ix = Instruction::new(program_id, &0, vec![AccountMeta::new(id0, true)]);
         let mut tx = Transaction::new_unsigned_instructions(vec![ix]);
@@ -608,7 +613,7 @@ mod tests {
     #[test]
     fn test_transaction_instruction_with_duplicate_keys() {
         let program_id = Pubkey::default();
-        let keypair0 = Keypair::new();
+        let keypair0 = generate_keypair();
         let id0 = keypair0.pubkey();
         let id1 = Pubkey::new_rand();
         let ix = Instruction::new(

--- a/vote-signer/src/rpc.rs
+++ b/vote-signer/src/rpc.rs
@@ -4,7 +4,7 @@ use jsonrpc_core::{Error, MetaIoHandler, Metadata, Result};
 use jsonrpc_derive::rpc;
 use jsonrpc_http_server::{hyper, AccessControlAllowOrigin, DomainsValidation, ServerBuilder};
 use solana_sdk::pubkey::Pubkey;
-use solana_sdk::signature::{Keypair, KeypairUtil, Signature};
+use solana_sdk::signature::{generate_keypair, Keypair, KeypairUtil, Signature};
 use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -138,7 +138,7 @@ impl VoteSigner for LocalVoteSigner {
                 return Ok(voting_keypair.pubkey());
             }
         }
-        let voting_keypair = Keypair::new();
+        let voting_keypair = generate_keypair();
         let voting_pubkey = voting_keypair.pubkey();
         self.nodes.write().unwrap().insert(*pubkey, voting_keypair);
         Ok(voting_pubkey)
@@ -169,7 +169,7 @@ impl Default for LocalVoteSigner {
 mod tests {
     use super::*;
     use jsonrpc_core::{types::*, Response};
-    use solana_sdk::signature::{Keypair, KeypairUtil};
+    use solana_sdk::signature::{generate_keypair, KeypairUtil};
     use std::mem;
 
     fn start_rpc_handler() -> (MetaIoHandler<Meta>, Meta) {
@@ -185,7 +185,7 @@ mod tests {
     fn test_rpc_register_node() {
         let (io, meta) = start_rpc_handler();
 
-        let node_keypair = Keypair::new();
+        let node_keypair = generate_keypair();
         let node_pubkey = node_keypair.pubkey();
         let msg = "This is a test";
         let sig = node_keypair.sign_message(msg.as_bytes());
@@ -221,7 +221,7 @@ mod tests {
     fn test_rpc_register_node_invalid_sig() {
         let (io, meta) = start_rpc_handler();
 
-        let node_keypair = Keypair::new();
+        let node_keypair = generate_keypair();
         let node_pubkey = node_keypair.pubkey();
         let msg = "This is a test";
         let msg1 = "This is a Test1";
@@ -253,7 +253,7 @@ mod tests {
     fn test_rpc_deregister_node() {
         let (io, meta) = start_rpc_handler();
 
-        let node_keypair = Keypair::new();
+        let node_keypair = generate_keypair();
         let node_pubkey = node_keypair.pubkey();
         let msg = "This is a test";
         let sig = node_keypair.sign_message(msg.as_bytes());
@@ -284,7 +284,7 @@ mod tests {
     fn test_rpc_deregister_node_invalid_sig() {
         let (io, meta) = start_rpc_handler();
 
-        let node_keypair = Keypair::new();
+        let node_keypair = generate_keypair();
         let node_pubkey = node_keypair.pubkey();
         let msg = "This is a test";
         let msg1 = "This is a Test1";
@@ -316,7 +316,7 @@ mod tests {
     fn test_rpc_sign_vote() {
         let (io, meta) = start_rpc_handler();
 
-        let node_keypair = Keypair::new();
+        let node_keypair = generate_keypair();
         let node_pubkey = node_keypair.pubkey();
         let msg = "This is a test";
         let sig = node_keypair.sign_message(msg.as_bytes());
@@ -380,7 +380,7 @@ mod tests {
     fn test_rpc_sign_vote_before_register() {
         let (io, meta) = start_rpc_handler();
 
-        let node_keypair = Keypair::new();
+        let node_keypair = generate_keypair();
         let node_pubkey = node_keypair.pubkey();
         let msg = "This is a test";
         let sig = node_keypair.sign_message(msg.as_bytes());
@@ -411,7 +411,7 @@ mod tests {
     fn test_rpc_sign_vote_after_deregister() {
         let (io, meta) = start_rpc_handler();
 
-        let node_keypair = Keypair::new();
+        let node_keypair = generate_keypair();
         let node_pubkey = node_keypair.pubkey();
         let msg = "This is a test";
         let sig = node_keypair.sign_message(msg.as_bytes());
@@ -459,7 +459,7 @@ mod tests {
     fn test_rpc_sign_vote_invalid_sig() {
         let (io, meta) = start_rpc_handler();
 
-        let node_keypair = Keypair::new();
+        let node_keypair = generate_keypair();
         let node_pubkey = node_keypair.pubkey();
         let msg = "This is a test";
         let msg1 = "This is a Test";


### PR DESCRIPTION
#### Problem

We want to sign transactions with multiple and different implementations of `KeypairUtil`. To do that, we want to add a new `sign()` method that accepts a list of `KeypairUtil` trait objects. We can't do that, because `KeypairUtil` has a method that returns `Self`.

#### Summary of Changes

Move `KeypairUtil::new()` to a utility function named `generate_keypair()`.

Another option would be to wrap dalvek_ed25519 in a struct, which will be explored in a separate draft PR.
