### PR TITLE
Remove AccountInfo's (De)Serialize

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -73,7 +73,7 @@ pub struct ErrorCounters {
     pub invalid_account_index: usize,
 }
 
-#[derive(Deserialize, Serialize, Default, Debug, PartialEq, Clone)]
+#[derive(Default, Debug, PartialEq, Clone)]
 pub struct AccountInfo {
     /// index identifying the append storage
     store_id: AppendVecId,


### PR DESCRIPTION
Just realized AccontInfo isn't serialized at all and these derives are needless.

Split off from #8012.