### PR TITLE
Add KeypairCreate trait to offload new() method; churn

### DIFF
--- a/bench-exchange/src/bench.rs
+++ b/bench-exchange/src/bench.rs
@@ -15,7 +15,7 @@ use solana_sdk::{
     client::{Client, SyncClient},
     commitment_config::CommitmentConfig,
     pubkey::Pubkey,
-    signature::{Keypair, KeypairUtil},
+    signature::{Keypair, KeypairCreate, KeypairUtil},
     timing::{duration_as_ms, duration_as_s},
     transaction::Transaction,
     {system_instruction, system_program},

--- a/bench-exchange/src/cli.rs
+++ b/bench-exchange/src/cli.rs
@@ -1,10 +1,8 @@
 use clap::{crate_description, crate_name, value_t, App, Arg, ArgMatches};
 use solana_core::gen_keys::GenKeys;
 use solana_faucet::faucet::FAUCET_PORT;
-use solana_sdk::signature::{read_keypair_file, Keypair, KeypairUtil};
-use std::net::SocketAddr;
-use std::process::exit;
-use std::time::Duration;
+use solana_sdk::signature::{read_keypair_file, Keypair, KeypairCreate};
+use std::{net::SocketAddr, process::exit, time::Duration};
 
 pub struct Config {
     pub entrypoint_addr: SocketAddr,

--- a/bench-exchange/tests/bench_exchange.rs
+++ b/bench-exchange/tests/bench_exchange.rs
@@ -1,19 +1,20 @@
 use log::*;
 use solana_bench_exchange::bench::{airdrop_lamports, do_bench_exchange, Config};
-use solana_core::gossip_service::{discover_cluster, get_multi_client};
-use solana_core::validator::ValidatorConfig;
-use solana_exchange_program::exchange_processor::process_instruction;
-use solana_exchange_program::id;
-use solana_exchange_program::solana_exchange_program;
+use solana_core::{
+    gossip_service::{discover_cluster, get_multi_client},
+    validator::ValidatorConfig,
+};
+use solana_exchange_program::{
+    exchange_processor::process_instruction, id, solana_exchange_program,
+};
 use solana_faucet::faucet::run_local_faucet;
 use solana_local_cluster::local_cluster::{ClusterConfig, LocalCluster};
-use solana_runtime::bank::Bank;
-use solana_runtime::bank_client::BankClient;
-use solana_sdk::genesis_config::create_genesis_config;
-use solana_sdk::signature::{Keypair, KeypairUtil};
-use std::process::exit;
-use std::sync::mpsc::channel;
-use std::time::Duration;
+use solana_runtime::{bank::Bank, bank_client::BankClient};
+use solana_sdk::{
+    genesis_config::create_genesis_config,
+    signature::{Keypair, KeypairCreate, KeypairUtil},
+};
+use std::{process::exit, sync::mpsc::channel, time::Duration};
 
 #[test]
 #[ignore]

--- a/bench-tps/src/cli.rs
+++ b/bench-tps/src/cli.rs
@@ -1,7 +1,7 @@
 use clap::{crate_description, crate_name, App, Arg, ArgMatches};
 use solana_faucet::faucet::FAUCET_PORT;
 use solana_sdk::fee_calculator::FeeCalculator;
-use solana_sdk::signature::{read_keypair_file, Keypair, KeypairUtil};
+use solana_sdk::signature::{read_keypair_file, Keypair, KeypairCreate};
 use std::{net::SocketAddr, process::exit, time::Duration};
 
 const NUM_LAMPORTS_PER_ACCOUNT_DEFAULT: u64 = solana_sdk::native_token::LAMPORTS_PER_SOL;

--- a/bench-tps/tests/bench_tps.rs
+++ b/bench-tps/tests/bench_tps.rs
@@ -1,16 +1,19 @@
 use serial_test_derive::serial;
-use solana_bench_tps::bench::{do_bench_tps, generate_and_fund_keypairs};
-use solana_bench_tps::cli::Config;
+use solana_bench_tps::{
+    bench::{do_bench_tps, generate_and_fund_keypairs},
+    cli::Config,
+};
 use solana_client::thin_client::create_client;
-use solana_core::cluster_info::VALIDATOR_PORT_RANGE;
-use solana_core::validator::ValidatorConfig;
+use solana_core::{cluster_info::VALIDATOR_PORT_RANGE, validator::ValidatorConfig};
 use solana_faucet::faucet::run_local_faucet;
 use solana_local_cluster::local_cluster::{ClusterConfig, LocalCluster};
 #[cfg(feature = "move")]
 use solana_sdk::move_loader::solana_move_loader_program;
-use solana_sdk::signature::{Keypair, KeypairUtil};
-use std::sync::{mpsc::channel, Arc};
-use std::time::Duration;
+use solana_sdk::signature::{Keypair, KeypairCreate, KeypairUtil};
+use std::{
+    sync::{mpsc::channel, Arc},
+    time::Duration,
+};
 
 fn test_bench_tps_local_cluster(config: Config) {
     #[cfg(feature = "move")]

--- a/chacha-cuda/src/chacha_cuda.rs
+++ b/chacha-cuda/src/chacha_cuda.rs
@@ -4,9 +4,7 @@ use solana_chacha::chacha::{CHACHA_BLOCK_SIZE, CHACHA_KEY_SIZE};
 use solana_ledger::blockstore::Blockstore;
 use solana_perf::perf_libs;
 use solana_sdk::hash::Hash;
-use std::io;
-use std::mem::size_of;
-use std::sync::Arc;
+use std::{io, mem::size_of, sync::Arc};
 
 // Encrypt a file with multiple starting IV states, determined by ivecs.len()
 //
@@ -115,12 +113,15 @@ mod tests {
     use super::*;
     use solana_archiver_utils::sample_file;
     use solana_chacha::chacha::chacha_cbc_encrypt_ledger;
-    use solana_ledger::entry::create_ticks;
-    use solana_ledger::get_tmp_ledger_path;
-    use solana_sdk::clock::DEFAULT_SLOTS_PER_SEGMENT;
-    use solana_sdk::signature::{Keypair, KeypairUtil};
-    use std::fs::{remove_dir_all, remove_file};
-    use std::path::Path;
+    use solana_ledger::{entry::create_ticks, get_tmp_ledger_path};
+    use solana_sdk::{
+        clock::DEFAULT_SLOTS_PER_SEGMENT,
+        signature::{Keypair, KeypairCreate},
+    };
+    use std::{
+        fs::{remove_dir_all, remove_file},
+        path::Path,
+    };
 
     #[test]
     fn test_encrypt_file_many_keys_single() {

--- a/clap-utils/src/input_parsers.rs
+++ b/clap-utils/src/input_parsers.rs
@@ -115,7 +115,7 @@ pub fn derivation_of(matches: &ArgMatches<'_>, name: &str) -> Option<DerivationP
 mod tests {
     use super::*;
     use clap::{App, Arg};
-    use solana_sdk::signature::write_keypair_file;
+    use solana_sdk::signature::{write_keypair_file, KeypairCreate};
     use std::fs;
 
     fn app<'ab, 'v>() -> App<'ab, 'v> {

--- a/clap-utils/src/keypair.rs
+++ b/clap-utils/src/keypair.rs
@@ -6,7 +6,7 @@ use solana_sdk::{
     pubkey::Pubkey,
     signature::{
         keypair_from_seed, keypair_from_seed_phrase_and_passphrase, read_keypair_file, Keypair,
-        KeypairUtil,
+        KeypairCreate,
     },
 };
 use std::{

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -36,7 +36,7 @@ use solana_sdk::{
     native_token::lamports_to_sol,
     program_utils::DecodeError,
     pubkey::Pubkey,
-    signature::{keypair_from_seed, Keypair, KeypairUtil, Signature},
+    signature::{keypair_from_seed, Keypair, KeypairCreate, KeypairUtil, Signature},
     system_instruction::{self, create_address_with_seed, SystemError, MAX_ADDRESS_SEED_LEN},
     system_transaction,
     transaction::{Transaction, TransactionError},
@@ -1913,17 +1913,17 @@ impl FaucetKeypair {
 }
 
 impl KeypairUtil for FaucetKeypair {
-    fn new() -> Self {
-        unimplemented!();
-    }
-
     /// Return the public key of the keypair used to sign votes
     fn pubkey(&self) -> Pubkey {
         self.transaction.message().account_keys[0]
     }
 
-    fn sign_message(&self, _msg: &[u8]) -> Signature {
+    fn sign_message(&self, _message: &[u8]) -> Signature {
         self.transaction.signatures[0]
+    }
+
+    fn try_sign_message(&self, _message: &[u8]) -> Result<Signature, Box<dyn error::Error>> {
+        Ok(self.transaction.signatures[0])
     }
 }
 

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -21,7 +21,7 @@ use solana_sdk::{
     epoch_schedule::Epoch,
     hash::Hash,
     pubkey::Pubkey,
-    signature::{Keypair, KeypairUtil},
+    signature::{Keypair, KeypairCreate, KeypairUtil},
     system_transaction,
 };
 use std::{

--- a/cli/src/nonce.rs
+++ b/cli/src/nonce.rs
@@ -618,7 +618,7 @@ mod tests {
         account::Account,
         hash::hash,
         nonce_state::{Meta as NonceMeta, NonceState},
-        signature::{read_keypair_file, write_keypair},
+        signature::{read_keypair_file, write_keypair, KeypairCreate},
         system_program,
     };
     use tempfile::NamedTempFile;

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -12,11 +12,10 @@ use clap::{App, Arg, ArgMatches, SubCommand};
 use console::style;
 use solana_clap_utils::{input_parsers::*, input_validators::*, ArgConstant};
 use solana_client::rpc_client::RpcClient;
-use solana_sdk::signature::{Keypair, Signature};
 use solana_sdk::{
     account_utils::StateMut,
     pubkey::Pubkey,
-    signature::KeypairUtil,
+    signature::{Keypair, KeypairUtil, Signature},
     system_instruction::{create_address_with_seed, SystemError},
     sysvar::{
         stake_history::{self, StakeHistory},
@@ -1230,7 +1229,7 @@ mod tests {
     use solana_sdk::{
         fee_calculator::FeeCalculator,
         hash::Hash,
-        signature::{keypair_from_seed, read_keypair_file, write_keypair, KeypairUtil},
+        signature::{keypair_from_seed, read_keypair_file, write_keypair, KeypairCreate},
     };
     use tempfile::NamedTempFile;
 

--- a/cli/src/storage.rs
+++ b/cli/src/storage.rs
@@ -5,10 +5,13 @@ use crate::cli::{
 use clap::{App, Arg, ArgMatches, SubCommand};
 use solana_clap_utils::{input_parsers::*, input_validators::*};
 use solana_client::rpc_client::RpcClient;
-use solana_sdk::signature::Keypair;
 use solana_sdk::{
-    account_utils::StateMut, message::Message, pubkey::Pubkey, signature::KeypairUtil,
-    system_instruction::SystemError, transaction::Transaction,
+    account_utils::StateMut,
+    message::Message,
+    pubkey::Pubkey,
+    signature::{Keypair, KeypairUtil},
+    system_instruction::SystemError,
+    transaction::Transaction,
 };
 use solana_storage_program::storage_instruction::{self, StorageAccountType};
 
@@ -259,7 +262,7 @@ pub fn process_show_storage_account(
 mod tests {
     use super::*;
     use crate::cli::{app, parse_command};
-    use solana_sdk::signature::write_keypair;
+    use solana_sdk::signature::{write_keypair, KeypairCreate};
     use tempfile::NamedTempFile;
 
     fn make_tmp_file() -> (String, NamedTempFile) {

--- a/cli/src/validator_info.rs
+++ b/cli/src/validator_info.rs
@@ -19,7 +19,7 @@ use solana_sdk::{
     commitment_config::CommitmentConfig,
     message::Message,
     pubkey::Pubkey,
-    signature::{Keypair, KeypairUtil},
+    signature::{Keypair, KeypairCreate, KeypairUtil},
     transaction::Transaction,
 };
 use std::error;

--- a/cli/src/vote.rs
+++ b/cli/src/vote.rs
@@ -474,7 +474,7 @@ pub fn process_show_vote_account(
 mod tests {
     use super::*;
     use crate::cli::{app, parse_command};
-    use solana_sdk::signature::write_keypair;
+    use solana_sdk::signature::{write_keypair, KeypairCreate};
     use tempfile::NamedTempFile;
 
     fn make_tmp_file() -> (String, NamedTempFile) {

--- a/cli/tests/nonce.rs
+++ b/cli/tests/nonce.rs
@@ -6,7 +6,7 @@ use solana_faucet::faucet::run_local_faucet;
 use solana_sdk::{
     hash::Hash,
     pubkey::Pubkey,
-    signature::{read_keypair_file, write_keypair, Keypair, KeypairUtil},
+    signature::{read_keypair_file, write_keypair, Keypair, KeypairCreate, KeypairUtil},
     system_instruction::create_address_with_seed,
     system_program,
 };

--- a/cli/tests/pay.rs
+++ b/cli/tests/pay.rs
@@ -11,16 +11,13 @@ use solana_sdk::{
     fee_calculator::FeeCalculator,
     nonce_state::NonceState,
     pubkey::Pubkey,
-    signature::{read_keypair_file, write_keypair, Keypair, KeypairUtil},
+    signature::{read_keypair_file, write_keypair, Keypair, KeypairCreate, KeypairUtil},
 };
-use std::fs::remove_dir_all;
-use std::sync::mpsc::channel;
+use std::{fs::remove_dir_all, sync::mpsc::channel, thread::sleep, time::Duration};
+use tempfile::NamedTempFile;
 
 #[cfg(test)]
 use solana_core::validator::new_validator_for_tests;
-use std::thread::sleep;
-use std::time::Duration;
-use tempfile::NamedTempFile;
 
 fn make_tmp_file() -> (String, NamedTempFile) {
     let tmp_file = NamedTempFile::new().unwrap();

--- a/cli/tests/stake.rs
+++ b/cli/tests/stake.rs
@@ -9,7 +9,9 @@ use solana_sdk::{
     fee_calculator::FeeCalculator,
     nonce_state::NonceState,
     pubkey::Pubkey,
-    signature::{keypair_from_seed, read_keypair_file, write_keypair, Keypair, KeypairUtil},
+    signature::{
+        keypair_from_seed, read_keypair_file, write_keypair, Keypair, KeypairCreate, KeypairUtil,
+    },
     system_instruction::create_address_with_seed,
 };
 use solana_stake_program::stake_state::{Lockup, StakeAuthorize, StakeState};

--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -1130,7 +1130,7 @@ mod tests {
     use solana_logger;
     use solana_sdk::{
         instruction::InstructionError,
-        signature::{Keypair, KeypairUtil},
+        signature::{Keypair, KeypairCreate},
         system_transaction,
         transaction::TransactionError,
     };

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -1026,7 +1026,7 @@ mod tests {
     use solana_runtime::bank::HashAgeKind;
     use solana_sdk::{
         instruction::InstructionError,
-        signature::{Keypair, KeypairUtil},
+        signature::{Keypair, KeypairCreate, KeypairUtil},
         system_transaction,
         transaction::TransactionError,
     };

--- a/core/src/blockstream.rs
+++ b/core/src/blockstream.rs
@@ -7,9 +7,11 @@ use chrono::{SecondsFormat, Utc};
 use serde_json::json;
 use solana_ledger::entry::Entry;
 use solana_sdk::{clock::Slot, hash::Hash, pubkey::Pubkey};
-use std::cell::RefCell;
-use std::io::Result;
-use std::path::{Path, PathBuf};
+use std::{
+    cell::RefCell,
+    io::Result,
+    path::{Path, PathBuf},
+};
 
 pub trait EntryWriter: std::fmt::Debug {
     fn write(&self, payload: String) -> Result<()>;
@@ -179,11 +181,12 @@ mod test {
     use super::*;
     use chrono::{DateTime, FixedOffset};
     use serde_json::Value;
-    use solana_sdk::hash::Hash;
-    use solana_sdk::signature::{Keypair, KeypairUtil};
-    use solana_sdk::system_transaction;
-    use std::collections::HashSet;
-    use std::path::PathBuf;
+    use solana_sdk::{
+        hash::Hash,
+        signature::{Keypair, KeypairCreate, KeypairUtil},
+        system_transaction,
+    };
+    use std::{collections::HashSet, path::PathBuf};
 
     #[test]
     fn test_serialize_transactions() {

--- a/core/src/blockstream_service.rs
+++ b/core/src/blockstream_service.rs
@@ -2,20 +2,26 @@
 //! using the `blockstream` module, providing client services such as a block explorer with
 //! real-time access to entries.
 
-use crate::blockstream::BlockstreamEvents;
 #[cfg(test)]
 use crate::blockstream::MockBlockstream as Blockstream;
 #[cfg(not(test))]
 use crate::blockstream::SocketBlockstream as Blockstream;
-use crate::result::{Error, Result};
+use crate::{
+    blockstream::BlockstreamEvents,
+    result::{Error, Result},
+};
 use solana_ledger::blockstore::Blockstore;
 use solana_sdk::pubkey::Pubkey;
-use std::path::Path;
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::mpsc::{Receiver, RecvTimeoutError};
-use std::sync::Arc;
-use std::thread::{self, Builder, JoinHandle};
-use std::time::Duration;
+use std::{
+    path::Path,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        mpsc::{Receiver, RecvTimeoutError},
+        Arc,
+    },
+    thread::{self, Builder, JoinHandle},
+    time::Duration,
+};
 
 pub struct BlockstreamService {
     t_blockstream: JoinHandle<()>,
@@ -104,13 +110,16 @@ mod test {
     use bincode::{deserialize, serialize};
     use chrono::{DateTime, FixedOffset};
     use serde_json::Value;
-    use solana_ledger::create_new_tmp_ledger;
-    use solana_ledger::entry::{create_ticks, Entry};
-    use solana_sdk::hash::Hash;
-    use solana_sdk::signature::{Keypair, KeypairUtil};
-    use solana_sdk::system_transaction;
-    use std::path::PathBuf;
-    use std::sync::mpsc::channel;
+    use solana_ledger::{
+        create_new_tmp_ledger,
+        entry::{create_ticks, Entry},
+    };
+    use solana_sdk::{
+        hash::Hash,
+        signature::{Keypair, KeypairCreate, KeypairUtil},
+        system_transaction,
+    };
+    use std::{path::PathBuf, sync::mpsc::channel};
 
     #[test]
     fn test_blockstream_service_process_entries() {

--- a/core/src/broadcast_stage.rs
+++ b/core/src/broadcast_stage.rs
@@ -1,22 +1,28 @@
 //! A stage to broadcast data from a leader node to validators
-use self::broadcast_fake_shreds_run::BroadcastFakeShredsRun;
-use self::fail_entry_verification_broadcast_run::FailEntryVerificationBroadcastRun;
-use self::standard_broadcast_run::StandardBroadcastRun;
-use crate::cluster_info::{ClusterInfo, ClusterInfoError};
-use crate::poh_recorder::WorkingBankEntry;
-use crate::result::{Error, Result};
-use solana_ledger::blockstore::Blockstore;
-use solana_ledger::shred::Shred;
-use solana_ledger::staking_utils;
+use self::{
+    broadcast_fake_shreds_run::BroadcastFakeShredsRun,
+    fail_entry_verification_broadcast_run::FailEntryVerificationBroadcastRun,
+    standard_broadcast_run::StandardBroadcastRun,
+};
+use crate::{
+    cluster_info::{ClusterInfo, ClusterInfoError},
+    poh_recorder::WorkingBankEntry,
+    result::{Error, Result},
+};
+use solana_ledger::{blockstore::Blockstore, shred::Shred, staking_utils};
 use solana_metrics::{inc_new_counter_error, inc_new_counter_info};
 use solana_sdk::pubkey::Pubkey;
-use std::collections::HashMap;
-use std::net::UdpSocket;
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::mpsc::{channel, Receiver, RecvError, RecvTimeoutError, Sender};
-use std::sync::{Arc, Mutex, RwLock};
-use std::thread::{self, Builder, JoinHandle};
-use std::time::Instant;
+use std::{
+    collections::HashMap,
+    net::UdpSocket,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        mpsc::{channel, Receiver, RecvError, RecvTimeoutError, Sender},
+        Arc, Mutex, RwLock,
+    },
+    thread::{self, Builder, JoinHandle},
+    time::Instant,
+};
 
 pub const NUM_INSERT_THREADS: usize = 2;
 
@@ -252,20 +258,23 @@ impl BroadcastStage {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::cluster_info::{ClusterInfo, Node};
-    use crate::genesis_utils::{create_genesis_config, GenesisConfigInfo};
-    use solana_ledger::entry::create_ticks;
-    use solana_ledger::{blockstore::Blockstore, get_tmp_ledger_path};
+    use crate::{
+        cluster_info::{ClusterInfo, Node},
+        genesis_utils::{create_genesis_config, GenesisConfigInfo},
+    };
+    use solana_ledger::{blockstore::Blockstore, entry::create_ticks, get_tmp_ledger_path};
     use solana_runtime::bank::Bank;
-    use solana_sdk::hash::Hash;
-    use solana_sdk::pubkey::Pubkey;
-    use solana_sdk::signature::{Keypair, KeypairUtil};
-    use std::path::Path;
-    use std::sync::atomic::AtomicBool;
-    use std::sync::mpsc::channel;
-    use std::sync::{Arc, RwLock};
-    use std::thread::sleep;
-    use std::time::Duration;
+    use solana_sdk::{
+        hash::Hash,
+        pubkey::Pubkey,
+        signature::{Keypair, KeypairCreate, KeypairUtil},
+    };
+    use std::{
+        path::Path,
+        sync::{atomic::AtomicBool, mpsc::channel, Arc, RwLock},
+        thread::sleep,
+        time::Duration,
+    };
 
     struct MockBroadcastStage {
         blockstore: Arc<Blockstore>,

--- a/core/src/broadcast_stage/standard_broadcast_run.rs
+++ b/core/src/broadcast_stage/standard_broadcast_run.rs
@@ -1,13 +1,14 @@
-use super::broadcast_utils::{self, ReceiveResults};
-use super::*;
+use super::{
+    broadcast_utils::{self, ReceiveResults},
+    *,
+};
 use crate::broadcast_stage::broadcast_utils::UnfinishedSlotInfo;
-use solana_ledger::entry::Entry;
-use solana_ledger::shred::{Shred, Shredder, RECOMMENDED_FEC_RATE, SHRED_TICK_REFERENCE_MASK};
-use solana_sdk::pubkey::Pubkey;
-use solana_sdk::signature::Keypair;
-use solana_sdk::timing::duration_as_us;
-use std::collections::HashMap;
-use std::time::Duration;
+use solana_ledger::{
+    entry::Entry,
+    shred::{Shred, Shredder, RECOMMENDED_FEC_RATE, SHRED_TICK_REFERENCE_MASK},
+};
+use solana_sdk::{pubkey::Pubkey, signature::Keypair, timing::duration_as_us};
+use std::{collections::HashMap, time::Duration};
 
 #[derive(Default)]
 struct BroadcastStats {
@@ -362,7 +363,7 @@ mod test {
     use solana_sdk::{
         clock::Slot,
         genesis_config::GenesisConfig,
-        signature::{Keypair, KeypairUtil},
+        signature::{Keypair, KeypairCreate, KeypairUtil},
     };
     use std::sync::{Arc, RwLock};
     use std::time::Duration;

--- a/core/src/cluster_info.rs
+++ b/core/src/cluster_info.rs
@@ -39,7 +39,7 @@ use solana_perf::packet::{to_packets_with_destination, Packets, PacketsRecycler}
 use solana_sdk::{
     clock::{Slot, DEFAULT_MS_PER_SLOT},
     pubkey::Pubkey,
-    signature::{Keypair, KeypairUtil, Signable, Signature},
+    signature::{Keypair, KeypairCreate, Signable, Signature},
     timing::{duration_as_ms, timestamp},
     transaction::Transaction,
 };

--- a/core/src/cluster_info_vote_listener.rs
+++ b/core/src/cluster_info_vote_listener.rs
@@ -1,14 +1,21 @@
-use crate::cluster_info::{ClusterInfo, GOSSIP_SLEEP_MILLIS};
-use crate::packet::Packets;
-use crate::poh_recorder::PohRecorder;
-use crate::result::Result;
-use crate::{packet, sigverify};
+use crate::{
+    cluster_info::{ClusterInfo, GOSSIP_SLEEP_MILLIS},
+    packet,
+    packet::Packets,
+    poh_recorder::PohRecorder,
+    result::Result,
+    sigverify,
+};
 use crossbeam_channel::Sender as CrossbeamSender;
 use solana_metrics::inc_new_counter_debug;
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Mutex, RwLock};
-use std::thread::{self, sleep, Builder, JoinHandle};
-use std::time::Duration;
+use std::{
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc, Mutex, RwLock,
+    },
+    thread::{self, sleep, Builder, JoinHandle},
+    time::Duration,
+};
 
 pub struct ClusterInfoVoteListener {
     thread_hdls: Vec<JoinHandle<()>>,
@@ -83,11 +90,12 @@ impl ClusterInfoVoteListener {
 #[cfg(test)]
 mod tests {
     use crate::packet;
-    use solana_sdk::hash::Hash;
-    use solana_sdk::signature::{Keypair, KeypairUtil};
-    use solana_sdk::transaction::Transaction;
-    use solana_vote_program::vote_instruction;
-    use solana_vote_program::vote_state::Vote;
+    use solana_sdk::{
+        hash::Hash,
+        signature::{Keypair, KeypairCreate, KeypairUtil},
+        transaction::Transaction,
+    };
+    use solana_vote_program::{vote_instruction, vote_state::Vote};
 
     #[test]
     fn test_max_vote_tx_fits() {

--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -479,15 +479,20 @@ pub mod test {
         clock::Slot,
         hash::Hash,
         pubkey::Pubkey,
-        signature::{Keypair, KeypairUtil},
+        signature::{Keypair, KeypairCreate, KeypairUtil},
         transaction::Transaction,
     };
     use solana_stake_program::stake_state;
-    use solana_vote_program::vote_state;
-    use solana_vote_program::{vote_instruction, vote_state::Vote};
-    use std::collections::{HashMap, VecDeque};
-    use std::sync::RwLock;
-    use std::{thread::sleep, time::Duration};
+    use solana_vote_program::{
+        vote_instruction,
+        vote_state::{self, Vote},
+    };
+    use std::{
+        collections::{HashMap, VecDeque},
+        sync::RwLock,
+        thread::sleep,
+        time::Duration,
+    };
     use trees::{tr, Node, Tree};
 
     pub(crate) struct ValidatorKeypairs {

--- a/core/src/contact_info.rs
+++ b/core/src/contact_info.rs
@@ -1,11 +1,13 @@
-use solana_sdk::pubkey::Pubkey;
+use solana_sdk::{pubkey::Pubkey, timing::timestamp};
 #[cfg(test)]
-use solana_sdk::rpc_port;
-#[cfg(test)]
-use solana_sdk::signature::{Keypair, KeypairUtil};
-use solana_sdk::timing::timestamp;
-use std::cmp::{Ord, Ordering, PartialEq, PartialOrd};
-use std::net::{IpAddr, SocketAddr};
+use solana_sdk::{
+    rpc_port,
+    signature::{Keypair, KeypairCreate, KeypairUtil},
+};
+use std::{
+    cmp::{Ord, Ordering, PartialEq, PartialOrd},
+    net::{IpAddr, SocketAddr},
+};
 
 /// Structure representing a node on the network
 #[derive(Serialize, Deserialize, Clone, Debug)]

--- a/core/src/crds_value.rs
+++ b/core/src/crds_value.rs
@@ -1,14 +1,16 @@
 use crate::contact_info::ContactInfo;
 use bincode::{serialize, serialized_size};
-use solana_sdk::clock::Slot;
-use solana_sdk::pubkey::Pubkey;
-use solana_sdk::signature::{Keypair, Signable, Signature};
-use solana_sdk::transaction::Transaction;
-use std::borrow::Borrow;
-use std::borrow::Cow;
-use std::collections::BTreeSet;
-use std::collections::HashSet;
-use std::fmt;
+use solana_sdk::{
+    clock::Slot,
+    pubkey::Pubkey,
+    signature::{Keypair, Signable, Signature},
+    transaction::Transaction,
+};
+use std::{
+    borrow::{Borrow, Cow},
+    collections::{BTreeSet, HashSet},
+    fmt,
+};
 
 pub type VoteIndex = u8;
 pub const MAX_VOTES: VoteIndex = 32;
@@ -246,8 +248,10 @@ mod test {
     use crate::contact_info::ContactInfo;
     use bincode::deserialize;
     use solana_perf::test_tx::test_tx;
-    use solana_sdk::signature::{Keypair, KeypairUtil};
-    use solana_sdk::timing::timestamp;
+    use solana_sdk::{
+        signature::{Keypair, KeypairCreate, KeypairUtil},
+        timing::timestamp,
+    };
 
     #[test]
     fn test_labels() {

--- a/core/src/gossip_service.rs
+++ b/core/src/gossip_service.rs
@@ -1,20 +1,28 @@
 //! The `gossip_service` module implements the network control plane.
 
-use crate::cluster_info::{ClusterInfo, VALIDATOR_PORT_RANGE};
-use crate::contact_info::ContactInfo;
-use crate::streamer;
+use crate::{
+    cluster_info::{ClusterInfo, VALIDATOR_PORT_RANGE},
+    contact_info::ContactInfo,
+    streamer,
+};
 use rand::{thread_rng, Rng};
 use solana_client::thin_client::{create_client, ThinClient};
 use solana_ledger::bank_forks::BankForks;
 use solana_perf::recycler::Recycler;
-use solana_sdk::pubkey::Pubkey;
-use solana_sdk::signature::{Keypair, KeypairUtil};
-use std::net::{SocketAddr, TcpListener, UdpSocket};
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::mpsc::channel;
-use std::sync::{Arc, RwLock};
-use std::thread::{self, sleep, JoinHandle};
-use std::time::{Duration, Instant};
+use solana_sdk::{
+    pubkey::Pubkey,
+    signature::{Keypair, KeypairCreate, KeypairUtil},
+};
+use std::{
+    net::{SocketAddr, TcpListener, UdpSocket},
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        mpsc::channel,
+        Arc, RwLock,
+    },
+    thread::{self, sleep, JoinHandle},
+    time::{Duration, Instant},
+};
 
 pub struct GossipService {
     thread_hdls: Vec<JoinHandle<()>>,

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -1063,7 +1063,7 @@ pub(crate) mod tests {
         instruction::InstructionError,
         packet::PACKET_DATA_SIZE,
         rent::Rent,
-        signature::{Keypair, KeypairUtil, Signature},
+        signature::{Keypair, KeypairCreate, KeypairUtil, Signature},
         system_transaction,
         transaction::TransactionError,
     };

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -1110,7 +1110,7 @@ pub mod tests {
         hash::{hash, Hash},
         instruction::InstructionError,
         rpc_port,
-        signature::{Keypair, KeypairUtil},
+        signature::{Keypair, KeypairCreate, KeypairUtil},
         system_transaction,
         transaction::TransactionError,
     };

--- a/core/src/rpc_pubsub.rs
+++ b/core/src/rpc_pubsub.rs
@@ -288,7 +288,7 @@ mod tests {
     use solana_runtime::bank::Bank;
     use solana_sdk::{
         pubkey::Pubkey,
-        signature::{Keypair, KeypairUtil},
+        signature::{Keypair, KeypairCreate, KeypairUtil},
         system_program, system_transaction,
         transaction::{self, Transaction},
     };

--- a/core/src/rpc_pubsub_service.rs
+++ b/core/src/rpc_pubsub_service.rs
@@ -1,14 +1,20 @@
 //! The `pubsub` module implements a threaded subscription service on client RPC request
 
-use crate::rpc_pubsub::{RpcSolPubSub, RpcSolPubSubImpl};
-use crate::rpc_subscriptions::RpcSubscriptions;
+use crate::{
+    rpc_pubsub::{RpcSolPubSub, RpcSolPubSubImpl},
+    rpc_subscriptions::RpcSubscriptions,
+};
 use jsonrpc_pubsub::{PubSubHandler, Session};
 use jsonrpc_ws_server::{RequestContext, ServerBuilder};
-use std::net::SocketAddr;
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
-use std::thread::{self, sleep, Builder, JoinHandle};
-use std::time::Duration;
+use std::{
+    net::SocketAddr,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+    thread::{self, sleep, Builder, JoinHandle},
+    time::Duration,
+};
 
 pub struct PubSubService {
     thread_hdl: JoinHandle<()>,

--- a/core/src/rpc_subscriptions.rs
+++ b/core/src/rpc_subscriptions.rs
@@ -11,14 +11,16 @@ use solana_sdk::{
     account::Account, clock::Slot, pubkey::Pubkey, signature::Signature, transaction,
 };
 use solana_vote_program::vote_state::MAX_LOCKOUT_HISTORY;
-use std::ops::DerefMut;
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::mpsc::{Receiver, RecvTimeoutError, SendError, Sender};
-use std::thread::{Builder, JoinHandle};
-use std::time::Duration;
 use std::{
     collections::HashMap,
-    sync::{Arc, Mutex, RwLock},
+    ops::DerefMut,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        mpsc::{Receiver, RecvTimeoutError, SendError, Sender},
+        Arc, Mutex, RwLock,
+    },
+    thread::{Builder, JoinHandle},
+    time::Duration,
 };
 
 const RECEIVE_DELAY_MILLIS: u64 = 100;
@@ -485,7 +487,7 @@ pub(crate) mod tests {
     use jsonrpc_pubsub::typed::Subscriber;
     use solana_budget_program;
     use solana_sdk::{
-        signature::{Keypair, KeypairUtil},
+        signature::{Keypair, KeypairCreate, KeypairUtil},
         system_transaction,
     };
     use tokio::prelude::{Async, Stream};

--- a/core/src/sigverify_shreds.rs
+++ b/core/src/sigverify_shreds.rs
@@ -72,11 +72,10 @@ impl SigVerifier for ShredSigVerifier {
 #[cfg(test)]
 pub mod tests {
     use super::*;
-    use crate::genesis_utils::create_genesis_config_with_leader;
-    use crate::packet::Packet;
+    use crate::{genesis_utils::create_genesis_config_with_leader, packet::Packet};
     use solana_ledger::shred::{Shred, Shredder};
     use solana_runtime::bank::Bank;
-    use solana_sdk::signature::{Keypair, KeypairUtil};
+    use solana_sdk::signature::{Keypair, KeypairCreate, KeypairUtil};
 
     #[test]
     fn test_sigverify_shreds_read_slots() {

--- a/core/src/storage_stage.rs
+++ b/core/src/storage_stage.rs
@@ -648,12 +648,18 @@ mod tests {
     use crate::genesis_utils::{create_genesis_config, GenesisConfigInfo};
     use rayon::prelude::*;
     use solana_runtime::bank::Bank;
-    use solana_sdk::hash::Hasher;
-    use solana_sdk::signature::{Keypair, KeypairUtil};
-    use std::cmp::{max, min};
-    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
-    use std::sync::mpsc::channel;
-    use std::sync::{Arc, RwLock};
+    use solana_sdk::{
+        hash::Hasher,
+        signature::{Keypair, KeypairCreate, KeypairUtil},
+    };
+    use std::{
+        cmp::{max, min},
+        sync::{
+            atomic::{AtomicBool, AtomicUsize, Ordering},
+            mpsc::channel,
+            Arc, RwLock,
+        },
+    };
 
     #[test]
     fn test_storage_stage_none_ledger() {

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -247,11 +247,14 @@ impl Tvu {
 #[cfg(test)]
 pub mod tests {
     use super::*;
-    use crate::banking_stage::create_test_recorder;
-    use crate::cluster_info::{ClusterInfo, Node};
-    use crate::genesis_utils::{create_genesis_config, GenesisConfigInfo};
+    use crate::{
+        banking_stage::create_test_recorder,
+        cluster_info::{ClusterInfo, Node},
+        genesis_utils::{create_genesis_config, GenesisConfigInfo},
+    };
     use solana_ledger::create_new_tmp_ledger;
     use solana_runtime::bank::Bank;
+    use solana_sdk::signature::KeypairCreate;
     use std::sync::atomic::Ordering;
 
     #[test]

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -39,7 +39,7 @@ use solana_sdk::{
     hash::Hash,
     poh_config::PohConfig,
     pubkey::Pubkey,
-    signature::{Keypair, KeypairUtil},
+    signature::{Keypair, KeypairCreate, KeypairUtil},
     timing::timestamp,
 };
 use std::{

--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -1,31 +1,39 @@
 //! `window_service` handles the data plane incoming shreds, storing them in
 //!   blockstore and retransmitting where required
 //!
-use crate::cluster_info::ClusterInfo;
-use crate::packet::Packets;
-use crate::repair_service::{RepairService, RepairStrategy};
-use crate::result::{Error, Result};
-use crate::streamer::PacketSender;
+use crate::{
+    cluster_info::ClusterInfo,
+    packet::Packets,
+    repair_service::{RepairService, RepairStrategy},
+    result::{Error, Result},
+    streamer::PacketSender,
+};
 use crossbeam_channel::{
     unbounded, Receiver as CrossbeamReceiver, RecvTimeoutError, Sender as CrossbeamSender,
 };
-use rayon::iter::IntoParallelRefMutIterator;
-use rayon::iter::ParallelIterator;
-use rayon::ThreadPool;
-use solana_ledger::bank_forks::BankForks;
-use solana_ledger::blockstore::{self, Blockstore, MAX_DATA_SHREDS_PER_SLOT};
-use solana_ledger::leader_schedule_cache::LeaderScheduleCache;
-use solana_ledger::shred::Shred;
+use rayon::{
+    iter::{IntoParallelRefMutIterator, ParallelIterator},
+    ThreadPool,
+};
+use solana_ledger::{
+    bank_forks::BankForks,
+    blockstore::{self, Blockstore, MAX_DATA_SHREDS_PER_SLOT},
+    leader_schedule_cache::LeaderScheduleCache,
+    shred::Shred,
+};
 use solana_metrics::{inc_new_counter_debug, inc_new_counter_error};
 use solana_rayon_threadlimit::get_thread_count;
 use solana_runtime::bank::Bank;
-use solana_sdk::pubkey::Pubkey;
-use solana_sdk::timing::duration_as_ms;
-use std::net::UdpSocket;
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, RwLock};
-use std::thread::{self, Builder, JoinHandle};
-use std::time::{Duration, Instant};
+use solana_sdk::{pubkey::Pubkey, timing::duration_as_ms};
+use std::{
+    net::UdpSocket,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc, RwLock,
+    },
+    thread::{self, Builder, JoinHandle},
+    time::{Duration, Instant},
+};
 
 fn verify_shred_slot(shred: &Shred, root: u64) -> bool {
     if shred.is_data() {
@@ -494,7 +502,7 @@ mod test {
         clock::Slot,
         epoch_schedule::MINIMUM_SLOTS_PER_EPOCH,
         hash::Hash,
-        signature::{Keypair, KeypairUtil},
+        signature::{Keypair, KeypairCreate, KeypairUtil},
     };
     use std::{
         net::UdpSocket,

--- a/core/tests/bank_forks.rs
+++ b/core/tests/bank_forks.rs
@@ -21,7 +21,7 @@ mod tests {
         clock::Slot,
         hash::hashv,
         pubkey::Pubkey,
-        signature::{Keypair, KeypairUtil},
+        signature::{Keypair, KeypairCreate, KeypairUtil},
         system_transaction,
     };
     use std::{fs, path::PathBuf, sync::atomic::AtomicBool, sync::mpsc::channel, sync::Arc};

--- a/core/tests/gossip.rs
+++ b/core/tests/gossip.rs
@@ -2,17 +2,24 @@
 extern crate log;
 
 use rayon::iter::*;
-use solana_core::cluster_info::{ClusterInfo, Node};
-use solana_core::gossip_service::GossipService;
-
-use solana_core::packet::Packet;
-use solana_sdk::signature::{Keypair, KeypairUtil};
-use solana_sdk::timing::timestamp;
-use std::net::UdpSocket;
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, RwLock};
-use std::thread::sleep;
-use std::time::Duration;
+use solana_core::{
+    cluster_info::{ClusterInfo, Node},
+    gossip_service::GossipService,
+    packet::Packet,
+};
+use solana_sdk::{
+    signature::{Keypair, KeypairCreate, KeypairUtil},
+    timing::timestamp,
+};
+use std::{
+    net::UdpSocket,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc, RwLock,
+    },
+    thread::sleep,
+    time::Duration,
+};
 
 fn test_node(exit: &Arc<AtomicBool>) -> (Arc<RwLock<ClusterInfo>>, GossipService, UdpSocket) {
     let keypair = Arc::new(Keypair::new());

--- a/core/tests/storage_stage.rs
+++ b/core/tests/storage_stage.rs
@@ -3,28 +3,34 @@
 #[cfg(test)]
 mod tests {
     use log::*;
-    use solana_core::genesis_utils::{create_genesis_config, GenesisConfigInfo};
-    use solana_core::storage_stage::{test_cluster_info, SLOTS_PER_TURN_TEST};
-    use solana_core::storage_stage::{StorageStage, StorageState};
-    use solana_ledger::bank_forks::BankForks;
-    use solana_ledger::blockstore_processor;
-    use solana_ledger::entry;
-    use solana_ledger::{blockstore::Blockstore, create_new_tmp_ledger};
+    use solana_core::{
+        genesis_utils::{create_genesis_config, GenesisConfigInfo},
+        storage_stage::{test_cluster_info, StorageStage, StorageState, SLOTS_PER_TURN_TEST},
+    };
+    use solana_ledger::{
+        bank_forks::BankForks, blockstore::Blockstore, blockstore_processor, create_new_tmp_ledger,
+        entry,
+    };
     use solana_runtime::bank::Bank;
-    use solana_sdk::clock::DEFAULT_TICKS_PER_SLOT;
-    use solana_sdk::hash::Hash;
-    use solana_sdk::message::Message;
-    use solana_sdk::pubkey::Pubkey;
-    use solana_sdk::signature::{Keypair, KeypairUtil};
-    use solana_sdk::transaction::Transaction;
-    use solana_storage_program::storage_instruction;
-    use solana_storage_program::storage_instruction::StorageAccountType;
-    use std::fs::remove_dir_all;
-    use std::sync::atomic::{AtomicBool, Ordering};
-    use std::sync::mpsc::channel;
-    use std::sync::{Arc, RwLock};
-    use std::thread::sleep;
-    use std::time::Duration;
+    use solana_sdk::{
+        clock::DEFAULT_TICKS_PER_SLOT,
+        hash::Hash,
+        message::Message,
+        pubkey::Pubkey,
+        signature::{Keypair, KeypairCreate, KeypairUtil},
+        transaction::Transaction,
+    };
+    use solana_storage_program::storage_instruction::{self, StorageAccountType};
+    use std::{
+        fs::remove_dir_all,
+        sync::{
+            atomic::{AtomicBool, Ordering},
+            mpsc::channel,
+            Arc, RwLock,
+        },
+        thread::sleep,
+        time::Duration,
+    };
 
     #[test]
     fn test_storage_stage_process_account_proofs() {

--- a/faucet/src/faucet.rs
+++ b/faucet/src/faucet.rs
@@ -307,7 +307,7 @@ pub fn run_faucet(
 mod tests {
     use super::*;
     use bytes::BufMut;
-    use solana_sdk::system_instruction::SystemInstruction;
+    use solana_sdk::{signature::KeypairCreate, system_instruction::SystemInstruction};
     use std::time::Duration;
 
     #[test]

--- a/faucet/src/faucet_mock.rs
+++ b/faucet/src/faucet_mock.rs
@@ -1,7 +1,7 @@
 use solana_sdk::{
     hash::Hash,
     pubkey::Pubkey,
-    signature::{Keypair, KeypairUtil},
+    signature::{Keypair, KeypairCreate},
     system_transaction,
     transaction::Transaction,
 };

--- a/faucet/tests/local-faucet.rs
+++ b/faucet/tests/local-faucet.rs
@@ -3,7 +3,7 @@ use solana_sdk::{
     hash::Hash,
     message::Message,
     pubkey::Pubkey,
-    signature::{Keypair, KeypairUtil},
+    signature::{Keypair, KeypairCreate, KeypairUtil},
     system_instruction,
     transaction::Transaction,
 };

--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -560,12 +560,8 @@ fn main() -> Result<(), Box<dyn error::Error>> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use solana_sdk::genesis_config::GenesisConfig;
-    use solana_sdk::pubkey::Pubkey;
-    use std::collections::HashMap;
-    use std::fs::remove_file;
-    use std::io::Write;
-    use std::path::Path;
+    use solana_sdk::{genesis_config::GenesisConfig, pubkey::Pubkey, signature::KeypairCreate};
+    use std::{collections::HashMap, fs::remove_file, io::Write, path::Path};
     use tempfile;
 
     #[test]

--- a/keygen/src/keygen.rs
+++ b/keygen/src/keygen.rs
@@ -21,7 +21,7 @@ use solana_sdk::{
     pubkey::{write_pubkey_file, Pubkey},
     signature::{
         keypair_from_seed, read_keypair, read_keypair_file, write_keypair, write_keypair_file,
-        Keypair, KeypairUtil, Signature,
+        Keypair, KeypairCreate, KeypairUtil, Signature,
     },
 };
 use std::{

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -35,7 +35,7 @@ use solana_sdk::{
     hash::Hash,
     program_utils::limited_deserialize,
     pubkey::Pubkey,
-    signature::{Keypair, KeypairUtil, Signature},
+    signature::{Keypair, KeypairCreate, KeypairUtil, Signature},
     timing::timestamp,
     transaction::Transaction,
 };

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -23,7 +23,7 @@ use solana_sdk::{
     clock::{Slot, MAX_RECENT_BLOCKHASHES},
     genesis_config::GenesisConfig,
     hash::Hash,
-    signature::{Keypair, KeypairUtil},
+    signature::{Keypair, KeypairCreate},
     timing::duration_as_ms,
     transaction::{Result, Transaction, TransactionError},
 };

--- a/ledger/src/entry.rs
+++ b/ledger/src/entry.rs
@@ -4,25 +4,24 @@
 //! represents an approximate amount of time since the last Entry was created.
 use crate::poh::Poh;
 use log::*;
-use rayon::prelude::*;
-use rayon::ThreadPool;
+use rayon::{prelude::*, ThreadPool};
 use serde::{Deserialize, Serialize};
 use solana_measure::measure::Measure;
 use solana_merkle_tree::MerkleTree;
 use solana_metrics::*;
-use solana_perf::cuda_runtime::PinnedVec;
-use solana_perf::perf_libs;
-use solana_perf::recycler::Recycler;
+use solana_perf::{cuda_runtime::PinnedVec, perf_libs, recycler::Recycler};
 use solana_rayon_threadlimit::get_thread_count;
-use solana_sdk::hash::Hash;
-use solana_sdk::timing;
-use solana_sdk::transaction::Transaction;
-use std::cell::RefCell;
-use std::sync::mpsc::{Receiver, Sender};
-use std::sync::{Arc, Mutex};
-use std::thread::JoinHandle;
-use std::time::Instant;
-use std::{cmp, thread};
+use solana_sdk::{hash::Hash, timing, transaction::Transaction};
+use std::{
+    cell::RefCell,
+    cmp,
+    sync::{
+        mpsc::{Receiver, Sender},
+        Arc, Mutex,
+    },
+    thread::{self, JoinHandle},
+    time::Instant,
+};
 
 thread_local!(static PAR_THREAD_POOL: RefCell<ThreadPool> = RefCell::new(rayon::ThreadPoolBuilder::new()
                     .num_threads(get_thread_count())
@@ -457,7 +456,7 @@ mod tests {
     use solana_sdk::{
         hash::{hash, Hash},
         message::Message,
-        signature::{Keypair, KeypairUtil},
+        signature::{Keypair, KeypairCreate, KeypairUtil},
         system_transaction,
         transaction::Transaction,
     };

--- a/ledger/src/leader_schedule_cache.rs
+++ b/ledger/src/leader_schedule_cache.rs
@@ -265,7 +265,7 @@ mod tests {
         EpochSchedule, DEFAULT_LEADER_SCHEDULE_SLOT_OFFSET, DEFAULT_SLOTS_PER_EPOCH,
         MINIMUM_SLOTS_PER_EPOCH,
     };
-    use solana_sdk::signature::{Keypair, KeypairUtil};
+    use solana_sdk::signature::{Keypair, KeypairCreate};
     use std::{sync::mpsc::channel, sync::Arc, thread::Builder};
 
     #[test]

--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -919,8 +919,7 @@ pub mod tests {
     use super::*;
     use bincode::serialized_size;
     use matches::assert_matches;
-    use solana_sdk::hash::hash;
-    use solana_sdk::system_transaction;
+    use solana_sdk::{hash::hash, signature::KeypairCreate, system_transaction};
     use std::collections::HashSet;
     use std::convert::TryInto;
 

--- a/ledger/src/sigverify_shreds.rs
+++ b/ledger/src/sigverify_shreds.rs
@@ -445,9 +445,8 @@ pub fn sign_shreds_gpu(
 #[cfg(test)]
 pub mod tests {
     use super::*;
-    use crate::shred::SIZE_OF_DATA_SHRED_PAYLOAD;
-    use crate::shred::{Shred, Shredder};
-    use solana_sdk::signature::{Keypair, KeypairUtil};
+    use crate::shred::{Shred, Shredder, SIZE_OF_DATA_SHRED_PAYLOAD};
+    use solana_sdk::signature::{Keypair, KeypairCreate, KeypairUtil};
     #[test]
     fn test_sigverify_shred_cpu() {
         solana_logger::setup();

--- a/ledger/src/staking_utils.rs
+++ b/ledger/src/staking_utils.rs
@@ -107,7 +107,7 @@ pub(crate) mod tests {
         clock::Clock,
         instruction::Instruction,
         pubkey::Pubkey,
-        signature::{Keypair, KeypairUtil},
+        signature::{Keypair, KeypairCreate, KeypairUtil},
         sysvar::{
             stake_history::{self, StakeHistory},
             Sysvar,

--- a/ledger/tests/shred.rs
+++ b/ledger/tests/shred.rs
@@ -2,7 +2,7 @@ use solana_ledger::entry::Entry;
 use solana_ledger::shred::{
     max_entries_per_n_shred, verify_test_data_shred, Shred, Shredder, MAX_DATA_SHREDS_PER_FEC_BLOCK,
 };
-use solana_sdk::signature::{Keypair, KeypairUtil};
+use solana_sdk::signature::{Keypair, KeypairCreate, KeypairUtil};
 use solana_sdk::{hash::Hash, system_transaction};
 use std::convert::TryInto;
 use std::sync::Arc;

--- a/local-cluster/src/cluster_tests.rs
+++ b/local-cluster/src/cluster_tests.rs
@@ -24,7 +24,7 @@ use solana_sdk::{
     hash::Hash,
     poh_config::PohConfig,
     pubkey::Pubkey,
-    signature::{Keypair, KeypairUtil, Signature},
+    signature::{Keypair, KeypairCreate, KeypairUtil, Signature},
     system_transaction,
     timing::duration_as_ms,
     transport::TransportError,

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -20,7 +20,7 @@ use solana_sdk::{
     message::Message,
     poh_config::PohConfig,
     pubkey::Pubkey,
-    signature::{Keypair, KeypairUtil},
+    signature::{Keypair, KeypairCreate, KeypairUtil},
     system_transaction,
     transaction::Transaction,
 };

--- a/local-cluster/tests/archiver.rs
+++ b/local-cluster/tests/archiver.rs
@@ -15,7 +15,7 @@ use solana_local_cluster::local_cluster::{ClusterConfig, LocalCluster};
 use solana_sdk::{
     commitment_config::CommitmentConfig,
     genesis_config::create_genesis_config,
-    signature::{Keypair, KeypairUtil},
+    signature::{Keypair, KeypairCreate, KeypairUtil},
 };
 use std::{
     fs::remove_dir_all,

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -23,7 +23,7 @@ use solana_sdk::{
     epoch_schedule::{EpochSchedule, MINIMUM_SLOTS_PER_EPOCH},
     genesis_config::OperatingMode,
     poh_config::PohConfig,
-    signature::{Keypair, KeypairUtil},
+    signature::{Keypair, KeypairCreate, KeypairUtil},
 };
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::{

--- a/perf/src/packet.rs
+++ b/perf/src/packet.rs
@@ -105,7 +105,7 @@ where
 mod tests {
     use super::*;
     use solana_sdk::hash::Hash;
-    use solana_sdk::signature::{Keypair, KeypairUtil};
+    use solana_sdk::signature::{Keypair, KeypairCreate, KeypairUtil};
     use solana_sdk::system_transaction;
 
     #[test]

--- a/perf/src/test_tx.rs
+++ b/perf/src/test_tx.rs
@@ -1,6 +1,6 @@
 use solana_sdk::hash::Hash;
 use solana_sdk::instruction::CompiledInstruction;
-use solana_sdk::signature::{Keypair, KeypairUtil};
+use solana_sdk::signature::{Keypair, KeypairCreate, KeypairUtil};
 use solana_sdk::system_instruction::SystemInstruction;
 use solana_sdk::system_program;
 use solana_sdk::system_transaction;

--- a/programs/budget/src/budget_processor.rs
+++ b/programs/budget/src/budget_processor.rs
@@ -222,18 +222,18 @@ pub fn process_instruction(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::budget_instruction;
-    use crate::id;
-    use solana_runtime::bank::Bank;
-    use solana_runtime::bank_client::BankClient;
-    use solana_sdk::account::Account;
-    use solana_sdk::client::SyncClient;
-    use solana_sdk::genesis_config::create_genesis_config;
-    use solana_sdk::hash::hash;
-    use solana_sdk::instruction::InstructionError;
-    use solana_sdk::message::Message;
-    use solana_sdk::signature::{Keypair, KeypairUtil};
-    use solana_sdk::transaction::TransactionError;
+    use crate::{budget_instruction, id};
+    use solana_runtime::{bank::Bank, bank_client::BankClient};
+    use solana_sdk::{
+        account::Account,
+        client::SyncClient,
+        genesis_config::create_genesis_config,
+        hash::hash,
+        instruction::InstructionError,
+        message::Message,
+        signature::{Keypair, KeypairCreate, KeypairUtil},
+        transaction::TransactionError,
+    };
 
     fn create_bank(lamports: u64) -> (Bank, Keypair) {
         let (genesis_config, mint_keypair) = create_genesis_config(lamports);

--- a/programs/config/src/config_processor.rs
+++ b/programs/config/src/config_processor.rs
@@ -108,7 +108,7 @@ mod tests {
     use serde_derive::{Deserialize, Serialize};
     use solana_sdk::{
         account::{create_keyed_is_signer_accounts, Account},
-        signature::{Keypair, KeypairUtil},
+        signature::{Keypair, KeypairCreate, KeypairUtil},
         system_instruction::SystemInstruction,
     };
     use std::cell::RefCell;

--- a/programs/exchange/src/exchange_processor.rs
+++ b/programs/exchange/src/exchange_processor.rs
@@ -464,13 +464,14 @@ pub fn process_instruction(
 mod test {
     use super::*;
     use crate::{exchange_instruction, id};
-    use solana_runtime::bank::Bank;
-    use solana_runtime::bank_client::BankClient;
-    use solana_sdk::client::SyncClient;
-    use solana_sdk::genesis_config::create_genesis_config;
-    use solana_sdk::message::Message;
-    use solana_sdk::signature::{Keypair, KeypairUtil};
-    use solana_sdk::system_instruction;
+    use solana_runtime::{bank::Bank, bank_client::BankClient};
+    use solana_sdk::{
+        client::SyncClient,
+        genesis_config::create_genesis_config,
+        message::Message,
+        signature::{Keypair, KeypairCreate, KeypairUtil},
+        system_instruction,
+    };
     use std::mem;
 
     fn try_calc(

--- a/programs/ownable/src/ownable_processor.rs
+++ b/programs/ownable/src/ownable_processor.rs
@@ -63,7 +63,7 @@ mod tests {
         client::SyncClient,
         genesis_config::create_genesis_config,
         message::Message,
-        signature::{Keypair, KeypairUtil, Signature},
+        signature::{Keypair, KeypairCreate, KeypairUtil, Signature},
         system_program,
         transport::Result,
     };

--- a/programs/vest/src/vest_processor.rs
+++ b/programs/vest/src/vest_processor.rs
@@ -144,18 +144,18 @@ pub fn process_instruction(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::id;
-    use crate::vest_instruction;
+    use crate::{id, vest_instruction};
     use solana_config_program::date_instruction;
-    use solana_runtime::bank::Bank;
-    use solana_runtime::bank_client::BankClient;
-    use solana_sdk::client::SyncClient;
-    use solana_sdk::genesis_config::create_genesis_config;
-    use solana_sdk::hash::hash;
-    use solana_sdk::message::Message;
-    use solana_sdk::signature::{Keypair, KeypairUtil, Signature};
-    use solana_sdk::transaction::TransactionError;
-    use solana_sdk::transport::Result;
+    use solana_runtime::{bank::Bank, bank_client::BankClient};
+    use solana_sdk::{
+        client::SyncClient,
+        genesis_config::create_genesis_config,
+        hash::hash,
+        message::Message,
+        signature::{Keypair, KeypairCreate, KeypairUtil, Signature},
+        transaction::TransactionError,
+        transport::Result,
+    };
     use std::sync::Arc;
 
     fn create_bank(lamports: u64) -> (Bank, Keypair) {

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -21,8 +21,7 @@ use solana_sdk::{
     native_loader,
     nonce_state::NonceState,
     pubkey::Pubkey,
-    transaction::Result,
-    transaction::{Transaction, TransactionError},
+    transaction::{Result, Transaction, TransactionError},
 };
 use std::{
     collections::{HashMap, HashSet},
@@ -678,7 +677,7 @@ mod tests {
         message::Message,
         nonce_state,
         rent::Rent,
-        signature::{Keypair, KeypairUtil},
+        signature::{Keypair, KeypairCreate, KeypairUtil},
         system_program,
         transaction::Transaction,
     };

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -48,8 +48,10 @@ use std::{
     fmt,
     io::{BufReader, Cursor, Error as IOError, ErrorKind, Read, Result as IOResult},
     path::{Path, PathBuf},
-    sync::atomic::{AtomicUsize, Ordering},
-    sync::{Arc, RwLock},
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc, RwLock,
+    },
 };
 use tempfile::TempDir;
 
@@ -1330,7 +1332,11 @@ pub mod tests {
     use assert_matches::assert_matches;
     use bincode::serialize_into;
     use rand::{thread_rng, Rng};
-    use solana_sdk::{account::Account, hash::HASH_BYTES};
+    use solana_sdk::{
+        account::Account,
+        hash::HASH_BYTES,
+        signature::{Keypair, KeypairCreate, KeypairUtil},
+    };
     use std::{fs, str::FromStr};
     use tempfile::TempDir;
 
@@ -2396,7 +2402,6 @@ pub mod tests {
 
     #[test]
     fn test_bad_bank_hash() {
-        use solana_sdk::signature::{Keypair, KeypairUtil};
         let db = AccountsDB::new(Vec::new());
 
         let some_slot: Slot = 0;

--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -178,7 +178,7 @@ impl<T: Clone> AccountsIndex<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use solana_sdk::signature::{Keypair, KeypairUtil};
+    use solana_sdk::signature::{Keypair, KeypairCreate, KeypairUtil};
 
     #[test]
     fn test_get_empty() {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2110,7 +2110,7 @@ mod tests {
         nonce_state,
         poh_config::PohConfig,
         rent::Rent,
-        signature::{Keypair, KeypairUtil},
+        signature::{Keypair, KeypairCreate, KeypairUtil},
         system_instruction,
         system_program::{self, solana_system_program},
         sysvar::{fees::Fees, rewards::Rewards},

--- a/runtime/src/bank_client.rs
+++ b/runtime/src/bank_client.rs
@@ -274,7 +274,9 @@ impl BankClient {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use solana_sdk::{genesis_config::create_genesis_config, instruction::AccountMeta};
+    use solana_sdk::{
+        genesis_config::create_genesis_config, instruction::AccountMeta, signature::KeypairCreate,
+    };
 
     #[test]
     fn test_bank_client_new_with_keypairs() {

--- a/runtime/src/genesis_utils.rs
+++ b/runtime/src/genesis_utils.rs
@@ -4,7 +4,7 @@ use solana_sdk::{
     genesis_config::GenesisConfig,
     pubkey::Pubkey,
     rent::Rent,
-    signature::{Keypair, KeypairUtil},
+    signature::{Keypair, KeypairCreate, KeypairUtil},
     system_program::{self, solana_system_program},
 };
 use solana_stake_program::stake_state;

--- a/runtime/src/loader_utils.rs
+++ b/runtime/src/loader_utils.rs
@@ -5,7 +5,7 @@ use solana_sdk::{
     loader_instruction,
     message::Message,
     pubkey::Pubkey,
-    signature::{Keypair, KeypairUtil},
+    signature::{Keypair, KeypairCreate, KeypairUtil},
     system_instruction,
 };
 

--- a/runtime/src/nonce_utils.rs
+++ b/runtime/src/nonce_utils.rs
@@ -79,7 +79,7 @@ mod tests {
         instruction::InstructionError,
         nonce_state::{with_test_keyed_account, Meta, NonceAccount},
         pubkey::Pubkey,
-        signature::{Keypair, KeypairUtil},
+        signature::{Keypair, KeypairCreate, KeypairUtil},
         system_instruction,
         sysvar::{recent_blockhashes::create_test_recent_blockhashes, rent::Rent},
     };

--- a/runtime/src/storage_utils.rs
+++ b/runtime/src/storage_utils.rs
@@ -84,7 +84,7 @@ pub(crate) mod tests {
         client::SyncClient,
         genesis_config::create_genesis_config,
         message::Message,
-        signature::{Keypair, KeypairUtil},
+        signature::{Keypair, KeypairCreate, KeypairUtil},
     };
     use solana_storage_program::{
         storage_contract::{StorageAccount, STORAGE_ACCOUNT_SPACE},

--- a/runtime/src/system_instruction_processor.rs
+++ b/runtime/src/system_instruction_processor.rs
@@ -329,7 +329,7 @@ mod tests {
         instruction::{AccountMeta, Instruction, InstructionError},
         message::Message,
         nonce_state,
-        signature::{Keypair, KeypairUtil},
+        signature::{Keypair, KeypairCreate, KeypairUtil},
         system_instruction, system_program, sysvar,
         transaction::TransactionError,
     };

--- a/runtime/src/transaction_batch.rs
+++ b/runtime/src/transaction_batch.rs
@@ -59,7 +59,7 @@ mod tests {
     use crate::genesis_utils::{create_genesis_config_with_leader, GenesisConfigInfo};
     use solana_sdk::{
         pubkey::Pubkey,
-        signature::{Keypair, KeypairUtil},
+        signature::{Keypair, KeypairCreate},
         system_transaction,
     };
 

--- a/runtime/tests/stake.rs
+++ b/runtime/tests/stake.rs
@@ -8,7 +8,7 @@ use solana_sdk::{
     client::SyncClient,
     message::Message,
     pubkey::Pubkey,
-    signature::{Keypair, KeypairUtil},
+    signature::{Keypair, KeypairCreate, KeypairUtil},
     system_instruction::create_address_with_seed,
     sysvar::{self, stake_history::StakeHistory, Sysvar},
 };

--- a/runtime/tests/storage.rs
+++ b/runtime/tests/storage.rs
@@ -13,7 +13,7 @@ use solana_sdk::{
     hash::{hash, Hash},
     message::Message,
     pubkey::Pubkey,
-    signature::{Keypair, KeypairUtil, Signature},
+    signature::{Keypair, KeypairCreate, KeypairUtil, Signature},
     system_instruction,
     sysvar::{
         rewards::{self, Rewards},

--- a/sdk-c/src/lib.rs
+++ b/sdk-c/src/lib.rs
@@ -8,7 +8,9 @@ use solana_sdk::{
     instruction::CompiledInstruction as CompiledInstructionNative,
     message::{Message as MessageNative, MessageHeader as MessageHeaderNative},
     pubkey::Pubkey,
-    signature::{Keypair as KeypairNative, KeypairUtil, Signature as SignatureNative},
+    signature::{
+        Keypair as KeypairNative, KeypairCreate, KeypairUtil, Signature as SignatureNative,
+    },
     transaction::Transaction as TransactionNative,
 };
 use std::{

--- a/sdk/src/genesis_config.rs
+++ b/sdk/src/genesis_config.rs
@@ -10,7 +10,7 @@ use crate::{
     poh_config::PohConfig,
     pubkey::Pubkey,
     rent::Rent,
-    signature::{Keypair, KeypairUtil},
+    signature::{Keypair, KeypairCreate, KeypairUtil},
     system_program::{self, solana_system_program},
 };
 use bincode::{deserialize, serialize};

--- a/sdk/src/message.rs
+++ b/sdk/src/message.rs
@@ -249,7 +249,7 @@ mod tests {
     use super::*;
     use crate::{
         instruction::AccountMeta,
-        signature::{Keypair, KeypairUtil},
+        signature::{Keypair, KeypairCreate, KeypairUtil},
     };
 
     #[test]

--- a/sdk/src/signature.rs
+++ b/sdk/src/signature.rs
@@ -102,19 +102,25 @@ impl FromStr for Signature {
     }
 }
 
-pub trait KeypairUtil {
+pub trait KeypairCreate {
     fn new() -> Self;
-    fn pubkey(&self) -> Pubkey;
-    fn sign_message(&self, message: &[u8]) -> Signature;
 }
 
-impl KeypairUtil for Keypair {
+impl KeypairCreate for Keypair {
     /// Return a new ED25519 keypair
     fn new() -> Self {
         let mut rng = OsRng::new().unwrap();
         Keypair::generate(&mut rng)
     }
+}
 
+pub trait KeypairUtil {
+    fn pubkey(&self) -> Pubkey;
+    fn sign_message(&self, message: &[u8]) -> Signature;
+    fn try_sign_message(&self, message: &[u8]) -> Result<Signature, Box<dyn error::Error>>;
+}
+
+impl KeypairUtil for Keypair {
     /// Return the public key for the given keypair
     fn pubkey(&self) -> Pubkey {
         Pubkey::new(self.public.as_ref())
@@ -122,6 +128,10 @@ impl KeypairUtil for Keypair {
 
     fn sign_message(&self, message: &[u8]) -> Signature {
         Signature::new(&self.sign(message).to_bytes())
+    }
+
+    fn try_sign_message(&self, message: &[u8]) -> Result<Signature, Box<dyn error::Error>> {
+        Ok(self.sign_message(message))
     }
 }
 

--- a/sdk/src/transaction.rs
+++ b/sdk/src/transaction.rs
@@ -339,7 +339,12 @@ impl Transaction {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{hash::hash, instruction::AccountMeta, signature::Keypair, system_instruction};
+    use crate::{
+        hash::hash,
+        instruction::AccountMeta,
+        signature::{Keypair, KeypairCreate},
+        system_instruction,
+    };
     use bincode::{deserialize, serialize, serialized_size};
     use std::mem::size_of;
 

--- a/vote-signer/src/rpc.rs
+++ b/vote-signer/src/rpc.rs
@@ -4,7 +4,7 @@ use jsonrpc_core::{Error, MetaIoHandler, Metadata, Result};
 use jsonrpc_derive::rpc;
 use jsonrpc_http_server::{hyper, AccessControlAllowOrigin, DomainsValidation, ServerBuilder};
 use solana_sdk::pubkey::Pubkey;
-use solana_sdk::signature::{Keypair, KeypairUtil, Signature};
+use solana_sdk::signature::{Keypair, KeypairCreate, KeypairUtil, Signature};
 use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::sync::atomic::{AtomicBool, Ordering};


### PR DESCRIPTION
#### Problem
We want to sign transactions with multiple and different implementations of `KeypairUtil`. To do that, we want to add a new `sign()` method that accepts a list of `KeypairUtil` trait objects. We can't do that, because `KeypairUtil` has a method that returns `Self`.

#### Summary of Changes
This is an alternative approach to #8242 

It moves `KeypairUtil::new()` to a new trait: `KeypairCreate::new()`
(I also cleaned up a bunch of `use` blocks that I was touching anyway, so the churn is bloated.)
