### PR TITLE
Remove needless uses

### DIFF
--- a/sdk/src/signature.rs
+++ b/sdk/src/signature.rs
@@ -1,12 +1,9 @@
 //! The `signature` module provides functionality for public, and private keys.
 
 use crate::pubkey::Pubkey;
-use bs58;
-use ed25519_dalek;
 use generic_array::{typenum::U64, GenericArray};
 use hmac::Hmac;
 use rand::{rngs::OsRng, CryptoRng, RngCore};
-use serde_json;
 use std::{
     borrow::{Borrow, Cow},
     error, fmt,


### PR DESCRIPTION
In preparation of [this](https://github.com/solana-labs/solana/pull/8012/files#diff-4b5263e29d55962afaf13a723bb3d2b9R23). :)
 
Fix errors like this:

```
error: this import is redundant
 --> sdk/src/signature.rs:7:1
  |
7 | use serde_json;
  | ^^^^^^^^^^^^^^^ help: remove it entirely
  |
  = note: `-D clippy::single-component-path-imports` implied by `-D warnings`
  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#single_component_path_imports
```

Split off from #8012.