### PR TITLE
CLI: Remote wallet signing

### DIFF
--- a/archiver-lib/src/archiver.rs
+++ b/archiver-lib/src/archiver.rs
@@ -384,7 +384,7 @@ impl Archiver {
                     );
                     let message =
                         Message::new_with_payer(vec![ix], Some(&archiver_keypair.pubkey()));
-                    if let Err(e) = client.send_message(&[&archiver_keypair], message) {
+                    if let Err(e) = client.send_message(&[archiver_keypair.as_ref()], message) {
                         error!("unable to redeem reward, tx failed: {:?}", e);
                     } else {
                         info!(
@@ -671,7 +671,7 @@ impl Archiver {
             blockhash,
         );
         if let Err(err) = client.send_and_confirm_transaction(
-            &[&archiver_keypair, &storage_keypair],
+            &[archiver_keypair.as_ref(), storage_keypair.as_ref()],
             &mut transaction,
             10,
             0,

--- a/bench-exchange/src/bench.rs
+++ b/bench-exchange/src/bench.rs
@@ -868,7 +868,7 @@ pub fn create_token_accounts(client: &dyn Client, signers: &[Arc<Keypair>], acco
                 to_create_txs
                     .par_iter_mut()
                     .for_each(|((from_keypair, to_keypair), tx)| {
-                        tx.sign(&[from_keypair.as_ref(), to_keypair], blockhash);
+                        tx.sign(&[from_keypair.as_ref(), **to_keypair], blockhash);
                     });
                 to_create_txs.iter().for_each(|(_, tx)| {
                     client.async_send_transaction(tx.clone()).expect("transfer");

--- a/bench-tps/src/bench.rs
+++ b/bench-tps/src/bench.rs
@@ -909,8 +909,10 @@ fn fund_move_keys<T: Client>(
         let keypairs: Vec<_> = keys.iter().map(|k| k).collect();
         let tx = librapay_transaction::create_accounts(funding_key, &keypairs, 1, blockhash);
         let ser_size = bincode::serialized_size(&tx).unwrap();
-        let mut keys = vec![funding_key];
-        keys.extend(&keypairs);
+        let mut keys: Vec<&dyn KeypairUtil> = vec![funding_key];
+        for keypair in keypairs.iter() {
+            keys.push(*keypair);
+        }
         client.send_message(&keys, tx.message).unwrap();
 
         if i % 10 == 0 {
@@ -957,7 +959,7 @@ fn fund_move_keys<T: Client>(
     for (i, key) in libra_funding_keys.iter().enumerate() {
         let tx = librapay_transaction::create_account(&funding_keys[i], &key, 1, blockhash);
         client
-            .send_message(&[&funding_keys[i], &key], tx.message)
+            .send_message(&[&funding_keys[i], key], tx.message)
             .unwrap();
 
         let tx = librapay_transaction::transfer(

--- a/bench-tps/src/bench.rs
+++ b/bench-tps/src/bench.rs
@@ -312,7 +312,7 @@ fn generate_system_txs(
         .par_iter()
         .map(|(from, to)| {
             (
-                system_transaction::transfer(from, &to.pubkey(), 1, *blockhash),
+                system_transaction::transfer(**from, &to.pubkey(), 1, *blockhash),
                 timestamp(),
             )
         })

--- a/book/src/paper-wallet/usage.md
+++ b/book/src/paper-wallet/usage.md
@@ -166,10 +166,10 @@ Refer to the following page for a comprehensive guide on running a validator:
 Solana CLI tooling supports secure keypair input for stake delegation. To do so,
 first create a stake account with some SOL. Use the special `ASK` keyword to
 trigger a seed phrase input prompt for the stake account and use
-`--ask-seed-phrase keypair` to securely input the funding keypair.
+`--keypair ASK` to securely input the funding keypair.
 
 ```bash
-solana create-stake-account ASK 1 --ask-seed-phrase keypair
+solana create-stake-account ASK 1 --keypair ASK
 
 [stake_account] seed phrase: 🔒
 [stake_account] If this seed phrase has an associated passphrase, enter it now. Otherwise, press ENTER to continue:
@@ -177,11 +177,11 @@ solana create-stake-account ASK 1 --ask-seed-phrase keypair
 [keypair] If this seed phrase has an associated passphrase, enter it now. Otherwise, press ENTER to continue:
 ```
 
-Then, to delegate that stake to a validator, use `--ask-seed-phrase keypair` to
+Then, to delegate that stake to a validator, use `--keypair ASK` to
 securely input the funding keypair.
 
 ```bash
-solana delegate-stake --ask-seed-phrase keypair <STAKE_ACCOUNT_PUBKEY> <VOTE_ACCOUNT_PUBKEY>
+solana delegate-stake --keypair ASK <STAKE_ACCOUNT_PUBKEY> <VOTE_ACCOUNT_PUBKEY>
 
 [keypair] seed phrase: 🔒
 [keypair] If this seed phrase has an associated passphrase, enter it now. Otherwise, press ENTER to continue:

--- a/clap-utils/src/input_parsers.rs
+++ b/clap-utils/src/input_parsers.rs
@@ -1,4 +1,6 @@
-use crate::keypair::{keypair_from_seed_phrase, ASK_KEYWORD, SKIP_SEED_PHRASE_VALIDATION_ARG};
+use crate::keypair::{
+    generate_keypair_util, keypair_from_seed_phrase, ASK_KEYWORD, SKIP_SEED_PHRASE_VALIDATION_ARG,
+};
 use chrono::DateTime;
 use clap::ArgMatches;
 use solana_remote_wallet::remote_wallet::DerivationPath;
@@ -91,6 +93,18 @@ pub fn pubkeys_sigs_of(matches: &ArgMatches<'_>, name: &str) -> Option<Vec<(Pubk
             })
             .collect()
     })
+}
+
+// Return a signer from matches at `name`
+pub fn signer_of(
+    name: &str,
+    matches: &ArgMatches<'_>,
+) -> Result<Option<Box<dyn KeypairUtil>>, Box<dyn std::error::Error>> {
+    if let Some(location) = matches.value_of(name) {
+        generate_keypair_util(matches, location, name).map(Some)
+    } else {
+        Ok(None)
+    }
 }
 
 pub fn lamports_of_sol(matches: &ArgMatches<'_>, name: &str) -> Option<u64> {

--- a/clap-utils/src/input_validators.rs
+++ b/clap-utils/src/input_validators.rs
@@ -1,5 +1,6 @@
-use crate::keypair::ASK_KEYWORD;
+use crate::keypair::{parse_keypair_path, KeypairUrl, ASK_KEYWORD};
 use chrono::DateTime;
+use solana_remote_wallet::remote_keypair::generate_remote_keypair;
 use solana_sdk::{
     hash::Hash,
     pubkey::Pubkey,
@@ -48,6 +49,16 @@ pub fn is_pubkey_or_keypair(string: String) -> Result<(), String> {
 // Return an error if string cannot be parsed as pubkey or keypair file or keypair ask keyword
 pub fn is_pubkey_or_keypair_or_ask_keyword(string: String) -> Result<(), String> {
     is_pubkey(string.clone()).or_else(|_| is_keypair_or_ask_keyword(string))
+}
+
+pub fn is_valid_signer(string: String) -> Result<(), String> {
+    match parse_keypair_path(&string) {
+        KeypairUrl::Usb(path) => generate_remote_keypair(path, None)
+            .map(|_| ())
+            .map_err(|err| format!("{:?}", err)),
+        KeypairUrl::Filepath(path) => is_keypair(path),
+        _ => Ok(()),
+    }
 }
 
 // Return an error if string cannot be parsed as pubkey=signature string

--- a/clap-utils/src/keypair.rs
+++ b/clap-utils/src/keypair.rs
@@ -10,7 +10,7 @@ use solana_sdk::{
     pubkey::Pubkey,
     signature::{
         keypair_from_seed, keypair_from_seed_phrase_and_passphrase, read_keypair,
-        read_keypair_file, Keypair, KeypairUtil, Presigner,
+        read_keypair_file, Keypair, KeypairUtil, Presigner, Signature,
     },
 };
 use std::{
@@ -42,6 +42,19 @@ pub fn parse_keypair_path(path: &str) -> KeypairUrl {
     }
 }
 
+pub fn presigner_from_pubkey_sigs(
+    pubkey: &Pubkey,
+    signers: &[(Pubkey, Signature)],
+) -> Option<Presigner> {
+    signers.iter().find_map(|(signer, sig)| {
+        if *signer == *pubkey {
+            Some(Presigner::new(signer, sig))
+        } else {
+            None
+        }
+    })
+}
+
 pub fn generate_keypair_util(
     matches: &ArgMatches,
     path: &str,
@@ -66,15 +79,9 @@ pub fn generate_keypair_util(
             derivation_of(matches, "derivation_path"),
         )?)),
         KeypairUrl::Pubkey(pubkey) => {
-            let presigner = pubkeys_sigs_of(matches, "signer").and_then(|presigners| {
-                presigners.iter().find_map(|(signer, sig)| {
-                    if *signer == pubkey {
-                        Some(Presigner::new(signer, sig))
-                    } else {
-                        None
-                    }
-                })
-            });
+            let presigner = pubkeys_sigs_of(matches, "signer")
+                .as_ref()
+                .and_then(|presigners| presigner_from_pubkey_sigs(&pubkey, presigners));
             if let Some(presigner) = presigner {
                 Ok(Box::new(presigner))
             } else {

--- a/clap-utils/src/keypair.rs
+++ b/clap-utils/src/keypair.rs
@@ -1,16 +1,20 @@
-use crate::{input_parsers::derivation_of, ArgConstant};
+use crate::{input_parsers::{derivation_of, pubkeys_sigs_of}, ArgConstant};
 use bip39::{Language, Mnemonic, Seed};
-use clap::{values_t, ArgMatches};
+use clap::{values_t, ArgMatches, Error, ErrorKind};
 use rpassword::prompt_password_stderr;
 use solana_remote_wallet::remote_keypair::generate_remote_keypair;
-use solana_sdk::signature::{
-    keypair_from_seed, keypair_from_seed_phrase_and_passphrase, read_keypair, read_keypair_file,
-    Keypair, KeypairUtil,
+use solana_sdk::{
+    pubkey::Pubkey,
+    signature::{
+        keypair_from_seed, keypair_from_seed_phrase_and_passphrase, read_keypair, read_keypair_file,
+        Keypair, KeypairUtil, Presigner,
+    },
 };
 use std::{
     error,
     io::{stdin, stdout, Write},
     process::exit,
+    str::FromStr,
 };
 
 pub enum KeypairUrl {
@@ -18,6 +22,7 @@ pub enum KeypairUrl {
     Filepath(String),
     Usb(String),
     Stdin,
+    Pubkey(Pubkey),
 }
 
 pub fn parse_keypair_path(path: &str) -> KeypairUrl {
@@ -27,6 +32,8 @@ pub fn parse_keypair_path(path: &str) -> KeypairUrl {
         KeypairUrl::Ask
     } else if path.starts_with("usb://") {
         KeypairUrl::Usb(path.split_at(6).1.to_string())
+    } else if let Ok(pubkey) = Pubkey::from_str(path) {
+        KeypairUrl::Pubkey(pubkey)
     } else {
         KeypairUrl::Filepath(path.to_string())
     }
@@ -55,6 +62,23 @@ pub fn generate_keypair_util(
             path,
             derivation_of(matches, "derivation_path"),
         )?)),
+        KeypairUrl::Pubkey(pubkey) => {
+            let presigner = pubkeys_sigs_of(matches, "signer")
+                .and_then(|presigners| {
+                    presigners.iter().find_map(|(signer, sig)| {
+                        if *signer == pubkey {
+                            Some(Presigner::new(signer, sig))
+                        } else {
+                            None
+                        }
+                    })
+                });
+            if let Some(presigner) = presigner {
+                Ok(Box::new(presigner))
+            } else {
+                Err(Error::with_description("Missing signature for supplied pubkey", ErrorKind::MissingRequiredArgument).into())
+            }
+        }
     }
 }
 

--- a/clap-utils/src/keypair.rs
+++ b/clap-utils/src/keypair.rs
@@ -1,4 +1,7 @@
-use crate::{input_parsers::{derivation_of, pubkeys_sigs_of}, ArgConstant};
+use crate::{
+    input_parsers::{derivation_of, pubkeys_sigs_of},
+    ArgConstant,
+};
 use bip39::{Language, Mnemonic, Seed};
 use clap::{values_t, ArgMatches, Error, ErrorKind};
 use rpassword::prompt_password_stderr;
@@ -6,8 +9,8 @@ use solana_remote_wallet::remote_keypair::generate_remote_keypair;
 use solana_sdk::{
     pubkey::Pubkey,
     signature::{
-        keypair_from_seed, keypair_from_seed_phrase_and_passphrase, read_keypair, read_keypair_file,
-        Keypair, KeypairUtil, Presigner,
+        keypair_from_seed, keypair_from_seed_phrase_and_passphrase, read_keypair,
+        read_keypair_file, Keypair, KeypairUtil, Presigner,
     },
 };
 use std::{
@@ -63,20 +66,23 @@ pub fn generate_keypair_util(
             derivation_of(matches, "derivation_path"),
         )?)),
         KeypairUrl::Pubkey(pubkey) => {
-            let presigner = pubkeys_sigs_of(matches, "signer")
-                .and_then(|presigners| {
-                    presigners.iter().find_map(|(signer, sig)| {
-                        if *signer == pubkey {
-                            Some(Presigner::new(signer, sig))
-                        } else {
-                            None
-                        }
-                    })
-                });
+            let presigner = pubkeys_sigs_of(matches, "signer").and_then(|presigners| {
+                presigners.iter().find_map(|(signer, sig)| {
+                    if *signer == pubkey {
+                        Some(Presigner::new(signer, sig))
+                    } else {
+                        None
+                    }
+                })
+            });
             if let Some(presigner) = presigner {
                 Ok(Box::new(presigner))
             } else {
-                Err(Error::with_description("Missing signature for supplied pubkey", ErrorKind::MissingRequiredArgument).into())
+                Err(Error::with_description(
+                    "Missing signature for supplied pubkey",
+                    ErrorKind::MissingRequiredArgument,
+                )
+                .into())
             }
         }
     }

--- a/clap-utils/src/keypair.rs
+++ b/clap-utils/src/keypair.rs
@@ -1,10 +1,11 @@
-use crate::ArgConstant;
+use crate::{input_parsers::derivation_of, ArgConstant};
 use bip39::{Language, Mnemonic, Seed};
-use clap::values_t;
+use clap::{values_t, ArgMatches};
 use rpassword::prompt_password_stderr;
+use solana_remote_wallet::remote_keypair::generate_remote_keypair;
 use solana_sdk::signature::{
-    keypair_from_seed, keypair_from_seed_phrase_and_passphrase, read_keypair_file, Keypair,
-    KeypairUtil,
+    keypair_from_seed, keypair_from_seed_phrase_and_passphrase, read_keypair, read_keypair_file,
+    Keypair, KeypairUtil,
 };
 use std::{
     error,
@@ -28,6 +29,32 @@ pub fn parse_keypair_path(path: &str) -> KeypairUrl {
         KeypairUrl::Usb(path.split_at(6).1.to_string())
     } else {
         KeypairUrl::Filepath(path.to_string())
+    }
+}
+
+pub fn generate_keypair_util(
+    matches: &ArgMatches,
+    path: &str,
+    keypair_name: &str,
+) -> Result<Box<dyn KeypairUtil>, Box<dyn error::Error>> {
+    match parse_keypair_path(path) {
+        KeypairUrl::Ask => {
+            let skip_validation = matches.is_present(SKIP_SEED_PHRASE_VALIDATION_ARG.name);
+            Ok(Box::new(keypair_from_seed_phrase(
+                keypair_name,
+                skip_validation,
+                false,
+            )?))
+        }
+        KeypairUrl::Filepath(path) => Ok(Box::new(read_keypair_file(&path)?)),
+        KeypairUrl::Stdin => {
+            let mut stdin = std::io::stdin();
+            Ok(Box::new(read_keypair(&mut stdin)?))
+        }
+        KeypairUrl::Usb(path) => Ok(Box::new(generate_remote_keypair(
+            path,
+            derivation_of(matches, "derivation_path"),
+        )?)),
     }
 }
 

--- a/cli-config/src/config.rs
+++ b/cli-config/src/config.rs
@@ -7,6 +7,12 @@ use std::{
 };
 
 lazy_static! {
+    pub static ref DEFAULT_USER_KEYPAIR: Option<String> = {
+        dirs::home_dir().map(|mut path| {
+            path.extend(&[".config", "solana", "cli", "id.json"]);
+            path.to_str().unwrap().to_string()
+        })
+    };
     pub static ref CONFIG_FILE: Option<String> = {
         dirs::home_dir().map(|mut path| {
             path.extend(&[".config", "solana", "cli", "config.yml"]);

--- a/cli-config/src/config.rs
+++ b/cli-config/src/config.rs
@@ -7,12 +7,6 @@ use std::{
 };
 
 lazy_static! {
-    pub static ref DEFAULT_USER_KEYPAIR: Option<String> = {
-        dirs::home_dir().map(|mut path| {
-            path.extend(&[".config", "solana", "cli", "id.json"]);
-            path.to_str().unwrap().to_string()
-        })
-    };
     pub static ref CONFIG_FILE: Option<String> = {
         dirs::home_dir().map(|mut path| {
             path.extend(&[".config", "solana", "cli", "config.yml"]);

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -2255,7 +2255,7 @@ mod tests {
         system_program,
         transaction::TransactionError,
     };
-    use std::{collections::HashMap, path::PathBuf};
+    use std::{collections::HashMap, path::PathBuf, rc::Rc};
 
     fn make_tmp_path(name: &str) -> String {
         let out_dir = std::env::var("FARF_DIR").unwrap_or_else(|_| "farf".to_string());
@@ -2770,7 +2770,7 @@ mod tests {
 
         let keypair = Keypair::new();
         let pubkey = keypair.pubkey().to_string();
-        config.keypair = keypair;
+        config.keypair = keypair.into();
         config.command = CliCommand::Address;
         assert_eq!(process_command(&config).unwrap(), pubkey);
 
@@ -2830,7 +2830,7 @@ mod tests {
         let bob_pubkey = bob_keypair.pubkey();
         let custodian = Pubkey::new_rand();
         config.command = CliCommand::CreateStakeAccount {
-            stake_account: bob_keypair.into(),
+            stake_account: Rc::new(bob_keypair.into()),
             seed: None,
             staker: None,
             withdrawer: None,
@@ -2888,7 +2888,7 @@ mod tests {
             blockhash_query: BlockhashQuery::default(),
             nonce_account: None,
             nonce_authority: None,
-            split_stake_account: split_stake_account.into(),
+            split_stake_account: Rc::new(split_stake_account.into()),
             seed: None,
             lamports: 1234,
             fee_payer: None,

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -14,7 +14,9 @@ use log::*;
 use num_traits::FromPrimitive;
 use serde_json::{self, json, Value};
 use solana_budget_program::budget_instruction::{self, BudgetError};
-use solana_clap_utils::{input_parsers::*, input_validators::*, keypair::generate_keypair_util, ArgConstant};
+use solana_clap_utils::{
+    input_parsers::*, input_validators::*, keypair::generate_keypair_util, ArgConstant,
+};
 use solana_client::{client_error::ClientError, rpc_client::RpcClient};
 #[cfg(not(test))]
 use solana_faucet::faucet::request_airdrop_transaction;
@@ -92,7 +94,10 @@ impl std::ops::Deref for KeypairEq {
     }
 }
 
-pub fn signer_from_matches(name: &str, matches: &ArgMatches<'_>) -> Result<Option<Box<dyn KeypairUtil>>, Box<dyn error::Error>> {
+pub fn signer_from_matches(
+    name: &str,
+    matches: &ArgMatches<'_>,
+) -> Result<Option<Box<dyn KeypairUtil>>, Box<dyn error::Error>> {
     if let Some(location) = matches.value_of(name) {
         generate_keypair_util(matches, location, name).map(Some)
     } else {

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -474,7 +474,7 @@ impl error::Error for CliError {
 pub struct CliConfig {
     pub command: CliCommand,
     pub json_rpc_url: String,
-    pub keypair: Keypair,
+    pub keypair: Box<dyn KeypairUtil>,
     pub keypair_path: Option<String>,
     pub derivation_path: Option<DerivationPath>,
     pub rpc_client: Option<RpcClient>,
@@ -505,7 +505,7 @@ impl Default for CliConfig {
                 use_lamports_unit: false,
             },
             json_rpc_url: Self::default_json_rpc_url(),
-            keypair: Keypair::new(),
+            keypair: Box::new(Keypair::new()),
             keypair_path: Some(Self::default_keypair_path()),
             derivation_path: None,
             rpc_client: None,
@@ -1041,7 +1041,7 @@ fn process_deploy(
     let (blockhash, fee_calculator) = rpc_client.get_recent_blockhash()?;
     let minimum_balance = rpc_client.get_minimum_balance_for_rent_exemption(program_data.len())?;
     let mut create_account_tx = system_transaction::create_account(
-        &config.keypair,
+        config.keypair.as_ref(),
         &program_id,
         blockhash,
         minimum_balance.max(1),
@@ -1049,7 +1049,7 @@ fn process_deploy(
         &bpf_loader::id(),
     );
     messages.push(&create_account_tx.message);
-    let signers = [&config.keypair, &program_id];
+    let signers = [config.keypair.as_ref(), &program_id];
     let write_transactions: Vec<_> = program_data
         .chunks(DATA_CHUNK_SIZE)
         .zip(0..)
@@ -1136,7 +1136,7 @@ fn process_pay(
                 .map(|authority| authority.keypair())
                 .unwrap_or(&config.keypair);
             system_transaction::nonced_transfer(
-                &config.keypair,
+                config.keypair.as_ref(),
                 to,
                 lamports,
                 nonce_account,
@@ -1144,7 +1144,7 @@ fn process_pay(
                 blockhash,
             )
         } else {
-            system_transaction::transfer(&config.keypair, to, lamports, blockhash)
+            system_transaction::transfer(config.keypair.as_ref(), to, lamports, blockhash)
         };
 
         if let Some(signers) = signers {
@@ -1167,7 +1167,8 @@ fn process_pay(
                 &fee_calculator,
                 &tx.message,
             )?;
-            let result = rpc_client.send_and_confirm_transaction(&mut tx, &[&config.keypair]);
+            let result =
+                rpc_client.send_and_confirm_transaction(&mut tx, &[config.keypair.as_ref()]);
             log_instruction_custom_error::<SystemError>(result)
         }
     } else if *witnesses == None {
@@ -1190,7 +1191,7 @@ fn process_pay(
             lamports,
         );
         let mut tx = Transaction::new_signed_instructions(
-            &[&config.keypair, &contract_state],
+            &[config.keypair.as_ref(), &contract_state],
             ixs,
             blockhash,
         );
@@ -1207,7 +1208,7 @@ fn process_pay(
                 &tx.message,
             )?;
             let result = rpc_client
-                .send_and_confirm_transaction(&mut tx, &[&config.keypair, &contract_state]);
+                .send_and_confirm_transaction(&mut tx, &[config.keypair.as_ref(), &contract_state]);
             let signature_str = log_instruction_custom_error::<BudgetError>(result)?;
 
             Ok(json!({
@@ -1238,7 +1239,7 @@ fn process_pay(
             lamports,
         );
         let mut tx = Transaction::new_signed_instructions(
-            &[&config.keypair, &contract_state],
+            &[config.keypair.as_ref(), &contract_state],
             ixs,
             blockhash,
         );
@@ -1249,7 +1250,7 @@ fn process_pay(
             return_signers(&tx)
         } else {
             let result = rpc_client
-                .send_and_confirm_transaction(&mut tx, &[&config.keypair, &contract_state]);
+                .send_and_confirm_transaction(&mut tx, &[config.keypair.as_ref(), &contract_state]);
             check_account_for_fee(
                 rpc_client,
                 &config.keypair.pubkey(),
@@ -1276,14 +1277,15 @@ fn process_cancel(rpc_client: &RpcClient, config: &CliConfig, pubkey: &Pubkey) -
         pubkey,
         &config.keypair.pubkey(),
     );
-    let mut tx = Transaction::new_signed_instructions(&[&config.keypair], vec![ix], blockhash);
+    let mut tx =
+        Transaction::new_signed_instructions(&[config.keypair.as_ref()], vec![ix], blockhash);
     check_account_for_fee(
         rpc_client,
         &config.keypair.pubkey(),
         &fee_calculator,
         &tx.message,
     )?;
-    let result = rpc_client.send_and_confirm_transaction(&mut tx, &[&config.keypair]);
+    let result = rpc_client.send_and_confirm_transaction(&mut tx, &[config.keypair.as_ref()]);
     log_instruction_custom_error::<BudgetError>(result)
 }
 
@@ -1297,14 +1299,15 @@ fn process_time_elapsed(
     let (blockhash, fee_calculator) = rpc_client.get_recent_blockhash()?;
 
     let ix = budget_instruction::apply_timestamp(&config.keypair.pubkey(), pubkey, to, dt);
-    let mut tx = Transaction::new_signed_instructions(&[&config.keypair], vec![ix], blockhash);
+    let mut tx =
+        Transaction::new_signed_instructions(&[config.keypair.as_ref()], vec![ix], blockhash);
     check_account_for_fee(
         rpc_client,
         &config.keypair.pubkey(),
         &fee_calculator,
         &tx.message,
     )?;
-    let result = rpc_client.send_and_confirm_transaction(&mut tx, &[&config.keypair]);
+    let result = rpc_client.send_and_confirm_transaction(&mut tx, &[config.keypair.as_ref()]);
     log_instruction_custom_error::<BudgetError>(result)
 }
 
@@ -1374,7 +1377,7 @@ fn process_transfer(
             &fee_calculator,
             &tx.message,
         )?;
-        let result = rpc_client.send_and_confirm_transaction(&mut tx, &[&config.keypair]);
+        let result = rpc_client.send_and_confirm_transaction(&mut tx, &[config.keypair.as_ref()]);
         log_instruction_custom_error::<SystemError>(result)
     }
 }
@@ -1388,14 +1391,15 @@ fn process_witness(
     let (blockhash, fee_calculator) = rpc_client.get_recent_blockhash()?;
 
     let ix = budget_instruction::apply_signature(&config.keypair.pubkey(), pubkey, to);
-    let mut tx = Transaction::new_signed_instructions(&[&config.keypair], vec![ix], blockhash);
+    let mut tx =
+        Transaction::new_signed_instructions(&[config.keypair.as_ref()], vec![ix], blockhash);
     check_account_for_fee(
         rpc_client,
         &config.keypair.pubkey(),
         &fee_calculator,
         &tx.message,
     )?;
-    let result = rpc_client.send_and_confirm_transaction(&mut tx, &[&config.keypair]);
+    let result = rpc_client.send_and_confirm_transaction(&mut tx, &[config.keypair.as_ref()]);
     log_instruction_custom_error::<BudgetError>(result)
 }
 

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -93,8 +93,11 @@ impl std::ops::Deref for KeypairEq {
 }
 
 pub fn signer_from_matches(name: &str, matches: &ArgMatches<'_>) -> Result<Option<Box<dyn KeypairUtil>>, Box<dyn error::Error>> {
-    let location = matches.value_of(name).unwrap();
-    generate_keypair_util(matches, location, name).map(Some)
+    if let Some(location) = matches.value_of(name) {
+        generate_keypair_util(matches, location, name).map(Some)
+    } else {
+        Ok(None)
+    }
 }
 
 pub fn nonce_authority_arg<'a, 'b>() -> Arg<'a, 'b> {

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -20,10 +20,7 @@ use solana_client::{client_error::ClientError, rpc_client::RpcClient};
 use solana_faucet::faucet::request_airdrop_transaction;
 #[cfg(test)]
 use solana_faucet::faucet_mock::request_airdrop_transaction;
-use solana_remote_wallet::{
-    ledger::get_ledger_from_info,
-    remote_wallet::{DerivationPath, RemoteWallet, RemoteWalletInfo},
-};
+use solana_remote_wallet::remote_wallet::DerivationPath;
 use solana_sdk::{
     bpf_loader,
     clock::{Epoch, Slot},
@@ -496,19 +493,7 @@ impl CliConfig {
     }
 
     pub(crate) fn pubkey(&self) -> Result<Pubkey, Box<dyn std::error::Error>> {
-        if let Some(path) = &self.keypair_path {
-            if path.starts_with("usb://") {
-                let (remote_wallet_info, mut derivation_path) =
-                    RemoteWalletInfo::parse_path(path.to_string())?;
-                if let Some(derivation) = &self.derivation_path {
-                    let derivation = derivation.clone();
-                    derivation_path = derivation;
-                }
-                let ledger = get_ledger_from_info(remote_wallet_info)?;
-                return Ok(ledger.get_pubkey(&derivation_path)?);
-            }
-        }
-        Ok(self.keypair.pubkey())
+        self.keypair.try_pubkey()
     }
 }
 

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -14,9 +14,7 @@ use log::*;
 use num_traits::FromPrimitive;
 use serde_json::{self, json, Value};
 use solana_budget_program::budget_instruction::{self, BudgetError};
-use solana_clap_utils::{
-    input_parsers::*, input_validators::*, keypair::generate_keypair_util, ArgConstant,
-};
+use solana_clap_utils::{input_parsers::*, input_validators::*, ArgConstant};
 use solana_client::{client_error::ClientError, rpc_client::RpcClient};
 #[cfg(not(test))]
 use solana_faucet::faucet::request_airdrop_transaction;
@@ -91,17 +89,6 @@ impl std::ops::Deref for KeypairEq {
     type Target = Keypair;
     fn deref(&self) -> &Self::Target {
         &self.0
-    }
-}
-
-pub fn signer_from_matches(
-    name: &str,
-    matches: &ArgMatches<'_>,
-) -> Result<Option<Box<dyn KeypairUtil>>, Box<dyn error::Error>> {
-    if let Some(location) = matches.value_of(name) {
-        generate_keypair_util(matches, location, name).map(Some)
-    } else {
-        Ok(None)
     }
 }
 
@@ -620,7 +607,7 @@ pub fn parse_command(matches: &ArgMatches<'_>) -> Result<CliCommandInfo, Box<dyn
             let sign_only = matches.is_present(SIGN_ONLY_ARG.name);
             let blockhash_query = BlockhashQuery::new_from_matches(&matches);
             let nonce_account = pubkey_of(&matches, NONCE_ARG.name);
-            let nonce_authority = signer_from_matches(NONCE_AUTHORITY_ARG.name, &matches)?;
+            let nonce_authority = signer_of(NONCE_AUTHORITY_ARG.name, &matches)?;
 
             Ok(CliCommandInfo {
                 command: CliCommand::Pay(PayCommand {
@@ -684,9 +671,9 @@ pub fn parse_command(matches: &ArgMatches<'_>) -> Result<CliCommandInfo, Box<dyn
             let sign_only = matches.is_present(SIGN_ONLY_ARG.name);
             let blockhash_query = BlockhashQuery::new_from_matches(matches);
             let nonce_account = pubkey_of(&matches, NONCE_ARG.name);
-            let nonce_authority = signer_from_matches(NONCE_AUTHORITY_ARG.name, &matches)?;
-            let fee_payer = signer_from_matches(FEE_PAYER_ARG.name, &matches)?;
-            let from = signer_from_matches("from", &matches)?;
+            let nonce_authority = signer_of(NONCE_AUTHORITY_ARG.name, &matches)?;
+            let fee_payer = signer_of(FEE_PAYER_ARG.name, &matches)?;
+            let from = signer_of("from", &matches)?;
             Ok(CliCommandInfo {
                 command: CliCommand::Transfer {
                     lamports,

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -67,8 +67,8 @@ pub fn fee_payer_arg<'a, 'b>() -> Arg<'a, 'b> {
     Arg::with_name(FEE_PAYER_ARG.name)
         .long(FEE_PAYER_ARG.long)
         .takes_value(true)
-        .value_name("KEYPAIR or PUBKEY")
-        .validator(is_pubkey_or_keypair_or_ask_keyword)
+        .value_name("KEYPAIR or PUBKEY or REMOTE WALLET PATH")
+        .validator(is_valid_signer)
         .help(FEE_PAYER_ARG.help)
 }
 
@@ -1988,7 +1988,7 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                         .index(1)
                         .value_name("PUBKEY")
                         .takes_value(true)
-                        .validator(is_pubkey_or_keypair)
+                        .validator(is_valid_signer)
                         .help("The public key of the balance to check"),
                 )
                 .arg(
@@ -2197,8 +2197,8 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                     Arg::with_name("from")
                         .long("from")
                         .takes_value(true)
-                        .value_name("KEYPAIR or PUBKEY")
-                        .validator(is_pubkey_or_keypair_or_ask_keyword)
+                        .value_name("KEYPAIR or PUBKEY or REMOTE WALLET PATH")
+                        .validator(is_valid_signer)
                         .help("Source account of funds (if different from client local account)"),
                 )
                 .offline_args()

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -1237,6 +1237,10 @@ fn process_transfer(
 
     let nonce_authority = nonce_authority.unwrap_or_else(|| config.keypair.as_ref());
     let fee_payer = fee_payer.unwrap_or_else(|| config.keypair.as_ref());
+    let mut signers = vec![fee_payer];
+    if *fee_payer != *from {
+        signers.push(from)
+    }
     let mut tx = if let Some(nonce_account) = &nonce_account {
         Transaction::new_signed_with_nonce(
             ixs,
@@ -1250,7 +1254,7 @@ fn process_transfer(
         Transaction::new_signed_with_payer(
             ixs,
             Some(&fee_payer.pubkey()),
-            &[fee_payer.as_ref(), from.as_ref()],
+            &signers,
             recent_blockhash,
         )
     };

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -2546,64 +2546,6 @@ mod tests {
             }
         );
 
-        // Test Pay Subcommand w/ signer
-        let key1 = Pubkey::new_rand();
-        let sig1 = Keypair::new().sign_message(&[0u8]);
-        let signer1 = format!("{}={}", key1, sig1);
-        let test_pay = test_commands.clone().get_matches_from(vec![
-            "test",
-            "pay",
-            &pubkey_string,
-            "50",
-            "--blockhash",
-            &blockhash_string,
-            "--signer",
-            &signer1,
-        ]);
-        assert_eq!(
-            parse_command(&test_pay).unwrap(),
-            CliCommandInfo {
-                command: CliCommand::Pay(PayCommand {
-                    lamports: 50_000_000_000,
-                    to: pubkey,
-                    blockhash_query: BlockhashQuery::FeeCalculator(blockhash),
-                    signers: Some(vec![(key1, sig1)]),
-                    ..PayCommand::default()
-                }),
-                require_keypair: true
-            }
-        );
-
-        // Test Pay Subcommand w/ signers
-        let key2 = Pubkey::new_rand();
-        let sig2 = Keypair::new().sign_message(&[1u8]);
-        let signer2 = format!("{}={}", key2, sig2);
-        let test_pay = test_commands.clone().get_matches_from(vec![
-            "test",
-            "pay",
-            &pubkey_string,
-            "50",
-            "--blockhash",
-            &blockhash_string,
-            "--signer",
-            &signer1,
-            "--signer",
-            &signer2,
-        ]);
-        assert_eq!(
-            parse_command(&test_pay).unwrap(),
-            CliCommandInfo {
-                command: CliCommand::Pay(PayCommand {
-                    lamports: 50_000_000_000,
-                    to: pubkey,
-                    blockhash_query: BlockhashQuery::FeeCalculator(blockhash),
-                    signers: Some(vec![(key1, sig1), (key2, sig2)]),
-                    ..PayCommand::default()
-                }),
-                require_keypair: true
-            }
-        );
-
         // Test Pay Subcommand w/ Blockhash
         let test_pay = test_commands.clone().get_matches_from(vec![
             "test",

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -744,7 +744,7 @@ pub fn process_ping(
         last_blockhash = recent_blockhash;
 
         let transaction =
-            system_transaction::transfer(&config.keypair, &to, lamports, recent_blockhash);
+            system_transaction::transfer(config.keypair.as_ref(), &to, lamports, recent_blockhash);
         check_account_for_fee(
             rpc_client,
             &config.keypair.pubkey(),

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -4,9 +4,7 @@ use console::style;
 use solana_clap_utils::{
     input_parsers::derivation_of,
     input_validators::{is_derivation, is_url},
-    keypair::{
-        generate_keypair_util, ASK_SEED_PHRASE_ARG, SKIP_SEED_PHRASE_VALIDATION_ARG,
-    },
+    keypair::{generate_keypair_util, ASK_SEED_PHRASE_ARG, SKIP_SEED_PHRASE_VALIDATION_ARG},
 };
 use solana_cli::{
     cli::{app, parse_command, process_command, CliCommandInfo, CliConfig, CliError},

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -105,25 +105,23 @@ pub fn parse_args(matches: &ArgMatches<'_>) -> Result<CliConfig, Box<dyn error::
             matches.value_of("keypair").unwrap()
         } else if config.keypair_path != "" {
             &config.keypair_path
-        } else {
-            if let Some(path) = &*DEFAULT_USER_KEYPAIR {
-                if !std::path::Path::new(&CliConfig::default_keypair_path()).exists() {
-                    return Err(CliError::KeypairFileNotFound(format!(
-                        "Generate a new keypair at {} with `solana-keygen new`",
-                        path
-                    ))
-                    .into());
-                }
-                path
-            } else {
+        } else if let Some(path) = &*DEFAULT_USER_KEYPAIR {
+            if !std::path::Path::new(&CliConfig::default_keypair_path()).exists() {
                 return Err(CliError::KeypairFileNotFound(format!(
-                    "Generate a new keypair with `solana-keygen new`"
+                    "Generate a new keypair at {} with `solana-keygen new`",
+                    path
                 ))
                 .into());
             }
+            path
+        } else {
+            return Err(CliError::KeypairFileNotFound(
+                "Generate a new keypair with `solana-keygen new`".to_string(),
+            )
+            .into());
         };
 
-        let keypair = generate_keypair_util(matches, path.clone(), "keypair")?;
+        let keypair = generate_keypair_util(matches, path, "keypair")?;
         (keypair, Some(path.to_string()))
     } else {
         let default = CliConfig::default();

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -5,8 +5,7 @@ use solana_clap_utils::{
     input_parsers::derivation_of,
     input_validators::{is_derivation, is_url},
     keypair::{
-        self, keypair_input, KeypairWithSource, ASK_SEED_PHRASE_ARG,
-        SKIP_SEED_PHRASE_VALIDATION_ARG,
+        generate_keypair_util, ASK_SEED_PHRASE_ARG, SKIP_SEED_PHRASE_VALIDATION_ARG,
     },
 };
 use solana_cli::{
@@ -14,7 +13,6 @@ use solana_cli::{
     display::{println_name_value, println_name_value_or},
 };
 use solana_cli_config::config::{Config, CONFIG_FILE, DEFAULT_USER_KEYPAIR};
-use solana_sdk::signature::read_keypair_file;
 
 use std::error;
 
@@ -110,8 +108,8 @@ pub fn parse_args(matches: &ArgMatches<'_>) -> Result<CliConfig, Box<dyn error::
         } else if config.keypair_path != "" {
             &config.keypair_path
         } else {
-            if let Some(path) = DEFAULT_USER_KEYPAIR {
-                if !std::path::Path::new(&default_keypair_path).exists() {
+            if let Some(path) = &*DEFAULT_USER_KEYPAIR {
+                if !std::path::Path::new(&CliConfig::default_keypair_path()).exists() {
                     return Err(CliError::KeypairFileNotFound(format!(
                         "Generate a new keypair at {} with `solana-keygen new`",
                         path
@@ -127,7 +125,7 @@ pub fn parse_args(matches: &ArgMatches<'_>) -> Result<CliConfig, Box<dyn error::
             }
         };
 
-        let keypair = generate_keypair_util(path.clone(), "keypair")?;
+        let keypair = generate_keypair_util(matches, path.clone(), "keypair")?;
         (keypair, Some(path.to_string()))
     } else {
         let default = CliConfig::default();

--- a/cli/src/nonce.rs
+++ b/cli/src/nonce.rs
@@ -348,7 +348,7 @@ pub fn process_authorize_nonce_account(
     let mut tx = Transaction::new_signed_with_payer(
         vec![ix],
         Some(&config.keypair.pubkey()),
-        &[&config.keypair, nonce_authority],
+        &[config.keypair.as_ref(), nonce_authority],
         recent_blockhash,
     );
     check_account_for_fee(
@@ -357,8 +357,8 @@ pub fn process_authorize_nonce_account(
         &fee_calculator,
         &tx.message,
     )?;
-    let result =
-        rpc_client.send_and_confirm_transaction(&mut tx, &[&config.keypair, nonce_authority]);
+    let result = rpc_client
+        .send_and_confirm_transaction(&mut tx, &[config.keypair.as_ref(), nonce_authority]);
     log_instruction_custom_error::<NonceError>(result)
 }
 
@@ -428,9 +428,9 @@ pub fn process_create_nonce_account(
     let (recent_blockhash, fee_calculator) = rpc_client.get_recent_blockhash()?;
 
     let signers = if nonce_account_pubkey != config.keypair.pubkey() {
-        vec![&config.keypair, nonce_account] // both must sign if `from` and `to` differ
+        vec![config.keypair.as_ref(), nonce_account] // both must sign if `from` and `to` differ
     } else {
-        vec![&config.keypair] // when stake_account == config.keypair and there's a seed, we only need one signature
+        vec![config.keypair.as_ref()] // when stake_account == config.keypair and there's a seed, we only need one signature
     };
 
     let mut tx = Transaction::new_signed_with_payer(
@@ -495,7 +495,7 @@ pub fn process_new_nonce(
     let mut tx = Transaction::new_signed_with_payer(
         vec![ix],
         Some(&config.keypair.pubkey()),
-        &[&config.keypair, nonce_authority],
+        &[config.keypair.as_ref(), nonce_authority],
         recent_blockhash,
     );
     check_account_for_fee(
@@ -504,8 +504,8 @@ pub fn process_new_nonce(
         &fee_calculator,
         &tx.message,
     )?;
-    let result =
-        rpc_client.send_and_confirm_transaction(&mut tx, &[&config.keypair, nonce_authority]);
+    let result = rpc_client
+        .send_and_confirm_transaction(&mut tx, &[config.keypair.as_ref(), nonce_authority]);
     log_instruction_custom_error::<SystemError>(result)
 }
 
@@ -580,7 +580,7 @@ pub fn process_withdraw_from_nonce_account(
     let mut tx = Transaction::new_signed_with_payer(
         vec![ix],
         Some(&config.keypair.pubkey()),
-        &[&config.keypair, nonce_authority],
+        &[config.keypair.as_ref(), nonce_authority],
         recent_blockhash,
     );
     check_account_for_fee(
@@ -589,8 +589,8 @@ pub fn process_withdraw_from_nonce_account(
         &fee_calculator,
         &tx.message,
     )?;
-    let result =
-        rpc_client.send_and_confirm_transaction(&mut tx, &[&config.keypair, nonce_authority]);
+    let result = rpc_client
+        .send_and_confirm_transaction(&mut tx, &[config.keypair.as_ref(), nonce_authority]);
     log_instruction_custom_error::<NonceError>(result)
 }
 

--- a/cli/src/nonce.rs
+++ b/cli/src/nonce.rs
@@ -65,8 +65,8 @@ pub fn nonce_authority_arg<'a, 'b>() -> Arg<'a, 'b> {
     Arg::with_name(NONCE_AUTHORITY_ARG.name)
         .long(NONCE_AUTHORITY_ARG.long)
         .takes_value(true)
-        .value_name("KEYPAIR or PUBKEY")
-        .validator(is_pubkey_or_keypair_or_ask_keyword)
+        .value_name("KEYPAIR or PUBKEY or REMOTE WALLET PATH")
+        .validator(is_valid_signer)
         .help(NONCE_AUTHORITY_ARG.help)
 }
 

--- a/cli/src/nonce.rs
+++ b/cli/src/nonce.rs
@@ -1,7 +1,6 @@
 use crate::cli::{
     build_balance_message, check_account_for_fee, check_unique_pubkeys,
-    log_instruction_custom_error, signer_from_matches, CliCommand, CliCommandInfo, CliConfig,
-    CliError, ProcessResult,
+    log_instruction_custom_error, CliCommand, CliCommandInfo, CliConfig, CliError, ProcessResult,
 };
 use crate::offline::BLOCKHASH_ARG;
 use clap::{App, Arg, ArgMatches, SubCommand};
@@ -218,7 +217,7 @@ impl NonceSubCommands for App<'_, '_> {
 pub fn parse_authorize_nonce_account(matches: &ArgMatches<'_>) -> Result<CliCommandInfo, CliError> {
     let nonce_account = pubkey_of(matches, "nonce_account_keypair").unwrap();
     let new_authority = pubkey_of(matches, "new_authority").unwrap();
-    let nonce_authority = signer_from_matches(NONCE_AUTHORITY_ARG.name, matches)?;
+    let nonce_authority = signer_of(NONCE_AUTHORITY_ARG.name, matches)?;
 
     Ok(CliCommandInfo {
         command: CliCommand::AuthorizeNonceAccount {
@@ -231,7 +230,7 @@ pub fn parse_authorize_nonce_account(matches: &ArgMatches<'_>) -> Result<CliComm
 }
 
 pub fn parse_nonce_create_account(matches: &ArgMatches<'_>) -> Result<CliCommandInfo, CliError> {
-    let nonce_account = signer_from_matches("nonce_account_keypair", matches)?.unwrap();
+    let nonce_account = signer_of("nonce_account_keypair", matches)?.unwrap();
     let seed = matches.value_of("seed").map(|s| s.to_string());
     let lamports = lamports_of_sol(matches, "amount").unwrap();
     let nonce_authority = pubkey_of(matches, NONCE_AUTHORITY_ARG.name);
@@ -258,7 +257,7 @@ pub fn parse_get_nonce(matches: &ArgMatches<'_>) -> Result<CliCommandInfo, CliEr
 
 pub fn parse_new_nonce(matches: &ArgMatches<'_>) -> Result<CliCommandInfo, CliError> {
     let nonce_account = pubkey_of(matches, "nonce_account_keypair").unwrap();
-    let nonce_authority = signer_from_matches(NONCE_AUTHORITY_ARG.name, matches)?;
+    let nonce_authority = signer_of(NONCE_AUTHORITY_ARG.name, matches)?;
 
     Ok(CliCommandInfo {
         command: CliCommand::NewNonce {
@@ -288,7 +287,7 @@ pub fn parse_withdraw_from_nonce_account(
     let nonce_account = pubkey_of(matches, "nonce_account_keypair").unwrap();
     let destination_account_pubkey = pubkey_of(matches, "destination_account_pubkey").unwrap();
     let lamports = lamports_of_sol(matches, "amount").unwrap();
-    let nonce_authority = signer_from_matches(NONCE_AUTHORITY_ARG.name, matches)?;
+    let nonce_authority = signer_of(NONCE_AUTHORITY_ARG.name, matches)?;
 
     Ok(CliCommandInfo {
         command: CliCommand::WithdrawFromNonceAccount {

--- a/cli/src/nonce.rs
+++ b/cli/src/nonce.rs
@@ -593,9 +593,10 @@ mod tests {
         account::Account,
         hash::hash,
         nonce_state::{Meta as NonceMeta, NonceState},
-        signature::{read_keypair_file, write_keypair},
+        signature::{read_keypair_file, write_keypair, Keypair},
         system_program,
     };
+    use std::rc::Rc;
     use tempfile::NamedTempFile;
 
     fn make_tmp_file() -> (String, NamedTempFile) {
@@ -669,7 +670,7 @@ mod tests {
             parse_command(&test_create_nonce_account).unwrap(),
             CliCommandInfo {
                 command: CliCommand::CreateNonceAccount {
-                    nonce_account: read_keypair_file(&keypair_file).unwrap().into(),
+                    nonce_account: Rc::new(read_keypair_file(&keypair_file).unwrap().into()),
                     seed: None,
                     nonce_authority: None,
                     lamports: 50_000_000_000,
@@ -691,7 +692,7 @@ mod tests {
             parse_command(&test_create_nonce_account).unwrap(),
             CliCommandInfo {
                 command: CliCommand::CreateNonceAccount {
-                    nonce_account: read_keypair_file(&keypair_file).unwrap().into(),
+                    nonce_account: Rc::new(read_keypair_file(&keypair_file).unwrap().into()),
                     seed: None,
                     nonce_authority: Some(
                         read_keypair_file(&authority_keypair_file).unwrap().pubkey()

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -2122,40 +2122,6 @@ mod tests {
             }
         );
 
-        // Test Delegate Subcommand w/ absentee fee-payer
-        let sig = fee_payer_keypair.sign_message(&[0u8]);
-        let signer = format!("{}={}", fee_payer_string, sig);
-        let test_delegate_stake = test_commands.clone().get_matches_from(vec![
-            "test",
-            "delegate-stake",
-            &stake_account_string,
-            &vote_account_string,
-            "--fee-payer",
-            &fee_payer_string,
-            "--blockhash",
-            &blockhash_string,
-            "--signer",
-            &signer,
-        ]);
-        assert_eq!(
-            parse_command(&test_delegate_stake).unwrap(),
-            CliCommandInfo {
-                command: CliCommand::DelegateStake {
-                    stake_account_pubkey,
-                    vote_account_pubkey,
-                    stake_authority: None,
-                    force: false,
-                    sign_only: false,
-                    signers: Some(vec![(fee_payer_pubkey, sig)]),
-                    blockhash_query: BlockhashQuery::FeeCalculator(blockhash),
-                    nonce_account: None,
-                    nonce_authority: None,
-                    fee_payer: Some(fee_payer_pubkey.into()),
-                },
-                require_keypair: false
-            }
-        );
-
         // Test WithdrawStake Subcommand
         let test_withdraw_stake = test_commands.clone().get_matches_from(vec![
             "test",
@@ -2448,37 +2414,6 @@ mod tests {
                     fee_payer: Some(read_keypair_file(&fee_payer_keypair_file).unwrap().into()),
                 },
                 require_keypair: true
-            }
-        );
-
-        // Test Deactivate Subcommand w/ absentee fee-payer
-        let sig = fee_payer_keypair.sign_message(&[0u8]);
-        let signer = format!("{}={}", fee_payer_string, sig);
-        let test_deactivate_stake = test_commands.clone().get_matches_from(vec![
-            "test",
-            "deactivate-stake",
-            &stake_account_string,
-            "--fee-payer",
-            &fee_payer_string,
-            "--blockhash",
-            &blockhash_string,
-            "--signer",
-            &signer,
-        ]);
-        assert_eq!(
-            parse_command(&test_deactivate_stake).unwrap(),
-            CliCommandInfo {
-                command: CliCommand::DeactivateStake {
-                    stake_account_pubkey,
-                    stake_authority: None,
-                    sign_only: false,
-                    signers: Some(vec![(fee_payer_pubkey, sig)]),
-                    blockhash_query: BlockhashQuery::FeeCalculator(blockhash),
-                    nonce_account: None,
-                    nonce_authority: None,
-                    fee_payer: Some(fee_payer_pubkey.into()),
-                },
-                require_keypair: false
             }
         );
 

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -1,8 +1,8 @@
 use crate::{
     cli::{
         build_balance_message, check_account_for_fee, check_unique_pubkeys, fee_payer_arg,
-        log_instruction_custom_error, nonce_authority_arg, return_signers, signer_from_matches,
-        CliCommand, CliCommandInfo, CliConfig, CliError, ProcessResult, FEE_PAYER_ARG,
+        log_instruction_custom_error, nonce_authority_arg, return_signers, CliCommand,
+        CliCommandInfo, CliConfig, CliError, ProcessResult, FEE_PAYER_ARG,
     },
     nonce::{check_nonce_account, nonce_arg, NONCE_ARG, NONCE_AUTHORITY_ARG},
     offline::*,
@@ -423,10 +423,10 @@ pub fn parse_stake_create_account(matches: &ArgMatches<'_>) -> Result<CliCommand
     let blockhash_query = BlockhashQuery::new_from_matches(matches);
     let require_keypair = signers.is_none();
     let nonce_account = pubkey_of(&matches, NONCE_ARG.name);
-    let nonce_authority = signer_from_matches(NONCE_AUTHORITY_ARG.name, matches)?;
-    let fee_payer = signer_from_matches(FEE_PAYER_ARG.name, matches)?;
-    let from = signer_from_matches("from", matches)?;
-    let stake_account = signer_from_matches("stake_account", matches)?.unwrap();
+    let nonce_authority = signer_of(NONCE_AUTHORITY_ARG.name, matches)?;
+    let fee_payer = signer_of(FEE_PAYER_ARG.name, matches)?;
+    let from = signer_of("from", matches)?;
+    let stake_account = signer_of("stake_account", matches)?.unwrap();
 
     Ok(CliCommandInfo {
         command: CliCommand::CreateStakeAccount {
@@ -460,9 +460,9 @@ pub fn parse_stake_delegate_stake(matches: &ArgMatches<'_>) -> Result<CliCommand
     let blockhash_query = BlockhashQuery::new_from_matches(matches);
     let require_keypair = signers.is_none();
     let nonce_account = pubkey_of(&matches, NONCE_ARG.name);
-    let stake_authority = signer_from_matches(STAKE_AUTHORITY_ARG.name, matches)?;
-    let nonce_authority = signer_from_matches(NONCE_AUTHORITY_ARG.name, matches)?;
-    let fee_payer = signer_from_matches(FEE_PAYER_ARG.name, matches)?;
+    let stake_authority = signer_of(STAKE_AUTHORITY_ARG.name, matches)?;
+    let nonce_authority = signer_of(NONCE_AUTHORITY_ARG.name, matches)?;
+    let fee_payer = signer_of(FEE_PAYER_ARG.name, matches)?;
 
     Ok(CliCommandInfo {
         command: CliCommand::DelegateStake {
@@ -491,11 +491,11 @@ pub fn parse_stake_authorize(
         StakeAuthorize::Withdrawer => WITHDRAW_AUTHORITY_ARG.name,
     };
     let sign_only = matches.is_present(SIGN_ONLY_ARG.name);
-    let authority = signer_from_matches(authority_flag, matches)?;
+    let authority = signer_of(authority_flag, matches)?;
     let blockhash_query = BlockhashQuery::new_from_matches(matches);
     let nonce_account = pubkey_of(&matches, NONCE_ARG.name);
-    let nonce_authority = signer_from_matches(NONCE_AUTHORITY_ARG.name, matches)?;
-    let fee_payer = signer_from_matches(FEE_PAYER_ARG.name, matches)?;
+    let nonce_authority = signer_of(NONCE_AUTHORITY_ARG.name, matches)?;
+    let fee_payer = signer_of(FEE_PAYER_ARG.name, matches)?;
 
     Ok(CliCommandInfo {
         command: CliCommand::StakeAuthorize {
@@ -515,7 +515,7 @@ pub fn parse_stake_authorize(
 
 pub fn parse_split_stake(matches: &ArgMatches<'_>) -> Result<CliCommandInfo, CliError> {
     let stake_account_pubkey = pubkey_of(matches, "stake_account_pubkey").unwrap();
-    let split_stake_account = signer_from_matches("split_stake_account", matches)?.unwrap();
+    let split_stake_account = signer_of("split_stake_account", matches)?.unwrap();
     let lamports = lamports_of_sol(matches, "amount").unwrap();
     let seed = matches.value_of("seed").map(|s| s.to_string());
 
@@ -524,9 +524,9 @@ pub fn parse_split_stake(matches: &ArgMatches<'_>) -> Result<CliCommandInfo, Cli
     let blockhash_query = BlockhashQuery::new_from_matches(matches);
     let require_keypair = signers.is_none();
     let nonce_account = pubkey_of(&matches, NONCE_ARG.name);
-    let stake_authority = signer_from_matches(STAKE_AUTHORITY_ARG.name, matches)?;
-    let nonce_authority = signer_from_matches(NONCE_AUTHORITY_ARG.name, matches)?;
-    let fee_payer = signer_from_matches(FEE_PAYER_ARG.name, matches)?;
+    let stake_authority = signer_of(STAKE_AUTHORITY_ARG.name, matches)?;
+    let nonce_authority = signer_of(NONCE_AUTHORITY_ARG.name, matches)?;
+    let fee_payer = signer_of(FEE_PAYER_ARG.name, matches)?;
 
     Ok(CliCommandInfo {
         command: CliCommand::SplitStake {
@@ -552,9 +552,9 @@ pub fn parse_stake_deactivate_stake(matches: &ArgMatches<'_>) -> Result<CliComma
     let blockhash_query = BlockhashQuery::new_from_matches(matches);
     let require_keypair = signers.is_none();
     let nonce_account = pubkey_of(&matches, NONCE_ARG.name);
-    let stake_authority = signer_from_matches(STAKE_AUTHORITY_ARG.name, matches)?;
-    let nonce_authority = signer_from_matches(NONCE_AUTHORITY_ARG.name, matches)?;
-    let fee_payer = signer_from_matches(FEE_PAYER_ARG.name, matches)?;
+    let stake_authority = signer_of(STAKE_AUTHORITY_ARG.name, matches)?;
+    let nonce_authority = signer_of(NONCE_AUTHORITY_ARG.name, matches)?;
+    let fee_payer = signer_of(FEE_PAYER_ARG.name, matches)?;
 
     Ok(CliCommandInfo {
         command: CliCommand::DeactivateStake {
@@ -579,9 +579,9 @@ pub fn parse_stake_withdraw_stake(matches: &ArgMatches<'_>) -> Result<CliCommand
     let blockhash_query = BlockhashQuery::new_from_matches(matches);
     let require_keypair = signers.is_none();
     let nonce_account = pubkey_of(&matches, NONCE_ARG.name);
-    let nonce_authority = signer_from_matches(NONCE_AUTHORITY_ARG.name, matches)?;
-    let withdraw_authority = signer_from_matches(WITHDRAW_AUTHORITY_ARG.name, matches)?;
-    let fee_payer = signer_from_matches(FEE_PAYER_ARG.name, matches)?;
+    let nonce_authority = signer_of(NONCE_AUTHORITY_ARG.name, matches)?;
+    let withdraw_authority = signer_of(WITHDRAW_AUTHORITY_ARG.name, matches)?;
+    let fee_payer = signer_of(FEE_PAYER_ARG.name, matches)?;
 
     Ok(CliCommandInfo {
         command: CliCommand::WithdrawStake {
@@ -611,9 +611,9 @@ pub fn parse_stake_set_lockup(matches: &ArgMatches<'_>) -> Result<CliCommandInfo
     let require_keypair = signers.is_none();
     let nonce_account = pubkey_of(&matches, NONCE_ARG.name);
 
-    let custodian = signer_from_matches("custodian", matches)?;
-    let nonce_authority = signer_from_matches(NONCE_AUTHORITY_ARG.name, matches)?;
-    let fee_payer = signer_from_matches(FEE_PAYER_ARG.name, matches)?;
+    let custodian = signer_of("custodian", matches)?;
+    let nonce_authority = signer_of(NONCE_AUTHORITY_ARG.name, matches)?;
+    let fee_payer = signer_of(FEE_PAYER_ARG.name, matches)?;
 
     Ok(CliCommandInfo {
         command: CliCommand::StakeSetLockup {

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -1399,8 +1399,11 @@ mod tests {
     use solana_sdk::{
         fee_calculator::FeeCalculator,
         hash::Hash,
-        signature::{keypair_from_seed, read_keypair_file, write_keypair, KeypairUtil, Presigner},
+        signature::{
+            keypair_from_seed, read_keypair_file, write_keypair, Keypair, KeypairUtil, Presigner,
+        },
     };
+    use std::rc::Rc;
     use tempfile::NamedTempFile;
 
     fn make_tmp_file() -> (String, NamedTempFile) {
@@ -1748,7 +1751,7 @@ mod tests {
             parse_command(&test_create_stake_account).unwrap(),
             CliCommandInfo {
                 command: CliCommand::CreateStakeAccount {
-                    stake_account: stake_account_keypair.into(),
+                    stake_account: Rc::new(stake_account_keypair.into()),
                     seed: None,
                     staker: Some(authorized),
                     withdrawer: Some(authorized),
@@ -1786,7 +1789,7 @@ mod tests {
             parse_command(&test_create_stake_account2).unwrap(),
             CliCommandInfo {
                 command: CliCommand::CreateStakeAccount {
-                    stake_account: read_keypair_file(&keypair_file).unwrap().into(),
+                    stake_account: Rc::new(read_keypair_file(&keypair_file).unwrap().into()),
                     seed: None,
                     staker: None,
                     withdrawer: None,
@@ -1836,7 +1839,7 @@ mod tests {
             parse_command(&test_create_stake_account2).unwrap(),
             CliCommandInfo {
                 command: CliCommand::CreateStakeAccount {
-                    stake_account: read_keypair_file(&keypair_file).unwrap().into(),
+                    stake_account: Rc::new(read_keypair_file(&keypair_file).unwrap().into()),
                     seed: None,
                     staker: None,
                     withdrawer: None,
@@ -2073,8 +2076,6 @@ mod tests {
         let (fee_payer_keypair_file, mut fee_payer_tmp_file) = make_tmp_file();
         let fee_payer_keypair = Keypair::new();
         write_keypair(&fee_payer_keypair, fee_payer_tmp_file.as_file_mut()).unwrap();
-        let fee_payer_pubkey = fee_payer_keypair.pubkey();
-        let fee_payer_string = fee_payer_pubkey.to_string();
         let test_delegate_stake = test_commands.clone().get_matches_from(vec![
             "test",
             "delegate-stake",
@@ -2421,9 +2422,11 @@ mod tests {
                     blockhash_query: BlockhashQuery::default(),
                     nonce_account: None,
                     nonce_authority: None,
-                    split_stake_account: read_keypair_file(&split_stake_account_keypair_file)
-                        .unwrap()
-                        .into(),
+                    split_stake_account: Rc::new(
+                        read_keypair_file(&split_stake_account_keypair_file)
+                            .unwrap()
+                            .into(),
+                    ),
                     seed: None,
                     lamports: 50_000_000_000,
                     fee_payer: None,
@@ -2479,9 +2482,11 @@ mod tests {
                     blockhash_query: BlockhashQuery::FeeCalculator(nonce_hash),
                     nonce_account: Some(nonce_account.into()),
                     nonce_authority: Some(Presigner::new(&nonce_auth_pubkey, &nonce_sig).into()),
-                    split_stake_account: read_keypair_file(&split_stake_account_keypair_file)
-                        .unwrap()
-                        .into(),
+                    split_stake_account: Rc::new(
+                        read_keypair_file(&split_stake_account_keypair_file)
+                            .unwrap()
+                            .into(),
+                    ),
                     seed: None,
                     lamports: 50_000_000_000,
                     fee_payer: Some(Presigner::new(&nonce_auth_pubkey, &nonce_sig).into()),

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -45,8 +45,8 @@ fn stake_authority_arg<'a, 'b>() -> Arg<'a, 'b> {
     Arg::with_name(STAKE_AUTHORITY_ARG.name)
         .long(STAKE_AUTHORITY_ARG.long)
         .takes_value(true)
-        .value_name("KEYPAIR or PUBKEY")
-        .validator(is_pubkey_or_keypair_or_ask_keyword)
+        .value_name("KEYPAIR or PUBKEY or REMOTE WALLET PATH")
+        .validator(is_valid_signer)
         .help(STAKE_AUTHORITY_ARG.help)
 }
 
@@ -54,8 +54,8 @@ fn withdraw_authority_arg<'a, 'b>() -> Arg<'a, 'b> {
     Arg::with_name(WITHDRAW_AUTHORITY_ARG.name)
         .long(WITHDRAW_AUTHORITY_ARG.long)
         .takes_value(true)
-        .value_name("KEYPAIR or PUBKEY")
-        .validator(is_pubkey_or_keypair_or_ask_keyword)
+        .value_name("KEYPAIR or PUBKEY or REMOTE WALLET PATH")
+        .validator(is_valid_signer)
         .help(WITHDRAW_AUTHORITY_ARG.help)
 }
 
@@ -74,7 +74,7 @@ impl StakeSubCommands for App<'_, '_> {
                         .value_name("STAKE ACCOUNT")
                         .takes_value(true)
                         .required(true)
-                        .validator(is_pubkey_or_keypair_or_ask_keyword)
+                        .validator(is_valid_signer)
                         .help("Signing authority of the stake address to fund")
                 )
                 .arg(
@@ -136,8 +136,8 @@ impl StakeSubCommands for App<'_, '_> {
                     Arg::with_name("from")
                         .long("from")
                         .takes_value(true)
-                        .value_name("KEYPAIR or PUBKEY")
-                        .validator(is_pubkey_or_keypair_or_ask_keyword)
+                        .value_name("KEYPAIR or PUBKEY or REMOTE WALLET PATH")
+                        .validator(is_valid_signer)
                         .help("Source account of funds (if different from client local account)"),
                 )
                 .offline_args()
@@ -367,8 +367,8 @@ impl StakeSubCommands for App<'_, '_> {
                     Arg::with_name("custodian")
                         .long("custodian")
                         .takes_value(true)
-                        .value_name("KEYPAIR or PUBKEY")
-                        .validator(is_pubkey_or_keypair_or_ask_keyword)
+                        .value_name("KEYPAIR or PUBKEY or REMOTE WALLET PATH")
+                        .validator(is_valid_signer)
                         .help("Public key of signing custodian (defaults to cli config pubkey)")
                 )
                 .offline_args()

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -1581,7 +1581,7 @@ mod tests {
                     authority: None,
                     sign_only: false,
                     blockhash_query: BlockhashQuery::FeeCalculator(blockhash),
-                    nonce_account: None,
+                    nonce_account: Some(nonce_account),
                     nonce_authority: Some(Presigner::new(&pubkey2, &sig2).into()),
                     fee_payer: Some(Presigner::new(&pubkey, &sig).into()),
                 },
@@ -2061,7 +2061,7 @@ mod tests {
             &key1.to_string(),
             "--nonce",
             &nonce_account.to_string(),
-            "--nonce_auhtority",
+            "--nonce-authority",
             &key2.to_string(),
         ]);
         assert_eq!(
@@ -2364,7 +2364,7 @@ mod tests {
             &key1.to_string(),
             "--nonce",
             &nonce_account.to_string(),
-            "--nonce-account",
+            "--nonce-authority",
             &key2.to_string(),
         ]);
         assert_eq!(
@@ -2375,7 +2375,7 @@ mod tests {
                     stake_authority: None,
                     sign_only: false,
                     blockhash_query: BlockhashQuery::FeeCalculator(blockhash),
-                    nonce_account: None,
+                    nonce_account: Some(nonce_account),
                     nonce_authority: Some(Presigner::new(&key2, &sig2).into()),
                     fee_payer: Some(Presigner::new(&key1, &sig1).into()),
                 },

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -671,6 +671,16 @@ pub fn process_create_stake_account(
     fee_payer: Option<&dyn KeypairUtil>,
     from: Option<&dyn KeypairUtil>,
 ) -> ProcessResult {
+    // Offline derived address creation currently is not possible
+    // https://github.com/solana-labs/solana/pull/8252
+    if seed.is_some() && sign_only {
+        return Err(CliError::BadParameter(
+            "Offline stake account creation with derived addresses are not yet supported"
+                .to_string(),
+        )
+        .into());
+    }
+
     let stake_account_address = if let Some(seed) = seed {
         create_address_with_seed(&stake_account.pubkey(), &seed, &solana_stake_program::id())?
     } else {

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -445,7 +445,6 @@ pub fn parse_stake_create_account(matches: &ArgMatches<'_>) -> Result<CliCommand
             },
             lamports,
             sign_only,
-            signers,
             blockhash_query,
             nonce_account,
             nonce_authority,
@@ -479,7 +478,6 @@ pub fn parse_stake_delegate_stake(matches: &ArgMatches<'_>) -> Result<CliCommand
             stake_authority,
             force,
             sign_only,
-            signers,
             blockhash_query,
             nonce_account,
             nonce_authority,
@@ -500,7 +498,6 @@ pub fn parse_stake_authorize(
         StakeAuthorize::Withdrawer => WITHDRAW_AUTHORITY_ARG.name,
     };
     let sign_only = matches.is_present(SIGN_ONLY_ARG.name);
-    let signers = pubkeys_sigs_of(&matches, SIGNER_ARG.name);
     let authority =
         signer_from_matches(authority_flag, matches)?;
     let blockhash_query = BlockhashQuery::new_from_matches(matches);
@@ -517,7 +514,6 @@ pub fn parse_stake_authorize(
             stake_authorize,
             authority,
             sign_only,
-            signers,
             blockhash_query,
             nonce_account,
             nonce_authority,
@@ -551,7 +547,6 @@ pub fn parse_split_stake(matches: &ArgMatches<'_>) -> Result<CliCommandInfo, Cli
             stake_account_pubkey,
             stake_authority,
             sign_only,
-            signers,
             blockhash_query,
             nonce_account,
             nonce_authority,
@@ -583,7 +578,6 @@ pub fn parse_stake_deactivate_stake(matches: &ArgMatches<'_>) -> Result<CliComma
             stake_account_pubkey,
             stake_authority,
             sign_only,
-            signers,
             blockhash_query,
             nonce_account,
             nonce_authority,
@@ -615,7 +609,6 @@ pub fn parse_stake_withdraw_stake(matches: &ArgMatches<'_>) -> Result<CliCommand
             lamports,
             withdraw_authority,
             sign_only,
-            signers,
             blockhash_query,
             nonce_account,
             nonce_authority,
@@ -653,7 +646,6 @@ pub fn parse_stake_set_lockup(matches: &ArgMatches<'_>) -> Result<CliCommandInfo
             },
             custodian,
             sign_only,
-            signers,
             blockhash_query,
             nonce_account,
             nonce_authority,
@@ -694,7 +686,6 @@ pub fn process_create_stake_account(
     lockup: &Lockup,
     lamports: u64,
     sign_only: bool,
-    signers: Option<&Vec<(Pubkey, Signature)>>,
     blockhash_query: &BlockhashQuery,
     nonce_account: Option<&Pubkey>,
     nonce_authority: Option<&dyn KeypairUtil>,
@@ -790,9 +781,6 @@ pub fn process_create_stake_account(
             recent_blockhash,
         )
     };
-    if let Some(signers) = signers {
-        replace_signatures(&mut tx, &signers)?;
-    }
     if sign_only {
         return_signers(&tx)
     } else {
@@ -820,7 +808,6 @@ pub fn process_stake_authorize(
     stake_authorize: StakeAuthorize,
     authority: Option<&dyn KeypairUtil>,
     sign_only: bool,
-    signers: &Option<Vec<(Pubkey, Signature)>>,
     blockhash_query: &BlockhashQuery,
     nonce_account: Option<Pubkey>,
     nonce_authority: Option<&dyn KeypairUtil>,
@@ -859,9 +846,6 @@ pub fn process_stake_authorize(
             recent_blockhash,
         )
     };
-    if let Some(signers) = signers {
-        replace_signatures(&mut tx, &signers)?;
-    }
     if sign_only {
         return_signers(&tx)
     } else {
@@ -887,7 +871,6 @@ pub fn process_deactivate_stake_account(
     stake_account_pubkey: &Pubkey,
     stake_authority: Option<&dyn KeypairUtil>,
     sign_only: bool,
-    signers: &Option<Vec<(Pubkey, Signature)>>,
     blockhash_query: &BlockhashQuery,
     nonce_account: Option<Pubkey>,
     nonce_authority: Option<&dyn KeypairUtil>,
@@ -919,9 +902,6 @@ pub fn process_deactivate_stake_account(
             recent_blockhash,
         )
     };
-    if let Some(signers) = signers {
-        replace_signatures(&mut tx, &signers)?;
-    }
     if sign_only {
         return_signers(&tx)
     } else {
@@ -949,7 +929,6 @@ pub fn process_withdraw_stake(
     lamports: u64,
     withdraw_authority: Option<&dyn KeypairUtil>,
     sign_only: bool,
-    signers: Option<&Vec<(Pubkey, Signature)>>,
     blockhash_query: &BlockhashQuery,
     nonce_account: Option<&Pubkey>,
     nonce_authority: Option<&dyn KeypairUtil>,
@@ -985,9 +964,6 @@ pub fn process_withdraw_stake(
             recent_blockhash,
         )
     };
-    if let Some(signers) = signers {
-        replace_signatures(&mut tx, &signers)?;
-    }
     if sign_only {
         return_signers(&tx)
     } else {
@@ -1013,7 +989,6 @@ pub fn process_split_stake(
     stake_account_pubkey: &Pubkey,
     stake_authority: Option<&dyn KeypairUtil>,
     sign_only: bool,
-    signers: &Option<Vec<(Pubkey, Signature)>>,
     blockhash_query: &BlockhashQuery,
     nonce_account: Option<Pubkey>,
     nonce_authority: Option<&dyn KeypairUtil>,
@@ -1127,9 +1102,6 @@ pub fn process_split_stake(
             recent_blockhash,
         )
     };
-    if let Some(signers) = signers {
-        replace_signatures(&mut tx, &signers)?;
-    }
     if sign_only {
         return_signers(&tx)
     } else {
@@ -1156,7 +1128,6 @@ pub fn process_stake_set_lockup(
     lockup: &mut Lockup,
     custodian: Option<&dyn KeypairUtil>,
     sign_only: bool,
-    signers: &Option<Vec<(Pubkey, Signature)>>,
     blockhash_query: &BlockhashQuery,
     nonce_account: Option<Pubkey>,
     nonce_authority: Option<&dyn KeypairUtil>,
@@ -1193,9 +1164,6 @@ pub fn process_stake_set_lockup(
             recent_blockhash,
         )
     };
-    if let Some(signers) = signers {
-        replace_signatures(&mut tx, &signers)?;
-    }
     if sign_only {
         return_signers(&tx)
     } else {
@@ -1427,9 +1395,6 @@ pub fn process_delegate_stake(
             recent_blockhash,
         )
     };
-    if let Some(signers) = signers {
-        replace_signatures(&mut tx, &signers)?;
-    }
     if sign_only {
         return_signers(&tx)
     } else {
@@ -1493,7 +1458,6 @@ mod tests {
                     stake_authorize,
                     authority: None,
                     sign_only: false,
-                    signers: None,
                     blockhash_query: BlockhashQuery::default(),
                     nonce_account: None,
                     nonce_authority: None,
@@ -1520,7 +1484,6 @@ mod tests {
                     stake_authorize,
                     authority: Some(read_keypair_file(&authority_keypair_file).unwrap().into()),
                     sign_only: false,
-                    signers: None,
                     blockhash_query: BlockhashQuery::default(),
                     nonce_account: None,
                     nonce_authority: None,
@@ -1550,7 +1513,6 @@ mod tests {
                     stake_authorize,
                     authority: None,
                     sign_only: true,
-                    signers: None,
                     blockhash_query: BlockhashQuery::None(blockhash, FeeCalculator::default()),
                     nonce_account: None,
                     nonce_authority: None,
@@ -1585,7 +1547,6 @@ mod tests {
                     stake_authorize,
                     authority: None,
                     sign_only: false,
-                    signers: Some(vec![(keypair.pubkey(), sig)]),
                     blockhash_query: BlockhashQuery::FeeCalculator(blockhash),
                     nonce_account: None,
                     nonce_authority: None,
@@ -1627,7 +1588,6 @@ mod tests {
                     stake_authorize,
                     authority: None,
                     sign_only: false,
-                    signers: Some(vec![(keypair.pubkey(), sig), (keypair2.pubkey(), sig2),]),
                     blockhash_query: BlockhashQuery::FeeCalculator(blockhash),
                     nonce_account: None,
                     nonce_authority: Some(Presigner::new(&pubkey2, &sig2).into()),
@@ -1654,7 +1614,6 @@ mod tests {
                     stake_authorize,
                     authority: None,
                     sign_only: false,
-                    signers: None,
                     blockhash_query: BlockhashQuery::FeeCalculator(blockhash),
                     nonce_account: None,
                     nonce_authority: None,
@@ -1690,7 +1649,6 @@ mod tests {
                     stake_authorize,
                     authority: None,
                     sign_only: false,
-                    signers: None,
                     blockhash_query: BlockhashQuery::FeeCalculator(blockhash),
                     nonce_account: Some(nonce_account_pubkey),
                     nonce_authority: Some(nonce_authority_keypair.into()),
@@ -1722,7 +1680,6 @@ mod tests {
                     stake_authorize,
                     authority: None,
                     sign_only: false,
-                    signers: None,
                     blockhash_query: BlockhashQuery::All,
                     nonce_account: None,
                     nonce_authority: None,
@@ -1755,7 +1712,6 @@ mod tests {
                     stake_authorize,
                     authority: None,
                     sign_only: false,
-                    signers: Some(vec![(fee_payer_pubkey, sig)]),
                     blockhash_query: BlockhashQuery::FeeCalculator(blockhash),
                     nonce_account: None,
                     nonce_authority: None,
@@ -1824,7 +1780,6 @@ mod tests {
                     },
                     lamports: 50_000_000_000,
                     sign_only: false,
-                    signers: None,
                     blockhash_query: BlockhashQuery::All,
                     nonce_account: None,
                     nonce_authority: None,
@@ -1859,7 +1814,6 @@ mod tests {
                     lockup: Lockup::default(),
                     lamports: 50_000_000_000,
                     sign_only: false,
-                    signers: None,
                     blockhash_query: BlockhashQuery::All,
                     nonce_account: None,
                     nonce_authority: None,
@@ -1910,7 +1864,6 @@ mod tests {
                     lockup: Lockup::default(),
                     lamports: 50_000_000_000,
                     sign_only: false,
-                    signers: Some(vec![(offline_pubkey, offline_sig)]),
                     blockhash_query: BlockhashQuery::FeeCalculator(nonce_hash),
                     nonce_account: Some(nonce_account),
                     nonce_authority: Some(Presigner::new(&offline_pubkey, &offline_sig).into()),
@@ -1939,7 +1892,6 @@ mod tests {
                     stake_authority: None,
                     force: false,
                     sign_only: false,
-                    signers: None,
                     blockhash_query: BlockhashQuery::default(),
                     nonce_account: None,
                     nonce_authority: None,
@@ -1973,7 +1925,6 @@ mod tests {
                     ),
                     force: false,
                     sign_only: false,
-                    signers: None,
                     blockhash_query: BlockhashQuery::default(),
                     nonce_account: None,
                     nonce_authority: None,
@@ -2000,7 +1951,6 @@ mod tests {
                     stake_authority: None,
                     force: true,
                     sign_only: false,
-                    signers: None,
                     blockhash_query: BlockhashQuery::default(),
                     nonce_account: None,
                     nonce_authority: None,
@@ -2030,7 +1980,6 @@ mod tests {
                     stake_authority: None,
                     force: false,
                     sign_only: false,
-                    signers: None,
                     blockhash_query: BlockhashQuery::FeeCalculator(blockhash),
                     nonce_account: None,
                     nonce_authority: None,
@@ -2058,7 +2007,6 @@ mod tests {
                     stake_authority: None,
                     force: false,
                     sign_only: true,
-                    signers: None,
                     blockhash_query: BlockhashQuery::None(blockhash, FeeCalculator::default()),
                     nonce_account: None,
                     nonce_authority: None,
@@ -2093,7 +2041,6 @@ mod tests {
                     stake_authority: None,
                     force: false,
                     sign_only: false,
-                    signers: Some(vec![(key1, sig1)]),
                     blockhash_query: BlockhashQuery::FeeCalculator(blockhash),
                     nonce_account: None,
                     nonce_authority: None,
@@ -2166,7 +2113,6 @@ mod tests {
                     stake_authority: None,
                     force: false,
                     sign_only: false,
-                    signers: None,
                     blockhash_query: BlockhashQuery::All,
                     nonce_account: None,
                     nonce_authority: None,
@@ -2228,7 +2174,6 @@ mod tests {
                     lamports: 42_000_000_000,
                     withdraw_authority: None,
                     sign_only: false,
-                    signers: None,
                     blockhash_query: BlockhashQuery::All,
                     nonce_account: None,
                     nonce_authority: None,
@@ -2262,7 +2207,6 @@ mod tests {
                             .into()
                     ),
                     sign_only: false,
-                    signers: None,
                     blockhash_query: BlockhashQuery::All,
                     nonce_account: None,
                     nonce_authority: None,
@@ -2306,7 +2250,6 @@ mod tests {
                             .into()
                     ),
                     sign_only: false,
-                    signers: Some(vec![(offline_pubkey, offline_sig)]),
                     blockhash_query: BlockhashQuery::FeeCalculator(nonce_hash),
                     nonce_account: Some(nonce_account),
                     nonce_authority: Some(Presigner::new(&offline_pubkey, &offline_sig).into()),
@@ -2329,7 +2272,6 @@ mod tests {
                     stake_account_pubkey,
                     stake_authority: None,
                     sign_only: false,
-                    signers: None,
                     blockhash_query: BlockhashQuery::default(),
                     nonce_account: None,
                     nonce_authority: None,
@@ -2358,7 +2300,6 @@ mod tests {
                             .into()
                     ),
                     sign_only: false,
-                    signers: None,
                     blockhash_query: BlockhashQuery::default(),
                     nonce_account: None,
                     nonce_authority: None,
@@ -2385,7 +2326,6 @@ mod tests {
                     stake_account_pubkey,
                     stake_authority: None,
                     sign_only: false,
-                    signers: None,
                     blockhash_query: BlockhashQuery::FeeCalculator(blockhash),
                     nonce_account: None,
                     nonce_authority: None,
@@ -2410,7 +2350,6 @@ mod tests {
                     stake_account_pubkey,
                     stake_authority: None,
                     sign_only: true,
-                    signers: None,
                     blockhash_query: BlockhashQuery::None(blockhash, FeeCalculator::default()),
                     nonce_account: None,
                     nonce_authority: None,
@@ -2442,7 +2381,6 @@ mod tests {
                     stake_account_pubkey,
                     stake_authority: None,
                     sign_only: false,
-                    signers: Some(vec![(key1, sig1)]),
                     blockhash_query: BlockhashQuery::FeeCalculator(blockhash),
                     nonce_account: None,
                     nonce_authority: None,
@@ -2480,7 +2418,6 @@ mod tests {
                     stake_account_pubkey,
                     stake_authority: None,
                     sign_only: false,
-                    signers: Some(vec![(key1, sig1), (key2, sig2)]),
                     blockhash_query: BlockhashQuery::FeeCalculator(blockhash),
                     nonce_account: None,
                     nonce_authority: Some(Presigner::new(&key2, &sig2).into()),
@@ -2505,7 +2442,6 @@ mod tests {
                     stake_account_pubkey,
                     stake_authority: None,
                     sign_only: false,
-                    signers: None,
                     blockhash_query: BlockhashQuery::All,
                     nonce_account: None,
                     nonce_authority: None,
@@ -2568,7 +2504,6 @@ mod tests {
                     stake_account_pubkey: stake_account_keypair.pubkey(),
                     stake_authority: None,
                     sign_only: false,
-                    signers: None,
                     blockhash_query: BlockhashQuery::default(),
                     nonce_account: None,
                     nonce_authority: None,
@@ -2627,10 +2562,6 @@ mod tests {
                     stake_account_pubkey: stake_account_keypair.pubkey(),
                     stake_authority: Some(Presigner::new(&stake_auth_pubkey, &stake_sig).into()),
                     sign_only: false,
-                    signers: Some(vec![
-                        (nonce_auth_pubkey, nonce_sig),
-                        (stake_auth_pubkey, stake_sig)
-                    ]),
                     blockhash_query: BlockhashQuery::FeeCalculator(nonce_hash),
                     nonce_account: Some(nonce_account.into()),
                     nonce_authority: Some(Presigner::new(&nonce_auth_pubkey, &nonce_sig).into()),

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -423,14 +423,10 @@ pub fn parse_stake_create_account(matches: &ArgMatches<'_>) -> Result<CliCommand
     let blockhash_query = BlockhashQuery::new_from_matches(matches);
     let require_keypair = signers.is_none();
     let nonce_account = pubkey_of(&matches, NONCE_ARG.name);
-    let nonce_authority =
-        signer_from_matches(NONCE_AUTHORITY_ARG.name, matches)?;
-    let fee_payer =
-        signer_from_matches(FEE_PAYER_ARG.name, matches)?;
+    let nonce_authority = signer_from_matches(NONCE_AUTHORITY_ARG.name, matches)?;
+    let fee_payer = signer_from_matches(FEE_PAYER_ARG.name, matches)?;
     let from = signer_from_matches("from", matches)?;
-    let stake_account =
-        signer_from_matches("stake_account", matches)?
-            .unwrap();
+    let stake_account = signer_from_matches("stake_account", matches)?.unwrap();
 
     Ok(CliCommandInfo {
         command: CliCommand::CreateStakeAccount {
@@ -464,12 +460,9 @@ pub fn parse_stake_delegate_stake(matches: &ArgMatches<'_>) -> Result<CliCommand
     let blockhash_query = BlockhashQuery::new_from_matches(matches);
     let require_keypair = signers.is_none();
     let nonce_account = pubkey_of(&matches, NONCE_ARG.name);
-    let stake_authority =
-        signer_from_matches(STAKE_AUTHORITY_ARG.name, matches)?;
-    let nonce_authority =
-        signer_from_matches(NONCE_AUTHORITY_ARG.name, matches)?;
-    let fee_payer =
-        signer_from_matches(FEE_PAYER_ARG.name, matches)?;
+    let stake_authority = signer_from_matches(STAKE_AUTHORITY_ARG.name, matches)?;
+    let nonce_authority = signer_from_matches(NONCE_AUTHORITY_ARG.name, matches)?;
+    let fee_payer = signer_from_matches(FEE_PAYER_ARG.name, matches)?;
 
     Ok(CliCommandInfo {
         command: CliCommand::DelegateStake {
@@ -498,14 +491,11 @@ pub fn parse_stake_authorize(
         StakeAuthorize::Withdrawer => WITHDRAW_AUTHORITY_ARG.name,
     };
     let sign_only = matches.is_present(SIGN_ONLY_ARG.name);
-    let authority =
-        signer_from_matches(authority_flag, matches)?;
+    let authority = signer_from_matches(authority_flag, matches)?;
     let blockhash_query = BlockhashQuery::new_from_matches(matches);
     let nonce_account = pubkey_of(&matches, NONCE_ARG.name);
-    let nonce_authority =
-        signer_from_matches(NONCE_AUTHORITY_ARG.name, matches)?;
-    let fee_payer =
-        signer_from_matches(FEE_PAYER_ARG.name, matches)?;
+    let nonce_authority = signer_from_matches(NONCE_AUTHORITY_ARG.name, matches)?;
+    let fee_payer = signer_from_matches(FEE_PAYER_ARG.name, matches)?;
 
     Ok(CliCommandInfo {
         command: CliCommand::StakeAuthorize {
@@ -525,8 +515,7 @@ pub fn parse_stake_authorize(
 
 pub fn parse_split_stake(matches: &ArgMatches<'_>) -> Result<CliCommandInfo, CliError> {
     let stake_account_pubkey = pubkey_of(matches, "stake_account_pubkey").unwrap();
-    let split_stake_account =
-        signer_from_matches("split_stake_account", matches)?.unwrap();
+    let split_stake_account = signer_from_matches("split_stake_account", matches)?.unwrap();
     let lamports = lamports_of_sol(matches, "amount").unwrap();
     let seed = matches.value_of("seed").map(|s| s.to_string());
 
@@ -535,12 +524,9 @@ pub fn parse_split_stake(matches: &ArgMatches<'_>) -> Result<CliCommandInfo, Cli
     let blockhash_query = BlockhashQuery::new_from_matches(matches);
     let require_keypair = signers.is_none();
     let nonce_account = pubkey_of(&matches, NONCE_ARG.name);
-    let stake_authority =
-        signer_from_matches(STAKE_AUTHORITY_ARG.name, matches)?;
-    let nonce_authority =
-        signer_from_matches(NONCE_AUTHORITY_ARG.name, matches)?;
-    let fee_payer =
-        signer_from_matches(FEE_PAYER_ARG.name, matches)?;
+    let stake_authority = signer_from_matches(STAKE_AUTHORITY_ARG.name, matches)?;
+    let nonce_authority = signer_from_matches(NONCE_AUTHORITY_ARG.name, matches)?;
+    let fee_payer = signer_from_matches(FEE_PAYER_ARG.name, matches)?;
 
     Ok(CliCommandInfo {
         command: CliCommand::SplitStake {
@@ -566,12 +552,9 @@ pub fn parse_stake_deactivate_stake(matches: &ArgMatches<'_>) -> Result<CliComma
     let blockhash_query = BlockhashQuery::new_from_matches(matches);
     let require_keypair = signers.is_none();
     let nonce_account = pubkey_of(&matches, NONCE_ARG.name);
-    let stake_authority =
-        signer_from_matches(STAKE_AUTHORITY_ARG.name, matches)?;
-    let nonce_authority =
-        signer_from_matches(NONCE_AUTHORITY_ARG.name, matches)?;
-    let fee_payer =
-        signer_from_matches(FEE_PAYER_ARG.name, matches)?;
+    let stake_authority = signer_from_matches(STAKE_AUTHORITY_ARG.name, matches)?;
+    let nonce_authority = signer_from_matches(NONCE_AUTHORITY_ARG.name, matches)?;
+    let fee_payer = signer_from_matches(FEE_PAYER_ARG.name, matches)?;
 
     Ok(CliCommandInfo {
         command: CliCommand::DeactivateStake {
@@ -596,11 +579,9 @@ pub fn parse_stake_withdraw_stake(matches: &ArgMatches<'_>) -> Result<CliCommand
     let blockhash_query = BlockhashQuery::new_from_matches(matches);
     let require_keypair = signers.is_none();
     let nonce_account = pubkey_of(&matches, NONCE_ARG.name);
-    let nonce_authority =
-        signer_from_matches(NONCE_AUTHORITY_ARG.name, matches)?;
+    let nonce_authority = signer_from_matches(NONCE_AUTHORITY_ARG.name, matches)?;
     let withdraw_authority = signer_from_matches(WITHDRAW_AUTHORITY_ARG.name, matches)?;
-    let fee_payer =
-        signer_from_matches(FEE_PAYER_ARG.name, matches)?;
+    let fee_payer = signer_from_matches(FEE_PAYER_ARG.name, matches)?;
 
     Ok(CliCommandInfo {
         command: CliCommand::WithdrawStake {
@@ -631,10 +612,8 @@ pub fn parse_stake_set_lockup(matches: &ArgMatches<'_>) -> Result<CliCommandInfo
     let nonce_account = pubkey_of(&matches, NONCE_ARG.name);
 
     let custodian = signer_from_matches("custodian", matches)?;
-    let nonce_authority =
-        signer_from_matches(NONCE_AUTHORITY_ARG.name, matches)?;
-    let fee_payer =
-        signer_from_matches(FEE_PAYER_ARG.name, matches)?;
+    let nonce_authority = signer_from_matches(NONCE_AUTHORITY_ARG.name, matches)?;
+    let fee_payer = signer_from_matches(FEE_PAYER_ARG.name, matches)?;
 
     Ok(CliCommandInfo {
         command: CliCommand::StakeSetLockup {

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -701,16 +701,6 @@ pub fn process_create_stake_account(
     fee_payer: Option<&dyn KeypairUtil>,
     from: Option<&dyn KeypairUtil>,
 ) -> ProcessResult {
-    // Offline derived address creation currently is not possible
-    // https://github.com/solana-labs/solana/pull/8252
-    if seed.is_some() && (sign_only || signers.is_some()) {
-        return Err(CliError::BadParameter(
-            "Offline stake account creation with derived addresses are not yet supported"
-                .to_string(),
-        )
-        .into());
-    }
-
     let stake_account_address = if let Some(seed) = seed {
         create_address_with_seed(&stake_account.pubkey(), &seed, &solana_stake_program::id())?
     } else {

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -898,7 +898,7 @@ pub fn process_stake_authorize(
             &fee_calculator,
             &tx.message,
         )?;
-        let result = rpc_client.send_and_confirm_transaction(&mut tx, &[&config.keypair]);
+        let result = rpc_client.send_and_confirm_transaction(&mut tx, &[config.keypair.as_ref()]);
         log_instruction_custom_error::<StakeError>(result)
     }
 }
@@ -962,7 +962,7 @@ pub fn process_deactivate_stake_account(
             &fee_calculator,
             &tx.message,
         )?;
-        let result = rpc_client.send_and_confirm_transaction(&mut tx, &[&config.keypair]);
+        let result = rpc_client.send_and_confirm_transaction(&mut tx, &[config.keypair.as_ref()]);
         log_instruction_custom_error::<StakeError>(result)
     }
 }
@@ -1032,7 +1032,7 @@ pub fn process_withdraw_stake(
             &fee_calculator,
             &tx.message,
         )?;
-        let result = rpc_client.send_and_confirm_transaction(&mut tx, &[&config.keypair]);
+        let result = rpc_client.send_and_confirm_transaction(&mut tx, &[config.keypair.as_ref()]);
         log_instruction_custom_error::<SystemError>(result)
     }
 }
@@ -1180,7 +1180,7 @@ pub fn process_split_stake(
             &fee_calculator,
             &tx.message,
         )?;
-        let result = rpc_client.send_and_confirm_transaction(&mut tx, &[&config.keypair]);
+        let result = rpc_client.send_and_confirm_transaction(&mut tx, &[config.keypair.as_ref()]);
         log_instruction_custom_error::<StakeError>(result)
     }
 }
@@ -1248,7 +1248,7 @@ pub fn process_stake_set_lockup(
             &fee_calculator,
             &tx.message,
         )?;
-        let result = rpc_client.send_and_confirm_transaction(&mut tx, &[&config.keypair]);
+        let result = rpc_client.send_and_confirm_transaction(&mut tx, &[config.keypair.as_ref()]);
         log_instruction_custom_error::<StakeError>(result)
     }
 }
@@ -1487,7 +1487,7 @@ pub fn process_delegate_stake(
             &fee_calculator,
             &tx.message,
         )?;
-        let result = rpc_client.send_and_confirm_transaction(&mut tx, &[&config.keypair]);
+        let result = rpc_client.send_and_confirm_transaction(&mut tx, &[config.keypair.as_ref()]);
         log_instruction_custom_error::<StakeError>(result)
     }
 }

--- a/cli/src/storage.rs
+++ b/cli/src/storage.rs
@@ -192,7 +192,7 @@ pub fn process_create_storage_account(
     let (recent_blockhash, fee_calculator) = rpc_client.get_recent_blockhash()?;
 
     let mut tx = Transaction::new_signed_instructions(
-        &[&config.keypair, &storage_account],
+        &[config.keypair.as_ref(), storage_account],
         ixs,
         recent_blockhash,
     );
@@ -202,8 +202,8 @@ pub fn process_create_storage_account(
         &fee_calculator,
         &tx.message,
     )?;
-    let result =
-        rpc_client.send_and_confirm_transaction(&mut tx, &[&config.keypair, &storage_account]);
+    let result = rpc_client
+        .send_and_confirm_transaction(&mut tx, &[config.keypair.as_ref(), storage_account]);
     log_instruction_custom_error::<SystemError>(result)
 }
 
@@ -217,7 +217,7 @@ pub fn process_claim_storage_reward(
 
     let instruction =
         storage_instruction::claim_reward(node_account_pubkey, storage_account_pubkey);
-    let signers = [&config.keypair];
+    let signers = [config.keypair.as_ref()];
     let message = Message::new_with_payer(vec![instruction], Some(&signers[0].pubkey()));
 
     let mut tx = Transaction::new(&signers, message, recent_blockhash);

--- a/cli/src/validator_info.rs
+++ b/cli/src/validator_info.rs
@@ -301,7 +301,7 @@ pub fn process_set_validator_info(
         .unwrap_or(0);
 
     let keys = vec![(id(), false), (config.keypair.pubkey(), true)];
-    let (message, signers): (Message, Vec<&Keypair>) = if balance == 0 {
+    let (message, signers): (Message, Vec<&dyn KeypairUtil>) = if balance == 0 {
         if info_pubkey != info_keypair.pubkey() {
             println!(
                 "Account {:?} does not exist. Generating new keypair...",
@@ -327,7 +327,7 @@ pub fn process_set_validator_info(
             keys,
             &validator_info,
         )]);
-        let signers = vec![&config.keypair, &info_keypair];
+        let signers = vec![config.keypair.as_ref(), &info_keypair];
         let message = Message::new(instructions);
         (message, signers)
     } else {
@@ -343,7 +343,7 @@ pub fn process_set_validator_info(
             &validator_info,
         )];
         let message = Message::new_with_payer(instructions, Some(&config.keypair.pubkey()));
-        let signers = vec![&config.keypair];
+        let signers = vec![config.keypair.as_ref()];
         (message, signers)
     };
 

--- a/cli/src/vote.rs
+++ b/cli/src/vote.rs
@@ -311,9 +311,9 @@ pub fn process_create_vote_account(
     let (recent_blockhash, fee_calculator) = rpc_client.get_recent_blockhash()?;
 
     let signers = if vote_account_pubkey != config.keypair.pubkey() {
-        vec![&config.keypair, vote_account] // both must sign if `from` and `to` differ
+        vec![config.keypair.as_ref(), vote_account] // both must sign if `from` and `to` differ
     } else {
-        vec![&config.keypair] // when stake_account == config.keypair and there's a seed, we only need one signature
+        vec![config.keypair.as_ref()] // when stake_account == config.keypair and there's a seed, we only need one signature
     };
 
     let mut tx = Transaction::new_signed_instructions(&signers, ixs, recent_blockhash);
@@ -349,7 +349,7 @@ pub fn process_vote_authorize(
     let mut tx = Transaction::new_signed_with_payer(
         ixs,
         Some(&config.keypair.pubkey()),
-        &[&config.keypair],
+        &[config.keypair.as_ref()],
         recent_blockhash,
     );
     check_account_for_fee(
@@ -358,7 +358,7 @@ pub fn process_vote_authorize(
         &fee_calculator,
         &tx.message,
     )?;
-    let result = rpc_client.send_and_confirm_transaction(&mut tx, &[&config.keypair]);
+    let result = rpc_client.send_and_confirm_transaction(&mut tx, &[config.keypair.as_ref()]);
     log_instruction_custom_error::<VoteError>(result)
 }
 
@@ -383,7 +383,7 @@ pub fn process_vote_update_validator(
     let mut tx = Transaction::new_signed_with_payer(
         ixs,
         Some(&config.keypair.pubkey()),
-        &[&config.keypair, authorized_voter],
+        &[config.keypair.as_ref(), authorized_voter],
         recent_blockhash,
     );
     check_account_for_fee(
@@ -392,7 +392,7 @@ pub fn process_vote_update_validator(
         &fee_calculator,
         &tx.message,
     )?;
-    let result = rpc_client.send_and_confirm_transaction(&mut tx, &[&config.keypair]);
+    let result = rpc_client.send_and_confirm_transaction(&mut tx, &[config.keypair.as_ref()]);
     log_instruction_custom_error::<VoteError>(result)
 }
 

--- a/cli/tests/nonce.rs
+++ b/cli/tests/nonce.rs
@@ -1,6 +1,4 @@
-use solana_cli::cli::{
-    process_command, request_and_confirm_airdrop, CliCommand, CliConfig, SigningAuthority,
-};
+use solana_cli::cli::{process_command, request_and_confirm_airdrop, CliCommand, CliConfig};
 use solana_client::rpc_client::RpcClient;
 use solana_faucet::faucet::run_local_faucet;
 use solana_sdk::{
@@ -15,6 +13,7 @@ use std::sync::mpsc::channel;
 
 #[cfg(test)]
 use solana_core::validator::new_validator_for_tests;
+use std::rc::Rc;
 use std::thread::sleep;
 use std::time::Duration;
 
@@ -141,7 +140,7 @@ fn test_nonce_with_authority() {
     remove_dir_all(ledger_path).unwrap();
 }
 
-fn read_keypair_from_option(keypair_file: &Option<&str>) -> Option<SigningAuthority> {
+fn read_keypair_from_option(keypair_file: &Option<&str>) -> Option<Box<dyn KeypairUtil>> {
     keypair_file.map(|akf| read_keypair_file(&akf).unwrap().into())
 }
 
@@ -172,10 +171,9 @@ fn full_battery_tests(
 
     // Create nonce account
     config_payer.command = CliCommand::CreateNonceAccount {
-        nonce_account: read_keypair_file(&nonce_keypair_file).unwrap().into(),
+        nonce_account: Rc::new(read_keypair_file(&nonce_keypair_file).unwrap().into()),
         seed,
-        nonce_authority: read_keypair_from_option(&authority_keypair_file)
-            .map(|na: SigningAuthority| na.pubkey()),
+        nonce_authority: read_keypair_from_option(&authority_keypair_file),
         lamports: 1000,
     };
 

--- a/cli/tests/nonce.rs
+++ b/cli/tests/nonce.rs
@@ -4,7 +4,7 @@ use solana_faucet::faucet::run_local_faucet;
 use solana_sdk::{
     hash::Hash,
     pubkey::Pubkey,
-    signature::{read_keypair_file, write_keypair, Keypair, KeypairUtil},
+    signature::{keypair_from_seed, read_keypair_file, write_keypair, Keypair, KeypairUtil},
     system_instruction::create_address_with_seed,
     system_program,
 };
@@ -50,11 +50,13 @@ fn test_nonce() {
     config_payer.json_rpc_url =
         format!("http://{}:{}", leader_data.rpc.ip(), leader_data.rpc.port());
 
+    let keypair = keypair_from_seed(&[0u8; 32]).unwrap();
+    let (keypair_file, mut tmp_file) = make_tmp_file();
+    write_keypair(&keypair, tmp_file.as_file_mut()).unwrap();
     let mut config_nonce = CliConfig::default();
+    config_nonce.keypair = keypair.into();
     config_nonce.json_rpc_url =
         format!("http://{}:{}", leader_data.rpc.ip(), leader_data.rpc.port());
-    let (keypair_file, mut tmp_file) = make_tmp_file();
-    write_keypair(&config_nonce.keypair, tmp_file.as_file_mut()).unwrap();
 
     full_battery_tests(
         &rpc_client,
@@ -83,11 +85,13 @@ fn test_nonce_with_seed() {
     config_payer.json_rpc_url =
         format!("http://{}:{}", leader_data.rpc.ip(), leader_data.rpc.port());
 
+    let keypair = keypair_from_seed(&[0u8; 32]).unwrap();
+    let (keypair_file, mut tmp_file) = make_tmp_file();
+    write_keypair(&keypair, tmp_file.as_file_mut()).unwrap();
     let mut config_nonce = CliConfig::default();
+    config_nonce.keypair = keypair.into();
     config_nonce.json_rpc_url =
         format!("http://{}:{}", leader_data.rpc.ip(), leader_data.rpc.port());
-    let (keypair_file, mut tmp_file) = make_tmp_file();
-    write_keypair(&config_nonce.keypair, tmp_file.as_file_mut()).unwrap();
 
     full_battery_tests(
         &rpc_client,
@@ -116,11 +120,12 @@ fn test_nonce_with_authority() {
     config_payer.json_rpc_url =
         format!("http://{}:{}", leader_data.rpc.ip(), leader_data.rpc.port());
 
+    let nonce_keypair = keypair_from_seed(&[0u8; 32]).unwrap();
+    let (nonce_keypair_file, mut tmp_file) = make_tmp_file();
+    write_keypair(&nonce_keypair, tmp_file.as_file_mut()).unwrap();
     let mut config_nonce = CliConfig::default();
     config_nonce.json_rpc_url =
         format!("http://{}:{}", leader_data.rpc.ip(), leader_data.rpc.port());
-    let (nonce_keypair_file, mut tmp_file) = make_tmp_file();
-    write_keypair(&config_nonce.keypair, tmp_file.as_file_mut()).unwrap();
 
     let nonce_authority = Keypair::new();
     let (authority_keypair_file, mut tmp_file2) = make_tmp_file();
@@ -166,14 +171,14 @@ fn full_battery_tests(
         create_address_with_seed(&config_nonce.keypair.pubkey(), seed, &system_program::id())
             .unwrap()
     } else {
-        config_nonce.keypair.pubkey()
+        read_keypair_file(&nonce_keypair_file).unwrap().pubkey()
     };
 
     // Create nonce account
     config_payer.command = CliCommand::CreateNonceAccount {
         nonce_account: Rc::new(read_keypair_file(&nonce_keypair_file).unwrap().into()),
         seed,
-        nonce_authority: read_keypair_from_option(&authority_keypair_file),
+        nonce_authority: read_keypair_from_option(&authority_keypair_file).map(|k| k.pubkey()),
         lamports: 1000,
     };
 

--- a/cli/tests/pay.rs
+++ b/cli/tests/pay.rs
@@ -18,6 +18,7 @@ use std::sync::mpsc::channel;
 
 #[cfg(test)]
 use solana_core::validator::new_validator_for_tests;
+use std::rc::Rc;
 use std::thread::sleep;
 use std::time::Duration;
 use tempfile::NamedTempFile;
@@ -303,11 +304,10 @@ fn test_offline_pay_tx() {
     check_balance(50, &rpc_client, &config_online.keypair.pubkey());
     check_balance(0, &rpc_client, &bob_pubkey);
 
-    let (blockhash, signers) = parse_sign_only_reply_string(&sig_response);
+    let (blockhash, _signers) = parse_sign_only_reply_string(&sig_response);
     config_online.command = CliCommand::Pay(PayCommand {
         lamports: 10,
         to: bob_pubkey,
-        signers: Some(signers),
         blockhash_query: BlockhashQuery::FeeCalculator(blockhash),
         ..PayCommand::default()
     });
@@ -357,7 +357,7 @@ fn test_nonced_pay_tx() {
     let (nonce_keypair_file, mut tmp_file) = make_tmp_file();
     write_keypair(&nonce_account, tmp_file.as_file_mut()).unwrap();
     config.command = CliCommand::CreateNonceAccount {
-        nonce_account: read_keypair_file(&nonce_keypair_file).unwrap().into(),
+        nonce_account: Rc::new(read_keypair_file(&nonce_keypair_file).unwrap().into()),
         seed: None,
         nonce_authority: Some(config.keypair.pubkey()),
         lamports: minimum_nonce_balance,

--- a/cli/tests/request_airdrop.rs
+++ b/cli/tests/request_airdrop.rs
@@ -2,7 +2,6 @@ use solana_cli::cli::{process_command, CliCommand, CliConfig};
 use solana_client::rpc_client::RpcClient;
 use solana_core::validator::new_validator_for_tests;
 use solana_faucet::faucet::run_local_faucet;
-use solana_sdk::signature::KeypairUtil;
 use std::fs::remove_dir_all;
 use std::sync::mpsc::channel;
 

--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -405,10 +405,10 @@ impl RpcClient {
         })
     }
 
-    pub fn send_and_confirm_transaction<T: KeypairUtil>(
+    pub fn send_and_confirm_transaction(
         &self,
         transaction: &mut Transaction,
-        signer_keys: &[&T],
+        signer_keys: &[&dyn KeypairUtil],
     ) -> Result<String, ClientError> {
         let mut send_retries = 20;
         loop {
@@ -456,10 +456,10 @@ impl RpcClient {
         }
     }
 
-    pub fn send_and_confirm_transactions<T: KeypairUtil>(
+    pub fn send_and_confirm_transactions(
         &self,
         mut transactions: Vec<Transaction>,
-        signer_keys: &[&T],
+        signer_keys: &[&dyn KeypairUtil],
     ) -> Result<(), Box<dyn error::Error>> {
         let mut send_retries = 5;
         loop {
@@ -526,10 +526,10 @@ impl RpcClient {
         }
     }
 
-    pub fn resign_transaction<T: KeypairUtil>(
+    pub fn resign_transaction(
         &self,
         tx: &mut Transaction,
-        signer_keys: &[&T],
+        signer_keys: &[&dyn KeypairUtil],
     ) -> Result<(), ClientError> {
         let (blockhash, _fee_calculator) =
             self.get_new_blockhash(&tx.message().recent_blockhash)?;

--- a/client/src/thin_client.rs
+++ b/client/src/thin_client.rs
@@ -204,7 +204,7 @@ impl ThinClient {
     /// Retry sending a signed Transaction to the server for processing
     pub fn send_and_confirm_transaction(
         &self,
-        keypairs: &[&Keypair],
+        keypairs: &[&dyn KeypairUtil],
         transaction: &mut Transaction,
         tries: usize,
         pending_confirmations: usize,
@@ -351,7 +351,11 @@ impl Client for ThinClient {
 }
 
 impl SyncClient for ThinClient {
-    fn send_message(&self, keypairs: &[&Keypair], message: Message) -> TransportResult<Signature> {
+    fn send_message(
+        &self,
+        keypairs: &[&dyn KeypairUtil],
+        message: Message,
+    ) -> TransportResult<Signature> {
         let (blockhash, _fee_calculator) = self.get_recent_blockhash()?;
         let mut transaction = Transaction::new(&keypairs, message, blockhash);
         let signature = self.send_and_confirm_transaction(keypairs, &mut transaction, 5, 0)?;
@@ -563,7 +567,7 @@ impl AsyncClient for ThinClient {
     }
     fn async_send_message(
         &self,
-        keypairs: &[&Keypair],
+        keypairs: &[&dyn KeypairUtil],
         message: Message,
         recent_blockhash: Hash,
     ) -> io::Result<Signature> {

--- a/client/src/thin_client.rs
+++ b/client/src/thin_client.rs
@@ -17,7 +17,7 @@ use solana_sdk::{
     message::Message,
     packet::PACKET_DATA_SIZE,
     pubkey::Pubkey,
-    signature::{Keypair, KeypairUtil, Signature},
+    signature::{KeypairUtil, Signature},
     system_instruction,
     timing::duration_as_ms,
     transaction::{self, Transaction},
@@ -183,7 +183,7 @@ impl ThinClient {
     /// Retry a sending a signed Transaction to the server for processing.
     pub fn retry_transfer_until_confirmed(
         &self,
-        keypair: &Keypair,
+        keypair: &dyn KeypairUtil,
         transaction: &mut Transaction,
         tries: usize,
         min_confirmed_blocks: usize,
@@ -191,10 +191,10 @@ impl ThinClient {
         self.send_and_confirm_transaction(&[keypair], transaction, tries, min_confirmed_blocks)
     }
 
-    /// Retry sending a signed Transaction with one signing Keypair to the server for processing.
+    /// Retry sending a signed Transaction with one signing T to the server for processing.
     pub fn retry_transfer(
         &self,
-        keypair: &Keypair,
+        keypair: &dyn KeypairUtil,
         transaction: &mut Transaction,
         tries: usize,
     ) -> io::Result<Signature> {
@@ -364,7 +364,7 @@ impl SyncClient for ThinClient {
 
     fn send_instruction(
         &self,
-        keypair: &Keypair,
+        keypair: &dyn KeypairUtil,
         instruction: Instruction,
     ) -> TransportResult<Signature> {
         let message = Message::new(vec![instruction]);
@@ -374,7 +374,7 @@ impl SyncClient for ThinClient {
     fn transfer(
         &self,
         lamports: u64,
-        keypair: &Keypair,
+        keypair: &dyn KeypairUtil,
         pubkey: &Pubkey,
     ) -> TransportResult<Signature> {
         let transfer_instruction =
@@ -576,7 +576,7 @@ impl AsyncClient for ThinClient {
     }
     fn async_send_instruction(
         &self,
-        keypair: &Keypair,
+        keypair: &dyn KeypairUtil,
         instruction: Instruction,
         recent_blockhash: Hash,
     ) -> io::Result<Signature> {
@@ -586,7 +586,7 @@ impl AsyncClient for ThinClient {
     fn async_transfer(
         &self,
         lamports: u64,
-        keypair: &Keypair,
+        keypair: &dyn KeypairUtil,
         pubkey: &Pubkey,
         recent_blockhash: Hash,
     ) -> io::Result<Signature> {

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -1609,8 +1609,7 @@ pub(crate) mod tests {
             let mut entries =
                 entry::create_ticks(bank.ticks_per_slot(), hashes_per_tick, blockhash.clone());
             let last_entry_hash = entries.last().unwrap().hash;
-            let tx =
-                system_transaction::transfer(genesis_keypair, &keypair.pubkey(), 2, blockhash);
+            let tx = system_transaction::transfer(genesis_keypair, &keypair.pubkey(), 2, blockhash);
             let trailing_entry = entry::next_entry(&last_entry_hash, 1, vec![tx]);
             entries.push(trailing_entry);
             entries_to_test_shreds(entries, slot, slot.saturating_sub(1), true, 0)
@@ -1821,8 +1820,7 @@ pub(crate) mod tests {
         let success_signature = success_tx.signatures[0];
         let entry_1 = next_entry(&blockhash, 1, vec![success_tx]);
         // Failed transaction, InstructionError
-        let ix_error_tx =
-            system_transaction::transfer(keypair2, &keypair3.pubkey(), 10, blockhash);
+        let ix_error_tx = system_transaction::transfer(keypair2, &keypair3.pubkey(), 10, blockhash);
         let ix_error_signature = ix_error_tx.signatures[0];
         let entry_2 = next_entry(&entry_1.hash, 1, vec![ix_error_tx]);
         // Failed transaction

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -1493,7 +1493,7 @@ pub(crate) mod tests {
                 &bad_hash,
                 hashes_per_tick.saturating_sub(1),
                 vec![system_transaction::transfer(
-                    &genesis_keypair,
+                    genesis_keypair,
                     &keypair2.pubkey(),
                     2,
                     blockhash,
@@ -1610,7 +1610,7 @@ pub(crate) mod tests {
                 entry::create_ticks(bank.ticks_per_slot(), hashes_per_tick, blockhash.clone());
             let last_entry_hash = entries.last().unwrap().hash;
             let tx =
-                system_transaction::transfer(&genesis_keypair, &keypair.pubkey(), 2, blockhash);
+                system_transaction::transfer(genesis_keypair, &keypair.pubkey(), 2, blockhash);
             let trailing_entry = entry::next_entry(&last_entry_hash, 1, vec![tx]);
             entries.push(trailing_entry);
             entries_to_test_shreds(entries, slot, slot.saturating_sub(1), true, 0)
@@ -1817,17 +1817,17 @@ pub(crate) mod tests {
         // Generate transactions for processing
         // Successful transaction
         let success_tx =
-            system_transaction::transfer(&mint_keypair, &keypair1.pubkey(), 2, blockhash);
+            system_transaction::transfer(mint_keypair, &keypair1.pubkey(), 2, blockhash);
         let success_signature = success_tx.signatures[0];
         let entry_1 = next_entry(&blockhash, 1, vec![success_tx]);
         // Failed transaction, InstructionError
         let ix_error_tx =
-            system_transaction::transfer(&keypair2, &keypair3.pubkey(), 10, blockhash);
+            system_transaction::transfer(keypair2, &keypair3.pubkey(), 10, blockhash);
         let ix_error_signature = ix_error_tx.signatures[0];
         let entry_2 = next_entry(&entry_1.hash, 1, vec![ix_error_tx]);
         // Failed transaction
         let fail_tx =
-            system_transaction::transfer(&mint_keypair, &keypair2.pubkey(), 2, Hash::default());
+            system_transaction::transfer(mint_keypair, &keypair2.pubkey(), 2, Hash::default());
         let entry_3 = next_entry(&entry_2.hash, 1, vec![fail_tx]);
         let entries = vec![entry_1, entry_2, entry_3];
 

--- a/core/src/storage_stage.rs
+++ b/core/src/storage_stage.rs
@@ -311,7 +311,7 @@ impl StorageStage {
             );
         }
 
-        let signer_keys = vec![keypair.as_ref(), storage_keypair.as_ref()];
+        let signer_keys: Vec<&dyn KeypairUtil> = vec![keypair.as_ref(), storage_keypair.as_ref()];
         let message = Message::new_with_payer(vec![instruction], Some(&signer_keys[0].pubkey()));
         let transaction = Transaction::new(&signer_keys, message, blockhash);
         // try sending the transaction upto 5 times

--- a/core/tests/bank_forks.rs
+++ b/core/tests/bank_forks.rs
@@ -157,12 +157,12 @@ mod tests {
             |bank, mint_keypair| {
                 let key1 = Keypair::new().pubkey();
                 let tx =
-                    system_transaction::transfer(&mint_keypair, &key1, 1, bank.last_blockhash());
+                    system_transaction::transfer(mint_keypair, &key1, 1, bank.last_blockhash());
                 assert_eq!(bank.process_transaction(&tx), Ok(()));
 
                 let key2 = Keypair::new().pubkey();
                 let tx =
-                    system_transaction::transfer(&mint_keypair, &key2, 0, bank.last_blockhash());
+                    system_transaction::transfer(mint_keypair, &key2, 0, bank.last_blockhash());
                 assert_eq!(bank.process_transaction(&tx), Ok(()));
 
                 bank.freeze();
@@ -226,7 +226,7 @@ mod tests {
             );
             let slot = bank.slot();
             let key1 = Keypair::new().pubkey();
-            let tx = system_transaction::transfer(&mint_keypair, &key1, 1, genesis_config.hash());
+            let tx = system_transaction::transfer(mint_keypair, &key1, 1, genesis_config.hash());
             assert_eq!(bank.process_transaction(&tx), Ok(()));
             bank.squash();
             bank_forks.insert(bank);
@@ -386,14 +386,14 @@ mod tests {
                 (MAX_CACHE_ENTRIES * 2 + 1) as u64,
                 |bank, mint_keypair| {
                     let tx = system_transaction::transfer(
-                        &mint_keypair,
+                        mint_keypair,
                         &key1,
                         1,
                         bank.parent().unwrap().last_blockhash(),
                     );
                     assert_eq!(bank.process_transaction(&tx), Ok(()));
                     let tx = system_transaction::transfer(
-                        &mint_keypair,
+                        mint_keypair,
                         &key2,
                         1,
                         bank.parent().unwrap().last_blockhash(),

--- a/core/tests/storage_stage.rs
+++ b/core/tests/storage_stage.rs
@@ -82,7 +82,7 @@ mod tests {
             StorageAccountType::Archiver,
         );
         let account_tx = Transaction::new_signed_instructions(
-            &[&mint_keypair, &archiver_keypair],
+            &[&mint_keypair, archiver_keypair.as_ref()],
             account_ix,
             bank.last_blockhash(),
         );

--- a/install/src/command.rs
+++ b/install/src/command.rs
@@ -219,7 +219,7 @@ fn new_update_manifest(
             vec![], // additional keys
         );
         let mut transaction = Transaction::new_unsigned_instructions(new_account);
-        let signers = [from_keypair, update_manifest_keypair];
+        let signers: [&dyn KeypairUtil; 2] = [from_keypair, update_manifest_keypair];
         transaction.sign(&signers, recent_blockhash);
 
         rpc_client.send_and_confirm_transaction(&mut transaction, &[from_keypair])?;
@@ -236,7 +236,7 @@ fn store_update_manifest(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let (recent_blockhash, _fee_calculator) = rpc_client.get_recent_blockhash()?;
 
-    let signers = [from_keypair, update_manifest_keypair];
+    let signers: [&dyn KeypairUtil; 2] = [from_keypair, update_manifest_keypair];
     let instruction = config_instruction::store::<SignedUpdateManifest>(
         &update_manifest_keypair.pubkey(),
         true,   // update_manifest_keypair is signer

--- a/keygen/src/keygen.rs
+++ b/keygen/src/keygen.rs
@@ -6,21 +6,16 @@ use clap::{
 };
 use num_cpus;
 use solana_clap_utils::{
-    input_parsers::derivation_of,
     input_validators::is_derivation,
     keypair::{
-        keypair_from_seed_phrase, parse_keypair_path, prompt_passphrase, KeypairUrl,
+        generate_keypair_util, keypair_from_seed_phrase, prompt_passphrase,
         SKIP_SEED_PHRASE_VALIDATION_ARG,
     },
 };
 use solana_cli_config::config::{Config, CONFIG_FILE};
-use solana_remote_wallet::remote_keypair::generate_remote_keypair;
 use solana_sdk::{
     pubkey::write_pubkey_file,
-    signature::{
-        keypair_from_seed, read_keypair, read_keypair_file, write_keypair, write_keypair_file,
-        Keypair, KeypairUtil,
-    },
+    signature::{keypair_from_seed, write_keypair, write_keypair_file, Keypair, KeypairUtil},
 };
 use std::{
     collections::HashSet,
@@ -64,26 +59,7 @@ fn get_keypair_from_matches(
         path.extend(&[".config", "solana", "id.json"]);
         path.to_str().unwrap()
     };
-
-    match parse_keypair_path(path) {
-        KeypairUrl::Ask => {
-            let skip_validation = matches.is_present(SKIP_SEED_PHRASE_VALIDATION_ARG.name);
-            Ok(Box::new(keypair_from_seed_phrase(
-                "pubkey recovery",
-                skip_validation,
-                false,
-            )?))
-        }
-        KeypairUrl::Filepath(path) => Ok(Box::new(read_keypair_file(&path)?)),
-        KeypairUrl::Stdin => {
-            let mut stdin = std::io::stdin();
-            Ok(Box::new(read_keypair(&mut stdin)?))
-        }
-        KeypairUrl::Usb(path) => Ok(Box::new(generate_remote_keypair(
-            path,
-            derivation_of(matches, "derivation_path"),
-        )?)),
-    }
+    generate_keypair_util(matches, path, "pubkey recovery")
 }
 
 fn output_keypair(

--- a/ledger/src/entry.rs
+++ b/ledger/src/entry.rs
@@ -627,7 +627,7 @@ mod tests {
     #[test]
     fn test_verify_tick_hash_count() {
         let hashes_per_tick = 10;
-        let keypairs: Vec<&Keypair> = Vec::new();
+        let keypairs: Vec<&dyn KeypairUtil> = Vec::new();
         let tx: Transaction =
             Transaction::new(&keypairs, Message::new(Vec::new()), Hash::default());
         let tx_entry = Entry::new(&Hash::default(), 1, vec![tx]);

--- a/ledger/src/staking_utils.rs
+++ b/ledger/src/staking_utils.rs
@@ -133,11 +133,7 @@ pub(crate) mod tests {
         amount: u64,
     ) {
         let vote_pubkey = vote_account.pubkey();
-        fn process_instructions<T: KeypairUtil>(
-            bank: &Bank,
-            keypairs: &[&T],
-            ixs: Vec<Instruction>,
-        ) {
+        fn process_instructions(bank: &Bank, keypairs: &[&dyn KeypairUtil], ixs: Vec<Instruction>) {
             bank.process_transaction(&Transaction::new_signed_with_payer(
                 ixs,
                 Some(&keypairs[0].pubkey()),

--- a/local-cluster/src/cluster_tests.rs
+++ b/local-cluster/src/cluster_tests.rs
@@ -61,7 +61,7 @@ pub fn spend_and_verify_all_nodes<S: ::std::hash::BuildHasher>(
             .get_recent_blockhash_with_commitment(CommitmentConfig::recent())
             .unwrap();
         let mut transaction =
-            system_transaction::transfer(&funding_keypair, &random_keypair.pubkey(), 1, blockhash);
+            system_transaction::transfer(funding_keypair, &random_keypair.pubkey(), 1, blockhash);
         let confs = VOTE_THRESHOLD_DEPTH + 1;
         let sig = client
             .retry_transfer_until_confirmed(&funding_keypair, &mut transaction, 10, confs)
@@ -109,7 +109,7 @@ pub fn send_many_transactions(
         let transfer_amount = thread_rng().gen_range(1, max_tokens_per_transfer);
 
         let mut transaction = system_transaction::transfer(
-            &funding_keypair,
+            funding_keypair,
             &random_keypair.pubkey(),
             transfer_amount,
             blockhash,
@@ -246,7 +246,7 @@ pub fn kill_entry_and_spend_and_verify_rest(
                 .get_recent_blockhash_with_commitment(CommitmentConfig::recent())
                 .unwrap();
             let mut transaction = system_transaction::transfer(
-                &funding_keypair,
+                funding_keypair,
                 &random_keypair.pubkey(),
                 1,
                 blockhash,

--- a/local-cluster/src/cluster_tests.rs
+++ b/local-cluster/src/cluster_tests.rs
@@ -41,7 +41,7 @@ const DEFAULT_SLOT_MILLIS: u64 = (DEFAULT_TICKS_PER_SLOT * 1000) / DEFAULT_TICKS
 /// Spend and verify from every node in the network
 pub fn spend_and_verify_all_nodes<S: ::std::hash::BuildHasher>(
     entry_point_info: &ContactInfo,
-    funding_keypair: &Keypair,
+    funding_keypair: &dyn KeypairUtil,
     nodes: usize,
     ignore_nodes: HashSet<Pubkey, S>,
 ) {
@@ -64,7 +64,7 @@ pub fn spend_and_verify_all_nodes<S: ::std::hash::BuildHasher>(
             system_transaction::transfer(funding_keypair, &random_keypair.pubkey(), 1, blockhash);
         let confs = VOTE_THRESHOLD_DEPTH + 1;
         let sig = client
-            .retry_transfer_until_confirmed(&funding_keypair, &mut transaction, 10, confs)
+            .retry_transfer_until_confirmed(funding_keypair, &mut transaction, 10, confs)
             .unwrap();
         for validator in &cluster_nodes {
             if ignore_nodes.contains(&validator.id) {
@@ -91,7 +91,7 @@ pub fn verify_balances<S: ::std::hash::BuildHasher>(
 
 pub fn send_many_transactions(
     node: &ContactInfo,
-    funding_keypair: &Keypair,
+    funding_keypair: &dyn KeypairUtil,
     max_tokens_per_transfer: u64,
     num_txs: u64,
 ) -> HashMap<Pubkey, u64> {
@@ -116,7 +116,7 @@ pub fn send_many_transactions(
         );
 
         client
-            .retry_transfer(&funding_keypair, &mut transaction, 5)
+            .retry_transfer(funding_keypair, &mut transaction, 5)
             .unwrap();
 
         expected_balances.insert(random_keypair.pubkey(), transfer_amount);
@@ -192,7 +192,7 @@ pub fn sleep_n_epochs(
 
 pub fn kill_entry_and_spend_and_verify_rest(
     entry_point_info: &ContactInfo,
-    funding_keypair: &Keypair,
+    funding_keypair: &dyn KeypairUtil,
     nodes: usize,
     slot_millis: u64,
 ) {
@@ -255,7 +255,7 @@ pub fn kill_entry_and_spend_and_verify_rest(
             let confs = VOTE_THRESHOLD_DEPTH + 1;
             let sig = {
                 let sig = client.retry_transfer_until_confirmed(
-                    &funding_keypair,
+                    funding_keypair,
                     &mut transaction,
                     5,
                     confs,

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -458,8 +458,7 @@ impl LocalCluster {
         let (blockhash, _fee_calculator) = client
             .get_recent_blockhash_with_commitment(CommitmentConfig::recent())
             .unwrap();
-        let mut tx =
-            system_transaction::transfer(source_keypair, dest_pubkey, lamports, blockhash);
+        let mut tx = system_transaction::transfer(source_keypair, dest_pubkey, lamports, blockhash);
         info!(
             "executing transfer of {} from {} to {}",
             lamports,

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -450,7 +450,7 @@ impl LocalCluster {
 
     fn transfer_with_client(
         client: &ThinClient,
-        source_keypair: &Keypair,
+        source_keypair: &dyn KeypairUtil,
         dest_pubkey: &Pubkey,
         lamports: u64,
     ) -> u64 {
@@ -466,7 +466,7 @@ impl LocalCluster {
             *dest_pubkey
         );
         client
-            .retry_transfer(&source_keypair, &mut tx, 10)
+            .retry_transfer(source_keypair, &mut tx, 10)
             .expect("client transfer");
         client
             .wait_for_balance_with_commitment(
@@ -515,7 +515,7 @@ impl LocalCluster {
                     .0,
             );
             client
-                .retry_transfer(&from_account, &mut transaction, 10)
+                .retry_transfer(from_account.as_ref(), &mut transaction, 10)
                 .expect("fund vote");
             client
                 .wait_for_balance_with_commitment(
@@ -630,7 +630,7 @@ impl LocalCluster {
             .0;
         let mut transaction = Transaction::new(&signer_keys, message, blockhash);
         client
-            .retry_transfer(&from_keypair, &mut transaction, 10)
+            .retry_transfer(from_keypair.as_ref(), &mut transaction, 10)
             .map(|_signature| ())
     }
 }

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -459,7 +459,7 @@ impl LocalCluster {
             .get_recent_blockhash_with_commitment(CommitmentConfig::recent())
             .unwrap();
         let mut tx =
-            system_transaction::transfer(&source_keypair, dest_pubkey, lamports, blockhash);
+            system_transaction::transfer(source_keypair, dest_pubkey, lamports, blockhash);
         info!(
             "executing transfer of {} from {} to {}",
             lamports,
@@ -624,7 +624,7 @@ impl LocalCluster {
             Some(&from_keypair.pubkey()),
         );
 
-        let signer_keys = vec![from_keypair.as_ref(), &storage_keypair];
+        let signer_keys: Vec<&dyn KeypairUtil> = vec![from_keypair.as_ref(), storage_keypair];
         let blockhash = client
             .get_recent_blockhash_with_commitment(CommitmentConfig::recent())
             .unwrap()

--- a/perf/src/test_tx.rs
+++ b/perf/src/test_tx.rs
@@ -16,7 +16,7 @@ pub fn test_tx() -> Transaction {
 pub fn test_multisig_tx() -> Transaction {
     let keypair0 = Keypair::new();
     let keypair1 = Keypair::new();
-    let keypairs = vec![&keypair0, &keypair1];
+    let keypairs: Vec<&dyn KeypairUtil> = vec![&keypair0, &keypair1];
     let lamports = 5;
     let blockhash = Hash::default();
 

--- a/programs/librapay/src/lib.rs
+++ b/programs/librapay/src/lib.rs
@@ -32,7 +32,7 @@ pub fn create_genesis<T: Client>(from: &Keypair, client: &T, amount: u64) -> Key
     );
 
     client
-        .send_message(&[&from, &genesis], Message::new(vec![instruction]))
+        .send_message(&[from, &genesis], Message::new(vec![instruction]))
         .unwrap();
 
     let instruction = librapay_instruction::genesis(&genesis.pubkey(), amount);

--- a/programs/librapay/src/librapay_transaction.rs
+++ b/programs/librapay/src/librapay_transaction.rs
@@ -90,8 +90,10 @@ pub fn create_accounts(
         })
         .collect();
 
-    let mut from_signers = vec![from_keypair];
-    from_signers.extend_from_slice(to_keypair);
+    let mut from_signers: Vec<&dyn KeypairUtil> = vec![from_keypair];
+    for keypair in to_keypair.iter() {
+        from_signers.push(*keypair);
+    }
     Transaction::new_signed_instructions(&from_signers, instructions, recent_blockhash)
 }
 

--- a/programs/ownable/src/ownable_processor.rs
+++ b/programs/ownable/src/ownable_processor.rs
@@ -82,8 +82,8 @@ mod tests {
 
     fn create_ownable_account(
         bank_client: &BankClient,
-        payer_keypair: &Keypair,
-        account_keypair: &Keypair,
+        payer_keypair: &dyn KeypairUtil,
+        account_keypair: &dyn KeypairUtil,
         owner_pubkey: &Pubkey,
         lamports: u64,
     ) -> Result<Signature> {
@@ -94,14 +94,14 @@ mod tests {
             lamports,
         );
         let message = Message::new(instructions);
-        bank_client.send_message(&[&payer_keypair, &account_keypair], message)
+        bank_client.send_message(&[payer_keypair, account_keypair], message)
     }
 
     fn send_set_owner(
         bank_client: &BankClient,
-        payer_keypair: &Keypair,
+        payer_keypair: &dyn KeypairUtil,
         account_pubkey: &Pubkey,
-        old_owner_keypair: &Keypair,
+        old_owner_keypair: &dyn KeypairUtil,
         new_owner_pubkey: &Pubkey,
     ) -> Result<Signature> {
         let instruction = ownable_instruction::set_owner(
@@ -110,7 +110,7 @@ mod tests {
             new_owner_pubkey,
         );
         let message = Message::new_with_payer(vec![instruction], Some(&payer_keypair.pubkey()));
-        bank_client.send_message(&[&payer_keypair, &old_owner_keypair], message)
+        bank_client.send_message(&[payer_keypair, old_owner_keypair], message)
     }
 
     #[test]

--- a/programs/vest/src/vest_processor.rs
+++ b/programs/vest/src/vest_processor.rs
@@ -177,8 +177,8 @@ mod tests {
     /// Create a config account and use it as a date oracle.
     fn create_date_account(
         bank_client: &BankClient,
-        date_keypair: &Keypair,
-        payer_keypair: &Keypair,
+        date_keypair: &dyn KeypairUtil,
+        payer_keypair: &dyn KeypairUtil,
         date: Date<Utc>,
     ) -> Result<Signature> {
         let date_pubkey = date_keypair.pubkey();
@@ -188,25 +188,25 @@ mod tests {
         instructions.push(date_instruction::store(&date_pubkey, date));
 
         let message = Message::new(instructions);
-        bank_client.send_message(&[&payer_keypair, &date_keypair], message)
+        bank_client.send_message(&[payer_keypair, date_keypair], message)
     }
 
     fn store_date(
         bank_client: &BankClient,
-        date_keypair: &Keypair,
-        payer_keypair: &Keypair,
+        date_keypair: &dyn KeypairUtil,
+        payer_keypair: &dyn KeypairUtil,
         date: Date<Utc>,
     ) -> Result<Signature> {
         let date_pubkey = date_keypair.pubkey();
         let instruction = date_instruction::store(&date_pubkey, date);
         let message = Message::new_with_payer(vec![instruction], Some(&payer_keypair.pubkey()));
-        bank_client.send_message(&[&payer_keypair, &date_keypair], message)
+        bank_client.send_message(&[payer_keypair, date_keypair], message)
     }
 
     fn create_vest_account(
         bank_client: &BankClient,
-        contract_keypair: &Keypair,
-        payer_keypair: &Keypair,
+        contract_keypair: &dyn KeypairUtil,
+        payer_keypair: &dyn KeypairUtil,
         terminator_pubkey: &Pubkey,
         payee_pubkey: &Pubkey,
         start_date: Date<Utc>,
@@ -223,42 +223,42 @@ mod tests {
             lamports,
         );
         let message = Message::new(instructions);
-        bank_client.send_message(&[&payer_keypair, &contract_keypair], message)
+        bank_client.send_message(&[payer_keypair, contract_keypair], message)
     }
 
     fn send_set_terminator(
         bank_client: &BankClient,
         contract_pubkey: &Pubkey,
-        old_keypair: &Keypair,
+        old_keypair: &dyn KeypairUtil,
         new_pubkey: &Pubkey,
     ) -> Result<Signature> {
         let instruction =
             vest_instruction::set_terminator(&contract_pubkey, &old_keypair.pubkey(), &new_pubkey);
-        bank_client.send_instruction(&old_keypair, instruction)
+        bank_client.send_instruction(old_keypair, instruction)
     }
 
     fn send_set_payee(
         bank_client: &BankClient,
         contract_pubkey: &Pubkey,
-        old_keypair: &Keypair,
+        old_keypair: &dyn KeypairUtil,
         new_pubkey: &Pubkey,
     ) -> Result<Signature> {
         let instruction =
             vest_instruction::set_payee(&contract_pubkey, &old_keypair.pubkey(), &new_pubkey);
-        bank_client.send_instruction(&old_keypair, instruction)
+        bank_client.send_instruction(old_keypair, instruction)
     }
 
     fn send_redeem_tokens(
         bank_client: &BankClient,
         contract_pubkey: &Pubkey,
-        payer_keypair: &Keypair,
+        payer_keypair: &dyn KeypairUtil,
         payee_pubkey: &Pubkey,
         date_pubkey: &Pubkey,
     ) -> Result<Signature> {
         let instruction =
             vest_instruction::redeem_tokens(&contract_pubkey, &date_pubkey, &payee_pubkey);
         let message = Message::new_with_payer(vec![instruction], Some(&payer_keypair.pubkey()));
-        bank_client.send_message(&[&payer_keypair], message)
+        bank_client.send_message(&[payer_keypair], message)
     }
 
     #[test]

--- a/remote-wallet/src/ledger.rs
+++ b/remote-wallet/src/ledger.rs
@@ -341,7 +341,7 @@ fn extend_and_serialize(derivation_path: &DerivationPath) -> Vec<u8> {
 pub fn get_ledger_from_info(
     info: RemoteWalletInfo,
 ) -> Result<Arc<LedgerWallet>, RemoteWalletError> {
-    let wallet_manager = initialize_wallet_manager();
+    let wallet_manager = initialize_wallet_manager()?;
     let _device_count = wallet_manager.update_devices()?;
     let devices = wallet_manager.list_devices();
     let (pubkeys, device_paths): (Vec<Pubkey>, Vec<String>) = devices

--- a/remote-wallet/src/remote_wallet.rs
+++ b/remote-wallet/src/remote_wallet.rs
@@ -274,9 +274,9 @@ pub fn is_valid_hid_device(usage_page: u16, interface_number: i32) -> bool {
 }
 
 /// Helper to initialize hidapi and RemoteWalletManager
-pub fn initialize_wallet_manager() -> Arc<RemoteWalletManager> {
-    let hidapi = Arc::new(Mutex::new(hidapi::HidApi::new().unwrap()));
-    RemoteWalletManager::new(hidapi)
+pub fn initialize_wallet_manager() -> Result<Arc<RemoteWalletManager>, RemoteWalletError> {
+    let hidapi = Arc::new(Mutex::new(hidapi::HidApi::new()?));
+    Ok(RemoteWalletManager::new(hidapi))
 }
 
 #[cfg(test)]

--- a/runtime/benches/bank.rs
+++ b/runtime/benches/bank.rs
@@ -38,7 +38,7 @@ fn process_instruction(
 
 pub fn create_builtin_transactions(
     bank_client: &BankClient,
-    mint_keypair: &Keypair,
+    mint_keypair: &dyn KeypairUtil,
 ) -> Vec<Transaction> {
     let program_id = Pubkey::new(&BUILTIN_PROGRAM_ID);
 
@@ -48,7 +48,7 @@ pub fn create_builtin_transactions(
             // Seed the signer account
             let rando0 = Keypair::new();
             bank_client
-                .transfer(10_000, &mint_keypair, &rando0.pubkey())
+                .transfer(10_000, mint_keypair, &rando0.pubkey())
                 .expect(&format!("{}:{}", line!(), file!()));
 
             let instruction = create_invoke_instruction(rando0.pubkey(), program_id, &1u8);
@@ -60,7 +60,7 @@ pub fn create_builtin_transactions(
 
 pub fn create_native_loader_transactions(
     bank_client: &BankClient,
-    mint_keypair: &Keypair,
+    mint_keypair: &dyn KeypairUtil,
 ) -> Vec<Transaction> {
     let program_id = Pubkey::new(&NOOP_PROGRAM_ID);
 
@@ -70,7 +70,7 @@ pub fn create_native_loader_transactions(
             // Seed the signer account©41
             let rando0 = Keypair::new();
             bank_client
-                .transfer(10_000, &mint_keypair, &rando0.pubkey())
+                .transfer(10_000, mint_keypair, &rando0.pubkey())
                 .expect(&format!("{}:{}", line!(), file!()));
 
             let instruction = create_invoke_instruction(rando0.pubkey(), program_id, &1u8);
@@ -115,7 +115,7 @@ fn async_bencher(bank: &Arc<Bank>, bank_client: &BankClient, transactions: &Vec<
 fn do_bench_transactions(
     bencher: &mut Bencher,
     bench_work: &dyn Fn(&Arc<Bank>, &BankClient, &Vec<Transaction>),
-    create_transactions: &dyn Fn(&BankClient, &Keypair) -> Vec<Transaction>,
+    create_transactions: &dyn Fn(&BankClient, &dyn KeypairUtil) -> Vec<Transaction>,
 ) {
     solana_logger::setup();
     let ns_per_s = 1_000_000_000;

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -744,7 +744,7 @@ mod tests {
         let mut error_counters = ErrorCounters::default();
 
         let instructions = vec![CompiledInstruction::new(0, &(), vec![0])];
-        let tx = Transaction::new_with_compiled_instructions::<Keypair>(
+        let tx = Transaction::new_with_compiled_instructions(
             &[],
             &[],
             Hash::default(),

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4372,7 +4372,7 @@ mod tests {
         transfer_instruction.accounts[0].is_signer = false;
 
         let tx = Transaction::new_signed_instructions(
-            &Vec::<&Keypair>::new(),
+            &Vec::<&dyn KeypairUtil>::new(),
             vec![transfer_instruction],
             bank.last_blockhash(),
         );

--- a/runtime/src/bank_client.rs
+++ b/runtime/src/bank_client.rs
@@ -44,11 +44,11 @@ impl AsyncClient for BankClient {
 
     fn async_send_message(
         &self,
-        keypairs: &[&Keypair],
+        keypairs: &[&dyn KeypairUtil],
         message: Message,
         recent_blockhash: Hash,
     ) -> io::Result<Signature> {
-        let transaction = Transaction::new(&keypairs, message, recent_blockhash);
+        let transaction = Transaction::new(keypairs, message, recent_blockhash);
         self.async_send_transaction(transaction)
     }
 
@@ -77,7 +77,7 @@ impl AsyncClient for BankClient {
 }
 
 impl SyncClient for BankClient {
-    fn send_message(&self, keypairs: &[&Keypair], message: Message) -> Result<Signature> {
+    fn send_message(&self, keypairs: &[&dyn KeypairUtil], message: Message) -> Result<Signature> {
         let blockhash = self.bank.last_blockhash();
         let transaction = Transaction::new(&keypairs, message, blockhash);
         self.bank.process_transaction(&transaction)?;

--- a/runtime/src/bank_client.rs
+++ b/runtime/src/bank_client.rs
@@ -8,7 +8,7 @@ use solana_sdk::{
     instruction::Instruction,
     message::Message,
     pubkey::Pubkey,
-    signature::{Keypair, KeypairUtil, Signature},
+    signature::{KeypairUtil, Signature},
     system_instruction,
     transaction::{self, Transaction},
     transport::{Result, TransportError},
@@ -54,7 +54,7 @@ impl AsyncClient for BankClient {
 
     fn async_send_instruction(
         &self,
-        keypair: &Keypair,
+        keypair: &dyn KeypairUtil,
         instruction: Instruction,
         recent_blockhash: Hash,
     ) -> io::Result<Signature> {
@@ -66,7 +66,7 @@ impl AsyncClient for BankClient {
     fn async_transfer(
         &self,
         lamports: u64,
-        keypair: &Keypair,
+        keypair: &dyn KeypairUtil,
         pubkey: &Pubkey,
         recent_blockhash: Hash,
     ) -> io::Result<Signature> {
@@ -85,13 +85,13 @@ impl SyncClient for BankClient {
     }
 
     /// Create and process a transaction from a single instruction.
-    fn send_instruction(&self, keypair: &Keypair, instruction: Instruction) -> Result<Signature> {
+    fn send_instruction(&self, keypair: &dyn KeypairUtil, instruction: Instruction) -> Result<Signature> {
         let message = Message::new(vec![instruction]);
         self.send_message(&[keypair], message)
     }
 
     /// Transfer `lamports` from `keypair` to `pubkey`
-    fn transfer(&self, lamports: u64, keypair: &Keypair, pubkey: &Pubkey) -> Result<Signature> {
+    fn transfer(&self, lamports: u64, keypair: &dyn KeypairUtil, pubkey: &Pubkey) -> Result<Signature> {
         let transfer_instruction =
             system_instruction::transfer(&keypair.pubkey(), pubkey, lamports);
         self.send_instruction(keypair, transfer_instruction)

--- a/runtime/src/bank_client.rs
+++ b/runtime/src/bank_client.rs
@@ -85,13 +85,22 @@ impl SyncClient for BankClient {
     }
 
     /// Create and process a transaction from a single instruction.
-    fn send_instruction(&self, keypair: &dyn KeypairUtil, instruction: Instruction) -> Result<Signature> {
+    fn send_instruction(
+        &self,
+        keypair: &dyn KeypairUtil,
+        instruction: Instruction,
+    ) -> Result<Signature> {
         let message = Message::new(vec![instruction]);
         self.send_message(&[keypair], message)
     }
 
     /// Transfer `lamports` from `keypair` to `pubkey`
-    fn transfer(&self, lamports: u64, keypair: &dyn KeypairUtil, pubkey: &Pubkey) -> Result<Signature> {
+    fn transfer(
+        &self,
+        lamports: u64,
+        keypair: &dyn KeypairUtil,
+        pubkey: &Pubkey,
+    ) -> Result<Signature> {
         let transfer_instruction =
             system_instruction::transfer(&keypair.pubkey(), pubkey, lamports);
         self.send_instruction(keypair, transfer_instruction)

--- a/runtime/src/bank_client.rs
+++ b/runtime/src/bank_client.rs
@@ -282,7 +282,7 @@ mod tests {
         let john_pubkey = john_doe_keypair.pubkey();
         let jane_doe_keypair = Keypair::new();
         let jane_pubkey = jane_doe_keypair.pubkey();
-        let doe_keypairs = vec![&john_doe_keypair, &jane_doe_keypair];
+        let doe_keypairs: Vec<&dyn KeypairUtil> = vec![&john_doe_keypair, &jane_doe_keypair];
         let bank = Bank::new(&genesis_config);
         let bank_client = BankClient::new(bank);
 

--- a/runtime/src/bank_client.rs
+++ b/runtime/src/bank_client.rs
@@ -283,7 +283,9 @@ impl BankClient {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use solana_sdk::{genesis_config::create_genesis_config, instruction::AccountMeta};
+    use solana_sdk::{
+        genesis_config::create_genesis_config, instruction::AccountMeta, signature::Keypair,
+    };
 
     #[test]
     fn test_bank_client_new_with_keypairs() {

--- a/runtime/src/nonce_utils.rs
+++ b/runtime/src/nonce_utils.rs
@@ -109,8 +109,11 @@ mod tests {
 
     #[test]
     fn tx_uses_nonce_empty_ix_fail() {
-        let tx =
-            Transaction::new_signed_instructions(&Vec::<&dyn KeypairUtil>::new(), vec![], Hash::default());
+        let tx = Transaction::new_signed_instructions(
+            &Vec::<&dyn KeypairUtil>::new(),
+            vec![],
+            Hash::default(),
+        );
         assert!(transaction_uses_durable_nonce(&tx).is_none());
     }
 

--- a/runtime/src/nonce_utils.rs
+++ b/runtime/src/nonce_utils.rs
@@ -110,7 +110,7 @@ mod tests {
     #[test]
     fn tx_uses_nonce_empty_ix_fail() {
         let tx =
-            Transaction::new_signed_instructions(&[&Keypair::new(); 0], vec![], Hash::default());
+            Transaction::new_signed_instructions(&Vec::<&dyn KeypairUtil>::new(), vec![], Hash::default());
         assert!(transaction_uses_durable_nonce(&tx).is_none());
     }
 

--- a/runtime/tests/stake.rs
+++ b/runtime/tests/stake.rs
@@ -61,7 +61,7 @@ fn fill_epoch_with_votes(
             Some(&mint_pubkey),
         );
         assert!(bank_client
-            .send_message(&[&mint_keypair, &vote_keypair], message)
+            .send_message(&[mint_keypair, vote_keypair], message)
             .is_ok());
     }
     bank

--- a/runtime/tests/storage.rs
+++ b/runtime/tests/storage.rs
@@ -301,13 +301,13 @@ fn init_storage_accounts(
     archiver_accounts_to_create: &[&Keypair],
     lamports: u64,
 ) {
-    let mut signers = vec![mint];
+    let mut signers: Vec<&dyn KeypairUtil> = vec![mint];
     let mut ixs: Vec<_> = vec![system_instruction::transfer(&mint.pubkey(), owner, 1)];
     ixs.append(
         &mut validator_accounts_to_create
-            .into_iter()
+            .iter()
             .flat_map(|account| {
-                signers.push(&account);
+                signers.push(*account);
                 storage_instruction::create_storage_account(
                     &mint.pubkey(),
                     owner,
@@ -318,8 +318,8 @@ fn init_storage_accounts(
             })
             .collect(),
     );
-    archiver_accounts_to_create.into_iter().for_each(|account| {
-        signers.push(&account);
+    archiver_accounts_to_create.iter().for_each(|account| {
+        signers.push(*account);
         ixs.append(&mut storage_instruction::create_storage_account(
             &mint.pubkey(),
             owner,
@@ -371,7 +371,7 @@ fn submit_proof(
     );
 
     assert_matches!(
-        bank_client.send_message(&[&mint_keypair, &storage_keypair], message),
+        bank_client.send_message(&[mint_keypair, storage_keypair], message),
         Ok(_)
     );
     ProofStatus::Valid

--- a/sdk-c/src/lib.rs
+++ b/sdk-c/src/lib.rs
@@ -451,7 +451,10 @@ pub unsafe extern "C" fn transaction_partial_sign(
     } else {
         return 1;
     };
-    let keypairs_ref: Vec<&KeypairNative> = keypairs.iter().collect();
+    let mut keypairs_ref: Vec<&dyn KeypairUtil> = Vec::new();
+    for keypair in keypairs.iter() {
+        keypairs_ref.push(keypair);
+    }
 
     let positions = if let Ok(v) = tx_native.get_signing_keypair_positions(&keypairs_ref[..]) {
         v

--- a/sdk/src/client.rs
+++ b/sdk/src/client.rs
@@ -16,7 +16,7 @@ use crate::{
     instruction::Instruction,
     message::Message,
     pubkey::Pubkey,
-    signature::{Keypair, KeypairUtil, Signature},
+    signature::{KeypairUtil, Signature},
     transaction,
     transport::Result,
 };
@@ -33,11 +33,11 @@ pub trait SyncClient {
 
     /// Create a transaction from a single instruction that only requires
     /// a single signer. Then send it to the server, retrying as-needed.
-    fn send_instruction(&self, keypair: &Keypair, instruction: Instruction) -> Result<Signature>;
+    fn send_instruction(&self, keypair: &dyn KeypairUtil, instruction: Instruction) -> Result<Signature>;
 
     /// Transfer lamports from `keypair` to `pubkey`, retrying until the
     /// transfer completes or produces and error.
-    fn transfer(&self, lamports: u64, keypair: &Keypair, pubkey: &Pubkey) -> Result<Signature>;
+    fn transfer(&self, lamports: u64, keypair: &dyn KeypairUtil, pubkey: &Pubkey) -> Result<Signature>;
 
     /// Get an account or None if not found.
     fn get_account_data(&self, pubkey: &Pubkey) -> Result<Option<Vec<u8>>>;
@@ -132,7 +132,7 @@ pub trait AsyncClient {
     /// a single signer. Then send it to the server, but don't wait for a reply.
     fn async_send_instruction(
         &self,
-        keypair: &Keypair,
+        keypair: &dyn KeypairUtil,
         instruction: Instruction,
         recent_blockhash: Hash,
     ) -> io::Result<Signature>;
@@ -141,7 +141,7 @@ pub trait AsyncClient {
     fn async_transfer(
         &self,
         lamports: u64,
-        keypair: &Keypair,
+        keypair: &dyn KeypairUtil,
         pubkey: &Pubkey,
         recent_blockhash: Hash,
     ) -> io::Result<Signature>;

--- a/sdk/src/client.rs
+++ b/sdk/src/client.rs
@@ -16,7 +16,7 @@ use crate::{
     instruction::Instruction,
     message::Message,
     pubkey::Pubkey,
-    signature::{Keypair, Signature},
+    signature::{Keypair, KeypairUtil, Signature},
     transaction,
     transport::Result,
 };
@@ -29,7 +29,7 @@ pub trait Client: SyncClient + AsyncClient {
 pub trait SyncClient {
     /// Create a transaction from the given message, and send it to the
     /// server, retrying as-needed.
-    fn send_message(&self, keypairs: &[&Keypair], message: Message) -> Result<Signature>;
+    fn send_message(&self, keypairs: &[&dyn KeypairUtil], message: Message) -> Result<Signature>;
 
     /// Create a transaction from a single instruction that only requires
     /// a single signer. Then send it to the server, retrying as-needed.
@@ -123,7 +123,7 @@ pub trait AsyncClient {
     /// server, but don't wait for to see if the server accepted it.
     fn async_send_message(
         &self,
-        keypairs: &[&Keypair],
+        keypairs: &[&dyn KeypairUtil],
         message: Message,
         recent_blockhash: Hash,
     ) -> io::Result<Signature>;

--- a/sdk/src/client.rs
+++ b/sdk/src/client.rs
@@ -33,11 +33,20 @@ pub trait SyncClient {
 
     /// Create a transaction from a single instruction that only requires
     /// a single signer. Then send it to the server, retrying as-needed.
-    fn send_instruction(&self, keypair: &dyn KeypairUtil, instruction: Instruction) -> Result<Signature>;
+    fn send_instruction(
+        &self,
+        keypair: &dyn KeypairUtil,
+        instruction: Instruction,
+    ) -> Result<Signature>;
 
     /// Transfer lamports from `keypair` to `pubkey`, retrying until the
     /// transfer completes or produces and error.
-    fn transfer(&self, lamports: u64, keypair: &dyn KeypairUtil, pubkey: &Pubkey) -> Result<Signature>;
+    fn transfer(
+        &self,
+        lamports: u64,
+        keypair: &dyn KeypairUtil,
+        pubkey: &Pubkey,
+    ) -> Result<Signature>;
 
     /// Get an account or None if not found.
     fn get_account_data(&self, pubkey: &Pubkey) -> Result<Option<Vec<u8>>>;

--- a/sdk/src/signature.rs
+++ b/sdk/src/signature.rs
@@ -179,6 +179,15 @@ where
     }
 }
 
+impl<T> From<T> for Box<dyn KeypairUtil>
+where
+    T: KeypairUtil + 'static,
+{
+    fn from(keypair_util: T) -> Self {
+        Box::new(keypair_util)
+    }
+}
+
 #[derive(Debug, Default)]
 pub struct Presigner {
     pubkey: Pubkey,

--- a/sdk/src/signature.rs
+++ b/sdk/src/signature.rs
@@ -186,8 +186,7 @@ pub struct Presigner {
 }
 
 impl Presigner {
-    #[allow(dead_code)]
-    fn new(pubkey: &Pubkey, signature: &Signature) -> Self {
+    pub fn new(pubkey: &Pubkey, signature: &Signature) -> Self {
         Self {
             pubkey: *pubkey,
             signature: *signature,

--- a/sdk/src/signature.rs
+++ b/sdk/src/signature.rs
@@ -188,7 +188,7 @@ where
     }
 }
 
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct Presigner {
     pubkey: Pubkey,
     signature: Signature,

--- a/sdk/src/signature.rs
+++ b/sdk/src/signature.rs
@@ -139,6 +139,18 @@ pub trait KeypairUtil {
     fn try_sign_message(&self, message: &[u8]) -> Result<Signature, Box<dyn error::Error>>;
 }
 
+impl PartialEq for dyn KeypairUtil {
+    fn eq(&self, other: &dyn KeypairUtil) -> bool {
+        self.pubkey() == other.pubkey()
+    }
+}
+
+impl std::fmt::Debug for Box<dyn KeypairUtil> {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(fmt, "KeypairUtil: {:?}", self.pubkey())
+    }
+}
+
 impl KeypairUtil for Keypair {
     /// Return the public key for the given keypair
     fn pubkey(&self) -> Pubkey {

--- a/sdk/src/system_transaction.rs
+++ b/sdk/src/system_transaction.rs
@@ -1,17 +1,14 @@
 //! The `system_transaction` module provides functionality for creating system transactions.
 
 use crate::{
-    hash::Hash,
-    pubkey::Pubkey,
-    signature::{Keypair, KeypairUtil},
-    system_instruction,
+    hash::Hash, pubkey::Pubkey, signature::KeypairUtil, system_instruction,
     transaction::Transaction,
 };
 
 /// Create and sign new SystemInstruction::CreateAccount transaction
 pub fn create_account(
-    from_keypair: &Keypair,
-    to_keypair: &Keypair,
+    from_keypair: &dyn KeypairUtil,
+    to_keypair: &dyn KeypairUtil,
     recent_blockhash: Hash,
     lamports: u64,
     space: u64,
@@ -30,7 +27,11 @@ pub fn create_account(
 }
 
 /// Create and sign new system_instruction::Assign transaction
-pub fn assign(from_keypair: &Keypair, recent_blockhash: Hash, program_id: &Pubkey) -> Transaction {
+pub fn assign(
+    from_keypair: &dyn KeypairUtil,
+    recent_blockhash: Hash,
+    program_id: &Pubkey,
+) -> Transaction {
     let from_pubkey = from_keypair.pubkey();
     let assign_instruction = system_instruction::assign(&from_pubkey, program_id);
     let instructions = vec![assign_instruction];
@@ -39,7 +40,7 @@ pub fn assign(from_keypair: &Keypair, recent_blockhash: Hash, program_id: &Pubke
 
 /// Create and sign new system_instruction::Transfer transaction
 pub fn transfer(
-    from_keypair: &Keypair,
+    from_keypair: &dyn KeypairUtil,
     to: &Pubkey,
     lamports: u64,
     recent_blockhash: Hash,
@@ -52,11 +53,11 @@ pub fn transfer(
 
 /// Create and sign new nonced system_instruction::Transfer transaction
 pub fn nonced_transfer(
-    from_keypair: &Keypair,
+    from_keypair: &dyn KeypairUtil,
     to: &Pubkey,
     lamports: u64,
     nonce_account: &Pubkey,
-    nonce_authority: &Keypair,
+    nonce_authority: &dyn KeypairUtil,
     nonce_hash: Hash,
 ) -> Transaction {
     let from_pubkey = from_keypair.pubkey();

--- a/sdk/src/transaction.rs
+++ b/sdk/src/transaction.rs
@@ -576,8 +576,7 @@ mod tests {
         let id0 = keypair0.pubkey();
         let ix = Instruction::new(program_id, &0, vec![AccountMeta::new(id0, true)]);
         let signers: Vec<&dyn KeypairUtil> = Vec::new();
-        Transaction::new_unsigned_instructions(vec![ix])
-            .sign(&signers, Hash::default());
+        Transaction::new_unsigned_instructions(vec![ix]).sign(&signers, Hash::default());
     }
 
     #[test]


### PR DESCRIPTION
#### Problem

Our signer interfaces are too restrictive to accommodate a rich signing experience.  This makes things like hardware wallets, offline signing and [certain instruction constructions](https://github.com/solana-labs/solana/pull/8252) difficult to implement and mixed signer types impossible.

#### Summary of Changes

Co-conspirator: @CriesofCarrots 

- Consolidate signer CLI argument specification and support HW wallet paths
- Replace `KeypairUtil` generics-based interfaces with `KeypairUtil` trait-objects-based ones
- Replace `Keypair` data structure fields with `Box<dyn KeypairUtil>` where appropriate
- Plumbing and adaptations throughout
- Doc updates

**For review purposes:**
The most essential changes in this PR can be seen in sdk/src/transaction.rs (use of `KeypairUtil` trait objects), and the `generate_keypair_util()` method in clap-utils/src/keypair.rs demonstrates how keypair inputs are parsed into different `KeypairUtil` objects.