### PR TITLE
Pass derived address base key in keys list instead of instruction data

### DIFF
--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -731,16 +731,6 @@ pub fn process_create_stake_account(
     fee_payer: Option<&SigningAuthority>,
     from: Option<&SigningAuthority>,
 ) -> ProcessResult {
-    // Offline derived address creation currently is not possible
-    // https://github.com/solana-labs/solana/pull/8252
-    if seed.is_some() && (sign_only || signers.is_some()) {
-        return Err(CliError::BadParameter(
-            "Offline stake account creation with derived addresses are not yet supported"
-                .to_string(),
-        )
-        .into());
-    }
-
     let (stake_account_pubkey, stake_account) = (stake_account.pubkey(), stake_account.keypair());
     let stake_account_address = if let Some(seed) = seed {
         create_address_with_seed(&stake_account_pubkey, &seed, &solana_stake_program::id())?

--- a/runtime/src/system_instruction_processor.rs
+++ b/runtime/src/system_instruction_processor.rs
@@ -197,7 +197,6 @@ pub fn process_instruction(
             )
         }
         SystemInstruction::CreateAccountWithSeed {
-            base,
             seed,
             lamports,
             space,
@@ -205,9 +204,9 @@ pub fn process_instruction(
         } => {
             let from = next_keyed_account(keyed_accounts_iter)?;
             let to = next_keyed_account(keyed_accounts_iter)?;
+            let base = next_keyed_account(keyed_accounts_iter)?.unsigned_key();
             let mut to_account = to.try_account_ref_mut()?;
-            let to_address =
-                Address::create(&to.unsigned_key(), Some((&base, &seed, &program_id)))?;
+            let to_address = Address::create(&to.unsigned_key(), Some((base, &seed, &program_id)))?;
             create_account(
                 from,
                 &mut to_account,
@@ -405,10 +404,10 @@ mod tests {
                 &Pubkey::default(),
                 &[
                     KeyedAccount::new(&from, true, &from_account),
-                    KeyedAccount::new(&to, false, &to_account)
+                    KeyedAccount::new(&to, false, &to_account),
+                    KeyedAccount::new(&from, true, &from_account),
                 ],
                 &bincode::serialize(&SystemInstruction::CreateAccountWithSeed {
-                    base: from,
                     seed: seed.to_string(),
                     lamports: 50,
                     space: 2,

--- a/sdk/src/system_instruction.rs
+++ b/sdk/src/system_instruction.rs
@@ -80,12 +80,12 @@ pub enum SystemInstruction {
     ///    a base pubkey and a seed
     /// * Transaction::keys[0] - source
     /// * Transaction::keys[1] - new account key
+    /// * Transaction::keys[2] - base account key
     /// * seed - string of ascii chars, no longer than MAX_ADDRESS_SEED_LEN
     /// * lamports - number of lamports to transfer to the new account
     /// * space - number of bytes of memory to allocate
     /// * program_id - the program id of the new account
     CreateAccountWithSeed {
-        base: Pubkey,
         seed: String,
         lamports: u64,
         space: u64,
@@ -199,13 +199,12 @@ pub fn create_account_with_seed(
     let account_metas = vec![
         AccountMeta::new(*from_pubkey, true),
         AccountMeta::new(*to_pubkey, false),
-    ]
-    .with_signer(base);
+        AccountMeta::new(*base, true),
+    ];
 
     Instruction::new(
         system_program::id(),
         &SystemInstruction::CreateAccountWithSeed {
-            base: *base,
             seed: seed.to_string(),
             lamports,
             space,


### PR DESCRIPTION
#### Problem

Passing derived address `base` keys in instruction data, while requiring their signature precludes offline signing.

Since one parameter is used to specify both the `base` and its role as a required signer, it isn't possible to construct the submission TX in an offline scenario with both the correct instruction data and the correct number of signers.  We typically construct this transaction by generating a dummy keypair for each offline signer, signing the transaction with them, then replacing the pubkeys and signatures after the fact.  With the `base`/signer in the instruction data, this results in either:
1. The correct number of signers, but wrong pubkey in instruction data, or
1. The correct pubkey in instruction data, but requires signing by both the `base` keypair and its dummy at construction time.  The former being unavailable.

#### Summary of Changes

Move the `base` pubkey from instruction data to keys list for `stake_instruction::create_account_with_seed` and its dependencies

***Once we sort this out I'll give all other instances the same treatment***