### PR TITLE
Drop packet if destination is unspecified (0.0.0.0/0)

### DIFF
--- a/perf/src/packet.rs
+++ b/perf/src/packet.rs
@@ -85,8 +85,12 @@ pub fn to_packets_with_destination<T: Serialize>(
     );
     out.packets.resize(dests_and_data.len(), Packet::default());
     for (dest_and_data, o) in dests_and_data.iter().zip(out.packets.iter_mut()) {
-        if let Err(e) = Packet::populate_packet(o, Some(&dest_and_data.0), &dest_and_data.1) {
-            error!("Couldn't write to packet {:?}. Data skipped.", e);
+        if !dest_and_data.0.ip().is_unspecified() && dest_and_data.0.port() != 0 {
+            if let Err(e) = Packet::populate_packet(o, Some(&dest_and_data.0), &dest_and_data.1) {
+                error!("Couldn't write to packet {:?}. Data skipped.", e);
+            }
+        } else {
+            trace!("Dropping packet, as destination is unknown");
         }
     }
     out


### PR DESCRIPTION
#### Problem
Gossip packets are getting dropped by kernel syscall, and printing a warning message in the log. The destination IP and port seems to be set to 0. 

#### Summary of Changes
Check if the packet's destination IP or port is unspecified. If so, don't try to send it. 

Fixes #8151 
