### PR TITLE
ledger-tool: Add print-accounts command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4100,6 +4100,7 @@ name = "solana-ledger-tool"
 version = "0.24.0"
 dependencies = [
  "assert_cmd 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bs58 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "histogram 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.46 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -121,7 +121,7 @@ impl JsonRpcRequestProcessor {
     ) -> Result<Vec<RpcKeyedAccount>> {
         Ok(self
             .bank(commitment)
-            .get_program_accounts(&program_id)
+            .get_program_accounts(Some(&program_id))
             .into_iter()
             .map(|(pubkey, account)| RpcKeyedAccount {
                 pubkey: pubkey.to_string(),

--- a/ledger-tool/Cargo.toml
+++ b/ledger-tool/Cargo.toml
@@ -9,6 +9,7 @@ license = "Apache-2.0"
 homepage = "https://solana.com/"
 
 [dependencies]
+bs58 = "0.3.0"
 clap = "2.33.0"
 histogram = "*"
 serde_json = "1.0.46"

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -387,13 +387,16 @@ impl Accounts {
     pub fn load_by_program(
         &self,
         ancestors: &HashMap<Slot, usize>,
-        program_id: &Pubkey,
+        program_id: Option<&Pubkey>,
     ) -> Vec<(Pubkey, Account)> {
         self.accounts_db.scan_accounts(
             ancestors,
             |collector: &mut Vec<(Pubkey, Account)>, option| {
                 if let Some(data) = option
-                    .filter(|(_, account, _)| account.owner == *program_id && account.lamports != 0)
+                    .filter(|(_, account, _)| {
+                        (program_id.is_none() || Some(&account.owner) == program_id)
+                            && account.lamports != 0
+                    })
                     .map(|(pubkey, account, _slot)| (*pubkey, account))
                 {
                     collector.push(data)

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1746,7 +1746,7 @@ impl Bank {
             .map(|(acc, _slot)| acc)
     }
 
-    pub fn get_program_accounts(&self, program_id: &Pubkey) -> Vec<(Pubkey, Account)> {
+    pub fn get_program_accounts(&self, program_id: Option<&Pubkey>) -> Vec<(Pubkey, Account)> {
         self.rc
             .accounts
             .load_by_program(&self.ancestors, program_id)
@@ -4743,11 +4743,24 @@ mod tests {
 
     #[test]
     fn test_bank_get_program_accounts() {
-        let (genesis_config, _mint_keypair) = create_genesis_config(500);
+        let (genesis_config, mint_keypair) = create_genesis_config(500);
         let parent = Arc::new(Bank::new(&genesis_config));
 
-        let bank0 = Arc::new(new_from_parent(&parent));
+        let genesis_accounts: Vec<_> = parent.get_program_accounts(None);
+        assert!(
+            genesis_accounts
+                .iter()
+                .any(|(pubkey, _)| *pubkey == mint_keypair.pubkey()),
+            "mint pubkey not found"
+        );
+        assert!(
+            genesis_accounts
+                .iter()
+                .any(|(pubkey, _)| solana_sdk::sysvar::is_sysvar_id(pubkey)),
+            "no sysvars found"
+        );
 
+        let bank0 = Arc::new(new_from_parent(&parent));
         let pubkey0 = Pubkey::new_rand();
         let program_id = Pubkey::new(&[2; 32]);
         let account0 = Account::new(1, 0, &program_id);
@@ -4761,11 +4774,11 @@ mod tests {
         let bank1 = Arc::new(new_from_parent(&bank0));
         bank1.squash();
         assert_eq!(
-            bank0.get_program_accounts(&program_id),
+            bank0.get_program_accounts(Some(&program_id)),
             vec![(pubkey0, account0.clone())]
         );
         assert_eq!(
-            bank1.get_program_accounts(&program_id),
+            bank1.get_program_accounts(Some(&program_id)),
             vec![(pubkey0, account0.clone())]
         );
         assert_eq!(
@@ -4784,8 +4797,8 @@ mod tests {
 
         let bank3 = Arc::new(new_from_parent(&bank2));
         bank3.squash();
-        assert_eq!(bank1.get_program_accounts(&program_id).len(), 2);
-        assert_eq!(bank3.get_program_accounts(&program_id).len(), 2);
+        assert_eq!(bank1.get_program_accounts(Some(&program_id)).len(), 2);
+        assert_eq!(bank3.get_program_accounts(Some(&program_id)).len(), 2);
     }
 
     #[test]


### PR DESCRIPTION
`solana-ledger-tool -l <ledger> print-accounts`  makes it possible to easily view the full set of accounts for a given bank.  This is useful for:
1. Whitelisting accounts that are created implicitly by genesis config 
2. Quickly examining the state of the world at any given snapshot or ledger snippet 
