### PR TITLE
Return ProgramError from programs

### DIFF
--- a/programs/stake/src/config.rs
+++ b/programs/stake/src/config.rs
@@ -6,7 +6,7 @@ use solana_config_program::{create_config_account, get_config_data, ConfigState}
 use solana_sdk::{
     account::{Account, KeyedAccount},
     genesis_config::GenesisConfig,
-    instruction::InstructionError,
+    program_error::ProgramError,
 };
 
 // stake config ID
@@ -63,11 +63,11 @@ pub fn create_account(lamports: u64, config: &Config) -> Account {
     create_config_account(vec![], config, lamports)
 }
 
-pub fn from_keyed_account(account: &KeyedAccount) -> Result<Config, InstructionError> {
+pub fn from_keyed_account(account: &KeyedAccount) -> Result<Config, ProgramError> {
     if !check_id(account.unsigned_key()) {
-        return Err(InstructionError::InvalidArgument);
+        return Err(ProgramError::InvalidArgument);
     }
-    Config::from(&*account.try_account_ref()?).ok_or(InstructionError::InvalidArgument)
+    Config::from(&*account.try_account_ref()?).ok_or(ProgramError::InvalidArgument)
 }
 
 #[cfg(test)]
@@ -82,7 +82,7 @@ mod tests {
         assert_eq!(Config::from(&account.borrow()), Some(Config::default()));
         assert_eq!(
             from_keyed_account(&KeyedAccount::new(&Pubkey::default(), false, &mut account)),
-            Err(InstructionError::InvalidArgument)
+            Err(ProgramError::InvalidArgument)
         );
     }
 }

--- a/programs/storage/src/storage_contract.rs
+++ b/programs/storage/src/storage_contract.rs
@@ -7,7 +7,7 @@ use solana_sdk::{
     account_utils::StateMut,
     clock::Epoch,
     hash::Hash,
-    instruction::InstructionError,
+    program_error::ProgramError,
     pubkey::Pubkey,
     signature::Signature,
     sysvar,
@@ -137,7 +137,7 @@ impl<'a> StorageAccount<'a> {
         &mut self,
         owner: Pubkey,
         account_type: StorageAccountType,
-    ) -> Result<(), InstructionError> {
+    ) -> Result<(), ProgramError> {
         let storage_contract = &mut self.account.state()?;
         if let StorageContract::Uninitialized = storage_contract {
             *storage_contract = match account_type {
@@ -157,7 +157,7 @@ impl<'a> StorageAccount<'a> {
             };
             self.account.set_state(storage_contract)
         } else {
-            Err(InstructionError::AccountAlreadyInitialized)
+            Err(ProgramError::AccountAlreadyInitialized)
         }
     }
 
@@ -168,7 +168,7 @@ impl<'a> StorageAccount<'a> {
         signature: Signature,
         blockhash: Hash,
         clock: sysvar::clock::Clock,
-    ) -> Result<(), InstructionError> {
+    ) -> Result<(), ProgramError> {
         let mut storage_contract = &mut self.account.state()?;
         if let StorageContract::ArchiverStorage {
             proofs,
@@ -194,7 +194,7 @@ impl<'a> StorageAccount<'a> {
 
             if segment_index >= current_segment {
                 // attempt to submit proof for unconfirmed segment
-                return Err(InstructionError::CustomError(
+                return Err(ProgramError::CustomError(
                     StorageError::InvalidSegment as u32,
                 ));
             }
@@ -207,7 +207,7 @@ impl<'a> StorageAccount<'a> {
             // TODO check that this blockhash is valid and recent
             //            if !is_valid(&blockhash) {
             //                // proof isn't using a recent blockhash
-            //                return Err(InstructionError::CustomError(InvalidBlockhash as u32));
+            //                return Err(ProgramError::CustomError(InvalidBlockhash as u32));
             //            }
 
             let proof = Proof {
@@ -220,13 +220,13 @@ impl<'a> StorageAccount<'a> {
             let segment_proofs = proofs.entry(current_segment).or_default();
             if segment_proofs.contains(&proof) {
                 // do not accept duplicate proofs
-                return Err(InstructionError::CustomError(
+                return Err(ProgramError::CustomError(
                     StorageError::DuplicateProof as u32,
                 ));
             }
             if segment_proofs.len() >= MAX_PROOFS_PER_SEGMENT {
                 // do not accept more than MAX_PROOFS_PER_SEGMENT
-                return Err(InstructionError::CustomError(
+                return Err(ProgramError::CustomError(
                     StorageError::ProofLimitReached as u32,
                 ));
             }
@@ -234,7 +234,7 @@ impl<'a> StorageAccount<'a> {
             segment_proofs.push(proof);
             self.account.set_state(storage_contract)
         } else {
-            Err(InstructionError::InvalidArgument)
+            Err(ProgramError::InvalidArgument)
         }
     }
 
@@ -243,7 +243,7 @@ impl<'a> StorageAccount<'a> {
         hash: Hash,
         segment: u64,
         clock: sysvar::clock::Clock,
-    ) -> Result<(), InstructionError> {
+    ) -> Result<(), ProgramError> {
         let mut storage_contract = &mut self.account.state()?;
         if let StorageContract::ValidatorStorage {
             segment: state_segment,
@@ -255,7 +255,7 @@ impl<'a> StorageAccount<'a> {
         {
             debug!("advertise new segment: {} orig: {}", segment, clock.segment);
             if segment < *state_segment || segment > clock.segment {
-                return Err(InstructionError::CustomError(
+                return Err(ProgramError::CustomError(
                     StorageError::InvalidSegment as u32,
                 ));
             }
@@ -270,7 +270,7 @@ impl<'a> StorageAccount<'a> {
             credits.current_epoch += total_validations;
             self.account.set_state(storage_contract)
         } else {
-            Err(InstructionError::InvalidArgument)
+            Err(ProgramError::InvalidArgument)
         }
     }
 
@@ -281,7 +281,7 @@ impl<'a> StorageAccount<'a> {
         segment_index: u64,
         proofs_per_account: Vec<Vec<ProofStatus>>,
         archiver_accounts: &mut [StorageAccount],
-    ) -> Result<(), InstructionError> {
+    ) -> Result<(), ProgramError> {
         let mut storage_contract = &mut self.account.state()?;
         if let StorageContract::ValidatorStorage {
             segment: state_segment,
@@ -290,7 +290,7 @@ impl<'a> StorageAccount<'a> {
         } = &mut storage_contract
         {
             if segment_index > *state_segment {
-                return Err(InstructionError::CustomError(
+                return Err(ProgramError::CustomError(
                     StorageError::InvalidSegment as u32,
                 ));
             }
@@ -329,7 +329,7 @@ impl<'a> StorageAccount<'a> {
 
             if accounts.len() != proofs_per_account.len() {
                 // don't have all the accounts to validate the proofs_per_account against
-                return Err(InstructionError::CustomError(
+                return Err(ProgramError::CustomError(
                     StorageError::InvalidProofMask as u32,
                 ));
             }
@@ -360,7 +360,7 @@ impl<'a> StorageAccount<'a> {
 
             self.account.set_state(storage_contract)
         } else {
-            Err(InstructionError::InvalidArgument)
+            Err(ProgramError::InvalidArgument)
         }
     }
 
@@ -370,7 +370,7 @@ impl<'a> StorageAccount<'a> {
         clock: sysvar::clock::Clock,
         rewards: sysvar::rewards::Rewards,
         owner: &mut StorageAccount,
-    ) -> Result<(), InstructionError> {
+    ) -> Result<(), ProgramError> {
         let mut storage_contract = &mut self.account.state()?;
 
         if let StorageContract::ValidatorStorage {
@@ -380,9 +380,7 @@ impl<'a> StorageAccount<'a> {
         } = &mut storage_contract
         {
             if owner.id != *account_owner {
-                return Err(InstructionError::CustomError(
-                    StorageError::InvalidOwner as u32,
-                ));
+                return Err(ProgramError::CustomError(StorageError::InvalidOwner as u32));
             }
 
             credits.update_epoch(clock.epoch);
@@ -397,9 +395,7 @@ impl<'a> StorageAccount<'a> {
         } = &mut storage_contract
         {
             if owner.id != *account_owner {
-                return Err(InstructionError::CustomError(
-                    StorageError::InvalidOwner as u32,
-                ));
+                return Err(ProgramError::CustomError(StorageError::InvalidOwner as u32));
             }
             credits.update_epoch(clock.epoch);
             let (num_validations, _total_proofs) = count_valid_proofs(&validations);
@@ -409,7 +405,7 @@ impl<'a> StorageAccount<'a> {
 
             self.account.set_state(storage_contract)
         } else {
-            Err(InstructionError::InvalidArgument)
+            Err(ProgramError::InvalidArgument)
         }
     }
 }
@@ -419,10 +415,10 @@ fn check_redeemable(
     storage_point_value: f64,
     rewards_pool: &KeyedAccount,
     owner: &mut StorageAccount,
-) -> Result<(), InstructionError> {
+) -> Result<(), ProgramError> {
     let rewards = (credits.redeemable as f64 * storage_point_value) as u64;
     if rewards_pool.lamports()? < rewards {
-        Err(InstructionError::CustomError(
+        Err(ProgramError::CustomError(
             StorageError::RewardPoolDepleted as u32,
         ))
     } else {
@@ -447,7 +443,7 @@ fn store_validation_result(
     storage_account: &mut StorageAccount,
     segment: u64,
     proof_mask: &[ProofStatus],
-) -> Result<(), InstructionError> {
+) -> Result<(), ProgramError> {
     let mut storage_contract = storage_account.account.state()?;
     match &mut storage_contract {
         StorageContract::ArchiverStorage {
@@ -457,11 +453,11 @@ fn store_validation_result(
             ..
         } => {
             if !proofs.contains_key(&segment) {
-                return Err(InstructionError::InvalidAccountData);
+                return Err(ProgramError::InvalidAccountData);
             }
 
             if proofs.get(&segment).unwrap().len() != proof_mask.len() {
-                return Err(InstructionError::InvalidAccountData);
+                return Err(ProgramError::InvalidAccountData);
             }
 
             let (recorded_validations, _) = count_valid_proofs(&validations);
@@ -473,7 +469,7 @@ fn store_validation_result(
             credits.update_epoch(clock.epoch);
             credits.current_epoch += total_validations - recorded_validations;
         }
-        _ => return Err(InstructionError::InvalidAccountData),
+        _ => return Err(ProgramError::InvalidAccountData),
     }
     storage_account.account.set_state(&storage_contract)
 }
@@ -629,7 +625,7 @@ mod tests {
         keyed_pool_account.account.borrow_mut().lamports = 0;
         assert_eq!(
             check_redeemable(&mut credits, 1.0, &keyed_pool_account, &mut owner),
-            Err(InstructionError::CustomError(
+            Err(ProgramError::CustomError(
                 StorageError::RewardPoolDepleted as u32,
             ))
         );

--- a/runtime/src/native_loader.rs
+++ b/runtime/src/native_loader.rs
@@ -7,8 +7,12 @@ use libloading::os::windows::*;
 use log::*;
 use num_derive::{FromPrimitive, ToPrimitive};
 use solana_sdk::{
+<<<<<<< HEAD
     account::KeyedAccount, entrypoint_native, instruction::InstructionError,
     program_utils::DecodeError, pubkey::Pubkey,
+=======
+    account::KeyedAccount, entrypoint_native, program_error::ProgramError, pubkey::Pubkey,
+>>>>>>> Rreturn ProgramError from programs
 };
 use std::{env, path::PathBuf, str};
 use thiserror::Error;
@@ -84,7 +88,7 @@ pub fn invoke_entrypoint(
     keyed_accounts: &[KeyedAccount],
     instruction_data: &[u8],
     symbol_cache: &SymbolCache,
-) -> Result<(), InstructionError> {
+) -> Result<(), ProgramError> {
     // dispatch it
     let (names, params) = keyed_accounts.split_at(1);
     let name_vec = &names[0].try_account_ref()?.data;

--- a/sdk/src/account.rs
+++ b/sdk/src/account.rs
@@ -1,6 +1,6 @@
 use crate::{
     hash::Hash,
-    instruction::InstructionError,
+    program_error::ProgramError,
     {clock::Epoch, pubkey::Pubkey},
 };
 use std::{
@@ -163,43 +163,43 @@ impl<'a> KeyedAccount<'a> {
         self.is_writable
     }
 
-    pub fn lamports(&self) -> Result<u64, InstructionError> {
+    pub fn lamports(&self) -> Result<u64, ProgramError> {
         Ok(self.try_borrow()?.lamports)
     }
 
-    pub fn data_len(&self) -> Result<usize, InstructionError> {
+    pub fn data_len(&self) -> Result<usize, ProgramError> {
         Ok(self.try_borrow()?.data.len())
     }
 
-    pub fn data_is_empty(&self) -> Result<bool, InstructionError> {
+    pub fn data_is_empty(&self) -> Result<bool, ProgramError> {
         Ok(self.try_borrow()?.data.is_empty())
     }
 
-    pub fn owner(&self) -> Result<Pubkey, InstructionError> {
+    pub fn owner(&self) -> Result<Pubkey, ProgramError> {
         Ok(self.try_borrow()?.owner)
     }
 
-    pub fn executable(&self) -> Result<bool, InstructionError> {
+    pub fn executable(&self) -> Result<bool, ProgramError> {
         Ok(self.try_borrow()?.executable)
     }
 
-    pub fn try_account_ref(&'a self) -> Result<Ref<Account>, InstructionError> {
+    pub fn try_account_ref(&'a self) -> Result<Ref<Account>, ProgramError> {
         self.try_borrow()
     }
 
-    pub fn try_account_ref_mut(&'a self) -> Result<RefMut<Account>, InstructionError> {
+    pub fn try_account_ref_mut(&'a self) -> Result<RefMut<Account>, ProgramError> {
         self.try_borrow_mut()
     }
 
-    fn try_borrow(&self) -> Result<Ref<Account>, InstructionError> {
+    fn try_borrow(&self) -> Result<Ref<Account>, ProgramError> {
         self.account
             .try_borrow()
-            .map_err(|_| InstructionError::AccountBorrowFailed)
+            .map_err(|_| ProgramError::AccountBorrowFailed)
     }
-    fn try_borrow_mut(&self) -> Result<RefMut<Account>, InstructionError> {
+    fn try_borrow_mut(&self) -> Result<RefMut<Account>, ProgramError> {
         self.account
             .try_borrow_mut()
-            .map_err(|_| InstructionError::AccountBorrowFailed)
+            .map_err(|_| ProgramError::AccountBorrowFailed)
     }
 
     pub fn new(key: &'a Pubkey, is_signer: bool, account: &'a RefCell<Account>) -> Self {

--- a/sdk/src/entrypoint_native.rs
+++ b/sdk/src/entrypoint_native.rs
@@ -1,13 +1,13 @@
 //! @brief Solana Native program entry point
 
-use crate::{account::KeyedAccount, instruction::InstructionError, pubkey::Pubkey};
+use crate::{account::KeyedAccount, program_error::ProgramError, pubkey::Pubkey};
 
 // Prototype of a native program entry point
 pub type Entrypoint = unsafe extern "C" fn(
     program_id: &Pubkey,
     keyed_accounts: &[KeyedAccount],
     instruction_data: &[u8],
-) -> Result<(), InstructionError>;
+) -> Result<(), ProgramError>;
 
 /// Convenience macro to declare a native program
 ///
@@ -23,7 +23,7 @@ pub type Entrypoint = unsafe extern "C" fn(
 /// # // rather than in the statement position which isn't allowed.
 /// # mod item_wrapper {
 /// use solana_sdk::account::KeyedAccount;
-/// use solana_sdk::instruction::InstructionError;
+/// use solana_sdk::instruction::ProgramError;
 /// use solana_sdk::pubkey::Pubkey;
 /// use solana_sdk::declare_program;
 ///
@@ -31,7 +31,7 @@ pub type Entrypoint = unsafe extern "C" fn(
 ///     program_id: &Pubkey,
 ///     keyed_accounts: &[KeyedAccount],
 ///     instruction_data: &[u8],
-/// ) -> Result<(), InstructionError> {
+/// ) -> Result<(), ProgramError> {
 ///   // Process an instruction
 ///   Ok(())
 /// }
@@ -54,7 +54,7 @@ pub type Entrypoint = unsafe extern "C" fn(
 /// # // rather than in the statement position which isn't allowed.
 /// # mod item_wrapper {
 /// use solana_sdk::account::KeyedAccount;
-/// use solana_sdk::instruction::InstructionError;
+/// use solana_sdk::instruction::ProgramError;
 /// use solana_sdk::pubkey::Pubkey;
 /// use solana_sdk::declare_program;
 ///
@@ -62,7 +62,7 @@ pub type Entrypoint = unsafe extern "C" fn(
 ///     program_id: &Pubkey,
 ///     keyed_accounts: &[KeyedAccount],
 ///     instruction_data: &[u8],
-/// ) -> Result<(), InstructionError> {
+/// ) -> Result<(), ProgramError> {
 ///   // Process an instruction
 ///   Ok(())
 /// }
@@ -94,7 +94,7 @@ macro_rules! declare_program(
             program_id: &$crate::pubkey::Pubkey,
             keyed_accounts: &[$crate::account::KeyedAccount],
             instruction_data: &[u8],
-        ) -> Result<(), $crate::instruction::InstructionError> {
+        ) -> Result<(), $crate::program_error::ProgramError> {
             $entrypoint(program_id, keyed_accounts, instruction_data)
         }
     )

--- a/sdk/src/instruction.rs
+++ b/sdk/src/instruction.rs
@@ -1,6 +1,8 @@
 //! Defines a composable Instruction type and a memory-efficient CompiledInstruction.
 
-use crate::{pubkey::Pubkey, short_vec, system_instruction::SystemError};
+use crate::{
+    program_error::ProgramError, pubkey::Pubkey, short_vec, system_instruction::SystemError,
+};
 use bincode::serialize;
 use serde::Serialize;
 
@@ -10,33 +12,6 @@ pub enum InstructionError {
     /// Deprecated! Use CustomError instead!
     /// The program instruction returned an error
     GenericError,
-
-    /// The arguments provided to a program instruction where invalid
-    InvalidArgument,
-
-    /// An instruction's data contents was invalid
-    InvalidInstructionData,
-
-    /// An account's data contents was invalid
-    InvalidAccountData,
-
-    /// An account's data was too small
-    AccountDataTooSmall,
-
-    /// An account's balance was too small to complete the instruction
-    InsufficientFunds,
-
-    /// The account did not have the expected program id
-    IncorrectProgramId,
-
-    /// A signature was required but not found
-    MissingRequiredSignature,
-
-    /// An initialize instruction was sent to an account that has already been initialized.
-    AccountAlreadyInitialized,
-
-    /// An attempt to operate on an account that hasn't been initialized.
-    UninitializedAccount,
 
     /// Program's instruction lamport balance does not equal the balance after the instruction
     UnbalancedInstruction,
@@ -66,9 +41,6 @@ pub enum InstructionError {
     /// Rent_epoch account changed, but shouldn't have
     RentEpochModified,
 
-    /// The instruction expected additional account keys
-    NotEnoughAccountKeys,
-
     /// A non-system program changed the size of the account data
     AccountDataSizeChanged,
 
@@ -86,14 +58,10 @@ pub enum InstructionError {
     /// the runtime cannot determine which changes to pick or how to merge them if both are modified
     DuplicateAccountOutOfSync,
 
-    /// The return value from the program was invalid.  Valid errors are either a defined builtin
-    /// error value or a user-defined error in the lower 32 bits.
-    InvalidError,
-
     /// Allows on-chain programs to implement program-specific error types and see them returned
     /// by the Solana runtime. A program-specific error may be any type that is represented as
     /// or serialized to a u32 integer.
-    CustomError(u32),
+    ProgramError(ProgramError),
 }
 
 impl InstructionError {

--- a/sdk/src/program_utils.rs
+++ b/sdk/src/program_utils.rs
@@ -1,14 +1,11 @@
-use crate::{
-    account::KeyedAccount, account_info::AccountInfo, instruction::InstructionError,
-    program_error::ProgramError,
-};
+use crate::{account::KeyedAccount, account_info::AccountInfo, program_error::ProgramError};
 use num_traits::FromPrimitive;
 
 /// Return the next KeyedAccount or a NotEnoughAccountKeys error
 pub fn next_keyed_account<'a, 'b, I: Iterator<Item = &'a KeyedAccount<'b>>>(
     iter: &mut I,
-) -> Result<I::Item, InstructionError> {
-    iter.next().ok_or(InstructionError::NotEnoughAccountKeys)
+) -> Result<I::Item, ProgramError> {
+    iter.next().ok_or(ProgramError::NotEnoughAccountKeys)
 }
 
 /// Return the next AccountInfo or a NotEnoughAccountKeys error
@@ -20,13 +17,13 @@ pub fn next_account_info<'a, 'b, I: Iterator<Item = &'a AccountInfo<'b>>>(
 
 /// Return true if the first keyed_account is executable, used to determine if
 /// the loader should call a program's 'main'
-pub fn is_executable(keyed_accounts: &[KeyedAccount]) -> Result<bool, InstructionError> {
+pub fn is_executable(keyed_accounts: &[KeyedAccount]) -> Result<bool, ProgramError> {
     Ok(!keyed_accounts.is_empty() && keyed_accounts[0].executable()?)
 }
 
 /// Deserialize with a limit based the maximum amount of data a program can expect to get.
 /// This function should be used in place of direct deserialization to help prevent OOM errors
-pub fn limited_deserialize<T>(instruction_data: &[u8]) -> Result<T, InstructionError>
+pub fn limited_deserialize<T>(instruction_data: &[u8]) -> Result<T, ProgramError>
 where
     T: serde::de::DeserializeOwned,
 {
@@ -34,7 +31,7 @@ where
     bincode::config()
         .limit(limit)
         .deserialize(instruction_data)
-        .map_err(|_| InstructionError::InvalidInstructionData)
+        .map_err(|_| ProgramError::InvalidInstructionData)
 }
 
 /// Allows customer errors to be decoded back to their original enum

--- a/sdk/src/sysvar/mod.rs
+++ b/sdk/src/sysvar/mod.rs
@@ -3,7 +3,6 @@
 use crate::{
     account::{Account, KeyedAccount},
     account_info::AccountInfo,
-    instruction::InstructionError,
     program_error::ProgramError,
     pubkey::Pubkey,
 };
@@ -77,12 +76,11 @@ pub trait Sysvar:
     fn to_account_info(&self, account_info: &mut AccountInfo) -> Option<()> {
         bincode::serialize_into(&mut account_info.data.borrow_mut()[..], self).ok()
     }
-    fn from_keyed_account(keyed_account: &KeyedAccount) -> Result<Self, InstructionError> {
+    fn from_keyed_account(keyed_account: &KeyedAccount) -> Result<Self, ProgramError> {
         if !Self::check_id(keyed_account.unsigned_key()) {
-            return Err(InstructionError::InvalidArgument);
+            return Err(ProgramError::InvalidArgument);
         }
-        Self::from_account(&*keyed_account.try_account_ref()?)
-            .ok_or(InstructionError::InvalidArgument)
+        Self::from_account(&*keyed_account.try_account_ref()?).ok_or(ProgramError::InvalidArgument)
     }
     fn create_account(&self, lamports: u64) -> Account {
         let data_len = Self::size_of().max(bincode::serialized_size(self).unwrap() as usize);

--- a/sdk/src/sysvar/rent.rs
+++ b/sdk/src/sysvar/rent.rs
@@ -4,7 +4,7 @@ pub use crate::rent::Rent;
 
 use crate::{
     account::{Account, KeyedAccount},
-    instruction::InstructionError,
+    program_error::ProgramError,
     sysvar::Sysvar,
 };
 
@@ -19,10 +19,10 @@ pub fn create_account(lamports: u64, rent: &Rent) -> Account {
 pub fn verify_rent_exemption(
     keyed_account: &KeyedAccount,
     rent_sysvar_account: &KeyedAccount,
-) -> Result<(), InstructionError> {
+) -> Result<(), ProgramError> {
     let rent = Rent::from_keyed_account(rent_sysvar_account)?;
     if !rent.is_exempt(keyed_account.lamports()?, keyed_account.data_len()?) {
-        Err(InstructionError::InsufficientFunds)
+        Err(ProgramError::InsufficientFunds)
     } else {
         Ok(())
     }


### PR DESCRIPTION
#### Problem

It's not clear if an error came from the runtime or from a program.  Distinguishing the two will help developers clarify the origin of the error.  This also unifies native and BPF program return values.

#### Summary of Changes

- Programs return `ProgramError`
- MessageProcessor returns `InstructionError`

CI is disabled for now in this PR but both the SDK and Runtime build and are clippy free

Fixes #
