### PR TITLE
Retry to curl to codecov.io unfortunately

### DIFF
--- a/ci/docker-run.sh
+++ b/ci/docker-run.sh
@@ -78,7 +78,9 @@ ARGS+=(
 # Also propagate environment variables needed for codecov
 # https://docs.codecov.io/docs/testing-with-docker#section-codecov-inside-docker
 # We normalize CI to `1`; but codecov expects it to be `true` to detect Buildkite...
-CODECOV_ENVS=$(CI=true bash <(curl -s https://codecov.io/env))
+# Unfortunately, codecov.io fails sometimes:
+#   curl: (7) Failed to connect to codecov.io port 443: Connection timed out
+CODECOV_ENVS=$(CI=true bash <(while ! curl -sS --retry 5 --retry-delay 2 --retry-connrefused https://codecov.io/env; do sleep 10; done))
 
 if $INTERACTIVE; then
   if [[ -n $1 ]]; then

--- a/ci/test-coverage.sh
+++ b/ci/test-coverage.sh
@@ -42,7 +42,9 @@ if [[ -z "$CODECOV_TOKEN" ]]; then
   echo CODECOV_TOKEN undefined, codecov.io upload skipped
 else
   # We normalize CI to `1`; but codecov expects it to be `true` to detect Buildkite...
-  CI=true bash <(curl -s https://codecov.io/bash) -X gcov -f target/cov/lcov.info
+  # Unfortunately, codecov.io fails sometimes:
+  #   curl: (7) Failed to connect to codecov.io port 443: Connection timed out
+  CI=true bash <(while ! curl -sS --retry 5 --retry-delay 2 --retry-connrefused https://codecov.io/bash; do sleep 10; done) -X gcov -f target/cov/lcov.info
 
   annotate --style success --context codecov.io \
     "CodeCov report: https://codecov.io/github/solana-labs/solana/commit/${CI_COMMIT:0:9}"

--- a/ci/test-coverage.sh
+++ b/ci/test-coverage.sh
@@ -44,7 +44,7 @@ else
   # We normalize CI to `1`; but codecov expects it to be `true` to detect Buildkite...
   # Unfortunately, codecov.io fails sometimes:
   #   curl: (7) Failed to connect to codecov.io port 443: Connection timed out
-  CI=true bash <(while ! curl -sS --retry 5 --retry-delay 2 --retry-connrefused https://codecov.io/bash; do sleep 10; done) -X gcov -f target/cov/lcov.info
+  CI=true bash <(while ! curl -sS --retry 5 --retry-delay 2 --retry-connrefused https://codecov.io/bash; do sleep 10; done) -Z -X gcov -f target/cov/lcov.info
 
   annotate --style success --context codecov.io \
     "CodeCov report: https://codecov.io/github/solana-labs/solana/commit/${CI_COMMIT:0:9}"


### PR DESCRIPTION
#### problem

codecov's infrastracture has severe problem:

```
ryoqun@ubuqun:~$ while curl -sS --retry-connrefused --retry 10 --retry-delay 2 https://codecov.io/env > /dev/null; do sleep 10; done
curl: (7) Failed to connect to codecov.io port 443: Connection timed out
```

Ultimately, this causes [coverage report upload to fail](https://buildkite.com/solana-labs/solana/builds/18898#7ac92dc1-7479-4ddc-9dde-c0d71349b9cd/2284).

That's because the needed environment variables are not passed to the docker container correctly. This is caused by [the silent failure of `curl`-ing the codecov-provided script](https://buildkite.com/solana-labs/solana/builds/18898#7ac92dc1-7479-4ddc-9dde-c0d71349b9cd/220-225).

Usually, docker arguments are populated like [this](https://buildkite.com/solana-labs/solana/builds/18941#2fa3fa13-a84e-44c0-8963-28f430d77a60/71-76).

#### solution

Retry very hard.

Even `curl --retry` isn't enough...