### PR TITLE
Add storage rewards pools in development mode only

### DIFF
--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -503,8 +503,9 @@ fn main() -> Result<(), Box<dyn error::Error>> {
         );
     }
 
-    // add genesis stuff from storage and stake
-    solana_storage_program::rewards_pools::add_genesis_accounts(&mut genesis_config);
+    if operating_mode == OperatingMode::Development {
+        solana_storage_program::rewards_pools::add_genesis_accounts(&mut genesis_config);
+    }
     solana_stake_program::add_genesis_accounts(&mut genesis_config);
 
     if let Some(files) = matches.values_of("primordial_accounts_file") {

--- a/sdk/src/genesis_config.rs
+++ b/sdk/src/genesis_config.rs
@@ -23,7 +23,7 @@ use std::{
     time::{SystemTime, UNIX_EPOCH},
 };
 
-#[derive(Serialize, Deserialize, Debug, Clone, Copy)]
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq)]
 pub enum OperatingMode {
     SoftLaunch,  // Cluster features incrementally enabled over time
     Development, // All features (including experimental features) available immediately from genesis


### PR DESCRIPTION
Storage program isn't ready for soft launch mode.  Remove its reward pools in soft launch mode to keep genesis fit, and as we'll likely reimplement storage rewards as in-protocol epoch-based rewards, like voting anyway.