### PR TITLE
CLI: Offline-ify remaining stake ops

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -357,6 +357,12 @@ pub enum CliCommand {
         destination_account_pubkey: Pubkey,
         lamports: u64,
         withdraw_authority: Option<SigningAuthority>,
+        sign_only: bool,
+        signers: Option<Vec<(Pubkey, Signature)>>,
+        blockhash_query: BlockhashQuery,
+        nonce_account: Option<Pubkey>,
+        nonce_authority: Option<SigningAuthority>,
+        fee_payer: Option<SigningAuthority>,
     },
     // Storage Commands
     CreateStorageAccount {
@@ -1726,6 +1732,12 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             destination_account_pubkey,
             lamports,
             ref withdraw_authority,
+            sign_only,
+            ref signers,
+            blockhash_query,
+            ref nonce_account,
+            ref nonce_authority,
+            ref fee_payer,
         } => process_withdraw_stake(
             &rpc_client,
             config,
@@ -1733,6 +1745,12 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             &destination_account_pubkey,
             *lamports,
             withdraw_authority.as_ref(),
+            *sign_only,
+            signers.as_ref(),
+            blockhash_query,
+            nonce_account.as_ref(),
+            nonce_authority.as_ref(),
+            fee_payer.as_ref(),
         ),
 
         // Storage Commands
@@ -3087,6 +3105,12 @@ mod tests {
             destination_account_pubkey: to_pubkey,
             lamports: 100,
             withdraw_authority: None,
+            sign_only: false,
+            signers: None,
+            blockhash_query: BlockhashQuery::All,
+            nonce_account: None,
+            nonce_authority: None,
+            fee_payer: None,
         };
         let signature = process_command(&config);
         assert_eq!(signature.unwrap(), SIGNATURE.to_string());

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -273,12 +273,19 @@ pub enum CliCommand {
     Deploy(String),
     // Stake Commands
     CreateStakeAccount {
-        stake_account: KeypairEq,
+        stake_account: SigningAuthority,
         seed: Option<String>,
         staker: Option<Pubkey>,
         withdrawer: Option<Pubkey>,
         lockup: Lockup,
         lamports: u64,
+        sign_only: bool,
+        signers: Option<Vec<(Pubkey, Signature)>>,
+        blockhash_query: BlockhashQuery,
+        nonce_account: Option<Pubkey>,
+        nonce_authority: Option<SigningAuthority>,
+        fee_payer: Option<SigningAuthority>,
+        from: Option<SigningAuthority>,
     },
     DeactivateStake {
         stake_account_pubkey: Pubkey,
@@ -1551,12 +1558,19 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
 
         // Create stake account
         CliCommand::CreateStakeAccount {
-            stake_account,
+            ref stake_account,
             seed,
             staker,
             withdrawer,
             lockup,
             lamports,
+            sign_only,
+            ref signers,
+            blockhash_query,
+            ref nonce_account,
+            ref nonce_authority,
+            ref fee_payer,
+            ref from,
         } => process_create_stake_account(
             &rpc_client,
             config,
@@ -1566,6 +1580,13 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             withdrawer,
             lockup,
             *lamports,
+            *sign_only,
+            signers.as_ref(),
+            blockhash_query,
+            nonce_account.as_ref(),
+            nonce_authority.as_ref(),
+            fee_payer.as_ref(),
+            from.as_ref(),
         ),
         CliCommand::DeactivateStake {
             stake_account_pubkey,
@@ -3048,6 +3069,13 @@ mod tests {
                 custodian,
             },
             lamports: 1234,
+            sign_only: false,
+            signers: None,
+            blockhash_query: BlockhashQuery::All,
+            nonce_account: None,
+            nonce_authority: None,
+            fee_payer: None,
+            from: None,
         };
         let signature = process_command(&config);
         assert_eq!(signature.unwrap(), SIGNATURE.to_string());

--- a/cli/tests/stake.rs
+++ b/cli/tests/stake.rs
@@ -83,6 +83,13 @@ fn test_stake_delegation_force() {
         withdrawer: None,
         lockup: Lockup::default(),
         lamports: 50_000,
+        sign_only: false,
+        signers: None,
+        blockhash_query: BlockhashQuery::All,
+        nonce_account: None,
+        nonce_authority: None,
+        fee_payer: None,
+        from: None,
     };
     process_command(&config).unwrap();
 
@@ -168,6 +175,13 @@ fn test_seed_stake_delegation_and_deactivation() {
         withdrawer: None,
         lockup: Lockup::default(),
         lamports: 50_000,
+        sign_only: false,
+        signers: None,
+        blockhash_query: BlockhashQuery::All,
+        nonce_account: None,
+        nonce_authority: None,
+        fee_payer: None,
+        from: None,
     };
     process_command(&config_validator).unwrap();
 
@@ -242,6 +256,13 @@ fn test_stake_delegation_and_deactivation() {
         withdrawer: None,
         lockup: Lockup::default(),
         lamports: 50_000,
+        sign_only: false,
+        signers: None,
+        blockhash_query: BlockhashQuery::All,
+        nonce_account: None,
+        nonce_authority: None,
+        fee_payer: None,
+        from: None,
     };
     process_command(&config_validator).unwrap();
 
@@ -335,6 +356,13 @@ fn test_offline_stake_delegation_and_deactivation() {
         withdrawer: None,
         lockup: Lockup::default(),
         lamports: 50_000,
+        sign_only: false,
+        signers: None,
+        blockhash_query: BlockhashQuery::All,
+        nonce_account: None,
+        nonce_authority: None,
+        fee_payer: None,
+        from: None,
     };
     process_command(&config_validator).unwrap();
 
@@ -431,6 +459,13 @@ fn test_nonced_stake_delegation_and_deactivation() {
         withdrawer: None,
         lockup: Lockup::default(),
         lamports: 50_000,
+        sign_only: false,
+        signers: None,
+        blockhash_query: BlockhashQuery::All,
+        nonce_account: None,
+        nonce_authority: None,
+        fee_payer: None,
+        from: None,
     };
     process_command(&config).unwrap();
 
@@ -538,6 +573,13 @@ fn test_stake_authorize() {
         withdrawer: None,
         lockup: Lockup::default(),
         lamports: 50_000,
+        sign_only: false,
+        signers: None,
+        blockhash_query: BlockhashQuery::All,
+        nonce_account: None,
+        nonce_authority: None,
+        fee_payer: None,
+        from: None,
     };
     process_command(&config).unwrap();
 
@@ -761,6 +803,13 @@ fn test_stake_authorize_with_fee_payer() {
         withdrawer: None,
         lockup: Lockup::default(),
         lamports: 50_000,
+        sign_only: false,
+        signers: None,
+        blockhash_query: BlockhashQuery::All,
+        nonce_account: None,
+        nonce_authority: None,
+        fee_payer: None,
+        from: None,
     };
     process_command(&config).unwrap();
     // `config` balance should be 50,000 - 1 stake account sig - 1 fee sig
@@ -890,6 +939,13 @@ fn test_stake_split() {
         withdrawer: Some(offline_pubkey),
         lockup: Lockup::default(),
         lamports: 10 * minimum_stake_balance,
+        sign_only: false,
+        signers: None,
+        blockhash_query: BlockhashQuery::All,
+        nonce_account: None,
+        nonce_authority: None,
+        fee_payer: None,
+        from: None,
     };
     process_command(&config).unwrap();
     check_balance(
@@ -1022,6 +1078,13 @@ fn test_stake_set_lockup() {
         withdrawer: Some(offline_pubkey),
         lockup,
         lamports: 10 * minimum_stake_balance,
+        sign_only: false,
+        signers: None,
+        blockhash_query: BlockhashQuery::All,
+        nonce_account: None,
+        nonce_authority: None,
+        fee_payer: None,
+        from: None,
     };
     process_command(&config).unwrap();
     check_balance(


### PR DESCRIPTION
#### Problem

CLI `create-stake-account` and `stake-withdraw` haven't yet received the offline/nonce treatment

#### Summary of Changes

Give it to them

Note 1: These should be the last of transaction producing CLI stake subcommands
Note 2: Using a seed with create account is explicitly gated to error until #8252 is resolved
