### PR TITLE
Add Preview operating mode, rename SoftLaunch operating mode to Stable

### DIFF
--- a/genesis-programs/src/lib.rs
+++ b/genesis-programs/src/lib.rs
@@ -32,7 +32,7 @@ pub fn get_inflation(operating_mode: OperatingMode, epoch: Epoch) -> Option<Infl
                 None
             }
         }
-        OperatingMode::SoftLaunch => {
+        OperatingMode::Stable | OperatingMode::Preview => {
             if epoch == 0 {
                 // No inflation at epoch 0
                 Some(Inflation::new_disabled())
@@ -54,7 +54,7 @@ pub fn get_programs(operating_mode: OperatingMode, epoch: Epoch) -> Option<Vec<(
         OperatingMode::Development => {
             if epoch == 0 {
                 Some(vec![
-                    // Enable all SoftLaunch programs
+                    // Enable all Stable programs
                     solana_bpf_loader_program!(),
                     solana_config_program!(),
                     solana_stake_program!(),
@@ -71,7 +71,7 @@ pub fn get_programs(operating_mode: OperatingMode, epoch: Epoch) -> Option<Vec<(
                 None
             }
         }
-        OperatingMode::SoftLaunch => {
+        OperatingMode::Stable => {
             if epoch == 0 {
                 Some(vec![
                     solana_config_program!(),
@@ -82,11 +82,28 @@ pub fn get_programs(operating_mode: OperatingMode, epoch: Epoch) -> Option<Vec<(
             } else if epoch == std::u64::MAX - 1 {
                 // The epoch of std::u64::MAX - 1 is a placeholder and is expected to be reduced in
                 // a future hard fork.
-                Some(vec![solana_storage_program!(), solana_vest_program!()])
+                Some(vec![solana_bpf_loader_program!()])
             } else if epoch == std::u64::MAX {
                 // The epoch of std::u64::MAX is a placeholder and is expected to be reduced in a
                 // future hard fork.
-                Some(vec![solana_bpf_loader_program!()])
+                Some(vec![solana_storage_program!(), solana_vest_program!()])
+            } else {
+                None
+            }
+        }
+        OperatingMode::Preview => {
+            if epoch == 0 {
+                Some(vec![
+                    solana_config_program!(),
+                    solana_stake_program!(),
+                    solana_system_program(),
+                    solana_vote_program!(),
+                    solana_bpf_loader_program!(),
+                ])
+            } else if epoch == std::u64::MAX {
+                // The epoch of std::u64::MAX is a placeholder and is expected to be reduced in a
+                // future hard fork.
+                Some(vec![solana_storage_program!(), solana_vest_program!()])
             } else {
                 None
             }
@@ -146,12 +163,12 @@ mod tests {
     #[test]
     fn test_softlaunch_inflation() {
         assert_eq!(
-            get_inflation(OperatingMode::SoftLaunch, 0).unwrap(),
+            get_inflation(OperatingMode::Stable, 0).unwrap(),
             Inflation::new_disabled()
         );
-        assert_eq!(get_inflation(OperatingMode::SoftLaunch, 1), None);
+        assert_eq!(get_inflation(OperatingMode::Stable, 1), None);
         assert_eq!(
-            get_inflation(OperatingMode::SoftLaunch, std::u64::MAX).unwrap(),
+            get_inflation(OperatingMode::Stable, std::u64::MAX).unwrap(),
             Inflation::default()
         );
     }
@@ -159,7 +176,7 @@ mod tests {
     #[test]
     fn test_softlaunch_programs() {
         assert_eq!(
-            get_programs(OperatingMode::SoftLaunch, 0),
+            get_programs(OperatingMode::Stable, 0),
             Some(vec![
                 solana_config_program!(),
                 solana_stake_program!(),
@@ -167,8 +184,8 @@ mod tests {
                 solana_vote_program!(),
             ])
         );
-        assert_eq!(get_programs(OperatingMode::SoftLaunch, 1), None);
-        assert!(get_programs(OperatingMode::SoftLaunch, std::u64::MAX - 1).is_some());
-        assert!(get_programs(OperatingMode::SoftLaunch, std::u64::MAX).is_some());
+        assert_eq!(get_programs(OperatingMode::Stable, 1), None);
+        assert!(get_programs(OperatingMode::Stable, std::u64::MAX - 1).is_some());
+        assert!(get_programs(OperatingMode::Stable, std::u64::MAX).is_some());
     }
 }

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -163,7 +163,7 @@ impl LocalCluster {
         genesis_config.poh_config = config.poh_config.clone();
 
         match genesis_config.operating_mode {
-            OperatingMode::SoftLaunch => {
+            OperatingMode::Stable | OperatingMode::Preview => {
                 genesis_config.native_instruction_processors =
                     solana_genesis_programs::get_programs(genesis_config.operating_mode, 0)
                         .unwrap()

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -552,7 +552,7 @@ fn test_softlaunch_operating_mode() {
     solana_logger::setup();
 
     let config = ClusterConfig {
-        operating_mode: OperatingMode::SoftLaunch,
+        operating_mode: OperatingMode::Stable,
         node_stakes: vec![100; 1],
         cluster_lamports: 1_000,
         validator_configs: vec![ValidatorConfig::default(); 1],

--- a/sdk/src/genesis_config.rs
+++ b/sdk/src/genesis_config.rs
@@ -25,8 +25,9 @@ use std::{
 
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq)]
 pub enum OperatingMode {
-    SoftLaunch,  // Cluster features incrementally enabled over time
-    Development, // All features (including experimental features) available immediately from genesis
+    Stable,      // Stable cluster features
+    Preview,     // Next set of cluster features to be promoted to Stable
+    Development, // All features (including experimental features)
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]


### PR DESCRIPTION
`solana-genesis --operating-mode preview` configures the cluster to enable the set of features that are scheduled to be enabled next.

So:
* devnet.solana.com runs in `Development` mode
* TdS runs in `Preview` mode
* SLP runs in `Stable` mode

<s>That's right, the "SLP" acronym is baaaack!  💥 </s>
