### PR TITLE
Simplify remote wallet

### DIFF
--- a/remote-wallet/src/ledger.rs
+++ b/remote-wallet/src/ledger.rs
@@ -4,7 +4,7 @@ use crate::remote_wallet::{
 use dialoguer::{theme::ColorfulTheme, Select};
 use log::*;
 use semver::Version as FirmwareVersion;
-use solana_sdk::{pubkey::Pubkey, signature::Signature, transaction::Transaction};
+use solana_sdk::{pubkey::Pubkey, signature::Signature};
 use std::{cmp::min, fmt, sync::Arc};
 
 const APDU_TAG: u8 = 0x05;
@@ -38,8 +38,8 @@ const HID_PREFIX_ZERO: usize = 0;
 mod commands {
     #[allow(dead_code)]
     pub const GET_APP_CONFIGURATION: u8 = 0x06;
-    pub const GET_SOL_PUBKEY: u8 = 0x02;
-    pub const SIGN_SOL_TRANSACTION: u8 = 0x03;
+    pub const GET_PUBKEY: u8 = 0x02;
+    pub const SIGN_MESSAGE_DATA: u8 = 0x03;
 }
 
 /// Ledger Wallet device
@@ -233,19 +233,6 @@ impl LedgerWallet {
             ver[3].into(),
         ))
     }
-
-    pub fn sign_raw_data(
-        &self,
-        derivation_path: &DerivationPath,
-        data: &[u8],
-    ) -> Result<Vec<u8>, RemoteWalletError> {
-        let mut payload = extend_and_serialize(&derivation_path);
-        for byte in (data.len() as u16).to_be_bytes().iter() {
-            payload.push(*byte);
-        }
-        payload.extend_from_slice(data);
-        self.send_apdu(0x03, 1, 0, &payload)
-    }
 }
 
 impl RemoteWallet for LedgerWallet {
@@ -282,7 +269,7 @@ impl RemoteWallet for LedgerWallet {
         let derivation_path = extend_and_serialize(derivation_path);
 
         let key = self.send_apdu(
-            commands::GET_SOL_PUBKEY,
+            commands::GET_PUBKEY,
             0, // In the naive implementation, default request is for no device confirmation
             0,
             &derivation_path,
@@ -293,13 +280,12 @@ impl RemoteWallet for LedgerWallet {
         Ok(Pubkey::new(&key))
     }
 
-    fn sign_transaction(
+    fn sign_message_data(
         &self,
         derivation_path: &DerivationPath,
-        transaction: Transaction,
+        data: &[u8],
     ) -> Result<Signature, RemoteWalletError> {
         let mut payload = extend_and_serialize(derivation_path);
-        let mut data = transaction.message_data();
         if data.len() > u16::max_value() as usize {
             return Err(RemoteWalletError::InvalidInput(
                 "Message to sign is too long".to_string(),
@@ -308,11 +294,11 @@ impl RemoteWallet for LedgerWallet {
         for byte in (data.len() as u16).to_be_bytes().iter() {
             payload.push(*byte);
         }
-        payload.append(&mut data);
+        payload.extend_from_slice(data);
         trace!("Serialized payload length {:?}", payload.len());
 
         let result = self.send_apdu(
-            commands::SIGN_SOL_TRANSACTION,
+            commands::SIGN_MESSAGE_DATA,
             1, // In the naive implementation, default request is for requred device confirmation
             0,
             &payload,

--- a/remote-wallet/src/ledger.rs
+++ b/remote-wallet/src/ledger.rs
@@ -39,7 +39,7 @@ mod commands {
     #[allow(dead_code)]
     pub const GET_APP_CONFIGURATION: u8 = 0x06;
     pub const GET_PUBKEY: u8 = 0x02;
-    pub const SIGN_MESSAGE_DATA: u8 = 0x03;
+    pub const SIGN_MESSAGE: u8 = 0x03;
 }
 
 /// Ledger Wallet device
@@ -280,7 +280,7 @@ impl RemoteWallet for LedgerWallet {
         Ok(Pubkey::new(&key))
     }
 
-    fn sign_message_data(
+    fn sign_message(
         &self,
         derivation_path: &DerivationPath,
         data: &[u8],
@@ -298,7 +298,7 @@ impl RemoteWallet for LedgerWallet {
         trace!("Serialized payload length {:?}", payload.len());
 
         let result = self.send_apdu(
-            commands::SIGN_MESSAGE_DATA,
+            commands::SIGN_MESSAGE,
             1, // In the naive implementation, default request is for requred device confirmation
             0,
             &payload,

--- a/remote-wallet/src/remote_wallet.rs
+++ b/remote-wallet/src/remote_wallet.rs
@@ -156,7 +156,7 @@ pub trait RemoteWallet {
     fn get_pubkey(&self, derivation_path: &DerivationPath) -> Result<Pubkey, RemoteWalletError>;
 
     /// Sign transaction data with wallet managing pubkey at derivation path m/44'/501'/<account>'/<change>'.
-    fn sign_message_data(
+    fn sign_message(
         &self,
         derivation_path: &DerivationPath,
         data: &[u8],

--- a/remote-wallet/src/remote_wallet.rs
+++ b/remote-wallet/src/remote_wallet.rs
@@ -1,7 +1,7 @@
 use crate::ledger::{is_valid_ledger, LedgerWallet};
 use log::*;
 use parking_lot::{Mutex, RwLock};
-use solana_sdk::{pubkey::Pubkey, signature::Signature, transaction::Transaction};
+use solana_sdk::{pubkey::Pubkey, signature::Signature};
 use std::{
     fmt,
     str::FromStr,
@@ -156,10 +156,10 @@ pub trait RemoteWallet {
     fn get_pubkey(&self, derivation_path: &DerivationPath) -> Result<Pubkey, RemoteWalletError>;
 
     /// Sign transaction data with wallet managing pubkey at derivation path m/44'/501'/<account>'/<change>'.
-    fn sign_transaction(
+    fn sign_message_data(
         &self,
         derivation_path: &DerivationPath,
-        transaction: Transaction,
+        data: &[u8],
     ) -> Result<Signature, RemoteWalletError>;
 }
 

--- a/sdk/src/message.rs
+++ b/sdk/src/message.rs
@@ -208,6 +208,10 @@ impl Message {
         )
     }
 
+    pub fn serialize(&self) -> Vec<u8> {
+        bincode::serialize(self).unwrap()
+    }
+
     pub fn program_ids(&self) -> Vec<&Pubkey> {
         self.instructions
             .iter()

--- a/sdk/src/transaction.rs
+++ b/sdk/src/transaction.rs
@@ -9,7 +9,6 @@ use crate::{
     signature::{KeypairUtil, Signature},
     system_instruction,
 };
-use bincode::serialize;
 use std::result;
 use thiserror::Error;
 
@@ -211,7 +210,7 @@ impl Transaction {
 
     /// Return the serialized message data to sign.
     pub fn message_data(&self) -> Vec<u8> {
-        serialize(&self.message()).unwrap()
+        self.message().serialize()
     }
 
     /// Check keys and keypair lengths, then sign this transaction.


### PR DESCRIPTION
#### Problem

The remote wallet interface asks for more data than it needs, requiring the client to create transactions when all they need is a message.

#### Summary of Changes

Get much closer to `KeypairUtil::sign_message()`.
