### PR TITLE
Validators now gossip their snapshot slots and select the highest for download

### DIFF
--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -153,7 +153,8 @@ impl Tvu {
             if snapshot_config.is_some() {
                 // Start a snapshot packaging service
                 let (sender, receiver) = channel();
-                let snapshot_packager_service = SnapshotPackagerService::new(receiver, exit);
+                let snapshot_packager_service =
+                    SnapshotPackagerService::new(cluster_info, receiver, exit);
                 (Some(snapshot_packager_service), Some(sender))
             } else {
                 (None, None)
@@ -251,7 +252,7 @@ impl Tvu {
 pub mod tests {
     use super::*;
     use crate::banking_stage::create_test_recorder;
-    use crate::cluster_info::{ClusterInfo, Node};
+    use crate::cluster_info::Node;
     use crate::genesis_utils::{create_genesis_config, GenesisConfigInfo};
     use solana_ledger::create_new_tmp_ledger;
     use solana_runtime::bank::Bank;

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -23,7 +23,7 @@ use crate::{
 };
 use crossbeam_channel::unbounded;
 use solana_ledger::{
-    bank_forks::{BankForks, SnapshotConfig},
+    bank_forks::{BankForks, SnapshotConfig, SnapshotInfo},
     bank_forks_utils,
     blockstore::{Blockstore, CompletedSlotsReceiver},
     blockstore_processor::{self, BankForksInfo},
@@ -38,7 +38,6 @@ use solana_sdk::{
     clock::{Slot, DEFAULT_SLOTS_PER_TURN},
     genesis_config::GenesisConfig,
     hash::Hash,
-    poh_config::PohConfig,
     pubkey::Pubkey,
     signature::{Keypair, KeypairUtil},
     timing::timestamp,
@@ -159,14 +158,14 @@ impl Validator {
 
         info!("creating bank...");
         let (
-            genesis_hash,
+            genesis_config,
             bank_forks,
             bank_forks_info,
             blockstore,
             ledger_signal_receiver,
             completed_slots_receiver,
             leader_schedule_cache,
-            poh_config,
+            snapshot_info,
         ) = new_banks_from_blockstore(
             config.expected_genesis_hash,
             ledger_path,
@@ -196,8 +195,10 @@ impl Validator {
         let validator_exit = Arc::new(RwLock::new(Some(validator_exit)));
 
         node.info.wallclock = timestamp();
-        node.info.shred_version =
-            compute_shred_version(&genesis_hash, Some(&bank.hard_forks().read().unwrap()));
+        node.info.shred_version = compute_shred_version(
+            &genesis_config.hash(),
+            Some(&bank.hard_forks().read().unwrap()),
+        );
         Self::print_node_info(&node);
 
         if let Some(expected_shred_version) = config.expected_shred_version {
@@ -241,7 +242,7 @@ impl Validator {
                     block_commitment_cache.clone(),
                     blockstore.clone(),
                     cluster_info.clone(),
-                    genesis_hash,
+                    genesis_config.hash(),
                     ledger_path,
                     storage_state.clone(),
                     validator_exit.clone(),
@@ -299,7 +300,7 @@ impl Validator {
             std::thread::park();
         }
 
-        let poh_config = Arc::new(poh_config);
+        let poh_config = Arc::new(genesis_config.poh_config);
         let (mut poh_recorder, entry_receiver) = PohRecorder::new_with_clear_signal(
             bank.tick_height(),
             bank.last_blockhash(),
@@ -342,6 +343,15 @@ impl Validator {
                 .unwrap()
                 .set_entrypoint(entrypoint_info.clone());
         }
+
+        if let Some(snapshot_info) = snapshot_info {
+            // If the validator booted from a snapshot, advertise it to other nodes
+            cluster_info.write().unwrap().push_snapshot_info(
+                id,
+                snapshot_info.slot,
+                snapshot_info.bank_hash,
+            );
+        };
 
         wait_for_supermajority(config, &bank, &cluster_info);
 
@@ -505,20 +515,21 @@ impl Validator {
     }
 }
 
+#[allow(clippy::type_complexity)]
 fn new_banks_from_blockstore(
     expected_genesis_hash: Option<Hash>,
     blockstore_path: &Path,
     poh_verify: bool,
     config: &ValidatorConfig,
 ) -> (
-    Hash,
+    GenesisConfig,
     BankForks,
     Vec<BankForksInfo>,
     Blockstore,
     Receiver<bool>,
     CompletedSlotsReceiver,
     LeaderScheduleCache,
-    PohConfig,
+    Option<SnapshotInfo>,
 ) {
     let genesis_config = GenesisConfig::load(blockstore_path).unwrap_or_else(|err| {
         error!("Failed to load genesis from {:?}: {}", blockstore_path, err);
@@ -548,31 +559,43 @@ fn new_banks_from_blockstore(
         ..blockstore_processor::ProcessOptions::default()
     };
 
-    let (mut bank_forks, bank_forks_info, mut leader_schedule_cache) = bank_forks_utils::load(
-        &genesis_config,
-        &blockstore,
-        config.account_paths.clone(),
+    let bank = bank_forks_utils::bank_from_snapshot(
         config.snapshot_config.as_ref(),
-        process_options,
-    )
-    .unwrap_or_else(|err| {
-        error!("Failed to load ledger: {:?}", err);
-        std::process::exit(1);
-    });
+        &config.account_paths,
+    );
+
+    let snapshot_info = if let Some(ref bank) = bank {
+        Some(SnapshotInfo::new(bank.slot(), bank.hash()))
+    } else {
+        None
+    };
+
+    let (mut bank_forks, bank_forks_info, mut leader_schedule_cache) =
+        bank_forks_utils::load_ledger(
+            &genesis_config,
+            &blockstore,
+            config.account_paths.clone(),
+            bank,
+            process_options,
+        )
+        .unwrap_or_else(|err| {
+            error!("Failed to load ledger: {:?}", err);
+            std::process::exit(1);
+        });
 
     leader_schedule_cache.set_fixed_leader_schedule(config.fixed_leader_schedule.clone());
 
     bank_forks.set_snapshot_config(config.snapshot_config.clone());
 
     (
-        genesis_hash,
+        genesis_config,
         bank_forks,
         bank_forks_info,
         blockstore,
         ledger_signal_receiver,
         completed_slots_receiver,
         leader_schedule_cache,
-        genesis_config.poh_config,
+        snapshot_info,
     )
 }
 

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -537,6 +537,7 @@ fn load_bank_forks(
             snapshot_interval_slots: 0, // Value doesn't matter
             snapshot_package_output_path: ledger_path.clone(),
             snapshot_path: ledger_path.clone().join("snapshot"),
+            expected_snapshot_info: None,
         })
     };
     let account_paths = if let Some(account_paths) = arg_matches.value_of("account_paths") {

--- a/ledger/src/bank_forks.rs
+++ b/ledger/src/bank_forks.rs
@@ -6,7 +6,7 @@ use log::*;
 use solana_measure::measure::Measure;
 use solana_metrics::inc_new_counter_info;
 use solana_runtime::{bank::Bank, status_cache::MAX_CACHE_ENTRIES};
-use solana_sdk::{clock::Slot, timing};
+use solana_sdk::{clock::Slot, hash::Hash, timing};
 use std::{
     collections::{HashMap, HashSet},
     ops::Index,
@@ -26,6 +26,9 @@ pub struct SnapshotConfig {
 
     // Where to place the snapshots for recent slots
     pub snapshot_path: PathBuf,
+
+    // When loading a snapshot from disk, the slot and bank_hash for the snapshot must match
+    pub expected_snapshot_info: Option<(Slot, Hash)>,
 }
 
 #[derive(Error, Debug)]

--- a/ledger/src/bank_forks.rs
+++ b/ledger/src/bank_forks.rs
@@ -17,6 +17,18 @@ use std::{
 use thiserror::Error;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SnapshotInfo {
+    pub slot: Slot,
+    pub bank_hash: Hash,
+}
+
+impl SnapshotInfo {
+    pub fn new(slot: Slot, bank_hash: Hash) -> Self {
+        Self { slot, bank_hash }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct SnapshotConfig {
     // Generate a new snapshot every this many slots
     pub snapshot_interval_slots: usize,
@@ -28,7 +40,7 @@ pub struct SnapshotConfig {
     pub snapshot_path: PathBuf,
 
     // When loading a snapshot from disk, the slot and bank_hash for the snapshot must match
-    pub expected_snapshot_info: Option<(Slot, Hash)>,
+    pub expected_snapshot_info: Option<SnapshotInfo>,
 }
 
 #[derive(Error, Debug)]

--- a/ledger/src/bank_forks_utils.rs
+++ b/ledger/src/bank_forks_utils.rs
@@ -6,16 +6,14 @@ use crate::{
     snapshot_utils,
 };
 use log::*;
+use solana_runtime::bank::Bank;
 use solana_sdk::genesis_config::GenesisConfig;
 use std::{fs, path::PathBuf, sync::Arc};
 
-pub fn load(
-    genesis_config: &GenesisConfig,
-    blockstore: &Blockstore,
-    account_paths: Vec<PathBuf>,
+pub fn bank_from_snapshot(
     snapshot_config: Option<&SnapshotConfig>,
-    process_options: ProcessOptions,
-) -> BlockstoreProcessorResult {
+    account_paths: &[PathBuf],
+) -> Option<Bank> {
     if let Some(snapshot_config) = snapshot_config.as_ref() {
         info!(
             "Initializing snapshot path: {:?}",
@@ -37,48 +35,79 @@ pub fn load(
             }
 
             let deserialized_bank = snapshot_utils::bank_from_archive(
-                &account_paths,
+                account_paths,
                 &snapshot_config.snapshot_path,
                 &tar,
             )
             .expect("Load from snapshot failed");
 
-            if let Some((slot, bank_hash)) = snapshot_config.expected_snapshot_info {
-                if slot != deserialized_bank.slot() {
+            if let Some(ref snapshot_info) = snapshot_config.expected_snapshot_info {
+                if snapshot_info.slot != deserialized_bank.slot() {
                     panic!(
                         "Snapshot bank slot mismatch: expected={} actual={}",
-                        slot,
+                        snapshot_info.slot,
                         deserialized_bank.slot()
                     );
                 }
-                if bank_hash != deserialized_bank.hash() {
+                if snapshot_info.bank_hash != deserialized_bank.hash() {
                     panic!(
                         "Snapshot bank bank_hash mismatch: expected={} actual={}",
-                        bank_hash,
+                        snapshot_info.bank_hash,
                         deserialized_bank.hash()
                     );
                 }
             }
-
-            return blockstore_processor::process_blockstore_from_root(
-                genesis_config,
-                blockstore,
-                Arc::new(deserialized_bank),
-                &process_options,
-                &VerifyRecyclers::default(),
-            );
+            Some(deserialized_bank)
         } else {
             info!("Snapshot package does not exist: {:?}", tar);
+            None
         }
     } else {
         info!("Snapshots disabled");
+        None
     }
+}
 
-    info!("Processing ledger from genesis");
-    blockstore_processor::process_blockstore(
-        &genesis_config,
-        &blockstore,
+pub fn load_ledger(
+    genesis_config: &GenesisConfig,
+    blockstore: &Blockstore,
+    account_paths: Vec<PathBuf>,
+    bank: Option<Bank>,
+    process_options: ProcessOptions,
+) -> BlockstoreProcessorResult {
+    if let Some(bank) = bank {
+        info!("Processing ledger from slot {}", bank.slot());
+        blockstore_processor::process_blockstore_from_root(
+            genesis_config,
+            blockstore,
+            Arc::new(bank),
+            &process_options,
+            &VerifyRecyclers::default(),
+        )
+    } else {
+        info!("Processing ledger from genesis");
+        blockstore_processor::process_blockstore(
+            &genesis_config,
+            &blockstore,
+            account_paths,
+            process_options,
+        )
+    }
+}
+
+pub fn load(
+    genesis_config: &GenesisConfig,
+    blockstore: &Blockstore,
+    account_paths: Vec<PathBuf>,
+    snapshot_config: Option<&SnapshotConfig>,
+    process_options: ProcessOptions,
+) -> BlockstoreProcessorResult {
+    let bank = bank_from_snapshot(snapshot_config, &account_paths);
+    load_ledger(
+        genesis_config,
+        blockstore,
         account_paths,
+        bank,
         process_options,
     )
 }

--- a/ledger/src/bank_forks_utils.rs
+++ b/ledger/src/bank_forks_utils.rs
@@ -43,6 +43,23 @@ pub fn load(
             )
             .expect("Load from snapshot failed");
 
+            if let Some((slot, bank_hash)) = snapshot_config.expected_snapshot_info {
+                if slot != deserialized_bank.slot() {
+                    panic!(
+                        "Snapshot bank slot mismatch: expected={} actual={}",
+                        slot,
+                        deserialized_bank.slot()
+                    );
+                }
+                if bank_hash != deserialized_bank.hash() {
+                    panic!(
+                        "Snapshot bank bank_hash mismatch: expected={} actual={}",
+                        bank_hash,
+                        deserialized_bank.hash()
+                    );
+                }
+            }
+
             return blockstore_processor::process_blockstore_from_root(
                 genesis_config,
                 blockstore,

--- a/ledger/src/snapshot_package.rs
+++ b/ledger/src/snapshot_package.rs
@@ -1,5 +1,5 @@
 use solana_runtime::{accounts_db::AccountStorageEntry, bank::BankSlotDelta};
-use solana_sdk::clock::Slot;
+use solana_sdk::{clock::Slot, hash::Hash};
 use std::{
     path::PathBuf,
     sync::{
@@ -16,6 +16,7 @@ pub type SnapshotPackageSendError = SendError<SnapshotPackage>;
 #[derive(Debug)]
 pub struct SnapshotPackage {
     pub root: Slot,
+    pub bank_hash: Hash,
     pub slot_deltas: Vec<BankSlotDelta>,
     pub snapshot_links: TempDir,
     pub storage_entries: Vec<Arc<AccountStorageEntry>>,
@@ -25,6 +26,7 @@ pub struct SnapshotPackage {
 impl SnapshotPackage {
     pub fn new(
         root: Slot,
+        bank_hash: Hash,
         slot_deltas: Vec<BankSlotDelta>,
         snapshot_links: TempDir,
         storage_entries: Vec<Arc<AccountStorageEntry>>,
@@ -32,6 +34,7 @@ impl SnapshotPackage {
     ) -> Self {
         Self {
             root,
+            bank_hash,
             slot_deltas,
             snapshot_links,
             storage_entries,

--- a/ledger/src/snapshot_utils.rs
+++ b/ledger/src/snapshot_utils.rs
@@ -102,6 +102,7 @@ pub fn package_snapshot<P: AsRef<Path>, Q: AsRef<Path>>(
 
     let package = SnapshotPackage::new(
         bank.slot(),
+        bank.hash(),
         bank.src.slot_deltas(slots_to_snapshot),
         snapshot_hard_links_dir,
         account_storage_entries,

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -1000,6 +1000,7 @@ fn setup_snapshot_validator_config(
         snapshot_interval_slots,
         snapshot_package_output_path: PathBuf::from(snapshot_output_path.path()),
         snapshot_path: PathBuf::from(snapshot_dir.path()),
+        expected_snapshot_info: None,
     };
 
     // Create the account paths

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -748,6 +748,7 @@ pub fn main() {
         },
         snapshot_path,
         snapshot_package_output_path: ledger_path.clone(),
+        expected_snapshot_info: None,
     });
 
     if matches.is_present("limit_ledger_size") {


### PR DESCRIPTION
Snapshot selection is currently too dumb, an RPC node at random is selected.  In a cluster with delinquency, there's a chance that a new validator will fetch a snapshot from a delinquent validator and then likely go delinquent itself.   This can cause a delinquency chain and take down a cluster.

To avoid this validators now gossip the latest snapshot they've created -- the slot and bank hash.   When a new validator starts, it now downloads a snapshot from one of the nodes with the highest snapshot slot

Fixes #8292