### PR TITLE
Remove BPF Loader's use of GenericError

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3645,9 +3645,12 @@ dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-logger 0.24.0",
  "solana-sdk 0.24.0",
  "solana_rbpf 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/programs/bpf_loader/Cargo.toml
+++ b/programs/bpf_loader/Cargo.toml
@@ -13,9 +13,12 @@ bincode = "1.2.1"
 byteorder = "1.3.2"
 libc = "0.2.66"
 log = "0.4.8"
+num-derive = { version = "0.3" }
+num-traits = { version = "0.2" }
 solana-logger = { path = "../../logger", version = "0.24.0" }
 solana-sdk = { path = "../../sdk", version = "0.24.0" }
 solana_rbpf = "=0.1.21"
+thiserror = "1.0"
 
 [lib]
 crate-type = ["lib", "cdylib"]


### PR DESCRIPTION
#### Problem

BPF Loader uses deprecated `GenericError`

#### Summary of Changes

Use `thiserror` instead

Fixes #
