### PR TITLE
Remove failure's use of GenericError

### DIFF
--- a/programs/failure/src/lib.rs
+++ b/programs/failure/src/lib.rs
@@ -13,5 +13,5 @@ fn process_instruction(
     _keyed_accounts: &[KeyedAccount],
     _data: &[u8],
 ) -> Result<(), InstructionError> {
-    Err(InstructionError::GenericError)
+    Err(InstructionError::CustomError(0))
 }

--- a/programs/failure/tests/failure.rs
+++ b/programs/failure/tests/failure.rs
@@ -23,6 +23,6 @@ fn test_program_native_failure() {
             .send_instruction(&alice_keypair, instruction)
             .unwrap_err()
             .unwrap(),
-        TransactionError::InstructionError(0, InstructionError::GenericError)
+        TransactionError::InstructionError(0, InstructionError::CustomError(0))
     );
 }


### PR DESCRIPTION
#### Problem

Failure program uses deprecated `GenericError`

#### Summary of Changes

Use `CustomError` instead

Fixes #
