### PR TITLE
Generate a snapshot at synchronized points

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ members = [
     "archiver",
     "archiver-lib",
     "archiver-utils",
+    "remote-wallet",
     "runtime",
     "sdk",
     "sdk-c",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,6 @@ members = [
     "archiver",
     "archiver-lib",
     "archiver-utils",
-    "remote-wallet",
     "runtime",
     "sdk",
     "sdk-c",
@@ -62,6 +61,3 @@ exclude = [
     "programs/move_loader",
     "programs/librapay",
 ]
-
-[profile.release]
-debug = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,3 +62,6 @@ exclude = [
     "programs/move_loader",
     "programs/librapay",
 ]
+
+[profile.release]
+debug = true

--- a/ledger/src/bank_forks.rs
+++ b/ledger/src/bank_forks.rs
@@ -189,7 +189,7 @@ impl BankForks {
                 if Self::check_interval(root, parent_slot, config.snapshot_interval_slots) {
                     // Generate a snapshot if snapshots are configured and it's been an appropriate number
                     // of banks since the last snapshot
-                    info!("setting snapshot root: {}", root);
+                    info!("setting snapshot root: {} interval: {}", root, config.snapshot_interval_slots);
                     if root - self.last_snapshot_slot >= config.snapshot_interval_slots as Slot {
                         bank.squash();
                         let mut snapshot_time = Measure::start("total-snapshot-ms");

--- a/ledger/src/bank_forks.rs
+++ b/ledger/src/bank_forks.rs
@@ -189,7 +189,10 @@ impl BankForks {
                 if Self::check_interval(root, parent_slot, config.snapshot_interval_slots) {
                     // Generate a snapshot if snapshots are configured and it's been an appropriate number
                     // of banks since the last snapshot
-                    info!("setting snapshot root: {} interval: {}", root, config.snapshot_interval_slots);
+                    info!(
+                        "setting snapshot root: {} interval: {}",
+                        root, config.snapshot_interval_slots
+                    );
                     if root - self.last_snapshot_slot >= config.snapshot_interval_slots as Slot {
                         bank.squash();
                         let mut snapshot_time = Measure::start("total-snapshot-ms");

--- a/ledger/src/bank_forks.rs
+++ b/ledger/src/bank_forks.rs
@@ -392,12 +392,19 @@ mod tests {
     fn test_bank_forks_check_interval() {
         assert!(BankForks::check_interval(1, 0, 1));
         assert!(BankForks::check_interval(0, 0, 1));
+        assert!(BankForks::check_interval(0, 0, 5));
 
         for i in 0..100 {
             assert!(BankForks::check_interval(5 + i, 0, 5));
         }
         for i in 1..100 {
             assert!(BankForks::check_interval(5 * i, 5 * i - 1, 5));
+        }
+        for i in 2..100 {
+            assert!(BankForks::check_interval(5 * i, 5 * i - 2, 5));
+        }
+        for i in 3..100 {
+            assert!(BankForks::check_interval(5 * i, 5 * i - 3, 5));
         }
         for i in 0..3 {
             assert!(!BankForks::check_interval(1 + i, 0, 5));


### PR DESCRIPTION
#### Problem

Snapshots are generated at a random root.

#### Summary of Changes

While each node may root a different bank at different times, they all root the same fork.  Therefore each node should observe the same parent slot when squashing a root bank. Instead of just generating a snapshot at the root, the node should find the parent which is at the synchronization point and generate a snapshot form that bank.

Fixes #
