### PR TITLE
Fix authorized voter ahead of time

### DIFF
--- a/cli/src/vote.rs
+++ b/cli/src/vote.rs
@@ -457,7 +457,7 @@ pub fn process_show_vote_account(
         build_balance_message(vote_account.lamports, use_lamports_unit, true)
     );
     println!("Validator Identity: {}", vote_state.node_pubkey);
-    println!("Authorized Voter: {}", vote_state.authorized_voter);
+    println!("Authorized Voter: {:?}", vote_state.authorized_voters());
     println!(
         "Authorized Withdrawer: {}",
         vote_state.authorized_withdrawer

--- a/programs/vote/src/authorized_voters.rs
+++ b/programs/vote/src/authorized_voters.rs
@@ -1,0 +1,102 @@
+use log::*;
+use serde_derive::{Deserialize, Serialize};
+use solana_sdk::pubkey::Pubkey;
+use std::collections::BTreeMap;
+
+#[derive(Debug, Default, Serialize, Deserialize, PartialEq, Eq, Clone)]
+pub struct AuthorizedVoters {
+    authorized_voters: BTreeMap<u64, Pubkey>,
+}
+
+impl AuthorizedVoters {
+    pub fn new(epoch: u64, pubkey: Pubkey) -> Self {
+        let mut authorized_voters = BTreeMap::new();
+        authorized_voters.insert(epoch, pubkey);
+        Self { authorized_voters }
+    }
+
+    pub fn get_authorized_voter(&self, epoch: u64) -> Option<Pubkey> {
+        self.get_or_calculate_authorized_voter_for_epoch(epoch)
+            .map(|(pubkey, _)| pubkey)
+    }
+
+    pub fn get_and_cache_authorized_voter_for_epoch(&mut self, epoch: u64) -> Option<Pubkey> {
+        let res = self.get_or_calculate_authorized_voter_for_epoch(epoch);
+
+        res.map(|(pubkey, existed)| {
+            if !existed {
+                self.authorized_voters.insert(epoch, pubkey);
+            }
+            pubkey
+        })
+    }
+
+    pub fn insert(&mut self, epoch: u64, authorized_voter: Pubkey) {
+        self.authorized_voters.insert(epoch, authorized_voter);
+    }
+
+    pub fn purge_authorized_voters(&mut self, current_epoch: u64) -> bool {
+        // Iterate through the keys in order, filtering out the ones
+        // less than the current epoch
+        let expired_keys: Vec<_> = self
+            .authorized_voters
+            .range(0..current_epoch)
+            .map(|(authorized_epoch, _)| *authorized_epoch)
+            .collect();
+
+        for key in expired_keys {
+            self.authorized_voters.remove(&key);
+        }
+
+        // Have to uphold this invariant b/c this is
+        // 1) The check for whether the vote state is initialized
+        // 2) How future authorized voters for uninitialized epochs are set
+        //    by this function
+        assert!(!self.authorized_voters.is_empty());
+        true
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.authorized_voters.is_empty()
+    }
+
+    pub fn first(&self) -> Option<(&u64, &Pubkey)> {
+        self.authorized_voters.iter().next()
+    }
+
+    pub fn last(&self) -> Option<(&u64, &Pubkey)> {
+        self.authorized_voters.iter().next_back()
+    }
+
+    pub fn len(&self) -> usize {
+        self.authorized_voters.len()
+    }
+
+    pub fn contains(&self, epoch: u64) -> bool {
+        self.authorized_voters.get(&epoch).is_some()
+    }
+
+    // Returns the authorized voter at the given epoch if the epoch is >= the
+    // current epoch, and a bool indicating whether the entry for this epoch
+    // exists in the self.authorized_voter map
+    fn get_or_calculate_authorized_voter_for_epoch(&self, epoch: u64) -> Option<(Pubkey, bool)> {
+        let res = self.authorized_voters.get(&epoch);
+        if res.is_none() {
+            // If no authorized voter has been set yet for this epoch,
+            // this must mean the authorized voter remains unchanged
+            // from the latest epoch before this one
+            let res = self.authorized_voters.range(0..epoch).next_back();
+
+            if res.is_none() {
+                warn!(
+                    "Tried to query for the authorized voter of an epoch earlier
+                    than the current epoch. Earlier epochs have been purged"
+                );
+            }
+
+            res.map(|(_, pubkey)| (*pubkey, false))
+        } else {
+            res.map(|pubkey| (*pubkey, true))
+        }
+    }
+}

--- a/programs/vote/src/lib.rs
+++ b/programs/vote/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod authorized_voters;
 pub mod vote_instruction;
 pub mod vote_state;
 

--- a/sdk/src/epoch_schedule.rs
+++ b/sdk/src/epoch_schedule.rs
@@ -8,6 +8,11 @@ pub use crate::clock::{Epoch, Slot, DEFAULT_SLOTS_PER_EPOCH};
 ///  the beginning of epoch X - 1.
 pub const DEFAULT_LEADER_SCHEDULE_SLOT_OFFSET: u64 = DEFAULT_SLOTS_PER_EPOCH;
 
+/// The maximum number of slots before an epoch starts to calculate the leader schedule.
+///  Default is an entire epoch, i.e. leader schedule for epoch X is calculated at
+///  the beginning of epoch X - 1.
+pub const MAX_LEADER_SCHEDULE_EPOCH_OFFSET: u64 = 3;
+
 /// based on MAX_LOCKOUT_HISTORY from vote_program
 pub const MINIMUM_SLOTS_PER_EPOCH: u64 = 32;
 


### PR DESCRIPTION
#### Problem
Authorized voter can change at any point during an epoch, making it hard to detect without monitoring vote account.

Working towards: https://github.com/solana-labs/solana/issues/8232

#### Summary of Changes
Fix the authorized voter ahead of time, similar to epoch stakes based on the `leader_schedule_epoch`
Fixes #
