### PR TITLE
Wrap ed25519_dalek::Keypair

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -407,7 +407,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "cbindgen"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4414,7 +4414,7 @@ version = "0.24.0"
 dependencies = [
  "bincode 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bs58 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "cbindgen 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cbindgen 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ed25519-dalek 1.0.0-pre.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6056,7 +6056,7 @@ dependencies = [
 "checksum c2-chacha 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7d64d04786e0f528460fc884753cf8dddcc466be308f6026f8e355c41a0e4101"
 "checksum c_linked_list 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4964518bd3b4a8190e832886cdc0da9794f12e8e6c1613a9e90ff331c4c8724b"
 "checksum cast 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "926013f2860c46252efceabb19f4a6b308197505082c609025aa6706c011d427"
-"checksum cbindgen 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e21019c4afc1dd5f5ab3ce212d8ccb953f43520db79e0bb6438f3e26cc57dccf"
+"checksum cbindgen 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2c955bd5e66e36a03612c877585d75219da64e3d9ae5f14d76c979ccb95de070"
 "checksum cc 1.0.49 (registry+https://github.com/rust-lang/crates.io-index)" = "e450b8da92aa6f274e7c6437692f9f2ce6d701fb73bacfcf87897b3f89a4c20e"
 "checksum cexpr 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "a7fa24eb00d5ffab90eaeaf1092ac85c04c64aaf358ea6f84505b8116d24c6af"
 "checksum cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "b486ce3ccf7ffd79fdeb678eac06a9e6c09fc88d33836340becb8fffe87c5e33"

--- a/bench-exchange/src/cli.rs
+++ b/bench-exchange/src/cli.rs
@@ -1,7 +1,7 @@
 use clap::{crate_description, crate_name, value_t, App, Arg, ArgMatches};
 use solana_core::gen_keys::GenKeys;
 use solana_faucet::faucet::FAUCET_PORT;
-use solana_sdk::signature::{read_keypair_file, Keypair, KeypairUtil};
+use solana_sdk::signature::{read_keypair_file, Keypair};
 use std::net::SocketAddr;
 use std::process::exit;
 use std::time::Duration;

--- a/bench-tps/src/cli.rs
+++ b/bench-tps/src/cli.rs
@@ -1,7 +1,7 @@
 use clap::{crate_description, crate_name, App, Arg, ArgMatches};
 use solana_faucet::faucet::FAUCET_PORT;
 use solana_sdk::fee_calculator::FeeCalculator;
-use solana_sdk::signature::{read_keypair_file, Keypair, KeypairUtil};
+use solana_sdk::signature::{read_keypair_file, Keypair};
 use std::{net::SocketAddr, process::exit, time::Duration};
 
 const NUM_LAMPORTS_PER_ACCOUNT_DEFAULT: u64 = solana_sdk::native_token::LAMPORTS_PER_SOL;

--- a/chacha-cuda/src/chacha_cuda.rs
+++ b/chacha-cuda/src/chacha_cuda.rs
@@ -118,7 +118,7 @@ mod tests {
     use solana_ledger::entry::create_ticks;
     use solana_ledger::get_tmp_ledger_path;
     use solana_sdk::clock::DEFAULT_SLOTS_PER_SEGMENT;
-    use solana_sdk::signature::{Keypair, KeypairUtil};
+    use solana_sdk::signature::Keypair;
     use std::fs::{remove_dir_all, remove_file};
     use std::path::Path;
 

--- a/clap-utils/src/keypair.rs
+++ b/clap-utils/src/keypair.rs
@@ -2,12 +2,9 @@ use crate::ArgConstant;
 use bip39::{Language, Mnemonic, Seed};
 use clap::values_t;
 use rpassword::prompt_password_stderr;
-use solana_sdk::{
-    pubkey::Pubkey,
-    signature::{
-        keypair_from_seed, keypair_from_seed_phrase_and_passphrase, read_keypair_file, Keypair,
-        KeypairUtil,
-    },
+use solana_sdk::signature::{
+    keypair_from_seed, keypair_from_seed_phrase_and_passphrase, read_keypair_file, Keypair,
+    KeypairUtil,
 };
 use std::{
     error,
@@ -87,7 +84,7 @@ pub fn keypair_from_seed_phrase(
     };
 
     if confirm_pubkey {
-        let pubkey = Pubkey::new(keypair.public.as_ref());
+        let pubkey = keypair.pubkey();
         print!("Recovered pubkey `{:?}`. Continue? (y/n): ", pubkey);
         let _ignored = stdout().flush();
         let mut input = String::new();

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -1912,10 +1912,6 @@ impl FaucetKeypair {
 }
 
 impl KeypairUtil for FaucetKeypair {
-    fn new() -> Self {
-        unimplemented!();
-    }
-
     /// Return the public key of the keypair used to sign votes
     fn pubkey(&self) -> Pubkey {
         self.transaction.message().account_keys[0]

--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -1129,9 +1129,7 @@ mod tests {
     use serde_json::Number;
     use solana_logger;
     use solana_sdk::{
-        instruction::InstructionError,
-        signature::{Keypair, KeypairUtil},
-        system_transaction,
+        instruction::InstructionError, signature::Keypair, system_transaction,
         transaction::TransactionError,
     };
     use std::{sync::mpsc::channel, thread};

--- a/core/src/cluster_info.rs
+++ b/core/src/cluster_info.rs
@@ -39,7 +39,7 @@ use solana_perf::packet::{to_packets_with_destination, Packets, PacketsRecycler}
 use solana_sdk::{
     clock::{Slot, DEFAULT_MS_PER_SLOT},
     pubkey::Pubkey,
-    signature::{Keypair, KeypairUtil, Signable, Signature},
+    signature::{Keypair, Signable, Signature},
     timing::{duration_as_ms, timestamp},
     transaction::Transaction,
 };

--- a/core/src/storage_stage.rs
+++ b/core/src/storage_stage.rs
@@ -376,7 +376,7 @@ impl StorageStage {
         total_proofs: usize,
     ) -> Result<()> {
         let mut seed = [0u8; 32];
-        let signature = storage_keypair.sign(&blockhash.as_ref());
+        let signature = storage_keypair.sign_message(&blockhash.as_ref());
 
         let ix = storage_instruction::advertise_recent_blockhash(
             &storage_keypair.pubkey(),
@@ -385,7 +385,7 @@ impl StorageStage {
         );
         instruction_sender.send(ix)?;
 
-        seed.copy_from_slice(&signature.to_bytes()[..32]);
+        seed.copy_from_slice(&signature.as_ref()[..32]);
 
         let mut rng = ChaChaRng::from_seed(seed);
 
@@ -406,7 +406,7 @@ impl StorageStage {
             return Ok(());
         }
         // TODO: what if the validator does not have this segment
-        let segment = signature.to_bytes()[0] as usize % num_segments;
+        let segment = signature.as_ref()[0] as usize % num_segments;
 
         debug!(
             "storage verifying: segment: {} identities: {}",

--- a/faucet/src/faucet_mock.rs
+++ b/faucet/src/faucet_mock.rs
@@ -1,9 +1,5 @@
 use solana_sdk::{
-    hash::Hash,
-    pubkey::Pubkey,
-    signature::{Keypair, KeypairUtil},
-    system_transaction,
-    transaction::Transaction,
+    hash::Hash, pubkey::Pubkey, signature::Keypair, system_transaction, transaction::Transaction,
 };
 use std::{
     io::{Error, ErrorKind},

--- a/keygen/src/keygen.rs
+++ b/keygen/src/keygen.rs
@@ -21,7 +21,7 @@ use solana_sdk::{
     pubkey::{write_pubkey_file, Pubkey},
     signature::{
         keypair_from_seed, read_keypair, read_keypair_file, write_keypair, write_keypair_file,
-        Keypair, KeypairUtil, Signature,
+        Keypair, KeypairUtil,
     },
 };
 use std::{
@@ -613,7 +613,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
         ("verify", Some(matches)) => {
             let keypair = get_keypair_from_matches(matches, config)?;
             let test_data = b"test";
-            let signature = Signature::new(&keypair.sign(test_data).to_bytes());
+            let signature = keypair.sign_message(test_data);
             let pubkey_bs58 = matches.value_of("pubkey").unwrap();
             let pubkey = bs58::decode(pubkey_bs58).into_vec().unwrap();
             if signature.verify(&pubkey, test_data) {

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -23,7 +23,7 @@ use solana_sdk::{
     clock::{Slot, MAX_RECENT_BLOCKHASHES},
     genesis_config::GenesisConfig,
     hash::Hash,
-    signature::{Keypair, KeypairUtil},
+    signature::Keypair,
     timing::duration_as_ms,
     transaction::{Result, Transaction, TransactionError},
 };

--- a/ledger/src/leader_schedule_cache.rs
+++ b/ledger/src/leader_schedule_cache.rs
@@ -265,7 +265,7 @@ mod tests {
         EpochSchedule, DEFAULT_LEADER_SCHEDULE_SLOT_OFFSET, DEFAULT_SLOTS_PER_EPOCH,
         MINIMUM_SLOTS_PER_EPOCH,
     };
-    use solana_sdk::signature::{Keypair, KeypairUtil};
+    use solana_sdk::signature::Keypair;
     use std::{sync::mpsc::channel, sync::Arc, thread::Builder};
 
     #[test]

--- a/ledger/src/sigverify_shreds.rs
+++ b/ledger/src/sigverify_shreds.rs
@@ -301,9 +301,9 @@ fn sign_shred_cpu(keypair: &Keypair, packet: &mut Packet) {
         packet.meta.size >= msg_end,
         "packet is not large enough for a signature"
     );
-    let signature = keypair.sign(&packet.data[msg_start..msg_end]);
+    let signature = keypair.sign_message(&packet.data[msg_start..msg_end]);
     trace!("signature {:?}", signature);
-    packet.data[0..sig_end].copy_from_slice(&signature.to_bytes());
+    packet.data[0..sig_end].copy_from_slice(&signature.as_ref());
 }
 
 pub fn sign_shreds_cpu(keypair: &Keypair, batches: &mut [Packets]) {
@@ -323,7 +323,7 @@ pub fn sign_shreds_cpu(keypair: &Keypair, batches: &mut [Packets]) {
 pub fn sign_shreds_gpu_pinned_keypair(keypair: &Keypair, cache: &RecyclerCache) -> PinnedVec<u8> {
     let mut vec = cache.buffer().allocate("pinned_keypair");
     let pubkey = keypair.pubkey().to_bytes();
-    let secret = keypair.secret.to_bytes();
+    let secret = keypair.secret().to_bytes();
     let mut hasher = Sha512::default();
     hasher.input(&secret);
     let mut result = hasher.result();

--- a/runtime/src/transaction_batch.rs
+++ b/runtime/src/transaction_batch.rs
@@ -57,11 +57,7 @@ impl<'a, 'b> Drop for TransactionBatch<'a, 'b> {
 mod tests {
     use super::*;
     use crate::genesis_utils::{create_genesis_config_with_leader, GenesisConfigInfo};
-    use solana_sdk::{
-        pubkey::Pubkey,
-        signature::{Keypair, KeypairUtil},
-        system_transaction,
-    };
+    use solana_sdk::{pubkey::Pubkey, signature::Keypair, system_transaction};
 
     #[test]
     fn test_transaction_batch() {


### PR DESCRIPTION
#### Problem

We want to sign transactions with multiple and different implementations of KeypairUtil. To do that, we want to add a new sign() method that accepts a list of KeypairUtil trait objects. We can't do that, because KeypairUtil has a method that returns Self.

#### Summary of Changes

* Wrap dalek_ed25519 in a struct, which implements `new()`.
* Remove `new()` from `KeypairUtil`

Competitor to https://github.com/solana-labs/solana/pull/8242