### PR TITLE
Remove Native Loader's use of GenericError

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4349,6 +4349,8 @@ dependencies = [
  "libloading 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "memmap 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4365,6 +4367,7 @@ dependencies = [
  "solana-vote-program 0.24.0",
  "sys-info 0.5.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -14,26 +14,30 @@ bv = { version = "0.11.0", features = ["serde"] }
 byteorder = "1.3.2"
 fnv = "1.0.6"
 fs_extra = "1.1.0"
+itertools = "0.8.2"
 libc = "0.2.66"
 libloading = "0.5.2"
 log = "0.4.8"
 memmap = "0.7.0"
+num-derive = { version = "0.3" }
+num-traits = { version = "0.2" }
 rand = "0.6.5"
 rayon = "1.2.0"
 serde = { version = "1.0.104", features = ["rc"] }
 serde_derive = "1.0.103"
+solana-bpf-loader-program = { path = "../programs/bpf_loader", version = "0.24.0" }
 solana-logger = { path = "../logger", version = "0.24.0" }
 solana-measure = { path = "../measure", version = "0.24.0" }
 solana-metrics = { path = "../metrics", version = "0.24.0" }
-solana-bpf-loader-program = { path = "../programs/bpf_loader", version = "0.24.0" }
+solana-rayon-threadlimit = { path = "../rayon-threadlimit", version = "0.24.0" }
 solana-sdk = { path = "../sdk", version = "0.24.0" }
 solana-stake-program = { path = "../programs/stake", version = "0.24.0" }
 solana-storage-program = { path = "../programs/storage", version = "0.24.0" }
 solana-vote-program = { path = "../programs/vote", version = "0.24.0" }
 sys-info = "0.5.9"
 tempfile = "3.1.0"
-solana-rayon-threadlimit = { path = "../rayon-threadlimit", version = "0.24.0" }
-itertools = "0.8.2"
+thiserror = "1.0"
+
 
 [lib]
 crate-type = ["lib"]


### PR DESCRIPTION
#### Problem

Native Loader uses deprecated `GenericError`

#### Summary of Changes

Use `thiserror` instead

Fixes #
