### PR TITLE
Cleanup new_result_with_negative_lamports

### DIFF
--- a/sdk/src/instruction.rs
+++ b/sdk/src/instruction.rs
@@ -98,7 +98,7 @@ pub enum InstructionError {
 
 impl InstructionError {
     pub fn new_result_with_negative_lamports() -> Self {
-        InstructionError::CustomError(SystemError::ResultWithNegativeLamports as u32)
+        SystemError::ResultWithNegativeLamports.into()
     }
 }
 


### PR DESCRIPTION
#### Problem

Overly verbose

#### Summary of Changes

Use `into()` instead

Fixes #
