### PR TITLE
Make generate_remote_keypair more generic for potential other remote-…

### DIFF
--- a/keygen/src/keygen.rs
+++ b/keygen/src/keygen.rs
@@ -14,10 +14,7 @@ use solana_clap_utils::{
     },
 };
 use solana_cli_config::config::{Config, CONFIG_FILE};
-use solana_remote_wallet::{
-    ledger::{generate_remote_keypair, get_ledger_from_info},
-    remote_wallet::RemoteWalletInfo,
-};
+use solana_remote_wallet::remote_keypair::generate_remote_keypair;
 use solana_sdk::{
     pubkey::write_pubkey_file,
     signature::{
@@ -82,14 +79,10 @@ fn get_keypair_from_matches(
             let mut stdin = std::io::stdin();
             Ok(Box::new(read_keypair(&mut stdin)?))
         }
-        KeypairUrl::Usb(path) => {
-            let (remote_wallet_info, mut derivation_path) = RemoteWalletInfo::parse_path(path)?;
-            if let Some(derivation) = derivation_of(matches, "derivation_path") {
-                derivation_path = derivation;
-            }
-            let ledger = get_ledger_from_info(remote_wallet_info)?;
-            Ok(Box::new(generate_remote_keypair(ledger, derivation_path)))
-        }
+        KeypairUrl::Usb(path) => Ok(Box::new(generate_remote_keypair(
+            path,
+            derivation_of(matches, "derivation_path"),
+        )?)),
     }
 }
 

--- a/remote-wallet/src/ledger.rs
+++ b/remote-wallet/src/ledger.rs
@@ -1,9 +1,5 @@
-use crate::{
-    remote_keypair::RemoteKeypair,
-    remote_wallet::{
-        initialize_wallet_manager, DerivationPath, RemoteWallet, RemoteWalletError,
-        RemoteWalletInfo, RemoteWalletType,
-    },
+use crate::remote_wallet::{
+    initialize_wallet_manager, DerivationPath, RemoteWallet, RemoteWalletError, RemoteWalletInfo,
 };
 use dialoguer::{theme::ColorfulTheme, Select};
 use log::*;
@@ -368,14 +364,4 @@ pub fn get_ledger_from_info(
         pubkeys[0]
     };
     wallet_manager.get_ledger(&wallet_base_pubkey)
-}
-
-pub fn generate_remote_keypair(
-    ledger: Arc<LedgerWallet>,
-    derivation_path: DerivationPath,
-) -> RemoteKeypair {
-    RemoteKeypair {
-        wallet_type: RemoteWalletType::Ledger(ledger),
-        derivation_path,
-    }
 }


### PR DESCRIPTION
…wallets

#### Problem
The `generate_remote_keypair` method sounds like it should work for any remote wallet type, but is oddly specific (even though we don't yet support any other remote wallets).
Also the code around generating RemoteKeypairs is prone to copy-pasta, discovered when attempting to use it in a 2nd place.

#### Summary of Changes
- Make `generate_remote_keypair()` generic, and handle device- and derivation-path parsing that is needed every use
