### PR TITLE
CLI: dynamic signing

### DIFF
--- a/book/src/paper-wallet/usage.md
+++ b/book/src/paper-wallet/usage.md
@@ -166,10 +166,10 @@ Refer to the following page for a comprehensive guide on running a validator:
 Solana CLI tooling supports secure keypair input for stake delegation. To do so,
 first create a stake account with some SOL. Use the special `ASK` keyword to
 trigger a seed phrase input prompt for the stake account and use
-`--ask-seed-phrase keypair` to securely input the funding keypair.
+`--keypair ASK` to securely input the funding keypair.
 
 ```bash
-solana create-stake-account ASK 1 --ask-seed-phrase keypair
+solana create-stake-account ASK 1 --keypair ASK
 
 [stake_account] seed phrase: 🔒
 [stake_account] If this seed phrase has an associated passphrase, enter it now. Otherwise, press ENTER to continue:
@@ -177,11 +177,11 @@ solana create-stake-account ASK 1 --ask-seed-phrase keypair
 [keypair] If this seed phrase has an associated passphrase, enter it now. Otherwise, press ENTER to continue:
 ```
 
-Then, to delegate that stake to a validator, use `--ask-seed-phrase keypair` to
+Then, to delegate that stake to a validator, use `--keypair ASK` to
 securely input the funding keypair.
 
 ```bash
-solana delegate-stake --ask-seed-phrase keypair <STAKE_ACCOUNT_PUBKEY> <VOTE_ACCOUNT_PUBKEY>
+solana delegate-stake --keypair ASK <STAKE_ACCOUNT_PUBKEY> <VOTE_ACCOUNT_PUBKEY>
 
 [keypair] seed phrase: 🔒
 [keypair] If this seed phrase has an associated passphrase, enter it now. Otherwise, press ENTER to continue:

--- a/clap-utils/src/input_parsers.rs
+++ b/clap-utils/src/input_parsers.rs
@@ -1,4 +1,6 @@
-use crate::keypair::{keypair_from_seed_phrase, ASK_KEYWORD, SKIP_SEED_PHRASE_VALIDATION_ARG};
+use crate::keypair::{
+    keypair_from_seed_phrase, keypair_util_from_path, ASK_KEYWORD, SKIP_SEED_PHRASE_VALIDATION_ARG,
+};
 use chrono::DateTime;
 use clap::ArgMatches;
 use solana_remote_wallet::remote_wallet::DerivationPath;
@@ -91,6 +93,18 @@ pub fn pubkeys_sigs_of(matches: &ArgMatches<'_>, name: &str) -> Option<Vec<(Pubk
             })
             .collect()
     })
+}
+
+// Return a signer from matches at `name`
+pub fn signer_of(
+    name: &str,
+    matches: &ArgMatches<'_>,
+) -> Result<Option<Box<dyn KeypairUtil>>, Box<dyn std::error::Error>> {
+    if let Some(location) = matches.value_of(name) {
+        keypair_util_from_path(matches, location, name).map(Some)
+    } else {
+        Ok(None)
+    }
 }
 
 pub fn lamports_of_sol(matches: &ArgMatches<'_>, name: &str) -> Option<u64> {

--- a/clap-utils/src/input_validators.rs
+++ b/clap-utils/src/input_validators.rs
@@ -1,5 +1,6 @@
-use crate::keypair::ASK_KEYWORD;
+use crate::keypair::{parse_keypair_path, KeypairUrl, ASK_KEYWORD};
 use chrono::DateTime;
+use solana_remote_wallet::remote_keypair::generate_remote_keypair;
 use solana_sdk::{
     hash::Hash,
     pubkey::Pubkey,
@@ -48,6 +49,16 @@ pub fn is_pubkey_or_keypair(string: String) -> Result<(), String> {
 // Return an error if string cannot be parsed as pubkey or keypair file or keypair ask keyword
 pub fn is_pubkey_or_keypair_or_ask_keyword(string: String) -> Result<(), String> {
     is_pubkey(string.clone()).or_else(|_| is_keypair_or_ask_keyword(string))
+}
+
+pub fn is_valid_signer(string: String) -> Result<(), String> {
+    match parse_keypair_path(&string) {
+        KeypairUrl::Usb(path) => generate_remote_keypair(path, None)
+            .map(|_| ())
+            .map_err(|err| format!("{:?}", err)),
+        KeypairUrl::Filepath(path) => is_keypair(path),
+        _ => Ok(()),
+    }
 }
 
 // Return an error if string cannot be parsed as pubkey=signature string

--- a/clap-utils/src/keypair.rs
+++ b/clap-utils/src/keypair.rs
@@ -1,10 +1,11 @@
-use crate::ArgConstant;
+use crate::{input_parsers::derivation_of, ArgConstant};
 use bip39::{Language, Mnemonic, Seed};
-use clap::values_t;
+use clap::{values_t, ArgMatches};
 use rpassword::prompt_password_stderr;
+use solana_remote_wallet::remote_keypair::generate_remote_keypair;
 use solana_sdk::signature::{
-    keypair_from_seed, keypair_from_seed_phrase_and_passphrase, read_keypair_file, Keypair,
-    KeypairUtil,
+    keypair_from_seed, keypair_from_seed_phrase_and_passphrase, read_keypair, read_keypair_file,
+    Keypair, KeypairUtil,
 };
 use std::{
     error,
@@ -28,6 +29,32 @@ pub fn parse_keypair_path(path: &str) -> KeypairUrl {
         KeypairUrl::Usb(path.split_at(6).1.to_string())
     } else {
         KeypairUrl::Filepath(path.to_string())
+    }
+}
+
+pub fn keypair_util_from_path(
+    matches: &ArgMatches,
+    path: &str,
+    keypair_name: &str,
+) -> Result<Box<dyn KeypairUtil>, Box<dyn error::Error>> {
+    match parse_keypair_path(path) {
+        KeypairUrl::Ask => {
+            let skip_validation = matches.is_present(SKIP_SEED_PHRASE_VALIDATION_ARG.name);
+            Ok(Box::new(keypair_from_seed_phrase(
+                keypair_name,
+                skip_validation,
+                false,
+            )?))
+        }
+        KeypairUrl::Filepath(path) => Ok(Box::new(read_keypair_file(&path)?)),
+        KeypairUrl::Stdin => {
+            let mut stdin = std::io::stdin();
+            Ok(Box::new(read_keypair(&mut stdin)?))
+        }
+        KeypairUrl::Usb(path) => Ok(Box::new(generate_remote_keypair(
+            path,
+            derivation_of(matches, "derivation_path"),
+        )?)),
     }
 }
 

--- a/clap-utils/src/keypair.rs
+++ b/clap-utils/src/keypair.rs
@@ -1,5 +1,6 @@
 use crate::{
     input_parsers::{derivation_of, pubkeys_sigs_of},
+    offline::SIGNER_ARG,
     ArgConstant,
 };
 use bip39::{Language, Mnemonic, Seed};
@@ -79,7 +80,7 @@ pub fn keypair_util_from_path(
             derivation_of(matches, "derivation_path"),
         )?)),
         KeypairUrl::Pubkey(pubkey) => {
-            let presigner = pubkeys_sigs_of(matches, "signer")
+            let presigner = pubkeys_sigs_of(matches, SIGNER_ARG.name)
                 .as_ref()
                 .and_then(|presigners| presigner_from_pubkey_sigs(&pubkey, presigners));
             if let Some(presigner) = presigner {

--- a/clap-utils/src/keypair.rs
+++ b/clap-utils/src/keypair.rs
@@ -10,7 +10,7 @@ use solana_sdk::{
     pubkey::Pubkey,
     signature::{
         keypair_from_seed, keypair_from_seed_phrase_and_passphrase, read_keypair,
-        read_keypair_file, Keypair, KeypairUtil, Presigner,
+        read_keypair_file, Keypair, KeypairUtil, Presigner, Signature,
     },
 };
 use std::{
@@ -42,6 +42,19 @@ pub fn parse_keypair_path(path: &str) -> KeypairUrl {
     }
 }
 
+pub fn presigner_from_pubkey_sigs(
+    pubkey: &Pubkey,
+    signers: &[(Pubkey, Signature)],
+) -> Option<Presigner> {
+    signers.iter().find_map(|(signer, sig)| {
+        if *signer == *pubkey {
+            Some(Presigner::new(signer, sig))
+        } else {
+            None
+        }
+    })
+}
+
 pub fn keypair_util_from_path(
     matches: &ArgMatches,
     path: &str,
@@ -66,15 +79,9 @@ pub fn keypair_util_from_path(
             derivation_of(matches, "derivation_path"),
         )?)),
         KeypairUrl::Pubkey(pubkey) => {
-            let presigner = pubkeys_sigs_of(matches, "signer").and_then(|presigners| {
-                presigners.iter().find_map(|(signer, sig)| {
-                    if *signer == pubkey {
-                        Some(Presigner::new(signer, sig))
-                    } else {
-                        None
-                    }
-                })
-            });
+            let presigner = pubkeys_sigs_of(matches, "signer")
+                .as_ref()
+                .and_then(|presigners| presigner_from_pubkey_sigs(&pubkey, presigners));
             if let Some(presigner) = presigner {
                 Ok(Box::new(presigner))
             } else {

--- a/clap-utils/src/keypair.rs
+++ b/clap-utils/src/keypair.rs
@@ -1,16 +1,23 @@
-use crate::{input_parsers::derivation_of, ArgConstant};
+use crate::{
+    input_parsers::{derivation_of, pubkeys_sigs_of},
+    ArgConstant,
+};
 use bip39::{Language, Mnemonic, Seed};
-use clap::{values_t, ArgMatches};
+use clap::{values_t, ArgMatches, Error, ErrorKind};
 use rpassword::prompt_password_stderr;
 use solana_remote_wallet::remote_keypair::generate_remote_keypair;
-use solana_sdk::signature::{
-    keypair_from_seed, keypair_from_seed_phrase_and_passphrase, read_keypair, read_keypair_file,
-    Keypair, KeypairUtil,
+use solana_sdk::{
+    pubkey::Pubkey,
+    signature::{
+        keypair_from_seed, keypair_from_seed_phrase_and_passphrase, read_keypair,
+        read_keypair_file, Keypair, KeypairUtil, Presigner,
+    },
 };
 use std::{
     error,
     io::{stdin, stdout, Write},
     process::exit,
+    str::FromStr,
 };
 
 pub enum KeypairUrl {
@@ -18,6 +25,7 @@ pub enum KeypairUrl {
     Filepath(String),
     Usb(String),
     Stdin,
+    Pubkey(Pubkey),
 }
 
 pub fn parse_keypair_path(path: &str) -> KeypairUrl {
@@ -27,6 +35,8 @@ pub fn parse_keypair_path(path: &str) -> KeypairUrl {
         KeypairUrl::Ask
     } else if path.starts_with("usb://") {
         KeypairUrl::Usb(path.split_at(6).1.to_string())
+    } else if let Ok(pubkey) = Pubkey::from_str(path) {
+        KeypairUrl::Pubkey(pubkey)
     } else {
         KeypairUrl::Filepath(path.to_string())
     }
@@ -55,6 +65,26 @@ pub fn keypair_util_from_path(
             path,
             derivation_of(matches, "derivation_path"),
         )?)),
+        KeypairUrl::Pubkey(pubkey) => {
+            let presigner = pubkeys_sigs_of(matches, "signer").and_then(|presigners| {
+                presigners.iter().find_map(|(signer, sig)| {
+                    if *signer == pubkey {
+                        Some(Presigner::new(signer, sig))
+                    } else {
+                        None
+                    }
+                })
+            });
+            if let Some(presigner) = presigner {
+                Ok(Box::new(presigner))
+            } else {
+                Err(Error::with_description(
+                    "Missing signature for supplied pubkey",
+                    ErrorKind::MissingRequiredArgument,
+                )
+                .into())
+            }
+        }
     }
 }
 

--- a/clap-utils/src/lib.rs
+++ b/clap-utils/src/lib.rs
@@ -26,3 +26,4 @@ pub struct ArgConstant<'a> {
 pub mod input_parsers;
 pub mod input_validators;
 pub mod keypair;
+pub mod offline;

--- a/clap-utils/src/offline.rs
+++ b/clap-utils/src/offline.rs
@@ -1,0 +1,19 @@
+use crate::ArgConstant;
+
+pub const BLOCKHASH_ARG: ArgConstant<'static> = ArgConstant {
+    name: "blockhash",
+    long: "blockhash",
+    help: "Use the supplied blockhash",
+};
+
+pub const SIGN_ONLY_ARG: ArgConstant<'static> = ArgConstant {
+    name: "sign_only",
+    long: "sign-only",
+    help: "Sign the transaction offline",
+};
+
+pub const SIGNER_ARG: ArgConstant<'static> = ArgConstant {
+    name: "signer",
+    long: "signer",
+    help: "Provide a public-key/signature pair for the transaction",
+};

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -35,7 +35,6 @@ use solana_sdk::{
     pubkey::Pubkey,
     signature::{Keypair, KeypairUtil, Signature},
     system_instruction::{self, create_address_with_seed, SystemError, MAX_ADDRESS_SEED_LEN},
-    system_transaction,
     transaction::{Transaction, TransactionError},
 };
 use solana_stake_program::stake_state::{Lockup, StakeAuthorize};
@@ -943,14 +942,16 @@ fn process_deploy(
     let mut messages: Vec<&Message> = Vec::new();
     let (blockhash, fee_calculator) = rpc_client.get_recent_blockhash()?;
     let minimum_balance = rpc_client.get_minimum_balance_for_rent_exemption(program_data.len())?;
-    let mut create_account_tx = system_transaction::create_account(
-        config.keypair.as_ref(),
-        &program_id,
-        blockhash,
+    let ix = system_instruction::create_account(
+        &config.keypair.pubkey(),
+        &program_id.pubkey(),
         minimum_balance.max(1),
         program_data.len() as u64,
         &bpf_loader::id(),
     );
+    let message = Message::new(vec![ix]);
+    let mut create_account_tx = Transaction::new_unsigned(message);
+    create_account_tx.sign_dynamic_signers(&[config.keypair.as_ref(), &program_id], blockhash);
     messages.push(&create_account_tx.message);
     let signers = [config.keypair.as_ref(), &program_id];
     let write_transactions: Vec<_> = program_data
@@ -964,7 +965,9 @@ fn process_deploy(
                 chunk.to_vec(),
             );
             let message = Message::new_with_payer(vec![instruction], Some(&signers[0].pubkey()));
-            Transaction::new(&signers, message, blockhash)
+            let mut tx = Transaction::new_unsigned(message);
+            tx.sign_dynamic_signers(&signers, blockhash);
+            tx
         })
         .collect();
     for transaction in write_transactions.iter() {
@@ -973,7 +976,8 @@ fn process_deploy(
 
     let instruction = loader_instruction::finalize(&program_id.pubkey(), &bpf_loader::id());
     let message = Message::new_with_payer(vec![instruction], Some(&signers[0].pubkey()));
-    let mut finalize_tx = Transaction::new(&signers, message, blockhash);
+    let mut finalize_tx = Transaction::new_unsigned(message);
+    finalize_tx.sign_dynamic_signers(&signers, blockhash);
     messages.push(&finalize_tx.message);
 
     check_account_for_multiple_fees(
@@ -1036,17 +1040,18 @@ fn process_pay(
 
     if timestamp == None && *witnesses == None {
         let nonce_authority = nonce_authority.unwrap_or_else(|| config.keypair.as_ref());
+        let ix = system_instruction::transfer(&config.keypair.pubkey(), to, lamports);
         let mut tx = if let Some(nonce_account) = &nonce_account {
-            system_transaction::nonced_transfer(
-                config.keypair.as_ref(),
-                to,
-                lamports,
-                nonce_account,
-                nonce_authority,
-                blockhash,
-            )
+            let message =
+                Message::new_with_nonce(vec![ix], None, nonce_account, &nonce_authority.pubkey());
+            let mut tx = Transaction::new_unsigned(message);
+            tx.sign_dynamic_signers(&[config.keypair.as_ref(), nonce_authority], blockhash);
+            tx
         } else {
-            system_transaction::transfer(config.keypair.as_ref(), to, lamports, blockhash)
+            let message = Message::new(vec![ix]);
+            let mut tx = Transaction::new_unsigned(message);
+            tx.sign_dynamic_signers(&[config.keypair.as_ref()], blockhash);
+            tx
         };
 
         if sign_only {
@@ -1085,11 +1090,9 @@ fn process_pay(
             cancelable,
             lamports,
         );
-        let mut tx = Transaction::new_signed_instructions(
-            &[config.keypair.as_ref(), &contract_state],
-            ixs,
-            blockhash,
-        );
+        let message = Message::new(ixs);
+        let mut tx = Transaction::new_unsigned(message);
+        tx.sign_dynamic_signers(&[config.keypair.as_ref(), &contract_state], blockhash);
         if sign_only {
             return_signers(&tx)
         } else {
@@ -1132,11 +1135,9 @@ fn process_pay(
             cancelable,
             lamports,
         );
-        let mut tx = Transaction::new_signed_instructions(
-            &[config.keypair.as_ref(), &contract_state],
-            ixs,
-            blockhash,
-        );
+        let message = Message::new(ixs);
+        let mut tx = Transaction::new_unsigned(message);
+        tx.sign_dynamic_signers(&[config.keypair.as_ref(), &contract_state], blockhash);
         if sign_only {
             return_signers(&tx)
         } else {
@@ -1170,8 +1171,9 @@ fn process_cancel(rpc_client: &RpcClient, config: &CliConfig, pubkey: &Pubkey) -
         pubkey,
         &config.keypair.pubkey(),
     );
-    let mut tx =
-        Transaction::new_signed_instructions(&[config.keypair.as_ref()], vec![ix], blockhash);
+    let message = Message::new(vec![ix]);
+    let mut tx = Transaction::new_unsigned(message);
+    tx.sign_dynamic_signers(&[config.keypair.as_ref()], blockhash);
     check_account_for_fee(
         rpc_client,
         &config.keypair.pubkey(),
@@ -1193,8 +1195,9 @@ fn process_time_elapsed(
     let (blockhash, fee_calculator) = rpc_client.get_recent_blockhash()?;
 
     let ix = budget_instruction::apply_timestamp(&config.keypair.pubkey(), pubkey, to, dt);
-    let mut tx =
-        Transaction::new_signed_instructions(&[config.keypair.as_ref()], vec![ix], blockhash);
+    let message = Message::new(vec![ix]);
+    let mut tx = Transaction::new_unsigned(message);
+    tx.sign_dynamic_signers(&[config.keypair.as_ref()], blockhash);
     check_account_for_fee(
         rpc_client,
         &config.keypair.pubkey(),
@@ -1237,21 +1240,21 @@ fn process_transfer(
         signers.push(from)
     }
     let mut tx = if let Some(nonce_account) = &nonce_account {
-        Transaction::new_signed_with_nonce(
+        signers.push(nonce_authority);
+        let message = Message::new_with_nonce(
             ixs,
             Some(&fee_payer.pubkey()),
-            &[fee_payer, from, nonce_authority],
             nonce_account,
             &nonce_authority.pubkey(),
-            recent_blockhash,
-        )
+        );
+        let mut tx = Transaction::new_unsigned(message);
+        tx.sign_dynamic_signers(&signers, recent_blockhash);
+        tx
     } else {
-        Transaction::new_signed_with_payer(
-            ixs,
-            Some(&fee_payer.pubkey()),
-            &signers,
-            recent_blockhash,
-        )
+        let message = Message::new_with_payer(ixs, Some(&fee_payer.pubkey()));
+        let mut tx = Transaction::new_unsigned(message);
+        tx.sign_dynamic_signers(&signers, recent_blockhash);
+        tx
     };
 
     if sign_only {
@@ -1282,8 +1285,9 @@ fn process_witness(
     let (blockhash, fee_calculator) = rpc_client.get_recent_blockhash()?;
 
     let ix = budget_instruction::apply_signature(&config.keypair.pubkey(), pubkey, to);
-    let mut tx =
-        Transaction::new_signed_instructions(&[config.keypair.as_ref()], vec![ix], blockhash);
+    let message = Message::new(vec![ix]);
+    let mut tx = Transaction::new_unsigned(message);
+    tx.sign_dynamic_signers(&[config.keypair.as_ref()], blockhash);
     check_account_for_fee(
         rpc_client,
         &config.keypair.pubkey(),

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -775,16 +775,6 @@ pub fn return_signers(tx: &Transaction) -> ProcessResult {
     .to_string())
 }
 
-pub fn replace_signatures(tx: &mut Transaction, signers: &[(Pubkey, Signature)]) -> ProcessResult {
-    tx.replace_signatures(signers).map_err(|_| {
-        CliError::BadParameter(
-            "Transaction construction failed, incorrect signature or public key provided"
-                .to_string(),
-        )
-    })?;
-    Ok("".to_string())
-}
-
 pub fn parse_create_address_with_seed(
     matches: &ArgMatches<'_>,
 ) -> Result<CliCommandInfo, CliError> {

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -1232,6 +1232,10 @@ fn process_transfer(
 
     let nonce_authority = nonce_authority.unwrap_or_else(|| config.keypair.as_ref());
     let fee_payer = fee_payer.unwrap_or_else(|| config.keypair.as_ref());
+    let mut signers = vec![fee_payer];
+    if *fee_payer != *from {
+        signers.push(from)
+    }
     let mut tx = if let Some(nonce_account) = &nonce_account {
         Transaction::new_signed_with_nonce(
             ixs,
@@ -1245,7 +1249,7 @@ fn process_transfer(
         Transaction::new_signed_with_payer(
             ixs,
             Some(&fee_payer.pubkey()),
-            &[fee_payer.as_ref(), from.as_ref()],
+            &signers,
             recent_blockhash,
         )
     };

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -65,8 +65,8 @@ pub fn fee_payer_arg<'a, 'b>() -> Arg<'a, 'b> {
     Arg::with_name(FEE_PAYER_ARG.name)
         .long(FEE_PAYER_ARG.long)
         .takes_value(true)
-        .value_name("KEYPAIR or PUBKEY")
-        .validator(is_pubkey_or_keypair_or_ask_keyword)
+        .value_name("KEYPAIR or PUBKEY or REMOTE WALLET PATH")
+        .validator(is_valid_signer)
         .help(FEE_PAYER_ARG.help)
 }
 
@@ -1985,7 +1985,7 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                         .index(1)
                         .value_name("PUBKEY")
                         .takes_value(true)
-                        .validator(is_pubkey_or_keypair)
+                        .validator(is_valid_signer)
                         .help("The public key of the balance to check"),
                 )
                 .arg(
@@ -2194,8 +2194,8 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                     Arg::with_name("from")
                         .long("from")
                         .takes_value(true)
-                        .value_name("KEYPAIR or PUBKEY")
-                        .validator(is_pubkey_or_keypair_or_ask_keyword)
+                        .value_name("KEYPAIR or PUBKEY or REMOTE WALLET PATH")
+                        .validator(is_valid_signer)
                         .help("Source account of funds (if different from client local account)"),
                 )
                 .offline_args()

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -14,7 +14,9 @@ use log::*;
 use num_traits::FromPrimitive;
 use serde_json::{self, json, Value};
 use solana_budget_program::budget_instruction::{self, BudgetError};
-use solana_clap_utils::{input_parsers::*, input_validators::*, ArgConstant};
+use solana_clap_utils::{
+    input_parsers::*, input_validators::*, offline::SIGN_ONLY_ARG, ArgConstant,
+};
 use solana_client::{client_error::ClientError, rpc_client::RpcClient};
 #[cfg(not(test))]
 use solana_faucet::faucet::request_airdrop_transaction;

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -2260,7 +2260,7 @@ mod tests {
         system_program,
         transaction::TransactionError,
     };
-    use std::{collections::HashMap, path::PathBuf};
+    use std::{collections::HashMap, path::PathBuf, rc::Rc};
 
     fn make_tmp_path(name: &str) -> String {
         let out_dir = std::env::var("FARF_DIR").unwrap_or_else(|_| "farf".to_string());
@@ -2775,7 +2775,7 @@ mod tests {
 
         let keypair = Keypair::new();
         let pubkey = keypair.pubkey().to_string();
-        config.keypair = keypair;
+        config.keypair = keypair.into();
         config.command = CliCommand::Address;
         assert_eq!(process_command(&config).unwrap(), pubkey);
 
@@ -2835,7 +2835,7 @@ mod tests {
         let bob_pubkey = bob_keypair.pubkey();
         let custodian = Pubkey::new_rand();
         config.command = CliCommand::CreateStakeAccount {
-            stake_account: bob_keypair.into(),
+            stake_account: Rc::new(bob_keypair.into()),
             seed: None,
             staker: None,
             withdrawer: None,
@@ -2893,7 +2893,7 @@ mod tests {
             blockhash_query: BlockhashQuery::default(),
             nonce_account: None,
             nonce_authority: None,
-            split_stake_account: split_stake_account.into(),
+            split_stake_account: Rc::new(split_stake_account.into()),
             seed: None,
             lamports: 1234,
             fee_payer: None,

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -20,10 +20,7 @@ use solana_client::{client_error::ClientError, rpc_client::RpcClient};
 use solana_faucet::faucet::request_airdrop_transaction;
 #[cfg(test)]
 use solana_faucet::faucet_mock::request_airdrop_transaction;
-use solana_remote_wallet::{
-    ledger::get_ledger_from_info,
-    remote_wallet::{DerivationPath, RemoteWallet, RemoteWalletInfo},
-};
+use solana_remote_wallet::remote_wallet::DerivationPath;
 use solana_sdk::{
     bpf_loader,
     clock::{Epoch, Slot},
@@ -496,19 +493,7 @@ impl CliConfig {
     }
 
     pub(crate) fn pubkey(&self) -> Result<Pubkey, Box<dyn std::error::Error>> {
-        if let Some(path) = &self.keypair_path {
-            if path.starts_with("usb://") {
-                let (remote_wallet_info, mut derivation_path) =
-                    RemoteWalletInfo::parse_path(path.to_string())?;
-                if let Some(derivation) = &self.derivation_path {
-                    let derivation = derivation.clone();
-                    derivation_path = derivation;
-                }
-                let ledger = get_ledger_from_info(remote_wallet_info)?;
-                return Ok(ledger.get_pubkey(&derivation_path)?);
-            }
-        }
-        Ok(self.keypair.pubkey())
+        self.keypair.try_pubkey()
     }
 }
 

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -2551,64 +2551,6 @@ mod tests {
             }
         );
 
-        // Test Pay Subcommand w/ signer
-        let key1 = Pubkey::new_rand();
-        let sig1 = Keypair::new().sign_message(&[0u8]);
-        let signer1 = format!("{}={}", key1, sig1);
-        let test_pay = test_commands.clone().get_matches_from(vec![
-            "test",
-            "pay",
-            &pubkey_string,
-            "50",
-            "--blockhash",
-            &blockhash_string,
-            "--signer",
-            &signer1,
-        ]);
-        assert_eq!(
-            parse_command(&test_pay).unwrap(),
-            CliCommandInfo {
-                command: CliCommand::Pay(PayCommand {
-                    lamports: 50_000_000_000,
-                    to: pubkey,
-                    blockhash_query: BlockhashQuery::FeeCalculator(blockhash),
-                    signers: Some(vec![(key1, sig1)]),
-                    ..PayCommand::default()
-                }),
-                require_keypair: true
-            }
-        );
-
-        // Test Pay Subcommand w/ signers
-        let key2 = Pubkey::new_rand();
-        let sig2 = Keypair::new().sign_message(&[1u8]);
-        let signer2 = format!("{}={}", key2, sig2);
-        let test_pay = test_commands.clone().get_matches_from(vec![
-            "test",
-            "pay",
-            &pubkey_string,
-            "50",
-            "--blockhash",
-            &blockhash_string,
-            "--signer",
-            &signer1,
-            "--signer",
-            &signer2,
-        ]);
-        assert_eq!(
-            parse_command(&test_pay).unwrap(),
-            CliCommandInfo {
-                command: CliCommand::Pay(PayCommand {
-                    lamports: 50_000_000_000,
-                    to: pubkey,
-                    blockhash_query: BlockhashQuery::FeeCalculator(blockhash),
-                    signers: Some(vec![(key1, sig1), (key2, sig2)]),
-                    ..PayCommand::default()
-                }),
-                require_keypair: true
-            }
-        );
-
         // Test Pay Subcommand w/ Blockhash
         let test_pay = test_commands.clone().get_matches_from(vec![
             "test",

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -33,7 +33,7 @@ use solana_sdk::{
     native_token::lamports_to_sol,
     program_utils::DecodeError,
     pubkey::Pubkey,
-    signature::{keypair_from_seed, Keypair, KeypairUtil, Signature},
+    signature::{Keypair, KeypairUtil, Signature},
     system_instruction::{self, create_address_with_seed, SystemError, MAX_ADDRESS_SEED_LEN},
     system_transaction,
     transaction::{Transaction, TransactionError},
@@ -45,6 +45,7 @@ use std::{
     fs::File,
     io::{Read, Write},
     net::{IpAddr, SocketAddr},
+    rc::Rc,
     thread::sleep,
     time::Duration,
     {error, fmt},
@@ -91,85 +92,6 @@ impl std::ops::Deref for KeypairEq {
     }
 }
 
-#[derive(Debug)]
-pub enum SigningAuthority {
-    Online(Keypair),
-    // We hold a random keypair alongside our legit pubkey in order
-    // to generate a placeholder signature in the transaction
-    Offline(Pubkey, Keypair),
-}
-
-impl SigningAuthority {
-    pub fn new_from_matches(
-        matches: &ArgMatches<'_>,
-        name: &str,
-        signers: Option<&[(Pubkey, Signature)]>,
-    ) -> Result<Option<Self>, CliError> {
-        if matches.is_present(name) {
-            keypair_of(matches, name)
-                .map(|keypair| keypair.into())
-                .or_else(|| {
-                    pubkey_of(matches, name)
-                        .filter(|pubkey| {
-                            signers
-                                .and_then(|signers| {
-                                    signers.iter().find(|(signer, _sig)| *signer == *pubkey)
-                                })
-                                .is_some()
-                        })
-                        .map(|pubkey| pubkey.into())
-                })
-                .ok_or_else(|| CliError::BadParameter("Invalid authority".to_string()))
-                .map(Some)
-        } else {
-            Ok(None)
-        }
-    }
-
-    pub fn keypair(&self) -> &Keypair {
-        match self {
-            SigningAuthority::Online(keypair) => keypair,
-            SigningAuthority::Offline(_pubkey, keypair) => keypair,
-        }
-    }
-
-    pub fn pubkey(&self) -> Pubkey {
-        match self {
-            SigningAuthority::Online(keypair) => keypair.pubkey(),
-            SigningAuthority::Offline(pubkey, _keypair) => *pubkey,
-        }
-    }
-}
-
-impl From<Keypair> for SigningAuthority {
-    fn from(keypair: Keypair) -> Self {
-        SigningAuthority::Online(keypair)
-    }
-}
-
-impl From<Pubkey> for SigningAuthority {
-    fn from(pubkey: Pubkey) -> Self {
-        SigningAuthority::Offline(pubkey, keypair_from_seed(pubkey.as_ref()).unwrap())
-    }
-}
-
-impl PartialEq for SigningAuthority {
-    fn eq(&self, other: &Self) -> bool {
-        match (self, other) {
-            (SigningAuthority::Online(keypair1), SigningAuthority::Online(keypair2)) => {
-                keypair1.pubkey() == keypair2.pubkey()
-            }
-            (SigningAuthority::Online(keypair), SigningAuthority::Offline(pubkey, _))
-            | (SigningAuthority::Offline(pubkey, _), SigningAuthority::Online(keypair)) => {
-                keypair.pubkey() == *pubkey
-            }
-            (SigningAuthority::Offline(pubkey1, _), SigningAuthority::Offline(pubkey2, _)) => {
-                pubkey1 == pubkey2
-            }
-        }
-    }
-}
-
 pub fn nonce_authority_arg<'a, 'b>() -> Arg<'a, 'b> {
     nonce::nonce_authority_arg().requires(NONCE_ARG.name)
 }
@@ -186,7 +108,7 @@ pub struct PayCommand {
     pub signers: Option<Vec<(Pubkey, Signature)>>,
     pub blockhash_query: BlockhashQuery,
     pub nonce_account: Option<Pubkey>,
-    pub nonce_authority: Option<SigningAuthority>,
+    pub nonce_authority: Option<Box<dyn KeypairUtil>>,
 }
 
 #[derive(Debug, PartialEq)]
@@ -242,11 +164,11 @@ pub enum CliCommand {
     // Nonce commands
     AuthorizeNonceAccount {
         nonce_account: Pubkey,
-        nonce_authority: Option<SigningAuthority>,
+        nonce_authority: Option<Box<dyn KeypairUtil>>,
         new_authority: Pubkey,
     },
     CreateNonceAccount {
-        nonce_account: KeypairEq,
+        nonce_account: Rc<Box<dyn KeypairUtil>>,
         seed: Option<String>,
         nonce_authority: Option<Pubkey>,
         lamports: u64,
@@ -254,7 +176,7 @@ pub enum CliCommand {
     GetNonce(Pubkey),
     NewNonce {
         nonce_account: Pubkey,
-        nonce_authority: Option<SigningAuthority>,
+        nonce_authority: Option<Box<dyn KeypairUtil>>,
     },
     ShowNonceAccount {
         nonce_account_pubkey: Pubkey,
@@ -262,7 +184,7 @@ pub enum CliCommand {
     },
     WithdrawFromNonceAccount {
         nonce_account: Pubkey,
-        nonce_authority: Option<SigningAuthority>,
+        nonce_authority: Option<Box<dyn KeypairUtil>>,
         destination_account_pubkey: Pubkey,
         lamports: u64,
     },
@@ -270,7 +192,7 @@ pub enum CliCommand {
     Deploy(String),
     // Stake Commands
     CreateStakeAccount {
-        stake_account: SigningAuthority,
+        stake_account: Rc<Box<dyn KeypairUtil>>,
         seed: Option<String>,
         staker: Option<Pubkey>,
         withdrawer: Option<Pubkey>,
@@ -280,44 +202,44 @@ pub enum CliCommand {
         signers: Option<Vec<(Pubkey, Signature)>>,
         blockhash_query: BlockhashQuery,
         nonce_account: Option<Pubkey>,
-        nonce_authority: Option<SigningAuthority>,
-        fee_payer: Option<SigningAuthority>,
-        from: Option<SigningAuthority>,
+        nonce_authority: Option<Box<dyn KeypairUtil>>,
+        fee_payer: Option<Box<dyn KeypairUtil>>,
+        from: Option<Box<dyn KeypairUtil>>,
     },
     DeactivateStake {
         stake_account_pubkey: Pubkey,
-        stake_authority: Option<SigningAuthority>,
+        stake_authority: Option<Box<dyn KeypairUtil>>,
         sign_only: bool,
         signers: Option<Vec<(Pubkey, Signature)>>,
         blockhash_query: BlockhashQuery,
         nonce_account: Option<Pubkey>,
-        nonce_authority: Option<SigningAuthority>,
-        fee_payer: Option<SigningAuthority>,
+        nonce_authority: Option<Box<dyn KeypairUtil>>,
+        fee_payer: Option<Box<dyn KeypairUtil>>,
     },
     DelegateStake {
         stake_account_pubkey: Pubkey,
         vote_account_pubkey: Pubkey,
-        stake_authority: Option<SigningAuthority>,
+        stake_authority: Option<Box<dyn KeypairUtil>>,
         force: bool,
         sign_only: bool,
         signers: Option<Vec<(Pubkey, Signature)>>,
         blockhash_query: BlockhashQuery,
         nonce_account: Option<Pubkey>,
-        nonce_authority: Option<SigningAuthority>,
-        fee_payer: Option<SigningAuthority>,
+        nonce_authority: Option<Box<dyn KeypairUtil>>,
+        fee_payer: Option<Box<dyn KeypairUtil>>,
     },
     SplitStake {
         stake_account_pubkey: Pubkey,
-        stake_authority: Option<SigningAuthority>,
+        stake_authority: Option<Box<dyn KeypairUtil>>,
         sign_only: bool,
         signers: Option<Vec<(Pubkey, Signature)>>,
         blockhash_query: BlockhashQuery,
         nonce_account: Option<Pubkey>,
-        nonce_authority: Option<SigningAuthority>,
-        split_stake_account: KeypairEq,
+        nonce_authority: Option<Box<dyn KeypairUtil>>,
+        split_stake_account: Rc<Box<dyn KeypairUtil>>,
         seed: Option<String>,
         lamports: u64,
-        fee_payer: Option<SigningAuthority>,
+        fee_payer: Option<Box<dyn KeypairUtil>>,
     },
     ShowStakeHistory {
         use_lamports_unit: bool,
@@ -330,36 +252,36 @@ pub enum CliCommand {
         stake_account_pubkey: Pubkey,
         new_authorized_pubkey: Pubkey,
         stake_authorize: StakeAuthorize,
-        authority: Option<SigningAuthority>,
+        authority: Option<Box<dyn KeypairUtil>>,
         sign_only: bool,
         signers: Option<Vec<(Pubkey, Signature)>>,
         blockhash_query: BlockhashQuery,
         nonce_account: Option<Pubkey>,
-        nonce_authority: Option<SigningAuthority>,
-        fee_payer: Option<SigningAuthority>,
+        nonce_authority: Option<Box<dyn KeypairUtil>>,
+        fee_payer: Option<Box<dyn KeypairUtil>>,
     },
     StakeSetLockup {
         stake_account_pubkey: Pubkey,
         lockup: Lockup,
-        custodian: Option<SigningAuthority>,
+        custodian: Option<Box<dyn KeypairUtil>>,
         sign_only: bool,
         signers: Option<Vec<(Pubkey, Signature)>>,
         blockhash_query: BlockhashQuery,
         nonce_account: Option<Pubkey>,
-        nonce_authority: Option<SigningAuthority>,
-        fee_payer: Option<SigningAuthority>,
+        nonce_authority: Option<Box<dyn KeypairUtil>>,
+        fee_payer: Option<Box<dyn KeypairUtil>>,
     },
     WithdrawStake {
         stake_account_pubkey: Pubkey,
         destination_account_pubkey: Pubkey,
         lamports: u64,
-        withdraw_authority: Option<SigningAuthority>,
+        withdraw_authority: Option<Box<dyn KeypairUtil>>,
         sign_only: bool,
         signers: Option<Vec<(Pubkey, Signature)>>,
         blockhash_query: BlockhashQuery,
         nonce_account: Option<Pubkey>,
-        nonce_authority: Option<SigningAuthority>,
-        fee_payer: Option<SigningAuthority>,
+        nonce_authority: Option<Box<dyn KeypairUtil>>,
+        fee_payer: Option<Box<dyn KeypairUtil>>,
     },
     // Storage Commands
     CreateStorageAccount {
@@ -426,13 +348,13 @@ pub enum CliCommand {
     Transfer {
         lamports: u64,
         to: Pubkey,
-        from: Option<SigningAuthority>,
+        from: Option<Box<dyn KeypairUtil>>,
         sign_only: bool,
         signers: Option<Vec<(Pubkey, Signature)>>,
         blockhash_query: BlockhashQuery,
         nonce_account: Option<Pubkey>,
-        nonce_authority: Option<SigningAuthority>,
-        fee_payer: Option<SigningAuthority>,
+        nonce_authority: Option<Box<dyn KeypairUtil>>,
+        fee_payer: Option<Box<dyn KeypairUtil>>,
     },
     Witness(Pubkey, Pubkey), // Witness(to, process_id)
 }
@@ -695,11 +617,7 @@ pub fn parse_command(matches: &ArgMatches<'_>) -> Result<CliCommandInfo, Box<dyn
             let signers = pubkeys_sigs_of(&matches, SIGNER_ARG.name);
             let blockhash_query = BlockhashQuery::new_from_matches(&matches);
             let nonce_account = pubkey_of(&matches, NONCE_ARG.name);
-            let nonce_authority = SigningAuthority::new_from_matches(
-                &matches,
-                NONCE_AUTHORITY_ARG.name,
-                signers.as_deref(),
-            )?;
+            let nonce_authority = signer_of(NONCE_AUTHORITY_ARG.name, &matches)?;
 
             Ok(CliCommandInfo {
                 command: CliCommand::Pay(PayCommand {
@@ -765,17 +683,9 @@ pub fn parse_command(matches: &ArgMatches<'_>) -> Result<CliCommandInfo, Box<dyn
             let signers = pubkeys_sigs_of(&matches, SIGNER_ARG.name);
             let blockhash_query = BlockhashQuery::new_from_matches(matches);
             let nonce_account = pubkey_of(&matches, NONCE_ARG.name);
-            let nonce_authority = SigningAuthority::new_from_matches(
-                &matches,
-                NONCE_AUTHORITY_ARG.name,
-                signers.as_deref(),
-            )?;
-            let fee_payer = SigningAuthority::new_from_matches(
-                &matches,
-                FEE_PAYER_ARG.name,
-                signers.as_deref(),
-            )?;
-            let from = SigningAuthority::new_from_matches(&matches, "from", signers.as_deref())?;
+            let nonce_authority = signer_of(NONCE_AUTHORITY_ARG.name, &matches)?;
+            let fee_payer = signer_of(FEE_PAYER_ARG.name, &matches)?;
+            let from = signer_of("from", &matches)?;
             Ok(CliCommandInfo {
                 command: CliCommand::Transfer {
                     lamports,
@@ -1123,7 +1033,7 @@ fn process_pay(
     signers: &Option<Vec<(Pubkey, Signature)>>,
     blockhash_query: &BlockhashQuery,
     nonce_account: Option<Pubkey>,
-    nonce_authority: Option<&SigningAuthority>,
+    nonce_authority: Option<&dyn KeypairUtil>,
 ) -> ProcessResult {
     check_unique_pubkeys(
         (&config.keypair.pubkey(), "cli keypair".to_string()),
@@ -1139,10 +1049,8 @@ fn process_pay(
     };
 
     if timestamp == None && *witnesses == None {
+        let nonce_authority = nonce_authority.unwrap_or_else(|| config.keypair.as_ref());
         let mut tx = if let Some(nonce_account) = &nonce_account {
-            let nonce_authority: &Keypair = nonce_authority
-                .map(|authority| authority.keypair())
-                .unwrap_or(&config.keypair);
             system_transaction::nonced_transfer(
                 config.keypair.as_ref(),
                 to,
@@ -1163,11 +1071,8 @@ fn process_pay(
             return_signers(&tx)
         } else {
             if let Some(nonce_account) = &nonce_account {
-                let nonce_authority: Pubkey = nonce_authority
-                    .map(|authority| authority.pubkey())
-                    .unwrap_or_else(|| config.keypair.pubkey());
                 let nonce_account = rpc_client.get_account(nonce_account)?;
-                check_nonce_account(&nonce_account, &nonce_authority, &blockhash)?;
+                check_nonce_account(&nonce_account, &nonce_authority.pubkey(), &blockhash)?;
             }
             check_account_for_fee(
                 rpc_client,
@@ -1331,20 +1236,18 @@ fn process_transfer(
     config: &CliConfig,
     lamports: u64,
     to: &Pubkey,
-    from: Option<&SigningAuthority>,
+    from: Option<&(dyn KeypairUtil + 'static)>,
     sign_only: bool,
     signers: Option<&Vec<(Pubkey, Signature)>>,
     blockhash_query: &BlockhashQuery,
     nonce_account: Option<&Pubkey>,
-    nonce_authority: Option<&SigningAuthority>,
-    fee_payer: Option<&SigningAuthority>,
+    nonce_authority: Option<&(dyn KeypairUtil + 'static)>,
+    fee_payer: Option<&(dyn KeypairUtil + 'static)>,
 ) -> ProcessResult {
-    let (from_pubkey, from) = from
-        .map(|f| (f.pubkey(), f.keypair()))
-        .unwrap_or((config.keypair.pubkey(), &config.keypair));
+    let from = from.unwrap_or_else(|| config.keypair.as_ref());
 
     check_unique_pubkeys(
-        (&from_pubkey, "cli keypair".to_string()),
+        (&from.pubkey(), "cli keypair".to_string()),
         (to, "to".to_string()),
     )?;
 
@@ -1352,10 +1255,8 @@ fn process_transfer(
         blockhash_query.get_blockhash_fee_calculator(rpc_client)?;
     let ixs = vec![system_instruction::transfer(&from.pubkey(), to, lamports)];
 
-    let (nonce_authority_pubkey, nonce_authority) = nonce_authority
-        .map(|authority| (authority.pubkey(), authority.keypair()))
-        .unwrap_or((config.keypair.pubkey(), &config.keypair));
-    let fee_payer = fee_payer.map(|fp| fp.keypair()).unwrap_or(&config.keypair);
+    let nonce_authority = nonce_authority.unwrap_or_else(|| config.keypair.as_ref());
+    let fee_payer = fee_payer.unwrap_or_else(|| config.keypair.as_ref());
     let mut tx = if let Some(nonce_account) = &nonce_account {
         Transaction::new_signed_with_nonce(
             ixs,
@@ -1369,7 +1270,7 @@ fn process_transfer(
         Transaction::new_signed_with_payer(
             ixs,
             Some(&fee_payer.pubkey()),
-            &[fee_payer, from],
+            &[fee_payer.as_ref(), from.as_ref()],
             recent_blockhash,
         )
     };
@@ -1383,7 +1284,7 @@ fn process_transfer(
     } else {
         if let Some(nonce_account) = &nonce_account {
             let nonce_account = rpc_client.get_account(nonce_account)?;
-            check_nonce_account(&nonce_account, &nonce_authority_pubkey, &recent_blockhash)?;
+            check_nonce_account(&nonce_account, &nonce_authority.pubkey(), &recent_blockhash)?;
         }
         check_account_for_fee(
             rpc_client,
@@ -1508,7 +1409,7 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             &rpc_client,
             config,
             nonce_account,
-            nonce_authority.as_ref(),
+            nonce_authority.as_deref(),
             new_authority,
         ),
         // Create nonce account
@@ -1520,7 +1421,7 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
         } => process_create_nonce_account(
             &rpc_client,
             config,
-            nonce_account,
+            nonce_account.as_ref().as_ref(),
             seed.clone(),
             *nonce_authority,
             *lamports,
@@ -1533,7 +1434,12 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
         CliCommand::NewNonce {
             nonce_account,
             ref nonce_authority,
-        } => process_new_nonce(&rpc_client, config, nonce_account, nonce_authority.as_ref()),
+        } => process_new_nonce(
+            &rpc_client,
+            config,
+            nonce_account,
+            nonce_authority.as_deref(),
+        ),
         // Show the contents of a nonce account
         CliCommand::ShowNonceAccount {
             nonce_account_pubkey,
@@ -1549,7 +1455,7 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             &rpc_client,
             config,
             &nonce_account,
-            nonce_authority.as_ref(),
+            nonce_authority.as_deref(),
             &destination_account_pubkey,
             *lamports,
         ),
@@ -1581,7 +1487,7 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
         } => process_create_stake_account(
             &rpc_client,
             config,
-            stake_account,
+            stake_account.as_ref().as_ref(),
             seed,
             staker,
             withdrawer,
@@ -1591,9 +1497,9 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             signers.as_ref(),
             blockhash_query,
             nonce_account.as_ref(),
-            nonce_authority.as_ref(),
-            fee_payer.as_ref(),
-            from.as_ref(),
+            nonce_authority.as_deref(),
+            fee_payer.as_deref(),
+            from.as_deref(),
         ),
         CliCommand::DeactivateStake {
             stake_account_pubkey,
@@ -1608,13 +1514,13 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             &rpc_client,
             config,
             &stake_account_pubkey,
-            stake_authority.as_ref(),
+            stake_authority.as_deref(),
             *sign_only,
             signers,
             blockhash_query,
             *nonce_account,
-            nonce_authority.as_ref(),
-            fee_payer.as_ref(),
+            nonce_authority.as_deref(),
+            fee_payer.as_deref(),
         ),
         CliCommand::DelegateStake {
             stake_account_pubkey,
@@ -1632,14 +1538,14 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             config,
             &stake_account_pubkey,
             &vote_account_pubkey,
-            stake_authority.as_ref(),
+            stake_authority.as_deref(),
             *force,
             *sign_only,
             signers,
             blockhash_query,
             *nonce_account,
-            nonce_authority.as_ref(),
-            fee_payer.as_ref(),
+            nonce_authority.as_deref(),
+            fee_payer.as_deref(),
         ),
         CliCommand::SplitStake {
             stake_account_pubkey,
@@ -1657,16 +1563,16 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             &rpc_client,
             config,
             &stake_account_pubkey,
-            stake_authority.as_ref(),
+            stake_authority.as_deref(),
             *sign_only,
             signers,
             blockhash_query,
             *nonce_account,
-            nonce_authority.as_ref(),
-            split_stake_account,
+            nonce_authority.as_deref(),
+            split_stake_account.as_ref().as_ref(),
             seed,
             *lamports,
-            fee_payer.as_ref(),
+            fee_payer.as_deref(),
         ),
         CliCommand::ShowStakeAccount {
             pubkey: stake_account_pubkey,
@@ -1697,13 +1603,13 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             &stake_account_pubkey,
             &new_authorized_pubkey,
             *stake_authorize,
-            authority.as_ref(),
+            authority.as_deref(),
             *sign_only,
             signers,
             blockhash_query,
             *nonce_account,
-            nonce_authority.as_ref(),
-            fee_payer.as_ref(),
+            nonce_authority.as_deref(),
+            fee_payer.as_deref(),
         ),
         CliCommand::StakeSetLockup {
             stake_account_pubkey,
@@ -1720,13 +1626,13 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             config,
             &stake_account_pubkey,
             &mut lockup,
-            custodian.as_ref(),
+            custodian.as_deref(),
             *sign_only,
             signers,
             blockhash_query,
             *nonce_account,
-            nonce_authority.as_ref(),
-            fee_payer.as_ref(),
+            nonce_authority.as_deref(),
+            fee_payer.as_deref(),
         ),
         CliCommand::WithdrawStake {
             stake_account_pubkey,
@@ -1745,13 +1651,13 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             &stake_account_pubkey,
             &destination_account_pubkey,
             *lamports,
-            withdraw_authority.as_ref(),
+            withdraw_authority.as_deref(),
             *sign_only,
             signers.as_ref(),
             blockhash_query,
             nonce_account.as_ref(),
-            nonce_authority.as_ref(),
-            fee_payer.as_ref(),
+            nonce_authority.as_deref(),
+            fee_payer.as_deref(),
         ),
 
         // Storage Commands
@@ -1912,7 +1818,7 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             signers,
             blockhash_query,
             *nonce_account,
-            nonce_authority.as_ref(),
+            nonce_authority.as_deref(),
         ),
         CliCommand::ShowAccount {
             pubkey,
@@ -1944,13 +1850,13 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             config,
             *lamports,
             to,
-            from.as_ref(),
+            from.as_deref(),
             *sign_only,
             signers.as_ref(),
             blockhash_query,
             nonce_account.as_ref(),
-            nonce_authority.as_ref(),
-            fee_payer.as_ref(),
+            nonce_authority.as_deref(),
+            fee_payer.as_deref(),
         ),
         // Apply witness signature to contract
         CliCommand::Witness(to, pubkey) => process_witness(&rpc_client, config, &to, &pubkey),
@@ -2389,7 +2295,7 @@ mod tests {
         account::Account,
         nonce_state::{Meta as NonceMeta, NonceState},
         pubkey::Pubkey,
-        signature::{keypair_from_seed, read_keypair_file, write_keypair_file},
+        signature::{keypair_from_seed, read_keypair_file, write_keypair_file, Presigner},
         system_program,
         transaction::TransactionError,
     };
@@ -2407,13 +2313,6 @@ mod tests {
         let _ignored = std::fs::remove_file(&path);
 
         path
-    }
-
-    #[test]
-    fn test_signing_authority_dummy_keypairs() {
-        let signing_authority: SigningAuthority = Pubkey::new(&[1u8; 32]).into();
-        assert_eq!(signing_authority, Pubkey::new(&[1u8; 32]).into());
-        assert_ne!(signing_authority, Pubkey::new(&[2u8; 32]).into());
     }
 
     #[test]
@@ -2865,7 +2764,7 @@ mod tests {
                     to: pubkey,
                     blockhash_query: BlockhashQuery::FeeCalculator(blockhash),
                     nonce_account: Some(pubkey),
-                    nonce_authority: Some(authority_pubkey.into()),
+                    nonce_authority: Some(Presigner::new(&authority_pubkey, &sig).into()),
                     signers: Some(vec![(authority_pubkey, sig)]),
                     ..PayCommand::default()
                 }),
@@ -3462,13 +3361,13 @@ mod tests {
                 command: CliCommand::Transfer {
                     lamports: 42_000_000_000,
                     to: to_pubkey,
-                    from: Some(from_pubkey.into()),
+                    from: Some(Presigner::new(&from_pubkey, &from_sig).into()),
                     sign_only: false,
                     signers: Some(vec![(from_pubkey, from_sig)]),
                     blockhash_query: BlockhashQuery::FeeCalculator(blockhash),
                     nonce_account: None,
                     nonce_authority: None,
-                    fee_payer: Some(from_pubkey.into()),
+                    fee_payer: Some(Presigner::new(&from_pubkey, &from_sig).into()),
                 },
                 require_keypair: true,
             }

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -471,6 +471,12 @@ impl error::Error for CliError {
     }
 }
 
+impl From<Box<dyn error::Error>> for CliError {
+    fn from(error: Box<dyn error::Error>) -> Self {
+        CliError::DynamicProgramError(format!("{:?}", error))
+    }
+}
+
 pub struct CliConfig {
     pub command: CliCommand,
     pub json_rpc_url: String,

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -744,7 +744,7 @@ pub fn process_ping(
         last_blockhash = recent_blockhash;
 
         let transaction =
-            system_transaction::transfer(&config.keypair, &to, lamports, recent_blockhash);
+            system_transaction::transfer(config.keypair.as_ref(), &to, lamports, recent_blockhash);
         check_account_for_fee(
             rpc_client,
             &config.keypair.pubkey(),

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -20,9 +20,11 @@ use solana_sdk::{
     commitment_config::CommitmentConfig,
     epoch_schedule::Epoch,
     hash::Hash,
+    message::Message,
     pubkey::Pubkey,
     signature::{Keypair, KeypairUtil},
-    system_transaction,
+    system_instruction,
+    transaction::Transaction,
 };
 use std::{
     collections::{HashMap, VecDeque},
@@ -743,8 +745,10 @@ pub fn process_ping(
         let (recent_blockhash, fee_calculator) = rpc_client.get_new_blockhash(&last_blockhash)?;
         last_blockhash = recent_blockhash;
 
-        let transaction =
-            system_transaction::transfer(config.keypair.as_ref(), &to, lamports, recent_blockhash);
+        let ix = system_instruction::transfer(&config.keypair.pubkey(), &to, lamports);
+        let message = Message::new(vec![ix]);
+        let mut transaction = Transaction::new_unsigned(message);
+        transaction.sign_dynamic_signers(&[config.keypair.as_ref()], recent_blockhash);
         check_account_for_fee(
             rpc_client,
             &config.keypair.pubkey(),

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -748,7 +748,7 @@ pub fn process_ping(
         let ix = system_instruction::transfer(&config.keypair.pubkey(), &to, lamports);
         let message = Message::new(vec![ix]);
         let mut transaction = Transaction::new_unsigned(message);
-        transaction.sign_dynamic_signers(&[config.keypair.as_ref()], recent_blockhash);
+        transaction.sign_dynamic_signers(&[config.keypair.as_ref()], recent_blockhash)?;
         check_account_for_fee(
             rpc_client,
             &config.keypair.pubkey(),

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -4,17 +4,13 @@ use console::style;
 use solana_clap_utils::{
     input_parsers::derivation_of,
     input_validators::{is_derivation, is_url},
-    keypair::{
-        self, keypair_input, KeypairWithSource, ASK_SEED_PHRASE_ARG,
-        SKIP_SEED_PHRASE_VALIDATION_ARG,
-    },
+    keypair::{keypair_util_from_path, ASK_SEED_PHRASE_ARG, SKIP_SEED_PHRASE_VALIDATION_ARG},
 };
 use solana_cli::{
     cli::{app, parse_command, process_command, CliCommandInfo, CliConfig, CliError},
     display::{println_name_value, println_name_value_or},
 };
 use solana_cli_config::config::{Config, CONFIG_FILE};
-use solana_sdk::signature::read_keypair_file;
 
 use std::error;
 
@@ -105,42 +101,24 @@ pub fn parse_args(matches: &ArgMatches<'_>) -> Result<CliConfig, Box<dyn error::
     } = parse_command(&matches)?;
 
     let (keypair, keypair_path) = if require_keypair {
-        let KeypairWithSource { keypair, source } = keypair_input(&matches, "keypair")?;
-        match source {
-            keypair::Source::Path => (
-                keypair,
-                Some(matches.value_of("keypair").unwrap().to_string()),
-            ),
-            keypair::Source::SeedPhrase => (keypair, None),
-            keypair::Source::Generated => {
-                let keypair_path = if config.keypair_path != "" {
-                    config.keypair_path
-                } else {
-                    let default_keypair_path = CliConfig::default_keypair_path();
-                    if !std::path::Path::new(&default_keypair_path).exists() {
-                        return Err(CliError::KeypairFileNotFound(format!(
-                            "Generate a new keypair at {} with `solana-keygen new`",
-                            default_keypair_path
-                        ))
-                        .into());
-                    }
+        let path = if matches.is_present("keypair") {
+            matches.value_of("keypair").unwrap().to_string()
+        } else if config.keypair_path != "" {
+            config.keypair_path
+        } else {
+            let default_keypair_path = CliConfig::default_keypair_path();
+            if !std::path::Path::new(&default_keypair_path).exists() {
+                return Err(CliError::KeypairFileNotFound(format!(
+                    "Generate a new keypair at {} with `solana-keygen new`",
                     default_keypair_path
-                };
-
-                let keypair = if keypair_path.starts_with("usb://") {
-                    keypair
-                } else {
-                    read_keypair_file(&keypair_path).or_else(|err| {
-                        Err(CliError::BadParameter(format!(
-                            "{}: Unable to open keypair file: {}",
-                            err, keypair_path
-                        )))
-                    })?
-                };
-
-                (keypair, Some(keypair_path))
+                ))
+                .into());
             }
-        }
+            default_keypair_path
+        };
+
+        let keypair = keypair_util_from_path(matches, &path, "keypair")?;
+        (keypair, Some(path))
     } else {
         let default = CliConfig::default();
         (default.keypair, None)
@@ -201,6 +179,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
         Arg::with_name("derivation_path")
             .long("derivation-path")
             .value_name("ACCOUNT or ACCOUNT/CHANGE")
+            .global(true)
             .takes_value(true)
             .validator(is_derivation)
             .help("Derivation path to use: m/44'/501'/ACCOUNT'/CHANGE'; default key is device base pubkey: m/44'/501'/0'")

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -4,7 +4,7 @@ use console::style;
 use solana_clap_utils::{
     input_parsers::derivation_of,
     input_validators::{is_derivation, is_url},
-    keypair::{keypair_util_from_path, ASK_SEED_PHRASE_ARG, SKIP_SEED_PHRASE_VALIDATION_ARG},
+    keypair::{keypair_util_from_path, SKIP_SEED_PHRASE_VALIDATION_ARG},
 };
 use solana_cli::{
     cli::{app, parse_command, process_command, CliCommandInfo, CliConfig, CliError},
@@ -190,15 +190,6 @@ fn main() -> Result<(), Box<dyn error::Error>> {
             .short("v")
             .global(true)
             .help("Show extra information header"),
-    )
-    .arg(
-        Arg::with_name(ASK_SEED_PHRASE_ARG.name)
-            .long(ASK_SEED_PHRASE_ARG.long)
-            .value_name("KEYPAIR NAME")
-            .global(true)
-            .takes_value(true)
-            .possible_values(&["keypair"])
-            .help(ASK_SEED_PHRASE_ARG.help),
     )
     .arg(
         Arg::with_name(SKIP_SEED_PHRASE_VALIDATION_ARG.name)

--- a/cli/src/nonce.rs
+++ b/cli/src/nonce.rs
@@ -2,9 +2,10 @@ use crate::cli::{
     build_balance_message, check_account_for_fee, check_unique_pubkeys,
     log_instruction_custom_error, CliCommand, CliCommandInfo, CliConfig, CliError, ProcessResult,
 };
-use crate::offline::BLOCKHASH_ARG;
 use clap::{App, Arg, ArgMatches, SubCommand};
-use solana_clap_utils::{input_parsers::*, input_validators::*, ArgConstant};
+use solana_clap_utils::{
+    input_parsers::*, input_validators::*, offline::BLOCKHASH_ARG, ArgConstant,
+};
 use solana_client::rpc_client::RpcClient;
 use solana_sdk::{
     account::Account,

--- a/cli/src/nonce.rs
+++ b/cli/src/nonce.rs
@@ -1,7 +1,6 @@
 use crate::cli::{
     build_balance_message, check_account_for_fee, check_unique_pubkeys,
     log_instruction_custom_error, CliCommand, CliCommandInfo, CliConfig, CliError, ProcessResult,
-    SigningAuthority,
 };
 use crate::offline::BLOCKHASH_ARG;
 use clap::{App, Arg, ArgMatches, SubCommand};
@@ -13,7 +12,7 @@ use solana_sdk::{
     hash::Hash,
     nonce_state::{Meta, NonceState},
     pubkey::Pubkey,
-    signature::{Keypair, KeypairUtil},
+    signature::KeypairUtil,
     system_instruction::{
         advance_nonce_account, authorize_nonce_account, create_address_with_seed,
         create_nonce_account, create_nonce_account_with_seed, withdraw_nonce_account, NonceError,
@@ -218,8 +217,7 @@ impl NonceSubCommands for App<'_, '_> {
 pub fn parse_authorize_nonce_account(matches: &ArgMatches<'_>) -> Result<CliCommandInfo, CliError> {
     let nonce_account = pubkey_of(matches, "nonce_account_keypair").unwrap();
     let new_authority = pubkey_of(matches, "new_authority").unwrap();
-    let nonce_authority =
-        SigningAuthority::new_from_matches(&matches, NONCE_AUTHORITY_ARG.name, None)?;
+    let nonce_authority = signer_of(NONCE_AUTHORITY_ARG.name, matches)?;
 
     Ok(CliCommandInfo {
         command: CliCommand::AuthorizeNonceAccount {
@@ -232,7 +230,7 @@ pub fn parse_authorize_nonce_account(matches: &ArgMatches<'_>) -> Result<CliComm
 }
 
 pub fn parse_nonce_create_account(matches: &ArgMatches<'_>) -> Result<CliCommandInfo, CliError> {
-    let nonce_account = keypair_of(matches, "nonce_account_keypair").unwrap();
+    let nonce_account = signer_of("nonce_account_keypair", matches)?.unwrap();
     let seed = matches.value_of("seed").map(|s| s.to_string());
     let lamports = lamports_of_sol(matches, "amount").unwrap();
     let nonce_authority = pubkey_of(matches, NONCE_AUTHORITY_ARG.name);
@@ -259,8 +257,7 @@ pub fn parse_get_nonce(matches: &ArgMatches<'_>) -> Result<CliCommandInfo, CliEr
 
 pub fn parse_new_nonce(matches: &ArgMatches<'_>) -> Result<CliCommandInfo, CliError> {
     let nonce_account = pubkey_of(matches, "nonce_account_keypair").unwrap();
-    let nonce_authority =
-        SigningAuthority::new_from_matches(&matches, NONCE_AUTHORITY_ARG.name, None)?;
+    let nonce_authority = signer_of(NONCE_AUTHORITY_ARG.name, matches)?;
 
     Ok(CliCommandInfo {
         command: CliCommand::NewNonce {
@@ -290,8 +287,7 @@ pub fn parse_withdraw_from_nonce_account(
     let nonce_account = pubkey_of(matches, "nonce_account_keypair").unwrap();
     let destination_account_pubkey = pubkey_of(matches, "destination_account_pubkey").unwrap();
     let lamports = lamports_of_sol(matches, "amount").unwrap();
-    let nonce_authority =
-        SigningAuthority::new_from_matches(&matches, NONCE_AUTHORITY_ARG.name, None)?;
+    let nonce_authority = signer_of(NONCE_AUTHORITY_ARG.name, matches)?;
 
     Ok(CliCommandInfo {
         command: CliCommand::WithdrawFromNonceAccount {
@@ -336,14 +332,12 @@ pub fn process_authorize_nonce_account(
     rpc_client: &RpcClient,
     config: &CliConfig,
     nonce_account: &Pubkey,
-    nonce_authority: Option<&SigningAuthority>,
+    nonce_authority: Option<&dyn KeypairUtil>,
     new_authority: &Pubkey,
 ) -> ProcessResult {
     let (recent_blockhash, fee_calculator) = rpc_client.get_recent_blockhash()?;
 
-    let nonce_authority = nonce_authority
-        .map(|a| a.keypair())
-        .unwrap_or(&config.keypair);
+    let nonce_authority = nonce_authority.unwrap_or_else(|| config.keypair.as_ref());
     let ix = authorize_nonce_account(nonce_account, &nonce_authority.pubkey(), new_authority);
     let mut tx = Transaction::new_signed_with_payer(
         vec![ix],
@@ -367,7 +361,7 @@ pub fn process_authorize_nonce_account(
 pub fn process_create_nonce_account(
     rpc_client: &RpcClient,
     config: &CliConfig,
-    nonce_account: &Keypair,
+    nonce_account: &dyn KeypairUtil,
     seed: Option<String>,
     nonce_authority: Option<Pubkey>,
     lamports: u64,
@@ -475,7 +469,7 @@ pub fn process_new_nonce(
     rpc_client: &RpcClient,
     config: &CliConfig,
     nonce_account: &Pubkey,
-    nonce_authority: Option<&SigningAuthority>,
+    nonce_authority: Option<&dyn KeypairUtil>,
 ) -> ProcessResult {
     check_unique_pubkeys(
         (&config.keypair.pubkey(), "cli keypair".to_string()),
@@ -489,9 +483,7 @@ pub fn process_new_nonce(
         .into());
     }
 
-    let nonce_authority = nonce_authority
-        .map(|a| a.keypair())
-        .unwrap_or(&config.keypair);
+    let nonce_authority = nonce_authority.unwrap_or_else(|| config.keypair.as_ref());
     let ix = advance_nonce_account(&nonce_account, &nonce_authority.pubkey());
     let (recent_blockhash, fee_calculator) = rpc_client.get_recent_blockhash()?;
     let mut tx = Transaction::new_signed_with_payer(
@@ -566,15 +558,13 @@ pub fn process_withdraw_from_nonce_account(
     rpc_client: &RpcClient,
     config: &CliConfig,
     nonce_account: &Pubkey,
-    nonce_authority: Option<&SigningAuthority>,
+    nonce_authority: Option<&dyn KeypairUtil>,
     destination_account_pubkey: &Pubkey,
     lamports: u64,
 ) -> ProcessResult {
     let (recent_blockhash, fee_calculator) = rpc_client.get_recent_blockhash()?;
 
-    let nonce_authority = nonce_authority
-        .map(|a| a.keypair())
-        .unwrap_or(&config.keypair);
+    let nonce_authority = nonce_authority.unwrap_or_else(|| config.keypair.as_ref());
     let ix = withdraw_nonce_account(
         nonce_account,
         &nonce_authority.pubkey(),

--- a/cli/src/nonce.rs
+++ b/cli/src/nonce.rs
@@ -64,8 +64,8 @@ pub fn nonce_authority_arg<'a, 'b>() -> Arg<'a, 'b> {
     Arg::with_name(NONCE_AUTHORITY_ARG.name)
         .long(NONCE_AUTHORITY_ARG.long)
         .takes_value(true)
-        .value_name("KEYPAIR or PUBKEY")
-        .validator(is_pubkey_or_keypair_or_ask_keyword)
+        .value_name("KEYPAIR or PUBKEY or REMOTE WALLET PATH")
+        .validator(is_valid_signer)
         .help(NONCE_AUTHORITY_ARG.help)
 }
 

--- a/cli/src/nonce.rs
+++ b/cli/src/nonce.rs
@@ -346,7 +346,7 @@ pub fn process_authorize_nonce_account(
     tx.sign_dynamic_signers(
         &[config.keypair.as_ref(), nonce_authority],
         recent_blockhash,
-    );
+    )?;
 
     check_account_for_fee(
         rpc_client,
@@ -434,7 +434,7 @@ pub fn process_create_nonce_account(
 
     let message = Message::new_with_payer(ixs, Some(&config.keypair.pubkey()));
     let mut tx = Transaction::new_unsigned(message);
-    tx.sign_dynamic_signers(&signers, recent_blockhash);
+    tx.sign_dynamic_signers(&signers, recent_blockhash)?;
 
     check_account_for_fee(
         rpc_client,
@@ -492,7 +492,7 @@ pub fn process_new_nonce(
     tx.sign_dynamic_signers(
         &[config.keypair.as_ref(), nonce_authority],
         recent_blockhash,
-    );
+    )?;
     check_account_for_fee(
         rpc_client,
         &config.keypair.pubkey(),
@@ -577,7 +577,7 @@ pub fn process_withdraw_from_nonce_account(
     tx.sign_dynamic_signers(
         &[config.keypair.as_ref(), nonce_authority],
         recent_blockhash,
-    );
+    )?;
     check_account_for_fee(
         rpc_client,
         &config.keypair.pubkey(),

--- a/cli/src/nonce.rs
+++ b/cli/src/nonce.rs
@@ -598,9 +598,10 @@ mod tests {
         account::Account,
         hash::hash,
         nonce_state::{Meta as NonceMeta, NonceState},
-        signature::{read_keypair_file, write_keypair},
+        signature::{read_keypair_file, write_keypair, Keypair},
         system_program,
     };
+    use std::rc::Rc;
     use tempfile::NamedTempFile;
 
     fn make_tmp_file() -> (String, NamedTempFile) {
@@ -674,7 +675,7 @@ mod tests {
             parse_command(&test_create_nonce_account).unwrap(),
             CliCommandInfo {
                 command: CliCommand::CreateNonceAccount {
-                    nonce_account: read_keypair_file(&keypair_file).unwrap().into(),
+                    nonce_account: Rc::new(read_keypair_file(&keypair_file).unwrap().into()),
                     seed: None,
                     nonce_authority: None,
                     lamports: 50_000_000_000,
@@ -696,7 +697,7 @@ mod tests {
             parse_command(&test_create_nonce_account).unwrap(),
             CliCommandInfo {
                 command: CliCommand::CreateNonceAccount {
-                    nonce_account: read_keypair_file(&keypair_file).unwrap().into(),
+                    nonce_account: Rc::new(read_keypair_file(&keypair_file).unwrap().into()),
                     seed: None,
                     nonce_authority: Some(
                         read_keypair_file(&authority_keypair_file).unwrap().pubkey()

--- a/cli/src/nonce.rs
+++ b/cli/src/nonce.rs
@@ -348,7 +348,7 @@ pub fn process_authorize_nonce_account(
     let mut tx = Transaction::new_signed_with_payer(
         vec![ix],
         Some(&config.keypair.pubkey()),
-        &[&config.keypair, nonce_authority],
+        &[config.keypair.as_ref(), nonce_authority],
         recent_blockhash,
     );
     check_account_for_fee(
@@ -357,8 +357,10 @@ pub fn process_authorize_nonce_account(
         &fee_calculator,
         &tx.message,
     )?;
-    let result =
-        rpc_client.send_and_confirm_transaction(&mut tx, &[&config.keypair, nonce_authority]);
+    let result = rpc_client.send_and_confirm_transaction_dynamic_signers(
+        &mut tx,
+        &[config.keypair.as_ref(), nonce_authority],
+    );
     log_instruction_custom_error::<NonceError>(result)
 }
 
@@ -428,9 +430,9 @@ pub fn process_create_nonce_account(
     let (recent_blockhash, fee_calculator) = rpc_client.get_recent_blockhash()?;
 
     let signers = if nonce_account_pubkey != config.keypair.pubkey() {
-        vec![&config.keypair, nonce_account] // both must sign if `from` and `to` differ
+        vec![config.keypair.as_ref(), nonce_account] // both must sign if `from` and `to` differ
     } else {
-        vec![&config.keypair] // when stake_account == config.keypair and there's a seed, we only need one signature
+        vec![config.keypair.as_ref()] // when stake_account == config.keypair and there's a seed, we only need one signature
     };
 
     let mut tx = Transaction::new_signed_with_payer(
@@ -445,7 +447,7 @@ pub fn process_create_nonce_account(
         &fee_calculator,
         &tx.message,
     )?;
-    let result = rpc_client.send_and_confirm_transaction(&mut tx, &signers);
+    let result = rpc_client.send_and_confirm_transaction_dynamic_signers(&mut tx, &signers);
     log_instruction_custom_error::<SystemError>(result)
 }
 
@@ -495,7 +497,7 @@ pub fn process_new_nonce(
     let mut tx = Transaction::new_signed_with_payer(
         vec![ix],
         Some(&config.keypair.pubkey()),
-        &[&config.keypair, nonce_authority],
+        &[config.keypair.as_ref(), nonce_authority],
         recent_blockhash,
     );
     check_account_for_fee(
@@ -504,8 +506,10 @@ pub fn process_new_nonce(
         &fee_calculator,
         &tx.message,
     )?;
-    let result =
-        rpc_client.send_and_confirm_transaction(&mut tx, &[&config.keypair, nonce_authority]);
+    let result = rpc_client.send_and_confirm_transaction_dynamic_signers(
+        &mut tx,
+        &[config.keypair.as_ref(), nonce_authority],
+    );
     log_instruction_custom_error::<SystemError>(result)
 }
 
@@ -580,7 +584,7 @@ pub fn process_withdraw_from_nonce_account(
     let mut tx = Transaction::new_signed_with_payer(
         vec![ix],
         Some(&config.keypair.pubkey()),
-        &[&config.keypair, nonce_authority],
+        &[config.keypair.as_ref(), nonce_authority],
         recent_blockhash,
     );
     check_account_for_fee(
@@ -589,8 +593,10 @@ pub fn process_withdraw_from_nonce_account(
         &fee_calculator,
         &tx.message,
     )?;
-    let result =
-        rpc_client.send_and_confirm_transaction(&mut tx, &[&config.keypair, nonce_authority]);
+    let result = rpc_client.send_and_confirm_transaction_dynamic_signers(
+        &mut tx,
+        &[config.keypair.as_ref(), nonce_authority],
+    );
     log_instruction_custom_error::<NonceError>(result)
 }
 

--- a/cli/src/nonce.rs
+++ b/cli/src/nonce.rs
@@ -10,6 +10,7 @@ use solana_sdk::{
     account::Account,
     account_utils::StateMut,
     hash::Hash,
+    message::Message,
     nonce_state::{Meta, NonceState},
     pubkey::Pubkey,
     signature::KeypairUtil,
@@ -339,12 +340,13 @@ pub fn process_authorize_nonce_account(
 
     let nonce_authority = nonce_authority.unwrap_or_else(|| config.keypair.as_ref());
     let ix = authorize_nonce_account(nonce_account, &nonce_authority.pubkey(), new_authority);
-    let mut tx = Transaction::new_signed_with_payer(
-        vec![ix],
-        Some(&config.keypair.pubkey()),
+    let message = Message::new_with_payer(vec![ix], Some(&config.keypair.pubkey()));
+    let mut tx = Transaction::new_unsigned(message);
+    tx.sign_dynamic_signers(
         &[config.keypair.as_ref(), nonce_authority],
         recent_blockhash,
     );
+
     check_account_for_fee(
         rpc_client,
         &config.keypair.pubkey(),
@@ -429,12 +431,10 @@ pub fn process_create_nonce_account(
         vec![config.keypair.as_ref()] // when stake_account == config.keypair and there's a seed, we only need one signature
     };
 
-    let mut tx = Transaction::new_signed_with_payer(
-        ixs,
-        Some(&config.keypair.pubkey()),
-        &signers,
-        recent_blockhash,
-    );
+    let message = Message::new_with_payer(ixs, Some(&config.keypair.pubkey()));
+    let mut tx = Transaction::new_unsigned(message);
+    tx.sign_dynamic_signers(&signers, recent_blockhash);
+
     check_account_for_fee(
         rpc_client,
         &config.keypair.pubkey(),
@@ -486,9 +486,9 @@ pub fn process_new_nonce(
     let nonce_authority = nonce_authority.unwrap_or_else(|| config.keypair.as_ref());
     let ix = advance_nonce_account(&nonce_account, &nonce_authority.pubkey());
     let (recent_blockhash, fee_calculator) = rpc_client.get_recent_blockhash()?;
-    let mut tx = Transaction::new_signed_with_payer(
-        vec![ix],
-        Some(&config.keypair.pubkey()),
+    let message = Message::new_with_payer(vec![ix], Some(&config.keypair.pubkey()));
+    let mut tx = Transaction::new_unsigned(message);
+    tx.sign_dynamic_signers(
         &[config.keypair.as_ref(), nonce_authority],
         recent_blockhash,
     );
@@ -571,9 +571,9 @@ pub fn process_withdraw_from_nonce_account(
         destination_account_pubkey,
         lamports,
     );
-    let mut tx = Transaction::new_signed_with_payer(
-        vec![ix],
-        Some(&config.keypair.pubkey()),
+    let message = Message::new_with_payer(vec![ix], Some(&config.keypair.pubkey()));
+    let mut tx = Transaction::new_unsigned(message);
+    tx.sign_dynamic_signers(
         &[config.keypair.as_ref(), nonce_authority],
         recent_blockhash,
     );

--- a/cli/src/offline.rs
+++ b/cli/src/offline.rs
@@ -3,29 +3,11 @@ use serde_json::Value;
 use solana_clap_utils::{
     input_parsers::value_of,
     input_validators::{is_hash, is_pubkey_sig},
-    ArgConstant,
+    offline::{BLOCKHASH_ARG, SIGNER_ARG, SIGN_ONLY_ARG},
 };
 use solana_client::rpc_client::RpcClient;
 use solana_sdk::{fee_calculator::FeeCalculator, hash::Hash, pubkey::Pubkey, signature::Signature};
 use std::str::FromStr;
-
-pub const BLOCKHASH_ARG: ArgConstant<'static> = ArgConstant {
-    name: "blockhash",
-    long: "blockhash",
-    help: "Use the supplied blockhash",
-};
-
-pub const SIGN_ONLY_ARG: ArgConstant<'static> = ArgConstant {
-    name: "sign_only",
-    long: "sign-only",
-    help: "Sign the transaction offline",
-};
-
-pub const SIGNER_ARG: ArgConstant<'static> = ArgConstant {
-    name: "signer",
-    long: "signer",
-    help: "Provide a public-key/signature pair for the transaction",
-};
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum BlockhashQuery {

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -1424,8 +1424,11 @@ mod tests {
     use solana_sdk::{
         fee_calculator::FeeCalculator,
         hash::Hash,
-        signature::{keypair_from_seed, read_keypair_file, write_keypair, KeypairUtil, Presigner},
+        signature::{
+            keypair_from_seed, read_keypair_file, write_keypair, Keypair, KeypairUtil, Presigner,
+        },
     };
+    use std::rc::Rc;
     use tempfile::NamedTempFile;
 
     fn make_tmp_file() -> (String, NamedTempFile) {
@@ -1773,7 +1776,7 @@ mod tests {
             parse_command(&test_create_stake_account).unwrap(),
             CliCommandInfo {
                 command: CliCommand::CreateStakeAccount {
-                    stake_account: stake_account_keypair.into(),
+                    stake_account: Rc::new(stake_account_keypair.into()),
                     seed: None,
                     staker: Some(authorized),
                     withdrawer: Some(authorized),
@@ -1811,7 +1814,7 @@ mod tests {
             parse_command(&test_create_stake_account2).unwrap(),
             CliCommandInfo {
                 command: CliCommand::CreateStakeAccount {
-                    stake_account: read_keypair_file(&keypair_file).unwrap().into(),
+                    stake_account: Rc::new(read_keypair_file(&keypair_file).unwrap().into()),
                     seed: None,
                     staker: None,
                     withdrawer: None,
@@ -1861,7 +1864,7 @@ mod tests {
             parse_command(&test_create_stake_account2).unwrap(),
             CliCommandInfo {
                 command: CliCommand::CreateStakeAccount {
-                    stake_account: read_keypair_file(&keypair_file).unwrap().into(),
+                    stake_account: Rc::new(read_keypair_file(&keypair_file).unwrap().into()),
                     seed: None,
                     staker: None,
                     withdrawer: None,
@@ -2098,8 +2101,6 @@ mod tests {
         let (fee_payer_keypair_file, mut fee_payer_tmp_file) = make_tmp_file();
         let fee_payer_keypair = Keypair::new();
         write_keypair(&fee_payer_keypair, fee_payer_tmp_file.as_file_mut()).unwrap();
-        let fee_payer_pubkey = fee_payer_keypair.pubkey();
-        let fee_payer_string = fee_payer_pubkey.to_string();
         let test_delegate_stake = test_commands.clone().get_matches_from(vec![
             "test",
             "delegate-stake",
@@ -2446,9 +2447,11 @@ mod tests {
                     blockhash_query: BlockhashQuery::default(),
                     nonce_account: None,
                     nonce_authority: None,
-                    split_stake_account: read_keypair_file(&split_stake_account_keypair_file)
-                        .unwrap()
-                        .into(),
+                    split_stake_account: Rc::new(
+                        read_keypair_file(&split_stake_account_keypair_file)
+                            .unwrap()
+                            .into(),
+                    ),
                     seed: None,
                     lamports: 50_000_000_000,
                     fee_payer: None,
@@ -2504,9 +2507,11 @@ mod tests {
                     blockhash_query: BlockhashQuery::FeeCalculator(nonce_hash),
                     nonce_account: Some(nonce_account.into()),
                     nonce_authority: Some(Presigner::new(&nonce_auth_pubkey, &nonce_sig).into()),
-                    split_stake_account: read_keypair_file(&split_stake_account_keypair_file)
-                        .unwrap()
-                        .into(),
+                    split_stake_account: Rc::new(
+                        read_keypair_file(&split_stake_account_keypair_file)
+                            .unwrap()
+                            .into(),
+                    ),
                     seed: None,
                     lamports: 50_000_000_000,
                     fee_payer: Some(Presigner::new(&nonce_auth_pubkey, &nonce_sig).into()),

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -1596,7 +1596,7 @@ mod tests {
                     authority: None,
                     sign_only: false,
                     blockhash_query: BlockhashQuery::FeeCalculator(blockhash),
-                    nonce_account: None,
+                    nonce_account: Some(nonce_account),
                     nonce_authority: Some(Presigner::new(&pubkey2, &sig2).into()),
                     fee_payer: Some(Presigner::new(&pubkey, &sig).into()),
                 },
@@ -2076,7 +2076,7 @@ mod tests {
             &key1.to_string(),
             "--nonce",
             &nonce_account.to_string(),
-            "--nonce_auhtority",
+            "--nonce-authority",
             &key2.to_string(),
         ]);
         assert_eq!(
@@ -2379,7 +2379,7 @@ mod tests {
             &key1.to_string(),
             "--nonce",
             &nonce_account.to_string(),
-            "--nonce-account",
+            "--nonce-authority",
             &key2.to_string(),
         ]);
         assert_eq!(
@@ -2390,7 +2390,7 @@ mod tests {
                     stake_authority: None,
                     sign_only: false,
                     blockhash_query: BlockhashQuery::FeeCalculator(blockhash),
-                    nonce_account: None,
+                    nonce_account: Some(nonce_account),
                     nonce_authority: Some(Presigner::new(&key2, &sig2).into()),
                     fee_payer: Some(Presigner::new(&key1, &sig1).into()),
                 },

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -1,9 +1,8 @@
 use crate::{
     cli::{
         build_balance_message, check_account_for_fee, check_unique_pubkeys, fee_payer_arg,
-        log_instruction_custom_error, nonce_authority_arg, replace_signatures, return_signers,
-        CliCommand, CliCommandInfo, CliConfig, CliError, ProcessResult, SigningAuthority,
-        FEE_PAYER_ARG,
+        log_instruction_custom_error, nonce_authority_arg, return_signers, CliCommand,
+        CliCommandInfo, CliConfig, CliError, ProcessResult, FEE_PAYER_ARG,
     },
     nonce::{check_nonce_account, nonce_arg, NONCE_ARG, NONCE_AUTHORITY_ARG},
     offline::*,
@@ -12,7 +11,6 @@ use clap::{App, Arg, ArgMatches, SubCommand};
 use console::style;
 use solana_clap_utils::{input_parsers::*, input_validators::*, ArgConstant};
 use solana_client::rpc_client::RpcClient;
-use solana_sdk::signature::{Keypair, Signature};
 use solana_sdk::{
     account_utils::StateMut,
     pubkey::Pubkey,
@@ -425,19 +423,14 @@ pub fn parse_stake_create_account(matches: &ArgMatches<'_>) -> Result<CliCommand
     let blockhash_query = BlockhashQuery::new_from_matches(matches);
     let require_keypair = signers.is_none();
     let nonce_account = pubkey_of(&matches, NONCE_ARG.name);
-    let nonce_authority =
-        SigningAuthority::new_from_matches(&matches, NONCE_AUTHORITY_ARG.name, signers.as_deref())?;
-    let fee_payer =
-        SigningAuthority::new_from_matches(&matches, FEE_PAYER_ARG.name, signers.as_deref())?;
-    let from = SigningAuthority::new_from_matches(&matches, "from", signers.as_deref())?;
-    let stake_account =
-        SigningAuthority::new_from_matches(&matches, "stake_account", signers.as_deref())
-            .unwrap()
-            .unwrap();
+    let nonce_authority = signer_of(NONCE_AUTHORITY_ARG.name, matches)?;
+    let fee_payer = signer_of(FEE_PAYER_ARG.name, matches)?;
+    let from = signer_of("from", matches)?;
+    let stake_account = signer_of("stake_account", matches)?.unwrap();
 
     Ok(CliCommandInfo {
         command: CliCommand::CreateStakeAccount {
-            stake_account,
+            stake_account: stake_account.into(),
             seed,
             staker,
             withdrawer,
@@ -468,12 +461,9 @@ pub fn parse_stake_delegate_stake(matches: &ArgMatches<'_>) -> Result<CliCommand
     let blockhash_query = BlockhashQuery::new_from_matches(matches);
     let require_keypair = signers.is_none();
     let nonce_account = pubkey_of(&matches, NONCE_ARG.name);
-    let stake_authority =
-        SigningAuthority::new_from_matches(&matches, STAKE_AUTHORITY_ARG.name, signers.as_deref())?;
-    let nonce_authority =
-        SigningAuthority::new_from_matches(&matches, NONCE_AUTHORITY_ARG.name, signers.as_deref())?;
-    let fee_payer =
-        SigningAuthority::new_from_matches(&matches, FEE_PAYER_ARG.name, signers.as_deref())?;
+    let stake_authority = signer_of(STAKE_AUTHORITY_ARG.name, matches)?;
+    let nonce_authority = signer_of(NONCE_AUTHORITY_ARG.name, matches)?;
+    let fee_payer = signer_of(FEE_PAYER_ARG.name, matches)?;
 
     Ok(CliCommandInfo {
         command: CliCommand::DelegateStake {
@@ -504,14 +494,11 @@ pub fn parse_stake_authorize(
     };
     let sign_only = matches.is_present(SIGN_ONLY_ARG.name);
     let signers = pubkeys_sigs_of(&matches, SIGNER_ARG.name);
-    let authority =
-        SigningAuthority::new_from_matches(&matches, authority_flag, signers.as_deref())?;
+    let authority = signer_of(authority_flag, matches)?;
     let blockhash_query = BlockhashQuery::new_from_matches(matches);
     let nonce_account = pubkey_of(&matches, NONCE_ARG.name);
-    let nonce_authority =
-        SigningAuthority::new_from_matches(&matches, NONCE_AUTHORITY_ARG.name, signers.as_deref())?;
-    let fee_payer =
-        SigningAuthority::new_from_matches(&matches, FEE_PAYER_ARG.name, signers.as_deref())?;
+    let nonce_authority = signer_of(NONCE_AUTHORITY_ARG.name, matches)?;
+    let fee_payer = signer_of(FEE_PAYER_ARG.name, matches)?;
 
     Ok(CliCommandInfo {
         command: CliCommand::StakeAuthorize {
@@ -532,7 +519,7 @@ pub fn parse_stake_authorize(
 
 pub fn parse_split_stake(matches: &ArgMatches<'_>) -> Result<CliCommandInfo, CliError> {
     let stake_account_pubkey = pubkey_of(matches, "stake_account_pubkey").unwrap();
-    let split_stake_account = keypair_of(matches, "split_stake_account").unwrap();
+    let split_stake_account = signer_of("split_stake_account", matches)?.unwrap();
     let lamports = lamports_of_sol(matches, "amount").unwrap();
     let seed = matches.value_of("seed").map(|s| s.to_string());
 
@@ -541,12 +528,9 @@ pub fn parse_split_stake(matches: &ArgMatches<'_>) -> Result<CliCommandInfo, Cli
     let blockhash_query = BlockhashQuery::new_from_matches(matches);
     let require_keypair = signers.is_none();
     let nonce_account = pubkey_of(&matches, NONCE_ARG.name);
-    let stake_authority =
-        SigningAuthority::new_from_matches(&matches, STAKE_AUTHORITY_ARG.name, signers.as_deref())?;
-    let nonce_authority =
-        SigningAuthority::new_from_matches(&matches, NONCE_AUTHORITY_ARG.name, signers.as_deref())?;
-    let fee_payer =
-        SigningAuthority::new_from_matches(&matches, FEE_PAYER_ARG.name, signers.as_deref())?;
+    let stake_authority = signer_of(STAKE_AUTHORITY_ARG.name, matches)?;
+    let nonce_authority = signer_of(NONCE_AUTHORITY_ARG.name, matches)?;
+    let fee_payer = signer_of(FEE_PAYER_ARG.name, matches)?;
 
     Ok(CliCommandInfo {
         command: CliCommand::SplitStake {
@@ -573,12 +557,9 @@ pub fn parse_stake_deactivate_stake(matches: &ArgMatches<'_>) -> Result<CliComma
     let blockhash_query = BlockhashQuery::new_from_matches(matches);
     let require_keypair = signers.is_none();
     let nonce_account = pubkey_of(&matches, NONCE_ARG.name);
-    let stake_authority =
-        SigningAuthority::new_from_matches(&matches, STAKE_AUTHORITY_ARG.name, signers.as_deref())?;
-    let nonce_authority =
-        SigningAuthority::new_from_matches(&matches, NONCE_AUTHORITY_ARG.name, signers.as_deref())?;
-    let fee_payer =
-        SigningAuthority::new_from_matches(&matches, FEE_PAYER_ARG.name, signers.as_deref())?;
+    let stake_authority = signer_of(STAKE_AUTHORITY_ARG.name, matches)?;
+    let nonce_authority = signer_of(NONCE_AUTHORITY_ARG.name, matches)?;
+    let fee_payer = signer_of(FEE_PAYER_ARG.name, matches)?;
 
     Ok(CliCommandInfo {
         command: CliCommand::DeactivateStake {
@@ -604,15 +585,9 @@ pub fn parse_stake_withdraw_stake(matches: &ArgMatches<'_>) -> Result<CliCommand
     let blockhash_query = BlockhashQuery::new_from_matches(matches);
     let require_keypair = signers.is_none();
     let nonce_account = pubkey_of(&matches, NONCE_ARG.name);
-    let nonce_authority =
-        SigningAuthority::new_from_matches(&matches, NONCE_AUTHORITY_ARG.name, signers.as_deref())?;
-    let withdraw_authority = SigningAuthority::new_from_matches(
-        &matches,
-        WITHDRAW_AUTHORITY_ARG.name,
-        signers.as_deref(),
-    )?;
-    let fee_payer =
-        SigningAuthority::new_from_matches(&matches, FEE_PAYER_ARG.name, signers.as_deref())?;
+    let nonce_authority = signer_of(NONCE_AUTHORITY_ARG.name, matches)?;
+    let withdraw_authority = signer_of(WITHDRAW_AUTHORITY_ARG.name, matches)?;
+    let fee_payer = signer_of(FEE_PAYER_ARG.name, matches)?;
 
     Ok(CliCommandInfo {
         command: CliCommand::WithdrawStake {
@@ -643,11 +618,9 @@ pub fn parse_stake_set_lockup(matches: &ArgMatches<'_>) -> Result<CliCommandInfo
     let require_keypair = signers.is_none();
     let nonce_account = pubkey_of(&matches, NONCE_ARG.name);
 
-    let custodian = SigningAuthority::new_from_matches(&matches, "custodian", signers.as_deref())?;
-    let nonce_authority =
-        SigningAuthority::new_from_matches(&matches, NONCE_AUTHORITY_ARG.name, signers.as_deref())?;
-    let fee_payer =
-        SigningAuthority::new_from_matches(&matches, FEE_PAYER_ARG.name, signers.as_deref())?;
+    let custodian = signer_of("custodian", matches)?;
+    let nonce_authority = signer_of(NONCE_AUTHORITY_ARG.name, matches)?;
+    let fee_payer = signer_of(FEE_PAYER_ARG.name, matches)?;
 
     Ok(CliCommandInfo {
         command: CliCommand::StakeSetLockup {
@@ -693,7 +666,7 @@ pub fn parse_show_stake_history(matches: &ArgMatches<'_>) -> Result<CliCommandIn
 pub fn process_create_stake_account(
     rpc_client: &RpcClient,
     config: &CliConfig,
-    stake_account: &SigningAuthority,
+    stake_account: &dyn KeypairUtil,
     seed: &Option<String>,
     staker: &Option<Pubkey>,
     withdrawer: &Option<Pubkey>,
@@ -703,13 +676,13 @@ pub fn process_create_stake_account(
     signers: Option<&Vec<(Pubkey, Signature)>>,
     blockhash_query: &BlockhashQuery,
     nonce_account: Option<&Pubkey>,
-    nonce_authority: Option<&SigningAuthority>,
-    fee_payer: Option<&SigningAuthority>,
-    from: Option<&SigningAuthority>,
+    nonce_authority: Option<&dyn KeypairUtil>,
+    fee_payer: Option<&dyn KeypairUtil>,
+    from: Option<&dyn KeypairUtil>,
 ) -> ProcessResult {
     // Offline derived address creation currently is not possible
     // https://github.com/solana-labs/solana/pull/8252
-    if seed.is_some() && (sign_only || signers.is_some()) {
+    if seed.is_some() && sign_only {
         return Err(CliError::BadParameter(
             "Offline stake account creation with derived addresses are not yet supported"
                 .to_string(),
@@ -717,17 +690,14 @@ pub fn process_create_stake_account(
         .into());
     }
 
-    let (stake_account_pubkey, stake_account) = (stake_account.pubkey(), stake_account.keypair());
     let stake_account_address = if let Some(seed) = seed {
-        create_address_with_seed(&stake_account_pubkey, &seed, &solana_stake_program::id())?
+        create_address_with_seed(&stake_account.pubkey(), &seed, &solana_stake_program::id())?
     } else {
-        stake_account_pubkey
+        stake_account.pubkey()
     };
-    let (from_pubkey, from) = from
-        .map(|f| (f.pubkey(), f.keypair()))
-        .unwrap_or((config.keypair.pubkey(), &config.keypair));
+    let from = from.unwrap_or_else(|| config.keypair.as_ref());
     check_unique_pubkeys(
-        (&from_pubkey, "from keypair".to_string()),
+        (&from.pubkey(), "from keypair".to_string()),
         (&stake_account_address, "stake_account".to_string()),
     )?;
 
@@ -757,8 +727,8 @@ pub fn process_create_stake_account(
     }
 
     let authorized = Authorized {
-        staker: staker.unwrap_or(from_pubkey),
-        withdrawer: withdrawer.unwrap_or(from_pubkey),
+        staker: staker.unwrap_or(from.pubkey()),
+        withdrawer: withdrawer.unwrap_or(from.pubkey()),
     };
 
     let ixs = if let Some(seed) = seed {
@@ -783,15 +753,13 @@ pub fn process_create_stake_account(
     let (recent_blockhash, fee_calculator) =
         blockhash_query.get_blockhash_fee_calculator(rpc_client)?;
 
-    let fee_payer = fee_payer.map(|fp| fp.keypair()).unwrap_or(&config.keypair);
-    let mut tx_signers = if stake_account_pubkey != from_pubkey {
+    let fee_payer = fee_payer.unwrap_or_else(|| config.keypair.as_ref());
+    let mut tx_signers = if stake_account.pubkey() != from.pubkey() {
         vec![fee_payer, from, stake_account] // both must sign if `from` and `to` differ
     } else {
         vec![fee_payer, from] // when stake_account == config.keypair and there's a seed, we only need one signature
     };
-    let (nonce_authority_pubkey, nonce_authority) = nonce_authority
-        .map(|na| (na.pubkey(), na.keypair()))
-        .unwrap_or((config.keypair.pubkey(), &config.keypair));
+    let nonce_authority = nonce_authority.unwrap_or_else(|| config.keypair.as_ref());
 
     let mut tx = if let Some(nonce_account) = &nonce_account {
         tx_signers.push(nonce_authority);
@@ -819,7 +787,7 @@ pub fn process_create_stake_account(
     } else {
         if let Some(nonce_account) = &nonce_account {
             let nonce_account = rpc_client.get_account(nonce_account)?;
-            check_nonce_account(&nonce_account, &nonce_authority_pubkey, &recent_blockhash)?;
+            check_nonce_account(&nonce_account, &nonce_authority.pubkey(), &recent_blockhash)?;
         }
         check_account_for_fee(
             rpc_client,
@@ -839,19 +807,19 @@ pub fn process_stake_authorize(
     stake_account_pubkey: &Pubkey,
     authorized_pubkey: &Pubkey,
     stake_authorize: StakeAuthorize,
-    authority: Option<&SigningAuthority>,
+    authority: Option<&dyn KeypairUtil>,
     sign_only: bool,
     signers: &Option<Vec<(Pubkey, Signature)>>,
     blockhash_query: &BlockhashQuery,
     nonce_account: Option<Pubkey>,
-    nonce_authority: Option<&SigningAuthority>,
-    fee_payer: Option<&SigningAuthority>,
+    nonce_authority: Option<&dyn KeypairUtil>,
+    fee_payer: Option<&dyn KeypairUtil>,
 ) -> ProcessResult {
     check_unique_pubkeys(
         (stake_account_pubkey, "stake_account_pubkey".to_string()),
         (authorized_pubkey, "new_authorized_pubkey".to_string()),
     )?;
-    let authority = authority.map(|a| a.keypair()).unwrap_or(&config.keypair);
+    let authority = authority.unwrap_or_else(|| config.keypair.as_ref());
     let (recent_blockhash, fee_calculator) =
         blockhash_query.get_blockhash_fee_calculator(rpc_client)?;
     let ixs = vec![stake_instruction::authorize(
@@ -861,10 +829,8 @@ pub fn process_stake_authorize(
         stake_authorize,      // stake or withdraw
     )];
 
-    let (nonce_authority, nonce_authority_pubkey) = nonce_authority
-        .map(|a| (a.keypair(), a.pubkey()))
-        .unwrap_or((&config.keypair, config.keypair.pubkey()));
-    let fee_payer = fee_payer.map(|f| f.keypair()).unwrap_or(&config.keypair);
+    let nonce_authority = nonce_authority.unwrap_or_else(|| config.keypair.as_ref());
+    let fee_payer = fee_payer.unwrap_or_else(|| config.keypair.as_ref());
     let mut tx = if let Some(nonce_account) = &nonce_account {
         Transaction::new_signed_with_nonce(
             ixs,
@@ -890,7 +856,7 @@ pub fn process_stake_authorize(
     } else {
         if let Some(nonce_account) = &nonce_account {
             let nonce_account = rpc_client.get_account(nonce_account)?;
-            check_nonce_account(&nonce_account, &nonce_authority_pubkey, &recent_blockhash)?;
+            check_nonce_account(&nonce_account, &nonce_authority.pubkey(), &recent_blockhash)?;
         }
         check_account_for_fee(
             rpc_client,
@@ -909,27 +875,23 @@ pub fn process_deactivate_stake_account(
     rpc_client: &RpcClient,
     config: &CliConfig,
     stake_account_pubkey: &Pubkey,
-    stake_authority: Option<&SigningAuthority>,
+    stake_authority: Option<&dyn KeypairUtil>,
     sign_only: bool,
     signers: &Option<Vec<(Pubkey, Signature)>>,
     blockhash_query: &BlockhashQuery,
     nonce_account: Option<Pubkey>,
-    nonce_authority: Option<&SigningAuthority>,
-    fee_payer: Option<&SigningAuthority>,
+    nonce_authority: Option<&dyn KeypairUtil>,
+    fee_payer: Option<&dyn KeypairUtil>,
 ) -> ProcessResult {
     let (recent_blockhash, fee_calculator) =
         blockhash_query.get_blockhash_fee_calculator(rpc_client)?;
-    let stake_authority = stake_authority
-        .map(|a| a.keypair())
-        .unwrap_or(&config.keypair);
+    let stake_authority = stake_authority.unwrap_or_else(|| config.keypair.as_ref());
     let ixs = vec![stake_instruction::deactivate_stake(
         stake_account_pubkey,
         &stake_authority.pubkey(),
     )];
-    let (nonce_authority, nonce_authority_pubkey) = nonce_authority
-        .map(|a| (a.keypair(), a.pubkey()))
-        .unwrap_or((&config.keypair, config.keypair.pubkey()));
-    let fee_payer = fee_payer.map(|f| f.keypair()).unwrap_or(&config.keypair);
+    let nonce_authority = nonce_authority.unwrap_or_else(|| config.keypair.as_ref());
+    let fee_payer = fee_payer.unwrap_or_else(|| config.keypair.as_ref());
     let mut tx = if let Some(nonce_account) = &nonce_account {
         Transaction::new_signed_with_nonce(
             ixs,
@@ -955,7 +917,7 @@ pub fn process_deactivate_stake_account(
     } else {
         if let Some(nonce_account) = &nonce_account {
             let nonce_account = rpc_client.get_account(nonce_account)?;
-            check_nonce_account(&nonce_account, &nonce_authority_pubkey, &recent_blockhash)?;
+            check_nonce_account(&nonce_account, &nonce_authority.pubkey(), &recent_blockhash)?;
         }
         check_account_for_fee(
             rpc_client,
@@ -976,19 +938,17 @@ pub fn process_withdraw_stake(
     stake_account_pubkey: &Pubkey,
     destination_account_pubkey: &Pubkey,
     lamports: u64,
-    withdraw_authority: Option<&SigningAuthority>,
+    withdraw_authority: Option<&dyn KeypairUtil>,
     sign_only: bool,
     signers: Option<&Vec<(Pubkey, Signature)>>,
     blockhash_query: &BlockhashQuery,
     nonce_account: Option<&Pubkey>,
-    nonce_authority: Option<&SigningAuthority>,
-    fee_payer: Option<&SigningAuthority>,
+    nonce_authority: Option<&dyn KeypairUtil>,
+    fee_payer: Option<&dyn KeypairUtil>,
 ) -> ProcessResult {
     let (recent_blockhash, fee_calculator) =
         blockhash_query.get_blockhash_fee_calculator(rpc_client)?;
-    let withdraw_authority = withdraw_authority
-        .map(|a| a.keypair())
-        .unwrap_or(&config.keypair);
+    let withdraw_authority = withdraw_authority.unwrap_or_else(|| config.keypair.as_ref());
 
     let ixs = vec![stake_instruction::withdraw(
         stake_account_pubkey,
@@ -997,10 +957,8 @@ pub fn process_withdraw_stake(
         lamports,
     )];
 
-    let fee_payer = fee_payer.map(|fp| fp.keypair()).unwrap_or(&config.keypair);
-    let (nonce_authority_pubkey, nonce_authority) = nonce_authority
-        .map(|na| (na.pubkey(), na.keypair()))
-        .unwrap_or((config.keypair.pubkey(), &config.keypair));
+    let fee_payer = fee_payer.unwrap_or_else(|| config.keypair.as_ref());
+    let nonce_authority = nonce_authority.unwrap_or_else(|| config.keypair.as_ref());
     let mut tx = if let Some(nonce_account) = &nonce_account {
         Transaction::new_signed_with_nonce(
             ixs,
@@ -1026,7 +984,7 @@ pub fn process_withdraw_stake(
     } else {
         if let Some(nonce_account) = &nonce_account {
             let nonce_account = rpc_client.get_account(nonce_account)?;
-            check_nonce_account(&nonce_account, &nonce_authority_pubkey, &recent_blockhash)?;
+            check_nonce_account(&nonce_account, &nonce_authority.pubkey(), &recent_blockhash)?;
         }
         check_account_for_fee(
             rpc_client,
@@ -1045,29 +1003,27 @@ pub fn process_split_stake(
     rpc_client: &RpcClient,
     config: &CliConfig,
     stake_account_pubkey: &Pubkey,
-    stake_authority: Option<&SigningAuthority>,
+    stake_authority: Option<&dyn KeypairUtil>,
     sign_only: bool,
     signers: &Option<Vec<(Pubkey, Signature)>>,
     blockhash_query: &BlockhashQuery,
     nonce_account: Option<Pubkey>,
-    nonce_authority: Option<&SigningAuthority>,
-    split_stake_account: &Keypair,
+    nonce_authority: Option<&dyn KeypairUtil>,
+    split_stake_account: &dyn KeypairUtil,
     split_stake_account_seed: &Option<String>,
     lamports: u64,
-    fee_payer: Option<&SigningAuthority>,
+    fee_payer: Option<&dyn KeypairUtil>,
 ) -> ProcessResult {
-    let (fee_payer_pubkey, fee_payer) = fee_payer
-        .map(|f| (f.pubkey(), f.keypair()))
-        .unwrap_or((config.keypair.pubkey(), &config.keypair));
+    let fee_payer = fee_payer.unwrap_or_else(|| config.keypair.as_ref());
     check_unique_pubkeys(
-        (&fee_payer_pubkey, "fee-payer keypair".to_string()),
+        (&fee_payer.pubkey(), "fee-payer keypair".to_string()),
         (
             &split_stake_account.pubkey(),
             "split_stake_account".to_string(),
         ),
     )?;
     check_unique_pubkeys(
-        (&fee_payer_pubkey, "fee-payer keypair".to_string()),
+        (&fee_payer.pubkey(), "fee-payer keypair".to_string()),
         (&stake_account_pubkey, "stake_account".to_string()),
     )?;
     check_unique_pubkeys(
@@ -1078,9 +1034,7 @@ pub fn process_split_stake(
         ),
     )?;
 
-    let stake_authority = stake_authority
-        .map(|a| a.keypair())
-        .unwrap_or(&config.keypair);
+    let stake_authority = stake_authority.unwrap_or_else(|| config.keypair.as_ref());
 
     let split_stake_account_address = if let Some(seed) = split_stake_account_seed {
         create_address_with_seed(
@@ -1141,9 +1095,7 @@ pub fn process_split_stake(
         )
     };
 
-    let (nonce_authority, nonce_authority_pubkey) = nonce_authority
-        .map(|a| (a.keypair(), a.pubkey()))
-        .unwrap_or((&config.keypair, config.keypair.pubkey()));
+    let nonce_authority = nonce_authority.unwrap_or_else(|| config.keypair.as_ref());
 
     let mut tx = if let Some(nonce_account) = &nonce_account {
         Transaction::new_signed_with_nonce(
@@ -1175,7 +1127,7 @@ pub fn process_split_stake(
     } else {
         if let Some(nonce_account) = &nonce_account {
             let nonce_account = rpc_client.get_account(nonce_account)?;
-            check_nonce_account(&nonce_account, &nonce_authority_pubkey, &recent_blockhash)?;
+            check_nonce_account(&nonce_account, &nonce_authority.pubkey(), &recent_blockhash)?;
         }
         check_account_for_fee(
             rpc_client,
@@ -1195,17 +1147,17 @@ pub fn process_stake_set_lockup(
     config: &CliConfig,
     stake_account_pubkey: &Pubkey,
     lockup: &mut Lockup,
-    custodian: Option<&SigningAuthority>,
+    custodian: Option<&dyn KeypairUtil>,
     sign_only: bool,
     signers: &Option<Vec<(Pubkey, Signature)>>,
     blockhash_query: &BlockhashQuery,
     nonce_account: Option<Pubkey>,
-    nonce_authority: Option<&SigningAuthority>,
-    fee_payer: Option<&SigningAuthority>,
+    nonce_authority: Option<&dyn KeypairUtil>,
+    fee_payer: Option<&dyn KeypairUtil>,
 ) -> ProcessResult {
     let (recent_blockhash, fee_calculator) =
         blockhash_query.get_blockhash_fee_calculator(rpc_client)?;
-    let custodian = custodian.map(|a| a.keypair()).unwrap_or(&config.keypair);
+    let custodian = custodian.unwrap_or_else(|| config.keypair.as_ref());
     // If new custodian is not explicitly set, default to current custodian
     if lockup.custodian == Pubkey::default() {
         lockup.custodian = custodian.pubkey();
@@ -1215,10 +1167,8 @@ pub fn process_stake_set_lockup(
         lockup,
         &custodian.pubkey(),
     )];
-    let (nonce_authority, nonce_authority_pubkey) = nonce_authority
-        .map(|a| (a.keypair(), a.pubkey()))
-        .unwrap_or((&config.keypair, config.keypair.pubkey()));
-    let fee_payer = fee_payer.map(|f| f.keypair()).unwrap_or(&config.keypair);
+    let nonce_authority = nonce_authority.unwrap_or_else(|| config.keypair.as_ref());
+    let fee_payer = fee_payer.unwrap_or_else(|| config.keypair.as_ref());
     let mut tx = if let Some(nonce_account) = &nonce_account {
         Transaction::new_signed_with_nonce(
             ixs,
@@ -1244,7 +1194,7 @@ pub fn process_stake_set_lockup(
     } else {
         if let Some(nonce_account) = &nonce_account {
             let nonce_account = rpc_client.get_account(nonce_account)?;
-            check_nonce_account(&nonce_account, &nonce_authority_pubkey, &recent_blockhash)?;
+            check_nonce_account(&nonce_account, &nonce_authority.pubkey(), &recent_blockhash)?;
         }
         check_account_for_fee(
             rpc_client,
@@ -1329,7 +1279,7 @@ pub fn process_show_stake_account(
     if stake_account.owner != solana_stake_program::id() {
         return Err(CliError::RpcRequestError(format!(
             "{:?} is not a stake account",
-            stake_account_pubkey
+            stake_account_pubkey,
         ))
         .into());
     }
@@ -1385,22 +1335,19 @@ pub fn process_delegate_stake(
     config: &CliConfig,
     stake_account_pubkey: &Pubkey,
     vote_account_pubkey: &Pubkey,
-    stake_authority: Option<&SigningAuthority>,
+    stake_authority: Option<&dyn KeypairUtil>,
     force: bool,
     sign_only: bool,
-    signers: &Option<Vec<(Pubkey, Signature)>>,
     blockhash_query: &BlockhashQuery,
     nonce_account: Option<Pubkey>,
-    nonce_authority: Option<&SigningAuthority>,
-    fee_payer: Option<&SigningAuthority>,
+    nonce_authority: Option<&dyn KeypairUtil>,
+    fee_payer: Option<&dyn KeypairUtil>,
 ) -> ProcessResult {
     check_unique_pubkeys(
         (&config.keypair.pubkey(), "cli keypair".to_string()),
         (stake_account_pubkey, "stake_account_pubkey".to_string()),
     )?;
-    let stake_authority = stake_authority
-        .map(|a| a.keypair())
-        .unwrap_or(&config.keypair);
+    let stake_authority = stake_authority.unwrap_or_else(|| config.keypair.as_ref());
 
     if !sign_only {
         // Sanity check the vote account to ensure it is attached to a validator that has recently
@@ -1455,10 +1402,8 @@ pub fn process_delegate_stake(
         &stake_authority.pubkey(),
         vote_account_pubkey,
     )];
-    let (nonce_authority, nonce_authority_pubkey) = nonce_authority
-        .map(|a| (a.keypair(), a.pubkey()))
-        .unwrap_or((&config.keypair, config.keypair.pubkey()));
-    let fee_payer = fee_payer.map(|f| f.keypair()).unwrap_or(&config.keypair);
+    let nonce_authority = nonce_authority.unwrap_or_else(|| config.keypair.as_ref());
+    let fee_payer = fee_payer.unwrap_or_else(|| config.keypair.as_ref());
     let mut tx = if let Some(nonce_account) = &nonce_account {
         Transaction::new_signed_with_nonce(
             ixs,
@@ -1484,7 +1429,7 @@ pub fn process_delegate_stake(
     } else {
         if let Some(nonce_account) = &nonce_account {
             let nonce_account = rpc_client.get_account(nonce_account)?;
-            check_nonce_account(&nonce_account, &nonce_authority_pubkey, &recent_blockhash)?;
+            check_nonce_account(&nonce_account, &nonce_authority.pubkey(), &recent_blockhash)?;
         }
         check_account_for_fee(
             rpc_client,
@@ -1505,7 +1450,7 @@ mod tests {
     use solana_sdk::{
         fee_calculator::FeeCalculator,
         hash::Hash,
-        signature::{keypair_from_seed, read_keypair_file, write_keypair, KeypairUtil},
+        signature::{keypair_from_seed, read_keypair_file, write_keypair, KeypairUtil, Presigner},
     };
     use tempfile::NamedTempFile;
 
@@ -1609,8 +1554,9 @@ mod tests {
                 require_keypair: true
             }
         );
-        // Test Authorize Subcommand w/ signer
+        // Test Authorize Subcommand w/ offline feepayer
         let keypair = Keypair::new();
+        let pubkey = keypair.pubkey();
         let sig = keypair.sign_message(&[0u8]);
         let signer = format!("{}={}", keypair.pubkey(), sig);
         let test_authorize = test_commands.clone().get_matches_from(vec![
@@ -1622,6 +1568,8 @@ mod tests {
             &blockhash_string,
             "--signer",
             &signer,
+            "--fee-payer",
+            &pubkey.to_string(),
         ]);
         assert_eq!(
             parse_command(&test_authorize).unwrap(),
@@ -1636,15 +1584,17 @@ mod tests {
                     blockhash_query: BlockhashQuery::FeeCalculator(blockhash),
                     nonce_account: None,
                     nonce_authority: None,
-                    fee_payer: None,
+                    fee_payer: Some(Presigner::new(&pubkey, &sig).into()),
                 },
                 require_keypair: true
             }
         );
-        // Test Authorize Subcommand w/ signers
+        // Test Authorize Subcommand w/ offline fee payer and nonce authority
         let keypair2 = Keypair::new();
+        let pubkey2 = keypair2.pubkey();
         let sig2 = keypair.sign_message(&[0u8]);
         let signer2 = format!("{}={}", keypair2.pubkey(), sig2);
+        let nonce_account = Pubkey::new(&[1u8; 32]);
         let test_authorize = test_commands.clone().get_matches_from(vec![
             "test",
             &subcommand,
@@ -1656,6 +1606,12 @@ mod tests {
             &signer,
             "--signer",
             &signer2,
+            "--fee-payer",
+            &pubkey.to_string(),
+            "--nonce",
+            &nonce_account.to_string(),
+            "--nonce-authority",
+            &pubkey2.to_string(),
         ]);
         assert_eq!(
             parse_command(&test_authorize).unwrap(),
@@ -1669,8 +1625,8 @@ mod tests {
                     signers: Some(vec![(keypair.pubkey(), sig), (keypair2.pubkey(), sig2),]),
                     blockhash_query: BlockhashQuery::FeeCalculator(blockhash),
                     nonce_account: None,
-                    nonce_authority: None,
-                    fee_payer: None,
+                    nonce_authority: Some(Presigner::new(&pubkey2, &sig2).into()),
+                    fee_payer: Some(Presigner::new(&pubkey, &sig).into()),
                 },
                 require_keypair: true
             }
@@ -1798,7 +1754,7 @@ mod tests {
                     blockhash_query: BlockhashQuery::FeeCalculator(blockhash),
                     nonce_account: None,
                     nonce_authority: None,
-                    fee_payer: Some(fee_payer_pubkey.into()),
+                    fee_payer: Some(Presigner::new(&fee_payer_pubkey, &sig).into()),
                 },
                 require_keypair: true
             }
@@ -1952,9 +1908,9 @@ mod tests {
                     signers: Some(vec![(offline_pubkey, offline_sig)]),
                     blockhash_query: BlockhashQuery::FeeCalculator(nonce_hash),
                     nonce_account: Some(nonce_account),
-                    nonce_authority: Some(offline_pubkey.into()),
-                    fee_payer: Some(offline_pubkey.into()),
-                    from: Some(offline_pubkey.into()),
+                    nonce_authority: Some(Presigner::new(&offline_pubkey, &offline_sig).into()),
+                    fee_payer: Some(Presigner::new(&offline_pubkey, &offline_sig).into()),
+                    from: Some(Presigner::new(&offline_pubkey, &offline_sig).into()),
                 },
                 require_keypair: false,
             }
@@ -2107,7 +2063,7 @@ mod tests {
             }
         );
 
-        // Test Delegate Subcommand w/ signer
+        // Test Delegate Subcommand w/ absent fee payer
         let key1 = Pubkey::new_rand();
         let sig1 = Keypair::new().sign_message(&[0u8]);
         let signer1 = format!("{}={}", key1, sig1);
@@ -2120,6 +2076,8 @@ mod tests {
             &blockhash_string,
             "--signer",
             &signer1,
+            "--fee-payer",
+            &key1.to_string(),
         ]);
         assert_eq!(
             parse_command(&test_delegate_stake).unwrap(),
@@ -2134,13 +2092,13 @@ mod tests {
                     blockhash_query: BlockhashQuery::FeeCalculator(blockhash),
                     nonce_account: None,
                     nonce_authority: None,
-                    fee_payer: None,
+                    fee_payer: Some(Presigner::new(&key1, &sig1).into()),
                 },
                 require_keypair: false
             }
         );
 
-        // Test Delegate Subcommand w/ signers
+        // Test Delegate Subcommand w/ absent fee payer and absent nonce authority
         let key2 = Pubkey::new_rand();
         let sig2 = Keypair::new().sign_message(&[0u8]);
         let signer2 = format!("{}={}", key2, sig2);
@@ -2155,6 +2113,12 @@ mod tests {
             &signer1,
             "--signer",
             &signer2,
+            "--fee-payer",
+            &key1.to_string(),
+            "--nonce",
+            &nonce_account.to_string(),
+            "--nonce_auhtority",
+            &key2.to_string(),
         ]);
         assert_eq!(
             parse_command(&test_delegate_stake).unwrap(),
@@ -2165,17 +2129,16 @@ mod tests {
                     stake_authority: None,
                     force: false,
                     sign_only: false,
-                    signers: Some(vec![(key1, sig1), (key2, sig2)]),
                     blockhash_query: BlockhashQuery::FeeCalculator(blockhash),
-                    nonce_account: None,
-                    nonce_authority: None,
-                    fee_payer: None,
+                    nonce_account: Some(nonce_account),
+                    nonce_authority: Some(Presigner::new(&key2, &sig2).into()),
+                    fee_payer: Some(Presigner::new(&key1, &sig1).into()),
                 },
                 require_keypair: false
             }
         );
 
-        // Test Delegate Subcommand w/ fee-payer
+        // Test Delegate Subcommand w/ present fee-payer
         let (fee_payer_keypair_file, mut fee_payer_tmp_file) = make_tmp_file();
         let fee_payer_keypair = Keypair::new();
         write_keypair(&fee_payer_keypair, fee_payer_tmp_file.as_file_mut()).unwrap();
@@ -2341,8 +2304,8 @@ mod tests {
                     signers: Some(vec![(offline_pubkey, offline_sig)]),
                     blockhash_query: BlockhashQuery::FeeCalculator(nonce_hash),
                     nonce_account: Some(nonce_account),
-                    nonce_authority: Some(offline_pubkey.into()),
-                    fee_payer: Some(offline_pubkey.into()),
+                    nonce_authority: Some(Presigner::new(&offline_pubkey, &offline_sig).into()),
+                    fee_payer: Some(Presigner::new(&offline_pubkey, &offline_sig).into()),
                 },
                 require_keypair: false,
             }
@@ -2452,7 +2415,7 @@ mod tests {
             }
         );
 
-        // Test Deactivate Subcommand w/ signers
+        // Test Deactivate Subcommand w/ absent fee payer
         let key1 = Pubkey::new_rand();
         let sig1 = Keypair::new().sign_message(&[0u8]);
         let signer1 = format!("{}={}", key1, sig1);
@@ -2464,6 +2427,8 @@ mod tests {
             &blockhash_string,
             "--signer",
             &signer1,
+            "--fee-payer",
+            &key1.to_string(),
         ]);
         assert_eq!(
             parse_command(&test_deactivate_stake).unwrap(),
@@ -2476,13 +2441,13 @@ mod tests {
                     blockhash_query: BlockhashQuery::FeeCalculator(blockhash),
                     nonce_account: None,
                     nonce_authority: None,
-                    fee_payer: None,
+                    fee_payer: Some(Presigner::new(&key1, &sig1).into()),
                 },
                 require_keypair: false
             }
         );
 
-        // Test Deactivate Subcommand w/ signers
+        // Test Deactivate Subcommand w/ absent fee payer and nonce authority
         let key2 = Pubkey::new_rand();
         let sig2 = Keypair::new().sign_message(&[0u8]);
         let signer2 = format!("{}={}", key2, sig2);
@@ -2496,6 +2461,12 @@ mod tests {
             &signer1,
             "--signer",
             &signer2,
+            "--fee-payer",
+            &key1.to_string(),
+            "--nonce",
+            &nonce_account.to_string(),
+            "--nonce-account",
+            &key2.to_string(),
         ]);
         assert_eq!(
             parse_command(&test_deactivate_stake).unwrap(),
@@ -2507,8 +2478,8 @@ mod tests {
                     signers: Some(vec![(key1, sig1), (key2, sig2)]),
                     blockhash_query: BlockhashQuery::FeeCalculator(blockhash),
                     nonce_account: None,
-                    nonce_authority: None,
-                    fee_payer: None,
+                    nonce_authority: Some(Presigner::new(&key2, &sig2).into()),
+                    fee_payer: Some(Presigner::new(&key1, &sig1).into()),
                 },
                 require_keypair: false
             }
@@ -2649,7 +2620,7 @@ mod tests {
             CliCommandInfo {
                 command: CliCommand::SplitStake {
                     stake_account_pubkey: stake_account_keypair.pubkey(),
-                    stake_authority: Some(stake_auth_pubkey.into()),
+                    stake_authority: Some(Presigner::new(&stake_auth_pubkey, &stake_sig).into()),
                     sign_only: false,
                     signers: Some(vec![
                         (nonce_auth_pubkey, nonce_sig),
@@ -2657,13 +2628,13 @@ mod tests {
                     ]),
                     blockhash_query: BlockhashQuery::FeeCalculator(nonce_hash),
                     nonce_account: Some(nonce_account.into()),
-                    nonce_authority: Some(nonce_auth_pubkey.into()),
+                    nonce_authority: Some(Presigner::new(&nonce_auth_pubkey, &nonce_sig).into()),
                     split_stake_account: read_keypair_file(&split_stake_account_keypair_file)
                         .unwrap()
                         .into(),
                     seed: None,
                     lamports: 50_000_000_000,
-                    fee_payer: Some(nonce_auth_pubkey.into()),
+                    fee_payer: Some(Presigner::new(&nonce_auth_pubkey, &nonce_sig).into()),
                 },
                 require_keypair: false,
             }

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -441,7 +441,6 @@ pub fn parse_stake_create_account(matches: &ArgMatches<'_>) -> Result<CliCommand
             },
             lamports,
             sign_only,
-            signers,
             blockhash_query,
             nonce_account,
             nonce_authority,
@@ -472,7 +471,6 @@ pub fn parse_stake_delegate_stake(matches: &ArgMatches<'_>) -> Result<CliCommand
             stake_authority,
             force,
             sign_only,
-            signers,
             blockhash_query,
             nonce_account,
             nonce_authority,
@@ -493,7 +491,6 @@ pub fn parse_stake_authorize(
         StakeAuthorize::Withdrawer => WITHDRAW_AUTHORITY_ARG.name,
     };
     let sign_only = matches.is_present(SIGN_ONLY_ARG.name);
-    let signers = pubkeys_sigs_of(&matches, SIGNER_ARG.name);
     let authority = signer_of(authority_flag, matches)?;
     let blockhash_query = BlockhashQuery::new_from_matches(matches);
     let nonce_account = pubkey_of(&matches, NONCE_ARG.name);
@@ -507,7 +504,6 @@ pub fn parse_stake_authorize(
             stake_authorize,
             authority,
             sign_only,
-            signers,
             blockhash_query,
             nonce_account,
             nonce_authority,
@@ -537,7 +533,6 @@ pub fn parse_split_stake(matches: &ArgMatches<'_>) -> Result<CliCommandInfo, Cli
             stake_account_pubkey,
             stake_authority,
             sign_only,
-            signers,
             blockhash_query,
             nonce_account,
             nonce_authority,
@@ -566,7 +561,6 @@ pub fn parse_stake_deactivate_stake(matches: &ArgMatches<'_>) -> Result<CliComma
             stake_account_pubkey,
             stake_authority,
             sign_only,
-            signers,
             blockhash_query,
             nonce_account,
             nonce_authority,
@@ -596,7 +590,6 @@ pub fn parse_stake_withdraw_stake(matches: &ArgMatches<'_>) -> Result<CliCommand
             lamports,
             withdraw_authority,
             sign_only,
-            signers,
             blockhash_query,
             nonce_account,
             nonce_authority,
@@ -632,7 +625,6 @@ pub fn parse_stake_set_lockup(matches: &ArgMatches<'_>) -> Result<CliCommandInfo
             },
             custodian,
             sign_only,
-            signers,
             blockhash_query,
             nonce_account,
             nonce_authority,
@@ -673,7 +665,6 @@ pub fn process_create_stake_account(
     lockup: &Lockup,
     lamports: u64,
     sign_only: bool,
-    signers: Option<&Vec<(Pubkey, Signature)>>,
     blockhash_query: &BlockhashQuery,
     nonce_account: Option<&Pubkey>,
     nonce_authority: Option<&dyn KeypairUtil>,
@@ -779,9 +770,6 @@ pub fn process_create_stake_account(
             recent_blockhash,
         )
     };
-    if let Some(signers) = signers {
-        replace_signatures(&mut tx, &signers)?;
-    }
     if sign_only {
         return_signers(&tx)
     } else {
@@ -809,7 +797,6 @@ pub fn process_stake_authorize(
     stake_authorize: StakeAuthorize,
     authority: Option<&dyn KeypairUtil>,
     sign_only: bool,
-    signers: &Option<Vec<(Pubkey, Signature)>>,
     blockhash_query: &BlockhashQuery,
     nonce_account: Option<Pubkey>,
     nonce_authority: Option<&dyn KeypairUtil>,
@@ -848,9 +835,6 @@ pub fn process_stake_authorize(
             recent_blockhash,
         )
     };
-    if let Some(signers) = signers {
-        replace_signatures(&mut tx, &signers)?;
-    }
     if sign_only {
         return_signers(&tx)
     } else {
@@ -877,7 +861,6 @@ pub fn process_deactivate_stake_account(
     stake_account_pubkey: &Pubkey,
     stake_authority: Option<&dyn KeypairUtil>,
     sign_only: bool,
-    signers: &Option<Vec<(Pubkey, Signature)>>,
     blockhash_query: &BlockhashQuery,
     nonce_account: Option<Pubkey>,
     nonce_authority: Option<&dyn KeypairUtil>,
@@ -909,9 +892,6 @@ pub fn process_deactivate_stake_account(
             recent_blockhash,
         )
     };
-    if let Some(signers) = signers {
-        replace_signatures(&mut tx, &signers)?;
-    }
     if sign_only {
         return_signers(&tx)
     } else {
@@ -940,7 +920,6 @@ pub fn process_withdraw_stake(
     lamports: u64,
     withdraw_authority: Option<&dyn KeypairUtil>,
     sign_only: bool,
-    signers: Option<&Vec<(Pubkey, Signature)>>,
     blockhash_query: &BlockhashQuery,
     nonce_account: Option<&Pubkey>,
     nonce_authority: Option<&dyn KeypairUtil>,
@@ -976,9 +955,6 @@ pub fn process_withdraw_stake(
             recent_blockhash,
         )
     };
-    if let Some(signers) = signers {
-        replace_signatures(&mut tx, &signers)?;
-    }
     if sign_only {
         return_signers(&tx)
     } else {
@@ -1005,7 +981,6 @@ pub fn process_split_stake(
     stake_account_pubkey: &Pubkey,
     stake_authority: Option<&dyn KeypairUtil>,
     sign_only: bool,
-    signers: &Option<Vec<(Pubkey, Signature)>>,
     blockhash_query: &BlockhashQuery,
     nonce_account: Option<Pubkey>,
     nonce_authority: Option<&dyn KeypairUtil>,
@@ -1119,9 +1094,6 @@ pub fn process_split_stake(
             recent_blockhash,
         )
     };
-    if let Some(signers) = signers {
-        replace_signatures(&mut tx, &signers)?;
-    }
     if sign_only {
         return_signers(&tx)
     } else {
@@ -1149,7 +1121,6 @@ pub fn process_stake_set_lockup(
     lockup: &mut Lockup,
     custodian: Option<&dyn KeypairUtil>,
     sign_only: bool,
-    signers: &Option<Vec<(Pubkey, Signature)>>,
     blockhash_query: &BlockhashQuery,
     nonce_account: Option<Pubkey>,
     nonce_authority: Option<&dyn KeypairUtil>,
@@ -1186,9 +1157,6 @@ pub fn process_stake_set_lockup(
             recent_blockhash,
         )
     };
-    if let Some(signers) = signers {
-        replace_signatures(&mut tx, &signers)?;
-    }
     if sign_only {
         return_signers(&tx)
     } else {
@@ -1421,9 +1389,6 @@ pub fn process_delegate_stake(
             recent_blockhash,
         )
     };
-    if let Some(signers) = signers {
-        replace_signatures(&mut tx, &signers)?;
-    }
     if sign_only {
         return_signers(&tx)
     } else {
@@ -1488,7 +1453,6 @@ mod tests {
                     stake_authorize,
                     authority: None,
                     sign_only: false,
-                    signers: None,
                     blockhash_query: BlockhashQuery::default(),
                     nonce_account: None,
                     nonce_authority: None,
@@ -1515,7 +1479,6 @@ mod tests {
                     stake_authorize,
                     authority: Some(read_keypair_file(&authority_keypair_file).unwrap().into()),
                     sign_only: false,
-                    signers: None,
                     blockhash_query: BlockhashQuery::default(),
                     nonce_account: None,
                     nonce_authority: None,
@@ -1545,7 +1508,6 @@ mod tests {
                     stake_authorize,
                     authority: None,
                     sign_only: true,
-                    signers: None,
                     blockhash_query: BlockhashQuery::None(blockhash, FeeCalculator::default()),
                     nonce_account: None,
                     nonce_authority: None,
@@ -1580,7 +1542,6 @@ mod tests {
                     stake_authorize,
                     authority: None,
                     sign_only: false,
-                    signers: Some(vec![(keypair.pubkey(), sig)]),
                     blockhash_query: BlockhashQuery::FeeCalculator(blockhash),
                     nonce_account: None,
                     nonce_authority: None,
@@ -1622,7 +1583,6 @@ mod tests {
                     stake_authorize,
                     authority: None,
                     sign_only: false,
-                    signers: Some(vec![(keypair.pubkey(), sig), (keypair2.pubkey(), sig2),]),
                     blockhash_query: BlockhashQuery::FeeCalculator(blockhash),
                     nonce_account: None,
                     nonce_authority: Some(Presigner::new(&pubkey2, &sig2).into()),
@@ -1649,7 +1609,6 @@ mod tests {
                     stake_authorize,
                     authority: None,
                     sign_only: false,
-                    signers: None,
                     blockhash_query: BlockhashQuery::FeeCalculator(blockhash),
                     nonce_account: None,
                     nonce_authority: None,
@@ -1685,7 +1644,6 @@ mod tests {
                     stake_authorize,
                     authority: None,
                     sign_only: false,
-                    signers: None,
                     blockhash_query: BlockhashQuery::FeeCalculator(blockhash),
                     nonce_account: Some(nonce_account_pubkey),
                     nonce_authority: Some(nonce_authority_keypair.into()),
@@ -1717,7 +1675,6 @@ mod tests {
                     stake_authorize,
                     authority: None,
                     sign_only: false,
-                    signers: None,
                     blockhash_query: BlockhashQuery::All,
                     nonce_account: None,
                     nonce_authority: None,
@@ -1750,7 +1707,6 @@ mod tests {
                     stake_authorize,
                     authority: None,
                     sign_only: false,
-                    signers: Some(vec![(fee_payer_pubkey, sig)]),
                     blockhash_query: BlockhashQuery::FeeCalculator(blockhash),
                     nonce_account: None,
                     nonce_authority: None,
@@ -1819,7 +1775,6 @@ mod tests {
                     },
                     lamports: 50_000_000_000,
                     sign_only: false,
-                    signers: None,
                     blockhash_query: BlockhashQuery::All,
                     nonce_account: None,
                     nonce_authority: None,
@@ -1854,7 +1809,6 @@ mod tests {
                     lockup: Lockup::default(),
                     lamports: 50_000_000_000,
                     sign_only: false,
-                    signers: None,
                     blockhash_query: BlockhashQuery::All,
                     nonce_account: None,
                     nonce_authority: None,
@@ -1905,7 +1859,6 @@ mod tests {
                     lockup: Lockup::default(),
                     lamports: 50_000_000_000,
                     sign_only: false,
-                    signers: Some(vec![(offline_pubkey, offline_sig)]),
                     blockhash_query: BlockhashQuery::FeeCalculator(nonce_hash),
                     nonce_account: Some(nonce_account),
                     nonce_authority: Some(Presigner::new(&offline_pubkey, &offline_sig).into()),
@@ -1934,7 +1887,6 @@ mod tests {
                     stake_authority: None,
                     force: false,
                     sign_only: false,
-                    signers: None,
                     blockhash_query: BlockhashQuery::default(),
                     nonce_account: None,
                     nonce_authority: None,
@@ -1968,7 +1920,6 @@ mod tests {
                     ),
                     force: false,
                     sign_only: false,
-                    signers: None,
                     blockhash_query: BlockhashQuery::default(),
                     nonce_account: None,
                     nonce_authority: None,
@@ -1995,7 +1946,6 @@ mod tests {
                     stake_authority: None,
                     force: true,
                     sign_only: false,
-                    signers: None,
                     blockhash_query: BlockhashQuery::default(),
                     nonce_account: None,
                     nonce_authority: None,
@@ -2025,7 +1975,6 @@ mod tests {
                     stake_authority: None,
                     force: false,
                     sign_only: false,
-                    signers: None,
                     blockhash_query: BlockhashQuery::FeeCalculator(blockhash),
                     nonce_account: None,
                     nonce_authority: None,
@@ -2053,7 +2002,6 @@ mod tests {
                     stake_authority: None,
                     force: false,
                     sign_only: true,
-                    signers: None,
                     blockhash_query: BlockhashQuery::None(blockhash, FeeCalculator::default()),
                     nonce_account: None,
                     nonce_authority: None,
@@ -2088,7 +2036,6 @@ mod tests {
                     stake_authority: None,
                     force: false,
                     sign_only: false,
-                    signers: Some(vec![(key1, sig1)]),
                     blockhash_query: BlockhashQuery::FeeCalculator(blockhash),
                     nonce_account: None,
                     nonce_authority: None,
@@ -2161,7 +2108,6 @@ mod tests {
                     stake_authority: None,
                     force: false,
                     sign_only: false,
-                    signers: None,
                     blockhash_query: BlockhashQuery::All,
                     nonce_account: None,
                     nonce_authority: None,
@@ -2223,7 +2169,6 @@ mod tests {
                     lamports: 42_000_000_000,
                     withdraw_authority: None,
                     sign_only: false,
-                    signers: None,
                     blockhash_query: BlockhashQuery::All,
                     nonce_account: None,
                     nonce_authority: None,
@@ -2257,7 +2202,6 @@ mod tests {
                             .into()
                     ),
                     sign_only: false,
-                    signers: None,
                     blockhash_query: BlockhashQuery::All,
                     nonce_account: None,
                     nonce_authority: None,
@@ -2301,7 +2245,6 @@ mod tests {
                             .into()
                     ),
                     sign_only: false,
-                    signers: Some(vec![(offline_pubkey, offline_sig)]),
                     blockhash_query: BlockhashQuery::FeeCalculator(nonce_hash),
                     nonce_account: Some(nonce_account),
                     nonce_authority: Some(Presigner::new(&offline_pubkey, &offline_sig).into()),
@@ -2324,7 +2267,6 @@ mod tests {
                     stake_account_pubkey,
                     stake_authority: None,
                     sign_only: false,
-                    signers: None,
                     blockhash_query: BlockhashQuery::default(),
                     nonce_account: None,
                     nonce_authority: None,
@@ -2353,7 +2295,6 @@ mod tests {
                             .into()
                     ),
                     sign_only: false,
-                    signers: None,
                     blockhash_query: BlockhashQuery::default(),
                     nonce_account: None,
                     nonce_authority: None,
@@ -2380,7 +2321,6 @@ mod tests {
                     stake_account_pubkey,
                     stake_authority: None,
                     sign_only: false,
-                    signers: None,
                     blockhash_query: BlockhashQuery::FeeCalculator(blockhash),
                     nonce_account: None,
                     nonce_authority: None,
@@ -2405,7 +2345,6 @@ mod tests {
                     stake_account_pubkey,
                     stake_authority: None,
                     sign_only: true,
-                    signers: None,
                     blockhash_query: BlockhashQuery::None(blockhash, FeeCalculator::default()),
                     nonce_account: None,
                     nonce_authority: None,
@@ -2437,7 +2376,6 @@ mod tests {
                     stake_account_pubkey,
                     stake_authority: None,
                     sign_only: false,
-                    signers: Some(vec![(key1, sig1)]),
                     blockhash_query: BlockhashQuery::FeeCalculator(blockhash),
                     nonce_account: None,
                     nonce_authority: None,
@@ -2475,7 +2413,6 @@ mod tests {
                     stake_account_pubkey,
                     stake_authority: None,
                     sign_only: false,
-                    signers: Some(vec![(key1, sig1), (key2, sig2)]),
                     blockhash_query: BlockhashQuery::FeeCalculator(blockhash),
                     nonce_account: None,
                     nonce_authority: Some(Presigner::new(&key2, &sig2).into()),
@@ -2500,7 +2437,6 @@ mod tests {
                     stake_account_pubkey,
                     stake_authority: None,
                     sign_only: false,
-                    signers: None,
                     blockhash_query: BlockhashQuery::All,
                     nonce_account: None,
                     nonce_authority: None,
@@ -2563,7 +2499,6 @@ mod tests {
                     stake_account_pubkey: stake_account_keypair.pubkey(),
                     stake_authority: None,
                     sign_only: false,
-                    signers: None,
                     blockhash_query: BlockhashQuery::default(),
                     nonce_account: None,
                     nonce_authority: None,
@@ -2622,10 +2557,6 @@ mod tests {
                     stake_account_pubkey: stake_account_keypair.pubkey(),
                     stake_authority: Some(Presigner::new(&stake_auth_pubkey, &stake_sig).into()),
                     sign_only: false,
-                    signers: Some(vec![
-                        (nonce_auth_pubkey, nonce_sig),
-                        (stake_auth_pubkey, stake_sig)
-                    ]),
                     blockhash_query: BlockhashQuery::FeeCalculator(nonce_hash),
                     nonce_account: Some(nonce_account.into()),
                     nonce_authority: Some(Presigner::new(&nonce_auth_pubkey, &nonce_sig).into()),

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -13,6 +13,7 @@ use solana_clap_utils::{input_parsers::*, input_validators::*, ArgConstant};
 use solana_client::rpc_client::RpcClient;
 use solana_sdk::{
     account_utils::StateMut,
+    message::Message,
     pubkey::Pubkey,
     signature::KeypairUtil,
     system_instruction::{create_address_with_seed, SystemError},
@@ -754,21 +755,20 @@ pub fn process_create_stake_account(
 
     let mut tx = if let Some(nonce_account) = &nonce_account {
         tx_signers.push(nonce_authority);
-        Transaction::new_signed_with_nonce(
+        let message = Message::new_with_nonce(
             ixs,
             Some(&fee_payer.pubkey()),
-            &tx_signers,
             nonce_account,
             &nonce_authority.pubkey(),
-            recent_blockhash,
-        )
+        );
+        let mut tx = Transaction::new_unsigned(message);
+        tx.sign_dynamic_signers(&tx_signers, recent_blockhash);
+        tx
     } else {
-        Transaction::new_signed_with_payer(
-            ixs,
-            Some(&fee_payer.pubkey()),
-            &tx_signers,
-            recent_blockhash,
-        )
+        let message = Message::new_with_payer(ixs, Some(&fee_payer.pubkey()));
+        let mut tx = Transaction::new_unsigned(message);
+        tx.sign_dynamic_signers(&tx_signers, recent_blockhash);
+        tx
     };
     if sign_only {
         return_signers(&tx)
@@ -819,21 +819,20 @@ pub fn process_stake_authorize(
     let nonce_authority = nonce_authority.unwrap_or_else(|| config.keypair.as_ref());
     let fee_payer = fee_payer.unwrap_or_else(|| config.keypair.as_ref());
     let mut tx = if let Some(nonce_account) = &nonce_account {
-        Transaction::new_signed_with_nonce(
+        let message = Message::new_with_nonce(
             ixs,
             Some(&fee_payer.pubkey()),
-            &[fee_payer, nonce_authority, authority],
             nonce_account,
             &nonce_authority.pubkey(),
-            recent_blockhash,
-        )
+        );
+        let mut tx = Transaction::new_unsigned(message);
+        tx.sign_dynamic_signers(&[fee_payer, nonce_authority, authority], recent_blockhash);
+        tx
     } else {
-        Transaction::new_signed_with_payer(
-            ixs,
-            Some(&fee_payer.pubkey()),
-            &[fee_payer, authority],
-            recent_blockhash,
-        )
+        let message = Message::new_with_payer(ixs, Some(&fee_payer.pubkey()));
+        let mut tx = Transaction::new_unsigned(message);
+        tx.sign_dynamic_signers(&[fee_payer, authority], recent_blockhash);
+        tx
     };
     if sign_only {
         return_signers(&tx)
@@ -876,21 +875,23 @@ pub fn process_deactivate_stake_account(
     let nonce_authority = nonce_authority.unwrap_or_else(|| config.keypair.as_ref());
     let fee_payer = fee_payer.unwrap_or_else(|| config.keypair.as_ref());
     let mut tx = if let Some(nonce_account) = &nonce_account {
-        Transaction::new_signed_with_nonce(
+        let message = Message::new_with_nonce(
             ixs,
             Some(&fee_payer.pubkey()),
-            &[fee_payer, nonce_authority, stake_authority],
             nonce_account,
             &nonce_authority.pubkey(),
+        );
+        let mut tx = Transaction::new_unsigned(message);
+        tx.sign_dynamic_signers(
+            &[fee_payer, nonce_authority, stake_authority],
             recent_blockhash,
-        )
+        );
+        tx
     } else {
-        Transaction::new_signed_with_payer(
-            ixs,
-            Some(&fee_payer.pubkey()),
-            &[fee_payer, stake_authority],
-            recent_blockhash,
-        )
+        let message = Message::new_with_payer(ixs, Some(&fee_payer.pubkey()));
+        let mut tx = Transaction::new_unsigned(message);
+        tx.sign_dynamic_signers(&[fee_payer, stake_authority], recent_blockhash);
+        tx
     };
     if sign_only {
         return_signers(&tx)
@@ -939,21 +940,23 @@ pub fn process_withdraw_stake(
     let fee_payer = fee_payer.unwrap_or_else(|| config.keypair.as_ref());
     let nonce_authority = nonce_authority.unwrap_or_else(|| config.keypair.as_ref());
     let mut tx = if let Some(nonce_account) = &nonce_account {
-        Transaction::new_signed_with_nonce(
+        let message = Message::new_with_nonce(
             ixs,
             Some(&fee_payer.pubkey()),
-            &[fee_payer, withdraw_authority, nonce_authority],
             nonce_account,
             &nonce_authority.pubkey(),
+        );
+        let mut tx = Transaction::new_unsigned(message);
+        tx.sign_dynamic_signers(
+            &[fee_payer, withdraw_authority, nonce_authority],
             recent_blockhash,
-        )
+        );
+        tx
     } else {
-        Transaction::new_signed_with_payer(
-            ixs,
-            Some(&fee_payer.pubkey()),
-            &[fee_payer, withdraw_authority],
-            recent_blockhash,
-        )
+        let message = Message::new_with_payer(ixs, Some(&fee_payer.pubkey()));
+        let mut tx = Transaction::new_unsigned(message);
+        tx.sign_dynamic_signers(&[fee_payer, withdraw_authority], recent_blockhash);
+        tx
     };
     if sign_only {
         return_signers(&tx)
@@ -1073,26 +1076,31 @@ pub fn process_split_stake(
     let nonce_authority = nonce_authority.unwrap_or_else(|| config.keypair.as_ref());
 
     let mut tx = if let Some(nonce_account) = &nonce_account {
-        Transaction::new_signed_with_nonce(
+        let message = Message::new_with_nonce(
             ixs,
             Some(&fee_payer.pubkey()),
+            nonce_account,
+            &nonce_authority.pubkey(),
+        );
+        let mut tx = Transaction::new_unsigned(message);
+        tx.sign_dynamic_signers(
             &[
                 fee_payer,
                 nonce_authority,
                 stake_authority,
                 split_stake_account,
             ],
-            nonce_account,
-            &nonce_authority.pubkey(),
             recent_blockhash,
-        )
+        );
+        tx
     } else {
-        Transaction::new_signed_with_payer(
-            ixs,
-            Some(&fee_payer.pubkey()),
+        let message = Message::new_with_payer(ixs, Some(&fee_payer.pubkey()));
+        let mut tx = Transaction::new_unsigned(message);
+        tx.sign_dynamic_signers(
             &[fee_payer, stake_authority, split_stake_account],
             recent_blockhash,
-        )
+        );
+        tx
     };
     if sign_only {
         return_signers(&tx)
@@ -1141,21 +1149,20 @@ pub fn process_stake_set_lockup(
     let nonce_authority = nonce_authority.unwrap_or_else(|| config.keypair.as_ref());
     let fee_payer = fee_payer.unwrap_or_else(|| config.keypair.as_ref());
     let mut tx = if let Some(nonce_account) = &nonce_account {
-        Transaction::new_signed_with_nonce(
+        let message = Message::new_with_nonce(
             ixs,
             Some(&fee_payer.pubkey()),
-            &[fee_payer, nonce_authority, custodian],
             nonce_account,
             &nonce_authority.pubkey(),
-            recent_blockhash,
-        )
+        );
+        let mut tx = Transaction::new_unsigned(message);
+        tx.sign_dynamic_signers(&[fee_payer, nonce_authority, custodian], recent_blockhash);
+        tx
     } else {
-        Transaction::new_signed_with_payer(
-            ixs,
-            Some(&fee_payer.pubkey()),
-            &[fee_payer, custodian],
-            recent_blockhash,
-        )
+        let message = Message::new_with_payer(ixs, Some(&fee_payer.pubkey()));
+        let mut tx = Transaction::new_unsigned(message);
+        tx.sign_dynamic_signers(&[fee_payer, custodian], recent_blockhash);
+        tx
     };
     if sign_only {
         return_signers(&tx)
@@ -1373,21 +1380,23 @@ pub fn process_delegate_stake(
     let nonce_authority = nonce_authority.unwrap_or_else(|| config.keypair.as_ref());
     let fee_payer = fee_payer.unwrap_or_else(|| config.keypair.as_ref());
     let mut tx = if let Some(nonce_account) = &nonce_account {
-        Transaction::new_signed_with_nonce(
+        let message = Message::new_with_nonce(
             ixs,
             Some(&fee_payer.pubkey()),
-            &[fee_payer, nonce_authority, stake_authority],
             nonce_account,
             &nonce_authority.pubkey(),
+        );
+        let mut tx = Transaction::new_unsigned(message);
+        tx.sign_dynamic_signers(
+            &[fee_payer, nonce_authority, stake_authority],
             recent_blockhash,
-        )
+        );
+        tx
     } else {
-        Transaction::new_signed_with_payer(
-            ixs,
-            Some(&fee_payer.pubkey()),
-            &[fee_payer, stake_authority],
-            recent_blockhash,
-        )
+        let message = Message::new_with_payer(ixs, Some(&fee_payer.pubkey()));
+        let mut tx = Transaction::new_unsigned(message);
+        tx.sign_dynamic_signers(&[fee_payer, stake_authority], recent_blockhash);
+        tx
     };
     if sign_only {
         return_signers(&tx)

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 use clap::{App, Arg, ArgMatches, SubCommand};
 use console::style;
-use solana_clap_utils::{input_parsers::*, input_validators::*, ArgConstant};
+use solana_clap_utils::{input_parsers::*, input_validators::*, offline::*, ArgConstant};
 use solana_client::rpc_client::RpcClient;
 use solana_sdk::{
     account_utils::StateMut,

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -45,8 +45,8 @@ fn stake_authority_arg<'a, 'b>() -> Arg<'a, 'b> {
     Arg::with_name(STAKE_AUTHORITY_ARG.name)
         .long(STAKE_AUTHORITY_ARG.long)
         .takes_value(true)
-        .value_name("KEYPAIR or PUBKEY")
-        .validator(is_pubkey_or_keypair_or_ask_keyword)
+        .value_name("KEYPAIR or PUBKEY or REMOTE WALLET PATH")
+        .validator(is_valid_signer)
         .help(STAKE_AUTHORITY_ARG.help)
 }
 
@@ -54,8 +54,8 @@ fn withdraw_authority_arg<'a, 'b>() -> Arg<'a, 'b> {
     Arg::with_name(WITHDRAW_AUTHORITY_ARG.name)
         .long(WITHDRAW_AUTHORITY_ARG.long)
         .takes_value(true)
-        .value_name("KEYPAIR or PUBKEY")
-        .validator(is_pubkey_or_keypair_or_ask_keyword)
+        .value_name("KEYPAIR or PUBKEY or REMOTE WALLET PATH")
+        .validator(is_valid_signer)
         .help(WITHDRAW_AUTHORITY_ARG.help)
 }
 
@@ -74,7 +74,7 @@ impl StakeSubCommands for App<'_, '_> {
                         .value_name("STAKE ACCOUNT")
                         .takes_value(true)
                         .required(true)
-                        .validator(is_pubkey_or_keypair_or_ask_keyword)
+                        .validator(is_valid_signer)
                         .help("Signing authority of the stake address to fund")
                 )
                 .arg(
@@ -136,8 +136,8 @@ impl StakeSubCommands for App<'_, '_> {
                     Arg::with_name("from")
                         .long("from")
                         .takes_value(true)
-                        .value_name("KEYPAIR or PUBKEY")
-                        .validator(is_pubkey_or_keypair_or_ask_keyword)
+                        .value_name("KEYPAIR or PUBKEY or REMOTE WALLET PATH")
+                        .validator(is_valid_signer)
                         .help("Source account of funds (if different from client local account)"),
                 )
                 .offline_args()
@@ -367,8 +367,8 @@ impl StakeSubCommands for App<'_, '_> {
                     Arg::with_name("custodian")
                         .long("custodian")
                         .takes_value(true)
-                        .value_name("KEYPAIR or PUBKEY")
-                        .validator(is_pubkey_or_keypair_or_ask_keyword)
+                        .value_name("KEYPAIR or PUBKEY or REMOTE WALLET PATH")
+                        .validator(is_valid_signer)
                         .help("Public key of signing custodian (defaults to cli config pubkey)")
                 )
                 .offline_args()

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -827,7 +827,7 @@ pub fn process_create_stake_account(
             &fee_calculator,
             &tx.message,
         )?;
-        let result = rpc_client.send_and_confirm_transaction(&mut tx, &tx_signers);
+        let result = rpc_client.send_and_confirm_transaction_dynamic_signers(&mut tx, &tx_signers);
         log_instruction_custom_error::<SystemError>(result)
     }
 }
@@ -898,7 +898,8 @@ pub fn process_stake_authorize(
             &fee_calculator,
             &tx.message,
         )?;
-        let result = rpc_client.send_and_confirm_transaction(&mut tx, &[&config.keypair]);
+        let result = rpc_client
+            .send_and_confirm_transaction_dynamic_signers(&mut tx, &[config.keypair.as_ref()]);
         log_instruction_custom_error::<StakeError>(result)
     }
 }
@@ -962,7 +963,8 @@ pub fn process_deactivate_stake_account(
             &fee_calculator,
             &tx.message,
         )?;
-        let result = rpc_client.send_and_confirm_transaction(&mut tx, &[&config.keypair]);
+        let result = rpc_client
+            .send_and_confirm_transaction_dynamic_signers(&mut tx, &[config.keypair.as_ref()]);
         log_instruction_custom_error::<StakeError>(result)
     }
 }
@@ -1032,7 +1034,8 @@ pub fn process_withdraw_stake(
             &fee_calculator,
             &tx.message,
         )?;
-        let result = rpc_client.send_and_confirm_transaction(&mut tx, &[&config.keypair]);
+        let result = rpc_client
+            .send_and_confirm_transaction_dynamic_signers(&mut tx, &[config.keypair.as_ref()]);
         log_instruction_custom_error::<SystemError>(result)
     }
 }
@@ -1180,7 +1183,8 @@ pub fn process_split_stake(
             &fee_calculator,
             &tx.message,
         )?;
-        let result = rpc_client.send_and_confirm_transaction(&mut tx, &[&config.keypair]);
+        let result = rpc_client
+            .send_and_confirm_transaction_dynamic_signers(&mut tx, &[config.keypair.as_ref()]);
         log_instruction_custom_error::<StakeError>(result)
     }
 }
@@ -1248,7 +1252,8 @@ pub fn process_stake_set_lockup(
             &fee_calculator,
             &tx.message,
         )?;
-        let result = rpc_client.send_and_confirm_transaction(&mut tx, &[&config.keypair]);
+        let result = rpc_client
+            .send_and_confirm_transaction_dynamic_signers(&mut tx, &[config.keypair.as_ref()]);
         log_instruction_custom_error::<StakeError>(result)
     }
 }
@@ -1487,7 +1492,8 @@ pub fn process_delegate_stake(
             &fee_calculator,
             &tx.message,
         )?;
-        let result = rpc_client.send_and_confirm_transaction(&mut tx, &[&config.keypair]);
+        let result = rpc_client
+            .send_and_confirm_transaction_dynamic_signers(&mut tx, &[config.keypair.as_ref()]);
         log_instruction_custom_error::<StakeError>(result)
     }
 }

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -762,12 +762,12 @@ pub fn process_create_stake_account(
             &nonce_authority.pubkey(),
         );
         let mut tx = Transaction::new_unsigned(message);
-        tx.sign_dynamic_signers(&tx_signers, recent_blockhash);
+        tx.sign_dynamic_signers(&tx_signers, recent_blockhash)?;
         tx
     } else {
         let message = Message::new_with_payer(ixs, Some(&fee_payer.pubkey()));
         let mut tx = Transaction::new_unsigned(message);
-        tx.sign_dynamic_signers(&tx_signers, recent_blockhash);
+        tx.sign_dynamic_signers(&tx_signers, recent_blockhash)?;
         tx
     };
     if sign_only {
@@ -826,12 +826,12 @@ pub fn process_stake_authorize(
             &nonce_authority.pubkey(),
         );
         let mut tx = Transaction::new_unsigned(message);
-        tx.sign_dynamic_signers(&[fee_payer, nonce_authority, authority], recent_blockhash);
+        tx.sign_dynamic_signers(&[fee_payer, nonce_authority, authority], recent_blockhash)?;
         tx
     } else {
         let message = Message::new_with_payer(ixs, Some(&fee_payer.pubkey()));
         let mut tx = Transaction::new_unsigned(message);
-        tx.sign_dynamic_signers(&[fee_payer, authority], recent_blockhash);
+        tx.sign_dynamic_signers(&[fee_payer, authority], recent_blockhash)?;
         tx
     };
     if sign_only {
@@ -885,12 +885,12 @@ pub fn process_deactivate_stake_account(
         tx.sign_dynamic_signers(
             &[fee_payer, nonce_authority, stake_authority],
             recent_blockhash,
-        );
+        )?;
         tx
     } else {
         let message = Message::new_with_payer(ixs, Some(&fee_payer.pubkey()));
         let mut tx = Transaction::new_unsigned(message);
-        tx.sign_dynamic_signers(&[fee_payer, stake_authority], recent_blockhash);
+        tx.sign_dynamic_signers(&[fee_payer, stake_authority], recent_blockhash)?;
         tx
     };
     if sign_only {
@@ -950,12 +950,12 @@ pub fn process_withdraw_stake(
         tx.sign_dynamic_signers(
             &[fee_payer, withdraw_authority, nonce_authority],
             recent_blockhash,
-        );
+        )?;
         tx
     } else {
         let message = Message::new_with_payer(ixs, Some(&fee_payer.pubkey()));
         let mut tx = Transaction::new_unsigned(message);
-        tx.sign_dynamic_signers(&[fee_payer, withdraw_authority], recent_blockhash);
+        tx.sign_dynamic_signers(&[fee_payer, withdraw_authority], recent_blockhash)?;
         tx
     };
     if sign_only {
@@ -1091,7 +1091,7 @@ pub fn process_split_stake(
                 split_stake_account,
             ],
             recent_blockhash,
-        );
+        )?;
         tx
     } else {
         let message = Message::new_with_payer(ixs, Some(&fee_payer.pubkey()));
@@ -1099,7 +1099,7 @@ pub fn process_split_stake(
         tx.sign_dynamic_signers(
             &[fee_payer, stake_authority, split_stake_account],
             recent_blockhash,
-        );
+        )?;
         tx
     };
     if sign_only {
@@ -1156,12 +1156,12 @@ pub fn process_stake_set_lockup(
             &nonce_authority.pubkey(),
         );
         let mut tx = Transaction::new_unsigned(message);
-        tx.sign_dynamic_signers(&[fee_payer, nonce_authority, custodian], recent_blockhash);
+        tx.sign_dynamic_signers(&[fee_payer, nonce_authority, custodian], recent_blockhash)?;
         tx
     } else {
         let message = Message::new_with_payer(ixs, Some(&fee_payer.pubkey()));
         let mut tx = Transaction::new_unsigned(message);
-        tx.sign_dynamic_signers(&[fee_payer, custodian], recent_blockhash);
+        tx.sign_dynamic_signers(&[fee_payer, custodian], recent_blockhash)?;
         tx
     };
     if sign_only {
@@ -1390,12 +1390,12 @@ pub fn process_delegate_stake(
         tx.sign_dynamic_signers(
             &[fee_payer, nonce_authority, stake_authority],
             recent_blockhash,
-        );
+        )?;
         tx
     } else {
         let message = Message::new_with_payer(ixs, Some(&fee_payer.pubkey()));
         let mut tx = Transaction::new_unsigned(message);
-        tx.sign_dynamic_signers(&[fee_payer, stake_authority], recent_blockhash);
+        tx.sign_dynamic_signers(&[fee_payer, stake_authority], recent_blockhash)?;
         tx
     };
     if sign_only {

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -2117,40 +2117,6 @@ mod tests {
             }
         );
 
-        // Test Delegate Subcommand w/ absentee fee-payer
-        let sig = fee_payer_keypair.sign_message(&[0u8]);
-        let signer = format!("{}={}", fee_payer_string, sig);
-        let test_delegate_stake = test_commands.clone().get_matches_from(vec![
-            "test",
-            "delegate-stake",
-            &stake_account_string,
-            &vote_account_string,
-            "--fee-payer",
-            &fee_payer_string,
-            "--blockhash",
-            &blockhash_string,
-            "--signer",
-            &signer,
-        ]);
-        assert_eq!(
-            parse_command(&test_delegate_stake).unwrap(),
-            CliCommandInfo {
-                command: CliCommand::DelegateStake {
-                    stake_account_pubkey,
-                    vote_account_pubkey,
-                    stake_authority: None,
-                    force: false,
-                    sign_only: false,
-                    signers: Some(vec![(fee_payer_pubkey, sig)]),
-                    blockhash_query: BlockhashQuery::FeeCalculator(blockhash),
-                    nonce_account: None,
-                    nonce_authority: None,
-                    fee_payer: Some(fee_payer_pubkey.into()),
-                },
-                require_keypair: false
-            }
-        );
-
         // Test WithdrawStake Subcommand
         let test_withdraw_stake = test_commands.clone().get_matches_from(vec![
             "test",
@@ -2443,37 +2409,6 @@ mod tests {
                     fee_payer: Some(read_keypair_file(&fee_payer_keypair_file).unwrap().into()),
                 },
                 require_keypair: true
-            }
-        );
-
-        // Test Deactivate Subcommand w/ absentee fee-payer
-        let sig = fee_payer_keypair.sign_message(&[0u8]);
-        let signer = format!("{}={}", fee_payer_string, sig);
-        let test_deactivate_stake = test_commands.clone().get_matches_from(vec![
-            "test",
-            "deactivate-stake",
-            &stake_account_string,
-            "--fee-payer",
-            &fee_payer_string,
-            "--blockhash",
-            &blockhash_string,
-            "--signer",
-            &signer,
-        ]);
-        assert_eq!(
-            parse_command(&test_deactivate_stake).unwrap(),
-            CliCommandInfo {
-                command: CliCommand::DeactivateStake {
-                    stake_account_pubkey,
-                    stake_authority: None,
-                    sign_only: false,
-                    signers: Some(vec![(fee_payer_pubkey, sig)]),
-                    blockhash_query: BlockhashQuery::FeeCalculator(blockhash),
-                    nonce_account: None,
-                    nonce_authority: None,
-                    fee_payer: Some(fee_payer_pubkey.into()),
-                },
-                require_keypair: false
             }
         );
 

--- a/cli/src/storage.rs
+++ b/cli/src/storage.rs
@@ -191,9 +191,10 @@ pub fn process_create_storage_account(
     );
     let (recent_blockhash, fee_calculator) = rpc_client.get_recent_blockhash()?;
 
-    let mut tx = Transaction::new_signed_instructions(
+    let message = Message::new(ixs);
+    let mut tx = Transaction::new_unsigned(message);
+    tx.sign_dynamic_signers(
         &[config.keypair.as_ref(), storage_account],
-        ixs,
         recent_blockhash,
     );
     check_account_for_fee(
@@ -221,8 +222,8 @@ pub fn process_claim_storage_reward(
         storage_instruction::claim_reward(node_account_pubkey, storage_account_pubkey);
     let signers = [config.keypair.as_ref()];
     let message = Message::new_with_payer(vec![instruction], Some(&signers[0].pubkey()));
-
-    let mut tx = Transaction::new(&signers, message, recent_blockhash);
+    let mut tx = Transaction::new_unsigned(message);
+    tx.sign_dynamic_signers(&signers, recent_blockhash);
     check_account_for_fee(
         rpc_client,
         &config.keypair.pubkey(),

--- a/cli/src/storage.rs
+++ b/cli/src/storage.rs
@@ -192,7 +192,7 @@ pub fn process_create_storage_account(
     let (recent_blockhash, fee_calculator) = rpc_client.get_recent_blockhash()?;
 
     let mut tx = Transaction::new_signed_instructions(
-        &[&config.keypair, &storage_account],
+        &[config.keypair.as_ref(), storage_account],
         ixs,
         recent_blockhash,
     );
@@ -202,8 +202,10 @@ pub fn process_create_storage_account(
         &fee_calculator,
         &tx.message,
     )?;
-    let result =
-        rpc_client.send_and_confirm_transaction(&mut tx, &[&config.keypair, &storage_account]);
+    let result = rpc_client.send_and_confirm_transaction_dynamic_signers(
+        &mut tx,
+        &[config.keypair.as_ref(), storage_account],
+    );
     log_instruction_custom_error::<SystemError>(result)
 }
 
@@ -217,7 +219,7 @@ pub fn process_claim_storage_reward(
 
     let instruction =
         storage_instruction::claim_reward(node_account_pubkey, storage_account_pubkey);
-    let signers = [&config.keypair];
+    let signers = [config.keypair.as_ref()];
     let message = Message::new_with_payer(vec![instruction], Some(&signers[0].pubkey()));
 
     let mut tx = Transaction::new(&signers, message, recent_blockhash);
@@ -227,7 +229,8 @@ pub fn process_claim_storage_reward(
         &fee_calculator,
         &tx.message,
     )?;
-    let signature_str = rpc_client.send_and_confirm_transaction(&mut tx, &signers)?;
+    let signature_str =
+        rpc_client.send_and_confirm_transaction_dynamic_signers(&mut tx, &signers)?;
     Ok(signature_str)
 }
 

--- a/cli/src/storage.rs
+++ b/cli/src/storage.rs
@@ -196,7 +196,7 @@ pub fn process_create_storage_account(
     tx.sign_dynamic_signers(
         &[config.keypair.as_ref(), storage_account],
         recent_blockhash,
-    );
+    )?;
     check_account_for_fee(
         rpc_client,
         &config.keypair.pubkey(),
@@ -223,7 +223,7 @@ pub fn process_claim_storage_reward(
     let signers = [config.keypair.as_ref()];
     let message = Message::new_with_payer(vec![instruction], Some(&signers[0].pubkey()));
     let mut tx = Transaction::new_unsigned(message);
-    tx.sign_dynamic_signers(&signers, recent_blockhash);
+    tx.sign_dynamic_signers(&signers, recent_blockhash)?;
     check_account_for_fee(
         rpc_client,
         &config.keypair.pubkey(),

--- a/cli/src/validator_info.rs
+++ b/cli/src/validator_info.rs
@@ -301,7 +301,7 @@ pub fn process_set_validator_info(
         .unwrap_or(0);
 
     let keys = vec![(id(), false), (config.keypair.pubkey(), true)];
-    let (message, signers): (Message, Vec<&Keypair>) = if balance == 0 {
+    let (message, signers): (Message, Vec<&dyn KeypairUtil>) = if balance == 0 {
         if info_pubkey != info_keypair.pubkey() {
             println!(
                 "Account {:?} does not exist. Generating new keypair...",
@@ -327,7 +327,7 @@ pub fn process_set_validator_info(
             keys,
             &validator_info,
         )]);
-        let signers = vec![&config.keypair, &info_keypair];
+        let signers = vec![config.keypair.as_ref(), &info_keypair];
         let message = Message::new(instructions);
         (message, signers)
     } else {
@@ -343,7 +343,7 @@ pub fn process_set_validator_info(
             &validator_info,
         )];
         let message = Message::new_with_payer(instructions, Some(&config.keypair.pubkey()));
-        let signers = vec![&config.keypair];
+        let signers = vec![config.keypair.as_ref()];
         (message, signers)
     };
 
@@ -356,7 +356,8 @@ pub fn process_set_validator_info(
         &fee_calculator,
         &tx.message,
     )?;
-    let signature_str = rpc_client.send_and_confirm_transaction(&mut tx, &signers)?;
+    let signature_str =
+        rpc_client.send_and_confirm_transaction_dynamic_signers(&mut tx, &signers)?;
 
     println!("Success! Validator info published at: {:?}", info_pubkey);
     println!("{}", signature_str);

--- a/cli/src/validator_info.rs
+++ b/cli/src/validator_info.rs
@@ -349,7 +349,8 @@ pub fn process_set_validator_info(
 
     // Submit transaction
     let (recent_blockhash, fee_calculator) = rpc_client.get_recent_blockhash()?;
-    let mut tx = Transaction::new(&signers, message, recent_blockhash);
+    let mut tx = Transaction::new_unsigned(message);
+    tx.sign_dynamic_signers(&signers, recent_blockhash);
     check_account_for_fee(
         rpc_client,
         &config.keypair.pubkey(),

--- a/cli/src/validator_info.rs
+++ b/cli/src/validator_info.rs
@@ -350,7 +350,7 @@ pub fn process_set_validator_info(
     // Submit transaction
     let (recent_blockhash, fee_calculator) = rpc_client.get_recent_blockhash()?;
     let mut tx = Transaction::new_unsigned(message);
-    tx.sign_dynamic_signers(&signers, recent_blockhash);
+    tx.sign_dynamic_signers(&signers, recent_blockhash)?;
     check_account_for_fee(
         rpc_client,
         &config.keypair.pubkey(),

--- a/cli/src/vote.rs
+++ b/cli/src/vote.rs
@@ -311,9 +311,9 @@ pub fn process_create_vote_account(
     let (recent_blockhash, fee_calculator) = rpc_client.get_recent_blockhash()?;
 
     let signers = if vote_account_pubkey != config.keypair.pubkey() {
-        vec![&config.keypair, vote_account] // both must sign if `from` and `to` differ
+        vec![config.keypair.as_ref(), vote_account] // both must sign if `from` and `to` differ
     } else {
-        vec![&config.keypair] // when stake_account == config.keypair and there's a seed, we only need one signature
+        vec![config.keypair.as_ref()] // when stake_account == config.keypair and there's a seed, we only need one signature
     };
 
     let mut tx = Transaction::new_signed_instructions(&signers, ixs, recent_blockhash);
@@ -323,7 +323,7 @@ pub fn process_create_vote_account(
         &fee_calculator,
         &tx.message,
     )?;
-    let result = rpc_client.send_and_confirm_transaction(&mut tx, &signers);
+    let result = rpc_client.send_and_confirm_transaction_dynamic_signers(&mut tx, &signers);
     log_instruction_custom_error::<SystemError>(result)
 }
 
@@ -349,7 +349,7 @@ pub fn process_vote_authorize(
     let mut tx = Transaction::new_signed_with_payer(
         ixs,
         Some(&config.keypair.pubkey()),
-        &[&config.keypair],
+        &[config.keypair.as_ref()],
         recent_blockhash,
     );
     check_account_for_fee(
@@ -358,7 +358,8 @@ pub fn process_vote_authorize(
         &fee_calculator,
         &tx.message,
     )?;
-    let result = rpc_client.send_and_confirm_transaction(&mut tx, &[&config.keypair]);
+    let result = rpc_client
+        .send_and_confirm_transaction_dynamic_signers(&mut tx, &[config.keypair.as_ref()]);
     log_instruction_custom_error::<VoteError>(result)
 }
 
@@ -383,7 +384,7 @@ pub fn process_vote_update_validator(
     let mut tx = Transaction::new_signed_with_payer(
         ixs,
         Some(&config.keypair.pubkey()),
-        &[&config.keypair, authorized_voter],
+        &[config.keypair.as_ref(), authorized_voter],
         recent_blockhash,
     );
     check_account_for_fee(
@@ -392,7 +393,8 @@ pub fn process_vote_update_validator(
         &fee_calculator,
         &tx.message,
     )?;
-    let result = rpc_client.send_and_confirm_transaction(&mut tx, &[&config.keypair]);
+    let result = rpc_client
+        .send_and_confirm_transaction_dynamic_signers(&mut tx, &[config.keypair.as_ref()]);
     log_instruction_custom_error::<VoteError>(result)
 }
 

--- a/cli/src/vote.rs
+++ b/cli/src/vote.rs
@@ -319,7 +319,7 @@ pub fn process_create_vote_account(
 
     let message = Message::new(ixs);
     let mut tx = Transaction::new_unsigned(message);
-    tx.sign_dynamic_signers(&signers, recent_blockhash);
+    tx.sign_dynamic_signers(&signers, recent_blockhash)?;
     check_account_for_fee(
         rpc_client,
         &config.keypair.pubkey(),
@@ -351,7 +351,7 @@ pub fn process_vote_authorize(
 
     let message = Message::new_with_payer(ixs, Some(&config.keypair.pubkey()));
     let mut tx = Transaction::new_unsigned(message);
-    tx.sign_dynamic_signers(&[config.keypair.as_ref()], recent_blockhash);
+    tx.sign_dynamic_signers(&[config.keypair.as_ref()], recent_blockhash)?;
     check_account_for_fee(
         rpc_client,
         &config.keypair.pubkey(),
@@ -386,7 +386,7 @@ pub fn process_vote_update_validator(
     tx.sign_dynamic_signers(
         &[config.keypair.as_ref(), authorized_voter],
         recent_blockhash,
-    );
+    )?;
     check_account_for_fee(
         rpc_client,
         &config.keypair.pubkey(),

--- a/cli/src/vote.rs
+++ b/cli/src/vote.rs
@@ -7,6 +7,7 @@ use solana_clap_utils::{input_parsers::*, input_validators::*};
 use solana_client::rpc_client::RpcClient;
 use solana_sdk::{
     account::Account,
+    message::Message,
     pubkey::Pubkey,
     signature::Keypair,
     signature::KeypairUtil,
@@ -316,7 +317,9 @@ pub fn process_create_vote_account(
         vec![config.keypair.as_ref()] // when stake_account == config.keypair and there's a seed, we only need one signature
     };
 
-    let mut tx = Transaction::new_signed_instructions(&signers, ixs, recent_blockhash);
+    let message = Message::new(ixs);
+    let mut tx = Transaction::new_unsigned(message);
+    tx.sign_dynamic_signers(&signers, recent_blockhash);
     check_account_for_fee(
         rpc_client,
         &config.keypair.pubkey(),
@@ -346,12 +349,9 @@ pub fn process_vote_authorize(
         vote_authorize,           // vote or withdraw
     )];
 
-    let mut tx = Transaction::new_signed_with_payer(
-        ixs,
-        Some(&config.keypair.pubkey()),
-        &[config.keypair.as_ref()],
-        recent_blockhash,
-    );
+    let message = Message::new_with_payer(ixs, Some(&config.keypair.pubkey()));
+    let mut tx = Transaction::new_unsigned(message);
+    tx.sign_dynamic_signers(&[config.keypair.as_ref()], recent_blockhash);
     check_account_for_fee(
         rpc_client,
         &config.keypair.pubkey(),
@@ -381,9 +381,9 @@ pub fn process_vote_update_validator(
         new_identity_pubkey,
     )];
 
-    let mut tx = Transaction::new_signed_with_payer(
-        ixs,
-        Some(&config.keypair.pubkey()),
+    let message = Message::new_with_payer(ixs, Some(&config.keypair.pubkey()));
+    let mut tx = Transaction::new_unsigned(message);
+    tx.sign_dynamic_signers(
         &[config.keypair.as_ref(), authorized_voter],
         recent_blockhash,
     );

--- a/cli/tests/nonce.rs
+++ b/cli/tests/nonce.rs
@@ -1,6 +1,4 @@
-use solana_cli::cli::{
-    process_command, request_and_confirm_airdrop, CliCommand, CliConfig, SigningAuthority,
-};
+use solana_cli::cli::{process_command, request_and_confirm_airdrop, CliCommand, CliConfig};
 use solana_client::rpc_client::RpcClient;
 use solana_faucet::faucet::run_local_faucet;
 use solana_sdk::{
@@ -15,6 +13,7 @@ use std::sync::mpsc::channel;
 
 #[cfg(test)]
 use solana_core::validator::new_validator_for_tests;
+use std::rc::Rc;
 use std::thread::sleep;
 use std::time::Duration;
 
@@ -141,7 +140,7 @@ fn test_nonce_with_authority() {
     remove_dir_all(ledger_path).unwrap();
 }
 
-fn read_keypair_from_option(keypair_file: &Option<&str>) -> Option<SigningAuthority> {
+fn read_keypair_from_option(keypair_file: &Option<&str>) -> Option<Box<dyn KeypairUtil>> {
     keypair_file.map(|akf| read_keypair_file(&akf).unwrap().into())
 }
 
@@ -172,10 +171,9 @@ fn full_battery_tests(
 
     // Create nonce account
     config_payer.command = CliCommand::CreateNonceAccount {
-        nonce_account: read_keypair_file(&nonce_keypair_file).unwrap().into(),
+        nonce_account: Rc::new(read_keypair_file(&nonce_keypair_file).unwrap().into()),
         seed,
-        nonce_authority: read_keypair_from_option(&authority_keypair_file)
-            .map(|na: SigningAuthority| na.pubkey()),
+        nonce_authority: read_keypair_from_option(&authority_keypair_file),
         lamports: 1000,
     };
 

--- a/cli/tests/nonce.rs
+++ b/cli/tests/nonce.rs
@@ -4,7 +4,7 @@ use solana_faucet::faucet::run_local_faucet;
 use solana_sdk::{
     hash::Hash,
     pubkey::Pubkey,
-    signature::{read_keypair_file, write_keypair, Keypair, KeypairUtil},
+    signature::{keypair_from_seed, read_keypair_file, write_keypair, Keypair, KeypairUtil},
     system_instruction::create_address_with_seed,
     system_program,
 };
@@ -50,11 +50,13 @@ fn test_nonce() {
     config_payer.json_rpc_url =
         format!("http://{}:{}", leader_data.rpc.ip(), leader_data.rpc.port());
 
+    let keypair = keypair_from_seed(&[0u8; 32]).unwrap();
+    let (keypair_file, mut tmp_file) = make_tmp_file();
+    write_keypair(&keypair, tmp_file.as_file_mut()).unwrap();
     let mut config_nonce = CliConfig::default();
+    config_nonce.keypair = keypair.into();
     config_nonce.json_rpc_url =
         format!("http://{}:{}", leader_data.rpc.ip(), leader_data.rpc.port());
-    let (keypair_file, mut tmp_file) = make_tmp_file();
-    write_keypair(&config_nonce.keypair, tmp_file.as_file_mut()).unwrap();
 
     full_battery_tests(
         &rpc_client,
@@ -83,11 +85,13 @@ fn test_nonce_with_seed() {
     config_payer.json_rpc_url =
         format!("http://{}:{}", leader_data.rpc.ip(), leader_data.rpc.port());
 
+    let keypair = keypair_from_seed(&[0u8; 32]).unwrap();
+    let (keypair_file, mut tmp_file) = make_tmp_file();
+    write_keypair(&keypair, tmp_file.as_file_mut()).unwrap();
     let mut config_nonce = CliConfig::default();
+    config_nonce.keypair = keypair.into();
     config_nonce.json_rpc_url =
         format!("http://{}:{}", leader_data.rpc.ip(), leader_data.rpc.port());
-    let (keypair_file, mut tmp_file) = make_tmp_file();
-    write_keypair(&config_nonce.keypair, tmp_file.as_file_mut()).unwrap();
 
     full_battery_tests(
         &rpc_client,
@@ -116,11 +120,12 @@ fn test_nonce_with_authority() {
     config_payer.json_rpc_url =
         format!("http://{}:{}", leader_data.rpc.ip(), leader_data.rpc.port());
 
+    let nonce_keypair = keypair_from_seed(&[0u8; 32]).unwrap();
+    let (nonce_keypair_file, mut tmp_file) = make_tmp_file();
+    write_keypair(&nonce_keypair, tmp_file.as_file_mut()).unwrap();
     let mut config_nonce = CliConfig::default();
     config_nonce.json_rpc_url =
         format!("http://{}:{}", leader_data.rpc.ip(), leader_data.rpc.port());
-    let (nonce_keypair_file, mut tmp_file) = make_tmp_file();
-    write_keypair(&config_nonce.keypair, tmp_file.as_file_mut()).unwrap();
 
     let nonce_authority = Keypair::new();
     let (authority_keypair_file, mut tmp_file2) = make_tmp_file();
@@ -166,14 +171,14 @@ fn full_battery_tests(
         create_address_with_seed(&config_nonce.keypair.pubkey(), seed, &system_program::id())
             .unwrap()
     } else {
-        config_nonce.keypair.pubkey()
+        read_keypair_file(&nonce_keypair_file).unwrap().pubkey()
     };
 
     // Create nonce account
     config_payer.command = CliCommand::CreateNonceAccount {
         nonce_account: Rc::new(read_keypair_file(&nonce_keypair_file).unwrap().into()),
         seed,
-        nonce_authority: read_keypair_from_option(&authority_keypair_file),
+        nonce_authority: read_keypair_from_option(&authority_keypair_file).map(|k| k.pubkey()),
         lamports: 1000,
     };
 

--- a/cli/tests/pay.rs
+++ b/cli/tests/pay.rs
@@ -18,6 +18,7 @@ use std::sync::mpsc::channel;
 
 #[cfg(test)]
 use solana_core::validator::new_validator_for_tests;
+use std::rc::Rc;
 use std::thread::sleep;
 use std::time::Duration;
 use tempfile::NamedTempFile;
@@ -303,11 +304,10 @@ fn test_offline_pay_tx() {
     check_balance(50, &rpc_client, &config_online.keypair.pubkey());
     check_balance(0, &rpc_client, &bob_pubkey);
 
-    let (blockhash, signers) = parse_sign_only_reply_string(&sig_response);
+    let (blockhash, _signers) = parse_sign_only_reply_string(&sig_response);
     config_online.command = CliCommand::Pay(PayCommand {
         lamports: 10,
         to: bob_pubkey,
-        signers: Some(signers),
         blockhash_query: BlockhashQuery::FeeCalculator(blockhash),
         ..PayCommand::default()
     });
@@ -357,7 +357,7 @@ fn test_nonced_pay_tx() {
     let (nonce_keypair_file, mut tmp_file) = make_tmp_file();
     write_keypair(&nonce_account, tmp_file.as_file_mut()).unwrap();
     config.command = CliCommand::CreateNonceAccount {
-        nonce_account: read_keypair_file(&nonce_keypair_file).unwrap().into(),
+        nonce_account: Rc::new(read_keypair_file(&nonce_keypair_file).unwrap().into()),
         seed: None,
         nonce_authority: Some(config.keypair.pubkey()),
         lamports: minimum_nonce_balance,

--- a/cli/tests/request_airdrop.rs
+++ b/cli/tests/request_airdrop.rs
@@ -2,7 +2,6 @@ use solana_cli::cli::{process_command, CliCommand, CliConfig};
 use solana_client::rpc_client::RpcClient;
 use solana_core::validator::new_validator_for_tests;
 use solana_faucet::faucet::run_local_faucet;
-use solana_sdk::signature::KeypairUtil;
 use std::fs::remove_dir_all;
 use std::sync::mpsc::channel;
 

--- a/client/src/client_error.rs
+++ b/client/src/client_error.rs
@@ -1,50 +1,20 @@
 use crate::rpc_request;
 use solana_sdk::transaction::TransactionError;
 use std::{fmt, io};
+use thiserror::Error;
 
-#[derive(Debug)]
+#[derive(Error, Debug)]
 pub enum ClientError {
-    Io(io::Error),
-    Reqwest(reqwest::Error),
-    RpcError(rpc_request::RpcError),
-    SerdeJson(serde_json::error::Error),
-    TransactionError(TransactionError),
+    Io(#[from] io::Error),
+    Reqwest(#[from] reqwest::Error),
+    RpcError(#[from] rpc_request::RpcError),
+    SerdeJson(#[from] serde_json::error::Error),
+    SigningError(String),
+    TransactionError(#[from] TransactionError),
 }
 
 impl fmt::Display for ClientError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "solana client error")
-    }
-}
-
-impl std::error::Error for ClientError {}
-
-impl From<io::Error> for ClientError {
-    fn from(err: io::Error) -> ClientError {
-        ClientError::Io(err)
-    }
-}
-
-impl From<reqwest::Error> for ClientError {
-    fn from(err: reqwest::Error) -> ClientError {
-        ClientError::Reqwest(err)
-    }
-}
-
-impl From<rpc_request::RpcError> for ClientError {
-    fn from(err: rpc_request::RpcError) -> ClientError {
-        ClientError::RpcError(err)
-    }
-}
-
-impl From<serde_json::error::Error> for ClientError {
-    fn from(err: serde_json::error::Error) -> ClientError {
-        ClientError::SerdeJson(err)
-    }
-}
-
-impl From<TransactionError> for ClientError {
-    fn from(err: TransactionError) -> ClientError {
-        ClientError::TransactionError(err)
     }
 }

--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -648,13 +648,13 @@ impl RpcClient {
             // Re-sign any failed transactions with a new blockhash and retry
             let (blockhash, _fee_calculator) =
                 self.get_new_blockhash(&transactions_signatures[0].0.message().recent_blockhash)?;
-            transactions = transactions_signatures
-                .into_iter()
-                .map(|(mut transaction, _)| {
-                    transaction.sign_dynamic_signers(signer_keys, blockhash);
-                    transaction
-                })
-                .collect();
+            transactions = vec![];
+            for (mut transaction, _) in transactions_signatures.into_iter() {
+                transaction
+                    .sign_dynamic_signers(signer_keys, blockhash)
+                    .map_err(|e| ClientError::SigningError(format!("{:?}", e)))?;
+                transactions.push(transaction);
+            }
         }
     }
 
@@ -665,7 +665,8 @@ impl RpcClient {
     ) -> Result<(), ClientError> {
         let (blockhash, _fee_calculator) =
             self.get_new_blockhash(&tx.message().recent_blockhash)?;
-        tx.sign_dynamic_signers(signer_keys, blockhash);
+        tx.sign_dynamic_signers(signer_keys, blockhash)
+            .map_err(|e| ClientError::SigningError(format!("{:?}", e)))?;
         Ok(())
     }
 

--- a/keygen/src/keygen.rs
+++ b/keygen/src/keygen.rs
@@ -6,21 +6,16 @@ use clap::{
 };
 use num_cpus;
 use solana_clap_utils::{
-    input_parsers::derivation_of,
     input_validators::is_derivation,
     keypair::{
-        keypair_from_seed_phrase, parse_keypair_path, prompt_passphrase, KeypairUrl,
+        keypair_from_seed_phrase, keypair_util_from_path, prompt_passphrase,
         SKIP_SEED_PHRASE_VALIDATION_ARG,
     },
 };
 use solana_cli_config::config::{Config, CONFIG_FILE};
-use solana_remote_wallet::remote_keypair::generate_remote_keypair;
 use solana_sdk::{
     pubkey::write_pubkey_file,
-    signature::{
-        keypair_from_seed, read_keypair, read_keypair_file, write_keypair, write_keypair_file,
-        Keypair, KeypairUtil,
-    },
+    signature::{keypair_from_seed, write_keypair, write_keypair_file, Keypair, KeypairUtil},
 };
 use std::{
     collections::HashSet,
@@ -64,26 +59,7 @@ fn get_keypair_from_matches(
         path.extend(&[".config", "solana", "id.json"]);
         path.to_str().unwrap()
     };
-
-    match parse_keypair_path(path) {
-        KeypairUrl::Ask => {
-            let skip_validation = matches.is_present(SKIP_SEED_PHRASE_VALIDATION_ARG.name);
-            Ok(Box::new(keypair_from_seed_phrase(
-                "pubkey recovery",
-                skip_validation,
-                false,
-            )?))
-        }
-        KeypairUrl::Filepath(path) => Ok(Box::new(read_keypair_file(&path)?)),
-        KeypairUrl::Stdin => {
-            let mut stdin = std::io::stdin();
-            Ok(Box::new(read_keypair(&mut stdin)?))
-        }
-        KeypairUrl::Usb(path) => Ok(Box::new(generate_remote_keypair(
-            path,
-            derivation_of(matches, "derivation_path"),
-        )?)),
-    }
+    keypair_util_from_path(matches, path, "pubkey recovery")
 }
 
 fn output_keypair(

--- a/remote-wallet/src/ledger.rs
+++ b/remote-wallet/src/ledger.rs
@@ -341,7 +341,7 @@ fn extend_and_serialize(derivation_path: &DerivationPath) -> Vec<u8> {
 pub fn get_ledger_from_info(
     info: RemoteWalletInfo,
 ) -> Result<Arc<LedgerWallet>, RemoteWalletError> {
-    let wallet_manager = initialize_wallet_manager();
+    let wallet_manager = initialize_wallet_manager()?;
     let _device_count = wallet_manager.update_devices()?;
     let devices = wallet_manager.list_devices();
     let (pubkeys, device_paths): (Vec<Pubkey>, Vec<String>) = devices

--- a/remote-wallet/src/remote_wallet.rs
+++ b/remote-wallet/src/remote_wallet.rs
@@ -274,9 +274,9 @@ pub fn is_valid_hid_device(usage_page: u16, interface_number: i32) -> bool {
 }
 
 /// Helper to initialize hidapi and RemoteWalletManager
-pub fn initialize_wallet_manager() -> Arc<RemoteWalletManager> {
-    let hidapi = Arc::new(Mutex::new(hidapi::HidApi::new().unwrap()));
-    RemoteWalletManager::new(hidapi)
+pub fn initialize_wallet_manager() -> Result<Arc<RemoteWalletManager>, RemoteWalletError> {
+    let hidapi = Arc::new(Mutex::new(hidapi::HidApi::new()?));
+    Ok(RemoteWalletManager::new(hidapi))
 }
 
 #[cfg(test)]

--- a/sdk/src/message.rs
+++ b/sdk/src/message.rs
@@ -4,7 +4,7 @@ use crate::{
     hash::Hash,
     instruction::{AccountMeta, CompiledInstruction, Instruction},
     pubkey::Pubkey,
-    short_vec,
+    short_vec, system_instruction,
 };
 use itertools::Itertools;
 
@@ -206,6 +206,20 @@ impl Message {
             Hash::default(),
             instructions,
         )
+    }
+
+    pub fn new_with_nonce(
+        mut instructions: Vec<Instruction>,
+        payer: Option<&Pubkey>,
+        nonce_account_pubkey: &Pubkey,
+        nonce_authority_pubkey: &Pubkey,
+    ) -> Self {
+        let nonce_ix = system_instruction::advance_nonce_account(
+            &nonce_account_pubkey,
+            &nonce_authority_pubkey,
+        );
+        instructions.insert(0, nonce_ix);
+        Self::new_with_payer(instructions, payer)
     }
 
     pub fn serialize(&self) -> Vec<u8> {

--- a/sdk/src/signature.rs
+++ b/sdk/src/signature.rs
@@ -179,6 +179,15 @@ where
     }
 }
 
+impl<T> From<T> for Box<dyn KeypairUtil>
+where
+    T: KeypairUtil + 'static,
+{
+    fn from(keypair_util: T) -> Self {
+        Box::new(keypair_util)
+    }
+}
+
 #[derive(Debug, Default)]
 pub struct Presigner {
     pubkey: Pubkey,

--- a/sdk/src/signature.rs
+++ b/sdk/src/signature.rs
@@ -186,8 +186,7 @@ pub struct Presigner {
 }
 
 impl Presigner {
-    #[allow(dead_code)]
-    fn new(pubkey: &Pubkey, signature: &Signature) -> Self {
+    pub fn new(pubkey: &Pubkey, signature: &Signature) -> Self {
         Self {
             pubkey: *pubkey,
             signature: *signature,

--- a/sdk/src/signature.rs
+++ b/sdk/src/signature.rs
@@ -188,7 +188,7 @@ where
     }
 }
 
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct Presigner {
     pubkey: Pubkey,
     signature: Signature,

--- a/sdk/src/signature.rs
+++ b/sdk/src/signature.rs
@@ -139,6 +139,18 @@ pub trait KeypairUtil {
     fn try_sign_message(&self, message: &[u8]) -> Result<Signature, Box<dyn error::Error>>;
 }
 
+impl PartialEq for dyn KeypairUtil {
+    fn eq(&self, other: &dyn KeypairUtil) -> bool {
+        self.pubkey() == other.pubkey()
+    }
+}
+
+impl std::fmt::Debug for dyn KeypairUtil {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(fmt, "KeypairUtil: {:?}", self.pubkey())
+    }
+}
+
 impl KeypairUtil for Keypair {
     /// Return the public key for the given keypair
     fn pubkey(&self) -> Pubkey {

--- a/sdk/src/transaction.rs
+++ b/sdk/src/transaction.rs
@@ -360,27 +360,6 @@ impl Transaction {
             .collect())
     }
 
-    /// Replace all the signatures and pubkeys
-    pub fn replace_signatures(&mut self, signers: &[(Pubkey, Signature)]) -> Result<()> {
-        let num_required_signatures = self.message.header.num_required_signatures as usize;
-        if signers.len() != num_required_signatures
-            || self.signatures.len() != num_required_signatures
-            || self.message.account_keys.len() < num_required_signatures
-        {
-            return Err(TransactionError::InvalidAccountIndex);
-        }
-
-        signers
-            .iter()
-            .enumerate()
-            .for_each(|(i, (pubkey, signature))| {
-                self.signatures[i] = *signature;
-                self.message.account_keys[i] = *pubkey;
-            });
-
-        self.verify()
-    }
-
     pub fn is_signed(&self) -> bool {
         self.signatures
             .iter()


### PR DESCRIPTION
#### Problem
Our signer interfaces are too restrictive to accommodate a rich signing experience. This makes things like hardware wallets, offline signing and certain instruction constructions difficult to implement and mixed signer types impossible.

#### Summary of Changes
Co-conspirator: @t-nelson 
- Consolidate signer CLI argument specification and support HW wallet paths
- In contrast to #8318 , which attempted a general solution, this PR adds a select set of new Transaction and RpcClient apis that utilize KeypairUtil trait-object signer types to allow for dynamic signing. Since some signers implementing KeypairUtil may fail in signing, these new methods are also fallible, bubbling up signing errors before a Transaction is submitted.
- Plumb the new methods into CLI, and replace Keypair data structure fields with Box<dyn KeypairUtil>
- Doc updates

Closes #8318 
