### PR TITLE
Add VoteTracker for tracking cluster's votes in gossip

### DIFF
--- a/core/src/cluster_info_vote_listener.rs
+++ b/core/src/cluster_info_vote_listener.rs
@@ -61,7 +61,10 @@ impl VoteTracker {
         let epoch = self.epoch_schedule.get_epoch(slot);
         self.epoch_authorized_voters
             .get(pubkey)
-            .map(|authorized_voters| authorized_voters.get_authorized_voter(epoch))
+            .map(|authorized_voters| {
+                println!("authorized voters: {:?}", authorized_voters);
+                authorized_voters.get_authorized_voter(epoch)
+            })
             .unwrap_or(None)
     }
 
@@ -88,7 +91,9 @@ impl VoteTracker {
                     return None;
                 }
                 let vote_state = vote_state.unwrap();
+                println!("Found vote state");
                 if *stake > 0 {
+                    println!("Found vote state with stake > 0, key: {:?}", key);
                     let mut authorized_voters = vote_state.authorized_voters().clone();
                     authorized_voters.get_and_cache_authorized_voter_for_epoch(epoch);
                     authorized_voters.get_and_cache_authorized_voter_for_epoch(epoch + 1);
@@ -292,6 +297,10 @@ impl ClusterInfoVoteListener {
                         let actual_authorized_voter =
                             vote_tracker.get_authorized_voter(&vote_pubkey, *last_vote_slot);
 
+                        println!(
+                            "vk: {:?}, actual_av: {:?}",
+                            vote_pubkey, actual_authorized_voter
+                        );
                         if actual_authorized_voter.is_none() {
                             continue;
                         }
@@ -476,6 +485,11 @@ mod tests {
         validator_voting_keypairs.iter().for_each(|keypairs| {
             let node_keypair = &keypairs.node_keypair;
             let vote_keypair = &keypairs.vote_keypair;
+            println!(
+                "nk: {:?}, vk: {:?}",
+                node_keypair.pubkey().to_string(),
+                vote_keypair.pubkey().to_string()
+            );
             let vote_ix = vote_instruction::vote(
                 &node_keypair.pubkey(),
                 &vote_keypair.pubkey(),

--- a/core/src/cluster_info_vote_listener.rs
+++ b/core/src/cluster_info_vote_listener.rs
@@ -6,15 +6,74 @@ use crate::{packet, sigverify};
 use crossbeam_channel::{
     unbounded, Receiver as CrossbeamReceiver, RecvTimeoutError, Sender as CrossbeamSender,
 };
+use solana_ledger::bank_forks::BankForks;
 use solana_metrics::inc_new_counter_debug;
-use solana_sdk::{clock::Slot, pubkey::Pubkey, transaction::Transaction};
+use solana_runtime::bank::Bank;
+use solana_sdk::{
+    clock::Slot, program_utils::limited_deserialize, pubkey::Pubkey, transaction::Transaction,
+};
+use solana_vote_program::vote_instruction::VoteInstruction;
+use std::collections::{HashMap, HashSet};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, RwLock};
 use std::thread::{self, sleep, Builder, JoinHandle};
 use std::time::Duration;
 
-pub type VoteSender = CrossbeamSender<(Pubkey, Vec<Slot>)>;
-pub type VoteReceiver = CrossbeamReceiver<(Pubkey, Vec<Slot>)>;
+pub struct VoteTracker {
+    // Don't track votes from people who are not staked, acts as a spam filter
+    epoch_validators: HashSet<Arc<Pubkey>>,
+    // Map from a slot to a set of validators who have voted for that slot
+    votes: HashMap<Slot, HashSet<Arc<Pubkey>>>,
+    current_epoch: u64,
+}
+
+impl VoteTracker {
+    pub fn new(root_bank: &Bank) -> Self {
+        let current_epoch = root_bank.epoch_schedule().get_epoch(root_bank.slot());
+        let epoch_validators = Self::get_staked_pubkeys(root_bank, current_epoch);
+        Self {
+            epoch_validators,
+            votes: HashMap::new(),
+            current_epoch,
+        }
+    }
+
+    pub fn votes(&self) -> &HashMap<Slot, HashSet<Arc<Pubkey>>> {
+        &self.votes
+    }
+
+    pub fn get_voter_pubkey(&self, pubkey: &Pubkey) -> Option<&Arc<Pubkey>> {
+        self.epoch_validators.get(pubkey)
+    }
+
+    pub fn get_staked_pubkeys(bank: &Bank, current_epoch: u64) -> HashSet<Arc<Pubkey>> {
+        let mut i = 0;
+        let epoch_validators = HashSet::new();
+        loop {
+            // Get all known vote accounts with nonzero stake in any
+            // upcoming epochs
+            if let Some(vote_accounts) = bank.epoch_vote_accounts(current_epoch + i) {
+                let staked_pubkeys = vote_accounts
+                    .into_iter()
+                    .filter_map(|(pk, (stake, _))| {
+                        if *stake > 0 {
+                            Some(Arc::new(*pk))
+                        } else {
+                            None
+                        }
+                    })
+                    .collect();
+
+                epoch_validators.union(&staked_pubkeys);
+            } else {
+                break;
+            }
+            i += 1;
+        }
+
+        epoch_validators
+    }
+}
 
 pub struct ClusterInfoVoteListener {
     thread_hdls: Vec<JoinHandle<()>>,
@@ -27,29 +86,32 @@ impl ClusterInfoVoteListener {
         sigverify_disabled: bool,
         sender: CrossbeamSender<Vec<Packets>>,
         poh_recorder: &Arc<Mutex<PohRecorder>>,
-        vote_sender: VoteSender,
+        vote_tracker: Arc<RwLock<VoteTracker>>,
+        bank_forks: Arc<RwLock<BankForks>>,
     ) -> Self {
-        let exit = exit.clone();
+        let exit_ = exit.clone();
         let poh_recorder = poh_recorder.clone();
-        let (vote_tx_sender, vote_tx_receiver) = unbounded();
+        let (vote_txs_sender, vote_txs_receiver) = unbounded();
         let listen_thread = Builder::new()
             .name("solana-cluster_info_vote_listener".to_string())
             .spawn(move || {
                 let _ = Self::recv_loop(
-                    exit,
+                    exit_,
                     &cluster_info,
                     sigverify_disabled,
                     &sender,
-                    vote_tx_sender,
+                    vote_txs_sender,
                     poh_recorder,
                 );
             })
             .unwrap();
 
+        let exit_ = exit.clone();
         let send_thread = Builder::new()
-            .name("solana-cluster_info_vote_sender".to_string())
+            .name("solana-cluster_info_process_votes".to_string())
             .spawn(move || {
-                let _ = Self::send_loop(exit, vote_tx_receiver, vote_sender);
+                let _ =
+                    Self::process_votes_loop(exit_, vote_txs_receiver, vote_tracker, &bank_forks);
             })
             .unwrap();
 
@@ -63,7 +125,7 @@ impl ClusterInfoVoteListener {
         cluster_info: &Arc<RwLock<ClusterInfo>>,
         sigverify_disabled: bool,
         packets_sender: &CrossbeamSender<Vec<Packets>>,
-        vote_tx_sender: CrossbeamSender<Transaction>,
+        vote_txs_sender: CrossbeamSender<Vec<Transaction>>,
         poh_recorder: Arc<Mutex<PohRecorder>>,
     ) -> Result<()> {
         loop {
@@ -84,14 +146,23 @@ impl ClusterInfoVoteListener {
                         sigverify::ed25519_verify_cpu(&msgs)
                     };
                     assert_eq!(
-                        r.iter().map(|packets_results| packets_results.len()).sum(),
-                        votes.len(0)
+                        r.iter()
+                            .map(|packets_results| packets_results.len())
+                            .sum::<usize>(),
+                        votes.len()
                     );
-                    for (vote_tx, result) in votes.zip(r.iter().flatten()) {
-                        if result != 0 {
-                            vote_tx_sender.send(vote_tx);
-                        }
-                    }
+                    let valid_votes: Vec<_> = votes
+                        .into_iter()
+                        .zip(r.iter().flatten())
+                        .filter_map(|(vote, verify_result)| {
+                            if *verify_result != 0 {
+                                Some(vote)
+                            } else {
+                                None
+                            }
+                        })
+                        .collect();
+                    vote_txs_sender.send(valid_votes)?;
                     sigverify::mark_disabled(&mut msgs, &r);
                     packets_sender.send(msgs)?;
                 }
@@ -100,16 +171,26 @@ impl ClusterInfoVoteListener {
         }
     }
 
-    fn send_loop(
+    fn process_votes_loop(
         exit: Arc<AtomicBool>,
-        vote_tx_receiver: CrossbeamReceiver<Transaction>,
-        vote_sender: VoteSender,
+        vote_txs_receiver: CrossbeamReceiver<Vec<Transaction>>,
+        vote_tracker: Arc<RwLock<VoteTracker>>,
+        bank_forks: &RwLock<BankForks>,
     ) -> Result<()> {
+        let mut old_root = bank_forks.read().unwrap().root();
         loop {
             if exit.load(Ordering::Relaxed) {
                 return Ok(());
             }
-            if let Err(e) = Self::run_deserialize_and_send_vote(&vote_tx_receiver, &vote_sender) {
+
+            let root_bank = bank_forks.read().unwrap().root_bank().clone();
+
+            if root_bank.slot() != old_root {
+                Self::process_new_root(&root_bank, &vote_tracker);
+                old_root = root_bank.slot();
+            }
+
+            if let Err(e) = Self::process_votes(&vote_txs_receiver, &vote_tracker) {
                 match e {
                     Error::CrossbeamRecvTimeoutError(RecvTimeoutError::Disconnected) => {
                         return Ok(());
@@ -123,17 +204,90 @@ impl ClusterInfoVoteListener {
         }
     }
 
-    fn run_deserialize_and_send_vote(
-        vote_tx_receiver: &CrossbeamReceiver<Transaction>,
-        vote_sender: &VoteSender,
+    fn process_votes(
+        vote_txs_receiver: &CrossbeamReceiver<Vec<Transaction>>,
+        vote_tracker: &Arc<RwLock<VoteTracker>>,
     ) -> Result<()> {
         let timer = Duration::from_millis(200);
-        let tx = vote_tx_receiver.recv_timeout(timer)?;
-        while let Ok(shred) = vote_tx_receiver.try_recv() {
-            vote_sender.send((0, Pubkey::default()));
+        let mut vote_txs = vote_txs_receiver.recv_timeout(timer)?;
+        let mut diff: HashMap<Slot, HashSet<Arc<Pubkey>>> = HashMap::new();
+        {
+            let vote_tracker = vote_tracker.read().unwrap();
+            let slot_pubkeys = &vote_tracker.votes;
+            while let Ok(new_txs) = vote_txs_receiver.try_recv() {
+                vote_txs.extend(new_txs);
+            }
+
+            for tx in vote_txs {
+                if let (Some(instruction), Some(vote_pubkey)) = (
+                    tx.message.instructions.first(),
+                    tx.message.instructions.first(),
+                ) {
+                    if let Ok(instruction) = limited_deserialize(&instruction.data) {
+                        let (vote, vote_pubkey) = {
+                            match instruction {
+                                VoteInstruction::Vote(vote) => (vote, Pubkey::default()),
+                                _ => {
+                                    continue;
+                                }
+                            }
+                        };
+
+                        // Only accept votes from vote pubkeys with non-zero stake
+                        if let Some(vote_pubkey) = vote_tracker.get_voter_pubkey(&vote_pubkey) {
+                            for slot in vote.slots {
+                                if slot_pubkeys
+                                    .get(&slot)
+                                    .map(|slot_vote_pubkeys| {
+                                        slot_vote_pubkeys.contains(vote_pubkey)
+                                    })
+                                    .unwrap_or(false)
+                                {
+                                    diff.entry(slot).or_default().insert(vote_pubkey.clone());
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        let mut vote_tracker = vote_tracker.write().unwrap();
+        let all_votes = &mut vote_tracker.votes;
+        for (slot, slot_diff) in diff {
+            let slot_pubkeys = all_votes.entry(slot).or_default();
+            for pk in slot_diff {
+                slot_pubkeys.insert(pk);
+            }
         }
 
         Ok(())
+    }
+
+    pub fn process_new_root(root_bank: &Bank, vote_tracker: &RwLock<VoteTracker>) {
+        let new_epoch = root_bank.epoch_schedule().get_epoch(root_bank.slot());
+        if new_epoch != vote_tracker.read().unwrap().current_epoch {
+            let mut current_validators = vote_tracker.read().unwrap().epoch_validators.clone();
+            let new_epoch_validators = VoteTracker::get_staked_pubkeys(root_bank, new_epoch);
+
+            // Remove the old pubkeys
+            current_validators.retain(|v| new_epoch_validators.contains(v));
+
+            // Insert any new pubkeys, don't re-insert ones we already have,
+            // otherwise memory usage increases from the duplicates being held
+            // in VoteTracker.votes
+            let new_public_keys: Vec<_> = new_epoch_validators
+                .difference(&current_validators)
+                .cloned()
+                .collect();
+            for key in new_public_keys {
+                current_validators.insert(key);
+            }
+
+            let mut vote_tracker = vote_tracker.write().unwrap();
+            std::mem::swap(&mut current_validators, &mut vote_tracker.epoch_validators);
+            vote_tracker.current_epoch = new_epoch;
+        }
     }
 
     pub fn join(self) -> thread::Result<()> {

--- a/core/src/cluster_info_vote_listener.rs
+++ b/core/src/cluster_info_vote_listener.rs
@@ -1,14 +1,20 @@
 use crate::cluster_info::{ClusterInfo, GOSSIP_SLEEP_MILLIS};
 use crate::packet::Packets;
 use crate::poh_recorder::PohRecorder;
-use crate::result::Result;
+use crate::result::{Error, Result};
 use crate::{packet, sigverify};
-use crossbeam_channel::Sender as CrossbeamSender;
+use crossbeam_channel::{
+    unbounded, Receiver as CrossbeamReceiver, RecvTimeoutError, Sender as CrossbeamSender,
+};
 use solana_metrics::inc_new_counter_debug;
+use solana_sdk::{clock::Slot, pubkey::Pubkey, transaction::Transaction};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, RwLock};
 use std::thread::{self, sleep, Builder, JoinHandle};
 use std::time::Duration;
+
+pub type VoteSender = CrossbeamSender<(Pubkey, Vec<Slot>)>;
+pub type VoteReceiver = CrossbeamReceiver<(Pubkey, Vec<Slot>)>;
 
 pub struct ClusterInfoVoteListener {
     thread_hdls: Vec<JoinHandle<()>>,
@@ -21,10 +27,12 @@ impl ClusterInfoVoteListener {
         sigverify_disabled: bool,
         sender: CrossbeamSender<Vec<Packets>>,
         poh_recorder: &Arc<Mutex<PohRecorder>>,
+        vote_sender: VoteSender,
     ) -> Self {
         let exit = exit.clone();
         let poh_recorder = poh_recorder.clone();
-        let thread = Builder::new()
+        let (vote_tx_sender, vote_tx_receiver) = unbounded();
+        let listen_thread = Builder::new()
             .name("solana-cluster_info_vote_listener".to_string())
             .spawn(move || {
                 let _ = Self::recv_loop(
@@ -32,19 +40,30 @@ impl ClusterInfoVoteListener {
                     &cluster_info,
                     sigverify_disabled,
                     &sender,
+                    vote_tx_sender,
                     poh_recorder,
                 );
             })
             .unwrap();
+
+        let send_thread = Builder::new()
+            .name("solana-cluster_info_vote_sender".to_string())
+            .spawn(move || {
+                let _ = Self::send_loop(exit, vote_tx_receiver, vote_sender);
+            })
+            .unwrap();
+
         Self {
-            thread_hdls: vec![thread],
+            thread_hdls: vec![listen_thread, send_thread],
         }
     }
+
     fn recv_loop(
         exit: Arc<AtomicBool>,
         cluster_info: &Arc<RwLock<ClusterInfo>>,
         sigverify_disabled: bool,
-        sender: &CrossbeamSender<Vec<Packets>>,
+        packets_sender: &CrossbeamSender<Vec<Packets>>,
+        vote_tx_sender: CrossbeamSender<Transaction>,
         poh_recorder: Arc<Mutex<PohRecorder>>,
     ) -> Result<()> {
         loop {
@@ -64,12 +83,57 @@ impl ClusterInfoVoteListener {
                     } else {
                         sigverify::ed25519_verify_cpu(&msgs)
                     };
+                    assert_eq!(
+                        r.iter().map(|packets_results| packets_results.len()).sum(),
+                        votes.len(0)
+                    );
+                    for (vote_tx, result) in votes.zip(r.iter().flatten()) {
+                        if result != 0 {
+                            vote_tx_sender.send(vote_tx);
+                        }
+                    }
                     sigverify::mark_disabled(&mut msgs, &r);
-                    sender.send(msgs)?;
+                    packets_sender.send(msgs)?;
                 }
             }
             sleep(Duration::from_millis(GOSSIP_SLEEP_MILLIS));
         }
+    }
+
+    fn send_loop(
+        exit: Arc<AtomicBool>,
+        vote_tx_receiver: CrossbeamReceiver<Transaction>,
+        vote_sender: VoteSender,
+    ) -> Result<()> {
+        loop {
+            if exit.load(Ordering::Relaxed) {
+                return Ok(());
+            }
+            if let Err(e) = Self::run_deserialize_and_send_vote(&vote_tx_receiver, &vote_sender) {
+                match e {
+                    Error::CrossbeamRecvTimeoutError(RecvTimeoutError::Disconnected) => {
+                        return Ok(());
+                    }
+                    Error::CrossbeamRecvTimeoutError(RecvTimeoutError::Timeout) => (),
+                    _ => {
+                        error!("thread {:?} error {:?}", thread::current().name(), e);
+                    }
+                }
+            }
+        }
+    }
+
+    fn run_deserialize_and_send_vote(
+        vote_tx_receiver: &CrossbeamReceiver<Transaction>,
+        vote_sender: &VoteSender,
+    ) -> Result<()> {
+        let timer = Duration::from_millis(200);
+        let tx = vote_tx_receiver.recv_timeout(timer)?;
+        while let Ok(shred) = vote_tx_receiver.try_recv() {
+            vote_sender.send((0, Pubkey::default()));
+        }
+
+        Ok(())
     }
 
     pub fn join(self) -> thread::Result<()> {

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -177,7 +177,7 @@ impl ReplayStage {
         cluster_info: Arc<RwLock<ClusterInfo>>,
         ledger_signal_receiver: Receiver<bool>,
         poh_recorder: Arc<Mutex<PohRecorder>>,
-        _vote_tracker: Arc<RwLock<VoteTracker>>,
+        _vote_tracker: Arc<VoteTracker>,
     ) -> (Self, Receiver<Vec<Arc<Bank>>>) {
         let ReplayStageConfig {
             my_pubkey,

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -177,7 +177,7 @@ impl ReplayStage {
         cluster_info: Arc<RwLock<ClusterInfo>>,
         ledger_signal_receiver: Receiver<bool>,
         poh_recorder: Arc<Mutex<PohRecorder>>,
-        vote_tracker: Arc<RwLock<VoteTracker>>,
+        _vote_tracker: Arc<RwLock<VoteTracker>>,
     ) -> (Self, Receiver<Vec<Arc<Bank>>>) {
         let ReplayStageConfig {
             my_pubkey,

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -2,11 +2,12 @@
 
 use crate::{
     cluster_info::ClusterInfo,
-    cluster_info_vote_listener::VoteReceiver,
+    cluster_info_vote_listener::VoteTracker,
     commitment::{AggregateCommitmentService, BlockCommitmentCache, CommitmentAggregationData},
     consensus::{StakeLockout, Tower},
     poh_recorder::{PohRecorder, GRACE_TICKS_FACTOR, MAX_GRACE_SLOTS},
     result::Result,
+    rewards_recorder_service::RewardsRecorderSender,
     rpc_subscriptions::RpcSubscriptions,
 };
 use solana_ledger::{
@@ -86,6 +87,7 @@ pub struct ReplayStageConfig {
     pub snapshot_package_sender: Option<SnapshotPackageSender>,
     pub block_commitment_cache: Arc<RwLock<BlockCommitmentCache>>,
     pub transaction_status_sender: Option<TransactionStatusSender>,
+    pub rewards_recorder_sender: Option<RewardsRecorderSender>,
 }
 
 pub struct ReplayStage {
@@ -175,7 +177,7 @@ impl ReplayStage {
         cluster_info: Arc<RwLock<ClusterInfo>>,
         ledger_signal_receiver: Receiver<bool>,
         poh_recorder: Arc<Mutex<PohRecorder>>,
-        vote_receiver: VoteReceiver,
+        vote_tracker: Arc<RwLock<VoteTracker>>,
     ) -> (Self, Receiver<Vec<Arc<Bank>>>) {
         let ReplayStageConfig {
             my_pubkey,
@@ -189,6 +191,7 @@ impl ReplayStage {
             snapshot_package_sender,
             block_commitment_cache,
             transaction_status_sender,
+            rewards_recorder_sender,
         } = config;
 
         let (root_bank_sender, root_bank_receiver) = channel();
@@ -235,6 +238,7 @@ impl ReplayStage {
                         &bank_forks,
                         &leader_schedule_cache,
                         &subscriptions,
+                        rewards_recorder_sender.clone(),
                     );
                     Self::report_memory(&allocated, "generate_new_bank_forks", start);
 
@@ -438,6 +442,7 @@ impl ReplayStage {
                             &poh_recorder,
                             &leader_schedule_cache,
                             &subscriptions,
+                            rewards_recorder_sender.clone(),
                         );
 
                         if let Some(bank) = poh_recorder.lock().unwrap().bank() {
@@ -519,6 +524,7 @@ impl ReplayStage {
         poh_recorder: &Arc<Mutex<PohRecorder>>,
         leader_schedule_cache: &Arc<LeaderScheduleCache>,
         subscriptions: &Arc<RpcSubscriptions>,
+        rewards_recorder_sender: Option<RewardsRecorderSender>,
     ) {
         // all the individual calls to poh_recorder.lock() are designed to
         // increase granularity, decrease contention
@@ -1182,6 +1188,7 @@ impl ReplayStage {
         forks_lock: &RwLock<BankForks>,
         leader_schedule_cache: &Arc<LeaderScheduleCache>,
         subscriptions: &Arc<RpcSubscriptions>,
+        rewards_recorder_sender: Option<RewardsRecorderSender>,
     ) {
         // Find the next slot that chains to the old slot
         let forks = forks_lock.read().unwrap();
@@ -1330,7 +1337,6 @@ pub(crate) mod tests {
     struct ForkSelectionResponse {
         slot: u64,
         is_locked_out: bool,
-        is_available: bool,
     }
 
     fn simulate_fork_selection(
@@ -1626,6 +1632,7 @@ pub(crate) mod tests {
                 &bank_forks,
                 &leader_schedule_cache,
                 &subscriptions,
+                None,
             );
             assert!(bank_forks.read().unwrap().get(1).is_some());
 
@@ -1638,6 +1645,7 @@ pub(crate) mod tests {
                 &bank_forks,
                 &leader_schedule_cache,
                 &subscriptions,
+                None,
             );
             assert!(bank_forks.read().unwrap().get(1).is_some());
             assert!(bank_forks.read().unwrap().get(2).is_some());

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -48,7 +48,7 @@ impl Tpu {
         broadcast_type: &BroadcastStageType,
         exit: &Arc<AtomicBool>,
         shred_version: u16,
-        vote_tracker: Arc<RwLock<VoteTracker>>,
+        vote_tracker: Arc<VoteTracker>,
         bank_forks: Arc<RwLock<BankForks>>,
     ) -> Self {
         let (packet_sender, packet_receiver) = channel();

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -5,7 +5,7 @@ use crate::{
     banking_stage::BankingStage,
     broadcast_stage::{BroadcastStage, BroadcastStageType},
     cluster_info::ClusterInfo,
-    cluster_info_vote_listener::ClusterInfoVoteListener,
+    cluster_info_vote_listener::{ClusterInfoVoteListener, VoteSender},
     fetch_stage::FetchStage,
     poh_recorder::{PohRecorder, WorkingBankEntry},
     sigverify::TransactionSigVerifier,
@@ -46,6 +46,7 @@ impl Tpu {
         broadcast_type: &BroadcastStageType,
         exit: &Arc<AtomicBool>,
         shred_version: u16,
+        vote_sender: VoteSender,
     ) -> Self {
         let (packet_sender, packet_receiver) = channel();
         let fetch_stage = FetchStage::new_with_sender(
@@ -72,6 +73,7 @@ impl Tpu {
             sigverify_disabled,
             verified_vote_sender,
             &poh_recorder,
+            vote_sender,
         );
 
         let banking_stage = BankingStage::new(

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -4,7 +4,7 @@
 use crate::{
     blockstream_service::BlockstreamService,
     cluster_info::ClusterInfo,
-    cluster_info_vote_listener::VoteReceiver,
+    cluster_info_vote_listener::VoteTracker,
     commitment::BlockCommitmentCache,
     ledger_cleanup_service::LedgerCleanupService,
     poh_recorder::PohRecorder,
@@ -172,7 +172,7 @@ impl Tvu {
             cluster_info.clone(),
             ledger_signal_receiver,
             poh_recorder.clone(),
-            vote_receiver,
+            vote_tracker,
         );
 
         let blockstream_service = if let Some(blockstream_unix_socket) = blockstream_unix_socket {

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -4,6 +4,7 @@
 use crate::{
     blockstream_service::BlockstreamService,
     cluster_info::ClusterInfo,
+    cluster_info_vote_listener::VoteReceiver,
     commitment::BlockCommitmentCache,
     ledger_cleanup_service::LedgerCleanupService,
     poh_recorder::PohRecorder,
@@ -171,6 +172,7 @@ impl Tvu {
             cluster_info.clone(),
             ledger_signal_receiver,
             poh_recorder.clone(),
+            vote_receiver,
         );
 
         let blockstream_service = if let Some(blockstream_unix_socket) = blockstream_unix_socket {

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -88,7 +88,11 @@ impl Tvu {
         shred_version: u16,
         transaction_status_sender: Option<TransactionStatusSender>,
         rewards_recorder_sender: Option<RewardsRecorderSender>,
+<<<<<<< HEAD
         snapshot_package_sender: Option<SnapshotPackageSender>,
+=======
+        vote_tracker: Arc<VoteTracker>,
+>>>>>>> Use more fine grained locking
     ) -> Self {
         let keypair: Arc<Keypair> = cluster_info
             .read()
@@ -304,7 +308,7 @@ pub mod tests {
             None,
             None,
             None,
-            Arc::new(RwLock::new(VoteTracker::new(&bank))),
+            Arc::new(VoteTracker::new(&bank)),
         );
         exit.store(true, Ordering::Relaxed);
         tvu.join().unwrap();

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -88,11 +88,8 @@ impl Tvu {
         shred_version: u16,
         transaction_status_sender: Option<TransactionStatusSender>,
         rewards_recorder_sender: Option<RewardsRecorderSender>,
-<<<<<<< HEAD
         snapshot_package_sender: Option<SnapshotPackageSender>,
-=======
         vote_tracker: Arc<VoteTracker>,
->>>>>>> Use more fine grained locking
     ) -> Self {
         let keypair: Arc<Keypair> = cluster_info
             .read()

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -304,6 +304,7 @@ pub mod tests {
             None,
             None,
             None,
+            Arc::new(RwLock::new(VoteTracker::new(&bank))),
         );
         exit.store(true, Ordering::Relaxed);
         tvu.join().unwrap();

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -429,6 +429,7 @@ impl Validator {
             transaction_status_sender.clone(),
             rewards_recorder_sender,
             snapshot_package_sender,
+            vote_tracker.clone(),
         );
 
         if config.dev_sigverify_disabled {

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -379,14 +379,7 @@ impl Validator {
             "New shred signal for the TVU should be the same as the clear bank signal."
         );
 
-        let vote_tracker = Arc::new(RwLock::new({
-            let bank_forks = bank_forks.read().unwrap();
-            VoteTracker::new(
-                bank_forks
-                    .get(bank_forks.root())
-                    .expect("Root bank must exist"),
-            )
-        }));
+        let vote_tracker = Arc::new({ VoteTracker::new(bank_forks.read().unwrap().root_bank()) });
 
         let tvu = Tvu::new(
             vote_account,

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -378,6 +378,7 @@ impl Validator {
             "New shred signal for the TVU should be the same as the clear bank signal."
         );
 
+        let (vote_sender, vote_receiver) = unbounded();
         let tvu = Tvu::new(
             vote_account,
             voting_keypair,
@@ -445,6 +446,7 @@ impl Validator {
             &config.broadcast_stage_type,
             &exit,
             node.info.shred_version,
+            vote_sender,
         );
 
         datapoint_info!("validator-new", ("id", id.to_string(), String));

--- a/ledger/src/bank_forks.rs
+++ b/ledger/src/bank_forks.rs
@@ -122,6 +122,10 @@ impl BankForks {
         self.banks.get(&bank_slot)
     }
 
+    pub fn root_bank(&self) -> &Arc<Bank> {
+        self.banks.get(&self.root()).expect("Root bank must exist")
+    }
+
     pub fn new_from_banks(initial_forks: &[Arc<Bank>], rooted_path: Vec<Slot>) -> Self {
         let mut banks = HashMap::new();
         let working_bank = initial_forks[0].clone();

--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -178,7 +178,7 @@ impl MessageProcessor {
             .accounts
             .iter()
             .map(|&index| {
-                let is_signer = index < message.header.num_required_signatures;
+                let is_signer = message.is_signer(index as usize);
                 let index = index as usize;
                 let key = &message.account_keys[index];
                 let account = &accounts[index];

--- a/sdk/src/message.rs
+++ b/sdk/src/message.rs
@@ -260,6 +260,10 @@ impl Message {
                     - self.header.num_readonly_unsigned_accounts as usize)
     }
 
+    pub fn is_signer(&self, i: usize) -> bool {
+        i < self.header.num_required_signatures as usize
+    }
+
     pub fn get_account_keys_by_lock_type(&self) -> (Vec<&Pubkey>, Vec<&Pubkey>) {
         let mut writable_keys = vec![];
         let mut readonly_keys = vec![];


### PR DESCRIPTION
#### Problem
No way to track which validators have voted for which slots in gossip

#### Summary of Changes
Add a VoteTracker in a listener service that monitors gossip to track the votes per slot.

Relies on `vote_state` updates in: https://github.com/solana-labs/solana/pull/8303 
Fixes #
